### PR TITLE
fix(terminal): stop the macOS IME forwarder from running on iPadOS

### DIFF
--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts
@@ -579,4 +579,10 @@ describe('isTouchIOSUserAgent', () => {
       isTouchIOSUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36', 5)
     ).toBe(false)
   })
+
+  it('keeps the forwarder on a Mac whose touch peripheral reports a single point', () => {
+    expect(
+      isTouchIOSUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15', 1)
+    ).toBe(false)
+  })
 })

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts
@@ -5,6 +5,7 @@ import {
   clearQueuedInitialCwdAfterFirstPane,
   getPreviousVisibleForTerminalPane,
   isTerminalPaneVisibilityResume,
+  isTouchIOSUserAgent,
   mapRestoredPaneTitlesByPaneId,
   resolvePaneLinkCwd,
   resolvePaneSeedCwd,
@@ -547,5 +548,35 @@ describe('terminal pane visibility resume tracking', () => {
       false
     )
     expect(isTerminalPaneVisibilityResume({ previousIsVisible: false, isVisible: true })).toBe(true)
+  })
+})
+
+describe('isTouchIOSUserAgent', () => {
+  it('is false for a real Mac (Macintosh UA, no touch points)', () => {
+    expect(
+      isTouchIOSUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15', 0)
+    ).toBe(false)
+  })
+
+  it('is true for iPadOS desktop-mode Safari (Macintosh UA plus touch points)', () => {
+    expect(
+      isTouchIOSUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15', 5)
+    ).toBe(true)
+  })
+
+  it('is true for iPhone Safari ("like Mac OS X" UA plus touch points)', () => {
+    expect(
+      isTouchIOSUserAgent(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15',
+        5
+      )
+    ).toBe(true)
+  })
+
+  it('is false for non-Mac UAs regardless of touch points', () => {
+    expect(isTouchIOSUserAgent('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36', 5)).toBe(false)
+    expect(
+      isTouchIOSUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36', 5)
+    ).toBe(false)
   })
 })

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -451,9 +451,11 @@ export function resolvePaneSeedCwd(splitPaneCwd: string | undefined, fallbackCwd
   return splitPaneCwd ?? fallbackCwd
 }
 
-/** iPadOS reports a desktop "Macintosh" UA and iOS reports "like Mac OS X" — maxTouchPoints is the only signal a real Mac never sets. */
+// Why > 1, matching isIOSWebView in mobile/src/terminal/terminal-webview-html.ts: a Mac with a
+// touch peripheral can report exactly 1, and it must keep the forwarder. Real iPads report 5.
+// Why UA rather than that helper's platform check: an iPhone reports platform "iPhone", not "MacIntel".
 export function isTouchIOSUserAgent(userAgent: string, maxTouchPoints: number): boolean {
-  return userAgent.includes('Mac') && maxTouchPoints > 0
+  return userAgent.includes('Mac') && maxTouchPoints > 1
 }
 
 type SplitStartupPayload = { command: string; env?: Record<string, string> }

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -451,6 +451,11 @@ export function resolvePaneSeedCwd(splitPaneCwd: string | undefined, fallbackCwd
   return splitPaneCwd ?? fallbackCwd
 }
 
