### PR TITLE
fix(relay): scope shell history for Windows -> WSL panes (STA-4682)

### DIFF
--- a/src/main/wsl.ts
+++ b/src/main/wsl.ts
@@ -8,7 +8,9 @@ import {
   dropStaleWslAvailabilityFailure
 } from './wsl-availability'
 
-export { toWindowsWslPath } from '../shared/wsl-paths'
+// Why re-exported rather than defined here: the relay bundle needs the path
+// conversion without this module's distro-probing subprocess graph.
+export { toLinuxPath, toWindowsWslPath } from '../shared/wsl-paths'
 export {
   getCachedWslAvailability,
   hasCachedWslAvailability,
@@ -115,31 +117,6 @@ export function wslUncDirectoryExistsAsync(uncPath: string): Promise<boolean | n
       resolve(parseWslDirectoryProbeOutput(stdout))
     })
   })
-}
-
-/**
- * Convert a Windows path to a Linux path for commands that will execute inside WSL.
- * Returns the path unchanged if it is already POSIX-style.
- *
- * Why: WSL hook/setup environments may need both the worktree UNC path
- * (\\wsl.localhost\...) and regular Windows install paths (C:\Users\...)
- * translated before passing them to bash. Leaving drive paths untouched
- * breaks scripts that read ORCA_ROOT_PATH or similar env vars inside WSL.
- */
-export function toLinuxPath(windowsPath: string): string {
-  const info = parseWslPath(windowsPath)
-  if (info) {
-    return info.linuxPath
-  }
-
-  const driveMatch = windowsPath.match(/^([A-Za-z]):[/\\](.*)$/)
-  if (!driveMatch) {
-    return windowsPath
-  }
-
-  const driveLetter = driveMatch[1].toLowerCase()
-  const rest = driveMatch[2].replace(/\\/g, '/')
-  return `/mnt/${driveLetter}/${rest}`
 }
 
 // ─── WSL home directory resolution ──────────────────────────────────

--- a/src/relay/pty-handler-spawn-environment.test.ts
+++ b/src/relay/pty-handler-spawn-environment.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
   resolveSetupAgentSequenceLaunchCommand,
@@ -194,6 +194,69 @@ describe('PtyHandler', () => {
         rows: 24,
         env: { fish_history: fishHistorySessionName(hashWorktreeId('r::/other')) }
       })
