### PR TITLE
test(orchestration): make the heartbeat straggler test able to fail

### DIFF
--- a/src/main/runtime/orchestration/db.test.ts
+++ b/src/main/runtime/orchestration/db.test.ts
@@ -658,11 +658,15 @@ describe('OrchestrationDb', () => {
       const d = createDb()
       const task = d.createTask({ spec: 'work' })
       const ctx = d.createDispatchContext(task.id, 'term_a')
+      // Why: seed a heartbeat while the row is still dispatched, so the expected value is a
+      // timestamp rather than null — the initial state. Asserting null would also pass if
+      // completing the dispatch cleared the column, which is not what this guards.
+      d.recordHeartbeat(ctx.id, '2026-05-03T00:00:00.000Z')
       d.completeDispatch(ctx.id)
 
       d.recordHeartbeat(ctx.id, '2026-05-04T00:00:00.000Z')
       const after = d.getDispatchContext(task.id)
-      expect(after?.last_heartbeat_at).toBeNull()
+      expect(after?.last_heartbeat_at).toBe('2026-05-03T00:00:00.000Z')
     })
 
     it('getStaleDispatches returns only dispatched rows past the grace window', () => {


### PR DESCRIPTION
## ELI5

A test says "a heartbeat arriving after the job finished is ignored". It checked that the heartbeat column ended up empty — but the column starts empty, so the test passed without the code doing anything. Now it puts a real heartbeat in first, so the check has something to actually compare against.

## What Changed

One test in `src/main/runtime/orchestration/db.test.ts`. No product code.

```diff
 it('recordHeartbeat is a no-op for completed rows (straggler ignored)', () => {
   const d = createDb()
   const task = d.createTask({ spec: 'work' })
   const ctx = d.createDispatchContext(task.id, 'term_a')
+  d.recordHeartbeat(ctx.id, '2026-05-03T00:00:00.000Z')
   d.completeDispatch(ctx.id)

   d.recordHeartbeat(ctx.id, '2026-05-04T00:00:00.000Z')
   const after = d.getDispatchContext(task.id)
-  expect(after?.last_heartbeat_at).toBeNull()
+  expect(after?.last_heartbeat_at).toBe('2026-05-03T00:00:00.000Z')
 })
```

## Why

`recordHeartbeat` carries a status filter with a stated reason:

```ts
// Why: only bump status='dispatched' — a zombie heartbeat from a finished dispatch would mask a hung retry from the stale detector (§5.3.4).
"UPDATE dispatch_contexts SET last_heartbeat_at = ? WHERE id = ? AND status = 'dispatched'"
```

The test guarding it never gave the row a heartbeat before settling it, so `last_heartbeat_at` was `null` from creation and `toBeNull()` held for two different reasons: the filter excluded the row, or something cleared the column on the way to `completed`. It could not fail for the reason its name claims.

Seeding a heartbeat first makes the expected value a timestamp rather than the initial state, so both regressions are now distinguishable — `null` means the column was cleared, `'2026-05-04…'` means the guard is gone.

This is a test-only gap. `recordHeartbeat` is correct today; nothing would notice if it stopped being.

## Linked Issue

Fixes #15164

## Visual Proof

`N/A` — test-only change, no product code and no rendered UI. The before/after that matters is the assertion behaviour, shown under Testing.

## Testing

Verified by regression injection, since a test that cannot fail is only provable by making it fail. Injected into `completeDispatch`:

```diff
-"UPDATE dispatch_contexts SET status = 'completed', completed_at = datetime('now'), …"
+"UPDATE dispatch_contexts SET status = 'completed', last_heartbeat_at = NULL, completed_at = datetime('now'), …"
```

`main`'s assertion, against that regression — green, which is the bug:

```
 Test Files  1 passed (1)
      Tests  1 passed | 60 skipped (61)
```

This PR's assertion, same regression — red:

```
 - Expected: "2026-05-03T00:00:00.000Z"
 + Received: null
 ❯ src/main/runtime/orchestration/db.test.ts:669:40
 Test Files  1 failed (1)
      Tests  1 failed | 60 skipped (61)
```

The injected change was reverted before committing; the diff in this PR is the test file only.

With the tree clean, on Windows 11 / Node 24.19.0:

```
vitest run src/main/runtime/orchestration/db.test.ts
  Test Files  1 passed (1)   Tests  61 passed (61)

tsc --noEmit -p config/tsconfig.node.json        clean
oxlint src config tests --deny-warnings          clean
check-reliability-gates.mjs   passed for 85 gate(s)
check-max-lines-ratchet.mjs   OK — 190 grandfathered, no new bypasses
verify:bundled-skill-guides   clean
```

`pnpm lint` runs clean through those and then stops at `verify:skill-bundle-manifest` — this is #14479, not this change:

```
Generated skill artifacts are stale:
resources\skills\current-manifest.json
resources\skills\snapshot-registry.json
resources\skills\release-mapping.json
```

That is not from this change — it reproduces identically on a pristine detached `upstream/main` (`60805f5c`) in the same checkout, and this PR touches one test file. Flagging it rather than regenerating artifacts that have nothing to do with the diff.

Not run locally: `pnpm build` and the full suite. Platforms exercised: Windows only — the change is a SQLite assertion with no platform-dependent behaviour.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Claude Opus 5 was used to write the regression-injection proof, the change, and this description.

## Review

Reviewed for the areas the template asks about; none are touched. No product code, so no security, performance, cross-platform, SSH/remote, mobile, or backwards-compatibility surface. The only cross-cutting consideration is the SQLite timestamp format, and the test stays on the explicit ISO strings the surrounding cases already use, so it does not depend on wall clock or timezone.

**Overlap worth flagging:** #14889 relocates this exact test to `db-dispatch-liveness.test.ts` without changing it. Whichever lands first, the other rebases cleanly — if #14889 goes first this assertion moves to the new file; if this goes first the relocation carries it. I kept them separate deliberately: #14889 is a byte-for-byte move, and its whole value is that a reviewer can confirm nothing changed inside it.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — see Testing for exactly what was run: `pnpm build` and the full suite were not, and `pnpm lint` stops on the `verify:skill-bundle-manifest` staleness reported in #14479, which reproduces on pristine `main`

## Author

- X / Twitter: @EnricoPin

