### PR TITLE
feat(terminal): move a live terminal tab to another worktree

### DIFF
--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -35,6 +35,7 @@ export {
   formatTerminalCreate,
   formatTerminalFocus,
   formatTerminalList,
+  formatTerminalMove,
   formatTerminalRead,
   formatTerminalRename,
   formatTerminalSend,

--- a/src/cli/handler-group-manifest.ts
+++ b/src/cli/handler-group-manifest.ts
@@ -95,6 +95,7 @@ export const HANDLER_GROUPS: readonly HandlerGroup[] = [
       'terminal create',
       'terminal switch',
       'terminal close',
+      'terminal move',
       'terminal split'
     ],
     load: async () => (await import('./handlers/terminal.js')).TERMINAL_HANDLERS

--- a/src/cli/handlers/terminal.test.ts
+++ b/src/cli/handlers/terminal.test.ts
@@ -62,6 +62,99 @@ describe('terminal close CLI', () => {
   })
 })
 
+describe('terminal move CLI', () => {
+  const originalHandle = process.env.ORCA_TERMINAL_HANDLE
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    if (originalHandle === undefined) {
+      delete process.env.ORCA_TERMINAL_HANDLE
+    } else {
+      process.env.ORCA_TERMINAL_HANDLE = originalHandle
+    }
+  })
+
+  it('defaults --terminal to $ORCA_TERMINAL_HANDLE', async () => {
+    process.env.ORCA_TERMINAL_HANDLE = 'term_env'
+    const call = vi.fn().mockResolvedValue({
+      result: {
+        move: {
+          handle: 'term_env',
+          tabId: 'tab-1',
+          sourceWorktreeId: 'repo::/src',
+          destWorktreeId: 'repo::/dest',
+          ptyIds: ['pty-1']
+        }
+      }
+    })
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await TERMINAL_HANDLERS['terminal move']({
+      flags: new Map([['worktree', 'id:repo::/dest']]),
+      client: { call } as unknown as RuntimeClient,
+      cwd: '/tmp/worktree',
+      json: true
+    })
+
+    expect(call).toHaveBeenCalledWith('terminal.move', {
+      terminal: 'term_env',
+      worktree: 'id:repo::/dest',
+      tab: false
+    })
+  })
+
+  it('routes --tab so a pane handle moves the whole tab', async () => {
+    const parsed = parseArgs([
+      'terminal',
+      'move',
+      '--terminal',
+      'term-1',
+      '--worktree',
+      'id:repo::/dest',
+      '--tab'
+    ])
+    const call = vi.fn().mockResolvedValue({
+      result: {
+        move: {
+          handle: 'term-1',
+          tabId: 'tab-1',
+          sourceWorktreeId: 'repo::/src',
+          destWorktreeId: 'repo::/dest',
+          ptyIds: ['pty-1']
+        }
+      }
+    })
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await TERMINAL_HANDLERS['terminal move']({
+      flags: parsed.flags,
+      client: { call } as unknown as RuntimeClient,
+      cwd: '/tmp/worktree',
+      json: true
+    })
+
+    expect(parsed.flags.get('tab')).toBe(true)
+    expect(call).toHaveBeenCalledWith('terminal.move', {
+      terminal: 'term-1',
+      worktree: 'id:repo::/dest',
+      tab: true
+    })
+  })
+
+  it('documents that --tab moves the whole tab', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    printHelp(COMMAND_SPECS, ['terminal', 'move'])
+
+    const help = String(log.mock.calls[0]?.[0])
+    expect(help).toContain(
+      'orca terminal move --worktree <selector> [--terminal <handle>] [--tab] [--json]'
+    )
+    expect(help).toContain('whole tab')
+    expect(help).toContain('ORCA_TERMINAL_HANDLE')
+  })
+})
+
 describe('terminal send CLI', () => {
   afterEach(() => {
     vi.restoreAllMocks()

--- a/src/cli/handlers/terminal.ts
+++ b/src/cli/handlers/terminal.ts
@@ -3,6 +3,7 @@ import type {
   RuntimeTerminalCreate,
   RuntimeTerminalFocus,
   RuntimeTerminalListResult,
+  RuntimeTerminalMove,
   RuntimeTerminalRead,
   RuntimeTerminalRename,
   RuntimeTerminalSend,
@@ -17,6 +18,7 @@ import {
   formatTerminalCreate,
   formatTerminalFocus,
   formatTerminalList,
+  formatTerminalMove,
   formatTerminalRead,
   formatTerminalRename,
   formatTerminalSend,
@@ -33,6 +35,7 @@ import {
 import { RuntimeClientError } from '../runtime-client'
 import {
   getBrowserWorktreeSelector,
+  getMoveTerminalHandle,
   getOptionalWorktreeSelector,
   getRequiredWorktreeSelector,
   getTerminalHandle
@@ -162,6 +165,14 @@ export const TERMINAL_HANDLERS: Record<string, CommandHandler> = {
       terminal: await getTerminalHandle(flags, cwd, client)
     })
     printResult(result, json, formatTerminalClose)
+  },
+  'terminal move': async ({ flags, client, cwd, json }) => {
+    const result = await client.call<{ move: RuntimeTerminalMove }>('terminal.move', {
+      terminal: getMoveTerminalHandle(flags),
+      worktree: await getRequiredWorktreeSelector(flags, 'worktree', cwd, client),
+      tab: flags.get('tab') === true
+    })
+    printResult(result, json, formatTerminalMove)
   },
   'terminal split': async ({ flags, client, cwd, json }) => {
     const directionFlag = getOptionalStringFlag(flags, 'direction')

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -91,6 +91,7 @@ Terminals:
   terminal switch           Bring a terminal tab to the foreground
   terminal focus            Alias for terminal switch
   terminal close            Close a terminal pane/session, or its whole tab with --tab
+  terminal move             Move a live terminal tab to another worktree
 
 Orchestration:
   orchestration run-create  Create and bind a lightweight orchestration Run
@@ -249,6 +250,7 @@ Common Commands:
   orca terminal split [--terminal <handle>] [--direction horizontal|vertical] [--json]
   orca terminal switch [--terminal <handle>] [--json]
   orca terminal close [--terminal <handle>] [--tab] [--json]
+  orca terminal move --worktree <selector> [--terminal <handle>] [--tab] [--json]
   orca project list [--json]
   orca project setups [--project <id>] [--host <host-id>] [--json]
   orca project setup-existing-folder --project <id> --host <host-id> --path <path> [--kind git|folder] [--display-name <name>] [--json]
@@ -434,6 +436,9 @@ function formatCommandFlagHelp(flag: string, commandPath: string[]): string {
   }
   if (command === 'terminal close' && flag === 'tab') {
     return '--tab                  Close the whole tab and wait for durable persistence'
+  }
+  if (command === 'terminal move' && flag === 'tab') {
+    return '--tab                  Move the whole tab when --terminal names a pane'
   }
   if (command === 'linear issue' && flag === 'id') {
     return '--id <id>             Linear issue key, id, or URL'

--- a/src/cli/selectors.ts
+++ b/src/cli/selectors.ts
@@ -145,6 +145,26 @@ export async function getBrowserWorktreeSelector(
 // Why: mirrors browser's implicit active-tab targeting. When --terminal is
 // omitted, resolve the active terminal in the current worktree so commands
 // like `orca terminal send --text "hello" --enter` Just Work.
+export function getEnvTerminalHandle(): string | undefined {
+  const value = process.env.ORCA_TERMINAL_HANDLE
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+export function getMoveTerminalHandle(flags: Map<string, string | boolean>): string {
+  const explicit = getOptionalStringFlag(flags, 'terminal')
+  if (explicit) {
+    return explicit
+  }
+  const envHandle = getEnvTerminalHandle()
+  if (envHandle) {
+    return envHandle
+  }
+  throw new RuntimeClientError(
+    'invalid_argument',
+    'Pass --terminal <handle> or run the command inside a live Orca terminal with ORCA_TERMINAL_HANDLE set.'
+  )
+}
+
 export async function getTerminalHandle(
   flags: Map<string, string | boolean>,
   cwd: string,

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -270,6 +270,22 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
     ]
   },
   {
+    path: ['terminal', 'move'],
+    summary: 'Move a live terminal tab to another worktree without killing its process',
+    usage:
+      'orca terminal move --worktree <selector> [--terminal <handle>] [--tab] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'terminal', 'worktree', 'tab'],
+    notes: [
+      'Keeps the PTY alive and reattaches the existing tab to the destination worktree. The child process is not forced to chdir.',
+      'Omit --terminal to use $ORCA_TERMINAL_HANDLE from the current Orca terminal.',
+      'With --tab, a pane handle moves the whole tab. The floating terminal is not a valid destination.'
+    ],
+    examples: [
+      'orca terminal move --worktree name:follow-up',
+      'orca terminal move --terminal term_abc123 --worktree path:/projects/myapp --tab --json'
+    ]
+  },
+  {
     path: ['terminal', 'rename'],
     summary: 'Set or clear the title of a terminal tab',
     usage: 'orca terminal rename [--terminal <handle>] [--title <text>] [--json]',

--- a/src/cli/terminal-format.ts
+++ b/src/cli/terminal-format.ts
@@ -3,6 +3,7 @@ import type {
   RuntimeTerminalClose,
   RuntimeTerminalCreate,
   RuntimeTerminalFocus,
+  RuntimeTerminalMove,
   RuntimeTerminalListHostScope,
   RuntimeTerminalListResult,
   RuntimeTerminalVisualLayout,
@@ -198,6 +199,10 @@ function describePtyStop(close: RuntimeTerminalClose): string {
     return ` ${describeUnconfirmedStop(close.ptyStopReason ?? 'its host could not be reached')}`
   }
   return ''
+}
+
+export function formatTerminalMove(result: { move: RuntimeTerminalMove }): string {
+  return `Moved terminal ${result.move.handle} (tab ${result.move.tabId}) from ${result.move.sourceWorktreeId} to ${result.move.destWorktreeId}.`
 }
 
 export function formatTerminalClose(result: { close: RuntimeTerminalClose }): string {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -5860,6 +5860,20 @@ export function registerPtyHandlers(
         return null
       }
     },
+    setWorktreeId: (ptyId, worktreeId) => {
+      // Why: a remote PTY must never fall through to the local map; lookup or
+      // missing rebind support has to fail closed so callers can refuse persist.
+      let provider: IPtyProvider
+      try {
+        provider = getProviderForPty(ptyId)
+      } catch {
+        return false
+      }
+      if (!provider.setWorktreeId) {
+        return false
+      }
+      return provider.setWorktreeId(ptyId, worktreeId)
+    },
     listProcesses: async (connectionId) => {
       if (connectionId === null) {
         return localProvider.listProcesses()

--- a/src/main/providers/local-pty-provider-session-inventory.test.ts
+++ b/src/main/providers/local-pty-provider-session-inventory.test.ts
@@ -175,6 +175,20 @@ describe('LocalPtyProvider', () => {
       expect(newEntries[1]).not.toHaveProperty('wslDistro')
     })
 
+    it('updates worktreeId on a live PTY without respawning', async () => {
+      const spawned = await provider.spawn({
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp/owned-cwd',
+        worktreeId: 'repo::/tmp/owned-cwd'
+      })
+      provider.setWorktreeId(spawned.id, 'repo::/tmp/moved-cwd')
+      const listed = await provider.listProcesses()
+      expect(listed.find((entry) => entry.id === spawned.id)?.worktreeId).toBe(
+        'repo::/tmp/moved-cwd'
+      )
+    })
+
     it('reports native and WSL ownership explicitly on Windows', async () => {
       Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
       const native = await provider.spawn({

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -1473,6 +1473,14 @@ export class LocalPtyProvider implements IPtyProvider {
     /* re-spawning handles local revival */
   }
 
+  setWorktreeId(id: string, worktreeId: string): boolean {
+    if (!ptyProcesses.has(id) || worktreeId.length === 0) {
+      return false
+    }
+    ptyWorktreeId.set(id, worktreeId)
+    return true
+  }
+
   async listProcesses(): Promise<PtyProcessInfo[]> {
     return Array.from(ptyProcesses.entries()).map(([id, proc]) => ({
       id,

--- a/src/main/providers/pty-provider-contract.ts
+++ b/src/main/providers/pty-provider-contract.ts
@@ -212,6 +212,8 @@ export type IPtyProvider = {
   revive(state: string): Promise<void>
   // Why: deadlineMs bounds the underlying RPC exactly like shutdown's deadlineMs.
   listProcesses(opts?: { deadlineMs?: number }): Promise<PtyProcessInfo[]>
+  /** Rebind a live PTY's worktree map without killing or respawning it. */
+  setWorktreeId?(id: string, worktreeId: string): boolean
   getDefaultShell(): Promise<string>
   getProfiles(): Promise<{ name: string; path: string }[]>
   onData(callback: (payload: PtyDataEvent) => void): () => void

--- a/src/main/providers/ssh-pty-provider-process-events.test.ts
+++ b/src/main/providers/ssh-pty-provider-process-events.test.ts
@@ -50,6 +50,32 @@ describe('SshPtyProvider process listings and events', () => {
     }
   })
 
+  it('rebinds a live remote PTY worktree without falling back to a local map', async () => {
+    mux.request.mockResolvedValue([
+      { id: 'pty-1', cwd: '/home', title: 'zsh', worktreeId: 'repo::/home' }
+    ])
+    await provider.listProcesses()
+
+    expect(provider.setWorktreeId(scopedPty1, 'repo::/moved')).toBe(true)
+    expect(mux.notify).toHaveBeenCalledWith('pty.setWorktreeId', {
+      id: 'pty-1',
+      worktreeId: 'repo::/moved'
+    })
+
+    mux.request.mockResolvedValue([
+      { id: 'pty-1', cwd: '/home', title: 'zsh', worktreeId: 'repo::/home' }
+    ])
+    await expect(provider.listProcesses()).resolves.toEqual([
+      { id: scopedPty1, cwd: '/home', title: 'zsh', worktreeId: 'repo::/moved' }
+    ])
+  })
+
+  it('fails closed when the SSH provider cannot own the PTY', () => {
+    expect(provider.setWorktreeId('ssh:other@@pty-1', 'repo::/moved')).toBe(false)
+    expect(provider.setWorktreeId(scopedPty1, '')).toBe(false)
+    expect(mux.notify).not.toHaveBeenCalled()
+  })
+
   it('scopes recovered claim owner ids with their SSH connection', async () => {
     mux.request.mockResolvedValue([
       {

--- a/src/main/providers/ssh-pty-provider.ts
+++ b/src/main/providers/ssh-pty-provider.ts
@@ -1,6 +1,6 @@
 import type { SshChannelMultiplexer } from '../ssh/ssh-channel-multiplexer'
 import type { IPtyProvider, PtyProcessInfo, PtySpawnOptions, PtySpawnResult } from './types'
-import { toAppSshPtyId, toRelaySshPtyId } from './ssh-pty-id'
+import { parseAppSshPtyId, toAppSshPtyId, toRelaySshPtyId } from './ssh-pty-id'
 import { createSshPtyAppliedSizeReader } from './ssh-pty-applied-size'
 import type {
   RemoteCliBridgeEnv,
@@ -34,6 +34,7 @@ export class SshPtyProvider implements IPtyProvider {
   private mux: SshChannelMultiplexer
   private connectionId: string
   private livePtyIds = new Set<string>()
+  private worktreeIdByPtyId = new Map<string, string>()
   readonly getAppliedSize: NonNullable<IPtyProvider['getAppliedSize']>
   private readonly agentSessionCapabilities: SshAgentSessionCapabilities
   private spawnExitRaces = new SshPtySpawnExitRaceTracker()
@@ -66,6 +67,7 @@ export class SshPtyProvider implements IPtyProvider {
   dispose(): void {
     this.outputState.dispose()
     this.livePtyIds.clear()
+    this.worktreeIdByPtyId.clear()
   }
 
   getConnectionId = (): string => this.connectionId
@@ -286,10 +288,36 @@ export class SshPtyProvider implements IPtyProvider {
     const processes = mapSshPtyProcessList(result as PtyProcessInfo[], (id) => this.toAppPtyId(id))
     for (const process of processes) {
       this.livePtyIds.add(process.id)
+      const remappedWorktreeId = this.worktreeIdByPtyId.get(process.id)
+      if (remappedWorktreeId) {
+        process.worktreeId = remappedWorktreeId
+      }
       const relayPtyId = this.toRelayPtyId(process.id)
       this.outputState.rememberPtyIncarnation(relayPtyId, process.incarnationId)
     }
     return processes
+  }
+
+  setWorktreeId(id: string, worktreeId: string): boolean {
+    if (worktreeId.length === 0) {
+      return false
+    }
+    const parsed = parseAppSshPtyId(id)
+    if (parsed && parsed.connectionId !== this.connectionId) {
+      return false
+    }
+    if (!this.livePtyIds.has(id) && !parsed) {
+      return false
+    }
+    this.livePtyIds.add(id)
+    this.worktreeIdByPtyId.set(id, worktreeId)
+    try {
+      this.mux.notify('pty.setWorktreeId', { id: this.toRelayPtyId(id), worktreeId })
+    } catch {
+      this.worktreeIdByPtyId.delete(id)
+      return false
+    }
+    return true
   }
 
   hasPty = (id: string): boolean => this.livePtyIds.has(id)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -389,6 +389,12 @@ import {
 import type { SshConnectionState } from '../../shared/ssh-types'
 import { getPublicSshState } from './public-ssh-state'
 import { closeTerminalTabInWorkspaceSession } from '../../shared/workspace-session-terminal-tab-close'
+import {
+  assertWorkspaceSessionTerminalTabMoveConsistent,
+  partitionMovedTerminalTabHostSessions
+} from '../../shared/workspace-session-terminal-tab-move'
+import { assertValidTerminalMoveDestination } from '../../shared/terminal-move-destination'
+import { rebindRuntimeTabWorktreeMaps } from './terminal-tab-worktree-rebind'
 import type {
   LinearCurrentIssueContextHints,
   LinearAttachResult,
@@ -428,6 +434,7 @@ import {
   type RuntimeTerminalSplit,
   type RuntimeTerminalFocus,
   type RuntimeTerminalClose,
+  type RuntimeTerminalMove,
   type RuntimeTerminalListHostScope,
   type RuntimeTerminalListResult,
   type RuntimeTerminalOrphanAdoptionRequest,
@@ -1030,7 +1037,8 @@ import { readIssueCommand, writeIssueCommand } from '../issue-command-file'
 import {
   DEFAULT_REPO_BADGE_COLOR,
   FLOATING_TERMINAL_WORKTREE_ID,
-  getDefaultVoiceSettings
+  getDefaultVoiceSettings,
+  getDefaultWorkspaceSession
 } from '../../shared/constants'
 import { pruneLineageForMissingRepoWorktrees } from '../worktree-lineage-pruning'
 import {
@@ -1898,6 +1906,7 @@ type RuntimePtyController = {
   resize?(ptyId: string, cols: number, rows: number): boolean
   // Why: exact-id mobile polls should not enumerate every local and SSH PTY.
   hasPty?(ptyId: string): boolean | null
+  setWorktreeId?(ptyId: string, worktreeId: string): boolean
   listProcesses?(connectionId?: string | null): Promise<PtyProcessInfo[]>
   listProcessesWithHostScope?(): Promise<{
     processes: PtyProcessInfo[]
@@ -2169,6 +2178,7 @@ type RuntimeNotifier = {
   focusEditorTab?(tabId: string, worktreeId: string): void
   closeSessionTab?(tabId: string, worktreeId: string): void
   moveSessionTab?(worktreeId: string, move: RuntimeMobileSessionTabMove): void
+  moveTerminalToWorktree?(tabId: string, destWorktreeId: string): Promise<void>
   openFile?(
     worktreeId: string,
     filePath: string,
@@ -29285,6 +29295,257 @@ export class OrcaRuntimeService {
     return { handle, tabId: leaf.tabId, closeMode: 'tab', ptyKilled: false }
   }
 
+  async moveTerminalToWorktree(
+    handle: string,
+    destSelector: string,
+    opts: { tab?: boolean } = {}
+  ): Promise<RuntimeTerminalMove> {
+    const dest = await this.resolveTerminalWorkspaceLaunchScope(destSelector)
+    const binding = this.resolveTerminalMoveBinding(handle)
+    assertValidTerminalMoveDestination(binding.sourceWorktreeId, dest.id)
+    this.assertTerminalMoveTabOption(opts, binding)
+    const sourceSession = this.getWorkspaceSessionForWorktree(binding.sourceWorktreeId)
+    if (sourceSession) {
+      assertWorkspaceSessionTerminalTabMoveConsistent(
+        sourceSession,
+        binding.sourceWorktreeId,
+        binding.tabId
+      )
+    }
+    this.assertPtyWorktreesRebound(binding.ptyIds, dest.id)
+    const persisted = this.persistMovedTerminalTab(
+      binding.sourceWorktreeId,
+      dest.id,
+      binding.tabId
+    )
+    if (persisted) {
+      await this.flushWorkspaceSessionOrThrowAsync()
+    }
+    this.rebindTerminalTabWorktree(binding.tabId, dest.id)
+    this.moveMobileSessionTerminalTab(binding.sourceWorktreeId, dest.id, binding.tabId)
+    if (this.notifier?.moveTerminalToWorktree) {
+      try {
+        await this.notifier.moveTerminalToWorktree(binding.tabId, dest.id)
+        this.rebindTerminalTabWorktree(binding.tabId, dest.id)
+      } catch (error) {
+        console.error('[runtime] failed to notify renderer of terminal move:', error)
+      }
+    }
+    return {
+      handle,
+      tabId: binding.tabId,
+      sourceWorktreeId: binding.sourceWorktreeId,
+      destWorktreeId: dest.id,
+      ptyIds: binding.ptyIds
+    }
+  }
+
+  private resolveTerminalMoveBinding(handle: string): {
+    tabId: string
+    sourceWorktreeId: string
+    ptyIds: string[]
+  } {
+    const pty = this.getLivePtyForHandle(handle)
+    if (pty) {
+      const tabId = pty.pty.tabId
+      if (!tabId) {
+        throw new Error('tab_not_found')
+      }
+      return {
+        tabId,
+        sourceWorktreeId: pty.pty.worktreeId,
+        ptyIds: this.collectPtyIdsForTab(pty.pty.worktreeId, tabId)
+      }
+    }
+    const { leaf } = this.getLiveLeafForHandle(handle)
+    return {
+      tabId: leaf.tabId,
+      sourceWorktreeId: leaf.worktreeId,
+      ptyIds: this.collectPtyIdsForTab(leaf.worktreeId, leaf.tabId)
+    }
+  }
+
+  private collectPtyIdsForTab(worktreeId: string, tabId: string): string[] {
+    const ptyIds = new Set<string>()
+    for (const leaf of this.leaves.values()) {
+      if (leaf.tabId === tabId && leaf.ptyId) {
+        ptyIds.add(leaf.ptyId)
+      }
+    }
+    for (const pty of this.ptysById.values()) {
+      if (pty.worktreeId === worktreeId && pty.tabId === tabId && pty.connected && pty.ptyId) {
+        ptyIds.add(pty.ptyId)
+      }
+    }
+    return [...ptyIds]
+  }
+
+  private assertTerminalMoveTabOption(
+    opts: { tab?: boolean },
+    binding: { tabId: string; ptyIds: string[] }
+  ): void {
+    if (opts.tab === true) {
+      return
+    }
+    // Why: pane-only rehome is not implemented; a split tab without --tab
+    // would silently move sibling panes too.
+    let paneCount = 0
+    for (const leaf of this.leaves.values()) {
+      if (leaf.tabId === binding.tabId) {
+        paneCount += 1
+      }
+    }
+    if (Math.max(paneCount, binding.ptyIds.length) > 1) {
+      throw new Error('terminal_move_requires_tab')
+    }
+  }
+
+  private assertPtyWorktreesRebound(ptyIds: string[], destWorktreeId: string): void {
+    for (const ptyId of ptyIds) {
+      const remote =
+        this.isSshOwnedPtyId(ptyId) || this.ptysById.get(ptyId)?.connectionId != null
+      const rebound = this.ptyController?.setWorktreeId?.(ptyId, destWorktreeId) === true
+      if (remote && !rebound) {
+        throw new Error('pty_worktree_rebind_failed')
+      }
+    }
+  }
+
+  private rebindTerminalTabWorktree(tabId: string, destWorktreeId: string): void {
+    rebindRuntimeTabWorktreeMaps({
+      tabId,
+      destWorktreeId,
+      tabs: this.tabs,
+      leaves: this.leaves,
+      ptys: this.ptysById.values(),
+      recordPtyWorktree: (ptyId, worktreeId) => {
+        const leaf = [...this.leaves.values()].find(
+          (candidate) => candidate.tabId === tabId && candidate.ptyId === ptyId
+        )
+        this.recordPtyWorktree(ptyId, worktreeId, {
+          tabId,
+          ...(leaf ? { paneKey: this.makeRuntimePaneKey(leaf) } : {})
+        })
+      }
+    })
+  }
+
+  private persistMovedTerminalTab(
+    sourceWorktreeId: string,
+    destWorktreeId: string,
+    tabId: string
+  ): boolean {
+    const sourceSession = this.getWorkspaceSessionForWorktree(sourceWorktreeId)
+    if (!sourceSession || !this.store?.setWorkspaceSession) {
+      return false
+    }
+    const destHostId = this.getWorkspaceSessionHostIdForWorktree(destWorktreeId)
+    const sourceHostId = this.getWorkspaceSessionHostIdForWorktree(sourceWorktreeId)
+    const sameHost = destHostId === sourceHostId
+    const destSession = sameHost
+      ? sourceSession
+      : (this.getWorkspaceSessionForWorktree(destWorktreeId) ?? getDefaultWorkspaceSession())
+    const partitioned = partitionMovedTerminalTabHostSessions({
+      sourceSession,
+      destSession,
+      sourceWorktreeId,
+      destWorktreeId,
+      tabId,
+      sameHost
+    })
+    if (!partitioned) {
+      return false
+    }
+    this.setWorkspaceSessionForWorktree(
+      destWorktreeId,
+      advanceTerminalTopologyRevision(partitioned.dest, destWorktreeId)
+    )
+    if (!sameHost) {
+      this.setWorkspaceSessionForWorktree(
+        sourceWorktreeId,
+        advanceTerminalTopologyRevision(partitioned.source, sourceWorktreeId)
+      )
+    }
+    return true
+  }
+
+  private moveMobileSessionTerminalTab(
+    sourceWorktreeId: string,
+    destWorktreeId: string,
+    tabId: string
+  ): void {
+    const sourceSnapshot = this.mobileSessionTabsByWorktree.get(sourceWorktreeId)
+    if (!sourceSnapshot) {
+      return
+    }
+    const moving = sourceSnapshot.tabs.filter(
+      (tab) =>
+        (tab.type === 'terminal' && (tab.parentTabId === tabId || tab.id === tabId)) ||
+        tab.id === tabId
+    )
+    if (moving.length === 0) {
+      return
+    }
+    const movingIds = new Set(moving.map((tab) => tab.id))
+    const remaining = sourceSnapshot.tabs.filter((tab) => !movingIds.has(tab.id))
+    const nextSourceActiveTabId =
+      sourceSnapshot.activeTabId && movingIds.has(sourceSnapshot.activeTabId)
+        ? (remaining[0]?.id ?? null)
+        : sourceSnapshot.activeTabId
+    const nextSourceActiveTab =
+      remaining.find((tab) => tab.id === nextSourceActiveTabId) ?? remaining[0] ?? null
+    const nextSource: RuntimeMobileSessionTabsSnapshot = {
+      ...sourceSnapshot,
+      publicationEpoch: `move:${Date.now().toString(36)}`,
+      snapshotVersion: sourceSnapshot.snapshotVersion + 1,
+      tabs: remaining,
+      activeTabId: nextSourceActiveTabId,
+      tabGroups: this.buildHeadlessMobileSessionTabGroups(
+        sourceWorktreeId,
+        remaining,
+        nextSourceActiveTab,
+        sourceSnapshot.tabGroups
+      )
+    }
+    this.mobileSessionTabsByWorktree.set(sourceWorktreeId, nextSource)
+    this.emitMobileSessionTabsSnapshot(nextSource)
+
+    const destSnapshot = this.mobileSessionTabsByWorktree.get(destWorktreeId)
+    const destTabs = [...(destSnapshot?.tabs ?? []).filter((tab) => !movingIds.has(tab.id)), ...moving]
+    const movedParent =
+      destTabs.find(
+        (tab) => tab.id === tabId || (tab.type === 'terminal' && tab.parentTabId === tabId)
+      ) ?? null
+    const destGroups = this.buildHeadlessMobileSessionTabGroups(
+      destWorktreeId,
+      destTabs,
+      movedParent,
+      destSnapshot?.tabGroups
+    )
+    const nextDest: RuntimeMobileSessionTabsSnapshot = destSnapshot
+      ? {
+          ...destSnapshot,
+          publicationEpoch: `move:${Date.now().toString(36)}`,
+          snapshotVersion: destSnapshot.snapshotVersion + 1,
+          tabs: destTabs,
+          activeTabId: destSnapshot.activeTabId ?? destTabs[0]?.id ?? null,
+          activeGroupId: destSnapshot.activeGroupId ?? destGroups[0]?.id ?? null,
+          tabGroups: destGroups
+        }
+      : {
+          worktree: destWorktreeId,
+          publicationEpoch: `move:${Date.now().toString(36)}`,
+          snapshotVersion: 1,
+          activeGroupId: destGroups[0]?.id ?? null,
+          activeTabId: destTabs[0]?.id ?? null,
+          activeTabType: 'terminal',
+          tabs: destTabs,
+          tabGroups: destGroups
+        }
+    this.mobileSessionTabsByWorktree.set(destWorktreeId, nextDest)
+    this.emitMobileSessionTabsSnapshot(nextDest)
+  }
+
   async splitTerminal(
     handle: string,
     opts: {
@@ -31698,6 +31959,7 @@ export class OrcaRuntimeService {
       }
       // Why: restored/controller-discovered PTYs learn their worktree here without registerPty(), so URL enrichment must bind at this source.
       advertisedUrlWatcher.bindPty(ptyId, worktreeId)
+      this.ptyController?.setWorktreeId?.(ptyId, worktreeId)
       return pty
     }
 
@@ -31753,6 +32015,7 @@ export class OrcaRuntimeService {
     }
     // Why: recordPtyWorktree is the common lifecycle point for every path that resolves a PTY's worktree (renderer restore, controller list).
     advertisedUrlWatcher.bindPty(ptyId, worktreeId)
+    this.ptyController?.setWorktreeId?.(ptyId, worktreeId)
     return pty
   }
 

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -829,6 +829,11 @@ const TerminalHandle = z.object({
   terminal: requiredString('Missing terminal handle')
 })
 
+const TerminalMove = TerminalHandle.extend({
+  worktree: requiredString('Missing worktree selector'),
+  tab: z.boolean().optional()
+})
+
 const TerminalFocus = TerminalHandle.extend({
   navigation: z.enum(['caller', 'host']).optional()
 })
@@ -1569,6 +1574,15 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
         params.terminal,
         () => context.runtime.closeTerminalTab(params.terminal)
       )
+    })
+  }),
+  defineMethod({
+    name: 'terminal.move',
+    params: TerminalMove,
+    handler: async (params, { runtime }) => ({
+      move: await runtime.moveTerminalToWorktree(params.terminal, params.worktree, {
+        tab: params.tab === true
+      })
     })
   }),
   defineMethod({

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -414,6 +414,7 @@ const MOBILE_RPC_METHOD_ALLOWLIST = new Set([
   'terminal.getAutoRestoreFit',
   'terminal.isRunningAgent',
   'terminal.list',
+  'terminal.move',
   'terminal.multiplex',
   'terminal.read',
   'terminal.rename',

--- a/src/main/runtime/terminal-tab-worktree-rebind.test.ts
+++ b/src/main/runtime/terminal-tab-worktree-rebind.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest'
+import { rebindRuntimeTabWorktreeMaps } from './terminal-tab-worktree-rebind'
+
+describe('rebindRuntimeTabWorktreeMaps', () => {
+  it('moves tab, leaf, and PTY worktree ids without dropping the PTY id', () => {
+    const tabs = new Map([['tab-1', { tabId: 'tab-1', worktreeId: 'src' }]])
+    const leaves = new Map([
+      ['tab-1:leaf-1', { tabId: 'tab-1', worktreeId: 'src', ptyId: 'pty-1' }],
+      ['tab-2:leaf-1', { tabId: 'tab-2', worktreeId: 'src', ptyId: 'pty-2' }]
+    ])
+    const ptys = [{ ptyId: 'pty-1', tabId: 'tab-1', worktreeId: 'src' }]
+    const recordPtyWorktree = vi.fn()
+
+    const ptyIds = rebindRuntimeTabWorktreeMaps({
+      tabId: 'tab-1',
+      destWorktreeId: 'dest',
+      tabs,
+      leaves,
+      ptys,
+      recordPtyWorktree
+    })
+
+    expect(tabs.get('tab-1')?.worktreeId).toBe('dest')
+    expect(leaves.get('tab-1:leaf-1')?.worktreeId).toBe('dest')
+    expect(leaves.get('tab-1:leaf-1')?.ptyId).toBe('pty-1')
+    expect(leaves.get('tab-2:leaf-1')?.worktreeId).toBe('src')
+    expect(ptyIds).toEqual(['pty-1'])
+    expect(recordPtyWorktree).toHaveBeenCalledWith('pty-1', 'dest')
+  })
+})

--- a/src/main/runtime/terminal-tab-worktree-rebind.ts
+++ b/src/main/runtime/terminal-tab-worktree-rebind.ts
@@ -1,0 +1,52 @@
+export type RebindableRuntimeTab = {
+  tabId: string
+  worktreeId: string
+}
+
+export type RebindableRuntimeLeaf = {
+  tabId: string
+  worktreeId: string
+  ptyId: string | null
+}
+
+export type RebindableRuntimePty = {
+  ptyId: string
+  tabId: string | null
+  worktreeId: string
+}
+
+export function rebindRuntimeTabWorktreeMaps<
+  TTab extends RebindableRuntimeTab,
+  TLeaf extends RebindableRuntimeLeaf
+>(args: {
+  tabId: string
+  destWorktreeId: string
+  tabs: Map<string, TTab>
+  leaves: Map<string, TLeaf>
+  ptys: Iterable<RebindableRuntimePty>
+  recordPtyWorktree: (ptyId: string, worktreeId: string) => void
+}): string[] {
+  const tab = args.tabs.get(args.tabId)
+  if (tab) {
+    args.tabs.set(args.tabId, { ...tab, worktreeId: args.destWorktreeId })
+  }
+  const ptyIds = new Set<string>()
+  for (const [leafKey, leaf] of args.leaves) {
+    if (leaf.tabId !== args.tabId) {
+      continue
+    }
+    args.leaves.set(leafKey, { ...leaf, worktreeId: args.destWorktreeId })
+    if (leaf.ptyId) {
+      ptyIds.add(leaf.ptyId)
+      args.recordPtyWorktree(leaf.ptyId, args.destWorktreeId)
+    }
+  }
+  for (const pty of args.ptys) {
+    if (pty.tabId !== args.tabId) {
+      continue
+    }
+    ptyIds.add(pty.ptyId)
+    args.recordPtyWorktree(pty.ptyId, args.destWorktreeId)
+  }
+  return [...ptyIds]
+}

--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -57,6 +57,7 @@ import type { TerminalTabCreateReply } from '../../shared/terminal-reveal-identi
 import { isNativeFileDropPayload, type NativeFileDropPayload } from '../../shared/native-file-drop'
 import { requestMobileMarkdownFromRenderer } from './mobile-markdown-request-relay'
 import { requestTerminalTabCloseFromRenderer } from './terminal-tab-close-request-relay'
+import { requestTerminalTabMoveFromRenderer } from './terminal-tab-move-request-relay'
 import type { ClaudeAccountSelectionTarget } from '../claude-accounts/runtime-selection'
 import { runWorktreeChangeInvalidators } from '../ipc/worktree-change-invalidators'
 import {
@@ -492,6 +493,8 @@ function registerRuntimeWindowLifecycle(
     closeTerminal: (tabId, paneRuntimeId) => send('ui:closeTerminal', { tabId, paneRuntimeId }),
     closeTerminalTab: (tabId, options) =>
       requestTerminalTabCloseFromRenderer(mainWindow, tabId, options),
+    moveTerminalToWorktree: (tabId, destWorktreeId) =>
+      requestTerminalTabMoveFromRenderer(mainWindow, tabId, destWorktreeId),
     sleepWorktree: (worktreeId) => send('ui:sleepWorktree', { worktreeId }),
     resumeSleepingAgents: (worktreeId) => send('ui:resumeSleepingAgents', { worktreeId }),
     terminalFitOverrideChanged: (ptyId, mode, cols, rows) =>

--- a/src/main/window/terminal-tab-move-request-relay.ts
+++ b/src/main/window/terminal-tab-move-request-relay.ts
@@ -1,0 +1,39 @@
+import { randomUUID } from 'node:crypto'
+
+import { ipcMain } from 'electron'
+import type { BrowserWindow } from 'electron'
+import type { TerminalTabMoveRequest, TerminalTabMoveResponse } from '../../shared/terminal-tab-move'
+
+const TERMINAL_TAB_MOVE_TIMEOUT_MS = 20_000
+
+export async function requestTerminalTabMoveFromRenderer(
+  mainWindow: BrowserWindow,
+  tabId: string,
+  destWorktreeId: string
+): Promise<void> {
+  if (mainWindow.isDestroyed() || mainWindow.webContents.isDestroyed()) {
+    throw new Error('renderer_unavailable')
+  }
+  const requestId = randomUUID()
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      ipcMain.removeListener('ui:terminalTabMoveResponse', onResponse)
+      reject(new Error('terminal_tab_move_timeout'))
+    }, TERMINAL_TAB_MOVE_TIMEOUT_MS)
+    const onResponse = (event: Electron.IpcMainEvent, response: TerminalTabMoveResponse): void => {
+      if (event.sender !== mainWindow.webContents || response.requestId !== requestId) {
+        return
+      }
+      clearTimeout(timeout)
+      ipcMain.removeListener('ui:terminalTabMoveResponse', onResponse)
+      if (response.error) {
+        reject(new Error(response.error))
+      } else {
+        resolve()
+      }
+    }
+    ipcMain.on('ui:terminalTabMoveResponse', onResponse)
+    const request: TerminalTabMoveRequest = { requestId, tabId, destWorktreeId }
+    mainWindow.webContents.send('ui:terminalTabMoveRequest', request)
+  })
+}

--- a/src/preload/api/ui-command-event-api.ts
+++ b/src/preload/api/ui-command-event-api.ts
@@ -27,6 +27,10 @@ import type {
   TerminalTabCloseRequest,
   TerminalTabCloseResponse
 } from '../../shared/terminal-tab-close'
+import type {
+  TerminalTabMoveRequest,
+  TerminalTabMoveResponse
+} from '../../shared/terminal-tab-move'
 
 export type UiCommandEventApi = {
   get: () => Promise<PersistedUIState>
@@ -203,6 +207,8 @@ export type UiCommandEventApi = {
   ) => () => void
   onTerminalTabCloseRequest: (callback: (request: TerminalTabCloseRequest) => void) => () => void
   respondTerminalTabClose: (response: TerminalTabCloseResponse) => void
+  onTerminalTabMoveRequest?: (callback: (request: TerminalTabMoveRequest) => void) => () => void
+  respondTerminalTabMove?: (response: TerminalTabMoveResponse) => void
   onSleepWorktree: (callback: (data: { worktreeId: string }) => void) => () => void
   onResumeSleepingAgents: (callback: (data: { worktreeId: string }) => void) => () => void
   onTerminalZoom: (callback: (direction: 'in' | 'out' | 'reset') => void) => () => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4259,6 +4259,17 @@ const api = {
     respondTerminalTabClose: (response) => {
       ipcRenderer.send('ui:terminalTabCloseResponse', response)
     },
+    onTerminalTabMoveRequest: (callback) => {
+      const listener = (
+        _event: Electron.IpcRendererEvent,
+        request: Parameters<typeof callback>[0]
+      ) => callback(request)
+      ipcRenderer.on('ui:terminalTabMoveRequest', listener)
+      return () => ipcRenderer.removeListener('ui:terminalTabMoveRequest', listener)
+    },
+    respondTerminalTabMove: (response) => {
+      ipcRenderer.send('ui:terminalTabMoveResponse', response)
+    },
     onSleepWorktree: (callback: (data: { worktreeId: string }) => void): (() => void) => {
       const listener = (_event: Electron.IpcRendererEvent, data: { worktreeId: string }) =>
         callback(data)

--- a/src/relay/pty-handler-spawn-admission.test.ts
+++ b/src/relay/pty-handler-spawn-admission.test.ts
@@ -79,6 +79,7 @@ describe('PtyHandler', () => {
     const notifMethods = Array.from(dispatcher._notificationHandlers.keys())
     expect(notifMethods).toContain('pty.data')
     expect(notifMethods).toContain('pty.resize')
+    expect(notifMethods).toContain('pty.setWorktreeId')
     expect(notifMethods).toContain('pty.ackData')
   })
 

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -882,6 +882,7 @@ export class PtyHandler {
 
     this.dispatcher.onNotification('pty.data', (p) => this.writeData(p))
     this.dispatcher.onNotification('pty.resize', (p) => this.resize(p))
+    this.dispatcher.onNotification('pty.setWorktreeId', (p) => this.setWorktreeId(p))
     this.dispatcher.onNotification('pty.ackData', (_p) => {
       /* flow control ack -- not yet enforced */
     })
@@ -1819,6 +1820,16 @@ export class PtyHandler {
     if (managed && !managed.disposed) {
       managed.pty.resize(cols, rows)
     }
+  }
+
+  private setWorktreeId(params: Record<string, unknown>): void {
+    const id = typeof params.id === 'string' ? params.id : ''
+    const worktreeId = typeof params.worktreeId === 'string' ? params.worktreeId : ''
+    const managed = this.ptys.get(id)
+    if (!managed || managed.disposed || worktreeId.length === 0) {
+      return
+    }
+    managed.worktreeId = worktreeId
   }
 
   private async getSize(

--- a/src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx
@@ -1,6 +1,22 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import type { ComponentProps } from 'react'
 import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/store', () => ({
+  useAppStore: (
+    selector: (state: {
+      worktreesByRepo: Record<string, never>
+      tabsByWorktree: Record<string, never>
+    }) => unknown
+  ) =>
+    selector({
+      worktreesByRepo: {},
+      folderWorkspaces: [],
+      tabsByWorktree: { 'wt-1': [] },
+      settings: {},
+      moveTerminalTabToWorktree: vi.fn()
+    } as never)
+}))
 import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
 import type { TerminalTab } from '../../../../shared/terminal-tab-types'
 import { TooltipProvider } from '../ui/tooltip'

--- a/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
@@ -13,6 +13,17 @@ import type { DashboardAgentRow as DashboardAgentRowData } from './useDashboardD
 import { getAgentRowPrimaryText } from '@/lib/agent-row-primary-text'
 import { useAgentRowConversationName } from './use-agent-row-conversation-name'
 import { lastEnteredDoneAt } from './agent-finished-timestamp'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuTrigger
+} from '@/components/ui/context-menu'
+import { WORKTREE_NATIVE_CONTEXT_MENU_ATTR } from '@/components/sidebar/WorktreeContextMenu'
+import {
+  MoveTerminalToWorktreeContextSection,
+  useTerminalMoveDestinations
+} from '@/components/tab-bar/MoveTerminalToWorktreeMenuSection'
+import { TAB_CONTEXT_MENU_CONTENT_CLASS } from '@/components/tab-bar/tab-context-menu-sizing'
 
 // Why: narrow the dashboard's rollup states to shared dot states, defaulting unknowns to 'idle' so a row never crashes.
 function asDotState(state: AgentStatusState | 'idle'): AgentDotState {
@@ -100,6 +111,7 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
   sendTargetDisabledReason,
   onSendTargetClick
 }: Props) {
+  const destinations = useTerminalMoveDestinations(agent.tab.worktreeId)
   const hasChildDisclosure =
     typeof childAgentCount === 'number' &&
     childAgentCount > 0 &&
@@ -179,7 +191,7 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
 
   const titleParts = sendTargetDisabledReason ? [sendTargetDisabledReason, ...tsParts] : tsParts
 
-  return (
+  const row = (
     // Why: no role="button" — nested interactive children (buttons, tooltip triggers) would violate ARIA nesting rules.
     <div
       onClickCapture={handleSendTargetClickCapture}
@@ -310,6 +322,24 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
         lastAssistantMessage={lastAssistantMessage}
       />
     </div>
+  )
+
+  if (agent.rowSource === 'subagent' || destinations.length === 0) {
+    return row
+  }
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild {...{ [WORKTREE_NATIVE_CONTEXT_MENU_ATTR]: '' }}>
+        {row}
+      </ContextMenuTrigger>
+      <ContextMenuContent className={TAB_CONTEXT_MENU_CONTENT_CLASS}>
+        <MoveTerminalToWorktreeContextSection
+          tabId={agent.tab.id}
+          sourceWorktreeId={agent.tab.worktreeId}
+        />
+      </ContextMenuContent>
+    </ContextMenu>
   )
 })
 

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx
@@ -95,6 +95,9 @@ vi.mock('@/store', () => ({
       tabsByWorktree: {},
       terminalLayoutsByTabId: {},
       sendPromptToSidebarAgentTarget: vi.fn(),
+      worktreesByRepo: {},
+      folderWorkspaces: [],
+      moveTerminalTabToWorktree: vi.fn(),
       settings: {
         promptCacheTimerEnabled: mockPromptCacheTimerEnabled,
         promptCacheTtlMs: mockPromptCacheTtlMs

--- a/src/renderer/src/components/sidebar/WorktreeList.lineage-agent-expansion-coupling.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.lineage-agent-expansion-coupling.test.tsx
@@ -369,6 +369,7 @@ function setAgentLineageState(options: {
     dropAgentStatus: vi.fn(),
     dismissRetainedAgent: vi.fn(),
     sendPromptToSidebarAgentTarget: vi.fn(),
+    moveTerminalTabToWorktree: vi.fn(),
     tabsByWorktree: { parent: [makeParentTab()] },
     agentStatusByPaneKey
   }

--- a/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx
@@ -11,6 +11,17 @@ import { getAgentRowPrimaryText } from '@/lib/agent-row-primary-text'
 import { useAgentRowConversationName } from '@/components/dashboard/use-agent-row-conversation-name'
 import { lastEnteredDoneAt } from '@/components/dashboard/agent-finished-timestamp'
 import CacheTimer, { usePromptCacheCountdownForPane } from './CacheTimer'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuTrigger
+} from '@/components/ui/context-menu'
+import { WORKTREE_NATIVE_CONTEXT_MENU_ATTR } from './WorktreeContextMenu'
+import {
+  MoveTerminalToWorktreeContextSection,
+  useTerminalMoveDestinations
+} from '@/components/tab-bar/MoveTerminalToWorktreeMenuSection'
+import { TAB_CONTEXT_MENU_CONTENT_CLASS } from '@/components/tab-bar/tab-context-menu-sizing'
 
 function formatShortTimeAgo(ts: number, now: number): string {
   const delta = now - ts
@@ -111,6 +122,7 @@ export const CompactAgentRow = React.memo(function CompactAgentRow({
   hideIdentityIcon = false,
   cacheTimerActive = true
 }: CompactAgentRowProps) {
+  const destinations = useTerminalMoveDestinations(agent.tab.worktreeId)
   const hasChildDisclosure =
     typeof childAgentCount === 'number' &&
     childAgentCount > 0 &&
@@ -251,7 +263,7 @@ export const CompactAgentRow = React.memo(function CompactAgentRow({
     </>
   )
 
-  return (
+  const row = (
     <div
       draggable={false}
       className={cn(
@@ -278,5 +290,23 @@ export const CompactAgentRow = React.memo(function CompactAgentRow({
     >
       {rowBody}
     </div>
+  )
+
+  if (agent.rowSource === 'subagent' || destinations.length === 0) {
+    return row
+  }
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild {...{ [WORKTREE_NATIVE_CONTEXT_MENU_ATTR]: '' }}>
+        {row}
+      </ContextMenuTrigger>
+      <ContextMenuContent className={TAB_CONTEXT_MENU_CONTENT_CLASS}>
+        <MoveTerminalToWorktreeContextSection
+          tabId={agent.tab.id}
+          sourceWorktreeId={agent.tab.worktreeId}
+        />
+      </ContextMenuContent>
+    </ContextMenu>
   )
 })

--- a/src/renderer/src/components/tab-bar/MoveTerminalToWorktreeMenuSection.tsx
+++ b/src/renderer/src/components/tab-bar/MoveTerminalToWorktreeMenuSection.tsx
@@ -1,0 +1,104 @@
+import { FolderGit2 } from 'lucide-react'
+import {
+  DropdownMenuItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger
+} from '@/components/ui/dropdown-menu'
+import {
+  ContextMenuItem,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger
+} from '@/components/ui/context-menu'
+import { useAppStore } from '../../store'
+import { translate } from '@/i18n/i18n'
+import { TAB_CONTEXT_SUBMENU_CONTENT_CLASS } from './tab-context-menu-sizing'
+import { listTerminalMoveWorktreeDestinations } from './move-terminal-to-worktree-destinations'
+
+export function useTerminalMoveDestinations(sourceWorktreeId: string) {
+  const worktreesByRepo = useAppStore((s) => s.worktreesByRepo)
+  const folderWorkspaces = useAppStore((s) => s.folderWorkspaces)
+  return listTerminalMoveWorktreeDestinations({
+    sourceWorktreeId,
+    worktreesByRepo,
+    folderWorkspaces
+  })
+}
+
+function MoveLabel(): string {
+  return translate(
+    'components.tab.bar.MoveTerminalToWorktreeMenuSection.moveToWorktree',
+    'Move to worktree…'
+  )
+}
+
+export function MoveTerminalToWorktreeDropdownSection({
+  tabId,
+  sourceWorktreeId
+}: {
+  tabId: string
+  sourceWorktreeId: string
+}): React.JSX.Element | null {
+  const destinations = useTerminalMoveDestinations(sourceWorktreeId)
+  const moveTerminalTabToWorktree = useAppStore((s) => s.moveTerminalTabToWorktree)
+  if (destinations.length === 0) {
+    return null
+  }
+  return (
+    <DropdownMenuSub>
+      <DropdownMenuSubTrigger className="[&>svg:last-child]:size-3.5">
+        <FolderGit2 className="size-3.5 shrink-0" />
+        {MoveLabel()}
+      </DropdownMenuSubTrigger>
+      <DropdownMenuSubContent className={TAB_CONTEXT_SUBMENU_CONTENT_CLASS}>
+        {destinations.map((destination) => (
+          <DropdownMenuItem
+            key={destination.id}
+            onSelect={() => {
+              moveTerminalTabToWorktree(tabId, destination.id)
+            }}
+          >
+            <FolderGit2 className="size-3.5 shrink-0" />
+            {destination.label}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuSubContent>
+    </DropdownMenuSub>
+  )
+}
+
+export function MoveTerminalToWorktreeContextSection({
+  tabId,
+  sourceWorktreeId
+}: {
+  tabId: string
+  sourceWorktreeId: string
+}): React.JSX.Element | null {
+  const destinations = useTerminalMoveDestinations(sourceWorktreeId)
+  const moveTerminalTabToWorktree = useAppStore((s) => s.moveTerminalTabToWorktree)
+  if (destinations.length === 0) {
+    return null
+  }
+  return (
+    <ContextMenuSub>
+      <ContextMenuSubTrigger className="[&>svg:last-child]:size-3.5">
+        <FolderGit2 className="size-3.5 shrink-0" />
+        {MoveLabel()}
+      </ContextMenuSubTrigger>
+      <ContextMenuSubContent className={TAB_CONTEXT_SUBMENU_CONTENT_CLASS}>
+        {destinations.map((destination) => (
+          <ContextMenuItem
+            key={destination.id}
+            onSelect={() => {
+              moveTerminalTabToWorktree(tabId, destination.id)
+            }}
+          >
+            <FolderGit2 className="size-3.5 shrink-0" />
+            {destination.label}
+          </ContextMenuItem>
+        ))}
+      </ContextMenuSubContent>
+    </ContextMenuSub>
+  )
+}

--- a/src/renderer/src/components/tab-bar/SortableTabContextMenu.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTabContextMenu.tsx
@@ -22,6 +22,7 @@ import { useAppStore } from '../../store'
 import { formatShortcutLabel, useOptionalShortcutLabel } from '@/hooks/useShortcutLabel'
 import { translate } from '@/i18n/i18n'
 import { TerminalTabSplitMenuSection } from './TerminalTabSplitMenuSection'
+import { MoveTerminalToWorktreeDropdownSection } from './MoveTerminalToWorktreeMenuSection'
 import { TAB_CONTEXT_MENU_CONTENT_CLASS } from './tab-context-menu-sizing'
 
 const TAB_COLORS = [
@@ -168,6 +169,7 @@ export function SortableTabContextMenu({
           splitRightShortcut={splitRightShortcut}
           splitDownShortcut={splitDownShortcut}
         />
+        <MoveTerminalToWorktreeDropdownSection tabId={tab.id} sourceWorktreeId={tab.worktreeId} />
         {canToggleViewMode && onToggleViewMode ? (
           <>
             <DropdownMenuSeparator />

--- a/src/renderer/src/components/tab-bar/move-terminal-to-worktree-destinations.test.ts
+++ b/src/renderer/src/components/tab-bar/move-terminal-to-worktree-destinations.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
+import { folderWorkspaceKey } from '../../../../shared/workspace-scope'
+import type { FolderWorkspace } from '../../../../shared/folder-workspace-types'
+import type { Worktree } from '../../../../shared/worktree/types'
+import { listTerminalMoveWorktreeDestinations } from './move-terminal-to-worktree-destinations'
+
+function worktree(overrides: Partial<Worktree> & { id: string }): Worktree {
+  return {
+    repoId: 'repo',
+    path: '/tmp',
+    head: 'abc',
+    branch: 'refs/heads/feature',
+    isBare: false,
+    isMainWorktree: false,
+    displayName: overrides.id,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    ...overrides
+  }
+}
+
+describe('listTerminalMoveWorktreeDestinations', () => {
+  it('lists other worktrees as displayName plus branch and excludes floating/source', () => {
+    const destinations = listTerminalMoveWorktreeDestinations({
+      sourceWorktreeId: 'repo::/src',
+      worktreesByRepo: {
+        repo: [
+          worktree({ id: 'repo::/src', displayName: 'src', branch: 'refs/heads/src' }),
+          worktree({
+            id: 'repo::/dest',
+            displayName: 'follow-up',
+            branch: 'refs/heads/follow-up'
+          }),
+          worktree({
+            id: FLOATING_TERMINAL_WORKTREE_ID,
+            displayName: 'Floating',
+            branch: ''
+          }),
+          worktree({ id: 'repo::/old', displayName: 'old', isArchived: true })
+        ]
+      }
+    })
+
+    expect(destinations).toEqual([
+      {
+        id: 'repo::/dest',
+        displayName: 'follow-up',
+        branch: 'refs/heads/follow-up',
+        label: 'follow-up'
+      }
+    ])
+  })
+
+  it('includes folder workspaces as destinations', () => {
+    const folder: FolderWorkspace = {
+      id: 'docs',
+      projectGroupId: 'group',
+      name: 'Docs',
+      folderPath: '/docs',
+      linkedTask: null,
+      comment: '',
+      isArchived: false,
+      isUnread: false,
+      isPinned: false,
+      sortOrder: 0,
+      lastActivityAt: 0,
+      createdAt: 0,
+      updatedAt: 0
+    }
+    const destinations = listTerminalMoveWorktreeDestinations({
+      sourceWorktreeId: 'repo::/src',
+      worktreesByRepo: { repo: [worktree({ id: 'repo::/src', displayName: 'src' })] },
+      folderWorkspaces: [folder]
+    })
+
+    expect(destinations.map((destination) => destination.id)).toEqual([
+      folderWorkspaceKey('docs')
+    ])
+    expect(destinations[0]?.label).toBe('Docs')
+  })
+})

--- a/src/renderer/src/components/tab-bar/move-terminal-to-worktree-destinations.ts
+++ b/src/renderer/src/components/tab-bar/move-terminal-to-worktree-destinations.ts
@@ -1,0 +1,54 @@
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
+import { folderWorkspaceToWorktree } from '../../../../shared/folder-workspace-worktree'
+import type { FolderWorkspace } from '../../../../shared/folder-workspace-types'
+import type { Worktree } from '../../../../shared/worktree/types'
+import { branchDisplayName } from '../sidebar/WorktreeCardHelpers'
+
+export type TerminalMoveWorktreeDestination = {
+  id: string
+  displayName: string
+  branch: string
+  label: string
+}
+
+export function formatTerminalMoveWorktreeLabel(
+  displayName: string,
+  branch: string
+): string {
+  const shortBranch = branchDisplayName(branch)
+  if (!shortBranch || shortBranch === displayName) {
+    return displayName
+  }
+  return `${displayName} (${shortBranch})`
+}
+
+export function listTerminalMoveWorktreeDestinations(args: {
+  sourceWorktreeId: string
+  worktreesByRepo: Record<string, Worktree[]>
+  folderWorkspaces?: readonly FolderWorkspace[]
+}): TerminalMoveWorktreeDestination[] {
+  const seen = new Set<string>()
+  const destinations: TerminalMoveWorktreeDestination[] = []
+  const candidates: Worktree[] = [
+    ...Object.values(args.worktreesByRepo).flat(),
+    ...(args.folderWorkspaces ?? []).map(folderWorkspaceToWorktree)
+  ]
+  for (const worktree of candidates) {
+    if (
+      seen.has(worktree.id) ||
+      worktree.id === args.sourceWorktreeId ||
+      worktree.id === FLOATING_TERMINAL_WORKTREE_ID ||
+      worktree.isArchived
+    ) {
+      continue
+    }
+    seen.add(worktree.id)
+    destinations.push({
+      id: worktree.id,
+      displayName: worktree.displayName,
+      branch: worktree.branch,
+      label: formatTerminalMoveWorktreeLabel(worktree.displayName, worktree.branch)
+    })
+  }
+  return destinations.sort((a, b) => a.label.localeCompare(b.label))
+}

--- a/src/renderer/src/components/tab-bar/tab-context-menu-consistency.test.tsx
+++ b/src/renderer/src/components/tab-bar/tab-context-menu-consistency.test.tsx
@@ -15,7 +15,8 @@ const TAB_MENU_SOURCES = [
   'SortableTabContextMenu.tsx',
   'BrowserTab.tsx',
   'TabWorkspaceLayoutMenuSection.tsx',
-  'TerminalTabSplitMenuSection.tsx'
+  'TerminalTabSplitMenuSection.tsx',
+  'MoveTerminalToWorktreeMenuSection.tsx'
 ] as const
 
 function readSource(fileName: string): string {

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -2096,6 +2096,30 @@ export function useIpcEvents(): void {
       )
     }
 
+    if (window.api.ui.onTerminalTabMoveRequest) {
+      unsubs.push(
+        window.api.ui.onTerminalTabMoveRequest(({ requestId, tabId, destWorktreeId }) => {
+          const respond = window.api.ui.respondTerminalTabMove
+          if (!respond) {
+            return
+          }
+          try {
+            const moved = useAppStore.getState().moveTerminalTabToWorktree(tabId, destWorktreeId)
+            if (!moved) {
+              respond({ requestId, error: 'tab_not_found' })
+              return
+            }
+            respond({ requestId })
+          } catch (error) {
+            respond({
+              requestId,
+              error: error instanceof Error ? error.message : 'terminal_tab_move_failed'
+            })
+          }
+        })
+      )
+    }
+
     unsubs.push(
       window.api.ui.onSleepWorktree(({ worktreeId }) => {
         void runSleepWorktree(worktreeId)

--- a/src/renderer/src/store/slices/move-terminal-tab-to-worktree.test.ts
+++ b/src/renderer/src/store/slices/move-terminal-tab-to-worktree.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest'
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import type { SleepingAgentSessionRecord } from '../../../../shared/agent-session-resume'
+import { makePaneKey } from '../../../../shared/stable-pane-id'
+import {
+  moveTerminalTabToWorktreeInStore,
+  type TerminalTabMoveStoreState
+} from './move-terminal-tab-to-worktree'
+
+const SOURCE = 'repo::/src'
+const DEST = 'repo::/dest'
+const TAB_ID = 'tab-1'
+const PANE_KEY = makePaneKey(TAB_ID, '11111111-1111-4111-8111-111111111111')
+
+function state(): TerminalTabMoveStoreState {
+  return {
+    tabsByWorktree: {
+      [SOURCE]: [
+        {
+          id: TAB_ID,
+          ptyId: 'pty-1',
+          worktreeId: SOURCE,
+          title: 'Agent',
+          customTitle: null,
+          color: null,
+          sortOrder: 0,
+          createdAt: 1
+        }
+      ],
+      [DEST]: []
+    },
+    unifiedTabsByWorktree: {
+      [SOURCE]: [
+        {
+          id: TAB_ID,
+          entityId: TAB_ID,
+          groupId: 'group-src',
+          worktreeId: SOURCE,
+          contentType: 'terminal',
+          label: 'Agent',
+          customLabel: null,
+          color: null,
+          sortOrder: 0,
+          createdAt: 1
+        }
+      ],
+      [DEST]: []
+    },
+    groupsByWorktree: {
+      [SOURCE]: [
+        {
+          id: 'group-src',
+          worktreeId: SOURCE,
+          activeTabId: TAB_ID,
+          tabOrder: [TAB_ID],
+          recentTabIds: [TAB_ID]
+        }
+      ]
+    },
+    layoutByWorktree: {
+      [SOURCE]: { type: 'leaf', groupId: 'group-src' }
+    },
+    activeGroupIdByWorktree: { [SOURCE]: 'group-src' },
+    tabBarOrderByWorktree: { [SOURCE]: [TAB_ID], [DEST]: [] },
+    activeTabIdByWorktree: { [SOURCE]: TAB_ID, [DEST]: null },
+    activeTabId: TAB_ID,
+    agentStatusByPaneKey: {
+      [PANE_KEY]: {
+        paneKey: PANE_KEY,
+        tabId: TAB_ID,
+        worktreeId: SOURCE,
+        agentType: 'codex',
+        state: 'working',
+        prompt: 'review',
+        updatedAt: 1,
+        stateStartedAt: 1,
+        stateHistory: []
+      } satisfies AgentStatusEntry
+    },
+    retainedAgentsByPaneKey: {},
+    sleepingAgentSessionsByPaneKey: {
+      [PANE_KEY]: {
+        paneKey: PANE_KEY,
+        tabId: TAB_ID,
+        worktreeId: SOURCE,
+        agent: 'codex',
+        providerSession: { key: 'session_id', id: 'session-1' },
+        prompt: 'review',
+        state: 'working',
+        capturedAt: 1,
+        updatedAt: 1
+      } satisfies SleepingAgentSessionRecord
+    }
+  }
+}
+
+describe('moveTerminalTabToWorktreeInStore', () => {
+  it('moves the live tab, bar order, and hook attribution to the destination', () => {
+    const result = moveTerminalTabToWorktreeInStore(state(), TAB_ID, DEST)
+    expect(result).not.toBeNull()
+    expect(result?.patch.tabsByWorktree?.[SOURCE]).toEqual([])
+    expect(result?.patch.tabsByWorktree?.[DEST]).toEqual([
+      expect.objectContaining({ id: TAB_ID, worktreeId: DEST, ptyId: 'pty-1' })
+    ])
+    expect(result?.patch.tabBarOrderByWorktree?.[SOURCE]).toEqual([])
+    expect(result?.patch.tabBarOrderByWorktree?.[DEST]).toEqual([TAB_ID])
+    expect(result?.patch.unifiedTabsByWorktree?.[DEST]?.[0]).toMatchObject({
+      id: TAB_ID,
+      worktreeId: DEST
+    })
+    expect(result?.patch.agentStatusByPaneKey?.[PANE_KEY]?.worktreeId).toBe(DEST)
+    expect(result?.patch.sleepingAgentSessionsByPaneKey?.[PANE_KEY]?.worktreeId).toBe(DEST)
+  })
+
+  it('does not move when the destination is the source or the tab is missing', () => {
+    expect(moveTerminalTabToWorktreeInStore(state(), TAB_ID, SOURCE)).toBeNull()
+    expect(moveTerminalTabToWorktreeInStore(state(), 'missing', DEST)).toBeNull()
+  })
+
+  it('remints sleeping agent sessions onto the destination worktree', () => {
+    const result = moveTerminalTabToWorktreeInStore(state(), TAB_ID, DEST)
+    expect(result?.patch.sleepingAgentSessionsByPaneKey?.[PANE_KEY]).toMatchObject({
+      tabId: TAB_ID,
+      worktreeId: DEST
+    })
+  })
+})

--- a/src/renderer/src/store/slices/move-terminal-tab-to-worktree.ts
+++ b/src/renderer/src/store/slices/move-terminal-tab-to-worktree.ts
@@ -1,0 +1,267 @@
+import type { Tab, TabGroup, TabGroupLayoutNode } from '../../../../shared/tab-types'
+import type { TerminalTab } from '../../../../shared/terminal-tab-types'
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import type { SleepingAgentSessionRecord } from '../../../../shared/agent-session-resume'
+import type { RetainedAgentEntry } from './agent-status'
+import { ensureGroup, sanitizeRecentTabIds } from './tab-group-state'
+import { parsePaneKey } from '../../../../shared/stable-pane-id'
+
+export type TerminalTabMoveStoreState = {
+  tabsByWorktree: Record<string, TerminalTab[]>
+  unifiedTabsByWorktree: Record<string, Tab[]>
+  groupsByWorktree: Record<string, TabGroup[]>
+  layoutByWorktree: Record<string, TabGroupLayoutNode>
+  activeGroupIdByWorktree: Record<string, string>
+  tabBarOrderByWorktree: Record<string, string[]>
+  activeTabIdByWorktree: Record<string, string | null>
+  activeTabId: string | null
+  agentStatusByPaneKey: Record<string, AgentStatusEntry>
+  retainedAgentsByPaneKey: Record<string, RetainedAgentEntry>
+  sleepingAgentSessionsByPaneKey: Record<string, SleepingAgentSessionRecord>
+}
+
+export type TerminalTabMoveStoreResult = {
+  patch: Partial<TerminalTabMoveStoreState>
+  sourceWorktreeId: string
+  destWorktreeId: string
+  tabId: string
+}
+
+function pruneGroupLayout(
+  node: TabGroupLayoutNode | undefined,
+  validGroupIds: ReadonlySet<string>
+): TabGroupLayoutNode | undefined {
+  if (!node) {
+    return undefined
+  }
+  if (node.type === 'leaf') {
+    return validGroupIds.has(node.groupId) ? node : undefined
+  }
+  const first = pruneGroupLayout(node.first, validGroupIds)
+  const second = pruneGroupLayout(node.second, validGroupIds)
+  if (!first) {
+    return second
+  }
+  if (!second) {
+    return first
+  }
+  return { ...node, first, second }
+}
+
+function remintRetainedWorktreeId(
+  records: Record<string, RetainedAgentEntry>,
+  tabId: string,
+  destWorktreeId: string
+): Record<string, RetainedAgentEntry> {
+  let changed = false
+  const next: Record<string, RetainedAgentEntry> = {}
+  for (const [key, record] of Object.entries(records)) {
+    const paneTabId = parsePaneKey(key)?.tabId
+    if (paneTabId === tabId || record.tab.id === tabId) {
+      next[key] = {
+        ...record,
+        worktreeId: destWorktreeId,
+        tab: { ...record.tab, worktreeId: destWorktreeId }
+      }
+      changed = true
+    } else {
+      next[key] = record
+    }
+  }
+  return changed ? next : records
+}
+
+function remintWorktreeId<T extends { worktreeId?: string; tabId?: string | null }>(
+  records: Record<string, T>,
+  tabId: string,
+  destWorktreeId: string
+): Record<string, T> {
+  let changed = false
+  const next: Record<string, T> = {}
+  for (const [key, record] of Object.entries(records)) {
+    const paneTabId = parsePaneKey(key)?.tabId
+    if (paneTabId === tabId || record.tabId === tabId) {
+      next[key] = { ...record, worktreeId: destWorktreeId }
+      changed = true
+    } else {
+      next[key] = record
+    }
+  }
+  return changed ? next : records
+}
+
+export function findTerminalTabWorktreeId(
+  tabsByWorktree: Record<string, TerminalTab[]>,
+  tabId: string
+): string | null {
+  for (const [worktreeId, tabs] of Object.entries(tabsByWorktree)) {
+    if (tabs.some((tab) => tab.id === tabId)) {
+      return worktreeId
+    }
+  }
+  return null
+}
+
+export function moveTerminalTabToWorktreeInStore(
+  state: TerminalTabMoveStoreState,
+  tabId: string,
+  destWorktreeId: string
+): TerminalTabMoveStoreResult | null {
+  const sourceWorktreeId = findTerminalTabWorktreeId(state.tabsByWorktree, tabId)
+  if (!sourceWorktreeId || sourceWorktreeId === destWorktreeId) {
+    return null
+  }
+  const terminalRow = (state.tabsByWorktree[sourceWorktreeId] ?? []).find((tab) => tab.id === tabId)
+  if (!terminalRow) {
+    return null
+  }
+  const sourceUnified = state.unifiedTabsByWorktree[sourceWorktreeId] ?? []
+  const movingUnified = sourceUnified.filter(
+    (tab) => tab.contentType === 'terminal' && (tab.entityId === tabId || tab.id === tabId)
+  )
+  const movingUnifiedIds = new Set(movingUnified.map((tab) => tab.id))
+  movingUnifiedIds.add(tabId)
+
+  const destEnsured = ensureGroup(
+    state.groupsByWorktree,
+    state.activeGroupIdByWorktree,
+    destWorktreeId,
+    state.activeGroupIdByWorktree[destWorktreeId]
+  )
+  const destGroup = destEnsured.group
+  const destUnifiedExisting = state.unifiedTabsByWorktree[destWorktreeId] ?? []
+  const destUnifiedIds = new Set(destUnifiedExisting.map((tab) => tab.id))
+  const movedUnified = movingUnified
+    .filter((tab) => !destUnifiedIds.has(tab.id))
+    .map((tab) => ({ ...tab, worktreeId: destWorktreeId, groupId: destGroup.id }))
+  const destTabOrder = [
+    ...destGroup.tabOrder.filter((id) => !movingUnifiedIds.has(id)),
+    ...movedUnified.map((tab) => tab.id)
+  ]
+  const destGroups = (destEnsured.groupsByWorktree[destWorktreeId] ?? []).map((group) =>
+    group.id === destGroup.id
+      ? {
+          ...group,
+          worktreeId: destWorktreeId,
+          tabOrder: destTabOrder,
+          activeTabId: movedUnified.at(-1)?.id ?? destGroup.activeTabId,
+          recentTabIds: [
+            ...sanitizeRecentTabIds(destGroup.recentTabIds, destTabOrder).filter(
+              (id) => !movingUnifiedIds.has(id)
+            ),
+            ...movedUnified.map((tab) => tab.id)
+          ]
+        }
+      : group
+  )
+
+  const sourceGroups = (state.groupsByWorktree[sourceWorktreeId] ?? [])
+    .map((group) => {
+      const tabOrder = group.tabOrder.filter((id) => !movingUnifiedIds.has(id))
+      const activeTabId = movingUnifiedIds.has(group.activeTabId ?? '')
+        ? (tabOrder[0] ?? null)
+        : group.activeTabId && tabOrder.includes(group.activeTabId)
+          ? group.activeTabId
+          : (tabOrder[0] ?? null)
+      return {
+        ...group,
+        tabOrder,
+        activeTabId,
+        recentTabIds: sanitizeRecentTabIds(group.recentTabIds, tabOrder)
+      }
+    })
+    .filter((group) => group.tabOrder.length > 0)
+  const validSourceGroupIds = new Set(sourceGroups.map((group) => group.id))
+  const sourceLayout = pruneGroupLayout(state.layoutByWorktree[sourceWorktreeId], validSourceGroupIds)
+  const nextLayoutByWorktree = { ...state.layoutByWorktree }
+  if (sourceLayout) {
+    nextLayoutByWorktree[sourceWorktreeId] = sourceLayout
+  } else {
+    delete nextLayoutByWorktree[sourceWorktreeId]
+  }
+  if (!nextLayoutByWorktree[destWorktreeId]) {
+    nextLayoutByWorktree[destWorktreeId] = { type: 'leaf', groupId: destGroup.id }
+  }
+
+  const sourceTerminals = (state.tabsByWorktree[sourceWorktreeId] ?? []).filter(
+    (tab) => tab.id !== tabId
+  )
+  const destTerminals = [
+    ...(state.tabsByWorktree[destWorktreeId] ?? []).filter((tab) => tab.id !== tabId),
+    { ...terminalRow, worktreeId: destWorktreeId }
+  ]
+
+  const sourceBar = (state.tabBarOrderByWorktree[sourceWorktreeId] ?? []).filter((id) => id !== tabId)
+  const destBar = [
+    ...(state.tabBarOrderByWorktree[destWorktreeId] ?? []).filter((id) => id !== tabId),
+    tabId
+  ]
+
+  const nextActiveGroupIdByWorktree = {
+    ...destEnsured.activeGroupIdByWorktree,
+    [destWorktreeId]: destGroup.id
+  }
+  const sourceActiveGroupId = validSourceGroupIds.has(
+    state.activeGroupIdByWorktree[sourceWorktreeId] ?? ''
+  )
+    ? state.activeGroupIdByWorktree[sourceWorktreeId]
+    : sourceGroups[0]?.id
+  if (sourceActiveGroupId) {
+    nextActiveGroupIdByWorktree[sourceWorktreeId] = sourceActiveGroupId
+  } else {
+    delete nextActiveGroupIdByWorktree[sourceWorktreeId]
+  }
+
+  return {
+    sourceWorktreeId,
+    destWorktreeId,
+    tabId,
+    patch: {
+      tabsByWorktree: {
+        ...state.tabsByWorktree,
+        [sourceWorktreeId]: sourceTerminals,
+        [destWorktreeId]: destTerminals
+      },
+      unifiedTabsByWorktree: {
+        ...state.unifiedTabsByWorktree,
+        [sourceWorktreeId]: sourceUnified.filter((tab) => !movingUnifiedIds.has(tab.id)),
+        [destWorktreeId]: [
+          ...destUnifiedExisting.filter((tab) => !movingUnifiedIds.has(tab.id)),
+          ...movedUnified
+        ]
+      },
+      groupsByWorktree: {
+        ...destEnsured.groupsByWorktree,
+        [sourceWorktreeId]: sourceGroups,
+        [destWorktreeId]: destGroups
+      },
+      layoutByWorktree: nextLayoutByWorktree,
+      activeGroupIdByWorktree: nextActiveGroupIdByWorktree,
+      tabBarOrderByWorktree: {
+        ...state.tabBarOrderByWorktree,
+        [sourceWorktreeId]: sourceBar,
+        [destWorktreeId]: destBar
+      },
+      activeTabIdByWorktree: {
+        ...state.activeTabIdByWorktree,
+        [sourceWorktreeId]:
+          state.activeTabIdByWorktree[sourceWorktreeId] === tabId
+            ? (sourceTerminals[0]?.id ?? null)
+            : state.activeTabIdByWorktree[sourceWorktreeId],
+        [destWorktreeId]: tabId
+      },
+      activeTabId: state.activeTabId === tabId ? (sourceTerminals[0]?.id ?? null) : state.activeTabId,
+      agentStatusByPaneKey: remintWorktreeId(state.agentStatusByPaneKey, tabId, destWorktreeId),
+      retainedAgentsByPaneKey: remintRetainedWorktreeId(
+        state.retainedAgentsByPaneKey,
+        tabId,
+        destWorktreeId
+      ),
+      sleepingAgentSessionsByPaneKey: remintWorktreeId(
+        state.sleepingAgentSessionsByPaneKey,
+        tabId,
+        destWorktreeId
+      )
+    }
+  }
+}

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -67,6 +67,7 @@ import {
 import { isClaudeAgent } from '@/lib/agent-status'
 import { recordTerminalInputActivity } from '@/lib/terminal-input-activity-coalescing'
 import { classifyTitleActivity } from '@/lib/pane-agent-evidence'
+import { moveTerminalTabToWorktreeInStore } from './move-terminal-tab-to-worktree'
 import { buildOrphanTerminalCleanupPatch, getOrphanTerminalIds } from './terminal-orphan-helpers'
 import {
   applyGeneratedTabTitleUpdates,
@@ -649,6 +650,7 @@ export type TerminalSlice = {
   ) => void
   reorderTabs: (worktreeId: string, tabIds: string[]) => void
   setTabBarOrder: (worktreeId: string, order: string[]) => void
+  moveTerminalTabToWorktree: (tabId: string, destWorktreeId: string) => boolean
   setActiveTab: (tabId: string) => void
   setActiveTabForWorktree: (worktreeId: string, tabId: string) => void
   updateTabTitle: (tabId: string, title: string) => void
@@ -1872,6 +1874,22 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         tabsByWorktree: { ...s.tabsByWorktree, [worktreeId]: reordered }
       }
     })
+  },
+
+  moveTerminalTabToWorktree: (tabId, destWorktreeId) => {
+    let moved = false
+    set((s) => {
+      const result = moveTerminalTabToWorktreeInStore(s, tabId, destWorktreeId)
+      if (!result) {
+        return {}
+      }
+      moved = true
+      return result.patch
+    })
+    if (moved) {
+      scheduleRuntimeGraphSync()
+    }
+    return moved
   },
 
   setTabBarOrder: (worktreeId, order) => {

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2889,6 +2889,8 @@ function createWebUiApi(): NonNullable<Partial<PreloadApi>['ui']> {
     onCloseTerminal: () => noopUnsubscribe,
     onTerminalTabCloseRequest: () => noopUnsubscribe,
     respondTerminalTabClose: () => {},
+    onTerminalTabMoveRequest: () => noopUnsubscribe,
+    respondTerminalTabMove: () => {},
     onSleepWorktree: () => noopUnsubscribe,
     // Why: paired web is a full renderer that wakes on activation; mobile wake is desktop-host-scoped and never reaches web.
     onResumeSleepingAgents: () => noopUnsubscribe,

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -728,6 +728,14 @@ export type RuntimeTerminalFocus = {
   navigated?: boolean
 }
 
+export type RuntimeTerminalMove = {
+  handle: string
+  tabId: string
+  sourceWorktreeId: string
+  destWorktreeId: string
+  ptyIds: string[]
+}
+
 export type RuntimeTerminalClose = {
   handle: string
   tabId: string

--- a/src/shared/terminal-move-destination.test.ts
+++ b/src/shared/terminal-move-destination.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { FLOATING_TERMINAL_WORKTREE_ID } from './constants'
+import {
+  assertValidTerminalMoveDestination,
+  getTerminalMoveDestinationError
+} from './terminal-move-destination'
+
+describe('terminal move destination guards', () => {
+  it('rejects the floating terminal and the current worktree', () => {
+    expect(
+      getTerminalMoveDestinationError('repo::/src', FLOATING_TERMINAL_WORKTREE_ID)
+    ).toBe('destination_is_floating')
+    expect(getTerminalMoveDestinationError('repo::/src', 'repo::/src')).toBe(
+      'destination_same_as_source'
+    )
+    expect(getTerminalMoveDestinationError('repo::/src', 'repo::/dest')).toBeNull()
+  })
+
+  it('throws the closed error codes', () => {
+    expect(() =>
+      assertValidTerminalMoveDestination('repo::/src', FLOATING_TERMINAL_WORKTREE_ID)
+    ).toThrow('destination_is_floating')
+    expect(() => assertValidTerminalMoveDestination('repo::/src', 'repo::/src')).toThrow(
+      'destination_same_as_source'
+    )
+  })
+})

--- a/src/shared/terminal-move-destination.ts
+++ b/src/shared/terminal-move-destination.ts
@@ -1,0 +1,28 @@
+import { FLOATING_TERMINAL_WORKTREE_ID } from './constants'
+
+export type TerminalMoveDestinationError =
+  | 'destination_same_as_source'
+  | 'destination_is_floating'
+
+export function getTerminalMoveDestinationError(
+  sourceWorktreeId: string,
+  destWorktreeId: string
+): TerminalMoveDestinationError | null {
+  if (destWorktreeId === FLOATING_TERMINAL_WORKTREE_ID) {
+    return 'destination_is_floating'
+  }
+  if (destWorktreeId === sourceWorktreeId) {
+    return 'destination_same_as_source'
+  }
+  return null
+}
+
+export function assertValidTerminalMoveDestination(
+  sourceWorktreeId: string,
+  destWorktreeId: string
+): void {
+  const error = getTerminalMoveDestinationError(sourceWorktreeId, destWorktreeId)
+  if (error) {
+    throw new Error(error)
+  }
+}

--- a/src/shared/terminal-tab-move.ts
+++ b/src/shared/terminal-tab-move.ts
@@ -1,0 +1,10 @@
+export type TerminalTabMoveRequest = {
+  requestId: string
+  tabId: string
+  destWorktreeId: string
+}
+
+export type TerminalTabMoveResponse = {
+  requestId: string
+  error?: string
+}

--- a/src/shared/workspace-session-terminal-tab-move.test.ts
+++ b/src/shared/workspace-session-terminal-tab-move.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from 'vitest'
+import { getDefaultWorkspaceSession } from './constants'
+import type { Tab } from './tab-types'
+import type { TerminalTab } from './terminal-tab-types'
+import type { WorkspaceSessionState } from './workspace-session-state-types'
+import {
+  moveTerminalTabInWorkspaceSession,
+  partitionMovedTerminalTabHostSessions
+} from './workspace-session-terminal-tab-move'
+
+const SOURCE = 'repo::/src'
+const DEST = 'repo::/dest'
+
+function terminalTab(id: string, worktreeId: string, ptyId = 'pty-1'): TerminalTab {
+  return {
+    id,
+    ptyId,
+    worktreeId,
+    title: id,
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1
+  }
+}
+
+function unifiedTab(id: string, worktreeId: string, groupId: string): Tab {
+  return {
+    id,
+    entityId: id,
+    groupId,
+    worktreeId,
+    contentType: 'terminal',
+    label: id,
+    customLabel: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1
+  }
+}
+
+function session(): WorkspaceSessionState {
+  return {
+    ...getDefaultWorkspaceSession(),
+    activeWorktreeId: SOURCE,
+    activeTabId: 'tab-1',
+    tabsByWorktree: {
+      [SOURCE]: [terminalTab('tab-1', SOURCE), terminalTab('tab-keep', SOURCE, 'pty-keep')],
+      [DEST]: [terminalTab('tab-dest', DEST, 'pty-dest')]
+    },
+    terminalLayoutsByTabId: {
+      'tab-1': {
+        root: { type: 'leaf', leafId: 'leaf-1' },
+        activeLeafId: 'leaf-1',
+        expandedLeafId: null,
+        ptyIdsByLeafId: { 'leaf-1': 'pty-1' }
+      }
+    },
+    activeTabIdByWorktree: { [SOURCE]: 'tab-1', [DEST]: 'tab-dest' },
+    unifiedTabs: {
+      [SOURCE]: [
+        unifiedTab('tab-1', SOURCE, 'group-src'),
+        unifiedTab('tab-keep', SOURCE, 'group-src')
+      ],
+      [DEST]: [unifiedTab('tab-dest', DEST, 'group-dest')]
+    },
+    tabGroups: {
+      [SOURCE]: [
+        {
+          id: 'group-src',
+          worktreeId: SOURCE,
+          activeTabId: 'tab-1',
+          tabOrder: ['tab-1', 'tab-keep'],
+          recentTabIds: ['tab-1']
+        }
+      ],
+      [DEST]: [
+        {
+          id: 'group-dest',
+          worktreeId: DEST,
+          activeTabId: 'tab-dest',
+          tabOrder: ['tab-dest'],
+          recentTabIds: ['tab-dest']
+        }
+      ]
+    },
+    tabGroupLayouts: {
+      [SOURCE]: { type: 'leaf', groupId: 'group-src' },
+      [DEST]: { type: 'leaf', groupId: 'group-dest' }
+    }
+  }
+}
+
+describe('moveTerminalTabInWorkspaceSession', () => {
+  it('reattaches the tab without dropping its PTY binding', () => {
+    const result = moveTerminalTabInWorkspaceSession(session(), SOURCE, DEST, 'tab-1')
+
+    expect(result.moved).toBe(true)
+    expect(result.session.tabsByWorktree[SOURCE]?.map((tab) => tab.id)).toEqual(['tab-keep'])
+    expect(result.session.tabsByWorktree[DEST]?.map((tab) => tab.id)).toEqual(['tab-dest', 'tab-1'])
+    expect(result.session.tabsByWorktree[DEST]?.at(-1)).toMatchObject({
+      id: 'tab-1',
+      worktreeId: DEST,
+      ptyId: 'pty-1'
+    })
+    expect(result.session.terminalLayoutsByTabId['tab-1']?.ptyIdsByLeafId).toEqual({
+      'leaf-1': 'pty-1'
+    })
+    expect(result.session.unifiedTabs?.[DEST]?.map((tab) => tab.id)).toEqual(['tab-dest', 'tab-1'])
+    expect(result.session.tabGroups?.[DEST]?.[0]?.tabOrder).toEqual(['tab-dest', 'tab-1'])
+  })
+
+  it('fails closed when the destination is the source or the tab is missing', () => {
+    expect(moveTerminalTabInWorkspaceSession(session(), SOURCE, SOURCE, 'tab-1').moved).toBe(false)
+    expect(moveTerminalTabInWorkspaceSession(session(), SOURCE, DEST, 'missing').moved).toBe(false)
+  })
+
+  it('rejects a terminal row that has no matching unified tab', () => {
+    const broken = session()
+    broken.unifiedTabs = {
+      [SOURCE]: [unifiedTab('tab-keep', SOURCE, 'group-src')],
+      [DEST]: [unifiedTab('tab-dest', DEST, 'group-dest')]
+    }
+
+    expect(() => moveTerminalTabInWorkspaceSession(broken, SOURCE, DEST, 'tab-1')).toThrow(
+      'terminal_tab_state_inconsistent'
+    )
+    expect(broken.tabsByWorktree[SOURCE]?.map((tab) => tab.id)).toEqual(['tab-1', 'tab-keep'])
+    expect(broken.tabGroups?.[DEST]?.[0]?.tabOrder).toEqual(['tab-dest'])
+  })
+
+  it('keeps dest and source host sessions from inheriting each other worktree keys', () => {
+    const sourceSession = session()
+    const destSession: WorkspaceSessionState = {
+      ...getDefaultWorkspaceSession(),
+      activeWorktreeId: DEST,
+      activeTabId: 'tab-dest',
+      tabsByWorktree: {
+        [DEST]: [terminalTab('tab-dest', DEST, 'pty-dest')]
+      },
+      unifiedTabs: {
+        [DEST]: [unifiedTab('tab-dest', DEST, 'group-dest')]
+      },
+      tabGroups: {
+        [DEST]: [
+          {
+            id: 'group-dest',
+            worktreeId: DEST,
+            activeTabId: 'tab-dest',
+            tabOrder: ['tab-dest'],
+            recentTabIds: ['tab-dest']
+          }
+        ]
+      },
+      tabGroupLayouts: {
+        [DEST]: { type: 'leaf', groupId: 'group-dest' }
+      },
+      activeTabIdByWorktree: { [DEST]: 'tab-dest' }
+    }
+
+    const partitioned = partitionMovedTerminalTabHostSessions({
+      sourceSession,
+      destSession,
+      sourceWorktreeId: SOURCE,
+      destWorktreeId: DEST,
+      tabId: 'tab-1',
+      sameHost: false
+    })
+
+    expect(partitioned).not.toBeNull()
+    expect(Object.keys(partitioned!.dest.tabsByWorktree)).toEqual([DEST])
+    expect(Object.keys(partitioned!.dest.unifiedTabs ?? {})).toEqual([DEST])
+    expect(Object.keys(partitioned!.dest.tabGroups ?? {})).toEqual([DEST])
+    expect(Object.keys(partitioned!.dest.tabGroupLayouts ?? {})).toEqual([DEST])
+    expect(partitioned!.dest.tabsByWorktree[DEST]?.map((tab) => tab.id)).toEqual([
+      'tab-dest',
+      'tab-1'
+    ])
+    expect(Object.keys(partitioned!.source.tabsByWorktree)).toEqual([SOURCE])
+    expect(partitioned!.source.tabsByWorktree[SOURCE]?.map((tab) => tab.id)).toEqual(['tab-keep'])
+  })
+})

--- a/src/shared/workspace-session-terminal-tab-move.ts
+++ b/src/shared/workspace-session-terminal-tab-move.ts
@@ -1,0 +1,314 @@
+import type { Tab, TabGroup, TabGroupLayoutNode } from './tab-types'
+import type { WorkspaceSessionState } from './workspace-session-state-types'
+
+export type WorkspaceSessionTerminalTabMoveResult = {
+  session: WorkspaceSessionState
+  moved: boolean
+}
+
+function pruneGroupLayout(
+  node: TabGroupLayoutNode | undefined,
+  validGroupIds: ReadonlySet<string>
+): TabGroupLayoutNode | undefined {
+  if (!node) {
+    return undefined
+  }
+  if (node.type === 'leaf') {
+    return validGroupIds.has(node.groupId) ? node : undefined
+  }
+  const first = pruneGroupLayout(node.first, validGroupIds)
+  const second = pruneGroupLayout(node.second, validGroupIds)
+  if (!first) {
+    return second
+  }
+  if (!second) {
+    return first
+  }
+  return { ...node, first, second }
+}
+
+function findUnifiedTerminalTabs(
+  session: WorkspaceSessionState,
+  worktreeId: string,
+  tabId: string
+): Tab[] {
+  return (session.unifiedTabs?.[worktreeId] ?? []).filter(
+    (tab) => tab.contentType === 'terminal' && (tab.entityId === tabId || tab.id === tabId)
+  )
+}
+
+function pickNextActiveTab(group: TabGroup, closingIds: ReadonlySet<string>): string | null {
+  const remaining = group.tabOrder.filter((id) => !closingIds.has(id))
+  for (let index = (group.recentTabIds?.length ?? 0) - 1; index >= 0; index -= 1) {
+    const id = group.recentTabIds![index]
+    if (remaining.includes(id)) {
+      return id
+    }
+  }
+  const closingIndex = group.tabOrder.findIndex((id) => closingIds.has(id))
+  return (
+    remaining.find((id) => group.tabOrder.indexOf(id) > closingIndex) ?? remaining.at(-1) ?? null
+  )
+}
+
+function ensureDestGroup(
+  session: WorkspaceSessionState,
+  destWorktreeId: string
+): { groups: TabGroup[]; group: TabGroup; layout: TabGroupLayoutNode } {
+  const groups = [...(session.tabGroups?.[destWorktreeId] ?? [])]
+  const existing = groups[0]
+  if (existing) {
+    return {
+      groups,
+      group: existing,
+      layout: session.tabGroupLayouts?.[destWorktreeId] ?? { type: 'leaf', groupId: existing.id }
+    }
+  }
+  const group: TabGroup = {
+    id: `group-${destWorktreeId}`,
+    worktreeId: destWorktreeId,
+    activeTabId: null,
+    tabOrder: [],
+    recentTabIds: []
+  }
+  return {
+    groups: [group],
+    group,
+    layout: { type: 'leaf', groupId: group.id }
+  }
+}
+
+const WORKTREE_KEYED_SESSION_FIELDS = [
+  'tabsByWorktree',
+  'unifiedTabs',
+  'tabGroups',
+  'tabGroupLayouts',
+  'activeGroupIdByWorktree',
+  'activeTabIdByWorktree'
+] as const
+
+export function assertWorkspaceSessionTerminalTabMoveConsistent(
+  session: WorkspaceSessionState,
+  sourceWorktreeId: string,
+  tabId: string
+): void {
+  const terminalRow = session.tabsByWorktree[sourceWorktreeId]?.find((tab) => tab.id === tabId)
+  const unifiedTerminalTabs = findUnifiedTerminalTabs(session, sourceWorktreeId, tabId)
+  // Why: a terminal row without its unified tab would persist a dest surface
+  // that never enters a TabGroup / active tab, so refuse before mutation.
+  if (terminalRow && unifiedTerminalTabs.length === 0) {
+    throw new Error('terminal_tab_state_inconsistent')
+  }
+}
+
+export function omitWorkspaceSessionWorktreeKeys(
+  session: WorkspaceSessionState,
+  worktreeId: string
+): WorkspaceSessionState {
+  const next: WorkspaceSessionState = { ...session }
+  for (const field of WORKTREE_KEYED_SESSION_FIELDS) {
+    const bag = session[field]
+    if (!bag || !(worktreeId in bag)) {
+      continue
+    }
+    const clone = { ...bag }
+    delete clone[worktreeId]
+    next[field] = clone as WorkspaceSessionState[typeof field]
+  }
+  return next
+}
+
+export function partitionMovedTerminalTabHostSessions(args: {
+  sourceSession: WorkspaceSessionState
+  destSession: WorkspaceSessionState
+  sourceWorktreeId: string
+  destWorktreeId: string
+  tabId: string
+  sameHost: boolean
+}): { source: WorkspaceSessionState; dest: WorkspaceSessionState } | null {
+  if (args.sameHost) {
+    const moved = moveTerminalTabInWorkspaceSession(
+      args.sourceSession,
+      args.sourceWorktreeId,
+      args.destWorktreeId,
+      args.tabId
+    )
+    return moved.moved ? { source: moved.session, dest: moved.session } : null
+  }
+
+  const destMoved = moveTerminalTabInWorkspaceSession(
+    {
+      ...args.destSession,
+      tabsByWorktree: {
+        ...args.destSession.tabsByWorktree,
+        [args.sourceWorktreeId]: args.sourceSession.tabsByWorktree[args.sourceWorktreeId]
+      },
+      unifiedTabs: {
+        ...args.destSession.unifiedTabs,
+        [args.sourceWorktreeId]: args.sourceSession.unifiedTabs?.[args.sourceWorktreeId]
+      },
+      tabGroups: {
+        ...args.destSession.tabGroups,
+        [args.sourceWorktreeId]: args.sourceSession.tabGroups?.[args.sourceWorktreeId]
+      },
+      tabGroupLayouts: {
+        ...args.destSession.tabGroupLayouts,
+        [args.sourceWorktreeId]: args.sourceSession.tabGroupLayouts?.[args.sourceWorktreeId]
+      }
+    },
+    args.sourceWorktreeId,
+    args.destWorktreeId,
+    args.tabId
+  )
+  const sourceMoved = moveTerminalTabInWorkspaceSession(
+    args.sourceSession,
+    args.sourceWorktreeId,
+    args.destWorktreeId,
+    args.tabId
+  )
+  if (!destMoved.moved || !sourceMoved.moved) {
+    return null
+  }
+  return {
+    dest: omitWorkspaceSessionWorktreeKeys(destMoved.session, args.sourceWorktreeId),
+    source: omitWorkspaceSessionWorktreeKeys(sourceMoved.session, args.destWorktreeId)
+  }
+}
+
+export function moveTerminalTabInWorkspaceSession(
+  session: WorkspaceSessionState,
+  sourceWorktreeId: string,
+  destWorktreeId: string,
+  tabId: string
+): WorkspaceSessionTerminalTabMoveResult {
+  if (sourceWorktreeId === destWorktreeId) {
+    return { session, moved: false }
+  }
+  assertWorkspaceSessionTerminalTabMoveConsistent(session, sourceWorktreeId, tabId)
+  const terminalRow = session.tabsByWorktree[sourceWorktreeId]?.find((tab) => tab.id === tabId)
+  const unifiedTerminalTabs = findUnifiedTerminalTabs(session, sourceWorktreeId, tabId)
+  if (!terminalRow && unifiedTerminalTabs.length === 0) {
+    return { session, moved: false }
+  }
+
+  const movingUnifiedIds = new Set(unifiedTerminalTabs.map((tab) => tab.id))
+  movingUnifiedIds.add(tabId)
+  const dest = ensureDestGroup(session, destWorktreeId)
+  const destUnifiedExisting = session.unifiedTabs?.[destWorktreeId] ?? []
+  const destUnifiedIds = new Set(destUnifiedExisting.map((tab) => tab.id))
+  const movedUnified = unifiedTerminalTabs
+    .filter((tab) => !destUnifiedIds.has(tab.id))
+    .map((tab) => ({
+      ...tab,
+      worktreeId: destWorktreeId,
+      groupId: dest.group.id
+    }))
+  const destTabOrder = [
+    ...dest.group.tabOrder.filter((id) => !movingUnifiedIds.has(id)),
+    ...movedUnified.map((tab) => tab.id)
+  ]
+  const destActiveTabId = movedUnified.at(-1)?.id ?? dest.group.activeTabId
+  const destRecent = [
+    ...(dest.group.recentTabIds ?? []).filter((id) => !movingUnifiedIds.has(id)),
+    ...movedUnified.map((tab) => tab.id)
+  ]
+  const destGroups = dest.groups.map((group) =>
+    group.id === dest.group.id
+      ? {
+          ...group,
+          worktreeId: destWorktreeId,
+          tabOrder: destTabOrder,
+          activeTabId: destActiveTabId,
+          recentTabIds: destRecent
+        }
+      : group
+  )
+
+  const sourceUnified = (session.unifiedTabs?.[sourceWorktreeId] ?? []).filter(
+    (tab) => !movingUnifiedIds.has(tab.id)
+  )
+  const sourceGroups = (session.tabGroups?.[sourceWorktreeId] ?? [])
+    .map((group) => {
+      const tabOrder = group.tabOrder.filter((id) => !movingUnifiedIds.has(id))
+      const activeTabId = movingUnifiedIds.has(group.activeTabId ?? '')
+        ? pickNextActiveTab(group, movingUnifiedIds)
+        : group.activeTabId && tabOrder.includes(group.activeTabId)
+          ? group.activeTabId
+          : (tabOrder[0] ?? null)
+      return {
+        ...group,
+        tabOrder,
+        activeTabId,
+        recentTabIds: group.recentTabIds?.filter((id) => tabOrder.includes(id))
+      }
+    })
+    .filter((group) => group.tabOrder.length > 0)
+  const validSourceGroupIds = new Set(sourceGroups.map((group) => group.id))
+  const sourceLayout = pruneGroupLayout(
+    session.tabGroupLayouts?.[sourceWorktreeId],
+    validSourceGroupIds
+  )
+  const sourceActiveGroupId = validSourceGroupIds.has(
+    session.activeGroupIdByWorktree?.[sourceWorktreeId] ?? ''
+  )
+    ? session.activeGroupIdByWorktree?.[sourceWorktreeId]
+    : sourceGroups[0]?.id
+
+  const sourceTerminals = (session.tabsByWorktree[sourceWorktreeId] ?? []).filter(
+    (tab) => tab.id !== tabId
+  )
+  const destTerminals = [
+    ...(session.tabsByWorktree[destWorktreeId] ?? []).filter((tab) => tab.id !== tabId),
+    ...(terminalRow ? [{ ...terminalRow, worktreeId: destWorktreeId }] : [])
+  ]
+
+  const next: WorkspaceSessionState = {
+    ...session,
+    tabsByWorktree: {
+      ...session.tabsByWorktree,
+      [sourceWorktreeId]: sourceTerminals,
+      [destWorktreeId]: destTerminals
+    },
+    unifiedTabs: {
+      ...session.unifiedTabs,
+      [sourceWorktreeId]: sourceUnified,
+      [destWorktreeId]: [...destUnifiedExisting.filter((tab) => !movingUnifiedIds.has(tab.id)), ...movedUnified]
+    },
+    tabGroups: {
+      ...session.tabGroups,
+      [sourceWorktreeId]: sourceGroups,
+      [destWorktreeId]: destGroups
+    },
+    tabGroupLayouts: {
+      ...session.tabGroupLayouts,
+      ...(sourceLayout
+        ? { [sourceWorktreeId]: sourceLayout }
+        : {}),
+      [destWorktreeId]: dest.layout
+    },
+    activeGroupIdByWorktree: {
+      ...session.activeGroupIdByWorktree,
+      [destWorktreeId]: dest.group.id
+    },
+    activeTabIdByWorktree: {
+      ...session.activeTabIdByWorktree,
+      [sourceWorktreeId]:
+        session.activeTabIdByWorktree?.[sourceWorktreeId] === tabId
+          ? (sourceTerminals[0]?.id ?? null)
+          : (session.activeTabIdByWorktree?.[sourceWorktreeId] ?? null),
+      [destWorktreeId]: terminalRow?.id ?? session.activeTabIdByWorktree?.[destWorktreeId] ?? null
+    }
+  }
+  if (sourceLayout === undefined && next.tabGroupLayouts) {
+    delete next.tabGroupLayouts[sourceWorktreeId]
+  }
+  if (sourceActiveGroupId) {
+    next.activeGroupIdByWorktree![sourceWorktreeId] = sourceActiveGroupId
+  } else if (next.activeGroupIdByWorktree) {
+    delete next.activeGroupIdByWorktree[sourceWorktreeId]
+  }
+  if (session.activeWorktreeId === sourceWorktreeId && session.activeTabId === tabId) {
+    next.activeTabId = sourceTerminals[0]?.id ?? null
+  }
+  return { session: next, moved: true }
+}


### PR DESCRIPTION
## ELI5

You can now move a running terminal (and its agent) from one worktree card to another without killing the process. Right-click the tab or the sidebar agent row, or use `orca terminal move`.

## What Changed

- CLI: `orca terminal move --worktree <selector> [--terminal <handle>] [--tab] [--json]`
- RPC `terminal.move` rebinds the live tab + PTY maps to the destination worktree. The child process is not killed and is not forced to `chdir`.
- Tab context menu and sidebar agent-row context menu: **Move to worktree…** (displayName + branch). Destination list excludes the current worktree, archived worktrees, and the floating terminal.
- Fail closed on dest === source, missing dest, or stale handle.

## Why

#9632: a live agent stays glued to the worktree where its terminal was created. Today the only options are a fresh terminal + resume (writer lock / lost live state) or the floating terminal (loses workspace association).

## Linked Issue

Fixes #9632

## Visual Proof

N/A for screenshots in this checkout (no Electron UI run). Interaction is a new context-menu submenu and CLI verb; existing tab chrome is unchanged besides that item.

## Testing

- [x] Automated tests added/updated, or explained why not below
- Focused: `terminal.test.ts`, `workspace-session-terminal-tab-move.test.ts`, `terminal-move-destination.test.ts`, `move-terminal-tab-to-worktree.test.ts`, `move-terminal-to-worktree-destinations.test.ts`, `terminal-tab-worktree-rebind.test.ts` (17 tests passed locally; agent run reported 85 including existing neighbors)
- No desktop UI run of this checkout.

## AI Disclosure

Implementation and write-up by Grok 4.6 (xAI) in a local coding-agent session.

## Review

### Agent code-review summary

- Cross-platform: move is store/RPC rebind; no path or shortcut changes. Destination filter is worktree metadata.
- SSH/remote: same-host rebind is the supported path; persist across hosts is best-effort (stated in the implementation).
- Agent compatibility: does not resume/restart the agent. Writer lock stays with the same process.
- Performance: one tab splice + map remint; no extra scans of all PTYs beyond existing maps.
- UI: one shared submenu component on tab + agent row.
- Security: dest must be a known worktree selector; no new command execution.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

`--tab` and the default path both move the **whole tab** (all panes). Single-pane extract across worktrees is out of scope. Child env `ORCA_WORKTREE_ID` / cwd stay as spawned; host-side maps follow the tab.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Focused unit tests passed locally.

## Author

- X / Twitter: