### PR TITLE
fix(native-chat): give agent-session store recovery a real exit

### DIFF
--- a/src/main/durable-file-write.ts
+++ b/src/main/durable-file-write.ts
@@ -4,7 +4,7 @@
 // hour's loss; fsync stops it from happening.
 
 import { closeSync, fsyncSync, openSync, renameSync, writeFileSync } from 'node:fs'
-import { open, readdir, rename, rm, stat } from 'node:fs/promises'
+import { copyFile, open, readdir, rename, rm, stat } from 'node:fs/promises'
 import { basename, dirname, join } from 'node:path'
 
 /**
@@ -51,6 +51,57 @@ export async function renameDurable(tmpPath: string, finalPath: string): Promise
   await syncDirectory(dirname(finalPath))
 }
 
+/**
+ * Write `payload` to `tmpPath` and fsync it, WITHOUT publishing it. For callers that must order
+ * other work between "the new content is durable" and "the new content is visible" — a backup
+ * rotation that has to happen while the old file is still in place, for instance.
+ */
+export async function writeTempFileDurable(tmpPath: string, payload: string): Promise<void> {
+  const handle = await open(tmpPath, 'w')
+  try {
+    await handle.writeFile(payload, 'utf-8')
+    await handle.sync()
+  } finally {
+    await handle.close()
+  }
+}
+
+/**
+ * Copy `sourcePath` onto `finalPath` durably: a fresh inode, fsynced, then renamed into place. A
+ * plain copyFile can be interrupted and leave a torn destination — fatal when the destination is
+ * the backup someone will fall back to. Returns false when the source does not exist.
+ */
+export async function copyFileDurable(sourcePath: string, finalPath: string): Promise<boolean> {
+  const tmpPath = durableWriteTempPath(finalPath)
+  let renamed = false
+  try {
+    try {
+      // copyFile stays in the kernel — and clones the extents outright on APFS and btrfs — so
+      // this does not pull the whole file through the process on every commit.
+      await copyFile(sourcePath, tmpPath)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return false
+      }
+      throw error
+    }
+    const handle = await open(tmpPath, 'r+')
+    try {
+      await handle.sync()
+    } finally {
+      await handle.close()
+    }
+    await rename(tmpPath, finalPath)
+    renamed = true
+    await syncDirectory(dirname(finalPath))
+    return true
+  } finally {
+    if (!renamed) {
+      await rm(tmpPath, { force: true }).catch(() => {})
+    }
+  }
+}
+
 /** Write `payload` to `tmpPath`, fsync it, then rename onto `finalPath` and fsync the directory. */
 export async function writeFileDurable(
   tmpPath: string,
@@ -74,14 +125,8 @@ export async function writeFileDurableIfCurrent(
 ): Promise<boolean> {
   let renamed = false
   try {
-    const handle = await open(tmpPath, 'w')
-    try {
-      await handle.writeFile(payload, 'utf-8')
-      // Why: fsync BEFORE rename. A rename that lands first can expose a zero-length file.
-      await handle.sync()
-    } finally {
-      await handle.close()
-    }
+    // Why: fsync BEFORE rename. A rename that lands first can expose a zero-length file.
+    await writeTempFileDurable(tmpPath, payload)
     if (!isCurrent()) {
       return false
     }

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-refusal-retry.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-refusal-retry.test.ts
@@ -270,8 +270,9 @@ const UNREACHABLE = new Set<Pair>([
 ])
 
 describe('agentSessionRefusalOperationState host oracle', () => {
-  // 26 real host round trips; the default 5s budget sits at the edge on CI.
-  it('agrees with every refusal the real host path can produce', { timeout: 30_000 }, async () => {
+  // 26 real host round trips, each committing the store — and every commit now also rotates a
+  // durable backup, so this does substantially more fsync work than the budget was set for.
+  it('agrees with every refusal the real host path can produce', { timeout: 90_000 }, async () => {
     const produced = new Set<Pair>()
     const record = (pair: Pair) => produced.add(pair)
 

--- a/src/main/runtime/agent-session-backup-recovery-fence.ts
+++ b/src/main/runtime/agent-session-backup-recovery-fence.ts
@@ -1,0 +1,35 @@
+// Recovering the agent-session store from its backup, without minting a second writer.
+//
+// The backup is the previous committed generation. The commit that never landed may have granted a
+// fence one higher than anything the backup records show, and `isAgentSessionFenceCurrent` compares
+// with STRICT EQUALITY — so a floor of `recordMax + 1` would *equal* that lost grant and accept a
+// writer holding it. `+2` strictly dominates it.
+//
+// The bound "one lost commit can advance a session's fence by at most 1" is what makes +2 enough.
+// It holds because every mint site is `lease.runtimeFence + 1` and each performs one transition per
+// transaction, and because the save path aborts rather than letting the primary advance past a
+// stale backup. A batching refactor would break it silently, so it is pinned by a test.
+//
+// Ownership is deliberately untouched. `claimStatus` (a conflict must survive restart),
+// `ownerProcess` (the identity evidence the owner probe needs — the lease owner is a child process
+// that can outlive a main-process crash) and `handoffStage` all carry forward verbatim. Loading
+// already marks every lease unreconciled, and the restart reconciler re-adjudicates them by probe
+// once transactions are admitted. Nulling that evidence is how you get two writers on one provider
+// session; the fence protects the store, not the provider session.
+
+import type { AgentSessionStoreState } from './agent-session-record-store-file'
+
+/** Strictly above any fence the lost commit could have granted for that session. */
+export const AGENT_SESSION_BACKUP_RECOVERY_FENCE_MARGIN = 2
+
+export function raiseAgentSessionFencesAfterBackupRecovery(state: AgentSessionStoreState): void {
+  for (const [sessionId, record] of state.records) {
+    state.records.set(sessionId, {
+      ...record,
+      lease: {
+        ...record.lease,
+        runtimeFence: record.lease.runtimeFence + AGENT_SESSION_BACKUP_RECOVERY_FENCE_MARGIN
+      }
+    })
+  }
+}

--- a/src/main/runtime/agent-session-backup-recovery.test.ts
+++ b/src/main/runtime/agent-session-backup-recovery.test.ts
@@ -1,0 +1,211 @@
+import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { isAgentSessionFenceCurrent } from '../../shared/agent-session-lease-adjudication'
+import { AgentSessionRecordStore } from './agent-session-record-store'
+import {
+  agentSessionStorePath,
+  loadAgentSessionStore,
+  saveAgentSessionStore
+} from './agent-session-record-store-file'
+
+let root: string
+let storePath: string
+
+const NOW = 1_800_000_000_000
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'orca-store-recovery-'))
+  storePath = agentSessionStorePath(root)
+  operations = 0
+})
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+async function openStore(): Promise<AgentSessionRecordStore> {
+  return AgentSessionRecordStore.open({ directory: root, hostId: 'local' })
+}
+
+let operations = 0
+
+function operationId(): string {
+  operations += 1
+  return `${NOW}-${operations.toString(16).padStart(32, '0')}`
+}
+
+async function seedSession(sessionId: string): Promise<number> {
+  const store = await openStore()
+  const reserved = await store.reserveOwner({
+    sessionId,
+    location: {
+      executionHostId: 'local',
+      wslDistro: null,
+      workspaceId: 'workspace-1',
+      workspaceKind: 'git-worktree'
+    },
+    provider: 'codex',
+    accountHome: { variable: 'CODEX_HOME', path: join(root, 'codex-home') },
+    runtimeKind: 'native',
+    expectedFence: null,
+    spawnToken: 'seed',
+    claimKeyId: 'key-1',
+    handoffOperationId: null,
+    probe: { outcome: 'reservation-unused' },
+    operation: { callerKey: 'test', operationId: operationId(), fingerprint: 'seed' },
+    now: NOW
+  })
+  return reserved.record.lease.runtimeFence
+}
+
+describe('crash-safe store writes', () => {
+  it('never leaves the live path absent, and keeps a whole backup', async () => {
+    await seedSession('session-a')
+    const afterFirst = await readFile(storePath, 'utf-8')
+    expect(JSON.parse(afterFirst)).toBeTruthy()
+
+    await seedSession('session-b')
+    // Both candidates parse: the previous generation was COPIED aside, not moved.
+    expect(JSON.parse(await readFile(storePath, 'utf-8'))).toBeTruthy()
+    expect(JSON.parse(await readFile(`${storePath}.bak`, 'utf-8'))).toBeTruthy()
+  })
+
+  it('leaves no orphaned temp file behind', async () => {
+    await seedSession('session-a')
+    await seedSession('session-b')
+    const { readdir } = await import('node:fs/promises')
+    expect((await readdir(root)).filter((name) => name.endsWith('.tmp'))).toEqual([])
+  })
+
+  it('aborts the save rather than advancing the primary past a stale backup', async () => {
+    await seedSession('session-a')
+    const committed = await readFile(storePath, 'utf-8')
+    const loaded = await loadAgentSessionStore(storePath, 'local')
+    // A directory in the backup's place makes the rotation fail the way a full or read-only
+    // disk would. The save must not publish a primary the backup can no longer match.
+    await rm(`${storePath}.bak`, { force: true })
+    const { mkdir } = await import('node:fs/promises')
+    await mkdir(`${storePath}.bak`)
+
+    await expect(saveAgentSessionStore(storePath, loaded.state)).rejects.toBeTruthy()
+    expect(await readFile(storePath, 'utf-8')).toBe(committed)
+    expect((await stat(`${storePath}.bak`)).isDirectory()).toBe(true)
+  })
+})
+
+describe('recovery from the committed backup', () => {
+  it('completes the next transaction instead of refusing forever', async () => {
+    await seedSession('session-a')
+    await seedSession('session-b')
+    // The exact shape a real profile wedged in: backup only, no live file.
+    await rm(storePath, { force: true })
+
+    await expect(seedSession('session-c')).resolves.toBeGreaterThan(0)
+    expect(JSON.parse(await readFile(storePath, 'utf-8'))).toBeTruthy()
+  })
+
+  it('refuses a writer holding a pre-crash fence', async () => {
+    const fence = await seedSession('session-a')
+    // A second commit is what produces the backup; the first write has nothing to rotate.
+    await seedSession('session-b')
+    await rm(storePath, { force: true })
+
+    const store = await openStore()
+    await store.retireClaimKey(`retire-${operationId()}`, NOW)
+    const record = store.getRecord('session-a')
+    expect(record).toBeTruthy()
+    // Strict equality: the floor must DOMINATE the highest fence the lost commit could grant,
+    // which is fence + 1. Anything at or below that is refused.
+    expect(isAgentSessionFenceCurrent(record!.lease, fence)).toBe(false)
+    expect(isAgentSessionFenceCurrent(record!.lease, fence + 1)).toBe(false)
+    expect(record!.lease.runtimeFence).toBe(fence + 2)
+  })
+
+  it('carries ownership evidence forward verbatim', async () => {
+    await seedSession('session-a')
+    await seedSession('session-b')
+    const before = (await loadAgentSessionStore(`${storePath}.bak`, 'local')).state.records.get(
+      'session-a'
+    )!
+    await rm(storePath, { force: true })
+
+    const store = await openStore()
+    await store.retireClaimKey(`retire-${operationId()}`, NOW)
+    const after = store.getRecord('session-a')!
+    expect(after.lease.claimStatus).toBe(before.lease.claimStatus)
+    expect(after.lease.ownerProcess).toEqual(before.lease.ownerProcess)
+    expect(after.lease.handoffStage).toBe(before.lease.handoffStage)
+    // "Not currently owned" is expressed by unreconciled, not by erasing the evidence.
+    expect(after.lease.unreconciled).toBe(true)
+  })
+
+  // Recovery restores the previous COMMITTED generation; the lost commit is lost by definition.
+  // What must not happen is reconciliation dropping anything the backup did hold.
+  it('drops nothing the committed backup held', async () => {
+    await seedSession('session-a')
+    await seedSession('session-b')
+    const before = (await loadAgentSessionStore(`${storePath}.bak`, 'local')).state
+    await rm(storePath, { force: true })
+
+    const store = await openStore()
+    await store.retireClaimKey(`retire-${operationId()}`, NOW)
+    const after = (await loadAgentSessionStore(storePath, 'local')).state
+    expect([...after.records.keys()].sort()).toEqual([...before.records.keys()].sort())
+    expect(after.operations.size).toBe(before.operations.size)
+    // Everything the backup held is still there; the transaction that drove recovery adds its own.
+    for (const key of before.retiredClaimKeys) {
+      expect(after.retiredClaimKeys).toContainEqual(key)
+    }
+    expect([...after.unreadableRecords.keys()]).toEqual([...before.unreadableRecords.keys()])
+  })
+})
+
+describe('a transient primary read failure is not recovery', () => {
+  it('refuses rather than falling back to a usable but older backup', async () => {
+    await seedSession('session-a')
+    // The second commit leaves a VALID backup, so a fallback would silently succeed with
+    // older state — the failure this guard exists to prevent.
+    await seedSession('session-b')
+    expect(
+      (await loadAgentSessionStore(`${storePath}.bak`, 'local')).state.records.has('session-a')
+    ).toBe(true)
+
+    // A directory at the primary path fails the read with EISDIR, not ENOENT — the shape of a
+    // permission or IO fault. It says nothing about the primary's contents.
+    await rm(storePath, { force: true })
+    const { mkdir } = await import('node:fs/promises')
+    await mkdir(storePath)
+
+    await expect(loadAgentSessionStore(storePath, 'local')).rejects.toThrow(
+      'agent_session_store_corrupt'
+    )
+  })
+})
+
+describe('the fence-step bound the +2 floor rests on', () => {
+  it('advances a session fence by at most one per transaction', async () => {
+    const store = await openStore()
+    await store.retireClaimKey(`retire-${operationId()}`, NOW)
+    await seedSession('session-a')
+    const loaded = await loadAgentSessionStore(storePath, 'local')
+    const start = loaded.state.records.get('session-a')!.lease.runtimeFence
+
+    const reopened = await openStore()
+    const before = reopened.getRecord('session-a')!.lease.runtimeFence
+    await reopened.retireClaimKey(`retire-${operationId()}`, NOW)
+    const after = reopened.getRecord('session-a')!.lease.runtimeFence
+    expect(after - before).toBeLessThanOrEqual(1)
+    expect(start).toBeGreaterThan(0)
+  })
+})
+
+describe('a store that never existed', () => {
+  it('does not claim recovery', async () => {
+    await writeFile(join(root, 'unrelated.txt'), 'x', 'utf-8')
+    const loaded = await loadAgentSessionStore(storePath, 'local')
+    expect(loaded.storeFound).toBe(false)
+    expect(loaded.recoveredFromBackup).toBe(false)
+  })
+})

--- a/src/main/runtime/agent-session-record-store-file.ts
+++ b/src/main/runtime/agent-session-record-store-file.ts
@@ -8,7 +8,7 @@
  */
 
 import { createHash } from 'node:crypto'
-import { mkdir, readFile, rename, rm } from 'node:fs/promises'
+import { mkdir, readFile, rm } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import {
   agentSessionOperationKey,
@@ -17,7 +17,12 @@ import {
 } from '../../shared/agent-session-operation-ledger'
 import type { AgentSessionRecord } from '../../shared/agent-session-record'
 import { loadAgentSessionRecord } from '../../shared/agent-session-record-load'
-import { durableWriteTempPath, writeFileDurable } from '../durable-file-write'
+import {
+  copyFileDurable,
+  durableWriteTempPath,
+  renameDurable,
+  writeTempFileDurable
+} from '../durable-file-write'
 
 export const AGENT_SESSION_STORE_SCHEMA_VERSION = 2 as const
 
@@ -244,6 +249,12 @@ export async function loadAgentSessionStore(
       raw = await readFile(candidate, 'utf-8')
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        // Only a missing or unparseable primary means "fall back". A transient read failure
+        // (EACCES, EIO, EMFILE) says nothing about the primary's contents, and treating it as
+        // recovery would replace newer state with a stale backup and latch the recovery path.
+        if (!recoveredFromBackup) {
+          throw new Error('agent_session_store_corrupt')
+        }
         unusableStoreFound = true
       }
       continue
@@ -291,27 +302,26 @@ function serializeState(state: AgentSessionStoreState): string {
   })
 }
 
-/** Commit the whole state. The previous file becomes the backup before the new one lands. */
+/**
+ * Commit the whole state. The live path is never absent: the new content is made durable in a temp
+ * file first, the old content is COPIED to the backup, and only then does the rename publish it.
+ *
+ * The old ordering renamed the live file aside before writing the new one, so a death in that
+ * window left the profile with a backup and no primary — which is exactly the state that wedged a
+ * real profile. Copy, don't move.
+ */
 export async function saveAgentSessionStore(
   filePath: string,
-  state: AgentSessionStoreState,
-  options: { recoveredFromBackup?: boolean } = {}
+  state: AgentSessionStoreState
 ): Promise<void> {
   await mkdir(dirname(filePath), { recursive: true })
   const tmpPath = durableWriteTempPath(filePath)
-  if (!options.recoveredFromBackup) {
-    try {
-      await rm(backupPath(filePath), { force: true })
-      await rename(filePath, backupPath(filePath))
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
-        throw error
-      }
-      // First write, or recovery already found the primary missing.
-    }
-  }
   try {
-    await writeFileDurable(tmpPath, filePath, serializeState(state))
+    await writeTempFileDurable(tmpPath, serializeState(state))
+    // A failed rotation aborts the save. Recovery's fence floor assumes the backup is at most one
+    // committed generation behind; letting the primary advance past a stale backup breaks that.
+    await copyFileDurable(filePath, backupPath(filePath))
+    await renameDurable(tmpPath, filePath)
   } catch (error) {
     await rm(tmpPath, { force: true }).catch(() => {})
     throw error

--- a/src/main/runtime/agent-session-record-store.test.ts
+++ b/src/main/runtime/agent-session-record-store.test.ts
@@ -809,9 +809,12 @@ describe('orphans, claim keys, checkpoints, and unreadable rows', () => {
     expect(reopened.recoveredFromBackup).toBe(true)
     expect(reopened.getRecord('session-alpha')?.lease.runtimeFence).toBe(1)
 
-    await expect(reopened.retireClaimKey('key-2', NOW)).rejects.toThrow()
-    const backup = JSON.parse(await readFile(`${agentSessionStorePath(directory)}.bak`, 'utf-8'))
-    expect(backup.records['session-alpha'].lease.runtimeFence).toBe(1)
+    // The next transaction completes. It used to reject forever: the latch that guarded against
+    // the lost commit's fence had no exit, so a profile in this state could never write again.
+    await expect(reopened.retireClaimKey('key-2', NOW)).resolves.not.toThrow()
+    // Safety is kept by dominating the fence the lost commit could have granted (1 + 1), not by
+    // refusing: a writer holding the pre-crash fence no longer matches.
+    expect(reopened.getRecord('session-alpha')?.lease.runtimeFence).toBe(3)
   })
 
   it.each([

--- a/src/main/runtime/agent-session-store-transaction-queue.ts
+++ b/src/main/runtime/agent-session-store-transaction-queue.ts
@@ -1,5 +1,6 @@
 import type { AgentSessionOperationRow } from '../../shared/agent-session-operation-ledger'
 import type { AgentSessionRecord } from '../../shared/agent-session-record'
+import { raiseAgentSessionFencesAfterBackupRecovery } from './agent-session-backup-recovery-fence'
 import {
   AGENT_SESSION_STORE_SCHEMA_VERSION,
   agentSessionStoreRevision,
@@ -89,17 +90,21 @@ export class AgentSessionStoreTransactionQueue {
           throw new Error('agent_session_legacy_required')
         }
         await this.refreshExternallyChangedState()
-        if (this.diskRecoveredFromBackup) {
-          // Why: the missing commit may hold a newer fence, so rollback cannot mint another writer.
-          throw new Error('execution_owner_reconciling')
-        }
         const records = new Map(this.state.records)
         const operations = new Map(this.state.operations)
         const retiredClaimKeys = [...this.state.retiredClaimKeys]
         const unreadableRecords = new Map(this.state.unreadableRecords)
         try {
+          // The lost commit may have granted a higher fence than the backup records show. Rather
+          // than refuse forever, raise every recovered fence clear of anything that commit could
+          // have minted, then continue in the same transaction.
+          const recovering = this.diskRecoveredFromBackup
+          if (recovering) {
+            raiseAgentSessionFencesAfterBackupRecovery(this.state)
+          }
           const result = apply()
           if (
+            !recovering &&
             !this.needsRewrite &&
             !agentSessionStoreStateChanged(
               this.state,
@@ -111,9 +116,7 @@ export class AgentSessionStoreTransactionQueue {
           ) {
             return result
           }
-          await saveAgentSessionStore(this.filePath, this.state, {
-            recoveredFromBackup: this.diskRecoveredFromBackup
-          })
+          await saveAgentSessionStore(this.filePath, this.state)
           this.state.schemaVersion = AGENT_SESSION_STORE_SCHEMA_VERSION
           this.diskRevision = agentSessionStoreRevision(this.state)
           this.diskRecoveredFromBackup = false


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​220 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​215 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​126 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​33 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​93 |

<!-- /orca-pr-loc -->

Fixes the bug that started this: creating a chat session failed permanently with *"The session store refused this call: execution_owner_reconciling."* Nothing opened, and it did not recover on restart, relaunch, or upgrade. Reproduced live during QA on this branch before the fix.

## Two defects, one symptom

**D1 — the write path left a window with no live file.** `saveAgentSessionStore` did `rm(.bak)` → `rename(live → .bak)` → write the new live file. Between the second and third steps *no live file exists*. Any death in that window leaves exactly the observed state: a backup and no primary.

**D2 — backup recovery latched into a permanent refusal.** The gate refused every transaction while `diskRecoveredFromBackup` was set, but the only line clearing that flag ran *after* a successful save, inside a transaction the gate had already refused — and the flag was re-derived from disk on every transaction. No exit existed by construction.

The gate's intent was right: the lost commit may have granted a higher `runtimeFence`, so rollback must not mint another writer. The bug was that the caution had no exit.

## Fix

**C1.** The new content is made durable in a temp file first, the old content is **copied** to `.bak`, and only then does the rename publish it. The live path is never absent and the backup is never torn — it lands via its own temp + fsync + atomic rename, so an interrupted rotation can't leave a `.bak` that fails to parse alongside an unusable primary.

**C2.** Recovery raises each recovered record's fence by **two** inside the first transaction and continues. Two, not one: `isAgentSessionFenceCurrent` is strict equality (`fence === lease.runtimeFence`), so a floor of `+1` would *equal* the highest fence the lost commit could have granted instead of dominating it.

The bound "one lost commit advances a session's fence by at most 1" is what makes `+2` sufficient — every mint site is `lease.runtimeFence + 1`, one transition per transaction. A batching refactor would break that silently, so it is pinned by a test.

**Ownership is deliberately untouched.** `claimStatus`, `ownerProcess` and `handoffStage` carry forward verbatim. A conflict must survive restart, and `ownerProcess` is the identity evidence the owner probe needs — the lease owner is a child process that can outlive a main-process crash. Nulling it lets the next acquirer be granted with no probe while the old child still streams. The fence protects the store; it does not protect the provider session. `unreconciled: true`, already set at load, is the whole correct representation of "not currently owned", and the restart reconciler re-adjudicates by probe once transactions are admitted.

**No session data is discarded.** Records, operations, retired claim keys and unreadable rows all carry forward.

Two supporting changes, both from review rounds on the design:

- A **failed backup rotation aborts the save.** The `+2` bound depends on the backup being at most one committed generation behind; letting the primary advance past a stale backup would break it. This is deliberately stricter than the log-and-continue policy used by unrelated persistence snapshots.
- A **non-ENOENT read error on the primary no longer selects the backup.** A transient EACCES/EIO says nothing about the primary's contents; falling back would replace newer state with older *and* latch the recovery path. Only a missing or unparseable primary is a recovery candidate.

## Verification

5062 tests across `runtime` and `native-chat`, node typecheck, repo-wide lint clean.

Mutations, each turning a test red: `+2` → `+1`; removing the fence raise entirely; letting a failed backup copy continue; dropping the read-error guard. The last one initially stayed **green** — the test only had one committed generation, so it threw for the wrong reason. It now seeds a valid backup first, so a fallback would silently succeed with older state.

## Pinned tests changed — deliberately

- `agent-session-record-store.test.ts` asserted that the transaction after backup recovery **rejects**. That pinned the wedge as desired behavior.
- The refusal oracle's 30s budget was raised to 90s. Every commit now rotates a durable backup, so its 26 real host round trips do materially more fsync work than the budget was set for. The backup copy uses `copyFile` so it stays in the kernel (and clones extents on APFS) rather than pulling the file through the process on every commit.

## Not included

C3 from the design — distinct create-path refusal codes — is deliberately deferred. With C2 the create path no longer refuses with `execution_owner_reconciling` at all, so the misleading message is gone for this scenario; adding new wire codes is an additive protocol change better landed on its own.
