### PR TITLE
fix(worktree): hide Codex home-level scratch capsules

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeVisibilityDialog.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeVisibilityDialog.test.tsx
@@ -650,7 +650,7 @@ describe('WorktreeVisibilityDialog', () => {
     expect(intro).not.toBeUndefined()
     expect(
       [...(intro?.nextElementSibling?.querySelectorAll('li') ?? [])].map((item) => item.textContent)
-    ).toEqual(['Claude CodeShow', 'GSDHide', 'Other locationsHide'])
+    ).toEqual(['Claude CodeShow', 'GSDHide', 'CodexHide', 'Other locationsHide'])
     expect(buttonWithText('Manage in Global Settings')).not.toBeNull()
   })
 
@@ -688,7 +688,7 @@ describe('WorktreeVisibilityDialog', () => {
 
     expect(mocks.state.updateRepo).toHaveBeenCalledWith('repo-1', {
       agentWorktreeVisibility: null,
-      worktreeVisibilitySourcePreferences: { builtIn: { gsd: 'show' } }
+      worktreeVisibilitySourcePreferences: { builtIn: { gsd: 'show', codex: 'show' } }
     })
   })
 
@@ -698,19 +698,20 @@ describe('WorktreeVisibilityDialog', () => {
     mocks.state.settings = {
       worktreeVisibilityDefaults: {
         external: 'hide',
-        sourcePreferences: { builtIn: { claude: 'show', gsd: 'show' } }
+        sourcePreferences: { builtIn: { claude: 'show', gsd: 'show', codex: 'show' } }
       }
     }
     await renderDialog()
 
     expect(sourceSwitch('Claude Code').getAttribute('aria-checked')).toBe('true')
     expect(sourceSwitch('GSD').getAttribute('aria-checked')).toBe('true')
+    expect(sourceSwitch('Codex').getAttribute('aria-checked')).toBe('true')
 
     await click(sourceSegment('Claude Code', 'hide'))
 
     expect(mocks.state.updateRepo).toHaveBeenCalledWith('repo-1', {
       worktreeVisibilitySourcePreferences: {
-        builtIn: { claude: 'hide', gsd: 'show' }
+        builtIn: { claude: 'hide', gsd: 'show', codex: 'show' }
       }
     })
   })

--- a/src/renderer/src/components/sidebar/WorktreeVisibilitySourceList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeVisibilitySourceList.tsx
@@ -66,9 +66,13 @@ const VISIBILITY_SEGMENTS: readonly ExternalWorktreeVisibility[] = ['show', 'hid
 
 export function getWorktreeVisibilitySourceLabel(source: WorktreeVisibilitySourceRow): string {
   if (source.kind === 'built-in') {
-    return source.id === 'claude'
-      ? translate('auto.components.sidebar.WorktreeVisibilitySourceList.claude', 'Claude Code')
-      : translate('auto.components.sidebar.WorktreeVisibilitySourceList.gsd', 'GSD')
+    if (source.id === 'claude') {
+      return translate('auto.components.sidebar.WorktreeVisibilitySourceList.claude', 'Claude Code')
+    }
+    if (source.id === 'codex') {
+      return translate('auto.components.sidebar.WorktreeVisibilitySourceList.codex', 'Codex')
+    }
+    return translate('auto.components.sidebar.WorktreeVisibilitySourceList.gsd', 'GSD')
   }
   if (source.kind === 'other') {
     return translate(
@@ -84,7 +88,9 @@ export function getWorktreeVisibilitySourceLabel(source: WorktreeVisibilitySourc
 
 function getSourcePath(source: WorktreeVisibilitySourceRow): string {
   if (source.kind === 'built-in') {
-    return source.id === 'claude' ? '.claude/worktrees/*' : '.gsd-workspaces/*'
+    if (source.id === 'claude') return '.claude/worktrees/*'
+    if (source.id === 'codex') return '.codex/worktrees/*'
+    return '.gsd-workspaces/*'
   }
   if (source.kind === 'other') {
     return translate(
@@ -178,6 +184,7 @@ export default function WorktreeVisibilitySourceList({
     () => [
       { kind: 'built-in', id: 'claude' },
       { kind: 'built-in', id: 'gsd' },
+      { kind: 'built-in', id: 'codex' },
       ...customSources.map((source) => ({ kind: 'custom' as const, source })),
       { kind: 'other' }
     ],

--- a/src/renderer/src/components/sidebar/worktree-visibility-source-provenance.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-visibility-source-provenance.test.ts
@@ -49,6 +49,7 @@ describe('listInheritedWorktreeVisibilitySources', () => {
     expect(listInheritedWorktreeVisibilitySources(repo(), shownClaude)).toEqual([
       { source: { kind: 'built-in', id: 'claude' }, globalVisibility: 'show' },
       { source: { kind: 'built-in', id: 'gsd' }, globalVisibility: 'hide' },
+      { source: { kind: 'built-in', id: 'codex' }, globalVisibility: 'hide' },
       { source: { kind: 'other' }, globalVisibility: 'hide' }
     ])
   })

--- a/src/renderer/src/components/sidebar/worktree-visibility-source-provenance.ts
+++ b/src/renderer/src/components/sidebar/worktree-visibility-source-provenance.ts
@@ -69,6 +69,7 @@ export function listInheritedWorktreeVisibilitySources(
   const sources: WorktreeVisibilitySourceRow[] = [
     { kind: 'built-in', id: 'claude' },
     { kind: 'built-in', id: 'gsd' },
+    { kind: 'built-in', id: 'codex' },
     ...(normalizeCustomWorktreeVisibilitySources(defaults.customSources) ?? []).map((source) => ({
       kind: 'custom' as const,
       source

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5923,6 +5923,7 @@
         "WorktreeVisibilitySourceList": {
           "claude": "Claude Code",
           "gsd": "GSD",
+          "codex": "Codex",
           "other": "Other locations",
           "custom": "Custom location",
           "otherPath": "Outside listed sources",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -4718,6 +4718,7 @@
         "WorktreeVisibilitySourceList": {
           "claude": "Claude Code",
           "gsd": "GSD",
+          "codex": "Codex",
           "other": "Otras ubicaciones",
           "custom": "Ubicación personalizada",
           "otherPath": "Fuera de las fuentes listadas",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -4699,6 +4699,7 @@
         "WorktreeVisibilitySourceList": {
           "claude": "Claude Code",
           "gsd": "GSD",
+          "codex": "Codex",
           "other": "その他の場所",
           "custom": "カスタムの場所",
           "otherPath": "一覧にないソース",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -4701,6 +4701,7 @@
         "WorktreeVisibilitySourceList": {
           "claude": "Claude Code",
           "gsd": "GSD",
+          "codex": "Codex",
           "other": "기타 위치",
           "custom": "사용자 지정 위치",
           "otherPath": "목록에 없는 소스",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -4711,6 +4711,7 @@
         "WorktreeVisibilitySourceList": {
           "claude": "Claude Code",
           "gsd": "GSD",
+          "codex": "Codex",
           "other": "其他位置",
           "custom": "自定义位置",
           "otherPath": "所列来源之外",

--- a/src/shared/agent-scratch-worktrees.test.ts
+++ b/src/shared/agent-scratch-worktrees.test.ts
@@ -23,6 +23,12 @@ describe('isAgentScratchWorktreePath', () => {
     ).toBe(true)
   })
 
+  it('matches Codex home-level and in-repo scratch worktrees', () => {
+    expect(isAgentScratchWorktreePath(repoPath, '/Users/dev/.codex/worktrees/1621/app')).toBe(true)
+    expect(isAgentScratchWorktreePath(repoPath, '/Users/dev/app/.codex/worktrees/review')).toBe(true)
+    expect(isAgentScratchWorktreePath(repoPath, '/Users/dev/.codex/checkouts/app')).toBe(false)
+  })
+
   it('matches scratch worktrees created from a linked checkout', () => {
     const matchesAgentScratch = createAgentScratchWorktreePathMatcher([
       repoPath,
@@ -124,6 +130,7 @@ describe('isAgentScratchRepoRootPath', () => {
   it('matches scratch worktree containers used as repo roots', () => {
     expect(isAgentScratchRepoRootPath('/Users/dev/app/.claude/worktrees/agent-a04ccaaa')).toBe(true)
     expect(isAgentScratchRepoRootPath('/Users/dev/app/.gsd-workspaces/phase-1')).toBe(true)
+    expect(isAgentScratchRepoRootPath('/Users/dev/.codex/worktrees/1621/app')).toBe(true)
   })
 
   it('matches Windows separators and casing', () => {

--- a/src/shared/agent-scratch-worktrees.ts
+++ b/src/shared/agent-scratch-worktrees.ts
@@ -8,7 +8,8 @@ import {
  *  can hide legitimate user worktrees (#9388). */
 const AGENT_SCRATCH_PATH_PREFIXES: readonly (readonly string[])[] = [
   ['.claude', 'worktrees'],
-  ['.gsd-workspaces']
+  ['.gsd-workspaces'],
+  ['.codex', 'worktrees']
 ]
 
 export type AgentScratchWorktreePathMatcher = (worktreePath: string) => boolean

--- a/src/shared/repo-types.ts
+++ b/src/shared/repo-types.ts
@@ -27,7 +27,7 @@ export type RepoKind = 'git' | 'folder'
 export type IssueSourcePreference = 'upstream' | 'origin' | 'auto'
 export type ExternalWorktreeVisibility = 'hide' | 'show'
 
-export type BuiltInWorktreeVisibilitySourceId = 'claude' | 'gsd'
+export type BuiltInWorktreeVisibilitySourceId = 'claude' | 'gsd' | 'codex'
 
 export type CustomWorktreeVisibilitySource = {
   id: string

--- a/src/shared/worktree/ownership.test.ts
+++ b/src/shared/worktree/ownership.test.ts
@@ -481,6 +481,29 @@ describe('external worktree visibility policy', () => {
 describe('agent scratch worktrees', () => {
   const scratchPath = '/repos/app/.claude/worktrees/agent-a04ccaaa55ddadb91'
 
+  it('classifies Codex home-level capsules as agent-scratch and hides them', () => {
+    const repo = makeRepo()
+    const settings = makeSettings()
+    const path = '/Users/dev/.codex/worktrees/1621/app'
+    expect(
+      classifyWorktreeOwnership({
+        repo,
+        settings,
+        worktree: makeWorktree({ path, isMainWorktree: false }),
+        knownOrcaLayouts: buildKnownOrcaWorkspaceLayouts(settings, repo)
+      })
+    ).toBe('agent-scratch')
+    const detected = toDetectedWorktree({
+      repo,
+      settings,
+      worktree: makeWorktree({ path, isMainWorktree: false }),
+      knownOrcaLayouts: buildKnownOrcaWorkspaceLayouts(settings, repo)
+    })
+    expect(detected.ownership).toBe('agent-scratch')
+    expect(detected.visible).toBe(false)
+    expect(detected.visibilitySource).toEqual({ kind: 'built-in', id: 'codex' })
+  })
+
   it('classifies sub-agent scratch paths as agent-scratch without metadata', () => {
     const repo = makeRepo()
     const settings = makeSettings()

--- a/src/shared/worktree/visibility-source-preferences.ts
+++ b/src/shared/worktree/visibility-source-preferences.ts
@@ -13,7 +13,11 @@ function legacyBuiltInPreferences(
   repo: Pick<Repo, 'agentWorktreeVisibility'>
 ): WorktreeVisibilitySourcePreferences['builtIn'] {
   return repo.agentWorktreeVisibility
-    ? { claude: repo.agentWorktreeVisibility, gsd: repo.agentWorktreeVisibility }
+    ? {
+        claude: repo.agentWorktreeVisibility,
+        gsd: repo.agentWorktreeVisibility,
+        codex: repo.agentWorktreeVisibility
+      }
     : {}
 }
 

--- a/src/shared/worktree/visibility-sources.test.ts
+++ b/src/shared/worktree/visibility-sources.test.ts
@@ -38,6 +38,20 @@ describe('worktree visibility sources', () => {
     expect(classify('/other/.claude/worktrees/review')).toBeNull()
   })
 
+  it('classifies home-level Codex capsules without a registered checkout', () => {
+    const classify = createWorktreeVisibilitySourceMatcher(['/Users/dev/app'])
+    expect(classify('/Users/dev/.codex/worktrees/1621/app')).toEqual({
+      kind: 'built-in',
+      id: 'codex'
+    })
+    expect(classify('/Users/dev/app/.codex/worktrees/review')).toEqual({
+      kind: 'built-in',
+      id: 'codex'
+    })
+    expect(classify('/Users/dev/.codex/checkouts/app')).toBeNull()
+    expect(classify('/Users/dev/.codex/worktrees')).toBeNull()
+  })
+
   it('matches custom descendants with Windows and WSL comparison semantics', () => {
     const windows = createWorktreeVisibilitySourceMatcher(
       [],
@@ -92,7 +106,7 @@ describe('worktree visibility sources', () => {
     expect(effectiveBuiltInWorktreeSourceVisibility(legacy, 'gsd')).toBe('show')
     expect(
       buildWorktreeSourcePreferenceUpdate(legacy, { kind: 'built-in', id: 'claude' }, 'hide')
-    ).toEqual({ builtIn: { claude: 'hide', gsd: 'show' } })
+    ).toEqual({ builtIn: { claude: 'hide', gsd: 'show', codex: 'show' } })
   })
 
   it('inherits global built-in and custom visibility without stamping sibling defaults', () => {

--- a/src/shared/worktree/visibility-sources.ts
+++ b/src/shared/worktree/visibility-sources.ts
@@ -19,9 +19,12 @@ const MAX_SOURCE_PATH_LENGTH = 4096
 export const BUILT_IN_WORKTREE_VISIBILITY_SOURCES: readonly {
   id: BuiltInWorktreeVisibilitySourceId
   relativeRootSegments: readonly string[]
+  /** Home-level Codex capsules live at ~/.codex/worktrees/<id>/<repo>, not under the checkout. */
+  matchUnanchored?: boolean
 }[] = [
   { id: 'claude', relativeRootSegments: ['.claude', 'worktrees'] },
-  { id: 'gsd', relativeRootSegments: ['.gsd-workspaces'] }
+  { id: 'gsd', relativeRootSegments: ['.gsd-workspaces'] },
+  { id: 'codex', relativeRootSegments: ['.codex', 'worktrees'], matchUnanchored: true }
 ]
 
 export type WorktreeVisibilitySourceMatch =
@@ -150,7 +153,7 @@ export function createWorktreeVisibilitySourceMatcher(
         const checkoutPathKey = /^[a-z]:$/i.test(checkoutPath)
           ? `${checkoutPath}/`
           : checkoutPath || '/'
-        if (checkoutPathKeys.has(checkoutPathKey)) {
+        if (checkoutPathKeys.has(checkoutPathKey) || source.matchUnanchored === true) {
           return { kind: 'built-in', id: source.id }
         }
       }


### PR DESCRIPTION
## Why

Running OMO/Codex inside Orca creates git worktrees at `~/.codex/worktrees/<id>/<repo>`. The built-in scratch matcher only knew `.claude/worktrees` and `.gsd-workspaces` **under a registered checkout**, so those capsules were imported as normal workspaces.

Every capsule landed on the default `in-progress` board status, with agent-status hooks firing on each tool call. The sidebar/board filled with fake work windows and the status UI broke.

## What changed

- Add a built-in `codex` visibility source for `.codex/worktrees`.
- Match **unanchored** home-level paths (`~/.codex/worktrees/<id>/<repo>`), not only `repo/.codex/worktrees/*`.
- Hide them by default, same as Claude/GSD. Users can still show the source in settings.
- Keep Claude/GSD checkout-anchored so we do not broaden #9388.

## Tested

`vitest` on visibility-sources, agent-scratch-worktrees, ownership, WorktreeVisibilityDialog, provenance — 111 passed.