### PR TITLE
fix(workspace-cleanup): stop pre-selecting workspaces for deletion

### DIFF
--- a/src/renderer/src/components/workspace-cleanup/WorkspaceCleanupDialog.stale-while-revalidate.test.tsx
+++ b/src/renderer/src/components/workspace-cleanup/WorkspaceCleanupDialog.stale-while-revalidate.test.tsx
@@ -7,6 +7,7 @@ import type {
   WorkspaceCleanupScanProgress,
   WorkspaceCleanupScanResult
 } from '../../../../shared/workspace-cleanup'
+import type { WorkspaceCleanupBrowseState } from '../../../../shared/workspace-cleanup-browse-state'
 import { createTestStore, seedStore } from '../../store/slices/store-test-helpers'
 import { resetWorkspaceCleanupBrowsePersistTimer } from '../../store/slices/workspace-cleanup-browse'
 import { NOW, makeCandidate } from '../../store/slices/workspace-cleanup-slice-test-harness'
@@ -349,6 +350,35 @@ describe('WorkspaceCleanupDialog stale-while-revalidate', () => {
     expect(rowCheckbox('alpha')?.getAttribute('aria-checked')).toBe('true')
   })
 
+  it('reports selections removed by facet filters', async () => {
+    installApi(cachedFleet())
+    await renderDialog()
+    await openDialog()
+
+    await act(async () => rowCheckbox('alpha')?.click())
+    const browse = holders.store.getState().workspaceCleanupBrowse as WorkspaceCleanupBrowseState
+    await act(async () => {
+      holders.store.setState({
+        workspaceCleanupBrowse: {
+          ...browse,
+          filters: {
+            ...browse.filters,
+            safety: { ...browse.filters.safety, tiers: ['review'] }
+          }
+        }
+      })
+    })
+    await flush()
+
+    expect(holders.infoToasts).toContain(
+      '1 selected workspace is hidden by the current filters and was deselected.'
+    )
+
+    await act(async () => holders.store.setState({ workspaceCleanupBrowse: browse }))
+    await flush()
+    expect(rowCheckbox('alpha')?.getAttribute('aria-checked')).toBe('false')
+  })
+
   it('adopts the in-flight scan on reopen instead of starting a duplicate', async () => {
     const rig = installApi(cachedFleet())
     await renderDialog()
@@ -432,5 +462,38 @@ describe('WorkspaceCleanupDialog stale-while-revalidate', () => {
     expect(rowCheckbox('alpha')?.getAttribute('aria-checked')).toBe('true')
     expect(rowNames()).not.toContain('beta')
     expect(holders.infoToasts).toContain('1 selected workspace no longer exists.')
+  })
+
+  it('keeps selected review rows outside the select-all scope', async () => {
+    installApi({
+      scannedAt: CACHED_AT,
+      candidates: [
+        makeCandidate({ worktreeId: 'repo1::/tmp/ready', displayName: 'ready' }),
+        makeCandidate({
+          worktreeId: 'repo1::/tmp/review',
+          displayName: 'review',
+          tier: 'review',
+          selectedByDefault: false,
+          git: { clean: null, upstreamAhead: 0, upstreamBehind: 0, checkedAt: null }
+        })
+      ],
+      errors: []
+    })
+    await renderDialog()
+    await openDialog()
+
+    await act(async () => rowCheckbox('review')?.click())
+    const selectAll = container?.querySelector<HTMLElement>(
+      '[aria-label="Select 1 safety-checked workspace"]'
+    )
+    expect(selectAll?.getAttribute('aria-checked')).toBe('false')
+
+    await act(async () => selectAll?.click())
+    expect(rowCheckbox('ready')?.getAttribute('aria-checked')).toBe('true')
+    expect(rowCheckbox('review')?.getAttribute('aria-checked')).toBe('true')
+
+    await act(async () => selectAll?.click())
+    expect(rowCheckbox('ready')?.getAttribute('aria-checked')).toBe('false')
+    expect(rowCheckbox('review')?.getAttribute('aria-checked')).toBe('true')
   })
 })

--- a/src/renderer/src/components/workspace-cleanup/WorkspaceCleanupDialog.stale-while-revalidate.test.tsx
+++ b/src/renderer/src/components/workspace-cleanup/WorkspaceCleanupDialog.stale-while-revalidate.test.tsx
@@ -399,7 +399,16 @@ describe('WorkspaceCleanupDialog stale-while-revalidate', () => {
     })
     await flush()
 
