### PR TITLE
fix(mobile): after closing a tab, return to the previous one

### DIFF
--- a/mobile/src/session/active-session-tab.ts
+++ b/mobile/src/session/active-session-tab.ts
@@ -1,3 +1,5 @@
+import { pickNextTabAfterClose } from '../../../src/shared/session-tab-close-successor'
+
 type SessionTabLike = {
   id: string
   isActive: boolean
@@ -21,10 +23,22 @@ export function resolveActiveSessionTab<T extends SessionTabLike>(
   opts: {
     pendingActiveSessionTabId: string | null
     selectedSessionTabId: string | null
+    previousActiveTabId?: string | null
+    recentTabIds?: readonly string[]
     navigationIntent?: 'follow'
   }
 ): ResolveActiveSessionTabResult<T> {
-  const snapshotActive = tabs.find((tab) => tab.isActive) ?? tabs[0] ?? null
+  const previousActive = opts.previousActiveTabId
+    ? (tabs.find((tab) => tab.id === opts.previousActiveTabId) ?? null)
+    : null
+  const snapshotActive =
+    tabs.find((tab) => tab.isActive) ??
+    previousActive ??
+    (opts.previousActiveTabId
+      ? pickNextTabAfterClose(tabs, opts.previousActiveTabId, opts.recentTabIds)
+      : null) ??
+    tabs[0] ??
+    null
   const pendingActiveSessionTabId = opts.pendingActiveSessionTabId
   // Why: targeted follow is the only host action allowed to supersede phone-local intent.
   if (opts.navigationIntent === 'follow') {

--- a/mobile/src/session/mobile-session-last-tab-close.test.ts
+++ b/mobile/src/session/mobile-session-last-tab-close.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+import type { MobileSessionTab } from './mobile-session-route-types'
+import type { MobileSessionContentCreateActionsModel } from './use-mobile-session-content-create-actions'
+import { useMobileSessionCloseActions } from './use-mobile-session-close-actions'
 import { readMobileSessionRouteSourceFamily } from './mobile-session-route-source-family.test-support'
 
 const sessionRouteSource = readMobileSessionRouteSourceFamily()
@@ -46,5 +49,50 @@ describe('mobile session last-tab close', () => {
 
     expect(block).toContain('pickNextTabAfterClose')
     expect(block).toContain('switchSessionTab(nextTab)')
+  })
+
+  it('activates the MRU successor for an active close but leaves a background close alone', async () => {
+    const tab = (id: string, isActive: boolean): MobileSessionTab => ({
+      type: 'markdown',
+      id,
+      title: id,
+      filePath: `/${id}.md`,
+      relativePath: `${id}.md`,
+      isDirty: false,
+      isActive,
+      documentVersion: '1'
+    })
+    const tabs = [tab('a', false), tab('b', true), tab('c', false)]
+    const sessionTabsRef = { current: tabs }
+    const switchSessionTab = vi.fn()
+    const setActiveSessionTabId = vi.fn()
+    const scope = {
+      client: { sendRequest: vi.fn(async () => ({ ok: true })) },
+      worktreeId: 'worktree',
+      sessionTabsRef,
+      setSessionTabs: vi.fn(),
+      reconcileBufferedDraftsRef: { current: vi.fn() },
+      closedTabTombstonesRef: { current: new Map<string, number>() },
+      activeSessionTabIdRef: { current: 'b' },
+      recentSessionTabIdsRef: { current: ['a', 'b'] },
+      selectedSessionTabIdRef: { current: 'b' },
+      setActiveSessionTabId,
+      switchSessionTab
+    } as unknown as MobileSessionContentCreateActionsModel
+    const { handleCloseSessionTab } = useMobileSessionCloseActions(scope)
+
+    await handleCloseSessionTab(tabs[1])
+    expect(switchSessionTab).toHaveBeenCalledWith(tabs[0])
+    expect(setActiveSessionTabId).not.toHaveBeenCalledWith(null)
+
+    sessionTabsRef.current = tabs
+    scope.activeSessionTabIdRef.current = 'b'
+    scope.recentSessionTabIdsRef.current = ['a', 'b']
+    switchSessionTab.mockClear()
+    setActiveSessionTabId.mockClear()
+
+    await handleCloseSessionTab(tabs[0])
+    expect(switchSessionTab).not.toHaveBeenCalled()
+    expect(setActiveSessionTabId).not.toHaveBeenCalled()
   })
 })

--- a/mobile/src/session/mobile-session-last-tab-close.test.ts
+++ b/mobile/src/session/mobile-session-last-tab-close.test.ts
@@ -18,9 +18,7 @@ describe('mobile session last-tab close', () => {
     const end = sessionRouteSource.indexOf('const bulkCloseActions', start)
     const block = sessionRouteSource.slice(start, end)
 
-    expect(block).toContain(
-      'activeSessionTabIdRef.current === tab.id || remainingTabs.length === 0'
-    )
+    expect(block).toContain('remainingTabs.length === 0')
     expect(block).toContain('activeSessionTabIdRef.current = null')
     expect(block).toContain('activeHandleRef.current = null')
     expect(block).toContain(
@@ -39,5 +37,14 @@ describe('mobile session last-tab close', () => {
     expect(followsHost).toBeGreaterThanOrEqual(0)
     expect(pendingHandle).toBeGreaterThan(followsHost)
     expect(block.slice(pendingHandle, pendingHandle + 150)).toContain('? null')
+  })
+
+  it('activates the previous viewed tab after closing the current one', () => {
+    const start = sessionRouteSource.indexOf('async function handleCloseSessionTab')
+    const end = sessionRouteSource.indexOf('const bulkCloseActions', start)
+    const block = sessionRouteSource.slice(start, end)
+
+    expect(block).toContain('pickNextTabAfterClose')
+    expect(block).toContain('switchSessionTab(nextTab)')
   })
 })

--- a/mobile/src/session/use-mobile-session-close-actions.ts
+++ b/mobile/src/session/use-mobile-session-close-actions.ts
@@ -1,4 +1,5 @@
 import type { MobileSessionTab, Terminal } from './mobile-session-route-types'
+import { pickNextTabAfterClose } from '../../../src/shared/session-tab-close-successor'
 import type { MobileSessionContentCreateActionsModel } from './use-mobile-session-content-create-actions'
 
 export function useMobileSessionCloseActions(scope: MobileSessionContentCreateActionsModel) {
@@ -16,6 +17,8 @@ export function useMobileSessionCloseActions(scope: MobileSessionContentCreateAc
     setActiveHandle,
     setActiveSessionTabId,
     activeSessionTabIdRef,
+    recentSessionTabIdsRef,
+    switchSessionTab,
     selectedSessionTabIdRef,
     renameTarget,
     setRenameTarget,
@@ -121,16 +124,35 @@ export function useMobileSessionCloseActions(scope: MobileSessionContentCreateAc
         setSessionTabs(remainingTabs)
         // Why: tombstone the closed tab and rely on the snapshot, not a blind refetch that often re-added the not-yet-closed tab.
         closedTabTombstonesRef.current.set(tab.id, Date.now() + 10_000)
+        recentSessionTabIdsRef.current = recentSessionTabIdsRef.current.filter(
+          (id) => id !== tab.id
+        )
         // Why: bulk close re-activates the anchor before awaiting each close;
         // the render-synced ref sees that switch while this closure would not,
         // so comparing against the ref keeps the anchor from being nulled out.
-        if (activeSessionTabIdRef.current === tab.id || remainingTabs.length === 0) {
+        if (remainingTabs.length === 0) {
           activeSessionTabTypeRef.current = null
           selectedSessionTabIdRef.current = null
           activeSessionTabIdRef.current = null
           setActiveSessionTabId(null)
           activeHandleRef.current = null
           setActiveHandle(null)
+        } else if (activeSessionTabIdRef.current === tab.id) {
+          const nextTab = pickNextTabAfterClose(
+            remainingTabs,
+            tab.id,
+            recentSessionTabIdsRef.current
+          )
+          if (nextTab) {
+            switchSessionTab(nextTab)
+          } else {
+            activeSessionTabTypeRef.current = null
+            selectedSessionTabIdRef.current = null
+            activeSessionTabIdRef.current = null
+            setActiveSessionTabId(null)
+            activeHandleRef.current = null
+            setActiveHandle(null)
+          }
         }
       }
     } catch {

--- a/mobile/src/session/use-mobile-session-screen-state.ts
+++ b/mobile/src/session/use-mobile-session-screen-state.ts
@@ -59,6 +59,8 @@ export function useMobileSessionScreenState(scope: MobileSessionFoundationModel)
   const [coveredStreamRevision, setCoveredStreamRevision] = useState(0)
   const [activeSessionTabId, setActiveSessionTabId] = useState<string | null>(null)
   const activeSessionTabIdRef = useRef<string | null>(null)
+  // Why: phone tab switches are caller-only and do not update host recentTabIds.
+  const recentSessionTabIdsRef = useRef<string[]>([])
   // Preserve an explicit phone tab pick while a host snapshot is transiently incomplete.
   const selectedSessionTabIdRef = useRef<string | null>(null)
   // Auto-scroll the tab strip so the desktop-synced active tab is revealed without a manual scroll.
@@ -159,6 +161,7 @@ export function useMobileSessionScreenState(scope: MobileSessionFoundationModel)
     activeSessionTabId,
     setActiveSessionTabId,
     activeSessionTabIdRef,
+    recentSessionTabIdsRef,
     selectedSessionTabIdRef,
     tabStripRef,
     tabStripOffsetRef,

--- a/mobile/src/session/use-mobile-session-startup.ts
+++ b/mobile/src/session/use-mobile-session-startup.ts
@@ -32,6 +32,7 @@ export function useMobileSessionStartup(scope: MobileSessionKeyboardStateModel) 
     activeSessionTabTypeRef,
     pendingActiveSessionTabIdRef,
     selectedSessionTabIdRef,
+    recentSessionTabIdsRef,
     pendingActiveTerminalHandleRef,
     pendingBrowserFocusPageIdRef,
     pendingTerminalActivationAttemptRef,
@@ -54,6 +55,7 @@ export function useMobileSessionStartup(scope: MobileSessionKeyboardStateModel) 
     activeSessionTabTypeRef.current = null
     pendingActiveSessionTabIdRef.current = null
     selectedSessionTabIdRef.current = null
+    recentSessionTabIdsRef.current = []
     pendingActiveTerminalHandleRef.current = null
     pendingBrowserFocusPageIdRef.current = null
     pendingTerminalActivationAttemptRef.current = null

--- a/mobile/src/session/use-mobile-session-tab-application.ts
+++ b/mobile/src/session/use-mobile-session-tab-application.ts
@@ -13,6 +13,7 @@ import {
 import type { SessionTabsApplyOutcome } from './mobile-session-tabs-stream-health'
 import { getActiveTabIdForHandle } from './mobile-session-route-helpers'
 import { resolveActiveSessionTab } from './active-session-tab'
+import { rememberRecentTabId } from '../../../src/shared/session-tab-close-successor'
 import type { MobileSessionTab, SessionTabsResult } from './mobile-session-route-types'
 import type { MobileSessionTerminalListModel } from './use-mobile-session-terminal-list'
 
@@ -31,6 +32,7 @@ export function useMobileSessionTabApplication(scope: MobileSessionTerminalListM
     setActiveHandle,
     setActiveSessionTabId,
     activeSessionTabIdRef,
+    recentSessionTabIdsRef,
     selectedSessionTabIdRef,
     markdownDocsRef,
     initializedHandlesRef,
@@ -59,6 +61,9 @@ export function useMobileSessionTabApplication(scope: MobileSessionTerminalListM
         Date.now()
       )
       const presentTabIds = new Set(nextTabs.map((tab) => tab.id))
+      recentSessionTabIdsRef.current = recentSessionTabIdsRef.current.filter((id) =>
+        presentTabIds.has(id)
+      )
       const orphanedDraftTabs: MobileSessionTab[] = []
       const currentMarkdownDocs = markdownDocsRef.current
       const currentSessionTabs = sessionTabsRef.current
@@ -118,6 +123,8 @@ export function useMobileSessionTabApplication(scope: MobileSessionTerminalListM
       }
       const resolved = resolveActiveSessionTab(nextTabs, {
         pendingActiveSessionTabId,
+        previousActiveTabId: activeSessionTabIdRef.current,
+        recentTabIds: recentSessionTabIdsRef.current,
         selectedSessionTabId: selectedSessionTabIdRef.current,
         navigationIntent: result.navigationIntent
       })
@@ -158,6 +165,12 @@ export function useMobileSessionTabApplication(scope: MobileSessionTerminalListM
           const nextActiveTabId = getActiveTabIdForHandle(nextTabs, pendingActiveTerminalHandle)
           activeSessionTabIdRef.current = nextActiveTabId
           setActiveSessionTabId(nextActiveTabId)
+          if (nextActiveTabId) {
+            recentSessionTabIdsRef.current = rememberRecentTabId(
+              recentSessionTabIdsRef.current,
+              nextActiveTabId
+            )
+          }
           activeSessionTabTypeRef.current = 'terminal'
           // Why: every other active-handle branch assigns the ref alongside the
           // state. Leaving it stale here makes `covered` resolve against the wrong
@@ -177,6 +190,12 @@ export function useMobileSessionTabApplication(scope: MobileSessionTerminalListM
       activeSessionTabTypeRef.current = active?.type ?? null
       activeSessionTabIdRef.current = active?.id ?? null
       setActiveSessionTabId(active?.id ?? null)
+      if (active?.id) {
+        recentSessionTabIdsRef.current = rememberRecentTabId(
+          recentSessionTabIdsRef.current,
+          active.id
+        )
+      }
       if (active?.type === 'terminal') {
         if (typeof active.terminal !== 'string') {
           const previous = activeHandleRef.current

--- a/mobile/src/session/use-mobile-session-tab-switching.ts
+++ b/mobile/src/session/use-mobile-session-tab-switching.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react'
 import { triggerSelection } from '../platform/haptics'
 import { activateMobileSessionTab } from './mobile-session-tab-activation'
+import { rememberRecentTabId } from '../../../src/shared/session-tab-close-successor'
 import type { MobileSessionTab } from './mobile-session-route-types'
 import type { MobileSessionKeyboardStateModel } from './use-mobile-session-keyboard-state'
 
@@ -12,6 +13,7 @@ export function useMobileSessionTabSwitching(scope: MobileSessionKeyboardStateMo
     defaultTerminalHandlesToLiveInput,
     setActiveHandle,
     setActiveSessionTabId,
+    recentSessionTabIdsRef,
     markdownDocs,
     terminalUnsubsRef,
     initializedHandlesRef,
@@ -34,6 +36,12 @@ export function useMobileSessionTabSwitching(scope: MobileSessionKeyboardStateMo
         (tab): tab is Extract<MobileSessionTab, { type: 'terminal' }> =>
           tab.type === 'terminal' && tab.terminal === handle
       )
+      if (matchingTab) {
+        recentSessionTabIdsRef.current = rememberRecentTabId(
+          recentSessionTabIdsRef.current,
+          matchingTab.id
+        )
+      }
       terminalDiagnosticsRef.current.tabSwitch('terminal', matchingTab?.id ?? '', false, handle)
       pendingActiveSessionTabIdRef.current = matchingTab?.id ?? null
       pendingActiveTerminalHandleRef.current = handle
@@ -77,6 +85,7 @@ export function useMobileSessionTabSwitching(scope: MobileSessionKeyboardStateMo
 
   const switchSessionTab = useCallback(
     (tab: MobileSessionTab) => {
+      recentSessionTabIdsRef.current = rememberRecentTabId(recentSessionTabIdsRef.current, tab.id)
       if (tab.type === 'terminal') {
         if (typeof tab.terminal === 'string') {
           switchTab(tab.terminal)

--- a/src/main/runtime/mobile-session-terminal-retirement.ts
+++ b/src/main/runtime/mobile-session-terminal-retirement.ts
@@ -121,7 +121,9 @@ function chooseGroupActiveTab(
   }
   const recent = (group.recentTabIds ?? []).toReversed().find((tabId) => retainedTabIds.has(tabId))
   // Why: no previous visit → most recently added remaining tab, not the leftmost.
-  return recent ?? [...group.tabOrder].toReversed().find((tabId) => retainedTabIds.has(tabId)) ?? null
+  return (
+    recent ?? [...group.tabOrder].toReversed().find((tabId) => retainedTabIds.has(tabId)) ?? null
+  )
 }
 
 export function repairMobileSessionTabGroupsAfterRetirement(
@@ -176,7 +178,8 @@ function chooseActiveSurface(
     pickNextTabAfterClose(
       tabs,
       previousActiveId ?? '',
-      collectRecentTabIdsFromGroups(groups)
+      collectRecentTabIdsFromGroups(groups),
+      topLevelTabId
     )
   )
 }

--- a/src/main/runtime/mobile-session-terminal-retirement.ts
+++ b/src/main/runtime/mobile-session-terminal-retirement.ts
@@ -5,6 +5,10 @@ import type {
   RuntimeMobileSessionTabsSnapshot,
   RuntimeMobileSessionTerminalTab
 } from '../../shared/runtime-types'
+import {
+  collectRecentTabIdsFromGroups,
+  pickNextTabAfterClose
+} from '../../shared/session-tab-close-successor'
 import type { TabGroupLayoutNode } from '../../shared/tab-types'
 import type {
   TerminalLayoutSnapshot,
@@ -116,7 +120,8 @@ function chooseGroupActiveTab(
     return group.activeTabId
   }
   const recent = (group.recentTabIds ?? []).toReversed().find((tabId) => retainedTabIds.has(tabId))
-  return recent ?? group.tabOrder.find((tabId) => retainedTabIds.has(tabId)) ?? null
+  // Why: no previous visit → most recently added remaining tab, not the leftmost.
+  return recent ?? [...group.tabOrder].toReversed().find((tabId) => retainedTabIds.has(tabId)) ?? null
 }
 
 export function repairMobileSessionTabGroupsAfterRetirement(
@@ -168,8 +173,11 @@ function chooseActiveSurface(
         tabs.find((tab) => topLevelTabId(tab) === activeTopLevelId))
       : undefined) ??
     tabs.find((tab) => tab.isActive) ??
-    tabs[0] ??
-    null
+    pickNextTabAfterClose(
+      tabs,
+      previousActiveId ?? '',
+      collectRecentTabIdsFromGroups(groups)
+    )
   )
 }
 

--- a/src/main/runtime/orca-runtime-close-headless-mobile-terminal-tab.ts
+++ b/src/main/runtime/orca-runtime-close-headless-mobile-terminal-tab.ts
@@ -7,6 +7,10 @@ import type {
   RuntimeMobileSessionTerminalTab
 } from '../../shared/runtime-types'
 import { parseAppSshPtyId } from '../../shared/ssh-pty-id'
+import {
+  collectRecentTabIdsFromGroups,
+  pickNextTabAfterClose
+} from '../../shared/session-tab-close-successor'
 import { buildHeadlessMobileSessionTabGroups } from './mobile-session-layout-projection'
 import { appendRetiredTerminalSurfaceProofs } from './mobile-session-terminal-retirement-proof'
 import type { RuntimePtyWorktreeRecord } from './runtime-terminal-state-records'
@@ -85,7 +89,14 @@ export class OrcaRuntimeWithCloseHeadlessMobileTerminalTab extends OrcaRuntimeWi
       }
       return false
     })
-    const active = nextTabs.find((candidate) => candidate.isActive) ?? nextTabs[0] ?? null
+    const active =
+      nextTabs.find((candidate) => candidate.isActive) ??
+      pickNextTabAfterClose(
+        nextTabs,
+        closedParentTabId,
+        collectRecentTabIdsFromGroups(snapshot.tabGroups),
+        (candidate) => (candidate.type === 'terminal' ? candidate.parentTabId : candidate.id)
+      )
     const nextSnapshot: RuntimeMobileSessionTabsSnapshot = {
       ...snapshot,
       publicationEpoch: `headless:${Date.now().toString(36)}`,

--- a/src/shared/session-tab-close-successor.test.ts
+++ b/src/shared/session-tab-close-successor.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import {
+  collectRecentTabIdsFromGroups,
+  pickNextTabAfterClose,
+  pickNextTabIdAfterClose,
+  rememberRecentTabId
+} from './session-tab-close-successor'
+
+describe('rememberRecentTabId', () => {
+  it('appends a newly viewed tab and moves repeats to the tail', () => {
+    expect(rememberRecentTabId(['a', 'b'], 'c')).toEqual(['a', 'b', 'c'])
+    expect(rememberRecentTabId(['a', 'b', 'c'], 'a')).toEqual(['b', 'c', 'a'])
+    expect(rememberRecentTabId(['a', 'b'], 'b')).toEqual(['a', 'b'])
+  })
+})
+
+describe('pickNextTabIdAfterClose', () => {
+  it('returns the previously viewed remaining tab', () => {
+    expect(
+      pickNextTabIdAfterClose({
+        remainingTabIds: ['term', 'doc-a'],
+        closingTabId: 'doc-b',
+        recentTabIds: ['term', 'doc-a', 'doc-b']
+      })
+    ).toBe('doc-a')
+  })
+
+  it('falls back to the most recently added remaining tab when there is no previous visit', () => {
+    expect(
+      pickNextTabIdAfterClose({
+        remainingTabIds: ['term', 'doc-a'],
+        closingTabId: 'doc-b',
+        recentTabIds: ['doc-b']
+      })
+    ).toBe('doc-a')
+    expect(
+      pickNextTabIdAfterClose({
+        remainingTabIds: ['term', 'doc-a'],
+        closingTabId: 'doc-b'
+      })
+    ).toBe('doc-a')
+  })
+
+  it('does not default to the leftmost remaining tab when a previous visit exists', () => {
+    expect(
+      pickNextTabIdAfterClose({
+        remainingTabIds: ['leftmost', 'middle', 'right'],
+        closingTabId: 'current',
+        recentTabIds: ['leftmost', 'middle', 'current']
+      })
+    ).toBe('middle')
+  })
+})
+
+describe('pickNextTabAfterClose', () => {
+  it('returns the matching remaining tab object', () => {
+    const remaining = [{ id: 'a' }, { id: 'b' }]
+    expect(pickNextTabAfterClose(remaining, 'c', ['a', 'c'])).toEqual({ id: 'a' })
+    expect(pickNextTabAfterClose(remaining, 'c', [])).toEqual({ id: 'b' })
+  })
+})
+
+describe('collectRecentTabIdsFromGroups', () => {
+  it('merges group MRU stacks in visit order', () => {
+    expect(
+      collectRecentTabIdsFromGroups([
+        { recentTabIds: ['a', 'b'] },
+        { recentTabIds: ['c', 'a'] }
+      ])
+    ).toEqual(['b', 'c', 'a'])
+  })
+})

--- a/src/shared/session-tab-close-successor.test.ts
+++ b/src/shared/session-tab-close-successor.test.ts
@@ -58,15 +58,27 @@ describe('pickNextTabAfterClose', () => {
     expect(pickNextTabAfterClose(remaining, 'c', ['a', 'c'])).toEqual({ id: 'a' })
     expect(pickNextTabAfterClose(remaining, 'c', [])).toEqual({ id: 'b' })
   })
+
+  it('selects by a top-level id and returns the matching leaf tab', () => {
+    const remaining = [
+      { id: 'parent-b::left', parentTabId: 'parent-b' },
+      { id: 'parent-c::left', parentTabId: 'parent-c' }
+    ]
+    expect(
+      pickNextTabAfterClose(
+        remaining,
+        'parent-a',
+        ['parent-c', 'parent-b'],
+        (tab) => tab.parentTabId
+      )
+    ).toEqual(remaining[0])
+  })
 })
 
 describe('collectRecentTabIdsFromGroups', () => {
   it('merges group MRU stacks in visit order', () => {
     expect(
-      collectRecentTabIdsFromGroups([
-        { recentTabIds: ['a', 'b'] },
-        { recentTabIds: ['c', 'a'] }
-      ])
+      collectRecentTabIdsFromGroups([{ recentTabIds: ['a', 'b'] }, { recentTabIds: ['c', 'a'] }])
     ).toEqual(['b', 'c', 'a'])
   })
 })

--- a/src/shared/session-tab-close-successor.ts
+++ b/src/shared/session-tab-close-successor.ts
@@ -1,5 +1,8 @@
 /** Push `tabId` to the tail of the MRU stack (most recently viewed). */
-export function rememberRecentTabId(recent: readonly string[] | undefined, tabId: string): string[] {
+export function rememberRecentTabId(
+  recent: readonly string[] | undefined,
+  tabId: string
+): string[] {
   const base = recent ?? []
   if (base.at(-1) === tabId) {
     return [...base]
@@ -29,17 +32,18 @@ export function pickNextTabIdAfterClose(args: {
   return args.remainingTabIds.at(-1) ?? null
 }
 
-export function pickNextTabAfterClose<T extends { id: string }>(
+export function pickNextTabAfterClose<T>(
   remaining: readonly T[],
   closingTabId: string,
-  recentTabIds?: readonly string[]
+  recentTabIds?: readonly string[],
+  getTabId: (tab: T) => string = (tab) => (tab as { id: string }).id
 ): T | null {
   const nextId = pickNextTabIdAfterClose({
-    remainingTabIds: remaining.map((tab) => tab.id),
+    remainingTabIds: remaining.map(getTabId),
     closingTabId,
     recentTabIds
   })
-  return nextId ? (remaining.find((tab) => tab.id === nextId) ?? null) : null
+  return nextId ? (remaining.find((tab) => getTabId(tab) === nextId) ?? null) : null
 }
 
 export function collectRecentTabIdsFromGroups(

--- a/src/shared/session-tab-close-successor.ts
+++ b/src/shared/session-tab-close-successor.ts
@@ -1,0 +1,58 @@
+/** Push `tabId` to the tail of the MRU stack (most recently viewed). */
+export function rememberRecentTabId(recent: readonly string[] | undefined, tabId: string): string[] {
+  const base = recent ?? []
+  if (base.at(-1) === tabId) {
+    return [...base]
+  }
+  return [...base.filter((id) => id !== tabId), tabId]
+}
+
+/**
+ * After closing `closingTabId`, pick the next tab id.
+ * Prefer the previously viewed tab still in `remainingTabIds` (MRU predecessor).
+ * If there is no previous visit, use the most recently added remaining tab
+ * (last in strip order), never the leftmost by default.
+ */
+export function pickNextTabIdAfterClose(args: {
+  remainingTabIds: readonly string[]
+  closingTabId: string
+  recentTabIds?: readonly string[]
+}): string | null {
+  const remaining = new Set(args.remainingTabIds)
+  const recent = args.recentTabIds ?? []
+  for (let index = recent.length - 1; index >= 0; index -= 1) {
+    const id = recent[index]
+    if (id !== args.closingTabId && remaining.has(id)) {
+      return id
+    }
+  }
+  return args.remainingTabIds.at(-1) ?? null
+}
+
+export function pickNextTabAfterClose<T extends { id: string }>(
+  remaining: readonly T[],
+  closingTabId: string,
+  recentTabIds?: readonly string[]
+): T | null {
+  const nextId = pickNextTabIdAfterClose({
+    remainingTabIds: remaining.map((tab) => tab.id),
+    closingTabId,
+    recentTabIds
+  })
+  return nextId ? (remaining.find((tab) => tab.id === nextId) ?? null) : null
+}
+
+export function collectRecentTabIdsFromGroups(
+  groups: readonly { recentTabIds?: readonly string[] }[] | undefined
+): string[] {
+  if (!groups || groups.length === 0) {
+    return []
+  }
+  let merged: string[] = []
+  for (const group of groups) {
+    for (const id of group.recentTabIds ?? []) {
+      merged = rememberRecentTabId(merged, id)
+    }
+  }
+  return merged
+}


### PR DESCRIPTION
## ELI5

If you close a document on your phone, Orca used to jump to the leftmost tab. It now goes back to the tab you were looking at before, and only if you never visited another tab does it land on the newest remaining one.

## What Changed

- Remember phone-side tab visits even when activation is caller-only.
- After Close, activate the previous visit if it is still open; otherwise the most recently added remaining tab.
- Stop using `tabs[0]` as the snapshot / headless-close fallback.

## Why

Phone switches do not update host `recentTabIds`. Close also cleared the local active tab, so the next snapshot picked the leftmost remaining tab.

## Linked Issue

Fixes #15219

## Visual Proof

N/A — mobile session tab selection after close. Covered by unit tests for previous-visit vs newest-remaining successor selection.