### PR TITLE
Fix populated sidebar lineage drop targets

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.compact-hover.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.compact-hover.test.tsx
@@ -550,7 +550,7 @@ describe('WorktreeCard compact hover details', () => {
     const surfaceTag = markup.match(/<div[^>]*data-worktree-card-surface="true"[^>]*>/)?.[0]
     expect(surfaceTag).toBeDefined()
     expect(surfaceTag).not.toContain('data-hover-card-trigger=""')
-    expect(markup).not.toContain('data-worktree-lineage-children=""')
+    expect(markup).toContain('data-worktree-lineage-children=""')
     expect(childIndex).toBeGreaterThanOrEqual(0)
   })
 

--- a/src/renderer/src/components/sidebar/worktree-card-secondary-rows.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-secondary-rows.tsx
@@ -113,7 +113,10 @@ export function WorktreeCardSecondaryRows({
       )}
 
       {!newCardStyle && lineageChildren && (
-        <div className="-ml-[1.125rem] mt-1.5 w-[calc(100%+1.125rem)] space-y-1">
+        <div
+          className="-ml-[1.125rem] mt-1.5 w-[calc(100%+1.125rem)] space-y-1"
+          data-worktree-lineage-children=""
+        >
           {lineageChildren}
         </div>
       )}

--- a/src/renderer/src/components/sidebar/worktree-lineage-drag-drop.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-lineage-drag-drop.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment happy-dom
+
 import { describe, expect, it } from 'vitest'
 import type { WorktreeLineage } from '../../../../shared/worktree/lineage-types'
 import type { Worktree } from '../../../../shared/worktree/types'
@@ -43,6 +45,38 @@ describe('getWorktreeLineageDropTargetId', () => {
     })
 
     expect(getWorktreeLineageDropTargetId({ container, target, pointerY: 150 })).toBeNull()
+  })
+
+  it('measures a populated parent before its nested child rows', () => {
+    const container = document.createElement('div')
+    const parentRow = document.createElement('div')
+    const parentContent = document.createElement('div')
+    const parentTarget = document.createElement('span')
+    const lineageChildren = document.createElement('div')
+    const childRow = document.createElement('div')
+    const childContent = document.createElement('div')
+    const childTarget = document.createElement('span')
+    parentRow.dataset.worktreeDragId = 'parent'
+    parentContent.dataset.worktreeCardHoverTrigger = ''
+    lineageChildren.dataset.worktreeLineageChildren = ''
+    childRow.dataset.worktreeDragId = 'child'
+    childContent.dataset.worktreeCardHoverTrigger = ''
+    childContent.append(childTarget)
+    childRow.append(childContent)
+    lineageChildren.append(childRow)
+    parentContent.append(parentTarget, lineageChildren)
+    parentRow.append(parentContent)
+    container.append(parentRow)
+    parentContent.getBoundingClientRect = () => ({ top: 100, bottom: 240 }) as DOMRect
+    lineageChildren.getBoundingClientRect = () => ({ top: 160, bottom: 240 }) as DOMRect
+    childContent.getBoundingClientRect = () => ({ top: 180, bottom: 220 }) as DOMRect
+
+    expect(getWorktreeLineageDropTargetId({ container, target: parentTarget, pointerY: 130 })).toBe(
+      'parent'
+    )
+    expect(getWorktreeLineageDropTargetId({ container, target: childTarget, pointerY: 200 })).toBe(
+      'child'
+    )
   })
 })
 
