### PR TITLE
fix(codex): show resumed sessions in the worktree sidebar before the first prompt

### DIFF
--- a/src/main/agent-hooks/server-codex-normalization.test.ts
+++ b/src/main/agent-hooks/server-codex-normalization.test.ts
@@ -208,7 +208,8 @@ describe('Codex hook normalization', () => {
       buildBody({ hook_event_name: 'SessionStart' }),
       'production'
     )
-    expect(result?.payload.state).toBe('working')
+    expect(result?.payload.state).toBe('done')
+    expect(result?.payload.sessionBoundary).toBe(true)
     expect(result?.payload.lastAssistantMessage).toBeUndefined()
   })
 
@@ -226,7 +227,8 @@ describe('Codex hook normalization', () => {
       buildBody({ hook_event_name: 'SessionStart' }),
       'production'
     )
-    expect(result?.payload.state).toBe('working')
+    expect(result?.payload.state).toBe('done')
+    expect(result?.payload.sessionBoundary).toBe(true)
     expect(result?.payload.prompt).toBe('')
   })
 })

--- a/src/shared/agent-detection.test.ts
+++ b/src/shared/agent-detection.test.ts
@@ -150,6 +150,32 @@ describe('OpenCode native title detection', () => {
   )
 })
 
+describe('Codex native session title detection', () => {
+  it.each([
+    ['ads_public | Ready | ads: Garvee US | main', 'idle'],
+    ['ads_public | Ready | 否定词阶段 | main', 'idle'],
+    ['ads_public | Starting | ads: MERACH US | main', 'working'],
+    ['yes-no-mystery | Thinking | 查找并继续多人游戏会话 | main', 'working']
+  ] as const)('classifies %j as title-derived %s Codex', (title, status) => {
+    expect(getAgentLabel(title)).toBe('Codex')
+    expect(detectAgentStatusFromTitle(title)).toBe(status)
+  })
+
+  it('does not let a spinner-decorated Ready-less Codex frame become Claude', () => {
+    const title = '\u2839 ads_public | Starting | ads: MERACH US | main'
+    expect(getAgentLabel(title)).toBe('Codex')
+    expect(detectAgentStatusFromTitle(title)).toBe('working')
+  })
+
+  it.each(['ads_public | Ready', 'foo | Ready to ship | main', 'timestamp ready'])(
+    'does not treat the lookalike title %j as an agent',
+    (title) => {
+      expect(getAgentLabel(title)).toBeNull()
+      expect(detectAgentStatusFromTitle(title)).toBeNull()
+    }
+  )
+})
+
 describe('Pi-compatible title detection', () => {
   it.each([
     ['\u280b OMP', 'OMP', 'working'],

--- a/src/shared/agent-detection.ts
+++ b/src/shared/agent-detection.ts
@@ -19,6 +19,10 @@ export {
   STRONG_IDLE_KEYWORDS_RE,
   STRONG_WORKING_KEYWORDS_RE
 } from './agent-title-core'
+export {
+  getCodexNativeSessionStatus,
+  isCodexNativeSessionTitle
+} from './codex-terminal-title'
 export { isOpenCodeNativeTitle, isMeaningfulOpenCodeTerminalTitle } from './opencode-terminal-title'
 export { getAgentLabel, isClaudeAgent } from './agent-title-identity'
 export {

--- a/src/shared/agent-hook-listener-hermes-codex-droid.test.ts
+++ b/src/shared/agent-hook-listener-hermes-codex-droid.test.ts
@@ -158,6 +158,33 @@ describe('shared agent-hook-listener', () => {
     expect(next?.payload.toolInput).toBeUndefined()
   })
 
+  it('maps Codex SessionStart to an idle done row so a resumed session earns its sidebar row before the first prompt', () => {
+    const event = normalizeHookPayload(
+      state,
+      'codex',
+      {
+        paneKey: PANE_KEY,
+        payload: {
+          hook_event_name: 'SessionStart',
+          session_id: '019ffea4-a02b-7b42-866a-f84fb1c71d58'
+        }
+      },
+      'production'
+    )
+
+    expect(event?.payload).toMatchObject({
+      state: 'done',
+      prompt: '',
+      agentType: 'codex',
+      sessionBoundary: true
+    })
+    expect(event?.hookEventName).toBe('SessionStart')
+    expect(event?.providerSession).toMatchObject({
+      key: 'session_id',
+      id: '019ffea4-a02b-7b42-866a-f84fb1c71d58'
+    })
+  })
+
   it('maps Codex request_user_input PreToolUse to waiting with the question card, then clears on the answer', () => {
     // Real Codex 0.145 shapes: PreToolUse fires while blocked on the answer (no Stop),
     // PostToolUse carries the answers, Stop ends the turn.

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -3573,18 +3573,13 @@ export function markCodexLeadTurnInterrupted(state: HookListenerState, paneKey: 
 function codexLeadStateForHookEvent(
   eventName: string | undefined
 ): CodexLeadTurnState['state'] | undefined {
-  if (eventName === 'Stop') {
+  if (eventName === 'Stop' || eventName === 'SessionStart') {
     return 'done'
   }
   if (eventName === 'PermissionRequest') {
     return 'waiting'
   }
-  if (
-    eventName === 'SessionStart' ||
-    eventName === 'UserPromptSubmit' ||
-    eventName === 'PreToolUse' ||
-    eventName === 'PostToolUse'
-  ) {
+  if (eventName === 'UserPromptSubmit' || eventName === 'PreToolUse' || eventName === 'PostToolUse') {
     return 'working'
   }
   return undefined
@@ -3649,7 +3644,11 @@ function buildCodexStatusPayload(
   promptText: string,
   paneKey: string,
   hookPayload: Record<string, unknown>,
-  options: { stateName: 'working' | 'waiting' | 'done'; updateLead: boolean }
+  options: {
+    stateName: 'working' | 'waiting' | 'done'
+    updateLead: boolean
+    sessionBoundary?: boolean
+  }
 ): ParsedAgentStatusPayload | null {
   const snapshot = options.updateLead
     ? resolveToolState(state, paneKey, extractToolFields('codex', eventName, hookPayload), {
@@ -3669,7 +3668,8 @@ function buildCodexStatusPayload(
     toolInput: snapshot.toolInput,
     interactivePrompt: snapshot.interactivePrompt,
     lastAssistantMessage: snapshot.lastAssistantMessage,
-    subagents: codexRosterToSnapshots(state.codexSubagentRosterByPaneKey.get(paneKey))
+    subagents: codexRosterToSnapshots(state.codexSubagentRosterByPaneKey.get(paneKey)),
+    sessionBoundary: options.sessionBoundary
   })
 }
 
@@ -3733,8 +3733,22 @@ function normalizeCodexEvent(
   const isUserInputPreTool =
     eventName === 'PreToolUse' &&
     isAskUserQuestionTool(readString(hookPayload, 'tool_name') ?? readString(hookPayload, 'name'))
+  const agentId = readString(hookPayload, 'agent_id')
+  if (eventName === 'SessionStart' && !agentId) {
+    // Why: SessionStart is the only signal a resumed idle Codex TUI emits before
+    // the first prompt (STA-3386). Land it as a session-boundary 'done' row so
+    // the sidebar appears without a phantom spinner or a ping.
+    state.codexSubagentRosterByPaneKey.delete(paneKey)
+    state.codexSubagentTranscriptByPaneKey.delete(paneKey)
+    state.codexLeadStateByPaneKey.set(paneKey, { state: 'done' })
+    return buildCodexStatusPayload(state, eventName, promptText, paneKey, hookPayload, {
+      stateName: 'done',
+      updateLead: true,
+      sessionBoundary: true
+    })
+  }
+
   const stateName =
-    eventName === 'SessionStart' ||
     eventName === 'UserPromptSubmit' ||
     (eventName === 'PreToolUse' && !isUserInputPreTool) ||
     eventName === 'PostToolUse'
@@ -3748,7 +3762,6 @@ function normalizeCodexEvent(
     return null
   }
 
-  const agentId = readString(hookPayload, 'agent_id')
   if (agentId) {
     upsertCodexSubagent(
       getOrCreateCodexSubagentRoster(state, paneKey),
@@ -3763,11 +3776,6 @@ function normalizeCodexEvent(
     return buildCodexChildDrivenStatusPayload(state, eventName, paneKey, hookPayload)
   }
 
-  if (eventName === 'SessionStart') {
-    // Why: a pane can host a new Codex process after the old one exited without child Stop hooks.
-    state.codexSubagentRosterByPaneKey.delete(paneKey)
-    state.codexSubagentTranscriptByPaneKey.delete(paneKey)
-  }
   const transcriptPath = readFirstString(hookPayload, ['transcript_path', 'transcriptPath'])
   if (transcriptPath) {
     reconcileCodexSubagentTranscript(

--- a/src/shared/agent-title-identity.ts
+++ b/src/shared/agent-title-identity.ts
@@ -10,6 +10,7 @@ import {
   isPiAgentTitle,
   titleHasAgentName
 } from './agent-title-core'
+import { isCodexNativeSessionTitle } from './codex-terminal-title'
 import { isOpenCodeNativeTitle } from './opencode-terminal-title'
 import { getPiCompatibleSyntheticAgentLabel } from './pi-compatible-synthetic-title'
 
@@ -18,7 +19,12 @@ import { getPiCompatibleSyntheticAgentLabel } from './pi-compatible-synthetic-ti
  * Used to scope prompt-cache-timer behavior to Claude sessions only.
  */
 export function isClaudeAgent(title: string): boolean {
-  if (!title || isClaudeManagementTitle(title) || isOpenCodeNativeTitle(title)) {
+  if (
+    !title ||
+    isClaudeManagementTitle(title) ||
+    isOpenCodeNativeTitle(title) ||
+    isCodexNativeSessionTitle(title)
+  ) {
     return false
   }
   const lower = title.toLowerCase()
@@ -51,6 +57,9 @@ export function getAgentLabel(title: string): string | null {
   // include status glyphs from other agents without changing OpenCode identity.
   if (isOpenCodeNativeTitle(title)) {
     return 'OpenCode'
+  }
+  if (isCodexNativeSessionTitle(title)) {
+    return 'Codex'
   }
   // Why: Claude task titles can mention another CLI; the prefix is the identity
   // signal, not arbitrary task text.

--- a/src/shared/agent-title-status.ts
+++ b/src/shared/agent-title-status.ts
@@ -24,6 +24,7 @@ import {
   isPiTerminalTitle
 } from './agent-title-core'
 import type { AgentStatus } from './agent-title-core'
+import { getCodexNativeSessionStatus, isCodexNativeSessionTitle } from './codex-terminal-title'
 import { isOpenCodeNativeTitle } from './opencode-terminal-title'
 import { getPiCompatibleSyntheticAgentStatus } from './pi-compatible-synthetic-title'
 import { isGrokRotatingWorkingTitle } from './terminal-title-agent-type'
@@ -164,6 +165,9 @@ export function detectAgentStatusFromTitle(title: string): AgentStatus | null {
 
   if (isOpenCodeNativeTitle(title)) {
     return containsAgentSpinnerGlyph(title) ? 'working' : 'idle'
+  }
+  if (isCodexNativeSessionTitle(title)) {
+    return getCodexNativeSessionStatus(title)
   }
 
   if (title.includes(GEMINI_PERMISSION)) {

--- a/src/shared/codex-terminal-title.test.ts
+++ b/src/shared/codex-terminal-title.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { getCodexNativeSessionStatus, isCodexNativeSessionTitle } from './codex-terminal-title'
+
+describe('Codex native session titles', () => {
+  it.each([
+    ['ads_public | Ready | ads: Garvee US | main', 'idle'],
+    ['ads_public | Ready | 否定词阶段 | main', 'idle'],
+    ['ads_public | Ready | ads: WiiM US', 'idle'],
+    ['ads_public | Starting | ads: MERACH US | main', 'working'],
+    ['yes-no-mystery | Working | 摸鱼上游 | main', 'working'],
+    ['yes-no-mystery | Thinking | 查找并继续多人游戏会话 | main', 'working'],
+    ['yes-no-mystery | Working | 01a00b10-96f8-7323-a2a1-b606486b1f88 | main | Tasks 6/6', 'working'],
+    ['\u2839 ads_public | Starting | ads: MERACH US | main', 'working']
+  ] as const)('classifies %j as %s', (title, status) => {
+    expect(isCodexNativeSessionTitle(title)).toBe(true)
+    expect(getCodexNativeSessionStatus(title)).toBe(status)
+  })
+
+  it.each([
+    'ads_public | Ready',
+    'ads_public | ready | ads: Garvee US | main',
+    'foo | Ready to ship | main',
+    'OC | Ready | something',
+    'timestamp ready',
+    'ads_public | Idle | ads: Garvee US | main',
+    'Grok'
+  ])('rejects the lookalike title %j', (title) => {
+    expect(isCodexNativeSessionTitle(title)).toBe(false)
+    expect(getCodexNativeSessionStatus(title)).toBeNull()
+  })
+})

--- a/src/shared/codex-terminal-title.ts
+++ b/src/shared/codex-terminal-title.ts
@@ -1,0 +1,26 @@
+// Why: Codex 0.147+ OSC titles are `{cwd} | Ready|Starting|Working|Thinking | {thread}`.
+// They name no `codex` token, so title-derived sidebar rows vanished until the
+// first UserPromptSubmit — same class as OpenCode's `OC |` marker.
+
+const CODEX_NATIVE_STATUS = 'Ready|Starting|Working|Thinking'
+const CODEX_NATIVE_SESSION_TITLE_RE = new RegExp(
+  String.raw`^\s*(?:[\u2800-\u28FF]+\s+)?(?!OC\b)[^|\n]+ \| (?:${CODEX_NATIVE_STATUS}) \| \S`,
+  'u'
+)
+const CODEX_NATIVE_STATUS_RE = new RegExp(
+  String.raw`(?:^|\| )(${CODEX_NATIVE_STATUS}) \| `
+)
+
+export function isCodexNativeSessionTitle(title: string | null | undefined): boolean {
+  return title ? CODEX_NATIVE_SESSION_TITLE_RE.test(title) : false
+}
+
+export function getCodexNativeSessionStatus(
+  title: string | null | undefined
+): 'idle' | 'working' | null {
+  if (!title || !isCodexNativeSessionTitle(title)) {
+    return null
+  }
+  const status = CODEX_NATIVE_STATUS_RE.exec(title)?.[1]
+  return status === 'Ready' ? 'idle' : 'working'
+}

--- a/src/shared/terminal-title-agent-type.test.ts
+++ b/src/shared/terminal-title-agent-type.test.ts
@@ -54,6 +54,12 @@ describe('resolveExplicitTerminalTitleAgentType', () => {
     expect(resolveExplicitTerminalTitleAgentType('* Review Codex behavior')).toBeNull()
   })
 
+  it('resolves Codex native session titles that omit the codex token', () => {
+    expect(resolveExplicitTerminalTitleAgentType('ads_public | Ready | ads: Garvee US | main')).toBe(
+      'codex'
+    )
+  })
+
   it('resolves OpenCode native abbreviated session titles before task-text identities', () => {
     expect(resolveExplicitTerminalTitleAgentType('OC | Understand about the plugin')).toBe(
       'opencode'

--- a/src/shared/terminal-title-agent-type.ts
+++ b/src/shared/terminal-title-agent-type.ts
@@ -6,6 +6,7 @@ import {
 } from './agent-name-token-match'
 import { containsAgentSpinnerGlyph, isCursorAgentTitle } from './agent-title-core'
 import { stripLeadingAgentTitleDecorationOrEmpty } from './agent-title-decoration'
+import { isCodexNativeSessionTitle } from './codex-terminal-title'
 import { isOpenCodeNativeTitle } from './opencode-terminal-title'
 import { getWrapperTitleSegments } from './terminal-title-wrapper-segments'
 import {
@@ -79,7 +80,12 @@ export function isPiAgentTitle(title: string): boolean {
  * agents have different (or no) caching semantics.
  */
 export function isClaudeAgent(title: string): boolean {
-  if (!title || isClaudeManagementTitle(title) || isOpenCodeNativeTitle(title)) {
+  if (
+    !title ||
+    isClaudeManagementTitle(title) ||
+    isOpenCodeNativeTitle(title) ||
+    isCodexNativeSessionTitle(title)
+  ) {
     return false
   }
   const lower = title.toLowerCase()
@@ -127,6 +133,9 @@ export function getAgentLabel(title: string): string | null {
   // include status glyphs from other agents without changing OpenCode identity.
   if (isOpenCodeNativeTitle(title)) {
     return 'OpenCode'
+  }
+  if (isCodexNativeSessionTitle(title)) {
+    return 'Codex'
   }
   // Why: Claude Code title text is often the task title. If that task mentions
   // another CLI, the Claude-specific prefix is the identity signal, not the words.


### PR DESCRIPTION
## ELI5

If you resume a Codex chat in Orca, the session is running, but it does not show up under the worktree on the left until you type something. This makes Orca notice the idle Codex window from its title (and from SessionStart), so the row appears immediately.

## What Changed

- Recognize Codex 0.147+ native OSC titles of the form `{cwd} | Ready|Starting|Working|Thinking | {thread}`.
- Map Codex `SessionStart` to an idle `done` + `sessionBoundary` row, matching Claude STA-3386.
- Keep unnamed spinner frames on that title as Codex, not Claude.

## Why

Title-derived sidebar rows required a `codex` token. The new title has none, so a resumed idle TUI was invisible until `UserPromptSubmit`. Claude already solved this class of bug; Codex did not.

## Linked Issue

Fixes #15096

## Visual Proof

N/A — sidebar row appears from existing title/hook classification. No new chrome. A resumed `… | Ready | …` title now classifies as idle Codex; previously it classified as nothing.

## Testing

- [x] Automated tests added/updated, or explained why not below
- Focused: `codex-terminal-title.test.ts`, `agent-detection.test.ts`, `terminal-title-agent-type.test.ts`, `agent-hook-listener-hermes-codex-droid.test.ts`, `server-codex-normalization.test.ts` (126 tests passed)
- Platforms: title regex is OSC-string only (macOS / Linux / Windows / SSH identical). No desktop UI run of this checkout.

## AI Disclosure

Implementation and write-up by Grok 4.6 (xAI) in a local coding-agent session.

## Review

### Agent code-review summary

- Cross-platform: matching is on the OSC title string; no path or shortcut changes.
- SSH/remote: hook + title classification already run on the client/host that owns the pane; no new RPC.
- Agent compatibility: Codex-only title marker and SessionStart mapping. OpenCode `OC |` still wins first. Claude spinner heuristic no longer claims `⠹ cwd | Starting | …`.
- Performance: one regex on title updates already in the hot path.
- UI: no new controls.
- Security: no new network, credentials, or command execution.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Focused unit tests passed locally. Full lint/typecheck/build not run on this checkout because it is a linked worktree without a full Electron install.

## Author

- X / Twitter: