### PR TITLE
Prevent tab search results from jumping while typing

### DIFF
--- a/src/renderer/src/components/tab-bar/TabBarCreateEntry.tab-results.test.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntry.tab-results.test.tsx
@@ -27,15 +27,63 @@ vi.mock('@/lib/agent-catalog', () => ({
 
 // `hold` stands in for the hook's deferred query: it pins the results to the
 // query they were built from, so later keystrokes leave them stale.
-const tabSearchMock = vi.hoisted(() => ({
-  hold: null as string | null,
-  resultsByQuery: {} as Record<string, unknown[]>
-}))
+const tabSearchMock = vi.hoisted(() => {
+  const worktree = {
+    id: 'wt',
+    repoId: 'repo-1',
+    path: '/tmp/wt',
+    hostId: 'local',
+    displayName: 'Aurora Workspace'
+  }
+  return {
+    hold: null as string | null,
+    resultsByQuery: {} as Record<string, unknown[]>,
+    // Retention re-checks each row against the live query with the real engines,
+    // so every registered row needs the searchable entry it came from.
+    entries(): unknown {
+      const rows = Object.values(tabSearchMock.resultsByQuery).flat() as {
+        source: string
+        tabId?: string
+        title: string
+        contentType: string
+        relativePath?: string | null
+      }[]
+      return {
+        browserPages: [],
+        simulatorTabs: [],
+        workspaceTabs: rows
+          .filter((row) => row.source === 'workspace')
+          .map((row) => ({
+            tab: {
+              id: row.tabId,
+              entityId: `${row.tabId}-entity`,
+              groupId: 'g',
+              worktreeId: worktree.id,
+              contentType: row.contentType
+            },
+            worktree,
+            repoName: 'octo/rocket',
+            worktreeSortIndex: 0,
+            groupSortIndex: 0,
+            tabSortIndex: 0,
+            title: row.title,
+            secondaryText: row.relativePath ?? '',
+            titleSearchText: row.title,
+            secondarySearchTexts: row.relativePath ? [row.relativePath] : [],
+            agentMetadata: [],
+            isCurrentTab: false,
+            isCurrentWorktree: true
+          }))
+      }
+    }
+  }
+})
 vi.mock('./use-open-tab-search', () => ({
   useOpenTabSearch: ({ enabled, query }: { enabled: boolean; query: string }) => {
     const resolved = tabSearchMock.hold ?? query
     return {
       query: enabled ? resolved : query,
+      entries: enabled ? tabSearchMock.entries() : null,
       results: enabled ? (tabSearchMock.resultsByQuery[resolved.trim()] ?? []) : []
     }
   }

--- a/src/renderer/src/components/tab-bar/TabBarCreateEntry.tab-results.test.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntry.tab-results.test.tsx
@@ -274,7 +274,27 @@ describe('TabBarCreateEntry tab results', () => {
     expect(activationMocks.workspace).not.toHaveBeenCalled()
   })
 
-  it('drops tab rows built for an earlier query until the search catches up', () => {
+  it('keeps a deferred tab row that still matches the newer query', () => {
+    entryOptionsMock.options = [newFileOption]
+    tabSearchMock.resultsByQuery['add tab'] = [terminalResult()]
+    const onOpenEntry = vi.fn().mockResolvedValue(undefined)
+    renderEntry({ onOpenEntry })
+
+    setQuery('add tab')
+    expect(rowTexts()[0]).toContain('Switch to tab')
+
+    // The user backspaces; the deferred search still describes 'add tab'.
+    tabSearchMock.hold = 'add tab'
+    setQuery('add ta')
+
+    expect(rowTexts()[0]).toContain('Switch to tab')
+    submitForm()
+
+    expect(activationMocks.workspace).toHaveBeenCalledTimes(1)
+    expect(onOpenEntry).not.toHaveBeenCalled()
+  })
+
+  it('drops a deferred tab row that the newer query no longer matches', () => {
     entryOptionsMock.options = [newFileOption]
     tabSearchMock.resultsByQuery['add tab'] = [terminalResult()]
     const onOpenEntry = vi.fn().mockResolvedValue(undefined)

--- a/src/renderer/src/components/tab-bar/TabBarCreateEntry.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntry.tsx
@@ -21,7 +21,7 @@ import {
 } from './TabBarCreateEntryRow'
 import { dropFileEntriesCoveredByTabResults } from './open-tab-entry-dedupe'
 import { activateOpenTabSearchResult } from './open-tab-selection-routing'
-import { useOpenTabSearch } from './use-open-tab-search'
+import { useTabCreateEntrySearchResults } from './use-tab-create-entry-search-results'
 import { DEFAULT_SEARCH_ENGINE } from '../../../../shared/browser-url'
 import { getRendererAppPlatform } from '@/lib/renderer-app-platform'
 import { useAppStore } from '@/store'
@@ -33,11 +33,7 @@ import {
   getTabEntryChooseActionMessage,
   getTabEntryOmniboxPlaceholder
 } from './tab-create-entry-copy'
-import {
-  EMPTY_AGENT_OPTIONS,
-  EMPTY_MENU_OPTIONS,
-  EMPTY_TAB_RESULTS
-} from './tab-create-entry-empty-options'
+import { EMPTY_AGENT_OPTIONS, EMPTY_MENU_OPTIONS } from './tab-create-entry-empty-options'
 import type { TabBarCreateEntryProps } from './tab-create-entry-props'
 
 export default function TabBarCreateEntry(props: TabBarCreateEntryProps): React.JSX.Element {
@@ -77,16 +73,11 @@ function TabBarCreateEntrySession({
   const rawQueryOversized = isQuickOpenQueryTooLarge(query)
   const forcedSearch = parseForcedSearchQuery(query)
   const terminalQueryMode = rawQueryOversized || forcedSearch.forced
-  const tabSearchQuery = terminalQueryMode ? '' : query
-  const tabSearch = useOpenTabSearch({
+  const tabResults = useTabCreateEntrySearchResults({
     enabled: menuOpen && !terminalQueryMode,
-    query: tabSearchQuery,
+    query,
     worktreeId
   })
-  // Why gate on the query: the search defers, so its rows can still describe an
-  // earlier query — Enter must never submit a tab the current query never matched.
-  const tabResults =
-    !terminalQueryMode && tabSearch.query === query ? tabSearch.results : EMPTY_TAB_RESULTS
   const shouldResolveAbsolutePaths =
     menuOpen && !terminalQueryMode && isTabEntryAbsolutePathLike(query.trim())
   const allowAbsolutePathsSelector = useMemo(

--- a/src/renderer/src/components/tab-bar/open-tab-search-retention.test.ts
+++ b/src/renderer/src/components/tab-bar/open-tab-search-retention.test.ts
@@ -1,114 +1,261 @@
 import { describe, expect, it } from 'vitest'
-import type { OpenTabSearchResult } from './open-tab-search'
+import type { BrowserPage, BrowserWorkspace } from '../../../../shared/browser-workspace-types'
+import type { Tab, TabContentType } from '../../../../shared/tab-types'
+import type { Worktree } from '../../../../shared/worktree/types'
+import type { SearchableBrowserPage } from '@/lib/browser-palette-search'
+import type { SearchableWorkspaceTab } from '@/lib/workspace-tab-palette-search'
+import { TERMINAL_TYPE_SEARCH_ALIASES } from '@/lib/workspace-tab-palette-search'
+import { searchOpenTabs } from './open-tab-search'
+import type { OpenTabSearchEntries } from './open-tab-search-entries'
 import { retainOpenTabResultsForQuery } from './open-tab-search-retention'
 
-function tabResult(overrides: Partial<OpenTabSearchResult> = {}): OpenTabSearchResult {
+const worktree: Worktree = {
+  id: 'wt-1',
+  repoId: 'repo-1',
+  path: '/tmp/wt-1',
+  head: 'abc123',
+  branch: 'refs/heads/main',
+  isBare: false,
+  isMainWorktree: false,
+  displayName: 'Aurora Workspace',
+  comment: '',
+  linkedIssue: null,
+  linkedPR: null,
+  linkedLinearIssue: null,
+  isArchived: false,
+  isUnread: false,
+  isPinned: false,
+  sortOrder: 0,
+  lastActivityAt: 0
+}
+
+function makeTab(id: string, contentType: TabContentType): Tab {
   return {
-    executionHostId: 'local',
-    source: 'workspace',
-    id: 'open-tab:workspace:tab-1',
-    title: 'Add tab search and jump in worktree',
-    matchedText: null,
-    worktreeId: 'wt',
-    contentType: 'terminal',
-    tabId: 'tab-1',
-    entityId: 'term-1',
-    groupId: 'g',
-    relativePath: null,
-    ...overrides
-  } as OpenTabSearchResult
+    id,
+    entityId: `${id}-entity`,
+    groupId: 'group-1',
+    worktreeId: worktree.id,
+    contentType,
+    label: id,
+    customLabel: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0
+  }
+}
+
+function makeWorkspaceTab({
+  id,
+  title,
+  contentType = 'terminal',
+  secondarySearchTexts = [],
+  agentSnippets = [],
+  typeSearchAliases
+}: {
+  id: string
+  title: string
+  contentType?: 'terminal' | 'editor'
+  secondarySearchTexts?: string[]
+  agentSnippets?: string[]
+  typeSearchAliases?: readonly string[]
+}): SearchableWorkspaceTab {
+  return {
+    tab: makeTab(id, contentType) as SearchableWorkspaceTab['tab'],
+    worktree,
+    repoName: 'octo/rocket',
+    worktreeSortIndex: 0,
+    groupSortIndex: 0,
+    tabSortIndex: 0,
+    title,
+    secondaryText: secondarySearchTexts[0] ?? '',
+    titleSearchText: title,
+    secondarySearchTexts,
+    typeSearchAliases:
+      typeSearchAliases ?? (contentType === 'terminal' ? TERMINAL_TYPE_SEARCH_ALIASES : undefined),
+    agentMetadata: agentSnippets.length
+      ? [{ paneKey: `${id}-pane`, textParts: [], snippetCandidates: agentSnippets }]
+      : [],
+    isCurrentTab: false,
+    isCurrentWorktree: true
+  }
+}
+
+function makeBrowserPage({
+  id,
+  title,
+  workspaceLabel
+}: {
+  id: string
+  title: string
+  workspaceLabel?: string
+}): SearchableBrowserPage {
+  const url = 'https://example.com/one'
+  const page: BrowserPage = {
+    id,
+    workspaceId: `${id}-ws`,
+    worktreeId: worktree.id,
+    url,
+    title,
+    loading: false,
+    faviconUrl: null,
+    canGoBack: false,
+    canGoForward: false,
+    loadError: null,
+    createdAt: 0
+  }
+  const workspace: BrowserWorkspace = {
+    id: `${id}-ws`,
+    worktreeId: worktree.id,
+    activePageId: id,
+    pageIds: [id],
+    url,
+    title,
+    label: workspaceLabel,
+    loading: false,
+    faviconUrl: null,
+    canGoBack: false,
+    canGoForward: false,
+    loadError: null,
+    createdAt: 0
+  }
+  return {
+    page,
+    workspace,
+    worktree,
+    repoName: 'octo/rocket',
+    worktreeSortIndex: 0,
+    isCurrentPage: false,
+    isCurrentWorktree: true
+  }
+}
+
+function makeEntries(overrides: Partial<OpenTabSearchEntries> = {}): OpenTabSearchEntries {
+  return { workspaceTabs: [], browserPages: [], simulatorTabs: [], ...overrides }
+}
+
+// Mirrors the hook: the deferred query builds the rows, the live query re-checks them.
+function retain({
+  entries,
+  deferredQuery,
+  query
+}: {
+  entries: OpenTabSearchEntries
+  deferredQuery: string
+  query: string
+}): { titles: string[]; sameList: boolean } {
+  const results = searchOpenTabs({ ...entries, query: deferredQuery })
+  const retained = retainOpenTabResultsForQuery({
+    entries,
+    query,
+    results,
+    resultsQuery: deferredQuery
+  })
+  return { titles: retained.map((result) => result.title), sameList: retained === results }
 }
 
 describe('retainOpenTabResultsForQuery', () => {
-  const results = [tabResult()]
+  const entries = makeEntries({
+    workspaceTabs: [makeWorkspaceTab({ id: 'tab-1', title: 'Add tab search and jump in worktree' })]
+  })
 
   it('returns the same list when the deferred query has caught up', () => {
-    expect(
-      retainOpenTabResultsForQuery({
-        query: 'add tab',
-        results,
-        resultsQuery: 'add tab'
-      })
-    ).toBe(results)
+    expect(retain({ entries, deferredQuery: 'add tab', query: 'add tab' })).toEqual({
+      titles: ['Add tab search and jump in worktree'],
+      sameList: true
+    })
   })
 
   it('treats extra surrounding whitespace as the same query', () => {
-    expect(
-      retainOpenTabResultsForQuery({
-        query: '  add tab ',
-        results,
-        resultsQuery: 'add tab'
-      })
-    ).toBe(results)
+    expect(retain({ entries, deferredQuery: 'add tab', query: '  add tab ' })).toEqual({
+      titles: ['Add tab search and jump in worktree'],
+      sameList: true
+    })
   })
 
   it('keeps rows while the user backspaces into a prefix of the deferred query', () => {
-    expect(
-      retainOpenTabResultsForQuery({
-        query: 'add ta',
-        results,
-        resultsQuery: 'add tab'
-      })
-    ).toBe(results)
+    expect(retain({ entries, deferredQuery: 'add tab', query: 'add ta' }).titles).toEqual([
+      'Add tab search and jump in worktree'
+    ])
   })
 
-  it('keeps a row whose title still contains the newer query', () => {
-    expect(
-      retainOpenTabResultsForQuery({
-        query: 'jump in',
-        results,
-        resultsQuery: 'add tab'
-      })
-    ).toEqual(results)
+  it('keeps the same array when nothing was dropped, so the row memos hold', () => {
+    expect(retain({ entries, deferredQuery: 'add tab', query: 'add ta' }).sameList).toBe(true)
   })
 
-  it('keeps a row whose matched secondary text still contains the newer query', () => {
-    const secondary = [
-      tabResult({
-        title: 'Claude Code',
-        matchedText: 'fix the flaky retry test'
-      })
-    ]
-    expect(
-      retainOpenTabResultsForQuery({
-        query: 'flaky retry',
-        results: secondary,
-        resultsQuery: 'fix the'
-      })
-    ).toEqual(secondary)
-  })
-
-  it('keeps an editor row whose relative path still contains the newer query', () => {
-    const editor = [
-      tabResult({
-        title: 'zebra.ts',
-        contentType: 'editor',
-        relativePath: 'src/zebra.ts'
-      })
-    ]
-    expect(
-      retainOpenTabResultsForQuery({
-        query: 'zebra.ts',
-        results: editor,
-        resultsQuery: 'zeb'
-      })
-    ).toEqual(editor)
-  })
-
-  it('drops rows that no longer mention the newer query', () => {
-    expect(
-      retainOpenTabResultsForQuery({
-        query: 'add tabs',
-        results,
-        resultsQuery: 'add tab'
-      })
-    ).toEqual([])
+  it('drops rows the newer query no longer matches', () => {
+    expect(retain({ entries, deferredQuery: 'add tab', query: 'add tabs' }).titles).toEqual([])
   })
 
   it('drops every row once the live query is cleared', () => {
+    expect(retain({ entries, deferredQuery: 'add tab', query: '   ' }).titles).toEqual([])
+  })
+
+  // The row text alone cannot answer these three: the engines match fields the
+  // result never carries once the match came from somewhere else.
+  it('keeps a terminal row the newer query matches through its type alias', () => {
+    const aliased = makeEntries({
+      workspaceTabs: [makeWorkspaceTab({ id: 'tab-1', title: 'zsh' })]
+    })
+    expect(retain({ entries: aliased, deferredQuery: 'term', query: 'termin' }).titles).toEqual([
+      'zsh'
+    ])
+  })
+
+  it('keeps a browser row the newer query matches through its workspace label', () => {
+    const labelled = makeEntries({
+      browserPages: [
+        makeBrowserPage({ id: 'page-1', title: 'Untitled', workspaceLabel: 'Release checklist' })
+      ]
+    })
+    expect(retain({ entries: labelled, deferredQuery: 'rele', query: 'release c' }).titles).toEqual(
+      ['Untitled']
+    )
+  })
+
+  it('keeps an editor row the newer query matches through its absolute path', () => {
+    const editor = makeEntries({
+      workspaceTabs: [
+        makeWorkspaceTab({
+          id: 'tab-1',
+          title: 'zebra.ts',
+          contentType: 'editor',
+          secondarySearchTexts: ['src/zebra.ts', '/tmp/wt-1/src/zebra.ts']
+        })
+      ]
+    })
+    expect(
+      retain({ entries: editor, deferredQuery: 'zeb', query: '/tmp/wt-1/src' }).titles
+    ).toEqual(['zebra.ts'])
+  })
+
+  it('keeps a row the newer query matches through an agent snippet', () => {
+    const withAgent = makeEntries({
+      workspaceTabs: [
+        makeWorkspaceTab({
+          id: 'tab-1',
+          title: 'zsh',
+          agentSnippets: ['rewriting the deferred retention path']
+        })
+      ]
+    })
+    expect(
+      retain({ entries: withAgent, deferredQuery: 'defer', query: 'deferred ret' }).titles
+    ).toEqual(['zsh'])
+  })
+
+  it('drops a row whose only remaining match is the workspace name the search ignores', () => {
+    const named = makeEntries({
+      workspaceTabs: [makeWorkspaceTab({ id: 'tab-1', title: 'zsh' })]
+    })
+    expect(retain({ entries: named, deferredQuery: 'zsh', query: 'aurora' }).titles).toEqual([])
+  })
+
+  it('drops every row when the entries behind them are gone', () => {
+    const results = searchOpenTabs({ ...entries, query: 'add tab' })
     expect(
       retainOpenTabResultsForQuery({
-        query: '   ',
+        entries: null,
+        query: 'add ta',
         results,
         resultsQuery: 'add tab'
       })

--- a/src/renderer/src/components/tab-bar/open-tab-search-retention.test.ts
+++ b/src/renderer/src/components/tab-bar/open-tab-search-retention.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+import type { OpenTabSearchResult } from './open-tab-search'
+import { retainOpenTabResultsForQuery } from './open-tab-search-retention'
+
+function tabResult(overrides: Partial<OpenTabSearchResult> = {}): OpenTabSearchResult {
+  return {
+    executionHostId: 'local',
+    source: 'workspace',
+    id: 'open-tab:workspace:tab-1',
+    title: 'Add tab search and jump in worktree',
+    matchedText: null,
+    worktreeId: 'wt',
+    contentType: 'terminal',
+    tabId: 'tab-1',
+    entityId: 'term-1',
+    groupId: 'g',
+    relativePath: null,
+    ...overrides
+  } as OpenTabSearchResult
+}
+
+describe('retainOpenTabResultsForQuery', () => {
+  const results = [tabResult()]
+
+  it('returns the same list when the deferred query has caught up', () => {
+    expect(
+      retainOpenTabResultsForQuery({
+        query: 'add tab',
+        results,
+        resultsQuery: 'add tab'
+      })
+    ).toBe(results)
+  })
+
+  it('treats extra surrounding whitespace as the same query', () => {
+    expect(
+      retainOpenTabResultsForQuery({
+        query: '  add tab ',
+        results,
+        resultsQuery: 'add tab'
+      })
+    ).toBe(results)
+  })
+
+  it('keeps rows while the user backspaces into a prefix of the deferred query', () => {
+    expect(
+      retainOpenTabResultsForQuery({
+        query: 'add ta',
+        results,
+        resultsQuery: 'add tab'
+      })
+    ).toBe(results)
+  })
+
+  it('keeps a row whose title still contains the newer query', () => {
+    expect(
+      retainOpenTabResultsForQuery({
+        query: 'jump in',
+        results,
+        resultsQuery: 'add tab'
+      })
+    ).toEqual(results)
+  })
+
+  it('keeps a row whose matched secondary text still contains the newer query', () => {
+    const secondary = [
+      tabResult({
+        title: 'Claude Code',
+        matchedText: 'fix the flaky retry test'
+      })
+    ]
+    expect(
+      retainOpenTabResultsForQuery({
+        query: 'flaky retry',
+        results: secondary,
+        resultsQuery: 'fix the'
+      })
+    ).toEqual(secondary)
+  })
+
+  it('keeps an editor row whose relative path still contains the newer query', () => {
+    const editor = [
+      tabResult({
+        title: 'zebra.ts',
+        contentType: 'editor',
+        relativePath: 'src/zebra.ts'
+      })
+    ]
+    expect(
+      retainOpenTabResultsForQuery({
+        query: 'zebra.ts',
+        results: editor,
+        resultsQuery: 'zeb'
+      })
+    ).toEqual(editor)
+  })
+
+  it('drops rows that no longer mention the newer query', () => {
+    expect(
+      retainOpenTabResultsForQuery({
+        query: 'add tabs',
+        results,
+        resultsQuery: 'add tab'
+      })
+    ).toEqual([])
+  })
+
+  it('drops every row once the live query is cleared', () => {
+    expect(
+      retainOpenTabResultsForQuery({
+        query: '   ',
+        results,
+        resultsQuery: 'add tab'
+      })
+    ).toEqual([])
+  })
+})

--- a/src/renderer/src/components/tab-bar/open-tab-search-retention.ts
+++ b/src/renderer/src/components/tab-bar/open-tab-search-retention.ts
@@ -1,0 +1,41 @@
+// Keeps deferred tab rows on screen while typing races ahead of search.
+
+import type { OpenTabSearchResult } from './open-tab-search'
+
+export function retainOpenTabResultsForQuery({
+  query,
+  results,
+  resultsQuery
+}: {
+  query: string
+  results: readonly OpenTabSearchResult[]
+  resultsQuery: string
+}): readonly OpenTabSearchResult[] {
+  const current = query.trim()
+  const previous = resultsQuery.trim()
+  if (previous === current) {
+    return results
+  }
+  if (!current) {
+    return []
+  }
+  const needle = current.toLowerCase()
+  // Why keep the whole list on a shorter prefix: every previous substring match
+  // still matches, so dropping rows here would flash the list on backspace.
+  if (previous.toLowerCase().startsWith(needle)) {
+    return results
+  }
+  return results.filter((result) => openTabResultStillMatchesQuery(result, needle))
+}
+
+function openTabResultStillMatchesQuery(result: OpenTabSearchResult, needle: string): boolean {
+  if (result.title.toLowerCase().includes(needle)) {
+    return true
+  }
+  if (result.matchedText?.toLowerCase().includes(needle)) {
+    return true
+  }
+  return Boolean(
+    result.source === 'workspace' && result.relativePath?.toLowerCase().includes(needle)
+  )
+}

--- a/src/renderer/src/components/tab-bar/open-tab-search-retention.ts
+++ b/src/renderer/src/components/tab-bar/open-tab-search-retention.ts
@@ -1,41 +1,62 @@
 // Keeps deferred tab rows on screen while typing races ahead of search.
 
-import type { OpenTabSearchResult } from './open-tab-search'
+import { searchOpenTabs, type OpenTabSearchResult } from './open-tab-search'
+import type { OpenTabSearchEntries } from './open-tab-search-entries'
+
+const NO_RESULTS: readonly OpenTabSearchResult[] = []
 
 export function retainOpenTabResultsForQuery({
+  entries,
   query,
   results,
   resultsQuery
 }: {
+  entries: OpenTabSearchEntries | null
   query: string
   results: readonly OpenTabSearchResult[]
   resultsQuery: string
 }): readonly OpenTabSearchResult[] {
-  const current = query.trim()
-  const previous = resultsQuery.trim()
-  if (previous === current) {
+  // Why return `results` when empty: an already-empty list must keep its identity
+  // rather than flip to another empty array and churn the caller's memos.
+  if (resultsQuery.trim() === query.trim() || results.length === 0) {
     return results
   }
-  if (!current) {
-    return []
+  if (!query.trim() || !entries) {
+    return NO_RESULTS
   }
-  const needle = current.toLowerCase()
-  // Why keep the whole list on a shorter prefix: every previous substring match
-  // still matches, so dropping rows here would flash the list on backspace.
-  if (previous.toLowerCase().startsWith(needle)) {
-    return results
-  }
-  return results.filter((result) => openTabResultStillMatchesQuery(result, needle))
+  // Why re-run the engines instead of re-reading the row text: only they know
+  // every matchable field — type aliases, absolute paths, agent snippets,
+  // browser workspace labels — and Enter must never submit a row the query on
+  // screen does not match.
+  const liveResultIds = new Set(
+    searchOpenTabs({ ...entriesBehindResults(entries, results), query }).map((result) => result.id)
+  )
+  const retained = results.filter((result) => liveResultIds.has(result.id))
+  // Why the same array: an unchanged list must not invalidate the row memos.
+  return retained.length === results.length ? results : retained
 }
 
-function openTabResultStillMatchesQuery(result: OpenTabSearchResult, needle: string): boolean {
-  if (result.title.toLowerCase().includes(needle)) {
-    return true
+// Narrowing to the rows on screen keeps the re-check to string work on at most
+// OPEN_TAB_SEARCH_RESULT_LIMIT entries, so its own limit can never truncate.
+function entriesBehindResults(
+  entries: OpenTabSearchEntries,
+  results: readonly OpenTabSearchResult[]
+): OpenTabSearchEntries {
+  const workspaceTabIds = new Set<string>()
+  const browserPageIds = new Set<string>()
+  const simulatorTabIds = new Set<string>()
+  for (const result of results) {
+    if (result.source === 'workspace') {
+      workspaceTabIds.add(result.tabId)
+    } else if (result.source === 'browser') {
+      browserPageIds.add(result.pageId)
+    } else {
+      simulatorTabIds.add(result.tabId)
+    }
   }
-  if (result.matchedText?.toLowerCase().includes(needle)) {
-    return true
+  return {
+    workspaceTabs: entries.workspaceTabs.filter((entry) => workspaceTabIds.has(entry.tab.id)),
+    browserPages: entries.browserPages.filter((entry) => browserPageIds.has(entry.page.id)),
+    simulatorTabs: entries.simulatorTabs.filter((entry) => simulatorTabIds.has(entry.tab.id))
   }
-  return Boolean(
-    result.source === 'workspace' && result.relativePath?.toLowerCase().includes(needle)
-  )
 }

--- a/src/renderer/src/components/tab-bar/use-open-tab-search.ts
+++ b/src/renderer/src/components/tab-bar/use-open-tab-search.ts
@@ -6,7 +6,8 @@ import { useAppStore } from '@/store'
 import {
   buildOpenTabSearchEntries,
   selectOpenTabSearchAgentState,
-  selectOpenTabSearchEntryState
+  selectOpenTabSearchEntryState,
+  type OpenTabSearchEntries
 } from './open-tab-search-entries'
 import { searchOpenTabs, type OpenTabSearchResult } from './open-tab-search'
 
@@ -22,6 +23,8 @@ export type OpenTabSearchSnapshot = {
   /** The query `results` describe; lags the requested query while deferred. */
   query: string
   results: OpenTabSearchResult[]
+  /** What `results` were searched from, so a caller can re-check a newer query. */
+  entries: OpenTabSearchEntries | null
 }
 
 export function useOpenTabSearch({
@@ -49,6 +52,7 @@ export function useOpenTabSearch({
   return useMemo(
     () => ({
       query: deferredQuery,
+      entries,
       results: entries ? searchOpenTabs({ ...entries, query: deferredQuery }) : EMPTY_RESULTS
     }),
     [deferredQuery, entries]

--- a/src/renderer/src/components/tab-bar/use-tab-create-entry-search-results.ts
+++ b/src/renderer/src/components/tab-bar/use-tab-create-entry-search-results.ts
@@ -18,10 +18,11 @@ export function useTabCreateEntrySearchResults({
     worktreeId
   })
   // Why retain instead of clearing: emptying deferred rows flashes the list on
-  // every keystroke. Kept rows still mention the live query, so Enter cannot
-  // submit a tab the current text never matched.
+  // every keystroke. Retention re-checks each row against the live query, so
+  // Enter cannot submit a tab the current text never matched.
   return enabled
     ? retainOpenTabResultsForQuery({
+        entries: tabSearch.entries,
         query,
         results: tabSearch.results,
         resultsQuery: tabSearch.query

--- a/src/renderer/src/components/tab-bar/use-tab-create-entry-search-results.ts
+++ b/src/renderer/src/components/tab-bar/use-tab-create-entry-search-results.ts
@@ -1,0 +1,30 @@
+import { retainOpenTabResultsForQuery } from './open-tab-search-retention'
+import { EMPTY_TAB_RESULTS } from './tab-create-entry-empty-options'
+import { useOpenTabSearch } from './use-open-tab-search'
+import type { OpenTabSearchResult } from './open-tab-search'
+
+export function useTabCreateEntrySearchResults({
+  enabled,
+  query,
+  worktreeId
+}: {
+  enabled: boolean
+  query: string
+  worktreeId: string
+}): readonly OpenTabSearchResult[] {
+  const tabSearch = useOpenTabSearch({
+    enabled,
+    query: enabled ? query : '',
+    worktreeId
+  })
+  // Why retain instead of clearing: emptying deferred rows flashes the list on
+  // every keystroke. Kept rows still mention the live query, so Enter cannot
+  // submit a tab the current text never matched.
+  return enabled
+    ? retainOpenTabResultsForQuery({
+        query,
+        results: tabSearch.results,
+        resultsQuery: tabSearch.query
+      })
+    : EMPTY_TAB_RESULTS
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​337 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​332 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​102 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​88 |

<!-- /orca-pr-loc -->

## Problem

When users type in the tab search field, results are deferred (async). While waiting, if they continue typing, the old logic would clear deferred results whenever the live query didn't exactly match, causing the list to flash and jump on every keystroke.

## Solution

Introduces a retention strategy that keeps deferred results on screen if they still match the current query:
- If current query is a prefix of deferred query (e.g., user backspaces from "add tab" to "add ta")
- If result's title, matchedText, or relativePath still contains the current query

This eliminates visual jumping while maintaining correctness—Enter only submits tabs that match.

## What Changed

- `open-tab-search-retention.ts`: Core logic to determine which deferred results to keep
- `use-tab-create-entry-search-results.ts`: React hook applying retention logic
- `TabBarCreateEntry.tsx`: Updated to use new hook instead of clearing results
- Tests refactored to verify kept vs dropped rows

## Testing

- Added unit tests for all retention scenarios (prefix match, secondary text match, dropped rows)
- Existing tab search tests updated to verify no spurious submission

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [ ] Self-reviewed for correctness, security, and performance
- [ ] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Notes

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance