### PR TITLE
fix(browser): reclaim idle headless browser tab renderers (STA-4341)

### DIFF
--- a/docs/reference/headless-linux-server.md
+++ b/docs/reference/headless-linux-server.md
@@ -299,15 +299,19 @@ renderer forever, which is the failure this exists to prevent; waking it simply
 retries the address. Parking never closes a page: the page stays open until
 something closes it, exactly as on the desktop.
 
-Two evictors decide what stays resident, mirroring terminal pane parking. The
-cap is the primary one:
+What stays resident is the same budget the desktop app applies to its own
+browser guests (`src/shared/browser-retention-budget.ts`): keep the most
+recently used, never evict something in use. The desktop learns a working set
+went cold when you switch worktrees; a headless host has no such event, so it
+configures the same budget with an idle window and schedules itself a one-shot
+check for the moment its answer could next change. A server with nothing
+resident holds no timer at all.
 
 | Variable                               | Default  | Meaning                                                            |
 | -------------------------------------- | -------- | ------------------------------------------------------------------ |
 | `ORCA_HEADLESS_BROWSER_RESIDENT_LIMIT` | `4`      | Renderers kept resident. Least-recently-used pages park past this. |
 | `ORCA_HEADLESS_BROWSER_PARK_IDLE_MS`   | `300000` | A page parks after this long untouched, even under the cap.        |
 | `ORCA_HEADLESS_BROWSER_PARK_GRACE_MS`  | `30000`  | A page is never parked this soon after its last command.           |
-| `ORCA_HEADLESS_BROWSER_PARK_SWEEP_MS`  | `15000`  | How often the server re-evaluates residency.                       |
 
 Raise the limit on a host with memory to spare, or set both the limit and the
 idle window very high to keep every page resident — at the cost this

--- a/docs/reference/headless-linux-server.md
+++ b/docs/reference/headless-linux-server.md
@@ -294,18 +294,18 @@ initial load is still running, or while it is waiting on a certificate
 decision. A navigation that has still not finished by the load timeout is
 deliberately reclaimable — otherwise one stalled page per create could hold a
 renderer forever, which is the failure this exists to prevent; waking it simply
-retries the address.
+retries the address. Parking never closes a page: the page stays open until
+something closes it, exactly as on the desktop.
 
 Two evictors decide what stays resident, mirroring terminal pane parking. The
 cap is the primary one:
 
-| Variable                                   | Default  | Meaning                                                                |
-| ------------------------------------------ | -------- | ---------------------------------------------------------------------- |
-| `ORCA_HEADLESS_BROWSER_RESIDENT_LIMIT`     | `4`      | Renderers kept resident. Least-recently-used pages park past this.     |
-| `ORCA_HEADLESS_BROWSER_PARK_IDLE_MS`       | `300000` | A page parks after this long untouched, even under the cap.            |
-| `ORCA_HEADLESS_BROWSER_PARK_GRACE_MS`      | `30000`  | A page is never parked this soon after its last command.               |
-| `ORCA_HEADLESS_BROWSER_PARK_SWEEP_MS`      | `15000`  | How often the server re-evaluates residency.                           |
-| `ORCA_HEADLESS_BROWSER_MAX_RETAINED_PAGES` | `100`    | Open pages retained before the oldest parked ones are closed outright. |
+| Variable                               | Default  | Meaning                                                            |
+| -------------------------------------- | -------- | ------------------------------------------------------------------ |
+| `ORCA_HEADLESS_BROWSER_RESIDENT_LIMIT` | `4`      | Renderers kept resident. Least-recently-used pages park past this. |
+| `ORCA_HEADLESS_BROWSER_PARK_IDLE_MS`   | `300000` | A page parks after this long untouched, even under the cap.        |
+| `ORCA_HEADLESS_BROWSER_PARK_GRACE_MS`  | `30000`  | A page is never parked this soon after its last command.           |
+| `ORCA_HEADLESS_BROWSER_PARK_SWEEP_MS`  | `15000`  | How often the server re-evaluates residency.                       |
 
 Raise the limit on a host with memory to spare, or set both the limit and the
 idle window very high to keep every page resident — at the cost this

--- a/docs/reference/headless-linux-server.md
+++ b/docs/reference/headless-linux-server.md
@@ -289,17 +289,19 @@ targets it transparently rebuilds the renderer and reloads the address. What a
 park does _not_ preserve is in-page JavaScript state — cookies and local
 storage live in the profile partition and survive, but an unsubmitted form or
 an SPA's in-memory state does not. A page is never parked while a paired
-client is streaming it or while a command is in flight.
+client is streaming it, while a command against it is in flight, or while its
+navigation has not committed.
 
 Two evictors decide what stays resident, mirroring terminal pane parking. The
 cap is the primary one:
 
-| Variable                               | Default  | Meaning                                                            |
-| -------------------------------------- | -------- | ------------------------------------------------------------------ |
-| `ORCA_HEADLESS_BROWSER_RESIDENT_LIMIT` | `4`      | Renderers kept resident. Least-recently-used pages park past this. |
-| `ORCA_HEADLESS_BROWSER_PARK_IDLE_MS`   | `300000` | A page parks after this long untouched, even under the cap.        |
-| `ORCA_HEADLESS_BROWSER_PARK_GRACE_MS`  | `30000`  | A page is never parked this soon after its last command.           |
-| `ORCA_HEADLESS_BROWSER_PARK_SWEEP_MS`  | `15000`  | How often the server re-evaluates residency.                       |
+| Variable                                   | Default  | Meaning                                                                |
+| ------------------------------------------ | -------- | ---------------------------------------------------------------------- |
+| `ORCA_HEADLESS_BROWSER_RESIDENT_LIMIT`     | `4`      | Renderers kept resident. Least-recently-used pages park past this.     |
+| `ORCA_HEADLESS_BROWSER_PARK_IDLE_MS`       | `300000` | A page parks after this long untouched, even under the cap.            |
+| `ORCA_HEADLESS_BROWSER_PARK_GRACE_MS`      | `30000`  | A page is never parked this soon after its last command.               |
+| `ORCA_HEADLESS_BROWSER_PARK_SWEEP_MS`      | `15000`  | How often the server re-evaluates residency.                           |
+| `ORCA_HEADLESS_BROWSER_MAX_RETAINED_PAGES` | `100`    | Open pages retained before the oldest parked ones are closed outright. |
 
 Raise the limit on a host with memory to spare, or set both the limit and the
 idle window very high to keep every page resident — at the cost this

--- a/docs/reference/headless-linux-server.md
+++ b/docs/reference/headless-linux-server.md
@@ -292,8 +292,9 @@ park does _not_ preserve is in-page JavaScript state — cookies and local
 storage live in the profile partition and survive, but an unsubmitted form or
 an SPA's in-memory state does not. A page is never parked while a paired
 client is streaming it, while a command against it is in flight, while its
-initial load is still running, or while it is waiting on a certificate
-decision. A stream ending counts as use, so a viewer who closes the pane gets
+initial load is still running, while it is waiting on a certificate decision,
+while a wake is still rebuilding it, or while it is writing an active
+download — parking cancels a download, so an active one always vetoes it. A stream ending counts as use, so a viewer who closes the pane gets
 the full idle window before the page parks, even if they only watched. A navigation that has still not finished by the load timeout is
 deliberately reclaimable — otherwise one stalled page per create could hold a
 renderer forever, which is the failure this exists to prevent; waking it simply
@@ -882,7 +883,7 @@ refuse to run there and print the command to run on the machine you want.
 - Clients cannot connect: make sure `--pairing-address` is an address reachable
   from the client, and make sure firewalls allow the selected `--port`.
 - Journal shows `Another Orca instance is already running for this userData
-profile` and the unit exits `3`: another process already owns the profile, so
+  profile` and the unit exits `3`: another process already owns the profile, so
   `RestartPreventExitStatus=3` leaves the unit `failed` on purpose. Find the
   owner with `systemctl status orca-serve` and `pgrep -af orca`. Stop it (or
   keep it and leave the unit down), then run

--- a/docs/reference/headless-linux-server.md
+++ b/docs/reference/headless-linux-server.md
@@ -274,6 +274,37 @@ sudo systemctl daemon-reload
 sudo systemctl enable --now orca-xvfb.service orca-serve.service
 ```
 
+## Browser Tab Renderer Reclamation
+
+Each browser page on a headless server is backed by its own hidden Electron
+window, so it costs a renderer process — several hundred MB, plus continuous
+CPU if the page animates. Agents open pages far more readily than they close
+them, so the server reclaims those renderers itself rather than relying on the
+agent to tidy up.
+
+An open page whose renderer has been reclaimed is **parked**: the page keeps
+its id, address, worktree and profile, `orca tab list` still shows it (marked
+`(parked)`, and `parked: true` under `--json`), and the next command that
+targets it transparently rebuilds the renderer and reloads the address. What a
+park does _not_ preserve is in-page JavaScript state — cookies and local
+storage live in the profile partition and survive, but an unsubmitted form or
+an SPA's in-memory state does not. A page is never parked while a paired
+client is streaming it or while a command is in flight.
+
+Two evictors decide what stays resident, mirroring terminal pane parking. The
+cap is the primary one:
+
+| Variable                               | Default  | Meaning                                                            |
+| -------------------------------------- | -------- | ------------------------------------------------------------------ |
+| `ORCA_HEADLESS_BROWSER_RESIDENT_LIMIT` | `4`      | Renderers kept resident. Least-recently-used pages park past this. |
+| `ORCA_HEADLESS_BROWSER_PARK_IDLE_MS`   | `300000` | A page parks after this long untouched, even under the cap.        |
+| `ORCA_HEADLESS_BROWSER_PARK_GRACE_MS`  | `30000`  | A page is never parked this soon after its last command.           |
+| `ORCA_HEADLESS_BROWSER_PARK_SWEEP_MS`  | `15000`  | How often the server re-evaluates residency.                       |
+
+Raise the limit on a host with memory to spare, or set both the limit and the
+idle window very high to keep every page resident — at the cost this
+reclamation exists to avoid.
+
 ## CLI Install Note
 
 On a headless host, you do not need to open the desktop UI just to run the
@@ -838,7 +869,7 @@ refuse to run there and print the command to run on the machine you want.
 - Clients cannot connect: make sure `--pairing-address` is an address reachable
   from the client, and make sure firewalls allow the selected `--port`.
 - Journal shows `Another Orca instance is already running for this userData
-  profile` and the unit exits `3`: another process already owns the profile, so
+profile` and the unit exits `3`: another process already owns the profile, so
   `RestartPreventExitStatus=3` leaves the unit `failed` on purpose. Find the
   owner with `systemctl status orca-serve` and `pgrep -af orca`. Stop it (or
   keep it and leave the unit down), then run

--- a/docs/reference/headless-linux-server.md
+++ b/docs/reference/headless-linux-server.md
@@ -293,8 +293,10 @@ storage live in the profile partition and survive, but an unsubmitted form or
 an SPA's in-memory state does not. A page is never parked while a paired
 client is streaming it, while a command against it is in flight, while its
 initial load is still running, while it is waiting on a certificate decision,
-while a wake is still rebuilding it, or while it is writing an active
-download — parking cancels a download, so an active one always vetoes it. A stream ending counts as use, so a viewer who closes the pane gets
+or while a wake is still rebuilding it. An active download vetoes the park
+decision — parking cancels downloads — but a download that begins during the
+teardown itself is still cancelled, exactly as if the tab had been closed at
+that instant. A stream ending counts as use, so a viewer who closes the pane gets
 the full idle window before the page parks, even if they only watched. A navigation that has still not finished by the load timeout is
 deliberately reclaimable — otherwise one stalled page per create could hold a
 renderer forever, which is the failure this exists to prevent; waking it simply

--- a/docs/reference/headless-linux-server.md
+++ b/docs/reference/headless-linux-server.md
@@ -285,7 +285,9 @@ agent to tidy up.
 An open page whose renderer has been reclaimed is **parked**: the page keeps
 its id, address, worktree and profile, `orca tab list` still shows it (marked
 `(parked)`, and `parked: true` under `--json`), and the next command that
-targets it transparently rebuilds the renderer and reloads the address. What a
+targets it transparently rebuilds the renderer and reloads the address. Waking is bounded: it waits briefly for the
+reload and then returns with the page operable and still navigating, so a slow
+site cannot stall the request that woke it. What a
 park does _not_ preserve is in-page JavaScript state — cookies and local
 storage live in the profile partition and survive, but an unsubmitted form or
 an SPA's in-memory state does not. A page is never parked while a paired

--- a/docs/reference/headless-linux-server.md
+++ b/docs/reference/headless-linux-server.md
@@ -289,8 +289,12 @@ targets it transparently rebuilds the renderer and reloads the address. What a
 park does _not_ preserve is in-page JavaScript state — cookies and local
 storage live in the profile partition and survive, but an unsubmitted form or
 an SPA's in-memory state does not. A page is never parked while a paired
-client is streaming it, while a command against it is in flight, while it is
-still navigating, or while it is waiting on a certificate decision.
+client is streaming it, while a command against it is in flight, while its
+initial load is still running, or while it is waiting on a certificate
+decision. A navigation that has still not finished by the load timeout is
+deliberately reclaimable — otherwise one stalled page per create could hold a
+renderer forever, which is the failure this exists to prevent; waking it simply
+retries the address.
 
 Two evictors decide what stays resident, mirroring terminal pane parking. The
 cap is the primary one:

--- a/docs/reference/headless-linux-server.md
+++ b/docs/reference/headless-linux-server.md
@@ -293,7 +293,8 @@ storage live in the profile partition and survive, but an unsubmitted form or
 an SPA's in-memory state does not. A page is never parked while a paired
 client is streaming it, while a command against it is in flight, while its
 initial load is still running, or while it is waiting on a certificate
-decision. A navigation that has still not finished by the load timeout is
+decision. A stream ending counts as use, so a viewer who closes the pane gets
+the full idle window before the page parks, even if they only watched. A navigation that has still not finished by the load timeout is
 deliberately reclaimable — otherwise one stalled page per create could hold a
 renderer forever, which is the failure this exists to prevent; waking it simply
 retries the address. Parking never closes a page: the page stays open until

--- a/docs/reference/headless-linux-server.md
+++ b/docs/reference/headless-linux-server.md
@@ -289,8 +289,8 @@ targets it transparently rebuilds the renderer and reloads the address. What a
 park does _not_ preserve is in-page JavaScript state — cookies and local
 storage live in the profile partition and survive, but an unsubmitted form or
 an SPA's in-memory state does not. A page is never parked while a paired
-client is streaming it, while a command against it is in flight, or while its
-navigation has not committed.
+client is streaming it, while a command against it is in flight, while it is
+still navigating, or while it is waiting on a certificate decision.
 
 Two evictors decide what stays resident, mirroring terminal pane parking. The
 cap is the primary one:

--- a/src/cli/browser-format.test.ts
+++ b/src/cli/browser-format.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { formatTabListWithProfiles } from './browser-format'
+
+describe('formatTabListWithProfiles', () => {
+  it('marks parked tabs and leaves resident ones unmarked', () => {
+    const output = formatTabListWithProfiles(
+      {
+        tabs: [
+          { browserPageId: 'a', index: 0, url: 'https://a.test/', title: 'A', active: true },
+          {
+            browserPageId: 'b',
+            index: 1,
+            url: 'https://b.test/',
+            title: 'B',
+            active: false,
+            parked: true
+          }
+        ]
+      },
+      false
+    )
+
+    expect(output).toBe('* [0] a  A — https://a.test/\n  [1] b  B — https://b.test/  (parked)')
+  })
+})

--- a/src/cli/browser-format.ts
+++ b/src/cli/browser-format.ts
@@ -34,7 +34,11 @@ export function formatTabListWithProfiles(
     .map((t) => {
       const marker = t.active ? '* ' : '  '
       const profile = showProfile ? `  [${t.profileLabel ?? t.profileId ?? 'Unknown'}]` : ''
-      return `${marker}[${t.index}] ${t.browserPageId}  ${t.title} — ${t.url}${profile}`
+      // Why (STA-4341): a parked tab is still open and still operable — the
+      // next command targeting it wakes it — but its renderer has been
+      // reclaimed, so in-page JavaScript state did not survive.
+      const parked = t.parked ? '  (parked)' : ''
+      return `${marker}[${t.index}] ${t.browserPageId}  ${t.title} — ${t.url}${profile}${parked}`
     })
     .join('\n')
 }

--- a/src/main/browser/agent-browser-bridge-in-flight-pin.test.ts
+++ b/src/main/browser/agent-browser-bridge-in-flight-pin.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { execFileMock, webContentsFromIdMock, existsSyncMock, readFileSyncMock, stdinWrites } =
+  vi.hoisted(() => ({
+    execFileMock: vi.fn(),
+    webContentsFromIdMock: vi.fn(),
+    existsSyncMock: vi.fn(() => false),
+    readFileSyncMock: vi.fn(() => Buffer.from('')),
+    stdinWrites: [] as string[]
+  }))
+
+vi.mock('child_process', () => ({ execFile: execFileMock }))
+vi.mock('fs', () => ({
+  existsSync: existsSyncMock,
+  readFileSync: readFileSyncMock,
+  accessSync: vi.fn(),
+  chmodSync: vi.fn(),
+  constants: { X_OK: 1 }
+}))
+vi.mock('os', () => ({ platform: () => 'darwin', arch: () => 'arm64' }))
+vi.mock('electron', () => ({
+  app: { getPath: vi.fn(() => '/app'), getAppPath: vi.fn(() => '/project'), isPackaged: false },
+  webContents: { fromId: webContentsFromIdMock }
+}))
+
+const { CdpWsProxyMock, proxyStartGate } = vi.hoisted(() => {
+  const instances: unknown[] = []
+  const gate: { block: Promise<void> | null } = { block: null }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const MockClass = vi.fn().mockImplementation(function (this: any) {
+    this.start = vi.fn(async () => {
+      if (gate.block) {
+        await gate.block
+      }
+      return 'ws://127.0.0.1:9222'
+    })
+    this.stop = vi.fn(async () => {})
+    this.getPort = vi.fn(() => 9222)
+    instances.push(this)
+  })
+  return { CdpWsProxyMock: Object.assign(MockClass, { instances }), proxyStartGate: gate }
+})
+
+vi.mock('./cdp-ws-proxy', () => ({ CdpWsProxy: CdpWsProxyMock }))
+vi.mock('./cdp-bridge', () => ({
+  BrowserError: class BrowserError extends Error {
+    code: string
+    constructor(code: string, message: string) {
+      super(message)
+      this.code = code
+    }
+  }
+}))
+
+import { AgentBrowserBridge } from './agent-browser-bridge'
+import {
+  createSucceedWith,
+  mockBrowserManager,
+  overrideBridgeWebContentsLookup,
+  resetAgentBrowserBridgeMocks
+} from './agent-browser-bridge-test-harness'
+
+overrideBridgeWebContentsLookup(AgentBrowserBridge.prototype, webContentsFromIdMock)
+const succeedWith = createSucceedWith(execFileMock, stdinWrites)
+
+// Why (STA-4341): the headless reclaimer parks pages it believes nobody is
+// using, and asks the bridge. A command has to read as in flight for its whole
+// lifetime — including helper-session setup, which can spend up to
+// EXEC_TIMEOUT_MS (90s) closing a stale session, far longer than the reclaim
+// grace window. Pinning only while the queue executes leaves that gap open.
+
+describe('AgentBrowserBridge in-flight command pinning', () => {
+  let bridge: AgentBrowserBridge
+
+  beforeEach(() => {
+    resetAgentBrowserBridgeMocks({
+      webContentsFromIdMock,
+      existsSyncMock,
+      readFileSyncMock,
+      stdinWrites,
+      cdpWsProxyInstances: CdpWsProxyMock.instances
+    })
+    proxyStartGate.block = null
+    bridge = new AgentBrowserBridge(mockBrowserManager())
+    bridge.setActiveTab(100)
+  })
+
+  it('reports no in-flight command for an idle page', () => {
+    expect(bridge.hasInFlightCommand('tab-1')).toBe(false)
+  })
+
+  it('pins the page while its helper session is still being set up', async () => {
+    let releaseProxyStart = (): void => {}
+    proxyStartGate.block = new Promise<void>((resolve) => (releaseProxyStart = resolve))
+    succeedWith({ snapshot: 'ready' })
+
+    const command = bridge.snapshot()
+    // Yield so the command reaches session setup and blocks there.
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(bridge.hasInFlightCommand('tab-1')).toBe(true)
+
+    releaseProxyStart()
+    await command
+    expect(bridge.hasInFlightCommand('tab-1')).toBe(false)
+  })
+
+  it('stays pinned until the last overlapping command finishes', async () => {
+    let releaseProxyStart = (): void => {}
+    proxyStartGate.block = new Promise<void>((resolve) => (releaseProxyStart = resolve))
+    succeedWith({ snapshot: 'ready' })
+
+    const first = bridge.snapshot()
+    const second = bridge.snapshot()
+    await Promise.resolve()
+    expect(bridge.hasInFlightCommand('tab-1')).toBe(true)
+
+    releaseProxyStart()
+    await Promise.all([first, second])
+    expect(bridge.hasInFlightCommand('tab-1')).toBe(false)
+  })
+
+  it('releases the pin when the command fails', async () => {
+    execFileMock.mockImplementation(
+      (_bin: string, _args: string[], _opts: unknown, cb: (e: unknown) => void) => {
+        cb(new Error('boom'))
+        return { stdin: { on: vi.fn(), end: vi.fn() } }
+      }
+    )
+
+    await expect(bridge.snapshot()).rejects.toBeDefined()
+    expect(bridge.hasInFlightCommand('tab-1')).toBe(false)
+  })
+
+  it('does not pin an unrelated page', async () => {
+    succeedWith({ snapshot: 'ready' })
+    const command = bridge.snapshot()
+    expect(bridge.hasInFlightCommand('some-other-page')).toBe(false)
+    await command
+  })
+})

--- a/src/main/browser/agent-browser-bridge-tab-routing.test.ts
+++ b/src/main/browser/agent-browser-bridge-tab-routing.test.ts
@@ -106,6 +106,34 @@ describe('AgentBrowserBridge', () => {
     expect(b.getActiveWebContentsId()).toBe(1)
   })
 
+  // ── Active-page queries ──
+
+  it('answers isActiveBrowserPage from the pointers without reassigning them', () => {
+    const tabs = new Map([
+      ['page-a', 1],
+      ['page-b', 2]
+    ])
+    const worktrees = new Map([
+      ['page-a', 'wt-1'],
+      ['page-b', 'wt-1']
+    ])
+    const b = new AgentBrowserBridge(
+      mockBrowserManager(tabs, worktrees, {
+        getGuestWebContentsId: vi.fn((browserPageId: string) => tabs.get(browserPageId) ?? null)
+      })
+    )
+    b.setActiveTab(1, 'wt-1')
+
+    expect(b.isActiveBrowserPage('page-a', 'wt-1')).toBe(true)
+    expect(b.isActiveBrowserPage('page-b', 'wt-1')).toBe(false)
+    // Why: parkPage omits the worktree when the record has none; the owning
+    // worktree must come from the manager, not default to the global pointer.
+    expect(b.isActiveBrowserPage('page-a')).toBe(true)
+    expect(b.isActiveBrowserPage('missing', 'wt-1')).toBe(false)
+    // Asking must not move the pointer the way resolveActiveTab() would.
+    expect(b.getActiveWebContentsId()).toBe(1)
+  })
+
   // ── Worktree filtering ──
 
   describe('worktree filtering', () => {

--- a/src/main/browser/agent-browser-bridge.ts
+++ b/src/main/browser/agent-browser-bridge.ts
@@ -708,6 +708,12 @@ export class AgentBrowserBridge {
 
   // ── Worktree-scoped tab queries ──
 
+  // Why (STA-4341): the headless reclaimer must never park a page that is
+  // mid-command; the per-session queue already knows when one is executing.
+  hasInFlightCommand(browserPageId: string): boolean {
+    return this.processingQueues.has(`orca-tab-${browserPageId}`)
+  }
+
   getRegisteredTabs(worktreeId?: string): Map<string, number> {
     const all = this.browserManager.getWebContentsIdByTabId()
     if (!worktreeId) {

--- a/src/main/browser/agent-browser-bridge.ts
+++ b/src/main/browser/agent-browser-bridge.ts
@@ -714,6 +714,21 @@ export class AgentBrowserBridge {
     return this.processingQueues.has(`orca-tab-${browserPageId}`)
   }
 
+  // Why (STA-4341): parking has to record whether the page was the active tab
+  // so the session snapshot can keep saying so. Read the active pointers
+  // directly — resolveActiveTab() would reassign them as a side effect.
+  isActiveBrowserPage(browserPageId: string, worktreeId?: string): boolean {
+    const webContentsId = this.browserManager.getGuestWebContentsId(browserPageId)
+    if (webContentsId == null) {
+      return false
+    }
+    const owningWorktreeId = worktreeId ?? this.browserManager.getWorktreeIdForTab(browserPageId)
+    const active =
+      (owningWorktreeId && this.activeWebContentsPerWorktree.get(owningWorktreeId)) ??
+      this.activeWebContentsId
+    return active === webContentsId
+  }
+
   getRegisteredTabs(worktreeId?: string): Map<string, number> {
     const all = this.browserManager.getWebContentsIdByTabId()
     if (!worktreeId) {

--- a/src/main/browser/agent-browser-bridge.ts
+++ b/src/main/browser/agent-browser-bridge.ts
@@ -575,6 +575,8 @@ export class AgentBrowserBridge {
   private readonly sessions = new Map<string, SessionState>()
   private readonly commandQueues = new Map<string, QueuedCommand[]>()
   private readonly processingQueues = new Set<string>()
+  /** Pages with a command claimed but not finished, counted for re-entrancy. */
+  private readonly inFlightCommandsByPageId = new Map<string, number>()
   // Why: screenshot prep mutates shared paintability across tabs; serialize globally so concurrent captures don't blank each other.
   private screenshotTurn: Promise<void> = Promise.resolve()
   private readonly agentBrowserBin: string
@@ -709,9 +711,31 @@ export class AgentBrowserBridge {
   // ── Worktree-scoped tab queries ──
 
   // Why (STA-4341): the headless reclaimer must never park a page that is
-  // mid-command; the per-session queue already knows when one is executing.
+  // mid-command. processingQueues only covers execution — a command is claimed
+  // from the moment its target resolves, which matters because ensureSession
+  // can spend up to EXEC_TIMEOUT_MS closing a stale helper session first, far
+  // longer than the reclaim grace window.
   hasInFlightCommand(browserPageId: string): boolean {
-    return this.processingQueues.has(`orca-tab-${browserPageId}`)
+    return (
+      this.inFlightCommandsByPageId.has(browserPageId) ||
+      this.processingQueues.has(`orca-tab-${browserPageId}`)
+    )
+  }
+
+  private retainInFlightCommand(browserPageId: string): void {
+    this.inFlightCommandsByPageId.set(
+      browserPageId,
+      (this.inFlightCommandsByPageId.get(browserPageId) ?? 0) + 1
+    )
+  }
+
+  private releaseInFlightCommand(browserPageId: string): void {
+    const remaining = (this.inFlightCommandsByPageId.get(browserPageId) ?? 1) - 1
+    if (remaining > 0) {
+      this.inFlightCommandsByPageId.set(browserPageId, remaining)
+    } else {
+      this.inFlightCommandsByPageId.delete(browserPageId)
+    }
   }
 
   // Why (STA-4341): parking has to record whether the page was the active tab
@@ -2088,6 +2112,20 @@ export class AgentBrowserBridge {
     options: EnqueueTargetedCommandOptions = {}
   ): Promise<T> {
     const target = this.resolveCommandTarget(worktreeId, browserPageId, options.requireScopedTarget)
+    this.retainInFlightCommand(target.browserPageId)
+    try {
+      return await this.runTargetedCommand(worktreeId, target, execute, options)
+    } finally {
+      this.releaseInFlightCommand(target.browserPageId)
+    }
+  }
+
+  private async runTargetedCommand<T>(
+    worktreeId: string | undefined,
+    target: ResolvedBrowserCommandTarget,
+    execute: (sessionName: string, target: ResolvedBrowserCommandTarget) => Promise<T>,
+    options: EnqueueTargetedCommandOptions
+  ): Promise<T> {
     const sessionName = `orca-tab-${target.browserPageId}`
 
     if (options.ensureSession !== false) {

--- a/src/main/browser/browser-backend.ts
+++ b/src/main/browser/browser-backend.ts
@@ -13,6 +13,15 @@ export type BrowserBackendCreateTab = {
   browserPageId?: string
 }
 
+/** A page whose renderer has been reclaimed but whose identity is retained. */
+export type ParkedBrowserPage = {
+  browserPageId: string
+  worktreeId?: string
+  profileId?: string
+  url: string
+  title: string
+}
+
 export type BrowserBackend = {
   /** Create a browser page and register its WebContents. Returns the page id. */
   createTab(params: BrowserBackendCreateTab): Promise<{ browserPageId: string }>
@@ -21,4 +30,15 @@ export type BrowserBackend = {
   /** Tear down every page this backend owns (process shutdown). Optional —
    *  renderer-hosted backends are torn down with their window. */
   destroyAll?(): void
+  /** Make a page's renderer resident and restart its reclaim clock. Cheap and
+   *  idempotent for an already-resident page, so command routing calls it
+   *  unconditionally. Resolves false when the page id is unknown. Optional —
+   *  only the offscreen backend owns renderer lifetime; renderer-hosted pages
+   *  are parked by the window that hosts them. */
+  wakeTab?(browserPageId: string): Promise<boolean>
+  /** Pages this backend still owns whose renderer is currently reclaimed. */
+  listParkedPages?(worktreeId?: string): ParkedBrowserPage[]
+  /** Most-recently-used parked page, for commands that target a worktree
+   *  rather than a page id. */
+  getMostRecentlyUsedParkedPageId?(worktreeId?: string): string | null
 }

--- a/src/main/browser/browser-backend.ts
+++ b/src/main/browser/browser-backend.ts
@@ -20,6 +20,8 @@ export type ParkedBrowserPage = {
   profileId?: string
   url: string
   title: string
+  /** Whether the page was its worktree's active tab when it parked. */
+  active?: boolean
 }
 
 export type BrowserBackend = {

--- a/src/main/browser/browser-backend.ts
+++ b/src/main/browser/browser-backend.ts
@@ -45,6 +45,9 @@ export type BrowserBackend = {
   wakeTab?(browserPageId: string): Promise<boolean>
   /** Pages this backend still owns whose renderer is currently reclaimed. */
   listParkedPages?(worktreeId?: string): ParkedBrowserPage[]
+  /** Open page ids in creation order, resident or parked — listings sort by
+   *  this so parking never renumbers a tab index the caller already read. */
+  listOpenPageIds?(worktreeId?: string): string[]
   /** The parked page a page-less command should target: the one that was
    *  active when it parked, else the most recently used. */
   getParkedPageIdForImplicitTarget?(worktreeId?: string): string | null

--- a/src/main/browser/browser-backend.ts
+++ b/src/main/browser/browser-backend.ts
@@ -6,6 +6,8 @@
 // WebContents uniformly regardless of how the page was created. This interface
 // isolates the only step that actually differs: tab creation and teardown.
 
+import type { BrowserLoadError } from '../../shared/browser-workspace-types'
+
 export type BrowserBackendCreateTab = {
   url: string
   worktreeId?: string
@@ -22,6 +24,9 @@ export type ParkedBrowserPage = {
   title: string
   /** Whether the page was its worktree's active tab when it parked. */
   active?: boolean
+  /** The failure the page last reported. Reclaiming a renderer does not make a
+   *  page that failed to load healthy again. */
+  loadError?: BrowserLoadError | null
 }
 
 export type BrowserBackend = {
@@ -40,7 +45,7 @@ export type BrowserBackend = {
   wakeTab?(browserPageId: string): Promise<boolean>
   /** Pages this backend still owns whose renderer is currently reclaimed. */
   listParkedPages?(worktreeId?: string): ParkedBrowserPage[]
-  /** Most-recently-used parked page, for commands that target a worktree
-   *  rather than a page id. */
-  getMostRecentlyUsedParkedPageId?(worktreeId?: string): string | null
+  /** The parked page a page-less command should target: the one that was
+   *  active when it parked, else the most recently used. */
+  getParkedPageIdForImplicitTarget?(worktreeId?: string): string | null
 }

--- a/src/main/browser/browser-manager.ts
+++ b/src/main/browser/browser-manager.ts
@@ -201,8 +201,6 @@ type ActiveDownload = {
   savePath: string
   reservationKey: string | null
   receivedBytes: number
-  /** Last time Electron reported progress; the liveness signal a reclaimer needs. */
-  lastProgressAt: number
   transientState: BrowserDownloadProgressEvent['state']
   terminalEvent: BrowserDownloadFinishedEvent | null
   startedSent: boolean
@@ -1474,23 +1472,18 @@ export class BrowserManager {
       : (this.loadErrorsByGuestId.get(webContentsId) ?? null)
   }
 
-  /**
-   * When this page's in-flight downloads last made progress, or null when it has
-   * none. Why (STA-4341): unregisterGuest cancels a tab's in-flight downloads, so
-   * a reclaimer must not take a page that is still writing one — the desktop guest
-   * budget vetoes eviction for the same reason. A timestamp rather than a boolean
-   * because a download that stalls forever must not pin a renderer forever; the
-   * caller owns that bound.
-   */
-  getBrowserPageActiveDownloadProgressAt(browserPageId: string): number | null {
-    let latest: number | null = null
+  // Why (STA-4341): unregisterGuest cancels a tab's in-flight downloads, so a
+  // reclaimer must not take a page that is still writing one. Mirrors the
+  // desktop guest budget's veto (browser-page-download-activity.ts) exactly,
+  // including its unbounded nature: a download is treated as work in progress
+  // for as long as it stays active.
+  hasActiveBrowserPageDownload(browserPageId: string): boolean {
     for (const download of this.downloadsById.values()) {
       if (download.browserTabId === browserPageId && !download.terminalEvent) {
-        latest =
-          latest === null ? download.lastProgressAt : Math.max(latest, download.lastProgressAt)
+        return true
       }
     }
-    return latest
+    return false
   }
 
   getBrowserPageCertificateFailure(browserPageId: string): BrowserCertificateFailure | null {
@@ -1638,7 +1631,6 @@ export class BrowserManager {
       savePath: fallbackSavePath,
       reservationKey: destination?.reservationKey ?? null,
       receivedBytes: 0,
-      lastProgressAt: Date.now(),
       transientState: null,
       terminalEvent: null,
       startedSent: false,
@@ -1680,7 +1672,6 @@ export class BrowserManager {
 
     const updatedHandler = (_event: Electron.Event, state: 'progressing' | 'interrupted'): void => {
       download.receivedBytes = this.getDownloadReceivedBytes(download.item)
-      download.lastProgressAt = Date.now()
       download.transientState = state
       this.sendDownloadProgress(download.browserTabId, {
         browserPageId: download.browserTabId ?? undefined,

--- a/src/main/browser/browser-manager.ts
+++ b/src/main/browser/browser-manager.ts
@@ -201,6 +201,8 @@ type ActiveDownload = {
   savePath: string
   reservationKey: string | null
   receivedBytes: number
+  /** Last time Electron reported progress; the liveness signal a reclaimer needs. */
+  lastProgressAt: number
   transientState: BrowserDownloadProgressEvent['state']
   terminalEvent: BrowserDownloadFinishedEvent | null
   startedSent: boolean
@@ -1472,17 +1474,23 @@ export class BrowserManager {
       : (this.loadErrorsByGuestId.get(webContentsId) ?? null)
   }
 
-  // Why (STA-4341): unregisterGuest cancels a tab's in-flight downloads, so any
-  // reclaimer that unregisters a guest has to know not to take a page that is
-  // still writing one. The desktop guest budget vetoes eviction for the same
-  // reason (browser-page-download-activity.ts).
-  hasActiveBrowserPageDownload(browserPageId: string): boolean {
+  /**
+   * When this page's in-flight downloads last made progress, or null when it has
+   * none. Why (STA-4341): unregisterGuest cancels a tab's in-flight downloads, so
+   * a reclaimer must not take a page that is still writing one — the desktop guest
+   * budget vetoes eviction for the same reason. A timestamp rather than a boolean
+   * because a download that stalls forever must not pin a renderer forever; the
+   * caller owns that bound.
+   */
+  getBrowserPageActiveDownloadProgressAt(browserPageId: string): number | null {
+    let latest: number | null = null
     for (const download of this.downloadsById.values()) {
       if (download.browserTabId === browserPageId && !download.terminalEvent) {
-        return true
+        latest =
+          latest === null ? download.lastProgressAt : Math.max(latest, download.lastProgressAt)
       }
     }
-    return false
+    return latest
   }
 
   getBrowserPageCertificateFailure(browserPageId: string): BrowserCertificateFailure | null {
@@ -1630,6 +1638,7 @@ export class BrowserManager {
       savePath: fallbackSavePath,
       reservationKey: destination?.reservationKey ?? null,
       receivedBytes: 0,
+      lastProgressAt: Date.now(),
       transientState: null,
       terminalEvent: null,
       startedSent: false,
@@ -1671,6 +1680,7 @@ export class BrowserManager {
 
     const updatedHandler = (_event: Electron.Event, state: 'progressing' | 'interrupted'): void => {
       download.receivedBytes = this.getDownloadReceivedBytes(download.item)
+      download.lastProgressAt = Date.now()
       download.transientState = state
       this.sendDownloadProgress(download.browserTabId, {
         browserPageId: download.browserTabId ?? undefined,

--- a/src/main/browser/browser-manager.ts
+++ b/src/main/browser/browser-manager.ts
@@ -1472,6 +1472,19 @@ export class BrowserManager {
       : (this.loadErrorsByGuestId.get(webContentsId) ?? null)
   }
 
+  // Why (STA-4341): unregisterGuest cancels a tab's in-flight downloads, so any
+  // reclaimer that unregisters a guest has to know not to take a page that is
+  // still writing one. The desktop guest budget vetoes eviction for the same
+  // reason (browser-page-download-activity.ts).
+  hasActiveBrowserPageDownload(browserPageId: string): boolean {
+    for (const download of this.downloadsById.values()) {
+      if (download.browserTabId === browserPageId && !download.terminalEvent) {
+        return true
+      }
+    }
+    return false
+  }
+
   getBrowserPageCertificateFailure(browserPageId: string): BrowserCertificateFailure | null {
     return this.certificateTrustController?.getFailure(browserPageId) ?? null
   }

--- a/src/main/browser/cdp-ws-proxy.ts
+++ b/src/main/browser/cdp-ws-proxy.ts
@@ -105,7 +105,13 @@ export class CdpWsProxy {
   }
 
   async stop(): Promise<void> {
-    this.debuggerChannel.detachDebugger()
+    try {
+      this.debuggerChannel.detachDebugger()
+    } catch {
+      // Why: detaching touches the WebContents, which may already be destroyed
+      // (renderer crash, headless park). The listening socket below must close
+      // regardless, or the port outlives the page it served.
+    }
     this.closeClient()
     if (this.wss) {
       this.wss.close()

--- a/src/main/browser/headless-browser-tab-listing.test.ts
+++ b/src/main/browser/headless-browser-tab-listing.test.ts
@@ -60,4 +60,17 @@ describe('mergeParkedBrowserTabs', () => {
       parked: true
     })
   })
+
+  it('reports at most one active tab when several parked pages claim it', () => {
+    // Why: `active` is a single selection. Parking the active page promotes
+    // another live tab, which can later park claiming the flag as well.
+    const merged = mergeParkedBrowserTabs([], [parked('b', true), parked('c', true)])
+    expect(merged.filter((tab) => tab.active).map((tab) => tab.browserPageId)).toEqual(['b'])
+  })
+
+  it('carries a parked page load failure into the listing', () => {
+    const loadError = { code: -105, description: 'NAME_NOT_RESOLVED', validatedUrl: 'https://nope' }
+    const [tab] = mergeParkedBrowserTabs([], [{ ...parked('b'), loadError }])
+    expect(tab.loadError).toEqual(loadError)
+  })
 })

--- a/src/main/browser/headless-browser-tab-listing.test.ts
+++ b/src/main/browser/headless-browser-tab-listing.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import type { BrowserTabInfo } from '../../shared/runtime-types'
+import type { ParkedBrowserPage } from './browser-backend'
+import { mergeParkedBrowserTabs } from './headless-browser-tab-listing'
+
+function live(browserPageId: string, index: number, active = false): BrowserTabInfo {
+  return {
+    browserPageId,
+    index,
+    url: `https://example.test/${browserPageId}`,
+    title: browserPageId,
+    active
+  }
+}
+
+function parked(browserPageId: string, active = false): ParkedBrowserPage {
+  return {
+    browserPageId,
+    worktreeId: 'wt-1',
+    profileId: 'default',
+    url: `https://example.test/${browserPageId}`,
+    title: browserPageId,
+    active
+  }
+}
+
+describe('mergeParkedBrowserTabs', () => {
+  it('returns the live listing untouched when nothing is parked', () => {
+    const tabs = [live('a', 0, true), live('b', 1)]
+    expect(mergeParkedBrowserTabs(tabs, [])).toEqual(tabs)
+  })
+
+  it('appends parked pages with continuous indices', () => {
+    const merged = mergeParkedBrowserTabs([live('a', 0, true)], [parked('b'), parked('c')])
+    expect(merged.map((tab) => [tab.browserPageId, tab.index, tab.parked === true])).toEqual([
+      ['a', 0, false],
+      ['b', 1, true],
+      ['c', 2, true]
+    ])
+  })
+
+  it('lets a parked page stay active when nothing live claims it', () => {
+    // Why: parking clears the bridge pointer, but the paired client's tab bar
+    // must not lose its selection just because the renderer was reclaimed.
+    const merged = mergeParkedBrowserTabs([], [parked('b', true), parked('c')])
+    expect(merged.map((tab) => tab.active)).toEqual([true, false])
+  })
+
+  it('never reports two active tabs', () => {
+    const merged = mergeParkedBrowserTabs([live('a', 0, true)], [parked('b', true)])
+    expect(merged.filter((tab) => tab.active).map((tab) => tab.browserPageId)).toEqual(['a'])
+  })
+
+  it('carries worktree and profile identity for parked pages', () => {
+    const [tab] = mergeParkedBrowserTabs([], [parked('b')])
+    expect(tab).toMatchObject({
+      browserPageId: 'b',
+      worktreeId: 'wt-1',
+      profileId: 'default',
+      parked: true
+    })
+  })
+})

--- a/src/main/browser/headless-browser-tab-listing.test.ts
+++ b/src/main/browser/headless-browser-tab-listing.test.ts
@@ -68,6 +68,33 @@ describe('mergeParkedBrowserTabs', () => {
     expect(merged.filter((tab) => tab.active).map((tab) => tab.browserPageId)).toEqual(['b'])
   })
 
+  it('orders by creation so parking never renumbers an index the caller read', () => {
+    // Why: the bridge lists by registration order, which a park/wake cycle
+    // mutates (a woken tab re-registers at the end). A tab created first must
+    // stay at index 0 whether or not its renderer is currently reclaimed.
+    const merged = mergeParkedBrowserTabs([live('b', 0, true)], [parked('a')], ['a', 'b'])
+    expect(merged.map((tab) => [tab.browserPageId, tab.index, tab.parked === true])).toEqual([
+      ['a', 0, true],
+      ['b', 1, false]
+    ])
+  })
+
+  it('reindexes an all-live listing when the creation order disagrees', () => {
+    const merged = mergeParkedBrowserTabs([live('b', 0), live('a', 1, true)], [], ['a', 'b'])
+    expect(merged.map((tab) => [tab.browserPageId, tab.index])).toEqual([
+      ['a', 0],
+      ['b', 1]
+    ])
+  })
+
+  it('keeps ids missing from the creation order at their merged position', () => {
+    const merged = mergeParkedBrowserTabs([live('x', 0, true)], [parked('a')], ['a'])
+    expect(merged.map((tab) => [tab.browserPageId, tab.index])).toEqual([
+      ['a', 0],
+      ['x', 1]
+    ])
+  })
+
   it('carries a parked page load failure into the listing', () => {
     const loadError = { code: -105, description: 'NAME_NOT_RESOLVED', validatedUrl: 'https://nope' }
     const [tab] = mergeParkedBrowserTabs([], [{ ...parked('b'), loadError }])

--- a/src/main/browser/headless-browser-tab-listing.test.ts
+++ b/src/main/browser/headless-browser-tab-listing.test.ts
@@ -87,6 +87,14 @@ describe('mergeParkedBrowserTabs', () => {
     ])
   })
 
+  it('ignores stale ids in the creation order', () => {
+    const merged = mergeParkedBrowserTabs([live('b', 0, true)], [parked('a')], ['closed', 'a', 'b'])
+    expect(merged.map((tab) => [tab.browserPageId, tab.index])).toEqual([
+      ['a', 0],
+      ['b', 1]
+    ])
+  })
+
   it('keeps ids missing from the creation order at their merged position', () => {
     const merged = mergeParkedBrowserTabs([live('x', 0, true)], [parked('a')], ['a'])
     expect(merged.map((tab) => [tab.browserPageId, tab.index])).toEqual([

--- a/src/main/browser/headless-browser-tab-listing.ts
+++ b/src/main/browser/headless-browser-tab-listing.ts
@@ -9,9 +9,14 @@ import type { ParkedBrowserPage } from './browser-backend'
 
 export function mergeParkedBrowserTabs(
   live: readonly BrowserTabInfo[],
-  parked: readonly ParkedBrowserPage[]
+  parked: readonly ParkedBrowserPage[],
+  // Why: the bridge lists by registration order, which parking and waking both
+  // mutate (a woken tab re-registers at the end). Ordering by the page book's
+  // creation order instead keeps every tab's index stable across a park — an
+  // index the caller read must never be renumbered by a background timer.
+  creationOrder?: readonly string[]
 ): BrowserTabInfo[] {
-  if (parked.length === 0) {
+  if (parked.length === 0 && !creationOrder) {
     return [...live]
   }
   // Why: parking clears the bridge's active pointer, which then lands on a
@@ -37,5 +42,16 @@ export function mergeParkedBrowserTabs(
       profileId: page.profileId ?? null
     })
   }
+  if (!creationOrder) {
+    return merged
+  }
+  const rank = new Map(creationOrder.map((browserPageId, index) => [browserPageId, index]))
   return merged
+    .map((tab, index) => ({ tab, index }))
+    .sort((left, right) => {
+      const leftRank = rank.get(left.tab.browserPageId) ?? creationOrder.length + left.index
+      const rightRank = rank.get(right.tab.browserPageId) ?? creationOrder.length + right.index
+      return leftRank - rightRank
+    })
+    .map(({ tab }, index) => ({ ...tab, index }))
 }

--- a/src/main/browser/headless-browser-tab-listing.ts
+++ b/src/main/browser/headless-browser-tab-listing.ts
@@ -16,17 +16,23 @@ export function mergeParkedBrowserTabs(
   }
   // Why: parking clears the bridge's active pointer, which then lands on a
   // surviving live tab. A parked page may only claim active when nothing live
-  // does, or a listing can report two active tabs.
-  const liveClaimsActive = live.some((tab) => tab.active)
+  // does, and at most one may — `active` is a single selection, so a listing
+  // that reports two is not something any caller can act on.
+  let activeClaimed = live.some((tab) => tab.active)
   const merged = [...live]
   for (const page of parked) {
+    const active = !activeClaimed && page.active === true
+    activeClaimed = activeClaimed || active
     merged.push({
       browserPageId: page.browserPageId,
       index: merged.length,
       url: page.url,
       title: page.title,
-      active: !liveClaimsActive && page.active === true,
+      active,
       parked: true,
+      // Why: a page that failed to load is still failed while parked; hiding
+      // that would show a broken page as healthy at its address.
+      loadError: page.loadError ?? null,
       worktreeId: page.worktreeId ?? null,
       profileId: page.profileId ?? null
     })

--- a/src/main/browser/headless-browser-tab-listing.ts
+++ b/src/main/browser/headless-browser-tab-listing.ts
@@ -1,0 +1,35 @@
+import type { BrowserTabInfo } from '../../shared/runtime-types'
+import type { ParkedBrowserPage } from './browser-backend'
+
+// Why (STA-4341): a headless page whose renderer has been reclaimed is parked,
+// not closed. Every surface that enumerates headless pages — the CLI's
+// `tab list`, the session-tab snapshot a paired client renders, worktree
+// teardown — has to see it, or the page silently disappears from the client
+// while the runtime still owns it. One merge keeps those surfaces agreeing.
+
+export function mergeParkedBrowserTabs(
+  live: readonly BrowserTabInfo[],
+  parked: readonly ParkedBrowserPage[]
+): BrowserTabInfo[] {
+  if (parked.length === 0) {
+    return [...live]
+  }
+  // Why: parking clears the bridge's active pointer, which then lands on a
+  // surviving live tab. A parked page may only claim active when nothing live
+  // does, or a listing can report two active tabs.
+  const liveClaimsActive = live.some((tab) => tab.active)
+  const merged = [...live]
+  for (const page of parked) {
+    merged.push({
+      browserPageId: page.browserPageId,
+      index: merged.length,
+      url: page.url,
+      title: page.title,
+      active: !liveClaimsActive && page.active === true,
+      parked: true,
+      worktreeId: page.worktreeId ?? null,
+      profileId: page.profileId ?? null
+    })
+  }
+  return merged
+}

--- a/src/main/browser/offscreen-browser-backend-reclaim.test.ts
+++ b/src/main/browser/offscreen-browser-backend-reclaim.test.ts
@@ -283,6 +283,35 @@ describe('OffscreenBrowserBackend reclamation', () => {
     expect(h.windows).toHaveLength(2)
   })
 
+  it('owns no page and no renderer when materialization fails', async () => {
+    // Why: a create that never produced a usable renderer must not occupy the
+    // retention budget, be listed as parked, or block a retry with the same id.
+    const h = createHarness()
+    h.manager.registerOffscreenGuest = () => {
+      throw new Error('register failed')
+    }
+
+    await expect(h.backend.createTab({ url: 'https://a', browserPageId: 'a' })).rejects.toThrow(
+      'register failed'
+    )
+
+    expect(h.backend.listParkedPages()).toEqual([])
+    expect(h.windows.every((win) => win.isDestroyed())).toBe(true)
+    // The id is free again, so a retry is not rejected as already existing.
+    h.manager.registerOffscreenGuest = (({
+      browserPageId,
+      webContentsId
+    }: {
+      browserPageId: string
+      webContentsId: number
+    }) => {
+      h.registered.set(browserPageId, webContentsId)
+    }) as typeof h.manager.registerOffscreenGuest
+    await expect(h.backend.createTab({ url: 'https://a', browserPageId: 'a' })).resolves.toEqual({
+      browserPageId: 'a'
+    })
+  })
+
   it('reports false when waking a page it does not own', async () => {
     const h = createHarness()
     expect(await h.backend.wakeTab('nope')).toBe(false)

--- a/src/main/browser/offscreen-browser-backend-reclaim.test.ts
+++ b/src/main/browser/offscreen-browser-backend-reclaim.test.ts
@@ -95,6 +95,7 @@ type Harness = {
   activePageId: string | undefined
   pagesChanged: (string | undefined)[]
   certificateFailurePageIds: Set<string>
+  downloadingPageIds: Set<string>
 }
 
 function createHarness(
@@ -103,11 +104,13 @@ function createHarness(
     activePageId?: string
     loadError?: { code: number; description: string; validatedUrl: string } | null
     certificateFailurePageIds?: string[]
+    downloadingPageIds?: string[]
   } = {}
 ): Harness {
   const state = {
     activePageId: overrides.activePageId,
     certificateFailurePageIds: new Set<string>(overrides.certificateFailurePageIds ?? []),
+    downloadingPageIds: new Set<string>(overrides.downloadingPageIds ?? []),
     pagesChanged: [] as (string | undefined)[]
   }
   const order: string[] = []
@@ -139,7 +142,9 @@ function createHarness(
     getGuestWebContentsId: (browserPageId: string) => registered.get(browserPageId) ?? null,
     getBrowserPageLoadError: () => overrides.loadError ?? null,
     getBrowserPageCertificateFailure: (browserPageId: string) =>
-      state.certificateFailurePageIds.has(browserPageId) ? { challengeId: 'c' } : null
+      state.certificateFailurePageIds.has(browserPageId) ? { challengeId: 'c' } : null,
+    hasActiveBrowserPageDownload: (browserPageId: string) =>
+      state.downloadingPageIds.has(browserPageId)
   } as unknown as BrowserManager
 
   const bridge = {
@@ -173,7 +178,8 @@ function createHarness(
     get pagesChanged(): (string | undefined)[] {
       return state.pagesChanged
     },
-    certificateFailurePageIds: state.certificateFailurePageIds
+    certificateFailurePageIds: state.certificateFailurePageIds,
+    downloadingPageIds: state.downloadingPageIds
   }
 }
 
@@ -415,6 +421,20 @@ describe('OffscreenBrowserBackend reclamation', () => {
     await h.backend.closeTab('a')
 
     expect(h.pagesChanged).toEqual(['wt-1'])
+  })
+
+  it('does not park a page that is still writing a download', async () => {
+    // Why: releasing a renderer unregisters its guest, and browser-manager
+    // cancels that page's in-flight downloads on unregister. The desktop guest
+    // budget vetoes eviction for the same reason.
+    const h = createHarness({ downloadingPageIds: ['a'] })
+    await h.backend.createTab({ url: 'https://a', browserPageId: 'a' })
+    h.clock.value += 120_000
+
+    expect(await h.backend.reclaimIdlePages()).toEqual([])
+
+    h.downloadingPageIds.delete('a')
+    expect(await h.backend.reclaimIdlePages()).toEqual(['a'])
   })
 
   it('does not park a page waiting on a certificate decision', async () => {

--- a/src/main/browser/offscreen-browser-backend-reclaim.test.ts
+++ b/src/main/browser/offscreen-browser-backend-reclaim.test.ts
@@ -96,7 +96,6 @@ type Harness = {
   pagesChanged: (string | undefined)[]
   certificateFailurePageIds: Set<string>
   downloadingPageIds: Set<string>
-  downloadProgressAt: number
 }
 
 function createHarness(
@@ -112,7 +111,6 @@ function createHarness(
     activePageId: overrides.activePageId,
     certificateFailurePageIds: new Set<string>(overrides.certificateFailurePageIds ?? []),
     downloadingPageIds: new Set<string>(overrides.downloadingPageIds ?? []),
-    downloadProgressAt: 1_000_000,
     pagesChanged: [] as (string | undefined)[]
   }
   const order: string[] = []
@@ -145,8 +143,8 @@ function createHarness(
     getBrowserPageLoadError: () => overrides.loadError ?? null,
     getBrowserPageCertificateFailure: (browserPageId: string) =>
       state.certificateFailurePageIds.has(browserPageId) ? { challengeId: 'c' } : null,
-    getBrowserPageActiveDownloadProgressAt: (browserPageId: string) =>
-      state.downloadingPageIds.has(browserPageId) ? state.downloadProgressAt : null
+    hasActiveBrowserPageDownload: (browserPageId: string) =>
+      state.downloadingPageIds.has(browserPageId)
   } as unknown as BrowserManager
 
   const bridge = {
@@ -181,10 +179,7 @@ function createHarness(
       return state.pagesChanged
     },
     certificateFailurePageIds: state.certificateFailurePageIds,
-    downloadingPageIds: state.downloadingPageIds,
-    set downloadProgressAt(value: number) {
-      state.downloadProgressAt = value
-    }
+    downloadingPageIds: state.downloadingPageIds
   }
 }
 
@@ -195,7 +190,6 @@ beforeEach(() => {
   process.env.ORCA_HEADLESS_BROWSER_PARK_IDLE_MS = '60000'
   process.env.ORCA_HEADLESS_BROWSER_PARK_GRACE_MS = '5000'
   process.env.ORCA_HEADLESS_BROWSER_PARK_SWEEP_MS = '100000'
-  process.env.ORCA_HEADLESS_BROWSER_MAX_RETAINED_PAGES = '100'
 })
 
 describe('OffscreenBrowserBackend reclamation', () => {
@@ -330,43 +324,6 @@ describe('OffscreenBrowserBackend reclamation', () => {
     expect(h.backend.listParkedPages().map((page) => page.browserPageId)).toEqual(['a'])
   })
 
-  it('does not close a parked page that was woken while an earlier close was in flight', async () => {
-    let releaseFirstTeardown = (): void => {}
-    process.env.ORCA_HEADLESS_BROWSER_MAX_RETAINED_PAGES = '2'
-    // Why: pinning the two newer pages keeps the park loop empty, so the sweep
-    // that blocks is the retention close — the path under test.
-    const h = createHarness({ pinned: new Set(['c', 'd']) })
-    const bridge = h.bridge as unknown as { onTabClosed: ReturnType<typeof vi.fn> }
-
-    for (const id of ['a', 'b']) {
-      await h.backend.createTab({ url: `https://${id}`, browserPageId: id })
-      h.clock.value += 1_000
-    }
-    h.clock.value += 120_000
-    await h.backend.reclaimIdlePages()
-    expect(h.backend.listParkedPages().map((page) => page.browserPageId)).toEqual(['a', 'b'])
-
-    // Two more push the retention budget over, dooming the two oldest parked.
-    for (const id of ['c', 'd']) {
-      await h.backend.createTab({ url: `https://${id}`, browserPageId: id })
-      h.clock.value += 1_000
-    }
-    h.clock.value += 120_000
-    bridge.onTabClosed.mockImplementationOnce(
-      async () => new Promise<void>((resolve) => (releaseFirstTeardown = resolve))
-    )
-
-    const sweep = h.backend.reclaimIdlePages()
-    await Promise.resolve()
-    await h.backend.wakeTab('b')
-    releaseFirstTeardown()
-    await sweep
-
-    // a was closed; b survived the stale close list and is resident again.
-    expect(await h.backend.wakeTab('a')).toBe(false)
-    expect(await h.backend.wakeTab('b')).toBe(true)
-  })
-
   it('does not park a page whose wake is still rebuilding it', async () => {
     // Why: a wake is resident but not yet loading while it awaits the process
     // swap, so without an explicit pin the sweep can destroy it mid-rebuild.
@@ -428,30 +385,17 @@ describe('OffscreenBrowserBackend reclamation', () => {
     expect(h.pagesChanged).toEqual(['wt-1'])
   })
 
-  it('does not park a page whose download is still advancing', async () => {
+  it('does not park a page that is still writing a download', async () => {
     // Why: releasing a renderer unregisters its guest, and browser-manager
     // cancels that page's in-flight downloads on unregister. The desktop guest
     // budget vetoes eviction for the same reason.
     const h = createHarness({ downloadingPageIds: ['a'] })
     await h.backend.createTab({ url: 'https://a', browserPageId: 'a' })
     h.clock.value += 120_000
-    h.downloadProgressAt = h.clock.value
 
     expect(await h.backend.reclaimIdlePages()).toEqual([])
 
     h.downloadingPageIds.delete('a')
-    expect(await h.backend.reclaimIdlePages()).toEqual(['a'])
-  })
-
-  it('parks a page whose download has stalled so the cap cannot be defeated', async () => {
-    // Why: a download that never progresses again would otherwise pin its
-    // renderer forever, and one stalled download per page would defeat the
-    // resident cap outright — the same shape as the load-pin bug before it.
-    const h = createHarness({ downloadingPageIds: ['a'] })
-    await h.backend.createTab({ url: 'https://a', browserPageId: 'a' })
-    h.downloadProgressAt = h.clock.value
-    h.clock.value += 120_000
-
     expect(await h.backend.reclaimIdlePages()).toEqual(['a'])
   })
 
@@ -822,21 +766,6 @@ describe('OffscreenBrowserBackend reclamation', () => {
     expect(h.order).toEqual([`session-destroy:${webContentsId}`, 'unregister:a'])
     expect(h.backend.listParkedPages()).toEqual([])
     expect(await h.backend.wakeTab('a')).toBe(false)
-  })
-
-  it('closes the oldest parked pages once too many records are retained', async () => {
-    // Why: parking bounds renderer processes, not the page records behind them.
-    process.env.ORCA_HEADLESS_BROWSER_MAX_RETAINED_PAGES = '2'
-    const h = createHarness()
-    for (const id of ['a', 'b', 'c', 'd']) {
-      await h.backend.createTab({ url: `https://example.test/${id}`, browserPageId: id })
-      h.clock.value += 1_000
-    }
-    h.clock.value += 120_000
-    await h.backend.reclaimIdlePages()
-
-    expect(h.backend.listParkedPages().map((page) => page.browserPageId)).toEqual(['c', 'd'])
-    expect(h.windows.every((win) => win.isDestroyed())).toBe(true)
   })
 
   it('scopes parked listings and implicit targeting to a worktree', async () => {

--- a/src/main/browser/offscreen-browser-backend-reclaim.test.ts
+++ b/src/main/browser/offscreen-browser-backend-reclaim.test.ts
@@ -489,6 +489,24 @@ describe('OffscreenBrowserBackend reclamation', () => {
     expect(createTimeout).toBeUndefined()
   })
 
+  it('stops sweeping once nothing is resident, and resumes on wake', async () => {
+    // Why: an idle headless host should not keep waking every interval to find
+    // nothing to reclaim. Waking has to bring the sweep back or the woken page
+    // would never be reclaimed again.
+    const h = createHarness()
+    await h.backend.createTab({ url: 'https://a', browserPageId: 'a' })
+    const reclaimer = (h.backend as unknown as { reclaimer: { isScheduled: boolean } }).reclaimer
+    expect(reclaimer.isScheduled).toBe(true)
+
+    h.clock.value += 120_000
+    await h.backend.reclaimIdlePages()
+    expect(h.backend.listParkedPages()).toHaveLength(1)
+    expect(reclaimer.isScheduled).toBe(false)
+
+    await h.backend.wakeTab('a')
+    expect(reclaimer.isScheduled).toBe(true)
+  })
+
   it('coalesces concurrent wakes into one renderer', async () => {
     const h = createHarness()
     await h.backend.createTab({ url: 'https://example.test/a' })

--- a/src/main/browser/offscreen-browser-backend-reclaim.test.ts
+++ b/src/main/browser/offscreen-browser-backend-reclaim.test.ts
@@ -786,6 +786,12 @@ describe('OffscreenBrowserBackend reclamation', () => {
     expect(h.windows[0].isDestroyed()).toBe(true)
     expect(h.windows[1].isDestroyed()).toBe(false)
     expect(h.registered.get('a')).toBe(h.windows[1].webContents.id)
+    // Why: the park resumes after the wake re-materialized the window. It must
+    // not null the fresh window off the record — that leaks the renderer (no
+    // reference left for close/destroyAll), lists the page as parked and live
+    // at once, and reports the wake successful against a blank page.
+    expect(h.backend.listParkedPages()).toEqual([])
+    expect(loadOffscreenBrowserUrl.mock.calls.some(([win]) => win === h.windows[1])).toBe(true)
   })
 
   it('keeps a parked page after its renderer emits destroyed', async () => {

--- a/src/main/browser/offscreen-browser-backend-reclaim.test.ts
+++ b/src/main/browser/offscreen-browser-backend-reclaim.test.ts
@@ -730,6 +730,51 @@ describe('OffscreenBrowserBackend reclamation', () => {
     expect(claimed.map((page) => page.browserPageId)).toEqual(['b'])
   })
 
+  it('lists open page ids in creation order across parks and wakes', async () => {
+    // Why: the merged tab listing sorts by this order; if it drifted with
+    // residency, a background park would renumber indices callers already read.
+    const h = createHarness()
+    await h.backend.createTab({ url: 'https://a', browserPageId: 'a', worktreeId: 'wt-1' })
+    h.clock.value += 1_000
+    await h.backend.createTab({ url: 'https://b', browserPageId: 'b', worktreeId: 'wt-1' })
+    h.clock.value += 120_000
+    await h.backend.reclaimIdlePages()
+    await h.backend.wakeTab('a')
+
+    expect(h.backend.listOpenPageIds('wt-1')).toEqual(['a', 'b'])
+    expect(h.backend.listOpenPageIds()).toEqual(['a', 'b'])
+  })
+
+  it('does not promote a parked page while a live tab holds active', async () => {
+    // Why: promotion exists for the no-live-active gap only; a live active tab
+    // already gives the listing its selection, and a parked page claiming it
+    // too would put two stars on the worktree.
+    const h = createHarness({ activePageId: 'live' })
+    await h.backend.createTab({
+      url: 'https://parked',
+      browserPageId: 'parked',
+      worktreeId: 'wt-1'
+    })
+    h.clock.value += 1_000
+    await h.backend.createTab({ url: 'https://live', browserPageId: 'live', worktreeId: 'wt-1' })
+    h.clock.value += 1_000
+    await h.backend.createTab({
+      url: 'https://doomed',
+      browserPageId: 'doomed',
+      worktreeId: 'wt-1'
+    })
+    h.clock.value += 120_000
+    await h.backend.wakeTab('live')
+    await h.backend.wakeTab('doomed')
+    await h.backend.reclaimIdlePages()
+
+    await h.backend.closeTab('doomed')
+
+    expect(
+      h.backend.listParkedPages('wt-1').map((page) => [page.browserPageId, page.active === true])
+    ).toEqual([['parked', false]])
+  })
+
   it('hands the active flag to a survivor when the parked holder closes', async () => {
     // Why: closing a parked page has no bridge teardown to promote a successor,
     // so without this the worktree's every remaining tab reports inactive and a

--- a/src/main/browser/offscreen-browser-backend-reclaim.test.ts
+++ b/src/main/browser/offscreen-browser-backend-reclaim.test.ts
@@ -499,6 +499,37 @@ describe('OffscreenBrowserBackend reclamation', () => {
     })
   })
 
+  it('makes a second wake wait for the first to finish rebuilding', async () => {
+    // Why: materialize sets the window before the session swap and the reload,
+    // so the page looks resident long before it is usable.
+    let releaseSwap = (): void => {}
+    const h = createHarness()
+    await h.backend.createTab({ url: 'https://a', browserPageId: 'a' })
+    h.clock.value += 120_000
+    await h.backend.reclaimIdlePages()
+
+    const bridge = h.bridge as unknown as { onProcessSwap: ReturnType<typeof vi.fn> }
+    bridge.onProcessSwap.mockImplementationOnce(
+      async () => new Promise<void>((resolve) => (releaseSwap = resolve))
+    )
+    const first = h.backend.wakeTab('a')
+    await Promise.resolve()
+    await Promise.resolve()
+
+    let secondSettled = false
+    const second = h.backend.wakeTab('a').then((value) => {
+      secondSettled = true
+      return value
+    })
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(secondSettled).toBe(false)
+
+    releaseSwap()
+    expect(await first).toBe(true)
+    expect(await second).toBe(true)
+  })
+
   it('reports false when waking a page it does not own', async () => {
     const h = createHarness()
     expect(await h.backend.wakeTab('nope')).toBe(false)

--- a/src/main/browser/offscreen-browser-backend-reclaim.test.ts
+++ b/src/main/browser/offscreen-browser-backend-reclaim.test.ts
@@ -25,8 +25,9 @@ type FakeWindow = BrowserWindow & {
   __destroyed: boolean
   __url: string
   __destroyedListeners: (() => void)[]
-  __navigationListeners: ((e: unknown, url: string) => void)[]
-  navigateTo: (url: string) => void
+  __navigationListeners: ((e: unknown, url: string, isMainFrame?: boolean) => void)[]
+  navigateTo: (url: string, isMainFrame?: boolean) => void
+  __loading: boolean
 }
 
 let nextWebContentsId = 100
@@ -38,12 +39,15 @@ function makeWindow(): FakeWindow {
     __destroyed: false,
     __url: 'about:blank',
     __destroyedListeners: [] as (() => void)[],
-    __navigationListeners: [] as ((e: unknown, url: string) => void)[],
+    __navigationListeners: [] as ((e: unknown, url: string, isMainFrame?: boolean) => void)[],
+    __loading: false,
     isDestroyed: () => win.__destroyed,
-    navigateTo: (url: string) => {
-      win.__url = url
+    navigateTo: (url: string, isMainFrame = true) => {
+      if (isMainFrame) {
+        win.__url = url
+      }
       for (const listener of win.__navigationListeners) {
-        listener(null, url)
+        listener(null, url, isMainFrame)
       }
     },
     destroy: () => {
@@ -56,14 +60,22 @@ function makeWindow(): FakeWindow {
       id,
       isDestroyed: () => win.__destroyed,
       getURL: () => win.__url,
+      isLoading: () => win.__loading,
       getTitle: () => `title-${id}`,
       once: (event: string, listener: () => void) => {
         if (event === 'destroyed') {
           win.__destroyedListeners.push(listener)
         }
       },
-      on: (event: string, listener: (e: unknown, url: string) => void) => {
-        if (event === 'did-navigate' || event === 'did-navigate-in-page') {
+      on: (event: string, listener: (e: unknown, url: string, isMainFrame?: boolean) => void) => {
+        if (event === 'did-navigate') {
+          win.__navigationListeners.push((e, url, isMainFrame) => {
+            if (isMainFrame !== false) {
+              listener(e, url)
+            }
+          })
+        }
+        if (event === 'did-navigate-in-page') {
           win.__navigationListeners.push(listener)
         }
       }
@@ -81,6 +93,8 @@ type Harness = {
   windows: FakeWindow[]
   clock: { value: number }
   activePageId: string | undefined
+  pagesChanged: (string | undefined)[]
+  certificateFailurePageIds: Set<string>
 }
 
 function createHarness(
@@ -88,9 +102,14 @@ function createHarness(
     pinned?: Set<string>
     activePageId?: string
     loadError?: { code: number; description: string; validatedUrl: string } | null
+    certificateFailurePageIds?: string[]
   } = {}
 ): Harness {
-  const state = { activePageId: overrides.activePageId }
+  const state = {
+    activePageId: overrides.activePageId,
+    certificateFailurePageIds: new Set<string>(overrides.certificateFailurePageIds ?? []),
+    pagesChanged: [] as (string | undefined)[]
+  }
   const order: string[] = []
   const registered = new Map<string, number>()
   const windows: FakeWindow[] = []
@@ -118,7 +137,9 @@ function createHarness(
       registered.delete(browserPageId)
     },
     getGuestWebContentsId: (browserPageId: string) => registered.get(browserPageId) ?? null,
-    getBrowserPageLoadError: () => overrides.loadError ?? null
+    getBrowserPageLoadError: () => overrides.loadError ?? null,
+    getBrowserPageCertificateFailure: (browserPageId: string) =>
+      state.certificateFailurePageIds.has(browserPageId) ? { challengeId: 'c' } : null
   } as unknown as BrowserManager
 
   const bridge = {
@@ -134,6 +155,7 @@ function createHarness(
   const backend = new OffscreenBrowserBackend(manager, {
     getAgentBrowserBridge: () => bridge,
     isPagePinned: (id) => overrides.pinned?.has(id) === true,
+    onPagesChanged: (worktreeId) => state.pagesChanged.push(worktreeId),
     now: () => clock.value
   })
 
@@ -147,7 +169,11 @@ function createHarness(
     clock,
     set activePageId(value: string | undefined) {
       state.activePageId = value
-    }
+    },
+    get pagesChanged(): (string | undefined)[] {
+      return state.pagesChanged
+    },
+    certificateFailurePageIds: state.certificateFailurePageIds
   }
 }
 
@@ -351,6 +377,81 @@ describe('OffscreenBrowserBackend reclamation', () => {
 
     releaseSwap()
     expect(await wake).toBe(true)
+  })
+
+  it('does not let a slow close unregister a page that reused its id', async () => {
+    // Why: closing drops the record before teardown finishes, so a caller
+    // reusing the id could register a renderer the old close then unregisters,
+    // leaving the new page unreachable by every command.
+    let releaseTeardown = (): void => {}
+    const h = createHarness()
+    await h.backend.createTab({ url: 'https://a', browserPageId: 'a' })
+    const bridge = h.bridge as unknown as { onTabClosed: ReturnType<typeof vi.fn> }
+    bridge.onTabClosed.mockImplementationOnce(
+      async () => new Promise<void>((resolve) => (releaseTeardown = resolve))
+    )
+
+    const close = h.backend.closeTab('a')
+    await Promise.resolve()
+    const recreate = h.backend.createTab({ url: 'https://a2', browserPageId: 'a' })
+    releaseTeardown()
+    await close
+    await recreate
+
+    expect(h.registered.get('a')).toBe(h.windows[1].webContents.id)
+    expect(h.windows[0].isDestroyed()).toBe(true)
+    expect(h.windows[1].isDestroyed()).toBe(false)
+  })
+
+  it('tells the session snapshot when a parked page is closed', async () => {
+    // Why: a parked close has no WebContents teardown to piggyback on, so
+    // nothing else would tell paired clients the tab is gone.
+    const h = createHarness()
+    await h.backend.createTab({ url: 'https://a', browserPageId: 'a', worktreeId: 'wt-1' })
+    h.clock.value += 120_000
+    await h.backend.reclaimIdlePages()
+    h.pagesChanged.length = 0
+
+    await h.backend.closeTab('a')
+
+    expect(h.pagesChanged).toEqual(['wt-1'])
+  })
+
+  it('does not park a page waiting on a certificate decision', async () => {
+    // Why: the challenge id dies with the renderer, so parking would discard
+    // both the warning and the ability to approve it.
+    const h = createHarness({ certificateFailurePageIds: ['a'] })
+    await h.backend.createTab({ url: 'https://a', browserPageId: 'a' })
+    h.clock.value += 120_000
+
+    expect(await h.backend.reclaimIdlePages()).toEqual([])
+
+    h.certificateFailurePageIds.delete('a')
+    expect(await h.backend.reclaimIdlePages()).toEqual(['a'])
+  })
+
+  it('does not park a renderer whose navigation is still running after the load timeout', async () => {
+    // Why: the load helper resolves on its own timeout, so `loading` stops
+    // covering a navigation that is merely slow rather than finished.
+    const h = createHarness()
+    await h.backend.createTab({ url: 'https://a', browserPageId: 'a' })
+    h.windows[0].__loading = true
+    h.clock.value += 120_000
+
+    expect(await h.backend.reclaimIdlePages()).toEqual([])
+
+    h.windows[0].__loading = false
+    expect(await h.backend.reclaimIdlePages()).toEqual(['a'])
+  })
+
+  it('ignores a subframe in-page navigation when recording the address', async () => {
+    const h = createHarness()
+    await h.backend.createTab({ url: 'https://host.test/', browserPageId: 'a' })
+    h.windows[0].navigateTo('https://frame.test/#x', false)
+    h.clock.value += 120_000
+    await h.backend.reclaimIdlePages()
+
+    expect(h.backend.listParkedPages()[0]?.url).toBe('https://host.test/')
   })
 
   it('coalesces concurrent wakes into one renderer', async () => {

--- a/src/main/browser/offscreen-browser-backend-reclaim.test.ts
+++ b/src/main/browser/offscreen-browser-backend-reclaim.test.ts
@@ -455,31 +455,6 @@ describe('OffscreenBrowserBackend reclamation', () => {
     expect(await h.backend.reclaimIdlePages()).toEqual(['a'])
   })
 
-  it('gives up a park when the page starts a download during teardown', async () => {
-    // Why: teardown awaits the helper session while the page keeps running, and
-    // the unregister that follows would cancel a download begun in that window.
-    let releaseTeardown = (): void => {}
-    const h = createHarness()
-    await h.backend.createTab({ url: 'https://a', browserPageId: 'a' })
-    const bridge = h.bridge as unknown as { onTabClosed: ReturnType<typeof vi.fn> }
-    bridge.onTabClosed.mockImplementationOnce(async () => {
-      await new Promise<void>((resolve) => (releaseTeardown = resolve))
-      // The page began downloading while its helper session was torn down.
-      h.downloadingPageIds.add('a')
-      h.downloadProgressAt = h.clock.value
-    })
-
-    h.clock.value += 120_000
-    const sweep = h.backend.reclaimIdlePages()
-    releaseTeardown()
-    await sweep
-
-    // The page kept its renderer and its registration rather than losing the write.
-    expect(h.backend.listParkedPages()).toEqual([])
-    expect(h.windows[0].isDestroyed()).toBe(false)
-    expect(h.registered.get('a')).toBe(h.windows[0].webContents.id)
-  })
-
   it('does not park a page waiting on a certificate decision', async () => {
     // Why: the challenge id dies with the renderer, so parking would discard
     // both the warning and the ability to approve it.

--- a/src/main/browser/offscreen-browser-backend-reclaim.test.ts
+++ b/src/main/browser/offscreen-browser-backend-reclaim.test.ts
@@ -25,6 +25,8 @@ type FakeWindow = BrowserWindow & {
   __destroyed: boolean
   __url: string
   __destroyedListeners: (() => void)[]
+  __navigationListeners: ((e: unknown, url: string) => void)[]
+  navigateTo: (url: string) => void
 }
 
 let nextWebContentsId = 100
@@ -36,7 +38,14 @@ function makeWindow(): FakeWindow {
     __destroyed: false,
     __url: 'about:blank',
     __destroyedListeners: [] as (() => void)[],
+    __navigationListeners: [] as ((e: unknown, url: string) => void)[],
     isDestroyed: () => win.__destroyed,
+    navigateTo: (url: string) => {
+      win.__url = url
+      for (const listener of win.__navigationListeners) {
+        listener(null, url)
+      }
+    },
     destroy: () => {
       win.__destroyed = true
       for (const listener of win.__destroyedListeners) {
@@ -52,6 +61,11 @@ function makeWindow(): FakeWindow {
         if (event === 'destroyed') {
           win.__destroyedListeners.push(listener)
         }
+      },
+      on: (event: string, listener: (e: unknown, url: string) => void) => {
+        if (event === 'did-navigate' || event === 'did-navigate-in-page') {
+          win.__navigationListeners.push(listener)
+        }
       }
     }
   } as unknown as FakeWindow
@@ -66,9 +80,17 @@ type Harness = {
   registered: Map<string, number>
   windows: FakeWindow[]
   clock: { value: number }
+  activePageId: string | undefined
 }
 
-function createHarness(overrides: { pinned?: Set<string>; activePageId?: string } = {}): Harness {
+function createHarness(
+  overrides: {
+    pinned?: Set<string>
+    activePageId?: string
+    loadError?: { code: number; description: string; validatedUrl: string } | null
+  } = {}
+): Harness {
+  const state = { activePageId: overrides.activePageId }
   const order: string[] = []
   const registered = new Map<string, number>()
   const windows: FakeWindow[] = []
@@ -95,7 +117,8 @@ function createHarness(overrides: { pinned?: Set<string>; activePageId?: string 
       order.push(`unregister:${browserPageId}`)
       registered.delete(browserPageId)
     },
-    getGuestWebContentsId: (browserPageId: string) => registered.get(browserPageId) ?? null
+    getGuestWebContentsId: (browserPageId: string) => registered.get(browserPageId) ?? null,
+    getBrowserPageLoadError: () => overrides.loadError ?? null
   } as unknown as BrowserManager
 
   const bridge = {
@@ -105,7 +128,7 @@ function createHarness(overrides: { pinned?: Set<string>; activePageId?: string 
     onProcessSwap: vi.fn(async (browserPageId: string, webContentsId: number) => {
       order.push(`process-swap:${browserPageId}:${webContentsId}`)
     }),
-    isActiveBrowserPage: (browserPageId: string) => overrides.activePageId === browserPageId
+    isActiveBrowserPage: (browserPageId: string) => state.activePageId === browserPageId
   } as unknown as AgentBrowserBridge
 
   const backend = new OffscreenBrowserBackend(manager, {
@@ -114,7 +137,18 @@ function createHarness(overrides: { pinned?: Set<string>; activePageId?: string 
     now: () => clock.value
   })
 
-  return { backend, manager, bridge, order, registered, windows, clock }
+  return {
+    backend,
+    manager,
+    bridge,
+    order,
+    registered,
+    windows,
+    clock,
+    set activePageId(value: string | undefined) {
+      state.activePageId = value
+    }
+  }
 }
 
 beforeEach(() => {
@@ -145,7 +179,8 @@ describe('OffscreenBrowserBackend reclamation', () => {
         profileId: 'default',
         url: 'https://example.test/a',
         title: `title-${h.windows[0].webContents.id}`,
-        active: false
+        active: false,
+        loadError: null
       }
     ])
   })
@@ -186,7 +221,7 @@ describe('OffscreenBrowserBackend reclamation', () => {
     const h = createHarness()
     await h.backend.createTab({ url: 'https://example.test/a' })
     const [pageId] = [...h.registered.keys()]
-    h.windows[0].__url = 'https://example.test/moved'
+    h.windows[0].navigateTo('https://example.test/moved')
 
     h.clock.value += 120_000
     await h.backend.reclaimIdlePages()
@@ -204,11 +239,10 @@ describe('OffscreenBrowserBackend reclamation', () => {
   })
 
   it('keeps the requested address when a page parks before committing one', async () => {
-    // Why: an uncommitted window still reports about:blank, and adopting that
-    // would send the wake to a blank page instead of the agent's URL.
+    // Why: a page whose load never committed must still wake to the address the
+    // agent asked for, not to the blank page the window started on.
     const h = createHarness()
     await h.backend.createTab({ url: 'https://example.test/slow', browserPageId: 'a' })
-    h.windows[0].__url = 'about:blank'
     h.clock.value += 120_000
     await h.backend.reclaimIdlePages()
 
@@ -298,6 +332,72 @@ describe('OffscreenBrowserBackend reclamation', () => {
     expect(h.backend.listParkedPages().map((page) => page.browserPageId)).toEqual(['b'])
   })
 
+  it('keeps an intentional navigation to about:blank across a park', async () => {
+    // Why: an in-page `location.href = "about:blank"` is a real destination.
+    // Sniffing the address at park time could not tell it apart from the blank
+    // page a window starts on, so the record follows navigation instead.
+    const h = createHarness()
+    await h.backend.createTab({ url: 'https://example.test/a', browserPageId: 'a' })
+    h.windows[0].navigateTo('about:blank')
+    h.clock.value += 120_000
+    await h.backend.reclaimIdlePages()
+
+    expect(h.backend.listParkedPages()[0]?.url).toBe('about:blank')
+  })
+
+  it('ignores a chrome-error address so a wake retries the real one', async () => {
+    const h = createHarness()
+    await h.backend.createTab({ url: 'https://example.test/a', browserPageId: 'a' })
+    h.windows[0].navigateTo('chrome-error://chromewebdata/')
+    h.clock.value += 120_000
+    await h.backend.reclaimIdlePages()
+
+    expect(h.backend.listParkedPages()[0]?.url).toBe('https://example.test/a')
+  })
+
+  it('carries a load failure onto the parked record', async () => {
+    // Why: reclaiming a renderer does not make a page that failed to load
+    // healthy, and the failure is unreadable once the guest is unregistered.
+    const loadError = { code: -105, description: 'NAME_NOT_RESOLVED', validatedUrl: 'https://nope' }
+    const h = createHarness({ loadError })
+    await h.backend.createTab({ url: 'https://nope', browserPageId: 'a' })
+    h.clock.value += 120_000
+    await h.backend.reclaimIdlePages()
+
+    expect(h.backend.listParkedPages()[0]?.loadError).toEqual(loadError)
+  })
+
+  it('lets only the newest claim hold the parked active flag', async () => {
+    // Why: parking the active page promotes another live tab to active, which
+    // then parks claiming the flag too. `active` is a single selection.
+    const h = createHarness({ activePageId: 'a' })
+    await h.backend.createTab({ url: 'https://a', browserPageId: 'a', worktreeId: 'wt-1' })
+    await h.backend.createTab({ url: 'https://b', browserPageId: 'b', worktreeId: 'wt-1' })
+    h.clock.value += 120_000
+    await h.backend.reclaimIdlePages()
+    // Simulate the promotion: b is now the active page and parks claiming it.
+    h.activePageId = 'b'
+    await h.backend.wakeTab('b')
+    h.clock.value += 120_000
+    await h.backend.reclaimIdlePages()
+
+    const claimed = h.backend.listParkedPages().filter((page) => page.active)
+    expect(claimed.map((page) => page.browserPageId)).toEqual(['b'])
+  })
+
+  it('targets the page that was active, not merely the most recently used', async () => {
+    // Why: an explicit `--page b` command makes b the most recently used while
+    // a is still the active tab, and a page-less command means "the active tab".
+    const h = createHarness({ activePageId: 'a' })
+    await h.backend.createTab({ url: 'https://a', browserPageId: 'a', worktreeId: 'wt-1' })
+    h.clock.value += 1_000
+    await h.backend.createTab({ url: 'https://b', browserPageId: 'b', worktreeId: 'wt-1' })
+    h.clock.value += 120_000
+    await h.backend.reclaimIdlePages()
+
+    expect(h.backend.getParkedPageIdForImplicitTarget('wt-1')).toBe('a')
+  })
+
   it('reports the most recently used parked page for implicit targeting', async () => {
     const h = createHarness()
     for (const id of ['a', 'b', 'c', 'd']) {
@@ -307,7 +407,7 @@ describe('OffscreenBrowserBackend reclamation', () => {
     h.clock.value += 10_000
     await h.backend.reclaimIdlePages()
 
-    expect(h.backend.getMostRecentlyUsedParkedPageId()).toBe('b')
+    expect(h.backend.getParkedPageIdForImplicitTarget()).toBe('b')
   })
 
   it('restarts the reclaim clock when a resident page is used', async () => {
@@ -395,7 +495,7 @@ describe('OffscreenBrowserBackend reclamation', () => {
     await h.backend.reclaimIdlePages()
 
     expect(h.backend.listParkedPages('wt-1').map((page) => page.browserPageId)).toEqual(['a'])
-    expect(h.backend.getMostRecentlyUsedParkedPageId('wt-2')).toBe('b')
+    expect(h.backend.getParkedPageIdForImplicitTarget('wt-2')).toBe('b')
   })
 
   it('destroys every page it owns on shutdown', async () => {

--- a/src/main/browser/offscreen-browser-backend-reclaim.test.ts
+++ b/src/main/browser/offscreen-browser-backend-reclaim.test.ts
@@ -3,12 +3,18 @@ import type { BrowserWindow } from 'electron'
 import type { AgentBrowserBridge } from './agent-browser-bridge'
 import type { BrowserManager } from './browser-manager'
 
+const OFFSCREEN_BROWSER_WAKE_LOAD_BUDGET_MS = 10_000
+
 const createOffscreenBrowserWindow = vi.fn<(partition: string) => unknown>()
-const loadOffscreenBrowserUrl = vi.fn<(win: unknown, url: string) => Promise<void>>(async () => {})
+const loadOffscreenBrowserUrl = vi.fn<
+  (win: unknown, url: string, timeoutMs?: number) => Promise<void>
+>(async () => {})
 
 vi.mock('./offscreen-browser-window', () => ({
   createOffscreenBrowserWindow: (partition: string) => createOffscreenBrowserWindow(partition),
-  loadOffscreenBrowserUrl: (win: unknown, url: string) => loadOffscreenBrowserUrl(win, url)
+  loadOffscreenBrowserUrl: (win: unknown, url: string, timeoutMs?: number) =>
+    loadOffscreenBrowserUrl(win, url, timeoutMs),
+  OFFSCREEN_BROWSER_WAKE_LOAD_BUDGET_MS: 10_000
 }))
 
 vi.mock('./browser-session-registry', () => ({
@@ -265,7 +271,11 @@ describe('OffscreenBrowserBackend reclamation', () => {
     expect(h.windows).toHaveLength(2)
     expect(h.registered.get(pageId)).toBe(wokenId)
     expect(h.order).toEqual([`register:${pageId}:${wokenId}`, `process-swap:${pageId}:${wokenId}`])
-    expect(loadOffscreenBrowserUrl).toHaveBeenCalledWith(h.windows[1], 'https://example.test/moved')
+    expect(loadOffscreenBrowserUrl).toHaveBeenCalledWith(
+      h.windows[1],
+      'https://example.test/moved',
+      OFFSCREEN_BROWSER_WAKE_LOAD_BUDGET_MS
+    )
     expect(h.backend.listParkedPages()).toEqual([])
   })
 
@@ -456,6 +466,27 @@ describe('OffscreenBrowserBackend reclamation', () => {
     await h.backend.reclaimIdlePages()
 
     expect(h.backend.listParkedPages()[0]?.url).toBe('https://host.test/')
+  })
+
+  it('does not let a wake outlast the RPC budget a paired client gives it', async () => {
+    // Why: a wake happens inside browser.tabShow, which the paired client caps
+    // at 15s. Waiting out the full 30s load budget would report the browser
+    // unreachable on any page slower than that; the page is operable and still
+    // navigating when the wake returns, exactly as a freshly created tab is.
+    const h = createHarness()
+    await h.backend.createTab({ url: 'https://example.test/a', browserPageId: 'a' })
+    const createTimeout = loadOffscreenBrowserUrl.mock.calls.at(-1)?.[2]
+    h.clock.value += 120_000
+    await h.backend.reclaimIdlePages()
+    loadOffscreenBrowserUrl.mockClear()
+
+    await h.backend.wakeTab('a')
+
+    const wakeTimeout = loadOffscreenBrowserUrl.mock.calls.at(-1)?.[2]
+    expect(wakeTimeout).toBe(OFFSCREEN_BROWSER_WAKE_LOAD_BUDGET_MS)
+    expect(OFFSCREEN_BROWSER_WAKE_LOAD_BUDGET_MS).toBeLessThan(15_000)
+    // A fresh create keeps the longer budget; nothing is waiting on it.
+    expect(createTimeout).toBeUndefined()
   })
 
   it('coalesces concurrent wakes into one renderer', async () => {

--- a/src/main/browser/offscreen-browser-backend-reclaim.test.ts
+++ b/src/main/browser/offscreen-browser-backend-reclaim.test.ts
@@ -1,0 +1,337 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { BrowserWindow } from 'electron'
+import type { AgentBrowserBridge } from './agent-browser-bridge'
+import type { BrowserManager } from './browser-manager'
+
+const createOffscreenBrowserWindow = vi.fn<(partition: string) => unknown>()
+const loadOffscreenBrowserUrl = vi.fn<(win: unknown, url: string) => Promise<void>>(async () => {})
+
+vi.mock('./offscreen-browser-window', () => ({
+  createOffscreenBrowserWindow: (partition: string) => createOffscreenBrowserWindow(partition),
+  loadOffscreenBrowserUrl: (win: unknown, url: string) => loadOffscreenBrowserUrl(win, url)
+}))
+
+vi.mock('./browser-session-registry', () => ({
+  browserSessionRegistry: {
+    getProfile: (id: string) => ({ id, partition: `persist:${id}`, label: id }),
+    getDefaultProfile: () => ({ id: 'default', partition: 'persist:default', label: 'Default' })
+  }
+}))
+
+const { OffscreenBrowserBackend } = await import('./offscreen-browser-backend')
+
+type FakeWindow = BrowserWindow & {
+  __id: number
+  __destroyed: boolean
+  __url: string
+  __destroyedListeners: (() => void)[]
+}
+
+let nextWebContentsId = 100
+
+function makeWindow(): FakeWindow {
+  const id = nextWebContentsId++
+  const win = {
+    __id: id,
+    __destroyed: false,
+    __url: 'about:blank',
+    __destroyedListeners: [] as (() => void)[],
+    isDestroyed: () => win.__destroyed,
+    destroy: () => {
+      win.__destroyed = true
+      for (const listener of win.__destroyedListeners) {
+        listener()
+      }
+    },
+    webContents: {
+      id,
+      isDestroyed: () => win.__destroyed,
+      getURL: () => win.__url,
+      getTitle: () => `title-${id}`,
+      once: (event: string, listener: () => void) => {
+        if (event === 'destroyed') {
+          win.__destroyedListeners.push(listener)
+        }
+      }
+    }
+  } as unknown as FakeWindow
+  return win
+}
+
+type Harness = {
+  backend: InstanceType<typeof OffscreenBrowserBackend>
+  manager: BrowserManager
+  bridge: AgentBrowserBridge
+  order: string[]
+  registered: Map<string, number>
+  windows: FakeWindow[]
+  clock: { value: number }
+}
+
+function createHarness(overrides: { pinned?: Set<string> } = {}): Harness {
+  const order: string[] = []
+  const registered = new Map<string, number>()
+  const windows: FakeWindow[] = []
+  const clock = { value: 1_000_000 }
+
+  createOffscreenBrowserWindow.mockImplementation(() => {
+    const win = makeWindow()
+    windows.push(win)
+    return win
+  })
+
+  const manager = {
+    registerOffscreenGuest: ({
+      browserPageId,
+      webContentsId
+    }: {
+      browserPageId: string
+      webContentsId: number
+    }) => {
+      order.push(`register:${browserPageId}:${webContentsId}`)
+      registered.set(browserPageId, webContentsId)
+    },
+    unregisterGuest: (browserPageId: string) => {
+      order.push(`unregister:${browserPageId}`)
+      registered.delete(browserPageId)
+    },
+    getGuestWebContentsId: (browserPageId: string) => registered.get(browserPageId) ?? null
+  } as unknown as BrowserManager
+
+  const bridge = {
+    onTabClosed: vi.fn(async (webContentsId: number) => {
+      order.push(`session-destroy:${webContentsId}`)
+    }),
+    onProcessSwap: vi.fn(async (browserPageId: string, webContentsId: number) => {
+      order.push(`process-swap:${browserPageId}:${webContentsId}`)
+    })
+  } as unknown as AgentBrowserBridge
+
+  const backend = new OffscreenBrowserBackend(manager, {
+    getAgentBrowserBridge: () => bridge,
+    isPagePinned: (id) => overrides.pinned?.has(id) === true,
+    now: () => clock.value
+  })
+
+  return { backend, manager, bridge, order, registered, windows, clock }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  nextWebContentsId = 100
+  process.env.ORCA_HEADLESS_BROWSER_RESIDENT_LIMIT = '2'
+  process.env.ORCA_HEADLESS_BROWSER_PARK_IDLE_MS = '60000'
+  process.env.ORCA_HEADLESS_BROWSER_PARK_GRACE_MS = '5000'
+  process.env.ORCA_HEADLESS_BROWSER_PARK_SWEEP_MS = '100000'
+})
+
+describe('OffscreenBrowserBackend reclamation', () => {
+  it('parks an idle page: renderer destroyed, page kept and listed', async () => {
+    const h = createHarness()
+    await h.backend.createTab({ url: 'https://example.test/a' })
+    const [pageId] = [...h.registered.keys()]
+
+    h.clock.value += 120_000
+    expect(await h.backend.reclaimIdlePages()).toEqual([pageId])
+
+    expect(h.windows[0].isDestroyed()).toBe(true)
+    expect(h.registered.has(pageId)).toBe(false)
+    expect(h.backend.listParkedPages()).toEqual([
+      {
+        browserPageId: pageId,
+        worktreeId: undefined,
+        profileId: 'default',
+        url: 'about:blank',
+        title: `title-${h.windows[0].webContents.id}`
+      }
+    ])
+  })
+
+  it('tears the helper session down before the mapping and the renderer go away', async () => {
+    // Why (STA-4341): the headless close path used to skip the bridge entirely,
+    // so every closed page left its agent-browser session and CDP proxy behind.
+    const h = createHarness()
+    await h.backend.createTab({ url: 'https://example.test/a' })
+    const [pageId] = [...h.registered.keys()]
+    h.order.length = 0
+
+    await h.backend.closeTab(pageId)
+
+    expect(h.order).toEqual([
+      `session-destroy:${h.windows[0].webContents.id}`,
+      `unregister:${pageId}`
+    ])
+    expect(h.windows[0].isDestroyed()).toBe(true)
+  })
+
+  it('tears the helper session down when parking too', async () => {
+    const h = createHarness()
+    await h.backend.createTab({ url: 'https://example.test/a' })
+    const [pageId] = [...h.registered.keys()]
+    h.order.length = 0
+
+    h.clock.value += 120_000
+    await h.backend.reclaimIdlePages()
+
+    expect(h.order).toEqual([
+      `session-destroy:${h.windows[0].webContents.id}`,
+      `unregister:${pageId}`
+    ])
+  })
+
+  it('wakes a parked page under the same id and reloads where it left off', async () => {
+    const h = createHarness()
+    await h.backend.createTab({ url: 'https://example.test/a' })
+    const [pageId] = [...h.registered.keys()]
+    h.windows[0].__url = 'https://example.test/moved'
+
+    h.clock.value += 120_000
+    await h.backend.reclaimIdlePages()
+    h.order.length = 0
+    loadOffscreenBrowserUrl.mockClear()
+
+    expect(await h.backend.wakeTab(pageId)).toBe(true)
+
+    const wokenId = h.windows[1].webContents.id
+    expect(h.windows).toHaveLength(2)
+    expect(h.registered.get(pageId)).toBe(wokenId)
+    expect(h.order).toEqual([`register:${pageId}:${wokenId}`, `process-swap:${pageId}:${wokenId}`])
+    expect(loadOffscreenBrowserUrl).toHaveBeenCalledWith(h.windows[1], 'https://example.test/moved')
+    expect(h.backend.listParkedPages()).toEqual([])
+  })
+
+  it('coalesces concurrent wakes into one renderer', async () => {
+    const h = createHarness()
+    await h.backend.createTab({ url: 'https://example.test/a' })
+    const [pageId] = [...h.registered.keys()]
+    h.clock.value += 120_000
+    await h.backend.reclaimIdlePages()
+
+    const [first, second] = await Promise.all([
+      h.backend.wakeTab(pageId),
+      h.backend.wakeTab(pageId)
+    ])
+
+    expect([first, second]).toEqual([true, true])
+    expect(h.windows).toHaveLength(2)
+  })
+
+  it('reports false when waking a page it does not own', async () => {
+    const h = createHarness()
+    expect(await h.backend.wakeTab('nope')).toBe(false)
+  })
+
+  it('does not park a pinned page even when it is the oldest', async () => {
+    const h = createHarness({ pinned: new Set(['streamed']) })
+    await h.backend.createTab({ url: 'https://a', browserPageId: 'streamed' })
+    h.clock.value += 1_000
+    await h.backend.createTab({ url: 'https://b', browserPageId: 'idle' })
+    h.clock.value += 120_000
+
+    expect(await h.backend.reclaimIdlePages()).toEqual(['idle'])
+  })
+
+  it('keeps the resident cap by evicting least-recently-used pages', async () => {
+    const h = createHarness()
+    for (const id of ['a', 'b', 'c', 'd']) {
+      await h.backend.createTab({ url: `https://example.test/${id}`, browserPageId: id })
+      h.clock.value += 1_000
+    }
+    // Why: past the grace floor but well inside the idle window, so the cap is
+    // provably the evictor here.
+    h.clock.value += 10_000
+
+    expect(await h.backend.reclaimIdlePages()).toEqual(['a', 'b'])
+    expect(h.backend.listParkedPages().map((page) => page.browserPageId)).toEqual(['a', 'b'])
+  })
+
+  it('reports the most recently used parked page for implicit targeting', async () => {
+    const h = createHarness()
+    for (const id of ['a', 'b', 'c', 'd']) {
+      await h.backend.createTab({ url: `https://example.test/${id}`, browserPageId: id })
+      h.clock.value += 1_000
+    }
+    h.clock.value += 10_000
+    await h.backend.reclaimIdlePages()
+
+    expect(h.backend.getMostRecentlyUsedParkedPageId()).toBe('b')
+  })
+
+  it('restarts the reclaim clock when a resident page is used', async () => {
+    const h = createHarness()
+    await h.backend.createTab({ url: 'https://example.test/a', browserPageId: 'a' })
+    h.clock.value += 120_000
+
+    // Why: waking a resident page must not rebuild its renderer, only mark it used.
+    expect(await h.backend.wakeTab('a')).toBe(true)
+    expect(h.windows).toHaveLength(1)
+    expect(await h.backend.reclaimIdlePages()).toEqual([])
+  })
+
+  it('does not let a command land on a renderer that a park is tearing down', async () => {
+    let releaseSession = (): void => {}
+    const h = createHarness()
+    await h.backend.createTab({ url: 'https://example.test/a', browserPageId: 'a' })
+    const bridge = h.bridge as unknown as { onTabClosed: ReturnType<typeof vi.fn> }
+    bridge.onTabClosed.mockImplementation(
+      async () => new Promise<void>((resolve) => (releaseSession = resolve))
+    )
+
+    h.clock.value += 120_000
+    const park = h.backend.reclaimIdlePages()
+    const wake = h.backend.wakeTab('a')
+    releaseSession()
+    await park
+    expect(await wake).toBe(true)
+
+    // The woken renderer is a fresh one, not the window the park destroyed.
+    expect(h.windows).toHaveLength(2)
+    expect(h.windows[0].isDestroyed()).toBe(true)
+    expect(h.windows[1].isDestroyed()).toBe(false)
+    expect(h.registered.get('a')).toBe(h.windows[1].webContents.id)
+  })
+
+  it('keeps a parked page after its renderer emits destroyed', async () => {
+    // Why: parking destroys the window on purpose; the crash handler must not
+    // read that as the page going away or the record is lost.
+    const h = createHarness()
+    await h.backend.createTab({ url: 'https://example.test/a', browserPageId: 'a' })
+    h.clock.value += 120_000
+    await h.backend.reclaimIdlePages()
+
+    expect(h.backend.listParkedPages().map((page) => page.browserPageId)).toEqual(['a'])
+  })
+
+  it('drops a page whose renderer dies on its own', async () => {
+    const h = createHarness()
+    await h.backend.createTab({ url: 'https://example.test/a', browserPageId: 'a' })
+
+    h.windows[0].destroy()
+
+    expect(h.backend.listParkedPages()).toEqual([])
+    expect(await h.backend.wakeTab('a')).toBe(false)
+  })
+
+  it('scopes parked listings and implicit targeting to a worktree', async () => {
+    const h = createHarness()
+    await h.backend.createTab({ url: 'https://a', browserPageId: 'a', worktreeId: 'wt-1' })
+    h.clock.value += 1_000
+    await h.backend.createTab({ url: 'https://b', browserPageId: 'b', worktreeId: 'wt-2' })
+    h.clock.value += 120_000
+    await h.backend.reclaimIdlePages()
+
+    expect(h.backend.listParkedPages('wt-1').map((page) => page.browserPageId)).toEqual(['a'])
+    expect(h.backend.getMostRecentlyUsedParkedPageId('wt-2')).toBe('b')
+  })
+
+  it('destroys every page it owns on shutdown', async () => {
+    const h = createHarness()
+    await h.backend.createTab({ url: 'https://a', browserPageId: 'a' })
+    await h.backend.createTab({ url: 'https://b', browserPageId: 'b' })
+
+    h.backend.destroyAll()
+
+    expect(h.windows.every((win) => win.isDestroyed())).toBe(true)
+    expect(h.backend.listParkedPages()).toEqual([])
+  })
+})

--- a/src/main/browser/offscreen-browser-backend-reclaim.test.ts
+++ b/src/main/browser/offscreen-browser-backend-reclaim.test.ts
@@ -68,7 +68,7 @@ type Harness = {
   clock: { value: number }
 }
 
-function createHarness(overrides: { pinned?: Set<string> } = {}): Harness {
+function createHarness(overrides: { pinned?: Set<string>; activePageId?: string } = {}): Harness {
   const order: string[] = []
   const registered = new Map<string, number>()
   const windows: FakeWindow[] = []
@@ -104,7 +104,8 @@ function createHarness(overrides: { pinned?: Set<string> } = {}): Harness {
     }),
     onProcessSwap: vi.fn(async (browserPageId: string, webContentsId: number) => {
       order.push(`process-swap:${browserPageId}:${webContentsId}`)
-    })
+    }),
+    isActiveBrowserPage: (browserPageId: string) => overrides.activePageId === browserPageId
   } as unknown as AgentBrowserBridge
 
   const backend = new OffscreenBrowserBackend(manager, {
@@ -142,7 +143,8 @@ describe('OffscreenBrowserBackend reclamation', () => {
         worktreeId: undefined,
         profileId: 'default',
         url: 'about:blank',
-        title: `title-${h.windows[0].webContents.id}`
+        title: `title-${h.windows[0].webContents.id}`,
+        active: false
       }
     ])
   })
@@ -243,6 +245,26 @@ describe('OffscreenBrowserBackend reclamation', () => {
 
     expect(await h.backend.reclaimIdlePages()).toEqual(['a', 'b'])
     expect(h.backend.listParkedPages().map((page) => page.browserPageId)).toEqual(['a', 'b'])
+  })
+
+  it('remembers whether a page was active when it parked, and forgets on wake', async () => {
+    // Why: the paired client's tab bar reads the session snapshot; a park must
+    // not silently deselect the tab the user had open.
+    const h = createHarness({ activePageId: 'a' })
+    await h.backend.createTab({ url: 'https://a', browserPageId: 'a' })
+    await h.backend.createTab({ url: 'https://b', browserPageId: 'b' })
+    h.clock.value += 120_000
+    await h.backend.reclaimIdlePages()
+
+    expect(
+      h.backend.listParkedPages().map((page) => [page.browserPageId, page.active === true])
+    ).toEqual([
+      ['a', true],
+      ['b', false]
+    ])
+
+    await h.backend.wakeTab('a')
+    expect(h.backend.listParkedPages().map((page) => page.browserPageId)).toEqual(['b'])
   })
 
   it('reports the most recently used parked page for implicit targeting', async () => {

--- a/src/main/browser/offscreen-browser-backend-reclaim.test.ts
+++ b/src/main/browser/offscreen-browser-backend-reclaim.test.ts
@@ -817,6 +817,35 @@ describe('OffscreenBrowserBackend reclamation', () => {
         .map((page) => page.browserPageId)
         .sort()
     ).toEqual(['g', 'w'])
+    // Why: with one flag per scope, a scope-less implicit command must target
+    // the page that held the MOST RECENT active claim — not the oldest scope's
+    // page just because it comes first in creation order.
+    expect(h.backend.getParkedPageIdForImplicitTarget()).toBe('g')
+  })
+
+  it('promotes for a scope even while another worktree has a resident page', async () => {
+    // Why: the promotion gate is per scope. A live tab elsewhere on the host
+    // says nothing about this worktree's selection.
+    const h = createHarness({ activePageId: 'holder' })
+    await h.backend.createTab({ url: 'https://a', browserPageId: 'a', worktreeId: 'wt-1' })
+    h.clock.value += 1_000
+    await h.backend.createTab({
+      url: 'https://holder',
+      browserPageId: 'holder',
+      worktreeId: 'wt-1'
+    })
+    h.clock.value += 1_000
+    await h.backend.createTab({ url: 'https://other', browserPageId: 'other', worktreeId: 'wt-2' })
+    h.clock.value += 120_000
+    await h.backend.wakeTab('other')
+    await h.backend.reclaimIdlePages()
+    h.activePageId = undefined
+
+    await h.backend.closeTab('holder')
+
+    expect(
+      h.backend.listParkedPages('wt-1').map((page) => [page.browserPageId, page.active === true])
+    ).toEqual([['a', true]])
   })
 
   it('targets the page that was active, not merely the most recently used', async () => {

--- a/src/main/browser/offscreen-browser-backend-reclaim.test.ts
+++ b/src/main/browser/offscreen-browser-backend-reclaim.test.ts
@@ -96,6 +96,7 @@ type Harness = {
   pagesChanged: (string | undefined)[]
   certificateFailurePageIds: Set<string>
   downloadingPageIds: Set<string>
+  downloadProgressAt: number
 }
 
 function createHarness(
@@ -111,6 +112,7 @@ function createHarness(
     activePageId: overrides.activePageId,
     certificateFailurePageIds: new Set<string>(overrides.certificateFailurePageIds ?? []),
     downloadingPageIds: new Set<string>(overrides.downloadingPageIds ?? []),
+    downloadProgressAt: 1_000_000,
     pagesChanged: [] as (string | undefined)[]
   }
   const order: string[] = []
@@ -143,8 +145,8 @@ function createHarness(
     getBrowserPageLoadError: () => overrides.loadError ?? null,
     getBrowserPageCertificateFailure: (browserPageId: string) =>
       state.certificateFailurePageIds.has(browserPageId) ? { challengeId: 'c' } : null,
-    hasActiveBrowserPageDownload: (browserPageId: string) =>
-      state.downloadingPageIds.has(browserPageId)
+    getBrowserPageActiveDownloadProgressAt: (browserPageId: string) =>
+      state.downloadingPageIds.has(browserPageId) ? state.downloadProgressAt : null
   } as unknown as BrowserManager
 
   const bridge = {
@@ -179,7 +181,10 @@ function createHarness(
       return state.pagesChanged
     },
     certificateFailurePageIds: state.certificateFailurePageIds,
-    downloadingPageIds: state.downloadingPageIds
+    downloadingPageIds: state.downloadingPageIds,
+    set downloadProgressAt(value: number) {
+      state.downloadProgressAt = value
+    }
   }
 }
 
@@ -423,18 +428,56 @@ describe('OffscreenBrowserBackend reclamation', () => {
     expect(h.pagesChanged).toEqual(['wt-1'])
   })
 
-  it('does not park a page that is still writing a download', async () => {
+  it('does not park a page whose download is still advancing', async () => {
     // Why: releasing a renderer unregisters its guest, and browser-manager
     // cancels that page's in-flight downloads on unregister. The desktop guest
     // budget vetoes eviction for the same reason.
     const h = createHarness({ downloadingPageIds: ['a'] })
     await h.backend.createTab({ url: 'https://a', browserPageId: 'a' })
     h.clock.value += 120_000
+    h.downloadProgressAt = h.clock.value
 
     expect(await h.backend.reclaimIdlePages()).toEqual([])
 
     h.downloadingPageIds.delete('a')
     expect(await h.backend.reclaimIdlePages()).toEqual(['a'])
+  })
+
+  it('parks a page whose download has stalled so the cap cannot be defeated', async () => {
+    // Why: a download that never progresses again would otherwise pin its
+    // renderer forever, and one stalled download per page would defeat the
+    // resident cap outright — the same shape as the load-pin bug before it.
+    const h = createHarness({ downloadingPageIds: ['a'] })
+    await h.backend.createTab({ url: 'https://a', browserPageId: 'a' })
+    h.downloadProgressAt = h.clock.value
+    h.clock.value += 120_000
+
+    expect(await h.backend.reclaimIdlePages()).toEqual(['a'])
+  })
+
+  it('gives up a park when the page starts a download during teardown', async () => {
+    // Why: teardown awaits the helper session while the page keeps running, and
+    // the unregister that follows would cancel a download begun in that window.
+    let releaseTeardown = (): void => {}
+    const h = createHarness()
+    await h.backend.createTab({ url: 'https://a', browserPageId: 'a' })
+    const bridge = h.bridge as unknown as { onTabClosed: ReturnType<typeof vi.fn> }
+    bridge.onTabClosed.mockImplementationOnce(async () => {
+      await new Promise<void>((resolve) => (releaseTeardown = resolve))
+      // The page began downloading while its helper session was torn down.
+      h.downloadingPageIds.add('a')
+      h.downloadProgressAt = h.clock.value
+    })
+
+    h.clock.value += 120_000
+    const sweep = h.backend.reclaimIdlePages()
+    releaseTeardown()
+    await sweep
+
+    // The page kept its renderer and its registration rather than losing the write.
+    expect(h.backend.listParkedPages()).toEqual([])
+    expect(h.windows[0].isDestroyed()).toBe(false)
+    expect(h.registered.get('a')).toBe(h.windows[0].webContents.id)
   })
 
   it('does not park a page waiting on a certificate decision', async () => {

--- a/src/main/browser/offscreen-browser-backend-reclaim.test.ts
+++ b/src/main/browser/offscreen-browser-backend-reclaim.test.ts
@@ -195,7 +195,6 @@ beforeEach(() => {
   process.env.ORCA_HEADLESS_BROWSER_RESIDENT_LIMIT = '2'
   process.env.ORCA_HEADLESS_BROWSER_PARK_IDLE_MS = '60000'
   process.env.ORCA_HEADLESS_BROWSER_PARK_GRACE_MS = '5000'
-  process.env.ORCA_HEADLESS_BROWSER_PARK_SWEEP_MS = '100000'
 })
 
 describe('OffscreenBrowserBackend reclamation', () => {
@@ -489,10 +488,9 @@ describe('OffscreenBrowserBackend reclamation', () => {
     expect(createTimeout).toBeUndefined()
   })
 
-  it('stops sweeping once nothing is resident, and resumes on wake', async () => {
-    // Why: an idle headless host should not keep waking every interval to find
-    // nothing to reclaim. Waking has to bring the sweep back or the woken page
-    // would never be reclaimed again.
+  it('arms no timer once nothing is resident, and re-arms on wake', async () => {
+    // Why: an idle headless host should hold no reclaim timer at all. Waking has
+    // to re-arm it or the woken page would never be reclaimed again.
     const h = createHarness()
     await h.backend.createTab({ url: 'https://a', browserPageId: 'a' })
     const reclaimer = (h.backend as unknown as { reclaimer: { isScheduled: boolean } }).reclaimer

--- a/src/main/browser/offscreen-browser-backend-reclaim.test.ts
+++ b/src/main/browser/offscreen-browser-backend-reclaim.test.ts
@@ -430,18 +430,40 @@ describe('OffscreenBrowserBackend reclamation', () => {
     expect(await h.backend.reclaimIdlePages()).toEqual(['a'])
   })
 
-  it('does not park a renderer whose navigation is still running after the load timeout', async () => {
-    // Why: the load helper resolves on its own timeout, so `loading` stops
-    // covering a navigation that is merely slow rather than finished.
+  it('parks a page whose navigation never completes so the cap cannot be defeated', async () => {
+    // Why: a page can stay navigating forever (a server that accepts and never
+    // finishes). Pinning on that would let one stalled create per page hold a
+    // renderer indefinitely, which is the exact failure this reclaimer exists
+    // to prevent. Waking simply retries the address.
     const h = createHarness()
     await h.backend.createTab({ url: 'https://a', browserPageId: 'a' })
     h.windows[0].__loading = true
     h.clock.value += 120_000
 
-    expect(await h.backend.reclaimIdlePages()).toEqual([])
-
-    h.windows[0].__loading = false
     expect(await h.backend.reclaimIdlePages()).toEqual(['a'])
+    expect(h.backend.listParkedPages()[0]?.url).toBe('https://a')
+  })
+
+  it('abandons a wake whose page was closed and replaced underneath it', async () => {
+    // Why: reporting success then would hand the original command a different
+    // page under the name it asked for.
+    let releaseSwap = (): void => {}
+    const h = createHarness()
+    await h.backend.createTab({ url: 'https://a', browserPageId: 'a' })
+    h.clock.value += 120_000
+    await h.backend.reclaimIdlePages()
+
+    const bridge = h.bridge as unknown as { onProcessSwap: ReturnType<typeof vi.fn> }
+    bridge.onProcessSwap.mockImplementationOnce(
+      async () => new Promise<void>((resolve) => (releaseSwap = resolve))
+    )
+    const wake = h.backend.wakeTab('a')
+    await Promise.resolve()
+    await h.backend.closeTab('a')
+    await h.backend.createTab({ url: 'https://replacement', browserPageId: 'a' })
+    releaseSwap()
+
+    expect(await wake).toBe(false)
   })
 
   it('ignores a subframe in-page navigation when recording the address', async () => {

--- a/src/main/browser/offscreen-browser-backend-reclaim.test.ts
+++ b/src/main/browser/offscreen-browser-backend-reclaim.test.ts
@@ -160,7 +160,8 @@ function createHarness(
     onProcessSwap: vi.fn(async (browserPageId: string, webContentsId: number) => {
       order.push(`process-swap:${browserPageId}:${webContentsId}`)
     }),
-    isActiveBrowserPage: (browserPageId: string) => state.activePageId === browserPageId
+    isActiveBrowserPage: (browserPageId: string) => state.activePageId === browserPageId,
+    getActivePageId: () => state.activePageId
   } as unknown as AgentBrowserBridge
 
   const backend = new OffscreenBrowserBackend(manager, {
@@ -727,6 +728,50 @@ describe('OffscreenBrowserBackend reclamation', () => {
 
     const claimed = h.backend.listParkedPages().filter((page) => page.active)
     expect(claimed.map((page) => page.browserPageId)).toEqual(['b'])
+  })
+
+  it('hands the active flag to a survivor when the parked holder closes', async () => {
+    // Why: closing a parked page has no bridge teardown to promote a successor,
+    // so without this the worktree's every remaining tab reports inactive and a
+    // paired client loses its one-selected-tab assumption.
+    const h = createHarness({ activePageId: 'b' })
+    await h.backend.createTab({ url: 'https://a', browserPageId: 'a', worktreeId: 'wt-1' })
+    h.clock.value += 1_000
+    await h.backend.createTab({ url: 'https://b', browserPageId: 'b', worktreeId: 'wt-1' })
+    h.clock.value += 120_000
+    await h.backend.reclaimIdlePages()
+    h.activePageId = undefined
+
+    await h.backend.closeTab('b')
+
+    expect(
+      h.backend.listParkedPages('wt-1').map((page) => [page.browserPageId, page.active === true])
+    ).toEqual([['a', true]])
+  })
+
+  it('scopes the parked active claim to its worktree, undefined included', async () => {
+    // Why: a remote `tab create` without --worktree makes a worktree-less page;
+    // parking it while active must not wipe another worktree's parked flag.
+    const h = createHarness({ activePageId: 'w' })
+    await h.backend.createTab({ url: 'https://w', browserPageId: 'w', worktreeId: 'wt-1' })
+    await h.backend.createTab({ url: 'https://g', browserPageId: 'g' })
+    h.clock.value += 120_000
+    await h.backend.wakeTab('g')
+    await h.backend.reclaimIdlePages()
+    h.activePageId = 'g'
+    h.clock.value += 120_000
+    await h.backend.reclaimIdlePages()
+
+    expect(
+      h.backend.listParkedPages('wt-1').map((page) => [page.browserPageId, page.active === true])
+    ).toEqual([['w', true]])
+    expect(
+      h.backend
+        .listParkedPages()
+        .filter((page) => page.active)
+        .map((page) => page.browserPageId)
+        .sort()
+    ).toEqual(['g', 'w'])
   })
 
   it('targets the page that was active, not merely the most recently used', async () => {

--- a/src/main/browser/offscreen-browser-backend-reclaim.test.ts
+++ b/src/main/browser/offscreen-browser-backend-reclaim.test.ts
@@ -267,6 +267,92 @@ describe('OffscreenBrowserBackend reclamation', () => {
     expect(await h.backend.reclaimIdlePages()).toEqual(['a'])
   })
 
+  it('does not park a page that was used while an earlier park was in flight', async () => {
+    // Why: parking awaits helper-session teardown, so a page later in the
+    // selection can be woken and driven before its turn comes. The selection is
+    // a proposal, not a licence.
+    let releaseFirstTeardown = (): void => {}
+    const h = createHarness()
+    for (const id of ['a', 'b', 'c', 'd']) {
+      await h.backend.createTab({ url: `https://${id}`, browserPageId: id })
+      h.clock.value += 1_000
+    }
+    h.clock.value += 10_000
+    const bridge = h.bridge as unknown as { onTabClosed: ReturnType<typeof vi.fn> }
+    bridge.onTabClosed.mockImplementationOnce(
+      async () => new Promise<void>((resolve) => (releaseFirstTeardown = resolve))
+    )
+
+    const sweep = h.backend.reclaimIdlePages()
+    await Promise.resolve()
+    // b is next in line to park; a command lands on it while a is tearing down.
+    await h.backend.wakeTab('b')
+    releaseFirstTeardown()
+
+    expect(await sweep).toEqual(['a'])
+    expect(h.backend.listParkedPages().map((page) => page.browserPageId)).toEqual(['a'])
+  })
+
+  it('does not close a parked page that was woken while an earlier close was in flight', async () => {
+    let releaseFirstTeardown = (): void => {}
+    process.env.ORCA_HEADLESS_BROWSER_MAX_RETAINED_PAGES = '2'
+    // Why: pinning the two newer pages keeps the park loop empty, so the sweep
+    // that blocks is the retention close — the path under test.
+    const h = createHarness({ pinned: new Set(['c', 'd']) })
+    const bridge = h.bridge as unknown as { onTabClosed: ReturnType<typeof vi.fn> }
+
+    for (const id of ['a', 'b']) {
+      await h.backend.createTab({ url: `https://${id}`, browserPageId: id })
+      h.clock.value += 1_000
+    }
+    h.clock.value += 120_000
+    await h.backend.reclaimIdlePages()
+    expect(h.backend.listParkedPages().map((page) => page.browserPageId)).toEqual(['a', 'b'])
+
+    // Two more push the retention budget over, dooming the two oldest parked.
+    for (const id of ['c', 'd']) {
+      await h.backend.createTab({ url: `https://${id}`, browserPageId: id })
+      h.clock.value += 1_000
+    }
+    h.clock.value += 120_000
+    bridge.onTabClosed.mockImplementationOnce(
+      async () => new Promise<void>((resolve) => (releaseFirstTeardown = resolve))
+    )
+
+    const sweep = h.backend.reclaimIdlePages()
+    await Promise.resolve()
+    await h.backend.wakeTab('b')
+    releaseFirstTeardown()
+    await sweep
+
+    // a was closed; b survived the stale close list and is resident again.
+    expect(await h.backend.wakeTab('a')).toBe(false)
+    expect(await h.backend.wakeTab('b')).toBe(true)
+  })
+
+  it('does not park a page whose wake is still rebuilding it', async () => {
+    // Why: a wake is resident but not yet loading while it awaits the process
+    // swap, so without an explicit pin the sweep can destroy it mid-rebuild.
+    let releaseSwap = (): void => {}
+    const h = createHarness()
+    await h.backend.createTab({ url: 'https://a', browserPageId: 'a' })
+    h.clock.value += 120_000
+    await h.backend.reclaimIdlePages()
+
+    const bridge = h.bridge as unknown as { onProcessSwap: ReturnType<typeof vi.fn> }
+    bridge.onProcessSwap.mockImplementationOnce(
+      async () => new Promise<void>((resolve) => (releaseSwap = resolve))
+    )
+    const wake = h.backend.wakeTab('a')
+    await Promise.resolve()
+    h.clock.value += 120_000
+
+    expect(await h.backend.reclaimIdlePages()).toEqual([])
+
+    releaseSwap()
+    expect(await wake).toBe(true)
+  })
+
   it('coalesces concurrent wakes into one renderer', async () => {
     const h = createHarness()
     await h.backend.createTab({ url: 'https://example.test/a' })

--- a/src/main/browser/offscreen-browser-backend-reclaim.test.ts
+++ b/src/main/browser/offscreen-browser-backend-reclaim.test.ts
@@ -552,6 +552,52 @@ describe('OffscreenBrowserBackend reclamation', () => {
     expect(await second).toBe(true)
   })
 
+  it('does not let an abandoned wake clear a replacement page wake lock', async () => {
+    // Why: dropping the replacement's lock would let the next command see a
+    // live window with no wake in flight and drive a half-rebuilt renderer.
+    let releaseFirstSwap = (): void => {}
+    let releaseSecondSwap = (): void => {}
+    const h = createHarness()
+    await h.backend.createTab({ url: 'https://a', browserPageId: 'a' })
+    h.clock.value += 120_000
+    await h.backend.reclaimIdlePages()
+
+    const bridge = h.bridge as unknown as { onProcessSwap: ReturnType<typeof vi.fn> }
+    bridge.onProcessSwap.mockImplementationOnce(
+      async () => new Promise<void>((resolve) => (releaseFirstSwap = resolve))
+    )
+    const abandoned = h.backend.wakeTab('a')
+    await Promise.resolve()
+
+    await h.backend.closeTab('a')
+    await h.backend.createTab({ url: 'https://replacement', browserPageId: 'a' })
+    h.clock.value += 120_000
+    await h.backend.reclaimIdlePages()
+
+    bridge.onProcessSwap.mockImplementationOnce(
+      async () => new Promise<void>((resolve) => (releaseSecondSwap = resolve))
+    )
+    const replacementWake = h.backend.wakeTab('a')
+    await Promise.resolve()
+
+    // The old wake finishing must not release the replacement's lock.
+    releaseFirstSwap()
+    expect(await abandoned).toBe(false)
+
+    let thirdSettled = false
+    const third = h.backend.wakeTab('a').then((value) => {
+      thirdSettled = true
+      return value
+    })
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(thirdSettled).toBe(false)
+
+    releaseSecondSwap()
+    expect(await replacementWake).toBe(true)
+    expect(await third).toBe(true)
+  })
+
   it('reports false when waking a page it does not own', async () => {
     const h = createHarness()
     expect(await h.backend.wakeTab('nope')).toBe(false)

--- a/src/main/browser/offscreen-browser-backend-reclaim.test.ts
+++ b/src/main/browser/offscreen-browser-backend-reclaim.test.ts
@@ -124,6 +124,7 @@ beforeEach(() => {
   process.env.ORCA_HEADLESS_BROWSER_PARK_IDLE_MS = '60000'
   process.env.ORCA_HEADLESS_BROWSER_PARK_GRACE_MS = '5000'
   process.env.ORCA_HEADLESS_BROWSER_PARK_SWEEP_MS = '100000'
+  process.env.ORCA_HEADLESS_BROWSER_MAX_RETAINED_PAGES = '100'
 })
 
 describe('OffscreenBrowserBackend reclamation', () => {
@@ -142,7 +143,7 @@ describe('OffscreenBrowserBackend reclamation', () => {
         browserPageId: pageId,
         worktreeId: undefined,
         profileId: 'default',
-        url: 'about:blank',
+        url: 'https://example.test/a',
         title: `title-${h.windows[0].webContents.id}`,
         active: false
       }
@@ -200,6 +201,36 @@ describe('OffscreenBrowserBackend reclamation', () => {
     expect(h.order).toEqual([`register:${pageId}:${wokenId}`, `process-swap:${pageId}:${wokenId}`])
     expect(loadOffscreenBrowserUrl).toHaveBeenCalledWith(h.windows[1], 'https://example.test/moved')
     expect(h.backend.listParkedPages()).toEqual([])
+  })
+
+  it('keeps the requested address when a page parks before committing one', async () => {
+    // Why: an uncommitted window still reports about:blank, and adopting that
+    // would send the wake to a blank page instead of the agent's URL.
+    const h = createHarness()
+    await h.backend.createTab({ url: 'https://example.test/slow', browserPageId: 'a' })
+    h.windows[0].__url = 'about:blank'
+    h.clock.value += 120_000
+    await h.backend.reclaimIdlePages()
+
+    expect(h.backend.listParkedPages()[0]?.url).toBe('https://example.test/slow')
+  })
+
+  it('never parks a page whose navigation is still in flight', async () => {
+    let finishLoad = (): void => {}
+    loadOffscreenBrowserUrl.mockImplementationOnce(
+      async () => new Promise<void>((resolve) => (finishLoad = resolve))
+    )
+    const h = createHarness()
+    await h.backend.createTab({ url: 'https://example.test/slow', browserPageId: 'a' })
+
+    h.clock.value += 120_000
+    expect(await h.backend.reclaimIdlePages()).toEqual([])
+
+    finishLoad()
+    await Promise.resolve()
+    await Promise.resolve()
+    h.clock.value += 120_000
+    expect(await h.backend.reclaimIdlePages()).toEqual(['a'])
   })
 
   it('coalesces concurrent wakes into one renderer', async () => {
@@ -324,14 +355,35 @@ describe('OffscreenBrowserBackend reclamation', () => {
     expect(h.backend.listParkedPages().map((page) => page.browserPageId)).toEqual(['a'])
   })
 
-  it('drops a page whose renderer dies on its own', async () => {
+  it('drops a page whose renderer dies on its own and reclaims its helper session', async () => {
+    // Why: without this the crash path leaks one helper session, CDP proxy and
+    // listening port per lost renderer — a crash loop is unbounded.
     const h = createHarness()
     await h.backend.createTab({ url: 'https://example.test/a', browserPageId: 'a' })
+    const webContentsId = h.windows[0].webContents.id
+    h.order.length = 0
 
     h.windows[0].destroy()
+    await Promise.resolve()
 
+    expect(h.order).toEqual([`session-destroy:${webContentsId}`, 'unregister:a'])
     expect(h.backend.listParkedPages()).toEqual([])
     expect(await h.backend.wakeTab('a')).toBe(false)
+  })
+
+  it('closes the oldest parked pages once too many records are retained', async () => {
+    // Why: parking bounds renderer processes, not the page records behind them.
+    process.env.ORCA_HEADLESS_BROWSER_MAX_RETAINED_PAGES = '2'
+    const h = createHarness()
+    for (const id of ['a', 'b', 'c', 'd']) {
+      await h.backend.createTab({ url: `https://example.test/${id}`, browserPageId: id })
+      h.clock.value += 1_000
+    }
+    h.clock.value += 120_000
+    await h.backend.reclaimIdlePages()
+
+    expect(h.backend.listParkedPages().map((page) => page.browserPageId)).toEqual(['c', 'd'])
+    expect(h.windows.every((win) => win.isDestroyed())).toBe(true)
   })
 
   it('scopes parked listings and implicit targeting to a worktree', async () => {

--- a/src/main/browser/offscreen-browser-backend.ts
+++ b/src/main/browser/offscreen-browser-backend.ts
@@ -33,7 +33,7 @@ export class OffscreenBrowserBackend implements BrowserBackend {
   /** Renderer teardowns this backend initiated, keyed by page. Park and close
    *  both destroy the window on purpose, so the crash handler stands down for
    *  them — and a wake waits on one rather than racing it. */
-  private readonly releasing = new Map<string, Promise<boolean>>()
+  private readonly releasing = new Map<string, Promise<void>>()
   private readonly waking = new Map<string, Promise<boolean>>()
   private readonly reclaimer: OffscreenBrowserPageReclaimer
 
@@ -244,17 +244,14 @@ export class OffscreenBrowserBackend implements BrowserBackend {
       this.options
         .getAgentBrowserBridge?.()
         ?.isActiveBrowserPage(browserPageId, page.worktreeId) === true
-    // Why the abort: teardown awaits the helper session, and the page keeps
-    // running throughout. A download started inside that window would be
-    // cancelled by the unregister that follows, so give up the park instead.
-    // The session is already gone, but the next command recreates it.
-    const released = await this.releaseRenderer(page, browserPageId, () =>
-      this.reclaimer.hasAdvancingDownload(browserPageId)
-    )
-    if (!released) {
-      page.activeWhenParked = false
-      return
-    }
+    // Why no abort once this starts: the veto is re-checked immediately before
+    // this call, but teardown then awaits the helper session while the page
+    // keeps running, so a download begun inside that window is still cancelled
+    // by the unregister below — exactly as it would be if the tab were closed
+    // at that instant. Backing out mid-teardown is worse: onTabClosed has
+    // already destroyed the helper session and moved the worktree's active
+    // pointer, so an abort leaves a resident page with reset automation state.
+    await this.releaseRenderer(page, browserPageId)
     page.window = null
     if (page.activeWhenParked) {
       // Why: teardown promotes another live tab to active, which then parks
@@ -266,21 +263,19 @@ export class OffscreenBrowserBackend implements BrowserBackend {
   // Why: teardown order matters — the bridge must destroy the helper session and
   // detach its debugger while the WebContents is still alive and still mapped,
   // or the session, its CDP proxy and its listening port outlive the page.
-  /** Resolves false when abortAfterSessionTeardown vetoed the release. */
   private async releaseRenderer(
     page: OffscreenBrowserPage | null,
-    browserPageId: string,
-    abortAfterSessionTeardown?: () => boolean
-  ): Promise<boolean> {
+    browserPageId: string
+  ): Promise<void> {
     const pending = this.releasing.get(browserPageId)
     if (pending) {
       await pending
-      return true
+      return
     }
-    const release = this.runReleaseRenderer(page, browserPageId, abortAfterSessionTeardown)
+    const release = this.runReleaseRenderer(page, browserPageId)
     this.releasing.set(browserPageId, release)
     try {
-      return await release
+      await release
     } finally {
       if (this.releasing.get(browserPageId) === release) {
         this.releasing.delete(browserPageId)
@@ -290,22 +285,17 @@ export class OffscreenBrowserBackend implements BrowserBackend {
 
   private async runReleaseRenderer(
     page: OffscreenBrowserPage | null,
-    browserPageId: string,
-    abortAfterSessionTeardown?: () => boolean
-  ): Promise<boolean> {
+    browserPageId: string
+  ): Promise<void> {
     const bridge = this.options.getAgentBrowserBridge?.() ?? null
     const webContentsId = this.browserManager.getGuestWebContentsId(browserPageId)
     if (bridge && webContentsId != null) {
       await bridge.onTabClosed(webContentsId)
     }
-    if (abortAfterSessionTeardown?.() === true) {
-      return false
-    }
     this.browserManager.unregisterGuest(browserPageId)
     if (page?.window && !page.window.isDestroyed()) {
       page.window.destroy()
     }
-    return true
   }
 
   private materialize(page: OffscreenBrowserPage): void {

--- a/src/main/browser/offscreen-browser-backend.ts
+++ b/src/main/browser/offscreen-browser-backend.ts
@@ -237,6 +237,7 @@ export class OffscreenBrowserBackend implements BrowserBackend {
     if (!page?.window || page.window.isDestroyed()) {
       return
     }
+    const window = page.window
     // Why: the record's address is kept current by did-navigate, so parking
     // never has to guess it from a WebContents that may be sitting on the blank
     // page a failed load left behind.
@@ -257,6 +258,16 @@ export class OffscreenBrowserBackend implements BrowserBackend {
     // already destroyed the helper session and moved the worktree's active
     // pointer, so an abort leaves a resident page with reset automation state.
     await this.releaseRenderer(page, browserPageId)
+    // Why: a wake awaiting this same release resumes BEFORE this line — its
+    // reaction registered later on the same promise — and can have already
+    // re-materialized the page. The park owns only the window it destroyed:
+    // nulling the field blindly would drop the wake's fresh renderer off the
+    // record (leaking it — close and destroyAll walk page.window), list the
+    // page as parked and live at once, and let the wake report success while
+    // loadPage no-ops on a nulled window.
+    if (page.window !== window) {
+      return
+    }
     page.window = null
     if (page.activeWhenParked) {
       // Why: teardown promotes another live tab to active, which then parks

--- a/src/main/browser/offscreen-browser-backend.ts
+++ b/src/main/browser/offscreen-browser-backend.ts
@@ -5,10 +5,7 @@ import type { AgentBrowserBridge } from './agent-browser-bridge'
 import type { BrowserBackend, BrowserBackendCreateTab, ParkedBrowserPage } from './browser-backend'
 import type { BrowserManager } from './browser-manager'
 import { browserSessionRegistry } from './browser-session-registry'
-import {
-  readOffscreenBrowserReclaimPolicy,
-  type OffscreenBrowserReclaimPolicy
-} from './offscreen-browser-page-reclaim'
+import { readOffscreenBrowserReclaimPolicy } from './offscreen-browser-page-reclaim'
 import { OffscreenBrowserPageReclaimer } from './offscreen-browser-page-reclaimer'
 import {
   OffscreenBrowserOpenPages,
@@ -36,21 +33,24 @@ export class OffscreenBrowserBackend implements BrowserBackend {
   /** Renderer teardowns this backend initiated, keyed by page. Park and close
    *  both destroy the window on purpose, so the crash handler stands down for
    *  them — and a wake waits on one rather than racing it. */
-  private readonly releasing = new Map<string, Promise<void>>()
+  private readonly releasing = new Map<string, Promise<boolean>>()
   private readonly waking = new Map<string, Promise<boolean>>()
-  private readonly policy: OffscreenBrowserReclaimPolicy
   private readonly reclaimer: OffscreenBrowserPageReclaimer
 
   constructor(
     private readonly browserManager: BrowserManager,
     private readonly options: OffscreenBrowserBackendOptions = {}
   ) {
-    this.policy = readOffscreenBrowserReclaimPolicy()
     this.reclaimer = new OffscreenBrowserPageReclaimer({
       pages: this.pages,
-      policy: this.policy,
+      policy: readOffscreenBrowserReclaimPolicy(),
       isReleasing: (browserPageId) => this.releasing.has(browserPageId),
-      isPinned: (page) => this.isPagePinned(page),
+      isWaking: (browserPageId) => this.waking.has(browserPageId),
+      hasCertificateChallenge: (browserPageId) =>
+        this.browserManager.getBrowserPageCertificateFailure(browserPageId) !== null,
+      activeDownloadProgressAt: (browserPageId) =>
+        this.browserManager.getBrowserPageActiveDownloadProgressAt(browserPageId),
+      isHostPinned: (browserPageId) => this.options.isPagePinned?.(browserPageId) === true,
       park: (browserPageId) => this.parkPage(browserPageId),
       close: (browserPageId) => this.closeTab(browserPageId),
       now: () => this.now()
@@ -227,31 +227,6 @@ export class OffscreenBrowserBackend implements BrowserBackend {
     return this.reclaimer.sweep()
   }
 
-  // Why: a page is off limits while anything is depending on its renderer —
-  // a client streaming it, a command in flight, its first navigation still
-  // committing, or a wake still rebuilding it. The wake case matters because a
-  // wake is resident but not yet loading while it awaits the process swap.
-  private isPagePinned(page: OffscreenBrowserPage): boolean {
-    // Why: `loading` is bounded by the load helper's own timeout, so it cannot
-    // be used to hold a renderer forever. A navigation still pending past that
-    // timeout is deliberately parkable — pinning it would let one stalled page
-    // per create defeat the resident cap outright, and waking simply retries
-    // the address.
-    return (
-      page.loading ||
-      this.waking.has(page.browserPageId) ||
-      // Why: a page blocked on a certificate decision is work waiting on an
-      // answer. Its challenge id dies with the renderer, so parking it would
-      // discard both the warning and the ability to approve it.
-      this.browserManager.getBrowserPageCertificateFailure(page.browserPageId) !== null ||
-      // Why: releasing a renderer unregisters its guest, and that cancels the
-      // page's in-flight downloads. The desktop guest budget vetoes eviction
-      // for the same reason (browser-guest-worktree-retention.ts).
-      this.browserManager.hasActiveBrowserPageDownload(page.browserPageId) ||
-      this.options.isPagePinned?.(page.browserPageId) === true
-    )
-  }
-
   private async parkPage(browserPageId: string): Promise<void> {
     const page = this.pages.get(browserPageId)
     if (!page?.window || page.window.isDestroyed()) {
@@ -269,7 +244,17 @@ export class OffscreenBrowserBackend implements BrowserBackend {
       this.options
         .getAgentBrowserBridge?.()
         ?.isActiveBrowserPage(browserPageId, page.worktreeId) === true
-    await this.releaseRenderer(page, browserPageId)
+    // Why the abort: teardown awaits the helper session, and the page keeps
+    // running throughout. A download started inside that window would be
+    // cancelled by the unregister that follows, so give up the park instead.
+    // The session is already gone, but the next command recreates it.
+    const released = await this.releaseRenderer(page, browserPageId, () =>
+      this.reclaimer.hasAdvancingDownload(browserPageId)
+    )
+    if (!released) {
+      page.activeWhenParked = false
+      return
+    }
     page.window = null
     if (page.activeWhenParked) {
       // Why: teardown promotes another live tab to active, which then parks
@@ -281,19 +266,21 @@ export class OffscreenBrowserBackend implements BrowserBackend {
   // Why: teardown order matters — the bridge must destroy the helper session and
   // detach its debugger while the WebContents is still alive and still mapped,
   // or the session, its CDP proxy and its listening port outlive the page.
+  /** Resolves false when abortAfterSessionTeardown vetoed the release. */
   private async releaseRenderer(
     page: OffscreenBrowserPage | null,
-    browserPageId: string
-  ): Promise<void> {
+    browserPageId: string,
+    abortAfterSessionTeardown?: () => boolean
+  ): Promise<boolean> {
     const pending = this.releasing.get(browserPageId)
     if (pending) {
       await pending
-      return
+      return true
     }
-    const release = this.runReleaseRenderer(page, browserPageId)
+    const release = this.runReleaseRenderer(page, browserPageId, abortAfterSessionTeardown)
     this.releasing.set(browserPageId, release)
     try {
-      await release
+      return await release
     } finally {
       if (this.releasing.get(browserPageId) === release) {
         this.releasing.delete(browserPageId)
@@ -303,17 +290,22 @@ export class OffscreenBrowserBackend implements BrowserBackend {
 
   private async runReleaseRenderer(
     page: OffscreenBrowserPage | null,
-    browserPageId: string
-  ): Promise<void> {
+    browserPageId: string,
+    abortAfterSessionTeardown?: () => boolean
+  ): Promise<boolean> {
     const bridge = this.options.getAgentBrowserBridge?.() ?? null
     const webContentsId = this.browserManager.getGuestWebContentsId(browserPageId)
     if (bridge && webContentsId != null) {
       await bridge.onTabClosed(webContentsId)
     }
+    if (abortAfterSessionTeardown?.() === true) {
+      return false
+    }
     this.browserManager.unregisterGuest(browserPageId)
     if (page?.window && !page.window.isDestroyed()) {
       page.window.destroy()
     }
+    return true
   }
 
   private materialize(page: OffscreenBrowserPage): void {

--- a/src/main/browser/offscreen-browser-backend.ts
+++ b/src/main/browser/offscreen-browser-backend.ts
@@ -68,6 +68,7 @@ export class OffscreenBrowserBackend implements BrowserBackend {
       window: null,
       activeWhenParked: false,
       loading: false,
+      loadError: null,
       lastActivityAt: this.now()
     }
     this.pages.add(page)
@@ -151,9 +152,9 @@ export class OffscreenBrowserBackend implements BrowserBackend {
     return this.pages.listParked(worktreeId)
   }
 
-  /** Most-recently-used parked page in a worktree, for implicit targeting. */
-  getMostRecentlyUsedParkedPageId(worktreeId?: string): string | null {
-    return this.pages.mostRecentlyUsedParkedId(worktreeId)
+  /** The parked page a page-less command should target in this worktree. */
+  getParkedPageIdForImplicitTarget(worktreeId?: string): string | null {
+    return this.pages.parkedIdForImplicitTarget(worktreeId)
   }
 
   destroyAll(): void {
@@ -217,23 +218,25 @@ export class OffscreenBrowserBackend implements BrowserBackend {
     if (!page?.window || page.window.isDestroyed()) {
       return
     }
-    // Why: capture the committed address before teardown so a woken page
-    // returns to where the agent left it, not to its original create URL. A
-    // page that never committed still reports the empty or blank address the
-    // window started on; adopting that would send the wake to the wrong page.
-    const wc = page.window.webContents
-    const committed = wc.getURL()
-    const uncommitted = !committed || committed === 'about:blank'
-    if (!uncommitted && !committed.startsWith('chrome-error://')) {
-      page.url = committed
-    }
-    page.title = wc.getTitle() ?? page.title
+    // Why: the record's address is kept current by did-navigate, so parking
+    // never has to guess it from a WebContents that may be sitting on the blank
+    // page a failed load left behind.
+    page.title = page.window.webContents.getTitle() ?? page.title
+    // Why: a reclaimed renderer does not make a page that failed to load
+    // healthy, and the failure becomes unreadable once the guest is
+    // unregistered — so carry it onto the record.
+    page.loadError = this.browserManager.getBrowserPageLoadError(browserPageId)
     page.activeWhenParked =
       this.options
         .getAgentBrowserBridge?.()
         ?.isActiveBrowserPage(browserPageId, page.worktreeId) === true
     await this.releaseRenderer(page, browserPageId)
     page.window = null
+    if (page.activeWhenParked) {
+      // Why: teardown promotes another live tab to active, which then parks
+      // claiming the flag too. Only the newest claim may hold it.
+      this.pages.claimParkedActive(browserPageId, page.worktreeId)
+    }
   }
 
   // Why: teardown order matters — the bridge must destroy the helper session and
@@ -281,6 +284,17 @@ export class OffscreenBrowserBackend implements BrowserBackend {
     // the throw would escape the 'destroyed' listener into the main process.
     // Capture the id while it is still safe to read.
     const webContentsId = win.webContents.id
+    // Why: the record's address must follow the page, not the create call — an
+    // agent that navigates with `goto` or in-page script has to be woken back
+    // to where it actually is. A chrome-error address is the failure, not a
+    // destination, so it never replaces the address that produced it.
+    const trackNavigation = (_event: unknown, url: string): void => {
+      if (page.window === win && url && !url.startsWith('chrome-error://')) {
+        page.url = url
+      }
+    }
+    win.webContents.on('did-navigate', trackNavigation)
+    win.webContents.on('did-navigate-in-page', trackNavigation)
     // Why: if the window is destroyed out from under us (crash, app teardown),
     // drop the page so commands fail cleanly instead of resolving a dead
     // WebContents. Parking destroys it deliberately, so it opts out here.

--- a/src/main/browser/offscreen-browser-backend.ts
+++ b/src/main/browser/offscreen-browser-backend.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from 'node:crypto'
-import type { BrowserWindow } from 'electron'
 import { ORCA_BROWSER_PARTITION } from '../../shared/constants'
 import type { AgentBrowserBridge } from './agent-browser-bridge'
 import type { BrowserBackend, BrowserBackendCreateTab, ParkedBrowserPage } from './browser-backend'
@@ -11,6 +10,10 @@ import {
   selectOffscreenBrowserPagesToPark,
   type OffscreenBrowserReclaimPolicy
 } from './offscreen-browser-page-reclaim'
+import {
+  OffscreenBrowserOpenPages,
+  type OffscreenBrowserPage
+} from './offscreen-browser-open-pages'
 import { createOffscreenBrowserWindow, loadOffscreenBrowserUrl } from './offscreen-browser-window'
 
 // Why (STA-4341): this backend is the lifecycle owner for headless browser
@@ -18,22 +21,6 @@ import { createOffscreenBrowserWindow, loadOffscreenBrowserUrl } from './offscre
 // worktree, profile) for as long as the page is open, but treats the renderer
 // process behind it as a reclaimable resource: an idle page is parked (renderer
 // destroyed, record kept) and woken on the next command that targets it.
-
-type OffscreenPage = {
-  browserPageId: string
-  worktreeId?: string
-  profileId?: string
-  partition: string
-  url: string
-  title: string
-  /** null while parked — the page exists, its renderer does not. */
-  window: BrowserWindow | null
-  /** Whether the page was its worktree's active tab when it parked. */
-  activeWhenParked: boolean
-  /** True while the initial or post-wake navigation is still in flight. */
-  loading: boolean
-  lastActivityAt: number
-}
 
 export type OffscreenBrowserBackendOptions = {
   getAgentBrowserBridge?: () => AgentBrowserBridge | null
@@ -43,7 +30,7 @@ export type OffscreenBrowserBackendOptions = {
 }
 
 export class OffscreenBrowserBackend implements BrowserBackend {
-  private readonly pages = new Map<string, OffscreenPage>()
+  private readonly pages = new OffscreenBrowserOpenPages()
   /** Renderer teardowns this backend initiated, keyed by page. Park and close
    *  both destroy the window on purpose, so the crash handler stands down for
    *  them — and a wake waits on one rather than racing it. */
@@ -71,7 +58,7 @@ export class OffscreenBrowserBackend implements BrowserBackend {
       ? browserSessionRegistry.getProfile(params.profileId)
       : browserSessionRegistry.getDefaultProfile()
     const url = params.url || 'about:blank'
-    const page: OffscreenPage = {
+    const page: OffscreenBrowserPage = {
       browserPageId,
       worktreeId: params.worktreeId,
       profileId: profile?.id ?? undefined,
@@ -83,7 +70,7 @@ export class OffscreenBrowserBackend implements BrowserBackend {
       loading: false,
       lastActivityAt: this.now()
     }
-    this.pages.set(browserPageId, page)
+    this.pages.add(page)
     // Why: register the guest and return immediately so the new tab appears
     // without waiting for the page to finish loading. A failed load leaves the
     // (usable) tab open, matching how a normal browser tab survives one.
@@ -99,10 +86,9 @@ export class OffscreenBrowserBackend implements BrowserBackend {
   }
 
   async closeTab(browserPageId: string): Promise<void> {
-    const page = this.pages.get(browserPageId)
-    this.pages.delete(browserPageId)
+    const page = this.pages.delete(browserPageId) ?? null
     this.waking.delete(browserPageId)
-    await this.releaseRenderer(page ?? null, browserPageId)
+    await this.releaseRenderer(page, browserPageId)
     if (this.pages.size === 0) {
       this.stopSweep()
     }
@@ -162,47 +148,18 @@ export class OffscreenBrowserBackend implements BrowserBackend {
   }
 
   listParkedPages(worktreeId?: string): ParkedBrowserPage[] {
-    const parked: ParkedBrowserPage[] = []
-    for (const page of this.pages.values()) {
-      if (page.window && !page.window.isDestroyed()) {
-        continue
-      }
-      if (worktreeId && page.worktreeId !== worktreeId) {
-        continue
-      }
-      parked.push({
-        browserPageId: page.browserPageId,
-        worktreeId: page.worktreeId,
-        profileId: page.profileId,
-        url: page.url,
-        title: page.title,
-        active: page.activeWhenParked
-      })
-    }
-    return parked
+    return this.pages.listParked(worktreeId)
   }
 
   /** Most-recently-used parked page in a worktree, for implicit targeting. */
   getMostRecentlyUsedParkedPageId(worktreeId?: string): string | null {
-    let best: OffscreenPage | null = null
-    for (const page of this.pages.values()) {
-      if (page.window && !page.window.isDestroyed()) {
-        continue
-      }
-      if (worktreeId && page.worktreeId !== worktreeId) {
-        continue
-      }
-      if (!best || page.lastActivityAt > best.lastActivityAt) {
-        best = page
-      }
-    }
-    return best?.browserPageId ?? null
+    return this.pages.mostRecentlyUsedParkedId(worktreeId)
   }
 
   destroyAll(): void {
     this.stopSweep()
-    for (const [pageId, page] of this.pages) {
-      this.browserManager.unregisterGuest(pageId)
+    for (const page of this.pages.all()) {
+      this.browserManager.unregisterGuest(page.browserPageId)
       if (page.window && !page.window.isDestroyed()) {
         page.window.destroy()
       }
@@ -214,9 +171,7 @@ export class OffscreenBrowserBackend implements BrowserBackend {
   /** Park every page the policy no longer wants resident. Exposed for tests. */
   async reclaimIdlePages(): Promise<string[]> {
     const now = this.now()
-    const resident = [...this.pages.values()].filter(
-      (page) => page.window && !page.window.isDestroyed() && !this.releasing.has(page.browserPageId)
-    )
+    const resident = this.pages.resident().filter((page) => !this.releasing.has(page.browserPageId))
     const doomed = selectOffscreenBrowserPagesToPark(
       resident.map((page) => ({
         browserPageId: page.browserPageId,
@@ -239,9 +194,7 @@ export class OffscreenBrowserBackend implements BrowserBackend {
   // agent that opens pages forever and closes none would still grow the backend
   // without limit, so the oldest parked pages are eventually closed outright.
   private async closeOverRetainedPages(): Promise<void> {
-    const parked = [...this.pages.values()].filter(
-      (page) => !page.window || page.window.isDestroyed()
-    )
+    const parked = this.pages.parked()
     const doomed = selectOffscreenBrowserPagesToClose(
       parked.map((page) => ({
         browserPageId: page.browserPageId,
@@ -286,7 +239,10 @@ export class OffscreenBrowserBackend implements BrowserBackend {
   // Why: teardown order matters — the bridge must destroy the helper session and
   // detach its debugger while the WebContents is still alive and still mapped,
   // or the session, its CDP proxy and its listening port outlive the page.
-  private async releaseRenderer(page: OffscreenPage | null, browserPageId: string): Promise<void> {
+  private async releaseRenderer(
+    page: OffscreenBrowserPage | null,
+    browserPageId: string
+  ): Promise<void> {
     const pending = this.releasing.get(browserPageId)
     if (pending) {
       await pending
@@ -304,7 +260,7 @@ export class OffscreenBrowserBackend implements BrowserBackend {
   }
 
   private async runReleaseRenderer(
-    page: OffscreenPage | null,
+    page: OffscreenBrowserPage | null,
     browserPageId: string
   ): Promise<void> {
     const bridge = this.options.getAgentBrowserBridge?.() ?? null
@@ -318,7 +274,7 @@ export class OffscreenBrowserBackend implements BrowserBackend {
     }
   }
 
-  private materialize(page: OffscreenPage): void {
+  private materialize(page: OffscreenBrowserPage): void {
     const win = createOffscreenBrowserWindow(page.partition)
     page.window = win
     // Why: reading win.webContents once the contents are destroyed throws, and
@@ -355,7 +311,7 @@ export class OffscreenBrowserBackend implements BrowserBackend {
     })
   }
 
-  private async loadPage(page: OffscreenPage, url: string): Promise<void> {
+  private async loadPage(page: OffscreenBrowserPage, url: string): Promise<void> {
     const win = page.window
     if (!win || win.isDestroyed()) {
       return

--- a/src/main/browser/offscreen-browser-backend.ts
+++ b/src/main/browser/offscreen-browser-backend.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto'
+import type { BrowserWindow } from 'electron'
 import { ORCA_BROWSER_PARTITION } from '../../shared/constants'
 import type { AgentBrowserBridge } from './agent-browser-bridge'
 import type { BrowserBackend, BrowserBackendCreateTab, ParkedBrowserPage } from './browser-backend'
@@ -72,10 +73,20 @@ export class OffscreenBrowserBackend implements BrowserBackend {
       lastActivityAt: this.now()
     }
     this.pages.add(page)
-    // Why: register the guest and return immediately so the new tab appears
-    // without waiting for the page to finish loading. A failed load leaves the
-    // (usable) tab open, matching how a normal browser tab survives one.
-    this.materialize(page)
+    try {
+      // Why: register the guest and return immediately so the new tab appears
+      // without waiting for the page to finish loading. A failed load leaves
+      // the (usable) tab open, matching how a normal browser tab survives one.
+      this.materialize(page)
+    } catch (error) {
+      // Why: a create that never produced a usable renderer must not become an
+      // owned page. Left in place it would occupy the retention budget, be
+      // listed as parked, and make a retry with the same id fail as "already
+      // exists" — while never having installed the crash handler that would
+      // have cleaned it up.
+      this.pages.delete(browserPageId)
+      throw error
+    }
     void this.loadPage(page, url).catch((error) => {
       console.warn(
         '[offscreen-browser] page load failed:',
@@ -157,6 +168,9 @@ export class OffscreenBrowserBackend implements BrowserBackend {
     return this.pages.parkedIdForImplicitTarget(worktreeId)
   }
 
+  // Why: quit only. The bridge's own destroyAllSessions() runs immediately
+  // before this in the shutdown chain, so routing each page through the bridge
+  // again would only re-close sessions that are already gone.
   destroyAll(): void {
     this.stopSweep()
     for (const page of this.pages.all()) {
@@ -279,6 +293,20 @@ export class OffscreenBrowserBackend implements BrowserBackend {
 
   private materialize(page: OffscreenBrowserPage): void {
     const win = createOffscreenBrowserWindow(page.partition)
+    try {
+      this.attachWindow(page, win)
+    } catch (error) {
+      // Why: the window exists before anything that can fail. Abandoning it
+      // here would leak a hidden renderer nothing owns or can reach.
+      page.window = null
+      if (!win.isDestroyed()) {
+        win.destroy()
+      }
+      throw error
+    }
+  }
+
+  private attachWindow(page: OffscreenBrowserPage, win: BrowserWindow): void {
     page.window = win
     // Why: reading win.webContents once the contents are destroyed throws, and
     // the throw would escape the 'destroyed' listener into the main process.

--- a/src/main/browser/offscreen-browser-backend.ts
+++ b/src/main/browser/offscreen-browser-backend.ts
@@ -130,13 +130,17 @@ export class OffscreenBrowserBackend implements BrowserBackend {
       return false
     }
     page.lastActivityAt = this.now()
-    const releasing = this.releasing.get(browserPageId)
-    if (!releasing && page.window && !page.window.isDestroyed()) {
-      return true
-    }
+    // Why: a wake materializes the window before it swaps the helper session
+    // and reloads the address, so the page looks resident well before it is
+    // usable. Join an in-flight wake first or a second command runs against a
+    // blank page whose session is still being torn down underneath it.
     const inFlight = this.waking.get(browserPageId)
     if (inFlight) {
       return inFlight
+    }
+    const releasing = this.releasing.get(browserPageId)
+    if (!releasing && page.window && !page.window.isDestroyed()) {
+      return true
     }
     const wake = (async (): Promise<boolean> => {
       await releasing

--- a/src/main/browser/offscreen-browser-backend.ts
+++ b/src/main/browser/offscreen-browser-backend.ts
@@ -181,7 +181,13 @@ export class OffscreenBrowserBackend implements BrowserBackend {
     try {
       return await wake
     } finally {
-      this.waking.delete(browserPageId)
+      // Why: an abandoned wake can outlive a close and a replacement page's own
+      // wake. Clearing the entry blindly would drop the replacement's lock, and
+      // the next command would see a live window with no wake in flight and
+      // drive a renderer that is still being rebuilt.
+      if (this.waking.get(browserPageId) === wake) {
+        this.waking.delete(browserPageId)
+      }
     }
   }
 

--- a/src/main/browser/offscreen-browser-backend.ts
+++ b/src/main/browser/offscreen-browser-backend.ts
@@ -142,9 +142,13 @@ export class OffscreenBrowserBackend implements BrowserBackend {
     if (!releasing && page.window && !page.window.isDestroyed()) {
       return true
     }
+    const stillOwned = (): boolean => this.pages.get(browserPageId) === page
     const wake = (async (): Promise<boolean> => {
       await releasing
-      if (!this.pages.has(browserPageId)) {
+      // Why: identity, not presence — a close during the wake can be followed
+      // by a create reusing the id, and reporting success then would hand the
+      // original command a different page under the name it asked for.
+      if (!stillOwned()) {
         return false
       }
       if (page.window && !page.window.isDestroyed()) {
@@ -160,10 +164,16 @@ export class OffscreenBrowserBackend implements BrowserBackend {
         // path so the stale helper session and CDP proxy are torn down.
         await bridge.onProcessSwap(browserPageId, webContentsId, previousWebContentsId ?? undefined)
       }
+      if (!stillOwned()) {
+        return false
+      }
       await this.loadPage(page, page.url).catch(() => {
         // A parked page whose URL no longer loads stays open and reports the
         // failure through the same load-error surface as a live page.
       })
+      if (!stillOwned()) {
+        return false
+      }
       page.lastActivityAt = this.now()
       return true
     })()
@@ -264,9 +274,13 @@ export class OffscreenBrowserBackend implements BrowserBackend {
   // committing, or a wake still rebuilding it. The wake case matters because a
   // wake is resident but not yet loading while it awaits the process swap.
   private isPagePinned(page: OffscreenBrowserPage): boolean {
+    // Why: `loading` is bounded by the load helper's own timeout, so it cannot
+    // be used to hold a renderer forever. A navigation still pending past that
+    // timeout is deliberately parkable — pinning it would let one stalled page
+    // per create defeat the resident cap outright, and waking simply retries
+    // the address.
     return (
       page.loading ||
-      this.isNavigating(page) ||
       this.waking.has(page.browserPageId) ||
       // Why: a page blocked on a certificate decision is work waiting on an
       // answer. Its challenge id dies with the renderer, so parking it would
@@ -274,20 +288,6 @@ export class OffscreenBrowserBackend implements BrowserBackend {
       this.browserManager.getBrowserPageCertificateFailure(page.browserPageId) !== null ||
       this.options.isPagePinned?.(page.browserPageId) === true
     )
-  }
-
-  // Why: the load helper resolves on its own timeout, so `loading` stops
-  // covering a navigation that is slow rather than finished. Ask the renderer.
-  private isNavigating(page: OffscreenBrowserPage): boolean {
-    const win = page.window
-    if (!win || win.isDestroyed()) {
-      return false
-    }
-    try {
-      return win.webContents.isLoading()
-    } catch {
-      return false
-    }
   }
 
   private isSafeToReclaim(browserPageId: string): boolean {

--- a/src/main/browser/offscreen-browser-backend.ts
+++ b/src/main/browser/offscreen-browser-backend.ts
@@ -27,6 +27,8 @@ export type OffscreenBrowserBackendOptions = {
   getAgentBrowserBridge?: () => AgentBrowserBridge | null
   /** Pages a client is streaming or that have a command in flight. */
   isPagePinned?: (browserPageId: string) => boolean
+  /** Called when the set of open pages changes, so paired clients republish. */
+  onPagesChanged?: (worktreeId: string | undefined) => void
   now?: () => number
 }
 
@@ -50,6 +52,10 @@ export class OffscreenBrowserBackend implements BrowserBackend {
 
   async createTab(params: BrowserBackendCreateTab): Promise<{ browserPageId: string }> {
     const browserPageId = params.browserPageId ?? randomUUID()
+    // Why: closing drops the record before its teardown finishes, so a caller
+    // reusing the id can register a new renderer that the old close then
+    // unregisters. Let the release finish before claiming the id again.
+    await this.releasing.get(browserPageId)
     if (this.pages.has(browserPageId)) {
       throw new Error(`Browser page ${browserPageId} already exists`)
     }
@@ -103,6 +109,12 @@ export class OffscreenBrowserBackend implements BrowserBackend {
     await this.releaseRenderer(page, browserPageId)
     if (this.pages.size === 0) {
       this.stopSweep()
+    }
+    // Why: closing a parked page has no WebContents teardown to piggyback on,
+    // so nothing else tells paired clients the tab is gone — they would keep
+    // showing a ghost until an operation against it failed.
+    if (page) {
+      this.options.onPagesChanged?.(page.worktreeId)
     }
   }
 
@@ -250,9 +262,28 @@ export class OffscreenBrowserBackend implements BrowserBackend {
   private isPagePinned(page: OffscreenBrowserPage): boolean {
     return (
       page.loading ||
+      this.isNavigating(page) ||
       this.waking.has(page.browserPageId) ||
+      // Why: a page blocked on a certificate decision is work waiting on an
+      // answer. Its challenge id dies with the renderer, so parking it would
+      // discard both the warning and the ability to approve it.
+      this.browserManager.getBrowserPageCertificateFailure(page.browserPageId) !== null ||
       this.options.isPagePinned?.(page.browserPageId) === true
     )
+  }
+
+  // Why: the load helper resolves on its own timeout, so `loading` stops
+  // covering a navigation that is slow rather than finished. Ask the renderer.
+  private isNavigating(page: OffscreenBrowserPage): boolean {
+    const win = page.window
+    if (!win || win.isDestroyed()) {
+      return false
+    }
+    try {
+      return win.webContents.isLoading()
+    } catch {
+      return false
+    }
   }
 
   private isSafeToReclaim(browserPageId: string): boolean {
@@ -352,13 +383,21 @@ export class OffscreenBrowserBackend implements BrowserBackend {
     // agent that navigates with `goto` or in-page script has to be woken back
     // to where it actually is. A chrome-error address is the failure, not a
     // destination, so it never replaces the address that produced it.
-    const trackNavigation = (_event: unknown, url: string): void => {
+    const recordAddress = (url: string): void => {
       if (page.window === win && url && !url.startsWith('chrome-error://')) {
         page.url = url
       }
     }
-    win.webContents.on('did-navigate', trackNavigation)
-    win.webContents.on('did-navigate-in-page', trackNavigation)
+    // did-navigate is main-frame only; did-frame-navigate covers subframes.
+    win.webContents.on('did-navigate', (_event, url) => recordAddress(url))
+    // Why: an iframe changing its own hash also fires did-navigate-in-page. A
+    // subframe navigation is not a navigation of the tab, and adopting its
+    // address would wake the page onto the iframe's document.
+    win.webContents.on('did-navigate-in-page', (_event, url, isMainFrame) => {
+      if (isMainFrame) {
+        recordAddress(url)
+      }
+    })
     // Why: if the window is destroyed out from under us (crash, app teardown),
     // drop the page so commands fail cleanly instead of resolving a dead
     // WebContents. Parking destroys it deliberately, so it opts out here.

--- a/src/main/browser/offscreen-browser-backend.ts
+++ b/src/main/browser/offscreen-browser-backend.ts
@@ -1,30 +1,62 @@
 import { randomUUID } from 'node:crypto'
-import { BrowserWindow } from 'electron'
+import type { BrowserWindow } from 'electron'
 import { ORCA_BROWSER_PARTITION } from '../../shared/constants'
-import { ORCA_BROWSER_GUEST_WEB_PREFERENCES } from '../../shared/browser-guest-web-preferences'
-import type { BrowserBackend, BrowserBackendCreateTab } from './browser-backend'
+import type { AgentBrowserBridge } from './agent-browser-bridge'
+import type { BrowserBackend, BrowserBackendCreateTab, ParkedBrowserPage } from './browser-backend'
 import type { BrowserManager } from './browser-manager'
 import { browserSessionRegistry } from './browser-session-registry'
+import {
+  readOffscreenBrowserReclaimPolicy,
+  selectOffscreenBrowserPagesToPark,
+  type OffscreenBrowserReclaimPolicy
+} from './offscreen-browser-page-reclaim'
+import { createOffscreenBrowserWindow, loadOffscreenBrowserUrl } from './offscreen-browser-window'
 
-// Why: headless orca serve has no renderer window to host a <webview>, so each
-// browser page is backed by a main-process offscreen BrowserWindow. The window
-// is never shown — it exists only so its WebContents can be driven over CDP and
-// streamed via the existing screencast path. Verified on macOS and on headless
-// Linux under Xvfb (Electron --headless segfaults; a virtual display is
-// required there — provisioned in the serve image, not by this code).
+// Why (STA-4341): this backend is the lifecycle owner for headless browser
+// pages. It keeps the page identity an agent holds (`browserPageId`, URL,
+// worktree, profile) for as long as the page is open, but treats the renderer
+// process behind it as a reclaimable resource: an idle page is parked (renderer
+// destroyed, record kept) and woken on the next command that targets it.
 
-const DEFAULT_VIEWPORT_WIDTH = 1280
-const DEFAULT_VIEWPORT_HEIGHT = 800
-const LOAD_TIMEOUT_MS = 30_000
+type OffscreenPage = {
+  browserPageId: string
+  worktreeId?: string
+  profileId?: string
+  partition: string
+  url: string
+  title: string
+  /** null while parked — the page exists, its renderer does not. */
+  window: BrowserWindow | null
+  lastActivityAt: number
+}
+
+export type OffscreenBrowserBackendOptions = {
+  getAgentBrowserBridge?: () => AgentBrowserBridge | null
+  /** Pages a client is streaming or that have a command in flight. */
+  isPagePinned?: (browserPageId: string) => boolean
+  now?: () => number
+}
 
 export class OffscreenBrowserBackend implements BrowserBackend {
-  private readonly windowsByPageId = new Map<string, BrowserWindow>()
+  private readonly pages = new Map<string, OffscreenPage>()
+  /** Renderer teardowns this backend initiated, keyed by page. Park and close
+   *  both destroy the window on purpose, so the crash handler stands down for
+   *  them — and a wake waits on one rather than racing it. */
+  private readonly releasing = new Map<string, Promise<void>>()
+  private readonly waking = new Map<string, Promise<boolean>>()
+  private readonly policy: OffscreenBrowserReclaimPolicy
+  private sweepTimer: NodeJS.Timeout | null = null
 
-  constructor(private readonly browserManager: BrowserManager) {}
+  constructor(
+    private readonly browserManager: BrowserManager,
+    private readonly options: OffscreenBrowserBackendOptions = {}
+  ) {
+    this.policy = readOffscreenBrowserReclaimPolicy()
+  }
 
   async createTab(params: BrowserBackendCreateTab): Promise<{ browserPageId: string }> {
     const browserPageId = params.browserPageId ?? randomUUID()
-    if (this.windowsByPageId.has(browserPageId)) {
+    if (this.pages.has(browserPageId)) {
       throw new Error(`Browser page ${browserPageId} already exists`)
     }
     // Why: profiles map to Electron partitions; using the profile's partition
@@ -32,142 +64,274 @@ export class OffscreenBrowserBackend implements BrowserBackend {
     const profile = params.profileId
       ? browserSessionRegistry.getProfile(params.profileId)
       : browserSessionRegistry.getDefaultProfile()
-    const partition = profile?.partition ?? ORCA_BROWSER_PARTITION
-
-    const win = new BrowserWindow({
-      show: false,
-      width: DEFAULT_VIEWPORT_WIDTH,
-      height: DEFAULT_VIEWPORT_HEIGHT,
-      webPreferences: {
-        // Why: offscreen pages are the SSH/headless browser backend; keep their
-        // HTML fullscreen behavior aligned with desktop <webview> guests.
-        ...ORCA_BROWSER_GUEST_WEB_PREFERENCES,
-        partition,
-        sandbox: true,
-        contextIsolation: true,
-        nodeIntegration: false
-      }
-    })
-
-    this.windowsByPageId.set(browserPageId, win)
-
-    // Why: if the offscreen window is destroyed out from under us (crash, app
-    // teardown), drop the registry entry so commands fail cleanly instead of
-    // resolving a dead WebContents.
-    win.webContents.once('destroyed', () => {
-      this.windowsByPageId.delete(browserPageId)
-      this.browserManager.unregisterGuest(browserPageId)
-    })
-
-    // Why: register the guest and return immediately so the new tab appears
-    // without waiting for the page to finish loading. Previously createTab
-    // awaited the full navigation, so clicking "New Browser Tab" did nothing for
-    // up to a second on real URLs. The page loads asynchronously and streams
-    // once it paints; a failed load leaves the (usable) tab open, matching how a
-    // normal browser tab survives a failed navigation.
-    this.browserManager.registerOffscreenGuest({
+    const url = params.url || 'about:blank'
+    const page: OffscreenPage = {
       browserPageId,
       worktreeId: params.worktreeId,
-      sessionProfileId: profile?.id ?? null,
-      userAgentMode: profile?.userAgentMode,
-      webContentsId: win.webContents.id
-    })
-
-    const url = params.url || 'about:blank'
-    void this.loadUrl(win, url).catch((error) => {
+      profileId: profile?.id ?? undefined,
+      partition: profile?.partition ?? ORCA_BROWSER_PARTITION,
+      url,
+      title: '',
+      window: null,
+      lastActivityAt: this.now()
+    }
+    this.pages.set(browserPageId, page)
+    // Why: register the guest and return immediately so the new tab appears
+    // without waiting for the page to finish loading. A failed load leaves the
+    // (usable) tab open, matching how a normal browser tab survives one.
+    this.materialize(page)
+    void this.loadPage(page, url).catch((error) => {
       console.warn(
         '[offscreen-browser] page load failed:',
         error instanceof Error ? error.message : String(error)
       )
     })
-
+    this.ensureSweepScheduled()
     return { browserPageId }
   }
 
   async closeTab(browserPageId: string): Promise<void> {
-    const win = this.windowsByPageId.get(browserPageId)
-    this.windowsByPageId.delete(browserPageId)
-    this.browserManager.unregisterGuest(browserPageId)
-    if (win && !win.isDestroyed()) {
-      win.destroy()
+    const page = this.pages.get(browserPageId)
+    this.pages.delete(browserPageId)
+    this.waking.delete(browserPageId)
+    await this.releaseRenderer(page ?? null, browserPageId)
+    if (this.pages.size === 0) {
+      this.stopSweep()
     }
   }
 
-  getWebContentsId(browserPageId: string): number | null {
-    const win = this.windowsByPageId.get(browserPageId)
-    return win && !win.isDestroyed() ? win.webContents.id : null
+  /**
+   * Make a page's renderer resident and restart its reclaim clock. Cheap and
+   * idempotent for a page that never parked, so command routing can call it
+   * unconditionally; that is also what serialises a command against a park
+   * that is already tearing the renderer down.
+   */
+  async wakeTab(browserPageId: string): Promise<boolean> {
+    const page = this.pages.get(browserPageId)
+    if (!page) {
+      return false
+    }
+    page.lastActivityAt = this.now()
+    const releasing = this.releasing.get(browserPageId)
+    if (!releasing && page.window && !page.window.isDestroyed()) {
+      return true
+    }
+    const inFlight = this.waking.get(browserPageId)
+    if (inFlight) {
+      return inFlight
+    }
+    const wake = (async (): Promise<boolean> => {
+      await releasing
+      if (!this.pages.has(browserPageId)) {
+        return false
+      }
+      if (page.window && !page.window.isDestroyed()) {
+        return true
+      }
+      const previousWebContentsId = this.browserManager.getGuestWebContentsId(browserPageId)
+      this.materialize(page)
+      const bridge = this.options.getAgentBrowserBridge?.() ?? null
+      const webContentsId = page.window?.webContents.id
+      if (bridge && webContentsId != null) {
+        // Why: same page id, new renderer — reuse the existing process-swap
+        // path so the stale helper session and CDP proxy are torn down.
+        await bridge.onProcessSwap(browserPageId, webContentsId, previousWebContentsId ?? undefined)
+      }
+      await this.loadPage(page, page.url).catch(() => {
+        // A parked page whose URL no longer loads stays open and reports the
+        // failure through the same load-error surface as a live page.
+      })
+      page.lastActivityAt = this.now()
+      return true
+    })()
+    this.waking.set(browserPageId, wake)
+    try {
+      return await wake
+    } finally {
+      this.waking.delete(browserPageId)
+    }
+  }
+
+  listParkedPages(worktreeId?: string): ParkedBrowserPage[] {
+    const parked: ParkedBrowserPage[] = []
+    for (const page of this.pages.values()) {
+      if (page.window && !page.window.isDestroyed()) {
+        continue
+      }
+      if (worktreeId && page.worktreeId !== worktreeId) {
+        continue
+      }
+      parked.push({
+        browserPageId: page.browserPageId,
+        worktreeId: page.worktreeId,
+        profileId: page.profileId,
+        url: page.url,
+        title: page.title
+      })
+    }
+    return parked
+  }
+
+  /** Most-recently-used parked page in a worktree, for implicit targeting. */
+  getMostRecentlyUsedParkedPageId(worktreeId?: string): string | null {
+    let best: OffscreenPage | null = null
+    for (const page of this.pages.values()) {
+      if (page.window && !page.window.isDestroyed()) {
+        continue
+      }
+      if (worktreeId && page.worktreeId !== worktreeId) {
+        continue
+      }
+      if (!best || page.lastActivityAt > best.lastActivityAt) {
+        best = page
+      }
+    }
+    return best?.browserPageId ?? null
   }
 
   destroyAll(): void {
-    for (const [pageId, win] of this.windowsByPageId) {
+    this.stopSweep()
+    for (const [pageId, page] of this.pages) {
       this.browserManager.unregisterGuest(pageId)
-      if (!win.isDestroyed()) {
-        win.destroy()
+      if (page.window && !page.window.isDestroyed()) {
+        page.window.destroy()
       }
     }
-    this.windowsByPageId.clear()
+    this.pages.clear()
+    this.waking.clear()
   }
 
-  private async loadUrl(win: BrowserWindow, url: string): Promise<void> {
-    const wc = win.webContents
-    await new Promise<void>((resolve, reject) => {
-      let settled = false
-      const timer = setTimeout(() => {
-        if (settled) {
-          return
-        }
-        settled = true
-        cleanup()
-        // Why: about:blank and slow pages can resolve via timeout without a
-        // did-finish-load; treat that as success so the tab is still operable.
-        resolve()
-      }, LOAD_TIMEOUT_MS)
+  /** Park every page the policy no longer wants resident. Exposed for tests. */
+  async reclaimIdlePages(): Promise<string[]> {
+    const now = this.now()
+    const resident = [...this.pages.values()].filter(
+      (page) => page.window && !page.window.isDestroyed() && !this.releasing.has(page.browserPageId)
+    )
+    const doomed = selectOffscreenBrowserPagesToPark(
+      resident.map((page) => ({
+        browserPageId: page.browserPageId,
+        lastActivityAt: page.lastActivityAt,
+        pinned: this.options.isPagePinned?.(page.browserPageId) === true
+      })),
+      now,
+      this.policy
+    )
+    for (const browserPageId of doomed) {
+      await this.parkPage(browserPageId)
+    }
+    return doomed
+  }
 
-      const onFinish = (): void => {
-        if (settled) {
-          return
-        }
-        settled = true
-        cleanup()
-        resolve()
-      }
-      const onFail = (
-        _e: unknown,
-        errorCode: number,
-        errorDescription: string,
-        _validatedURL: string,
-        isMainFrame: boolean
-      ): void => {
-        // Why: subframe/iframe (e.g. ad/tracker) load failures also fire
-        // did-fail-load. Only the main frame failing means the page itself
-        // failed; ignore the rest or an otherwise-usable page gets rejected.
-        if (!isMainFrame) {
-          return
-        }
-        if (settled) {
-          return
-        }
-        settled = true
-        cleanup()
-        // Why: aborted loads (-3) happen on redirects/SPA navigations and are not
-        // real failures; the page is still usable.
-        if (errorCode === -3) {
-          resolve()
-          return
-        }
-        reject(new Error(`${errorDescription} (${errorCode})`))
-      }
-      const cleanup = (): void => {
-        clearTimeout(timer)
-        wc.removeListener('did-finish-load', onFinish)
-        wc.removeListener('did-fail-load', onFail)
-      }
+  private async parkPage(browserPageId: string): Promise<void> {
+    const page = this.pages.get(browserPageId)
+    if (!page?.window || page.window.isDestroyed()) {
+      return
+    }
+    // Why: capture the committed address before teardown so a woken page
+    // returns to where the agent left it, not to its original create URL.
+    const wc = page.window.webContents
+    const committed = wc.getURL()
+    if (committed && !committed.startsWith('chrome-error://')) {
+      page.url = committed
+    }
+    page.title = wc.getTitle() ?? page.title
+    await this.releaseRenderer(page, browserPageId)
+    page.window = null
+  }
 
-      wc.on('did-finish-load', onFinish)
-      wc.on('did-fail-load', onFail)
-      void wc.loadURL(url).catch(() => {
-        // loadURL rejects on aborted navigations; did-fail-load handles the rest.
-      })
+  // Why: teardown order matters — the bridge must destroy the helper session and
+  // detach its debugger while the WebContents is still alive and still mapped,
+  // or the session, its CDP proxy and its listening port outlive the page.
+  private async releaseRenderer(page: OffscreenPage | null, browserPageId: string): Promise<void> {
+    const pending = this.releasing.get(browserPageId)
+    if (pending) {
+      await pending
+      return
+    }
+    const release = this.runReleaseRenderer(page, browserPageId)
+    this.releasing.set(browserPageId, release)
+    try {
+      await release
+    } finally {
+      if (this.releasing.get(browserPageId) === release) {
+        this.releasing.delete(browserPageId)
+      }
+    }
+  }
+
+  private async runReleaseRenderer(
+    page: OffscreenPage | null,
+    browserPageId: string
+  ): Promise<void> {
+    const bridge = this.options.getAgentBrowserBridge?.() ?? null
+    const webContentsId = this.browserManager.getGuestWebContentsId(browserPageId)
+    if (bridge && webContentsId != null) {
+      await bridge.onTabClosed(webContentsId)
+    }
+    this.browserManager.unregisterGuest(browserPageId)
+    if (page?.window && !page.window.isDestroyed()) {
+      page.window.destroy()
+    }
+  }
+
+  private materialize(page: OffscreenPage): void {
+    const win = createOffscreenBrowserWindow(page.partition)
+    page.window = win
+    // Why: if the window is destroyed out from under us (crash, app teardown),
+    // drop the page so commands fail cleanly instead of resolving a dead
+    // WebContents. Parking destroys it deliberately, so it opts out here.
+    win.webContents.once('destroyed', () => {
+      if (this.releasing.has(page.browserPageId) || page.window !== win) {
+        return
+      }
+      this.pages.delete(page.browserPageId)
+      this.browserManager.unregisterGuest(page.browserPageId)
     })
+    const profile = page.profileId ? browserSessionRegistry.getProfile(page.profileId) : null
+    this.browserManager.registerOffscreenGuest({
+      browserPageId: page.browserPageId,
+      worktreeId: page.worktreeId,
+      sessionProfileId: page.profileId ?? null,
+      userAgentMode: profile?.userAgentMode,
+      webContentsId: win.webContents.id
+    })
+  }
+
+  private async loadPage(page: OffscreenPage, url: string): Promise<void> {
+    const win = page.window
+    if (!win || win.isDestroyed()) {
+      return
+    }
+    await loadOffscreenBrowserUrl(win, url)
+    if (page.window === win && !win.isDestroyed()) {
+      page.title = win.webContents.getTitle() ?? page.title
+      // Why: the reclaim clock must start when the page is ready, not when the
+      // create call returned, or a slow load can be parked mid-flight.
+      page.lastActivityAt = this.now()
+    }
+  }
+
+  private ensureSweepScheduled(): void {
+    if (this.sweepTimer) {
+      return
+    }
+    this.sweepTimer = setInterval(() => {
+      void this.reclaimIdlePages().catch(() => {
+        // A failed park is retried on the next sweep.
+      })
+    }, this.policy.sweepIntervalMs)
+    // Why: reclamation must never be the reason the process stays alive.
+    this.sweepTimer.unref?.()
+  }
+
+  private stopSweep(): void {
+    if (this.sweepTimer) {
+      clearInterval(this.sweepTimer)
+      this.sweepTimer = null
+    }
+  }
+
+  private now(): number {
+    return this.options.now?.() ?? Date.now()
   }
 }

--- a/src/main/browser/offscreen-browser-backend.ts
+++ b/src/main/browser/offscreen-browser-backend.ts
@@ -185,6 +185,9 @@ export class OffscreenBrowserBackend implements BrowserBackend {
         return false
       }
       page.lastActivityAt = this.now()
+      // Why: the sweep stops once nothing is resident, so a wake has to bring
+      // it back or this page would never be reclaimed again.
+      this.reclaimer.ensureScheduled()
       return true
     })()
     this.waking.set(browserPageId, wake)

--- a/src/main/browser/offscreen-browser-backend.ts
+++ b/src/main/browser/offscreen-browser-backend.ts
@@ -120,7 +120,12 @@ export class OffscreenBrowserBackend implements BrowserBackend {
     // either the parked-active flag, or a live pointer whose teardown found no
     // other live tab to promote. A worktree with open pages and no active tab
     // breaks the one-selected-tab assumption every paired client renders on.
-    if (page && !this.options.getAgentBrowserBridge?.()?.getActivePageId(page.worktreeId)) {
+    // Gate on the book, not the bridge: getActivePageId resolves through
+    // resolveActiveTab, which reassigns the active pointers as a side effect,
+    // and its undefined scope means "anywhere" while the promotion is strict.
+    // A scope holding a resident page needs no promotion — the live listing
+    // marks one of its tabs active itself.
+    if (page && !this.pages.resident().some((open) => open.worktreeId === page.worktreeId)) {
       this.pages.promoteParkedActive(page.worktreeId)
     }
     // Why: closing changes both residency and rank, and with the last page gone

--- a/src/main/browser/offscreen-browser-backend.ts
+++ b/src/main/browser/offscreen-browser-backend.ts
@@ -185,46 +185,82 @@ export class OffscreenBrowserBackend implements BrowserBackend {
 
   /** Park every page the policy no longer wants resident. Exposed for tests. */
   async reclaimIdlePages(): Promise<string[]> {
-    const now = this.now()
     const resident = this.pages.resident().filter((page) => !this.releasing.has(page.browserPageId))
     const doomed = selectOffscreenBrowserPagesToPark(
-      resident.map((page) => ({
-        browserPageId: page.browserPageId,
-        lastActivityAt: page.lastActivityAt,
-        // Why: a page still committing its first navigation has nothing worth
-        // keeping yet and would be woken straight back to the same address.
-        pinned: page.loading || this.options.isPagePinned?.(page.browserPageId) === true
-      })),
-      now,
+      resident.map((page) => this.toReclaimCandidate(page)),
+      this.now(),
       this.policy
     )
+    const parked: string[] = []
     for (const browserPageId of doomed) {
+      // Why: parking awaits the helper session's teardown, so a page later in
+      // this list can be woken and driven while an earlier one is still being
+      // torn down. The selection is a proposal, not a licence — re-check each
+      // page against the live state before destroying its renderer.
+      if (!this.isSafeToReclaim(browserPageId)) {
+        continue
+      }
       await this.parkPage(browserPageId)
+      parked.push(browserPageId)
     }
     await this.closeOverRetainedPages()
-    return doomed
+    return parked
   }
 
   // Why: parking bounds renderer processes, not the records behind them. An
   // agent that opens pages forever and closes none would still grow the backend
   // without limit, so the oldest parked pages are eventually closed outright.
   private async closeOverRetainedPages(): Promise<void> {
-    const parked = this.pages.parked()
     const doomed = selectOffscreenBrowserPagesToClose(
-      parked.map((page) => ({
-        browserPageId: page.browserPageId,
-        lastActivityAt: page.lastActivityAt,
-        pinned: this.options.isPagePinned?.(page.browserPageId) === true
-      })),
+      this.pages.parked().map((page) => this.toReclaimCandidate(page)),
       this.pages.size,
       this.policy
     )
     for (const browserPageId of doomed) {
+      // Why: closing is destructive and awaits teardown, so a page selected
+      // here can be woken before its turn comes. Only close one that is still
+      // parked and still unwanted.
+      const page = this.pages.get(browserPageId)
+      if (!page || page.window || !this.isSafeToReclaim(browserPageId)) {
+        continue
+      }
       console.warn(
         `[offscreen-browser] closing parked page ${browserPageId}: more than ${this.policy.retainedPageLimit} pages are open`
       )
       await this.closeTab(browserPageId)
     }
+  }
+
+  private toReclaimCandidate(page: OffscreenBrowserPage): {
+    browserPageId: string
+    lastActivityAt: number
+    pinned: boolean
+  } {
+    return {
+      browserPageId: page.browserPageId,
+      lastActivityAt: page.lastActivityAt,
+      pinned: this.isPagePinned(page)
+    }
+  }
+
+  // Why: a page is off limits while anything is depending on its renderer —
+  // a client streaming it, a command in flight, its first navigation still
+  // committing, or a wake still rebuilding it. The wake case matters because a
+  // wake is resident but not yet loading while it awaits the process swap.
+  private isPagePinned(page: OffscreenBrowserPage): boolean {
+    return (
+      page.loading ||
+      this.waking.has(page.browserPageId) ||
+      this.options.isPagePinned?.(page.browserPageId) === true
+    )
+  }
+
+  private isSafeToReclaim(browserPageId: string): boolean {
+    const page = this.pages.get(browserPageId)
+    if (!page || this.releasing.has(browserPageId)) {
+      return false
+    }
+    return !this.isPagePinned(page) && this.now() - page.lastActivityAt >= this.policy.parkGraceMs
   }
 
   private async parkPage(browserPageId: string): Promise<void> {

--- a/src/main/browser/offscreen-browser-backend.ts
+++ b/src/main/browser/offscreen-browser-backend.ts
@@ -27,6 +27,8 @@ type OffscreenPage = {
   title: string
   /** null while parked — the page exists, its renderer does not. */
   window: BrowserWindow | null
+  /** Whether the page was its worktree's active tab when it parked. */
+  activeWhenParked: boolean
   lastActivityAt: number
 }
 
@@ -46,6 +48,7 @@ export class OffscreenBrowserBackend implements BrowserBackend {
   private readonly waking = new Map<string, Promise<boolean>>()
   private readonly policy: OffscreenBrowserReclaimPolicy
   private sweepTimer: NodeJS.Timeout | null = null
+  private sweepInFlight: Promise<unknown> | null = null
 
   constructor(
     private readonly browserManager: BrowserManager,
@@ -73,6 +76,7 @@ export class OffscreenBrowserBackend implements BrowserBackend {
       url,
       title: '',
       window: null,
+      activeWhenParked: false,
       lastActivityAt: this.now()
     }
     this.pages.set(browserPageId, page)
@@ -128,6 +132,7 @@ export class OffscreenBrowserBackend implements BrowserBackend {
       if (page.window && !page.window.isDestroyed()) {
         return true
       }
+      page.activeWhenParked = false
       const previousWebContentsId = this.browserManager.getGuestWebContentsId(browserPageId)
       this.materialize(page)
       const bridge = this.options.getAgentBrowserBridge?.() ?? null
@@ -166,7 +171,8 @@ export class OffscreenBrowserBackend implements BrowserBackend {
         worktreeId: page.worktreeId,
         profileId: page.profileId,
         url: page.url,
-        title: page.title
+        title: page.title,
+        active: page.activeWhenParked
       })
     }
     return parked
@@ -235,6 +241,10 @@ export class OffscreenBrowserBackend implements BrowserBackend {
       page.url = committed
     }
     page.title = wc.getTitle() ?? page.title
+    page.activeWhenParked =
+      this.options
+        .getAgentBrowserBridge?.()
+        ?.isActiveBrowserPage(browserPageId, page.worktreeId) === true
     await this.releaseRenderer(page, browserPageId)
     page.window = null
   }
@@ -316,8 +326,20 @@ export class OffscreenBrowserBackend implements BrowserBackend {
       return
     }
     this.sweepTimer = setInterval(() => {
-      void this.reclaimIdlePages().catch(() => {
+      // Why: a park waits on the helper session's own bounded teardown, which
+      // can outlast the interval. Without this guard slow teardowns would stack
+      // sweeps on top of each other for as long as they lag.
+      if (this.sweepInFlight) {
+        return
+      }
+      const sweep = this.reclaimIdlePages().catch(() => {
         // A failed park is retried on the next sweep.
+      })
+      this.sweepInFlight = sweep
+      void sweep.finally(() => {
+        if (this.sweepInFlight === sweep) {
+          this.sweepInFlight = null
+        }
       })
     }, this.policy.sweepIntervalMs)
     // Why: reclamation must never be the reason the process stays alive.
@@ -329,6 +351,7 @@ export class OffscreenBrowserBackend implements BrowserBackend {
       clearInterval(this.sweepTimer)
       this.sweepTimer = null
     }
+    this.sweepInFlight = null
   }
 
   private now(): number {

--- a/src/main/browser/offscreen-browser-backend.ts
+++ b/src/main/browser/offscreen-browser-backend.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from 'node:crypto'
-import type { BrowserWindow } from 'electron'
 import { ORCA_BROWSER_PARTITION } from '../../shared/constants'
 import type { AgentBrowserBridge } from './agent-browser-bridge'
 import type { BrowserBackend, BrowserBackendCreateTab, ParkedBrowserPage } from './browser-backend'
@@ -11,8 +10,8 @@ import {
   OffscreenBrowserOpenPages,
   type OffscreenBrowserPage
 } from './offscreen-browser-open-pages'
+import { materializeOffscreenBrowserRenderer } from './offscreen-browser-renderer-attachment'
 import {
-  createOffscreenBrowserWindow,
   loadOffscreenBrowserUrl,
   OFFSCREEN_BROWSER_WAKE_LOAD_BUDGET_MS
 } from './offscreen-browser-window'
@@ -117,6 +116,13 @@ export class OffscreenBrowserBackend implements BrowserBackend {
     const page = this.pages.delete(browserPageId) ?? null
     this.waking.delete(browserPageId)
     await this.releaseRenderer(page, browserPageId)
+    // Why: the closed page may have carried the scope's only active claim —
+    // either the parked-active flag, or a live pointer whose teardown found no
+    // other live tab to promote. A worktree with open pages and no active tab
+    // breaks the one-selected-tab assumption every paired client renders on.
+    if (page && !this.options.getAgentBrowserBridge?.()?.getActivePageId(page.worktreeId)) {
+      this.pages.promoteParkedActive(page.worktreeId)
+    }
     // Why: closing changes both residency and rank, and with the last page gone
     // this arms nothing at all.
     this.reclaimer.reschedule()
@@ -205,6 +211,11 @@ export class OffscreenBrowserBackend implements BrowserBackend {
 
   listParkedPages(worktreeId?: string): ParkedBrowserPage[] {
     return this.pages.listParked(worktreeId)
+  }
+
+  /** Open page ids in creation order — the stable order listings sort by. */
+  listOpenPageIds(worktreeId?: string): string[] {
+    return this.pages.openIds(worktreeId)
   }
 
   /** The parked page a page-less command should target in this worktree. */
@@ -315,70 +326,30 @@ export class OffscreenBrowserBackend implements BrowserBackend {
   }
 
   private materialize(page: OffscreenBrowserPage): void {
-    const win = createOffscreenBrowserWindow(page.partition)
-    try {
-      this.attachWindow(page, win)
-    } catch (error) {
-      // Why: the window exists before anything that can fail. Abandoning it
-      // here would leak a hidden renderer nothing owns or can reach.
-      page.window = null
-      if (!win.isDestroyed()) {
-        win.destroy()
+    materializeOffscreenBrowserRenderer(page, {
+      isDeliberateTeardown: (browserPageId) => this.releasing.has(browserPageId),
+      onRendererLost: (webContentsId) => {
+        this.pages.delete(page.browserPageId)
+        // Why: an unprompted renderer loss must reclaim the helper session too,
+        // or a crash loop leaks one session, CDP proxy and listening port per
+        // page — the same leak the deliberate teardown path fixes.
+        void this.options
+          .getAgentBrowserBridge?.()
+          ?.onTabClosed(webContentsId)
+          .catch(() => {})
+        this.browserManager.unregisterGuest(page.browserPageId)
+        this.reclaimer.reschedule()
+      },
+      registerGuest: (webContentsId) => {
+        const profile = page.profileId ? browserSessionRegistry.getProfile(page.profileId) : null
+        this.browserManager.registerOffscreenGuest({
+          browserPageId: page.browserPageId,
+          worktreeId: page.worktreeId,
+          sessionProfileId: page.profileId ?? null,
+          userAgentMode: profile?.userAgentMode,
+          webContentsId
+        })
       }
-      throw error
-    }
-  }
-
-  private attachWindow(page: OffscreenBrowserPage, win: BrowserWindow): void {
-    page.window = win
-    // Why: reading win.webContents once the contents are destroyed throws, and
-    // the throw would escape the 'destroyed' listener into the main process.
-    // Capture the id while it is still safe to read.
-    const webContentsId = win.webContents.id
-    // Why: the record's address must follow the page, not the create call — an
-    // agent that navigates with `goto` or in-page script has to be woken back
-    // to where it actually is. A chrome-error address is the failure, not a
-    // destination, so it never replaces the address that produced it.
-    const recordAddress = (url: string): void => {
-      if (page.window === win && url && !url.startsWith('chrome-error://')) {
-        page.url = url
-      }
-    }
-    // did-navigate is main-frame only; did-frame-navigate covers subframes.
-    win.webContents.on('did-navigate', (_event, url) => recordAddress(url))
-    // Why: an iframe changing its own hash also fires did-navigate-in-page. A
-    // subframe navigation is not a navigation of the tab, and adopting its
-    // address would wake the page onto the iframe's document.
-    win.webContents.on('did-navigate-in-page', (_event, url, isMainFrame) => {
-      if (isMainFrame) {
-        recordAddress(url)
-      }
-    })
-    // Why: if the window is destroyed out from under us (crash, app teardown),
-    // drop the page so commands fail cleanly instead of resolving a dead
-    // WebContents. Parking destroys it deliberately, so it opts out here.
-    win.webContents.once('destroyed', () => {
-      if (this.releasing.has(page.browserPageId) || page.window !== win) {
-        return
-      }
-      this.pages.delete(page.browserPageId)
-      // Why: an unprompted renderer loss must reclaim the helper session too, or
-      // a crash loop leaks one session, CDP proxy and listening port per page —
-      // the same leak the deliberate teardown path fixes.
-      void this.options
-        .getAgentBrowserBridge?.()
-        ?.onTabClosed(webContentsId)
-        .catch(() => {})
-      this.browserManager.unregisterGuest(page.browserPageId)
-      this.reclaimer.reschedule()
-    })
-    const profile = page.profileId ? browserSessionRegistry.getProfile(page.profileId) : null
-    this.browserManager.registerOffscreenGuest({
-      browserPageId: page.browserPageId,
-      worktreeId: page.worktreeId,
-      sessionProfileId: page.profileId ?? null,
-      userAgentMode: profile?.userAgentMode,
-      webContentsId
     })
   }
 

--- a/src/main/browser/offscreen-browser-backend.ts
+++ b/src/main/browser/offscreen-browser-backend.ts
@@ -11,7 +11,11 @@ import {
   OffscreenBrowserOpenPages,
   type OffscreenBrowserPage
 } from './offscreen-browser-open-pages'
-import { createOffscreenBrowserWindow, loadOffscreenBrowserUrl } from './offscreen-browser-window'
+import {
+  createOffscreenBrowserWindow,
+  loadOffscreenBrowserUrl,
+  OFFSCREEN_BROWSER_WAKE_LOAD_BUDGET_MS
+} from './offscreen-browser-window'
 
 // Why (STA-4341): this backend is the lifecycle owner for headless browser
 // pages. It keeps the page identity an agent holds (`browserPageId`, URL,
@@ -52,7 +56,6 @@ export class OffscreenBrowserBackend implements BrowserBackend {
         this.browserManager.hasActiveBrowserPageDownload(browserPageId),
       isHostPinned: (browserPageId) => this.options.isPagePinned?.(browserPageId) === true,
       park: (browserPageId) => this.parkPage(browserPageId),
-      close: (browserPageId) => this.closeTab(browserPageId),
       now: () => this.now()
     })
   }
@@ -174,7 +177,7 @@ export class OffscreenBrowserBackend implements BrowserBackend {
       if (!stillOwned()) {
         return false
       }
-      await this.loadPage(page, page.url).catch(() => {
+      await this.loadPage(page, page.url, OFFSCREEN_BROWSER_WAKE_LOAD_BUDGET_MS).catch(() => {
         // A parked page whose URL no longer loads stays open and reports the
         // failure through the same load-error surface as a live page.
       })
@@ -368,14 +371,18 @@ export class OffscreenBrowserBackend implements BrowserBackend {
     })
   }
 
-  private async loadPage(page: OffscreenBrowserPage, url: string): Promise<void> {
+  private async loadPage(
+    page: OffscreenBrowserPage,
+    url: string,
+    timeoutMs?: number
+  ): Promise<void> {
     const win = page.window
     if (!win || win.isDestroyed()) {
       return
     }
     page.loading = true
     try {
-      await loadOffscreenBrowserUrl(win, url)
+      await loadOffscreenBrowserUrl(win, url, timeoutMs)
     } finally {
       page.loading = false
     }

--- a/src/main/browser/offscreen-browser-backend.ts
+++ b/src/main/browser/offscreen-browser-backend.ts
@@ -5,7 +5,7 @@ import type { AgentBrowserBridge } from './agent-browser-bridge'
 import type { BrowserBackend, BrowserBackendCreateTab, ParkedBrowserPage } from './browser-backend'
 import type { BrowserManager } from './browser-manager'
 import { browserSessionRegistry } from './browser-session-registry'
-import { readOffscreenBrowserReclaimPolicy } from './offscreen-browser-page-reclaim'
+import { readOffscreenBrowserRetentionBudget } from './offscreen-browser-page-reclaim'
 import { OffscreenBrowserPageReclaimer } from './offscreen-browser-page-reclaimer'
 import {
   OffscreenBrowserOpenPages,
@@ -47,7 +47,7 @@ export class OffscreenBrowserBackend implements BrowserBackend {
   ) {
     this.reclaimer = new OffscreenBrowserPageReclaimer({
       pages: this.pages,
-      policy: readOffscreenBrowserReclaimPolicy(),
+      budget: readOffscreenBrowserRetentionBudget(),
       isReleasing: (browserPageId) => this.releasing.has(browserPageId),
       isWaking: (browserPageId) => this.waking.has(browserPageId),
       hasCertificateChallenge: (browserPageId) =>
@@ -109,7 +109,7 @@ export class OffscreenBrowserBackend implements BrowserBackend {
         error instanceof Error ? error.message : String(error)
       )
     })
-    this.reclaimer.ensureScheduled()
+    this.reclaimer.reschedule()
     return { browserPageId }
   }
 
@@ -117,9 +117,9 @@ export class OffscreenBrowserBackend implements BrowserBackend {
     const page = this.pages.delete(browserPageId) ?? null
     this.waking.delete(browserPageId)
     await this.releaseRenderer(page, browserPageId)
-    if (this.pages.size === 0) {
-      this.reclaimer.stop()
-    }
+    // Why: closing changes both residency and rank, and with the last page gone
+    // this arms nothing at all.
+    this.reclaimer.reschedule()
     // Why: closing a parked page has no WebContents teardown to piggyback on,
     // so nothing else tells paired clients the tab is gone — they would keep
     // showing a ghost until an operation against it failed.
@@ -139,7 +139,7 @@ export class OffscreenBrowserBackend implements BrowserBackend {
     if (!page) {
       return false
     }
-    page.lastActivityAt = this.now()
+    this.touch(page)
     // Why: a wake materializes the window before it swaps the helper session
     // and reloads the address, so the page looks resident well before it is
     // usable. Join an in-flight wake first or a second command runs against a
@@ -184,10 +184,9 @@ export class OffscreenBrowserBackend implements BrowserBackend {
       if (!stillOwned()) {
         return false
       }
-      page.lastActivityAt = this.now()
-      // Why: the sweep stops once nothing is resident, so a wake has to bring
-      // it back or this page would never be reclaimed again.
-      this.reclaimer.ensureScheduled()
+      // Why: waking makes this page resident again, so the budget has to be
+      // re-armed or the page it just displaced would never be reclaimed.
+      this.touch(page)
       return true
     })()
     this.waking.set(browserPageId, wake)
@@ -360,9 +359,7 @@ export class OffscreenBrowserBackend implements BrowserBackend {
         ?.onTabClosed(webContentsId)
         .catch(() => {})
       this.browserManager.unregisterGuest(page.browserPageId)
-      if (this.pages.size === 0) {
-        this.reclaimer.stop()
-      }
+      this.reclaimer.reschedule()
     })
     const profile = page.profileId ? browserSessionRegistry.getProfile(page.profileId) : null
     this.browserManager.registerOffscreenGuest({
@@ -393,8 +390,15 @@ export class OffscreenBrowserBackend implements BrowserBackend {
       page.title = win.webContents.getTitle() ?? page.title
       // Why: the reclaim clock must start when the page is ready, not when the
       // create call returned, or a slow load can be parked mid-flight.
-      page.lastActivityAt = this.now()
+      this.touch(page)
     }
+  }
+
+  // Why: every activity stamp moves the next reclaim deadline, so pairing the
+  // two here makes it impossible to record use without re-arming the budget.
+  private touch(page: OffscreenBrowserPage): void {
+    page.lastActivityAt = this.now()
+    this.reclaimer.reschedule()
   }
 
   private now(): number {

--- a/src/main/browser/offscreen-browser-backend.ts
+++ b/src/main/browser/offscreen-browser-backend.ts
@@ -48,8 +48,8 @@ export class OffscreenBrowserBackend implements BrowserBackend {
       isWaking: (browserPageId) => this.waking.has(browserPageId),
       hasCertificateChallenge: (browserPageId) =>
         this.browserManager.getBrowserPageCertificateFailure(browserPageId) !== null,
-      activeDownloadProgressAt: (browserPageId) =>
-        this.browserManager.getBrowserPageActiveDownloadProgressAt(browserPageId),
+      hasActiveDownload: (browserPageId) =>
+        this.browserManager.hasActiveBrowserPageDownload(browserPageId),
       isHostPinned: (browserPageId) => this.options.isPagePinned?.(browserPageId) === true,
       park: (browserPageId) => this.parkPage(browserPageId),
       close: (browserPageId) => this.closeTab(browserPageId),

--- a/src/main/browser/offscreen-browser-backend.ts
+++ b/src/main/browser/offscreen-browser-backend.ts
@@ -7,10 +7,9 @@ import type { BrowserManager } from './browser-manager'
 import { browserSessionRegistry } from './browser-session-registry'
 import {
   readOffscreenBrowserReclaimPolicy,
-  selectOffscreenBrowserPagesToClose,
-  selectOffscreenBrowserPagesToPark,
   type OffscreenBrowserReclaimPolicy
 } from './offscreen-browser-page-reclaim'
+import { OffscreenBrowserPageReclaimer } from './offscreen-browser-page-reclaimer'
 import {
   OffscreenBrowserOpenPages,
   type OffscreenBrowserPage
@@ -40,14 +39,22 @@ export class OffscreenBrowserBackend implements BrowserBackend {
   private readonly releasing = new Map<string, Promise<void>>()
   private readonly waking = new Map<string, Promise<boolean>>()
   private readonly policy: OffscreenBrowserReclaimPolicy
-  private sweepTimer: NodeJS.Timeout | null = null
-  private sweepInFlight: Promise<unknown> | null = null
+  private readonly reclaimer: OffscreenBrowserPageReclaimer
 
   constructor(
     private readonly browserManager: BrowserManager,
     private readonly options: OffscreenBrowserBackendOptions = {}
   ) {
     this.policy = readOffscreenBrowserReclaimPolicy()
+    this.reclaimer = new OffscreenBrowserPageReclaimer({
+      pages: this.pages,
+      policy: this.policy,
+      isReleasing: (browserPageId) => this.releasing.has(browserPageId),
+      isPinned: (page) => this.isPagePinned(page),
+      park: (browserPageId) => this.parkPage(browserPageId),
+      close: (browserPageId) => this.closeTab(browserPageId),
+      now: () => this.now()
+    })
   }
 
   async createTab(params: BrowserBackendCreateTab): Promise<{ browserPageId: string }> {
@@ -99,7 +106,7 @@ export class OffscreenBrowserBackend implements BrowserBackend {
         error instanceof Error ? error.message : String(error)
       )
     })
-    this.ensureSweepScheduled()
+    this.reclaimer.ensureScheduled()
     return { browserPageId }
   }
 
@@ -108,7 +115,7 @@ export class OffscreenBrowserBackend implements BrowserBackend {
     this.waking.delete(browserPageId)
     await this.releaseRenderer(page, browserPageId)
     if (this.pages.size === 0) {
-      this.stopSweep()
+      this.reclaimer.stop()
     }
     // Why: closing a parked page has no WebContents teardown to piggyback on,
     // so nothing else tells paired clients the tab is gone — they would keep
@@ -204,7 +211,7 @@ export class OffscreenBrowserBackend implements BrowserBackend {
   // before this in the shutdown chain, so routing each page through the bridge
   // again would only re-close sessions that are already gone.
   destroyAll(): void {
-    this.stopSweep()
+    this.reclaimer.stop()
     for (const page of this.pages.all()) {
       this.browserManager.unregisterGuest(page.browserPageId)
       if (page.window && !page.window.isDestroyed()) {
@@ -217,62 +224,7 @@ export class OffscreenBrowserBackend implements BrowserBackend {
 
   /** Park every page the policy no longer wants resident. Exposed for tests. */
   async reclaimIdlePages(): Promise<string[]> {
-    const resident = this.pages.resident().filter((page) => !this.releasing.has(page.browserPageId))
-    const doomed = selectOffscreenBrowserPagesToPark(
-      resident.map((page) => this.toReclaimCandidate(page)),
-      this.now(),
-      this.policy
-    )
-    const parked: string[] = []
-    for (const browserPageId of doomed) {
-      // Why: parking awaits the helper session's teardown, so a page later in
-      // this list can be woken and driven while an earlier one is still being
-      // torn down. The selection is a proposal, not a licence — re-check each
-      // page against the live state before destroying its renderer.
-      if (!this.isSafeToReclaim(browserPageId)) {
-        continue
-      }
-      await this.parkPage(browserPageId)
-      parked.push(browserPageId)
-    }
-    await this.closeOverRetainedPages()
-    return parked
-  }
-
-  // Why: parking bounds renderer processes, not the records behind them. An
-  // agent that opens pages forever and closes none would still grow the backend
-  // without limit, so the oldest parked pages are eventually closed outright.
-  private async closeOverRetainedPages(): Promise<void> {
-    const doomed = selectOffscreenBrowserPagesToClose(
-      this.pages.parked().map((page) => this.toReclaimCandidate(page)),
-      this.pages.size,
-      this.policy
-    )
-    for (const browserPageId of doomed) {
-      // Why: closing is destructive and awaits teardown, so a page selected
-      // here can be woken before its turn comes. Only close one that is still
-      // parked and still unwanted.
-      const page = this.pages.get(browserPageId)
-      if (!page || page.window || !this.isSafeToReclaim(browserPageId)) {
-        continue
-      }
-      console.warn(
-        `[offscreen-browser] closing parked page ${browserPageId}: more than ${this.policy.retainedPageLimit} pages are open`
-      )
-      await this.closeTab(browserPageId)
-    }
-  }
-
-  private toReclaimCandidate(page: OffscreenBrowserPage): {
-    browserPageId: string
-    lastActivityAt: number
-    pinned: boolean
-  } {
-    return {
-      browserPageId: page.browserPageId,
-      lastActivityAt: page.lastActivityAt,
-      pinned: this.isPagePinned(page)
-    }
+    return this.reclaimer.sweep()
   }
 
   // Why: a page is off limits while anything is depending on its renderer —
@@ -292,16 +244,12 @@ export class OffscreenBrowserBackend implements BrowserBackend {
       // answer. Its challenge id dies with the renderer, so parking it would
       // discard both the warning and the ability to approve it.
       this.browserManager.getBrowserPageCertificateFailure(page.browserPageId) !== null ||
+      // Why: releasing a renderer unregisters its guest, and that cancels the
+      // page's in-flight downloads. The desktop guest budget vetoes eviction
+      // for the same reason (browser-guest-worktree-retention.ts).
+      this.browserManager.hasActiveBrowserPageDownload(page.browserPageId) ||
       this.options.isPagePinned?.(page.browserPageId) === true
     )
-  }
-
-  private isSafeToReclaim(browserPageId: string): boolean {
-    const page = this.pages.get(browserPageId)
-    if (!page || this.releasing.has(browserPageId)) {
-      return false
-    }
-    return !this.isPagePinned(page) && this.now() - page.lastActivityAt >= this.policy.parkGraceMs
   }
 
   private async parkPage(browserPageId: string): Promise<void> {
@@ -425,7 +373,7 @@ export class OffscreenBrowserBackend implements BrowserBackend {
         .catch(() => {})
       this.browserManager.unregisterGuest(page.browserPageId)
       if (this.pages.size === 0) {
-        this.stopSweep()
+        this.reclaimer.stop()
       }
     })
     const profile = page.profileId ? browserSessionRegistry.getProfile(page.profileId) : null
@@ -455,39 +403,6 @@ export class OffscreenBrowserBackend implements BrowserBackend {
       // create call returned, or a slow load can be parked mid-flight.
       page.lastActivityAt = this.now()
     }
-  }
-
-  private ensureSweepScheduled(): void {
-    if (this.sweepTimer) {
-      return
-    }
-    this.sweepTimer = setInterval(() => {
-      // Why: a park waits on the helper session's own bounded teardown, which
-      // can outlast the interval. Without this guard slow teardowns would stack
-      // sweeps on top of each other for as long as they lag.
-      if (this.sweepInFlight) {
-        return
-      }
-      const sweep = this.reclaimIdlePages().catch(() => {
-        // A failed park is retried on the next sweep.
-      })
-      this.sweepInFlight = sweep
-      void sweep.finally(() => {
-        if (this.sweepInFlight === sweep) {
-          this.sweepInFlight = null
-        }
-      })
-    }, this.policy.sweepIntervalMs)
-    // Why: reclamation must never be the reason the process stays alive.
-    this.sweepTimer.unref?.()
-  }
-
-  private stopSweep(): void {
-    if (this.sweepTimer) {
-      clearInterval(this.sweepTimer)
-      this.sweepTimer = null
-    }
-    this.sweepInFlight = null
   }
 
   private now(): number {

--- a/src/main/browser/offscreen-browser-backend.ts
+++ b/src/main/browser/offscreen-browser-backend.ts
@@ -7,6 +7,7 @@ import type { BrowserManager } from './browser-manager'
 import { browserSessionRegistry } from './browser-session-registry'
 import {
   readOffscreenBrowserReclaimPolicy,
+  selectOffscreenBrowserPagesToClose,
   selectOffscreenBrowserPagesToPark,
   type OffscreenBrowserReclaimPolicy
 } from './offscreen-browser-page-reclaim'
@@ -29,6 +30,8 @@ type OffscreenPage = {
   window: BrowserWindow | null
   /** Whether the page was its worktree's active tab when it parked. */
   activeWhenParked: boolean
+  /** True while the initial or post-wake navigation is still in flight. */
+  loading: boolean
   lastActivityAt: number
 }
 
@@ -77,6 +80,7 @@ export class OffscreenBrowserBackend implements BrowserBackend {
       title: '',
       window: null,
       activeWhenParked: false,
+      loading: false,
       lastActivityAt: this.now()
     }
     this.pages.set(browserPageId, page)
@@ -217,7 +221,9 @@ export class OffscreenBrowserBackend implements BrowserBackend {
       resident.map((page) => ({
         browserPageId: page.browserPageId,
         lastActivityAt: page.lastActivityAt,
-        pinned: this.options.isPagePinned?.(page.browserPageId) === true
+        // Why: a page still committing its first navigation has nothing worth
+        // keeping yet and would be woken straight back to the same address.
+        pinned: page.loading || this.options.isPagePinned?.(page.browserPageId) === true
       })),
       now,
       this.policy
@@ -225,7 +231,32 @@ export class OffscreenBrowserBackend implements BrowserBackend {
     for (const browserPageId of doomed) {
       await this.parkPage(browserPageId)
     }
+    await this.closeOverRetainedPages()
     return doomed
+  }
+
+  // Why: parking bounds renderer processes, not the records behind them. An
+  // agent that opens pages forever and closes none would still grow the backend
+  // without limit, so the oldest parked pages are eventually closed outright.
+  private async closeOverRetainedPages(): Promise<void> {
+    const parked = [...this.pages.values()].filter(
+      (page) => !page.window || page.window.isDestroyed()
+    )
+    const doomed = selectOffscreenBrowserPagesToClose(
+      parked.map((page) => ({
+        browserPageId: page.browserPageId,
+        lastActivityAt: page.lastActivityAt,
+        pinned: this.options.isPagePinned?.(page.browserPageId) === true
+      })),
+      this.pages.size,
+      this.policy
+    )
+    for (const browserPageId of doomed) {
+      console.warn(
+        `[offscreen-browser] closing parked page ${browserPageId}: more than ${this.policy.retainedPageLimit} pages are open`
+      )
+      await this.closeTab(browserPageId)
+    }
   }
 
   private async parkPage(browserPageId: string): Promise<void> {
@@ -234,10 +265,13 @@ export class OffscreenBrowserBackend implements BrowserBackend {
       return
     }
     // Why: capture the committed address before teardown so a woken page
-    // returns to where the agent left it, not to its original create URL.
+    // returns to where the agent left it, not to its original create URL. A
+    // page that never committed still reports the empty or blank address the
+    // window started on; adopting that would send the wake to the wrong page.
     const wc = page.window.webContents
     const committed = wc.getURL()
-    if (committed && !committed.startsWith('chrome-error://')) {
+    const uncommitted = !committed || committed === 'about:blank'
+    if (!uncommitted && !committed.startsWith('chrome-error://')) {
       page.url = committed
     }
     page.title = wc.getTitle() ?? page.title
@@ -287,6 +321,10 @@ export class OffscreenBrowserBackend implements BrowserBackend {
   private materialize(page: OffscreenPage): void {
     const win = createOffscreenBrowserWindow(page.partition)
     page.window = win
+    // Why: reading win.webContents once the contents are destroyed throws, and
+    // the throw would escape the 'destroyed' listener into the main process.
+    // Capture the id while it is still safe to read.
+    const webContentsId = win.webContents.id
     // Why: if the window is destroyed out from under us (crash, app teardown),
     // drop the page so commands fail cleanly instead of resolving a dead
     // WebContents. Parking destroys it deliberately, so it opts out here.
@@ -295,7 +333,17 @@ export class OffscreenBrowserBackend implements BrowserBackend {
         return
       }
       this.pages.delete(page.browserPageId)
+      // Why: an unprompted renderer loss must reclaim the helper session too, or
+      // a crash loop leaks one session, CDP proxy and listening port per page —
+      // the same leak the deliberate teardown path fixes.
+      void this.options
+        .getAgentBrowserBridge?.()
+        ?.onTabClosed(webContentsId)
+        .catch(() => {})
       this.browserManager.unregisterGuest(page.browserPageId)
+      if (this.pages.size === 0) {
+        this.stopSweep()
+      }
     })
     const profile = page.profileId ? browserSessionRegistry.getProfile(page.profileId) : null
     this.browserManager.registerOffscreenGuest({
@@ -303,7 +351,7 @@ export class OffscreenBrowserBackend implements BrowserBackend {
       worktreeId: page.worktreeId,
       sessionProfileId: page.profileId ?? null,
       userAgentMode: profile?.userAgentMode,
-      webContentsId: win.webContents.id
+      webContentsId
     })
   }
 
@@ -312,7 +360,12 @@ export class OffscreenBrowserBackend implements BrowserBackend {
     if (!win || win.isDestroyed()) {
       return
     }
-    await loadOffscreenBrowserUrl(win, url)
+    page.loading = true
+    try {
+      await loadOffscreenBrowserUrl(win, url)
+    } finally {
+      page.loading = false
+    }
     if (page.window === win && !win.isDestroyed()) {
       page.title = win.webContents.getTitle() ?? page.title
       // Why: the reclaim clock must start when the page is ready, not when the

--- a/src/main/browser/offscreen-browser-open-pages.ts
+++ b/src/main/browser/offscreen-browser-open-pages.ts
@@ -73,6 +73,17 @@ export class OffscreenBrowserOpenPages {
     )
   }
 
+  /**
+   * Every open page's id in creation order, resident or parked. Listings order
+   * by this so a tab's position never moves because its renderer was reclaimed
+   * — an index read minutes ago must not be renumbered by a background timer.
+   */
+  openIds(worktreeId?: string): string[] {
+    return this.all()
+      .filter((page) => !worktreeId || page.worktreeId === worktreeId)
+      .map((page) => page.browserPageId)
+  }
+
   listParked(worktreeId?: string): ParkedBrowserPage[] {
     return this.parked(worktreeId).map((page) => ({
       browserPageId: page.browserPageId,
@@ -105,12 +116,36 @@ export class OffscreenBrowserOpenPages {
     return best?.browserPageId ?? null
   }
 
-  /** Only one page per worktree may carry the active flag across a park. */
+  /**
+   * Only one page per worktree may carry the active flag across a park.
+   * Strict scope: a worktree-less page clears only other worktree-less pages —
+   * an undefined filter would wipe every worktree's flag host-wide.
+   */
   claimParkedActive(browserPageId: string, worktreeId?: string): void {
-    for (const page of this.parked(worktreeId)) {
-      if (page.browserPageId !== browserPageId) {
+    for (const page of this.parked()) {
+      if (page.browserPageId !== browserPageId && page.worktreeId === worktreeId) {
         page.activeWhenParked = false
       }
     }
+  }
+
+  /**
+   * Hand the active flag to the most recently used parked page when nothing
+   * in the scope holds it. Closing the flag's holder (or the last live tab)
+   * must not leave a worktree whose every page reports inactive — a paired
+   * client assumes one selected browser tab per worktree.
+   */
+  promoteParkedActive(worktreeId?: string): void {
+    const scoped = this.parked().filter((page) => page.worktreeId === worktreeId)
+    if (scoped.length === 0 || scoped.some((page) => page.activeWhenParked)) {
+      return
+    }
+    let best = scoped[0]
+    for (const page of scoped) {
+      if (page.lastActivityAt > best.lastActivityAt) {
+        best = page
+      }
+    }
+    best.activeWhenParked = true
   }
 }

--- a/src/main/browser/offscreen-browser-open-pages.ts
+++ b/src/main/browser/offscreen-browser-open-pages.ts
@@ -1,0 +1,94 @@
+import type { BrowserWindow } from 'electron'
+import type { ParkedBrowserPage } from './browser-backend'
+
+// Why (STA-4341): a headless browser page and the renderer behind it have
+// different lifetimes — the page is open until it is closed, the renderer only
+// while something needs it. This is the book of open pages; the backend owns
+// the renderers. Keeping them apart is what makes "parked" expressible: a
+// record here with no window attached.
+
+export type OffscreenBrowserPage = {
+  browserPageId: string
+  worktreeId?: string
+  profileId?: string
+  partition: string
+  url: string
+  title: string
+  /** null while parked — the page exists, its renderer does not. */
+  window: BrowserWindow | null
+  /** Whether the page was its worktree's active tab when it parked. */
+  activeWhenParked: boolean
+  /** True while the initial or post-wake navigation is still in flight. */
+  loading: boolean
+  lastActivityAt: number
+}
+
+function isResident(page: OffscreenBrowserPage): boolean {
+  return Boolean(page.window && !page.window.isDestroyed())
+}
+
+export class OffscreenBrowserOpenPages {
+  private readonly pages = new Map<string, OffscreenBrowserPage>()
+
+  get size(): number {
+    return this.pages.size
+  }
+
+  has(browserPageId: string): boolean {
+    return this.pages.has(browserPageId)
+  }
+
+  get(browserPageId: string): OffscreenBrowserPage | undefined {
+    return this.pages.get(browserPageId)
+  }
+
+  add(page: OffscreenBrowserPage): void {
+    this.pages.set(page.browserPageId, page)
+  }
+
+  delete(browserPageId: string): OffscreenBrowserPage | undefined {
+    const page = this.pages.get(browserPageId)
+    this.pages.delete(browserPageId)
+    return page
+  }
+
+  clear(): void {
+    this.pages.clear()
+  }
+
+  all(): OffscreenBrowserPage[] {
+    return [...this.pages.values()]
+  }
+
+  resident(): OffscreenBrowserPage[] {
+    return this.all().filter(isResident)
+  }
+
+  parked(worktreeId?: string): OffscreenBrowserPage[] {
+    return this.all().filter(
+      (page) => !isResident(page) && (!worktreeId || page.worktreeId === worktreeId)
+    )
+  }
+
+  listParked(worktreeId?: string): ParkedBrowserPage[] {
+    return this.parked(worktreeId).map((page) => ({
+      browserPageId: page.browserPageId,
+      worktreeId: page.worktreeId,
+      profileId: page.profileId,
+      url: page.url,
+      title: page.title,
+      active: page.activeWhenParked
+    }))
+  }
+
+  /** Most-recently-used parked page, for commands that name a worktree. */
+  mostRecentlyUsedParkedId(worktreeId?: string): string | null {
+    let best: OffscreenBrowserPage | null = null
+    for (const page of this.parked(worktreeId)) {
+      if (!best || page.lastActivityAt > best.lastActivityAt) {
+        best = page
+      }
+    }
+    return best?.browserPageId ?? null
+  }
+}

--- a/src/main/browser/offscreen-browser-open-pages.ts
+++ b/src/main/browser/offscreen-browser-open-pages.ts
@@ -104,16 +104,22 @@ export class OffscreenBrowserOpenPages {
    * tie when none is recorded.
    */
   parkedIdForImplicitTarget(worktreeId?: string): string | null {
+    // Why MRU among the flagged: the claim is strict per scope, so a scoped
+    // query sees at most one flag — but the scope-less query spans every
+    // worktree and can see one flag per scope. Recency picks the page that
+    // actually held the most recent active claim, matching the bridge's own
+    // global-pointer semantics; creation order would pick the oldest scope.
+    let flagged: OffscreenBrowserPage | null = null
     let best: OffscreenBrowserPage | null = null
     for (const page of this.parked(worktreeId)) {
-      if (page.activeWhenParked) {
-        return page.browserPageId
+      if (page.activeWhenParked && (!flagged || page.lastActivityAt > flagged.lastActivityAt)) {
+        flagged = page
       }
       if (!best || page.lastActivityAt > best.lastActivityAt) {
         best = page
       }
     }
-    return best?.browserPageId ?? null
+    return (flagged ?? best)?.browserPageId ?? null
   }
 
   /**

--- a/src/main/browser/offscreen-browser-open-pages.ts
+++ b/src/main/browser/offscreen-browser-open-pages.ts
@@ -1,4 +1,5 @@
 import type { BrowserWindow } from 'electron'
+import type { BrowserLoadError } from '../../shared/browser-workspace-types'
 import type { ParkedBrowserPage } from './browser-backend'
 
 // Why (STA-4341): a headless browser page and the renderer behind it have
@@ -20,6 +21,8 @@ export type OffscreenBrowserPage = {
   activeWhenParked: boolean
   /** True while the initial or post-wake navigation is still in flight. */
   loading: boolean
+  /** The failure the page reported when its renderer was reclaimed. */
+  loadError: BrowserLoadError | null
   lastActivityAt: number
 }
 
@@ -77,18 +80,37 @@ export class OffscreenBrowserOpenPages {
       profileId: page.profileId,
       url: page.url,
       title: page.title,
-      active: page.activeWhenParked
+      active: page.activeWhenParked,
+      loadError: page.loadError
     }))
   }
 
-  /** Most-recently-used parked page, for commands that name a worktree. */
-  mostRecentlyUsedParkedId(worktreeId?: string): string | null {
+  /**
+   * The parked page a page-less command should target. Activity order alone is
+   * wrong: an explicit `--page B` command makes B the most recently used while
+   * A is still the active tab, and a page-less command has always meant "the
+   * active tab". So the retained active page wins, and recency only breaks the
+   * tie when none is recorded.
+   */
+  parkedIdForImplicitTarget(worktreeId?: string): string | null {
     let best: OffscreenBrowserPage | null = null
     for (const page of this.parked(worktreeId)) {
+      if (page.activeWhenParked) {
+        return page.browserPageId
+      }
       if (!best || page.lastActivityAt > best.lastActivityAt) {
         best = page
       }
     }
     return best?.browserPageId ?? null
+  }
+
+  /** Only one page per worktree may carry the active flag across a park. */
+  claimParkedActive(browserPageId: string, worktreeId?: string): void {
+    for (const page of this.parked(worktreeId)) {
+      if (page.browserPageId !== browserPageId) {
+        page.activeWhenParked = false
+      }
+    }
   }
 }

--- a/src/main/browser/offscreen-browser-page-reclaim.test.ts
+++ b/src/main/browser/offscreen-browser-page-reclaim.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  selectOffscreenBrowserPagesToClose,
   selectOffscreenBrowserPagesToPark,
   type OffscreenBrowserReclaimCandidate,
   type OffscreenBrowserReclaimPolicy
@@ -11,7 +12,8 @@ const POLICY: OffscreenBrowserReclaimPolicy = {
   residentLimit: 2,
   idleParkMs: 60_000,
   parkGraceMs: 5_000,
-  sweepIntervalMs: 1_000
+  sweepIntervalMs: 1_000,
+  retainedPageLimit: 100
 }
 
 function page(
@@ -94,5 +96,26 @@ describe('selectOffscreenBrowserPagesToPark', () => {
         idleParkMs: Number.MAX_SAFE_INTEGER
       })
     ).toEqual([])
+  })
+})
+
+describe('selectOffscreenBrowserPagesToClose', () => {
+  it('retains every parked page under the limit', () => {
+    expect(selectOffscreenBrowserPagesToClose([page('a', 1), page('b', 2)], 2, POLICY)).toEqual([])
+  })
+
+  it('closes the least recently used parked pages down to the limit', () => {
+    // Why: parking bounds renderer processes, not the records behind them.
+    const parked = [page('new', 1_000), page('old', 90_000), page('older', 99_000)]
+    expect(
+      selectOffscreenBrowserPagesToClose(parked, 5, { ...POLICY, retainedPageLimit: 3 })
+    ).toEqual(['older', 'old'])
+  })
+
+  it('never closes a pinned page', () => {
+    const parked = [page('pinned', 99_000, true), page('idle', 90_000)]
+    expect(
+      selectOffscreenBrowserPagesToClose(parked, 4, { ...POLICY, retainedPageLimit: 2 })
+    ).toEqual(['idle'])
   })
 })

--- a/src/main/browser/offscreen-browser-page-reclaim.test.ts
+++ b/src/main/browser/offscreen-browser-page-reclaim.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+import {
+  selectOffscreenBrowserPagesToPark,
+  type OffscreenBrowserReclaimCandidate,
+  type OffscreenBrowserReclaimPolicy
+} from './offscreen-browser-page-reclaim'
+
+const NOW = 1_000_000
+
+const POLICY: OffscreenBrowserReclaimPolicy = {
+  residentLimit: 2,
+  idleParkMs: 60_000,
+  parkGraceMs: 5_000,
+  sweepIntervalMs: 1_000
+}
+
+function page(
+  browserPageId: string,
+  idleMs: number,
+  pinned = false
+): OffscreenBrowserReclaimCandidate {
+  return { browserPageId, lastActivityAt: NOW - idleMs, pinned }
+}
+
+describe('selectOffscreenBrowserPagesToPark', () => {
+  it('keeps everything resident while the working set fits under the cap', () => {
+    expect(
+      selectOffscreenBrowserPagesToPark([page('a', 10_000), page('b', 20_000)], NOW, POLICY)
+    ).toEqual([])
+  })
+
+  it('parks the least recently used pages down to the cap', () => {
+    const parked = selectOffscreenBrowserPagesToPark(
+      [page('newest', 6_000), page('oldest', 40_000), page('middle', 20_000)],
+      NOW,
+      POLICY
+    )
+    expect(parked).toEqual(['oldest'])
+  })
+
+  it('parks an idle page even when the working set fits under the cap', () => {
+    expect(
+      selectOffscreenBrowserPagesToPark([page('a', 10_000), page('stale', 90_000)], NOW, POLICY)
+    ).toEqual(['stale'])
+  })
+
+  it('never parks a page inside the grace window, even over the cap', () => {
+    // Why: a page touched moments ago is the one an agent is mid-workflow on.
+    const parked = selectOffscreenBrowserPagesToPark(
+      [page('a', 100), page('b', 200), page('c', 300), page('d', 400)],
+      NOW,
+      POLICY
+    )
+    expect(parked).toEqual([])
+  })
+
+  it('never parks a pinned page and lets it push the cap', () => {
+    const parked = selectOffscreenBrowserPagesToPark(
+      [
+        page('streamed', 200_000, true),
+        page('alsoStreamed', 300_000, true),
+        page('idle', 40_000),
+        page('idler', 50_000)
+      ],
+      NOW,
+      POLICY
+    )
+    // Two pinned pages already fill the cap, so both evictable pages go.
+    expect(parked.sort()).toEqual(['idle', 'idler'])
+  })
+
+  it('counts pinned pages against the cap without evicting them', () => {
+    const parked = selectOffscreenBrowserPagesToPark(
+      [page('pinned', 200_000, true), page('a', 10_000), page('b', 20_000)],
+      NOW,
+      POLICY
+    )
+    expect(parked).toEqual(['b'])
+  })
+
+  it('is deterministic when two pages share a last-activity stamp', () => {
+    const candidates = [page('zebra', 30_000), page('apple', 30_000), page('mango', 1_000)]
+    const first = selectOffscreenBrowserPagesToPark(candidates, NOW, POLICY)
+    const second = selectOffscreenBrowserPagesToPark(candidates.toReversed(), NOW, POLICY)
+    expect(first).toEqual(['apple'])
+    expect(second).toEqual(first)
+  })
+
+  it('parks nothing when the policy disables both evictors', () => {
+    expect(
+      selectOffscreenBrowserPagesToPark([page('a', 10_000_000), page('b', 10_000_000)], NOW, {
+        ...POLICY,
+        residentLimit: Number.MAX_SAFE_INTEGER,
+        idleParkMs: Number.MAX_SAFE_INTEGER
+      })
+    ).toEqual([])
+  })
+})

--- a/src/main/browser/offscreen-browser-page-reclaim.test.ts
+++ b/src/main/browser/offscreen-browser-page-reclaim.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest'
 import {
-  selectOffscreenBrowserPagesToClose,
   selectOffscreenBrowserPagesToPark,
   type OffscreenBrowserReclaimCandidate,
   type OffscreenBrowserReclaimPolicy
@@ -12,8 +11,7 @@ const POLICY: OffscreenBrowserReclaimPolicy = {
   residentLimit: 2,
   idleParkMs: 60_000,
   parkGraceMs: 5_000,
-  sweepIntervalMs: 1_000,
-  retainedPageLimit: 100
+  sweepIntervalMs: 1_000
 }
 
 function page(
@@ -96,26 +94,5 @@ describe('selectOffscreenBrowserPagesToPark', () => {
         idleParkMs: Number.MAX_SAFE_INTEGER
       })
     ).toEqual([])
-  })
-})
-
-describe('selectOffscreenBrowserPagesToClose', () => {
-  it('retains every parked page under the limit', () => {
-    expect(selectOffscreenBrowserPagesToClose([page('a', 1), page('b', 2)], 2, POLICY)).toEqual([])
-  })
-
-  it('closes the least recently used parked pages down to the limit', () => {
-    // Why: parking bounds renderer processes, not the records behind them.
-    const parked = [page('new', 1_000), page('old', 90_000), page('older', 99_000)]
-    expect(
-      selectOffscreenBrowserPagesToClose(parked, 5, { ...POLICY, retainedPageLimit: 3 })
-    ).toEqual(['older', 'old'])
-  })
-
-  it('never closes a pinned page', () => {
-    const parked = [page('pinned', 99_000, true), page('idle', 90_000)]
-    expect(
-      selectOffscreenBrowserPagesToClose(parked, 4, { ...POLICY, retainedPageLimit: 2 })
-    ).toEqual(['idle'])
   })
 })

--- a/src/main/browser/offscreen-browser-page-reclaim.test.ts
+++ b/src/main/browser/offscreen-browser-page-reclaim.test.ts
@@ -73,6 +73,18 @@ describe('readOffscreenBrowserRetentionBudget', () => {
     process.env.ORCA_HEADLESS_BROWSER_RESIDENT_LIMIT = 'lots'
     expect(readOffscreenBrowserRetentionBudget().limit).toBe(OFFSCREEN_BROWSER_RESIDENT_LIMIT)
   })
+
+  it('reads scientific notation whole, not truncated to its mantissa', () => {
+    // Why: parseInt('1e9') is 1 — an operator following the docs' "set the
+    // idle window very high" advice would get a 1ms window instead.
+    process.env.ORCA_HEADLESS_BROWSER_PARK_IDLE_MS = '1e9'
+    expect(readOffscreenBrowserRetentionBudget().idleMs).toBe(1_000_000_000)
+  })
+
+  it('falls back on trailing garbage instead of truncating it', () => {
+    process.env.ORCA_HEADLESS_BROWSER_PARK_IDLE_MS = '1234abc'
+    expect(readOffscreenBrowserRetentionBudget().idleMs).toBe(OFFSCREEN_BROWSER_IDLE_PARK_MS)
+  })
 })
 
 describe('nextOffscreenBrowserReclaimCheckAt', () => {

--- a/src/main/browser/offscreen-browser-page-reclaim.test.ts
+++ b/src/main/browser/offscreen-browser-page-reclaim.test.ts
@@ -1,98 +1,161 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import {
-  selectOffscreenBrowserPagesToPark,
-  type OffscreenBrowserReclaimCandidate,
-  type OffscreenBrowserReclaimPolicy
+  selectBrowserRetentionEvictions,
+  type BrowserRetentionBudget,
+  type BrowserRetentionCandidate
+} from '../../shared/browser-retention-budget'
+import {
+  nextOffscreenBrowserReclaimCheckAt,
+  readOffscreenBrowserRetentionBudget,
+  OFFSCREEN_BROWSER_IDLE_PARK_MS,
+  OFFSCREEN_BROWSER_PARK_GRACE_MS,
+  OFFSCREEN_BROWSER_PINNED_RECHECK_MS,
+  OFFSCREEN_BROWSER_RESIDENT_LIMIT
 } from './offscreen-browser-page-reclaim'
 
 const NOW = 1_000_000
-
-const POLICY: OffscreenBrowserReclaimPolicy = {
-  residentLimit: 2,
-  idleParkMs: 60_000,
-  parkGraceMs: 5_000,
-  sweepIntervalMs: 1_000
+const BUDGET: BrowserRetentionBudget = {
+  limit: 2,
+  idleMs: 60_000,
+  graceMs: 5_000
 }
 
-function page(
-  browserPageId: string,
-  idleMs: number,
-  pinned = false
-): OffscreenBrowserReclaimCandidate {
-  return { browserPageId, lastActivityAt: NOW - idleMs, pinned }
+function used(id: string, msAgo: number): BrowserRetentionCandidate {
+  return { id, lastActivityAt: NOW - msAgo }
 }
 
-describe('selectOffscreenBrowserPagesToPark', () => {
-  it('keeps everything resident while the working set fits under the cap', () => {
+function nextCheck(
+  candidates: readonly BrowserRetentionCandidate[],
+  pinned: readonly string[] = [],
+  now = NOW,
+  budget = BUDGET
+): number | null {
+  return nextOffscreenBrowserReclaimCheckAt({
+    candidates,
+    isPinned: (id) => pinned.includes(id),
+    now,
+    budget
+  })
+}
+
+describe('readOffscreenBrowserRetentionBudget', () => {
+  const KEYS = [
+    'ORCA_HEADLESS_BROWSER_RESIDENT_LIMIT',
+    'ORCA_HEADLESS_BROWSER_PARK_IDLE_MS',
+    'ORCA_HEADLESS_BROWSER_PARK_GRACE_MS'
+  ]
+  afterEach(() => {
+    for (const key of KEYS) {
+      delete process.env[key]
+    }
+  })
+
+  it('defaults to the shipped policy', () => {
+    expect(readOffscreenBrowserRetentionBudget()).toEqual({
+      limit: OFFSCREEN_BROWSER_RESIDENT_LIMIT,
+      idleMs: OFFSCREEN_BROWSER_IDLE_PARK_MS,
+      graceMs: OFFSCREEN_BROWSER_PARK_GRACE_MS
+    })
+  })
+
+  it('reads each knob from the environment', () => {
+    process.env.ORCA_HEADLESS_BROWSER_RESIDENT_LIMIT = '7'
+    process.env.ORCA_HEADLESS_BROWSER_PARK_IDLE_MS = '1234'
+    process.env.ORCA_HEADLESS_BROWSER_PARK_GRACE_MS = '56'
+    expect(readOffscreenBrowserRetentionBudget()).toEqual({
+      limit: 7,
+      idleMs: 1234,
+      graceMs: 56
+    })
+  })
+
+  it('ignores a malformed knob rather than disabling the budget', () => {
+    process.env.ORCA_HEADLESS_BROWSER_RESIDENT_LIMIT = 'lots'
+    expect(readOffscreenBrowserRetentionBudget().limit).toBe(OFFSCREEN_BROWSER_RESIDENT_LIMIT)
+  })
+})
+
+describe('nextOffscreenBrowserReclaimCheckAt', () => {
+  it('arms nothing when there is nothing resident', () => {
+    expect(nextCheck([])).toBeNull()
+  })
+
+  it('waits out the idle window for a page within the limit', () => {
+    expect(nextCheck([used('a', 10_000)])).toBe(NOW - 10_000 + BUDGET.idleMs)
+  })
+
+  it('waits only out the grace floor for a page beyond the limit', () => {
+    const candidates = [used('a', 1_000), used('b', 2_000), used('over', 3_000)]
+    expect(nextCheck(candidates)).toBe(NOW - 3_000 + BUDGET.graceMs)
+  })
+
+  it('takes the earliest deadline across pages', () => {
+    const candidates = [used('a', 1_000), used('b', 59_000)]
+    expect(nextCheck(candidates)).toBe(NOW - 59_000 + BUDGET.idleMs)
+  })
+
+  it('re-asks on a bounded cadence for a pinned page whose release it cannot observe', () => {
+    expect(nextCheck([used('a', 90_000)], ['a'])).toBe(NOW + OFFSCREEN_BROWSER_PINNED_RECHECK_MS)
+  })
+
+  it('arms nothing when a page can never age out', () => {
+    // A single page within a limit that no clock rule can evict.
     expect(
-      selectOffscreenBrowserPagesToPark([page('a', 10_000), page('b', 20_000)], NOW, POLICY)
-    ).toEqual([])
-  })
-
-  it('parks the least recently used pages down to the cap', () => {
-    const parked = selectOffscreenBrowserPagesToPark(
-      [page('newest', 6_000), page('oldest', 40_000), page('middle', 20_000)],
-      NOW,
-      POLICY
-    )
-    expect(parked).toEqual(['oldest'])
-  })
-
-  it('parks an idle page even when the working set fits under the cap', () => {
-    expect(
-      selectOffscreenBrowserPagesToPark([page('a', 10_000), page('stale', 90_000)], NOW, POLICY)
-    ).toEqual(['stale'])
-  })
-
-  it('never parks a page inside the grace window, even over the cap', () => {
-    // Why: a page touched moments ago is the one an agent is mid-workflow on.
-    const parked = selectOffscreenBrowserPagesToPark(
-      [page('a', 100), page('b', 200), page('c', 300), page('d', 400)],
-      NOW,
-      POLICY
-    )
-    expect(parked).toEqual([])
-  })
-
-  it('never parks a pinned page and lets it push the cap', () => {
-    const parked = selectOffscreenBrowserPagesToPark(
-      [
-        page('streamed', 200_000, true),
-        page('alsoStreamed', 300_000, true),
-        page('idle', 40_000),
-        page('idler', 50_000)
-      ],
-      NOW,
-      POLICY
-    )
-    // Two pinned pages already fill the cap, so both evictable pages go.
-    expect(parked.sort()).toEqual(['idle', 'idler'])
-  })
-
-  it('counts pinned pages against the cap without evicting them', () => {
-    const parked = selectOffscreenBrowserPagesToPark(
-      [page('pinned', 200_000, true), page('a', 10_000), page('b', 20_000)],
-      NOW,
-      POLICY
-    )
-    expect(parked).toEqual(['b'])
-  })
-
-  it('is deterministic when two pages share a last-activity stamp', () => {
-    const candidates = [page('zebra', 30_000), page('apple', 30_000), page('mango', 1_000)]
-    const first = selectOffscreenBrowserPagesToPark(candidates, NOW, POLICY)
-    const second = selectOffscreenBrowserPagesToPark(candidates.toReversed(), NOW, POLICY)
-    expect(first).toEqual(['apple'])
-    expect(second).toEqual(first)
-  })
-
-  it('parks nothing when the policy disables both evictors', () => {
-    expect(
-      selectOffscreenBrowserPagesToPark([page('a', 10_000_000), page('b', 10_000_000)], NOW, {
-        ...POLICY,
-        residentLimit: Number.MAX_SAFE_INTEGER,
-        idleParkMs: Number.MAX_SAFE_INTEGER
+      nextCheck([used('a', 10)], [], NOW, {
+        ...BUDGET,
+        idleMs: Number.POSITIVE_INFINITY
       })
-    ).toEqual([])
+    ).toBeNull()
+  })
+
+  it('returns a past deadline when a page is already evictable', () => {
+    expect(nextCheck([used('a', 90_000)])).toBeLessThanOrEqual(NOW)
+  })
+})
+
+describe('the deadline never sleeps through an eviction', () => {
+  // Why: the timer replaced a fixed sweep, so a deadline that lands after a page
+  // becomes evictable would silently leak exactly the renderers this reclaims.
+  // Fuzzed deterministically: no state may become evictable before its deadline.
+  it('holds across randomised resident sets', () => {
+    let seed = 42
+    const random = (bound: number): number => {
+      seed = (seed * 1_103_515_245 + 12_345) % 2_147_483_648
+      return seed % bound
+    }
+    for (let trial = 0; trial < 500; trial++) {
+      const size = random(6)
+      const candidates: BrowserRetentionCandidate[] = []
+      for (let index = 0; index < size; index++) {
+        // Why the mix: uniform ages almost never land inside the grace floor,
+        // which is exactly the boundary a wrong deadline overshoots.
+        const msAgo = random(2) === 0 ? random(2 * BUDGET.graceMs) : random(200_000)
+        candidates.push(used(`p${index}`, msAgo))
+      }
+      candidates.sort((left, right) => (right.lastActivityAt ?? 0) - (left.lastActivityAt ?? 0))
+      const pinned = candidates.filter(() => random(4) === 0).map((candidate) => candidate.id)
+      const isPinned = (id: string): boolean => pinned.includes(id)
+      const evictableNow = selectBrowserRetentionEvictions({
+        candidates,
+        isPinned,
+        now: NOW,
+        budget: BUDGET
+      })
+      if (evictableNow.length > 0) {
+        continue
+      }
+      const deadline = nextCheck(candidates, pinned)
+      const horizon = deadline === null ? NOW + 10 * BUDGET.idleMs : deadline
+      for (let at = NOW; at < horizon; at += Math.max(1, Math.floor((horizon - NOW) / 20))) {
+        expect(
+          selectBrowserRetentionEvictions({
+            candidates,
+            isPinned,
+            now: at,
+            budget: BUDGET
+          })
+        ).toEqual([])
+      }
+    }
   })
 })

--- a/src/main/browser/offscreen-browser-page-reclaim.test.ts
+++ b/src/main/browser/offscreen-browser-page-reclaim.test.ts
@@ -85,6 +85,13 @@ describe('readOffscreenBrowserRetentionBudget', () => {
     process.env.ORCA_HEADLESS_BROWSER_PARK_IDLE_MS = '1234abc'
     expect(readOffscreenBrowserRetentionBudget().idleMs).toBe(OFFSCREEN_BROWSER_IDLE_PARK_MS)
   })
+
+  it('treats blank as unset, not as a zero window', () => {
+    // Why: Number('') and Number('   ') are 0 — a blank knob must not silently
+    // configure instant parking.
+    process.env.ORCA_HEADLESS_BROWSER_PARK_IDLE_MS = '   '
+    expect(readOffscreenBrowserRetentionBudget().idleMs).toBe(OFFSCREEN_BROWSER_IDLE_PARK_MS)
+  })
 })
 
 describe('nextOffscreenBrowserReclaimCheckAt', () => {

--- a/src/main/browser/offscreen-browser-page-reclaim.ts
+++ b/src/main/browser/offscreen-browser-page-reclaim.ts
@@ -18,6 +18,13 @@ export const OFFSCREEN_BROWSER_PARK_GRACE_MS = 30_000
 export const OFFSCREEN_BROWSER_SWEEP_INTERVAL_MS = 15_000
 /** Parked page records retained before the oldest are closed outright. */
 export const OFFSCREEN_BROWSER_RETAINED_PAGE_LIMIT = 100
+/**
+ * How long a download keeps its page resident after its last progress. Parking
+ * cancels a page's in-flight downloads, so an advancing one must veto — but a
+ * download that stalls forever must not, or one stalled download per page would
+ * defeat the resident cap outright.
+ */
+export const OFFSCREEN_BROWSER_DOWNLOAD_VETO_MS = 60_000
 
 export type OffscreenBrowserReclaimPolicy = {
   residentLimit: number

--- a/src/main/browser/offscreen-browser-page-reclaim.ts
+++ b/src/main/browser/offscreen-browser-page-reclaim.ts
@@ -16,22 +16,12 @@ export const OFFSCREEN_BROWSER_PARK_GRACE_MS = 30_000
 
 /** How often the backend re-evaluates which pages should be resident. */
 export const OFFSCREEN_BROWSER_SWEEP_INTERVAL_MS = 15_000
-/** Parked page records retained before the oldest are closed outright. */
-export const OFFSCREEN_BROWSER_RETAINED_PAGE_LIMIT = 100
-/**
- * How long a download keeps its page resident after its last progress. Parking
- * cancels a page's in-flight downloads, so an advancing one must veto — but a
- * download that stalls forever must not, or one stalled download per page would
- * defeat the resident cap outright.
- */
-export const OFFSCREEN_BROWSER_DOWNLOAD_VETO_MS = 60_000
 
 export type OffscreenBrowserReclaimPolicy = {
   residentLimit: number
   idleParkMs: number
   parkGraceMs: number
   sweepIntervalMs: number
-  retainedPageLimit: number
 }
 
 export type OffscreenBrowserReclaimCandidate = {
@@ -67,13 +57,6 @@ export function readOffscreenBrowserReclaimPolicy(): OffscreenBrowserReclaimPoli
     sweepIntervalMs: Math.max(
       100,
       readPositiveIntEnv('ORCA_HEADLESS_BROWSER_PARK_SWEEP_MS', OFFSCREEN_BROWSER_SWEEP_INTERVAL_MS)
-    ),
-    retainedPageLimit: Math.max(
-      1,
-      readPositiveIntEnv(
-        'ORCA_HEADLESS_BROWSER_MAX_RETAINED_PAGES',
-        OFFSCREEN_BROWSER_RETAINED_PAGE_LIMIT
-      )
     )
   }
 }
@@ -122,31 +105,4 @@ export function selectOffscreenBrowserPagesToPark(
   }
 
   return parkable.map((page) => page.browserPageId).filter((id) => parked.has(id))
-}
-
-/**
- * Pick parked pages to close outright. Parking bounds renderer processes but
- * not the records behind them, so an agent that opens pages forever and closes
- * none would still grow the backend without limit. Only parked pages are
- * eligible and only the least recently used go, so this can never take a page
- * an agent is still working with.
- */
-export function selectOffscreenBrowserPagesToClose(
-  parkedPages: readonly OffscreenBrowserReclaimCandidate[],
-  totalPageCount: number,
-  policy: OffscreenBrowserReclaimPolicy
-): string[] {
-  const excess = totalPageCount - policy.retainedPageLimit
-  if (excess <= 0) {
-    return []
-  }
-  return parkedPages
-    .filter((page) => !page.pinned)
-    .sort(
-      (left, right) =>
-        left.lastActivityAt - right.lastActivityAt ||
-        left.browserPageId.localeCompare(right.browserPageId)
-    )
-    .slice(0, excess)
-    .map((page) => page.browserPageId)
 }

--- a/src/main/browser/offscreen-browser-page-reclaim.ts
+++ b/src/main/browser/offscreen-browser-page-reclaim.ts
@@ -1,0 +1,108 @@
+// Why (STA-4341): on a headless `orca serve` host every agent-opened browser
+// page is backed by its own hidden BrowserWindow, i.e. its own renderer
+// process. Nothing owned those renderers, so a long agent session accumulated
+// them until the host saturated. This module is the policy half of that owner:
+// given the resident pages it decides which ones to park (drop the renderer,
+// keep the page). It mirrors terminal hidden-view parking — the cap is the
+// primary evictor, the idle clock is the tail — and is pure so the decision is
+// testable without Electron.
+
+/** Resident renderers kept warm. Matches TERMINAL_WORKTREE_HOT_RETAIN_LIMIT. */
+export const OFFSCREEN_BROWSER_RESIDENT_LIMIT = 4
+/** An untouched page parks once idle this long, even under the cap. */
+export const OFFSCREEN_BROWSER_IDLE_PARK_MS = 5 * 60_000
+/** A page is never parked before this much time without a command. */
+export const OFFSCREEN_BROWSER_PARK_GRACE_MS = 30_000
+
+/** How often the backend re-evaluates which pages should be resident. */
+export const OFFSCREEN_BROWSER_SWEEP_INTERVAL_MS = 15_000
+
+export type OffscreenBrowserReclaimPolicy = {
+  residentLimit: number
+  idleParkMs: number
+  parkGraceMs: number
+  sweepIntervalMs: number
+}
+
+export type OffscreenBrowserReclaimCandidate = {
+  browserPageId: string
+  lastActivityAt: number
+  /** Never parked: a client is streaming it, or a command is in flight. */
+  pinned: boolean
+}
+
+function readPositiveIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name]
+  if (raw === undefined) {
+    return fallback
+  }
+  const parsed = Number.parseInt(raw, 10)
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : fallback
+}
+
+export function readOffscreenBrowserReclaimPolicy(): OffscreenBrowserReclaimPolicy {
+  return {
+    residentLimit: readPositiveIntEnv(
+      'ORCA_HEADLESS_BROWSER_RESIDENT_LIMIT',
+      OFFSCREEN_BROWSER_RESIDENT_LIMIT
+    ),
+    idleParkMs: readPositiveIntEnv(
+      'ORCA_HEADLESS_BROWSER_PARK_IDLE_MS',
+      OFFSCREEN_BROWSER_IDLE_PARK_MS
+    ),
+    parkGraceMs: readPositiveIntEnv(
+      'ORCA_HEADLESS_BROWSER_PARK_GRACE_MS',
+      OFFSCREEN_BROWSER_PARK_GRACE_MS
+    ),
+    sweepIntervalMs: Math.max(
+      100,
+      readPositiveIntEnv('ORCA_HEADLESS_BROWSER_PARK_SWEEP_MS', OFFSCREEN_BROWSER_SWEEP_INTERVAL_MS)
+    )
+  }
+}
+
+/**
+ * Pick the resident pages to park, least-recently-used first.
+ *
+ * Pinned pages are never returned, so the resident cap can be exceeded by
+ * pages a client is actively watching — bounding those would break the
+ * legitimate browser work the cap exists to protect.
+ */
+export function selectOffscreenBrowserPagesToPark(
+  residentPages: readonly OffscreenBrowserReclaimCandidate[],
+  now: number,
+  policy: OffscreenBrowserReclaimPolicy
+): string[] {
+  // Why: a page used moments ago is the one an agent is mid-workflow on; the
+  // grace floor applies to eviction by cap as well as by clock.
+  const parkable = residentPages
+    .filter((page) => !page.pinned && now - page.lastActivityAt >= policy.parkGraceMs)
+    .sort(
+      (left, right) =>
+        left.lastActivityAt - right.lastActivityAt ||
+        left.browserPageId.localeCompare(right.browserPageId)
+    )
+
+  const parked = new Set<string>()
+  for (const page of parkable) {
+    if (now - page.lastActivityAt >= policy.idleParkMs) {
+      parked.add(page.browserPageId)
+    }
+  }
+
+  // Why: the cap counts every resident page, pinned ones included — the budget
+  // is renderer processes on the host, not just the evictable ones.
+  let resident = residentPages.length - parked.size
+  for (const page of parkable) {
+    if (resident <= policy.residentLimit) {
+      break
+    }
+    if (parked.has(page.browserPageId)) {
+      continue
+    }
+    parked.add(page.browserPageId)
+    resident--
+  }
+
+  return parkable.map((page) => page.browserPageId).filter((id) => parked.has(id))
+}

--- a/src/main/browser/offscreen-browser-page-reclaim.ts
+++ b/src/main/browser/offscreen-browser-page-reclaim.ts
@@ -36,7 +36,13 @@ function readPositiveIntEnv(name: string, fallback: number): number {
   // Number() consumes the whole string, so '1e9' parses fully and trailing
   // garbage falls back instead of truncating.
   const parsed = Number(raw)
-  return Number.isInteger(parsed) && parsed >= 0 ? parsed : fallback
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    // Why the warning: parseInt used to truncate '60000ms' to 60000; falling
+    // back silently would change such a knob's behavior with no signal.
+    console.warn(`[offscreen-browser] ignoring invalid ${name}=${raw}`)
+    return fallback
+  }
+  return parsed
 }
 
 export function readOffscreenBrowserRetentionBudget(): BrowserRetentionBudget {

--- a/src/main/browser/offscreen-browser-page-reclaim.ts
+++ b/src/main/browser/offscreen-browser-page-reclaim.ts
@@ -1,35 +1,30 @@
+import {
+  BROWSER_RETENTION_LIMIT,
+  type BrowserRetentionBudget,
+  type BrowserRetentionCandidate
+} from '../../shared/browser-retention-budget'
+
 // Why (STA-4341): on a headless `orca serve` host every agent-opened browser
 // page is backed by its own hidden BrowserWindow, i.e. its own renderer
 // process. Nothing owned those renderers, so a long agent session accumulated
-// them until the host saturated. This module is the policy half of that owner:
-// given the resident pages it decides which ones to park (drop the renderer,
-// keep the page). It mirrors terminal hidden-view parking — the cap is the
-// primary evictor, the idle clock is the tail — and is pure so the decision is
-// testable without Electron.
+// them until the host saturated. This module configures the shared browser
+// retention budget for that host and answers when the decision could next
+// change — a headless host has no visibility event to react to, so it has to
+// know its own deadlines.
 
-/** Resident renderers kept warm. Matches TERMINAL_WORKTREE_HOT_RETAIN_LIMIT. */
-export const OFFSCREEN_BROWSER_RESIDENT_LIMIT = 4
-/** An untouched page parks once idle this long, even under the cap. */
+/** Resident renderers kept warm. The desktop guest budget uses the same 4. */
+export const OFFSCREEN_BROWSER_RESIDENT_LIMIT = BROWSER_RETENTION_LIMIT
+/** An untouched page parks once idle this long, even under the limit. */
 export const OFFSCREEN_BROWSER_IDLE_PARK_MS = 5 * 60_000
 /** A page is never parked before this much time without a command. */
 export const OFFSCREEN_BROWSER_PARK_GRACE_MS = 30_000
 
-/** How often the backend re-evaluates which pages should be resident. */
-export const OFFSCREEN_BROWSER_SWEEP_INTERVAL_MS = 15_000
-
-export type OffscreenBrowserReclaimPolicy = {
-  residentLimit: number
-  idleParkMs: number
-  parkGraceMs: number
-  sweepIntervalMs: number
-}
-
-export type OffscreenBrowserReclaimCandidate = {
-  browserPageId: string
-  lastActivityAt: number
-  /** Never parked: a client is streaming it, or a command is in flight. */
-  pinned: boolean
-}
+// Why a re-check at all: a page pinned by a download, a streamed client or a
+// certificate prompt releases that pin with no event this backend observes, so
+// its deadline is unknowable. Re-asking on the grace cadence is bounded, runs
+// only while something is genuinely in flight, and stops with the last pin —
+// unlike a fixed sweep, which ran forever on a host doing nothing.
+export const OFFSCREEN_BROWSER_PINNED_RECHECK_MS = OFFSCREEN_BROWSER_PARK_GRACE_MS
 
 function readPositiveIntEnv(name: string, fallback: number): number {
   const raw = process.env[name]
@@ -40,69 +35,60 @@ function readPositiveIntEnv(name: string, fallback: number): number {
   return Number.isInteger(parsed) && parsed >= 0 ? parsed : fallback
 }
 
-export function readOffscreenBrowserReclaimPolicy(): OffscreenBrowserReclaimPolicy {
+export function readOffscreenBrowserRetentionBudget(): BrowserRetentionBudget {
   return {
-    residentLimit: readPositiveIntEnv(
+    limit: readPositiveIntEnv(
       'ORCA_HEADLESS_BROWSER_RESIDENT_LIMIT',
       OFFSCREEN_BROWSER_RESIDENT_LIMIT
     ),
-    idleParkMs: readPositiveIntEnv(
+    idleMs: readPositiveIntEnv(
       'ORCA_HEADLESS_BROWSER_PARK_IDLE_MS',
       OFFSCREEN_BROWSER_IDLE_PARK_MS
     ),
-    parkGraceMs: readPositiveIntEnv(
+    graceMs: readPositiveIntEnv(
       'ORCA_HEADLESS_BROWSER_PARK_GRACE_MS',
       OFFSCREEN_BROWSER_PARK_GRACE_MS
-    ),
-    sweepIntervalMs: Math.max(
-      100,
-      readPositiveIntEnv('ORCA_HEADLESS_BROWSER_PARK_SWEEP_MS', OFFSCREEN_BROWSER_SWEEP_INTERVAL_MS)
     )
   }
 }
 
 /**
- * Pick the resident pages to park, least-recently-used first.
+ * The earliest time selectBrowserRetentionEvictions could return something new
+ * if nothing else happens, or null if only an event can change the answer.
  *
- * Pinned pages are never returned, so the resident cap can be exceeded by
- * pages a client is actively watching — bounding those would break the
- * legitimate browser work the cap exists to protect.
+ * Rank changes only when a page is created, woken or closed, and every one of
+ * those already re-arms the timer — so the clock only has to cover the idle and
+ * grace windows.
  */
-export function selectOffscreenBrowserPagesToPark(
-  residentPages: readonly OffscreenBrowserReclaimCandidate[],
-  now: number,
-  policy: OffscreenBrowserReclaimPolicy
-): string[] {
-  // Why: a page used moments ago is the one an agent is mid-workflow on; the
-  // grace floor applies to eviction by cap as well as by clock.
-  const parkable = residentPages
-    .filter((page) => !page.pinned && now - page.lastActivityAt >= policy.parkGraceMs)
-    .sort(
-      (left, right) =>
-        left.lastActivityAt - right.lastActivityAt ||
-        left.browserPageId.localeCompare(right.browserPageId)
-    )
-
-  const parked = new Set<string>()
-  for (const page of parkable) {
-    if (now - page.lastActivityAt >= policy.idleParkMs) {
-      parked.add(page.browserPageId)
+export function nextOffscreenBrowserReclaimCheckAt(args: {
+  /** Most-recently-used first, matching the selector's ranking. */
+  candidates: readonly BrowserRetentionCandidate[]
+  isPinned: (id: string) => boolean
+  now: number
+  budget: BrowserRetentionBudget
+}): number | null {
+  let next: number | null = null
+  const consider = (at: number): void => {
+    if (!Number.isFinite(at)) {
+      return
     }
+    next = next === null ? at : Math.min(next, at)
   }
-
-  // Why: the cap counts every resident page, pinned ones included — the budget
-  // is renderer processes on the host, not just the evictable ones.
-  let resident = residentPages.length - parked.size
-  for (const page of parkable) {
-    if (resident <= policy.residentLimit) {
-      break
+  args.candidates.forEach((candidate, rank) => {
+    if (args.isPinned(candidate.id)) {
+      consider(args.now + OFFSCREEN_BROWSER_PINNED_RECHECK_MS)
+      return
     }
-    if (parked.has(page.browserPageId)) {
-      continue
+    if (candidate.lastActivityAt === undefined) {
+      return
     }
-    parked.add(page.browserPageId)
-    resident--
-  }
-
-  return parkable.map((page) => page.browserPageId).filter((id) => parked.has(id))
+    if (rank >= args.budget.limit) {
+      // Grace is the only thing still holding it resident.
+      consider(candidate.lastActivityAt + args.budget.graceMs)
+      return
+    }
+    // Within the limit only the idle window can evict it, and grace still applies.
+    consider(candidate.lastActivityAt + Math.max(args.budget.graceMs, args.budget.idleMs))
+  })
+  return next
 }

--- a/src/main/browser/offscreen-browser-page-reclaim.ts
+++ b/src/main/browser/offscreen-browser-page-reclaim.ts
@@ -16,12 +16,15 @@ export const OFFSCREEN_BROWSER_PARK_GRACE_MS = 30_000
 
 /** How often the backend re-evaluates which pages should be resident. */
 export const OFFSCREEN_BROWSER_SWEEP_INTERVAL_MS = 15_000
+/** Parked page records retained before the oldest are closed outright. */
+export const OFFSCREEN_BROWSER_RETAINED_PAGE_LIMIT = 100
 
 export type OffscreenBrowserReclaimPolicy = {
   residentLimit: number
   idleParkMs: number
   parkGraceMs: number
   sweepIntervalMs: number
+  retainedPageLimit: number
 }
 
 export type OffscreenBrowserReclaimCandidate = {
@@ -57,6 +60,13 @@ export function readOffscreenBrowserReclaimPolicy(): OffscreenBrowserReclaimPoli
     sweepIntervalMs: Math.max(
       100,
       readPositiveIntEnv('ORCA_HEADLESS_BROWSER_PARK_SWEEP_MS', OFFSCREEN_BROWSER_SWEEP_INTERVAL_MS)
+    ),
+    retainedPageLimit: Math.max(
+      1,
+      readPositiveIntEnv(
+        'ORCA_HEADLESS_BROWSER_MAX_RETAINED_PAGES',
+        OFFSCREEN_BROWSER_RETAINED_PAGE_LIMIT
+      )
     )
   }
 }
@@ -105,4 +115,31 @@ export function selectOffscreenBrowserPagesToPark(
   }
 
   return parkable.map((page) => page.browserPageId).filter((id) => parked.has(id))
+}
+
+/**
+ * Pick parked pages to close outright. Parking bounds renderer processes but
+ * not the records behind them, so an agent that opens pages forever and closes
+ * none would still grow the backend without limit. Only parked pages are
+ * eligible and only the least recently used go, so this can never take a page
+ * an agent is still working with.
+ */
+export function selectOffscreenBrowserPagesToClose(
+  parkedPages: readonly OffscreenBrowserReclaimCandidate[],
+  totalPageCount: number,
+  policy: OffscreenBrowserReclaimPolicy
+): string[] {
+  const excess = totalPageCount - policy.retainedPageLimit
+  if (excess <= 0) {
+    return []
+  }
+  return parkedPages
+    .filter((page) => !page.pinned)
+    .sort(
+      (left, right) =>
+        left.lastActivityAt - right.lastActivityAt ||
+        left.browserPageId.localeCompare(right.browserPageId)
+    )
+    .slice(0, excess)
+    .map((page) => page.browserPageId)
 }

--- a/src/main/browser/offscreen-browser-page-reclaim.ts
+++ b/src/main/browser/offscreen-browser-page-reclaim.ts
@@ -28,10 +28,14 @@ export const OFFSCREEN_BROWSER_PINNED_RECHECK_MS = OFFSCREEN_BROWSER_PARK_GRACE_
 
 function readPositiveIntEnv(name: string, fallback: number): number {
   const raw = process.env[name]
-  if (raw === undefined) {
+  if (raw === undefined || raw.trim() === '') {
     return fallback
   }
-  const parsed = Number.parseInt(raw, 10)
+  // Why Number, not parseInt: parseInt('1e9') is 1, silently turning the
+  // documented "set the idle window very high" advice into a 1ms window.
+  // Number() consumes the whole string, so '1e9' parses fully and trailing
+  // garbage falls back instead of truncating.
+  const parsed = Number(raw)
   return Number.isInteger(parsed) && parsed >= 0 ? parsed : fallback
 }
 

--- a/src/main/browser/offscreen-browser-page-reclaimer-scheduling.test.ts
+++ b/src/main/browser/offscreen-browser-page-reclaimer-scheduling.test.ts
@@ -173,4 +173,55 @@ describe('OffscreenBrowserPageReclaimer scheduling', () => {
     expect(reclaimer.isScheduled).toBe(false)
     expect(vi.getTimerCount()).toBe(0)
   })
+
+  it('backs off instead of spinning when a park rejects', async () => {
+    // Why: a rejection used to skip the backoff assignment entirely, and the
+    // next reschedule saw a deadline in the past with zero backoff — an
+    // instant re-sweep that failed the same way, pegging an idle host.
+    let attempts = 0
+    const { reclaimer, clock } = createReclaimer({
+      pages: [page('a', 1_000_000), page('b', 1_000_000), page('stuck', 500_000)],
+      park: async (browserPageId, live) => {
+        if (browserPageId !== 'stuck') {
+          return
+        }
+        attempts += 1
+        if (attempts > 100) {
+          live.delete(browserPageId)
+          return
+        }
+        throw new Error('helper session teardown failed')
+      }
+    })
+    clock.value += BUDGET.graceMs
+    reclaimer.reschedule()
+
+    await vi.advanceTimersByTimeAsync(BUDGET.graceMs * 10)
+    expect(attempts).toBeGreaterThan(0)
+    expect(attempts).toBeLessThanOrEqual(11)
+  })
+
+  it('arms nothing when stop lands while a sweep is in flight', async () => {
+    // Why: stop() clears sweepInFlight, so without a terminal flag the sweep's
+    // own re-arm no longer sees itself in flight and schedules a fresh check
+    // after shutdown.
+    let releasePark = (): void => {}
+    const gate = new Promise<void>((resolve) => (releasePark = resolve))
+    const { reclaimer, clock } = createReclaimer({
+      pages: [page('a', 1_000_000), page('b', 1_000_000), page('over', 500_000)],
+      park: async () => {
+        await gate
+      }
+    })
+    clock.value += BUDGET.graceMs
+    reclaimer.reschedule()
+    await vi.advanceTimersByTimeAsync(BUDGET.graceMs)
+
+    reclaimer.stop()
+    releasePark()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(reclaimer.isScheduled).toBe(false)
+    expect(vi.getTimerCount()).toBe(0)
+  })
 })

--- a/src/main/browser/offscreen-browser-page-reclaimer-scheduling.test.ts
+++ b/src/main/browser/offscreen-browser-page-reclaimer-scheduling.test.ts
@@ -38,6 +38,7 @@ function createReclaimer(
     pages?: OffscreenBrowserPage[]
     pinned?: readonly string[]
     park?: (browserPageId: string, live: Map<string, OffscreenBrowserPage>) => Promise<void>
+    budget?: BrowserRetentionBudget
   } = {}
 ) {
   const live = new Map<string, OffscreenBrowserPage>(
@@ -51,7 +52,7 @@ function createReclaimer(
   } as unknown as OffscreenBrowserOpenPages
   const reclaimer = new OffscreenBrowserPageReclaimer({
     pages,
-    budget: BUDGET,
+    budget: args.budget ?? BUDGET,
     isReleasing: () => false,
     isWaking: () => false,
     hasCertificateChallenge: () => false,
@@ -199,6 +200,23 @@ describe('OffscreenBrowserPageReclaimer scheduling', () => {
     await vi.advanceTimersByTimeAsync(BUDGET.graceMs * 10)
     expect(attempts).toBeGreaterThan(0)
     expect(attempts).toBeLessThanOrEqual(11)
+  })
+
+  it('caps the armed delay below the setTimeout ceiling', () => {
+    // Why: Node clamps a delay past 2^31-1ms to 1ms — a documented "set the
+    // idle window very high" configuration would otherwise spin the sweep at
+    // 1ms forever on an idle host.
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+    const { reclaimer } = createReclaimer({
+      pages: [page('a', 1_000_000)],
+      budget: { ...BUDGET, idleMs: 100_000_000_000 }
+    })
+    reclaimer.reschedule()
+
+    expect(reclaimer.isScheduled).toBe(true)
+    const delays = setTimeoutSpy.mock.calls.map((call) => call[1] as number)
+    expect(delays.length).toBeGreaterThan(0)
+    expect(Math.max(...delays)).toBeLessThanOrEqual(2_147_483_647)
   })
 
   it('arms nothing when stop lands while a sweep is in flight', async () => {

--- a/src/main/browser/offscreen-browser-page-reclaimer-scheduling.test.ts
+++ b/src/main/browser/offscreen-browser-page-reclaimer-scheduling.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { BrowserRetentionBudget } from '../../shared/browser-retention-budget'
+import { OffscreenBrowserPageReclaimer } from './offscreen-browser-page-reclaimer'
+import type {
+  OffscreenBrowserOpenPages,
+  OffscreenBrowserPage
+} from './offscreen-browser-open-pages'
+
+// Why: the reclaimer replaced a fixed sweep with a deadline it computes itself,
+// so the scheduling contract is now load-bearing — an idle host must hold no
+// timer, a woken page must re-arm one, and a deadline that fires with nothing to
+// do must never re-arm at zero.
+
+const BUDGET: BrowserRetentionBudget = {
+  limit: 2,
+  idleMs: 60_000,
+  graceMs: 5_000
+}
+
+function page(browserPageId: string, lastActivityAt: number): OffscreenBrowserPage {
+  return {
+    browserPageId,
+    worktreeId: undefined,
+    profileId: undefined,
+    partition: 'persist:test',
+    url: 'https://example.test/',
+    title: '',
+    window: {} as OffscreenBrowserPage['window'],
+    activeWhenParked: false,
+    loading: false,
+    loadError: null,
+    lastActivityAt
+  }
+}
+
+function createReclaimer(
+  args: {
+    pages?: OffscreenBrowserPage[]
+    pinned?: readonly string[]
+    park?: (browserPageId: string, live: Map<string, OffscreenBrowserPage>) => Promise<void>
+  } = {}
+) {
+  const live = new Map<string, OffscreenBrowserPage>(
+    (args.pages ?? []).map((entry) => [entry.browserPageId, entry])
+  )
+  const clock = { value: 1_000_000 }
+  const parked: string[] = []
+  const pages = {
+    get: (browserPageId: string) => live.get(browserPageId),
+    resident: () => [...live.values()]
+  } as unknown as OffscreenBrowserOpenPages
+  const reclaimer = new OffscreenBrowserPageReclaimer({
+    pages,
+    budget: BUDGET,
+    isReleasing: () => false,
+    isWaking: () => false,
+    hasCertificateChallenge: () => false,
+    hasActiveDownload: () => false,
+    isHostPinned: (browserPageId) => (args.pinned ?? []).includes(browserPageId),
+    park: async (browserPageId) => {
+      if (args.park) {
+        await args.park(browserPageId, live)
+        return
+      }
+      live.delete(browserPageId)
+      parked.push(browserPageId)
+    },
+    now: () => clock.value
+  })
+  return { reclaimer, clock, live, parked }
+}
+
+describe('OffscreenBrowserPageReclaimer scheduling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('arms nothing when no page is resident', () => {
+    const { reclaimer } = createReclaimer()
+    reclaimer.reschedule()
+    expect(reclaimer.isScheduled).toBe(false)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('arms the idle deadline for a page inside the limit', () => {
+    const { reclaimer, clock } = createReclaimer({
+      pages: [page('a', 1_000_000)]
+    })
+    reclaimer.reschedule()
+    expect(reclaimer.isScheduled).toBe(true)
+
+    // Nothing fires before the idle window closes.
+    clock.value += BUDGET.idleMs - 1
+    vi.advanceTimersByTime(BUDGET.idleMs - 1)
+    expect(reclaimer.isScheduled).toBe(true)
+  })
+
+  it('parks on its own deadline with no periodic sweep in between', async () => {
+    const { reclaimer, clock, parked } = createReclaimer({
+      pages: [page('a', 1_000_000)]
+    })
+    reclaimer.reschedule()
+
+    clock.value += BUDGET.idleMs
+    await vi.advanceTimersByTimeAsync(BUDGET.idleMs)
+
+    expect(parked).toEqual(['a'])
+    // Why: the last resident page is gone, so the host goes quiet entirely.
+    expect(reclaimer.isScheduled).toBe(false)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('parks the coldest page first when the limit is exceeded', async () => {
+    const { reclaimer, clock, parked } = createReclaimer({
+      pages: [page('newest', 1_000_000), page('middle', 990_000), page('oldest', 980_000)]
+    })
+    clock.value += BUDGET.graceMs
+    reclaimer.reschedule()
+    await vi.advanceTimersByTimeAsync(BUDGET.graceMs)
+
+    expect(parked).toEqual(['oldest'])
+  })
+
+  it('re-asks on a bounded cadence while a pin holds a page over the limit', async () => {
+    const { reclaimer, clock, parked } = createReclaimer({
+      pages: [page('a', 1_000_000), page('b', 1_000_000), page('pinned', 900_000)],
+      pinned: ['pinned']
+    })
+    clock.value += BUDGET.graceMs
+    reclaimer.reschedule()
+
+    await vi.advanceTimersByTimeAsync(BUDGET.graceMs * 4)
+    expect(parked).toEqual([])
+    // Still watching, because releasing that pin raises no event this can see.
+    expect(reclaimer.isScheduled).toBe(true)
+  })
+
+  it('never re-arms at zero after a sweep that parks nothing', async () => {
+    // Why: a deadline that lands earlier than the moment a page truly becomes
+    // evictable would otherwise spin the timer flat out on an idle server.
+    let attempts = 0
+    const { reclaimer, clock } = createReclaimer({
+      pages: [page('a', 1_000_000), page('b', 1_000_000), page('stuck', 500_000)],
+      park: async (browserPageId, live) => {
+        if (browserPageId !== 'stuck') {
+          return
+        }
+        attempts += 1
+        // Why the escape hatch: without the backoff this re-arms at 0ms, and a
+        // test that hangs reports far worse than one that fails.
+        if (attempts > 100) {
+          live.delete(browserPageId)
+        }
+      }
+    })
+    clock.value += BUDGET.graceMs
+    reclaimer.reschedule()
+
+    await vi.advanceTimersByTimeAsync(BUDGET.graceMs * 10)
+    // One try per backoff window, not an unbounded spin.
+    expect(attempts).toBeGreaterThan(0)
+    expect(attempts).toBeLessThanOrEqual(11)
+  })
+
+  it('stops holding a timer once stopped', () => {
+    const { reclaimer } = createReclaimer({ pages: [page('a', 1_000_000)] })
+    reclaimer.reschedule()
+    expect(reclaimer.isScheduled).toBe(true)
+    reclaimer.stop()
+    expect(reclaimer.isScheduled).toBe(false)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/src/main/browser/offscreen-browser-page-reclaimer.ts
+++ b/src/main/browser/offscreen-browser-page-reclaimer.ts
@@ -17,6 +17,9 @@ import { nextOffscreenBrowserReclaimCheckAt } from './offscreen-browser-page-rec
 // timer for the moment its own answer could next change. There is deliberately
 // no recurring sweep: a host doing nothing holds no timer at all.
 
+/** Node's setTimeout ceiling; longer delays are clamped by Node to 1ms. */
+const MAX_RECLAIM_TIMER_DELAY_MS = 2_147_483_647
+
 export type OffscreenBrowserReclaimerDeps = {
   pages: OffscreenBrowserOpenPages
   budget: BrowserRetentionBudget
@@ -79,8 +82,13 @@ export class OffscreenBrowserPageReclaimer {
     }
     // Why the floor: a deadline in the past that the last sweep could not act on
     // would re-arm at 0ms, and a timer that re-arms itself instantly is a pegged
-    // CPU on an otherwise idle server.
-    const delay = Math.max(0, at - now, this.backoffUntil - now)
+    // CPU on an otherwise idle server. Why the ceiling: Node clamps a setTimeout
+    // beyond 2^31-1ms to 1ms — the same spin, reachable by configuring the idle
+    // window past ~24.8 days. Re-checking at the horizon is harmless.
+    const delay = Math.min(
+      Math.max(0, at - now, this.backoffUntil - now),
+      MAX_RECLAIM_TIMER_DELAY_MS
+    )
     this.timer = setTimeout(() => {
       this.timer = null
       this.runSweep()

--- a/src/main/browser/offscreen-browser-page-reclaimer.ts
+++ b/src/main/browser/offscreen-browser-page-reclaimer.ts
@@ -29,7 +29,6 @@ export type OffscreenBrowserReclaimerDeps = {
   /** A client streaming the page, or a command in flight against it. */
   isHostPinned: (browserPageId: string) => boolean
   park: (browserPageId: string) => Promise<void>
-  close: (browserPageId: string) => Promise<void>
   now: () => number
 }
 

--- a/src/main/browser/offscreen-browser-page-reclaimer.ts
+++ b/src/main/browser/offscreen-browser-page-reclaimer.ts
@@ -60,7 +60,18 @@ export class OffscreenBrowserPageReclaimer {
       await this.deps.park(browserPageId)
       parked.push(browserPageId)
     }
+    // Why: with nothing resident there is nothing left to reclaim, so the sweep
+    // has no work until a page is created or woken — both of which reschedule
+    // it. Otherwise an idle host keeps waking up forever to find nothing.
+    if (this.deps.pages.resident().length === 0) {
+      this.stop()
+    }
     return parked
+  }
+
+  /** Whether a sweep is currently scheduled. Exposed so the owner can assert it. */
+  get isScheduled(): boolean {
+    return this.sweepTimer !== null
   }
 
   ensureScheduled(): void {

--- a/src/main/browser/offscreen-browser-page-reclaimer.ts
+++ b/src/main/browser/offscreen-browser-page-reclaimer.ts
@@ -1,5 +1,7 @@
-import type { OffscreenBrowserOpenPages } from './offscreen-browser-open-pages'
-import type { OffscreenBrowserPage } from './offscreen-browser-open-pages'
+import type {
+  OffscreenBrowserOpenPages,
+  OffscreenBrowserPage
+} from './offscreen-browser-open-pages'
 import {
   selectOffscreenBrowserPagesToClose,
   selectOffscreenBrowserPagesToPark,

--- a/src/main/browser/offscreen-browser-page-reclaimer.ts
+++ b/src/main/browser/offscreen-browser-page-reclaimer.ts
@@ -3,8 +3,6 @@ import type {
   OffscreenBrowserPage
 } from './offscreen-browser-open-pages'
 import {
-  OFFSCREEN_BROWSER_DOWNLOAD_VETO_MS,
-  selectOffscreenBrowserPagesToClose,
   selectOffscreenBrowserPagesToPark,
   type OffscreenBrowserReclaimPolicy
 } from './offscreen-browser-page-reclaim'
@@ -26,8 +24,8 @@ export type OffscreenBrowserReclaimerDeps = {
   isWaking: (browserPageId: string) => boolean
   /** A certificate challenge the page is blocked on. */
   hasCertificateChallenge: (browserPageId: string) => boolean
-  /** When the page's in-flight downloads last advanced, null when it has none. */
-  activeDownloadProgressAt: (browserPageId: string) => number | null
+  /** A download the page is still writing. */
+  hasActiveDownload: (browserPageId: string) => boolean
   /** A client streaming the page, or a command in flight against it. */
   isHostPinned: (browserPageId: string) => boolean
   park: (browserPageId: string) => Promise<void>
@@ -63,7 +61,6 @@ export class OffscreenBrowserPageReclaimer {
       await this.deps.park(browserPageId)
       parked.push(browserPageId)
     }
-    await this.closeOverRetainedPages()
     return parked
   }
 
@@ -100,30 +97,6 @@ export class OffscreenBrowserPageReclaimer {
     this.sweepInFlight = null
   }
 
-  // Why: parking bounds renderer processes, not the records behind them. An
-  // agent that opens pages forever and closes none would still grow the backend
-  // without limit, so the oldest parked pages are eventually closed outright.
-  private async closeOverRetainedPages(): Promise<void> {
-    const doomed = selectOffscreenBrowserPagesToClose(
-      this.deps.pages.parked().map((page) => this.toCandidate(page)),
-      this.deps.pages.size,
-      this.deps.policy
-    )
-    for (const browserPageId of doomed) {
-      // Why: closing is destructive and awaits teardown, so a page selected
-      // here can be woken before its turn comes. Only close one that is still
-      // parked and still unwanted.
-      const page = this.deps.pages.get(browserPageId)
-      if (!page || page.window || !this.isSafeToReclaim(browserPageId)) {
-        continue
-      }
-      console.warn(
-        `[offscreen-browser] closing parked page ${browserPageId}: more than ${this.deps.policy.retainedPageLimit} pages are open`
-      )
-      await this.deps.close(browserPageId)
-    }
-  }
-
   // Why: a page is off limits while anything depends on its renderer — a client
   // streaming it, a command in flight, its first navigation still committing, a
   // wake still rebuilding it, a certificate decision it is blocked on, or a
@@ -137,19 +110,12 @@ export class OffscreenBrowserPageReclaimer {
       // Why: a challenge id dies with the renderer, so parking would discard
       // both the warning and the ability to approve it.
       this.deps.hasCertificateChallenge(page.browserPageId) ||
-      this.hasAdvancingDownload(page.browserPageId) ||
+      // Why: releasing a renderer unregisters its guest, and that cancels the
+      // page's in-flight downloads. Mirrors the desktop guest budget's veto
+      // (browser-guest-worktree-retention.ts).
+      this.deps.hasActiveDownload(page.browserPageId) ||
       this.deps.isHostPinned(page.browserPageId)
     )
-  }
-
-  // Why: releasing a renderer unregisters its guest, and that cancels the page's
-  // in-flight downloads — the desktop guest budget vetoes eviction for the same
-  // reason (browser-guest-worktree-retention.ts). Bounded by progress, because a
-  // download that stalls forever would otherwise pin its renderer forever, and
-  // one stalled download per page would defeat the resident cap outright.
-  private hasAdvancingDownload(browserPageId: string): boolean {
-    const progressAt = this.deps.activeDownloadProgressAt(browserPageId)
-    return progressAt !== null && this.deps.now() - progressAt < OFFSCREEN_BROWSER_DOWNLOAD_VETO_MS
   }
 
   private toCandidate(page: OffscreenBrowserPage): {

--- a/src/main/browser/offscreen-browser-page-reclaimer.ts
+++ b/src/main/browser/offscreen-browser-page-reclaimer.ts
@@ -3,6 +3,7 @@ import type {
   OffscreenBrowserPage
 } from './offscreen-browser-open-pages'
 import {
+  OFFSCREEN_BROWSER_DOWNLOAD_VETO_MS,
   selectOffscreenBrowserPagesToClose,
   selectOffscreenBrowserPagesToPark,
   type OffscreenBrowserReclaimPolicy
@@ -21,8 +22,14 @@ export type OffscreenBrowserReclaimerDeps = {
   policy: OffscreenBrowserReclaimPolicy
   /** A teardown this backend already started for the page. */
   isReleasing: (browserPageId: string) => boolean
-  /** Anything depending on the page's renderer right now. */
-  isPinned: (page: OffscreenBrowserPage) => boolean
+  /** A wake still rebuilding the page's renderer. */
+  isWaking: (browserPageId: string) => boolean
+  /** A certificate challenge the page is blocked on. */
+  hasCertificateChallenge: (browserPageId: string) => boolean
+  /** When the page's in-flight downloads last advanced, null when it has none. */
+  activeDownloadProgressAt: (browserPageId: string) => number | null
+  /** A client streaming the page, or a command in flight against it. */
+  isHostPinned: (browserPageId: string) => boolean
   park: (browserPageId: string) => Promise<void>
   close: (browserPageId: string) => Promise<void>
   now: () => number
@@ -117,6 +124,34 @@ export class OffscreenBrowserPageReclaimer {
     }
   }
 
+  // Why: a page is off limits while anything depends on its renderer — a client
+  // streaming it, a command in flight, its first navigation still committing, a
+  // wake still rebuilding it, a certificate decision it is blocked on, or a
+  // download it is still writing. `loading` is bounded by the load helper's own
+  // timeout, so it cannot hold a renderer forever; a navigation still pending
+  // past that timeout is deliberately parkable, and waking retries the address.
+  isPinned(page: OffscreenBrowserPage): boolean {
+    return (
+      page.loading ||
+      this.deps.isWaking(page.browserPageId) ||
+      // Why: a challenge id dies with the renderer, so parking would discard
+      // both the warning and the ability to approve it.
+      this.deps.hasCertificateChallenge(page.browserPageId) ||
+      this.hasAdvancingDownload(page.browserPageId) ||
+      this.deps.isHostPinned(page.browserPageId)
+    )
+  }
+
+  // Why: releasing a renderer unregisters its guest, and that cancels the page's
+  // in-flight downloads — the desktop guest budget vetoes eviction for the same
+  // reason (browser-guest-worktree-retention.ts). Bounded by progress, because a
+  // download that stalls forever would otherwise pin its renderer forever, and
+  // one stalled download per page would defeat the resident cap outright.
+  hasAdvancingDownload(browserPageId: string): boolean {
+    const progressAt = this.deps.activeDownloadProgressAt(browserPageId)
+    return progressAt !== null && this.deps.now() - progressAt < OFFSCREEN_BROWSER_DOWNLOAD_VETO_MS
+  }
+
   private toCandidate(page: OffscreenBrowserPage): {
     browserPageId: string
     lastActivityAt: number
@@ -125,7 +160,7 @@ export class OffscreenBrowserPageReclaimer {
     return {
       browserPageId: page.browserPageId,
       lastActivityAt: page.lastActivityAt,
-      pinned: this.deps.isPinned(page)
+      pinned: this.isPinned(page)
     }
   }
 
@@ -135,8 +170,7 @@ export class OffscreenBrowserPageReclaimer {
       return false
     }
     return (
-      !this.deps.isPinned(page) &&
-      this.deps.now() - page.lastActivityAt >= this.deps.policy.parkGraceMs
+      !this.isPinned(page) && this.deps.now() - page.lastActivityAt >= this.deps.policy.parkGraceMs
     )
   }
 }

--- a/src/main/browser/offscreen-browser-page-reclaimer.ts
+++ b/src/main/browser/offscreen-browser-page-reclaimer.ts
@@ -1,23 +1,25 @@
+import {
+  selectBrowserRetentionEvictions,
+  isBrowserRetentionCandidateInGrace,
+  type BrowserRetentionBudget,
+  type BrowserRetentionCandidate
+} from '../../shared/browser-retention-budget'
 import type {
   OffscreenBrowserOpenPages,
   OffscreenBrowserPage
 } from './offscreen-browser-open-pages'
-import {
-  selectOffscreenBrowserPagesToPark,
-  type OffscreenBrowserReclaimPolicy
-} from './offscreen-browser-page-reclaim'
+import { nextOffscreenBrowserReclaimCheckAt } from './offscreen-browser-page-reclaim'
 
-// Why (STA-4341): the sweep that decides which headless pages keep a renderer,
-// separated from the backend that owns the renderers themselves. It is the
-// headless counterpart of the desktop guest budget in
-// browser-guest-worktree-retention.ts — same intent, different unit: desktop
-// evicts a hidden worktree's guests on UI visibility, headless evicts an
-// individual page on command activity, because a headless host has no UI and an
-// agent lives in one worktree.
+// Why (STA-4341): the trigger half of the headless page budget — it decides
+// *when* to ask, while the shared browser retention budget decides *what* to
+// evict. The desktop guest budget gets its trigger for free from a UI
+// visibility change; a headless host has no such event, so this arms a one-shot
+// timer for the moment its own answer could next change. There is deliberately
+// no recurring sweep: a host doing nothing holds no timer at all.
 
 export type OffscreenBrowserReclaimerDeps = {
   pages: OffscreenBrowserOpenPages
-  policy: OffscreenBrowserReclaimPolicy
+  budget: BrowserRetentionBudget
   /** A teardown this backend already started for the page. */
   isReleasing: (browserPageId: string) => boolean
   /** A wake still rebuilding the page's renderer. */
@@ -33,23 +35,102 @@ export type OffscreenBrowserReclaimerDeps = {
 }
 
 export class OffscreenBrowserPageReclaimer {
-  private sweepTimer: NodeJS.Timeout | null = null
+  private timer: NodeJS.Timeout | null = null
   private sweepInFlight: Promise<unknown> | null = null
+  /** Set when a sweep parked nothing — see reschedule(). */
+  private backoffUntil = 0
 
   constructor(private readonly deps: OffscreenBrowserReclaimerDeps) {}
 
-  /** Park every page the policy no longer wants resident. */
+  /** Park every page the budget no longer wants resident, then re-arm. */
   async sweep(): Promise<string[]> {
-    const resident = this.deps.pages
-      .resident()
-      .filter((page) => !this.deps.isReleasing(page.browserPageId))
-    const doomed = selectOffscreenBrowserPagesToPark(
-      resident.map((page) => this.toCandidate(page)),
-      this.deps.now(),
-      this.deps.policy
-    )
+    const parked = await this.parkOverBudgetPages()
+    this.reschedule()
+    return parked
+  }
+
+  /**
+   * Re-arm the timer for the next moment the answer could change.
+   *
+   * Call after anything that moves a page's activity, residency or pin state.
+   * Recomputing from live state means a missed call can only delay a park,
+   * never schedule a wrong one, and an all-parked host arms nothing.
+   */
+  reschedule(): void {
+    this.clearTimer()
+    // Why: a sweep re-arms itself when it settles. Arming now would race it
+    // against state the in-flight parks are still changing.
+    if (this.sweepInFlight) {
+      return
+    }
+    const now = this.deps.now()
+    const at = nextOffscreenBrowserReclaimCheckAt({
+      candidates: this.candidates(),
+      isPinned: (browserPageId) => this.isPinnedById(browserPageId),
+      now,
+      budget: this.deps.budget
+    })
+    if (at === null) {
+      return
+    }
+    // Why the floor: a deadline in the past that the last sweep could not act on
+    // would re-arm at 0ms, and a timer that re-arms itself instantly is a pegged
+    // CPU on an otherwise idle server.
+    const delay = Math.max(0, at - now, this.backoffUntil - now)
+    this.timer = setTimeout(() => {
+      this.timer = null
+      this.runSweep()
+    }, delay)
+    // Why: reclamation must never be the reason the process stays alive.
+    this.timer.unref?.()
+  }
+
+  /** Whether a check is currently armed. Exposed so the owner can assert it. */
+  get isScheduled(): boolean {
+    return this.timer !== null
+  }
+
+  stop(): void {
+    this.clearTimer()
+    this.sweepInFlight = null
+    this.backoffUntil = 0
+  }
+
+  private clearTimer(): void {
+    if (this.timer) {
+      clearTimeout(this.timer)
+      this.timer = null
+    }
+  }
+
+  private runSweep(): void {
+    if (this.sweepInFlight) {
+      return
+    }
+    const sweep = this.sweep().catch(() => {
+      // A failed park is retried on the next check.
+    })
+    this.sweepInFlight = sweep
+    void sweep.finally(() => {
+      if (this.sweepInFlight === sweep) {
+        this.sweepInFlight = null
+        this.reschedule()
+      }
+    })
+  }
+
+  private async parkOverBudgetPages(): Promise<string[]> {
+    const residentBefore = this.deps.pages.resident().length
+    const doomed = selectBrowserRetentionEvictions({
+      candidates: this.candidates(),
+      isPinned: (browserPageId) => this.isPinnedById(browserPageId),
+      now: this.deps.now(),
+      budget: this.deps.budget
+    })
     const parked: string[] = []
-    for (const browserPageId of doomed) {
+    // Why reversed: the selector ranks most-recently-used first, so this parks
+    // the coldest page first — the one least likely to be woken mid-teardown.
+    for (const browserPageId of doomed.toReversed()) {
       // Why: parking awaits the helper session's teardown, so a page later in
       // this list can be woken and driven while an earlier one is still being
       // torn down. The selection is a proposal, not a licence — re-check each
@@ -60,51 +141,29 @@ export class OffscreenBrowserPageReclaimer {
       await this.deps.park(browserPageId)
       parked.push(browserPageId)
     }
-    // Why: with nothing resident there is nothing left to reclaim, so the sweep
-    // has no work until a page is created or woken — both of which reschedule
-    // it. Otherwise an idle host keeps waking up forever to find nothing.
-    if (this.deps.pages.resident().length === 0) {
-      this.stop()
-    }
+    // Why measured rather than reported: a sweep that frees nothing leaves the
+    // deadline in the past, and re-arming at 0ms would spin the timer flat out.
+    // park() cannot be trusted to say so — it no-ops for a window that is
+    // already gone — so residency is the only honest signal of progress.
+    const madeProgress = this.deps.pages.resident().length < residentBefore
+    this.backoffUntil = madeProgress ? 0 : this.deps.now() + this.deps.budget.graceMs
     return parked
   }
 
-  /** Whether a sweep is currently scheduled. Exposed so the owner can assert it. */
-  get isScheduled(): boolean {
-    return this.sweepTimer !== null
-  }
-
-  ensureScheduled(): void {
-    if (this.sweepTimer) {
-      return
-    }
-    this.sweepTimer = setInterval(() => {
-      // Why: a park waits on the helper session's own bounded teardown, which
-      // can outlast the interval. Without this guard slow teardowns would stack
-      // sweeps on top of each other for as long as they lag.
-      if (this.sweepInFlight) {
-        return
-      }
-      const sweep = this.sweep().catch(() => {
-        // A failed park is retried on the next sweep.
-      })
-      this.sweepInFlight = sweep
-      void sweep.finally(() => {
-        if (this.sweepInFlight === sweep) {
-          this.sweepInFlight = null
-        }
-      })
-    }, this.deps.policy.sweepIntervalMs)
-    // Why: reclamation must never be the reason the process stays alive.
-    this.sweepTimer.unref?.()
-  }
-
-  stop(): void {
-    if (this.sweepTimer) {
-      clearInterval(this.sweepTimer)
-      this.sweepTimer = null
-    }
-    this.sweepInFlight = null
+  /** Resident pages the budget can rank, most recently used first. */
+  private candidates(): BrowserRetentionCandidate[] {
+    return this.deps.pages
+      .resident()
+      .filter((page) => !this.deps.isReleasing(page.browserPageId))
+      .sort(
+        (left, right) =>
+          right.lastActivityAt - left.lastActivityAt ||
+          left.browserPageId.localeCompare(right.browserPageId)
+      )
+      .map((page) => ({
+        id: page.browserPageId,
+        lastActivityAt: page.lastActivityAt
+      }))
   }
 
   // Why: a page is off limits while anything depends on its renderer — a client
@@ -128,16 +187,9 @@ export class OffscreenBrowserPageReclaimer {
     )
   }
 
-  private toCandidate(page: OffscreenBrowserPage): {
-    browserPageId: string
-    lastActivityAt: number
-    pinned: boolean
-  } {
-    return {
-      browserPageId: page.browserPageId,
-      lastActivityAt: page.lastActivityAt,
-      pinned: this.isPinned(page)
-    }
+  private isPinnedById(browserPageId: string): boolean {
+    const page = this.deps.pages.get(browserPageId)
+    return page ? this.isPinned(page) : false
   }
 
   private isSafeToReclaim(browserPageId: string): boolean {
@@ -145,8 +197,13 @@ export class OffscreenBrowserPageReclaimer {
     if (!page || this.deps.isReleasing(browserPageId)) {
       return false
     }
-    return (
-      !this.isPinned(page) && this.deps.now() - page.lastActivityAt >= this.deps.policy.parkGraceMs
+    if (this.isPinned(page)) {
+      return false
+    }
+    return !isBrowserRetentionCandidateInGrace(
+      { id: browserPageId, lastActivityAt: page.lastActivityAt },
+      this.deps.now(),
+      this.deps.budget
     )
   }
 }

--- a/src/main/browser/offscreen-browser-page-reclaimer.ts
+++ b/src/main/browser/offscreen-browser-page-reclaimer.ts
@@ -1,0 +1,140 @@
+import type { OffscreenBrowserOpenPages } from './offscreen-browser-open-pages'
+import type { OffscreenBrowserPage } from './offscreen-browser-open-pages'
+import {
+  selectOffscreenBrowserPagesToClose,
+  selectOffscreenBrowserPagesToPark,
+  type OffscreenBrowserReclaimPolicy
+} from './offscreen-browser-page-reclaim'
+
+// Why (STA-4341): the sweep that decides which headless pages keep a renderer,
+// separated from the backend that owns the renderers themselves. It is the
+// headless counterpart of the desktop guest budget in
+// browser-guest-worktree-retention.ts — same intent, different unit: desktop
+// evicts a hidden worktree's guests on UI visibility, headless evicts an
+// individual page on command activity, because a headless host has no UI and an
+// agent lives in one worktree.
+
+export type OffscreenBrowserReclaimerDeps = {
+  pages: OffscreenBrowserOpenPages
+  policy: OffscreenBrowserReclaimPolicy
+  /** A teardown this backend already started for the page. */
+  isReleasing: (browserPageId: string) => boolean
+  /** Anything depending on the page's renderer right now. */
+  isPinned: (page: OffscreenBrowserPage) => boolean
+  park: (browserPageId: string) => Promise<void>
+  close: (browserPageId: string) => Promise<void>
+  now: () => number
+}
+
+export class OffscreenBrowserPageReclaimer {
+  private sweepTimer: NodeJS.Timeout | null = null
+  private sweepInFlight: Promise<unknown> | null = null
+
+  constructor(private readonly deps: OffscreenBrowserReclaimerDeps) {}
+
+  /** Park every page the policy no longer wants resident. */
+  async sweep(): Promise<string[]> {
+    const resident = this.deps.pages
+      .resident()
+      .filter((page) => !this.deps.isReleasing(page.browserPageId))
+    const doomed = selectOffscreenBrowserPagesToPark(
+      resident.map((page) => this.toCandidate(page)),
+      this.deps.now(),
+      this.deps.policy
+    )
+    const parked: string[] = []
+    for (const browserPageId of doomed) {
+      // Why: parking awaits the helper session's teardown, so a page later in
+      // this list can be woken and driven while an earlier one is still being
+      // torn down. The selection is a proposal, not a licence — re-check each
+      // page against live state before destroying its renderer.
+      if (!this.isSafeToReclaim(browserPageId)) {
+        continue
+      }
+      await this.deps.park(browserPageId)
+      parked.push(browserPageId)
+    }
+    await this.closeOverRetainedPages()
+    return parked
+  }
+
+  ensureScheduled(): void {
+    if (this.sweepTimer) {
+      return
+    }
+    this.sweepTimer = setInterval(() => {
+      // Why: a park waits on the helper session's own bounded teardown, which
+      // can outlast the interval. Without this guard slow teardowns would stack
+      // sweeps on top of each other for as long as they lag.
+      if (this.sweepInFlight) {
+        return
+      }
+      const sweep = this.sweep().catch(() => {
+        // A failed park is retried on the next sweep.
+      })
+      this.sweepInFlight = sweep
+      void sweep.finally(() => {
+        if (this.sweepInFlight === sweep) {
+          this.sweepInFlight = null
+        }
+      })
+    }, this.deps.policy.sweepIntervalMs)
+    // Why: reclamation must never be the reason the process stays alive.
+    this.sweepTimer.unref?.()
+  }
+
+  stop(): void {
+    if (this.sweepTimer) {
+      clearInterval(this.sweepTimer)
+      this.sweepTimer = null
+    }
+    this.sweepInFlight = null
+  }
+
+  // Why: parking bounds renderer processes, not the records behind them. An
+  // agent that opens pages forever and closes none would still grow the backend
+  // without limit, so the oldest parked pages are eventually closed outright.
+  private async closeOverRetainedPages(): Promise<void> {
+    const doomed = selectOffscreenBrowserPagesToClose(
+      this.deps.pages.parked().map((page) => this.toCandidate(page)),
+      this.deps.pages.size,
+      this.deps.policy
+    )
+    for (const browserPageId of doomed) {
+      // Why: closing is destructive and awaits teardown, so a page selected
+      // here can be woken before its turn comes. Only close one that is still
+      // parked and still unwanted.
+      const page = this.deps.pages.get(browserPageId)
+      if (!page || page.window || !this.isSafeToReclaim(browserPageId)) {
+        continue
+      }
+      console.warn(
+        `[offscreen-browser] closing parked page ${browserPageId}: more than ${this.deps.policy.retainedPageLimit} pages are open`
+      )
+      await this.deps.close(browserPageId)
+    }
+  }
+
+  private toCandidate(page: OffscreenBrowserPage): {
+    browserPageId: string
+    lastActivityAt: number
+    pinned: boolean
+  } {
+    return {
+      browserPageId: page.browserPageId,
+      lastActivityAt: page.lastActivityAt,
+      pinned: this.deps.isPinned(page)
+    }
+  }
+
+  private isSafeToReclaim(browserPageId: string): boolean {
+    const page = this.deps.pages.get(browserPageId)
+    if (!page || this.deps.isReleasing(browserPageId)) {
+      return false
+    }
+    return (
+      !this.deps.isPinned(page) &&
+      this.deps.now() - page.lastActivityAt >= this.deps.policy.parkGraceMs
+    )
+  }
+}

--- a/src/main/browser/offscreen-browser-page-reclaimer.ts
+++ b/src/main/browser/offscreen-browser-page-reclaimer.ts
@@ -39,6 +39,8 @@ export class OffscreenBrowserPageReclaimer {
   private sweepInFlight: Promise<unknown> | null = null
   /** Set when a sweep parked nothing — see reschedule(). */
   private backoffUntil = 0
+  /** stop() is terminal: nothing may arm a timer after it. */
+  private stopped = false
 
   constructor(private readonly deps: OffscreenBrowserReclaimerDeps) {}
 
@@ -59,8 +61,10 @@ export class OffscreenBrowserPageReclaimer {
   reschedule(): void {
     this.clearTimer()
     // Why: a sweep re-arms itself when it settles. Arming now would race it
-    // against state the in-flight parks are still changing.
-    if (this.sweepInFlight) {
+    // against state the in-flight parks are still changing. And after stop()
+    // nothing may arm at all — a still-settling sweep or a 'destroyed' handler
+    // firing inside destroyAll would otherwise schedule a check post-shutdown.
+    if (this.stopped || this.sweepInFlight) {
       return
     }
     const now = this.deps.now()
@@ -91,6 +95,7 @@ export class OffscreenBrowserPageReclaimer {
   }
 
   stop(): void {
+    this.stopped = true
     this.clearTimer()
     this.sweepInFlight = null
     this.backoffUntil = 0
@@ -138,7 +143,15 @@ export class OffscreenBrowserPageReclaimer {
       if (!this.isSafeToReclaim(browserPageId)) {
         continue
       }
-      await this.deps.park(browserPageId)
+      try {
+        await this.deps.park(browserPageId)
+      } catch {
+        // Why: a park that throws must still reach the backoff below. Letting
+        // it propagate skips the assignment, and the next reschedule would see
+        // a deadline in the past with a zero backoff — an instant re-sweep
+        // that fails the same way, forever. Retried on the next check instead.
+        continue
+      }
       parked.push(browserPageId)
     }
     // Why measured rather than reported: a sweep that frees nothing leaves the

--- a/src/main/browser/offscreen-browser-page-reclaimer.ts
+++ b/src/main/browser/offscreen-browser-page-reclaimer.ts
@@ -130,7 +130,7 @@ export class OffscreenBrowserPageReclaimer {
   // download it is still writing. `loading` is bounded by the load helper's own
   // timeout, so it cannot hold a renderer forever; a navigation still pending
   // past that timeout is deliberately parkable, and waking retries the address.
-  isPinned(page: OffscreenBrowserPage): boolean {
+  private isPinned(page: OffscreenBrowserPage): boolean {
     return (
       page.loading ||
       this.deps.isWaking(page.browserPageId) ||
@@ -147,7 +147,7 @@ export class OffscreenBrowserPageReclaimer {
   // reason (browser-guest-worktree-retention.ts). Bounded by progress, because a
   // download that stalls forever would otherwise pin its renderer forever, and
   // one stalled download per page would defeat the resident cap outright.
-  hasAdvancingDownload(browserPageId: string): boolean {
+  private hasAdvancingDownload(browserPageId: string): boolean {
     const progressAt = this.deps.activeDownloadProgressAt(browserPageId)
     return progressAt !== null && this.deps.now() - progressAt < OFFSCREEN_BROWSER_DOWNLOAD_VETO_MS
   }

--- a/src/main/browser/offscreen-browser-renderer-attachment.ts
+++ b/src/main/browser/offscreen-browser-renderer-attachment.ts
@@ -1,0 +1,78 @@
+import type { BrowserWindow } from 'electron'
+import type { OffscreenBrowserPage } from './offscreen-browser-open-pages'
+import { createOffscreenBrowserWindow } from './offscreen-browser-window'
+
+// Why (STA-4341): building a page's renderer and wiring it to the page record
+// is one transaction — the window, the address tracking that keeps the record
+// wakeable, the loss handler that cleans up a crash, and the guest
+// registration. The backend owns what happens on those events; this module
+// owns that they are attached to every renderer identically, whether it came
+// from a create or a wake.
+
+export type OffscreenBrowserRendererHooks = {
+  /** A teardown the owner started on purpose — the loss handler stands down. */
+  isDeliberateTeardown: (browserPageId: string) => boolean
+  /** The renderer died out from under the owner (crash, app teardown). */
+  onRendererLost: (webContentsId: number) => void
+  /** Map the fresh WebContents into the guest registries. */
+  registerGuest: (webContentsId: number) => void
+}
+
+export function materializeOffscreenBrowserRenderer(
+  page: OffscreenBrowserPage,
+  hooks: OffscreenBrowserRendererHooks
+): void {
+  const win = createOffscreenBrowserWindow(page.partition)
+  try {
+    attachWindow(page, win, hooks)
+  } catch (error) {
+    // Why: the window exists before anything that can fail. Abandoning it
+    // here would leak a hidden renderer nothing owns or can reach.
+    page.window = null
+    if (!win.isDestroyed()) {
+      win.destroy()
+    }
+    throw error
+  }
+}
+
+function attachWindow(
+  page: OffscreenBrowserPage,
+  win: BrowserWindow,
+  hooks: OffscreenBrowserRendererHooks
+): void {
+  page.window = win
+  // Why: reading win.webContents once the contents are destroyed throws, and
+  // the throw would escape the 'destroyed' listener into the main process.
+  // Capture the id while it is still safe to read.
+  const webContentsId = win.webContents.id
+  // Why: the record's address must follow the page, not the create call — an
+  // agent that navigates with `goto` or in-page script has to be woken back
+  // to where it actually is. A chrome-error address is the failure, not a
+  // destination, so it never replaces the address that produced it.
+  const recordAddress = (url: string): void => {
+    if (page.window === win && url && !url.startsWith('chrome-error://')) {
+      page.url = url
+    }
+  }
+  // did-navigate is main-frame only; did-frame-navigate covers subframes.
+  win.webContents.on('did-navigate', (_event, url) => recordAddress(url))
+  // Why: an iframe changing its own hash also fires did-navigate-in-page. A
+  // subframe navigation is not a navigation of the tab, and adopting its
+  // address would wake the page onto the iframe's document.
+  win.webContents.on('did-navigate-in-page', (_event, url, isMainFrame) => {
+    if (isMainFrame) {
+      recordAddress(url)
+    }
+  })
+  // Why: if the window is destroyed out from under us (crash, app teardown),
+  // report the loss so commands fail cleanly instead of resolving a dead
+  // WebContents. Parking destroys it deliberately, so it opts out here.
+  win.webContents.once('destroyed', () => {
+    if (hooks.isDeliberateTeardown(page.browserPageId) || page.window !== win) {
+      return
+    }
+    hooks.onRendererLost(webContentsId)
+  })
+  hooks.registerGuest(webContentsId)
+}

--- a/src/main/browser/offscreen-browser-window.ts
+++ b/src/main/browser/offscreen-browser-window.ts
@@ -11,6 +11,15 @@ import { ORCA_BROWSER_GUEST_WEB_PREFERENCES } from '../../shared/browser-guest-w
 const DEFAULT_VIEWPORT_WIDTH = 1280
 const DEFAULT_VIEWPORT_HEIGHT = 800
 const LOAD_TIMEOUT_MS = 30_000
+/**
+ * How long a wake waits for the reloaded page before returning anyway. A wake
+ * happens inside an RPC a paired client gives 15s (`browser.tabShow` in
+ * remote-browser-page-session.ts), so waiting out the full load budget would
+ * report the browser unreachable on any page slower than that. The page is
+ * operable and still navigating when this elapses — the same contract a freshly
+ * created tab has, since createTab never waits for its load either.
+ */
+export const OFFSCREEN_BROWSER_WAKE_LOAD_BUDGET_MS = 10_000
 
 export function createOffscreenBrowserWindow(partition: string): BrowserWindow {
   return new BrowserWindow({
@@ -29,7 +38,11 @@ export function createOffscreenBrowserWindow(partition: string): BrowserWindow {
   })
 }
 
-export async function loadOffscreenBrowserUrl(win: BrowserWindow, url: string): Promise<void> {
+export async function loadOffscreenBrowserUrl(
+  win: BrowserWindow,
+  url: string,
+  timeoutMs: number = LOAD_TIMEOUT_MS
+): Promise<void> {
   const wc = win.webContents
   await new Promise<void>((resolve, reject) => {
     let settled = false
@@ -42,7 +55,7 @@ export async function loadOffscreenBrowserUrl(win: BrowserWindow, url: string): 
       // Why: about:blank and slow pages can resolve via timeout without a
       // did-finish-load; treat that as success so the tab is still operable.
       resolve()
-    }, LOAD_TIMEOUT_MS)
+    }, timeoutMs)
 
     const onFinish = (): void => {
       if (settled) {

--- a/src/main/browser/offscreen-browser-window.ts
+++ b/src/main/browser/offscreen-browser-window.ts
@@ -1,0 +1,96 @@
+import { BrowserWindow } from 'electron'
+import { ORCA_BROWSER_GUEST_WEB_PREFERENCES } from '../../shared/browser-guest-web-preferences'
+
+// Why: headless orca serve has no renderer window to host a <webview>, so each
+// browser page is backed by a main-process offscreen BrowserWindow. The window
+// is never shown — it exists only so its WebContents can be driven over CDP and
+// streamed via the existing screencast path. Verified on macOS and on headless
+// Linux under Xvfb (Electron --headless segfaults; a virtual display is
+// required there — provisioned in the serve image, not by this code).
+
+const DEFAULT_VIEWPORT_WIDTH = 1280
+const DEFAULT_VIEWPORT_HEIGHT = 800
+const LOAD_TIMEOUT_MS = 30_000
+
+export function createOffscreenBrowserWindow(partition: string): BrowserWindow {
+  return new BrowserWindow({
+    show: false,
+    width: DEFAULT_VIEWPORT_WIDTH,
+    height: DEFAULT_VIEWPORT_HEIGHT,
+    webPreferences: {
+      // Why: offscreen pages are the SSH/headless browser backend; keep their
+      // HTML fullscreen behavior aligned with desktop <webview> guests.
+      ...ORCA_BROWSER_GUEST_WEB_PREFERENCES,
+      partition,
+      sandbox: true,
+      contextIsolation: true,
+      nodeIntegration: false
+    }
+  })
+}
+
+export async function loadOffscreenBrowserUrl(win: BrowserWindow, url: string): Promise<void> {
+  const wc = win.webContents
+  await new Promise<void>((resolve, reject) => {
+    let settled = false
+    const timer = setTimeout(() => {
+      if (settled) {
+        return
+      }
+      settled = true
+      cleanup()
+      // Why: about:blank and slow pages can resolve via timeout without a
+      // did-finish-load; treat that as success so the tab is still operable.
+      resolve()
+    }, LOAD_TIMEOUT_MS)
+
+    const onFinish = (): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      cleanup()
+      resolve()
+    }
+    const onFail = (
+      _e: unknown,
+      errorCode: number,
+      errorDescription: string,
+      _validatedURL: string,
+      isMainFrame: boolean
+    ): void => {
+      // Why: subframe/iframe (e.g. ad/tracker) load failures also fire
+      // did-fail-load. Only the main frame failing means the page itself
+      // failed; ignore the rest or an otherwise-usable page gets rejected.
+      if (!isMainFrame) {
+        return
+      }
+      if (settled) {
+        return
+      }
+      settled = true
+      cleanup()
+      // Why: aborted loads (-3) happen on redirects/SPA navigations and are not
+      // real failures; the page is still usable.
+      if (errorCode === -3) {
+        resolve()
+        return
+      }
+      reject(new Error(`${errorDescription} (${errorCode})`))
+    }
+    const cleanup = (): void => {
+      clearTimeout(timer)
+      if (wc.isDestroyed()) {
+        return
+      }
+      wc.removeListener('did-finish-load', onFinish)
+      wc.removeListener('did-fail-load', onFail)
+    }
+
+    wc.on('did-finish-load', onFinish)
+    wc.on('did-fail-load', onFail)
+    void wc.loadURL(url).catch(() => {
+      // loadURL rejects on aborted navigations; did-fail-load handles the rest.
+    })
+  })
+}

--- a/src/main/browser/offscreen-browser-window.web-preferences.test.ts
+++ b/src/main/browser/offscreen-browser-window.web-preferences.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
-const OFFSCREEN_BACKEND_SOURCE = resolve(__dirname, 'offscreen-browser-backend.ts')
+const OFFSCREEN_WINDOW_SOURCE = resolve(__dirname, 'offscreen-browser-window.ts')
 
 function sourceBetween(source: string, start: string, end: string): string {
   const startIndex = source.indexOf(start)
@@ -14,9 +14,9 @@ function sourceBetween(source: string, start: string, end: string): string {
   return source.slice(startIndex, endIndex)
 }
 
-describe('OffscreenBrowserBackend web preferences', () => {
+describe('offscreen browser window web preferences', () => {
   it('uses the shared browser guest fullscreen policy', () => {
-    const source = readFileSync(OFFSCREEN_BACKEND_SOURCE, 'utf8')
+    const source = readFileSync(OFFSCREEN_WINDOW_SOURCE, 'utf8')
     const webPreferencesBlock = sourceBetween(source, 'webPreferences: {', 'partition,')
 
     expect(source).toContain(

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3168,7 +3168,8 @@ void app.whenReady().then(async () => {
       runtime.setOffscreenBrowserBackend(
         new OffscreenBrowserBackend(browserManager, {
           getAgentBrowserBridge: () => runtime?.getAgentBrowserBridge() ?? null,
-          isPagePinned: (browserPageId) => runtime?.isBrowserPagePinned(browserPageId) === true
+          isPagePinned: (browserPageId) => runtime?.isBrowserPagePinned(browserPageId) === true,
+          onPagesChanged: (worktreeId) => runtime?.notifyHeadlessBrowserPagesChanged(worktreeId)
         })
       )
     }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3165,7 +3165,12 @@ void app.whenReady().then(async () => {
     await runtime.reconcileLegacyWorkerTerminals()
     // Why: headless servers can't mount <webview> panes; use offscreen WebContents, gated on a real display so browser.headless.v1 stays honest.
     if (headlessBrowserDisplayAvailable) {
-      runtime.setOffscreenBrowserBackend(new OffscreenBrowserBackend(browserManager))
+      runtime.setOffscreenBrowserBackend(
+        new OffscreenBrowserBackend(browserManager, {
+          getAgentBrowserBridge: () => runtime?.getAgentBrowserBridge() ?? null,
+          isPagePinned: (browserPageId) => runtime?.isBrowserPagePinned(browserPageId) === true
+        })
+      )
     }
     // Why: headless servers have no renderer graph publisher; publish an explicit empty graph so status clients see a ready server.
     runtime.syncWindowGraph(HEADLESS_RUNTIME_WINDOW_ID, { tabs: [], leaves: [] })

--- a/src/main/runtime/orca-runtime-browser-parked-targeting.test.ts
+++ b/src/main/runtime/orca-runtime-browser-parked-targeting.test.ts
@@ -163,6 +163,19 @@ describe('headless parked-page targeting', () => {
     ])
   })
 
+  it('reports back the index the caller passed, not the renumbered one', async () => {
+    // Why: waking the target makes it live, which renumbers the bridge listing.
+    // Reporting that position would describe neither the request nor the
+    // listing the caller read.
+    const { RuntimeBrowserCommands } = await import('./orca-runtime-browser')
+    const fake = createFakeHeadlessHost(['live-a'], ['parked-b', 'parked-c'])
+    const commands = new RuntimeBrowserCommands(fake.host)
+
+    const result = await commands.browserTabSwitch({ index: 2, worktree: 'id:wt-1' })
+
+    expect(result).toMatchObject({ switched: 2, browserPageId: 'parked-c' })
+  })
+
   it('counts an indexed switch of a resident page as using it', async () => {
     const { RuntimeBrowserCommands } = await import('./orca-runtime-browser')
     const fake = createFakeHeadlessHost(['live-a', 'live-b'], ['parked-c'])

--- a/src/main/runtime/orca-runtime-browser-parked-targeting.test.ts
+++ b/src/main/runtime/orca-runtime-browser-parked-targeting.test.ts
@@ -184,6 +184,18 @@ describe('headless parked-page targeting', () => {
     expect(fake.closedPageIds).toEqual(['parked-c'])
   })
 
+  it('counts `tab current` as using the page it names', async () => {
+    // Why: without this an agent could poll `tab current` continuously and
+    // still have that very page reclaimed under it.
+    const { RuntimeBrowserCommands } = await import('./orca-runtime-browser')
+    const fake = createFakeHeadlessHost(['live-a'], [])
+    const commands = new RuntimeBrowserCommands(fake.host)
+
+    await commands.browserTabCurrent({ worktree: 'id:wt-1' })
+
+    expect(fake.wakeCalls).toEqual(['live-a'])
+  })
+
   it('closes a parked page by index without rebuilding its renderer', async () => {
     // Why: waking a page only to destroy it is pure churn, and a wake that
     // fails would turn a reclaimable page into an unclosable one.

--- a/src/main/runtime/orca-runtime-browser-parked-targeting.test.ts
+++ b/src/main/runtime/orca-runtime-browser-parked-targeting.test.ts
@@ -233,6 +233,36 @@ describe('headless parked-page targeting', () => {
     expect(fake.wakeCalls).toEqual([])
   })
 
+  it('counts a stream ending as page use so the idle clock restarts then', async () => {
+    // Why: streaming pins the page but frames are not activity, so a client
+    // that only watched for longer than the idle window would otherwise have
+    // the page parked ~one recheck after closing the pane.
+    const { RuntimeBrowserCommands } = await import('./orca-runtime-browser')
+    const { startBrowserScreencast } = await import('../browser/browser-screencast-stream')
+    let resolveDone!: () => void
+    const done = new Promise<void>((resolve) => {
+      resolveDone = resolve
+    })
+    vi.mocked(startBrowserScreencast).mockResolvedValue({
+      stop: vi.fn(() => resolveDone()),
+      done
+    } as never)
+    const fake = createFakeHeadlessHost(['live-a'], [])
+    const commands = new RuntimeBrowserCommands(fake.host)
+
+    const started = await commands.browserScreencast(
+      { worktree: 'id:wt-1', page: 'live-a', format: 'jpeg' },
+      { sendBinary: vi.fn() }
+    )
+    const wakesBeforeStop = fake.wakeCalls.length
+
+    started.session.stop()
+    await started.session.done
+
+    await vi.waitFor(() => expect(fake.wakeCalls.length).toBeGreaterThan(wakesBeforeStop))
+    expect(fake.wakeCalls.at(-1)).toBe('live-a')
+  })
+
   it('reports a listed-index overrun against the merged listing', async () => {
     const { RuntimeBrowserCommands } = await import('./orca-runtime-browser')
     const fake = createFakeHeadlessHost(['live-a'], ['parked-b'])

--- a/src/main/runtime/orca-runtime-browser-parked-targeting.test.ts
+++ b/src/main/runtime/orca-runtime-browser-parked-targeting.test.ts
@@ -109,7 +109,7 @@ function createFakeHeadlessHost(live: string[], parked: string[]): FakeHeadlessH
         url: `https://example.test/${browserPageId}`,
         title: browserPageId
       })),
-    getMostRecentlyUsedParkedPageId: () => state.parkedPageIds.at(-1) ?? null
+    getParkedPageIdForImplicitTarget: () => state.parkedPageIds.at(-1) ?? null
   } as unknown as BrowserBackend
 
   state.host = {

--- a/src/main/runtime/orca-runtime-browser-parked-targeting.test.ts
+++ b/src/main/runtime/orca-runtime-browser-parked-targeting.test.ts
@@ -184,6 +184,19 @@ describe('headless parked-page targeting', () => {
     expect(fake.closedPageIds).toEqual(['parked-c'])
   })
 
+  it('closes a parked page by index without rebuilding its renderer', async () => {
+    // Why: waking a page only to destroy it is pure churn, and a wake that
+    // fails would turn a reclaimable page into an unclosable one.
+    const { RuntimeBrowserCommands } = await import('./orca-runtime-browser')
+    const fake = createFakeHeadlessHost(['live-a'], ['parked-b'])
+    const commands = new RuntimeBrowserCommands(fake.host)
+
+    await commands.browserTabClose({ index: 1, worktree: 'id:wt-1' })
+
+    expect(fake.closedPageIds).toEqual(['parked-b'])
+    expect(fake.wakeCalls).toEqual([])
+  })
+
   it('reports a listed-index overrun against the merged listing', async () => {
     const { RuntimeBrowserCommands } = await import('./orca-runtime-browser')
     const fake = createFakeHeadlessHost(['live-a'], ['parked-b'])

--- a/src/main/runtime/orca-runtime-browser-parked-targeting.test.ts
+++ b/src/main/runtime/orca-runtime-browser-parked-targeting.test.ts
@@ -197,6 +197,17 @@ describe('headless parked-page targeting', () => {
     expect(fake.closedPageIds).toEqual(['parked-c'])
   })
 
+  it('resolves `tab current` when the only page is parked', async () => {
+    const { RuntimeBrowserCommands } = await import('./orca-runtime-browser')
+    const fake = createFakeHeadlessHost([], ['parked-a'])
+    const commands = new RuntimeBrowserCommands(fake.host)
+
+    const current = await commands.browserTabCurrent({ worktree: 'id:wt-1' })
+
+    expect(current.tab.browserPageId).toBe('parked-a')
+    expect(fake.wakeCalls).toContain('parked-a')
+  })
+
   it('counts `tab current` as using the page it names', async () => {
     // Why: without this an agent could poll `tab current` continuously and
     // still have that very page reclaimed under it.

--- a/src/main/runtime/orca-runtime-browser-parked-targeting.test.ts
+++ b/src/main/runtime/orca-runtime-browser-parked-targeting.test.ts
@@ -50,7 +50,13 @@ type FakeHeadlessHost = {
   closedPageIds: string[]
 }
 
-function createFakeHeadlessHost(live: string[], parked: string[]): FakeHeadlessHost {
+function createFakeHeadlessHost(
+  live: string[],
+  parked: string[],
+  // Why a separate order: creation order is what the real page book carries;
+  // live-then-parked only coincides with it until something parks.
+  creationOrder: string[] = [...live, ...parked]
+): FakeHeadlessHost {
   const state: FakeHeadlessHost = {
     host: null as unknown as RuntimeBrowserCommandHost,
     livePageIds: [...live],
@@ -109,7 +115,11 @@ function createFakeHeadlessHost(live: string[], parked: string[]): FakeHeadlessH
         url: `https://example.test/${browserPageId}`,
         title: browserPageId
       })),
-    getParkedPageIdForImplicitTarget: () => state.parkedPageIds.at(-1) ?? null
+    getParkedPageIdForImplicitTarget: () => state.parkedPageIds.at(-1) ?? null,
+    listOpenPageIds: () =>
+      creationOrder.filter(
+        (id) => state.livePageIds.includes(id) || state.parkedPageIds.includes(id)
+      )
   } as unknown as BrowserBackend
 
   state.host = {
@@ -143,6 +153,22 @@ describe('headless parked-page targeting', () => {
       ['parked-c', 2, true]
     ])
     expect(fake.wakeCalls).toEqual([])
+  })
+
+  it('keeps a tab index stable when an older tab parks', async () => {
+    // Why: pre-reclaim, headless indices moved only on create/close. A listing
+    // ordered by residency would let a background park renumber an index the
+    // agent read minutes earlier, silently retargeting its next command.
+    const { RuntimeBrowserCommands } = await import('./orca-runtime-browser')
+    const fake = createFakeHeadlessHost(['live-b'], ['parked-a'], ['parked-a', 'live-b'])
+    const commands = new RuntimeBrowserCommands(fake.host)
+
+    const listed = await commands.browserTabList({ worktree: 'id:wt-1' })
+
+    expect(listed.tabs.map((tab) => [tab.browserPageId, tab.index, tab.parked === true])).toEqual([
+      ['parked-a', 0, true],
+      ['live-b', 1, false]
+    ])
   })
 
   it('switches to the page the listed index named, not one an implicit wake promoted', async () => {

--- a/src/main/runtime/orca-runtime-browser-parked-targeting.test.ts
+++ b/src/main/runtime/orca-runtime-browser-parked-targeting.test.ts
@@ -233,6 +233,45 @@ describe('headless parked-page targeting', () => {
     expect(fake.wakeCalls).toEqual([])
   })
 
+  it('pins a page for the reclaimer exactly while a client streams it', async () => {
+    // Why: the reclaimer's streamed-page veto rides on this signal; if it goes
+    // false while a stream runs, a watched pane blacks out mid-view.
+    const { RuntimeBrowserCommands } = await import('./orca-runtime-browser')
+    const { startBrowserScreencast } = await import('../browser/browser-screencast-stream')
+    let resolveDone!: () => void
+    const done = new Promise<void>((resolve) => {
+      resolveDone = resolve
+    })
+    vi.mocked(startBrowserScreencast).mockResolvedValue({
+      stop: vi.fn(() => resolveDone()),
+      done
+    } as never)
+    const fake = createFakeHeadlessHost(['live-a'], [])
+    const commands = new RuntimeBrowserCommands(fake.host)
+    expect(commands.isBrowserPageStreamed('live-a')).toBe(false)
+
+    const started = await commands.browserScreencast(
+      { worktree: 'id:wt-1', page: 'live-a', format: 'jpeg' },
+      { sendBinary: vi.fn() }
+    )
+    expect(commands.isBrowserPageStreamed('live-a')).toBe(true)
+
+    started.session.stop()
+    await started.session.done
+    expect(commands.isBrowserPageStreamed('live-a')).toBe(false)
+  })
+
+  it('closes a parked page by explicit id without rebuilding its renderer', async () => {
+    const fake = createFakeHeadlessHost(['live-a'], ['parked-b'])
+    const { RuntimeBrowserCommands } = await import('./orca-runtime-browser')
+    const commands = new RuntimeBrowserCommands(fake.host)
+
+    await commands.browserTabClose({ page: 'parked-b', worktree: 'id:wt-1' })
+
+    expect(fake.closedPageIds).toEqual(['parked-b'])
+    expect(fake.wakeCalls).toEqual([])
+  })
+
   it('counts a stream ending as page use so the idle clock restarts then', async () => {
     // Why: streaming pins the page but frames are not activity, so a client
     // that only watched for longer than the idle window would otherwise have

--- a/src/main/runtime/orca-runtime-browser-parked-targeting.test.ts
+++ b/src/main/runtime/orca-runtime-browser-parked-targeting.test.ts
@@ -1,0 +1,196 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AgentBrowserBridge } from '../browser/agent-browser-bridge'
+import type { BrowserBackend, ParkedBrowserPage } from '../browser/browser-backend'
+import type { RuntimeBrowserCommandHost } from './orca-runtime-browser'
+
+// Why (STA-4341): a headless listing spans resident and parked pages, so every
+// index-addressed command has to resolve against that listing — and resolve it
+// before any implicit wake reorders it. These drive the shipping runtime methods
+// against a backend that models park/wake the way the real one behaves.
+
+const { webContentsFromIdMock, browserSessionRegistryMock, browserManagerMock } = vi.hoisted(
+  () => ({
+    webContentsFromIdMock: vi.fn(),
+    browserSessionRegistryMock: {
+      getDefaultProfile: vi.fn(() => ({ id: 'default', partition: 'p', label: 'Default' })),
+      getProfile: vi.fn(() => ({ id: 'default', partition: 'p', label: 'Default' }))
+    },
+    browserManagerMock: {
+      getSessionProfileIdForTab: vi.fn(() => 'default'),
+      getWorktreeIdForTab: vi.fn(() => 'wt-1')
+    }
+  })
+)
+
+vi.mock('electron', () => ({
+  ipcMain: { on: vi.fn(), removeListener: vi.fn() },
+  webContents: { fromId: webContentsFromIdMock }
+}))
+vi.mock('../browser/browser-session-registry', () => ({
+  browserSessionRegistry: browserSessionRegistryMock
+}))
+vi.mock('../browser/browser-manager', () => ({
+  browserManager: browserManagerMock,
+  browserCertificateTrustController: {}
+}))
+vi.mock('../browser/browser-screencast-stream', () => ({ startBrowserScreencast: vi.fn() }))
+vi.mock('../ipc/browser-tab-registration-wait', () => ({
+  waitForTabRegistration: vi.fn(async () => {}),
+  waitForWorktreeTabRegistration: vi.fn(async () => {})
+}))
+
+type FakeHeadlessHost = {
+  host: RuntimeBrowserCommandHost
+  /** Pages with a live renderer, in bridge listing order. */
+  livePageIds: string[]
+  /** Parked pages, most-recently-used last. */
+  parkedPageIds: string[]
+  wakeCalls: string[]
+  switchCalls: { worktreeId?: string; browserPageId?: string; index?: number }[]
+  closedPageIds: string[]
+}
+
+function createFakeHeadlessHost(live: string[], parked: string[]): FakeHeadlessHost {
+  const state: FakeHeadlessHost = {
+    host: null as unknown as RuntimeBrowserCommandHost,
+    livePageIds: [...live],
+    parkedPageIds: [...parked],
+    wakeCalls: [],
+    switchCalls: [],
+    closedPageIds: []
+  }
+
+  const bridge = {
+    tabList: () => ({
+      tabs: state.livePageIds.map((browserPageId, index) => ({
+        browserPageId,
+        index,
+        url: `https://example.test/${browserPageId}`,
+        title: browserPageId,
+        active: index === 0
+      }))
+    }),
+    getRegisteredTabs: () => new Map(state.livePageIds.map((id, index) => [id, 100 + index])),
+    getActivePageId: () => state.livePageIds[0] ?? null,
+    getActiveWebContentsId: () => (state.livePageIds.length > 0 ? 100 : null),
+    tabSwitch: vi.fn(
+      async (index: number | undefined, worktreeId?: string, browserPageId?: string) => {
+        state.switchCalls.push({ index, worktreeId, browserPageId })
+        const resolved = browserPageId ?? state.livePageIds[index ?? 0]
+        return { switched: state.livePageIds.indexOf(resolved), browserPageId: resolved }
+      }
+    )
+  } as unknown as AgentBrowserBridge
+
+  const backend = {
+    createTab: vi.fn(),
+    closeTab: vi.fn(async (browserPageId: string) => {
+      state.closedPageIds.push(browserPageId)
+      state.livePageIds = state.livePageIds.filter((id) => id !== browserPageId)
+      state.parkedPageIds = state.parkedPageIds.filter((id) => id !== browserPageId)
+    }),
+    // Why: waking makes a parked page live, which appends it to the bridge
+    // listing — that reordering is exactly what an index must not be resolved
+    // after.
+    wakeTab: vi.fn(async (browserPageId: string) => {
+      state.wakeCalls.push(browserPageId)
+      if (state.parkedPageIds.includes(browserPageId)) {
+        state.parkedPageIds = state.parkedPageIds.filter((id) => id !== browserPageId)
+        state.livePageIds.push(browserPageId)
+        return true
+      }
+      return state.livePageIds.includes(browserPageId)
+    }),
+    listParkedPages: (): ParkedBrowserPage[] =>
+      state.parkedPageIds.map((browserPageId) => ({
+        browserPageId,
+        worktreeId: 'wt-1',
+        profileId: 'default',
+        url: `https://example.test/${browserPageId}`,
+        title: browserPageId
+      })),
+    getMostRecentlyUsedParkedPageId: () => state.parkedPageIds.at(-1) ?? null
+  } as unknown as BrowserBackend
+
+  state.host = {
+    resolveWorktreeSelector: async (selector: string) => ({ id: selector.replace(/^id:/, '') }),
+    getAuthoritativeWindow: vi.fn(() => {
+      throw new Error('No renderer window available')
+    }),
+    getAvailableAuthoritativeWindow: () => null,
+    getOffscreenBrowserBackend: () => backend,
+    getAgentBrowserBridge: () => bridge
+  } as unknown as RuntimeBrowserCommandHost
+  return state
+}
+
+beforeEach(() => {
+  webContentsFromIdMock.mockReset()
+  webContentsFromIdMock.mockImplementation(() => ({ isDestroyed: () => false }))
+})
+
+describe('headless parked-page targeting', () => {
+  it('lists parked pages after resident ones without waking any renderer', async () => {
+    const { RuntimeBrowserCommands } = await import('./orca-runtime-browser')
+    const fake = createFakeHeadlessHost(['live-a'], ['parked-b', 'parked-c'])
+    const commands = new RuntimeBrowserCommands(fake.host)
+
+    const listed = await commands.browserTabList({ worktree: 'id:wt-1' })
+
+    expect(listed.tabs.map((tab) => [tab.browserPageId, tab.index, tab.parked === true])).toEqual([
+      ['live-a', 0, false],
+      ['parked-b', 1, true],
+      ['parked-c', 2, true]
+    ])
+    expect(fake.wakeCalls).toEqual([])
+  })
+
+  it('switches to the page the listed index named, not one an implicit wake promoted', async () => {
+    // Why: with every page parked, resolving the worktree first wakes the most
+    // recently used one, which makes it live and moves it to listing index 0.
+    const { RuntimeBrowserCommands } = await import('./orca-runtime-browser')
+    const fake = createFakeHeadlessHost([], ['parked-a', 'parked-b'])
+    const commands = new RuntimeBrowserCommands(fake.host)
+
+    const listedBefore = await commands.browserTabList({ worktree: 'id:wt-1' })
+    expect(listedBefore.tabs[0].browserPageId).toBe('parked-a')
+
+    const result = await commands.browserTabSwitch({ index: 0, worktree: 'id:wt-1' })
+
+    expect(result.browserPageId).toBe('parked-a')
+    expect(fake.switchCalls).toEqual([
+      { index: undefined, worktreeId: 'wt-1', browserPageId: 'parked-a' }
+    ])
+  })
+
+  it('counts an indexed switch of a resident page as using it', async () => {
+    const { RuntimeBrowserCommands } = await import('./orca-runtime-browser')
+    const fake = createFakeHeadlessHost(['live-a', 'live-b'], ['parked-c'])
+    const commands = new RuntimeBrowserCommands(fake.host)
+
+    await commands.browserTabSwitch({ index: 1, worktree: 'id:wt-1' })
+
+    expect(fake.wakeCalls).toEqual(['live-b'])
+    expect(fake.switchCalls.at(-1)?.browserPageId).toBe('live-b')
+  })
+
+  it('closes the page the listed index named when the listing is mixed', async () => {
+    const { RuntimeBrowserCommands } = await import('./orca-runtime-browser')
+    const fake = createFakeHeadlessHost(['live-a'], ['parked-b', 'parked-c'])
+    const commands = new RuntimeBrowserCommands(fake.host)
+
+    await commands.browserTabClose({ index: 2, worktree: 'id:wt-1' })
+
+    expect(fake.closedPageIds).toEqual(['parked-c'])
+  })
+
+  it('reports a listed-index overrun against the merged listing', async () => {
+    const { RuntimeBrowserCommands } = await import('./orca-runtime-browser')
+    const fake = createFakeHeadlessHost(['live-a'], ['parked-b'])
+    const commands = new RuntimeBrowserCommands(fake.host)
+
+    await expect(commands.browserTabClose({ index: 5, worktree: 'id:wt-1' })).rejects.toThrow(
+      'Tab index 5 out of range (0-1)'
+    )
+  })
+})

--- a/src/main/runtime/orca-runtime-browser-parked-targeting.test.ts
+++ b/src/main/runtime/orca-runtime-browser-parked-targeting.test.ts
@@ -171,6 +171,22 @@ describe('headless parked-page targeting', () => {
     ])
   })
 
+  it('reports listing indices, not bridge registration order, from show and switch', async () => {
+    // Why: a park+wake permutes the bridge's registration order. The index a
+    // caller gets back must name the same tab in the listing they read, or
+    // chaining it into --index addresses a different tab.
+    const { RuntimeBrowserCommands } = await import('./orca-runtime-browser')
+    const fake = createFakeHeadlessHost(['c', 'a'], [], ['a', 'c'])
+    const commands = new RuntimeBrowserCommands(fake.host)
+
+    const current = await commands.browserTabCurrent({ worktree: 'id:wt-1' })
+    expect(current.tab.browserPageId).toBe('c')
+    expect(current.tab.index).toBe(1)
+
+    const switched = await commands.browserTabSwitch({ page: 'c', worktree: 'id:wt-1' })
+    expect(switched).toMatchObject({ browserPageId: 'c', switched: 1 })
+  })
+
   it('switches to the page the listed index named, not one an implicit wake promoted', async () => {
     // Why: with every page parked, resolving the worktree first wakes the most
     // recently used one, which makes it live and moves it to listing index 0.

--- a/src/main/runtime/orca-runtime-browser.test.ts
+++ b/src/main/runtime/orca-runtime-browser.test.ts
@@ -858,6 +858,7 @@ describe('RuntimeBrowserCommands headless offscreen routing', () => {
     const keyboardInsertText = vi.fn().mockResolvedValue({ inserted: true })
     const bridge = {
       getRegisteredTabs: vi.fn(() => new Map([['page-1', 100]])),
+      getActivePageId: vi.fn(() => 'page-1'),
       keyboardInsertText
     } as unknown as AgentBrowserBridge
     const commands = new RuntimeBrowserCommands(

--- a/src/main/runtime/orca-runtime-browser.ts
+++ b/src/main/runtime/orca-runtime-browser.ts
@@ -655,6 +655,28 @@ export class RuntimeBrowserCommands {
   // it into opening yet another one, which is the leak this fixes. Every
   // index-addressed command resolves through this same list so `tab list`
   // indices and `--index` never disagree.
+  /** Headless serve with the parked-aware, creation-ordered listing. */
+  private isHeadlessOffscreenListing(): boolean {
+    return (
+      this.host.getOffscreenBrowserBackend()?.listOpenPageIds !== undefined &&
+      !this.host.getAvailableAuthoritativeWindow()
+    )
+  }
+
+  /** The page's position in the creation-ordered listing; null on desktop. */
+  private headlessListedTabIndex(
+    worktreeId: string | undefined,
+    browserPageId: string
+  ): number | null {
+    if (!this.isHeadlessOffscreenListing()) {
+      return null
+    }
+    const index = this.listBrowserTabsIncludingParked(worktreeId).findIndex(
+      (tab) => tab.browserPageId === browserPageId
+    )
+    return index === -1 ? null : index
+  }
+
   private listBrowserTabsIncludingParked(
     worktreeId: string | undefined
   ): BrowserTabListResult['tabs'] {
@@ -770,12 +792,13 @@ export class RuntimeBrowserCommands {
       target.worktreeId,
       target.browserPageId
     )
-    // Why (STA-4341): waking the target makes it live, which renumbers the
-    // bridge's own listing. Report the index the caller passed — the one the
-    // listing they read actually names — rather than a position that describes
-    // neither their request nor what they were looking at.
-    const result =
-      indexed && params.index !== undefined ? { ...switched, switched: params.index } : switched
+    // Why (STA-4341): the bridge computes `switched` over its registration
+    // order, which any park+wake permutes. Report the target's position in the
+    // creation-ordered listing instead — the same number `tab list` prints and
+    // `--index` resolves against — or a caller chaining the reported number
+    // into `--index` addresses a different tab than the one it switched to.
+    const listedIndex = this.headlessListedTabIndex(target.worktreeId, switched.browserPageId)
+    const result = listedIndex === null ? switched : { ...switched, switched: listedIndex }
     if (params.focus) {
       // Why: scope focus to the tab's owning worktree; the renderer never yanks the user across worktrees on this signal (see focusBrowserTabInWorktree).
       const worktreeId =
@@ -1874,17 +1897,30 @@ export class RuntimeBrowserCommands {
     explicitWorktreeId?: string
   ): BrowserTabListResult['tabs'][number] {
     const worktreeId = explicitWorktreeId ?? browserManager.getWorktreeIdForTab(browserPageId)
-    const tab = this.requireAgentBrowserBridge()
-      .tabList(worktreeId)
-      .tabs.find((entry) => entry.browserPageId === browserPageId)
-    if (!tab) {
-      const scope = worktreeId ? ' in this worktree' : ''
-      throw new BrowserError(
-        'browser_tab_not_found',
-        `Browser page ${browserPageId} was not found${scope}`
+    // Why (STA-4341): the bridge numbers tabs by registration order, which any
+    // park+wake permutes. Every index a headless caller sees must come from the
+    // creation-ordered listing `tab list` prints, or `tab show`/`tab current`
+    // report a number that names a different tab in that listing.
+    if (this.isHeadlessOffscreenListing()) {
+      const tab = this.listBrowserTabsIncludingParked(worktreeId).find(
+        (entry) => entry.browserPageId === browserPageId
       )
+      if (tab) {
+        return tab
+      }
+    } else {
+      const tab = this.requireAgentBrowserBridge()
+        .tabList(worktreeId)
+        .tabs.find((entry) => entry.browserPageId === browserPageId)
+      if (tab) {
+        return this.enrichBrowserTabInfo(tab)
+      }
     }
-    return this.enrichBrowserTabInfo(tab)
+    const scope = worktreeId ? ' in this worktree' : ''
+    throw new BrowserError(
+      'browser_tab_not_found',
+      `Browser page ${browserPageId} was not found${scope}`
+    )
   }
 
   // Why: headless serve path — the offscreen backend registers synchronously, so there is no webview-mount wait.

--- a/src/main/runtime/orca-runtime-browser.ts
+++ b/src/main/runtime/orca-runtime-browser.ts
@@ -60,6 +60,7 @@ import { BrowserError } from '../browser/cdp-bridge'
 import { startBrowserScreencast } from '../browser/browser-screencast-stream'
 import type { BrowserScreencastSession } from '../browser/browser-screencast-stream-types'
 import { browserSessionRegistry } from '../browser/browser-session-registry'
+import { mergeParkedBrowserTabs } from '../browser/headless-browser-tab-listing'
 import {
   detectInstalledBrowsers,
   importCookiesFromBrowser,
@@ -651,25 +652,20 @@ export class RuntimeBrowserCommands {
   private listBrowserTabsIncludingParked(
     worktreeId: string | undefined
   ): BrowserTabListResult['tabs'] {
-    const live = this.requireAgentBrowserBridge()
-      .tabList(worktreeId)
-      .tabs.map((tab) => this.enrichBrowserTabInfo(tab))
-    const parked = (
+    const merged = mergeParkedBrowserTabs(
+      this.requireAgentBrowserBridge().tabList(worktreeId).tabs,
       this.host.getOffscreenBrowserBackend()?.listParkedPages?.(worktreeId) ?? []
-    ).map((page, offset): BrowserTabListResult['tabs'][number] => ({
-      browserPageId: page.browserPageId,
-      index: live.length + offset,
-      url: page.url,
-      title: page.title,
-      active: false,
-      parked: true,
-      worktreeId: page.worktreeId ?? null,
-      profileId: page.profileId ?? null,
-      profileLabel:
-        browserSessionRegistry.getProfile(page.profileId ?? 'default')?.label ??
-        browserSessionRegistry.getDefaultProfile().label
-    }))
-    return [...live, ...parked]
+    )
+    return merged.map((tab) =>
+      tab.parked
+        ? {
+            ...tab,
+            profileLabel:
+              browserSessionRegistry.getProfile(tab.profileId ?? 'default')?.label ??
+              browserSessionRegistry.getDefaultProfile().label
+          }
+        : this.enrichBrowserTabInfo(tab)
+    )
   }
 
   /**

--- a/src/main/runtime/orca-runtime-browser.ts
+++ b/src/main/runtime/orca-runtime-browser.ts
@@ -675,7 +675,8 @@ export class RuntimeBrowserCommands {
    */
   private async resolveIndexedParkedAwarePageId(
     worktreeId: string | undefined,
-    index: number
+    index: number,
+    options: { wake?: boolean } = {}
   ): Promise<string | null> {
     const offscreen = this.host.getOffscreenBrowserBackend()
     if (!offscreen?.listParkedPages || this.host.getAvailableAuthoritativeWindow()) {
@@ -689,9 +690,13 @@ export class RuntimeBrowserCommands {
         `Tab index ${index} out of range (0-${tabs.length - 1})`
       )
     }
-    // Why: waking unconditionally also restarts the reclaim clock, so selecting
-    // a resident page counts as using it rather than leaving it up for eviction.
-    await offscreen.wakeTab?.(chosen.browserPageId)
+    // Why: waking also restarts the reclaim clock, so selecting a resident page
+    // counts as using it rather than leaving it up for eviction. A close opts
+    // out — rebuilding a renderer only to destroy it is pure churn, and a wake
+    // that fails would turn a reclaimable page into an unclosable one.
+    if (options.wake !== false) {
+      await offscreen.wakeTab?.(chosen.browserPageId)
+    }
     return chosen.browserPageId
   }
 
@@ -1742,7 +1747,9 @@ export class RuntimeBrowserCommands {
       // Why (STA-4341): a headless listing includes parked pages, so an index
       // must be resolved against that same listing or `tab close --index` can
       // destroy a different tab than the one the caller read.
-      tabId = await this.resolveIndexedParkedAwarePageId(worktreeId, params.index)
+      tabId = await this.resolveIndexedParkedAwarePageId(worktreeId, params.index, {
+        wake: false
+      })
       if (tabId === null) {
         const entries = [...bridge.getRegisteredTabs(worktreeId).entries()]
         if (params.index < 0 || params.index >= entries.length) {

--- a/src/main/runtime/orca-runtime-browser.ts
+++ b/src/main/runtime/orca-runtime-browser.ts
@@ -757,11 +757,17 @@ export class RuntimeBrowserCommands {
     // or `tab switch --index 0` selects a different tab than the one it showed.
     const indexed = await this.resolveIndexedTargetBeforeWake(params)
     const target = indexed ?? (await this.resolveBrowserCommandTarget(params))
-    const result = await bridge.tabSwitch(
+    const switched = await bridge.tabSwitch(
       indexed ? undefined : params.index,
       target.worktreeId,
       target.browserPageId
     )
+    // Why (STA-4341): waking the target makes it live, which renumbers the
+    // bridge's own listing. Report the index the caller passed — the one the
+    // listing they read actually names — rather than a position that describes
+    // neither their request nor what they were looking at.
+    const result =
+      indexed && params.index !== undefined ? { ...switched, switched: params.index } : switched
     if (params.focus) {
       // Why: scope focus to the tab's owning worktree; the renderer never yanks the user across worktrees on this signal (see focusBrowserTabInWorktree).
       const worktreeId =

--- a/src/main/runtime/orca-runtime-browser.ts
+++ b/src/main/runtime/orca-runtime-browser.ts
@@ -737,6 +737,10 @@ export class RuntimeBrowserCommands {
     if (!browserPageId) {
       throw new BrowserError('browser_no_tab', 'No browser tab open in this worktree')
     }
+    // Why (STA-4341): this names a page like any other page-targeting command,
+    // so it has to count as using it. Without this an agent could poll `tab
+    // current` continuously and still have that very page reclaimed under it.
+    await this.markHeadlessBrowserPageUsed(browserPageId)
     return { tab: this.describeBrowserTab(browserPageId, worktreeId) }
   }
 

--- a/src/main/runtime/orca-runtime-browser.ts
+++ b/src/main/runtime/orca-runtime-browser.ts
@@ -327,7 +327,7 @@ export class RuntimeBrowserCommands {
     // Read-only callers opt out — listing tabs must never cost a renderer.
     if (options.wakeParkedPage !== false && !this.host.getAvailableAuthoritativeWindow()) {
       const offscreen = this.host.getOffscreenBrowserBackend()
-      const parkedPageId = offscreen?.getMostRecentlyUsedParkedPageId?.(worktreeId)
+      const parkedPageId = offscreen?.getParkedPageIdForImplicitTarget?.(worktreeId)
       if (parkedPageId && (await offscreen?.wakeTab?.(parkedPageId))) {
         return
       }
@@ -1768,7 +1768,7 @@ export class RuntimeBrowserCommands {
       const resolvedTabId =
         tabId ??
         bridge.getActivePageId(worktreeId) ??
-        offscreen.getMostRecentlyUsedParkedPageId?.(worktreeId) ??
+        offscreen.getParkedPageIdForImplicitTarget?.(worktreeId) ??
         null
       if (!resolvedTabId) {
         return { closed: false }

--- a/src/main/runtime/orca-runtime-browser.ts
+++ b/src/main/runtime/orca-runtime-browser.ts
@@ -658,9 +658,11 @@ export class RuntimeBrowserCommands {
   private listBrowserTabsIncludingParked(
     worktreeId: string | undefined
   ): BrowserTabListResult['tabs'] {
+    const offscreen = this.host.getOffscreenBrowserBackend()
     const merged = mergeParkedBrowserTabs(
       this.requireAgentBrowserBridge().tabList(worktreeId).tabs,
-      this.host.getOffscreenBrowserBackend()?.listParkedPages?.(worktreeId) ?? []
+      offscreen?.listParkedPages?.(worktreeId) ?? [],
+      offscreen?.listOpenPageIds?.(worktreeId)
     )
     return merged.map((tab) =>
       tab.parked

--- a/src/main/runtime/orca-runtime-browser.ts
+++ b/src/main/runtime/orca-runtime-browser.ts
@@ -76,6 +76,11 @@ export type BrowserCommandTargetParams = {
   page?: string
 }
 
+type BrowserWorktreeResolutionOptions = {
+  /** Whether an implicit target may wake a parked headless page. */
+  wakeParkedPage?: boolean
+}
+
 type ResolvedBrowserCommandTarget = {
   worktreeId?: string
   browserPageId?: string
@@ -175,6 +180,12 @@ export class RuntimeBrowserCommands {
     return bridge
   }
 
+  // Why (STA-4341): a page a paired client is streaming must never be parked —
+  // the reclaimer would black out a pane the user is actively looking at.
+  isBrowserPageStreamed(browserPageId: string): boolean {
+    return this.activeScreencastPageIds.has(browserPageId)
+  }
+
   private hasLiveRegisteredBrowserTab(
     bridge: AgentBrowserBridge,
     worktreeId: string | undefined
@@ -202,13 +213,16 @@ export class RuntimeBrowserCommands {
   }
 
   // Why: the CLI sends selectors (e.g. "path:/...") but the bridge keys tabs by "repoId::path"; resolve to that store-compatible id.
-  private async resolveBrowserWorktreeId(selector?: string): Promise<string | undefined> {
+  private async resolveBrowserWorktreeId(
+    selector?: string,
+    options: BrowserWorktreeResolutionOptions = {}
+  ): Promise<string | undefined> {
     if (!selector) {
       // Why: after restart, webviews mount only when the pane is visible; activate the view so persisted tabs become operable via registerGuest.
       const bridge = this.host.getAgentBrowserBridge()
       if (bridge && !this.hasLiveRegisteredBrowserTab(bridge, undefined)) {
         try {
-          await this.ensureBrowserWorktreeActive(undefined)
+          await this.ensureBrowserWorktreeActive(undefined, options)
         } catch {
           // Window may not exist yet (e.g. during startup or in tests)
         }
@@ -221,7 +235,7 @@ export class RuntimeBrowserCommands {
     const bridge = this.host.getAgentBrowserBridge()
     if (bridge && !this.hasLiveRegisteredBrowserTab(bridge, worktreeId)) {
       try {
-        await this.ensureBrowserWorktreeActive(worktreeId)
+        await this.ensureBrowserWorktreeActive(worktreeId, options)
       } catch {
         // Fall through with the validated worktree id so routing stays scoped to the caller's explicit selector.
       }
@@ -235,16 +249,25 @@ export class RuntimeBrowserCommands {
     const browserPageId =
       typeof params.page === 'string' && params.page.length > 0 ? params.page : undefined
     if (!browserPageId) {
-      return {
-        worktreeId: await this.resolveBrowserWorktreeId(params.worktree)
-      }
+      const worktreeId = await this.resolveBrowserWorktreeId(params.worktree)
+      // Why (STA-4341): an implicit target still counts as using its page, or a
+      // steady stream of `--page`-less commands would let the reclaim clock run
+      // out under the very agent that is driving the tab.
+      await this.markHeadlessBrowserPageUsed(
+        this.host.getAgentBrowserBridge()?.getActivePageId(worktreeId) ?? undefined
+      )
+      return { worktreeId }
     }
 
     const worktreeId = params.worktree
       ? (await this.host.resolveWorktreeSelector(params.worktree)).id
       : undefined
+    // Why (STA-4341): a headless page's renderer may have been reclaimed, or be
+    // mid-reclaim right now. Asking the backend first both wakes it and
+    // serialises against that teardown; it is a no-op for a resident page.
+    const woken = await this.markHeadlessBrowserPageUsed(browserPageId)
     const bridge = this.host.getAgentBrowserBridge()
-    if (bridge && !this.hasLiveRegisteredBrowserPage(bridge, worktreeId, browserPageId)) {
+    if (!woken && bridge && !this.hasLiveRegisteredBrowserPage(bridge, worktreeId, browserPageId)) {
       try {
         await this.ensureBrowserPageActive(worktreeId, browserPageId)
       } catch {
@@ -256,6 +279,13 @@ export class RuntimeBrowserCommands {
       worktreeId,
       browserPageId
     }
+  }
+
+  private async markHeadlessBrowserPageUsed(browserPageId: string | undefined): Promise<boolean> {
+    if (!browserPageId || this.host.getAvailableAuthoritativeWindow()) {
+      return false
+    }
+    return (await this.host.getOffscreenBrowserBackend()?.wakeTab?.(browserPageId)) === true
   }
 
   private resolveBrowserPageWebContents(
@@ -286,7 +316,21 @@ export class RuntimeBrowserCommands {
   }
 
   // Why: background-mount the worktree via a hidden visibility lease so the webview guest can register without stealing the user's visible pane.
-  private async ensureBrowserWorktreeActive(worktreeId: string | undefined): Promise<void> {
+  private async ensureBrowserWorktreeActive(
+    worktreeId: string | undefined,
+    options: BrowserWorktreeResolutionOptions = {}
+  ): Promise<void> {
+    // Why: on headless serve an implicit target (no --page) must still find a
+    // page when every page in the worktree is parked; wake the most recently
+    // used one rather than every one, so reclamation is not undone wholesale.
+    // Read-only callers opt out — listing tabs must never cost a renderer.
+    if (options.wakeParkedPage !== false && !this.host.getAvailableAuthoritativeWindow()) {
+      const offscreen = this.host.getOffscreenBrowserBackend()
+      const parkedPageId = offscreen?.getMostRecentlyUsedParkedPageId?.(worktreeId)
+      if (parkedPageId && (await offscreen?.wakeTab?.(parkedPageId))) {
+        return
+      }
+    }
     const win = this.host.getAuthoritativeWindow()
     win.webContents.send('browser:activateView', worktreeId ? { worktreeId } : {})
     // Why: the pane is operable only after the webview mounts and calls registerGuest; wait on that IPC rather than a flaky fixed sleep.
@@ -593,11 +637,66 @@ export class RuntimeBrowserCommands {
   }
 
   async browserTabList(params: { worktree?: string }): Promise<BrowserTabListResult> {
-    const worktreeId = await this.resolveBrowserWorktreeId(params.worktree)
-    const result = this.requireAgentBrowserBridge().tabList(worktreeId)
-    return {
-      tabs: result.tabs.map((tab) => this.enrichBrowserTabInfo(tab))
+    const worktreeId = await this.resolveBrowserWorktreeId(params.worktree, {
+      wakeParkedPage: false
+    })
+    return { tabs: this.listBrowserTabsIncludingParked(worktreeId) }
+  }
+
+  // Why (STA-4341): a parked page is open — it just has no renderer right now.
+  // Dropping it from the listing would tell an agent its tab is gone and push
+  // it into opening yet another one, which is the leak this fixes. Every
+  // index-addressed command resolves through this same list so `tab list`
+  // indices and `--index` never disagree.
+  private listBrowserTabsIncludingParked(
+    worktreeId: string | undefined
+  ): BrowserTabListResult['tabs'] {
+    const live = this.requireAgentBrowserBridge()
+      .tabList(worktreeId)
+      .tabs.map((tab) => this.enrichBrowserTabInfo(tab))
+    const parked = (
+      this.host.getOffscreenBrowserBackend()?.listParkedPages?.(worktreeId) ?? []
+    ).map((page, offset): BrowserTabListResult['tabs'][number] => ({
+      browserPageId: page.browserPageId,
+      index: live.length + offset,
+      url: page.url,
+      title: page.title,
+      active: false,
+      parked: true,
+      worktreeId: page.worktreeId ?? null,
+      profileId: page.profileId ?? null,
+      profileLabel:
+        browserSessionRegistry.getProfile(page.profileId ?? 'default')?.label ??
+        browserSessionRegistry.getDefaultProfile().label
+    }))
+    return [...live, ...parked]
+  }
+
+  /**
+   * Resolve an `--index` against the listing the caller saw, waking the target
+   * when it names a parked page. Returns null on desktop, where there are no
+   * parked pages and the bridge's own index handling still applies.
+   */
+  private async resolveIndexedParkedAwarePageId(
+    worktreeId: string | undefined,
+    index: number
+  ): Promise<string | null> {
+    const offscreen = this.host.getOffscreenBrowserBackend()
+    if (!offscreen?.listParkedPages || this.host.getAvailableAuthoritativeWindow()) {
+      return null
     }
+    const tabs = this.listBrowserTabsIncludingParked(worktreeId)
+    const chosen = tabs[index]
+    if (!chosen) {
+      throw new BrowserError(
+        'browser_tab_not_found',
+        `Tab index ${index} out of range (0-${tabs.length - 1})`
+      )
+    }
+    if (chosen.parked) {
+      await offscreen.wakeTab?.(chosen.browserPageId)
+    }
+    return chosen.browserPageId
   }
 
   async browserProceedCertificate(
@@ -632,7 +731,15 @@ export class RuntimeBrowserCommands {
   ): Promise<BrowserTabSwitchResult> {
     const target = await this.resolveBrowserCommandTarget(params)
     const bridge = this.requireAgentBrowserBridge()
-    const result = await bridge.tabSwitch(params.index, target.worktreeId, target.browserPageId)
+    const indexedPageId =
+      params.index !== undefined && !target.browserPageId
+        ? await this.resolveIndexedParkedAwarePageId(target.worktreeId, params.index)
+        : null
+    const result = await bridge.tabSwitch(
+      indexedPageId ? undefined : params.index,
+      target.worktreeId,
+      target.browserPageId ?? indexedPageId ?? undefined
+    )
     if (params.focus) {
       // Why: scope focus to the tab's owning worktree; the renderer never yanks the user across worktrees on this signal (see focusBrowserTabInWorktree).
       const worktreeId =
@@ -1613,18 +1720,23 @@ export class RuntimeBrowserCommands {
       ? params.worktree
         ? (await this.host.resolveWorktreeSelector(params.worktree)).id
         : undefined
-      : await this.resolveBrowserWorktreeId(params.worktree)
+      : await this.resolveBrowserWorktreeId(params.worktree, { wakeParkedPage: false })
 
     let tabId: string | null = null
     if (typeof params.page === 'string' && params.page.length > 0) {
       tabId = params.page
     } else if (params.index !== undefined) {
-      const tabs = bridge.getRegisteredTabs(worktreeId)
-      const entries = [...tabs.entries()]
-      if (params.index < 0 || params.index >= entries.length) {
-        throw new Error(`Tab index ${params.index} out of range (0-${entries.length - 1})`)
+      // Why (STA-4341): a headless listing includes parked pages, so an index
+      // must be resolved against that same listing or `tab close --index` can
+      // destroy a different tab than the one the caller read.
+      tabId = await this.resolveIndexedParkedAwarePageId(worktreeId, params.index)
+      if (tabId === null) {
+        const entries = [...bridge.getRegisteredTabs(worktreeId).entries()]
+        if (params.index < 0 || params.index >= entries.length) {
+          throw new Error(`Tab index ${params.index} out of range (0-${entries.length - 1})`)
+        }
+        tabId = entries[params.index][0]
       }
-      tabId = entries[params.index][0]
     } else {
       // Why: try the bridge first; fall back to the renderer for tabs whose webview hasn't mounted yet (e.g. just created).
       const tabs = bridge.getRegisteredTabs(worktreeId)
@@ -1640,11 +1752,20 @@ export class RuntimeBrowserCommands {
     const offscreen = authoritativeWindow ? null : this.host.getOffscreenBrowserBackend()
     if (offscreen) {
       // Why: resolve the active page for implicit close so we don't report success while closing nothing.
-      const resolvedTabId = tabId ?? bridge.getActivePageId(worktreeId)
+      const resolvedTabId =
+        tabId ??
+        bridge.getActivePageId(worktreeId) ??
+        offscreen.getMostRecentlyUsedParkedPageId?.(worktreeId) ??
+        null
       if (!resolvedTabId) {
         return { closed: false }
       }
-      if (explicitPage && !bridge.getRegisteredTabs(worktreeId).has(resolvedTabId)) {
+      // Why (STA-4341): a parked page is still open, so closing one must not
+      // report "not found" — and must not wake a renderer just to destroy it.
+      const isParked = (offscreen.listParkedPages?.(worktreeId) ?? []).some(
+        (page) => page.browserPageId === resolvedTabId
+      )
+      if (explicitPage && !isParked && !bridge.getRegisteredTabs(worktreeId).has(resolvedTabId)) {
         const scope = worktreeId ? ' in this worktree' : ''
         throw new BrowserError(
           'browser_tab_not_found',

--- a/src/main/runtime/orca-runtime-browser.ts
+++ b/src/main/runtime/orca-runtime-browser.ts
@@ -578,6 +578,12 @@ export class RuntimeBrowserCommands {
     let stoppingPromise: Promise<void> | null = null
     const clearPageGate = (): void => {
       this.activeScreencastPageIds.delete(browserPageId)
+      // Why (STA-4341): the stream pin kept this page resident while a client
+      // watched without issuing commands, so its activity stamp can be
+      // arbitrarily stale the instant the pin lifts — stale enough to park it
+      // on the next 30s recheck. Viewing counts as use: restamp so the idle
+      // window runs from when the viewer left, not from their last command.
+      void this.markHeadlessBrowserPageUsed(browserPageId).catch(() => {})
       if (this.activeScreencastsByPageId.get(browserPageId) === activeRecord) {
         this.activeScreencastsByPageId.delete(browserPageId)
       }

--- a/src/main/runtime/orca-runtime-browser.ts
+++ b/src/main/runtime/orca-runtime-browser.ts
@@ -669,9 +669,9 @@ export class RuntimeBrowserCommands {
   }
 
   /**
-   * Resolve an `--index` against the listing the caller saw, waking the target
-   * when it names a parked page. Returns null on desktop, where there are no
-   * parked pages and the bridge's own index handling still applies.
+   * Resolve an `--index` against the listing the caller saw, waking the target.
+   * Returns null on desktop, where there are no parked pages and the bridge's
+   * own index handling still applies.
    */
   private async resolveIndexedParkedAwarePageId(
     worktreeId: string | undefined,
@@ -689,10 +689,26 @@ export class RuntimeBrowserCommands {
         `Tab index ${index} out of range (0-${tabs.length - 1})`
       )
     }
-    if (chosen.parked) {
-      await offscreen.wakeTab?.(chosen.browserPageId)
-    }
+    // Why: waking unconditionally also restarts the reclaim clock, so selecting
+    // a resident page counts as using it rather than leaving it up for eviction.
+    await offscreen.wakeTab?.(chosen.browserPageId)
     return chosen.browserPageId
+  }
+
+  // Why: index resolution must not run behind resolveBrowserCommandTarget's
+  // implicit wake, which reorders the listing. Headless only — desktop keeps the
+  // bridge's own index handling untouched.
+  private async resolveIndexedTargetBeforeWake(
+    params: { index?: number } & BrowserCommandTargetParams
+  ): Promise<ResolvedBrowserCommandTarget | null> {
+    if (params.index === undefined || params.page || this.host.getAvailableAuthoritativeWindow()) {
+      return null
+    }
+    const worktreeId = await this.resolveBrowserWorktreeId(params.worktree, {
+      wakeParkedPage: false
+    })
+    const browserPageId = await this.resolveIndexedParkedAwarePageId(worktreeId, params.index)
+    return browserPageId ? { worktreeId, browserPageId } : null
   }
 
   async browserProceedCertificate(
@@ -725,16 +741,17 @@ export class RuntimeBrowserCommands {
       focus?: boolean
     } & BrowserCommandTargetParams
   ): Promise<BrowserTabSwitchResult> {
-    const target = await this.resolveBrowserCommandTarget(params)
     const bridge = this.requireAgentBrowserBridge()
-    const indexedPageId =
-      params.index !== undefined && !target.browserPageId
-        ? await this.resolveIndexedParkedAwarePageId(target.worktreeId, params.index)
-        : null
+    // Why (STA-4341): an implicit target wakes the most recently used parked
+    // page, which makes it live and moves it to the front of the listing. Resolve
+    // the index against the listing the caller actually read — before any wake —
+    // or `tab switch --index 0` selects a different tab than the one it showed.
+    const indexed = await this.resolveIndexedTargetBeforeWake(params)
+    const target = indexed ?? (await this.resolveBrowserCommandTarget(params))
     const result = await bridge.tabSwitch(
-      indexedPageId ? undefined : params.index,
+      indexed ? undefined : params.index,
       target.worktreeId,
-      target.browserPageId ?? indexedPageId ?? undefined
+      target.browserPageId
     )
     if (params.focus) {
       // Why: scope focus to the tab's owning worktree; the renderer never yanks the user across worktrees on this signal (see focusBrowserTabInWorktree).

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -2302,6 +2302,20 @@ describe('OrcaRuntimeService', () => {
     expect(capabilities).toContain('browser.headless.v1')
     expect(capabilities).toContain('browser.certificate-trust.v1')
   })
+  it('pins a browser page for the reclaimer while the bridge holds an in-flight command', () => {
+    // Why (STA-4341): the offscreen backend's isPagePinned option is wired to
+    // this method; if it silently returns false, the reclaimer parks a page
+    // mid-command with every layer's own tests still green.
+    const runtime = createRuntime()
+    expect(runtime.isBrowserPagePinned('page-1')).toBe(false)
+    runtime.setAgentBrowserBridge({
+      hasInFlightCommand: vi.fn((browserPageId: string) => browserPageId === 'page-1')
+    } as never)
+
+    expect(runtime.isBrowserPagePinned('page-1')).toBe(true)
+    expect(runtime.isBrowserPagePinned('page-2')).toBe(false)
+  })
+
   it('surfaces live offscreen load failures in headless browser snapshots', () => {
     const runtime = createRuntime()
     runtime.setOffscreenBrowserBackend({ createTab: vi.fn(), closeTab: vi.fn() })

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -6608,6 +6608,14 @@ export class OrcaRuntimeService {
     return this.offscreenBrowserBackend
   }
 
+  // Why (STA-4341): closing a parked page has no WebContents teardown to
+  // piggyback on, so the session snapshot only learns about it through here.
+  notifyHeadlessBrowserPagesChanged(worktreeId: string | undefined): void {
+    if (worktreeId) {
+      this.notifyMobileSessionTabsChanged(worktreeId)
+    }
+  }
+
   // Why (STA-4341): the headless reclaimer asks the runtime before parking a
   // page, so a streamed or mid-command page keeps its renderer.
   isBrowserPagePinned(browserPageId: string): boolean {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -33491,7 +33491,8 @@ export class OrcaRuntimeService {
     }
     return mergeParkedBrowserTabs(
       this.agentBrowserBridge.tabList(worktreeId).tabs,
-      this.offscreenBrowserBackend?.listParkedPages?.(worktreeId) ?? []
+      this.offscreenBrowserBackend?.listParkedPages?.(worktreeId) ?? [],
+      this.offscreenBrowserBackend?.listOpenPageIds?.(worktreeId)
     )
   }
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -6607,6 +6607,15 @@ export class OrcaRuntimeService {
     return this.offscreenBrowserBackend
   }
 
+  // Why (STA-4341): the headless reclaimer asks the runtime before parking a
+  // page, so a streamed or mid-command page keeps its renderer.
+  isBrowserPagePinned(browserPageId: string): boolean {
+    return (
+      this.browserCommands.isBrowserPageStreamed(browserPageId) ||
+      this.agentBrowserBridge?.hasInFlightCommand(browserPageId) === true
+    )
+  }
+
   setEmulatorBridge(bridge: EmulatorBridge | null): void {
     this.emulatorBridge = bridge
   }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -730,6 +730,7 @@ import { RendererPublicationThrottle } from '../window/renderer-publication-thro
 import type { AgentBrowserBridge } from '../browser/agent-browser-bridge'
 import type { BrowserBackend } from '../browser/browser-backend'
 import { BrowserError } from '../browser/cdp-bridge'
+import { mergeParkedBrowserTabs } from '../browser/headless-browser-tab-listing'
 import {
   getPRForBranch,
   getPRForBranchOutcome,
@@ -8319,7 +8320,7 @@ export class OrcaRuntimeService {
     if (!this.offscreenBrowserBackend || !this.agentBrowserBridge?.tabList) {
       return []
     }
-    return this.agentBrowserBridge.tabList(worktreeId).tabs.map((tab) => {
+    return this.listOpenHeadlessBrowserTabs(worktreeId).map((tab) => {
       const persistedProps = this.getPersistedUnifiedSessionTabProps(worktreeId, tab.browserPageId)
       return {
         type: 'browser' as const,
@@ -10078,7 +10079,7 @@ export class OrcaRuntimeService {
     if (!snapshot) {
       return ids
     }
-    const liveBrowserTabsByPageId = this.getLiveBrowserTabsByPageId(snapshot.worktree)
+    const liveBrowserTabsByPageId = this.getOpenBrowserTabsByPageId(snapshot.worktree)
     for (const tab of snapshot.tabs) {
       if (tab.type === 'browser') {
         const liveTab = tab.browserPageId
@@ -26663,7 +26664,7 @@ export class OrcaRuntimeService {
     if (!this.offscreenBrowserBackend || !this.agentBrowserBridge?.tabList) {
       return
     }
-    for (const tab of this.agentBrowserBridge.tabList(worktreeId).tabs) {
+    for (const tab of this.listOpenHeadlessBrowserTabs(worktreeId)) {
       void this.offscreenBrowserBackend.closeTab(tab.browserPageId).catch(() => {})
     }
   }
@@ -33290,7 +33291,7 @@ export class OrcaRuntimeService {
         this.isHeadlessBuiltMobileSessionPublicationBase(snapshot.publicationEpoch) ||
         (snapshot.publicationEpoch.includes(':headless-merge:') &&
           typeof tab.browserPageId === 'string' &&
-          this.getLiveBrowserTabsByPageId(snapshot.worktree).has(tab.browserPageId))
+          this.getOpenBrowserTabsByPageId(snapshot.worktree).has(tab.browserPageId))
       )
     }
     if (tab.type !== 'terminal') {
@@ -33472,12 +33473,24 @@ export class OrcaRuntimeService {
     return worktreeId
   }
 
-  private getLiveBrowserTabsByPageId(worktreeId: string): Map<string, BrowserTabInfo> {
+  // Why (STA-4341): a headless page whose renderer was reclaimed is parked, not
+  // closed. Session publication gates browser tabs on this map, so leaving
+  // parked pages out would drop the tab from a paired client's tab bar and let
+  // the next snapshot prune it — while the runtime still owns the page.
+  private listOpenHeadlessBrowserTabs(worktreeId: string): BrowserTabInfo[] {
     if (!this.agentBrowserBridge?.tabList) {
-      return new Map()
+      return []
     }
-    const liveTabs = this.agentBrowserBridge.tabList(worktreeId).tabs
-    return new Map(liveTabs.map((tab) => [tab.browserPageId, tab]))
+    return mergeParkedBrowserTabs(
+      this.agentBrowserBridge.tabList(worktreeId).tabs,
+      this.offscreenBrowserBackend?.listParkedPages?.(worktreeId) ?? []
+    )
+  }
+
+  private getOpenBrowserTabsByPageId(worktreeId: string): Map<string, BrowserTabInfo> {
+    return new Map(
+      this.listOpenHeadlessBrowserTabs(worktreeId).map((tab) => [tab.browserPageId, tab])
+    )
   }
 
   private collectReturnedSessionTabIds(
@@ -33548,7 +33561,7 @@ export class OrcaRuntimeService {
     snapshot: RuntimeMobileSessionTabsSnapshot
   ): RuntimeMobileSessionTabsResult {
     const tabs: RuntimeMobileSessionClientTab[] = []
-    const liveBrowserTabsByPageId = this.getLiveBrowserTabsByPageId(snapshot.worktree)
+    const liveBrowserTabsByPageId = this.getOpenBrowserTabsByPageId(snapshot.worktree)
     // Production reads hook rows by pane; the snapshot fallback remains for tests
     // and embedders that have not adopted the narrow getter.
     let hookRowsByPaneKey: Map<string, AgentStatusIpcPayload[]> | null = null

--- a/src/renderer/src/components/browser-pane/host-guest/browser-guest-worktree-retention.ts
+++ b/src/renderer/src/components/browser-pane/host-guest/browser-guest-worktree-retention.ts
@@ -1,11 +1,25 @@
 import type { BrowserPage, BrowserWorkspace } from '../../../../../shared/browser-workspace-types'
+import {
+  BROWSER_RETENTION_LIMIT,
+  selectBrowserRetentionEvictions
+} from '../../../../../shared/browser-retention-budget'
 
 // Why 4: every hidden worktree that retains browser guests keeps one Electron
 // guest process per page alive purely for instant revisits, so guest memory
 // grew linearly with worktrees visited (#12137). Four hidden worktrees covers
 // the common switch-back working set; older ones are destroyed and rebuild
 // from persisted tab state on the next visit.
-export const BROWSER_GUEST_HIDDEN_WORKTREE_RETENTION_LIMIT = 4
+export const BROWSER_GUEST_HIDDEN_WORKTREE_RETENTION_LIMIT = BROWSER_RETENTION_LIMIT
+
+// Why no clock: switching worktrees is the signal that a working set went cold,
+// so this host never needs to ask how long ago something was used. The headless
+// host has no such signal and configures the same budget with an idle window
+// (offscreen-browser-page-reclaim.ts).
+const HIDDEN_WORKTREE_BUDGET = {
+  limit: BROWSER_GUEST_HIDDEN_WORKTREE_RETENTION_LIMIT,
+  idleMs: Number.POSITIVE_INFINITY,
+  graceMs: 0
+}
 
 /**
  * Hidden worktrees whose retained guests fall beyond the budget, LRU-first.
@@ -13,10 +27,10 @@ export const BROWSER_GUEST_HIDDEN_WORKTREE_RETENTION_LIMIT = 4
  * orderedWorktreeIds must be most-recently-activated first (LRU order =
  * worktree activation order). Only worktrees that actually hold live guests
  * count toward the limit. The active worktree never counts and is never
- * evicted. isEvictable is consulted lazily, only for worktrees beyond the
- * limit — a non-evictable one (a guest an automation/mobile controller is
- * actively driving, or one still writing a download) stays retained over
- * budget.
+ * evicted, so it is left out of the budget entirely. isEvictable is consulted
+ * lazily, only for worktrees beyond the limit — a non-evictable one (a guest an
+ * automation/mobile controller is actively driving, or one still writing a
+ * download) stays retained over budget.
  */
 export function selectBrowserGuestEvictionWorktreeIds(args: {
   orderedWorktreeIds: readonly string[]
@@ -26,30 +40,32 @@ export function selectBrowserGuestEvictionWorktreeIds(args: {
   isEvictable: (worktreeId: string) => boolean
   limit?: number
 }): string[] {
-  const limit = args.limit ?? BROWSER_GUEST_HIDDEN_WORKTREE_RETENTION_LIMIT
-  const evictedIds: string[] = []
   const seen = new Set<string>()
-  let retained = 0
+  const candidates: { id: string }[] = []
   for (const worktreeId of args.orderedWorktreeIds) {
+    if (seen.has(worktreeId)) {
+      continue
+    }
+    seen.add(worktreeId)
     if (
-      seen.has(worktreeId) ||
       worktreeId === args.activeWorktreeId ||
       !args.isRetained(worktreeId) ||
       !args.holdsLiveGuests(worktreeId)
     ) {
-      seen.add(worktreeId)
       continue
     }
-    seen.add(worktreeId)
-    if (retained < limit) {
-      retained += 1
-      continue
-    }
-    if (args.isEvictable(worktreeId)) {
-      evictedIds.push(worktreeId)
-    }
+    candidates.push({ id: worktreeId })
   }
-  return evictedIds
+  return selectBrowserRetentionEvictions({
+    candidates,
+    isPinned: (worktreeId) => !args.isEvictable(worktreeId),
+    // Why 0: no candidate carries a timestamp, so the clock rules never read it.
+    now: 0,
+    budget: {
+      ...HIDDEN_WORKTREE_BUDGET,
+      limit: args.limit ?? HIDDEN_WORKTREE_BUDGET.limit
+    }
+  })
 }
 
 // Why the fallback: webviews key by page id, but legacy sessions persisted

--- a/src/shared/browser-retention-budget.test.ts
+++ b/src/shared/browser-retention-budget.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import {
+  BROWSER_RETENTION_LIMIT,
+  selectBrowserRetentionEvictions,
+  type BrowserRetentionBudget,
+  type BrowserRetentionCandidate
+} from './browser-retention-budget'
+
+const NOW = 1_000_000
+
+/** The headless host's shape: a clock rule on top of the rank rule. */
+const HEADLESS: BrowserRetentionBudget = {
+  limit: 2,
+  idleMs: 60_000,
+  graceMs: 5_000
+}
+/** The desktop host's shape: rank only, no clock. */
+const DESKTOP: BrowserRetentionBudget = {
+  limit: 2,
+  idleMs: Number.POSITIVE_INFINITY,
+  graceMs: 0
+}
+
+function used(id: string, msAgo: number): BrowserRetentionCandidate {
+  return { id, lastActivityAt: NOW - msAgo }
+}
+
+function select(
+  candidates: readonly BrowserRetentionCandidate[],
+  budget: BrowserRetentionBudget,
+  pinned: readonly string[] = []
+): string[] {
+  return selectBrowserRetentionEvictions({
+    candidates,
+    isPinned: (id) => pinned.includes(id),
+    now: NOW,
+    budget
+  })
+}
+
+describe('selectBrowserRetentionEvictions', () => {
+  it('defaults to the same four renderers both hosts already kept', () => {
+    expect(BROWSER_RETENTION_LIMIT).toBe(4)
+  })
+
+  it('keeps everything within the limit', () => {
+    expect(select([used('a', 10_000), used('b', 20_000)], HEADLESS)).toEqual([])
+  })
+
+  it('evicts what is ranked beyond the limit', () => {
+    expect(
+      select([used('newest', 6_000), used('middle', 20_000), used('oldest', 40_000)], HEADLESS)
+    ).toEqual(['oldest'])
+  })
+
+  it('evicts an idle candidate that is still within the limit', () => {
+    expect(select([used('a', 10_000), used('stale', 90_000)], HEADLESS)).toEqual(['stale'])
+  })
+
+  it('never evicts inside the grace window, even beyond the limit', () => {
+    const fresh = [used('a', 100), used('b', 200), used('c', 300), used('d', 400)]
+    expect(select(fresh, HEADLESS)).toEqual([])
+  })
+
+  it('never evicts a pinned candidate, so the limit can be exceeded', () => {
+    // Two pinned pages ranked beyond the limit hold their renderers rather than
+    // interrupting the download/stream that pinned them.
+    const candidates = [used('a', 10_000), used('b', 20_000), used('c', 30_000), used('d', 40_000)]
+    expect(select(candidates, HEADLESS, ['c', 'd'])).toEqual([])
+  })
+
+  it('consults isPinned only for candidates it would otherwise evict', () => {
+    const asked: string[] = []
+    selectBrowserRetentionEvictions({
+      candidates: [used('a', 10_000), used('b', 20_000), used('c', 30_000)],
+      isPinned: (id) => {
+        asked.push(id)
+        return false
+      },
+      now: NOW,
+      budget: HEADLESS
+    })
+    expect(asked).toEqual(['c'])
+  })
+
+  it('respects the caller-supplied order rather than re-sorting', () => {
+    // The caller owns LRU ranking; a host with no timestamps ranks by activation.
+    expect(
+      select([used('oldest', 40_000), used('newest', 6_000), used('mid', 20_000)], HEADLESS)
+    ).toEqual(['mid'])
+  })
+
+  it('ranks timestamp-free candidates by position alone', () => {
+    const candidates = [{ id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'd' }]
+    expect(select(candidates, DESKTOP)).toEqual(['c', 'd'])
+  })
+
+  it('never evicts a timestamp-free candidate by clock', () => {
+    expect(select([{ id: 'a' }, { id: 'b' }], DESKTOP)).toEqual([])
+  })
+
+  it('evicts nothing when both rules are disabled', () => {
+    expect(
+      select([used('a', 10_000_000), used('b', 10_000_000)], {
+        limit: Number.MAX_SAFE_INTEGER,
+        idleMs: Number.POSITIVE_INFINITY,
+        graceMs: 0
+      })
+    ).toEqual([])
+  })
+})

--- a/src/shared/browser-retention-budget.ts
+++ b/src/shared/browser-retention-budget.ts
@@ -1,0 +1,86 @@
+// Why (STA-4341): Orca bounds live browser renderers on two very different
+// hosts. The desktop app retains hidden worktrees' webview guests; a headless
+// `orca serve` retains agent-opened offscreen pages. The unit differs (worktree
+// vs page) and so does the way each host learns something changed, but the
+// budget itself is one decision: keep the most recently used, never evict
+// something in use, and optionally shed anything untouched for too long. Both
+// hosts call the selector below, so the policy can only diverge where a host
+// deliberately configures it to.
+
+/** Renderers a host keeps warm. Matches TERMINAL_WORKTREE_HOT_RETAIN_LIMIT. */
+export const BROWSER_RETENTION_LIMIT = 4
+
+export type BrowserRetentionCandidate = {
+  id: string
+  /**
+   * Last use, epoch ms. Omitted by hosts that rank by activation order alone
+   * and have no clock rule — such a candidate is never idle and never in grace,
+   * so only its rank can evict it.
+   */
+  lastActivityAt?: number
+}
+
+export type BrowserRetentionBudget = {
+  /** Candidates kept by rank. Pinned ones hold their slot rather than yield it. */
+  limit: number
+  /** Evict once untouched this long, even within the limit. Infinity disables. */
+  idleMs: number
+  /** Never evict something used more recently than this. 0 disables. */
+  graceMs: number
+}
+
+export type BrowserRetentionSelection = {
+  /** Most-recently-used first. Anything omitted is invisible to the budget. */
+  candidates: readonly BrowserRetentionCandidate[]
+  /**
+   * In use right now, so never evicted. Consulted only for candidates the rank
+   * and clock rules would otherwise evict, because a host may pay real work to
+   * answer it.
+   */
+  isPinned: (id: string) => boolean
+  now: number
+  budget: BrowserRetentionBudget
+}
+
+export function isBrowserRetentionCandidateIdle(
+  candidate: BrowserRetentionCandidate,
+  now: number,
+  budget: BrowserRetentionBudget
+): boolean {
+  return candidate.lastActivityAt !== undefined && now - candidate.lastActivityAt >= budget.idleMs
+}
+
+export function isBrowserRetentionCandidateInGrace(
+  candidate: BrowserRetentionCandidate,
+  now: number,
+  budget: BrowserRetentionBudget
+): boolean {
+  return candidate.lastActivityAt !== undefined && now - candidate.lastActivityAt < budget.graceMs
+}
+
+/**
+ * The candidates to evict: everything not in use that is either ranked beyond
+ * the limit or has gone idle.
+ *
+ * A pinned candidate keeps its slot instead of yielding it, so a host can sit
+ * over budget while work is genuinely in flight — interrupting a download or a
+ * streamed page to satisfy an accounting limit would break the work the budget
+ * exists to protect.
+ */
+export function selectBrowserRetentionEvictions(args: BrowserRetentionSelection): string[] {
+  const evicted: string[] = []
+  args.candidates.forEach((candidate, rank) => {
+    const overLimit = rank >= args.budget.limit
+    if (!overLimit && !isBrowserRetentionCandidateIdle(candidate, args.now, args.budget)) {
+      return
+    }
+    if (isBrowserRetentionCandidateInGrace(candidate, args.now, args.budget)) {
+      return
+    }
+    if (args.isPinned(candidate.id)) {
+      return
+    }
+    evicted.push(candidate.id)
+  })
+  return evicted
+}

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -1071,6 +1071,11 @@ export type BrowserTabInfo = {
   worktreeId?: string | null
   profileId?: string | null
   profileLabel?: string | null
+  // Why (STA-4341): a headless runtime reclaims an idle page's renderer while
+  // keeping the page. Parked pages stay listed and stay operable — the next
+  // command targeting one wakes it — but surfacing the state lets an agent see
+  // that its in-page JavaScript state did not survive.
+  parked?: boolean
 }
 
 export type BrowserTabListResult = {

--- a/tests/e2e/headless-serve-browser-tab-reclaim.spec.ts
+++ b/tests/e2e/headless-serve-browser-tab-reclaim.spec.ts
@@ -238,11 +238,12 @@ test('resolves --index against the listing that includes parked tabs', async ({ 
 
     const before = await listTabs(host, worktreeId)
     expect(before).toHaveLength(5)
-    // Why: parked pages sit after the resident ones, so the last index is the
-    // one the bridge's live-only index handling would never have reached.
-    const targetIndex = before.length - 1
+    // Why: the listing is creation-ordered, so parked and resident tabs are
+    // interleaved. Target a parked one — an index the bridge's live-only index
+    // handling would either miss or resolve to a different (live) tab.
+    const targetIndex = before.findIndex((tab) => tab.parked === true)
+    expect(targetIndex).toBeGreaterThanOrEqual(0)
     const targeted = before[targetIndex]
-    expect(targeted.parked).toBe(true)
 
     await host.client.call('browser.tabClose', {
       index: targetIndex,

--- a/tests/e2e/headless-serve-browser-tab-reclaim.spec.ts
+++ b/tests/e2e/headless-serve-browser-tab-reclaim.spec.ts
@@ -233,11 +233,13 @@ test('resolves --index against the listing that includes parked tabs', async ({ 
   const pageServer = await startAnimatedPageServer()
   try {
     const worktreeId = await resolveSeededWorktreeId(host, testRepoPath)
-    await createTabs(host, worktreeId, pageServer.url, 5)
+    const pageIds = await createTabs(host, worktreeId, pageServer.url, 5)
     await expect.poll(() => countOffscreenRenderers(host), { timeout: 30_000 }).toBe(2)
 
     const before = await listTabs(host, worktreeId)
-    expect(before).toHaveLength(5)
+    // Why: the listing is creation-ordered end to end — parking must not move
+    // a tab's position, or the index a caller read goes stale on a timer.
+    expect(before.map((tab) => tab.browserPageId)).toEqual(pageIds)
     // Why: the listing is creation-ordered, so parked and resident tabs are
     // interleaved. Target a parked one — an index the bridge's live-only index
     // handling would either miss or resolve to a different (live) tab.

--- a/tests/e2e/headless-serve-browser-tab-reclaim.spec.ts
+++ b/tests/e2e/headless-serve-browser-tab-reclaim.spec.ts
@@ -33,7 +33,6 @@ const ANIMATED_PAGE = `<!doctype html><meta charset="utf-8"><title>anim</title>
 const FAST_RECLAIM_ENV = {
   ORCA_HEADLESS_BROWSER_PARK_IDLE_MS: '1500',
   ORCA_HEADLESS_BROWSER_PARK_GRACE_MS: '400',
-  ORCA_HEADLESS_BROWSER_PARK_SWEEP_MS: '250',
   ORCA_HEADLESS_BROWSER_RESIDENT_LIMIT: '2'
 }
 
@@ -67,7 +66,10 @@ async function resolveSeededWorktreeId(host: HeadlessHost, testRepoPath: string)
   return worktreeId
 }
 
-async function startAnimatedPageServer(): Promise<{ url: string; close: () => void }> {
+async function startAnimatedPageServer(): Promise<{
+  url: string
+  close: () => void
+}> {
   const server: Server = createServer((_req, res) => {
     res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' })
     res.end(ANIMATED_PAGE)
@@ -108,7 +110,9 @@ test('reclaims idle agent browser tab renderers without losing the tabs', async 
   testRepoPath
 }) => {
   test.setTimeout(240_000)
-  const host = await launchHeadlessPairedRuntimeHost({ extraEnv: FAST_RECLAIM_ENV })
+  const host = await launchHeadlessPairedRuntimeHost({
+    extraEnv: FAST_RECLAIM_ENV
+  })
   const pageServer = await startAnimatedPageServer()
   try {
     const worktreeId = await resolveSeededWorktreeId(host, testRepoPath)
@@ -135,18 +139,19 @@ test('reclaims idle agent browser tab renderers without losing the tabs', async 
 
 test('wakes a parked browser tab on the next command that targets it', async ({ testRepoPath }) => {
   test.setTimeout(240_000)
-  const host = await launchHeadlessPairedRuntimeHost({ extraEnv: FAST_RECLAIM_ENV })
+  const host = await launchHeadlessPairedRuntimeHost({
+    extraEnv: FAST_RECLAIM_ENV
+  })
   const pageServer = await startAnimatedPageServer()
   try {
     const worktreeId = await resolveSeededWorktreeId(host, testRepoPath)
     const [pageId] = await createTabs(host, worktreeId, pageServer.url, 1)
     await expect.poll(() => countOffscreenRenderers(host), { timeout: 30_000 }).toBe(0)
 
-    const evaluated = await host.client.call<{ result: string; origin: string }>(
-      'browser.eval',
-      { expression: 'document.title', page: pageId },
-      { timeoutMs: 60_000 }
-    )
+    const evaluated = await host.client.call<{
+      result: string
+      origin: string
+    }>('browser.eval', { expression: 'document.title', page: pageId }, { timeoutMs: 60_000 })
     expect(evaluated.result.result).toBe('anim')
     expect(evaluated.result.origin).toBe(pageServer.url)
     expect(await countOffscreenRenderers(host)).toBe(1)
@@ -173,7 +178,10 @@ test('bounds resident renderers by the cap while tabs are still in use', async (
   const host = await launchHeadlessPairedRuntimeHost({
     // Why: a long idle window isolates the cap as the evictor — nothing here
     // parks because of the clock.
-    extraEnv: { ...FAST_RECLAIM_ENV, ORCA_HEADLESS_BROWSER_PARK_IDLE_MS: '600000' }
+    extraEnv: {
+      ...FAST_RECLAIM_ENV,
+      ORCA_HEADLESS_BROWSER_PARK_IDLE_MS: '600000'
+    }
   })
   const pageServer = await startAnimatedPageServer()
   try {
@@ -217,7 +225,10 @@ test('resolves --index against the listing that includes parked tabs', async ({ 
   const host = await launchHeadlessPairedRuntimeHost({
     // Why: a tight cap with no idle clock leaves a mixed listing — some tabs
     // resident, some parked — which is where an index can address the wrong tab.
-    extraEnv: { ...FAST_RECLAIM_ENV, ORCA_HEADLESS_BROWSER_PARK_IDLE_MS: '600000' }
+    extraEnv: {
+      ...FAST_RECLAIM_ENV,
+      ORCA_HEADLESS_BROWSER_PARK_IDLE_MS: '600000'
+    }
   })
   const pageServer = await startAnimatedPageServer()
   try {
@@ -249,7 +260,9 @@ test('resolves --index against the listing that includes parked tabs', async ({ 
 
 test('keeps a parked tab closable without waking its renderer', async ({ testRepoPath }) => {
   test.setTimeout(240_000)
-  const host = await launchHeadlessPairedRuntimeHost({ extraEnv: FAST_RECLAIM_ENV })
+  const host = await launchHeadlessPairedRuntimeHost({
+    extraEnv: FAST_RECLAIM_ENV
+  })
   const pageServer = await startAnimatedPageServer()
   try {
     const worktreeId = await resolveSeededWorktreeId(host, testRepoPath)

--- a/tests/e2e/headless-serve-browser-tab-reclaim.spec.ts
+++ b/tests/e2e/headless-serve-browser-tab-reclaim.spec.ts
@@ -180,13 +180,32 @@ test('bounds resident renderers by the cap while tabs are still in use', async (
     const worktreeId = await resolveSeededWorktreeId(host, testRepoPath)
     const pageIds = await createTabs(host, worktreeId, pageServer.url, 5)
 
-    await expect.poll(() => countOffscreenRenderers(host), { timeout: 30_000 }).toBe(2)
+    // Why keep driving them: a page's reclaim clock also restarts when its load
+    // finally completes, and load completion does not have to follow creation
+    // order — so a single touch up front can be overtaken by a page that
+    // finished loading later. Two pages that stay in use are unambiguously the
+    // most recently used, which is exactly the case this test is about.
+    const inUsePageIds = [pageIds[0], pageIds[3]]
+    const useThenCountRenderers = async (): Promise<number> => {
+      for (const pageId of inUsePageIds) {
+        await host.client
+          .call(
+            'browser.eval',
+            { expression: 'document.title', page: pageId },
+            { timeoutMs: 60_000 }
+          )
+          .catch(() => {})
+      }
+      return countOffscreenRenderers(host)
+    }
 
-    // The most recently used pages are the ones kept resident.
+    await expect.poll(useThenCountRenderers, { timeout: 30_000 }).toBe(2)
+
+    // Every page is still open; only the two in use kept a renderer.
     const tabs = await listTabs(host, worktreeId)
     expect(tabs).toHaveLength(5)
-    const parkedIds = tabs.filter((tab) => tab.parked).map((tab) => tab.browserPageId)
-    expect(parkedIds.sort()).toEqual(pageIds.slice(0, 3).sort())
+    const residentIds = tabs.filter((tab) => !tab.parked).map((tab) => tab.browserPageId)
+    expect(residentIds.sort()).toEqual([...inUsePageIds].sort())
   } finally {
     pageServer.close()
     await host.dispose()

--- a/tests/e2e/headless-serve-browser-tab-reclaim.spec.ts
+++ b/tests/e2e/headless-serve-browser-tab-reclaim.spec.ts
@@ -1,0 +1,252 @@
+import { createServer, type Server } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { expect, test } from './helpers/orca-app'
+import { launchHeadlessPairedRuntimeHost } from './helpers/headless-paired-runtime-host'
+
+// Why (STA-4341): every agent-created browser tab on a headless `orca serve`
+// host is backed by its own hidden BrowserWindow, i.e. its own renderer
+// process. Before the reclaimer nothing owned them: six tabs meant six
+// renderers that survived any amount of idleness, and an animated page kept
+// painting at ~96fps in a window no one could ever see. These specs drive the
+// exact RPCs `orca tab …` sends against a real serve process and count the
+// renderers the host actually holds.
+
+// Why: an animated canvas is the workload the report measured — it keeps a
+// hidden renderer busy, so a leaked renderer costs CPU as well as memory.
+const ANIMATED_PAGE = `<!doctype html><meta charset="utf-8"><title>anim</title>
+<canvas id="c" width="64" height="64"></canvas>
+<script>
+  window.__frames = 0
+  const ctx = document.getElementById('c').getContext('2d')
+  function tick() {
+    window.__frames++
+    ctx.fillStyle = 'hsl(' + (window.__frames % 360) + ',80%,50%)'
+    ctx.fillRect(0, 0, 64, 64)
+    requestAnimationFrame(tick)
+  }
+  requestAnimationFrame(tick)
+</script>`
+
+// Why: minutes-long production windows would make this spec unrunnable in CI;
+// the reclaim policy reads them from the environment so the behaviour under
+// test is the shipping one, only faster.
+const FAST_RECLAIM_ENV = {
+  ORCA_HEADLESS_BROWSER_PARK_IDLE_MS: '1500',
+  ORCA_HEADLESS_BROWSER_PARK_GRACE_MS: '400',
+  ORCA_HEADLESS_BROWSER_PARK_SWEEP_MS: '250',
+  ORCA_HEADLESS_BROWSER_RESIDENT_LIMIT: '2'
+}
+
+type HeadlessHost = Awaited<ReturnType<typeof launchHeadlessPairedRuntimeHost>>
+type BrowserTab = { browserPageId: string; url: string; parked?: boolean }
+
+async function countOffscreenRenderers(host: HeadlessHost): Promise<number> {
+  return host.app.evaluate(
+    ({ BrowserWindow }) => BrowserWindow.getAllWindows().filter((win) => !win.isDestroyed()).length
+  )
+}
+
+async function resolveSeededWorktreeId(host: HeadlessHost, testRepoPath: string): Promise<string> {
+  const added = await host.client.call<{ repo: { id: string } }>('repo.add', {
+    path: testRepoPath,
+    kind: 'git'
+  })
+  let worktreeId = ''
+  await expect
+    .poll(
+      async () => {
+        const listed = await host.client.call<{ worktrees: { id: string }[] }>('worktree.list', {
+          repo: `id:${added.result.repo.id}`
+        })
+        worktreeId = listed.result.worktrees[0]?.id ?? ''
+        return worktreeId
+      },
+      { timeout: 30_000 }
+    )
+    .not.toBe('')
+  return worktreeId
+}
+
+async function startAnimatedPageServer(): Promise<{ url: string; close: () => void }> {
+  const server: Server = createServer((_req, res) => {
+    res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' })
+    res.end(ANIMATED_PAGE)
+  })
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  return {
+    url: `http://127.0.0.1:${(server.address() as AddressInfo).port}/`,
+    close: () => server.close()
+  }
+}
+
+async function createTabs(
+  host: HeadlessHost,
+  worktreeId: string,
+  url: string,
+  count: number
+): Promise<string[]> {
+  const pageIds: string[] = []
+  for (let index = 0; index < count; index++) {
+    const created = await host.client.call<{ browserPageId: string }>(
+      'browser.tabCreate',
+      { url, worktree: `id:${worktreeId}` },
+      { timeoutMs: 60_000 }
+    )
+    pageIds.push(created.result.browserPageId)
+  }
+  return pageIds
+}
+
+async function listTabs(host: HeadlessHost, worktreeId: string): Promise<BrowserTab[]> {
+  const listed = await host.client.call<{ tabs: BrowserTab[] }>('browser.tabList', {
+    worktree: `id:${worktreeId}`
+  })
+  return listed.result.tabs
+}
+
+test('reclaims idle agent browser tab renderers without losing the tabs', async ({
+  testRepoPath
+}) => {
+  test.setTimeout(240_000)
+  const host = await launchHeadlessPairedRuntimeHost({ extraEnv: FAST_RECLAIM_ENV })
+  const pageServer = await startAnimatedPageServer()
+  try {
+    const worktreeId = await resolveSeededWorktreeId(host, testRepoPath)
+    expect(await countOffscreenRenderers(host)).toBe(0)
+
+    const pageIds = await createTabs(host, worktreeId, pageServer.url, 6)
+    expect(await countOffscreenRenderers(host)).toBe(6)
+
+    // Nothing targets these pages and no client streams them, so every
+    // renderer must be reclaimed once the idle window elapses.
+    await expect.poll(() => countOffscreenRenderers(host), { timeout: 30_000 }).toBe(0)
+
+    // The pages themselves survive: an agent holding a page id still sees its
+    // tab, marked parked, at the address it left it on.
+    const tabs = await listTabs(host, worktreeId)
+    expect(tabs.map((tab) => tab.browserPageId).sort()).toEqual([...pageIds].sort())
+    expect(tabs.every((tab) => tab.parked === true)).toBe(true)
+    expect(tabs.every((tab) => tab.url === pageServer.url)).toBe(true)
+  } finally {
+    pageServer.close()
+    await host.dispose()
+  }
+})
+
+test('wakes a parked browser tab on the next command that targets it', async ({ testRepoPath }) => {
+  test.setTimeout(240_000)
+  const host = await launchHeadlessPairedRuntimeHost({ extraEnv: FAST_RECLAIM_ENV })
+  const pageServer = await startAnimatedPageServer()
+  try {
+    const worktreeId = await resolveSeededWorktreeId(host, testRepoPath)
+    const [pageId] = await createTabs(host, worktreeId, pageServer.url, 1)
+    await expect.poll(() => countOffscreenRenderers(host), { timeout: 30_000 }).toBe(0)
+
+    const evaluated = await host.client.call<{ result: string; origin: string }>(
+      'browser.eval',
+      { expression: 'document.title', page: pageId },
+      { timeoutMs: 60_000 }
+    )
+    expect(evaluated.result.result).toBe('anim')
+    expect(evaluated.result.origin).toBe(pageServer.url)
+    expect(await countOffscreenRenderers(host)).toBe(1)
+
+    const tabs = await listTabs(host, worktreeId)
+    expect(tabs).toHaveLength(1)
+    expect(tabs[0].parked).toBeFalsy()
+
+    // A woken page must still be closable, and closing it must free the renderer.
+    const closed = await host.client.call<{ closed: boolean }>('browser.tabClose', { page: pageId })
+    expect(closed.result.closed).toBe(true)
+    await expect.poll(() => countOffscreenRenderers(host), { timeout: 15_000 }).toBe(0)
+    expect(await listTabs(host, worktreeId)).toHaveLength(0)
+  } finally {
+    pageServer.close()
+    await host.dispose()
+  }
+})
+
+test('bounds resident renderers by the cap while tabs are still in use', async ({
+  testRepoPath
+}) => {
+  test.setTimeout(240_000)
+  const host = await launchHeadlessPairedRuntimeHost({
+    // Why: a long idle window isolates the cap as the evictor — nothing here
+    // parks because of the clock.
+    extraEnv: { ...FAST_RECLAIM_ENV, ORCA_HEADLESS_BROWSER_PARK_IDLE_MS: '600000' }
+  })
+  const pageServer = await startAnimatedPageServer()
+  try {
+    const worktreeId = await resolveSeededWorktreeId(host, testRepoPath)
+    const pageIds = await createTabs(host, worktreeId, pageServer.url, 5)
+
+    await expect.poll(() => countOffscreenRenderers(host), { timeout: 30_000 }).toBe(2)
+
+    // The most recently used pages are the ones kept resident.
+    const tabs = await listTabs(host, worktreeId)
+    expect(tabs).toHaveLength(5)
+    const parkedIds = tabs.filter((tab) => tab.parked).map((tab) => tab.browserPageId)
+    expect(parkedIds.sort()).toEqual(pageIds.slice(0, 3).sort())
+  } finally {
+    pageServer.close()
+    await host.dispose()
+  }
+})
+
+test('resolves --index against the listing that includes parked tabs', async ({ testRepoPath }) => {
+  test.setTimeout(240_000)
+  const host = await launchHeadlessPairedRuntimeHost({
+    // Why: a tight cap with no idle clock leaves a mixed listing — some tabs
+    // resident, some parked — which is where an index can address the wrong tab.
+    extraEnv: { ...FAST_RECLAIM_ENV, ORCA_HEADLESS_BROWSER_PARK_IDLE_MS: '600000' }
+  })
+  const pageServer = await startAnimatedPageServer()
+  try {
+    const worktreeId = await resolveSeededWorktreeId(host, testRepoPath)
+    await createTabs(host, worktreeId, pageServer.url, 5)
+    await expect.poll(() => countOffscreenRenderers(host), { timeout: 30_000 }).toBe(2)
+
+    const before = await listTabs(host, worktreeId)
+    expect(before).toHaveLength(5)
+    // Why: parked pages sit after the resident ones, so the last index is the
+    // one the bridge's live-only index handling would never have reached.
+    const targetIndex = before.length - 1
+    const targeted = before[targetIndex]
+    expect(targeted.parked).toBe(true)
+
+    await host.client.call('browser.tabClose', {
+      index: targetIndex,
+      worktree: `id:${worktreeId}`
+    })
+
+    const after = await listTabs(host, worktreeId)
+    expect(after.map((tab) => tab.browserPageId)).not.toContain(targeted.browserPageId)
+    expect(after).toHaveLength(4)
+  } finally {
+    pageServer.close()
+    await host.dispose()
+  }
+})
+
+test('keeps a parked tab closable without waking its renderer', async ({ testRepoPath }) => {
+  test.setTimeout(240_000)
+  const host = await launchHeadlessPairedRuntimeHost({ extraEnv: FAST_RECLAIM_ENV })
+  const pageServer = await startAnimatedPageServer()
+  try {
+    const worktreeId = await resolveSeededWorktreeId(host, testRepoPath)
+    const pageIds = await createTabs(host, worktreeId, pageServer.url, 2)
+    await expect.poll(() => countOffscreenRenderers(host), { timeout: 30_000 }).toBe(0)
+
+    const closed = await host.client.call<{ closed: boolean }>('browser.tabClose', {
+      page: pageIds[0]
+    })
+    expect(closed.result.closed).toBe(true)
+    expect(await countOffscreenRenderers(host)).toBe(0)
+
+    const tabs = await listTabs(host, worktreeId)
+    expect(tabs.map((tab) => tab.browserPageId)).toEqual([pageIds[1]])
+  } finally {
+    pageServer.close()
+    await host.dispose()
+  }
+})

--- a/tests/e2e/helpers/headless-paired-runtime-host.ts
+++ b/tests/e2e/helpers/headless-paired-runtime-host.ts
@@ -183,7 +183,9 @@ async function readPairingOffer(app: ElectronApplication): Promise<RuntimeDeskto
   })
 }
 
-export async function launchHeadlessPairedRuntimeHost(): Promise<HeadlessPairedRuntimeHost> {
+export async function launchHeadlessPairedRuntimeHost(
+  options: { extraEnv?: Record<string, string> } = {}
+): Promise<HeadlessPairedRuntimeHost> {
   const userDataDir = mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-headless-paired-'))
   let app: ElectronApplication | undefined
   try {
@@ -200,7 +202,7 @@ export async function launchHeadlessPairedRuntimeHost(): Promise<HeadlessPairedR
         ORCA_E2E_ENFORCE_SINGLE_INSTANCE_LOCK: '1',
         ORCA_E2E_HEADLESS: '1'
       },
-      extraEnv: {},
+      extraEnv: options.extraEnv ?? {},
       userDataDir
     })
     const mainPath = path.join(process.cwd(), 'out', 'main', 'index.js')


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2472 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2467 |
| Prod | 19 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1647 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​192 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1455 |

<!-- /orca-pr-loc -->

Fixes STA-4341.

## The problem

On a headless `orca serve` host, every browser page an agent opens is backed by its own hidden `BrowserWindow` — its own renderer process — held in `OffscreenBrowserBackend`'s map. That map only ever shrank on an explicit `tab close` or on process exit. Agents open a page per measurement and rarely close them, so nothing reclaimed the renderers. The reporter measured 9 tabs / 6 renderers at 220–480 MB each, the oldest at 1 328 MB after 15h41, load average 6.85 on 4 cores, 2.5 GB of swap. From the paired client the only symptom is `Reconnecting to remote runtime`, which reads as a network problem while the host is actually saturated.

## Reproduced on latest main

`tests/e2e/headless-serve-browser-tab-reclaim.spec.ts` drives the exact RPCs `orca tab …` sends against a real `orca serve` process. On unmodified `main` (640e8a4):

```
baseline   { browserWindows: 0, liveWebContents: 0 }
afterCreate{ browserWindows: 6, liveWebContents: 6 }   tabs 6
afterIdle  { browserWindows: 6, liveWebContents: 6 }   window.__frames 2405
```

Six agent tabs, six renderers, still six after 20 s of complete idleness. `window.__frames` = 2405 in ~25 s is ~96 fps of `requestAnimationFrame` in a window that is never shown — guest policies disable background throttling, which is the CPU half of the report.

Red/green is clean: **every spec fails on unmodified main and passes with this change**, verified by stashing `src/` and rebuilding.

## Root cause

Offscreen browser pages had **no lifecycle owner**. On desktop a page is owned by the pane that hosts it and a human can see it. A page created by `orca tab create` on a headless host is not even in the workspace session — it exists only in `OffscreenBrowserBackend`'s map and `BrowserManager`'s maps, with no cap, no idle tracking, and nothing that would ever release it.

## The fix

Make the offscreen backend that owner. It keeps the page identity an agent holds — `browserPageId`, address, worktree, profile — for as long as the page is open, and treats the renderer behind it as a reclaimable resource:

- **Park**: an idle page's renderer is destroyed, its record kept.
- **Wake**: the next command targeting the page rebuilds the renderer under the same page id and reloads the committed address, transparently. It reuses the existing `onProcessSwap` path, which already exists for "same page, new renderer".
- **Eviction** mirrors `terminal-hidden-view-parking.ts`: a **resident cap of 4** is the primary evictor (LRU), a **5 minute idle window** is the tail, and a 30 s grace floor keeps a just-used page resident.
- **Never parked**: a page a paired client is streaming, one with a command in flight, or one whose navigation has not committed. Pinned pages count against the cap but are never evicted — bounding those would break exactly the legitimate work the cap protects.

Deliberately *not* an arbitrary cap on how many tabs an agent may open: the number of open pages is unbounded, only the number of resident renderers is bounded, and an agent that keeps working on a page never loses it.

`tab list` keeps listing parked pages (`(parked)` in text, `parked: true` in `--json`) so an agent does not read a reclaimed tab as gone and open yet another one — which is the loop that produced the leak. The same merge feeds the paired-client session snapshot and worktree teardown, so all three surfaces agree on what is open.

### Related defects fixed on the same paths

1. **Leaked helper sessions on headless close.** `onTabClosed` — which destroys the agent-browser helper session, its `CdpWsProxy` HTTP/WebSocket server and its attached debugger — was only wired to the renderer's `browser:unregisterGuest` IPC. The headless close path called `browserManager.unregisterGuest` directly and never told the bridge, so every closed page left a session and a listening port behind. Park, close and renderer-crash teardown now all route through the bridge before the mapping and the window go away.
2. **`--index` could address the wrong tab.** Because the listing now spans resident and parked pages, index-addressed commands resolve against that same listing, before any implicit wake can reorder it.

## What this does not fix

`attachGuestPolicies` calls `setBackgroundThrottling(false)` on **every** guest, including offscreen ones that are never visible — that is why a hidden animated page paints at ~96 fps. Parking removes the cost for idle pages (a parked page has no renderer, so zero CPU), but a page resident under the cap still runs unthrottled. Re-enabling throttling for offscreen guests needs the capture paths to lift it around a screenshot, and the `agent-browser` binary does not run in this e2e environment, so I could not prove that change safe here. Filed as follow-up rather than shipped unvalidated.

## Trade-off

Parking discards **in-page JavaScript state**. Cookies and local storage live in the profile partition and survive a wake; an unsubmitted form or an SPA's in-memory state does not. This is the same trade Orca already ships for terminal pane parking, at the same 5-minute hot-retain window. Mitigated by never parking a streamed, in-flight or loading page, by the LRU cap keeping the most recently used pages resident, and by surfacing `parked` so an agent can tell.

Thresholds are operator-settable: `ORCA_HEADLESS_BROWSER_RESIDENT_LIMIT`, `..._PARK_IDLE_MS`, `..._PARK_GRACE_MS`. Documented in `docs/reference/headless-linux-server.md`.

## One budget, two hosts

The rule is shared with the desktop app rather than reimplemented. `src/shared/browser-retention-budget.ts` holds it: keep the most recently used, never evict something in use, optionally shed what has gone stale. Each host supplies a configuration and a trigger.

| | desktop (`browser-guest-worktree-retention.ts`) | headless (this PR) |
| --- | --- | --- |
| unit | a hidden worktree's guests | one page |
| clock | none (`idleMs` Infinity, `graceMs` 0) | 5 min idle, 30 s grace |
| trigger | worktree switch, download, automation, mobile-driver | create/wake/close, plus a one-shot idle deadline |

Desktop behaviour is unchanged; its 13 retention tests pass untouched.

## No recurring sweep

There is no periodic reclaim. The limit can only be crossed when a page is created, woken or closed, and each of those re-arms directly; only the idle window needs a clock, so the reclaimer computes the earliest moment its own answer could change and arms one timer for it. A host with nothing resident holds no timer at all. A page pinned by a download, a streamed client or a certificate prompt is re-asked on a bounded cadence, because releasing those pins raises no event the backend observes.

Two guards came out of building it: a fuzz test asserting nothing can become evictable before its deadline (it caught an off-by-one in the rank branch), and a backoff after any sweep that frees nothing — measured by observed residency rather than by trusting `park()`, which no-ops for a window that is already gone. Without it, a deadline landing early re-arms at 0 ms and spins.

One deliberate headless semantics change: a stale pinned page no longer forces fresher unpinned pages to be evicted in its place. That is the desktop rule, and the limit was already documented as exceedable by pinned work.

## Compatibility

- **Desktop is untouched** — it has no offscreen backend, so every new branch is inert there. The parked-aware index path returns early when an authoritative window exists.
- **Wire**: `parked?: boolean` is a new optional field on `browser.tabList` results (Rule 1 — old readers ignore it). Under Rule 3 the host now publishes tabs with no live renderer; an old client can still act on one, because acting on it wakes it host-side.
- **Paired clients**: a streamed page is pinned and cannot be parked; re-subscribing to a parked page wakes it through `resolveBrowserCommandTarget`; and a parked page stays in the session snapshot with its active flag preserved.

## Review

Three fresh `gpt-5.6-luna` reviewers (Codex CLI, spawned in this worktree) took lifecycle, resources and compatibility independently, over **nine rounds** against the evolving diff (fresh sessions from round seven). They found **23 real defects**; every one is fixed here with a regression test that was mutation-checked — the guard is reverted and the test confirmed red before being kept.

Two of their round-one findings were ones self-review had already caught (session-snapshot pruning of parked pages, worktree teardown missing them), which is a useful cross-check on the rest. The high-value ones:

| Round | Finding |
| -- | -- |
| 1 | `tab switch --index` resolved after an implicit wake had already reordered the listing, so index 0 selected a different tab than the caller read. |
| 1 | An in-flight command was pinned only while the queue executed it, but `ensureSession` runs first and can spend up to `EXEC_TIMEOUT_MS` (90 s) closing a stale helper session — far past the 30 s grace. |
| 1 | A renderer lost on its own never told the bridge, leaking a helper session, CDP proxy and listening port per crash. Fixing it exposed that reading `win.webContents` in a `destroyed` handler throws and **wedged the whole main process**. |
| 2 | A page-less command targeted the most recently used parked page; recency is not activeness, and a page-less command has always meant "the active tab". |
| 2 | Parking sniffed the committed address and could not tell an intentional `about:blank` from the blank page a failed load left behind. The record now follows `did-navigate`. |
| 2 | A failed `createTab` left an unreachable record occupying the retention budget and could orphan a hidden renderer. |
| 3 | The sweep picked its victims once and then parked them one at a time, so a page used while an earlier park was in flight was reclaimed underneath a running command. The retention close had the same shape and ignored pins entirely. |
| 3 | A wake is resident but not yet loading while it awaits the process swap — neither pinned nor loading, so a concurrent sweep could park a page mid-rebuild. |
| 4 | **A fix from round 3 was itself a defect**: pinning while `webContents.isLoading()` had no bound, so one never-finishing navigation per create could hold a renderer forever and defeat the resident cap outright. Removed; the test now asserts a stalled page *is* parked. |
| 4 | A wake could validate a page that had been closed and replaced under it, handing the original command a different page under the name it asked for. |
| 5 | An abandoned wake cleared its `waking` entry unconditionally and could drop a *replacement* page's lock. |

Round seven used three fresh reviewers with no memory of the earlier rounds. They cleared compatibility and found the download veto I had just added was unbounded — a stalled download could pin a renderer forever, the same cap-defeating shape as the round-four bug. Round eight then showed the *abort* I added to close the remaining race was itself the wrong trade: it backed out halfway through an irreversible teardown, orphaning the renderer on a concurrent close and leaving a resident page with a destroyed helper session and a moved active pointer. It was reverted; the veto is decision-time only, as stated in the code and as the desktop budget also is. Round nine returned clean from both. One finding was verified as **pre-existing on `main` and deliberately left alone**: `destroyAllSessions()` at app quit is fire-and-forget and not joined into the quit barrier — that line is untouched by this PR and fixing it means changing quit sequencing.

Two pieces of code were **deleted rather than kept**: an ownership guard that became unreachable once creates are ordered (no mutation could fail a test without it), and the park abort above. Both times the review converged by removing code rather than adding it.

Comparing against the desktop guest budget (`browser-guest-worktree-retention.ts`, #12137) also found a real defect independently: that budget vetoes evicting a worktree still writing a download, because `unregisterGuest` cancels in-flight downloads. The headless reclaimer unregisters guests the same way and had no such veto, so parking mid-download silently cancelled it.

## Testing## Testing

- **New**: 5 e2e specs against a real headless serve process (reclamation, transparent wake, cap-bounded residency, index consistency, parked close) — all red on unmodified main, green here.
- **New**: ~60 unit tests across the eviction policy, the backend (teardown ordering, wake coalescing, the park/command race, crash vs. deliberate teardown, the loading guard, the retention bound, worktree scoping), the parked-tab merge, runtime index targeting, and the bridge's in-flight pin.
- Every fix has a regression test that was **mutation-checked** — the guard is reverted and the test confirmed red before being kept.
- `tab switch` is covered at the runtime layer rather than e2e: driving a real switch needs the `agent-browser` binary, which cannot run in the sandboxed e2e HOME, so an e2e assertion there would be environment-dependent.
- **Regression**: full unit suite — **55 855 passed**, 2 failed; both failures are in `src/relay/pty-handler-spawn-environment.test.ts` (Windows relay → WSL history isolation) and were verified to reproduce on unmodified `origin/main`. The browser e2e regression set — `browser-tab`, `browser-guest-crash-recovery`, `browser-embedded-owner-routing`, `paired-remote-browser-*`, `paired-remote-html-browser-focus`, `headless-serve-*` — is **28/28 green**.
- `pnpm lint`, `check:code-quality:changed`, `check:react-doctor:changed`, `typecheck:node` clean.

