### PR TITLE
fix(skills): normalize stale artifact paths on Windows

### DIFF
--- a/config/scripts/generate-bundled-skill-guides.mjs
+++ b/config/scripts/generate-bundled-skill-guides.mjs
@@ -243,7 +243,7 @@ async function verifyArtifacts(artifacts, repoRoot = REPO_ROOT) {
   if (stale.length > 0) {
     throw new Error(
       `Generated bundled skill guides are stale:\n${stale
-        .map((filePath) => path.relative(repoRoot, filePath))
+        .map((filePath) => path.relative(repoRoot, filePath).split(path.sep).join('/'))
         .join('\n')}\nRun node config/scripts/generate-bundled-skill-guides.mjs --write.`
     )
   }


### PR DESCRIPTION
## ELI5

Windows and Unix use different characters between folders. Normalize generated diagnostic paths to `/` so the same validation output and tests work on every platform.

## What Changed

- Normalize stale bundled-skill artifact paths to forward slashes before including them in the validation error.
- Keep generated artifacts and write/check behavior unchanged.

## Why

`path.relative()` returns platform-native separators. On Windows, the validation error contained paths such as `src\cli\bundled-skill-guides.ts`, while the existing assertions and contributor-facing path format use `src/cli/bundled-skill-guides.ts`.

Normalizing the diagnostic output makes it deterministic across Windows, macOS, and Linux, and keeps the printed paths easy to copy into commands.

## Linked Issue

Fixes #15200

## Visual Proof

N/A — this only changes path formatting in a CLI/config validation error. There is no UI or interaction change.

## Testing

Tested on Windows with Node.js 24.16.0 and pnpm 10.24.0.

Before the fix:

```text
corepack pnpm exec vitest run --config config/vitest.config.ts config/scripts/generate-bundled-skill-guides.test.mjs

Test Files  1 failed (1)
Tests       1 failed | 10 passed | 1 skipped (12)
```

After the fix:

```text
corepack pnpm exec vitest run --config config/vitest.config.ts config/scripts/generate-bundled-skill-guides.test.mjs

Test Files  1 passed (1)
Tests       11 passed | 1 skipped (12)
```

Additional checks passed:

```text
corepack pnpm run verify:bundled-skill-guides
corepack pnpm exec oxfmt --check config/scripts/generate-bundled-skill-guides.mjs
git diff --check
```

No test file was changed because the existing stale-output assertions already cover the regression: they failed with Windows-native separators before this change and pass after normalization.

A full `pnpm test` run was attempted, but the local test preflight could not rebuild `windows-native-registry` because this machine does not have the Visual Studio C++ toolchain installed. The failure occurred before Vitest started; the complete suite is left to CI.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

OpenAI Codex (GPT-5) was used to investigate the Windows failure.

## Review

The change is limited to formatting contributor-facing stale-artifact paths. It does not alter artifact contents, filesystem access, or generation behavior.

## Agent skill upstream boundary

- [x] Not applicable; this change only normalizes diagnostic path separators and copies or translates no upstream skill-installer content.

## Notes

- Security: no impact.
- Cross-platform support: produces deterministic `/`-separated diagnostic paths on Windows, macOS, and Linux.
- Remote SSH and Mobile: no impact.
- Backwards compatibility: no behavior or artifact-format change.
- Performance: negligible.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] Targeted local checks pass; the complete lint, typecheck, test, and build matrix will be covered by CI

## Author

- X / Twitter: N/A