### PR TITLE
fix(native-chat): stop journal recovery from destroying transcripts

### DIFF
--- a/src/main/native-chat/agent-session-journal/journal-blob-store.ts
+++ b/src/main/native-chat/agent-session-journal/journal-blob-store.ts
@@ -50,6 +50,14 @@ export async function readJournalBlob(journalDir: string, digest: string): Promi
   }
 }
 
+/** Remove a blob written speculatively for a row that was rejected. */
+export async function removeJournalBlob(journalDir: string, digest: string): Promise<void> {
+  const target = blobPath(journalDir, digest)
+  if (target) {
+    await rm(target, { force: true })
+  }
+}
+
 /** Drop every blob outside `retained`. Called from compaction, under the
  *  current lease fence, after the snapshot is durable — so a crash mid-prune
  *  leaves extra blobs rather than dangling references. */

--- a/src/main/native-chat/agent-session-journal/journal-compaction.ts
+++ b/src/main/native-chat/agent-session-journal/journal-compaction.ts
@@ -9,6 +9,7 @@
 // client that was merely asleep gets a full snapshot reload instead of a resume.
 
 import {
+  blobDigestsInBody,
   referencedBlobDigests,
   renderJournalState,
   type JournalReducerState
@@ -58,6 +59,7 @@ export async function compactJournal(input: {
     v: AGENT_SESSION_JOURNAL_SCHEMA_VERSION,
     epoch: input.state.epoch,
     compactedThrough,
+    highestFence: input.state.highestFence,
     items: rendered.items,
     submissions: rendered.submissions,
     receipts: [...input.state.receipts.values()].map((receipt) => ({
@@ -71,6 +73,10 @@ export async function compactJournal(input: {
       providerItemId,
       itemId
     })),
+    tombstones: [...input.state.tombstones.entries()].map(([itemId, revision]) => ({
+      itemId,
+      revision
+    })),
     tail: retained
   }
 
@@ -78,7 +84,13 @@ export async function compactJournal(input: {
   await rewriteJournalLog(input.journalDir, retained)
   // Blobs are pruned last: a crash before this leaks bytes, whereas pruning
   // first would strand a snapshot pointing at a payload that no longer exists.
-  await pruneJournalBlobs(input.journalDir, referencedBlobDigests(input.state))
+  const retainedDigests = referencedBlobDigests(input.state)
+  for (const row of retained) {
+    if (row.kind === 'item') {
+      blobDigestsInBody(row.body, retainedDigests)
+    }
+  }
+  await pruneJournalBlobs(input.journalDir, retainedDigests)
 
   return {
     tailRows: retained,

--- a/src/main/native-chat/agent-session-journal/journal-corruption-quarantine.ts
+++ b/src/main/native-chat/agent-session-journal/journal-corruption-quarantine.ts
@@ -1,0 +1,40 @@
+// Corruption never deletes history. A journal that cannot be read end to end
+// keeps its intact prefix live and moves the unreadable remainder aside, so the
+// bytes stay on disk for inspection instead of being rebuilt into an empty epoch.
+
+import {
+  quarantineJournalRemainder,
+  readJournalLog,
+  readJournalSnapshotFile,
+  rewriteJournalLog
+} from './journal-log-file'
+import type { JournalRow } from './journal-row-schema'
+
+/** Keep the readable prefix and set the unreadable suffix aside. */
+export async function quarantineCorruptSuffix(
+  journalDir: string,
+  retainedRows: readonly JournalRow[],
+  remainder: string | undefined
+): Promise<void> {
+  if (remainder) {
+    await quarantineJournalRemainder(journalDir, remainder)
+  }
+  await rewriteJournalLog(journalDir, retainedRows)
+}
+
+/** Copy everything aside before a read-only journal is rebuilt under a newer
+ *  schema: those rows are unreadable to THIS build, not worthless. */
+export async function quarantineUnreadableSchema(journalDir: string): Promise<void> {
+  const snapshot = await readJournalSnapshotFile(journalDir)
+  const log = await readJournalLog(journalDir)
+  const preserved = [
+    snapshot ? JSON.stringify(snapshot) : '',
+    log.rows.map((row) => JSON.stringify(row)).join('\n'),
+    log.remainder ?? ''
+  ]
+    .filter(Boolean)
+    .join('\n')
+  if (preserved) {
+    await quarantineJournalRemainder(journalDir, preserved)
+  }
+}

--- a/src/main/native-chat/agent-session-journal/journal-cursor.ts
+++ b/src/main/native-chat/agent-session-journal/journal-cursor.ts
@@ -8,6 +8,8 @@ import type {
   AgentJournalCursor,
   AgentJournalResetReason
 } from '../../../shared/agent-session-journal-types'
+import type { JournalReadSince } from './journal-store-contracts'
+import type { JournalRow } from './journal-row-schema'
 
 export type JournalCursorRange = {
   epoch: string
@@ -68,4 +70,29 @@ export function findSequenceGap(
     expected += 1
   }
   return null
+}
+
+/** Rows appended after `cursor`, or the reset a client must take instead. A
+ *  read-only journal always resets: this build cannot vouch for what it holds. */
+export function readJournalSince(
+  source: {
+    state: { epoch: string; lastSequence: number; oldestSequence: number }
+    tailRows: readonly JournalRow[]
+    readOnly: boolean
+  },
+  cursor: AgentJournalCursor,
+  currentCursor: () => AgentJournalCursor
+): JournalReadSince {
+  if (source.readOnly) {
+    return { ok: false, reset: 'schema_unreadable' }
+  }
+  const resume = resolveJournalResume(source.state, cursor)
+  if (!resume.ok) {
+    return { ok: false, reset: resume.reset }
+  }
+  return {
+    ok: true,
+    rows: source.tailRows.filter((row) => row.seq > resume.afterSequence),
+    cursor: currentCursor()
+  }
 }

--- a/src/main/native-chat/agent-session-journal/journal-log-file.ts
+++ b/src/main/native-chat/agent-session-journal/journal-log-file.ts
@@ -9,6 +9,7 @@
 // superset of the tail, and recovery unions the two by sequence — never a hole.
 
 import { appendFile, mkdir, open, readFile } from 'node:fs/promises'
+import { randomUUID } from 'node:crypto'
 import { join } from 'node:path'
 import { durableWriteTempPath, writeFileDurable } from '../../durable-file-write'
 import type {
@@ -25,6 +26,8 @@ export type JournalSnapshotFile = {
   epoch: string
   /** Highest sequence folded into `items`; the tail starts after it. */
   compactedThrough: number
+  /** Fence monotonicity survives compaction and restart. */
+  highestFence: number
   items: AgentJournalRenderItem[]
   submissions: AgentJournalSubmission[]
   /** Receipts outlive the rows that minted them: a client reconnecting after
@@ -39,6 +42,7 @@ export type JournalSnapshotFile = {
   /** Provider item id → submission slot, preserved so a post-compaction echo
    *  still reconciles into the bubble it belongs to. */
   aliases: { providerItemId: string; itemId: string }[]
+  tombstones: { itemId: string; revision: number }[]
   tail: JournalRow[]
 }
 
@@ -50,7 +54,11 @@ export type JournalReadResult = {
   unreadable: boolean
   /** Lines that failed to parse for reasons other than schema version. */
   malformed: number
+  /** Raw suffix beginning at the first malformed line, if any. */
+  remainder?: string
 }
+
+const NEWLINE_BYTE = 0x0a
 
 export async function ensureJournalDir(journalDir: string): Promise<void> {
   await mkdir(journalDir, { recursive: true })
@@ -86,13 +94,17 @@ export async function readJournalLog(journalDir: string): Promise<JournalReadRes
   const rows: JournalRow[] = []
   let unreadable = false
   let malformed = 0
-  for (const line of raw.split('\n')) {
+  const lines = raw.split('\n')
+  let offset = 0
+  for (const line of lines) {
     if (!line.trim()) {
+      offset += line.length + 1
       continue
     }
     const parsed = parseJournalRow(line)
     if (parsed.ok) {
       rows.push(parsed.row)
+      offset += line.length + 1
       continue
     }
     if (parsed.unreadable) {
@@ -100,6 +112,7 @@ export async function readJournalLog(journalDir: string): Promise<JournalReadRes
       break
     }
     malformed += 1
+    return { rows, unreadable, malformed, remainder: raw.slice(offset) }
   }
   return { rows, unreadable, malformed }
 }
@@ -117,6 +130,29 @@ export async function appendJournalRows(
     return
   }
   const path = join(journalDir, JOURNAL_LOG_FILE)
+  // A process death can leave a final JSON fragment without its newline. Never
+  // concatenate a new durable row onto that fragment: truncate the torn tail
+  // first, then fsync the repair before acknowledging this append.
+  try {
+    // Read as bytes, not text: `truncate`/`write` take byte offsets, and a
+    // transcript's multi-byte characters make string indices the wrong unit.
+    const existing = await readFile(path)
+    if (existing.length > 0 && existing.at(-1) !== NEWLINE_BYTE) {
+      const boundary = existing.lastIndexOf(NEWLINE_BYTE)
+      const finalLine = existing.subarray(boundary + 1).toString('utf-8')
+      // A whole row that merely lost its newline is kept; a real fragment goes.
+      const complete = parseJournalRow(finalLine).ok
+      const handle = await open(path, 'r+')
+      try {
+        await (complete ? handle.write('\n', existing.length) : handle.truncate(boundary + 1))
+        await handle.sync()
+      } finally {
+        await handle.close()
+      }
+    }
+  } catch {
+    // The append below creates a missing log; other read errors remain visible.
+  }
   const payload = `${rows.map(serializeJournalRow).join('\n')}\n`
   await appendFile(path, payload, 'utf-8')
   const handle = await open(path, 'r+')
@@ -125,6 +161,22 @@ export async function appendJournalRows(
   } finally {
     await handle.close()
   }
+  try {
+    const directory = await open(journalDir, 'r')
+    await directory.sync()
+    await directory.close()
+  } catch {
+    // Directory fsync is unavailable on some platforms (notably Windows).
+  }
+}
+
+export async function quarantineJournalRemainder(
+  journalDir: string,
+  remainder: string
+): Promise<string> {
+  const path = join(journalDir, `quarantine-${Date.now()}-${randomUUID()}.jsonl`)
+  await writeFileDurable(durableWriteTempPath(path), path, remainder)
+  return path
 }
 
 /** Replace the log with exactly the retained tail. Runs only after the snapshot

--- a/src/main/native-chat/agent-session-journal/journal-open.ts
+++ b/src/main/native-chat/agent-session-journal/journal-open.ts
@@ -13,6 +13,7 @@ import {
   readJournalSnapshotFile,
   type JournalSnapshotFile
 } from './journal-log-file'
+import { AGENT_SESSION_JOURNAL_SCHEMA_VERSION } from '../../../shared/agent-session-journal-types'
 import {
   applyJournalRow,
   createJournalReducerState,
@@ -31,6 +32,8 @@ export type JournalLoad = {
   /** Set when the surviving prefix is unusable and the caller must roll the epoch. */
   corrupt: boolean
   sizeBytes: number
+  /** Raw unreadable suffix retained for quarantine instead of deletion. */
+  quarantineRemainder?: string
 }
 
 /** Returns null when no journal exists yet for this session. */
@@ -48,7 +51,7 @@ export async function loadJournal(
   const compactedThrough = snapshot?.epoch === epoch ? snapshot.compactedThrough : 0
   const state = seedState(sessionId, epoch, snapshot?.epoch === epoch ? snapshot : null)
   const liveRows = log.rows.filter((row) => row.epoch === epoch)
-  const tailRows = unionBySequence(snapshot?.epoch === epoch ? snapshot.tail : [], liveRows, epoch)
+  let tailRows = unionBySequence(snapshot?.epoch === epoch ? snapshot.tail : [], liveRows, epoch)
 
   const oldest = tailRows[0]?.seq ?? compactedThrough + 1
   const gap = findSequenceGap(
@@ -57,9 +60,21 @@ export async function loadJournal(
   )
   // A hole below the snapshot boundary is unrecoverable too: the snapshot only
   // covers `compactedThrough`, so a tail that starts above it lost rows.
-  const corrupt = Boolean(gap) || oldest > compactedThrough + 1
+  let corrupt = Boolean(gap) || oldest > compactedThrough + 1 || log.malformed > 0
+  let quarantineRemainder = log.remainder
+  if (gap) {
+    const firstBad = tailRows.findIndex((row, index) => {
+      const expected = (tailRows[0]?.seq ?? compactedThrough + 1) + index
+      return row.seq !== expected
+    })
+    if (firstBad !== -1) {
+      const suffix = tailRows.slice(firstBad)
+      tailRows = tailRows.slice(0, firstBad)
+      quarantineRemainder ??= `${suffix.map((row) => JSON.stringify(row)).join('\n')}\n`
+    }
+  }
 
-  for (const row of liveRows) {
+  for (const row of tailRows) {
     if (row.seq > compactedThrough) {
       applyJournalRow(state, row)
     }
@@ -71,9 +86,10 @@ export async function loadJournal(
     state,
     tailRows,
     compactedThrough,
-    readOnly: log.unreadable,
+    readOnly: log.unreadable || (snapshot?.v ?? 0) > AGENT_SESSION_JOURNAL_SCHEMA_VERSION,
     corrupt,
-    sizeBytes: tailRows.reduce((total, row) => total + journalRowByteLength(row), 0)
+    sizeBytes: tailRows.reduce((total, row) => total + journalRowByteLength(row), 0),
+    quarantineRemainder
   }
 }
 
@@ -129,6 +145,10 @@ function seedState(
   for (const alias of snapshot.aliases) {
     state.aliases.set(alias.providerItemId, alias.itemId)
   }
+  for (const tombstone of snapshot.tombstones ?? []) {
+    state.tombstones.set(tombstone.itemId, tombstone.revision)
+  }
+  state.highestFence = snapshot.highestFence ?? 0
   state.lastSequence = snapshot.compactedThrough
   state.oldestSequence = snapshot.compactedThrough + 1
   return state

--- a/src/main/native-chat/agent-session-journal/journal-reducer.ts
+++ b/src/main/native-chat/agent-session-journal/journal-reducer.ts
@@ -9,6 +9,7 @@
 
 import type {
   AgentJournalAcceptanceReceipt,
+  AgentJournalItemBody,
   AgentJournalRenderItem,
   AgentJournalSnapshot,
   AgentJournalSubmission
@@ -232,17 +233,25 @@ export function renderJournalState(state: JournalReducerState): AgentJournalSnap
   }
 }
 
+/** Blob digests one body points at. A retained row can outlive its render item
+ *  (a tombstone drops the item), so compaction reads rows through this too. */
+export function blobDigestsInBody(body: AgentJournalItemBody, into: Set<string>): void {
+  if (body.kind === 'tool-call' && body.output?.truncated) {
+    into.add(body.output.digest)
+  }
+  if (body.kind === 'diff' && body.patch.truncated) {
+    into.add(body.patch.digest)
+  }
+  if (body.kind === 'status' && body.providerFrame?.payload.truncated) {
+    into.add(body.providerFrame.payload.digest)
+  }
+}
+
 /** Digests referenced by live rows, so compaction knows which blobs to keep. */
 export function referencedBlobDigests(state: JournalReducerState): Set<string> {
   const digests = new Set<string>()
   for (const item of state.items.values()) {
-    const body = item.body
-    if (body.kind === 'tool-call' && body.output?.truncated) {
-      digests.add(body.output.digest)
-    }
-    if (body.kind === 'diff' && body.patch.truncated) {
-      digests.add(body.patch.digest)
-    }
+    blobDigestsInBody(item.body, digests)
   }
   return digests
 }

--- a/src/main/native-chat/agent-session-journal/journal-store.test.ts
+++ b/src/main/native-chat/agent-session-journal/journal-store.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
@@ -147,7 +147,7 @@ describe('replay', () => {
     expect(reopened.snapshot().items).toHaveLength(0)
   })
 
-  it('rolls the epoch when the log lost a row', async () => {
+  it('preserves the intact prefix and quarantines a corrupt suffix', async () => {
     const journal = await open()
     for (let index = 0; index < 4; index += 1) {
       await journal.appendItem(item(index), body(`m${index}`), { fence: 1 })
@@ -158,12 +158,34 @@ describe('replay', () => {
     await writeFile(logPath, `${[...lines.slice(0, 2), ...lines.slice(3)].join('\n')}\n`, 'utf-8')
 
     const reopened = await open()
-    expect(reopened.epoch).not.toBe(before)
-    expect(reopened.snapshot().items).toHaveLength(0)
+    expect(reopened.epoch).toBe(before)
+    expect(reopened.snapshot().items.map((entry) => entry.body)).toEqual([body('m0')])
+    const files = await readdir(root)
+    expect(files.some((name) => name.startsWith('quarantine-'))).toBe(true)
   })
 })
 
 describe('compaction and retention', () => {
+  it('preserves the highest fence across compaction and reopen', async () => {
+    const journal = await open({ compaction: { minTailRows: 1, retainTailMs: 0 } })
+    await journal.appendItem(item(0), body('a'), { fence: 7 })
+    await journal.compact()
+    const reopened = await open({ compaction: { minTailRows: 1, retainTailMs: 0 } })
+    await expect(reopened.appendItem(item(1), body('stale'), { fence: 6 })).rejects.toMatchObject({
+      code: 'journal_stale_fence'
+    })
+  })
+
+  it('preserves tombstones across compaction and reopen', async () => {
+    const journal = await open({ compaction: { minTailRows: 1, retainTailMs: 0 } })
+    await journal.appendItem(item(0), body('a'), { fence: 1 })
+    await journal.appendTombstone(item(0), { fence: 1 })
+    await journal.compact()
+    const reopened = await open({ compaction: { minTailRows: 1, retainTailMs: 0 } })
+    await reopened.appendItem(item(0), body('stale'), { fence: 1 })
+    expect(reopened.snapshot().items).toHaveLength(0)
+  })
+
   it('folds the prefix into the snapshot and keeps serving the retained tail', async () => {
     const journal = await open({ compaction: { minTailRows: 2, retainTailMs: 0 } })
     for (let index = 0; index < 6; index += 1) {
@@ -194,6 +216,10 @@ describe('compaction and retention', () => {
     const rendered = journal.snapshot()
     const logBefore = await readFile(join(root, JOURNAL_LOG_FILE), 'utf-8')
     await journal.compact()
+    const persistedSnapshot = JSON.parse(
+      await readFile(join(root, JOURNAL_SNAPSHOT_FILE), 'utf-8')
+    ) as { tail: unknown[] }
+    expect(persistedSnapshot.tail).toHaveLength(2)
     // Simulate the crash: the snapshot landed, the truncation did not.
     await writeFile(join(root, JOURNAL_LOG_FILE), logBefore, 'utf-8')
 
@@ -330,6 +356,67 @@ describe('schema', () => {
     const reopened = await open()
     expect(reopened.isReadOnly).toBe(false)
     expect(reopened.snapshot().items).toHaveLength(1)
+  })
+
+  it('repairs a torn tail before acknowledging the next append', async () => {
+    const journal = await open()
+    await journal.appendItem(item(0), body('a'), { fence: 1 })
+    const logPath = join(root, JOURNAL_LOG_FILE)
+    const intact = await readFile(logPath, 'utf-8')
+    await writeFile(logPath, intact.slice(0, -1), 'utf-8')
+
+    await journal.appendItem(item(1), body('b'), { fence: 1 })
+    const reopened = await open()
+    expect(reopened.snapshot().items.map((entry) => entry.body)).toEqual([body('a'), body('b')])
+  })
+
+  // Transcripts are full of emoji and CJK, so the repair's file offsets must be
+  // bytes: string indices would truncate mid-character and corrupt the prefix.
+  it('repairs a torn tail whose rows contain multi-byte characters', async () => {
+    const journal = await open()
+    await journal.appendItem(item(0), body('안녕하세요 🌊 café'), { fence: 1 })
+    const logPath = join(root, JOURNAL_LOG_FILE)
+    const intact = await readFile(logPath)
+    // Kill mid-row: keep the complete first row plus a fragment of the second.
+    const torn = Buffer.concat([intact, Buffer.from('{"seq":2,"kind":"it', 'utf-8')])
+    await writeFile(logPath, torn)
+
+    await journal.appendItem(item(1), body('b'), { fence: 1 })
+    const reopened = await open()
+    expect(reopened.snapshot().items.map((entry) => entry.body)).toEqual([
+      body('안녕하세요 🌊 café'),
+      body('b')
+    ])
+  })
+
+  it('degrades to read-only when the snapshot comes from a newer schema', async () => {
+    const journal = await open()
+    await journal.appendItem(item(0), body('a'), { fence: 1 })
+    const snapshotPath = join(root, JOURNAL_SNAPSHOT_FILE)
+    const snapshot = JSON.parse(await readFile(snapshotPath, 'utf-8')) as Record<string, unknown>
+    snapshot.v = 99
+    await writeFile(snapshotPath, JSON.stringify(snapshot), 'utf-8')
+
+    const reopened = await open()
+    expect(reopened.isReadOnly).toBe(true)
+    await expect(reopened.appendItem(item(1), body('b'), { fence: 1 })).rejects.toMatchObject({
+      code: 'journal_read_only'
+    })
+  })
+
+  it('allows the explicit schema-unreadable epoch escape hatch while preserving the old files', async () => {
+    const journal = await open()
+    await journal.appendItem(item(0), body('a'), { fence: 1 })
+    const snapshotPath = join(root, JOURNAL_SNAPSHOT_FILE)
+    const snapshot = JSON.parse(await readFile(snapshotPath, 'utf-8')) as Record<string, unknown>
+    snapshot.v = 99
+    await writeFile(snapshotPath, JSON.stringify(snapshot), 'utf-8')
+    const reopened = await open()
+
+    await reopened.rollEpoch('schema_unreadable', 2)
+    expect(reopened.isReadOnly).toBe(false)
+    expect(reopened.snapshot().items).toHaveLength(0)
+    expect((await readdir(root)).some((name) => name.startsWith('quarantine-'))).toBe(true)
   })
 })
 

--- a/src/main/native-chat/agent-session-journal/journal-store.ts
+++ b/src/main/native-chat/agent-session-journal/journal-store.ts
@@ -18,15 +18,24 @@ import type {
 } from '../../../shared/agent-session-journal-types'
 import { AGENT_SESSION_JOURNAL_SCHEMA_VERSION } from '../../../shared/agent-session-journal-types'
 import { agentJournalItemKey } from '../../../shared/agent-session-journal-item-key'
-import { compactJournal, type JournalCompactionPolicy } from './journal-compaction'
-import { resolveJournalResume, type JournalResume } from './journal-cursor'
+import {
+  compactJournal,
+  DEFAULT_JOURNAL_COMPACTION_POLICY,
+  type JournalCompactionPolicy
+} from './journal-compaction'
+import { readJournalSince } from './journal-cursor'
 import { publishNewEpoch } from './journal-epoch-rollover'
 import { appendJournalRows, ensureJournalDir } from './journal-log-file'
+import {
+  quarantineCorruptSuffix,
+  quarantineUnreadableSchema
+} from './journal-corruption-quarantine'
 import { loadJournal } from './journal-open'
 import { DEFAULT_JOURNAL_PAYLOAD_LIMITS } from './journal-payload-bounds'
 import {
   applyJournalRow,
   createJournalReducerState,
+  referencedBlobDigests,
   renderJournalState,
   resolveJournalItemId,
   type JournalReducerState
@@ -62,7 +71,7 @@ export class AgentSessionJournal {
   private readonly identity: AgentSessionJournalIdentity
   private readonly journalDir: string
   private readonly budget: JournalAppendBudget
-  private readonly compaction: JournalCompactionPolicy | undefined
+  private readonly compaction: JournalCompactionPolicy
   private readonly now: () => number
   private readonly mintEpoch: () => string
 
@@ -81,7 +90,7 @@ export class AgentSessionJournal {
       options.identity.sessionId,
       options.limits ?? DEFAULT_JOURNAL_PAYLOAD_LIMITS
     )
-    this.compaction = options.compaction
+    this.compaction = options.compaction ?? DEFAULT_JOURNAL_COMPACTION_POLICY
     this.now = options.now ?? (() => Date.now())
     this.mintEpoch = options.mintEpoch ?? randomUUID
     this.state = createJournalReducerState(options.identity.sessionId, '')
@@ -118,9 +127,8 @@ export class AgentSessionJournal {
     this.sizeBytes = loaded.sizeBytes
     this.readOnly = loaded.readOnly
     if (loaded.corrupt && !loaded.readOnly) {
-      // A reader that observes a gap rolls the epoch rather than rendering a
-      // partial timeline; clients take the snapshot reload they already handle.
-      await this.rollEpoch('corruption', this.state.highestFence)
+      // The epoch stays put: no intact history is discarded to recover.
+      await quarantineCorruptSuffix(this.journalDir, this.tailRows, loaded.quarantineRemainder)
     }
   }
 
@@ -149,29 +157,16 @@ export class AgentSessionJournal {
   canonicalItemId(itemId: string): string {
     return resolveJournalItemId(this.state, itemId)
   }
-  readSince(cursor: AgentJournalCursor): JournalReadSince {
-    const resume = this.resume(cursor)
-    if (!resume.ok) {
-      return { ok: false, reset: resume.reset }
-    }
-    return {
-      ok: true,
-      rows: this.tailRows.filter((row) => row.seq > resume.afterSequence),
-      cursor: this.cursor()
-    }
+
+  referencedBlobDigests(): Set<string> {
+    return referencedBlobDigests(this.state)
   }
 
-  private resume(cursor: AgentJournalCursor): JournalResume {
-    if (this.readOnly) {
-      return { ok: false, reset: 'schema_unreadable' }
-    }
-    return resolveJournalResume(
-      {
-        epoch: this.state.epoch,
-        lastSequence: this.state.lastSequence,
-        oldestSequence: this.state.oldestSequence
-      },
-      cursor
+  readSince(cursor: AgentJournalCursor): JournalReadSince {
+    return readJournalSince(
+      { state: this.state, tailRows: this.tailRows, readOnly: this.readOnly },
+      cursor,
+      () => this.cursor()
     )
   }
 
@@ -271,14 +266,14 @@ export class AgentSessionJournal {
     return pending
   }
 
-  async compact(): Promise<void> {
+  async compact(now = this.now()): Promise<void> {
     assertJournalWritable(this.readOnly, this.identity.sessionId)
     const result = await compactJournal({
       journalDir: this.journalDir,
       state: this.state,
       tailRows: this.tailRows,
       policy: this.compaction,
-      now: this.now()
+      now
     })
     this.tailRows = result.tailRows
     this.compactedThrough = result.compactedThrough
@@ -289,8 +284,13 @@ export class AgentSessionJournal {
   /** The escape hatch for corruption, an unreconcilable prefix, a forked handle,
    *  and an unreadable schema. It invalidates every cursor; clients reload. */
   async rollEpoch(reason: AgentJournalEpochReason, fence: number): Promise<AgentJournalCursor> {
-    assertJournalWritable(this.readOnly, this.identity.sessionId)
+    if (reason !== 'schema_unreadable') {
+      assertJournalWritable(this.readOnly, this.identity.sessionId)
+    } else if (this.readOnly) {
+      await quarantineUnreadableSchema(this.journalDir)
+    }
     await this.startEpoch(reason, fence)
+    this.readOnly = false
     return this.cursor()
   }
 

--- a/src/main/native-chat/agent-session-wire/agent-session-journal-recovery.test.ts
+++ b/src/main/native-chat/agent-session-wire/agent-session-journal-recovery.test.ts
@@ -159,7 +159,7 @@ describe('openAgentSessionJournalWithRecovery', () => {
 
   it('still opens the session when provider history cannot be read', async () => {
     const lines = await seedJournal(3)
-    const holed = lines.filter((_line, index) => index !== 1)
+    const holed = lines.filter((_line, index) => index !== 2)
     await writeFile(join(journalDir, 'log.jsonl'), `${holed.join('\n')}\n`, 'utf-8')
 
     const opened = await openAgentSessionJournalWithRecovery({
@@ -170,6 +170,7 @@ describe('openAgentSessionJournalWithRecovery', () => {
     })
     expect(opened.recovery).toMatchObject({ trigger: 'journal_corrupt', imported: 0 })
     expect(opened.recovery?.error).toBeTruthy()
-    expect(opened.journal.snapshot().items).toHaveLength(0)
+    // A missing provider transcript must not clear the intact journal prefix.
+    expect(opened.journal.snapshot().items).toHaveLength(1)
   })
 })

--- a/src/main/native-chat/agent-session-wire/agent-session-journal-recovery.ts
+++ b/src/main/native-chat/agent-session-wire/agent-session-journal-recovery.ts
@@ -27,9 +27,7 @@ export type AgentSessionJournalRecovery = {
   reset: AgentJournalResetReason
   epoch: string
   imported: number
-  /** Set when provider history could not be read. The session still opens, on
-   *  an empty fresh epoch — an unreadable transcript is not a reason to refuse
-   *  the user their session. */
+  /** Set when provider history could not be read; the intact journal prefix remains live. */
   error?: string
 }
 
@@ -77,8 +75,8 @@ export async function openAgentSessionJournalWithRecovery(input: {
   if (!probe?.corrupt) {
     return { journal, recovery: null }
   }
-  // `open()` already rolled the epoch off the unusable prefix; the import rolls
-  // once more so the rebuilt timeline is the only content of its epoch.
+  // `open()` quarantines the unusable suffix; a successful import rolls once
+  // more so the rebuilt timeline is the only content of its epoch.
   return { journal, recovery: await rehydrate({ ...input, journal, trigger: 'journal_corrupt' }) }
 }
 

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-event-sink.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-event-sink.ts
@@ -16,7 +16,7 @@ import type {
   AgentJournalItemIdentity
 } from '../../../shared/agent-session-journal-types'
 import type { AgentSessionJournal } from '../agent-session-journal/journal-store'
-import { putJournalBlob } from '../agent-session-journal/journal-blob-store'
+import { putJournalBlob, removeJournalBlob } from '../agent-session-journal/journal-blob-store'
 
 export type StructuredAgentSessionJournalBlob = { digest: string; payload: string }
 
@@ -97,10 +97,22 @@ export function createDeferredStructuredAgentSessionEventSink(
     sink: {
       appendItem: (identity, body: AgentJournalItemBody, blobs = []) => {
         submit(async (bound) => {
-          for (const blob of blobs) {
-            await putJournalBlob(bound.journal.directory, blob.digest, blob.payload)
+          const persisted: string[] = []
+          try {
+            for (const blob of blobs) {
+              await putJournalBlob(bound.journal.directory, blob.digest, blob.payload)
+              persisted.push(blob.digest)
+            }
+            await bound.journal.appendItem(identity, body, { fence: bound.fence })
+          } catch (error) {
+            const retained = bound.journal.referencedBlobDigests?.() ?? new Set<string>()
+            for (const digest of persisted) {
+              if (!retained.has(digest)) {
+                await removeJournalBlob(bound.journal.directory, digest)
+              }
+            }
+            throw error
           }
-          await bound.journal.appendItem(identity, body, { fence: bound.fence })
         })
       },
       appendTombstone: (identity) => {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​94 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​88 |
| Prod | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​232 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​54 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​178 |

<!-- /orca-pr-loc -->

## Defect

Two confirmed findings from the #14600 audit, both of the same species: journal recovery destroyed the user's transcript instead of preserving what was readable.

**A single corrupt line wiped the whole transcript.** `open()` detected a gap, set `corrupt`, and called `rollEpoch('corruption')` — which built an *empty* reducer state and rewrote the log wholesale. Every intact message before the bad row was discarded, with no quarantine copy. The rollover test asserted that wipe as the desired outcome.

**A torn final line turned an acknowledged append into loss.** A crash can leave a partial JSON fragment with no trailing newline. The next append concatenated its row onto that fragment, fsynced, and *resolved successfully* — telling the caller the write had durably landed. Reopen then skipped the malformed combined line, later rows exposed a sequence gap, and the session entered the destructive path above. Existing malformed-line coverage never appended and reopened, which is why this stayed invisible.

Three smaller findings in the same subsystem, all reachable in normal use:

- A future-schema **snapshot** stayed writable. Snapshot parsing accepted any object with an epoch and ignored `snapshot.v`; read-only was derived only from future *log rows*. An older host could seed a newer snapshot, append into it, and later overwrite unknown state.
- The `schema_unreadable` escape hatch was gated on the flag its own condition sets: a newer-schema row sets `readOnly`, `rollEpoch` asserts `!readOnly` first, and nothing clears it. The documented remedy could never run — the session froze permanently.
- Compaction persisted neither `highestFence` nor tombstones, and omitted provider-frame blob digests from retention. After compact/reopen a **lower fence was accepted** and tombstoned content could resurrect, while still-referenced payloads were pruned.

## Failure scenario

Kill Orca mid-append (crash, OOM, or an external kill). The log keeps a partial final line. On the next send, the append resolves — the user is told the message landed. On the next open, the transcript is empty and the original bytes are gone.

## Fix

Corruption never deletes history. The readable prefix stays live in place, the unreadable remainder moves to a `quarantine-*.jsonl` file, and the epoch does not roll. A torn tail is repaired before any new row is appended — a whole row that merely lost its newline gets it back, a real fragment is truncated — and the repair is fsynced first. Appends now fsync the parent directory too.

Future-schema snapshots degrade to read-only. `schema_unreadable` rollover is reachable and copies the unknown rows aside before rebuilding. Compaction persists `highestFence` and tombstones, and retention covers provider-frame digests plus rows whose render item is gone.

Quarantine logic lives in a new `journal-corruption-quarantine.ts`; `readSince`'s resume moved to `journal-cursor.ts`, which already owned resume resolution.

## Verification

- 499 native-chat tests, node typecheck, oxlint clean.
- The pinned `agent-session-journal-recovery.test.ts` assertion that a failed recovery yields an *empty* session was changed. That assertion encoded a violation of the no-auto-clear-user-data-on-error rule — it was asserting the bug.
- Mutation: the new multi-byte torn-tail test goes red against a string-offset repair. `truncate`/`write` take **byte** offsets, and transcripts are full of emoji and CJK, so the original string-index implementation would have truncated mid-character and corrupted the prefix it was trying to save.

Stacked: #NEXT enables compaction on top of this, and must not land first.
