### PR TITLE
Move a rejected worker_done off ready instead of stranding its Dispatch

### DIFF
--- a/src/main/runtime/orchestration/db.ts
+++ b/src/main/runtime/orchestration/db.ts
@@ -37,6 +37,7 @@ import type {
   FederationRelayDirection,
   FederationRelayItemRow
 } from './types'
+import { WORKER_REPORT_REJECTED_STAGE } from './types'
 import { buildOrchestrationTaskDisplayMetadata } from '../../../shared/orchestration-task-display'
 import { ORCHESTRATION_LEGACY_RUN_ID } from '../../../shared/orchestration-rpc-contract'
 import { parsePaneKey } from '../../../shared/stable-pane-id'
@@ -4524,7 +4525,11 @@ export class OrchestrationDb {
       }
 
       const activeDispatch = dispatch.status === 'pending' || dispatch.status === 'dispatched'
-      const stopWasPending = worker.state === 'stopping' || worker.state === 'stop_unknown'
+      // Why: a lane parked by a refused report never had a stop requested, so its Task still needs
+      // requeuing here — treating it as a pending stop would leave the Task at 'dispatched'.
+      const stopWasPending =
+        worker.state === 'stopping' ||
+        (worker.state === 'stop_unknown' && worker.stage !== WORKER_REPORT_REJECTED_STAGE)
       if (activeDispatch) {
         const failureCount = dispatch.failure_count + 1
         const dispatchStatus: DispatchStatus = failureCount >= 3 ? 'circuit_broken' : 'failed'
@@ -6448,6 +6453,19 @@ export class OrchestrationDb {
     }
   }
 
