### PR TITLE
ci: run the IME e2e suite when terminal input code changes

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -605,6 +605,19 @@ jobs:
               'tests/e2e/ssh-startup-exec-readiness.spec.ts' \
               'tests/e2e/ssh-terminal-window-wake-stale-grid-repro.spec.ts' | sort -u)"
           fi
+          # Why: same lesson as the SSH specs above. The IME e2e suite asserts real pty bytes and
+          # real overlay geometry, but only ran when someone edited a spec, so every IME fix in the
+          # 1.4.18x window shipped without it - including one whose diagnosis hardware later refuted.
+          # config/patches is listed because the terminal's input handling lives in the xterm patch.
+          if printf '%s\n' "$CHANGED" | grep -Ev '\.test\.tsx?$' | grep -Eq '^(config/patches/|src/renderer/src/components/terminal-pane/(terminal-ime-|use-terminal-pane-lifecycle|xterm-bypass-policy|terminal-option-shortcut-policy))'; then
+            TEST_FILES="$(printf '%s\n' "$TEST_FILES" \
+              'tests/e2e/terminal-cjk-ime-committed-text.spec.ts' \
+              'tests/e2e/terminal-hangul-wrap-boundary-bytes.spec.ts' \
+              'tests/e2e/terminal-ime-exact-byte.spec.ts' \
+              'tests/e2e/terminal-korean-composing-chord-order.spec.ts' \
+              'tests/e2e/terminal-korean-midline-preedit-occlusion.spec.ts' \
+              'tests/e2e/terminal-korean-preedit-visibility.spec.ts' | sort -u)"
+          fi
           TEST_FILES_JSON="$(printf '%s\n' "$TEST_FILES" | jq --raw-input --slurp --compact-output 'split("\n") | map(select(length > 0))')"
           echo "test_files=$TEST_FILES_JSON" >> "$GITHUB_OUTPUT"
           if [ "$TEST_FILES_JSON" != '[]' ]; then


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​13 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​13 |

<!-- /orca-pr-loc -->

PR e2e runs only specs whose **own spec file changed**, plus two hardcoded source→spec mappings (ephemeral-VM and SSH). There is no mapping for `src/renderer/src/components/terminal-pane/` or `config/patches/`.

So an edit to the IME forwarder, to the terminal pane lifecycle, or to the xterm patch itself runs **zero** e2e on the PR. The suite only runs later, in the twice-daily scheduled full run.

## What that cost

Every terminal IME merge in the 1.4.18x window shipped without triggering a single e2e spec:

| merge | | |
| --- | --- | --- |
| #15218 | iPadOS forwarder gate | its diagnosis was later **refuted by hardware** — it fixes a real defect, but not the bug it claimed |
| #15223 | xterm patch harness | changed the xterm bundle; no IME spec ran |
| #15198 | async IME commit | third patch to the same guard; no IME spec ran |
| #14758 | cancelled preedit | unit only |
| #13284 | resumed preedit | unit only at merge time |

The suite they skipped is not thin. It drives real compositions over CDP, reads **real pty bytes**, asserts **real overlay geometry**, and exercises the macOS-only input path on Linux runners through a user-agent policy override. It was simply never pointed at the code it covers.

## This is a lesson the repo already learned once

The SSH block immediately above this change says so in its own comment:

> the Docker-SSH specs only ever ran when someone edited a spec, so four pane-restore regressions shipped from SSH source edits that touched no test

Same cause, same shape, never applied to terminal input.

## The change

Eight lines, following that block's idiom exactly, including its exclusion of `*.test.ts` (unit tests prove the same source without paying for a browser).

Triggers on `config/patches/` and on `terminal-pane/{terminal-ime-*, use-terminal-pane-lifecycle, xterm-bypass-policy, terminal-option-shortcut-policy}`, selecting six existing specs:

```
terminal-cjk-ime-committed-text.spec.ts
terminal-hangul-wrap-boundary-bytes.spec.ts
terminal-ime-exact-byte.spec.ts
terminal-korean-composing-chord-order.spec.ts
terminal-korean-midline-preedit-occlusion.spec.ts
terminal-korean-preedit-visibility.spec.ts
```

`config/patches/` is included because the terminal's composition and key handling live inside the xterm patch, so a change there is precisely what this suite exists to catch.

## Verified rather than assumed

I replayed the filter against the merges that skipped it:

```
598ba5d2765 (#15218) -> WOULD RUN
49752477a68 (#15223) -> WOULD RUN
        #15198       -> WOULD RUN
```

The workflow also still parses as YAML.

## Not covered by this

Ten native-input e2e specs were deleted as collateral in `17cfc968cf5` and never restored — including the two covering macOS text substitution, which is the entire reason the native-text forwarder exists. Nothing in CI has run against a real system input source since. That is a separate piece of work; this change only reconnects the suite that still exists.
