### PR TITLE
feat(notifications): let orchestration-dispatched workers stay silent

### DIFF
--- a/src/main/codex-accounts/runtime-home-settings-test-fixtures.ts
+++ b/src/main/codex-accounts/runtime-home-settings-test-fixtures.ts
@@ -79,6 +79,7 @@ export function createSettings(overrides: TestSettingsOverrides = {}): GlobalSet
     notifications: {
       enabled: true,
       agentTaskComplete: true,
+      dispatchedWorkerTaskComplete: true,
       terminalBell: false,
       suppressWhenFocused: true,
       customSoundId: 'system',

--- a/src/main/codex-accounts/service-test-harness.ts
+++ b/src/main/codex-accounts/service-test-harness.ts
@@ -100,6 +100,7 @@ export function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalS
     notifications: {
       enabled: true,
       agentTaskComplete: true,
+      dispatchedWorkerTaskComplete: true,
       terminalBell: false,
       suppressWhenFocused: true,
       customSoundId: 'system',

--- a/src/main/persistence/applying-settings/onboarding-normalization.ts
+++ b/src/main/persistence/applying-settings/onboarding-normalization.ts
@@ -49,6 +49,10 @@ export function normalizeNotificationSettings(value: unknown): NotificationSetti
   return {
     enabled: booleanOr(candidate.enabled, defaults.enabled),
     agentTaskComplete: booleanOr(candidate.agentTaskComplete, defaults.agentTaskComplete),
+    dispatchedWorkerTaskComplete: booleanOr(
+      candidate.dispatchedWorkerTaskComplete,
+      defaults.dispatchedWorkerTaskComplete
+    ),
     terminalBell: booleanOr(candidate.terminalBell, defaults.terminalBell),
     suppressWhenFocused: booleanOr(candidate.suppressWhenFocused, defaults.suppressWhenFocused),
     customSoundId,

--- a/src/renderer/src/components/onboarding/use-onboarding-flow-persistence.test.ts
+++ b/src/renderer/src/components/onboarding/use-onboarding-flow-persistence.test.ts
@@ -118,6 +118,7 @@ describe('onboarding flow persistence', () => {
     const notifications = buildCompletedOnboardingNotificationSettings({
       enabled: false,
       agentTaskComplete: false,
+      dispatchedWorkerTaskComplete: false,
       terminalBell: false,
       suppressWhenFocused: false,
       customSoundId: 'two-tone',
@@ -128,6 +129,8 @@ describe('onboarding flow persistence', () => {
     expect(notifications).toEqual({
       enabled: true,
       agentTaskComplete: true,
+      // Why: onboarding turns the alert sources on, but a deliberate worker-silence choice is a user preference and survives.
+      dispatchedWorkerTaskComplete: false,
       terminalBell: true,
       suppressWhenFocused: false,
       customSoundId: 'two-tone',

--- a/src/renderer/src/components/settings/NotificationsPane.tsx
+++ b/src/renderer/src/components/settings/NotificationsPane.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import type { GlobalSettings } from '../../../../shared/global-settings-types'
 import { Button } from '../ui/button'
 import { Separator } from '../ui/separator'
-import { BellRing, Bot, Siren } from 'lucide-react'
+import { BellRing, Bot, Siren, Users } from 'lucide-react'
 import { useAppStore } from '@/store'
 import {
   MacNotificationPermissionCard,
@@ -143,6 +143,25 @@ export function NotificationsPane({
         onToggle={() =>
           void updateNotificationSettings({
             agentTaskComplete: !notificationSettings.agentTaskComplete
+          })
+        }
+      />
+
+      <NotificationSettingToggle
+        icon={<Users className="size-4" />}
+        label={translate(
+          'auto.components.settings.NotificationsPane.49a7af1d43',
+          'Dispatched Worker Complete'
+        )}
+        description={translate(
+          'auto.components.settings.NotificationsPane.19cbfde300',
+          'A worker dispatched by an orchestration coordinator finishes.'
+        )}
+        checked={notificationSettings.dispatchedWorkerTaskComplete}
+        disabled={!notificationSettings.enabled || !notificationSettings.agentTaskComplete}
+        onToggle={() =>
+          void updateNotificationSettings({
+            dispatchedWorkerTaskComplete: !notificationSettings.dispatchedWorkerTaskComplete
           })
         }
       />

--- a/src/renderer/src/components/terminal-pane/dispatched-worker-notification-policy.test.ts
+++ b/src/renderer/src/components/terminal-pane/dispatched-worker-notification-policy.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isDispatchedOrchestrationWorkerPane,
+  shouldSuppressDispatchedWorkerNotification
+} from './dispatched-worker-notification-policy'
+
+const workerPaneKey = 'tab-1:leaf-1'
+const coordinatorPaneKey = 'tab-2:leaf-2'
+const dispatchContext = { taskId: 'task-1', dispatchId: 'dispatch-1' }
+
+function makeState(overrides?: {
+  dispatchedWorkerTaskComplete?: boolean
+  runtime?: Record<string, typeof dispatchContext>
+  live?: Record<string, { orchestration?: typeof dispatchContext }>
+  retained?: Record<string, { entry?: { orchestration?: typeof dispatchContext } }>
+}) {
+  return {
+    settings: {
+      notifications: {
+        dispatchedWorkerTaskComplete: overrides?.dispatchedWorkerTaskComplete ?? false
+      }
+    },
+    runtimeAgentOrchestrationByPaneKey: overrides?.runtime ?? {
+      [workerPaneKey]: dispatchContext
+    },
+    agentStatusByPaneKey: overrides?.live ?? {},
+    retainedAgentsByPaneKey: overrides?.retained ?? {}
+  }
+}
+
+describe('isDispatchedOrchestrationWorkerPane', () => {
+  it('matches a pane the runtime holds a dispatch for', () => {
+    expect(isDispatchedOrchestrationWorkerPane(makeState(), workerPaneKey)).toBe(true)
+  })
+
+  it('does not match the coordinator pane', () => {
+    expect(isDispatchedOrchestrationWorkerPane(makeState(), coordinatorPaneKey)).toBe(false)
+  })
+
+  it('falls back to the live agent status when the runtime map is empty', () => {
+    const state = makeState({
+      runtime: {},
+      live: { [workerPaneKey]: { orchestration: dispatchContext } }
+    })
+    expect(isDispatchedOrchestrationWorkerPane(state, workerPaneKey)).toBe(true)
+  })
+
+  it('falls back to a retained agent row after the live row is gone', () => {
+    const state = makeState({
+      runtime: {},
+      retained: { [workerPaneKey]: { entry: { orchestration: dispatchContext } } }
+    })
+    expect(isDispatchedOrchestrationWorkerPane(state, workerPaneKey)).toBe(true)
+  })
+
+  it('needs a dispatch id, not just an orchestration context shell', () => {
+    const state = makeState({
+      runtime: {},
+      live: { [workerPaneKey]: { orchestration: { taskId: 'task-1' } as typeof dispatchContext } }
+    })
+    expect(isDispatchedOrchestrationWorkerPane(state, workerPaneKey)).toBe(false)
+  })
+
+  it('matches nothing without a pane key', () => {
+    expect(isDispatchedOrchestrationWorkerPane(makeState(), undefined)).toBe(false)
+  })
+})
+
+describe('shouldSuppressDispatchedWorkerNotification', () => {
+  it('suppresses a worker completion once the setting is off', () => {
+    expect(shouldSuppressDispatchedWorkerNotification(makeState(), workerPaneKey)).toBe(true)
+  })
+
+  it('keeps the coordinator loud with the setting off', () => {
+    expect(shouldSuppressDispatchedWorkerNotification(makeState(), coordinatorPaneKey)).toBe(false)
+  })
+
+  it('suppresses nothing while the setting is on', () => {
+    const state = makeState({ dispatchedWorkerTaskComplete: true })
+    expect(shouldSuppressDispatchedWorkerNotification(state, workerPaneKey)).toBe(false)
+  })
+
+  it('suppresses nothing when settings are missing', () => {
+    const state = { runtimeAgentOrchestrationByPaneKey: { [workerPaneKey]: dispatchContext } }
+    expect(shouldSuppressDispatchedWorkerNotification(state, workerPaneKey)).toBe(false)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/dispatched-worker-notification-policy.ts
+++ b/src/renderer/src/components/terminal-pane/dispatched-worker-notification-policy.ts
@@ -1,0 +1,39 @@
+import type { AgentStatusOrchestrationContext } from '../../../../shared/agent-status-types'
+
+type DispatchedWorkerPolicyState = {
+  settings?: { notifications?: { dispatchedWorkerTaskComplete?: boolean } } | null
+  runtimeAgentOrchestrationByPaneKey?: Record<string, AgentStatusOrchestrationContext>
+  agentStatusByPaneKey?: Record<string, { orchestration?: AgentStatusOrchestrationContext }>
+  retainedAgentsByPaneKey?: Record<
+    string,
+    { entry?: { orchestration?: AgentStatusOrchestrationContext } }
+  >
+}
+
+/** A pane is a dispatched worker only while it carries an orchestration dispatch.
+ *  A coordinator is nobody's dispatch target, so it never matches. */
+export function isDispatchedOrchestrationWorkerPane(
+  state: DispatchedWorkerPolicyState,
+  paneKey: string | undefined
+): boolean {
+  if (!paneKey) {
+    return false
+  }
+  const context =
+    state.runtimeAgentOrchestrationByPaneKey?.[paneKey] ??
+    state.agentStatusByPaneKey?.[paneKey]?.orchestration ??
+    state.retainedAgentsByPaneKey?.[paneKey]?.entry?.orchestration
+  return Boolean(context?.dispatchId)
+}
+
+/** Silences the OS banner and the phone push for a worker completion; unread
+ *  markers are set by the caller before this gate, so nothing is lost in-app. */
+export function shouldSuppressDispatchedWorkerNotification(
+  state: DispatchedWorkerPolicyState,
+  paneKey: string | undefined
+): boolean {
+  if (state.settings?.notifications?.dispatchedWorkerTaskComplete !== false) {
+    return false
+  }
+  return isDispatchedOrchestrationWorkerPane(state, paneKey)
+}

--- a/src/renderer/src/components/terminal-pane/dispatched-worker-notification-suppression.test.ts
+++ b/src/renderer/src/components/terminal-pane/dispatched-worker-notification-suppression.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { dispatchTerminalNotification } from './use-notification-dispatch'
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import type { TerminalLayoutSnapshot } from '../../../../shared/terminal-tab-types'
+
+const playDesktopNotificationSound = vi.hoisted(() => vi.fn())
+let mockState: ReturnType<typeof makeMockState>
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: () => mockState
+  }
+}))
+
+vi.mock('@/lib/desktop-notification-sound', () => ({
+  playDesktopNotificationSound
+}))
+
+const leafId = '11111111-1111-4111-8111-111111111111'
+const paneKey = `tab-1:${leafId}`
+const dispatchContext = { taskId: 'task-1', dispatchId: 'dispatch-1' }
+
+function makeAgentStatus(): AgentStatusEntry {
+  const now = Date.now()
+  return {
+    state: 'done',
+    prompt: 'ship the slice',
+    updatedAt: now,
+    stateStartedAt: now,
+    agentType: 'claude',
+    paneKey,
+    terminalTitle: 'claude',
+    stateHistory: [],
+    lastAssistantMessage: 'Done.'
+  }
+}
+
+function makeMockState() {
+  const layout: TerminalLayoutSnapshot = {
+    root: { type: 'leaf', leafId },
+    activeLeafId: leafId,
+    expandedLeafId: null,
+    ptyIdsByLeafId: { [leafId]: 'pty-1' }
+  }
+  return {
+    activeWorktreeId: 'wt-other',
+    activeTabId: 'tab-1',
+    tabsByWorktree: { 'wt-worker': [{ id: 'tab-1', ptyId: 'pty-1' }] },
+    ptyIdsByTabId: { 'tab-1': ['pty-1'] },
+    suppressedPtyExitIds: {},
+    terminalLayoutsByTabId: { 'tab-1': layout },
+    browserTabsByWorktree: {},
+    retainedAgentsByPaneKey: {},
+    agentStatusByPaneKey: { [paneKey]: makeAgentStatus() },
+    runtimeAgentOrchestrationByPaneKey: {} as Record<string, typeof dispatchContext>,
+    worktreesByRepo: {
+      repo1: [
+        { id: 'wt-worker', repoId: 'repo1', displayName: 'worker', branch: 'worker' },
+        { id: 'wt-other', repoId: 'repo1', displayName: 'other', branch: 'other' }
+      ]
+    },
+    repos: [{ id: 'repo1', displayName: 'orca', connectionId: null }],
+    settings: {
+      experimentalTerminalAttention: true,
+      notifications: { customSoundPath: null, dispatchedWorkerTaskComplete: true }
+    },
+    markWorktreeUnread: vi.fn(),
+    markTerminalTabUnread: vi.fn(),
+    markTerminalPaneUnread: vi.fn(),
+    markAgentCompletionPaneUnread: vi.fn()
+  }
+}
+
+describe('dispatched worker notification suppression', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockState = makeMockState()
+    vi.stubGlobal('window', {
+      api: {
+        notifications: {
+          dispatch: vi.fn().mockResolvedValue({ delivered: true })
+        }
+      }
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('still alerts for a dispatched worker while the setting is on', () => {
+    mockState.runtimeAgentOrchestrationByPaneKey = { [paneKey]: dispatchContext }
+
+    dispatchTerminalNotification('wt-worker', {
+      source: 'agent-task-complete',
+      terminalTitle: 'claude',
+      paneKey
+    })
+
+    expect(window.api.notifications.dispatch).toHaveBeenCalledOnce()
+  })
+
+  it('drops the banner and the phone push for a dispatched worker once the setting is off', () => {
+    mockState.settings.notifications.dispatchedWorkerTaskComplete = false
+    mockState.runtimeAgentOrchestrationByPaneKey = { [paneKey]: dispatchContext }
+
+    dispatchTerminalNotification('wt-worker', {
+      source: 'agent-task-complete',
+      terminalTitle: 'claude',
+      paneKey
+    })
+
+    expect(window.api.notifications.dispatch).not.toHaveBeenCalled()
+  })
+
+  it('keeps in-app unread state for the suppressed worker', () => {
+    mockState.settings.notifications.dispatchedWorkerTaskComplete = false
+    mockState.runtimeAgentOrchestrationByPaneKey = { [paneKey]: dispatchContext }
+
+    dispatchTerminalNotification('wt-worker', {
+      source: 'agent-task-complete',
+      terminalTitle: 'claude',
+      paneKey
+    })
+
+    expect(mockState.markWorktreeUnread).toHaveBeenCalledWith('wt-worker')
+    expect(mockState.markAgentCompletionPaneUnread).toHaveBeenCalledWith(paneKey)
+    expect(mockState.markTerminalTabUnread).toHaveBeenCalledWith('tab-1')
+  })
+
+  it('keeps alerting for the coordinator pane with the setting off', () => {
+    mockState.settings.notifications.dispatchedWorkerTaskComplete = false
+
+    dispatchTerminalNotification('wt-worker', {
+      source: 'agent-task-complete',
+      terminalTitle: 'claude',
+      paneKey
+    })
+
+    expect(window.api.notifications.dispatch).toHaveBeenCalledOnce()
+  })
+
+  it('leaves terminal bells alone', () => {
+    mockState.settings.notifications.dispatchedWorkerTaskComplete = false
+    mockState.runtimeAgentOrchestrationByPaneKey = { [paneKey]: dispatchContext }
+
+    dispatchTerminalNotification('wt-worker', {
+      source: 'terminal-bell',
+      terminalTitle: 'claude',
+      paneKey
+    })
+
+    expect(window.api.notifications.dispatch).toHaveBeenCalledOnce()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
@@ -11,6 +11,7 @@ import {
   type AgentStatusEntry
 } from '../../../../shared/agent-status-types'
 import { isSupersededAgentCompletionSnapshot } from './agent-completion-snapshot-staleness'
+import { shouldSuppressDispatchedWorkerNotification } from './dispatched-worker-notification-policy'
 import type {
   AgentCompletionDispatchMeta,
   AgentCompletionStatusSnapshot
@@ -177,6 +178,15 @@ export function dispatchTerminalNotification(
   }
 
   if (event.suppressOsNotification) {
+    return
+  }
+
+  // Why: a wave of dispatched workers reports to its coordinator, not to the user;
+  // only the coordinator's own completion is worth a banner or a phone push.
+  if (
+    event.source === 'agent-task-complete' &&
+    shouldSuppressDispatchedWorkerNotification(state, event.paneKey)
+  ) {
     return
   }
 

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -7215,7 +7215,9 @@
           "274af61bc0": "system",
           "6e6df3a09a": "Choose Custom File",
           "76e02467b8": "Change Custom File",
-          "d3756cf5bc": "disabled"
+          "d3756cf5bc": "disabled",
+          "49a7af1d43": "Dispatched Worker Complete",
+          "19cbfde300": "A worker dispatched by an orchestration coordinator finishes."
         },
         "OpenAiTranscriptionKeyDialog": {
           "fa83512e48": "Save Key",

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -131,6 +131,7 @@ export function getDefaultNotificationSettings(): NotificationSettings {
   return {
     enabled: true,
     agentTaskComplete: true,
+    dispatchedWorkerTaskComplete: true,
     terminalBell: false,
     suppressWhenFocused: true,
     customSoundId: 'system',

--- a/src/shared/notification-settings-types.ts
+++ b/src/shared/notification-settings-types.ts
@@ -3,6 +3,8 @@ import type { AgentStatusState, AgentType } from './agent-status-types'
 export type NotificationSettings = {
   enabled: boolean
   agentTaskComplete: boolean
+  /** Off keeps orchestration-dispatched workers silent; only the coordinator alerts. In-app unread state is unaffected. */
+  dispatchedWorkerTaskComplete: boolean
   terminalBell: boolean
   suppressWhenFocused: boolean
   customSoundId:


### PR DESCRIPTION
## ELI5

When a coordinator agent farms work out to worker agents, only the coordinator's "done" is meant for you. This adds a switch that keeps the workers quiet and leaves the coordinator loud.

## What Changed

New notification setting `dispatchedWorkerTaskComplete`, default `true`, so nothing changes until a user turns it off.

- `src/shared/notification-settings-types.ts`, `src/shared/constants.ts` — the field and its default.
- `src/main/persistence/applying-settings/onboarding-normalization.ts` — field-by-field normalization, same `booleanOr` guard as its neighbours, so an old settings file hydrates to the default.
- `src/renderer/src/components/terminal-pane/dispatched-worker-notification-policy.ts` (new) — `isDispatchedOrchestrationWorkerPane` reads the pane's orchestration dispatch context from `runtimeAgentOrchestrationByPaneKey`, then the live `agentStatusByPaneKey` row, then the retained row. A dispatch id is required; a context shell without one does not count.
- `src/renderer/src/components/terminal-pane/use-notification-dispatch.ts` — one gate next to the existing `suppressOsNotification` return.
- `src/renderer/src/components/settings/NotificationsPane.tsx` — toggle under "Agent Task Complete", disabled while that source is off.

The gate sits **after** the unread block, so the worktree dot, the pane marker and the tab marker still fire. Only the OS banner and the phone push go quiet — both come from the same `window.api.notifications.dispatch` call, and `src/main/ipc/notifications.ts` fans that one call out to `runtime.dispatchMobileNotification`.

Why this identity: `buildAgentOrchestrationByPaneKey` (`orca-runtime.ts`) publishes a context for a pane only when the orchestration DB holds a dispatch for that terminal. A coordinator terminal is nobody's dispatch target, so it never matches and keeps alerting. A nested coordinator that was itself dispatched does match, which is the wanted behavior — it reports to its parent, not to the user.

No wire change: no RPC params, no stream frames, no new host-published content. The settings field is a new optional-with-default boolean, so a mixed-version client that has never seen it normalizes to `true`.

## Why

Fixes the case in the linked issue: a wave of workers produces one alert per worker plus one for the coordinator, and the alert that matters arrives last. The only existing control, `notifications.agentTaskComplete`, is all or nothing and would silence the coordinator too.

## Linked Issue

Fixes #15148

## Visual Proof

Settings gains one toggle row, built from the existing `NotificationSettingToggle` primitive with a `lucide-react` icon, matching the rows above and below it. No other visual change; the rest of the change removes notifications rather than drawing anything. Behaviour repro is under Testing.

## Testing

Automated:

- `src/renderer/src/components/terminal-pane/dispatched-worker-notification-policy.test.ts` — runtime map, live-status fallback, retained-row fallback, dispatch-id requirement, coordinator pane, missing settings.
- `src/renderer/src/components/terminal-pane/dispatched-worker-notification-suppression.test.ts` — through `dispatchTerminalNotification`: alerts while the setting is on, drops banner and push once it is off, keeps unread state, keeps the coordinator loud, leaves terminal bells alone.
- `pnpm exec vitest run src/renderer/src/components/terminal-pane src/renderer/src/components/settings src/renderer/src/components/onboarding src/shared src/main/persistence` — green, except pre-existing IME preedit failures also present on `main`.
- `pnpm typecheck:web`, `pnpm typecheck:node`, `oxlint`, `oxfmt`, `pnpm check:max-lines-ratchet`, `pnpm verify:localization-catalog`, `pnpm verify:localization-extraction`, `pnpm verify:localization-coverage` — clean. Locale catalog synced with `pnpm sync:localization-catalog`.

Manual repro for a reviewer:

1. Run an orchestration wave: coordinator dispatches two or more workers.
2. With the new toggle on, watch one notification per worker plus one for the coordinator (today's behavior).
3. Turn "Dispatched Worker Complete" off and run the wave again: only the coordinator's completion raises a banner and a phone push; every worker still marks its workspace and tab unread.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Written with Claude Code (Opus 5).

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Security: no new IO, IPC or persisted secret. Cross-platform: pure policy code, no paths or accelerators. SSH/remote: the dispatch context comes from the orchestration DB by terminal handle, so a worker on an SSH or paired host is classified the same way. Mobile: covered by the same gate, since mobile pushes leave through the same handler. Performance: one map lookup per completion notification.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
