### PR TITLE
fix(ssh): stop a failed relay --connect from orphaning the live relay (STA-1756)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -73,11 +73,15 @@ jobs:
 
       # Why: building here avoids parallel builds inside Playwright globalSetup;
       # paired-browser specs also need the standalone web bundle.
+      # Why build:relay: every SSH spec deploys the client's own relay build to the host, and
+      # without out/relay the connect fails at "local relay build is missing its version
+      # marker" — reaching those specs only when a change selects them.
       - name: Build Electron app for E2E
         env:
           VITE_EXPOSE_STORE: 'true'
         run: |
           npx electron-vite build --mode e2e
+          pnpm run build:relay
           pnpm run build:web-from-renderer
 
       - name: Upload E2E build output

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -385,6 +385,7 @@ jobs:
             --exclude=src/shared/posix-command-path-lookup.test.ts \
             --exclude=tests/e2e/cross-version-wire/** \
             --exclude=src/main/ssh/ssh-relay-socket-owner.integration.test.ts \
+            --exclude=src/main/ssh/ssh-relay-launch-ownership.integration.test.ts \
             --shard=${{ matrix.shard }}/${{ matrix.shard_total }}
 
   cross-version-wire:
@@ -429,7 +430,11 @@ jobs:
         with:
           persist-credentials: false
 
+      # Why native-runtime: the oracle spawns a real PTY on the daemon, and the default
+      # install skips scripts, which leaves node-pty without its native build.
       - uses: ./.github/actions/install-node-dependencies
+        with:
+          native-runtime: node
 
       # Why: the oracle runs real relay daemons, which need the bundled relay.js the
       # sharded test lane never builds.
@@ -439,7 +444,8 @@ jobs:
       - name: Test relay socket ownership against live daemons
         run: |
           pnpm exec vitest run --config config/vitest.config.ts \
-            src/main/ssh/ssh-relay-socket-owner.integration.test.ts
+            src/main/ssh/ssh-relay-socket-owner.integration.test.ts \
+            src/main/ssh/ssh-relay-launch-ownership.integration.test.ts
 
   managed_hook_node18:
     name: managed hooks on Node 18

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -384,6 +384,7 @@ jobs:
             --exclude=src/shared/startup-shell-portability.live-shell.test.ts \
             --exclude=src/shared/posix-command-path-lookup.test.ts \
             --exclude=tests/e2e/cross-version-wire/** \
+            --exclude=src/main/ssh/ssh-relay-socket-owner.integration.test.ts \
             --shard=${{ matrix.shard }}/${{ matrix.shard_total }}
 
   cross-version-wire:
@@ -412,6 +413,33 @@ jobs:
       # lane cannot report success while running zero tests.
       - name: Old/new client and server terminal journey
         run: pnpm exec vitest run --config config/vitest.config.ts tests/e2e/cross-version-wire/cross-version-terminal-wire.unit.test.ts
+
+  relay_socket_ownership:
+    name: relay socket ownership
+    runs-on: ubuntu-latest
+    env:
+      # Why: the oracle skips itself when out/relay is absent, which is right on a
+      # developer machine and wrong here — this job exists to run it, so a skip would
+      # report green with no daemon ever started. Turns that skip into a failure.
+      ORCA_REQUIRE_RELAY_BUNDLE: '1'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/install-node-dependencies
+
+      # Why: the oracle runs real relay daemons, which need the bundled relay.js the
+      # sharded test lane never builds.
+      - name: Build relay companions
+        run: pnpm run build:relay
+
+      - name: Test relay socket ownership against live daemons
+        run: |
+          pnpm exec vitest run --config config/vitest.config.ts \
+            src/main/ssh/ssh-relay-socket-owner.integration.test.ts
 
   managed_hook_node18:
     name: managed hooks on Node 18

--- a/src/main/ssh/ssh-relay-bridge-client.ts
+++ b/src/main/ssh/ssh-relay-bridge-client.ts
@@ -1,0 +1,125 @@
+// Drives a `relay.js --connect` bridge over its stdio, the same surface the SSH exec
+// channel gives the app, so tests can speak the relay's JSON-RPC to a live daemon.
+
+import { spawn, type ChildProcess } from 'node:child_process'
+import { join } from 'node:path'
+
+const FRAME_HEADER_BYTES = 13
+const MESSAGE_TYPE_REGULAR = 1
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+export class RelayBridge {
+  readonly process: ChildProcess
+  private buffer = Buffer.alloc(0)
+  private sentinelSeen = false
+  private nextId = 1
+  private readonly pending = new Map<
+    number,
+    { resolve: (value: never) => void; reject: (error: Error) => void }
+  >()
+
+  constructor(relayDir: string, sockPath: string, credentialFile: string) {
+    this.process = spawn(
+      process.execPath,
+      [
+        join(relayDir, 'relay.js'),
+        '--connect',
+        '--sock-path',
+        sockPath,
+        '--credential-file',
+        credentialFile
+      ],
+      { cwd: relayDir, stdio: ['pipe', 'pipe', 'pipe'] }
+    )
+    this.process.stderr?.resume()
+    this.process.stdout?.on('data', (chunk: Buffer) => this.ingest(chunk))
+  }
+
+  private ingest(chunk: Buffer): void {
+    this.buffer = Buffer.concat([this.buffer, chunk])
+    while (!this.sentinelSeen) {
+      const newline = this.buffer.indexOf('\n')
+      if (newline === -1) {
+        return
+      }
+      // Why: consume whole lines until the sentinel; a stray pre-sentinel line would
+      // otherwise be mistaken for it and desynchronise every frame after it.
+      const line = this.buffer.subarray(0, newline).toString('utf-8')
+      this.buffer = this.buffer.subarray(newline + 1)
+      this.sentinelSeen = line.includes('ORCA-RELAY')
+    }
+    while (this.buffer.length >= FRAME_HEADER_BYTES) {
+      const length = this.buffer.readUInt32BE(9)
+      if (this.buffer.length < FRAME_HEADER_BYTES + length) {
+        return
+      }
+      const type = this.buffer[0]
+      const payload = this.buffer.subarray(FRAME_HEADER_BYTES, FRAME_HEADER_BYTES + length)
+      this.buffer = this.buffer.subarray(FRAME_HEADER_BYTES + length)
+      if (type !== MESSAGE_TYPE_REGULAR) {
+        continue
+      }
+      let message: { id?: number; result?: unknown; error?: unknown }
+      try {
+        message = JSON.parse(payload.toString('utf-8'))
+      } catch {
+        continue
+      }
+      const waiter = message.id === undefined ? undefined : this.pending.get(message.id)
+      if (!waiter || message.id === undefined) {
+        continue
+      }
+      this.pending.delete(message.id)
+      if (message.error) {
+        waiter.reject(new Error(JSON.stringify(message.error)))
+      } else {
+        waiter.resolve(message.result as never)
+      }
+    }
+  }
+
+  async waitForSentinel(timeoutMs = 20_000): Promise<void> {
+    const start = Date.now()
+    while (Date.now() - start < timeoutMs) {
+      if (this.sentinelSeen) {
+        return
+      }
+      await delay(50)
+    }
+    throw new Error('relay --connect never emitted its sentinel')
+  }
+
+  request<T>(method: string, params: Record<string, unknown> = {}, timeoutMs = 20_000): Promise<T> {
+    const id = this.nextId++
+    const payload = Buffer.from(JSON.stringify({ jsonrpc: '2.0', id, method, params }), 'utf-8')
+    const header = Buffer.alloc(FRAME_HEADER_BYTES)
+    header[0] = MESSAGE_TYPE_REGULAR
+    header.writeUInt32BE(0, 1)
+    header.writeUInt32BE(0, 5)
+    header.writeUInt32BE(payload.length, 9)
+    return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id)
+        reject(new Error(`${method} timed out`))
+      }, timeoutMs)
+      this.pending.set(id, {
+        resolve: ((value: T) => {
+          clearTimeout(timer)
+          resolve(value)
+        }) as (value: never) => void,
+        reject: (error: Error) => {
+          clearTimeout(timer)
+          reject(error)
+        }
+      })
+      this.process.stdin?.write(Buffer.concat([header, payload]))
+    })
+  }
+
+  close(): void {
+    this.process.kill('SIGKILL')
+  }
+}

--- a/src/main/ssh/ssh-relay-deploy.test.ts
+++ b/src/main/ssh/ssh-relay-deploy.test.ts
@@ -186,27 +186,6 @@ describe('deployAndLaunchRelay', () => {
     expect(progress).toContain('Starting relay...')
   })
 
-  it('does not launch fresh after unconfirmed stale-socket cleanup', async () => {
-    const conn = makeMockConnection()
-    const unconfirmedCleanup = Object.assign(new Error('socket cleanup still running'), {
-      sshChannelCloseConfirmed: false
-    })
-    vi.mocked(waitForSentinel).mockRejectedValueOnce(new Error('stale relay reconnect failed'))
-    vi.mocked(execCommand)
-      .mockResolvedValueOnce('__ORCA_REMOTE_PLATFORM__ Linux x86_64')
-      .mockResolvedValueOnce('/home/user')
-      .mockResolvedValueOnce('ORCA-NATIVE-DEPS-OK')
-      .mockResolvedValueOnce('') // launch namespace marker
-      .mockResolvedValueOnce('ALIVE')
-      .mockRejectedValueOnce(unconfirmedCleanup)
-
-    await expect(deployAndLaunchRelay(conn)).rejects.toBe(unconfirmedCleanup)
-
-    const commands = vi.mocked(conn.exec).mock.calls.map(([command]) => command)
-    expect(commands).toHaveLength(1)
-    expect(commands.some((command) => command.includes('--detached'))).toBe(false)
-  })
-
   it('resolves the remote node path once per deploy', async () => {
     const conn = makeMockConnection()
     const mockExecCommand = vi.mocked(execCommand)

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -77,7 +77,7 @@ import {
 import { detectRemoteHostPlatform } from './ssh-remote-platform-detection'
 import { powerShellCommand, powerShellLiteral, powerShellNativeArg } from './ssh-remote-powershell'
 import { relaySocketNameForInstanceId } from './ssh-relay-instance-id'
-import { isRelaySocketOwnerLiveError, removeUnownedRelaySocket } from './ssh-relay-socket-owner'
+import { isRelaySocketOwnerLiveError, releaseUnownedRelaySocket } from './ssh-relay-socket-owner'
 import { isSshSessionLimitError } from './ssh-session-limit-error'
 import {
   isWindowsRelayPipePath,
@@ -1440,11 +1440,11 @@ async function launchRelay(
           '[ssh-relay] Socket reconnect failed:',
           err instanceof Error ? err.message : String(err)
         )
-        // Why: a refused --connect is loss of contact, never proof the relay died, so the socket is
-        // removed only once a probe shows nothing is listening. Unlinking a live owner's path cannot
-        // stop it — it just hides it from the fresh launch's EADDRINUSE check and orphans it and its
-        // PTYs forever (STA-1756). See docs/reference/ssh-execution-boundary.md.
-        await removeUnownedRelaySocket(conn, nodePath, sockFile, { signal, cause: err })
+        // Why: a refused --connect is loss of contact, never proof the relay died, so the socket
+        // is released only once the host proves nothing owns it. Unlinking a live owner's path
+        // cannot stop it — it just hides it from the fresh launch's EADDRINUSE check and orphans
+        // it and its PTYs forever (STA-1756).
+        await releaseUnownedRelaySocket(conn, nodePath, sockFile, { signal, cause: err })
       }
     }
   } catch (err) {

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -77,7 +77,7 @@ import {
 import { detectRemoteHostPlatform } from './ssh-remote-platform-detection'
 import { powerShellCommand, powerShellLiteral, powerShellNativeArg } from './ssh-remote-powershell'
 import { relaySocketNameForInstanceId } from './ssh-relay-instance-id'
-import { isRelaySocketOwnerLiveError, releaseUnownedRelaySocket } from './ssh-relay-socket-owner'
+import { isRelaySocketOwnerLiveError, requireUnownedRelaySocket } from './ssh-relay-socket-owner'
 import { isSshSessionLimitError } from './ssh-session-limit-error'
 import {
   isWindowsRelayPipePath,
@@ -1446,11 +1446,12 @@ export async function launchRelay(
           '[ssh-relay] Socket reconnect failed:',
           err instanceof Error ? err.message : String(err)
         )
-        // Why: a refused --connect is loss of contact, never proof the relay died, so the socket
-        // is released only once the host proves nothing owns it. Unlinking a live owner's path
-        // cannot stop it — it just hides it from the fresh launch's EADDRINUSE check and orphans
-        // it and its PTYs forever (STA-1756).
-        await releaseUnownedRelaySocket(conn, nodePath, sockFile, { signal, cause: err })
+        // Why: a refused --connect is loss of contact, never proof the relay died, so the path
+        // is only taken once the host proves nothing owns it. Launching over a live owner
+        // cannot stop it — it just hides it from the fresh daemon's EADDRINUSE check and
+        // orphans it and its PTYs forever (STA-1756). The daemon reclaims a proven-stale
+        // socket itself, under its own identity check.
+        await requireUnownedRelaySocket(conn, nodePath, sockFile, { signal, cause: err })
       }
     }
   } catch (err) {

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -1353,7 +1353,13 @@ export function getLocalRelayCandidates(platform: RelayPlatform): string[] {
   return [...new Set(candidates)]
 }
 
-async function launchRelay(
+/**
+ * Reconnect to the relay owning this target's socket, or launch a fresh detached one.
+ *
+ * Exported for the live-daemon ownership oracle, which drives this decision against real
+ * relay processes rather than asserting on the commands a mocked connection recorded.
+ */
+export async function launchRelay(
   conn: SshConnection,
   remoteDir: string,
   hostPlatform: RemoteHostPlatform,

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -77,6 +77,7 @@ import {
 import { detectRemoteHostPlatform } from './ssh-remote-platform-detection'
 import { powerShellCommand, powerShellLiteral, powerShellNativeArg } from './ssh-remote-powershell'
 import { relaySocketNameForInstanceId } from './ssh-relay-instance-id'
+import { isRelaySocketOwnerLiveError, removeUnownedRelaySocket } from './ssh-relay-socket-owner'
 import { isSshSessionLimitError } from './ssh-session-limit-error'
 import {
   isWindowsRelayPipePath,
@@ -1436,22 +1437,20 @@ async function launchRelay(
       } catch (err) {
         signal?.throwIfAborted()
         console.warn(
-          '[ssh-relay] Socket reconnect failed, launching fresh relay:',
+          '[ssh-relay] Socket reconnect failed:',
           err instanceof Error ? err.message : String(err)
         )
-        // Why: stale socket from a crashed relay — remove it so the fresh launch can bind at the same path.
-        await execCommand(conn, `rm -f ${shellEscape(sockFile)}`, { signal }).catch(
-          (cleanupErr) => {
-            if (isUnconfirmedSshCommandTermination(cleanupErr)) {
-              throw cleanupErr
-            }
-          }
-        )
-        signal?.throwIfAborted()
+        // Why: a refused --connect is loss of contact, never proof the relay died, so the socket is
+        // removed only once a probe shows nothing is listening. Unlinking a live owner's path cannot
+        // stop it — it just hides it from the fresh launch's EADDRINUSE check and orphans it and its
+        // PTYs forever (STA-1756). See docs/reference/ssh-execution-boundary.md.
+        await removeUnownedRelaySocket(conn, nodePath, sockFile, { signal, cause: err })
       }
     }
   } catch (err) {
-    if (isUnconfirmedSshCommandTermination(err)) {
+    if (isUnconfirmedSshCommandTermination(err) || isRelaySocketOwnerLiveError(err)) {
+      // Why rethrow: falling through would launch a fresh relay over a socket path whose
+      // owner is still listening, which is exactly the displacement this branch refused.
       throw err
     }
     signal?.throwIfAborted()

--- a/src/main/ssh/ssh-relay-launch-ownership.integration.test.ts
+++ b/src/main/ssh/ssh-relay-launch-ownership.integration.test.ts
@@ -1,0 +1,95 @@
+// The STA-1756 journey, end to end, through the production launch path.
+//
+// Everything here is real: a detached relay daemon holding a real PTY, a real `--connect`
+// bridge that the daemon refuses, and the shipping `launchRelay` deciding what to do about
+// the socket. The only substitution is the SSH transport, which runs the same command
+// strings through a local shell.
+//
+// Before this change that decision was "unlink the socket and start a replacement", which
+// left the incumbent alive, unreachable, and holding the user's shell forever.
+//
+// Requires `pnpm build:relay`; the relay_socket_ownership CI job builds it first.
+
+import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({ app: { getAppPath: () => process.cwd() } }))
+
+import { launchRelay } from './ssh-relay-deploy'
+import {
+  LiveRelayFixture,
+  createLocalShellConnection,
+  isProcessAlive,
+  relayBundleDirForHost
+} from './ssh-relay-live-daemon-harness'
+import { isRelaySocketOwnerLiveError } from './ssh-relay-socket-owner'
+import { getRemoteHostPlatform } from './ssh-remote-platform'
+
+const REPO_ROOT = process.cwd()
+const BUNDLE_DIR = relayBundleDirForHost(REPO_ROOT)
+const TARGET_ID = 'sta-1756-live-journey'
+
+if (process.env.ORCA_REQUIRE_RELAY_BUNDLE === '1' && !BUNDLE_DIR) {
+  throw new Error(
+    `No relay bundle at out/relay/${process.platform}-${process.arch}; run pnpm build:relay first.`
+  )
+}
+
+type RelayStatus = { pid: number; ptys: { active: number } }
+
+describe.skipIf(!BUNDLE_DIR || process.platform === 'win32')('launchRelay socket ownership', () => {
+  let fixture: LiveRelayFixture | null = null
+  let root: string | null = null
+
+  afterEach(async () => {
+    await fixture?.dispose()
+    fixture = null
+    if (root) {
+      rmSync(root, { recursive: true, force: true })
+      root = null
+    }
+  })
+
+  it('refuses to displace a live relay whose reconnect it cannot complete', async () => {
+    // Why the short prefix: sun_path caps a Unix socket at 104 bytes on macOS.
+    root = mkdtempSync(join(tmpdir(), 'orca-rel-'))
+    const live = new LiveRelayFixture(root, BUNDLE_DIR!, REPO_ROOT, TARGET_ID)
+    fixture = live
+    live.launchDaemon('incumbent')
+    expect(await live.waitForSocket()).toBe(true)
+
+    const bridge = live.openBridge()
+    await bridge.waitForSentinel()
+    await bridge.request('pty.spawn', { cwd: root, cols: 80, rows: 24 })
+    const incumbent = await bridge.request<RelayStatus>('relay.status')
+    expect(incumbent.ptys.active).toBe(1)
+    const mark = live.logMark('incumbent')
+    bridge.close()
+    await live.waitForClientDisconnect('incumbent', mark)
+
+    // Why rotate the credential: the daemon read it at startup and keeps it for life, so
+    // this is the real shape of a reconnect a healthy relay refuses — an interrupted deploy
+    // that rewrote the file after the daemon had already claimed the socket.
+    live.rotateCredential()
+
+    const hostPlatform = getRemoteHostPlatform(
+      process.platform === 'darwin' ? 'darwin-arm64' : 'linux-x64'
+    )
+    const error = await launchRelay(
+      createLocalShellConnection(),
+      root,
+      hostPlatform,
+      process.execPath,
+      0,
+      TARGET_ID
+    ).catch((err) => err)
+
+    expect(isRelaySocketOwnerLiveError(error)).toBe(true)
+    // The incumbent still owns its socket and its shell, and nothing was started over it.
+    expect(existsSync(live.sockPath)).toBe(true)
+    expect(isProcessAlive(incumbent.pid)).toBe(true)
+    expect(live.logMark('replacement')).toBe(0)
+  })
+})

--- a/src/main/ssh/ssh-relay-launch-ownership.integration.test.ts
+++ b/src/main/ssh/ssh-relay-launch-ownership.integration.test.ts
@@ -24,20 +24,14 @@ import {
   delay,
   isProcessAlive,
   killProcessTree,
-  relayBundleDirForHost
+  relayBundleDirOrFailWhenRequired
 } from './ssh-relay-live-daemon-harness'
 import { isRelaySocketOwnerLiveError } from './ssh-relay-socket-owner'
 import { getRemoteHostPlatform } from './ssh-remote-platform'
 
 const REPO_ROOT = process.cwd()
-const BUNDLE_DIR = relayBundleDirForHost(REPO_ROOT)
+const BUNDLE_DIR = relayBundleDirOrFailWhenRequired(REPO_ROOT)
 const TARGET_ID = 'sta-1756-live-journey'
-
-if (process.env.ORCA_REQUIRE_RELAY_BUNDLE === '1' && !BUNDLE_DIR) {
-  throw new Error(
-    `No relay bundle at out/relay/${process.platform}-${process.arch}; run pnpm build:relay first.`
-  )
-}
 
 type RelayStatus = { pid: number; ptys: { active: number } }
 

--- a/src/main/ssh/ssh-relay-launch-ownership.integration.test.ts
+++ b/src/main/ssh/ssh-relay-launch-ownership.integration.test.ts
@@ -21,7 +21,9 @@ import { launchRelay } from './ssh-relay-deploy'
 import {
   LiveRelayFixture,
   createLocalShellConnection,
+  delay,
   isProcessAlive,
+  killProcessTree,
   relayBundleDirForHost
 } from './ssh-relay-live-daemon-harness'
 import { isRelaySocketOwnerLiveError } from './ssh-relay-socket-owner'
@@ -38,6 +40,10 @@ if (process.env.ORCA_REQUIRE_RELAY_BUNDLE === '1' && !BUNDLE_DIR) {
 }
 
 type RelayStatus = { pid: number; ptys: { active: number } }
+
+const hostPlatform = getRemoteHostPlatform(
+  process.platform === 'darwin' ? 'darwin-arm64' : 'linux-x64'
+)
 
 describe.skipIf(!BUNDLE_DIR || process.platform === 'win32')('launchRelay socket ownership', () => {
   let fixture: LiveRelayFixture | null = null
@@ -74,9 +80,6 @@ describe.skipIf(!BUNDLE_DIR || process.platform === 'win32')('launchRelay socket
     // that rewrote the file after the daemon had already claimed the socket.
     live.rotateCredential()
 
-    const hostPlatform = getRemoteHostPlatform(
-      process.platform === 'darwin' ? 'darwin-arm64' : 'linux-x64'
-    )
     const error = await launchRelay(
       createLocalShellConnection(),
       root,
@@ -91,5 +94,43 @@ describe.skipIf(!BUNDLE_DIR || process.platform === 'win32')('launchRelay socket
     expect(existsSync(live.sockPath)).toBe(true)
     expect(isProcessAlive(incumbent.pid)).toBe(true)
     expect(live.logMark('replacement')).toBe(0)
+  })
+
+  // Why this pairs with the test above: reset no longer unlinks the socket it stopped, so the
+  // inode a killed relay leaves behind has to be the deploy path's problem — and it is.
+  it('takes over the socket a killed relay left behind', async () => {
+    root = mkdtempSync(join(tmpdir(), 'orca-rel-'))
+    const live = new LiveRelayFixture(root, BUNDLE_DIR!, REPO_ROOT, TARGET_ID)
+    fixture = live
+    live.launchDaemon('incumbent')
+    expect(await live.waitForSocket()).toBe(true)
+
+    const bridge = live.openBridge()
+    await bridge.waitForSentinel()
+    const incumbent = await bridge.request<RelayStatus>('relay.status')
+    bridge.close()
+
+    // A relay stopped by reset (or a crash) leaves its socket inode behind.
+    killProcessTree(incumbent.pid)
+    for (let attempt = 0; attempt < 50 && isProcessAlive(incumbent.pid); attempt++) {
+      await delay(100)
+    }
+    expect(existsSync(live.sockPath)).toBe(true)
+
+    const launched = await launchRelay(
+      createLocalShellConnection(),
+      root,
+      hostPlatform,
+      process.execPath,
+      0,
+      TARGET_ID
+    )
+
+    expect(launched.sockPath).toBe(live.sockPath)
+    const fresh = live.openBridge()
+    await fresh.waitForSentinel()
+    const status = await fresh.request<RelayStatus>('relay.status')
+    expect(status.pid).not.toBe(incumbent.pid)
+    fresh.close()
   })
 })

--- a/src/main/ssh/ssh-relay-live-daemon-harness.ts
+++ b/src/main/ssh/ssh-relay-live-daemon-harness.ts
@@ -1,0 +1,279 @@
+// Runs real relay daemons on the host that runs the test, so socket-ownership
+// claims are settled by actual processes rather than by mocked exec output.
+//
+// Needs `pnpm build:relay` — callers skip when relayBundleDirForHost() is null.
+
+import { spawn, type ChildProcess } from 'node:child_process'
+import { randomBytes } from 'node:crypto'
+import { EventEmitter } from 'node:events'
+import { cpSync, existsSync, mkdirSync, symlinkSync, writeFileSync } from 'node:fs'
+import { connect } from 'node:net'
+import { join } from 'node:path'
+import type { SshConnection } from './ssh-connection'
+
+const FRAME_HEADER_BYTES = 13
+const MESSAGE_TYPE_REGULAR = 1
+
+export function relayBundleDirForHost(repoRoot: string): string | null {
+  const dir = join(repoRoot, 'out', 'relay', `${process.platform}-${process.arch}`)
+  return existsSync(join(dir, 'relay.js')) ? dir : null
+}
+
+export function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+export function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export class LiveRelayFixture {
+  readonly sockPath: string
+  readonly credentialFile: string
+  private readonly children = new Set<ChildProcess>()
+  private readonly daemonPids = new Set<number>()
+
+  constructor(
+    readonly relayDir: string,
+    bundleDir: string,
+    repoRoot: string
+  ) {
+    mkdirSync(relayDir, { recursive: true })
+    cpSync(bundleDir, relayDir, { recursive: true })
+    // Why: node-pty is external to the relay bundle and must resolve beside relay.js.
+    symlinkSync(join(repoRoot, 'node_modules'), join(relayDir, 'node_modules'))
+    this.sockPath = join(relayDir, 'relay-ownership.sock')
+    this.credentialFile = join(relayDir, 'relay-ownership.credential')
+    writeFileSync(this.credentialFile, randomBytes(32).toString('base64url'), { mode: 0o600 })
+  }
+
+  /** Launch a detached daemon exactly as ssh-relay-deploy does: --detached --grace-time 0. */
+  launchDaemon(label: string): ChildProcess {
+    const child = spawn(
+      process.execPath,
+      [
+        join(this.relayDir, 'relay.js'),
+        '--detached',
+        '--grace-time',
+        '0',
+        '--sock-path',
+        this.sockPath,
+        '--credential-file',
+        this.credentialFile,
+        '--log-file',
+        join(this.relayDir, `relay-${label}.log`)
+      ],
+      {
+        cwd: this.relayDir,
+        detached: true,
+        stdio: 'ignore',
+        env: { ...process.env, ORCA_DISABLE_MACOS_LOGIN_SHELL: '1' }
+      }
+    )
+    child.unref()
+    if (child.pid) {
+      this.daemonPids.add(child.pid)
+    }
+    this.children.add(child)
+    return child
+  }
+
+  /** 'READY' when a listener accepted, otherwise the connect error code. */
+  connectProbe(): Promise<string> {
+    return new Promise((resolve) => {
+      const sock = connect(this.sockPath)
+      sock.once('connect', () => {
+        sock.destroy()
+        resolve('READY')
+      })
+      sock.once('error', (err: NodeJS.ErrnoException) => resolve(err.code ?? 'ERROR'))
+    })
+  }
+
+  async waitForSocket(timeoutMs = 20_000): Promise<boolean> {
+    const start = Date.now()
+    while (Date.now() - start < timeoutMs) {
+      if ((await this.connectProbe()) === 'READY') {
+        return true
+      }
+      await delay(100)
+    }
+    return false
+  }
+
+  openBridge(): RelayBridge {
+    const bridge = new RelayBridge(this.relayDir, this.sockPath, this.credentialFile)
+    this.children.add(bridge.process)
+    return bridge
+  }
+
+  dispose(): void {
+    for (const child of this.children) {
+      try {
+        child.kill('SIGKILL')
+      } catch {
+        /* already gone */
+      }
+    }
+    for (const pid of this.daemonPids) {
+      try {
+        process.kill(pid, 'SIGKILL')
+      } catch {
+        /* already gone */
+      }
+    }
+  }
+}
+
+/** A `relay.js --connect` bridge, driven over its stdio like the SSH exec channel does. */
+export class RelayBridge {
+  readonly process: ChildProcess
+  private buffer = Buffer.alloc(0)
+  private sentinelSeen = false
+  private nextId = 1
+  private readonly pending = new Map<
+    number,
+    { resolve: (value: never) => void; reject: (error: Error) => void }
+  >()
+
+  constructor(relayDir: string, sockPath: string, credentialFile: string) {
+    this.process = spawn(
+      process.execPath,
+      [
+        join(relayDir, 'relay.js'),
+        '--connect',
+        '--sock-path',
+        sockPath,
+        '--credential-file',
+        credentialFile
+      ],
+      { cwd: relayDir, stdio: ['pipe', 'pipe', 'pipe'] }
+    )
+    this.process.stderr?.resume()
+    this.process.stdout?.on('data', (chunk: Buffer) => this.ingest(chunk))
+  }
+
+  private ingest(chunk: Buffer): void {
+    this.buffer = Buffer.concat([this.buffer, chunk])
+    if (!this.sentinelSeen) {
+      const newline = this.buffer.indexOf('\n')
+      if (newline === -1) {
+        return
+      }
+      this.sentinelSeen = true
+      this.buffer = this.buffer.subarray(newline + 1)
+    }
+    while (this.buffer.length >= FRAME_HEADER_BYTES) {
+      const length = this.buffer.readUInt32BE(9)
+      if (this.buffer.length < FRAME_HEADER_BYTES + length) {
+        return
+      }
+      const type = this.buffer[0]
+      const payload = this.buffer.subarray(FRAME_HEADER_BYTES, FRAME_HEADER_BYTES + length)
+      this.buffer = this.buffer.subarray(FRAME_HEADER_BYTES + length)
+      if (type !== MESSAGE_TYPE_REGULAR) {
+        continue
+      }
+      let message: { id?: number; result?: unknown; error?: unknown }
+      try {
+        message = JSON.parse(payload.toString('utf-8'))
+      } catch {
+        continue
+      }
+      const waiter = message.id === undefined ? undefined : this.pending.get(message.id)
+      if (!waiter || message.id === undefined) {
+        continue
+      }
+      this.pending.delete(message.id)
+      if (message.error) {
+        waiter.reject(new Error(JSON.stringify(message.error)))
+      } else {
+        waiter.resolve(message.result as never)
+      }
+    }
+  }
+
+  async waitForSentinel(timeoutMs = 20_000): Promise<void> {
+    const start = Date.now()
+    while (Date.now() - start < timeoutMs) {
+      if (this.sentinelSeen) {
+        return
+      }
+      await delay(50)
+    }
+    throw new Error('relay --connect never emitted its sentinel')
+  }
+
+  request<T>(method: string, params: Record<string, unknown> = {}, timeoutMs = 20_000): Promise<T> {
+    const id = this.nextId++
+    const payload = Buffer.from(JSON.stringify({ jsonrpc: '2.0', id, method, params }), 'utf-8')
+    const header = Buffer.alloc(FRAME_HEADER_BYTES)
+    header[0] = MESSAGE_TYPE_REGULAR
+    header.writeUInt32BE(0, 1)
+    header.writeUInt32BE(0, 5)
+    header.writeUInt32BE(payload.length, 9)
+    return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id)
+        reject(new Error(`${method} timed out`))
+      }, timeoutMs)
+      this.pending.set(id, {
+        resolve: ((value: T) => {
+          clearTimeout(timer)
+          resolve(value)
+        }) as (value: never) => void,
+        reject: (error: Error) => {
+          clearTimeout(timer)
+          reject(error)
+        }
+      })
+      this.process.stdin?.write(Buffer.concat([header, payload]))
+    })
+  }
+
+  close(): void {
+    this.process.kill('SIGKILL')
+  }
+}
+
+/**
+ * An SshConnection whose exec runs on this machine, so production command
+ * strings and production execCommand parsing are both exercised for real.
+ */
+export function createLocalShellConnection(): SshConnection {
+  return {
+    usesSystemSshTransport: () => false,
+    canRunConcurrentExecCommands: () => true,
+    exec: (command: string) => Promise.resolve(createLocalShellChannel(command))
+  } as unknown as SshConnection
+}
+
+function createLocalShellChannel(command: string): EventEmitter & {
+  stderr: EventEmitter
+  close: () => void
+  resume: () => void
+} {
+  const channel = new EventEmitter() as EventEmitter & {
+    stderr: EventEmitter & { resume: () => void }
+    close: () => void
+    resume: () => void
+  }
+  const stderr = new EventEmitter() as EventEmitter & { resume: () => void }
+  stderr.resume = (): void => {}
+  channel.stderr = stderr
+  channel.resume = (): void => {}
+  const child = spawn('/bin/sh', ['-c', command])
+  channel.close = (): void => {
+    child.kill('SIGKILL')
+  }
+  child.stdout.on('data', (chunk: Buffer) => channel.emit('data', chunk))
+  child.stderr.on('data', (chunk: Buffer) => stderr.emit('data', chunk))
+  child.on('error', (error: Error) => channel.emit('error', error))
+  child.on('close', (code: number | null) => channel.emit('close', code ?? 0))
+  return channel
+}

