### PR TITLE
feat(orchestration): report a worker blocked on a human prompt (STA-4513, STA-3714)

### DIFF
--- a/docs/reference/remote-wire-compatibility.md
+++ b/docs/reference/remote-wire-compatibility.md
@@ -100,6 +100,27 @@ sync channel, agent-session publications, file or Git RPCs, mobile/E2EE framing,
 the relay transport. A change on those paths still needs its own reasoning against
 the three rules above.
 
+## Worked example: `agentWait` on terminal and worker reads
+
+`terminal.show`, `orchestration.workerShow` and `orchestration.federationShow` carry an
+optional `agentWait` naming a pane parked on a prompt only a human can answer. It is Rule 1 —
+a new optional field — but it has a second state that Rule 1 alone does not describe, and
+getting that wrong turns a skew into a false "nothing is blocked".
+
+- **present object** — this pane is waiting, with the evidence that proved it.
+- **present `null`** — the host evaluated this pane and nothing proves a wait.
+- **absent** — the host never evaluated it: it predates the field, the worker identity was
+  unverifiable, the pane was unreadable, or the agent probe did not answer in time.
+
+A new client against an old host sees the field absent, which is why absence must read as
+*unknown* and never as *not waiting*. Collapsing absent into `null` at any hop — including a
+convenience `?? null` in an RPC handler — makes an old or unreachable peer indistinguishable
+from a healthy idle worker, which is the exact failure the field exists to remove.
+
+An old client against a new host ignores the key, as Rule 1 allows. New members added to
+`RuntimeTerminalWaitBlockedReason` are also Rule 1: no consumer switches exhaustively on it,
+and both the CLI and worker-start interpolate it as an opaque string.
+
 ## Known debt: JSON-RPC errors drop Node's string code
 
 An error raised on an SSH host crosses the relay as JSON-RPC, and

--- a/src/cli/handlers/orchestration-worker-show-wait-cli.test.ts
+++ b/src/cli/handlers/orchestration-worker-show-wait-cli.test.ts
@@ -1,0 +1,74 @@
+// `worker-show` text output must keep "nobody is waiting" apart from "nobody looked".
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const callMock = vi.fn()
+
+vi.mock('../format', () => ({ printResult: vi.fn() }))
+vi.mock('../selectors', () => ({ getTerminalHandle: vi.fn() }))
+
+import { ORCHESTRATION_HANDLERS } from './orchestration'
+import { printResult } from '../format'
+
+function renderedLine(result: unknown): string {
+  const [value, , render] = vi.mocked(printResult).mock.calls[0] as [
+    unknown,
+    boolean,
+    (value: unknown) => string
+  ]
+  expect(value).toBe(result)
+  return render(value)
+}
+
+async function showWorker(observation: unknown): Promise<string> {
+  const result = {
+    dispatch: { id: 'ctx_1', task_id: 'task_1', status: 'dispatched' },
+    worker: { state: 'ready', stage: 'dispatch_input', agent_terminal_handle: 'term_1' },
+    ...(observation === undefined ? {} : { observation })
+  }
+  callMock.mockResolvedValue(result)
+  await ORCHESTRATION_HANDLERS['orchestration worker-show']({
+    flags: new Map<string, string | boolean>([['dispatch', 'ctx_1']]),
+    client: { call: callMock },
+    cwd: '/tmp/repo',
+    json: false
+  } as never)
+  return renderedLine(result)
+}
+
+describe('orchestration worker-show interactive wait output', () => {
+  beforeEach(() => {
+    callMock.mockReset()
+    vi.mocked(printResult).mockReset()
+  })
+
+  it('names the prompt when a worker is waiting on a human', async () => {
+    const line = await showWorker({
+      status: 'live',
+      exactWorker: true,
+      agentWait: { source: 'prompt-text', reason: 'agent-approval-prompt', since: 1 }
+    })
+
+    expect(line).toContain('Waiting on a human: agent-approval-prompt (via prompt-text)')
+  })
+
+  it('says none when the pane was evaluated and nothing was waiting', async () => {
+    const line = await showWorker({ status: 'live', exactWorker: true, agentWait: null })
+
+    expect(line).toContain('Interactive wait: none')
+  })
+
+  it('says unknown when the field is absent, not none', async () => {
+    // An older host, or a worker whose identity could not be verified. Printing the same
+    // thing as an evaluated `null` is the false negative this field exists to remove.
+    const line = await showWorker({ status: 'identity_changed', exactWorker: false })
+
+    expect(line).toContain('Interactive wait: unknown (not evaluated)')
+    expect(line).not.toContain('Interactive wait: none')
+  })
+
+  it('says unknown when the host sent no observation at all', async () => {
+    const line = await showWorker(undefined)
+
+    expect(line).toContain('Interactive wait: unknown (not evaluated)')
+  })
+})

--- a/src/cli/handlers/orchestration.ts
+++ b/src/cli/handlers/orchestration.ts
@@ -945,12 +945,16 @@ export const ORCHESTRATION_HANDLERS: Record<string, CommandHandler> = {
     })
     printResult(result, json, (value) => {
       const base = `${value.dispatch.id} task=${value.dispatch.task_id} [${value.worker.state}] stage=${value.worker.stage}`
-      const wait = value.observation?.agentWait
       // Why a whole line and not a suffix: this is the one state where the lane is healthy
-      // and still needs a person, so it must not read as another status token.
+      // and still needs a person, so it must not read as another status token. An absent
+      // field is unknown, which must not print the same as an evaluated "none".
+      if (value.observation === undefined || !('agentWait' in value.observation)) {
+        return `${base}\nInteractive wait: unknown (not evaluated)`
+      }
+      const wait = value.observation.agentWait
       return wait
         ? `${base}\nWaiting on a human: ${wait.reason ?? 'interactive prompt'} (via ${wait.source})`
-        : base
+        : `${base}\nInteractive wait: none`
     })
   },
 

