### PR TITLE
fix(mobile): send multi-line agent prompts from the launch paths as one paste

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -170,6 +170,7 @@ import {
   removeDeliveredMobileDiffComments,
   removeMobileDiffComments
 } from '../../../../src/session/mobile-diff-comments'
+import { buildDiffNotesAgentLaunchPrompt } from '../../../../src/session/diff-notes-agent-launch-prompt'
 import {
   buildPlainMobileDiffSyntaxLines,
   highlightMobileCode,
@@ -4271,7 +4272,7 @@ export default function SessionScreen() {
                   return
                 }
                 void handleCreateTerminal(option.agent, {
-                  initialPrompt: delivery.prompt,
+                  initialPrompt: buildDiffNotesAgentLaunchPrompt(delivery.prompt),
                   onPromptSent: () => void clearDeliveredDiffComments(delivery.comments)
                 })
               }

--- a/mobile/src/session/diff-notes-agent-launch-prompt.ts
+++ b/mobile/src/session/diff-notes-agent-launch-prompt.ts
@@ -1,0 +1,15 @@
+import { frameMultilineTerminalPasteText } from '../../../src/shared/terminal-bracketed-paste-bytes'
+
+/**
+ * Diff review notes are multi-line prose bound for an agent TUI, so they must
+ * arrive as one paste — unframed, each note boundary is an Enter and the notes
+ * are submitted a line at a time.
+ *
+ * The opt-in lives here at the caller, not on the launch seam: that same seam
+ * carries insert-only shell quick commands, and framing one of those would
+ * corrupt it. The notes are also offered to the clipboard unframed, so the
+ * framing cannot move up into where the delivery is built either.
+ */
+export function buildDiffNotesAgentLaunchPrompt(prompt: string): string {
+  return frameMultilineTerminalPasteText(prompt)
+}

--- a/mobile/src/session/pr-ai-triage-launch.ts
+++ b/mobile/src/session/pr-ai-triage-launch.ts
@@ -1,4 +1,5 @@
 import type { RpcClient } from '../transport/rpc-client'
