### PR TITLE
test(terminal): pin that the CJK block is the preedit overlay, not the cursor

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -615,6 +615,7 @@ jobs:
               'tests/e2e/terminal-hangul-wrap-boundary-bytes.spec.ts' \
               'tests/e2e/terminal-ime-exact-byte.spec.ts' \
               'tests/e2e/terminal-korean-composing-chord-order.spec.ts' \
+              'tests/e2e/terminal-korean-endofrow-preedit-cell-span.spec.ts' \
               'tests/e2e/terminal-korean-midline-preedit-occlusion.spec.ts' \
               'tests/e2e/terminal-korean-preedit-visibility.spec.ts' | sort -u)"
           fi

--- a/src/renderer/src/components/terminal-pane/terminal-cjk-cursor-cell-placement.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-cjk-cursor-cell-placement.test.ts
@@ -13,6 +13,11 @@
  *
  * The occluding box in that report is the IME preedit overlay, not the cursor — see
  * `terminal-ime-xterm-trailing-preedit-occlusion.test.ts`.
+ *
+ * Claim 2 is pinned against the DOM renderer, which is the only one happy-dom can drive. The
+ * shipped default on macOS is webgl, where the same guarantee comes from a different mechanism —
+ * the cursor fill spans `cursorX .. cursorX + cell.getWidth() - 1`, so it covers both cells of a
+ * wide glyph rather than clipping one. That arm cannot live here.
  */
 import { Terminal } from '@xterm/xterm'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -20,30 +25,46 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 // Escapes made visible in the issue: hide cursor, home, CUF 2, CUD 24, the text, then two CUPs.
 const REPORTED_PTY_STREAM = '\x1b[?25l\x1b[H\x1b[2C\x1b[24B가나다라\x1b[30;1H\x1b[25;11H\x1b[?25h'
 
+type Rig = {
+  container: HTMLElement
+  terminal: Terminal
+}
+
 const openTerminals: Terminal[] = []
 
