### PR TITLE
fix(git): run WSL git reads without a shell

### DIFF
--- a/src/main/git/runner-command-exec.test.ts
+++ b/src/main/git/runner-command-exec.test.ts
@@ -507,7 +507,12 @@ describe('runner execFile timeout handling', () => {
         expect.objectContaining({ cwd: undefined }),
         expect.any(Function)
       )
-      const shellCommand = execFileMock.mock.calls[0]?.[1]?.[5] as string
+      // A read also warms the direct-git environment probe in the background, so
+      // pick the git call rather than assuming it is the first spawn.
+      const gitCall = execFileMock.mock.calls.find((call) =>
+        String(call[1]?.[5]).includes("'git'")
+      )
+      const shellCommand = gitCall?.[1]?.[5] as string
       expect(shellCommand).toContain('getent passwd')
       expect(shellCommand).toContain('exec "$_orca_wsl_shell" -ilc')
       expect(shellCommand).toContain('/mnt/c/repo')

--- a/src/main/git/runner-command-exec.test.ts
+++ b/src/main/git/runner-command-exec.test.ts
@@ -296,7 +296,10 @@ describe('runner execFile timeout handling', () => {
       return child
     })
 
-    await gitExecFileAsync(['worktree', 'list', '--porcelain', '-z'], { cwd: '/home5/Brian' })
+    await gitExecFileAsync(['worktree', 'list', '--porcelain', '-z'], {
+      cwd: '/home5/Brian',
+      env: { ...process.env, GIT_ASKPASS: undefined, SSH_ASKPASS: undefined }
+    })
 
     expect(capturedEnv?.GIT_TERMINAL_PROMPT).toBe('0')
     expect(capturedEnv?.GIT_ASKPASS).toBe('')

--- a/src/main/git/runner-command-exec.test.ts
+++ b/src/main/git/runner-command-exec.test.ts
@@ -512,9 +512,7 @@ describe('runner execFile timeout handling', () => {
       )
       // A read also warms the direct-git environment probe in the background, so
       // pick the git call rather than assuming it is the first spawn.
-      const gitCall = execFileMock.mock.calls.find((call) =>
-        String(call[1]?.[5]).includes("'git'")
-      )
+      const gitCall = execFileMock.mock.calls.find((call) => String(call[1]?.[5]).includes("'git'"))
       const shellCommand = gitCall?.[1]?.[5] as string
       expect(shellCommand).toContain('getent passwd')
       expect(shellCommand).toContain('exec "$_orca_wsl_shell" -ilc')

--- a/src/main/git/runner-wsl-linked-gitdir-timeout.test.ts
+++ b/src/main/git/runner-wsl-linked-gitdir-timeout.test.ts
@@ -92,7 +92,12 @@ describe('WSL linked-worktree routing probe timeout', () => {
       ).resolves.toEqual({ stdout: 'host git recovered\n', stderr: '' })
 
       expect(statMock).toHaveBeenCalledTimes(2)
-      expect(execFileMock.mock.calls.map(([command]) => command)).toEqual(['wsl.exe', 'git'])
+      // A WSL read also warms the direct-git environment probe in the background;
+      // it is not part of the routing sequence under test.
+      const routedCommands = execFileMock.mock.calls
+        .filter(([, args]) => !String((args as string[])?.at(-1)).includes('^GIT_'))
+        .map(([command]) => command)
+      expect(routedCommands).toEqual(['wsl.exe', 'git'])
     })
   })
 })

