### PR TITLE
fix(sidebar): show phone-launched agent tabs before desktop mounts them

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -126,6 +126,70 @@ describe('buildTitleDerivedAgentRows', () => {
     expect(rows).toHaveLength(0)
   })
 
+  it('keeps a phone-launched agent even when its desktop layout has no leaf yet', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { launchAgent: 'claude', title: 'Terminal 1' })],
+      entries: [],
+      retained: [],
+      ptyIdsByTabId: {},
+      terminalLayoutsByTabId: {
+        'tab-1': { root: null, activeLeafId: null, expandedLeafId: null }
+      },
+      now: 2000
+    })
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0].agentType).toBe('claude')
+    expect(rows[0].state).toBe('idle')
+    expect(rows[0].paneKey.startsWith('tab-1:')).toBe(true)
+  })
+
+  it('keeps a phone-launched agent on the worktree card before the desktop mounts its PTY', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { launchAgent: 'codex', title: 'Terminal 1', createdAt: 1500 })],
+      entries: [],
+      retained: [],
+      ptyIdsByTabId: {},
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      paneKey: makePaneKey('tab-1', LEAF_ID_1),
+      agentType: 'codex',
+      rowSource: 'live',
+      state: 'idle',
+      startedAt: 1500
+    })
+  })
+
+  it('does not duplicate a phone-launched agent once hook status arrives', () => {
+    const paneKey = makePaneKey('tab-1', LEAF_ID_1)
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { launchAgent: 'codex', title: 'Terminal 1' })],
+      entries: [
+        {
+          paneKey,
+          state: 'working',
+          prompt: 'ship it',
+          updatedAt: 2000,
+          stateStartedAt: 1800,
+          stateHistory: [],
+          agentType: 'codex'
+        }
+      ],
+      retained: [],
+      ptyIdsByTabId: {},
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+
+    expect(rows.map((row) => row.paneKey)).toEqual([paneKey])
+    expect(rows[0].entry.prompt).toBe('ship it')
+    expect(rows[0].state).toBe('working')
+  })
+
   it('uses runtime orchestration metadata for title-derived worker rows', () => {
     const parentPaneKey = makePaneKey('tab-parent', LEAF_ID_1)
     const childPaneKey = makePaneKey('tab-child', LEAF_ID_2)

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -9,7 +9,7 @@ import type {
   AgentStatusState,
   AgentType
 } from '../../../../shared/agent-status-types'
-import { isTerminalLeafId, makePaneKey } from '../../../../shared/stable-pane-id'
+import { isTerminalLeafId, makePaneKey, parsePaneKey } from '../../../../shared/stable-pane-id'
 import type {
   TerminalLayoutSnapshot,
   TerminalPaneLayoutNode,
@@ -61,61 +61,79 @@ export function buildTitleDerivedAgentRows(args: {
   const terminalLayoutsByTabId = args.terminalLayoutsByTabId ?? EMPTY_TERMINAL_LAYOUTS
 
   for (const tab of args.tabs) {
-    if (!tabHasLivePty(ptyIdsByTabId, tab.id)) {
+    const hasLivePty = tabHasLivePty(ptyIdsByTabId, tab.id)
+    // Why: phone-created agent tabs often exist in the host store before the
+    // desktop mounts a PTY or receives a hook ping. launchAgent is enough to
+    // keep them on the worktree card; a later live status replaces this row.
+    if (!hasLivePty && !tab.launchAgent) {
       continue
     }
     const layout = terminalLayoutsByTabId[tab.id]
-    const paneTitles = runtimePaneTitlesByTabId[tab.id]
-    const paneTitleEntries =
-      paneTitles && Object.keys(paneTitles).length > 0
-        ? Object.entries(paneTitles).sort(([a], [b]) => Number(a) - Number(b))
-        : []
+    if (hasLivePty) {
+      const paneTitles = runtimePaneTitlesByTabId[tab.id]
+      const paneTitleEntries =
+        paneTitles && Object.keys(paneTitles).length > 0
+          ? Object.entries(paneTitles).sort(([a], [b]) => Number(a) - Number(b))
+          : []
 
-    if (paneTitleEntries.length > 0) {
-      for (const [paneId, title] of paneTitleEntries) {
-        const leafId = resolveLeafIdForTitleFallback({
-          layout,
-          paneTitleEntries,
-          paneId: Number(paneId),
-          title
-        })
-        if (!leafId) {
-          continue
+      if (paneTitleEntries.length > 0) {
+        for (const [paneId, title] of paneTitleEntries) {
+          const leafId = resolveLeafIdForTitleFallback({
+            layout,
+            paneTitleEntries,
+            paneId: Number(paneId),
+            title
+          })
+          if (!leafId) {
+            continue
+          }
+          const row = buildTitleDerivedAgentRow({
+            tab,
+            leafId,
+            title,
+            ownerAgentType: resolveTitleDerivedPaneOwner(tab, layout, leafId),
+            now: args.now,
+            runtimeAgentOrchestrationByPaneKey: args.runtimeAgentOrchestrationByPaneKey
+          })
+          if (!row || args.seenPaneKeys.has(row.paneKey)) {
+            continue
+          }
+          rows.push(row)
+          args.seenPaneKeys.add(row.paneKey)
         }
+        continue
+      }
+
+      const liveLeafId = layout?.activeLeafId ?? collectLeafIds(layout?.root ?? null)[0]
+      if (liveLeafId) {
         const row = buildTitleDerivedAgentRow({
           tab,
-          leafId,
-          title,
-          ownerAgentType: resolveTitleDerivedPaneOwner(tab, layout, leafId),
+          leafId: liveLeafId,
+          title: tab.title,
+          ownerAgentType: resolveTitleDerivedPaneOwner(tab, layout, liveLeafId),
           now: args.now,
           runtimeAgentOrchestrationByPaneKey: args.runtimeAgentOrchestrationByPaneKey
         })
-        if (!row || args.seenPaneKeys.has(row.paneKey)) {
+        if (row && !args.seenPaneKeys.has(row.paneKey)) {
+          rows.push(row)
+          args.seenPaneKeys.add(row.paneKey)
           continue
         }
-        rows.push(row)
-        args.seenPaneKeys.add(row.paneKey)
       }
-      continue
     }
 
-    const leafId = layout?.activeLeafId ?? collectLeafIds(layout?.root ?? null)[0]
-    if (!leafId) {
-      continue
-    }
-    const row = buildTitleDerivedAgentRow({
+    const launchAgentRow = buildLaunchAgentFallbackRow({
       tab,
-      leafId,
-      title: tab.title,
-      ownerAgentType: resolveTitleDerivedPaneOwner(tab, layout, leafId),
+      layout,
+      seenPaneKeys: args.seenPaneKeys,
       now: args.now,
       runtimeAgentOrchestrationByPaneKey: args.runtimeAgentOrchestrationByPaneKey
     })
-    if (!row || args.seenPaneKeys.has(row.paneKey)) {
+    if (!launchAgentRow) {
       continue
     }
-    rows.push(row)
-    args.seenPaneKeys.add(row.paneKey)
+    rows.push(launchAgentRow)
+    args.seenPaneKeys.add(launchAgentRow.paneKey)
   }
 
   return rows
@@ -218,6 +236,79 @@ export function resolveTitleDerivedAgentType(
     return null
   }
   return agentType
+}
+
+function launchAgentFallbackLeafId(tabId: string): string {
+  let h1 = 0x811c9dc5
+  let h2 = 0x01000193
+  for (let index = 0; index < tabId.length; index += 1) {
+    const code = tabId.charCodeAt(index)
+    h1 = Math.imul(h1 ^ code, 0x01000193)
+    h2 = Math.imul(h2 ^ code, 0x811c9dc5)
+  }
+  const hex = [
+    (h1 >>> 0).toString(16).padStart(8, '0'),
+    (h2 >>> 0).toString(16).padStart(8, '0'),
+    ((h1 ^ h2) >>> 0).toString(16).padStart(8, '0'),
+    ((h1 + h2) >>> 0).toString(16).padStart(8, '0')
+  ].join('')
+  // Why: makePaneKey requires a UUID leaf; this is only for unmounted
+  // launchAgent tabs whose layout has not been minted yet.
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-4${hex.slice(13, 16)}-8${hex.slice(17, 20)}-${hex.slice(20, 32)}`
+}
+
+function tabHasSeenPaneKey(seenPaneKeys: ReadonlySet<string>, tabId: string): boolean {
+  for (const paneKey of seenPaneKeys) {
+    if (parsePaneKey(paneKey)?.tabId === tabId) {
+      return true
+    }
+  }
+  return false
+}
+
+function buildLaunchAgentFallbackRow(args: {
+  tab: TerminalTab
+  layout: TerminalLayoutSnapshot | undefined
+  seenPaneKeys: ReadonlySet<string>
+  now: number
+  runtimeAgentOrchestrationByPaneKey?: Record<string, AgentStatusOrchestrationContext>
+}): DashboardAgentRow | null {
+  if (!args.tab.launchAgent || tabHasSeenPaneKey(args.seenPaneKeys, args.tab.id)) {
+    return null
+  }
+  const layoutLeafId = args.layout?.activeLeafId ?? collectLeafIds(args.layout?.root ?? null)[0]
+  const leafId =
+    layoutLeafId && isTerminalLeafId(layoutLeafId)
+      ? layoutLeafId
+      : launchAgentFallbackLeafId(args.tab.id)
+  const agentType =
+    resolveCompatibleAgentTypeForOwner(args.tab.launchAgent, args.tab.launchAgent) ??
+    args.tab.launchAgent
+  const paneKey = makePaneKey(args.tab.id, leafId)
+  const orchestration = args.runtimeAgentOrchestrationByPaneKey?.[paneKey]
+  const rowLabel = formatAgentTypeLabel(agentType)
+  const entry: AgentStatusEntry = {
+    paneKey,
+    state: 'working',
+    prompt: rowLabel,
+    updatedAt: args.now,
+    stateStartedAt: args.tab.createdAt || args.now,
+    stateHistory: [],
+    agentType,
+    terminalTitle: args.tab.title,
+    lastAssistantMessage: 'Idle',
+    worktreeId: args.tab.worktreeId,
+    ...(orchestration ? { orchestration } : {})
+  }
+  return {
+    paneKey,
+    entry,
+    tab: args.tab,
+    agentType,
+    rowSource: 'live',
+    state: 'idle',
+    startedAt: args.tab.createdAt
+  }
 }
 
 function resolveTitleDerivedPaneOwner(

--- a/src/renderer/src/store/slices/terminals-launch-agent-layout.test.ts
+++ b/src/renderer/src/store/slices/terminals-launch-agent-layout.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { createTestStore, makeWorktree, seedStore } from './store-test-helpers'
+
+const WORKTREE_ID = 'repo1::/path/wt1'
+
+describe('createTab launch-agent layout', () => {
+  it('mints a single-leaf layout so an unmounted phone-launched agent can appear in the sidebar', () => {
+    const store = createTestStore()
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: WORKTREE_ID, repoId: 'repo1', path: '/path/wt1' })]
+      }
+    })
+
+    const tab = store.getState().createTab(WORKTREE_ID, undefined, undefined, {
+      launchAgent: 'codex',
+      activate: false
+    })
+    const layout = store.getState().terminalLayoutsByTabId[tab.id]
+
+    expect(tab.launchAgent).toBe('codex')
+    expect(layout?.root).toEqual({ type: 'leaf', leafId: expect.any(String) })
+    expect(layout?.activeLeafId).toBe(layout?.root?.type === 'leaf' ? layout.root.leafId : null)
+  })
+
+  it('keeps a blank terminal rootless until its pane mounts', () => {
+    const store = createTestStore()
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: WORKTREE_ID, repoId: 'repo1', path: '/path/wt1' })]
+      }
+    })
+
+    const tab = store.getState().createTab(WORKTREE_ID, undefined, undefined, { activate: false })
+    expect(store.getState().terminalLayoutsByTabId[tab.id]).toEqual({
+      root: null,
+      activeLeafId: null,
+      expandedLeafId: null
+    })
+  })
+})

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -53,7 +53,11 @@ import { forgetAgentHibernationTabOutput } from '@/lib/agent-hibernation-output-
 import { forgetForegroundTerminalTabs } from '@/lib/foreground-terminal-tabs'
 import { terminalLayoutEqual } from '@/lib/terminal-layout-equality'
 import { forgetAgentStartupDeliveriesForTabs } from '@/lib/agent-startup-delivery-guards'
-import { clearTransientTerminalState, emptyLayoutSnapshot } from './terminal-helpers'
+import {
+  clearTransientTerminalState,
+  emptyLayoutSnapshot,
+  singlePaneLayoutSnapshot
+} from './terminal-helpers'
 import {
   collectReleasedLeafIds,
   hydrateWorkspaceTerminalRows,
@@ -1488,7 +1492,11 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         },
         terminalLayoutsByTabId: {
           ...orphanCleanupPatch.terminalLayoutsByTabId,
-          [tab.id]: emptyLayoutSnapshot()
+          // Why: phone-created agent tabs stay unmounted on desktop until
+          // clicked; a real leaf lets the sidebar address the row immediately.
+          [tab.id]: options?.launchAgent
+            ? singlePaneLayoutSnapshot(createBrowserUuid())
+            : emptyLayoutSnapshot()
         }
       }
     })


### PR DESCRIPTION
## ELI5

If you start an agent from your phone, the desktop already knows the tab exists, but the left sidebar Agents list waited for a live terminal or a hook ping. That wait never finished for a background phone launch, so the session stayed invisible. This shows it immediately from the launch agent, then upgrades the row when real status arrives.

## What Changed

- Treat `launchAgent` as enough to render an idle worktree-card agent row when the desktop has not mounted a PTY or received hook status yet.
- Skip that placeholder if the same tab already has a live/hook row, so there is no duplicate.
- When creating a tab with `launchAgent`, mint a single-leaf layout so the row has a stable pane key instead of an empty snapshot.

## Why

Phone creates default to `navigation: caller`, so the desktop tab is created with `activate: false`. The sidebar builder required `tabHasLivePty` plus a recognizable title (or an applied hook status). A phone-launched Codex/Claude tab is often just `{ launchAgent, title: "Terminal N" }` with no PTY, so it never appeared.

## Linked Issue

Fixes #15203

## Visual Proof

N/A — worktree-card agent list composition only. Covered by unit tests:

- phone-launched tab with no PTY appears as an idle row
- the same tab does not duplicate once hook status arrives
- creating an agent tab mints a single-leaf layout; a blank terminal stays rootless