-function openTerminal(): Terminal {
+function openTerminal(): Rig {
   const container = document.createElement('div')
   document.body.appendChild(container)
   const terminal = new Terminal({ cols: 80, rows: 30 })
   terminal.open(container)
   openTerminals.push(terminal)
-  return terminal
+  return { container, terminal }
 }
 
 function write(terminal: Terminal, data: string): Promise<void> {
   return new Promise((resolve) => terminal.write(data, resolve))
 }
 
-/** Awaits the repaint the write triggers, so the row spans under assertion are the rendered ones. */
+/**
+ * Lets the write settle, drains the frame it already scheduled, then subscribes before forcing the
+ * one under assertion — so the row spans read below are the rendered ones, and the listener is
+ * always in place before its trigger rather than racing a frame that already fired.
+ */
 async function writeAwaitingRender(terminal: Terminal, data: string): Promise<void> {
   await write(terminal, data)
-  await new Promise<void>((resolve) => {
-    const rendered = terminal.onRender(() => {
-      rendered.dispose()
+  await new Promise<void>((resolve) => window.setTimeout(resolve, 0))
+  const rendered = new Promise<void>((resolve) => {
+    const listener = terminal.onRender(() => {
+      listener.dispose()
       resolve()
     })
   })
+  terminal.refresh(0, terminal.rows - 1)
+  await rendered
+}
+
+function cursorCell(container: HTMLElement): Element | null {
+  return container.querySelector('.xterm-rows .xterm-cursor')
 }
 
 function describeCells(terminal: Terminal, count: number): string[] {
@@ -77,7 +98,7 @@ describe('#12729 — the cursor is not displaced by full-width text', () => {
   })
 
   it('leaves the reported pty stream with the cursor on the requested column', async () => {
-    const terminal = openTerminal()
+    const { terminal } = openTerminal()
 
     await write(terminal, REPORTED_PTY_STREAM)
 
@@ -103,25 +124,25 @@ describe('#12729 — the cursor is not displaced by full-width text', () => {
   })
 
   it('paints the cursor after the run, not on the last syllable', async () => {
-    const terminal = openTerminal()
+    const { container, terminal } = openTerminal()
     terminal.focus()
 
     await writeAwaitingRender(terminal, '> 가나다라')
 
-    const cursorSpan = document.querySelector('.xterm-rows .xterm-cursor')
+    const cursorSpan = cursorCell(container)
     expect(cursorSpan?.previousElementSibling?.textContent).toBe('> 가나다라')
     expect(cursorSpan?.textContent).toBe(' ')
   })
 
   it('carries the whole syllable when the cursor does sit on a full-width glyph', async () => {
-    const terminal = openTerminal()
+    const { container, terminal } = openTerminal()
     terminal.focus()
 
     // CHA 9: back onto 라's starting cell, the placement the report describes.
     await writeAwaitingRender(terminal, '> 가나다라\x1b[9G')
 
     expect(terminal.buffer.active.cursorX).toBe(8)
-    const cursorSpan = document.querySelector('.xterm-rows .xterm-cursor')
+    const cursorSpan = cursorCell(container)
     // The whole syllable is inside the cursor span, so a block cursor cannot clip its right half.
     expect(cursorSpan?.textContent).toBe('라')
     expect(cursorSpan?.classList.contains('xterm-cursor-block')).toBe(true)

--- a/src/renderer/src/components/terminal-pane/terminal-cjk-cursor-cell-placement.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-cjk-cursor-cell-placement.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment happy-dom
+/**
+ * Issue #12729 — "the cursor lands on the wide character's first cell and clips its right half".
+ *
+ * The report pins two claims about the cursor. Both are pinned here against the vendored xterm,
+ * because neither reproduces and a regression in either would change what the answer to that
+ * issue is:
+ *
+ *   1. the reporter's captured pty stream must leave the cursor on the column the application
+ *      asked for (`CSI 25;11H`), not on the last syllable's starting cell; and
+ *   2. a block cursor sitting on a full-width glyph must carry the whole syllable, so nothing
+ *      about the cursor can hide half a character.
+ *
+ * The occluding box in that report is the IME preedit overlay, not the cursor — see
+ * `terminal-ime-xterm-trailing-preedit-occlusion.test.ts`.
+ */
+import { Terminal } from '@xterm/xterm'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Escapes made visible in the issue: hide cursor, home, CUF 2, CUD 24, the text, then two CUPs.
+const REPORTED_PTY_STREAM = '\x1b[?25l\x1b[H\x1b[2C\x1b[24B가나다라\x1b[30;1H\x1b[25;11H\x1b[?25h'
+
+const openTerminals: Terminal[] = []
+
+function openTerminal(): Terminal {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const terminal = new Terminal({ cols: 80, rows: 30 })
+  terminal.open(container)
+  openTerminals.push(terminal)
+  return terminal
+}
+
+function write(terminal: Terminal, data: string): Promise<void> {
+  return new Promise((resolve) => terminal.write(data, resolve))
+}
+
+/** Awaits the repaint the write triggers, so the row spans under assertion are the rendered ones. */
+async function writeAwaitingRender(terminal: Terminal, data: string): Promise<void> {
+  await write(terminal, data)
+  await new Promise<void>((resolve) => {
+    const rendered = terminal.onRender(() => {
+      rendered.dispose()
+      resolve()
+    })
+  })
+}
+
+function describeCells(terminal: Terminal, count: number): string[] {
+  const buffer = terminal.buffer.active
+  const line = buffer.getLine(buffer.cursorY)
+  if (!line) {
+    throw new Error('cursor row is missing')
+  }
+  const cells: string[] = []
+  for (let x = 0; x < count; x++) {
+    const cell = line.getCell(x)
+    cells.push(`${cell?.getChars() ?? ''}:${cell?.getWidth() ?? -1}`)
+  }
+  return cells
+}
+
+describe('#12729 — the cursor is not displaced by full-width text', () => {
+  beforeEach(() => {
+    // happy-dom has no 2d context, which the DOM renderer's WidthCache requires.
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      measureText: () => ({ width: 10 })
+    } as unknown as CanvasRenderingContext2D)
+  })
+
+  afterEach(() => {
+    while (openTerminals.length > 0) {
+      openTerminals.pop()?.dispose()
+    }
+    vi.restoreAllMocks()
+    document.body.replaceChildren()
+  })
+
+  it('leaves the reported pty stream with the cursor on the requested column', async () => {
+    const terminal = openTerminal()
+
+    await write(terminal, REPORTED_PTY_STREAM)
+
+    const buffer = terminal.buffer.active
+    // `CSI 25;11H` is 1-based; the last syllable's starting cell would be 8.
+    expect(buffer.cursorX).toBe(10)
+    expect(buffer.cursorY).toBe(24)
+    // Each syllable owns its cell plus a zero-width continuation, so the run ends at cell 9.
+    // Cells 0-1 were never written: the row was reached with CUD, so they stay null.
+    expect(describeCells(terminal, 11)).toEqual([
+      ':1',
+      ':1',
+      '가:2',
+      ':0',
+      '나:2',
+      ':0',
+      '다:2',
+      ':0',
+      '라:2',
+      ':0',
+      ':1'
+    ])
+  })
+
+  it('paints the cursor after the run, not on the last syllable', async () => {
+    const terminal = openTerminal()
+    terminal.focus()
+
+    await writeAwaitingRender(terminal, '> 가나다라')
+
+    const cursorSpan = document.querySelector('.xterm-rows .xterm-cursor')
+    expect(cursorSpan?.previousElementSibling?.textContent).toBe('> 가나다라')
+    expect(cursorSpan?.textContent).toBe(' ')
+  })
+
+  it('carries the whole syllable when the cursor does sit on a full-width glyph', async () => {
+    const terminal = openTerminal()
+    terminal.focus()
+
+    // CHA 9: back onto 라's starting cell, the placement the report describes.
+    await writeAwaitingRender(terminal, '> 가나다라\x1b[9G')
+
+    expect(terminal.buffer.active.cursorX).toBe(8)
+    const cursorSpan = document.querySelector('.xterm-rows .xterm-cursor')
+    // The whole syllable is inside the cursor span, so a block cursor cannot clip its right half.
+    expect(cursorSpan?.textContent).toBe('라')
+    expect(cursorSpan?.classList.contains('xterm-cursor-block')).toBe(true)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-cursor-appearance-precedence.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-cursor-appearance-precedence.test.ts
@@ -10,6 +10,11 @@
  * The one thing that does override the preference is a `DECSCUSR` from the running program, which
  * every terminal honours and which prompt frameworks emit routinely. That precedence is pinned
  * here because it is the answer to "my setting does nothing" whenever the overlay is not involved.
+ *
+ * Note what this file does NOT establish: composing the opacity into `theme.cursor` is not the same
+ * as it reaching the screen. The webgl renderer uses the cursor colour as a cell background and
+ * drops its alpha, so opacity is inert for a block cursor there — the default style on the default
+ * renderer. That is upstream in the addon, and only the DOM renderer is exercised below.
  */
 import { Terminal } from '@xterm/xterm'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -24,7 +29,41 @@ function decPrivateCursorStyle(terminal: Terminal): string | undefined {
   )._core.coreService.decPrivateModes.cursorStyle
 }
 
-describe('#12729 — cursor style and opacity reach the terminal', () => {
+function cursorClasses(container: HTMLElement): string[] {
+  const cursor = container.querySelector('.xterm-rows .xterm-cursor')
+  if (!cursor) {
+    throw new Error('no cursor cell was rendered')
+  }
+  return [...cursor.classList]
+}
+
+/** Resolves once the emulator has parsed `data`, so the escape has taken effect before any read. */
+function write(terminal: Terminal, data: string): Promise<void> {
+  return new Promise((resolve) => terminal.write(data, resolve))
+}
+
+/**
+ * Lets the act settle, drains the frame it already scheduled, then subscribes before forcing the
+ * one under assertion — so the awaited render is guaranteed to post-date the act, and the listener
+ * is always in place before its trigger runs.
+ */
+async function actAndAwaitRender(
+  terminal: Terminal,
+  act: () => void | Promise<void>
+): Promise<void> {
+  await act()
+  await new Promise<void>((resolve) => window.setTimeout(resolve, 0))
+  const rendered = new Promise<void>((resolve) => {
+    const listener = terminal.onRender(() => {
+      listener.dispose()
+      resolve()
+    })
+  })
+  terminal.refresh(0, terminal.rows - 1)
+  await rendered
+}
+
+describe('#12729 — cursor style and opacity survive the settings path', () => {
   it('keeps an explicitly chosen bar across the settings write and the next load', () => {
     // The write path stamps the migration flag alongside the user's choice.
     const written = normalizeTerminalCursorStyleDefault(
@@ -74,19 +113,30 @@ describe('#12729 — DECSCUSR from the program outranks the preference', () => {
     const terminal = new Terminal({ cols: 40, rows: 6, cursorStyle: 'bar' })
     terminal.open(container)
     openTerminals.push(terminal)
+    terminal.focus()
 
+    await actAndAwaitRender(terminal, () => write(terminal, 'x'))
     expect(decPrivateCursorStyle(terminal)).toBeUndefined()
+    expect(cursorClasses(container)).toContain('xterm-cursor-bar')
 
     // `CSI 2 SP q` — steady block, what a prompt framework emits on every redraw.
-    await new Promise<void>((resolve) => terminal.write('\x1b[2 q', resolve))
+    await actAndAwaitRender(terminal, () => write(terminal, '\x1b[2 q'))
     expect(decPrivateCursorStyle(terminal)).toBe('block')
+    // The rendered class, not the private mode: the two are separate fields, so only what the
+    // renderer resolved out of them can fail when the precedence itself is dropped.
+    expect(cursorClasses(container)).toContain('xterm-cursor-block')
+    expect(cursorClasses(container)).not.toContain('xterm-cursor-bar')
 
     // Changing the preference while that is set cannot win it back; only the reset does.
-    terminal.options.cursorStyle = 'underline'
-    expect(decPrivateCursorStyle(terminal)).toBe('block')
+    await actAndAwaitRender(terminal, () => {
+      terminal.options.cursorStyle = 'underline'
+    })
+    expect(cursorClasses(container)).toContain('xterm-cursor-block')
 
     // Orca sends this reset on replay and on the agent-idle path (RESET_TERMINAL_CURSOR_STYLE).
-    await new Promise<void>((resolve) => terminal.write('\x1b[0 q', resolve))
+    await actAndAwaitRender(terminal, () => write(terminal, '\x1b[0 q'))
     expect(decPrivateCursorStyle(terminal)).toBeUndefined()
+    // And control lands back on the preference, which moved to underline while DECSCUSR held it.
+    expect(cursorClasses(container)).toContain('xterm-cursor-underline')
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-cursor-appearance-precedence.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-cursor-appearance-precedence.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment happy-dom
+/**
+ * Issue #12729's second claim — "`terminalCursorStyle` / `terminalCursorOpacity` are ignored".
+ *
+ * Neither reproduces as a plumbing defect: an explicit `bar` survives the settings round trip and
+ * the opacity composes into the theme's cursor colour. What the report was looking at is the IME
+ * preedit overlay, which no cursor option reaches by construction
+ * (`terminal-ime-xterm-trailing-preedit-occlusion.test.ts`).
+ *
+ * The one thing that does override the preference is a `DECSCUSR` from the running program, which
+ * every terminal honours and which prompt frameworks emit routinely. That precedence is pinned
+ * here because it is the answer to "my setting does nothing" whenever the overlay is not involved.
+ */
+import { Terminal } from '@xterm/xterm'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { normalizeTerminalCursorStyleDefault } from '../../../../shared/terminal-cursor-style-settings'
+import { composeActiveTerminalTheme } from './terminal-appearance'
+
+function decPrivateCursorStyle(terminal: Terminal): string | undefined {
+  return (
+    terminal as unknown as {
+      _core: { coreService: { decPrivateModes: { cursorStyle?: string } } }
+    }
+  )._core.coreService.decPrivateModes.cursorStyle
+}
+
+describe('#12729 — cursor style and opacity reach the terminal', () => {
+  it('keeps an explicitly chosen bar across the settings write and the next load', () => {
+    // The write path stamps the migration flag alongside the user's choice.
+    const written = normalizeTerminalCursorStyleDefault(
+      { terminalCursorStyle: 'bar' },
+      { preserveExplicitValue: true }
+    )
+    expect(written).toEqual({
+      terminalCursorStyle: 'bar',
+      terminalCursorStyleDefaultedToBlock: true
+    })
+
+    // The load path re-runs the migration over what was persisted and must not re-default it.
+    expect(normalizeTerminalCursorStyleDefault(written).terminalCursorStyle).toBe('bar')
+  })
+
+  it('composes terminalCursorOpacity into the theme cursor colour', () => {
+    const theme = composeActiveTerminalTheme(
+      { background: '#112233', foreground: '#aabbcc', cursor: '#ffffff' },
+      { terminalCursorOpacity: 0.1 }
+    )
+
+    expect(theme?.cursor).toBe('rgba(255, 255, 255, 0.1)')
+  })
+})
+
+describe('#12729 — DECSCUSR from the program outranks the preference', () => {
+  const openTerminals: Terminal[] = []
+
+  beforeEach(() => {
+    // happy-dom has no 2d context, which the DOM renderer's WidthCache requires.
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      measureText: () => ({ width: 10 })
+    } as unknown as CanvasRenderingContext2D)
+  })
+
+  afterEach(() => {
+    while (openTerminals.length > 0) {
+      openTerminals.pop()?.dispose()
+    }
+    vi.restoreAllMocks()
+    document.body.replaceChildren()
+  })
+
+  it('pins the shape a prompt asked for until CSI 0 SP q hands it back', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const terminal = new Terminal({ cols: 40, rows: 6, cursorStyle: 'bar' })
+    terminal.open(container)
+    openTerminals.push(terminal)
+
+    expect(decPrivateCursorStyle(terminal)).toBeUndefined()
+
+    // `CSI 2 SP q` — steady block, what a prompt framework emits on every redraw.
+    await new Promise<void>((resolve) => terminal.write('\x1b[2 q', resolve))
+    expect(decPrivateCursorStyle(terminal)).toBe('block')
+
+    // Changing the preference while that is set cannot win it back; only the reset does.
+    terminal.options.cursorStyle = 'underline'
+    expect(decPrivateCursorStyle(terminal)).toBe('block')
+
+    // Orca sends this reset on replay and on the agent-idle path (RESET_TERMINAL_CURSOR_STYLE).
+    await new Promise<void>((resolve) => terminal.write('\x1b[0 q', resolve))
+    expect(decPrivateCursorStyle(terminal)).toBeUndefined()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-ime-xterm-trailing-preedit-occlusion.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-xterm-trailing-preedit-occlusion.test.ts
@@ -1,0 +1,178 @@
+// @vitest-environment happy-dom
+/**
+ * Issue #12729 — typing `가나다라` leaves the last syllable inside an opaque block.
+ *
+ * The report reads the block as a mis-placed cursor, but no cursor can produce it: the cursor sits
+ * on the column the application asked for and a block cursor carries the whole wide glyph
+ * (`terminal-cjk-cursor-cell-placement.test.ts`). What sits there is the preedit overlay.
+ *
+ * macOS 2-set Korean keeps the trailing syllable composing until a terminator, so after four
+ * keystrokes only `가나다` has reached the pty; `라` lives in `.composition-view`, an opaque box
+ * anchored to the cursor cell. Stock xterm styles that box `#000`/`#FFF` in its own stylesheet,
+ * which is the black block the report measured, and no cursor setting can reach it — matching the
+ * report's second claim that `terminalCursorStyle` / `terminalCursorOpacity` do nothing.
+ *
+ * #15014 themed the overlay from `options.theme`; this pins the end-of-row arm of that, which is
+ * the shape #12729 hits. happy-dom performs no layout, so the cell size is supplied and only the
+ * anchor is asserted, not glyph geometry.
+ */
+import { Terminal } from '@xterm/xterm'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const CELL_WIDTH_PX = 8
+const CELL_HEIGHT_PX = 16
+const THEME = { background: '#112233', foreground: '#aabbcc' }
+
+const openTerminals: Terminal[] = []
+
+function nextEventLoop(): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, 0))
+}
+
+type Rig = {
+  commit: (syllable: string) => Promise<void>
+  compositionView: HTMLElement
+  composeUpdate: (preedit: string) => void
+  composeStart: () => void
+  sent: string[]
+  terminal: Terminal
+}
+
+function openTerminal(): Rig {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const terminal = new Terminal({ cols: 80, rows: 24, theme: THEME })
+  terminal.open(container)
+  const textarea = terminal.textarea
+  const compositionView = container.querySelector<HTMLElement>('.composition-view')
+  if (!textarea || !compositionView) {
+    throw new Error('xterm did not create the helper textarea and composition view')
+  }
+  openTerminals.push(terminal)
+
+  const cell = (
+    terminal as unknown as {
+      _core: {
+        _renderService: { dimensions: { css: { cell: { height: number; width: number } } } }
+      }
+    }
+  )._core._renderService.dimensions.css.cell
+  cell.width = CELL_WIDTH_PX
+  cell.height = CELL_HEIGHT_PX
+
+  // A local-echo shell: committed syllables come back through the pty and land in the buffer.
+  const sent: string[] = []
+  terminal.onData((data) => {
+    sent.push(data)
+    terminal.write(data)
+  })
+
+  const composeStart = (): void => {
+    const start = new CompositionEvent('compositionstart', { bubbles: true })
+    Object.defineProperty(start, 'data', { value: '' })
+    textarea.dispatchEvent(start)
+  }
+
+  const composeUpdate = (preedit: string): void => {
+    const update = new CompositionEvent('compositionupdate', { bubbles: true })
+    Object.defineProperty(update, 'data', { value: preedit })
+    textarea.value = preedit
+    textarea.dispatchEvent(update)
+  }
+
+  const commit = async (syllable: string): Promise<void> => {
+    const end = new CompositionEvent('compositionend', { bubbles: true })
+    Object.defineProperty(end, 'data', { value: syllable })
+    textarea.dispatchEvent(end)
+    textarea.value = ''
+    await nextEventLoop()
+    await nextEventLoop()
+  }
+
+  return { commit, compositionView, composeStart, composeUpdate, sent, terminal }
+}
+
+function stripMarks(text: string | null): string {
+  return (text ?? '').replaceAll('‎', '')
+}
+
+/** Rolling 2-set Korean: each new consonant commits the previous syllable and opens the next. */
+async function typeHangulRun(rig: Rig, syllables: readonly string[]): Promise<void> {
+  for (let index = 0; index < syllables.length; index++) {
+    if (index > 0) {
+      await rig.commit(syllables[index - 1]!)
+    }
+    rig.composeStart()
+    rig.composeUpdate(syllables[index]!)
+    await nextEventLoop()
+  }
+}
+
+describe('#12729 — the block over a trailing Korean syllable is the preedit overlay', () => {
+  beforeEach(() => {
+    // happy-dom has no 2d context, which the DOM renderer's WidthCache requires.
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      measureText: () => ({ width: 10 })
+    } as unknown as CanvasRenderingContext2D)
+  })
+
+  afterEach(async () => {
+    // updateCompositionElements re-arms on a timer; let the pending one run before dispose.
+    await nextEventLoop()
+    await nextEventLoop()
+    while (openTerminals.length > 0) {
+      openTerminals.pop()?.dispose()
+    }
+    vi.restoreAllMocks()
+    document.body.replaceChildren()
+  })
+
+  it('holds the trailing syllable in the overlay while the earlier ones reach the pty', async () => {
+    const rig = openTerminal()
+
+    await typeHangulRun(rig, ['가', '나', '다', '라'])
+
+    expect(rig.sent.join('')).toBe('가나다')
+    // Three committed syllables at two cells each: the cursor is at the next free cell.
+    expect(rig.terminal.buffer.active.cursorX).toBe(6)
+    expect(rig.compositionView.classList.contains('active')).toBe(true)
+    expect(stripMarks(rig.compositionView.textContent)).toBe('라')
+    // Nothing follows the cursor, so the overlay carries the preedit alone.
+    expect(rig.compositionView.children).toHaveLength(0)
+  })
+
+  it('anchors the overlay to the cursor cell so the preedit continues the run', async () => {
+    const rig = openTerminal()
+
+    await typeHangulRun(rig, ['가', '나', '다', '라'])
+
+    expect(rig.compositionView.style.left).toBe(`${6 * CELL_WIDTH_PX}px`)
+    expect(rig.compositionView.style.height).toBe(`${CELL_HEIGHT_PX}px`)
+    // Synced to the grid's font so the preedit keeps the advance the committed syllables have.
+    expect(rig.compositionView.style.fontFamily).toBe(rig.terminal.options.fontFamily)
+    expect(rig.compositionView.style.fontSize).toBe(`${rig.terminal.options.fontSize}px`)
+  })
+
+  it('themes the trailing overlay instead of the stock opaque #000/#FFF block', async () => {
+    const rig = openTerminal()
+
+    await typeHangulRun(rig, ['가', '나', '다', '라'])
+
+    const { background, color } = rig.compositionView.style
+    expect([THEME.background, 'rgb(17, 34, 51)']).toContain(background)
+    expect([THEME.foreground, 'rgb(170, 187, 204)']).toContain(color)
+  })
+
+  it('clears the overlay once the trailing syllable commits', async () => {
+    const rig = openTerminal()
+    await typeHangulRun(rig, ['가', '나', '다', '라'])
+
+    await rig.commit('라')
+
+    expect(rig.sent.join('')).toBe('가나다라')
+    expect(rig.compositionView.classList.contains('active')).toBe(false)
+    expect(rig.compositionView.textContent).toBe('')
+    // The whole run is now committed cells, with the cursor after it.
+    expect(rig.terminal.buffer.active.cursorX).toBe(8)
+  })
+})

--- a/tests/e2e/terminal-korean-endofrow-preedit-cell-span.spec.ts
+++ b/tests/e2e/terminal-korean-endofrow-preedit-cell-span.spec.ts
@@ -1,0 +1,99 @@
+/**
+ * How many grid cells does an end-of-row preedit overlay actually occupy on screen?
+ *
+ * #12729 reported a black block over the last syllable of `가나다라`, and measured it at one cell
+ * wide (14px against a 14px grid). We answer that report by saying the block is the preedit
+ * overlay, not the cursor — but an overlay holding one Hangul syllable is shrink-to-fit around a
+ * full-width glyph, so it should span about two cells, not one. That mismatch is the only measured
+ * quantity in the report that argues against our explanation, and nothing in the unit suite can
+ * settle it: `CompositionHelper` sets `maxWidth` but never `width`, so the rendered width comes
+ * entirely from layout, and happy-dom reports every rect as zero.
+ *
+ * So this is the arm that measures it. If it fails, our answer to #12729 is wrong and the report's
+ * one-cell measurement was right.
+ *
+ * The assertion is a floor, not a band. How many cells a syllable occupies is a function of the
+ * runner's font metrics and fallback — the mid-line spec records a preedit measured at 34.4px over
+ * an 8.43px grid, which is four cells, not two — so pinning "about two" would pin the machine. The
+ * claim under test is only that the overlay is materially wider than the single cell the report
+ * measured, which is what discriminates the overlay from the cursor.
+ */
+import type { Page } from '@stablyai/playwright-test'
+import { expect, test } from './helpers/orca-app'
+import { closeTerminalImePaneArena, openTerminalImePaneArena } from './terminal-ime-pane-arena'
+import { setImeComposition } from './terminal-ime-cdp-composition'
+import {
+  sampleMidlinePreeditOcclusion,
+  writeToActiveTerminal,
+  type MidlinePreeditOcclusionSample
+} from './terminal-ime-midline-occlusion-probe'
+import { samplePreeditOverlay } from './terminal-ime-preedit-overlay-probe'
+
+/** Below this the overlay is the one-cell block the report measured; above it, a full-width glyph. */
+const MIN_CELLS_FOR_A_FULL_WIDTH_SYLLABLE = 1.5
+
+/**
+ * Waits for the preedit to reach the overlay at a non-zero size, then samples once — the pane runs
+ * a live shell that can repaint the row, so only the frame the composition opened on carries the
+ * state under assertion.
+ */
+async function sampleOpenComposition(page: Page): Promise<MidlinePreeditOcclusionSample> {
+  await expect
+    .poll(
+      async () => {
+        const overlay = await samplePreeditOverlay(page)
+        return overlay.active && overlay.rect.width > 0 && overlay.text === '가'
+      },
+      { message: 'the preedit never reached the overlay at a non-zero size' }
+    )
+    .toBe(true)
+  return sampleMidlinePreeditOcclusion(page)
+}
+
+function describeSpan(sample: MidlinePreeditOcclusionSample): string {
+  const cells = sample.cellWidth > 0 ? sample.overlayRect.width / sample.cellWidth : 0
+  return `overlay ${sample.overlayRect.width}px over a ${sample.cellWidth}px cell = ${cells.toFixed(2)} cells, covering columns ${JSON.stringify(sample.coveredColumns)}`
+}
+
+test.describe('Terminal end-of-row Korean preedit cell span', () => {
+  test('renders a composing syllable wider than the one cell #12729 measured', async ({
+    orcaPage
+  }, testInfo) => {
+    const arena = await openTerminalImePaneArena(orcaPage)
+    let completed = false
+    try {
+      // 안녕하세요 is ten cells, so the cursor lands at the end of the row with nothing after it —
+      // the shape #12729 hits, and the one where the overlay carries the preedit alone.
+      await writeToActiveTerminal(orcaPage, '\x1b[2J\x1b[H안녕하세요')
+      await setImeComposition(arena.session, '가')
+
+      const sample = await sampleOpenComposition(orcaPage)
+      expect(sample.rowTailFromCursor, 'text still sits after the cursor').toBe('')
+      expect(sample.cursorColumn, 'the cursor is not at the end of the committed run').toBe(10)
+      expect(
+        sample.cellWidth,
+        'the grid reported no cell width to measure against'
+      ).toBeGreaterThan(0)
+
+      // The load-bearing assertion, and the one no unit arm can make: a preedit overlay holding a
+      // full-width syllable is wider than a single cell, so the one-cell block in the report
+      // cannot be an overlay rendering the same way this one does.
+      expect(
+        sample.overlayRect.width / sample.cellWidth,
+        `a composing Hangul syllable must occupy more than one cell — ${describeSpan(sample)}`
+      ).toBeGreaterThan(MIN_CELLS_FOR_A_FULL_WIDTH_SYLLABLE)
+      expect(
+        sample.coveredColumns,
+        `the overlay covers no grid columns to assert about — ${describeSpan(sample)}`
+      ).not.toBe(null)
+      completed = true
+    } finally {
+      await closeTerminalImePaneArena(
+        arena,
+        testInfo,
+        'korean-endofrow-preedit-cell-span',
+        !completed
+      )
+    }
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​569 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​569 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 |

<!-- /orca-pr-loc -->

Refs #12729.

**Neither claimed defect reproduces. The black block is not the cursor — it is the IME preedit overlay, and it was already fixed by #15014, which landed the day after the reported release.**

Tests only; no production change.

## Defect 1 — cursor on the wide char's first cell: does not reproduce

Replaying the reporter's own captured stream (`ESC[?25l ESC[H ESC[2C ESC[24B 가나다라 ESC[30;1H ESC[25;11H ESC[?25h`):

- `buffer.cursorX === 10` — column 11, exactly what `CSI 25;11H` requested. Not cell 8.
- cells pair correctly: `가:2 ·:0 나:2 ·:0 다:2 ·:0 라:2 ·:0`
- the cursor renders as its own span *after* the run; forced onto the wide cell it carries the whole syllable (`textContent === '라'`)

And the structural point: **a block cursor inverts a cell, it does not mask it.** It cannot hide half a glyph. That alone rules out every cursor-based explanation of "the right half is never drawn."

## Defect 2 — cursor style/opacity ignored: not a plumbing bug

The settings path is intact end to end — explicit `bar` survives write and reload, `applyTerminalAppearance` writes `cursorStyle` to every mounted pane, opacity composes to `rgba(...)`, and all 30 builtin themes define `cursor`, so the gate never silently drops it.

Two real findings, neither being the reported symptom:

1. **A `DECSCUSR` from the running program outranks the setting** (`decPrivateModes.cursorStyle ?? options.cursorStyle`). Prompt frameworks emit this on every redraw. Correct terminal behaviour and matches other terminals — but it is the honest answer whenever someone says "my cursor setting does nothing."
2. **Cursor opacity genuinely does nothing for a block cursor under WebGL** — the default style on the default renderer. The cursor colour is used as a cell background and the alpha is stripped (`rgba >> 8 & 16777215`). The DOM renderer keeps it. **This is upstream in the webgl addon**, not in xterm or in our code, and is left alone here.

## What is actually happening

macOS 2-set Korean keeps the **trailing syllable composing** until a terminator. After typing `가나다라` only `가나다` has reached the pty; `라` lives in `.composition-view`, an opaque absolutely-positioned box anchored at the cursor cell and painted over the grid.

In v1.4.184 that box used stock upstream colours — `background: #000; color: #FFF`. That is the black block.

It accounts for every observation, including the ones no cursor theory can:

| reported | the overlay explains it |
| --- | --- |
| opaque regardless of cursor style/opacity | it is not the cursor; no cursor option reaches it |
| identical with GPU acceleration off | it is a DOM node above **both** renderers |
| Latin unaffected | Latin never opens a composition |
| Enter makes it correct | Enter **commits** the composition and clears the overlay |
| glyph unreadable / half missing | an opaque box masks; a block cursor inverts |

The follow-up comment's "it is not composition state" was inferred from "Enter fixes it" — but Enter is precisely the terminator that ends the composition.

## Already fixed

`453237cc57c` (#15014, 2026-08-17) themes the overlay from `options.theme` with the alpha dropped, and renders the row tail it covers.

```
#15014 in v1.4.184?   NO   (v1.4.184 tagged 2026-08-16)
#15014 in main?       YES
```

So the answer to the reporter is "fixed, ships in the next release" — plus the separate upstream opacity gap above.

## The tests

- `terminal-cjk-cursor-cell-placement.test.ts` — pins defect 1's negative result so the cursor explanation cannot be re-derived
- `terminal-cursor-appearance-precedence.test.ts` — settings round-trip, opacity composition, and DECSCUSR precedence including the reset handing control back
- `terminal-ime-xterm-trailing-preedit-occlusion.test.ts` — pins the real mechanism: only `가나다` reaches the pty while `라` sits in a **themed** overlay at the cursor cell, cleared on commit. The theming assertion is the arm with teeth against 1.4.184, where the inline background was never set at all. Sits beside #15014's existing mid-line arm; this is the end-of-row arm, which is the shape this issue hits.

```
Test Files  3 passed (3)      Tests  10 passed (10)
```

## The strongest evidence, and the one measurement that argues against us

What actually rules out the cursor is structural, not arithmetic: **a block cursor spans the whole wide glyph.** Under the WebGL renderer — the default on macOS — `lastCursorX = cursorX + cell.getWidth() - 1` and the fill runs `x >= cursorX && x <= lastCursorX` (`addon-webgl` `WebglRenderer.ts:550,552`). The DOM renderer puts the syllable inside the cursor span. So "the cursor covers one cell of a two-cell glyph" fails on **both** renderers. That closes it far harder than any pixel sum.

I want to retract an argument that appeared in an earlier draft of this description, because it was wrong and it dismissed careful work:

- The `23 + 8×14 = 135` calculation has **no discriminating power**. Cell index 8 is column 9, which is the reporter's own stated cursor column. Both theories put the block's left edge at the same pixel. It restates their number rather than explaining it.
- I claimed their pixel table derives cell width *from* the block and is therefore circular. **It is not.** The report carries a second, independent measurement — the Korean glyph advance 가→나→다 of 28px, over glyphs on the grid under either theory. Hangul occupies two cells, so cell width = 28/2 = 14px, derived without reference to the block at all.

With 14px standing on its own, **the reported block width of 14px is exactly one cell — and the overlay would be two.** `.composition-view` sets no `width`, only `maxWidth`, and is `white-space: nowrap` (`CompositionHelper.ts:875-876`), so a view holding one Hangul syllable renders about 28px.

That is the only measured quantity in the report that discriminates between the two explanations, and **it points away from the overlay.**

I still believe the overlay explanation, because it accounts for six independent observations that no cursor theory can, and because a block cursor provably cannot mask half a glyph. The most likely reading is that "Cell width (from the cursor block)" is ambiguous about which block was measured. But that is a mis-measurement hypothesis, and it should be stated as one rather than waved away.

## Not verified

No visual confirmation — this rests on the structural argument above, the observations no cursor theory explains, and the code path, not on a screenshot.

**The disputed width is settleable and is not settled here.** happy-dom performs no layout, so every geometry assertion in these tests is attribute-level; the overlay's *rendered* width — the exact number the diagnosis turns on — cannot be asserted anywhere in this PR. The tooling already exists: `tests/e2e/terminal-ime-preedit-overlay-probe.ts` already returns `getBoundingClientRect().width` for `.composition-view`. An end-of-row arm alongside the existing mid-line spec, asserting a single Hangul syllable renders about two cells wide, would resolve 14 vs 28 outright. That is the highest-value follow-up and it is nearly free.