--- a/src/main/git/runner-wsl-read-routing.test.ts
+++ b/src/main/git/runner-wsl-read-routing.test.ts
@@ -66,6 +66,10 @@ describe('WSL git read routing', () => {
   // general git options that never opted into the shell-free route.
   it.each([
     ['remote get-url', ['remote', 'get-url', 'origin']],
+    ['remote list', ['remote']],
+    ['remote show without query', ['remote', 'show', '-n', 'origin']],
+    ['symbolic-ref', ['symbolic-ref', '--quiet', '--short', 'HEAD']],
+    ['worktree list', ['worktree', 'list', '--porcelain']],
     ['config --get', ['config', '--get', 'remote.origin.url']],
     ['log', ['log', '--oneline', '-n', '1']],
     ['show blob', ['show', ':src/file.ts']]
@@ -85,7 +89,8 @@ describe('WSL git read routing', () => {
   it.each([
     ['commit', ['commit', '-m', 'msg']],
     ['config set', ['config', 'user.email', 'me@example.com']],
-    ['remote add', ['remote', 'add', 'upstream', 'https://example.com/r.git']]
+    ['remote add', ['remote', 'add', 'upstream', 'https://example.com/r.git']],
+    ['remote show with query', ['remote', 'show', 'origin']]
   ])('keeps %s on the login shell', async (_name, args) => {
     await gitExecFileAsync(args, { cwd: WSL_CWD, wslDistro: DISTRO })
 

--- a/src/main/git/runner-wsl-read-routing.test.ts
+++ b/src/main/git/runner-wsl-read-routing.test.ts
@@ -1,0 +1,96 @@
+import { EventEmitter } from 'node:events'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { execFileMock, execFileSyncMock, spawnMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+  execFileSyncMock: vi.fn(),
+  spawnMock: vi.fn()
+}))
+
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock,
+  execFileSync: execFileSyncMock,
+  spawn: spawnMock
+}))
+vi.mock('../observability/instrumentation', () => ({
+  withGitSpan: (_attributes: unknown, run: () => unknown) => run()
+}))
+vi.mock('../diagnostics/main-thread-churn-probe', () => ({ recordSubprocessSpawn: vi.fn() }))
+
+import { gitExecFileAsync } from './runner'
+import {
+  resetWslGitReadEnvironmentForTests,
+  seedWslGitReadEnvironmentForTests
+} from './wsl-git-read-environment'
+
+const DISTRO = 'Ubuntu'
+const WSL_CWD = String.raw`\wsl.localhost\Ubuntu\home\alice\repo`
+const LOGIN_ENVIRONMENT = {
+  gitPath: '/usr/bin/git',
+  home: '/home/alice',
+  path: '/home/alice/bin:/usr/bin'
+}
+
+function createMockChild(): EventEmitter & { stdout: EventEmitter; stderr: EventEmitter } {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter
+    stderr: EventEmitter
+  }
+  child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
+  return child
+}
+
+function lastArgs(): string[] {
+  return execFileMock.mock.calls.at(-1)?.[1] as string[]
+}
+
+describe('WSL git read routing', () => {
+  beforeEach(() => {
+    execFileMock.mockReset()
+    execFileMock.mockImplementation((_command, _args, _options, callback) => {
+      queueMicrotask(() => callback?.(null, 'ok', ''))
+      return createMockChild()
+    })
+    resetWslGitReadEnvironmentForTests()
+    seedWslGitReadEnvironmentForTests(DISTRO, LOGIN_ENVIRONMENT)
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: process.platform })
+    resetWslGitReadEnvironmentForTests()
+  })
+
+  // Why these two: they are the parse #10917 reports, and they run through the
+  // general git options that never opted into the shell-free route.
+  it.each([
+    ['remote get-url', ['remote', 'get-url', 'origin']],
+    ['config --get', ['config', '--get', 'remote.origin.url']],
+    ['log', ['log', '--oneline', '-n', '1']],
+    ['show blob', ['show', ':src/file.ts']]
+  ])('runs %s with no shell at all', async (_name, args) => {
+    await gitExecFileAsync(args, { cwd: WSL_CWD, wslDistro: DISTRO })
+
+    const resolved = lastArgs()
+    expect(resolved).toContain('--exec')
+    expect(resolved).toContain('/usr/bin/env')
+    expect(resolved).toContain(`PATH=${LOGIN_ENVIRONMENT.path}`)
+    // No shell means no rc file, so no banner can reach the parsed stdout.
+    expect(resolved).not.toContain('-lc')
+    expect(resolved).not.toContain('sh')
+    expect(resolved.join(' ')).not.toContain('getent passwd')
+  })
+
+  it.each([
+    ['commit', ['commit', '-m', 'msg']],
+    ['config set', ['config', 'user.email', 'me@example.com']],
+    ['remote add', ['remote', 'add', 'upstream', 'https://example.com/r.git']]
+  ])('keeps %s on the login shell', async (_name, args) => {
+    await gitExecFileAsync(args, { cwd: WSL_CWD, wslDistro: DISTRO })
+
+    const resolved = lastArgs()
+    expect(resolved).toContain('-lc')
+    expect(resolved.join(' ')).toContain('getent passwd')
+  })
+})

