### PR TITLE
Display occupant agent icons in tab search results

### DIFF
--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -68,6 +68,7 @@ import {
   shouldOpenTabsLeadPaletteSections,
   NO_PALETTE_QUALITY_RANK
 } from '@/lib/cmd-j-section-leadership'
+import { AgentIcon } from '@/lib/agent-catalog'
 import { cn } from '@/lib/utils'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { queueWorkspaceActivationTerminalFocus } from '@/lib/workspace-activation-terminal-focus'
@@ -743,6 +744,7 @@ function WorktreeJumpPaletteContent({
   const groupsByWorktree = useAppStore((s) => s.groupsByWorktree)
   const retainedAgentsByPaneKey = useAppStore((s) => s.retainedAgentsByPaneKey)
   const sleepingAgentSessionsByPaneKey = useAppStore((s) => s.sleepingAgentSessionsByPaneKey)
+  const paneForegroundAgentByPaneKey = useAppStore((s) => s.paneForegroundAgentByPaneKey)
   const settings = useAppStore((s) => s.settings)
   const worktreeVisibilityDefaultsByHost = useAppStore((s) => s.worktreeVisibilityDefaultsByHost)
   const sshTargetLabels = useAppStore((s) => s.sshTargetLabels)
@@ -1208,7 +1210,9 @@ function WorktreeJumpPaletteContent({
       activeFileId,
       activeFileIdByWorktree,
       activeTabTypeByWorktree,
-      generatedTitlesEnabled: settings?.tabAutoGenerateTitle === true
+      generatedTitlesEnabled: settings?.tabAutoGenerateTitle === true,
+      terminalLayoutsByTabId,
+      paneForegroundAgentByPaneKey
     })
   }, [
     paletteStatusInputsActive,
@@ -1228,7 +1232,9 @@ function WorktreeJumpPaletteContent({
     retainedAgentsByPaneKey,
     settings?.tabAutoGenerateTitle,
     sleepingAgentSessionsByPaneKey,
+    paneForegroundAgentByPaneKey,
     tabsByWorktree,
+    terminalLayoutsByTabId,
     unifiedTabsByWorktree,
     worktreeOrder
   ])
@@ -3339,8 +3345,20 @@ function WorktreeJumpPaletteContent({
                   hostOptions,
                   hostFilterActive
                 )
-                const WorkspaceTabIcon =
-                  result.contentType === 'terminal' ? SquareTerminal : FileText
+                const workspaceTabFallback =
+                  result.contentType === 'terminal' && result.occupantAgent ? (
+                    <span
+                      className="inline-flex"
+                      data-agent-icon={result.occupantAgent}
+                      aria-hidden="true"
+                    >
+                      <AgentIcon agent={result.occupantAgent} size={14} />
+                    </span>
+                  ) : result.contentType === 'terminal' ? (
+                    <SquareTerminal className="size-3.5" aria-hidden="true" />
+                  ) : (
+                    <FileText className="size-3.5" aria-hidden="true" />
+                  )
                 // Why regardless of query: a searched-for tab is exactly when you need to know it's
                 // still working — the map covers every open tab, not just the recent section.
                 const recentRow = recentTabRowById.get(entry.id) ?? null
@@ -3353,10 +3371,7 @@ function WorktreeJumpPaletteContent({
                     className={cn(JUMP_PALETTE_ITEM_CLASSNAME, 'py-2.5')}
                   >
                     <div className="flex h-5 w-4 shrink-0 items-center justify-center self-start text-muted-foreground/85">
-                      <PaletteRecentTabStatusDot
-                        row={recentRow}
-                        fallback={<WorkspaceTabIcon className="size-3.5" aria-hidden="true" />}
-                      />
+                      <PaletteRecentTabStatusDot row={recentRow} fallback={workspaceTabFallback} />
                     </div>
                     <div className="min-w-0 flex-1 overflow-hidden">
                       <div className="flex items-center justify-between gap-2.5">

--- a/src/renderer/src/components/tab-bar/TabBarCreateEntry.tab-results.test.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntry.tab-results.test.tsx
@@ -140,6 +140,7 @@ function terminalResult(overrides: Partial<OpenTabSearchResult> = {}): OpenTabSe
     entityId: 'term-1',
     groupId: 'g',
     relativePath: null,
+    occupantAgent: null,
     ...overrides
   } as OpenTabSearchResult
 }

--- a/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.test.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.test.tsx
@@ -147,6 +147,8 @@ describe('EntryActionRow', () => {
     })
 
     expect(container.querySelector('[data-agent-icon]')).toBeNull()
+    // Guard against the row rendering no icon at all, which "no agent icon" alone would pass.
+    expect(container.querySelector('svg.lucide-square-terminal')).toBeTruthy()
     expect(container.textContent).toContain('Switch to tab')
   })
 })

--- a/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.test.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.test.tsx
@@ -103,4 +103,50 @@ describe('EntryActionRow', () => {
     expect(container.textContent).toBe('Search Kagi·private project')
     expect(container.textContent).not.toContain('https://')
   })