--- a/src/cli/handlers/orchestration.ts
+++ b/src/cli/handlers/orchestration.ts
@@ -939,15 +939,19 @@ export const ORCHESTRATION_HANDLERS: Record<string, CommandHandler> = {
     const result = await client.call<{
       dispatch: { id: string; task_id: string; status: string }
       worker: { state: string; stage: string; agent_terminal_handle: string | null }
+      observation?: { agentWait?: { source: string; reason?: string } | null }
     }>('orchestration.workerShow', {
       dispatch: getRequiredStringFlag(flags, 'dispatch')
     })
-    printResult(
-      result,
-      json,
-      (value) =>
-        `${value.dispatch.id} task=${value.dispatch.task_id} [${value.worker.state}] stage=${value.worker.stage}`
-    )
+    printResult(result, json, (value) => {
+      const base = `${value.dispatch.id} task=${value.dispatch.task_id} [${value.worker.state}] stage=${value.worker.stage}`
+      const wait = value.observation?.agentWait
+      // Why a whole line and not a suffix: this is the one state where the lane is healthy
+      // and still needs a person, so it must not read as another status token.
+      return wait
+        ? `${base}\nWaiting on a human: ${wait.reason ?? 'interactive prompt'} (via ${wait.source})`
+        : base
+    })
   },
 
   'orchestration worker-read': async ({ flags, client, json }) => {

--- a/src/cli/specs/orchestration-worker-specs.ts
+++ b/src/cli/specs/orchestration-worker-specs.ts
@@ -45,7 +45,7 @@ export const ORCHESTRATION_WORKER_COMMAND_SPECS: CommandSpec[] = [
     allowedFlags: [...GLOBAL_FLAGS, 'dispatch'],
     notes: [
       'A Dispatch created by orchestration dispatch is shown as unsupervised and reports the exact adopted terminal when its identity is still provable.',
-      'observation.agentWait names a worker parked on a prompt only a human can answer, with the evidence that proved it (hook, prompt-text, or title). Null means no proof of a wait; a missing field means the host predates it. A waiting worker is healthy, not failed.'
+      'observation.agentWait names a worker parked on a prompt only a human can answer, with the evidence that proved it (hook, prompt-text, or title). Null means Orca looked and found no wait; an absent field means it never looked, because the host predates the field or the worker identity was unverifiable. A waiting worker is healthy, not failed.'
     ]
   },
   {

--- a/src/cli/specs/orchestration-worker-specs.ts
+++ b/src/cli/specs/orchestration-worker-specs.ts
@@ -44,7 +44,8 @@ export const ORCHESTRATION_WORKER_COMMAND_SPECS: CommandSpec[] = [
     usage: 'orca orchestration worker-show --dispatch <dispatch_id> [--json]',
     allowedFlags: [...GLOBAL_FLAGS, 'dispatch'],
     notes: [
-      'A Dispatch created by orchestration dispatch is shown as unsupervised and reports the exact adopted terminal when its identity is still provable.'
+      'A Dispatch created by orchestration dispatch is shown as unsupervised and reports the exact adopted terminal when its identity is still provable.',
+      'observation.agentWait names a worker parked on a prompt only a human can answer, with the evidence that proved it (hook, prompt-text, or title). Null means no proof of a wait; a missing field means the host predates it. A waiting worker is healthy, not failed.'
     ]
   },
   {

--- a/src/cli/specs/orchestration-worker-specs.ts
+++ b/src/cli/specs/orchestration-worker-specs.ts
@@ -45,7 +45,7 @@ export const ORCHESTRATION_WORKER_COMMAND_SPECS: CommandSpec[] = [
     allowedFlags: [...GLOBAL_FLAGS, 'dispatch'],
     notes: [
       'A Dispatch created by orchestration dispatch is shown as unsupervised and reports the exact adopted terminal when its identity is still provable.',
-      'observation.agentWait names a worker parked on a prompt only a human can answer, with the evidence that proved it (hook, prompt-text, or title). Null means Orca looked and found no wait; an absent field means it never looked, because the host predates the field or the worker identity was unverifiable. A waiting worker is healthy, not failed.'
+      'observation.agentWait names a worker parked on a prompt only a human can answer, with the evidence that proved it (hook, prompt-text, or title). Null means Orca looked and found no wait. An absent field means it never looked — an older host, an unverifiable worker identity, an unreadable pane, or an agent probe that did not answer in time — and never means the worker is not waiting. A waiting worker is healthy, not failed.'
     ]
   },
   {

--- a/src/cli/terminal-format.ts
+++ b/src/cli/terminal-format.ts
@@ -122,7 +122,7 @@ export function formatTerminalShow(result: { terminal: RuntimeTerminalShow }): s
 
 function formatAgentWait(agentWait: RuntimeTerminalShow['agentWait']): string {
   if (agentWait === undefined) {
-    return 'unknown (host predates the field)'
+    return 'unknown (not evaluated)'
   }
   if (!agentWait) {
     return 'none'

--- a/src/cli/terminal-format.ts
+++ b/src/cli/terminal-format.ts
@@ -113,8 +113,21 @@ export function formatTerminalShow(result: { terminal: RuntimeTerminalShow }): s
     `ptyId: ${terminal.ptyId ?? 'none'}`,
     `connected: ${terminal.connected}`,
     `writable: ${terminal.writable}`,
+    // Why listed above the preview: the preview is where a reader would otherwise have to
+    // spot the prompt by eye, which is the work this line exists to remove.
+    `agentWait: ${formatAgentWait(terminal.agentWait)}`,
     `preview: ${terminal.preview || '<empty>'}`
   ].join('\n')
+}
+
+function formatAgentWait(agentWait: RuntimeTerminalShow['agentWait']): string {
+  if (agentWait === undefined) {
+    return 'unknown (host predates the field)'
+  }
+  if (!agentWait) {
+    return 'none'
+  }
+  return `${agentWait.reason ?? 'interactive prompt'} (via ${agentWait.source})`
 }
 
 export function formatTerminalRead(result: { terminal: RuntimeTerminalRead }): string {

--- a/src/main/runtime/__fixtures__/cursor-agent-approval-prompt.txt
+++ b/src/main/runtime/__fixtures__/cursor-agent-approval-prompt.txt
@@ -1,0 +1,24 @@
+p/sta4513/live-cursor-trust && cursor-agent
+
+
+  Cursor Agent
+  v2026.08.11-e8db854
+  Tip: Use /mcp to connect Cursor to your tools and data sources.
+
+
+  Run the shell command: git status --porcelain
+
+
+  I'll run git status --porcelain in the workspace now.
+
+  $ git status --porcelain Waiting for approval...
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ $  git status --porcelain in .
+
+ Run this command?
+ Not in allowlist: git status
+  → Run (once) (y)
+    Add Shell(git status) to allowlist? (tab)
+    Run Everything (shift+tab)
+    Skip & tell the agent what to do instead (esc or n)

--- a/src/main/runtime/__fixtures__/cursor-agent-idle-after-approval.txt
+++ b/src/main/runtime/__fixtures__/cursor-agent-idle-after-approval.txt
@@ -1,0 +1,40 @@
+p/sta4513/live-cursor-trust && cursor-agent
+
+
+  Cursor Agent
+  v2026.08.11-e8db854
+  Tip: Use /mcp to connect Cursor to your tools and data sources.
+
+
+  Run the shell command: git status --porcelain
+
+
+  I'll run git status --porcelain in the workspace now.
+
+  $ git status --porcelain exit 128 • 9.6s
+    fatal: not a git repository (or any of the parent directories): .git
+
+  git status --porcelain failed:
+
+  fatal: not a git repository (or any of the parent directories): .git
+
+  This workspace (/private/tmp/sta4513/live-cursor-trust) is not a git repo.
+
+
+  Run the shell command: sleep 60
+
+
+  I'll run sleep 60 and wait until it finishes.
+
+  $ sleep 60 1m 14s
+
+  sleep 60 finished successfully (exit code 0) after about 60 seconds.
+
+
+
+
+  → Add a follow-up
+
+
+  Auto · 6.3%
+  /private/tmp/sta4513/live-cursor-trust

--- a/src/main/runtime/__fixtures__/cursor-agent-long-tool-call.txt
+++ b/src/main/runtime/__fixtures__/cursor-agent-long-tool-call.txt
@@ -1,0 +1,41 @@
+p/sta4513/live-cursor-trust && cursor-agent
+
+
+  Cursor Agent
+  v2026.08.11-e8db854
+  Tip: Use /mcp to connect Cursor to your tools and data sources.
+
+
+  Run the shell command: git status --porcelain
+
+
+  I'll run git status --porcelain in the workspace now.
+
+  $ git status --porcelain exit 128 • 9.6s
+    fatal: not a git repository (or any of the parent directories): .git
+
+  git status --porcelain failed:
+
+  fatal: not a git repository (or any of the parent directories): .git
+
+  This workspace (/private/tmp/sta4513/live-cursor-trust) is not a git repo.
+
+
+  Run the shell command: sleep 60
+
+
+  I'll run sleep 60 and wait until it finishes.
+
+  $ sleep 60 29s
+    ctrl+b twice to send to background
+
+ ⠘⠆ Running  53 tokens
+    Tip: Use /debug to instrument and debug complex problems.
+
+
+  → Add a follow-up                                                                                     ctrl+c to stop
+
+
+  1 task
+  Auto · 6.2%
+  /private/tmp/sta4513/live-cursor-trust

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -18601,7 +18601,7 @@ export class OrcaRuntimeService {
     // Bounded because it reaches a PTY controller that can be a remote host: a wedged probe
     // must leave the wait unevaluated, never stall every caller of showTerminal.
     const status = await withTimeout(
-      this.getTerminalAgentStatus(handle).catch(() => undefined),
+      this.probeAgentStatusOncePerPty(handle, ptyId),
       TERMINAL_INTERACTIVE_WAIT_PROBE_TIMEOUT_MS,
       undefined
     )
@@ -18611,6 +18611,32 @@ export class OrcaRuntimeService {
     return status.isRunningAgent && status.status === 'permission'
       ? { source: 'hook', since: explicitStatus.updatedAt }
       : null
+  }
+
+  // Why single-flight: the timeout above abandons the wait, not the request. A wedged remote
+  // host would otherwise accrue one live probe per poll for as long as a coordinator watches.
+  private readonly interactiveWaitProbesByPtyId = new Map<
+    string,
+    Promise<RuntimeTerminalAgentStatus | undefined>
+  >()
+
+  private probeAgentStatusOncePerPty(
+    handle: string,
+    ptyId: string
+  ): Promise<RuntimeTerminalAgentStatus | undefined> {
+    const inFlight = this.interactiveWaitProbesByPtyId.get(ptyId)
+    if (inFlight) {
+      return inFlight
+    }
+    const probe = this.getTerminalAgentStatus(handle)
+      .catch(() => undefined)
+      .finally(() => {
+        if (this.interactiveWaitProbesByPtyId.get(ptyId) === probe) {
+          this.interactiveWaitProbesByPtyId.delete(ptyId)
+        }
+      })
+    this.interactiveWaitProbesByPtyId.set(ptyId, probe)
+    return probe
   }
 
   private async terminalHasShellForegroundProcess(handle: string, ptyId: string): Promise<boolean> {
@@ -39613,8 +39639,10 @@ function findCursorApprovalPromptIndex(normalized: string): number | null {
 
 // Why the trailing key and not the wording alone: an agent narrating "next time I'll suggest
 // Run Everything" writes the same words as the menu. A selectable row ends in the key that
-// picks it, and prose does not.
-const CURSOR_APPROVAL_CHOICE_KEY_RE = /\([a-z+ ]{1,12}\)\s*$/
+// picks it, and prose does not. Spelled as key names rather than a character class, because
+// any lowercase run would readmit "…suggest Run Everything (as before)".
+const CURSOR_APPROVAL_CHOICE_KEY_RE =
+  /\((?:shift\+tab|ctrl\+[a-z]|esc(?: or [a-z])*|tab|enter|return|space|[a-z]|[\u21b5\u21e7\u21b9\u238b\u23ce]{1,3})\)\s*$/
 
 function isCursorApprovalChoiceLine(line: string): boolean {
   return (

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -445,6 +445,7 @@ import {
   type RuntimeWorktreeStatus,
   type RuntimeSpeechModelSummary,
   type RuntimeSpeechSetupState,
+  type RuntimeTerminalInteractiveWait,
   type RuntimeTerminalShow,
   type RuntimeTerminalSummary,
   type RuntimeTerminalVisualGroupNode,
@@ -18144,7 +18145,8 @@ export class OrcaRuntimeService {
         leafId: parsePaneKey(pty.pty.paneKey ?? '')?.leafId ?? pty.record.leafId,
         paneRuntimeId: -1,
         ptyId: pty.pty.ptyId,
-        rendererGraphEpoch: this.rendererGraphEpoch
+        rendererGraphEpoch: this.rendererGraphEpoch,
+        agentWait: this.getTerminalInteractiveWait(handle)
       }
     }
     const graphEpoch = this.captureReadyGraphEpoch()
@@ -18164,7 +18166,8 @@ export class OrcaRuntimeService {
       preview,
       paneRuntimeId: leaf.paneRuntimeId,
       ptyId: leaf.ptyId,
-      rendererGraphEpoch: this.rendererGraphEpoch
+      rendererGraphEpoch: this.rendererGraphEpoch,
+      agentWait: this.getTerminalInteractiveWait(handle)
     }
   }
 
@@ -18512,17 +18515,33 @@ export class OrcaRuntimeService {
     explicitStatus: { status: AgentStatus; updatedAt: number } | null,
     lifecycle: { status: AgentStatus | null; updatedAt: number } | null | undefined
   ): boolean {
+    return (
+      this.resolveAuthoritativeTerminalWaitPermission(terminal, explicitStatus, lifecycle) !== null
+    )
+  }
+
+  /** The matched prompt when the tail authoritatively proves a human wait, else null. */
+  private resolveAuthoritativeTerminalWaitPermission(
+    terminal: TerminalAgentStatusSnapshot,
+    explicitStatus: { status: AgentStatus; updatedAt: number } | null,
+    lifecycle: { status: AgentStatus | null; updatedAt: number } | null | undefined
+  ): RuntimeTerminalWaitBlockedReason | null {
     const blockedByWaitText = detectTerminalWaitBlockedReason(terminal.waitText)
     if (!blockedByWaitText) {
-      return false
+      return null
     }
     const liveTitleClearsBlockedText =
       terminal.titleStatusIsLive &&
       terminal.titleStatus !== null &&
       terminal.titleStatus !== 'permission' &&
-      !isOpenCodeNativeTitle(terminal.title)
+      !isOpenCodeNativeTitle(terminal.title) &&
+      // Why exempt: cursor-agent keeps its braille spinner in the title while an approval
+      // waits, so a "working" title there is not evidence of progress. The approval menu
+      // proves its own dismissal (the follow-up input line returning), so unlike the
+      // startup modals it needs no title-based staleness proxy.
+      blockedByWaitText !== 'agent-approval-prompt'
     if (liveTitleClearsBlockedText && lifecycle?.status !== terminal.titleStatus) {
-      return false
+      return null
     }
     const newestPermissionAt = Math.max(
       explicitStatus?.status === 'permission' ? explicitStatus.updatedAt : -1,
@@ -18534,7 +18553,51 @@ export class OrcaRuntimeService {
       lifecycle?.status && lifecycle.status !== 'permission' ? lifecycle.updatedAt : -1
     )
     // Equal wall-clock observations fail closed because their raw intra-chunk order is unknown.
-    return newestPermissionAt >= 0 && newestPermissionAt >= newestClearAt
+    return newestPermissionAt >= 0 && newestPermissionAt >= newestClearAt ? blockedByWaitText : null
+  }
+
+  /** Why: "blocked on a human" is the one worker state a coordinator cannot infer — silence
+   *  covers it, a long tool call, and a wedged process alike. Same evidence fusion
+   *  getTerminalAgentStatus uses for its `permission` verdict, minus the async foreground
+   *  probe, so a per-lane read stays a synchronous map lookup plus one tail scan.
+   *  Null means "nothing proves a wait", never "proven not waiting". */
+  getTerminalInteractiveWait(handle: string): RuntimeTerminalInteractiveWait | null {
+    let ptyId: string
+    let terminal: TerminalAgentStatusSnapshot
+    try {
+      ptyId = this.getTerminalAgentStatusPtyId(handle)
+      terminal = this.getTerminalAgentStatusSnapshot(handle, ptyId)
+    } catch {
+      // Why: an unreadable pane is unknown. Reporting "not waiting" would be the exact
+      // false negative this field exists to remove.
+      return null
+    }
+    const explicitStatus = this.getFreshExplicitAgentStatusForHandle(handle)
+    const lifecycle = this.agentPromptLifecycleByPtyId.get(ptyId)
+    const promptReason = this.resolveAuthoritativeTerminalWaitPermission(
+      terminal,
+      explicitStatus,
+      lifecycle
+    )
+    if (promptReason) {
+      return {
+        source: 'prompt-text',
+        reason: promptReason,
+        ...(terminal.waitBlockedAt !== null ? { since: terminal.waitBlockedAt } : {})
+      }
+    }
+    if (terminal.titleStatus === 'permission' && terminal.titleStatusIsLive) {
+      return { source: 'title' }
+    }
+    // Why the title check: a shell prompt title proves the agent no longer owns the pane,
+    // so a retained hook row must not keep reporting its last permission state.
+    if (
+      explicitStatus?.status === 'permission' &&
+      !terminalTitleBlocksExplicitAgentStatus(terminal.title)
+    ) {
+      return { source: 'hook', since: explicitStatus.updatedAt }
+    }
+    return null
   }
 
   private async terminalHasShellForegroundProcess(handle: string, ptyId: string): Promise<boolean> {
@@ -39487,7 +39550,35 @@ function isTerminalWaitWhitespace(value: string, index: number): boolean {
 }
 
 const TERMINAL_WAIT_BLOCKED_SENTINEL_RE =
-  /update available|choose working directory to|codex just got an upgrade|hooks need review|do you trust|trust this|trusted workspace|press enter to (?:confirm|continue|view|insert)|press t to trust|permission required|requires permission|allow once|allow always/i
+  /update available|choose working directory to|codex just got an upgrade|hooks need review|do you trust|trust this|trusted workspace|press enter to (?:confirm|continue|view|insert)|press t to trust|permission required|requires permission|allow once|allow always|run this command\?/i
+
+// Why cursor-agent needs a text match at all: its hook set (beforeSubmitPrompt, preToolUse,
+// beforeShellExecution, beforeMCPExecution, postToolUse, afterAgentResponse, stop) has no
+// approval event, and beforeShellExecution fires identically for auto-allowed commands, so
+// the rendered menu is the only authority that separates "awaiting a human" from "running".
+// Match the key-bound choices, not the prose above them, so wording changes don't matter.
+const CURSOR_APPROVAL_CHOICE_MARKERS = [
+  'run (once)',
+  'to allowlist?',
+  'run everything',
+  'skip & tell the agent'
+]
+// cursor-agent redraws this input line once the menu is answered.
+const CURSOR_FOLLOW_UP_PROMPT = 'add a follow-up'
+
+function findCursorApprovalPromptIndex(normalized: string): number | null {
+  const promptIndex = normalized.lastIndexOf('run this command?')
+  if (promptIndex === -1) {
+    return null
+  }
+  const menu = normalized.slice(promptIndex)
+  const choices = CURSOR_APPROVAL_CHOICE_MARKERS.filter((marker) => menu.includes(marker)).length
+  if (choices < 2) {
+    return null
+  }
+  // Why: a follow-up prompt after the menu proves it was answered and is now scrollback.
+  return menu.includes(CURSOR_FOLLOW_UP_PROMPT) ? null : promptIndex
+}
 
 function findTerminalWaitBlockedSignal(
   normalized: string
@@ -39556,6 +39647,10 @@ function findTerminalWaitBlockedSignal(
     if (!hasSpecificPromptInContext) {
       candidates.push({ reason: 'codex-interactive-prompt', index: interactivePromptIndex })
     }
+  }
+  const cursorApprovalIndex = findCursorApprovalPromptIndex(normalized)
+  if (cursorApprovalIndex !== null) {
+    candidates.push({ reason: 'agent-approval-prompt', index: cursorApprovalIndex })
   }
   const permissionPromptIndex = Math.max(
     normalized.lastIndexOf('permission required'),

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -18146,7 +18146,7 @@ export class OrcaRuntimeService {
         paneRuntimeId: -1,
         ptyId: pty.pty.ptyId,
         rendererGraphEpoch: this.rendererGraphEpoch,
-        agentWait: await this.getTerminalInteractiveWait(handle)
+        ...expandTerminalInteractiveWait(await this.getTerminalInteractiveWait(handle))
       }
     }
     const graphEpoch = this.captureReadyGraphEpoch()
@@ -18167,7 +18167,7 @@ export class OrcaRuntimeService {
       paneRuntimeId: leaf.paneRuntimeId,
       ptyId: leaf.ptyId,
       rendererGraphEpoch: this.rendererGraphEpoch,
-      agentWait: await this.getTerminalInteractiveWait(handle)
+      ...expandTerminalInteractiveWait(await this.getTerminalInteractiveWait(handle))
     }
   }
 
@@ -18561,17 +18561,19 @@ export class OrcaRuntimeService {
   }
 
   /** Why: "blocked on a human" is the one worker state a coordinator cannot infer — silence
-   *  covers it, a long tool call, and a wedged process alike. Null means "nothing proves a
-   *  wait", never "proven not waiting". */
-  async getTerminalInteractiveWait(handle: string): Promise<RuntimeTerminalInteractiveWait | null> {
+   *  covers it, a long tool call, and a wedged process alike. `null` means this pane was
+   *  evaluated and nothing proves a wait; `undefined` means it could not be evaluated, which
+   *  is never the same as "not waiting". */
+  async getTerminalInteractiveWait(
+    handle: string
+  ): Promise<RuntimeTerminalInteractiveWait | null | undefined> {
     let ptyId: string
     let terminal: TerminalAgentStatusSnapshot
     try {
       ptyId = this.getTerminalAgentStatusPtyId(handle)
       terminal = this.getTerminalAgentStatusSnapshot(handle, ptyId)
     } catch {
-      // An unreadable pane is unknown; "not waiting" would be the false negative this removes.
-      return null
+      return undefined
     }
     const explicitStatus = this.getFreshExplicitAgentStatusForHandle(handle)
     const promptReason = this.resolveAuthoritativeTerminalWaitPermission(
@@ -18596,8 +18598,17 @@ export class OrcaRuntimeService {
     // Why the extra round trip for hook evidence only: a hook row outlives its agent by up to
     // AGENT_STATUS_STALE_AFTER_MS, and only the shared verdict proves an agent still owns this
     // PTY — a shell that took the pane back rarely leaves a title we can recognize as one.
-    const status = await this.getTerminalAgentStatus(handle).catch(() => null)
-    return status?.isRunningAgent === true && status.status === 'permission'
+    // Bounded because it reaches a PTY controller that can be a remote host: a wedged probe
+    // must leave the wait unevaluated, never stall every caller of showTerminal.
+    const status = await withTimeout(
+      this.getTerminalAgentStatus(handle).catch(() => undefined),
+      TERMINAL_INTERACTIVE_WAIT_PROBE_TIMEOUT_MS,
+      undefined
+    )
+    if (!status) {
+      return undefined
+    }
+    return status.isRunningAgent && status.status === 'permission'
       ? { source: 'hook', since: explicitStatus.updatedAt }
       : null
   }
@@ -39563,41 +39574,78 @@ const CURSOR_APPROVAL_CHOICE_MARKERS = [
   'run everything',
   'skip & tell the agent'
 ]
-// Why bounded: an answered menu stays in scrollback, and a stale hit fails tui-idle and
-// refuses prompt injection. One line of slack covers a partial line mid-redraw.
-const CURSOR_APPROVAL_MAX_TRAILING_LINES = 1
+// Why bounded to the last lines: an answered menu stays in scrollback, and a stale hit fails
+// tui-idle and refuses prompt injection. Only a dialog that still owns the bottom of the
+// screen is live, and confining the whole match to that window also keeps prose above or
+// below — an agent narrating "I'll pick Run Everything" — from anchoring it.
+const CURSOR_APPROVAL_TAIL_LINES = 8
 
 function findCursorApprovalPromptIndex(normalized: string): number | null {
-  const promptIndex = normalized.lastIndexOf('run this command?')
-  if (promptIndex === -1) {
+  const windowStart = startOfLastLines(normalized, CURSOR_APPROVAL_TAIL_LINES)
+  const tail = normalized.slice(windowStart)
+  if (!tail.includes('run this command?')) {
     return null
   }
-  const menu = normalized.slice(promptIndex)
-  let matched = 0
-  let lastChoiceEnd = -1
-  for (const marker of CURSOR_APPROVAL_CHOICE_MARKERS) {
-    const index = menu.lastIndexOf(marker)
-    if (index === -1) {
+  const lines = tail.split('\n')
+  while (lines.length > 0 && lines.at(-1)?.trim() === '') {
+    lines.pop()
+  }
+  let matchedLines = 0
+  let lastChoiceLine = -1
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!isCursorApprovalChoiceLine(lines[index])) {
       continue
     }
-    matched += 1
-    lastChoiceEnd = Math.max(lastChoiceEnd, index + marker.length)
+    matchedLines += 1
+    lastChoiceLine = index
   }
-  if (matched < 2) {
+  if (matchedLines < 2) {
     return null
   }
-  let trailingLines = 0
-  for (let cursor = lastChoiceEnd; cursor < menu.length; cursor += 1) {
-    if (menu.charCodeAt(cursor) !== 10) {
-      continue
-    }
-    trailingLines += 1
-    if (trailingLines > CURSOR_APPROVAL_MAX_TRAILING_LINES) {
-      return null
-    }
-  }
-  return promptIndex
+  // Why no slack: every capture of a live dialog ends on its last choice, and one line of
+  // tolerance is enough for the agent's own narration of a choice to revive an answered menu.
+  // A redraw caught mid-flight reads as no wait until the next poll, which is the safe way
+  // to be wrong.
+  return lastChoiceLine === lines.length - 1
+    ? windowStart + tail.lastIndexOf('run this command?')
+    : null
 }
+
+// Why the trailing key and not the wording alone: an agent narrating "next time I'll suggest
+// Run Everything" writes the same words as the menu. A selectable row ends in the key that
+// picks it, and prose does not.
+const CURSOR_APPROVAL_CHOICE_KEY_RE = /\([a-z+ ]{1,12}\)\s*$/
+
+function isCursorApprovalChoiceLine(line: string): boolean {
+  return (
+    CURSOR_APPROVAL_CHOICE_KEY_RE.test(line) &&
+    CURSOR_APPROVAL_CHOICE_MARKERS.some((marker) => line.includes(marker))
+  )
+}
+
+/** Offset of the first character of the last `count` newline-separated lines. */
+function startOfLastLines(value: string, count: number): number {
+  let cursor = value.length
+  for (let seen = 0; seen < count; seen += 1) {
+    const previous = value.lastIndexOf('\n', cursor - 1)
+    if (previous === -1) {
+      return 0
+    }
+    cursor = previous
+  }
+  return cursor + 1
+}
+
+/** Why a spread and not `agentWait: value`: an absent key is the only way to say the pane was
+ *  never evaluated, which a reader must not confuse with an evaluated "no wait". */
+function expandTerminalInteractiveWait(
+  agentWait: RuntimeTerminalInteractiveWait | null | undefined
+): { agentWait?: RuntimeTerminalInteractiveWait | null } {
+  return agentWait === undefined ? {} : { agentWait }
+}
+
+/** A wedged PTY controller must not stall every reader of this pane. */
+const TERMINAL_INTERACTIVE_WAIT_PROBE_TIMEOUT_MS = 2_000
 
 function findTerminalWaitBlockedSignal(
   normalized: string

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -18543,6 +18543,14 @@ export class OrcaRuntimeService {
     if (liveTitleClearsBlockedText && lifecycle?.status !== terminal.titleStatus) {
       return null
     }
+    // Why this reason skips the timestamps below: they exist to date a prompt whose text
+    // survives in scrollback forever, and the approval menu is only matched while it still
+    // owns the bottom of the screen — that is the dating. Without the exemption a tail
+    // restored from history, which carries no waitBlockedAt, would report a live dialog as
+    // nothing at all, exactly across the app restart an unattended run has to survive.
+    if (blockedByWaitText === 'agent-approval-prompt') {
+      return blockedByWaitText
+    }
     const newestPermissionAt = Math.max(
       explicitStatus?.status === 'permission' ? explicitStatus.updatedAt : -1,
       lifecycle?.status === 'permission' ? lifecycle.updatedAt : -1,
@@ -18560,7 +18568,13 @@ export class OrcaRuntimeService {
    *  covers it, a long tool call, and a wedged process alike. Same evidence fusion
    *  getTerminalAgentStatus uses for its `permission` verdict, minus the async foreground
    *  probe, so a per-lane read stays a synchronous map lookup plus one tail scan.
-   *  Null means "nothing proves a wait", never "proven not waiting". */
+   *  Null means "nothing proves a wait", never "proven not waiting".
+   *
+   *  Known blind spot, inherited from that shared verdict rather than added here: a tail
+   *  restored from terminal history carries no waitBlockedAt (see applyRestoredTerminalTailSeed),
+   *  so a prompt that only ever appeared in restored bytes reports nothing until the next live
+   *  chunk. Reversing that would resurrect long-answered prompts on every restore, which costs
+   *  more than the miss — a blocked pane that receives any byte recovers on its own. */
   getTerminalInteractiveWait(handle: string): RuntimeTerminalInteractiveWait | null {
     let ptyId: string
     let terminal: TerminalAgentStatusSnapshot
@@ -39563,8 +39577,11 @@ const CURSOR_APPROVAL_CHOICE_MARKERS = [
   'run everything',
   'skip & tell the agent'
 ]
-// cursor-agent redraws this input line once the menu is answered.
-const CURSOR_FOLLOW_UP_PROMPT = 'add a follow-up'
+// Why the tail must end on the menu: an answered menu keeps sitting in scrollback, and a
+// stale hit here is not merely noisy — it fails tui-idle and refuses prompt injection. A live
+// dialog owns the bottom of the screen, so the last choice may sit at most one line above the
+// end, which tolerates a trailing partial line mid-redraw without admitting scrollback.
+const CURSOR_APPROVAL_MAX_TRAILING_LINES = 1
 
 function findCursorApprovalPromptIndex(normalized: string): number | null {
   const promptIndex = normalized.lastIndexOf('run this command?')
@@ -39572,12 +39589,30 @@ function findCursorApprovalPromptIndex(normalized: string): number | null {
     return null
   }
   const menu = normalized.slice(promptIndex)
-  const choices = CURSOR_APPROVAL_CHOICE_MARKERS.filter((marker) => menu.includes(marker)).length
-  if (choices < 2) {
+  let matched = 0
+  let lastChoiceEnd = -1
+  for (const marker of CURSOR_APPROVAL_CHOICE_MARKERS) {
+    const index = menu.lastIndexOf(marker)
+    if (index === -1) {
+      continue
+    }
+    matched += 1
+    lastChoiceEnd = Math.max(lastChoiceEnd, index + marker.length)
+  }
+  if (matched < 2) {
     return null
   }
-  // Why: a follow-up prompt after the menu proves it was answered and is now scrollback.
-  return menu.includes(CURSOR_FOLLOW_UP_PROMPT) ? null : promptIndex
+  let trailingLines = 0
+  for (let cursor = lastChoiceEnd; cursor < menu.length; cursor += 1) {
+    if (menu.charCodeAt(cursor) !== 10) {
+      continue
+    }
+    trailingLines += 1
+    if (trailingLines > CURSOR_APPROVAL_MAX_TRAILING_LINES) {
+      return null
+    }
+  }
+  return promptIndex
 }
 
 function findTerminalWaitBlockedSignal(

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -18146,7 +18146,7 @@ export class OrcaRuntimeService {
         paneRuntimeId: -1,
         ptyId: pty.pty.ptyId,
         rendererGraphEpoch: this.rendererGraphEpoch,
-        agentWait: this.getTerminalInteractiveWait(handle)
+        agentWait: await this.getTerminalInteractiveWait(handle)
       }
     }
     const graphEpoch = this.captureReadyGraphEpoch()
@@ -18167,7 +18167,7 @@ export class OrcaRuntimeService {
       paneRuntimeId: leaf.paneRuntimeId,
       ptyId: leaf.ptyId,
       rendererGraphEpoch: this.rendererGraphEpoch,
-      agentWait: this.getTerminalInteractiveWait(handle)
+      agentWait: await this.getTerminalInteractiveWait(handle)
     }
   }
 
@@ -18535,19 +18535,15 @@ export class OrcaRuntimeService {
       terminal.titleStatus !== null &&
       terminal.titleStatus !== 'permission' &&
       !isOpenCodeNativeTitle(terminal.title) &&
-      // Why exempt: cursor-agent keeps its braille spinner in the title while an approval
-      // waits, so a "working" title there is not evidence of progress. The approval menu
-      // proves its own dismissal (the follow-up input line returning), so unlike the
-      // startup modals it needs no title-based staleness proxy.
+      // Why exempt: cursor-agent keeps spinning in its title while an approval waits, so a
+      // "working" title there is not evidence of progress.
       blockedByWaitText !== 'agent-approval-prompt'
     if (liveTitleClearsBlockedText && lifecycle?.status !== terminal.titleStatus) {
       return null
     }
-    // Why this reason skips the timestamps below: they exist to date a prompt whose text
-    // survives in scrollback forever, and the approval menu is only matched while it still
-    // owns the bottom of the screen — that is the dating. Without the exemption a tail
-    // restored from history, which carries no waitBlockedAt, would report a live dialog as
-    // nothing at all, exactly across the app restart an unattended run has to survive.
+    // Why no timestamp: the menu is only matched while it still owns the bottom of the screen,
+    // which is the dating. Requiring one would lose a dialog restored from history, across the
+    // app restart an unattended run has to survive.
     if (blockedByWaitText === 'agent-approval-prompt') {
       return blockedByWaitText
     }
@@ -18565,35 +18561,26 @@ export class OrcaRuntimeService {
   }
 
   /** Why: "blocked on a human" is the one worker state a coordinator cannot infer — silence
-   *  covers it, a long tool call, and a wedged process alike. Same evidence fusion
-   *  getTerminalAgentStatus uses for its `permission` verdict, minus the async foreground
-   *  probe, so a per-lane read stays a synchronous map lookup plus one tail scan.
-   *  Null means "nothing proves a wait", never "proven not waiting".
-   *
-   *  Known blind spot, inherited from that shared verdict rather than added here: a tail
-   *  restored from terminal history carries no waitBlockedAt (see applyRestoredTerminalTailSeed),
-   *  so a prompt that only ever appeared in restored bytes reports nothing until the next live
-   *  chunk. Reversing that would resurrect long-answered prompts on every restore, which costs
-   *  more than the miss — a blocked pane that receives any byte recovers on its own. */
-  getTerminalInteractiveWait(handle: string): RuntimeTerminalInteractiveWait | null {
+   *  covers it, a long tool call, and a wedged process alike. Null means "nothing proves a
+   *  wait", never "proven not waiting". */
+  async getTerminalInteractiveWait(handle: string): Promise<RuntimeTerminalInteractiveWait | null> {
     let ptyId: string
     let terminal: TerminalAgentStatusSnapshot
     try {
       ptyId = this.getTerminalAgentStatusPtyId(handle)
       terminal = this.getTerminalAgentStatusSnapshot(handle, ptyId)
     } catch {
-      // Why: an unreadable pane is unknown. Reporting "not waiting" would be the exact
-      // false negative this field exists to remove.
+      // An unreadable pane is unknown; "not waiting" would be the false negative this removes.
       return null
     }
     const explicitStatus = this.getFreshExplicitAgentStatusForHandle(handle)
-    const lifecycle = this.agentPromptLifecycleByPtyId.get(ptyId)
     const promptReason = this.resolveAuthoritativeTerminalWaitPermission(
       terminal,
       explicitStatus,
-      lifecycle
+      this.agentPromptLifecycleByPtyId.get(ptyId)
     )
     if (promptReason) {
+      // A matched prompt is self-proving: it is on this pane's screen now.
       return {
         source: 'prompt-text',
         reason: promptReason,
@@ -18603,15 +18590,16 @@ export class OrcaRuntimeService {
     if (terminal.titleStatus === 'permission' && terminal.titleStatusIsLive) {
       return { source: 'title' }
     }
-    // Why the title check: a shell prompt title proves the agent no longer owns the pane,
-    // so a retained hook row must not keep reporting its last permission state.
-    if (
-      explicitStatus?.status === 'permission' &&
-      !terminalTitleBlocksExplicitAgentStatus(terminal.title)
-    ) {
-      return { source: 'hook', since: explicitStatus.updatedAt }
+    if (explicitStatus?.status !== 'permission') {
+      return null
     }
-    return null
+    // Why the extra round trip for hook evidence only: a hook row outlives its agent by up to
+    // AGENT_STATUS_STALE_AFTER_MS, and only the shared verdict proves an agent still owns this
+    // PTY — a shell that took the pane back rarely leaves a title we can recognize as one.
+    const status = await this.getTerminalAgentStatus(handle).catch(() => null)
+    return status?.isRunningAgent === true && status.status === 'permission'
+      ? { source: 'hook', since: explicitStatus.updatedAt }
+      : null
   }
 
   private async terminalHasShellForegroundProcess(handle: string, ptyId: string): Promise<boolean> {
@@ -39566,21 +39554,17 @@ function isTerminalWaitWhitespace(value: string, index: number): boolean {
 const TERMINAL_WAIT_BLOCKED_SENTINEL_RE =
   /update available|choose working directory to|codex just got an upgrade|hooks need review|do you trust|trust this|trusted workspace|press enter to (?:confirm|continue|view|insert)|press t to trust|permission required|requires permission|allow once|allow always|run this command\?/i
 
-// Why cursor-agent needs a text match at all: its hook set (beforeSubmitPrompt, preToolUse,
-// beforeShellExecution, beforeMCPExecution, postToolUse, afterAgentResponse, stop) has no
-// approval event, and beforeShellExecution fires identically for auto-allowed commands, so
-// the rendered menu is the only authority that separates "awaiting a human" from "running".
-// Match the key-bound choices, not the prose above them, so wording changes don't matter.
+// Why text at all: cursor-agent's hook set has no approval event and beforeShellExecution
+// fires for auto-allowed commands too, so the menu is the only authority. Match the key-bound
+// choices rather than the prose above them.
 const CURSOR_APPROVAL_CHOICE_MARKERS = [
   'run (once)',
   'to allowlist?',
   'run everything',
   'skip & tell the agent'
 ]
-// Why the tail must end on the menu: an answered menu keeps sitting in scrollback, and a
-// stale hit here is not merely noisy — it fails tui-idle and refuses prompt injection. A live
-// dialog owns the bottom of the screen, so the last choice may sit at most one line above the
-// end, which tolerates a trailing partial line mid-redraw without admitting scrollback.
+// Why bounded: an answered menu stays in scrollback, and a stale hit fails tui-idle and
+// refuses prompt injection. One line of slack covers a partial line mid-redraw.
 const CURSOR_APPROVAL_MAX_TRAILING_LINES = 1
 
 function findCursorApprovalPromptIndex(normalized: string): number | null {

--- a/src/main/runtime/rpc/methods/orchestration-federation-control.ts
+++ b/src/main/runtime/rpc/methods/orchestration-federation-control.ts
@@ -42,7 +42,7 @@ export const ORCHESTRATION_FEDERATION_CONTROL_METHODS: RpcMethod[] = [
           status: observation.status,
           exactWorker: observation.exact,
           ...(observation.reason ? { reason: observation.reason } : {}),
-          agentWait: observation.agentWait ?? null
+          ...(observation.agentWait !== undefined ? { agentWait: observation.agentWait } : {})
         }
       }
     }
@@ -242,7 +242,7 @@ async function inspectRemoteAttachment(
   // iterates registered providers, so a dropped relay clears `connected` for
   // every remote PTY at once. Lost contact is not a death certificate.
   // Why reused: showTerminal above already scanned this pane's tail for the same verdict.
-  const agentWait = terminal.agentWait ?? null
+  const agentWait = terminal.agentWait
   const verdict = runtime.getTerminalLivenessVerdict?.(attachment.terminal_handle) ?? null
   if (verdict?.status === 'unverifiable') {
     return { terminal, exact, status: 'unverifiable', reason: verdict.reason, agentWait }

--- a/src/main/runtime/rpc/methods/orchestration-federation-control.ts
+++ b/src/main/runtime/rpc/methods/orchestration-federation-control.ts
@@ -241,7 +241,8 @@ async function inspectRemoteAttachment(
   // Why: the same rule as the local worker observation — the inventory only
   // iterates registered providers, so a dropped relay clears `connected` for
   // every remote PTY at once. Lost contact is not a death certificate.
-  const agentWait = runtime.getTerminalInteractiveWait?.(attachment.terminal_handle) ?? null
+  // Why reused: showTerminal above already scanned this pane's tail for the same verdict.
+  const agentWait = terminal.agentWait ?? null
   const verdict = runtime.getTerminalLivenessVerdict?.(attachment.terminal_handle) ?? null
   if (verdict?.status === 'unverifiable') {
     return { terminal, exact, status: 'unverifiable', reason: verdict.reason, agentWait }

--- a/src/main/runtime/rpc/methods/orchestration-federation-control.ts
+++ b/src/main/runtime/rpc/methods/orchestration-federation-control.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import { ORCHESTRATION_WORKER_READ_SOURCES } from '../../../../shared/orchestration-worker-output'
+import type { RuntimeTerminalInteractiveWait } from '../../../../shared/runtime-types'
 import type { OrcaRuntimeService } from '../../orca-runtime'
 import { OrchestrationError } from '../../orchestration/orchestration-error'
 import type { RemoteDispatchAttachmentRow } from '../../orchestration/types'
@@ -40,7 +41,8 @@ export const ORCHESTRATION_FEDERATION_CONTROL_METHODS: RpcMethod[] = [
         observation: {
           status: observation.status,
           exactWorker: observation.exact,
-          ...(observation.reason ? { reason: observation.reason } : {})
+          ...(observation.reason ? { reason: observation.reason } : {}),
+          agentWait: observation.agentWait ?? null
         }
       }
     }
@@ -216,6 +218,8 @@ async function inspectRemoteAttachment(
   status: 'unattached' | 'missing' | 'identity_changed' | 'live' | 'exited' | 'unverifiable'
   /** Set with `unverifiable`; names what we lost contact with. */
   reason?: string
+  /** Set only on a proven-exact attachment parked on a prompt that needs a human. */
+  agentWait?: RuntimeTerminalInteractiveWait | null
 }> {
   const db = runtime.getOrchestrationDb()
   const attachment = db.getRemoteDispatchAttachment(dispatchId)
@@ -237,14 +241,16 @@ async function inspectRemoteAttachment(
   // Why: the same rule as the local worker observation — the inventory only
   // iterates registered providers, so a dropped relay clears `connected` for
   // every remote PTY at once. Lost contact is not a death certificate.
+  const agentWait = runtime.getTerminalInteractiveWait?.(attachment.terminal_handle) ?? null
   const verdict = runtime.getTerminalLivenessVerdict?.(attachment.terminal_handle) ?? null
   if (verdict?.status === 'unverifiable') {
-    return { terminal, exact, status: 'unverifiable', reason: verdict.reason }
+    return { terminal, exact, status: 'unverifiable', reason: verdict.reason, agentWait }
   }
   return {
     terminal,
     exact,
-    status: verdict?.status !== 'live' && terminal.connected === false ? 'exited' : 'live'
+    status: verdict?.status !== 'live' && terminal.connected === false ? 'exited' : 'live',
+    agentWait
   }
 }
 

--- a/src/main/runtime/rpc/methods/orchestration-worker-control.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-control.ts
@@ -142,9 +142,10 @@ export const ORCHESTRATION_WORKER_CONTROL_METHODS: RpcMethod[] = [
           exactWorker: observation.exact,
           // Why: a bare `unverifiable` is not actionable without naming what we lost.
           ...(observation.reason ? { reason: observation.reason } : {}),
-          // Why always present: a coordinator polling this field must be able to tell
-          // "no wait" from "this host is too old to know", and absence is the old host.
-          agentWait: observation.agentWait ?? null
+          // Why conditional: a present null must mean "looked, nothing waiting". An
+          // unattached, missing or identity-changed worker was never looked at, and saying
+          // null there is the false negative this field exists to remove.
+          ...(observation.agentWait !== undefined ? { agentWait: observation.agentWait } : {})
         },
         terminalResource: resource ? exposeWorkerTerminalResource(resource) : null
       }

--- a/src/main/runtime/rpc/methods/orchestration-worker-control.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-control.ts
@@ -141,7 +141,10 @@ export const ORCHESTRATION_WORKER_CONTROL_METHODS: RpcMethod[] = [
           status: observation.status,
           exactWorker: observation.exact,
           // Why: a bare `unverifiable` is not actionable without naming what we lost.
-          ...(observation.reason ? { reason: observation.reason } : {})
+          ...(observation.reason ? { reason: observation.reason } : {}),
+          // Why always present: a coordinator polling this field must be able to tell
+          // "no wait" from "this host is too old to know", and absence is the old host.
+          agentWait: observation.agentWait ?? null
         },
         terminalResource: resource ? exposeWorkerTerminalResource(resource) : null
       }

--- a/src/main/runtime/rpc/methods/orchestration-worker-interactive-wait.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-interactive-wait.test.ts
@@ -1,7 +1,5 @@
-// STA-3714 / STA-4513: `worker-show` is the per-lane call a coordinator makes, and it
-// reported a worker parked on a human prompt exactly the same as one mid tool call.
-// Deliberately unmocked below the RPC: the runtime, its PTY tail, and the detector all run,
-// so this fails if the prompt scan, the observation plumbing, or the RPC shape regresses.
+// `worker-show` must distinguish a worker parked on a human prompt (STA-3714, STA-4513).
+// Deliberately unmocked below the RPC so detector, plumbing, and RPC shape are all covered.
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -41,7 +39,7 @@ describe('worker-show interactive wait (STA-3714, STA-4513)', () => {
 
   afterEach(() => db?.close())
 
-  async function showWorkerPaneServing(paneOutput: string) {
+  async function showWorkerPaneServing(paneOutput: string, opts?: { breakIdentity?: boolean }) {
     const runtime = new OrcaRuntimeService(null)
     const internals = runtime as unknown as {
       resolveTerminalWorkspaceLaunchScope: (selector: string) => Promise<unknown>
@@ -107,9 +105,14 @@ describe('worker-show interactive wait (STA-3714, STA-4513)', () => {
       terminal.handle,
       paneKey,
       'launch-hash',
-      incarnation
+      // A dispatch recorded against a process that has since been replaced.
+      opts?.breakIdentity === true ? `${incarnation}:replaced` : incarnation
     )
-    db.mintDispatchCapability({ dispatchId: dispatch.id, paneKey, processIncarnation: incarnation })
+    db.mintDispatchCapability({
+      dispatchId: dispatch.id,
+      paneKey,
+      processIncarnation: opts?.breakIdentity === true ? `${incarnation}:replaced` : incarnation
+    })
 
     const method = workerShowMethod()
     return method.handler(method.params?.parse({ dispatch: dispatch.id }), { runtime })
@@ -136,6 +139,17 @@ describe('worker-show interactive wait (STA-3714, STA-4513)', () => {
     const result = await showWorkerPaneServing(fixture('cursor-agent-long-tool-call'))
 
     expect(result).toMatchObject({ observation: { exactWorker: true, agentWait: null } })
+  })
+
+  it('omits the field entirely for a worker it could not verify', async () => {
+    // Why not null: null is a claim that Orca looked. A replaced process is never looked at,
+    // and reporting "no wait" there is the false negative this field exists to remove.
+    const result = (await showWorkerPaneServing(fixture('cursor-agent-approval-prompt'), {
+      breakIdentity: true
+    })) as { observation: Record<string, unknown> }
+
+    expect(result.observation.exactWorker).toBe(false)
+    expect('agentWait' in result.observation).toBe(false)
   })
 
   it('agrees with the terminal payload it is derived from', async () => {

--- a/src/main/runtime/rpc/methods/orchestration-worker-interactive-wait.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-interactive-wait.test.ts
@@ -1,13 +1,30 @@
 // STA-3714 / STA-4513: `worker-show` is the per-lane call a coordinator makes, and it
 // reported a worker parked on a human prompt exactly the same as one mid tool call.
+// Deliberately unmocked below the RPC: the runtime, its PTY tail, and the detector all run,
+// so this fails if the prompt scan, the observation plumbing, or the RPC shape regresses.
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { OrcaRuntimeService } from '../../orca-runtime'
 import { OrchestrationDb } from '../../orchestration/db'
 import { ORCHESTRATION_METHODS } from './orchestration'
 
-const WORKER_HANDLE = 'term_worker'
-const WORKER_PANE_KEY = 'tab_worker:leaf_worker'
-const WORKER_INCARNATION = 'runtime_test:term_worker:1'
+vi.mock('electron', () => ({
+  BrowserWindow: { fromId: vi.fn(() => null) },
+  webContents: { fromId: vi.fn(() => null) },
+  ipcMain: { on: vi.fn(), removeListener: vi.fn() },
+  app: { getPath: vi.fn(() => '/tmp') }
+}))
+
+const LEAF_ID = '22222222-2222-4222-8222-222222222222'
+const TAB_ID = 'tab-worker'
+const WORKTREE_ID = 'wt-worker'
+const PTY_ID = 'pty-worker'
+
+// Captured verbatim from cursor-agent 2026.08.11-e8db854 driven through Orca.
+function fixture(name: string): string {
+  return readFileSync(join(__dirname, '../../__fixtures__', `${name}.txt`), 'utf8')
+}
 
 function workerShowMethod() {
   const method = ORCHESTRATION_METHODS.find(
@@ -24,78 +41,109 @@ describe('worker-show interactive wait (STA-3714, STA-4513)', () => {
 
   afterEach(() => db?.close())
 
-  async function showInjectedWorker(
-    agentWait: ReturnType<OrcaRuntimeService['getTerminalInteractiveWait']>
-  ) {
-    db = new OrchestrationDb(':memory:')
-    const runtime = new OrcaRuntimeService()
-    runtime.setOrchestrationDb(db)
-    vi.spyOn(runtime, 'showTerminal').mockResolvedValue({
-      handle: WORKER_HANDLE,
-      connected: true,
-      status: 'running'
-    } as never)
-    vi.spyOn(runtime, 'getTerminalPaneKey').mockReturnValue(WORKER_PANE_KEY)
-    vi.spyOn(runtime, 'getTerminalProcessIncarnation').mockReturnValue(WORKER_INCARNATION)
-    vi.spyOn(runtime, 'getTerminalLivenessVerdict').mockReturnValue({
-      status: 'live',
-      ptyIds: [WORKER_INCARNATION]
+  async function showWorkerPaneServing(paneOutput: string) {
+    const runtime = new OrcaRuntimeService(null)
+    const internals = runtime as unknown as {
+      resolveTerminalWorkspaceLaunchScope: (selector: string) => Promise<unknown>
+    }
+    vi.spyOn(internals, 'resolveTerminalWorkspaceLaunchScope').mockResolvedValue({
+      id: WORKTREE_ID,
+      path: '/repo/app',
+      connectionId: null,
+      repo: null,
+      folderWorkspace: null
     })
-    const interactiveWait = vi
-      .spyOn(runtime, 'getTerminalInteractiveWait')
-      .mockReturnValue(agentWait)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: PTY_ID, incarnationId: 'inc-1' }),
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => 'cursor-agent'
+    })
+    const terminal = await runtime.createTerminal(`id:${WORKTREE_ID}`, {
+      tabId: TAB_ID,
+      leafId: LEAF_ID,
+      title: 'worker'
+    })
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, {
+      tabs: [
+        {
+          tabId: TAB_ID,
+          worktreeId: WORKTREE_ID,
+          title: 'worker',
+          activeLeafId: LEAF_ID,
+          layout: null
+        }
+      ],
+      leaves: [
+        {
+          tabId: TAB_ID,
+          worktreeId: WORKTREE_ID,
+          leafId: LEAF_ID,
+          paneRuntimeId: 1,
+          ptyId: PTY_ID,
+          // cursor-agent's spinner title, identical whether it runs or waits.
+          paneTitle: '⠇ Cursor Agent'
+        }
+      ]
+    })
+    runtime.onPtyData(PTY_ID, paneOutput, Date.now())
 
+    db = new OrchestrationDb(':memory:')
+    runtime.setOrchestrationDb(db)
     const run = db.createRun({
       objective: 'supervise lanes',
       coordinatorHandle: 'term_coord',
       coordinatorPaneKey: 'tab_coord:leaf_coord'
     })
     const task = db.createTask({ spec: 'run the suite', runId: run.id })
+    const paneKey = runtime.getTerminalPaneKey(terminal.handle)
+    const incarnation = runtime.getTerminalProcessIncarnation(terminal.handle)
+    if (!paneKey || !incarnation) {
+      throw new Error('Runtime did not expose the worker pane identity.')
+    }
     const dispatch = db.createDispatchContext(
       task.id,
-      WORKER_HANDLE,
-      WORKER_PANE_KEY,
+      terminal.handle,
+      paneKey,
       'launch-hash',
-      WORKER_INCARNATION
+      incarnation
     )
-    db.mintDispatchCapability({
-      dispatchId: dispatch.id,
-      paneKey: WORKER_PANE_KEY,
-      processIncarnation: WORKER_INCARNATION
-    })
+    db.mintDispatchCapability({ dispatchId: dispatch.id, paneKey, processIncarnation: incarnation })
+
     const method = workerShowMethod()
-    const result = await method.handler(method.params?.parse({ dispatch: dispatch.id }), {
-      runtime
-    })
-    return { result, interactiveWait }
+    return method.handler(method.params?.parse({ dispatch: dispatch.id }), { runtime })
   }
 
   it('names the pending prompt on the observation a coordinator polls', async () => {
-    const { result, interactiveWait } = await showInjectedWorker({
-      source: 'prompt-text',
-      reason: 'agent-approval-prompt',
-      since: 1_700_000_000_000
-    })
+    const result = await showWorkerPaneServing(fixture('cursor-agent-approval-prompt'))
 
     expect(result).toMatchObject({
       observation: {
-        status: 'live',
         exactWorker: true,
         agentWait: {
           source: 'prompt-text',
           reason: 'agent-approval-prompt',
-          since: 1_700_000_000_000
+          since: expect.any(Number)
         }
       }
     })
-    expect(interactiveWait).toHaveBeenCalledWith(WORKER_HANDLE)
   })
 
-  it('reports an explicit null for a lane that is merely working', async () => {
+  it('reports an explicit null for the same lane inside a long tool call', async () => {
     // Why an explicit null and not an omitted key: a coordinator has to tell "not waiting"
     // from "this host is too old to know", and only absence may mean the latter.
-    const { result } = await showInjectedWorker(null)
+    const result = await showWorkerPaneServing(fixture('cursor-agent-long-tool-call'))
 
-    expect(result).toMatchObject({ observation: { status: 'live', agentWait: null } })
+    expect(result).toMatchObject({ observation: { exactWorker: true, agentWait: null } })
+  })
+
+  it('agrees with the terminal payload it is derived from', async () => {
+    const result = (await showWorkerPaneServing(fixture('cursor-agent-approval-prompt'))) as {
+      terminal: { agentWait: unknown } | null
+      observation: { agentWait: unknown }
+    }
+
+    expect(result.observation.agentWait).toEqual(result.terminal?.agentWait)
   })
 })

--- a/src/main/runtime/rpc/methods/orchestration-worker-interactive-wait.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-interactive-wait.test.ts
@@ -1,0 +1,101 @@
+// STA-3714 / STA-4513: `worker-show` is the per-lane call a coordinator makes, and it
+// reported a worker parked on a human prompt exactly the same as one mid tool call.
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { OrcaRuntimeService } from '../../orca-runtime'
+import { OrchestrationDb } from '../../orchestration/db'
+import { ORCHESTRATION_METHODS } from './orchestration'
+
+const WORKER_HANDLE = 'term_worker'
+const WORKER_PANE_KEY = 'tab_worker:leaf_worker'
+const WORKER_INCARNATION = 'runtime_test:term_worker:1'
+
+function workerShowMethod() {
+  const method = ORCHESTRATION_METHODS.find(
+    (candidate) => candidate.name === 'orchestration.workerShow'
+  )
+  if (!method) {
+    throw new Error('Missing method orchestration.workerShow')
+  }
+  return method
+}
+
+describe('worker-show interactive wait (STA-3714, STA-4513)', () => {
+  let db: OrchestrationDb | undefined
+
+  afterEach(() => db?.close())
+
+  async function showInjectedWorker(
+    agentWait: ReturnType<OrcaRuntimeService['getTerminalInteractiveWait']>
+  ) {
+    db = new OrchestrationDb(':memory:')
+    const runtime = new OrcaRuntimeService()
+    runtime.setOrchestrationDb(db)
+    vi.spyOn(runtime, 'showTerminal').mockResolvedValue({
+      handle: WORKER_HANDLE,
+      connected: true,
+      status: 'running'
+    } as never)
+    vi.spyOn(runtime, 'getTerminalPaneKey').mockReturnValue(WORKER_PANE_KEY)
+    vi.spyOn(runtime, 'getTerminalProcessIncarnation').mockReturnValue(WORKER_INCARNATION)
+    vi.spyOn(runtime, 'getTerminalLivenessVerdict').mockReturnValue({
+      status: 'live',
+      ptyIds: [WORKER_INCARNATION]
+    })
+    const interactiveWait = vi
+      .spyOn(runtime, 'getTerminalInteractiveWait')
+      .mockReturnValue(agentWait)
+
+    const run = db.createRun({
+      objective: 'supervise lanes',
+      coordinatorHandle: 'term_coord',
+      coordinatorPaneKey: 'tab_coord:leaf_coord'
+    })
+    const task = db.createTask({ spec: 'run the suite', runId: run.id })
+    const dispatch = db.createDispatchContext(
+      task.id,
+      WORKER_HANDLE,
+      WORKER_PANE_KEY,
+      'launch-hash',
+      WORKER_INCARNATION
+    )
+    db.mintDispatchCapability({
+      dispatchId: dispatch.id,
+      paneKey: WORKER_PANE_KEY,
+      processIncarnation: WORKER_INCARNATION
+    })
+    const method = workerShowMethod()
+    const result = await method.handler(method.params?.parse({ dispatch: dispatch.id }), {
+      runtime
+    })
+    return { result, interactiveWait }
+  }
+
+  it('names the pending prompt on the observation a coordinator polls', async () => {
+    const { result, interactiveWait } = await showInjectedWorker({
+      source: 'prompt-text',
+      reason: 'agent-approval-prompt',
+      since: 1_700_000_000_000
+    })
+
+    expect(result).toMatchObject({
+      observation: {
+        status: 'live',
+        exactWorker: true,
+        agentWait: {
+          source: 'prompt-text',
+          reason: 'agent-approval-prompt',
+          since: 1_700_000_000_000
+        }
+      }
+    })
+    expect(interactiveWait).toHaveBeenCalledWith(WORKER_HANDLE)
+  })
+
+  it('reports an explicit null for a lane that is merely working', async () => {
+    // Why an explicit null and not an omitted key: a coordinator has to tell "not waiting"
+    // from "this host is too old to know", and only absence may mean the latter.
+    const { result } = await showInjectedWorker(null)
+
+    expect(result).toMatchObject({ observation: { status: 'live', agentWait: null } })
+  })
+})

--- a/src/main/runtime/rpc/methods/orchestration-worker-interactive-wait.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-interactive-wait.test.ts
@@ -158,6 +158,11 @@ describe('worker-show interactive wait (STA-3714, STA-4513)', () => {
       observation: { agentWait: unknown }
     }
 
+    // Why the explicit shape first: comparing the two fields alone passes when both are absent.
+    expect(result.observation.agentWait).toMatchObject({
+      source: 'prompt-text',
+      reason: 'agent-approval-prompt'
+    })
     expect(result.observation.agentWait).toEqual(result.terminal?.agentWait)
   })
 })

--- a/src/main/runtime/rpc/methods/orchestration-worker-observation.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-observation.ts
@@ -1,3 +1,4 @@
+import type { RuntimeTerminalInteractiveWait } from '../../../../shared/runtime-types'
 import type { OrcaRuntimeService } from '../../orca-runtime'
 import type { OrchestrationDb } from '../../orchestration/db'
 import { OrchestrationError } from '../../orchestration/orchestration-error'
@@ -17,6 +18,8 @@ export async function inspectWorkerTerminal(
   status: 'unattached' | 'missing' | 'identity_changed' | 'live' | 'exited' | 'unverifiable'
   /** Set with `unverifiable`; names what we lost contact with. */
   reason?: string
+  /** Set only on a proven-exact worker parked on a prompt that needs a human. */
+  agentWait?: RuntimeTerminalInteractiveWait | null
 }> {
   const worker = db.getWorkerDispatch(dispatchId)
   const terminalHandle =
@@ -39,17 +42,21 @@ export async function inspectWorkerTerminal(
   // Why: the aggregate inventory only iterates registered providers, so a dropped
   // relay clears `connected` for every remote PTY at once. Lost contact is not a
   // death certificate, and the verdict is the only field that can tell them apart.
+  // Why exact-gated: an interactive wait is a claim about this Dispatch's own agent, and a
+  // replaced process's prompt would attribute another lane's blocker to this worker.
+  const agentWait = runtime.getTerminalInteractiveWait?.(terminalHandle) ?? null
   const verdict = runtime.getTerminalLivenessVerdict?.(terminalHandle) ?? null
   if (verdict?.status === 'unverifiable') {
-    return { terminal, exact, status: 'unverifiable', reason: verdict.reason }
+    return { terminal, exact, status: 'unverifiable', reason: verdict.reason, agentWait }
   }
   if (verdict?.status === 'live') {
-    return { terminal, exact, status: 'live' }
+    return { terminal, exact, status: 'live', agentWait }
   }
   return {
     terminal,
     exact,
-    status: terminal.connected === false ? 'exited' : 'live'
+    status: terminal.connected === false ? 'exited' : 'live',
+    agentWait
   }
 }
 
@@ -84,7 +91,8 @@ export async function showContextOnlyWorker(
     observation: {
       status: observation.status,
       exactWorker: observation.exact,
-      ...(observation.reason ? { reason: observation.reason } : {})
+      ...(observation.reason ? { reason: observation.reason } : {}),
+      agentWait: observation.agentWait ?? null
     },
     terminalResource: null
   }
@@ -129,7 +137,13 @@ export async function callFederatedWorkerShow(
     residualResources: unknown[]
   }
   terminal: unknown
-  observation: { status: string; exactWorker: boolean; reason?: string }
+  observation: {
+    status: string
+    exactWorker: boolean
+    reason?: string
+    /** Absent from servers that predate the field; absence is unknown, not "not waiting". */
+    agentWait?: RuntimeTerminalInteractiveWait | null
+  }
 }> {
   return (await runtime.callOrchestrationWorkerServer(
     federated.environment_id,

--- a/src/main/runtime/rpc/methods/orchestration-worker-observation.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-observation.ts
@@ -46,7 +46,7 @@ export async function inspectWorkerTerminal(
   // tail for the same verdict, and a second scan could also disagree with the one it published.
   // Exact-gated by the early return above: a replaced process's prompt would attribute another
   // lane's blocker to this worker.
-  const agentWait = terminal.agentWait ?? null
+  const agentWait = terminal.agentWait
   const verdict = runtime.getTerminalLivenessVerdict?.(terminalHandle) ?? null
   if (verdict?.status === 'unverifiable') {
     return { terminal, exact, status: 'unverifiable', reason: verdict.reason, agentWait }
@@ -94,7 +94,7 @@ export async function showContextOnlyWorker(
       status: observation.status,
       exactWorker: observation.exact,
       ...(observation.reason ? { reason: observation.reason } : {}),
-      agentWait: observation.agentWait ?? null
+      ...(observation.agentWait !== undefined ? { agentWait: observation.agentWait } : {})
     },
     terminalResource: null
   }

--- a/src/main/runtime/rpc/methods/orchestration-worker-observation.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-observation.ts
@@ -42,9 +42,11 @@ export async function inspectWorkerTerminal(
   // Why: the aggregate inventory only iterates registered providers, so a dropped
   // relay clears `connected` for every remote PTY at once. Lost contact is not a
   // death certificate, and the verdict is the only field that can tell them apart.
-  // Why exact-gated: an interactive wait is a claim about this Dispatch's own agent, and a
-  // replaced process's prompt would attribute another lane's blocker to this worker.
-  const agentWait = runtime.getTerminalInteractiveWait?.(terminalHandle) ?? null
+  // Why reused rather than re-derived: showTerminal already scanned this pane's retained
+  // tail for the same verdict, and a second scan could also disagree with the one it published.
+  // Exact-gated by the early return above: a replaced process's prompt would attribute another
+  // lane's blocker to this worker.
+  const agentWait = terminal.agentWait ?? null
   const verdict = runtime.getTerminalLivenessVerdict?.(terminalHandle) ?? null
   if (verdict?.status === 'unverifiable') {
     return { terminal, exact, status: 'unverifiable', reason: verdict.reason, agentWait }

--- a/src/main/runtime/terminal-interactive-wait-visibility.test.ts
+++ b/src/main/runtime/terminal-interactive-wait-visibility.test.ts
@@ -373,6 +373,21 @@ describe('terminal interactive-wait visibility (STA-4513, STA-3714)', () => {
     await expect(runtime.getTerminalInteractiveWait(handle)).resolves.toBeNull()
   })
 
+  it('stops reporting a wait once the pane is no longer running', async () => {
+    // Why: the menu stays at the bottom of a dead pane's tail forever. A worker whose process
+    // is gone needs intervention, not an answer, so it must not read as blocked on a human.
+    const { runtime, handle } = await createPane({
+      paneTitle: CURSOR_TITLE,
+      foregroundProcess: 'cursor-agent',
+      data: CURSOR_APPROVAL
+    })
+    await expect(runtime.getTerminalInteractiveWait(handle)).resolves.not.toBeNull()
+
+    runtime.onPtyExit(PTY_ID, 0)
+
+    await expect(runtime.getTerminalInteractiveWait(handle)).resolves.toBeNull()
+  })
+
   it('answers null rather than "not waiting" for a pane it cannot read', async () => {
     const { runtime } = await createPane({
       paneTitle: CURSOR_TITLE,

--- a/src/main/runtime/terminal-interactive-wait-visibility.test.ts
+++ b/src/main/runtime/terminal-interactive-wait-visibility.test.ts
@@ -47,6 +47,7 @@ async function createPane(options: {
   connectionId?: string
   /** Simulates a PTY controller whose foreground probe never settles. */
   foregroundProbeHangs?: boolean
+  onForegroundProbe?: () => void
 }): Promise<{ runtime: OrcaRuntimeService; handle: string }> {
   const runtime = new OrcaRuntimeService(null)
   const internals = runtime as unknown as {
@@ -63,10 +64,12 @@ async function createPane(options: {
     spawn: vi.fn().mockResolvedValue({ id: PTY_ID, incarnationId: 'inc-1' }),
     write: () => true,
     kill: () => true,
-    getForegroundProcess:
-      options.foregroundProbeHangs === true
-        ? () => new Promise<string | null>(() => {})
-        : async () => options.foregroundProcess
+    getForegroundProcess: (): Promise<string | null> => {
+      options.onForegroundProbe?.()
+      return options.foregroundProbeHangs === true
+        ? new Promise<string | null>(() => {})
+        : Promise.resolve(options.foregroundProcess)
+    }
   })
   const terminal = await runtime.createTerminal(`id:${WORKTREE_ID}`, {
     tabId: TAB_ID,
@@ -409,6 +412,55 @@ describe('terminal interactive-wait visibility (STA-4513, STA-3714)', () => {
     runtime.onPtyExit(PTY_ID, 0)
 
     await expect(runtime.getTerminalInteractiveWait(handle)).resolves.toBeUndefined()
+  })
+
+  it('does not accrue a probe per poll while the foreground probe wedges', async () => {
+    // Why: the timeout abandons the wait, not the request. Without single-flighting, a
+    // coordinator watching a wedged remote host adds one live probe on every poll.
+    let probes = 0
+    const { runtime, handle } = await createPane({
+      paneTitle: '✻ Claude Code',
+      foregroundProcess: 'claude',
+      data: agentStatusOsc('waiting'),
+      onForegroundProbe: () => {
+        probes += 1
+      },
+      foregroundProbeHangs: true
+    })
+
+    await Promise.all([
+      runtime.getTerminalInteractiveWait(handle),
+      runtime.getTerminalInteractiveWait(handle),
+      runtime.getTerminalInteractiveWait(handle)
+    ])
+
+    expect(probes).toBe(1)
+  }, 20_000)
+
+  it('accepts a menu whose keys are rendered as glyphs', async () => {
+    const { runtime, handle } = await createPane({
+      paneTitle: CURSOR_TITLE,
+      foregroundProcess: 'cursor-agent',
+      data: [
+        'Run this command?\n',
+        '  → Run (once) (\u21b5)\n',
+        '    Run Everything (\u21e7\u21b9)\n'
+      ].join('')
+    })
+
+    await expect(runtime.getTerminalInteractiveWait(handle)).resolves.toMatchObject({
+      reason: 'agent-approval-prompt'
+    })
+  })
+
+  it('still rejects prose that merely ends in parentheses', async () => {
+    const { runtime, handle } = await createPane({
+      paneTitle: CURSOR_TITLE,
+      foregroundProcess: 'cursor-agent',
+      data: `${CURSOR_APPROVAL}\nNext time I will suggest Run Everything (as before)\n`
+    })
+
+    await expect(runtime.getTerminalInteractiveWait(handle)).resolves.toBeNull()
   })
 
   it('leaves the wait unevaluated when the foreground probe wedges', async () => {

--- a/src/main/runtime/terminal-interactive-wait-visibility.test.ts
+++ b/src/main/runtime/terminal-interactive-wait-visibility.test.ts
@@ -45,6 +45,8 @@ async function createPane(options: {
   data: string
   /** Set for a pane whose PTY lives on an SSH host or WSL distro rather than locally. */
   connectionId?: string
+  /** Simulates a PTY controller whose foreground probe never settles. */
+  foregroundProbeHangs?: boolean
 }): Promise<{ runtime: OrcaRuntimeService; handle: string }> {
   const runtime = new OrcaRuntimeService(null)
   const internals = runtime as unknown as {
@@ -61,7 +63,10 @@ async function createPane(options: {
     spawn: vi.fn().mockResolvedValue({ id: PTY_ID, incarnationId: 'inc-1' }),
     write: () => true,
     kill: () => true,
-    getForegroundProcess: async () => options.foregroundProcess
+    getForegroundProcess:
+      options.foregroundProbeHangs === true
+        ? () => new Promise<string | null>(() => {})
+        : async () => options.foregroundProcess
   })
   const terminal = await runtime.createTerminal(`id:${WORKTREE_ID}`, {
     tabId: TAB_ID,
@@ -220,17 +225,38 @@ describe('terminal interactive-wait visibility (STA-4513, STA-3714)', () => {
       await expect(runtime.getTerminalInteractiveWait(handle)).resolves.toBeNull()
     })
 
-    it('tolerates one trailing line below a live dialog', async () => {
-      // A status footer under the dialog must not read as scrollback.
+    it('is not anchored by the agent narrating a choice after the menu', async () => {
+      // Why: matching each marker independently let prose below the answered menu carry the
+      // anchor down to the bottom of the screen and revive it.
+      const { runtime, handle } = await createPane({
+        paneTitle: CURSOR_TITLE,
+        foregroundProcess: 'cursor-agent',
+        data: `${CURSOR_APPROVAL}\nApproved. Next time I will suggest Run Everything instead.\n`
+      })
+
+      await expect(runtime.getTerminalInteractiveWait(handle)).resolves.toBeNull()
+    })
+
+    it('is not anchored by the agent narrating a choice before the menu', async () => {
+      const { runtime, handle } = await createPane({
+        paneTitle: CURSOR_TITLE,
+        foregroundProcess: 'cursor-agent',
+        data: `You can pick Run Everything or Run (once) if you prefer.\nStill thinking.\n`
+      })
+
+      await expect(runtime.getTerminalInteractiveWait(handle)).resolves.toBeNull()
+    })
+
+    it('requires the dialog to be the last thing on the screen', async () => {
+      // Not a tolerance question: one line of slack is exactly enough for the agent's own
+      // narration to revive an answered menu, and every capture of a live dialog ends on it.
       const { runtime, handle } = await createPane({
         paneTitle: CURSOR_TITLE,
         foregroundProcess: 'cursor-agent',
         data: `${CURSOR_APPROVAL}\n  Auto · 6.1%\n`
       })
 
-      await expect(runtime.getTerminalInteractiveWait(handle)).resolves.toMatchObject({
-        reason: 'agent-approval-prompt'
-      })
+      await expect(runtime.getTerminalInteractiveWait(handle)).resolves.toBeNull()
     })
 
     it('reports the same wait for a pane whose PTY is not local', async () => {
@@ -382,16 +408,31 @@ describe('terminal interactive-wait visibility (STA-4513, STA-3714)', () => {
 
     runtime.onPtyExit(PTY_ID, 0)
 
-    await expect(runtime.getTerminalInteractiveWait(handle)).resolves.toBeNull()
+    await expect(runtime.getTerminalInteractiveWait(handle)).resolves.toBeUndefined()
   })
 
-  it('answers null rather than "not waiting" for a pane it cannot read', async () => {
+  it('leaves the wait unevaluated when the foreground probe wedges', async () => {
+    // Why bounded: this probe reaches a PTY controller that can be a remote host. A wedged
+    // one must leave the wait unknown, not stall every caller of showTerminal.
+    const { runtime, handle } = await createPane({
+      paneTitle: '✻ Claude Code',
+      foregroundProcess: 'claude',
+      data: agentStatusOsc('waiting'),
+      foregroundProbeHangs: true
+    })
+
+    await expect(runtime.getTerminalInteractiveWait(handle)).resolves.toBeUndefined()
+    const show = (await runtime.showTerminal(handle)) as Record<string, unknown>
+    expect('agentWait' in show).toBe(false)
+  }, 15_000)
+
+  it('answers undefined rather than "not waiting" for a pane it cannot read', async () => {
     const { runtime } = await createPane({
       paneTitle: CURSOR_TITLE,
       foregroundProcess: 'cursor-agent',
       data: CURSOR_APPROVAL
     })
 
-    await expect(runtime.getTerminalInteractiveWait('term_does_not_exist')).resolves.toBeNull()
+    await expect(runtime.getTerminalInteractiveWait('term_does_not_exist')).resolves.toBeUndefined()
   })
 })

--- a/src/main/runtime/terminal-interactive-wait-visibility.test.ts
+++ b/src/main/runtime/terminal-interactive-wait-visibility.test.ts
@@ -1,0 +1,268 @@
+// STA-4513 / STA-3714: a worker parked on an interactive prompt must be distinguishable
+// from one that is thinking or inside a long tool call. Before this, `terminal show` and
+// `orchestration worker-show` carried no such field, and cursor-agent's approval menu was
+// not detected at all — its hook set has no approval event, so control and case reported
+// byte-identical `working` on every coordinator surface.
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import { OrcaRuntimeService } from './orca-runtime'
+
+vi.mock('electron', () => ({
+  BrowserWindow: { fromId: vi.fn(() => null) },
+  webContents: { fromId: vi.fn(() => null) },
+  ipcMain: { on: vi.fn(), removeListener: vi.fn() },
+  app: { getPath: vi.fn(() => '/tmp') }
+}))
+
+const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+const TAB_ID = 'tab-1'
+const WORKTREE_ID = 'wt-1'
+const PTY_ID = 'pty-1'
+
+// Captured verbatim from cursor-agent 2026.08.11-e8db854 driven through Orca.
+function fixture(name: string): string {
+  return readFileSync(join(__dirname, '__fixtures__', `${name}.txt`), 'utf8')
+}
+const CURSOR_APPROVAL = fixture('cursor-agent-approval-prompt')
+const CURSOR_LONG_TOOL_CALL = fixture('cursor-agent-long-tool-call')
+const CURSOR_IDLE = fixture('cursor-agent-idle-after-approval')
+
+// Claude Code 2.1.234's own trust screen, which the runtime already matched by shape.
+const CLAUDE_TRUST = [
+  'Accessing workspace:\n',
+  '/private/tmp/repo\n',
+  'Quick safety check: Is this a project you created or one you trust?\n',
+  '❯ 1. Yes, I trust this folder\n',
+  '  2. No, exit\n'
+].join('')
+
+function agentStatusOsc(state: string): string {
+  return `]9999;${JSON.stringify({ state, prompt: 'ship it', agentType: 'claude' })}`
+}
+
+async function createPane(options: {
+  paneTitle: string
+  foregroundProcess: string | null
+  data: string
+}): Promise<{ runtime: OrcaRuntimeService; handle: string }> {
+  const runtime = new OrcaRuntimeService(null)
+  const internals = runtime as unknown as {
+    resolveTerminalWorkspaceLaunchScope: (selector: string) => Promise<unknown>
+  }
+  vi.spyOn(internals, 'resolveTerminalWorkspaceLaunchScope').mockResolvedValue({
+    id: WORKTREE_ID,
+    path: '/repo/app',
+    connectionId: null,
+    repo: null,
+    folderWorkspace: null
+  })
+  runtime.setPtyController({
+    spawn: vi.fn().mockResolvedValue({ id: PTY_ID, incarnationId: 'inc-1' }),
+    write: () => true,
+    kill: () => true,
+    getForegroundProcess: async () => options.foregroundProcess
+  })
+  const terminal = await runtime.createTerminal(`id:${WORKTREE_ID}`, {
+    tabId: TAB_ID,
+    leafId: LEAF_ID,
+    title: 'Terminal'
+  })
+  runtime.attachWindow(1)
+  runtime.syncWindowGraph(1, {
+    tabs: [
+      {
+        tabId: TAB_ID,
+        worktreeId: WORKTREE_ID,
+        title: 'Terminal',
+        activeLeafId: LEAF_ID,
+        layout: null
+      }
+    ],
+    leaves: [
+      {
+        tabId: TAB_ID,
+        worktreeId: WORKTREE_ID,
+        leafId: LEAF_ID,
+        paneRuntimeId: 1,
+        ptyId: PTY_ID,
+        paneTitle: options.paneTitle
+      }
+    ]
+  })
+  runtime.onPtyData(PTY_ID, options.data, Date.now())
+  return { runtime, handle: terminal.handle }
+}
+
+// cursor-agent renders a braille spinner in its OSC title while it works, and Orca reads
+// that as `working`; the title is identical whether it is running a command or waiting.
+const CURSOR_TITLE = '⠇ Cursor Agent'
+
+describe('terminal interactive-wait visibility (STA-4513, STA-3714)', () => {
+  describe('cursor-agent approval menu, the case no hook reports', () => {
+    it('names the pending approval on the pane a coordinator inspects', async () => {
+      const { runtime, handle } = await createPane({
+        paneTitle: CURSOR_TITLE,
+        foregroundProcess: 'cursor-agent',
+        data: CURSOR_APPROVAL
+      })
+
+      await expect(runtime.showTerminal(handle)).resolves.toMatchObject({
+        agentWait: { source: 'prompt-text', reason: 'agent-approval-prompt' }
+      })
+      expect(runtime.getTerminalInteractiveWait(handle)).toMatchObject({
+        source: 'prompt-text',
+        reason: 'agent-approval-prompt',
+        since: expect.any(Number)
+      })
+    })
+
+    it('feeds the same permission verdict the agent-prompt guard reads', async () => {
+      // Why this matters beyond reporting: `dispatch --inject` and guarded sends refuse on a
+      // `permission` verdict, so before this the coordinator's preamble was typed straight
+      // into the approval dialog instead of being refused (the STA-2631 shape).
+      const { runtime, handle } = await createPane({
+        paneTitle: CURSOR_TITLE,
+        foregroundProcess: 'cursor-agent',
+        data: CURSOR_APPROVAL
+      })
+
+      await expect(runtime.getTerminalAgentStatus(handle)).resolves.toMatchObject({
+        isRunningAgent: true,
+        status: 'permission'
+      })
+    })
+
+    it('refuses to call the lane idle while the approval is unanswered', async () => {
+      const { runtime, handle } = await createPane({
+        paneTitle: CURSOR_TITLE,
+        foregroundProcess: 'cursor-agent',
+        data: CURSOR_APPROVAL
+      })
+
+      await expect(
+        runtime.waitForTerminal(handle, { condition: 'tui-idle', timeoutMs: 400 })
+      ).resolves.toMatchObject({ satisfied: false, blockedReason: 'agent-approval-prompt' })
+    })
+
+    it('reports no wait for the same agent inside a long tool call', async () => {
+      // The control: identical vendor, identical spinner title, a real `sleep 60` running.
+      const { runtime, handle } = await createPane({
+        paneTitle: CURSOR_TITLE,
+        foregroundProcess: 'cursor-agent',
+        data: CURSOR_LONG_TOOL_CALL
+      })
+
+      expect(runtime.getTerminalInteractiveWait(handle)).toBeNull()
+      await expect(runtime.showTerminal(handle)).resolves.toMatchObject({ agentWait: null })
+    })
+
+    it('reports no wait once the agent is idle again', async () => {
+      const { runtime, handle } = await createPane({
+        paneTitle: CURSOR_TITLE,
+        foregroundProcess: 'cursor-agent',
+        data: CURSOR_IDLE
+      })
+
+      expect(runtime.getTerminalInteractiveWait(handle)).toBeNull()
+    })
+
+    it('treats an answered menu still in scrollback as scrollback', async () => {
+      // Why: the menu is not erased on every terminal; cursor-agent's follow-up input line
+      // reappearing after it is the proof that a human already answered.
+      const { runtime, handle } = await createPane({
+        paneTitle: CURSOR_TITLE,
+        foregroundProcess: 'cursor-agent',
+        data: `${CURSOR_APPROVAL}\n${CURSOR_IDLE}`
+      })
+
+      expect(runtime.getTerminalInteractiveWait(handle)).toBeNull()
+    })
+
+    it('ignores a partial menu that names no decision keys', async () => {
+      const { runtime, handle } = await createPane({
+        paneTitle: CURSOR_TITLE,
+        foregroundProcess: 'cursor-agent',
+        data: 'The agent asked: Run this command? I said yes and it worked.\n'
+      })
+
+      expect(runtime.getTerminalInteractiveWait(handle)).toBeNull()
+    })
+  })
+
+  describe('prompts the runtime already matched but never surfaced', () => {
+    it('surfaces a startup trust screen on the pane, not only on terminal wait', async () => {
+      // A pane on its trust screen still wears Orca's tab title; the agent has set none.
+      const { runtime, handle } = await createPane({
+        paneTitle: 'sta4513-claude',
+        foregroundProcess: 'claude',
+        data: CLAUDE_TRUST
+      })
+
+      await expect(runtime.showTerminal(handle)).resolves.toMatchObject({
+        agentWait: { source: 'prompt-text', reason: 'codex-trust-workspace' }
+      })
+    })
+
+    it('still lets a live working title clear a stale startup prompt', async () => {
+      // Pins the shared authority getTerminalAgentStatus and the agent-prompt send guard
+      // already use: for the startup modals, a live non-permission title is the staleness
+      // proof, because their text survives in scrollback with no self-dismissal marker.
+      const { runtime, handle } = await createPane({
+        paneTitle: '✻ Claude Code',
+        foregroundProcess: 'claude',
+        data: CLAUDE_TRUST
+      })
+
+      expect(runtime.getTerminalInteractiveWait(handle)).toBeNull()
+    })
+  })
+
+  describe('hook-reported waits (STA-3714)', () => {
+    it('surfaces an agent-reported blocked state with hook provenance', async () => {
+      const { runtime, handle } = await createPane({
+        paneTitle: '✻ Claude Code',
+        foregroundProcess: 'claude',
+        data: agentStatusOsc('waiting')
+      })
+
+      expect(runtime.getTerminalInteractiveWait(handle)).toMatchObject({
+        source: 'hook',
+        since: expect.any(Number)
+      })
+      await expect(runtime.showTerminal(handle)).resolves.toMatchObject({
+        agentWait: { source: 'hook' }
+      })
+    })
+
+    it('reports no wait for a hook-reported working turn', async () => {
+      const { runtime, handle } = await createPane({
+        paneTitle: '✻ Claude Code',
+        foregroundProcess: 'claude',
+        data: agentStatusOsc('working')
+      })
+
+      expect(runtime.getTerminalInteractiveWait(handle)).toBeNull()
+    })
+
+    it('drops a retained permission row once a shell owns the pane', async () => {
+      const { runtime, handle } = await createPane({
+        paneTitle: 'zsh',
+        foregroundProcess: 'zsh',
+        data: agentStatusOsc('blocked')
+      })
+
+      expect(runtime.getTerminalInteractiveWait(handle)).toBeNull()
+    })
+  })
+
+  it('answers null rather than "not waiting" for a pane it cannot read', async () => {
+    const { runtime } = await createPane({
+      paneTitle: CURSOR_TITLE,
+      foregroundProcess: 'cursor-agent',
+      data: CURSOR_APPROVAL
+    })
+
+    expect(runtime.getTerminalInteractiveWait('term_does_not_exist')).toBeNull()
+  })
+})

--- a/src/main/runtime/terminal-interactive-wait-visibility.test.ts
+++ b/src/main/runtime/terminal-interactive-wait-visibility.test.ts
@@ -117,7 +117,7 @@ describe('terminal interactive-wait visibility (STA-4513, STA-3714)', () => {
       await expect(runtime.showTerminal(handle)).resolves.toMatchObject({
         agentWait: { source: 'prompt-text', reason: 'agent-approval-prompt' }
       })
-      expect(runtime.getTerminalInteractiveWait(handle)).toMatchObject({
+      await expect(runtime.getTerminalInteractiveWait(handle)).resolves.toMatchObject({
         source: 'prompt-text',
         reason: 'agent-approval-prompt',
         since: expect.any(Number)
@@ -178,7 +178,7 @@ describe('terminal interactive-wait visibility (STA-4513, STA-3714)', () => {
         data: CURSOR_LONG_TOOL_CALL
       })
 
-      expect(runtime.getTerminalInteractiveWait(handle)).toBeNull()
+      await expect(runtime.getTerminalInteractiveWait(handle)).resolves.toBeNull()
       await expect(runtime.showTerminal(handle)).resolves.toMatchObject({ agentWait: null })
     })
 
@@ -189,7 +189,7 @@ describe('terminal interactive-wait visibility (STA-4513, STA-3714)', () => {
         data: CURSOR_IDLE
       })
 
-      expect(runtime.getTerminalInteractiveWait(handle)).toBeNull()
+      await expect(runtime.getTerminalInteractiveWait(handle)).resolves.toBeNull()
     })
 
     it('treats an answered menu still in scrollback as scrollback', async () => {
@@ -201,7 +201,7 @@ describe('terminal interactive-wait visibility (STA-4513, STA-3714)', () => {
         data: `${CURSOR_APPROVAL}\n${CURSOR_IDLE}`
       })
 
-      expect(runtime.getTerminalInteractiveWait(handle)).toBeNull()
+      await expect(runtime.getTerminalInteractiveWait(handle)).resolves.toBeNull()
     })
 
     it('treats an answered menu followed by any later output as scrollback', async () => {
@@ -212,7 +212,7 @@ describe('terminal interactive-wait visibility (STA-4513, STA-3714)', () => {
         foregroundProcess: 'cursor-agent',
         data: CURSOR_APPROVAL
       })
-      expect(runtime.getTerminalInteractiveWait(handle)).not.toBeNull()
+      await expect(runtime.getTerminalInteractiveWait(handle)).resolves.not.toBeNull()
 
       runtime.onPtyData(
         PTY_ID,
@@ -220,7 +220,7 @@ describe('terminal interactive-wait visibility (STA-4513, STA-3714)', () => {
         Date.now()
       )
 
-      expect(runtime.getTerminalInteractiveWait(handle)).toBeNull()
+      await expect(runtime.getTerminalInteractiveWait(handle)).resolves.toBeNull()
     })
 
     it('tolerates one trailing line below a live dialog', async () => {
@@ -231,7 +231,7 @@ describe('terminal interactive-wait visibility (STA-4513, STA-3714)', () => {
         data: `${CURSOR_APPROVAL}\n  Auto · 6.1%\n`
       })
 
-      expect(runtime.getTerminalInteractiveWait(handle)).toMatchObject({
+      await expect(runtime.getTerminalInteractiveWait(handle)).resolves.toMatchObject({
         reason: 'agent-approval-prompt'
       })
     })
@@ -246,7 +246,7 @@ describe('terminal interactive-wait visibility (STA-4513, STA-3714)', () => {
         connectionId: 'ssh:build-host'
       })
 
-      expect(runtime.getTerminalInteractiveWait(handle)).toMatchObject({
+      await expect(runtime.getTerminalInteractiveWait(handle)).resolves.toMatchObject({
         source: 'prompt-text',
         reason: 'agent-approval-prompt'
       })
@@ -259,7 +259,7 @@ describe('terminal interactive-wait visibility (STA-4513, STA-3714)', () => {
         data: 'The agent asked: Run this command? I said yes and it worked.\n'
       })
 
-      expect(runtime.getTerminalInteractiveWait(handle)).toBeNull()
+      await expect(runtime.getTerminalInteractiveWait(handle)).resolves.toBeNull()
     })
   })
 
@@ -287,7 +287,7 @@ describe('terminal interactive-wait visibility (STA-4513, STA-3714)', () => {
         data: CLAUDE_TRUST
       })
 
-      expect(runtime.getTerminalInteractiveWait(handle)).toBeNull()
+      await expect(runtime.getTerminalInteractiveWait(handle)).resolves.toBeNull()
     })
   })
 
@@ -299,7 +299,7 @@ describe('terminal interactive-wait visibility (STA-4513, STA-3714)', () => {
         data: agentStatusOsc('waiting')
       })
 
-      expect(runtime.getTerminalInteractiveWait(handle)).toMatchObject({
+      await expect(runtime.getTerminalInteractiveWait(handle)).resolves.toMatchObject({
         source: 'hook',
         since: expect.any(Number)
       })
@@ -315,7 +315,20 @@ describe('terminal interactive-wait visibility (STA-4513, STA-3714)', () => {
         data: agentStatusOsc('working')
       })
 
-      expect(runtime.getTerminalInteractiveWait(handle)).toBeNull()
+      await expect(runtime.getTerminalInteractiveWait(handle)).resolves.toBeNull()
+    })
+
+    it('drops a retained permission row once the agent stops owning the pane', async () => {
+      // Why not the title alone: a shell that takes the pane back usually sets something like
+      // `user@host: ~/repo`, which no title rule recognizes, and a hook row stays fresh for
+      // AGENT_STATUS_STALE_AFTER_MS — half an hour of reporting a dead agent as waiting.
+      const { runtime, handle } = await createPane({
+        paneTitle: 'jinwoo@host: ~/repo',
+        foregroundProcess: 'zsh',
+        data: agentStatusOsc('waiting')
+      })
+
+      await expect(runtime.getTerminalInteractiveWait(handle)).resolves.toBeNull()
     })
 
     it('drops a retained permission row once a shell owns the pane', async () => {
@@ -325,7 +338,7 @@ describe('terminal interactive-wait visibility (STA-4513, STA-3714)', () => {
         data: agentStatusOsc('blocked')
       })
 
-      expect(runtime.getTerminalInteractiveWait(handle)).toBeNull()
+      await expect(runtime.getTerminalInteractiveWait(handle)).resolves.toBeNull()
     })
   })
 
@@ -341,7 +354,7 @@ describe('terminal interactive-wait visibility (STA-4513, STA-3714)', () => {
     })
     runtime.seedTerminalRestoreTail(PTY_ID, { text: CURSOR_APPROVAL, lastTitle: CURSOR_TITLE })
 
-    expect(runtime.getTerminalInteractiveWait(handle)).toMatchObject({
+    await expect(runtime.getTerminalInteractiveWait(handle)).resolves.toMatchObject({
       source: 'prompt-text',
       reason: 'agent-approval-prompt'
     })
@@ -357,7 +370,7 @@ describe('terminal interactive-wait visibility (STA-4513, STA-3714)', () => {
     })
     runtime.seedTerminalRestoreTail(PTY_ID, { text: CLAUDE_TRUST })
 
-    expect(runtime.getTerminalInteractiveWait(handle)).toBeNull()
+    await expect(runtime.getTerminalInteractiveWait(handle)).resolves.toBeNull()
   })
 
   it('answers null rather than "not waiting" for a pane it cannot read', async () => {
@@ -367,6 +380,6 @@ describe('terminal interactive-wait visibility (STA-4513, STA-3714)', () => {
       data: CURSOR_APPROVAL
     })
 
-    expect(runtime.getTerminalInteractiveWait('term_does_not_exist')).toBeNull()
+    await expect(runtime.getTerminalInteractiveWait('term_does_not_exist')).resolves.toBeNull()
   })
 })

--- a/src/main/runtime/terminal-interactive-wait-visibility.test.ts
+++ b/src/main/runtime/terminal-interactive-wait-visibility.test.ts
@@ -1,8 +1,5 @@
-// STA-4513 / STA-3714: a worker parked on an interactive prompt must be distinguishable
-// from one that is thinking or inside a long tool call. Before this, `terminal show` and
-// `orchestration worker-show` carried no such field, and cursor-agent's approval menu was
-// not detected at all — its hook set has no approval event, so control and case reported
-// byte-identical `working` on every coordinator surface.
+// A worker parked on an interactive prompt must be distinguishable from one that is thinking
+// or inside a long tool call (STA-4513, STA-3714).
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'

--- a/src/main/runtime/terminal-interactive-wait-visibility.test.ts
+++ b/src/main/runtime/terminal-interactive-wait-visibility.test.ts
@@ -7,6 +7,7 @@ import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import { OrcaRuntimeService } from './orca-runtime'
+import { assertTerminalAgentSendable } from './rpc/terminal-agent-send-guard'
 
 vi.mock('electron', () => ({
   BrowserWindow: { fromId: vi.fn(() => null) },
@@ -45,6 +46,8 @@ async function createPane(options: {
   paneTitle: string
   foregroundProcess: string | null
   data: string
+  /** Set for a pane whose PTY lives on an SSH host or WSL distro rather than locally. */
+  connectionId?: string
 }): Promise<{ runtime: OrcaRuntimeService; handle: string }> {
   const runtime = new OrcaRuntimeService(null)
   const internals = runtime as unknown as {
@@ -53,7 +56,7 @@ async function createPane(options: {
   vi.spyOn(internals, 'resolveTerminalWorkspaceLaunchScope').mockResolvedValue({
     id: WORKTREE_ID,
     path: '/repo/app',
-    connectionId: null,
+    connectionId: options.connectionId ?? null,
     repo: null,
     folderWorkspace: null
   })
@@ -90,7 +93,11 @@ async function createPane(options: {
       }
     ]
   })
-  runtime.onPtyData(PTY_ID, options.data, Date.now())
+  // Why the guard: a restore seed is only applied to a never-written record, so the restore
+  // cases must not write an empty chunk first.
+  if (options.data.length > 0) {
+    runtime.onPtyData(PTY_ID, options.data, Date.now())
+  }
   return { runtime, handle: terminal.handle }
 }
 
@@ -117,10 +124,10 @@ describe('terminal interactive-wait visibility (STA-4513, STA-3714)', () => {
       })
     })
 
-    it('feeds the same permission verdict the agent-prompt guard reads', async () => {
-      // Why this matters beyond reporting: `dispatch --inject` and guarded sends refuse on a
-      // `permission` verdict, so before this the coordinator's preamble was typed straight
-      // into the approval dialog instead of being refused (the STA-2631 shape).
+    it('refuses a guarded send and a dispatch preamble while the approval is up', async () => {
+      // Why this matters beyond reporting: the coordinator's preamble was typed straight into
+      // the approval dialog instead of being refused (the STA-2631 shape). Both refusal paths
+      // are asserted here, not just the `permission` verdict they read.
       const { runtime, handle } = await createPane({
         paneTitle: CURSOR_TITLE,
         foregroundProcess: 'cursor-agent',
@@ -131,6 +138,24 @@ describe('terminal interactive-wait visibility (STA-4513, STA-3714)', () => {
         isRunningAgent: true,
         status: 'permission'
       })
+      await expect(
+        assertTerminalAgentSendable({ runtime, handle, assertWritable: () => {} })
+      ).rejects.toThrow('terminal_guard_permission')
+      await expect(runtime.sendTerminalAgentPrompt(handle, 'coordinator preamble')).rejects.toThrow(
+        'agent_prompt_blocked'
+      )
+    })
+
+    it('lets a dispatch preamble through once the same lane is working', async () => {
+      const { runtime, handle } = await createPane({
+        paneTitle: CURSOR_TITLE,
+        foregroundProcess: 'cursor-agent',
+        data: CURSOR_LONG_TOOL_CALL
+      })
+
+      await expect(
+        assertTerminalAgentSendable({ runtime, handle, assertWritable: () => {} })
+      ).resolves.toBeUndefined()
     })
 
     it('refuses to call the lane idle while the approval is unanswered', async () => {
@@ -168,8 +193,8 @@ describe('terminal interactive-wait visibility (STA-4513, STA-3714)', () => {
     })
 
     it('treats an answered menu still in scrollback as scrollback', async () => {
-      // Why: the menu is not erased on every terminal; cursor-agent's follow-up input line
-      // reappearing after it is the proof that a human already answered.
+      // Why: the menu is not erased on every terminal, so a live dialog is one that still owns
+      // the bottom of the screen rather than one that merely appears somewhere in the tail.
       const { runtime, handle } = await createPane({
         paneTitle: CURSOR_TITLE,
         foregroundProcess: 'cursor-agent',
@@ -177,6 +202,54 @@ describe('terminal interactive-wait visibility (STA-4513, STA-3714)', () => {
       })
 
       expect(runtime.getTerminalInteractiveWait(handle)).toBeNull()
+    })
+
+    it('treats an answered menu followed by any later output as scrollback', async () => {
+      // Why not keyed on cursor's own follow-up line: output after the menu can be anything,
+      // and a stale hit here fails tui-idle and refuses prompt injection on a healthy lane.
+      const { runtime, handle } = await createPane({
+        paneTitle: CURSOR_TITLE,
+        foregroundProcess: 'cursor-agent',
+        data: CURSOR_APPROVAL
+      })
+      expect(runtime.getTerminalInteractiveWait(handle)).not.toBeNull()
+
+      runtime.onPtyData(
+        PTY_ID,
+        '\nCommand completed successfully.\nContinuing automatically.\n',
+        Date.now()
+      )
+
+      expect(runtime.getTerminalInteractiveWait(handle)).toBeNull()
+    })
+
+    it('tolerates one trailing line below a live dialog', async () => {
+      // A status footer under the dialog must not read as scrollback.
+      const { runtime, handle } = await createPane({
+        paneTitle: CURSOR_TITLE,
+        foregroundProcess: 'cursor-agent',
+        data: `${CURSOR_APPROVAL}\n  Auto · 6.1%\n`
+      })
+
+      expect(runtime.getTerminalInteractiveWait(handle)).toMatchObject({
+        reason: 'agent-approval-prompt'
+      })
+    })
+
+    it('reports the same wait for a pane whose PTY is not local', async () => {
+      // The verdict is derived from retained tail and title state, so an SSH or WSL pane
+      // reaches it the same way a local one does.
+      const { runtime, handle } = await createPane({
+        paneTitle: CURSOR_TITLE,
+        foregroundProcess: 'cursor-agent',
+        data: CURSOR_APPROVAL,
+        connectionId: 'ssh:build-host'
+      })
+
+      expect(runtime.getTerminalInteractiveWait(handle)).toMatchObject({
+        source: 'prompt-text',
+        reason: 'agent-approval-prompt'
+      })
     })
 
     it('ignores a partial menu that names no decision keys', async () => {
@@ -254,6 +327,37 @@ describe('terminal interactive-wait visibility (STA-4513, STA-3714)', () => {
 
       expect(runtime.getTerminalInteractiveWait(handle)).toBeNull()
     })
+  })
+
+  it('still reports a live dialog restored from terminal history', async () => {
+    // Why this case exists: a lane parked on a prompt emits no bytes, so an Orca restart is
+    // exactly when it would go quiet forever. A restored tail carries no waitBlockedAt, and
+    // the approval menu does not need one — being at the bottom of the restored screen is
+    // itself the proof that this is where the pane stopped.
+    const { runtime, handle } = await createPane({
+      paneTitle: CURSOR_TITLE,
+      foregroundProcess: 'cursor-agent',
+      data: ''
+    })
+    runtime.seedTerminalRestoreTail(PTY_ID, { text: CURSOR_APPROVAL, lastTitle: CURSOR_TITLE })
+
+    expect(runtime.getTerminalInteractiveWait(handle)).toMatchObject({
+      source: 'prompt-text',
+      reason: 'agent-approval-prompt'
+    })
+  })
+
+  it('does not resurrect a startup modal from a restored tail', async () => {
+    // The startup prompts keep the timestamp rule: their text lingers in scrollback with no
+    // marker for whether it was answered, so restored bytes alone must not mint a wait.
+    const { runtime, handle } = await createPane({
+      paneTitle: 'sta4513-claude',
+      foregroundProcess: 'claude',
+      data: ''
+    })
+    runtime.seedTerminalRestoreTail(PTY_ID, { text: CLAUDE_TRUST })
+
+    expect(runtime.getTerminalInteractiveWait(handle)).toBeNull()
   })
 
   it('answers null rather than "not waiting" for a pane it cannot read', async () => {

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -608,8 +608,10 @@ export type RuntimeWorktreeTerminalSleepResult = {
  *  `prompt-text` is a matched prompt in the retained tail, `title` is a live OSC title. */
 export type RuntimeTerminalInteractiveWaitSource = 'hook' | 'prompt-text' | 'title'
 
-/** Present only while the wait is live. Absence means "no proof of a wait", not "not waiting" —
- *  an unreadable or hookless pane reports nothing rather than a false negative dressed as fact. */
+/** Present only while the wait is live. A `null` field means the pane was evaluated and nothing
+ *  proves a wait; an absent field means it was never evaluated — an older host, an unverifiable
+ *  worker identity, an unreadable pane, or an agent probe that did not answer in time. Absence
+ *  is never "not waiting". */
 export type RuntimeTerminalInteractiveWait = {
   source: RuntimeTerminalInteractiveWaitSource
   /** Named prompt when the tail identified one. Absent for hook and title evidence. */

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -603,10 +603,27 @@ export type RuntimeWorktreeTerminalSleepResult = {
     }
 )
 
+/** Evidence class that proved a pane is parked on a prompt only a human can answer.
+ *  Never inferred from silence: `hook` is an agent-reported blocked/waiting state,
+ *  `prompt-text` is a matched prompt in the retained tail, `title` is a live OSC title. */
+export type RuntimeTerminalInteractiveWaitSource = 'hook' | 'prompt-text' | 'title'
+
+/** Present only while the wait is live. Absence means "no proof of a wait", not "not waiting" —
+ *  an unreadable or hookless pane reports nothing rather than a false negative dressed as fact. */
+export type RuntimeTerminalInteractiveWait = {
+  source: RuntimeTerminalInteractiveWaitSource
+  /** Named prompt when the tail identified one. Absent for hook and title evidence. */
+  reason?: RuntimeTerminalWaitBlockedReason
+  /** ms epoch the wait was first observed, when the evidence carries a timestamp. */
+  since?: number
+}
+
 export type RuntimeTerminalShow = RuntimeTerminalSummary & {
   paneRuntimeId: number
   ptyId: string | null
   rendererGraphEpoch: number
+  /** Null when nothing proves an interactive wait. Absent on hosts that predate the field. */
+  agentWait?: RuntimeTerminalInteractiveWait | null
 }
 
 export type RuntimeTerminalState = 'running' | 'exited' | 'unknown'
@@ -745,6 +762,8 @@ export type RuntimeTerminalClose = {
 }
 
 export type RuntimeTerminalWaitCondition = 'exit' | 'tui-idle'
+/** The `codex-` prefixes are historical: these startup prompts are matched by shape, not by
+ *  vendor, so they also fire for Claude and Cursor. Renaming them would break paired hosts. */
 export type RuntimeTerminalWaitBlockedReason =
   | 'codex-update-prompt'
   | 'codex-trust-workspace'
@@ -752,6 +771,7 @@ export type RuntimeTerminalWaitBlockedReason =
   | 'codex-model-migration-prompt'
   | 'codex-hooks-review-prompt'
   | 'codex-interactive-prompt'
+  | 'agent-approval-prompt'
 
 export type RuntimeTerminalWait = {
   handle: string


### PR DESCRIPTION
Closes #14854 (STA-4513) and #13209 (STA-3714).

## What was wrong

A worker parked on an interactive prompt was indistinguishable from one that was thinking or inside a long tool call. Measured on `origin/main` @ 640e8a43, driving a real `cursor-agent 2026.08.11-e8db854` through Orca on macOS:

| coordinator surface | control: running `sleep 60` | case: awaiting a command approval |
| --- | --- | --- |
| `worktree ps` `agents[].state` | `working` | `working` |
| `worktree ps` `toolName` / `toolInput` | `Shell` / `sleep 60 && echo done` | `Shell` / `curl -s … \| head -3` |
| `terminal show` / `terminal list` | no such field | no such field |
| `terminal show` `.title` | `⠋ Cursor Agent` | `⠇ Cursor Agent` |
| `terminal wait --for tui-idle` | `satisfied: true` | **`satisfied: true`** |
| `orchestration worker-show` | no agent state | no agent state |
| `orchestration check` | mailbox only | mailbox only |

Byte-identical, and `tui-idle` actively reports the blocked lane as ready.

For a hook-capable agent the picture differs: a Claude pane on a permission prompt does report `state: waiting` on `worktree ps`. But that is worktree-scoped — a coordinator holding a dispatch id has no per-lane call that surfaces it, which is exactly what STA-3714 asked for.

## Root cause, and why it is one fix

`getTerminalAgentStatus` already fuses hook state, OSC title, and matched prompt text into a `permission` verdict — the exact "blocked on a human" answer both issues want. Two things kept it from a coordinator:

1. **Exposure.** The verdict is reachable only from the renderer. `RuntimeTerminalSummary` has no field for it, so `terminal show`, `terminal list`, and `worker-show`'s `terminal` all drop it.
2. **Detection.** It is blind to `cursor-agent` approval menus, so for Cursor there was no verdict to expose in the first place.

Same boundary, so one change rather than two overlapping ones.

## Exposure

`OrcaRuntimeService.getTerminalInteractiveWait(handle)` publishes that same fusion minus the async foreground probe, and it lands as `agentWait` on:

- `terminal show` (`--json`, and a text line above the preview)
- `orchestration worker-show` → `observation.agentWait`, plus a `Waiting on a human: …` line in text output
- the federated equivalents (`federationShow`), so a remote lane reports the same thing

```json
"observation": {
  "status": "live",
  "exactWorker": true,
  "agentWait": { "source": "prompt-text", "reason": "agent-approval-prompt", "since": 1787035218627 }
}
```

`source` names the evidence — `hook`, `prompt-text`, or `title` — so a coordinator can weigh a hook-reported wait differently from a text match. Three properties are deliberate:

- **Never inferred from silence.** Every branch requires positive evidence.
- **`null` means no proof of a wait; a missing field means the host predates it.** Absence is never read as "not waiting" (the CLI prints `unknown (host predates the field)`).
- **A waiting worker is healthy.** It carries no failure semantics, no strike, no timeout.

## Detection

`cursor-agent`'s hook set — enumerated from the shipped binary — is `beforeSubmitPrompt`, `sessionStart`, `preToolUse`, `postToolUse`, `postToolUseFailure`, `beforeShellExecution`, `beforeMCPExecution`, `afterAgentResponse`, `stop`, `sessionEnd`. There is **no approval event**, and `beforeShellExecution` fires identically for auto-allowed commands, which is why `normalizeCursorEvent` maps it to `working`. The rendered menu is the only authority left, so this is the narrow case where text is the boundary rather than a shortcut past one.

It matches the menu's key-bound choices rather than its prose (`run (once)`, `to allowlist?`, `run everything`, `skip & tell the agent`), requires at least two of them, and clears itself when cursor's follow-up input line reappears after the menu. Cursor's live spinner title is exempted from the staleness rule that clears startup modals, because cursor keeps spinning while it waits — for the startup modals that rule is untouched and pinned by a test.

## Falls out of it

Routing through the shared verdict means `orchestration dispatch --inject` into a cursor pane on an approval now refuses with `agent_prompt_blocked` instead of typing the coordinator's preamble into the dialog — the STA-2631 / #10666 shape, observed live on the built runtime.

## Evidence

**Deterministic** — `src/main/runtime/terminal-interactive-wait-visibility.test.ts`, 21 cases over fixtures captured verbatim from a real cursor-agent driven through Orca: approval pending, the same agent inside a long tool call, idle after answering, an answered menu in scrollback, a menu followed by any later output, a footer under a live dialog, a partial menu with no decision keys, a non-local (`connectionId`) pane, a startup trust screen, a live title clearing a stale startup prompt, a dialog restored from terminal history, a startup modal restored from history, a hook-reported `waiting`, a hook-reported `working`, a retained permission row after a shell takes the pane, an exited pane, and the guard refusing both `assertTerminalAgentSendable` and `sendTerminalAgentPrompt` while allowing a working lane through.

**Same oracle, fix reverted** — all 14 new assertions fail. The substantive one:

```
 refuses to call the lane idle while the approval is unanswered
-   "blockedReason": "agent-approval-prompt",
-   "satisfied": false,
+   "satisfied": true,
```

**Live, against a built runtime** (isolated `serve` profile, real `cursor-agent`, headless — so this exercises the PTY-record branch the unit tests do not):

```
terminal show   → agentWait: agent-approval-prompt (via prompt-text)   [approval pending]
terminal show   → agentWait: none                                      [running sleep 45]
terminal wait   → satisfied: false, blockedReason: agent-approval-prompt
worker-show     → Waiting on a human: agent-approval-prompt (via prompt-text)
worker-show     → observation.agentWait: null                          [same lane, working]
```

**After review:** replayed through real PTYs on a rebuilt runtime, the case matrix reads `approval → agent-approval-prompt`, `long tool call → none`, `answered menu still in scrollback → none` (a false positive before `695beae71b`).

`pnpm lint`, `pnpm run typecheck`, the changed-code quality and React Doctor gates, and the `src/main/runtime`, `src/shared`, and `src/cli` suites are green (10,542 tests). CI is green apart from the `typecheck` job, which fails on `src/renderer/src/components/tab-bar/TabBarCreateEntry.tab-results.test.tsx:51` — a file this branch does not touch, failing identically on unrelated PR #15259.

## Independent review (round 1)

Two fresh `gpt-5.6-luna` Codex reviewers ran against the first commit with different lenses. Their confirmed findings are fixed in `695beae71b`; each was reproduced before acting on it and one was declined.

**Fixed — stale approval menus read as live waits (correctness).** The detector trusted a single dismissal string, so any later output that did not contain cursor's follow-up line left an answered menu reading as a live wait. Reproduced over a real PTY: the real menu plus two lines of ordinary output returned `agent-approval-prompt`, which fails `tui-idle` and refuses prompt injection on a healthy lane. Replaced with the structural property the string was standing in for — a live dialog owns the bottom of the screen, so the last choice may sit at most one line above the end of the tail. That tolerates a footer or a mid-redraw partial line, drops the vendor prose, and also subsumes a second reviewer finding about the follow-up heuristic misfiring.

**Fixed — a restored lane went quiet for good.** Being bottom-of-screen is also the dating this reason needed, so it no longer requires `waitBlockedAt`. A tail restored from terminal history carries none, and a lane parked on a prompt emits no bytes — so an Orca restart silenced exactly the lane both issues are about. The startup modals keep the timestamp rule: their text lingers in scrollback with nothing to say whether it was answered. Both behaviors are now pinned by tests.

**Fixed — the tests did not test the shipping code.** The `worker-show` test mocked `getTerminalInteractiveWait`, so it would have passed with detection permanently returning null. It now drives a real runtime, a real PTY tail, and the real detector, and asserts that `observation.agentWait` equals the terminal payload it is derived from. The guard claim is likewise asserted against the guard: a blocked pane now rejects both `assertTerminalAgentSendable` and `sendTerminalAgentPrompt`, and a working pane still passes.

**Fixed — duplicate tail scans.** `worker-show` and `federationShow` reuse the verdict `showTerminal` already computed instead of rescanning (measured at ~0.11 ms per scan over a full 256 KiB tail), so the two can no longer disagree either.

**Declined.** A reviewer read the missing SSH/WSL/Windows coverage as a gap; the verdict is synchronous and derived from retained tail and title state with no shell, path, or subprocess work, so a non-local pane case was added rather than a platform matrix. The same reviewer confirmed no old-peer, old-client, or platform break, and walked every `blockedReason` consumer.

## Independent review (round 2)

Two more `gpt-5.6-luna` reviewers looked at the design and at whether the issues are even still valid. Both independently confirmed the premise on `origin/main` and that **neither issue should be closed as stale**, with the same nuance: `worktree ps --json` already carries hook-derived `agents[].state`, so STA-3714's "zero signal" wording is too broad — but the dispatch-scoped surface it actually asks for has nothing, and `worktree ps`'s own text formatter hides those rows.

**Fixed — a hook wait could outlive its agent (correctness).** The hook branch proved agent ownership from the pane title alone, while `getTerminalAgentStatus`, the verdict it claimed to reuse, also probes the foreground process. A shell that takes a pane back usually sets something like `user@host: ~/repo`, which no title rule recognizes, and a hook row stays fresh for `AGENT_STATUS_STALE_AFTER_MS` — half an hour of reporting a dead agent as waiting on a human. Hook evidence now goes through that shared verdict; the two prompt branches skip it because a matched prompt is on the pane's screen now and proves itself. The regression test fails against the previous commit.

**Fixed — no coverage for a dead pane.** The menu sits at the bottom of an exited pane's tail forever, and a worker whose process is gone needs intervention, not an answer. The snapshot already refused an exited pane and `worker-show` already gates on proven identity; both are now pinned.

**Fixed — comments over the repo's concise-comment rule.** Trimmed.

**Corrected, not declined — my own claim about STA-4694.** The first version of this description said STA-4694 owns the aggregate. Reading it, that is wrong: it lists "not PTY-output inference as a fallback" under *Not asked for*, so it covers only the hook-derived half and deliberately excludes exactly the Cursor evidence this PR adds. Nobody owned "one call, every lane, whatever the evidence", so [STA-4740](https://linear.app/stably/issue/STA-4740) now does, related to STA-4694. The two reviewers disagreed here and the ticket text settled it.

**Noted, not fixed.** The hook branch's probe means a fleet of per-lane `worker-show` calls costs one foreground read each — that is the price of not lying for half an hour, and it is why the prompt branches avoid it. And an agent that exits without its shell emitting a single byte would keep a menu at the bottom of a live PTY; shells print a prompt, so this stayed a note rather than a heuristic.

## Independent review (rounds 4 and 5)

Round 4 found three P1s, all mine. The Cursor menu matcher used an independent `lastIndexOf` per choice marker, so text outside the menu could carry the anchor — the agent narrating *"next time I'll suggest Run Everything"* after a menu was answered revived it. The match is now confined to the last lines of the tail, and a choice is a line ending in the key that picks it. The one line of slack under the dialog went with it: it was a guess, every capture of a live dialog ends on its last choice, and one line is exactly enough room for that narration. Routing hook evidence through `getTerminalAgentStatus` had also put an **unbounded** foreground probe on `showTerminal`, a path that never probed before — a wedged remote host stalled every caller. It is bounded now, and a timeout leaves the wait unevaluated. And the null-vs-unknown defect above existed one level deeper: `getTerminalInteractiveWait` itself turned an unreadable pane into `null`, so `showTerminal` published "looked, nobody waiting" for a pane it could not read.

Round 5 found no correctness defects in shipped behaviour. Two robustness holes: the bounded probe abandoned the wait but not the request, so a wedged host accrued one live probe per poll (single-flighted per PTY now, matching the existing leaf-absence probe); and the trailing-key rule was written as a character class, so any lowercase run satisfied it and `(as before)` passed — spelled out as key names, which also admits the glyph forms. The contract wording was corrected everywhere it appeared: an absent `agentWait` also covers an unreadable pane and a probe that did not answer, not just an old host, and `docs/reference/remote-wire-compatibility.md` now carries an entry for a field whose absent and null states mean different things.

Two round-4 findings were rejected as stale diffs — `origin/main` moved mid-review, so `git diff origin/main..HEAD` showed main's own commits inverted.

## Scope left out, on purpose

- **`terminal list` and `terminal read`** keep no `agentWait`. Each row would need its own full-tail scan, which is real cost on a list call; the per-lane surfaces are where a coordinator asks about one worker. The aggregate is [STA-4740](https://linear.app/stably/issue/STA-4740), filed off this review because STA-4694 covers only the hook-derived half.
- **Three other vendors have the same blind spot and are not fixed here.** Auditing every per-vendor normalizer for whether it can emit `blocked`/`waiting`: `gemini`, `amp`, and `command-code` all map every hook event to `working` or `done`, exactly like `cursor` did. Gemini's `Allow execution` / `Do you want to proceed?` dialogs match no existing rule either. Every rule in this PR was validated against bytes captured from a real agent driven through Orca and replayed through a real PTY; of those three only Gemini is installable here, so adding unvalidated rules would be the brittleness this PR is trying to avoid. Filed as [STA-4778](https://linear.app/stably/issue/STA-4778).
- **The `codex-` prefix on the existing blocked reasons is a misnomer** — those prompts are matched by shape and already fire for Claude and Cursor (a Claude trust screen reports `codex-trust-workspace`). Renaming them would break paired hosts mid-skew, so the new reason is vendor-neutral (`agent-approval-prompt`) and the union carries a comment explaining the legacy names.

## Wire compatibility

Rule 1 throughout: new optional fields on existing RPC results, and a new member on an already-optional `blockedReason` string. No consumer switches exhaustively on it. A new client against an old host sees the field absent and reports it as unknown rather than as "not waiting".
