### PR TITLE
fix(native-chat): actually run journal compaction in production

### DIFF
--- a/src/main/native-chat/agent-session-journal/journal-store-contracts.ts
+++ b/src/main/native-chat/agent-session-journal/journal-store-contracts.ts
@@ -13,6 +13,8 @@ export type AgentSessionJournalOptions = {
   journalDir: string
   limits?: JournalPayloadLimits
   compaction?: JournalCompactionPolicy
+  /** Compact as the tail grows. Defaults on: without it the log never sheds. */
+  autoCompact?: boolean
   now?: () => number
   mintEpoch?: () => string
 }

--- a/src/main/native-chat/agent-session-journal/journal-store.test.ts
+++ b/src/main/native-chat/agent-session-journal/journal-store.test.ts
@@ -165,6 +165,43 @@ describe('replay', () => {
   })
 })
 
+describe('automatic compaction', () => {
+  // Production passes no policy and never called compact(), so the log only
+  // ever grew — until the size bound refused every append for good.
+  it('compacts on append once the retention window has rows to shed', async () => {
+    const policy = { minTailRows: 2, retainTailMs: 0 }
+    const journal = await open({ compaction: policy })
+    for (let index = 0; index < 6; index += 1) {
+      await journal.appendItem(item(index), body(`m${index}`), { fence: 1 })
+    }
+    expect(journal.compactionBoundary).toBeGreaterThan(0)
+    // The log sheds instead of growing with every append (7 = epoch row + 6).
+    const log = await readFile(join(root, JOURNAL_LOG_FILE), 'utf-8')
+    expect(log.trim().split('\n').length).toBeLessThan(7)
+    // Nothing is lost: the folded prefix is served from the snapshot.
+    expect(journal.snapshot().items).toHaveLength(6)
+  })
+
+  it('does not rewrite the log while every row is inside the retention window', async () => {
+    const journal = await open({ compaction: { minTailRows: 2, retainTailMs: 60_000 } })
+    for (let index = 0; index < 6; index += 1) {
+      await journal.appendItem(item(index), body(`m${index}`), { fence: 1 })
+    }
+    expect(journal.compactionBoundary).toBe(0)
+  })
+
+  it('can be turned off explicitly', async () => {
+    const journal = await open({
+      autoCompact: false,
+      compaction: { minTailRows: 2, retainTailMs: 0 }
+    })
+    for (let index = 0; index < 6; index += 1) {
+      await journal.appendItem(item(index), body(`m${index}`), { fence: 1 })
+    }
+    expect(journal.compactionBoundary).toBe(0)
+  })
+})
+
 describe('compaction and retention', () => {
   it('preserves the highest fence across compaction and reopen', async () => {
     const journal = await open({ compaction: { minTailRows: 1, retainTailMs: 0 } })

--- a/src/main/native-chat/agent-session-journal/journal-store.ts
+++ b/src/main/native-chat/agent-session-journal/journal-store.ts
@@ -72,6 +72,7 @@ export class AgentSessionJournal {
   private readonly journalDir: string
   private readonly budget: JournalAppendBudget
   private readonly compaction: JournalCompactionPolicy
+  private readonly autoCompact: boolean
   private readonly now: () => number
   private readonly mintEpoch: () => string
 
@@ -90,6 +91,7 @@ export class AgentSessionJournal {
       options.identity.sessionId,
       options.limits ?? DEFAULT_JOURNAL_PAYLOAD_LIMITS
     )
+    this.autoCompact = options.autoCompact ?? true
     this.compaction = options.compaction ?? DEFAULT_JOURNAL_COMPACTION_POLICY
     this.now = options.now ?? (() => Date.now())
     this.mintEpoch = options.mintEpoch ?? randomUUID
@@ -266,6 +268,16 @@ export class AgentSessionJournal {
     return pending
   }
 
+  /** Only when the retention window would actually drop rows: inside it,
+   *  compaction rewrites an identical log, and doing that per append is a full
+   *  state serialization on the hot path. */
+  private shouldAutoCompact(now: number): boolean {
+    if (!this.autoCompact || this.tailRows.length <= this.compaction.minTailRows * 2) {
+      return false
+    }
+    return (this.tailRows[0]?.ts ?? now) < now - this.compaction.retainTailMs
+  }
+
   async compact(now = this.now()): Promise<void> {
     assertJournalWritable(this.readOnly, this.identity.sessionId)
     const result = await compactJournal({
@@ -340,6 +352,11 @@ export class AgentSessionJournal {
       applyJournalRow(this.state, row)
       this.tailRows.push(row)
       this.sizeBytes += journalRowByteLength(row)
+      // Nothing else calls compact(), so without this the log only ever grows —
+      // until the size bound refuses every append for the rest of the session.
+      if (this.shouldAutoCompact(ts)) {
+        await this.compact(ts)
+      }
       return row
     })
     this.writes = run.catch(() => undefined)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​37 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​37 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​19 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​19 |

<!-- /orca-pr-loc -->

Stacked on #15159 — **that must land first.** Before its fix, enabling compaction lets a reopened journal accept a lower fence and resurrect tombstoned content.

## Defect

`AgentSessionJournal.compact()` had **zero production callers** (only epoch rollover reached `compactJournal`). So for every structured session:

- `log.jsonl` grew without bound and was read in full — twice — on every open.
- `blobs/` never shed anything.
- At 256MB of row bytes, `journal_bound_exceeded` refused every subsequent append **for the life of the session**, and no consumer handles that code. The deferred provider sink catches the error and invokes an optional callback the production runtime never installs, so Codex kept running while transcript activity silently vanished.

The 512-row / 2h retention policy was written and tested, but never shipped.

## Failure scenario

A long-lived chat session crosses the size bound. Codex keeps responding, the user keeps typing, and nothing is recorded — no error surfaces. Recovering requires editing files by hand.

## Fix

Compaction runs from the append path, gated on the retention window actually having rows to shed.

That gate is the non-obvious part. Inside the retention window `retainTail` returns *every* row, so an unconditional trigger would serialize the entire reducer state and rewrite a byte-identical log on **every append** past the threshold — a full state write per row on the hot path. The trigger fires only when the oldest retained row has aged out.

`autoCompact` is an explicit option defaulting to on, rather than being inferred from whether a `compaction` policy was passed. The inferred form was a footgun: tuning the policy would have silently disabled shedding.

## Verification

- 101 journal tests, node typecheck, oxlint clean.
- Three new tests: sheds once rows age out; does **not** rewrite the log while every row is inside the window; can be disabled explicitly.
- Mutation: stubbing the trigger to `false` turns the shed assertion red.

## Not fixed here

`journal_bound_exceeded` still has no consumer, so a session that generates 256MB *inside* the retention window can still brick. Compaction cannot help there by policy — recent rows are retained by design. That needs a separate decision about surfacing the bound to the user, and is called out in the audit.