+
+      const spawnEnv = mockPtySpawn.mock.calls.at(-1)?.[2]?.env as Record<string, string>
+      expect(spawnEnv.fish_history).toBeUndefined()
+    })
+  })
+
+  describe('history isolation for a Windows relay launching WSL', () => {
+    const wslWorktreeId = 'r::/remote/wsl-worktree'
+    const wslHistoryFile = join(
+      homedir(),
+      '.orca-remote',
+      'terminal-history',
+      `${hashWorktreeId(wslWorktreeId)}-bash_history`
+    )
+    let previousPlatform: PropertyDescriptor | undefined
+
+    beforeEach(() => {
+      previousPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    })
+
+    afterEach(() => {
+      if (previousPlatform) {
+        Object.defineProperty(process, 'platform', previousPlatform)
+      }
+      rmSync(wslHistoryFile, { force: true })
+    })
+
+    const spawnWslPane = (): Promise<unknown> =>
+      dispatcher.callRequest('pty.spawn', {
+        cols: 80,
+        rows: 24,
+        shellOverride: 'wsl.exe',
+        terminalWindowsWslDistro: 'Ubuntu',
+        worktreeId: wslWorktreeId,
+        historyIsolationEnabled: true
+      })
+
+    it('scopes HISTFILE past the wsl.exe wrapper and carries it over WSLENV', async () => {
+      await spawnWslPane()
+
+      const spawnEnv = mockPtySpawn.mock.calls.at(-1)?.[2]?.env as Record<string, string>
+      expect(spawnEnv.HISTFILE?.endsWith(`${hashWorktreeId(wslWorktreeId)}-bash_history`)).toBe(
+        true
+      )
+      expect(spawnEnv.WSLENV?.split(':')).toContain('HISTFILE')
+    })
+
+    // The injected file lives on the relay host, so the existing host-side
+    // unlink is the deletion counterpart — no distro-scoped root is involved.
+    it('deletes the injected file through the ordinary relay history deletion', async () => {
+      await spawnWslPane()
+      expect(existsSync(wslHistoryFile)).toBe(true)
+
+      await dispatcher.callRequest('pty.deleteWorktreeHistory', { worktreeId: wslWorktreeId })
+
+      expect(existsSync(wslHistoryFile)).toBe(false)
+    })
+
+    // Guest fish keeps its history inside the distro, where relay deletion cannot
+    // reach it, so wsl.exe panes intentionally stay on shared fish history.
+    it('does not mint a fish session for a WSL pane', async () => {
+      await spawnWslPane()
 
       const spawnEnv = mockPtySpawn.mock.calls.at(-1)?.[2]?.env as Record<string, string>
       expect(spawnEnv.fish_history).toBeUndefined()

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -16,7 +16,8 @@ import {
   isProcessAlive,
   listShellProfiles
 } from './pty-shell-utils'
-import { getRelayShellLaunchConfig } from './pty-shell-launch'
+import { getRelayShellLaunchConfig, isRelayWslShell } from './pty-shell-launch'
+import { addWslEnvKeys } from '../shared/wsl-env'
 import { DEFAULT_SSH_RELAY_GRACE_PERIOD_SECONDS } from '../shared/ssh-types'
 import { shouldUseShellReadyStartupDelivery } from '../shared/codex-startup-delivery'
 import { buildStartupCommandSubmission } from '../shared/startup-command-submission'
@@ -1554,11 +1555,18 @@ export class PtyHandler {
     const worktreeId =
       typeof params.worktreeId === 'string' ? params.worktreeId : env?.ORCA_WORKTREE_ID
     const historyIsolationEnabled = params.historyIsolationEnabled === true
+    // Deliberately not reached by wsl.exe: a guest fish writes its history file
+    // inside the distro, where relay deletion cannot reach it (STA-4682).
     if (historyIsolationEnabled && worktreeId && basename(shell).toLowerCase().startsWith('fish')) {
       injectRelayFishHistoryEnv(spawnEnv, worktreeId)
     }
+    const wslShell = isRelayWslShell(shell)
     if (historyIsolationEnabled && worktreeId) {
-      injectRelayHistoryEnv(spawnEnv, worktreeId, shell)
+      const historyRoot = injectRelayHistoryEnv(spawnEnv, worktreeId, shell, { wsl: wslShell })
+      if (wslShell && historyRoot) {
+        // WSLENV is the only channel that carries a host env var into the guest.
+        addWslEnvKeys(spawnEnv, ['HISTFILE'])
+      }
     }
     const launchCommandHint = resolveSetupAgentSequenceLaunchCommand(spawnEnv, command)
     // Why: SSH PTYs bypass main's host-env builder, so apply the guard after the relay merges its authoritative env.
@@ -2162,6 +2170,8 @@ export class PtyHandler {
     ) {
       injectRelayFishHistoryEnv(spawnEnv, entry.worktreeId)
     }
+    // No WSL branch on purpose: revive re-spawns the host default shell rather
+    // than the entry's stored override, so this env matches the shell it launches.
     if (historyIsolationEnabled && entry.worktreeId) {
       injectRelayHistoryEnv(spawnEnv, entry.worktreeId, shell)
     }

--- a/src/relay/pty-shell-launch.test.ts
+++ b/src/relay/pty-shell-launch.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { spawnSync } from 'node:child_process'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { getRelayShellLaunchConfig } from './pty-shell-launch'
+import { getRelayShellLaunchConfig, isRelayWslShell } from './pty-shell-launch'
 
 const hasBash = process.platform !== 'win32' && spawnSync('bash', ['--version']).status === 0
 const itWithBash = hasBash ? it : it.skip
@@ -68,6 +68,24 @@ function expectFinalZdotdirRestoreContext(content: string) {
   expect(content).toContain("after Orca's last wrapper file has loaded")
   expect(content).toContain('export ZDOTDIR="$_orca_home"')
 }
+
+describe('isRelayWslShell', () => {
+  it.each(['wsl.exe', 'WSL.EXE', 'C:\\Windows\\System32\\wsl.exe', 'wsl'])(
+    'recognizes %s on a Windows relay',
+    (shell) => {
+      expect(isRelayWslShell(shell, 'win32')).toBe(true)
+    }
+  )
+
+  it.each([
+    ['C:\\Program Files\\Git\\bin\\bash.exe', 'win32' as const],
+    ['/bin/bash', 'win32' as const],
+    // A POSIX remote reaches no distro, so a like-named binary is an ordinary shell.
+    ['wsl.exe', 'linux' as const]
+  ])('does not treat %s on %s as a WSL launch', (shell, platform) => {
+    expect(isRelayWslShell(shell, platform)).toBe(false)
+  })
+})
 
 describe('getRelayShellLaunchConfig', () => {
   let homeDir: string

--- a/src/relay/pty-shell-launch.ts
+++ b/src/relay/pty-shell-launch.ts
@@ -13,6 +13,19 @@ function shellBasename(shellPath: string): string {
   return shellPath.replace(/\\/g, '/').split('/').pop()?.toLowerCase() ?? ''
 }
 
+/** The outer exe of a WSL launch; the shell the user actually types into lives
+ *  inside the distro, so history/env handling must look past this name. */
+export function isRelayWslShell(
+  shellPath: string,
+  platform: NodeJS.Platform = process.platform
+): boolean {
+  if (platform !== 'win32') {
+    return false
+  }
+  const name = shellBasename(shellPath)
+  return name === 'wsl.exe' || name === 'wsl'
+}
+
 function windowsShellArgs(
   shellName: string,
   options: { terminalWindowsWslDistro?: string | null } = {}

--- a/src/relay/terminal-history-wsl.test.ts
+++ b/src/relay/terminal-history-wsl.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest'
+import type * as NodeFs from 'node:fs'
+import type * as NodeOs from 'node:os'
+import { hashWorktreeId } from '../main/terminal-history-id'
+
+// Why mocked rather than a real temp dir: the assertion is the Windows -> Linux
+// path conversion, which only happens for a drive-letter root that cannot exist
+// on the macOS/Linux runners this suite executes on.
+vi.mock('node:os', async (importOriginal) => ({
+  ...(await importOriginal<typeof NodeOs>()),
+  homedir: () => 'C:\\Users\\relay'
+}))
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFs>()
+  const dirStat = { isSymbolicLink: () => false, isDirectory: () => true, isFile: () => false }
+  const fileStat = {
+    isSymbolicLink: () => false,
+    isDirectory: () => false,
+    isFile: () => true,
+    dev: 1n,
+    ino: 2n
+  }
+  return {
+    ...actual,
+    constants: actual.constants,
+    mkdirSync: vi.fn(),
+    lstatSync: vi.fn((path: string) => (path.endsWith('terminal-history') ? dirStat : fileStat)),
+    openSync: vi.fn(() => 42),
+    fstatSync: vi.fn(() => fileStat),
+    closeSync: vi.fn(),
+    unlinkSync: vi.fn()
+  }
+})
+
+const worktreeId = 'relay-wsl::/remote/worktree'
+
+describe('relay WSL shell history', () => {
+  it('hands the guest a drvfs path for the host history file', async () => {
+    const { injectRelayHistoryEnv } = await import('./terminal-history')
+    const env: Record<string, string> = {}
+
+    const root = injectRelayHistoryEnv(env, worktreeId, 'C:\\Windows\\System32\\wsl.exe', {
+      wsl: true
+    })
+
+    expect(root).toBe('C:\\Users\\relay/.orca-remote/terminal-history')
+    expect(env.HISTFILE).toBe(
+      `/mnt/c/Users/relay/.orca-remote/terminal-history/${hashWorktreeId(worktreeId)}-bash_history`
+    )
+    expect(env.ORCA_HISTFILE).toBe(env.HISTFILE)
+  })
+
+  it('leaves a host shell on the untranslated host path', async () => {
+    const { injectRelayHistoryEnv } = await import('./terminal-history')
+    const env: Record<string, string> = {}
+
+    injectRelayHistoryEnv(env, worktreeId, '/bin/bash')
+
+    expect(env.HISTFILE).toBe(
+      `C:\\Users\\relay/.orca-remote/terminal-history/${hashWorktreeId(worktreeId)}-bash_history`
+    )
+  })
+
+  it('scopes nothing for wsl.exe when the caller does not flag it as WSL', async () => {
+    const { injectRelayHistoryEnv } = await import('./terminal-history')
+    const env: Record<string, string> = {}
+
+    expect(injectRelayHistoryEnv(env, worktreeId, 'wsl.exe')).toBeNull()
+    expect(env.HISTFILE).toBeUndefined()
+  })
+})

--- a/src/relay/terminal-history.ts
+++ b/src/relay/terminal-history.ts
@@ -9,6 +9,7 @@ import {
 } from 'node:fs'
 import { homedir } from 'node:os'
 import { basename, join } from 'node:path'
+import { toLinuxPath } from '../shared/wsl-paths'
 import { hashWorktreeId } from '../main/terminal-history-id'
 import {
   deleteFishHistoryFile,
@@ -33,7 +34,8 @@ function historyFilename(shell: string): string | null {
 export function injectRelayHistoryEnv(
   env: Record<string, string>,
   worktreeId: string,
-  shell: string
+  shell: string,
+  options: { wsl?: boolean } = {}
 ): string | null {
   // Why first: same reason as the desktop path — an inherited ORCA_HISTFILE
   // would otherwise survive every early return below and let the remote wrapper
@@ -42,7 +44,9 @@ export function injectRelayHistoryEnv(
   if (env.HISTFILE) {
     return null
   }
-  const filename = historyFilename(shell)
+  // WSL's outer exe is wsl.exe, which matches no shell name; the guest login
+  // shell reads HISTFILE regardless, so pick the file the desktop path picks.
+  const filename = historyFilename(options.wsl ? 'bash' : shell)
   if (!filename) {
     return null
   }
@@ -81,12 +85,15 @@ export function injectRelayHistoryEnv(
       return null
     }
     closeSync(fd)
-    env.HISTFILE = path
+    // Why the same host file rather than a distro-scoped one: the guest reaches
+    // it over drvfs, so `deleteRelayHistory` still reclaims it by host path.
+    env.HISTFILE = options.wsl ? toLinuxPath(path) : path
     // Why a second variable: a remote macOS `/etc/zshrc` assigns HISTFILE
     // unconditionally before the wrapper runs, so the injected value is gone by
     // the first prompt. The wrapper restores it from here (#11044) — the same
-    // contract the desktop PTY path uses.
-    env.ORCA_HISTFILE = path
+    // contract the desktop PTY path uses. Under WSL it holds the guest-visible
+    // path and stays out of WSLENV, matching the desktop; no wrapper reads it there.
+    env.ORCA_HISTFILE = env.HISTFILE
     return HISTORY_ROOT
   } catch {
     return null

--- a/src/shared/wsl-paths.ts
+++ b/src/shared/wsl-paths.ts
@@ -20,6 +20,33 @@ export function isWslUncPath(path: string): boolean {
   return parseWslUncPath(path) !== null
 }
 
+/**
+ * Convert a Windows path to a Linux path for commands that will execute inside WSL.
+ * Returns the path unchanged if it is already POSIX-style.
+ *
+ * Why: WSL hook/setup environments may need both the worktree UNC path
+ * (\\wsl.localhost\...) and regular Windows install paths (C:\Users\...)
+ * translated before passing them to bash. Leaving drive paths untouched
+ * breaks scripts that read ORCA_ROOT_PATH or similar env vars inside WSL.
+ */
+export function toLinuxPath(windowsPath: string): string {
+  // Why the platform guard: on a POSIX host a literal `//wsl$/x` path is an
+  // ordinary directory, not a distro mount, so it must survive unchanged.
+  const info = process.platform === 'win32' ? parseWslUncPath(windowsPath) : null
+  if (info) {
+    return info.linuxPath
+  }
+
+  const driveMatch = windowsPath.match(/^([A-Za-z]):[/\\](.*)$/)
+  if (!driveMatch) {
+    return windowsPath
+  }
+
+  const driveLetter = driveMatch[1].toLowerCase()
+  const rest = driveMatch[2].replace(/\\/g, '/')
+  return `/mnt/${driveLetter}/${rest}`
+}
+
 /** Convert an absolute Linux path in a known WSL distro to its Windows form. */
 export function toWindowsWslPath(linuxPath: string, distro: string): string {
   const mntMatch = linuxPath.match(/^\/mnt\/([a-z])(\/.*)?$/)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​155 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​153 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​67 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​33 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​34 |

<!-- /orca-pr-loc -->

## ELI5

On a Windows remote host, opening a terminal that runs WSL gave you the *global* shell history — every worktree mixed together — while every other shell got its own per-worktree history. This teaches the relay that `wsl.exe` is a wrapper around a Linux shell, gives that shell a per-worktree `HISTFILE`, and hands it a path the Linux side can actually open.

## What Changed

- `src/relay/terminal-history.ts`: `injectRelayHistoryEnv` takes an optional `{ wsl }` flag. When set, it resolves the history filename as if the shell were `bash` (the outer exe is `wsl.exe`, which matches no shell name) and exports the guest-visible `/mnt/<drive>/...` form of the host path.
- `src/relay/pty-handler.ts` (spawn): detects a WSL launch and, when injection succeeded, adds `HISTFILE` to `WSLENV` — the only channel that carries a host env var into the distro.
- `src/relay/pty-shell-launch.ts`: new `isRelayWslShell(shellPath, platform)`, next to the existing `wsl.exe` arg handling.
- `src/shared/wsl-paths.ts` / `src/main/wsl.ts`: `toLinuxPath` moved to the pure shared path module and re-exported from `main/wsl`, so the relay bundle gets the conversion without `main/wsl`'s distro-probing subprocess graph. No behavior change; the `win32`-only UNC branch is preserved inline.

## Why

STA-4682 claim 2. `historyFilename` only matched `bash*`/`zsh*`, so `wsl.exe` — an allowed shell override the client already ships along with `historyIsolationEnabled` and `terminalWindowsWslDistro` — fell through with no `HISTFILE`. The desktop already handles exactly this case in `local-pty-provider.ts` by mapping the effective shell to `bash` and adding WSLENV keys; the relay had no equivalent.

**Deletion is the reason this is shaped the way it is.** Injecting history that nothing can delete is worse than today's no-op, so the injected file deliberately stays on the relay host under the existing flat `~/.orca-remote/terminal-history` root — the guest reaches it over drvfs, and only the *path representation* differs. That means `deleteRelayHistory` is already the working deletion counterpart and needed **no change at all**: no distro-scoped roots, no metadata sidecar, no `wsl.exe`-based cleanup. A test asserts the round trip (spawn creates the file, `pty.deleteWorktreeHistory` removes it).

Trade-off accepted: a Git-Bash pane and a WSL pane in the *same* worktree share one `bash_history` file, where the desktop would separate them by distro. Cross-worktree isolation — the point of the feature — holds either way, and it buys a deletion path that provably works.

### Not covered (deliberate)

- **fish inside the distro.** The desktop calls `injectWslFishHistoryEnv` for WSL panes because the guest login shell may be fish. Not done here: a fish history file minted into WSL lands at `$XDG_DATA_HOME/fish/<session>_history` *inside the distro*, and `deleteRelayFishHistory` resolves that directory from the relay's own Windows environment, so it would never delete it. Doing it properly needs the desktop's machinery (per-worktree metadata recording the distro, plus a `wsl.exe --exec fish` cleanup like `wsl-fish-history-cleanup.ts`), which is a larger change than this. Guest fish therefore keeps shared history, exactly as today — no regression, no orphan files. There is a comment at the injection site and a test pinning the behavior.
- **The revive path** (`reviveEntry`) is left as-is and is *not* inconsistent with the spawn path: it calls `resolveDefaultShell()` and ignores the entry's stored shell override, so it re-spawns the host default shell and its history env matches the shell it actually launches. A revived "WSL pane" is not running WSL at all today — that is a separate, larger bug (it would need the shell override serialized into the revive state) and is out of scope here. Noted in a code comment so the divergence is explicit.

## Linked Issue

STA-4682 (claim 2)

Fixes #

## Visual Proof

`N/A` — no UI surface. The change is shell environment plumbing on the relay host.

## Testing

Automated, measured on **macOS** (WSL cannot run here, so every WSL path is unit-tested with a mocked platform/homedir rather than a live distro):

- `src/relay/terminal-history-wsl.test.ts` (new): mocks `node:os` homedir to `C:\Users\relay` and `node:fs` so the drive-letter root is reachable off Windows, and asserts the guest gets `/mnt/c/.../<hash>-bash_history`. Also pins that a host shell keeps the untranslated path and that `wsl.exe` without the flag still scopes nothing.
- `src/relay/pty-handler-spawn-environment.test.ts`: a `win32`-simulated spawn with `shellOverride: 'wsl.exe'` asserts (1) `HISTFILE` is worktree-scoped, (2) `WSLENV` carries `HISTFILE`, (3) `pty.deleteWorktreeHistory` removes the created file, (4) no fish session is minted.
- `src/relay/pty-shell-launch.test.ts`: `isRelayWslShell` positive/negative cases including a POSIX remote.

Every new assertion was verified to fail without the fix: stashing the source changes and re-running produced 3 failures (`hands the guest a drvfs path...`, `scopes HISTFILE past the wsl.exe wrapper...`, `deletes the injected file...`); the remaining new cases are regression guards for behavior this PR must not change.

Commands run:

- `npx oxlint <changed files>` — clean
- `npx tsc --noEmit -p config/tsconfig.node.json` — clean
- `npx vitest run --config config/vitest.config.ts` over the relay pty/history suites plus `src/main/terminal-history.test.ts`, `src/main/wsl.test.ts`, `src/shared/wsl-paths.test.ts` and the `toLinuxPath` consumers touched by the move — all passing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Not manually tested: reproducing it needs a Windows relay host with WSL, reached over SSH from a second machine.

## AI Disclosure

Claude Opus.

## Review

### Remote wire compatibility

No wire change. `historyIsolationEnabled`, `shellOverride`, and `terminalWindowsWslDistro` are all already sent by `buildSshPtySpawnRequest`; this only changes what the host does with them. An old host paired with a new client keeps today's behavior (no WSL history scoping); a new host paired with an old client gets scoping as soon as the client sends `historyIsolationEnabled`, which it already does. The serialized revive state is untouched.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Security**: the history file is created on the host with the same `O_NOFOLLOW`/`lstat`/`fstat` symlink checks as before; the WSL branch only changes the *string* exported to the child. No new path is accepted from the client.
- **Cross-platform**: the new branch is gated on `platform === 'win32'` inside `isRelayWslShell`, so POSIX relays are untouched even if a binary is literally named `wsl`.
- **Degradation**: if a user has disabled drvfs automount in their distro, `HISTFILE` names an unreachable path and that pane saves no history. The desktop path has the identical exposure, so this sets no new precedent.
- **Performance**: one extra regex on the spawn path.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
