### PR TITLE
fix(mobile): escalate a persistently rejected Relay pairing to re-pair (STA-4681)

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-08-17",
+  "updatedAt": "2026-08-18",
   "policy": {
     "maturityLevels": ["experimental", "soak", "blocking", "accepted-gap", "deprecated"],
     "blockingPromotion": {
@@ -943,15 +943,16 @@
       "providers": ["lan", "tailscale", "cloud-relay"],
       "coveredPlatforms": ["macos"],
       "coveredProviders": ["lan", "tailscale", "cloud-relay"],
-      "coverageNotes": "Deterministic TypeScript tests cover shared close-code policy, foreground retry timers, continuous-outage escalation, direct-winner cancellation, credential-gated Relay presentation, and concurrent LAN/Tailscale authentication. Physical iOS/Android radios, GFE, and production relay recovery remain live-test gaps.",
+      "coverageNotes": "Deterministic TypeScript tests cover shared close-code policy, foreground retry timers, continuous-outage escalation, persistent pairing-rejection escalation, direct-winner cancellation, credential-gated Relay presentation, and concurrent LAN/Tailscale authentication. Physical iOS/Android radios, GFE, and production relay recovery remain live-test gaps.",
       "motivatingLinks": [
         "https://github.com/stablyai/orca-cloud/pull/96",
-        "https://linear.app/stably/issue/STA-4587"
+        "https://linear.app/stably/issue/STA-4587",
+        "https://linear.app/stably/issue/STA-4681"
       ],
-      "invariant": "A foregrounded paired phone must recover from relay HOST_OFFLINE without a foreground or network-change signal, while direct recovery must select the first authenticated configured LAN or Tailscale endpoint without serial timeout delays. Relay recovery presentation starts only for a failed active Relay or a dial backed by an eligible credential, remains pending through a genuine failed-dial cooldown, and exposes the supervisor's consecutive failed-dial count so a continuous outage escalates to unreachable. Backgrounding, direct success, or stop must cancel pending work, and losing probes must close without affecting the winner.",
-      "oracle": "Inject deterministic relay close codes, missing and expired credentials, delayed credential reads, random bytes, fake timers, and independently controlled direct clients. Require HOST_OFFLINE to replace any faster transport timer with one 5-15 second retry, require no retry before the selected delay, keep Relay presentation absent when no socket can open, clear it across lifecycle races, retain it through real dial cooldowns, establish Relay through the supervisor and require its active close plus 11 failed replacements to publish reconnect attempt 12 and a Relay-unreachable verdict, race all unique non-relay endpoints, select the first authenticated path, close every loser exactly once, and retain no retry after direct connectivity wins.",
+      "invariant": "A foregrounded paired phone must recover from relay HOST_OFFLINE without a foreground or network-change signal, while direct recovery must select the first authenticated configured LAN or Tailscale endpoint without serial timeout delays. Relay recovery presentation starts only for a failed active Relay or a dial backed by an eligible credential, remains pending through a genuine failed-dial cooldown, and exposes the supervisor's consecutive failed-dial count so a continuous outage escalates to unreachable. A relay credential the desktop keeps refusing escalates to re-pair once its transient-rejection budget is spent, and only an authenticated session clears that verdict. Backgrounding, direct success, or stop must cancel pending work, and losing probes must close without affecting the winner.",
+      "oracle": "Inject deterministic relay close codes, missing and expired credentials, delayed credential reads, random bytes, fake timers, and independently controlled direct clients. Require HOST_OFFLINE to replace any faster transport timer with one 5-15 second retry, require no retry before the selected delay, keep Relay presentation absent when no socket can open, clear it across lifecycle races, retain it through real dial cooldowns, establish Relay through the supervisor and require its active close plus 11 failed replacements to publish reconnect attempt 12 and a Relay-unreachable verdict, race all unique non-relay endpoints, select the first authenticated path, close every loser exactly once, and retain no retry after direct connectivity wins. Drive a supervisor-established Relay through four simulated hours of E2EE rejections and require the re-pair verdict, require it to survive a background/foreground cycle, require two rejections followed by acceptance to never latch it, and require a plain transport outage to still read Relay-unreachable.",
       "commands": [
-        "pnpm --dir mobile exec vitest run --root .. mobile/src/transport/mobile-direct-endpoint-probe.test.ts mobile/src/transport/mobile-relay-reconnect-controller.test.ts mobile/src/transport/mobile-endpoint-supervisor.test.ts mobile/src/transport/mobile-relay-outage-escalation.test.ts mobile/src/transport/stable-logical-rpc-client.test.ts mobile/src/transport/mobile-relay-runtime-failover.test.ts",
+        "pnpm --dir mobile exec vitest run --root .. mobile/src/transport/mobile-direct-endpoint-probe.test.ts mobile/src/transport/mobile-relay-reconnect-controller.test.ts mobile/src/transport/mobile-endpoint-supervisor.test.ts mobile/src/transport/mobile-relay-outage-escalation.test.ts mobile/src/transport/mobile-relay-pairing-rejection-escalation.test.ts mobile/src/transport/stable-logical-rpc-client.test.ts mobile/src/transport/mobile-relay-runtime-failover.test.ts mobile/src/transport/connection-health.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/shared/mobile-relay-close-codes.test.ts --reporter=dot"
       ],
       "testFiles": [
@@ -959,8 +960,10 @@
         "mobile/src/transport/mobile-relay-reconnect-controller.test.ts",
         "mobile/src/transport/mobile-endpoint-supervisor.test.ts",
         "mobile/src/transport/mobile-relay-outage-escalation.test.ts",
+        "mobile/src/transport/mobile-relay-pairing-rejection-escalation.test.ts",
         "mobile/src/transport/stable-logical-rpc-client.test.ts",
         "mobile/src/transport/mobile-relay-runtime-failover.test.ts",
+        "mobile/src/transport/connection-health.test.ts",
         "src/shared/mobile-relay-close-codes.test.ts"
       ],
       "assertionRefs": [
@@ -995,6 +998,22 @@
           ]
         },
         {
+          "file": "mobile/src/transport/mobile-relay-pairing-rejection-escalation.test.ts",
+          "assertions": [
+            "a persistent E2EE rejection escalates to Pairing invalid — re-pair with your desktop",
+            "the re-pair verdict survives a background/foreground cycle",
+            "rejections inside the transient budget followed by acceptance never latch it",
+            "a plain transport outage still reads Can't connect via Relay"
+          ]
+        },
+        {
+          "file": "mobile/src/transport/connection-health.test.ts",
+          "assertions": [
+            "a rejected pairing outranks a pending Relay recovery",
+            "a rejected pairing never overrides a live connection"
+          ]
+        },
+        {
           "file": "mobile/src/transport/stable-logical-rpc-client.test.ts",
           "assertions": [
             "supervisor Relay attempts overlay but never replace a larger active-session retry count",
@@ -1015,13 +1034,13 @@
       ],
       "evidenceRuns": [
         {
-          "date": "2026-08-17",
+          "date": "2026-08-18",
           "runner": "local",
           "platform": "macos",
-          "command": "pnpm --dir mobile exec vitest run --root .. mobile/src/transport/mobile-direct-endpoint-probe.test.ts mobile/src/transport/mobile-relay-reconnect-controller.test.ts mobile/src/transport/mobile-endpoint-supervisor.test.ts mobile/src/transport/mobile-relay-outage-escalation.test.ts mobile/src/transport/stable-logical-rpc-client.test.ts mobile/src/transport/mobile-relay-runtime-failover.test.ts",
+          "command": "pnpm --dir mobile exec vitest run --root .. mobile/src/transport/mobile-direct-endpoint-probe.test.ts mobile/src/transport/mobile-relay-reconnect-controller.test.ts mobile/src/transport/mobile-endpoint-supervisor.test.ts mobile/src/transport/mobile-relay-outage-escalation.test.ts mobile/src/transport/mobile-relay-pairing-rejection-escalation.test.ts mobile/src/transport/stable-logical-rpc-client.test.ts mobile/src/transport/mobile-relay-runtime-failover.test.ts mobile/src/transport/connection-health.test.ts",
           "result": "passed",
-          "durationSeconds": 2.31,
-          "summary": "Six focused mobile transport files passed with 82 assertions, including production-lifecycle outage escalation and logical count publication."
+          "durationSeconds": 1.25,
+          "summary": "Eight focused mobile transport files passed with 109 assertions, including production-lifecycle outage escalation, persistent pairing-rejection escalation, and logical count publication."
         },
         {
           "date": "2026-08-16",
@@ -1043,11 +1062,11 @@
       },
       "redGreenEvidence": {
         "status": "complete",
-        "evidence": "The pre-fix production-lifecycle oracle establishes Relay through the supervisor, then completes one active close plus 11 replacement failures while the public retry count remains 0; the candidate publishes 12 and reaches the existing Relay-unreachable verdict. The prior external-signal HOST_OFFLINE policy and serial direct probe also fail their respective retry and first-authenticated-endpoint timing oracles."
+        "evidence": "Banking the pairing rejection after registerFailure's gated early return — the pre-fix placement — leaves the four-hour E2EE oracle on 'Connecting via Relay…' and reds 7 assertions while the 17 others stay green; moving it ahead of the gate turns them green. The pre-fix production-lifecycle oracle establishes Relay through the supervisor, then completes one active close plus 11 replacement failures while the public retry count remains 0; the candidate publishes 12 and reaches the existing Relay-unreachable verdict. The prior external-signal HOST_OFFLINE policy and serial direct probe also fail their respective retry and first-authenticated-endpoint timing oracles."
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "The production diff only projects the existing supervisor failure count through local setters and subscribers; it adds no call to a Relay dial, timer, socket, probe, or wire API. The deterministic outage asserts exactly one successful establishment plus 11 failed replacements at the escalation boundary. All configured direct candidates start in one turn, the first authenticated candidate wins after 100 ms, and every losing client is closed."
+        "evidence": "The production diff only projects existing supervisor state — the failure count and a consecutive-rejection latch — through local setters and subscribers; it adds no call to a Relay dial, timer, socket, probe, or wire API, and the four screens read both recovery inputs from one host subscription instead of two. The deterministic outage asserts exactly one successful establishment plus 11 failed replacements at the escalation boundary. All configured direct candidates start in one turn, the first authenticated candidate wins after 100 ms, and every losing client is closed."
       },
       "promotionCriteria": [
         "Collect 100 consecutive CI passes or 14 days of soak history.",

--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -32,7 +32,7 @@ import { useWorktreeResync } from '../../../src/transport/use-worktree-resync'
 import { startHostWorktreeRefresh } from '../../../src/worktree/host-worktree-refresh'
 import {
   useLastConnectedAt,
-  usePendingConnectionPath,
+  useRelayRecoveryStatus,
   useReconnectAttempt
 } from '../../../src/transport/client-context-connection-metrics'
 import {
@@ -139,7 +139,7 @@ export function HostScreen({
   const { client, state: connState } = useHostClient(hostId)
   const reconnectAttempts = useReconnectAttempt(hostId)
   const lastConnectedAt = useLastConnectedAt(hostId)
-  const pendingConnectionPath = usePendingConnectionPath(hostId)
+  const relayRecovery = useRelayRecoveryStatus(hostId)
   const clientRef = useRef<RpcClient | null>(null)
   const fetchWorktreesInFlightRef = useRef(false)
   // Why: useRef, not useMemo — React may discard memoized values, which would silently
@@ -820,7 +820,7 @@ export function HostScreen({
               state: connState,
               reconnectAttempts,
               lastConnectedAt,
-              pendingPath: pendingConnectionPath
+              ...relayRecovery
             })
             return (
               <>

--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -1099,8 +1099,8 @@ export function HostScreen({
         )}
       </View>
 
-      {/* Auth failed banner */}
-      {connState === 'auth-failed' && (
+      {/* Auth failed: a latched relay rejection must reach the same re-pair affordance. */}
+      {(connState === 'auth-failed' || relayRecovery.pairingRejected) && (
         <AuthFailedBanner
           canRetry={!!hostId}
           onRetry={() => hostId && void forceReconnectHost(hostId)}

--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -61,7 +61,7 @@ import {
 import { useHostClient, useForceReconnect } from '../../../../src/transport/client-context'
 import {
   useLastConnectedAt,
-  usePendingConnectionPath,
+  useRelayRecoveryStatus,
   useReconnectAttempt
 } from '../../../../src/transport/client-context-connection-metrics'
 import {
@@ -738,7 +738,7 @@ export default function SessionScreen() {
   const { client, state: connState } = useHostClient(hostId)
   const reconnectAttempts = useReconnectAttempt(hostId)
   const lastConnectedAt = useLastConnectedAt(hostId)
-  const pendingConnectionPath = usePendingConnectionPath(hostId)
+  const relayRecovery = useRelayRecoveryStatus(hostId)
   const forceReconnectHost = useForceReconnect()
   const { name: worktreeName, resolution: worktreeResolution } = useLiveWorktreeName({
     client,
@@ -4186,7 +4186,7 @@ export default function SessionScreen() {
     reconnectAttempts,
     lastConnectedAt,
     endpoint: hostEndpoint,
-    pendingPath: pendingConnectionPath
+    ...relayRecovery
   })
   const showConnectionRetry =
     connectionVerdict.kind === 'warning' || connectionVerdict.kind === 'unreachable'

--- a/mobile/app/h/[hostId]/tasks.tsx
+++ b/mobile/app/h/[hostId]/tasks.tsx
@@ -37,7 +37,7 @@ import type { RpcSuccess } from '../../../src/transport/types'
 import { useHostClient } from '../../../src/transport/client-context'
 import {
   useLastConnectedAt,
-  usePendingConnectionPath,
+  useRelayRecoveryStatus,
   useReconnectAttempt
 } from '../../../src/transport/client-context-connection-metrics'
 import { classifyConnection } from '../../../src/transport/connection-health'
@@ -2074,7 +2074,7 @@ export default function MobileTasksScreen() {
   const { client, state: connState } = useHostClient(hostId)
   const reconnectAttempts = useReconnectAttempt(hostId)
   const lastConnectedAt = useLastConnectedAt(hostId)
-  const pendingConnectionPath = usePendingConnectionPath(hostId)
+  const relayRecovery = useRelayRecoveryStatus(hostId)
   const clientRef = useRef<RpcClient | null>(null)
   const loadGenerationRef = useRef(0)
   const taskResumeRef = useRef<TaskResumeState>({})
@@ -8676,7 +8676,7 @@ export default function MobileTasksScreen() {
     state: connState,
     reconnectAttempts,
     lastConnectedAt,
-    pendingPath: pendingConnectionPath
+    ...relayRecovery
   })
   const emptyLabel =
     connState !== 'connected'

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -263,6 +263,13 @@ export default function HomeScreen() {
     () => Object.fromEntries(allClients.map(({ hostId, pendingPath }) => [hostId, pendingPath])),
     [allClients]
   )
+  const hostPairingRejected = useMemo(
+    () =>
+      Object.fromEntries(
+        allClients.map(({ hostId, pairingRejected }) => [hostId, pairingRejected])
+      ),
+    [allClients]
+  )
   const disconnectHostClient = useDisconnectHostClient()
   const forgetHostClient = useForgetHostClient()
   const forceReconnectHost = useForceReconnect()
@@ -770,7 +777,8 @@ export default function HomeScreen() {
               reconnectAttempts: attempts,
               lastConnectedAt,
               endpoint: item.endpoint,
-              pendingPath: hostPendingPaths[item.id] ?? null
+              pendingPath: hostPendingPaths[item.id] ?? null,
+              pairingRejected: hostPairingRejected[item.id] ?? false
             })
             return (
               <MobileHostCard

--- a/mobile/src/transport/client-context-connection-metrics.ts
+++ b/mobile/src/transport/client-context-connection-metrics.ts
@@ -10,8 +10,20 @@ export function useLastConnectedAt(hostId: string | undefined): number | null {
   return useHostMetric(hostId, (context, id) => context.getLastConnectedAt(id), null)
 }
 
-export function usePendingConnectionPath(hostId: string | undefined): MobileConnectionPath | null {
-  return useHostMetric(hostId, (context, id) => context.getPendingPath(id), null)
+// Both inputs classifyConnection needs about a relay recovery, read from one
+// subscription so a screen cannot render half of the escalation.
+export function useRelayRecoveryStatus(hostId: string | undefined): {
+  pendingPath: MobileConnectionPath | null
+  pairingRejected: boolean
+} {
+  return useHostMetric(
+    hostId,
+    (context, id) => ({
+      pendingPath: context.getPendingPath(id),
+      pairingRejected: context.isPairingRejected(id)
+    }),
+    { pendingPath: null, pairingRejected: false }
+  )
 }
 
 function useHostMetric<T>(

--- a/mobile/src/transport/client-context.test.ts
+++ b/mobile/src/transport/client-context.test.ts
@@ -28,17 +28,20 @@ import {
   useHostClient
 } from './client-context'
 import { useAllHostClients } from './use-all-host-clients'
+import { useRelayRecoveryStatus } from './client-context-connection-metrics'
 import { selectHomeAutoConnectHostIds } from './home-host-auto-connect'
 
 type FakeClient = RpcClient & {
   emitState: (state: ConnectionState) => void
   emitPendingPath: (path: MobileConnectionPath | null) => void
+  emitPairingRejected: (rejected: boolean) => void
   closeMock: ReturnType<typeof vi.fn>
 }
 
 function makeFakeClient(initialState: ConnectionState): FakeClient {
   let state = initialState
   let pendingPath: MobileConnectionPath | null = null
+  let pairingRejected = false
   const listeners = new Set<(state: ConnectionState) => void>()
   const pathListeners = new Set<() => void>()
   const closeMock = vi.fn()
@@ -51,6 +54,7 @@ function makeFakeClient(initialState: ConnectionState): FakeClient {
     getLastConnectedAt: () => null,
     getActivePath: () => 'tailscale',
     getPendingPath: () => pendingPath,
+    isPairingRejected: () => pairingRejected,
     onConnectionPathChange: (listener: () => void) => {
       pathListeners.add(listener)
       return () => pathListeners.delete(listener)
@@ -70,6 +74,12 @@ function makeFakeClient(initialState: ConnectionState): FakeClient {
     },
     emitPendingPath: (next) => {
       pendingPath = next
+      for (const listener of pathListeners) {
+        listener()
+      }
+    },
+    emitPairingRejected: (next) => {
+      pairingRejected = next
       for (const listener of pathListeners) {
         listener()
       }
@@ -429,6 +439,35 @@ describe('useAllHostClients', () => {
 
     act(() => client.emitPendingPath('relay'))
     expect(pendingPath).toBe('relay')
+
+    act(() => renderer.unmount())
+  })
+
+  it('publishes a latched pairing rejection to the screens', async () => {
+    const client = makeFakeClient('reconnecting')
+    connectMock.mockReturnValue(client)
+    loadHostsMock.mockResolvedValue([HOST])
+    let status: { pendingPath: MobileConnectionPath | null; pairingRejected: boolean } | undefined
+    let renderer!: ReturnType<typeof create>
+
+    function Probe(): null {
+      // Why: a screen holds the host client and reads the metric hooks beside it.
+      useAllHostClients([HOST.id])
+      status = useRelayRecoveryStatus(HOST.id)
+      return null
+    }
+
+    await act(async () => {
+      renderer = create(createElement(RpcClientProvider, null, createElement(Probe)))
+      await Promise.resolve()
+    })
+    act(() => client.emitPendingPath('relay'))
+    expect(status).toEqual({ pendingPath: 'relay', pairingRejected: false })
+
+    // Why: the desktop refusing the credential is a status-only change — no
+    // transport state moves, so only the connection-path signal can carry it.
+    act(() => client.emitPairingRejected(true))
+    expect(status).toEqual({ pendingPath: 'relay', pairingRejected: true })
 
     act(() => renderer.unmount())
   })

--- a/mobile/src/transport/connection-health.test.ts
+++ b/mobile/src/transport/connection-health.test.ts
@@ -14,6 +14,32 @@ describe('classifyConnection auth-failed verdict', () => {
   })
 })
 
+describe('classifyConnection pairing-rejected verdict', () => {
+  it('outranks a pending Relay recovery that would otherwise read as progress', () => {
+    const verdict = classifyConnection({
+      state: 'disconnected',
+      reconnectAttempts: 1,
+      lastConnectedAt: 1_000,
+      pendingPath: 'relay',
+      pairingRejected: true,
+      nowMs: 1_000_000
+    })
+    expect(verdict.kind).toBe('auth-failed')
+    expect(verdictDisplayLabel(verdict)).toBe('Pairing invalid — re-pair with your desktop')
+  })
+
+  it('never overrides a live connection', () => {
+    const verdict = classifyConnection({
+      state: 'connected',
+      reconnectAttempts: 0,
+      lastConnectedAt: 999_000,
+      pairingRejected: true,
+      nowMs: 1_000_000
+    })
+    expect(verdict).toEqual({ kind: 'normal', label: 'Connected' })
+  })
+})
+
 describe('classifyConnection Tailscale hint', () => {
   const base = {
     state: 'reconnecting' as const,

--- a/mobile/src/transport/connection-health.ts
+++ b/mobile/src/transport/connection-health.ts
@@ -51,6 +51,9 @@ export function classifyConnection(args: {
   // warning/unreachable verdicts. Callers without it get plain labels.
   endpoint?: string | null
   pendingPath?: MobileConnectionPath | null
+  // The desktop has repeatedly refused this device's relay credential — retrying
+  // cannot fix it, so it outranks any "still connecting" reading (STA-4681).
+  pairingRejected?: boolean
   nowMs?: number
 }): ConnectionVerdict {
   const { state, reconnectAttempts, lastConnectedAt } = args
@@ -59,7 +62,7 @@ export function classifyConnection(args: {
 
   // Why: auth-failed means the desktop no longer recognizes this pairing (e.g. it
   // lost its device registry) — retrying can't fix it, only re-pairing can, so say so.
-  if (state === 'auth-failed') {
+  if (state === 'auth-failed' || (args.pairingRejected && state !== 'connected')) {
     return { kind: 'auth-failed', label: 'Pairing invalid — re-pair with your desktop' }
   }
 

--- a/mobile/src/transport/host-client-context-state.ts
+++ b/mobile/src/transport/host-client-context-state.ts
@@ -86,8 +86,15 @@ export function createHostClientSelectors(
     getActivePath: (hostId: string): MobileConnectionPath =>
       clientActivePath(entries.get(hostId)?.client),
     getPendingPath: (hostId: string): MobileConnectionPath | null =>
-      clientPendingPath(entries.get(hostId)?.client)
+      clientPendingPath(entries.get(hostId)?.client),
+    isPairingRejected: (hostId: string): boolean =>
+      clientPairingRejected(entries.get(hostId)?.client)
   }
+}
+
+export function clientPairingRejected(client: RpcClient | undefined): boolean {
+  const logical = client as Partial<StableLogicalRpcClient> | undefined
+  return logical?.isPairingRejected?.() ?? false
 }
 
 export function clientActivePath(client: RpcClient | undefined): MobileConnectionPath {

--- a/mobile/src/transport/logical-client-connection-path.ts
+++ b/mobile/src/transport/logical-client-connection-path.ts
@@ -4,6 +4,7 @@ export class LogicalClientConnectionPath {
   private migration: MobileConnectionPath | null = null
   private recovery: MobileConnectionPath | null = null
   private recoveryAttempt = 0
+  private pairingRejected = false
   private readonly listeners = new Set<() => void>()
 
   constructor(private readonly isConnected: () => boolean) {}
@@ -24,10 +25,22 @@ export class LogicalClientConnectionPath {
       : activeAttempt
   }
 
+  isPairingRejected(): boolean {
+    return this.pairingRejected
+  }
+
+  setPairingRejected(rejected: boolean): void {
+    this.update(() => {
+      this.pairingRejected = rejected
+    })
+  }
+
   clearAfterConnected(): void {
     this.migration = null
     this.recovery = null
     this.recoveryAttempt = 0
+    // Why: an authenticated session is the desktop accepting this device.
+    this.pairingRejected = false
   }
 
   setRecovery(path: MobileConnectionPath | null, attempt?: number): void {
@@ -55,8 +68,13 @@ export class LogicalClientConnectionPath {
   private update(apply: () => void): void {
     const previousPath = this.pending()
     const previousAttempt = this.reconnectAttempt(0)
+    const previousRejected = this.pairingRejected
     apply()
-    if (previousPath === this.pending() && previousAttempt === this.reconnectAttempt(0)) {
+    if (
+      previousPath === this.pending() &&
+      previousAttempt === this.reconnectAttempt(0) &&
+      previousRejected === this.pairingRejected
+    ) {
       return
     }
     for (const listener of this.listeners) {

--- a/mobile/src/transport/mobile-endpoint-supervisor-test-fakes.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor-test-fakes.ts
@@ -129,6 +129,13 @@ export class FakeLogicalClient extends FakeSession implements StableLogicalRpcCl
     }
   })
   isPairingRejected = () => this.pairingRejected
+  // Mirrors LogicalClientConnectionPath.clearAfterConnected.
+  publishState(state: ConnectionState): void {
+    if (state === 'connected') {
+      this.pairingRejected = false
+    }
+    super.publishState(state)
+  }
   setRecoveryAttempt = vi.fn((attempt: number) => {
     const previous = this.getReconnectAttempt()
     this.recoveryAttempt = attempt

--- a/mobile/src/transport/mobile-endpoint-supervisor-test-fakes.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor-test-fakes.ts
@@ -118,6 +118,17 @@ export class FakeLogicalClient extends FakeSession implements StableLogicalRpcCl
       }
     }
   })
+  private pairingRejected = false
+  setPairingRejected = vi.fn((rejected: boolean) => {
+    if (this.pairingRejected === rejected) {
+      return
+    }
+    this.pairingRejected = rejected
+    for (const listener of this.pathListeners) {
+      listener()
+    }
+  })
+  isPairingRejected = () => this.pairingRejected
   setRecoveryAttempt = vi.fn((attempt: number) => {
     const previous = this.getReconnectAttempt()
     this.recoveryAttempt = attempt

--- a/mobile/src/transport/mobile-endpoint-supervisor.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.ts
@@ -58,7 +58,7 @@ export class MobileEndpointSupervisor {
     })
     this.logRelay = createRelayRecoveryLog(dependencies.now, dependencies.onLog)
     this.relayReconnect = new RelayReconnectController(dependencies, this.recoverRelay.bind(this))
-    this.relayReconnect.reportFailureCountTo(logical.setRecoveryAttempt)
+    this.relayReconnect.reportRecoveryTo(logical)
     this.nudgeRouter = new MobileEndpointNudgeRouter({
       logical,
       controller: this.relayReconnect,

--- a/mobile/src/transport/mobile-relay-pairing-rejection-escalation.test.ts
+++ b/mobile/src/transport/mobile-relay-pairing-rejection-escalation.test.ts
@@ -143,6 +143,59 @@ describe('continuous Relay pairing-rejection escalation', () => {
     logical.close()
   })
 
+  it('escalates inside a bounded window, and never on a brief blip', async () => {
+    // Why: the budget is only meaningful with a cadence. Three rejections cost one fast
+    // transport retry plus two gated reprobes (60s and 120s bases, jittered 0.75-1.25x),
+    // so the floor is ~2m15s and the ceiling ~3m45s in production.
+    const { activeRelay, logical, supervisor } = harness(new MobileE2EEAuthenticationError())
+
+    await supervisor.start()
+    activeRelay.publishState('disconnected')
+
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(logical.isPairingRejected()).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(4 * 60_000)
+    expect(logical.isPairingRejected()).toBe(true)
+    supervisor.stop()
+    logical.close()
+  })
+
+  it('clears the verdict end to end when the desktop accepts the pairing again', async () => {
+    // Why: the unit tests clear the latch through controller methods directly. If the
+    // supervisor's success wiring regressed, a re-paired phone would stay on "re-pair"
+    // forever with every other assertion still green.
+    const { activeRelay, logical, supervisor } = harness(new MobileE2EEAuthenticationError(), 4)
+
+    await supervisor.start()
+    activeRelay.publishState('disconnected')
+    await vi.advanceTimersByTimeAsync(4 * 60_000)
+    expect(logical.isPairingRejected()).toBe(true)
+
+    await vi.advanceTimersByTimeAsync(FOUR_HOURS_MS)
+
+    expect(logical.isPairingRejected()).toBe(false)
+    expect(logical.getActivePath()).toBe('relay')
+    expect(verdict(logical)).toMatchObject({ kind: 'normal' })
+    supervisor.stop()
+    logical.close()
+  })
+
+  it('never reports re-pair for a rejected relay credential', async () => {
+    // Why: a 4401 close enters the fresh-credential gate, not the pairing-rejection
+    // path. It is repaired by credential rotation, so it must not accuse the pairing.
+    const { activeRelay, logical, supervisor } = harness(new RelayOuterError(4401))
+
+    await supervisor.start()
+    activeRelay.publishState('disconnected')
+    await vi.advanceTimersByTimeAsync(FOUR_HOURS_MS)
+
+    expect(logical.isPairingRejected()).toBe(false)
+    expect(verdict(logical).kind).not.toBe('auth-failed')
+    supervisor.stop()
+    logical.close()
+  })
+
   it('leaves a plain transport outage on the Relay-unreachable verdict', async () => {
     const { activeRelay, logical, supervisor } = harness(new RelayOuterError(4408))
 

--- a/mobile/src/transport/mobile-relay-pairing-rejection-escalation.test.ts
+++ b/mobile/src/transport/mobile-relay-pairing-rejection-escalation.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { classifyConnection, type ConnectionVerdict } from './connection-health'
+import { MobileEndpointSupervisor } from './mobile-endpoint-supervisor'
+import {
+  dependencies,
+  FakeRelaySession,
+  FakeSession,
+  host
+} from './mobile-endpoint-supervisor-test-fakes'
+import { MobileE2EEAuthenticationError } from './mobile-e2ee-v2-physical-channel'
+import { RelayOuterError } from './mobile-relay-e2ee-link'
+import {
+  createStableLogicalRpcClient,
+  type StableLogicalRpcClient
+} from './stable-logical-rpc-client'
+
+vi.mock('react-native', () => ({ Platform: { OS: 'ios' } }))
+vi.mock('expo-secure-store', () => ({ WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'when-unlocked' }))
+vi.mock('expo-crypto', () => ({ getRandomBytes: (length: number) => new Uint8Array(length) }))
+
+// Why: 12+ gated reprobe ticks (45s escalating to the 675s floored ceiling) — long
+// past any transient post-pairing rejection, which is the window under test.
+const FOUR_HOURS_MS = 4 * 60 * 60_000
+
+function verdict(logical: StableLogicalRpcClient): ConnectionVerdict {
+  return classifyConnection({
+    state: logical.getState(),
+    reconnectAttempts: logical.getReconnectAttempt(),
+    lastConnectedAt: logical.getLastConnectedAt(),
+    pendingPath: logical.getPendingPath(),
+    pairingRejected: logical.isPairingRejected()
+  })
+}
+
+describe('continuous Relay pairing-rejection escalation', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-18T04:00:00Z'))
+  })
+
+  afterEach(() => vi.useRealTimers())
+
+  // Establishes Relay through the supervisor, then fails every replacement dial.
+  function harness(replacementFailure: Error, replacementsAfter = Number.POSITIVE_INFINITY) {
+    const activeRelay = new FakeRelaySession('connected', new RelayOuterError(4408))
+    activeRelay.getLastConnectedAt = () => Date.now() - 120_000
+    const logical = createStableLogicalRpcClient(new FakeSession('disconnected'), 'tailscale')
+    let replacements = 0
+    const openRelay = vi.fn(() => {
+      replacements += 1
+      if (replacements > replacementsAfter) {
+        return new FakeRelaySession('connected')
+      }
+      const session = new FakeRelaySession('connecting', replacementFailure)
+      setTimeout(() => session.publishState('auth-failed'), 0)
+      return session
+    })
+    openRelay.mockImplementationOnce(() => activeRelay)
+    const deps = dependencies({
+      openDirect: vi.fn(() => new FakeSession('disconnected')),
+      openRelay,
+      randomBytes: () => new Uint8Array([0, 0]),
+      onLog: () => {}
+    })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+    return { activeRelay, logical, openRelay, supervisor }
+  }
+
+  it('escalates a persistent rejection to re-pair instead of "Connecting via Relay…"', async () => {
+    const { activeRelay, logical, openRelay, supervisor } = harness(
+      new MobileE2EEAuthenticationError()
+    )
+
+    await supervisor.start()
+    expect(logical.getActivePath()).toBe('relay')
+    activeRelay.publishState('disconnected')
+    await vi.advanceTimersByTimeAsync(FOUR_HOURS_MS)
+
+    // Pre-fix, the gate suppressed the failure count so this stalled on
+    // "Connecting via Relay…" for every one of these dials (STA-4681).
+    expect(openRelay.mock.calls.length).toBeGreaterThan(3)
+    expect(logical.isPairingRejected()).toBe(true)
+    expect(verdict(logical)).toMatchObject({
+      kind: 'auth-failed',
+      label: 'Pairing invalid — re-pair with your desktop'
+    })
+    supervisor.stop()
+    logical.close()
+  })
+
+  it('escalates a relay-only phone rejected from its very first dial', async () => {
+    const { logical, openRelay, supervisor } = harness(new MobileE2EEAuthenticationError())
+    openRelay.mockReset()
+    openRelay.mockImplementation(() => {
+      const session = new FakeRelaySession('connecting', new MobileE2EEAuthenticationError())
+      setTimeout(() => session.publishState('auth-failed'), 0)
+      return session
+    })
+
+    // Why: the first dial fails, so start() only settles once fake timers run.
+    const started = supervisor.start()
+    await vi.advanceTimersByTimeAsync(FOUR_HOURS_MS)
+    await started
+
+    expect(openRelay.mock.calls.length).toBeGreaterThan(3)
+    expect(verdict(logical)).toMatchObject({ kind: 'auth-failed' })
+    supervisor.stop()
+    logical.close()
+  })
+
+  it('holds the verdict through a background/foreground cycle', async () => {
+    const { activeRelay, logical, supervisor } = harness(new MobileE2EEAuthenticationError())
+
+    await supervisor.start()
+    activeRelay.publishState('disconnected')
+    await vi.advanceTimersByTimeAsync(FOUR_HOURS_MS)
+    expect(logical.isPairingRejected()).toBe(true)
+
+    // Why: an app resume resets the retry cadence, but it is not evidence the
+    // desktop changed its mind — pre-fix this walked the count backwards.
+    supervisor.setForeground(false)
+    supervisor.setForeground(true)
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(logical.isPairingRejected()).toBe(true)
+    expect(verdict(logical)).toMatchObject({ kind: 'auth-failed' })
+    supervisor.stop()
+    logical.close()
+  })
+
+  it('never latches when the desktop accepts before the budget is spent', async () => {
+    const { activeRelay, logical, supervisor } = harness(new MobileE2EEAuthenticationError(), 2)
+
+    await supervisor.start()
+    activeRelay.publishState('disconnected')
+    await vi.advanceTimersByTimeAsync(FOUR_HOURS_MS)
+
+    // Two transient rejections while the desktop commits credentials, then success.
+    expect(logical.isPairingRejected()).toBe(false)
+    expect(logical.getActivePath()).toBe('relay')
+    expect(verdict(logical)).toMatchObject({ kind: 'normal' })
+    supervisor.stop()
+    logical.close()
+  })
+
+  it('leaves a plain transport outage on the Relay-unreachable verdict', async () => {
+    const { activeRelay, logical, supervisor } = harness(new RelayOuterError(4408))
+
+    await supervisor.start()
+    activeRelay.publishState('disconnected')
+    await vi.advanceTimersByTimeAsync(3_000)
+
+    expect(logical.isPairingRejected()).toBe(false)
+    expect(verdict(logical)).toMatchObject({
+      kind: 'unreachable',
+      label: "Can't connect via Relay"
+    })
+    supervisor.stop()
+    logical.close()
+  })
+})

--- a/mobile/src/transport/mobile-relay-reconnect-controller.test.ts
+++ b/mobile/src/transport/mobile-relay-reconnect-controller.test.ts
@@ -60,6 +60,60 @@ describe('relay reconnect controller', () => {
     expect(published).toEqual([0, 1, 2, 0])
   })
 
+  it('latches pairing-rejected only after the transient-rejection budget is spent', () => {
+    const rejected: boolean[] = []
+    const reconnect = createController(vi.fn(), undefined, (value) => rejected.push(value))
+
+    reconnect.registerFailure(new MobileE2EEAuthenticationError(), false)
+    reconnect.registerFailure(new MobileE2EEAuthenticationError(), false)
+    expect(rejected).toEqual([false])
+
+    // Why: the gate is held by now, so this rejection takes registerFailure's early
+    // return — pre-fix it was invisible and the latch never fired (STA-4681).
+    reconnect.registerFailure(new MobileE2EEAuthenticationError(), false)
+    expect(rejected).toEqual([false, true])
+  })
+
+  it('keeps the pairing-rejected latch across a gate lift and app resume', () => {
+    const logical = { getState: () => 'disconnected' } as never
+    const rejected: boolean[] = []
+    const reconnect = createController(vi.fn(), undefined, (value) => rejected.push(value))
+    for (let attempt = 0; attempt < 3; attempt++) {
+      reconnect.registerFailure(new MobileE2EEAuthenticationError(), false)
+    }
+
+    // Why: a resume re-arms the retry cadence but is not the desktop changing its
+    // mind — only an authenticated session is.
+    reconnect.handleForeground(logical, false)
+
+    expect(rejected).toEqual([false, true])
+  })
+
+  it('clears the pairing-rejected latch once the desktop authenticates the device', () => {
+    const rejected: boolean[] = []
+    const reconnect = createController(vi.fn(), undefined, (value) => rejected.push(value))
+    for (let attempt = 0; attempt < 3; attempt++) {
+      reconnect.registerFailure(new MobileE2EEAuthenticationError(), false)
+    }
+
+    reconnect.setActiveSession({ getFailure: () => null } as unknown as MobileRelayRpcSession)
+
+    expect(rejected).toEqual([false, true, false])
+  })
+
+  it('clears the pairing-rejected latch when direct connectivity proves the pairing', () => {
+    const rejected: boolean[] = []
+    const reconnect = createController(vi.fn(), undefined, (value) => rejected.push(value))
+    for (let attempt = 0; attempt < 3; attempt++) {
+      reconnect.registerFailure(new MobileE2EEAuthenticationError(), false)
+    }
+
+    // Why: direct auth resolves the same desktop device registry.
+    reconnect.resetForDirectConnection()
+
+    expect(rejected).toEqual([false, true, false])
+  })
+
   it('reprobes slowly after rejected E2EE authentication instead of parking forever', () => {
     // Why: on a relay-only phone a permanent gate is a permanent outage — the
     // desktop can commit pairing credentials moments after the first rejection.
@@ -280,7 +334,8 @@ describe('relay reconnect controller', () => {
 
 function createController(
   onRetry: () => void,
-  reportFailureCount: (count: number) => void = () => {}
+  reportFailureCount: (count: number) => void = () => {},
+  reportPairingRejected: (rejected: boolean) => void = () => {}
 ): RelayReconnectController {
   const controller = new RelayReconnectController(
     {
@@ -291,6 +346,9 @@ function createController(
     },
     onRetry
   )
-  controller.reportFailureCountTo(reportFailureCount)
+  controller.reportRecoveryTo({
+    setRecoveryAttempt: reportFailureCount,
+    setPairingRejected: reportPairingRejected
+  } as unknown as StableLogicalRpcClient)
   return controller
 }

--- a/mobile/src/transport/mobile-relay-reconnect-controller.test.ts
+++ b/mobile/src/transport/mobile-relay-reconnect-controller.test.ts
@@ -89,6 +89,22 @@ describe('relay reconnect controller', () => {
     expect(rejected).toEqual([false, true])
   })
 
+  it('never latches pairing-rejected while an authenticated relay is still live', () => {
+    // Why: a live authenticated session is the desktop currently accepting this
+    // device. A replacement dial that trips E2EE (relay identity mismatch, or the
+    // transient window while the desktop commits a rotation) is not revocation, and
+    // banking it would fire a false re-pair alarm the moment that session drops.
+    const rejected: boolean[] = []
+    const reconnect = createController(vi.fn(), undefined, (value) => rejected.push(value))
+    reconnect.setActiveSession({ getFailure: () => null } as unknown as MobileRelayRpcSession)
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      reconnect.registerFailure(new MobileE2EEAuthenticationError(), false)
+    }
+
+    expect(rejected).toEqual([false])
+  })
+
   it('clears the pairing-rejected latch once the desktop authenticates the device', () => {
     const rejected: boolean[] = []
     const reconnect = createController(vi.fn(), undefined, (value) => rejected.push(value))

--- a/mobile/src/transport/mobile-relay-reconnect-controller.ts
+++ b/mobile/src/transport/mobile-relay-reconnect-controller.ts
@@ -236,8 +236,11 @@ export class RelayReconnectController {
 
   registerFailure(error: Error | null, scheduleRetry = true): void {
     // Why: the gated early return below skips every later failure, so a revoked
-    // pairing must bank its evidence first or the UI waits forever (STA-4681).
-    this.pairingRejection.record(error)
+    // pairing must bank its evidence first or the UI waits forever (STA-4681). A live
+    // authenticated relay is the desktop accepting this device right now, so a failed
+    // replacement dial is not revocation — banking it would fire a false re-pair alarm
+    // the moment that healthy session drops for an unrelated transport error.
+    this.pairingRejection.record(this.activeSession ? null : error)
     const code = error instanceof RelayOuterError ? error.code : null
     const recovery =
       code != null && isMobileRelayCloseCode(code)

--- a/mobile/src/transport/mobile-relay-reconnect-controller.ts
+++ b/mobile/src/transport/mobile-relay-reconnect-controller.ts
@@ -8,6 +8,7 @@ import { MobileE2EEAuthenticationError } from './mobile-e2ee-v2-physical-channel
 import { RelayOuterError } from './mobile-relay-e2ee-link'
 import { RELAY_STABLE_CONNECTION_MS, RelayRetryDelays } from './mobile-relay-retry-delays'
 import { RelayCredentialEligibility } from './relay-credential-eligibility'
+import { RelayPairingRejectionLatch } from './relay-pairing-rejection-latch'
 import { RelayRecoveryFailureCount } from './relay-recovery-failure-count'
 import type { StableLogicalRpcClient } from './stable-logical-rpc-client'
 import type { ConnectionState, ForegroundNudgeReason } from './types'
@@ -25,6 +26,7 @@ type RecoveryGate = 'external-signal' | 'fresh-credential'
 
 export class RelayReconnectController {
   private readonly failureCount = new RelayRecoveryFailureCount(RELAY_STABLE_CONNECTION_MS)
+  private readonly pairingRejection = new RelayPairingRejectionLatch()
   private activeRelayConnectedAt: number | null = null
   private nextAttemptAt = 0
   private timer: ReturnType<typeof setTimeout> | null = null
@@ -47,8 +49,9 @@ export class RelayReconnectController {
     return this.failureCount.current()
   }
 
-  reportFailureCountTo(reporter: (count: number) => void): void {
-    this.failureCount.reportTo(reporter)
+  reportRecoveryTo(logical: StableLogicalRpcClient): void {
+    this.failureCount.reportTo(logical.setRecoveryAttempt)
+    this.pairingRejection.reportTo(logical.setPairingRejected)
   }
 
   handleForeground(logical: StableLogicalRpcClient, wasForeground: boolean): void {
@@ -110,6 +113,9 @@ export class RelayReconnectController {
   }
 
   setActiveSession(session: MobileRelayRpcSession): void {
+    // Why: an authenticated relay is the desktop accepting this device — the only
+    // evidence that outranks a rejection streak.
+    this.pairingRejection.clear()
     this.activeSession = session
     this.activeRelayConnectedAt = this.dependencies.now()
     this.nextAttemptAt = 0
@@ -121,6 +127,9 @@ export class RelayReconnectController {
       this.recoveryGate === 'fresh-credential' || this.credentials.hasRejected()
     this.activeSession = null
     this.activeRelayConnectedAt = null
+    // Why: direct auth resolves the same desktop device registry, so a live direct
+    // session disproves revocation even though relay is still gated.
+    this.pairingRejection.clear()
     if (needsCredentialRefresh) {
       // Why: the rejected credential stays unusable until its replacement is
       // durable. No reprobe timer here — direct is live, rotation over it
@@ -139,6 +148,7 @@ export class RelayReconnectController {
 
   completeCredentialRefresh(): void {
     if (this.recoveryGate === 'fresh-credential') {
+      this.pairingRejection.clear()
       this.credentials.clearRejected()
       this.reset()
     }
@@ -155,9 +165,7 @@ export class RelayReconnectController {
   ): T[] {
     const eligible = this.credentials.eligible(...credentials)
     if (eligible.length === 0 && this.credentials.hasRejected()) {
-      this.recoveryGate = 'fresh-credential'
-      this.clearTimer()
-      this.scheduleGateReprobe()
+      this.holdGate(true, 'fresh-credential')
     }
     return eligible
   }
@@ -166,16 +174,13 @@ export class RelayReconnectController {
   // alive so a later durable write can recover.
   armCredentialReprobe(): void {
     if (this.credentials.hasRejected()) {
-      this.recoveryGate = 'fresh-credential'
-      this.clearTimer()
-      this.scheduleGateReprobe()
+      this.holdGate(true, 'fresh-credential')
       return
     }
     if (this.recoveryGate) {
       // Why: under a held gate the tick must mint its pass token — a plain
       // cooldown tick bounces off shouldDefer and doubles the effective cadence.
-      this.clearTimer()
-      this.scheduleGateReprobe()
+      this.holdGate(true)
       return
     }
     // Why: a merely missing or expired bundle must not enter the credential
@@ -230,6 +235,9 @@ export class RelayReconnectController {
   }
 
   registerFailure(error: Error | null, scheduleRetry = true): void {
+    // Why: the gated early return below skips every later failure, so a revoked
+    // pairing must bank its evidence first or the UI waits forever (STA-4681).
+    this.pairingRejection.record(error)
     const code = error instanceof RelayOuterError ? error.code : null
     const recovery =
       code != null && isMobileRelayCloseCode(code)
@@ -241,10 +249,7 @@ export class RelayReconnectController {
     ) {
       // Why: a failed reprobe stays gated, but the slow cadence must keep going
       // — unless the supervisor is backgrounded/stopped; resume re-arms it.
-      this.clearTimer()
-      if (scheduleRetry) {
-        this.scheduleGateReprobe()
-      }
+      this.holdGate(scheduleRetry)
       return
     }
     const now = this.dependencies.now()
@@ -260,21 +265,13 @@ export class RelayReconnectController {
       // Why: an E2EE rejection is usually pairing revocation, but it also fires
       // transiently right after pairing while the desktop commits credentials —
       // reprobe slowly instead of waiting forever for a UI nudge.
-      this.recoveryGate = 'external-signal'
-      this.clearTimer()
-      if (scheduleRetry) {
-        this.scheduleGateReprobe()
-      }
+      this.holdGate(scheduleRetry, 'external-signal')
       return
     }
     if (recovery?.kind === 'disable-relay-credential') {
       // Why: never redial a rejected credential fast, but keep a slow reprobe
       // alive — the caller re-reads durable state before each gated attempt.
-      this.recoveryGate = 'fresh-credential'
-      this.clearTimer()
-      if (scheduleRetry) {
-        this.scheduleGateReprobe()
-      }
+      this.holdGate(scheduleRetry, 'fresh-credential')
       return
     }
     if (recovery?.kind === 'retry-after-host-offline') {
@@ -357,6 +354,16 @@ export class RelayReconnectController {
       }
       this.onRetry()
     }, delay)
+  }
+
+  // Holds (or enters) a gate: only the slow reprobe cadence survives, and a
+  // backgrounded or stopped supervisor gets no timer at all until it resumes.
+  private holdGate(scheduleRetry: boolean, gate = this.recoveryGate): void {
+    this.recoveryGate = gate
+    this.clearTimer()
+    if (scheduleRetry) {
+      this.scheduleGateReprobe()
+    }
   }
 
   // Why: clearing a gate must also drop its timer, pending tick, and cadence —

--- a/mobile/src/transport/mobile-relay-runtime-failover.test.ts
+++ b/mobile/src/transport/mobile-relay-runtime-failover.test.ts
@@ -131,6 +131,17 @@ class FakeLogicalClient extends FakeSession implements StableLogicalRpcClient {
       }
     }
   })
+  private pairingRejected = false
+  setPairingRejected = vi.fn((rejected: boolean) => {
+    if (this.pairingRejected === rejected) {
+      return
+    }
+    this.pairingRejected = rejected
+    for (const listener of this.pathListeners) {
+      listener()
+    }
+  })
+  isPairingRejected = () => this.pairingRejected
   setRecoveryAttempt = vi.fn((attempt: number) => {
     const previous = this.getReconnectAttempt()
     this.recoveryAttempt = attempt

--- a/mobile/src/transport/mobile-relay-runtime-failover.test.ts
+++ b/mobile/src/transport/mobile-relay-runtime-failover.test.ts
@@ -142,6 +142,13 @@ class FakeLogicalClient extends FakeSession implements StableLogicalRpcClient {
     }
   })
   isPairingRejected = () => this.pairingRejected
+  // Mirrors LogicalClientConnectionPath.clearAfterConnected.
+  publishState(state: ConnectionState): void {
+    if (state === 'connected') {
+      this.pairingRejected = false
+    }
+    super.publishState(state)
+  }
   setRecoveryAttempt = vi.fn((attempt: number) => {
     const previous = this.getReconnectAttempt()
     this.recoveryAttempt = attempt

--- a/mobile/src/transport/relay-pairing-rejection-latch.ts
+++ b/mobile/src/transport/relay-pairing-rejection-latch.ts
@@ -1,0 +1,43 @@
+import { MobileE2EEAuthenticationError } from './mobile-e2ee-v2-physical-channel'
+
+// Why: one E2EE rejection is not proof the pairing is dead — the desktop fires it
+// transiently while it commits credentials right after pairing. Mirrors rpc-client's
+// AUTH_RETRY_BUDGET so both transports latch "re-pair" on the same weight of evidence.
+const RELAY_PAIRING_REJECTION_BUDGET = 3
+
+// Consecutive desktop rejections of this device's relay credential. Only an
+// authenticated connection clears it — a gate lift or app resume must not, or a
+// revoked phone re-enters the reassuring "Connecting via Relay…" label forever.
+export class RelayPairingRejectionLatch {
+  private count = 0
+  private reporter: ((rejected: boolean) => void) | null = null
+
+  rejected(): boolean {
+    return this.count >= RELAY_PAIRING_REJECTION_BUDGET
+  }
+
+  reportTo(reporter: (rejected: boolean) => void): void {
+    this.reporter = reporter
+    reporter(this.rejected())
+  }
+
+  // Only an E2EE rejection is evidence; every other relay failure leaves the streak
+  // untouched so a flaky network cannot masquerade as a revoked pairing.
+  record(error: Error | null): void {
+    if (error instanceof MobileE2EEAuthenticationError) {
+      this.update(Math.min(this.count + 1, RELAY_PAIRING_REJECTION_BUDGET))
+    }
+  }
+
+  clear(): void {
+    this.update(0)
+  }
+
+  private update(count: number): void {
+    const wasRejected = this.rejected()
+    this.count = count
+    if (wasRejected !== this.rejected()) {
+      this.reporter?.(this.rejected())
+    }
+  }
+}

--- a/mobile/src/transport/rpc-client-context-contract.ts
+++ b/mobile/src/transport/rpc-client-context-contract.ts
@@ -22,6 +22,7 @@ export type RpcClientContextValue = {
   getLastConnectedAt: (hostId: string) => number | null
   getActivePath: (hostId: string) => MobileConnectionPath
   getPendingPath: (hostId: string) => MobileConnectionPath | null
+  isPairingRejected: (hostId: string) => boolean
   subscribeHostState: (hostId: string, listener: (state: ConnectionState) => void) => () => void
   getAllClients: () => { hostId: string; client: RpcClient }[]
   subscribeAllHosts: (listener: () => void) => () => void

--- a/mobile/src/transport/stable-logical-rpc-client.test.ts
+++ b/mobile/src/transport/stable-logical-rpc-client.test.ts
@@ -321,6 +321,19 @@ describe('stable logical RPC client', () => {
     expect(attempts).toEqual([5, 7, 5])
   })
 
+  it('notifies connection-path subscribers when the pairing-rejected latch flips', () => {
+    const direct = new FakeSession('reconnecting')
+    const client = createStableLogicalRpcClient(direct, 'tailscale')
+    const rejected: boolean[] = []
+    client.onConnectionPathChange(() => rejected.push(client.isPairingRejected()))
+
+    client.setPairingRejected(true)
+    client.setPairingRejected(true)
+    client.setPairingRejected(false)
+
+    expect(rejected).toEqual([true, false])
+  })
+
   it('does not revive a stale recovery path after a connection later drops', () => {
     const direct = new FakeSession('reconnecting')
     const client = createStableLogicalRpcClient(direct, 'tailscale')

--- a/mobile/src/transport/stable-logical-rpc-client.ts
+++ b/mobile/src/transport/stable-logical-rpc-client.ts
@@ -52,6 +52,9 @@ export type StableLogicalRpcClient = RpcClient & {
   getPendingPath(): MobileConnectionPath | null
   setRecoveryPath(path: MobileConnectionPath | null, attempt?: number): void
   setRecoveryAttempt(attempt: number): void
+  // Latched when the desktop has repeatedly refused this device's relay credential.
+  setPairingRejected(rejected: boolean): void
+  isPairingRejected(): boolean
   // Recovery attempts share this signal so status-only changes rerender.
   onConnectionPathChange(listener: () => void): () => void
   getGeneration(): number
@@ -276,6 +279,8 @@ export function createStableLogicalRpcClient(
     getPendingPath: () => connectionPath.pending(),
     setRecoveryPath: (path, attempt) => connectionPath.setRecovery(path, attempt),
     setRecoveryAttempt: (attempt) => connectionPath.setRecoveryAttempt(attempt),
+    setPairingRejected: (rejected) => connectionPath.setPairingRejected(rejected),
+    isPairingRejected: () => connectionPath.isPairingRejected(),
     onConnectionPathChange: (listener) => connectionPath.subscribe(listener),
     getGeneration: () => generation
   }

--- a/mobile/src/transport/use-all-host-clients.ts
+++ b/mobile/src/transport/use-all-host-clients.ts
@@ -137,6 +137,7 @@ export function useAllHostClients(hostIds: string[], options?: UseAllHostClients
       state: ConnectionState
       path: MobileConnectionPath
       pendingPath: MobileConnectionPath | null
+      pairingRejected: boolean
     }>((hostId) => {
       const client = clientsByHostId.get(hostId)
       return client
@@ -146,7 +147,8 @@ export function useAllHostClients(hostIds: string[], options?: UseAllHostClients
               client,
               state: ctx.getState(hostId),
               path: ctx.getActivePath(hostId),
-              pendingPath: ctx.getPendingPath(hostId)
+              pendingPath: ctx.getPendingPath(hostId),
+              pairingRejected: ctx.isPairingRejected(hostId)
             }
           ]
         : []


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​386 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​384 |
| Prod | 16 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​201 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​55 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​146 |

<!-- /orca-pr-loc -->

## ELI5

If your desktop stops recognizing your phone — you unpaired it, or the desktop lost its device list — the phone kept saying **"Connecting via Relay…"** forever. It was still trying (26 real dials over four simulated hours), it just never admitted anything was wrong, and the one action that fixes it is re-pairing.

Now, after three consecutive rejections, it says **"Pairing invalid — re-pair with your desktop"**.

## What Changed

- Bank an E2EE rejection **before** `registerFailure`'s gated early return instead of after it.
- Add `RelayPairingRejectionLatch`: three consecutive rejections latch a distinct pairing-rejected signal, cleared only by an authenticated Relay session or a live direct session.
- Thread that signal through the connection path, the logical client, and the context selector; `classifyConnection` returns the existing auth-failed verdict when it is set.
- Replace `usePendingConnectionPath` with `useRelayRecoveryStatus`, returning both recovery inputs from one host subscription so a screen cannot render half of the escalation.
- Collapse the four-line gate-hold tail repeated five times in `RelayReconnectController` into `holdGate`.
- Add the deterministic pairing-rejection oracle and register it on the mobile Relay reliability gate.

## Why

STA-4587 (#15071) made the supervisor's failure count the escalation authority, which fixed transport-class outages. It did not cover gate-suppressed failures: the first E2EE rejection sets `recoveryGate = 'external-signal'`, and every later failure takes the gated early return before the count increments. The count froze at 1–2, far below the 12 `UNREACHABLE_ATTEMPTS` needs, so the verdict never moved. A background/foreground cycle made it worse — `handleForeground` calls `reset()`, walking the count *backwards*.

**Why re-pair and not "Can't connect via Relay".** Counting gated failures is the smaller diff, but it points the user at their network when the only fix is re-pairing. `classifyConnection` already has the right sentence behind its `auth-failed` verdict; this routes to it.

**Why a budget of three.** The desktop also emits this rejection transiently while it commits credentials right after pairing — the code comments call that out, and `rpc-client.ts` already tolerates it with `AUTH_RETRY_BUDGET = 3` on the direct path. A one-shot latch would cry wolf on every fresh pair. Both transports now latch on the same weight of evidence.

**Why a resume does not clear it.** An app resume re-arms the retry cadence but is not the desktop changing its mind. Only an authenticated session is.

This is presentation-only: no new Relay dial, timer, socket, probe, or wire message, and no change to retry cadence or traffic. Nothing crosses the client/host wire, so there is no remote-compatibility surface.

**Line caps.** Two `max-lines` caps were paid for by removing duplication rather than raised — `mobile-relay-reconnect-controller.ts` ends up smaller than before this change.

## Linked Issue

[STA-4681](https://linear.app/stably/issue/STA-4681/p2continuous-mobile-e2ee-failures-stall-relay-outage-escalation-pr)

## Visual Proof

N/A — reproducing the rendered state needs a physically paired phone whose desktop revokes it mid-session. The deterministic oracle drives the real supervisor, controller, logical client, and classifier and asserts the exact verdict object the card renders, and a React-level test asserts the flag reaching a mounted component through the provider.

## Testing

- [x] I manually reproduced the pre-fix stall with deterministic fake time: 26 real Relay dials across four simulated hours, published count frozen at 2, verdict stuck on "Connecting via Relay…".
- [x] Automated tests added (13 new).

Red/green proven by controlled disable at two layers rather than by a green suite alone:

- Restoring the pre-fix counting placement (rejection banked *after* the gated early return) reds 7 assertions while the other 17 stay green — including the negative controls, so the suite is not uniformly red.
- Stubbing `clientPairingRejected` to always return false reds the screen-level publication test, proving it watches the wiring rather than asserting a tautology.

Negative controls: two rejections followed by acceptance never latch; a plain transport outage still reads "Can't connect via Relay".

Validated on macOS:

- `pnpm --dir mobile test` — 456 files; 3,643 passed, 3 skipped.
- `pnpm --dir mobile typecheck`, `pnpm --dir mobile lint`, `pnpm --dir mobile format:check`
- Focused reliability suite — 109 passed; `pnpm exec vitest run --config config/vitest.config.ts src/shared/mobile-relay-close-codes.test.ts` — 5 passed.
- `pnpm check:reliability-gates` — 85 gates.
- `pnpm check:code-quality:changed` and `pnpm check:react-doctor:changed` — 0 new findings.

Physical iOS/Android radio behavior remains a live-test gap. No platform-specific, remote-wire, SSH, or Git-binary surface is touched.

## AI Disclosure

## Review

Please focus on the latch's clear boundaries — specifically that a gate lift or app resume must *not* clear it while `setActiveSession` / `resetForDirectConnection` / `completeCredentialRefresh` must — and on the `holdGate` extraction, which is the only part of this diff that touches existing timer semantics.

Known pre-existing gap, deliberately not changed here: tapping a card showing this verdict opens the host screen, not the pairing scanner. That shortcut is gated on the phone's own keychain being empty, which is not this case. The existing `auth-failed` verdict has the same dead end; worth a follow-up rather than a silent tap-behavior change in this PR.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