+
+  it('uses the occupant agent icon when a terminal tab is confidently occupied', () => {
+    renderRow({
+      kind: 'tab',
+      option: {
+        executionHostId: 'local',
+        source: 'workspace',
+        id: 'open-tab:workspace:tab-1',
+        title: 'grok',
+        matchedText: null,
+        worktreeId: 'wt',
+        contentType: 'terminal',
+        tabId: 'tab-1',
+        entityId: 'term-1',
+        groupId: 'g',
+        relativePath: null,
+        occupantAgent: 'grok'
+      }
+    })
+
+    expect(container.querySelector('[data-agent-icon="grok"]')).toBeTruthy()
+    expect(container.textContent).toContain('Switch to tab')
+  })
+
+  it('keeps the generic terminal icon when occupancy is not known', () => {
+    renderRow({
+      kind: 'tab',
+      option: {
+        executionHostId: 'local',
+        source: 'workspace',
+        id: 'open-tab:workspace:tab-1',
+        title: 'grok',
+        matchedText: null,
+        worktreeId: 'wt',
+        contentType: 'terminal',
+        tabId: 'tab-1',
+        entityId: 'term-1',
+        groupId: 'g',
+        relativePath: null,
+        occupantAgent: null
+      }
+    })
+
+    expect(container.querySelector('[data-agent-icon]')).toBeNull()
+    expect(container.textContent).toContain('Switch to tab')
+  })
 })

--- a/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.tsx
@@ -120,9 +120,19 @@ function FilenameFirstPath({ path }: { path: string }): React.JSX.Element {
   )
 }
 
