### PR TITLE
fix(orchestration): record why a terminal's process is gone (STA-4603, STA-4536)

### DIFF
--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -698,14 +698,19 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
 
   describe('onExit', () => {
     it('routes exit events from daemon', async () => {
-      const exits: { id: string; code: number }[] = []
+      const exits: { id: string; code: number; cause?: unknown }[] = []
       adapter.onExit((payload) => exits.push(payload))
 
       const { id } = await adapter.spawn({ cols: 80, rows: 24 })
       lastSubprocess._simulateExit(42)
 
       await waitFor(() => exits.length > 0)
-      expect(exits[0]).toEqual({ id, code: 42, incarnationId: expect.any(String) })
+      expect(exits[0]).toEqual({
+        id,
+        code: 42,
+        incarnationId: expect.any(String),
+        cause: { kind: 'exited', exitCode: 42 }
+      })
     })
   })
 

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -94,6 +94,7 @@ import {
 import type { DaemonEvidenceSource, ExactDaemonIncarnation } from './daemon-incarnation-evidence'
 import { createDaemonAuditEligibilityTracker } from './daemon-audit-eligibility-event'
 import { normalizeDesktopTerminalSnapshotRows } from '../../shared/terminal-scrollback-policy'
+import type { TerminalExitCause } from '../../shared/terminal-exit-cause'
 
 type PendingDaemonSpawnOperation = {
   exitsBySessionId: Map<string, { incarnationId?: string }[]>
@@ -261,6 +262,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
     id: string
     code: number
     incarnationId?: PtyIncarnationId
+    cause?: TerminalExitCause
   }) => void)[] = []
   private backgroundStreamListeners: ((payload: PtyBackgroundStreamEvent) => void)[] = []
   // Why: lets main fan a dead-endpoint signal to every affected pane, not just the written one (STA-2373 sibling-freeze).
@@ -2999,7 +3001,8 @@ export class DaemonPtyAdapter implements IPtyProvider {
           listener({
             id: event.sessionId,
             code: event.payload.code,
-            ...(event.payload.incarnationId ? { incarnationId: event.payload.incarnationId } : {})
+            ...(event.payload.incarnationId ? { incarnationId: event.payload.incarnationId } : {}),
+            ...(event.payload.cause ? { cause: event.payload.cause } : {})
           })
         }
       }

--- a/src/main/daemon/daemon-pty-router-events.ts
+++ b/src/main/daemon/daemon-pty-router-events.ts
@@ -1,4 +1,5 @@
 import type { PtyIncarnationId } from '../../shared/pty-incarnation'
+import type { TerminalExitCause } from '../../shared/terminal-exit-cause'
 
 export type DaemonPtyRouterDataEvent = {
   id: string
@@ -12,4 +13,6 @@ export type DaemonPtyRouterExitEvent = {
   id: string
   code: number
   incarnationId?: PtyIncarnationId
+  /** Absent from a daemon predating exit causes; readers fall back to `unknown`. */
+  cause?: TerminalExitCause
 }

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -1168,17 +1168,18 @@ export class DaemonServer {
                   seq
                 })
               },
