### PR TITLE
fix(orchestration): preserve live agent on readiness timeout

### DIFF
--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -19249,7 +19249,7 @@ export class OrcaRuntimeService {
         if (effectiveTimeoutMs > 0) {
           waiter.timeout = setTimeout(() => {
             this.removeWaiter(waiter)
-            reject(new Error('timeout'))
+            reject(createTerminalWaitTimeoutError(Boolean(this.getLivePtyForHandle(waiter.handle))))
           }, effectiveTimeoutMs)
         }
         let waiters = this.waitersByHandle.get(handle)
@@ -19348,7 +19348,14 @@ export class OrcaRuntimeService {
       if (effectiveTimeoutMs > 0) {
         waiter.timeout = setTimeout(() => {
           this.removeWaiter(waiter)
-          reject(new Error('timeout'))
+          let terminalLive = false
+          try {
+            this.getLiveLeafForHandle(waiter.handle)
+            terminalLive = true
+          } catch {
+            // The handle may have gone stale while the timeout callback ran.
+          }
+          reject(createTerminalWaitTimeoutError(terminalLive))
         }, effectiveTimeoutMs)
       }
 
@@ -39626,6 +39633,15 @@ function buildTerminalWait(
     exitCode,
     ...(blockedReason ? { blockedReason } : {})
   }
+}
+
+function createTerminalWaitTimeoutError(
+  terminalLive: boolean
+): Error & { code: 'terminal_wait_timeout'; terminalLive: boolean } {
+  return Object.assign(new Error('timeout'), {
+    code: 'terminal_wait_timeout' as const,
+    terminalLive
+  })
 }
 
 function getPtyTerminalState(pty: RuntimePtyWorktreeRecord): RuntimeTerminalState {

--- a/src/main/runtime/rpc/methods/orchestration-worker-readiness-verdict.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-readiness-verdict.test.ts
@@ -1,0 +1,205 @@
+import { spawn, type ChildProcess } from 'node:child_process'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RuntimeTerminalWait } from '../../../../shared/runtime-types'
+import { OrcaRuntimeService } from '../../orca-runtime'
+import { OrchestrationDb } from '../../orchestration/db'
+import { ORCHESTRATION_METHODS } from './orchestration'
+
+type RuntimeInternals = {
+  recordPtyWorktree: (ptyId: string, worktreeId: string, state?: { connected?: boolean }) => void
+  handleByPtyId: Map<string, string>
+}
+
+function runtimeInternals(runtime: OrcaRuntimeService): RuntimeInternals {
+  return runtime as unknown as RuntimeInternals
+}
+
+describe('orchestration worker readiness verdict', () => {
+  let db: OrchestrationDb
+  let runtime: OrcaRuntimeService
+  let runId: string
+  let child: ChildProcess | undefined
+
+  beforeEach(() => {
+    db = new OrchestrationDb(':memory:')
+    runtime = new OrcaRuntimeService()
+    runtime.setOrchestrationDb(db)
+    runId = db.createRun({
+      objective: 'Readiness verdict oracle',
+      coordinatorHandle: 'term_coord',
+      coordinatorPaneKey: 'tab_coord:pane_coord'
+    }).id
+    vi.spyOn(runtime, 'getTerminalPaneKey').mockImplementation((handle) =>
+      handle === 'term_coord' ? 'tab_coord:pane_coord' : 'tab_worker:pane_worker'
+    )
+    vi.spyOn(runtime, 'getTerminalProcessIncarnation').mockReturnValue('runtime_test:worker:1')
+    vi.spyOn(runtime, 'validateOrchestrationAgentLauncher').mockImplementation(() => {})
+    vi.spyOn(runtime, 'showTerminal').mockResolvedValue({
+      handle: 'term_coord',
+      worktreeId: 'repo::parent',
+      status: 'running'
+    } as never)
+    vi.spyOn(runtime, 'showManagedWorktree').mockResolvedValue({
+      id: 'repo::parent',
+      repoId: 'repo'
+    } as never)
+    vi.spyOn(runtime, 'showRepo').mockResolvedValue({ id: 'repo', kind: 'git' } as never)
+    vi.spyOn(runtime, 'listTerminals').mockResolvedValue({
+      terminals: [{ handle: 'term_worker', title: 'Codex' }],
+      totalCount: 1,
+      truncated: false
+    } as never)
+    vi.spyOn(runtime, 'waitForTerminal').mockResolvedValue({
+      handle: 'term_worker',
+      condition: 'tui-idle',
+      satisfied: true,
+      status: 'running',
+      exitCode: null
+    })
+    vi.spyOn(runtime, 'getTerminalOrchestrationCliCommand').mockReturnValue('orca')
+    vi.spyOn(runtime, 'sendTerminalAgentPrompt').mockResolvedValue({
+      handle: 'term_worker',
+      accepted: true,
+      bytesWritten: 1
+    })
+    vi.spyOn(runtime, 'waitForSetupTerminalCompletion').mockReturnValue(
+      new Promise(() => undefined)
+    )
+    vi.spyOn(runtime, 'createManagedWorktree').mockResolvedValue({
+      worktree: { id: 'repo::created', repoId: 'repo' },
+      startupTerminal: { spawned: true, handle: 'term_worker' },
+      setupReceipt: {
+        requested: 'run',
+        hookFound: false,
+        startupPolicy: 'start-immediately',
+        state: 'not_configured'
+      }
+    } as never)
+  })
+
+  afterEach(() => {
+    if (child?.pid && child.exitCode === null) {
+      child.kill()
+    }
+    child = undefined
+    db.close()
+    vi.useRealTimers()
+  })
+
+  async function startWorker(wait: Promise<RuntimeTerminalWait> | RuntimeTerminalWait) {
+    const task = db.createTask({ spec: 'readiness oracle task', runId })
+    const method = ORCHESTRATION_METHODS.find(
+      (candidate) => candidate.name === 'orchestration.workerStart'
+    )
+    if (!method) {
+      throw new Error('workerStart method is not registered')
+    }
+    vi.mocked(runtime.waitForTerminal).mockImplementationOnce(async () => await wait)
+    const result = await method.handler(
+      method.params!.parse({
+        task: task.id,
+        from: 'term_coord',
+        worktree: 'new-child',
+        name: 'readiness-worker',
+        agent: 'codex'
+      }),
+      { runtime }
+    )
+    return { result: result as Record<string, unknown>, task }
+  }
+
+  it('captures a live terminal at timeout instead of treating timeout as a dead launch', async () => {
+    vi.useFakeTimers()
+    vi.mocked(runtime.waitForTerminal).mockRestore()
+    runtimeInternals(runtime).recordPtyWorktree('pty-worker', 'repo::created', { connected: true })
+    runtimeInternals(runtime).handleByPtyId.set('pty-worker', 'term_worker')
+
+    const waiting = runtime.waitForTerminal('term_worker', {
+      condition: 'tui-idle',
+      timeoutMs: 1
+    })
+    const rejected = waiting.catch((error: unknown) => error as Error & { terminalLive?: boolean })
+    await vi.advanceTimersByTimeAsync(1)
+
+    await expect(rejected).resolves.toMatchObject({
+      message: 'timeout',
+      terminalLive: true
+    })
+  })
+
+  it('keeps a live process independently observable and leaves timeout reportable', async () => {
+    const launched = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 30_000)'], {
+      stdio: 'ignore'
+    })
+    child = launched
+    await new Promise<void>((resolve, reject) => {
+      launched.once('spawn', () => resolve())
+      launched.once('error', reject)
+    })
+    expect(launched.pid).toBeDefined()
+    expect(() => process.kill(launched.pid!, 0)).not.toThrow()
+    expect((await runtime.listTerminals()).terminals).toEqual(
+      expect.arrayContaining([expect.objectContaining({ handle: 'term_worker' })])
+    )
+
+    const { result, task } = await startWorker(
+      Promise.reject(
+        Object.assign(new Error('timeout'), {
+          code: 'terminal_wait_timeout',
+          terminalLive: true
+        })
+      )
+    )
+    const dispatch = db.getDispatchContext(task.id)!
+    const worker = db.getWorkerDispatch(dispatch.id)!
+
+    expect(result).toMatchObject({ state: 'outcome_unknown', failedStage: 'agent_readiness' })
+    expect(db.getTask(task.id)).toMatchObject({ status: 'blocked' })
+    expect(dispatch).toMatchObject({ status: 'pending' })
+    expect(dispatch.capability_revoked_at).not.toBeNull()
+    expect(worker).toMatchObject({ state: 'start_unknown', stage: 'agent_readiness' })
+    expect(runtime.sendTerminalAgentPrompt).not.toHaveBeenCalled()
+    expect(() =>
+      db.createStartingWorkerDispatch({
+        taskId: task.id,
+        retryOf: dispatch.id,
+        startOptions: { worktree: 'new-child' },
+        runtimeEpoch: runtime.getRuntimeId()
+      })
+    ).toThrowError(/cannot retry/)
+  })
+
+  it.each([
+    {
+      name: 'exited',
+      wait: {
+        handle: 'term_worker',
+        condition: 'tui-idle',
+        satisfied: false,
+        status: 'exited',
+        exitCode: 1
+      } satisfies RuntimeTerminalWait
+    },
+    {
+      name: 'blocked',
+      wait: {
+        handle: 'term_worker',
+        condition: 'tui-idle',
+        satisfied: false,
+        status: 'running',
+        exitCode: null,
+        blockedReason: 'codex-trust-workspace'
+      } satisfies RuntimeTerminalWait
+    }
+  ])('keeps genuine $name readiness verdicts failed', async ({ wait }) => {
+    const { result, task } = await startWorker(wait)
+    const dispatch = db.getDispatchContext(task.id)!
+    const worker = db.getWorkerDispatch(dispatch.id)!
+
+    expect(result).toMatchObject({ state: 'failed', failedStage: 'agent_readiness' })
+    expect(db.getTask(task.id)).toMatchObject({ status: 'failed' })
+    expect(dispatch).toMatchObject({ status: 'failed' })
+    expect(dispatch.capability_revoked_at).not.toBeNull()
+    expect(worker).toMatchObject({ state: 'failed', stage: 'agent_readiness' })
+  })
+})