@@ -174,11 +208,12 @@ function makeTarget(args: {
 } {
   const row = {
     getAttribute: (name: string) => (name === 'data-worktree-drag-id' ? args.worktreeId : null)
-  } as HTMLElement
+  } as unknown as HTMLElement
   const content = {
     getBoundingClientRect: () => ({ top: args.top, bottom: args.bottom }),
+    querySelector: () => null,
     closest: (selector: string) => (selector === '[data-worktree-drag-id]' ? row : null)
-  } as HTMLElement
+  } as unknown as HTMLElement
   const target = {
     closest: (selector: string) =>
       selector === '[data-worktree-card-hover-trigger]' ? content : null

--- a/src/renderer/src/components/sidebar/worktree-lineage-drag-drop.ts
+++ b/src/renderer/src/components/sidebar/worktree-lineage-drag-drop.ts
@@ -4,6 +4,7 @@ import { getLineageRenderInfo } from './worktree-lineage-projection'
 
 const WORKTREE_CARD_CONTENT_TARGET_SELECTOR = '[data-worktree-card-hover-trigger]'
 const WORKTREE_DRAG_ROW_SELECTOR = '[data-worktree-drag-id]'
+const WORKTREE_LINEAGE_CHILDREN_SELECTOR = '[data-worktree-lineage-children]'
 
 const LINEAGE_DROP_ZONE_RATIO = 0.4
 const LINEAGE_DROP_ZONE_MAX_HEIGHT_PX = 44
@@ -40,7 +41,7 @@ export function getWorktreeLineageDropTargetId(args: {
   if (
     !isWorktreeLineageDropZoneHit({
       pointerY: args.pointerY,
-      rect: contentTarget.getBoundingClientRect()
+      rect: getWorktreeLineageDropContentRect(contentTarget)
     })
   ) {
     return null
@@ -51,6 +52,16 @@ export function getWorktreeLineageDropTargetId(args: {
     return null
   }
   return rowTarget.getAttribute('data-worktree-drag-id')
+}
+
+function getWorktreeLineageDropContentRect(contentTarget: HTMLElement): VerticalRect {
+  const contentRect = contentTarget.getBoundingClientRect()
+  const lineageChildren = contentTarget.querySelector<HTMLElement>(
+    WORKTREE_LINEAGE_CHILDREN_SELECTOR
+  )
+  return lineageChildren
+    ? { top: contentRect.top, bottom: lineageChildren.getBoundingClientRect().top }
+    : contentRect
 }
 
 export function getReorderedWorktreeIdsToUnnest(args: {

--- a/tests/e2e/worktree-lineage-populated-parent-drag.spec.ts
+++ b/tests/e2e/worktree-lineage-populated-parent-drag.spec.ts
@@ -1,0 +1,146 @@
+import type { Page } from '@stablyai/playwright-test'
+import { expect, test } from './helpers/orca-app'
+import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import { worktreeRow } from './worktree-row-locators'
+
+type PopulatedParentScenario = {
+  parentId: string
+  originalChildId: string
+  newChildId: string
+}
+
+async function seedPopulatedParentScenario(page: Page): Promise<PopulatedParentScenario> {
+  return page.evaluate(() => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('window.__store is not available')
+    }
+    const state = store.getState()
+    const worktrees = Object.values(state.worktreesByRepo).flat()
+    const [parent, originalChild] = worktrees
+    if (!parent?.instanceId || !originalChild?.instanceId) {
+      throw new Error('Populated parent E2E needs two instance-stamped worktrees')
+    }
+    const newChildId = `${parent.repoId}::populated-parent-new-child`
+    const newChild = {
+      ...originalChild,
+      id: newChildId,
+      instanceId: 'populated-parent-new-child-instance',
+      path: `${originalChild.path}-populated-parent-new-child`,
+      branch: 'populated-parent-new-child',
+      displayName: 'E2E new lineage child',
+      isMainWorktree: false,
+      manualOrder: 1,
+      sortOrder: 1
+    }
+    const originalLineage = {
+      worktreeId: originalChild.id,
+      worktreeInstanceId: originalChild.instanceId,
+      parentWorktreeId: parent.id,
+      parentWorktreeInstanceId: parent.instanceId,
+      origin: 'manual' as const,
+      capture: { source: 'manual-action' as const, confidence: 'explicit' as const },
+      createdAt: Date.now()
+    }
+    store.setState({
+      groupBy: 'none',
+      sortBy: 'manual',
+      showActiveOnly: false,
+      showSleepingWorkspaces: true,
+      hideDefaultBranchWorkspace: false,
+      filterRepoIds: [],
+      sidebarOpen: true,
+      settings: state.settings
+        ? { ...state.settings, experimentalNewWorktreeCardStyle: false }
+        : state.settings,
+      worktreeLineageById: { [originalChild.id]: originalLineage },
+      worktreesByRepo: {
+        ...state.worktreesByRepo,
+        [parent.repoId]: [
+          { ...parent, displayName: 'E2E populated parent', manualOrder: 3, sortOrder: 3 },
+          {
+            ...originalChild,
+            displayName: 'E2E original lineage child',
+            manualOrder: 2,
+            sortOrder: 2
+          },
+          newChild
+        ]
+      },
+      assignWorktreeParent: async (worktreeId, { parentWorktreeId }) => {
+        const current = store.getState()
+        const child = Object.values(current.worktreesByRepo)
+          .flat()
+          .find((worktree) => worktree.id === worktreeId)
+        const lineageParent = Object.values(current.worktreesByRepo)
+          .flat()
+          .find((worktree) => worktree.id === parentWorktreeId)
+        if (!child?.instanceId || !lineageParent?.instanceId) {
+          throw new Error('Assigned worktree lineage is missing instance ids')
+        }
+        store.setState((latest) => ({
+          worktreeLineageById: {
+            ...latest.worktreeLineageById,
+            [worktreeId]: {
+              worktreeId,
+              worktreeInstanceId: child.instanceId!,
+              parentWorktreeId,
+              parentWorktreeInstanceId: lineageParent.instanceId!,
+              origin: 'manual',
+              capture: { source: 'manual-action', confidence: 'explicit' },
+              createdAt: Date.now()
+            }
+          }
+        }))
+      }
+    })
+    store.getState().setActiveWorktree(parent.id)
+    return { parentId: parent.id, originalChildId: originalChild.id, newChildId }
+  })
+}
+
+test('drops a separate worktree beside every existing child of a populated parent', async ({
+  orcaPage
+}) => {
+  await waitForSessionReady(orcaPage)
+  await waitForActiveWorktree(orcaPage)
+  const { parentId, originalChildId, newChildId } = await seedPopulatedParentScenario(orcaPage)
+  const parent = worktreeRow(orcaPage, parentId)
+  const originalChild = worktreeRow(orcaPage, originalChildId)
+  const newChild = worktreeRow(orcaPage, newChildId)
+  await expect(parent).toBeVisible()
+  await expect(originalChild).toBeVisible()
+  await expect(newChild).toBeVisible()
+
+  const [sourceBox, parentDropPoint] = await Promise.all([
+    newChild.boundingBox(),
+    parent.evaluate((parentElement, childId) => {
+      const content = parentElement.querySelector<HTMLElement>('[data-worktree-card-hover-trigger]')
+      const child = [...parentElement.querySelectorAll<HTMLElement>('[data-worktree-id]')].find(
+        (element) => element.dataset.worktreeId === childId
+      )
+      if (!content || !child) {
+        return null
+      }
+      const contentRect = content.getBoundingClientRect()
+      const childRect = child.getBoundingClientRect()
+      return {
+        x: contentRect.left + contentRect.width / 2,
+        y: contentRect.top + (childRect.top - contentRect.top) / 2
+      }
+    }, originalChildId)
+  ])
+  if (!sourceBox || !parentDropPoint) {
+    throw new Error('Expected visible source and populated parent rows')
+  }
+  await orcaPage.mouse.move(sourceBox.x + sourceBox.width / 2, sourceBox.y + sourceBox.height / 2)
+  await orcaPage.mouse.down()
+  await orcaPage.mouse.move(parentDropPoint.x, parentDropPoint.y, { steps: 8 })
+  await orcaPage.mouse.up()
+
+  await expect(parent.getByRole('button', { name: 'Hide 2 child workspaces' })).toBeVisible()
+  const directChildren = parent.locator('[data-worktree-lineage-children] > [data-worktree-id]')
+  await expect(directChildren).toHaveCount(2)
+  await expect(directChildren.filter({ hasText: 'E2E original lineage child' })).toBeVisible()
+  await expect(directChildren.filter({ hasText: 'E2E new lineage child' })).toBeVisible()
+})


### PR DESCRIPTION
## ELI5

Dragging a workspace onto a parent that already had children measured the whole expanded subtree as the parent card. That moved the intentional center drop zone away from the parent itself. The drop zone now stops where the rendered child list begins, so adding another child works without disturbing the existing subtree.

## What Changed

- Mark the legacy lineage-children wrapper with the same DOM boundary used by the current card layout.
- Clip lineage parent hit testing to the parent card content before nested child rows.
- Add nested DOM unit coverage that keeps parent and child center targets independent.
- Add an Electron pointer-drag regression that starts with one child, drops a separate worktree onto the populated parent, and verifies both children remain directly rendered under it.

## Why

The legacy card layout renders descendant rows inside `[data-worktree-card-hover-trigger]`. `getWorktreeLineageDropTargetId` used that element's full bounding rect, so a populated parent's 40% middle band was centered over its descendants instead of its own content. Eligibility, preview, and commit logic were already correct: the shared pointer/native resolver simply returned no parent target at the intended coordinate. Clipping the measured rect at `[data-worktree-lineage-children]` fixes the shared targeting boundary without changing cycle prevention, repo/host/project eligibility, selection semantics, reorder/unnest behavior, virtualization, or lineage writes.

## Linked Issue

No linked issue was provided for this branch.

## Visual Proof

Before: dropping on the populated parent's own center content left the separate workspace unnested because the hover rectangle included the existing child row.

After: the rendered parent shows `2 children`, and both `E2E original lineage child` and `E2E new lineage child` remain direct DOM children after the real pointer drag. This transient interaction is covered by `tests/e2e/worktree-lineage-populated-parent-drag.spec.ts`.

## Testing

- [x] Automated tests added/updated.
- `pnpm exec electron-vite build --mode e2e`
- `SKIP_BUILD=1 pnpm run test:e2e -- tests/e2e/worktree-lineage-populated-parent-drag.spec.ts --workers=1`
- `pnpm vitest run --config config/vitest.config.ts` across 15 adjacent worktree-lineage test files: 151 passed.
- Focused `WorktreeCard.compact-hover` and drag-drop unit tests: 34 passed.
- `pnpm run typecheck`
- Changed-file `oxlint --deny-warnings`
- `pnpm run lint:react-doctor:changed`
- `pnpm run check:max-lines-ratchet`
- Adjacent Electron lineage E2Es: 5 passed; `renders existing child lineage in the sidebar` has an unrelated pre-existing `worktrees:updateLineage` / `selector_not_found` failure reproducible in isolation after its DOM assertions.
- Platform exercised: macOS Electron. No path, shortcut, host routing, persistence, wire, SSH, or platform-specific behavior changed.

## Review

Please focus on the DOM boundary used for legacy/current card parity and preservation of nested child targeting.

## Agent skill upstream boundary

- [x] Not applicable; this change contains no agent skill source or installer material.

## Notes

Security, cross-platform, remote/SSH, folder-workspace, mixed-version wire, and performance impact were reviewed. The fix is renderer-local DOM geometry and adds no external input or protocol surface.

## Checklist

- [x] This PR is small and focused.
- [x] I explained what changed and why (including ELI5).
- [x] Self-reviewed for correctness, security, and performance.
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered.
- [ ] Full-repository `pnpm lint`, `pnpm test`, and release build will be covered by CI; focused local gates are listed above.
