### PR TITLE
fix(editor): detect .liquid files as Liquid

### DIFF
--- a/src/renderer/src/lib/language-detect.test.ts
+++ b/src/renderer/src/lib/language-detect.test.ts
@@ -70,6 +70,13 @@ describe('detectLanguage', () => {
     expect(detectLanguage('C:\\app\\WebContent\\WEB-INF\\jsp\\LIST.JSP')).toBe('html')
   })
 
+  it('maps .liquid files to the Monaco built-in liquid language id, including the compound .html.liquid form', () => {
+    expect(detectLanguage('theme.liquid')).toBe('liquid')
+    expect(detectLanguage('sections/header.liquid')).toBe('liquid')
+    expect(detectLanguage('templates/product.html.liquid')).toBe('liquid')
+    expect(detectLanguage('C:\\theme\\snippets\\CART.LIQUID')).toBe('liquid')
+  })
+
   it('keeps .json/.jsonc on the built-in json language and unknown on plaintext', () => {
     expect(detectLanguage('config/settings.json')).toBe('json')
     expect(detectLanguage('config/tsconfig.jsonc')).toBe('json')

--- a/src/renderer/src/lib/language-detect.ts
+++ b/src/renderer/src/lib/language-detect.ts
@@ -39,6 +39,9 @@ const EXT_TO_LANGUAGE: Record<string, string> = {
   // Why: stopgap until a real JSP grammar — 'html' colors the markup; <% %> and ${} stay plain.
   '.jsp': 'html',
   '.jspf': 'html',
+  // Why: Monaco declares Liquid as both '.liquid' and '.html.liquid'; the final-extension
+  // lookup below covers the compound form, so the single entry is enough.
+  '.liquid': 'liquid',
   '.xml': 'xml',
   '.svg': 'xml',
   '.py': 'python',


### PR DESCRIPTION
## ELI5

Orca already ships the coloring rules for Shopify Liquid templates — it just never
looked them up. When you opened a `.liquid` file, Orca asked "what language is this?",
found no answer, and said "plain text", so the editor showed the file in one flat color.
This adds the missing lookup entry so Liquid files get colored like every other language.

## What Changed

One entry in `EXT_TO_LANGUAGE` in `src/renderer/src/lib/language-detect.ts`:

```ts
'.liquid': 'liquid',
```

Plus a regression test covering the plain, compound, and case-varying forms.

## Why

Monaco already bundles and registers the Liquid grammar — `monaco-setup.ts` imports the
full `monaco-editor` entry, and `editor.main.js` imports `liquid.contribution.js`, which
registers language id `liquid` with extensions `['.liquid', '.html.liquid']`.

The gap was purely in Orca's detector. `detectLanguage()` resolves the language id itself
rather than deferring to Monaco's extension registry, so a missing map entry fell through
to `plaintext` and the grammar was never attached to the model. Shopify theme files
rendered completely uncolored.

The final-extension lookup in `detectLanguage()` already covers the compound `.html.liquid`
form that Monaco declares separately (`extname()` returns only the last extension), so a
single map entry is sufficient — no special-casing needed.

## Linked Issue

Fixes #15128

## Visual Proof

Syntax highlighting only — no layout, spacing, or interaction change.

**Before:** a `.liquid` file resolves to `plaintext`, so the whole buffer renders in the
default foreground color with no token coloring at all.

**After:** the same file resolves to Monaco's `liquid` language, so Liquid tags
(`{% ... %}`), objects (`{{ ... }}`), strings, and the surrounding HTML markup are colored
by the active theme. Coloring comes entirely from Monaco's own bundled Monarch grammar, so
it follows light and dark themes with no new tokens or styles.

No captures attached yet — I did not want to claim a screenshot I hadn't taken. If you'd like
the before/after pair on the record before merging, say the word and I'll add them.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Added `language-detect.test.ts` coverage asserting `liquid` for `theme.liquid`,
`sections/header.liquid`, the compound `templates/product.html.liquid`, and the
case-varying Windows path `C:\theme\snippets\CART.LIQUID`.

Verified the test genuinely catches the regression by reverting only the source change
and re-running — it fails with `expected 'plaintext' to be 'liquid'`, and passes once
restored.

Checks run locally on macOS:

- `pnpm lint` — exit 0
- `pnpm typecheck` — exit 0
- `pnpm build` — exit 0
- `pnpm test` — 1034 files / 9406 tests pass across every area consuming `detectLanguage`
  (`lib`, `editor`, `terminal-pane`, `tab-bar`, `store/slices/editor`). The full-suite run
  also surfaces 27 failing files under `src/main/` (claude-accounts, skills, updater, ssh);
  those reproduce identically on a pristine `upstream/main` checkout without this commit
  (25/27, same 238-test count), so they are pre-existing and unrelated.

## AI Disclosure

Claude Opus 5 (Claude Code) was used to verify the diagnosis against the Monaco bundle,
write the regression test, and confirm the pre-existing `src/main/` failures reproduce on
`upstream/main`. The change itself is a single map entry.

## Review

Pure renderer-side lookup addition; no runtime, IO, or wire surface touched.

- **Cross-platform (macOS/Linux/Windows):** no platform-dependent code. `detectLanguage()`
  splits on both `/` and `\` and lowercases the extension, and the test covers a Windows
  path with an uppercase extension.
- **SSH / remote / local:** language detection runs in the renderer against a file path
  string; it does not touch the filesystem, so remote, SSH, and folder-workspace files
  resolve identically to local ones.
- **Remote wire compatibility:** no RPC params, stream frames, or published content
  changed. Nothing crosses the client/host boundary.
- **Agent / integration / git-provider compatibility:** not touched.
- **Performance:** one additional key in an object literal consulted on file open. No hot-path
  impact.
- **UI quality:** the grammar is Monaco's own built-in, so coloring follows the active theme
  in both light and dark mode with no new tokens or styles.
- **Security:** no new input handling, no execution, no network or filesystem access.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md`
      and copies or mechanically translates no upstream skill-installer source, tests, fixtures,
      registry entries, path tables, comments, or documentation.

## Notes

Follow-up noted in the issue and deliberately left out of scope: Monaco's built-in Monarch
grammar colors Liquid + HTML but not embedded CSS/JS (`{% stylesheet %}` / `{% javascript %}`)
or `{% schema %}` JSON. Full theme-file fidelity would need a Shopify TextMate grammar via the
existing `registerTextMateLanguage()` infra — a larger change that deserves its own PR.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason — described below; happy to attach captures on request
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: n/a — no longer on X, but thanks for the offer to shout it out.
