### PR TITLE
fix(native-chat): close minor silent-drop seams in the journal path

### DIFF
--- a/src/main/codex/codex-structured-item-translation.test.ts
+++ b/src/main/codex/codex-structured-item-translation.test.ts
@@ -53,6 +53,23 @@ function keysFor(items: CodexThreadItem[]): string[] {
     )
 }
 
+describe('codex turn ordinals', () => {
+  it('releases a forgotten turn without ever reusing an ordinal it assigned', () => {
+    const ordinals = new CodexTurnOrdinals()
+    expect(ordinals.ordinalFor('thread-1', 'turn-1', 'item-1')).toBe(0)
+    expect(ordinals.ordinalFor('thread-1', 'turn-1', 'item-2')).toBe(1)
+
+    ordinals.forgetTurn('thread-1', 'turn-1')
+
+    // A straggler for the released turn — even a previously seen item id — gets
+    // a FRESH ordinal: reusing a released slot would upsert another item's row.
+    expect(ordinals.ordinalFor('thread-1', 'turn-1', 'item-1')).toBe(2)
+    expect(ordinals.ordinalFor('thread-1', 'turn-1', 'item-3')).toBe(3)
+    // Other turns are untouched.
+    expect(ordinals.ordinalFor('thread-1', 'turn-2', 'item-1')).toBe(0)
+  })
+})
+
 describe('codex item identity', () => {
   it('gives a resumed turn the same message keys as the live turn it renumbered', () => {
     expect(keysFor(LIVE_TURN)).toEqual(keysFor(RESUMED_TURN))

--- a/src/main/codex/codex-structured-item-translation.ts
+++ b/src/main/codex/codex-structured-item-translation.ts
@@ -54,23 +54,33 @@ export function readCodexThreadItem(value: unknown): CodexThreadItem | null {
  * than no key, because it would look reconcilable and reconcile wrongly.
  */
 export class CodexTurnOrdinals {
-  private readonly turns = new Map<string, Map<string, number>>()
+  private readonly turns = new Map<string, { assigned: Map<string, number>; next: number }>()
 
   ordinalFor(threadId: string, turnId: string, codexItemId: string): number {
     const turnKey = `${encodeURIComponent(threadId)}:${encodeURIComponent(turnId)}`
-    const assigned = this.turns.get(turnKey) ?? new Map<string, number>()
-    this.turns.set(turnKey, assigned)
-    const existing = assigned.get(codexItemId)
+    let turn = this.turns.get(turnKey)
+    if (!turn) {
+      turn = { assigned: new Map(), next: 0 }
+      this.turns.set(turnKey, turn)
+    }
+    const existing = turn.assigned.get(codexItemId)
     if (existing !== undefined) {
       return existing
     }
-    const ordinal = assigned.size
-    assigned.set(codexItemId, ordinal)
+    const ordinal = turn.next
+    turn.assigned.set(codexItemId, ordinal)
+    turn.next += 1
     return ordinal
   }
 
-  forgetTurn(turnId: string): void {
-    this.turns.delete(turnId)
+  /** Releases a finished turn's per-item map while keeping its counter, so a
+   *  straggler frame can never be assigned an ordinal the turn already used —
+   *  a reused slot would upsert another item's journal row. */
+  forgetTurn(threadId: string, turnId: string): void {
+    const turn = this.turns.get(`${encodeURIComponent(threadId)}:${encodeURIComponent(turnId)}`)
+    if (turn) {
+      turn.assigned = new Map()
+    }
   }
 }
 

--- a/src/main/codex/codex-structured-journal-translation.test.ts
+++ b/src/main/codex/codex-structured-journal-translation.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type {
   AgentJournalItemBody,
   AgentJournalItemIdentity
@@ -6,6 +6,7 @@ import type {
 import { agentJournalItemKey } from '../../shared/agent-session-journal-item-key'
 import { projectStructuredItemsToNativeChat } from '../../shared/structured-agent-session-projection'
 import type { StructuredAgentSessionEventSink } from '../native-chat/agent-session-wire/structured-agent-session-event-sink'
+import { CodexTurnOrdinals } from './codex-structured-item-translation'
 import {
   createCodexJournalTranslator,
   MAX_CODEX_GENERIC_ROWS_PER_TURN
@@ -460,6 +461,18 @@ describe('codex journal translation', () => {
     )
 
     expect(tap.publishes()).toBe(1)
+  })
+
+  it('releases a turn ordinal map when the turn completes', () => {
+    const spy = vi.spyOn(CodexTurnOrdinals.prototype, 'forgetTurn')
+    try {
+      const { translator } = translatorWith()
+      translator.handle(TURN_STARTED)
+      translator.handle(notification('turn/completed', { turn: { id: TURN_ID } }))
+      expect(spy).toHaveBeenCalledWith(THREAD_ID, TURN_ID)
+    } finally {
+      spy.mockRestore()
+    }
   })
 
   it('journals malformed item events but never malformed deltas', () => {

--- a/src/main/codex/codex-structured-journal-translation.ts
+++ b/src/main/codex/codex-structured-journal-translation.ts
@@ -270,6 +270,7 @@ export function createCodexJournalTranslator(
         const turnId = readCodexTurnId(event.params) ?? currentTurnIds.get(event.threadId)
         if (turnId) {
           publishTurnLifecycle(event.sessionId, event.threadId, turnId, 'completed')
+          ordinals.forgetTurn(event.threadId, turnId)
         }
         // A later item with no turn of its own belongs to no turn, not to the
         // one that just ended.

--- a/src/main/codex/codex-tui-rollout-proof.test.ts
+++ b/src/main/codex/codex-tui-rollout-proof.test.ts
@@ -1,3 +1,6 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import {
   codexTuiStatusProbeInput,
@@ -38,6 +41,32 @@ describe('Codex TUI rollout proof', () => {
       resolvePinnedCodexRolloutProof('/pinned', THREAD, { listFiles: files, readSessionMetaId })
     ).resolves.toBe(`/pinned/sessions/2026/08/11/rollout-now-${THREAD}.jsonl`)
     expect(readSessionMetaId).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips a rollout file that vanishes mid-scan instead of aborting the proof', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-rollout-proof-'))
+    try {
+      const day = join(root, 'sessions', '2026', '08', '11')
+      await mkdir(day, { recursive: true })
+      const real = join(day, `rollout-now-${THREAD}.jsonl`)
+      await writeFile(
+        real,
+        `${JSON.stringify({ type: 'session_meta', payload: { id: THREAD } })}\n`
+      )
+      // Listed but already deleted by the time the scan reads it — Codex prunes
+      // and rewrites rollout files while the scan runs.
+      const vanished = join(day, `rollout-gone-${THREAD}.jsonl`)
+      const files = async function* (): AsyncGenerator<string> {
+        yield vanished
+        yield real
+      }
+
+      await expect(
+        resolvePinnedCodexRolloutProof(root, THREAD, { listFiles: files })
+      ).resolves.toBe(real)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
   })
 
   it('rejects a rollout whose session_meta names another thread', async () => {

--- a/src/main/codex/codex-tui-rollout-proof.ts
+++ b/src/main/codex/codex-tui-rollout-proof.ts
@@ -118,7 +118,14 @@ export async function proveCodexTuiRollout(input: {
 }
 
 async function readCodexRolloutSessionMetaId(filePath: string): Promise<string | null> {
-  const file = await open(filePath, 'r')
+  // A listed rollout may vanish before it is read — Codex prunes and rewrites
+  // these files. One missing file must not abort the whole scan.
+  let file: Awaited<ReturnType<typeof open>>
+  try {
+    file = await open(filePath, 'r')
+  } catch {
+    return null
+  }
   try {
     const buffer = Buffer.alloc(ROLLOUT_READ_LIMIT)
     const { bytesRead } = await file.read(buffer, 0, buffer.length, 0)

--- a/src/main/native-chat/agent-session-journal/journal-compaction.ts
+++ b/src/main/native-chat/agent-session-journal/journal-compaction.ts
@@ -113,3 +113,17 @@ function retainTail(
   const start = byAge === -1 ? byCount : Math.min(byAge, byCount)
   return rows.slice(start)
 }
+
+/** Only when the retention window would actually drop rows: inside it,
+ *  compaction rewrites an identical log, and doing that per append is a full
+ *  state serialization on the hot path. */
+export function journalTailIsReadyToCompact(
+  tailRows: readonly JournalRow[],
+  policy: JournalCompactionPolicy,
+  now: number
+): boolean {
+  if (tailRows.length <= policy.minTailRows * 2) {
+    return false
+  }
+  return (tailRows[0]?.ts ?? now) < now - policy.retainTailMs
+}

--- a/src/main/native-chat/agent-session-journal/journal-corruption-quarantine.ts
+++ b/src/main/native-chat/agent-session-journal/journal-corruption-quarantine.ts
@@ -38,3 +38,20 @@ export async function quarantineUnreadableSchema(journalDir: string): Promise<vo
     await quarantineJournalRemainder(journalDir, preserved)
   }
 }
+
+/** The disclosure row for lines that failed to parse. Skipped lines are lost
+ *  rows; counting them silently is the drop this exists to prevent. */
+export function malformedRowsDisclosure(count: number): {
+  identity: { provider: 'orca'; clientMessageId: string }
+  body: { kind: 'status'; text: string }
+} {
+  const plural = count === 1 ? '' : 's'
+  return {
+    // One stable identity, so a reopen upserts the same row instead of adding one.
+    identity: { provider: 'orca', clientMessageId: 'journal-malformed-lines' },
+    body: {
+      kind: 'status',
+      text: `${count} journal line${plural} could not be read and ${count === 1 ? 'was' : 'were'} skipped`
+    }
+  }
+}

--- a/src/main/native-chat/agent-session-journal/journal-open.ts
+++ b/src/main/native-chat/agent-session-journal/journal-open.ts
@@ -31,6 +31,9 @@ export type JournalLoad = {
   readOnly: boolean
   /** Set when the surviving prefix is unusable and the caller must roll the epoch. */
   corrupt: boolean
+  /** Log lines skipped because they failed to parse (schema-version rows are
+   *  `readOnly`, never counted here). The store discloses these in the timeline. */
+  malformedRows: number
   sizeBytes: number
   /** Raw unreadable suffix retained for quarantine instead of deletion. */
   quarantineRemainder?: string
@@ -88,6 +91,7 @@ export async function loadJournal(
     compactedThrough,
     readOnly: log.unreadable || (snapshot?.v ?? 0) > AGENT_SESSION_JOURNAL_SCHEMA_VERSION,
     corrupt,
+    malformedRows: log.malformed,
     sizeBytes: tailRows.reduce((total, row) => total + journalRowByteLength(row), 0),
     quarantineRemainder
   }
@@ -101,6 +105,7 @@ function emptyReadOnlyLoad(sessionId: string): JournalLoad {
     compactedThrough: 0,
     readOnly: true,
     corrupt: false,
+    malformedRows: 0,
     sizeBytes: 0
   }
 }

--- a/src/main/native-chat/agent-session-journal/journal-row-schema.test.ts
+++ b/src/main/native-chat/agent-session-journal/journal-row-schema.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest'
+import { parseJournalRow } from './journal-row-schema'
+
+const BASE = { v: 1, epoch: 'epoch-1', seq: 1, fence: 1, ts: 1 }
+
+function parse(row: Record<string, unknown>): boolean {
+  return parseJournalRow(JSON.stringify(row)).ok
+}
+
+describe('journal row validation', () => {
+  it('accepts every fully-formed row shape this build writes', () => {
+    expect(
+      parse({
+        ...BASE,
+        kind: 'epoch',
+        reason: 'session_created',
+        providerHandle: { kind: 'codex', threadId: 't' }
+      })
+    ).toBe(true)
+    expect(
+      parse({
+        ...BASE,
+        kind: 'item',
+        itemId: 'i-1',
+        revision: 1,
+        body: { kind: 'status', text: 'x' }
+      })
+    ).toBe(true)
+    expect(parse({ ...BASE, kind: 'tombstone', itemId: 'i-1', revision: 2 })).toBe(true)
+    expect(
+      parse({
+        ...BASE,
+        kind: 'submission',
+        clientMessageId: 'm-1',
+        payloadFingerprint: 'a'.repeat(64),
+        providerHandle: { kind: 'codex', threadId: 't' },
+        body: { kind: 'message', role: 'user', blocks: [] }
+      })
+    ).toBe(true)
+    expect(
+      parse({
+        ...BASE,
+        kind: 'dispatch',
+        clientMessageId: 'm-1',
+        state: 'accepted',
+        providerItemId: 'codex:t:turn:0',
+        reason: null
+      })
+    ).toBe(true)
+  })
+
+  it('rejects a dispatch row missing its state or with mistyped fields', () => {
+    expect(parse({ ...BASE, kind: 'dispatch', clientMessageId: 'm-1' })).toBe(false)
+    expect(
+      parse({
+        ...BASE,
+        kind: 'dispatch',
+        clientMessageId: 'm-1',
+        state: 7,
+        providerItemId: null,
+        reason: null
+      })
+    ).toBe(false)
+    expect(
+      parse({
+        ...BASE,
+        kind: 'dispatch',
+        clientMessageId: 'm-1',
+        state: 'accepted',
+        providerItemId: 7,
+        reason: null
+      })
+    ).toBe(false)
+    expect(
+      parse({
+        ...BASE,
+        kind: 'dispatch',
+        clientMessageId: 'm-1',
+        state: 'rejected',
+        providerItemId: null,
+        reason: 7
+      })
+    ).toBe(false)
+  })
+
+  it('rejects a submission row without its fingerprint, handle, or message body', () => {
+    const submission = {
+      ...BASE,
+      kind: 'submission',
+      clientMessageId: 'm-1',
+      payloadFingerprint: 'a'.repeat(64),
+      providerHandle: { kind: 'codex', threadId: 't' },
+      body: { kind: 'message', role: 'user', blocks: [] }
+    }
+    expect(parse({ ...submission, payloadFingerprint: undefined as never })).toBe(false)
+    expect(parse({ ...submission, providerHandle: 'codex' })).toBe(false)
+    expect(parse({ ...submission, body: 'hi' })).toBe(false)
+  })
+
+  it('rejects an item row whose body is not a kinded object', () => {
+    expect(parse({ ...BASE, kind: 'item', itemId: 'i-1', revision: 1 })).toBe(false)
+    expect(parse({ ...BASE, kind: 'item', itemId: 'i-1', revision: 1, body: 'text' })).toBe(false)
+    expect(parse({ ...BASE, kind: 'item', itemId: 'i-1', revision: 1, body: {} })).toBe(false)
+  })
+
+  it('rejects an epoch row without a provider handle', () => {
+    expect(parse({ ...BASE, kind: 'epoch', reason: 'session_created' })).toBe(false)
+  })
+
+  it('keeps forward compatibility for new dispatch states without a version bump', () => {
+    expect(
+      parse({
+        ...BASE,
+        kind: 'dispatch',
+        clientMessageId: 'm-1',
+        state: 'some-future-state',
+        providerItemId: null,
+        reason: null
+      })
+    ).toBe(true)
+  })
+})

--- a/src/main/native-chat/agent-session-journal/journal-row-schema.ts
+++ b/src/main/native-chat/agent-session-journal/journal-row-schema.ts
@@ -134,6 +134,18 @@ function upcastRow(record: Record<string, unknown>, version: number): Record<str
   return current
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/** Every render body is a kinded object; anything else would poison the reducer. */
+function isKindedBody(value: unknown): boolean {
+  return isPlainObject(value) && typeof value.kind === 'string' && value.kind.length > 0
+}
+
+/** Field values are type-checked, never enum-checked: a future build adding a
+ *  dispatch state or handle kind must bump the row version, but this build
+ *  should not misread a same-version row as malformed over a wider enum. */
 function isJournalRow(record: Record<string, unknown>): record is JournalRow {
   if (typeof record.kind !== 'string' || !ROW_KINDS.has(record.kind)) {
     return false
@@ -148,13 +160,36 @@ function isJournalRow(record: Record<string, unknown>): record is JournalRow {
   ) {
     return false
   }
-  if (record.kind === 'item' || record.kind === 'tombstone') {
+  if (record.kind === 'item') {
+    return (
+      typeof record.itemId === 'string' &&
+      Number.isInteger(record.revision) &&
+      isKindedBody(record.body)
+    )
+  }
+  if (record.kind === 'tombstone') {
     return typeof record.itemId === 'string' && Number.isInteger(record.revision)
   }
-  if (record.kind === 'submission' || record.kind === 'dispatch') {
-    return typeof record.clientMessageId === 'string' && record.clientMessageId.length > 0
+  if (record.kind === 'submission') {
+    return (
+      typeof record.clientMessageId === 'string' &&
+      record.clientMessageId.length > 0 &&
+      typeof record.payloadFingerprint === 'string' &&
+      isPlainObject(record.providerHandle) &&
+      isKindedBody(record.body)
+    )
   }
-  return typeof record.reason === 'string'
+  if (record.kind === 'dispatch') {
+    return (
+      typeof record.clientMessageId === 'string' &&
+      record.clientMessageId.length > 0 &&
+      typeof record.state === 'string' &&
+      record.state.length > 0 &&
+      (record.providerItemId === null || typeof record.providerItemId === 'string') &&
+      (record.reason === null || typeof record.reason === 'string')
+    )
+  }
+  return typeof record.reason === 'string' && isPlainObject(record.providerHandle)
 }
 
 /** Approximate on-disk cost of a row, used for the per-session size bound. */

--- a/src/main/native-chat/agent-session-journal/journal-store.test.ts
+++ b/src/main/native-chat/agent-session-journal/journal-store.test.ts
@@ -384,7 +384,7 @@ describe('schema', () => {
     expect(await readFile(logPath, 'utf-8')).toContain('"v":99')
   })
 
-  it('skips a malformed line without giving up the journal', async () => {
+  it('skips a malformed line without giving up the journal, and discloses the skip', async () => {
     const journal = await open()
     await journal.appendItem(item(0), body('a'), { fence: 1 })
     const logPath = join(root, JOURNAL_LOG_FILE)
@@ -392,7 +392,32 @@ describe('schema', () => {
 
     const reopened = await open()
     expect(reopened.isReadOnly).toBe(false)
-    expect(reopened.snapshot().items).toHaveLength(1)
+    const items = reopened.snapshot().items
+    // The surviving row is untouched…
+    expect(items.some((entry) => entry.body.kind === 'message')).toBe(true)
+    // …and the skip is visible in the timeline instead of silently swallowed.
+    expect(
+      items.some(
+        (entry) => entry.body.kind === 'status' && entry.body.text.includes('could not be read')
+      )
+    ).toBe(true)
+  })
+
+  it('keeps one disclosure row across reopens instead of stacking duplicates', async () => {
+    const journal = await open()
+    await journal.appendItem(item(0), body('a'), { fence: 1 })
+    const logPath = join(root, JOURNAL_LOG_FILE)
+    await writeFile(logPath, `${await readFile(logPath, 'utf-8')}{not json\n`, 'utf-8')
+
+    await open()
+    const reopened = await open()
+    expect(
+      reopened
+        .snapshot()
+        .items.filter(
+          (entry) => entry.body.kind === 'status' && entry.body.text.includes('could not be read')
+        )
+    ).toHaveLength(1)
   })
 
   it('repairs a torn tail before acknowledging the next append', async () => {

--- a/src/main/native-chat/agent-session-journal/journal-store.ts
+++ b/src/main/native-chat/agent-session-journal/journal-store.ts
@@ -21,12 +21,14 @@ import { agentJournalItemKey } from '../../../shared/agent-session-journal-item-
 import {
   compactJournal,
   DEFAULT_JOURNAL_COMPACTION_POLICY,
+  journalTailIsReadyToCompact,
   type JournalCompactionPolicy
 } from './journal-compaction'
 import { readJournalSince } from './journal-cursor'
 import { publishNewEpoch } from './journal-epoch-rollover'
 import { appendJournalRows, ensureJournalDir } from './journal-log-file'
 import {
+  malformedRowsDisclosure,
   quarantineCorruptSuffix,
   quarantineUnreadableSchema
 } from './journal-corruption-quarantine'
@@ -81,6 +83,7 @@ export class AgentSessionJournal {
   private compactedThrough = 0
   private sizeBytes = 0
   private readOnly = false
+  private malformedRows = 0
   /** Serializes sequence assignment with the durable write behind it. */
   private writes: Promise<unknown> = Promise.resolve()
 
@@ -128,9 +131,16 @@ export class AgentSessionJournal {
     this.compactedThrough = loaded.compactedThrough
     this.sizeBytes = loaded.sizeBytes
     this.readOnly = loaded.readOnly
+    this.malformedRows = loaded.malformedRows
     if (loaded.corrupt && !loaded.readOnly) {
       // The epoch stays put: no intact history is discarded to recover.
       await quarantineCorruptSuffix(this.journalDir, this.tailRows, loaded.quarantineRemainder)
+    }
+    if (this.malformedRows > 0 && !this.readOnly) {
+      const disclosure = malformedRowsDisclosure(this.malformedRows)
+      await this.appendItem(disclosure.identity, disclosure.body, {
+        fence: this.state.highestFence
+      })
     }
   }
 
@@ -268,16 +278,6 @@ export class AgentSessionJournal {
     return pending
   }
 
-  /** Only when the retention window would actually drop rows: inside it,
-   *  compaction rewrites an identical log, and doing that per append is a full
-   *  state serialization on the hot path. */
-  private shouldAutoCompact(now: number): boolean {
-    if (!this.autoCompact || this.tailRows.length <= this.compaction.minTailRows * 2) {
-      return false
-    }
-    return (this.tailRows[0]?.ts ?? now) < now - this.compaction.retainTailMs
-  }
-
   async compact(now = this.now()): Promise<void> {
     assertJournalWritable(this.readOnly, this.identity.sessionId)
     const result = await compactJournal({
@@ -354,7 +354,7 @@ export class AgentSessionJournal {
       this.sizeBytes += journalRowByteLength(row)
       // Nothing else calls compact(), so without this the log only ever grows —
       // until the size bound refuses every append for the rest of the session.
-      if (this.shouldAutoCompact(ts)) {
+      if (this.autoCompact && journalTailIsReadyToCompact(this.tailRows, this.compaction, ts)) {
         await this.compact(ts)
       }
       return row


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​209 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​206 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​113 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​24 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​89 |

<!-- /orca-pr-loc -->

Part of the #14600 review follow-ups (grouped minor no-silent-drop items, V4). Four of the five grouped items are fixed here; the event-sink item is reported instead (see end).

## Defects and fixes

1. **One vanished rollout file aborted the whole TUI proof scan.** `codex-tui-rollout-proof.ts` called `open()` outside its try, so a rollout file deleted between listing and reading rejected the entire scan and fed the indeterminate-owner path. The open is now guarded; a missing file is skipped and the scan continues. (The indeterminate-path latch itself is another worker's scope.)

2. **`CodexTurnOrdinals.forgetTurn` was dead code with a key mismatch** — it deleted a bare `turnId` while keys are `thread:turn`, so translator ordinal maps grew for the acquisition lifetime. It now takes `(threadId, turnId)`, is called on `turn/completed`, and releases the finished turn's per-item map while **keeping the ordinal counter**: deleting the counter too would let a straggler frame reuse an ordinal the turn already assigned, upserting another item's journal row. (The translator's `identities` cache is deliberately retained — it is what shields duplicate frames from re-deriving identities.)

3. **The `malformed` line counter was incremented but never consumed.** Skipped journal lines are lost rows the user never heard about. The count now propagates through `loadJournal` to the store (`journal.malformedRowCount`) and, when writable, the open discloses it in the timeline as one status row under a stable identity (`orca:journal-malformed-lines`) — reopens upsert the same row, never stack duplicates. The malformed lines themselves stay on disk untouched; nothing is deleted or rewritten.

4. **Dispatch rows were barely schema-validated** (only `clientMessageId`), and submission/epoch/item rows skipped their payloads. `isJournalRow` now type-checks every field this build writes: dispatch `state`/`providerItemId`/`reason`, submission fingerprint + provider handle + kinded body, item kinded body, epoch provider handle. Values are **type-checked, never enum-checked** — a same-version row with a wider enum (e.g. a future dispatch state) still parses, keeping remote-wire forward compatibility; genuinely new shapes must bump the row version, which already fails closed as `unreadable`.

## Changed pinned test (deliberate)

`journal-store.test.ts` "skips a malformed line without giving up the journal" asserted `snapshot().items` has exactly 1 item — pinning the silent skip. It now asserts the surviving row is untouched AND the skip is disclosed in the timeline, plus a second test that reopens do not stack duplicate disclosure rows. The old assertion violated the no-silent-drop rule.

## Verification

All nine new tests written first and proven red against the unmodified source. **Mutation tests** (break → red → restore), all red:
1. Unguard `open()` → vanish-mid-scan test fails.
2. Make `forgetTurn` delete the counter too → ordinal-reuse test fails.
3. Drop the `turn/completed` wiring → wiring test fails.
4. Remove the disclosure append → both disclosure tests fail.
5. Revert dispatch/submission validation → both schema-rejection tests fail.

Full `src/main/native-chat` + `src/main/codex` + `src/shared` suites pass (6646 tests; one earlier run hit a known-flaky perf test that did not reproduce across two re-runs). Mobile suite (3630 tests) and BOTH typechecks pass. oxfmt clean.

## Reported, not fixed here

**Event-sink journal-append failures only reach a logger** (`onEventSinkError` → `deps.onError` log scope): a persistent disk-full condition still drops provider frames with no user-visible signal. Surfacing it requires new subscriber/host plumbing that overlaps files other review workers are changing in parallel (and the never-compacted-journal finding lands in the same seam), so it is reported to the coordinator rather than half-fixed here.
