### PR TITLE
fix(session): keep hidden-but-detected worktrees hydratable so live agent panes survive a restart

### DIFF
--- a/src/renderer/src/store/slices/degraded-repo-worktree-validity.ts
+++ b/src/renderer/src/store/slices/degraded-repo-worktree-validity.ts
@@ -8,7 +8,7 @@ type WorktreeValidityCatalog = {
   repos: readonly Pick<Repo, 'id'>[]
   worktreesByRepo: Readonly<Record<string, readonly Pick<Worktree, 'id'>[]>>
   detectedWorktreesByRepo?: Readonly<
-    Record<string, Pick<DetectedWorktreeListResult, 'authoritative'> | undefined>
+    Record<string, Pick<DetectedWorktreeListResult, 'authoritative' | 'worktrees'> | undefined>
   >
 }
 
@@ -61,8 +61,23 @@ export function buildValidWorktreeIdsForSessionHydration(
       .map(([repoId]) => repoId)
   )
 
+  // Why: `worktreesByRepo` carries only the rows the sidebar shows, so a detected-but-hidden
+  // worktree (agent-scratch, un-imported external) looks identical to a deleted one here. Dropping
+  // it discards its persisted panes, and the live PTYs the daemon kept across the restart come back
+  // with no leaf — invisible in every surface while `terminal list` still reports them running.
+  // Detection still proves existence, so a genuinely removed worktree is unaffected.
+  const detectedWorktreeIds = new Set(
+    Object.values(detectedWorktreesByRepo).flatMap((detected) =>
+      (detected?.worktrees ?? []).map((worktree) => worktree.id)
+    )
+  )
+
   for (const worktreeId of persistedWorktreeIds) {
     if (validWorktreeIds.has(worktreeId) || parseWorkspaceKey(worktreeId)?.type === 'folder') {
+      continue
+    }
+    if (detectedWorktreeIds.has(worktreeId)) {
+      validWorktreeIds.add(worktreeId)
       continue
     }
     const repoId = getRepoIdFromWorktreeId(worktreeId)

--- a/src/renderer/src/store/slices/hidden-worktree-tab-hydration.test.ts
+++ b/src/renderer/src/store/slices/hidden-worktree-tab-hydration.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { DetectedWorktree } from '../../../../shared/worktree/types'
+import type { WorkspaceSessionState } from '../../../../shared/workspace-session-state-types'
+import { getDefaultWorkspaceSession } from '../../../../shared/constants'
+import { buildValidWorktreeIdsForSessionHydration } from './degraded-repo-worktree-validity'
+
+vi.mock('sonner', () => ({ toast: { info: vi.fn(), success: vi.fn(), error: vi.fn() } }))
+
+// @ts-expect-error -- mocked browser preload API
+globalThis.window = { api: {} }
+
+const { createTestStore, makeTab } = await import('./store-test-helpers')
+
+const REPO_ID = 'repo1'
+const VISIBLE_ID = `${REPO_ID}::/repo/main`
+// A lane an agent CLI created with `git worktree add` under the repo's scratch container.
+const HIDDEN_ID = `${REPO_ID}::/repo/.claude/worktrees/lane-a`
+const DELETED_ID = `${REPO_ID}::/repo/.claude/worktrees/gone`
+const HIDDEN_TAB_ID = 'terminal-lane-a'
+const HIDDEN_GROUP_ID = 'group-lane-a'
+
+function detected(id: string, visible: boolean): DetectedWorktree {
+  return {
+    id,
+    repoId: REPO_ID,
+    path: id.split('::')[1]!,
+    head: 'abc123',
+    branch: 'refs/heads/lane',
+    isBare: false,
+    isMainWorktree: false,
+    displayName: 'lane',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    linkedGitLabMR: null,
+    linkedGitLabIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    ownership: visible ? 'orca-managed' : 'agent-scratch',
+    selectedCheckout: false,
+    visible
+  } as DetectedWorktree
+}
+
+const DETECTED = [detected(VISIBLE_ID, true), detected(HIDDEN_ID, false)]
+
+function catalog() {
+  return {
+    repos: [{ id: REPO_ID }],
+    // Mirrors the real store: worktreesByRepo carries only the rows the sidebar shows.
+    worktreesByRepo: {
+      [REPO_ID]: DETECTED.filter((worktree) => worktree.visible).map(({ id }) => ({ id }))
+    },
+    detectedWorktreesByRepo: {
+      [REPO_ID]: {
+        repoId: REPO_ID,
+        authoritative: true,
+        source: 'git' as const,
+        worktrees: DETECTED
+      }
+    }
+  }
+}
+
+describe('session hydration for worktrees hidden from the sidebar', () => {
+  it('keeps a hidden-but-detected worktree valid so its persisted panes survive a restart', () => {
+    expect(buildValidWorktreeIdsForSessionHydration(catalog(), [HIDDEN_ID]).has(HIDDEN_ID)).toBe(
+      true
+    )
+  })
+
+  it('still drops a persisted worktree an authoritative scan no longer detects', () => {
+    expect(buildValidWorktreeIdsForSessionHydration(catalog(), [DELETED_ID]).has(DELETED_ID)).toBe(
+      false
+    )
+  })
+
+  it('leaves the visible worktree valid', () => {
+    expect(buildValidWorktreeIdsForSessionHydration(catalog(), [VISIBLE_ID]).has(VISIBLE_ID)).toBe(
+      true
+    )
+  })
+
+  it('restores the terminal tab of a hidden worktree through a full hydration pass', () => {
+    const session: WorkspaceSessionState = {
+      ...getDefaultWorkspaceSession(),
+      activeRepoId: REPO_ID,
+      activeWorktreeId: HIDDEN_ID,
+      activeTabId: HIDDEN_TAB_ID,
+      tabsByWorktree: {
+        [HIDDEN_ID]: [makeTab({ id: HIDDEN_TAB_ID, worktreeId: HIDDEN_ID })]
+      },
+      unifiedTabs: {
+        [HIDDEN_ID]: [
+          {
+            id: HIDDEN_TAB_ID,
+            entityId: HIDDEN_TAB_ID,
+            groupId: HIDDEN_GROUP_ID,
+            worktreeId: HIDDEN_ID,
+            contentType: 'terminal',
+            label: 'Terminal',
+            customLabel: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1
+          }
+        ]
+      },
+      tabGroups: {
+        [HIDDEN_ID]: [
+          {
+            id: HIDDEN_GROUP_ID,
+            worktreeId: HIDDEN_ID,
+            activeTabId: HIDDEN_TAB_ID,
+            tabOrder: [HIDDEN_TAB_ID],
+            recentTabIds: [HIDDEN_TAB_ID]
+          }
+        ]
+      },
+      activeGroupIdByWorktree: { [HIDDEN_ID]: HIDDEN_GROUP_ID }
+    }
+
+    const store = createTestStore()
+    store.setState({
+      repos: [
+        { id: REPO_ID, path: '/repo', displayName: 'Repo', badgeColor: '#000', addedAt: 0 }
+      ],
+      // The authoritative scan sees both; only the visible one reaches worktreesByRepo.
+      worktreesByRepo: { [REPO_ID]: DETECTED.filter((w) => w.visible) },
+      detectedWorktreesByRepo: {
+        [REPO_ID]: {
+          repoId: REPO_ID,
+          authoritative: true,
+          source: 'git',
+          worktrees: DETECTED
+        }
+      }
+    })
+    store.getState().hydrateTabsSession(session)
+
+    expect(store.getState().unifiedTabsByWorktree[HIDDEN_ID]?.map((tab) => tab.id)).toEqual([
+      HIDDEN_TAB_ID
+    ])
+  })
+})


### PR DESCRIPTION
## ELI5

Orca hides some worktrees from the sidebar on purpose — anything under a path like `.claude/worktrees` that Orca did not create itself, even when that path is the one configured as the project’s worktree base. On restart, the code that decides "which workspaces may restore their tabs" could not tell *hidden* from *deleted*, so it threw those tabs away. The agents running in them stayed alive in the background daemon, but with nowhere on screen to appear. This teaches that check to keep a worktree the scan actually found on disk, even when it is not shown.

## What Changed

`buildValidWorktreeIdsForSessionHydration` now admits a persisted worktree id when the repo's detected-worktree listing contains it, regardless of whether it is visible in the sidebar.

Sixteen lines in one file, plus a test file.

The existing #1158 rule is untouched: a worktree an authoritative scan no longer detects is still dropped. Detection is what proves existence here, and detection includes hidden rows — visibility is a separate field on each detected worktree.

## Why

`worktreesByRepo` carries only the rows the sidebar shows, so a detected-but-hidden worktree (`agent-scratch`, or an un-imported external one) was indistinguishable from a deleted one at hydration. `tabs-hydration.ts` then skipped and deleted its entry, and the pruned state was persisted, making the loss permanent.

The visible symptom is worse than lost tabs. The terminal daemon outlives the app, so a PTY running an agent survives the restart while its pane does not. It comes back with no renderer leaf and is reported `orphaned: true` by `orca terminal list` while still `connected`, readable and writable — a live agent editing the repo that no UI surface can display. On my machine that was 12 of 15 running agent processes after one restart.

I considered fixing this at the persistence layer instead, by making `persistHostSessionBinding` true for agent terminals (`src/main/runtime/orca-runtime.ts:27737-27740`). That would help new terminals but leaves the destructive prune in place for everything already persisted, so the hydration check is the narrower and more correct place.

## Linked Issue

Fixes #15227

## Visual Proof

`N/A` — no UI or interaction change. This restores tab state that was previously discarded; there is no new or altered surface to show. The behavioural change is covered by the test below, which fails without the fix.

## Testing

The new test file fails on `main` and passes with the change:

```
$ npx vitest run --config config/vitest.config.ts \
    src/renderer/src/store/slices/hidden-worktree-tab-hydration.test.ts

# without the change
 × keeps a hidden-but-detected worktree valid so its persisted panes survive a restart
 × restores the terminal tab of a hidden worktree through a full hydration pass
   AssertionError: expected undefined to deeply equal [ 'terminal-lane-a' ]
 Tests  2 failed | 2 passed (4)

# with the change
 Tests  4 passed (4)
```

Four cases: the hidden worktree stays valid; a worktree an authoritative scan no longer detects is still dropped; the visible worktree is unaffected; and a full `hydrateTabsSession` pass restores the hidden worktree's terminal tab.

No regressions in the surrounding store:

```
$ npx vitest run --config config/vitest.config.ts src/renderer/src/store/slices/
 Test Files  265 passed (265)
      Tests  2660 passed (2660)
```

`pnpm typecheck` and `pnpm build` pass on Node 24.19.0 (both exit 0).

`pnpm lint` passes every gate except `verify:skill-bundle-manifest`, which reports `resources/skills/{current-manifest,snapshot-registry,release-mapping}.json` as stale. That failure reproduces identically with my commit stashed, on a tree matching `main` at 13b10e0b54, so it is pre-existing in my environment and not caused by this change. I have deliberately not run `pnpm generate:skill-bundle-manifest`, since regenerating those artifacts would add unrelated changes to this PR.

Platform tested: **Windows 11**. The change is pure store logic with no platform-dependent behaviour, no path handling, and no shell interaction, so it should behave identically on macOS and Linux — but I have not run it there.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Manual verification was of the diagnosis, on a running Orca: correlating `orca terminal list --json`, `orca terminal show`, `orca terminal read`, the daemon and app process start times, and the persisted workspace session. I did **not** run a rebuilt Orca against my own live fleet, since a dev build shares the profile and daemon with the production instance and I had agents running in it.

## AI Disclosure

Investigation and implementation done with Claude (Opus 5) in Claude Code. The diagnosis was verified against the running runtime and the persisted state rather than accepted from the model; the test was written before the fix and observed failing.

## Review

- **Security** — no new inputs, no I/O, no privilege or path handling. Reads store state already in memory.
- **Cross-platform** — pure store logic, no platform branches, no path parsing. Worktree ids are compared as opaque strings, exactly as the surrounding code already does.
- **Remote SSH** — the detected listing is per-repo and already host-scoped upstream of this function; SSH repos gain the same protection as local ones. Folder workspaces keep their existing early-continue.
- **Mobile** — none; renderer store only.
- **Backwards compatibility** — no persisted schema change. The widened catalog type reads a field the store already holds (`DetectedWorktreeListResult.worktrees`); older sessions with no detected listing fall through to the pre-existing #1158 path unchanged.
- **Performance** — one `Set` built per hydration from data already in memory, on a path that runs once at startup.
- **UI quality** — no UI change. A hidden worktree stays hidden in the sidebar; only its session state stops being destroyed.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — see the `verify:skill-bundle-manifest` note under Testing

## Author

- X / Twitter: @EnricoPin
