### PR TITLE
fix(tab-bar): restore the tab-results fixture after occupantAgent became required

### DIFF
--- a/src/renderer/src/components/tab-bar/TabBarCreateEntry.tab-results.test.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntry.tab-results.test.tsx
@@ -79,6 +79,7 @@ const tabSearchMock = vi.hoisted(() => {
               repoName: 'octo/rocket'
             }),
             agentMetadata: [],
+            occupantAgent: null,
             isCurrentTab: false,
             isCurrentWorktree: true
           }))


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

`main` is red. #15134 made `occupantAgent` required on `SearchableWorkspaceTab` but didn't update this test's fixture, so the web typecheck fails **on main itself**:

```
TabBarCreateEntry.tab-results.test.tsx(51,9): error TS2322
  Property 'occupantAgent' is missing in type '{ ... }'
  but required in type 'SearchableWorkspaceTab'
```

Reproduced on pristine `origin/main` (`545b3fba08d`) with no other commits present, so this blocks **every** open PR, not one branch. I hit it on an unrelated dev-tooling PR whose diff touches only `config/scripts/`.

The field is `TuiAgent | null`, and this fixture models tabs with no occupant, so `null` is the accurate value rather than a placeholder.

Verified: `tsc -p config/tsconfig.tc.web.json` clean, and the suite still passes 10/10.