### PR TITLE
fix(native-chat): keep the working dots up while a command runs

### DIFF
--- a/src/renderer/src/components/native-chat/native-chat-typing-indicator.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-typing-indicator.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import { NATIVE_CHAT_STREAMING_ID } from '../../../../shared/native-chat-streaming'
 import type { NativeChatMessage } from '../../../../shared/native-chat-types'
+import type { AgentJournalRenderItem } from '../../../../shared/agent-session-journal-types'
+import { projectStructuredItemsToNativeChat } from '../../../../shared/structured-agent-session-projection'
 import { shouldShowNativeChatTypingIndicator } from './native-chat-typing-indicator'
 
 function message(id: string, role: NativeChatMessage['role'], text = id): NativeChatMessage {
@@ -80,5 +82,57 @@ describe('shouldShowNativeChatTypingIndicator', () => {
 
   it('shows on a session whose transcript is still empty', () => {
     expect(shouldShowNativeChatTypingIndicator({ messages: [], isWorking: true })).toBe(true)
+  })
+})
+
+// These build rows through the REAL structured projection instead of hand-made
+// `command:` marker ids. The hand-made ids only exist on the PTY transport, so
+// tests using them were blind to how the shipping transport actually looks.
+describe('with rows projected from the structured journal', () => {
+  function toolCallItem(sequence: number): AgentJournalRenderItem {
+    return {
+      itemId: `codex:thread-1:turn-1:${sequence}`,
+      revision: 1,
+      sequence,
+      observedAt: 1_800_000_000_000,
+      body: {
+        kind: 'tool-call',
+        name: 'shell',
+        state: 'running',
+        input: { command: 'sed -n 1,240p README.md' }
+      }
+    } as AgentJournalRenderItem
+  }
+
+  function assistantTextItem(sequence: number): AgentJournalRenderItem {
+    return {
+      itemId: `codex:thread-1:turn-1:${sequence}`,
+      revision: 1,
+      sequence,
+      observedAt: 1_800_000_000_000,
+      body: {
+        kind: 'message',
+        role: 'assistant',
+        blocks: [{ type: 'text', text: "I'm checking PR 14696's metadata." }]
+      }
+    } as AgentJournalRenderItem
+  }
+
+  it('keeps showing while a running command is the newest row', () => {
+    // The screenshot case: prose landed, then codex started running shell commands
+    // and the chat body went still for the length of the command.
+    const messages = projectStructuredItemsToNativeChat([assistantTextItem(1), toolCallItem(2)])
+    expect(messages.at(-1)?.role).toBe('assistant')
+    expect(shouldShowNativeChatTypingIndicator({ messages, isWorking: true })).toBe(true)
+  })
+
+  it('still hides once prose is the newest row', () => {
+    const messages = projectStructuredItemsToNativeChat([toolCallItem(1), assistantTextItem(2)])
+    expect(shouldShowNativeChatTypingIndicator({ messages, isWorking: true })).toBe(false)
+  })
+
+  it('stays hidden when the turn is not working, command row or not', () => {
+    const messages = projectStructuredItemsToNativeChat([toolCallItem(1)])
+    expect(shouldShowNativeChatTypingIndicator({ messages, isWorking: false })).toBe(false)
   })
 })

--- a/src/renderer/src/components/native-chat/native-chat-typing-indicator.ts
+++ b/src/renderer/src/components/native-chat/native-chat-typing-indicator.ts
@@ -1,12 +1,28 @@
-// When the trailing "…" row is allowed to render. The rule is pure so the two
-// transports can't drift: the PTY path grows a synthetic streaming bubble while
-// the structured path appends real journal items, but both mean the same thing —
-// the turn's own assistant row is on screen, so a second placeholder below it is
-// just an extra row that reflows the list when it later disappears.
+// When the trailing "…" row is allowed to render.
+//
+// The rule suppresses the dots once the turn's own assistant ANSWER is on screen,
+// because a placeholder below streamed text reflows the list when it disappears.
+// It must not suppress on a row that only reports tool work: a shell command can
+// run for a minute with nothing else arriving, and that is precisely when the
+// user needs to see that the turn is still alive.
+//
+// Both transports have to agree, and matching on `role` alone does not get there:
+// the PTY path emits synthetic `command:` marker rows, while the structured path
+// projects a journal tool-call item as `role: 'assistant'` with tool blocks. Same
+// meaning, different shape — so the predicate is about the row's CONTENT.
 
 import type { NativeChatMessage } from '../../../../shared/native-chat-types'
 import { NATIVE_CHAT_STREAMING_ID } from '../../../../shared/native-chat-streaming'
 import { isCommandMarkerId } from './native-chat-pending'
+
+/** A row carrying only tool activity — no prose. It is progress, not an answer. */
+function isToolActivityOnlyRow(message: NativeChatMessage): boolean {
+  const blocks = message.blocks
+  if (!blocks || blocks.length === 0) {
+    return false
+  }
+  return blocks.every((block) => block.type === 'tool-call' || block.type === 'tool-result')
+}
 
 export function shouldShowNativeChatTypingIndicator(args: {
   messages: readonly NativeChatMessage[]
@@ -21,6 +37,11 @@ export function shouldShowNativeChatTypingIndicator(args: {
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const message = messages[index]
     if (!message || message.role === 'user' || isCommandMarkerId(message.id)) {
+      return true
+    }
+    // Tool work is the strongest reason to KEEP the dots, so it decides here
+    // rather than falling through to the assistant-role check below.
+    if (isToolActivityOnlyRow(message)) {
       return true
     }
     // Status/system rows interleave mid-turn; they neither suppress nor unsuppress,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​54 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​54 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​26 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​21 |

<!-- /orca-pr-loc -->

The trailing `…` vanished as soon as Codex started running shell commands — the part of a turn that actually takes time. Within one turn you got dots while it was thinking, then nothing for the length of a minute-long command.

## Cause

The rule suppressed on `role === 'assistant'`.

- **PTY transport:** a command row arrives as a synthetic `command:` marker → hits the *show* branch.
- **Structured transport:** the same work is a journal tool-call item, projected by `projectStructuredItemToNativeChat` as `role: 'assistant'` with tool blocks → hits the *suppress* branch.

The module header claimed the rule was "pure so the two transports can't drift." The logic was pure; the **inputs** drifted. `isCommandMarkerId` is dead code on the shipping transport.

## Fix

Suppression now keys on the row's **content**, not its role: a row carrying only `tool-call`/`tool-result` blocks is progress, not the turn's answer, so it keeps the dots. Prose still suppresses them — that is what stopped a placeholder from reflowing the list underneath streamed text, which was the original reason for the suppression.

Reference precedent points at a deeper version of this — drive the affordance from turn state and animate the active tool row itself, rather than inferring either from the tail row. That is a larger change than this fix and is called out separately.

## Verification

5778 tests across renderer `native-chat` and `shared`, web typecheck, oxlint clean. Mutation: removing the tool-activity branch turns the new running-command assertion red.

The pre-existing tests only ever constructed `command:`-prefixed rows — a shape that exists on the PTY path alone — which is precisely why they could not see this. The new cases build rows through the **real structured projection**.