-              onExit: (code, incarnationId) => {
+              onExit: (code, incarnationId, cause) => {
                 // Why: exit tears down renderer handlers, so it must ride the ordered queue behind final output.
                 this.log.log('session-exited', {
                   sessionId: routedSessionId,
-                  code
+                  code,
+                  cause: cause?.kind
                 })
                 this.streamDataBatcher.enqueueControlEvent(clientId, routedSessionId, {
                   type: 'event',
                   event: 'exit',
                   sessionId: routedSessionId,
-                  payload: { code, incarnationId }
+                  payload: { code, incarnationId, ...(cause ? { cause } : {}) }
                 })
                 this.streamDataBatcher.flush(clientId)
                 recordDaemonStreamBacklogEvent('sessionExit', {

--- a/src/main/daemon/daemon-stream-events.ts
+++ b/src/main/daemon/daemon-stream-events.ts
@@ -1,6 +1,7 @@
 // ─── Events (Daemon → Client, on stream socket) ────────────────────
 import type { TerminalGitHubPRLink } from '../../shared/terminal-github-pr-link-detector'
 import type { PtyIncarnationId } from '../../shared/pty-incarnation'
+import type { TerminalExitCause } from '../../shared/terminal-exit-cause'
 
 export type DataEvent = {
   type: 'event'
@@ -20,7 +21,9 @@ export type ExitEvent = {
   type: 'event'
   event: 'exit'
   sessionId: string
-  payload: { code: number; incarnationId?: PtyIncarnationId }
+  /** `cause` is additive: a daemon predating it omits the field and readers fall
+   *  back to `unknown` rather than reading meaning into `code` (STA-4536). */
+  payload: { code: number; incarnationId?: PtyIncarnationId; cause?: TerminalExitCause }
 }
 
 export type TerminalErrorEvent = {

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -15,7 +15,11 @@ import {
   validateWorkingDirectoryAsync,
   WorkingDirectoryValidationAbortedError
 } from '../providers/local-pty-utils'
-import { wrapShellSpawnForMacosTccAttribution } from '../providers/macos-tcc-login-shell'
+import {
+  hostReportsChildExitStatus,
+  wrapShellSpawnForMacosTccAttribution
+} from '../providers/macos-tcc-login-shell'
+import { resolveProcessExitCause, type TerminalExitCause } from '../../shared/terminal-exit-cause'
 import { signalPosixPtyForegroundGroup } from '../pty/posix-pty-foreground-group'
 import { readPtsName } from '../pty/node-pty-pts-name'
 import {
@@ -578,7 +582,10 @@ function spawnDaemonPtyWithWindowsFallback(args: {
   shellPath: string
   spawnCwd: string
   startupCommandDeliveredInShellArgs?: boolean
+  /** False when a wrapper owns the reported status, so no exit code may be read from it. */
+  reportsChildExitStatus: boolean
 } {
+  let reportsChildExitStatus = true
   const spawnAt = (shellPath: string, shellArgs: string[], cwd: string): pty.IPty => {
     const wrapped = wrapShellSpawnForMacosTccAttribution(shellPath, shellArgs, args.env)
     const proc = pty.spawn(wrapped.file, wrapped.args, {
@@ -590,15 +597,18 @@ function spawnDaemonPtyWithWindowsFallback(args: {
       // Why: legacy system ConPTY can corrupt full-width TUI rows in scrollback; bundled ConPTY has the wrap-marker behavior xterm expects.
       ...(process.platform === 'win32' ? { useConptyDll: true } : {})
     })
+    reportsChildExitStatus = hostReportsChildExitStatus(wrapped.file)
     args.onMacosTccSpawnStrategy?.(wrapped.file === shellPath ? 'direct' : 'wrapped')
     return proc
   }
 
   try {
+    const process_ = spawnAt(args.shellPath, args.shellArgs, args.spawnCwd)
     return {
-      process: spawnAt(args.shellPath, args.shellArgs, args.spawnCwd),
+      process: process_,
       shellPath: args.shellPath,
-      spawnCwd: args.spawnCwd
+      spawnCwd: args.spawnCwd,
+      reportsChildExitStatus
     }
   } catch (primaryErr) {
     if (process.platform !== 'win32') {
@@ -616,7 +626,8 @@ function spawnDaemonPtyWithWindowsFallback(args: {
           process,
           shellPath: attempt.shellPath,
           spawnCwd: attempt.effectiveCwd,
-          startupCommandDeliveredInShellArgs: attempt.startupCommandDeliveredInShellArgs
+          startupCommandDeliveredInShellArgs: attempt.startupCommandDeliveredInShellArgs,
+          reportsChildExitStatus
         }
       } catch {
         // This fallback shell also failed -- try the next link in the chain.
@@ -908,6 +919,7 @@ export async function createPtySubprocess(opts: PtySubprocessOptions): Promise<S
   }
 
   let proc: pty.IPty
+  let reportsChildExitStatus = true
   try {
     const spawned = spawnDaemonPtyWithWindowsFallback({
       shellPath,
@@ -923,6 +935,7 @@ export async function createPtySubprocess(opts: PtySubprocessOptions): Promise<S
     // Why: a Windows fallback (e.g. cmd.exe) carries its own argv-embedded startup command; adopt the winning shell's identity + delivery flag.
     shellPath = spawned.shellPath
     spawnCwd = spawned.spawnCwd
+    reportsChildExitStatus = spawned.reportsChildExitStatus
     if (spawned.startupCommandDeliveredInShellArgs !== undefined) {
       startupCommandDeliveredInShellArgs = spawned.startupCommandDeliveredInShellArgs
     }
@@ -934,10 +947,11 @@ export async function createPtySubprocess(opts: PtySubprocessOptions): Promise<S
   }
 
   let onDataCb: ((data: string) => void) | null = null
-  let onExitCb: ((code: number) => void) | null = null
+  let onExitCb: ((code: number, cause?: TerminalExitCause) => void) | null = null
   let pendingPreListenerData: string[] = []
   let pendingPreListenerDataChars = 0
   let pendingPreListenerExitCode: number | null = null
+  let pendingPreListenerExitCause: TerminalExitCause | null = null
 
   const bufferPreListenerData = (data: string): void => {
     // Why: Windows shell-arg startup commands can print before Session wires this subprocess in; preserve that spawn-time race window.
@@ -976,12 +990,21 @@ export async function createPtySubprocess(opts: PtySubprocessOptions): Promise<S
       bufferPreListenerData(data)
     }
   })
-  proc.onExit(({ exitCode }) => {
+  proc.onExit(({ exitCode, signal }) => {
+    // Why: node-pty reports a signalled death as {exitCode: 0, signal: N}, and a
+    // wrapper spawn reports the wrapper's status — so build the cause here,
+    // where both facts are still in hand, rather than shipping a bare number.
+    const cause = resolveProcessExitCause({
+      exitCode,
+      signal,
+      hostReportsChildExitStatus: reportsChildExitStatus
+    })
     if (onExitCb) {
       flushPreListenerData()
-      onExitCb(exitCode)
+      onExitCb(exitCode, cause)
     } else {
       pendingPreListenerExitCode = exitCode
+      pendingPreListenerExitCause = cause
     }
   })
 
@@ -1341,9 +1364,11 @@ export async function createPtySubprocess(opts: PtySubprocessOptions): Promise<S
       onExitCb = cb
       if (pendingPreListenerExitCode !== null) {
         const code = pendingPreListenerExitCode
+        const cause = pendingPreListenerExitCause ?? resolveProcessExitCause({ exitCode: code })
         pendingPreListenerExitCode = null
+        pendingPreListenerExitCause = null
         flushPreListenerData()
-        cb(code)
+        cb(code, cause)
       }
     },
     dispose: () => {
@@ -1357,6 +1382,7 @@ export async function createPtySubprocess(opts: PtySubprocessOptions): Promise<S
       pendingPreListenerData = []
       pendingPreListenerDataChars = 0
       pendingPreListenerExitCode = null
+      pendingPreListenerExitCause = null
       // Why: UnixTerminal.destroy()'s async socket-close SIGHUP can land on a recycled pid, hitting an unrelated user process; neutralize kill on POSIX.
       // Windows destroy() uses kill() to close the ConPTY agent, so the guard is POSIX-only.
       if (process.platform !== 'win32') {

--- a/src/main/daemon/session-output-plane.ts
+++ b/src/main/daemon/session-output-plane.ts
@@ -1,3 +1,4 @@
+import { resolveProcessExitCause, type TerminalExitCause } from '../../shared/terminal-exit-cause'
 import { HeadlessEmulator } from './headless-emulator'
 import { StartupDeviceAttributesQueryFilter } from './startup-device-attributes-responder'
 import { normalizePtySize } from './daemon-pty-size'
@@ -11,7 +12,7 @@ const PENDING_OUTPUT_MAX_BYTES = 2 * 1024 * 1024
 export type AttachedClient = {
   token: symbol
   onData: (data: string, rawLength?: number, transformed?: boolean, seq?: number) => void
-  onExit: (code: number, incarnationId: string) => void
+  onExit: (code: number, incarnationId: string, cause?: TerminalExitCause) => void
 }
 
 export type SessionOutputPlaneOptions = {
@@ -87,9 +88,12 @@ export class SessionOutputPlane {
     return this.attachedClients.slice()
   }
 
-  broadcastExit(code: number, incarnationId: string): void {
+  broadcastExit(code: number, incarnationId: string, cause?: TerminalExitCause): void {
+    // Why the fallback here: a handle that predates exit causes still reports a
+    // code, and every client deserves the same shape.
+    const resolved = cause ?? resolveProcessExitCause({ exitCode: code })
     for (const client of this.attachedClients) {
-      client.onExit(code, incarnationId)
+      client.onExit(code, incarnationId, resolved)
     }
   }
 

--- a/src/main/daemon/session-subprocess-handle.ts
+++ b/src/main/daemon/session-subprocess-handle.ts
@@ -1,3 +1,5 @@
+import type { TerminalExitCause } from '../../shared/terminal-exit-cause'
+
 export type SubprocessHandle = {
   pid: number
   /** Live foreground process name of the PTY (node-pty's `.process`), e.g.
@@ -28,7 +30,7 @@ export type SubprocessHandle = {
   forceKill(): void
   signal(sig: string): void
   onData(cb: (data: string) => void): void
-  onExit(cb: (code: number) => void): void
+  onExit(cb: (code: number, cause?: TerminalExitCause) => void): void
   /** Release the native PTY handle via node-pty's destroy(). Idempotent; safe to call after exit. */
   dispose(): void
 }

--- a/src/main/daemon/session.test.ts
+++ b/src/main/daemon/session.test.ts
@@ -736,7 +736,10 @@ describe('Session', () => {
 
       expect(onData).toHaveBeenCalledWith('late output')
       expect(onExit).toHaveBeenCalledTimes(1)
-      expect(onExit).toHaveBeenCalledWith(23, session.incarnationId)
+      expect(onExit).toHaveBeenCalledWith(23, session.incarnationId, {
+        kind: 'exited',
+        exitCode: 23
+      })
       expect(session.exitCode).toBe(23)
     })
   })

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -20,6 +20,7 @@ import type {
   TerminalSnapshot
 } from './types'
 import { createPtySlaveEchoProbe } from '../../shared/pty-slave-line-discipline-echo'
+import type { TerminalExitCause } from '../../shared/terminal-exit-cause'
 
 export class Session {
   readonly sessionId: string
@@ -82,7 +83,7 @@ export class Session {
     })
     this.shellReady.startPromptReadinessProbe()
     this.subprocess.onData((data) => this.handleSubprocessData(data))
-    this.subprocess.onExit((code) => this.handleSubprocessExit(code))
+    this.subprocess.onExit((code, cause) => this.handleSubprocessExit(code, cause))
   }
 
   get state(): SessionState {
@@ -342,7 +343,7 @@ export class Session {
     this.shellReady.ingestSubprocessData(data)
   }
 
-  private handleSubprocessExit(code: number): void {
+  private handleSubprocessExit(code: number, cause?: TerminalExitCause): void {
     this.termination.markPhysicalExit()
     if (this._disposed) {
       return
@@ -366,7 +367,7 @@ export class Session {
     // Not via #teardownSubprocess: it flips `_disposed`, short-circuiting the later Session.dispose() reaper.
     this.termination.disposeSubprocessHandle()
 
-    this.output.broadcastExit(code, this.incarnationId)
+    this.output.broadcastExit(code, this.incarnationId, cause)
 
     // Why: hand off to the owner's reaper (disposes emulator, drops session from host map); else dead sessions accumulate.
     this.onSessionExit?.(code)

--- a/src/main/daemon/terminal-host-create-contract.ts
+++ b/src/main/daemon/terminal-host-create-contract.ts
@@ -8,6 +8,7 @@ import type {
   AgentSessionSurfaceBinding
 } from '../../shared/agent-session-host-authority'
 import type { PtyIncarnationId } from '../../shared/pty-incarnation'
+import type { TerminalExitCause } from '../../shared/terminal-exit-cause'
 
 export type CreateOrAttachOptions = {
   sessionId: string
@@ -35,7 +36,7 @@ export type CreateOrAttachOptions = {
   }
   streamClient: {
     onData: (data: string, rawLength?: number, transformed?: boolean, seq?: number) => void
-    onExit: (code: number, incarnationId: PtyIncarnationId) => void
+    onExit: (code: number, incarnationId: PtyIncarnationId, cause?: TerminalExitCause) => void
   }
   /** Lets the daemon route output under the adopted owner's canonical id before
    *  attaching its stream callbacks. */

--- a/src/main/ipc/pty-daemon-ssh-lease-lifecycle.test.ts
+++ b/src/main/ipc/pty-daemon-ssh-lease-lifecycle.test.ts
@@ -289,7 +289,7 @@ describe('registerPtyHandlers', () => {
         await Promise.resolve()
 
         expect(runtime.onPtyExit).toHaveBeenCalledTimes(1)
-        expect(runtime.onPtyExit).toHaveBeenCalledWith('local-pty', 0, undefined)
+        expect(runtime.onPtyExit).toHaveBeenCalledWith('local-pty', 0, undefined, undefined)
         expect(
           mainWindow.webContents.send.mock.calls.filter((call) => call[0] === 'pty:exit')
         ).toEqual([['pty:exit', { id: 'local-pty', code: 0 }]])
@@ -342,7 +342,7 @@ describe('registerPtyHandlers', () => {
         await expect(stopPromise).resolves.toBe(true)
 
         expect(runtime.onPtyExit).toHaveBeenCalledTimes(1)
-        expect(runtime.onPtyExit).toHaveBeenCalledWith('local-pty', 0, undefined)
+        expect(runtime.onPtyExit).toHaveBeenCalledWith('local-pty', 0, undefined, undefined)
         expect(
           mainWindow.webContents.send.mock.calls.filter((call) => call[0] === 'pty:exit')
         ).toEqual([['pty:exit', { id: 'local-pty', code: 0 }]])

--- a/src/main/ipc/pty-listener-teardown-and-orphans.test.ts
+++ b/src/main/ipc/pty-listener-teardown-and-orphans.test.ts
@@ -436,7 +436,9 @@ describe('registerPtyHandlers', () => {
     await Promise.resolve()
 
     expect(killSpy).toHaveBeenCalled()
-    expect(runtime.onPtyExit).toHaveBeenCalledWith(spawnResult.id, -1, spawnResult.incarnationId)
+    expect(runtime.onPtyExit).toHaveBeenCalledWith(spawnResult.id, -1, spawnResult.incarnationId, {
+      cause: { kind: 'unknown', reason: 'stop_unverified' }
+    })
     const listed = await getLocalPtyProvider().listProcesses()
     expect(listed.some((info) => info.id === spawnResult.id)).toBe(false)
   })

--- a/src/main/ipc/pty-runtime-kill-and-exit.test.ts
+++ b/src/main/ipc/pty-runtime-kill-and-exit.test.ts
@@ -287,7 +287,7 @@ describe('registerPtyHandlers', () => {
     await handlers.get('pty:kill')!(null, { id: 'local-pty' })
 
     expect(runtime.onPtyExit).toHaveBeenCalledTimes(1)
-    expect(runtime.onPtyExit).toHaveBeenCalledWith('local-pty', 0, undefined)
+    expect(runtime.onPtyExit).toHaveBeenCalledWith('local-pty', 0, undefined, undefined)
     expect(mainWindow.webContents.send.mock.calls.filter((call) => call[0] === 'pty:exit')).toEqual(
       [['pty:exit', { id: 'local-pty', code: 0 }]]
     )
@@ -529,7 +529,7 @@ describe('registerPtyHandlers', () => {
         seq: 13,
         rawLength: 'daemon output'.length
       })
-      expect(runtime.onPtyExit).toHaveBeenCalledWith(result.id, 0, undefined)
+      expect(runtime.onPtyExit).toHaveBeenCalledWith(result.id, 0, undefined, undefined)
       expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:exit', {
         id: result.id,
         code: 0

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -2569,14 +2569,14 @@ export function registerPtyHandlers(
         return env
       },
       onSpawned: (id, incarnationId) => runtime?.onPtySpawned(id, incarnationId),
-      onExit: (id, code, incarnationId) => {
+      onExit: (id, code, incarnationId, cause) => {
         if (!isCurrentPtyExit({ id, incarnationId })) {
           return
         }
         clearProviderPtyState(id)
         ptyOwnership.delete(id)
         markClaudePtyExited(id)
-        runtime?.onPtyExit(id, code, incarnationId)
+        runtime?.onPtyExit(id, code, incarnationId, cause ? { cause } : undefined)
       },
       onData: (id, data, timestamp, sequenceChars, transformed) =>
         runtime?.onPtyData(id, data, timestamp, sequenceChars ?? data.length, transformed)
@@ -4121,9 +4121,20 @@ export function registerPtyHandlers(
         clearProviderPtyState(payload.id)
         ptyOwnership.delete(payload.id)
         markClaudePtyExited(payload.id)
-        runtime?.onPtyExit(payload.id, payload.code, payload.incarnationId)
+        runtime?.onPtyExit(
+          payload.id,
+          payload.code,
+          payload.incarnationId,
+          payload.cause ? { cause: payload.cause } : undefined
+        )
       }
-      sendPtyExitToRenderer(payload)
+      // Why not the whole payload: the exit cause is a main-process fact for the
+      // runtime's records; the renderer's pty:exit contract stays as it was.
+      sendPtyExitToRenderer({
+        id: payload.id,
+        code: payload.code,
+        ...(payload.incarnationId ? { incarnationId: payload.incarnationId } : {})
+      })
     })
   }
 
@@ -5591,6 +5602,7 @@ export function registerPtyHandlers(
       }
     },
     kill: (ptyId) => {
+      runtime?.markPtyStopRequested?.(ptyId)
       let connectionId: string | null | undefined = ptyOwnership.get(ptyId)
       const parsedSshId = connectionId === undefined ? parseAppSshPtyId(ptyId) : null
       connectionId ??= parsedSshId?.connectionId
@@ -5724,6 +5736,7 @@ export function registerPtyHandlers(
       }
     },
     stopAndWait: async (ptyId, opts) => {
+      runtime?.markPtyStopRequested?.(ptyId)
       let connectionId: string | null | undefined = ptyOwnership.get(ptyId)
       const parsedSshId = connectionId === undefined ? parseAppSshPtyId(ptyId) : null
       connectionId ??= parsedSshId?.connectionId
@@ -7708,6 +7721,7 @@ export function registerPtyHandlers(
       // Why: runtime terminal handles belong to terminal.close; unowned PTY routing could target the local provider.
       throw new Error('Invalid PTY provider id')
     }
+    runtime?.markPtyStopRequested?.(args.id)
     const ownedConnectionId = ptyOwnership.get(args.id)
     const parsedSshId = ownedConnectionId === undefined ? parseAppSshPtyId(args.id) : null
     const connectionId = ownedConnectionId ?? parsedSshId?.connectionId

--- a/src/main/providers/local-pty-provider-io-events.test.ts
+++ b/src/main/providers/local-pty-provider-io-events.test.ts
@@ -124,7 +124,7 @@ import {
 describe('LocalPtyProvider', () => {
   let provider: LocalPtyProvider
   let mockProc: LocalPtyMockProcess
-  let exitCb: ((info: { exitCode: number }) => void) | undefined
+  let exitCb: ((info: { exitCode: number; signal?: number }) => void) | undefined
 
   installLocalPtyProviderEnvSandbox()
 
@@ -318,6 +318,23 @@ describe('LocalPtyProvider', () => {
         code: 0,
         incarnationId,
         cause: { kind: 'exited', exitCode: 0 }
+      })
+    })
+
+    it('reports a signalled death as a signal, not as the zero node-pty pairs with it', async () => {
+      const exitHandler = vi.fn()
+      provider.onExit(exitHandler)
+      const { id, incarnationId } = await provider.spawn({ cols: 80, rows: 24 })
+
+      // node-pty reports an OOM/SIGKILL as {exitCode: 0, signal: 9}; dropping
+      // the signal is what made a crash read as a clean finish (STA-4536).
+      exitCb?.({ exitCode: 0, signal: 9 })
+
+      expect(exitHandler).toHaveBeenCalledWith({
+        id,
+        code: 0,
+        incarnationId,
+        cause: { kind: 'signaled', signal: 9 }
       })
     })
 

--- a/src/main/providers/local-pty-provider-io-events.test.ts
+++ b/src/main/providers/local-pty-provider-io-events.test.ts
@@ -313,7 +313,12 @@ describe('LocalPtyProvider', () => {
       // Simulate node-pty exit event
       exitCb?.({ exitCode: 0 })
 
-      expect(exitHandler).toHaveBeenCalledWith({ id, code: 0, incarnationId })
+      expect(exitHandler).toHaveBeenCalledWith({
+        id,
+        code: 0,
+        incarnationId,
+        cause: { kind: 'exited', exitCode: 0 }
+      })
     })
 
     it('allows unsubscribing from events', async () => {

--- a/src/main/providers/local-pty-provider-shutdown.test.ts
+++ b/src/main/providers/local-pty-provider-shutdown.test.ts
@@ -178,7 +178,10 @@ describe('LocalPtyProvider', () => {
       provider.configure({ onExit })
       const { id, incarnationId } = await provider.spawn({ cols: 80, rows: 24 })
       await provider.shutdown(id, { immediate: true })
-      expect(onExit).toHaveBeenCalledWith(id, -1, incarnationId)
+      expect(onExit).toHaveBeenCalledWith(id, -1, incarnationId, {
+        kind: 'unknown',
+        reason: 'stop_unverified'
+      })
     })
 
     it('does not destroy after an intentional Windows shutdown kill', async () => {

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -93,6 +93,7 @@ import {
   expandWindowsEnvironmentVariables,
   expandWindowsPathEnvironmentVariables
 } from '../../shared/windows-environment-expansion'
+import { resolveProcessExitCause, type TerminalExitCause } from '../../shared/terminal-exit-cause'
 
 const PANE_IDENTITY_ENV_KEYS = [
   'ORCA_PANE_KEY',
@@ -133,6 +134,9 @@ const ptyExitDisposables = new Map<string, { dispose: () => void }>()
 const ptyCleanupCallbacks = new Map<string, () => void>()
 const ptyTerminationMode = new Map<string, 'graceful' | 'force'>()
 const ptyPhysicalExits = new Map<string, PhysicalExitTracker>()
+// Why: a wrapper spawn (macOS TCC login) reports its own status, never the
+// shell's, so its exit numbers must not be read as the agent's (STA-4536).
+const ptyReportsChildExitStatus = new Map<string, boolean>()
 const ptyForceKillTimers = new Map<string, ReturnType<typeof setTimeout>>()
 
 export const LOCAL_PTY_PHYSICAL_EXIT_TIMEOUT_MS = 8_000
@@ -149,7 +153,12 @@ type DataCallback = (payload: {
   transformed?: boolean
   seq?: number
 }) => void
-type ExitCallback = (payload: { id: string; code: number; incarnationId?: string }) => void
+type ExitCallback = (payload: {
+  id: string
+  code: number
+  incarnationId?: string
+  cause?: TerminalExitCause
+}) => void
 
 const dataListeners = new Set<DataCallback>()
 const exitListeners = new Set<ExitCallback>()
@@ -279,6 +288,7 @@ function clearPtyState(id: string): void {
   ptyWslDistroById.delete(id)
   ptyLoadGeneration.delete(id)
   ptyTerminationMode.delete(id)
+  ptyReportsChildExitStatus.delete(id)
   ptyPhysicalExits.delete(id)
 }
 
@@ -525,7 +535,7 @@ export type LocalPtyProviderOptions = {
   getWindowsPowerShellImplementation?: () => 'auto' | 'powershell.exe' | 'pwsh.exe' | undefined
   pwshAvailable?: () => boolean | Promise<boolean>
   onSpawned?: (id: string, incarnationId: string) => void
-  onExit?: (id: string, code: number, incarnationId: string) => void
+  onExit?: (id: string, code: number, incarnationId: string, cause?: TerminalExitCause) => void
   onData?: (
     id: string,
     data: string,
@@ -945,6 +955,7 @@ export class LocalPtyProvider implements IPtyProvider {
         ? null
         : undefined
     createPtyPhysicalExit(id)
+    ptyReportsChildExitStatus.set(id, spawnResult.reportsChildExitStatus !== false)
     ptyProcesses.set(id, proc)
     ptyInitialCwd.set(id, cwd)
     if (spawnedWslDistro !== undefined) {
@@ -1106,7 +1117,15 @@ export class LocalPtyProvider implements IPtyProvider {
       disposables.push(onDataDisposable)
     }
 
-    const onExitDisposable = proc.onExit(({ exitCode }) => {
+    const onExitDisposable = proc.onExit(({ exitCode, signal }) => {
+      // Why: node-pty reports a signalled death as {exitCode: 0, signal: N}; the
+      // cause is built here, where the signal and the spawn's trustworthiness
+      // are both still in hand.
+      const cause = resolveProcessExitCause({
+        exitCode,
+        signal,
+        hostReportsChildExitStatus: ptyReportsChildExitStatus.get(id)
+      })
       const wasTerminationRequested = ptyTerminationMode.has(id)
       ptyPhysicalExits.get(id)?.markExited()
       // Why: neutralize proc.kill before destroy — node-pty SIGHUPs on socket 'close', which can race here and signal a reaped/recycled pid.
@@ -1125,9 +1144,10 @@ export class LocalPtyProvider implements IPtyProvider {
       startupIngressByPty.delete(id)
       // Why: release the master ptmx fd on natural exit, else a clean exit leaks the fd until GC. See docs/fix-pty-fd-leak.md.
       destroyPtyProcess(proc, { alreadyKilled: wasTerminationRequested })
-      this.opts.onExit?.(id, exitCode, incarnationId)
+      ptyReportsChildExitStatus.delete(id)
+      this.opts.onExit?.(id, exitCode, incarnationId, cause)
       for (const cb of exitListeners) {
-        cb({ id, code: exitCode, incarnationId })
+        cb({ id, code: exitCode, incarnationId, cause })
       }
     })
     if (onExitDisposable) {

--- a/src/main/providers/local-pty-utils.test.ts
+++ b/src/main/providers/local-pty-utils.test.ts
@@ -30,7 +30,8 @@ vi.mock('../wsl', () => ({
 }))
 
 vi.mock('./macos-tcc-login-shell', () => ({
-  wrapShellSpawnForMacosTccAttribution: wrapSpawnMock
+  wrapShellSpawnForMacosTccAttribution: wrapSpawnMock,
+  hostReportsChildExitStatus: (file: string) => file !== '/usr/bin/login'
 }))
 
 import {

--- a/src/main/providers/local-pty-utils.ts
+++ b/src/main/providers/local-pty-utils.ts
@@ -1,7 +1,10 @@
 import { basename, isAbsolute, join } from 'node:path'
 import { existsSync, accessSync, statSync, chmodSync, constants as fsConstants } from 'node:fs'
 import type * as pty from 'node-pty'
-import { wrapShellSpawnForMacosTccAttribution } from './macos-tcc-login-shell'
+import {
+  hostReportsChildExitStatus,
+  wrapShellSpawnForMacosTccAttribution
+} from './macos-tcc-login-shell'
 import { formatLocalPtyEnvironmentDiag } from './working-directory-validation'
 
 export {
@@ -145,6 +148,9 @@ export type ShellSpawnParams = {
 export type ShellSpawnResult = {
   process: pty.IPty
   shellPath: string
+  /** False when a wrapper owns the reported status, so no exit code or signal
+   *  from this process describes the shell (STA-4536). */
+  reportsChildExitStatus?: boolean
   /** True when the winning shell's startup command was already embedded in its
    *  argv, so callers must not re-deliver it through stdin. Only set when a
    *  Windows fallback attempt other than the primary was used. */
@@ -234,7 +240,8 @@ export function spawnShellWithFallback(params: ShellSpawnParams): ShellSpawnResu
           env,
           ...windowsConptyDllOptions()
         }),
-        shellPath
+        shellPath,
+        reportsChildExitStatus: hostReportsChildExitStatus(wrapped.file)
       }
     } catch (err) {
       primaryError = err instanceof Error ? err.message : String(err)
@@ -285,7 +292,11 @@ export function spawnShellWithFallback(params: ShellSpawnParams): ShellSpawnResu
         console.warn(
           `[pty] Primary shell "${shellPath}" failed (${primaryError ?? 'unknown error'}), fell back to "${fallback}"`
         )
-        return { process: proc, shellPath: fallback }
+        return {
+          process: proc,
+          shellPath: fallback,
+          reportsChildExitStatus: hostReportsChildExitStatus(wrapped.file)
+        }
       } catch {
         // Fallback also failed -- try next.
       }

--- a/src/main/providers/macos-tcc-login-shell.ts
+++ b/src/main/providers/macos-tcc-login-shell.ts
@@ -318,6 +318,20 @@ export async function probeMacosLoginSessionAlive(
  * No-op off macOS, when already wrapped, when disabled via {@link DISABLE_ENV_VAR},
  * or when the login(1) PAM preflight rejects this process's user.
  */
+/**
+ * Whether a PTY spawned on `file` reports its own child's exit status.
+ *
+ * login(1) forks the shell, waits, then exits with its own status — it forwards
+ * neither the shell's exit code nor its signal. Proved with node-pty: a raw
+ * `sh -c 'exit 42'` reports `{exitCode: 42}` and a self-SIGKILL reports
+ * `{signal: 9}`, while the same commands behind this wrapper both report
+ * `{exitCode: 0, signal: 0}`. Callers must not read a status from a wrapped
+ * spawn — say `unknown` instead (STA-4536).
+ */
+export function hostReportsChildExitStatus(file: string): boolean {
+  return file !== MACOS_LOGIN_PATH
+}
+
 export function wrapShellSpawnForMacosTccAttribution(
   file: string,
   args: string[],

--- a/src/main/providers/pty-provider-contract.ts
+++ b/src/main/providers/pty-provider-contract.ts
@@ -10,6 +10,7 @@ import type {
   AgentSessionSurfaceBinding
 } from '../../shared/agent-session-host-authority'
 import type { PtyProcessInfo } from './pty-process-info'
+import type { TerminalExitCause } from '../../shared/terminal-exit-cause'
 
 export type {
   PtyBackgroundStreamEvent,
@@ -217,6 +218,12 @@ export type IPtyProvider = {
   onData(callback: (payload: PtyDataEvent) => void): () => void
   onReplay(callback: (payload: { id: string; data: string }) => void): () => void
   onExit(
-    callback: (payload: { id: string; code: number; incarnationId?: PtyIncarnationId }) => void
+    callback: (payload: {
+      id: string
+      code: number
+      incarnationId?: PtyIncarnationId
+      /** Absent when the provider predates exit causes; readers must not infer one from `code`. */
+      cause?: TerminalExitCause
+    }) => void
   ): () => void
 }

--- a/src/main/runtime/exit-provenance-audit.test.ts
+++ b/src/main/runtime/exit-provenance-audit.test.ts
@@ -61,14 +61,22 @@ function createRuntime(db: OrchestrationDb): OrcaRuntimeService {
   return runtime
 }
 
-function dispatchOnHandle(db: OrchestrationDb, spec: string): DispatchContextRow {
+function dispatchOnHandle(
+  db: OrchestrationDb,
+  spec: string
+): DispatchContextRow & { runId: string } {
   const run = db.createRun({
     objective: spec,
     coordinatorHandle: 'term_coordinator',
     coordinatorPaneKey: '99999999-9999-4999-8999-999999999999:88888888-8888-4888-8888-888888888888'
   })
   const task = db.createTask({ spec, runId: run.id })
-  return db.createDispatchContext(task.id, HANDLE, PANE_KEY)
+  return { ...db.createDispatchContext(task.id, HANDLE, PANE_KEY), runId: run.id }
+}
+
+/** Where a lightweight Run's coordinator actually reads its mail (STA-4604). */
+function escalations(db: OrchestrationDb, runId: string) {
+  return db.getUnreadMessages(`run:${runId}`, ['escalation'])
 }
 
 function observe(db: OrchestrationDb, ctxId: string) {
@@ -162,21 +170,19 @@ describe('STA-4603/STA-4536 exit provenance', () => {
   it('does not escalate a deliberate close, but still escalates a crash', () => {
     const closedDb = createDb()
     const closed = createRuntime(closedDb)
-    closedDb.createCoordinatorRun({ spec: 'watch', coordinatorHandle: 'term_coordinator' })
     const closedCtx = dispatchOnHandle(closedDb, 'no escalation on close')
     closed.markPtyStopRequested(PTY_ID)
     closed.onPtyExit(PTY_ID, 0)
     // Assert the dispatch actually settled first: an empty inbox also happens
     // when nothing was settled at all, which would make this vacuous.
     expect(observe(closedDb, closedCtx.id).termination_reason).toBe('operator_close')
-    expect(closedDb.getUnreadMessages('term_coordinator', ['escalation'])).toHaveLength(0)
+    expect(escalations(closedDb, closedCtx.runId)).toHaveLength(0)
 
     const crashDb = createDb()
     const crashed = createRuntime(crashDb)
-    crashDb.createCoordinatorRun({ spec: 'watch', coordinatorHandle: 'term_coordinator' })
-    dispatchOnHandle(crashDb, 'escalate on crash')
+    const crashCtx = dispatchOnHandle(crashDb, 'escalate on crash')
     crashed.onPtyExit(PTY_ID, 0, undefined, { cause: { kind: 'signaled', signal: 9 } })
-    expect(crashDb.getUnreadMessages('term_coordinator', ['escalation'])).toHaveLength(1)
+    expect(escalations(crashDb, crashCtx.runId)).toHaveLength(1)
   })
 
   it('does not carry an unconsumed stop intent across a same-id respawn', () => {
@@ -201,7 +207,6 @@ describe('STA-4603/STA-4536 exit provenance', () => {
   it('does not file an unconfirmed stop as a completed operator close', () => {
     const db = createDb()
     const runtime = createRuntime(db)
-    db.createCoordinatorRun({ spec: 'watch', coordinatorHandle: 'term_coordinator' })
     const ctx = dispatchOnHandle(db, 'stop requested but never confirmed')
     runtime.markPtyStopRequested(PTY_ID)
     // The stop paths pass -1 when they asked a process to die and never saw it.
@@ -213,7 +218,7 @@ describe('STA-4603/STA-4536 exit provenance', () => {
       termination_reason: 'unknown'
     })
     // ...and it must still wake the coordinator, unlike a clean close.
-    expect(db.getUnreadMessages('term_coordinator', ['escalation'])).toHaveLength(1)
+    expect(escalations(db, ctx.runId)).toHaveLength(1)
   })
 
   it('treats a reported completion as authoritative and makes the later exit a no-op', () => {

--- a/src/main/runtime/exit-provenance-audit.test.ts
+++ b/src/main/runtime/exit-provenance-audit.test.ts
@@ -129,6 +129,20 @@ describe('STA-4603/STA-4536 exit provenance', () => {
     })
   })
 
+  it('does not read a bare code from an older daemon or an SSH relay as a clean finish', () => {
+    const db = createDb()
+    const runtime = createRuntime(db)
+    const ctx = dispatchOnHandle(db, 'exit delivered without a cause')
+    // No `cause`: the reporter forwards a number and nothing else. Its 0 may be
+    // a SIGKILL, so the record must not claim the agent finished.
+    runtime.onPtyExit(PTY_ID, 0)
+    expect(observe(db, ctx.id)).toEqual({
+      status: 'failed',
+      last_failure: 'Agent process ended; the reporting host did not say why',
+      termination_reason: 'unknown'
+    })
+  })
+
   it('settles the dispatch when the whole tab is closed before the exit lands', () => {
     const db = createDb()
     const runtime = createRuntime(db)
@@ -149,9 +163,12 @@ describe('STA-4603/STA-4536 exit provenance', () => {
     const closedDb = createDb()
     const closed = createRuntime(closedDb)
     closedDb.createCoordinatorRun({ spec: 'watch', coordinatorHandle: 'term_coordinator' })
-    dispatchOnHandle(closedDb, 'no escalation on close')
+    const closedCtx = dispatchOnHandle(closedDb, 'no escalation on close')
     closed.markPtyStopRequested(PTY_ID)
     closed.onPtyExit(PTY_ID, 0)
+    // Assert the dispatch actually settled first: an empty inbox also happens
+    // when nothing was settled at all, which would make this vacuous.
+    expect(observe(closedDb, closedCtx.id).termination_reason).toBe('operator_close')
     expect(closedDb.getUnreadMessages('term_coordinator', ['escalation'])).toHaveLength(0)
 
     const crashDb = createDb()
@@ -160,6 +177,43 @@ describe('STA-4603/STA-4536 exit provenance', () => {
     dispatchOnHandle(crashDb, 'escalate on crash')
     crashed.onPtyExit(PTY_ID, 0, undefined, { cause: { kind: 'signaled', signal: 9 } })
     expect(crashDb.getUnreadMessages('term_coordinator', ['escalation'])).toHaveLength(1)
+  })
+
+  it('does not carry an unconsumed stop intent across a same-id respawn', () => {
+    const db = createDb()
+    const runtime = createRuntime(db)
+    // The operator asked for a stop, but the stop never produced an exit — the
+    // process outlived it. A respawn then reuses the same session id.
+    runtime.markPtyStopRequested(PTY_ID)
+    runtime.synchronizePtyOutputSequenceFromProvider(PTY_ID, { value: 0, generation: 'reset' })
+    expect(runtime.isPtyStopRequested(PTY_ID)).toBe(false)
+
+    const ctx = dispatchOnHandle(db, 'crash after respawn')
+    runtime.onPtyExit(PTY_ID, 0, undefined, { cause: { kind: 'signaled', signal: 9 } })
+    // The replacement's crash must not inherit the old close's provenance.
+    expect(observe(db, ctx.id)).toEqual({
+      status: 'failed',
+      last_failure: 'Agent process killed by signal 9',
+      termination_reason: 'signaled'
+    })
+  })
+
+  it('does not file an unconfirmed stop as a completed operator close', () => {
+    const db = createDb()
+    const runtime = createRuntime(db)
+    db.createCoordinatorRun({ spec: 'watch', coordinatorHandle: 'term_coordinator' })
+    const ctx = dispatchOnHandle(db, 'stop requested but never confirmed')
+    runtime.markPtyStopRequested(PTY_ID)
+    // The stop paths pass -1 when they asked a process to die and never saw it.
+    // The process may still be running against a revoked dispatch.
+    runtime.onPtyExit(PTY_ID, -1)
+    expect(observe(db, ctx.id)).toEqual({
+      status: 'failed',
+      last_failure: 'Agent process stop was requested but never confirmed',
+      termination_reason: 'unknown'
+    })
+    // ...and it must still wake the coordinator, unlike a clean close.
+    expect(db.getUnreadMessages('term_coordinator', ['escalation'])).toHaveLength(1)
   })
 
   it('treats a reported completion as authoritative and makes the later exit a no-op', () => {
@@ -175,6 +229,54 @@ describe('STA-4603/STA-4536 exit provenance', () => {
     expect(settlement.action).toBe('settled')
     runtime.onPtyExit(PTY_ID, 0)
     expect(observe(db, ctx.id)).toMatchObject({ status: 'completed', last_failure: null })
+  })
+
+  it('marks the intent from the real close path, not just from the helper', async () => {
+    const db = createDb()
+    const runtime = new OrcaRuntimeService(null)
+    runtime.setOrchestrationDb(db)
+    // Model the shipping controller: `orca terminal close` reaches stopAndWait,
+    // which verifies the stop and then reports it with a synthetic code 0 --
+    // a number indistinguishable from a clean agent finish.
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      stopAndWait: async (ptyId: string) => {
+        runtime.onPtyExit(ptyId, 0)
+        return true
+      }
+    })
+    runtime.registerPty(PTY_ID, WORKTREE_ID, null, {
+      tabId: TAB_ID,
+      leafId: LEAF_ID,
+      incarnationId: 'audit-incarnation'
+    })
+    runtime.registerPreAllocatedHandleForPty(PTY_ID, HANDLE)
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, {
+      tabs: [
+        {
+          tabId: TAB_ID,
+          worktreeId: WORKTREE_ID,
+          title: 'Agent',
+          activeLeafId: LEAF_ID,
+          layout: null
+        }
+      ],
+      leaves: [
+        { tabId: TAB_ID, worktreeId: WORKTREE_ID, leafId: LEAF_ID, paneRuntimeId: 1, ptyId: PTY_ID }
+      ]
+    })
+    const ctx = dispatchOnHandle(db, 'close through the real path')
+
+    await runtime.closeTerminal(HANDLE)
+
+    expect(observe(db, ctx.id)).toEqual({
+      status: 'failed',
+      last_failure: 'Terminal closed by operator request',
+      termination_reason: 'operator_close'
+    })
   })
 
   it('publishes the cause on the terminal record a coordinator polls', async () => {

--- a/src/main/runtime/exit-provenance-audit.test.ts
+++ b/src/main/runtime/exit-provenance-audit.test.ts
@@ -1,0 +1,198 @@
+// STA-4603 / STA-4536: an operator close, a clean finish and a crash must not
+// leave the same record. Each case here was byte-identical before the fix.
+import { afterEach, describe, expect, it } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { OrcaRuntimeService } from './orca-runtime'
+import { OrchestrationDb } from './orchestration/db'
+import type { DispatchContextRow } from './orchestration/types'
+
+const TAB_ID = '11111111-1111-4111-8111-111111111111'
+const LEAF_ID = '22222222-2222-4222-8222-222222222222'
+const PANE_KEY = `${TAB_ID}:${LEAF_ID}`
+const PTY_ID = 'pty-exit-provenance'
+const HANDLE = 'term_exit_provenance'
+const WORKTREE_ID = 'repo-audit::/tmp/audit'
+
+const directories: string[] = []
+
+afterEach(() => {
+  for (const directory of directories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+function createDb(): OrchestrationDb {
+  const directory = mkdtempSync(join(tmpdir(), 'exit-provenance-'))
+  directories.push(directory)
+  return new OrchestrationDb(join(directory, 'orchestration.db'))
+}
+
+function createRuntime(db: OrchestrationDb): OrcaRuntimeService {
+  const runtime = new OrcaRuntimeService(null)
+  runtime.setOrchestrationDb(db)
+  runtime.setPtyController({
+    write: () => true,
+    kill: () => true,
+    getForegroundProcess: async () => null
+  })
+  runtime.registerPty(PTY_ID, WORKTREE_ID, null, {
+    tabId: TAB_ID,
+    leafId: LEAF_ID,
+    incarnationId: 'audit-incarnation'
+  })
+  runtime.registerPreAllocatedHandleForPty(PTY_ID, HANDLE)
+  runtime.attachWindow(1)
+  runtime.syncWindowGraph(1, {
+    tabs: [
+      {
+        tabId: TAB_ID,
+        worktreeId: WORKTREE_ID,
+        title: 'Agent',
+        activeLeafId: LEAF_ID,
+        layout: null
+      }
+    ],
+    leaves: [
+      { tabId: TAB_ID, worktreeId: WORKTREE_ID, leafId: LEAF_ID, paneRuntimeId: 1, ptyId: PTY_ID }
+    ]
+  })
+  return runtime
+}
+
+function dispatchOnHandle(db: OrchestrationDb, spec: string): DispatchContextRow {
+  const run = db.createRun({
+    objective: spec,
+    coordinatorHandle: 'term_coordinator',
+    coordinatorPaneKey: '99999999-9999-4999-8999-999999999999:88888888-8888-4888-8888-888888888888'
+  })
+  const task = db.createTask({ spec, runId: run.id })
+  return db.createDispatchContext(task.id, HANDLE, PANE_KEY)
+}
+
+function observe(db: OrchestrationDb, ctxId: string) {
+  const row = db.getDispatchContextById(ctxId)!
+  return {
+    status: row.status,
+    last_failure: row.last_failure,
+    termination_reason: row.termination_reason
+  }
+}
+
+describe('STA-4603/STA-4536 exit provenance', () => {
+  it('separates a deliberate close from a crash and from a clean finish', () => {
+    const closedDb = createDb()
+    const closed = createRuntime(closedDb)
+    const closedCtx = dispatchOnHandle(closedDb, 'operator close')
+    closed.markPtyStopRequested(PTY_ID)
+    closed.onPtyExit(PTY_ID, 0)
+
+    const crashDb = createDb()
+    const crashed = createRuntime(crashDb)
+    const crashCtx = dispatchOnHandle(crashDb, 'sigkill crash')
+    crashed.onPtyExit(PTY_ID, 0, undefined, { cause: { kind: 'signaled', signal: 9 } })
+
+    const cleanDb = createDb()
+    const clean = createRuntime(cleanDb)
+    const cleanCtx = dispatchOnHandle(cleanDb, 'clean finish')
+    clean.onPtyExit(PTY_ID, 0, undefined, { cause: { kind: 'exited', exitCode: 0 } })
+
+    expect(observe(closedDb, closedCtx.id)).toEqual({
+      status: 'failed',
+      last_failure: 'Terminal closed by operator request',
+      termination_reason: 'operator_close'
+    })
+    expect(observe(crashDb, crashCtx.id)).toEqual({
+      status: 'failed',
+      last_failure: 'Agent process killed by signal 9',
+      termination_reason: 'signaled'
+    })
+    expect(observe(cleanDb, cleanCtx.id)).toEqual({
+      status: 'failed',
+      last_failure: 'Agent process exited with code 0',
+      termination_reason: 'exited'
+    })
+  })
+
+  it('says unknown rather than inventing a status the host never reported', () => {
+    const db = createDb()
+    const runtime = createRuntime(db)
+    const ctx = dispatchOnHandle(db, 'macOS login wrapper')
+    runtime.onPtyExit(PTY_ID, 0, undefined, {
+      cause: { kind: 'unknown', reason: 'host_status_unavailable' }
+    })
+    expect(observe(db, ctx.id)).toEqual({
+      status: 'failed',
+      last_failure: 'Agent process ended; this host cannot report why',
+      termination_reason: 'unknown'
+    })
+  })
+
+  it('settles the dispatch when the whole tab is closed before the exit lands', () => {
+    const db = createDb()
+    const runtime = createRuntime(db)
+    const ctx = dispatchOnHandle(db, 'whole-tab operator close')
+    runtime.markPtyStopRequested(PTY_ID)
+    // The tab teardown drops the leaf from the renderer graph first; the exit
+    // used to find no leaf and leave the row reading 'dispatched' forever.
+    runtime.syncWindowGraph(1, { tabs: [], leaves: [] })
+    runtime.onPtyExit(PTY_ID, 0)
+    expect(observe(db, ctx.id)).toEqual({
+      status: 'failed',
+      last_failure: 'Terminal closed by operator request',
+      termination_reason: 'operator_close'
+    })
+  })
+
+  it('does not escalate a deliberate close, but still escalates a crash', () => {
+    const closedDb = createDb()
+    const closed = createRuntime(closedDb)
+    closedDb.createCoordinatorRun({ spec: 'watch', coordinatorHandle: 'term_coordinator' })
+    dispatchOnHandle(closedDb, 'no escalation on close')
+    closed.markPtyStopRequested(PTY_ID)
+    closed.onPtyExit(PTY_ID, 0)
+    expect(closedDb.getUnreadMessages('term_coordinator', ['escalation'])).toHaveLength(0)
+
+    const crashDb = createDb()
+    const crashed = createRuntime(crashDb)
+    crashDb.createCoordinatorRun({ spec: 'watch', coordinatorHandle: 'term_coordinator' })
+    dispatchOnHandle(crashDb, 'escalate on crash')
+    crashed.onPtyExit(PTY_ID, 0, undefined, { cause: { kind: 'signaled', signal: 9 } })
+    expect(crashDb.getUnreadMessages('term_coordinator', ['escalation'])).toHaveLength(1)
+  })
+
+  it('treats a reported completion as authoritative and makes the later exit a no-op', () => {
+    const db = createDb()
+    const runtime = createRuntime(db)
+    const ctx = dispatchOnHandle(db, 'worker_done then exit')
+    const settlement = db.settleWorkerReport({
+      taskId: ctx.task_id,
+      dispatchId: ctx.id,
+      outcome: 'succeeded',
+      result: JSON.stringify({ provenance: 'worker_report', outcome: 'succeeded' })
+    })
+    expect(settlement.action).toBe('settled')
+    runtime.onPtyExit(PTY_ID, 0)
+    expect(observe(db, ctx.id)).toMatchObject({ status: 'completed', last_failure: null })
+  })
+
+  it('publishes the cause on the terminal record a coordinator polls', async () => {
+    const db = createDb()
+    const runtime = createRuntime(db)
+    dispatchOnHandle(db, 'terminal summary shape')
+    runtime.markPtyStopRequested(PTY_ID)
+    runtime.onPtyExit(PTY_ID, 0)
+    const summary = await runtime.showTerminal(HANDLE)
+    expect(summary.connected).toBe(false)
+    expect(summary.exitCause).toEqual({ kind: 'operator_close' })
+  })
+
+  it('leaves no exitCause on a terminal that is still running', async () => {
+    const db = createDb()
+    const runtime = createRuntime(db)
+    dispatchOnHandle(db, 'still running')
+    const summary = await runtime.showTerminal(HANDLE)
+    expect(summary.exitCause).toBeUndefined()
+  })
+})

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -390,6 +390,13 @@ import {
 import type { SshConnectionState } from '../../shared/ssh-types'
 import { getPublicSshState } from './public-ssh-state'
 import { closeTerminalTabInWorkspaceSession } from '../../shared/workspace-session-terminal-tab-close'
+import {
+  describeTerminalExitCause,
+  isDeliberateTerminalExit,
+  OPERATOR_CLOSE_EXIT_CAUSE,
+  resolveProcessExitCause,
+  type TerminalExitCause
+} from '../../shared/terminal-exit-cause'
 import type {
   LinearCurrentIssueContextHints,
   LinearAttachResult,
@@ -1419,6 +1426,7 @@ type RuntimeLeafRecord = RuntimeSyncedLeaf & {
   writable: boolean
   lastOutputAt: number | null
   lastExitCode: number | null
+  lastExitCause: TerminalExitCause | null
   tailBuffer: string[]
   tailTranscriptBuffer: string[]
   tailTranscriptChars: number
@@ -1471,6 +1479,7 @@ type RuntimePtyWorktreeRecord = {
   connected: boolean
   disconnectedAt: number | null
   lastExitCode: number | null
+  lastExitCause: TerminalExitCause | null
   lastAgentStatus: AgentStatus | null
   /** False until a live OSC frame sets the status; restore seeds never set it. */
   lastAgentStatusObservedLive: boolean
@@ -3142,6 +3151,9 @@ export class OrcaRuntimeService {
   private ptyForegroundAgentRefreshes = new Map<string, PtyForegroundAgentRefresh>()
   private ptyForegroundProcessReads = new Map<string, PtyForegroundProcessReadEntry>()
   private ptyDelayedForegroundSnapshotTitleObservations = new Map<string, number>()
+  // Why a set and not a timer: the intent is retired by the exit it explains, or
+  // by the next spawn on that id (advancePtyLifecycleGeneration).
+  private readonly stopRequestedPtyIds = new Set<string>()
   private _orchestrationDb: OrchestrationDb | null = null
   private messageWaitersByHandle = new Map<string, Set<MessageWaiter>>()
   private readonly orchestrationMailboxOwner = new OrchestrationMailboxOwner({
@@ -6750,6 +6762,7 @@ export class OrcaRuntimeService {
         writable: this.graphStatus === 'ready' && ptyId !== null,
         lastOutputAt: tailSource?.lastOutputAt ?? null,
         lastExitCode: tailSource?.lastExitCode ?? null,
+        lastExitCause: tailSource?.lastExitCause ?? null,
         tailBuffer: tailSource?.tailBuffer ?? [],
         tailTranscriptBuffer: tailSource?.tailTranscriptBuffer ?? [],
         tailTranscriptChars: tailSource?.tailTranscriptChars ?? 0,
@@ -15024,12 +15037,18 @@ export class OrcaRuntimeService {
     ptyId: string,
     exitCode: number,
     exitIncarnationId?: PtyIncarnationId,
-    options?: { hostExitConfirmed?: boolean }
+    options?: { hostExitConfirmed?: boolean; cause?: TerminalExitCause }
   ): void {
     const pty = this.ptysById.get(ptyId)
     if (exitIncarnationId && pty?.incarnationId && exitIncarnationId !== pty.incarnationId) {
       return
     }
+    // Why intent first: a requested stop can still be delivered by the provider's
+    // own exit event, whose status looks exactly like a natural finish.
+    const exitCause: TerminalExitCause = this.stopRequestedPtyIds.has(ptyId)
+      ? OPERATOR_CLOSE_EXIT_CAUSE
+      : (options?.cause ?? resolveProcessExitCause({ exitCode }))
+    this.stopRequestedPtyIds.delete(ptyId)
     const preservesAbnormalSshSurface =
       this.isSshOwnedPtyId(ptyId) &&
       pty?.connectionId != null &&
@@ -15171,6 +15190,7 @@ export class OrcaRuntimeService {
       this.setPairedRendererSessionOwnership(pty.ptyId, false)
       pty.disconnectedAt = Date.now()
       pty.lastExitCode = exitCode
+      pty.lastExitCause = exitCause
       if (exitCode >= 0 || options?.hostExitConfirmed === true) {
         // A real wait status from the owning host is the death certificate; the
         // synthetic -1 we emit on a failed/unroutable stop is not.
@@ -15193,15 +15213,31 @@ export class OrcaRuntimeService {
       this.retireMobileSessionSurfacesForPty(ptyId, incarnationId, exactSurfaces)
     }
 
+    const exitedSurfaces: { handle: string; paneKey: string | null }[] = []
     for (const leaf of this.getLeavesForPty(ptyId)) {
       this.detachedPreAllocatedLeaves.delete(ptyId)
       leaf.connected = false
       leaf.writable = false
       leaf.lastExitCode = exitCode
+      leaf.lastExitCause = exitCause
       leaf.lastAgentStatusObservedLive = false
       this.resolveExitWaiters(leaf)
-      if (!preservesAbnormalSshSurface) {
-        this.failActiveDispatchOnExit(leaf, exitCode)
+      const leafHandle = this.handleByLeafKey.get(this.getLeafKey(leaf.tabId, leaf.leafId))
+      if (leafHandle) {
+        exitedSurfaces.push({ handle: leafHandle, paneKey: `${leaf.tabId}:${leaf.leafId}` })
+      }
+    }
+    // Why: an explicit whole-tab close drops the leaf from the graph *before*
+    // this exit lands, so a leaf-only walk found nothing and left the dispatch
+    // reading 'dispatched' forever against a dead process. The PTY's own handle
+    // and pane key survive that teardown, so settle from them too (STA-4603).
+    const ptyHandle = this.handleByPtyId.get(ptyId)
+    if (ptyHandle && !exitedSurfaces.some((surface) => surface.handle === ptyHandle)) {
+      exitedSurfaces.push({ handle: ptyHandle, paneKey: pty?.paneKey ?? null })
+    }
+    if (!preservesAbnormalSshSurface) {
+      for (const surface of exitedSurfaces) {
+        this.failActiveDispatchOnExit(surface.handle, surface.paneKey, exitCause)
       }
     }
     this.pruneDisconnectedPtyRecords()
@@ -16813,25 +16849,36 @@ export class OrcaRuntimeService {
   // dispatch contexts immediately, rather than waiting for the coordinator's
   // next poll cycle. This catches agent crashes and unexpected exits within
   // milliseconds. The task is set back to 'pending' so it can be re-dispatched.
-  private failActiveDispatchOnExit(leaf: RuntimeLeafRecord, exitCode: number): void {
+  private failActiveDispatchOnExit(
+    handle: string,
+    paneKey: string | null,
+    cause: TerminalExitCause
+  ): void {
     if (!this._orchestrationDb) {
       return
     }
 
-    const handle = this.handleByLeafKey.get(this.getLeafKey(leaf.tabId, leaf.leafId))
-    if (!handle) {
-      return
-    }
-
-    const dispatch = this._orchestrationDb.getActiveDispatchForTerminal(handle)
+    // Why the pane key too: a reminted handle no longer matches the row, but the
+    // pane identity behind it outlives the remint.
+    const dispatch = this._orchestrationDb.getActiveDispatchForTerminal(
+      handle,
+      paneKey ?? undefined
+    )
     if (!dispatch) {
       return
     }
 
-    const errorContext = `Agent exited with code ${exitCode}`
+    const errorContext = describeTerminalExitCause(cause)
     const settled = this._orchestrationDb.failDispatch(dispatch.id, errorContext, {
-      workerProcessExited: true
+      workerProcessExited: true,
+      terminationReason: cause.kind
     })
+
+    // Why: a deliberate close is not an incident. Escalating it trains
+    // coordinators to ignore the channel that should wake them for a real one.
+    if (isDeliberateTerminalExit(cause)) {
+      return
+    }
 
     // Why: failDispatch above is the authoritative state transition and has already
     // committed. Everything below is best-effort mail on top of it — resolving the
@@ -16848,8 +16895,8 @@ export class OrcaRuntimeService {
       const escalation = this._orchestrationDb.insertMessage({
         from: handle,
         to: recipient.to,
-        subject: `Agent exited unexpectedly (code ${exitCode})`,
-        body: this.describeWorkerExit(dispatch, exitCode, handle, settled?.status),
+        subject: `Agent exited unexpectedly (${errorContext})`,
+        body: this.describeWorkerExit(dispatch, cause, handle, settled?.status),
         type: 'escalation',
         priority: 'high',
         // Why: applyEscalationToDispatch rejects an escalation without an exact Dispatch
@@ -16857,7 +16904,7 @@ export class OrcaRuntimeService {
         payload: JSON.stringify({
           taskId: dispatch.task_id,
           dispatchId: dispatch.id,
-          exitCode,
+          exitCause: cause,
           handle
         }),
         ...(recipient.runId ? { runId: recipient.runId } : {})
@@ -16880,7 +16927,7 @@ export class OrcaRuntimeService {
   // has to resolve ids by hand to learn what died and whether the task is still retryable.
   private describeWorkerExit(
     dispatch: { id: string; task_id: string; run_id: string },
-    exitCode: number,
+    cause: TerminalExitCause,
     handle: string,
     settledStatus: DispatchStatus | undefined
   ): string {
@@ -16900,7 +16947,11 @@ export class OrcaRuntimeService {
         : settledStatus === 'failed'
           ? ' The task is ready to be dispatched again.'
           : ''
-    return `Worker ${handle} exited with code ${exitCode} while running task ${named}.${outcome}`
+    // Why the cause and not a code: `code 0` reads as success even when the
+    // worker was killed, which is what sent operators chasing phantom OOMs.
+    return `Worker ${handle} stopped while running task ${named}. ${describeTerminalExitCause(
+      cause
+    )}.${outcome}`
   }
 
   // Why: a lightweight Run keeps its coordinator in runs/run_coordinator_handles and
@@ -18012,6 +18063,23 @@ export class OrcaRuntimeService {
 
   markPtyLivenessLive(ptyId: string): void {
     this.rememberPtyLivenessVerdict(ptyId, { status: 'live', ptyIds: [ptyId] })
+  }
+
+  /**
+   * Records that Orca asked this PTY to stop — a close, a stop, a teardown.
+   *
+   * Why before the kill and not at the exit: a requested stop can still be
+   * delivered by the provider's own exit event, which carries a process status
+   * indistinguishable from a natural finish. The intent is the only thing that
+   * separates "the operator closed it" from "the agent died", so it is recorded
+   * where it is known rather than reconstructed afterwards (STA-4603).
+   */
+  markPtyStopRequested(ptyId: string): void {
+    this.stopRequestedPtyIds.add(ptyId)
+  }
+
+  isPtyStopRequested(ptyId: string): boolean {
+    return this.stopRequestedPtyIds.has(ptyId)
   }
 
   /** Null when nothing has been observed either way, so callers keep their own default. */
@@ -29207,6 +29275,10 @@ export class OrcaRuntimeService {
     let addressedPtyStopped = false
     const deadlineMs = Date.now() + EXPLICIT_TERMINAL_CLOSE_STOP_TIMEOUT_MS
     for (const ptyId of ptyIds) {
+      // Why here: this is the single funnel for an explicit close, and the
+      // intent must be on record before the stop, since the provider may report
+      // the exit itself with a status that reads like a natural finish.
+      this.markPtyStopRequested(ptyId)
       let stopped = false
       if (this.ptyController?.stopAndWait) {
         try {
@@ -31947,6 +32019,7 @@ export class OrcaRuntimeService {
         connected: state.connected ?? true,
         disconnectedAt: state.connected === false ? Date.now() : null,
         lastExitCode: null,
+        lastExitCause: null,
         lastAgentStatus: null,
         lastAgentStatusObservedLive: false,
         lastAgentStatusStartedAtEpochMs: null,
@@ -32613,6 +32686,7 @@ export class OrcaRuntimeService {
       writable: provenAbsent ? false : leaf.writable,
       lastOutputAt: leaf.lastOutputAt,
       preview: leaf.preview,
+      ...(leaf.lastExitCause ? { exitCause: leaf.lastExitCause } : {}),
       ...this.terminalExecutionHostField(leaf.ptyId, leaf.worktreeId)
     }
   }
@@ -34571,6 +34645,7 @@ export class OrcaRuntimeService {
       writable: pty.connected,
       lastOutputAt: pty.lastOutputAt,
       preview: pty.preview,
+      ...(pty.lastExitCause ? { exitCause: pty.lastExitCause } : {}),
       ...this.terminalExecutionHostField(pty.ptyId, pty.worktreeId)
     }
   }
@@ -39652,7 +39727,14 @@ function buildTerminalWaitResult(
   condition: RuntimeTerminalWaitCondition,
   leaf: RuntimeLeafRecord
 ): RuntimeTerminalWait {
-  return buildTerminalWait(handle, condition, getTerminalState(leaf), leaf.lastExitCode)
+  return buildTerminalWait(
+    handle,
+    condition,
+    getTerminalState(leaf),
+    leaf.lastExitCode,
+    undefined,
+    leaf.lastExitCause
+  )
 }
 
 function buildTerminalWaitBlockedResult(
@@ -39666,7 +39748,8 @@ function buildTerminalWaitBlockedResult(
     condition,
     getTerminalState(leaf),
     leaf.lastExitCode,
-    blockedReason
+    blockedReason,
+    leaf.lastExitCause
   )
 }
 
@@ -39675,7 +39758,14 @@ function buildPtyTerminalWaitResult(
   condition: RuntimeTerminalWaitCondition,
   pty: RuntimePtyWorktreeRecord
 ): RuntimeTerminalWait {
-  return buildTerminalWait(handle, condition, getPtyTerminalState(pty), pty.lastExitCode)
+  return buildTerminalWait(
+    handle,
+    condition,
+    getPtyTerminalState(pty),
+    pty.lastExitCode,
+    undefined,
+    pty.lastExitCause
+  )
 }
 
 function buildPtyTerminalWaitBlockedResult(
@@ -39689,7 +39779,8 @@ function buildPtyTerminalWaitBlockedResult(
     condition,
     getPtyTerminalState(pty),
     pty.lastExitCode,
-    blockedReason
+    blockedReason,
+    pty.lastExitCause
   )
 }
 
@@ -39698,7 +39789,8 @@ function buildTerminalWait(
   condition: RuntimeTerminalWaitCondition,
   status: RuntimeTerminalState,
   exitCode: number | null,
-  blockedReason?: RuntimeTerminalWaitBlockedReason
+  blockedReason?: RuntimeTerminalWaitBlockedReason,
+  exitCause?: TerminalExitCause | null
 ): RuntimeTerminalWait {
   return {
     handle,
@@ -39706,6 +39798,7 @@ function buildTerminalWait(
     satisfied: blockedReason === undefined,
     status,
     exitCode,
+    ...(exitCause ? { exitCause } : {}),
     ...(blockedReason ? { blockedReason } : {})
   }
 }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -394,7 +394,7 @@ import {
   describeTerminalExitCause,
   isDeliberateTerminalExit,
   OPERATOR_CLOSE_EXIT_CAUSE,
-  resolveProcessExitCause,
+  resolveUnreportedExitCause,
   type TerminalExitCause
 } from '../../shared/terminal-exit-cause'
 import type {
@@ -3152,7 +3152,8 @@ export class OrcaRuntimeService {
   private ptyForegroundProcessReads = new Map<string, PtyForegroundProcessReadEntry>()
   private ptyDelayedForegroundSnapshotTitleObservations = new Map<string, number>()
   // Why a set and not a timer: the intent is retired by the exit it explains, or
-  // by the next spawn on that id (advancePtyLifecycleGeneration).
+  // by the next lifecycle generation on that id (advancePtyLifecycleGeneration),
+  // so a stop that never produced an exit cannot outlive its process.
   private readonly stopRequestedPtyIds = new Set<string>()
   private _orchestrationDb: OrchestrationDb | null = null
   private messageWaitersByHandle = new Map<string, Set<MessageWaiter>>()
@@ -12117,6 +12118,10 @@ export class OrcaRuntimeService {
 
   private advancePtyLifecycleGeneration(ptyId: string): void {
     this.ptyLifecycleGenerationById.set(ptyId, this.nextPtyLifecycleGeneration++)
+    // Why: a stop whose exit never arrived would otherwise stay armed across a
+    // same-id respawn and label the NEXT process's crash an operator close —
+    // the exact lie this cause model exists to remove.
+    this.stopRequestedPtyIds.delete(ptyId)
     this.agentPromptLifecycleByPtyId.delete(ptyId)
     this.agentPromptPermissionSequenceByPtyId.delete(ptyId)
     this.agentPromptExplicitStatusFloorByPtyId.set(ptyId, Date.now())
@@ -15045,9 +15050,18 @@ export class OrcaRuntimeService {
     }
     // Why intent first: a requested stop can still be delivered by the provider's
     // own exit event, whose status looks exactly like a natural finish.
-    const exitCause: TerminalExitCause = this.stopRequestedPtyIds.has(ptyId)
-      ? OPERATOR_CLOSE_EXIT_CAUSE
-      : (options?.cause ?? resolveProcessExitCause({ exitCode }))
+    //
+    // Why it yields to stop_unverified: a stop nobody confirmed is not a
+    // completed close. The process may still be running against a revoked
+    // dispatch — an incident a coordinator must hear about, not a routine
+    // teardown to be filed away and left unescalated.
+    const observedCause = options?.cause ?? resolveUnreportedExitCause(exitCode)
+    const stopNeverConfirmed =
+      observedCause.kind === 'unknown' && observedCause.reason === 'stop_unverified'
+    const exitCause: TerminalExitCause =
+      this.stopRequestedPtyIds.has(ptyId) && !stopNeverConfirmed
+        ? OPERATOR_CLOSE_EXIT_CAUSE
+        : observedCause
     this.stopRequestedPtyIds.delete(ptyId)
     const preservesAbnormalSshSurface =
       this.isSshOwnedPtyId(ptyId) &&

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -15251,7 +15251,7 @@ export class OrcaRuntimeService {
     }
     if (!preservesAbnormalSshSurface) {
       for (const surface of exitedSurfaces) {
-        this.failActiveDispatchOnExit(surface.handle, surface.paneKey, exitCause)
+        this.failActiveDispatchOnExit(surface.handle, surface.paneKey, exitCode, exitCause)
       }
     }
     this.pruneDisconnectedPtyRecords()
@@ -16866,6 +16866,7 @@ export class OrcaRuntimeService {
   private failActiveDispatchOnExit(
     handle: string,
     paneKey: string | null,
+    exitCode: number,
     cause: TerminalExitCause
   ): void {
     if (!this._orchestrationDb) {
@@ -16918,6 +16919,10 @@ export class OrcaRuntimeService {
         payload: JSON.stringify({
           taskId: dispatch.task_id,
           dispatchId: dispatch.id,
+          // Why both: `exitCode` stays for readers that already parse it, but it
+          // is the raw number the host handed over, not a verdict — `exitCause`
+          // is what says whether the agent was killed, finished, or was closed.
+          exitCode,
           exitCause: cause,
           handle
         }),

--- a/src/main/runtime/orchestration/db/contract-constants.ts
+++ b/src/main/runtime/orchestration/db/contract-constants.ts
@@ -7,4 +7,4 @@ export const LEGACY_CONTRACT_VERSION = 0
 export const CURRENT_CONTRACT_VERSION = ORCHESTRATION_CONTRACT_VERSION
 
 // Schema versions: v2 'heartbeat'+last_heartbeat_at, v3 delivered_at, v4 task-creator terminal, v5 task_title/display_name, v6 pane identity, v7 lightweight Runs, v8 crash-safe Run deliveries, v9 durable question threads, v10 Dispatch capabilities, v11 durable mutation receipts, v12 composed worker state, v18 post-v6 version-skew repair, v19 adopted legacy Runs and compatibility receipts, v20 legacy question backfill, v21 legacy scheduler-loss provenance, v22 dispatch assignee lookup, v23 worker terminal resource ownership, v24 creator-incarnation authority, v25 active Dispatch handle lookup, v26 indexed mutation receipt capacity, v27 durable federation acknowledgments, v28 durable local mutation caller identity.
-export const SCHEMA_VERSION = 28
+export const SCHEMA_VERSION = 29

--- a/src/main/runtime/orchestration/db/dispatch-context/dispatch-completion.ts
+++ b/src/main/runtime/orchestration/db/dispatch-context/dispatch-completion.ts
@@ -77,7 +77,7 @@ export function failDispatch(
   this: OrchestrationDb,
   ctxId: string,
   error: string,
-  options: { workerProcessExited?: boolean } = {}
+  options: { workerProcessExited?: boolean; terminationReason?: string } = {}
 ): DispatchContextRow | undefined {
   this.db.exec(`SAVEPOINT ${FAIL_DISPATCH_SAVEPOINT}`)
   try {
@@ -86,6 +86,7 @@ export function failDispatch(
         `UPDATE dispatch_contexts
          SET status = CASE WHEN failure_count + 1 >= ? THEN 'circuit_broken' ELSE 'failed' END,
              failure_count = failure_count + 1, last_failure = ?,
+             termination_reason = COALESCE(?, termination_reason),
              completed_at = COALESCE(completed_at, datetime('now')),
              capability_revoked_at = COALESCE(capability_revoked_at, datetime('now'))
          WHERE id = ? AND status IN ('pending', 'dispatched')
@@ -95,7 +96,13 @@ export function failDispatch(
                AND worker.state NOT IN ('failed', 'succeeded', 'stopped', 'abandoned')
            ))`
       )
-      .run(DISPATCH_CIRCUIT_BREAK_FAILURES, error, ctxId, options.workerProcessExited ? 1 : 0)
+      .run(
+        DISPATCH_CIRCUIT_BREAK_FAILURES,
+        error,
+        options.terminationReason ?? null,
+        ctxId,
+        options.workerProcessExited ? 1 : 0
+      )
     const ctx = this.db.prepare('SELECT * FROM dispatch_contexts WHERE id = ?').get(ctxId) as
       | DispatchContextRow
       | undefined

--- a/src/main/runtime/orchestration/db/dispatch-context/dispatch-lookup.ts
+++ b/src/main/runtime/orchestration/db/dispatch-context/dispatch-lookup.ts
@@ -9,9 +9,12 @@ import type { OrchestrationDb } from '../orchestration-db'
 
 export function getActiveDispatchForTerminal(
   this: OrchestrationDb,
-  handle: string
+  handle: string,
+  // Why optional: a handle reminted between dispatch and exit no longer matches
+  // the row, but the pane identity behind it survives the remint.
+  assigneePaneKey?: string
 ): DispatchContextRow | undefined {
-  return this.findActiveDispatchForAssignee(handle)
+  return this.findActiveDispatchForAssignee(handle, assigneePaneKey)
 }
 
 /**

--- a/src/main/runtime/orchestration/db/schema/create-graph-tables-sql.ts
+++ b/src/main/runtime/orchestration/db/schema/create-graph-tables-sql.ts
@@ -125,6 +125,8 @@ CREATE TABLE IF NOT EXISTS dispatch_contexts (
     CHECK(status IN ('pending', 'dispatched', 'completed', 'failed', 'circuit_broken')),
   failure_count       INTEGER NOT NULL DEFAULT 0,
   last_failure        TEXT,
+  -- Why the process is gone, when Orca could establish it. See TerminalExitCause.
+  termination_reason  TEXT,
   dispatched_at       TEXT,
   completed_at        TEXT,
   created_at          TEXT NOT NULL DEFAULT (datetime('now')),

--- a/src/main/runtime/orchestration/db/schema/migrate-v13-v29.ts
+++ b/src/main/runtime/orchestration/db/schema/migrate-v13-v29.ts
@@ -2,7 +2,7 @@ import { migrateMutationReceiptCapacity } from '../../mutation-receipt-capacity'
 import { DISPATCH_PANE_KEY_MATCH_SUFFIX_SQL } from '../pane-key-match'
 import type { OrchestrationDb } from '../orchestration-db'
 
-export function applySchemaMigrationsV13ToV28(this: OrchestrationDb, current: number): void {
+export function applySchemaMigrationsV13ToV29(this: OrchestrationDb, current: number): void {
   if (current < 13 && !this.hasColumn('worker_dispatches', 'runtime_epoch')) {
     this.db.exec('ALTER TABLE worker_dispatches ADD COLUMN runtime_epoch TEXT')
   }
@@ -150,6 +150,12 @@ export function applySchemaMigrationsV13ToV28(this: OrchestrationDb, current: nu
           caller_fingerprint  TEXT NOT NULL UNIQUE
         );
       `)
+  }
+  // Why a column and not a parsed `last_failure`: an operator close and a crash
+  // used to write the same sentence, so post-mortem tooling had to reconcile
+  // against external logs to tell them apart (STA-4603).
+  if (current < 29 && !this.hasColumn('dispatch_contexts', 'termination_reason')) {
+    this.db.exec('ALTER TABLE dispatch_contexts ADD COLUMN termination_reason TEXT')
   }
   this.db.exec(`
       CREATE INDEX IF NOT EXISTS idx_dispatch_assignee_pane_leaf

--- a/src/main/runtime/orchestration/db/schema/migrate.ts
+++ b/src/main/runtime/orchestration/db/schema/migrate.ts
@@ -1,7 +1,7 @@
 import { resolveOrchestrationMigrationStartVersion } from '../../orchestration-schema-version-skew'
 import { SCHEMA_VERSION } from '../contract-constants'
 import type { OrchestrationDb } from '../orchestration-db'
-import { applySchemaMigrationsV13ToV28 } from './migrate-v13-v28'
+import { applySchemaMigrationsV13ToV29 } from './migrate-v13-v29'
 import { applySchemaMigrationsV2ToV12 } from './migrate-v2-v12'
 
 // Why: CREATE TABLE IF NOT EXISTS won't alter existing DBs; migrate in a txn that bumps user_version only on success (atomic all-or-nothing).
@@ -15,7 +15,7 @@ export function migrate(this: OrchestrationDb): void {
   this.db.exec('BEGIN IMMEDIATE')
   try {
     applySchemaMigrationsV2ToV12.call(this, current)
-    applySchemaMigrationsV13ToV28.call(this, current)
+    applySchemaMigrationsV13ToV29.call(this, current)
     this.db.pragma(`user_version = ${SCHEMA_VERSION}`)
     this.db.exec('COMMIT')
   } catch (err) {

--- a/src/main/runtime/orchestration/federation-acknowledgment-migration.test.ts
+++ b/src/main/runtime/orchestration/federation-acknowledgment-migration.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import Database from '../../sqlite/sync-database'
 import { OrchestrationDb } from './db'
 import { resolveOrchestrationMigrationStartVersion } from './orchestration-schema-version-skew'
+import { SCHEMA_VERSION } from './db/contract-constants'
 
 describe('federation acknowledgment migration', () => {
   let db: OrchestrationDb | undefined
@@ -41,7 +42,7 @@ describe('federation acknowledgment migration', () => {
     db = new OrchestrationDb(dbPath)
     const sqlite = (db as unknown as { db: Database.Database }).db
 
-    expect(sqlite.pragma('user_version', { simple: true })).toBe(28)
+    expect(sqlite.pragma('user_version', { simple: true })).toBe(SCHEMA_VERSION)
     expect(db.getFederatedDispatch('ctx_migrated')).toMatchObject({
       to_home_imported_sequence: 2,
       to_home_acknowledged_sequence: 0

--- a/src/main/runtime/orchestration/lightweight-run-worker-exit-escalation.test.ts
+++ b/src/main/runtime/orchestration/lightweight-run-worker-exit-escalation.test.ts
@@ -185,15 +185,19 @@ describe('STA-4604 worker PTY exit escalation reaches the coordinator', () => {
       runId: graded.runId,
       type: 'escalation',
       priority: 'high',
-      subject: 'Agent exited unexpectedly (code 137)',
+      subject: 'Agent exited unexpectedly (Agent process exited with code 137)',
       body:
-        `Worker ${graded.workerHandle} exited with code 137 while running task ` +
-        `"do the work" (${graded.taskId}). The task is ready to be dispatched again.`,
+        `Worker ${graded.workerHandle} stopped while running task ` +
+        `"do the work" (${graded.taskId}). Agent process exited with code 137. ` +
+        `The task is ready to be dispatched again.`,
       deliveryContract: 'current_delivery',
       payload: {
         taskId: expect.any(String),
         dispatchId: expect.any(String),
         exitCode: 137,
+        // Why: the code alone cannot say whether the agent was killed, finished,
+        // or was closed on purpose (STA-4603/STA-4536).
+        exitCause: { kind: 'exited', exitCode: 137 },
         handle: graded.workerHandle
       }
     })
@@ -211,7 +215,7 @@ describe('STA-4604 worker PTY exit escalation reaches the coordinator', () => {
       to: expect.stringMatching(/^term_/),
       runId: LEGACY_RUN_ID,
       type: 'escalation',
-      subject: 'Agent exited unexpectedly (code 137)'
+      subject: 'Agent exited unexpectedly (Agent process exited with code 137)'
     })
   })
 
@@ -363,8 +367,9 @@ describe('STA-4604 worker PTY exit escalation reaches the coordinator', () => {
       // Why: a tripped breaker means nobody will retry it, so the body must not
       // tell the coordinator the task is ready to go again.
       expect(escalations.at(-1)?.body).toBe(
-        `Worker ${workerHandle} exited with code 137 while running task ` +
-          `"repeatedly failing work" (${task.id}). This task has now failed too many ` +
+        `Worker ${workerHandle} stopped while running task ` +
+          `"repeatedly failing work" (${task.id}). Agent process exited with code 137. ` +
+          `This task has now failed too many ` +
           `times, so it will not be retried automatically.`
       )
     } finally {
@@ -467,8 +472,9 @@ describe('STA-4604 worker PTY exit escalation reaches the coordinator', () => {
     // Why: onPtyExit walks leaves synchronously — a throwing mailbox would abandon the
     // rest of the exit, so the worker death must stay durable and the exit must complete.
     expect(() => runtime.onPtyExit(WORKER_PTY_ID, 137)).not.toThrow()
-    expect(failDispatch).toHaveBeenCalledWith('ctx-1', 'Agent exited with code 137', {
-      workerProcessExited: true
+    expect(failDispatch).toHaveBeenCalledWith('ctx-1', 'Agent process exited with code 137', {
+      workerProcessExited: true,
+      terminationReason: 'exited'
     })
     expect(warn).toHaveBeenCalledWith(
       '[orchestration] failed to escalate worker exit',

--- a/src/main/runtime/orchestration/mutation-receipt-capacity.test.ts
+++ b/src/main/runtime/orchestration/mutation-receipt-capacity.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import Database from '../../sqlite/sync-database'
 import { OrchestrationDb } from './db'
 import { MUTATION_RECEIPT_MAX_ROWS } from './mutation-receipt-capacity'
+import { SCHEMA_VERSION } from './db/contract-constants'
 
 function sqliteFor(db: OrchestrationDb): Database.Database {
   return (db as unknown as { db: Database.Database }).db
@@ -103,7 +104,7 @@ describe('mutation receipt capacity schema', () => {
 
     db = new OrchestrationDb(dbPath)
     const sqlite = sqliteFor(db)
-    expect(sqlite.pragma('user_version', { simple: true })).toBe(28)
+    expect(sqlite.pragma('user_version', { simple: true })).toBe(SCHEMA_VERSION)
     expect(sqlite.prepare('SELECT receipt_count FROM mutation_receipt_ledger').get()).toEqual({
       receipt_count: 20
     })

--- a/src/main/runtime/orchestration/orchestration-db-retention-pagination.test.ts
+++ b/src/main/runtime/orchestration/orchestration-db-retention-pagination.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import Database from '../../sqlite/sync-database'
 import { OrchestrationDb } from './db'
+import { SCHEMA_VERSION } from './db/contract-constants'
 
 const MUTATION_RECEIPT_MAX_ROWS = 10_000
 
@@ -240,7 +241,7 @@ describe('OrchestrationDb dispatch assignee index migration', () => {
 
     db = new OrchestrationDb(dbPath)
     const sqlite = sqliteFor(db)
-    expect(sqlite.pragma('user_version', { simple: true })).toBe(28)
+    expect(sqlite.pragma('user_version', { simple: true })).toBe(SCHEMA_VERSION)
     expect(db.getDispatchContextById(dispatch.id)).toMatchObject({ assignee_handle: 'term_worker' })
     expect(db.getTask(task.id)).toMatchObject({
       created_by_pane_key: null,
@@ -277,7 +278,7 @@ describe('OrchestrationDb dispatch assignee index migration', () => {
 
     db.close()
     db = new OrchestrationDb(dbPath)
-    expect(sqliteFor(db).pragma('user_version', { simple: true })).toBe(28)
+    expect(sqliteFor(db).pragma('user_version', { simple: true })).toBe(SCHEMA_VERSION)
     expect(db.getDispatchContextById(dispatch.id)).toBeDefined()
   })
 
@@ -309,7 +310,7 @@ describe('OrchestrationDb dispatch assignee index migration', () => {
 
     db = new OrchestrationDb(dbPath)
     const sqlite = sqliteFor(db)
-    expect(sqlite.pragma('user_version', { simple: true })).toBe(28)
+    expect(sqlite.pragma('user_version', { simple: true })).toBe(SCHEMA_VERSION)
     expect(db.getTask(task.id)).toMatchObject({
       created_by_pane_key: 'tab_creator:leaf_creator',
       created_by_process_incarnation: 'pty_creator:incarnation-a',
@@ -328,7 +329,7 @@ describe('OrchestrationDb dispatch assignee index migration', () => {
 
     db.close()
     db = new OrchestrationDb(dbPath)
-    expect(sqliteFor(db).pragma('user_version', { simple: true })).toBe(28)
+    expect(sqliteFor(db).pragma('user_version', { simple: true })).toBe(SCHEMA_VERSION)
     expect(db.getTask(task.id)?.created_by_process_incarnation).toBe('pty_creator:incarnation-a')
   })
 })

--- a/src/main/runtime/orchestration/run-coordinator-handle-migration.test.ts
+++ b/src/main/runtime/orchestration/run-coordinator-handle-migration.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import Database from '../../sqlite/sync-database'
 import { OrchestrationDb } from './db'
+import { SCHEMA_VERSION } from './db/contract-constants'
 
 describe('Run coordinator handle history migration', () => {
   let db: OrchestrationDb | undefined
@@ -37,7 +38,7 @@ describe('Run coordinator handle history migration', () => {
 
     db = new OrchestrationDb(dbPath)
     const sqlite = (db as unknown as { db: Database.Database }).db
-    expect(sqlite.pragma('user_version', { simple: true })).toBe(28)
+    expect(sqlite.pragma('user_version', { simple: true })).toBe(SCHEMA_VERSION)
     expect(
       sqlite
         .prepare('SELECT run_id, terminal_handle FROM run_coordinator_handles WHERE run_id = ?')
@@ -79,12 +80,12 @@ describe('Run coordinator handle history migration', () => {
 
     const v28Db = new Database(dbPath)
     v28Db.exec('DROP TABLE run_coordinator_handles')
-    expect(v28Db.pragma('user_version', { simple: true })).toBe(28)
+    expect(v28Db.pragma('user_version', { simple: true })).toBe(SCHEMA_VERSION)
     v28Db.close()
 
     db = new OrchestrationDb(dbPath)
     const sqlite = (db as unknown as { db: Database.Database }).db
-    expect(sqlite.pragma('user_version', { simple: true })).toBe(28)
+    expect(sqlite.pragma('user_version', { simple: true })).toBe(SCHEMA_VERSION)
     expect(
       sqlite
         .prepare('SELECT run_id, terminal_handle FROM run_coordinator_handles WHERE run_id = ?')
@@ -111,7 +112,7 @@ describe('Run coordinator handle history migration', () => {
     oldRuntimeDb
       .prepare('UPDATE runs SET coordinator_handle = ? WHERE id = ?')
       .run('term_v27_second', run.id)
-    expect(oldRuntimeDb.pragma('user_version', { simple: true })).toBe(28)
+    expect(oldRuntimeDb.pragma('user_version', { simple: true })).toBe(SCHEMA_VERSION)
     oldRuntimeDb.close()
 
     db = new OrchestrationDb(dbPath)

--- a/src/main/runtime/orchestration/types.ts
+++ b/src/main/runtime/orchestration/types.ts
@@ -1,3 +1,4 @@
+import type { TerminalExitCause } from '../../../shared/terminal-exit-cause'
 export const MESSAGE_TYPES = [
   'status',
   'dispatch',
@@ -274,6 +275,9 @@ export type DispatchContextRow = {
   status: DispatchStatus
   failure_count: number
   last_failure: string | null
+  /** Why the dispatch ended, when Orca could establish it — `operator_close`,
+   *  `signaled`, `exited`, `unknown`. Null on rows written before STA-4603. */
+  termination_reason: TerminalExitCause['kind'] | null
   dispatched_at: string | null
   completed_at: string | null
   created_at: string

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -39,6 +39,7 @@ import type { RemoteServerUpdateSupport } from './remote-server-update'
 import type { ExecutionHostId } from './execution-host'
 import type { PtyIncarnationId } from './pty-incarnation'
 import type { RasterImageDimensions } from './raster-image-dimensions'
+import type { TerminalExitCause } from './terminal-exit-cause'
 
 export type { RuntimeMarkdownReadTabResult, RuntimeMarkdownSaveTabResult }
 
@@ -465,6 +466,10 @@ export type RuntimeTerminalSummary = {
   writable: boolean
   lastOutputAt: number | null
   preview: string
+  /** Why this terminal's process is gone. Absent while it is still running, and
+   *  absent from a host predating the field — never read an absent value as a
+   *  clean finish (STA-4536). */
+  exitCause?: TerminalExitCause
   /** Where this terminal actually runs. Absent when the host predates the field
    *  or could not name the host — never read an absent value as local. */
   executionHostId?: ExecutionHostId
@@ -759,6 +764,8 @@ export type RuntimeTerminalWait = {
   satisfied: boolean
   status: RuntimeTerminalState
   exitCode: number | null
+  /** Why it exited. `exitCode` alone cannot answer that — see {@link TerminalExitCause}. */
+  exitCause?: TerminalExitCause
   blockedReason?: RuntimeTerminalWaitBlockedReason
 }
 

--- a/src/shared/terminal-exit-cause.test.ts
+++ b/src/shared/terminal-exit-cause.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import {
+  describeTerminalExitCause,
+  isDeliberateTerminalExit,
+  resolveProcessExitCause
+} from './terminal-exit-cause'
+
+describe('resolveProcessExitCause', () => {
+  it('reports a signalled death as a signal, not as the zero node-pty pairs with it', () => {
+    expect(resolveProcessExitCause({ exitCode: 0, signal: 9 })).toEqual({
+      kind: 'signaled',
+      signal: 9
+    })
+  })
+
+  it('refuses to read a status the host cannot report', () => {
+    // macOS wraps every PTY in `login -flpq`, which returns 0 for a shell that
+    // exited 42 and 0 for one that was SIGKILLed.
+    expect(
+      resolveProcessExitCause({ exitCode: 0, signal: 0, hostReportsChildExitStatus: false })
+    ).toEqual({ kind: 'unknown', reason: 'host_status_unavailable' })
+    expect(
+      resolveProcessExitCause({ exitCode: 42, signal: 9, hostReportsChildExitStatus: false })
+    ).toEqual({ kind: 'unknown', reason: 'host_status_unavailable' })
+  })
+
+  it('treats the stop paths’ negative sentinel as absence of evidence', () => {
+    expect(resolveProcessExitCause({ exitCode: -1 })).toEqual({
+      kind: 'unknown',
+      reason: 'stop_unverified'
+    })
+  })
+
+  it('keeps a real status when the host vouches for it', () => {
+    expect(resolveProcessExitCause({ exitCode: 42, signal: 0 })).toEqual({
+      kind: 'exited',
+      exitCode: 42
+    })
+    expect(resolveProcessExitCause({ exitCode: 0 })).toEqual({ kind: 'exited', exitCode: 0 })
+  })
+
+  it('treats a missing signal as no signal rather than as unknown', () => {
+    expect(resolveProcessExitCause({ exitCode: 7, signal: null })).toEqual({
+      kind: 'exited',
+      exitCode: 7
+    })
+  })
+})
+
+describe('describeTerminalExitCause', () => {
+  it('gives every cause a sentence that does not need a number decoded', () => {
+    expect(describeTerminalExitCause({ kind: 'operator_close' })).toBe(
+      'Terminal closed by operator request'
+    )
+    expect(describeTerminalExitCause({ kind: 'signaled', signal: 9 })).toBe(
+      'Agent process killed by signal 9'
+    )
+    expect(describeTerminalExitCause({ kind: 'exited', exitCode: 3 })).toBe(
+      'Agent process exited with code 3'
+    )
+    expect(describeTerminalExitCause({ kind: 'unknown', reason: 'stop_unverified' })).toBe(
+      'Agent process stop was requested but never confirmed'
+    )
+    expect(describeTerminalExitCause({ kind: 'unknown', reason: 'host_status_unavailable' })).toBe(
+      'Agent process ended; this host cannot report why'
+    )
+  })
+})
+
+describe('isDeliberateTerminalExit', () => {
+  it('counts only an operator close as deliberate', () => {
+    expect(isDeliberateTerminalExit({ kind: 'operator_close' })).toBe(true)
+    expect(isDeliberateTerminalExit({ kind: 'exited', exitCode: 0 })).toBe(false)
+    expect(isDeliberateTerminalExit({ kind: 'signaled', signal: 9 })).toBe(false)
+    expect(isDeliberateTerminalExit({ kind: 'unknown', reason: 'stop_unverified' })).toBe(false)
+  })
+})

--- a/src/shared/terminal-exit-cause.test.ts
+++ b/src/shared/terminal-exit-cause.test.ts
@@ -49,11 +49,16 @@ describe('resolveProcessExitCause', () => {
 })
 
 describe('resolveUnreportedExitCause', () => {
-  it('refuses to turn a bare code into a clean finish', () => {
+  it('refuses to turn a bare zero into a clean finish', () => {
     // An older daemon, or the SSH relay, forwards a code and no cause. Its 0 may
     // be a clean finish or a SIGKILL; nothing downstream can tell them apart.
     expect(resolveUnreportedExitCause(0)).toEqual({ kind: 'unknown', reason: 'cause_unreported' })
-    expect(resolveUnreportedExitCause(7)).toEqual({ kind: 'unknown', reason: 'cause_unreported' })
+  })
+
+  it('keeps a bare nonzero status, which nothing fabricates', () => {
+    // node-pty only ever pairs a signal with 0, and a wrapper only ever returns
+    // 0, so a nonzero code really is the child's wait status.
+    expect(resolveUnreportedExitCause(137)).toEqual({ kind: 'exited', exitCode: 137 })
   })
 
   it('keeps the more specific reason for the stop sentinel', () => {

--- a/src/shared/terminal-exit-cause.test.ts
+++ b/src/shared/terminal-exit-cause.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from 'vitest'
 import {
   describeTerminalExitCause,
   isDeliberateTerminalExit,
-  resolveProcessExitCause
+  resolveProcessExitCause,
+  resolveUnreportedExitCause
 } from './terminal-exit-cause'
 
 describe('resolveProcessExitCause', () => {
@@ -47,6 +48,19 @@ describe('resolveProcessExitCause', () => {
   })
 })
 
+describe('resolveUnreportedExitCause', () => {
+  it('refuses to turn a bare code into a clean finish', () => {
+    // An older daemon, or the SSH relay, forwards a code and no cause. Its 0 may
+    // be a clean finish or a SIGKILL; nothing downstream can tell them apart.
+    expect(resolveUnreportedExitCause(0)).toEqual({ kind: 'unknown', reason: 'cause_unreported' })
+    expect(resolveUnreportedExitCause(7)).toEqual({ kind: 'unknown', reason: 'cause_unreported' })
+  })
+
+  it('keeps the more specific reason for the stop sentinel', () => {
+    expect(resolveUnreportedExitCause(-1)).toEqual({ kind: 'unknown', reason: 'stop_unverified' })
+  })
+})
+
 describe('describeTerminalExitCause', () => {
   it('gives every cause a sentence that does not need a number decoded', () => {
     expect(describeTerminalExitCause({ kind: 'operator_close' })).toBe(
@@ -63,6 +77,9 @@ describe('describeTerminalExitCause', () => {
     )
     expect(describeTerminalExitCause({ kind: 'unknown', reason: 'host_status_unavailable' })).toBe(
       'Agent process ended; this host cannot report why'
+    )
+    expect(describeTerminalExitCause({ kind: 'unknown', reason: 'cause_unreported' })).toBe(
+      'Agent process ended; the reporting host did not say why'
     )
   })
 })

--- a/src/shared/terminal-exit-cause.ts
+++ b/src/shared/terminal-exit-cause.ts
@@ -25,6 +25,12 @@ export type TerminalExitUnknownReason =
   | 'stop_unverified'
   /** The host cannot report its child's status at all (see {@link hostReportsChildExitStatus}). */
   | 'host_status_unavailable'
+  /**
+   * The exit arrived from a source that reports a code but no cause — an SSH
+   * relay, or a daemon older than this field. Its `0` may be a clean finish or
+   * a signal; nothing here can tell, so nothing here claims to.
+   */
+  | 'cause_unreported'
 
 export const OPERATOR_CLOSE_EXIT_CAUSE: TerminalExitCause = { kind: 'operator_close' }
 
@@ -53,6 +59,19 @@ export function resolveProcessExitCause(observation: {
   return { kind: 'exited', exitCode: observation.exitCode }
 }
 
+/**
+ * The cause for an exit delivered without one.
+ *
+ * Why not `exited(code)`: a bare code is not evidence. node-pty pairs `0` with a
+ * signal, and the reporter may itself sit behind a wrapper. Only the process
+ * that watched the child can vouch for a status, and it did not.
+ */
+export function resolveUnreportedExitCause(exitCode: number): TerminalExitCause {
+  return exitCode < 0
+    ? { kind: 'unknown', reason: 'stop_unverified' }
+    : { kind: 'unknown', reason: 'cause_unreported' }
+}
+
 /** One line an operator or a coordinating agent can read without decoding a number. */
 export function describeTerminalExitCause(cause: TerminalExitCause): string {
   switch (cause.kind) {
@@ -63,9 +82,14 @@ export function describeTerminalExitCause(cause: TerminalExitCause): string {
     case 'exited':
       return `Agent process exited with code ${cause.exitCode}`
     case 'unknown':
-      return cause.reason === 'stop_unverified'
-        ? 'Agent process stop was requested but never confirmed'
-        : 'Agent process ended; this host cannot report why'
+      switch (cause.reason) {
+        case 'stop_unverified':
+          return 'Agent process stop was requested but never confirmed'
+        case 'host_status_unavailable':
+          return 'Agent process ended; this host cannot report why'
+        case 'cause_unreported':
+          return 'Agent process ended; the reporting host did not say why'
+      }
   }
 }
 

--- a/src/shared/terminal-exit-cause.ts
+++ b/src/shared/terminal-exit-cause.ts
@@ -60,16 +60,20 @@ export function resolveProcessExitCause(observation: {
 }
 
 /**
- * The cause for an exit delivered without one.
+ * The cause for an exit delivered without one — an older daemon, or the SSH
+ * relay, which forwards a code and nothing else.
  *
- * Why not `exited(code)`: a bare code is not evidence. node-pty pairs `0` with a
- * signal, and the reporter may itself sit behind a wrapper. Only the process
- * that watched the child can vouch for a status, and it did not.
+ * Zero is the ambiguous one, and the only one worth refusing: node-pty pairs it
+ * with every signalled death, and a wrapper spawn returns it for any outcome at
+ * all. A nonzero status is never fabricated that way, so it is still reported.
  */
 export function resolveUnreportedExitCause(exitCode: number): TerminalExitCause {
-  return exitCode < 0
-    ? { kind: 'unknown', reason: 'stop_unverified' }
-    : { kind: 'unknown', reason: 'cause_unreported' }
+  if (exitCode < 0) {
+    return { kind: 'unknown', reason: 'stop_unverified' }
+  }
+  return exitCode === 0
+    ? { kind: 'unknown', reason: 'cause_unreported' }
+    : { kind: 'exited', exitCode }
 }
 
 /** One line an operator or a coordinating agent can read without decoding a number. */

--- a/src/shared/terminal-exit-cause.ts
+++ b/src/shared/terminal-exit-cause.ts
@@ -1,0 +1,75 @@
+/**
+ * Why a terminal's process is gone.
+ *
+ * Orca used to record one number and let every reader guess. That number is not
+ * evidence: the stop paths synthesize it, node-pty reports 0 for a signalled
+ * death, and macOS's TCC `login(1)` wrapper returns its own status instead of
+ * the shell's. A clean finish, an OOM kill and an operator close all arrived as
+ * "code 0" (STA-4536, STA-4603).
+ *
+ * So a cause is only ever built from evidence someone actually holds, and the
+ * absence of evidence is spelled `unknown` rather than guessed.
+ */
+export type TerminalExitCause =
+  /** Teardown was requested through Orca — a close, a stop, a worktree removal. Not a failure. */
+  | { kind: 'operator_close' }
+  /** The host reported a signal. The agent did not choose to stop. */
+  | { kind: 'signaled'; signal: number }
+  /** The process ended on its own and the host vouched for the status. */
+  | { kind: 'exited'; exitCode: number }
+  /** Nothing here is provable. Never narrow this by guessing. */
+  | { kind: 'unknown'; reason: TerminalExitUnknownReason }
+
+export type TerminalExitUnknownReason =
+  /** A stop was issued and no exit was ever observed, so the process may still be alive. */
+  | 'stop_unverified'
+  /** The host cannot report its child's status at all (see {@link hostReportsChildExitStatus}). */
+  | 'host_status_unavailable'
+
+export const OPERATOR_CLOSE_EXIT_CAUSE: TerminalExitCause = { kind: 'operator_close' }
+
+/**
+ * Build a cause from what the host actually observed.
+ *
+ * `hostReportsChildExitStatus: false` means the number and signal below describe
+ * a wrapper process, not the agent — so they are dropped rather than reported.
+ */
+export function resolveProcessExitCause(observation: {
+  exitCode: number
+  signal?: number | null
+  hostReportsChildExitStatus?: boolean
+}): TerminalExitCause {
+  if (observation.hostReportsChildExitStatus === false) {
+    return { kind: 'unknown', reason: 'host_status_unavailable' }
+  }
+  if (typeof observation.signal === 'number' && observation.signal > 0) {
+    return { kind: 'signaled', signal: observation.signal }
+  }
+  // Why: the stop paths pass a negative code to mean "we asked it to stop and
+  // never saw it die". That is an absence of evidence, not an exit status.
+  if (observation.exitCode < 0) {
+    return { kind: 'unknown', reason: 'stop_unverified' }
+  }
+  return { kind: 'exited', exitCode: observation.exitCode }
+}
+
+/** One line an operator or a coordinating agent can read without decoding a number. */
+export function describeTerminalExitCause(cause: TerminalExitCause): string {
+  switch (cause.kind) {
+    case 'operator_close':
+      return 'Terminal closed by operator request'
+    case 'signaled':
+      return `Agent process killed by signal ${cause.signal}`
+    case 'exited':
+      return `Agent process exited with code ${cause.exitCode}`
+    case 'unknown':
+      return cause.reason === 'stop_unverified'
+        ? 'Agent process stop was requested but never confirmed'
+        : 'Agent process ended; this host cannot report why'
+  }
+}
+
+/** True when a dispatch that ended this way was torn down deliberately rather than lost. */
+export function isDeliberateTerminalExit(cause: TerminalExitCause): boolean {
+  return cause.kind === 'operator_close'
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 15 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​480 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​30 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​450 |
| Prod | 24 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​417 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​63 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​354 |

<!-- /orca-pr-loc -->

## ELI5

When an agent's terminal dies, Orca wrote down *that* it died but not *why*. Closing a pane on purpose, an agent finishing cleanly, and an agent getting OOM-killed all left the identical note: `last_failure = "Agent exited with code 0"`. A coordinator polling `terminal show` or `dispatch-show` could not tell "lane delivered and went home" from "lane crashed" — one reporter chased an OOM that never happened.

This makes Orca record the cause, and — where it genuinely cannot know — say so instead of guessing.

## Why it was broken (two separate layers)

**1. The exit number was destroyed before Orca could read it.**
- node-pty reports a signalled death as `{exitCode: 0, signal: N}`. Both PTY paths destructured `exitCode` alone, so SIGKILL arrived as `0`.
- On macOS every PTY is wrapped in `/usr/bin/login -flpq` for TCC attribution (#6996, #8985), and `login(1)` returns *its own* status. Proved directly with node-pty:

  | spawn | `exit 42` | self-SIGKILL |
  |---|---|---|
  | raw `sh` | `{exitCode: 42, signal: 0}` | `{exitCode: 0, signal: 9}` |
  | through Orca's login wrapper | `{exitCode: 0, signal: 0}` | `{exitCode: 0, signal: 0}` |

- The stop paths also *synthesize* codes (`0` on a verified stop, `-1` on an unconfirmed one), so one number carried three unrelated meanings.

**2. The teardown intent was known and thrown away.** `closeTerminal` knew it was an operator close and told the orchestration DB nothing. `rememberSyntheticKillExit` literally tracked "this exit was one I synthesized on a requested stop" — only to de-duplicate a late provider exit, then discarded it.

## What changed

`TerminalExitCause` — `operator_close` / `signaled` / `exited` / `unknown` — built only from evidence someone actually holds:

- **Intent is recorded before the stop**, so a requested teardown stays an operator close even when the provider delivers the exit itself with a status that looks like a natural finish.
- **`signal` is now captured** in both PTY paths and carried over the daemon wire (additive `cause` field on the exit event; a daemon predating it omits it and readers fall back to `unknown`).
- **A wrapper spawn reports `unknown`, not a status it cannot vouch for.** This is the deliberate choice: a confident wrong answer is what caused the original misdiagnosis.
- Surfaced on `RuntimeTerminalSummary.exitCause` and the `terminal wait` result (both additive, old clients strip them).
- Persisted on a new `dispatch_contexts.termination_reason` column (schema v29), alongside a `last_failure` sentence that no longer requires decoding a number.
- **A deliberate close no longer escalates to the coordinator** — escalating routine closes trains coordinators to ignore the channel that should wake them for a real incident.

### Also fixes an unreported bug

An explicit **whole-tab** close drops the leaf from the renderer graph *before* the exit lands, so `failActiveDispatchOnExit`'s leaf-only walk found nothing and left the dispatch reading `dispatched` **forever** against a dead process. Exits now settle from the PTY's own handle and pane key too. Found while building the repro for STA-4603; arguably worse than the ambiguity both issues report, since half the operator-close population was silently invisible.

## Before / after

Verified on a live runtime with a real daemon (not mocks):

| case | before | after (macOS, wrapper on) | after (wrapper off = Linux/Windows shape) |
|---|---|---|---|
| operator closes a pane | `Agent exited with code 0` | `operator_close` | `operator_close` |
| whole-tab close | *no record — stuck `dispatched`* | `operator_close` | `operator_close` |
| agent SIGKILLed | `Agent exited with code 0` | `unknown` (host cannot report) | `signaled` / 9 |
| clean `exit 7` | `Agent exited with code 0` | `unknown` (host cannot report) | `exited` / 7 |
| agent sent `worker_done` | `completed` | `completed` (unchanged) | `completed` (unchanged) |

The first four rows were byte-identical before this PR.

## Testing

- New: `src/shared/terminal-exit-cause.test.ts` (7) and `src/main/runtime/exit-provenance-audit.test.ts` (7) — the full case matrix, including the whole-tab strand and the no-escalation-on-close rule.
- Full suite: **55,683 passed, 0 failed** (5,922 files).
- `tsc --noEmit` clean on node / cli / web; `oxlint --deny-warnings` clean; max-lines ratchet, reliability gates, and both changed-code gates pass.
- Live e2e on an isolated dev runtime, twice — once with the macOS TCC wrapper active and once with `ORCA_DISABLE_MACOS_LOGIN_SHELL=1` to exercise the full-fidelity path.

## Review notes

- **Remote wire:** additive only. `exitCause` on the terminal summary and wait result are new optional fields old clients strip. The daemon exit event gains an optional `cause`; the daemon is version-locked to the app, and an older one simply omits it. No new stream opcode. The renderer's `pty:exit` IPC payload is deliberately left unchanged.
- **Cross-platform:** the `login(1)` status loss is macOS-only; the dropped `signal` was cross-platform. Linux/Windows now get true `exited`/`signaled` causes. **I could only test on macOS** — the wrapper-disabled runs are the closest proxy for the Linux/Windows path and they exercise the same code.
- **Schema:** v28 → v29, one nullable column, guarded by `hasColumn`. Migration tests now assert against `SCHEMA_VERSION` instead of a hardcoded literal so the next bump doesn't break them. `migrate-v13-v28.ts` renamed to `migrate-v13-v29.ts` to match its contents.
- **Follow-up not in scope:** recovering clean-exit fidelity on macOS needs the shell to report its own status out-of-band (a shell EXIT trap emitting a private OSC), since `login(1)` will never forward it. That changes shell startup injection and deserves its own PR. Until then macOS honestly reports `unknown` for process exits, which is a strict improvement over a confident `code 0`.

## Linked issues

Fixes STA-4603, Fixes STA-4536 (#15048, #14905).

Relates to #14891 (open, unmerged): that PR reports a lane's *absence* (`dead`/`unknown`) and deliberately does not claim a cause. This supplies the cause it left out. The two do not conflict.

## AI Disclosure

Written with Claude Opus 5 via Claude Code, from a reproduce-first audit of both issues on latest main.


---

## Review round (3 independent agents, Codex gpt-5.6-luna xhigh)

Three real defects were found in the first commit and fixed in `4cd2189f56`. Each new regression test was confirmed to fail with its fix reverted.

1. **Stop intent outlived its process.** `advancePtyLifecycleGeneration` did not clear `stopRequestedPtyIds` despite a comment claiming it did. A stop whose exit never arrived stayed armed across a same-id respawn, so the *next* process's crash was filed `operator_close` and silently not escalated.
2. **A bare exit code was read as a clean finish.** An exit delivered without a `cause` — from a daemon older than the field, or over the SSH relay — was reconstructed as `exited(code)`. An OOM kill on an SSH host arrived as `exited(0)`: the original bug wearing a new name. Unreported exits now resolve to `unknown: cause_unreported`.
3. **Intent outranked evidence that the stop never happened.** Intent is recorded *before* a stop is known to have succeeded, so a synthetic `-1` became `operator_close` and suppressed the escalation. A process that may still be running against a revoked dispatch is an incident. Intent now yields to `stop_unverified`.

Review also judged the tests as not covering the shipping wiring. Fixed: a close now drives the real `closeTerminal` -> `stopAndWait` path instead of calling `markPtyStopRequested` directly; the local provider is asserted to carry node-pty's `signal` through; and the no-escalation assertion first proves the dispatch actually settled rather than passing vacuously.

### Corrections to this PR description

- **The "before" column was macOS-specific.** Review is right: on a host *without* the TCC login wrapper, a clean `exit 7` did record `code 7`, and the stop paths did produce `code -1`. The universal collision was between a **normal exit-0 finish, a SIGKILL, and a confirmed operator close** — all `code 0`. The wrapper widened that to swallow every status on macOS. The table above should be read as macOS unless the row says otherwise.
- **`preservesAbnormalSshSurface` still skips dispatch settlement** for unconfirmed SSH exits, so the whole-tab fix is not universal. That guard is deliberate and unchanged: a detached relay PTY is designed to outlive the provider addressing it, and an unprovable absence must not settle a dispatch.

### Known gap, deliberately not in this PR

The SSH relay wire (`src/relay/pty-handler.ts`) forwards only `code`, so a remote SIGKILL cannot yet be reported as `signaled`. With fix 2 above it now reports `unknown: cause_unreported` instead of a false `exited(0)`. Carrying the cause across the relay touches an independently-deployed component and belongs in its own change.

### Verification after the review round

- Full suite: **55,694 passed, 0 failed**. `tsc` clean on node/cli/web, `oxlint --deny-warnings` clean, max-lines ratchet + reliability gates + both changed-code gates pass.
- Live e2e re-run on a fresh dev runtime: operator close -> `operator_close`; SIGKILL -> `unknown` (wrapper active).
- One caveat on evidence: the "crash still escalates" behaviour is covered by unit test, not by the live run — escalations require an active *legacy* coordinator run, which the live harness did not create.