### PR TITLE
fix(project-groups): route mutations by owner

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-list/rows/SectionHeader.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/SectionHeader.tsx
@@ -56,8 +56,8 @@ export type SectionHeaderRowContext = {
   }) => FolderWorkspacePathStatus | null
   toggleGroupWithScrollAnchor: (groupKey: string) => void
   projectActions: RepoHeaderProjectActions
-  onRenameProjectGroup: (groupId: string, currentName: string) => void
-  onDeleteProjectGroup: (groupId: string, groupName: string) => void
+  onRenameProjectGroup: (group: ProjectGroup) => void
+  onDeleteProjectGroup: (group: ProjectGroup) => void
   onCreateFolderWorkspace: (projectGroup: ProjectGroup) => void
   onWorkspaceStatusDragOver: (event: React.DragEvent, status: WorkspaceStatus) => void
   onWorkspaceStatusDragLeave: (event: React.DragEvent) => void
@@ -350,9 +350,12 @@ export function renderWorktreeSectionHeaderRow(args: {
             </div>
           ) : null}
 
-          {isProjectGroupHeader && !row.repo && projectGroupIdForHeader ? (
+          {isProjectGroupHeader &&
+          !row.repo &&
+          row.projectGroup &&
+          'parentPath' in row.projectGroup ? (
             <ProjectGroupHeaderMenu
-              groupId={projectGroupIdForHeader}
+              group={row.projectGroup}
               label={row.label}
               onRename={ctx.onRenameProjectGroup}
               onDelete={ctx.onDeleteProjectGroup}

--- a/src/renderer/src/components/sidebar/worktree-list/rows/project-group-header-actions.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/project-group-header-actions.tsx
@@ -21,15 +21,15 @@ import {
 } from './header-event-guards'
 
 export function ProjectGroupHeaderMenu({
-  groupId,
+  group,
   label,
   onRename,
   onDelete
 }: {
-  groupId: string
+  group: ProjectGroup
   label: string
-  onRename: (groupId: string, currentName: string) => void
-  onDelete: (groupId: string, groupName: string) => void
+  onRename: (group: ProjectGroup) => void
+  onDelete: (group: ProjectGroup) => void
 }): React.JSX.Element {
   return (
     <DropdownMenu modal={false}>
@@ -64,10 +64,10 @@ export function ProjectGroupHeaderMenu({
         onClick={stopRepoHeaderMenuEvent}
         onKeyDown={stopRepoHeaderMenuEvent}
       >
-        <DropdownMenuItem onSelect={() => onRename(groupId, label)}>
+        <DropdownMenuItem onSelect={() => onRename(group)}>
           {translate('auto.components.sidebar.WorktreeList.4d7b73658c', 'Rename group')}
         </DropdownMenuItem>
-        <DropdownMenuItem variant="destructive" onSelect={() => onDelete(groupId, label)}>
+        <DropdownMenuItem variant="destructive" onSelect={() => onDelete(group)}>
           {translate('auto.components.sidebar.WorktreeList.902115cdbe', 'Delete group')}
         </DropdownMenuItem>
       </DropdownMenuContent>

--- a/src/renderer/src/components/sidebar/worktree-list/rows/use-project-group-dialogs.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/use-project-group-dialogs.ts
@@ -3,16 +3,27 @@ import { toast } from 'sonner'
 import { useAppStore } from '@/store'
 import { translate } from '@/i18n/i18n'
 import { selectProjectGroupRemovalTargets } from '@/store/slices/project-group-removal-targets'
+import {
+  getRepoExecutionHostId,
+  type ExecutionHostId
+} from '../../../../../../shared/execution-host'
 import type { ProjectGroup } from '../../../../../../shared/project-group-types'
 import type { Repo } from '../../../../../../shared/repo-types'
+import { getProjectGroupExecutionHostIdForRows } from '../listing/host-filtering'
 
 export type ProjectGroupNameDialogState =
   | { type: 'create-from-repo'; repo: Repo }
-  | { type: 'rename'; groupId: string; currentName: string }
+  | {
+      type: 'rename'
+      groupId: string
+      currentName: string
+      executionHostId: ExecutionHostId
+    }
 
 export type ProjectGroupDeleteDialogState = {
   groupId: string
   groupName: string
+  executionHostId: ExecutionHostId
   removeContainedProjects: boolean
 }
 
@@ -95,8 +106,13 @@ export function useProjectGroupDialogs(args: {
     [moveProjectToGroup]
   )
 
-  const handleRenameProjectGroup = useCallback((groupId: string, currentName: string) => {
-    setNameDialog({ type: 'rename', groupId, currentName })
+  const handleRenameProjectGroup = useCallback((group: ProjectGroup) => {
+    setNameDialog({
+      type: 'rename',
+      groupId: group.id,
+      currentName: group.name,
+      executionHostId: getProjectGroupExecutionHostIdForRows(group, 'local')
+    })
   }, [])
 
   const handleSubmitProjectGroupName = useCallback(
@@ -111,7 +127,11 @@ export function useProjectGroupDialogs(args: {
         }
         return
       }
-      await updateProjectGroup(nameDialog.groupId, { name })
+      await updateProjectGroup(
+        nameDialog.groupId,
+        { name },
+        { executionHostId: nameDialog.executionHostId }
+      )
     },
     [createProjectGroup, moveProjectToGroup, nameDialog, updateProjectGroup]
   )
@@ -120,7 +140,14 @@ export function useProjectGroupDialogs(args: {
     if (!deleteDialog) {
       return null
     }
-    return selectProjectGroupRemovalTargets(projectGroups, repos, deleteDialog.groupId)
+    const ownerHostId = deleteDialog.executionHostId
+    return selectProjectGroupRemovalTargets(
+      projectGroups.filter(
+        (group) => getProjectGroupExecutionHostIdForRows(group, 'local') === ownerHostId
+      ),
+      repos.filter((repo) => getRepoExecutionHostId(repo) === ownerHostId),
+      deleteDialog.groupId
+    )
   }, [deleteDialog, projectGroups, repos])
   const deleteProjectCount = deleteTargets?.projectIds.length ?? 0
   const deleteProjectNames = useMemo(
@@ -133,8 +160,13 @@ export function useProjectGroupDialogs(args: {
   const removeContainedProjects =
     deleteProjectCount > 0 && deleteDialog?.removeContainedProjects === true
 
-  const handleDeleteProjectGroup = useCallback((groupId: string, groupName: string) => {
-    setDeleteDialog({ groupId, groupName, removeContainedProjects: false })
+  const handleDeleteProjectGroup = useCallback((group: ProjectGroup) => {
+    setDeleteDialog({
+      groupId: group.id,
+      groupName: group.name,
+      executionHostId: getProjectGroupExecutionHostIdForRows(group, 'local'),
+      removeContainedProjects: false
+    })
   }, [])
 
   const handleConfirmDeleteProjectGroup = useCallback(async () => {
@@ -144,7 +176,8 @@ export function useProjectGroupDialogs(args: {
     try {
       reportProjectGroupDeleteFailures(
         await deleteProjectGroupWithContainedProjects(deleteDialog.groupId, {
-          removeContainedProjects
+          removeContainedProjects,
+          executionHostId: deleteDialog.executionHostId
         })
       )
     } finally {

--- a/src/renderer/src/components/sidebar/worktree-list/viewport/viewport-props.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/viewport/viewport-props.ts
@@ -46,8 +46,8 @@ export type VirtualizedWorktreeViewportProps = {
   handleCreateGroupFromRepo: (repo: Repo) => void
   handleMoveProjectToGroup: (repo: Repo, groupId: string) => void
   handleRemoveProjectFromGroup: (repo: Repo) => void
-  handleRenameProjectGroup: (groupId: string, currentName: string) => void
-  handleDeleteProjectGroup: (groupId: string, groupName: string) => void
+  handleRenameProjectGroup: (group: ProjectGroup) => void
+  handleDeleteProjectGroup: (group: ProjectGroup) => void
   handleCreateFolderWorkspace: (projectGroup: ProjectGroup) => void
   activeModal: string
   pendingRevealWorktree: PendingSidebarWorktreeReveal | null

--- a/src/renderer/src/store/slices/project-group-owner-routed-mutations.test.ts
+++ b/src/renderer/src/store/slices/project-group-owner-routed-mutations.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ProjectGroup } from '../../../../shared/project-group-types'
+import {
+  createCompatibleRuntimeStatusResponseIfNeeded,
+  type RuntimeEnvironmentCallRequest
+} from '../../runtime/runtime-compatibility-test-fixture'
+import { clearRuntimeCompatibilityCacheForTests } from '../../runtime/runtime-rpc-client'
+import { createTestStore } from './store-test-helpers'
+
+const projectGroup: ProjectGroup = {
+  id: 'group-1',
+  name: 'Platform',
+  parentPath: null,
+  parentGroupId: null,
+  createdFrom: 'manual',
+  tabOrder: 0,
+  isCollapsed: false,
+  color: null,
+  createdAt: 1,
+  updatedAt: 1
+}
+
+const projectGroupsUpdate = vi.fn()
+const runtimeEnvironmentCall = vi.fn()
+const runtimeEnvironmentTransportCall = vi.fn()
+
+beforeEach(() => {
+  clearRuntimeCompatibilityCacheForTests()
+  projectGroupsUpdate.mockReset()
+  runtimeEnvironmentCall.mockReset()
+  runtimeEnvironmentTransportCall.mockReset()
+  runtimeEnvironmentTransportCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
+    return createCompatibleRuntimeStatusResponseIfNeeded(args) ?? runtimeEnvironmentCall(args)
+  })
+  vi.stubGlobal('window', {
+    api: {
+      projectGroups: { update: projectGroupsUpdate },
+      runtimeEnvironments: { call: runtimeEnvironmentTransportCall }
+    }
+  })
+})
+
+describe('project group owner-routed mutations', () => {
+  it('routes a web rename to its row owner and preserves a same-id local row', async () => {
+    const remoteGroup = { ...projectGroup, executionHostId: 'runtime:env-owner' as const }
+    const localCollision = { ...projectGroup, name: 'Local', executionHostId: 'local' as const }
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-update-group',
+      ok: true,
+      result: { group: { ...projectGroup, name: 'Core' } },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: null } as never,
+      projectGroups: [localCollision, remoteGroup]
+    })
+
+    await expect(
+      store
+        .getState()
+        .updateProjectGroup(
+          projectGroup.id,
+          { name: 'Core' },
+          { executionHostId: remoteGroup.executionHostId }
+        )
+    ).resolves.toBe(true)
+
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-owner',
+      method: 'projectGroup.update',
+      params: { groupId: projectGroup.id, updates: { name: 'Core' } },
+      timeoutMs: 15_000
+    })
+    expect(projectGroupsUpdate).not.toHaveBeenCalled()
+    expect(store.getState().projectGroups).toEqual([
+      localCollision,
+      { ...projectGroup, name: 'Core', executionHostId: 'runtime:env-owner' }
+    ])
+  })
+})

--- a/src/renderer/src/store/slices/repos-project-groups-delete.test.ts
+++ b/src/renderer/src/store/slices/repos-project-groups-delete.test.ts
@@ -105,6 +105,31 @@ describe('project group deletion store routing', () => {
     ])
   })
 
+  it('routes a desktop local group delete by row owner when a remote runtime is focused', async () => {
+    projectGroupsDelete.mockResolvedValue(true)
+    const localGroup = { ...projectGroup, executionHostId: 'local' as const }
+    const remoteCollision = {
+      ...projectGroup,
+      name: 'Remote',
+      executionHostId: 'runtime:wrong-env' as const
+    }
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'wrong-env' } as never,
+      projectGroups: [localGroup, remoteCollision]
+    })
+
+    await expect(
+      store
+        .getState()
+        .deleteProjectGroup(projectGroup.id, { executionHostId: localGroup.executionHostId })
+    ).resolves.toBe(true)
+
+    expect(projectGroupsDelete).toHaveBeenCalledWith({ groupId: projectGroup.id })
+    expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
+    expect(store.getState().projectGroups).toEqual([remoteCollision])
+  })
+
   it('uses the remote delete response shape before mutating local state', async () => {
     runtimeEnvironmentCall.mockResolvedValue({
       id: 'rpc-delete-group',
@@ -112,17 +137,22 @@ describe('project group deletion store routing', () => {
       result: { deleted: false },
       _meta: { runtimeId: 'runtime-remote' }
     })
-    const groupedRepo = { ...remoteRepo, projectGroupId: projectGroup.id }
+    const remoteGroup = { ...projectGroup, executionHostId: 'runtime:env-1' as const }
+    const groupedRepo = {
+      ...remoteRepo,
+      projectGroupId: projectGroup.id,
+      executionHostId: 'runtime:env-1' as const
+    }
     const store = createTestStore()
     store.setState({
       settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
-      projectGroups: [projectGroup],
+      projectGroups: [remoteGroup],
       repos: [groupedRepo]
     })
 
     await expect(store.getState().deleteProjectGroup(projectGroup.id)).resolves.toBe(false)
 
-    expect(store.getState().projectGroups).toEqual([projectGroup])
+    expect(store.getState().projectGroups).toEqual([remoteGroup])
     expect(store.getState().repos).toEqual([groupedRepo])
     expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
       selector: 'env-1',

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -88,6 +88,7 @@ import {
   getRepoExecutionHostId,
   isRuntimeOwnedSshTargetId,
   LOCAL_EXECUTION_HOST_ID,
+  normalizeExecutionHostId,
   parseExecutionHostId,
   toRuntimeExecutionHostId,
   toSshExecutionHostId,
@@ -218,6 +219,11 @@ export type FolderWorkspacePathStatusCacheEntry = {
 
 export type DeleteProjectGroupWithContainedProjectsOptions = {
   removeContainedProjects: boolean
+  executionHostId?: ExecutionHostId
+}
+
+type ProjectGroupMutationOptions = {
+  executionHostId?: ExecutionHostId
 }
 
 type AllHostCatalogFetchOptions = {
@@ -1120,11 +1126,39 @@ function mergeProjectCompatibilityForHostRepoChange({
   })
 }
 
-function getProjectGroupHostId(group: Pick<ProjectGroup, 'connectionId' | 'executionHostId'>) {
-  if (group.executionHostId) {
-    return group.executionHostId
+function getProjectGroupHostId(
+  group: Pick<ProjectGroup, 'connectionId' | 'executionHostId'>
+): ExecutionHostId {
+  const executionHostId = normalizeExecutionHostId(group.executionHostId)
+  if (executionHostId) {
+    return executionHostId
   }
   return group.connectionId ? toSshExecutionHostId(group.connectionId) : LOCAL_EXECUTION_HOST_ID
+}
+
+function getProjectGroupRuntimeTarget(
+  group: Pick<ProjectGroup, 'connectionId' | 'executionHostId'>
+): ReturnType<typeof getActiveRuntimeTarget> {
+  const owner = parseExecutionHostId(getProjectGroupHostId(group))
+  return owner?.kind === 'runtime'
+    ? { kind: 'environment', environmentId: owner.environmentId }
+    : { kind: 'local' }
+}
+
+function findProjectGroupForMutation(
+  state: Pick<AppState, 'projectGroups' | 'settings'>,
+  groupId: string,
+  options?: ProjectGroupMutationOptions
+): ProjectGroup | null {
+  const matches = state.projectGroups.filter((group) => group.id === groupId)
+  if (options?.executionHostId) {
+    return matches.find((group) => getProjectGroupHostId(group) === options.executionHostId) ?? null
+  }
+  const focusedHostId = getRuntimeTargetHostId(getActiveRuntimeTarget(state.settings))
+  return (
+    matches.find((group) => getProjectGroupHostId(group) === focusedHostId) ??
+    (matches.length === 1 ? matches[0]! : null)
+  )
 }
 
 function getProjectGroupHostIdentity(group: ProjectGroup): string {
@@ -1885,9 +1919,10 @@ export type RepoSlice = {
   deleteFolderWorkspace: (folderWorkspaceId: string) => Promise<boolean>
   updateProjectGroup: (
     groupId: string,
-    updates: Partial<Pick<ProjectGroup, 'name' | 'isCollapsed' | 'tabOrder' | 'color'>>
+    updates: Partial<Pick<ProjectGroup, 'name' | 'isCollapsed' | 'tabOrder' | 'color'>>,
+    options?: ProjectGroupMutationOptions
   ) => Promise<boolean>
-  deleteProjectGroup: (groupId: string) => Promise<boolean>
+  deleteProjectGroup: (groupId: string, options?: ProjectGroupMutationOptions) => Promise<boolean>
   deleteProjectGroupWithContainedProjects: (
     groupId: string,
     options: DeleteProjectGroupWithContainedProjectsOptions
@@ -2990,10 +3025,15 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
     }
   },
 
-  updateProjectGroup: async (groupId, updates) => {
+  updateProjectGroup: async (groupId, updates, options) => {
+    const group = findProjectGroupForMutation(get(), groupId, options)
+    if (!group) {
+      return false
+    }
+    const ownerHostId = getProjectGroupHostId(group)
     try {
-      // Why: project groups are focused-host-scoped by design; all CRUD routes by the focused host and the list is replaced, not merged.
-      const target = getActiveRuntimeTarget(get().settings)
+      // Why: all-host catalogs outlive focus changes, so mutations must follow the row's persisted owner.
+      const target = getProjectGroupRuntimeTarget(group)
       const updated =
         target.kind === 'local'
           ? await window.api.projectGroups.update({ groupId, updates })
@@ -3010,7 +3050,9 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       }
       const ownedGroup = projectGroupWithFetchedOwner(updated, target)
       set((s) => ({
-        projectGroups: s.projectGroups.map((group) => (group.id === groupId ? ownedGroup : group)),
+        projectGroups: s.projectGroups.map((entry) =>
+          entry.id === groupId && getProjectGroupHostId(entry) === ownerHostId ? ownedGroup : entry
+        ),
         folderWorkspacePathStatuses: {}
       }))
       return true
@@ -3020,10 +3062,14 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
     }
   },
 
-  deleteProjectGroup: async (groupId) => {
+  deleteProjectGroup: async (groupId, options) => {
+    const group = findProjectGroupForMutation(get(), groupId, options)
+    if (!group) {
+      return false
+    }
+    const ownerHostId = getProjectGroupHostId(group)
     try {
-      // Why: project groups are focused-host-scoped by design (see updateProjectGroup).
-      const target = getActiveRuntimeTarget(get().settings)
+      const target = getProjectGroupRuntimeTarget(group)
       const deleted =
         target.kind === 'local'
           ? await window.api.projectGroups.delete({ groupId })
@@ -3039,14 +3085,24 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
         return false
       }
       set((s) => {
-        const deletedGroupIds = getProjectGroupSubtreeIds(s.projectGroups, groupId)
+        const ownerGroups = s.projectGroups.filter(
+          (entry) => getProjectGroupHostId(entry) === ownerHostId
+        )
+        const deletedGroupIds = getProjectGroupSubtreeIds(ownerGroups, groupId)
         return {
-          projectGroups: s.projectGroups.filter((group) => !deletedGroupIds.has(group.id)),
+          projectGroups: s.projectGroups.filter(
+            (entry) =>
+              getProjectGroupHostId(entry) !== ownerHostId || !deletedGroupIds.has(entry.id)
+          ),
           folderWorkspaces: s.folderWorkspaces.filter(
-            (workspace) => !deletedGroupIds.has(workspace.projectGroupId)
+            (workspace) =>
+              getFolderWorkspaceHostId(workspace, s.projectGroups) !== ownerHostId ||
+              !deletedGroupIds.has(workspace.projectGroupId)
           ),
           repos: s.repos.map((repo) =>
-            repo.projectGroupId && deletedGroupIds.has(repo.projectGroupId)
+            repo.projectGroupId &&
+            getRepoExecutionHostId(repo) === ownerHostId &&
+            deletedGroupIds.has(repo.projectGroupId)
               ? { ...repo, projectGroupId: null }
               : repo
           ),
@@ -3061,7 +3117,16 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
   },
 
   deleteProjectGroupWithContainedProjects: async (groupId, options) => {
-    const targets = selectProjectGroupRemovalTargets(get().projectGroups, get().repos, groupId)
+    const state = get()
+    const group = findProjectGroupForMutation(state, groupId, options)
+    const ownerHostId = group ? getProjectGroupHostId(group) : null
+    const targets = selectProjectGroupRemovalTargets(
+      ownerHostId
+        ? state.projectGroups.filter((entry) => getProjectGroupHostId(entry) === ownerHostId)
+        : [],
+      ownerHostId ? state.repos.filter((repo) => getRepoExecutionHostId(repo) === ownerHostId) : [],
+      groupId
+    )
     const requestedProjectIds = options.removeContainedProjects ? targets.projectIds : []
     if (!targets.groupExists) {
       return {
@@ -3073,7 +3138,10 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       }
     }
 
-    const deleted = await get().deleteProjectGroup(groupId)
+    const deleted = await get().deleteProjectGroup(
+      groupId,
+      ownerHostId ? { executionHostId: ownerHostId } : undefined
+    )
     if (!deleted) {
       return {
         status: 'group-delete-failed',


### PR DESCRIPTION
## ELI5

Project Group actions now follow the machine that owns the selected group instead of whichever machine happens to be focused.

## What Changed

- Carry the selected Project Group object and its `executionHostId` through the rename/delete dialogs.
- Resolve update/delete mutations by `[executionHostId, groupId]` and route them to the owner runtime.
- Scope group subtree, workspace, and project cleanup to the same owner.
- Preserve backward compatibility for callers that omit an owner by preferring the focused host, then a unique row.
- Add same-ID local/remote collision regression coverage for rename and delete.

## Why

The all-host catalog already treats `[hostId, groupId]` as identity, but Project Group mutations discarded the host and routed through the currently focused runtime. Served Web clients can have no focused runtime, and paired Desktop clients can focus a different host, so rename/delete could hit the wrong persistence store and silently return `false`/`null`.

## Linked Issue

Fixes #15099

## Visual Proof

N/A — this fixes routing behind the existing sidebar actions and does not change visual design. A served-Web RuntimeClient rename round trip was verified on the original v1.4.183 headless deployment before the patch was rebased onto current `main`.

## Testing

- [x] Tested locally
- [x] Added or updated automated tests

Commands/results on current `main`:

- `pnpm exec vitest run --config config/vitest.config.ts ...` — 3 files, 31 tests passed.
- `pnpm run typecheck:web` — passed.
- `pnpm exec oxlint <7 changed files>` — passed.
- `pnpm exec oxfmt --check <7 changed files>` — passed.
- `git diff --check` — passed.
- `pnpm run check:code-quality:changed` — passed with 0 new findings across 7 files, including type-aware checks and React Doctor. The first attempt from the original shallow/grafted v1.4.183 checkout could not find an `origin/main` merge-base; after unshallowing and rebuilding the branch on current `main`, the same gate passed.
- `pnpm run build:electron-vite && pnpm run build:web-from-renderer` — passed; projected 879 web files (42.5 MiB).

The installed packaged Windows Desktop client was not validated with this source patch; CI/release packaging is still required for that client.

## AI Disclosure

Implemented and reviewed with OpenAI Codex.

## Review

- **Cross-platform:** Renderer/store-only change; no platform-specific paths or shortcuts.
- **Remote/SSH/local:** Runtime-owned groups route remotely; local and SSH-owned groups keep the local persistence path. Selected owner remains stable if focus changes.
- **Agents/providers/integrations:** No agent or provider behavior changed.
- **Performance:** Mutation-time filtering over the in-memory Project Group catalog only.
- **Security:** No authentication, permission, or RPC wire-surface changes.
- **Backward compatibility:** The owner option is optional; legacy callers still resolve via focused host or a unique matching row.

## Checklist

- [x] This PR is focused and scoped to the linked bug.
- [x] No release/version files were changed.
- [x] Tests cover cross-host `groupId` collision safety.
- [x] Targeted tests, changed-file quality checks, typecheck, and renderer/Web builds pass locally.
- [ ] Full repository `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` suite (CI will cover broader matrices).

## Author

- X / Twitter: not provided (GitHub: @JasonJarvan)