### PR TITLE
fix(shell): repair worktree HISTFILE in plain zsh panes via one positive feature channel

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -336,8 +336,10 @@ jobs:
             src/main/providers/local-pty-shell-ready-zsh-zdotdir-normalization.test.ts \
             src/main/providers/__tests__/shell-ready-framework-example.test.ts \
             src/main/pty/omp-shell-wrapper.node-pty.test.ts \
+            src/main/shell-startup-feature-channel.test.ts \
             src/main/terminal-history-fish-session.node-pty.test.ts \
             src/main/zsh-scoped-histfile.live-shell.test.ts \
+            src/main/zsh-wrapper-version-mismatch.live-shell.test.ts \
             src/renderer/src/components/terminal-pane/fish-color-scheme-child-stdin.node-pty.test.ts \
             src/shared/startup-shell-portability.live-shell.test.ts \
             src/shared/posix-command-path-lookup.test.ts
@@ -378,8 +380,10 @@ jobs:
             --exclude=src/main/providers/local-pty-shell-ready-zsh-zdotdir-normalization.test.ts \
             --exclude=src/main/providers/__tests__/shell-ready-framework-example.test.ts \
             --exclude=src/main/pty/omp-shell-wrapper.node-pty.test.ts \
+            --exclude=src/main/shell-startup-feature-channel.test.ts \
             --exclude=src/main/terminal-history-fish-session.node-pty.test.ts \
             --exclude=src/main/zsh-scoped-histfile.live-shell.test.ts \
+            --exclude=src/main/zsh-wrapper-version-mismatch.live-shell.test.ts \
             --exclude=src/renderer/src/components/terminal-pane/fish-color-scheme-child-stdin.node-pty.test.ts \
             --exclude=src/shared/startup-shell-portability.live-shell.test.ts \
             --exclude=src/shared/posix-command-path-lookup.test.ts \

--- a/config/scripts/pr-workflow-parallelism.test.mjs
+++ b/config/scripts/pr-workflow-parallelism.test.mjs
@@ -15,7 +15,9 @@ const shellContractFiles = [
   'src/main/providers/local-pty-shell-ready-zsh-zdotdir-discovery.test.ts',
   'src/main/providers/local-pty-shell-ready-zsh-zdotdir-normalization.test.ts',
   'src/main/providers/__tests__/shell-ready-framework-example.test.ts',
+  'src/main/shell-startup-feature-channel.test.ts',
   'src/main/zsh-scoped-histfile.live-shell.test.ts',
+  'src/main/zsh-wrapper-version-mismatch.live-shell.test.ts',
   'src/shared/posix-command-path-lookup.test.ts'
 ]
 const patchedNodePtyContractFiles = [

--- a/src/main/daemon/bash-prompt-command-composition.test.ts
+++ b/src/main/daemon/bash-prompt-command-composition.test.ts
@@ -29,7 +29,7 @@ function runInteractiveBash(
     {
       input,
       encoding: 'utf8',
-      env: { ...process.env, HOME: tempHome, ORCA_SHELL_READY_MARKER: '1', TERM: 'xterm' },
+      env: { ...process.env, HOME: tempHome, ORCA_SHELL_FEATURES: 'ready', TERM: 'xterm' },
       timeout: 5000
     }
   )

--- a/src/main/daemon/daemon-bash-shell-ready-rcfile.ts
+++ b/src/main/daemon/daemon-bash-shell-ready-rcfile.ts
@@ -1,12 +1,19 @@
 import { getPosixOmpShellWrapper } from '../pty/omp-shell-wrapper'
 import { getPosixCodexShellLaunchPreflight } from '../pty/codex-shell-launch-preflight'
 import { BASH_PROMPT_COMMAND_COMPOSITION_BLOCK } from '../bash-prompt-command-composition'
-import { SHELL_STARTUP_IDENTITY_MARKER_BLOCK } from '../shell-templates'
+import { BASH_FEATURE_CHANNEL_BLOCK, SHELL_STARTUP_IDENTITY_MARKER_BLOCK } from '../shell-templates'
 import { SHELL_READY_MARKER } from './daemon-shell-ready-marker'
 
 export function getDaemonBashShellReadyRcfileContent(): string {
   return `# Orca daemon bash shell-ready wrapper
+${BASH_FEATURE_CHANNEL_BLOCK}
 ${SHELL_STARTUP_IDENTITY_MARKER_BLOCK}
+# Why a plain variable: the channel is consumed and destroyed in these first
+# lines, so nothing this shell later spawns can see or inherit the selection.
+__orca_ready_marker=""
+__orca_has_feature ready && __orca_ready_marker=1
+unset _orca_shell_features
+unset -f __orca_has_feature
 [[ -f /etc/profile ]] && source /etc/profile
 if [[ -f "$HOME/.bash_profile" ]]; then
   source "$HOME/.bash_profile"
@@ -52,7 +59,7 @@ __orca_osc133_precmd() {
   # Why: emit the shell-ready marker here (not a trailing PROMPT_COMMAND entry)
   # so a framework that must be last in PROMPT_COMMAND — bash-preexec — is not
   # displaced by one of Orca's own hooks.
-  [[ "\${ORCA_SHELL_READY_MARKER:-0}" == "1" ]] && printf "${SHELL_READY_MARKER}"
+  [[ -n "$__orca_ready_marker" ]] && printf "${SHELL_READY_MARKER}"
   return "$exit_code"
 }
 __orca_osc133_preexec() {

--- a/src/main/daemon/daemon-zsh-shell-ready-wrapper-spec.ts
+++ b/src/main/daemon/daemon-zsh-shell-ready-wrapper-spec.ts
@@ -10,16 +10,13 @@ export function getDaemonZshWrapperSpec(zshDir: string): ZshStartupWrapperSpec {
     readyMarkerEscaped: SHELL_READY_MARKER,
     osc133CommandMarkers: true,
     skipUserZshrcWhenHomeIsWrapperDir: true,
-    interactiveRestoreComment:
+    overlayRestoreComment:
       "# Why: ~/.zshrc can export the user's default OpenCode config after spawn.",
-    loginRestoreComment:
-      '# Why: .zlogin is the final login startup file before the prompt is shown.',
     restores: {
       agentTeamsPath: true,
       remoteCliBinDir: false,
       codexHome: true,
       codexLaunchPreflight: true
-    },
-    readyMarkerOrder: 'before-zdotdir-restore'
+    }
   }
 }

--- a/src/main/daemon/pty-subprocess-env-inheritance.test.ts
+++ b/src/main/daemon/pty-subprocess-env-inheritance.test.ts
@@ -250,6 +250,46 @@ describe('createPtySubprocess', () => {
     expect(spawnMock.mock.calls.at(-1)?.[2].env.HISTFILE).toBe(expected)
   })
 
+  it.each([
+    // ORCA_HISTFILE is exported into every pane, so a daemon started from an
+    // Orca pane inherits one. Left in place it BOTH re-scopes the pane to
+    // another worktree's history file (#11146) and wraps a zsh pane nothing
+    // asked to wrap, since `history` is selected on its presence.
+    ['drops an inherited Orca ORCA_HISTFILE', undefined, undefined],
+    [
+      'keeps the path this spawn injected',
+      '/fake/userData/terminal-history/00112233445566aa/zsh_history',
+      '/fake/userData/terminal-history/00112233445566aa/zsh_history'
+    ],
+    ['keeps a caller-supplied value', '/home/me/.zsh_history', '/home/me/.zsh_history']
+  ])('%s', async (_name, requested, expected) => {
+    spawnMock.mockReturnValue(mockPtyProcess())
+    const saved = process.env.ORCA_HISTFILE
+    process.env.ORCA_HISTFILE = '/fake/userData/terminal-history/aabbccddeeff0011/zsh_history'
+
+    try {
+      await createPtySubprocess({
+        sessionId: 'test',
+        cols: 80,
+        rows: 24,
+        shellOverride: '/bin/zsh',
+        ...(requested === undefined ? {} : { env: { ORCA_HISTFILE: requested } })
+      })
+    } finally {
+      if (saved === undefined) {
+        delete process.env.ORCA_HISTFILE
+      } else {
+        process.env.ORCA_HISTFILE = saved
+      }
+    }
+
+    const env = spawnMock.mock.calls.at(-1)?.[2].env
+    expect(env.ORCA_HISTFILE).toBe(expected)
+    // The wrapping consequence: no inherited value may point a pane at Orca's
+    // ZDOTDIR that the client scoped no history for.
+    expect(env.ORCA_SHELL_FEATURES).toBe(expected === undefined ? undefined : 'history')
+  })
+
   it('does not inherit ELECTRON_RUN_AS_NODE from the daemon process env', async () => {
     // Why: the daemon is forked with ELECTRON_RUN_AS_NODE=1. If that flag
     // reaches user shells, nested Electron commands run as plain Node.

--- a/src/main/daemon/pty-subprocess-env-inheritance.test.ts
+++ b/src/main/daemon/pty-subprocess-env-inheritance.test.ts
@@ -217,6 +217,39 @@ describe('createPtySubprocess', () => {
     expect(spawnMock.mock.calls.at(-1)?.[2].env.fish_history).toBe(expected)
   })
 
+  it.each([
+    // HISTFILE is exported too, so a daemon started from an Orca pane would hand
+    // every session the launching worktree's history file.
+    ['drops an inherited Orca HISTFILE', undefined, undefined],
+    [
+      'keeps the path this spawn injected',
+      '/fake/userData/terminal-history/00112233445566aa/zsh_history',
+      '/fake/userData/terminal-history/00112233445566aa/zsh_history'
+    ],
+    ['keeps a caller-supplied value', '/home/me/.zsh_history', '/home/me/.zsh_history']
+  ])('%s', async (_name, requested, expected) => {
+    spawnMock.mockReturnValue(mockPtyProcess())
+    const saved = process.env.HISTFILE
+    process.env.HISTFILE = '/fake/userData/terminal-history/aabbccddeeff0011/zsh_history'
+
+    try {
+      await createPtySubprocess({
+        sessionId: 'test',
+        cols: 80,
+        rows: 24,
+        ...(requested === undefined ? {} : { env: { HISTFILE: requested } })
+      })
+    } finally {
+      if (saved === undefined) {
+        delete process.env.HISTFILE
+      } else {
+        process.env.HISTFILE = saved
+      }
+    }
+
+    expect(spawnMock.mock.calls.at(-1)?.[2].env.HISTFILE).toBe(expected)
+  })
+
   it('does not inherit ELECTRON_RUN_AS_NODE from the daemon process env', async () => {
     // Why: the daemon is forked with ELECTRON_RUN_AS_NODE=1. If that flag
     // reaches user shells, nested Electron commands run as plain Node.

--- a/src/main/daemon/pty-subprocess-managed-agent-env.test.ts
+++ b/src/main/daemon/pty-subprocess-managed-agent-env.test.ts
@@ -112,7 +112,7 @@ describe('createPtySubprocess', () => {
     const lastCall = spawnMock.mock.calls.at(-1)!
     expect(lastCall[1]).toEqual(['-l'])
     expect(lastCall[2].env.ZDOTDIR).toMatch(ZSH_SHELL_READY_DIR)
-    expect(lastCall[2].env.ORCA_SHELL_READY_MARKER).toBe('0')
+    expect(lastCall[2].env.ORCA_SHELL_FEATURES).not.toContain('ready')
   })
 
   it('uses shell wrapper when OpenCode config must survive shell startup', async () => {
@@ -141,7 +141,7 @@ describe('createPtySubprocess', () => {
     const lastCall = spawnMock.mock.calls.at(-1)!
     expect(lastCall[1]).toEqual(['-l'])
     expect(lastCall[2].env.ZDOTDIR).toMatch(ZSH_SHELL_READY_DIR)
-    expect(lastCall[2].env.ORCA_SHELL_READY_MARKER).toBe('0')
+    expect(lastCall[2].env.ORCA_SHELL_FEATURES).not.toContain('ready')
   })
 
   it('uses shell wrapper when MiMo home must survive shell startup', async () => {
@@ -170,7 +170,7 @@ describe('createPtySubprocess', () => {
     const lastCall = spawnMock.mock.calls.at(-1)!
     expect(lastCall[1]).toEqual(['-l'])
     expect(lastCall[2].env.ZDOTDIR).toMatch(ZSH_SHELL_READY_DIR)
-    expect(lastCall[2].env.ORCA_SHELL_READY_MARKER).toBe('0')
+    expect(lastCall[2].env.ORCA_SHELL_FEATURES).not.toContain('ready')
   })
 
   it('uses shell wrapper when typed OMP commands need the status extension', async () => {
@@ -198,7 +198,7 @@ describe('createPtySubprocess', () => {
     const lastCall = spawnMock.mock.calls.at(-1)!
     expect(lastCall[1]).toEqual(['-l'])
     expect(lastCall[2].env.ZDOTDIR).toMatch(ZSH_SHELL_READY_DIR)
-    expect(lastCall[2].env.ORCA_SHELL_READY_MARKER).toBe('0')
+    expect(lastCall[2].env.ORCA_SHELL_FEATURES).not.toContain('ready')
   })
 
   it('uses shell wrapper when Codex home must survive shell startup', async () => {
@@ -227,7 +227,7 @@ describe('createPtySubprocess', () => {
     const lastCall = spawnMock.mock.calls.at(-1)!
     expect(lastCall[1]).toEqual(['-l'])
     expect(lastCall[2].env.ZDOTDIR).toMatch(ZSH_SHELL_READY_DIR)
-    expect(lastCall[2].env.ORCA_SHELL_READY_MARKER).toBe('0')
+    expect(lastCall[2].env.ORCA_SHELL_FEATURES).not.toContain('ready')
   })
 
   it('uses shell wrapper when Agent Teams shim path must survive shell startup', async () => {
@@ -257,7 +257,7 @@ describe('createPtySubprocess', () => {
     const lastCall = spawnMock.mock.calls.at(-1)!
     expect(lastCall[1]).toEqual(['-l'])
     expect(lastCall[2].env.ZDOTDIR).toMatch(ZSH_SHELL_READY_DIR)
-    expect(lastCall[2].env.ORCA_SHELL_READY_MARKER).toBe('0')
+    expect(lastCall[2].env.ORCA_SHELL_FEATURES).not.toContain('ready')
   })
 
   it('keeps plain Codex startup commands on the no-marker wrapper', async () => {
@@ -284,7 +284,7 @@ describe('createPtySubprocess', () => {
     const lastCall = spawnMock.mock.calls.at(-1)!
     expect(lastCall[1]).toEqual(['-l'])
     expect(lastCall[2].env.ZDOTDIR).toMatch(ZSH_SHELL_READY_DIR)
-    expect(lastCall[2].env.ORCA_SHELL_READY_MARKER).toBe('0')
+    expect(lastCall[2].env.ORCA_SHELL_FEATURES).not.toContain('ready')
   })
 
   it('uses shell-ready wrapper for delivery-hinted Codex startup commands', async () => {
@@ -312,7 +312,7 @@ describe('createPtySubprocess', () => {
     const lastCall = spawnMock.mock.calls.at(-1)!
     expect(lastCall[1]).toEqual(['-l'])
     expect(lastCall[2].env.ZDOTDIR).toMatch(ZSH_SHELL_READY_DIR)
-    expect(lastCall[2].env.ORCA_SHELL_READY_MARKER).toBe('1')
+    expect(lastCall[2].env.ORCA_SHELL_FEATURES).toContain('ready')
   })
 
   it('uses shell-ready wrapper for Codex native prefill flags', async () => {
@@ -339,7 +339,7 @@ describe('createPtySubprocess', () => {
     const lastCall = spawnMock.mock.calls.at(-1)!
     expect(lastCall[1]).toEqual(['-l'])
     expect(lastCall[2].env.ZDOTDIR).toMatch(ZSH_SHELL_READY_DIR)
-    expect(lastCall[2].env.ORCA_SHELL_READY_MARKER).toBe('1')
+    expect(lastCall[2].env.ORCA_SHELL_FEATURES).toContain('ready')
   })
 
   it('deletes requested env keys after merging daemon process env', async () => {

--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -233,14 +233,14 @@ describe('createPtySubprocess', () => {
     resolveUnixShellPathMock.mockReturnValue('/bin/sh')
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
     const previousShell = process.env.SHELL
-    const previousMarker = process.env.ORCA_SHELL_READY_MARKER
+    const previousFeatures = process.env.ORCA_SHELL_FEATURES
     const previousZdotdir = process.env.ZDOTDIR
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' })
     delete process.env.SHELL
     // Why: the test runner itself can execute inside an Orca-wrapped shell
     // whose exported wrapper vars would leak through the process.env spread.
-    delete process.env.ORCA_SHELL_READY_MARKER
+    delete process.env.ORCA_SHELL_FEATURES
     delete process.env.ZDOTDIR
 
     try {
@@ -257,9 +257,9 @@ describe('createPtySubprocess', () => {
       expect(shellPath).toBe('/bin/sh')
       expect(shellArgs).toEqual(['-l'])
       // A launch config derived from the missing preferred zsh would inject
-      // ZDOTDIR and ORCA_SHELL_READY_MARKER; /bin/sh must spawn without them.
+      // ZDOTDIR and ORCA_SHELL_FEATURES; /bin/sh must spawn without them.
       expect(spawnOptions.env.ZDOTDIR).toBeUndefined()
-      expect(spawnOptions.env.ORCA_SHELL_READY_MARKER).toBeUndefined()
+      expect(spawnOptions.env.ORCA_SHELL_FEATURES).toBeUndefined()
       expect(spawnOptions.env.SHELL).toBe('/bin/sh')
     } finally {
       warn.mockRestore()
@@ -271,10 +271,10 @@ describe('createPtySubprocess', () => {
       } else {
         process.env.SHELL = previousShell
       }
-      if (previousMarker === undefined) {
-        delete process.env.ORCA_SHELL_READY_MARKER
+      if (previousFeatures === undefined) {
+        delete process.env.ORCA_SHELL_FEATURES
       } else {
-        process.env.ORCA_SHELL_READY_MARKER = previousMarker
+        process.env.ORCA_SHELL_FEATURES = previousFeatures
       }
       if (previousZdotdir === undefined) {
         delete process.env.ZDOTDIR

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -665,6 +665,14 @@ export async function createPtySubprocess(opts: PtySubprocessOptions): Promise<S
   if (opts.env?.HISTFILE === undefined) {
     dropInheritedOrcaHistFile(env)
   }
+  // Why ORCA_HISTFILE too: the desktop drops an inherited one on both of its
+  // branches, and the daemon inherits one from the pane that launched it just
+  // as readily. Left in place it now both WRAPS a pane the client scoped
+  // nothing for (shell-startup-features selects `history` on its presence) and
+  // makes the wrapper re-export another worktree's history path (#11146).
+  if (opts.env?.ORCA_HISTFILE === undefined) {
+    delete env.ORCA_HISTFILE
+  }
   removeInheritedDevAgentHookEndpoint(env, opts.env)
   removeInheritedElectronRunAsNode(env)
   removeAppImageRuntimeEnv(env)

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -35,6 +35,7 @@ import { isPwshAvailable } from '../pwsh'
 import { isHostCodexHomeForWsl, isWslCodexHomeForHost } from '../pty/codex-home-wsl-env'
 import { removeInheritedNoColor } from '../pty/terminal-color-env'
 import { dropInheritedOrcaFishHistory } from '../fish-history-session'
+import { dropInheritedOrcaHistFile } from '../worktree-history-file-path'
 import { removeAppImageRuntimeEnv } from '../pty/appimage-terminal-env'
 import { stripInheritedBuildModeEnv } from '../pty/build-mode-env'
 import { stripLegacyTerminalShimEnv } from '../pty/legacy-terminal-shim-dir'
@@ -657,6 +658,12 @@ export async function createPtySubprocess(opts: PtySubprocessOptions): Promise<S
   // panes write into the launching worktree's history file (STA-4682).
   if (opts.env?.fish_history === undefined) {
     dropInheritedOrcaFishHistory(env)
+  }
+  // Why the same for HISTFILE: it is exported too, so a daemon started from an
+  // Orca pane hands that worktree's history file to every pane this spawn did
+  // not scope itself — including panes of other worktrees.
+  if (opts.env?.HISTFILE === undefined) {
+    dropInheritedOrcaHistFile(env)
   }
   removeInheritedDevAgentHookEndpoint(env, opts.env)
   removeInheritedElectronRunAsNode(env)

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -5,11 +5,8 @@ import { release } from 'node:os'
 import { delimiter, win32 as pathWin32 } from 'node:path'
 import type { SubprocessHandle } from './session-subprocess-handle'
 import { DaemonProtocolError } from './types'
-import {
-  getMarkerlessShellLaunchConfig,
-  getShellReadyLaunchConfig,
-  resolvePtyShellPath
-} from './shell-ready'
+import { getShellLaunchConfig, resolvePtyShellPath } from './shell-ready'
+import { selectShellStartupFeatures } from '../shell-startup-features'
 import { isValidPtySize, normalizePtySize } from './daemon-pty-size'
 import {
   ensureNodePtySpawnHelperExecutable,
@@ -824,33 +821,34 @@ export async function createPtySubprocess(opts: PtySubprocessOptions): Promise<S
         `[daemon/pty] Preferred shell "${preferredShellPath}" is unavailable, fell back to "${shellPath}"`
       )
     }
-    // Why: OpenCode/Codex path restoration and OMP's typed-command status wrapper need shell-ready code after user startup files run.
-    let shellLaunch: ReturnType<typeof getShellReadyLaunchConfig> | null = null
-    if (opts.command && isCodexStartupCommand) {
-      const shouldWaitForShellReady = shouldUseShellReadyStartupDelivery({
-        command: opts.command,
-        startupCommandDelivery: opts.startupCommandDelivery
+    // Why: OpenCode/Codex path restoration, OMP's typed-command status wrapper,
+    // and the worktree HISTFILE repair all need shell-ready code that runs after
+    // the user's own startup files.
+    // Why: payload-bearing Codex startup text can be dropped by rc-file noise; plain Codex stays markerless for the startup-speed path.
+    const waitsForShellReady =
+      Boolean(opts.command) &&
+      (!isCodexStartupCommand ||
+        shouldUseShellReadyStartupDelivery({
+          command: opts.command as string,
+          startupCommandDelivery: opts.startupCommandDelivery
+        }))
+    // Why delete: ORCA_SHELL_FEATURES is Orca-owned, and only the launch config
+    // below may name features for this shell.
+    delete env.ORCA_SHELL_FEATURES
+    const shellLaunch = getShellLaunchConfig(
+      shellPath,
+      selectShellStartupFeatures({
+        shellPath,
+        env,
+        hasStartupCommand: Boolean(opts.command),
+        waitsForShellReady,
+        // Why identical: the identity marker exists so the readiness handshake
+        // can bind output to the right shell PID.
+        emitsStartupIdentity: waitsForShellReady
       })
-      // Why: payload-bearing Codex startup text can be dropped by rc-file noise; plain Codex stays markerless for the startup-speed path.
-      shellLaunch = shouldWaitForShellReady
-        ? getShellReadyLaunchConfig(shellPath)
-        : getMarkerlessShellLaunchConfig(shellPath)
-    } else if (opts.command) {
-      shellLaunch = getShellReadyLaunchConfig(shellPath)
-    } else {
-      shellLaunch =
-        env.ORCA_OPENCODE_CONFIG_DIR ||
-        env.ORCA_MIMOCODE_HOME ||
-        env.ORCA_OMP_STATUS_EXTENSION ||
-        env.ORCA_CODEX_HOME ||
-        env.ORCA_AGENT_TEAMS_SHIM_DIR
-          ? getMarkerlessShellLaunchConfig(shellPath)
-          : null
-    }
-    if (shellLaunch) {
-      Object.assign(env, shellLaunch.env)
-    }
-    shellArgs = shellLaunch?.args ?? ['-l']
+    )
+    Object.assign(env, shellLaunch.env)
+    shellArgs = shellLaunch.args ?? ['-l']
   }
   seedPowerlevel10kWizardEnv(env, { envToDelete: opts.envToDelete })
   if (

--- a/src/main/daemon/shell-ready.test.ts
+++ b/src/main/daemon/shell-ready.test.ts
@@ -506,7 +506,10 @@ describePosix('daemon shell-ready launch config', () => {
     // Why .zshenv: the final restore is the last step of the single epilogue,
     // which .zshrc (non-login) and .zlogin (login) each invoke once.
     expectFinalZdotdirRestoreContext(zshenv)
-    expect(zshrc).toContain('[[ -o login ]] || __orca_shell_epilogue')
+    // Why the emulation probe: sh/ksh emulation makes zsh read $HOME/.zlogin
+    // rather than the wrapper's, so the epilogue has to run from here instead.
+    expect(zshrc).toContain('if [[ ! -o login || "$(emulate 2>/dev/null)" != zsh ]]; then')
+    expect(zshrc).toContain('(( ${+functions[__orca_shell_epilogue]} )) && __orca_shell_epilogue')
   })
 
   it('owns zle-line-init for the shell-ready marker instead of an azhw hook', async () => {

--- a/src/main/daemon/shell-ready.test.ts
+++ b/src/main/daemon/shell-ready.test.ts
@@ -186,7 +186,7 @@ function expectZdotdirSourceContext(content: string, fileName: '.zprofile' | '.z
 
 function expectFinalZdotdirRestoreContext(content: string) {
   expect(content).toContain("after Orca's last wrapper file has loaded")
-  expect(content).toContain('export ZDOTDIR="$REPLY"')
+  expect(content).toContain('export ZDOTDIR="$_orca_resolved_config_dir"')
 }
 
 describePosix('daemon shell-ready launch config', () => {
@@ -498,8 +498,8 @@ describePosix('daemon shell-ready launch config', () => {
     const zlogin = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zlogin'), 'utf8')
     expect(zshenv).toContain('__orca_resolve_inherited_config_dir "${ORCA_ORIG_ZDOTDIR:-$HOME}"')
     expect(zshenv).toContain('printf "\\033]777;orca-shell-start:%s\\007" "$$"')
-    expect(zshenv).toContain('"$REPLY" == */shell-ready/zsh ]]; then')
-    expect(zshenv).toContain('export ORCA_ORIG_ZDOTDIR="$REPLY"')
+    expect(zshenv).toContain('"$_orca_resolved_config_dir" == */shell-ready/zsh ]]; then')
+    expect(zshenv).toContain('export ORCA_ORIG_ZDOTDIR="$_orca_resolved_config_dir"')
     expectZdotdirSourceContext(zprofile, '.zprofile')
     expectZdotdirSourceContext(zshrc, '.zshrc')
     expectZdotdirSourceContext(zlogin, '.zlogin')
@@ -931,7 +931,7 @@ describePosix('daemon shell-ready launch config', () => {
     const zshenv = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshenv'), 'utf8')
 
     // Save spawn-env value before sourcing user .zshenv
-    expect(zshenv).toContain('_orca_user_zdotdir="$REPLY"')
+    expect(zshenv).toContain('_orca_user_zdotdir="$_orca_resolved_config_dir"')
 
     // Fallback chain: discovered → normalized spawn-env path → HOME
     expect(zshenv).toContain('${_orca_discovered_zdotdir:-${_orca_user_zdotdir:-$HOME}}')

--- a/src/main/daemon/shell-ready.test.ts
+++ b/src/main/daemon/shell-ready.test.ts
@@ -3,8 +3,12 @@ import { spawnSync } from 'node:child_process'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
-import type * as ShellReadyModule from './shell-ready'
 import type * as DaemonBashRcfileModule from './daemon-bash-shell-ready-rcfile'
+import {
+  OVERLAY_ONLY_FEATURES,
+  STARTUP_COMMAND_FEATURES
+} from '../shell-startup-launch-intent-fixtures'
+import { makeUserZdotdir } from '../zsh-user-config-dir-fixture'
 import { getZshShellReadyMarkerRegistrationBlock } from '../shell-templates'
 import { fishRequirementViolation, resolveFishBinary } from '../../shared/fish-binary-requirement'
 import {
@@ -14,9 +18,16 @@ import {
 } from '../shell-startup-output-scanner'
 import { HeadlessEmulator } from './headless-emulator'
 
-async function importFreshShellReady(): Promise<typeof ShellReadyModule> {
+async function importFreshShellReady() {
   vi.resetModules()
-  return import('./shell-ready')
+  const module = await import('./shell-ready')
+  return {
+    ...module,
+    getShellReadyLaunchConfig: (shell: string) =>
+      module.getShellLaunchConfig(shell, STARTUP_COMMAND_FEATURES),
+    getMarkerlessShellLaunchConfig: (shell: string) =>
+      module.getShellLaunchConfig(shell, OVERLAY_ONLY_FEATURES)
+  }
 }
 
 async function importFreshDaemonBashRcfile(): Promise<typeof DaemonBashRcfileModule> {
@@ -68,7 +79,7 @@ async function runInteractiveZshLogin(args: {
       ZDOTDIR: args.wrapperZdotdir,
       ORCA_ORIG_ZDOTDIR: args.tempHome,
       ORCA_ZSHENV_SOURCE_DIR: args.tempHome,
-      ORCA_SHELL_READY_MARKER: '1'
+      ORCA_SHELL_FEATURES: 'ready'
     }
   })
   let output = ''
@@ -106,7 +117,7 @@ async function runInteractiveZshRc(args: {
       HOME: args.zdotdir,
       TERM: 'xterm-256color',
       ZDOTDIR: args.zdotdir,
-      ORCA_SHELL_READY_MARKER: '1'
+      ORCA_SHELL_FEATURES: 'ready'
     }
   })
   let output = ''
@@ -140,7 +151,7 @@ function runInteractiveBashRcfile(rcfileContent: string, tempDir: string): strin
       env: {
         ...process.env,
         HOME: tempDir,
-        ORCA_SHELL_READY_MARKER: '1',
+        ORCA_SHELL_FEATURES: 'ready',
         TERM: process.env.TERM || 'xterm'
       },
       timeout: 5000
@@ -175,7 +186,7 @@ function expectZdotdirSourceContext(content: string, fileName: '.zprofile' | '.z
 
 function expectFinalZdotdirRestoreContext(content: string) {
   expect(content).toContain("after Orca's last wrapper file has loaded")
-  expect(content).toContain('export ZDOTDIR="$_orca_home"')
+  expect(content).toContain('export ZDOTDIR="$REPLY"')
 }
 
 describePosix('daemon shell-ready launch config', () => {
@@ -259,7 +270,9 @@ describePosix('daemon shell-ready launch config', () => {
     const config = getShellReadyLaunchConfig('/opt/homebrew/bin/fish')
 
     expect(config.supportsReadyMarker).toBe(true)
-    expect(config.env).toEqual({ ORCA_SHELL_READY_MARKER: '1' })
+    // Why empty: fish's selection is baked into the init command text, so it
+    // needs no exported feature variable at all.
+    expect(config.env).toEqual({})
     expect(config.args?.slice(0, 2)).toEqual(['-l', '-C'])
     const init = config.args?.[2] ?? ''
     expect(init).toContain('--on-event fish_prompt')
@@ -415,14 +428,15 @@ describePosix('daemon shell-ready launch config', () => {
     const previousZdotdir = process.env.ZDOTDIR
     const previousOrigZdotdir = process.env.ORCA_ORIG_ZDOTDIR
     const previousHome = process.env.HOME
+    const userZdotdir = makeUserZdotdir(userDataPath, '.config', 'zsh')
     process.env.ZDOTDIR = '/some/other/orca/shell-ready/zsh'
-    process.env.ORCA_ORIG_ZDOTDIR = '/Users/alice/.config/zsh'
-    process.env.HOME = '/Users/alice'
+    process.env.ORCA_ORIG_ZDOTDIR = userZdotdir
+    process.env.HOME = userDataPath
     try {
       const { getShellReadyLaunchConfig } = await importFreshShellReady()
       const config = getShellReadyLaunchConfig('/bin/zsh')
-      expect(config.env.ORCA_ORIG_ZDOTDIR).toBe('/Users/alice/.config/zsh')
-      expect(config.env.ORCA_ZSHENV_SOURCE_DIR).toBe('/Users/alice')
+      expect(config.env.ORCA_ORIG_ZDOTDIR).toBe(userZdotdir)
+      expect(config.env.ORCA_ZSHENV_SOURCE_DIR).toBe(userDataPath)
     } finally {
       if (previousZdotdir === undefined) {
         delete process.env.ZDOTDIR
@@ -482,15 +496,17 @@ describePosix('daemon shell-ready launch config', () => {
     const zprofile = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zprofile'), 'utf8')
     const zshrc = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshrc'), 'utf8')
     const zlogin = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zlogin'), 'utf8')
-    expect(zshenv).toContain('_orca_user_zdotdir="${_orca_spawn_orig_zdotdir:-$HOME}"')
+    expect(zshenv).toContain('__orca_resolve_inherited_config_dir "${ORCA_ORIG_ZDOTDIR:-$HOME}"')
     expect(zshenv).toContain('printf "\\033]777;orca-shell-start:%s\\007" "$$"')
-    expect(zshenv).toContain('*/shell-ready/zsh) _orca_user_zdotdir="$HOME" ;;')
-    expect(zshenv).toContain('""|*/shell-ready/zsh) export ORCA_ORIG_ZDOTDIR="$HOME" ;;')
+    expect(zshenv).toContain('"$REPLY" == */shell-ready/zsh ]]; then')
+    expect(zshenv).toContain('export ORCA_ORIG_ZDOTDIR="$REPLY"')
     expectZdotdirSourceContext(zprofile, '.zprofile')
     expectZdotdirSourceContext(zshrc, '.zshrc')
     expectZdotdirSourceContext(zlogin, '.zlogin')
-    expectFinalZdotdirRestoreContext(zshrc)
-    expectFinalZdotdirRestoreContext(zlogin)
+    // Why .zshenv: the final restore is the last step of the single epilogue,
+    // which .zshrc (non-login) and .zlogin (login) each invoke once.
+    expectFinalZdotdirRestoreContext(zshenv)
+    expect(zshrc).toContain('[[ -o login ]] || __orca_shell_epilogue')
   })
 
   it('owns zle-line-init for the shell-ready marker instead of an azhw hook', async () => {
@@ -498,14 +514,16 @@ describePosix('daemon shell-ready launch config', () => {
 
     getShellReadyLaunchConfig('/bin/zsh')
 
-    const zlogin = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zlogin'), 'utf8')
-    expect(zlogin).toContain('zle -N zle-line-init __orca_prompt_mark')
-    expect(zlogin).toContain('__orca_prev_line_init_fn="${widgets[zle-line-init]#user:}"')
-    expect(zlogin).toContain('printf "\\033]777;orca-shell-ready\\007"')
+    // Why .zshenv: the widget registration lives in the epilogue, which .zlogin
+    // (login) and .zshrc (non-login) both call exactly once.
+    const zshenv = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshenv'), 'utf8')
+    expect(zshenv).toContain('zle -N zle-line-init __orca_prompt_mark')
+    expect(zshenv).toContain('__orca_prev_line_init_fn="${widgets[zle-line-init]#user:}"')
+    expect(zshenv).toContain('printf "\\033]777;orca-shell-ready\\007"')
     // Why: add-zle-hook-widget aborts its chain when an earlier hook exits non-zero, so don't register the marker through it.
-    expect(zlogin).not.toContain('add-zle-hook-widget line-init')
+    expect(zshenv).not.toContain('add-zle-hook-widget line-init')
     // Why: re-source guard — skip re-capturing when already the bound widget so the prior chain survives a second source.
-    expect(zlogin).toContain('== "user:__orca_prompt_mark"')
+    expect(zshenv).toContain('== "user:__orca_prompt_mark"')
   })
 
   // Why: oh-my-zsh vi-mode's zle-line-init returns non-zero; add-zle-hook-widget then aborts the chain and the marker never fires.
@@ -621,8 +639,10 @@ describePosix('daemon shell-ready launch config', () => {
     getShellReadyLaunchConfig('/bin/zsh')
     getShellReadyLaunchConfig('/bin/bash')
 
-    const zshrc = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshrc'), 'utf8')
-    const zlogin = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zlogin'), 'utf8')
+    // Why one file: every restore now lives in the single epilogue in .zshenv,
+    // which .zshrc and .zlogin each invoke on their own startup path.
+    const zshrc = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshenv'), 'utf8')
+    const zlogin = zshrc
     const bashRc = readFileSync(join(userDataPath, 'shell-ready', 'bash', 'rcfile'), 'utf8')
     const restoreLine =
       '[[ -n "${ORCA_OPENCODE_CONFIG_DIR:-}" ]] && export OPENCODE_CONFIG_DIR="${ORCA_OPENCODE_CONFIG_DIR}"'
@@ -668,7 +688,8 @@ describePosix('daemon shell-ready launch config', () => {
     getShellReadyLaunchConfig('/bin/zsh')
     getShellReadyLaunchConfig('/bin/bash')
 
-    const zshrc = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshrc'), 'utf8')
+    // Why .zshenv: the zsh markers live in the epilogue, behind `markers`.
+    const zshrc = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshenv'), 'utf8')
     const bashRc = readFileSync(join(userDataPath, 'shell-ready', 'bash', 'rcfile'), 'utf8')
 
     expect(bashRc).toContain('printf "\\033]133;D;%s\\007"')
@@ -800,12 +821,13 @@ describePosix('daemon shell-ready launch config', () => {
   it('preserves a real inherited ZDOTDIR as ORCA_ORIG_ZDOTDIR', async () => {
     // Why: only the wrapper self-loop should be rejected; a real user ZDOTDIR must round-trip so their configs load.
     const previousZdotdir = process.env.ZDOTDIR
-    process.env.ZDOTDIR = '/Users/alice/.config/zsh'
+    const userZdotdir = makeUserZdotdir(userDataPath, '.config', 'zsh')
+    process.env.ZDOTDIR = userZdotdir
     try {
       const { getShellReadyLaunchConfig } = await importFreshShellReady()
       const config = getShellReadyLaunchConfig('/bin/zsh')
-      expect(config.env.ORCA_ORIG_ZDOTDIR).toBe('/Users/alice/.config/zsh')
-      expect(config.env.ORCA_ZSHENV_SOURCE_DIR).toBe('/Users/alice/.config/zsh')
+      expect(config.env.ORCA_ORIG_ZDOTDIR).toBe(userZdotdir)
+      expect(config.env.ORCA_ZSHENV_SOURCE_DIR).toBe(userZdotdir)
     } finally {
       if (previousZdotdir === undefined) {
         delete process.env.ZDOTDIR
@@ -866,11 +888,12 @@ describePosix('daemon shell-ready launch config', () => {
   it('preserves ZDOTDIR that contains /shell-ready/zsh as a substring but does not end with it', async () => {
     // Why: guard must match suffix not substring — `/Users/alice/shell-ready/zsh-custom` must round-trip unchanged.
     const previousZdotdir = process.env.ZDOTDIR
-    process.env.ZDOTDIR = '/Users/alice/shell-ready/zsh-custom'
+    const userZdotdir = makeUserZdotdir(userDataPath, 'shell-ready', 'zsh-custom')
+    process.env.ZDOTDIR = userZdotdir
     try {
       const { getShellReadyLaunchConfig } = await importFreshShellReady()
       const config = getShellReadyLaunchConfig('/bin/zsh')
-      expect(config.env.ORCA_ORIG_ZDOTDIR).toBe('/Users/alice/shell-ready/zsh-custom')
+      expect(config.env.ORCA_ORIG_ZDOTDIR).toBe(userZdotdir)
     } finally {
       if (previousZdotdir === undefined) {
         delete process.env.ZDOTDIR
@@ -889,12 +912,10 @@ describePosix('daemon shell-ready launch config', () => {
     const zshenv = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshenv'), 'utf8')
 
     expect(zshenv).toContain('unset ZDOTDIR')
-    expect(zshenv).toContain('_orca_zshenv_source_dir="${ORCA_ZSHENV_SOURCE_DIR:-$HOME}"')
+    expect(zshenv).toContain('__orca_resolve_inherited_config_dir "${ORCA_ZSHENV')
     expect(zshenv).toContain('source "${_orca_zshenv_path}"')
     expect(zshenv).toContain('_orca_discovered_zdotdir="${ZDOTDIR:-}"')
-    expect(zshenv).toContain(
-      'export ORCA_ORIG_ZDOTDIR="${_orca_discovered_zdotdir:-${_orca_user_zdotdir:-$HOME}}"'
-    )
+    expect(zshenv).toContain('${_orca_discovered_zdotdir:-${_orca_user_zdotdir:-$HOME}}')
     expect(zshenv).toContain('export ZDOTDIR=')
   })
 
@@ -907,7 +928,7 @@ describePosix('daemon shell-ready launch config', () => {
     const zshenv = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshenv'), 'utf8')
 
     // Save spawn-env value before sourcing user .zshenv
-    expect(zshenv).toContain('_orca_spawn_orig_zdotdir="${ORCA_ORIG_ZDOTDIR:-}"')
+    expect(zshenv).toContain('_orca_user_zdotdir="$REPLY"')
 
     // Fallback chain: discovered → normalized spawn-env path → HOME
     expect(zshenv).toContain('${_orca_discovered_zdotdir:-${_orca_user_zdotdir:-$HOME}}')

--- a/src/main/daemon/shell-ready.ts
+++ b/src/main/daemon/shell-ready.ts
@@ -1,13 +1,27 @@
 import { tmpdir } from 'node:os'
-import { basename, dirname, join, win32 as pathWin32 } from 'node:path'
-import { chmodSync, existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { basename, join, win32 as pathWin32 } from 'node:path'
+import { statSync } from 'node:fs'
 import {
   encodePowerShellCommand,
   getPowerShellOsc133Bootstrap,
   isPowerShellExecutableName
 } from '../powershell-osc133-bootstrap'
 import { getFishCodexShellLaunchPreflight } from '../pty/codex-shell-launch-preflight'
-import { getFishShellReadyInitCommand } from '../shell-templates'
+import {
+  getFishShellReadyInitCommand,
+  ZSH_WRAPPER_DIR_MARKER_CONTENT,
+  ZSH_WRAPPER_DIR_MARKER_FILE
+} from '../shell-templates'
+import {
+  encodeShellStartupFeatures,
+  SHELL_STARTUP_FEATURE_ENV,
+  type ShellStartupFeature
+} from '../shell-startup-features'
+import { writeShellWrapperFiles } from '../shell-wrapper-file-writer'
+import {
+  resolveInheritedZdotdir,
+  resolveInheritedZshenvSourceDir
+} from '../zsh-wrapper-dir-ownership'
 import { buildZshStartupWrapperFiles } from '../zsh-startup-wrapper-builder'
 import { SHELL_READY_MARKER } from './daemon-shell-ready-marker'
 import { getDaemonBashShellReadyRcfileContent } from './daemon-bash-shell-ready-rcfile'
@@ -24,105 +38,60 @@ function getShellReadyWrapperRoot(): string {
   return join(userDataPath || tmpdir(), userDataPath ? 'shell-ready' : 'orca-shell-ready')
 }
 
-// Why: if our own process inherited ZDOTDIR from a parent shell that was
-// itself an Orca PTY (e.g. the user launched Orca from a terminal inside a
-// running Orca), that ZDOTDIR points at an Orca shell-ready wrapper dir.
-// Propagating it as the new PTY's ORCA_ORIG_ZDOTDIR makes the wrapper's
-// `source "$ORCA_ORIG_ZDOTDIR/.zshenv"` line source itself recursively —
-// zsh gives "job table full or recursion limit exceeded" and the shell
-// never reaches a usable prompt.
-//
-// Any path component ending in `/shell-ready/zsh` is an Orca wrapper dir
-// (regardless of whether it came from this daemon's userData, a packaged
-// Orca, or a different dev build). Treat it as if ZDOTDIR were unset so the
-// caller falls back to HOME for the user's real config root.
-function normalizeOriginalZdotdirCandidate(value: string | undefined): string | null {
-  if (!value) {
-    return null
-  }
-  // Why: tolerate trailing slashes — some shell startup scripts export
-  // `ZDOTDIR="$dir/"`, and without normalization the suffix check would
-  // miss the self-loop path and restore the recursion bug. Also collapses
-  // a pathological `ZDOTDIR=/` to empty so we fall back to HOME rather than
-  // sourcing `/.zshenv` (which is never the user's real config).
-  const normalized = value.replace(/\/+$/, '')
-  if (!normalized || normalized.endsWith('/shell-ready/zsh')) {
-    return null
-  }
-  return value
-}
-
-function resolveOriginalZdotdir(): string {
-  return (
-    normalizeOriginalZdotdirCandidate(process.env.ZDOTDIR) ||
-    normalizeOriginalZdotdirCandidate(process.env.ORCA_ORIG_ZDOTDIR) ||
-    process.env.HOME ||
-    ''
-  )
-}
-
-function resolveOriginalZshenvSourceDir(): string {
-  return normalizeOriginalZdotdirCandidate(process.env.ZDOTDIR) || process.env.HOME || ''
-}
-
 function getRequiredShellReadyWrapperPaths(root = getShellReadyWrapperRoot()): string[] {
   return [
     join(root, 'zsh', '.zshenv'),
     join(root, 'zsh', '.zprofile'),
     join(root, 'zsh', '.zshrc'),
     join(root, 'zsh', '.zlogin'),
+    join(root, 'zsh', ZSH_WRAPPER_DIR_MARKER_FILE),
     join(root, 'bash', 'rcfile')
   ]
 }
 
+// Why non-empty and not just present: a partial write leaves a zero-byte
+// .zshenv, and pointing ZDOTDIR at that dir makes zsh skip the user's config.
 function shellReadyWrappersExist(): boolean {
-  return getRequiredShellReadyWrapperPaths().every((path) => existsSync(path))
+  return getRequiredShellReadyWrapperPaths().every((path) => {
+    try {
+      return statSync(path).size > 0
+    } catch {
+      return false
+    }
+  })
 }
 
-function ensureShellReadyWrappers(): void {
+/** True when every wrapper file is present and non-empty afterwards. */
+function ensureShellReadyWrappers(): boolean {
   if (process.platform === 'win32') {
-    return
+    return false
   }
   if (didEnsureShellReadyWrappers && shellReadyWrappersExist()) {
-    return
+    return true
   }
   didEnsureShellReadyWrappers = true
 
   const root = getShellReadyWrapperRoot()
   const zshDir = join(root, 'zsh')
-  const bashDir = join(root, 'bash')
-
   const zsh = buildZshStartupWrapperFiles(getDaemonZshWrapperSpec(zshDir))
-  const bashRc = getDaemonBashShellReadyRcfileContent()
 
-  const files = [
-    [join(zshDir, '.zshenv'), zsh.zshenv],
-    [join(zshDir, '.zprofile'), zsh.zprofile],
-    [join(zshDir, '.zshrc'), zsh.zshrc],
-    [join(zshDir, '.zlogin'), zsh.zlogin],
-    [join(bashDir, 'rcfile'), bashRc]
-  ] as const
-
-  try {
-    for (const [path, content] of files) {
-      mkdirSync(dirname(path), { recursive: true })
-      writeFileSync(path, content, 'utf8')
-      chmodSync(path, 0o644)
-    }
-  } catch (error) {
-    // Why: wrapper file creation can fail due to read-only filesystems, permission
-    // issues, or disk space. Rather than crashing, log the error and continue.
-    // The shell will launch without the wrapper, which means no shell-ready marker
-    // but at least the PTY is usable.
-    const errorMessage =
-      error instanceof Error
-        ? `${error.message} (${(error as NodeJS.ErrnoException).code || 'unknown'})`
-        : String(error)
-    console.error(`[daemon/shell-ready] Failed to create wrapper files in ${root}: ${errorMessage}`)
-    console.error('[daemon/shell-ready] Shell will launch without wrapper (no shell-ready marker)')
-    // Reset the flag so next attempt will try again
+  const written = writeShellWrapperFiles(
+    [
+      [join(zshDir, '.zshenv'), zsh.zshenv],
+      [join(zshDir, '.zprofile'), zsh.zprofile],
+      [join(zshDir, '.zshrc'), zsh.zshrc],
+      [join(zshDir, '.zlogin'), zsh.zlogin],
+      [join(zshDir, ZSH_WRAPPER_DIR_MARKER_FILE), ZSH_WRAPPER_DIR_MARKER_CONTENT],
+      [join(root, 'bash', 'rcfile'), getDaemonBashShellReadyRcfileContent()]
+    ],
+    '[daemon/shell-ready]'
+  )
+  if (!written || !shellReadyWrappersExist()) {
+    // Why reset: the next launch retries instead of trusting a half-written tree.
     didEnsureShellReadyWrappers = false
+    return false
   }
+  return true
 }
 
 export function resolvePtyShellPath(env: Record<string, string>): string {
@@ -146,44 +115,59 @@ export function supportsPtyStartupBarrier(env: Record<string, string>): boolean 
   return shellPathSupportsPtyStartupBarrier(resolvePtyShellPath(env))
 }
 
-type ShellLaunchConfig = {
+export type ShellLaunchConfig = {
   args: string[] | null
   env: Record<string, string>
   supportsReadyMarker: boolean
 }
 
-function getWrappedShellLaunchConfig(
+const UNWRAPPED: ShellLaunchConfig = {
+  args: null,
+  env: {},
+  supportsReadyMarker: false
+}
+
+/**
+ * The one launch-config entry point: args + env for a shell that should start
+ * with exactly `features` enabled. An empty selection is never wrapped.
+ */
+export function getShellLaunchConfig(
   shellPath: string,
-  options: { emitReadyMarker: boolean }
+  features: readonly ShellStartupFeature[]
 ): ShellLaunchConfig {
   const shellName = pathWin32.basename(basename(shellPath)).toLowerCase()
 
   if (shellName === 'zsh') {
-    ensureShellReadyWrappers()
-    const root = getShellReadyWrapperRoot()
+    if (features.length === 0) {
+      return UNWRAPPED
+    }
+    if (!ensureShellReadyWrappers()) {
+      // Why plain login zsh: ZDOTDIR pointed at an incomplete wrapper dir makes
+      // zsh skip the user's whole config. Losing Orca's features is recoverable.
+      return { args: ['-l'], env: {}, supportsReadyMarker: false }
+    }
     return {
       args: ['-l'],
       env: {
-        ORCA_ORIG_ZDOTDIR: resolveOriginalZdotdir(),
-        ORCA_ZSHENV_SOURCE_DIR: resolveOriginalZshenvSourceDir(),
-        ZDOTDIR: join(root, 'zsh'),
-        ORCA_SHELL_READY_MARKER: options.emitReadyMarker ? '1' : '0',
-        ORCA_SHELL_STARTUP_IDENTITY: options.emitReadyMarker ? '1' : '0'
+        ORCA_ORIG_ZDOTDIR: resolveInheritedZdotdir(process.env),
+        ORCA_ZSHENV_SOURCE_DIR: resolveInheritedZshenvSourceDir(process.env),
+        ZDOTDIR: join(getShellReadyWrapperRoot(), 'zsh'),
+        [SHELL_STARTUP_FEATURE_ENV]: encodeShellStartupFeatures(features)
       },
-      supportsReadyMarker: options.emitReadyMarker
+      supportsReadyMarker: features.includes('ready')
     }
   }
 
   if (shellName === 'bash') {
-    ensureShellReadyWrappers()
-    const root = getShellReadyWrapperRoot()
+    if (features.length === 0 || !ensureShellReadyWrappers()) {
+      return UNWRAPPED
+    }
     return {
-      args: ['--rcfile', join(root, 'bash', 'rcfile')],
+      args: ['--rcfile', join(getShellReadyWrapperRoot(), 'bash', 'rcfile')],
       env: {
-        ORCA_SHELL_READY_MARKER: options.emitReadyMarker ? '1' : '0',
-        ORCA_SHELL_STARTUP_IDENTITY: options.emitReadyMarker ? '1' : '0'
+        [SHELL_STARTUP_FEATURE_ENV]: encodeShellStartupFeatures(features)
       },
-      supportsReadyMarker: options.emitReadyMarker
+      supportsReadyMarker: features.includes('ready')
     }
   }
 
@@ -200,30 +184,19 @@ function getWrappedShellLaunchConfig(
     }
   }
 
-  // Why: mirrors local-pty-shell-ready.ts; markerless fish stays unwrapped.
-  if (shellName === 'fish' && options.emitReadyMarker) {
+  // Why: mirrors local-pty-shell-ready.ts; markerless fish stays unwrapped. The
+  // selection is baked into the init command, so fish needs no feature env var.
+  if (shellName === 'fish' && features.includes('ready')) {
     return {
       args: [
         '-l',
         '-C',
         `${getFishShellReadyInitCommand(SHELL_READY_MARKER)}\n${getFishCodexShellLaunchPreflight()}`
       ],
-      env: { ORCA_SHELL_READY_MARKER: '1' },
+      env: {},
       supportsReadyMarker: true
     }
   }
 
-  return {
-    args: null,
-    env: {},
-    supportsReadyMarker: false
-  }
-}
-
-export function getShellReadyLaunchConfig(shellPath: string): ShellLaunchConfig {
-  return getWrappedShellLaunchConfig(shellPath, { emitReadyMarker: true })
-}
-
-export function getMarkerlessShellLaunchConfig(shellPath: string): ShellLaunchConfig {
-  return getWrappedShellLaunchConfig(shellPath, { emitReadyMarker: false })
+  return UNWRAPPED
 }

--- a/src/main/ipc/pty-hidden-at-spawn-mark.test.ts
+++ b/src/main/ipc/pty-hidden-at-spawn-mark.test.ts
@@ -412,7 +412,8 @@ describe('registerPtyHandlers', () => {
           cwd: '/tmp',
           env: expect.objectContaining({
             ORCA_OPENCODE_CONFIG_DIR: '/tmp/orca-opencode-config',
-            ORCA_SHELL_READY_MARKER: '0',
+            // No `ready`: the fallback shell carries an overlay, not a startup command.
+            ORCA_SHELL_FEATURES: 'overlay,history,markers',
             ZDOTDIR: '/tmp/orca-user-data/shell-ready/zsh'
           })
         })

--- a/src/main/ipc/pty-ipc-mock-registry.ts
+++ b/src/main/ipc/pty-ipc-mock-registry.ts
@@ -17,6 +17,8 @@ export const mkdirSyncMock: Mock = vi.fn()
 export const readFileSyncMock: Mock = vi.fn()
 export const writeFileSyncMock: Mock = vi.fn()
 export const chmodSyncMock: Mock = vi.fn()
+export const renameSyncMock: Mock = vi.fn()
+export const rmSyncMock: Mock = vi.fn()
 export const getPathMock: Mock = vi.fn()
 export const loginPreflightExecFileMock: Mock = vi.fn()
 export const spawnMock: Mock = vi.fn()
@@ -85,6 +87,8 @@ export const fsModuleMock = () => ({
   readFileSync: readFileSyncMock,
   writeFileSync: writeFileSyncMock,
   chmodSync: chmodSyncMock,
+  renameSync: renameSyncMock,
+  rmSync: rmSyncMock,
   constants: {
     X_OK: 1,
     R_OK: 4

--- a/src/main/ipc/pty-ipc-spawn-drivers.ts
+++ b/src/main/ipc/pty-ipc-spawn-drivers.ts
@@ -122,7 +122,8 @@ export function createPtyIpcSpawnDrivers(ctx: {
     statSyncMock.mockImplementation((target: string) => ({
       isDirectory: () => target !== BUNDLED_CLI_PATH,
       isFile: () => target === BUNDLED_CLI_PATH,
-      mode: 0o755
+      mode: 0o755,
+      size: 1
     }))
     if (!launcherExecutable) {
       accessSyncMock.mockImplementation((target: string) => {

--- a/src/main/ipc/pty-ipc-suite-environment.ts
+++ b/src/main/ipc/pty-ipc-suite-environment.ts
@@ -164,7 +164,8 @@ export function createPtyIpcSuiteEnvironment(): PtyIpcSuiteEnvironment {
     // Why: wrapper roots resolve from ORCA_USER_DATA_PATH; mirror the mocked userData so ZDOTDIR/wrapper assertions match.
     process.env.ORCA_USER_DATA_PATH = '/tmp/orca-user-data'
     existsSyncMock.mockReturnValue(true)
-    statSyncMock.mockReturnValue({ isDirectory: () => true, mode: 0o755 })
+    // size: the shell wrapper writer verifies each generated file is non-empty.
+    statSyncMock.mockReturnValue({ isDirectory: () => true, mode: 0o755, size: 1 })
     readFileSyncMock.mockReturnValue('')
     openCodeBuildPtyEnvMock.mockImplementation((_ptyId: string, existingConfigDir?: string) => ({
       ORCA_OPENCODE_HOOK_PORT: '4567',

--- a/src/main/ipc/pty-listener-teardown-and-orphans.test.ts
+++ b/src/main/ipc/pty-listener-teardown-and-orphans.test.ts
@@ -86,7 +86,7 @@ describe('registerPtyHandlers', () => {
           env: expect.objectContaining({
             SHELL: '/bin/zsh',
             ORCA_OPENCODE_CONFIG_DIR: '/tmp/orca-opencode-config',
-            ORCA_SHELL_READY_MARKER: '0',
+            ORCA_SHELL_FEATURES: 'overlay,history,markers',
             ZDOTDIR: '/tmp/orca-user-data/shell-ready/zsh'
           })
         })

--- a/src/main/ipc/pty-login-shell-startup-commands.test.ts
+++ b/src/main/ipc/pty-login-shell-startup-commands.test.ts
@@ -122,7 +122,7 @@ describe('registerPtyHandlers', () => {
       expect(options.env.OPENCODE_CONFIG_DIR).toBe('/tmp/orca-opencode-config')
       expect(options.env.ORCA_OPENCODE_CONFIG_DIR).toBe('/tmp/orca-opencode-config')
       expect(options.env.ZDOTDIR).toBe('/tmp/orca-user-data/shell-ready/zsh')
-      expect(options.env.ORCA_SHELL_READY_MARKER).toBe('0')
+      expect(options.env.ORCA_SHELL_FEATURES).not.toContain('ready')
     } finally {
       Object.defineProperty(process, 'platform', {
         configurable: true,
@@ -163,7 +163,7 @@ describe('registerPtyHandlers', () => {
       expect(options.env.ORCA_PI_CODING_AGENT_DIR).toBeUndefined()
       expect(options.env.ORCA_PI_SOURCE_AGENT_DIR).toBe('/tmp/user-pi-agent')
       expect(options.env.ZDOTDIR).toBe('/tmp/orca-user-data/shell-ready/zsh')
-      expect(options.env.ORCA_SHELL_READY_MARKER).toBe('0')
+      expect(options.env.ORCA_SHELL_FEATURES).not.toContain('ready')
     } finally {
       Object.defineProperty(process, 'platform', {
         configurable: true,
@@ -306,7 +306,7 @@ describe('registerPtyHandlers', () => {
         })
 
         const [, , options] = spawnMock.mock.calls[0]!
-        expect(options.env.ORCA_SHELL_READY_MARKER).toBe('0')
+        expect(options.env.ORCA_SHELL_FEATURES).not.toContain('ready')
 
         await Promise.resolve()
         vi.advanceTimersByTime(49)
@@ -338,7 +338,7 @@ describe('registerPtyHandlers', () => {
       })
 
       const [, , options] = spawnMock.mock.calls[0]!
-      expect(options.env.ORCA_SHELL_READY_MARKER).toBe('1')
+      expect(options.env.ORCA_SHELL_FEATURES).toContain('ready')
       expect(mockProc.proc.write).not.toHaveBeenCalled()
 
       mockProc.emitData('last login: today\r\n')
@@ -405,7 +405,7 @@ describe('registerPtyHandlers', () => {
       })
 
       const [, , options] = spawnMock.mock.calls[0]!
-      expect(options.env.ORCA_SHELL_READY_MARKER).toBe('1')
+      expect(options.env.ORCA_SHELL_FEATURES).toContain('ready')
       expect(mockProc.proc.write).not.toHaveBeenCalled()
 
       mockProc.emitData('\x1b]777;orca-shell-ready\x07')

--- a/src/main/ipc/pty-wsl-cwd-validation.test.ts
+++ b/src/main/ipc/pty-wsl-cwd-validation.test.ts
@@ -166,7 +166,7 @@ describe('registerPtyHandlers', () => {
       if (target === missingCwd) {
         throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
       }
-      return { isDirectory: () => true, mode: 0o755 }
+      return { isDirectory: () => true, mode: 0o755, size: 1 }
     })
 
     try {
@@ -229,7 +229,7 @@ describe('registerPtyHandlers', () => {
       if (target === '/repo/app/deleted-folder') {
         throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
       }
-      return { isDirectory: () => true, mode: 0o755 }
+      return { isDirectory: () => true, mode: 0o755, size: 1 }
     })
 
     // Why: without the renderer opt-in the provider surfaces its normal missing-directory error — API/runtime callers keep exact cwd semantics.
@@ -266,7 +266,7 @@ describe('registerPtyHandlers', () => {
       if (target === '/repo/app/deleted-folder') {
         throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
       }
-      return { isDirectory: () => true, mode: 0o755 }
+      return { isDirectory: () => true, mode: 0o755, size: 1 }
     })
 
     // Why: a reattach must keep the session's exact cwd; remapping would silently detach the restored terminal from its recorded state.

--- a/src/main/providers/__tests__/shell-ready-framework/README.md
+++ b/src/main/providers/__tests__/shell-ready-framework/README.md
@@ -39,7 +39,7 @@ EOF
    - Lines before the marker → setup commands
    - Lines after the marker → run command to test
 
-3. **Gets Orca's wrapper config** by calling `getShellReadyLaunchConfig()`
+3. **Gets Orca's wrapper config** by calling `getShellLaunchConfig()` with the features `selectShellStartupFeatures()` picks for a startup-command launch
 
 4. **Executes setup** (if present) with bash in temp HOME, using wrapper env
 

--- a/src/main/providers/__tests__/shell-ready-framework/shell-script-test.ts
+++ b/src/main/providers/__tests__/shell-ready-framework/shell-script-test.ts
@@ -2,7 +2,8 @@ import { tmpdir } from 'node:os'
 import { join, basename } from 'node:path'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { spawnSync } from 'node:child_process'
-import { getShellReadyLaunchConfig } from '../../local-pty-shell-ready'
+import { getShellLaunchConfig } from '../../local-pty-shell-ready'
+import { selectShellStartupFeatures } from '../../../shell-startup-features'
 import { escapeRegex } from '../../../../shared/string-utils'
 
 const RUN_MARKER = /^[ \t]*#[ \t]*Run:.*$/m
@@ -58,12 +59,25 @@ export async function shellScriptTest(
     const runScript = hasRunMarker ? parts[1].trim() : script.trim()
 
     const wrapperShell = detectShellFromCommand(runScript, options.shell || '/bin/zsh')
-    const config = getShellReadyLaunchConfig(wrapperShell)
+    const config = getShellLaunchConfig(
+      wrapperShell,
+      selectShellStartupFeatures({
+        shellPath: wrapperShell,
+        env: {},
+        hasStartupCommand: true,
+        waitsForShellReady: true,
+        emitsStartupIdentity: true
+      })
+    )
 
     const env: Record<string, string> = {
       ...config.env,
-      // Why: these examples inspect startup-file discovery, not the PTY-owner protocol stream.
-      ORCA_SHELL_STARTUP_IDENTITY: '0',
+      // Why: these examples inspect startup-file discovery, not the PTY-owner
+      // protocol stream, so drop the tokens that write to stdout.
+      ORCA_SHELL_FEATURES: (config.env.ORCA_SHELL_FEATURES ?? '')
+        .split(',')
+        .filter((feature) => feature !== 'identity' && feature !== 'markers')
+        .join(','),
       // Why: the framework creates user startup files under testHome after
       // computing the wrapper config; route wrapper discovery to that fixture.
       HOME: testHome,

--- a/src/main/providers/local-pty-provider-foreground-process.test.ts
+++ b/src/main/providers/local-pty-provider-foreground-process.test.ts
@@ -38,6 +38,8 @@ vi.mock('fs', () => ({
   mkdirSync: mkdirSyncMock,
   writeFileSync: writeFileSyncMock,
   chmodSync: vi.fn(),
+  renameSync: vi.fn(),
+  rmSync: vi.fn(),
   constants: { X_OK: 1 }
 }))
 

--- a/src/main/providers/local-pty-provider-io-events.test.ts
+++ b/src/main/providers/local-pty-provider-io-events.test.ts
@@ -38,6 +38,8 @@ vi.mock('fs', () => ({
   mkdirSync: mkdirSyncMock,
   writeFileSync: writeFileSyncMock,
   chmodSync: vi.fn(),
+  renameSync: vi.fn(),
+  rmSync: vi.fn(),
   constants: { X_OK: 1 }
 }))
 

--- a/src/main/providers/local-pty-provider-session-inventory.test.ts
+++ b/src/main/providers/local-pty-provider-session-inventory.test.ts
@@ -38,6 +38,8 @@ vi.mock('fs', () => ({
   mkdirSync: mkdirSyncMock,
   writeFileSync: writeFileSyncMock,
   chmodSync: vi.fn(),
+  renameSync: vi.fn(),
+  rmSync: vi.fn(),
   constants: { X_OK: 1 }
 }))
 

--- a/src/main/providers/local-pty-provider-shell-readiness.test.ts
+++ b/src/main/providers/local-pty-provider-shell-readiness.test.ts
@@ -38,6 +38,8 @@ vi.mock('fs', () => ({
   mkdirSync: mkdirSyncMock,
   writeFileSync: writeFileSyncMock,
   chmodSync: vi.fn(),
+  renameSync: vi.fn(),
+  rmSync: vi.fn(),
   constants: { X_OK: 1 }
 }))
 

--- a/src/main/providers/local-pty-provider-shutdown.test.ts
+++ b/src/main/providers/local-pty-provider-shutdown.test.ts
@@ -38,6 +38,8 @@ vi.mock('fs', () => ({
   mkdirSync: mkdirSyncMock,
   writeFileSync: writeFileSyncMock,
   chmodSync: vi.fn(),
+  renameSync: vi.fn(),
+  rmSync: vi.fn(),
   constants: { X_OK: 1 }
 }))
 

--- a/src/main/providers/local-pty-provider-spawn-cwd-safety.test.ts
+++ b/src/main/providers/local-pty-provider-spawn-cwd-safety.test.ts
@@ -38,6 +38,8 @@ vi.mock('fs', () => ({
   mkdirSync: mkdirSyncMock,
   writeFileSync: writeFileSyncMock,
   chmodSync: vi.fn(),
+  renameSync: vi.fn(),
+  rmSync: vi.fn(),
   constants: { X_OK: 1 }
 }))
 

--- a/src/main/providers/local-pty-provider-spawn-env.test.ts
+++ b/src/main/providers/local-pty-provider-spawn-env.test.ts
@@ -40,6 +40,8 @@ vi.mock('fs', () => ({
   mkdirSync: mkdirSyncMock,
   writeFileSync: writeFileSyncMock,
   chmodSync: vi.fn(),
+  renameSync: vi.fn(),
+  rmSync: vi.fn(),
   constants: { X_OK: 1 }
 }))
 
@@ -421,7 +423,7 @@ describe('LocalPtyProvider', () => {
       const spawnCall = spawnMock.mock.calls.at(-1)!
       expect(spawnCall[1]).toEqual(['-l'])
       expect(spawnCall[2].env.ZDOTDIR).toMatch(/shell-ready[\\/]zsh/)
-      expect(spawnCall[2].env.ORCA_SHELL_READY_MARKER).toBe('0')
+      expect(spawnCall[2].env.ORCA_SHELL_FEATURES).not.toContain('ready')
     })
 
     it('promotes the agent-teams shim onto the Windows `Path` spelling', async () => {

--- a/src/main/providers/local-pty-provider-spawn-env.test.ts
+++ b/src/main/providers/local-pty-provider-spawn-env.test.ts
@@ -212,6 +212,32 @@ describe('LocalPtyProvider', () => {
       expect(spawnMock.mock.calls.at(-1)![2].env.fish_history).toBe(expected)
     })
 
+    it.each([
+      // HISTFILE is exported, so an Orca launched from a pane in another worktree
+      // hands every pane that worktree's history file — isolation off included.
+      [
+        'an inherited Orca path',
+        '/fake/userData/terminal-history/aabbccddeeff0011/zsh_history',
+        undefined
+      ],
+      ['a user value', '/home/me/.zsh_history', '/home/me/.zsh_history']
+    ])('history isolation off: %s HISTFILE', async (_kind, inherited, expected) => {
+      const previous = process.env.HISTFILE
+      process.env.HISTFILE = inherited
+      try {
+        // No worktreeId: the history-disabled branch of spawn.
+        await provider.spawn({ cols: 80, rows: 24 })
+      } finally {
+        if (previous === undefined) {
+          delete process.env.HISTFILE
+        } else {
+          process.env.HISTFILE = previous
+        }
+      }
+
+      expect(spawnMock.mock.calls.at(-1)![2].env.HISTFILE).toBe(expected)
+    })
+
     it('does not inherit NODE_ENV from the Orca process env', async () => {
       // Why: NODE_ENV in Orca's process is Orca's build mode (electron-vite sets
       // `development` in dev runs); leaking it breaks `next build` and Vitest.

--- a/src/main/providers/local-pty-provider-spawn-session.test.ts
+++ b/src/main/providers/local-pty-provider-spawn-session.test.ts
@@ -38,6 +38,8 @@ vi.mock('fs', () => ({
   mkdirSync: mkdirSyncMock,
   writeFileSync: writeFileSyncMock,
   chmodSync: vi.fn(),
+  renameSync: vi.fn(),
+  rmSync: vi.fn(),
   constants: { X_OK: 1 }
 }))
 

--- a/src/main/providers/local-pty-provider-test-harness.ts
+++ b/src/main/providers/local-pty-provider-test-harness.ts
@@ -74,7 +74,8 @@ export function installLocalPtyProviderEnvSandbox(): void {
 
 export function applyLocalPtyProviderMockDefaults(mocks: LocalPtyProviderMocks): void {
   mocks.existsSyncMock.mockReturnValue(true)
-  mocks.statSyncMock.mockReturnValue({ isDirectory: () => true, mode: 0o755 })
+  // size: the wrapper writer verifies each generated file is non-empty.
+  mocks.statSyncMock.mockReturnValue({ isDirectory: () => true, mode: 0o755, size: 1 })
   mocks.accessSyncMock.mockReturnValue(undefined)
   mocks.mkdirSyncMock.mockReset()
   mocks.writeFileSyncMock.mockReset()

--- a/src/main/providers/local-pty-provider-windows-shell-launch.test.ts
+++ b/src/main/providers/local-pty-provider-windows-shell-launch.test.ts
@@ -38,6 +38,8 @@ vi.mock('fs', () => ({
   mkdirSync: mkdirSyncMock,
   writeFileSync: writeFileSyncMock,
   chmodSync: vi.fn(),
+  renameSync: vi.fn(),
+  rmSync: vi.fn(),
   constants: { X_OK: 1 }
 }))
 

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -32,7 +32,8 @@ import {
   spawnShellWithFallback
 } from './local-pty-utils'
 import { prepareMacosTccLoginShell } from './macos-tcc-login-shell'
-import { getMarkerlessShellLaunchConfig, getShellReadyLaunchConfig } from './local-pty-shell-ready'
+import { getShellLaunchConfig } from './local-pty-shell-ready'
+import { selectShellStartupFeatures } from '../shell-startup-features'
 import {
   writeStartupCommandWhenShellReady,
   STARTUP_COMMAND_READY_MAX_WAIT_MS
@@ -596,9 +597,9 @@ export class LocalPtyProvider implements IPtyProvider {
     let validationCwd: string
     let startupCommandDeliveredInShellArgs = false
     let windowsFallbackAttempts: ReturnType<typeof buildWindowsPowerShellSpawnAttempts> = []
-    let shellReadyLaunch: ReturnType<typeof getShellReadyLaunchConfig> | null = null
+    let shellReadyLaunch: ReturnType<typeof getShellLaunchConfig> | null = null
     let getFallbackShellReadyConfig:
-      | ((shell: string) => ReturnType<typeof getShellReadyLaunchConfig>)
+      | ((shell: string) => ReturnType<typeof getShellLaunchConfig>)
       | undefined
     if (wslInfo) {
       shellPath = 'wsl.exe'
@@ -815,44 +816,6 @@ export class LocalPtyProvider implements IPtyProvider {
     ) {
       addWslEnvKeys(finalEnv, [POWERLEVEL10K_WIZARD_DISABLE_ENV])
     }
-    if (!wslInfo && process.platform !== 'win32') {
-      // Why: OpenCode/Codex PATH restoration and OMP's status wrapper need shell-ready code after user startup files run.
-      const needsNoMarkerWrapper =
-        finalEnv.ORCA_OPENCODE_CONFIG_DIR ||
-        finalEnv.ORCA_MIMOCODE_HOME ||
-        finalEnv.ORCA_OMP_STATUS_EXTENSION ||
-        finalEnv.ORCA_CODEX_HOME ||
-        finalEnv.ORCA_AGENT_TEAMS_SHIM_DIR
-      const isCodexStartupCommand = startupAgentRecognition?.agent === 'codex'
-      let shellLaunch: ReturnType<typeof getShellReadyLaunchConfig> | null = null
-      if (args.command && isCodexStartupCommand) {
-        const shouldWaitForShellReady = shouldUseShellReadyStartupDelivery({
-          command: args.command,
-          startupCommandDelivery: args.startupCommandDelivery
-        })
-        // Why: payload-bearing Codex startup can be lost to rc-file noise; plain Codex stays markerless for startup speed.
-        getFallbackShellReadyConfig = (shell) =>
-          shouldWaitForShellReady
-            ? getShellReadyLaunchConfig(shell)
-            : getMarkerlessShellLaunchConfig(shell)
-        shellLaunch = shouldWaitForShellReady
-          ? getShellReadyLaunchConfig(shellPath)
-          : getMarkerlessShellLaunchConfig(shellPath)
-      } else if (args.command) {
-        getFallbackShellReadyConfig = (shell) => getShellReadyLaunchConfig(shell)
-        shellLaunch = getShellReadyLaunchConfig(shellPath)
-      } else if (needsNoMarkerWrapper) {
-        getFallbackShellReadyConfig = (shell) => getMarkerlessShellLaunchConfig(shell)
-        shellLaunch = getMarkerlessShellLaunchConfig(shellPath)
-      } else {
-        getFallbackShellReadyConfig = undefined
-      }
-      if (shellLaunch) {
-        Object.assign(finalEnv, shellLaunch.env)
-        shellArgs = shellLaunch.args ?? shellArgs
-        shellReadyLaunch = args.command ? shellLaunch : null
-      }
-    }
     const requestedEnv = args.env
     expandWindowsPathEnvironmentVariables(finalEnv)
     promoteAgentTeamsShimPath(
@@ -887,6 +850,41 @@ export class LocalPtyProvider implements IPtyProvider {
       // Same for an exported `fish_history` from the fish pane that launched this
       // Orca: history off means fish's own default, not another worktree's file.
       dropInheritedOrcaFishHistory(finalEnv)
+    }
+
+    if (!wslInfo && process.platform !== 'win32') {
+      // Why after history injection: the wrapper is what repairs a worktree
+      // HISTFILE that the system zshrc clobbers, so the decision to wrap has to
+      // see whether this spawn actually injected one.
+      const isCodexStartupCommand = startupAgentRecognition?.agent === 'codex'
+      // Why: payload-bearing Codex startup can be lost to rc-file noise; plain Codex stays markerless for startup speed.
+      const waitsForShellReady =
+        Boolean(args.command) &&
+        (!isCodexStartupCommand ||
+          shouldUseShellReadyStartupDelivery({
+            command: args.command as string,
+            startupCommandDelivery: args.startupCommandDelivery
+          }))
+      // Why delete: ORCA_SHELL_FEATURES is Orca-owned, and only the launch
+      // config below may name features for this shell.
+      delete finalEnv.ORCA_SHELL_FEATURES
+      getFallbackShellReadyConfig = (shell) =>
+        getShellLaunchConfig(
+          shell,
+          selectShellStartupFeatures({
+            shellPath: shell,
+            env: finalEnv,
+            hasStartupCommand: Boolean(args.command),
+            waitsForShellReady,
+            // Why identical: the identity marker exists so the readiness
+            // handshake can bind output to the right shell PID.
+            emitsStartupIdentity: waitsForShellReady
+          })
+        )
+      const shellLaunch = getFallbackShellReadyConfig(shellPath)
+      Object.assign(finalEnv, shellLaunch.env)
+      shellArgs = shellLaunch.args ?? shellArgs
+      shellReadyLaunch = args.command ? shellLaunch : null
     }
 
     await prepareLocalPtySpawn(id)

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -25,6 +25,7 @@ import {
   type HistoryInjectionResult
 } from '../terminal-history'
 import { dropInheritedOrcaFishHistory } from '../fish-history-session'
+import { dropInheritedOrcaHistFile } from '../worktree-history-file-path'
 import type { IPtyProvider, PtyProcessInfo, PtySpawnOptions, PtySpawnResult } from './types'
 import {
   ensureNodePtySpawnHelperExecutable,
@@ -601,6 +602,9 @@ export class LocalPtyProvider implements IPtyProvider {
     let getFallbackShellReadyConfig:
       | ((shell: string) => ReturnType<typeof getShellLaunchConfig>)
       | undefined
+    // Why hoisted: a fallback shell must drop the primary's launch env, and
+    // re-deriving the key names would re-run wrapper generation.
+    let primaryLaunchEnvKeys: string[] = []
     if (wslInfo) {
       shellPath = 'wsl.exe'
       const resolved = resolveWindowsShellLaunchArgs(shellPath, cwd, defaultCwd)
@@ -850,6 +854,9 @@ export class LocalPtyProvider implements IPtyProvider {
       // Same for an exported `fish_history` from the fish pane that launched this
       // Orca: history off means fish's own default, not another worktree's file.
       dropInheritedOrcaFishHistory(finalEnv)
+      // And for an exported HISTFILE: history off means the shell's own default,
+      // not the history file of the worktree this Orca was launched from.
+      dropInheritedOrcaHistFile(finalEnv)
     }
 
     if (!wslInfo && process.platform !== 'win32') {
@@ -885,6 +892,7 @@ export class LocalPtyProvider implements IPtyProvider {
       Object.assign(finalEnv, shellLaunch.env)
       shellArgs = shellLaunch.args ?? shellArgs
       shellReadyLaunch = args.command ? shellLaunch : null
+      primaryLaunchEnvKeys = Object.keys(shellLaunch.env)
     }
 
     await prepareLocalPtySpawn(id)
@@ -906,6 +914,7 @@ export class LocalPtyProvider implements IPtyProvider {
       termName: finalEnv.TERM,
       ptySpawn: pty.spawn,
       getShellReadyConfig: getFallbackShellReadyConfig,
+      launchEnvKeys: primaryLaunchEnvKeys,
       // Why: on zsh→bash fallback HISTFILE still points to zsh_history; update before spawn so the child inherits it (design doc §8).
       onBeforeFallbackSpawn: historyResult?.historyDir
         ? (env, fallbackShell) =>

--- a/src/main/providers/local-pty-shell-ready-bash-rcfile.ts
+++ b/src/main/providers/local-pty-shell-ready-bash-rcfile.ts
@@ -7,12 +7,19 @@
 import { BASH_PROMPT_COMMAND_COMPOSITION_BLOCK } from '../bash-prompt-command-composition'
 import { getPosixOmpShellWrapper } from '../pty/omp-shell-wrapper'
 import { getPosixCodexShellLaunchPreflight } from '../pty/codex-shell-launch-preflight'
-import { SHELL_STARTUP_IDENTITY_MARKER_BLOCK } from '../shell-templates'
+import { BASH_FEATURE_CHANNEL_BLOCK, SHELL_STARTUP_IDENTITY_MARKER_BLOCK } from '../shell-templates'
 import { SHELL_READY_MARKER_ESCAPED } from './local-pty-shell-ready-wrapper-root'
 
 export function getBashShellReadyRcfileContent(): string {
   return `# Orca bash shell-ready wrapper
+${BASH_FEATURE_CHANNEL_BLOCK}
 ${SHELL_STARTUP_IDENTITY_MARKER_BLOCK}
+# Why a plain variable: the channel is consumed and destroyed in these first
+# lines, so nothing this shell later spawns can see or inherit the selection.
+__orca_ready_marker=""
+__orca_has_feature ready && __orca_ready_marker=1
+unset _orca_shell_features
+unset -f __orca_has_feature
 [[ -f /etc/profile ]] && source /etc/profile
 if [[ -f "$HOME/.bash_profile" ]]; then
   source "$HOME/.bash_profile"
@@ -107,7 +114,7 @@ ${BASH_PROMPT_COMMAND_COMPOSITION_BLOCK}
 __orca_prepend_prompt_command "__orca_osc133_precmd"
 # Why: append the marker through PROMPT_COMMAND so it fires after the login
 # startup files have rebuilt the prompt, without re-running user rc files.
-if [[ "\${ORCA_SHELL_READY_MARKER:-0}" == "1" ]]; then
+if [[ -n "$__orca_ready_marker" ]]; then
   __orca_prompt_mark() {
     printf "${SHELL_READY_MARKER_ESCAPED}"
   }

--- a/src/main/providers/local-pty-shell-ready-test-harness.ts
+++ b/src/main/providers/local-pty-shell-ready-test-harness.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, vi } from 'vitest'
 import { spawnSync } from 'node:child_process'
-import type * as LocalPtyShellReadyModule from './local-pty-shell-ready'
+import {
+  OVERLAY_ONLY_FEATURES,
+  STARTUP_COMMAND_FEATURES
+} from '../shell-startup-launch-intent-fixtures'
 
 // Why: can't import electron (bundled into the plain-node daemon-entry fork), so tests set the wrapper root via ORCA_USER_DATA_PATH instead of mocking app.
 export function setTestUserDataPath(path: string): void {
@@ -18,9 +21,18 @@ export function restoreUserDataPathAfterEach(): void {
   })
 }
 
-export async function importFreshLocalPtyShellReady(): Promise<typeof LocalPtyShellReadyModule> {
+export async function importFreshLocalPtyShellReady() {
   vi.resetModules()
-  return import('./local-pty-shell-ready')
+  const module = await import('./local-pty-shell-ready')
+  // Why the two adapters: the module exposes one feature-driven entry point, and
+  // these are the two launch intents the call sites select between.
+  return {
+    ...module,
+    getShellReadyLaunchConfig: (shell: string) =>
+      module.getShellLaunchConfig(shell, STARTUP_COMMAND_FEATURES),
+    getMarkerlessShellLaunchConfig: (shell: string) =>
+      module.getShellLaunchConfig(shell, OVERLAY_ONLY_FEATURES)
+  }
 }
 
 /** Plain suite call only; annotated because the inferred `describe.skip` type names vitest-runner internals. */

--- a/src/main/providers/local-pty-shell-ready-wrapper-generation.test.ts
+++ b/src/main/providers/local-pty-shell-ready-wrapper-generation.test.ts
@@ -96,7 +96,7 @@ function expectZdotdirSourceContext(content: string, fileName: '.zprofile' | '.z
 
 function expectFinalZdotdirRestoreContext(content: string) {
   expect(content).toContain("after Orca's last wrapper file has loaded")
-  expect(content).toContain('export ZDOTDIR="$REPLY"')
+  expect(content).toContain('export ZDOTDIR="$_orca_resolved_config_dir"')
 }
 
 describePosix('local PTY shell-ready launch config', () => {
@@ -246,8 +246,8 @@ describePosix('local PTY shell-ready launch config', () => {
     const zlogin = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zlogin'), 'utf8')
     expect(zshenv).toContain('__orca_resolve_inherited_config_dir "${ORCA_ORIG_ZDOTDIR:-$HOME}"')
     expect(zshenv).toContain('printf "\\033]777;orca-shell-start:%s\\007" "$$"')
-    expect(zshenv).toContain('"$REPLY" == */shell-ready/zsh ]]; then')
-    expect(zshenv).toContain('export ORCA_ORIG_ZDOTDIR="$REPLY"')
+    expect(zshenv).toContain('"$_orca_resolved_config_dir" == */shell-ready/zsh ]]; then')
+    expect(zshenv).toContain('export ORCA_ORIG_ZDOTDIR="$_orca_resolved_config_dir"')
     expectZdotdirSourceContext(zprofile, '.zprofile')
     expectZdotdirSourceContext(zshrc, '.zshrc')
     expectZdotdirSourceContext(zlogin, '.zlogin')
@@ -538,7 +538,7 @@ describePosix('local PTY shell-ready launch config', () => {
     const zshenv = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshenv'), 'utf8')
 
     // Save spawn-env value before sourcing user .zshenv
-    expect(zshenv.indexOf('_orca_user_zdotdir="$REPLY"')).toBeLessThan(
+    expect(zshenv.indexOf('_orca_user_zdotdir="$_orca_resolved_config_dir"')).toBeLessThan(
       zshenv.indexOf('source "${_orca_zshenv_path}"')
     )
 

--- a/src/main/providers/local-pty-shell-ready-wrapper-generation.test.ts
+++ b/src/main/providers/local-pty-shell-ready-wrapper-generation.test.ts
@@ -51,7 +51,7 @@ function runInteractiveBashRcfile(
       env: {
         ...process.env,
         HOME: tempDir,
-        ORCA_SHELL_READY_MARKER: '1',
+        ORCA_SHELL_FEATURES: 'ready',
         TERM: process.env.TERM || 'xterm'
       },
       timeout: 5000

--- a/src/main/providers/local-pty-shell-ready-wrapper-generation.test.ts
+++ b/src/main/providers/local-pty-shell-ready-wrapper-generation.test.ts
@@ -254,8 +254,11 @@ describePosix('local PTY shell-ready launch config', () => {
     // Why .zshenv: the final restore is the last step of the single epilogue,
     // which .zshrc (non-login) and .zlogin (login) each invoke once.
     expectFinalZdotdirRestoreContext(zshenv)
-    expect(zshrc).toContain('[[ -o login ]] || __orca_shell_epilogue')
-    expect(zlogin).toContain('__orca_shell_epilogue')
+    // Why the emulation probe: sh/ksh emulation makes zsh read $HOME/.zlogin
+    // rather than the wrapper's, so the epilogue has to run from here instead.
+    expect(zshrc).toContain('if [[ ! -o login || "$(emulate 2>/dev/null)" != zsh ]]; then')
+    expect(zshrc).toContain('(( ${+functions[__orca_shell_epilogue]} )) && __orca_shell_epilogue')
+    expect(zlogin).toContain('(( ${+functions[__orca_shell_epilogue]} )) && __orca_shell_epilogue')
   })
 
   it('owns zle-line-init for the shell-ready marker instead of an azhw hook', async () => {

--- a/src/main/providers/local-pty-shell-ready-wrapper-generation.test.ts
+++ b/src/main/providers/local-pty-shell-ready-wrapper-generation.test.ts
@@ -11,7 +11,8 @@ import {
 } from './local-pty-shell-ready-test-harness'
 // Why: rcfile content is pure, so a static import is equivalent to the fresh-module import used for wrapper writing.
 import { getBashShellReadyRcfileContent } from './local-pty-shell-ready-bash-rcfile'
-import { getZshShellReadyRcfileContent } from './local-pty-shell-ready-wrapper-generation'
+import { getZshShellReadyWrapperFiles } from './local-pty-shell-ready-wrapper-generation'
+import { makeUserZdotdir } from '../zsh-user-config-dir-fixture'
 
 restoreUserDataPathAfterEach()
 
@@ -95,7 +96,7 @@ function expectZdotdirSourceContext(content: string, fileName: '.zprofile' | '.z
 
 function expectFinalZdotdirRestoreContext(content: string) {
   expect(content).toContain("after Orca's last wrapper file has loaded")
-  expect(content).toContain('export ZDOTDIR="$_orca_home"')
+  expect(content).toContain('export ZDOTDIR="$REPLY"')
 }
 
 describePosix('local PTY shell-ready launch config', () => {
@@ -127,7 +128,9 @@ describePosix('local PTY shell-ready launch config', () => {
     const config = getShellReadyLaunchConfig('/opt/homebrew/bin/fish')
 
     expect(config.supportsReadyMarker).toBe(true)
-    expect(config.env).toEqual({ ORCA_SHELL_READY_MARKER: '1' })
+    // Why empty: fish's selection is baked into the init command text, so it
+    // needs no exported feature variable at all.
+    expect(config.env).toEqual({})
     expect(config.args?.slice(0, 2)).toEqual(['-l', '-C'])
     const init = config.args?.[2] ?? ''
     expect(init).toContain('--on-event fish_prompt')
@@ -173,14 +176,15 @@ describePosix('local PTY shell-ready launch config', () => {
     const previousZdotdir = process.env.ZDOTDIR
     const previousOrigZdotdir = process.env.ORCA_ORIG_ZDOTDIR
     const previousHome = process.env.HOME
+    const userZdotdir = makeUserZdotdir(userDataPath, '.config', 'zsh')
     process.env.ZDOTDIR = '/some/other/orca/shell-ready/zsh'
-    process.env.ORCA_ORIG_ZDOTDIR = '/Users/alice/.config/zsh'
-    process.env.HOME = '/Users/alice'
+    process.env.ORCA_ORIG_ZDOTDIR = userZdotdir
+    process.env.HOME = userDataPath
     try {
       const { getShellReadyLaunchConfig } = await importFreshLocalPtyShellReady()
       const config = getShellReadyLaunchConfig('/bin/zsh')
-      expect(config.env.ORCA_ORIG_ZDOTDIR).toBe('/Users/alice/.config/zsh')
-      expect(config.env.ORCA_ZSHENV_SOURCE_DIR).toBe('/Users/alice')
+      expect(config.env.ORCA_ORIG_ZDOTDIR).toBe(userZdotdir)
+      expect(config.env.ORCA_ZSHENV_SOURCE_DIR).toBe(userDataPath)
     } finally {
       if (previousZdotdir === undefined) {
         delete process.env.ZDOTDIR
@@ -240,15 +244,18 @@ describePosix('local PTY shell-ready launch config', () => {
     const zprofile = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zprofile'), 'utf8')
     const zshrc = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshrc'), 'utf8')
     const zlogin = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zlogin'), 'utf8')
-    expect(zshenv).toContain('_orca_user_zdotdir="${_orca_spawn_orig_zdotdir:-$HOME}"')
+    expect(zshenv).toContain('__orca_resolve_inherited_config_dir "${ORCA_ORIG_ZDOTDIR:-$HOME}"')
     expect(zshenv).toContain('printf "\\033]777;orca-shell-start:%s\\007" "$$"')
-    expect(zshenv).toContain('*/shell-ready/zsh) _orca_user_zdotdir="$HOME" ;;')
-    expect(zshenv).toContain('""|*/shell-ready/zsh) export ORCA_ORIG_ZDOTDIR="$HOME" ;;')
+    expect(zshenv).toContain('"$REPLY" == */shell-ready/zsh ]]; then')
+    expect(zshenv).toContain('export ORCA_ORIG_ZDOTDIR="$REPLY"')
     expectZdotdirSourceContext(zprofile, '.zprofile')
     expectZdotdirSourceContext(zshrc, '.zshrc')
     expectZdotdirSourceContext(zlogin, '.zlogin')
-    expectFinalZdotdirRestoreContext(zshrc)
-    expectFinalZdotdirRestoreContext(zlogin)
+    // Why .zshenv: the final restore is the last step of the single epilogue,
+    // which .zshrc (non-login) and .zlogin (login) each invoke once.
+    expectFinalZdotdirRestoreContext(zshenv)
+    expect(zshrc).toContain('[[ -o login ]] || __orca_shell_epilogue')
+    expect(zlogin).toContain('__orca_shell_epilogue')
   })
 
   it('owns zle-line-init for the shell-ready marker instead of an azhw hook', async () => {
@@ -256,14 +263,19 @@ describePosix('local PTY shell-ready launch config', () => {
 
     getShellReadyLaunchConfig('/bin/zsh')
 
-    const zlogin = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zlogin'), 'utf8')
-    expect(zlogin).toContain('zle -N zle-line-init __orca_prompt_mark')
-    expect(zlogin).toContain('__orca_prev_line_init_fn="${widgets[zle-line-init]#user:}"')
-    expect(zlogin).toContain('printf "\\033]777;orca-shell-ready\\007"')
+    // Why .zshenv: the widget registration lives in the epilogue, which .zlogin
+    // (login) and .zshrc (non-login) both call exactly once.
+    const zshenv = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshenv'), 'utf8')
+    expect(zshenv).toContain('zle -N zle-line-init __orca_prompt_mark')
+    expect(zshenv).toContain('__orca_prev_line_init_fn="${widgets[zle-line-init]#user:}"')
+    expect(zshenv).toContain('printf "\\033]777;orca-shell-ready\\007"')
     // Why: add-zle-hook-widget aborts its chain on a non-zero earlier hook (e.g. oh-my-zsh vi-mode); don't register the marker through it.
-    expect(zlogin).not.toContain('add-zle-hook-widget line-init')
+    expect(zshenv).not.toContain('add-zle-hook-widget line-init')
     // Why: re-source guard — skip re-capturing when already the bound widget so the prior chain survives a second source.
-    expect(zlogin).toContain('== "user:__orca_prompt_mark"')
+    expect(zshenv).toContain('== "user:__orca_prompt_mark"')
+    expect(readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zlogin'), 'utf8')).toContain(
+      '__orca_shell_epilogue'
+    )
   })
 
   it('writes wrappers without restoring Pi/OMP homes after user startup files', async () => {
@@ -271,8 +283,10 @@ describePosix('local PTY shell-ready launch config', () => {
 
     getShellReadyLaunchConfig('/bin/zsh')
 
-    const zshrc = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshrc'), 'utf8')
-    const zlogin = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zlogin'), 'utf8')
+    // Why one file: every restore now lives in the single epilogue in .zshenv,
+    // which .zshrc and .zlogin each invoke on their own startup path.
+    const zshrc = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshenv'), 'utf8')
+    const zlogin = zshrc
     const bashRc = getBashShellReadyRcfileContent()
     const restoreLine =
       '[[ -n "${ORCA_OPENCODE_CONFIG_DIR:-}" ]] && export OPENCODE_CONFIG_DIR="${ORCA_OPENCODE_CONFIG_DIR}"'
@@ -314,7 +328,8 @@ describePosix('local PTY shell-ready launch config', () => {
   // Why: issue #2422 — without OSC 133 C/D markers, bash sessions kept the worktree spinner "working" ~30min after the agent exited.
   it('emits OSC 133 C/D markers in the bash wrapper so agent exit cleanup fires', async () => {
     const bashRc = getBashShellReadyRcfileContent()
-    const zshRc = getZshShellReadyRcfileContent()
+    // Why .zshenv: the zsh markers live in the epilogue, behind `markers`.
+    const zshRc = getZshShellReadyWrapperFiles().zshenv
 
     // The exact escape sequences terminal-command-lifecycle parses (133;D = finished, 133;C = start).
     expect(bashRc).toContain('printf "\\033]133;D;%s\\007"')
@@ -323,9 +338,10 @@ describePosix('local PTY shell-ready launch config', () => {
     expect(bashRc).toContain('__orca_prepend_prompt_command "__orca_osc133_precmd"')
     // DEBUG is armed after setup; lastIndexOf skips the dispatcher's conditional re-arm.
     expect(bashRc.lastIndexOf("trap '__orca_osc133_preexec' DEBUG")).toBeGreaterThan(
-      bashRc.indexOf('if [[ "${ORCA_SHELL_READY_MARKER:-0}" == "1" ]]; then')
+      bashRc.indexOf('if [[ -n "$__orca_ready_marker" ]]; then')
     )
-    // Sanity: zsh wrapper emits the same markers — both branches must stay in sync.
+    // Sanity: zsh wrapper emits the same markers — both branches must stay in
+    // sync. They live in the .zshenv epilogue, behind the `markers` feature.
     expect(zshRc).toContain('printf "\\033]133;D;%s\\007"')
     expect(zshRc).toContain('printf "\\033]133;C\\007"')
   })
@@ -411,12 +427,13 @@ describePosix('local PTY shell-ready launch config', () => {
 
   it('preserves a real inherited ZDOTDIR as ORCA_ORIG_ZDOTDIR', async () => {
     const previousZdotdir = process.env.ZDOTDIR
-    process.env.ZDOTDIR = '/Users/alice/.config/zsh'
+    const userZdotdir = makeUserZdotdir(userDataPath, '.config', 'zsh')
+    process.env.ZDOTDIR = userZdotdir
     try {
       const { getShellReadyLaunchConfig } = await importFreshLocalPtyShellReady()
       const config = getShellReadyLaunchConfig('/bin/zsh')
-      expect(config.env.ORCA_ORIG_ZDOTDIR).toBe('/Users/alice/.config/zsh')
-      expect(config.env.ORCA_ZSHENV_SOURCE_DIR).toBe('/Users/alice/.config/zsh')
+      expect(config.env.ORCA_ORIG_ZDOTDIR).toBe(userZdotdir)
+      expect(config.env.ORCA_ZSHENV_SOURCE_DIR).toBe(userZdotdir)
     } finally {
       if (previousZdotdir === undefined) {
         delete process.env.ZDOTDIR
@@ -474,11 +491,12 @@ describePosix('local PTY shell-ready launch config', () => {
 
   it('preserves ZDOTDIR that contains /shell-ready/zsh as a substring but does not end with it', async () => {
     const previousZdotdir = process.env.ZDOTDIR
-    process.env.ZDOTDIR = '/Users/alice/shell-ready/zsh-custom'
+    const userZdotdir = makeUserZdotdir(userDataPath, 'shell-ready', 'zsh-custom')
+    process.env.ZDOTDIR = userZdotdir
     try {
       const { getShellReadyLaunchConfig } = await importFreshLocalPtyShellReady()
       const config = getShellReadyLaunchConfig('/bin/zsh')
-      expect(config.env.ORCA_ORIG_ZDOTDIR).toBe('/Users/alice/shell-ready/zsh-custom')
+      expect(config.env.ORCA_ORIG_ZDOTDIR).toBe(userZdotdir)
     } finally {
       if (previousZdotdir === undefined) {
         delete process.env.ZDOTDIR
@@ -497,11 +515,13 @@ describePosix('local PTY shell-ready launch config', () => {
     const zshenv = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshenv'), 'utf8')
 
     expect(zshenv).toContain('unset ZDOTDIR')
-    expect(zshenv).toContain('_orca_zshenv_source_dir="${ORCA_ZSHENV_SOURCE_DIR:-$HOME}"')
+    expect(zshenv).toContain(
+      '__orca_resolve_inherited_config_dir "${ORCA_ZSHENV_SOURCE_DIR:-$HOME}"'
+    )
     expect(zshenv).toContain('source "${_orca_zshenv_path}"')
     expect(zshenv).toContain('_orca_discovered_zdotdir="${ZDOTDIR:-}"')
     expect(zshenv).toContain(
-      'export ORCA_ORIG_ZDOTDIR="${_orca_discovered_zdotdir:-${_orca_user_zdotdir:-$HOME}}"'
+      '__orca_resolve_user_config_dir "${_orca_discovered_zdotdir:-${_orca_user_zdotdir:-$HOME}}"'
     )
     expect(zshenv).toContain('export ZDOTDIR=')
   })
@@ -515,7 +535,9 @@ describePosix('local PTY shell-ready launch config', () => {
     const zshenv = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshenv'), 'utf8')
 
     // Save spawn-env value before sourcing user .zshenv
-    expect(zshenv).toContain('_orca_spawn_orig_zdotdir="${ORCA_ORIG_ZDOTDIR:-}"')
+    expect(zshenv.indexOf('_orca_user_zdotdir="$REPLY"')).toBeLessThan(
+      zshenv.indexOf('source "${_orca_zshenv_path}"')
+    )
 
     // Fallback chain: discovered → normalized spawn-env path → HOME
     expect(zshenv).toContain('${_orca_discovered_zdotdir:-${_orca_user_zdotdir:-$HOME}}')

--- a/src/main/providers/local-pty-shell-ready-wrapper-generation.ts
+++ b/src/main/providers/local-pty-shell-ready-wrapper-generation.ts
@@ -4,11 +4,13 @@
  * Why: the wrappers emit an OSC 777 marker after startup files finish, which the
  * readiness scanner watches for before a startup command is written.
  */
-import { mkdirSync, writeFileSync, chmodSync } from 'node:fs'
 import {
   buildZshStartupWrapperFiles,
+  type ZshStartupWrapperFiles,
   type ZshStartupWrapperSpec
 } from '../zsh-startup-wrapper-builder'
+import { writeShellWrapperFiles } from '../shell-wrapper-file-writer'
+import { ZSH_WRAPPER_DIR_MARKER_CONTENT, ZSH_WRAPPER_DIR_MARKER_FILE } from '../shell-templates'
 import { getBashShellReadyRcfileContent } from './local-pty-shell-ready-bash-rcfile'
 import {
   getShellReadyWrapperRoot,
@@ -26,73 +28,53 @@ function getLocalZshWrapperSpec(zshDir: string): ZshStartupWrapperSpec {
     readyMarkerEscaped: SHELL_READY_MARKER_ESCAPED,
     osc133CommandMarkers: true,
     skipUserZshrcWhenHomeIsWrapperDir: true,
-    interactiveRestoreComment:
+    overlayRestoreComment:
       "# Why: ~/.zshrc can export the user's default OpenCode config after spawn.",
-    loginRestoreComment:
-      '# Why: .zlogin is the final login startup file before the prompt is shown.',
     restores: {
       agentTeamsPath: true,
       remoteCliBinDir: false,
       codexHome: true,
       codexLaunchPreflight: true
-    },
-    readyMarkerOrder: 'before-zdotdir-restore',
-    legacyFormatting: {
-      unindentedMimocodeRestore: true,
-      codexHomeRestoreComment:
-        "# Why: Codex must keep using Orca's runtime CODEX_HOME after rc files."
     }
   }
 }
 
-export function getZshShellReadyRcfileContent(): string {
+export function getZshShellReadyWrapperFiles(): ZshStartupWrapperFiles {
   return buildZshStartupWrapperFiles(getLocalZshWrapperSpec(`${getShellReadyWrapperRoot()}/zsh`))
-    .zshrc
 }
 
-export function ensureShellReadyWrappersAt(root = getShellReadyWrapperRoot()): void {
+/** True when every wrapper file is present and non-empty afterwards. */
+export function ensureShellReadyWrappersAt(root = getShellReadyWrapperRoot()): boolean {
   if (didEnsureShellReadyWrappers && shellReadyWrappersExist(root)) {
-    return
+    return true
   }
   didEnsureShellReadyWrappers = true
 
   const zshDir = `${root}/zsh`
-  const bashDir = `${root}/bash`
-
   const zsh = buildZshStartupWrapperFiles(getLocalZshWrapperSpec(zshDir))
-  const bashRc = getBashShellReadyRcfileContent()
 
-  const files = [
-    [`${zshDir}/.zshenv`, zsh.zshenv],
-    [`${zshDir}/.zprofile`, zsh.zprofile],
-    [`${zshDir}/.zshrc`, zsh.zshrc],
-    [`${zshDir}/.zlogin`, zsh.zlogin],
-    [`${bashDir}/rcfile`, bashRc]
-  ] as const
-
-  try {
-    for (const [path, content] of files) {
-      const dir = path.slice(0, path.lastIndexOf('/'))
-      mkdirSync(dir, { recursive: true })
-      writeFileSync(path, content, 'utf8')
-      chmodSync(path, 0o644)
-    }
-  } catch (error) {
-    // Why: degrade gracefully — a failed wrapper (read-only FS, perms, disk) just means no ready marker, PTY stays usable.
-    const errorMessage =
-      error instanceof Error
-        ? `${error.message} (${(error as NodeJS.ErrnoException).code || 'unknown'})`
-        : String(error)
-    console.error(`[shell-ready] Failed to create wrapper files in ${root}: ${errorMessage}`)
-    console.error('[shell-ready] Shell will launch without wrapper (no shell-ready marker)')
-    // Reset the flag so next attempt will try again
+  const written = writeShellWrapperFiles(
+    [
+      [`${zshDir}/.zshenv`, zsh.zshenv],
+      [`${zshDir}/.zprofile`, zsh.zprofile],
+      [`${zshDir}/.zshrc`, zsh.zshrc],
+      [`${zshDir}/.zlogin`, zsh.zlogin],
+      [`${zshDir}/${ZSH_WRAPPER_DIR_MARKER_FILE}`, ZSH_WRAPPER_DIR_MARKER_CONTENT],
+      [`${root}/bash/rcfile`, getBashShellReadyRcfileContent()]
+    ],
+    '[shell-ready]'
+  )
+  if (!written || !shellReadyWrappersExist(root)) {
+    // Why reset: the next launch retries instead of trusting a half-written tree.
     didEnsureShellReadyWrappers = false
+    return false
   }
+  return true
 }
 
-export function ensureShellReadyWrappers(): void {
+export function ensureShellReadyWrappers(): boolean {
   if (process.platform === 'win32') {
-    return
+    return false
   }
-  ensureShellReadyWrappersAt()
+  return ensureShellReadyWrappersAt()
 }

--- a/src/main/providers/local-pty-shell-ready-wrapper-root.ts
+++ b/src/main/providers/local-pty-shell-ready-wrapper-root.ts
@@ -3,7 +3,8 @@
  * wrappers emit — the shared contract between wrapper generation and shell launch.
  */
 import { tmpdir } from 'node:os'
-import { existsSync } from 'node:fs'
+import { statSync } from 'node:fs'
+import { ZSH_WRAPPER_DIR_MARKER_FILE } from '../shell-templates'
 
 export const SHELL_READY_MARKER_ESCAPED = '\\033]777;orca-shell-ready\\007'
 
@@ -19,10 +20,24 @@ export function getRequiredShellReadyWrapperPaths(root = getShellReadyWrapperRoo
     `${root}/zsh/.zprofile`,
     `${root}/zsh/.zshrc`,
     `${root}/zsh/.zlogin`,
+    `${root}/zsh/${ZSH_WRAPPER_DIR_MARKER_FILE}`,
     `${root}/bash/rcfile`
   ]
 }
 
+/**
+ * Every wrapper file exists and has content.
+ *
+ * Why non-empty and not just present: a partial write (full disk, killed mid
+ * write) leaves a zero-byte .zshenv, and pointing ZDOTDIR at that directory
+ * makes zsh skip the user's entire configuration silently.
+ */
 export function shellReadyWrappersExist(root = getShellReadyWrapperRoot()): boolean {
-  return getRequiredShellReadyWrapperPaths(root).every((path) => existsSync(path))
+  return getRequiredShellReadyWrapperPaths(root).every((path) => {
+    try {
+      return statSync(path).size > 0
+    } catch {
+      return false
+    }
+  })
 }

--- a/src/main/providers/local-pty-shell-ready-zsh-launch-environment.test.ts
+++ b/src/main/providers/local-pty-shell-ready-zsh-launch-environment.test.ts
@@ -86,7 +86,11 @@ describePosix('live zsh subprocess tests', () => {
     })
 
     it('handles sudo -E where HOME and ZDOTDIR mismatch', async () => {
-      const userZdotdir = join('/home', 'alice', '.config', 'zsh')
+      // Why a real dir: an inherited ZDOTDIR only counts as the user's config
+      // root when it actually holds a zsh startup file.
+      const userZdotdir = join(testHome, '.config', 'zsh')
+      mkdirSync(userZdotdir, { recursive: true })
+      writeFileSync(join(userZdotdir, '.zshrc'), '')
 
       const previousZdotdir = process.env.ZDOTDIR
       const previousHome = process.env.HOME

--- a/src/main/providers/local-pty-shell-ready.ts
+++ b/src/main/providers/local-pty-shell-ready.ts
@@ -12,9 +12,19 @@ import {
 } from '../powershell-osc133-bootstrap'
 import { getFishCodexShellLaunchPreflight } from '../pty/codex-shell-launch-preflight'
 import { getFishShellReadyInitCommand } from '../shell-templates'
+import {
+  encodeShellStartupFeatures,
+  SHELL_STARTUP_FEATURE_ENV,
+  type ShellStartupFeature
+} from '../shell-startup-features'
+import {
+  resolveInheritedZdotdir,
+  resolveInheritedZshenvSourceDir
+} from '../zsh-wrapper-dir-ownership'
 import { ensureShellReadyWrappers } from './local-pty-shell-ready-wrapper-generation'
 import {
   getShellReadyWrapperRoot,
+  shellReadyWrappersExist,
   SHELL_READY_MARKER_ESCAPED
 } from './local-pty-shell-ready-wrapper-root'
 export {
@@ -25,68 +35,77 @@ export {
 } from '../shell-ready-marker-scanner'
 export type { ShellReadyScanResult, ShellReadyScanState } from '../shell-ready-marker-scanner'
 
-// Why: an Orca wrapper ZDOTDIR recurses; treat it as unset and fall back to HOME.
-function normalizeOriginalZdotdirCandidate(value: string | undefined): string | null {
-  if (!value) {
-    return null
-  }
-  // Why: strip trailing slashes so wrapper paths match; `/` falls back to HOME.
-  const normalized = value.replace(/\/+$/, '')
-  if (!normalized || normalized.endsWith('/shell-ready/zsh')) {
-    return null
-  }
-  return value
-}
-
-function resolveOriginalZdotdir(): string {
-  return (
-    normalizeOriginalZdotdirCandidate(process.env.ZDOTDIR) ||
-    normalizeOriginalZdotdirCandidate(process.env.ORCA_ORIG_ZDOTDIR) ||
-    process.env.HOME ||
-    ''
-  )
-}
-
-function resolveOriginalZshenvSourceDir(): string {
-  return normalizeOriginalZdotdirCandidate(process.env.ZDOTDIR) || process.env.HOME || ''
-}
-
 export type ShellReadyLaunchConfig = {
   args: string[] | null
   env: Record<string, string>
   supportsReadyMarker: boolean
 }
 
-function getWrappedShellLaunchConfig(
+const UNWRAPPED: ShellReadyLaunchConfig = {
+  args: null,
+  env: {},
+  supportsReadyMarker: false
+}
+
+/** True when the wrapper tree is complete on disk right now. */
+function wrapperTreeUsable(): boolean {
+  const ensured = ensureShellReadyWrappers()
+  return ensured && shellReadyWrappersExist()
+}
+
+/** Args that point bash at Orca's rcfile, or null when it is not usable. */
+export function getBashWrapperLaunchArgs(): string[] | null {
+  return shellReadyWrappersExist()
+    ? ['--rcfile', `${getShellReadyWrapperRoot()}/bash/rcfile`]
+    : null
+}
+
+/**
+ * The one launch-config entry point: args + env for a shell that should start
+ * with exactly `features` enabled. An empty selection is never wrapped.
+ */
+export function getShellLaunchConfig(
   shellPath: string,
-  options: { emitReadyMarker: boolean }
+  features: readonly ShellStartupFeature[]
 ): ShellReadyLaunchConfig {
   const shellName = pathWin32.basename(basename(shellPath)).toLowerCase()
 
   if (shellName === 'zsh') {
-    ensureShellReadyWrappers()
+    if (features.length === 0) {
+      return UNWRAPPED
+    }
+    if (!wrapperTreeUsable()) {
+      // Why plain login zsh: ZDOTDIR pointed at an incomplete wrapper dir makes
+      // zsh skip the user's whole config. Losing Orca's features is recoverable.
+      return { args: ['-l'], env: {}, supportsReadyMarker: false }
+    }
     return {
       args: ['-l'],
       env: {
-        ORCA_ORIG_ZDOTDIR: resolveOriginalZdotdir(),
-        ORCA_ZSHENV_SOURCE_DIR: resolveOriginalZshenvSourceDir(),
+        ORCA_ORIG_ZDOTDIR: resolveInheritedZdotdir(process.env),
+        ORCA_ZSHENV_SOURCE_DIR: resolveInheritedZshenvSourceDir(process.env),
         ZDOTDIR: `${getShellReadyWrapperRoot()}/zsh`,
-        ORCA_SHELL_READY_MARKER: options.emitReadyMarker ? '1' : '0',
-        ORCA_SHELL_STARTUP_IDENTITY: options.emitReadyMarker ? '1' : '0'
+        [SHELL_STARTUP_FEATURE_ENV]: encodeShellStartupFeatures(features)
       },
-      supportsReadyMarker: options.emitReadyMarker
+      supportsReadyMarker: features.includes('ready')
     }
   }
 
   if (shellName === 'bash') {
+    if (features.length === 0) {
+      return UNWRAPPED
+    }
     ensureShellReadyWrappers()
+    const args = getBashWrapperLaunchArgs()
+    if (!args) {
+      return UNWRAPPED
+    }
     return {
-      args: ['--rcfile', `${getShellReadyWrapperRoot()}/bash/rcfile`],
+      args,
       env: {
-        ORCA_SHELL_READY_MARKER: options.emitReadyMarker ? '1' : '0',
-        ORCA_SHELL_STARTUP_IDENTITY: options.emitReadyMarker ? '1' : '0'
+        [SHELL_STARTUP_FEATURE_ENV]: encodeShellStartupFeatures(features)
       },
-      supportsReadyMarker: options.emitReadyMarker
+      supportsReadyMarker: features.includes('ready')
     }
   }
 
@@ -103,30 +122,19 @@ function getWrappedShellLaunchConfig(
     }
   }
 
-  // Why: mirrors daemon/shell-ready.ts; markerless fish stays unwrapped.
-  if (shellName === 'fish' && options.emitReadyMarker) {
+  // Why: mirrors daemon/shell-ready.ts; markerless fish stays unwrapped. The
+  // selection is baked into the init command, so fish needs no feature env var.
+  if (shellName === 'fish' && features.includes('ready')) {
     return {
       args: [
         '-l',
         '-C',
         `${getFishShellReadyInitCommand(SHELL_READY_MARKER_ESCAPED)}\n${getFishCodexShellLaunchPreflight()}`
       ],
-      env: { ORCA_SHELL_READY_MARKER: '1' },
+      env: {},
       supportsReadyMarker: true
     }
   }
 
-  return {
-    args: null,
-    env: {},
-    supportsReadyMarker: false
-  }
-}
-
-export function getShellReadyLaunchConfig(shellPath: string): ShellReadyLaunchConfig {
-  return getWrappedShellLaunchConfig(shellPath, { emitReadyMarker: true })
-}
-
-export function getMarkerlessShellLaunchConfig(shellPath: string): ShellReadyLaunchConfig {
-  return getWrappedShellLaunchConfig(shellPath, { emitReadyMarker: false })
+  return UNWRAPPED
 }

--- a/src/main/providers/local-pty-utils.test.ts
+++ b/src/main/providers/local-pty-utils.test.ts
@@ -263,6 +263,7 @@ describe('spawnShellWithFallback macOS TCC login wrapping', () => {
       cwd: '/work',
       env,
       ptySpawn: ptySpawn as never,
+      launchEnvKeys: Object.keys(zshLaunchEnv),
       getShellReadyConfig: (shell) =>
         shell === '/bin/zsh' ? { args: ['-l'], env: zshLaunchEnv } : { args: null, env: {} }
     })
@@ -270,6 +271,41 @@ describe('spawnShellWithFallback macOS TCC login wrapping', () => {
     expect(env.ORCA_SHELL_FEATURES).toBeUndefined()
     expect(env.ZDOTDIR).toBeUndefined()
     expect(env.ORCA_ORIG_ZDOTDIR).toBeUndefined()
+    expect(env.HOME).toBe('/home/jin')
+  })
+
+  it('drops the first fallback’s launch env when a second fallback takes over', () => {
+    // Why: the keys to scrub are the ones the LAST attempt wrote. Computed once
+    // from the primary, a wrapped first fallback leaks its own ZDOTDIR and
+    // feature channel into the shell that finally starts.
+    const bashLaunchEnv = { ORCA_SHELL_FEATURES: 'markers', BASH_ENV: '/userdata/bash/rcfile' }
+    const env: Record<string, string> = { HOME: '/home/jin', ZDOTDIR: '/userdata/shell-ready/zsh' }
+    const ptySpawn = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        throw new Error('primary boom')
+      })
+      .mockImplementationOnce(() => {
+        throw new Error('first fallback boom')
+      })
+      .mockReturnValue({ pid: 4 })
+
+    spawnShellWithFallback({
+      shellPath: '/bin/zsh',
+      shellArgs: ['-l'],
+      cols: 80,
+      rows: 24,
+      cwd: '/work',
+      env,
+      ptySpawn: ptySpawn as never,
+      launchEnvKeys: ['ZDOTDIR'],
+      getShellReadyConfig: (shell) =>
+        shell === '/bin/bash' ? { args: ['--rcfile', '/rc'], env: bashLaunchEnv } : null
+    })
+
+    expect(env.ORCA_SHELL_FEATURES).toBeUndefined()
+    expect(env.BASH_ENV).toBeUndefined()
+    expect(env.ZDOTDIR).toBeUndefined()
     expect(env.HOME).toBe('/home/jin')
   })
 })

--- a/src/main/providers/local-pty-utils.test.ts
+++ b/src/main/providers/local-pty-utils.test.ts
@@ -237,4 +237,39 @@ describe('spawnShellWithFallback macOS TCC login wrapping', () => {
     )
     expect(result.shellPath).toBe('/bin/bash')
   })
+
+  it('drops the primary shell’s launch env when an unwrapped fallback takes over', () => {
+    // Why: nothing in an unwrapped bash pane consumes the feature channel, so a
+    // leftover ZDOTDIR would point a nested zsh at Orca's wrapper and turn on
+    // features Orca never selected for it.
+    const zshLaunchEnv = {
+      ZDOTDIR: '/userdata/shell-ready/zsh',
+      ORCA_ORIG_ZDOTDIR: '/home/jin',
+      ORCA_SHELL_FEATURES: 'history'
+    }
+    const env: Record<string, string> = { HOME: '/home/jin', ...zshLaunchEnv }
+    const ptySpawn = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        throw new Error('primary boom')
+      })
+      .mockReturnValue({ pid: 3 })
+
+    spawnShellWithFallback({
+      shellPath: '/bin/zsh',
+      shellArgs: ['-l'],
+      cols: 80,
+      rows: 24,
+      cwd: '/work',
+      env,
+      ptySpawn: ptySpawn as never,
+      getShellReadyConfig: (shell) =>
+        shell === '/bin/zsh' ? { args: ['-l'], env: zshLaunchEnv } : { args: null, env: {} }
+    })
+
+    expect(env.ORCA_SHELL_FEATURES).toBeUndefined()
+    expect(env.ZDOTDIR).toBeUndefined()
+    expect(env.ORCA_ORIG_ZDOTDIR).toBeUndefined()
+    expect(env.HOME).toBe('/home/jin')
+  })
 })

--- a/src/main/providers/local-pty-utils.ts
+++ b/src/main/providers/local-pty-utils.ts
@@ -128,6 +128,10 @@ export type ShellSpawnParams = {
   getShellReadyConfig?: (
     shell: string
   ) => { args: string[] | null; env: Record<string, string> } | null
+  /** Env keys the primary shell's launch config wrote into `env`. Passed in
+   *  rather than re-derived: asking for the config again re-runs wrapper
+   *  generation just to read back its key names. */
+  launchEnvKeys?: readonly string[]
   /** Called before each fallback shell spawn so callers can update env vars
    *  (e.g. HISTFILE) that depend on which shell is about to run. */
   onBeforeFallbackSpawn?: (env: Record<string, string>, fallbackShell: string) => void
@@ -247,11 +251,12 @@ export function spawnShellWithFallback(params: ShellSpawnParams): ShellSpawnResu
   // Try fallback shells on Unix
   if (process.platform !== 'win32') {
     const fallbackShells = UNIX_SHELL_FALLBACKS.filter((candidate) => candidate !== shellPath)
-    // Why: the primary shell's launch keys (its wrapper ZDOTDIR and the feature
+    // Why: the previous shell's launch keys (its wrapper ZDOTDIR and the feature
     // channel) mean nothing to a different shell. An unwrapped fallback writes
     // none of them back, so they would stay exported to the pane and to every
-    // child — including a nested zsh that would then load Orca's wrapper.
-    const primaryLaunchEnvKeys = Object.keys(getShellReadyConfig?.(shellPath)?.env ?? {})
+    // child — including a nested zsh that would then load Orca's wrapper. Tracked
+    // per attempt, not once: the second fallback must not inherit the first's.
+    let staleLaunchEnvKeys: readonly string[] = params.launchEnvKeys ?? []
     for (const fallback of fallbackShells) {
       if (getShellValidationError(fallback)) {
         continue
@@ -260,10 +265,11 @@ export function spawnShellWithFallback(params: ShellSpawnParams): ShellSpawnResu
         const fallbackReady = getShellReadyConfig?.(fallback)
         env.SHELL = fallback
         onBeforeFallbackSpawn?.(env, fallback)
-        for (const key of primaryLaunchEnvKeys) {
+        for (const key of staleLaunchEnvKeys) {
           delete env[key]
         }
         Object.assign(env, fallbackReady?.env ?? {})
+        staleLaunchEnvKeys = Object.keys(fallbackReady?.env ?? {})
         const wrapped = wrapShellSpawnForMacosTccAttribution(
           fallback,
           fallbackReady?.args ?? ['-l'],

--- a/src/main/providers/local-pty-utils.ts
+++ b/src/main/providers/local-pty-utils.ts
@@ -247,6 +247,11 @@ export function spawnShellWithFallback(params: ShellSpawnParams): ShellSpawnResu
   // Try fallback shells on Unix
   if (process.platform !== 'win32') {
     const fallbackShells = UNIX_SHELL_FALLBACKS.filter((candidate) => candidate !== shellPath)
+    // Why: the primary shell's launch keys (its wrapper ZDOTDIR and the feature
+    // channel) mean nothing to a different shell. An unwrapped fallback writes
+    // none of them back, so they would stay exported to the pane and to every
+    // child — including a nested zsh that would then load Orca's wrapper.
+    const primaryLaunchEnvKeys = Object.keys(getShellReadyConfig?.(shellPath)?.env ?? {})
     for (const fallback of fallbackShells) {
       if (getShellValidationError(fallback)) {
         continue
@@ -255,6 +260,9 @@ export function spawnShellWithFallback(params: ShellSpawnParams): ShellSpawnResu
         const fallbackReady = getShellReadyConfig?.(fallback)
         env.SHELL = fallback
         onBeforeFallbackSpawn?.(env, fallback)
+        for (const key of primaryLaunchEnvKeys) {
+          delete env[key]
+        }
         Object.assign(env, fallbackReady?.env ?? {})
         const wrapped = wrapShellSpawnForMacosTccAttribution(
           fallback,

--- a/src/main/providers/windows-shell-args.test.ts
+++ b/src/main/providers/windows-shell-args.test.ts
@@ -384,8 +384,9 @@ describe('resolveWindowsShellLaunchArgs', () => {
     // Why: typed OMP keeps its existing shell integration, while typed Prime
     // commands must reach the user's binary without Orca rewriting argv.
     const bashRcfile = readFileSync(join(userDataPath, 'shell-ready', 'bash', 'rcfile'), 'utf8')
-    const zshLogin = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zlogin'), 'utf8')
-    for (const wrapperFile of [bashRcfile, zshLogin]) {
+    // Why .zshenv: the omp wrapper is part of the epilogue defined there.
+    const zshEnv = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshenv'), 'utf8')
+    for (const wrapperFile of [bashRcfile, zshEnv]) {
       expect(wrapperFile).toContain('command omp --extension "${ORCA_OMP_STATUS_EXTENSION}" "$@"')
       expect(wrapperFile).toContain('omp() { __orca_omp "$@"; }')
       expect(wrapperFile).not.toContain('prime-agent()')

--- a/src/main/providers/windows-shell-args.ts
+++ b/src/main/providers/windows-shell-args.ts
@@ -6,7 +6,7 @@ import {
   escapeWslShCommandForWindows,
   quotePosixShell
 } from '../../shared/wsl-login-shell-command'
-import { getMarkerlessShellLaunchConfig } from './local-pty-shell-ready'
+import { getBashWrapperLaunchArgs } from './local-pty-shell-ready'
 import { ensureShellReadyWrappersAt } from './local-pty-shell-ready-wrapper-generation'
 import {
   encodePowerShellCommand,
@@ -34,7 +34,7 @@ function getGitBashLaunchCommand(codexLaunchPreflightCommand?: string): string {
   }
 
   ensureShellReadyWrappersAt()
-  const wrapperArgs = getMarkerlessShellLaunchConfig('bash').args
+  const wrapperArgs = getBashWrapperLaunchArgs()
   if (!wrapperArgs) {
     return GIT_BASH_UTF8_LOGIN_COMMAND
   }

--- a/src/main/pty/codex-preflight-profile-path-rewrite.test.ts
+++ b/src/main/pty/codex-preflight-profile-path-rewrite.test.ts
@@ -72,8 +72,8 @@ function launchCodexThroughRcfile(fixture: Fixture, preflightValue: string): voi
       PATH: ['/usr/bin', '/bin', '/usr/sbin', '/sbin'].join(delimiter),
       TERM: 'dumb',
       SHELL: '/bin/bash',
-      ORCA_SHELL_READY_MARKER: '0',
-      ORCA_SHELL_STARTUP_IDENTITY: '0',
+      // Why no ORCA_SHELL_FEATURES: absent means no features, so the rcfile
+      // emits neither the identity nor the readiness marker into stdout.
       ORCA_CODEX_HOME: join(fixture.root, 'codex-home'),
       ORCA_CODEX_LAUNCH_PREFLIGHT: preflightValue
     }

--- a/src/main/shell-startup-feature-channel.test.ts
+++ b/src/main/shell-startup-feature-channel.test.ts
@@ -371,8 +371,7 @@ describePosix('history-only pane in a real zsh', () => {
       env: { PATH: '/usr/bin:/bin', HOME: home }
     })
 
-    // eslint-disable-next-line no-control-regex
-    expect(wrapped).not.toMatch(/]133;/)
+    expect(wrapped).not.toContain('\x1b]133;')
     expect(wrapped).toContain('PRECMD=\n')
     expect(wrapped).toContain('LINEINIT=none')
     // Startup files run in the same order with the same hooks, so the pane is

--- a/src/main/shell-startup-feature-channel.test.ts
+++ b/src/main/shell-startup-feature-channel.test.ts
@@ -192,6 +192,85 @@ describePosix('zsh launch config', () => {
   })
 })
 
+describePosix('epilogue under hostile user shell options', () => {
+  let userDataPath = ''
+  let home = ''
+
+  beforeEach(() => {
+    userDataPath = mkdtempSync(join(tmpdir(), 'orca-feature-channel-options-'))
+    setTestUserDataPath(userDataPath)
+    home = mkdtempSync(join(tmpdir(), 'orca-feature-options-home-'))
+  })
+
+  afterEach(() => {
+    rmSync(userDataPath, { recursive: true, force: true })
+    rmSync(home, { recursive: true, force: true })
+  })
+
+  // Why these two: the epilogue is one function that runs after the user's own
+  // config, so an option that config left set applies to all of it. NO_UNSET
+  // made the prompt-hook append a fatal error that returned from the epilogue
+  // before the ready widget and the ZDOTDIR restore; KSH_ARRAYS made the
+  // 1-based feature subscript miss whichever feature is listed first.
+  it.each(['no_unset', 'ksh_arrays'])(
+    'still runs every feature when the user set %s',
+    async (option) => {
+      if (!hasZsh) {
+        return
+      }
+      const scoped = join(home, 'orca-history', 'zsh_history')
+      const opencodeDir = join(home, 'opencode-overlay')
+      writeFileSync(join(home, '.zshrc'), `setopt ${option}\n`)
+      // Why an overlay pane: KSH_ARRAYS only drops whichever feature is listed
+      // first, and `overlay` is the first token the selector ever emits.
+      const spawnEnv: Record<string, string> = {
+        HOME: home,
+        ORCA_HISTFILE: scoped,
+        ORCA_OPENCODE_CONFIG_DIR: opencodeDir
+      }
+      const features = selectShellStartupFeatures({
+        shellPath: ZSH_PATH,
+        env: spawnEnv,
+        hasStartupCommand: true,
+        waitsForShellReady: true,
+        emitsStartupIdentity: true
+      })
+      const { getShellLaunchConfig } = await importFreshLocalPtyShellReady()
+      const launch = getShellLaunchConfig(ZSH_PATH, features)
+
+      const output = execFileSync(
+        ZSH_PATH,
+        [
+          ...(launch.args ?? ['-l']),
+          '-i',
+          '-c',
+          'print -r -- "LINEINIT=${widgets[zle-line-init]:-none}"; ' +
+            'print -r -- "PRECMD=${precmd_functions[*]:-none}"; ' +
+            'print -r -- "OPENCODE=${OPENCODE_CONFIG_DIR:-none}"; ' +
+            'print -r -- "ZDOTDIR=${ZDOTDIR:-}"; print -r -- "HISTFILE=${HISTFILE:-}"'
+        ],
+        {
+          encoding: 'utf8',
+          timeout: 20_000,
+          env: {
+            PATH: '/usr/bin:/bin',
+            ...spawnEnv,
+            ...launch.env,
+            ORCA_ORIG_ZDOTDIR: home,
+            ORCA_ZSHENV_SOURCE_DIR: home
+          }
+        }
+      )
+
+      expect(output).toContain('LINEINIT=user:__orca_prompt_mark')
+      expect(output).toContain('PRECMD=__orca_osc133_precmd')
+      expect(output).toContain(`OPENCODE=${opencodeDir}`)
+      expect(output).toContain(`ZDOTDIR=${home}`)
+      expect(output).toContain(`HISTFILE=${scoped}`)
+    }
+  )
+})
+
 /** A temp HOME whose four zsh startup files each announce that they ran. */
 function makeUserHome(): string {
   const home = mkdtempSync(join(tmpdir(), 'orca-feature-home-'))

--- a/src/main/shell-startup-feature-channel.test.ts
+++ b/src/main/shell-startup-feature-channel.test.ts
@@ -1,0 +1,312 @@
+/**
+ * The feature channel's two load-bearing guarantees:
+ *
+ * 1. Leak-proof — the selection is a pure function of spawn env + launch intent,
+ *    and the variable that carries it is destroyed by the wrapper before the
+ *    user's own config runs. Neither an inherited value nor a stale one in
+ *    `process.env` can turn a feature on or off for a shell or its children.
+ *    (#15197 shipped exported switches twice and re-broke #11146 and agent
+ *    status both times.)
+ * 2. Behaviour parity — a pane wrapped only because Orca injected a worktree
+ *    HISTFILE runs exactly what an unwrapped pane runs, with no OSC 133.
+ */
+import { execFileSync, spawnSync } from 'node:child_process'
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { selectShellStartupFeatures } from './shell-startup-features'
+import { ZSH_WRAPPER_DIR_MARKER_FILE } from './shell-templates'
+import {
+  importFreshLocalPtyShellReady,
+  restoreUserDataPathAfterEach,
+  setTestUserDataPath
+} from './providers/local-pty-shell-ready-test-harness'
+
+restoreUserDataPathAfterEach()
+
+const hasZsh = process.platform !== 'win32' && spawnSync('zsh', ['--version']).status === 0
+const ZSH_PATH = hasZsh
+  ? (spawnSync('sh', ['-c', 'command -v zsh'], { encoding: 'utf8' }).stdout || '').trim()
+  : ''
+const itWithZsh = hasZsh ? it : it.skip
+const describePosix = process.platform === 'win32' ? describe.skip : describe
+
+const PLAIN_PANE = {
+  hasStartupCommand: false,
+  waitsForShellReady: false,
+  emitsStartupIdentity: false
+}
+
+describe('shell startup feature selection', () => {
+  it('ignores an inherited ORCA_SHELL_FEATURES in the spawn env', () => {
+    // Why: the value a parent shell exported is not an input. If it were, a pane
+    // opened from another pane would inherit that pane's feature set.
+    expect(
+      selectShellStartupFeatures({
+        shellPath: '/bin/zsh',
+        env: { ORCA_SHELL_FEATURES: 'overlay,markers,ready,identity,history' },
+        ...PLAIN_PANE
+      })
+    ).toEqual([])
+  })
+
+  it('cannot be turned off for a pane that needs a feature', () => {
+    // Why: the allowlist is positive only — there is no value of the variable
+    // that suppresses anything, so an inherited one can never mean "less".
+    expect(
+      selectShellStartupFeatures({
+        shellPath: '/bin/zsh',
+        env: { ORCA_SHELL_FEATURES: '', ORCA_HISTFILE: '/tmp/wt/zsh_history' },
+        ...PLAIN_PANE
+      })
+    ).toEqual(['history'])
+  })
+
+  it('gives a history-only pane no command markers', () => {
+    // Why: markers would be new output on a pane that emitted none before.
+    expect(
+      selectShellStartupFeatures({
+        shellPath: '/bin/zsh',
+        env: { ORCA_HISTFILE: '/tmp/wt/zsh_history' },
+        ...PLAIN_PANE
+      })
+    ).not.toContain('markers')
+  })
+
+  it('keeps markers on a pane that already had them', () => {
+    expect(
+      selectShellStartupFeatures({
+        shellPath: '/bin/zsh',
+        env: { ORCA_CODEX_HOME: '/tmp/codex' },
+        ...PLAIN_PANE
+      })
+    ).toContain('markers')
+  })
+
+  it('does not wrap bash for history alone', () => {
+    // Why: bash has no system rc that clobbers HISTFILE, and `--rcfile` would
+    // replace its login startup-file chain with Orca's approximation.
+    expect(
+      selectShellStartupFeatures({
+        shellPath: '/bin/bash',
+        env: { ORCA_HISTFILE: '/tmp/wt/bash_history' },
+        ...PLAIN_PANE
+      })
+    ).toEqual([])
+  })
+})
+
+describePosix('zsh launch config', () => {
+  let userDataPath = ''
+  let previousFeatures: string | undefined
+
+  beforeEach(() => {
+    userDataPath = mkdtempSync(join(tmpdir(), 'orca-feature-channel-'))
+    setTestUserDataPath(userDataPath)
+    previousFeatures = process.env.ORCA_SHELL_FEATURES
+  })
+
+  afterEach(() => {
+    if (previousFeatures === undefined) {
+      delete process.env.ORCA_SHELL_FEATURES
+    } else {
+      process.env.ORCA_SHELL_FEATURES = previousFeatures
+    }
+    chmodSync(userDataPath, 0o755)
+    rmSync(userDataPath, { recursive: true, force: true })
+  })
+
+  it('publishes exactly the selected features, whatever process.env holds', async () => {
+    process.env.ORCA_SHELL_FEATURES = 'overlay,markers,ready,identity'
+    const { getShellLaunchConfig } = await importFreshLocalPtyShellReady()
+
+    const config = getShellLaunchConfig('/bin/zsh', ['history'])
+
+    expect(config.env.ORCA_SHELL_FEATURES).toBe('history')
+  })
+
+  it('falls back to plain login zsh when the wrapper tree cannot be written', async () => {
+    // Why: pointing ZDOTDIR at an unwritten wrapper dir makes zsh skip the
+    // user's entire configuration — silently, and for every future pane.
+    chmodSync(userDataPath, 0o500)
+    if (
+      spawnSync('sh', ['-c', `touch ${JSON.stringify(join(userDataPath, 'probe'))}`]).status === 0
+    ) {
+      return // running with write access regardless of mode (e.g. root)
+    }
+    const { getShellLaunchConfig } = await importFreshLocalPtyShellReady()
+
+    const config = getShellLaunchConfig('/bin/zsh', ['history'])
+
+    expect(config).toEqual({
+      args: ['-l'],
+      env: {},
+      supportsReadyMarker: false
+    })
+  })
+
+  it('does not treat another terminal’s hijacked ZDOTDIR as the user config dir', async () => {
+    // Why: Orca can be launched from a terminal that already owns ZDOTDIR. Only
+    // a dir Orca can prove is its own, or one holding no zsh startup file at
+    // all, may be rejected — never a vendor guessed at by name.
+    const home = mkdtempSync(join(tmpdir(), 'orca-stacked-zdotdir-'))
+    const foreignWrapper = join(home, 'other-terminal', 'zsh')
+    mkdirSync(foreignWrapper, { recursive: true })
+    const previousZdotdir = process.env.ZDOTDIR
+    const previousHome = process.env.HOME
+    process.env.ZDOTDIR = foreignWrapper
+    process.env.HOME = home
+    try {
+      const { getShellLaunchConfig } = await importFreshLocalPtyShellReady()
+
+      // Empty dir: not a config root whoever wrote it.
+      expect(getShellLaunchConfig('/bin/zsh', ['history']).env.ORCA_ORIG_ZDOTDIR).toBe(home)
+
+      // Stamped as Orca-owned: rejected by positive identification, even though
+      // the path shape is not one of Orca's.
+      writeFileSync(join(foreignWrapper, '.zshrc'), '')
+      writeFileSync(join(foreignWrapper, ZSH_WRAPPER_DIR_MARKER_FILE), '')
+      const stamped = await importFreshLocalPtyShellReady()
+      expect(stamped.getShellLaunchConfig('/bin/zsh', ['history']).env.ORCA_ORIG_ZDOTDIR).toBe(home)
+
+      // A real user config dir still round-trips.
+      rmSync(join(foreignWrapper, ZSH_WRAPPER_DIR_MARKER_FILE))
+      const real = await importFreshLocalPtyShellReady()
+      expect(real.getShellLaunchConfig('/bin/zsh', ['history']).env.ORCA_ORIG_ZDOTDIR).toBe(
+        foreignWrapper
+      )
+    } finally {
+      if (previousZdotdir === undefined) {
+        delete process.env.ZDOTDIR
+      } else {
+        process.env.ZDOTDIR = previousZdotdir
+      }
+      if (previousHome === undefined) {
+        delete process.env.HOME
+      } else {
+        process.env.HOME = previousHome
+      }
+      rmSync(home, { recursive: true, force: true })
+    }
+  })
+})
+
+/** A temp HOME whose four zsh startup files each announce that they ran. */
+function makeUserHome(): string {
+  const home = mkdtempSync(join(tmpdir(), 'orca-feature-home-'))
+  for (const file of ['.zshenv', '.zprofile', '.zshrc', '.zlogin']) {
+    writeFileSync(join(home, file), `print -r -- "RAN=${file}"\n`)
+  }
+  return home
+}
+
+describePosix('history-only pane in a real zsh', () => {
+  let userDataPath = ''
+  let home = ''
+
+  beforeEach(() => {
+    userDataPath = mkdtempSync(join(tmpdir(), 'orca-feature-channel-live-'))
+    setTestUserDataPath(userDataPath)
+    home = makeUserHome()
+  })
+
+  afterEach(() => {
+    rmSync(userDataPath, { recursive: true, force: true })
+    rmSync(home, { recursive: true, force: true })
+  })
+
+  const OBSERVABLES =
+    'print -r -- "PRECMD=${precmd_functions[*]}"; ' +
+    'print -r -- "PREEXEC=${preexec_functions[*]}"; ' +
+    'print -r -- "LINEINIT=${widgets[zle-line-init]:-none}"; ' +
+    'print -r -- "ZDOTDIR=$ZDOTDIR"; ' +
+    'print -r -- "FEATURES=[${ORCA_SHELL_FEATURES:-}]"; ' +
+    'print -r -- "ORCA_HISTFILE=[${ORCA_HISTFILE:-}]"'
+
+  async function launchHistoryOnly(): Promise<{
+    args: string[]
+    env: Record<string, string>
+    zdotdir: string
+  }> {
+    const scoped = join(home, 'orca-history', 'zsh_history')
+    const spawnEnv: Record<string, string> = {
+      HOME: home,
+      HISTFILE: scoped,
+      ORCA_HISTFILE: scoped
+    }
+    const features = selectShellStartupFeatures({
+      shellPath: ZSH_PATH,
+      env: spawnEnv,
+      ...PLAIN_PANE
+    })
+    expect(features).toEqual(['history'])
+    const { getShellLaunchConfig } = await importFreshLocalPtyShellReady()
+    const launch = getShellLaunchConfig(ZSH_PATH, features)
+    return {
+      args: launch.args ?? ['-l'],
+      env: {
+        PATH: '/usr/bin:/bin',
+        ...spawnEnv,
+        ...launch.env,
+        // Why override: the launch config reads the real process env, and this
+        // run must resolve the user's config against the sandbox home.
+        ORCA_ORIG_ZDOTDIR: home,
+        ORCA_ZSHENV_SOURCE_DIR: home
+      },
+      zdotdir: launch.env.ZDOTDIR
+    }
+  }
+
+  itWithZsh('unsets the feature channel for the shell and for a grandchild', async () => {
+    const { args, env } = await launchHistoryOnly()
+
+    const output = execFileSync(
+      ZSH_PATH,
+      [
+        ...args,
+        '-i',
+        '-c',
+        `print -r -- "SELF=[\${ORCA_SHELL_FEATURES:-}]"; zsh -c 'printenv ORCA_SHELL_FEATURES; print -r -- CHILD_CLEAN'`
+      ],
+      { encoding: 'utf8', timeout: 20_000, env }
+    )
+
+    expect(output).toContain('SELF=[]')
+    expect(output).toContain('CHILD_CLEAN')
+    // A grandchild that saw the variable would have printed its value first.
+    expect(output).not.toContain('history')
+  })
+
+  itWithZsh('emits no OSC 133 and matches an unwrapped pane', async () => {
+    const { args, env } = await launchHistoryOnly()
+
+    const wrapped = execFileSync(ZSH_PATH, [...args, '-i', '-c', OBSERVABLES], {
+      encoding: 'utf8',
+      timeout: 20_000,
+      env
+    })
+    const unwrapped = execFileSync(ZSH_PATH, ['-l', '-i', '-c', OBSERVABLES], {
+      encoding: 'utf8',
+      timeout: 20_000,
+      env: { PATH: '/usr/bin:/bin', HOME: home }
+    })
+
+    // eslint-disable-next-line no-control-regex
+    expect(wrapped).not.toMatch(/]133;/)
+    expect(wrapped).toContain('PRECMD=\n')
+    expect(wrapped).toContain('LINEINIT=none')
+    // Startup files run in the same order with the same hooks, so the pane is
+    // observably what it was before it got wrapped.
+    const comparable = (output: string): string[] =>
+      output
+        .split('\n')
+        .filter((line) => !line.startsWith('ORCA_HISTFILE=') && !line.startsWith('ZDOTDIR='))
+    expect(comparable(wrapped)).toEqual(comparable(unwrapped))
+    // The one carried-over difference, unchanged from every pane Orca already
+    // wrapped: ZDOTDIR ends up explicitly set to the user's config dir, which
+    // is the value zsh itself defaults to when it is unset.
+    expect(wrapped).toContain(`ZDOTDIR=${home}`)
+    expect(unwrapped).toContain('ZDOTDIR=\n')
+  })
+})

--- a/src/main/shell-startup-features.ts
+++ b/src/main/shell-startup-features.ts
@@ -1,0 +1,95 @@
+/**
+ * The single env variable Orca uses to tell a launched shell which startup
+ * features its wrapper should turn on, plus the pure selection that fills it.
+ *
+ * Why a positive allowlist the wrapper destroys before anything else runs:
+ * every earlier switch was a negative, exported one (`ORCA_SHELL_READY_MARKER=0`,
+ * `ORCA_SHELL_COMMAND_MARKERS=0`). Those live in the pane's PTY env, so every
+ * child inherits them — a pane launched with a feature suppressed suppressed it
+ * for an Orca started from that pane too. With an allowlist, an inherited or
+ * stale value can only ever mean *fewer* features, never more, and the wrapper
+ * unsets it before the user's own config (or anything it spawns) can see it.
+ */
+
+export const SHELL_STARTUP_FEATURE_ENV = 'ORCA_SHELL_FEATURES'
+
+export const SHELL_STARTUP_FEATURES = [
+  'overlay',
+  'history',
+  'markers',
+  'ready',
+  'identity'
+] as const
+
+export type ShellStartupFeature = (typeof SHELL_STARTUP_FEATURES)[number]
+
+/** Spawn-env keys that mean this pane carries an Orca overlay the wrapper must re-apply. */
+const OVERLAY_ENV_KEYS = [
+  'ORCA_OPENCODE_CONFIG_DIR',
+  'ORCA_MIMOCODE_HOME',
+  'ORCA_OMP_STATUS_EXTENSION',
+  'ORCA_CODEX_HOME',
+  'ORCA_AGENT_TEAMS_SHIM_DIR',
+  'ORCA_REMOTE_CLI_BIN_DIR'
+] as const
+
+export type ShellStartupFeatureInput = {
+  /** Path (or bare name) of the shell being launched. */
+  shellPath: string
+  /** The env this spawn will hand the shell — never `process.env`. */
+  env: Record<string, string | undefined>
+  /** True when Orca will deliver a startup command into this pane. */
+  hasStartupCommand: boolean
+  /** True when that delivery waits for the wrapper's OSC 777 readiness marker. */
+  waitsForShellReady: boolean
+  /** True when Orca needs the shell to announce its PID at startup. */
+  emitsStartupIdentity: boolean
+}
+
+function shellName(shellPath: string): string {
+  return shellPath.replace(/\\/g, '/').split('/').pop()?.toLowerCase() ?? ''
+}
+
+/**
+ * Pure function of spawn env + launch intent. Nothing here reads
+ * `ORCA_SHELL_FEATURES`, so a value inherited from a parent shell cannot
+ * enable or disable anything for the shell Orca is about to launch.
+ */
+export function selectShellStartupFeatures(input: ShellStartupFeatureInput): ShellStartupFeature[] {
+  const overlay = OVERLAY_ENV_KEYS.some((key) => Boolean(input.env[key]))
+  // Exactly the panes Orca wrapped before history widened wrapping.
+  const wrappedBefore = overlay || input.hasStartupCommand
+  const ready = input.waitsForShellReady
+  // Why zsh only: the unguarded HISTFILE assignment lives in the *system zshrc*.
+  // bash has no equivalent, and wrapping bash for history alone would swap its
+  // login startup-file chain for Orca's approximation of one.
+  // Why also when Orca injected nothing: any wrapped pane has Orca's ZDOTDIR in
+  // place while the system zshrc runs, so the clobbered value it derives lands
+  // inside Orca's wrapper dir and has to be repaired the same way.
+  const history =
+    shellName(input.shellPath) === 'zsh' && (Boolean(input.env.ORCA_HISTFILE) || wrappedBefore)
+
+  const features: ShellStartupFeature[] = []
+  if (overlay) {
+    features.push('overlay')
+  }
+  if (history) {
+    features.push('history')
+  }
+  // Why gated on wrappedBefore: a pane wrapped only for history must stay
+  // observably identical to the unwrapped pane it was before this change.
+  if (wrappedBefore) {
+    features.push('markers')
+  }
+  if (ready) {
+    features.push('ready')
+  }
+  if (input.emitsStartupIdentity) {
+    features.push('identity')
+  }
+  return features
+}
+
+export function encodeShellStartupFeatures(features: readonly ShellStartupFeature[]): string {
+  return features.join(',')
+}

--- a/src/main/shell-startup-launch-intent-fixtures.ts
+++ b/src/main/shell-startup-launch-intent-fixtures.ts
@@ -1,0 +1,25 @@
+/**
+ * The two launch intents Orca's call sites choose between, resolved through the
+ * real selector so tests cannot drift from the decision production makes.
+ *
+ * Test support only; nothing under src/main imports this at runtime.
+ */
+import { selectShellStartupFeatures } from './shell-startup-features'
+
+/** A pane Orca will write a startup command into. */
+export const STARTUP_COMMAND_FEATURES = selectShellStartupFeatures({
+  shellPath: 'zsh',
+  env: {},
+  hasStartupCommand: true,
+  waitsForShellReady: true,
+  emitsStartupIdentity: true
+})
+
+/** A pane carrying an Orca overlay but no startup command. */
+export const OVERLAY_ONLY_FEATURES = selectShellStartupFeatures({
+  shellPath: 'zsh',
+  env: { ORCA_CODEX_HOME: '/tmp/orca-codex-home' },
+  hasStartupCommand: false,
+  waitsForShellReady: false,
+  emitsStartupIdentity: false
+})

--- a/src/main/shell-templates.ts
+++ b/src/main/shell-templates.ts
@@ -45,6 +45,12 @@ export const SHELL_STARTUP_IDENTITY_MARKER_BLOCK = `__orca_has_feature identity 
  * its own. A stamped marker file (or Orca's own wrapper path shape, for
  * wrappers written by older builds) is that proof. Guessing at other
  * terminals' wrapper dirs by name never can be, so this never tries.
+ *
+ * Why every generated file redefines it instead of relying on .zshenv: one
+ * wrapper dir can be rewritten by two concurrently installed builds, so a shell
+ * can read one build's .zshenv and another's .zshrc. A .zshrc that called a
+ * function only the newer .zshenv defines printed `command not found` AND left
+ * $REPLY empty, which skipped sourcing the user's own startup file entirely.
  */
 export const ZSH_USER_CONFIG_DIR_RESOLVER_BLOCK = `__orca_resolve_user_config_dir() {
   REPLY="\${1:-}"
@@ -52,8 +58,15 @@ export const ZSH_USER_CONFIG_DIR_RESOLVER_BLOCK = `__orca_resolve_user_config_di
   if [[ -z "$REPLY" || -f "$REPLY/${ZSH_WRAPPER_DIR_MARKER_FILE}" || "$REPLY" == */shell-ready/zsh ]]; then
     REPLY="$HOME"
   fi
-}
-# Why stricter for an inherited value: Orca can be launched from a terminal that
+}`
+
+/**
+ * The stricter resolver .zshenv uses for a ZDOTDIR this shell INHERITED.
+ *
+ * Why only .zshenv needs it: nothing after .zshenv re-reads an inherited value —
+ * the later files resolve ORCA_ORIG_ZDOTDIR, which .zshenv already vetted.
+ */
+export const ZSH_INHERITED_CONFIG_DIR_RESOLVER_BLOCK = `# Why stricter for an inherited value: Orca can be launched from a terminal that
 # already pointed ZDOTDIR at its own wrapper dir, and a directory holding no zsh
 # startup file at all is not the user's config root whoever wrote it.
 __orca_resolve_inherited_config_dir() {

--- a/src/main/shell-templates.ts
+++ b/src/main/shell-templates.ts
@@ -50,13 +50,24 @@ export const SHELL_STARTUP_IDENTITY_MARKER_BLOCK = `__orca_has_feature identity 
  * wrapper dir can be rewritten by two concurrently installed builds, so a shell
  * can read one build's .zshenv and another's .zshrc. A .zshrc that called a
  * function only the newer .zshenv defines printed `command not found` AND left
- * $REPLY empty, which skipped sourcing the user's own startup file entirely.
+ * the out-parameter empty, which skipped sourcing the user's own startup file.
+ *
+ * Why an Orca-private out-parameter and not `REPLY`: `REPLY` is zsh's shared
+ * scratch global, so a user config is entitled to constrain it. `typeset -r
+ * REPLY` made the very first assignment a fatal error and aborted the wrapper
+ * file; `typeset -i REPLY` silently turned every resolved path into `0`. Both
+ * left HISTFILE inside Orca's wrapper dir. Harmless while Orca wrapped a few
+ * percent of panes; not harmless now that it wraps every zsh pane.
+ *
+ * Why `typeset -g`: .zshrc/.zlogin call this AFTER the user's own config, so
+ * creating a plain global inside a function would print a warning per call
+ * under `setopt warn_create_global`.
  */
 export const ZSH_USER_CONFIG_DIR_RESOLVER_BLOCK = `__orca_resolve_user_config_dir() {
-  REPLY="\${1:-}"
-  while [[ "$REPLY" == */ ]]; do REPLY="\${REPLY%/}"; done
-  if [[ -z "$REPLY" || -f "$REPLY/${ZSH_WRAPPER_DIR_MARKER_FILE}" || "$REPLY" == */shell-ready/zsh ]]; then
-    REPLY="$HOME"
+  typeset -g _orca_resolved_config_dir="\${1:-}"
+  while [[ "$_orca_resolved_config_dir" == */ ]]; do _orca_resolved_config_dir="\${_orca_resolved_config_dir%/}"; done
+  if [[ -z "$_orca_resolved_config_dir" || -f "$_orca_resolved_config_dir/${ZSH_WRAPPER_DIR_MARKER_FILE}" || "$_orca_resolved_config_dir" == */shell-ready/zsh ]]; then
+    _orca_resolved_config_dir="$HOME"
   fi
 }`
 
@@ -71,16 +82,60 @@ export const ZSH_INHERITED_CONFIG_DIR_RESOLVER_BLOCK = `# Why stricter for an in
 # startup file at all is not the user's config root whoever wrote it.
 __orca_resolve_inherited_config_dir() {
   __orca_resolve_user_config_dir "\${1:-}"
-  [[ "$REPLY" == "$HOME" ]] && return 0
+  [[ "$_orca_resolved_config_dir" == "$HOME" ]] && return 0
   local _orca_startup_file
   for _orca_startup_file in .zshenv .zshrc .zprofile .zlogin; do
-    [[ -r "$REPLY/$_orca_startup_file" ]] && return 0
+    [[ -r "$_orca_resolved_config_dir/$_orca_startup_file" ]] && return 0
   done
-  REPLY="$HOME"
+  _orca_resolved_config_dir="$HOME"
 }`
 
 // Why: daemon, local, and relay wrappers must preserve one Bash prompt-hook contract.
 export { BASH_PROMPT_COMMAND_COMPOSITION_BLOCK } from './bash-prompt-command-composition'
+
+/**
+ * Hands the pane back to the user unwrapped when zsh has entered sh/ksh
+ * emulation, and stops reading the rest of the current wrapper file.
+ *
+ * Why: zsh's `sourcehome()` ignores ZDOTDIR entirely once the shell is in sh or
+ * ksh emulation, so a user .zshenv (or .zprofile) ending in `emulate sh` means
+ * NO later wrapper file is ever read — the epilogue runs zero times, while the
+ * user's own $HOME startup files load normally. The pane looks fine and writes
+ * its history inside Orca's wrapper dir, where the user will never find it.
+ *
+ * Nothing can repair that from here (`/etc/zshrc` assigns HISTFILE after
+ * .zshenv and .zprofile both), so the wrapper does the next best thing: it
+ * restores the user's own ZDOTDIR and consumes Orca's variables, leaving
+ * exactly the shell an unwrapped pane would have produced. Degrading to the
+ * pre-wrapping behaviour is the bar; degrading to something worse is not.
+ *
+ * Why a positive `sh|ksh` match rather than `!= zsh`: a zsh too old for the
+ * query form of `emulate` prints nothing, and must not unwrap every pane.
+ *
+ * Why `sourcedUserFileTest` gates the probe rather than it running
+ * unconditionally: `$(emulate)` forks, and every zsh pane now pays for it. The
+ * gate loses no coverage — this wrapper file is itself read through ZDOTDIR, so
+ * anything that had already entered emulation (a system /etc/zshenv or
+ * /etc/zprofile) would have hidden this very file too. The only thing that can
+ * have entered emulation by this line is the user file this file just sourced.
+ */
+export function getZshEmulationDegradeBlock(options: {
+  userZdotdirExpression: string
+  sourcedUserFileTest: string
+}): string {
+  return `if [[ ${options.sourcedUserFileTest} ]]; then
+  case "$(emulate 2>/dev/null)" in
+    sh|ksh)
+      export ZDOTDIR=${options.userZdotdirExpression}
+      # Why unset: an ORCA_HISTFILE no wrapper file will ever consume is
+      # inherited by everything this pane spawns, including a nested Orca.
+      builtin unset ORCA_HISTFILE _orca_shell_features _orca_home _orca_resolved_config_dir _orca_wrapper_zdotdir_self
+      unfunction __orca_shell_epilogue __orca_has_feature __orca_resolve_user_config_dir __orca_resolve_inherited_config_dir 2>/dev/null
+      return 0
+      ;;
+  esac
+fi`
+}
 
 /** The ZDOTDIR-discovery body of the wrapper .zshenv (no header, no epilogue). */
 export function getZshEnvDiscoveryBody(zshDir: string): string {
@@ -106,9 +161,9 @@ _orca_zshenv_path=""
 # Normalize fallback and source roots before reading user .zshenv so nested
 # Orca PTYs never source another Orca wrapper recursively.
 __orca_resolve_inherited_config_dir "\${ORCA_ORIG_ZDOTDIR:-$HOME}"
-_orca_user_zdotdir="$REPLY"
+_orca_user_zdotdir="$_orca_resolved_config_dir"
 __orca_resolve_inherited_config_dir "\${ORCA_ZSHENV_SOURCE_DIR:-$HOME}"
-_orca_zshenv_source_dir="$REPLY"
+_orca_zshenv_source_dir="$_orca_resolved_config_dir"
 unset ORCA_ZSHENV_SOURCE_DIR
 
 # Why: source at wrapper top level, not in a function/subshell, so .zshenv
@@ -140,7 +195,14 @@ fi
 # Why only the ownership check here: a ZDOTDIR the user's own .zshenv just
 # exported is the user's by construction, whatever it happens to contain.
 __orca_resolve_user_config_dir "\${_orca_discovered_zdotdir:-\${_orca_user_zdotdir:-$HOME}}"
-export ORCA_ORIG_ZDOTDIR="$REPLY"
+export ORCA_ORIG_ZDOTDIR="$_orca_resolved_config_dir"
+unset _orca_user_zdotdir _orca_zshenv_source_dir _orca_discovered_zdotdir
+
+${getZshEmulationDegradeBlock({
+  userZdotdirExpression: '"$ORCA_ORIG_ZDOTDIR"',
+  sourcedUserFileTest: '-n "${_orca_zshenv_path:-}"'
+})}
+unset _orca_zshenv_path
 
 # Why: use :- after user .zshenv — a pathological unset under set -u must not
 # abort the wrapper; empty falls through to the baked-literal branch.
@@ -149,7 +211,7 @@ if [[ -n "\${_orca_wrapper_zdotdir_self:-}" && -f "\${_orca_wrapper_zdotdir_self
 else
   export ZDOTDIR=${quotePosixSingle(zshDir)}
 fi
-unset _orca_user_zdotdir _orca_zshenv_source_dir _orca_zshenv_path _orca_discovered_zdotdir _orca_wrapper_zdotdir_self
+unset _orca_wrapper_zdotdir_self
 `
 }
 
@@ -163,10 +225,16 @@ unset _orca_user_zdotdir _orca_zshenv_source_dir _orca_zshenv_path _orca_discove
  */
 export function getZshOverlayEnvBody(zshDir: string): string {
   return `__orca_resolve_inherited_config_dir "\${ORCA_ORIG_ZDOTDIR:-$HOME}"
-export ORCA_ORIG_ZDOTDIR="$REPLY"
+export ORCA_ORIG_ZDOTDIR="$_orca_resolved_config_dir"
 [[ -f "$ORCA_ORIG_ZDOTDIR/.zshenv" ]] && source "$ORCA_ORIG_ZDOTDIR/.zshenv"
 __orca_resolve_user_config_dir "\${ZDOTDIR:-\${ORCA_ORIG_ZDOTDIR:-$HOME}}"
-export ORCA_USER_ZDOTDIR="$REPLY"
+export ORCA_USER_ZDOTDIR="$_orca_resolved_config_dir"
+
+${getZshEmulationDegradeBlock({
+  userZdotdirExpression: '"$ORCA_USER_ZDOTDIR"',
+  sourcedUserFileTest: '-f "$ORCA_ORIG_ZDOTDIR/.zshenv"'
+})}
+
 export ZDOTDIR=${quotePosixSingle(zshDir)}
 `
 }
@@ -210,7 +278,7 @@ export function getZshStartupFileSourceBlock(options: {
   ].filter(Boolean)
 
   return `__orca_resolve_user_config_dir ${homeExpression}
-_orca_home="$REPLY"
+_orca_home="$_orca_resolved_config_dir"
 if [[ ${checks.join(' && ')} ]]; then
   _orca_wrapper_zdotdir="$ZDOTDIR"
   # Why: user startup files resolve plugin/config paths from their own ZDOTDIR;
@@ -277,7 +345,7 @@ export function getZshFinalZdotdirRestoreBlock(homeExpression = '"${ORCA_ORIG_ZD
   return `__orca_resolve_user_config_dir ${homeExpression}
 # Why: after Orca's last wrapper file has loaded, the interactive shell should
 # expose the same ZDOTDIR a normal zsh startup would expose.
-export ZDOTDIR="$REPLY"
-unset _orca_home REPLY
+export ZDOTDIR="$_orca_resolved_config_dir"
+unset _orca_home _orca_resolved_config_dir
 `
 }

--- a/src/main/shell-templates.ts
+++ b/src/main/shell-templates.ts
@@ -1,24 +1,77 @@
 // Why: local PTYs and the daemon/SSH path must use identical ZDOTDIR discovery;
 // small drift here breaks different terminal transports in different ways.
+import { SHELL_STARTUP_FEATURE_ENV } from './shell-startup-features'
 
 function quotePosixSingle(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`
 }
 
-export const SHELL_STARTUP_IDENTITY_MARKER_BLOCK = `if [[ "\${ORCA_SHELL_STARTUP_IDENTITY:-0}" == "1" ]]; then
-  unset ORCA_SHELL_STARTUP_IDENTITY
-  printf "\\033]777;orca-shell-start:%s\\007" "$$"
-fi`
+/** Basename of the file every Orca-generated zsh wrapper dir is stamped with. */
+export const ZSH_WRAPPER_DIR_MARKER_FILE = '.orca-shell-wrapper'
+
+export const ZSH_WRAPPER_DIR_MARKER_CONTENT = `# Orca-generated zsh startup wrapper directory.
+# Its presence is how Orca recognises its own wrapper dir instead of treating it
+# as the user's ZDOTDIR. Do not edit; the whole directory is regenerated.
+`
+
+/**
+ * The first executable lines of every zsh wrapper: read the feature allowlist,
+ * then destroy the variable.
+ *
+ * Why destroy it here: `_orca_shell_features` is a plain (non-exported) shell
+ * variable, so it survives .zshenv -> .zprofile -> .zshrc -> .zlogin in this
+ * process but physically cannot reach a child. Unsetting before the user's own
+ * .zshenv is sourced means nothing the user's config spawns can see or inherit
+ * Orca's feature selection.
+ */
+export const ZSH_FEATURE_CHANNEL_BLOCK = `typeset -ga _orca_shell_features
+_orca_shell_features=(\${(s:,:)\${${SHELL_STARTUP_FEATURE_ENV}:-}})
+builtin unset ${SHELL_STARTUP_FEATURE_ENV}
+__orca_has_feature() { (( \${_orca_shell_features[(Ie)$1]} )) }`
+
+/** The bash rcfile equivalent of ZSH_FEATURE_CHANNEL_BLOCK. */
+export const BASH_FEATURE_CHANNEL_BLOCK = `_orca_shell_features=",\${${SHELL_STARTUP_FEATURE_ENV}:-},"
+builtin unset ${SHELL_STARTUP_FEATURE_ENV}
+__orca_has_feature() { [[ "$_orca_shell_features" == *",$1,"* ]]; }`
+
+// Why one line usable by both languages: __orca_has_feature is defined with the
+// same name and semantics in the zsh and bash channel blocks above.
+export const SHELL_STARTUP_IDENTITY_MARKER_BLOCK = `__orca_has_feature identity && printf "\\033]777;orca-shell-start:%s\\007" "$$"`
+
+/**
+ * Resolves the directory Orca should treat as the user's zsh config root.
+ *
+ * Why positive identification: Orca may only reject a config dir it can prove is
+ * its own. A stamped marker file (or Orca's own wrapper path shape, for
+ * wrappers written by older builds) is that proof. Guessing at other
+ * terminals' wrapper dirs by name never can be, so this never tries.
+ */
+export const ZSH_USER_CONFIG_DIR_RESOLVER_BLOCK = `__orca_resolve_user_config_dir() {
+  REPLY="\${1:-}"
+  while [[ "$REPLY" == */ ]]; do REPLY="\${REPLY%/}"; done
+  if [[ -z "$REPLY" || -f "$REPLY/${ZSH_WRAPPER_DIR_MARKER_FILE}" || "$REPLY" == */shell-ready/zsh ]]; then
+    REPLY="$HOME"
+  fi
+}
+# Why stricter for an inherited value: Orca can be launched from a terminal that
+# already pointed ZDOTDIR at its own wrapper dir, and a directory holding no zsh
+# startup file at all is not the user's config root whoever wrote it.
+__orca_resolve_inherited_config_dir() {
+  __orca_resolve_user_config_dir "\${1:-}"
+  [[ "$REPLY" == "$HOME" ]] && return 0
+  local _orca_startup_file
+  for _orca_startup_file in .zshenv .zshrc .zprofile .zlogin; do
+    [[ -r "$REPLY/$_orca_startup_file" ]] && return 0
+  done
+  REPLY="$HOME"
+}`
 
 // Why: daemon, local, and relay wrappers must preserve one Bash prompt-hook contract.
 export { BASH_PROMPT_COMMAND_COMPOSITION_BLOCK } from './bash-prompt-command-composition'
-export function getZshEnvTemplate(
-  zshDir: string,
-  headerLabel = 'Orca zsh shell-ready wrapper'
-): string {
-  return `# ${headerLabel}
-${SHELL_STARTUP_IDENTITY_MARKER_BLOCK}
-# Why: capture the runtime wrapper dir before it is unset below. On WSL this
+
+/** The ZDOTDIR-discovery body of the wrapper .zshenv (no header, no epilogue). */
+export function getZshEnvDiscoveryBody(zshDir: string): string {
+  return `# Why: capture the runtime wrapper dir before it is unset below. On WSL this
 # file is generated with a Windows path but sourced via /mnt/c, so the baked
 # literal is unusable there and ZDOTDIR must be restored from this value.
 # Derive it from the file being sourced (%x, zsh's internal script name) rather
@@ -35,26 +88,15 @@ fi
 while [[ "\${_orca_wrapper_zdotdir_self:-}" == */ ]]; do
   _orca_wrapper_zdotdir_self="\${_orca_wrapper_zdotdir_self%/}"
 done
-_orca_spawn_orig_zdotdir="\${ORCA_ORIG_ZDOTDIR:-}"
-_orca_user_zdotdir="\${_orca_spawn_orig_zdotdir:-$HOME}"
-_orca_zshenv_source_dir="\${ORCA_ZSHENV_SOURCE_DIR:-$HOME}"
 _orca_zshenv_path=""
-unset ORCA_ZSHENV_SOURCE_DIR
 
 # Normalize fallback and source roots before reading user .zshenv so nested
 # Orca PTYs never source another Orca wrapper recursively.
-while [[ "\${_orca_user_zdotdir}" == */ ]]; do
-  _orca_user_zdotdir="\${_orca_user_zdotdir%/}"
-done
-case "\${_orca_user_zdotdir}" in
-  ""|*/shell-ready/zsh) _orca_user_zdotdir="$HOME" ;;
-esac
-while [[ "\${_orca_zshenv_source_dir}" == */ ]]; do
-  _orca_zshenv_source_dir="\${_orca_zshenv_source_dir%/}"
-done
-case "\${_orca_zshenv_source_dir}" in
-  ""|*/shell-ready/zsh) _orca_zshenv_source_dir="$HOME" ;;
-esac
+__orca_resolve_inherited_config_dir "\${ORCA_ORIG_ZDOTDIR:-$HOME}"
+_orca_user_zdotdir="$REPLY"
+__orca_resolve_inherited_config_dir "\${ORCA_ZSHENV_SOURCE_DIR:-$HOME}"
+_orca_zshenv_source_dir="$REPLY"
+unset ORCA_ZSHENV_SOURCE_DIR
 
 # Why: source at wrapper top level, not in a function/subshell, so .zshenv
 # exports, functions, path/fpath typesets, and zsh options keep normal scope.
@@ -82,15 +124,10 @@ if [[ -n "\${_orca_discovered_zdotdir}" && ! -d "\${_orca_discovered_zdotdir}" ]
   _orca_discovered_zdotdir=""
 fi
 
-export ORCA_ORIG_ZDOTDIR="\${_orca_discovered_zdotdir:-\${_orca_user_zdotdir:-$HOME}}"
-
-while [[ "\${ORCA_ORIG_ZDOTDIR}" == */ ]]; do
-  ORCA_ORIG_ZDOTDIR="\${ORCA_ORIG_ZDOTDIR%/}"
-done
-
-case "\${ORCA_ORIG_ZDOTDIR}" in
-  ""|*/shell-ready/zsh) export ORCA_ORIG_ZDOTDIR="$HOME" ;;
-esac
+# Why only the ownership check here: a ZDOTDIR the user's own .zshenv just
+# exported is the user's by construction, whatever it happens to contain.
+__orca_resolve_user_config_dir "\${_orca_discovered_zdotdir:-\${_orca_user_zdotdir:-$HOME}}"
+export ORCA_ORIG_ZDOTDIR="$REPLY"
 
 # Why: use :- after user .zshenv — a pathological unset under set -u must not
 # abort the wrapper; empty falls through to the baked-literal branch.
@@ -99,30 +136,24 @@ if [[ -n "\${_orca_wrapper_zdotdir_self:-}" && -f "\${_orca_wrapper_zdotdir_self
 else
   export ZDOTDIR=${quotePosixSingle(zshDir)}
 fi
-unset _orca_spawn_orig_zdotdir _orca_user_zdotdir _orca_zshenv_source_dir _orca_zshenv_path _orca_discovered_zdotdir _orca_wrapper_zdotdir_self
+unset _orca_user_zdotdir _orca_zshenv_source_dir _orca_zshenv_path _orca_discovered_zdotdir _orca_wrapper_zdotdir_self
 `
 }
 
 /**
- * The relay variant of the .zshenv above: it trusts the ZDOTDIR the remote
+ * The relay variant of the discovery body: it trusts the ZDOTDIR the remote
  * shell already inherited instead of re-deriving one, and republishes it as
  * ORCA_USER_ZDOTDIR for the later wrapper files.
  *
  * Why separate: this diverged from the discovery template before unification
- * and is preserved verbatim here — reconciling the two is a follow-up.
+ * and is preserved here — reconciling the two is a follow-up.
  */
-export function getZshOverlayEnvTemplate(zshDir: string, headerLabel: string): string {
-  return `# ${headerLabel}
-${SHELL_STARTUP_IDENTITY_MARKER_BLOCK}
-export ORCA_ORIG_ZDOTDIR="\${ORCA_ORIG_ZDOTDIR:-$HOME}"
-case "\${ORCA_ORIG_ZDOTDIR%/}" in
-  */shell-ready/zsh) export ORCA_ORIG_ZDOTDIR="$HOME" ;;
-esac
+export function getZshOverlayEnvBody(zshDir: string): string {
+  return `__orca_resolve_inherited_config_dir "\${ORCA_ORIG_ZDOTDIR:-$HOME}"
+export ORCA_ORIG_ZDOTDIR="$REPLY"
 [[ -f "$ORCA_ORIG_ZDOTDIR/.zshenv" ]] && source "$ORCA_ORIG_ZDOTDIR/.zshenv"
-export ORCA_USER_ZDOTDIR="\${ZDOTDIR:-\${ORCA_ORIG_ZDOTDIR:-$HOME}}"
-case "\${ORCA_USER_ZDOTDIR%/}" in
-  */shell-ready/zsh) export ORCA_USER_ZDOTDIR="$HOME" ;;
-esac
+__orca_resolve_user_config_dir "\${ZDOTDIR:-\${ORCA_ORIG_ZDOTDIR:-$HOME}}"
+export ORCA_USER_ZDOTDIR="$REPLY"
 export ZDOTDIR=${quotePosixSingle(zshDir)}
 `
 }
@@ -136,11 +167,13 @@ export ZDOTDIR=${quotePosixSingle(zshDir)}
  * wrapper dir the replacement lands INSIDE it. Per-worktree history was a
  * silent no-op on the primary platform as a result (#11044).
  *
- * Emitted after the user's own startup file has been sourced, so it is the last
- * word, exactly like the CODEX_HOME/OPENCODE_CONFIG_DIR restores beside it.
+ * `builtin unset ORCA_HISTFILE` is the root-cause fix for #11146: the variable
+ * cannot be inherited by anything the shell later spawns if it no longer exists
+ * once it has been consumed. HISTFILE itself stays exported.
  */
 export const ZSH_HISTFILE_RESTORE_BLOCK = `if [[ -n "\${ORCA_HISTFILE:-}" ]]; then
   HISTFILE="$ORCA_HISTFILE"
+  builtin unset ORCA_HISTFILE
 elif [[ "\${HISTFILE:-}" == "$ZDOTDIR/.zsh_history" ]]; then
   # Why also when Orca injected nothing: /etc/zshrc derived this from Orca's
   # wrapper ZDOTDIR, so history would accumulate INSIDE the wrapper dir and the
@@ -163,10 +196,8 @@ export function getZshStartupFileSourceBlock(options: {
     `-f "$_orca_home/${options.fileName}"`
   ].filter(Boolean)
 
-  return `_orca_home=${homeExpression}
-case "\${_orca_home%/}" in
-  */shell-ready/zsh) _orca_home="$HOME" ;;
-esac
+  return `__orca_resolve_user_config_dir ${homeExpression}
+_orca_home="$REPLY"
 if [[ ${checks.join(' && ')} ]]; then
   _orca_wrapper_zdotdir="$ZDOTDIR"
   # Why: user startup files resolve plugin/config paths from their own ZDOTDIR;
@@ -188,31 +219,28 @@ fi
 // startup command on the pre-ready timeout. Instead, own zle-line-init: emit
 // the marker first, then chain to whatever widget was installed before.
 export function getZshShellReadyMarkerRegistrationBlock(escapedMarker: string): string {
-  return `if [[ "\${ORCA_SHELL_READY_MARKER:-0}" == "1" ]]; then
-  # Why: capture the prior zle-line-init so the marker chains to it. On a
-  # re-source we are already the bound widget, so keep the function captured
-  # the first time instead of clobbering it to empty (which would silently
-  # drop the user's widget on every prompt after the second source). Only
-  # user-defined widgets are chainable as plain functions; builtin/completion
-  # forms (rare for zle-line-init) are left unchained.
-  if [[ "\${widgets[zle-line-init]:-}" == "user:__orca_prompt_mark" ]]; then
-    :
-  elif (( \${+widgets[zle-line-init]} )) && [[ "\${widgets[zle-line-init]}" == user:* ]]; then
-    __orca_prev_line_init_fn="\${widgets[zle-line-init]#user:}"
-  else
-    __orca_prev_line_init_fn=""
-  fi
-  __orca_prompt_mark() {
-    printf "${escapedMarker}"
-    # Why: call the prior hook as a plain function, not an aliased widget, so
-    # $WIDGET stays zle-line-init for add-zle-hook-widget dispatchers.
-    if [[ -n "\${__orca_prev_line_init_fn:-}" ]]; then
-      "\${__orca_prev_line_init_fn}" "$@"
-    fi
-  }
-  zle -N zle-line-init __orca_prompt_mark
+  return `# Why: capture the prior zle-line-init so the marker chains to it. On a
+# re-source we are already the bound widget, so keep the function captured
+# the first time instead of clobbering it to empty (which would silently
+# drop the user's widget on every prompt after the second source). Only
+# user-defined widgets are chainable as plain functions; builtin/completion
+# forms (rare for zle-line-init) are left unchained.
+if [[ "\${widgets[zle-line-init]:-}" == "user:__orca_prompt_mark" ]]; then
+  :
+elif (( \${+widgets[zle-line-init]} )) && [[ "\${widgets[zle-line-init]}" == user:* ]]; then
+  __orca_prev_line_init_fn="\${widgets[zle-line-init]#user:}"
+else
+  __orca_prev_line_init_fn=""
 fi
-`
+__orca_prompt_mark() {
+  printf "${escapedMarker}"
+  # Why: call the prior hook as a plain function, not an aliased widget, so
+  # $WIDGET stays zle-line-init for add-zle-hook-widget dispatchers.
+  if [[ -n "\${__orca_prev_line_init_fn:-}" ]]; then
+    "\${__orca_prev_line_init_fn}" "$@"
+  fi
+}
+zle -N zle-line-init __orca_prompt_mark`
 }
 
 // Why: fish has no ZDOTDIR-style wrapper dir, so the marker rides `--init-command`,
@@ -222,23 +250,21 @@ fi
 // just *before* fish arms `?2004h`, which PostReadyFlushGate absorbs. `builtin
 // printf` so a user-defined printf can't silently swallow the marker and send
 // every launch to the ready timeout.
+//
+// Why no feature variable: the init command is composed per pane, so the
+// selection is already baked into the text and nothing needs to be exported.
 export function getFishShellReadyInitCommand(escapedMarker: string): string {
-  return `if test "$ORCA_SHELL_READY_MARKER" = 1
-  function __orca_shell_ready_marker --on-event fish_prompt
-    builtin printf "${escapedMarker}"
-    functions -e __orca_shell_ready_marker
-  end
+  return `function __orca_shell_ready_marker --on-event fish_prompt
+  builtin printf "${escapedMarker}"
+  functions -e __orca_shell_ready_marker
 end`
 }
 
 export function getZshFinalZdotdirRestoreBlock(homeExpression = '"${ORCA_ORIG_ZDOTDIR:-$HOME}"') {
-  return `_orca_home=${homeExpression}
-case "\${_orca_home%/}" in
-  */shell-ready/zsh) _orca_home="$HOME" ;;
-esac
+  return `__orca_resolve_user_config_dir ${homeExpression}
 # Why: after Orca's last wrapper file has loaded, the interactive shell should
 # expose the same ZDOTDIR a normal zsh startup would expose.
-export ZDOTDIR="$_orca_home"
-unset _orca_home
+export ZDOTDIR="$REPLY"
+unset _orca_home REPLY
 `
 }

--- a/src/main/shell-wrapper-file-writer.ts
+++ b/src/main/shell-wrapper-file-writer.ts
@@ -1,0 +1,44 @@
+/**
+ * Writes a generated shell wrapper tree atomically, and says whether it worked.
+ *
+ * Why the boolean matters: the launch config points ZDOTDIR at the wrapper dir.
+ * If a write failed — read-only FS, full disk, EACCES — the old code still
+ * pointed ZDOTDIR at that dir, so zsh found no .zshrc there and the user
+ * silently lost their entire configuration. Callers use the result to fall back
+ * to an unwrapped shell instead.
+ */
+import { chmodSync, mkdirSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import { dirname } from 'node:path'
+
+export type ShellWrapperFile = readonly [path: string, content: string]
+
+export function writeShellWrapperFiles(
+  files: readonly ShellWrapperFile[],
+  logPrefix: string
+): boolean {
+  try {
+    for (const [path, content] of files) {
+      mkdirSync(dirname(path), { recursive: true })
+      // Why temp+rename: a shell reading the wrapper concurrently sees either
+      // the old file or the new one, never a truncated prefix of the new one.
+      const temporaryPath = `${path}.orca-tmp-${process.pid}`
+      try {
+        writeFileSync(temporaryPath, content, 'utf8')
+        chmodSync(temporaryPath, 0o644)
+        renameSync(temporaryPath, path)
+      } catch (error) {
+        rmSync(temporaryPath, { force: true })
+        throw error
+      }
+    }
+    return true
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error
+        ? `${error.message} (${(error as NodeJS.ErrnoException).code || 'unknown'})`
+        : String(error)
+    console.error(`${logPrefix} Failed to write shell wrapper files: ${errorMessage}`)
+    console.error(`${logPrefix} Shell will launch unwrapped`)
+    return false
+  }
+}

--- a/src/main/shell-wrapper-generated-file-snapshot.test.ts
+++ b/src/main/shell-wrapper-generated-file-snapshot.test.ts
@@ -52,6 +52,49 @@ async function expectWrapperFiles(transport: string, root: string): Promise<void
   }
 }
 
+/**
+ * Every shell name the wrapper is allowed to write that is not Orca-namespaced.
+ *
+ * Each is a deliberate contract with the shell or with Orca's own features, not
+ * scratch space: the history path, the config dir, the two PATH-shaped exports
+ * agent overlays need, and the prompt-hook arrays the readiness and OSC 133
+ * markers register through.
+ */
+const CONTRACT_GLOBALS = new Set([
+  'CODEX_HOME',
+  'HISTFILE',
+  'MIMOCODE_HOME',
+  'OPENCODE_CONFIG_DIR',
+  'PATH',
+  'PROMPT_COMMAND',
+  'ZDOTDIR',
+  'precmd_functions',
+  'preexec_functions'
+])
+
+// `local`/`local -a` declarations are function-scoped and cannot collide.
+const LINE_START_ASSIGNMENT =
+  /^[ \t]*(?:builtin[ \t]+)?(?:export[ \t]+|typeset[ \t]+-[a-zA-Z]+[ \t]+|declare[ \t]+-[a-zA-Z]+[ \t]+)?([A-Za-z_][A-Za-z0-9_]*)\+?=/
+const INLINE_EXPORT = /\bexport[ \t]+([A-Za-z_][A-Za-z0-9_]*)\+?=/g
+
+function foreignGlobalsWritten(content: string): string[] {
+  const names = new Set<string>()
+  for (const line of content.split('\n')) {
+    if (/^[ \t]*#/.test(line) || /^[ \t]*local\b/.test(line)) {
+      continue
+    }
+    for (const name of [
+      LINE_START_ASSIGNMENT.exec(line)?.[1],
+      ...[...line.matchAll(INLINE_EXPORT)].map((match) => match[1])
+    ]) {
+      if (name && !/^_{0,2}orca_/i.test(name) && !CONTRACT_GLOBALS.has(name)) {
+        names.add(name)
+      }
+    }
+  }
+  return [...names].sort()
+}
+
 // Why: all three generators are POSIX-only (the launch configs skip wrapping on
 // win32), and native Windows path separators would make the fixtures unstable.
 const describePosix = process.platform === 'win32' ? describe.skip : describe
@@ -88,6 +131,31 @@ describePosix('generated shell wrapper files', () => {
   it('relay overlay wrappers', async () => {
     ensureOverlayRestoreWrappers(root)
     await expectWrapperFiles('relay', root)
+  })
+
+  // Why a rule and not another fixture: `REPLY`, zsh's shared scratch global,
+  // was the wrapper's resolver out-parameter. A user config that constrained it
+  // (`typeset -r REPLY`) aborted the wrapper at its first executable line — on
+  // every zsh pane, once wrapping widened past overlay/startup panes. The
+  // fixtures above would have shown that only to a reader who knew to look.
+  it.each([
+    ['local', (): void => void ensureShellReadyWrappersAt(root), (): string => root],
+    [
+      'daemon',
+      (): void => {
+        process.env.ORCA_USER_DATA_PATH = root
+        getDaemonShellLaunchConfig('/bin/zsh', STARTUP_COMMAND_FEATURES)
+      },
+      (): string => join(root, 'shell-ready')
+    ],
+    ['relay', (): void => void ensureOverlayRestoreWrappers(root), (): string => root]
+  ])('%s wrappers write no shell global outside Orca’s namespace', (_transport, generate, dir) => {
+    generate()
+
+    for (const [, relativePath] of WRAPPER_FILES) {
+      const content = readFileSync(join(dir(), relativePath), 'utf8')
+      expect({ [relativePath]: foreignGlobalsWritten(content) }).toEqual({ [relativePath]: [] })
+    }
   })
 
   it('fish shell-ready init commands', async () => {

--- a/src/main/shell-wrapper-generated-file-snapshot.test.ts
+++ b/src/main/shell-wrapper-generated-file-snapshot.test.ts
@@ -10,9 +10,20 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { ensureShellReadyWrappersAt } from './providers/local-pty-shell-ready-wrapper-generation'
-import { getShellReadyLaunchConfig as getDaemonShellReadyLaunchConfig } from './daemon/shell-ready'
+import { getShellLaunchConfig as getDaemonShellLaunchConfig } from './daemon/shell-ready'
 import { ensureOverlayRestoreWrappers } from '../relay/pty-shell-overlay-wrappers'
-import { getShellReadyLaunchConfig as getLocalShellReadyLaunchConfig } from './providers/local-pty-shell-ready'
+import { getShellLaunchConfig as getLocalShellLaunchConfig } from './providers/local-pty-shell-ready'
+import { selectShellStartupFeatures } from './shell-startup-features'
+
+// Why the real selector: the snapshots then pin what a startup-command pane
+// actually launches with, not a hand-written feature list.
+const STARTUP_COMMAND_FEATURES = selectShellStartupFeatures({
+  shellPath: 'zsh',
+  env: {},
+  hasStartupCommand: true,
+  waitsForShellReady: true,
+  emitsStartupIdentity: true
+})
 
 const WRAPPER_FILES = [
   ['zsh-zshenv', join('zsh', '.zshenv')],
@@ -70,7 +81,7 @@ describePosix('generated shell wrapper files', () => {
 
   it('daemon wrappers', async () => {
     process.env.ORCA_USER_DATA_PATH = root
-    getDaemonShellReadyLaunchConfig('/bin/zsh')
+    getDaemonShellLaunchConfig('/bin/zsh', STARTUP_COMMAND_FEATURES)
     await expectWrapperFiles('daemon', join(root, 'shell-ready'))
   })
 
@@ -81,8 +92,8 @@ describePosix('generated shell wrapper files', () => {
 
   it('fish shell-ready init commands', async () => {
     process.env.ORCA_USER_DATA_PATH = root
-    const local = getLocalShellReadyLaunchConfig('/usr/bin/fish')
-    const daemon = getDaemonShellReadyLaunchConfig('/usr/bin/fish')
+    const local = getLocalShellLaunchConfig('/usr/bin/fish', STARTUP_COMMAND_FEATURES)
+    const daemon = getDaemonShellLaunchConfig('/usr/bin/fish', STARTUP_COMMAND_FEATURES)
     await expect(local.args?.[2]).toMatchFileSnapshot(snapshotPath('local', 'fish-init'))
     await expect(daemon.args?.[2]).toMatchFileSnapshot(snapshotPath('daemon', 'fish-init'))
   })

--- a/src/main/shell-wrapper-snapshots/daemon-bash-rcfile.txt
+++ b/src/main/shell-wrapper-snapshots/daemon-bash-rcfile.txt
@@ -1,8 +1,14 @@
 # Orca daemon bash shell-ready wrapper
-if [[ "${ORCA_SHELL_STARTUP_IDENTITY:-0}" == "1" ]]; then
-  unset ORCA_SHELL_STARTUP_IDENTITY
-  printf "\033]777;orca-shell-start:%s\007" "$$"
-fi
+_orca_shell_features=",${ORCA_SHELL_FEATURES:-},"
+builtin unset ORCA_SHELL_FEATURES
+__orca_has_feature() { [[ "$_orca_shell_features" == *",$1,"* ]]; }
+__orca_has_feature identity && printf "\033]777;orca-shell-start:%s\007" "$$"
+# Why a plain variable: the channel is consumed and destroyed in these first
+# lines, so nothing this shell later spawns can see or inherit the selection.
+__orca_ready_marker=""
+__orca_has_feature ready && __orca_ready_marker=1
+unset _orca_shell_features
+unset -f __orca_has_feature
 [[ -f /etc/profile ]] && source /etc/profile
 if [[ -f "$HOME/.bash_profile" ]]; then
   source "$HOME/.bash_profile"
@@ -84,7 +90,7 @@ __orca_osc133_precmd() {
   # Why: emit the shell-ready marker here (not a trailing PROMPT_COMMAND entry)
   # so a framework that must be last in PROMPT_COMMAND — bash-preexec — is not
   # displaced by one of Orca's own hooks.
-  [[ "${ORCA_SHELL_READY_MARKER:-0}" == "1" ]] && printf "\033]777;orca-shell-ready\007"
+  [[ -n "$__orca_ready_marker" ]] && printf "\033]777;orca-shell-ready\007"
   return "$exit_code"
 }
 __orca_osc133_preexec() {

--- a/src/main/shell-wrapper-snapshots/daemon-fish-init.txt
+++ b/src/main/shell-wrapper-snapshots/daemon-fish-init.txt
@@ -1,8 +1,6 @@
-if test "$ORCA_SHELL_READY_MARKER" = 1
-  function __orca_shell_ready_marker --on-event fish_prompt
-    builtin printf "\033]777;orca-shell-ready\007"
-    functions -e __orca_shell_ready_marker
-  end
+function __orca_shell_ready_marker --on-event fish_prompt
+  builtin printf "\033]777;orca-shell-ready\007"
+  functions -e __orca_shell_ready_marker
 end
 if test -n "$ORCA_CODEX_LAUNCH_PREFLIGHT"; and test (type -t codex 2>/dev/null) = file
   function codex

--- a/src/main/shell-wrapper-snapshots/daemon-zsh-zlogin.txt
+++ b/src/main/shell-wrapper-snapshots/daemon-zsh-zlogin.txt
@@ -11,4 +11,4 @@ if [[ -o interactive && -f "$_orca_home/.zlogin" ]]; then
   unset _orca_wrapper_zdotdir
 fi
 
-__orca_shell_epilogue
+(( ${+functions[__orca_shell_epilogue]} )) && __orca_shell_epilogue

--- a/src/main/shell-wrapper-snapshots/daemon-zsh-zlogin.txt
+++ b/src/main/shell-wrapper-snapshots/daemon-zsh-zlogin.txt
@@ -1,13 +1,13 @@
 # Orca daemon zsh shell-ready wrapper
 __orca_resolve_user_config_dir() {
-  REPLY="${1:-}"
-  while [[ "$REPLY" == */ ]]; do REPLY="${REPLY%/}"; done
-  if [[ -z "$REPLY" || -f "$REPLY/.orca-shell-wrapper" || "$REPLY" == */shell-ready/zsh ]]; then
-    REPLY="$HOME"
+  typeset -g _orca_resolved_config_dir="${1:-}"
+  while [[ "$_orca_resolved_config_dir" == */ ]]; do _orca_resolved_config_dir="${_orca_resolved_config_dir%/}"; done
+  if [[ -z "$_orca_resolved_config_dir" || -f "$_orca_resolved_config_dir/.orca-shell-wrapper" || "$_orca_resolved_config_dir" == */shell-ready/zsh ]]; then
+    _orca_resolved_config_dir="$HOME"
   fi
 }
 __orca_resolve_user_config_dir "${ORCA_ORIG_ZDOTDIR:-$HOME}"
-_orca_home="$REPLY"
+_orca_home="$_orca_resolved_config_dir"
 if [[ -o interactive && -f "$_orca_home/.zlogin" ]]; then
   _orca_wrapper_zdotdir="$ZDOTDIR"
   # Why: user startup files resolve plugin/config paths from their own ZDOTDIR;

--- a/src/main/shell-wrapper-snapshots/daemon-zsh-zlogin.txt
+++ b/src/main/shell-wrapper-snapshots/daemon-zsh-zlogin.txt
@@ -1,4 +1,11 @@
 # Orca daemon zsh shell-ready wrapper
+__orca_resolve_user_config_dir() {
+  REPLY="${1:-}"
+  while [[ "$REPLY" == */ ]]; do REPLY="${REPLY%/}"; done
+  if [[ -z "$REPLY" || -f "$REPLY/.orca-shell-wrapper" || "$REPLY" == */shell-ready/zsh ]]; then
+    REPLY="$HOME"
+  fi
+}
 __orca_resolve_user_config_dir "${ORCA_ORIG_ZDOTDIR:-$HOME}"
 _orca_home="$REPLY"
 if [[ -o interactive && -f "$_orca_home/.zlogin" ]]; then

--- a/src/main/shell-wrapper-snapshots/daemon-zsh-zlogin.txt
+++ b/src/main/shell-wrapper-snapshots/daemon-zsh-zlogin.txt
@@ -1,8 +1,6 @@
 # Orca daemon zsh shell-ready wrapper
-_orca_home="${ORCA_ORIG_ZDOTDIR:-$HOME}"
-case "${_orca_home%/}" in
-  */shell-ready/zsh) _orca_home="$HOME" ;;
-esac
+__orca_resolve_user_config_dir "${ORCA_ORIG_ZDOTDIR:-$HOME}"
+_orca_home="$REPLY"
 if [[ -o interactive && -f "$_orca_home/.zlogin" ]]; then
   _orca_wrapper_zdotdir="$ZDOTDIR"
   # Why: user startup files resolve plugin/config paths from their own ZDOTDIR;
@@ -13,97 +11,4 @@ if [[ -o interactive && -f "$_orca_home/.zlogin" ]]; then
   unset _orca_wrapper_zdotdir
 fi
 
-__orca_restore_agent_teams_path() {
-  [[ -n "${ORCA_AGENT_TEAMS_SHIM_DIR:-}" ]] || return 0
-  case "$PATH" in
-    "${ORCA_AGENT_TEAMS_SHIM_DIR}"|"${ORCA_AGENT_TEAMS_SHIM_DIR}:"*) return 0 ;;
-  esac
-  export PATH="${ORCA_AGENT_TEAMS_SHIM_DIR}:$PATH"
-}
-__orca_restore_agent_teams_path
-# Why: .zlogin is the final login startup file before the prompt is shown.
-[[ -n "${ORCA_OPENCODE_CONFIG_DIR:-}" ]] && export OPENCODE_CONFIG_DIR="${ORCA_OPENCODE_CONFIG_DIR}"
-[[ -n "${ORCA_MIMOCODE_HOME:-}" ]] && export MIMOCODE_HOME="${ORCA_MIMOCODE_HOME}"
-# Why: OMP does not auto-load Orca's managed status extension; wrap only
-# interactive launch invocations so subcommands such as `omp config` keep
-# their normal argv shape.
-__orca_omp_should_skip_extension() {
-  case "${1:-}" in
-    help|--help|-h|--version|-v) return 0 ;;
-    __complete|acp|agents|auth-broker|auth-gateway|bench|commit|completions|config|dry-balance|gallery|grep|grievances|install|join|models|plugin|read|say|search|setup|shell|ssh|stats|tiny-models|token|ttsr|update|usage|worktree|q|wt) return 0 ;;
-  esac
-  return 1
-}
-__orca_omp() {
-  local __orca_use_extension=1
-  __orca_omp_should_skip_extension "${1:-}" && __orca_use_extension=0
-  if [[ $__orca_use_extension -eq 1 && -n "${ORCA_OMP_STATUS_EXTENSION:-}" && -f "${ORCA_OMP_STATUS_EXTENSION}" ]]; then
-    if [[ "${1:-}" == "launch" ]]; then
-      shift
-      command omp launch --extension "${ORCA_OMP_STATUS_EXTENSION}" "$@"
-    else
-      command omp --extension "${ORCA_OMP_STATUS_EXTENSION}" "$@"
-    fi
-  else
-    command omp "$@"
-  fi
-}
-if [[ -n "${ORCA_OMP_STATUS_EXTENSION:-}" ]]; then
-  omp() { __orca_omp "$@"; }
-fi
-
-[[ -n "${ORCA_CODEX_HOME:-}" ]] && export CODEX_HOME="${ORCA_CODEX_HOME}"
-if [[ -n "${ORCA_HISTFILE:-}" ]]; then
-  HISTFILE="$ORCA_HISTFILE"
-elif [[ "${HISTFILE:-}" == "$ZDOTDIR/.zsh_history" ]]; then
-  # Why also when Orca injected nothing: /etc/zshrc derived this from Orca's
-  # wrapper ZDOTDIR, so history would accumulate INSIDE the wrapper dir and the
-  # user's real history would be invisible — the plain #11044 bug, with no
-  # per-worktree scoping involved. Matching the exact clobbered value means a
-  # HISTFILE the user set deliberately is never touched.
-  HISTFILE="${ORCA_ORIG_ZDOTDIR:-$HOME}/.zsh_history"
-fi
-# Why: a typed alias expands inside the shell, after pane launch prep.
-__orca_codex_binary="$(command -v codex 2>/dev/null || :)"
-if [[ -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" && -n "${__orca_codex_binary:-}" && -x "${__orca_codex_binary}" ]]; then
-  codex() {
-    "${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex >/dev/null 2>&1 || :
-    command codex "$@"
-  }
-fi
-unset __orca_codex_binary
-
-if [[ "${ORCA_SHELL_READY_MARKER:-0}" == "1" ]]; then
-  # Why: capture the prior zle-line-init so the marker chains to it. On a
-  # re-source we are already the bound widget, so keep the function captured
-  # the first time instead of clobbering it to empty (which would silently
-  # drop the user's widget on every prompt after the second source). Only
-  # user-defined widgets are chainable as plain functions; builtin/completion
-  # forms (rare for zle-line-init) are left unchained.
-  if [[ "${widgets[zle-line-init]:-}" == "user:__orca_prompt_mark" ]]; then
-    :
-  elif (( ${+widgets[zle-line-init]} )) && [[ "${widgets[zle-line-init]}" == user:* ]]; then
-    __orca_prev_line_init_fn="${widgets[zle-line-init]#user:}"
-  else
-    __orca_prev_line_init_fn=""
-  fi
-  __orca_prompt_mark() {
-    printf "\033]777;orca-shell-ready\007"
-    # Why: call the prior hook as a plain function, not an aliased widget, so
-    # $WIDGET stays zle-line-init for add-zle-hook-widget dispatchers.
-    if [[ -n "${__orca_prev_line_init_fn:-}" ]]; then
-      "${__orca_prev_line_init_fn}" "$@"
-    fi
-  }
-  zle -N zle-line-init __orca_prompt_mark
-fi
-
-_orca_home="${ORCA_ORIG_ZDOTDIR:-$HOME}"
-case "${_orca_home%/}" in
-  */shell-ready/zsh) _orca_home="$HOME" ;;
-esac
-# Why: after Orca's last wrapper file has loaded, the interactive shell should
-# expose the same ZDOTDIR a normal zsh startup would expose.
-export ZDOTDIR="$_orca_home"
-unset _orca_home
-
+__orca_shell_epilogue

--- a/src/main/shell-wrapper-snapshots/daemon-zsh-zprofile.txt
+++ b/src/main/shell-wrapper-snapshots/daemon-zsh-zprofile.txt
@@ -1,13 +1,13 @@
 # Orca daemon zsh shell-ready wrapper
 __orca_resolve_user_config_dir() {
-  REPLY="${1:-}"
-  while [[ "$REPLY" == */ ]]; do REPLY="${REPLY%/}"; done
-  if [[ -z "$REPLY" || -f "$REPLY/.orca-shell-wrapper" || "$REPLY" == */shell-ready/zsh ]]; then
-    REPLY="$HOME"
+  typeset -g _orca_resolved_config_dir="${1:-}"
+  while [[ "$_orca_resolved_config_dir" == */ ]]; do _orca_resolved_config_dir="${_orca_resolved_config_dir%/}"; done
+  if [[ -z "$_orca_resolved_config_dir" || -f "$_orca_resolved_config_dir/.orca-shell-wrapper" || "$_orca_resolved_config_dir" == */shell-ready/zsh ]]; then
+    _orca_resolved_config_dir="$HOME"
   fi
 }
 __orca_resolve_user_config_dir "${ORCA_ORIG_ZDOTDIR:-$HOME}"
-_orca_home="$REPLY"
+_orca_home="$_orca_resolved_config_dir"
 if [[ -f "$_orca_home/.zprofile" ]]; then
   _orca_wrapper_zdotdir="$ZDOTDIR"
   # Why: user startup files resolve plugin/config paths from their own ZDOTDIR;
@@ -18,3 +18,15 @@ if [[ -f "$_orca_home/.zprofile" ]]; then
   unset _orca_wrapper_zdotdir
 fi
 
+if [[ -f "$_orca_home/.zprofile" ]]; then
+  case "$(emulate 2>/dev/null)" in
+    sh|ksh)
+      export ZDOTDIR="$_orca_home"
+      # Why unset: an ORCA_HISTFILE no wrapper file will ever consume is
+      # inherited by everything this pane spawns, including a nested Orca.
+      builtin unset ORCA_HISTFILE _orca_shell_features _orca_home _orca_resolved_config_dir _orca_wrapper_zdotdir_self
+      unfunction __orca_shell_epilogue __orca_has_feature __orca_resolve_user_config_dir __orca_resolve_inherited_config_dir 2>/dev/null
+      return 0
+      ;;
+  esac
+fi

--- a/src/main/shell-wrapper-snapshots/daemon-zsh-zprofile.txt
+++ b/src/main/shell-wrapper-snapshots/daemon-zsh-zprofile.txt
@@ -1,8 +1,6 @@
 # Orca daemon zsh shell-ready wrapper
-_orca_home="${ORCA_ORIG_ZDOTDIR:-$HOME}"
-case "${_orca_home%/}" in
-  */shell-ready/zsh) _orca_home="$HOME" ;;
-esac
+__orca_resolve_user_config_dir "${ORCA_ORIG_ZDOTDIR:-$HOME}"
+_orca_home="$REPLY"
 if [[ -f "$_orca_home/.zprofile" ]]; then
   _orca_wrapper_zdotdir="$ZDOTDIR"
   # Why: user startup files resolve plugin/config paths from their own ZDOTDIR;

--- a/src/main/shell-wrapper-snapshots/daemon-zsh-zprofile.txt
+++ b/src/main/shell-wrapper-snapshots/daemon-zsh-zprofile.txt
@@ -1,4 +1,11 @@
 # Orca daemon zsh shell-ready wrapper
+__orca_resolve_user_config_dir() {
+  REPLY="${1:-}"
+  while [[ "$REPLY" == */ ]]; do REPLY="${REPLY%/}"; done
+  if [[ -z "$REPLY" || -f "$REPLY/.orca-shell-wrapper" || "$REPLY" == */shell-ready/zsh ]]; then
+    REPLY="$HOME"
+  fi
+}
 __orca_resolve_user_config_dir "${ORCA_ORIG_ZDOTDIR:-$HOME}"
 _orca_home="$REPLY"
 if [[ -f "$_orca_home/.zprofile" ]]; then

--- a/src/main/shell-wrapper-snapshots/daemon-zsh-zshenv.txt
+++ b/src/main/shell-wrapper-snapshots/daemon-zsh-zshenv.txt
@@ -91,6 +91,12 @@ fi
 unset _orca_user_zdotdir _orca_zshenv_source_dir _orca_zshenv_path _orca_discovered_zdotdir _orca_wrapper_zdotdir_self
 
 __orca_shell_epilogue() {
+  # Why first: this body runs after the user's own config, so it would otherwise
+  # inherit whatever options that config left set. Under NO_UNSET an unset
+  # precmd_functions is a fatal error that returns from the whole epilogue
+  # (skipping the ready widget and the ZDOTDIR restore), and KSH_ARRAYS makes
+  # the 1-based feature lookup drop the first selected feature.
+  emulate -L zsh
   (( $+_orca_epilogue_done )) && return 0
   typeset -g _orca_epilogue_done=1
   if __orca_has_feature overlay; then
@@ -145,18 +151,16 @@ __orca_shell_epilogue() {
     fi
     unset __orca_codex_binary
   fi
-  if __orca_has_feature history; then
-    if [[ -n "${ORCA_HISTFILE:-}" ]]; then
-      HISTFILE="$ORCA_HISTFILE"
-      builtin unset ORCA_HISTFILE
-    elif [[ "${HISTFILE:-}" == "$ZDOTDIR/.zsh_history" ]]; then
-      # Why also when Orca injected nothing: /etc/zshrc derived this from Orca's
-      # wrapper ZDOTDIR, so history would accumulate INSIDE the wrapper dir and the
-      # user's real history would be invisible — the plain #11044 bug, with no
-      # per-worktree scoping involved. Matching the exact clobbered value means a
-      # HISTFILE the user set deliberately is never touched.
-      HISTFILE="${ORCA_ORIG_ZDOTDIR:-$HOME}/.zsh_history"
-    fi
+  if [[ -n "${ORCA_HISTFILE:-}" ]]; then
+    HISTFILE="$ORCA_HISTFILE"
+    builtin unset ORCA_HISTFILE
+  elif [[ "${HISTFILE:-}" == "$ZDOTDIR/.zsh_history" ]]; then
+    # Why also when Orca injected nothing: /etc/zshrc derived this from Orca's
+    # wrapper ZDOTDIR, so history would accumulate INSIDE the wrapper dir and the
+    # user's real history would be invisible — the plain #11044 bug, with no
+    # per-worktree scoping involved. Matching the exact clobbered value means a
+    # HISTFILE the user set deliberately is never touched.
+    HISTFILE="${ORCA_ORIG_ZDOTDIR:-$HOME}/.zsh_history"
   fi
   if __orca_has_feature markers; then
     __orca_osc133_precmd() {

--- a/src/main/shell-wrapper-snapshots/daemon-zsh-zshenv.txt
+++ b/src/main/shell-wrapper-snapshots/daemon-zsh-zshenv.txt
@@ -1,8 +1,28 @@
 # Orca daemon zsh shell-ready wrapper
-if [[ "${ORCA_SHELL_STARTUP_IDENTITY:-0}" == "1" ]]; then
-  unset ORCA_SHELL_STARTUP_IDENTITY
-  printf "\033]777;orca-shell-start:%s\007" "$$"
-fi
+typeset -ga _orca_shell_features
+_orca_shell_features=(${(s:,:)${ORCA_SHELL_FEATURES:-}})
+builtin unset ORCA_SHELL_FEATURES
+__orca_has_feature() { (( ${_orca_shell_features[(Ie)$1]} )) }
+__orca_has_feature identity && printf "\033]777;orca-shell-start:%s\007" "$$"
+__orca_resolve_user_config_dir() {
+  REPLY="${1:-}"
+  while [[ "$REPLY" == */ ]]; do REPLY="${REPLY%/}"; done
+  if [[ -z "$REPLY" || -f "$REPLY/.orca-shell-wrapper" || "$REPLY" == */shell-ready/zsh ]]; then
+    REPLY="$HOME"
+  fi
+}
+# Why stricter for an inherited value: Orca can be launched from a terminal that
+# already pointed ZDOTDIR at its own wrapper dir, and a directory holding no zsh
+# startup file at all is not the user's config root whoever wrote it.
+__orca_resolve_inherited_config_dir() {
+  __orca_resolve_user_config_dir "${1:-}"
+  [[ "$REPLY" == "$HOME" ]] && return 0
+  local _orca_startup_file
+  for _orca_startup_file in .zshenv .zshrc .zprofile .zlogin; do
+    [[ -r "$REPLY/$_orca_startup_file" ]] && return 0
+  done
+  REPLY="$HOME"
+}
 # Why: capture the runtime wrapper dir before it is unset below. On WSL this
 # file is generated with a Windows path but sourced via /mnt/c, so the baked
 # literal is unusable there and ZDOTDIR must be restored from this value.
@@ -20,26 +40,15 @@ fi
 while [[ "${_orca_wrapper_zdotdir_self:-}" == */ ]]; do
   _orca_wrapper_zdotdir_self="${_orca_wrapper_zdotdir_self%/}"
 done
-_orca_spawn_orig_zdotdir="${ORCA_ORIG_ZDOTDIR:-}"
-_orca_user_zdotdir="${_orca_spawn_orig_zdotdir:-$HOME}"
-_orca_zshenv_source_dir="${ORCA_ZSHENV_SOURCE_DIR:-$HOME}"
 _orca_zshenv_path=""
-unset ORCA_ZSHENV_SOURCE_DIR
 
 # Normalize fallback and source roots before reading user .zshenv so nested
 # Orca PTYs never source another Orca wrapper recursively.
-while [[ "${_orca_user_zdotdir}" == */ ]]; do
-  _orca_user_zdotdir="${_orca_user_zdotdir%/}"
-done
-case "${_orca_user_zdotdir}" in
-  ""|*/shell-ready/zsh) _orca_user_zdotdir="$HOME" ;;
-esac
-while [[ "${_orca_zshenv_source_dir}" == */ ]]; do
-  _orca_zshenv_source_dir="${_orca_zshenv_source_dir%/}"
-done
-case "${_orca_zshenv_source_dir}" in
-  ""|*/shell-ready/zsh) _orca_zshenv_source_dir="$HOME" ;;
-esac
+__orca_resolve_inherited_config_dir "${ORCA_ORIG_ZDOTDIR:-$HOME}"
+_orca_user_zdotdir="$REPLY"
+__orca_resolve_inherited_config_dir "${ORCA_ZSHENV_SOURCE_DIR:-$HOME}"
+_orca_zshenv_source_dir="$REPLY"
+unset ORCA_ZSHENV_SOURCE_DIR
 
 # Why: source at wrapper top level, not in a function/subshell, so .zshenv
 # exports, functions, path/fpath typesets, and zsh options keep normal scope.
@@ -67,15 +76,10 @@ if [[ -n "${_orca_discovered_zdotdir}" && ! -d "${_orca_discovered_zdotdir}" ]];
   _orca_discovered_zdotdir=""
 fi
 
-export ORCA_ORIG_ZDOTDIR="${_orca_discovered_zdotdir:-${_orca_user_zdotdir:-$HOME}}"
-
-while [[ "${ORCA_ORIG_ZDOTDIR}" == */ ]]; do
-  ORCA_ORIG_ZDOTDIR="${ORCA_ORIG_ZDOTDIR%/}"
-done
-
-case "${ORCA_ORIG_ZDOTDIR}" in
-  ""|*/shell-ready/zsh) export ORCA_ORIG_ZDOTDIR="$HOME" ;;
-esac
+# Why only the ownership check here: a ZDOTDIR the user's own .zshenv just
+# exported is the user's by construction, whatever it happens to contain.
+__orca_resolve_user_config_dir "${_orca_discovered_zdotdir:-${_orca_user_zdotdir:-$HOME}}"
+export ORCA_ORIG_ZDOTDIR="$REPLY"
 
 # Why: use :- after user .zshenv — a pathological unset under set -u must not
 # abort the wrapper; empty falls through to the baked-literal branch.
@@ -84,4 +88,122 @@ if [[ -n "${_orca_wrapper_zdotdir_self:-}" && -f "${_orca_wrapper_zdotdir_self:-
 else
   export ZDOTDIR='<WRAPPER_ROOT>/zsh'
 fi
-unset _orca_spawn_orig_zdotdir _orca_user_zdotdir _orca_zshenv_source_dir _orca_zshenv_path _orca_discovered_zdotdir _orca_wrapper_zdotdir_self
+unset _orca_user_zdotdir _orca_zshenv_source_dir _orca_zshenv_path _orca_discovered_zdotdir _orca_wrapper_zdotdir_self
+
+__orca_shell_epilogue() {
+  (( $+_orca_epilogue_done )) && return 0
+  typeset -g _orca_epilogue_done=1
+  if __orca_has_feature overlay; then
+    # Why: ~/.zshrc can export the user's default OpenCode config after spawn.
+    __orca_restore_agent_teams_path() {
+      [[ -n "${ORCA_AGENT_TEAMS_SHIM_DIR:-}" ]] || return 0
+      case "$PATH" in
+        "${ORCA_AGENT_TEAMS_SHIM_DIR}"|"${ORCA_AGENT_TEAMS_SHIM_DIR}:"*) return 0 ;;
+      esac
+      export PATH="${ORCA_AGENT_TEAMS_SHIM_DIR}:$PATH"
+    }
+    __orca_restore_agent_teams_path
+    [[ -n "${ORCA_OPENCODE_CONFIG_DIR:-}" ]] && export OPENCODE_CONFIG_DIR="${ORCA_OPENCODE_CONFIG_DIR}"
+    [[ -n "${ORCA_MIMOCODE_HOME:-}" ]] && export MIMOCODE_HOME="${ORCA_MIMOCODE_HOME}"
+    # Why: OMP does not auto-load Orca's managed status extension; wrap only
+    # interactive launch invocations so subcommands such as `omp config` keep
+    # their normal argv shape.
+    __orca_omp_should_skip_extension() {
+      case "${1:-}" in
+        help|--help|-h|--version|-v) return 0 ;;
+        __complete|acp|agents|auth-broker|auth-gateway|bench|commit|completions|config|dry-balance|gallery|grep|grievances|install|join|models|plugin|read|say|search|setup|shell|ssh|stats|tiny-models|token|ttsr|update|usage|worktree|q|wt) return 0 ;;
+      esac
+      return 1
+    }
+    __orca_omp() {
+      local __orca_use_extension=1
+      __orca_omp_should_skip_extension "${1:-}" && __orca_use_extension=0
+      if [[ $__orca_use_extension -eq 1 && -n "${ORCA_OMP_STATUS_EXTENSION:-}" && -f "${ORCA_OMP_STATUS_EXTENSION}" ]]; then
+        if [[ "${1:-}" == "launch" ]]; then
+          shift
+          command omp launch --extension "${ORCA_OMP_STATUS_EXTENSION}" "$@"
+        else
+          command omp --extension "${ORCA_OMP_STATUS_EXTENSION}" "$@"
+        fi
+      else
+        command omp "$@"
+      fi
+    }
+    if [[ -n "${ORCA_OMP_STATUS_EXTENSION:-}" ]]; then
+      omp() { __orca_omp "$@"; }
+    fi
+
+    # Why: Codex must keep using Orca's runtime CODEX_HOME after rc files.
+    [[ -n "${ORCA_CODEX_HOME:-}" ]] && export CODEX_HOME="${ORCA_CODEX_HOME}"
+    # Why: a typed alias expands inside the shell, after pane launch prep.
+    __orca_codex_binary="$(command -v codex 2>/dev/null || :)"
+    if [[ -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" && -n "${__orca_codex_binary:-}" && -x "${__orca_codex_binary}" ]]; then
+      codex() {
+        "${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex >/dev/null 2>&1 || :
+        command codex "$@"
+      }
+    fi
+    unset __orca_codex_binary
+  fi
+  if __orca_has_feature history; then
+    if [[ -n "${ORCA_HISTFILE:-}" ]]; then
+      HISTFILE="$ORCA_HISTFILE"
+      builtin unset ORCA_HISTFILE
+    elif [[ "${HISTFILE:-}" == "$ZDOTDIR/.zsh_history" ]]; then
+      # Why also when Orca injected nothing: /etc/zshrc derived this from Orca's
+      # wrapper ZDOTDIR, so history would accumulate INSIDE the wrapper dir and the
+      # user's real history would be invisible — the plain #11044 bug, with no
+      # per-worktree scoping involved. Matching the exact clobbered value means a
+      # HISTFILE the user set deliberately is never touched.
+      HISTFILE="${ORCA_ORIG_ZDOTDIR:-$HOME}/.zsh_history"
+    fi
+  fi
+  if __orca_has_feature markers; then
+    __orca_osc133_precmd() {
+      local exit_code=$?
+      if [[ -n "${__orca_in_command:-}" ]]; then
+        printf "\033]133;D;%s\007" "$exit_code"
+        unset __orca_in_command
+      fi
+      printf "\033]133;A\007"
+    }
+    __orca_osc133_preexec() {
+      printf "\033]133;C\007"
+      __orca_in_command=1
+    }
+    # Why: prepend so Orca captures $? before user prompt hooks can overwrite it.
+    precmd_functions=(__orca_osc133_precmd ${precmd_functions[@]})
+    preexec_functions=(__orca_osc133_preexec ${preexec_functions[@]})
+  fi
+  if __orca_has_feature ready; then
+    # Why: capture the prior zle-line-init so the marker chains to it. On a
+    # re-source we are already the bound widget, so keep the function captured
+    # the first time instead of clobbering it to empty (which would silently
+    # drop the user's widget on every prompt after the second source). Only
+    # user-defined widgets are chainable as plain functions; builtin/completion
+    # forms (rare for zle-line-init) are left unchained.
+    if [[ "${widgets[zle-line-init]:-}" == "user:__orca_prompt_mark" ]]; then
+      :
+    elif (( ${+widgets[zle-line-init]} )) && [[ "${widgets[zle-line-init]}" == user:* ]]; then
+      __orca_prev_line_init_fn="${widgets[zle-line-init]#user:}"
+    else
+      __orca_prev_line_init_fn=""
+    fi
+    __orca_prompt_mark() {
+      printf "\033]777;orca-shell-ready\007"
+      # Why: call the prior hook as a plain function, not an aliased widget, so
+      # $WIDGET stays zle-line-init for add-zle-hook-widget dispatchers.
+      if [[ -n "${__orca_prev_line_init_fn:-}" ]]; then
+        "${__orca_prev_line_init_fn}" "$@"
+      fi
+    }
+    zle -N zle-line-init __orca_prompt_mark
+  fi
+  __orca_resolve_user_config_dir "${ORCA_ORIG_ZDOTDIR:-$HOME}"
+  # Why: after Orca's last wrapper file has loaded, the interactive shell should
+  # expose the same ZDOTDIR a normal zsh startup would expose.
+  export ZDOTDIR="$REPLY"
+  unset _orca_home REPLY
+  unset _orca_shell_features
+  unfunction __orca_shell_epilogue __orca_has_feature __orca_resolve_user_config_dir __orca_resolve_inherited_config_dir
+}

--- a/src/main/shell-wrapper-snapshots/daemon-zsh-zshenv.txt
+++ b/src/main/shell-wrapper-snapshots/daemon-zsh-zshenv.txt
@@ -5,10 +5,10 @@ builtin unset ORCA_SHELL_FEATURES
 __orca_has_feature() { (( ${_orca_shell_features[(Ie)$1]} )) }
 __orca_has_feature identity && printf "\033]777;orca-shell-start:%s\007" "$$"
 __orca_resolve_user_config_dir() {
-  REPLY="${1:-}"
-  while [[ "$REPLY" == */ ]]; do REPLY="${REPLY%/}"; done
-  if [[ -z "$REPLY" || -f "$REPLY/.orca-shell-wrapper" || "$REPLY" == */shell-ready/zsh ]]; then
-    REPLY="$HOME"
+  typeset -g _orca_resolved_config_dir="${1:-}"
+  while [[ "$_orca_resolved_config_dir" == */ ]]; do _orca_resolved_config_dir="${_orca_resolved_config_dir%/}"; done
+  if [[ -z "$_orca_resolved_config_dir" || -f "$_orca_resolved_config_dir/.orca-shell-wrapper" || "$_orca_resolved_config_dir" == */shell-ready/zsh ]]; then
+    _orca_resolved_config_dir="$HOME"
   fi
 }
 # Why stricter for an inherited value: Orca can be launched from a terminal that
@@ -16,12 +16,12 @@ __orca_resolve_user_config_dir() {
 # startup file at all is not the user's config root whoever wrote it.
 __orca_resolve_inherited_config_dir() {
   __orca_resolve_user_config_dir "${1:-}"
-  [[ "$REPLY" == "$HOME" ]] && return 0
+  [[ "$_orca_resolved_config_dir" == "$HOME" ]] && return 0
   local _orca_startup_file
   for _orca_startup_file in .zshenv .zshrc .zprofile .zlogin; do
-    [[ -r "$REPLY/$_orca_startup_file" ]] && return 0
+    [[ -r "$_orca_resolved_config_dir/$_orca_startup_file" ]] && return 0
   done
-  REPLY="$HOME"
+  _orca_resolved_config_dir="$HOME"
 }
 # Why: capture the runtime wrapper dir before it is unset below. On WSL this
 # file is generated with a Windows path but sourced via /mnt/c, so the baked
@@ -45,9 +45,9 @@ _orca_zshenv_path=""
 # Normalize fallback and source roots before reading user .zshenv so nested
 # Orca PTYs never source another Orca wrapper recursively.
 __orca_resolve_inherited_config_dir "${ORCA_ORIG_ZDOTDIR:-$HOME}"
-_orca_user_zdotdir="$REPLY"
+_orca_user_zdotdir="$_orca_resolved_config_dir"
 __orca_resolve_inherited_config_dir "${ORCA_ZSHENV_SOURCE_DIR:-$HOME}"
-_orca_zshenv_source_dir="$REPLY"
+_orca_zshenv_source_dir="$_orca_resolved_config_dir"
 unset ORCA_ZSHENV_SOURCE_DIR
 
 # Why: source at wrapper top level, not in a function/subshell, so .zshenv
@@ -79,7 +79,22 @@ fi
 # Why only the ownership check here: a ZDOTDIR the user's own .zshenv just
 # exported is the user's by construction, whatever it happens to contain.
 __orca_resolve_user_config_dir "${_orca_discovered_zdotdir:-${_orca_user_zdotdir:-$HOME}}"
-export ORCA_ORIG_ZDOTDIR="$REPLY"
+export ORCA_ORIG_ZDOTDIR="$_orca_resolved_config_dir"
+unset _orca_user_zdotdir _orca_zshenv_source_dir _orca_discovered_zdotdir
+
+if [[ -n "${_orca_zshenv_path:-}" ]]; then
+  case "$(emulate 2>/dev/null)" in
+    sh|ksh)
+      export ZDOTDIR="$ORCA_ORIG_ZDOTDIR"
+      # Why unset: an ORCA_HISTFILE no wrapper file will ever consume is
+      # inherited by everything this pane spawns, including a nested Orca.
+      builtin unset ORCA_HISTFILE _orca_shell_features _orca_home _orca_resolved_config_dir _orca_wrapper_zdotdir_self
+      unfunction __orca_shell_epilogue __orca_has_feature __orca_resolve_user_config_dir __orca_resolve_inherited_config_dir 2>/dev/null
+      return 0
+      ;;
+  esac
+fi
+unset _orca_zshenv_path
 
 # Why: use :- after user .zshenv — a pathological unset under set -u must not
 # abort the wrapper; empty falls through to the baked-literal branch.
@@ -88,7 +103,7 @@ if [[ -n "${_orca_wrapper_zdotdir_self:-}" && -f "${_orca_wrapper_zdotdir_self:-
 else
   export ZDOTDIR='<WRAPPER_ROOT>/zsh'
 fi
-unset _orca_user_zdotdir _orca_zshenv_source_dir _orca_zshenv_path _orca_discovered_zdotdir _orca_wrapper_zdotdir_self
+unset _orca_wrapper_zdotdir_self
 
 __orca_shell_epilogue() {
   # Why first: this body runs after the user's own config, so it would otherwise
@@ -173,7 +188,9 @@ __orca_shell_epilogue() {
     }
     __orca_osc133_preexec() {
       printf "\033]133;C\007"
-      __orca_in_command=1
+      # Why typeset -g: a plain assignment here creates a global inside a function,
+      # which prints a warning above every command under warn_create_global.
+      typeset -g __orca_in_command=1
     }
     # Why: prepend so Orca captures $? before user prompt hooks can overwrite it.
     precmd_functions=(__orca_osc133_precmd ${precmd_functions[@]})
@@ -206,8 +223,8 @@ __orca_shell_epilogue() {
   __orca_resolve_user_config_dir "${ORCA_ORIG_ZDOTDIR:-$HOME}"
   # Why: after Orca's last wrapper file has loaded, the interactive shell should
   # expose the same ZDOTDIR a normal zsh startup would expose.
-  export ZDOTDIR="$REPLY"
-  unset _orca_home REPLY
+  export ZDOTDIR="$_orca_resolved_config_dir"
+  unset _orca_home _orca_resolved_config_dir
   unset _orca_shell_features
   unfunction __orca_shell_epilogue __orca_has_feature __orca_resolve_user_config_dir __orca_resolve_inherited_config_dir
 }

--- a/src/main/shell-wrapper-snapshots/daemon-zsh-zshrc.txt
+++ b/src/main/shell-wrapper-snapshots/daemon-zsh-zshrc.txt
@@ -1,13 +1,13 @@
 # Orca daemon zsh shell-ready wrapper
 __orca_resolve_user_config_dir() {
-  REPLY="${1:-}"
-  while [[ "$REPLY" == */ ]]; do REPLY="${REPLY%/}"; done
-  if [[ -z "$REPLY" || -f "$REPLY/.orca-shell-wrapper" || "$REPLY" == */shell-ready/zsh ]]; then
-    REPLY="$HOME"
+  typeset -g _orca_resolved_config_dir="${1:-}"
+  while [[ "$_orca_resolved_config_dir" == */ ]]; do _orca_resolved_config_dir="${_orca_resolved_config_dir%/}"; done
+  if [[ -z "$_orca_resolved_config_dir" || -f "$_orca_resolved_config_dir/.orca-shell-wrapper" || "$_orca_resolved_config_dir" == */shell-ready/zsh ]]; then
+    _orca_resolved_config_dir="$HOME"
   fi
 }
 __orca_resolve_user_config_dir "${ORCA_ORIG_ZDOTDIR:-$HOME}"
-_orca_home="$REPLY"
+_orca_home="$_orca_resolved_config_dir"
 if [[ "$_orca_home" != "$ZDOTDIR" && -o interactive && -f "$_orca_home/.zshrc" ]]; then
   _orca_wrapper_zdotdir="$ZDOTDIR"
   # Why: user startup files resolve plugin/config paths from their own ZDOTDIR;

--- a/src/main/shell-wrapper-snapshots/daemon-zsh-zshrc.txt
+++ b/src/main/shell-wrapper-snapshots/daemon-zsh-zshrc.txt
@@ -1,4 +1,11 @@
 # Orca daemon zsh shell-ready wrapper
+__orca_resolve_user_config_dir() {
+  REPLY="${1:-}"
+  while [[ "$REPLY" == */ ]]; do REPLY="${REPLY%/}"; done
+  if [[ -z "$REPLY" || -f "$REPLY/.orca-shell-wrapper" || "$REPLY" == */shell-ready/zsh ]]; then
+    REPLY="$HOME"
+  fi
+}
 __orca_resolve_user_config_dir "${ORCA_ORIG_ZDOTDIR:-$HOME}"
 _orca_home="$REPLY"
 if [[ "$_orca_home" != "$ZDOTDIR" && -o interactive && -f "$_orca_home/.zshrc" ]]; then

--- a/src/main/shell-wrapper-snapshots/daemon-zsh-zshrc.txt
+++ b/src/main/shell-wrapper-snapshots/daemon-zsh-zshrc.txt
@@ -1,8 +1,6 @@
 # Orca daemon zsh shell-ready wrapper
-_orca_home="${ORCA_ORIG_ZDOTDIR:-$HOME}"
-case "${_orca_home%/}" in
-  */shell-ready/zsh) _orca_home="$HOME" ;;
-esac
+__orca_resolve_user_config_dir "${ORCA_ORIG_ZDOTDIR:-$HOME}"
+_orca_home="$REPLY"
 if [[ "$_orca_home" != "$ZDOTDIR" && -o interactive && -f "$_orca_home/.zshrc" ]]; then
   _orca_wrapper_zdotdir="$ZDOTDIR"
   # Why: user startup files resolve plugin/config paths from their own ZDOTDIR;
@@ -13,91 +11,5 @@ if [[ "$_orca_home" != "$ZDOTDIR" && -o interactive && -f "$_orca_home/.zshrc" ]
   unset _orca_wrapper_zdotdir
 fi
 
-__orca_restore_agent_teams_path() {
-  [[ -n "${ORCA_AGENT_TEAMS_SHIM_DIR:-}" ]] || return 0
-  case "$PATH" in
-    "${ORCA_AGENT_TEAMS_SHIM_DIR}"|"${ORCA_AGENT_TEAMS_SHIM_DIR}:"*) return 0 ;;
-  esac
-  export PATH="${ORCA_AGENT_TEAMS_SHIM_DIR}:$PATH"
-}
-[[ ! -o login ]] && __orca_restore_agent_teams_path
-if [[ ! -o login ]]; then
-  # Why: ~/.zshrc can export the user's default OpenCode config after spawn.
-  [[ -n "${ORCA_OPENCODE_CONFIG_DIR:-}" ]] && export OPENCODE_CONFIG_DIR="${ORCA_OPENCODE_CONFIG_DIR}"
-  [[ -n "${ORCA_MIMOCODE_HOME:-}" ]] && export MIMOCODE_HOME="${ORCA_MIMOCODE_HOME}"
-  # Why: OMP does not auto-load Orca's managed status extension; wrap only
-# interactive launch invocations so subcommands such as `omp config` keep
-# their normal argv shape.
-__orca_omp_should_skip_extension() {
-  case "${1:-}" in
-    help|--help|-h|--version|-v) return 0 ;;
-    __complete|acp|agents|auth-broker|auth-gateway|bench|commit|completions|config|dry-balance|gallery|grep|grievances|install|join|models|plugin|read|say|search|setup|shell|ssh|stats|tiny-models|token|ttsr|update|usage|worktree|q|wt) return 0 ;;
-  esac
-  return 1
-}
-__orca_omp() {
-  local __orca_use_extension=1
-  __orca_omp_should_skip_extension "${1:-}" && __orca_use_extension=0
-  if [[ $__orca_use_extension -eq 1 && -n "${ORCA_OMP_STATUS_EXTENSION:-}" && -f "${ORCA_OMP_STATUS_EXTENSION}" ]]; then
-    if [[ "${1:-}" == "launch" ]]; then
-      shift
-      command omp launch --extension "${ORCA_OMP_STATUS_EXTENSION}" "$@"
-    else
-      command omp --extension "${ORCA_OMP_STATUS_EXTENSION}" "$@"
-    fi
-  else
-    command omp "$@"
-  fi
-}
-if [[ -n "${ORCA_OMP_STATUS_EXTENSION:-}" ]]; then
-  omp() { __orca_omp "$@"; }
-fi
-
-  [[ -n "${ORCA_CODEX_HOME:-}" ]] && export CODEX_HOME="${ORCA_CODEX_HOME}"
-if [[ -n "${ORCA_HISTFILE:-}" ]]; then
-  HISTFILE="$ORCA_HISTFILE"
-elif [[ "${HISTFILE:-}" == "$ZDOTDIR/.zsh_history" ]]; then
-  # Why also when Orca injected nothing: /etc/zshrc derived this from Orca's
-  # wrapper ZDOTDIR, so history would accumulate INSIDE the wrapper dir and the
-  # user's real history would be invisible — the plain #11044 bug, with no
-  # per-worktree scoping involved. Matching the exact clobbered value means a
-  # HISTFILE the user set deliberately is never touched.
-  HISTFILE="${ORCA_ORIG_ZDOTDIR:-$HOME}/.zsh_history"
-fi
-  # Why: a typed alias expands inside the shell, after pane launch prep.
-__orca_codex_binary="$(command -v codex 2>/dev/null || :)"
-if [[ -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" && -n "${__orca_codex_binary:-}" && -x "${__orca_codex_binary}" ]]; then
-  codex() {
-    "${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex >/dev/null 2>&1 || :
-    command codex "$@"
-  }
-fi
-unset __orca_codex_binary
-
-fi
-__orca_osc133_precmd() {
-  local exit_code=$?
-  if [[ -n "${__orca_in_command:-}" ]]; then
-    printf "\033]133;D;%s\007" "$exit_code"
-    unset __orca_in_command
-  fi
-  printf "\033]133;A\007"
-}
-__orca_osc133_preexec() {
-  printf "\033]133;C\007"
-  __orca_in_command=1
-}
-# Why: prepend so Orca captures $? before user prompt hooks can overwrite it.
-precmd_functions=(__orca_osc133_precmd ${precmd_functions[@]})
-preexec_functions=(__orca_osc133_preexec ${preexec_functions[@]})
-if [[ ! -o login ]]; then
-_orca_home="${ORCA_ORIG_ZDOTDIR:-$HOME}"
-case "${_orca_home%/}" in
-  */shell-ready/zsh) _orca_home="$HOME" ;;
-esac
-# Why: after Orca's last wrapper file has loaded, the interactive shell should
-# expose the same ZDOTDIR a normal zsh startup would expose.
-export ZDOTDIR="$_orca_home"
-unset _orca_home
-
-fi
+# Why: a login shell still has .zlogin to load; it runs the epilogue instead.
+[[ -o login ]] || __orca_shell_epilogue

--- a/src/main/shell-wrapper-snapshots/daemon-zsh-zshrc.txt
+++ b/src/main/shell-wrapper-snapshots/daemon-zsh-zshrc.txt
@@ -11,5 +11,6 @@ if [[ "$_orca_home" != "$ZDOTDIR" && -o interactive && -f "$_orca_home/.zshrc" ]
   unset _orca_wrapper_zdotdir
 fi
 
-# Why: a login shell still has .zlogin to load; it runs the epilogue instead.
-[[ -o login ]] || __orca_shell_epilogue
+if [[ ! -o login || "$(emulate 2>/dev/null)" != zsh ]]; then
+  (( ${+functions[__orca_shell_epilogue]} )) && __orca_shell_epilogue
+fi

--- a/src/main/shell-wrapper-snapshots/local-bash-rcfile.txt
+++ b/src/main/shell-wrapper-snapshots/local-bash-rcfile.txt
@@ -1,8 +1,14 @@
 # Orca bash shell-ready wrapper
-if [[ "${ORCA_SHELL_STARTUP_IDENTITY:-0}" == "1" ]]; then
-  unset ORCA_SHELL_STARTUP_IDENTITY
-  printf "\033]777;orca-shell-start:%s\007" "$$"
-fi
+_orca_shell_features=",${ORCA_SHELL_FEATURES:-},"
+builtin unset ORCA_SHELL_FEATURES
+__orca_has_feature() { [[ "$_orca_shell_features" == *",$1,"* ]]; }
+__orca_has_feature identity && printf "\033]777;orca-shell-start:%s\007" "$$"
+# Why a plain variable: the channel is consumed and destroyed in these first
+# lines, so nothing this shell later spawns can see or inherit the selection.
+__orca_ready_marker=""
+__orca_has_feature ready && __orca_ready_marker=1
+unset _orca_shell_features
+unset -f __orca_has_feature
 [[ -f /etc/profile ]] && source /etc/profile
 if [[ -f "$HOME/.bash_profile" ]]; then
   source "$HOME/.bash_profile"
@@ -311,7 +317,7 @@ __orca_append_prompt_command() {
 __orca_prepend_prompt_command "__orca_osc133_precmd"
 # Why: append the marker through PROMPT_COMMAND so it fires after the login
 # startup files have rebuilt the prompt, without re-running user rc files.
-if [[ "${ORCA_SHELL_READY_MARKER:-0}" == "1" ]]; then
+if [[ -n "$__orca_ready_marker" ]]; then
   __orca_prompt_mark() {
     printf "\033]777;orca-shell-ready\007"
   }

--- a/src/main/shell-wrapper-snapshots/local-fish-init.txt
+++ b/src/main/shell-wrapper-snapshots/local-fish-init.txt
@@ -1,8 +1,6 @@
-if test "$ORCA_SHELL_READY_MARKER" = 1
-  function __orca_shell_ready_marker --on-event fish_prompt
-    builtin printf "\033]777;orca-shell-ready\007"
-    functions -e __orca_shell_ready_marker
-  end
+function __orca_shell_ready_marker --on-event fish_prompt
+  builtin printf "\033]777;orca-shell-ready\007"
+  functions -e __orca_shell_ready_marker
 end
 if test -n "$ORCA_CODEX_LAUNCH_PREFLIGHT"; and test (type -t codex 2>/dev/null) = file
   function codex

--- a/src/main/shell-wrapper-snapshots/local-zsh-zlogin.txt
+++ b/src/main/shell-wrapper-snapshots/local-zsh-zlogin.txt
@@ -1,8 +1,6 @@
 # Orca zsh shell-ready wrapper
-_orca_home="${ORCA_ORIG_ZDOTDIR:-$HOME}"
-case "${_orca_home%/}" in
-  */shell-ready/zsh) _orca_home="$HOME" ;;
-esac
+__orca_resolve_user_config_dir "${ORCA_ORIG_ZDOTDIR:-$HOME}"
+_orca_home="$REPLY"
 if [[ -o interactive && -f "$_orca_home/.zlogin" ]]; then
   _orca_wrapper_zdotdir="$ZDOTDIR"
   # Why: user startup files resolve plugin/config paths from their own ZDOTDIR;
@@ -13,97 +11,4 @@ if [[ -o interactive && -f "$_orca_home/.zlogin" ]]; then
   unset _orca_wrapper_zdotdir
 fi
 
-__orca_restore_agent_teams_path() {
-  [[ -n "${ORCA_AGENT_TEAMS_SHIM_DIR:-}" ]] || return 0
-  case "$PATH" in
-    "${ORCA_AGENT_TEAMS_SHIM_DIR}"|"${ORCA_AGENT_TEAMS_SHIM_DIR}:"*) return 0 ;;
-  esac
-  export PATH="${ORCA_AGENT_TEAMS_SHIM_DIR}:$PATH"
-}
-__orca_restore_agent_teams_path
-# Why: .zlogin is the final login startup file before the prompt is shown.
-[[ -n "${ORCA_OPENCODE_CONFIG_DIR:-}" ]] && export OPENCODE_CONFIG_DIR="${ORCA_OPENCODE_CONFIG_DIR}"
-[[ -n "${ORCA_MIMOCODE_HOME:-}" ]] && export MIMOCODE_HOME="${ORCA_MIMOCODE_HOME}"
-# Why: OMP does not auto-load Orca's managed status extension; wrap only
-# interactive launch invocations so subcommands such as `omp config` keep
-# their normal argv shape.
-__orca_omp_should_skip_extension() {
-  case "${1:-}" in
-    help|--help|-h|--version|-v) return 0 ;;
-    __complete|acp|agents|auth-broker|auth-gateway|bench|commit|completions|config|dry-balance|gallery|grep|grievances|install|join|models|plugin|read|say|search|setup|shell|ssh|stats|tiny-models|token|ttsr|update|usage|worktree|q|wt) return 0 ;;
-  esac
-  return 1
-}
-__orca_omp() {
-  local __orca_use_extension=1
-  __orca_omp_should_skip_extension "${1:-}" && __orca_use_extension=0
-  if [[ $__orca_use_extension -eq 1 && -n "${ORCA_OMP_STATUS_EXTENSION:-}" && -f "${ORCA_OMP_STATUS_EXTENSION}" ]]; then
-    if [[ "${1:-}" == "launch" ]]; then
-      shift
-      command omp launch --extension "${ORCA_OMP_STATUS_EXTENSION}" "$@"
-    else
-      command omp --extension "${ORCA_OMP_STATUS_EXTENSION}" "$@"
-    fi
-  else
-    command omp "$@"
-  fi
-}
-if [[ -n "${ORCA_OMP_STATUS_EXTENSION:-}" ]]; then
-  omp() { __orca_omp "$@"; }
-fi
-
-[[ -n "${ORCA_CODEX_HOME:-}" ]] && export CODEX_HOME="${ORCA_CODEX_HOME}"
-if [[ -n "${ORCA_HISTFILE:-}" ]]; then
-  HISTFILE="$ORCA_HISTFILE"
-elif [[ "${HISTFILE:-}" == "$ZDOTDIR/.zsh_history" ]]; then
-  # Why also when Orca injected nothing: /etc/zshrc derived this from Orca's
-  # wrapper ZDOTDIR, so history would accumulate INSIDE the wrapper dir and the
-  # user's real history would be invisible — the plain #11044 bug, with no
-  # per-worktree scoping involved. Matching the exact clobbered value means a
-  # HISTFILE the user set deliberately is never touched.
-  HISTFILE="${ORCA_ORIG_ZDOTDIR:-$HOME}/.zsh_history"
-fi
-# Why: a typed alias expands inside the shell, after pane launch prep.
-__orca_codex_binary="$(command -v codex 2>/dev/null || :)"
-if [[ -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" && -n "${__orca_codex_binary:-}" && -x "${__orca_codex_binary}" ]]; then
-  codex() {
-    "${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex >/dev/null 2>&1 || :
-    command codex "$@"
-  }
-fi
-unset __orca_codex_binary
-
-if [[ "${ORCA_SHELL_READY_MARKER:-0}" == "1" ]]; then
-  # Why: capture the prior zle-line-init so the marker chains to it. On a
-  # re-source we are already the bound widget, so keep the function captured
-  # the first time instead of clobbering it to empty (which would silently
-  # drop the user's widget on every prompt after the second source). Only
-  # user-defined widgets are chainable as plain functions; builtin/completion
-  # forms (rare for zle-line-init) are left unchained.
-  if [[ "${widgets[zle-line-init]:-}" == "user:__orca_prompt_mark" ]]; then
-    :
-  elif (( ${+widgets[zle-line-init]} )) && [[ "${widgets[zle-line-init]}" == user:* ]]; then
-    __orca_prev_line_init_fn="${widgets[zle-line-init]#user:}"
-  else
-    __orca_prev_line_init_fn=""
-  fi
-  __orca_prompt_mark() {
-    printf "\033]777;orca-shell-ready\007"
-    # Why: call the prior hook as a plain function, not an aliased widget, so
-    # $WIDGET stays zle-line-init for add-zle-hook-widget dispatchers.
-    if [[ -n "${__orca_prev_line_init_fn:-}" ]]; then
-      "${__orca_prev_line_init_fn}" "$@"
-    fi
-  }
-  zle -N zle-line-init __orca_prompt_mark
-fi
-
-_orca_home="${ORCA_ORIG_ZDOTDIR:-$HOME}"
-case "${_orca_home%/}" in
-  */shell-ready/zsh) _orca_home="$HOME" ;;
-esac
-# Why: after Orca's last wrapper file has loaded, the interactive shell should
-# expose the same ZDOTDIR a normal zsh startup would expose.
-export ZDOTDIR="$_orca_home"
-unset _orca_home
-
+__orca_shell_epilogue

--- a/src/main/shell-wrapper-snapshots/local-zsh-zlogin.txt
+++ b/src/main/shell-wrapper-snapshots/local-zsh-zlogin.txt
@@ -11,4 +11,4 @@ if [[ -o interactive && -f "$_orca_home/.zlogin" ]]; then
   unset _orca_wrapper_zdotdir
 fi
 
-__orca_shell_epilogue
+(( ${+functions[__orca_shell_epilogue]} )) && __orca_shell_epilogue

--- a/src/main/shell-wrapper-snapshots/local-zsh-zlogin.txt
+++ b/src/main/shell-wrapper-snapshots/local-zsh-zlogin.txt
@@ -1,13 +1,13 @@
 # Orca zsh shell-ready wrapper
 __orca_resolve_user_config_dir() {
-  REPLY="${1:-}"
-  while [[ "$REPLY" == */ ]]; do REPLY="${REPLY%/}"; done
-  if [[ -z "$REPLY" || -f "$REPLY/.orca-shell-wrapper" || "$REPLY" == */shell-ready/zsh ]]; then
-    REPLY="$HOME"
+  typeset -g _orca_resolved_config_dir="${1:-}"
+  while [[ "$_orca_resolved_config_dir" == */ ]]; do _orca_resolved_config_dir="${_orca_resolved_config_dir%/}"; done
+  if [[ -z "$_orca_resolved_config_dir" || -f "$_orca_resolved_config_dir/.orca-shell-wrapper" || "$_orca_resolved_config_dir" == */shell-ready/zsh ]]; then
+    _orca_resolved_config_dir="$HOME"
   fi
 }
 __orca_resolve_user_config_dir "${ORCA_ORIG_ZDOTDIR:-$HOME}"
-_orca_home="$REPLY"
+_orca_home="$_orca_resolved_config_dir"
 if [[ -o interactive && -f "$_orca_home/.zlogin" ]]; then
   _orca_wrapper_zdotdir="$ZDOTDIR"
   # Why: user startup files resolve plugin/config paths from their own ZDOTDIR;

--- a/src/main/shell-wrapper-snapshots/local-zsh-zlogin.txt
+++ b/src/main/shell-wrapper-snapshots/local-zsh-zlogin.txt
@@ -1,4 +1,11 @@
 # Orca zsh shell-ready wrapper
+__orca_resolve_user_config_dir() {
+  REPLY="${1:-}"
+  while [[ "$REPLY" == */ ]]; do REPLY="${REPLY%/}"; done
+  if [[ -z "$REPLY" || -f "$REPLY/.orca-shell-wrapper" || "$REPLY" == */shell-ready/zsh ]]; then
+    REPLY="$HOME"
+  fi
+}
 __orca_resolve_user_config_dir "${ORCA_ORIG_ZDOTDIR:-$HOME}"
 _orca_home="$REPLY"
 if [[ -o interactive && -f "$_orca_home/.zlogin" ]]; then

--- a/src/main/shell-wrapper-snapshots/local-zsh-zprofile.txt
+++ b/src/main/shell-wrapper-snapshots/local-zsh-zprofile.txt
@@ -1,4 +1,11 @@
 # Orca zsh shell-ready wrapper
+__orca_resolve_user_config_dir() {
+  REPLY="${1:-}"
+  while [[ "$REPLY" == */ ]]; do REPLY="${REPLY%/}"; done
+  if [[ -z "$REPLY" || -f "$REPLY/.orca-shell-wrapper" || "$REPLY" == */shell-ready/zsh ]]; then
+    REPLY="$HOME"
+  fi
+}
 __orca_resolve_user_config_dir "${ORCA_ORIG_ZDOTDIR:-$HOME}"
 _orca_home="$REPLY"
 if [[ -f "$_orca_home/.zprofile" ]]; then

--- a/src/main/shell-wrapper-snapshots/local-zsh-zprofile.txt
+++ b/src/main/shell-wrapper-snapshots/local-zsh-zprofile.txt
@@ -1,13 +1,13 @@
 # Orca zsh shell-ready wrapper
 __orca_resolve_user_config_dir() {
-  REPLY="${1:-}"
-  while [[ "$REPLY" == */ ]]; do REPLY="${REPLY%/}"; done
-  if [[ -z "$REPLY" || -f "$REPLY/.orca-shell-wrapper" || "$REPLY" == */shell-ready/zsh ]]; then
-    REPLY="$HOME"
+  typeset -g _orca_resolved_config_dir="${1:-}"
+  while [[ "$_orca_resolved_config_dir" == */ ]]; do _orca_resolved_config_dir="${_orca_resolved_config_dir%/}"; done
+  if [[ -z "$_orca_resolved_config_dir" || -f "$_orca_resolved_config_dir/.orca-shell-wrapper" || "$_orca_resolved_config_dir" == */shell-ready/zsh ]]; then
+    _orca_resolved_config_dir="$HOME"
   fi
 }
 __orca_resolve_user_config_dir "${ORCA_ORIG_ZDOTDIR:-$HOME}"
-_orca_home="$REPLY"
+_orca_home="$_orca_resolved_config_dir"
 if [[ -f "$_orca_home/.zprofile" ]]; then
   _orca_wrapper_zdotdir="$ZDOTDIR"
   # Why: user startup files resolve plugin/config paths from their own ZDOTDIR;
@@ -18,3 +18,15 @@ if [[ -f "$_orca_home/.zprofile" ]]; then
   unset _orca_wrapper_zdotdir
 fi
 
+if [[ -f "$_orca_home/.zprofile" ]]; then
+  case "$(emulate 2>/dev/null)" in
+    sh|ksh)
+      export ZDOTDIR="$_orca_home"
+      # Why unset: an ORCA_HISTFILE no wrapper file will ever consume is
+      # inherited by everything this pane spawns, including a nested Orca.
+      builtin unset ORCA_HISTFILE _orca_shell_features _orca_home _orca_resolved_config_dir _orca_wrapper_zdotdir_self
+      unfunction __orca_shell_epilogue __orca_has_feature __orca_resolve_user_config_dir __orca_resolve_inherited_config_dir 2>/dev/null
+      return 0
+      ;;
+  esac
+fi

--- a/src/main/shell-wrapper-snapshots/local-zsh-zprofile.txt
+++ b/src/main/shell-wrapper-snapshots/local-zsh-zprofile.txt
@@ -1,8 +1,6 @@
 # Orca zsh shell-ready wrapper
-_orca_home="${ORCA_ORIG_ZDOTDIR:-$HOME}"
-case "${_orca_home%/}" in
-  */shell-ready/zsh) _orca_home="$HOME" ;;
-esac
+__orca_resolve_user_config_dir "${ORCA_ORIG_ZDOTDIR:-$HOME}"
+_orca_home="$REPLY"
 if [[ -f "$_orca_home/.zprofile" ]]; then
   _orca_wrapper_zdotdir="$ZDOTDIR"
   # Why: user startup files resolve plugin/config paths from their own ZDOTDIR;

--- a/src/main/shell-wrapper-snapshots/local-zsh-zshenv.txt
+++ b/src/main/shell-wrapper-snapshots/local-zsh-zshenv.txt
@@ -91,6 +91,12 @@ fi
 unset _orca_user_zdotdir _orca_zshenv_source_dir _orca_zshenv_path _orca_discovered_zdotdir _orca_wrapper_zdotdir_self
 
 __orca_shell_epilogue() {
+  # Why first: this body runs after the user's own config, so it would otherwise
+  # inherit whatever options that config left set. Under NO_UNSET an unset
+  # precmd_functions is a fatal error that returns from the whole epilogue
+  # (skipping the ready widget and the ZDOTDIR restore), and KSH_ARRAYS makes
+  # the 1-based feature lookup drop the first selected feature.
+  emulate -L zsh
   (( $+_orca_epilogue_done )) && return 0
   typeset -g _orca_epilogue_done=1
   if __orca_has_feature overlay; then
@@ -145,18 +151,16 @@ __orca_shell_epilogue() {
     fi
     unset __orca_codex_binary
   fi
-  if __orca_has_feature history; then
-    if [[ -n "${ORCA_HISTFILE:-}" ]]; then
-      HISTFILE="$ORCA_HISTFILE"
-      builtin unset ORCA_HISTFILE
-    elif [[ "${HISTFILE:-}" == "$ZDOTDIR/.zsh_history" ]]; then
-      # Why also when Orca injected nothing: /etc/zshrc derived this from Orca's
-      # wrapper ZDOTDIR, so history would accumulate INSIDE the wrapper dir and the
-      # user's real history would be invisible — the plain #11044 bug, with no
-      # per-worktree scoping involved. Matching the exact clobbered value means a
-      # HISTFILE the user set deliberately is never touched.
-      HISTFILE="${ORCA_ORIG_ZDOTDIR:-$HOME}/.zsh_history"
-    fi
+  if [[ -n "${ORCA_HISTFILE:-}" ]]; then
+    HISTFILE="$ORCA_HISTFILE"
+    builtin unset ORCA_HISTFILE
+  elif [[ "${HISTFILE:-}" == "$ZDOTDIR/.zsh_history" ]]; then
+    # Why also when Orca injected nothing: /etc/zshrc derived this from Orca's
+    # wrapper ZDOTDIR, so history would accumulate INSIDE the wrapper dir and the
+    # user's real history would be invisible — the plain #11044 bug, with no
+    # per-worktree scoping involved. Matching the exact clobbered value means a
+    # HISTFILE the user set deliberately is never touched.
+    HISTFILE="${ORCA_ORIG_ZDOTDIR:-$HOME}/.zsh_history"
   fi
   if __orca_has_feature markers; then
     __orca_osc133_precmd() {

--- a/src/main/shell-wrapper-snapshots/local-zsh-zshenv.txt
+++ b/src/main/shell-wrapper-snapshots/local-zsh-zshenv.txt
@@ -1,8 +1,28 @@
 # Orca zsh shell-ready wrapper
-if [[ "${ORCA_SHELL_STARTUP_IDENTITY:-0}" == "1" ]]; then
-  unset ORCA_SHELL_STARTUP_IDENTITY
-  printf "\033]777;orca-shell-start:%s\007" "$$"
-fi
+typeset -ga _orca_shell_features
+_orca_shell_features=(${(s:,:)${ORCA_SHELL_FEATURES:-}})
+builtin unset ORCA_SHELL_FEATURES
+__orca_has_feature() { (( ${_orca_shell_features[(Ie)$1]} )) }
+__orca_has_feature identity && printf "\033]777;orca-shell-start:%s\007" "$$"
+__orca_resolve_user_config_dir() {
+  REPLY="${1:-}"
+  while [[ "$REPLY" == */ ]]; do REPLY="${REPLY%/}"; done
+  if [[ -z "$REPLY" || -f "$REPLY/.orca-shell-wrapper" || "$REPLY" == */shell-ready/zsh ]]; then
+    REPLY="$HOME"
+  fi
+}
+# Why stricter for an inherited value: Orca can be launched from a terminal that
+# already pointed ZDOTDIR at its own wrapper dir, and a directory holding no zsh
+# startup file at all is not the user's config root whoever wrote it.
+__orca_resolve_inherited_config_dir() {
+  __orca_resolve_user_config_dir "${1:-}"
+  [[ "$REPLY" == "$HOME" ]] && return 0
+  local _orca_startup_file
+  for _orca_startup_file in .zshenv .zshrc .zprofile .zlogin; do
+    [[ -r "$REPLY/$_orca_startup_file" ]] && return 0
+  done
+  REPLY="$HOME"
+}
 # Why: capture the runtime wrapper dir before it is unset below. On WSL this
 # file is generated with a Windows path but sourced via /mnt/c, so the baked
 # literal is unusable there and ZDOTDIR must be restored from this value.
@@ -20,26 +40,15 @@ fi
 while [[ "${_orca_wrapper_zdotdir_self:-}" == */ ]]; do
   _orca_wrapper_zdotdir_self="${_orca_wrapper_zdotdir_self%/}"
 done
-_orca_spawn_orig_zdotdir="${ORCA_ORIG_ZDOTDIR:-}"
-_orca_user_zdotdir="${_orca_spawn_orig_zdotdir:-$HOME}"
-_orca_zshenv_source_dir="${ORCA_ZSHENV_SOURCE_DIR:-$HOME}"
 _orca_zshenv_path=""
-unset ORCA_ZSHENV_SOURCE_DIR
 
 # Normalize fallback and source roots before reading user .zshenv so nested
 # Orca PTYs never source another Orca wrapper recursively.
-while [[ "${_orca_user_zdotdir}" == */ ]]; do
-  _orca_user_zdotdir="${_orca_user_zdotdir%/}"
-done
-case "${_orca_user_zdotdir}" in
-  ""|*/shell-ready/zsh) _orca_user_zdotdir="$HOME" ;;
-esac
-while [[ "${_orca_zshenv_source_dir}" == */ ]]; do
-  _orca_zshenv_source_dir="${_orca_zshenv_source_dir%/}"
-done
-case "${_orca_zshenv_source_dir}" in
-  ""|*/shell-ready/zsh) _orca_zshenv_source_dir="$HOME" ;;
-esac
+__orca_resolve_inherited_config_dir "${ORCA_ORIG_ZDOTDIR:-$HOME}"
+_orca_user_zdotdir="$REPLY"
+__orca_resolve_inherited_config_dir "${ORCA_ZSHENV_SOURCE_DIR:-$HOME}"
+_orca_zshenv_source_dir="$REPLY"
+unset ORCA_ZSHENV_SOURCE_DIR
 
 # Why: source at wrapper top level, not in a function/subshell, so .zshenv
 # exports, functions, path/fpath typesets, and zsh options keep normal scope.
@@ -67,15 +76,10 @@ if [[ -n "${_orca_discovered_zdotdir}" && ! -d "${_orca_discovered_zdotdir}" ]];
   _orca_discovered_zdotdir=""
 fi
 
-export ORCA_ORIG_ZDOTDIR="${_orca_discovered_zdotdir:-${_orca_user_zdotdir:-$HOME}}"
-
-while [[ "${ORCA_ORIG_ZDOTDIR}" == */ ]]; do
-  ORCA_ORIG_ZDOTDIR="${ORCA_ORIG_ZDOTDIR%/}"
-done
-
-case "${ORCA_ORIG_ZDOTDIR}" in
-  ""|*/shell-ready/zsh) export ORCA_ORIG_ZDOTDIR="$HOME" ;;
-esac
+# Why only the ownership check here: a ZDOTDIR the user's own .zshenv just
+# exported is the user's by construction, whatever it happens to contain.
+__orca_resolve_user_config_dir "${_orca_discovered_zdotdir:-${_orca_user_zdotdir:-$HOME}}"
+export ORCA_ORIG_ZDOTDIR="$REPLY"
 
 # Why: use :- after user .zshenv — a pathological unset under set -u must not
 # abort the wrapper; empty falls through to the baked-literal branch.
@@ -84,4 +88,122 @@ if [[ -n "${_orca_wrapper_zdotdir_self:-}" && -f "${_orca_wrapper_zdotdir_self:-
 else
   export ZDOTDIR='<WRAPPER_ROOT>/zsh'
 fi
-unset _orca_spawn_orig_zdotdir _orca_user_zdotdir _orca_zshenv_source_dir _orca_zshenv_path _orca_discovered_zdotdir _orca_wrapper_zdotdir_self
+unset _orca_user_zdotdir _orca_zshenv_source_dir _orca_zshenv_path _orca_discovered_zdotdir _orca_wrapper_zdotdir_self
+
+__orca_shell_epilogue() {
+  (( $+_orca_epilogue_done )) && return 0
+  typeset -g _orca_epilogue_done=1
+  if __orca_has_feature overlay; then
+    # Why: ~/.zshrc can export the user's default OpenCode config after spawn.
+    __orca_restore_agent_teams_path() {
+      [[ -n "${ORCA_AGENT_TEAMS_SHIM_DIR:-}" ]] || return 0
+      case "$PATH" in
+        "${ORCA_AGENT_TEAMS_SHIM_DIR}"|"${ORCA_AGENT_TEAMS_SHIM_DIR}:"*) return 0 ;;
+      esac
+      export PATH="${ORCA_AGENT_TEAMS_SHIM_DIR}:$PATH"
+    }
+    __orca_restore_agent_teams_path
+    [[ -n "${ORCA_OPENCODE_CONFIG_DIR:-}" ]] && export OPENCODE_CONFIG_DIR="${ORCA_OPENCODE_CONFIG_DIR}"
+    [[ -n "${ORCA_MIMOCODE_HOME:-}" ]] && export MIMOCODE_HOME="${ORCA_MIMOCODE_HOME}"
+    # Why: OMP does not auto-load Orca's managed status extension; wrap only
+    # interactive launch invocations so subcommands such as `omp config` keep
+    # their normal argv shape.
+    __orca_omp_should_skip_extension() {
+      case "${1:-}" in
+        help|--help|-h|--version|-v) return 0 ;;
+        __complete|acp|agents|auth-broker|auth-gateway|bench|commit|completions|config|dry-balance|gallery|grep|grievances|install|join|models|plugin|read|say|search|setup|shell|ssh|stats|tiny-models|token|ttsr|update|usage|worktree|q|wt) return 0 ;;
+      esac
+      return 1
+    }
+    __orca_omp() {
+      local __orca_use_extension=1
+      __orca_omp_should_skip_extension "${1:-}" && __orca_use_extension=0
+      if [[ $__orca_use_extension -eq 1 && -n "${ORCA_OMP_STATUS_EXTENSION:-}" && -f "${ORCA_OMP_STATUS_EXTENSION}" ]]; then
+        if [[ "${1:-}" == "launch" ]]; then
+          shift
+          command omp launch --extension "${ORCA_OMP_STATUS_EXTENSION}" "$@"
+        else
+          command omp --extension "${ORCA_OMP_STATUS_EXTENSION}" "$@"
+        fi
+      else
+        command omp "$@"
+      fi
+    }
+    if [[ -n "${ORCA_OMP_STATUS_EXTENSION:-}" ]]; then
+      omp() { __orca_omp "$@"; }
+    fi
+
+    # Why: Codex must keep using Orca's runtime CODEX_HOME after rc files.
+    [[ -n "${ORCA_CODEX_HOME:-}" ]] && export CODEX_HOME="${ORCA_CODEX_HOME}"
+    # Why: a typed alias expands inside the shell, after pane launch prep.
+    __orca_codex_binary="$(command -v codex 2>/dev/null || :)"
+    if [[ -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" && -n "${__orca_codex_binary:-}" && -x "${__orca_codex_binary}" ]]; then
+      codex() {
+        "${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex >/dev/null 2>&1 || :
+        command codex "$@"
+      }
+    fi
+    unset __orca_codex_binary
+  fi
+  if __orca_has_feature history; then
+    if [[ -n "${ORCA_HISTFILE:-}" ]]; then
+      HISTFILE="$ORCA_HISTFILE"
+      builtin unset ORCA_HISTFILE
+    elif [[ "${HISTFILE:-}" == "$ZDOTDIR/.zsh_history" ]]; then
+      # Why also when Orca injected nothing: /etc/zshrc derived this from Orca's
+      # wrapper ZDOTDIR, so history would accumulate INSIDE the wrapper dir and the
+      # user's real history would be invisible — the plain #11044 bug, with no
+      # per-worktree scoping involved. Matching the exact clobbered value means a
+      # HISTFILE the user set deliberately is never touched.
+      HISTFILE="${ORCA_ORIG_ZDOTDIR:-$HOME}/.zsh_history"
+    fi
+  fi
+  if __orca_has_feature markers; then
+    __orca_osc133_precmd() {
+      local exit_code=$?
+      if [[ -n "${__orca_in_command:-}" ]]; then
+        printf "\033]133;D;%s\007" "$exit_code"
+        unset __orca_in_command
+      fi
+      printf "\033]133;A\007"
+    }
+    __orca_osc133_preexec() {
+      printf "\033]133;C\007"
+      __orca_in_command=1
+    }
+    # Why: prepend so Orca captures $? before user prompt hooks can overwrite it.
+    precmd_functions=(__orca_osc133_precmd ${precmd_functions[@]})
+    preexec_functions=(__orca_osc133_preexec ${preexec_functions[@]})
+  fi
+  if __orca_has_feature ready; then
+    # Why: capture the prior zle-line-init so the marker chains to it. On a
+    # re-source we are already the bound widget, so keep the function captured
+    # the first time instead of clobbering it to empty (which would silently
+    # drop the user's widget on every prompt after the second source). Only
+    # user-defined widgets are chainable as plain functions; builtin/completion
+    # forms (rare for zle-line-init) are left unchained.
+    if [[ "${widgets[zle-line-init]:-}" == "user:__orca_prompt_mark" ]]; then
+      :
+    elif (( ${+widgets[zle-line-init]} )) && [[ "${widgets[zle-line-init]}" == user:* ]]; then
+      __orca_prev_line_init_fn="${widgets[zle-line-init]#user:}"
+    else
+      __orca_prev_line_init_fn=""
+    fi
+    __orca_prompt_mark() {
+      printf "\033]777;orca-shell-ready\007"
+      # Why: call the prior hook as a plain function, not an aliased widget, so
+      # $WIDGET stays zle-line-init for add-zle-hook-widget dispatchers.
+      if [[ -n "${__orca_prev_line_init_fn:-}" ]]; then
+        "${__orca_prev_line_init_fn}" "$@"
+      fi
+    }
+    zle -N zle-line-init __orca_prompt_mark
+  fi
+  __orca_resolve_user_config_dir "${ORCA_ORIG_ZDOTDIR:-$HOME}"
+  # Why: after Orca's last wrapper file has loaded, the interactive shell should
+  # expose the same ZDOTDIR a normal zsh startup would expose.
+  export ZDOTDIR="$REPLY"
+  unset _orca_home REPLY
+  unset _orca_shell_features
+  unfunction __orca_shell_epilogue __orca_has_feature __orca_resolve_user_config_dir __orca_resolve_inherited_config_dir
+}

--- a/src/main/shell-wrapper-snapshots/local-zsh-zshenv.txt
+++ b/src/main/shell-wrapper-snapshots/local-zsh-zshenv.txt
@@ -5,10 +5,10 @@ builtin unset ORCA_SHELL_FEATURES
 __orca_has_feature() { (( ${_orca_shell_features[(Ie)$1]} )) }
 __orca_has_feature identity && printf "\033]777;orca-shell-start:%s\007" "$$"
 __orca_resolve_user_config_dir() {
-  REPLY="${1:-}"
-  while [[ "$REPLY" == */ ]]; do REPLY="${REPLY%/}"; done
-  if [[ -z "$REPLY" || -f "$REPLY/.orca-shell-wrapper" || "$REPLY" == */shell-ready/zsh ]]; then
-    REPLY="$HOME"
+  typeset -g _orca_resolved_config_dir="${1:-}"
+  while [[ "$_orca_resolved_config_dir" == */ ]]; do _orca_resolved_config_dir="${_orca_resolved_config_dir%/}"; done
+  if [[ -z "$_orca_resolved_config_dir" || -f "$_orca_resolved_config_dir/.orca-shell-wrapper" || "$_orca_resolved_config_dir" == */shell-ready/zsh ]]; then
+    _orca_resolved_config_dir="$HOME"
   fi
 }
 # Why stricter for an inherited value: Orca can be launched from a terminal that
@@ -16,12 +16,12 @@ __orca_resolve_user_config_dir() {
 # startup file at all is not the user's config root whoever wrote it.
 __orca_resolve_inherited_config_dir() {
   __orca_resolve_user_config_dir "${1:-}"
-  [[ "$REPLY" == "$HOME" ]] && return 0
+  [[ "$_orca_resolved_config_dir" == "$HOME" ]] && return 0
   local _orca_startup_file
   for _orca_startup_file in .zshenv .zshrc .zprofile .zlogin; do
-    [[ -r "$REPLY/$_orca_startup_file" ]] && return 0
+    [[ -r "$_orca_resolved_config_dir/$_orca_startup_file" ]] && return 0
   done
-  REPLY="$HOME"
+  _orca_resolved_config_dir="$HOME"
 }
 # Why: capture the runtime wrapper dir before it is unset below. On WSL this
 # file is generated with a Windows path but sourced via /mnt/c, so the baked
@@ -45,9 +45,9 @@ _orca_zshenv_path=""
 # Normalize fallback and source roots before reading user .zshenv so nested
 # Orca PTYs never source another Orca wrapper recursively.
 __orca_resolve_inherited_config_dir "${ORCA_ORIG_ZDOTDIR:-$HOME}"
-_orca_user_zdotdir="$REPLY"
+_orca_user_zdotdir="$_orca_resolved_config_dir"
 __orca_resolve_inherited_config_dir "${ORCA_ZSHENV_SOURCE_DIR:-$HOME}"
-_orca_zshenv_source_dir="$REPLY"
+_orca_zshenv_source_dir="$_orca_resolved_config_dir"
 unset ORCA_ZSHENV_SOURCE_DIR
 
 # Why: source at wrapper top level, not in a function/subshell, so .zshenv
@@ -79,7 +79,22 @@ fi
 # Why only the ownership check here: a ZDOTDIR the user's own .zshenv just
 # exported is the user's by construction, whatever it happens to contain.
 __orca_resolve_user_config_dir "${_orca_discovered_zdotdir:-${_orca_user_zdotdir:-$HOME}}"
-export ORCA_ORIG_ZDOTDIR="$REPLY"
+export ORCA_ORIG_ZDOTDIR="$_orca_resolved_config_dir"
+unset _orca_user_zdotdir _orca_zshenv_source_dir _orca_discovered_zdotdir
+
+if [[ -n "${_orca_zshenv_path:-}" ]]; then
+  case "$(emulate 2>/dev/null)" in
+    sh|ksh)
+      export ZDOTDIR="$ORCA_ORIG_ZDOTDIR"
+      # Why unset: an ORCA_HISTFILE no wrapper file will ever consume is
+      # inherited by everything this pane spawns, including a nested Orca.
+      builtin unset ORCA_HISTFILE _orca_shell_features _orca_home _orca_resolved_config_dir _orca_wrapper_zdotdir_self
+      unfunction __orca_shell_epilogue __orca_has_feature __orca_resolve_user_config_dir __orca_resolve_inherited_config_dir 2>/dev/null
+      return 0
+      ;;
+  esac
+fi
+unset _orca_zshenv_path
 
 # Why: use :- after user .zshenv — a pathological unset under set -u must not
 # abort the wrapper; empty falls through to the baked-literal branch.
@@ -88,7 +103,7 @@ if [[ -n "${_orca_wrapper_zdotdir_self:-}" && -f "${_orca_wrapper_zdotdir_self:-
 else
   export ZDOTDIR='<WRAPPER_ROOT>/zsh'
 fi
-unset _orca_user_zdotdir _orca_zshenv_source_dir _orca_zshenv_path _orca_discovered_zdotdir _orca_wrapper_zdotdir_self
+unset _orca_wrapper_zdotdir_self
 
 __orca_shell_epilogue() {
   # Why first: this body runs after the user's own config, so it would otherwise
@@ -173,7 +188,9 @@ __orca_shell_epilogue() {
     }
     __orca_osc133_preexec() {
       printf "\033]133;C\007"
-      __orca_in_command=1
+      # Why typeset -g: a plain assignment here creates a global inside a function,
+      # which prints a warning above every command under warn_create_global.
+      typeset -g __orca_in_command=1
     }
     # Why: prepend so Orca captures $? before user prompt hooks can overwrite it.
     precmd_functions=(__orca_osc133_precmd ${precmd_functions[@]})
@@ -206,8 +223,8 @@ __orca_shell_epilogue() {
   __orca_resolve_user_config_dir "${ORCA_ORIG_ZDOTDIR:-$HOME}"
   # Why: after Orca's last wrapper file has loaded, the interactive shell should
   # expose the same ZDOTDIR a normal zsh startup would expose.
-  export ZDOTDIR="$REPLY"
-  unset _orca_home REPLY
+  export ZDOTDIR="$_orca_resolved_config_dir"
+  unset _orca_home _orca_resolved_config_dir
   unset _orca_shell_features
   unfunction __orca_shell_epilogue __orca_has_feature __orca_resolve_user_config_dir __orca_resolve_inherited_config_dir
 }

--- a/src/main/shell-wrapper-snapshots/local-zsh-zshrc.txt
+++ b/src/main/shell-wrapper-snapshots/local-zsh-zshrc.txt
@@ -1,8 +1,6 @@
 # Orca zsh shell-ready wrapper
-_orca_home="${ORCA_ORIG_ZDOTDIR:-$HOME}"
-case "${_orca_home%/}" in
-  */shell-ready/zsh) _orca_home="$HOME" ;;
-esac
+__orca_resolve_user_config_dir "${ORCA_ORIG_ZDOTDIR:-$HOME}"
+_orca_home="$REPLY"
 if [[ "$_orca_home" != "$ZDOTDIR" && -o interactive && -f "$_orca_home/.zshrc" ]]; then
   _orca_wrapper_zdotdir="$ZDOTDIR"
   # Why: user startup files resolve plugin/config paths from their own ZDOTDIR;
@@ -13,92 +11,5 @@ if [[ "$_orca_home" != "$ZDOTDIR" && -o interactive && -f "$_orca_home/.zshrc" ]
   unset _orca_wrapper_zdotdir
 fi
 
-__orca_restore_agent_teams_path() {
-  [[ -n "${ORCA_AGENT_TEAMS_SHIM_DIR:-}" ]] || return 0
-  case "$PATH" in
-    "${ORCA_AGENT_TEAMS_SHIM_DIR}"|"${ORCA_AGENT_TEAMS_SHIM_DIR}:"*) return 0 ;;
-  esac
-  export PATH="${ORCA_AGENT_TEAMS_SHIM_DIR}:$PATH"
-}
-[[ ! -o login ]] && __orca_restore_agent_teams_path
-if [[ ! -o login ]]; then
-  # Why: ~/.zshrc can export the user's default OpenCode config after spawn.
-  [[ -n "${ORCA_OPENCODE_CONFIG_DIR:-}" ]] && export OPENCODE_CONFIG_DIR="${ORCA_OPENCODE_CONFIG_DIR}"
-[[ -n "${ORCA_MIMOCODE_HOME:-}" ]] && export MIMOCODE_HOME="${ORCA_MIMOCODE_HOME}"
-  # Why: OMP does not auto-load Orca's managed status extension; wrap only
-# interactive launch invocations so subcommands such as `omp config` keep
-# their normal argv shape.
-__orca_omp_should_skip_extension() {
-  case "${1:-}" in
-    help|--help|-h|--version|-v) return 0 ;;
-    __complete|acp|agents|auth-broker|auth-gateway|bench|commit|completions|config|dry-balance|gallery|grep|grievances|install|join|models|plugin|read|say|search|setup|shell|ssh|stats|tiny-models|token|ttsr|update|usage|worktree|q|wt) return 0 ;;
-  esac
-  return 1
-}
-__orca_omp() {
-  local __orca_use_extension=1
-  __orca_omp_should_skip_extension "${1:-}" && __orca_use_extension=0
-  if [[ $__orca_use_extension -eq 1 && -n "${ORCA_OMP_STATUS_EXTENSION:-}" && -f "${ORCA_OMP_STATUS_EXTENSION}" ]]; then
-    if [[ "${1:-}" == "launch" ]]; then
-      shift
-      command omp launch --extension "${ORCA_OMP_STATUS_EXTENSION}" "$@"
-    else
-      command omp --extension "${ORCA_OMP_STATUS_EXTENSION}" "$@"
-    fi
-  else
-    command omp "$@"
-  fi
-}
-if [[ -n "${ORCA_OMP_STATUS_EXTENSION:-}" ]]; then
-  omp() { __orca_omp "$@"; }
-fi
-
-  # Why: Codex must keep using Orca's runtime CODEX_HOME after rc files.
-  [[ -n "${ORCA_CODEX_HOME:-}" ]] && export CODEX_HOME="${ORCA_CODEX_HOME}"
-if [[ -n "${ORCA_HISTFILE:-}" ]]; then
-  HISTFILE="$ORCA_HISTFILE"
-elif [[ "${HISTFILE:-}" == "$ZDOTDIR/.zsh_history" ]]; then
-  # Why also when Orca injected nothing: /etc/zshrc derived this from Orca's
-  # wrapper ZDOTDIR, so history would accumulate INSIDE the wrapper dir and the
-  # user's real history would be invisible — the plain #11044 bug, with no
-  # per-worktree scoping involved. Matching the exact clobbered value means a
-  # HISTFILE the user set deliberately is never touched.
-  HISTFILE="${ORCA_ORIG_ZDOTDIR:-$HOME}/.zsh_history"
-fi
-  # Why: a typed alias expands inside the shell, after pane launch prep.
-__orca_codex_binary="$(command -v codex 2>/dev/null || :)"
-if [[ -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" && -n "${__orca_codex_binary:-}" && -x "${__orca_codex_binary}" ]]; then
-  codex() {
-    "${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex >/dev/null 2>&1 || :
-    command codex "$@"
-  }
-fi
-unset __orca_codex_binary
-
-fi
-__orca_osc133_precmd() {
-  local exit_code=$?
-  if [[ -n "${__orca_in_command:-}" ]]; then
-    printf "\033]133;D;%s\007" "$exit_code"
-    unset __orca_in_command
-  fi
-  printf "\033]133;A\007"
-}
-__orca_osc133_preexec() {
-  printf "\033]133;C\007"
-  __orca_in_command=1
-}
-# Why: prepend so Orca captures $? before user prompt hooks can overwrite it.
-precmd_functions=(__orca_osc133_precmd ${precmd_functions[@]})
-preexec_functions=(__orca_osc133_preexec ${preexec_functions[@]})
-if [[ ! -o login ]]; then
-_orca_home="${ORCA_ORIG_ZDOTDIR:-$HOME}"
-case "${_orca_home%/}" in
-  */shell-ready/zsh) _orca_home="$HOME" ;;
-esac
-# Why: after Orca's last wrapper file has loaded, the interactive shell should
-# expose the same ZDOTDIR a normal zsh startup would expose.
-export ZDOTDIR="$_orca_home"
-unset _orca_home
-
-fi
+# Why: a login shell still has .zlogin to load; it runs the epilogue instead.
+[[ -o login ]] || __orca_shell_epilogue

--- a/src/main/shell-wrapper-snapshots/local-zsh-zshrc.txt
+++ b/src/main/shell-wrapper-snapshots/local-zsh-zshrc.txt
@@ -1,4 +1,11 @@
 # Orca zsh shell-ready wrapper
+__orca_resolve_user_config_dir() {
+  REPLY="${1:-}"
+  while [[ "$REPLY" == */ ]]; do REPLY="${REPLY%/}"; done
+  if [[ -z "$REPLY" || -f "$REPLY/.orca-shell-wrapper" || "$REPLY" == */shell-ready/zsh ]]; then
+    REPLY="$HOME"
+  fi
+}
 __orca_resolve_user_config_dir "${ORCA_ORIG_ZDOTDIR:-$HOME}"
 _orca_home="$REPLY"
 if [[ "$_orca_home" != "$ZDOTDIR" && -o interactive && -f "$_orca_home/.zshrc" ]]; then

--- a/src/main/shell-wrapper-snapshots/local-zsh-zshrc.txt
+++ b/src/main/shell-wrapper-snapshots/local-zsh-zshrc.txt
@@ -1,13 +1,13 @@
 # Orca zsh shell-ready wrapper
 __orca_resolve_user_config_dir() {
-  REPLY="${1:-}"
-  while [[ "$REPLY" == */ ]]; do REPLY="${REPLY%/}"; done
-  if [[ -z "$REPLY" || -f "$REPLY/.orca-shell-wrapper" || "$REPLY" == */shell-ready/zsh ]]; then
-    REPLY="$HOME"
+  typeset -g _orca_resolved_config_dir="${1:-}"
+  while [[ "$_orca_resolved_config_dir" == */ ]]; do _orca_resolved_config_dir="${_orca_resolved_config_dir%/}"; done
+  if [[ -z "$_orca_resolved_config_dir" || -f "$_orca_resolved_config_dir/.orca-shell-wrapper" || "$_orca_resolved_config_dir" == */shell-ready/zsh ]]; then
+    _orca_resolved_config_dir="$HOME"
   fi
 }
 __orca_resolve_user_config_dir "${ORCA_ORIG_ZDOTDIR:-$HOME}"
-_orca_home="$REPLY"
+_orca_home="$_orca_resolved_config_dir"
 if [[ "$_orca_home" != "$ZDOTDIR" && -o interactive && -f "$_orca_home/.zshrc" ]]; then
   _orca_wrapper_zdotdir="$ZDOTDIR"
   # Why: user startup files resolve plugin/config paths from their own ZDOTDIR;

--- a/src/main/shell-wrapper-snapshots/local-zsh-zshrc.txt
+++ b/src/main/shell-wrapper-snapshots/local-zsh-zshrc.txt
@@ -11,5 +11,6 @@ if [[ "$_orca_home" != "$ZDOTDIR" && -o interactive && -f "$_orca_home/.zshrc" ]
   unset _orca_wrapper_zdotdir
 fi
 
-# Why: a login shell still has .zlogin to load; it runs the epilogue instead.
-[[ -o login ]] || __orca_shell_epilogue
+if [[ ! -o login || "$(emulate 2>/dev/null)" != zsh ]]; then
+  (( ${+functions[__orca_shell_epilogue]} )) && __orca_shell_epilogue
+fi

--- a/src/main/shell-wrapper-snapshots/relay-bash-rcfile.txt
+++ b/src/main/shell-wrapper-snapshots/relay-bash-rcfile.txt
@@ -1,8 +1,14 @@
 # Orca relay bash overlay wrapper
-if [[ "${ORCA_SHELL_STARTUP_IDENTITY:-0}" == "1" ]]; then
-  unset ORCA_SHELL_STARTUP_IDENTITY
-  printf "\033]777;orca-shell-start:%s\007" "$$"
-fi
+_orca_shell_features=",${ORCA_SHELL_FEATURES:-},"
+builtin unset ORCA_SHELL_FEATURES
+__orca_has_feature() { [[ "$_orca_shell_features" == *",$1,"* ]]; }
+__orca_has_feature identity && printf "\033]777;orca-shell-start:%s\007" "$$"
+# Why a plain variable: the channel is consumed and destroyed in these first
+# lines, so nothing this shell later spawns can see or inherit the selection.
+__orca_ready_marker=""
+__orca_has_feature ready && __orca_ready_marker=1
+unset _orca_shell_features
+unset -f __orca_has_feature
 [[ -f /etc/profile ]] && source /etc/profile
 if [[ -f "$HOME/.bash_profile" ]]; then
   source "$HOME/.bash_profile"
@@ -50,6 +56,7 @@ fi
 
 if [[ -n "${ORCA_HISTFILE:-}" ]]; then
   HISTFILE="$ORCA_HISTFILE"
+  builtin unset ORCA_HISTFILE
 elif [[ "${HISTFILE:-}" == "$ZDOTDIR/.zsh_history" ]]; then
   # Why also when Orca injected nothing: /etc/zshrc derived this from Orca's
   # wrapper ZDOTDIR, so history would accumulate INSIDE the wrapper dir and the
@@ -291,7 +298,7 @@ __orca_append_prompt_command() {
 __orca_prepend_prompt_command "__orca_osc133_precmd"
 # Why: SSH startup commands are renderer-delivered; emit the same internal
 # readiness marker as local shells only when that delivery mode asks for it.
-if [[ "${ORCA_SHELL_READY_MARKER:-0}" == "1" ]]; then
+if [[ -n "$__orca_ready_marker" ]]; then
   __orca_prompt_mark() {
     printf "\033]777;orca-shell-ready\007"
   }

--- a/src/main/shell-wrapper-snapshots/relay-zsh-zlogin.txt
+++ b/src/main/shell-wrapper-snapshots/relay-zsh-zlogin.txt
@@ -1,13 +1,13 @@
 # Orca relay zsh overlay wrapper
 __orca_resolve_user_config_dir() {
-  REPLY="${1:-}"
-  while [[ "$REPLY" == */ ]]; do REPLY="${REPLY%/}"; done
-  if [[ -z "$REPLY" || -f "$REPLY/.orca-shell-wrapper" || "$REPLY" == */shell-ready/zsh ]]; then
-    REPLY="$HOME"
+  typeset -g _orca_resolved_config_dir="${1:-}"
+  while [[ "$_orca_resolved_config_dir" == */ ]]; do _orca_resolved_config_dir="${_orca_resolved_config_dir%/}"; done
+  if [[ -z "$_orca_resolved_config_dir" || -f "$_orca_resolved_config_dir/.orca-shell-wrapper" || "$_orca_resolved_config_dir" == */shell-ready/zsh ]]; then
+    _orca_resolved_config_dir="$HOME"
   fi
 }
 __orca_resolve_user_config_dir "${ORCA_USER_ZDOTDIR:-${ORCA_ORIG_ZDOTDIR:-$HOME}}"
-_orca_home="$REPLY"
+_orca_home="$_orca_resolved_config_dir"
 if [[ -o interactive && -f "$_orca_home/.zlogin" ]]; then
   _orca_wrapper_zdotdir="$ZDOTDIR"
   # Why: user startup files resolve plugin/config paths from their own ZDOTDIR;

--- a/src/main/shell-wrapper-snapshots/relay-zsh-zlogin.txt
+++ b/src/main/shell-wrapper-snapshots/relay-zsh-zlogin.txt
@@ -11,4 +11,4 @@ if [[ -o interactive && -f "$_orca_home/.zlogin" ]]; then
   unset _orca_wrapper_zdotdir
 fi
 
-__orca_shell_epilogue
+(( ${+functions[__orca_shell_epilogue]} )) && __orca_shell_epilogue

--- a/src/main/shell-wrapper-snapshots/relay-zsh-zlogin.txt
+++ b/src/main/shell-wrapper-snapshots/relay-zsh-zlogin.txt
@@ -1,8 +1,6 @@
 # Orca relay zsh overlay wrapper
-_orca_home="${ORCA_USER_ZDOTDIR:-${ORCA_ORIG_ZDOTDIR:-$HOME}}"
-case "${_orca_home%/}" in
-  */shell-ready/zsh) _orca_home="$HOME" ;;
-esac
+__orca_resolve_user_config_dir "${ORCA_USER_ZDOTDIR:-${ORCA_ORIG_ZDOTDIR:-$HOME}}"
+_orca_home="$REPLY"
 if [[ -o interactive && -f "$_orca_home/.zlogin" ]]; then
   _orca_wrapper_zdotdir="$ZDOTDIR"
   # Why: user startup files resolve plugin/config paths from their own ZDOTDIR;
@@ -13,79 +11,4 @@ if [[ -o interactive && -f "$_orca_home/.zlogin" ]]; then
   unset _orca_wrapper_zdotdir
 fi
 
-# Why: .zlogin is the final zsh login startup file before the prompt.
-[[ -n "${ORCA_OPENCODE_CONFIG_DIR:-}" ]] && export OPENCODE_CONFIG_DIR="${ORCA_OPENCODE_CONFIG_DIR}"
-[[ -n "${ORCA_MIMOCODE_HOME:-}" ]] && export MIMOCODE_HOME="${ORCA_MIMOCODE_HOME}"
-[[ -n "${ORCA_REMOTE_CLI_BIN_DIR:-}" ]] && case ":$PATH:" in *:"${ORCA_REMOTE_CLI_BIN_DIR}":*) ;; *) export PATH="${ORCA_REMOTE_CLI_BIN_DIR}:$PATH" ;; esac
-# Why: OMP does not auto-load Orca's managed status extension; wrap only
-# interactive launch invocations so subcommands such as `omp config` keep
-# their normal argv shape.
-__orca_omp_should_skip_extension() {
-  case "${1:-}" in
-    help|--help|-h|--version|-v) return 0 ;;
-    __complete|acp|agents|auth-broker|auth-gateway|bench|commit|completions|config|dry-balance|gallery|grep|grievances|install|join|models|plugin|read|say|search|setup|shell|ssh|stats|tiny-models|token|ttsr|update|usage|worktree|q|wt) return 0 ;;
-  esac
-  return 1
-}
-__orca_omp() {
-  local __orca_use_extension=1
-  __orca_omp_should_skip_extension "${1:-}" && __orca_use_extension=0
-  if [[ $__orca_use_extension -eq 1 && -n "${ORCA_OMP_STATUS_EXTENSION:-}" && -f "${ORCA_OMP_STATUS_EXTENSION}" ]]; then
-    if [[ "${1:-}" == "launch" ]]; then
-      shift
-      command omp launch --extension "${ORCA_OMP_STATUS_EXTENSION}" "$@"
-    else
-      command omp --extension "${ORCA_OMP_STATUS_EXTENSION}" "$@"
-    fi
-  else
-    command omp "$@"
-  fi
-}
-if [[ -n "${ORCA_OMP_STATUS_EXTENSION:-}" ]]; then
-  omp() { __orca_omp "$@"; }
-fi
-
-if [[ -n "${ORCA_HISTFILE:-}" ]]; then
-  HISTFILE="$ORCA_HISTFILE"
-elif [[ "${HISTFILE:-}" == "$ZDOTDIR/.zsh_history" ]]; then
-  # Why also when Orca injected nothing: /etc/zshrc derived this from Orca's
-  # wrapper ZDOTDIR, so history would accumulate INSIDE the wrapper dir and the
-  # user's real history would be invisible — the plain #11044 bug, with no
-  # per-worktree scoping involved. Matching the exact clobbered value means a
-  # HISTFILE the user set deliberately is never touched.
-  HISTFILE="${ORCA_ORIG_ZDOTDIR:-$HOME}/.zsh_history"
-fi
-_orca_home="${ORCA_USER_ZDOTDIR:-${ORCA_ORIG_ZDOTDIR:-$HOME}}"
-case "${_orca_home%/}" in
-  */shell-ready/zsh) _orca_home="$HOME" ;;
-esac
-# Why: after Orca's last wrapper file has loaded, the interactive shell should
-# expose the same ZDOTDIR a normal zsh startup would expose.
-export ZDOTDIR="$_orca_home"
-unset _orca_home
-
-if [[ "${ORCA_SHELL_READY_MARKER:-0}" == "1" ]]; then
-  # Why: capture the prior zle-line-init so the marker chains to it. On a
-  # re-source we are already the bound widget, so keep the function captured
-  # the first time instead of clobbering it to empty (which would silently
-  # drop the user's widget on every prompt after the second source). Only
-  # user-defined widgets are chainable as plain functions; builtin/completion
-  # forms (rare for zle-line-init) are left unchained.
-  if [[ "${widgets[zle-line-init]:-}" == "user:__orca_prompt_mark" ]]; then
-    :
-  elif (( ${+widgets[zle-line-init]} )) && [[ "${widgets[zle-line-init]}" == user:* ]]; then
-    __orca_prev_line_init_fn="${widgets[zle-line-init]#user:}"
-  else
-    __orca_prev_line_init_fn=""
-  fi
-  __orca_prompt_mark() {
-    printf "\033]777;orca-shell-ready\007"
-    # Why: call the prior hook as a plain function, not an aliased widget, so
-    # $WIDGET stays zle-line-init for add-zle-hook-widget dispatchers.
-    if [[ -n "${__orca_prev_line_init_fn:-}" ]]; then
-      "${__orca_prev_line_init_fn}" "$@"
-    fi
-  }
-  zle -N zle-line-init __orca_prompt_mark
-fi
-
+__orca_shell_epilogue

--- a/src/main/shell-wrapper-snapshots/relay-zsh-zlogin.txt
+++ b/src/main/shell-wrapper-snapshots/relay-zsh-zlogin.txt
@@ -1,4 +1,11 @@
 # Orca relay zsh overlay wrapper
+__orca_resolve_user_config_dir() {
+  REPLY="${1:-}"
+  while [[ "$REPLY" == */ ]]; do REPLY="${REPLY%/}"; done
+  if [[ -z "$REPLY" || -f "$REPLY/.orca-shell-wrapper" || "$REPLY" == */shell-ready/zsh ]]; then
+    REPLY="$HOME"
+  fi
+}
 __orca_resolve_user_config_dir "${ORCA_USER_ZDOTDIR:-${ORCA_ORIG_ZDOTDIR:-$HOME}}"
 _orca_home="$REPLY"
 if [[ -o interactive && -f "$_orca_home/.zlogin" ]]; then

--- a/src/main/shell-wrapper-snapshots/relay-zsh-zprofile.txt
+++ b/src/main/shell-wrapper-snapshots/relay-zsh-zprofile.txt
@@ -1,8 +1,6 @@
 # Orca relay zsh overlay wrapper
-_orca_home="${ORCA_USER_ZDOTDIR:-${ORCA_ORIG_ZDOTDIR:-$HOME}}"
-case "${_orca_home%/}" in
-  */shell-ready/zsh) _orca_home="$HOME" ;;
-esac
+__orca_resolve_user_config_dir "${ORCA_USER_ZDOTDIR:-${ORCA_ORIG_ZDOTDIR:-$HOME}}"
+_orca_home="$REPLY"
 if [[ -f "$_orca_home/.zprofile" ]]; then
   _orca_wrapper_zdotdir="$ZDOTDIR"
   # Why: user startup files resolve plugin/config paths from their own ZDOTDIR;

--- a/src/main/shell-wrapper-snapshots/relay-zsh-zprofile.txt
+++ b/src/main/shell-wrapper-snapshots/relay-zsh-zprofile.txt
@@ -1,13 +1,13 @@
 # Orca relay zsh overlay wrapper
 __orca_resolve_user_config_dir() {
-  REPLY="${1:-}"
-  while [[ "$REPLY" == */ ]]; do REPLY="${REPLY%/}"; done
-  if [[ -z "$REPLY" || -f "$REPLY/.orca-shell-wrapper" || "$REPLY" == */shell-ready/zsh ]]; then
-    REPLY="$HOME"
+  typeset -g _orca_resolved_config_dir="${1:-}"
+  while [[ "$_orca_resolved_config_dir" == */ ]]; do _orca_resolved_config_dir="${_orca_resolved_config_dir%/}"; done
+  if [[ -z "$_orca_resolved_config_dir" || -f "$_orca_resolved_config_dir/.orca-shell-wrapper" || "$_orca_resolved_config_dir" == */shell-ready/zsh ]]; then
+    _orca_resolved_config_dir="$HOME"
   fi
 }
 __orca_resolve_user_config_dir "${ORCA_USER_ZDOTDIR:-${ORCA_ORIG_ZDOTDIR:-$HOME}}"
-_orca_home="$REPLY"
+_orca_home="$_orca_resolved_config_dir"
 if [[ -f "$_orca_home/.zprofile" ]]; then
   _orca_wrapper_zdotdir="$ZDOTDIR"
   # Why: user startup files resolve plugin/config paths from their own ZDOTDIR;
@@ -18,3 +18,15 @@ if [[ -f "$_orca_home/.zprofile" ]]; then
   unset _orca_wrapper_zdotdir
 fi
 
+if [[ -f "$_orca_home/.zprofile" ]]; then
+  case "$(emulate 2>/dev/null)" in
+    sh|ksh)
+      export ZDOTDIR="$_orca_home"
+      # Why unset: an ORCA_HISTFILE no wrapper file will ever consume is
+      # inherited by everything this pane spawns, including a nested Orca.
+      builtin unset ORCA_HISTFILE _orca_shell_features _orca_home _orca_resolved_config_dir _orca_wrapper_zdotdir_self
+      unfunction __orca_shell_epilogue __orca_has_feature __orca_resolve_user_config_dir __orca_resolve_inherited_config_dir 2>/dev/null
+      return 0
+      ;;
+  esac
+fi

--- a/src/main/shell-wrapper-snapshots/relay-zsh-zprofile.txt
+++ b/src/main/shell-wrapper-snapshots/relay-zsh-zprofile.txt
@@ -1,4 +1,11 @@
 # Orca relay zsh overlay wrapper
+__orca_resolve_user_config_dir() {
+  REPLY="${1:-}"
+  while [[ "$REPLY" == */ ]]; do REPLY="${REPLY%/}"; done
+  if [[ -z "$REPLY" || -f "$REPLY/.orca-shell-wrapper" || "$REPLY" == */shell-ready/zsh ]]; then
+    REPLY="$HOME"
+  fi
+}
 __orca_resolve_user_config_dir "${ORCA_USER_ZDOTDIR:-${ORCA_ORIG_ZDOTDIR:-$HOME}}"
 _orca_home="$REPLY"
 if [[ -f "$_orca_home/.zprofile" ]]; then

--- a/src/main/shell-wrapper-snapshots/relay-zsh-zshenv.txt
+++ b/src/main/shell-wrapper-snapshots/relay-zsh-zshenv.txt
@@ -1,15 +1,113 @@
 # Orca relay zsh overlay wrapper
-if [[ "${ORCA_SHELL_STARTUP_IDENTITY:-0}" == "1" ]]; then
-  unset ORCA_SHELL_STARTUP_IDENTITY
-  printf "\033]777;orca-shell-start:%s\007" "$$"
-fi
-export ORCA_ORIG_ZDOTDIR="${ORCA_ORIG_ZDOTDIR:-$HOME}"
-case "${ORCA_ORIG_ZDOTDIR%/}" in
-  */shell-ready/zsh) export ORCA_ORIG_ZDOTDIR="$HOME" ;;
-esac
+typeset -ga _orca_shell_features
+_orca_shell_features=(${(s:,:)${ORCA_SHELL_FEATURES:-}})
+builtin unset ORCA_SHELL_FEATURES
+__orca_has_feature() { (( ${_orca_shell_features[(Ie)$1]} )) }
+__orca_has_feature identity && printf "\033]777;orca-shell-start:%s\007" "$$"
+__orca_resolve_user_config_dir() {
+  REPLY="${1:-}"
+  while [[ "$REPLY" == */ ]]; do REPLY="${REPLY%/}"; done
+  if [[ -z "$REPLY" || -f "$REPLY/.orca-shell-wrapper" || "$REPLY" == */shell-ready/zsh ]]; then
+    REPLY="$HOME"
+  fi
+}
+# Why stricter for an inherited value: Orca can be launched from a terminal that
+# already pointed ZDOTDIR at its own wrapper dir, and a directory holding no zsh
+# startup file at all is not the user's config root whoever wrote it.
+__orca_resolve_inherited_config_dir() {
+  __orca_resolve_user_config_dir "${1:-}"
+  [[ "$REPLY" == "$HOME" ]] && return 0
+  local _orca_startup_file
+  for _orca_startup_file in .zshenv .zshrc .zprofile .zlogin; do
+    [[ -r "$REPLY/$_orca_startup_file" ]] && return 0
+  done
+  REPLY="$HOME"
+}
+__orca_resolve_inherited_config_dir "${ORCA_ORIG_ZDOTDIR:-$HOME}"
+export ORCA_ORIG_ZDOTDIR="$REPLY"
 [[ -f "$ORCA_ORIG_ZDOTDIR/.zshenv" ]] && source "$ORCA_ORIG_ZDOTDIR/.zshenv"
-export ORCA_USER_ZDOTDIR="${ZDOTDIR:-${ORCA_ORIG_ZDOTDIR:-$HOME}}"
-case "${ORCA_USER_ZDOTDIR%/}" in
-  */shell-ready/zsh) export ORCA_USER_ZDOTDIR="$HOME" ;;
-esac
+__orca_resolve_user_config_dir "${ZDOTDIR:-${ORCA_ORIG_ZDOTDIR:-$HOME}}"
+export ORCA_USER_ZDOTDIR="$REPLY"
 export ZDOTDIR='<WRAPPER_ROOT>/zsh'
+
+__orca_shell_epilogue() {
+  (( $+_orca_epilogue_done )) && return 0
+  typeset -g _orca_epilogue_done=1
+  if __orca_has_feature overlay; then
+    # Why: remote startup files can re-export user defaults after relay spawn.
+    [[ -n "${ORCA_OPENCODE_CONFIG_DIR:-}" ]] && export OPENCODE_CONFIG_DIR="${ORCA_OPENCODE_CONFIG_DIR}"
+    [[ -n "${ORCA_MIMOCODE_HOME:-}" ]] && export MIMOCODE_HOME="${ORCA_MIMOCODE_HOME}"
+    [[ -n "${ORCA_REMOTE_CLI_BIN_DIR:-}" ]] && case ":$PATH:" in *:"${ORCA_REMOTE_CLI_BIN_DIR}":*) ;; *) export PATH="${ORCA_REMOTE_CLI_BIN_DIR}:$PATH" ;; esac
+    # Why: OMP does not auto-load Orca's managed status extension; wrap only
+    # interactive launch invocations so subcommands such as `omp config` keep
+    # their normal argv shape.
+    __orca_omp_should_skip_extension() {
+      case "${1:-}" in
+        help|--help|-h|--version|-v) return 0 ;;
+        __complete|acp|agents|auth-broker|auth-gateway|bench|commit|completions|config|dry-balance|gallery|grep|grievances|install|join|models|plugin|read|say|search|setup|shell|ssh|stats|tiny-models|token|ttsr|update|usage|worktree|q|wt) return 0 ;;
+      esac
+      return 1
+    }
+    __orca_omp() {
+      local __orca_use_extension=1
+      __orca_omp_should_skip_extension "${1:-}" && __orca_use_extension=0
+      if [[ $__orca_use_extension -eq 1 && -n "${ORCA_OMP_STATUS_EXTENSION:-}" && -f "${ORCA_OMP_STATUS_EXTENSION}" ]]; then
+        if [[ "${1:-}" == "launch" ]]; then
+          shift
+          command omp launch --extension "${ORCA_OMP_STATUS_EXTENSION}" "$@"
+        else
+          command omp --extension "${ORCA_OMP_STATUS_EXTENSION}" "$@"
+        fi
+      else
+        command omp "$@"
+      fi
+    }
+    if [[ -n "${ORCA_OMP_STATUS_EXTENSION:-}" ]]; then
+      omp() { __orca_omp "$@"; }
+    fi
+  fi
+  if __orca_has_feature history; then
+    if [[ -n "${ORCA_HISTFILE:-}" ]]; then
+      HISTFILE="$ORCA_HISTFILE"
+      builtin unset ORCA_HISTFILE
+    elif [[ "${HISTFILE:-}" == "$ZDOTDIR/.zsh_history" ]]; then
+      # Why also when Orca injected nothing: /etc/zshrc derived this from Orca's
+      # wrapper ZDOTDIR, so history would accumulate INSIDE the wrapper dir and the
+      # user's real history would be invisible — the plain #11044 bug, with no
+      # per-worktree scoping involved. Matching the exact clobbered value means a
+      # HISTFILE the user set deliberately is never touched.
+      HISTFILE="${ORCA_ORIG_ZDOTDIR:-$HOME}/.zsh_history"
+    fi
+  fi
+  if __orca_has_feature ready; then
+    # Why: capture the prior zle-line-init so the marker chains to it. On a
+    # re-source we are already the bound widget, so keep the function captured
+    # the first time instead of clobbering it to empty (which would silently
+    # drop the user's widget on every prompt after the second source). Only
+    # user-defined widgets are chainable as plain functions; builtin/completion
+    # forms (rare for zle-line-init) are left unchained.
+    if [[ "${widgets[zle-line-init]:-}" == "user:__orca_prompt_mark" ]]; then
+      :
+    elif (( ${+widgets[zle-line-init]} )) && [[ "${widgets[zle-line-init]}" == user:* ]]; then
+      __orca_prev_line_init_fn="${widgets[zle-line-init]#user:}"
+    else
+      __orca_prev_line_init_fn=""
+    fi
+    __orca_prompt_mark() {
+      printf "\033]777;orca-shell-ready\007"
+      # Why: call the prior hook as a plain function, not an aliased widget, so
+      # $WIDGET stays zle-line-init for add-zle-hook-widget dispatchers.
+      if [[ -n "${__orca_prev_line_init_fn:-}" ]]; then
+        "${__orca_prev_line_init_fn}" "$@"
+      fi
+    }
+    zle -N zle-line-init __orca_prompt_mark
+  fi
+  __orca_resolve_user_config_dir "${ORCA_USER_ZDOTDIR:-${ORCA_ORIG_ZDOTDIR:-$HOME}}"
+  # Why: after Orca's last wrapper file has loaded, the interactive shell should
+  # expose the same ZDOTDIR a normal zsh startup would expose.
+  export ZDOTDIR="$REPLY"
+  unset _orca_home REPLY
+  unset _orca_shell_features
+  unfunction __orca_shell_epilogue __orca_has_feature __orca_resolve_user_config_dir __orca_resolve_inherited_config_dir
+}

--- a/src/main/shell-wrapper-snapshots/relay-zsh-zshenv.txt
+++ b/src/main/shell-wrapper-snapshots/relay-zsh-zshenv.txt
@@ -31,6 +31,12 @@ export ORCA_USER_ZDOTDIR="$REPLY"
 export ZDOTDIR='<WRAPPER_ROOT>/zsh'
 
 __orca_shell_epilogue() {
+  # Why first: this body runs after the user's own config, so it would otherwise
+  # inherit whatever options that config left set. Under NO_UNSET an unset
+  # precmd_functions is a fatal error that returns from the whole epilogue
+  # (skipping the ready widget and the ZDOTDIR restore), and KSH_ARRAYS makes
+  # the 1-based feature lookup drop the first selected feature.
+  emulate -L zsh
   (( $+_orca_epilogue_done )) && return 0
   typeset -g _orca_epilogue_done=1
   if __orca_has_feature overlay; then
@@ -66,18 +72,16 @@ __orca_shell_epilogue() {
       omp() { __orca_omp "$@"; }
     fi
   fi
-  if __orca_has_feature history; then
-    if [[ -n "${ORCA_HISTFILE:-}" ]]; then
-      HISTFILE="$ORCA_HISTFILE"
-      builtin unset ORCA_HISTFILE
-    elif [[ "${HISTFILE:-}" == "$ZDOTDIR/.zsh_history" ]]; then
-      # Why also when Orca injected nothing: /etc/zshrc derived this from Orca's
-      # wrapper ZDOTDIR, so history would accumulate INSIDE the wrapper dir and the
-      # user's real history would be invisible — the plain #11044 bug, with no
-      # per-worktree scoping involved. Matching the exact clobbered value means a
-      # HISTFILE the user set deliberately is never touched.
-      HISTFILE="${ORCA_ORIG_ZDOTDIR:-$HOME}/.zsh_history"
-    fi
+  if [[ -n "${ORCA_HISTFILE:-}" ]]; then
+    HISTFILE="$ORCA_HISTFILE"
+    builtin unset ORCA_HISTFILE
+  elif [[ "${HISTFILE:-}" == "$ZDOTDIR/.zsh_history" ]]; then
+    # Why also when Orca injected nothing: /etc/zshrc derived this from Orca's
+    # wrapper ZDOTDIR, so history would accumulate INSIDE the wrapper dir and the
+    # user's real history would be invisible — the plain #11044 bug, with no
+    # per-worktree scoping involved. Matching the exact clobbered value means a
+    # HISTFILE the user set deliberately is never touched.
+    HISTFILE="${ORCA_ORIG_ZDOTDIR:-$HOME}/.zsh_history"
   fi
   if __orca_has_feature ready; then
     # Why: capture the prior zle-line-init so the marker chains to it. On a

--- a/src/main/shell-wrapper-snapshots/relay-zsh-zshenv.txt
+++ b/src/main/shell-wrapper-snapshots/relay-zsh-zshenv.txt
@@ -5,10 +5,10 @@ builtin unset ORCA_SHELL_FEATURES
 __orca_has_feature() { (( ${_orca_shell_features[(Ie)$1]} )) }
 __orca_has_feature identity && printf "\033]777;orca-shell-start:%s\007" "$$"
 __orca_resolve_user_config_dir() {
-  REPLY="${1:-}"
-  while [[ "$REPLY" == */ ]]; do REPLY="${REPLY%/}"; done
-  if [[ -z "$REPLY" || -f "$REPLY/.orca-shell-wrapper" || "$REPLY" == */shell-ready/zsh ]]; then
-    REPLY="$HOME"
+  typeset -g _orca_resolved_config_dir="${1:-}"
+  while [[ "$_orca_resolved_config_dir" == */ ]]; do _orca_resolved_config_dir="${_orca_resolved_config_dir%/}"; done
+  if [[ -z "$_orca_resolved_config_dir" || -f "$_orca_resolved_config_dir/.orca-shell-wrapper" || "$_orca_resolved_config_dir" == */shell-ready/zsh ]]; then
+    _orca_resolved_config_dir="$HOME"
   fi
 }
 # Why stricter for an inherited value: Orca can be launched from a terminal that
@@ -16,18 +16,32 @@ __orca_resolve_user_config_dir() {
 # startup file at all is not the user's config root whoever wrote it.
 __orca_resolve_inherited_config_dir() {
   __orca_resolve_user_config_dir "${1:-}"
-  [[ "$REPLY" == "$HOME" ]] && return 0
+  [[ "$_orca_resolved_config_dir" == "$HOME" ]] && return 0
   local _orca_startup_file
   for _orca_startup_file in .zshenv .zshrc .zprofile .zlogin; do
-    [[ -r "$REPLY/$_orca_startup_file" ]] && return 0
+    [[ -r "$_orca_resolved_config_dir/$_orca_startup_file" ]] && return 0
   done
-  REPLY="$HOME"
+  _orca_resolved_config_dir="$HOME"
 }
 __orca_resolve_inherited_config_dir "${ORCA_ORIG_ZDOTDIR:-$HOME}"
-export ORCA_ORIG_ZDOTDIR="$REPLY"
+export ORCA_ORIG_ZDOTDIR="$_orca_resolved_config_dir"
 [[ -f "$ORCA_ORIG_ZDOTDIR/.zshenv" ]] && source "$ORCA_ORIG_ZDOTDIR/.zshenv"
 __orca_resolve_user_config_dir "${ZDOTDIR:-${ORCA_ORIG_ZDOTDIR:-$HOME}}"
-export ORCA_USER_ZDOTDIR="$REPLY"
+export ORCA_USER_ZDOTDIR="$_orca_resolved_config_dir"
+
+if [[ -f "$ORCA_ORIG_ZDOTDIR/.zshenv" ]]; then
+  case "$(emulate 2>/dev/null)" in
+    sh|ksh)
+      export ZDOTDIR="$ORCA_USER_ZDOTDIR"
+      # Why unset: an ORCA_HISTFILE no wrapper file will ever consume is
+      # inherited by everything this pane spawns, including a nested Orca.
+      builtin unset ORCA_HISTFILE _orca_shell_features _orca_home _orca_resolved_config_dir _orca_wrapper_zdotdir_self
+      unfunction __orca_shell_epilogue __orca_has_feature __orca_resolve_user_config_dir __orca_resolve_inherited_config_dir 2>/dev/null
+      return 0
+      ;;
+  esac
+fi
+
 export ZDOTDIR='<WRAPPER_ROOT>/zsh'
 
 __orca_shell_epilogue() {
@@ -110,8 +124,8 @@ __orca_shell_epilogue() {
   __orca_resolve_user_config_dir "${ORCA_USER_ZDOTDIR:-${ORCA_ORIG_ZDOTDIR:-$HOME}}"
   # Why: after Orca's last wrapper file has loaded, the interactive shell should
   # expose the same ZDOTDIR a normal zsh startup would expose.
-  export ZDOTDIR="$REPLY"
-  unset _orca_home REPLY
+  export ZDOTDIR="$_orca_resolved_config_dir"
+  unset _orca_home _orca_resolved_config_dir
   unset _orca_shell_features
   unfunction __orca_shell_epilogue __orca_has_feature __orca_resolve_user_config_dir __orca_resolve_inherited_config_dir
 }

--- a/src/main/shell-wrapper-snapshots/relay-zsh-zshrc.txt
+++ b/src/main/shell-wrapper-snapshots/relay-zsh-zshrc.txt
@@ -1,4 +1,11 @@
 # Orca relay zsh overlay wrapper
+__orca_resolve_user_config_dir() {
+  REPLY="${1:-}"
+  while [[ "$REPLY" == */ ]]; do REPLY="${REPLY%/}"; done
+  if [[ -z "$REPLY" || -f "$REPLY/.orca-shell-wrapper" || "$REPLY" == */shell-ready/zsh ]]; then
+    REPLY="$HOME"
+  fi
+}
 __orca_resolve_user_config_dir "${ORCA_USER_ZDOTDIR:-${ORCA_ORIG_ZDOTDIR:-$HOME}}"
 _orca_home="$REPLY"
 if [[ -o interactive && -f "$_orca_home/.zshrc" ]]; then

--- a/src/main/shell-wrapper-snapshots/relay-zsh-zshrc.txt
+++ b/src/main/shell-wrapper-snapshots/relay-zsh-zshrc.txt
@@ -11,5 +11,6 @@ if [[ -o interactive && -f "$_orca_home/.zshrc" ]]; then
   unset _orca_wrapper_zdotdir
 fi
 
-# Why: a login shell still has .zlogin to load; it runs the epilogue instead.
-[[ -o login ]] || __orca_shell_epilogue
+if [[ ! -o login || "$(emulate 2>/dev/null)" != zsh ]]; then
+  (( ${+functions[__orca_shell_epilogue]} )) && __orca_shell_epilogue
+fi

--- a/src/main/shell-wrapper-snapshots/relay-zsh-zshrc.txt
+++ b/src/main/shell-wrapper-snapshots/relay-zsh-zshrc.txt
@@ -1,8 +1,6 @@
 # Orca relay zsh overlay wrapper
-_orca_home="${ORCA_USER_ZDOTDIR:-${ORCA_ORIG_ZDOTDIR:-$HOME}}"
-case "${_orca_home%/}" in
-  */shell-ready/zsh) _orca_home="$HOME" ;;
-esac
+__orca_resolve_user_config_dir "${ORCA_USER_ZDOTDIR:-${ORCA_ORIG_ZDOTDIR:-$HOME}}"
+_orca_home="$REPLY"
 if [[ -o interactive && -f "$_orca_home/.zshrc" ]]; then
   _orca_wrapper_zdotdir="$ZDOTDIR"
   # Why: user startup files resolve plugin/config paths from their own ZDOTDIR;
@@ -13,58 +11,5 @@ if [[ -o interactive && -f "$_orca_home/.zshrc" ]]; then
   unset _orca_wrapper_zdotdir
 fi
 
-if [[ ! -o login ]]; then
-  # Why: remote startup files can re-export user defaults after relay spawn.
-  [[ -n "${ORCA_OPENCODE_CONFIG_DIR:-}" ]] && export OPENCODE_CONFIG_DIR="${ORCA_OPENCODE_CONFIG_DIR}"
-  [[ -n "${ORCA_MIMOCODE_HOME:-}" ]] && export MIMOCODE_HOME="${ORCA_MIMOCODE_HOME}"
-  [[ -n "${ORCA_REMOTE_CLI_BIN_DIR:-}" ]] && case ":$PATH:" in *:"${ORCA_REMOTE_CLI_BIN_DIR}":*) ;; *) export PATH="${ORCA_REMOTE_CLI_BIN_DIR}:$PATH" ;; esac
-  # Why: OMP does not auto-load Orca's managed status extension; wrap only
-# interactive launch invocations so subcommands such as `omp config` keep
-# their normal argv shape.
-__orca_omp_should_skip_extension() {
-  case "${1:-}" in
-    help|--help|-h|--version|-v) return 0 ;;
-    __complete|acp|agents|auth-broker|auth-gateway|bench|commit|completions|config|dry-balance|gallery|grep|grievances|install|join|models|plugin|read|say|search|setup|shell|ssh|stats|tiny-models|token|ttsr|update|usage|worktree|q|wt) return 0 ;;
-  esac
-  return 1
-}
-__orca_omp() {
-  local __orca_use_extension=1
-  __orca_omp_should_skip_extension "${1:-}" && __orca_use_extension=0
-  if [[ $__orca_use_extension -eq 1 && -n "${ORCA_OMP_STATUS_EXTENSION:-}" && -f "${ORCA_OMP_STATUS_EXTENSION}" ]]; then
-    if [[ "${1:-}" == "launch" ]]; then
-      shift
-      command omp launch --extension "${ORCA_OMP_STATUS_EXTENSION}" "$@"
-    else
-      command omp --extension "${ORCA_OMP_STATUS_EXTENSION}" "$@"
-    fi
-  else
-    command omp "$@"
-  fi
-}
-if [[ -n "${ORCA_OMP_STATUS_EXTENSION:-}" ]]; then
-  omp() { __orca_omp "$@"; }
-fi
-
-if [[ -n "${ORCA_HISTFILE:-}" ]]; then
-  HISTFILE="$ORCA_HISTFILE"
-elif [[ "${HISTFILE:-}" == "$ZDOTDIR/.zsh_history" ]]; then
-  # Why also when Orca injected nothing: /etc/zshrc derived this from Orca's
-  # wrapper ZDOTDIR, so history would accumulate INSIDE the wrapper dir and the
-  # user's real history would be invisible — the plain #11044 bug, with no
-  # per-worktree scoping involved. Matching the exact clobbered value means a
-  # HISTFILE the user set deliberately is never touched.
-  HISTFILE="${ORCA_ORIG_ZDOTDIR:-$HOME}/.zsh_history"
-fi
-fi
-if [[ ! -o login ]]; then
-_orca_home="${ORCA_USER_ZDOTDIR:-${ORCA_ORIG_ZDOTDIR:-$HOME}}"
-case "${_orca_home%/}" in
-  */shell-ready/zsh) _orca_home="$HOME" ;;
-esac
-# Why: after Orca's last wrapper file has loaded, the interactive shell should
-# expose the same ZDOTDIR a normal zsh startup would expose.
-export ZDOTDIR="$_orca_home"
-unset _orca_home
-
-fi
+# Why: a login shell still has .zlogin to load; it runs the epilogue instead.
+[[ -o login ]] || __orca_shell_epilogue

--- a/src/main/shell-wrapper-snapshots/relay-zsh-zshrc.txt
+++ b/src/main/shell-wrapper-snapshots/relay-zsh-zshrc.txt
@@ -1,13 +1,13 @@
 # Orca relay zsh overlay wrapper
 __orca_resolve_user_config_dir() {
-  REPLY="${1:-}"
-  while [[ "$REPLY" == */ ]]; do REPLY="${REPLY%/}"; done
-  if [[ -z "$REPLY" || -f "$REPLY/.orca-shell-wrapper" || "$REPLY" == */shell-ready/zsh ]]; then
-    REPLY="$HOME"
+  typeset -g _orca_resolved_config_dir="${1:-}"
+  while [[ "$_orca_resolved_config_dir" == */ ]]; do _orca_resolved_config_dir="${_orca_resolved_config_dir%/}"; done
+  if [[ -z "$_orca_resolved_config_dir" || -f "$_orca_resolved_config_dir/.orca-shell-wrapper" || "$_orca_resolved_config_dir" == */shell-ready/zsh ]]; then
+    _orca_resolved_config_dir="$HOME"
   fi
 }
 __orca_resolve_user_config_dir "${ORCA_USER_ZDOTDIR:-${ORCA_ORIG_ZDOTDIR:-$HOME}}"
-_orca_home="$REPLY"
+_orca_home="$_orca_resolved_config_dir"
 if [[ -o interactive && -f "$_orca_home/.zshrc" ]]; then
   _orca_wrapper_zdotdir="$ZDOTDIR"
   # Why: user startup files resolve plugin/config paths from their own ZDOTDIR;

--- a/src/main/terminal-history.test.ts
+++ b/src/main/terminal-history.test.ts
@@ -103,6 +103,8 @@ import {
 
 import { runHistoryGc, scheduleHistoryGc } from './terminal-history-gc'
 
+const OTHER_WORKTREE_HASH = hashWorktreeId('repo-1::/path/other-wt')
+
 describe('terminal-history', () => {
   afterEach(() => {
     cancelPendingHistoryTreeRemovalRetries()
@@ -369,6 +371,45 @@ describe('terminal-history', () => {
 
       expect(env.HISTFILE).toBe(['', 'mine', 'zsh_history'].join(sep))
       expect(env.ORCA_HISTFILE).toBeUndefined()
+    })
+
+    it.each([
+      [
+        'desktop',
+        ['', 'fake', 'userData', 'terminal-history', OTHER_WORKTREE_HASH, 'zsh_history'].join(sep)
+      ],
+      [
+        'relay',
+        [
+          '',
+          'home',
+          'me',
+          '.orca-remote',
+          'terminal-history',
+          `${OTHER_WORKTREE_HASH}-zsh_history`
+        ].join(sep)
+      ]
+    ])('drops a %s HISTFILE inherited from a parent Orca pane', (_kind, inherited) => {
+      // HISTFILE stays EXPORTED once the wrapper restores it, so an Orca launched
+      // from a pane in another worktree would otherwise hit the check-before-set
+      // early return in EVERY pane and append into that one worktree's file.
+      const env: Record<string, string> = { HISTFILE: inherited }
+
+      const result = injectHistoryEnv(env, 'repo-1::/path/wt', '/bin/zsh', '/path/wt')
+
+      expect(result.histFile).toBe(env.HISTFILE)
+      expect(env.HISTFILE).toContain(hashWorktreeId('repo-1::/path/wt'))
+      expect(env.HISTFILE).not.toContain(OTHER_WORKTREE_HASH)
+    })
+
+    it('preserves a HISTFILE the user set themselves', () => {
+      // Only a path Orca minted is droppable; everything else is the user's.
+      const env: Record<string, string> = { HISTFILE: ['', 'home', 'me', '.zsh_history'].join(sep) }
+
+      const result = injectHistoryEnv(env, 'repo-1::/path/wt', '/bin/zsh', '/path/wt')
+
+      expect(env.HISTFILE).toBe(['', 'home', 'me', '.zsh_history'].join(sep))
+      expect(result.histFile).toBeNull()
     })
 
     it('preserves a caller-supplied fish_history', () => {

--- a/src/main/terminal-history.test.ts
+++ b/src/main/terminal-history.test.ts
@@ -402,13 +402,21 @@ describe('terminal-history', () => {
       expect(env.HISTFILE).not.toContain(OTHER_WORKTREE_HASH)
     })
 
-    it('preserves a HISTFILE the user set themselves', () => {
+    it.each([
+      ['an ordinary path', ['', 'home', 'me', '.zsh_history'].join(sep)],
+      // Orca only ever mints absolute paths, so the same shape relative to the
+      // user's cwd is theirs.
+      [
+        'a relative path of Orca’s shape',
+        ['terminal-history', OTHER_WORKTREE_HASH, 'zsh_history'].join(sep)
+      ]
+    ])('preserves %s the user set as HISTFILE', (_kind, histFile) => {
       // Only a path Orca minted is droppable; everything else is the user's.
-      const env: Record<string, string> = { HISTFILE: ['', 'home', 'me', '.zsh_history'].join(sep) }
+      const env: Record<string, string> = { HISTFILE: histFile }
 
       const result = injectHistoryEnv(env, 'repo-1::/path/wt', '/bin/zsh', '/path/wt')
 
-      expect(env.HISTFILE).toBe(['', 'home', 'me', '.zsh_history'].join(sep))
+      expect(env.HISTFILE).toBe(histFile)
       expect(result.histFile).toBeNull()
     })
 

--- a/src/main/terminal-history.ts
+++ b/src/main/terminal-history.ts
@@ -6,6 +6,7 @@ import {
   isSafeFishHistorySession,
   resolveFishHistoryDir
 } from './fish-history-session'
+import { dropInheritedOrcaHistFile } from './worktree-history-file-path'
 import { parseWslPath, toLinuxPath } from './wsl'
 import { getHistoryRoot, getHistoryRootWsl } from './terminal-history-paths'
 import { hashWorktreeId } from './terminal-history-id'
@@ -193,6 +194,11 @@ export function injectHistoryEnv(
   // process the LAUNCHING worktree's session name — and the check-before-set
   // below would honour it, writing every pane's history into that worktree.
   dropInheritedOrcaFishHistory(spawnEnv)
+  // Why HISTFILE too: it stays EXPORTED after the wrapper restores it, so the
+  // same nesting hands this process worktree A's path — and the check-before-set
+  // below would honour it for every pane, in every worktree. Only a path Orca
+  // minted is dropped; a user's own HISTFILE still wins.
+  dropInheritedOrcaHistFile(spawnEnv)
 
   const shell = resolveShellKind(shellPath)
   const result: HistoryInjectionResult = {

--- a/src/main/worktree-history-file-path.ts
+++ b/src/main/worktree-history-file-path.ts
@@ -1,0 +1,47 @@
+/**
+ * Recognises a `HISTFILE` value Orca itself minted for a worktree.
+ *
+ * Why: HISTFILE is EXPORTED into the pane, so an Orca launched from an Orca
+ * pane inherits the launching worktree's history path in `process.env`. Every
+ * pane of the nested app then hits the check-before-set early return in
+ * `injectHistoryEnv`, gets no injection of its own, and appends into that ONE
+ * worktree's history file — per-worktree isolation silently off. Same bug class
+ * as the inherited `fish_history` fixed in #15195, and the same shape of fix:
+ * only a value Orca can prove it minted is dropped, so a HISTFILE the user set
+ * deliberately still wins.
+ *
+ * Matching is on the path shape rather than a resolved root because the same
+ * predicate has to work in three processes that cannot all compute the roots:
+ * the desktop (Electron userData), the daemon subprocess (no Electron), and the
+ * relay on a remote host. Desktop and relay drop each other's shapes on purpose
+ * — neither owns the other's worktree ids.
+ */
+
+/** 16 hex chars: `hashWorktreeId`. */
+const WORKTREE_HASH = '[0-9a-f]{16}'
+const HISTORY_FILE = '(?:zsh|bash)_history'
+
+const ORCA_MINTED_HISTFILE = new RegExp(
+  '(?:^|/)(?:' +
+    // Desktop: <userData>/terminal-history/<hash>/<file>
+    `terminal-history/${WORKTREE_HASH}/${HISTORY_FILE}` +
+    '|' +
+    // Desktop WSL: <userData>/terminal-history-wsl/<distro>/<hash>/<file>,
+    // which reaches the guest as the /mnt/<drive>/... form of the same tail.
+    `terminal-history-wsl/[^/]+/${WORKTREE_HASH}/${HISTORY_FILE}` +
+    '|' +
+    // Relay: ~/.orca-remote/terminal-history/<hash>-<file>
+    `\\.orca-remote/terminal-history/${WORKTREE_HASH}-${HISTORY_FILE}` +
+    ')$'
+)
+
+export function isOrcaMintedHistFile(value: string | undefined): boolean {
+  return typeof value === 'string' && ORCA_MINTED_HISTFILE.test(value.replace(/\\/g, '/'))
+}
+
+/** Drop a `HISTFILE` this process inherited from an outer Orca pane. */
+export function dropInheritedOrcaHistFile(env: Record<string, string | undefined>): void {
+  if (isOrcaMintedHistFile(env.HISTFILE)) {
+    delete env.HISTFILE
+  }
+}

--- a/src/main/worktree-history-file-path.ts
+++ b/src/main/worktree-history-file-path.ts
@@ -15,14 +15,27 @@
  * the desktop (Electron userData), the daemon subprocess (no Electron), and the
  * relay on a remote host. Desktop and relay drop each other's shapes on purpose
  * — neither owns the other's worktree ids.
+ *
+ * Why the shape is enough without an Orca-specific token: two of the three
+ * shapes carry one already (`.orca-remote`, `terminal-history-wsl`), and the
+ * third needs an absolute path whose LAST TWO segments are a 16-char lowercase
+ * hex directory directly under `terminal-history`, holding a file named exactly
+ * `zsh_history`/`bash_history`. That is a machine-minted layout, not one a
+ * person types. The blast radius if it were ever hit is also bounded: the value
+ * is dropped from ONE spawn's env, so the pane gets Orca's own worktree history
+ * (isolation on) or the shell's default (isolation off). Nothing on disk is
+ * read, written, moved, or deleted.
  */
 
 /** 16 hex chars: `hashWorktreeId`. */
 const WORKTREE_HASH = '[0-9a-f]{16}'
 const HISTORY_FILE = '(?:zsh|bash)_history'
 
+// Why a leading `/` rather than `(?:^|/)`: every minted value is absolute (or a
+// Windows path normalized to forward slashes), so a relative path of the same
+// shape is the user's, not Orca's.
 const ORCA_MINTED_HISTFILE = new RegExp(
-  '(?:^|/)(?:' +
+  '/(?:' +
     // Desktop: <userData>/terminal-history/<hash>/<file>
     `terminal-history/${WORKTREE_HASH}/${HISTORY_FILE}` +
     '|' +

--- a/src/main/zsh-scoped-histfile.live-shell.test.ts
+++ b/src/main/zsh-scoped-histfile.live-shell.test.ts
@@ -48,6 +48,16 @@ function runZsh(
   })
 }
 
+/** Both streams, because a wrapper that breaks does it on stderr. */
+function runZshCapturingStderr(args: string[], env: Record<string, string>, probe: string): string {
+  const result = spawnSync(ZSH_PATH, [...args, '-i', '-c', probe], {
+    encoding: 'utf8',
+    timeout: 20_000,
+    env: { PATH: '/usr/bin:/bin', ...env }
+  })
+  return `${result.stdout ?? ''}${result.stderr ?? ''}`
+}
+
 /**
  * True when this host's system zshrc is the thing that destroys HISTFILE.
  *
@@ -264,6 +274,72 @@ describe('worktree-scoped HISTFILE survives zsh startup', () => {
 
       expect(histfileOf(wrapped)).toBe(histfileOf(unwrapped))
       expect(wrapped).not.toContain('ORCA_HISTFILE')
+    })
+  })
+})
+
+describe('the wrapper survives a hostile user zsh config', () => {
+  const PROBE =
+    'echo "RESULT=$HISTFILE"; print -r -- "ZDOTDIR=[$ZDOTDIR]"; ' +
+    'print -r -- "ORCA_HISTFILE=[${ORCA_HISTFILE:-unset}]"'
+
+  // Why both forms: `REPLY` is zsh's shared scratch global, and the two ways a
+  // user config constrains it fail differently. `typeset -r` makes the
+  // wrapper's first assignment fatal and prints into the pane; `typeset -i`
+  // turns every resolved path into 0 with no error text at all. Both aborted
+  // the wrapper before the epilogue, leaving history inside Orca's own wrapper
+  // dir — on 100% of zsh panes, not the few percent wrapped before.
+  it.each(['typeset -r REPLY', 'typeset -i REPLY'])(
+    'resolves the user config dir when the user .zshrc runs `%s`',
+    (declaration) => {
+      if (!hasZsh) {
+        return
+      }
+      withTempHome((home) => {
+        const scoped = join(home, 'orca-history', 'zsh_history')
+        const { launch, env } = launchPlainHistoryPane(home, scoped)
+        writeFileSync(join(home, '.zshrc'), `${declaration}\n`)
+
+        const output = runZshCapturingStderr(launch.args ?? ['-l'], env, PROBE)
+
+        expect(histfileOf(output)).toBe(scoped)
+        expect(output).toContain(`ZDOTDIR=[${home}]`)
+        expect(output).toContain('ORCA_HISTFILE=[unset]')
+        expect(output).not.toContain('__orca_resolve_user_config_dir:')
+      })
+    }
+  )
+
+  // Why these two files and not .zshrc: zsh's sourcehome() ignores ZDOTDIR once
+  // the shell is in sh/ksh emulation, so emulation entered from .zshenv or
+  // .zprofile hides EVERY later wrapper file — the epilogue runs zero times and
+  // can repair nothing. A .zshrc that does it is already covered by running the
+  // epilogue from the wrapper .zshrc, which /etc/zshrc has run before.
+  it.each([
+    ['.zshenv', 'emulate sh'],
+    ['.zshenv', 'emulate ksh'],
+    ['.zprofile', 'emulate sh']
+  ])('degrades to an unwrapped pane when the user %s runs `%s`', (file, statement) => {
+    if (!hasZsh) {
+      return
+    }
+    withTempHome((home) => {
+      const scoped = join(home, 'orca-history', 'zsh_history')
+      const { launch, env } = launchPlainHistoryPane(home, scoped)
+      writeFileSync(join(home, file), `${statement}\n`)
+
+      const wrapped = runZshCapturingStderr(launch.args ?? ['-l'], env, PROBE)
+      const unwrapped = runZsh(['-l'], { HOME: home, HISTFILE: scoped })
+
+      // The bar: never worse off than the pane Orca did not wrap. What that is
+      // differs per host (macOS /etc/zshrc clobbers HISTFILE, stock Ubuntu does
+      // not), so it is read from an unwrapped run rather than hardcoded.
+      expect(histfileOf(wrapped)).toBe(histfileOf(unwrapped))
+      expect(histfileOf(wrapped)).not.toContain(launch.env.ZDOTDIR)
+      expect(wrapped).toContain(`ZDOTDIR=[${home}]`)
+      // Nothing this pane spawns may inherit a history path no wrapper file
+      // will ever consume.
+      expect(wrapped).toContain('ORCA_HISTFILE=[unset]')
     })
   })
 })

--- a/src/main/zsh-scoped-histfile.live-shell.test.ts
+++ b/src/main/zsh-scoped-histfile.live-shell.test.ts
@@ -17,7 +17,7 @@
  * Orca would not wrap cannot pass here by construction.
  */
 import { execFileSync, spawnSync } from 'node:child_process'
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
@@ -35,9 +35,13 @@ const ZSH_PATH = hasZsh
   : ''
 const itWithZsh = hasZsh ? it : it.skip
 
-function runZsh(args: string[], env: Record<string, string>): string {
+function runZsh(
+  args: string[],
+  env: Record<string, string>,
+  probe = 'echo "RESULT=$HISTFILE"'
+): string {
   // -o noglobalrcs is deliberately NOT passed: /etc/zshrc is the thing under test.
-  return execFileSync(ZSH_PATH, [...args, '-i', '-c', 'echo "RESULT=$HISTFILE"'], {
+  return execFileSync(ZSH_PATH, [...args, '-i', '-c', probe], {
     encoding: 'utf8',
     timeout: 20_000,
     env: { PATH: '/usr/bin:/bin', ...env }
@@ -154,23 +158,64 @@ describe('worktree-scoped HISTFILE survives zsh startup', () => {
     })
   })
 
-  itWithClobber('repairs the clobber for a shell that re-enters the wrapper with no features', () => {
-    // Why: a non-interactive zsh runs .zshenv (which exports Orca's wrapper
-    // ZDOTDIR) but never the epilogue that restores it, so an interactive zsh
-    // started from there re-enters the wrapper with the feature channel already
-    // consumed. /etc/zshrc still lands HISTFILE inside the wrapper dir — #11044
-    // with no per-worktree scoping involved — so the repair cannot be gated on
-    // a feature that no longer exists by then.
-    withTempHome((home) => {
-      const { launch } = launchPlainHistoryPane(home, join(home, 'orca-history', 'zsh_history'))
+  itWithClobber(
+    'repairs the clobber for a shell that re-enters the wrapper with no features',
+    () => {
+      // Why: a non-interactive zsh runs .zshenv (which exports Orca's wrapper
+      // ZDOTDIR) but never the epilogue that restores it, so an interactive zsh
+      // started from there re-enters the wrapper with the feature channel already
+      // consumed. /etc/zshrc still lands HISTFILE inside the wrapper dir — #11044
+      // with no per-worktree scoping involved — so the repair cannot be gated on
+      // a feature that no longer exists by then.
+      withTempHome((home) => {
+        const { launch } = launchPlainHistoryPane(home, join(home, 'orca-history', 'zsh_history'))
 
-      const output = runZsh(launch.args ?? ['-l'], {
-        HOME: home,
-        ZDOTDIR: launch.env.ZDOTDIR,
-        ORCA_ORIG_ZDOTDIR: home
+        const output = runZsh(launch.args ?? ['-l'], {
+          HOME: home,
+          ZDOTDIR: launch.env.ZDOTDIR,
+          ORCA_ORIG_ZDOTDIR: home
+        })
+
+        expect(histfileOf(output)).toBe(join(home, '.zsh_history'))
       })
+    }
+  )
 
-      expect(histfileOf(output)).toBe(join(home, '.zsh_history'))
+  itWithZsh('runs the epilogue for a login shell whose .zshrc ends in `emulate sh`', () => {
+    // Why: zsh's sourcehome() ignores ZDOTDIR once the shell is in sh/ksh
+    // emulation, so such a login shell reads $HOME/.zlogin instead of the
+    // wrapper's. Everything the epilogue owns — the HISTFILE repair, the OSC 133
+    // hooks, the readiness widget every startup command waits on — would be
+    // skipped entirely.
+    withTempHome((home) => {
+      const scoped = join(home, 'orca-history', 'zsh_history')
+      const env: Record<string, string> = {
+        HOME: home,
+        HISTFILE: scoped,
+        ORCA_HISTFILE: scoped
+      }
+      const launch = getShellLaunchConfig(
+        ZSH_PATH,
+        selectShellStartupFeatures({
+          shellPath: ZSH_PATH,
+          env,
+          hasStartupCommand: true,
+          waitsForShellReady: true,
+          // Why off: the identity marker is printed with no trailing newline, so
+          // it would prefix the first probe line and defeat the parser.
+          emitsStartupIdentity: false
+        })
+      )
+      writeFileSync(join(home, '.zshrc'), 'emulate sh\n')
+
+      const output = runZsh(
+        launch.args ?? ['-l'],
+        { ...env, ...launch.env, ...sandboxConfigDir(home) },
+        'echo "RESULT=$HISTFILE"; echo "WIDGET=[${widgets[zle-line-init]:-none}]"'
+      )
+
+      expect(histfileOf(output)).toBe(scoped)
+      expect(output).toContain('WIDGET=[user:__orca_prompt_mark]')
     })
   })
 

--- a/src/main/zsh-scoped-histfile.live-shell.test.ts
+++ b/src/main/zsh-scoped-histfile.live-shell.test.ts
@@ -154,6 +154,26 @@ describe('worktree-scoped HISTFILE survives zsh startup', () => {
     })
   })
 
+  itWithClobber('repairs the clobber for a shell that re-enters the wrapper with no features', () => {
+    // Why: a non-interactive zsh runs .zshenv (which exports Orca's wrapper
+    // ZDOTDIR) but never the epilogue that restores it, so an interactive zsh
+    // started from there re-enters the wrapper with the feature channel already
+    // consumed. /etc/zshrc still lands HISTFILE inside the wrapper dir — #11044
+    // with no per-worktree scoping involved — so the repair cannot be gated on
+    // a feature that no longer exists by then.
+    withTempHome((home) => {
+      const { launch } = launchPlainHistoryPane(home, join(home, 'orca-history', 'zsh_history'))
+
+      const output = runZsh(launch.args ?? ['-l'], {
+        HOME: home,
+        ZDOTDIR: launch.env.ZDOTDIR,
+        ORCA_ORIG_ZDOTDIR: home
+      })
+
+      expect(histfileOf(output)).toBe(join(home, '.zsh_history'))
+    })
+  })
+
   itWithZsh('consumes ORCA_HISTFILE so nothing the shell spawns can inherit it', () => {
     withTempHome((home) => {
       const scoped = join(home, 'orca-history', 'zsh_history')

--- a/src/main/zsh-scoped-histfile.live-shell.test.ts
+++ b/src/main/zsh-scoped-histfile.live-shell.test.ts
@@ -11,14 +11,18 @@
  * Only a real zsh can show this: the string the wrapper emits looks correct
  * either way, and the whole bug lives in what /etc/zshrc does between the spawn
  * env and the first prompt.
+ *
+ * These tests drive the REAL launch decision (`selectShellStartupFeatures` +
+ * `getShellLaunchConfig`) rather than an inline copy of the gate, so a pane that
+ * Orca would not wrap cannot pass here by construction.
  */
 import { execFileSync, spawnSync } from 'node:child_process'
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { getZshShellReadyRcfileContent } from './providers/local-pty-shell-ready-wrapper-generation'
-import { getZshEnvTemplate, ZSH_HISTFILE_RESTORE_BLOCK } from './shell-templates'
+import { getShellLaunchConfig } from './providers/local-pty-shell-ready'
+import { selectShellStartupFeatures } from './shell-startup-features'
 
 // Why probe and execute the same binary: guarding on `zsh` from PATH but then
 // running a hardcoded `/bin/zsh` lets the guard pass on a host that installs zsh
@@ -31,55 +35,142 @@ const ZSH_PATH = hasZsh
   : ''
 const itWithZsh = hasZsh ? it : it.skip
 
-function runLoginZsh(home: string, zdotdir: string, env: Record<string, string>): string {
+function runZsh(args: string[], env: Record<string, string>): string {
   // -o noglobalrcs is deliberately NOT passed: /etc/zshrc is the thing under test.
-  return execFileSync(ZSH_PATH, ['-li', '-c', 'echo "RESULT=$HISTFILE"'], {
+  return execFileSync(ZSH_PATH, [...args, '-i', '-c', 'echo "RESULT=$HISTFILE"'], {
     encoding: 'utf8',
     timeout: 20_000,
-    env: {
-      PATH: '/usr/bin:/bin',
-      HOME: home,
-      ZDOTDIR: zdotdir,
-      ORCA_ORIG_ZDOTDIR: home,
-      ORCA_ZSHENV_SOURCE_DIR: home,
-      ...env
-    }
+    env: { PATH: '/usr/bin:/bin', ...env }
   })
 }
 
-describe('worktree-scoped HISTFILE survives zsh startup', () => {
-  const withWrapper = (run: (home: string, zdotdir: string) => void): void => {
-    const home = mkdtempSync(join(tmpdir(), 'orca-scoped-histfile-'))
-    const zdotdir = join(home, 'shell-ready', 'zsh')
-    mkdirSync(zdotdir, { recursive: true })
-    writeFileSync(join(zdotdir, '.zshenv'), getZshEnvTemplate(zdotdir))
-    writeFileSync(join(zdotdir, '.zshrc'), getZshShellReadyRcfileContent())
-    writeFileSync(join(zdotdir, '.zlogin'), `${ZSH_HISTFILE_RESTORE_BLOCK}\n`)
-    try {
-      run(home, zdotdir)
-    } finally {
-      rmSync(home, { recursive: true, force: true })
-    }
+/**
+ * True when this host's system zshrc is the thing that destroys HISTFILE.
+ *
+ * Why probed and not keyed off `process.platform`: macOS ships the clobber in
+ * /etc/zshrc, stock Ubuntu ships no such assignment, and a hardened corporate
+ * image can go either way. Assertions that only mean something under a clobber
+ * are skipped where there is none rather than asserting a tautology.
+ */
+const systemZshrcClobbersHistfile = (() => {
+  if (!hasZsh) {
+    return false
   }
+  const home = mkdtempSync(join(tmpdir(), 'orca-histfile-probe-'))
+  try {
+    const output = execFileSync(ZSH_PATH, ['-l', '-i', '-c', 'echo "RESULT=$HISTFILE"'], {
+      encoding: 'utf8',
+      timeout: 20_000,
+      env: {
+        PATH: '/usr/bin:/bin',
+        HOME: home,
+        HISTFILE: join(home, 'injected-history')
+      }
+    })
+    return !output.includes(join(home, 'injected-history'))
+  } catch {
+    return false
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})()
 
-  itWithZsh('keeps the injected path that a system zshrc would otherwise clobber', () => {
-    withWrapper((home, zdotdir) => {
-      const scoped = join(home, 'orca-history', 'zsh_history')
+const itWithClobber = systemZshrcClobbersHistfile ? itWithZsh : it.skip
 
-      const output = runLoginZsh(home, zdotdir, { HISTFILE: scoped, ORCA_HISTFILE: scoped })
+/** The launch config Orca produces for a plain pane whose only Orca-owned
+ *  concern is a worktree-scoped HISTFILE. */
+function launchPlainHistoryPane(home: string, scopedHistfile: string) {
+  const env: Record<string, string> = {
+    HOME: home,
+    HISTFILE: scopedHistfile,
+    ORCA_HISTFILE: scopedHistfile
+  }
+  const features = selectShellStartupFeatures({
+    shellPath: ZSH_PATH,
+    env,
+    hasStartupCommand: false,
+    waitsForShellReady: false,
+    emitsStartupIdentity: false
+  })
+  const launch = getShellLaunchConfig(ZSH_PATH, features)
+  return {
+    features,
+    launch,
+    env: { ...env, ...launch.env, ...sandboxConfigDir(home) }
+  }
+}
 
-      expect(output).toContain(`RESULT=${scoped}`)
+// Why override: the launch config resolves the user's config dir from the real
+// process env, and these runs must resolve against the sandbox home instead.
+function sandboxConfigDir(home: string): Record<string, string> {
+  return { ORCA_ORIG_ZDOTDIR: home, ORCA_ZSHENV_SOURCE_DIR: home }
+}
+
+function withTempHome(run: (home: string) => void): void {
+  const home = mkdtempSync(join(tmpdir(), 'orca-scoped-histfile-'))
+  try {
+    run(home)
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+}
+
+const histfileOf = (output: string): string =>
+  /^RESULT=(.*)$/m.exec(output)?.[1]?.trim() ?? '<unmatched>'
+
+describe('worktree-scoped HISTFILE survives zsh startup', () => {
+  itWithZsh('wraps a plain pane once Orca injected a worktree HISTFILE', () => {
+    withTempHome((home) => {
+      const { features, launch } = launchPlainHistoryPane(home, join(home, 'zsh_history'))
+
+      // The whole bug: this pane has no overlay env and no startup command, so
+      // before this change nothing pointed it at a wrapper at all.
+      expect(features).toEqual(['history'])
+      expect(launch.env.ZDOTDIR).toBeTruthy()
+      expect(launch.env.ORCA_SHELL_FEATURES).toBe('history')
     })
   })
 
-  itWithZsh('never leaves history inside Orca’s own wrapper directory', () => {
-    withWrapper((home, zdotdir) => {
+  itWithClobber('keeps the injected path that the system zshrc would otherwise clobber', () => {
+    withTempHome((home) => {
       const scoped = join(home, 'orca-history', 'zsh_history')
+      const { launch, env } = launchPlainHistoryPane(home, scoped)
 
-      const output = runLoginZsh(home, zdotdir, { HISTFILE: scoped, ORCA_HISTFILE: scoped })
+      const output = runZsh(launch.args ?? ['-l'], env)
+
+      expect(histfileOf(output)).toBe(scoped)
+    })
+  })
+
+  itWithClobber('never leaves history inside Orca’s own wrapper directory', () => {
+    withTempHome((home) => {
+      const scoped = join(home, 'orca-history', 'zsh_history')
+      const { launch, env } = launchPlainHistoryPane(home, scoped)
+
+      const output = runZsh(launch.args ?? ['-l'], env)
 
       // The exact failure mode of #11044: history written into shell-ready/zsh.
-      expect(output).not.toContain(zdotdir)
+      expect(output).not.toContain(launch.env.ZDOTDIR)
+    })
+  })
+
+  itWithZsh('consumes ORCA_HISTFILE so nothing the shell spawns can inherit it', () => {
+    withTempHome((home) => {
+      const scoped = join(home, 'orca-history', 'zsh_history')
+      const { launch, env } = launchPlainHistoryPane(home, scoped)
+
+      const output = execFileSync(
+        ZSH_PATH,
+        [...(launch.args ?? ['-l']), '-i', '-c', 'echo "LEAK=[${ORCA_HISTFILE:-}]"'],
+        {
+          encoding: 'utf8',
+          timeout: 20_000,
+          env: { PATH: '/usr/bin:/bin', ...env }
+        }
+      )
+
+      // Root-cause fix for #11146: the variable no longer exists after use.
+      expect(output).toContain('LEAK=[]')
     })
   })
 
@@ -89,16 +180,23 @@ describe('worktree-scoped HISTFILE survives zsh startup', () => {
     // so it is always set there; a stock Ubuntu zsh has no such file and leaves
     // it EMPTY. The contract is that Orca's wrapper does not change it either
     // way, which is the same assertion on both.
-    withWrapper((home, zdotdir) => {
-      const wrapped = runLoginZsh(home, zdotdir, {})
-      const unwrapped = execFileSync(ZSH_PATH, ['-li', '-c', 'echo "RESULT=$HISTFILE"'], {
-        encoding: 'utf8',
-        timeout: 20_000,
-        env: { PATH: '/usr/bin:/bin', HOME: home }
+    withTempHome((home) => {
+      const features = selectShellStartupFeatures({
+        shellPath: ZSH_PATH,
+        env: { HOME: home, ORCA_CODEX_HOME: join(home, 'codex') },
+        hasStartupCommand: false,
+        waitsForShellReady: false,
+        emitsStartupIdentity: false
       })
+      const launch = getShellLaunchConfig(ZSH_PATH, features)
+      const wrapped = runZsh(launch.args ?? ['-l'], {
+        HOME: home,
+        ORCA_CODEX_HOME: join(home, 'codex'),
+        ...launch.env,
+        ...sandboxConfigDir(home)
+      })
+      const unwrapped = runZsh(['-l'], { HOME: home })
 
-      const histfileOf = (output: string): string =>
-        /^RESULT=(.*)$/m.exec(output)?.[1]?.trim() ?? '<unmatched>'
       expect(histfileOf(wrapped)).toBe(histfileOf(unwrapped))
       expect(wrapped).not.toContain('ORCA_HISTFILE')
     })

--- a/src/main/zsh-startup-wrapper-builder.ts
+++ b/src/main/zsh-startup-wrapper-builder.ts
@@ -187,6 +187,31 @@ function buildZshenv(spec: ZshStartupWrapperSpec): string {
   ])}\n`
 }
 
+/**
+ * Why guarded: the generated files are inter-dependent (this call, the function
+ * in .zshenv), and one wrapper dir can be shared by two concurrently installed
+ * Orca builds. Pairing this file with an older .zshenv then loses the features
+ * either way; degrade silently instead of printing "command not found" into the
+ * user's pane. Braced subscript because sh/ksh emulation (KSH_ARRAYS) rejects
+ * the unbraced `$+functions[...]` form outright.
+ */
+const EPILOGUE_CALL = '(( ${+functions[__orca_shell_epilogue]} )) && __orca_shell_epilogue'
+
+/**
+ * A login shell normally runs the epilogue from .zlogin, after the user's own
+ * .zlogin. The exception: zsh's `sourcehome()` ignores ZDOTDIR once the shell is
+ * in sh/ksh emulation, so a user .zshrc ending in `emulate sh` makes zsh read
+ * $HOME/.zlogin and never the wrapper's — no OSC 133 hooks, no ready widget, and
+ * HISTFILE left pointing inside the wrapper dir. Running the epilogue here
+ * instead means the user's own .zlogin can undo its overlay restores, which
+ * beats not running it at all. An older zsh whose `emulate` has no query form
+ * prints nothing, fails the comparison, and runs it here too; the epilogue's
+ * once-flag makes the later .zlogin call a no-op.
+ */
+const ZSHRC_EPILOGUE_INVOCATION = `if [[ ! -o login || "$(emulate 2>/dev/null)" != zsh ]]; then
+  ${EPILOGUE_CALL}
+fi`
+
 export function buildZshStartupWrapperFiles(spec: ZshStartupWrapperSpec): ZshStartupWrapperFiles {
   return {
     zshenv: buildZshenv(spec),
@@ -205,8 +230,7 @@ export function buildZshStartupWrapperFiles(spec: ZshStartupWrapperSpec): ZshSta
         interactiveOnly: true,
         skipWhenHomeIsCurrentZdotdir: spec.skipUserZshrcWhenHomeIsWrapperDir
       }),
-      '# Why: a login shell still has .zlogin to load; it runs the epilogue instead.',
-      '[[ -o login ]] || __orca_shell_epilogue'
+      ZSHRC_EPILOGUE_INVOCATION
     ])}\n`,
     zlogin: `${joinBlocks([
       `# ${spec.headerLabel}`,
@@ -215,7 +239,7 @@ export function buildZshStartupWrapperFiles(spec: ZshStartupWrapperSpec): ZshSta
         homeExpression: spec.homeExpression,
         interactiveOnly: true
       }),
-      '__orca_shell_epilogue'
+      EPILOGUE_CALL
     ])}\n`
   }
 }

--- a/src/main/zsh-startup-wrapper-builder.ts
+++ b/src/main/zsh-startup-wrapper-builder.ts
@@ -6,16 +6,25 @@
  * one transport and silently missed the other two. Everything they genuinely
  * disagree on is a field on ZshStartupWrapperSpec, so the disagreements are
  * visible in one place instead of spread across three template literals.
+ *
+ * All order-sensitive Orca work lives in ONE `__orca_shell_epilogue` defined in
+ * .zshenv and invoked exactly once — from .zshrc for a non-login shell, from
+ * .zlogin for a login shell. Each feature inside it is an independent guard on
+ * the allowlist snapshotted (and destroyed) at the top of .zshenv, so a pane
+ * wrapped only for one feature runs only that feature's code.
  */
 import { getPosixOmpShellWrapper } from './pty/omp-shell-wrapper'
 import { getPosixCodexShellLaunchPreflight } from './pty/codex-shell-launch-preflight'
 import {
-  getZshEnvTemplate,
+  getZshEnvDiscoveryBody,
   getZshFinalZdotdirRestoreBlock,
-  getZshOverlayEnvTemplate,
+  getZshOverlayEnvBody,
   getZshShellReadyMarkerRegistrationBlock,
   getZshStartupFileSourceBlock,
-  ZSH_HISTFILE_RESTORE_BLOCK
+  SHELL_STARTUP_IDENTITY_MARKER_BLOCK,
+  ZSH_FEATURE_CHANNEL_BLOCK,
+  ZSH_HISTFILE_RESTORE_BLOCK,
+  ZSH_USER_CONFIG_DIR_RESOLVER_BLOCK
 } from './shell-templates'
 
 /** Runtime values the wrapper re-exports after the user's own startup files ran. */
@@ -28,18 +37,6 @@ export type ZshWrapperRestoreSpec = {
   codexHome: boolean
   /** The `codex()` wrapper that runs Orca's launch preflight. */
   codexLaunchPreflight: boolean
-}
-
-/**
- * Pre-existing cosmetic drift in the .zshrc restore block. Carried as explicit
- * fields so unifying the generators stays byte-identical; normalizing these
- * away is a follow-up, not part of the unification.
- */
-export type ZshWrapperLegacyFormatting = {
-  /** Local .zshrc lost the two-space indent on the MIMOCODE_HOME restore. */
-  unindentedMimocodeRestore?: boolean
-  /** Only local .zshrc carries a comment above the CODEX_HOME restore. */
-  codexHomeRestoreComment?: string
 }
 
 export type ZshStartupWrapperSpec = {
@@ -56,18 +53,13 @@ export type ZshStartupWrapperSpec = {
   /** zsh expression the wrapper resolves the user's startup-file dir from. */
   homeExpression?: string
   readyMarkerEscaped: string
-  /** OSC 133 command-lifecycle hooks in .zshrc. */
+  /** OSC 133 command-lifecycle hooks (behind the `markers` feature). */
   osc133CommandMarkers: boolean
   /** Skip the user .zshrc when its dir is already the wrapper ZDOTDIR. */
   skipUserZshrcWhenHomeIsWrapperDir: boolean
-  /** Comment heading the non-login restore block in .zshrc. */
-  interactiveRestoreComment: string
-  /** Comment heading the restore block in .zlogin. */
-  loginRestoreComment: string
+  /** Comment heading the overlay restores inside the epilogue. */
+  overlayRestoreComment: string
   restores: ZshWrapperRestoreSpec
-  /** Where the ready-marker widget lands relative to the final ZDOTDIR restore. */
-  readyMarkerOrder: 'before-zdotdir-restore' | 'after-zdotdir-restore'
-  legacyFormatting?: ZshWrapperLegacyFormatting
 }
 
 export type ZshStartupWrapperFiles = {
@@ -77,18 +69,20 @@ export type ZshStartupWrapperFiles = {
   zlogin: string
 }
 
-const AGENT_TEAMS_PATH_RESTORE_FUNCTION = `__orca_restore_agent_teams_path() {
+const AGENT_TEAMS_PATH_RESTORE_BLOCK = `__orca_restore_agent_teams_path() {
   [[ -n "\${ORCA_AGENT_TEAMS_SHIM_DIR:-}" ]] || return 0
   case "$PATH" in
     "\${ORCA_AGENT_TEAMS_SHIM_DIR}"|"\${ORCA_AGENT_TEAMS_SHIM_DIR}:"*) return 0 ;;
   esac
   export PATH="\${ORCA_AGENT_TEAMS_SHIM_DIR}:$PATH"
-}`
+}
+__orca_restore_agent_teams_path`
 
 const OPENCODE_CONFIG_DIR_RESTORE = `[[ -n "\${ORCA_OPENCODE_CONFIG_DIR:-}" ]] && export OPENCODE_CONFIG_DIR="\${ORCA_OPENCODE_CONFIG_DIR}"`
 const MIMOCODE_HOME_RESTORE = `[[ -n "\${ORCA_MIMOCODE_HOME:-}" ]] && export MIMOCODE_HOME="\${ORCA_MIMOCODE_HOME}"`
 const REMOTE_CLI_BIN_DIR_RESTORE = `[[ -n "\${ORCA_REMOTE_CLI_BIN_DIR:-}" ]] && case ":$PATH:" in *:"\${ORCA_REMOTE_CLI_BIN_DIR}":*) ;; *) export PATH="\${ORCA_REMOTE_CLI_BIN_DIR}:$PATH" ;; esac`
-const CODEX_HOME_RESTORE = `[[ -n "\${ORCA_CODEX_HOME:-}" ]] && export CODEX_HOME="\${ORCA_CODEX_HOME}"`
+const CODEX_HOME_RESTORE = `# Why: Codex must keep using Orca's runtime CODEX_HOME after rc files.
+[[ -n "\${ORCA_CODEX_HOME:-}" ]] && export CODEX_HOME="\${ORCA_CODEX_HOME}"`
 
 const ZSH_OSC133_COMMAND_MARKER_BLOCK = `__orca_osc133_precmd() {
   local exit_code=$?
@@ -115,78 +109,76 @@ function joinBlocks(blocks: (string | null)[]): string {
   return blocks.filter((block): block is string => block !== null).join('\n')
 }
 
+function indentBlock(block: string, indent: string): string {
+  return block
+    .split('\n')
+    .map((line) => (line.length > 0 ? `${indent}${line}` : line))
+    .join('\n')
+}
+
+/** One epilogue feature: `if __orca_has_feature <name>; then ... fi`. */
+function featureGuard(name: string, body: (string | null)[]): string | null {
+  const blocks = body.filter((block): block is string => block !== null)
+  if (blocks.length === 0) {
+    return null
+  }
+  return `  if __orca_has_feature ${name}; then\n${indentBlock(joinBlocks(blocks).replace(/\n$/, ''), '    ')}\n  fi`
+}
+
 /** The env/PATH restores that must outlast the user's own startup files. */
-function getRestoreLines(
-  spec: ZshStartupWrapperSpec,
-  indent: string,
-  legacyFormatting?: ZshWrapperLegacyFormatting
-): (string | null)[] {
-  const mimocodeIndent = legacyFormatting?.unindentedMimocodeRestore ? '' : indent
-  const codexHomeComment = legacyFormatting?.codexHomeRestoreComment
+function getOverlayRestoreBlocks(spec: ZshStartupWrapperSpec): (string | null)[] {
   return [
-    `${indent}${OPENCODE_CONFIG_DIR_RESTORE}`,
-    `${mimocodeIndent}${MIMOCODE_HOME_RESTORE}`,
-    spec.restores.remoteCliBinDir ? `${indent}${REMOTE_CLI_BIN_DIR_RESTORE}` : null,
-    `${indent}${getPosixOmpShellWrapper()}`,
-    spec.restores.codexHome && codexHomeComment ? `${indent}${codexHomeComment}` : null,
-    spec.restores.codexHome ? `${indent}${CODEX_HOME_RESTORE}` : null,
-    ZSH_HISTFILE_RESTORE_BLOCK,
-    spec.restores.codexLaunchPreflight ? `${indent}${getPosixCodexShellLaunchPreflight()}` : null
+    spec.overlayRestoreComment,
+    spec.restores.agentTeamsPath ? AGENT_TEAMS_PATH_RESTORE_BLOCK : null,
+    OPENCODE_CONFIG_DIR_RESTORE,
+    MIMOCODE_HOME_RESTORE,
+    spec.restores.remoteCliBinDir ? REMOTE_CLI_BIN_DIR_RESTORE : null,
+    getPosixOmpShellWrapper(),
+    spec.restores.codexHome ? CODEX_HOME_RESTORE : null,
+    spec.restores.codexLaunchPreflight ? getPosixCodexShellLaunchPreflight() : null
   ]
 }
 
-function buildZshrc(spec: ZshStartupWrapperSpec): string {
-  return `${joinBlocks([
-    `# ${spec.headerLabel}`,
-    getZshStartupFileSourceBlock({
-      fileName: '.zshrc',
-      homeExpression: spec.homeExpression,
-      interactiveOnly: true,
-      skipWhenHomeIsCurrentZdotdir: spec.skipUserZshrcWhenHomeIsWrapperDir
-    }),
-    spec.restores.agentTeamsPath
-      ? `${AGENT_TEAMS_PATH_RESTORE_FUNCTION}\n[[ ! -o login ]] && __orca_restore_agent_teams_path`
-      : null,
-    joinBlocks([
-      'if [[ ! -o login ]]; then',
-      `  ${spec.interactiveRestoreComment}`,
-      ...getRestoreLines(spec, '  ', spec.legacyFormatting),
-      'fi'
-    ]),
-    spec.osc133CommandMarkers ? ZSH_OSC133_COMMAND_MARKER_BLOCK : null,
-    `if [[ ! -o login ]]; then\n${getZshFinalZdotdirRestoreBlock(spec.homeExpression)}\nfi`
-  ])}\n`
+/**
+ * Every Orca-owned, order-sensitive step, in one function called once.
+ *
+ * Why a function in .zshenv rather than inline code in .zshrc/.zlogin: login and
+ * non-login shells load a different last file, and duplicating the body in both
+ * is how the two copies drifted before. The once-flag makes a double invocation
+ * (re-sourced rc files) a no-op rather than a double-registered prompt hook.
+ */
+function buildEpilogue(spec: ZshStartupWrapperSpec): string {
+  return `__orca_shell_epilogue() {
+  (( $+_orca_epilogue_done )) && return 0
+  typeset -g _orca_epilogue_done=1
+${joinBlocks([
+  featureGuard('overlay', getOverlayRestoreBlocks(spec)),
+  featureGuard('history', [ZSH_HISTFILE_RESTORE_BLOCK]),
+  featureGuard('markers', [spec.osc133CommandMarkers ? ZSH_OSC133_COMMAND_MARKER_BLOCK : null]),
+  featureGuard('ready', [getZshShellReadyMarkerRegistrationBlock(spec.readyMarkerEscaped)])
+])}
+${indentBlock(getZshFinalZdotdirRestoreBlock(spec.homeExpression).replace(/\n$/, ''), '  ')}
+  unset _orca_shell_features
+  unfunction __orca_shell_epilogue __orca_has_feature __orca_resolve_user_config_dir __orca_resolve_inherited_config_dir
+}`
 }
 
-function buildZlogin(spec: ZshStartupWrapperSpec): string {
-  const finalZdotdirRestore = getZshFinalZdotdirRestoreBlock(spec.homeExpression)
-  const readyMarker = getZshShellReadyMarkerRegistrationBlock(spec.readyMarkerEscaped)
-  const tail =
-    spec.readyMarkerOrder === 'before-zdotdir-restore'
-      ? [readyMarker, finalZdotdirRestore]
-      : [finalZdotdirRestore, readyMarker]
-
+function buildZshenv(spec: ZshStartupWrapperSpec): string {
   return `${joinBlocks([
     `# ${spec.headerLabel}`,
-    getZshStartupFileSourceBlock({
-      fileName: '.zlogin',
-      homeExpression: spec.homeExpression,
-      interactiveOnly: true
-    }),
-    spec.restores.agentTeamsPath
-      ? `${AGENT_TEAMS_PATH_RESTORE_FUNCTION}\n__orca_restore_agent_teams_path`
-      : null,
-    joinBlocks([spec.loginRestoreComment, ...getRestoreLines(spec, '')]),
-    ...tail
+    ZSH_FEATURE_CHANNEL_BLOCK,
+    SHELL_STARTUP_IDENTITY_MARKER_BLOCK,
+    ZSH_USER_CONFIG_DIR_RESOLVER_BLOCK,
+    spec.zshenvStrategy === 'discover-user-zdotdir'
+      ? getZshEnvDiscoveryBody(spec.zshDir)
+      : getZshOverlayEnvBody(spec.zshDir),
+    buildEpilogue(spec)
   ])}\n`
 }
 
 export function buildZshStartupWrapperFiles(spec: ZshStartupWrapperSpec): ZshStartupWrapperFiles {
   return {
-    zshenv:
-      spec.zshenvStrategy === 'discover-user-zdotdir'
-        ? getZshEnvTemplate(spec.zshDir, spec.headerLabel)
-        : getZshOverlayEnvTemplate(spec.zshDir, spec.headerLabel),
+    zshenv: buildZshenv(spec),
     zprofile: `${joinBlocks([
       `# ${spec.headerLabel}`,
       getZshStartupFileSourceBlock({
@@ -194,7 +186,25 @@ export function buildZshStartupWrapperFiles(spec: ZshStartupWrapperSpec): ZshSta
         homeExpression: spec.homeExpression
       })
     ])}\n`,
-    zshrc: buildZshrc(spec),
-    zlogin: buildZlogin(spec)
+    zshrc: `${joinBlocks([
+      `# ${spec.headerLabel}`,
+      getZshStartupFileSourceBlock({
+        fileName: '.zshrc',
+        homeExpression: spec.homeExpression,
+        interactiveOnly: true,
+        skipWhenHomeIsCurrentZdotdir: spec.skipUserZshrcWhenHomeIsWrapperDir
+      }),
+      '# Why: a login shell still has .zlogin to load; it runs the epilogue instead.',
+      '[[ -o login ]] || __orca_shell_epilogue'
+    ])}\n`,
+    zlogin: `${joinBlocks([
+      `# ${spec.headerLabel}`,
+      getZshStartupFileSourceBlock({
+        fileName: '.zlogin',
+        homeExpression: spec.homeExpression,
+        interactiveOnly: true
+      }),
+      '__orca_shell_epilogue'
+    ])}\n`
   }
 }

--- a/src/main/zsh-startup-wrapper-builder.ts
+++ b/src/main/zsh-startup-wrapper-builder.ts
@@ -22,6 +22,7 @@ import { getPosixOmpShellWrapper } from './pty/omp-shell-wrapper'
 import { getPosixCodexShellLaunchPreflight } from './pty/codex-shell-launch-preflight'
 import {
   getZshEnvDiscoveryBody,
+  getZshEmulationDegradeBlock,
   getZshFinalZdotdirRestoreBlock,
   getZshOverlayEnvBody,
   getZshShellReadyMarkerRegistrationBlock,
@@ -100,7 +101,9 @@ const ZSH_OSC133_COMMAND_MARKER_BLOCK = `__orca_osc133_precmd() {
 }
 __orca_osc133_preexec() {
   printf "\\033]133;C\\007"
-  __orca_in_command=1
+  # Why typeset -g: a plain assignment here creates a global inside a function,
+  # which prints a warning above every command under warn_create_global.
+  typeset -g __orca_in_command=1
 }
 # Why: prepend so Orca captures $? before user prompt hooks can overwrite it.
 precmd_functions=(__orca_osc133_precmd \${precmd_functions[@]})
@@ -227,6 +230,14 @@ export function buildZshStartupWrapperFiles(spec: ZshStartupWrapperSpec): ZshSta
       getZshStartupFileSourceBlock({
         fileName: '.zprofile',
         homeExpression: spec.homeExpression
+      }),
+      // Why here too: a user .zprofile ending in `emulate sh` hides .zshrc and
+      // .zlogin from the wrapper exactly as a user .zshenv does, and .zprofile
+      // is the last wrapper file that still runs before /etc/zshrc clobbers
+      // HISTFILE — so this is the last point where degrading cleanly is possible.
+      getZshEmulationDegradeBlock({
+        userZdotdirExpression: '"$_orca_home"',
+        sourcedUserFileTest: '-f "$_orca_home/.zprofile"'
       })
     ])}\n`,
     zshrc: `${joinBlocks([

--- a/src/main/zsh-startup-wrapper-builder.ts
+++ b/src/main/zsh-startup-wrapper-builder.ts
@@ -7,6 +7,9 @@
  * disagree on is a field on ZshStartupWrapperSpec, so the disagreements are
  * visible in one place instead of spread across three template literals.
  *
+ * Every generated file redefines the helpers it calls, so the epilogue is the
+ * only thing one file needs another to have defined — see EPILOGUE_CALL.
+ *
  * All order-sensitive Orca work lives in ONE `__orca_shell_epilogue` defined in
  * .zshenv and invoked exactly once — from .zshrc for a non-login shell, from
  * .zlogin for a login shell. Each feature inside it is an independent guard on
@@ -26,6 +29,7 @@ import {
   SHELL_STARTUP_IDENTITY_MARKER_BLOCK,
   ZSH_FEATURE_CHANNEL_BLOCK,
   ZSH_HISTFILE_RESTORE_BLOCK,
+  ZSH_INHERITED_CONFIG_DIR_RESOLVER_BLOCK,
   ZSH_USER_CONFIG_DIR_RESOLVER_BLOCK
 } from './shell-templates'
 
@@ -180,6 +184,7 @@ function buildZshenv(spec: ZshStartupWrapperSpec): string {
     ZSH_FEATURE_CHANNEL_BLOCK,
     SHELL_STARTUP_IDENTITY_MARKER_BLOCK,
     ZSH_USER_CONFIG_DIR_RESOLVER_BLOCK,
+    ZSH_INHERITED_CONFIG_DIR_RESOLVER_BLOCK,
     spec.zshenvStrategy === 'discover-user-zdotdir'
       ? getZshEnvDiscoveryBody(spec.zshDir)
       : getZshOverlayEnvBody(spec.zshDir),
@@ -188,12 +193,13 @@ function buildZshenv(spec: ZshStartupWrapperSpec): string {
 }
 
 /**
- * Why guarded: the generated files are inter-dependent (this call, the function
- * in .zshenv), and one wrapper dir can be shared by two concurrently installed
- * Orca builds. Pairing this file with an older .zshenv then loses the features
- * either way; degrade silently instead of printing "command not found" into the
- * user's pane. Braced subscript because sh/ksh emulation (KSH_ARRAYS) rejects
- * the unbraced `$+functions[...]` form outright.
+ * Why guarded: one wrapper dir can be shared by two concurrently installed Orca
+ * builds, so a shell can read one build's .zshenv and another's .zshrc/.zlogin.
+ * The epilogue is the only cross-file dependency left — every other function
+ * these files call is redefined at the top of each of them — so an older .zshenv
+ * costs this shell the epilogue's features and nothing else, without printing
+ * "command not found" into the user's pane. Braced subscript because sh/ksh
+ * emulation (KSH_ARRAYS) rejects the unbraced `$+functions[...]` form outright.
  */
 const EPILOGUE_CALL = '(( ${+functions[__orca_shell_epilogue]} )) && __orca_shell_epilogue'
 
@@ -217,6 +223,7 @@ export function buildZshStartupWrapperFiles(spec: ZshStartupWrapperSpec): ZshSta
     zshenv: buildZshenv(spec),
     zprofile: `${joinBlocks([
       `# ${spec.headerLabel}`,
+      ZSH_USER_CONFIG_DIR_RESOLVER_BLOCK,
       getZshStartupFileSourceBlock({
         fileName: '.zprofile',
         homeExpression: spec.homeExpression
@@ -224,6 +231,7 @@ export function buildZshStartupWrapperFiles(spec: ZshStartupWrapperSpec): ZshSta
     ])}\n`,
     zshrc: `${joinBlocks([
       `# ${spec.headerLabel}`,
+      ZSH_USER_CONFIG_DIR_RESOLVER_BLOCK,
       getZshStartupFileSourceBlock({
         fileName: '.zshrc',
         homeExpression: spec.homeExpression,
@@ -234,6 +242,7 @@ export function buildZshStartupWrapperFiles(spec: ZshStartupWrapperSpec): ZshSta
     ])}\n`,
     zlogin: `${joinBlocks([
       `# ${spec.headerLabel}`,
+      ZSH_USER_CONFIG_DIR_RESOLVER_BLOCK,
       getZshStartupFileSourceBlock({
         fileName: '.zlogin',
         homeExpression: spec.homeExpression,

--- a/src/main/zsh-startup-wrapper-builder.ts
+++ b/src/main/zsh-startup-wrapper-builder.ts
@@ -11,7 +11,9 @@
  * .zshenv and invoked exactly once — from .zshrc for a non-login shell, from
  * .zlogin for a login shell. Each feature inside it is an independent guard on
  * the allowlist snapshotted (and destroyed) at the top of .zshenv, so a pane
- * wrapped only for one feature runs only that feature's code.
+ * wrapped only for one feature runs only that feature's code — except the
+ * HISTFILE repair, which undoes damage the wrapper's own ZDOTDIR caused and so
+ * must also run for a shell that re-entered the wrapper with no allowlist.
  */
 import { getPosixOmpShellWrapper } from './pty/omp-shell-wrapper'
 import { getPosixCodexShellLaunchPreflight } from './pty/codex-shell-launch-preflight'
@@ -149,11 +151,20 @@ function getOverlayRestoreBlocks(spec: ZshStartupWrapperSpec): (string | null)[]
  */
 function buildEpilogue(spec: ZshStartupWrapperSpec): string {
   return `__orca_shell_epilogue() {
+  # Why first: this body runs after the user's own config, so it would otherwise
+  # inherit whatever options that config left set. Under NO_UNSET an unset
+  # precmd_functions is a fatal error that returns from the whole epilogue
+  # (skipping the ready widget and the ZDOTDIR restore), and KSH_ARRAYS makes
+  # the 1-based feature lookup drop the first selected feature.
+  emulate -L zsh
   (( $+_orca_epilogue_done )) && return 0
   typeset -g _orca_epilogue_done=1
 ${joinBlocks([
   featureGuard('overlay', getOverlayRestoreBlocks(spec)),
-  featureGuard('history', [ZSH_HISTFILE_RESTORE_BLOCK]),
+  // Why ungated: this repairs damage Orca's own ZDOTDIR caused, so it must also
+  // run for a shell that re-enters the wrapper with no feature channel left
+  // (a nested zsh under an inherited wrapper ZDOTDIR) — the plain #11044 shape.
+  indentBlock(ZSH_HISTFILE_RESTORE_BLOCK, '  '),
   featureGuard('markers', [spec.osc133CommandMarkers ? ZSH_OSC133_COMMAND_MARKER_BLOCK : null]),
   featureGuard('ready', [getZshShellReadyMarkerRegistrationBlock(spec.readyMarkerEscaped)])
 ])}

--- a/src/main/zsh-user-config-dir-fixture.ts
+++ b/src/main/zsh-user-config-dir-fixture.ts
@@ -1,0 +1,17 @@
+/**
+ * Builds a directory that counts as a user's real zsh config root.
+ *
+ * Why a fixture: the inherited-ZDOTDIR guard only accepts a directory that
+ * actually holds a zsh startup file, so tests can no longer use a made-up path.
+ *
+ * Test support only; nothing under src/main imports this at runtime.
+ */
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+export function makeUserZdotdir(parent: string, ...segments: string[]): string {
+  const dir = join(parent, ...segments)
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, '.zshrc'), '')
+  return dir
+}

--- a/src/main/zsh-wrapper-dir-ownership.ts
+++ b/src/main/zsh-wrapper-dir-ownership.ts
@@ -1,0 +1,57 @@
+/**
+ * Decides which inherited ZDOTDIR Orca may treat as the user's real zsh config
+ * dir, on the Node side of the launch.
+ *
+ * Why: Orca used to recognise only its OWN wrapper path shape (a path ending in
+ * shell-ready/zsh). Launched from any other terminal that had already
+ * hijacked ZDOTDIR, Orca captured that dir as "the user's config" and re-sourced
+ * it. Ownership is now established positively — a stamped marker file, or Orca's
+ * own dir shape for wrappers written by older builds — and a dir holding no zsh
+ * startup file at all is not a config dir whoever wrote it. No vendor is
+ * detected by name, because that can never be complete.
+ */
+import { existsSync } from 'node:fs'
+import { ZSH_WRAPPER_DIR_MARKER_FILE } from './shell-templates'
+
+type EnvLike = Record<string, string | undefined>
+
+const ZSH_STARTUP_FILES = ['.zshenv', '.zshrc', '.zprofile', '.zlogin'] as const
+
+export function isOrcaOwnedZshWrapperDir(dir: string): boolean {
+  const normalized = dir.replace(/\/+$/, '')
+  if (!normalized) {
+    return false
+  }
+  return (
+    existsSync(`${normalized}/${ZSH_WRAPPER_DIR_MARKER_FILE}`) ||
+    normalized.endsWith('/shell-ready/zsh')
+  )
+}
+
+/** The inherited value if it is usable as the user's config dir, else null. */
+function usableInheritedZdotdir(value: string | undefined): string | null {
+  if (!value) {
+    return null
+  }
+  const normalized = value.replace(/\/+$/, '')
+  if (!normalized || isOrcaOwnedZshWrapperDir(normalized)) {
+    return null
+  }
+  if (!ZSH_STARTUP_FILES.some((file) => existsSync(`${normalized}/${file}`))) {
+    return null
+  }
+  return value
+}
+
+export function resolveInheritedZdotdir(env: EnvLike, homeFallback = ''): string {
+  return (
+    usableInheritedZdotdir(env.ZDOTDIR) ??
+    usableInheritedZdotdir(env.ORCA_ORIG_ZDOTDIR) ??
+    env.HOME ??
+    homeFallback
+  )
+}
+
+export function resolveInheritedZshenvSourceDir(env: EnvLike, homeFallback = ''): string {
+  return usableInheritedZdotdir(env.ZDOTDIR) ?? env.HOME ?? homeFallback
+}

--- a/src/main/zsh-wrapper-version-mismatch.live-shell.test.ts
+++ b/src/main/zsh-wrapper-version-mismatch.live-shell.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Real-zsh proof that a wrapper dir written by two different Orca builds still
+ * loads the user's own zsh config.
+ *
+ * One wrapper dir (`<userData>/shell-ready/zsh`, or `~/.orca-relay/shell-ready/
+ * zsh` for a remote host) is shared by every concurrently installed build, and
+ * each rewrites it on spawn. A shell can therefore read one build's `.zshenv`
+ * and another's `.zprofile`/`.zshrc`/`.zlogin`. Only a real zsh shows the cost:
+ * a helper the newer files call but the older `.zshenv` never defined both
+ * prints `command not found` into the pane AND leaves `$REPLY` empty, which
+ * silently skips sourcing the user's own startup files.
+ */
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { ensureShellReadyWrappersAt } from './providers/local-pty-shell-ready-wrapper-generation'
+
+const hasZsh = process.platform !== 'win32' && spawnSync('zsh', ['--version']).status === 0
+const ZSH_PATH = hasZsh
+  ? (spawnSync('sh', ['-c', 'command -v zsh'], { encoding: 'utf8' }).stdout || '').trim()
+  : ''
+const itWithZsh = hasZsh ? it : it.skip
+
+/**
+ * A `.zshenv` from a build that predates everything the other three files now
+ * call: it exports the wrapper ZDOTDIR and nothing else.
+ */
+function olderBuildZshenv(zshDir: string): string {
+  return `# Orca zsh shell-ready wrapper
+export ORCA_ORIG_ZDOTDIR="$HOME"
+export ZDOTDIR=${JSON.stringify(zshDir)}
+`
+}
+
+describe.skipIf(process.platform === 'win32')('zsh wrapper dir written by mixed builds', () => {
+  itWithZsh('still sources the user config when the .zshenv is from an older build', () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-wrapper-mismatch-'))
+    const home = mkdtempSync(join(tmpdir(), 'orca-wrapper-mismatch-home-'))
+    try {
+      expect(ensureShellReadyWrappersAt(root)).toBe(true)
+      const zshDir = join(root, 'zsh')
+      writeFileSync(join(zshDir, '.zshenv'), olderBuildZshenv(zshDir))
+      for (const file of ['.zprofile', '.zshrc', '.zlogin']) {
+        writeFileSync(join(home, file), `echo "RAN ${file}"\n`)
+      }
+
+      const result = spawnSync(ZSH_PATH, ['-l', '-i', '-c', 'exit 0'], {
+        encoding: 'utf8',
+        timeout: 20_000,
+        env: { PATH: '/usr/bin:/bin', HOME: home, ZDOTDIR: zshDir }
+      })
+      // Why both streams: zsh prints `command not found` on stderr and the
+      // fixture files echo on stdout, and this asserts about each.
+      const output = `${result.stdout}${result.stderr}`
+
+      expect(output).not.toContain('command not found')
+      expect(output).toContain('RAN .zprofile')
+      expect(output).toContain('RAN .zshrc')
+      expect(output).toContain('RAN .zlogin')
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+      rmSync(home, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/relay/pty-handler-revive.test.ts
+++ b/src/relay/pty-handler-revive.test.ts
@@ -79,15 +79,17 @@ describe('PtyHandler', () => {
       ORCA_AGENT_HOOK_TOKEN: 'abc-uuid'
     }))
     const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
-    const oldStartupIdentity = process.env.ORCA_SHELL_STARTUP_IDENTITY
-    process.env.ORCA_SHELL_STARTUP_IDENTITY = '1'
+    // Why seeded: a revived pane must not inherit a feature selection from the
+    // relay process's own environment.
+    const oldShellFeatures = process.env.ORCA_SHELL_FEATURES
+    process.env.ORCA_SHELL_FEATURES = 'ready,identity,markers,overlay'
     try {
       await dispatcher.callRequest('pty.revive', { state })
     } finally {
-      if (oldStartupIdentity === undefined) {
-        delete process.env.ORCA_SHELL_STARTUP_IDENTITY
+      if (oldShellFeatures === undefined) {
+        delete process.env.ORCA_SHELL_FEATURES
       } else {
-        process.env.ORCA_SHELL_STARTUP_IDENTITY = oldStartupIdentity
+        process.env.ORCA_SHELL_FEATURES = oldShellFeatures
       }
       killSpy.mockRestore()
     }
@@ -101,8 +103,8 @@ describe('PtyHandler', () => {
     expect(callArgs.env.ORCA_AGENT_HOOK_TOKEN).toBe('abc-uuid')
     expect(callArgs.env.TERM).toBe('xterm-256color')
     expect(callArgs.env.TERM_PROGRAM).toBe('Orca')
-    expect(callArgs.env.ORCA_SHELL_READY_MARKER).toBe('0')
-    expect(callArgs.env.ORCA_SHELL_STARTUP_IDENTITY).toBe('0')
+    expect(callArgs.env.ORCA_SHELL_FEATURES).not.toContain('ready')
+    expect(callArgs.env.ORCA_SHELL_FEATURES).not.toContain('identity')
   })
 
   it('fences both revived worktree identity and cwd with rollback', async () => {

--- a/src/relay/pty-handler-spawn-environment.test.ts
+++ b/src/relay/pty-handler-spawn-environment.test.ts
@@ -188,6 +188,38 @@ describe('PtyHandler', () => {
       expect(spawnEnv.fish_history).toBe(expected)
     })
 
+    it.each([
+      [
+        'a relay-minted path',
+        `${process.env.HOME ?? ''}/.orca-remote/terminal-history/aabbccddeeff0011-zsh_history`,
+        undefined
+      ],
+      [
+        'a desktop-minted path',
+        '/fake/userData/terminal-history/aabbccddeeff0011/zsh_history',
+        undefined
+      ],
+      ['a user value', '/home/me/.zsh_history', '/home/me/.zsh_history']
+    ])(
+      '%s inherited as HISTFILE from the relay process env',
+      async (_kind, inherited, expected) => {
+        const previous = process.env.HISTFILE
+        process.env.HISTFILE = inherited
+        try {
+          await dispatcher.callRequest('pty.spawn', { cols: 80, rows: 24 })
+        } finally {
+          if (previous === undefined) {
+            delete process.env.HISTFILE
+          } else {
+            process.env.HISTFILE = previous
+          }
+        }
+
+        const spawnEnv = mockPtySpawn.mock.calls.at(-1)?.[2]?.env as Record<string, string>
+        expect(spawnEnv.HISTFILE).toBe(expected)
+      }
+    )
+
     it('drops a desktop-minted session handed over in the client env', async () => {
       await dispatcher.callRequest('pty.spawn', {
         cols: 80,

--- a/src/relay/pty-handler-spawn-environment.test.ts
+++ b/src/relay/pty-handler-spawn-environment.test.ts
@@ -220,6 +220,50 @@ describe('PtyHandler', () => {
       }
     )
 
+    // Why unconditionally, not only with isolation on: injectRelayHistoryEnv is
+    // what normally mints (and first clears) ORCA_HISTFILE, and it runs only
+    // with isolation on. An inherited one — the relay can be launched from an
+    // Orca pane — would otherwise reach the remote wrapper on the disabled and
+    // revive paths, re-exporting another worktree's history path (#11146) and
+    // wrapping a zsh pane nothing asked to wrap.
+    it.each([
+      [
+        'a relay-minted path',
+        `${process.env.HOME ?? ''}/.orca-remote/terminal-history/aabbccddeeff0011-zsh_history`
+      ],
+      ['a desktop-minted path', '/fake/userData/terminal-history/aabbccddeeff0011/zsh_history'],
+      ['a user value', '/home/me/.zsh_history']
+    ])(
+      'drops %s inherited as ORCA_HISTFILE from the relay process env',
+      async (_kind, inherited) => {
+        const previous = process.env.ORCA_HISTFILE
+        process.env.ORCA_HISTFILE = inherited
+        try {
+          await dispatcher.callRequest('pty.spawn', { cols: 80, rows: 24 })
+        } finally {
+          if (previous === undefined) {
+            delete process.env.ORCA_HISTFILE
+          } else {
+            process.env.ORCA_HISTFILE = previous
+          }
+        }
+
+        const spawnEnv = mockPtySpawn.mock.calls.at(-1)?.[2]?.env as Record<string, string>
+        expect(spawnEnv.ORCA_HISTFILE).toBeUndefined()
+      }
+    )
+
+    it('drops an ORCA_HISTFILE handed over in the client env', async () => {
+      await dispatcher.callRequest('pty.spawn', {
+        cols: 80,
+        rows: 24,
+        env: { ORCA_HISTFILE: '/fake/userData/terminal-history/aabbccddeeff0011/zsh_history' }
+      })
+
+      const spawnEnv = mockPtySpawn.mock.calls.at(-1)?.[2]?.env as Record<string, string>
+      expect(spawnEnv.ORCA_HISTFILE).toBeUndefined()
+    })
+
     it('drops a desktop-minted session handed over in the client env', async () => {
       await dispatcher.callRequest('pty.spawn', {
         cols: 80,

--- a/src/relay/pty-handler-startup-command-delivery.test.ts
+++ b/src/relay/pty-handler-startup-command-delivery.test.ts
@@ -122,7 +122,7 @@ describe('PtyHandler', () => {
       const spawnOptions = mockPtySpawn.mock.calls[0]?.[2] as
         | { env?: Record<string, string> }
         | undefined
-      expect(spawnOptions?.env?.ORCA_SHELL_READY_MARKER).toBe('1')
+      expect(spawnOptions?.env?.ORCA_SHELL_FEATURES).toContain('ready')
       expect(handler.retainedStartupCommandCount).toBe(1)
       expect(handler.retainedStartupCommandBytes).toBe(0)
       vi.advanceTimersByTime(15_000)
@@ -161,7 +161,7 @@ describe('PtyHandler', () => {
       const spawnOptions = mockPtySpawn.mock.calls[0]?.[2] as
         | { env?: Record<string, string> }
         | undefined
-      expect(spawnOptions?.env?.ORCA_SHELL_READY_MARKER).toBe('1')
+      expect(spawnOptions?.env?.ORCA_SHELL_FEATURES).toContain('ready')
       expect(handler.retainedStartupCommandCount).toBe(1)
     }
   )
@@ -199,7 +199,7 @@ describe('PtyHandler', () => {
       const spawnOptions = mockPtySpawn.mock.calls[0]?.[2] as
         | { env?: Record<string, string> }
         | undefined
-      expect(spawnOptions?.env?.ORCA_SHELL_READY_MARKER).toBe('1')
+      expect(spawnOptions?.env?.ORCA_SHELL_FEATURES).toContain('ready')
     }
   )
 
@@ -238,7 +238,7 @@ describe('PtyHandler', () => {
       const spawnOptions = mockPtySpawn.mock.calls[0]?.[2] as
         | { env?: Record<string, string> }
         | undefined
-      expect(spawnOptions?.env?.ORCA_SHELL_READY_MARKER).toBe('1')
+      expect(spawnOptions?.env?.ORCA_SHELL_FEATURES).toContain('ready')
     }
   )
 
@@ -512,7 +512,7 @@ describe('PtyHandler', () => {
       const spawnOptions = mockPtySpawn.mock.calls[0]?.[2] as
         | { env?: Record<string, string> }
         | undefined
-      expect(spawnOptions?.env?.ORCA_SHELL_READY_MARKER).toBe('0')
+      expect(spawnOptions?.env?.ORCA_SHELL_FEATURES).toBe('')
       expect(handler.retainedStartupCommandCount).toBe(0)
     }
   )

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -18,6 +18,7 @@ import {
 } from './pty-shell-utils'
 import { getRelayShellLaunchConfig, isRelayWslShell } from './pty-shell-launch'
 import { addWslEnvKeys } from '../shared/wsl-env'
+import { SHELL_STARTUP_FEATURE_ENV } from '../main/shell-startup-features'
 import { DEFAULT_SSH_RELAY_GRACE_PERIOD_SECONDS } from '../shared/ssh-types'
 import { shouldUseShellReadyStartupDelivery } from '../shared/codex-startup-delivery'
 import { buildStartupCommandSubmission } from '../shared/startup-command-submission'
@@ -1590,7 +1591,7 @@ export class PtyHandler {
       emitStartupIdentity: shouldEmitShellReadyMarker
     })
     const rendererShellReadySupported =
-      !shouldProviderDeliverCommand && shellLaunch.env.ORCA_SHELL_READY_MARKER === '1'
+      !shouldProviderDeliverCommand && shellLaunch.supportsReadyMarker
 
     if (context?.signal?.aborted || context?.isStale()) {
       // Why: cancellation remains side-effect-free until the exact native spawn seam.
@@ -1610,11 +1611,11 @@ export class PtyHandler {
         cols,
         rows,
         cwd,
-        // Why: relay shells inherit process.env; don't let an ambient Orca marker enable shell-ready unless requested.
+        // Why the empty default: relay shells inherit process.env, and the launch
+        // config is the only thing allowed to name features for this shell.
         env: {
           ...spawnEnv,
-          ORCA_SHELL_READY_MARKER: '0',
-          ORCA_SHELL_STARTUP_IDENTITY: '0',
+          [SHELL_STARTUP_FEATURE_ENV]: '',
           ...shellLaunch.env
         }
       })
@@ -1671,11 +1672,10 @@ export class PtyHandler {
               command: shouldProviderDeliverCommand ? managedStartupCommand : null,
               providerDelivery: shouldProviderDeliverCommand,
               delivered: false,
-              waitForShellReady: shellLaunch.env.ORCA_SHELL_READY_MARKER === '1',
-              outputScanState:
-                shellLaunch.env.ORCA_SHELL_READY_MARKER === '1'
-                  ? createShellStartupOutputScanState()
-                  : null,
+              waitForShellReady: shellLaunch.supportsReadyMarker,
+              outputScanState: shellLaunch.supportsReadyMarker
+                ? createShellStartupOutputScanState()
+                : null,
               shellPid: null,
               promptProbe: null,
               timer: null
@@ -2189,8 +2189,7 @@ export class PtyHandler {
       // Why: no provider-delivered command is waiting for a ready marker.
       env: {
         ...spawnEnv,
-        ORCA_SHELL_READY_MARKER: '0',
-        ORCA_SHELL_STARTUP_IDENTITY: '0',
+        [SHELL_STARTUP_FEATURE_ENV]: '',
         ...shellLaunch.env
       }
     })

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -641,6 +641,13 @@ export class PtyHandler {
     // on, yet an inherited Orca HISTFILE must not scope a pane to someone else's
     // worktree on the disabled and revive paths either.
     dropInheritedOrcaHistFile(result)
+    // Why unconditionally: ORCA_HISTFILE is Orca-owned and minted below by
+    // injectRelayHistoryEnv, which also runs only with isolation on. An
+    // inherited one (the relay can be launched from an Orca pane) would
+    // otherwise reach the wrapper on the disabled and revive paths, scoping the
+    // pane to another worktree's history file — and wrapping a zsh pane that
+    // nothing asked to wrap, since `history` is selected on its presence.
+    delete result.ORCA_HISTFILE
     // Why: match local/daemon precedence so defaults/augmenters can't resurrect explicitly-removed values.
     for (const key of envToDelete) {
       delete result[key]

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -51,6 +51,7 @@ import { forceKillPosixPtyProcessGroups } from '../main/pty/posix-pty-process-gr
 import { stripInheritedBuildModeEnv } from '../main/pty/build-mode-env'
 import { stripLegacyTerminalShimEnv } from '../main/pty/legacy-terminal-shim-dir'
 import { dropInheritedOrcaFishHistory } from '../main/fish-history-session'
+import { dropInheritedOrcaHistFile } from '../main/worktree-history-file-path'
 import {
   PTY_STARTUP_INGRESS_VERSION,
   PtyStartupIngress,
@@ -636,6 +637,10 @@ export class PtyHandler {
     // any pane to someone else's worktree. Matches the desktop, which drops it on both
     // branches (STA-4682).
     dropInheritedOrcaFishHistory(result)
+    // Why here as well as in injectRelayHistoryEnv: that runs only with isolation
+    // on, yet an inherited Orca HISTFILE must not scope a pane to someone else's
+    // worktree on the disabled and revive paths either.
+    dropInheritedOrcaHistFile(result)
     // Why: match local/daemon precedence so defaults/augmenters can't resurrect explicitly-removed values.
     for (const key of envToDelete) {
       delete result[key]

--- a/src/relay/pty-shell-launch.test.ts
+++ b/src/relay/pty-shell-launch.test.ts
@@ -66,7 +66,7 @@ function expectZdotdirSourceContext(content: string, fileName: '.zprofile' | '.z
 
 function expectFinalZdotdirRestoreContext(content: string) {
   expect(content).toContain("after Orca's last wrapper file has loaded")
-  expect(content).toContain('export ZDOTDIR="$_orca_home"')
+  expect(content).toContain('export ZDOTDIR="$REPLY"')
 }
 
 describe('isRelayWslShell', () => {
@@ -109,22 +109,21 @@ describe('getRelayShellLaunchConfig', () => {
 
       expect(config.args).toEqual(['-l'])
       expect(config.env.ZDOTDIR).toBe(zshRoot)
-      expect(readFileSync(join(zshRoot, '.zshenv'), 'utf8')).toContain(
-        'export ORCA_USER_ZDOTDIR="${ZDOTDIR:-${ORCA_ORIG_ZDOTDIR:-$HOME}}"'
-      )
-      expect(readFileSync(join(zshRoot, '.zprofile'), 'utf8')).toContain(
-        '_orca_home="${ORCA_USER_ZDOTDIR:-${ORCA_ORIG_ZDOTDIR:-$HOME}}"'
-      )
+      const zshenv = readFileSync(join(zshRoot, '.zshenv'), 'utf8')
+      const userZdotdirResolution =
+        '__orca_resolve_user_config_dir "${ORCA_USER_ZDOTDIR:-${ORCA_ORIG_ZDOTDIR:-$HOME}}"'
+      expect(zshenv).toContain('export ORCA_USER_ZDOTDIR="$REPLY"')
       const zprofile = readFileSync(join(zshRoot, '.zprofile'), 'utf8')
       const zshrc = readFileSync(join(zshRoot, '.zshrc'), 'utf8')
       const zlogin = readFileSync(join(zshRoot, '.zlogin'), 'utf8')
-      expect(zshrc).toContain('_orca_home="${ORCA_USER_ZDOTDIR:-${ORCA_ORIG_ZDOTDIR:-$HOME}}"')
-      expect(zlogin).toContain('_orca_home="${ORCA_USER_ZDOTDIR:-${ORCA_ORIG_ZDOTDIR:-$HOME}}"')
+      expect(zprofile).toContain(userZdotdirResolution)
+      expect(zshrc).toContain(userZdotdirResolution)
+      expect(zlogin).toContain(userZdotdirResolution)
       expectZdotdirSourceContext(zprofile, '.zprofile')
       expectZdotdirSourceContext(zshrc, '.zshrc')
       expectZdotdirSourceContext(zlogin, '.zlogin')
-      expectFinalZdotdirRestoreContext(zshrc)
-      expectFinalZdotdirRestoreContext(zlogin)
+      // Why .zshenv: the final restore is the last step of the one epilogue.
+      expectFinalZdotdirRestoreContext(zshenv)
     }
   )
 
@@ -133,7 +132,8 @@ describe('getRelayShellLaunchConfig', () => {
       getRelayShellLaunchConfig('C:\\Windows\\System32\\cmd.exe', { HOME: homeDir }, 'win32')
     ).toEqual({
       args: [],
-      env: {}
+      env: {},
+      supportsReadyMarker: false
     })
     expect(
       getRelayShellLaunchConfig(
@@ -143,14 +143,16 @@ describe('getRelayShellLaunchConfig', () => {
       )
     ).toEqual({
       args: ['-NoLogo'],
-      env: {}
+      env: {},
+      supportsReadyMarker: false
     })
   })
 
   it('keeps PowerShell Core on POSIX remotes as a login shell', () => {
     expect(getRelayShellLaunchConfig('/usr/bin/pwsh', { HOME: homeDir }, 'linux')).toEqual({
       args: ['-l'],
-      env: {}
+      env: {},
+      supportsReadyMarker: false
     })
   })
 
@@ -165,7 +167,7 @@ describe('getRelayShellLaunchConfig', () => {
     })
 
     expect(readFileSync(join(zshRoot, '.zshenv'), 'utf8')).toContain(
-      'export ORCA_USER_ZDOTDIR="${ZDOTDIR:-${ORCA_ORIG_ZDOTDIR:-$HOME}}"'
+      'export ORCA_USER_ZDOTDIR="$REPLY"'
     )
   })
 
@@ -177,11 +179,13 @@ describe('getRelayShellLaunchConfig', () => {
         ORCA_MIMOCODE_HOME: '/tmp/orca-mimocode-overlay'
       })
       const zshRoot = join(homeDir, '.orca-relay', 'shell-ready', 'zsh')
-      const zshrc = readFileSync(join(zshRoot, '.zshrc'), 'utf8')
+      // Why .zshenv: the overlay restores live in the one epilogue defined there.
+      const zshenv = readFileSync(join(zshRoot, '.zshenv'), 'utf8')
 
       expect(config.args).toEqual(['-l'])
       expect(config.env.ZDOTDIR).toBe(zshRoot)
-      expect(zshrc).toContain(
+      expect(config.env.ORCA_SHELL_FEATURES).toBe('overlay,history,markers')
+      expect(zshenv).toContain(
         '[[ -n "${ORCA_MIMOCODE_HOME:-}" ]] && export MIMOCODE_HOME="${ORCA_MIMOCODE_HOME}"'
       )
     }
@@ -195,7 +199,9 @@ describe('getRelayShellLaunchConfig', () => {
       const bashRc = readFileSync(rcfile, 'utf8')
 
       expect(config.args).toEqual(['--rcfile', rcfile])
-      expect(config.env).toEqual({})
+      // Why the empty allowlist: bash keeps its unconditional OSC 133 hooks, and
+      // an explicit empty value also overrides anything the relay inherited.
+      expect(config.env).toEqual({ ORCA_SHELL_FEATURES: '' })
       expect(bashRc).toContain('printf "\\033]133;D;%s\\007"')
       expect(bashRc).toContain('printf "\\033]133;C\\007"')
     }
@@ -208,19 +214,17 @@ describe('getRelayShellLaunchConfig', () => {
         emitReadyMarker: true
       })
       const zshRoot = join(homeDir, '.orca-relay', 'shell-ready', 'zsh')
-      const zlogin = readFileSync(join(zshRoot, '.zlogin'), 'utf8')
+      const zshenv = readFileSync(join(zshRoot, '.zshenv'), 'utf8')
 
       expect(config.args).toEqual(['-l'])
       expect(config.env.ZDOTDIR).toBe(zshRoot)
-      expect(config.env.ORCA_SHELL_READY_MARKER).toBe('1')
-      expect(readFileSync(join(zshRoot, '.zshenv'), 'utf8')).toContain(
-        'printf "\\033]777;orca-shell-start:%s\\007" "$$"'
-      )
-      expect(readFileSync(join(zshRoot, '.zshenv'), 'utf8')).toContain(
-        'unset ORCA_SHELL_STARTUP_IDENTITY'
-      )
-      expect(zlogin).toContain('zle -N zle-line-init __orca_prompt_mark')
-      expect(zlogin).toContain('printf "\\033]777;orca-shell-ready\\007"')
+      expect(config.supportsReadyMarker).toBe(true)
+      expect(config.env.ORCA_SHELL_FEATURES).toContain('ready')
+      expect(zshenv).toContain('printf "\\033]777;orca-shell-start:%s\\007" "$$"')
+      // Why: the channel is destroyed before the user's own config is sourced.
+      expect(zshenv).toContain('builtin unset ORCA_SHELL_FEATURES')
+      expect(zshenv).toContain('zle -N zle-line-init __orca_prompt_mark')
+      expect(zshenv).toContain('printf "\\033]777;orca-shell-ready\\007"')
     }
   )
 
@@ -232,9 +236,10 @@ describe('getRelayShellLaunchConfig', () => {
       })
       const bashRc = readFileSync(config.args[1] as string, 'utf8')
 
-      expect(config.env.ORCA_SHELL_READY_MARKER).toBe('1')
+      expect(config.supportsReadyMarker).toBe(true)
+      expect(config.env.ORCA_SHELL_FEATURES).toContain('ready')
       expect(bashRc).toContain('printf "\\033]777;orca-shell-start:%s\\007" "$$"')
-      expect(bashRc).toContain('unset ORCA_SHELL_STARTUP_IDENTITY')
+      expect(bashRc).toContain('builtin unset ORCA_SHELL_FEATURES')
       expect(bashRc).toContain('__orca_append_prompt_command "__orca_prompt_mark"')
       expect(bashRc).toContain('printf "\\033]777;orca-shell-ready\\007"')
     }
@@ -248,8 +253,7 @@ describe('getRelayShellLaunchConfig', () => {
       })
 
       expect(config.env.ZDOTDIR).toBe(join(homeDir, '.orca-relay', 'shell-ready', 'zsh'))
-      expect(config.env.ORCA_SHELL_STARTUP_IDENTITY).toBe('1')
-      expect(config.env.ORCA_SHELL_READY_MARKER).toBeUndefined()
+      expect(config.env.ORCA_SHELL_FEATURES).toContain('identity')
     }
   )
 

--- a/src/relay/pty-shell-launch.test.ts
+++ b/src/relay/pty-shell-launch.test.ts
@@ -67,7 +67,7 @@ function expectZdotdirSourceContext(content: string, fileName: '.zprofile' | '.z
 
 function expectFinalZdotdirRestoreContext(content: string) {
   expect(content).toContain("after Orca's last wrapper file has loaded")
-  expect(content).toContain('export ZDOTDIR="$REPLY"')
+  expect(content).toContain('export ZDOTDIR="$_orca_resolved_config_dir"')
 }
 
 describe('isRelayWslShell', () => {
@@ -113,7 +113,7 @@ describe('getRelayShellLaunchConfig', () => {
       const zshenv = readFileSync(join(zshRoot, '.zshenv'), 'utf8')
       const userZdotdirResolution =
         '__orca_resolve_user_config_dir "${ORCA_USER_ZDOTDIR:-${ORCA_ORIG_ZDOTDIR:-$HOME}}"'
-      expect(zshenv).toContain('export ORCA_USER_ZDOTDIR="$REPLY"')
+      expect(zshenv).toContain('export ORCA_USER_ZDOTDIR="$_orca_resolved_config_dir"')
       const zprofile = readFileSync(join(zshRoot, '.zprofile'), 'utf8')
       const zshrc = readFileSync(join(zshRoot, '.zshrc'), 'utf8')
       const zlogin = readFileSync(join(zshRoot, '.zlogin'), 'utf8')
@@ -222,7 +222,7 @@ describe('getRelayShellLaunchConfig', () => {
     })
 
     expect(readFileSync(join(zshRoot, '.zshenv'), 'utf8')).toContain(
-      'export ORCA_USER_ZDOTDIR="$REPLY"'
+      'export ORCA_USER_ZDOTDIR="$_orca_resolved_config_dir"'
     )
   })
 

--- a/src/relay/pty-shell-launch.test.ts
+++ b/src/relay/pty-shell-launch.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { spawnSync } from 'node:child_process'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { buildSshPtySpawnEnv } from '../main/providers/ssh-pty-spawn-env'
 import { getRelayShellLaunchConfig, isRelayWslShell } from './pty-shell-launch'
 
 const hasBash = process.platform !== 'win32' && spawnSync('bash', ['--version']).status === 0
@@ -149,18 +150,56 @@ describe('getRelayShellLaunchConfig', () => {
   })
 
   it.skipIf(process.platform === 'win32')(
-    'keeps a remote zsh on the plain login path when only history would wrap it',
+    'wraps an ordinary SSH pane, as every remote pane with a CLI bridge already was',
     () => {
-      // Why: the relay .zshenv resolves the user's config dir from a ZDOTDIR
-      // Orca has already overwritten, so a remote user whose zsh config lives in
-      // a relocated ZDOTDIR loses that config the moment the pane is wrapped.
-      // A worktree HISTFILE is not worth trading a whole shell config for.
-      expect(
-        getRelayShellLaunchConfig('/bin/zsh', {
-          HOME: homeDir,
-          ORCA_HISTFILE: join(homeDir, 'orca-history', 'zsh_history')
-        })
-      ).toEqual({ args: ['-l'], env: {}, supportsReadyMarker: false })
+      // Why the real builder: the relay's wrapping rule is only meaningful
+      // against the env main actually sends. Every relay session with a CLI
+      // bridge sets ORCA_REMOTE_CLI_BIN_DIR, which was already enough to wrap.
+      const env = buildSshPtySpawnEnv({
+        env: { HOME: homeDir, PATH: '/usr/bin:/bin' },
+        remoteCliBridgeEnv: {
+          binDir: '/home/remote/.orca-relay/bin',
+          relayDir: '/home/remote/.orca-relay',
+          nodePath: '/home/remote/.orca-relay/node',
+          sockPath: '/home/remote/.orca-relay/relay.sock'
+        }
+      })
+      env.ORCA_HISTFILE = join(homeDir, 'orca-history', 'zsh_history')
+
+      const config = getRelayShellLaunchConfig('/bin/zsh', env)
+
+      expect(config.env.ZDOTDIR).toBe(join(homeDir, '.orca-relay', 'shell-ready', 'zsh'))
+      expect(config.env.ORCA_SHELL_FEATURES).toBe('overlay,history,markers')
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'repairs worktree history on a remote pane whose host reports no CLI bridge',
+    () => {
+      // Why this env shape: a host too old to report its platform leaves
+      // remoteCliBridgeEnv null, so the pane carries no overlay key at all.
+      // It is the one pane class the relay was NOT already wrapping, and
+      // leaving it unwrapped silently loses its worktree history.
+      const env = buildSshPtySpawnEnv({ env: { HOME: homeDir, PATH: '/usr/bin:/bin' } })
+      env.ORCA_HISTFILE = join(homeDir, 'orca-history', 'zsh_history')
+
+      const config = getRelayShellLaunchConfig('/bin/zsh', env)
+
+      expect(config.env.ZDOTDIR).toBe(join(homeDir, '.orca-relay', 'shell-ready', 'zsh'))
+      expect(config.env.ORCA_SHELL_FEATURES).toBe('history')
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'keeps a remote zsh with nothing Orca-owned on the plain login path',
+    () => {
+      const env = buildSshPtySpawnEnv({ env: { HOME: homeDir, PATH: '/usr/bin:/bin' } })
+
+      expect(getRelayShellLaunchConfig('/bin/zsh', env)).toEqual({
+        args: ['-l'],
+        env: {},
+        supportsReadyMarker: false
+      })
     }
   )
 
@@ -270,6 +309,11 @@ describe('getRelayShellLaunchConfig', () => {
 
       expect(config.env.ZDOTDIR).toBe(join(homeDir, '.orca-relay', 'shell-ready', 'zsh'))
       expect(config.env.ORCA_SHELL_FEATURES).toContain('identity')
+      // Why the negative half: identity emission alone must not arm the
+      // readiness handshake, or the delivering side waits for a marker that
+      // this shell was never told to print.
+      expect(config.env.ORCA_SHELL_FEATURES).not.toContain('ready')
+      expect(config.supportsReadyMarker).toBe(false)
     }
   )
 

--- a/src/relay/pty-shell-launch.test.ts
+++ b/src/relay/pty-shell-launch.test.ts
@@ -148,6 +148,22 @@ describe('getRelayShellLaunchConfig', () => {
     })
   })
 
+  it.skipIf(process.platform === 'win32')(
+    'keeps a remote zsh on the plain login path when only history would wrap it',
+    () => {
+      // Why: the relay .zshenv resolves the user's config dir from a ZDOTDIR
+      // Orca has already overwritten, so a remote user whose zsh config lives in
+      // a relocated ZDOTDIR loses that config the moment the pane is wrapped.
+      // A worktree HISTFILE is not worth trading a whole shell config for.
+      expect(
+        getRelayShellLaunchConfig('/bin/zsh', {
+          HOME: homeDir,
+          ORCA_HISTFILE: join(homeDir, 'orca-history', 'zsh_history')
+        })
+      ).toEqual({ args: ['-l'], env: {}, supportsReadyMarker: false })
+    }
+  )
+
   it('keeps PowerShell Core on POSIX remotes as a login shell', () => {
     expect(getRelayShellLaunchConfig('/usr/bin/pwsh', { HOME: homeDir }, 'linux')).toEqual({
       args: ['-l'],

--- a/src/relay/pty-shell-launch.ts
+++ b/src/relay/pty-shell-launch.ts
@@ -54,24 +54,6 @@ function windowsShellArgs(
   return null
 }
 
-/**
- * Overlay values the relay's own wrapper re-applies. Only these (or a startup
- * command) may pull a remote zsh off the plain login fast path.
- *
- * Why the relay gates on its own list instead of `features.length`: its .zshenv
- * uses the overlay strategy, which resolves the user's config dir from a ZDOTDIR
- * Orca has already overwritten. A remote user whose zsh config lives in a
- * relocated ZDOTDIR therefore loses that config the moment the pane is wrapped,
- * so wrapping a pane just for `history` would trade a real config for a history
- * repair. Reconciling the overlay and discovery strategies is a follow-up.
- */
-const RELAY_RESTORED_OVERLAY_ENV_KEYS = [
-  'ORCA_OPENCODE_CONFIG_DIR',
-  'ORCA_MIMOCODE_HOME',
-  'ORCA_OMP_STATUS_EXTENSION',
-  'ORCA_REMOTE_CLI_BIN_DIR'
-] as const
-
 function getWrapperRoot(env: Record<string, string>): string {
   return join(env.HOME || process.env.HOME || homedir(), RELAY_SHELL_READY_DIR)
 }
@@ -122,10 +104,9 @@ export function getRelayShellLaunchConfig(
   })
   // Why bash is always wrapped: its rcfile carries the OSC 133 command-lifecycle
   // hooks unconditionally today, and dropping them would strand agent rows on
-  // "working". zsh keeps the plain startup fast path when nothing needs it.
-  const requiresZshWrapper =
-    startupCommandRequested || RELAY_RESTORED_OVERLAY_ENV_KEYS.some((key) => Boolean(env[key]))
-  if (shellName !== 'bash' && !requiresZshWrapper) {
+  // "working". zsh keeps the plain startup fast path when nothing needs it —
+  // the same `features.length` rule the local and daemon transports use.
+  if (shellName !== 'bash' && features.length === 0) {
     return unwrapped
   }
 

--- a/src/relay/pty-shell-launch.ts
+++ b/src/relay/pty-shell-launch.ts
@@ -1,5 +1,12 @@
 import { homedir } from 'node:os'
 import { join } from 'node:path'
+import {
+  encodeShellStartupFeatures,
+  selectShellStartupFeatures,
+  SHELL_STARTUP_FEATURE_ENV,
+  type ShellStartupFeature
+} from '../main/shell-startup-features'
+import { resolveInheritedZdotdir } from '../main/zsh-wrapper-dir-ownership'
 import { ensureOverlayRestoreWrappers } from './pty-shell-overlay-wrappers'
 const RELAY_SHELL_READY_DIR = '.orca-relay/shell-ready'
 const POSIX_LOGIN_ARGS = ['-l']
@@ -7,6 +14,7 @@ const POSIX_LOGIN_ARGS = ['-l']
 export type RelayShellLaunchConfig = {
   args: string[]
   env: Record<string, string>
+  supportsReadyMarker: boolean
 }
 
 function shellBasename(shellPath: string): string {
@@ -46,38 +54,8 @@ function windowsShellArgs(
   return null
 }
 
-function hasOverlayRestoreEnv(env: Record<string, string>): boolean {
-  return Boolean(
-    env.ORCA_OPENCODE_CONFIG_DIR ||
-    env.ORCA_MIMOCODE_HOME ||
-    env.ORCA_REMOTE_CLI_BIN_DIR ||
-    env.ORCA_OMP_STATUS_EXTENSION
-  )
-}
-
 function getWrapperRoot(env: Record<string, string>): string {
   return join(env.HOME || process.env.HOME || homedir(), RELAY_SHELL_READY_DIR)
-}
-
-function normalizeOriginalZdotdirCandidate(value: string | undefined): string | null {
-  if (!value) {
-    return null
-  }
-  const normalized = value.replace(/\/+$/, '')
-  if (!normalized || normalized.endsWith('/shell-ready/zsh')) {
-    return null
-  }
-  return value
-}
-
-function resolveOriginalZdotdir(env: Record<string, string>): string {
-  return (
-    normalizeOriginalZdotdirCandidate(env.ZDOTDIR) ||
-    normalizeOriginalZdotdirCandidate(env.ORCA_ORIG_ZDOTDIR) ||
-    env.HOME ||
-    process.env.HOME ||
-    ''
-  )
 }
 
 export function getRelayShellLaunchConfig(
@@ -91,8 +69,11 @@ export function getRelayShellLaunchConfig(
   } = {}
 ): RelayShellLaunchConfig {
   const shellName = shellBasename(shellPath)
-  const emitReadyMarker = options.emitReadyMarker === true
-  const emitStartupIdentity = options.emitStartupIdentity === true
+  const unwrapped: RelayShellLaunchConfig = {
+    args: POSIX_LOGIN_ARGS,
+    env: {},
+    supportsReadyMarker: false
+  }
   if (platform === 'win32') {
     // Why: pwsh also exists on POSIX remotes; Windows-specific shell args must
     // only apply when the relay itself is running on native Windows.
@@ -101,39 +82,70 @@ export function getRelayShellLaunchConfig(
         windowsShellArgs(shellName, {
           terminalWindowsWslDistro: options.terminalWindowsWslDistro
         }) ?? [],
-      env: {}
+      env: {},
+      supportsReadyMarker: false
     }
   }
 
   if (shellName !== 'zsh' && shellName !== 'bash') {
-    return { args: POSIX_LOGIN_ARGS, env: {} }
+    return unwrapped
   }
-  // Why: preserve plain zsh startup fast path unless markers or overlay restoration are requested.
-  const requiresZshWrapper = hasOverlayRestoreEnv(env) || emitReadyMarker || emitStartupIdentity
-  if (shellName === 'zsh' && !requiresZshWrapper) {
-    return { args: POSIX_LOGIN_ARGS, env: {} }
+
+  // Why both map to the same flag: the relay only wraps for a startup command
+  // when that command's delivery asked for the readiness handshake.
+  const startupCommandRequested =
+    options.emitReadyMarker === true || options.emitStartupIdentity === true
+  const features = selectShellStartupFeatures({
+    shellPath: shellName,
+    env,
+    hasStartupCommand: startupCommandRequested,
+    waitsForShellReady: options.emitReadyMarker === true,
+    emitsStartupIdentity: options.emitStartupIdentity === true
+  })
+  // Why bash is always wrapped: its rcfile carries the OSC 133 command-lifecycle
+  // hooks unconditionally today, and dropping them would strand agent rows on
+  // "working". zsh keeps the plain startup fast path when nothing needs it.
+  if (features.length === 0 && shellName !== 'bash') {
+    return unwrapped
   }
 
   const root = getWrapperRoot(env)
-  ensureOverlayRestoreWrappers(root)
+  let wrappersReady = false
+  try {
+    wrappersReady = ensureOverlayRestoreWrappers(root)
+  } catch {
+    // Why swallow: a remote HOME can be read-only or root-owned (EACCES), and
+    // that must not stop the pane from opening at all.
+    wrappersReady = false
+  }
+  if (!wrappersReady) {
+    // Why plain login shell: ZDOTDIR pointed at an incomplete wrapper dir makes
+    // zsh skip the user's whole config. Losing Orca's features is recoverable.
+    return unwrapped
+  }
+
+  const featureEnv = {
+    [SHELL_STARTUP_FEATURE_ENV]: encodeShellStartupFeatures(features)
+  }
+  const supportsReadyMarker = features.includes('ready')
 
   if (shellName === 'zsh') {
     return {
       args: POSIX_LOGIN_ARGS,
       env: {
-        ORCA_ORIG_ZDOTDIR: resolveOriginalZdotdir(env),
+        ORCA_ORIG_ZDOTDIR: resolveInheritedZdotdir(env, process.env.HOME ?? ''),
         ZDOTDIR: join(root, 'zsh'),
-        ...(emitReadyMarker ? { ORCA_SHELL_READY_MARKER: '1' } : {}),
-        ...(emitStartupIdentity ? { ORCA_SHELL_STARTUP_IDENTITY: '1' } : {})
-      }
+        ...featureEnv
+      },
+      supportsReadyMarker
     }
   }
 
   return {
     args: ['--rcfile', join(root, 'bash', 'rcfile')],
-    env: {
-      ...(emitReadyMarker ? { ORCA_SHELL_READY_MARKER: '1' } : {}),
-      ...(emitStartupIdentity ? { ORCA_SHELL_STARTUP_IDENTITY: '1' } : {})
-    }
+    env: featureEnv,
+    supportsReadyMarker
   }
 }
+
+export type { ShellStartupFeature }

--- a/src/relay/pty-shell-launch.ts
+++ b/src/relay/pty-shell-launch.ts
@@ -54,6 +54,24 @@ function windowsShellArgs(
   return null
 }
 
+/**
+ * Overlay values the relay's own wrapper re-applies. Only these (or a startup
+ * command) may pull a remote zsh off the plain login fast path.
+ *
+ * Why the relay gates on its own list instead of `features.length`: its .zshenv
+ * uses the overlay strategy, which resolves the user's config dir from a ZDOTDIR
+ * Orca has already overwritten. A remote user whose zsh config lives in a
+ * relocated ZDOTDIR therefore loses that config the moment the pane is wrapped,
+ * so wrapping a pane just for `history` would trade a real config for a history
+ * repair. Reconciling the overlay and discovery strategies is a follow-up.
+ */
+const RELAY_RESTORED_OVERLAY_ENV_KEYS = [
+  'ORCA_OPENCODE_CONFIG_DIR',
+  'ORCA_MIMOCODE_HOME',
+  'ORCA_OMP_STATUS_EXTENSION',
+  'ORCA_REMOTE_CLI_BIN_DIR'
+] as const
+
 function getWrapperRoot(env: Record<string, string>): string {
   return join(env.HOME || process.env.HOME || homedir(), RELAY_SHELL_READY_DIR)
 }
@@ -105,7 +123,9 @@ export function getRelayShellLaunchConfig(
   // Why bash is always wrapped: its rcfile carries the OSC 133 command-lifecycle
   // hooks unconditionally today, and dropping them would strand agent rows on
   // "working". zsh keeps the plain startup fast path when nothing needs it.
-  if (features.length === 0 && shellName !== 'bash') {
+  const requiresZshWrapper =
+    startupCommandRequested || RELAY_RESTORED_OVERLAY_ENV_KEYS.some((key) => Boolean(env[key]))
+  if (shellName !== 'bash' && !requiresZshWrapper) {
     return unwrapped
   }
 

--- a/src/relay/pty-shell-overlay-wrappers.ts
+++ b/src/relay/pty-shell-overlay-wrappers.ts
@@ -1,11 +1,15 @@
-import { chmodSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { dirname, join } from 'node:path'
+import { readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
 import { getPosixOmpShellWrapper } from '../main/pty/omp-shell-wrapper'
 import {
+  BASH_FEATURE_CHANNEL_BLOCK,
   BASH_PROMPT_COMMAND_COMPOSITION_BLOCK,
   SHELL_STARTUP_IDENTITY_MARKER_BLOCK,
-  ZSH_HISTFILE_RESTORE_BLOCK
+  ZSH_HISTFILE_RESTORE_BLOCK,
+  ZSH_WRAPPER_DIR_MARKER_CONTENT,
+  ZSH_WRAPPER_DIR_MARKER_FILE
 } from '../main/shell-templates'
+import { writeShellWrapperFiles } from '../main/shell-wrapper-file-writer'
 import {
   buildZshStartupWrapperFiles,
   type ZshStartupWrapperSpec
@@ -30,26 +34,32 @@ function getRelayZshWrapperSpec(zshDir: string): ZshStartupWrapperSpec {
     readyMarkerEscaped: SHELL_READY_MARKER_ESCAPED,
     osc133CommandMarkers: false,
     skipUserZshrcWhenHomeIsWrapperDir: false,
-    interactiveRestoreComment:
+    overlayRestoreComment:
       '# Why: remote startup files can re-export user defaults after relay spawn.',
-    loginRestoreComment: '# Why: .zlogin is the final zsh login startup file before the prompt.',
     restores: {
       agentTeamsPath: false,
       remoteCliBinDir: true,
       codexHome: false,
       codexLaunchPreflight: false
-    },
-    readyMarkerOrder: 'after-zdotdir-restore'
+    }
   }
 }
 
-export function ensureOverlayRestoreWrappers(root: string): void {
+/** True when every overlay wrapper file is present and non-empty afterwards. */
+export function ensureOverlayRestoreWrappers(root: string): boolean {
   const zshDir = join(root, 'zsh')
   const bashDir = join(root, 'bash')
 
   const zsh = buildZshStartupWrapperFiles(getRelayZshWrapperSpec(zshDir))
   const bashRc = `# Orca relay bash overlay wrapper
+${BASH_FEATURE_CHANNEL_BLOCK}
 ${SHELL_STARTUP_IDENTITY_MARKER_BLOCK}
+# Why a plain variable: the channel is consumed and destroyed in these first
+# lines, so nothing this shell later spawns can see or inherit the selection.
+__orca_ready_marker=""
+__orca_has_feature ready && __orca_ready_marker=1
+unset _orca_shell_features
+unset -f __orca_has_feature
 [[ -f /etc/profile ]] && source /etc/profile
 if [[ -f "$HOME/.bash_profile" ]]; then
   source "$HOME/.bash_profile"
@@ -124,7 +134,7 @@ ${BASH_PROMPT_COMMAND_COMPOSITION_BLOCK}
 __orca_prepend_prompt_command "__orca_osc133_precmd"
 # Why: SSH startup commands are renderer-delivered; emit the same internal
 # readiness marker as local shells only when that delivery mode asks for it.
-if [[ "\${ORCA_SHELL_READY_MARKER:-0}" == "1" ]]; then
+if [[ -n "$__orca_ready_marker" ]]; then
   __orca_prompt_mark() {
     printf "${SHELL_READY_MARKER_ESCAPED}"
   }
@@ -157,23 +167,32 @@ unset __orca_initializing_wrapper
     [join(zshDir, '.zprofile'), zsh.zprofile],
     [join(zshDir, '.zshrc'), zsh.zshrc],
     [join(zshDir, '.zlogin'), zsh.zlogin],
+    [join(zshDir, ZSH_WRAPPER_DIR_MARKER_FILE), ZSH_WRAPPER_DIR_MARKER_CONTENT],
     [join(bashDir, 'rcfile'), bashRc]
   ] as const
 
-  for (const [path, content] of files) {
-    mkdirSync(dirname(path), { recursive: true })
-    let existing: string | null = null
-    try {
-      existing = readFileSync(path, 'utf8')
-    } catch {
-      existing = null
-    }
-    // Why: relay wrapper files persist under ~/.orca-relay across app
-    // upgrades. Existence alone is not enough; stale wrappers would miss
-    // later fixes such as preserving post-.zshenv ZDOTDIR.
-    if (existing !== content) {
-      writeFileSync(path, content, 'utf8')
-    }
-    chmodSync(path, 0o644)
+  // Why: relay wrapper files persist under ~/.orca-relay across app upgrades.
+  // Existence alone is not enough; stale wrappers would miss later fixes such
+  // as preserving post-.zshenv ZDOTDIR.
+  const stale = files.filter(([path, content]) => readFileOrNull(path) !== content)
+  if (stale.length > 0 && !writeShellWrapperFiles(stale, '[relay/shell-overlay]')) {
+    return false
+  }
+  return files.every(([path]) => isNonEmptyFile(path))
+}
+
+function readFileOrNull(path: string): string | null {
+  try {
+    return readFileSync(path, 'utf8')
+  } catch {
+    return null
+  }
+}
+
+function isNonEmptyFile(path: string): boolean {
+  try {
+    return statSync(path).size > 0
+  } catch {
+    return false
   }
 }

--- a/src/relay/terminal-history.test.ts
+++ b/src/relay/terminal-history.test.ts
@@ -37,6 +37,26 @@ describe('relay shell history', () => {
     expect(custom.HISTFILE).toBe('/custom/history')
   })
 
+  it.each([
+    ['relay', join(historyDir, `${hashWorktreeId('relay-test::/remote/other')}-zsh_history`)],
+    [
+      'desktop',
+      join(
+        '/fake/userData/terminal-history',
+        hashWorktreeId('relay-test::/remote/other'),
+        'zsh_history'
+      )
+    ]
+  ])('replaces a %s HISTFILE inherited from a parent Orca', (_kind, inherited) => {
+    // HISTFILE is exported, so a relay (or the client that spawned it) started
+    // from an Orca pane would otherwise scope every remote pane to that one
+    // worktree's history file.
+    const env: Record<string, string> = { HISTFILE: inherited }
+
+    expect(injectRelayHistoryEnv(env, worktreeId, '/usr/bin/zsh')).toBe(historyDir)
+    expect(env.HISTFILE).toBe(join(historyDir, `${historyPrefix}-zsh_history`))
+  })
+
   it('does not scope unsupported shells and cleans up idempotently', () => {
     const env: Record<string, string> = {}
     expect(injectRelayHistoryEnv(env, worktreeId, '/bin/fish')).toBeNull()

--- a/src/relay/terminal-history.ts
+++ b/src/relay/terminal-history.ts
@@ -11,6 +11,7 @@ import { homedir } from 'node:os'
 import { basename, join } from 'node:path'
 import { toLinuxPath } from '../shared/wsl-paths'
 import { hashWorktreeId } from '../main/terminal-history-id'
+import { dropInheritedOrcaHistFile } from '../main/worktree-history-file-path'
 import {
   deleteFishHistoryFile,
   dropInheritedOrcaFishHistory,
@@ -41,6 +42,10 @@ export function injectRelayHistoryEnv(
   // would otherwise survive every early return below and let the remote wrapper
   // re-export another worktree's history path.
   delete env.ORCA_HISTFILE
+  // Why: HISTFILE stays exported, so a relay (or a client) launched from an Orca
+  // pane carries the launching worktree's path into this one; honouring it below
+  // would scope every pane to that worktree's history file.
+  dropInheritedOrcaHistFile(env)
   if (env.HISTFILE) {
     return null
   }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 36 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1442 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​197 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1245 |
| Prod | 47 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1765 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1181 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​584 |

<!-- /orca-pr-loc -->

> #15245 (`nwparker/zsh-wrapper-shared-builder`) has merged. This branch is rebased onto `main` and its base **is** `main`, so the diff below is only this change.
>
> **This replaces #15197**, which should be closed in favour of this one — its approach was abandoned rather than iterated on; see "Why not #15197" below.

## ELI5

Every Orca worktree is supposed to get its own shell history. On macOS the system's `/etc/zshrc` overwrites `HISTFILE` on the way to your prompt, and Orca's repair for that only ran in panes that were already wrapped for some *other* reason. An ordinary pane was never wrapped, so it never got the repair — your per-worktree history quietly went nowhere.

To wrap those panes, Orca needs a way to tell the shell "turn on exactly these things". This PR makes that one variable carrying a **list of things to turn on**, which the wrapper reads and then **deletes** before your own config runs. Nothing you launch from that pane can see it, so it can't leak into anything else.

## What Changed

**One channel, positive, consumed and destroyed**

- New `ORCA_SHELL_FEATURES`: a comma-separated allowlist from a closed token set — `history`, `markers`, `ready`, `identity`, `overlay`. Absent = no features (fail-safe). There is **no** negative/suppression variable anywhere; `ORCA_SHELL_READY_MARKER` and `ORCA_SHELL_STARTUP_IDENTITY` are gone, including the `: '0'` pins in `src/relay/pty-handler.ts`.
- The wrapper `.zshenv` consumes it in its **first executable lines**, before the user's `.zshenv` is sourced:
  ```zsh
  typeset -ga _orca_shell_features
  _orca_shell_features=(${(s:,:)${ORCA_SHELL_FEATURES:-}})
  builtin unset ORCA_SHELL_FEATURES
  __orca_has_feature() { (( ${_orca_shell_features[(Ie)$1]} )) }
  ```
  `_orca_shell_features` is a plain, **non-exported** shell variable: it survives `.zshenv -> .zprofile -> .zshrc -> .zlogin` in this process and physically cannot reach a child. The bash rcfile does the equivalent and destroys the channel in its first six lines. fish needs no variable — its selection is baked into the per-pane `--init-command`, so the `if test "$ORCA_SHELL_READY_MARKER" = 1` gate is gone from the init text.
- `ORCA_HISTFILE` is consume-and-destroy too: the epilogue does `HISTFILE=$ORCA_HISTFILE; builtin unset ORCA_HISTFILE`. That removes the **root cause** of #11146 rather than patching it. The existing TypeScript `delete env.ORCA_HISTFILE` calls stay as belt-and-braces but are no longer load-bearing. `HISTFILE` itself stays exported.
- Because `HISTFILE` stays exported, a wrapped pane now hands the worktree history path to everything it launches — including another Orca. `src/main/worktree-history-file-path.ts` drops an inherited `HISTFILE` that Orca itself minted (desktop, desktop-WSL and relay path shapes) before every check-before-set, on the desktop, daemon and relay injection paths and on both history-disabled branches, so a nested Orca cannot silently scope all of its panes to the launching worktree's history file. A user-supplied `HISTFILE` still wins. Same fix shape as #15195 for `fish_history`; see follow-up #5.

**One epilogue**

All Orca-owned, order-sensitive work moved into a single `__orca_shell_epilogue` defined in the wrapper `.zshenv` and invoked exactly once — from the end of `.zshrc` for a non-login shell, from the end of `.zlogin` for a login shell — guarded by a `(( $+_orca_epilogue_done ))` once-flag. Inside it, each feature is an independent guard: `overlay` (CODEX_HOME / OPENCODE_CONFIG_DIR / MIMOCODE_HOME / omp wrapper / agent-teams PATH shim / remote-CLI bin dir), `markers` (OSC 133, still *prepended* to `precmd_functions`/`preexec_functions`), `ready` (the `zle-line-init` OSC 777 widget with its existing prior-widget chaining). `identity` stays early in `.zshenv`, gated on the snapshotted array. The epilogue ends by restoring the user's real `ZDOTDIR`, unsetting `_orca_shell_features`, and `unfunction`-ing itself.

Its **first statement is `emulate -L zsh`**. The epilogue runs after the user's own config, so it would otherwise inherit whatever shell options that config left set — and a single consolidated function means the first failure inside it skips everything after it. Two real options broke it (both measured on zsh 5.9, see "Review follow-ups"): `setopt no_unset` made `precmd_functions=(… ${precmd_functions[@]})` a fatal *parameter not set*, and `setopt ksh_arrays` (also implied by `emulate sh`/`emulate ksh`) made the 1-based `[(Ie)…]` feature subscript return `0` for whichever feature is listed first. `emulate -L zsh` restores zsh-native option state for the body and `LOCAL_OPTIONS` puts the user's options back on return.

The `/etc/zshrc` HISTFILE repair is **not** behind a feature guard. It undoes damage the wrapper's own `ZDOTDIR` caused, so it must also run for a shell that re-enters the wrapper after the allowlist has been consumed — e.g. an interactive zsh started from a non-interactive one, which ran `.zshenv` (exporting Orca's `ZDOTDIR`) but never the epilogue that restores it. Its `elif` fires only when `HISTFILE` is byte-identical to `$ZDOTDIR/.zsh_history` with `$ZDOTDIR` being Orca's own wrapper dir, so that branch never touches a `HISTFILE` the user set deliberately. The `if` branch is not so narrow, and the earlier claim that "a `HISTFILE` the user set deliberately is never touched" was only true of the `elif`: whenever Orca injected an `ORCA_HISTFILE` it assigns it unconditionally, which overrides a `HISTFILE` the user set **inside their own `.zshrc`**. A `HISTFILE` already present in the spawn env cannot collide with it — `injectHistoryEnv`'s check-before-set means Orca never mints `ORCA_HISTFILE` in that case. For every pane Orca actually launches this is equivalent to the guarded form (`features.length > 0` ⟺ `history ∈ features` for zsh).

**One launch config**

`getShellReadyLaunchConfig` / `getMarkerlessShellLaunchConfig` collapse into `getShellLaunchConfig(shellPath, features)` (local and daemon) plus `getRelayShellLaunchConfig`. Selection is `selectShellStartupFeatures(...)` — a pure function of spawn env + launch intent, in `src/main/shell-startup-features.ts`:

| token | selected when |
| --- | --- |
| `overlay` | any Orca overlay dir var is in the spawn env |
| `history` | **zsh only**, and either this spawn injected `ORCA_HISTFILE`, or the pane was already wrapped |
| `markers` | the pane was already wrapped before this change (overlay, or a startup command) |
| `ready` | the startup-command delivery waits for the readiness marker |
| `identity` | Orca needs the shell PID announced at startup |

Empty token set ⇒ **do not wrap at all and do not set the variable**. `history` is zsh-only because the unguarded HISTFILE assignment lives in the *system zshrc*; bash has no equivalent, and wrapping bash via `--rcfile` for history alone would swap its login startup-file chain for Orca's approximation of one.

**Fail-closed generation**

`writeShellWrapperFiles` writes each file to a temp name and renames, and generation returns a boolean. `ZDOTDIR` is set only when that is true **and** every required path exists non-empty. Otherwise the launch returns plain login zsh (`['-l']`, no env) so the user's real config still loads. Previously a failed write still pointed `ZDOTDIR` at an empty dir and the user silently lost their entire zsh config, on every pane, until it was noticed. The relay's `ensureOverlayRestoreWrappers` (which can throw `EACCES` straight through `getRelayShellLaunchConfig` on a root-owned remote `$HOME`) is wrapped in try/catch with the same fallback.

**Stacked-ZDOTDIR guard**

Orca recognised only its own wrapper path shape (`case "${ORCA_ORIG_ZDOTDIR}" in ""|*/shell-ready/zsh)`). Launched from any *other* terminal that had already hijacked `ZDOTDIR`, Orca captured that as "the user's config dir" and re-sourced it. Narrow today; far more panes get wrapped after this change, so it is widened here rather than left as exposure. Ownership is now established **positively**: a stamped `.orca-shell-wrapper` marker file Orca writes into its wrapper dirs, or Orca's own `*/shell-ready/zsh` shape for wrappers written by older builds. Additionally, an *inherited* `ZDOTDIR` containing no readable `.zshenv`/`.zshrc`/`.zprofile`/`.zlogin` is ignored. No other vendor is detected by name — that can never be complete. Both the shell side (`__orca_resolve_user_config_dir` / `__orca_resolve_inherited_config_dir`) and the Node side (`src/main/zsh-wrapper-dir-ownership.ts`) apply it.

## Why

### The bug

Orca gives each workspace its own zsh history by injecting `HISTFILE` into the spawn env. On macOS, `/etc/zshrc` contains an unguarded

```zsh
HISTFILE=${ZDOTDIR:-$HOME}/.zsh_history
```

that runs *before* the user's rc and before any wrapper file Orca controls, so the injected value is already gone by the first prompt. Orca has a repair block for this, but it only ran when the pane was already wrapped for some other reason (an overlay env var, or a startup command). A **plain** pane was never wrapped, so it never got the repair.

Confirmed directly:

```
$ HISTFILE=/tmp/x ORCA_HISTFILE=/tmp/x HOME=/tmp/fake zsh -li -c 'echo $HISTFILE'
/tmp/fake/.zsh_history
```

### Why not #15197

#15197 introduced a **new regression in each of three review rounds**, twice by the same mechanism:

1. It gated on `env.ORCA_HISTFILE` but nothing scrubbed an **inherited** one, so a pane opened with history scoping *off* wrote into the launching worktree's history — re-opening #11146.
2. It suppressed OSC 133 with `ORCA_SHELL_COMMAND_MARKERS=0`. That variable lives in the pane's PTY env and is inherited by every child, so an Orca launched from such a pane had markers disabled for **all its own agent panes**, leaving agent rows stuck on "working".

Both are the same defect class: a **negative, exported switch used as a cross-process control channel**. The fix is not to add another scrub; it is to make that class unrepresentable. Hence: one positive allowlist, no suppression value at any level, and a variable that stops existing before anything can inherit it.

## Linked Issue

Fixes #11044

Also removes the root cause of #11146 (an inherited `ORCA_HISTFILE` reaching a pane it was not meant for) rather than patching the symptom.

Also closes the `HISTFILE` half of the same inheritance class (a wrapped pane exporting its worktree history path to a nested Orca), the sibling of the `fish_history` fix in #15195.

## Visual Proof

`N/A` — there is no UI surface here. The change is which env/args a PTY is spawned with and what the generated shell wrapper files contain; the observable effect is *where a history file is written*, which is a filesystem path, not pixels. The behaviour is covered by real-shell tests below.

## Testing

Platform: **macOS 15 (Darwin 25.3.0), arm64, zsh 5.9 with the system `/etc/zshrc` present.** The clobber-premised assertions are probed, not hardcoded to a platform (`systemZshrcClobbersHistfile` launches a real login zsh with an injected `HISTFILE` and checks whether it survives). On this machine the probe returned **true**, so both clobber-premised assertions in `zsh-scoped-histfile.live-shell.test.ts` ran for real and were meaningful. On a stock Ubuntu zsh with no such assignment they skip rather than assert a tautology.

### Leak proof

`src/main/shell-startup-feature-channel.test.ts`:

- `selectShellStartupFeatures` given `env.ORCA_SHELL_FEATURES = 'overlay,markers,ready,identity,history'` and nothing else returns `[]` — an inherited value is not an input and cannot **enable** anything.
- The same function given `ORCA_SHELL_FEATURES: ''` plus an injected `ORCA_HISTFILE` still returns `['history']` — there is no value of the variable that **disables** anything.
- `getShellLaunchConfig('/bin/zsh', ['history'])` with a stale `process.env.ORCA_SHELL_FEATURES = 'overlay,markers,ready,identity'` publishes exactly `history`.
- **Real shell:** a history-only pane launched through the real launch config runs `print ORCA_SHELL_FEATURES; zsh -c 'printenv ORCA_SHELL_FEATURES'` and the variable is unset in **both** the launched shell and the grandchild.
- `src/relay/pty-handler-revive.test.ts` seeds `process.env.ORCA_SHELL_FEATURES = 'ready,identity,markers,overlay'` before a revive and asserts the spawned pane gets neither `ready` nor `identity` — the case the deleted `: '0'` pins used to cover.
- `src/main/zsh-scoped-histfile.live-shell.test.ts` asserts `ORCA_HISTFILE` is empty in the launched shell after the epilogue consumed it.

### Behaviour parity

`src/main/shell-startup-feature-channel.test.ts` builds a temp `$HOME` whose `.zshenv`/`.zprofile`/`.zshrc`/`.zlogin` each announce that they ran, then launches the same command through (a) the real history-only launch config and (b) a plain `zsh -l`, and compares the full output: startup-file order, `precmd_functions`, `preexec_functions`, `widgets[zle-line-init]`. They are identical, `precmd_functions` is empty, and the output contains **no** OSC 133. The one documented carried-over difference — already true of every pane Orca wrapped before this change — is that a wrapped shell ends with `ZDOTDIR` explicitly set to the user's config dir, which is the value zsh itself defaults to when it is unset; the test asserts that explicitly rather than hiding it.

## Review follow-ups

Defects found in release-readiness and adversarial review, each verified against a real zsh 5.9 on macOS before and after the fix.

**1 — the consolidated epilogue was not option-proof (P1).** With `setopt no_unset` in the user's `.zshrc`:

```
before: __orca_shell_epilogue:82: precmd_functions[@]: parameter not set
        ZDOTDIR=/tmp/orcachk/wrap/zsh        widget=none
after:  ZDOTDIR=/tmp/orcachk/home            widget=user:__orca_prompt_mark
```

Because everything now lives in one function, that error returned from the epilogue and skipped the `ready` widget **and** the final `ZDOTDIR` restore — before this PR the same error only truncated the wrapper `.zshrc`, and `.zlogin` still did both. With `setopt ksh_arrays` the feature lookup silently dropped the first token (`overlay` for an agent pane, so `OPENCODE_CONFIG_DIR`/`CODEX_HOME` were not restored). `emulate -L zsh` as the epilogue's first line fixes both, plus `sh_word_split` and `emulate sh` for non-login shells.

**2 — the relay wrapping gate was built on a false premise, and has been removed (P0, self-inflicted then reverted).** An earlier round added a relay-only wrapping list (`ORCA_OPENCODE_CONFIG_DIR`, `ORCA_MIMOCODE_HOME`, `ORCA_OMP_STATUS_EXTENSION`, `ORCA_REMOTE_CLI_BIN_DIR`) to avoid "newly wrapping" remote zsh panes, on the theory that the relay's `overlay-user-zdotdir` `.zshenv` would lose a relocated user `ZDOTDIR`. The premise about *which panes were newly wrapped* was wrong:

- `origin/main`'s `hasOverlayRestoreEnv` already included `ORCA_REMOTE_CLI_BIN_DIR` (`src/relay/pty-shell-launch.ts:53`).
- `src/main/providers/ssh-pty-spawn-env.ts` sets `ORCA_REMOTE_CLI_BIN_DIR` on **every** SSH pane whenever the CLI bridge exists, and `ssh-relay-session.ts` populates `remoteCliBridgeEnv` for every relay session whose host reports its platform.

So ordinary remote zsh panes were **already wrapped on `main`**, the relocated-`ZDOTDIR` defect is pre-existing and untouched by this PR, and the gate was a no-op for them. Where it was not a no-op it was strictly worse: on a host too old to report its platform, `remoteCliBridgeEnv` is `null`, no overlay key is set, and the gate kept that pane unwrapped — silently losing its worktree history, which `features.length > 0` repairs. The gate is gone; all three transports now share one rule (`features.length === 0` ⇒ plain `-l`, bash excepted). The test that pinned an env with no `ORCA_REMOTE_CLI_BIN_DIR` — a configuration production never produces — is replaced by three tests built from the real `buildSshPtySpawnEnv` output.

**3 — the HISTFILE repair lost its self-healing property (P2).** Putting the `/etc/zshrc` clobber repair behind `if __orca_has_feature history` meant a zsh that re-enters the wrapper with Orca's `ZDOTDIR` inherited but the (deliberately destroyed) allowlist absent kept `HISTFILE=<orca-wrapper-dir>/.zsh_history` — silently reproducing #11044. The repair is now emitted ungated, as it was on `main`.

**4 — the shell-fallback path leaked the previous attempt's launch env (P2).** `spawnShellWithFallback` merged the fallback's launch env into the same object without clearing the primary's, and an unwrapped fallback (`/bin/bash` with no features) contributes `{}`. A bash pane therefore inherited `ORCA_SHELL_FEATURES=history` and `ZDOTDIR=<userData>/shell-ready/zsh`, which nothing in that pane consumes — so typing `zsh` there loaded Orca's wrapper via the stale `ZDOTDIR` and enabled a feature Orca never selected for it. The keys to scrub are now tracked **per attempt**: the first fix computed them once from the primary, so a wrapped first fallback leaked its own `ZDOTDIR`/`ORCA_SHELL_FEATURES` into the second. The key list is also passed in from the launch config the provider already computed, instead of re-invoking `getShellReadyConfig(shellPath)` — for zsh/bash that call re-runs `ensureShellReadyWrappers()` and rewrites six files purely to read back key names.

**5 — the PR widened the identical leak on `HISTFILE` that it closes on `ORCA_HISTFILE` (P1).** `HISTFILE` stays exported by design. A newly wrapped plain zsh pane now ends startup with the worktree history path exported to every child; before this PR `/etc/zshrc` had already overwritten it with `$HOME/.zsh_history`, so the worktree value never escaped the pane. Measured: a child sees `HISTFILE=[/tmp/leak/wtA/.zsh_history]` on this branch vs `[/tmp/base1/home/.zsh_history]` pre-PR. The next Orca launched from that pane honours it — every pane env starts from `stripInheritedBuildModeEnv(process.env)`, and `injectHistoryEnv`'s check-before-set (`src/main/terminal-history.ts`) early-returns on any `HISTFILE`, so **every** pane of the nested app, in every worktree, appended into worktree A's history file. Same bug class as the inherited `fish_history` fixed in #15195 (`3d29a2604ed`), and the same shape of fix: `src/main/worktree-history-file-path.ts` recognises a path Orca itself minted (desktop `terminal-history/<hash>/<file>`, desktop-WSL `terminal-history-wsl/<distro>/<hash>/<file>`, relay `.orca-remote/terminal-history/<hash>-<file>`) and drops only that, before the check-before-set. A `HISTFILE` the user set themselves still wins. Applied on the desktop injection path, the desktop history-**disabled** branch, the daemon subprocess spawn, `injectRelayHistoryEnv`, and the relay's `buildSpawnEnv` (covering relay spawn, revive, and isolation-off), exactly as the fish fix did.

**6 — a login zsh lost the whole epilogue under `emulate sh` (P2, regression vs `main`).** zsh's `sourcehome()` ignores `ZDOTDIR` once the shell is in `EMULATE_SH`/`EMULATE_KSH`, so a user `.zshrc` ending in `emulate sh` makes a **login** shell read `$HOME/.zlogin` instead of the wrapper's — the epilogue never ran. Measured on zsh 5.9: `main` still registered the OSC 133 hooks (its `.zshrc` carried them inline), this branch registered nothing, the ready widget never registered (so startup-command delivery waited out the pre-ready timeout), and `HISTFILE` was left at `<wrapper dir>/.zsh_history` — #11044 itself. The wrapper `.zshrc` now runs the epilogue when `[[ ! -o login || "$(emulate 2>/dev/null)" != zsh ]]`. Ordering is preserved for every normal login shell (the `.zlogin` invocation still runs after the user's own `.zlogin`); only in the emulation case does the epilogue run earlier, where the user's `.zlogin` can undo its overlay restores — which beats not running it at all. An old zsh with no query form of `emulate` prints nothing, fails the comparison and runs the epilogue from `.zshrc` too; the once-flag makes the later `.zlogin` call a no-op.

**7 — the version-mismatch mitigation covered one cross-file call out of four (P2, self-inflicted).** The `(( ${+functions[__orca_shell_epilogue]} )) && …` guard was added so a wrapper dir written by two concurrently installed builds degrades quietly. It did not: `.zprofile`, `.zshrc` and `.zlogin` each **begin** with `__orca_resolve_user_config_dir "${ORCA_ORIG_ZDOTDIR:-$HOME}"`, a function only `.zshenv` defined. Measured on zsh 5.9 / macOS 15 with this branch's three files beside an older `.zshenv`:

```
before: <wrap>/.zprofile:2: command not found: __orca_resolve_user_config_dir
        <wrap>/.zshrc:2:    command not found: __orca_resolve_user_config_dir
        <wrap>/.zlogin:2:   command not found: __orca_resolve_user_config_dir
        (the user's own .zprofile/.zshrc/.zlogin never ran)
after:  RAN .zprofile / RAN .zshrc / RAN .zlogin, no diagnostics
```

So the cost was not "the epilogue's features": `$REPLY` was left empty, every `-f "$_orca_home/<file>"` check failed, and the user's **entire zsh config** was skipped — while three errors printed into the pane. Fix: `ZSH_USER_CONFIG_DIR_RESOLVER_BLOCK` is now emitted at the top of all four generated files (the stricter inherited-value resolver stays in `.zshenv`, which is the only file that reads an inherited value). +7 lines per file × 3 files × 3 transports in the byte snapshots; `.zshenv` is byte-identical. The epilogue is now the only cross-file dependency left, and it is the one thing the existing guard actually covers. New live-shell test: `src/main/zsh-wrapper-version-mismatch.live-shell.test.ts`.

**8 — stale assertions on variables this PR deleted (CI red).** `ORCA_SHELL_READY_MARKER` / `ORCA_SHELL_STARTUP_IDENTITY` are gone from production, but seven test sites still named them; one (`src/main/ipc/pty-hidden-at-spawn-mark.test.ts`, "falls back when SHELL points to a non-executable binary") asserted `ORCA_SHELL_READY_MARKER: '0'` inside an `objectContaining` on the spawn env and failed in CI. Repo-wide sweep and disposition:

| site | disposition |
| --- | --- |
| `src/main/ipc/pty-hidden-at-spawn-mark.test.ts:415` | → `ORCA_SHELL_FEATURES: 'overlay,history,markers'` (the real selection for that pane: overlay env, worktree history, no startup command ⇒ no `ready`) |
| `src/main/daemon/pty-subprocess.test.ts` (×6) | scrub + `toBeUndefined()` retargeted to `ORCA_SHELL_FEATURES`; the old assertion had become vacuous |
| `src/main/daemon/bash-prompt-command-composition.test.ts:32` | → `ORCA_SHELL_FEATURES: 'ready'` (live bash, same intent) |
| `src/main/providers/local-pty-shell-ready-wrapper-generation.test.ts:54` | → `ORCA_SHELL_FEATURES: 'ready'` (live bash, same intent) |
| `src/main/pty/codex-preflight-profile-path-rewrite.test.ts:75-76` | deleted — an absent `ORCA_SHELL_FEATURES` already means no markers, so both keys were dead |
| `src/main/providers/__tests__/shell-ready-framework/README.md:42` | → `getShellLaunchConfig()` + `selectShellStartupFeatures()` |
| `src/main/shell-startup-features.ts:6-7` | **kept** — prose naming the old switches to explain why the new one is a positive allowlist |

No harness scrub was needed for hermeticity: production now `delete`s `ORCA_SHELL_FEATURES` and `ORCA_HISTFILE` from the spawn env on every path before `selectShellStartupFeatures` runs, so a developer's own exported values cannot reach the selection. That is what made the old `ORCA_SHELL_READY_MARKER` pins fragile (they read straight off `process.env`) and is structurally gone.

**9 — the `HISTFILE` scrub matched a shape with no Orca token (nit, tightened + justified).** `isOrcaMintedHistFile` now requires a leading `/`, so a path relative to the user's cwd with the same tail is theirs. Beyond that the shape is left as-is, deliberately: two of the three forms already carry an Orca token (`.orca-remote`, `terminal-history-wsl`), the third needs an absolute path whose last two segments are a 16-char lowercase-hex directory directly under `terminal-history` holding a file named exactly `zsh_history`/`bash_history`, and the blast radius of a false positive is one spawn's env — the pane gets Orca's own worktree history (isolation on) or the shell's default (isolation off), with nothing on disk read, written, moved or deleted. Resolving a real root is not available to the predicate: it runs in the desktop (Electron `userData`), the daemon subprocess (no Electron), and the relay on a remote host.

**10 — the config-dir resolver collided on zsh's shared `REPLY` global (P0, regression vs `main`).** `__orca_resolve_user_config_dir` used `REPLY` as its out-parameter, and this PR emits that block at the top of all four wrapper files, on every zsh pane. `REPLY` is zsh's conventional shared scratch global, so a user config is entitled to constrain it. Reproduced on zsh 5.9 / macOS, all three transports, plain history-only pane:

| user `.zshrc` ends in | result before | result now |
| --- | --- | --- |
| `typeset -r REPLY` | `__orca_resolve_user_config_dir:1: read-only variable: REPLY` printed into the pane; the assignment is fatal, so the wrapper file aborts at its first executable line, the epilogue never runs, `ZDOTDIR` stays at `<wrapper>/zsh`, `HISTFILE=<wrapper>/zsh/.zsh_history`, `ORCA_HISTFILE` leaks to every child | `HISTFILE=<worktree>/zsh_history`, `ZDOTDIR=$HOME`, `ORCA_HISTFILE` consumed, nothing printed |
| `typeset -i REPLY` | every resolved path becomes `0`; same wrong `HISTFILE`, ZDOTDIR exported empty, epilogue skipped | same as above |

`main` never touched `REPLY` (its snapshots use `_orca_home` only), so this is a regression this PR introduced and then widened to 100% of zsh panes. The out-parameter is now `_orca_resolved_config_dir`, assigned with `typeset -g` — a plain assignment would have traded the `REPLY` collision for a `warn_create_global` warning on every call, since `.zshrc`/`.zlogin` call the resolver *after* the user's own config.

**The class, not the instance.** Every shell global the generated wrapper writes was enumerated across all four zsh files, the bash rcfile and the fish init command, for all three transports. `REPLY` was the only name outside Orca's namespace that was not a deliberate contract. A new rule test (`shell-wrapper-generated-file-snapshot.test.ts`) now scans every generated file and fails on any assignment or `export` whose name is neither `_orca_*`/`__orca_*`/`ORCA_*` nor one of nine documented contract names (`HISTFILE`, `ZDOTDIR`, `PATH`, `PROMPT_COMMAND`, `precmd_functions`, `preexec_functions`, `CODEX_HOME`, `OPENCODE_CONFIG_DIR`, `MIMOCODE_HOME`). Reverting the rename makes it fail with `expected { 'zsh/.zshenv': [ 'REPLY' ] } to deeply equal { 'zsh/.zshenv': [] }`.

**11 — the daemon and the relay dropped an inherited `HISTFILE` but never an inherited `ORCA_HISTFILE` (P1).** Follow-up #5 added `dropInheritedOrcaHistFile` on five paths; `ORCA_HISTFILE` — which is *also* exported into every pane, and which the bash wrapper never consumes — was only cleared where `injectHistoryEnv`/`injectRelayHistoryEnv` ran. `createPtySubprocess` builds `{...stripInheritedBuildModeEnv(process.env), ...opts.env}` and deleted neither; the relay's `buildSpawnEnv` deleted it only via `injectRelayHistoryEnv`, i.e. never on the isolation-off or revive paths. This PR is what makes that bite: `selectShellStartupFeatures` selects `history` on `Boolean(env.ORCA_HISTFILE)`, so an inherited value now **wraps a pane the client scoped nothing for** and is then re-installed by the epilogue (`HISTFILE="$ORCA_HISTFILE"`). On `main` the same inherited value was inert because the pane was not wrapped. Both paths now mirror the desktop, which deletes it on both of its branches.

**12 — `emulate sh` in a user `.zshenv` or `.zprofile` skipped the wrapper entirely (P1, regression vs `main`) — the pane now degrades to unwrapped.** Follow-up #6 handled emulation entered from the user's `.zshrc`. Entered *earlier*, it is worse: zsh's `sourcehome()` ignores `ZDOTDIR` from that point on, so **no** later wrapper file is read — not `.zprofile`, not `.zshrc`, not `.zlogin` — and the epilogue runs zero times, while the user's own `$HOME` startup files load normally. Reproduced on zsh 5.9, plain pane, `features=history`: `ZDOTDIR=[<wrapper>/zsh]`, `HISTFILE=[<wrapper>/zsh/.zsh_history]`, `ORCA_HISTFILE` still exported, epilogue never ran — the shell looks completely normal while history goes somewhere the user will never find and `~/.zsh_history` stops growing. On `main` that pane was unwrapped and correctly got `HISTFILE=$HOME/.zsh_history`, so widening wrapping turned "isolation off" into "history written somewhere invisible".

Nothing can repair `HISTFILE` from there — `/etc/zshrc` assigns it *after* both `.zshenv` and `.zprofile`, so running the epilogue early (the `.zshrc` fix from #6) repairs nothing. The wrapper therefore does the only other thing worth doing: after sourcing the user's file it checks `case "$(emulate 2>/dev/null)" in sh|ksh)`, and if so restores `ZDOTDIR` to the user's own config dir, consumes `ORCA_HISTFILE`, drops its own variables and functions, and `return`s. The pane is then **exactly the unwrapped pane it was before this PR** rather than something worse. Measured after the fix, both trigger files: `HISTFILE` equal to an unwrapped run's, `ZDOTDIR=$HOME`, `ORCA_HISTFILE` unset.

Two details worth stating. The match is positive (`sh|ksh`), not `!= zsh`, so a zsh too old for the query form of `emulate` — which prints nothing — does not unwrap every pane. And the probe is gated on "did this file actually source a user file", because `$(emulate)` forks and every zsh pane now pays for it; that gate loses no coverage, since a wrapper file is itself reached *through* `ZDOTDIR`, so anything that had already entered emulation (a system `/etc/zshenv` or `/etc/zprofile`) would have hidden that very file too. Measured: with no user `.zshenv`/`.zprofile`, wrapped startup is unchanged (≈10.5 ms/run before and after, 30 runs, zsh 5.9 / macOS); with one, it costs a single extra fork.

**13 — `warn_create_global` noise above every command (nit, fixed).** `__orca_in_command=1` in `__orca_osc133_preexec` creates a global inside a function, which `setopt warn_create_global` reports on every command line. Not a regression (identical on `main`, and `markers` is gated on `wrappedBefore` so newly wrapped plain panes never had it), but `typeset -g` removes it, and the same reasoning is why the new resolver out-parameter uses `typeset -g` too.

### Every new test fails without its fix

Verified by reverting each fix in place and re-running:

| reverted | tests that fail |
| --- | --- |
| `builtin unset ORCA_SHELL_FEATURES` in the zsh channel | grandchild-leak + parity (2) |
| `markers` gate → always select markers | 6, incl. parity |
| `history` gate → only when already wrapped | 6, incl. the live-shell clobber tests |
| fail-closed verification → always trust the write | fail-closed fallback (1) |
| ownership check → suffix-only, no readability check | stacked-ZDOTDIR guard (1) |
| `emulate -L zsh` in the epilogue | both hostile-option cases (2), on real zsh |
| HISTFILE repair back behind the `history` guard | re-entrant clobber repair (1), on real zsh |
| relay gate reinstated (overlay-key list) | remote pane with no CLI bridge keeps its worktree history (1) |
| per-attempt key delete in `spawnShellWithFallback` | first-fallback env leak into the second fallback (1) |
| `dropInheritedOrcaHistFile` removed from all five call sites | inherited-HISTFILE tests (8): desktop inject ×2, desktop isolation-off, daemon, relay inject ×2, relay `buildSpawnEnv` ×2 |
| `.zshrc` epilogue call back to `[[ -o login ]] \|\| …` | `emulate sh` login shell (1), on real zsh |
| resolver block removed from `.zprofile`/`.zshrc`/`.zlogin` | mixed-build wrapper dir (1), on real zsh — both the `command not found` and the skipped-user-config assertions |
| `isOrcaMintedHistFile` anchor back to `(?:^\|/)` | relative-shape HISTFILE preserved (1) |
| resolver out-parameter back to `REPLY` | `typeset -r REPLY` + `typeset -i REPLY` panes (2) on real zsh, plus the three namespace-rule cases and all three wrapper byte snapshots |
| emulation degrade removed from `.zshenv`/`.zprofile` | `emulate sh`/`emulate ksh` degrade cases (3), on real zsh |
| `delete env.ORCA_HISTFILE` in `createPtySubprocess` | daemon inherited-`ORCA_HISTFILE` case (1) |
| `delete result.ORCA_HISTFILE` in the relay's `buildSpawnEnv` | relay inherited/client-carried `ORCA_HISTFILE` cases (4) |

### Suites

All run with `ORCA_SHELL_FEATURES`, `ORCA_HISTFILE` and `ORCA_SHELL_READY_MARKER` explicitly unset, so no assertion can pass on a value inherited from the developer's own Orca pane.

- `npx oxlint` and `npx oxfmt --check` on every changed file — clean. No `max-lines` disable added, no mobile ratchet bump.
- `npx tsc --noEmit -p config/tsconfig.node.json` — clean.
- `src/main/ipc src/main/providers src/main/daemon src/relay src/main/shell-startup-feature-channel.test.ts src/main/shell-wrapper-generated-file-snapshot.test.ts` — **6639 passed, 16 skipped, 10 failed**, plus 8 suites that fail to collect. **Every one of them fails identically on `origin/main` in the same checkout**, verified by detaching to `origin/main` and re-running them: the 8 collection failures are `Error: Cannot find package 'psl'` (a dependency this checkout's shared `node_modules` predates, reached via `src/main/browser/browser-cookie-import-policy.ts`), and the 10 are xterm snapshot/emulator-fidelity assertions in `terminal-snapshot-osc8-roundtrip`, `terminal-snapshot-color-parity` and `headless-emulator-fidelity.fuzz`. None of those files is touched by this PR.
- `src/main/zsh-scoped-histfile.live-shell.test.ts` against real zsh 5.9 / macOS: **12/12, none skipped** (7 pre-existing + 5 new: two `REPLY` declarations, `emulate sh` and `emulate ksh` in `.zshenv`, `emulate sh` in `.zprofile`). It drives the **real** launch decision (`selectShellStartupFeatures` + `getShellLaunchConfig`), so a pane Orca would not wrap cannot pass it by construction.
- `src/main/shell-startup-feature-channel.test.ts` (real zsh) — 13/13. `src/main/zsh-wrapper-version-mismatch.live-shell.test.ts` (real zsh) — 1/1. `src/main/shell-wrapper-generated-file-snapshot.test.ts` — 7/7 including the three new namespace-rule cases. `src/main/terminal-history.test.ts` + `src/relay/terminal-history.test.ts` — green.

### CI failures that are not this PR's

- **`typecheck`** — was red on the previous run with `src/renderer/src/components/tab-bar/TabBarCreateEntry.tab-results.test.tsx(51,9): Property 'occupantAgent' is missing`, a pre-existing `origin/main` breakage since fixed on `main` by #15277. It passes on this run. This branch's own target, `config/tsconfig.node.json`, was clean throughout.
- **`e2e / changed e2e specs` and `e2e / ssh docker watcher isolation`** — still failing, and every failing spec dies on the same line: `Orca's local relay build is missing its version marker at out/relay/linux-x64/.version`. That is the e2e lane's relay build artifact, not shell-wrapper behaviour; e2e is deliberately absent from `verify`'s `needs` because it is red on `main`. Not fixed here — it needs its own blast radius in the e2e packaging lane.

Everything else is green: `static analysis`, `typecheck`, `shell contracts`, and all 32 `tests node` shards.
- **`verify`** — the aggregator; it reports the above.

### Snapshot updates (#15245's byte snapshots)

These **had** to change here — that is the point of this PR, and unlike in #15245 updating them is correct. Every changed line falls into one of eight buckets:

1. **`.zshenv` gains the feature channel + config-dir resolver + the epilogue.** The channel is 4 lines; the resolver replaces the repeated `case "${x%/}" in */shell-ready/zsh)` pattern; the epilogue is the code that moved out of `.zshrc`/`.zlogin`.
2. **`.zshrc` and `.zlogin` shrink to "source the user's file, then call the epilogue."** `.zlogin` ends with `(( ${+functions[__orca_shell_epilogue]} )) && __orca_shell_epilogue`; `.zshrc` wraps the same call in `if [[ ! -o login || "$(emulate 2>/dev/null)" != zsh ]]` (a login shell normally has `.zlogin` to load — unless sh/ksh emulation sent it to `$HOME/.zlogin`; follow-up #6). The `${+functions[…]}` guard is braced because `KSH_ARRAYS` rejects the unbraced form outright, and it exists so a wrapper dir shared by two concurrently installed builds loses the epilogue's features rather than erroring (follow-up #7 and "Scoped out"). Everything deleted from these two files reappears verbatim inside the epilogue.
   **`.zprofile`/`.zshrc`/`.zlogin` also each carry the 7-line `__orca_resolve_user_config_dir` definition** (follow-up #7): they call it on their first executable line, so defining it only in `.zshenv` made a mixed-build wrapper dir fail loudly and skip the user's config.
3. **`ORCA_SHELL_STARTUP_IDENTITY` gate → `__orca_has_feature identity`,** and `ORCA_SHELL_READY_MARKER` gate → the `ready` guard (zsh) / `__orca_ready_marker` (bash). Same emission, different channel.
4. **`ORCA_HISTFILE` branch gains `builtin unset ORCA_HISTFILE`.** The consume-and-destroy step.
5. **fish init loses its `if test "$ORCA_SHELL_READY_MARKER" = 1` wrapper.** The command is only passed when `ready` is selected, so the gate was dead weight; this also removes the last reader of that variable.
6. **Relay `.zlogin` ready-marker ordering.** The pre-existing `readyMarkerOrder` drift field is deleted: local/daemon registered the widget before the final `ZDOTDIR` restore, relay after. The widget registration does not read `ZDOTDIR`, so the order was immaterial; unifying it removes a spec field whose only job was to preserve cosmetic drift. Same for the `legacyFormatting` indent/comment drift, which became meaningless once the restores were re-indented into a function body.

7. **The resolver's out-parameter is `_orca_resolved_config_dir`, declared `typeset -g`, instead of `REPLY`.** Pure rename plus the declaration; the resolver's logic is unchanged (follow-up #10).
8. **`.zshenv` and `.zprofile` gain the sh/ksh emulation degrade block**, gated on having sourced a user file (follow-up #12), and the OSC 133 preexec hook gains `typeset -g` (follow-up #13).

No generated line changed for any reason outside those eight.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

## Blast radius

Honestly stated, because this is the part that matters.

**Exactly which pane classes get the history repair** (one rule for all three transports: an empty feature set is never wrapped; relay bash is the one unconditional wrap, unchanged):

| pane class | wrapped on `main` | wrapped after this PR | `/etc/zshrc` HISTFILE repair |
| --- | --- | --- | --- |
| local PTY / daemon zsh, worktree history on, no overlay var, no startup command | no | **yes (new)** | **new** |
| local PTY / daemon zsh with an overlay var or a startup command | yes | yes | already had it |
| relay (SSH) zsh, host reports a CLI bridge — i.e. every normal remote pane, since `ssh-pty-spawn-env.ts` always sets `ORCA_REMOTE_CLI_BIN_DIR` | yes | yes | already had it |
| relay zsh on a host too old to report its platform (`remoteCliBridgeEnv === null`), worktree history on | no | **yes (new)** | **new** |
| any zsh with nothing Orca-owned (history off, no overlay, no startup command), all transports | no | no | n/a — nothing to repair |
| zsh that re-enters an inherited wrapper `ZDOTDIR` with the allowlist already consumed | wrapped, repair ran | wrapped, repair runs (ungated) | unchanged |
| bash — local/daemon (overlay or startup command only) and relay (always) | unchanged | unchanged | n/a: the unguarded assignment is in the *system zshrc*, zsh only |
| fish | init-command only | unchanged | n/a (`fish_history`, not `HISTFILE`) |
| Windows PowerShell / cmd / the WSL outer exe | unchanged | unchanged | n/a |

**Newly wrapped, therefore:** local and daemon plain zsh panes, and the one relay class above. Everything else was already wrapped or stays unwrapped. The relay is **not** excluded — an earlier revision of this PR said it was, and that was wrong (see follow-up #2).

**What that does:** the `/etc/zshrc` HISTFILE clobber is repaired, so per-worktree history actually works on macOS for the first time. That is the whole fix.

**What it does not change:** those panes get **no** OSC 133 (the `markers` token is gated on "was this pane wrapped before"), no readiness marker, no identity marker, and no overlay restores. They run `.zshenv`, `.zprofile`, `.zshrc`, `.zlogin` from the user's real config dir in the normal order, with the same prompt hooks and the same `zle-line-init`, proven by the parity test above. Launch args are unchanged: local POSIX panes already spawned `['-l']`.

**What it also changes for a newly wrapped pane:** `HISTFILE` now reaches the pane's children with the worktree path in it, where before `/etc/zshrc` had already overwritten it with `$HOME/.zsh_history`. That is inherent to repairing the value at all — the repair has to happen after the system zshrc, and `HISTFILE` is exported. The one case where that mattered (an Orca launched from such a pane) is closed by follow-up #5; other children simply see the history file the pane is actually using, which is the intended contract.

**What it costs:** those panes now source four small generated files and run one function. A login zsh additionally forks once for `$(emulate)` in the wrapper `.zshrc` (follow-up #6), and once more per user `.zshenv`/`.zprofile` that actually exists (follow-up #12 — the probe is gated on having sourced one, so a user with neither pays nothing). Measured on zsh 5.9 / macOS over 30 runs: wrapped startup is ≈10.5 ms/run with and without the emulation probes when no user `.zshenv`/`.zprofile` exists, against ≈8.5 ms/run unwrapped. The rest is a handful of `[[ ]]` tests and, in the guard, up to four `-r` stats on the user's config dir.

**Panes deliberately left alone:** bash is never wrapped for history alone, so its login startup-file chain is untouched. Relay bash stays wrapped unconditionally, exactly as before, because its rcfile carries the OSC 133 hooks that agent status depends on — unwrapping it would have been regression #2 in a new costume. Windows/PowerShell and non-zsh/bash shells are untouched. WSL panes go through the bash path and are unchanged.

**Backwards compatibility:** the wrapper is regenerated on launch, and the `*/shell-ready/zsh` shape is still accepted as proof of Orca ownership, so a stale wrapper dir written by an older build is still recognised and not mistaken for the user's config. A wrapper dir left half-rewritten by a *different* build no longer costs the user their zsh config either — see follow-up #7. Nothing here crosses the client/host wire — `ORCA_SHELL_FEATURES` only travels from a relay process into a PTY it spawns on the same host, never over an RPC or stream frame, so no capability negotiation is needed.

## Scoped out

- **Reconciling the relay's `overlay-user-zdotdir` `.zshenv` with the local/daemon `discover-user-zdotdir` one.** Still two strategies behind one spec field, preserved from #15245. Unifying them changes which file the remote shell's `ZDOTDIR` is discovered from and deserves its own PR. **Disclosed defect:** the overlay body never `unset ZDOTDIR` before sourcing the user's `.zshenv`, so for a *wrapped* relay pane whose user keeps their zsh config in a relocated `ZDOTDIR`, `ORCA_USER_ZDOTDIR` collapses to `$HOME` and that config is not loaded. This is present on `origin/main` today and reaches every already-wrapped remote pane there (which is every remote pane whose host reports a CLI bridge). This PR adds exactly one newly exposed class — a remote zsh pane on a host too old to report its platform, with worktree history on — and does not fix the defect. The fix is `unset ZDOTDIR` + re-resolve inside `getZshOverlayEnvBody`, which changes remote startup for every already-wrapped relay pane and belongs in the reconciliation PR.
- **`emulate sh`/`emulate ksh` is now handled everywhere it can be, not scoped out.** zsh does not "skip `$ZDOTDIR/.zlogin`" as an earlier revision of this note claimed — its `sourcehome()` ignores `ZDOTDIR` under those emulations and reads the `$HOME` file instead, so the *wrapper's* file never runs while the user's does. Entered from the user's `.zshrc`, the epilogue now runs from the wrapper `.zshrc` (follow-up #6) and the residual is ordering, not omission. Entered from the user's `.zshenv` or `.zprofile`, no wrapper file after it is read at all and `HISTFILE` cannot be repaired from there, so the pane is handed back unwrapped instead (follow-up #12) — the same shell `main` produced for it. **Residual, accepted:** such a pane gets none of Orca's features, including the readiness marker, so a startup command in it waits out the pre-ready timeout before delivery. That is exactly what happened on `main` for these configurations too; nothing here makes it worse.
- **`skipUserZshrcWhenHomeIsWrapperDir`.** With positive ownership identification this check can no longer fire, but it is left in place rather than removed in the same PR that widens wrapping.
- **Making a wrapped pane leave `ZDOTDIR` unset when the spawn env had none.** Documented in the parity test as the single carried-over difference; it predates this PR and applies to every pane Orca has ever wrapped.
- **Versioning the relay wrapper dir (`~/.orca-relay/shell-ready/zsh`).** It is shared by every Orca build that connects to that remote user, and the generated files are now inter-dependent — the `.zlogin`/`.zshrc` call a function defined in the `.zshenv`. Two concurrently installed builds that disagree about the file contents rewrite the dir on every spawn, so a shell can in principle read one build's `.zshenv` and another's `.zlogin`. **Mitigated, not eliminated:** every function these files call except the epilogue is now redefined at the top of each file that calls it (follow-up #7), and the epilogue call is guarded on the function existing — so the worst a mismatch costs is the epilogue's features for that one shell, with nothing printed into the pane, and the next spawn rewrites the dir consistently. Redefining one shared constant per file is not the drift the shared builder removed: there is still exactly one source for the text. A real fix is a versioned dir (which then needs its own GC for abandoned versions), and that does not belong here.

- **`docs/reference/*` for the feature channel.** The contract is documented in the module header of `src/main/shell-startup-features.ts`, next to the code that owns it.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

- **Security:** the change removes a cross-process control channel rather than adding one. Nothing new is exported to child processes; one variable that used to be exported (`ORCA_SHELL_READY_MARKER`) is gone, and the new one is destroyed before user code runs.
- **Cross-platform:** zsh/bash paths are POSIX-only and already guarded by `process.platform !== 'win32'`; Windows PowerShell/cmd and the Git Bash and WSL launch paths are unchanged apart from `getBashWrapperLaunchArgs()` now returning `null` (and falling back to a plain login bash) when the rcfile is missing, which is strictly safer than handing ConPTY a path to a file that does not exist.
- **Remote SSH:** covered — the relay and daemon transports both go through the same selection and the same fail-closed generation, and the relay path additionally tolerates an `EACCES` `$HOME`.
- **Folder workspaces and git worktrees:** the selection reads `ORCA_HISTFILE` from the spawn env and does not care how the workspace was created.
- **Performance:** unchanged for already-wrapped panes; for newly wrapped panes, four small generated files and one function call at startup, plus the gated `$(emulate)` probes described under Blast radius (≈2 ms of the ≈10.5 ms wrapped startup measured on zsh 5.9 / macOS, and zero for a user with no `.zshenv`/`.zprofile`).