+/** iPadOS reports a desktop "Macintosh" UA and iOS reports "like Mac OS X" — maxTouchPoints is the only signal a real Mac never sets. */
+export function isTouchIOSUserAgent(userAgent: string, maxTouchPoints: number): boolean {
+  return userAgent.includes('Mac') && maxTouchPoints > 0
+}
+
 type SplitStartupPayload = { command: string; env?: Record<string, string> }
 
 type SplitWithStartupDeps = {
@@ -995,6 +1000,8 @@ export function useTerminalPaneLifecycle({
           !isMac &&
           navigator.userAgent.includes('Linux') &&
           !/Android|CrOS/.test(navigator.userAgent)
+        // Why: gates the forwarder only — isMac stays as-is for the Ctrl+C, clipboard, JIS-yen and 229 policies.
+        const isTouchIOS = isTouchIOSUserAgent(navigator.userAgent, navigator.maxTouchPoints)
         const linuxImeCandidateState = isLinux
           ? installTerminalImeLinuxCandidateState(pane.terminal.element)
           : null
@@ -1006,18 +1013,20 @@ export function useTerminalPaneLifecycle({
           }
         })
         // Why: macOS commits an input source's substituted text through the input event alone, so printable keydowns must not reach xterm's encoder.
-        const imeNativeTextForwarder = isMac
-          ? installTerminalImeNativeTextForwarder({
-              terminalElement: pane.terminal.element,
-              isComposing: () => imeCompositionTracker.isActive(),
-              sendInput: (data) => pane.terminal.input(data),
-              getKittyKeyboardFlags: () =>
-                paneKittyKeyboardModesRef.current.get(pane.id)?.flags ?? 0
-            })
-          : {
-              claimKeyEvent: () => false,
-              dispose: () => undefined
-            }
+        // Not on touch iOS/iPadOS: the forwarder stands aside for IME input via composition events, which iPad Hangul appears not to fire (#13345).
+        const imeNativeTextForwarder =
+          isMac && !isTouchIOS
+            ? installTerminalImeNativeTextForwarder({
+                terminalElement: pane.terminal.element,
+                isComposing: () => imeCompositionTracker.isActive(),
+                sendInput: (data) => pane.terminal.input(data),
+                getKittyKeyboardFlags: () =>
+                  paneKittyKeyboardModesRef.current.get(pane.id)?.flags ?? 0
+              })
+            : {
+                claimKeyEvent: () => false,
+                dispose: () => undefined
+              }
         imeNativeTextForwarderDisposablesRef.current.set(pane.id, imeNativeTextForwarder)
         pane.terminal.attachCustomKeyEventHandler((e) => {
           const linuxCandidateClassification = linuxImeCandidateState?.classifyKeyboardEvent(e) ?? {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​37 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​37 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​23 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​11 |

<!-- /orca-pr-loc -->

Refs #13345 — Korean typed into a terminal from an iPad web client arrives as loose jamo (ㅎㅏㄴㄱㅡㄹ) instead of composed syllables (한글).

## Why the forwarder runs on an iPad at all

`installTerminalImeNativeTextForwarder` is a **macOS** workaround. It is installed from a check that reduces to:

```ts
const isMac = navigator.userAgent.includes('Mac')
```

**Every iOS and iPadOS user agent contains `Mac`** — `Macintosh` in iPad desktop mode, which has been the default since iPadOS 13, and `like Mac OS X` in mobile mode. So a macOS-only workaround installs on every iPad and iPhone web client. `navigator.maxTouchPoints` is the only signal a real Mac never sets.

The Linux branch immediately below already makes the mirror-image exclusion, ruling out Android and CrOS whose user agents both contain `Linux`. The idiom was already in the file; the Mac branch never got the same treatment.

## Why that breaks Hangul

The forwarder claims a printable keydown and delivers the input method's substituted text from the `input` event alone. It is built for **one-shot** native-text substitution — dead keys, smart punctuation — not for multi-keystroke composition, and it stands aside for composition by checking `isComposing` and `compositionActive` in `isNativeTextKeydown`.

On desktop macOS a genuine CJK composition session fires `compositionstart`, so the forwarder correctly steps aside. If those events do not fire on touch iOS/iPadOS for hardware-keyboard input, nothing ever sets `compositionActive`, so **every jamo keydown is independently claimed and forwarded as its own commit** — which is exactly six separate jamo for `한글`, matching the report.

## Scope of the change

The gate applies to the forwarder install **only**. `isMac` itself is untouched, and its other five consumers keep current behaviour deliberately:

| consumer | why it should still treat an iPad like a Mac |
| --- | --- |
| `xterm-bypass-policy.ts:127` standalone 229 keydown | this is the path that must remain open for xterm's own composition handling to work |
| `xterm-bypass-policy.ts:214` Ctrl+C interrupt | matches iPadOS keyboard conventions |
| `xterm-bypass-policy.ts:248-280` Mod+C / Mod+V clipboard bypass | an iPad hardware keyboard uses Cmd, like a Mac |
| `terminal-jis-yen-input.ts:38` JIS yen input | unrelated to touch |

Redefining `isMac` would have changed all of them. A narrow `isTouchIOSUserAgent` predicate does not.

Without the forwarder, xterm's own composition path plus the deferred textarea diff becomes the sole delivery mechanism — **which is already the arrangement on Linux**, where no forwarder exists and CJK input works. That is the precedent for believing the native path suffices.

## Remote / SSH

The check reads the renderer's own `navigator`, so it describes the client doing the typing, not the PTY host. Correct identically for local, SSH and paired-web sessions — the iPad reaches Orca as a paired web client, and it is the iPad's WebKit being detected.

## Tests

Four cases on the extracted predicate: real Mac UA with 0 touch points, iPad desktop-mode `Macintosh` UA with touch points, iPhone `like Mac OS X` UA with touch points, and non-Mac UAs regardless of touch points.

```
use-terminal-pane-lifecycle.test.ts + terminal-ime-native-text-forwarder.test.ts
Test Files  2 passed (2)
     Tests  84 passed (84)
```

oxlint and oxfmt clean.

## Not verified

**No hardware capture.** The claim that composition events are absent on iPadOS is the mechanism the code supports and the only one that matches the reported symptom, but no on-device trace confirms it. I have an iPad capture pending; if it shows composition events firing normally, the mechanism above is wrong and this explanation needs revisiting.

**The platform detection stands on its own regardless.** A macOS-specific workaround installing on every iPad and iPhone is a defect whatever the Hangul mechanism turns out to be, and that half is not in doubt.

## Follow-up, not fixed here

`terminal-ime-input-context-refresh.ts` gates a separate macOS NSTextInputContext blur/refocus behind the same user-agent check, so it has the identical collision. Narrower trigger surface — split-pane focus handoff and app reactivation rather than every keystroke — so it is left for a follow-up rather than folded in.
