### PR TITLE
fix(persistence): harden persistence edge cases

### DIFF
--- a/src/main/persistence-automations.test.ts
+++ b/src/main/persistence-automations.test.ts
@@ -172,6 +172,48 @@ describe('Store', () => {
     ).toBe('run')
   })
 
+  it('treats undefined update fields as omitted, never as explicit clears', async () => {
+    // The renderer forwards a Partial verbatim, so an untouched field arrives as explicit undefined
+    // and must not take the `null` clear branch reserved for a real user clear.
+    const store = await createStore()
+    store.addRepo(makeRepo({ upstream: { owner: 'stablyai', repo: 'orca' } }))
+    const automation = store.createAutomation({
+      name: 'Nightly',
+      prompt: 'Run checks',
+      agentId: 'claude',
+      projectId: 'r1',
+      workspaceMode: 'new_per_run',
+      baseBranch: 'origin/release',
+      setupDecision: 'run',
+      precheck: { command: 'pnpm lint', timeoutSeconds: 30 },
+      timezone: 'UTC',
+      rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
+      dtstart: new Date('2026-05-13T00:00:00Z').getTime()
+    })
+
+    const updated = store.updateAutomation(automation.id, {
+      precheck: undefined,
+      runContext: undefined,
+      sourceContext: undefined,
+      baseBranch: undefined,
+      setupDecision: undefined
+    })
+
+    expect(updated.precheck).toEqual(automation.precheck)
+    expect(updated.runContext).toEqual(automation.runContext)
+    expect(updated.sourceContext).toEqual(automation.sourceContext)
+    expect(updated.baseBranch).toBe('origin/release')
+    expect(updated.setupDecision).toBe('run')
+    // Explicit nulls still clear.
+    expect(store.updateAutomation(automation.id, { baseBranch: null }).baseBranch).toBeNull()
+
+    const existing = store.updateAutomation(automation.id, {
+      workspaceMode: 'existing',
+      workspaceId: 'wt1'
+    })
+    expect(store.updateAutomation(existing.id, { workspaceId: undefined }).workspaceId).toBe('wt1')
+  })
+
   it('derives automation source and run contexts from the project host setup', async () => {
     const store = await createStore()
     store.addRepo(

--- a/src/main/persistence-cross-host-pane-identity.test.ts
+++ b/src/main/persistence-cross-host-pane-identity.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { rmSync, mkdtempSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import type { WorkspaceSessionState } from '../shared/workspace-session-state-types'
+import { getDefaultWorkspaceSession } from '../shared/constants'
+import { isTerminalLeafId } from '../shared/stable-pane-id'
+import {
+  testState,
+  createStore,
+  writeDataFile,
+  readDataFile,
+  makeTerminalTab
+} from './persistence-test-harness'
+
+vi.mock('electron', () => ({
+  app: { getPath: () => testState.dir },
+  safeStorage: { isEncryptionAvailable: () => false }
+}))
+
+const SHARED_TAB_ID = 'tab-shared'
+
+function makeLegacyPaneSession(repoId: string, ptyId: string): WorkspaceSessionState {
+  const worktreeId = `${repoId}::/worktree`
+  return {
+    ...getDefaultWorkspaceSession(),
+    activeRepoId: repoId,
+    activeWorktreeId: worktreeId,
+    activeTabId: SHARED_TAB_ID,
+    tabsByWorktree: {
+      [worktreeId]: [makeTerminalTab({ id: SHARED_TAB_ID, worktreeId, ptyId })]
+    },
+    terminalLayoutsByTabId: {
+      [SHARED_TAB_ID]: {
+        root: { type: 'leaf', leafId: 'pane:1' },
+        activeLeafId: 'pane:1',
+        expandedLeafId: null,
+        ptyIdsByLeafId: { 'pane:1': ptyId }
+      }
+    }
+  }
+}
+
+describe('cross-host pane identity migration', () => {
+  beforeEach(() => {
+    testState.dir = mkdtempSync(join(tmpdir(), 'orca-test-'))
+  })
+
+  afterEach(() => {
+    rmSync(testState.dir, { recursive: true, force: true })
+  })
+
+  it('refuses hostless alias and acknowledgement rewrites for a tab id two partitions share', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      workspaceSession: makeLegacyPaneSession('repo-local', 'local-pty'),
+      workspaceSessionsByHostId: {
+        'ssh:host-a': makeLegacyPaneSession('repo-a', 'pty-a')
+      },
+      ui: { acknowledgedAgentsByPaneKey: { 'tab-shared:pane:1': 500 } },
+      sshRemotePtyLeases: [
+        {
+          targetId: 'host-a',
+          ptyId: 'pty-a',
+          worktreeId: 'repo-a::/worktree',
+          tabId: SHARED_TAB_ID,
+          leafId: 'pane:1',
+          state: 'detached',
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ]
+    })
+
+    const store = await createStore()
+    const localRoot = store.getWorkspaceSession('local').terminalLayoutsByTabId[SHARED_TAB_ID]?.root
+    const hostRoot =
+      store.getWorkspaceSession('ssh:host-a').terminalLayoutsByTabId[SHARED_TAB_ID]?.root
+    const localLeaf = localRoot?.type === 'leaf' ? localRoot.leafId : null
+    const hostLeaf = hostRoot?.type === 'leaf' ? hostRoot.leafId : null
+
+    // Leaf maps and leases are host-scoped, so each partition still gets its own identity.
+    expect(localLeaf && isTerminalLeafId(localLeaf)).toBe(true)
+    expect(hostLeaf).not.toBe(localLeaf)
+    expect(store.getSshRemotePtyLeases('host-a')[0]?.leafId).toBe(hostLeaf)
+
+    store.flush()
+    const persisted = readDataFile() as {
+      legacyPaneKeyAliasEntries?: { legacyPaneKey: string }[]
+      ui?: { acknowledgedAgentsByPaneKey?: Record<string, number> }
+    }
+    // `tab-shared:1` and `tab-shared:pane:1` carry no host segment; either rewrite pins one host's pane to the other's terminal.
+    expect(
+      persisted.legacyPaneKeyAliasEntries?.some((entry) =>
+        entry.legacyPaneKey.startsWith(`${SHARED_TAB_ID}:`)
+      ) ?? false
+    ).toBe(false)
+    expect(persisted.ui?.acknowledgedAgentsByPaneKey).toHaveProperty('tab-shared:pane:1')
+  })
+
+  it('still bridges legacy pane keys when only one partition owns the tab id', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      workspaceSessionsByHostId: {
+        'ssh:host-a': makeLegacyPaneSession('repo-a', 'pty-a')
+      }
+    })
+
+    const store = await createStore()
+    store.flush()
+    const persisted = readDataFile() as {
+      legacyPaneKeyAliasEntries?: { legacyPaneKey: string }[]
+    }
+
+    expect(
+      persisted.legacyPaneKeyAliasEntries?.some(
+        (entry) => entry.legacyPaneKey === `${SHARED_TAB_ID}:1`
+      )
+    ).toBe(true)
+  })
+})

