### PR TITLE
fix(native-chat): bound history pages by bytes as well as rows

### DIFF
--- a/src/main/native-chat/agent-session-wire/agent-session-history-page.test.ts
+++ b/src/main/native-chat/agent-session-wire/agent-session-history-page.test.ts
@@ -10,6 +10,7 @@ import type {
   AgentSessionJournalIdentity
 } from '../../../shared/agent-session-journal-types'
 import { AGENT_SESSION_HISTORY_MAX_LIMIT } from '../../../shared/agent-session-wire'
+import { serializeRemoteRuntimePayload } from '../../../shared/remote-runtime-memory-limits'
 import { structuredAgentSessionPayloadFingerprint } from '../../../shared/structured-agent-session-mutation'
 import {
   openAgentSessionJournal,
@@ -190,6 +191,109 @@ describe('readAgentSessionHistory', () => {
       clientMessageId: 'msg-1',
       dispatchState: 'pending'
     })
+  })
+})
+
+describe('history page byte ceiling', () => {
+  // A legal user message may be 256 KiB; twenty of them serialize past the
+  // 4 MiB outbound channel cap, which closes the socket on overflow.
+  const LARGE_TEXT = 'x'.repeat(250 * 1024)
+
+  async function appendLargeItems(count: number): Promise<void> {
+    for (let ordinal = 1; ordinal <= count; ordinal += 1) {
+      await journal.appendItem(item(ordinal), body(`${ordinal}:${LARGE_TEXT}`), { fence: 1 })
+    }
+  }
+
+  function pageOf(result: ReturnType<typeof readAgentSessionHistory>) {
+    if (!result.ok) {
+      throw new Error(`expected a page, got reset ${result.reset}`)
+    }
+    // The actual channel gate: the page must serialize under the outbound cap.
+    serializeRemoteRuntimePayload(result.page)
+    return result.page
+  }
+
+  it('keeps a tail of legal large messages under the channel cap and still pages back to every item', async () => {
+    await appendLargeItems(20)
+
+    const tail = pageOf(
+      readAgentSessionHistory(journal, { sessionId: 'session-1', direction: 'tail', limit: 40 })
+    )
+    expect(tail.items.length).toBeGreaterThan(0)
+    expect(tail.hasOlder).toBe(true)
+
+    const seen = tail.items.map((entry) => entry.itemId)
+    let cursor = tail.window.nextCursor
+    let hasOlder = tail.hasOlder
+    let guard = 0
+    while (hasOlder) {
+      guard += 1
+      expect(guard).toBeLessThan(30)
+      const page = pageOf(
+        readAgentSessionHistory(journal, {
+          sessionId: 'session-1',
+          direction: 'before',
+          cursor,
+          limit: 40
+        })
+      )
+      expect(page.items.length).toBeGreaterThan(0)
+      seen.push(...page.items.map((entry) => entry.itemId))
+      cursor = page.window.nextCursor
+      hasOlder = page.hasOlder
+    }
+    expect(new Set(seen).size).toBe(20)
+  })
+
+  it('bounds a forward catch-up page by bytes and keeps replaying to the head', async () => {
+    const start = { epoch: journal.epoch, sequence: 0 }
+    await appendLargeItems(20)
+
+    const first = pageOf(
+      readAgentSessionHistory(journal, {
+        sessionId: 'session-1',
+        direction: 'after',
+        cursor: start,
+        limit: 40
+      })
+    )
+    expect(first.items.length).toBeGreaterThan(0)
+    expect(first.hasNewer).toBe(true)
+
+    const seen = first.items.map((entry) => entry.itemId)
+    let cursor = first.window.nextCursor
+    let hasNewer = first.hasNewer
+    let guard = 0
+    while (hasNewer) {
+      guard += 1
+      expect(guard).toBeLessThan(30)
+      const page = pageOf(
+        readAgentSessionHistory(journal, {
+          sessionId: 'session-1',
+          direction: 'after',
+          cursor,
+          limit: 40
+        })
+      )
+      expect(page.items.length).toBeGreaterThan(0)
+      seen.push(...page.items.map((entry) => entry.itemId))
+      cursor = page.window.nextCursor
+      hasNewer = page.hasNewer
+    }
+    expect(new Set(seen).size).toBe(20)
+  })
+
+  it('degrades a single over-budget item to a visible truncation marker instead of overflowing', async () => {
+    await journal.appendItem(item(1), body(`1:${'y'.repeat(3 * 1024 * 1024)}`), { fence: 1 })
+
+    const tail = pageOf(
+      readAgentSessionHistory(journal, { sessionId: 'session-1', direction: 'tail', limit: 40 })
+    )
+    expect(tail.items).toHaveLength(1)
+    const bodyOnPage = tail.items[0]?.body
+    expect(bodyOnPage?.kind).toBe('status')
+    expect(bodyOnPage?.kind === 'status' ? bodyOnPage.text : '').toContain('[Orca: item truncated')
   })
 })
 

