### PR TITLE
fix(native-chat): show what a failed provider dependency actually said

### DIFF
--- a/src/main/native-chat/agent-session-wire/unhandled-provider-frame.test.ts
+++ b/src/main/native-chat/agent-session-wire/unhandled-provider-frame.test.ts
@@ -222,3 +222,32 @@ describe('unhandled provider frame journal fallback', () => {
     ).toBe('codex \u00b7 notification:future/event')
   })
 })
+
+describe('a failed provider dependency', () => {
+  it('leads with the failure the provider reported, not the method name', () => {
+    const item = unhandledProviderFrameJournalItem(
+      'codex',
+      'notification:mcpServer/startupStatus/updated',
+      {
+        threadId: 'thread-1',
+        name: 'codex_apps',
+        status: 'failed',
+        error: 'MCP client for `codex_apps` failed to start: authentication token invalidated',
+        failureReason: 'reauthenticationRequired'
+      }
+    )
+    expect(item?.classification).toBe('error-surface')
+    expect(item?.body.text).toContain('failed to start')
+    expect(item?.body.text).not.toContain('notification:mcpServer')
+  })
+
+  it('stays out of the timeline while the dependency is merely starting', () => {
+    expect(
+      unhandledProviderFrameJournalItem('codex', 'notification:mcpServer/startupStatus/updated', {
+        threadId: 'thread-1',
+        name: 'codex_apps',
+        status: 'starting'
+      })
+    ).toBeNull()
+  })
+})

--- a/src/main/native-chat/agent-session-wire/unhandled-provider-frame.ts
+++ b/src/main/native-chat/agent-session-wire/unhandled-provider-frame.ts
@@ -25,7 +25,18 @@ function serializeProviderPayload(payload: unknown): string {
 
 /** Fields providers use for the human-facing sentence on a frame, most specific
  *  first. Nested one level because warnings arrive wrapped as often as not. */
-const MESSAGE_KEYS = ['message', 'text', 'warning', 'detail', 'description', 'reason'] as const
+const MESSAGE_KEYS = [
+  'message',
+  'text',
+  'warning',
+  'detail',
+  'description',
+  'reason',
+  // `error` is how a failed dependency reports itself — an MCP server that could not start says
+  // so here and nowhere else. Without it the row falls back to the bare method name, which is how
+  // "MCP server X failed to start: auth expired" reached users as `notification:mcpServer/...`.
+  'error'
+] as const
 
 function directReadableMessage(payload: unknown): string | null {
   if (typeof payload === 'string') {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​29 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​29 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​11 |

<!-- /orca-pr-loc -->

## What this was

A row reading `codex · notification:mcpServer/startupStatus/updated` appeared in a live chat during QA. It looks like protocol noise. It is not — it is a **real MCP server startup failure**, and the payload said so:

```
name: codex_apps
status: failed
error: MCP client for `codex_apps` failed to start: … HTTP 401:
       "Your authentication token has been invalidated. Please try signing in again"
failureReason: reauthenticationRequired
```

## Who sees it

Anyone whose Codex has MCP servers configured, whenever one fails to start. `mcpServer/startupStatus/updated` is a first-class notification in the app-server protocol and fires on thread start, and a default desktop Codex install ships MCP servers — so an expired sign-in surfaces this for ordinary users, not just this profile.

## The defect

The classification was already correct: the frame carries an error, so it is surfaced rather than suppressed, and a merely `starting`/`ready` server stays chrome. The gap is the row **text**.

`readableMessage` looks at `message`, `text`, `warning`, `detail`, `description`, `reason` — but not `error`, which is the only field a failed dependency reports itself in. So it fell through to `${provider} · ${kind}`, turning an actionable message into a method name.

## Fix

Add `error` to the message keys. The row now leads with the provider's own sentence, and the raw frame stays behind the disclosure as before.

## Verification

1728 tests across `native-chat` and `codex`. Two new cases: a failed server renders the failure text and not the method name; a starting server still renders nothing. Mutation: removing `error` from the key list turns the first red.