-function getOpenTabIcon(
-  contentType: Extract<ActiveOption, { kind: 'tab' }>['option']['contentType']
-): React.ReactNode {
+function getOpenTabIcon(option: Extract<ActiveOption, { kind: 'tab' }>['option']): React.ReactNode {
+  if (option.contentType === 'terminal' && option.source === 'workspace' && option.occupantAgent) {
+    return (
+      <span
+        className="inline-flex shrink-0"
+        data-agent-icon={option.occupantAgent}
+        aria-hidden="true"
+      >
+        <AgentIcon agent={option.occupantAgent} size={14} />
+      </span>
+    )
+  }
+  const { contentType } = option
   if (contentType === 'terminal') {
     return <TerminalSquare className="size-3.5 shrink-0" aria-hidden="true" />
   }
@@ -168,7 +178,7 @@ function getActionPresentation(option: ActiveOption): {
   if (option.kind === 'tab') {
     return {
       detail: option.option.matchedText ?? option.option.title,
-      icon: getOpenTabIcon(option.option.contentType),
+      icon: getOpenTabIcon(option.option),
       label: translate('auto.components.tab.bar.TabBarCreateEntry.8f0a1c4d92', 'Switch to tab'),
       showDetail: true
     }

--- a/src/renderer/src/components/tab-bar/open-tab-entry-dedupe.test.ts
+++ b/src/renderer/src/components/tab-bar/open-tab-entry-dedupe.test.ts
@@ -24,7 +24,8 @@ function editorTab(
     tabId: 'tab-1',
     entityId: 'file-1',
     groupId: 'group-1',
-    relativePath
+    relativePath,
+    occupantAgent: null
   }
 }
 

--- a/src/renderer/src/components/tab-bar/open-tab-search-entries.ts
+++ b/src/renderer/src/components/tab-bar/open-tab-search-entries.ts
@@ -52,7 +52,11 @@ export type OpenTabSearchEntryState = Pick<
 
 export type OpenTabSearchAgentState = Pick<
   AppState,
-  'agentStatusByPaneKey' | 'retainedAgentsByPaneKey' | 'sleepingAgentSessionsByPaneKey'
+  | 'agentStatusByPaneKey'
+  | 'paneForegroundAgentByPaneKey'
+  | 'retainedAgentsByPaneKey'
+  | 'sleepingAgentSessionsByPaneKey'
+  | 'terminalLayoutsByTabId'
 >
 
 // No group id: every tab of the worktree is offered, including the one the
@@ -107,8 +111,10 @@ export function selectOpenTabSearchEntryState(
 export function selectOpenTabSearchAgentState(state: AppState): OpenTabSearchAgentState {
   return {
     agentStatusByPaneKey: state.agentStatusByPaneKey,
+    paneForegroundAgentByPaneKey: state.paneForegroundAgentByPaneKey,
     retainedAgentsByPaneKey: state.retainedAgentsByPaneKey,
-    sleepingAgentSessionsByPaneKey: state.sleepingAgentSessionsByPaneKey
+    sleepingAgentSessionsByPaneKey: state.sleepingAgentSessionsByPaneKey,
+    terminalLayoutsByTabId: state.terminalLayoutsByTabId
   }
 }
 
@@ -137,6 +143,8 @@ export function buildOpenTabSearchEntries(
       agentStatusByPaneKey: agentState.agentStatusByPaneKey,
       retainedAgentsByPaneKey: agentState.retainedAgentsByPaneKey,
       sleepingAgentSessionsByPaneKey: agentState.sleepingAgentSessionsByPaneKey,
+      terminalLayoutsByTabId: agentState.terminalLayoutsByTabId,
+      paneForegroundAgentByPaneKey: agentState.paneForegroundAgentByPaneKey,
       activeGroupIdByWorktree: state.activeGroupIdByWorktree,
       groupsByWorktree: state.groupsByWorktree,
       activeWorktreeId: state.activeWorktreeId,

--- a/src/renderer/src/components/tab-bar/open-tab-search-retention.test.ts
+++ b/src/renderer/src/components/tab-bar/open-tab-search-retention.test.ts
@@ -89,6 +89,7 @@ function makeWorkspaceTab({
     agentMetadata: agentSnippets.length
       ? [{ paneKey: `${id}-pane`, textParts: [], snippetCandidates: agentSnippets }]
       : [],
+    occupantAgent: null,
     isCurrentTab: false,
     isCurrentWorktree: true
   }

--- a/src/renderer/src/components/tab-bar/open-tab-search.test.ts
+++ b/src/renderer/src/components/tab-bar/open-tab-search.test.ts
@@ -68,6 +68,7 @@ function makeWorkspaceTab({
   secondaryText = '',
   secondarySearchTexts,
   agentSnippets = [],
+  occupantAgent = null,
   tabSortIndex = 0,
   groupSortIndex = 0,
   isCurrentTab = false
@@ -78,6 +79,7 @@ function makeWorkspaceTab({
   secondaryText?: string
   secondarySearchTexts?: string[]
   agentSnippets?: string[]
+  occupantAgent?: SearchableWorkspaceTab['occupantAgent']
   tabSortIndex?: number
   groupSortIndex?: number
   isCurrentTab?: boolean
@@ -105,6 +107,7 @@ function makeWorkspaceTab({
     agentMetadata: agentSnippets.length
       ? [{ paneKey: `${id}-pane`, textParts: [], snippetCandidates: agentSnippets }]
       : [],
+    occupantAgent,
     isCurrentTab,
     isCurrentWorktree: true
   }
@@ -421,6 +424,19 @@ describe('searchOpenTabs result fields', () => {
     })
   })
 
+  it('copies a confident occupant agent onto workspace results', () => {
+    const results = search({
+      query: 'grok',
+      workspaceTabs: [makeWorkspaceTab({ id: 'tab-1', title: 'grok', occupantAgent: 'grok' })]
+    })
+
+    expect(results[0]).toMatchObject({
+      source: 'workspace',
+      contentType: 'terminal',
+      occupantAgent: 'grok'
+    })
+  })
+
   it('carries the activation identifiers each source needs', () => {
     const results = search({
       query: 'zebra',
@@ -436,7 +452,8 @@ describe('searchOpenTabs result fields', () => {
         tabId: 'tab-1',
         entityId: 'tab-1-entity',
         groupId: 'group-1',
-        worktreeId: 'wt-1'
+        worktreeId: 'wt-1',
+        occupantAgent: null
       },
       {
         source: 'browser',

--- a/src/renderer/src/components/tab-bar/open-tab-search.ts
+++ b/src/renderer/src/components/tab-bar/open-tab-search.ts
@@ -17,6 +17,7 @@ import {
   type SearchableSimulatorTab,
   type SimulatorPaletteSearchResult
 } from '@/lib/simulator-palette-search'
+import type { TuiAgent } from '../../../../shared/tui-agent'
 import {
   searchWorkspaceTabs,
   type SearchableWorkspaceTab,
@@ -49,6 +50,7 @@ export type OpenTabSearchResult =
       entityId: string
       groupId: string
       relativePath: string | null
+      occupantAgent: TuiAgent | null
     })
   | (OpenTabSearchResultBase & {
       source: 'browser'
@@ -194,7 +196,8 @@ export function searchOpenTabs({
       tabId: result.tabId,
       entityId: result.entityId,
       groupId: result.groupId,
-      relativePath: getEditorRelativePath(workspaceEntriesByTabId.get(result.tabId))
+      relativePath: getEditorRelativePath(workspaceEntriesByTabId.get(result.tabId)),
+      occupantAgent: result.occupantAgent
     })),
     ...rank('browser', searchBrowserPages([...browserPages], trimmed), (result) => ({
       ...baseResult('browser', result.pageId, result, executionHostId),

--- a/src/renderer/src/components/tab-bar/open-tab-selection-routing.test.ts
+++ b/src/renderer/src/components/tab-bar/open-tab-selection-routing.test.ts
@@ -40,7 +40,8 @@ const terminalResult: Extract<OpenTabSearchResult, { source: 'workspace' }> = {
   tabId: 'tab-1',
   entityId: 'term-1',
   groupId: 'group-2',
-  relativePath: null
+  relativePath: null,
+  occupantAgent: null
 }
 
 const editorResult: OpenTabSearchResult = {

--- a/src/renderer/src/lib/open-tab-occupant-agent.test.ts
+++ b/src/renderer/src/lib/open-tab-occupant-agent.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from 'vitest'
+import type { RetainedAgentEntry } from '@/store/slices/agent-status'
+import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-resume'
+import type { AgentStatusEntry } from '../../../shared/agent-status-types'
+import { makePaneKey } from '../../../shared/stable-pane-id'
+import type { TerminalLayoutSnapshot, TerminalTab } from '../../../shared/terminal-tab-types'
+import type { TuiAgent } from '../../../shared/tui-agent'
+import { resolveOpenTabOccupantAgent } from './open-tab-occupant-agent'
+
+const TAB_ID = 'tab-1'
+const LEAF_A = '11111111-1111-4111-8111-111111111111'
+const LEAF_B = '22222222-2222-4222-8222-222222222222'
+
+function layout(activeLeafId: string | null): TerminalLayoutSnapshot {
+  return {
+    root: {
+      type: 'split',
+      direction: 'horizontal',
+      first: { type: 'leaf', leafId: LEAF_A },
+      second: { type: 'leaf', leafId: LEAF_B }
+    },
+    activeLeafId,
+    expandedLeafId: null
+  }
+}
+
+function status(
+  leafId: string,
+  agentType: TuiAgent,
+  state: AgentStatusEntry['state'] = 'working'
+): AgentStatusEntry {
+  const paneKey = makePaneKey(TAB_ID, leafId)
+  return {
+    state,
+    prompt: '',
+    updatedAt: 1,
+    stateStartedAt: 1,
+    paneKey,
+    tabId: TAB_ID,
+    worktreeId: 'wt-1',
+    stateHistory: [],
+    agentType
+  }
+}
+
+function sleeping(leafId: string, agent: TuiAgent): SleepingAgentSessionRecord {
+  return {
+    paneKey: makePaneKey(TAB_ID, leafId),
+    tabId: TAB_ID,
+    worktreeId: 'wt-1',
+    agent: agent as SleepingAgentSessionRecord['agent'],
+    providerSession: { key: 'session_id', id: 'sess-1' },
+    prompt: '',
+    state: 'waiting',
+    capturedAt: 1,
+    updatedAt: 1
+  }
+}
+
+function retained(leafId: string, agentType: TuiAgent): RetainedAgentEntry {
+  const entry = status(leafId, agentType, 'done')
+  return {
+    entry,
+    worktreeId: 'wt-1',
+    tab: { id: TAB_ID, title: 'done' } as TerminalTab,
+    agentType,
+    startedAt: 1
+  }
+}
+
+function resolve(
+  overrides: Partial<Parameters<typeof resolveOpenTabOccupantAgent>[0]> = {}
+): TuiAgent | null {
+  return resolveOpenTabOccupantAgent({
+    tabId: TAB_ID,
+    agentStatusByPaneKey: {},
+    retainedAgentsByPaneKey: {},
+    sleepingAgentSessionsByPaneKey: {},
+    ...overrides
+  })
+}
+
+describe('resolveOpenTabOccupantAgent', () => {
+  it('uses launchAgent when no hook or sleeping record exists', () => {
+    expect(resolve({ launchAgent: 'grok' })).toBe('grok')
+  })
+
+  it('prefers a live focused hook over launchAgent', () => {
+    expect(
+      resolve({
+        launchAgent: 'grok',
+        layout: layout(LEAF_A),
+        agentStatusByPaneKey: {
+          [makePaneKey(TAB_ID, LEAF_A)]: status(LEAF_A, 'claude'),
+          [makePaneKey(TAB_ID, LEAF_B)]: status(LEAF_B, 'grok')
+        }
+      })
+    ).toBe('claude')
+  })
+
+  it('uses the focused split leaf, not insertion order', () => {
+    expect(
+      resolve({
+        layout: layout(LEAF_B),
+        agentStatusByPaneKey: {
+          [makePaneKey(TAB_ID, LEAF_A)]: status(LEAF_A, 'claude'),
+          [makePaneKey(TAB_ID, LEAF_B)]: status(LEAF_B, 'grok')
+        }
+      })
+    ).toBe('grok')
+  })
+
+  it('uses the tab-strip title identity when hooks have not reported yet', () => {
+    expect(resolve({ recordTitle: 'grok' })).toBe('grok')
+    expect(resolve({ title: 'grok' })).toBe('grok')
+  })
+
+  it('does not let a grok mention in the title steal a launched Claude pane', () => {
+    expect(
+      resolve({
+        launchAgent: 'claude',
+        recordTitle: 'fix grok parser',
+        title: 'fix grok parser'
+      })
+    ).toBe('claude')
+  })
+
+  it('does not treat a hyphenated grok mention as occupancy', () => {
+    expect(resolve({ recordTitle: 'session-scanner-grok-parser' })).toBeNull()
+  })
+
+  it('uses the focused sleeping session, matching useTabAgent', () => {
+    expect(
+      resolve({
+        layout: layout(LEAF_A),
+        sleepingAgentSessionsByPaneKey: {
+          [makePaneKey(TAB_ID, LEAF_A)]: sleeping(LEAF_A, 'grok'),
+          [makePaneKey(TAB_ID, LEAF_B)]: sleeping(LEAF_B, 'claude')
+        }
+      })
+    ).toBe('grok')
+  })
+
+  it('does not invent a sibling sleeping occupant when the focused leaf has none', () => {
+    expect(
+      resolve({
+        layout: layout(LEAF_A),
+        sleepingAgentSessionsByPaneKey: {
+          [makePaneKey(TAB_ID, LEAF_B)]: sleeping(LEAF_B, 'grok')
+        }
+      })
+    ).toBeNull()
+  })
+
+  it('falls back to a completed focused hook after launchAgent is gone', () => {
+    expect(
+      resolve({
+        layout: layout(LEAF_A),
+        agentStatusByPaneKey: {
+          [makePaneKey(TAB_ID, LEAF_A)]: status(LEAF_A, 'grok', 'done')
+        }
+      })
+    ).toBe('grok')
+  })
+
+  it('falls back to a retained completion when live status is gone', () => {
+    expect(
+      resolve({
+        layout: layout(LEAF_A),
+        retainedAgentsByPaneKey: {
+          [makePaneKey(TAB_ID, LEAF_A)]: retained(LEAF_A, 'codex')
+        }
+      })
+    ).toBe('codex')
+  })
+
+  it('uses a live sibling when the focused pane is a shell', () => {
+    expect(
+      resolve({
+        layout: layout(LEAF_A),
+        agentStatusByPaneKey: {
+          [makePaneKey(TAB_ID, LEAF_B)]: status(LEAF_B, 'grok')
+        }
+      })
+    ).toBe('grok')
+  })
+
+  it('ignores a live hook that belongs to another tab', () => {
+    expect(
+      resolve({
+        launchAgent: undefined,
+        agentStatusByPaneKey: {
+          [makePaneKey('tab-other', LEAF_A)]: {
+            ...status(LEAF_A, 'grok'),
+            tabId: 'tab-other',
+            paneKey: makePaneKey('tab-other', LEAF_A)
+          }
+        }
+      })
+    ).toBeNull()
+  })
+})

--- a/src/renderer/src/lib/open-tab-occupant-agent.test.ts
+++ b/src/renderer/src/lib/open-tab-occupant-agent.test.ts
@@ -111,7 +111,6 @@ describe('resolveOpenTabOccupantAgent', () => {
   })
 
   it('uses the tab-strip title identity when hooks have not reported yet', () => {
-    expect(resolve({ recordTitle: 'grok' })).toBe('grok')
     expect(resolve({ title: 'grok' })).toBe('grok')
   })
 
@@ -119,14 +118,13 @@ describe('resolveOpenTabOccupantAgent', () => {
     expect(
       resolve({
         launchAgent: 'claude',
-        recordTitle: 'fix grok parser',
         title: 'fix grok parser'
       })
     ).toBe('claude')
   })
 
   it('does not treat a hyphenated grok mention as occupancy', () => {
-    expect(resolve({ recordTitle: 'session-scanner-grok-parser' })).toBeNull()
+    expect(resolve({ title: 'session-scanner-grok-parser' })).toBeNull()
   })
 
   it('uses the focused sleeping session, matching useTabAgent', () => {

--- a/src/renderer/src/lib/open-tab-occupant-agent.ts
+++ b/src/renderer/src/lib/open-tab-occupant-agent.ts
@@ -18,10 +18,12 @@ import { resolveTabAgentFromSignals } from './use-tab-agent'
 
 export type OpenTabOccupantAgentInput = {
   tabId: string
-  /** Visible search/tab-strip label. Used only when the terminal record title is empty. */
+  /**
+   * Resolved unified tab label — the same string the tab strip feeds `useTabAgent`.
+   * The terminal record's own title is not used: it can stay a stale "Terminal N"
+   * while the unified label already carries the live OSC title.
+   */
   title?: string
-  /** OSC title `useTabAgent` reads. */
-  recordTitle?: string
   defaultTitle?: string
   launchAgent?: TuiAgent
   layout?: TerminalLayoutSnapshot
@@ -38,7 +40,6 @@ export type OpenTabOccupantAgentInput = {
 export function resolveOpenTabOccupantAgent({
   tabId,
   title,
-  recordTitle,
   defaultTitle,
   launchAgent,
   layout,
@@ -61,7 +62,7 @@ export function resolveOpenTabOccupantAgent({
   const sleepingSessionAgent = focusedPaneKey
     ? (sleepingAgentSessionsByPaneKey[focusedPaneKey]?.agent ?? null)
     : null
-  const oscTitle = recordTitle?.trim() || title?.trim() || ''
+  const oscTitle = title?.trim() || ''
   const explicitTitleAgent = resolveExplicitTerminalTitleAgentType(oscTitle)
   const fallbackAgentSignal = launchAgent
     ? explicitTitleAgent === launchAgent

--- a/src/renderer/src/lib/open-tab-occupant-agent.ts
+++ b/src/renderer/src/lib/open-tab-occupant-agent.ts
@@ -1,0 +1,95 @@
+import type { RetainedAgentEntry } from '@/store/slices/agent-status'
+import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
+import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-resume'
+import type { AgentStatusEntry } from '../../../shared/agent-status-types'
+import { isTerminalLeafId, makePaneKey } from '../../../shared/stable-pane-id'
+import { resolveExplicitTerminalTitleAgentType } from '../../../shared/terminal-title-agent-type'
+import type { TerminalLayoutSnapshot } from '../../../shared/terminal-tab-types'
+import type { TuiAgent } from '../../../shared/tui-agent'
+import {
+  resolveFocusedCompletedTabAgent,
+  resolveFocusedRetainedTabAgent,
+  resolveFocusedTabAgent,
+  resolveSiblingCompletedTabAgent,
+  resolveSiblingRetainedTabAgent,
+  resolveSiblingTabAgent
+} from './tab-agent'
+import { resolveTabAgentFromSignals } from './use-tab-agent'
+
+export type OpenTabOccupantAgentInput = {
+  tabId: string
+  /** Visible search/tab-strip label. Used only when the terminal record title is empty. */
+  title?: string
+  /** OSC title `useTabAgent` reads. */
+  recordTitle?: string
+  defaultTitle?: string
+  launchAgent?: TuiAgent
+  layout?: TerminalLayoutSnapshot
+  agentStatusByPaneKey: Record<string, AgentStatusEntry>
+  retainedAgentsByPaneKey: Record<string, RetainedAgentEntry>
+  sleepingAgentSessionsByPaneKey: Record<string, SleepingAgentSessionRecord>
+  paneForegroundAgentByPaneKey?: Record<string, PaneForegroundAgentEntry>
+}
+
+/**
+ * Search-row occupant: the tab-strip identity function, with the same
+ * hook/sibling/sleeping/process inputs `useTabAgent` gathers. No second ladder.
+ */
+export function resolveOpenTabOccupantAgent({
+  tabId,
+  title,
+  recordTitle,
+  defaultTitle,
+  launchAgent,
+  layout,
+  agentStatusByPaneKey,
+  retainedAgentsByPaneKey,
+  sleepingAgentSessionsByPaneKey,
+  paneForegroundAgentByPaneKey
+}: OpenTabOccupantAgentInput): TuiAgent | null {
+  const hookAgent = resolveFocusedTabAgent(agentStatusByPaneKey, layout, tabId)
+  const siblingHookAgent = resolveSiblingTabAgent(agentStatusByPaneKey, layout, tabId)
+  const focusedCompletedHookAgent =
+    resolveFocusedCompletedTabAgent(agentStatusByPaneKey, layout, tabId) ??
+    resolveFocusedRetainedTabAgent(retainedAgentsByPaneKey, layout, tabId)
+  const siblingCompletedHookAgent =
+    resolveSiblingCompletedTabAgent(agentStatusByPaneKey, layout, tabId) ??
+    resolveSiblingRetainedTabAgent(retainedAgentsByPaneKey, layout, tabId)
+  const focusedPaneKey = focusedPaneKeyFor(tabId, layout)
+  const process = focusedPaneKey ? paneForegroundAgentByPaneKey?.[focusedPaneKey] : undefined
+  const processAgent = process?.agent ?? null
+  const sleepingSessionAgent = focusedPaneKey
+    ? (sleepingAgentSessionsByPaneKey[focusedPaneKey]?.agent ?? null)
+    : null
+  const oscTitle = recordTitle?.trim() || title?.trim() || ''
+  const explicitTitleAgent = resolveExplicitTerminalTitleAgentType(oscTitle)
+  const fallbackAgentSignal = launchAgent
+    ? explicitTitleAgent === launchAgent
+    : Boolean(explicitTitleAgent || siblingHookAgent)
+
+  return resolveTabAgentFromSignals({
+    hasObservedAgentSignal: Boolean(
+      hookAgent || focusedCompletedHookAgent || processAgent || fallbackAgentSignal
+    ),
+    // Search does not observe OSC 133;D, so do not apply local-only exit clearing.
+    isRemote: true,
+    title: oscTitle,
+    defaultTitle,
+    hookAgent,
+    siblingHookAgent,
+    focusedCompletedHookAgent,
+    siblingCompletedHookAgent,
+    processAgent,
+    processShellForeground: Boolean(process?.shellForeground),
+    sleepingSessionAgent,
+    launchAgent
+  })
+}
+
+function focusedPaneKeyFor(
+  tabId: string,
+  layout: TerminalLayoutSnapshot | undefined
+): string | null {
+  const activeLeafId = layout?.activeLeafId
+  return activeLeafId && isTerminalLeafId(activeLeafId) ? makePaneKey(tabId, activeLeafId) : null
+}

--- a/src/renderer/src/lib/workspace-tab-palette-activation.test.ts
+++ b/src/renderer/src/lib/workspace-tab-palette-activation.test.ts
@@ -102,6 +102,7 @@ function makeResult(
     worktreeId: 'wt-1',
     groupId: 'group-1',
     contentType: 'terminal',
+    occupantAgent: null,
     title: 'Terminal',
     secondaryText: '',
     repoName: 'repo/orca',

--- a/src/renderer/src/lib/workspace-tab-palette-results.ts
+++ b/src/renderer/src/lib/workspace-tab-palette-results.ts
@@ -13,6 +13,7 @@ import { matchWorkspaceTabAgentSnippet } from './workspace-tab-agent-snippet-mat
 import type { MatchRange } from './palette-match/normalized-text'
 import type { PaletteDocumentRank } from './palette-match/palette-document'
 import type { PaletteResultQualityClass } from './palette-match/match-quality'
+import type { TuiAgent } from '../../../shared/tui-agent'
 import type {
   SearchableWorkspaceTab,
   WorkspaceTabContentType
@@ -26,6 +27,7 @@ export type WorkspaceTabPaletteSearchResult = {
   worktreeId: string
   groupId: string
   contentType: WorkspaceTabContentType
+  occupantAgent: TuiAgent | null
   title: string
   secondaryText: string
   repoName: string
@@ -84,6 +86,7 @@ function baseResult(entry: SearchableWorkspaceTab): WorkspaceTabPaletteSearchRes
     worktreeId: entry.worktree.id,
     groupId: entry.tab.groupId,
     contentType: entry.tab.contentType,
+    occupantAgent: entry.occupantAgent,
     title: entry.title,
     secondaryText: entry.secondaryText,
     repoName: entry.repoName,

--- a/src/renderer/src/lib/workspace-tab-palette-search.test.ts
+++ b/src/renderer/src/lib/workspace-tab-palette-search.test.ts
@@ -559,4 +559,23 @@ describe('workspace-tab-palette-search', () => {
     const query = Array.from({ length: PALETTE_QUERY_MAX_TOKENS + 1 }, (_, i) => `t${i}`).join(' ')
     expect(searchWorkspaceTabs(buildEntries(), query)).toEqual([])
   })
+
+  it('stamps grok occupancy from the idle OSC title the sidebar already shows', () => {
+    const titledOnly = buildEntries({
+      tabsByWorktree: { 'wt-1': [makeTerminalTab({ title: 'grok' })] },
+      unifiedTabsByWorktree: { 'wt-1': [makeUnifiedTab({ label: 'grok' })] }
+    })
+    expect(titledOnly[0]?.occupantAgent).toBe('grok')
+    expect(searchWorkspaceTabs(titledOnly, 'grok')[0]?.occupantAgent).toBe('grok')
+  })
+
+  it('does not stamp grok occupancy from a hyphenated filename-style title', () => {
+    const hyphenated = buildEntries({
+      tabsByWorktree: { 'wt-1': [makeTerminalTab({ title: 'session-scanner-grok-parser' })] },
+      unifiedTabsByWorktree: {
+        'wt-1': [makeUnifiedTab({ label: 'session-scanner-grok-parser' })]
+      }
+    })
+    expect(hyphenated[0]?.occupantAgent).toBeNull()
+  })
 })

--- a/src/renderer/src/lib/workspace-tab-palette-search.test.ts
+++ b/src/renderer/src/lib/workspace-tab-palette-search.test.ts
@@ -569,6 +569,15 @@ describe('workspace-tab-palette-search', () => {
     expect(searchWorkspaceTabs(titledOnly, 'grok')[0]?.occupantAgent).toBe('grok')
   })
 
+  it('stamps occupancy from the live unified label when the terminal record title is stale', () => {
+    const staleRecord = buildEntries({
+      tabsByWorktree: { 'wt-1': [makeTerminalTab({ title: 'Terminal 1' })] },
+      unifiedTabsByWorktree: { 'wt-1': [makeUnifiedTab({ label: 'grok' })] }
+    })
+    expect(staleRecord[0]?.title).toBe('grok')
+    expect(staleRecord[0]?.occupantAgent).toBe('grok')
+  })
+
   it('does not stamp grok occupancy from a hyphenated filename-style title', () => {
     const hyphenated = buildEntries({
       tabsByWorktree: { 'wt-1': [makeTerminalTab({ title: 'session-scanner-grok-parser' })] },

--- a/src/renderer/src/lib/workspace-tab-palette-search.ts
+++ b/src/renderer/src/lib/workspace-tab-palette-search.ts
@@ -275,8 +275,8 @@ export function buildSearchableWorkspaceTabs({
           agentMetadata: collectAgentMetadataFromIndex(agentIndex, tab.entityId, worktree.id),
           occupantAgent: resolveOpenTabOccupantAgent({
             tabId: tab.entityId,
+            // The unified label, not terminalTab.title: the record can lag it (see above).
             title,
-            recordTitle: terminalTab?.title,
             defaultTitle: terminalTab?.defaultTitle,
             launchAgent: terminalTab?.launchAgent,
             layout: terminalLayoutsByTabId?.[tab.entityId],

--- a/src/renderer/src/lib/workspace-tab-palette-search.ts
+++ b/src/renderer/src/lib/workspace-tab-palette-search.ts
@@ -11,8 +11,11 @@ import {
   resolveUnifiedTabLabel
 } from '../../../shared/tab-title-resolution'
 import type { Tab, TabContentType, TabGroup } from '../../../shared/tab-types'
-import type { TerminalTab } from '../../../shared/terminal-tab-types'
+import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
+import type { TerminalLayoutSnapshot, TerminalTab } from '../../../shared/terminal-tab-types'
+import type { TuiAgent } from '../../../shared/tui-agent'
 import type { Worktree } from '../../../shared/worktree/types'
+import { resolveOpenTabOccupantAgent } from './open-tab-occupant-agent'
 import {
   buildAgentMetadataTabIndex,
   collectAgentMetadataFromIndex,
@@ -50,6 +53,8 @@ export type SearchableWorkspaceTab = {
   /** Normalized field index, built once per entry rather than per keystroke. */
   document: PaletteDocument
   agentMetadata: AgentMetadata[]
+  /** Confident occupant for the row icon; null when the pane is a plain shell. */
+  occupantAgent: TuiAgent | null
   isCurrentTab: boolean
   isCurrentWorktree: boolean
 }
@@ -77,6 +82,8 @@ export type BuildSearchableWorkspaceTabsOptions = WorkspaceTabAgentMetadataState
   activeFileIdByWorktree: Record<string, string | null | undefined>
   activeTabTypeByWorktree: Record<string, WorkspaceTabPaletteActiveTabType | undefined>
   generatedTitlesEnabled: boolean
+  terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot | undefined>
+  paneForegroundAgentByPaneKey?: Record<string, PaneForegroundAgentEntry>
 }
 
 function getActiveUnifiedTabId({
@@ -170,7 +177,9 @@ export function buildSearchableWorkspaceTabs({
   activeFileId,
   activeFileIdByWorktree,
   activeTabTypeByWorktree,
-  generatedTitlesEnabled
+  generatedTitlesEnabled,
+  terminalLayoutsByTabId,
+  paneForegroundAgentByPaneKey
 }: BuildSearchableWorkspaceTabsOptions): SearchableWorkspaceTab[] {
   const entries: SearchableWorkspaceTab[] = []
   const openFilesById = new Map(openFiles.map((file) => [file.id, file]))
@@ -263,7 +272,19 @@ export function buildSearchableWorkspaceTabs({
             repoName,
             typeAliases: TERMINAL_TYPE_SEARCH_ALIASES
           }),
-          agentMetadata: collectAgentMetadataFromIndex(agentIndex, tab.entityId, worktree.id)
+          agentMetadata: collectAgentMetadataFromIndex(agentIndex, tab.entityId, worktree.id),
+          occupantAgent: resolveOpenTabOccupantAgent({
+            tabId: tab.entityId,
+            title,
+            recordTitle: terminalTab?.title,
+            defaultTitle: terminalTab?.defaultTitle,
+            launchAgent: terminalTab?.launchAgent,
+            layout: terminalLayoutsByTabId?.[tab.entityId],
+            agentStatusByPaneKey,
+            retainedAgentsByPaneKey,
+            sleepingAgentSessionsByPaneKey,
+            paneForegroundAgentByPaneKey
+          })
         })
         continue
       }
@@ -287,7 +308,8 @@ export function buildSearchableWorkspaceTabs({
           branch,
           repoName
         }),
-        agentMetadata: []
+        agentMetadata: [],
+        occupantAgent: null
       })
     }
   }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​301 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​298 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​175 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​18 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​157 |

<!-- /orca-pr-loc -->

## Problem

Terminal tabs don't clearly show which agent is running in them. In search results and tab bar, users see generic terminal icons regardless of whether a Claude, Grok, or other agent is actively occupying the pane.

## Solution

Detect and display the occupant agent's icon when available. The detection logic checks the focused pane's live agent status, completed hook status, terminal title hints, sibling panes, and sleeping sessions—using the same signal hierarchy as the tab-strip title display.

## What Changed

- New module `open-tab-occupant-agent.ts`: resolves which agent (if any) is occupying a terminal pane
- Added optional `occupantAgent` field to search result types
- Tab bar and palette UI now show agent icon when occupancy is detected; falls back to generic terminal icon otherwise

## Visual Proof

Agent icons now display in:
- Workspace tab palette search results
- Tab bar create entry rows

## Testing

- Unit tests for agent detection covering hook priority, sleeping sessions, title parsing, sibling fallback, and isolation
- UI integration tests verifying agent icon vs terminal icon display
- Occupant agent stamping tests across search sources

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)