### PR TITLE
feat(editor): add Show Whitespace toggle option in diff viewer

### DIFF
--- a/src/main/codex-accounts/runtime-home-settings-test-fixtures.ts
+++ b/src/main/codex-accounts/runtime-home-settings-test-fixtures.ts
@@ -130,6 +130,7 @@ export function createSettings(overrides: TestSettingsOverrides = {}): GlobalSet
     terminalWindowsPowerShellImplementation: 'powershell.exe',
     ...overrides,
     diffWordWrap: overrides.diffWordWrap ?? false,
+    diffShowWhitespace: overrides.diffShowWhitespace ?? false,
     localWindowsRuntimeDefault: overrides.localWindowsRuntimeDefault ?? { kind: 'windows-host' },
     leftSidebarAppearanceMode: overrides.leftSidebarAppearanceMode ?? 'default',
     appFontFamily,

--- a/src/main/codex-accounts/service-test-harness.ts
+++ b/src/main/codex-accounts/service-test-harness.ts
@@ -151,6 +151,7 @@ export function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalS
     terminalWindowsPowerShellImplementation: 'powershell.exe',
     ...overrides,
     diffWordWrap: overrides.diffWordWrap ?? false,
+    diffShowWhitespace: overrides.diffShowWhitespace ?? false,
     localWindowsRuntimeDefault: overrides.localWindowsRuntimeDefault ?? { kind: 'windows-host' },
     leftSidebarAppearanceMode: overrides.leftSidebarAppearanceMode ?? 'default',
     appFontFamily,

--- a/src/renderer/src/components/editor/DiffSectionBody.tsx
+++ b/src/renderer/src/components/editor/DiffSectionBody.tsx
@@ -11,6 +11,7 @@ import type { DiffSection } from './diff-section-types'
 import { translate } from '@/i18n/i18n'
 import { LargeDiffFallback } from './LargeDiffFallback'
 import { LargeDiffLoadPrompt } from './LargeDiffLoadPrompt'
+import { buildDiffEditorWhitespaceOptions } from './diff-editor-whitespace-options'
 import { buildDiffEditorWordWrapOptions } from './diff-editor-word-wrap-options'
 import { monacoFindOptions } from './monaco-find-options'
 
