### PR TITLE
fix(browser): stop the auth-host UA write from cancelling redirects

### DIFF
--- a/src/main/browser/browser-manager-auth-user-agent.test.ts
+++ b/src/main/browser/browser-manager-auth-user-agent.test.ts
@@ -233,4 +233,149 @@ describe('browserManager', () => {
     popupDidStartNavigation(null, 'https://accounts.google.com/v3/signin/identifier', false, true)
     expect(popupSetUserAgent).not.toHaveBeenCalled()
   })
+
+  // Why: WebContents.setUserAgent() from will-redirect makes Chromium cancel the in-flight navigation
+  // (ERR_ABORTED) and replay the original request. A "Sign in with Google" button POSTs to the
+  // provider and lands on accounts.google.com only by redirect, so the replay never reproduces it and
+  // the tab is left blank. Verified against Electron 43.1.0: the server sees the original request twice.
+  it('retargets the auth-host UA over CDP during a redirect instead of cancelling it', async () => {
+    const sendCommand = vi.fn(async () => undefined)
+    const guest = {
+      id: 418,
+      isDestroyed: vi.fn(() => false),
+      getType: vi.fn(() => 'webview'),
+      setBackgroundThrottling: guestSetBackgroundThrottlingMock,
+      setWindowOpenHandler: guestSetWindowOpenHandlerMock,
+      on: guestOnMock,
+      off: guestOffMock,
+      openDevTools: guestOpenDevToolsMock,
+      getURL: vi.fn(() => 'https://mail.google.com/'),
+      getUserAgent: vi.fn(() => guestBaseUserAgent),
+      setUserAgent: vi.fn(),
+      debugger: { isAttached: vi.fn(() => true), sendCommand },
+      session: { getUserAgent: vi.fn(() => guestBaseUserAgent) }
+    }
+    webContentsFromIdMock.mockReturnValue(guest)
+
+    browserManager.attachGuestPolicies(guest as never)
+    browserManager.registerGuest({
+      browserPageId: 'browser-redirect-ua',
+      webContentsId: guest.id,
+      rendererWebContentsId
+    })
+    const willRedirect = guestOnMock.mock.calls.find(
+      ([event]) => event === 'will-redirect'
+    )?.[1] as (event: unknown, url: string, isInPlace: boolean, isMainFrame: boolean) => void
+    sendCommand.mockClear()
+
+    willRedirect(
+      { preventDefault: vi.fn() },
+      'https://accounts.google.com/v3/signin/identifier',
+      false,
+      true
+    )
+
+    expect(guest.setUserAgent).not.toHaveBeenCalled()
+    expect(sendCommand).toHaveBeenCalledWith('Emulation.setUserAgentOverride', {
+      userAgent: googleAuthUserAgent()
+    })
+
+    // Why: the CDP override outranks the WebContents UA, so getUserAgent() still reports the base
+    // identity. Leaving the auth host must read the override, not that stale value, or the guest
+    // keeps presenting Firefox on every later host.
+    sendCommand.mockClear()
+    const didStartNavigation = guestOnMock.mock.calls.find(
+      ([event]) => event === 'did-start-navigation'
+    )?.[1] as (event: unknown, url: string, isInPlace: boolean, isMainFrame: boolean) => void
+    didStartNavigation(null, 'https://example.com/', false, true)
+
+    expect(guest.setUserAgent).not.toHaveBeenCalled()
+    expect(sendCommand).toHaveBeenCalledWith('Emulation.setUserAgentOverride', {
+      userAgent: guestBaseUserAgent
+    })
+  })
+
+  // Why: a redirect must never be cancelled to keep the identity in sync. Without a debugger there is
+  // no cancel-free write available, and a stale navigator.userAgent is recoverable where a dead
+  // navigation is not.
+  it('leaves a redirect alone when no debugger is attached to write the UA', () => {
+    const guest = {
+      id: 419,
+      isDestroyed: vi.fn(() => false),
+      getType: vi.fn(() => 'webview'),
+      setBackgroundThrottling: guestSetBackgroundThrottlingMock,
+      setWindowOpenHandler: guestSetWindowOpenHandlerMock,
+      on: guestOnMock,
+      off: guestOffMock,
+      openDevTools: guestOpenDevToolsMock,
+      getURL: vi.fn(() => 'https://mail.google.com/'),
+      getUserAgent: vi.fn(() => guestBaseUserAgent),
+      setUserAgent: vi.fn(),
+      debugger: { isAttached: vi.fn(() => false), sendCommand: vi.fn() },
+      session: { getUserAgent: vi.fn(() => guestBaseUserAgent) }
+    }
+    webContentsFromIdMock.mockReturnValue(guest)
+
+    browserManager.attachGuestPolicies(guest as never)
+    browserManager.registerGuest({
+      browserPageId: 'browser-redirect-no-debugger',
+      webContentsId: guest.id,
+      rendererWebContentsId
+    })
+    const willRedirect = guestOnMock.mock.calls.find(
+      ([event]) => event === 'will-redirect'
+    )?.[1] as (event: unknown, url: string, isInPlace: boolean, isMainFrame: boolean) => void
+
+    willRedirect(
+      { preventDefault: vi.fn() },
+      'https://accounts.google.com/v3/signin/identifier',
+      false,
+      true
+    )
+
+    expect(guest.setUserAgent).not.toHaveBeenCalled()
+    expect(guest.debugger.sendCommand).not.toHaveBeenCalledWith(
+      'Emulation.setUserAgentOverride',
+      expect.anything()
+    )
+  })
+
+  // Why: a direct load reaches did-start-navigation before the request is dispatched, so the
+  // WebContents write is safe there and must stay — CDP is the redirect-path mechanism only.
+  it('still uses the WebContents UA write for navigations that are not redirects', () => {
+    const guest = {
+      id: 420,
+      isDestroyed: vi.fn(() => false),
+      getType: vi.fn(() => 'webview'),
+      setBackgroundThrottling: guestSetBackgroundThrottlingMock,
+      setWindowOpenHandler: guestSetWindowOpenHandlerMock,
+      on: guestOnMock,
+      off: guestOffMock,
+      openDevTools: guestOpenDevToolsMock,
+      getURL: vi.fn(() => 'https://example.com/'),
+      getUserAgent: vi.fn(() => guestBaseUserAgent),
+      setUserAgent: vi.fn(),
+      debugger: { isAttached: vi.fn(() => true), sendCommand: vi.fn(async () => undefined) },
+      session: { getUserAgent: vi.fn(() => guestBaseUserAgent) }
+    }
+    webContentsFromIdMock.mockReturnValue(guest)
+
+    browserManager.attachGuestPolicies(guest as never)
+    browserManager.registerGuest({
+      browserPageId: 'browser-direct-ua',
+      webContentsId: guest.id,
+      rendererWebContentsId
+    })
+    const didStartNavigation = guestOnMock.mock.calls.find(
+      ([event]) => event === 'did-start-navigation'
+    )?.[1] as (event: unknown, url: string, isInPlace: boolean, isMainFrame: boolean) => void
+
+    didStartNavigation(null, 'https://accounts.google.com/v3/signin/identifier', false, true)
+
+    expect(guest.setUserAgent).toHaveBeenLastCalledWith(googleAuthUserAgent())
+    expect(guest.debugger.sendCommand).not.toHaveBeenCalledWith(
+      'Emulation.setUserAgentOverride',
+      expect.anything()
+    )
+  })
 })

