### PR TITLE
test(updater): await the linux install re-proof instead of budgeting event-loop turns

### DIFF
--- a/src/main/updater.linux-root-package-install.test.ts
+++ b/src/main/updater.linux-root-package-install.test.ts
@@ -77,6 +77,95 @@ function stageLinuxUpdateCache(): StagedLinuxPackages {
   }
 }
 
+type RevalidationProbe = {
+  /** Switch to held mode, where a verdict only lands when the test says so. Must precede startUpdater. */
+  hold: () => void
+  settle: (verdict: RevalidationVerdict) => void
+  fail: (error: Error) => void
+  invocationCount: () => number
+  /** Resolves once every re-proof this test started has finished. */
+  drain: () => Promise<void>
+}
+
+/** One outstanding re-proof; `awaitable` stays false while a held verdict has no way to settle. */
+type OutstandingRevalidation = { promise: Promise<unknown>; awaitable: boolean }
+
+/**
+ * Wraps the pre-install re-proof so tests can await the real disk read instead of budgeting
+ * event-loop turns, and can hold a verdict open at an exact point in the cycle. Only that one call
+ * is wrapped — the artifact state stays real.
+ */
+function probeRevalidation(): RevalidationProbe {
+  type Artifact = Parameters<typeof RecoveryModule.revalidateLinuxPackageForInstall>[0]
+  let held = false
+  let invocationCount = 0
+  let pending: {
+    resolve: (verdict: RevalidationVerdict) => void
+    reject: (error: Error) => void
+    entry: OutstandingRevalidation
+  } | null = null
+  const outstanding: OutstandingRevalidation[] = []
+
+  const track = (verdict: Promise<RevalidationVerdict>, awaitable: boolean) => {
+    const noop = (): void => undefined
+    const entry: OutstandingRevalidation = { promise: verdict.then(noop, noop), awaitable }
+    outstanding.push(entry)
+    return entry
+  }
+
+  vi.doMock('./linux-package-update-recovery', async () => {
+    const actual = await vi.importActual<typeof RecoveryModule>('./linux-package-update-recovery')
+    return {
+      ...actual,
+      revalidateLinuxPackageForInstall: vi.fn((artifact: Artifact) => {
+        invocationCount += 1
+        if (!held) {
+          const verdict = actual.revalidateLinuxPackageForInstall(artifact)
+          track(verdict, true)
+          return verdict
+        }
+        let resolve!: (verdict: RevalidationVerdict) => void
+        let reject!: (error: Error) => void
+        const verdict = new Promise<RevalidationVerdict>((res, rej) => {
+          resolve = res
+          reject = rej
+        })
+        pending = { resolve, reject, entry: track(verdict, false) }
+        return verdict
+      })
+    }
+  })
+
+  const release = (): typeof pending => {
+    const current = pending
+    if (current) {
+      current.entry.awaitable = true
+      pending = null
+    }
+    return current
+  }
+
+  return {
+    hold: () => {
+      held = true
+    },
+    settle: (verdict) => release()?.resolve(verdict),
+    fail: (error) => release()?.reject(error),
+    invocationCount: () => invocationCount,
+    drain: async () => {
+      // A verdict still held open can never settle on its own, so draining skips it.
+      let ready = outstanding.filter((entry) => entry.awaitable)
+      while (ready.length > 0) {
+        for (const entry of ready) {
+          outstanding.splice(outstanding.indexOf(entry), 1)
+        }
+        await Promise.all(ready.map((entry) => entry.promise))
+        ready = outstanding.filter((entry) => entry.awaitable)
+      }
+    }
+  }
+}
+
 describe('updater', () => {
   beforeEach(() => {
     resetUpdaterMocks()
@@ -85,11 +174,15 @@ describe('updater', () => {
   describe('linux root package install recovery', () => {
     let staged: StagedLinuxPackages
     let EXIT_127: string
+    let revalidation: RevalidationProbe
 
-    // Why: the pre-install digest re-proof streams the package off real disk. Fake timers never
-    // advance libuv, so the quit timer needs fake time while the read needs real event-loop turns.
+    // Why: the quit timer needs fake time, and the work it starts needs real event-loop turns —
+    // fake timers never advance libuv. The re-proof itself is awaited rather than counted out
+    // (#15243): its disk read is wall-clock bound, so a loaded runner outlasts any turn budget and
+    // the tail lands in the next test.
     const settleQuitAndInstall = async (): Promise<void> => {
       await vi.advanceTimersByTimeAsync(100)
+      await revalidation.drain()
       for (let turn = 0; turn < 40; turn += 1) {
         await new Promise((resolve) => realSetTimeout(resolve, 0))
       }
@@ -100,54 +193,17 @@ describe('updater', () => {
       staged = stageLinuxUpdateCache()
       vi.stubEnv('XDG_CACHE_HOME', staged.cacheRoot)
       EXIT_127 = `Command failed: /usr/bin/pkexec /usr/bin/dpkg -i ${staged.debPath}, exited with code 127`
+      revalidation = probeRevalidation()
     })
 
-    afterEach(() => {
+    afterEach(async () => {
+      // Why: an unfinished re-proof keeps running against this test's module instance, whose mocks
+      // are the same singletons the next test asserts on — it would double every install-path count.
+      await revalidation.drain()
       vi.doUnmock('./linux-package-update-recovery')
       vi.unstubAllEnvs()
       rmSync(staged.cacheRoot, { recursive: true, force: true })
     })
-
-    /**
-     * Holds the pre-install re-proof open so a verdict can be delivered at an exact point in the
-     * cycle. Only that call is replaced — the artifact state stays real. Must precede startUpdater.
-     */
-    const holdRevalidation = (): {
-      settle: (verdict: RevalidationVerdict) => void
-      fail: (error: Error) => void
-      invocationCount: () => number
-    } => {
-      let invocationCount = 0
-      let pending: {
-        resolve: (verdict: RevalidationVerdict) => void
-        reject: (error: Error) => void
-      } | null = null
-      vi.doMock('./linux-package-update-recovery', async () => {
-        const actual = await vi.importActual<typeof RecoveryModule>(
-          './linux-package-update-recovery'
-        )
-        return {
-          ...actual,
-          revalidateLinuxPackageForInstall: vi.fn(() => {
-            invocationCount += 1
-            return new Promise<RevalidationVerdict>((resolve, reject) => {
-              pending = { resolve, reject }
-            })
-          })
-        }
-      })
-      return {
-        settle: (verdict) => {
-          pending?.resolve(verdict)
-          pending = null
-        },
-        fail: (error) => {
-          pending?.reject(error)
-          pending = null
-        },
-        invocationCount: () => invocationCount
-      }
-    }
 
     const lastStatus = (send: ReturnType<typeof vi.fn>): UpdateStatus | undefined =>
       send.mock.calls.findLast(([channel]) => channel === 'updater:status')?.[1]
@@ -501,7 +557,7 @@ describe('updater', () => {
     // Why: hashing 160 MB outlives the cycle it started in, and Check for Updates stays enabled
     // while it runs — a verdict from the old cycle must not replace the card that took over.
     it('drops an abort verdict once a newer check replaced the card', async () => {
-      const revalidation = holdRevalidation()
+      revalidation.hold()
       const { send, updater } = await startUpdater('deb')
       await reachDownloaded(updater, downloadedEvent())
 
@@ -531,7 +587,7 @@ describe('updater', () => {
     // Why: EMFILE/EIO during the stream says nothing about the bytes, so the copy must not claim
     // the package changed and the card must keep the actions that still work.
     it('keeps the recovery card usable when the re-proof cannot read the package', async () => {
-      const revalidation = holdRevalidation()
+      revalidation.hold()
       const { send, updater } = await startUpdater('deb')
       await reachDownloaded(updater, downloadedEvent())
       autoUpdaterMock.quitAndInstall.mockImplementation(() => {
@@ -565,7 +621,7 @@ describe('updater', () => {
     // Why: the re-proof runs before performQuitAndInstall's own error handling, so a rejection
     // there would strand the quit timer and make every later install a silent no-op.
     it('stays installable after a re-proof that rejects outright', async () => {
-      const revalidation = holdRevalidation()
+      revalidation.hold()
       const { send, updater } = await startUpdater('deb')
       await reachDownloaded(updater, downloadedEvent())
 
@@ -592,7 +648,7 @@ describe('updater', () => {
 
     // Why: a second click during the multi-second hash must not schedule a parallel install.
     it('ignores a second install request while the digest re-proof runs', async () => {
-      const revalidation = holdRevalidation()
+      revalidation.hold()
       const { updater } = await startUpdater('deb')
       await reachDownloaded(updater, downloadedEvent())
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​104 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​48 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​56 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

Fixes #15243.

## What this is

`src/main/updater.linux-root-package-install.test.ts` is the test file for Orca's **Linux root-package install path** — the flow behind "Restart to Update" on a `.deb`/`.rpm` install, where Orca hands a downloaded package to `dpkg`/`rpm` as root. The tests stage real `.deb`/`.rpm` files in a real temp cache directory, because a key part of that path is that Orca **re-hashes the package off disk immediately before installing it** (the cache path is user-writable, so the digest checked at download time says nothing about the bytes a root installer will read minutes later).

Two of those tests were failing at random in PR CI on changes that touch nothing near the updater — an IME change, a build-tooling change. Both passed on a plain re-run. That's the thing worth killing: it reddens unrelated PRs and trains people to re-run CI without reading it.

## ELI5

The test needs to wait for Orca to finish reading a file off the disk before it checks the result.

Instead of *actually waiting for the read to finish*, the test **guessed how long it would take**: "I'll tick 40 times, that's usually enough."

On a fast laptop, 40 ticks is plenty. On a CI machine running 16 test shards that are all hammering the same disk at once, the read is slower — and 40 ticks runs out first. So:

1. The test checks its answer **before the work finished** → it fails, saying the thing it expected never happened.
2. The unfinished work **doesn't stop**. It keeps running, and finishes in the middle of the *next* test — where it presses the same buttons a second time. That test then fails with "expected this to be called once, but it was called twice."

One slow read, two broken tests, neither of them the real problem.

The fix: **stop guessing, actually wait.** The test now holds onto the read's promise and awaits it, so it doesn't matter whether the read takes 2ms or 2 seconds. And it double-checks after every test that nothing is still running, so no leftovers can wander into the next one.

Nothing in the shipped app changed. The app was always fine — only the test was guessing.

## Root cause

The issue guessed cross-test leakage from an un-awaited promise. That is what happens, and here is the specific mechanism.

`settleQuitAndInstall` gave the pre-install digest re-proof a fixed budget of **40 real event-loop turns**:

```ts
await vi.advanceTimersByTimeAsync(100)
for (let turn = 0; turn < 40; turn += 1) {
  await new Promise((resolve) => realSetTimeout(resolve, 0))
}
```

That budget is wall-clock, not work. `revalidateLinuxPackageForInstall` → `validateArtifact` does two `fsp.realpath` calls, an `fsp.lstat`, and a streamed sha512 — six-ish sequential libuv threadpool ops. 40 × `setTimeout(0)` is roughly 40ms of wall clock, so the budget is about 6ms per fs op. On a CI runner with 16 shards contending for the same threadpool and disk, that is not a budget the read is guaranteed to fit in.

When it doesn't fit, two things go wrong at once:

1. The test asserts before its own install flow reached the assertion point — the `post_commit_cleanup_failed` failure.
2. The unfinished flow keeps running *into the next test*. `resetUpdaterMocks()` calls `vi.resetModules()`, but that only affects later imports; the previously-imported `./updater` instance stays alive and its closures still hold the same hoisted mock singletons. So the leftover flow calls `armUpdateInstallExitWatchdog()` / `killAllPty()` a second time — the "called 1 times, but got 2 times" failure.

That is exactly the reported pair, and in the reported order: `keeps a committed install intact when post-commit cleanup throws` followed by `still suppresses late post-commit errors while an artifact is retained`.

**The product is fine.** Two `killAllPty` calls require two module instances; a single instance is guarded by `quitAndInstallInProgress` / `linuxPackageRevalidationInFlight`. This is test isolation only, and no `src/main/updater.ts` change was needed.

## Fix

`probeRevalidation()` wraps `revalidateLinuxPackageForInstall` for every test in the describe. The wrapper delegates to the real implementation by default, so artifact state and the disk re-proof stay real — it only records the promise so the test can **await** it instead of counting turns. `holdRevalidation` folds into the same probe as an opt-in `hold()` mode, unchanged in behaviour.

- `settleQuitAndInstall` awaits the outstanding re-proof before its turn loop.
- `afterEach` drains again, so no re-proof can outlive the test that started it — closing the leak class rather than just the one instance of it.

The turn loop stays as slack for microtask-only tails, but is no longer load-bearing.

## Verification

The interesting part is showing the fix removes the wall-clock dependency rather than just widening the margin. Setting the loop to **zero** real turns starves exactly the resource that was scarce:

| turn budget | before | after |
| --- | --- | --- |
| 40 (as shipped) | 19 passed | 19 passed |
| 0 | **11 failed / 8 passed** | **19 passed** |

At zero turns the pre-fix run reproduces the reported assertions verbatim, including `expected "vi.fn()" to be called with arguments: [ 'post_commit_cleanup_failed', …(2) ]`. After the fix the suite passes with no real turns at all, because the read is awaited.

Also run: full file ×5 under 12 concurrent CPU hogs (pass), `src/main/updater*` + `linux-package-update-recovery` ×3 — 314 tests, all passing. `typecheck:node`, `oxlint`, `oxfmt`, and the max-lines ratchet are clean.

Not reproduced on macOS at the shipped budget, consistent with the issue: the local SSD finishes the read well inside 40 turns.
