### PR TITLE
ci(e2e): install a CJK font on the e2e runners

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -130,7 +130,7 @@ jobs:
       # scripts still need the Linux toolchain even though this shard reuses
       # the prebuilt Electron output.
       - name: Install native build tools
-        run: sudo apt-get update && sudo apt-get install -y build-essential python3 zsh
+        run: sudo apt-get update && sudo apt-get install -y build-essential fonts-noto-cjk python3 zsh
 
       # Why: Electron on Linux needs an X display even when the app
       # suppresses mainWindow.show() via ORCA_E2E_HEADLESS. xvfb provides a
@@ -213,7 +213,7 @@ jobs:
       - name: Install native build and headless UI tools
         # Why openssh-client: the Docker-SSH fixture shells out to ssh/ssh-keygen, and this
         # lane now receives those specs from pr.yml's SSH source mapping.
-        run: sudo apt-get update && sudo apt-get install -y build-essential openssh-client python3 xvfb zsh
+        run: sudo apt-get update && sudo apt-get install -y build-essential fonts-noto-cjk openssh-client python3 xvfb zsh
 
       # Why pnpm first: setup-node needs pnpm on PATH to locate the store it caches.
       # Without that cache every E2E job re-downloaded the whole dependency set.
@@ -297,7 +297,7 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
 
       - name: Install native build and headless UI tools
-        run: sudo apt-get update && sudo apt-get install -y build-essential openssh-client python3 xvfb zsh
+        run: sudo apt-get update && sudo apt-get install -y build-essential fonts-noto-cjk openssh-client python3 xvfb zsh
 
       # Why pnpm first: setup-node needs pnpm on PATH to locate the store it caches.
       # Without that cache every E2E job re-downloaded the whole dependency set.


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | 0 |

<!-- /orca-pr-loc -->

The e2e runners have **no font covering Hangul, Han or Kana**, so any spec asserting how CJK text renders is measuring tofu rather than the glyph.

## This is not hypothetical

An end-of-row preedit spec added for #12729 came back with:

```
overlay 8.59px over an 8.43px cell = 1.02 cells, covering columns [10,10]
Expected: > 1.5
```

The composition overlay is **shrink-to-fit with no `width` of its own** — it sets `left`, `top`, `height`, `fontFamily`, `fontSize` and `maxWidth`, so its width tracks the glyph's natural advance rather than the two cells the grid reserves for a wide character. With no Korean font that advance is one cell.

So the assertion could not distinguish *"the overlay really is one cell"* from *"there is no font"* — which is precisely the question that spec exists to answer, and the reason #12729's diagnosis is still not settled.

## The change

`fonts-noto-cjk` covers all three scripts, added to both jobs that execute specs — the sharded suite and the changed-spec job — plus the ssh-docker lane so the three stay consistent.

## What this does and does not do

**Does not** make any spec pass on its own. It makes the CJK ones *mean something*.

It also unblocks a question on a live report: a Windows user seeing doubled Korean is running a font with no Hangul glyphs, and font fallback at the wide-character boundary is a live hypothesis there. Right now we cannot test that hypothesis in CI at all.

## Verification

`e2e.yml` parses; the three install steps are the only lines changed.