### PR TITLE
fix(terminal): end a url at CJK punctuation instead of swallowing it

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-http-url-extraction.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-http-url-extraction.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { extractTerminalHttpLinks } from './terminal-http-url-extraction'
+
+const urlsIn = (line: string): string[] => extractTerminalHttpLinks(line).map((link) => link.url)
+
+describe('extractTerminalHttpLinks', () => {
+  it('stops at a full-width parenthesis instead of swallowing the annotation', () => {
+    expect(
+      urlsIn('- PR: https://github.com/stablyai/orca/pull/12345（作成済み・マージ待ち）')
+    ).toEqual(['https://github.com/stablyai/orca/pull/12345'])
+  })
+
+  it('stops at a full-width closing quote', () => {
+    expect(urlsIn('詳細は「https://example.com/docs」を参照')).toEqual(['https://example.com/docs'])
+  })
+
+  it('stops at an ideographic space', () => {
+    expect(urlsIn('PR: https://example.com/a　（全角スペース区切り）')).toEqual([
+      'https://example.com/a'
+    ])
+  })
+
+  it('keeps unencoded CJK letters that are genuinely part of the path', () => {
+    // Why: wrapped URLs with Chinese path segments are supported; only punctuation ends a url.
+    expect(urlsIn('https://example.com/文档/路径')).toEqual([
+      new URL('https://example.com/文档/路径').toString()
+    ])
+  })
+
+  it('stops at a full-width comma and full stop between a url and prose', () => {
+    expect(urlsIn('https://example.com/a、次へ')).toEqual(['https://example.com/a'])
+    expect(urlsIn('https://example.com/b。')).toEqual(['https://example.com/b'])
+  })
+
+  it('still extracts a plain ascii url and keeps its own punctuation', () => {
+    expect(urlsIn('see https://example.com/a_b-c?d=1&e=2#f end')).toEqual([
+      'https://example.com/a_b-c?d=1&e=2#f'
+    ])
+  })
+
+  it('still trims ascii trailing punctuation', () => {
+    expect(urlsIn('see https://example.com/a.')).toEqual(['https://example.com/a'])
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-http-url-extraction.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-http-url-extraction.ts
@@ -98,6 +98,7 @@ function trimHttpUrlTrailingPunctuation(
 
 function isHttpUrlBodyTerminator(code: number): boolean {
   return (
+    isNonAsciiUrlTerminator(code) ||
     isAsciiWhitespace(code) ||
     code === 0x22 ||
     code === 0x27 ||
@@ -140,6 +141,14 @@ function isHttpUrlTrailingPunctuation(code: number): boolean {
     code === 0x3e ||
     code === 0x60
   )
+}
+
+// Why not all non-ascii: a url path may legitimately carry unencoded CJK (see the wrapped-url
+// tests), so only punctuation and spaces end it - full-width brackets, an ideographic space, `\u30fb`.
+const NON_ASCII_URL_TERMINATOR = /[\p{P}\p{S}\p{Z}]/u
+
+function isNonAsciiUrlTerminator(code: number): boolean {
+  return code > 0x7e && NON_ASCII_URL_TERMINATOR.test(String.fromCharCode(code))
 }
 
 function isAsciiWhitespace(code: number): boolean {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​44 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​44 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 |

<!-- /orca-pr-loc -->

Closes #10571.

Terminal URL detection treated every non-ASCII character as part of the url, so Japanese or Chinese text written straight after one was absorbed into the link:

```
- PR: https://github.com/org/repo/pull/12345（作成済み・マージ待ち）
```

underlined the whole run, and ⌘-click opened the annotation percent-encoded onto the end of the url, which 404s.

## Root cause

`isHttpUrlBodyTerminator` (`terminal-http-url-extraction.ts`) listed only ASCII code points, so nothing at or above `0x80` could ever end a url — not full-width brackets, not an ideographic space, not `、`, `。` or `・`.

## The obvious fix is wrong, and I shipped it first

RFC 3986 says URIs are ASCII, so "terminate on any non-ASCII" looks correct. It made all three reported cases pass — and **broke four existing tests**:

```
× opens a URL when a wide glyph starts the continuation row
× opens a URL when a multi-code-point wide cell starts the continuation row
× reconstructs a wide-glyph URL whose row span exceeds the single-width column bound
× joins a real multi-line URL whose continuation is a Chinese path segment
```

Those tests are right. A url path may legitimately carry unencoded CJK, and `edge-wrapped-terminal-http-links.test.ts:352` deliberately covers `https://example.com/…文档/路径` wrapped across rows. Terminating on non-ASCII would have fixed one CJK bug by creating another.

**The distinction is punctuation, not ASCII.** Non-ASCII punctuation, symbols and separators end a url; letters do not. Full-width brackets, an ideographic space, a full-width comma and the katakana middle dot are prose. `文档` in a path is not.

## Behaviour

| input | result |
| --- | --- |
| `…/12345（作成済み・マージ待ち）` | stops at `（` |
| `詳細は「https://example.com/docs」を参照` | stops at `」` |
| `…/a　（全角スペース区切り）` | stops at U+3000 |
| `…/a、次へ` | stops at `、` |
| `https://example.com/文档/路径` | **stays one url** |
| `https://example.com/a_b-c?d=1&e=2#f` | unchanged |
| `https://example.com/a.` | trailing `.` still trimmed |

ASCII handling is untouched — the existing explicit ASCII lists still run, so this cannot change behaviour for a url with no non-ASCII near it.

## Tests

`terminal-http-url-extraction.ts` had **no test file of its own**; this adds one, covering the reporter's three cases, the CJK-path case that must keep working, and ASCII behaviour as a regression guard.

```
terminal-http-url-extraction        7 passed
edge-wrapped-terminal-http-links   ) all previously
hard-wrapped-terminal-http-links   ) failing cases
terminal-handle-links              ) now pass
                                    50 passed (50)
```

## Note

This is the mirror image of #13396, where *file* link detection truncated at the first non-Latin character so CJK paths never opened. Different module, opposite failure, same underlying gap: neither had a considered rule for where non-ASCII belongs in a path.