+import { frameMultilineTerminalPasteText } from '../../../src/shared/terminal-bracketed-paste-bytes'
 import {
   readMobileReviewCreatedTerminal,
   readMobileReviewTerminalSendAccepted
@@ -30,7 +31,8 @@ export async function createTerminalAndSendPrompt(
   }
   const sent = await client.sendRequest('terminal.send', {
     terminal: terminalTab.terminal,
-    text: prompt,
+    // Prose for an agent TUI: unframed, every newline would submit early.
+    text: frameMultilineTerminalPasteText(prompt),
     enter: true
   })
   if (!sent.ok) {

--- a/mobile/src/session/prose-launch-paste-framing.test.ts
+++ b/mobile/src/session/prose-launch-paste-framing.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import { buildDiffNotesAgentLaunchPrompt } from './diff-notes-agent-launch-prompt'
+import { createTerminalAndSendPrompt } from './pr-ai-triage-launch'
+import { buildMobileQuickCommandLaunch } from '../terminal/quick-commands'
+import type { RpcClient } from '../transport/rpc-client'
+
+const PASTE_START = '\u001b[200~'
+const PASTE_END = '\u001b[201~'
+
+const MULTILINE_NOTES = 'Address these notes.\n\nsrc/a.ts:1 fix this\n\nsrc/b.ts:2 and this'
+
+type Sent = { method: string; text?: string; enter?: boolean }
+
+function launchClient(sent: Sent[]): Pick<RpcClient, 'sendRequest'> {
+  return {
+    sendRequest: async (method: string, params: unknown) => {
+      const sendParams = params as { text?: string; enter?: boolean }
+      sent.push({ method, text: sendParams.text, enter: sendParams.enter })
+      if (method === 'session.tabs.createTerminal') {
+        return { ok: true, result: { tab: { type: 'terminal', id: 'tab-1', terminal: 'term-1' } } }
+      }
+      return { ok: true, result: { send: { accepted: true } } }
+    }
+  }
+}
+
+describe('diff notes launched into a new agent session', () => {
+  it('frames the notes so the agent receives them as one prompt', () => {
+    const launched = buildDiffNotesAgentLaunchPrompt(MULTILINE_NOTES)
+
+    expect(launched.startsWith(PASTE_START)).toBe(true)
+    expect(launched.endsWith(PASTE_END)).toBe(true)
+    expect(launched).not.toContain('\n')
+  })
+
+  it('leaves a single-line note untouched', () => {
+    expect(buildDiffNotesAgentLaunchPrompt('one note')).toBe('one note')
+  })
+})
+
+describe('prompt sent into a freshly created agent terminal', () => {
+  it('frames a multi-line prompt', async () => {
+    const sent: Sent[] = []
+
+    await createTerminalAndSendPrompt(launchClient(sent) as RpcClient, 'wt-1', MULTILINE_NOTES)
+
+    const send = sent.find((entry) => entry.method === 'terminal.send')
+    expect(send?.text?.startsWith(PASTE_START)).toBe(true)
+    expect(send?.text).not.toContain('\n')
+    expect(send?.enter).toBe(true)
+  })
+
+  it('leaves a single-line prompt untouched', async () => {
+    const sent: Sent[] = []
+
+    await createTerminalAndSendPrompt(launchClient(sent) as RpcClient, 'wt-1', 'do the thing')
+
+    expect(sent.find((entry) => entry.method === 'terminal.send')?.text).toBe('do the thing')
+  })
+})
+
+describe('the launch seam is overloaded, so shell commands stay unframed', () => {
+  it('keeps a multi-line insert-only quick command byte-identical', () => {
+    // Same initialPrompt seam as the diff-notes launch above. Framing here would
+    // corrupt the command, which is why the opt-in lives at the prose caller.
+    const launch = buildMobileQuickCommandLaunch({
+      label: 'two liner',
+      command: 'echo one\necho two',
+      appendEnter: false
+    } as never)
+
+    expect(launch?.options.initialPrompt).toBe('echo one\necho two')
+    expect(launch?.options.initialPrompt).not.toContain(PASTE_START)
+    expect(launch?.options.enter).toBe(false)
+  })
+})

--- a/mobile/src/session/use-mobile-diff-review-send-actions.test.ts
+++ b/mobile/src/session/use-mobile-diff-review-send-actions.test.ts
@@ -105,6 +105,12 @@ describe('useMobileDiffReviewSendActions', () => {
     expect(sendRequest.mock.calls[1]?.[1]).toMatchObject({ terminal: 'terminal-1', enter: true })
     // The second call is the notes themselves, not another clear.
     expect(String(sendRequest.mock.calls[1]?.[1]?.text)).toContain('rename this')
+    // Notes are multi-line prose: unframed, each line break submits early and one
+    // send becomes a turn per line.
+    const notes = String(sendRequest.mock.calls[1]?.[1]?.text)
+    expect(notes.startsWith('\u001b[200~')).toBe(true)
+    expect(notes.endsWith('\u001b[201~')).toBe(true)
+    expect(notes).not.toContain('\n')
     expect(isMobileNativeChatInputStale('terminal-1')).toBe(false)
     expect(setActionError).toHaveBeenCalledWith('Review notes sent')
   })

--- a/mobile/src/session/use-mobile-diff-review-send-actions.ts
+++ b/mobile/src/session/use-mobile-diff-review-send-actions.ts
@@ -1,4 +1,5 @@
 import { useCallback, type Dispatch, type SetStateAction } from 'react'
+import { frameMultilineTerminalPasteText } from '../../../src/shared/terminal-bracketed-paste-bytes'
 import * as Clipboard from 'expo-clipboard'
 import type { DiffComment, MobileDiffReviewState } from '../../../src/shared/diff-comment-types'
 import type { ConnectionState } from '../transport/types'
@@ -82,7 +83,7 @@ export function useMobileDiffReviewSendActions(input: SendActionsInput) {
       }
       const response = await client.sendRequest('terminal.send', {
         terminal,
-        text: formatMobileDiffReviewPrompt(comments),
+        text: frameMultilineTerminalPasteText(formatMobileDiffReviewPrompt(comments)),
         enter: true
       })
       if (!response.ok) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​82 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​82 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​22 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​19 |

<!-- /orca-pr-loc -->

## ELI5

When you send review notes to an agent from your phone, the notes are typed into the agent's input box one character at a time — and every line break acts like you pressed Enter. So a nine-line block of notes gets submitted as roughly nine separate messages. This wraps the text so it arrives as a single paste, the way pasting into a terminal already works.

## What Changed

Frame multi-line prose as one bracketed paste at the three mobile launch paths that write it into an agent TUI:

- diff review notes sent to an **existing** terminal (`use-mobile-diff-review-send-actions.ts`)
- diff review notes launched into a **new** agent session (the `initialPrompt` send in the session screen)
- the prompt written into a freshly created agent terminal (`pr-ai-triage-launch.ts`) — reached by **both** PR triage and commit-failure recovery

Each opts in at its own call site using the shared helper added in the base PR. No shared seam is changed.

## Why

`terminal.send` writes text verbatim, with no paste framing, and the host's framed-prompt path is gated on desktop clients. Unframed, each newline is an Enter, so one send becomes N agent turns. `formatMobileDiffReviewPrompt` is newline-joined, so sending review notes fires **roughly nine separate agent submissions today**.

**The opt-in has to live at the caller, not the seam.** The `initialPrompt` send is overloaded: it also carries insert-only shell quick commands (`quick-commands.ts`, `appendEnter === false`, `enter: false`), which can themselves be multi-line and must arrive verbatim. And the diff-notes prompt is separately offered to the clipboard unframed, so the framing cannot move up into where the delivery is built either. Both constraints are covered by tests.

**Inventory was re-derived by grep, not copied from the plan.** `rg "'terminal\.send'" mobile/src mobile/app` returns 15 call sites. All 15 were classified; the four prose paths are the three here plus the composer (base PR). **No fifth prose path exists** — the previously unclassified site is gesture arrow bytes with `enter: false`.

## Linked Issue

Defect (A) from the mobile "double sending" investigation. Plan and full review history: `docs/plans/2026-08-17-mobile-multiline-send-framing.md` (committed in the base PR).

Fixes #

## Visual Proof

N/A — no UI change. The change is to the bytes written to the PTY; the visible difference is that the agent receives one message instead of N, which shows up in the agent's own transcript rather than in Orca chrome.

## Testing

- [x] Automated tests added/updated
- [ ] I manually tested these changes locally — mobile QA not yet run; see Notes.

Every test that pins the defect was **proven RED before the fix and green after**, by reverting the production change and re-running:

- diff review notes to an existing terminal — RED at the real call site through the existing hook test (`1 failed | 6 passed` → `7 passed`)
- diff notes into a new agent session, and the fresh-terminal prompt — RED `2 failed | 3 passed` → `5 passed`

Green guards that must stay green: single-line prompts byte-identical on every path, and a **multi-line insert-only quick command stays unframed and byte-identical**.

Full mobile suite: `456 files / 3636 tests passed`. Lint and format clean (`oxlint`, `oxfmt`); the mobile lint gate was proven live by injecting a violation and confirming it was reported, rather than trusting a silent pass.

## AI Disclosure

## Review

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

- **Stacked on 15206 — merge that first.** This branch is based on it and needs the shared helper it adds.
- Security: framing neutralizes embedded escapes, so a pasted paste-end marker can no longer close the frame early and run the tail as keystrokes. This is stricter than today.
- Backwards compatibility: no wire change. `terminal.send` text is opaque bytes on every host version, so framed bytes reach old hosts and land in the PTY unchanged. Mobile already ships framed bytes through this RPC today (image paste).
- SSH / remote / folder workspaces: all converge on the same host write path; no path-specific behavior.
- Cross-platform: unchanged relative to the base PR's analysis.
- Mobile QA via `orca emulator` has **not** been run yet.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — targeted lint/format/tests run locally; full typecheck and build left to CI.

## Author

- X / Twitter: @BrennanKB5

