### PR TITLE
ci: stop refreshing every apt repo three times to install fish

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -259,14 +259,17 @@ jobs:
           # non-zero and would red this required check over something unrelated to the
           # PR. Every fish outcome is judged by the version gate below instead, so only
           # the zsh install (which has no such gate) stays fatal here.
-          sudo apt-get update || true
           # Why retry only here: adding the PPA is the network-flaky step, and the
           # version gate below is fatal, so a transient Launchpad blip would
           # otherwise red a required check on PRs unrelated to shells.
+          # Why -n: add-apt-repository refreshes every configured repo on its own. With
+          # an update on each side of it this step refreshed them three times over, and
+          # the Azure archive mirror alone costs ~15-30s a pass. The PPA index is the
+          # only thing the repo list gains here, and the single update below fetches it.
           for attempt in 1 2 3; do
-            sudo add-apt-repository -y ppa:fish-shell/release-4 && break
+            sudo add-apt-repository -y -n ppa:fish-shell/release-4 && break
             echo "add-apt-repository attempt ${attempt} failed; retrying" >&2
-            sudo add-apt-repository -y -r ppa:fish-shell/release-4 || true
+            sudo add-apt-repository -y -n -r ppa:fish-shell/release-4 || true
             sleep 5
           done
           sudo apt-get update || true

--- a/config/scripts/pr-workflow-parallelism.test.mjs
+++ b/config/scripts/pr-workflow-parallelism.test.mjs
@@ -96,6 +96,37 @@ describe('PR workflow parallelism', () => {
     }
   })
 
+  it('refreshes the apt index once while adding the fish PPA', () => {
+    const installStep = workflow.jobs.shell_contracts.steps.find(
+      (step) => step.name === 'Install zsh and fish'
+    )
+    // Comment lines mention both commands by name, so count the executed ones only.
+    const commands = installStep.run
+      .split('\n')
+      .filter((line) => !line.trim().startsWith('#'))
+      .join('\n')
+    const updates = commands.match(/apt-get update/g) ?? []
+    // Anchored to the start of a line so the retry message that names the command in
+    // prose is not mistaken for an invocation of it.
+    const addRepoCalls = commands
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => /^(sudo\s+)?add-apt-repository\b/.test(line))
+
+    // add-apt-repository refreshes every configured repo unless told not to, so an
+    // update on each side of it made this step pay for three full passes.
+    expect(updates).toHaveLength(1)
+    expect(addRepoCalls.length).toBeGreaterThan(0)
+    for (const call of addRepoCalls) {
+      expect(call.split(/\s+/)).toContain('-n')
+    }
+    // The one remaining update has to come after the PPA is on the list, or the fish
+    // index it exists to fetch would not be there yet.
+    expect(commands.lastIndexOf('add-apt-repository')).toBeLessThan(
+      commands.indexOf('apt-get update')
+    )
+  })
+
   it('keeps every real-zsh test in the dedicated shell lane', () => {
     const discoveredFiles = globSync(testFilePatterns)
       .filter((testFile) => realZshUsage.test(readFileSync(testFile, 'utf8')))


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​31 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​31 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |

<!-- /orca-pr-loc -->

## What

The `shell contracts` lane refreshed **every configured apt repo three times** to install two shells.

`add-apt-repository` runs its own `apt-get update` unless told not to, and the step had an explicit update on each side of it. Measured on [run `32089257337`](https://github.com/stablyai/orca/actions/runs/32089257337) by the gaps between log lines:

| Phase | Cost |
|---|---|
| `apt-get update` before the PPA | ~15s |
| `add-apt-repository`'s own internal update | ~30s |
| `apt-get update` after the PPA | ~30s |
| `apt-get install -y zsh fish` — the actual point | ~10s |

Each pass re-fetches the full Ubuntu archive through `azure.archive.ubuntu.com`, which is the slow part.

## Change

Pass `-n` so `add-apt-repository` only edits the repo list, and drop the update that ran *before* it — nothing needs a fresh index to add a PPA. The single update after the PPA is kept, because that is the one that actually fetches the fish index the install needs.

The retry loop and the `|| true` tolerance are unchanged, so a transient Launchpad blip still cannot red this required check on an unrelated PR.

## Expected

The step has been running **127–149s** on recent PRs (31s on an older baseline, so it varies with mirror health). Removing two of the three passes should take it to roughly **40–50s**.

## Guard

A contract test asserts the step runs exactly one `apt-get update`, that every `add-apt-repository` invocation carries `-n`, and that the update comes after the PPA is added — otherwise it would fetch an index that isn't there yet.

Verified the guard actually bites: reverting the workflow change makes it fail, restoring it makes it pass. It counts executed lines only, since the surrounding comments and the retry message both mention these commands by name.
