### PR TITLE
test(folder-workspaces): await routed update admission

### DIFF
--- a/src/renderer/src/store/slices/folder-workspace-owner-routed-mutations.test.ts
+++ b/src/renderer/src/store/slices/folder-workspace-owner-routed-mutations.test.ts
@@ -270,6 +270,7 @@ describe('folder workspace owner-routed mutations', () => {
         { isUnread: true },
         { executionHostId: 'runtime:env-owner' }
       )
+    await vi.waitFor(() => expect(runtimeEnvironmentCall).toHaveBeenCalledTimes(1))
     await store.getState().fetchFolderWorkspaces({ runtimeEnvironmentId: null })
     resolveRuntimeUpdate({
       id: 'rpc-update-folder',


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

Makes the folder-workspace owner-routing regression test deterministic by waiting for the pending runtime RPC to be admitted before starting the concurrent local catalog refresh.

The previous ordering raced the compatibility probe under Node 24/26 shard execution, leaving the resolver unset and failing with `resolveRuntimeUpdate is not a function`. This is test-only and unrelated to STA-4525.