+  // Why: a rejected worker_done still means its assignee stopped working, so the lane must not keep
+  // reading 'ready' — an ended Dispatch would be indistinguishable from a live one (#13364).
+  markWorkerReportRejected(dispatchId: string, reason: string): WorkerDispatchRow | undefined {
+    this.db
+      .prepare(
+        `UPDATE worker_dispatches
+         SET state = 'stop_unknown', stage = ?, last_error = ?, updated_at = datetime('now')
+         WHERE dispatch_id = ? AND state = 'ready'`
+      )
+      .run(WORKER_REPORT_REJECTED_STAGE, reason, dispatchId)
+    return this.getWorkerDispatch(dispatchId)
+  }
+
   settleWorkerReport(params: {
     taskId: string
     dispatchId: string
@@ -6497,19 +6515,15 @@ export class OrchestrationDb {
       return { action: 'settled', outcome: params.outcome, duplicate: true }
     }
     if (dispatch.status !== 'dispatched' || task.status !== 'dispatched') {
-      return {
-        action: 'rejected',
-        code: 'inactive_dispatch',
-        reason: `inactive dispatch ${params.dispatchId}: it or task ${params.taskId} is already settled.`
-      }
+      const reason = `inactive dispatch ${params.dispatchId}: it or task ${params.taskId} is already settled.`
+      this.markWorkerReportRejected(params.dispatchId, reason)
+      return { action: 'rejected', code: 'inactive_dispatch', reason }
     }
     const latest = this.getDispatchContext(params.taskId)
     if (latest?.id !== params.dispatchId) {
-      return {
-        action: 'rejected',
-        code: 'stale_dispatch',
-        reason: `Dispatch ${params.dispatchId} is not the current dispatch for task ${params.taskId}.`
-      }
+      const reason = `Dispatch ${params.dispatchId} is not the current dispatch for task ${params.taskId}.`
+      this.markWorkerReportRejected(params.dispatchId, reason)
+      return { action: 'rejected', code: 'stale_dispatch', reason }
     }
 
     this.db.exec('SAVEPOINT settle_worker_report')
@@ -6532,19 +6546,24 @@ export class OrchestrationDb {
     if (dispatchUpdate.changes !== 1 || taskUpdate.changes !== 1) {
       this.db.exec('ROLLBACK TO settle_worker_report')
       this.db.exec('RELEASE settle_worker_report')
-      return {
-        action: 'rejected',
-        code: 'inactive_dispatch',
-        reason: `Dispatch ${params.dispatchId} changed while its worker report was settling.`
-      }
+      const reason = `Dispatch ${params.dispatchId} changed while its worker report was settling.`
+      this.markWorkerReportRejected(params.dispatchId, reason)
+      return { action: 'rejected', code: 'inactive_dispatch', reason }
     }
+    // Why: a lane parked by an earlier refused report is still settleable — a corrected retry must
+    // not leave it at stop_unknown while its Task reads completed.
     this.db
       .prepare(
         `UPDATE worker_dispatches
-         SET state = ?, stage = 'settled', updated_at = datetime('now')
-         WHERE dispatch_id = ? AND state = 'ready'`
+         SET state = ?, stage = 'settled', last_error = NULL, updated_at = datetime('now')
+         WHERE dispatch_id = ?
+           AND (state = 'ready' OR (state = 'stop_unknown' AND stage = ?))`
       )
-      .run(params.outcome === 'succeeded' ? 'succeeded' : 'failed', params.dispatchId)
+      .run(
+        params.outcome === 'succeeded' ? 'succeeded' : 'failed',
+        params.dispatchId,
+        WORKER_REPORT_REJECTED_STAGE
+      )
     this.closeQuestionsForDispatch(params.dispatchId)
     if (params.outcome === 'succeeded') {
       this.promoteReadyTasks(params.taskId)

--- a/src/main/runtime/orchestration/lifecycle-reconciliation.ts
+++ b/src/main/runtime/orchestration/lifecycle-reconciliation.ts
@@ -13,7 +13,7 @@ function isSamePane(assigneePaneKey: string, senderPaneKey: string): boolean {
   return Boolean(assigneeLeaf && senderLeaf && assigneeLeaf === senderLeaf)
 }
 
-function hasLifecycleAuthority(
+export function hasLifecycleAuthority(
   dispatch: { assignee_handle: string | null; assignee_pane_key: string | null },
   msg: MessageRow
 ): boolean {

--- a/src/main/runtime/orchestration/types.ts
+++ b/src/main/runtime/orchestration/types.ts
@@ -143,6 +143,10 @@ export type WorkerDispatchState =
   | 'stopped'
   | 'abandoned'
 
+// Why: distinguishes a lane parked by a refused report from one parked by a stop that lost its
+// receipt, and marks the only stop_unknown lane a later accepted report may still settle.
+export const WORKER_REPORT_REJECTED_STAGE = 'worker_report_rejected'
+
 export type WorkerDispatchRow = {
   dispatch_id: string
   runtime_epoch: string | null

--- a/src/main/runtime/orchestration/worker-report-identity.ts
+++ b/src/main/runtime/orchestration/worker-report-identity.ts
@@ -1,13 +1,7 @@
 import type { MessageRow } from './types'
 
-/**
- * Whether a `worker_done` payload names this Dispatch's own work.
- *
- * Why: parking a lane on a rejected report is a courtesy to a worker that really finished, so it
- * needs the same identity proof reconciliation applies — the right task, the right Dispatch and a
- * real outcome. A report that names another task, or no task, proves nothing about this lane and
- * must leave it as it was.
- */
+// Why: parking a lane on a rejected report needs the same identity proof reconciliation applies,
+// or a report naming another task would move a lane it never worked.
 export function isWorkerReportForDispatch(
   dispatch: { id: string; task_id: string },
   msg: MessageRow

--- a/src/main/runtime/orchestration/worker-report-identity.ts
+++ b/src/main/runtime/orchestration/worker-report-identity.ts
@@ -1,0 +1,39 @@
+import type { MessageRow } from './types'
+
+/**
+ * Whether a `worker_done` payload names this Dispatch's own work.
+ *
+ * Why: parking a lane on a rejected report is a courtesy to a worker that really finished, so it
+ * needs the same identity proof reconciliation applies — the right task, the right Dispatch and a
+ * real outcome. A report that names another task, or no task, proves nothing about this lane and
+ * must leave it as it was.
+ */
+export function isWorkerReportForDispatch(
+  dispatch: { id: string; task_id: string },
+  msg: MessageRow
+): boolean {
+  if (!msg.payload) {
+    return false
+  }
+  const payload = parsePayloadObject(msg.payload)
+  if (!payload) {
+    return false
+  }
+  const outcome = payload.outcome
+  return (
+    payload.taskId === dispatch.task_id &&
+    payload.dispatchId === dispatch.id &&
+    (outcome === 'succeeded' || outcome === 'failed')
+  )
+}
+
+function parsePayloadObject(payload: string): Record<string, unknown> | undefined {
+  try {
+    const parsed: unknown = JSON.parse(payload)
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : undefined
+  } catch {
+    return undefined
+  }
+}

--- a/src/main/runtime/rpc/methods/orchestration-rejected-worker-report-lane.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-rejected-worker-report-lane.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { OrcaRuntimeService } from '../../orca-runtime'
+import { OrchestrationDb } from '../../orchestration/db'
+import { reconcileLifecycleMessage } from '../../orchestration/lifecycle-reconciliation'
+import { WORKER_REPORT_REJECTED_STAGE } from '../../orchestration/types'
+import { ORCHESTRATION_METHODS } from './orchestration'
+
+const COORDINATOR = 'term_coordinator'
+const WORKER = 'term_worker'
+const OUTSIDER = 'term_outsider'
+
+describe('rejected worker_done Dispatch state', () => {
+  let db: OrchestrationDb
+  let runtime: OrcaRuntimeService
+  let runId: string
+  let taskId: string
+  let dispatchId: string
+  let capability: string
+
+  beforeEach(() => {
+    db = new OrchestrationDb(':memory:')
+    runtime = new OrcaRuntimeService()
+    runtime.setOrchestrationDb(db)
+    vi.spyOn(runtime, 'getTerminalPaneKey').mockImplementation((handle) => paneKey(handle))
+    vi.spyOn(runtime, 'getTerminalProcessIncarnation').mockImplementation(
+      (handle) => `${handle}:process`
+    )
+    vi.spyOn(runtime, 'notifyMessageArrived').mockImplementation(() => {})
+    vi.spyOn(runtime, 'deliverPendingMessagesForHandle').mockImplementation(() => {})
+
+    runId = db.createRun({
+      objective: 'Report a finished worker',
+      coordinatorHandle: COORDINATOR,
+      coordinatorPaneKey: paneKey(COORDINATOR)
+    }).id
+    taskId = db.createTask({ spec: 'supervised work', runId }).id
+    const started = db.createStartingWorkerDispatch({ taskId, startOptions: {} })
+    dispatchId = started.dispatch.id
+    capability = db.prepareStartingWorkerAuthority({
+      dispatchId,
+      handle: WORKER,
+      paneKey: paneKey(WORKER),
+      processIncarnation: `${WORKER}:process`,
+      worktreeId: 'repo::worktree',
+      setupState: 'not_applicable',
+      effects: []
+    })
+    db.markWorkerDispatchReady(dispatchId)
+  })
+
+  afterEach(() => db.close())
+
+  it('parks the lane when the assignee reports without its Dispatch capability', async () => {
+    const rejected = (await send({})) as { lifecycle: { action: string; code: string } }
+
+    expect(rejected.lifecycle).toMatchObject({
+      action: 'rejected',
+      code: 'dispatch_capability_invalid'
+    })
+    expect(db.getWorkerDispatch(dispatchId)).toMatchObject({
+      state: 'stop_unknown',
+      stage: WORKER_REPORT_REJECTED_STAGE,
+      last_error: expect.stringContaining('capability')
+    })
+  })
+
+  it('parks the lane when the report loses to a revoked Dispatch', async () => {
+    db.failDispatch(dispatchId, 'the worker never reported readiness')
+
+    const rejected = (await send({ capability })) as { lifecycle: { action: string } }
+
+    expect(rejected.lifecycle.action).toBe('rejected')
+    expect(db.getWorkerDispatch(dispatchId)).toMatchObject({
+      state: 'stop_unknown',
+      stage: WORKER_REPORT_REJECTED_STAGE
+    })
+  })
+
+  it('parks the lane when settlement rejects a Task that left the dispatched state', () => {
+    db.updateTaskStatus(taskId, 'blocked')
+    const message = db.insertMessage({
+      from: WORKER,
+      to: `run:${runId}`,
+      subject: 'Done',
+      type: 'worker_done',
+      payload: JSON.stringify({ taskId, dispatchId, outcome: 'succeeded' }),
+      senderPaneKey: paneKey(WORKER),
+      runId
+    })
+
+    expect(reconcileLifecycleMessage(db, message)).toMatchObject({
+      action: 'rejected',
+      code: 'inactive_dispatch'
+    })
+    expect(db.getWorkerDispatch(dispatchId)).toMatchObject({
+      state: 'stop_unknown',
+      stage: WORKER_REPORT_REJECTED_STAGE
+    })
+  })
+
+  it('leaves the lane alone when a terminal that is not the assignee reports', async () => {
+    const rejected = (await send({ from: OUTSIDER })) as { lifecycle: { code: string } }
+
+    expect(rejected.lifecycle.code).toBe('dispatch_capability_invalid')
+    expect(db.getWorkerDispatch(dispatchId)).toMatchObject({
+      state: 'ready',
+      stage: 'input_accepted'
+    })
+  })
+
+  it('settles the lane when the report is accepted', async () => {
+    const accepted = (await send({ capability })) as { lifecycle?: unknown }
+
+    expect(accepted.lifecycle).toBeUndefined()
+    expect(db.getTask(taskId)?.status).toBe('completed')
+    expect(db.getWorkerDispatch(dispatchId)).toMatchObject({
+      state: 'succeeded',
+      stage: 'settled'
+    })
+  })
+
+  it('settles a parked lane when the worker retries with its capability', async () => {
+    await send({})
+    expect(db.getWorkerDispatch(dispatchId)?.state).toBe('stop_unknown')
+
+    await send({ capability })
+
+    expect(db.getTask(taskId)?.status).toBe('completed')
+    expect(db.getWorkerDispatch(dispatchId)).toMatchObject({
+      state: 'succeeded',
+      stage: 'settled',
+      last_error: null
+    })
+  })
+
+  it('still requeues the Task when a parked lane loses its terminal', async () => {
+    await send({})
+
+    expect(db.reconcileMissingWorkerTerminal(dispatchId, 'worker terminal is gone')).toMatchObject({
+      state: 'abandoned'
+    })
+    expect(db.getTask(taskId)?.status).toBe('ready')
+  })
+
+  async function send(options: { from?: string; capability?: string }): Promise<unknown> {
+    const method = ORCHESTRATION_METHODS.find(
+      (candidate) => candidate.name === 'orchestration.send'
+    )
+    if (!method) {
+      throw new Error('orchestration.send was not registered')
+    }
+    return method.handler(
+      method.params!.parse({
+        from: options.from ?? WORKER,
+        subject: 'Done',
+        type: 'worker_done',
+        payload: JSON.stringify({ taskId, dispatchId, outcome: 'succeeded' })
+      }),
+      { runtime, orchestrationCapability: options.capability }
+    )
+  }
+})
+
+function paneKey(handle: string): string {
+  return `tab:${handle}`
+}

--- a/src/main/runtime/rpc/methods/orchestration-rejected-worker-report-lane.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-rejected-worker-report-lane.test.ts
@@ -108,6 +108,36 @@ describe('rejected worker_done Dispatch state', () => {
     })
   })
 
+  it('leaves the lane alone when the assignee reports a task the Dispatch does not hold', async () => {
+    // Why: parking is a courtesy to a worker that really finished. A report naming another task
+    // proves nothing about this lane, so a capability-invalid one must not move it off ready.
+    const otherTask = db.createTask({ spec: 'another lane', runId }).id
+
+    const rejected = (await send({
+      payload: { taskId: otherTask, dispatchId, outcome: 'succeeded' }
+    })) as {
+      lifecycle: { code: string }
+    }
+
+    expect(rejected.lifecycle.code).toBe('dispatch_capability_invalid')
+    expect(db.getWorkerDispatch(dispatchId)).toMatchObject({
+      state: 'ready',
+      stage: 'input_accepted'
+    })
+  })
+
+  it('leaves the lane alone when the assignee reports with no taskId at all', async () => {
+    const rejected = (await send({ payload: { dispatchId, outcome: 'succeeded' } })) as {
+      lifecycle: { code: string }
+    }
+
+    expect(rejected.lifecycle.code).toBe('dispatch_capability_invalid')
+    expect(db.getWorkerDispatch(dispatchId)).toMatchObject({
+      state: 'ready',
+      stage: 'input_accepted'
+    })
+  })
+
   it('settles the lane when the report is accepted', async () => {
     const accepted = (await send({ capability })) as { lifecycle?: unknown }
 
@@ -142,7 +172,11 @@ describe('rejected worker_done Dispatch state', () => {
     expect(db.getTask(taskId)?.status).toBe('ready')
   })
 
-  async function send(options: { from?: string; capability?: string }): Promise<unknown> {
+  async function send(options: {
+    from?: string
+    capability?: string
+    payload?: Record<string, unknown>
+  }): Promise<unknown> {
     const method = ORCHESTRATION_METHODS.find(
       (candidate) => candidate.name === 'orchestration.send'
     )
@@ -154,7 +188,7 @@ describe('rejected worker_done Dispatch state', () => {
         from: options.from ?? WORKER,
         subject: 'Done',
         type: 'worker_done',
-        payload: JSON.stringify({ taskId, dispatchId, outcome: 'succeeded' })
+        payload: JSON.stringify(options.payload ?? { taskId, dispatchId, outcome: 'succeeded' })
       }),
       { runtime, orchestrationCapability: options.capability }
     )

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -12,7 +12,10 @@ import { MESSAGE_TYPES } from '../../orchestration/types'
 import { buildDispatchPreamble } from '../../orchestration/preamble'
 import { formatMessageBanner } from '../../orchestration/formatter'
 import { isGroupAddress, resolveGroupAddress } from '../../orchestration/groups'
-import { reconcileLifecycleMessage } from '../../orchestration/lifecycle-reconciliation'
+import {
+  hasLifecycleAuthority,
+  reconcileLifecycleMessage
+} from '../../orchestration/lifecycle-reconciliation'
 import { abbreviateOrchestrationTasks } from '../../../../shared/orchestration-task-summary'
 import {
   ORCHESTRATION_LEGACY_RUN_ID,
@@ -605,6 +608,12 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
                 'dispatch_capability_invalid',
                 authority.reason
               ) ?? msg
+            // Why: this branch returns before reconciliation, so the lane has to be parked here or a
+            // worker that reported done keeps reading 'ready' forever (#13364). Pane authority gates
+            // it so an unassigned sender cannot park someone else's lane.
+            if (msg.type === 'worker_done' && hasLifecycleAuthority(dispatch, msg)) {
+              db.markWorkerReportRejected(dispatch.id, authority.reason)
+            }
             runtime.notifyMessageArrived(to, rejection.type)
             return {
               message: rejection,

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -12,6 +12,7 @@ import { MESSAGE_TYPES } from '../../orchestration/types'
 import { buildDispatchPreamble } from '../../orchestration/preamble'
 import { formatMessageBanner } from '../../orchestration/formatter'
 import { isGroupAddress, resolveGroupAddress } from '../../orchestration/groups'
+import { isWorkerReportForDispatch } from '../../orchestration/worker-report-identity'
 import {
   hasLifecycleAuthority,
   reconcileLifecycleMessage
@@ -611,7 +612,11 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
             // Why: this branch returns before reconciliation, so the lane has to be parked here or a
             // worker that reported done keeps reading 'ready' forever (#13364). Pane authority gates
             // it so an unassigned sender cannot park someone else's lane.
-            if (msg.type === 'worker_done' && hasLifecycleAuthority(dispatch, msg)) {
+            if (
+              msg.type === 'worker_done' &&
+              hasLifecycleAuthority(dispatch, msg) &&
+              isWorkerReportForDispatch(dispatch, msg)
+            ) {
               db.markWorkerReportRejected(dispatch.id, authority.reason)
             }
             runtime.notifyMessageArrived(to, rejection.type)


### PR DESCRIPTION
## What changes

A `worker_done` that Orca refuses now takes its worker Dispatch out of `ready`. A refused report **from the assigned pane** parks the lane at `state = stop_unknown`, `stage = worker_report_rejected`, with the rejection reason in `last_error`.

Fixes #13364 (point 2 — "never leave the dispatch reading `ready`").

## Evidence

Two traces of the same shape, from waves run against v1.4.176/v1.4.178.

**2026-08-09.** A supervised worker tried to report twice, twenty seconds apart. Both attempts came back rejected and were stored as `Rejected worker_done: … blocked at finish gate` with a body beginning "Orca rejected this worker_done". Its escalation went to the Run mailbox. The work itself was fine — the branch merged and the ticket closed three minutes later — but `ctx_5781041c767c` still read `state = ready, stage = input_accepted` hours afterwards, which is exactly what a live worker looks like. Two of that wave's nine dispatch contexts were in this state and nothing in Orca would ever have noticed.

**2026-08-10.** Six workers finished their task and every `worker_done` came back rejected, because their dispatches had been revoked after a readiness timeout while the agents themselves ran to completion. The coordinator ended up detecting completion by reading files on disk, because the one channel that reports completion had refused all six.

## Why this branch and not the other one

The alternative was to leave the dispatch alone and make the rejection loud to the sender. That is already true on `main`, so there was nothing to add:

- `orchestration.send` returns `lifecycle: { action: 'rejected', code, reason }` (`orchestration.ts`).
- The CLI sets a non-zero exit code and prints `Rejected <id>: <reason>` (`src/cli/handlers/orchestration.ts:592`), covered by `orchestration-lifecycle-rejection.test.ts`.
- The SSH fallback recognises the same shape through `hasRemoteLifecycleRejection`.

The 2026-08-09 worker did learn — it retried, then escalated. What no one learned was that its lane had ended. So the gap is the dispatch row, not the sender.

## How

`markWorkerReportRejected` on `OrchestrationDb` is called from the two places a `worker_done` can be refused after its sender has proved it owns the dispatch:

1. The capability branch in `orchestration.send`. This branch returns before `reconcileLifecycleMessage`, which is why the row was never touched. It is gated on `hasLifecycleAuthority`, so a terminal that is not the assignee cannot park someone else's lane by naming its dispatch id.
2. `settleWorkerReportInTransaction`, for `inactive_dispatch` and `stale_dispatch` — the codes that mean this exact dispatch can no longer settle. This path is reached only after the authority check in `reconcileWorkerDoneMessage`, and it also covers reports that arrive over the federation relay.

Rejections that cannot identify a lane the sender owns — `sender_not_assignee`, `unknown_dispatch`, `task_dispatch_mismatch`, a malformed payload — leave the row alone.

`stop_unknown` rather than `failed`: `failed` is in `WORKER_RELEASABLE_STATES`, so it would mark the agent's terminal reclaimable while the agent may still be running. `stop_unknown` keeps the terminal retained and reads as "this ended and I do not know how", which is what a refused report actually tells us. `worker-abandon` — "fence a worker without claiming its process stopped" — still fences a parked lane in full.

Two consequences handled in the same change, so the fix does not create a new way to strand things:

- A corrected retry (for instance re-sending with `--dispatch-capability`) still settles a parked lane, instead of completing the Task while the lane stays at `stop_unknown`.
- `reconcileMissingWorkerTerminal` still requeues the Task for a parked lane. Its `stopWasPending` test now excludes the report-rejected stage, because such a lane never had a stop requested.

Nothing in readiness, revocation, the dispatch lifecycle, or the mailbox changes.

## Test plan

New: `src/main/runtime/rpc/methods/orchestration-rejected-worker-report-lane.test.ts` — 7 tests over a real supervised worker lane.

- parks the lane when the assignee reports without its Dispatch capability
- parks the lane when the report loses to a revoked Dispatch
- parks the lane when settlement rejects a Task that left the dispatched state
- leaves the lane alone when a terminal that is not the assignee reports
- settles the lane when the report is accepted
- settles a parked lane when the worker retries with its capability
- still requeues the Task when a parked lane loses its terminal

Results on this branch:

```
vitest run src/main/runtime/rpc/methods/orchestration-rejected-worker-report-lane.test.ts
  Test Files  1 passed (1)        Tests  7 passed (7)

vitest run src/main/runtime/orchestration src/main/runtime/rpc/methods/orchestration \
           src/cli/handlers/orchestration src/main/ssh/ssh-remote-orca-cli.test.ts
  Test Files  62 passed | 1 skipped (63)     Tests  770 passed | 2 skipped (772)

pnpm typecheck   pass
pnpm lint        pass
```

The full `pnpm test` run also passed except for two timing assertions unrelated to this change (`terminal-output-frame-chunks-equivalence`, `ai-vault-session-worktree-map`), which the machine's load caused; both pass when re-run on their own.



---

Moved from #13655, same commits, same head SHA. That pull request was opened from an organisation-owned fork, and GitHub refuses maintainer pushes on org-owned forks even when `maintainer_can_modify` reports `true` — so a maintainer could not push a fixup to it, only ask or rewrite. This one is on a personal fork, where a maintainer push works.

The review history stays readable on #13655: https://github.com/stablyai/orca/pull/13655