-    // Both rows are default-selected suggestions after the first settle.
+    // Nothing is pre-selected: the dialog no longer acts on its own verdict.
+    expect(rowCheckbox('alpha')?.getAttribute('aria-checked')).toBe('false')
+    expect(rowCheckbox('beta')?.getAttribute('aria-checked')).toBe('false')
+
+    // The user selects both, which is what must survive the refresh.
+    await act(async () => {
+      rowCheckbox('alpha')?.click()
+      rowCheckbox('beta')?.click()
+    })
+    await flush()
     expect(rowCheckbox('alpha')?.getAttribute('aria-checked')).toBe('true')
     expect(rowCheckbox('beta')?.getAttribute('aria-checked')).toBe('true')
 

--- a/src/renderer/src/components/workspace-cleanup/WorkspaceCleanupDialog.tsx
+++ b/src/renderer/src/components/workspace-cleanup/WorkspaceCleanupDialog.tsx
@@ -286,10 +286,9 @@ function WorkspaceCleanupDialogContent({
   )
   // Header state is scoped to the same rows the header action controls.
   const selectedSelectableCount = useMemo(() => {
-    const selectable = new Set(selectableIdentities)
     let count = 0
-    for (const id of selectedIds) {
-      if (selectable.has(id)) {
+    for (const identity of selectableIdentities) {
+      if (selectedIds.has(identity)) {
         count += 1
       }
     }

--- a/src/renderer/src/components/workspace-cleanup/WorkspaceCleanupDialog.tsx
+++ b/src/renderer/src/components/workspace-cleanup/WorkspaceCleanupDialog.tsx
@@ -43,7 +43,7 @@ import { useWorkspaceCleanupGitEvidence } from './use-workspace-cleanup-git-evid
 import { useWorkspaceCleanupRowOrder } from './use-workspace-cleanup-row-order'
 import {
   formatVanishedSelectionNotice,
-  getDefaultSelectedWorkspaceCleanupIdentities,
+  formatWithheldSelectionNotice,
   toggleSetMember
 } from './workspace-cleanup-selection-model'
 
@@ -84,12 +84,7 @@ function WorkspaceCleanupDialogContent({
   const [facetPanelOpen, setFacetPanelOpen] = useState(false)
   const [expandedRowIds, setExpandedRowIds] = useState<Set<string>>(() => new Set())
   const [rowsScrollElement, setRowsScrollElement] = useState<HTMLDivElement | null>(null)
-  const selectedDefaultsScanAtRef = useRef<number | null>(null)
   const wasOpenRef = useRef(open)
-  // Why: a refresh completing mid-open must not clobber a selection the user
-  // already made (or was given) for this open — defaults apply at most once.
-  const defaultsAppliedForOpenRef = useRef(false)
-  const selectionTouchedRef = useRef(false)
   const mountedRef = useMountedRef()
 
   // Why: the facet clock must be stable across renders but never older than
@@ -99,8 +94,6 @@ function WorkspaceCleanupDialogContent({
 
   useEffect(() => {
     if (open && !wasOpenRef.current) {
-      defaultsAppliedForOpenRef.current = false
-      selectionTouchedRef.current = false
       setOpenedAt(Date.now())
     }
     wasOpenRef.current = open
@@ -193,33 +186,20 @@ function WorkspaceCleanupDialogContent({
   }, [deletingIdentities, rows, selectedIds])
   const selectedCount = selectedCandidates.length
 
-  useEffect(() => {
-    if (loading || !scan || selectedDefaultsScanAtRef.current === scan.scannedAt) {
-      return
-    }
-    selectedDefaultsScanAtRef.current = scan.scannedAt
-    if (removalInFlightRef.current) {
-      return
-    }
-    if (defaultsAppliedForOpenRef.current || selectionTouchedRef.current) {
-      return
-    }
-    defaultsAppliedForOpenRef.current = true
-    setSelectedIds(
-      getDefaultSelectedWorkspaceCleanupIdentities(scan.candidates, deletingIdentities)
-    )
-  }, [deletingIdentities, loading, removalInFlightRef, scan, setSelectedIds])
+  // A destructive dialog leaves selection to the user.
 
   const pruneSelectionToVisibleRows = useEffectEvent(() => {
-    setSelectedIds((current) => {
-      const next = new Set(
-        [...current].filter(
-          (identity) =>
-            facetRows.facetMatchedIdentities.has(identity) && !deletingIdentities.has(identity)
-        )
+    const next = new Set(
+      [...selectedIds].filter(
+        (identity) =>
+          facetRows.facetMatchedIdentities.has(identity) && !deletingIdentities.has(identity)
       )
-      return next.size === current.size ? current : next
-    })
+    )
+    if (next.size === selectedIds.size) {
+      return
+    }
+    setSelectedIds(next)
+    toast.info(formatWithheldSelectionNotice(selectedIds.size - next.size))
   })
 
   useEffect(() => {
@@ -292,7 +272,6 @@ function WorkspaceCleanupDialogContent({
 
   const toggleSelectedRow = useCallback(
     (identity: string) => {
-      selectionTouchedRef.current = true
       setSelectedIds((current) => toggleSetMember(current, identity))
     },
     [setSelectedIds]
@@ -305,10 +284,31 @@ function WorkspaceCleanupDialogContent({
         : facetRows.selectableIdentities.filter((identity) => !deletingIdentities.has(identity)),
     [deletingIdentities, facetRows.selectableIdentities, removal.removalInFlight]
   )
+  // Header state is scoped to the same rows the header action controls.
+  const selectedSelectableCount = useMemo(() => {
+    const selectable = new Set(selectableIdentities)
+    let count = 0
+    for (const id of selectedIds) {
+      if (selectable.has(id)) {
+        count += 1
+      }
+    }
+    return count
+  }, [selectableIdentities, selectedIds])
+
   const toggleSelectAll = useCallback(
     (selectAll: boolean) => {
-      selectionTouchedRef.current = true
-      setSelectedIds(selectAll ? new Set(selectableIdentities) : new Set())
+      setSelectedIds((current) => {
+        const next = new Set(current)
+        for (const identity of selectableIdentities) {
+          if (selectAll) {
+            next.add(identity)
+          } else {
+            next.delete(identity)
+          }
+        }
+        return next
+      })
     },
     [selectableIdentities, setSelectedIds]
   )
@@ -323,7 +323,6 @@ function WorkspaceCleanupDialogContent({
       if (removalInFlightRef.current) {
         return
       }
-      selectionTouchedRef.current = true
       setSelectedIds(new Set([getWorkspaceCleanupCandidateIdentity(candidate)]))
       openConfirmRemove([candidate])
     },
@@ -390,7 +389,7 @@ function WorkspaceCleanupDialogContent({
               facetPanelOpen={facetPanelOpen}
               onFacetPanelOpenChange={setFacetPanelOpen}
               selectableCount={selectableIdentities.length}
-              selectedCount={selectedCount}
+              selectedCount={selectedSelectableCount}
               spaceScanning={workspaceSpaceScanning}
               spaceProgress={workspaceSpaceProgress}
               gitPendingCount={gitEvidence.pendingWorktreeIds.size}

--- a/src/renderer/src/components/workspace-cleanup/use-workspace-cleanup-scan-lifecycle.ts
+++ b/src/renderer/src/components/workspace-cleanup/use-workspace-cleanup-scan-lifecycle.ts
@@ -56,19 +56,13 @@ export function useWorkspaceCleanupScanLifecycle({
             return
           }
           latestReadyToastScanAtRef.current = result.scannedAt
-          const suggestedCount = result.candidates.filter(
-            (candidate) => candidate.selectedByDefault
-          ).length
           toast.success(
             translate(
               'auto.components.workspace.cleanup.WorkspaceCleanupDialog.0e2d235c63',
               'Workspace scan ready'
             ),
             {
-              description: formatWorkspaceCleanupReadyToast(
-                result.candidates.length,
-                suggestedCount
-              ),
+              description: formatWorkspaceCleanupReadyToast(result.candidates.length),
               action: {
                 label: translate(
                   'auto.components.workspace.cleanup.WorkspaceCleanupDialog.4a35c08764',

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-scan-notice.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-scan-notice.ts
@@ -64,36 +64,20 @@ export function formatWorkspaceCleanupScanProgress(
   )
 }
 
-export function formatWorkspaceCleanupReadyToast(
-  workspaceCount: number,
-  suggestedCount: number
-): string {
+/**
+ * Why no suggestion count: "suggestion" is Orca's verdict about the user's own
+ * work. The dialog stopped acting on it; this toast must stop announcing it.
+ */
+export function formatWorkspaceCleanupReadyToast(workspaceCount: number): string {
   if (workspaceCount === 0) {
     return translate('components.workspace.cleanup.scan.noWorkspaces', 'No workspaces found.')
   }
   if (workspaceCount === 1) {
-    return suggestedCount === 1
-      ? translate(
-          'components.workspace.cleanup.scan.readyOneOne',
-          '1 workspace found, with 1 cleanup suggestion.'
-        )
-      : translate(
-          'components.workspace.cleanup.scan.readyOneMany',
-          '1 workspace found, with {{value0}} cleanup suggestions.',
-          { value0: suggestedCount }
-        )
+    return translate('components.workspace.cleanup.scan.readyOne', '1 workspace found.')
   }
-  return suggestedCount === 1
-    ? translate(
-        'components.workspace.cleanup.scan.readyManyOne',
-        '{{value0}} workspaces found, with 1 cleanup suggestion.',
-        { value0: workspaceCount }
-      )
-    : translate(
-        'components.workspace.cleanup.scan.readyManyMany',
-        '{{value0}} workspaces found, with {{value1}} cleanup suggestions.',
-        { value0: workspaceCount, value1: suggestedCount }
-      )
+  return translate('components.workspace.cleanup.scan.readyMany', '{{value0}} workspaces found.', {
+    value0: workspaceCount
+  })
 }
 
 function formatScanErrorRepoName(

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-scan-notice.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-scan-notice.ts
@@ -64,10 +64,7 @@ export function formatWorkspaceCleanupScanProgress(
   )
 }
 
-/**
- * Why no suggestion count: "suggestion" is Orca's verdict about the user's own
- * work. The dialog stopped acting on it; this toast must stop announcing it.
- */
+/** Reports scan size without classifying the user's work. */
 export function formatWorkspaceCleanupReadyToast(workspaceCount: number): string {
   if (workspaceCount === 0) {
     return translate('components.workspace.cleanup.scan.noWorkspaces', 'No workspaces found.')

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-selection-model.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-selection-model.ts
@@ -1,6 +1,4 @@
 import { translate } from '@/i18n/i18n'
-import type { WorkspaceCleanupCandidate } from '../../../../shared/workspace-cleanup'
-import { getWorkspaceCleanupCandidateIdentity } from '../../../../shared/workspace-cleanup-host-identity'
 
 export function formatVanishedSelectionNotice(count: number): string {
   return count === 1
@@ -15,20 +13,18 @@ export function formatVanishedSelectionNotice(count: number): string {
       )
 }
 
-/** Host-qualified identities, so a default selection cannot span two hosts' rows. */
-export function getDefaultSelectedWorkspaceCleanupIdentities(
-  candidates: readonly WorkspaceCleanupCandidate[],
-  deletingIdentities: ReadonlySet<string> = new Set()
-): Set<string> {
-  return new Set(
-    candidates
-      .filter(
-        (candidate) =>
-          candidate.selectedByDefault &&
-          !deletingIdentities.has(getWorkspaceCleanupCandidateIdentity(candidate))
+/** Explains selection removed when a facet filter hides rows. */
+export function formatWithheldSelectionNotice(count: number): string {
+  return count === 1
+    ? translate(
+        'components.workspace.cleanup.browse.selectionWithheldOne',
+        '1 selected workspace is hidden by the current filters and was deselected.'
       )
-      .map((candidate) => getWorkspaceCleanupCandidateIdentity(candidate))
-  )
+    : translate(
+        'components.workspace.cleanup.browse.selectionWithheld',
+        '{{value0}} selected workspaces are hidden by the current filters and were deselected.',
+        { value0: count }
+      )
 }
 
 export function toggleSetMember(current: Set<string>, value: string): Set<string> {

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-sort-header.test.tsx
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-sort-header.test.tsx
@@ -92,4 +92,28 @@ describe('WorkspaceCleanupSortHeader', () => {
       container?.querySelector<HTMLButtonElement>('[role="checkbox"]')?.getAttribute('aria-checked')
     ).toBe('mixed')
   })
+  it('states how many workspaces select-all would take', () => {
+    render({ field: 'name', direction: 'asc' }, { selectableCount: 12 })
+
+    // Why: select-all takes the deletable subset, not every matched row; an
+    // unqualified label would overstate a destructive action's scope.
+    expect(container?.textContent).toContain('Select all 12 deletable workspaces')
+  })
+
+  it('does not report all-selected when the selected rows are not the selectable ones', () => {
+    const onToggleSelectAll = vi.fn()
+    // Why: `selectedCount` used to be canQueue-scoped while `selectableCount`
+    // is canSelect-scoped, so hand-picking review rows flipped the header to
+    // fully-checked and the next click cleared the whole selection.
+    render(
+      { field: 'name', direction: 'asc' },
+      { selectableCount: 3, selectedCount: 0, onToggleSelectAll }
+    )
+
+    const checkbox = container?.querySelector('[role="checkbox"]')
+    expect(checkbox?.getAttribute('aria-checked')).toBe('false')
+
+    act(() => (checkbox as HTMLElement | null)?.click())
+    expect(onToggleSelectAll).toHaveBeenCalledWith(true)
+  })
 })

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-sort-header.test.tsx
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-sort-header.test.tsx
@@ -95,16 +95,17 @@ describe('WorkspaceCleanupSortHeader', () => {
   it('states how many workspaces select-all would take', () => {
     render({ field: 'name', direction: 'asc' }, { selectableCount: 12 })
 
-    // Why: select-all takes the deletable subset, not every matched row; an
-    // unqualified label would overstate a destructive action's scope.
-    expect(container?.textContent).toContain('Select all 12 deletable workspaces')
+    expect(container?.textContent).toContain('Select all 12 safety-checked workspaces')
+  })
+
+  it('uses singular copy for one safety-checked workspace', () => {
+    render({ field: 'name', direction: 'asc' }, { selectableCount: 1 })
+
+    expect(container?.textContent).toContain('Select 1 safety-checked workspace')
   })
 
   it('does not report all-selected when the selected rows are not the selectable ones', () => {
     const onToggleSelectAll = vi.fn()
-    // Why: `selectedCount` used to be canQueue-scoped while `selectableCount`
-    // is canSelect-scoped, so hand-picking review rows flipped the header to
-    // fully-checked and the next click cleared the whole selection.
     render(
       { field: 'name', direction: 'asc' },
       { selectableCount: 3, selectedCount: 0, onToggleSelectAll }

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-sort-header.tsx
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-sort-header.tsx
@@ -52,9 +52,13 @@ export function WorkspaceCleanupSortHeader({
         ) : null}
       </button>
       <span className="min-w-0 flex-1 text-xs text-muted-foreground">
+        {/* Why the count: select-all takes the deletable subset of the matched
+            rows, not every matched row — an unqualified label would overstate
+            the scope of a destructive action. */}
         {translate(
-          'components.workspace.cleanup.browse.selectAll',
-          'Select all matching workspaces'
+          'components.workspace.cleanup.browse.selectAllCount',
+          'Select all {{value0}} deletable workspaces',
+          { value0: selectableCount }
         )}
       </span>
       <DropdownMenu modal={false}>

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-sort-header.tsx
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-sort-header.tsx
@@ -31,6 +31,17 @@ export function WorkspaceCleanupSortHeader({
 }): React.JSX.Element {
   const allSelected = selectableCount > 0 && selectedCount >= selectableCount
   const someSelected = selectableCount > 0 && selectedCount > 0 && !allSelected
+  const selectAllLabel =
+    selectableCount === 1
+      ? translate(
+          'components.workspace.cleanup.browse.selectAllCountOne',
+          'Select 1 safety-checked workspace'
+        )
+      : translate(
+          'components.workspace.cleanup.browse.selectAllCount',
+          'Select all {{value0}} safety-checked workspaces',
+          { value0: selectableCount }
+        )
   return (
     <div className="flex items-center gap-1 border-b border-border bg-muted/25 px-3 py-1.5">
       <button
@@ -38,10 +49,7 @@ export function WorkspaceCleanupSortHeader({
         role="checkbox"
         aria-checked={someSelected ? 'mixed' : allSelected}
         disabled={selectableCount === 0}
-        aria-label={translate(
-          'components.workspace.cleanup.browse.selectAll',
-          'Select all matching workspaces'
-        )}
+        aria-label={selectAllLabel}
         onClick={() => onToggleSelectAll(!allSelected)}
         className="flex size-4 shrink-0 items-center justify-center rounded border border-border bg-background text-primary hover:bg-accent disabled:opacity-40 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
       >
@@ -51,16 +59,7 @@ export function WorkspaceCleanupSortHeader({
           <Minus className="size-3" strokeWidth={3} />
         ) : null}
       </button>
-      <span className="min-w-0 flex-1 text-xs text-muted-foreground">
-        {/* Why the count: select-all takes the deletable subset of the matched
-            rows, not every matched row — an unqualified label would overstate
-            the scope of a destructive action. */}
-        {translate(
-          'components.workspace.cleanup.browse.selectAllCount',
-          'Select all {{value0}} deletable workspaces',
-          { value0: selectableCount }
-        )}
-      </span>
+      <span className="min-w-0 flex-1 text-xs text-muted-foreground">{selectAllLabel}</span>
       <DropdownMenu modal={false}>
         <DropdownMenuTrigger asChild>
           <Button

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -16229,7 +16229,8 @@
           "selectedCount": "{{value0}} selected",
           "selectionWithheldOne": "1 selected workspace is hidden by the current filters and was deselected.",
           "selectionWithheld": "{{value0}} selected workspaces are hidden by the current filters and were deselected.",
-          "selectAllCount": "Select all {{value0}} deletable workspaces"
+          "selectAllCountOne": "Select 1 safety-checked workspace",
+          "selectAllCount": "Select all {{value0}} safety-checked workspaces"
         },
         "scan": {
           "progress": "Scanning workspaces ({{value0}}/{{value1}})",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -16226,7 +16226,10 @@
           "measuringSizesProgress": "Scanning {{value0}}/{{value1}}",
           "measuringSizes": "Scanning sizes",
           "measureSizesFailed": "Could not scan workspace sizes",
-          "selectedCount": "{{value0}} selected"
+          "selectedCount": "{{value0}} selected",
+          "selectionWithheldOne": "1 selected workspace is hidden by the current filters and was deselected.",
+          "selectionWithheld": "{{value0}} selected workspaces are hidden by the current filters and were deselected.",
+          "selectAllCount": "Select all {{value0}} deletable workspaces"
         },
         "scan": {
           "progress": "Scanning workspaces ({{value0}}/{{value1}})",
@@ -16239,7 +16242,9 @@
           "readyManyOne": "{{value0}} workspaces found, with 1 cleanup suggestion.",
           "readyManyMany": "{{value0}} workspaces found, with {{value1}} cleanup suggestions.",
           "fallbackRepository": "a repository",
-          "gitListFailed": "Git could not list worktrees"
+          "gitListFailed": "Git could not list worktrees",
+          "readyOne": "1 workspace found.",
+          "readyMany": "{{value0}} workspaces found."
         },
         "relativeTime": {
           "never": "Never",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -14546,6 +14546,16 @@
     },
     "workspace": {
       "cleanup": {
+        "browse": {
+          "selectionWithheldOne": "선택한 워크스페이스 1개가 현재 필터에 의해 숨겨져 선택이 해제되었습니다.",
+          "selectionWithheld": "선택한 워크스페이스 {{value0}}개가 현재 필터에 의해 숨겨져 선택이 해제되었습니다.",
+          "selectAllCountOne": "안전 검사를 통과한 워크스페이스 1개 선택",
+          "selectAllCount": "안전 검사를 통과한 워크스페이스 {{value0}}개 모두 선택"
+        },
+        "scan": {
+          "readyOne": "워크스페이스 1개를 찾았습니다.",
+          "readyMany": "워크스페이스 {{value0}}개를 찾았습니다."
+        },
         "presentationFixtures": {
           "reviewAlphaCleanup": "알파 정리 검토"
         },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -14537,6 +14537,16 @@
     },
     "workspace": {
       "cleanup": {
+        "browse": {
+          "selectionWithheldOne": "当前筛选条件隐藏了 1 个已选工作区，已取消选择。",
+          "selectionWithheld": "当前筛选条件隐藏了 {{value0}} 个已选工作区，已取消选择。",
+          "selectAllCountOne": "选择 1 个通过安全检查的工作区",
+          "selectAllCount": "选择全部 {{value0}} 个通过安全检查的工作区"
+        },
+        "scan": {
+          "readyOne": "找到 1 个工作区。",
+          "readyMany": "找到 {{value0}} 个工作区。"
+        },
         "presentationFixtures": {
           "reviewAlphaCleanup": "评审 Alpha 清理"
         },


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​98 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​97 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​94 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​96 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 |

<!-- /orca-pr-loc -->

## ELI5

The cleanup dialog used to open with workspaces already ticked for deletion, picked by Orca's own guess at which ones you were "done with". Now nothing is ticked — you choose. Removing that also exposed two selection bugs it had been hiding, so those are fixed here too.

## What Changed

- Deleted the auto-select effect. The dialog opens with an empty selection and a disabled Delete button.
- **Header checkbox predicate fixed.** It now compares a `canSelect`-scoped selected count against the `canSelect`-scoped selectable count.
- **Filter-change selection loss is now reported** instead of silent.
- **Scan toast drops "with M cleanup suggestions"**, keeping the workspace count.
- **Select-all is labelled with its real scope** — "Select all N deletable workspaces" rather than "Select all matching workspaces".
- Removed the now-dead default-selection scaffolding (`getDefaultSelectedWorkspaceCleanupIds`, `selectedDefaultsScanAtRef`, `defaultsAppliedForOpenRef`, `selectionTouchedRef`).

Deliberately **not** here: `selectedByDefault` is still computed, tier chips and the Safety sort still exist, and `WORKSPACE_CLEANUP_CLASSIFIER_VERSION` is untouched. Those come in a follow-up so this PR carries no schema or persisted-state change.

## Why

`applyWorkspaceCleanupPolicy` marks a row `ready` when it has an inactivity reason, git is verified clean, and it has no hard blocker — then pre-checks it. That is a judgement about the user's own work. The dialog already refuses to *show* the tier as a workspace fact (there is a test asserting exactly that), so acting on it was the louder version of the thing we'd decided not to say.

The two selection fixes ship together with it on purpose. Both are live defects today, and both are currently masked by auto-select constantly repopulating the selection — removing auto-select without them would leave a real silent-data-loss window where a click can wipe a hand-picked selection.

Ordering matters for safety: auto-select reads **all** candidates and ignores filters, so ready rows hidden behind a filter sit dormant in `selectedIds` and become live Delete targets the moment filters clear. A planned follow-up clears everyone's filters once; landing that first would have *widened* the pre-checked destructive set. Removing auto-select first means there is no pre-checked set to widen.

## Linked Issue

Fixes #15151

## Visual Proof

**BEFORE** — the dialog opened with rows already ticked and Delete armed: on a 684-workspace fleet, the header read **"14 selected"** with a live **Delete selected** button before the user touched anything. The reported screenshot is on #15151. (The original paste was cleaned out of temp before I could attach it here, so I am describing it rather than posting a stand-in.)

**AFTER** — header reads **"0 selected"** with Delete disabled until the user picks rows, and the select-all row reads **"Select all N deletable workspaces"**. Rendered before/after screenshots to be attached by the Electron QA pass on this PR, which can capture both sides by checking out `main` and this branch.

## Testing

macOS, local:

- Updated `WorkspaceCleanupDialog.stale-while-revalidate.test.tsx` to the new contract: asserts nothing is pre-checked, then selects both rows explicitly and keeps the original guarantees (selection survives a refresh; vanished selections are reported).
- Added to `workspace-cleanup-sort-header.test.tsx`: select-all states its count, and the header does not report all-selected when the selected rows are not the selectable ones (the erase-your-selection defect; previously only 3/0 and 3/1 were covered).
- `npx vitest run --config config/vitest.config.ts src/renderer/src/components/workspace-cleanup src/renderer/src/store/slices/workspace-cleanup-scan-progress.test.ts` — 173 passed.
- `pnpm run typecheck` clean; `oxlint` clean; React Doctor changed-lines gate clean.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

- **Security:** none — removes a default selection and fixes two comparisons. No IPC, no new data flow, no dependency change.
- **Cross-platform (Linux/Windows/Mac):** renderer-only logic and copy; no paths, shells, or platform branches.
- **Remote SSH:** unaffected. No scan, transport, or host behaviour changes; SSH-backed rows simply arrive unselected like every other row.
- **Mobile:** no mobile-facing surface touched (desktop-only dialog).
- **Backwards compatibility:** no persisted state, schema, or wire contract touched. `selectedByDefault` still ships on the candidate, and `WORKSPACE_CLEANUP_CLASSIFIER_VERSION` is deliberately unchanged (a bump would prune version-mismatched dismissals and un-ignore every previously Ignored row).
- **Performance:** slightly less work per settle — one fewer full-candidate pass, and no default-selection recomputation per open.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @BrennanKB5