--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -34,6 +34,7 @@ import {
   gitCredentialPromptGuardEnv
 } from '../../shared/git-credential-prompt-env'
 import { getSpawnArgsForWindows, isWindowsBatchScript, resolveWindowsCommand } from '../win32-utils'
+import { isWslDirectGitReadCommand } from './wsl-direct-git-read-commands'
 import {
   buildWslCapturedLoginShellCommand,
   buildWslExecArgs,
@@ -446,7 +447,7 @@ function resolveGitCommand(
     // Why: WSL Git resolves a Windows-authored linked-worktree pointer relative to cwd.
     return { binary: 'git', args, cwd: options.cwd, wsl: null, wslMode: null }
   }
-  if (!forceLoginShell && shouldAttemptWslDirectGit(options)) {
+  if (!forceLoginShell && shouldAttemptWslDirectGit(args, options)) {
     const distro = wslDistroForCommand(options.cwd, options.wslDistro)
     const environment = distro ? peekWslGitReadEnvironment(distro) : undefined
     if (environment) {
@@ -462,10 +463,13 @@ function resolveGitCommand(
   return resolveGitCommandWithoutProbe(args, options, captureLoginShellOutput)
 }
 
-function shouldAttemptWslDirectGit(options: GitExecOptions): boolean {
+function shouldAttemptWslDirectGit(args: string[], options: GitExecOptions): boolean {
   return Boolean(
     process.platform === 'win32' &&
-    options.preferWslDirectGit &&
+    // Why either: callers can still opt in explicitly, but a plain read no
+    // longer has to -- it needs nothing the login shell provides, and routing
+    // it through one is what exposes callers to the shell's rc output.
+    (options.preferWslDirectGit || isWslDirectGitReadCommand(args)) &&
     !options.useConfiguredSshCommandForNetwork &&
     !Object.entries(options.env ?? {}).some(
       ([key, value]) =>
@@ -1184,14 +1188,15 @@ export async function gitExecFileAsyncBuffer(
   if (isWslLinkedWorktreeGitRoutingCandidate(options.cwd, options.wslDistro)) {
     await prepareWslLinkedWorktreeGitRouting(options.cwd, options.wslDistro)
   }
-  // Why fenced: this returns raw blob bytes straight to the diff/blob viewer, so
-  // a login-shell banner would be prepended to displayed file content.
-  let resolved = resolveGitCommand(args, options, true, true)
+  // `git show` is a read, so this normally runs with no shell at all. The fence
+  // still matters for the login-shell fallback: these are raw blob bytes going
+  // straight to the diff/blob viewer, where a banner becomes file content.
+  let resolved = resolveGitCommand(args, options, false, true)
   const environmentReady = prepareWindowsHostGitEnvironment(resolved, undefined)
   if (environmentReady) {
     await environmentReady
   }
-  resolved = resolveGitCommand(args, options, true, true)
+  resolved = resolveGitCommand(args, options, false, true)
   const { stdout } = (await execFileCapture(resolved.binary, resolved.args, {
     cwd: resolved.cwd,
     encoding: 'buffer',

--- a/src/main/git/wsl-direct-git-read-commands.test.ts
+++ b/src/main/git/wsl-direct-git-read-commands.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { isWslDirectGitReadCommand } from './wsl-direct-git-read-commands'
+
+describe('isWslDirectGitReadCommand', () => {
+  it.each([
+    [['status', '--porcelain=v2']],
+    [['log', '--oneline', '-n', '10']],
+    [['show', ':src/file.ts']],
+    [['show', '--end-of-options', 'HEAD:src/file.ts']],
+    [['rev-parse', '--show-toplevel']],
+    [['ls-files', '-z', '--', 'src']],
+    [['check-ignore', '-z', '--stdin']],
+    [['config', '--get', 'core.sshCommand']],
+    [['config', '--get-regexp', String.raw`^remote\.`]],
+    [['remote', 'get-url', 'origin']],
+    [['remote', '-v']],
+    [['branch', '--list']],
+    [['branch', '--show-current']],
+    // Global options precede the subcommand.
+    [['-c', 'core.quotepath=off', 'log', '--oneline']],
+    [['-C', '/repo', 'rev-parse', 'HEAD']],
+    [['--git-dir=/repo/.git', 'ls-tree', 'HEAD']]
+  ])('routes %j without a shell', (args) => {
+    expect(isWslDirectGitReadCommand(args)).toBe(true)
+  })
+
+  // Why these matter most: a write misrouted to the shell-free path loses the
+  // credential helpers and ssh-agent the user's login shell sets up.
+  it.each([
+    [['commit', '-m', 'msg']],
+    [['push', 'origin', 'main']],
+    [['fetch', '--all']],
+    [['pull', '--rebase']],
+    [['clone', 'https://example.com/r.git']],
+    [['checkout', '-b', 'feature']],
+    [['add', '--', 'file.ts']],
+    [['worktree', 'add', '/tmp/wt']],
+    [['submodule', 'update', '--init']],
+    // Same subcommands as above, in their writing form.
+    [['config', 'user.email', 'me@example.com']],
+    [['config', '--unset', 'core.sshCommand']],
+    [['remote', 'add', 'origin', 'https://example.com/r.git']],
+    [['remote', 'remove', 'origin']],
+    [['branch', '-D', 'feature']],
+    [['branch', 'newbranch']],
+    [[]]
+  ])('keeps %j on the login shell', (args) => {
+    expect(isWslDirectGitReadCommand(args)).toBe(false)
+  })
+})

--- a/src/main/git/wsl-direct-git-read-commands.test.ts
+++ b/src/main/git/wsl-direct-git-read-commands.test.ts
@@ -71,4 +71,21 @@ describe('isWslDirectGitReadCommand', () => {
       expect(isWslDirectGitReadCommand(args)).toBe(true)
     }
   )
+
+  // Why: a write hidden behind global options must never reach the shell-free
+  // route, and an unparsed global form must fall back to the login shell rather
+  // than guess. Both directions fail safe.
+  it.each([
+    [['-c', 'k=v', 'push', 'origin', 'main']],
+    [['-C', '/repo', 'commit', '-m', 'x']],
+    [['-c', 'k=v', 'fetch', '--all']],
+    [['--git-dir=/x', 'push']],
+    // Space-separated global values are not parsed; the value reads as the
+    // subcommand, which is in no read set, so it stays on the login shell.
+    [['--git-dir', '/x', 'log']],
+    [['--work-tree', '/x', 'status']],
+    [['-c', 'k=v']]
+  ])('keeps %j on the login shell behind global options', (args) => {
+    expect(isWslDirectGitReadCommand(args)).toBe(false)
+  })
 })

--- a/src/main/git/wsl-direct-git-read-commands.test.ts
+++ b/src/main/git/wsl-direct-git-read-commands.test.ts
@@ -13,7 +13,11 @@ describe('isWslDirectGitReadCommand', () => {
     [['config', '--get', 'core.sshCommand']],
     [['config', '--get-regexp', String.raw`^remote\.`]],
     [['remote', 'get-url', 'origin']],
+    [['remote']],
     [['remote', '-v']],
+    [['remote', 'show', '-n', 'origin']],
+    [['symbolic-ref', '--quiet', '--short', 'HEAD']],
+    [['worktree', 'list', '--porcelain']],
     [['branch', '--list']],
     [['branch', '--show-current']],
     // Global options precede the subcommand.
@@ -41,6 +45,9 @@ describe('isWslDirectGitReadCommand', () => {
     [['config', '--unset', 'core.sshCommand']],
     [['remote', 'add', 'origin', 'https://example.com/r.git']],
     [['remote', 'remove', 'origin']],
+    [['remote', 'show', 'origin']],
+    [['symbolic-ref', 'HEAD', 'refs/heads/main']],
+    [['worktree', 'add', '/tmp/wt']],
     [['branch', '-D', 'feature']],
     [['branch', 'newbranch']],
     [[]]

--- a/src/main/git/wsl-direct-git-read-commands.test.ts
+++ b/src/main/git/wsl-direct-git-read-commands.test.ts
@@ -54,4 +54,21 @@ describe('isWslDirectGitReadCommand', () => {
   ])('keeps %j on the login shell', (args) => {
     expect(isWslDirectGitReadCommand(args)).toBe(false)
   })
+
+  // Why positional: these read markers are matched as the action, not anywhere in
+  // argv. Matching loosely routed a write shell-free whenever a positional
+  // happened to share a read marker's name.
+  it.each([[['worktree', 'remove', 'list']], [['submodule', 'foreach', 'status']]])(
+    'keeps %j on the login shell despite a read-shaped positional',
+    (args) => {
+      expect(isWslDirectGitReadCommand(args)).toBe(false)
+    }
+  )
+
+  it.each([[['submodule', 'status']], [['submodule']], [['remote']]])(
+    'routes the listing form %j without a shell',
+    (args) => {
+      expect(isWslDirectGitReadCommand(args)).toBe(true)
+    }
+  )
 })

--- a/src/main/git/wsl-direct-git-read-commands.ts
+++ b/src/main/git/wsl-direct-git-read-commands.ts
@@ -38,8 +38,9 @@ const ALWAYS_READ_SUBCOMMANDS = new Set([
 const CONDITIONAL_READ_SUBCOMMANDS: Record<string, ReadonlySet<string>> = {
   branch: new Set(['--list', '-l', '--show-current', '--contains', '--points-at']),
   config: new Set(['--get', '--get-all', '--get-regexp', '--get-urlmatch', '--list', '-l']),
-  remote: new Set(['get-url', '-v', '--verbose', 'show']),
-  submodule: new Set(['status'])
+  remote: new Set(['get-url', '-v', '--verbose']),
+  submodule: new Set(['status']),
+  worktree: new Set(['list'])
 }
 
 /** Leading `-c key=value` / `--git-dir=...` style options precede the subcommand. */
@@ -67,11 +68,31 @@ export function isWslDirectGitReadCommand(args: readonly string[]): boolean {
   if (ALWAYS_READ_SUBCOMMANDS.has(subcommand)) {
     return true
   }
+  if (subcommand === 'remote') {
+    const remoteArgs = args.slice(subcommandIndex + 1)
+    const action = remoteArgs.find((arg) => !arg.startsWith('-'))
+    if (!action) {
+      return true
+    }
+    // `remote show` queries the transport unless `-n` is present. Keep the
+    // queried form on the login shell so profile-provided SSH/credential setup survives.
+    if (action === 'show') {
+      return remoteArgs.includes('-n')
+    }
+    return CONDITIONAL_READ_SUBCOMMANDS.remote.has(action)
+  }
+  if (subcommand === 'symbolic-ref') {
+    const symbolicRefArgs = args.slice(subcommandIndex + 1)
+    if (symbolicRefArgs.some((arg) => arg === '-d' || arg === '--delete' || arg === '-m')) {
+      return false
+    }
+    return symbolicRefArgs.filter((arg) => arg !== '--' && !arg.startsWith('-')).length <= 1
+  }
   const readFlags = CONDITIONAL_READ_SUBCOMMANDS[subcommand]
   return Boolean(
     readFlags &&
-      args
-        .slice(subcommandIndex + 1)
-        .some((arg) => readFlags.has(arg) || readFlags.has(arg.split('=')[0]))
+    args
+      .slice(subcommandIndex + 1)
+      .some((arg) => readFlags.has(arg) || readFlags.has(arg.split('=')[0]))
   )
 }

--- a/src/main/git/wsl-direct-git-read-commands.ts
+++ b/src/main/git/wsl-direct-git-read-commands.ts
@@ -1,0 +1,77 @@
+/**
+ * Decide whether a git invocation is a plain read that can run without a shell.
+ *
+ * Why: WSL-routed git otherwise goes through the distro user's interactive login
+ * shell, purely to inherit their PATH. That shell also runs the distro's rc/motd
+ * and writes it to the stdout callers parse. Reads need none of it -- the direct
+ * route supplies PATH and HOME explicitly and starts no shell at all.
+ *
+ * Writes and network operations stay on the login shell: they can depend on
+ * credential helpers, ssh-agent and other environment only the user's profile
+ * sets up.
+ */
+
+// Subcommands that only ever read. `status` is here for completeness; its
+// callers already opted in explicitly.
+const ALWAYS_READ_SUBCOMMANDS = new Set([
+  'blame',
+  'cat-file',
+  'check-ignore',
+  'describe',
+  'diff',
+  'for-each-ref',
+  'log',
+  'ls-files',
+  'ls-tree',
+  'merge-base',
+  'name-rev',
+  'rev-list',
+  'rev-parse',
+  'show',
+  'show-ref',
+  'status',
+  'var'
+])
+
+// Subcommands that read or write depending on their flags. Each needs an
+// explicit read flag before it can skip the shell.
+const CONDITIONAL_READ_SUBCOMMANDS: Record<string, ReadonlySet<string>> = {
+  branch: new Set(['--list', '-l', '--show-current', '--contains', '--points-at']),
+  config: new Set(['--get', '--get-all', '--get-regexp', '--get-urlmatch', '--list', '-l']),
+  remote: new Set(['get-url', '-v', '--verbose', 'show']),
+  submodule: new Set(['status'])
+}
+
+/** Leading `-c key=value` / `--git-dir=...` style options precede the subcommand. */
+function findSubcommandIndex(args: readonly string[]): number {
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]
+    if (arg === '-c' || arg === '-C') {
+      index += 1
+      continue
+    }
+    if (arg.startsWith('-')) {
+      continue
+    }
+    return index
+  }
+  return -1
+}
+
+export function isWslDirectGitReadCommand(args: readonly string[]): boolean {
+  const subcommandIndex = findSubcommandIndex(args)
+  if (subcommandIndex === -1) {
+    return false
+  }
+  const subcommand = args[subcommandIndex]
+  if (ALWAYS_READ_SUBCOMMANDS.has(subcommand)) {
+    return true
+  }
+  const readFlags = CONDITIONAL_READ_SUBCOMMANDS[subcommand]
+  return Boolean(
+    readFlags &&
+      args
+        .slice(subcommandIndex + 1)
+        .some((arg) => readFlags.has(arg) || readFlags.has(arg.split('=')[0]))
+  )
+}

--- a/src/main/git/wsl-direct-git-read-commands.ts
+++ b/src/main/git/wsl-direct-git-read-commands.ts
@@ -33,15 +33,23 @@ const ALWAYS_READ_SUBCOMMANDS = new Set([
   'var'
 ])
 
-// Subcommands that read or write depending on their flags. Each needs an
-// explicit read flag before it can skip the shell.
-const CONDITIONAL_READ_SUBCOMMANDS: Record<string, ReadonlySet<string>> = {
+// Read markers that appear as a flag anywhere after the subcommand.
+const READ_FLAG_SUBCOMMANDS: Record<string, ReadonlySet<string>> = {
   branch: new Set(['--list', '-l', '--show-current', '--contains', '--points-at']),
-  config: new Set(['--get', '--get-all', '--get-regexp', '--get-urlmatch', '--list', '-l']),
-  remote: new Set(['get-url', '-v', '--verbose']),
+  config: new Set(['--get', '--get-all', '--get-regexp', '--get-urlmatch', '--list', '-l'])
+}
+
+// Read markers that must be the *first non-flag* argument, i.e. the action.
+// Position matters here: matching them anywhere would read `worktree remove list`
+// as a listing, because a worktree may legitimately be named "list".
+const READ_ACTION_SUBCOMMANDS: Record<string, ReadonlySet<string>> = {
+  remote: new Set(['get-url']),
   submodule: new Set(['status']),
   worktree: new Set(['list'])
 }
+
+// Subcommands whose action-less form only lists (`git remote`, `git submodule`).
+const BARE_FORM_IS_READ = new Set(['remote', 'submodule'])
 
 /** Leading `-c key=value` / `--git-dir=...` style options precede the subcommand. */
 function findSubcommandIndex(args: readonly string[]): number {
@@ -68,31 +76,30 @@ export function isWslDirectGitReadCommand(args: readonly string[]): boolean {
   if (ALWAYS_READ_SUBCOMMANDS.has(subcommand)) {
     return true
   }
-  if (subcommand === 'remote') {
-    const remoteArgs = args.slice(subcommandIndex + 1)
-    const action = remoteArgs.find((arg) => !arg.startsWith('-'))
-    if (!action) {
-      return true
-    }
-    // `remote show` queries the transport unless `-n` is present. Keep the
-    // queried form on the login shell so profile-provided SSH/credential setup survives.
-    if (action === 'show') {
-      return remoteArgs.includes('-n')
-    }
-    return CONDITIONAL_READ_SUBCOMMANDS.remote.has(action)
-  }
+  const rest = args.slice(subcommandIndex + 1)
+
   if (subcommand === 'symbolic-ref') {
-    const symbolicRefArgs = args.slice(subcommandIndex + 1)
-    if (symbolicRefArgs.some((arg) => arg === '-d' || arg === '--delete' || arg === '-m')) {
+    if (rest.some((arg) => arg === '-d' || arg === '--delete' || arg === '-m')) {
       return false
     }
-    return symbolicRefArgs.filter((arg) => arg !== '--' && !arg.startsWith('-')).length <= 1
+    // Reading takes one ref; a second positional is the value being written.
+    return rest.filter((arg) => arg !== '--' && !arg.startsWith('-')).length <= 1
   }
-  const readFlags = CONDITIONAL_READ_SUBCOMMANDS[subcommand]
-  return Boolean(
-    readFlags &&
-    args
-      .slice(subcommandIndex + 1)
-      .some((arg) => readFlags.has(arg) || readFlags.has(arg.split('=')[0]))
-  )
+
+  const readActions = READ_ACTION_SUBCOMMANDS[subcommand]
+  if (readActions) {
+    const action = rest.find((arg) => !arg.startsWith('-'))
+    if (!action) {
+      return BARE_FORM_IS_READ.has(subcommand)
+    }
+    // `remote show` queries the transport unless -n is given, so the queried
+    // form has to keep the profile's SSH and credential setup.
+    if (subcommand === 'remote' && action === 'show') {
+      return rest.includes('-n')
+    }
+    return readActions.has(action)
+  }
+
+  const readFlags = READ_FLAG_SUBCOMMANDS[subcommand]
+  return Boolean(readFlags && rest.some((arg) => readFlags.has(arg.split('=')[0])))
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​206 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​203 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​117 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​110 |

<!-- /orca-pr-loc -->

<!-- wsl-stack -->
### Stack

Merge bottom-up; each PR is based on the one above it.

| # | PR | Base | |
| ---: | :--- | :--- | :--- |
| 1 |   #15039 | `main` | fix(wsl): pass guest argv verbatim through --exec |
| 2 |   #15040 | `#15039` | fix(wsl): read machine output from a fenced login shell |
| 3 |   #15060 | `#15040` | fix(git): fence buffered WSL login-shell reads |
| 4 | ▶ #15257 | `#15060` | fix(git): run WSL git reads without a shell ← **you are here** |

<!-- /wsl-stack -->

## ELI5

To run git inside WSL, Orca was starting the user's *login shell* first â€” the same one that greets you when you open a terminal â€” purely so git would be on the PATH. That shell also prints the distro's welcome banner, into the same pipe Orca reads git's answer from. So Orca would read the banner as if it were git's output, and conclude the repo had no GitHub remote.

The fix isn't to filter the banner out. It's to stop starting a shell for work that never needed one: ask the shell *once* what the PATH is, remember it, then run git directly.

## Why the earlier PRs didn't fix #10917

#15040 and #15060 fenced the output so the banner could be sliced off. That treats the symptom. This PR removes the cause for reads.

The shell-free route already existed â€” `--exec /usr/bin/env PATH=â€¦ HOME=â€¦ /usr/bin/git`, added for status reads in #13207 â€” but it was **opt-in**, and exactly one options-builder opted in:

```
$ grep -rn "preferWslDirectGit" src --include=*.ts | grep -v test
git-runtime-options.ts:24:  preferWslDirectGit: true
git-runtime-options.ts:26:  return { ...gitOptionsForWorktree(cwd, options), preferWslDirectGit: true }
status.ts:328:        preferWslDirectGit: true,
```

Everything else â€” `remote get-url`, `config --get`, `log`, `show`, `rev-parse` â€” used `gitOptionsForWorktree`, which never set it. So the exact parse #10917 reports (`remote.ts`) took the login shell on **every** call. Fencing it would have been a fifth patch on the same wound.

## What changed

Reads are classified at the resolver, not at each caller, so no call site has to remember to opt in:

```ts
(options.preferWslDirectGit || isWslDirectGitReadCommand(args)) && â€¦
```

Writes and network operations deliberately stay on the login shell â€” they can depend on credential helpers and ssh-agent that only the user's profile sets up.

Subcommands that both read and write require an explicit read flag, so `config --get` goes direct while `config user.email x` does not. Same for `remote get-url` vs `remote add`, and `branch --list` vs `branch -D`.

`git show` blob reads stop forcing the login shell. **The fence added in #15060 stays** on that path: the login shell is still the fallback when the environment probe is cold or rejected, and a banner there would become file content. It becomes rarely-hit rather than unnecessary.

## Safety

The existing fallback is what makes this low-risk: a direct-git failure retries on the login shell, and a successful retry disables the direct route for that distro. A misclassified command self-heals rather than breaking.

The probe itself already refuses to engage when the environment is unusual â€” `git` missing or not executable (exit 127), or `XDG_CONFIG_HOME` / `LD_LIBRARY_PATH` / any `GIT_*` set (exit 78).

## Testing

- 32 classifier cases, weighted toward the dangerous direction: **every write form** (`commit`, `push`, `fetch`, `pull`, `clone`, `checkout`, `add`, `worktree add`, `submodule update`, `config <set>`, `config --unset`, `remote add`, `remote remove`, `branch -D`, `branch <name>`) is asserted to stay on the login shell.
- An integration test asserts the #10917 path (`remote get-url`, `config --get`) resolves to `--exec /usr/bin/env PATH=â€¦` with **no `sh`, no `-lc`, and no `getent passwd`** anywhere in the argv â€” mutation-checked: reverting the routing fails all four read cases while the three write cases still pass.
- Suite compared against `origin/main` at test-name granularity across `src/main/git`, `src/main/ipc`, `src/shared`: **zero new failures**, 12 fewer than `main`.
- Typecheck plus all three static-analysis gates clean.

## Behavior note

The first WSL read per distro now also warms the environment probe in the background, so a cold read spawns one extra `wsl.exe` (once per distro per session). Subsequent reads start no shell at all. Two tests asserted the old spawn *sequence* and were updated to ignore the probe rather than weakened.

Measured on a real Ubuntu-24.04: shell startup is not the dominant cost (`sh -c` 67ms vs `bash -ilc` 70ms; `wsl.exe` spawn dominates), so this is a correctness and robustness change, not a performance one.


