### PR TITLE
fix(dev): stop caching unsigned bundles and reclaim stale dev copies

### DIFF
--- a/config/scripts/dev-electron-bundle-cache.mjs
+++ b/config/scripts/dev-electron-bundle-cache.mjs
@@ -1,0 +1,19 @@
+// Why this module exists: `out/electron-dev` accumulates one ~270MB copy of Electron.app per
+// (branch title x Electron version x bundle layout). The runner only ever clears the directory it is
+// about to rebuild, so siblings from renamed branches and past upgrades are never reclaimed --
+// measured at 143 directories / 38GB across one developer's worktrees.
+
+/** Directory holding a bundle is "in use" if a live process path points inside it. */
+function isInUse(dir, livePaths) {
+  return livePaths.some((livePath) => livePath === dir || livePath.startsWith(`${dir}/`))
+}
+
+/**
+ * Which cached bundle directories are safe to reclaim.
+ *
+ * Never returns the directory in use by a running dev instance: deleting a bundle out from under a
+ * live Electron process can crash it mid-session, and developers routinely run several at once.
+ */
+export function selectStaleDevBundleDirs({ dirs, currentDir, livePaths }) {
+  return dirs.filter((dir) => dir !== currentDir && !isInUse(dir, livePaths))
+}

--- a/config/scripts/dev-electron-bundle-cache.mjs
+++ b/config/scripts/dev-electron-bundle-cache.mjs
@@ -3,8 +3,11 @@
 // about to rebuild, so siblings from renamed branches and past upgrades are never reclaimed --
 // measured at 143 directories / 38GB across one developer's worktrees.
 
-// A bundle takes tens of seconds to copy. Anything marker-less and newer than this is assumed to be
-// a build in flight rather than debris; generous because a cold copy on a busy machine is slow.
+// Measured from BUILD START, not from last activity: a directory's mtime only changes when a
+// top-level entry is created, so it freezes once `<app>.app` appears and the 276MB copy, helper
+// compiles and signing that follow never refresh it. So this is a hard cliff -- a build still
+// running after this long becomes eligible for deletion by a concurrent instance. Full builds
+// measured at 130-200s, so the margin is 5-10x.
 export const IN_PROGRESS_WINDOW_MS = 15 * 60 * 1000
 
 /**
@@ -25,10 +28,18 @@ export const IN_PROGRESS_WINDOW_MS = 15 * 60 * 1000
  * directory is immune to spaces and shell-significant characters in the path, and the trailing
  * slash keeps `<dir>2` from being mistaken for `<dir>`.
  */
