### PR TITLE
fix(tests): give tab-search fixtures the required palette document

### DIFF
--- a/src/renderer/src/components/tab-bar/TabBarCreateEntry.tab-results.test.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntry.tab-results.test.tsx
@@ -4,6 +4,7 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TooltipProvider } from '@/components/ui/tooltip'
+import { buildPaletteTabDocument } from '@/lib/palette-match/tab-document'
 import type { OpenTabSearchResult } from './open-tab-search'
 import type { TabAgentLaunchOption } from './tab-agent-launch-options'
 import type { TabCreateMenuOption } from './tab-create-menu-options'
@@ -70,6 +71,15 @@ const tabSearchMock = vi.hoisted(() => {
             secondaryText: row.relativePath ?? '',
             titleSearchText: row.title,
             secondarySearchTexts: row.relativePath ? [row.relativePath] : [],
+            // Retention matches with the real engine, which reads the prebuilt index.
+            document: buildPaletteTabDocument({
+              id: row.tabId ?? '',
+              title: row.title,
+              secondaryTexts: row.relativePath ? [row.relativePath] : [],
+              worktreeName: worktree.displayName,
+              branch: '',
+              repoName: 'octo/rocket'
+            }),
             agentMetadata: [],
             isCurrentTab: false,
             isCurrentWorktree: true

--- a/src/renderer/src/components/tab-bar/open-tab-search-retention.test.ts
+++ b/src/renderer/src/components/tab-bar/open-tab-search-retention.test.ts
@@ -3,8 +3,14 @@ import type { BrowserPage, BrowserWorkspace } from '../../../../shared/browser-w
 import type { Tab, TabContentType } from '../../../../shared/tab-types'
 import type { Worktree } from '../../../../shared/worktree/types'
 import type { SearchableBrowserPage } from '@/lib/browser-palette-search'
+import { buildSearchableBrowserPageDocument } from '@/lib/browser-palette-search'
+import { buildPaletteTabDocument } from '@/lib/palette-match/tab-document'
 import type { SearchableWorkspaceTab } from '@/lib/workspace-tab-palette-search'
 import { TERMINAL_TYPE_SEARCH_ALIASES } from '@/lib/workspace-tab-palette-search'
+import {
+  resolveWorktreeBranchLabel,
+  resolveWorktreeDisplayName
+} from '@/lib/worktree-default-display-name'
 import { searchOpenTabs } from './open-tab-search'
 import type { OpenTabSearchEntries } from './open-tab-search-entries'
 import { retainOpenTabResultsForQuery } from './open-tab-search-retention'
@@ -59,6 +65,8 @@ function makeWorkspaceTab({
   agentSnippets?: string[]
   typeSearchAliases?: readonly string[]
 }): SearchableWorkspaceTab {
+  const resolvedTypeSearchAliases =
+    typeSearchAliases ?? (contentType === 'terminal' ? TERMINAL_TYPE_SEARCH_ALIASES : undefined)
   return {
     tab: makeTab(id, contentType) as SearchableWorkspaceTab['tab'],
     worktree,
@@ -70,8 +78,16 @@ function makeWorkspaceTab({
     secondaryText: secondarySearchTexts[0] ?? '',
     titleSearchText: title,
     secondarySearchTexts,
-    typeSearchAliases:
-      typeSearchAliases ?? (contentType === 'terminal' ? TERMINAL_TYPE_SEARCH_ALIASES : undefined),
+    typeSearchAliases: resolvedTypeSearchAliases,
+    document: buildPaletteTabDocument({
+      id,
+      title,
+      secondaryTexts: secondarySearchTexts,
+      worktreeName: resolveWorktreeDisplayName(worktree),
+      branch: resolveWorktreeBranchLabel(worktree),
+      repoName: 'octo/rocket',
+      typeAliases: resolvedTypeSearchAliases
+    }),
     agentMetadata: agentSnippets.length
       ? [{ paneKey: `${id}-pane`, textParts: [], snippetCandidates: agentSnippets }]
       : [],
@@ -124,6 +140,12 @@ function makeBrowserPage({
     worktree,
     repoName: 'octo/rocket',
     worktreeSortIndex: 0,
+    document: buildSearchableBrowserPageDocument({
+      page,
+      workspace,
+      worktree,
+      repoName: 'octo/rocket'
+    }),
     isCurrentPage: false,
     isCurrentWorktree: true
   }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​34 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​32 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## ELI5

Two tab-search PRs were each green on their own, but they landed on top of each other and left `main` broken. One of them made every searchable row carry a prebuilt search index; the other added new tests whose fake rows were written before that field existed. This gives those fake rows the field, so `main` is green again.

## What Changed

Test-only. No production code.

`open-tab-search-retention.test.ts` and `TabBarCreateEntry.tab-results.test.tsx` now build their `SearchableWorkspaceTab` / `SearchableBrowserPage` fixtures with the required `document` field, via the same helpers production uses — `buildPaletteTabDocument` and `buildSearchableBrowserPageDocument` — rather than hand-rolling a field index. If the document shape changes again, these fixtures move with it instead of silently drifting.

## Why

#15170 made `document: PaletteDocument` a required field, built once per entry so matching does not rebuild the field index on every keystroke. #15133 added new tab-search tests whose fixtures predate that field.

Neither PR was wrong, and CI passed on both, because each was tested against a `main` that did not yet contain the other. Merged together they leave `main` red:

- **14 failing tests** across the two files — `TypeError: Cannot read properties of undefined (reading 'fields')` at `palette-match/match-document.ts:87`, reached through `matchPaletteTabDocument` → `matchEntry` → `searchOpenTabs`.
- **2 typecheck errors** — `TS2741: Property 'document' is missing`, at `open-tab-search-retention.test.ts:62` and `:121`.

Verified on a clean checkout of `origin/main` at `6ee265e579` with nothing else applied, so this is not attributable to any open PR. Note the second file's fixture factory returns `unknown`, which is why only two of the sixteen sites were visible to `tsc` — the rest surfaced only at runtime.

Worth noting separately: the PR test suite runs on `pull_request`, not on pushes to `main`, so a semantic conflict between two individually-green PRs has nothing watching for it. That gap is what let this sit red.

## Linked Issue

N/A — repairing `main` directly.

## Visual Proof

N/A. Test-only change with no user-visible surface.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Against `origin/main` at `6ee265e579`:

| | Before | After |
| :--- | :--- | :--- |
| `open-tab-search-retention` + `TabBarCreateEntry.tab-results` | 14 failed / 8 passed | **22 passed** |
| `tsc --noEmit -p config/tsconfig.tc.web.json` | 2 × TS2741 | **clean** |

`oxlint` and `oxfmt --check` pass on both changed files.

No new test cases were added: the existing assertions were already correct and are what proves the fix — they went from erroring inside the matcher to passing. Adding coverage here would test the fixtures rather than the product.

## Review

Fixtures are built through the production helpers deliberately, so this cannot rot the same way twice.

## Agent skill upstream boundary

- [x] Not applicable.
