### PR TITLE
fix(shell): open Runtime worktrees in external editors

### DIFF
--- a/src/main/external-editor-launch.test.ts
+++ b/src/main/external-editor-launch.test.ts
@@ -10,9 +10,12 @@ vi.mock('./codex-cli/command', () => ({
 
 import { getCmdExePath } from './win32-utils'
 import {
+  resolveCursorRemoteSshLaunchSpec,
   resolveExternalEditorLaunchSpec,
   resolveVsCodeRemoteSshLaunchSpec
 } from './external-editor-launch'
+import { resolveZedRemoteSshLaunchSpec } from './zed-remote-ssh-launch'
+import { isZedRemoteSshCommand } from '../shared/zed-remote-ssh-launcher'
 
 describe('resolveExternalEditorLaunchSpec', () => {
   beforeEach(() => {
@@ -494,6 +497,147 @@ describe('resolveVsCodeRemoteSshLaunchSpec', () => {
     (command) => {
       expect(
         resolveVsCodeRemoteSshLaunchSpec(command, '/srv/project', 'builder', {
+          platform: 'linux'
+        })
+      ).toBeNull()
+    }
+  )
+})
+
+describe('resolveCursorRemoteSshLaunchSpec', () => {
+  beforeEach(() => {
+    resolveCliCommandMock.mockReset()
+    resolveCliCommandMock.mockImplementation((command: string) => command)
+  })
+
+  it('builds exact Remote-SSH arguments for Cursor', () => {
+    expect(
+      resolveCursorRemoteSshLaunchSpec('cursor', '/home/Ada Lovelace/project', 'builder', {
+        platform: 'linux'
+      })
+    ).toEqual({
+      kind: 'executable',
+      hideWindowsConsole: true,
+      spawnCmd: 'cursor',
+      spawnArgs: ['--remote', 'ssh-remote+builder', '/home/Ada Lovelace/project']
+    })
+  })
+
+  it('supports a direct Windows Cursor launcher', () => {
+    const command = 'C:\\Program Files\\Cursor\\Cursor.exe'
+    expect(
+      resolveCursorRemoteSshLaunchSpec(command, '/srv/project', 'builder', {
+        platform: 'win32'
+      })
+    ).toMatchObject({
+      spawnCmd: command,
+      spawnArgs: ['--remote', 'ssh-remote+builder', '/srv/project']
+    })
+  })
+
+  it('recognizes a simple CLI name resolved to a Windows shim', () => {
+    resolveCliCommandMock.mockReturnValueOnce('C:\\Tools\\cursor.cmd')
+    expect(
+      resolveCursorRemoteSshLaunchSpec('cursor', '/srv/project', 'builder', {
+        platform: 'win32'
+      })
+    ).toMatchObject({ spawnCmd: 'C:\\Tools\\cursor.cmd' })
+  })
+
+  it.each(['code', 'zed', 'cursor.bat', 'tools/cursor', 'cursor --new-window', 'open -a "Cursor"'])(
+    'rejects unsupported and compound SSH commands: %s',
+    (command) => {
+      expect(
+        resolveCursorRemoteSshLaunchSpec(command, '/srv/project', 'builder', {
+          platform: 'linux'
+        })
+      ).toBeNull()
+    }
+  )
+})
+
+describe('resolveZedRemoteSshLaunchSpec', () => {
+  beforeEach(() => {
+    resolveCliCommandMock.mockReset()
+    resolveCliCommandMock.mockImplementation((command: string) => command)
+  })
+
+  it('builds an encoded SSH URI for POSIX runtime paths', () => {
+    expect(
+      resolveZedRemoteSshLaunchSpec('zed', '/srv/Ada Project/\u6587\u6863', 'builder', {
+        platform: 'linux'
+      })
+    ).toEqual({
+      kind: 'executable',
+      hideWindowsConsole: true,
+      spawnCmd: 'zed',
+      spawnArgs: ['--new', 'ssh://builder/srv/Ada%20Project/%E6%96%87%E6%A1%A3']
+    })
+  })
+
+  it('supports a direct Windows Zed launcher', () => {
+    const command = 'C:\\Users\\Ada\\Zed\\bin\\zed.exe'
+    expect(
+      resolveZedRemoteSshLaunchSpec(command, '/srv/project', 'builder', {
+        platform: 'win32'
+      })
+    ).toMatchObject({
+      spawnCmd: command,
+      spawnArgs: ['--new', 'ssh://builder/srv/project']
+    })
+  })
+
+  it('supports a quoted Windows Zed launcher with arguments', () => {
+    const command = '"C:\\Program Files\\Zed\\zed.exe" --remote'
+    expect(isZedRemoteSshCommand(command)).toBe(true)
+    expect(
+      resolveZedRemoteSshLaunchSpec(command, '/srv/project', 'builder', {
+        platform: 'win32'
+      })
+    ).toMatchObject({
+      spawnCmd: 'C:\\Program Files\\Zed\\zed.exe',
+      spawnArgs: ['--new', 'ssh://builder/srv/project']
+    })
+  })
+
+  it('supports a quoted Unix Zed launcher with arguments', () => {
+    const command = '"/opt/Zed/zed" --remote'
+    expect(isZedRemoteSshCommand(command)).toBe(true)
+    expect(
+      resolveZedRemoteSshLaunchSpec(command, '/srv/project', 'builder', {
+        platform: 'linux',
+        fileExists: (candidate) => candidate === '/opt/Zed/zed'
+      })
+    ).toMatchObject({
+      spawnCmd: '/opt/Zed/zed',
+      spawnArgs: ['--new', 'ssh://builder/srv/project']
+    })
+  })
+
+  it('brackets an IPv6 SSH host without encoding the username separator', () => {
+    expect(
+      resolveZedRemoteSshLaunchSpec('zed', '/srv/project', 'ada@2001:db8::1', {
+        platform: 'linux'
+      })?.spawnArgs
+    ).toEqual(['--new', 'ssh://ada@[2001:db8::1]/srv/project'])
+  })
+
+  it.each(['ada@host@other', 'builder%host'])(
+    'rejects ambiguous or malformed SSH URI authorities: %s',
+    (authority) => {
+      expect(
+        resolveZedRemoteSshLaunchSpec('zed', '/srv/project', authority, {
+          platform: 'linux'
+        })
+      ).toBeNull()
+    }
+  )
+
+  it.each(['cursor', 'code', 'zed --new'])(
+    'rejects unsupported and compound SSH commands: %s',
+    (command) => {
+      expect(
+        resolveZedRemoteSshLaunchSpec(command, '/srv/project', 'builder', {
           platform: 'linux'
         })
       ).toBeNull()

--- a/src/main/external-editor-launch.ts
+++ b/src/main/external-editor-launch.ts
@@ -1,6 +1,10 @@
 import { spawn } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { posix, win32 } from 'node:path'
+import {
+  isCursorLauncherExecutable,
+  isCursorRemoteSshCommand
+} from '../shared/cursor-remote-ssh-launcher'
 import { parseWslUncPath } from '../shared/wsl-paths'
 import { isVsCodeLauncherExecutable } from '../shared/vscode-remote-ssh-launcher'
 import { resolveCliCommand } from './codex-cli/command'
@@ -63,7 +67,7 @@ function isWindowsExecutablePath(command: string): boolean {
   return win32.isAbsolute(command) && /\.(?:cmd|exe|bat|com)$/i.test(command)
 }
 
-function isDirectExecutablePath(
+export function isDirectExecutablePath(
   command: string,
   platform: NodeJS.Platform,
   fileExists: (path: string) => boolean
@@ -114,7 +118,7 @@ function buildExecutableArgs(
   return [pathValue]
 }
 
-function isCompoundShellCommand(command: string): boolean {
+export function isCompoundShellCommand(command: string): boolean {
   return /\s/.test(command)
 }
 
@@ -215,10 +219,11 @@ export function resolveExternalEditorLaunchSpec(
   )
 }
 
-export function resolveVsCodeRemoteSshLaunchSpec(
+function resolveRemoteSshLaunchSpec(
   command: string | undefined,
   pathValue: string,
   authority: string,
+  isSupportedLauncher: (command: string) => boolean,
   options: { platform?: NodeJS.Platform; fileExists?: (path: string) => boolean } = {}
 ): ExternalEditorLaunchSpec | null {
   const platform = options.platform ?? process.platform
@@ -235,7 +240,7 @@ export function resolveVsCodeRemoteSshLaunchSpec(
     editorCommand = resolveCliCommand(trimmed, { platform })
   }
 
-  if (!isVsCodeLauncherExecutable(editorCommand)) {
+  if (!isSupportedLauncher(editorCommand)) {
     return null
   }
   return {
@@ -244,6 +249,39 @@ export function resolveVsCodeRemoteSshLaunchSpec(
     spawnCmd: editorCommand,
     spawnArgs: ['--remote', `ssh-remote+${authority}`, pathValue]
   }
+}
+
+export function resolveVsCodeRemoteSshLaunchSpec(
+  command: string | undefined,
+  pathValue: string,
+  authority: string,
+  options: { platform?: NodeJS.Platform; fileExists?: (path: string) => boolean } = {}
+): ExternalEditorLaunchSpec | null {
+  return resolveRemoteSshLaunchSpec(
+    command,
+    pathValue,
+    authority,
+    isVsCodeLauncherExecutable,
+    options
+  )
+}
+
+export function resolveCursorRemoteSshLaunchSpec(
+  command: string | undefined,
+  pathValue: string,
+  authority: string,
+  options: { platform?: NodeJS.Platform; fileExists?: (path: string) => boolean } = {}
+): ExternalEditorLaunchSpec | null {
+  if (!isCursorRemoteSshCommand(command)) {
+    return null
+  }
+  return resolveRemoteSshLaunchSpec(
+    command,
+    pathValue,
+    authority,
+    isCursorLauncherExecutable,
+    options
+  )
 }
 
 function resolveExternalEditorSpawn(launchSpec: ExternalEditorLaunchSpec): {

--- a/src/main/ipc/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers.test.ts
@@ -555,7 +555,16 @@ describe('registerCoreHandlers', () => {
     expect(registerNativeChatHandlersMock).toHaveBeenCalled()
     expect(registerCliHandlersMock).toHaveBeenCalled()
     expect(registerPreflightHandlersMock).toHaveBeenCalled()
-    expect(registerShellHandlersMock).toHaveBeenCalledWith(store)
+    const runtimeEnvironment = { id: 'env-123' } as never
+    listEnvironmentsMock.mockReturnValue([runtimeEnvironment])
+    expect(registerShellHandlersMock).toHaveBeenCalledWith(store, {
+      resolveRuntimeEnvironment: expect.any(Function)
+    })
+    const shellOptions = registerShellHandlersMock.mock.calls[0]?.[1] as {
+      resolveRuntimeEnvironment: (environmentId: string) => unknown
+    }
+    expect(shellOptions.resolveRuntimeEnvironment('env-123')).toBe(runtimeEnvironment)
+    expect(listEnvironmentsMock).toHaveBeenCalledWith('/test/user-data')
     expect(registerClipboardHandlersMock).toHaveBeenCalledWith(store)
     expect(registerUpdaterHandlersMock).toHaveBeenCalled()
     expect(setTrustedBrowserRendererWebContentsIdMock).toHaveBeenCalledWith(null)

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -23,6 +23,7 @@ import { registerMemoryHandlers } from './memory'
 import { registerRateLimitHandlers } from './rate-limits'
 import { registerRuntimeHandlers } from './runtime'
 import { registerRuntimeEnvironmentHandlers } from './runtime-environments'
+import { listEnvironments } from '../../shared/runtime-environment-store'
 import { registerEphemeralVmHandlers } from './ephemeral-vm'
 import { registerAiVaultHandlers } from './ai-vault'
 import { registerNativeChatHandlers } from './native-chat'
@@ -194,7 +195,12 @@ export function registerCoreHandlers(
     onBeforeSignOut: lifecycleOptions.onBeforeOrcaProfileSignOut
   })
   registerBrowserHandlers()
-  registerShellHandlers(store)
+  registerShellHandlers(store, {
+    resolveRuntimeEnvironment: (environmentId) =>
+      listEnvironments(app.getPath('userData')).find(
+        (environment) => environment.id === environmentId
+      )
+  })
   registerPetHandlers()
   registerSessionHandlers(store)
   registerUIHandlers(store, { isDashboardPopoutRenderer })

--- a/src/main/ipc/runtime-external-editor.ts
+++ b/src/main/ipc/runtime-external-editor.ts
@@ -1,0 +1,68 @@
+import { posix, win32 } from 'node:path'
+import { isCursorRemoteSshCommand } from '../../shared/cursor-remote-ssh-launcher'
+import { parseExecutionHostId } from '../../shared/execution-host'
+import type {
+  ShellOpenExternalEditorRequest,
+  ShellOpenExternalEditorResult
+} from '../../shared/shell-open-types'
+import type { KnownRuntimeEnvironment } from '../../shared/runtime-environments'
+import { isZedRemoteSshCommand } from '../../shared/zed-remote-ssh-launcher'
+import type { Store } from '../persistence'
+import {
+  launchExternalEditor,
+  resolveCursorRemoteSshLaunchSpec,
+  resolveVsCodeRemoteSshLaunchSpec
+} from '../external-editor-launch'
+import { resolveZedRemoteSshLaunchSpec } from '../zed-remote-ssh-launch'
+import { resolveRuntimeEnvironmentEditorSshTarget } from '../runtime-environment-editor-ssh-target'
+import { resolveVsCodeSshAuthority } from '../ssh/vscode-ssh-authority'
+
+export type RuntimeExternalEditorDependencies = {
+  resolveRuntimeEnvironment?: (environmentId: string) => KnownRuntimeEnvironment | undefined
+}
+
+export async function openRuntimePathInExternalEditor(
+  store: Store,
+  request: ShellOpenExternalEditorRequest,
+  dependencies: RuntimeExternalEditorDependencies
+): Promise<ShellOpenExternalEditorResult> {
+  const executionHost = parseExecutionHostId(request.executionHostId)
+  if (executionHost?.kind !== 'runtime' || request.connectionId?.trim()) {
+    return { ok: false, reason: 'remote-runtime-unsupported' }
+  }
+  if (!posix.isAbsolute(request.path) && !win32.isAbsolute(request.path)) {
+    return { ok: false, reason: 'not-absolute' }
+  }
+
+  let environment: KnownRuntimeEnvironment | undefined
+  try {
+    environment = dependencies.resolveRuntimeEnvironment?.(executionHost.environmentId)
+  } catch {
+    environment = undefined
+  }
+  if (!environment) {
+    return { ok: false, reason: 'runtime-ssh-target-required' }
+  }
+  const target = resolveRuntimeEnvironmentEditorSshTarget(environment, store.getSshTargets())
+  if (!target.ok) {
+    return target
+  }
+  const authority = resolveVsCodeSshAuthority(target.target)
+  if (!authority.ok) {
+    return authority
+  }
+  const launchSpec = isZedRemoteSshCommand(request.command)
+    ? resolveZedRemoteSshLaunchSpec(request.command, request.path, authority.authority)
+    : isCursorRemoteSshCommand(request.command)
+      ? resolveCursorRemoteSshLaunchSpec(request.command, request.path, authority.authority)
+      : resolveVsCodeRemoteSshLaunchSpec(request.command, request.path, authority.authority)
+  if (!launchSpec) {
+    return { ok: false, reason: 'remote-editor-unsupported' }
+  }
+  try {
+    await launchExternalEditor(launchSpec)
+    return { ok: true }
+  } catch {
+    return { ok: false, reason: 'launch-failed' }
+  }
+}

--- a/src/main/ipc/shell-runtime-external-editor.test.ts
+++ b/src/main/ipc/shell-runtime-external-editor.test.ts
@@ -1,0 +1,284 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { normalize, resolve } from 'node:path'
+import type { KnownRuntimeEnvironment } from '../../shared/runtime-environments'
+import type { SshTarget } from '../../shared/ssh-types'
+
+const { getSpawnArgsForWindowsMock, handleMock, resolveCliCommandMock, spawnMock, statMock } =
+  vi.hoisted(() => ({
+    getSpawnArgsForWindowsMock: vi.fn(),
+    handleMock: vi.fn(),
+    resolveCliCommandMock: vi.fn(),
+    spawnMock: vi.fn(),
+    statMock: vi.fn()
+  }))
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: handleMock },
+  shell: {
+    showItemInFolder: vi.fn(),
+    openExternal: vi.fn(),
+    openPath: vi.fn()
+  },
+  dialog: { showOpenDialog: vi.fn() }
+}))
+
+vi.mock('node:fs/promises', () => ({
+  constants: { COPYFILE_EXCL: 1 },
+  copyFile: vi.fn(),
+  stat: statMock
+}))
+
+vi.mock('node:child_process', () => ({ spawn: spawnMock }))
+
+vi.mock('../codex-cli/command', () => ({
+  resolveCliCommand: resolveCliCommandMock
+}))
+
+vi.mock('../win32-utils', () => ({
+  getCmdExePath: () => 'C:\\Windows\\System32\\cmd.exe',
+  getSpawnArgsForWindows: getSpawnArgsForWindowsMock
+}))
+
+import { registerShellHandlers } from './shell'
+
+function spawnedProcess(): {
+  once: ReturnType<typeof vi.fn>
+  off: ReturnType<typeof vi.fn>
+  unref: ReturnType<typeof vi.fn>
+} {
+  const child = {
+    once: vi.fn((eventName: string, callback: () => void) => {
+      if (eventName === 'spawn') {
+        queueMicrotask(callback)
+      }
+      return child
+    }),
+    off: vi.fn(() => child),
+    unref: vi.fn()
+  }
+  return child
+}
+
+function sshTarget(overrides: Partial<SshTarget> = {}): SshTarget {
+  return {
+    id: 'ssh-1',
+    label: 'Builder',
+    host: 'builder.example.com',
+    port: 22,
+    username: 'ada',
+    source: 'ssh-config',
+    configHost: 'builder',
+    ...overrides
+  }
+}
+
+function runtimeEnvironment(
+  overrides: Partial<KnownRuntimeEnvironment> = {}
+): KnownRuntimeEnvironment {
+  return {
+    id: 'runtime-1',
+    name: 'Runtime builder',
+    createdAt: 1,
+    updatedAt: 1,
+    lastUsedAt: null,
+    runtimeId: 'server-runtime-1',
+    endpoints: [
+      {
+        id: 'ws-runtime-1',
+        kind: 'websocket',
+        label: 'WebSocket',
+        endpoint: 'wss://builder.example.com:6768',
+        deviceToken: 'token',
+        publicKeyB64: 'public-key'
+      }
+    ],
+    preferredEndpointId: 'ws-runtime-1',
+    ...overrides
+  }
+}
+
+describe('runtime external editor shell routing', () => {
+  const settings = { activeRuntimeEnvironmentId: null as string | null }
+  const sshTargets = new Map<string, SshTarget>()
+  const runtimeEnvironments = new Map<string, KnownRuntimeEnvironment>()
+  const store = {
+    getSettings: () => settings,
+    getSshTarget: (id: string) => sshTargets.get(id),
+    getSshTargets: () => [...sshTargets.values()]
+  }
+
+  beforeEach(() => {
+    handleMock.mockReset()
+    getSpawnArgsForWindowsMock.mockReset()
+    resolveCliCommandMock.mockReset()
+    resolveCliCommandMock.mockImplementation((command: string) => command)
+    spawnMock.mockReset()
+    statMock.mockReset()
+    settings.activeRuntimeEnvironmentId = null
+    sshTargets.clear()
+    runtimeEnvironments.clear()
+    getSpawnArgsForWindowsMock.mockImplementation((command: string, args: string[]) => ({
+      spawnCmd: command,
+      spawnArgs: args
+    }))
+    spawnMock.mockReturnValue(spawnedProcess())
+    statMock.mockResolvedValue({ isDirectory: () => true })
+  })
+
+  function handler(): (event: unknown, request: unknown) => Promise<unknown> {
+    registerShellHandlers(store as never, {
+      resolveRuntimeEnvironment: (environmentId) => runtimeEnvironments.get(environmentId)
+    })
+    const call = handleMock.mock.calls.find((entry: unknown[]) => {
+      return entry[0] === 'shell:openInExternalEditor'
+    })
+    if (!call) {
+      throw new Error('shell:openInExternalEditor handler not registered')
+    }
+    return call[1] as (event: unknown, request: unknown) => Promise<unknown>
+  }
+
+  it('opens a Runtime path in VS Code through the matching local SSH target', async () => {
+    runtimeEnvironments.set('runtime-1', runtimeEnvironment())
+    sshTargets.set('ssh-1', sshTarget())
+    resolveCliCommandMock.mockReturnValueOnce('C:\\Tools\\code.cmd')
+    const remotePath = '/srv/Ada Project'
+
+    await expect(
+      handler()({}, { path: remotePath, command: 'code', executionHostId: 'runtime:runtime-1' })
+    ).resolves.toEqual({ ok: true })
+    expect(statMock).not.toHaveBeenCalled()
+    expect(getSpawnArgsForWindowsMock).toHaveBeenCalledWith(
+      'C:\\Tools\\code.cmd',
+      ['--remote', 'ssh-remote+builder', remotePath],
+      { detachedGui: false }
+    )
+  })
+
+  it('opens a Runtime path in Cursor through the matching local SSH target', async () => {
+    runtimeEnvironments.set('runtime-1', runtimeEnvironment())
+    sshTargets.set('ssh-1', sshTarget())
+    resolveCliCommandMock.mockReturnValueOnce('C:\\Tools\\cursor.cmd')
+    const remotePath = '/srv/Ada Project'
+
+    await expect(
+      handler()({}, { path: remotePath, command: 'cursor', executionHostId: 'runtime:runtime-1' })
+    ).resolves.toEqual({ ok: true })
+    expect(statMock).not.toHaveBeenCalled()
+    expect(getSpawnArgsForWindowsMock).toHaveBeenCalledWith(
+      'C:\\Tools\\cursor.cmd',
+      ['--remote', 'ssh-remote+builder', remotePath],
+      { detachedGui: false }
+    )
+  })
+
+  it('opens a Runtime path in Zed with an encoded SSH URI', async () => {
+    runtimeEnvironments.set('runtime-1', runtimeEnvironment())
+    sshTargets.set('ssh-1', sshTarget())
+    resolveCliCommandMock.mockReturnValueOnce('C:\\Tools\\zed.exe')
+
+    await expect(
+      handler()(
+        {},
+        {
+          path: '/srv/Ada Project/\u6587\u6863',
+          command: 'zed',
+          executionHostId: 'runtime:runtime-1'
+        }
+      )
+    ).resolves.toEqual({ ok: true })
+    expect(statMock).not.toHaveBeenCalled()
+    expect(getSpawnArgsForWindowsMock).toHaveBeenCalledWith(
+      'C:\\Tools\\zed.exe',
+      ['--new', 'ssh://builder/srv/Ada%20Project/%E6%96%87%E6%A1%A3'],
+      { detachedGui: false }
+    )
+  })
+
+  it('fails closed when no local SSH target matches the Runtime endpoint', async () => {
+    runtimeEnvironments.set('runtime-1', runtimeEnvironment())
+
+    await expect(
+      handler()({}, { path: '/srv/project', command: 'code', executionHostId: 'runtime:runtime-1' })
+    ).resolves.toEqual({ ok: false, reason: 'runtime-ssh-target-required' })
+    expect(statMock).not.toHaveBeenCalled()
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects nested SSH context on a Runtime-owned request', async () => {
+    runtimeEnvironments.set('runtime-1', runtimeEnvironment())
+    sshTargets.set('ssh-1', sshTarget())
+
+    await expect(
+      handler()(
+        {},
+        {
+          path: '/srv/project',
+          command: 'code',
+          connectionId: 'ssh-1',
+          executionHostId: 'runtime:runtime-1'
+        }
+      )
+    ).resolves.toEqual({ ok: false, reason: 'remote-runtime-unsupported' })
+    expect(statMock).not.toHaveBeenCalled()
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects relative Runtime paths without local filesystem access', async () => {
+    runtimeEnvironments.set('runtime-1', runtimeEnvironment())
+    sshTargets.set('ssh-1', sshTarget())
+
+    await expect(
+      handler()(
+        {},
+        { path: 'relative/project', command: 'code', executionHostId: 'runtime:runtime-1' }
+      )
+    ).resolves.toEqual({ ok: false, reason: 'not-absolute' })
+    expect(statMock).not.toHaveBeenCalled()
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
+  it('honors explicit Runtime ownership while another Runtime is active', async () => {
+    settings.activeRuntimeEnvironmentId = 'runtime-2'
+    runtimeEnvironments.set('runtime-1', runtimeEnvironment())
+    sshTargets.set('ssh-1', sshTarget())
+    resolveCliCommandMock.mockReturnValueOnce('C:\\Tools\\code.cmd')
+
+    await expect(
+      handler()({}, { path: '/srv/project', command: 'code', executionHostId: 'runtime:runtime-1' })
+    ).resolves.toEqual({ ok: true })
+    expect(statMock).not.toHaveBeenCalled()
+    expect(spawnMock).toHaveBeenCalled()
+  })
+
+  it('honors explicit SSH ownership while a Runtime is active', async () => {
+    settings.activeRuntimeEnvironmentId = 'runtime-1'
+    sshTargets.set('ssh-1', sshTarget())
+    resolveCliCommandMock.mockReturnValueOnce('C:\\Tools\\code.cmd')
+
+    await expect(
+      handler()(
+        {},
+        {
+          path: '/home/project',
+          command: 'code',
+          connectionId: 'ssh-1',
+          executionHostId: 'ssh:ssh-1'
+        }
+      )
+    ).resolves.toEqual({ ok: true })
+    expect(statMock).not.toHaveBeenCalled()
+    expect(spawnMock).toHaveBeenCalled()
+  })
+
+  it('honors explicit local ownership while another Runtime is active', async () => {
+    settings.activeRuntimeEnvironmentId = 'runtime-1'
+    const workspacePath = resolve('workspace')
+
+    await expect(
+      handler()({}, { path: workspacePath, command: 'code', executionHostId: 'local' })
+    ).resolves.toEqual({ ok: true })
+    expect(statMock).toHaveBeenCalledWith(normalize(workspacePath))
+    expect(spawnMock).toHaveBeenCalled()
+  })
+})

--- a/src/main/ipc/shell.test.ts
+++ b/src/main/ipc/shell.test.ts
@@ -248,6 +248,27 @@ describe('registerShellHandlers', () => {
       expect(showItemInFolderMock).toHaveBeenCalledWith(normalize(workspacePath))
     })
 
+    it('honors explicit local ownership while a Runtime is active', async () => {
+      settings.activeRuntimeEnvironmentId = 'runtime-1'
+      const workspacePath = resolve('workspace')
+      const handler = getHandler('shell:openInFileManager')
+
+      await expect(handler({}, workspacePath, 'local')).resolves.toEqual({ ok: true })
+      expect(statMock).toHaveBeenCalledWith(normalize(workspacePath))
+      expect(showItemInFolderMock).toHaveBeenCalledWith(normalize(workspacePath))
+    })
+
+    it('rejects explicit remote ownership without local validation', async () => {
+      const handler = getHandler('shell:openInFileManager')
+
+      await expect(handler({}, '/srv/workspace', 'runtime:runtime-1')).resolves.toEqual({
+        ok: false,
+        reason: 'remote-runtime-unsupported'
+      })
+      expect(statMock).not.toHaveBeenCalled()
+      expect(showItemInFolderMock).not.toHaveBeenCalled()
+    })
+
     it('opens existing absolute paths in the OS file manager', async () => {
       const workspacePath = resolve('workspace')
       const handler = getHandler('shell:openInFileManager')
@@ -561,6 +582,15 @@ describe('registerShellHandlers', () => {
       await expect(
         handler({}, { path: '/srv/project', command: 'code', connectionId: 'ssh-1' })
       ).resolves.toEqual({ ok: false, reason: 'remote-runtime-unsupported' })
+
+      const runtimeOwnedTargetId = 'runtime-ssh-runtime-2'
+      sshTargets.set(
+        runtimeOwnedTargetId,
+        createSshTarget({ id: runtimeOwnedTargetId, owner: undefined })
+      )
+      await expect(
+        handler({}, { path: '/srv/project', command: 'code', connectionId: runtimeOwnedTargetId })
+      ).resolves.toEqual({ ok: false, reason: 'remote-runtime-unsupported' })
       expect(spawnMock).not.toHaveBeenCalled()
     })
 
@@ -670,18 +700,52 @@ describe('registerShellHandlers', () => {
       expect(spawnMock).not.toHaveBeenCalled()
     })
 
-    it.each(['cursor', 'zed', 'code --reuse-window'])(
-      'rejects the unsupported SSH launcher %s',
-      async (command) => {
-        sshTargets.set('ssh-1', createSshTarget())
-        const handler = getHandler('shell:openInExternalEditor')
+    it('opens a Cursor SSH workspace through Remote-SSH', async () => {
+      sshTargets.set('ssh-1', createSshTarget())
+      resolveCliCommandMock.mockReturnValueOnce('C:\\Tools\\cursor.cmd')
+      const handler = getHandler('shell:openInExternalEditor')
 
-        await expect(
-          handler({}, { path: '/srv/project', command, connectionId: 'ssh-1' })
-        ).resolves.toEqual({ ok: false, reason: 'remote-editor-unsupported' })
-        expect(spawnMock).not.toHaveBeenCalled()
-      }
-    )
+      await expect(
+        handler({}, { path: '/srv/project', command: 'cursor', connectionId: 'ssh-1' })
+      ).resolves.toEqual({ ok: true })
+      expect(getSpawnArgsForWindowsMock).toHaveBeenCalledWith(
+        'C:\\Tools\\cursor.cmd',
+        ['--remote', 'ssh-remote+builder', '/srv/project'],
+        { detachedGui: false }
+      )
+    })
+
+    it('opens a Zed SSH workspace with an encoded SSH URI', async () => {
+      sshTargets.set('ssh-1', createSshTarget())
+      resolveCliCommandMock.mockReturnValueOnce('C:\\Tools\\zed.exe')
+      const handler = getHandler('shell:openInExternalEditor')
+
+      await expect(
+        handler(
+          {},
+          {
+            path: '/srv/Ada Project/\u6587\u6863',
+            command: 'zed',
+            connectionId: 'ssh-1'
+          }
+        )
+      ).resolves.toEqual({ ok: true })
+      expect(getSpawnArgsForWindowsMock).toHaveBeenCalledWith(
+        'C:\\Tools\\zed.exe',
+        ['--new', 'ssh://builder/srv/Ada%20Project/%E6%96%87%E6%A1%A3'],
+        { detachedGui: false }
+      )
+    })
+
+    it('rejects an unsupported SSH compound launcher', async () => {
+      sshTargets.set('ssh-1', createSshTarget())
+      const handler = getHandler('shell:openInExternalEditor')
+
+      await expect(
+        handler({}, { path: '/srv/project', command: 'code --reuse-window', connectionId: 'ssh-1' })
+      ).resolves.toEqual({ ok: false, reason: 'remote-editor-unsupported' })
+      expect(spawnMock).not.toHaveBeenCalled()
+    })
 
     it('maps unsafe Windows batch arguments to a closed launch failure', async () => {
       sshTargets.set('ssh-1', createSshTarget())

--- a/src/main/ipc/shell.ts
+++ b/src/main/ipc/shell.ts
@@ -2,20 +2,33 @@ import { ipcMain, shell, dialog } from 'electron'
 import { constants, copyFile, readFile, stat } from 'node:fs/promises'
 import { basename, extname, isAbsolute, normalize, posix, win32 } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { isCursorRemoteSshCommand } from '../../shared/cursor-remote-ssh-launcher'
+import { isZedRemoteSshCommand } from '../../shared/zed-remote-ssh-launcher'
 import type {
   ShellOpenExternalEditorRequest,
   ShellOpenExternalEditorResult,
   ShellOpenLocalPathResult
 } from '../../shared/shell-open-types'
 import { MAX_REPO_ICON_UPLOAD_BYTES } from '../../shared/repo-icon'
+import {
+  isRuntimeOwnedSshTargetId,
+  parseExecutionHostId,
+  type ExecutionHostId
+} from '../../shared/execution-host'
 import type { Store } from '../persistence'
 import {
   EXTERNAL_EDITOR_CLI_COMMAND,
   launchExternalEditor,
+  resolveCursorRemoteSshLaunchSpec,
   resolveExternalEditorLaunchSpec,
   resolveVsCodeRemoteSshLaunchSpec
 } from '../external-editor-launch'
 import { resolveVsCodeSshAuthority } from '../ssh/vscode-ssh-authority'
+import { resolveZedRemoteSshLaunchSpec } from '../zed-remote-ssh-launch'
+import {
+  openRuntimePathInExternalEditor,
+  type RuntimeExternalEditorDependencies as ShellHandlerOptions
+} from './runtime-external-editor'
 
 export { EXTERNAL_EDITOR_CLI_COMMAND }
 
@@ -51,9 +64,15 @@ function hasActiveRuntime(store: Store): boolean {
 
 async function openInFileManager(
   store: Store,
-  pathValue: string
+  pathValue: string,
+  executionHostId?: ExecutionHostId
 ): Promise<ShellOpenLocalPathResult> {
-  if (hasActiveRuntime(store)) {
+  const hasExplicitExecutionHost = executionHostId !== undefined
+  const executionHost = parseExecutionHostId(executionHostId)
+  if (
+    (hasExplicitExecutionHost && executionHost?.kind !== 'local') ||
+    (!hasExplicitExecutionHost && hasActiveRuntime(store))
+  ) {
     return { ok: false, reason: 'remote-runtime-unsupported' }
   }
   const target = await validateLocalPathTarget(pathValue)
@@ -61,8 +80,7 @@ async function openInFileManager(
     return target
   }
   try {
-    // Why: the file-manager action uses reveal semantics, matching the
-    // previous sidebar behavior while still validating the path per click.
+    // Why: preserve reveal semantics while validating the path per click.
     shell.showItemInFolder(target.path)
     return { ok: true }
   } catch {
@@ -72,19 +90,37 @@ async function openInFileManager(
 
 async function openInExternalEditor(
   store: Store,
-  request: ShellOpenExternalEditorRequest
+  request: ShellOpenExternalEditorRequest,
+  options: ShellHandlerOptions
 ): Promise<ShellOpenExternalEditorResult> {
-  if (hasActiveRuntime(store)) {
+  const hasExplicitExecutionHost = request.executionHostId !== undefined
+  const executionHost = parseExecutionHostId(request.executionHostId)
+  if (hasExplicitExecutionHost && !executionHost) {
+    return { ok: false, reason: 'remote-runtime-unsupported' }
+  }
+  if (executionHost?.kind === 'runtime') {
+    return openRuntimePathInExternalEditor(store, request, options)
+  }
+  if (!hasExplicitExecutionHost && hasActiveRuntime(store)) {
     return { ok: false, reason: 'remote-runtime-unsupported' }
   }
 
-  const connectionId = request.connectionId?.trim()
+  let connectionId = request.connectionId?.trim()
+  if (executionHost?.kind === 'ssh') {
+    if (connectionId && connectionId !== executionHost.targetId) {
+      return { ok: false, reason: 'ssh-target-not-found' }
+    }
+    connectionId = executionHost.targetId
+  } else if (executionHost?.kind === 'local' && connectionId) {
+    return { ok: false, reason: 'ssh-target-not-found' }
+  }
+
   if (connectionId) {
     const sshTarget = store.getSshTarget(connectionId)
     if (!sshTarget) {
       return { ok: false, reason: 'ssh-target-not-found' }
     }
-    if (sshTarget.owner?.type === 'on-demand-runtime') {
+    if (sshTarget.owner?.type === 'on-demand-runtime' || isRuntimeOwnedSshTargetId(sshTarget.id)) {
       return { ok: false, reason: 'remote-runtime-unsupported' }
     }
     if (!posix.isAbsolute(request.path) && !win32.isAbsolute(request.path)) {
@@ -94,11 +130,11 @@ async function openInExternalEditor(
     if (!authority.ok) {
       return authority
     }
-    const launchSpec = resolveVsCodeRemoteSshLaunchSpec(
-      request.command,
-      request.path,
-      authority.authority
-    )
+    const launchSpec = isZedRemoteSshCommand(request.command)
+      ? resolveZedRemoteSshLaunchSpec(request.command, request.path, authority.authority)
+      : isCursorRemoteSshCommand(request.command)
+        ? resolveCursorRemoteSshLaunchSpec(request.command, request.path, authority.authority)
+        : resolveVsCodeRemoteSshLaunchSpec(request.command, request.path, authority.authority)
     if (!launchSpec) {
       return { ok: false, reason: 'remote-editor-unsupported' }
     }
@@ -135,7 +171,7 @@ async function openWithSystemDefault(pathValue: string): Promise<boolean> {
   }
 }
 
-export function registerShellHandlers(store: Store): void {
+export function registerShellHandlers(store: Store, options: ShellHandlerOptions = {}): void {
   ipcMain.handle('shell:openPath', async (_event, path: string): Promise<void> => {
     // Why: keep the legacy fire-and-forget renderer contract while reusing the
     // same absolute/existing path validation as the explicit file-manager API.
@@ -144,13 +180,14 @@ export function registerShellHandlers(store: Store): void {
 
   ipcMain.handle(
     'shell:openInFileManager',
-    (_event, path: string): Promise<ShellOpenLocalPathResult> => openInFileManager(store, path)
+    (_event, path: string, executionHostId?: ExecutionHostId): Promise<ShellOpenLocalPathResult> =>
+      openInFileManager(store, path, executionHostId)
   )
 
   ipcMain.handle(
     'shell:openInExternalEditor',
     (_event, request: ShellOpenExternalEditorRequest): Promise<ShellOpenExternalEditorResult> =>
-      openInExternalEditor(store, request)
+      openInExternalEditor(store, request, options)
   )
 
   ipcMain.handle('shell:openUrl', (_event, rawUrl: string) => {

--- a/src/main/runtime-environment-editor-ssh-target.test.ts
+++ b/src/main/runtime-environment-editor-ssh-target.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from 'vitest'
+import type { KnownRuntimeEnvironment } from '../shared/runtime-environments'
+import type { SshTarget } from '../shared/ssh-types'
+import { resolveRuntimeEnvironmentEditorSshTarget } from './runtime-environment-editor-ssh-target'
+
+function environment(
+  endpoint: string,
+  overrides: Partial<KnownRuntimeEnvironment> = {}
+): KnownRuntimeEnvironment {
+  return {
+    id: 'env-1',
+    name: 'Build server',
+    createdAt: 1,
+    updatedAt: 1,
+    lastUsedAt: null,
+    runtimeId: 'runtime-1',
+    endpoints: [
+      {
+        id: 'ws-env-1',
+        kind: 'websocket',
+        label: 'WebSocket',
+        endpoint,
+        deviceToken: 'token',
+        publicKeyB64: 'public-key'
+      }
+    ],
+    preferredEndpointId: 'ws-env-1',
+    ...overrides
+  }
+}
+
+function target(overrides: Partial<SshTarget> = {}): SshTarget {
+  return {
+    id: 'ssh-1',
+    label: 'Build server',
+    configHost: 'build-box',
+    host: 'runtime.example.com',
+    port: 22,
+    username: 'ada',
+    source: 'ssh-config',
+    ...overrides
+  }
+}
+
+describe('resolveRuntimeEnvironmentEditorSshTarget', () => {
+  it('prefers one exact config alias match over resolved-host matches', () => {
+    const aliasMatch = target({ id: 'ssh-alias', configHost: 'runtime.example.com' })
+    const hostMatch = target({ id: 'ssh-host', configHost: 'other-alias' })
+
+    expect(
+      resolveRuntimeEnvironmentEditorSshTarget(environment('wss://RUNTIME.EXAMPLE.COM.:6768'), [
+        hostMatch,
+        aliasMatch
+      ])
+    ).toEqual({ ok: true, target: aliasMatch })
+  })
+
+  it('does not treat a manual target configHost as an executable SSH alias', () => {
+    const misleadingManualTarget = target({
+      source: 'manual',
+      configHost: 'runtime.example.com',
+      host: 'other.example.com'
+    })
+
+    expect(
+      resolveRuntimeEnvironmentEditorSshTarget(environment('ws://runtime.example.com:6768'), [
+        misleadingManualTarget
+      ])
+    ).toEqual({ ok: false, reason: 'runtime-ssh-target-required' })
+  })
+
+  it('uses one resolved-host match when no config alias matches', () => {
+    const match = target({ configHost: 'build-box', host: 'runtime.example.com' })
+
+    expect(
+      resolveRuntimeEnvironmentEditorSshTarget(environment('ws://runtime.example.com:6768'), [
+        match
+      ])
+    ).toEqual({ ok: true, target: match })
+  })
+
+  it.each([
+    ['no matching target', [target({ host: 'other.example.com' })]],
+    [
+      'ambiguous alias matches',
+      [
+        target({ id: 'ssh-1', configHost: 'runtime.example.com' }),
+        target({ id: 'ssh-2', configHost: 'runtime.example.com' })
+      ]
+    ],
+    [
+      'ambiguous resolved-host matches',
+      [target({ id: 'ssh-1', configHost: 'first' }), target({ id: 'ssh-2', configHost: 'second' })]
+    ],
+    [
+      'only a hidden runtime-owned target',
+      [target({ owner: { type: 'on-demand-runtime', runtimeId: 'runtime-1' } })]
+    ],
+    ['legacy runtime-owned target id', [target({ id: 'runtime-ssh-runtime-1' })]]
+  ])('requires an explicit usable SSH target for %s', (_label, targets) => {
+    expect(
+      resolveRuntimeEnvironmentEditorSshTarget(
+        environment('ws://runtime.example.com:6768'),
+        targets
+      )
+    ).toEqual({ ok: false, reason: 'runtime-ssh-target-required' })
+  })
+
+  it.each([
+    ['loopback endpoint', environment('ws://127.0.0.1:6768')],
+    [
+      'SSH-tunnel dependency',
+      environment('ws://runtime.example.com:6768', { connectionDependency: 'ssh-tunnel' })
+    ],
+    ['ephemeral VM', environment('ws://runtime.example.com:6768', { source: 'ephemeral-vm' })],
+    ['non-WebSocket endpoint', environment('https://runtime.example.com')],
+    ['malformed endpoint', environment('not a URL')],
+    ['wildcard endpoint', environment('ws://0.0.0.0:6768')],
+    ['zero port endpoint', environment('ws://runtime.example.com:0')],
+    ['reverse-proxy endpoint', environment('ws://runtime.example.com/orca')]
+  ])('rejects the unsupported Runtime topology: %s', (_label, runtimeEnvironment) => {
+    expect(resolveRuntimeEnvironmentEditorSshTarget(runtimeEnvironment, [target()])).toEqual({
+      ok: false,
+      reason: 'remote-runtime-unsupported'
+    })
+  })
+
+  it('uses the preferred direct endpoint when a Runtime has multiple endpoints', () => {
+    const selected = target({ host: 'selected.example.com' })
+    const runtime = environment('ws://first.example.com:6768', {
+      endpoints: [
+        {
+          id: 'ws-first',
+          kind: 'websocket',
+          label: 'First',
+          endpoint: 'ws://first.example.com:6768',
+          deviceToken: 'token-1',
+          publicKeyB64: 'public-key-1'
+        },
+        {
+          id: 'ws-selected',
+          kind: 'websocket',
+          label: 'Selected',
+          endpoint: 'wss://selected.example.com:6768',
+          deviceToken: 'token-2',
+          publicKeyB64: 'public-key-2'
+        }
+      ],
+      preferredEndpointId: 'ws-selected'
+    })
+
+    expect(resolveRuntimeEnvironmentEditorSshTarget(runtime, [selected])).toEqual({
+      ok: true,
+      target: selected
+    })
+  })
+
+  it('rejects a stale preferred endpoint instead of using another endpoint', () => {
+    expect(
+      resolveRuntimeEnvironmentEditorSshTarget(
+        environment('ws://runtime.example.com:6768', { preferredEndpointId: 'missing-endpoint' }),
+        [target()]
+      )
+    ).toEqual({ ok: false, reason: 'remote-runtime-unsupported' })
+  })
+
+  it('fails closed for an IPv6 wildcard endpoint', () => {
+    expect(
+      resolveRuntimeEnvironmentEditorSshTarget(environment('ws://[::]:6768'), [
+        target({ host: '::' })
+      ])
+    ).toEqual({ ok: false, reason: 'remote-runtime-unsupported' })
+  })
+})

--- a/src/main/runtime-environment-editor-ssh-target.ts
+++ b/src/main/runtime-environment-editor-ssh-target.ts
@@ -1,0 +1,82 @@
+import { isOpenSshConfigBackedTarget } from './ssh/system-ssh-args'
+import { isRuntimeOwnedSshTargetId } from '../shared/execution-host'
+import { classifyRemotePairingHostname } from '../shared/remote-pairing-address'
+import {
+  isUserManagedRuntimeEnvironment,
+  type KnownRuntimeEnvironment
+} from '../shared/runtime-environments'
+import type { SshTarget } from '../shared/ssh-types'
+
+export type RuntimeEnvironmentEditorSshTargetResult =
+  | { ok: true; target: SshTarget }
+  | {
+      ok: false
+      reason: 'remote-runtime-unsupported' | 'runtime-ssh-target-required'
+    }
+
+function normalizeHostname(value: string | null | undefined): string {
+  return (value ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/^\[|\]$/g, '')
+    .replace(/\.$/, '')
+}
+
+export function resolveRuntimeEnvironmentEditorSshTarget(
+  environment: KnownRuntimeEnvironment,
+  targets: readonly SshTarget[]
+): RuntimeEnvironmentEditorSshTargetResult {
+  if (
+    !isUserManagedRuntimeEnvironment(environment) ||
+    environment.connectionDependency === 'ssh-tunnel'
+  ) {
+    return { ok: false, reason: 'remote-runtime-unsupported' }
+  }
+
+  const endpoint = environment.preferredEndpointId
+    ? environment.endpoints.find((entry) => entry.id === environment.preferredEndpointId)
+    : environment.endpoints[0]
+  if (!endpoint) {
+    return { ok: false, reason: 'remote-runtime-unsupported' }
+  }
+
+  let endpointUrl: URL
+  try {
+    endpointUrl = new URL(endpoint.endpoint)
+  } catch {
+    return { ok: false, reason: 'remote-runtime-unsupported' }
+  }
+  if (
+    (endpointUrl.protocol !== 'ws:' && endpointUrl.protocol !== 'wss:') ||
+    !endpointUrl.hostname ||
+    endpointUrl.username ||
+    endpointUrl.password ||
+    endpointUrl.pathname !== '/' ||
+    endpointUrl.search ||
+    endpointUrl.hash ||
+    classifyRemotePairingHostname(endpointUrl.hostname) === 'loopback' ||
+    ['0.0.0.0', '::'].includes(normalizeHostname(endpointUrl.hostname)) ||
+    endpointUrl.port === '0'
+  ) {
+    return { ok: false, reason: 'remote-runtime-unsupported' }
+  }
+
+  const hostname = normalizeHostname(endpointUrl.hostname)
+  const usableTargets = targets.filter(
+    (target) => target.owner?.type !== 'on-demand-runtime' && !isRuntimeOwnedSshTargetId(target.id)
+  )
+  const aliasMatches = usableTargets.filter(
+    (target) =>
+      isOpenSshConfigBackedTarget(target) && normalizeHostname(target.configHost) === hostname
+  )
+  if (aliasMatches.length > 0) {
+    return aliasMatches.length === 1
+      ? { ok: true, target: aliasMatches[0]! }
+      : { ok: false, reason: 'runtime-ssh-target-required' }
+  }
+
+  const hostMatches = usableTargets.filter((target) => normalizeHostname(target.host) === hostname)
+  return hostMatches.length === 1
+    ? { ok: true, target: hostMatches[0]! }
+    : { ok: false, reason: 'runtime-ssh-target-required' }
+}

--- a/src/main/zed-remote-ssh-launch.ts
+++ b/src/main/zed-remote-ssh-launch.ts
@@ -1,0 +1,79 @@
+import { existsSync } from 'node:fs'
+import { posix } from 'node:path'
+import type { ExternalEditorLaunchSpec } from './external-editor-launch'
+import { isCompoundShellCommand, isDirectExecutablePath } from './external-editor-launch'
+import { resolveCliCommand } from './codex-cli/command'
+import { stripMatchingQuotes } from './editor-launcher-name'
+import {
+  getZedLauncherCommandToken,
+  isZedLauncherExecutable
+} from '../shared/zed-remote-ssh-launcher'
+
+function encodeRemoteSshPath(pathValue: string): string {
+  return pathValue
+    .split('/')
+    .map((segment, index) => (index === 0 ? '' : encodeURIComponent(segment)))
+    .join('/')
+}
+
+function formatZedSshAuthority(authority: string): string | null {
+  if (!authority || /[\s/?#\\%]/.test(authority)) {
+    return null
+  }
+  const separatorIndex = authority.indexOf('@')
+  if (separatorIndex !== -1 && separatorIndex !== authority.lastIndexOf('@')) {
+    return null
+  }
+  const user = separatorIndex !== -1 ? authority.slice(0, separatorIndex + 1) : ''
+  const host = separatorIndex !== -1 ? authority.slice(separatorIndex + 1) : authority
+  if (!host) {
+    return null
+  }
+  const bracketed = host.startsWith('[') && host.endsWith(']')
+  if (host.includes('[') || host.includes(']')) {
+    return bracketed && host.includes(':') ? authority : null
+  }
+  if (!host.includes(':')) {
+    return authority
+  }
+  return /^[0-9a-f:]+$/i.test(host) ? `${user}[${host}]` : null
+}
+
+export function resolveZedRemoteSshLaunchSpec(
+  command: string | undefined,
+  pathValue: string,
+  authority: string,
+  options: { platform?: NodeJS.Platform; fileExists?: (path: string) => boolean } = {}
+): ExternalEditorLaunchSpec | null {
+  const formattedAuthority = formatZedSshAuthority(authority)
+  if (!posix.isAbsolute(pathValue) || !formattedAuthority) {
+    return null
+  }
+
+  const platform = options.platform ?? process.platform
+  const fileExists = options.fileExists ?? existsSync
+  const trimmed = command?.trim()
+  if (!trimmed) {
+    return null
+  }
+
+  const commandToken = getZedLauncherCommandToken(trimmed)
+  const unquoted = stripMatchingQuotes(trimmed)
+  const hasArguments = unquoted !== commandToken
+  const editorCommand = isDirectExecutablePath(trimmed, platform, fileExists)
+    ? stripMatchingQuotes(trimmed)
+    : isDirectExecutablePath(commandToken, platform, fileExists)
+      ? commandToken
+      : !hasArguments && !isCompoundShellCommand(trimmed)
+        ? resolveCliCommand(commandToken, { platform })
+        : null
+  if (!editorCommand || !isZedLauncherExecutable(editorCommand)) {
+    return null
+  }
+  return {
+    kind: 'executable',
+    hideWindowsConsole: true,
+    spawnCmd: editorCommand,
+    spawnArgs: ['--new', `ssh://${formattedAuthority}${encodeRemoteSshPath(pathValue)}`]
+  }
+}

--- a/src/preload/api/shell-api.ts
+++ b/src/preload/api/shell-api.ts
@@ -1,3 +1,4 @@
+import type { ExecutionHostId } from '../../shared/execution-host'
 import type {
   ShellOpenExternalEditorRequest,
   ShellOpenExternalEditorResult,
@@ -12,7 +13,10 @@ export type {
 
 export type ShellApi = {
   openPath: (path: string) => Promise<void>
-  openInFileManager: (path: string) => Promise<ShellOpenLocalPathResult>
+  openInFileManager: (
+    path: string,
+    executionHostId?: ExecutionHostId
+  ) => Promise<ShellOpenLocalPathResult>
   openInExternalEditor: (
     request: ShellOpenExternalEditorRequest
   ) => Promise<ShellOpenExternalEditorResult>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2547,8 +2547,11 @@ const api = {
   shell: {
     openPath: (path: string): Promise<void> => ipcRenderer.invoke('shell:openPath', path),
 
-    openInFileManager: (path: string): Promise<ShellOpenLocalPathResult> =>
-      ipcRenderer.invoke('shell:openInFileManager', path),
+    openInFileManager: (
+      path: string,
+      executionHostId?: ExecutionHostId
+    ): Promise<ShellOpenLocalPathResult> =>
+      ipcRenderer.invoke('shell:openInFileManager', path, executionHostId),
 
     openInExternalEditor: (
       request: ShellOpenExternalEditorRequest

--- a/src/renderer/src/components/right-sidebar/FileExplorer.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.tsx
@@ -27,6 +27,8 @@ import { useFileExplorerNameFilter } from './use-file-explorer-name-filter'
 import { useFileExplorerTreePaneState } from './use-file-explorer-tree-pane-state'
 import { translate } from '@/i18n/i18n'
 import type { RightSidebarExplorerView } from '../../../../shared/ui-chrome-types'
+import { parseExecutionHostId } from '../../../../shared/execution-host'
+import { getExecutionHostIdForWorktree } from '@/lib/worktree-runtime-owner'
 
 function FileExplorerFiles(): React.JSX.Element {
   const explorerView = useAppStore((s) => s.rightSidebarExplorerView)
@@ -35,6 +37,9 @@ function FileExplorerFiles(): React.JSX.Element {
   const searchPanel = useFileSearchPanel(explorerView)
   const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
   const activeWorktree = useActiveWorktree()
+  const executionHostId = useAppStore((s) => getExecutionHostIdForWorktree(s, activeWorktreeId))
+  const executionHost = parseExecutionHostId(executionHostId)
+  const openInConnectionId = executionHost?.kind === 'ssh' ? executionHost.targetId : null
   const activeRepo = useRepoById(activeWorktree?.repoId ?? null)
   const expandedDirs = useAppStore((s) => s.expandedDirs)
   const collapseAllDirs = useAppStore((s) => s.collapseAllDirs)
@@ -208,7 +213,8 @@ function FileExplorerFiles(): React.JSX.Element {
         <FileExplorerToolbar
           repoName={repoName}
           worktreePath={worktreePath}
-          connectionId={activeRepo?.connectionId ?? null}
+          connectionId={openInConnectionId}
+          executionHostId={executionHostId}
           refresh={manualRefresh}
           canRefresh={isFilesViewActive}
           canCollapseAll={canCollapseAll}

--- a/src/renderer/src/components/right-sidebar/FileExplorerToolbar.test.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerToolbar.test.tsx
@@ -305,6 +305,17 @@ describe('FileExplorerToolbar', () => {
     expect(openInItems.props.labelPrefix).toBe('Open in ')
   })
 
+  it('forwards worktree execution ownership to Open In actions', () => {
+    const element = makeToolbar({
+      connectionId: 'runtime-transport',
+      executionHostId: 'runtime:runtime-1'
+    })
+
+    const openInItems = findOpenInMenuItems(element)
+    expect(openInItems.props.connectionId).toBe('runtime-transport')
+    expect(openInItems.props.executionHostId).toBe('runtime:runtime-1')
+  })
+
   it('keeps the overflow menu as the last toolbar button', () => {
     const element = makeToolbar()
 

--- a/src/renderer/src/components/right-sidebar/FileExplorerToolbar.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerToolbar.tsx
@@ -11,12 +11,14 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { WorktreeOpenInMenuItems } from '@/components/sidebar/WorktreeOpenInMenu'
 import { translate } from '@/i18n/i18n'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
 import { cn } from '@/lib/utils'
 
 type FileExplorerToolbarProps = {
   repoName: string
   worktreePath: string
   connectionId?: string | null
+  executionHostId?: ExecutionHostId
   refresh: {
     isRefreshing: boolean
     showRefreshSpinner: boolean
@@ -36,6 +38,7 @@ export function FileExplorerToolbar({
   repoName,
   worktreePath,
   connectionId,
+  executionHostId,
   refresh,
   canRefresh,
   canCollapseAll,
@@ -173,7 +176,11 @@ export function FileExplorerToolbar({
           <WorktreeOpenInMenuItems
             worktreePath={worktreePath}
             connectionId={connectionId}
-            labelPrefix="Open in "
+            executionHostId={executionHostId}
+            labelPrefix={`${translate(
+              'auto.components.sidebar.WorktreeOpenInMenu.8009ab69a6',
+              'Open in'
+            )} `}
           />
         </DropdownMenuContent>
       </DropdownMenu>

--- a/src/renderer/src/components/right-sidebar/source-control-entry-context-menu.test.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control-entry-context-menu.test.tsx
@@ -6,6 +6,11 @@ import { SourceControlEntryContextMenu } from './source-control/listing/entry-co
 type ItemProps = { onSelect?: () => void; children?: React.ReactNode }
 
 const items = vi.hoisted(() => ({ list: [] as ItemProps[] }))
+const openInMocks = vi.hoisted(() => ({
+  executionHostId: 'local' as 'local' | `ssh:${string}` | `runtime:${string}`,
+  getOpenInEntryAvailability: vi.fn(() => ({ disabled: false })),
+  openWorktreePath: vi.fn()
+}))
 
 vi.mock('@/components/ui/context-menu', async () => {
   const React_ = await import('react')
@@ -45,14 +50,28 @@ vi.mock('@/lib/open-in-app-catalog', () => ({
 }))
 
 vi.mock('@/components/sidebar/WorktreeOpenInMenu', () => ({
-  getWorktreeOpenInEntries: () => [],
+  getOpenInEntryAvailability: openInMocks.getOpenInEntryAvailability,
+  getWorktreeOpenInEntries: () => [
+    { id: 'vscode', label: 'VS Code', target: 'external-editor', command: 'code' }
+  ],
   openOpenInAppsSettings: vi.fn(),
-  openWorktreePath: vi.fn()
+  openWorktreePath: openInMocks.openWorktreePath
+}))
+
+vi.mock('@/lib/worktree-runtime-owner', () => ({
+  getExecutionHostIdForWorktree: () => openInMocks.executionHostId
 }))
 
 function childrenText(children: React.ReactNode): string {
   return React.Children.toArray(children)
-    .filter((child): child is string => typeof child === 'string')
+    .map((child) => {
+      if (typeof child === 'string') {
+        return child
+      }
+      return React.isValidElement<{ children?: React.ReactNode }>(child)
+        ? childrenText(child.props.children)
+        : ''
+    })
     .join('')
 }
 
@@ -61,6 +80,9 @@ describe('SourceControlEntryContextMenu', () => {
 
   beforeEach(() => {
     items.list = []
+    openInMocks.executionHostId = 'local'
+    openInMocks.getOpenInEntryAvailability.mockClear()
+    openInMocks.openWorktreePath.mockReset()
     writeClipboardText.mockReset()
     vi.stubGlobal('window', {
       api: { ui: { writeClipboardText } }
@@ -90,5 +112,102 @@ describe('SourceControlEntryContextMenu', () => {
     expect(copyRelativePathItem).toBeDefined()
     copyRelativePathItem?.onSelect?.()
     expect(writeClipboardText).toHaveBeenCalledWith('src/example.ts')
+  })
+
+  it('opens runtime-owned paths with the worktree execution host', () => {
+    openInMocks.executionHostId = 'runtime:devbox'
+
+    renderToStaticMarkup(
+      <SourceControlEntryContextMenu
+        currentWorktreeId="worktree-1"
+        absolutePath="/workspaces/project/src/example.ts"
+        relativePath="src/example.ts"
+        onRevealInExplorer={vi.fn()}
+      >
+        <div />
+      </SourceControlEntryContextMenu>
+    )
+
+    const vscodeItem = items.list.find((item) => childrenText(item.children) === 'VS Code')
+
+    expect(vscodeItem).toBeDefined()
+    expect(openInMocks.getOpenInEntryAvailability).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'vscode' }),
+      expect.anything(),
+      null,
+      'runtime:devbox'
+    )
+    vscodeItem?.onSelect?.()
+    expect(openInMocks.openWorktreePath).toHaveBeenCalledWith({
+      target: 'external-editor',
+      worktreePath: '/workspaces/project/src/example.ts',
+      connectionId: null,
+      executionHostId: 'runtime:devbox',
+      command: 'code'
+    })
+  })
+
+  it('drops the repository SSH connection for an explicitly local worktree', () => {
+    renderToStaticMarkup(
+      <SourceControlEntryContextMenu
+        currentWorktreeId="worktree-1"
+        absolutePath="/repo/src/example.ts"
+        relativePath="src/example.ts"
+        connectionId="repo-ssh"
+        onRevealInExplorer={vi.fn()}
+      >
+        <div />
+      </SourceControlEntryContextMenu>
+    )
+
+    const vscodeItem = items.list.find((item) => childrenText(item.children) === 'VS Code')
+
+    expect(openInMocks.getOpenInEntryAvailability).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'vscode' }),
+      expect.anything(),
+      null,
+      'local'
+    )
+    vscodeItem?.onSelect?.()
+    expect(openInMocks.openWorktreePath).toHaveBeenCalledWith({
+      target: 'external-editor',
+      worktreePath: '/repo/src/example.ts',
+      connectionId: null,
+      executionHostId: 'local',
+      command: 'code'
+    })
+  })
+
+  it('uses the worktree SSH target instead of the repository connection', () => {
+    openInMocks.executionHostId = 'ssh:worktree-ssh'
+
+    renderToStaticMarkup(
+      <SourceControlEntryContextMenu
+        currentWorktreeId="worktree-1"
+        absolutePath="/repo/src/example.ts"
+        relativePath="src/example.ts"
+        connectionId="repo-ssh"
+        onRevealInExplorer={vi.fn()}
+      >
+        <div />
+      </SourceControlEntryContextMenu>
+    )
+
+    const vscodeItem = items.list.find((item) => childrenText(item.children) === 'VS Code')
+
+    expect(openInMocks.getOpenInEntryAvailability).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'vscode' }),
+      expect.anything(),
+      'worktree-ssh',
+      'ssh:worktree-ssh'
+    )
+    vscodeItem?.onSelect?.()
+    expect(openInMocks.openWorktreePath).toHaveBeenCalledWith({
+      target: 'external-editor',
+      worktreePath: '/repo/src/example.ts',
+      connectionId: 'worktree-ssh',
+      executionHostId: 'ssh:worktree-ssh',
+      command: 'code'
+    })
   })
 })

--- a/src/renderer/src/components/right-sidebar/source-control/listing/entry-context-menu.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control/listing/entry-context-menu.tsx
@@ -15,6 +15,8 @@ import { OpenInApplicationIcon } from '@/lib/open-in-app-catalog'
 import { translate } from '@/i18n/i18n'
 import { getLocalFileManagerLabel } from '@/lib/local-file-manager-label'
 import { NO_OPEN_IN_APPLICATIONS } from '@/lib/open-in-application-selection'
+import { getExecutionHostIdForWorktree } from '@/lib/worktree-runtime-owner'
+import { parseExecutionHostId } from '../../../../../../shared/execution-host'
 import {
   getOpenInEntryAvailability,
   getWorktreeOpenInEntries,
@@ -43,6 +45,14 @@ export function SourceControlEntryContextMenu({
   onOpenChange,
   children
 }: SourceControlEntryContextMenuProps): React.JSX.Element {
+  const executionHostId = useAppStore((s) => getExecutionHostIdForWorktree(s, currentWorktreeId))
+  const executionHost = parseExecutionHostId(executionHostId)
+  const openInConnectionId =
+    executionHost?.kind === 'ssh'
+      ? executionHost.targetId
+      : executionHostId === undefined
+        ? connectionId
+        : null
   const openInApplications = useAppStore(
     (s) => s.settings?.openInApplications ?? NO_OPEN_IN_APPLICATIONS
   )
@@ -82,11 +92,12 @@ export function SourceControlEntryContextMenu({
       void openWorktreePath({
         target,
         worktreePath: absolutePath,
-        connectionId,
+        connectionId: openInConnectionId,
+        executionHostId,
         command
       })
     },
-    [absolutePath, connectionId]
+    [absolutePath, executionHostId, openInConnectionId]
   )
 
   return (
@@ -120,7 +131,12 @@ export function SourceControlEntryContextMenu({
           </ContextMenuSubTrigger>
           <ContextMenuSubContent className="w-52">
             {openInEntries.map((entry) => {
-              const availability = getOpenInEntryAvailability(entry, settings, connectionId)
+              const availability = getOpenInEntryAvailability(
+                entry,
+                settings,
+                openInConnectionId,
+                executionHostId
+              )
               return (
                 <ContextMenuItem
                   key={entry.id}

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.test.ts
@@ -11,6 +11,7 @@ import {
   hasWorktreeParentLink,
   isWorktreeParentPickerDisabled,
   planWorkspaceStatusAssignment,
+  resolveContextWorktreeExecutionHostId,
   selectMenuScopedMap,
   shouldRevealWorktreeDeveloperMenu
 } from './WorktreeContextMenu'
@@ -38,6 +39,21 @@ describe('shouldRevealWorktreeDeveloperMenu', () => {
     expect(
       shouldRevealWorktreeDeveloperMenu({ developerMenuRevealed: true, isMultiContext: true })
     ).toBe(false)
+  })
+})
+
+describe('resolveContextWorktreeExecutionHostId', () => {
+  it('keeps the clicked row host when the same worktree id is active on another host', () => {
+    expect(
+      resolveContextWorktreeExecutionHostId({ hostId: 'runtime:runtime-1' }, 'ssh:ssh-2')
+    ).toBe('runtime:runtime-1')
+    expect(resolveContextWorktreeExecutionHostId({ hostId: 'local' }, 'runtime:runtime-1')).toBe(
+      'local'
+    )
+  })
+
+  it('uses indexed ownership for legacy rows without a host stamp', () => {
+    expect(resolveContextWorktreeExecutionHostId({}, 'ssh:ssh-1')).toBe('ssh:ssh-1')
   })
 })
 

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -34,6 +34,8 @@ import { useAppStore } from '@/store'
 import type { AppState } from '@/store/types'
 import { useAllWorktrees, useRepoById, useRepoMap, useWorktreeMap } from '@/store/selectors'
 import { cn } from '@/lib/utils'
+import { getExecutionHostIdForWorktree } from '@/lib/worktree-runtime-owner'
+import { parseExecutionHostId, type ExecutionHostId } from '../../../../shared/execution-host'
 import type { Repo } from '../../../../shared/repo-types'
 import type {
   WorkspaceStatus,
@@ -110,6 +112,13 @@ const EMPTY_CYCLIC_LINEAGE_IDS: ReadonlySet<string> = new Set()
 // data. Extracted as a pure function so the stable-reference contract is unit-testable.
 export function selectMenuScopedMap<T>(menuOpen: boolean, live: T, empty: T): T {
   return menuOpen ? live : empty
+}
+
+export function resolveContextWorktreeExecutionHostId(
+  worktree: Pick<Worktree, 'hostId'>,
+  fallback: ExecutionHostId
+): ExecutionHostId {
+  return worktree.hostId ?? fallback
 }
 
 // Why: the Developer submenu is hidden by default and revealed only by holding
@@ -334,6 +343,10 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
   const createProjectGroup = useAppStore((s) => s.createProjectGroup)
   const moveProjectToGroup = useAppStore((s) => s.moveProjectToGroup)
   const repo = useRepoById(worktree.repoId)
+  const fallbackExecutionHostId = useAppStore((s) => getExecutionHostIdForWorktree(s, worktree.id))
+  const executionHostId = resolveContextWorktreeExecutionHostId(worktree, fallbackExecutionHostId)
+  const executionHost = parseExecutionHostId(executionHostId)
+  const openInConnectionId = executionHost?.kind === 'ssh' ? executionHost.targetId : null
   const deleteState = useAppStore((s) =>
     getDeleteStateForWorktreeHost(worktree, s.deleteStateByWorktreeId)
   )
@@ -886,7 +899,8 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
             <>
               <WorktreeOpenInSubMenu
                 worktreePath={worktree.path}
-                connectionId={repo?.connectionId ?? null}
+                connectionId={openInConnectionId}
+                executionHostId={executionHostId}
                 disabled={isDeleting}
               />
               <DropdownMenuItem onSelect={handleCopyPath} disabled={isDeleting}>

--- a/src/renderer/src/components/sidebar/WorktreeOpenInMenu.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeOpenInMenu.test.tsx
@@ -153,6 +153,37 @@ describe('WorktreeOpenInMenu', () => {
     expect(openInExternalEditorMock).not.toHaveBeenCalled()
   })
 
+  it.each(['runtime:runtime-1', 'ssh:ssh-1'] as const)(
+    'blocks remote file-manager actions without an ambient Runtime: %s',
+    async (executionHostId) => {
+      await openWorktreePath({
+        target: 'file-manager',
+        worktreePath: '/srv/remote-workspace',
+        connectionId: null,
+        executionHostId
+      })
+
+      expect(openInFileManagerMock).not.toHaveBeenCalled()
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        'Opening remote paths in the local OS is not available.'
+      )
+    }
+  )
+
+  it('honors explicit local ownership while an ambient Runtime is active', async () => {
+    mockState.settings = { activeRuntimeEnvironmentId: 'runtime-1', openInApplications: [] }
+
+    await openWorktreePath({
+      target: 'file-manager',
+      worktreePath: '/tmp/workspace',
+      connectionId: null,
+      executionHostId: 'local'
+    })
+
+    expect(openInFileManagerMock).toHaveBeenCalledWith('/tmp/workspace', 'local')
+    expect(toastErrorMock).not.toHaveBeenCalled()
+  })
+
   it('shows an actionable toast when the host launcher fails', async () => {
     openInExternalEditorMock.mockResolvedValueOnce({ ok: false, reason: 'launch-failed' })
 
@@ -227,11 +258,98 @@ describe('WorktreeOpenInMenu', () => {
     )
   })
 
-  it('enables only VS Code-compatible launchers for SSH paths', () => {
+  it('enables VS Code, Cursor, and Zed for a runtime-owned worktree', () => {
+    const entries = getWorktreeOpenInEntries(
+      [
+        { id: 'vscode', label: 'VS Code', command: 'code' },
+        { id: 'zed', label: 'Zed', command: 'zed' },
+        { id: 'cursor', label: 'Cursor', command: 'cursor' }
+      ],
+      'Finder'
+    )
+
+    expect(
+      getOpenInEntryAvailability(entries[0], mockState.settings, null, 'runtime:runtime-1')
+    ).toEqual({ disabled: false, metadata: 'Remote SSH' })
+    expect(
+      getOpenInEntryAvailability(entries[1], mockState.settings, null, 'runtime:runtime-1')
+    ).toEqual({ disabled: false, metadata: 'Remote SSH' })
+    expect(
+      getOpenInEntryAvailability(entries[2], mockState.settings, null, 'runtime:runtime-1')
+    ).toEqual({ disabled: false, metadata: 'Remote SSH' })
+  })
+
+  it('forwards runtime worktree ownership to main IPC', async () => {
+    await openWorktreePath({
+      target: 'external-editor',
+      worktreePath: '/srv/Ada Project',
+      connectionId: null,
+      executionHostId: 'runtime:runtime-1',
+      command: 'zed'
+    })
+
+    expect(openInExternalEditorMock).toHaveBeenCalledWith({
+      path: '/srv/Ada Project',
+      command: 'zed',
+      connectionId: null,
+      executionHostId: 'runtime:runtime-1'
+    })
+  })
+
+  it('uses remote-neutral copy for an unsupported Runtime launcher', async () => {
+    await openWorktreePath({
+      target: 'external-editor',
+      worktreePath: '/srv/project',
+      connectionId: null,
+      executionHostId: 'runtime:runtime-1',
+      command: 'subl'
+    })
+
+    expect(openInExternalEditorMock).not.toHaveBeenCalled()
+    expect(toastErrorMock).toHaveBeenCalledWith('This app cannot open remote workspaces.', {
+      description: 'Choose an editor with remote workspace support or use the app locally.'
+    })
+  })
+
+  it('enables file-manager entries for explicit local ownership under an ambient Runtime', () => {
+    mockState.settings = { activeRuntimeEnvironmentId: 'runtime-1', openInApplications: [] }
+    const entries = getWorktreeOpenInEntries([], 'File Manager')
+
+    expect(getOpenInEntryAvailability(entries[0], mockState.settings, null, 'local')).toEqual({
+      disabled: false
+    })
+  })
+
+  it('disables file-manager entries for Runtime-owned worktrees without an ambient Runtime', () => {
+    const entries = getWorktreeOpenInEntries([], 'File Manager')
+
+    expect(
+      getOpenInEntryAvailability(entries[0], mockState.settings, null, 'runtime:runtime-1')
+    ).toEqual({ disabled: true, metadata: 'Local only' })
+  })
+
+  it('uses editor-neutral recovery copy when a Runtime Zed launch fails', async () => {
+    openInExternalEditorMock.mockResolvedValueOnce({ ok: false, reason: 'launch-failed' })
+
+    await openWorktreePath({
+      target: 'external-editor',
+      worktreePath: '/srv/project',
+      connectionId: null,
+      executionHostId: 'runtime:runtime-1',
+      command: 'zed'
+    })
+
+    expect(toastErrorMock).toHaveBeenCalledWith('Could not open the remote workspace.', {
+      description: 'Check the editor command configured on this machine.'
+    })
+  })
+
+  it('enables VS Code, Cursor, and Zed for SSH paths', () => {
     const entries = getWorktreeOpenInEntries(
       [
         { id: 'renamed', label: 'My Remote Editor', command: 'code-insiders' },
-        { id: 'fake', label: 'VS Code', command: 'cursor' },
+        { id: 'cursor', label: 'Cursor', command: 'cursor' },
+        { id: 'zed', label: 'Zed', command: 'zed' },
         { id: 'compound', label: 'VS Code Reuse', command: 'code --reuse-window' }
       ],
       'Finder'
@@ -242,14 +360,18 @@ describe('WorktreeOpenInMenu', () => {
       metadata: 'Remote SSH'
     })
     expect(getOpenInEntryAvailability(entries[1], mockState.settings, 'ssh-1')).toEqual({
-      disabled: true,
-      metadata: 'Local only'
+      disabled: false,
+      metadata: 'Remote SSH'
     })
     expect(getOpenInEntryAvailability(entries[2], mockState.settings, 'ssh-1')).toEqual({
+      disabled: false,
+      metadata: 'Remote SSH'
+    })
+    expect(getOpenInEntryAvailability(entries[3], mockState.settings, 'ssh-1')).toEqual({
       disabled: true,
       metadata: 'Local only'
     })
-    expect(getOpenInEntryAvailability(entries[3], mockState.settings, 'ssh-1')).toEqual({
+    expect(getOpenInEntryAvailability(entries[4], mockState.settings, 'ssh-1')).toEqual({
       disabled: true,
       metadata: 'Local only'
     })
@@ -270,17 +392,17 @@ describe('WorktreeOpenInMenu', () => {
     })
   })
 
-  it('blocks SSH local-only launchers before IPC with actionable copy', async () => {
+  it('blocks SSH compound launchers before IPC with actionable copy', async () => {
     await openWorktreePath({
       target: 'external-editor',
       worktreePath: '/home/ada/project',
       connectionId: 'ssh-1',
-      command: 'cursor'
+      command: 'code --reuse-window'
     })
 
     expect(openInExternalEditorMock).not.toHaveBeenCalled()
-    expect(toastErrorMock).toHaveBeenCalledWith('This app cannot open SSH workspaces.', {
-      description: 'Choose VS Code or use the app locally.'
+    expect(toastErrorMock).toHaveBeenCalledWith('This app cannot open remote workspaces.', {
+      description: 'Choose an editor with remote workspace support or use the app locally.'
     })
   })
 

--- a/src/renderer/src/components/sidebar/WorktreeOpenInMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeOpenInMenu.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback } from 'react'
 import { ExternalLink, FolderOpen } from 'lucide-react'
-import { toast } from 'sonner'
 import {
   DropdownMenuItem,
   DropdownMenuSeparator,
@@ -14,7 +13,8 @@ import { getLocalFileManagerLabel } from '@/lib/local-file-manager-label'
 import { OpenInApplicationIcon } from '@/lib/open-in-app-catalog'
 import { getExternalEditorOpenCapability } from '@/lib/external-editor-open-capability'
 import { NO_OPEN_IN_APPLICATIONS } from '@/lib/open-in-application-selection'
-import type { ShellOpenExternalEditorResult } from '../../../../shared/shell-open-types'
+import { showWorktreeOpenFailureToast } from './worktree-open-failure-toast'
+import { parseExecutionHostId, type ExecutionHostId } from '../../../../shared/execution-host'
 import type { GlobalSettings } from '../../../../shared/global-settings-types'
 import type { OpenInApplication } from '../../../../shared/ui-chrome-types'
 import { translate } from '@/i18n/i18n'
@@ -24,6 +24,7 @@ export { getLocalFileManagerLabel } from '@/lib/local-file-manager-label'
 type WorktreeOpenInMenuItemsProps = {
   worktreePath: string
   connectionId?: string | null
+  executionHostId?: ExecutionHostId
   disabled?: boolean
   labelPrefix?: string
 }
@@ -53,10 +54,11 @@ export function getWorktreeOpenInEntries(
 export function getOpenInEntryAvailability(
   entry: OpenInMenuEntry,
   settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined,
-  connectionId?: string | null
+  connectionId?: string | null,
+  executionHostId?: ExecutionHostId
 ): { disabled: boolean; metadata?: string } {
   if (entry.target === 'file-manager') {
-    const disabled = isLocalPathOpenBlocked(settings, { connectionId })
+    const disabled = isFileManagerOpenBlocked(settings, connectionId, executionHostId)
     return disabled
       ? {
           disabled: true,
@@ -66,7 +68,8 @@ export function getOpenInEntryAvailability(
   }
   const capability = getExternalEditorOpenCapability(settings, {
     connectionId,
-    command: entry.command
+    command: entry.command,
+    executionHostId
   })
   if (!capability.allowed) {
     return {
@@ -80,152 +83,6 @@ export function getOpenInEntryAvailability(
         metadata: translate('auto.components.sidebar.WorktreeOpenInMenu.remoteSsh', 'Remote SSH')
       }
     : { disabled: false }
-}
-
-function showOpenFailureToast(
-  result: Exclude<ShellOpenExternalEditorResult, { ok: true }>,
-  remote: boolean
-): void {
-  if (result.reason === 'remote-runtime-unsupported') {
-    toast.error(
-      translate(
-        'auto.components.sidebar.WorktreeOpenInMenu.remoteRuntimeUnsupported',
-        'Opening this path in a local app is not available.'
-      ),
-      {
-        description: translate(
-          'auto.components.sidebar.WorktreeOpenInMenu.remoteRuntimeUnsupportedDetail',
-          'Switch to a local or SSH workspace, then try again.'
-        )
-      }
-    )
-    return
-  }
-  if (result.reason === 'ssh-target-not-found') {
-    toast.error(
-      translate(
-        'auto.components.sidebar.WorktreeOpenInMenu.sshTargetNotFound',
-        'SSH host is no longer available.'
-      ),
-      {
-        description: translate(
-          'auto.components.sidebar.WorktreeOpenInMenu.sshTargetNotFoundDetail',
-          'Refresh workspaces or reconnect the host, then try again.'
-        )
-      }
-    )
-    return
-  }
-  if (result.reason === 'ssh-target-invalid') {
-    toast.error(
-      translate(
-        'auto.components.sidebar.WorktreeOpenInMenu.sshTargetInvalid',
-        'SSH host configuration is incomplete.'
-      ),
-      {
-        description: translate(
-          'auto.components.sidebar.WorktreeOpenInMenu.sshTargetInvalidDetail',
-          'Edit or reconnect the SSH host, then try again.'
-        )
-      }
-    )
-    return
-  }
-  if (result.reason === 'ssh-alias-required') {
-    toast.error(
-      translate(
-        'auto.components.sidebar.WorktreeOpenInMenu.sshAliasRequired',
-        'VS Code needs an SSH config alias for this host.'
-      ),
-      {
-        description: translate(
-          'auto.components.sidebar.WorktreeOpenInMenu.sshAliasRequiredDetail',
-          'Add a Host alias for {{host}}:{{port}} to your local SSH config, reconnect the workspace, then try again.',
-          { host: result.host, port: result.port }
-        )
-      }
-    )
-    return
-  }
-  if (result.reason === 'remote-editor-unsupported') {
-    toast.error(
-      translate(
-        'auto.components.sidebar.WorktreeOpenInMenu.remoteEditorUnsupported',
-        'This app cannot open SSH workspaces.'
-      ),
-      {
-        description: translate(
-          'auto.components.sidebar.WorktreeOpenInMenu.remoteEditorUnsupportedDetail',
-          'Choose VS Code or use the app locally.'
-        )
-      }
-    )
-    return
-  }
-  if (result.reason === 'not-absolute') {
-    toast.error(
-      remote
-        ? translate(
-            'auto.components.sidebar.WorktreeOpenInMenu.remotePathInvalid',
-            'Path is not valid for the SSH host.'
-          )
-        : translate(
-            'auto.components.sidebar.WorktreeOpenInMenu.f387af445b',
-            'Workspace path is not a valid local path.'
-          ),
-      remote
-        ? {
-            description: translate(
-              'auto.components.sidebar.WorktreeOpenInMenu.remotePathInvalidDetail',
-              'Refresh the workspace before trying again.'
-            )
-          }
-        : undefined
-    )
-    return
-  }
-  if (result.reason === 'not-found') {
-    toast.error(
-      translate(
-        'auto.components.sidebar.WorktreeOpenInMenu.3921d3d9a5',
-        'Workspace folder was not found.'
-      ),
-      {
-        description: translate(
-          'auto.components.sidebar.WorktreeOpenInMenu.0bed8727db',
-          'It may have been moved or deleted. Refresh workspaces or remove it from Orca.'
-        )
-      }
-    )
-    return
-  }
-  if (remote) {
-    toast.error(
-      translate(
-        'auto.components.sidebar.WorktreeOpenInMenu.remoteLaunchFailed',
-        'Could not open the path in VS Code.'
-      ),
-      {
-        description: translate(
-          'auto.components.sidebar.WorktreeOpenInMenu.remoteLaunchFailedDetail',
-          'Check the VS Code command configured on this machine.'
-        )
-      }
-    )
-    return
-  }
-  toast.error(
-    translate(
-      'auto.components.sidebar.WorktreeOpenInMenu.9a5381eb09',
-      'Could not open workspace folder.'
-    ),
-    {
-      description: translate(
-        'auto.components.sidebar.WorktreeOpenInMenu.bd0e8159f8',
-        'Check the editor command or file manager configuration on this machine.'
-      )
-    }
-  )
 }
 
 function stopMenuPropagation(event: React.SyntheticEvent): void {
@@ -242,28 +99,45 @@ export function openOpenInAppsSettings(): void {
   store.openSettingsPage()
 }
 
+function isFileManagerOpenBlocked(
+  settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined,
+  connectionId?: string | null,
+  executionHostId?: ExecutionHostId
+): boolean {
+  const hasExplicitExecutionHost = executionHostId !== undefined
+  const executionHost = parseExecutionHostId(executionHostId)
+  if (hasExplicitExecutionHost) {
+    return executionHost?.kind !== 'local' || Boolean(connectionId?.trim())
+  }
+  return isLocalPathOpenBlocked(settings, { connectionId })
+}
+
 export async function openWorktreePath(args: {
   target: 'file-manager' | 'external-editor'
   worktreePath: string
   connectionId?: string | null
+  executionHostId?: ExecutionHostId
   command?: string
 }): Promise<void> {
   const settings = useAppStore.getState().settings
+  const executionHost = parseExecutionHostId(args.executionHostId)
+  const remoteExecutionHost = executionHost?.kind === 'ssh' || executionHost?.kind === 'runtime'
   if (args.target === 'file-manager') {
-    if (isLocalPathOpenBlocked(settings, { connectionId: args.connectionId ?? null })) {
+    if (isFileManagerOpenBlocked(settings, args.connectionId, args.executionHostId)) {
       showLocalPathOpenBlockedToast()
       return
     }
   } else {
     const capability = getExternalEditorOpenCapability(settings, {
       connectionId: args.connectionId,
-      command: args.command
+      command: args.command,
+      executionHostId: args.executionHostId
     })
     if (!capability.allowed) {
       if (capability.reason === 'remote-runtime') {
-        showOpenFailureToast({ ok: false, reason: 'remote-runtime-unsupported' }, false)
+        showWorktreeOpenFailureToast({ ok: false, reason: 'remote-runtime-unsupported' }, false)
       } else {
-        showOpenFailureToast({ ok: false, reason: 'remote-editor-unsupported' }, true)
+        showWorktreeOpenFailureToast({ ok: false, reason: 'remote-editor-unsupported' }, true)
       }
       return
     }
@@ -271,39 +145,52 @@ export async function openWorktreePath(args: {
 
   const result =
     args.target === 'file-manager'
-      ? await window.api.shell.openInFileManager(args.worktreePath)
+      ? await window.api.shell.openInFileManager(args.worktreePath, args.executionHostId)
       : await window.api.shell.openInExternalEditor({
           path: args.worktreePath,
           command: args.command,
-          connectionId: args.connectionId
+          connectionId: args.connectionId,
+          executionHostId: args.executionHostId
         })
   if (!result.ok) {
-    showOpenFailureToast(result, Boolean(args.connectionId?.trim()))
+    showWorktreeOpenFailureToast(result, remoteExecutionHost || Boolean(args.connectionId?.trim()))
   }
 }
 
 function useOpenInWorktreePath({
   worktreePath,
-  connectionId
+  connectionId,
+  executionHostId
 }: WorktreeOpenInMenuItemsProps): (
   target: 'file-manager' | 'external-editor',
   command?: string
 ) => Promise<void> {
   return useCallback(
     async (target, command) => {
-      await openWorktreePath({ target, worktreePath, connectionId, command })
+      await openWorktreePath({
+        target,
+        worktreePath,
+        connectionId,
+        executionHostId,
+        command
+      })
     },
-    [connectionId, worktreePath]
+    [connectionId, executionHostId, worktreePath]
   )
 }
 
 export function WorktreeOpenInMenuItems({
   worktreePath,
   connectionId,
+  executionHostId,
   disabled,
   labelPrefix = ''
 }: WorktreeOpenInMenuItemsProps): React.JSX.Element {
-  const openInWorktreePath = useOpenInWorktreePath({ worktreePath, connectionId })
+  const openInWorktreePath = useOpenInWorktreePath({
+    worktreePath,
+    connectionId,
+    executionHostId
+  })
   const openInApplications = useAppStore(
     (s) => s.settings?.openInApplications ?? NO_OPEN_IN_APPLICATIONS
   )
@@ -314,7 +201,12 @@ export function WorktreeOpenInMenuItems({
   return (
     <>
       {entries.map((entry) => {
-        const availability = getOpenInEntryAvailability(entry, settings, connectionId)
+        const availability = getOpenInEntryAvailability(
+          entry,
+          settings,
+          connectionId,
+          executionHostId
+        )
         return (
           <DropdownMenuItem
             key={entry.id}
@@ -350,6 +242,7 @@ export function WorktreeOpenInMenuItems({
 export function WorktreeOpenInSubMenu({
   worktreePath,
   connectionId,
+  executionHostId,
   disabled
 }: WorktreeOpenInMenuItemsProps): React.JSX.Element {
   return (
@@ -366,6 +259,7 @@ export function WorktreeOpenInSubMenu({
         <WorktreeOpenInMenuItems
           worktreePath={worktreePath}
           connectionId={connectionId}
+          executionHostId={executionHostId}
           disabled={disabled}
         />
         <DropdownMenuSeparator />

--- a/src/renderer/src/components/sidebar/worktree-open-failure-toast.ts
+++ b/src/renderer/src/components/sidebar/worktree-open-failure-toast.ts
@@ -1,0 +1,164 @@
+import { toast } from 'sonner'
+import type { ShellOpenExternalEditorResult } from '../../../../shared/shell-open-types'
+import { translate } from '@/i18n/i18n'
+
+export function showWorktreeOpenFailureToast(
+  result: Exclude<ShellOpenExternalEditorResult, { ok: true }>,
+  remote: boolean
+): void {
+  if (result.reason === 'remote-runtime-unsupported') {
+    toast.error(
+      translate(
+        'auto.components.sidebar.WorktreeOpenInMenu.remoteRuntimeUnsupported',
+        'Opening this path in a local app is not available.'
+      ),
+      {
+        description: translate(
+          'auto.components.sidebar.WorktreeOpenInMenu.remoteRuntimeUnsupportedDetail',
+          'Switch to a local or SSH workspace, then try again.'
+        )
+      }
+    )
+    return
+  }
+  if (result.reason === 'runtime-ssh-target-required') {
+    toast.error(
+      translate(
+        'auto.components.sidebar.WorktreeOpenInMenu.runtimeSshTargetRequired',
+        'A matching SSH host is required.'
+      ),
+      {
+        description: translate(
+          'auto.components.sidebar.WorktreeOpenInMenu.runtimeSshTargetRequiredDetail',
+          'Add exactly one SSH host matching this Orca server, then try again.'
+        )
+      }
+    )
+    return
+  }
+  if (result.reason === 'ssh-target-not-found') {
+    toast.error(
+      translate(
+        'auto.components.sidebar.WorktreeOpenInMenu.sshTargetNotFound',
+        'SSH host is no longer available.'
+      ),
+      {
+        description: translate(
+          'auto.components.sidebar.WorktreeOpenInMenu.sshTargetNotFoundDetail',
+          'Refresh workspaces or reconnect the host, then try again.'
+        )
+      }
+    )
+    return
+  }
+  if (result.reason === 'ssh-target-invalid') {
+    toast.error(
+      translate(
+        'auto.components.sidebar.WorktreeOpenInMenu.sshTargetInvalid',
+        'SSH host configuration is incomplete.'
+      ),
+      {
+        description: translate(
+          'auto.components.sidebar.WorktreeOpenInMenu.sshTargetInvalidDetail',
+          'Edit or reconnect the SSH host, then try again.'
+        )
+      }
+    )
+    return
+  }
+  if (result.reason === 'ssh-alias-required') {
+    toast.error(
+      translate(
+        'auto.components.sidebar.WorktreeOpenInMenu.sshAliasRequired',
+        'VS Code needs an SSH config alias for this host.'
+      ),
+      {
+        description: translate(
+          'auto.components.sidebar.WorktreeOpenInMenu.sshAliasRequiredDetail',
+          'Add a Host alias for {{host}}:{{port}} to your local SSH config, reconnect the workspace, then try again.',
+          { host: result.host, port: result.port }
+        )
+      }
+    )
+    return
+  }
+  if (result.reason === 'remote-editor-unsupported') {
+    toast.error(
+      translate(
+        'auto.components.sidebar.WorktreeOpenInMenu.remoteEditorUnsupported',
+        'This app cannot open remote workspaces.'
+      ),
+      {
+        description: translate(
+          'auto.components.sidebar.WorktreeOpenInMenu.remoteEditorUnsupportedDetail',
+          'Choose an editor with remote workspace support or use the app locally.'
+        )
+      }
+    )
+    return
+  }
+  if (result.reason === 'not-absolute') {
+    toast.error(
+      remote
+        ? translate(
+            'auto.components.sidebar.WorktreeOpenInMenu.remotePathInvalid',
+            'Path is not valid for the SSH host.'
+          )
+        : translate(
+            'auto.components.sidebar.WorktreeOpenInMenu.f387af445b',
+            'Workspace path is not a valid local path.'
+          ),
+      remote
+        ? {
+            description: translate(
+              'auto.components.sidebar.WorktreeOpenInMenu.remotePathInvalidDetail',
+              'Refresh the workspace before trying again.'
+            )
+          }
+        : undefined
+    )
+    return
+  }
+  if (result.reason === 'not-found') {
+    toast.error(
+      translate(
+        'auto.components.sidebar.WorktreeOpenInMenu.3921d3d9a5',
+        'Workspace folder was not found.'
+      ),
+      {
+        description: translate(
+          'auto.components.sidebar.WorktreeOpenInMenu.0bed8727db',
+          'It may have been moved or deleted. Refresh workspaces or remove it from Orca.'
+        )
+      }
+    )
+    return
+  }
+  if (remote) {
+    toast.error(
+      translate(
+        'auto.components.sidebar.WorktreeOpenInMenu.remoteLaunchFailed',
+        'Could not open the remote workspace.'
+      ),
+      {
+        description: translate(
+          'auto.components.sidebar.WorktreeOpenInMenu.remoteLaunchFailedDetail',
+          'Check the editor command configured on this machine.'
+        )
+      }
+    )
+    return
+  }
+  toast.error(
+    translate(
+      'auto.components.sidebar.WorktreeOpenInMenu.9a5381eb09',
+      'Could not open workspace folder.'
+    ),
+    {
+      description: translate(
+        'auto.components.sidebar.WorktreeOpenInMenu.bd0e8159f8',
+        'Check the editor command or file manager configuration on this machine.'
+      )
+    }
+  )
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5369,12 +5369,12 @@
           "sshTargetInvalidDetail": "Edit or reconnect the SSH host, then try again.",
           "sshAliasRequired": "VS Code needs an SSH config alias for this host.",
           "sshAliasRequiredDetail": "Add a Host alias for {{host}}:{{port}} to your local SSH config, reconnect the workspace, then try again.",
-          "remoteEditorUnsupported": "This app cannot open SSH workspaces.",
-          "remoteEditorUnsupportedDetail": "Choose VS Code or use the app locally.",
+          "remoteEditorUnsupported": "This app cannot open remote workspaces.",
+          "remoteEditorUnsupportedDetail": "Choose an editor with remote workspace support or use the app locally.",
           "remotePathInvalid": "Path is not valid for the SSH host.",
           "remotePathInvalidDetail": "Refresh the workspace before trying again.",
-          "remoteLaunchFailed": "Could not open the path in VS Code.",
-          "remoteLaunchFailedDetail": "Check the VS Code command configured on this machine.",
+          "remoteLaunchFailed": "Could not open the remote workspace.",
+          "remoteLaunchFailedDetail": "Check the editor command configured on this machine.",
           "1417fd8380": "Customize apps...",
           "8009ab69a6": "Open in",
           "bd0e8159f8": "Check the editor command or file manager configuration on this machine.",
@@ -5382,7 +5382,9 @@
           "0bed8727db": "It may have been moved or deleted. Refresh workspaces or remove it from Orca.",
           "3921d3d9a5": "Workspace folder was not found.",
           "f387af445b": "Workspace path is not a valid local path.",
-          "3ec372b664": "file-manager"
+          "3ec372b664": "file-manager",
+          "runtimeSshTargetRequired": "A matching SSH host is required.",
+          "runtimeSshTargetRequiredDetail": "Add exactly one SSH host matching this Orca server, then try again."
         },
         "WorktreeTitleInlineRename": {
           "2f42ae024f": "Unread:",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -4666,12 +4666,12 @@
           "sshTargetInvalidDetail": "Edit or reconnect the SSH host, then try again.",
           "sshAliasRequired": "VS Code needs an SSH config alias for this host.",
           "sshAliasRequiredDetail": "Add a Host alias for {{host}}:{{port}} to your local SSH config, reconnect the workspace, then try again.",
-          "remoteEditorUnsupported": "This app cannot open SSH workspaces.",
-          "remoteEditorUnsupportedDetail": "Choose VS Code or use the app locally.",
+          "remoteEditorUnsupported": "Esta aplicación no puede abrir espacios de trabajo remotos.",
+          "remoteEditorUnsupportedDetail": "Elige un editor compatible con espacios de trabajo remotos o usa la aplicación localmente.",
           "remotePathInvalid": "Path is not valid for the SSH host.",
           "remotePathInvalidDetail": "Refresh the workspace before trying again.",
-          "remoteLaunchFailed": "Could not open the path in VS Code.",
-          "remoteLaunchFailedDetail": "Check the VS Code command configured on this machine."
+          "remoteLaunchFailed": "No se pudo abrir el espacio de trabajo remoto.",
+          "remoteLaunchFailedDetail": "Comprueba el comando del editor configurado en este equipo."
         },
         "WorktreeTitleInlineRename": {
           "2f42ae024f": "No leído:",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -4647,12 +4647,12 @@
           "sshTargetInvalidDetail": "SSH ホストを編集するか再接続してから、もう一度お試しください。",
           "sshAliasRequired": "VS Code には、このホストの SSH 設定エイリアスが必要です。",
           "sshAliasRequiredDetail": "ローカルの SSH 設定に {{host}}:{{port}} の Host エイリアスを追加し、ワークスペースを再接続してから、もう一度お試しください。",
-          "remoteEditorUnsupported": "このアプリは SSH ワークスペースを開けません。",
-          "remoteEditorUnsupportedDetail": "VS Code を選択するか、このアプリをローカルで使用してください。",
+          "remoteEditorUnsupported": "このアプリはリモートワークスペースを開けません。",
+          "remoteEditorUnsupportedDetail": "リモートワークスペースに対応したエディターを選択するか、アプリをローカルで使用してください。",
           "remotePathInvalid": "このパスは SSH ホストでは無効です。",
           "remotePathInvalidDetail": "ワークスペースを更新してから、もう一度お試しください。",
-          "remoteLaunchFailed": "VS Code でパスを開けませんでした。",
-          "remoteLaunchFailedDetail": "このマシンに設定されている VS Code のコマンドを確認してください。"
+          "remoteLaunchFailed": "リモートワークスペースを開けませんでした。",
+          "remoteLaunchFailedDetail": "このマシンに設定されているエディターコマンドを確認してください。"
         },
         "WorktreeTitleInlineRename": {
           "2f42ae024f": "未読:",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -4649,12 +4649,12 @@
           "sshTargetInvalidDetail": "Edit or reconnect the SSH host, then try again.",
           "sshAliasRequired": "VS Code needs an SSH config alias for this host.",
           "sshAliasRequiredDetail": "Add a Host alias for {{host}}:{{port}} to your local SSH config, reconnect the workspace, then try again.",
-          "remoteEditorUnsupported": "This app cannot open SSH workspaces.",
-          "remoteEditorUnsupportedDetail": "Choose VS Code or use the app locally.",
+          "remoteEditorUnsupported": "이 앱은 원격 워크스페이스를 열 수 없습니다.",
+          "remoteEditorUnsupportedDetail": "원격 워크스페이스를 지원하는 편집기를 선택하거나 앱을 로컬에서 사용하세요.",
           "remotePathInvalid": "Path is not valid for the SSH host.",
           "remotePathInvalidDetail": "Refresh the workspace before trying again.",
-          "remoteLaunchFailed": "Could not open the path in VS Code.",
-          "remoteLaunchFailedDetail": "Check the VS Code command configured on this machine."
+          "remoteLaunchFailed": "원격 워크스페이스를 열 수 없습니다.",
+          "remoteLaunchFailedDetail": "이 머신에 구성된 편집기 명령을 확인하세요."
         },
         "WorktreeTitleInlineRename": {
           "2f42ae024f": "읽지 않음:",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -4659,12 +4659,12 @@
           "sshTargetInvalidDetail": "请编辑或重新连接 SSH 主机，然后重试。",
           "sshAliasRequired": "VS Code 需要此主机的 SSH 配置别名。",
           "sshAliasRequiredDetail": "请在本地 SSH 配置中为 {{host}}:{{port}} 添加 Host 别名，重新连接工作区，然后重试。",
-          "remoteEditorUnsupported": "此应用无法打开 SSH 工作区。",
-          "remoteEditorUnsupportedDetail": "请选择 VS Code 或在本地使用该应用。",
+          "remoteEditorUnsupported": "此应用无法打开远程工作区。",
+          "remoteEditorUnsupportedDetail": "请选择支持远程工作区的编辑器，或在本地使用此应用。",
           "remotePathInvalid": "路径对此 SSH 主机无效。",
           "remotePathInvalidDetail": "请先刷新工作区，再重试。",
-          "remoteLaunchFailed": "无法在 VS Code 中打开此路径。",
-          "remoteLaunchFailedDetail": "请检查此机器上配置的 VS Code 命令。"
+          "remoteLaunchFailed": "无法打开远程工作区。",
+          "remoteLaunchFailedDetail": "请检查此机器上配置的编辑器命令。"
         },
         "WorktreeTitleInlineRename": {
           "2f42ae024f": "未读：",

--- a/src/renderer/src/lib/external-editor-open-capability.test.ts
+++ b/src/renderer/src/lib/external-editor-open-capability.test.ts
@@ -20,13 +20,16 @@ describe('getExternalEditorOpenCapability', () => {
     ).toEqual({ allowed: true, remote: true })
   })
 
-  it('rejects non-VS Code and compound commands for SSH paths', () => {
+  it.each(['cursor', 'zed'])('allows %s for SSH paths', (command) => {
     expect(
       getExternalEditorOpenCapability(
         { activeRuntimeEnvironmentId: null },
-        { connectionId: 'ssh-1', command: 'cursor' }
+        { connectionId: 'ssh-1', command }
       )
-    ).toEqual({ allowed: false, reason: 'local-only-editor' })
+    ).toEqual({ allowed: true, remote: true })
+  })
+
+  it('rejects compound commands for SSH paths', () => {
     expect(
       getExternalEditorOpenCapability(
         { activeRuntimeEnvironmentId: null },
@@ -35,7 +38,40 @@ describe('getExternalEditorOpenCapability', () => {
     ).toEqual({ allowed: false, reason: 'local-only-editor' })
   })
 
-  it('rejects every local-app launch while a remote runtime is active', () => {
+  it.each(['code', 'code-insiders', 'cursor', 'zed'])(
+    'allows the remote-capable launcher %s for a runtime-owned worktree',
+    (command) => {
+      expect(
+        getExternalEditorOpenCapability(
+          { activeRuntimeEnvironmentId: null },
+          { executionHostId: 'runtime:runtime-1', command }
+        )
+      ).toEqual({ allowed: true, remote: true })
+    }
+  )
+
+  it.each(['code --reuse-window', 'zed --new'])(
+    'rejects the unsupported runtime launcher %s',
+    (command) => {
+      expect(
+        getExternalEditorOpenCapability(
+          { activeRuntimeEnvironmentId: null },
+          { executionHostId: 'runtime:runtime-1', command }
+        )
+      ).toEqual({ allowed: false, reason: 'local-only-editor' })
+    }
+  )
+
+  it('keeps explicit local ownership local while another runtime is active', () => {
+    expect(
+      getExternalEditorOpenCapability(
+        { activeRuntimeEnvironmentId: 'runtime-1' },
+        { executionHostId: 'local', command: 'cursor' }
+      )
+    ).toEqual({ allowed: true, remote: false })
+  })
+
+  it('rejects legacy requests without host provenance while a remote runtime is active', () => {
     expect(
       getExternalEditorOpenCapability(
         { activeRuntimeEnvironmentId: 'runtime-1' },

--- a/src/renderer/src/lib/external-editor-open-capability.ts
+++ b/src/renderer/src/lib/external-editor-open-capability.ts
@@ -1,5 +1,8 @@
+import { isCursorRemoteSshCommand } from '../../../shared/cursor-remote-ssh-launcher'
+import { parseExecutionHostId, type ExecutionHostId } from '../../../shared/execution-host'
 import type { GlobalSettings } from '../../../shared/global-settings-types'
 import { isVsCodeRemoteSshCommand } from '../../../shared/vscode-remote-ssh-launcher'
+import { isZedRemoteSshCommand } from '../../../shared/zed-remote-ssh-launcher'
 
 export type ExternalEditorOpenCapability =
   | { allowed: true; remote: boolean }
@@ -7,15 +10,33 @@ export type ExternalEditorOpenCapability =
 
 export function getExternalEditorOpenCapability(
   settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined,
-  context: { connectionId?: string | null; command?: string }
+  context: { connectionId?: string | null; command?: string; executionHostId?: ExecutionHostId }
 ): ExternalEditorOpenCapability {
-  if (settings?.activeRuntimeEnvironmentId?.trim()) {
+  const hasExplicitExecutionHost = context.executionHostId !== undefined
+  const executionHost = parseExecutionHostId(context.executionHostId)
+  if (hasExplicitExecutionHost && !executionHost) {
     return { allowed: false, reason: 'remote-runtime' }
   }
-  if (!context.connectionId?.trim()) {
+  if (executionHost?.kind === 'runtime') {
+    return isVsCodeRemoteSshCommand(context.command) ||
+      isCursorRemoteSshCommand(context.command) ||
+      isZedRemoteSshCommand(context.command)
+      ? { allowed: true, remote: true }
+      : { allowed: false, reason: 'local-only-editor' }
+  }
+  if (executionHost?.kind === 'local') {
     return { allowed: true, remote: false }
   }
-  return isVsCodeRemoteSshCommand(context.command)
+  if (!hasExplicitExecutionHost && settings?.activeRuntimeEnvironmentId?.trim()) {
+    return { allowed: false, reason: 'remote-runtime' }
+  }
+  const hasSshContext = executionHost?.kind === 'ssh' || context.connectionId?.trim()
+  if (!hasSshContext) {
+    return { allowed: true, remote: false }
+  }
+  return isVsCodeRemoteSshCommand(context.command) ||
+    isCursorRemoteSshCommand(context.command) ||
+    isZedRemoteSshCommand(context.command)
     ? { allowed: true, remote: true }
     : { allowed: false, reason: 'local-only-editor' }
 }

--- a/src/shared/cursor-remote-ssh-launcher.test.ts
+++ b/src/shared/cursor-remote-ssh-launcher.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { isCursorLauncherExecutable, isCursorRemoteSshCommand } from './cursor-remote-ssh-launcher'
+
+describe('Cursor Remote-SSH launcher capability', () => {
+  it.each([
+    'cursor',
+    'cursor.cmd',
+    '/usr/local/bin/cursor',
+    '/Applications/Cursor.app/Contents/Resources/app/bin/cursor',
+    'C:\\Program Files\\Cursor\\Cursor.exe',
+    'C:\\Tools\\CURSOR.CMD'
+  ])('recognizes a safe configured launcher: %s', (command) => {
+    expect(isCursorLauncherExecutable(command)).toBe(true)
+    expect(isCursorRemoteSshCommand(command)).toBe(true)
+  })
+
+  it.each([
+    'code',
+    'cursor.bat',
+    'tools/cursor',
+    '.\\cursor.exe',
+    'cursor --new-window',
+    'cmd /c cursor',
+    'C:\\Tools\\cursor helper.cmd'
+  ])('rejects an unsupported or compound launcher: %s', (command) => {
+    expect(isCursorRemoteSshCommand(command)).toBe(false)
+  })
+})

--- a/src/shared/cursor-remote-ssh-launcher.ts
+++ b/src/shared/cursor-remote-ssh-launcher.ts
@@ -1,0 +1,32 @@
+const CURSOR_LAUNCHER_PATTERN = /^cursor(?:\.(?:cmd|exe))?$/i
+const WINDOWS_ABSOLUTE_PATH = /^(?:[a-z]:[\\/]|\\\\)/i
+
+function stripMatchingQuotes(value: string): string {
+  const trimmed = value.trim()
+  const quote = trimmed[0]
+  if ((quote === '"' || quote === "'") && trimmed.endsWith(quote)) {
+    return trimmed.slice(1, -1)
+  }
+  return trimmed
+}
+
+export function isCursorLauncherExecutable(command: string): boolean {
+  const unquoted = stripMatchingQuotes(command)
+  const segments = unquoted.split(/[\\/]/)
+  const fileName = segments.at(-1) ?? ''
+  return CURSOR_LAUNCHER_PATTERN.test(fileName)
+}
+
+export function isCursorRemoteSshCommand(command: string | undefined): boolean {
+  const trimmed = command?.trim()
+  if (!trimmed) {
+    return false
+  }
+  const unquoted = stripMatchingQuotes(trimmed)
+  const isAbsolutePath = unquoted.startsWith('/') || WINDOWS_ABSOLUTE_PATH.test(unquoted)
+  const hasPathSeparator = /[\\/]/.test(unquoted)
+  if ((hasPathSeparator || /\s/.test(unquoted)) && !isAbsolutePath) {
+    return false
+  }
+  return isCursorLauncherExecutable(unquoted)
+}

--- a/src/shared/shell-open-types.ts
+++ b/src/shared/shell-open-types.ts
@@ -1,7 +1,10 @@
+import type { ExecutionHostId } from './execution-host'
+
 export type ShellOpenExternalEditorRequest = {
   path: string
   command?: string
   connectionId?: string | null
+  executionHostId?: ExecutionHostId
 }
 
 export type ShellOpenPathFailureReason =
@@ -13,6 +16,7 @@ export type ShellOpenPathFailureReason =
   | 'ssh-target-invalid'
   | 'ssh-alias-required'
   | 'remote-editor-unsupported'
+  | 'runtime-ssh-target-required'
 
 export type ShellOpenLocalPathFailureReason = Extract<
   ShellOpenPathFailureReason,

--- a/src/shared/zed-remote-ssh-launcher.ts
+++ b/src/shared/zed-remote-ssh-launcher.ts
@@ -1,0 +1,46 @@
+const ZED_LAUNCHER_NAMES = new Set(['zed'])
+const WINDOWS_ABSOLUTE_PATH = /^(?:[a-z]:[\\/]|\\\\)/i
+
+function stripMatchingQuotes(value: string): string {
+  const trimmed = value.trim()
+  const quote = trimmed[0]
+  if ((quote === '"' || quote === "'") && trimmed.endsWith(quote)) {
+    return trimmed.slice(1, -1)
+  }
+  return trimmed
+}
+
+export function getZedLauncherCommandToken(command: string): string {
+  const trimmed = command.trim()
+  const quote = trimmed[0]
+  if (quote === '"' || quote === "'") {
+    const closingIndex = trimmed.indexOf(quote, 1)
+    if (closingIndex > 0) {
+      return stripMatchingQuotes(trimmed.slice(0, closingIndex + 1))
+    }
+  }
+  return stripMatchingQuotes(trimmed.split(/\s+/, 1)[0] ?? '')
+}
+
+export function isZedLauncherExecutable(command: string): boolean {
+  const unquoted = stripMatchingQuotes(command)
+  const segments = unquoted.split(/[\\/]/)
+  const fileName = segments.at(-1) ?? ''
+  const launcherName = fileName.replace(/\.(?:cmd|exe|bat)$/i, '').toLowerCase()
+  return ZED_LAUNCHER_NAMES.has(launcherName)
+}
+
+export function isZedRemoteSshCommand(command: string | undefined): boolean {
+  const trimmed = command?.trim()
+  if (!trimmed) {
+    return false
+  }
+  const commandToken = getZedLauncherCommandToken(trimmed)
+  const unquoted = stripMatchingQuotes(trimmed)
+  const isAbsolutePath = commandToken.startsWith('/') || WINDOWS_ABSOLUTE_PATH.test(commandToken)
+  const hasArguments = unquoted !== commandToken
+  if (hasArguments && !isAbsolutePath) {
+    return false
+  }
+  return isZedLauncherExecutable(commandToken)
+}


### PR DESCRIPTION
## ELI5

When a worktree lives on a Headless Runtime, Orca should ask a remote-capable editor to open that server path. Previously it treated paths such as `/workspaces/project` as local Windows paths and reported that the folder did not exist.

## What Changed

- propagate the clicked worktree execution host through worktree, File Explorer, and Source Control **Open in** actions
- resolve direct user-managed Runtime endpoints to one eligible local OpenSSH target
- launch VS Code and Cursor with Remote-SSH arguments and Zed with an encoded SSH URL
- derive Source Control connection ownership from the worktree host, not the repository ambient connection
- reject stale Runtime endpoint preferences instead of falling back to another endpoint
- keep local paths local and reject unsupported or ambiguous remote topology

## Why

A Runtime WebSocket endpoint identifies the Orca server but is not automatically a valid SSH authority. Matching it to an explicit user-managed SSH target preserves ownership, avoids client-side filesystem checks for server paths, and fails closed when Orca cannot determine one safe route.

## Linked Issue

N/A. The original report previously referenced as issue 13929 is no longer publicly accessible. The reproduced failure and supported topology are documented in this PR.

## Visual Proof

N/A - there is no in-app layout change. The behavior launches an external editor process; routing, argv, encoded URLs, and failure copy are verified by tests.

## Testing

Validated on Windows with Windows OpenSSH and a Linux Headless Runtime. Runtime VS Code, Cursor, and Zed flows were manually exercised; the review follow-ups are covered by deterministic launch/routing tests.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated
- 11 focused test files: 237 tests passed
- Node and Web TypeScript checks passed
- Oxfmt and Oxlint passed on every changed TypeScript file
- max-lines ratchet passed
- localization catalog and coverage checks passed
- Electron-Vite production build passed
- Web projection verification passed (879 files, 42.5 MiB)

## AI Disclosure

OpenAI Codex (GPT-5) assisted with investigation, implementation, regression tests, and review-response analysis. All changes were inspected and validated before push.

## Review

CodeRabbit follow-ups addressed:

- ordinary SSH Zed opens now use the Zed SSH URL launcher
- stale preferred Runtime endpoints fail closed
- Source Control derives the SSH connection from worktree ownership
- unsupported editor copy now applies accurately to SSH and Runtime workspaces

Independent read-only reviews were also run against the PR migration and follow-up diff.

## Agent skill upstream boundary

- [x] Not applicable; this change copies or translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- No Runtime wire schema or capability opcode changes
- Existing execution-host IPC arguments remain optional for compatibility
- Runtime paths never use client-side `stat`, `existsSync`, or local normalization
- loopback, SSH tunnels, reverse-proxy paths, wildcard/zero-port endpoints, ephemeral VMs, nested SSH, Runtime-owned targets, missing matches, and ambiguous matches fail closed
- Zed remains POSIX-remote-only because Zed Remote SSH does not support Windows remote hosts
- No broad docstrings were added; repository guidance requires concise comments only for non-obvious reasoning

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Visual proof is marked N/A with the process-routing reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path impact considered
- [x] Focused lint, typecheck, tests, and production builds pass; upstream CI remains authoritative

## Author

GitHub: @mozhu811