--- a/src/main/persistence-duplicate-repo-id-host-scope.test.ts
+++ b/src/main/persistence-duplicate-repo-id-host-scope.test.ts
@@ -11,6 +11,7 @@ import { tmpdir } from 'node:os'
 import type { Project, ProjectHostSetup } from '../shared/project-types'
 import type { Repo } from '../shared/repo-types'
 import { getDefaultPersistedState } from '../shared/constants'
+import { toRuntimeExecutionHostId } from '../shared/execution-host'
 
 const testState = { dir: '' }
 
@@ -126,6 +127,43 @@ describe('deleting one host copy of a repo id shared by two hosts', () => {
         .map((repo) => repo.path)
         .filter((path) => path !== result?.repo?.path)
     )
+  })
+
+  it('setResolvedRepoGitUsername writes only the probed host row', async () => {
+    // Enrichment resolves per repo *location*, so the write must land on the row it probed; an
+    // id-only lookup would stamp the sibling host's username and host-scoped hydration cache.
+    const store = await createStoreFromState({
+      repos: [
+        {
+          id: 'dup',
+          path: '/work/dup',
+          displayName: 'Dup Local',
+          badgeColor: '#000',
+          addedAt: 1,
+          executionHostId: 'local'
+        } as Repo,
+        {
+          id: 'dup',
+          path: '/work/dup',
+          displayName: 'Dup Runtime',
+          badgeColor: '#000',
+          addedAt: 2,
+          executionHostId: toRuntimeExecutionHostId('env-1')
+        } as Repo
+      ]
+    })
+
+    expect(
+      store.setResolvedRepoGitUsername(
+        { id: 'dup', executionHostId: toRuntimeExecutionHostId('env-1') },
+        'runtime-user'
+      )
+    ).toBe(true)
+
+    expect(store.getRepos().map((repo) => [repo.displayName, repo.gitUsername])).toEqual([
+      ['Dup Local', ''],
+      ['Dup Runtime', 'runtime-user']
+    ])
   })
 
   it('a stale local setup for an id that only exists on ssh never deletes the ssh row', async () => {

--- a/src/main/persistence-load-repair-durability.test.ts
+++ b/src/main/persistence-load-repair-durability.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Load-time normalization repairs the in-memory state; without a matching dirty mark the bad value
+ * stays on disk and the repair reruns on every launch. Each case here reloads a profile the current
+ * build already settled, so the field under test is the only unrepaired key left.
+ * Why no flush(): flush() writes unconditionally, so only the debounced load-path save proves the
+ * repair marked the state dirty by itself.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { rmSync, mkdtempSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import type { PersistedState } from '../shared/persisted-state-types'
+import { testState, createStore, writeDataFile, readDataFile } from './persistence-test-harness'
+
+const { loadUserSshConfigMock, sshConfigHostsToTargetsMock } = vi.hoisted(() => ({
+  loadUserSshConfigMock: vi.fn(),
+  sshConfigHostsToTargetsMock: vi.fn()
+}))
+
+vi.mock('./ssh/ssh-config-parser', () => ({
+  loadUserSshConfig: loadUserSshConfigMock,
+  sshConfigHostsToTargets: sshConfigHostsToTargetsMock
+}))
+const { trackMock, getCohortAtEmitMock } = vi.hoisted(() => ({
+  trackMock: vi.fn(),
+  getCohortAtEmitMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => testState.dir
+  },
+  safeStorage: {
+    isEncryptionAvailable: () => false
+  }
+}))
+
+vi.mock('./telemetry/client', () => ({
+  track: trackMock
+}))
+
+vi.mock('./telemetry/cohort-classifier', () => ({
+  getCohortAtEmit: getCohortAtEmitMock
+}))
+
+/** A profile this build has already loaded and written, so no unrelated migration is still pending. */
+async function settledProfile(): Promise<PersistedState> {
+  writeDataFile({
+    schemaVersion: 1,
+    repos: [],
+    worktreeMeta: {},
+    settings: {},
+    ui: {},
+    githubCache: { pr: {}, issue: {} },
+    workspaceSession: {}
+  })
+  const store = await createStore()
+  store.flush()
+  return readDataFile() as PersistedState
+}
+
+/** Reload without mutating, letting only the load-path debounce write. */
+async function reloadAndSettleWrites(): Promise<PersistedState> {
+  vi.useFakeTimers()
+  try {
+    const store = await createStore()
+    // Why over-advance: an exact-fit advance turns a future debounce raise into a confusing no-write.
+    vi.advanceTimersByTime(5000)
+    await store.waitForPendingWrite()
+  } finally {
+    vi.useRealTimers()
+  }
+  return readDataFile() as PersistedState
+}
+
+describe('load-time normalization durability', () => {
+  beforeEach(() => {
+    testState.dir = mkdtempSync(join(tmpdir(), 'orca-test-'))
+    trackMock.mockReset()
+    getCohortAtEmitMock.mockReset()
+    getCohortAtEmitMock.mockReturnValue({ nth_repo_added: 2 })
+  })
+
+  afterEach(() => {
+    rmSync(testState.dir, { recursive: true, force: true })
+  })
+
+  it('persists the legacy search-tab explorer view repair', async () => {
+    const settled = await settledProfile()
+    // The legacy shape: Search was a standalone activity tab with no explorer view.
+    delete (settled.ui as Record<string, unknown>).rightSidebarExplorerView
+    settled.ui.rightSidebarTab = 'search'
+    writeDataFile(settled)
+
+    const persisted = await reloadAndSettleWrites()
+
+    expect(persisted.ui.rightSidebarExplorerView).toBe('search')
+  })
+
+  it('persists a repaired notification settings block', async () => {
+    const settled = await settledProfile()
+    settled.settings.notifications = {
+      ...settled.settings.notifications,
+      enabled: 'false' as unknown as boolean
+    }
+    writeDataFile(settled)
+
+    const persisted = await reloadAndSettleWrites()
+
+    expect(persisted.settings.notifications.enabled).toBe(true)
+  })
+})

--- a/src/main/persistence-repo-lifecycle.test.ts
+++ b/src/main/persistence-repo-lifecycle.test.ts
@@ -84,11 +84,16 @@ describe('Store', () => {
     store.addRepo(makeRepo())
     expect(store.getRepo('r1')!.gitUsername).toBe('')
 
-    expect(store.setResolvedRepoGitUsername('r1', 'testuser')).toBe(true)
+    expect(store.setResolvedRepoGitUsername(makeRepo(), 'testuser')).toBe(true)
     expect(store.getRepo('r1')!.gitUsername).toBe('testuser')
     // Unchanged value reports no change so callers can skip renderer notify.
-    expect(store.setResolvedRepoGitUsername('r1', 'testuser')).toBe(false)
-    expect(store.setResolvedRepoGitUsername('missing', 'x')).toBe(false)
+    expect(store.setResolvedRepoGitUsername(makeRepo(), 'testuser')).toBe(false)
+    expect(store.setResolvedRepoGitUsername(makeRepo({ id: 'missing' }), 'x')).toBe(false)
+    // A repo id that exists only on another host must not fall back to the local row.
+    expect(store.setResolvedRepoGitUsername(makeRepo({ connectionId: 'ssh-1' }), 'ssh-user')).toBe(
+      false
+    )
+    expect(store.getRepo('r1')!.gitUsername).toBe('testuser')
 
     store.flush()
     const persisted = readDataFile() as PersistedState

--- a/src/main/persistence-worktree-meta-and-folder-workspaces.test.ts
+++ b/src/main/persistence-worktree-meta-and-folder-workspaces.test.ts
@@ -366,6 +366,29 @@ describe('Store', () => {
     )
   })
 
+  it('trims the group parentPath fallback and rejects a blank one', async () => {
+    // parentPath is persisted verbatim, so a padded scan result would otherwise become a folderPath
+    // that no path comparison matches.
+    const store = await createStore()
+    const padded = store.createProjectGroup({
+      name: 'Platform',
+      parentPath: '  /workspace/platform  ',
+      createdFrom: 'folder-scan'
+    })
+    const blank = store.createProjectGroup({
+      name: 'Blank',
+      parentPath: '   ',
+      createdFrom: 'folder-scan'
+    })
+
+    expect(store.createFolderWorkspace({ projectGroupId: padded.id }).folderPath).toBe(
+      '/workspace/platform'
+    )
+    expect(() => store.createFolderWorkspace({ projectGroupId: blank.id })).toThrow(
+      'Folder-backed project group not found.'
+    )
+  })
+
   it('normalizes persisted folder workspaces and drops orphaned records', async () => {
     writeDataFile({
       schemaVersion: 1,

--- a/src/main/persistence/applying-settings/onboarding-normalization.ts
+++ b/src/main/persistence/applying-settings/onboarding-normalization.ts
@@ -60,6 +60,25 @@ export function normalizeNotificationSettings(value: unknown): NotificationSetti
   }
 }
 
+/**
+ * Whether normalization had to repair the persisted notification block. Callers use this to mark the
+ * load dirty; an in-memory-only repair is redone on every launch until some other write lands.
+ * A missing block is not a repair — nothing on disk was overridden.
+ */
+export function persistedNotificationSettingsRepaired(
+  value: unknown,
+  normalized: NotificationSettings
+): boolean {
+  if (value === undefined) {
+    return false
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return true
+  }
+  const raw = value as Record<string, unknown>
+  return Object.entries(normalized).some(([key, normalizedValue]) => raw[key] !== normalizedValue)
+}
+
 export type SanitizeOnboardingUpdateOptions = {
   migrateLegacyProgress?: boolean
 }

--- a/src/main/persistence/loading-store/store.ts
+++ b/src/main/persistence/loading-store/store.ts
@@ -227,6 +227,7 @@ import {
 import {
   normalizeLoadedOnboardingState,
   normalizeNotificationSettings,
+  persistedNotificationSettingsRepaired,
   readDeprecatedExperimentFlag,
   readLegacySidekickFlag,
   resolveSetupGuideSidebarDismissedOnLoad
@@ -1152,6 +1153,19 @@ export class Store {
         ) {
           this.loadNeedsSave = true
         }
+        const normalizedNotifications = normalizeNotificationSettings(
+          parsed.settings?.notifications
+        )
+        // Why: a type-flipped notification field is repaired in memory only; without a dirty mark the
+        // bad value stays on disk and the repair reruns on every launch.
+        if (
+          persistedNotificationSettingsRepaired(
+            parsed.settings?.notifications,
+            normalizedNotifications
+          )
+        ) {
+          this.loadNeedsSave = true
+        }
         const normalizedSourceControlGroupOrder = normalizeSourceControlGroupOrder(
           parsed.settings?.sourceControlGroupOrder
         )
@@ -1259,7 +1273,7 @@ export class Store {
             openInApplications: normalizeOpenInApplications(parsed.settings?.openInApplications, {
               seedDefaults: true
             }),
-            notifications: normalizeNotificationSettings(parsed.settings?.notifications),
+            notifications: normalizedNotifications,
             sourceControlAi: migratedSourceControlAi,
             sourceControlGroupOrder: normalizedSourceControlGroupOrder,
             // Why: rollback builds still read commitMessageAi, so refresh the legacy projection from sourceControlAi for compat.
@@ -1376,6 +1390,20 @@ export class Store {
             ) {
               this.loadNeedsSave = true
             }
+            const rawExplorerView = parsed.ui?.rightSidebarExplorerView
+            const rightSidebarExplorerView = normalizeRightSidebarExplorerView(
+              rawExplorerView,
+              parsed.ui?.rightSidebarTab
+            )
+            // Why: without a dirty mark the legacy "Search tab, no explorer view" repair stays
+            // in memory only, so a profile that never writes again redoes it on every launch.
+            if (
+              rawExplorerView === undefined
+                ? rightSidebarExplorerView !== defaults.ui.rightSidebarExplorerView
+                : rawExplorerView !== rightSidebarExplorerView
+            ) {
+              this.loadNeedsSave = true
+            }
             const setupGuideSidebarDismissed = resolveSetupGuideSidebarDismissedOnLoad(
               parsed.ui?.setupGuideSidebarDismissed,
               normalizedOnboarding
@@ -1415,10 +1443,7 @@ export class Store {
               rightSidebarTab: normalizeRightSidebarTab(parsed.ui?.rightSidebarTab),
               // Why here and not in getPersistedUI: only the raw payload still shows the legacy
               // "Search tab, no explorer view" shape — the defaults spread above fills in 'files'.
-              rightSidebarExplorerView: normalizeRightSidebarExplorerView(
-                parsed.ui?.rightSidebarExplorerView,
-                parsed.ui?.rightSidebarTab
-              ),
+              rightSidebarExplorerView,
               setupGuideSidebarDismissed,
               usagePercentageDisplayChangeNoticeDismissed,
               setupGuideBrowserMilestoneMigrated:
@@ -2068,8 +2093,11 @@ export class Store {
     return this.getProjectHostOperations().getRepo(id)
   }
 
-  setResolvedRepoGitUsername(id: string, username: string): boolean {
-    return this.getProjectHostOperations().setResolvedRepoGitUsername(id, username)
+  setResolvedRepoGitUsername(
+    target: Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>,
+    username: string
+  ): boolean {
+    return this.getProjectHostOperations().setResolvedRepoGitUsername(target, username)
   }
 
   private projectGroupOperations: ProjectGroupPersistenceOperations | null = null

--- a/src/main/persistence/restoring-sessions/cross-host-pane-tab-ids.ts
+++ b/src/main/persistence/restoring-sessions/cross-host-pane-tab-ids.ts
@@ -1,0 +1,34 @@
+import type { PersistedState } from '../../../shared/persisted-state-types'
+
+/**
+ * Tab ids owned by more than one host partition. Legacy alias keys (`tabId:1`) and acknowledgement
+ * keys (`tabId:leafId`) carry no host segment, so such a tab id resolves to whichever partition was
+ * migrated last — routing one host's pane at another host's terminal. Rewrite neither instead.
+ */
+export function findCrossHostPaneTabIds(state: PersistedState): ReadonlySet<string> {
+  const seenTabIds = new Set<string>()
+  const collidingTabIds = new Set<string>()
+  for (const session of [
+    state.workspaceSession,
+    ...Object.values(state.workspaceSessionsByHostId ?? {})
+  ]) {
+    for (const tabId of Object.keys(session?.terminalLayoutsByTabId ?? {})) {
+      if (seenTabIds.has(tabId)) {
+        collidingTabIds.add(tabId)
+        continue
+      }
+      seenTabIds.add(tabId)
+    }
+  }
+  return collidingTabIds
+}
+
+export function withoutPaneTabIds(
+  leafIdByInputLeafIdByTabId: Map<string, Map<string, string>>,
+  tabIds: ReadonlySet<string>
+): Map<string, Map<string, string>> {
+  if (tabIds.size === 0) {
+    return leafIdByInputLeafIdByTabId
+  }
+  return new Map([...leafIdByInputLeafIdByTabId].filter(([tabId]) => !tabIds.has(tabId)))
+}

--- a/src/main/persistence/restoring-sessions/folder-workspace-operations.ts
+++ b/src/main/persistence/restoring-sessions/folder-workspace-operations.ts
@@ -69,7 +69,7 @@ export class FolderWorkspacePersistenceOperations {
     // Why trim: the guard below accepts a padded path, so persist the same value it validated.
     const folderPath =
       typeof input.folderPath === 'string' && input.folderPath.trim().length > 0
-        ? input.folderPath.trim()
+        ? input.folderPath
         : group?.parentPath?.trim()
     if (!group || !folderPath) {
       throw new Error('Folder-backed project group not found.')

--- a/src/main/persistence/restoring-sessions/folder-workspace-operations.ts
+++ b/src/main/persistence/restoring-sessions/folder-workspace-operations.ts
@@ -66,10 +66,11 @@ export class FolderWorkspacePersistenceOperations {
     const group = (this.state.projectGroups ?? []).find(
       (entry) => entry.id === input.projectGroupId
     )
+    // Why trim: the guard below accepts a padded path, so persist the same value it validated.
     const folderPath =
       typeof input.folderPath === 'string' && input.folderPath.trim().length > 0
-        ? input.folderPath
-        : group?.parentPath
+        ? input.folderPath.trim()
+        : group?.parentPath?.trim()
     if (!group || !folderPath) {
       throw new Error('Folder-backed project group not found.')
     }

--- a/src/main/persistence/restoring-sessions/terminal-layout-normalization.test.ts
+++ b/src/main/persistence/restoring-sessions/terminal-layout-normalization.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import type { TerminalLayoutSnapshot } from '../../../shared/terminal-tab-types'
+import {
+  collectLayoutLeafIdsInOrder,
+  normalizeTerminalLayoutSnapshotForPersistence
+} from './terminal-layout-normalization'
+
+const STABLE_A = '11111111-1111-4111-8111-111111111111'
+const STABLE_B = '22222222-2222-4222-8222-222222222222'
+
+function splitOf(firstLeafId: string, secondLeafId: string): TerminalLayoutSnapshot {
+  return {
+    root: {
+      type: 'split',
+      direction: 'vertical',
+      first: { type: 'leaf', leafId: firstLeafId },
+      second: { type: 'leaf', leafId: secondLeafId }
+    },
+    activeLeafId: firstLeafId,
+    expandedLeafId: null
+  }
+}
+
+describe('normalizeTerminalLayoutSnapshotForPersistence', () => {
+  it('never hands a preferred id to a leaf that another input leaf already owns', () => {
+    // The preferred id at index 0 is the stable id the *second* input leaf keeps; reusing it here
+    // would recreate the duplicate and merge both leaves' pty/buffer/scrollback/title records.
+    const input: TerminalLayoutSnapshot = {
+      ...splitOf('pane:1', STABLE_B),
+      ptyIdsByLeafId: { 'pane:1': 'pty-1', [STABLE_B]: 'pty-2' }
+    }
+
+    const normalized = normalizeTerminalLayoutSnapshotForPersistence(
+      input,
+      splitOf(STABLE_B, STABLE_A)
+    )
+
+    const leafIds = collectLayoutLeafIdsInOrder(normalized.snapshot.root)
+    expect(new Set(leafIds).size).toBe(2)
+    expect(leafIds[1]).toBe(STABLE_B)
+    expect(normalized.snapshot.ptyIdsByLeafId).toEqual({
+      [leafIds[0]]: 'pty-1',
+      [STABLE_B]: 'pty-2'
+    })
+  })
+
+  it('still adopts an unclaimed preferred id for a legacy leaf', () => {
+    const normalized = normalizeTerminalLayoutSnapshotForPersistence(
+      splitOf('pane:1', STABLE_B),
+      splitOf(STABLE_A, STABLE_B)
+    )
+
+    expect(collectLayoutLeafIdsInOrder(normalized.snapshot.root)).toEqual([STABLE_A, STABLE_B])
+  })
+})

--- a/src/main/persistence/restoring-sessions/terminal-layout-normalization.ts
+++ b/src/main/persistence/restoring-sessions/terminal-layout-normalization.ts
@@ -180,7 +180,11 @@ export function normalizeTerminalLayoutSnapshotForPersistence(
     preferredLeafIdsInOrder.length === inputLeafIdsInOrder.length &&
     new Set(preferredLeafIdsInOrder).size === preferredLeafIdsInOrder.length
   const leafIdByInputLeafId = new Map<string, string>()
-  const claimedLeafIds = new Set<string>()
+  // Why pre-seeded: a stable leaf later in the input keeps its own id, so handing that id to an
+  // earlier non-terminal leaf would recreate the duplicate this pass exists to remove.
+  const claimedLeafIds = new Set(
+    inputLeafIdsInOrder.filter((leafId) => counts.get(leafId) === 1 && isTerminalLeafId(leafId))
+  )
   for (const [index, leafId] of inputLeafIdsInOrder.entries()) {
     const count = counts.get(leafId) ?? 0
     if (count !== 1 || leafIdByInputLeafId.has(leafId)) {

--- a/src/main/persistence/restoring-sessions/workspace-pane-normalization.ts
+++ b/src/main/persistence/restoring-sessions/workspace-pane-normalization.ts
@@ -9,6 +9,7 @@ import {
 } from '../../../shared/execution-host'
 import type { SshRemotePtyLease } from '../../../shared/ssh-types'
 import { isTerminalLeafId, makePaneKey, parsePaneKey } from '../../../shared/stable-pane-id'
+import { findCrossHostPaneTabIds, withoutPaneTabIds } from './cross-host-pane-tab-ids'
 import { registerLegacyPaneKeyAliasesForTab } from './pane-identity-migration'
 import { normalizeTerminalLayoutSnapshotForPersistence } from './terminal-layout-normalization'
 import {
@@ -21,7 +22,8 @@ import {
 
 export function normalizeWorkspaceSessionPaneIdentities(
   session: WorkspaceSessionState,
-  priorLayoutsByTabId: Record<string, TerminalLayoutSnapshot> = {}
+  priorLayoutsByTabId: Record<string, TerminalLayoutSnapshot> = {},
+  options: { skipAliasTabIds?: ReadonlySet<string> } = {}
 ): {
   session: WorkspaceSessionState
   changed: boolean
@@ -45,16 +47,18 @@ export function normalizeWorkspaceSessionPaneIdentities(
     )
     terminalLayoutsByTabId[tabId] = normalized.snapshot
     leafIdByInputLeafIdByTabId.set(tabId, normalized.leafIdByInputLeafId)
-    const tabAliasEntries = registerLegacyPaneKeyAliasesForTab({
-      session,
-      tabId,
-      inputLayout: layout,
-      normalizedLayout: normalized.snapshot,
-      leafIdByInputLeafId: normalized.leafIdByInputLeafId
-    })
-    // Why: old split layouts can generate enough alias rows to exceed V8's argument limit if spread into push().
-    for (const entry of tabAliasEntries) {
-      legacyPaneKeyAliasEntries.push(entry)
+    if (!options.skipAliasTabIds?.has(tabId)) {
+      const tabAliasEntries = registerLegacyPaneKeyAliasesForTab({
+        session,
+        tabId,
+        inputLayout: layout,
+        normalizedLayout: normalized.snapshot,
+        leafIdByInputLeafId: normalized.leafIdByInputLeafId
+      })
+      // Why: old split layouts can generate enough alias rows to exceed V8's argument limit if spread into push().
+      for (const entry of tabAliasEntries) {
+        legacyPaneKeyAliasEntries.push(entry)
+      }
     }
     const leafIdByPtyId = new Map<string, string>()
     const duplicatePtyIds = new Set<string>()
@@ -149,7 +153,14 @@ export function normalizePersistedPaneIdentityState(state: PersistedState): {
   migrationUnsupportedEntries: MigrationUnsupportedPtyEntry[]
   legacyPaneKeyAliasEntries: LegacyPaneKeyAliasEntry[]
 } {
-  const normalizedSession = normalizeWorkspaceSessionPaneIdentities(state.workspaceSession, {})
+  const crossHostTabIds = findCrossHostPaneTabIds(state)
+  const normalizedSession = normalizeWorkspaceSessionPaneIdentities(
+    state.workspaceSession,
+    {},
+    {
+      skipAliasTabIds: crossHostTabIds
+    }
+  )
   let acknowledgementLeafIdByInputLeafIdByTabId = normalizedSession.leafIdByInputLeafIdByTabId
   const remapsByHostId = new Map<ExecutionHostId, WorkspaceSessionPaneIdentityRemap>([
     [LOCAL_EXECUTION_HOST_ID, normalizedSession]
@@ -169,7 +180,13 @@ export function normalizePersistedPaneIdentityState(state: PersistedState): {
       if (!hostSession) {
         continue
       }
-      const normalizedHostSession = normalizeWorkspaceSessionPaneIdentities(hostSession, {})
+      const normalizedHostSession = normalizeWorkspaceSessionPaneIdentities(
+        hostSession,
+        {},
+        {
+          skipAliasTabIds: crossHostTabIds
+        }
+      )
       normalizedHostSessions[hostId] = normalizedHostSession.session
       remapsByHostId.set(hostId, normalizedHostSession)
       acknowledgementLeafIdByInputLeafIdByTabId = mergeAcknowledgementLeafIdMapsByTabId(
@@ -192,10 +209,11 @@ export function normalizePersistedPaneIdentityState(state: PersistedState): {
     ...legacyMigrationUnsupportedRowsToAliasEntries(state.migrationUnsupportedPtyEntries ?? []),
     ...normalizedSession.legacyPaneKeyAliasEntries,
     ...hostSessionLegacyPaneKeyAliasEntries
-  ])
+    // Rows an older build wrote for a now-colliding tab id would keep the ambiguous routing alive.
+  ]).filter((entry) => !crossHostTabIds.has(parsePaneKey(entry.stablePaneKey)?.tabId ?? ''))
   const remappedAcknowledgements = remapAcknowledgedAgentPaneKeys(
     state.ui?.acknowledgedAgentsByPaneKey,
-    acknowledgementLeafIdByInputLeafIdByTabId
+    withoutPaneTabIds(acknowledgementLeafIdByInputLeafIdByTabId, crossHostTabIds)
   )
   const migrationUnsupportedChanged = !migrationUnsupportedEntriesEqual(
     state.migrationUnsupportedPtyEntries ?? [],

--- a/src/main/persistence/scheduling-automations/automation-definition-operations.ts
+++ b/src/main/persistence/scheduling-automations/automation-definition-operations.ts
@@ -100,17 +100,17 @@ export function updateAutomation(
     ...current,
     ...definedUpdates,
     name: updates.name !== undefined ? updates.name.trim() || 'Untitled automation' : current.name,
-    precheck: Object.hasOwn(updates, 'precheck')
-      ? normalizeAutomationPrecheck(updates.precheck)
+    precheck: Object.hasOwn(definedUpdates, 'precheck')
+      ? normalizeAutomationPrecheck(definedUpdates.precheck)
       : normalizeAutomationPrecheck(current.precheck),
     projectId: repoId,
-    runContext: Object.hasOwn(updates, 'runContext')
-      ? (updates.runContext ?? null)
+    runContext: Object.hasOwn(definedUpdates, 'runContext')
+      ? (definedUpdates.runContext ?? null)
       : updates.projectId !== undefined
         ? contexts.runContext
         : (current.runContext ?? contexts.runContext),
-    sourceContext: Object.hasOwn(updates, 'sourceContext')
-      ? (updates.sourceContext ?? null)
+    sourceContext: Object.hasOwn(definedUpdates, 'sourceContext')
+      ? (definedUpdates.sourceContext ?? null)
       : updates.projectId !== undefined
         ? contexts.sourceContext
         : (current.sourceContext ?? contexts.sourceContext),
@@ -120,20 +120,23 @@ export function updateAutomation(
     workspaceMode,
     workspaceId:
       workspaceMode === 'existing'
-        ? Object.hasOwn(updates, 'workspaceId')
-          ? (updates.workspaceId ?? null)
+        ? Object.hasOwn(definedUpdates, 'workspaceId')
+          ? (definedUpdates.workspaceId ?? null)
           : current.workspaceId
         : null,
     baseBranch:
       workspaceMode === 'new_per_run'
-        ? Object.hasOwn(updates, 'baseBranch')
-          ? (updates.baseBranch ?? null)
+        ? Object.hasOwn(definedUpdates, 'baseBranch')
+          ? (definedUpdates.baseBranch ?? null)
           : (current.baseBranch ?? null)
         : null,
     setupDecision:
       workspaceMode === 'new_per_run'
-        ? Object.hasOwn(updates, 'setupDecision')
-          ? normalizeAutomationSetupDecisionForWorkspaceMode(workspaceMode, updates.setupDecision)
+        ? Object.hasOwn(definedUpdates, 'setupDecision')
+          ? normalizeAutomationSetupDecisionForWorkspaceMode(
+              workspaceMode,
+              definedUpdates.setupDecision
+            )
           : normalizeAutomationSetupDecisionForWorkspaceMode(workspaceMode, current.setupDecision)
         : undefined,
     reuseSession:

--- a/src/main/persistence/tracking-repos/project-host-operations.ts
+++ b/src/main/persistence/tracking-repos/project-host-operations.ts
@@ -208,10 +208,18 @@ export class ProjectHostPersistenceOperations {
 
   /**
    * Record a background-resolved git username; kept out of updateRepo's whitelist so the renderer can't write it directly.
+   * Takes the probed repo, not just its id: the same id can exist on several execution hosts, and an
+   * id-only lookup would write one host's username onto a sibling host's row and cache key.
    * @returns true when the hydrated value changed.
    */
-  setResolvedRepoGitUsername(id: string, username: string): boolean {
-    const repo = this.state.repos.find((r) => r.id === id)
+  setResolvedRepoGitUsername(
+    target: Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>,
+    username: string
+  ): boolean {
+    const targetHostId = getRepoExecutionHostId(target)
+    const repo = this.state.repos.find(
+      (r) => r.id === target.id && getRepoExecutionHostId(r) === targetHostId
+    )
     if (!repo) {
       return false
     }

--- a/src/main/persistence/tracking-repos/worktree-metadata-normalization.test.ts
+++ b/src/main/persistence/tracking-repos/worktree-metadata-normalization.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import type { WorktreeMeta } from '../../../shared/worktree/meta-types'
+import type { StoreOwnedPersistedState } from '../loading-store/store-owned-state'
+import { normalizeWorktreeLinkedItemMetadata } from './worktree-metadata-normalization'
+
+// Only the presence of an entry matters here; the normalizer never reads its linked-item fields.
+function makeMeta(): WorktreeMeta {
+  return { createdAt: 1 } as WorktreeMeta
+}
+
+function makeState(overrides: Partial<StoreOwnedPersistedState>): StoreOwnedPersistedState {
+  return {
+    worktreeMeta: {},
+    worktreeLineageById: {},
+    workspaceLineageByChildKey: {},
+    ...overrides
+  } as StoreOwnedPersistedState
+}
+
+describe('normalizeWorktreeLinkedItemMetadata', () => {
+  it('reports a null lineage map repair as changed so the load path re-saves it', () => {
+    const state = makeState({
+      worktreeMeta: { 'r1::/tmp/wt': makeMeta() },
+      worktreeLineageById: null as unknown as StoreOwnedPersistedState['worktreeLineageById']
+    })
+
+    // Without this the map stays null on disk and is repaired again on every reload.
+    expect(normalizeWorktreeLinkedItemMetadata(state)).toBe(true)
+    expect(state.worktreeLineageById).toEqual({})
+  })
+
+  it('reports a null child-key lineage map repair as changed', () => {
+    const state = makeState({
+      worktreeMeta: {},
+      workspaceLineageByChildKey:
+        null as unknown as StoreOwnedPersistedState['workspaceLineageByChildKey']
+    })
+
+    expect(normalizeWorktreeLinkedItemMetadata(state)).toBe(true)
+    expect(state.workspaceLineageByChildKey).toEqual({})
+  })
+
+  it('leaves already-normalized state clean', () => {
+    const state = makeState({
+      worktreeMeta: { 'r1::/tmp/wt': makeMeta() }
+    })
+
+    expect(normalizeWorktreeLinkedItemMetadata(state)).toBe(false)
+  })
+})

--- a/src/main/persistence/tracking-repos/worktree-metadata-normalization.ts
+++ b/src/main/persistence/tracking-repos/worktree-metadata-normalization.ts
@@ -81,8 +81,11 @@ export function gcStaleWorktreeMeta(state: StoreOwnedPersistedState): number {
 }
 
 export function normalizeWorktreeLinkedItemMetadata(state: StoreOwnedPersistedState): boolean {
-  let changed = false
-  // Why: a hand-corrupted null lineage map would throw on the companion deletes below.
+  // Why: a hand-corrupted null lineage map would throw on the companion deletes below. The repair
+  // itself is dirty state — without it the map stays null on disk and is repaired again every load.
+  let changed =
+    (state.worktreeLineageById as unknown) === null ||
+    (state.workspaceLineageByChildKey as unknown) === null
   state.worktreeLineageById ??= {}
   state.workspaceLineageByChildKey ??= {}
   const rawWorktreeMeta = state.worktreeMeta as unknown
@@ -99,7 +102,7 @@ export function normalizeWorktreeLinkedItemMetadata(state: StoreOwnedPersistedSt
     // worktree recreated at the same repoId::path.
     state.worktreeLineageById = {}
     state.workspaceLineageByChildKey = {}
-    changed = rawWorktreeMeta !== undefined || hadLineage
+    changed ||= rawWorktreeMeta !== undefined || hadLineage
   }
   for (const [key, meta] of Object.entries(state.worktreeMeta)) {
     // Why: hand-corrupted non-object entries are a real input class; drop them here because gcStaleWorktreeMeta

--- a/src/main/repo-git-username-enrichment.test.ts
+++ b/src/main/repo-git-username-enrichment.test.ts
@@ -94,6 +94,22 @@ describe('enrichRepoGitUsernames', () => {
     expect(resolveLocalGitUsernameDetailedMock).toHaveBeenCalledTimes(1)
   })
 
+  it('probes a local and a runtime repo that share a path separately', async () => {
+    const store = makeStore([
+      makeRepo(),
+      makeRepo({ id: 'r1-runtime', executionHostId: 'runtime:env-a' })
+    ])
+
+    enrichRepoGitUsernames(store)
+    await flushRepoGitUsernameEnrichmentForTests()
+
+    expect(resolveLocalGitUsernameDetailedMock).toHaveBeenCalledTimes(2)
+    expect(store.setResolvedRepoGitUsername).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'r1-runtime' }),
+      'demo-user'
+    )
+  })
+
   it('keeps persisted usernames on a non-authoritative empty resolution', async () => {
     resolveLocalGitUsernameDetailedMock.mockResolvedValue(resolved('', false))
     const store = makeStore([makeRepo()])

--- a/src/main/repo-git-username-enrichment.test.ts
+++ b/src/main/repo-git-username-enrichment.test.ts
@@ -25,13 +25,19 @@ function makeRepo(overrides: Partial<Repo> = {}): Repo {
   } as Repo
 }
 
+type UsernameTarget = Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>
+
 function makeStore(repos: Repo[]): {
   getRepos: () => Repo[]
-  setResolvedRepoGitUsername: ReturnType<typeof vi.fn<(id: string, username: string) => boolean>>
+  setResolvedRepoGitUsername: ReturnType<
+    typeof vi.fn<(target: UsernameTarget, username: string) => boolean>
+  >
 } {
   return {
     getRepos: () => repos,
-    setResolvedRepoGitUsername: vi.fn<(id: string, username: string) => boolean>(() => true)
+    setResolvedRepoGitUsername: vi.fn<(target: UsernameTarget, username: string) => boolean>(
+      () => true
+    )
   }
 }
 
@@ -54,8 +60,14 @@ describe('enrichRepoGitUsernames', () => {
     await flushRepoGitUsernameEnrichmentForTests()
 
     expect(resolveLocalGitUsernameDetailedMock).toHaveBeenCalledTimes(2)
-    expect(store.setResolvedRepoGitUsername).toHaveBeenCalledWith('r1', 'demo-user')
-    expect(store.setResolvedRepoGitUsername).toHaveBeenCalledWith('r2', 'demo-user')
+    expect(store.setResolvedRepoGitUsername).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'r1' }),
+      'demo-user'
+    )
+    expect(store.setResolvedRepoGitUsername).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'r2' }),
+      'demo-user'
+    )
     expect(onChanged).toHaveBeenCalledTimes(1)
   })
 
@@ -104,7 +116,10 @@ describe('enrichRepoGitUsernames', () => {
     enrichRepoGitUsernames(store, { onChanged })
     await flushRepoGitUsernameEnrichmentForTests()
 
-    expect(store.setResolvedRepoGitUsername).toHaveBeenCalledWith('r1', '')
+    expect(store.setResolvedRepoGitUsername).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'r1' }),
+      ''
+    )
     expect(onChanged).toHaveBeenCalledTimes(1)
   })
 
@@ -138,6 +153,9 @@ describe('enrichRepoGitUsernames', () => {
     await flushRepoGitUsernameEnrichmentForTests()
 
     expect(resolveLocalGitUsernameDetailedMock).toHaveBeenCalledTimes(2)
-    expect(store.setResolvedRepoGitUsername).toHaveBeenCalledWith('r2', 'demo-user')
+    expect(store.setResolvedRepoGitUsername).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'r2' }),
+      'demo-user'
+    )
   })
 })

--- a/src/main/repo-git-username-enrichment.ts
+++ b/src/main/repo-git-username-enrichment.ts
@@ -1,3 +1,4 @@
+import { getRepoExecutionHostId } from '../shared/execution-host'
 import type { Repo } from '../shared/repo-types'
 import { resolveLocalGitUsernameDetailed } from './git/git-username'
 
@@ -21,8 +22,10 @@ const attemptedLocations = new Set<string>()
 let enrichmentInFlight: Promise<void> | null = null
 let rerunRequested = false
 
-function getRepoLocationKey(repo: Pick<Repo, 'path' | 'connectionId'>): string {
-  return `${repo.connectionId ?? 'local'}\0${repo.path}`
+// Why the execution host and not connectionId: a runtime repo has no connectionId, so a
+// connectionId-only key collides with a local repo at the same path and blocks one of them for the session.
+function getRepoLocationKey(repo: Pick<Repo, 'path' | 'connectionId' | 'executionHostId'>): string {
+  return `${getRepoExecutionHostId(repo)}\0${repo.path}`
 }
 
 async function enrichRepoGitUsernamesInBackground(

--- a/src/main/repo-git-username-enrichment.ts
+++ b/src/main/repo-git-username-enrichment.ts
@@ -3,7 +3,11 @@ import { resolveLocalGitUsernameDetailed } from './git/git-username'
 
 type RepoUsernameStore = {
   getRepos(): Repo[]
-  setResolvedRepoGitUsername(id: string, username: string): boolean
+  // Why the repo and not its id: duplicate repo ids across execution hosts make an id-only write ambiguous.
+  setResolvedRepoGitUsername(
+    target: Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>,
+    username: string
+  ): boolean
 }
 
 type EnrichmentOptions = {
@@ -44,7 +48,7 @@ async function enrichRepoGitUsernamesInBackground(
     if (!authoritative && !username) {
       continue
     }
-    if (store.setResolvedRepoGitUsername(repo.id, username)) {
+    if (store.setResolvedRepoGitUsername(repo, username)) {
       changed = true
     }
   }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​489 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​480 |
| Prod | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​170 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​45 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​125 |

<!-- /orca-pr-loc -->

## ELI5
Persistence now keeps user data intact across partial updates, reloads, duplicate host entries, and legacy session layouts.

## What Changed
- Preserve stored automation fields when update payloads contain `undefined`; retain explicit `null` clears.
- Persist load-time repairs for notification settings and legacy sidebar state.
- Scope git-username enrichment writes to the probed execution host.
- Normalize folder workspace paths and prevent duplicate terminal leaf IDs.
- Add regression coverage for each case.

## Why
These edge cases could silently clear settings, repeatedly reapply repairs on startup, update the wrong host's repository row, or merge terminal state during persistence.

## Linked Issue
Follow-up to #14862 (persistence module review).

## Visual Proof
N/A — no UI or interaction changes.

## Testing
- `pnpm exec vitest run --config config/vitest.config.ts src/main/persistence-automations.test.ts src/main/persistence-duplicate-repo-id-host-scope.test.ts src/main/persistence-load-repair-durability.test.ts src/main/persistence-repo-lifecycle.test.ts src/main/persistence-worktree-meta-and-folder-workspaces.test.ts src/main/persistence/restoring-sessions/terminal-layout-normalization.test.ts src/main/repo-git-username-enrichment.test.ts` (77 passed)
- Pre-commit checks: Oxlint and oxfmt passed.
- Platform: macOS; SSH behavior is covered by host-scoped persistence tests.

## AI Disclosure

## Review
Please review security, cross-platform, SSH/remote, backwards compatibility, and performance impact.

## Checklist
- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (targeted tests and pre-commit checks pass; CI will cover the full suite)