--- a/src/main/native-chat/agent-session-wire/agent-session-history-page.ts
+++ b/src/main/native-chat/agent-session-wire/agent-session-history-page.ts
@@ -11,8 +11,10 @@ import { agentJournalSubmissionKey } from '../../../shared/agent-session-journal
 import type {
   AgentJournalCursor,
   AgentJournalRenderItem,
-  AgentJournalSnapshot
+  AgentJournalSnapshot,
+  AgentJournalSubmission
 } from '../../../shared/agent-session-journal-types'
+import { REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES } from '../../../shared/remote-runtime-memory-limits'
 import {
   AGENT_SESSION_HISTORY_DEFAULT_LIMIT,
   AGENT_SESSION_HISTORY_MAX_LIMIT,
@@ -23,6 +25,83 @@ import {
 } from '../../../shared/agent-session-wire'
 import type { AgentSessionJournal } from '../agent-session-journal/journal-store'
 import { projectJournalBatch } from './agent-session-journal-batch'
+
+/** Byte budget for one history page. Half the outbound channel cap, so the RPC
+ *  envelope and page framing always fit beside the items: row counts alone
+ *  cannot protect the channel — forty legal 256 KiB messages serialize past the
+ *  4 MiB outbound cap, and an overflow closes the client's socket on every
+ *  reopen. Pages degrade to fewer rows instead; `hasOlder`/`hasNewer` keep the
+ *  client paging. */
+export const AGENT_SESSION_HISTORY_MAX_PAGE_BYTES = REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES / 2
+
+/** Item bytes plus the submission the page would carry alongside it. */
+function historyEntryBytes(
+  item: AgentJournalRenderItem,
+  submissionBytes: ReadonlyMap<string, number>
+): number {
+  return Buffer.byteLength(JSON.stringify(item), 'utf8') + (submissionBytes.get(item.itemId) ?? 0)
+}
+
+function submissionBytesByItemId(
+  submissions: readonly AgentJournalSubmission[]
+): Map<string, number> {
+  return new Map(
+    submissions.map((submission) => [
+      agentJournalSubmissionKey(submission.clientMessageId),
+      Buffer.byteLength(JSON.stringify(submission), 'utf8')
+    ])
+  )
+}
+
+/** Visible stand-in for an item whose body alone exceeds the page budget. The
+ *  full body stays in the journal — this bounds what ONE PAGE carries, it never
+ *  rewrites the record. */
+function oversizedHistoryItem(
+  item: AgentJournalRenderItem,
+  byteLength: number
+): AgentJournalRenderItem {
+  return {
+    ...item,
+    body: {
+      kind: 'status',
+      text: `[Orca: item truncated — ${byteLength} bytes exceeds the history page budget]`
+    }
+  }
+}
+
+/**
+ * Keep the edge of the window nearest the requested position within the byte
+ * budget: `newest` for tail/backward pages, `oldest` for forward catch-up. The
+ * page stays contiguous, so the dropped remainder is exactly what the next page
+ * serves. Never empties a non-empty window — a single over-budget item degrades
+ * to a visible marker so the client always makes progress.
+ */
+function boundHistoryItemsByBytes(
+  items: AgentJournalRenderItem[],
+  keep: 'newest' | 'oldest',
+  submissionBytes: ReadonlyMap<string, number>,
+  maxBytes: number
+): { items: AgentJournalRenderItem[]; dropped: number } {
+  const ordered = keep === 'newest' ? items.toReversed() : items
+  const kept: AgentJournalRenderItem[] = []
+  let total = 0
+  for (const item of ordered) {
+    const bytes = historyEntryBytes(item, submissionBytes)
+    if (kept.length === 0 && bytes > maxBytes) {
+      kept.push(oversizedHistoryItem(item, bytes))
+      break
+    }
+    if (total + bytes > maxBytes) {
+      break
+    }
+    kept.push(item)
+    total += bytes
+  }
+  return {
+    items: keep === 'newest' ? kept.toReversed() : kept,
+    dropped: items.length - kept.length
+  }
+}
 
 /** Clamped, never rejected: a client asking for more than the host will serve
  *  should get a smaller page and keep paging, not an error mid-scroll. */
@@ -57,14 +136,20 @@ export function readAgentSessionHistory(
   const older = cursor
     ? snapshot.items.filter((item) => item.sequence < cursor.sequence)
     : snapshot.items
-  const items = older.slice(Math.max(0, older.length - limit))
+  const windowed = older.slice(Math.max(0, older.length - limit))
+  const { items, dropped } = boundHistoryItemsByBytes(
+    windowed,
+    'newest',
+    submissionBytesByItemId(snapshot.submissions),
+    AGENT_SESSION_HISTORY_MAX_PAGE_BYTES
+  )
   return {
     ok: true,
     page: buildPage({
       snapshot,
       direction: request.direction,
       items,
-      hasOlder: older.length > items.length,
+      hasOlder: older.length > windowed.length || dropped > 0,
       hasNewer: older.length < snapshot.items.length,
       fallbackCursor: cursor ?? { epoch: snapshot.cursor.epoch, sequence: 0 },
       nextCursor: items[0]
@@ -90,8 +175,14 @@ function readForward(
   if (!since.ok) {
     return { ok: false, reset: since.reset, snapshot }
   }
-  const rows = since.rows.slice(0, limit)
-  const projected = projectJournalBatch({
+  const submissionBytes = submissionBytesByItemId(snapshot.submissions)
+  const batchBytes = (items: readonly AgentJournalRenderItem[]): number =>
+    items.reduce((total, item) => total + historyEntryBytes(item, submissionBytes), 0)
+  // Rows replay forward, so the byte bound shrinks the ROW window rather than
+  // clipping projected items: dropping an item while advancing the cursor past
+  // the rows that touched it would lose that revision for good.
+  let rows = since.rows.slice(0, limit)
+  let projected = projectJournalBatch({
     rows,
     snapshot,
     afterSequence: cursor.sequence,
@@ -100,13 +191,39 @@ function readForward(
   if (!projected.ok) {
     return { ok: false, reset: projected.reset, snapshot }
   }
+  while (
+    rows.length > 1 &&
+    batchBytes(projected.batch.items) > AGENT_SESSION_HISTORY_MAX_PAGE_BYTES
+  ) {
+    rows = rows.slice(0, Math.ceil(rows.length / 2))
+    const shrunk = projectJournalBatch({
+      rows,
+      snapshot,
+      afterSequence: cursor.sequence,
+      canonicalItemId: (itemId) => journal.canonicalItemId(itemId)
+    })
+    if (!shrunk.ok) {
+      return { ok: false, reset: shrunk.reset, snapshot }
+    }
+    projected = shrunk
+  }
+  // One row can still touch an over-budget item; degrade it visibly.
+  const items =
+    batchBytes(projected.batch.items) > AGENT_SESSION_HISTORY_MAX_PAGE_BYTES
+      ? projected.batch.items.map((item) => {
+          const bytes = historyEntryBytes(item, submissionBytes)
+          return bytes > AGENT_SESSION_HISTORY_MAX_PAGE_BYTES
+            ? oversizedHistoryItem(item, bytes)
+            : item
+        })
+      : projected.batch.items
   const lastSequence = rows.at(-1)?.seq ?? cursor.sequence
   return {
     ok: true,
     page: buildPage({
       snapshot,
       direction: 'after',
-      items: projected.batch.items,
+      items,
       removedItemIds: projected.batch.removedItemIds,
       // Reading after a position means there is something before it.
       hasOlder: cursor.sequence > 0,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​104 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​104 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​123 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​117 |

<!-- /orca-pr-loc -->

Part of the #14600 review follow-ups (no-silent-drop finding V3, confirmed by both review passes). Mobile is the primary proof target for this program — this is user-facing.

## Defect

History pagination was ROW-bounded only (`agent-session-history-page.ts`). A legal user message may be 256 KiB (`MAX_PROMPT_BYTES`), and mobile requests a 40-row tail before it subscribes, so a single history response could serialize past `REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES` (4 MiB). The outbound channel closes the socket on overflow.

## Failure scenario

A user sends a handful of large recent messages (e.g. pasted logs). On the next mobile open, `agentSession.history { direction: 'tail', limit: 40 }` produces a >4 MiB response, the channel refuses it, and the stream drops before the client can page or subscribe. Every reopen repeats the same request — an unrecoverable disconnect loop from the user's side.

## Fix

`AGENT_SESSION_HISTORY_MAX_PAGE_BYTES` = half the outbound cap (2 MiB), applied host-side to all three directions:

- **tail / before**: the page keeps the newest contiguous run of the window that fits the budget (items measured together with their overlapping submissions); the dropped older remainder sets `hasOlder`, so the client keeps paging with strictly smaller pages. Progress is guaranteed — a page is never emptied.
- **after** (catch-up): the ROW window shrinks until the projected batch fits, rather than clipping projected items — dropping an item while advancing the cursor past the rows that touched it would lose that revision. The remainder sets `hasNewer`.
- A single item whose body alone exceeds the budget degrades to a **visible truncation marker** (`[Orca: item truncated — N bytes exceeds the history page budget]`). The journal record itself is never rewritten; only what one page carries is bounded.

No wire change: fewer rows per page and `hasOlder`/`hasNewer` are existing semantics, so old clients keep working unchanged.

## Verification

Real size-based tests, not row-count proxies (`agent-session-history-page.test.ts`), each proven red against the unmodified source:

- 20 × 250 KiB messages in a real on-disk journal: the tail page and every subsequent `before` page must pass `serializeRemoteRuntimePayload` (the actual channel gate) and the paging loop must reach all 20 items.
- Same for a forward `after` catch-up replay to the head.
- A single 3 MiB item pages as one visibly-truncated marker item instead of overflowing.

**Mutation tests** (break fix → red → restore), all red:
1. Bypass tail/before byte bounding → tail test and marker test fail.
2. Disable the forward shrink loop → catch-up test fails.
3. Ship the oversized item unmarked → marker test fails.

Full `src/main/native-chat` + `src/main/codex` + `src/shared` suites pass (6.6k tests). Mobile suite (3630 tests) and BOTH typechecks pass. oxfmt clean.

## Adjacent gap (not in this PR)

The `ok:false` reset path and the subscribe `snapshot` event still inline a full snapshot, which can also exceed the outbound cap for a very large timeline. That is a separate seam from history paging and likely interacts with other in-flight review fixes; flagged in the worker report rather than expanded into here.