+export function isDevBundleInUse(dir, processTable) {
+  // Both spellings: macOS realpaths /tmp to /private/tmp, and `ps` preserves whatever spelling the
+  // process was launched with. A mismatch would read as "not running" and delete a live bundle.
+  // Checking both can only ever protect more, which is the safe direction.
+  const alternate = dir.startsWith('/private/') ? dir.slice('/private'.length) : `/private${dir}`
+  return processTable.includes(`${dir}/`) || processTable.includes(`${alternate}/`)
+}
+
 export function selectStaleDevBundleDirs({ bundles, currentDir, processTable, nowMs }) {
   return bundles
     .filter(({ dir, hasMarker, mtimeMs }) => {
-      if (dir === currentDir || processTable.includes(`${dir}/`)) {
+      if (dir === currentDir || isDevBundleInUse(dir, processTable)) {
         return false
       }
       const buildInFlight = !hasMarker && nowMs - mtimeMs < IN_PROGRESS_WINDOW_MS

--- a/config/scripts/dev-electron-bundle-cache.mjs
+++ b/config/scripts/dev-electron-bundle-cache.mjs
@@ -3,17 +3,18 @@
 // about to rebuild, so siblings from renamed branches and past upgrades are never reclaimed --
 // measured at 143 directories / 38GB across one developer's worktrees.
 
-/** Directory holding a bundle is "in use" if a live process path points inside it. */
-function isInUse(dir, livePaths) {
-  return livePaths.some((livePath) => livePath === dir || livePath.startsWith(`${dir}/`))
-}
-
 /**
  * Which cached bundle directories are safe to reclaim.
  *
- * Never returns the directory in use by a running dev instance: deleting a bundle out from under a
+ * Never returns a directory in use by a running dev instance: deleting a bundle out from under a
  * live Electron process can crash it mid-session, and developers routinely run several at once.
+ *
+ * `processTable` is raw `ps` output, searched for each candidate rather than parsed into paths.
+ * Parsing was tried twice and failed twice in the same dangerous direction -- a regex that missed a
+ * live process yielded "nothing is running" and deleted its bundle. Searching for a known absolute
+ * directory is immune to spaces and shell-significant characters in the path, and the trailing
+ * slash keeps `<dir>2` from being mistaken for `<dir>`.
  */
-export function selectStaleDevBundleDirs({ dirs, currentDir, livePaths }) {
-  return dirs.filter((dir) => dir !== currentDir && !isInUse(dir, livePaths))
+export function selectStaleDevBundleDirs({ dirs, currentDir, processTable }) {
+  return dirs.filter((dir) => dir !== currentDir && !processTable.includes(`${dir}/`))
 }

--- a/config/scripts/dev-electron-bundle-cache.mjs
+++ b/config/scripts/dev-electron-bundle-cache.mjs
@@ -3,11 +3,21 @@
 // about to rebuild, so siblings from renamed branches and past upgrades are never reclaimed --
 // measured at 143 directories / 38GB across one developer's worktrees.
 
+// A bundle takes tens of seconds to copy. Anything marker-less and newer than this is assumed to be
+// a build in flight rather than debris; generous because a cold copy on a busy machine is slow.
+export const IN_PROGRESS_WINDOW_MS = 15 * 60 * 1000
+
 /**
  * Which cached bundle directories are safe to reclaim.
  *
- * Never returns a directory in use by a running dev instance: deleting a bundle out from under a
- * live Electron process can crash it mid-session, and developers routinely run several at once.
+ * Three things are protected, and every one of them is a directory some other process still needs:
+ *
+ * - the bundle this run is about to use;
+ * - a bundle a live dev instance is running from. Deleting it can crash that instance mid-session,
+ *   and developers routinely run several at once;
+ * - a bundle still being copied. Between `mkdirSync` and the marker write it exists, has no marker,
+ *   and cannot appear in the process table because its instance has not launched yet -- so a
+ *   concurrently starting instance would otherwise delete it mid-copy.
  *
  * `processTable` is raw `ps` output, searched for each candidate rather than parsed into paths.
  * Parsing was tried twice and failed twice in the same dangerous direction -- a regex that missed a
@@ -15,6 +25,14 @@
  * directory is immune to spaces and shell-significant characters in the path, and the trailing
  * slash keeps `<dir>2` from being mistaken for `<dir>`.
  */
-export function selectStaleDevBundleDirs({ dirs, currentDir, processTable }) {
-  return dirs.filter((dir) => dir !== currentDir && !processTable.includes(`${dir}/`))
+export function selectStaleDevBundleDirs({ bundles, currentDir, processTable, nowMs }) {
+  return bundles
+    .filter(({ dir, hasMarker, mtimeMs }) => {
+      if (dir === currentDir || processTable.includes(`${dir}/`)) {
+        return false
+      }
+      const buildInFlight = !hasMarker && nowMs - mtimeMs < IN_PROGRESS_WINDOW_MS
+      return !buildInFlight
+    })
+    .map(({ dir }) => dir)
 }

--- a/config/scripts/dev-electron-bundle-cache.test.ts
+++ b/config/scripts/dev-electron-bundle-cache.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { IN_PROGRESS_WINDOW_MS, selectStaleDevBundleDirs } from './dev-electron-bundle-cache.mjs'
+import {
+  IN_PROGRESS_WINDOW_MS,
+  isDevBundleInUse,
+  selectStaleDevBundleDirs
+} from './dev-electron-bundle-cache.mjs'
 
 const NOW = 1_800_000_000_000
 const ROOT = '/repo/out/electron-dev'
@@ -98,6 +102,23 @@ describe('dev-electron-bundle-cache', () => {
         nowMs: NOW
       })
     ).toEqual([A])
+  })
+
+  it('matches a live bundle across the /tmp and /private/tmp spellings', () => {
+    // macOS realpaths /tmp to /private/tmp, and `ps` preserves whatever spelling the process was
+    // launched with. A mismatch would read as "not running" and delete a live bundle.
+    const priv = '/private/tmp/wt/out/electron-dev/aaaaaaaaaaaa'
+    const plain = '/tmp/wt/out/electron-dev/aaaaaaaaaaaa'
+    expect(isDevBundleInUse(priv, psLine(plain))).toBe(true)
+    expect(isDevBundleInUse(plain, psLine(priv))).toBe(true)
+    expect(isDevBundleInUse(priv, psLine('/private/tmp/wt/out/electron-dev/bbbbbbbbbbbb'))).toBe(
+      false
+    )
+  })
+
+  it('still honours the path boundary across spellings', () => {
+    const priv = '/private/tmp/wt/out/electron-dev/aaaaaaaaaaaa'
+    expect(isDevBundleInUse(priv, psLine('/tmp/wt/out/electron-dev/aaaaaaaaaaaa2'))).toBe(false)
   })
 
   it('reclaims nothing when every directory is current or live', () => {

--- a/config/scripts/dev-electron-bundle-cache.test.ts
+++ b/config/scripts/dev-electron-bundle-cache.test.ts
@@ -6,9 +6,14 @@ const A = `${ROOT}/aaaaaaaaaaaa`
 const B = `${ROOT}/bbbbbbbbbbbb`
 const C = `${ROOT}/cccccccccccc`
 
+/** A `ps -Awwo command=` line for a dev instance running out of `dir`. */
+function psLine(dir: string, appName = 'Orca: some-branch') {
+  return `${dir}/${appName}.app/Contents/MacOS/Electron --remote-debugging-port=9333`
+}
+
 describe('dev-electron-bundle-cache', () => {
   it('reclaims siblings while keeping the current bundle', () => {
-    expect(selectStaleDevBundleDirs({ dirs: [A, B, C], currentDir: B, livePaths: [] })).toEqual([
+    expect(selectStaleDevBundleDirs({ dirs: [A, B, C], currentDir: B, processTable: '' })).toEqual([
       A,
       C
     ])
@@ -17,23 +22,39 @@ describe('dev-electron-bundle-cache', () => {
   it('never reclaims a bundle a live process is running from', () => {
     // Deleting a bundle out from under a live Electron process can crash it mid-session, and
     // developers routinely run several dev instances at once.
-    const livePaths = [`${A}/Orca: some-branch.app/Contents/MacOS/Electron`]
-    expect(selectStaleDevBundleDirs({ dirs: [A, B, C], currentDir: B, livePaths })).toEqual([C])
+    expect(
+      selectStaleDevBundleDirs({ dirs: [A, B, C], currentDir: B, processTable: psLine(A) })
+    ).toEqual([C])
   })
 
-  it('matches on a path boundary, not a bare prefix', () => {
-    // `${ROOT}/aaaaaaaaaaaa2` must not be treated as in use just because it starts with A.
-    const sibling = `${A}2`
-    const livePaths = [`${A}/x.app/Contents/MacOS/Electron`]
-    expect(selectStaleDevBundleDirs({ dirs: [A, sibling], currentDir: C, livePaths })).toEqual([
-      sibling
-    ])
+  it('protects a live bundle whose path contains spaces', () => {
+    // Regression: an extraction regex using \S* could not cross a space, so any developer with a
+    // space in their checkout path (or in the .app name, which always has one) got "nothing is
+    // live" and had the running instance's bundle deleted.
+    const spaced = '/Users/me/My Projects/orca/out/electron-dev/aaaaaaaaaaaa'
+    const other = '/Users/me/My Projects/orca/out/electron-dev/bbbbbbbbbbbb'
+    expect(
+      selectStaleDevBundleDirs({
+        dirs: [spaced, other],
+        currentDir: C,
+        processTable: psLine(spaced, 'Orca: my branch')
+      })
+    ).toEqual([other])
+  })
+
+  it('does not treat a sibling as live just because it shares a prefix', () => {
+    // Boundary: `<dir>2` being live must not protect `<dir>`. Without the trailing slash in the
+    // needle, `A` would be found inside `A2`'s path and wrongly spared.
+    const a2 = `${A}2`
+    expect(
+      selectStaleDevBundleDirs({ dirs: [A, a2], currentDir: C, processTable: psLine(a2) })
+    ).toEqual([A])
   })
 
   it('reclaims nothing when every directory is current or live', () => {
     expect(
-      selectStaleDevBundleDirs({ dirs: [A, B], currentDir: A, livePaths: [`${B}/x`] })
+      selectStaleDevBundleDirs({ dirs: [A, B], currentDir: A, processTable: psLine(B) })
     ).toEqual([])
-    expect(selectStaleDevBundleDirs({ dirs: [], currentDir: A, livePaths: [] })).toEqual([])
+    expect(selectStaleDevBundleDirs({ dirs: [], currentDir: A, processTable: '' })).toEqual([])
   })
 })

--- a/config/scripts/dev-electron-bundle-cache.test.ts
+++ b/config/scripts/dev-electron-bundle-cache.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { selectStaleDevBundleDirs } from './dev-electron-bundle-cache.mjs'
+
+const ROOT = '/repo/out/electron-dev'
+const A = `${ROOT}/aaaaaaaaaaaa`
+const B = `${ROOT}/bbbbbbbbbbbb`
+const C = `${ROOT}/cccccccccccc`
+
+describe('dev-electron-bundle-cache', () => {
+  it('reclaims siblings while keeping the current bundle', () => {
+    expect(selectStaleDevBundleDirs({ dirs: [A, B, C], currentDir: B, livePaths: [] })).toEqual([
+      A,
+      C
+    ])
+  })
+
+  it('never reclaims a bundle a live process is running from', () => {
+    // Deleting a bundle out from under a live Electron process can crash it mid-session, and
+    // developers routinely run several dev instances at once.
+    const livePaths = [`${A}/Orca: some-branch.app/Contents/MacOS/Electron`]
+    expect(selectStaleDevBundleDirs({ dirs: [A, B, C], currentDir: B, livePaths })).toEqual([C])
+  })
+
+  it('matches on a path boundary, not a bare prefix', () => {
+    // `${ROOT}/aaaaaaaaaaaa2` must not be treated as in use just because it starts with A.
+    const sibling = `${A}2`
+    const livePaths = [`${A}/x.app/Contents/MacOS/Electron`]
+    expect(selectStaleDevBundleDirs({ dirs: [A, sibling], currentDir: C, livePaths })).toEqual([
+      sibling
+    ])
+  })
+
+  it('reclaims nothing when every directory is current or live', () => {
+    expect(
+      selectStaleDevBundleDirs({ dirs: [A, B], currentDir: A, livePaths: [`${B}/x`] })
+    ).toEqual([])
+    expect(selectStaleDevBundleDirs({ dirs: [], currentDir: A, livePaths: [] })).toEqual([])
+  })
+})

--- a/config/scripts/dev-electron-bundle-cache.test.ts
+++ b/config/scripts/dev-electron-bundle-cache.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it } from 'vitest'
-import { selectStaleDevBundleDirs } from './dev-electron-bundle-cache.mjs'
+import { IN_PROGRESS_WINDOW_MS, selectStaleDevBundleDirs } from './dev-electron-bundle-cache.mjs'
 
+const NOW = 1_800_000_000_000
 const ROOT = '/repo/out/electron-dev'
 const A = `${ROOT}/aaaaaaaaaaaa`
 const B = `${ROOT}/bbbbbbbbbbbb`
 const C = `${ROOT}/cccccccccccc`
+
+/** A finished bundle: marker present, copied long ago. */
+function settled(dir: string) {
+  return { dir, hasMarker: true, mtimeMs: NOW - IN_PROGRESS_WINDOW_MS * 2 }
+}
 
 /** A `ps -Awwo command=` line for a dev instance running out of `dir`. */
 function psLine(dir: string, appName = 'Orca: some-branch') {
@@ -13,31 +19,40 @@ function psLine(dir: string, appName = 'Orca: some-branch') {
 
 describe('dev-electron-bundle-cache', () => {
   it('reclaims siblings while keeping the current bundle', () => {
-    expect(selectStaleDevBundleDirs({ dirs: [A, B, C], currentDir: B, processTable: '' })).toEqual([
-      A,
-      C
-    ])
+    expect(
+      selectStaleDevBundleDirs({
+        bundles: [settled(A), settled(B), settled(C)],
+        currentDir: B,
+        processTable: '',
+        nowMs: NOW
+      })
+    ).toEqual([A, C])
   })
 
   it('never reclaims a bundle a live process is running from', () => {
     // Deleting a bundle out from under a live Electron process can crash it mid-session, and
     // developers routinely run several dev instances at once.
     expect(
-      selectStaleDevBundleDirs({ dirs: [A, B, C], currentDir: B, processTable: psLine(A) })
+      selectStaleDevBundleDirs({
+        bundles: [settled(A), settled(B), settled(C)],
+        currentDir: B,
+        processTable: psLine(A),
+        nowMs: NOW
+      })
     ).toEqual([C])
   })
 
   it('protects a live bundle whose path contains spaces', () => {
     // Regression: an extraction regex using \S* could not cross a space, so any developer with a
-    // space in their checkout path (or in the .app name, which always has one) got "nothing is
-    // live" and had the running instance's bundle deleted.
+    // space in their checkout path got "nothing is live" and had the running bundle deleted.
     const spaced = '/Users/me/My Projects/orca/out/electron-dev/aaaaaaaaaaaa'
     const other = '/Users/me/My Projects/orca/out/electron-dev/bbbbbbbbbbbb'
     expect(
       selectStaleDevBundleDirs({
-        dirs: [spaced, other],
+        bundles: [settled(spaced), settled(other)],
         currentDir: C,
-        processTable: psLine(spaced, 'Orca: my branch')
+        processTable: psLine(spaced, 'Orca: my branch'),
+        nowMs: NOW
       })
     ).toEqual([other])
   })
@@ -47,14 +62,55 @@ describe('dev-electron-bundle-cache', () => {
     // needle, `A` would be found inside `A2`'s path and wrongly spared.
     const a2 = `${A}2`
     expect(
-      selectStaleDevBundleDirs({ dirs: [A, a2], currentDir: C, processTable: psLine(a2) })
+      selectStaleDevBundleDirs({
+        bundles: [settled(A), settled(a2)],
+        currentDir: C,
+        processTable: psLine(a2),
+        nowMs: NOW
+      })
+    ).toEqual([A])
+  })
+
+  it('never deletes a bundle that is still being copied', () => {
+    // Between mkdirSync and the marker write there is a ~270MB copy taking tens of seconds, during
+    // which the directory exists, has no marker, and cannot appear in `ps` because its instance has
+    // not launched yet. A concurrently starting instance would otherwise delete it mid-copy.
+    const inFlight = { dir: A, hasMarker: false, mtimeMs: NOW - 30_000 }
+    expect(
+      selectStaleDevBundleDirs({
+        bundles: [inFlight, settled(B)],
+        currentDir: C,
+        processTable: '',
+        nowMs: NOW
+      })
+    ).toEqual([B])
+  })
+
+  it('reclaims a marker-less bundle once it is too old to be in flight', () => {
+    // A build that crashed partway leaves the same signature; only age separates it from the case
+    // above, otherwise abandoned debris would be protected forever.
+    const abandoned = { dir: A, hasMarker: false, mtimeMs: NOW - IN_PROGRESS_WINDOW_MS - 1 }
+    expect(
+      selectStaleDevBundleDirs({
+        bundles: [abandoned],
+        currentDir: C,
+        processTable: '',
+        nowMs: NOW
+      })
     ).toEqual([A])
   })
 
   it('reclaims nothing when every directory is current or live', () => {
     expect(
-      selectStaleDevBundleDirs({ dirs: [A, B], currentDir: A, processTable: psLine(B) })
+      selectStaleDevBundleDirs({
+        bundles: [settled(A), settled(B)],
+        currentDir: A,
+        processTable: psLine(B),
+        nowMs: NOW
+      })
     ).toEqual([])
-    expect(selectStaleDevBundleDirs({ dirs: [], currentDir: A, processTable: '' })).toEqual([])
+    expect(
+      selectStaleDevBundleDirs({ bundles: [], currentDir: A, processTable: '', nowMs: NOW })
+    ).toEqual([])
   })
 })

--- a/config/scripts/run-electron-vite-dev.mjs
+++ b/config/scripts/run-electron-vite-dev.mjs
@@ -17,6 +17,7 @@ import net from 'node:net'
 import { createRequire } from 'node:module'
 import path from 'node:path'
 import { prepareDevCliTerminalWrappers } from './dev-cli-terminal-wrapper.mjs'
+import { selectStaleDevBundleDirs } from './dev-electron-bundle-cache.mjs'
 import {
   DEV_BUNDLE_ID,
   getDevBundlePlistPatches,
@@ -115,6 +116,48 @@ function sanitizeMacAppBundleName(value) {
   )
 }
 
+function getLiveDevBundlePaths() {
+  // One `ps` for every instance, rather than one probe per directory. Not pgrep: macOS pgrep has no
+  // -a (that is a Linux procps extension) and silently prints bare PIDs, which would read as
+  // "nothing is running" and delete a live bundle. -ww prevents the command column being truncated.
+  try {
+    return execFileSync('/bin/ps', ['-Awwo', 'command='], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 5000
+    })
+      .split('\n')
+      .flatMap((line) => line.match(/\/\S*\/out\/electron-dev\/[^\s/]+/g) ?? [])
+  } catch {
+    // Treating a failure as "nothing live" would risk deleting a running bundle, so skip pruning.
+    return null
+  }
+}
+
+function pruneStaleDevBundles(distDir) {
+  const root = path.dirname(distDir)
+  let dirs
+  try {
+    dirs = readdirSync(root, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => path.join(root, entry.name))
+  } catch {
+    return
+  }
+  if (dirs.length <= 1) {
+    return
+  }
+  const livePaths = getLiveDevBundlePaths()
+  if (livePaths === null) {
+    return
+  }
+  for (const dir of selectStaleDevBundleDirs({ dirs, currentDir: distDir, livePaths })) {
+    try {
+      rmSync(dir, { recursive: true, force: true })
+    } catch {}
+  }
+}
+
 function prepareMacDevElectronApp() {
   if (process.platform !== 'darwin') {
     return
@@ -209,6 +252,7 @@ function prepareMacDevElectronApp() {
   }
 
   if (copiedAppIsUsable()) {
+    pruneStaleDevBundles(distDir)
     process.env.ELECTRON_EXEC_PATH = executablePath
     return
   }
@@ -290,14 +334,24 @@ function prepareMacDevElectronApp() {
   // An ad-hoc re-sign restores delivery, the permission prompt, and the
   // notification-settings deep link for dev builds. Non-fatal: a signing
   // failure should not block `pnpm dev`.
+  let signed = true
   try {
     execFileSync('/usr/bin/codesign', ['--force', '--deep', '--sign', '-', appPath])
   } catch (error) {
+    signed = false
     console.warn(
       `[orca-dev] ad-hoc codesign failed (dev notifications will not deliver): ${error?.message ?? error}`
     )
   }
-  writeFileSync(markerPath, expectedMarker, 'utf8')
+  // Why only when signed: the marker is what marks this bundle reusable. Writing it after a failed
+  // sign cached an unsigned bundle permanently -- the warning above scrolled past once and every
+  // later launch silently reused it, losing notification delivery and the stable cdhash that keeps
+  // safeStorage from re-prompting. Leaving it unwritten costs a re-copy per launch until signing
+  // works, and still does not block `pnpm dev`.
+  if (signed) {
+    writeFileSync(markerPath, expectedMarker, 'utf8')
+  }
+  pruneStaleDevBundles(distDir)
   process.env.ELECTRON_EXEC_PATH = executablePath
 }
 

--- a/config/scripts/run-electron-vite-dev.mjs
+++ b/config/scripts/run-electron-vite-dev.mjs
@@ -277,10 +277,14 @@ function prepareMacDevElectronApp() {
   if (
     rebuildProcessTable !== null &&
     isDevBundleInUse(distDir, rebuildProcessTable) &&
-    existsSync(executablePath)
+    // Why the same completeness check the cache path uses: a bundle missing Chromium's resources
+    // blank-crashes, and its orphaned crashpad helper still matches the process table -- so without
+    // this the runner would reuse a broken bundle forever and never be able to rebuild itself out.
+    existsSync(executablePath) &&
+    requiredResourcePaths.every((resourcePath) => existsSync(resourcePath))
   ) {
     console.warn(
-      `[orca-dev] Another dev instance is running from this bundle; reusing it instead of rebuilding.`
+      `[orca-dev] Another dev instance is running from this bundle; reusing it instead of rebuilding. Quit the other instance (or delete ${distDir}) to force a rebuild.`
     )
     process.env.ELECTRON_EXEC_PATH = executablePath
     return

--- a/config/scripts/run-electron-vite-dev.mjs
+++ b/config/scripts/run-electron-vite-dev.mjs
@@ -135,22 +135,35 @@ function getDevBundleProcessTable() {
 
 function pruneStaleDevBundles(distDir) {
   const root = path.dirname(distDir)
-  let dirs
+  let bundles
   try {
-    dirs = readdirSync(root, { withFileTypes: true })
+    bundles = readdirSync(root, { withFileTypes: true })
       .filter((entry) => entry.isDirectory())
-      .map((entry) => path.join(root, entry.name))
+      .map((entry) => {
+        const dir = path.join(root, entry.name)
+        return {
+          dir,
+          hasMarker: existsSync(path.join(dir, 'orca-dev-electron-app.json')),
+          mtimeMs: getMtimeMs(dir)
+        }
+      })
   } catch {
     return
   }
-  if (dirs.length <= 1) {
+  if (bundles.length <= 1) {
     return
   }
   const processTable = getDevBundleProcessTable()
   if (processTable === null) {
     return
   }
-  for (const dir of selectStaleDevBundleDirs({ dirs, currentDir: distDir, processTable })) {
+  const stale = selectStaleDevBundleDirs({
+    bundles,
+    currentDir: distDir,
+    processTable,
+    nowMs: Date.now()
+  })
+  for (const dir of stale) {
     try {
       rmSync(dir, { recursive: true, force: true })
     } catch {}

--- a/config/scripts/run-electron-vite-dev.mjs
+++ b/config/scripts/run-electron-vite-dev.mjs
@@ -17,7 +17,7 @@ import net from 'node:net'
 import { createRequire } from 'node:module'
 import path from 'node:path'
 import { prepareDevCliTerminalWrappers } from './dev-cli-terminal-wrapper.mjs'
-import { selectStaleDevBundleDirs } from './dev-electron-bundle-cache.mjs'
+import { isDevBundleInUse, selectStaleDevBundleDirs } from './dev-electron-bundle-cache.mjs'
 import {
   DEV_BUNDLE_ID,
   getDevBundlePlistPatches,
@@ -265,6 +265,23 @@ function prepareMacDevElectronApp() {
 
   if (copiedAppIsUsable()) {
     pruneStaleDevBundles(distDir)
+    process.env.ELECTRON_EXEC_PATH = executablePath
+    return
+  }
+
+  // Why this guard: a rebuild replaces this exact directory, and making the marker conditional on a
+  // successful sign means an unsigned bundle is a permanent cache miss -- so every later run would
+  // reach this rmSync while another instance is still running from it, deleting its app mid-session.
+  // Reusing what is there matches what the runner did before the marker became conditional.
+  const rebuildProcessTable = getDevBundleProcessTable()
+  if (
+    rebuildProcessTable !== null &&
+    isDevBundleInUse(distDir, rebuildProcessTable) &&
+    existsSync(executablePath)
+  ) {
+    console.warn(
+      `[orca-dev] Another dev instance is running from this bundle; reusing it instead of rebuilding.`
+    )
     process.env.ELECTRON_EXEC_PATH = executablePath
     return
   }

--- a/config/scripts/run-electron-vite-dev.mjs
+++ b/config/scripts/run-electron-vite-dev.mjs
@@ -232,15 +232,19 @@ function prepareMacDevElectronApp() {
     2
   )
   const executablePath = path.join(appPath, 'Contents', 'MacOS', 'Electron')
+  // Split by consequence: without this Chromium blank-crashes, so it gates whether the bundle can
+  // run at all. The keyboard-layout helper below is optional -- swiftc builds it non-fatally, so on
+  // a Mac without full Xcode it is simply absent and only a keyboard feature degrades.
+  const chromiumResourcePath = path.join(
+    appPath,
+    'Contents',
+    'Frameworks',
+    'Electron Framework.framework',
+    'Resources',
+    'icudtl.dat'
+  )
   const requiredResourcePaths = [
-    path.join(
-      appPath,
-      'Contents',
-      'Frameworks',
-      'Electron Framework.framework',
-      'Resources',
-      'icudtl.dat'
-    ),
+    chromiumResourcePath,
     path.join(appPath, 'Contents', 'MacOS', 'orca-keyboard-layout')
   ]
 
@@ -277,11 +281,13 @@ function prepareMacDevElectronApp() {
   if (
     rebuildProcessTable !== null &&
     isDevBundleInUse(distDir, rebuildProcessTable) &&
-    // Why the same completeness check the cache path uses: a bundle missing Chromium's resources
-    // blank-crashes, and its orphaned crashpad helper still matches the process table -- so without
-    // this the runner would reuse a broken bundle forever and never be able to rebuild itself out.
+    // Why a runnability check: a bundle missing Chromium's resources blank-crashes, and its
+    // orphaned crashpad helper still matches the process table -- so without this the runner would
+    // reuse a broken bundle forever and never rebuild itself out. Deliberately narrower than
+    // copiedAppIsUsable, which also demands the optional keyboard-layout helper: gating on that
+    // would strand every Mac without swiftc back on the rmSync path this guard exists to avoid.
     existsSync(executablePath) &&
-    requiredResourcePaths.every((resourcePath) => existsSync(resourcePath))
+    existsSync(chromiumResourcePath)
   ) {
     console.warn(
       `[orca-dev] Another dev instance is running from this bundle; reusing it instead of rebuilding. Quit the other instance (or delete ${distDir}) to force a rebuild.`

--- a/config/scripts/run-electron-vite-dev.mjs
+++ b/config/scripts/run-electron-vite-dev.mjs
@@ -116,18 +116,17 @@ function sanitizeMacAppBundleName(value) {
   )
 }
 
-function getLiveDevBundlePaths() {
-  // One `ps` for every instance, rather than one probe per directory. Not pgrep: macOS pgrep has no
-  // -a (that is a Linux procps extension) and silently prints bare PIDs, which would read as
-  // "nothing is running" and delete a live bundle. -ww prevents the command column being truncated.
+function getDevBundleProcessTable() {
+  // Not pgrep: macOS pgrep has no -a (a Linux procps extension) and silently prints bare PIDs,
+  // which reads as "nothing is running" and deletes a live bundle. -ww keeps the command column
+  // from being truncated. The raw text is searched directly; see dev-electron-bundle-cache.mjs
+  // for why it is deliberately not parsed into paths.
   try {
     return execFileSync('/bin/ps', ['-Awwo', 'command='], {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'ignore'],
       timeout: 5000
     })
-      .split('\n')
-      .flatMap((line) => line.match(/\/\S*\/out\/electron-dev\/[^\s/]+/g) ?? [])
   } catch {
     // Treating a failure as "nothing live" would risk deleting a running bundle, so skip pruning.
     return null
@@ -147,11 +146,11 @@ function pruneStaleDevBundles(distDir) {
   if (dirs.length <= 1) {
     return
   }
-  const livePaths = getLiveDevBundlePaths()
-  if (livePaths === null) {
+  const processTable = getDevBundleProcessTable()
+  if (processTable === null) {
     return
   }
-  for (const dir of selectStaleDevBundleDirs({ dirs, currentDir: distDir, livePaths })) {
+  for (const dir of selectStaleDevBundleDirs({ dirs, currentDir: distDir, processTable })) {
     try {
       rmSync(dir, { recursive: true, force: true })
     } catch {}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​137 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​137 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​151 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​142 |

<!-- /orca-pr-loc -->

Follow-up to #15183 (now merged). Two dev-runner cache bugs found while reviewing it.

## 1. Unsigned bundles were cached permanently

The marker that marks a bundle reusable was written outside the codesign `try/catch`:

```js
try { execFileSync('/usr/bin/codesign', …) } catch { console.warn(…) }
writeFileSync(markerPath, expectedMarker)   // ran even when signing failed
```

So a failed sign cached an **unsigned** bundle that was never rebuilt. The warning scrolls past once; every later launch silently reuses it. macOS refuses Notification Center registration for invalidly-signed apps, and with no stable cdhash the Keychain ACL can't match — it would resurface the exact prompt #15183 fixes, but sticky.

Now the marker is written only after a successful sign. A failure costs a re-copy per launch until signing works, and still doesn't block `pnpm dev` — the documented non-fatal behavior is preserved.

**Mutation-verified:** pointing codesign at a nonexistent binary produces the warning and leaves no marker.

## 2. Stale bundles were never reclaimed

`out/electron-dev` only ever cleared the directory it was about to rebuild. Siblings from renamed branches and past Electron upgrades accumulated forever — **143 directories / 38 GB** measured across one set of worktrees, at ~270 MB each.

Now siblings are pruned on every prepare, skipping any directory a live process is running from.

### The liveness check deliberately avoids `pgrep`

My first draft used `pgrep -af`. **macOS `pgrep` has no `-a`** — that's a Linux procps extension. It silently ignores it and prints bare PIDs, so the path regex matched nothing, `livePaths` came back empty, every bundle looked stale, and the prune **deleted a running instance's bundle**. Caught in testing:

```
dirs before second run: 24c30334d268
dirs after second run : 7fada60b28fd
FAIL: live bundle was deleted
```

It now parses `ps -Awwo command=` (`-ww` so the command column isn't truncated), and **skips pruning entirely if that call fails** — treating a failure as "nothing live" is the dangerous direction.

```
dirs before second: 24c30334d268
dirs after second : 24c30334d268 7fada60b28fd
PASS: live bundle survived the prune
```

…and it's reclaimed once that instance exits. Pruning is scoped to the worktree's own `out/electron-dev`, so it never touches another worktree.

## Tests

`selectStaleDevBundleDirs` is a pure function with 4 cases, including a path-boundary case so `…/aaaa2` isn't treated as in-use just because it prefixes `…/aaaa`. Full suite 1072 passing; typecheck, oxlint, max-lines ratchet clean.