@@ -39,6 +40,7 @@ type DiffSectionBodyProps = {
   isEditable: boolean
   diffEditorFontSize: number
   diffWordWrap?: boolean
+  diffShowWhitespace?: boolean
   editorFontFamily?: string
   onCancelComment: () => void
   onSubmitComment: (body: string) => Promise<void>
@@ -65,6 +67,7 @@ export function DiffSectionBody({
   isEditable,
   diffEditorFontSize,
   diffWordWrap,
+  diffShowWhitespace,
   editorFontFamily,
   onCancelComment,
   onSubmitComment,
@@ -204,6 +207,7 @@ export function DiffSectionBody({
             fontFamily: editorFontFamily || 'monospace',
             lineNumbers: 'on',
             ...buildDiffEditorWordWrapOptions(diffWordWrap),
+            ...buildDiffEditorWhitespaceOptions(diffShowWhitespace),
             automaticLayout: true,
             renderOverviewRuler: false,
             scrollbar: combinedDiffSectionScrollbarOptions,

--- a/src/renderer/src/components/editor/DiffSectionItem.tsx
+++ b/src/renderer/src/components/editor/DiffSectionItem.tsx
@@ -373,6 +373,7 @@ export function DiffSectionItem({
           isEditable={isEditable}
           diffEditorFontSize={diffEditorFontSize}
           diffWordWrap={settings?.diffWordWrap}
+          diffShowWhitespace={settings?.diffShowWhitespace}
           editorFontFamily={resolveEditorFontFamily(settings)}
           onCancelComment={() => setPopover(null)}
           onSubmitComment={handleSubmitComment}

--- a/src/renderer/src/components/editor/DiffViewer.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.tsx
@@ -23,6 +23,7 @@ import { getLargeDiffRenderLimit } from './large-diff-render-limit'
 import { useDiffViewerLargeDiffLifecycle } from './useDiffViewerLargeDiffLifecycle'
 import { getDiffViewerLargeDiffSaveAction } from './diff-viewer-large-diff-save-action'
 import type { DiffViewerProps } from './diff-viewer-props'
+import { buildDiffEditorWhitespaceOptions } from './diff-editor-whitespace-options'
 import { buildDiffEditorWordWrapOptions } from './diff-editor-word-wrap-options'
 import { useDiffEditorRegistration } from './diff-navigation-context'
 import { preserveDiffViewStateAcrossModelSwaps } from './diff-model-swap-view-state'
@@ -426,7 +427,7 @@ export default function DiffViewer({
               fontFamily: resolveEditorFontFamily(settings),
               lineNumbers: 'on',
               ...buildDiffEditorWordWrapOptions(settings?.diffWordWrap),
-              ignoreTrimWhitespace: !settings?.diffShowWhitespace,
+              ...buildDiffEditorWhitespaceOptions(settings?.diffShowWhitespace),
               automaticLayout: true,
               renderOverviewRuler: true,
               scrollbar: diffEditorScrollbarOptions,

--- a/src/renderer/src/components/editor/DiffViewer.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.tsx
@@ -426,6 +426,7 @@ export default function DiffViewer({
               fontFamily: resolveEditorFontFamily(settings),
               lineNumbers: 'on',
               ...buildDiffEditorWordWrapOptions(settings?.diffWordWrap),
+              ignoreTrimWhitespace: !settings?.diffShowWhitespace,
               automaticLayout: true,
               renderOverviewRuler: true,
               scrollbar: diffEditorScrollbarOptions,

--- a/src/renderer/src/components/editor/EditorPanelHeader.tsx
+++ b/src/renderer/src/components/editor/EditorPanelHeader.tsx
@@ -95,6 +95,7 @@ export function EditorPanelHeader({
   )
   const activeGroupId = useAppStore((s) => s.activeGroupIdByWorktree[activeFile.worktreeId])
   const diffWordWrap = useAppStore((s) => s.settings?.diffWordWrap === true)
+  const diffShowWhitespace = useAppStore((s) => s.settings?.diffShowWhitespace === true)
   // Why: undefined/true mean wrap on; only explicit false turns wrap off (#9974).
   const editorWordWrap = useAppStore((s) => s.settings?.editorWordWrap !== false)
   const updateSettings = useAppStore((s) => s.updateSettings)
@@ -327,12 +328,16 @@ export function EditorPanelHeader({
         isMarkdown={isMarkdown}
         isDiffSurface={isDiffSurface}
         diffWordWrap={diffWordWrap}
+        diffShowWhitespace={diffShowWhitespace}
         editorWordWrap={editorWordWrap}
         shouldShowMarkdownExportAction={shouldShowMarkdownExportAction}
         canExportMarkdownToPdf={canExportMarkdownToPdf}
         canShowMarkdownFrontmatterToggle={canShowMarkdownFrontmatterToggle}
         markdownFrontmatterVisible={markdownFrontmatterVisible}
         onToggleDiffWordWrap={() => void updateSettings({ diffWordWrap: !diffWordWrap })}
+        onToggleDiffWhitespace={() =>
+          void updateSettings({ diffShowWhitespace: !diffShowWhitespace })
+        }
         onToggleEditorWordWrap={() => void updateSettings({ editorWordWrap: !editorWordWrap })}
         onToggleMarkdownFrontmatter={onToggleMarkdownFrontmatter}
         onExportMarkdownToPdf={onExportMarkdownToPdf}

--- a/src/renderer/src/components/editor/EditorPanelMarkdownActionsMenu.test.tsx
+++ b/src/renderer/src/components/editor/EditorPanelMarkdownActionsMenu.test.tsx
@@ -54,12 +54,14 @@ describe('EditorPanelMarkdownActionsMenu', () => {
         isMarkdown: false,
         isDiffSurface: false,
         diffWordWrap: false,
+        diffShowWhitespace: false,
         editorWordWrap: true,
         shouldShowMarkdownExportAction: false,
         canExportMarkdownToPdf: false,
         canShowMarkdownFrontmatterToggle: false,
         markdownFrontmatterVisible: false,
         onToggleDiffWordWrap,
+        onToggleDiffWhitespace: () => {},
         onToggleEditorWordWrap,
         onToggleMarkdownFrontmatter: () => {},
         onExportMarkdownToPdf: () => {}
@@ -81,22 +83,54 @@ describe('EditorPanelMarkdownActionsMenu', () => {
         isMarkdown: false,
         isDiffSurface: true,
         diffWordWrap: true,
+        diffShowWhitespace: false,
         editorWordWrap: false,
         shouldShowMarkdownExportAction: false,
         canExportMarkdownToPdf: false,
         canShowMarkdownFrontmatterToggle: false,
         markdownFrontmatterVisible: false,
         onToggleDiffWordWrap,
+        onToggleDiffWhitespace: () => {},
         onToggleEditorWordWrap,
         onToggleMarkdownFrontmatter: () => {},
         onExportMarkdownToPdf: () => {}
       })
     )
 
-    expect(checkboxItems.list).toHaveLength(1)
+    expect(checkboxItems.list).toHaveLength(2)
     expect(checkboxItems.list[0]).toMatchObject({ checked: true, label: 'Word Wrap' })
     checkboxItems.list[0]?.onCheckedChange?.(false)
     expect(onToggleDiffWordWrap).toHaveBeenCalledOnce()
     expect(onToggleEditorWordWrap).not.toHaveBeenCalled()
+  })
+
+  it('shows and binds Show Whitespace on diff surfaces', () => {
+    const onToggleDiffWhitespace = vi.fn()
+    renderToStaticMarkup(
+      React.createElement(EditorPanelMarkdownActionsMenu, {
+        isMarkdown: false,
+        isDiffSurface: true,
+        diffWordWrap: false,
+        diffShowWhitespace: true,
+        editorWordWrap: false,
+        shouldShowMarkdownExportAction: false,
+        canExportMarkdownToPdf: false,
+        canShowMarkdownFrontmatterToggle: false,
+        markdownFrontmatterVisible: false,
+        onToggleDiffWordWrap: () => {},
+        onToggleDiffWhitespace,
+        onToggleEditorWordWrap: () => {},
+        onToggleMarkdownFrontmatter: () => {},
+        onExportMarkdownToPdf: () => {}
+      })
+    )
+
+    expect(checkboxItems.list).toHaveLength(2)
+    expect(checkboxItems.list[1]).toMatchObject({
+      checked: true,
+      label: 'Show Whitespace'
+    })
+    checkboxItems.list[1]?.onCheckedChange?.(false)
+    expect(onToggleDiffWhitespace).toHaveBeenCalledOnce()
   })
 })

--- a/src/renderer/src/components/editor/EditorPanelMarkdownActionsMenu.tsx
+++ b/src/renderer/src/components/editor/EditorPanelMarkdownActionsMenu.tsx
@@ -15,6 +15,8 @@ type EditorPanelMarkdownActionsMenuProps = {
   isDiffSurface: boolean
   /** Diff-only wrap preference; ignored for normal file tabs. */
   diffWordWrap: boolean
+  /** Diff-only whitespace preference; ignored for normal file tabs. */
+  diffShowWhitespace: boolean
   /** File editor wrap preference (`settings.editorWordWrap`). */
   editorWordWrap: boolean
   shouldShowMarkdownExportAction: boolean
@@ -22,6 +24,7 @@ type EditorPanelMarkdownActionsMenuProps = {
   canShowMarkdownFrontmatterToggle: boolean
   markdownFrontmatterVisible: boolean
   onToggleDiffWordWrap: () => void
+  onToggleDiffWhitespace: () => void
   onToggleEditorWordWrap: () => void
   onToggleMarkdownFrontmatter: () => void
   onExportMarkdownToPdf: () => void
@@ -31,12 +34,14 @@ export function EditorPanelMarkdownActionsMenu({
   isMarkdown,
   isDiffSurface,
   diffWordWrap,
+  diffShowWhitespace,
   editorWordWrap,
   shouldShowMarkdownExportAction,
   canExportMarkdownToPdf,
   canShowMarkdownFrontmatterToggle,
   markdownFrontmatterVisible,
   onToggleDiffWordWrap,
+  onToggleDiffWhitespace,
   onToggleEditorWordWrap,
   onToggleMarkdownFrontmatter,
   onExportMarkdownToPdf
@@ -72,6 +77,17 @@ export function EditorPanelMarkdownActionsMenu({
             'Word Wrap'
           )}
         </DropdownMenuCheckboxItem>
+        {isDiffSurface ? (
+          <DropdownMenuCheckboxItem
+            checked={diffShowWhitespace}
+            onCheckedChange={onToggleDiffWhitespace}
+          >
+            {translate(
+              'auto.components.editor.EditorPanelMarkdownActionsMenu.4dedd55efa',
+              'Show Whitespace'
+            )}
+          </DropdownMenuCheckboxItem>
+        ) : null}
         {hasMarkdownActions ? <DropdownMenuSeparator /> : null}
         {canShowMarkdownFrontmatterToggle ? (
           <>

--- a/src/renderer/src/components/editor/combined-diff/CombinedDiffViewer.tsx
+++ b/src/renderer/src/components/editor/combined-diff/CombinedDiffViewer.tsx
@@ -89,6 +89,7 @@ export default function CombinedDiffViewer({
   const preferences = useCombinedDiffViewPreferences({
     combinedDiffFileTreeVisibleByDefault: settings?.combinedDiffFileTreeVisibleByDefault,
     diffDefaultView: settings?.diffDefaultView,
+    diffShowWhitespace: settings?.diffShowWhitespace,
     diffWordWrap: settings?.diffWordWrap,
     registry,
     setSections,
@@ -308,6 +309,7 @@ export default function CombinedDiffViewer({
           commitCompare={entrySet.commitCompare}
           diffCommentCount={notes.diffCommentCount}
           diffCommentsForWorktree={diffCommentsForWorktree}
+          diffShowWhitespace={settings?.diffShowWhitespace}
           diffWordWrap={settings?.diffWordWrap}
           file={file}
           fileTreeCollapsed={preferences.fileTreeCollapsed}
@@ -323,6 +325,7 @@ export default function CombinedDiffViewer({
           sectionCount={sections.length}
           setAllSectionsCollapsed={preferences.setAllSectionsCollapsed}
           sideBySide={preferences.sideBySide}
+          toggleDiffShowWhitespace={preferences.toggleDiffShowWhitespace}
           toggleDiffWordWrap={preferences.toggleDiffWordWrap}
           toggleSideBySide={preferences.toggleSideBySide}
         />

--- a/src/renderer/src/components/editor/combined-diff/review-controls/combined-diff-toolbar.tsx
+++ b/src/renderer/src/components/editor/combined-diff/review-controls/combined-diff-toolbar.tsx
@@ -1,5 +1,5 @@
 import type React from 'react'
-import { PanelLeftOpen, Sparkles, WrapText } from 'lucide-react'
+import { PanelLeftOpen, Space, Sparkles, WrapText } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -16,6 +16,7 @@ export function CombinedDiffToolbar({
   commitCompare,
   diffCommentCount,
   diffCommentsForWorktree,
+  diffShowWhitespace,
   diffWordWrap,
   file,
   fileTreeCollapsed,
@@ -31,6 +32,7 @@ export function CombinedDiffToolbar({
   sectionCount,
   setAllSectionsCollapsed,
   sideBySide,
+  toggleDiffShowWhitespace,
   toggleDiffWordWrap,
   toggleSideBySide
 }: {
@@ -40,6 +42,7 @@ export function CombinedDiffToolbar({
   commitCompare: NonNullable<OpenFile['commitCompare']> | null
   diffCommentCount: number
   diffCommentsForWorktree: DiffComment[]
+  diffShowWhitespace: boolean | undefined
   diffWordWrap: boolean | undefined
   file: OpenFile
   fileTreeCollapsed: boolean
@@ -55,6 +58,7 @@ export function CombinedDiffToolbar({
   sectionCount: number
   setAllSectionsCollapsed: (collapsed: boolean) => void
   sideBySide: boolean
+  toggleDiffShowWhitespace: () => void
   toggleDiffWordWrap: () => void
   toggleSideBySide: () => void
 }): React.JSX.Element {
@@ -186,6 +190,18 @@ export function CombinedDiffToolbar({
           {diffWordWrap === true
             ? translate('auto.components.editor.CombinedDiffViewer.a4420ca1f7', 'Wrap On')
             : translate('auto.components.editor.CombinedDiffViewer.dde325ddfe', 'Wrap Off')}
+        </button>
+        <button
+          className={`inline-flex h-6 items-center gap-1 rounded border border-border px-2 text-xs transition-colors hover:text-foreground ${
+            diffShowWhitespace === true ? 'bg-accent text-foreground' : 'text-muted-foreground'
+          }`}
+          onClick={toggleDiffShowWhitespace}
+          aria-pressed={diffShowWhitespace === true}
+        >
+          <Space className="size-3.5" />
+          {diffShowWhitespace === true
+            ? translate('auto.components.editor.CombinedDiffViewer.2e91bc89d1', 'Whitespace On')
+            : translate('auto.components.editor.CombinedDiffViewer.2bf19c54ad', 'Whitespace Off')}
         </button>
       </div>
     </div>

--- a/src/renderer/src/components/editor/combined-diff/review-controls/use-combined-diff-view-preferences.ts
+++ b/src/renderer/src/components/editor/combined-diff/review-controls/use-combined-diff-view-preferences.ts
@@ -11,6 +11,7 @@ export type CombinedDiffViewPreferences = {
   setFileTreeCollapsed: (collapsed: boolean) => void
   setSideBySide: React.Dispatch<React.SetStateAction<boolean>>
   sideBySide: boolean
+  toggleDiffShowWhitespace: () => void
   toggleDiffWordWrap: () => void
   toggleSideBySide: () => void
 }
@@ -18,6 +19,7 @@ export type CombinedDiffViewPreferences = {
 export function useCombinedDiffViewPreferences({
   combinedDiffFileTreeVisibleByDefault,
   diffDefaultView,
+  diffShowWhitespace,
   diffWordWrap,
   registry,
   setSections,
@@ -25,10 +27,11 @@ export function useCombinedDiffViewPreferences({
 }: {
   combinedDiffFileTreeVisibleByDefault: boolean | undefined
   diffDefaultView: string | undefined
+  diffShowWhitespace: boolean | undefined
   diffWordWrap: boolean | undefined
   registry: CombinedDiffSectionLoadRegistry
   setSections: React.Dispatch<React.SetStateAction<DiffSection[]>>
-  updateSettings: (patch: { diffWordWrap: boolean }) => unknown
+  updateSettings: (patch: { diffShowWhitespace?: boolean; diffWordWrap?: boolean }) => unknown
 }): CombinedDiffViewPreferences {
   const { loadSchedulerRef, loadedIndicesRef, sectionsRef } = registry
   const [sideBySide, setSideBySide] = useState(
@@ -89,12 +92,17 @@ export function useCombinedDiffViewPreferences({
     void updateSettings({ diffWordWrap: diffWordWrap !== true })
   }, [diffWordWrap, updateSettings])
 
+  const toggleDiffShowWhitespace = useCallback(() => {
+    void updateSettings({ diffShowWhitespace: diffShowWhitespace !== true })
+  }, [diffShowWhitespace, updateSettings])
+
   return {
     fileTreeCollapsed,
     setAllSectionsCollapsed,
     setFileTreeCollapsed,
     setSideBySide,
     sideBySide,
+    toggleDiffShowWhitespace,
     toggleDiffWordWrap,
     toggleSideBySide
   }

--- a/src/renderer/src/components/editor/diff-editor-whitespace-options.test.ts
+++ b/src/renderer/src/components/editor/diff-editor-whitespace-options.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import { buildDiffEditorWhitespaceOptions } from './diff-editor-whitespace-options'
+
+describe('buildDiffEditorWhitespaceOptions', () => {
+  it('ignores trim whitespace by default', () => {
+    expect(buildDiffEditorWhitespaceOptions(undefined)).toEqual({ ignoreTrimWhitespace: true })
+    expect(buildDiffEditorWhitespaceOptions(false)).toEqual({ ignoreTrimWhitespace: true })
+  })
+
+  it('includes whitespace in the diff when the preference is on', () => {
+    expect(buildDiffEditorWhitespaceOptions(true)).toEqual({ ignoreTrimWhitespace: false })
+  })
+})

--- a/src/renderer/src/components/editor/diff-editor-whitespace-options.ts
+++ b/src/renderer/src/components/editor/diff-editor-whitespace-options.ts
@@ -1,0 +1,10 @@
+import type { editor } from 'monaco-editor'
+
+export function buildDiffEditorWhitespaceOptions(
+  diffShowWhitespace: boolean | undefined
+): Pick<editor.IStandaloneDiffEditorConstructionOptions, 'ignoreTrimWhitespace'> {
+  return {
+    // Why: Monaco defaults this to true, which hides indentation-only diffs.
+    ignoreTrimWhitespace: diffShowWhitespace !== true
+  }
+}

--- a/src/renderer/src/components/editor/diff-section-item-props.ts
+++ b/src/renderer/src/components/editor/diff-section-item-props.ts
@@ -13,6 +13,7 @@ export type DiffSectionItemProps = {
     terminalFontSize?: number
     terminalFontFamily?: string
     diffWordWrap?: boolean
+    diffShowWhitespace?: boolean
   } | null
   sectionHeight: number | undefined
   worktreeId?: string

--- a/src/renderer/src/components/settings/DiffShowWhitespaceSetting.test.tsx
+++ b/src/renderer/src/components/settings/DiffShowWhitespaceSetting.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment happy-dom
+
+import { join } from 'node:path'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getDefaultSettings } from '../../../../shared/constants'
+
+vi.mock('../../store', () => ({
+  useAppStore: (selector: (state: { settingsSearchQuery: string }) => unknown) =>
+    selector({ settingsSearchQuery: '' })
+}))
+
+import { DiffShowWhitespaceSetting } from './DiffShowWhitespaceSetting'
+
+let root: Root | null = null
+let container: HTMLDivElement | null = null
+
+afterEach(() => {
+  if (root) {
+    act(() => root?.unmount())
+  }
+  container?.remove()
+  root = null
+  container = null
+})
+
+function renderSetting(diffShowWhitespace: boolean, updateSettings = vi.fn()) {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  act(() => {
+    root?.render(
+      <DiffShowWhitespaceSetting
+        settings={{ ...getDefaultSettings(join('test', 'home')), diffShowWhitespace }}
+        updateSettings={updateSettings}
+      />
+    )
+  })
+  return { container, updateSettings }
+}
+
+describe('DiffShowWhitespaceSetting', () => {
+  it('defaults to off so whitespace-only diffs stay quiet', () => {
+    const { container } = renderSetting(false)
+    const off = [...container.querySelectorAll('[role="radio"]')].find(
+      (button) => button.textContent === 'Off'
+    )
+
+    expect(off?.getAttribute('aria-checked')).toBe('true')
+  })
+
+  it('shows on when the preference is enabled', () => {
+    const { container } = renderSetting(true)
+    const on = [...container.querySelectorAll('[role="radio"]')].find(
+      (button) => button.textContent === 'On'
+    )
+
+    expect(on?.getAttribute('aria-checked')).toBe('true')
+  })
+
+  it('persists the on choice', () => {
+    const updateSettings = vi.fn()
+    const { container } = renderSetting(false, updateSettings)
+    const on = [...container.querySelectorAll<HTMLButtonElement>('[role="radio"]')].find(
+      (button) => button.textContent === 'On'
+    )
+
+    act(() => on?.click())
+
+    expect(updateSettings).toHaveBeenCalledWith({ diffShowWhitespace: true })
+  })
+})

--- a/src/renderer/src/components/settings/DiffShowWhitespaceSetting.tsx
+++ b/src/renderer/src/components/settings/DiffShowWhitespaceSetting.tsx
@@ -1,0 +1,69 @@
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import { translate } from '@/i18n/i18n'
+import { SearchableSetting } from './SearchableSetting'
+import { Label } from '../ui/label'
+import { SettingsSegmentedControl } from './SettingsFormControls'
+
+type DiffShowWhitespaceSettingProps = {
+  settings: GlobalSettings
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+}
+
+export function DiffShowWhitespaceSetting({
+  settings,
+  updateSettings
+}: DiffShowWhitespaceSettingProps): React.JSX.Element {
+  return (
+    <SearchableSetting
+      title={translate(
+        'auto.components.settings.GeneralEditorSettingsSection.f1b3ceeb98',
+        'Diff Show Whitespace'
+      )}
+      description={translate(
+        'auto.components.settings.GeneralEditorSettingsSection.94a479cef3',
+        'Show leading and trailing whitespace differences in diffs.'
+      )}
+      keywords={['diff', 'whitespace', 'spaces', 'tabs', 'trim', 'indentation']}
+      className="flex items-center justify-between gap-4 py-2"
+    >
+      <div className="min-w-0 flex-1 space-y-0.5">
+        <Label>
+          {translate(
+            'auto.components.settings.GeneralEditorSettingsSection.f1b3ceeb98',
+            'Diff Show Whitespace'
+          )}
+        </Label>
+        <p className="text-xs text-muted-foreground">
+          {translate(
+            'auto.components.settings.GeneralEditorSettingsSection.94a479cef3',
+            'Show leading and trailing whitespace differences in diffs.'
+          )}
+        </p>
+      </div>
+      <SettingsSegmentedControl
+        ariaLabel={translate(
+          'auto.components.settings.GeneralEditorSettingsSection.f1b3ceeb98',
+          'Diff Show Whitespace'
+        )}
+        value={settings.diffShowWhitespace ? 'on' : 'off'}
+        onChange={(option) => updateSettings({ diffShowWhitespace: option === 'on' })}
+        options={[
+          {
+            value: 'off',
+            label: translate(
+              'auto.components.settings.GeneralEditorSettingsSection.bf16ef0af2',
+              'Off'
+            )
+          },
+          {
+            value: 'on',
+            label: translate(
+              'auto.components.settings.GeneralEditorSettingsSection.3f6892f307',
+              'On'
+            )
+          }
+        ]}
+      />
+    </SearchableSetting>
+  )
+}

--- a/src/renderer/src/components/settings/GeneralEditorSettingsSection.tsx
+++ b/src/renderer/src/components/settings/GeneralEditorSettingsSection.tsx
@@ -17,6 +17,7 @@ import {
 } from './SettingsFormControls'
 import { translate } from '@/i18n/i18n'
 import { RichMarkdownSpellcheckSetting } from './RichMarkdownSpellcheckSetting'
+import { DiffShowWhitespaceSetting } from './DiffShowWhitespaceSetting'
 import { EditorWordWrapSetting } from './EditorWordWrapSetting'
 import { EditorFontFamilySetting } from './EditorFontFamilySetting'
 import {
@@ -231,6 +232,8 @@ export function GeneralEditorSettingsSection({
       />
 
       <EditorWordWrapSetting settings={settings} updateSettings={updateSettings} />
+
+      <DiffShowWhitespaceSetting settings={settings} updateSettings={updateSettings} />
 
       <SearchableSetting
         title={translate(

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -14390,7 +14390,8 @@
           "561251019a": "More actions",
           "8c8b7f5ff5": "Show front matter",
           "10c39d58c1": "Hide front matter",
-          "1eef809708": "Word Wrap"
+          "1eef809708": "Word Wrap",
+          "4dedd55efa": "Show Whitespace"
         },
         "EditorPanelShell": {
           "e2c4dec350": "Loading editor..."

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -7002,6 +7002,8 @@
           "45c6e85c4d": "Editor",
           "8f1afdfbd8": "Diff Word Wrap",
           "4aa4d9fb73": "Wrap long lines in diff editors instead of requiring horizontal scrolling.",
+          "f1b3ceeb98": "Diff Show Whitespace",
+          "94a479cef3": "Show leading and trailing whitespace differences in diffs.",
           "bf16ef0af2": "Off",
           "3f6892f307": "On",
           "b82f86d7d2": "Rich Markdown Spellcheck",
@@ -14299,7 +14301,9 @@
           "724a13568d": " in {{value0}}",
           "6094135eec": " vs {{value0}}",
           "a4420ca1f7": "Wrap On",
-          "dde325ddfe": "Wrap Off"
+          "dde325ddfe": "Wrap Off",
+          "2e91bc89d1": "Whitespace On",
+          "2bf19c54ad": "Whitespace Off"
         },
         "ConflictComponents": {
           "f338288514": "Loading conflict contents...",

--- a/src/shared/default-global-settings.ts
+++ b/src/shared/default-global-settings.ts
@@ -157,6 +157,7 @@ export function buildDefaultSettings(args: {
     notifications: args.notifications,
     diffDefaultView: 'inline',
     diffWordWrap: false,
+    diffShowWhitespace: false,
     combinedDiffFileTreeVisibleByDefault: false,
     prBotAuthorOverrides: [],
     promptCacheTimerEnabled: false,

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -272,6 +272,7 @@ export type GlobalSettings = {
   keybindings?: KeybindingOverrides
   diffDefaultView: 'inline' | 'side-by-side'
   diffWordWrap: boolean
+  diffShowWhitespace: boolean
   combinedDiffFileTreeVisibleByDefault: boolean
   /** Bot-marked comment-author logins (stored lowercased); escape hatch for review bots on regular accounts that defeat provider metadata/heuristics. */
   prBotAuthorOverrides: string[]


### PR DESCRIPTION
## ELI5

When reviewing diffs that only contain indentation or whitespace changes, Orca previously hid those differences by default with no way to reveal them or jump between changed lines. This PR adds a **"Show Whitespace"** toggle in the diff viewer's action menu so you can easily see and review whitespace and formatting changes whenever needed.

## What Changed

1. **Global Settings**:
   - Added `diffShowWhitespace: boolean` to `GlobalSettings` (`src/shared/global-settings-types.ts`) and initialized default to `false` in `src/shared/constants.ts`.
   - Updated test fixture helpers (`runtime-home-settings-test-fixtures.ts`, `service-test-harness.ts`).

2. **Diff Viewer Integration**:
   - Configured Monaco Diff Editor options in `src/renderer/src/components/editor/DiffViewer.tsx` to set `ignoreTrimWhitespace: !settings?.diffShowWhitespace`.

3. **Editor Actions Menu & Header**:
   - Added `diffShowWhitespace` state and `onToggleDiffWhitespace` handler in `src/renderer/src/components/editor/EditorPanelHeader.tsx`.
   - Added a "Show Whitespace" checkbox item to `src/renderer/src/components/editor/EditorPanelMarkdownActionsMenu.tsx` for diff surfaces (`isDiffSurface`).
   - Added translation key `auto.components.editor.EditorPanelMarkdownActionsMenu.4dedd55efa` in `src/renderer/src/i18n/locales/en.json`.

4. **Unit Tests**:
   - Added unit test in `EditorPanelMarkdownActionsMenu.test.tsx` verifying that "Show Whitespace" renders on diff surfaces and triggers the toggle handler.

## Why

Developers frequently perform formatting, indentation fixes, and trailing whitespace cleanups. When diffing such files, Monaco's default `ignoreTrimWhitespace: true` made the diff look completely identical while marking the file as modified and disabling change jump points.

Providing an explicit toggle aligns Orca with industry-standard IDE behavior (VS Code / JetBrains / GitHub) and ensures complete visibility and navigation control during code reviews.

## Linked Issue

Fixes #15118

## Visual Proof

| Area | Default State (`Show Whitespace: OFF`) | Toggled State (`Show Whitespace: ON`) |
|---|---|---|
| **Diff Action Menu** | `[ ] Show Whitespace` unchecked | `[x] Show Whitespace` checked |
| **Monaco Diff Engine** | `ignoreTrimWhitespace: true` (whitespace diffs suppressed) | `ignoreTrimWhitespace: false` (whitespace diffs highlighted & navigable) |
| **Whitespace-only Diffs** | Appears unchanged; navigation disabled | Spaces/tabs highlighted; change navigation enabled |


<img width="1428" height="597" alt="image" src="https://github.com/user-attachments/assets/b8b3994b-5b9a-405e-9c68-cb606f92a693" />


## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Developed and reviewed with Gemini 3.7 Flash via Antigravity pair-programming agent.


## Review


- **Cross-platform**: Standard React UI and Monaco Diff Editor configuration change. Compatible across macOS, Linux, and Windows.
- **SSH / Remote / Local**: Pure renderer setting and editor option. Works identically in local, SSH remote, and containerized workspaces.
- **Performance**: Zero performance penalty when inactive; Monaco handles diff computation natively.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Security**: No security risk. Reads and updates existing internal settings schema without external process execution.
- **Default Behavior**: Defaults to `false` (`diffShowWhitespace: false`) to preserve existing low-noise diff viewing for the majority of standard code reviews.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- Github: @hwantage 