--- a/src/main/browser/browser-manager-auth-user-agent.test.ts
+++ b/src/main/browser/browser-manager-auth-user-agent.test.ts
@@ -68,8 +68,9 @@ describe('browserManager', () => {
     vi.useRealTimers()
   })
 
-  it('presents the Firefox UA on Google auth hosts and restores the base UA off them', () => {
+  it('presents the Firefox UA on Google auth hosts and restores the base UA off them', async () => {
     let currentUa = guestBaseUserAgent
+    const sendCommand = vi.fn().mockResolvedValue(undefined)
     const setUserAgent = vi.fn((ua: string) => {
       currentUa = ua
     })
@@ -85,6 +86,7 @@ describe('browserManager', () => {
       getURL: vi.fn(() => 'https://accounts.google.com/'),
       getUserAgent: vi.fn(() => currentUa),
       setUserAgent,
+      debugger: { isAttached: vi.fn(() => true), sendCommand },
       session: { getUserAgent: vi.fn(() => guestBaseUserAgent) }
     }
     webContentsFromIdMock.mockReturnValue(guest)
@@ -98,14 +100,26 @@ describe('browserManager', () => {
     const didStartNavigation = guestOnMock.mock.calls.find(
       ([event]) => event === 'did-start-navigation'
     )?.[1] as (event: unknown, url: string, isInPlace: boolean, isMainFrame: boolean) => void
+    const willRedirect = guestOnMock.mock.calls.find(
+      ([event]) => event === 'will-redirect'
+    )?.[1] as (event: unknown, url: string, isInPlace: boolean, isMainFrame: boolean) => void
     setUserAgent.mockClear()
 
     didStartNavigation(null, 'https://accounts.google.com/v3/signin/identifier', false, true)
     expect(setUserAgent).toHaveBeenLastCalledWith(googleAuthUserAgent())
 
-    // Off the auth host, the guest's base identity is restored.
-    didStartNavigation(null, 'https://myaccount.google.com/', false, true)
-    expect(setUserAgent).toHaveBeenLastCalledWith(guestBaseUserAgent)
+    // A redirect off the auth host must derive the CDP write from the session UA, not the stale
+    // Firefox WebContents UA installed by the direct navigation.
+    sendCommand.mockClear()
+    willRedirect(null, 'https://myaccount.google.com/', false, true)
+    const uaOverrideIndex = sendCommand.mock.calls.findIndex(
+      ([method]) => method === 'Emulation.setUserAgentOverride'
+    )
+    await expect(sendCommand.mock.results[uaOverrideIndex]?.value).resolves.toBeUndefined()
+    expect(sendCommand.mock.calls[uaOverrideIndex]).toEqual([
+      'Emulation.setUserAgentOverride',
+      { userAgent: guestBaseUserAgent }
+    ])
 
     // A navigation that doesn't change the required UA must not thrash setUserAgent.
     setUserAgent.mockClear()
@@ -239,7 +253,23 @@ describe('browserManager', () => {
   // provider and lands on accounts.google.com only by redirect, so the replay never reproduces it and
   // the tab is left blank. Verified against Electron 43.1.0: the server sees the original request twice.
   it('retargets the auth-host UA over CDP during a redirect instead of cancelling it', async () => {
-    const sendCommand = vi.fn(async () => undefined)
+    const debuggerHandlers = new Map<string, () => void>()
+    let holdNextUserAgentOverride = false
+    let releaseHeldUserAgentOverride = (): void => {}
+    let rejectNextUserAgentOverride = false
+    const sendCommand = vi.fn((method: string) => {
+      if (method === 'Emulation.setUserAgentOverride' && holdNextUserAgentOverride) {
+        holdNextUserAgentOverride = false
+        return new Promise<void>((resolve) => {
+          releaseHeldUserAgentOverride = resolve
+        })
+      }
+      if (method === 'Emulation.setUserAgentOverride' && rejectNextUserAgentOverride) {
+        rejectNextUserAgentOverride = false
+        return Promise.reject(new Error('debugger detached'))
+      }
+      return Promise.resolve(undefined)
+    })
     const guest = {
       id: 418,
       isDestroyed: vi.fn(() => false),
@@ -252,7 +282,12 @@ describe('browserManager', () => {
       getURL: vi.fn(() => 'https://mail.google.com/'),
       getUserAgent: vi.fn(() => guestBaseUserAgent),
       setUserAgent: vi.fn(),
-      debugger: { isAttached: vi.fn(() => true), sendCommand },
+      debugger: {
+        isAttached: vi.fn(() => true),
+        sendCommand,
+        on: vi.fn((event: string, handler: () => void) => debuggerHandlers.set(event, handler)),
+        off: vi.fn((event: string) => debuggerHandlers.delete(event))
+      },
       session: { getUserAgent: vi.fn(() => guestBaseUserAgent) }
     }
     webContentsFromIdMock.mockReturnValue(guest)
@@ -268,14 +303,38 @@ describe('browserManager', () => {
     )?.[1] as (event: unknown, url: string, isInPlace: boolean, isMainFrame: boolean) => void
     sendCommand.mockClear()
 
+    rejectNextUserAgentOverride = true
     willRedirect(
       { preventDefault: vi.fn() },
       'https://accounts.google.com/v3/signin/identifier',
       false,
       true
     )
+    await expect(sendCommand.mock.results.at(-1)?.value).rejects.toThrow('debugger detached')
+
+    // A rejected write must not be recorded as installed; the next navigation retries it.
+    willRedirect(
+      { preventDefault: vi.fn() },
+      'https://accounts.google.com/v3/signin/identifier',
+      false,
+      true
+    )
+    await expect(sendCommand.mock.results.at(-1)?.value).resolves.toBeUndefined()
 
     expect(guest.setUserAgent).not.toHaveBeenCalled()
+    expect(sendCommand).toHaveBeenCalledWith('Emulation.setUserAgentOverride', {
+      userAgent: googleAuthUserAgent()
+    })
+
+    // Detaching clears Chromium's CDP overrides, so the confirmed identity must be invalidated too.
+    sendCommand.mockClear()
+    debuggerHandlers.get('detach')?.()
+    willRedirect(
+      { preventDefault: vi.fn() },
+      'https://accounts.google.com/v3/signin/identifier',
+      false,
+      true
+    )
     expect(sendCommand).toHaveBeenCalledWith('Emulation.setUserAgentOverride', {
       userAgent: googleAuthUserAgent()
     })
@@ -287,12 +346,65 @@ describe('browserManager', () => {
     const didStartNavigation = guestOnMock.mock.calls.find(
       ([event]) => event === 'did-start-navigation'
     )?.[1] as (event: unknown, url: string, isInPlace: boolean, isMainFrame: boolean) => void
+    rejectNextUserAgentOverride = true
+    didStartNavigation(null, 'https://example.com/', false, true)
+    await expect(sendCommand.mock.results.at(-1)?.value).rejects.toThrow('debugger detached')
     didStartNavigation(null, 'https://example.com/', false, true)
 
     expect(guest.setUserAgent).not.toHaveBeenCalled()
+    expect(sendCommand.mock.calls).toEqual([
+      ['Emulation.setUserAgentOverride', { userAgent: guestBaseUserAgent }],
+      ['Emulation.setUserAgentOverride', { userAgent: guestBaseUserAgent }]
+    ])
+
+    // A newer confirmed write outranks an older write that remains in flight.
+    debuggerHandlers.get('detach')?.()
+    holdNextUserAgentOverride = true
+    willRedirect(
+      { preventDefault: vi.fn() },
+      'https://accounts.google.com/v3/signin/identifier',
+      false,
+      true
+    )
+    const olderHeldWrite = sendCommand.mock.results.at(-1)?.value as Promise<void>
+    didStartNavigation(null, 'https://example.com/', false, true)
+    await expect(sendCommand.mock.results.at(-1)?.value).resolves.toBeUndefined()
+
+    sendCommand.mockClear()
+    willRedirect(
+      { preventDefault: vi.fn() },
+      'https://accounts.google.com/v3/signin/identifier',
+      false,
+      true
+    )
+    expect(sendCommand).toHaveBeenCalledWith('Emulation.setUserAgentOverride', {
+      userAgent: googleAuthUserAgent()
+    })
+    releaseHeldUserAgentOverride()
+    await olderHeldWrite
+
+    // A newer failure must not discard an older write that is still in flight.
+    debuggerHandlers.get('detach')?.()
+    holdNextUserAgentOverride = true
+    willRedirect(
+      { preventDefault: vi.fn() },
+      'https://accounts.google.com/v3/signin/identifier',
+      false,
+      true
+    )
+    const heldWrite = sendCommand.mock.results.at(-1)?.value as Promise<void>
+    rejectNextUserAgentOverride = true
+    didStartNavigation(null, 'https://example.com/', false, true)
+    await expect(sendCommand.mock.results.at(-1)?.value).rejects.toThrow('debugger detached')
+    releaseHeldUserAgentOverride()
+    await heldWrite
+
+    sendCommand.mockClear()
+    didStartNavigation(null, 'https://example.com/', false, true)
     expect(sendCommand).toHaveBeenCalledWith('Emulation.setUserAgentOverride', {
       userAgent: guestBaseUserAgent
     })
+    browserManager.unregisterGuest('browser-redirect-ua')
   })
 
   // Why: a redirect must never be cancelled to keep the identity in sync. Without a debugger there is

--- a/src/main/browser/browser-manager-auth-user-agent.test.ts
+++ b/src/main/browser/browser-manager-auth-user-agent.test.ts
@@ -48,6 +48,11 @@ import {
   resetBrowserManagerMocks,
   resetBrowserManagerState
 } from './browser-manager-test-harness'
+import {
+  createViewportGuestFactory,
+  flushViewportOps,
+  GUEST_CLEAN_UA
+} from './browser-manager-viewport-test-fixtures'
 
 const {
   guestOffMock,
@@ -57,6 +62,7 @@ const {
   guestOpenDevToolsMock,
   webContentsFromIdMock
 } = browserMocks
+const makeViewportGuest = createViewportGuestFactory(browserMocks)
 
 describe('browserManager', () => {
   beforeEach(() => {
@@ -489,5 +495,55 @@ describe('browserManager', () => {
       'Emulation.setUserAgentOverride',
       expect.anything()
     )
+  })
+
+  // Why: the direct-navigation branch still writes the Firefox UA through WebContents.setUserAgent,
+  // and nothing ever restores it once the guest switches to the CDP override. A viewport preset that
+  // read getUserAgent() back as its base identity would therefore republish Firefox on every ordinary
+  // host — the wire UA saying Firefox while sec-ch-ua still says Chrome, the exact cross-layer tell
+  // this scope exists to remove.
+  it('keeps a viewport preset on the session identity after an auth-host visit', async () => {
+    const { guest, debuggerSendCommand } = makeViewportGuest(9001)
+    webContentsFromIdMock.mockReturnValue(guest)
+    browserManager.attachGuestPolicies(guest as never)
+    browserManager.registerGuest({
+      browserPageId: 'tab-auth-then-preset',
+      webContentsId: guest.id as number,
+      rendererWebContentsId
+    })
+    await browserManager.setViewportOverride('tab-auth-then-preset', {
+      width: 1280,
+      height: 800,
+      deviceScaleFactor: 1,
+      mobile: false
+    })
+    await flushViewportOps()
+
+    const didStartNavigation = guestOnMock.mock.calls.find(
+      ([event]) => event === 'did-start-navigation'
+    )?.[1] as (event: unknown, url: string, isInPlace: boolean, isMainFrame: boolean) => void
+    const willRedirect = guestOnMock.mock.calls.find(
+      ([event]) => event === 'will-redirect'
+    )?.[1] as (event: unknown, url: string, isInPlace: boolean, isMainFrame: boolean) => void
+
+    didStartNavigation(null, 'https://accounts.google.com/v3/signin/identifier', false, true)
+    await flushViewportOps()
+    // The direct branch pins the WebContents UA to Firefox and never restores it.
+    expect((guest.getUserAgent as () => string)()).toBe(googleAuthUserAgent())
+
+    willRedirect({ preventDefault: vi.fn() }, 'https://myaccount.google.com/', false, true)
+    await flushViewportOps()
+
+    debuggerSendCommand.mockClear()
+    didStartNavigation(null, 'https://github.com/', false, true)
+    await flushViewportOps()
+
+    const uaWrites = debuggerSendCommand.mock.calls.filter(
+      ([method]) => method === 'Emulation.setUserAgentOverride'
+    )
+    expect(uaWrites.length).toBeGreaterThan(0)
+    for (const [, params] of uaWrites) {
+      expect((params as { userAgent: string }).userAgent).toBe(GUEST_CLEAN_UA)
+    }
   })
 })

--- a/src/main/browser/browser-manager-viewport-override.test.ts
+++ b/src/main/browser/browser-manager-viewport-override.test.ts
@@ -450,12 +450,16 @@ describe('browserManager', () => {
       willRedirect({ preventDefault: vi.fn() }, 'https://accounts.google.com/same', false, true)
       didStartNavigation(null, 'https://accounts.google.com/same', false, true)
       await flushViewportOps()
+      expect(lastUserAgentOverride(debuggerSendCommand)).toEqual({
+        userAgent: googleAuthUserAgent()
+      })
 
       debuggerSendCommand.mockClear()
       didFailLoad(null, -3, 'Aborted', 'https://accounts.google.com/same', true)
       await flushViewportOps()
 
-      expect(guest.setUserAgent).toHaveBeenLastCalledWith(googleAuthUserAgent())
+      // Why: the redirect path never writes the WebContents UA — that write cancels the navigation.
+      expect(guest.setUserAgent).not.toHaveBeenCalled()
       expect(debuggerSendCommand).not.toHaveBeenCalledWith(
         'Emulation.setUserAgentOverride',
         expect.objectContaining({ userAgent: GUEST_CLEAN_UA })
@@ -507,14 +511,17 @@ describe('browserManager', () => {
       )
       await flushViewportOps()
 
-      expect(guest.setUserAgent).toHaveBeenLastCalledWith(googleAuthUserAgent())
+      // Why: the identity switch for a redirect goes over CDP only. WebContents.setUserAgent() here
+      // makes Chromium cancel the in-flight navigation and replay the original request, which is what
+      // left Google sign-in on a blank tab.
+      expect(guest.setUserAgent).not.toHaveBeenCalled()
       expect(lastUserAgentOverride(debuggerSendCommand)).toEqual({
         userAgent: googleAuthUserAgent()
       })
 
       didFailLoad(null, -3, 'Aborted', 'https://accounts.google.com/redirected', true)
       await flushViewportOps()
-      expect(guest.setUserAgent).toHaveBeenLastCalledWith(GUEST_ELECTRON_UA)
+      expect(guest.setUserAgent).not.toHaveBeenCalled()
       expect(lastUserAgentOverride(debuggerSendCommand)).toEqual({ userAgent: GUEST_CLEAN_UA })
     })
 

--- a/src/main/browser/browser-manager-viewport-override.test.ts
+++ b/src/main/browser/browser-manager-viewport-override.test.ts
@@ -55,6 +55,12 @@ import {
 
 const { guestOnMock, webContentsFromIdMock } = browserMocks
 const makeGuest = createViewportGuestFactory(browserMocks)
+const MOBILE_VIEWPORT_OVERRIDE = {
+  width: 375,
+  height: 667,
+  deviceScaleFactor: 2,
+  mobile: true
+} as const
 
 describe('browserManager', () => {
   beforeEach(() => {
@@ -68,12 +74,7 @@ describe('browserManager', () => {
 
   describe('setViewportOverride', () => {
     it('returns false when the tab is not registered', async () => {
-      const result = await browserManager.setViewportOverride('missing', {
-        width: 375,
-        height: 667,
-        deviceScaleFactor: 2,
-        mobile: true
-      })
+      const result = await browserManager.setViewportOverride('missing', MOBILE_VIEWPORT_OVERRIDE)
       expect(result).toBe(false)
     })
 
@@ -89,12 +90,7 @@ describe('browserManager', () => {
       webContentsFromIdMock.mockReset()
       webContentsFromIdMock.mockReturnValue(guest)
 
-      const ok = await browserManager.setViewportOverride('tab-mobile', {
-        width: 375,
-        height: 667,
-        deviceScaleFactor: 2,
-        mobile: true
-      })
+      const ok = await browserManager.setViewportOverride('tab-mobile', MOBILE_VIEWPORT_OVERRIDE)
       expect(ok).toBe(true)
 
       expect(debuggerSendCommand).toHaveBeenCalledWith('Emulation.setDeviceMetricsOverride', {
@@ -194,6 +190,14 @@ describe('browserManager', () => {
       const didStartNavigation = guestOnMock.mock.calls.find(
         ([event]) => event === 'did-start-navigation'
       )?.[1] as (event: unknown, url: string, isInPlace: boolean, isMainFrame: boolean) => void
+      const willRedirect = guestOnMock.mock.calls.find(
+        ([event]) => event === 'will-redirect'
+      )?.[1] as (
+        event: { preventDefault: () => void },
+        url: string,
+        isInPlace: boolean,
+        isMainFrame: boolean
+      ) => void
 
       // Case A: the desktop preset lands first, while the tab is still off the auth host.
       await browserManager.setViewportOverride('tab-auth-nav', {
@@ -216,11 +220,9 @@ describe('browserManager', () => {
 
       // Leaving the auth host restores the clean Chrome-shaped preset UA.
       debuggerSendCommand.mockClear()
-      didStartNavigation(null, 'https://example.com/', false, true)
+      willRedirect({ preventDefault: vi.fn() }, 'https://example.com/', false, true)
       await flushViewportOps()
-      expect(debuggerSendCommand).toHaveBeenCalledWith('Emulation.setUserAgentOverride', {
-        userAgent: GUEST_CLEAN_UA
-      })
+      expect(lastUserAgentOverride(debuggerSendCommand)).toEqual({ userAgent: GUEST_CLEAN_UA })
     })
 
     // Why: not an ordering race — debugger.sendCommand dispatches in call order over one channel, so
@@ -263,12 +265,10 @@ describe('browserManager', () => {
         ([event]) => event === 'did-start-navigation'
       )?.[1] as (event: unknown, url: string, isInPlace: boolean, isMainFrame: boolean) => void
 
-      const presetDone = browserManager.setViewportOverride('tab-race-onto-auth', {
-        width: 375,
-        height: 667,
-        deviceScaleFactor: 2,
-        mobile: true
-      })
+      const presetDone = browserManager.setViewportOverride(
+        'tab-race-onto-auth',
+        MOBILE_VIEWPORT_OVERRIDE
+      )
       await flushViewportOps()
 
       // The tab navigates to the auth host while the preset is still awaiting its first command.
@@ -382,12 +382,7 @@ describe('browserManager', () => {
 
       // A later preset must also resolve the committed, non-auth URL.
       debuggerSendCommand.mockClear()
-      await browserManager.setViewportOverride('tab-pending-cleared', {
-        width: 375,
-        height: 667,
-        deviceScaleFactor: 2,
-        mobile: true
-      })
+      await browserManager.setViewportOverride('tab-pending-cleared', MOBILE_VIEWPORT_OVERRIDE)
       await flushViewportOps()
       expect(lastUserAgentOverride(debuggerSendCommand)?.userAgent).toContain('iPhone')
 
@@ -522,6 +517,81 @@ describe('browserManager', () => {
       didFailLoad(null, -3, 'Aborted', 'https://accounts.google.com/redirected', true)
       await flushViewportOps()
       expect(guest.setUserAgent).not.toHaveBeenCalled()
+      expect(lastUserAgentOverride(debuggerSendCommand)).toEqual({ userAgent: GUEST_CLEAN_UA })
+    })
+
+    it('preserves the auth identity when a viewport preset is cleared after a redirect', async () => {
+      const { guest, debuggerSendCommand } = makeGuest(4262, 'https://example.com/')
+      webContentsFromIdMock.mockReturnValue(guest)
+      browserManager.attachGuestPolicies(guest as never)
+      browserManager.registerGuest({
+        browserPageId: 'tab-clear-on-auth',
+        webContentsId: guest.id as number,
+        rendererWebContentsId
+      })
+      const didStartNavigation = guestOnMock.mock.calls.find(
+        ([event]) => event === 'did-start-navigation'
+      )?.[1] as (event: unknown, url: string, isInPlace: boolean, isMainFrame: boolean) => void
+      const willRedirect = guestOnMock.mock.calls.find(
+        ([event]) => event === 'will-redirect'
+      )?.[1] as (
+        event: { preventDefault: () => void },
+        url: string,
+        isInPlace: boolean,
+        isMainFrame: boolean
+      ) => void
+
+      await browserManager.setViewportOverride('tab-clear-on-auth', MOBILE_VIEWPORT_OVERRIDE)
+      didStartNavigation(null, 'https://example.com/start', false, true)
+      willRedirect({ preventDefault: vi.fn() }, 'https://accounts.google.com/', false, true)
+      await flushViewportOps()
+
+      debuggerSendCommand.mockClear()
+      await expect(browserManager.setViewportOverride('tab-clear-on-auth', null)).resolves.toBe(
+        true
+      )
+      expect(lastUserAgentOverride(debuggerSendCommand)).toEqual({
+        userAgent: googleAuthUserAgent()
+      })
+      expect(debuggerSendCommand).not.toHaveBeenCalledWith('Emulation.setUserAgentOverride', {
+        userAgent: ''
+      })
+    })
+
+    it('does not inherit a mobile owner UA in a desktop popup', async () => {
+      const { guest: ownerGuest } = makeGuest(4263)
+      webContentsFromIdMock.mockReturnValue(ownerGuest)
+      browserManager.attachGuestPolicies(ownerGuest as never)
+      browserManager.registerGuest({
+        browserPageId: 'tab-mobile-popup-owner',
+        webContentsId: ownerGuest.id as number,
+        rendererWebContentsId
+      })
+      await browserManager.setViewportOverride('tab-mobile-popup-owner', MOBILE_VIEWPORT_OVERRIDE)
+
+      const { guest: popupGuest, debuggerSendCommand } = makeGuest(4264, 'https://mail.google.com/')
+      const popupOn = vi.fn()
+      popupGuest.on = popupOn
+      browserManager.attachGuestPolicies(popupGuest as never, {
+        browserTabId: 'tab-mobile-popup-owner',
+        rootGuestWebContentsId: ownerGuest.id as number
+      })
+      const willRedirect = popupOn.mock.calls.find(([event]) => event === 'will-redirect')?.[1] as (
+        event: { preventDefault: () => void },
+        url: string,
+        isInPlace: boolean,
+        isMainFrame: boolean
+      ) => void
+      const didStartNavigation = popupOn.mock.calls.find(
+        ([event]) => event === 'did-start-navigation'
+      )?.[1] as (event: unknown, url: string, isInPlace: boolean, isMainFrame: boolean) => void
+
+      willRedirect({ preventDefault: vi.fn() }, 'https://accounts.google.com/', false, true)
+      await flushViewportOps()
+      debuggerSendCommand.mockClear()
+      didStartNavigation(null, 'https://example.com/', false, true)
+      await flushViewportOps()
+
       expect(lastUserAgentOverride(debuggerSendCommand)).toEqual({ userAgent: GUEST_CLEAN_UA })
     })
 

--- a/src/main/browser/browser-manager.ts
+++ b/src/main/browser/browser-manager.ts
@@ -229,6 +229,10 @@ export class BrowserManager {
   // Why: presence means the preset requires a CDP UA override (installed or in flight), so navigation
   // can re-issue it against the target URL's identity.
   private readonly viewportUaOverrideMobileByTabId = new Map<string, boolean>()
+  // Why: the auth-host UA of a guest whose identity moved to the CDP override. That override outranks
+  // WebContents.setUserAgent, so once it is installed getUserAgent() no longer reports what the
+  // document sees and this is the only accurate reading of the guest's current identity.
+  private readonly authUserAgentOverrideByGuestId = new Map<number, string>()
   // Why: the in-flight main-frame navigation target, held only until commit or failure — getURL()
   // still reports the outgoing page until then. See resolveTabNavigationUrl.
   private readonly pendingNavigationByGuestId = new Map<number, PendingMainFrameNavigation>()
@@ -810,7 +814,7 @@ export class BrowserManager {
         return
       }
       this.updatePendingNavigationForRedirect(guest.id, url)
-      this.applyGoogleAuthUserAgent(guest, url)
+      this.applyGoogleAuthUserAgent(guest, url, { duringRedirect: true })
     }
 
     const didFailLoadHandler = (
@@ -946,7 +950,11 @@ export class BrowserManager {
   // must be matched here per navigation or the two layers disagree — itself a bot tell.
   // Restores the session's base identity off the auth hosts. Native-UA profiles opt out
   // of the whole clean-UA path, so they keep their untouched identity everywhere.
-  private applyGoogleAuthUserAgent(guest: Electron.WebContents, url: string): void {
+  private applyGoogleAuthUserAgent(
+    guest: Electron.WebContents,
+    url: string,
+    options: { duringRedirect?: boolean } = {}
+  ): void {
     const browserPageId = this.tabIdByWebContentsId.get(guest.id)
     // Why: popup child windows get these policies but are never in tabIdByWebContentsId, so a direct
     // lookup misses the native-UA opt-out and would hand a native profile's popup the Firefox UA.
@@ -961,20 +969,54 @@ export class BrowserManager {
       return
     }
     const firefoxUa = googleAuthUserAgent()
-    const currentUa = guest.getUserAgent()
-    if (isGoogleAuthUrl(url)) {
-      if (currentUa !== firefoxUa) {
-        guest.setUserAgent(firefoxUa)
+    const overriddenUa = this.authUserAgentOverrideByGuestId.get(guest.id)
+    const currentUa = overriddenUa ?? guest.getUserAgent()
+    const nextUa = isGoogleAuthUrl(url)
+      ? firefoxUa
+      : // Only restore when the auth-host override is actually in place, so normal
+        // navigation never touches the session UA.
+        currentUa === firefoxUa
+        ? guest.session.getUserAgent()
+        : null
+    if (nextUa !== null && nextUa !== currentUa) {
+      // Why: WebContents.setUserAgent() during a redirect makes Chromium cancel the in-flight
+      // navigation (ERR_ABORTED) and replay the original request, which a POST-started OAuth chain
+      // cannot survive — the sign-in lands on a blank tab. CDP retargets navigator.userAgent without
+      // touching the navigation, and it outranks the WebContents UA from then on, so a guest that
+      // switches to it stays on it. The wire UA never depended on this write: setupClientHintsOverride
+      // rewrites User-Agent per request for auth-host URLs on its own.
+      if (options.duringRedirect === true || overriddenUa !== undefined) {
+        if (this.canOverrideUserAgentOverCdp(guest)) {
+          this.authUserAgentOverrideByGuestId.set(guest.id, nextUa)
+          // Why: go through the viewport builder rather than writing nextUa raw, so both CDP writers
+          // resolve one identity for this URL — Firefox on auth hosts, the profile's clean base off
+          // them, any mobile preset preserved. Writing the session UA directly would put the
+          // unlaundered Electron token back on the wire.
+          void this.sendViewportUserAgentOverride(
+            guest,
+            (ownerTabId ? this.viewportUaOverrideMobileByTabId.get(ownerTabId) : undefined) ??
+              false,
+            url
+          ).catch(() => {})
+        }
+        // Why: with no debugger there is no way to retarget the identity without cancelling the
+        // redirect. A stale navigator.userAgent is recoverable; a dead navigation is not.
+      } else {
+        guest.setUserAgent(nextUa)
       }
-    } else if (currentUa === firefoxUa) {
-      // Only restore when the auth-host override is actually in place, so normal
-      // navigation never touches the session UA.
-      guest.setUserAgent(guest.session.getUserAgent())
     }
     // Why: gate on the DIRECT page id, not ownerTabId — a popup has no device-metrics override of
     // its own, so inheriting the owner tab's preset UA would pair a mobile UA with a desktop viewport.
     if (browserPageId) {
       this.reapplyViewportUserAgentOverride(guest, browserPageId, url)
+    }
+  }
+
+  private canOverrideUserAgentOverCdp(guest: Electron.WebContents): boolean {
+    try {
+      return !guest.isDestroyed() && guest.debugger.isAttached()
+    } catch {
+      return false
     }
   }
 
@@ -1107,6 +1149,7 @@ export class BrowserManager {
     this.clickedLinkFrameNameByGuestId.delete(guestWebContentsId)
     this.offscreenGuestIds.delete(guestWebContentsId)
     this.popupOwnerContextByGuestId.delete(guestWebContentsId)
+    this.authUserAgentOverrideByGuestId.delete(guestWebContentsId)
     this.pendingNavigationByGuestId.delete(guestWebContentsId)
     // Why: a popup must stop inheriting authorization the moment its owner retires, before Chromium destroys the child.
     if (isPrimaryGuest) {
@@ -1311,6 +1354,7 @@ export class BrowserManager {
     this.sessionProfileIdByPageId.clear()
     this.userAgentModeByPageId.clear()
     this.viewportUaOverrideMobileByTabId.clear()
+    this.authUserAgentOverrideByGuestId.clear()
     this.pendingNavigationByGuestId.clear()
     this.pendingLoadFailuresByGuestId.clear()
     this.loadErrorsByGuestId.clear()

--- a/src/main/browser/browser-manager.ts
+++ b/src/main/browser/browser-manager.ts
@@ -1165,7 +1165,10 @@ export class BrowserManager {
       buildViewportUserAgentOverride({
         url: url ?? this.resolveTabNavigationUrl(guest),
         mobile,
-        baseUserAgent: cleanElectronUserAgent(baseUserAgent ?? guest.getUserAgent())
+        // Why: the session UA is the profile's stable base identity. guest.getUserAgent() is not:
+        // applyGoogleAuthUserAgent leaves it pinned to the Firefox auth UA once a guest switches to
+        // the CDP override, so reading it back here would republish that identity on ordinary hosts.
+        baseUserAgent: cleanElectronUserAgent(baseUserAgent ?? guest.session.getUserAgent())
       })
     )
   }

--- a/src/main/browser/browser-manager.ts
+++ b/src/main/browser/browser-manager.ts
@@ -153,6 +153,15 @@ type PendingMainFrameNavigation = {
   currentUrl: string
   supersededUrls: string[]
 }
+type AuthUserAgentOverrideOperation = {
+  sequence: number
+  userAgent: string
+}
+type AuthUserAgentOverrideState = {
+  confirmed: AuthUserAgentOverrideOperation | null
+  nextSequence: number
+  pending: AuthUserAgentOverrideOperation[]
+}
 const SAFE_POPUP_WINDOW_OPTIONS = {
   alwaysOnTop: false,
   closable: true,
@@ -229,10 +238,12 @@ export class BrowserManager {
   // Why: presence means the preset requires a CDP UA override (installed or in flight), so navigation
   // can re-issue it against the target URL's identity.
   private readonly viewportUaOverrideMobileByTabId = new Map<string, boolean>()
-  // Why: the auth-host UA of a guest whose identity moved to the CDP override. That override outranks
-  // WebContents.setUserAgent, so once it is installed getUserAgent() no longer reports what the
-  // document sees and this is the only accurate reading of the guest's current identity.
-  private readonly authUserAgentOverrideByGuestId = new Map<number, string>()
+  // Why: the confirmed CDP identity outranks getUserAgent; pending intent keeps rapid navigations
+  // ordered without claiming a failed write was installed.
+  private readonly authUserAgentOverrideStateByGuestId = new Map<
+    number,
+    AuthUserAgentOverrideState
+  >()
   // Why: the in-flight main-frame navigation target, held only until commit or failure — getURL()
   // still reports the outgoing page until then. See resolveTabNavigationUrl.
   private readonly pendingNavigationByGuestId = new Map<number, PendingMainFrameNavigation>()
@@ -319,6 +330,7 @@ export class BrowserManager {
 
     // Why: proxy/bridge stop detaches the debugger and drops injections; re-attach (500ms delay to avoid racing a mid-restart) to keep overrides.
     const onDetach = (): void => {
+      this.authUserAgentOverrideStateByGuestId.delete(guest.id)
       if (!disposed && !guest.isDestroyed() && reattachTimer === null) {
         reattachTimer = setTimeout(() => {
           reattachTimer = null
@@ -969,8 +981,14 @@ export class BrowserManager {
       return
     }
     const firefoxUa = googleAuthUserAgent()
-    const overriddenUa = this.authUserAgentOverrideByGuestId.get(guest.id)
-    const currentUa = overriddenUa ?? guest.getUserAgent()
+    const overrideState = this.authUserAgentOverrideStateByGuestId.get(guest.id)
+    const latestPendingOverride = overrideState?.pending.at(-1)
+    const confirmedOverride = overrideState?.confirmed
+    const currentOverride =
+      latestPendingOverride && latestPendingOverride.sequence > (confirmedOverride?.sequence ?? -1)
+        ? latestPendingOverride
+        : confirmedOverride
+    const currentUa = currentOverride?.userAgent ?? guest.getUserAgent()
     const nextUa = isGoogleAuthUrl(url)
       ? firefoxUa
       : // Only restore when the auth-host override is actually in place, so normal
@@ -978,6 +996,7 @@ export class BrowserManager {
         currentUa === firefoxUa
         ? guest.session.getUserAgent()
         : null
+    let authOverrideIssuedOverCdp = false
     if (nextUa !== null && nextUa !== currentUa) {
       // Why: WebContents.setUserAgent() during a redirect makes Chromium cancel the in-flight
       // navigation (ERR_ABORTED) and replay the original request, which a POST-started OAuth chain
@@ -985,19 +1004,20 @@ export class BrowserManager {
       // touching the navigation, and it outranks the WebContents UA from then on, so a guest that
       // switches to it stays on it. The wire UA never depended on this write: setupClientHintsOverride
       // rewrites User-Agent per request for auth-host URLs on its own.
-      if (options.duringRedirect === true || overriddenUa !== undefined) {
+      if (options.duringRedirect === true || overrideState !== undefined) {
         if (this.canOverrideUserAgentOverCdp(guest)) {
-          this.authUserAgentOverrideByGuestId.set(guest.id, nextUa)
+          authOverrideIssuedOverCdp = true
           // Why: go through the viewport builder rather than writing nextUa raw, so both CDP writers
           // resolve one identity for this URL — Firefox on auth hosts, the profile's clean base off
           // them, any mobile preset preserved. Writing the session UA directly would put the
           // unlaundered Electron token back on the wire.
-          void this.sendViewportUserAgentOverride(
+          void this.applyAuthUserAgentOverrideOverCdp(
             guest,
-            (ownerTabId ? this.viewportUaOverrideMobileByTabId.get(ownerTabId) : undefined) ??
+            (browserPageId ? this.viewportUaOverrideMobileByTabId.get(browserPageId) : undefined) ??
               false,
-            url
-          ).catch(() => {})
+            url,
+            nextUa
+          )
         }
         // Why: with no debugger there is no way to retarget the identity without cancelling the
         // redirect. A stale navigator.userAgent is recoverable; a dead navigation is not.
@@ -1007,7 +1027,7 @@ export class BrowserManager {
     }
     // Why: gate on the DIRECT page id, not ownerTabId — a popup has no device-metrics override of
     // its own, so inheriting the owner tab's preset UA would pair a mobile UA with a desktop viewport.
-    if (browserPageId) {
+    if (browserPageId && !authOverrideIssuedOverCdp) {
       this.reapplyViewportUserAgentOverride(guest, browserPageId, url)
     }
   }
@@ -1018,6 +1038,54 @@ export class BrowserManager {
     } catch {
       return false
     }
+  }
+
+  private applyAuthUserAgentOverrideOverCdp(
+    guest: Electron.WebContents,
+    mobile: boolean,
+    url: string,
+    userAgent: string
+  ): Promise<boolean> {
+    if (!this.canOverrideUserAgentOverCdp(guest)) {
+      return Promise.resolve(false)
+    }
+    const state = this.authUserAgentOverrideStateByGuestId.get(guest.id) ?? {
+      confirmed: null,
+      nextSequence: 0,
+      pending: []
+    }
+    const operation = { sequence: ++state.nextSequence, userAgent }
+    state.pending.push(operation)
+    this.authUserAgentOverrideStateByGuestId.set(guest.id, state)
+    return this.sendViewportUserAgentOverride(guest, mobile, url, userAgent).then(
+      () => this.settleAuthUserAgentOverride(guest.id, state, operation, true),
+      () => {
+        this.settleAuthUserAgentOverride(guest.id, state, operation, false)
+        return false
+      }
+    )
+  }
+
+  private settleAuthUserAgentOverride(
+    guestId: number,
+    state: AuthUserAgentOverrideState,
+    operation: AuthUserAgentOverrideOperation,
+    succeeded: boolean
+  ): boolean {
+    if (this.authUserAgentOverrideStateByGuestId.get(guestId) !== state) {
+      return false
+    }
+    if (succeeded && (state.confirmed?.sequence ?? -1) < operation.sequence) {
+      state.confirmed = operation
+    }
+    const pendingIndex = state.pending.indexOf(operation)
+    if (pendingIndex !== -1) {
+      state.pending.splice(pendingIndex, 1)
+    }
+    if (state.confirmed === null && state.pending.length === 0) {
+      this.authUserAgentOverrideStateByGuestId.delete(guestId)
+    }
+    return true
   }
 
   private startPendingNavigation(guestId: number, url: string): void {
@@ -1086,7 +1154,8 @@ export class BrowserManager {
   private async sendViewportUserAgentOverride(
     guest: Electron.WebContents,
     mobile: boolean,
-    url?: string
+    url?: string,
+    baseUserAgent?: string
   ): Promise<void> {
     if (guest.isDestroyed() || !guest.debugger.isAttached()) {
       return
@@ -1096,7 +1165,7 @@ export class BrowserManager {
       buildViewportUserAgentOverride({
         url: url ?? this.resolveTabNavigationUrl(guest),
         mobile,
-        baseUserAgent: cleanElectronUserAgent(guest.getUserAgent())
+        baseUserAgent: cleanElectronUserAgent(baseUserAgent ?? guest.getUserAgent())
       })
     )
   }
@@ -1149,7 +1218,7 @@ export class BrowserManager {
     this.clickedLinkFrameNameByGuestId.delete(guestWebContentsId)
     this.offscreenGuestIds.delete(guestWebContentsId)
     this.popupOwnerContextByGuestId.delete(guestWebContentsId)
-    this.authUserAgentOverrideByGuestId.delete(guestWebContentsId)
+    this.authUserAgentOverrideStateByGuestId.delete(guestWebContentsId)
     this.pendingNavigationByGuestId.delete(guestWebContentsId)
     // Why: a popup must stop inheriting authorization the moment its owner retires, before Chromium destroys the child.
     if (isPrimaryGuest) {
@@ -1354,7 +1423,7 @@ export class BrowserManager {
     this.sessionProfileIdByPageId.clear()
     this.userAgentModeByPageId.clear()
     this.viewportUaOverrideMobileByTabId.clear()
-    this.authUserAgentOverrideByGuestId.clear()
+    this.authUserAgentOverrideStateByGuestId.clear()
     this.pendingNavigationByGuestId.clear()
     this.pendingLoadFailuresByGuestId.clear()
     this.loadErrorsByGuestId.clear()
@@ -1774,9 +1843,22 @@ export class BrowserManager {
         const trackedMobile = this.viewportUaOverrideMobileByTabId.get(browserTabId)
         // A navigation after this point must not re-install the override behind the clear.
         this.viewportUaOverrideMobileByTabId.delete(browserTabId)
-        // Why: passing an empty string restores the session default UA.
         try {
-          await dbg.sendCommand('Emulation.setUserAgentOverride', { userAgent: '' })
+          if (this.authUserAgentOverrideStateByGuestId.has(guest.id)) {
+            const url = this.resolveTabNavigationUrl(guest)
+            const restored = await this.applyAuthUserAgentOverrideOverCdp(
+              guest,
+              false,
+              url,
+              isGoogleAuthUrl(url) ? googleAuthUserAgent() : guest.session.getUserAgent()
+            )
+            if (!restored) {
+              throw new Error('Failed to preserve auth user agent')
+            }
+          } else {
+            // Why: passing an empty string restores the session default UA.
+            await dbg.sendCommand('Emulation.setUserAgentOverride', { userAgent: '' })
+          }
         } catch (error) {
           if (trackedMobile !== undefined) {
             this.viewportUaOverrideMobileByTabId.set(browserTabId, trackedMobile)


### PR DESCRIPTION
## ELI5

Orca changed the browser's user agent in the middle of a redirect. Chromium reacts to that by cancelling the page load and starting over, and a "Sign in with Google" flow cannot start over — so the tab went blank and the click looked ignored. Orca now changes the identity in a way that does not interrupt the load.

## What Changed

- `applyGoogleAuthUserAgent` takes a `duringRedirect` flag. On that path it no longer calls `WebContents.setUserAgent()`; it writes the identity through the CDP override instead, reusing `sendViewportUserAgentOverride` so both CDP writers resolve one identity per URL.
- Added `authUserAgentOverrideByGuestId` — the CDP override outranks the WebContents UA, so `getUserAgent()` stops reporting what the document sees. Without this reading, a guest that entered an auth host by redirect would keep presenting Firefox on every later host. Cleared on guest retire and on shutdown.
- With no debugger attached the redirect is left alone rather than cancelled. A stale `navigator.userAgent` is recoverable; a dead navigation is not.
- `did-start-navigation` keeps the `setUserAgent` write — it runs before the request is dispatched and does not cancel anything.

No change to the wire UA: `setupClientHintsOverride` already rewrites `User-Agent` and strips `sec-ch-ua*` per request for auth-host URLs, independently of this call.

## Why

`WebContents.setUserAgent()` inside `will-redirect` makes Chromium abort the in-flight navigation with `ERR_ABORTED (-3)` and **replay the original request**. A chain that cannot be replayed — one started by a `POST`, or one carrying one-time auth state — never lands, so the navigation dies with `loadError: null` and the tab is left at `data:text/html,`.

That is every redirect crossing `GOOGLE_AUTH_HOSTS`, which is exactly the "Sign in with Google" path: the provider button POSTs, and `accounts.google.com` is reached only by redirect.

Isolated on the Electron 43.1.0 the app ships, no Google and no Orca involved — local server, `/start` → `302` → `/dest`, one arm per process:

| Arm | aborted | requests the server saw on `/start` | `navigator.userAgent` |
|---|---|---|---|
| A — control, no UA write in `will-redirect` | no | 1× base | base |
| **B — `WebContents.setUserAgent()`** (before this PR) | **`ERR_ABORTED (-3)`** | **2× — base, then Firefox** | Firefox |
| C — CDP `Emulation.setUserAgentOverride` (this PR) | no | 1× base | Firefox |

Arm B is the defect: the original request is issued twice and `will-redirect` fires twice. In that trivial local GET the replay happens to succeed, which is why the damage stays invisible until the chain cannot be replayed.

Two alternatives were measured and rejected. `did-redirect-navigation` **crashes the main process** (exit 133, 3/3 runs). Dropping the redirect-path write entirely leaves `navigator.userAgent` disagreeing with the header-level Firefox switch, which is the mismatch #12884 exists to remove.

## Linked Issue

Fixes #15216

## Visual Proof

Same machine, same profile state, `https://accounts.google.com/` opened in an embedded browser tab:

| | committed URL | `navigator.userAgent` |
|---|---|---|
| 1.4.184 (before) | `data:text/html,` — blank, no error surfaced | `…Chrome/150.0.7871.47 Electron/43.1.0…` |
| this branch (after) | `https://accounts.google.com/v3/signin/identifier?continue=…` | `Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:140.0) Gecko/20100101 Firefox/140.0` |

`https://mail.google.com/` (non-auth host redirecting into one) behaves the same way: blank before, commits at `accounts.google.com/v3/signin/identifier?continue=https://mail.google.com/mail/u/0/&…` after, on the Firefox auth UA.

There is no UI surface of its own here — the visible change is that the page loads at all.

## Testing

Final merge base: `f8e728bb8b87c0375b320fcd31316996f73e3d88`

**Manual, macOS, on a dev build of this branch against installed 1.4.184 as the before-arm** — the table above. Reproduction that motivated it: `https://gitlab.com/users/sign_in` → click **Google** → nothing happens on 1.4.184, while the **GitHub** button on the same page (same `<form class="js-omniauth-form" method="post">` markup, non-Google redirect target) navigates correctly.

**Automated**

```
npx vitest run --config config/vitest.config.ts \
  src/main/browser/browser-manager-auth-user-agent.test.ts \
  src/main/browser/browser-manager-viewport-override.test.ts
# Test Files 2 passed (2) | Tests 29 passed (29)
```

Three new cases in `browser-manager-auth-user-agent.test.ts`:
- a redirect onto an auth host retargets over CDP and never calls `setUserAgent`, and leaving the host afterwards reads the override rather than the stale `getUserAgent()`
- a redirect with no debugger attached is left alone
- a non-redirect navigation still uses the `WebContents` write

Two cases in `browser-manager-viewport-override.test.ts` asserted the cancelling write and were updated to the CDP contract.

Full `src/main/browser/` suite is unchanged against this merge base: 18 pre-existing failures before and after (all in `browser-cookie-*`, unrelated), 570 → 573 passing (+3 new).

Not tested on Linux, Windows, or SSH. The path is main-process Chromium behavior with no platform branch, and the embedded browser runs in the desktop process on every platform.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Investigated and written with Claude (Opus 5) via Claude Code. The Electron oracle, the before/after app runs, and the test results above were produced by running them, not inferred.
