### PR TITLE
fix(native-chat): keep capped and error provider frames visible

### DIFF
--- a/src/main/codex/codex-structured-item-translation.ts
+++ b/src/main/codex/codex-structured-item-translation.ts
@@ -273,7 +273,9 @@ export function codexJournalItem(item: CodexThreadItem): CodexJournalItem {
     }
   }
   const unhandled = unhandledProviderFrameJournalItem('codex', `item:${item.type}`, item)
-  return unhandled ? { ...unhandled, handled: false } : { body: null, blobs: [], handled: true }
+  return unhandled
+    ? { body: unhandled.body, blobs: unhandled.blobs, handled: false }
+    : { body: null, blobs: [], handled: true }
 }
 
 export function codexItemBody(item: CodexThreadItem): AgentJournalItemBody | null {

--- a/src/main/codex/codex-structured-journal-translation.test.ts
+++ b/src/main/codex/codex-structured-journal-translation.test.ts
@@ -502,7 +502,7 @@ describe('codex journal translation', () => {
     ).toEqual(['notification:future/notification', 'request:future/request', 'frame:unclassified'])
   })
 
-  it('bounds generic rows per turn while preserving unknown non-delta evidence', () => {
+  it('bounds generic rows per turn while keeping the suppression visible and countable', () => {
     const { translator, tap } = translatorWith()
     translator.handle(TURN_STARTED)
     for (let index = 0; index < MAX_CODEX_GENERIC_ROWS_PER_TURN + 20; index += 1) {
@@ -510,10 +510,25 @@ describe('codex journal translation', () => {
     }
     translator.handle(notification('item/future/outputDelta', { itemId: 'future', delta: 'x' }))
 
-    expect(tap.rows).toHaveLength(MAX_CODEX_GENERIC_ROWS_PER_TURN)
-    expect(tap.rows[0]?.body).toMatchObject({
+    const generic = tap.rows.filter(
+      (row) => row.body.kind === 'status' && row.body.providerFrame !== undefined
+    )
+    expect(generic).toHaveLength(MAX_CODEX_GENERIC_ROWS_PER_TURN)
+    expect(generic[0]?.body).toMatchObject({
       kind: 'status',
       providerFrame: { kind: 'notification:future/notification' }
+    })
+    // The 20 capped frames reduce to ONE summary row whose count is exact, so
+    // suppressed provider activity is never invisible.
+    const summaries = new Map(
+      tap.rows
+        .filter((row) => row.key.includes('provider-frame-suppressed'))
+        .map((row) => [row.key, row.body])
+    )
+    expect(summaries.size).toBe(1)
+    expect([...summaries.values()][0]).toEqual({
+      kind: 'status',
+      text: '20 more provider notifications not shown for this turn'
     })
     expect(
       tap.rows.some(
@@ -522,6 +537,23 @@ describe('codex journal translation', () => {
           row.body.providerFrame?.kind === 'notification:item/future/outputDelta'
       )
     ).toBe(false)
+  })
+
+  it('never lets the generic-row cap hide an error frame', () => {
+    const { translator, tap } = translatorWith()
+    translator.handle(TURN_STARTED)
+    for (let index = 0; index < MAX_CODEX_GENERIC_ROWS_PER_TURN + 3; index += 1) {
+      translator.handle(notification('future/notification', { value: index }))
+    }
+    translator.handle(notification('future/failure', { error: 'provider exploded' }))
+
+    expect(
+      tap.rows.some(
+        (row) =>
+          row.body.kind === 'status' &&
+          row.body.providerFrame?.kind === 'notification:future/failure'
+      )
+    ).toBe(true)
   })
 
   it('keeps a fresh session timeline empty through startup and status notifications', () => {

--- a/src/main/codex/codex-structured-journal-translation.ts
+++ b/src/main/codex/codex-structured-journal-translation.ts
@@ -66,6 +66,7 @@ export function createCodexJournalTranslator(
   const details = new Map<string, string>()
   const currentTurnIds = new Map<string, string>()
   const genericRowsByTurn = new Map<string, number>()
+  const suppressedRowsByTurn = new Map<string, number>()
   let fallbackSequence = 0
 
   const appendUnhandled = (kind: string, payload: unknown, threadId = 'session'): void => {
@@ -76,7 +77,21 @@ export function createCodexJournalTranslator(
     const turnId = readCodexTurnId(payload) ?? currentTurnIds.get(threadId) ?? 'outside-turn'
     const bucket = `${encodeURIComponent(threadId)}:${encodeURIComponent(turnId)}`
     const rowCount = genericRowsByTurn.get(bucket) ?? 0
-    if (rowCount >= MAX_CODEX_GENERIC_ROWS_PER_TURN) {
+    // The cap bounds noise, never evidence: an error frame is always journaled,
+    // and capped frames stay countable through one summary row per turn.
+    const capped =
+      rowCount >= MAX_CODEX_GENERIC_ROWS_PER_TURN && translated.classification !== 'error-surface'
+    if (capped) {
+      const suppressed = (suppressedRowsByTurn.get(bucket) ?? 0) + 1
+      suppressedRowsByTurn.set(bucket, suppressed)
+      deps.sink.appendItem(
+        { provider: 'orca', clientMessageId: `provider-frame-suppressed:codex:${bucket}` },
+        {
+          kind: 'status',
+          text: `${suppressed} more provider notification${suppressed === 1 ? '' : 's'} not shown for this turn`
+        }
+      )
+      deps.sink.publish()
       return
     }
     genericRowsByTurn.set(bucket, rowCount + 1)
@@ -276,6 +291,7 @@ export function createCodexJournalTranslator(
       details.clear()
       currentTurnIds.clear()
       genericRowsByTurn.clear()
+      suppressedRowsByTurn.clear()
     }
   }
 }

--- a/src/main/native-chat/agent-session-wire/provider-frame-disposition.ts
+++ b/src/main/native-chat/agent-session-wire/provider-frame-disposition.ts
@@ -225,11 +225,14 @@ export function classifyProviderFrame(
   kind: string,
   payload: unknown
 ): ProviderFrameClassification {
-  if (isDeltaShapedProviderFrameKind(kind)) {
-    return 'stream-into-item'
-  }
+  // Payload failure inspection outranks the name-shape heuristic below: an
+  // unknown frame that reports an error must reach the user even when its
+  // method name happens to look like a stream delta.
   if (hasProviderError(payload)) {
     return 'error-surface'
+  }
+  if (isDeltaShapedProviderFrameKind(kind)) {
+    return 'stream-into-item'
   }
   if (provider === 'claude' && kind === 'message:result') {
     const subtype =

--- a/src/main/native-chat/agent-session-wire/unhandled-provider-frame.test.ts
+++ b/src/main/native-chat/agent-session-wire/unhandled-provider-frame.test.ts
@@ -73,7 +73,7 @@ describe('unhandled provider frame journal fallback', () => {
     ).toBeNull()
   })
 
-  it('never creates generic rows for known or unknown delta-shaped frames', () => {
+  it('never creates generic rows for delta-shaped frames that report no failure', () => {
     expect(
       unhandledProviderFrameJournalItem('codex', 'notification:item/commandExecution/outputDelta', {
         itemId: 'exec-1',
@@ -82,9 +82,23 @@ describe('unhandled provider frame journal fallback', () => {
     ).toBeNull()
     expect(
       unhandledProviderFrameJournalItem('codex', 'notification:item/future/outputDelta', {
-        error: 'still a delta'
+        itemId: 'future-1',
+        delta: 'y'
       })
     ).toBeNull()
+  })
+
+  it('surfaces an unknown delta-shaped frame whose payload reports an error', () => {
+    const row = unhandledProviderFrameJournalItem('codex', 'notification:item/future/outputDelta', {
+      error: 'stream broke mid-item'
+    })
+
+    expect(row).not.toBeNull()
+    expect(row?.classification).toBe('error-surface')
+    expect(row?.body.providerFrame).toMatchObject({
+      provider: 'codex',
+      kind: 'notification:item/future/outputDelta'
+    })
   })
 
   it('renders codex systemError and Claude error result variants', () => {

--- a/src/main/native-chat/agent-session-wire/unhandled-provider-frame.ts
+++ b/src/main/native-chat/agent-session-wire/unhandled-provider-frame.ts
@@ -10,6 +10,8 @@ import { classifyProviderFrame } from './provider-frame-disposition'
 export type UnhandledProviderFrameJournalItem = {
   body: AgentJournalStatusItem
   blobs: { digest: string; payload: string }[]
+  /** Why the frame surfaced. Error frames are exempt from generic-row caps. */
+  classification: 'timeline-substantive' | 'error-surface'
 }
 
 function serializeProviderPayload(payload: unknown): string {
@@ -85,6 +87,7 @@ export function unhandledProviderFrameJournalItem(
       text: display?.text ?? `${provider} · ${kind}`,
       providerFrame: { provider, kind, payload: bounded }
     },
-    blobs: bounded.truncated ? [{ digest: bounded.digest, payload: serialized }] : []
+    blobs: bounded.truncated ? [{ digest: bounded.digest, payload: serialized }] : [],
+    classification: classification === 'error-surface' ? 'error-surface' : 'timeline-substantive'
   }
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​51 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​46 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​30 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​24 |

<!-- /orca-pr-loc -->

Part of the #14600 review follow-ups (no-silent-drop findings V1 + V2, confirmed by both review passes).

## Defects

**V1 — substantive provider activity silently dropped after eight fallback rows.** Once a turn had eight generic frames, every later unknown frame returned with no row, no count, and no suppression summary (`codex-structured-journal-translation.ts`). A provider upgrade emitting more unmatched notifications could hide real work — or real failures — from desktop and mobile.

**V2 — unknown future delta methods vanished even when the payload reported an error.** `classifyProviderFrame` ran the `…delta` name-suffix heuristic before payload error inspection, so an unknown delta method carrying `error` fell to the unhandled path and returned null (`provider-frame-disposition.ts`).

## Failure scenarios

- A Codex release adds a chatty notification family; the ninth and later frames of a turn — including a failure notice — never reach the journal, so the user sees a turn "complete" while activity was discarded.
- A future `item/<new>/outputDelta` whose payload is `{ error: … }` is classified `stream-into-item`, has no stream handler, and disappears entirely.

## Fix

- The per-turn cap now upserts **one summary row per turn** (`provider-frame-suppressed:codex:<thread>:<turn>`) with an exact count ("N more provider notifications not shown for this turn"), so suppression is itself visible and countable.
- Frames classified `error-surface` are **exempt from the cap** — a cap can bound noise, never evidence.
- `classifyProviderFrame` now runs payload error inspection **before** the delta name-shape heuristic. Pinned stream methods are unaffected (they are handled by the item streams before this path runs); unknown deltas without error remain suppressed as stream-shaped, unchanged.
- `unhandledProviderFrameJournalItem` now returns its `classification` so the translator can apply the exemption.

## Changed pinned tests (deliberate)

- `codex-structured-journal-translation.test.ts` "bounds generic rows per turn…" previously asserted 28 unknown notifications produce **exactly eight rows and nothing else** — i.e. it pinned the silent drop as desired. It now asserts eight generic rows **plus one summary row with the exact count of 20**.
- `unhandled-provider-frame.test.ts` "never creates generic rows for known or unknown delta-shaped frames" previously asserted an unknown delta carrying `error` returns null — pinning the vanishing error. Split into: no-error deltas stay suppressed; an unknown delta reporting an error must surface as `error-surface`.

Both old assertions violated the program's no-silent-drop rule: content or activity must be surfaced, never quietly discarded.

## Verification

- New tests written first and proven red against the unmodified source (3 red: cap summary, cap error-bypass, delta-with-error).
- **Mutation tests** (break fix → red → restore), all red as required:
  1. Remove the error-surface cap exemption → "never lets the generic-row cap hide an error frame" fails.
  2. Restore the silent capped return (no summary row) → "bounds generic rows per turn while keeping the suppression visible and countable" fails.
  3. Restore the old classification order (delta heuristic before error inspection) → "surfaces an unknown delta-shaped frame whose payload reports an error" fails.
- Full `src/main/codex` + `src/main/native-chat` suites: 171 files, 1686 tests passed.
- Desktop typecheck (all three tsconfigs) and mobile typecheck pass. oxfmt clean.

Wire note: the summary row is an ordinary `status` journal item under the existing `orca` identity namespace — no new opcodes, no schema change, old clients render it as plain status text.