--- a/src/main/runtime/rpc/methods/orchestration-worker-topology.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-topology.ts
@@ -271,6 +271,15 @@ export function isUnknownWorkerStartOutcome(error: unknown, stage: string): bool
     error && typeof error === 'object' && typeof (error as { code?: unknown }).code === 'string'
       ? (error as { code: string }).code
       : ''
+  if (
+    code === 'terminal_wait_timeout' &&
+    stage === 'agent_readiness' &&
+    error &&
+    typeof error === 'object' &&
+    (error as { terminalLive?: unknown }).terminalLive === true
+  ) {
+    return true
+  }
   if (code === 'operation_unknown') {
     return true
   }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​205 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​205 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​27 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​25 |

<!-- /orca-pr-loc -->

## Summary

A readiness timeout is absence of a verdict, not proof that the launched agent died. Capture terminal liveness at the timeout boundary and classify only a live agent_readiness timeout as outcome_unknown.

## Evidence

- Historical baseline: c0c893d17165e7327eb0d9bbd8ee01e4ab39209f. Final oracle: 2 failures (bare timeout has no terminalLive; worker state is failed).
- Latest origin/main at validation: a54c27f00d8aca6f35759c378375f07f6fd4fc5c. Identical final oracle: same 2 failures.
- Genuine exited and blocked readiness outcomes pass as failed on both candidate and oracle.
- PR #13642 is closed/unmerged and fixes late shell startup-command delivery, not worker readiness verdicts.

## Change

- PTY and leaf timeout callbacks emit terminal_wait_timeout with terminalLive captured at rejection.
- Worker-start topology maps only live agent_readiness timeout to the existing start_unknown/outcome_unknown path.
- Existing retry fencing rejects retryOf=start_unknown, preventing a second spawn into the occupied worktree.

## Validation

- Candidate oracle: 4/4.
- Focused orchestration suite: 7 files, 89 tests passed.
- pnpm typecheck: passed.
- pnpm lint: passed (including reliability manifest and max-lines ratchet).
- No merge performed.

Closes STA-3844
