### PR TITLE
fix(sidebar): explain a same-path delete refusal in the user's terms

### DIFF
--- a/src/renderer/src/components/sidebar/delete-worktree-failure-toast.tsx
+++ b/src/renderer/src/components/sidebar/delete-worktree-failure-toast.tsx
@@ -3,6 +3,7 @@ import { Button } from '../ui/button'
 import { getDeleteWorktreeToastCopy } from './delete-worktree-toast'
 import { translate } from '@/i18n/i18n'
 import {
+  isAmbiguousHostRemovalError,
   isLockedWorktreeRemovalError,
   type WorktreeForceDeleteReason
 } from '../../../../shared/worktree/removal'
@@ -96,7 +97,13 @@ export function showDeleteWorktreeFailureToast({
       <DeleteWorktreeFailureToastBody
         description={toastCopy.description}
         canForceDelete={canForceDelete}
-        showViewChanges={!isLockedWorktreeRemovalError(error) || hasKnownChanges === true}
+        // Why: View opens the workspace diff by id, and an id that two hosts share cannot
+        // pick one — the button would either do nothing useful or open the other machine's
+        // changes. Hide it for the collision refusal.
+        showViewChanges={
+          !isAmbiguousHostRemovalError(error) &&
+          (!isLockedWorktreeRemovalError(error) || hasKnownChanges === true)
+        }
         onViewChanges={onViewChanges}
         onForceDelete={onForceDelete}
         toastId={id}

--- a/src/renderer/src/components/sidebar/delete-worktree-toast.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-toast.ts
@@ -1,5 +1,6 @@
 import { translate } from '@/i18n/i18n'
 import {
+  isAmbiguousHostRemovalError,
   isLockedWorktreeRemovalError,
   isProvenLivePtyRemovalError,
   type WorktreeForceDeleteReason
@@ -16,6 +17,24 @@ export function getDeleteWorktreeToastCopy(
   error: string,
   lockReason: string | null = null
 ): DeleteWorktreeToastCopy {
+  // Why: the raw refusal names execution-host routing, which is Orca's problem, not the
+  // user's. Say what it means for their workspace and that nothing was lost; there is no
+  // action they can take, so offer none rather than a remedy that does not work.
+  if (isAmbiguousHostRemovalError(error)) {
+    return {
+      title: translate(
+        'auto.components.sidebar.delete.worktree.toast.1d0fa5c0a5',
+        'Failed to delete workspace {{value0}}',
+        { value0: worktreeName }
+      ),
+      description: translate(
+        'auto.components.sidebar.delete.worktree.toast.ambiguousHost',
+        "This workspace exists on more than one machine at the same path, so Orca can't tell which one to remove. Nothing was deleted. We're improving this — for now, delete it directly on the machine you want it gone from."
+      ),
+      isDestructive: false
+    }
+  }
+
   if (isLockedWorktreeRemovalError(error)) {
     return {
       title: translate(

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5464,7 +5464,8 @@
               "locked": "This workspace is locked by Git. Run git worktree unlock <worktree-path> from its repository, then retry deletion.",
               "lockedReason": "This workspace is locked by Git. Git reported: {{value0}}. Run git worktree unlock <worktree-path> from its repository, then retry deletion.",
               "unstoppedPty": "Orca could not confirm every terminal in this workspace has exited, so it stopped before deleting any files. Use Force Delete to remove it anyway.",
-              "unstoppedPtyLive": "This workspace still has running terminals, so Orca stopped before deleting any files. Force Delete will kill them and discard any uncommitted work they hold."
+              "unstoppedPtyLive": "This workspace still has running terminals, so Orca stopped before deleting any files. Force Delete will kill them and discard any uncommitted work they hold.",
+              "ambiguousHost": "This workspace exists on more than one machine at the same path, so Orca can't tell which one to remove. Nothing was deleted. We're improving this — for now, delete it directly on the machine you want it gone from."
             }
           }
         },

--- a/src/shared/worktree/removal.ts
+++ b/src/shared/worktree/removal.ts
@@ -45,6 +45,20 @@ export function isProvenLivePtyRemovalError(error: string): boolean {
   )
 }
 
+/**
+ * True when the removal was refused because the same workspace path exists on
+ * more than one execution host, so routing cannot say which one the row is.
+ *
+ * Matched on the message because the refusal is raised as a plain Error from
+ * the store slice; keep this in step with WORKTREE_REMOVAL_AMBIGUOUS_ERROR.
+ */
+export function isAmbiguousHostRemovalError(error: string): boolean {
+  return error.includes(AMBIGUOUS_HOST_REMOVAL_MARKER)
+}
+
+/** The stable fragment of WORKTREE_REMOVAL_AMBIGUOUS_ERROR that identifies the refusal. */
+export const AMBIGUOUS_HOST_REMOVAL_MARKER = 'ambiguous across hosts'
+
 export function createLockedWorktreeRemovalError(lockReason?: string): Error {
   const reason = lockReason?.trim()
   return new Error(


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​43 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​41 |

<!-- /orca-pr-loc -->

Fixes the wording a user sees when Orca refuses to delete a workspace that exists at the same path on two machines.

### Before

> **Failed to delete workspace feature-auth**
> Workspace identity is ambiguous across hosts. Refresh projects and try again.  `[View]`

Three problems:

1. **"Workspace identity is ambiguous across hosts"** is implementation vocabulary — execution-host routing is Orca's problem, not the user's.
2. **"Refresh projects and try again" does not work.** Refreshing cannot disambiguate two real checkouts at the same path, so the copy sends the user around a loop that always ends here.
3. **`View`** opens the workspace diff *by id* — and an id both machines share cannot pick one, so the button either does nothing useful or opens the other machine's changes.

### After

![final2.png](https://github.com/user-attachments/assets/fdb9709b-b6b5-466e-82ee-c3f70b85f176)

> **Failed to delete workspace feature-auth**
> This workspace exists on more than one machine at the same path, so Orca can't tell which one to remove. Nothing was deleted. We're improving this — for now, delete it directly on the machine you want it gone from.

`View` is hidden for this case. The toast is now `isDestructive: false`, so it renders as info rather than a destructive error — nothing was lost.

### The remedy is verified, not assumed

Removing the checkout on the machine clears the collision on Orca's next scan, leaving no orphaned row and needing no Force Delete. I tested that before putting it in shipped copy.

### Scope

Copy and the `View` gate only — no routing behaviour changes. The refusal itself is pre-existing on `main`; routing a colliding delete to the confirmed host is #15013.

**Known, not addressed here:** after a refusal the row stays greyed out reading "Deleting…" indefinitely (`isDeleting` is never cleared). That reproduces on `main` today, and since the toast auto-dismisses after 10s, the stuck row is what the user is ultimately left with. Worth its own fix.

### Verification

typecheck 0 · changed-code quality 0 findings · localization coverage passed · sidebar suite 250 files / 2,193 tests green · copy confirmed in a live dev instance (screenshot above).
