### PR TITLE
fix(agent-resume): restore Kimi Code sessions after Orca restart

### DIFF
--- a/src/shared/agent-session-resume.test.ts
+++ b/src/shared/agent-session-resume.test.ts
@@ -20,6 +20,10 @@ describe('agent session resume metadata', () => {
     expect(isResumableTuiAgent('prime-agent')).toBe(true)
   })
 
+  it('treats Kimi Code as a resumable TUI agent', () => {
+    expect(isResumableTuiAgent('kimi')).toBe(true)
+  })
+
   it.each([
     ['claude', { session_id: 'claude-session' }, { key: 'session_id', id: 'claude-session' }],
     ['codex', { session_id: 'codex-session' }, { key: 'session_id', id: 'codex-session' }],
@@ -44,6 +48,11 @@ describe('agent session resume metadata', () => {
       'prime-agent',
       { session_id: 'prime-session', session_file: '/tmp/prime-session.jsonl' },
       { key: 'session_id', id: 'prime-session', transcriptPath: '/tmp/prime-session.jsonl' }
+    ],
+    [
+      'kimi',
+      { session_id: 'session_431324d7-2165-42f0-9ecd-9f93437b3201' },
+      { key: 'session_id', id: 'session_431324d7-2165-42f0-9ecd-9f93437b3201' }
     ]
   ] as const)('extracts %s provider session ids', (source, payload, expected) => {
     expect(extractAgentProviderSession(source, payload)).toEqual(expected)
@@ -69,6 +78,11 @@ describe('agent session resume metadata', () => {
       'prime-agent',
       { key: 'session_id', id: 's1', transcriptPath: '/tmp/prime-session.jsonl' },
       ['prime-agent', '--resume', '/tmp/prime-session.jsonl']
+    ],
+    [
+      'kimi',
+      { key: 'session_id', id: 'session_431324d7' },
+      ['kimi', '--session', 'session_431324d7']
     ]
   ] as const)('builds %s resume argv', (agent, providerSession, expected) => {
     expect(getAgentResumeArgv(agent, providerSession)).toEqual(expected)

--- a/src/shared/agent-session-resume.ts
+++ b/src/shared/agent-session-resume.ts
@@ -14,7 +14,8 @@ export const RESUMABLE_TUI_AGENTS = [
   'grok',
   'devin',
   'omp',
-  'prime-agent'
+  'prime-agent',
+  'kimi'
 ] as const satisfies readonly TuiAgent[]
 
 export type ResumableTuiAgent = (typeof RESUMABLE_TUI_AGENTS)[number]
@@ -276,5 +277,9 @@ export function getAgentResumeArgv(
       return providerSession.key === 'session_id'
         ? ['omp', '--resume', ompResumeFilePath?.trim() || id]
         : null
+    // Why: Kimi sessions are work-dir-scoped, so this only resumes from the pane's
+    // own cwd — which is where restore relaunches it.
+    case 'kimi':
+      return providerSession.key === 'session_id' ? ['kimi', '--session', id] : null
   }
 }


### PR DESCRIPTION
Fixes #15155. Same symptom as #15150 (Copilot), separate cause — kept as its own PR so each can be reviewed and verified independently.

## Problem

After an Orca restart, Kimi Code panes come back as a fresh session while Claude panes resume.

Unlike Copilot, Kimi already clears the hardest gate: `extractAgentProviderSession()` handles `kimi` and returns its `session_id`. What is missing is the other two:

* `kimi` is absent from `RESUMABLE_TUI_AGENTS`
* `getAgentResumeArgv()` has no `kimi` case

`sleepingRecordFromEntry()` requires all three, so no sleeping-agent record is captured on quit and restore has nothing to relaunch.

The manual AI Vault path already knows the invocation — `buildAgentResumeInvocation` returns `${baseCommand} --session ${sessionArg}` for `kimi` — it just was never wired into restart restore.

## Fix

* `kimi` added to `RESUMABLE_TUI_AGENTS`
* `getAgentResumeArgv('kimi', …)` returns `['kimi', '--session', id]`

`extractAgentProviderSession()` is untouched. A restored Kimi pane is relaunched as `kimi '--session' '<session-id>'`.

## Verification

Hook payloads captured from a real Kimi Code 0.29.2 run:

```json
{
  "hook_event_name": "UserPromptSubmit",
  "session_id": "session_431324d7-2165-42f0-9ecd-9f93437b3201",
  "cwd": "…",
  "prompt": [{ "type": "text", "text": "reply with just: ok" }]
}
```

Kimi prints its own resume command on exit (`To resume this session: kimi -r session_431324d7-…`), and both `kimi --session <id>` (documented as `-S, --session [id]`) and the `-r` alias reattach to that exact session and continue it.

* `pnpm run typecheck` — clean
* `pnpm test` — the only failures are the pre-existing `src/main/ssh/ssh-posix-command-wrapper.test.ts` csh/tcsh cases, which fail identically on an unmodified checkout of this branch point
* `pnpm run check:code-quality:changed` — 0 new findings

New coverage in `src/shared/agent-session-resume.test.ts`: `kimi` is resumable, its provider session extracts from a real `session_<uuid>` payload, and its resume argv is `['kimi', '--session', id]`.

## Notes for reviewers

* **Work-dir scoping.** Kimi sessions live under `~/.kimi-code/sessions/wd_<name>_<hash>/session_<uuid>/` and resuming from another directory is rejected outright (`Session "…" was created under a different directory.`). The auto-resume path relaunches in the pane's own worktree, so this holds — but it is the reason a cwd-agnostic resume would not work here, and it is worth keeping in mind for folder workspaces and SSH panes where the pane cwd must match the original.
* Making `isResumableTuiAgent('kimi')` true also moves the AI Vault manual-resume branch for Kimi from `buildAiVaultResumeCommand` to `buildAgentResumeStartupPlan`. Both emit `--session <id>`; the AI Vault variant additionally prefixes `cd <cwd>`, which the startup-plan path covers by launching in the pane's cwd.
