### PR TITLE
fix(cmd-j): give the open-tab search test fixtures their palette document

### DIFF
--- a/src/renderer/src/components/tab-bar/TabBarCreateEntry.tab-results.test.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntry.tab-results.test.tsx
@@ -3,6 +3,7 @@
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { buildPaletteTabDocument } from '@/lib/palette-match/tab-document'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import type { OpenTabSearchResult } from './open-tab-search'
 import type { TabAgentLaunchOption } from './tab-agent-launch-options'
@@ -70,6 +71,14 @@ const tabSearchMock = vi.hoisted(() => {
             secondaryText: row.relativePath ?? '',
             titleSearchText: row.title,
             secondarySearchTexts: row.relativePath ? [row.relativePath] : [],
+            document: buildPaletteTabDocument({
+              id: row.tabId ?? '',
+              title: row.title,
+              secondaryTexts: row.relativePath ? [row.relativePath] : [],
+              worktreeName: worktree.displayName,
+              branch: '',
+              repoName: 'octo/rocket'
+            }),
             agentMetadata: [],
             isCurrentTab: false,
             isCurrentWorktree: true

--- a/src/renderer/src/components/tab-bar/open-tab-search-retention.test.ts
+++ b/src/renderer/src/components/tab-bar/open-tab-search-retention.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest'
 import type { BrowserPage, BrowserWorkspace } from '../../../../shared/browser-workspace-types'
 import type { Tab, TabContentType } from '../../../../shared/tab-types'
 import type { Worktree } from '../../../../shared/worktree/types'
+import { buildSearchableBrowserPageDocument } from '@/lib/browser-palette-search'
 import type { SearchableBrowserPage } from '@/lib/browser-palette-search'
+import { buildPaletteTabDocument } from '@/lib/palette-match/tab-document'
 import type { SearchableWorkspaceTab } from '@/lib/workspace-tab-palette-search'
 import { TERMINAL_TYPE_SEARCH_ALIASES } from '@/lib/workspace-tab-palette-search'
 import { searchOpenTabs } from './open-tab-search'
@@ -59,6 +61,8 @@ function makeWorkspaceTab({
   agentSnippets?: string[]
   typeSearchAliases?: readonly string[]
 }): SearchableWorkspaceTab {
+  const resolvedTypeAliases =
+    typeSearchAliases ?? (contentType === 'terminal' ? TERMINAL_TYPE_SEARCH_ALIASES : undefined)
   return {
     tab: makeTab(id, contentType) as SearchableWorkspaceTab['tab'],
     worktree,
@@ -70,8 +74,16 @@ function makeWorkspaceTab({
     secondaryText: secondarySearchTexts[0] ?? '',
     titleSearchText: title,
     secondarySearchTexts,
-    typeSearchAliases:
-      typeSearchAliases ?? (contentType === 'terminal' ? TERMINAL_TYPE_SEARCH_ALIASES : undefined),
+    document: buildPaletteTabDocument({
+      id,
+      title,
+      secondaryTexts: secondarySearchTexts,
+      worktreeName: worktree.displayName,
+      branch: worktree.branch,
+      repoName: 'octo/rocket',
+      typeAliases: resolvedTypeAliases
+    }),
+    typeSearchAliases: resolvedTypeAliases,
     agentMetadata: agentSnippets.length
       ? [{ paneKey: `${id}-pane`, textParts: [], snippetCandidates: agentSnippets }]
       : [],
@@ -125,7 +137,13 @@ function makeBrowserPage({
     repoName: 'octo/rocket',
     worktreeSortIndex: 0,
     isCurrentPage: false,
-    isCurrentWorktree: true
+    isCurrentWorktree: true,
+    document: buildSearchableBrowserPageDocument({
+      page,
+      workspace,
+      worktree,
+      repoName: 'octo/rocket'
+    })
   }
 }
 


### PR DESCRIPTION
## ELI5

Two PRs landed that are each fine on their own but broken together, and `main` is currently red because of it. This adds the one missing field, in the two test files that need it.

## What Changed

Two test files build `SearchableWorkspaceTab` / `SearchableBrowserPage` fixtures without a `document`:

- `open-tab-search-retention.test.ts` — both fixtures now use the same builders the sibling `open-tab-search.test.ts` already uses (`buildPaletteTabDocument`, `buildSearchableBrowserPageDocument`).
- `TabBarCreateEntry.tab-results.test.tsx` — the hoisted `useOpenTabSearch` mock builds workspace tab entries the same way, so it needs the same field.

In the retention test the resolved type aliases are hoisted into a local and passed to the document as `typeAliases` as well as to `typeSearchAliases`. Without that, the "keeps a terminal row the newer query matches through its type alias" case would pass for the wrong reason — the alias field would be absent rather than matched.

## Why

- #15133 (`9b8e9dc2269`) added `open-tab-search-retention.test.ts`.
- #15170 (`2aebcfe2885`) made `document: PaletteDocument` required on `SearchableWorkspaceTab` and updated the fixtures it knew about.

Neither touched the other, so nothing conflicted textually and both merged green. On `main` together:

```
open-tab-search-retention.test.ts(62,3): error TS2741: Property 'document' is missing ... but required in type 'SearchableWorkspaceTab'
open-tab-search-retention.test.ts(121,3): error TS2741: Property 'document' is missing ... but required in type 'SearchableBrowserPage'
```

and at runtime the affected tests die with `TypeError: Cannot read properties of undefined (reading 'fields')` at `collectTokenCandidates` (`match-document.ts:87`).

This is why `typecheck` and test shards 6/16 and 7/16 are failing on every open PR right now, not just mine — every PR merges against a broken `main`.

## Linked Issue

No issue — found while trying to get CI green on unrelated PRs.

## Visual Proof

`N/A` — test-fixture-only change, no product behavior touched.

## Testing

Verified on a pristine `origin/main` checkout (`6ee265e579e`) that both failures reproduce with no other changes, then that these commits clear them. macOS.

| check | before | after |
|---|---|---|
| `tsc --noEmit -p config/tsconfig.tc.web.json` | 2 errors | clean |
| `open-tab-search-retention.test.ts` | 12 failed | 12 passed |
| `TabBarCreateEntry.tab-results.test.tsx` | 2 failed / 8 passed | 10 passed |
| full `src/renderer/src/components/tab-bar/` | — | 49 files, 388 passed |
| `oxlint` on changed files | clean | clean |

Dropping the `typeAliases` argument alone re-fails exactly one case ("keeps a terminal row the newer query matches through its type alias"), so that argument is load-bearing rather than decorative.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

Fixture-only. No production source touched, so there is no cross-platform, SSH/remote, mobile, wire-compatibility, or performance surface.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

Worth considering a CI job that typechecks and tests `main` after merge — this class of semantic conflict between two independently-green PRs is invisible to per-PR CI, and it took down every open PR until someone noticed.

## AI Disclosure

Claude Opus.