--- a/src/main/ssh/ssh-relay-live-daemon-harness.ts
+++ b/src/main/ssh/ssh-relay-live-daemon-harness.ts
@@ -4,15 +4,13 @@
 // Needs `pnpm build:relay` — callers skip when relayBundleDirForHost() is null.
 
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
+import { RelayBridge } from './ssh-relay-bridge-client'
 import { randomBytes } from 'node:crypto'
 import { EventEmitter } from 'node:events'
-import { cpSync, existsSync, mkdirSync, symlinkSync, writeFileSync } from 'node:fs'
+import { cpSync, existsSync, mkdirSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs'
 import { connect } from 'node:net'
 import { join } from 'node:path'
 import type { SshConnection } from './ssh-connection'
-
-const FRAME_HEADER_BYTES = 13
-const MESSAGE_TYPE_REGULAR = 1
 
 export function relayBundleDirForHost(repoRoot: string): string | null {
   const dir = join(repoRoot, 'out', 'relay', `${process.platform}-${process.arch}`)
@@ -80,7 +78,7 @@ export function waitForExit(child: ChildProcess, timeoutMs = 20_000): Promise<nu
 export class LiveRelayFixture {
   readonly sockPath: string
   readonly credentialFile: string
-  private readonly children = new Set<ChildProcess>()
+  private readonly bridges = new Set<ChildProcess>()
   private readonly daemonPids = new Set<number>()
 
   constructor(
@@ -124,7 +122,8 @@ export class LiveRelayFixture {
     if (child.pid) {
       this.daemonPids.add(child.pid)
     }
-    this.children.add(child)
+    // Why not tracked as a bridge child: bridges are SIGKILLed on teardown, and a daemon
+    // killed that way never runs the SIGTERM shutdown that disposes its PTYs.
     return child
   }
 
@@ -153,15 +152,15 @@ export class LiveRelayFixture {
 
   openBridge(): RelayBridge {
     const bridge = new RelayBridge(this.relayDir, this.sockPath, this.credentialFile)
-    this.children.add(bridge.process)
+    this.bridges.add(bridge.process)
     return bridge
   }
 
   /** Ask each daemon to shut down (which disposes its PTYs), then kill whatever is left. */
   async dispose(): Promise<void> {
-    for (const child of this.children) {
+    for (const bridge of this.bridges) {
       try {
-        child.kill('SIGKILL')
+        bridge.kill('SIGKILL')
       } catch {
         /* already gone */
       }
@@ -173,126 +172,28 @@ export class LiveRelayFixture {
         /* already gone */
       }
     }
-    for (let attempt = 0; attempt < 30 && [...this.daemonPids].some(isProcessAlive); attempt++) {
+    for (let attempt = 0; attempt < 50 && [...this.daemonPids].some(isProcessAlive); attempt++) {
       await delay(100)
     }
+    // Why a tree kill as the fallback: a daemon that ignored SIGTERM still owns PTY shells,
+    // and killing it alone would reparent them to init — the leak these tests are about.
     for (const pid of this.daemonPids) {
       killProcessTree(pid)
     }
   }
-}
 
-/** A `relay.js --connect` bridge, driven over its stdio like the SSH exec channel does. */
-export class RelayBridge {
-  readonly process: ChildProcess
-  private buffer = Buffer.alloc(0)
-  private sentinelSeen = false
-  private nextId = 1
-  private readonly pending = new Map<
-    number,
-    { resolve: (value: never) => void; reject: (error: Error) => void }
-  >()
-
-  constructor(relayDir: string, sockPath: string, credentialFile: string) {
-    this.process = spawn(
-      process.execPath,
-      [
-        join(relayDir, 'relay.js'),
-        '--connect',
-        '--sock-path',
-        sockPath,
-        '--credential-file',
-        credentialFile
-      ],
-      { cwd: relayDir, stdio: ['pipe', 'pipe', 'pipe'] }
-    )
-    this.process.stderr?.resume()
-    this.process.stdout?.on('data', (chunk: Buffer) => this.ingest(chunk))
-  }
-
-  private ingest(chunk: Buffer): void {
-    this.buffer = Buffer.concat([this.buffer, chunk])
-    while (!this.sentinelSeen) {
-      const newline = this.buffer.indexOf('\n')
-      if (newline === -1) {
-        return
-      }
-      // Why: consume whole lines until the sentinel; a stray pre-sentinel line would
-      // otherwise be mistaken for it and desynchronise every frame after it.
-      const line = this.buffer.subarray(0, newline).toString('utf-8')
-      this.buffer = this.buffer.subarray(newline + 1)
-      this.sentinelSeen = line.includes('ORCA-RELAY')
-    }
-    while (this.buffer.length >= FRAME_HEADER_BYTES) {
-      const length = this.buffer.readUInt32BE(9)
-      if (this.buffer.length < FRAME_HEADER_BYTES + length) {
-        return
-      }
-      const type = this.buffer[0]
-      const payload = this.buffer.subarray(FRAME_HEADER_BYTES, FRAME_HEADER_BYTES + length)
-      this.buffer = this.buffer.subarray(FRAME_HEADER_BYTES + length)
-      if (type !== MESSAGE_TYPE_REGULAR) {
-        continue
-      }
-      let message: { id?: number; result?: unknown; error?: unknown }
-      try {
-        message = JSON.parse(payload.toString('utf-8'))
-      } catch {
-        continue
-      }
-      const waiter = message.id === undefined ? undefined : this.pending.get(message.id)
-      if (!waiter || message.id === undefined) {
-        continue
-      }
-      this.pending.delete(message.id)
-      if (message.error) {
-        waiter.reject(new Error(JSON.stringify(message.error)))
-      } else {
-        waiter.resolve(message.result as never)
-      }
-    }
-  }
-
-  async waitForSentinel(timeoutMs = 20_000): Promise<void> {
+  /** Resolve once the daemon's log records that its last client went away. */
+  async waitForClientDisconnect(label: string, timeoutMs = 20_000): Promise<void> {
+    const logPath = join(this.relayDir, `relay-${label}.log`)
     const start = Date.now()
     while (Date.now() - start < timeoutMs) {
-      if (this.sentinelSeen) {
+      const log = existsSync(logPath) ? readFileSync(logPath, 'utf-8') : ''
+      if (log.includes('Socket client closed (clients=0)')) {
         return
       }
       await delay(50)
     }
-    throw new Error('relay --connect never emitted its sentinel')
-  }
-
-  request<T>(method: string, params: Record<string, unknown> = {}, timeoutMs = 20_000): Promise<T> {
-    const id = this.nextId++
-    const payload = Buffer.from(JSON.stringify({ jsonrpc: '2.0', id, method, params }), 'utf-8')
-    const header = Buffer.alloc(FRAME_HEADER_BYTES)
-    header[0] = MESSAGE_TYPE_REGULAR
-    header.writeUInt32BE(0, 1)
-    header.writeUInt32BE(0, 5)
-    header.writeUInt32BE(payload.length, 9)
-    return new Promise<T>((resolve, reject) => {
-      const timer = setTimeout(() => {
-        this.pending.delete(id)
-        reject(new Error(`${method} timed out`))
-      }, timeoutMs)
-      this.pending.set(id, {
-        resolve: ((value: T) => {
-          clearTimeout(timer)
-          resolve(value)
-        }) as (value: never) => void,
-        reject: (error: Error) => {
-          clearTimeout(timer)
-          reject(error)
-        }
-      })
-      this.process.stdin?.write(Buffer.concat([header, payload]))
-    })
-  }
-
-  close(): void {
-    this.process.kill('SIGKILL')
+    throw new Error(`relay ${label} never reported its last client closing`)
   }
 }
 
@@ -300,15 +201,19 @@ export class RelayBridge {
  * An SshConnection whose exec runs on this machine, so production command
  * strings and production execCommand parsing are both exercised for real.
  */
-export function createLocalShellConnection(): SshConnection {
+export function createLocalShellConnection(options?: { path?: string }): SshConnection {
   return {
     usesSystemSshTransport: () => false,
     canRunConcurrentExecCommands: () => true,
-    exec: (command: string) => Promise.resolve(createLocalShellChannel(command))
+    exec: (command: string) => Promise.resolve(createLocalShellChannel(command, options?.path))
   } as unknown as SshConnection
 }
 
-function createLocalShellChannel(command: string): EventEmitter & {
+/** `path` overrides PATH, so a caller can model a host without lsof or pgrep. */
+function createLocalShellChannel(
+  command: string,
+  path?: string
+): EventEmitter & {
   stderr: EventEmitter
   close: () => void
   resume: () => void
@@ -322,7 +227,9 @@ function createLocalShellChannel(command: string): EventEmitter & {
   stderr.resume = (): void => {}
   channel.stderr = stderr
   channel.resume = (): void => {}
-  const child = spawn('/bin/sh', ['-c', command])
+  const child = spawn('/bin/sh', ['-c', command], {
+    env: path === undefined ? process.env : { ...process.env, PATH: path }
+  })
   channel.close = (): void => {
     child.kill('SIGKILL')
   }

--- a/src/main/ssh/ssh-relay-live-daemon-harness.ts
+++ b/src/main/ssh/ssh-relay-live-daemon-harness.ts
@@ -3,7 +3,7 @@
 //
 // Needs `pnpm build:relay` — callers skip when relayBundleDirForHost() is null.
 
-import { spawn, type ChildProcess } from 'node:child_process'
+import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
 import { randomBytes } from 'node:crypto'
 import { EventEmitter } from 'node:events'
 import { cpSync, existsSync, mkdirSync, symlinkSync, writeFileSync } from 'node:fs'
@@ -30,6 +30,51 @@ export function isProcessAlive(pid: number): boolean {
   } catch {
     return false
   }
+}
+
+/**
+ * SIGKILL a process and every descendant, deepest first.
+ *
+ * Why: a relay killed on its own leaves its PTY shells reparented to init — the very
+ * leak these tests are about, reproduced on the machine running them.
+ */
+export function killProcessTree(pid: number): void {
+  const listing = spawnSync('ps', ['-eo', 'pid=,ppid=']).stdout?.toString() ?? ''
+  const childrenByParent = new Map<number, number[]>()
+  for (const line of listing.split('\n')) {
+    const [child, parent] = line.trim().split(/\s+/).map(Number)
+    if (Number.isInteger(child) && Number.isInteger(parent)) {
+      childrenByParent.set(parent, [...(childrenByParent.get(parent) ?? []), child])
+    }
+  }
+  const ordered: number[] = []
+  const visit = (current: number): void => {
+    for (const child of childrenByParent.get(current) ?? []) {
+      visit(child)
+    }
+    ordered.push(current)
+  }
+  visit(pid)
+  for (const target of ordered) {
+    try {
+      process.kill(target, 'SIGKILL')
+    } catch {
+      /* already gone */
+    }
+  }
+}
+
+export function waitForExit(child: ChildProcess, timeoutMs = 20_000): Promise<number | null> {
+  if (child.exitCode !== null) {
+    return Promise.resolve(child.exitCode)
+  }
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('relay daemon never exited')), timeoutMs)
+    child.once('exit', (code) => {
+      clearTimeout(timer)
+      resolve(code)
+    })
+  })
 }
 
 export class LiveRelayFixture {
@@ -112,7 +157,8 @@ export class LiveRelayFixture {
     return bridge
   }
 
-  dispose(): void {
+  /** Ask each daemon to shut down (which disposes its PTYs), then kill whatever is left. */
+  async dispose(): Promise<void> {
     for (const child of this.children) {
       try {
         child.kill('SIGKILL')
@@ -122,10 +168,16 @@ export class LiveRelayFixture {
     }
     for (const pid of this.daemonPids) {
       try {
-        process.kill(pid, 'SIGKILL')
+        process.kill(pid, 'SIGTERM')
       } catch {
         /* already gone */
       }
+    }
+    for (let attempt = 0; attempt < 30 && [...this.daemonPids].some(isProcessAlive); attempt++) {
+      await delay(100)
+    }
+    for (const pid of this.daemonPids) {
+      killProcessTree(pid)
     }
   }
 }
@@ -160,13 +212,16 @@ export class RelayBridge {
 
   private ingest(chunk: Buffer): void {
     this.buffer = Buffer.concat([this.buffer, chunk])
-    if (!this.sentinelSeen) {
+    while (!this.sentinelSeen) {
       const newline = this.buffer.indexOf('\n')
       if (newline === -1) {
         return
       }
-      this.sentinelSeen = true
+      // Why: consume whole lines until the sentinel; a stray pre-sentinel line would
+      // otherwise be mistaken for it and desynchronise every frame after it.
+      const line = this.buffer.subarray(0, newline).toString('utf-8')
       this.buffer = this.buffer.subarray(newline + 1)
+      this.sentinelSeen = line.includes('ORCA-RELAY')
     }
     while (this.buffer.length >= FRAME_HEADER_BYTES) {
       const length = this.buffer.readUInt32BE(9)

--- a/src/main/ssh/ssh-relay-live-daemon-harness.ts
+++ b/src/main/ssh/ssh-relay-live-daemon-harness.ts
@@ -27,6 +27,24 @@ export function relayBundleDirForHost(repoRoot: string): string | null {
   return existsSync(join(dir, 'relay.js')) ? dir : null
 }
 
+/**
+ * The bundle these oracles need, or null so the caller can skip.
+ *
+ * Why the env guard: skipping is right on a developer machine that never ran
+ * `pnpm build:relay`, and wrong in the CI job that exists to run these files — there a skip
+ * is green with no daemon ever started. The job sets ORCA_REQUIRE_RELAY_BUNDLE so the
+ * missing bundle fails instead.
+ */
+export function relayBundleDirOrFailWhenRequired(repoRoot: string): string | null {
+  const dir = relayBundleDirForHost(repoRoot)
+  if (!dir && process.env.ORCA_REQUIRE_RELAY_BUNDLE === '1') {
+    throw new Error(
+      `No relay bundle at out/relay/${process.platform}-${process.arch}; run pnpm build:relay first.`
+    )
+  }
+  return dir
+}
+
 export function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }

--- a/src/main/ssh/ssh-relay-live-daemon-harness.ts
+++ b/src/main/ssh/ssh-relay-live-daemon-harness.ts
@@ -8,7 +8,15 @@ import { RelayBridge } from './ssh-relay-bridge-client'
 import { randomBytes } from 'node:crypto'
 import { EventEmitter } from 'node:events'
 import type { Writable } from 'node:stream'
-import { cpSync, existsSync, mkdirSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs'
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  symlinkSync,
+  writeFileSync
+} from 'node:fs'
 import { connect } from 'node:net'
 import { join } from 'node:path'
 import type { SshConnection } from './ssh-connection'
@@ -39,7 +47,7 @@ export function isProcessAlive(pid: number): boolean {
  * leak these tests are about, reproduced on the machine running them.
  */
 export function killProcessTree(pid: number): void {
-  const listing = spawnSync('ps', ['-eo', 'pid=,ppid=']).stdout?.toString() ?? ''
+  const listing = spawnSync('ps', ['-eo', 'pid=,ppid=']).stdout?.toString() || readProcPpids()
   const childrenByParent = new Map<number, number[]>()
   for (const line of listing.split('\n')) {
     const [child, parent] = line.trim().split(/\s+/).map(Number)
@@ -77,7 +85,60 @@ function pidsHoldingSockPath(sockPath: string): number[] {
       pids.push(pid)
     }
   }
+  // Why the /proc fallback: a slim Linux image ships without procps, and an empty listing
+  // would silently leave a daemon (and its PTY shell) running after teardown.
+  return pids.length > 0 ? pids : pidsFromProcCmdline(sockPath)
+}
+
+function pidsFromProcCmdline(sockPath: string): number[] {
+  let entries: string[]
+  try {
+    entries = readdirSync('/proc')
+  } catch {
+    return []
+  }
+  const pids: number[] = []
+  for (const entry of entries) {
+    const pid = Number(entry)
+    if (!Number.isInteger(pid) || pid === process.pid) {
+      continue
+    }
+    try {
+      const argv = readFileSync(`/proc/${entry}/cmdline`, 'utf-8').split('\0')
+      if (argv.includes(sockPath) && argv.some((arg) => arg.endsWith('relay.js'))) {
+        pids.push(pid)
+      }
+    } catch {
+      /* vanished or unreadable */
+    }
+  }
   return pids
+}
+
+/** `pid ppid` per line from /proc, for hosts whose image ships no procps. */
+function readProcPpids(): string {
+  let entries: string[]
+  try {
+    entries = readdirSync('/proc')
+  } catch {
+    return ''
+  }
+  const rows: string[] = []
+  for (const entry of entries) {
+    if (!Number.isInteger(Number(entry))) {
+      continue
+    }
+    try {
+      const status = readFileSync(`/proc/${entry}/status`, 'utf-8')
+      const ppid = /^PPid:\s*(\d+)/m.exec(status)?.[1]
+      if (ppid) {
+        rows.push(`${entry} ${ppid}`)
+      }
+    } catch {
+      /* vanished or unreadable */
+    }
+  }
+  return rows.join('\n')
 }
 
 export function waitForExit(child: ChildProcess, timeoutMs = 20_000): Promise<number | null> {

--- a/src/main/ssh/ssh-relay-live-daemon-harness.ts
+++ b/src/main/ssh/ssh-relay-live-daemon-harness.ts
@@ -7,10 +7,12 @@ import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
 import { RelayBridge } from './ssh-relay-bridge-client'
 import { randomBytes } from 'node:crypto'
 import { EventEmitter } from 'node:events'
+import type { Writable } from 'node:stream'
 import { cpSync, existsSync, mkdirSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs'
 import { connect } from 'node:net'
 import { join } from 'node:path'
 import type { SshConnection } from './ssh-connection'
+import { relaySocketNameForInstanceId } from './ssh-relay-instance-id'
 
 export function relayBundleDirForHost(repoRoot: string): string | null {
   const dir = join(repoRoot, 'out', 'relay', `${process.platform}-${process.arch}`)
@@ -62,6 +64,22 @@ export function killProcessTree(pid: number): void {
   }
 }
 
+/** Pids whose argv names this socket path — the fixture's own daemons and any launched for it. */
+function pidsHoldingSockPath(sockPath: string): number[] {
+  const listing = spawnSync('ps', ['-eo', 'pid=,command=']).stdout?.toString() ?? ''
+  const pids: number[] = []
+  for (const line of listing.split('\n')) {
+    if (!line.includes(sockPath) || !line.includes('relay.js')) {
+      continue
+    }
+    const pid = Number(line.trim().split(/\s+/)[0])
+    if (Number.isInteger(pid) && pid !== process.pid) {
+      pids.push(pid)
+    }
+  }
+  return pids
+}
+
 export function waitForExit(child: ChildProcess, timeoutMs = 20_000): Promise<number | null> {
   if (child.exitCode !== null) {
     return Promise.resolve(child.exitCode)
@@ -84,14 +102,17 @@ export class LiveRelayFixture {
   constructor(
     readonly relayDir: string,
     bundleDir: string,
-    repoRoot: string
+    repoRoot: string,
+    readonly relayInstanceId = 'relay-ownership-target'
   ) {
     mkdirSync(relayDir, { recursive: true })
     cpSync(bundleDir, relayDir, { recursive: true })
     // Why: node-pty is external to the relay bundle and must resolve beside relay.js.
     symlinkSync(join(repoRoot, 'node_modules'), join(relayDir, 'node_modules'))
-    this.sockPath = join(relayDir, 'relay-ownership.sock')
-    this.credentialFile = join(relayDir, 'relay-ownership.credential')
+    // Why derived: the live journey drives the production launchRelay, which computes this
+    // name from the target id — a fixture with its own name would test a path nothing uses.
+    this.sockPath = join(relayDir, relaySocketNameForInstanceId(relayInstanceId))
+    this.credentialFile = `${this.sockPath}.credential`
     writeFileSync(this.credentialFile, randomBytes(32).toString('base64url'), { mode: 0o600 })
   }
 
@@ -180,15 +201,37 @@ export class LiveRelayFixture {
     for (const pid of this.daemonPids) {
       killProcessTree(pid)
     }
+    // Why sweep by socket path too: a test that drives the production launch path (or runs
+    // against a reverted guard) gets a daemon this fixture never spawned, and leaving it
+    // behind would leak exactly what these tests are about.
+    for (const pid of pidsHoldingSockPath(this.sockPath)) {
+      killProcessTree(pid)
+    }
   }
 
-  /** Resolve once the daemon's log records that its last client went away. */
-  async waitForClientDisconnect(label: string, timeoutMs = 20_000): Promise<void> {
+  /** Replace the endpoint credential the daemon already read, so its next --connect is refused. */
+  rotateCredential(): void {
+    writeFileSync(this.credentialFile, randomBytes(32).toString('base64url'), { mode: 0o600 })
+  }
+
+  /** Byte length of a daemon's log right now, to anchor a later wait to what follows it. */
+  logMark(label: string): number {
+    const logPath = join(this.relayDir, `relay-${label}.log`)
+    return existsSync(logPath) ? readFileSync(logPath, 'utf-8').length : 0
+  }
+
+  /**
+   * Resolve once the daemon logs that its last client went away, after `mark`.
+   *
+   * Why the mark: every readiness probe is itself a socket that opens and closes, so the
+   * log already holds that line and an unanchored search would return immediately.
+   */
+  async waitForClientDisconnect(label: string, mark: number, timeoutMs = 20_000): Promise<void> {
     const logPath = join(this.relayDir, `relay-${label}.log`)
     const start = Date.now()
     while (Date.now() - start < timeoutMs) {
       const log = existsSync(logPath) ? readFileSync(logPath, 'utf-8') : ''
-      if (log.includes('Socket client closed (clients=0)')) {
+      if (log.slice(mark).includes('Socket client closed (clients=0)')) {
         return
       }
       await delay(50)
@@ -215,11 +258,13 @@ function createLocalShellChannel(
   path?: string
 ): EventEmitter & {
   stderr: EventEmitter
+  stdin: Writable
   close: () => void
   resume: () => void
 } {
   const channel = new EventEmitter() as EventEmitter & {
     stderr: EventEmitter & { resume: () => void }
+    stdin: Writable
     close: () => void
     resume: () => void
   }
@@ -233,9 +278,13 @@ function createLocalShellChannel(
   channel.close = (): void => {
     child.kill('SIGKILL')
   }
+  channel.stdin = child.stdin
   child.stdout.on('data', (chunk: Buffer) => channel.emit('data', chunk))
   child.stderr.on('data', (chunk: Buffer) => stderr.emit('data', chunk))
   child.on('error', (error: Error) => channel.emit('error', error))
+  // Why both: waitForSentinel reads the exit code on 'exit' to type a handshake mismatch,
+  // and settles on the later 'close', the same order ssh2 emits them in.
+  child.on('exit', (code: number | null) => channel.emit('exit', code))
   child.on('close', (code: number | null) => channel.emit('close', code ?? 0))
   return channel
 }

--- a/src/main/ssh/ssh-relay-reset.test.ts
+++ b/src/main/ssh/ssh-relay-reset.test.ts
@@ -31,6 +31,16 @@ fi`
 /** How the sandboxed host behaves while the reset script runs. */
 type HostMode = 'lsof-finds-owner' | 'only-pgrep-finds-owner' | 'kill-refused' | 'no-process-tools'
 
+function resolveTool(tool: string): string | null {
+  for (const dir of (process.env.PATH ?? '').split(delimiter)) {
+    const candidate = join(dir, tool)
+    if (dir && existsSync(candidate)) {
+      return candidate
+    }
+  }
+  return null
+}
+
 function writeExecutable(filePath: string, body: string): void {
   writeFileSync(filePath, `#!/bin/sh\n${body}\n`, { mode: 0o755 })
 }
@@ -124,7 +134,15 @@ printf '%s\\n' "$OWNER_PID"`
   }
   // Why a real sleep: the script's post-kill re-check is only meaningful once the owner has
   // actually gone, and a no-op stub made it observe a process that was still dying.
-  writeExecutable(join(binDir, 'sleep'), 'exec /bin/sleep "$@"')
+  // Why link the ordinary utilities: the no-process-tools host is one without lsof and
+  // pgrep, not one without a shell. Stripping PATH outright also removed awk and tr, and the
+  // script then took a branch no real host takes.
+  for (const tool of ['awk', 'sleep', 'tr']) {
+    const resolved = resolveTool(tool)
+    if (resolved) {
+      writeExecutable(join(binDir, tool), `exec ${resolved} "$@"`)
+    }
+  }
 
   // Why a shell function: it records what reset asked for, and in the refused mode it lets
   // the owner survive the signal the way a permission error would.

--- a/src/main/ssh/ssh-relay-reset.test.ts
+++ b/src/main/ssh/ssh-relay-reset.test.ts
@@ -116,7 +116,10 @@ async function runReset(mode: HostMode): Promise<ResetRun> {
   if (mode !== 'no-process-tools') {
     // Why the -a split: without it lsof would also return an unrelated Unix-socket holder,
     // which reset must never pass to kill (#8762).
-    const lsofBody =
+    // Why the -p arm answers unconditionally: the script asks lsof about its own process
+    // first to prove the tool works at all, and a stub that tied that to the socket's owner
+    // would make a working lsof look broken the moment the relay stopped.
+    const lsofSocketArm =
       mode === 'only-pgrep-finds-owner'
         ? 'exit 1'
         : `${OWNER_ALIVE_GUARD}
@@ -124,6 +127,10 @@ case " $* " in
   *" -a "*) printf '%s\\n' "$OWNER_PID" ;;
   *) printf '%s\\n' "$OWNER_PID" "$UNRELATED_PID" ;;
 esac`
+    const lsofBody = `case " $* " in
+  *" -p "*) printf '%s\\n' "$$" ; exit 0 ;;
+esac
+${lsofSocketArm}`
     writeExecutable(join(binDir, 'lsof'), lsofBody)
     writeExecutable(
       join(binDir, 'pgrep'),

--- a/src/main/ssh/ssh-relay-reset.test.ts
+++ b/src/main/ssh/ssh-relay-reset.test.ts
@@ -212,6 +212,12 @@ describe('forceStopRelayForTarget', () => {
     expect(command).toContain('lsof -t -a -U "$1"')
     expect(command).toContain('pgrep -f "$sock_name"')
     expect(command).toContain('/proc/net/unix')
+    // Why ENVIRON: awk expands escape sequences in a -v value, so a socket path holding a
+    // backslash would never equal its own /proc/net/unix entry and a live owner would read
+    // as absent. (The branch itself needs /proc, so it is exercised on Linux.)
+    expect(command).toContain('ORCA_SOCKET_TARGET="$1" awk')
+    expect(command).toContain('ENVIRON["ORCA_SOCKET_TARGET"]')
+    expect(command).not.toContain('awk -v target')
     // Why not: a stopped relay unlinks its own socket, and one that was killed leaves an
     // inode the next deploy releases under its identity guard (STA-1756).
     expect(command).not.toContain('rm -f')

--- a/src/main/ssh/ssh-relay-reset.test.ts
+++ b/src/main/ssh/ssh-relay-reset.test.ts
@@ -17,7 +17,8 @@ import type { SshConnection } from './ssh-connection'
 const TARGET_PID = '11111'
 const UNRELATED_PID = '22222'
 
-type LsofMode = 'match' | 'empty'
+/** How the sandboxed host behaves while the reset script runs. */
+type HostMode = 'lsof-finds-owner' | 'only-pgrep-finds-owner' | 'kill-refused' | 'no-process-tools'
 
 function writeExecutable(filePath: string, body: string): void {
   writeFileSync(filePath, `#!/bin/sh\n${body}\n`, { mode: 0o755 })
@@ -41,73 +42,92 @@ async function closeServer(server: Server): Promise<void> {
   await new Promise<void>((resolve) => server.close(() => resolve()))
 }
 
-async function capturedResetScript(): Promise<string> {
-  const conn = {} as SshConnection
-  await forceStopRelayForTarget(conn, 'ssh-1')
-  return vi.mocked(execCommand).mock.lastCall?.[1] ?? ''
-}
-
-async function runResetScript(lsofMode: LsofMode): Promise<{
+type ResetRun = {
   killCalls: string[]
   pgrepCalls: string[]
   socketExists: boolean
-}> {
-  const script = await capturedResetScript()
+  error: Error | null
+}
+
+/**
+ * Run the real reset script against a sandboxed host.
+ *
+ * Why a live socket and stubbed tools: the script's whole job is deciding whether the
+ * owner is gone, so the stubs model an owner that stops answering only once `kill`
+ * reaches it — a stub that always reports the pid would hide the post-kill re-check.
+ */
+async function runReset(mode: HostMode): Promise<ResetRun> {
   const home = mkdtempSync(join(tmpdir(), 'orca-'))
   const binDir = join(home, 'bin')
   const socketDir = join(home, '.orca-remote')
   const socketPath = join(socketDir, relaySocketNameForInstanceId('ssh-1'))
   const killLog = join(home, 'kill.log')
   const pgrepLog = join(home, 'pgrep.log')
+  const holderFile = join(home, 'holder')
   mkdirSync(binDir)
   mkdirSync(socketDir, { recursive: true })
   writeFileSync(killLog, '')
   writeFileSync(pgrepLog, '')
+  writeFileSync(holderFile, TARGET_PID)
 
-  const lsofBody =
-    lsofMode === 'empty'
-      ? 'exit 1'
-      : `case " $* " in
+  if (mode !== 'no-process-tools') {
+    // Why the -a split: without it lsof would also return an unrelated Unix-socket holder,
+    // which reset must never pass to kill (#8762).
+    const lsofBody =
+      mode === 'only-pgrep-finds-owner'
+        ? 'exit 1'
+        : `[ -s "$HOLDER_FILE" ] || exit 1
+case " $* " in
   *" -a "*) printf '%s\\n' "$TARGET_PID" ;;
   *) printf '%s\\n' "$TARGET_PID" "$UNRELATED_PID" ;;
 esac`
-  writeExecutable(join(binDir, 'lsof'), lsofBody)
-  writeExecutable(
-    join(binDir, 'pgrep'),
-    `printf 'called\\n' >> "$PGREP_LOG"
+    writeExecutable(join(binDir, 'lsof'), lsofBody)
+    writeExecutable(
+      join(binDir, 'pgrep'),
+      `printf 'called\\n' >> "$PGREP_LOG"
+[ -s "$HOLDER_FILE" ] || exit 1
 printf '%s\\n' "$TARGET_PID"`
-  )
+    )
+  }
   writeExecutable(join(binDir, 'sleep'), 'exit 0')
 
+  const killBody =
+    mode === 'kill-refused'
+      ? `kill() { printf '%s\\n' "$*" >> "$KILL_LOG"; }`
+      : `kill() { printf '%s\\n' "$*" >> "$KILL_LOG"; : > "$HOLDER_FILE"; }`
+
   const server = createServer()
+  let error: Error | null = null
   try {
     await listenOnSocket(server, socketPath)
-    execFileSync(
-      '/bin/sh',
-      [
-        '-c',
-        `kill() {
-  printf '%s\\n' "$*" >> "$KILL_LOG"
-}
-eval "$RESET_SCRIPT"`
-      ],
-      {
-        env: {
-          ...process.env,
-          HOME: home,
-          KILL_LOG: killLog,
-          PATH: `${binDir}${delimiter}${process.env.PATH ?? ''}`,
-          PGREP_LOG: pgrepLog,
-          RESET_SCRIPT: script,
-          TARGET_PID,
-          UNRELATED_PID
-        }
-      }
+    vi.mocked(execCommand).mockImplementation((_conn, script) =>
+      Promise.resolve(
+        execFileSync('/bin/sh', ['-c', `${killBody}\neval "$RESET_SCRIPT"`], {
+          env: {
+            ...process.env,
+            HOME: home,
+            HOLDER_FILE: holderFile,
+            KILL_LOG: killLog,
+            PATH:
+              mode === 'no-process-tools'
+                ? binDir
+                : `${binDir}${delimiter}${process.env.PATH ?? ''}`,
+            PGREP_LOG: pgrepLog,
+            RESET_SCRIPT: script,
+            TARGET_PID,
+            UNRELATED_PID
+          }
+        }).toString()
+      )
     )
+    await forceStopRelayForTarget({} as SshConnection, 'ssh-1').catch((err) => {
+      error = err as Error
+    })
     return {
       killCalls: readFileSync(killLog, 'utf8').split('\n').filter(Boolean),
       pgrepCalls: readFileSync(pgrepLog, 'utf8').split('\n').filter(Boolean),
-      socketExists: existsSync(socketPath)
+      socketExists: existsSync(socketPath),
+      error
     }
   } finally {
     await closeServer(server)
@@ -118,6 +138,7 @@ eval "$RESET_SCRIPT"`
 describe('forceStopRelayForTarget', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(execCommand).mockResolvedValue('')
   })
 
   it('targets only the relay socket for the requested SSH target', async () => {
@@ -128,7 +149,7 @@ describe('forceStopRelayForTarget', () => {
     const command = vi.mocked(execCommand).mock.calls[0]?.[1] ?? ''
     expect(execCommand).toHaveBeenCalledWith(conn, expect.any(String))
     expect(command).toContain(`sock_name='${relaySocketNameForInstanceId('ssh-1')}'`)
-    expect(command).toContain('lsof -t -a -U "$sock"')
+    expect(command).toContain('lsof -t -a -U "$1"')
     expect(command).toContain('pgrep -f "$sock_name"')
     expect(command).toContain('rm -f "$sock"')
   })
@@ -136,23 +157,51 @@ describe('forceStopRelayForTarget', () => {
   it.skipIf(process.platform === 'win32')(
     'never passes unrelated unix-socket holders to kill',
     async () => {
-      const result = await runResetScript('match')
+      const result = await runReset('lsof-finds-owner')
 
       expect(result.killCalls).toEqual([`-TERM ${TARGET_PID}`, `-KILL ${TARGET_PID}`])
       expect(result.killCalls.join(' ')).not.toContain(UNRELATED_PID)
-      expect(result.pgrepCalls).toEqual([])
+      // Why one call: the post-kill re-check finds lsof silent and falls through to pgrep.
+      expect(result.pgrepCalls).toEqual(['called'])
       expect(result.socketExists).toBe(false)
+      expect(result.error).toBeNull()
     }
   )
 
   it.skipIf(process.platform === 'win32')(
     'uses the command-line fallback when lsof cannot match the socket',
     async () => {
-      const result = await runResetScript('empty')
+      const result = await runReset('only-pgrep-finds-owner')
 
       expect(result.killCalls).toEqual([`-TERM ${TARGET_PID}`, `-KILL ${TARGET_PID}`])
-      expect(result.pgrepCalls).toEqual(['called'])
+      // Why two calls: once to find the owner, once to prove it stopped answering.
+      expect(result.pgrepCalls).toEqual(['called', 'called'])
       expect(result.socketExists).toBe(false)
+      expect(result.error).toBeNull()
+    }
+  )
+
+  // STA-1756: removing the socket of a relay that is still running does not stop it — it
+  // strands it, which is the leak reset exists to clean up.
+  it.skipIf(process.platform === 'win32')(
+    'keeps the socket and reports failure when the owner survives the kill',
+    async () => {
+      const result = await runReset('kill-refused')
+
+      expect(result.killCalls).toEqual([`-TERM ${TARGET_PID}`, `-KILL ${TARGET_PID}`])
+      expect(result.socketExists).toBe(true)
+      expect(result.error?.message).toContain('still running')
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'keeps the socket and reports failure when the host cannot identify the owner',
+    async () => {
+      const result = await runReset('no-process-tools')
+
+      expect(result.killCalls).toEqual([])
+      expect(result.socketExists).toBe(true)
+      expect(result.error?.message).toContain('neither lsof nor pgrep')
     }
   )
 })

--- a/src/main/ssh/ssh-relay-reset.test.ts
+++ b/src/main/ssh/ssh-relay-reset.test.ts
@@ -187,7 +187,9 @@ describe('forceStopRelayForTarget', () => {
     expect(command).toContain('lsof -t -a -U "$1"')
     expect(command).toContain('pgrep -f "$sock_name"')
     expect(command).toContain('/proc/net/unix')
-    expect(command).toContain('rm -f "$sock"')
+    // Why not: a stopped relay unlinks its own socket, and one that was killed leaves an
+    // inode the next deploy releases under its identity guard (STA-1756).
+    expect(command).not.toContain('rm -f')
   })
 
   it.skipIf(process.platform === 'win32')(
@@ -198,7 +200,6 @@ describe('forceStopRelayForTarget', () => {
       expect(result.killCalls.join(' ')).toContain('-TERM')
       expect(result.killCalls.join(' ')).not.toContain(UNRELATED_PID)
       expect(result.ownerAlive).toBe(false)
-      expect(result.socketExists).toBe(false)
       expect(result.error).toBeNull()
     }
   )
@@ -210,7 +211,6 @@ describe('forceStopRelayForTarget', () => {
 
       expect(result.pgrepCalls.length).toBeGreaterThan(0)
       expect(result.ownerAlive).toBe(false)
-      expect(result.socketExists).toBe(false)
       expect(result.error).toBeNull()
     }
   )

--- a/src/main/ssh/ssh-relay-reset.test.ts
+++ b/src/main/ssh/ssh-relay-reset.test.ts
@@ -1,6 +1,5 @@
-import { execFileSync } from 'node:child_process'
+import { execFileSync, spawn, type ChildProcess } from 'node:child_process'
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
-import { createServer, type Server } from 'node:net'
 import { tmpdir } from 'node:os'
 import { delimiter, join } from 'node:path'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -14,8 +13,20 @@ import { execCommand } from './ssh-relay-deploy-helpers'
 import { relaySocketNameForInstanceId } from './ssh-relay-instance-id'
 import type { SshConnection } from './ssh-connection'
 
-const TARGET_PID = '11111'
 const UNRELATED_PID = '22222'
+
+// Why not plain `kill -0`: the owner is a child of this process, so between the signal and
+// the event-loop turn that reaps it there is a zombie that `kill -0` still calls alive.
+// Why the ladder rather than `ps`: a slim Linux image can ship without procps, and a stub
+// that silently answered "gone" there would make these tests assert the wrong branch.
+const OWNER_ALIVE_GUARD = `if [ -r /proc/"$OWNER_PID"/status ]; then
+  grep -q '^State:.*Z' /proc/"$OWNER_PID"/status && exit 1
+elif command -v ps >/dev/null 2>&1; then
+  st=$(ps -p "$OWNER_PID" -o stat= 2>/dev/null | tr -d ' ')
+  case "$st" in ""|Z*) exit 1 ;; esac
+elif ! kill -0 "$OWNER_PID" 2>/dev/null; then
+  exit 1
+fi`
 
 /** How the sandboxed host behaves while the reset script runs. */
 type HostMode = 'lsof-finds-owner' | 'only-pgrep-finds-owner' | 'kill-refused' | 'no-process-tools'
@@ -24,37 +35,58 @@ function writeExecutable(filePath: string, body: string): void {
   writeFileSync(filePath, `#!/bin/sh\n${body}\n`, { mode: 0o755 })
 }
 
-async function listenOnSocket(server: Server, socketPath: string): Promise<void> {
+/** A real process holding a real Unix socket, so kill and the host's inventories agree. */
+async function startSocketOwner(socketPath: string): Promise<ChildProcess> {
+  const owner = spawn(
+    process.execPath,
+    [
+      '-e',
+      'require("net").createServer(()=>{}).listen(process.argv[1],()=>console.log("up"));' +
+        'setInterval(()=>{},1000)',
+      socketPath
+    ],
+    { stdio: ['ignore', 'pipe', 'ignore'] }
+  )
   await new Promise<void>((resolve, reject) => {
-    const onError = (error: Error): void => reject(error)
-    server.once('error', onError)
-    server.listen(socketPath, () => {
-      server.off('error', onError)
-      resolve()
-    })
+    owner.stdout?.once('data', () => resolve())
+    owner.once('exit', () => reject(new Error('socket owner exited before listening')))
   })
+  return owner
 }
 
-async function closeServer(server: Server): Promise<void> {
-  if (!server.listening) {
-    return
+/** Wait on the child's own exit: the kill lands in a nested shell, so the parent needs a
+ *  turn to reap it, and process.kill(pid, 0) answers true for the zombie in between. */
+async function settleOwnerLiveness(owner: ChildProcess, timeoutMs = 3_000): Promise<boolean> {
+  if (owner.exitCode !== null || owner.signalCode !== null) {
+    return false
   }
-  await new Promise<void>((resolve) => server.close(() => resolve()))
+  return new Promise<boolean>((resolve) => {
+    const timer = setTimeout(() => {
+      owner.off('exit', onExit)
+      resolve(true)
+    }, timeoutMs)
+    const onExit = (): void => {
+      clearTimeout(timer)
+      resolve(false)
+    }
+    owner.once('exit', onExit)
+  })
 }
 
 type ResetRun = {
   killCalls: string[]
   pgrepCalls: string[]
   socketExists: boolean
+  ownerAlive: boolean
   error: Error | null
 }
 
 /**
  * Run the real reset script against a sandboxed host.
  *
- * Why a live socket and stubbed tools: the script's whole job is deciding whether the
- * owner is gone, so the stubs model an owner that stops answering only once `kill`
- * reaches it — a stub that always reports the pid would hide the post-kill re-check.
+ * Why a real owner process and a real kill: the script's job is deciding whether the owner
+ * is gone, and on Linux it reads /proc/net/unix for that. Stubs answering from a flag file
+ * would disagree with the kernel and make this test say different things on macOS and CI.
  */
 async function runReset(mode: HostMode): Promise<ResetRun> {
   const home = mkdtempSync(join(tmpdir(), 'orca-'))
@@ -63,12 +95,13 @@ async function runReset(mode: HostMode): Promise<ResetRun> {
   const socketPath = join(socketDir, relaySocketNameForInstanceId('ssh-1'))
   const killLog = join(home, 'kill.log')
   const pgrepLog = join(home, 'pgrep.log')
-  const holderFile = join(home, 'holder')
   mkdirSync(binDir)
   mkdirSync(socketDir, { recursive: true })
   writeFileSync(killLog, '')
   writeFileSync(pgrepLog, '')
-  writeFileSync(holderFile, TARGET_PID)
+
+  const owner = await startSocketOwner(socketPath)
+  const ownerPid = String(owner.pid)
 
   if (mode !== 'no-process-tools') {
     // Why the -a split: without it lsof would also return an unrelated Unix-socket holder,
@@ -76,45 +109,46 @@ async function runReset(mode: HostMode): Promise<ResetRun> {
     const lsofBody =
       mode === 'only-pgrep-finds-owner'
         ? 'exit 1'
-        : `[ -s "$HOLDER_FILE" ] || exit 1
+        : `${OWNER_ALIVE_GUARD}
 case " $* " in
-  *" -a "*) printf '%s\\n' "$TARGET_PID" ;;
-  *) printf '%s\\n' "$TARGET_PID" "$UNRELATED_PID" ;;
+  *" -a "*) printf '%s\\n' "$OWNER_PID" ;;
+  *) printf '%s\\n' "$OWNER_PID" "$UNRELATED_PID" ;;
 esac`
     writeExecutable(join(binDir, 'lsof'), lsofBody)
     writeExecutable(
       join(binDir, 'pgrep'),
       `printf 'called\\n' >> "$PGREP_LOG"
-[ -s "$HOLDER_FILE" ] || exit 1
-printf '%s\\n' "$TARGET_PID"`
+${OWNER_ALIVE_GUARD}
+printf '%s\\n' "$OWNER_PID"`
     )
   }
-  writeExecutable(join(binDir, 'sleep'), 'exit 0')
+  // Why a real sleep: the script's post-kill re-check is only meaningful once the owner has
+  // actually gone, and a no-op stub made it observe a process that was still dying.
+  writeExecutable(join(binDir, 'sleep'), 'exec /bin/sleep "$@"')
 
+  // Why a shell function: it records what reset asked for, and in the refused mode it lets
+  // the owner survive the signal the way a permission error would.
   const killBody =
     mode === 'kill-refused'
       ? `kill() { printf '%s\\n' "$*" >> "$KILL_LOG"; }`
-      : `kill() { printf '%s\\n' "$*" >> "$KILL_LOG"; : > "$HOLDER_FILE"; }`
+      : `kill() { printf '%s\\n' "$*" >> "$KILL_LOG"; command kill "$@" 2>/dev/null || true; }`
 
-  const server = createServer()
   let error: Error | null = null
   try {
-    await listenOnSocket(server, socketPath)
     vi.mocked(execCommand).mockImplementation((_conn, script) =>
       Promise.resolve(
         execFileSync('/bin/sh', ['-c', `${killBody}\neval "$RESET_SCRIPT"`], {
           env: {
             ...process.env,
             HOME: home,
-            HOLDER_FILE: holderFile,
             KILL_LOG: killLog,
+            OWNER_PID: ownerPid,
             PATH:
               mode === 'no-process-tools'
                 ? binDir
                 : `${binDir}${delimiter}${process.env.PATH ?? ''}`,
             PGREP_LOG: pgrepLog,
             RESET_SCRIPT: script,
-            TARGET_PID,
             UNRELATED_PID
           }
         }).toString()
@@ -127,10 +161,11 @@ printf '%s\\n' "$TARGET_PID"`
       killCalls: readFileSync(killLog, 'utf8').split('\n').filter(Boolean),
       pgrepCalls: readFileSync(pgrepLog, 'utf8').split('\n').filter(Boolean),
       socketExists: existsSync(socketPath),
+      ownerAlive: await settleOwnerLiveness(owner),
       error
     }
   } finally {
-    await closeServer(server)
+    owner.kill('SIGKILL')
     rmSync(home, { recursive: true, force: true })
   }
 }
@@ -151,6 +186,7 @@ describe('forceStopRelayForTarget', () => {
     expect(command).toContain(`sock_name='${relaySocketNameForInstanceId('ssh-1')}'`)
     expect(command).toContain('lsof -t -a -U "$1"')
     expect(command).toContain('pgrep -f "$sock_name"')
+    expect(command).toContain('/proc/net/unix')
     expect(command).toContain('rm -f "$sock"')
   })
 
@@ -159,10 +195,9 @@ describe('forceStopRelayForTarget', () => {
     async () => {
       const result = await runReset('lsof-finds-owner')
 
-      expect(result.killCalls).toEqual([`-TERM ${TARGET_PID}`, `-KILL ${TARGET_PID}`])
+      expect(result.killCalls.join(' ')).toContain('-TERM')
       expect(result.killCalls.join(' ')).not.toContain(UNRELATED_PID)
-      // Why one call: the post-kill re-check finds lsof silent and falls through to pgrep.
-      expect(result.pgrepCalls).toEqual(['called'])
+      expect(result.ownerAlive).toBe(false)
       expect(result.socketExists).toBe(false)
       expect(result.error).toBeNull()
     }
@@ -173,9 +208,8 @@ describe('forceStopRelayForTarget', () => {
     async () => {
       const result = await runReset('only-pgrep-finds-owner')
 
-      expect(result.killCalls).toEqual([`-TERM ${TARGET_PID}`, `-KILL ${TARGET_PID}`])
-      // Why two calls: once to find the owner, once to prove it stopped answering.
-      expect(result.pgrepCalls).toEqual(['called', 'called'])
+      expect(result.pgrepCalls.length).toBeGreaterThan(0)
+      expect(result.ownerAlive).toBe(false)
       expect(result.socketExists).toBe(false)
       expect(result.error).toBeNull()
     }
@@ -188,20 +222,25 @@ describe('forceStopRelayForTarget', () => {
     async () => {
       const result = await runReset('kill-refused')
 
-      expect(result.killCalls).toEqual([`-TERM ${TARGET_PID}`, `-KILL ${TARGET_PID}`])
+      expect(result.killCalls.join(' ')).toContain('-TERM')
+      expect(result.ownerAlive).toBe(true)
       expect(result.socketExists).toBe(true)
       expect(result.error?.message).toContain('still running')
     }
   )
 
   it.skipIf(process.platform === 'win32')(
-    'keeps the socket and reports failure when the host cannot identify the owner',
+    'keeps the socket when it cannot identify the owner it failed to stop',
     async () => {
       const result = await runReset('no-process-tools')
 
+      // Why no kill: with no way to name the owner there is nothing to signal. On Linux
+      // /proc/net/unix still shows the socket is held; on hosts without it nothing does —
+      // either way the only safe answer is to leave it alone and say so.
       expect(result.killCalls).toEqual([])
+      expect(result.ownerAlive).toBe(true)
       expect(result.socketExists).toBe(true)
-      expect(result.error?.message).toContain('neither lsof nor pgrep')
+      expect(result.error?.message).toMatch(/still running|no way to see/)
     }
   )
 })

--- a/src/main/ssh/ssh-relay-reset.ts
+++ b/src/main/ssh/ssh-relay-reset.ts
@@ -10,6 +10,15 @@ import { relaySocketNameForInstanceId } from './ssh-relay-instance-id'
 const RESET_NO_OWNER_PROOF_MARKER = 'ORCA-RELAY-RESET-NO-OWNER-PROOF'
 const RESET_OWNER_SURVIVED_MARKER = 'ORCA-RELAY-RESET-OWNER-SURVIVED'
 
+/**
+ * Stop the relay owning this target's socket.
+ *
+ * Why it no longer removes the socket: a relay that stops cleanly unlinks its own path, and
+ * one that had to be killed leaves an inode the next deploy releases under its identity
+ * guard. Removing it here would need the same guard and would still race a relay binding the
+ * path between the check and the unlink — for no gain, since the leftover inode blocks
+ * nothing.
+ */
 export async function forceStopRelayForTarget(
   conn: SshConnection,
   relayInstanceId: string
@@ -32,7 +41,7 @@ export async function forceStopRelayForTarget(
     '  fi',
     '}',
     // Why an inventory rather than "no pid found": a lookup that returned nothing may
-    // simply have been unable to look, and reset must not read that silence as absence.
+    // simply have been unable to look, and reset must not read that silence as a stop.
     // 0 = a process holds the socket, 1 = an inventory ran and none does, 2 = none ran.
     'socket_listed() {',
     '  if [ -r /proc/net/unix ]; then',
@@ -46,27 +55,25 @@ export async function forceStopRelayForTarget(
     'if [ -d "$base" ]; then',
     '  for sock in "$base"/relay-*/"$sock_name" "$base"/"$sock_name"; do',
     '    [ -S "$sock" ] || continue',
+    '    signalled=no',
     '    find_holder "$sock"',
     '    if [ -n "$holder" ]; then',
+    '      signalled=yes',
     '      kill -TERM $holder 2>/dev/null || true',
     '      sleep 0.2',
     '      kill -KILL $holder 2>/dev/null || true',
     '      sleep 0.2',
     '    fi',
     // Why re-check both: a refused kill (permissions, a wedged process) leaves the owner
-    // listening, and removing its socket then hides it instead of stopping it.
+    // running, and reporting success then tells the user a relay was stopped that was not.
     '    socket_listed "$sock"',
     '    listed=$?',
     '    find_holder "$sock"',
-    '    if [ "$listed" = 2 ]; then',
-    `      echo ${RESET_NO_OWNER_PROOF_MARKER}`,
-    '      continue',
-    '    fi',
     '    if [ "$listed" = 0 ] || [ -n "$holder" ]; then',
     `      echo ${RESET_OWNER_SURVIVED_MARKER}`,
-    '      continue',
+    '    elif [ "$listed" = 2 ] && [ "$signalled" = no ]; then',
+    `      echo ${RESET_NO_OWNER_PROOF_MARKER}`,
     '    fi',
-    '    rm -f "$sock"',
     '  done',
     'fi'
   ].join('\n')
@@ -74,14 +81,14 @@ export async function forceStopRelayForTarget(
   const output = await execCommand(conn, script)
   if (output.includes(RESET_OWNER_SURVIVED_MARKER)) {
     throw new Error(
-      'The remote relay is still running after the reset signal, so its socket was left in ' +
-        'place rather than stranding it. Stop the relay process on the host, then retry.'
+      'The remote relay is still running after the reset signal. Stop the relay process on ' +
+        'the host, then retry.'
     )
   }
   if (output.includes(RESET_NO_OWNER_PROOF_MARKER)) {
     throw new Error(
       'This host offers no way to see which process owns the relay socket (no /proc/net/unix ' +
-        'and no lsof), so it was left in place. Stop the relay process on the host, then retry.'
+        'and no lsof), so nothing was stopped. Stop the relay process on the host, then retry.'
     )
   }
 }

--- a/src/main/ssh/ssh-relay-reset.ts
+++ b/src/main/ssh/ssh-relay-reset.ts
@@ -64,10 +64,8 @@ export async function forceStopRelayForTarget(
     'if [ -d "$base" ]; then',
     '  for sock in "$base"/relay-*/"$sock_name" "$base"/"$sock_name"; do',
     '    [ -S "$sock" ] || continue',
-    '    signalled=no',
     '    find_holder "$sock"',
     '    if [ -n "$holder" ]; then',
-    '      signalled=yes',
     '      kill -TERM $holder 2>/dev/null || true',
     '      sleep 0.2',
     '      kill -KILL $holder 2>/dev/null || true',
@@ -80,7 +78,9 @@ export async function forceStopRelayForTarget(
     '    find_holder "$sock"',
     '    if [ "$listed" = 0 ] || [ -n "$holder" ]; then',
     `      echo ${RESET_OWNER_SURVIVED_MARKER}`,
-    '    elif [ "$listed" = 2 ] && [ "$signalled" = no ]; then',
+    // Why regardless of whether we signalled: sending a signal is not evidence the process
+    // took it, so with no inventory to ask afterwards the stop stays unproven either way.
+    '    elif [ "$listed" = 2 ]; then',
     `      echo ${RESET_NO_OWNER_PROOF_MARKER}`,
     '    fi',
     '  done',

--- a/src/main/ssh/ssh-relay-reset.ts
+++ b/src/main/ssh/ssh-relay-reset.ts
@@ -31,15 +31,21 @@ export async function forceStopRelayForTarget(
       'awk -v self="$$" -v parent="$PPID" \'$1 != self && $1 != parent\' | tr "\\n" " ")',
     '  fi',
     '}',
+    // Why an inventory rather than "no pid found": a lookup that returned nothing may
+    // simply have been unable to look, and reset must not read that silence as absence.
+    // 0 = a process holds the socket, 1 = an inventory ran and none does, 2 = none ran.
+    'socket_listed() {',
+    '  if [ -r /proc/net/unix ]; then',
+    '    grep -q " $1$" /proc/net/unix && return 0 || return 1',
+    '  fi',
+    '  if command -v lsof >/dev/null 2>&1; then',
+    '    [ -n "$(lsof -t -a -U "$1" 2>/dev/null)" ] && return 0 || return 1',
+    '  fi',
+    '  return 2',
+    '}',
     'if [ -d "$base" ]; then',
     '  for sock in "$base"/relay-*/"$sock_name" "$base"/"$sock_name"; do',
     '    [ -S "$sock" ] || continue',
-    // Why: with neither tool the host offers no way to see an owner, and an unlink here
-    // would strand a live relay rather than stop it.
-    '    if ! command -v lsof >/dev/null 2>&1 && ! command -v pgrep >/dev/null 2>&1; then',
-    `      echo ${RESET_NO_OWNER_PROOF_MARKER}`,
-    '      continue',
-    '    fi',
     '    find_holder "$sock"',
     '    if [ -n "$holder" ]; then',
     '      kill -TERM $holder 2>/dev/null || true',
@@ -47,10 +53,16 @@ export async function forceStopRelayForTarget(
     '      kill -KILL $holder 2>/dev/null || true',
     '      sleep 0.2',
     '    fi',
-    // Why re-check: a refused kill (permissions, a wedged process) leaves the owner
+    // Why re-check both: a refused kill (permissions, a wedged process) leaves the owner
     // listening, and removing its socket then hides it instead of stopping it.
+    '    socket_listed "$sock"',
+    '    listed=$?',
     '    find_holder "$sock"',
-    '    if [ -n "$holder" ]; then',
+    '    if [ "$listed" = 2 ]; then',
+    `      echo ${RESET_NO_OWNER_PROOF_MARKER}`,
+    '      continue',
+    '    fi',
+    '    if [ "$listed" = 0 ] || [ -n "$holder" ]; then',
     `      echo ${RESET_OWNER_SURVIVED_MARKER}`,
     '      continue',
     '    fi',
@@ -68,8 +80,8 @@ export async function forceStopRelayForTarget(
   }
   if (output.includes(RESET_NO_OWNER_PROOF_MARKER)) {
     throw new Error(
-      'This host has neither lsof nor pgrep, so the relay owning the socket could not be ' +
-        'identified. The socket was left in place; stop the relay process on the host, then retry.'
+      'This host offers no way to see which process owns the relay socket (no /proc/net/unix ' +
+        'and no lsof), so it was left in place. Stop the relay process on the host, then retry.'
     )
   }
 }

--- a/src/main/ssh/ssh-relay-reset.ts
+++ b/src/main/ssh/ssh-relay-reset.ts
@@ -51,9 +51,12 @@ export async function forceStopRelayForTarget(
     // fail on a legal path. Why the exit-code split: a missing or failing tool answers
     // nothing, and reading that as "no owner" is the inference this change removes.
     '  if [ -r /proc/net/unix ] && command -v awk >/dev/null 2>&1; then',
-    '    awk -v target="$1" \'NR>1{line=$0;' +
+    // Why ENVIRON rather than -v: awk expands escape sequences in a -v value, so a path
+    // holding a backslash would never equal its own /proc/net/unix entry.
+    '    ORCA_SOCKET_TARGET="$1" awk \'NR>1{line=$0;' +
       'sub(/^[^ ]+ +[^ ]+ +[^ ]+ +[^ ]+ +[^ ]+ +[^ ]+ +[^ ]+ +/,"",line);' +
-      "if(line==target){found=1}}END{exit(found?0:1)}' /proc/net/unix",
+      'if(line==ENVIRON["ORCA_SOCKET_TARGET"]){found=1}}' +
+      "END{exit(found?0:1)}' /proc/net/unix",
     '    case $? in 0) return 0 ;; 1) return 1 ;; *) return 2 ;; esac',
     '  fi',
     '  if command -v lsof >/dev/null 2>&1 && [ -n "$(lsof -t -p $$ 2>/dev/null)" ]; then',

--- a/src/main/ssh/ssh-relay-reset.ts
+++ b/src/main/ssh/ssh-relay-reset.ts
@@ -44,10 +44,19 @@ export async function forceStopRelayForTarget(
     // simply have been unable to look, and reset must not read that silence as a stop.
     // 0 = a process holds the socket, 1 = an inventory ran and none does, 2 = none ran.
     'socket_listed() {',
-    '  if [ -r /proc/net/unix ]; then',
-    '    grep -q " $1$" /proc/net/unix && return 0 || return 1',
+    // Why the columns are spelled out below: mawk, Debian's default awk, does not support
+    // {n} interval expressions, and the strip silently matched nothing there.
+    // Why awk on the eighth column rather than grep on the line: the pathname may contain
+    // spaces and regex metacharacters, and an interpolated pattern would both over-match and
+    // fail on a legal path. Why the exit-code split: a missing or failing tool answers
+    // nothing, and reading that as "no owner" is the inference this change removes.
+    '  if [ -r /proc/net/unix ] && command -v awk >/dev/null 2>&1; then',
+    '    awk -v target="$1" \'NR>1{line=$0;' +
+      'sub(/^[^ ]+ +[^ ]+ +[^ ]+ +[^ ]+ +[^ ]+ +[^ ]+ +[^ ]+ +/,"",line);' +
+      "if(line==target){found=1}}END{exit(found?0:1)}' /proc/net/unix",
+    '    case $? in 0) return 0 ;; 1) return 1 ;; *) return 2 ;; esac',
     '  fi',
-    '  if command -v lsof >/dev/null 2>&1; then',
+    '  if command -v lsof >/dev/null 2>&1 && [ -n "$(lsof -t -p $$ 2>/dev/null)" ]; then',
     '    [ -n "$(lsof -t -a -U "$1" 2>/dev/null)" ] && return 0 || return 1',
     '  fi',
     '  return 2',

--- a/src/main/ssh/ssh-relay-reset.ts
+++ b/src/main/ssh/ssh-relay-reset.ts
@@ -3,6 +3,13 @@ import { shellEscape } from './ssh-connection-utils'
 import { execCommand } from './ssh-relay-deploy-helpers'
 import { relaySocketNameForInstanceId } from './ssh-relay-instance-id'
 
+// Why: reset is the escape hatch a failed deploy points users at, so it must not repeat the
+// displacement it exists to undo — unlinking a socket whose owner is still running orphans
+// that relay and every PTY it holds (STA-1756). These markers report the two ways reset can
+// fail to prove the owner is gone, so the caller can say so instead of silently leaking.
+const RESET_NO_OWNER_PROOF_MARKER = 'ORCA-RELAY-RESET-NO-OWNER-PROOF'
+const RESET_OWNER_SURVIVED_MARKER = 'ORCA-RELAY-RESET-OWNER-SURVIVED'
+
 export async function forceStopRelayForTarget(
   conn: SshConnection,
   relayInstanceId: string
@@ -12,28 +19,57 @@ export async function forceStopRelayForTarget(
   const script = [
     `sock_name=${escapedSockName}`,
     'base="${HOME}/.orca-remote"',
+    // Why: lsof ORs selectors by default; -a prevents reset from targeting
+    // every Unix-socket holder instead of only the per-relay socket (#8762).
+    'find_holder() {',
+    '  holder=""',
+    '  if command -v lsof >/dev/null 2>&1; then',
+    '    holder=$(lsof -t -a -U "$1" 2>/dev/null | tr "\\n" " ")',
+    '  fi',
+    '  if [ -z "$holder" ] && command -v pgrep >/dev/null 2>&1; then',
+    '    holder=$(pgrep -f "$sock_name" 2>/dev/null | ' +
+      'awk -v self="$$" -v parent="$PPID" \'$1 != self && $1 != parent\' | tr "\\n" " ")',
+    '  fi',
+    '}',
     'if [ -d "$base" ]; then',
     '  for sock in "$base"/relay-*/"$sock_name" "$base"/"$sock_name"; do',
     '    [ -S "$sock" ] || continue',
-    '    pid=""',
-    // Why: lsof ORs selectors by default; -a prevents reset from targeting
-    // every Unix-socket holder instead of only the per-relay socket (#8762).
-    '    if command -v lsof >/dev/null 2>&1; then',
-    '      pid=$(lsof -t -a -U "$sock" 2>/dev/null | tr "\\n" " ")',
+    // Why: with neither tool the host offers no way to see an owner, and an unlink here
+    // would strand a live relay rather than stop it.
+    '    if ! command -v lsof >/dev/null 2>&1 && ! command -v pgrep >/dev/null 2>&1; then',
+    `      echo ${RESET_NO_OWNER_PROOF_MARKER}`,
+    '      continue',
     '    fi',
-    '    if [ -z "$pid" ] && command -v pgrep >/dev/null 2>&1; then',
-    '      pid=$(pgrep -f "$sock_name" 2>/dev/null | ' +
-      'awk -v self="$$" -v parent="$PPID" \'$1 != self && $1 != parent\' | tr "\\n" " ")',
-    '    fi',
-    '    if [ -n "$pid" ]; then',
-    '      kill -TERM $pid 2>/dev/null || true',
+    '    find_holder "$sock"',
+    '    if [ -n "$holder" ]; then',
+    '      kill -TERM $holder 2>/dev/null || true',
     '      sleep 0.2',
-    '      kill -KILL $pid 2>/dev/null || true',
+    '      kill -KILL $holder 2>/dev/null || true',
+    '      sleep 0.2',
+    '    fi',
+    // Why re-check: a refused kill (permissions, a wedged process) leaves the owner
+    // listening, and removing its socket then hides it instead of stopping it.
+    '    find_holder "$sock"',
+    '    if [ -n "$holder" ]; then',
+    `      echo ${RESET_OWNER_SURVIVED_MARKER}`,
+    '      continue',
     '    fi',
     '    rm -f "$sock"',
     '  done',
     'fi'
   ].join('\n')
 
-  await execCommand(conn, script)
+  const output = await execCommand(conn, script)
+  if (output.includes(RESET_OWNER_SURVIVED_MARKER)) {
+    throw new Error(
+      'The remote relay is still running after the reset signal, so its socket was left in ' +
+        'place rather than stranding it. Stop the relay process on the host, then retry.'
+    )
+  }
+  if (output.includes(RESET_NO_OWNER_PROOF_MARKER)) {
+    throw new Error(
+      'This host has neither lsof nor pgrep, so the relay owning the socket could not be ' +
+        'identified. The socket was left in place; stop the relay process on the host, then retry.'
+    )
+  }
 }

--- a/src/main/ssh/ssh-relay-socket-displacement.test.ts
+++ b/src/main/ssh/ssh-relay-socket-displacement.test.ts
@@ -117,7 +117,7 @@ describe('deployAndLaunchRelay socket displacement', () => {
     const conn = makeMockConnection()
     vi.mocked(waitForSentinel).mockRejectedValueOnce(new Error('relay reconnect refused'))
     queueDeployUpToOccupiedSocket()
-    vi.mocked(execCommand).mockResolvedValueOnce('LIVE') // socket release: a live owner
+    vi.mocked(execCommand).mockResolvedValueOnce('LIVE') // owner probe: a live owner
 
     await expect(deployAndLaunchRelay(conn)).rejects.toSatisfy(isRelaySocketOwnerLiveError)
 
@@ -131,7 +131,7 @@ describe('deployAndLaunchRelay socket displacement', () => {
     const conn = makeMockConnection()
     vi.mocked(waitForSentinel).mockRejectedValueOnce(new Error('relay reconnect refused'))
     queueDeployUpToOccupiedSocket()
-    vi.mocked(execCommand).mockResolvedValueOnce('') // release produced no verdict
+    vi.mocked(execCommand).mockResolvedValueOnce('') // probe produced no verdict
 
     await expect(deployAndLaunchRelay(conn)).rejects.toSatisfy(isRelaySocketOwnerLiveError)
 
@@ -139,14 +139,14 @@ describe('deployAndLaunchRelay socket displacement', () => {
     expect(writeRelayEndpointCredential).not.toHaveBeenCalled()
   })
 
-  it('still launches fresh once the host reports the stale socket released', async () => {
+  it('still launches fresh once the host proves the stale socket unowned', async () => {
     const conn = makeMockConnection()
     vi.mocked(waitForSentinel)
       .mockRejectedValueOnce(new Error('relay reconnect refused'))
       .mockResolvedValue({ write: vi.fn(), onData: vi.fn(), onClose: vi.fn() } as never)
     queueDeployUpToOccupiedSocket()
     vi.mocked(execCommand)
-      .mockResolvedValueOnce('RELEASED') // socket release: nothing owned the path
+      .mockResolvedValueOnce('EXITED') // owner probe: nothing owns the path
       .mockResolvedValueOnce('READY') // socket readiness poll
 
     await expect(deployAndLaunchRelay(conn)).resolves.toMatchObject({ nodePath: '/usr/bin/node' })
@@ -154,24 +154,21 @@ describe('deployAndLaunchRelay socket displacement', () => {
     expect(execChannelCommands(conn).some((command) => command.includes('--detached'))).toBe(true)
   })
 
-  // Moved here from ssh-relay-deploy.test.ts: the removal it guards now lives inside the
-  // release command, so an unconfirmed close of that command must still stop the launch.
-  it('does not launch fresh after an unconfirmed socket release', async () => {
+  // Replaces the unconfirmed-cleanup case from ssh-relay-deploy.test.ts: deploy no longer
+  // removes anything, so a probe it could not run must stop the launch on its own.
+  it('does not launch fresh after a probe it could not run', async () => {
     const conn = makeMockConnection()
-    const unconfirmedRelease = Object.assign(new Error('socket release still running'), {
-      sshChannelCloseConfirmed: false
-    })
     vi.mocked(waitForSentinel).mockRejectedValueOnce(new Error('relay reconnect refused'))
     queueDeployUpToOccupiedSocket()
-    vi.mocked(execCommand).mockRejectedValueOnce(unconfirmedRelease)
+    vi.mocked(execCommand).mockRejectedValueOnce(new Error('channel open failure'))
 
-    await expect(deployAndLaunchRelay(conn)).rejects.toBe(unconfirmedRelease)
+    await expect(deployAndLaunchRelay(conn)).rejects.toSatisfy(isRelaySocketOwnerLiveError)
 
     expect(execChannelCommands(conn)).toHaveLength(1)
     expect(execChannelCommands(conn).some((command) => command.includes('--detached'))).toBe(false)
   })
 
-  it('decides with one host command that probes and unlinks together', async () => {
+  it('decides by asking the host who owns the socket, and removes nothing', async () => {
     const conn = makeMockConnection()
     vi.mocked(waitForSentinel).mockRejectedValueOnce(new Error('relay reconnect refused'))
     queueDeployUpToOccupiedSocket()
@@ -179,13 +176,13 @@ describe('deployAndLaunchRelay socket displacement', () => {
 
     await expect(deployAndLaunchRelay(conn)).rejects.toSatisfy(isRelaySocketOwnerLiveError)
 
-    // Why one command: probing here and unlinking in a second round-trip leaves a window
-    // in which another client can bind the path, and the removal would then strand it.
-    const release = execCommands().at(-1) ?? ''
-    expect(release).toContain('/usr/bin/node')
-    expect(release).toContain('connect')
-    expect(release).toContain('unlinkSync')
-    expect(release).not.toContain('test -S')
-    expect(execCommands().some((command) => command.startsWith('rm -f'))).toBe(false)
+    // Why nothing removed: the daemon reclaims a stale path under its own identity check,
+    // and an unlink here would put an SSH round-trip between that check and the launch.
+    const probe = execCommands().at(-1) ?? ''
+    expect(probe).toContain('/usr/bin/node')
+    expect(probe).toContain('connect')
+    expect(probe).not.toContain('test -S')
+    expect(execCommands().some((command) => command.includes('rm -f'))).toBe(false)
+    expect(execCommands().some((command) => command.includes('unlinkSync'))).toBe(false)
   })
 })

--- a/src/main/ssh/ssh-relay-socket-displacement.test.ts
+++ b/src/main/ssh/ssh-relay-socket-displacement.test.ts
@@ -105,7 +105,7 @@ function execChannelCommands(conn: SshConnection): string[] {
 describe('deployAndLaunchRelay socket displacement', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    // Why: an ordered queue drives the probes below; the default only absorbs the
+    // Why: an ordered queue drives the decision below; the default only absorbs the
     // best-effort teardown commands deploy issues after the decision under test.
     vi.mocked(execCommand).mockReset().mockResolvedValue('')
     vi.mocked(waitForSentinel)
@@ -113,71 +113,65 @@ describe('deployAndLaunchRelay socket displacement', () => {
       .mockResolvedValue({ write: vi.fn(), onData: vi.fn(), onClose: vi.fn() } as never)
   })
 
-  it('never removes or replaces a socket a live relay still owns', async () => {
+  it('never replaces a socket a live relay still owns', async () => {
     const conn = makeMockConnection()
     vi.mocked(waitForSentinel).mockRejectedValueOnce(new Error('relay reconnect refused'))
     queueDeployUpToOccupiedSocket()
-    vi.mocked(execCommand).mockResolvedValueOnce('LIVE') // owner probe
+    vi.mocked(execCommand).mockResolvedValueOnce('LIVE') // socket release: a live owner
 
     await expect(deployAndLaunchRelay(conn)).rejects.toSatisfy(isRelaySocketOwnerLiveError)
 
-    expect(execCommands().some((command) => command.startsWith('rm -f'))).toBe(false)
     expect(execChannelCommands(conn).some((command) => command.includes('--detached'))).toBe(false)
     // Why: the credential is rotated per fresh launch, so writing one would lock the
-    // surviving relay out of every later --connect even if the socket were left alone.
+    // surviving relay out of every later --connect even with its socket left alone.
     expect(writeRelayEndpointCredential).not.toHaveBeenCalled()
   })
 
-  it('never removes or replaces a socket whose owner it could not probe', async () => {
+  it('never replaces a socket whose owner it could not prove gone', async () => {
     const conn = makeMockConnection()
     vi.mocked(waitForSentinel).mockRejectedValueOnce(new Error('relay reconnect refused'))
     queueDeployUpToOccupiedSocket()
-    vi.mocked(execCommand).mockResolvedValueOnce('') // owner probe produced no verdict
+    vi.mocked(execCommand).mockResolvedValueOnce('') // release produced no verdict
 
     await expect(deployAndLaunchRelay(conn)).rejects.toSatisfy(isRelaySocketOwnerLiveError)
 
-    expect(execCommands().some((command) => command.startsWith('rm -f'))).toBe(false)
     expect(execChannelCommands(conn).some((command) => command.includes('--detached'))).toBe(false)
+    expect(writeRelayEndpointCredential).not.toHaveBeenCalled()
   })
 
-  it('still clears a stale socket whose owner is proven gone', async () => {
+  it('still launches fresh once the host reports the stale socket released', async () => {
     const conn = makeMockConnection()
     vi.mocked(waitForSentinel)
       .mockRejectedValueOnce(new Error('relay reconnect refused'))
       .mockResolvedValue({ write: vi.fn(), onData: vi.fn(), onClose: vi.fn() } as never)
     queueDeployUpToOccupiedSocket()
     vi.mocked(execCommand)
-      .mockResolvedValueOnce('EXITED') // owner probe: connect refused
-      .mockResolvedValueOnce('') // rm -f
+      .mockResolvedValueOnce('RELEASED') // socket release: nothing owned the path
       .mockResolvedValueOnce('READY') // socket readiness poll
 
     await expect(deployAndLaunchRelay(conn)).resolves.toMatchObject({ nodePath: '/usr/bin/node' })
 
-    const removals = execCommands().filter((command) => command.startsWith('rm -f'))
-    expect(removals).toHaveLength(1)
-    expect(removals[0]).toContain('.sock')
     expect(execChannelCommands(conn).some((command) => command.includes('--detached'))).toBe(true)
   })
 
-  // Moved here from ssh-relay-deploy.test.ts: the removal it guards now lives behind the owner probe.
-  it('does not launch fresh after unconfirmed stale-socket cleanup', async () => {
+  // Moved here from ssh-relay-deploy.test.ts: the removal it guards now lives inside the
+  // release command, so an unconfirmed close of that command must still stop the launch.
+  it('does not launch fresh after an unconfirmed socket release', async () => {
     const conn = makeMockConnection()
-    const unconfirmedCleanup = Object.assign(new Error('socket cleanup still running'), {
+    const unconfirmedRelease = Object.assign(new Error('socket release still running'), {
       sshChannelCloseConfirmed: false
     })
-    vi.mocked(waitForSentinel).mockRejectedValueOnce(new Error('stale relay reconnect failed'))
+    vi.mocked(waitForSentinel).mockRejectedValueOnce(new Error('relay reconnect refused'))
     queueDeployUpToOccupiedSocket()
-    vi.mocked(execCommand)
-      .mockResolvedValueOnce('EXITED') // owner probe
-      .mockRejectedValueOnce(unconfirmedCleanup)
+    vi.mocked(execCommand).mockRejectedValueOnce(unconfirmedRelease)
 
-    await expect(deployAndLaunchRelay(conn)).rejects.toBe(unconfirmedCleanup)
+    await expect(deployAndLaunchRelay(conn)).rejects.toBe(unconfirmedRelease)
 
     expect(execChannelCommands(conn)).toHaveLength(1)
     expect(execChannelCommands(conn).some((command) => command.includes('--detached'))).toBe(false)
   })
 
-  it('probes the socket by connecting to it, not by testing the inode again', async () => {
+  it('decides with one host command that probes and unlinks together', async () => {
     const conn = makeMockConnection()
     vi.mocked(waitForSentinel).mockRejectedValueOnce(new Error('relay reconnect refused'))
     queueDeployUpToOccupiedSocket()
@@ -185,9 +179,13 @@ describe('deployAndLaunchRelay socket displacement', () => {
 
     await expect(deployAndLaunchRelay(conn)).rejects.toSatisfy(isRelaySocketOwnerLiveError)
 
-    const ownerProbe = execCommands().at(-1) ?? ''
-    expect(ownerProbe).toContain('/usr/bin/node')
-    expect(ownerProbe).toContain('connect')
-    expect(ownerProbe).not.toContain('test -S')
+    // Why one command: probing here and unlinking in a second round-trip leaves a window
+    // in which another client can bind the path, and the removal would then strand it.
+    const release = execCommands().at(-1) ?? ''
+    expect(release).toContain('/usr/bin/node')
+    expect(release).toContain('connect')
+    expect(release).toContain('unlinkSync')
+    expect(release).not.toContain('test -S')
+    expect(execCommands().some((command) => command.startsWith('rm -f'))).toBe(false)
   })
 })

--- a/src/main/ssh/ssh-relay-socket-displacement.test.ts
+++ b/src/main/ssh/ssh-relay-socket-displacement.test.ts
@@ -1,0 +1,193 @@
+// STA-1756: a failed --connect used to `rm -f` the relay socket and launch a fresh
+// detached relay over the same path. Unlinking cannot stop a relay that already bound
+// that path — it only hides the live owner from the fresh launch's EADDRINUSE check,
+// so the old relay keeps running forever with its PTYs and every agent inside them.
+//
+// These pin the shipping wiring: deploy must not remove a socket, and must not launch
+// a replacement, unless the owner probe proves nothing is listening.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: { getAppPath: () => '/mock/app' }
+}))
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn().mockReturnValue(true),
+  readFileSync: vi.fn().mockReturnValue('0.1.0+abcdef012345')
+}))
+
+vi.mock('./relay-protocol', () => ({
+  RELAY_VERSION: '0.1.0',
+  RELAY_REMOTE_DIR: '.orca-remote',
+  parseUnameToRelayPlatform: vi.fn().mockReturnValue('linux-x64'),
+  RELAY_SENTINEL: 'ORCA-RELAY v0.1.0 READY\n',
+  RELAY_SENTINEL_TIMEOUT_MS: 10_000
+}))
+
+vi.mock('./ssh-relay-deploy-helpers', () => ({
+  uploadDirectory: vi.fn().mockResolvedValue(undefined),
+  waitForSentinel: vi.fn(),
+  isUnconfirmedSshCommandTermination: (error: unknown) =>
+    error instanceof Error &&
+    (error as Error & { sshChannelCloseConfirmed?: boolean }).sshChannelCloseConfirmed === false,
+  execCommand: vi.fn()
+}))
+
+vi.mock('./ssh-remote-node-resolution', () => ({
+  resolveRemoteNodePath: vi.fn().mockResolvedValue('/usr/bin/node')
+}))
+
+vi.mock('./ssh-relay-endpoint-credential', () => ({
+  writeRelayEndpointCredential: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('./ssh-relay-versioned-install', () => ({
+  readLocalFullVersion: vi.fn().mockReturnValue('0.1.0+abcdef012345'),
+  computeRemoteRelayDir: (home: string, v: string) => `${home}/.orca-remote/relay-${v}`,
+  isRelayAlreadyInstalled: vi.fn().mockResolvedValue(true),
+  finalizeInstall: vi.fn().mockResolvedValue(undefined),
+  abandonInstall: vi.fn().mockResolvedValue(undefined),
+  gcOldRelayVersions: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('./ssh-relay-install-lock', () => ({
+  acquireInstallLock: vi.fn().mockResolvedValue(undefined),
+  RELAY_INSTALL_LOCK_NAME: '.install-lock'
+}))
+
+vi.mock('./ssh-relay-repair-lock', () => ({
+  tryAcquireRelayRepairLock: vi.fn().mockResolvedValue('acquired')
+}))
+
+import { deployAndLaunchRelay } from './ssh-relay-deploy'
+import { execCommand, waitForSentinel } from './ssh-relay-deploy-helpers'
+import { writeRelayEndpointCredential } from './ssh-relay-endpoint-credential'
+import { isRelaySocketOwnerLiveError } from './ssh-relay-socket-owner'
+import type { SshConnection } from './ssh-connection'
+
+function makeMockConnection(): SshConnection {
+  return {
+    canRunConcurrentExecCommands: vi.fn().mockReturnValue(true),
+    exec: vi.fn().mockResolvedValue({
+      on: vi.fn(),
+      stderr: { on: vi.fn() },
+      stdin: {},
+      stdout: { on: vi.fn() },
+      close: vi.fn()
+    }),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+    sftp: vi.fn().mockResolvedValue({
+      mkdir: vi.fn((_p: string, cb: (err: Error | null) => void) => cb(null)),
+      end: vi.fn()
+    })
+  } as unknown as SshConnection
+}
+
+/** Queue the exec replies deploy makes before it decides what to do with an occupied socket. */
+function queueDeployUpToOccupiedSocket(): void {
+  vi.mocked(execCommand)
+    .mockResolvedValueOnce('__ORCA_REMOTE_PLATFORM__ Linux x86_64')
+    .mockResolvedValueOnce('/home/user')
+    .mockResolvedValueOnce('ORCA-NATIVE-DEPS-OK')
+    .mockResolvedValueOnce('') // launch namespace marker
+    .mockResolvedValueOnce('ALIVE') // test -S: a socket inode is present
+}
+
+function execCommands(): string[] {
+  return vi.mocked(execCommand).mock.calls.map(([, command]) => command)
+}
+
+function execChannelCommands(conn: SshConnection): string[] {
+  return vi.mocked(conn.exec).mock.calls.map(([command]) => command)
+}
+
+describe('deployAndLaunchRelay socket displacement', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Why: an ordered queue drives the probes below; the default only absorbs the
+    // best-effort teardown commands deploy issues after the decision under test.
+    vi.mocked(execCommand).mockReset().mockResolvedValue('')
+    vi.mocked(waitForSentinel)
+      .mockReset()
+      .mockResolvedValue({ write: vi.fn(), onData: vi.fn(), onClose: vi.fn() } as never)
+  })
+
+  it('never removes or replaces a socket a live relay still owns', async () => {
+    const conn = makeMockConnection()
+    vi.mocked(waitForSentinel).mockRejectedValueOnce(new Error('relay reconnect refused'))
+    queueDeployUpToOccupiedSocket()
+    vi.mocked(execCommand).mockResolvedValueOnce('LIVE') // owner probe
+
+    await expect(deployAndLaunchRelay(conn)).rejects.toSatisfy(isRelaySocketOwnerLiveError)
+
+    expect(execCommands().some((command) => command.startsWith('rm -f'))).toBe(false)
+    expect(execChannelCommands(conn).some((command) => command.includes('--detached'))).toBe(false)
+    // Why: the credential is rotated per fresh launch, so writing one would lock the
+    // surviving relay out of every later --connect even if the socket were left alone.
+    expect(writeRelayEndpointCredential).not.toHaveBeenCalled()
+  })
+
+  it('never removes or replaces a socket whose owner it could not probe', async () => {
+    const conn = makeMockConnection()
+    vi.mocked(waitForSentinel).mockRejectedValueOnce(new Error('relay reconnect refused'))
+    queueDeployUpToOccupiedSocket()
+    vi.mocked(execCommand).mockResolvedValueOnce('') // owner probe produced no verdict
+
+    await expect(deployAndLaunchRelay(conn)).rejects.toSatisfy(isRelaySocketOwnerLiveError)
+
+    expect(execCommands().some((command) => command.startsWith('rm -f'))).toBe(false)
+    expect(execChannelCommands(conn).some((command) => command.includes('--detached'))).toBe(false)
+  })
+
+  it('still clears a stale socket whose owner is proven gone', async () => {
+    const conn = makeMockConnection()
+    vi.mocked(waitForSentinel)
+      .mockRejectedValueOnce(new Error('relay reconnect refused'))
+      .mockResolvedValue({ write: vi.fn(), onData: vi.fn(), onClose: vi.fn() } as never)
+    queueDeployUpToOccupiedSocket()
+    vi.mocked(execCommand)
+      .mockResolvedValueOnce('EXITED') // owner probe: connect refused
+      .mockResolvedValueOnce('') // rm -f
+      .mockResolvedValueOnce('READY') // socket readiness poll
+
+    await expect(deployAndLaunchRelay(conn)).resolves.toMatchObject({ nodePath: '/usr/bin/node' })
+
+    const removals = execCommands().filter((command) => command.startsWith('rm -f'))
+    expect(removals).toHaveLength(1)
+    expect(removals[0]).toContain('.sock')
+    expect(execChannelCommands(conn).some((command) => command.includes('--detached'))).toBe(true)
+  })
+
+  // Moved here from ssh-relay-deploy.test.ts: the removal it guards now lives behind the owner probe.
+  it('does not launch fresh after unconfirmed stale-socket cleanup', async () => {
+    const conn = makeMockConnection()
+    const unconfirmedCleanup = Object.assign(new Error('socket cleanup still running'), {
+      sshChannelCloseConfirmed: false
+    })
+    vi.mocked(waitForSentinel).mockRejectedValueOnce(new Error('stale relay reconnect failed'))
+    queueDeployUpToOccupiedSocket()
+    vi.mocked(execCommand)
+      .mockResolvedValueOnce('EXITED') // owner probe
+      .mockRejectedValueOnce(unconfirmedCleanup)
+
+    await expect(deployAndLaunchRelay(conn)).rejects.toBe(unconfirmedCleanup)
+
+    expect(execChannelCommands(conn)).toHaveLength(1)
+    expect(execChannelCommands(conn).some((command) => command.includes('--detached'))).toBe(false)
+  })
+
+  it('probes the socket by connecting to it, not by testing the inode again', async () => {
+    const conn = makeMockConnection()
+    vi.mocked(waitForSentinel).mockRejectedValueOnce(new Error('relay reconnect refused'))
+    queueDeployUpToOccupiedSocket()
+    vi.mocked(execCommand).mockResolvedValueOnce('LIVE')
+
+    await expect(deployAndLaunchRelay(conn)).rejects.toSatisfy(isRelaySocketOwnerLiveError)
+
+    const ownerProbe = execCommands().at(-1) ?? ''
+    expect(ownerProbe).toContain('/usr/bin/node')
+    expect(ownerProbe).toContain('connect')
+    expect(ownerProbe).not.toContain('test -S')
+  })
+})

--- a/src/main/ssh/ssh-relay-socket-owner.integration.test.ts
+++ b/src/main/ssh/ssh-relay-socket-owner.integration.test.ts
@@ -24,22 +24,13 @@ import {
   delay,
   isProcessAlive,
   killProcessTree,
-  relayBundleDirForHost,
+  relayBundleDirOrFailWhenRequired,
   waitForExit
 } from './ssh-relay-live-daemon-harness'
 import { isRelaySocketOwnerLiveError, requireUnownedRelaySocket } from './ssh-relay-socket-owner'
 
 const REPO_ROOT = process.cwd()
-const BUNDLE_DIR = relayBundleDirForHost(REPO_ROOT)
-
-// Why: skipping is right on a developer machine that never ran `pnpm build:relay`, and
-// wrong in the CI job that exists to run this file — there a skip is green with no daemon
-// ever started. The job sets this so the missing bundle fails instead.
-if (process.env.ORCA_REQUIRE_RELAY_BUNDLE === '1' && !BUNDLE_DIR) {
-  throw new Error(
-    `No relay bundle at out/relay/${process.platform}-${process.arch}; run pnpm build:relay first.`
-  )
-}
+const BUNDLE_DIR = relayBundleDirOrFailWhenRequired(REPO_ROOT)
 
 type RelayStatus = {
   pid: number

--- a/src/main/ssh/ssh-relay-socket-owner.integration.test.ts
+++ b/src/main/ssh/ssh-relay-socket-owner.integration.test.ts
@@ -6,13 +6,15 @@
 // inside them — invisible to the app, and never reaped (`--grace-time 0` arms no timer
 // while a PTY is held).
 //
-// The control case below is latest-main's behaviour: it performs the raw `rm -f` and
-// asserts the orphan appears. The guarded case asserts removeUnownedRelaySocket refuses
-// the same displacement, which restores the relay's own EADDRINUSE interlock.
+// The control case below is latest-main's behaviour: it performs the raw unlink and
+// asserts the orphan appears. The guarded case asserts releaseUnownedRelaySocket refuses
+// the same displacement, which restores the relay's own EADDRINUSE interlock. Which
+// production call site issues that release is pinned separately, by the mocked deploy
+// wiring in ssh-relay-socket-displacement.test.ts.
 //
-// Requires `pnpm build:relay`; skipped when the bundle for this host is absent.
+// Requires `pnpm build:relay`; the CI job that runs this file builds it first.
 
-import { mkdtempSync, rmSync, existsSync } from 'node:fs'
+import { existsSync, mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -25,14 +27,19 @@ import {
   relayBundleDirForHost,
   waitForExit
 } from './ssh-relay-live-daemon-harness'
-import {
-  isRelaySocketOwnerLiveError,
-  probeRelaySocketOwner,
-  removeUnownedRelaySocket
-} from './ssh-relay-socket-owner'
+import { isRelaySocketOwnerLiveError, releaseUnownedRelaySocket } from './ssh-relay-socket-owner'
 
 const REPO_ROOT = process.cwd()
 const BUNDLE_DIR = relayBundleDirForHost(REPO_ROOT)
+
+// Why: skipping is right on a developer machine that never ran `pnpm build:relay`, and
+// wrong in the CI job that exists to run this file — there a skip is green with no daemon
+// ever started. The job sets this so the missing bundle fails instead.
+if (process.env.ORCA_REQUIRE_RELAY_BUNDLE === '1' && !BUNDLE_DIR) {
+  throw new Error(
+    `No relay bundle at out/relay/${process.platform}-${process.arch}; run pnpm build:relay first.`
+  )
+}
 
 type RelayStatus = {
   pid: number
@@ -68,38 +75,46 @@ describe.skipIf(!BUNDLE_DIR || process.platform === 'win32')('relay socket owner
     // Why: the app walking away is what starts the incumbent's grace window; with
     // --grace-time 0 and a live PTY that window arms no timer, so nothing reaps it.
     bridge.close()
-    await delay(500)
+    await live.waitForClientDisconnect('incumbent')
     return { fixture: live, pid: status.pid }
   }
 
-  it('reports a daemon that is listening as live, and a socket nobody holds as exited', async () => {
+  async function waitForDeath(pid: number): Promise<void> {
+    for (let attempt = 0; attempt < 50 && isProcessAlive(pid); attempt++) {
+      await delay(100)
+    }
+    expect(isProcessAlive(pid)).toBe(false)
+  }
+
+  it('releases the socket of a relay that is really gone', async () => {
     const { fixture: live, pid } = await startRelayHoldingAPty()
     const conn = createLocalShellConnection()
-
-    await expect(probeRelaySocketOwner(conn, process.execPath, live.sockPath)).resolves.toBe('live')
 
     // A crashed relay leaves the inode behind; that, and only that, is a stale socket.
     killProcessTree(pid)
-    await delay(500)
+    await waitForDeath(pid)
     expect(existsSync(live.sockPath)).toBe(true)
-    await expect(probeRelaySocketOwner(conn, process.execPath, live.sockPath)).resolves.toBe(
-      'exited'
-    )
+
+    await expect(
+      releaseUnownedRelaySocket(conn, process.execPath, live.sockPath)
+    ).resolves.toBeUndefined()
+
+    expect(existsSync(live.sockPath)).toBe(false)
   })
 
-  it('refuses to unlink the socket of a relay that still holds a PTY', async () => {
+  it('refuses to release the socket of a relay that still holds a PTY', async () => {
     const { fixture: live, pid } = await startRelayHoldingAPty()
     const conn = createLocalShellConnection()
 
-    await expect(removeUnownedRelaySocket(conn, process.execPath, live.sockPath)).rejects.toSatisfy(
-      isRelaySocketOwnerLiveError
-    )
+    await expect(
+      releaseUnownedRelaySocket(conn, process.execPath, live.sockPath)
+    ).rejects.toSatisfy(isRelaySocketOwnerLiveError)
 
     expect(existsSync(live.sockPath)).toBe(true)
     expect(isProcessAlive(pid)).toBe(true)
 
     // The socket kept its owner, so a fresh daemon hits EADDRINUSE, finds a live
-    // listener, and refuses to start — the interlock the unconditional rm -f defeated.
+    // listener, and refuses to start — the interlock the unconditional unlink defeated.
     const replacement = live.launchDaemon('replacement')
     expect(await waitForExit(replacement)).not.toBe(0)
     const bridge = live.openBridge()
@@ -108,6 +123,21 @@ describe.skipIf(!BUNDLE_DIR || process.platform === 'win32')('relay socket owner
     expect(status.pid).toBe(pid)
     expect(status.ptys.active).toBe(1)
     bridge.close()
+  })
+
+  it('still sees a live owner on a host with no lsof', async () => {
+    const { fixture: live, pid } = await startRelayHoldingAPty()
+    // Why: minimal hosts ship neither lsof nor pgrep, so the connect probe is the only
+    // owner evidence there — and it is the branch that must never mistake a live daemon
+    // for a stale inode.
+    const conn = createLocalShellConnection({ path: '' })
+
+    await expect(
+      releaseUnownedRelaySocket(conn, process.execPath, live.sockPath)
+    ).rejects.toSatisfy(isRelaySocketOwnerLiveError)
+
+    expect(existsSync(live.sockPath)).toBe(true)
+    expect(isProcessAlive(pid)).toBe(true)
   })
 
   it('control: unlinking first orphans the incumbent relay and its PTY', async () => {

--- a/src/main/ssh/ssh-relay-socket-owner.integration.test.ts
+++ b/src/main/ssh/ssh-relay-socket-owner.integration.test.ts
@@ -61,8 +61,10 @@ describe.skipIf(!BUNDLE_DIR || process.platform === 'win32')('relay socket owner
   })
 
   async function startRelayHoldingAPty(): Promise<{ fixture: LiveRelayFixture; pid: number }> {
-    root = mkdtempSync(join(tmpdir(), 'orca-relay-ownership-'))
-    const live = new LiveRelayFixture(join(root, 'relay'), BUNDLE_DIR!, REPO_ROOT)
+    // Why the short prefix and no nested dir: sun_path caps a Unix socket at 104 bytes on
+    // macOS, and this machine's tmpdir already spends 62 of them.
+    root = mkdtempSync(join(tmpdir(), 'orca-rel-'))
+    const live = new LiveRelayFixture(root, BUNDLE_DIR!, REPO_ROOT)
     fixture = live
     live.launchDaemon('incumbent')
     expect(await live.waitForSocket()).toBe(true)
@@ -74,8 +76,9 @@ describe.skipIf(!BUNDLE_DIR || process.platform === 'win32')('relay socket owner
     expect(status.ptys.active).toBe(1)
     // Why: the app walking away is what starts the incumbent's grace window; with
     // --grace-time 0 and a live PTY that window arms no timer, so nothing reaps it.
+    const mark = live.logMark('incumbent')
     bridge.close()
-    await live.waitForClientDisconnect('incumbent')
+    await live.waitForClientDisconnect('incumbent', mark)
     return { fixture: live, pid: status.pid }
   }
 

--- a/src/main/ssh/ssh-relay-socket-owner.integration.test.ts
+++ b/src/main/ssh/ssh-relay-socket-owner.integration.test.ts
@@ -1,0 +1,128 @@
+// STA-1756 oracle, run against real relay daemons rather than mocked exec output.
+//
+// The reported defect: a failed `--connect` unlinked the relay socket and launched a
+// fresh detached relay over the same path. Unlinking cannot stop a daemon that already
+// bound that path, so the old relay stayed alive forever with its PTYs and every agent
+// inside them — invisible to the app, and never reaped (`--grace-time 0` arms no timer
+// while a PTY is held).
+//
+// The control case below is latest-main's behaviour: it performs the raw `rm -f` and
+// asserts the orphan appears. The guarded case asserts removeUnownedRelaySocket refuses
+// the same displacement, which restores the relay's own EADDRINUSE interlock.
+//
+// Requires `pnpm build:relay`; skipped when the bundle for this host is absent.
+
+import { mkdtempSync, rmSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  LiveRelayFixture,
+  createLocalShellConnection,
+  delay,
+  isProcessAlive,
+  relayBundleDirForHost
+} from './ssh-relay-live-daemon-harness'
+import {
+  isRelaySocketOwnerLiveError,
+  probeRelaySocketOwner,
+  removeUnownedRelaySocket
+} from './ssh-relay-socket-owner'
+
+const REPO_ROOT = process.cwd()
+const BUNDLE_DIR = relayBundleDirForHost(REPO_ROOT)
+
+type RelayStatus = {
+  pid: number
+  ptys: { active: number }
+  socket: { path: string; owned: boolean; listening: boolean }
+}
+
+describe.skipIf(!BUNDLE_DIR || process.platform === 'win32')('relay socket ownership', () => {
+  let fixture: LiveRelayFixture | null = null
+  let root: string | null = null
+
+  afterEach(() => {
+    fixture?.dispose()
+    fixture = null
+    if (root) {
+      rmSync(root, { recursive: true, force: true })
+      root = null
+    }
+  })
+
+  async function startRelayHoldingAPty(): Promise<{ fixture: LiveRelayFixture; pid: number }> {
+    root = mkdtempSync(join(tmpdir(), 'orca-relay-ownership-'))
+    const live = new LiveRelayFixture(join(root, 'relay'), BUNDLE_DIR!, REPO_ROOT)
+    fixture = live
+    live.launchDaemon('incumbent')
+    expect(await live.waitForSocket()).toBe(true)
+
+    const bridge = live.openBridge()
+    await bridge.waitForSentinel()
+    await bridge.request('pty.spawn', { cwd: root, cols: 80, rows: 24 })
+    const status = await bridge.request<RelayStatus>('relay.status')
+    expect(status.ptys.active).toBe(1)
+    // Why: the app walking away is what starts the incumbent's grace window; with
+    // --grace-time 0 and a live PTY that window arms no timer, so nothing reaps it.
+    bridge.close()
+    await delay(500)
+    return { fixture: live, pid: status.pid }
+  }
+
+  it('reports a daemon that is listening as live, and a socket nobody holds as exited', async () => {
+    const { fixture: live, pid } = await startRelayHoldingAPty()
+    const conn = createLocalShellConnection()
+
+    await expect(probeRelaySocketOwner(conn, process.execPath, live.sockPath)).resolves.toBe('live')
+
+    // A crashed relay leaves the inode behind; that, and only that, is a stale socket.
+    process.kill(pid, 'SIGKILL')
+    await delay(500)
+    expect(existsSync(live.sockPath)).toBe(true)
+    await expect(probeRelaySocketOwner(conn, process.execPath, live.sockPath)).resolves.toBe(
+      'exited'
+    )
+  })
+
+  it('refuses to unlink the socket of a relay that still holds a PTY', async () => {
+    const { fixture: live, pid } = await startRelayHoldingAPty()
+    const conn = createLocalShellConnection()
+
+    await expect(removeUnownedRelaySocket(conn, process.execPath, live.sockPath)).rejects.toSatisfy(
+      isRelaySocketOwnerLiveError
+    )
+
+    expect(existsSync(live.sockPath)).toBe(true)
+    expect(isProcessAlive(pid)).toBe(true)
+
+    // The socket kept its owner, so a fresh daemon hits EADDRINUSE, finds a live
+    // listener, and refuses to start — the interlock the unconditional rm -f defeated.
+    live.launchDaemon('replacement')
+    await delay(2_000)
+    const bridge = live.openBridge()
+    await bridge.waitForSentinel()
+    const status = await bridge.request<RelayStatus>('relay.status')
+    expect(status.pid).toBe(pid)
+    expect(status.ptys.active).toBe(1)
+    bridge.close()
+  })
+
+  it('control: unlinking first orphans the incumbent relay and its PTY', async () => {
+    const { fixture: live, pid } = await startRelayHoldingAPty()
+
+    rmSync(live.sockPath, { force: true })
+    live.launchDaemon('replacement')
+    expect(await live.waitForSocket()).toBe(true)
+    const bridge = live.openBridge()
+    await bridge.waitForSentinel()
+    const status = await bridge.request<RelayStatus>('relay.status')
+
+    // The socket path now answers for a different daemon that owns no PTYs, while the
+    // incumbent is still running with the user's shell and no way to ever be reached.
+    expect(status.pid).not.toBe(pid)
+    expect(status.ptys.active).toBe(0)
+    expect(isProcessAlive(pid)).toBe(true)
+    bridge.close()
+  })
+})

--- a/src/main/ssh/ssh-relay-socket-owner.integration.test.ts
+++ b/src/main/ssh/ssh-relay-socket-owner.integration.test.ts
@@ -21,7 +21,9 @@ import {
   createLocalShellConnection,
   delay,
   isProcessAlive,
-  relayBundleDirForHost
+  killProcessTree,
+  relayBundleDirForHost,
+  waitForExit
 } from './ssh-relay-live-daemon-harness'
 import {
   isRelaySocketOwnerLiveError,
@@ -42,8 +44,8 @@ describe.skipIf(!BUNDLE_DIR || process.platform === 'win32')('relay socket owner
   let fixture: LiveRelayFixture | null = null
   let root: string | null = null
 
-  afterEach(() => {
-    fixture?.dispose()
+  afterEach(async () => {
+    await fixture?.dispose()
     fixture = null
     if (root) {
       rmSync(root, { recursive: true, force: true })
@@ -77,7 +79,7 @@ describe.skipIf(!BUNDLE_DIR || process.platform === 'win32')('relay socket owner
     await expect(probeRelaySocketOwner(conn, process.execPath, live.sockPath)).resolves.toBe('live')
 
     // A crashed relay leaves the inode behind; that, and only that, is a stale socket.
-    process.kill(pid, 'SIGKILL')
+    killProcessTree(pid)
     await delay(500)
     expect(existsSync(live.sockPath)).toBe(true)
     await expect(probeRelaySocketOwner(conn, process.execPath, live.sockPath)).resolves.toBe(
@@ -98,8 +100,8 @@ describe.skipIf(!BUNDLE_DIR || process.platform === 'win32')('relay socket owner
 
     // The socket kept its owner, so a fresh daemon hits EADDRINUSE, finds a live
     // listener, and refuses to start — the interlock the unconditional rm -f defeated.
-    live.launchDaemon('replacement')
-    await delay(2_000)
+    const replacement = live.launchDaemon('replacement')
+    expect(await waitForExit(replacement)).not.toBe(0)
     const bridge = live.openBridge()
     await bridge.waitForSentinel()
     const status = await bridge.request<RelayStatus>('relay.status')

--- a/src/main/ssh/ssh-relay-socket-owner.integration.test.ts
+++ b/src/main/ssh/ssh-relay-socket-owner.integration.test.ts
@@ -7,7 +7,7 @@
 // while a PTY is held).
 //
 // The control case below is latest-main's behaviour: it performs the raw unlink and
-// asserts the orphan appears. The guarded case asserts releaseUnownedRelaySocket refuses
+// asserts the orphan appears. The guarded case asserts requireUnownedRelaySocket refuses
 // the same displacement, which restores the relay's own EADDRINUSE interlock. Which
 // production call site issues that release is pinned separately, by the mocked deploy
 // wiring in ssh-relay-socket-displacement.test.ts.
@@ -27,7 +27,7 @@ import {
   relayBundleDirForHost,
   waitForExit
 } from './ssh-relay-live-daemon-harness'
-import { isRelaySocketOwnerLiveError, releaseUnownedRelaySocket } from './ssh-relay-socket-owner'
+import { isRelaySocketOwnerLiveError, requireUnownedRelaySocket } from './ssh-relay-socket-owner'
 
 const REPO_ROOT = process.cwd()
 const BUNDLE_DIR = relayBundleDirForHost(REPO_ROOT)
@@ -89,7 +89,7 @@ describe.skipIf(!BUNDLE_DIR || process.platform === 'win32')('relay socket owner
     expect(isProcessAlive(pid)).toBe(false)
   }
 
-  it('releases the socket of a relay that is really gone', async () => {
+  it('clears a relay that is really gone, without touching its socket', async () => {
     const { fixture: live, pid } = await startRelayHoldingAPty()
     const conn = createLocalShellConnection()
 
@@ -99,18 +99,20 @@ describe.skipIf(!BUNDLE_DIR || process.platform === 'win32')('relay socket owner
     expect(existsSync(live.sockPath)).toBe(true)
 
     await expect(
-      releaseUnownedRelaySocket(conn, process.execPath, live.sockPath)
+      requireUnownedRelaySocket(conn, process.execPath, live.sockPath)
     ).resolves.toBeUndefined()
 
-    expect(existsSync(live.sockPath)).toBe(false)
+    // Why still there: reclaiming the path belongs to the daemon that binds it, which does
+    // the identity check and the bind in one process.
+    expect(existsSync(live.sockPath)).toBe(true)
   })
 
-  it('refuses to release the socket of a relay that still holds a PTY', async () => {
+  it('refuses to hand the socket of a relay that still holds a PTY to a replacement', async () => {
     const { fixture: live, pid } = await startRelayHoldingAPty()
     const conn = createLocalShellConnection()
 
     await expect(
-      releaseUnownedRelaySocket(conn, process.execPath, live.sockPath)
+      requireUnownedRelaySocket(conn, process.execPath, live.sockPath)
     ).rejects.toSatisfy(isRelaySocketOwnerLiveError)
 
     expect(existsSync(live.sockPath)).toBe(true)
@@ -136,7 +138,7 @@ describe.skipIf(!BUNDLE_DIR || process.platform === 'win32')('relay socket owner
     const conn = createLocalShellConnection({ path: '' })
 
     await expect(
-      releaseUnownedRelaySocket(conn, process.execPath, live.sockPath)
+      requireUnownedRelaySocket(conn, process.execPath, live.sockPath)
     ).rejects.toSatisfy(isRelaySocketOwnerLiveError)
 
     expect(existsSync(live.sockPath)).toBe(true)

--- a/src/main/ssh/ssh-relay-socket-owner.test.ts
+++ b/src/main/ssh/ssh-relay-socket-owner.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./ssh-relay-deploy-helpers', () => ({
+  execCommand: vi.fn(),
+  isUnconfirmedSshCommandTermination: (error: unknown) =>
+    error instanceof Error &&
+    (error as Error & { sshChannelCloseConfirmed?: boolean }).sshChannelCloseConfirmed === false
+}))
+
+import type { SshConnection } from './ssh-connection'
+import { execCommand } from './ssh-relay-deploy-helpers'
+import {
+  isRelaySocketOwnerLiveError,
+  parseRelaySocketOwnerProbe,
+  probeRelaySocketOwner,
+  relaySocketOwnerProbeCommand,
+  removeUnownedRelaySocket
+} from './ssh-relay-socket-owner'
+
+const SOCK = '/home/u/.orca-remote/relay-0.1.0+abc/relay-deadbeef.sock'
+const NODE = '/usr/bin/node'
+const conn = {} as SshConnection
+
+function commands(): string[] {
+  return vi.mocked(execCommand).mock.calls.map(([, command]) => command)
+}
+
+describe('relay socket owner probe', () => {
+  beforeEach(() => {
+    vi.mocked(execCommand).mockReset()
+  })
+
+  it('probes by connecting, not by testing the inode', () => {
+    const command = relaySocketOwnerProbeCommand(NODE, SOCK)
+    expect(command).toContain('net')
+    expect(command).toContain('connect')
+    // Why: `test -S` is what the deploy probe already does, and it cannot tell a
+    // listening owner from an inode a crashed relay left behind.
+    expect(command).not.toContain('test -S')
+    expect(command).toContain(`'${SOCK}'`)
+  })
+
+  it('reads ECONNREFUSED and ENOENT as the only proof of an absent owner', () => {
+    expect(parseRelaySocketOwnerProbe('LIVE')).toBe('live')
+    expect(parseRelaySocketOwnerProbe('EXITED\n')).toBe('exited')
+    expect(parseRelaySocketOwnerProbe('UNVERIFIABLE')).toBe('unverifiable')
+  })
+
+  it('refuses to guess from ambiguous or empty probe output', () => {
+    expect(parseRelaySocketOwnerProbe('')).toBe('unverifiable')
+    expect(parseRelaySocketOwnerProbe('LIVE\nEXITED')).toBe('unverifiable')
+    expect(parseRelaySocketOwnerProbe('command not found: node')).toBe('unverifiable')
+  })
+
+  it('answers unverifiable when the probe cannot run at all', async () => {
+    vi.mocked(execCommand).mockRejectedValueOnce(new Error('channel open failure'))
+    await expect(probeRelaySocketOwner(conn, NODE, SOCK)).resolves.toBe('unverifiable')
+  })
+
+  it('propagates an abort instead of reporting a verdict', async () => {
+    const controller = new AbortController()
+    vi.mocked(execCommand).mockImplementationOnce(() => {
+      controller.abort()
+      return Promise.reject(new Error('aborted'))
+    })
+    await expect(probeRelaySocketOwner(conn, NODE, SOCK, controller.signal)).rejects.toThrow()
+  })
+})
+
+describe('removeUnownedRelaySocket', () => {
+  beforeEach(() => {
+    vi.mocked(execCommand).mockReset()
+  })
+
+  it('removes the socket once the probe proves nothing is listening', async () => {
+    vi.mocked(execCommand).mockResolvedValueOnce('EXITED').mockResolvedValueOnce('')
+
+    await removeUnownedRelaySocket(conn, NODE, SOCK)
+
+    expect(commands()[1]).toBe(`rm -f '${SOCK}'`)
+  })
+
+  it('leaves the socket of a live owner in place', async () => {
+    vi.mocked(execCommand).mockResolvedValueOnce('LIVE')
+
+    await expect(removeUnownedRelaySocket(conn, NODE, SOCK)).rejects.toSatisfy(
+      isRelaySocketOwnerLiveError
+    )
+
+    expect(commands().some((command) => command.startsWith('rm -f'))).toBe(false)
+  })
+
+  it('leaves the socket in place when ownership is merely unverifiable', async () => {
+    vi.mocked(execCommand).mockResolvedValueOnce('UNVERIFIABLE')
+
+    await expect(removeUnownedRelaySocket(conn, NODE, SOCK)).rejects.toSatisfy(
+      isRelaySocketOwnerLiveError
+    )
+
+    expect(commands().some((command) => command.startsWith('rm -f'))).toBe(false)
+  })
+
+  it('rethrows an unconfirmed removal so no fresh relay launches over it', async () => {
+    const unconfirmed = Object.assign(new Error('socket cleanup still running'), {
+      sshChannelCloseConfirmed: false
+    })
+    vi.mocked(execCommand).mockResolvedValueOnce('EXITED').mockRejectedValueOnce(unconfirmed)
+
+    await expect(removeUnownedRelaySocket(conn, NODE, SOCK)).rejects.toBe(unconfirmed)
+  })
+
+  it('names the socket and the recovery action in the error', async () => {
+    vi.mocked(execCommand).mockResolvedValueOnce('LIVE')
+    const cause = new Error('handshake refused')
+
+    const error = await removeUnownedRelaySocket(conn, NODE, SOCK, { cause }).catch((err) => err)
+
+    expect(error.sockPath).toBe(SOCK)
+    expect(error.verdict).toBe('live')
+    expect(error.cause).toBe(cause)
+    expect(error.message).toContain('Reset remote relay')
+  })
+})

--- a/src/main/ssh/ssh-relay-socket-owner.test.ts
+++ b/src/main/ssh/ssh-relay-socket-owner.test.ts
@@ -11,28 +11,21 @@ import type { SshConnection } from './ssh-connection'
 import { execCommand } from './ssh-relay-deploy-helpers'
 import {
   isRelaySocketOwnerLiveError,
-  parseRelaySocketOwnerProbe,
-  probeRelaySocketOwner,
-  relaySocketOwnerProbeCommand,
-  removeUnownedRelaySocket
+  parseRelaySocketReleaseOutcome,
+  relaySocketReleaseCommand,
+  releaseUnownedRelaySocket
 } from './ssh-relay-socket-owner'
 
 const SOCK = '/home/u/.orca-remote/relay-0.1.0+abc/relay-deadbeef.sock'
 const NODE = '/usr/bin/node'
 const conn = {} as SshConnection
 
-function commands(): string[] {
-  return vi.mocked(execCommand).mock.calls.map(([, command]) => command)
-}
+describe('relay socket release command', () => {
+  const command = relaySocketReleaseCommand(NODE, SOCK)
 
-describe('relay socket owner probe', () => {
-  beforeEach(() => {
-    vi.mocked(execCommand).mockReset()
-  })
-
-  it('probes by connecting, not by testing the inode', () => {
-    const command = relaySocketOwnerProbeCommand(NODE, SOCK)
-    expect(command).toContain('net')
+  it('proves an owner is present with lsof before falling back to a connect probe', () => {
+    expect(command).toContain('lsof -t -a -U "$sock"')
+    expect(command).toContain('echo LIVE')
     expect(command).toContain('connect')
     // Why: `test -S` is what the deploy probe already does, and it cannot tell a
     // listening owner from an inode a crashed relay left behind.
@@ -40,84 +33,101 @@ describe('relay socket owner probe', () => {
     expect(command).toContain(`'${SOCK}'`)
   })
 
-  it('reads ECONNREFUSED and ENOENT as the only proof of an absent owner', () => {
-    expect(parseRelaySocketOwnerProbe('LIVE')).toBe('live')
-    expect(parseRelaySocketOwnerProbe('EXITED\n')).toBe('exited')
-    expect(parseRelaySocketOwnerProbe('UNVERIFIABLE')).toBe('unverifiable')
+  it('unlinks inside the same host command, guarded by the inode it probed', () => {
+    // Why: probing here and removing in a second round-trip leaves a window in which
+    // another client can bind the path, and the removal would then strand it.
+    expect(command).toContain('unlinkSync')
+    expect(command).toContain('statSync')
+    expect(command).toContain('st.dev+":"+st.ino')
   })
 
-  it('refuses to guess from ambiguous or empty probe output', () => {
-    expect(parseRelaySocketOwnerProbe('')).toBe('unverifiable')
-    expect(parseRelaySocketOwnerProbe('LIVE\nEXITED')).toBe('unverifiable')
-    expect(parseRelaySocketOwnerProbe('command not found: node')).toBe('unverifiable')
+  it('retries a refused connect before concluding the path is unowned', () => {
+    // Why: a live listener with a momentarily full accept backlog also refuses.
+    expect(command).toContain('left=3')
+    expect(command).toContain('ECONNREFUSED')
+  })
+})
+
+describe('relay socket release outcome', () => {
+  it('reads the host markers', () => {
+    expect(parseRelaySocketReleaseOutcome('LIVE')).toBe('live')
+    expect(parseRelaySocketReleaseOutcome('RELEASED\n')).toBe('released')
+    expect(parseRelaySocketReleaseOutcome('UNVERIFIABLE')).toBe('unverifiable')
   })
 
-  it('answers unverifiable when the probe cannot run at all', async () => {
+  it('refuses to guess from ambiguous or empty output', () => {
+    expect(parseRelaySocketReleaseOutcome('')).toBe('unverifiable')
+    expect(parseRelaySocketReleaseOutcome('LIVE\nRELEASED')).toBe('unverifiable')
+    expect(parseRelaySocketReleaseOutcome('command not found: node')).toBe('unverifiable')
+  })
+})
+
+describe('releaseUnownedRelaySocket', () => {
+  beforeEach(() => {
+    vi.mocked(execCommand).mockReset()
+  })
+
+  it('succeeds once the host reports the path released', async () => {
+    vi.mocked(execCommand).mockResolvedValueOnce('RELEASED')
+
+    await expect(releaseUnownedRelaySocket(conn, NODE, SOCK)).resolves.toBeUndefined()
+  })
+
+  it('refuses when a live owner still holds the socket', async () => {
+    vi.mocked(execCommand).mockResolvedValueOnce('LIVE')
+
+    await expect(releaseUnownedRelaySocket(conn, NODE, SOCK)).rejects.toSatisfy(
+      isRelaySocketOwnerLiveError
+    )
+  })
+
+  it('refuses when ownership is merely unverifiable', async () => {
+    vi.mocked(execCommand).mockResolvedValueOnce('UNVERIFIABLE')
+
+    await expect(releaseUnownedRelaySocket(conn, NODE, SOCK)).rejects.toSatisfy(
+      isRelaySocketOwnerLiveError
+    )
+  })
+
+  it('refuses when the command could not run at all', async () => {
     vi.mocked(execCommand).mockRejectedValueOnce(new Error('channel open failure'))
-    await expect(probeRelaySocketOwner(conn, NODE, SOCK)).resolves.toBe('unverifiable')
+
+    await expect(releaseUnownedRelaySocket(conn, NODE, SOCK)).rejects.toSatisfy(
+      isRelaySocketOwnerLiveError
+    )
   })
 
-  it('propagates an abort instead of reporting a verdict', async () => {
+  it('rethrows an unconfirmed termination so its in-flight state survives', async () => {
+    const unconfirmed = Object.assign(new Error('socket cleanup still running'), {
+      sshChannelCloseConfirmed: false
+    })
+    vi.mocked(execCommand).mockRejectedValueOnce(unconfirmed)
+
+    await expect(releaseUnownedRelaySocket(conn, NODE, SOCK)).rejects.toBe(unconfirmed)
+  })
+
+  it('propagates an abort instead of reporting an outcome', async () => {
     const controller = new AbortController()
     vi.mocked(execCommand).mockImplementationOnce(() => {
       controller.abort()
       return Promise.reject(new Error('aborted'))
     })
-    await expect(probeRelaySocketOwner(conn, NODE, SOCK, controller.signal)).rejects.toThrow()
-  })
-})
 
-describe('removeUnownedRelaySocket', () => {
-  beforeEach(() => {
-    vi.mocked(execCommand).mockReset()
+    await expect(
+      releaseUnownedRelaySocket(conn, NODE, SOCK, { signal: controller.signal })
+    ).rejects.not.toSatisfy(isRelaySocketOwnerLiveError)
   })
 
-  it('removes the socket once the probe proves nothing is listening', async () => {
-    vi.mocked(execCommand).mockResolvedValueOnce('EXITED').mockResolvedValueOnce('')
-
-    await removeUnownedRelaySocket(conn, NODE, SOCK)
-
-    expect(commands()[1]).toBe(`rm -f '${SOCK}'`)
-  })
-
-  it('leaves the socket of a live owner in place', async () => {
-    vi.mocked(execCommand).mockResolvedValueOnce('LIVE')
-
-    await expect(removeUnownedRelaySocket(conn, NODE, SOCK)).rejects.toSatisfy(
-      isRelaySocketOwnerLiveError
-    )
-
-    expect(commands().some((command) => command.startsWith('rm -f'))).toBe(false)
-  })
-
-  it('leaves the socket in place when ownership is merely unverifiable', async () => {
-    vi.mocked(execCommand).mockResolvedValueOnce('UNVERIFIABLE')
-
-    await expect(removeUnownedRelaySocket(conn, NODE, SOCK)).rejects.toSatisfy(
-      isRelaySocketOwnerLiveError
-    )
-
-    expect(commands().some((command) => command.startsWith('rm -f'))).toBe(false)
-  })
-
-  it('rethrows an unconfirmed removal so no fresh relay launches over it', async () => {
-    const unconfirmed = Object.assign(new Error('socket cleanup still running'), {
-      sshChannelCloseConfirmed: false
-    })
-    vi.mocked(execCommand).mockResolvedValueOnce('EXITED').mockRejectedValueOnce(unconfirmed)
-
-    await expect(removeUnownedRelaySocket(conn, NODE, SOCK)).rejects.toBe(unconfirmed)
-  })
-
-  it('names the socket and the recovery action in the error', async () => {
+  it('names the socket, the reconnect failure, and the recovery action', async () => {
     vi.mocked(execCommand).mockResolvedValueOnce('LIVE')
     const cause = new Error('handshake refused')
 
-    const error = await removeUnownedRelaySocket(conn, NODE, SOCK, { cause }).catch((err) => err)
+    const error = await releaseUnownedRelaySocket(conn, NODE, SOCK, { cause }).catch((err) => err)
 
     expect(error.sockPath).toBe(SOCK)
-    expect(error.verdict).toBe('live')
+    expect(error.outcome).toBe('live')
     expect(error.cause).toBe(cause)
+    expect(error.message).toContain('handshake refused')
     expect(error.message).toContain('Reset remote relay')
   })
 })

--- a/src/main/ssh/ssh-relay-socket-owner.test.ts
+++ b/src/main/ssh/ssh-relay-socket-owner.test.ts
@@ -11,9 +11,9 @@ import type { SshConnection } from './ssh-connection'
 import { execCommand } from './ssh-relay-deploy-helpers'
 import {
   isRelaySocketOwnerLiveError,
-  parseRelaySocketReleaseOutcome,
-  relaySocketReleaseCommand,
-  releaseUnownedRelaySocket
+  parseRelaySocketOwnerVerdict,
+  relaySocketOwnerProbeCommand,
+  requireUnownedRelaySocket
 } from './ssh-relay-socket-owner'
 import {
   isRelayVersionMismatchError,
@@ -24,8 +24,8 @@ const SOCK = '/home/u/.orca-remote/relay-0.1.0+abc/relay-deadbeef.sock'
 const NODE = '/usr/bin/node'
 const conn = {} as SshConnection
 
-describe('relay socket release command', () => {
-  const command = relaySocketReleaseCommand(NODE, SOCK)
+describe('relay socket owner probe command', () => {
+  const command = relaySocketOwnerProbeCommand(NODE, SOCK)
 
   it('proves an owner is present with lsof before falling back to a connect probe', () => {
     expect(command).toContain('lsof -t -a -U "$sock"')
@@ -37,13 +37,12 @@ describe('relay socket release command', () => {
     expect(command).toContain(`'${SOCK}'`)
   })
 
-  it('unlinks inside the same host command, guarded by the inode it probed', () => {
-    // Why: probing here and removing in a second round-trip leaves a window in which
-    // another client can bind the path, and the removal would then strand it.
-    expect(command).toContain('unlinkSync')
-    expect(command).toContain('statSync')
-    // Why ctime: inode numbers are recycled, so dev+ino alone can match a recreated socket.
-    expect(command).toContain('st.dev+":"+st.ino+":"+st.ctimeNs')
+  it('only looks, and never removes anything itself', () => {
+    // Why: reclaiming the path is the fresh daemon's job, which checks the socket's identity
+    // and binds in one process. Unlinking here would put an SSH round-trip between that check
+    // and the launch, and a relay that bound the path in between would be the one displaced.
+    expect(command).not.toContain('unlinkSync')
+    expect(command).not.toContain('rm -f')
   })
 
   it('retries a refused connect before concluding the path is unowned', () => {
@@ -67,35 +66,35 @@ describe('relay socket release command', () => {
   })
 })
 
-describe('relay socket release outcome', () => {
+describe('relay socket owner verdict', () => {
   it('reads the host markers', () => {
-    expect(parseRelaySocketReleaseOutcome('LIVE')).toBe('live')
-    expect(parseRelaySocketReleaseOutcome('RELEASED\n')).toBe('released')
-    expect(parseRelaySocketReleaseOutcome('UNVERIFIABLE')).toBe('unverifiable')
+    expect(parseRelaySocketOwnerVerdict('LIVE')).toBe('live')
+    expect(parseRelaySocketOwnerVerdict('EXITED\n')).toBe('exited')
+    expect(parseRelaySocketOwnerVerdict('UNVERIFIABLE')).toBe('unverifiable')
   })
 
   it('refuses to guess from ambiguous or empty output', () => {
-    expect(parseRelaySocketReleaseOutcome('')).toBe('unverifiable')
-    expect(parseRelaySocketReleaseOutcome('LIVE\nRELEASED')).toBe('unverifiable')
-    expect(parseRelaySocketReleaseOutcome('command not found: node')).toBe('unverifiable')
+    expect(parseRelaySocketOwnerVerdict('')).toBe('unverifiable')
+    expect(parseRelaySocketOwnerVerdict('LIVE\nEXITED')).toBe('unverifiable')
+    expect(parseRelaySocketOwnerVerdict('command not found: node')).toBe('unverifiable')
   })
 })
 
-describe('releaseUnownedRelaySocket', () => {
+describe('requireUnownedRelaySocket', () => {
   beforeEach(() => {
     vi.mocked(execCommand).mockReset()
   })
 
-  it('succeeds once the host reports the path released', async () => {
-    vi.mocked(execCommand).mockResolvedValueOnce('RELEASED')
+  it('succeeds once the host proves nothing owns the path', async () => {
+    vi.mocked(execCommand).mockResolvedValueOnce('EXITED')
 
-    await expect(releaseUnownedRelaySocket(conn, NODE, SOCK)).resolves.toBeUndefined()
+    await expect(requireUnownedRelaySocket(conn, NODE, SOCK)).resolves.toBeUndefined()
   })
 
   it('refuses when a live owner still holds the socket', async () => {
     vi.mocked(execCommand).mockResolvedValueOnce('LIVE')
 
-    await expect(releaseUnownedRelaySocket(conn, NODE, SOCK)).rejects.toSatisfy(
+    await expect(requireUnownedRelaySocket(conn, NODE, SOCK)).rejects.toSatisfy(
       isRelaySocketOwnerLiveError
     )
   })
@@ -103,7 +102,7 @@ describe('releaseUnownedRelaySocket', () => {
   it('refuses when ownership is merely unverifiable', async () => {
     vi.mocked(execCommand).mockResolvedValueOnce('UNVERIFIABLE')
 
-    await expect(releaseUnownedRelaySocket(conn, NODE, SOCK)).rejects.toSatisfy(
+    await expect(requireUnownedRelaySocket(conn, NODE, SOCK)).rejects.toSatisfy(
       isRelaySocketOwnerLiveError
     )
   })
@@ -111,18 +110,9 @@ describe('releaseUnownedRelaySocket', () => {
   it('refuses when the command could not run at all', async () => {
     vi.mocked(execCommand).mockRejectedValueOnce(new Error('channel open failure'))
 
-    await expect(releaseUnownedRelaySocket(conn, NODE, SOCK)).rejects.toSatisfy(
+    await expect(requireUnownedRelaySocket(conn, NODE, SOCK)).rejects.toSatisfy(
       isRelaySocketOwnerLiveError
     )
-  })
-
-  it('rethrows an unconfirmed termination so its in-flight state survives', async () => {
-    const unconfirmed = Object.assign(new Error('socket cleanup still running'), {
-      sshChannelCloseConfirmed: false
-    })
-    vi.mocked(execCommand).mockRejectedValueOnce(unconfirmed)
-
-    await expect(releaseUnownedRelaySocket(conn, NODE, SOCK)).rejects.toBe(unconfirmed)
   })
 
   it('propagates an abort instead of reporting an outcome', async () => {
@@ -133,7 +123,7 @@ describe('releaseUnownedRelaySocket', () => {
     })
 
     await expect(
-      releaseUnownedRelaySocket(conn, NODE, SOCK, { signal: controller.signal })
+      requireUnownedRelaySocket(conn, NODE, SOCK, { signal: controller.signal })
     ).rejects.not.toSatisfy(isRelaySocketOwnerLiveError)
   })
 
@@ -141,10 +131,10 @@ describe('releaseUnownedRelaySocket', () => {
     vi.mocked(execCommand).mockResolvedValueOnce('LIVE')
     const cause = new Error('handshake refused')
 
-    const error = await releaseUnownedRelaySocket(conn, NODE, SOCK, { cause }).catch((err) => err)
+    const error = await requireUnownedRelaySocket(conn, NODE, SOCK, { cause }).catch((err) => err)
 
     expect(error.sockPath).toBe(SOCK)
-    expect(error.outcome).toBe('live')
+    expect(error.verdict).toBe('live')
     expect(error.cause).toBe(cause)
     expect(error.message).toContain('handshake refused')
     expect(error.message).toContain('Reset remote relay')
@@ -156,7 +146,7 @@ describe('terminal causes carried by the owner error', () => {
     vi.mocked(execCommand).mockReset().mockResolvedValueOnce('LIVE')
     const mismatch = new RelayVersionMismatchError('0.1.0+new', '0.1.0+old')
 
-    const error = await releaseUnownedRelaySocket(conn, NODE, SOCK, { cause: mismatch }).catch(
+    const error = await requireUnownedRelaySocket(conn, NODE, SOCK, { cause: mismatch }).catch(
       (err) => err
     )
 
@@ -168,7 +158,7 @@ describe('terminal causes carried by the owner error', () => {
   it('does not classify an ordinary reconnect failure as terminal', async () => {
     vi.mocked(execCommand).mockReset().mockResolvedValueOnce('LIVE')
 
-    const error = await releaseUnownedRelaySocket(conn, NODE, SOCK, {
+    const error = await requireUnownedRelaySocket(conn, NODE, SOCK, {
       cause: new Error('relay sentinel timeout')
     }).catch((err) => err)
 

--- a/src/main/ssh/ssh-relay-socket-owner.test.ts
+++ b/src/main/ssh/ssh-relay-socket-owner.test.ts
@@ -51,6 +51,20 @@ describe('relay socket release command', () => {
     expect(command).toContain('left=3')
     expect(command).toContain('ECONNREFUSED')
   })
+
+  it('needs an owner inventory, not just refusals, before it may unlink', () => {
+    // Why: refusals are an inference. /proc/net/unix, or an lsof proven able to inspect
+    // this user's own process, is the evidence — with neither the answer is unverifiable.
+    expect(command).toContain('/proc/net/unix')
+    expect(command).toContain('lsof -t -p $$')
+    expect(command).toContain('proof=none')
+  })
+
+  it('compares the pathname column exactly rather than matching a line suffix', () => {
+    // Why: a live socket whose own path ends with " " plus ours would match a suffix test,
+    // and a path holding regex metacharacters would break an interpolated pattern.
+    expect(command).toContain('replace(/^(?:[^ ]+ +){7}/,"")===p')
+  })
 })
 
 describe('relay socket release outcome', () => {

--- a/src/main/ssh/ssh-relay-socket-owner.test.ts
+++ b/src/main/ssh/ssh-relay-socket-owner.test.ts
@@ -15,6 +15,10 @@ import {
   relaySocketReleaseCommand,
   releaseUnownedRelaySocket
 } from './ssh-relay-socket-owner'
+import {
+  isRelayVersionMismatchError,
+  RelayVersionMismatchError
+} from './ssh-relay-version-mismatch-error'
 
 const SOCK = '/home/u/.orca-remote/relay-0.1.0+abc/relay-deadbeef.sock'
 const NODE = '/usr/bin/node'
@@ -38,7 +42,8 @@ describe('relay socket release command', () => {
     // another client can bind the path, and the removal would then strand it.
     expect(command).toContain('unlinkSync')
     expect(command).toContain('statSync')
-    expect(command).toContain('st.dev+":"+st.ino')
+    // Why ctime: inode numbers are recycled, so dev+ino alone can match a recreated socket.
+    expect(command).toContain('st.dev+":"+st.ino+":"+st.ctimeNs')
   })
 
   it('retries a refused connect before concluding the path is unowned', () => {
@@ -129,5 +134,30 @@ describe('releaseUnownedRelaySocket', () => {
     expect(error.cause).toBe(cause)
     expect(error.message).toContain('handshake refused')
     expect(error.message).toContain('Reset remote relay')
+  })
+})
+
+describe('terminal causes carried by the owner error', () => {
+  it('keeps a wrapped version mismatch classified as terminal', async () => {
+    vi.mocked(execCommand).mockReset().mockResolvedValueOnce('LIVE')
+    const mismatch = new RelayVersionMismatchError('0.1.0+new', '0.1.0+old')
+
+    const error = await releaseUnownedRelaySocket(conn, NODE, SOCK, { cause: mismatch }).catch(
+      (err) => err
+    )
+
+    // Why: without this the bounded relay-lost backoff would spend six attempts on a
+    // version the daemon cannot change, then blame a dropping channel.
+    expect(isRelayVersionMismatchError(error)).toBe(true)
+  })
+
+  it('does not classify an ordinary reconnect failure as terminal', async () => {
+    vi.mocked(execCommand).mockReset().mockResolvedValueOnce('LIVE')
+
+    const error = await releaseUnownedRelaySocket(conn, NODE, SOCK, {
+      cause: new Error('relay sentinel timeout')
+    }).catch((err) => err)
+
+    expect(isRelayVersionMismatchError(error)).toBe(false)
   })
 })

--- a/src/main/ssh/ssh-relay-socket-owner.ts
+++ b/src/main/ssh/ssh-relay-socket-owner.ts
@@ -3,41 +3,61 @@ import { shellEscape } from './ssh-connection-utils'
 import { execCommand, isUnconfirmedSshCommandTermination } from './ssh-relay-deploy-helpers'
 
 /**
- * Who owns a relay socket path, as observed from the client.
+ * What happened when we asked the host to release a relay socket path.
  *
- * The vocabulary is pinned by docs/reference/ssh-execution-boundary.md:
- * `exited` requires positive evidence of absence, and anything we could not
- * observe stays `unverifiable` — never collapsed into either neighbour.
- * Here the subject is the socket path: `exited` means the connect attempt was
- * actively refused, so no process is listening at that path any more.
+ * The vocabulary follows `src/shared/pty-liveness-verdict.ts`: `released` needs
+ * positive evidence that nothing owns the path, and anything we could not
+ * observe stays `unverifiable` — never read as absence.
  */
-export type RelaySocketOwnerVerdict = 'live' | 'exited' | 'unverifiable'
+export type RelaySocketReleaseOutcome = 'live' | 'released' | 'unverifiable'
 
 const PROBE_TIMEOUT_MS = 3_000
+const PROBE_ATTEMPTS = 3
+const PROBE_RETRY_MS = 250
 
-// Why: probe via node (guaranteed present on the host — it is what runs the relay)
-// rather than lsof/fuser/socat, which vary by distro and are often absent.
-// Why: `test -S` only proves the inode exists; a connect-and-close is the only
-// thing that separates a listening owner from an inode a crashed relay left behind.
-const RELAY_SOCKET_OWNER_PROBE_SCRIPT =
-  'var net=require("net"),done=false,' +
-  'say=function(v){if(done)return;done=true;clearTimeout(t);process.stdout.write(v);s.destroy()},' +
-  's=net.connect(process.argv[1]),' +
-  `t=setTimeout(function(){say("UNVERIFIABLE")},${PROBE_TIMEOUT_MS});` +
-  's.on("connect",function(){say("LIVE")});' +
-  's.on("error",function(e){say(e.code==="ECONNREFUSED"||e.code==="ENOENT"?"EXITED":"UNVERIFIABLE")})'
+// Why one host-side script rather than probe-then-remove from here: an SSH round-trip
+// between the two is wide enough for another client to bind the path, and the removal
+// would then unlink a live owner's socket. The unlink is guarded by the same dev/ino
+// recheck the relay uses for its own stale-socket cleanup (relay.ts unlinkIfStillStale).
+//
+// Why retry ECONNREFUSED: a live Unix listener whose accept backlog is momentarily full
+// also refuses connections. A stale inode refuses every time; saturation drains.
+const RELAY_SOCKET_RELEASE_SCRIPT =
+  'var net=require("net"),fs=require("fs"),p=process.argv[1],' +
+  `left=${PROBE_ATTEMPTS},mark=null,done=false,sock=null,timer=null;` +
+  'function ident(){try{var st=fs.statSync(p);return st.dev+":"+st.ino}catch(e){return null}}' +
+  'function say(v){if(done)return;done=true;if(timer)clearTimeout(timer);' +
+  'if(sock)sock.destroy();process.stdout.write(v)}' +
+  'function release(){if(mark===null){say("RELEASED");return}' +
+  'if(ident()!==mark){say("UNVERIFIABLE");return}' +
+  'try{fs.unlinkSync(p)}catch(e){if(e.code!=="ENOENT"){say("UNVERIFIABLE");return}}say("RELEASED")}' +
+  'function attempt(){mark=ident();sock=net.connect(p);' +
+  `timer=setTimeout(function(){say("UNVERIFIABLE")},${PROBE_TIMEOUT_MS});` +
+  'sock.on("connect",function(){say("LIVE")});' +
+  'sock.on("error",function(e){clearTimeout(timer);' +
+  'if(e.code==="ENOENT"){say("RELEASED");return}' +
+  'if(e.code!=="ECONNREFUSED"){say("UNVERIFIABLE");return}' +
+  `if(--left>0){setTimeout(attempt,${PROBE_RETRY_MS});return}release()})}attempt()`
 
-export function relaySocketOwnerProbeCommand(nodePath: string, sockPath: string): string {
-  // Why: pass the socket path as argv[1] rather than interpolating it into -e, to dodge quoting issues.
-  return `${shellEscape(nodePath)} -e ${shellEscape(RELAY_SOCKET_OWNER_PROBE_SCRIPT)} ${shellEscape(sockPath)}`
+export function relaySocketReleaseCommand(nodePath: string, sockPath: string): string {
+  // Why lsof first: it is the one portable way to prove an owner is *there*. Its silence is
+  // never read as absence — a denied or absent lsof just falls through to the probe.
+  // Why -a: lsof ORs selectors by default, which would match every Unix-socket holder (#8762).
+  return (
+    `sock=${shellEscape(sockPath)}; ` +
+    'if command -v lsof >/dev/null 2>&1 && [ -n "$(lsof -t -a -U "$sock" 2>/dev/null)" ]; ' +
+    'then echo LIVE; ' +
+    // Why argv[1]: passing the path as an argument dodges quoting issues inside -e.
+    `else ${shellEscape(nodePath)} -e ${shellEscape(RELAY_SOCKET_RELEASE_SCRIPT)} "$sock"; fi`
+  )
 }
 
-export function parseRelaySocketOwnerProbe(output: string): RelaySocketOwnerVerdict {
+export function parseRelaySocketReleaseOutcome(output: string): RelaySocketReleaseOutcome {
   const markers = new Set(
     output
       .split(/\r?\n/)
       .map((line) => line.trim())
-      .filter((line) => line === 'LIVE' || line === 'EXITED' || line === 'UNVERIFIABLE')
+      .filter((line) => line === 'LIVE' || line === 'RELEASED' || line === 'UNVERIFIABLE')
   )
   if (markers.size !== 1) {
     return 'unverifiable'
@@ -45,25 +65,7 @@ export function parseRelaySocketOwnerProbe(output: string): RelaySocketOwnerVerd
   if (markers.has('LIVE')) {
     return 'live'
   }
-  return markers.has('EXITED') ? 'exited' : 'unverifiable'
-}
-
-export async function probeRelaySocketOwner(
-  conn: SshConnection,
-  nodePath: string,
-  sockPath: string,
-  signal?: AbortSignal
-): Promise<RelaySocketOwnerVerdict> {
-  try {
-    return parseRelaySocketOwnerProbe(
-      await execCommand(conn, relaySocketOwnerProbeCommand(nodePath, sockPath), { signal })
-    )
-  } catch {
-    // Why: a probe we could not run answers nothing about the owner, and the
-    // caller must not treat that silence as death.
-    signal?.throwIfAborted()
-    return 'unverifiable'
-  }
+  return markers.has('RELEASED') ? 'released' : 'unverifiable'
 }
 
 export class RelaySocketOwnerLiveError extends Error {
@@ -71,14 +73,17 @@ export class RelaySocketOwnerLiveError extends Error {
 
   constructor(
     readonly sockPath: string,
-    readonly verdict: Exclude<RelaySocketOwnerVerdict, 'exited'>,
-    readonly cause?: unknown
+    readonly outcome: Exclude<RelaySocketReleaseOutcome, 'released'>,
+    cause?: unknown
   ) {
     super(
       `Could not reach the relay at ${sockPath}, and its socket is ${
-        verdict === 'live' ? 'still owned by a running relay' : 'of unproven ownership'
-      }. Leaving it in place — replacing it would strand that relay and every terminal it holds. ` +
-        'Retry, or use "Reset remote relay" on the SSH target to stop it.'
+        outcome === 'live' ? 'still owned by a running relay' : 'of unproven ownership'
+      }. Leaving it in place — replacing it would strand that relay and every terminal it ` +
+        `holds. Retry, or use "Reset remote relay" on the SSH target to stop it.${
+          cause instanceof Error ? ` Reconnect failed with: ${cause.message}` : ''
+        }`,
+      { cause }
     )
   }
 }
@@ -88,30 +93,42 @@ export function isRelaySocketOwnerLiveError(err: unknown): err is RelaySocketOwn
 }
 
 /**
- * Remove a relay socket so a fresh daemon can bind the same path — but only
- * once the probe proves nothing is listening there.
+ * Release a relay socket path so a fresh daemon can bind it — and only when the host
+ * proves nothing owns it.
  *
- * Why this gate: unlinking cannot stop a relay that already bound the path. It
- * only hides the live owner from the fresh launch's EADDRINUSE stale-socket
- * check, which is the one interlock that refuses to displace a running daemon.
- * A failed `--connect` is loss of contact, never proof of death (STA-1756).
+ * Why the guard: unlinking cannot stop a relay that already bound the path. It only hides
+ * the live owner from the fresh launch's EADDRINUSE check, which is the one interlock that
+ * refuses to displace a running daemon. A failed `--connect` is loss of contact, never
+ * proof of death (STA-1756).
+ *
+ * POSIX hosts only: Windows relays take the named-pipe path in launchWindowsRelay, where
+ * there is no inode to unlink.
  */
-export async function removeUnownedRelaySocket(
+export async function releaseUnownedRelaySocket(
   conn: SshConnection,
   nodePath: string,
   sockPath: string,
   options?: { signal?: AbortSignal; cause?: unknown }
 ): Promise<void> {
   const signal = options?.signal
-  const verdict = await probeRelaySocketOwner(conn, nodePath, sockPath, signal)
-  signal?.throwIfAborted()
-  if (verdict !== 'exited') {
-    throw new RelaySocketOwnerLiveError(sockPath, verdict, options?.cause)
-  }
-  await execCommand(conn, `rm -f ${shellEscape(sockPath)}`, { signal }).catch((cleanupErr) => {
-    if (isUnconfirmedSshCommandTermination(cleanupErr)) {
-      throw cleanupErr
+  let outcome: RelaySocketReleaseOutcome
+  try {
+    outcome = parseRelaySocketReleaseOutcome(
+      await execCommand(conn, relaySocketReleaseCommand(nodePath, sockPath), { signal })
+    )
+  } catch (err) {
+    signal?.throwIfAborted()
+    // Why rethrow: an unconfirmed close means the removal may still be in flight, and the
+    // caller must not launch a relay over a path whose state it cannot describe.
+    if (isUnconfirmedSshCommandTermination(err)) {
+      throw err
     }
-  })
+    // Why: a command we could not run says nothing about the owner, and the caller must not
+    // read that silence as death.
+    outcome = 'unverifiable'
+  }
   signal?.throwIfAborted()
+  if (outcome !== 'released') {
+    throw new RelaySocketOwnerLiveError(sockPath, outcome, options?.cause)
+  }
 }

--- a/src/main/ssh/ssh-relay-socket-owner.ts
+++ b/src/main/ssh/ssh-relay-socket-owner.ts
@@ -31,10 +31,13 @@ const RELAY_SOCKET_RELEASE_SCRIPT =
   'var net=require("net"),fs=require("fs"),p=process.argv[1],lsofProof=process.argv[2]==="lsof",' +
   `left=${PROBE_ATTEMPTS},mark=null,done=false,sock=null,timer=null;` +
   // "live" if an inventory lists the path, "absent" if one ran without it, null if none ran.
+  // Why the field strip rather than a suffix test: the pathname is everything after the
+  // seventh column, so a socket whose own path ends with " " + ours would match a suffix.
   'function inventory(){var data;try{data=fs.readFileSync("/proc/net/unix","utf8")}' +
   'catch(e){return lsofProof?"absent":null}' +
-  'var lines=data.split(String.fromCharCode(10)),tail=" "+p;' +
-  'for(var i=0;i<lines.length;i++){if(lines[i].slice(-tail.length)===tail){return "live"}}' +
+  'var lines=data.split(String.fromCharCode(10));' +
+  'for(var i=1;i<lines.length;i++){' +
+  'if(lines[i].replace(/^(?:[^ ]+ +){7}/,"")===p){return "live"}}' +
   'return "absent"}' +
   // Why ctime too: inode numbers are recycled, so dev+ino alone can match a socket that
   // was unlinked and recreated inside the probe window. Same identity as relay.ts.
@@ -64,7 +67,11 @@ export function relaySocketReleaseCommand(nodePath: string, sockPath: string): s
   // Why -a: lsof ORs selectors by default, which would match every Unix-socket holder (#8762).
   return (
     `sock=${shellEscape(sockPath)}; holders=; proof=none; ` +
-    'if command -v lsof >/dev/null 2>&1; then ' +
+    // Why probe lsof against our own process first: an lsof that is present but cannot
+    // inspect anything reports nothing, and reading that silence as "no owner" is the
+    // inference this whole change exists to remove. The relay runs as this same user, so
+    // an lsof that can see our files can see its socket.
+    'if command -v lsof >/dev/null 2>&1 && [ -n "$(lsof -t -p $$ 2>/dev/null)" ]; then ' +
     'holders=$(lsof -t -a -U "$sock" 2>/dev/null); [ -n "$holders" ] || proof=lsof; fi; ' +
     'if [ -n "$holders" ]; then echo LIVE; ' +
     // Why argv: passing the path and proof as arguments dodges quoting issues inside -e.

--- a/src/main/ssh/ssh-relay-socket-owner.ts
+++ b/src/main/ssh/ssh-relay-socket-owner.ts
@@ -17,15 +17,29 @@ const PROBE_RETRY_MS = 250
 
 // Why one host-side script rather than probe-then-remove from here: an SSH round-trip
 // between the two is wide enough for another client to bind the path, and the removal
-// would then unlink a live owner's socket. The unlink is guarded by the same dev/ino
-// recheck the relay uses for its own stale-socket cleanup (relay.ts unlinkIfStillStale).
+// would then unlink a live owner's socket. The unlink is guarded by the same
+// dev+ino+ctime identity the relay uses for its own stale-socket cleanup (relay.ts
+// unlinkIfStillStale).
 //
-// Why retry ECONNREFUSED: a live Unix listener whose accept backlog is momentarily full
-// also refuses connections. A stale inode refuses every time; saturation drains.
+// Why refusals alone never authorize the unlink: a live Unix listener whose accept
+// backlog is full also answers ECONNREFUSED, so N refusals are an inference, not the
+// positive evidence of absence this whole change is about. The unlink additionally
+// requires an owner inventory that ran and did not list the path — /proc/net/unix where
+// it exists, otherwise an lsof that ran and matched nothing. With neither, the answer is
+// unverifiable and the socket stays.
 const RELAY_SOCKET_RELEASE_SCRIPT =
-  'var net=require("net"),fs=require("fs"),p=process.argv[1],' +
+  'var net=require("net"),fs=require("fs"),p=process.argv[1],lsofProof=process.argv[2]==="lsof",' +
   `left=${PROBE_ATTEMPTS},mark=null,done=false,sock=null,timer=null;` +
-  'function ident(){try{var st=fs.statSync(p);return st.dev+":"+st.ino}catch(e){return null}}' +
+  // "live" if an inventory lists the path, "absent" if one ran without it, null if none ran.
+  'function inventory(){var data;try{data=fs.readFileSync("/proc/net/unix","utf8")}' +
+  'catch(e){return lsofProof?"absent":null}' +
+  'var lines=data.split(String.fromCharCode(10)),tail=" "+p;' +
+  'for(var i=0;i<lines.length;i++){if(lines[i].slice(-tail.length)===tail){return "live"}}' +
+  'return "absent"}' +
+  // Why ctime too: inode numbers are recycled, so dev+ino alone can match a socket that
+  // was unlinked and recreated inside the probe window. Same identity as relay.ts.
+  'function ident(){try{var st=fs.statSync(p,{bigint:true});' +
+  'return st.dev+":"+st.ino+":"+st.ctimeNs}catch(e){return null}}' +
   'function say(v){if(done)return;done=true;if(timer)clearTimeout(timer);' +
   'if(sock)sock.destroy();process.stdout.write(v)}' +
   'function release(){if(mark===null){say("RELEASED");return}' +
@@ -37,18 +51,24 @@ const RELAY_SOCKET_RELEASE_SCRIPT =
   'sock.on("error",function(e){clearTimeout(timer);' +
   'if(e.code==="ENOENT"){say("RELEASED");return}' +
   'if(e.code!=="ECONNREFUSED"){say("UNVERIFIABLE");return}' +
-  `if(--left>0){setTimeout(attempt,${PROBE_RETRY_MS});return}release()})}attempt()`
+  `if(--left>0){setTimeout(attempt,${PROBE_RETRY_MS});return}` +
+  'var inv=inventory();' +
+  'if(inv==="live"){say("LIVE");return}' +
+  'if(inv===null){say("UNVERIFIABLE");return}' +
+  'release()})}attempt()'
 
 export function relaySocketReleaseCommand(nodePath: string, sockPath: string): string {
-  // Why lsof first: it is the one portable way to prove an owner is *there*. Its silence is
-  // never read as absence — a denied or absent lsof just falls through to the probe.
+  // Why lsof first: on hosts without /proc it is the only owner inventory available, and it
+  // answers both ways — a match proves an owner is there, and a clean run that matches
+  // nothing is the absence evidence the unlink needs. A missing lsof proves neither.
   // Why -a: lsof ORs selectors by default, which would match every Unix-socket holder (#8762).
   return (
-    `sock=${shellEscape(sockPath)}; ` +
-    'if command -v lsof >/dev/null 2>&1 && [ -n "$(lsof -t -a -U "$sock" 2>/dev/null)" ]; ' +
-    'then echo LIVE; ' +
-    // Why argv[1]: passing the path as an argument dodges quoting issues inside -e.
-    `else ${shellEscape(nodePath)} -e ${shellEscape(RELAY_SOCKET_RELEASE_SCRIPT)} "$sock"; fi`
+    `sock=${shellEscape(sockPath)}; holders=; proof=none; ` +
+    'if command -v lsof >/dev/null 2>&1; then ' +
+    'holders=$(lsof -t -a -U "$sock" 2>/dev/null); [ -n "$holders" ] || proof=lsof; fi; ' +
+    'if [ -n "$holders" ]; then echo LIVE; ' +
+    // Why argv: passing the path and proof as arguments dodges quoting issues inside -e.
+    `else ${shellEscape(nodePath)} -e ${shellEscape(RELAY_SOCKET_RELEASE_SCRIPT)} "$sock" "$proof"; fi`
   )
 }
 

--- a/src/main/ssh/ssh-relay-socket-owner.ts
+++ b/src/main/ssh/ssh-relay-socket-owner.ts
@@ -1,0 +1,117 @@
+import type { SshConnection } from './ssh-connection'
+import { shellEscape } from './ssh-connection-utils'
+import { execCommand, isUnconfirmedSshCommandTermination } from './ssh-relay-deploy-helpers'
+
+/**
+ * Who owns a relay socket path, as observed from the client.
+ *
+ * The vocabulary is pinned by docs/reference/ssh-execution-boundary.md:
+ * `exited` requires positive evidence of absence, and anything we could not
+ * observe stays `unverifiable` — never collapsed into either neighbour.
+ * Here the subject is the socket path: `exited` means the connect attempt was
+ * actively refused, so no process is listening at that path any more.
+ */
+export type RelaySocketOwnerVerdict = 'live' | 'exited' | 'unverifiable'
+
+const PROBE_TIMEOUT_MS = 3_000
+
+// Why: probe via node (guaranteed present on the host — it is what runs the relay)
+// rather than lsof/fuser/socat, which vary by distro and are often absent.
+// Why: `test -S` only proves the inode exists; a connect-and-close is the only
+// thing that separates a listening owner from an inode a crashed relay left behind.
+const RELAY_SOCKET_OWNER_PROBE_SCRIPT =
+  'var net=require("net"),done=false,' +
+  'say=function(v){if(done)return;done=true;clearTimeout(t);process.stdout.write(v);s.destroy()},' +
+  's=net.connect(process.argv[1]),' +
+  `t=setTimeout(function(){say("UNVERIFIABLE")},${PROBE_TIMEOUT_MS});` +
+  's.on("connect",function(){say("LIVE")});' +
+  's.on("error",function(e){say(e.code==="ECONNREFUSED"||e.code==="ENOENT"?"EXITED":"UNVERIFIABLE")})'
+
+export function relaySocketOwnerProbeCommand(nodePath: string, sockPath: string): string {
+  // Why: pass the socket path as argv[1] rather than interpolating it into -e, to dodge quoting issues.
+  return `${shellEscape(nodePath)} -e ${shellEscape(RELAY_SOCKET_OWNER_PROBE_SCRIPT)} ${shellEscape(sockPath)}`
+}
+
+export function parseRelaySocketOwnerProbe(output: string): RelaySocketOwnerVerdict {
+  const markers = new Set(
+    output
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line === 'LIVE' || line === 'EXITED' || line === 'UNVERIFIABLE')
+  )
+  if (markers.size !== 1) {
+    return 'unverifiable'
+  }
+  if (markers.has('LIVE')) {
+    return 'live'
+  }
+  return markers.has('EXITED') ? 'exited' : 'unverifiable'
+}
+
+export async function probeRelaySocketOwner(
+  conn: SshConnection,
+  nodePath: string,
+  sockPath: string,
+  signal?: AbortSignal
+): Promise<RelaySocketOwnerVerdict> {
+  try {
+    return parseRelaySocketOwnerProbe(
+      await execCommand(conn, relaySocketOwnerProbeCommand(nodePath, sockPath), { signal })
+    )
+  } catch {
+    // Why: a probe we could not run answers nothing about the owner, and the
+    // caller must not treat that silence as death.
+    signal?.throwIfAborted()
+    return 'unverifiable'
+  }
+}
+
+export class RelaySocketOwnerLiveError extends Error {
+  readonly name = 'RelaySocketOwnerLiveError'
+
+  constructor(
+    readonly sockPath: string,
+    readonly verdict: Exclude<RelaySocketOwnerVerdict, 'exited'>,
+    readonly cause?: unknown
+  ) {
+    super(
+      `Could not reach the relay at ${sockPath}, and its socket is ${
+        verdict === 'live' ? 'still owned by a running relay' : 'of unproven ownership'
+      }. Leaving it in place — replacing it would strand that relay and every terminal it holds. ` +
+        'Retry, or use "Reset remote relay" on the SSH target to stop it.'
+    )
+  }
+}
+
+export function isRelaySocketOwnerLiveError(err: unknown): err is RelaySocketOwnerLiveError {
+  return err instanceof RelaySocketOwnerLiveError
+}
+
+/**
+ * Remove a relay socket so a fresh daemon can bind the same path — but only
+ * once the probe proves nothing is listening there.
+ *
+ * Why this gate: unlinking cannot stop a relay that already bound the path. It
+ * only hides the live owner from the fresh launch's EADDRINUSE stale-socket
+ * check, which is the one interlock that refuses to displace a running daemon.
+ * A failed `--connect` is loss of contact, never proof of death (STA-1756).
+ */
+export async function removeUnownedRelaySocket(
+  conn: SshConnection,
+  nodePath: string,
+  sockPath: string,
+  options?: { signal?: AbortSignal; cause?: unknown }
+): Promise<void> {
+  const signal = options?.signal
+  const verdict = await probeRelaySocketOwner(conn, nodePath, sockPath, signal)
+  signal?.throwIfAborted()
+  if (verdict !== 'exited') {
+    throw new RelaySocketOwnerLiveError(sockPath, verdict, options?.cause)
+  }
+  await execCommand(conn, `rm -f ${shellEscape(sockPath)}`, { signal }).catch((cleanupErr) => {
+    if (isUnconfirmedSshCommandTermination(cleanupErr)) {
+      throw cleanupErr
+    }
+  })
+  signal?.throwIfAborted()
+}

--- a/src/main/ssh/ssh-relay-socket-owner.ts
+++ b/src/main/ssh/ssh-relay-socket-owner.ts
@@ -1,90 +1,75 @@
 import type { SshConnection } from './ssh-connection'
 import { shellEscape } from './ssh-connection-utils'
-import { execCommand, isUnconfirmedSshCommandTermination } from './ssh-relay-deploy-helpers'
+import { execCommand } from './ssh-relay-deploy-helpers'
 
 /**
- * What happened when we asked the host to release a relay socket path.
+ * Who owns a relay socket path, as observed from the client.
  *
- * The vocabulary follows `src/shared/pty-liveness-verdict.ts`: `released` needs
- * positive evidence that nothing owns the path, and anything we could not
- * observe stays `unverifiable` — never read as absence.
+ * The vocabulary follows `src/shared/pty-liveness-verdict.ts`: `exited` needs positive
+ * evidence that nothing owns the path, and anything we could not observe stays
+ * `unverifiable` — never read as absence.
  */
-export type RelaySocketReleaseOutcome = 'live' | 'released' | 'unverifiable'
+export type RelaySocketOwnerVerdict = 'live' | 'exited' | 'unverifiable'
 
 const PROBE_TIMEOUT_MS = 3_000
 const PROBE_ATTEMPTS = 3
 const PROBE_RETRY_MS = 250
 
-// Why one host-side script rather than probe-then-remove from here: an SSH round-trip
-// between the two is wide enough for another client to bind the path, and the removal
-// would then unlink a live owner's socket. The unlink is guarded by the same
-// dev+ino+ctime identity the relay uses for its own stale-socket cleanup (relay.ts
-// unlinkIfStillStale).
+// Why this only looks: the fresh daemon reclaims a stale path itself, checking the socket's
+// identity and binding in one process (relay.ts unlinkIfStillStale). Unlinking here would
+// put an SSH round-trip between that check and the launch, and a relay that bound the path
+// in between would be the one we displaced.
 //
-// Why refusals alone never authorize the unlink: a live Unix listener whose accept
-// backlog is full also answers ECONNREFUSED, so N refusals are an inference, not the
-// positive evidence of absence this whole change is about. The unlink additionally
-// requires an owner inventory that ran and did not list the path — /proc/net/unix where
-// it exists, otherwise an lsof that ran and matched nothing. With neither, the answer is
-// unverifiable and the socket stays.
-const RELAY_SOCKET_RELEASE_SCRIPT =
+// Why refusals alone are not absence: a live Unix listener whose accept backlog is full also
+// answers ECONNREFUSED, so N refusals are an inference. A verdict of `exited` additionally
+// needs an owner inventory that ran and did not list the path — /proc/net/unix where it
+// exists, otherwise an lsof proven able to inspect this user's own processes.
+const RELAY_SOCKET_OWNER_PROBE_SCRIPT =
   'var net=require("net"),fs=require("fs"),p=process.argv[1],lsofProof=process.argv[2]==="lsof",' +
-  `left=${PROBE_ATTEMPTS},mark=null,done=false,sock=null,timer=null;` +
-  // "live" if an inventory lists the path, "absent" if one ran without it, null if none ran.
-  // Why the field strip rather than a suffix test: the pathname is everything after the
+  `left=${PROBE_ATTEMPTS},done=false,sock=null,timer=null;` +
+  // "live" if an inventory lists the path, "exited" if one ran without it, null if none ran.
+  // Why the column strip rather than a suffix test: the pathname is everything after the
   // seventh column, so a socket whose own path ends with " " + ours would match a suffix.
   'function inventory(){var data;try{data=fs.readFileSync("/proc/net/unix","utf8")}' +
-  'catch(e){return lsofProof?"absent":null}' +
+  'catch(e){return lsofProof?"exited":null}' +
   'var lines=data.split(String.fromCharCode(10));' +
   'for(var i=1;i<lines.length;i++){' +
   'if(lines[i].replace(/^(?:[^ ]+ +){7}/,"")===p){return "live"}}' +
-  'return "absent"}' +
-  // Why ctime too: inode numbers are recycled, so dev+ino alone can match a socket that
-  // was unlinked and recreated inside the probe window. Same identity as relay.ts.
-  'function ident(){try{var st=fs.statSync(p,{bigint:true});' +
-  'return st.dev+":"+st.ino+":"+st.ctimeNs}catch(e){return null}}' +
+  'return "exited"}' +
   'function say(v){if(done)return;done=true;if(timer)clearTimeout(timer);' +
   'if(sock)sock.destroy();process.stdout.write(v)}' +
-  'function release(){if(mark===null){say("RELEASED");return}' +
-  'if(ident()!==mark){say("UNVERIFIABLE");return}' +
-  'try{fs.unlinkSync(p)}catch(e){if(e.code!=="ENOENT"){say("UNVERIFIABLE");return}}say("RELEASED")}' +
-  'function attempt(){mark=ident();sock=net.connect(p);' +
+  'function attempt(){sock=net.connect(p);' +
   `timer=setTimeout(function(){say("UNVERIFIABLE")},${PROBE_TIMEOUT_MS});` +
   'sock.on("connect",function(){say("LIVE")});' +
   'sock.on("error",function(e){clearTimeout(timer);' +
-  'if(e.code==="ENOENT"){say("RELEASED");return}' +
+  'if(e.code==="ENOENT"){say("EXITED");return}' +
   'if(e.code!=="ECONNREFUSED"){say("UNVERIFIABLE");return}' +
   `if(--left>0){setTimeout(attempt,${PROBE_RETRY_MS});return}` +
   'var inv=inventory();' +
-  'if(inv==="live"){say("LIVE");return}' +
-  'if(inv===null){say("UNVERIFIABLE");return}' +
-  'release()})}attempt()'
+  'say(inv==="live"?"LIVE":inv==="exited"?"EXITED":"UNVERIFIABLE")})}attempt()'
 
-export function relaySocketReleaseCommand(nodePath: string, sockPath: string): string {
-  // Why lsof first: on hosts without /proc it is the only owner inventory available, and it
-  // answers both ways — a match proves an owner is there, and a clean run that matches
-  // nothing is the absence evidence the unlink needs. A missing lsof proves neither.
+export function relaySocketOwnerProbeCommand(nodePath: string, sockPath: string): string {
+  // Why ask lsof about our own process first: an lsof that is present but cannot inspect
+  // anything reports nothing, and reading that silence as "no owner" is the inference this
+  // whole change removes. The relay runs as this same user, so an lsof that can see our
+  // files can see its socket.
   // Why -a: lsof ORs selectors by default, which would match every Unix-socket holder (#8762).
   return (
     `sock=${shellEscape(sockPath)}; holders=; proof=none; ` +
-    // Why probe lsof against our own process first: an lsof that is present but cannot
-    // inspect anything reports nothing, and reading that silence as "no owner" is the
-    // inference this whole change exists to remove. The relay runs as this same user, so
-    // an lsof that can see our files can see its socket.
     'if command -v lsof >/dev/null 2>&1 && [ -n "$(lsof -t -p $$ 2>/dev/null)" ]; then ' +
     'holders=$(lsof -t -a -U "$sock" 2>/dev/null); [ -n "$holders" ] || proof=lsof; fi; ' +
     'if [ -n "$holders" ]; then echo LIVE; ' +
     // Why argv: passing the path and proof as arguments dodges quoting issues inside -e.
-    `else ${shellEscape(nodePath)} -e ${shellEscape(RELAY_SOCKET_RELEASE_SCRIPT)} "$sock" "$proof"; fi`
+    `else ${shellEscape(nodePath)} -e ${shellEscape(RELAY_SOCKET_OWNER_PROBE_SCRIPT)} "$sock" "$proof"; fi`
   )
 }
 
-export function parseRelaySocketReleaseOutcome(output: string): RelaySocketReleaseOutcome {
+export function parseRelaySocketOwnerVerdict(output: string): RelaySocketOwnerVerdict {
   const markers = new Set(
     output
       .split(/\r?\n/)
       .map((line) => line.trim())
-      .filter((line) => line === 'LIVE' || line === 'RELEASED' || line === 'UNVERIFIABLE')
+      .filter((line) => line === 'LIVE' || line === 'EXITED' || line === 'UNVERIFIABLE')
   )
   if (markers.size !== 1) {
     return 'unverifiable'
@@ -92,7 +77,7 @@ export function parseRelaySocketReleaseOutcome(output: string): RelaySocketRelea
   if (markers.has('LIVE')) {
     return 'live'
   }
-  return markers.has('RELEASED') ? 'released' : 'unverifiable'
+  return markers.has('EXITED') ? 'exited' : 'unverifiable'
 }
 
 export class RelaySocketOwnerLiveError extends Error {
@@ -100,12 +85,12 @@ export class RelaySocketOwnerLiveError extends Error {
 
   constructor(
     readonly sockPath: string,
-    readonly outcome: Exclude<RelaySocketReleaseOutcome, 'released'>,
+    readonly verdict: Exclude<RelaySocketOwnerVerdict, 'exited'>,
     cause?: unknown
   ) {
     super(
       `Could not reach the relay at ${sockPath}, and its socket is ${
-        outcome === 'live' ? 'still owned by a running relay' : 'of unproven ownership'
+        verdict === 'live' ? 'still owned by a running relay' : 'of unproven ownership'
       }. Leaving it in place — replacing it would strand that relay and every terminal it ` +
         `holds. Retry, or use "Reset remote relay" on the SSH target to stop it.${
           cause instanceof Error ? ` Reconnect failed with: ${cause.message}` : ''
@@ -120,42 +105,36 @@ export function isRelaySocketOwnerLiveError(err: unknown): err is RelaySocketOwn
 }
 
 /**
- * Release a relay socket path so a fresh daemon can bind it — and only when the host
- * proves nothing owns it.
+ * Establish that nothing owns this relay socket, so a fresh daemon may take the path.
  *
- * Why the guard: unlinking cannot stop a relay that already bound the path. It only hides
- * the live owner from the fresh launch's EADDRINUSE check, which is the one interlock that
- * refuses to displace a running daemon. A failed `--connect` is loss of contact, never
- * proof of death (STA-1756).
+ * Why this gate: a failed `--connect` is loss of contact, never proof of death. Launching
+ * over a path whose owner is still listening cannot stop that owner — it only hides it from
+ * the fresh daemon's EADDRINUSE check, and it keeps running with its PTYs forever
+ * (STA-1756). Reclaiming the path itself is the daemon's job, which it does under its own
+ * identity check.
  *
- * POSIX hosts only: Windows relays take the named-pipe path in launchWindowsRelay, where
- * there is no inode to unlink.
+ * POSIX hosts only: Windows relays take the named-pipe path in launchWindowsRelay.
  */
-export async function releaseUnownedRelaySocket(
+export async function requireUnownedRelaySocket(
   conn: SshConnection,
   nodePath: string,
   sockPath: string,
   options?: { signal?: AbortSignal; cause?: unknown }
 ): Promise<void> {
   const signal = options?.signal
-  let outcome: RelaySocketReleaseOutcome
+  let verdict: RelaySocketOwnerVerdict
   try {
-    outcome = parseRelaySocketReleaseOutcome(
-      await execCommand(conn, relaySocketReleaseCommand(nodePath, sockPath), { signal })
+    verdict = parseRelaySocketOwnerVerdict(
+      await execCommand(conn, relaySocketOwnerProbeCommand(nodePath, sockPath), { signal })
     )
-  } catch (err) {
+  } catch {
     signal?.throwIfAborted()
-    // Why rethrow: an unconfirmed close means the removal may still be in flight, and the
-    // caller must not launch a relay over a path whose state it cannot describe.
-    if (isUnconfirmedSshCommandTermination(err)) {
-      throw err
-    }
-    // Why: a command we could not run says nothing about the owner, and the caller must not
+    // Why: a probe we could not run says nothing about the owner, and the caller must not
     // read that silence as death.
-    outcome = 'unverifiable'
+    verdict = 'unverifiable'
   }
   signal?.throwIfAborted()
-  if (outcome !== 'released') {
-    throw new RelaySocketOwnerLiveError(sockPath, outcome, options?.cause)
+  if (verdict !== 'exited') {
+    throw new RelaySocketOwnerLiveError(sockPath, verdict, options?.cause)
   }
 }

--- a/src/main/ssh/ssh-relay-version-mismatch-error.ts
+++ b/src/main/ssh/ssh-relay-version-mismatch-error.ts
@@ -24,8 +24,29 @@ export class RelayVersionMismatchError extends Error {
   }
 }
 
-export function isRelayVersionMismatchError(err: unknown): err is RelayVersionMismatchError {
-  return err instanceof RelayVersionMismatchError
+// Why bounded: causes are attacker-free but not cycle-free, and a plain recursion over a
+// self-referential chain would hang the connect path instead of failing it.
+const MAX_CAUSE_DEPTH = 8
+
+/**
+ * True for a mismatch reported directly, or carried as the cause of a wrapper.
+ *
+ * Why unwrap: a reconnect refused by a live daemon surfaces as a socket-owner error whose
+ * cause is this one, and a version the daemon cannot change is no more reconcilable by
+ * backoff there than it is here (STA-1756).
+ */
+export function isRelayVersionMismatchError(err: unknown): err is Error {
+  let current = err
+  for (let depth = 0; depth <= MAX_CAUSE_DEPTH; depth++) {
+    if (current instanceof RelayVersionMismatchError) {
+      return true
+    }
+    if (!(current instanceof Error) || current.cause === undefined) {
+      return false
+    }
+    current = current.cause
+  }
+  return false
 }
 
 // Why: the remote --connect process uses this exit code to signal the wire


### PR DESCRIPTION
Fixes STA-1756 (#8585).

## What was broken

`launchRelay` probes for an existing relay socket and, when `--connect` to it fails, it removed the socket and launched a fresh detached relay over the same path:

```ts
// Why: stale socket from a crashed relay — remove it so the fresh launch can bind at the same path.
await execCommand(conn, `rm -f ${shellEscape(sockFile)}`, { signal })
```

That comment states an inference the code never checked. A refused `--connect` is loss of contact, not proof of death. On Unix, unlinking a socket path does not close a listening socket its owner already holds, so when the old relay was alive it kept running, kept its PTYs and every shell/agent inside them, and became permanently unreachable. With the shipped `--grace-time 0`, a relay still holding a PTY takes the `configured` grace branch with `timeoutMs=0`, which arms no timer — so nothing ever reaped it.

The relay already refuses this displacement on its own: a fresh daemon that hits `EADDRINUSE` probe-connects the path and declines to steal it from a live owner (`src/relay/relay.ts`, `onInitialError`). The unconditional `rm -f` destroyed exactly the evidence that interlock runs on.

## Reproduction (real processes, not mocks)

Two live-daemon files, both in the new `relay socket ownership` CI job:

`ssh-relay-launch-ownership.integration.test.ts` drives the **production** `launchRelay` against a real detached relay holding a real PTY, over an `SshConnection` whose exec runs the same command strings through a local shell. The reconnect is made to fail the way it fails in the field — by rotating the endpoint credential the daemon read at startup, which is what an interrupted deploy does. It asserts the incumbent keeps its socket and its shell and that nothing was started over it. **That test fails when the guard is reverted.** A second case proves the other direction: a killed relay's leftover socket is taken over normally.

`ssh-relay-socket-owner.integration.test.ts` isolates the decision, including a control arm that performs the old raw unlink and observes the orphan appear: the socket path answers for a daemon owning `ptys: 0` while the incumbent is still alive with the user's shell, its log ending at `Grace started (socket client closed): timeoutMs=0, branch=configured, ptys=1` and never saying anything again.

## The fix

One new boundary, `src/main/ssh/ssh-relay-socket-owner.ts`: the socket's own owner decides. No pidfile, no process scavenger.

`relaySocketOwnerProbeCommand` asks the host who owns the path, and answers `exited` only on positive evidence that nothing does:

- **`lsof -t -a -U`**, when present, both ways: a match proves an owner is there, and a clean run that matches nothing is absence evidence.
- **A connect probe**, retried three times — `ECONNREFUSED` is not by itself absence, since a live listener with a full accept backlog refuses too (measured: 199 of 200 simultaneous connects to a live listener with `backlog: 1`).
- **`/proc/net/unix`**, the authority where it exists: an owner inventory that ran and did not list the path, compared on the pathname column exactly. A refused connect alone never proves absence; with no inventory at all the verdict is `unverifiable` and nothing is launched. (`ENOENT` is the one direct answer — the path is simply not there.)

Outcomes are `live` / `exited` / `unverifiable`, following `src/shared/pty-liveness-verdict.ts`. `requireUnownedRelaySocket` throws `RelaySocketOwnerLiveError` for anything but `exited`; `launchRelay` calls it in place of the raw `rm -f` and rethrows the typed error from the outer catch so it cannot fall through to a fresh launch.

Verified on a real Linux host with no `lsof`: a saturated live listener reports `LIVE` and keeps its socket; a genuinely stale inode is taken over. Verified across `sh`/`dash`/`bash`/`zsh`, and for socket paths containing spaces, apostrophes and backslashes.

Behaviour deliberately preserved: ordinary stale sockets are still cleaned up and the fresh launch proceeds; relays intentionally surviving with live PTYs are never displaced; empty husks are already handled on main by the `idle-no-ptys` grace branch.

## Reset, the recovery path this change points at

`forceStopRelayForTarget` removed the socket even when it found no owner to kill or the kill was refused — on a host where the lookup came back silent that stranded exactly the relay the user asked it to stop. It now stops the owner, checks an inventory to confirm it is gone, and reports an actionable failure otherwise. It no longer unlinks anything: a relay that stops cleanly removes its own path, one that had to be killed leaves an inode the deploy path releases under its identity guard, and unlinking here would need that same guard and still race a relay binding the path in between.

## Trade-off

A relay that is alive but permanently unreachable now fails the deploy instead of silently connecting. That is the honest outcome: the alternative is what this PR removes — a connection that appears to work while a full process tree leaks forever. A generic owner-live failure stays retryable, so `ssh.ts`'s bounded relay-lost backoff still gives a transiently busy relay six chances to recover *with the user's sessions*, which the old path destroyed. A wrapped `RelayVersionMismatchError` stays terminal, since no amount of backoff changes a version. If a relay stays unreachable, **Reset remote relay** stops it deliberately.

## Scope notes

- **Not fixed here, different mechanism:** the one-relay-per-build accumulation in the issue's later comments is upgrade churn (STA-3832) — version-scoped install dirs mean the new relay binds a different path, so nothing is stolen and nothing is unlinked; the old relay is simply abandoned.
- **Windows is untouched by this branch**, but review surfaced two pre-existing Windows analogues worth their own tickets: `launchWindowsRelay` moves to a fallback pipe on a failed reconnect and rotates the shared credential, abandoning the incumbent; and Windows GC reads an inconclusive pipe probe (`WAITING`) as safe-to-delete.
- **Residual, stated plainly:** on a host with neither `/proc/net/unix` nor a working `lsof`, a stale socket is never taken over and the deploy asks the user to reset. That is the safe direction, and no such host is known to run the relay. All three reviewers examined this residual and agreed not to re-file it.
- **No reuse of `hasLiveRelaySocket`**: that probe is deliberately `test -S`-only because its job is to *never authorize* deleting a version dir. This one must prove absence to authorize an unlink.
- **Remote wire compatibility**: no RPC params, stream opcodes, or host-published content change — only which shell command the client runs on the host.

## Tests

- `ssh-relay-socket-owner.test.ts` — command shape (lsof proven functional before it counts, inventory requirement, exact pathname column, removes nothing, retry budget), verdict parsing, every refusal path including abort, and the terminal-cause unwrap.
- `ssh-relay-socket-displacement.test.ts` — the shipping wiring: no `--detached` launch and no credential rotation on `live` or `unverifiable`; both still happen on `released`.
- `ssh-relay-launch-ownership.integration.test.ts` / `ssh-relay-socket-owner.integration.test.ts` — the live journeys above.
- `ssh-relay-reset.test.ts` — the real reset script against a sandboxed host with a real killable socket owner: kill works, kill refused, and a host that cannot name the owner.

Reverting the guard fails the live journey and four wiring tests. `src/main/ssh` (1621 tests), `src/main/ipc`, typecheck, and the changed-code quality gate all pass. Two `pty-handler-spawn-environment` Windows/WSL failures reproduce on clean `origin/main` on macOS and are unrelated.

Reviewed across four rounds by three independent GPT-5.6 reviewers, all three now SHIP. Every finding above the nit line was reproduced before it was fixed — including two that only appear on Linux (mawk has no `{n}` interval expressions, so the inventory silently matched nothing; and `awk -v` expands escapes, so a socket path holding a backslash never matched its own entry).
