### PR TITLE
feat(worktrees): preserve slashes in derived branch names

### DIFF
--- a/src/main/ipc/worktree-branch-name-git-validity.test.ts
+++ b/src/main/ipc/worktree-branch-name-git-validity.test.ts
@@ -10,6 +10,8 @@ const ADVERSARIAL_INPUTS = [
   'feature/.hidden',
   'feature/tti.lock',
   'feature/tti.LOCK',
+  'feature/tti.lock.lock',
+  'feature/tti.Lock.lock',
   'a..b/c...d',
   'feature/中文',
   'feature/🚀',

--- a/src/main/ipc/worktree-branch-name-git-validity.test.ts
+++ b/src/main/ipc/worktree-branch-name-git-validity.test.ts
@@ -1,0 +1,84 @@
+import { execFileSync } from 'node:child_process'
+import { describe, expect, it } from 'vitest'
+import { sanitizeWorktreeBranchName } from './worktree-logic'
+
+const ADVERSARIAL_INPUTS = [
+  'feature/tti_fix_1440',
+  'feature/tti fix',
+  '/feature//tti/',
+  'foo/../bar',
+  'feature/.hidden',
+  'feature/tti.lock',
+  'feature/tti.LOCK',
+  'a..b/c...d',
+  'feature/中文',
+  'feature/🚀',
+  'feat: 中文 (v2)',
+  'a/b/c/d/e',
+  'feature/tti@{v2}',
+  'feature/tti~1',
+  'feature/tti^2',
+  'feature/tti:1',
+  'feature/tti?',
+  'feature/tti*',
+  'feature/tti[1]',
+  'feature/tti\\win',
+  'feature/tti fix 123',
+  '...',
+  '///',
+  'a/./b',
+  'feature/tti.',
+  'feature/.tti',
+  'feature/-tti-',
+  'feature/tti--fix',
+  'feature/tti.lock.bak',
+  'feature/tti_lock',
+  'FEATURE/Tti_Fix',
+  'feature/123',
+  'feature/tti(fix)',
+  'feature/tti[fix]',
+  'feature/tti@fix',
+  'feature/tti+fix',
+  'feature/tti=fix',
+  'feature/tti&fix',
+  'feature/tti%fix',
+  'feature/tti#fix',
+  'feature/tti!fix',
+  'feature/tti`fix`',
+  'feature/tti|fix',
+  'feature/tti;fix',
+  'feature/tti"fix"',
+  "feature/tti'fix'",
+  'feature/tti<fix>',
+  'feature/tti{fix}',
+  'feature/tti fix / v2',
+  '\tfeature/tti\n',
+  'feature//tti///fix',
+  'feature/tti fix/other thing',
+  'feature/日本語/テスト',
+  'feature/Привет/мир',
+  'feature/café/déjà',
+  'feature/🚀/✨',
+  'feature/1️⃣/2️⃣'
+]
+
+describe('sanitizeWorktreeBranchName git validity', () => {
+  it('produces names git check-ref-format accepts for every adversarial input', () => {
+    const failures: string[] = []
+    for (const input of ADVERSARIAL_INPUTS) {
+      let branch: string
+      try {
+        branch = sanitizeWorktreeBranchName(input)
+      } catch {
+        // Throwing on unusable input is acceptable.
+        continue
+      }
+      try {
+        execFileSync('git', ['check-ref-format', '--branch', branch], { stdio: 'pipe' })
+      } catch {
+        failures.push(`${JSON.stringify(input)} -> ${JSON.stringify(branch)}`)
+      }
+    }
+    expect(failures).toEqual([])
+  })
+})

--- a/src/main/ipc/worktree-branch-name-git-validity.test.ts
+++ b/src/main/ipc/worktree-branch-name-git-validity.test.ts
@@ -64,6 +64,9 @@ const ADVERSARIAL_INPUTS = [
   'feature/1️⃣/2️⃣'
 ]
 
+// Inputs whose segments all sanitize away — the sanitizer is allowed to throw on these.
+const UNUSABLE_INPUTS = new Set(['...', '///'])
+
 describe('sanitizeWorktreeBranchName git validity', () => {
   it('produces names git check-ref-format accepts for every adversarial input', () => {
     const failures: string[] = []
@@ -71,8 +74,12 @@ describe('sanitizeWorktreeBranchName git validity', () => {
       let branch: string
       try {
         branch = sanitizeWorktreeBranchName(input)
-      } catch {
-        // Throwing on unusable input is acceptable.
+      } catch (error) {
+        if (UNUSABLE_INPUTS.has(input)) {
+          continue
+        }
+        const reason = error instanceof Error ? error.message : String(error)
+        failures.push(`${JSON.stringify(input)} threw unexpectedly: ${reason}`)
         continue
       }
       try {
@@ -82,5 +89,9 @@ describe('sanitizeWorktreeBranchName git validity', () => {
       }
     }
     expect(failures).toEqual([])
+  })
+
+  it('does not throw on documented sanitizable inputs', () => {
+    expect(() => sanitizeWorktreeBranchName('feature/tti_fix_1440')).not.toThrow()
   })
 })

--- a/src/main/ipc/worktree-logic.test.ts
+++ b/src/main/ipc/worktree-logic.test.ts
@@ -2,6 +2,7 @@ import { posix, resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
   sanitizeWorktreeName,
+  sanitizeWorktreeBranchName,
   sanitizeWorktreeDisplayName,
   ensurePathWithinWorkspace,
   computeBranchName,
@@ -101,6 +102,58 @@ describe('sanitizeWorktreeName', () => {
 
   it('throws for whitespace-only name', () => {
     expect(() => sanitizeWorktreeName('   ')).toThrow('Invalid worktree name')
+  })
+})
+
+describe('sanitizeWorktreeBranchName', () => {
+  it('preserves the slash separator for conventional feature/name branches', () => {
+    expect(sanitizeWorktreeBranchName('feature/tti_fix_1440')).toBe('feature/tti_fix_1440')
+  })
+
+  it('leaves slash-free names identical to sanitizeWorktreeName', () => {
+    expect(sanitizeWorktreeBranchName('tti_fix_1440')).toBe('tti_fix_1440')
+    expect(sanitizeWorktreeBranchName('my feature')).toBe('my-feature')
+  })
+
+  it('sanitizes each slash-separated segment independently', () => {
+    expect(sanitizeWorktreeBranchName('feature/tti fix')).toBe('feature/tti-fix')
+    expect(sanitizeWorktreeBranchName('feat: 中文 (v2)')).toBe('feat-中文-v2')
+  })
+
+  it('drops empty segments from leading, trailing, or doubled slashes', () => {
+    expect(sanitizeWorktreeBranchName('/feature//tti/')).toBe('feature/tti')
+  })
+
+  it('collapses dot sequences per segment so traversal sequences cannot reach git', () => {
+    expect(sanitizeWorktreeBranchName('foo/../bar')).toBe('foo/bar')
+    expect(sanitizeWorktreeBranchName('a..b/c...d')).toBe('a.b/c.d')
+  })
+
+  it('strips leading dots per segment, which git check-ref-format rejects', () => {
+    expect(sanitizeWorktreeBranchName('feature/.hidden')).toBe('feature/hidden')
+  })
+
+  it('strips a trailing .lock suffix, which git reserves for ref lock files', () => {
+    expect(sanitizeWorktreeBranchName('feature/tti.lock')).toBe('feature/tti')
+    expect(sanitizeWorktreeBranchName('feature/tti.LOCK')).toBe('feature/tti')
+  })
+
+  it('preserves non-ASCII letters and numbers per segment', () => {
+    expect(sanitizeWorktreeBranchName('feature/中文')).toBe('feature/中文')
+  })
+
+  it('uses readable git-safe shortcodes for known emoji', () => {
+    expect(sanitizeWorktreeBranchName('feature/🚀')).toBe('feature/rocket')
+  })
+
+  it('uses a git-safe fallback for emoji newer than the shortcode catalog', () => {
+    expect(sanitizeWorktreeBranchName('\u{1faeb}')).toBe('workspace')
+  })
+
+  it('throws for empty or punctuation-only names', () => {
+    expect(() => sanitizeWorktreeBranchName('')).toThrow('Invalid worktree name')
+    expect(() => sanitizeWorktreeBranchName('///')).toThrow('Invalid worktree name')
+    expect(() => sanitizeWorktreeBranchName('!!!')).toThrow('Invalid worktree name')
   })
 })
 

--- a/src/main/ipc/worktree-logic.test.ts
+++ b/src/main/ipc/worktree-logic.test.ts
@@ -136,6 +136,7 @@ describe('sanitizeWorktreeBranchName', () => {
   it('strips a trailing .lock suffix, which git reserves for ref lock files', () => {
     expect(sanitizeWorktreeBranchName('feature/tti.lock')).toBe('feature/tti')
     expect(sanitizeWorktreeBranchName('feature/tti.LOCK')).toBe('feature/tti')
+    expect(sanitizeWorktreeBranchName('feature/tti.lock.lock')).toBe('feature/tti')
   })
 
   it('preserves non-ASCII letters and numbers per segment', () => {

--- a/src/main/ipc/worktree-logic.ts
+++ b/src/main/ipc/worktree-logic.ts
@@ -50,6 +50,44 @@ export function sanitizeWorktreeName(input: string): string {
   return sanitized
 }
 
+/**
+ * Sanitize a worktree name for use as a git branch name, preserving `/` as a
+ * segment separator. The directory name still uses sanitizeWorktreeName, so a
+ * name like `feature/foo` creates a flat `feature-foo` folder while the branch
+ * keeps the conventional `feature/foo` form.
+ */
+export function sanitizeWorktreeBranchName(input: string): string {
+  const sanitized = replaceKnownEmojiWithShortcodes(input)
+    .split('/')
+    .map(sanitizeBranchNameSegment)
+    .filter(Boolean)
+    .join('/')
+
+  if (!sanitized && containsEmoji(input)) {
+    return 'workspace'
+  }
+
+  if (!sanitized) {
+    throw new Error('Invalid worktree name')
+  }
+
+  return sanitized
+}
+
+function sanitizeBranchNameSegment(input: string): string {
+  return (
+    input
+      .trim()
+      .replace(/[^\p{L}\p{N}._-]+/gu, '-')
+      .replace(/-+/g, '-')
+      .replace(/\.{2,}/g, '.')
+      .replace(/^[.-]+|[.-]+$/g, '')
+      // Why: git check-ref-format rejects ref components ending in `.lock`,
+      // case-insensitively on Windows/macOS filesystems.
+      .replace(/\.lock$/i, '')
+  )
+}
+
 function containsEmoji(input: string): boolean {
   return /[\p{Emoji_Presentation}\p{Extended_Pictographic}\p{Regional_Indicator}\u20e3]/u.test(
     input

--- a/src/main/ipc/worktree-logic.ts
+++ b/src/main/ipc/worktree-logic.ts
@@ -83,8 +83,9 @@ function sanitizeBranchNameSegment(input: string): string {
       .replace(/\.{2,}/g, '.')
       .replace(/^[.-]+|[.-]+$/g, '')
       // Why: git check-ref-format rejects ref components ending in `.lock`,
-      // case-insensitively on Windows/macOS filesystems.
-      .replace(/\.lock$/i, '')
+      // case-insensitively on Windows/macOS filesystems. Strip repeated
+      // suffixes so `foo.lock.lock` cannot survive as `foo.lock`.
+      .replace(/(?:\.lock)+$/i, '')
   )
 }
 

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -75,6 +75,7 @@ type CreateWorktreeArgsWithSystemProvenance = CreateWorktreeArgs & {
 }
 import {
   sanitizeWorktreeName,
+  sanitizeWorktreeBranchName,
   sanitizeWorktreeDisplayName,
   computeValidatedBranchName,
   computeWorktreePath,
@@ -1539,7 +1540,10 @@ export async function createRemoteWorktree(
   const worktreePathSettings = getWorktreePathSettings(repo, settings)
   let effectiveRequestedName = args.name
   const sanitizedName = sanitizeWorktreeName(args.name)
+  // Why: the branch keeps the user's `feature/...` convention; only the directory name is flattened.
+  const branchSafeName = sanitizeWorktreeBranchName(args.name)
   let effectiveSanitizedName = sanitizedName
+  let effectiveBranchName = branchSafeName
   const requestedDisplayName = args.displayName
     ? sanitizeWorktreeDisplayName(args.displayName)
     : undefined
@@ -1609,6 +1613,9 @@ export async function createRemoteWorktree(
           retiredNameRegistry?.exhaustedTiers
         )
       : getWorktreeCreateCandidate(sanitizedName, suffix)
+    effectiveBranchName = shouldRetireGeneratedName
+      ? effectiveSanitizedName
+      : getWorktreeCreateCandidate(branchSafeName, suffix)
     effectiveRequestedName = shouldRetireGeneratedName
       ? effectiveSanitizedName
       : args.name.trim()
@@ -1623,7 +1630,7 @@ export async function createRemoteWorktree(
       repo.path,
       selectedExistingLocalBranchName ??
         getBranchNameOverrideCandidate(args.branchNameOverride, suffix),
-      effectiveSanitizedName,
+      effectiveBranchName,
       settings,
       username
     )
@@ -1998,6 +2005,8 @@ export async function createLocalWorktree(
 
   const requestedName = args.name
   const sanitizedName = sanitizeWorktreeName(args.name)
+  // Why: the branch keeps the user's `feature/...` convention; only the directory name is flattened.
+  const branchSafeName = sanitizeWorktreeBranchName(args.name)
   const requestedDisplayName = args.displayName
     ? sanitizeWorktreeDisplayName(args.displayName)
     : undefined
@@ -2160,6 +2169,7 @@ export async function createLocalWorktree(
 
   let effectiveRequestedName = requestedName
   let effectiveSanitizedName = sanitizedName
+  let effectiveBranchName = branchSafeName
   let branchName = ''
   let worktreePath = ''
 
@@ -2185,6 +2195,9 @@ export async function createLocalWorktree(
           retiredNameRegistry?.exhaustedTiers
         )
       : getWorktreeCreateCandidate(sanitizedName, suffix)
+    effectiveBranchName = shouldRetireGeneratedName
+      ? effectiveSanitizedName
+      : getWorktreeCreateCandidate(branchSafeName, suffix)
     effectiveRequestedName = shouldRetireGeneratedName
       ? effectiveSanitizedName
       : requestedName.trim()
@@ -2201,7 +2214,7 @@ export async function createLocalWorktree(
       selectedExistingLocalBranchName
         ? selectedExistingLocalBranchName
         : getBranchNameOverrideCandidate(args.branchNameOverride, suffix),
-      effectiveSanitizedName,
+      effectiveBranchName,
       settings,
       username,
       localWorktreeGitOptions

--- a/src/main/ipc/worktrees-local-create-flow.test.ts
+++ b/src/main/ipc/worktrees-local-create-flow.test.ts
@@ -339,6 +339,35 @@ describe('registerWorktreeHandlers', () => {
     )
   })
 
+  it('preserves slashes in the branch name while flattening the worktree path', async () => {
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/feature-something',
+        head: 'abc123',
+        branch: 'refs/heads/feature/something',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    await handlers['worktrees:create'](null, {
+      repoId: 'repo-1',
+      name: 'feature/something'
+    })
+
+    expect(addWorktreeMock).toHaveBeenCalledWith(
+      '/workspace/repo',
+      '/workspace/feature-something',
+      'feature/something',
+      'origin/main',
+      false
+    )
+    expect(store.setWorktreeMeta).toHaveBeenCalledWith(
+      'repo-1::/workspace/feature-something',
+      expect.objectContaining({ displayName: 'feature/something' })
+    )
+  })
+
   it('uses a repo-specific worktree base path when creating local worktrees', async () => {
     store.getRepo.mockReturnValue({
       id: 'repo-1',

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1147,6 +1147,7 @@ import {
   isOrphanedWorktreeError,
   mergeWorktree,
   sanitizeWorktreeName,
+  sanitizeWorktreeBranchName,
   shouldSetDisplayName,
   areWorktreePathsEqual
 } from '../ipc/worktree-logic'
@@ -24912,7 +24913,10 @@ export class OrcaRuntimeService {
     let effectiveRequestedName = args.name
     const requestedDisplayName = args.displayName?.trim() || undefined
     const sanitizedName = sanitizeWorktreeName(args.name)
+    // Why: the branch keeps the user's `feature/...` convention; only the directory name is flattened.
+    const branchSafeName = sanitizeWorktreeBranchName(args.name)
     let effectiveSanitizedName = sanitizedName
+    let effectiveBranchName = branchSafeName
     // Why: explicit branches and non-username prefix modes never consume this
     // value; skipping the probes preserves the exact generated branch name.
     const username =
@@ -24994,6 +24998,9 @@ export class OrcaRuntimeService {
             retiredNameRegistry?.exhaustedTiers
           )
         : getWorktreeCreateCandidate(sanitizedName, suffix)
+      effectiveBranchName = shouldRetireGeneratedName
+        ? effectiveSanitizedName
+        : getWorktreeCreateCandidate(branchSafeName, suffix)
       effectiveRequestedName = shouldRetireGeneratedName
         ? effectiveSanitizedName
         : args.name.trim()
@@ -25007,7 +25014,7 @@ export class OrcaRuntimeService {
         repo.path,
         selectedExistingLocalBranchName ??
           getBranchNameOverrideCandidate(args.branchNameOverride, suffix),
-        effectiveSanitizedName,
+        effectiveBranchName,
         settings,
         username,
         localWorktreeGitOptions


### PR DESCRIPTION
## ELI5

When you name a new workspace `feature/tti_fix_1440`, Orca used to name the git branch `feature-tti_fix_1440` — the slash got flattened because the same sanitizer served both the folder name and the branch name. Now Orca keeps the slash in the branch (`feature/tti_fix_1440`) while the folder stays flat (`feature-tti_fix_1440`), so teams with `feature/xx` branch conventions get branches they can actually use.

## What Changed

- New `sanitizeWorktreeBranchName()` in `worktree-logic.ts`: splits the typed name on `/`, sanitizes each segment against git branch-name rules, drops empty segments, and joins with `/`.
- The directory name still uses the existing `sanitizeWorktreeName()` (flattened), so folders never nest.
- Wired into all three create flows: local IPC (`createLocalWorktree`), SSH (`createRemoteWorktree`), and runtime (`createManagedWorktree`, used by the CLI).
- Per-segment rules: git-illegal characters → `-`, `..` collapsed, leading dots and trailing `.lock` (case-insensitive, repeated suffixes stripped) removed — every output passes `git check-ref-format --branch`.
- `branchPrefix` setting and `branchNameOverride` paths are untouched.

## Why

The flattening only exists to keep workspace folders flat; git fully supports `/` in branch names, and Orca already produces slash branches when `branchPrefix` is set. Deriving the branch from the raw name aligns the actual branch with the name the user typed (and with the display name the UI already shows).

## Linked Issue

Fixes #15122

## Visual Proof

N/A — no visual or interaction change. The sidebar display name already preserved the typed `feature/...` form; only the underlying git branch name changes, which is visible via `git branch` / the worktree's branch metadata.

## Testing

- Unit tests for `sanitizeWorktreeBranchName`: slash preservation, per-segment sanitization, repeated `.lock` stripping, emoji shortcodes, non-ASCII, throw cases.
- Create-flow integration test: `feature/something` → branch `feature/something` + path `feature-something`.
- Property test: 60+ adversarial inputs (traversal sequences, git-illegal chars, control chars, emoji, CJK, repeated `.lock`) all produce names accepted by real `git check-ref-format --branch`.
- Real git end-to-end: `git worktree add -b feature/tti_fix_1440 … feature-tti_fix_1440` succeeds.
- `pnpm typecheck`, `oxlint`, and the worktree/runtime test suites (1200+ tests) pass locally on macOS. Full `pnpm test` / `pnpm build` left to CI.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

## AI Disclosure

Developed with Claude Code (Anthropic Claude).

## Review

- **Security**: branch names are sanitized per segment before reaching git; path traversal (`..`, empty segments) cannot survive. No new external input surface.
- **Cross-platform (Linux/Windows/macOS)**: sanitizer is platform-neutral; `.lock` stripping is case-insensitive to cover case-insensitive filesystems. Directory logic unchanged.
- **Remote SSH**: SSH create flow wired identically; no SSH-specific assumptions.
- **Mobile**: runtime create flow (shared with mobile callers) wired identically.
- **Backwards compatibility**: names without `/` produce byte-identical branch names to before; `branchPrefix` and `branchNameOverride` paths unchanged.
- **Performance**: one extra string sanitization per create attempt; negligible.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @MattYu172786
