### PR TITLE
fix(agent-resume): restore Copilot sessions after Orca restart

### DIFF
--- a/src/shared/agent-session-resume.test.ts
+++ b/src/shared/agent-session-resume.test.ts
@@ -20,6 +20,10 @@ describe('agent session resume metadata', () => {
     expect(isResumableTuiAgent('prime-agent')).toBe(true)
   })
 
+  it('treats copilot as a resumable TUI agent', () => {
+    expect(isResumableTuiAgent('copilot')).toBe(true)
+  })
+
   it.each([
     ['claude', { session_id: 'claude-session' }, { key: 'session_id', id: 'claude-session' }],
     ['codex', { session_id: 'codex-session' }, { key: 'session_id', id: 'codex-session' }],
@@ -44,7 +48,13 @@ describe('agent session resume metadata', () => {
       'prime-agent',
       { session_id: 'prime-session', session_file: '/tmp/prime-session.jsonl' },
       { key: 'session_id', id: 'prime-session', transcriptPath: '/tmp/prime-session.jsonl' }
-    ]
+    ],
+    [
+      'copilot',
+      { session_id: '940237d9-c712-48e8-bca1-fd75fc4a8d4b' },
+      { key: 'session_id', id: '940237d9-c712-48e8-bca1-fd75fc4a8d4b' }
+    ],
+    ['copilot', { sessionId: 'copilot-camel' }, { key: 'session_id', id: 'copilot-camel' }]
   ] as const)('extracts %s provider session ids', (source, payload, expected) => {
     expect(extractAgentProviderSession(source, payload)).toEqual(expected)
   })
@@ -69,7 +79,8 @@ describe('agent session resume metadata', () => {
       'prime-agent',
       { key: 'session_id', id: 's1', transcriptPath: '/tmp/prime-session.jsonl' },
       ['prime-agent', '--resume', '/tmp/prime-session.jsonl']
-    ]
+    ],
+    ['copilot', { key: 'session_id', id: 's1' }, ['copilot', '--resume', 's1']]
   ] as const)('builds %s resume argv', (agent, providerSession, expected) => {
     expect(getAgentResumeArgv(agent, providerSession)).toEqual(expected)
   })

--- a/src/shared/agent-session-resume.ts
+++ b/src/shared/agent-session-resume.ts
@@ -14,7 +14,8 @@ export const RESUMABLE_TUI_AGENTS = [
   'grok',
   'devin',
   'omp',
-  'prime-agent'
+  'prime-agent',
+  'copilot'
 ] as const satisfies readonly TuiAgent[]
 
 export type ResumableTuiAgent = (typeof RESUMABLE_TUI_AGENTS)[number]
@@ -230,10 +231,15 @@ export function extractAgentProviderSession(
       const id = readSessionId(payload, ['session_id'])
       return id ? { key: 'session_id', id } : null
     }
+    // Why: Copilot's hook `session_id` is also its `~/.copilot/session-state/<id>/`
+    // directory name, so the same id is the CLI's resume locator.
+    case 'copilot': {
+      const id = readSessionId(payload, ['session_id', 'sessionId'])
+      return id ? { key: 'session_id', id } : null
+    }
     case 'amp':
     case 'cursor':
     case 'command-code':
-    case 'copilot':
     case 'hermes':
       return null
   }
@@ -276,5 +282,9 @@ export function getAgentResumeArgv(
       return providerSession.key === 'session_id'
         ? ['omp', '--resume', ompResumeFilePath?.trim() || id]
         : null
+    // Why: Copilot documents `--resume=<id>`, but the space form resumes the same
+    // session and keeps the locator its own argv entry for the resume-argv drop.
+    case 'copilot':
+      return providerSession.key === 'session_id' ? ['copilot', '--resume', id] : null
   }
 }


### PR DESCRIPTION
Fixes #15150.

## Problem

After quitting/restarting Orca (or rebooting), Claude panes resume their session but Copilot panes come back as a brand-new session launched with `copilot '--yolo'`. Recovering the previous conversation requires manually running resume and picking the session from the picker.

Copilot was excluded from the auto-resume path in three separate places, so no sleeping-agent record was ever captured for a Copilot pane:

1. `RESUMABLE_TUI_AGENTS` did not include `copilot`.
2. `getAgentResumeArgv()` had no `copilot` case.
3. `extractAgentProviderSession()` explicitly returned `null` for `copilot`.

`sleepingRecordFromEntry()` bails when any of those is missing, so `captureAllSleepingAgentSessions` recorded nothing on quit and `resumeSleepingAgentSessionsForWorktree` had nothing to relaunch — the pane was recreated with the plain launch command plus the YOLO arg.

## Fix

Copilot hooks **do** report a `session_id`, and it is the same id as the `~/.copilot/session-state/<id>/` directory name that the AI Vault scanner (`createCopilotSessionResumeState`) already resolves — so it is a valid CLI resume locator. This wires that id into the auto-resume path:

* `extractAgentProviderSession('copilot', …)` now reads `session_id` (accepting `sessionId` too, matching the tolerance used for other agents).
* `copilot` added to `RESUMABLE_TUI_AGENTS`.
* `getAgentResumeArgv('copilot', …)` returns `['copilot', '--resume', id]`.

A restored Copilot pane is therefore relaunched as `copilot '--yolo' '--resume' '<session-id>'`.

### Why the space form rather than `--resume=<id>`

`buildAgentResumeInvocation` (AI Vault path) uses `--resume=<sessionId>` because `--resume` takes an optional value. Verified against Copilot CLI 1.0.24 that **both** forms reattach to the existing session (same `session-state` directory, no new session created). The space form is used here so the locator stays a separate argv entry, which is what `dropAgentResumeArgvFromCommand` and the shell-quoting in `buildAgentResumeStartupPlan` assume.

## Verification

Copilot hook payloads were captured from a real Copilot CLI 1.0.24 run:

```json
{
  "hook_event_name": "SessionStart",
  "session_id": "940237d9-c712-48e8-bca1-fd75fc4a8d4b",
  "timestamp": "…",
  "cwd": "…",
  "source": "new"
}
```

`~/.copilot/session-state/940237d9-c712-48e8-bca1-fd75fc4a8d4b/` exists for that id, and both `copilot --resume=<id>` and `copilot --resume <id>` appended to that session's `events.jsonl` without creating a new session directory.

* `pnpm run typecheck` — clean
* `pnpm test` — the only failure is the pre-existing `src/main/ssh/ssh-posix-command-wrapper.test.ts` csh/tcsh case, which fails identically on an unmodified checkout of this branch point
* `pnpm run check:code-quality:changed` — 0 new findings

New test coverage in `src/shared/agent-session-resume.test.ts`: `copilot` is resumable, its provider session extracts from `session_id`/`sessionId`, and its resume argv is `['copilot', '--resume', id]`.

## Notes for reviewers

* Copilot sessions are cwd-scoped; restore relaunches in the pane's own worktree, so no extra `cd` prefix is needed on this path.
* Making `isResumableTuiAgent('copilot')` true also shifts the AI Vault manual-resume branch for Copilot from `buildAiVaultResumeCommand` (`--resume=<id>`) to `buildAgentResumeStartupPlan` (`--resume <id>`). Both were verified to resume the same session, so the manual flow is unchanged in effect.
