### PR TITLE
fix(orchestration): push Dispatch mailbox mail to idle workers (STA-3105)

### DIFF
--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -246,6 +246,7 @@ import {
 } from './orchestration/federation-ack-checkpoints'
 import { syncFederatedDispatch } from './orchestration/federation-sync'
 import { MailPointerRepointScheduler } from './orchestration/mail-pointer-repoint-scheduler'
+import { isOrchestrationMailboxAddress } from './orchestration/mailbox-address'
 import { OrchestrationMailboxOwner } from './orchestration/mailbox-owner'
 import { OrchestrationMailboxNotificationCoordinator } from './orchestration/mailbox-notification-coordinator'
 import { OrchestrationMailboxDeliveryTarget } from './orchestration/mailbox-delivery-target'
@@ -34345,10 +34346,7 @@ export class OrcaRuntimeService {
     }
     for (const handle of handles) {
       try {
-        if (handle.startsWith('dispatch:')) {
-          continue
-        }
-        if (handle.startsWith('run:')) {
+        if (isOrchestrationMailboxAddress(handle)) {
           this.mailPointerRepointScheduler.schedule(handle)
           continue
         }

--- a/src/main/runtime/orchestration-dispatch-mailbox-push.test.ts
+++ b/src/main/runtime/orchestration-dispatch-mailbox-push.test.ts
@@ -71,6 +71,12 @@ describe('dispatch mailbox push-on-idle', () => {
     await vi.advanceTimersByTimeAsync(600)
 
     expect(pointerCount(harness.write)).toBe(1)
+    // A Dispatch pointer carries no --run flag: the bare command is what resolves
+    // the caller's own Dispatch mailbox, so pinning it to a Run would misdirect the worker.
+    expect(harness.write).toHaveBeenCalledWith(
+      PTY_ID,
+      '\nYou have 1 orchestration message. Run `orca orchestration check`.\n'
+    )
     // The pointer must be backed by mail the worker's own check then returns.
     await expect(
       checkBoundMailbox(harness.runtime, {
@@ -130,6 +136,26 @@ describe('dispatch mailbox push-on-idle', () => {
     await vi.advanceTimersByTimeAsync(3_000)
 
     expect(pointerCount(harness.write)).toBe(1)
+    db.close()
+  })
+
+  it('releases only the push stamp of the mailbox that staged it', () => {
+    const db = createDatabase('orca-dispatch-push-release-')
+    const { run, dispatch } = dispatchToWorker(db)
+    const message = sendToDispatch(db, run.id, dispatch.id, 'push authorization')
+    db.markAsDelivered([message.id])
+
+    // The mail moves to the Run mailbox and the coordinator is pointed at it.
+    db.routeUnreadDispatchMailboxToRunMailbox(dispatch.id, run.id)
+    db.markAsDelivered([message.id])
+    // Only now does the worker's abandoned Dispatch pointer flight clean up.
+    db.markAsUndelivered([message.id], `dispatch:${dispatch.id}`)
+
+    // Releasing the stale Dispatch stamp must not re-arm a push the coordinator already had.
+    expect(db.getMessageById(message.id)).toMatchObject({
+      to_handle: `run:${run.id}`,
+      delivered_at: expect.any(String)
+    })
     db.close()
   })
 

--- a/src/main/runtime/orchestration-dispatch-mailbox-push.test.ts
+++ b/src/main/runtime/orchestration-dispatch-mailbox-push.test.ts
@@ -1,0 +1,152 @@
+import { rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  checkBoundMailbox,
+  createDatabase,
+  createRuntime,
+  driveToLiveIdle,
+  LAUNCH_TOKEN,
+  PANE_KEY,
+  pointerCount,
+  PTY_ID,
+  TERMINAL_HANDLE,
+  temporaryDirectories
+} from './orchestration-mailbox-notification-test-harness'
+
+vi.mock('electron', () => ({
+  app: { getPath: vi.fn(() => tmpdir()), isPackaged: false },
+  BrowserWindow: { fromId: vi.fn(() => null) },
+  ipcMain: { on: vi.fn(), removeListener: vi.fn() },
+  webContents: { fromId: vi.fn(() => null) }
+}))
+
+const COORDINATOR_PANE_KEY =
+  '55555555-5555-4555-8555-555555555555:66666666-6666-4666-8666-666666666666'
+
+function dispatchToWorker(db: OrchestrationTestDb) {
+  const run = db.createRun({
+    objective: 'Coordinator run',
+    coordinatorHandle: 'term_coordinator',
+    coordinatorPaneKey: COORDINATOR_PANE_KEY
+  })
+  const task = db.createTask({ spec: 'Worker task', runId: run.id })
+  return { run, dispatch: db.createDispatchContext(task.id, TERMINAL_HANDLE, PANE_KEY) }
+}
+
+type OrchestrationTestDb = ReturnType<typeof createDatabase>
+
+function sendToDispatch(
+  db: OrchestrationTestDb,
+  runId: string,
+  dispatchId: string,
+  subject: string
+) {
+  return db.insertMessage({
+    from: 'term_coordinator',
+    to: `dispatch:${dispatchId}`,
+    subject,
+    type: 'status',
+    runId,
+    deliveryContract: 'current_delivery'
+  })
+}
+
+describe('dispatch mailbox push-on-idle', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    for (const directory of temporaryDirectories.splice(0)) {
+      rmSync(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('points an idle worker at mail already waiting in its Dispatch mailbox', async () => {
+    vi.useFakeTimers()
+    const db = createDatabase('orca-dispatch-push-idle-')
+    const harness = createRuntime(db)
+    const { run, dispatch } = dispatchToWorker(db)
+    sendToDispatch(db, run.id, dispatch.id, 'push authorization')
+
+    await driveToLiveIdle(harness.runtime)
+    await vi.advanceTimersByTimeAsync(600)
+
+    expect(pointerCount(harness.write)).toBe(1)
+    // The pointer must be backed by mail the worker's own check then returns.
+    await expect(
+      checkBoundMailbox(harness.runtime, {
+        terminal: TERMINAL_HANDLE,
+        paneKey: PANE_KEY,
+        launchToken: LAUNCH_TOKEN
+      })
+    ).resolves.toMatchObject({ dispatchId: dispatch.id, count: 1 })
+    db.close()
+  })
+
+  it('points a worker that is already idle when Dispatch mail arrives', async () => {
+    vi.useFakeTimers()
+    const db = createDatabase('orca-dispatch-push-arrival-')
+    const harness = createRuntime(db)
+    const { run, dispatch } = dispatchToWorker(db)
+
+    await driveToLiveIdle(harness.runtime)
+    sendToDispatch(db, run.id, dispatch.id, 'rule update')
+    harness.runtime.notifyMessageArrived(`dispatch:${dispatch.id}`, 'status')
+    await vi.advanceTimersByTimeAsync(600)
+
+    expect(pointerCount(harness.write)).toBe(1)
+    db.close()
+  })
+
+  it('holds Dispatch mail for a busy worker until it returns to idle', async () => {
+    vi.useFakeTimers()
+    const db = createDatabase('orca-dispatch-push-busy-')
+    const harness = createRuntime(db)
+    const { run, dispatch } = dispatchToWorker(db)
+
+    await harness.runtime.listTerminals()
+    harness.runtime.onPtyData(PTY_ID, '\x1b]0;Codex working\x07', 1)
+    sendToDispatch(db, run.id, dispatch.id, 'urgent rule update')
+    harness.runtime.notifyMessageArrived(`dispatch:${dispatch.id}`, 'status')
+    await vi.advanceTimersByTimeAsync(600)
+    expect(pointerCount(harness.write)).toBe(0)
+
+    harness.runtime.onPtyData(PTY_ID, '\x1b]0;Codex done\x07', 2)
+    await vi.advanceTimersByTimeAsync(600)
+
+    expect(pointerCount(harness.write)).toBe(1)
+    db.close()
+  })
+
+  it('repoints Dispatch mail left unread when the database attaches', async () => {
+    vi.useFakeTimers()
+    const db = createDatabase('orca-dispatch-push-restore-')
+    const harness = createRuntime(db)
+    const { run, dispatch } = dispatchToWorker(db)
+
+    await driveToLiveIdle(harness.runtime)
+    // Mail that landed while the app was down raises no arrival notification.
+    sendToDispatch(db, run.id, dispatch.id, 'offline rule update')
+    harness.runtime.setOrchestrationDb(db)
+    await vi.advanceTimersByTimeAsync(3_000)
+
+    expect(pointerCount(harness.write)).toBe(1)
+    db.close()
+  })
+
+  it('clears the push stamp when unread mail changes mailbox owner', () => {
+    const db = createDatabase('orca-dispatch-push-reroute-')
+    const { run, dispatch } = dispatchToWorker(db)
+    const message = sendToDispatch(db, run.id, dispatch.id, 'push authorization')
+    db.markAsDelivered([message.id])
+
+    db.routeUnreadDispatchMailboxToRunMailbox(dispatch.id, run.id)
+
+    // The coordinator inherits the mail unpointed, so it must be pushable again.
+    expect(db.getMessageById(message.id)).toMatchObject({
+      to_handle: `run:${run.id}`,
+      read: 0,
+      delivered_at: null
+    })
+    db.close()
+  })
+})

--- a/src/main/runtime/orchestration-mailbox-detached-routing.test.ts
+++ b/src/main/runtime/orchestration-mailbox-detached-routing.test.ts
@@ -32,7 +32,7 @@ describe('orchestration detached mailbox routing', () => {
     }
   })
 
-  it('routes active worker direct mail without injecting an unpinned Dispatch pointer', async () => {
+  it('routes active worker direct mail into the Dispatch mailbox and points the worker at it', async () => {
     vi.useFakeTimers()
     const db = createDatabase('orca-mailbox-dispatch-')
     const harness = createRuntime(db)
@@ -57,13 +57,14 @@ describe('orchestration detached mailbox routing', () => {
     await vi.advanceTimersByTimeAsync(500)
     const checked = await checkBoundMailbox(harness.runtime)
 
-    expect(pointerCount(harness.write)).toBe(0)
+    // The pointer must be backed by mail the worker's own check then returns.
+    expect(pointerCount(harness.write)).toBe(1)
     expect(checked).toMatchObject({ runId: run.id, dispatchId: dispatch.id, count: 1 })
     expect(checked.messages).toEqual([expect.objectContaining({ id: message.id })])
     expect(db.getMessageById(message.id)).toMatchObject({
       to_handle: `dispatch:${dispatch.id}`,
       read: 1,
-      delivered_at: null
+      delivered_at: expect.any(String)
     })
     db.close()
   })

--- a/src/main/runtime/orchestration/db/messages/direct-mailbox-routing.ts
+++ b/src/main/runtime/orchestration/db/messages/direct-mailbox-routing.ts
@@ -36,6 +36,7 @@ export function getLatestUnreadDirectMessageSequenceForRun(
 }
 
 // Why: change mailbox ownership without changing unread or acknowledgment state.
+// The push stamp is owner-scoped, so it resets: the new owner was never pointed at this mail.
 export function routeDirectMessagePage(
   this: OrchestrationDb,
   mailboxHandle: string,
@@ -76,7 +77,7 @@ export function routeDirectMessagePage(
     const placeholders = page.map(() => '?').join(',')
     const result = this.db
       .prepare(
-        `UPDATE messages INDEXED BY idx_messages_id SET to_handle = ?
+        `UPDATE messages INDEXED BY idx_messages_id SET to_handle = ?, delivered_at = NULL
          WHERE run_id = ? AND to_handle = ? AND read = 0
            AND delivery_contract = 'current_delivery' AND id IN (${placeholders})`
       )
@@ -143,7 +144,7 @@ export function routeUnreadDispatchMailboxToRunMailbox(
     const placeholders = page.map(() => '?').join(',')
     const result = this.db
       .prepare(
-        `UPDATE messages INDEXED BY idx_messages_id SET to_handle = ?
+        `UPDATE messages INDEXED BY idx_messages_id SET to_handle = ?, delivered_at = NULL
          WHERE run_id = ? AND to_handle = ? AND read = 0
            AND delivery_contract = 'current_delivery'
            AND id IN (${placeholders})`

--- a/src/main/runtime/orchestration/db/messages/message-inbox.ts
+++ b/src/main/runtime/orchestration/db/messages/message-inbox.ts
@@ -9,7 +9,8 @@ const MESSAGE_MUTATION_SAVEPOINT = 'message_id_mutation'
 function runBatchedMessageMutation(
   db: OrchestrationDb,
   ids: string[],
-  sqlForPlaceholders: (placeholders: string) => string
+  sqlForPlaceholders: (placeholders: string) => string,
+  leadingParams: string[] = []
 ): void {
   if (ids.length === 0) {
     return
@@ -19,7 +20,7 @@ function runBatchedMessageMutation(
     for (let offset = 0; offset < ids.length; offset += MESSAGE_ID_UPDATE_BATCH_SIZE) {
       const batch = ids.slice(offset, offset + MESSAGE_ID_UPDATE_BATCH_SIZE)
       const placeholders = batch.map(() => '?').join(',')
-      db.db.prepare(sqlForPlaceholders(placeholders)).run(...batch)
+      db.db.prepare(sqlForPlaceholders(placeholders)).run(...leadingParams, ...batch)
     }
     db.db.exec(`RELEASE ${MESSAGE_MUTATION_SAVEPOINT}`)
   } catch (error) {
@@ -168,13 +169,20 @@ export function markAsDelivered(this: OrchestrationDb, ids: string[]): void {
   )
 }
 
-export function markAsUndelivered(this: OrchestrationDb, ids: string[]): void {
+// Why: the push stamp is owner-scoped, so an abandoned flight may only release the
+// mailbox it staged — the mail may since have moved on and been pointed at by its new owner.
+export function markAsUndelivered(
+  this: OrchestrationDb,
+  ids: string[],
+  mailboxHandle: string
+): void {
   runBatchedMessageMutation(
     this,
     ids,
     (placeholders) =>
       `UPDATE messages SET delivered_at = NULL
-       WHERE read = 0 AND id IN (${placeholders})`
+       WHERE read = 0 AND to_handle = ? AND id IN (${placeholders})`,
+    [mailboxHandle]
   )
 }
 

--- a/src/main/runtime/orchestration/mailbox-address.ts
+++ b/src/main/runtime/orchestration/mailbox-address.ts
@@ -1,0 +1,7 @@
+export const RUN_MAILBOX_PREFIX = 'run:'
+export const DISPATCH_MAILBOX_PREFIX = 'dispatch:'
+
+/** Shared Run/Dispatch mailboxes, as opposed to a direct terminal handle. */
+export function isOrchestrationMailboxAddress(handle: string): boolean {
+  return handle.startsWith(RUN_MAILBOX_PREFIX) || handle.startsWith(DISPATCH_MAILBOX_PREFIX)
+}

--- a/src/main/runtime/orchestration/mailbox-pointer-delivery.ts
+++ b/src/main/runtime/orchestration/mailbox-pointer-delivery.ts
@@ -3,6 +3,7 @@ import { ORCHESTRATION_DELIVERY_BATCH_LIMIT, type OrchestrationDb } from './db'
 import { formatMessagePointer } from './formatter'
 import type { OrchestrationMailboxDeliveryTarget } from './mailbox-delivery-target'
 import {
+  canPointAtMailbox,
   hasUnfilteredOrchestrationWaiter,
   messageTypeHasOrchestrationWaiter,
   shouldReleaseOrchestrationPointer,
@@ -65,13 +66,10 @@ export class OrchestrationMailboxPointerDelivery<TWaiter extends OrchestrationMe
   ): void {
     const db = this.deps.getDb()
     const mailboxHandle = options.mailboxHandle
-    if (!db || !mailboxHandle.startsWith('run:')) {
+    if (!db || !canPointAtMailbox(db, mailboxHandle)) {
       return
     }
     if (!this.deps.getTerminalHandleForLeafKey(this.leafKey(leaf))) {
-      return
-    }
-    if (db.hasOutstandingRunDelivery?.(mailboxHandle.slice('run:'.length))) {
       return
     }
     if (leaf.ptyId && this.state.hasFlight(leaf.ptyId)) {

--- a/src/main/runtime/orchestration/mailbox-pointer-delivery.ts
+++ b/src/main/runtime/orchestration/mailbox-pointer-delivery.ts
@@ -142,8 +142,8 @@ export class OrchestrationMailboxPointerDelivery<TWaiter extends OrchestrationMe
     if (flight?.enterTimer != null) {
       clearTimeout(flight.enterTimer)
     }
-    if (flight?.stagedMessageIds.length) {
-      this.deps.getDb()?.markAsUndelivered(flight.stagedMessageIds)
+    if (flight?.stagedMessageIds.length && flight.stagedMailboxHandle) {
+      this.deps.getDb()?.markAsUndelivered(flight.stagedMessageIds, flight.stagedMailboxHandle)
     }
     for (const mailboxHandle of releasedMailboxes) {
       this.redrive(mailboxHandle, true)
@@ -237,6 +237,7 @@ export class OrchestrationMailboxPointerDelivery<TWaiter extends OrchestrationMe
         return
       }
       flight.stagedMessageIds = unread.map((message) => message.id)
+      flight.stagedMailboxHandle = mailboxHandle
       db.markAsDelivered(flight.stagedMessageIds)
       this.state.setWatermark(mailboxHandle, newestSequence, ptyId, this.leafKey(leaf))
       if (

--- a/src/main/runtime/orchestration/mailbox-pointer-eligibility.ts
+++ b/src/main/runtime/orchestration/mailbox-pointer-eligibility.ts
@@ -1,4 +1,16 @@
 import type { OrchestrationDb } from './db'
+import { isOrchestrationMailboxAddress, RUN_MAILBOX_PREFIX } from './mailbox-address'
+
+/** A pointable mailbox is a Run/Dispatch address whose prior delivery is settled. */
+export function canPointAtMailbox(db: OrchestrationDb, mailboxHandle: string): boolean {
+  if (!isOrchestrationMailboxAddress(mailboxHandle)) {
+    return false
+  }
+  return !(
+    mailboxHandle.startsWith(RUN_MAILBOX_PREFIX) &&
+    db.hasOutstandingRunDelivery?.(mailboxHandle.slice(RUN_MAILBOX_PREFIX.length))
+  )
+}
 
 export type OrchestrationMessageWaiter = { typeFilter: string[] | undefined }
 

--- a/src/main/runtime/orchestration/mailbox-pointer-state.ts
+++ b/src/main/runtime/orchestration/mailbox-pointer-state.ts
@@ -3,6 +3,7 @@ import type { OrchestrationMailboxLeaf } from './mailbox-owner'
 export type OrchestrationMailboxDeliveryFlight = {
   enterTimer: ReturnType<typeof setTimeout> | null
   stagedMessageIds: string[]
+  stagedMailboxHandle: string | null
 }
 
 export type ParkedOrchestrationMailboxDelivery = {
@@ -28,7 +29,7 @@ export class OrchestrationMailboxPointerState {
   }
 
   beginFlight(ptyId: string): OrchestrationMailboxDeliveryFlight {
-    const flight = { enterTimer: null, stagedMessageIds: [] }
+    const flight = { enterTimer: null, stagedMessageIds: [], stagedMailboxHandle: null }
     this.flightsByPtyId.set(ptyId, flight)
     return flight
   }

--- a/src/main/runtime/orchestration/mailbox-pointer-submit.ts
+++ b/src/main/runtime/orchestration/mailbox-pointer-submit.ts
@@ -76,7 +76,10 @@ export function submitOrchestrationMailboxPointer<TWaiter extends OrchestrationM
       let released = false
       if (finalizeReservation) {
         if (clearAndRedrive) {
-          deps.getDb()?.markAsUndelivered(input.messages.map((message) => message.id))
+          deps.getDb()?.markAsUndelivered(
+            input.messages.map((message) => message.id),
+            input.mailboxHandle
+          )
         }
         released =
           submitted || clearAndRedrive || releaseWithoutRedrive

--- a/src/main/runtime/orchestration/message-batch-atomicity.test.ts
+++ b/src/main/runtime/orchestration/message-batch-atomicity.test.ts
@@ -2,12 +2,6 @@ import { afterEach, describe, expect, it } from 'vitest'
 import type Database from '../../sqlite/sync-database'
 import { OrchestrationDb } from './db'
 
-type MessageMutation =
-  | 'markAsRead'
-  | 'markAsDelivered'
-  | 'markAsUndelivered'
-  | 'markAsReadAndDelivered'
-
 const messageIds = Array.from(
   { length: 501 },
   (_, index) => `m${index.toString().padStart(3, '0')}`
@@ -40,26 +34,34 @@ describe('message batch atomicity', () => {
   afterEach(() => db?.close())
 
   it.each<{
-    method: MessageMutation
+    method: string
     setup?: string
     changedCountSql: string
+    mutate: (db: OrchestrationDb) => void
   }>([
-    { method: 'markAsRead', changedCountSql: 'SELECT COUNT(*) count FROM messages WHERE read = 1' },
+    {
+      method: 'markAsRead',
+      changedCountSql: 'SELECT COUNT(*) count FROM messages WHERE read = 1',
+      mutate: (db) => db.markAsRead(messageIds)
+    },
     {
       method: 'markAsDelivered',
-      changedCountSql: 'SELECT COUNT(*) count FROM messages WHERE delivered_at IS NOT NULL'
+      changedCountSql: 'SELECT COUNT(*) count FROM messages WHERE delivered_at IS NOT NULL',
+      mutate: (db) => db.markAsDelivered(messageIds)
     },
     {
       method: 'markAsUndelivered',
       setup: "UPDATE messages SET delivered_at = datetime('now')",
-      changedCountSql: 'SELECT COUNT(*) count FROM messages WHERE delivered_at IS NULL'
+      changedCountSql: 'SELECT COUNT(*) count FROM messages WHERE delivered_at IS NULL',
+      mutate: (db) => db.markAsUndelivered(messageIds, 'recipient')
     },
     {
       method: 'markAsReadAndDelivered',
       changedCountSql:
-        'SELECT COUNT(*) count FROM messages WHERE read = 1 OR delivered_at IS NOT NULL'
+        'SELECT COUNT(*) count FROM messages WHERE read = 1 OR delivered_at IS NOT NULL',
+      mutate: (db) => db.markAsReadAndDelivered(messageIds)
     }
-  ])('rolls back $method when a later batch fails', ({ method, setup, changedCountSql }) => {
+  ])('rolls back $method when a later batch fails', ({ setup, changedCountSql, mutate }) => {
     db = new OrchestrationDb(':memory:')
     const sqlite = (db as unknown as { db: Database.Database }).db
     seedMessages(sqlite)
@@ -68,7 +70,7 @@ describe('message batch atomicity', () => {
     }
     rejectLastMessageUpdate(sqlite)
 
-    expect(() => db?.[method](messageIds)).toThrow('blocked')
+    expect(() => mutate(db!)).toThrow('blocked')
 
     const changed = sqlite.prepare(changedCountSql).get() as { count: number }
     expect(changed.count).toBe(0)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​197 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​16 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​181 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​47 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​18 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​29 |

<!-- /orca-pr-loc -->

## Problem

Push-on-idle pointed only `run:` mailboxes. Mail addressed to `dispatch:<id>` — the address coordinator→worker mail lands on — was reachable by an explicit `orca orchestration check` but never announced, so an idle worker sat next to unread instructions indefinitely.

Reported on STA-3105 from a live campaign: four reviewers were sent three rule updates (one authorizing them to push fixes). All four `send` calls returned message ids; none of the four workers ever saw them. One finished a review, then correctly followed the now-stale instruction from its original dispatch spec and shipped nothing.

## Latest-main oracle

`src/main/runtime/orchestration-dispatch-mailbox-push.test.ts`, on a real `OrchestrationDb` + runtime. Before this change, an idle worker with unread `dispatch:<id>` mail produced **0** pointer writes while `check` returned `count: 1` — reachable, never announced. The `run:` control case passed under the identical harness, isolating the gap to the Dispatch address.

## What was wrong

Three boundaries carried the same `run:`-only assumption:

1. **Pointer delivery** refused any mailbox not prefixed `run:`.
2. **The restore scan** (`scheduleRestoredMessageRepoints`) `continue`d past `dispatch:` handles, so mail that arrived while the app was down was never repointed.
3. **Mailbox rerouting** moved `to_handle` while keeping `delivered_at`. Harmless before — Dispatch mail was never stamped — but once it can be pushed, a worker that is pointed at mail and then loses its dispatch would hand the coordinator mail that its own push path treats as already delivered.

## Fix

`canPointAtMailbox` (in `mailbox-pointer-eligibility.ts`) now decides pointability for Run **and** Dispatch addresses, keeping the outstanding-delivery guard scoped to Run mailboxes that actually have a `deliveries` ledger. A mailbox ownership change clears `delivered_at`, because the new owner was never pointed at that mail.

**Ack semantics are unchanged.** Dispatch mailboxes have no `deliveries` row and no `--ack` cycle; `delivered_at` alone dedupes the push, and `check` still consumes by marking rows read. The pointer text for a Dispatch mailbox is a bare `orca orchestration check`, which is exactly what resolves a worker's own active dispatch.

**Busy workers are still not interrupted.** Mail is held and pointed at the next idle edge, matching Run mailbox behaviour — a covered case in the new suite.

## Coverage

Each of the three changes is independently revert-red against the new suite (4/1/1 failures respectively).

`orchestration-mailbox-detached-routing.test.ts` had asserted `pointerCount === 0` for a worker whose direct mail was routed into its Dispatch mailbox, while also asserting that `check` returned that mail — it pinned the defect. It now asserts the pointer is written and is backed by what `check` returns, preserving the pointer/check consistency invariant that #13717 established.

## Validation

- `src/main/runtime` — 4579 passed, 5 skipped
- `src/shared` + `src/cli` — 5944 passed
- `typecheck:node`, `check:code-quality:changed` (0 new findings), `check:max-lines-ratchet` all clean

`mailbox-pointer-delivery.ts` sat exactly at the 300-line cap; the pointability check moved to the eligibility module rather than bumping the limit.


## Review follow-up

Independent cross-model review (three `gpt-5.6-luna` reviewers) found one real defect this PR introduced — an ID-scoped push-stamp release let an abandoned Dispatch flight clear the stamp its mail's new owner had set, making a duplicate pointer reachable. Fixed in c8a6aa3db2 with revert-red coverage; see the review summary comment for details.

A separate **pre-existing** issue was split out to STA-4729: mail addressed to a Dispatch that goes inactive before the worker reads it is stranded with no reader on either side. That is unchanged by this PR and is deliberately out of scope.

Post-review validation: **10524 tests pass** across `src/main/runtime`, `src/shared`, `src/cli`; `typecheck:node`, `check:code-quality:changed`, and `check:max-lines-ratchet` clean.

Closes STA-3105.
