### PR TITLE
fix(codex): stop a locked auth.json from deleting a just-authenticated account (STA-4734)

### DIFF
--- a/src/main/codex-accounts/host-codex-managed-home-ownership.ts
+++ b/src/main/codex-accounts/host-codex-managed-home-ownership.ts
@@ -40,7 +40,11 @@ export class ManagedCodexHomeTemporarilyUnavailableError extends Error {
   }
 }
 
-function isDefinitiveAbsence(error: unknown): boolean {
+/**
+ * The one predicate both Codex credential lanes share. Exported so a second
+ * lane cannot drift by keeping its own copy of the errno allowlist.
+ */
+export function isDefinitiveAbsence(error: unknown): boolean {
   const code = (error as NodeJS.ErrnoException | null)?.code
   return code === 'ENOENT' || code === 'ENOTDIR'
 }

--- a/src/main/codex-accounts/host-codex-managed-home-ownership.ts
+++ b/src/main/codex-accounts/host-codex-managed-home-ownership.ts
@@ -1,5 +1,6 @@
 import { lstatSync, readFileSync, realpathSync, statSync } from 'node:fs'
 import { isAbsolute, join, relative, resolve, sep } from 'node:path'
+import { isDefinitiveAbsence } from '../../shared/definitive-filesystem-absence'
 
 type HostCodexManagedHomeOwnershipOptions = {
   candidatePath: string
@@ -38,15 +39,6 @@ export class ManagedCodexHomeTemporarilyUnavailableError extends Error {
   ) {
     super(message, options)
   }
-}
-
-/**
- * The one predicate both Codex credential lanes share. Exported so a second
- * lane cannot drift by keeping its own copy of the errno allowlist.
- */
-export function isDefinitiveAbsence(error: unknown): boolean {
-  const code = (error as NodeJS.ErrnoException | null)?.code
-  return code === 'ENOENT' || code === 'ENOTDIR'
 }
 
 function pathsEqual(left: string, right: string): boolean {

--- a/src/main/codex-accounts/service.ts
+++ b/src/main/codex-accounts/service.ts
@@ -58,6 +58,7 @@ import {
 } from './runtime-selection'
 import {
   assertOwnedHostCodexManagedHomePath,
+  isDefinitiveAbsence,
   ManagedCodexHomeTemporarilyUnavailableError
 } from './host-codex-managed-home-ownership'
 
@@ -762,7 +763,7 @@ export class CodexAccountService {
       await this.runCodexLogin(managedHomePath)
       return await this.persistCapturedCodexAccount(accountId, managedHome)
     } catch (error) {
-      this.safeRemoveManagedHome(managedHomePath, accountId)
+      this.removeManagedHomeUnlessUnproven(error, managedHomePath, accountId)
       throw error
     }
   }
@@ -781,7 +782,7 @@ export class CodexAccountService {
       this.importCodexAuthFromHome(sourceHome, managedHomePath, accountId)
       return await this.persistCapturedCodexAccount(accountId, managedHome)
     } catch (error) {
-      this.safeRemoveManagedHome(managedHomePath, accountId)
+      this.removeManagedHomeUnlessUnproven(error, managedHomePath, accountId)
       throw error
     }
   }
@@ -799,13 +800,22 @@ export class CodexAccountService {
       throw new Error('A Codex home directory path is required.')
     }
     const authPath = join(resolve(trimmed), 'auth.json')
-    if (!existsSync(authPath)) {
+    let sourceAuthContents: string
+    try {
+      sourceAuthContents = readFileSync(authPath, 'utf-8')
+    } catch (error) {
+      // Why: "no credentials here, run codex login" is only true for a definitive
+      // absence. A locked source file used to produce that advice, which sends the
+      // user to re-run a login they had already completed.
+      if (!isDefinitiveAbsence(error)) {
+        throw new ManagedCodexHomeTemporarilyUnavailableError(undefined, { cause: error })
+      }
       throw new Error(
         `No Codex credentials found in ${resolve(trimmed)}. Run \`codex login\` into this directory first.`
       )
     }
     const trustedHome = this.assertManagedHomePath(managedHomePath, accountId)
-    writeFileAtomically(join(trustedHome, 'auth.json'), readFileSync(authPath, 'utf-8'), {
+    writeFileAtomically(join(trustedHome, 'auth.json'), sourceAuthContents, {
       mode: 0o600
     })
   }
@@ -1624,6 +1634,22 @@ export class CodexAccountService {
     }
   }
 
+  /**
+   * Rollback deletes the managed home, so it may only run on a *proven* failure.
+   * An unreadable credential file means the login may well have succeeded, and a
+   * kept home is a recoverable leak where a deleted one is permanent data loss.
+   */
+  private removeManagedHomeUnlessUnproven(
+    error: unknown,
+    managedHomePath: string,
+    accountId: string
+  ): void {
+    if (error instanceof ManagedCodexHomeTemporarilyUnavailableError) {
+      return
+    }
+    this.safeRemoveManagedHome(managedHomePath, accountId)
+  }
+
   private safeRemoveManagedHome(candidatePath: string, expectedAccountId: string): void {
     let managedHomePath: string
     try {
@@ -1794,7 +1820,14 @@ export class CodexAccountService {
           // Why: the post-auth tree kill is a success path — auth.json already
           // exists and codex only failed to exit on its own, so the forced
           // non-zero exit must not surface as a login failure.
-          if (code === 0 || (loginTreeKilledAfterAuth && existsSync(authJsonPath))) {
+          // Why: the kill only arms after the watcher observed new credential
+          // bytes, so an unreadable auth.json here is a lock, not a failed login.
+          // Only a definitive absence may revoke that verdict — reading a lock as
+          // failure sends the caller's rollback at a home that just authenticated.
+          if (
+            code === 0 ||
+            (loginTreeKilledAfterAuth && readLoginAuthSnapshot(authJsonPath) !== null)
+          ) {
             resolvePromise()
             return
           }
@@ -1875,7 +1908,18 @@ export class CodexAccountService {
       this.assertManagedHomePath(managedHomePath, expectedAccountId),
       'auth.json'
     )
-    const authFileContents = readFileSync(authFilePath, 'utf-8')
+    let authFileContents: string
+    try {
+      authFileContents = readFileSync(authFilePath, 'utf-8')
+    } catch (error) {
+      // Why: an unreadable auth.json is not a missing credential. Surfacing it as
+      // a generic failure is what lets the add path's rollback delete a home
+      // holding freshly authenticated bytes.
+      if (isDefinitiveAbsence(error)) {
+        throw error
+      }
+      throw new ManagedCodexHomeTemporarilyUnavailableError(undefined, { cause: error })
+    }
     let parsed: Record<string, unknown>
     try {
       parsed = JSON.parse(authFileContents) as Record<string, unknown>

--- a/src/main/codex-accounts/service.ts
+++ b/src/main/codex-accounts/service.ts
@@ -58,9 +58,9 @@ import {
 } from './runtime-selection'
 import {
   assertOwnedHostCodexManagedHomePath,
-  isDefinitiveAbsence,
   ManagedCodexHomeTemporarilyUnavailableError
 } from './host-codex-managed-home-ownership'
+import { isDefinitiveAbsence } from '../../shared/definitive-filesystem-absence'
 
 const LOGIN_TIMEOUT_MS = 120_000
 const MAX_LOGIN_OUTPUT_CHARS = 4_000

--- a/src/main/codex-accounts/sta-4734-login-rollback-deletes-authenticated-home.test.ts
+++ b/src/main/codex-accounts/sta-4734-login-rollback-deletes-authenticated-home.test.ts
@@ -1,0 +1,368 @@
+import { describe, expect, it, vi } from 'vitest'
+import { EventEmitter } from 'node:events'
+import type * as NodeFs from 'node:fs'
+import type * as HostCodexManagedHomeOwnership from './host-codex-managed-home-ownership'
+import { PassThrough } from 'node:stream'
+import { join } from 'node:path'
+import {
+  createRateLimits,
+  createRuntimeHome,
+  createSettings,
+  createStore,
+  registerCodexAccountsTestHomes,
+  testState
+} from './service-test-harness'
+
+// STA-4734: the login verdict and the identity read both decided "no credentials"
+// from a read that had merely failed, and doAddAccount's rollback then deleted the
+// managed home that had just been authenticated successfully.
+
+/**
+ * One denial, modelled coherently: a path under an ACL denial fails `readFileSync`
+ * AND reports `false` from `existsSync`. Faulting only one of them lets a test pass
+ * against code that still consults the other.
+ */
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => testState.userDataDir
+  }
+}))
+
+vi.mock('node:os', async () => {
+  const actual = await vi.importActual<typeof import('node:os')>('node:os') // eslint-disable-line @typescript-eslint/consistent-type-imports -- vi.importActual requires inline import()
+  return {
+    ...actual,
+    homedir: () => testState.fakeHomeDir
+  }
+})
+
+const authFaults = vi.hoisted(() => {
+  const state = {
+    denied: new Set<string>(),
+    deny(path: string): void {
+      state.denied.add(path)
+    },
+    reset(): void {
+      state.denied.clear()
+    },
+    isDenied(target: unknown): boolean {
+      return typeof target === 'string' && state.denied.has(target)
+    },
+    throwDenial(target: string, syscall: string): never {
+      const error: NodeJS.ErrnoException = new Error(
+        `EPERM: operation not permitted, ${syscall} '${target}'`
+      )
+      error.code = 'EPERM'
+      error.errno = -4048
+      error.syscall = syscall
+      error.path = target
+      throw error
+    }
+  }
+  return state
+})
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFs>()
+  const originalRead = actual.readFileSync as (...args: unknown[]) => unknown
+  const originalExists = actual.existsSync as (...args: unknown[]) => boolean
+  const patched: Record<string, unknown> = {
+    ...actual,
+    readFileSync: Object.assign((...args: unknown[]): unknown => {
+      if (authFaults.isDenied(args[0])) {
+        authFaults.throwDenial(args[0] as string, 'read')
+      }
+      return originalRead(...args)
+    }, originalRead),
+    existsSync: Object.assign((...args: unknown[]): boolean => {
+      // Why: existsSync swallows every errno, so a denied path reads as absent —
+      // this is the exact collapse the fix removes, and modelling it is what lets
+      // the pre-fix behaviour be observed.
+      return authFaults.isDenied(args[0]) ? false : originalExists(...args)
+    }, originalExists)
+  }
+  return { ...patched, default: patched }
+})
+
+const {
+  existsSync: realExistsSync,
+  readdirSync: realReaddirSync,
+  readFileSync: realReadFileSync,
+  writeFileSync: realWriteFileSync
+} = await vi.importActual<typeof NodeFs>('node:fs')
+
+/**
+ * Why: `vi.resetModules()` gives each test a fresh module graph, so a top-level
+ * import of the error class is a DIFFERENT constructor than the one the service
+ * under test throws — `toBeInstanceOf` would fail against a correct fix.
+ */
+async function importTemporarilyUnavailableError(): Promise<
+  typeof HostCodexManagedHomeOwnership.ManagedCodexHomeTemporarilyUnavailableError
+> {
+  return (await import('./host-codex-managed-home-ownership'))
+    .ManagedCodexHomeTemporarilyUnavailableError
+}
+
+function makeLoginChild(): EventEmitter & {
+  stdout: PassThrough
+  stderr: PassThrough
+  kill: () => void
+} {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: PassThrough
+    stderr: PassThrough
+    kill: () => void
+  }
+  child.stdout = new PassThrough()
+  child.stderr = new PassThrough()
+  child.kill = vi.fn()
+  return child
+}
+
+function authJsonFor(email: string): string {
+  const payload = Buffer.from(JSON.stringify({ email })).toString('base64url')
+  return JSON.stringify({ tokens: { id_token: `header.${payload}.signature` } })
+}
+
+/** Every managed home the add path created, whether or not it survived. */
+function listManagedHomes(): string[] {
+  const root = join(testState.userDataDir, 'codex-accounts')
+  if (!realExistsSync(root)) {
+    return []
+  }
+  return realReaddirSync(root).map((accountId) => join(root, accountId, 'home'))
+}
+
+describe('STA-4734 a locked auth.json must not delete a just-authenticated home', () => {
+  registerCodexAccountsTestHomes()
+
+  it('keeps the managed home and its credentials when the identity read is denied', async () => {
+    vi.resetModules()
+    authFaults.reset()
+
+    let deniedAuthPath = ''
+    const spawnMock = vi.fn(
+      (_command: string, _args: string[], options: { env: NodeJS.ProcessEnv }) => {
+        const child = makeLoginChild()
+        const loginHome = options.env.CODEX_HOME!
+        // The login genuinely succeeds: real credential bytes land on disk.
+        deniedAuthPath = join(loginHome, 'auth.json')
+        realWriteFileSync(deniedAuthPath, authJsonFor('user@example.com'), 'utf-8')
+        // Only now does the scanner take the file.
+        authFaults.deny(deniedAuthPath)
+        queueMicrotask(() => child.emit('close', 0))
+        return child
+      }
+    )
+    vi.doMock('node:child_process', () => ({ execFileSync: vi.fn(), spawn: spawnMock }))
+    vi.doMock('../codex-cli/command', () => ({ resolveCodexCommand: () => 'codex' }))
+
+    try {
+      const store = createStore(createSettings())
+      const { CodexAccountService } = await import('./service')
+      const service = new CodexAccountService(
+        store as never,
+        createRateLimits() as never,
+        createRuntimeHome() as never
+      )
+
+      await expect(service.addAccount()).rejects.toBeInstanceOf(
+        await importTemporarilyUnavailableError()
+      )
+
+      // THE FIX: the rollback is refused, so the credentials survive the failure.
+      // Before it, safeRemoveManagedHome deleted this tree.
+      expect(deniedAuthPath).not.toBe('')
+      const survivors = listManagedHomes().filter((home) => realExistsSync(home))
+      expect(survivors).toHaveLength(1)
+      expect(realExistsSync(deniedAuthPath)).toBe(true)
+      expect(realReadFileSync(deniedAuthPath, 'utf-8')).toBe(authJsonFor('user@example.com'))
+    } finally {
+      authFaults.reset()
+      vi.doUnmock('node:child_process')
+      vi.doUnmock('../codex-cli/command')
+    }
+  })
+
+  it('still deletes the managed home when the login genuinely fails', async () => {
+    vi.resetModules()
+    authFaults.reset()
+
+    // Why: the fix must not turn every add failure into a kept home. A real
+    // failure — no credentials written, non-zero exit — still rolls back.
+    const spawnMock = vi.fn(() => {
+      const child = makeLoginChild()
+      queueMicrotask(() => child.emit('close', 1))
+      return child
+    })
+    vi.doMock('node:child_process', () => ({ execFileSync: vi.fn(), spawn: spawnMock }))
+    vi.doMock('../codex-cli/command', () => ({ resolveCodexCommand: () => 'codex' }))
+
+    try {
+      const { CodexAccountService } = await import('./service')
+      const service = new CodexAccountService(
+        createStore(createSettings()) as never,
+        createRateLimits() as never,
+        createRuntimeHome() as never
+      )
+
+      await expect(service.addAccount()).rejects.toThrow(/Codex login exited with code 1/)
+      expect(listManagedHomes().filter((home) => realExistsSync(home))).toHaveLength(0)
+    } finally {
+      vi.doUnmock('node:child_process')
+      vi.doUnmock('../codex-cli/command')
+    }
+  })
+
+  it('treats a denied auth.json after a Windows tree kill as the success it is', async () => {
+    vi.resetModules()
+    authFaults.reset()
+    vi.useFakeTimers()
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+
+    const child = makeLoginChild() as ReturnType<typeof makeLoginChild> & {
+      pid: number
+      exitCode: number | null
+      signalCode: string | null
+    }
+    child.pid = 5150
+    child.exitCode = null
+    child.signalCode = null
+    vi.doMock('node:child_process', () => ({ execFileSync: vi.fn(), spawn: vi.fn(() => child) }))
+    vi.doMock('../codex-cli/command', () => ({ resolveCodexCommand: () => 'codex' }))
+
+    try {
+      const { CodexAccountService } = await import('./service')
+      const service = new CodexAccountService(
+        createStore(createSettings()) as never,
+        createRateLimits() as never,
+        createRuntimeHome() as never
+      )
+      const loginPromise = (
+        service as unknown as { runCodexLogin(managedHomePath: string): Promise<void> }
+      ).runCodexLogin(testState.fakeHomeDir)
+
+      const authPath = join(testState.fakeHomeDir, 'auth.json')
+      realWriteFileSync(authPath, authJsonFor('user@example.com'), 'utf-8')
+      // The watcher observes the new bytes and arms the post-auth kill.
+      await vi.advanceTimersByTimeAsync(6_000)
+
+      // The scanner takes the file only after the kill is armed, so the close
+      // handler's re-confirmation is the read that fails.
+      authFaults.deny(authPath)
+      child.emit('close', 1)
+
+      // THE FIX: the kill only arms on observed credential bytes, so a denial here
+      // cannot revoke that. Before it, existsSync returned false and this rejected.
+      await expect(loginPromise).resolves.toBeUndefined()
+    } finally {
+      authFaults.reset()
+      Object.defineProperty(process, 'platform', originalPlatform)
+      vi.useRealTimers()
+      vi.doUnmock('node:child_process')
+      vi.doUnmock('../codex-cli/command')
+    }
+  })
+
+  it('still fails a Windows tree kill whose auth.json is definitively gone', async () => {
+    vi.resetModules()
+    authFaults.reset()
+    vi.useFakeTimers()
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+
+    const child = makeLoginChild() as ReturnType<typeof makeLoginChild> & {
+      pid: number
+      exitCode: number | null
+      signalCode: string | null
+    }
+    child.pid = 5151
+    child.exitCode = null
+    child.signalCode = null
+    vi.doMock('node:child_process', () => ({ execFileSync: vi.fn(), spawn: vi.fn(() => child) }))
+    vi.doMock('../codex-cli/command', () => ({ resolveCodexCommand: () => 'codex' }))
+
+    try {
+      const { CodexAccountService } = await import('./service')
+      const service = new CodexAccountService(
+        createStore(createSettings()) as never,
+        createRateLimits() as never,
+        createRuntimeHome() as never
+      )
+      const loginPromise = (
+        service as unknown as { runCodexLogin(managedHomePath: string): Promise<void> }
+      ).runCodexLogin(testState.fakeHomeDir)
+
+      // Why: ENOENT is a real answer. Without this anchor the fix could resolve
+      // every non-zero exit and the suite would not notice.
+      await vi.advanceTimersByTimeAsync(6_000)
+      child.emit('close', 1)
+
+      await expect(loginPromise).rejects.toThrow(/Codex login exited with code 1/)
+    } finally {
+      Object.defineProperty(process, 'platform', originalPlatform)
+      vi.useRealTimers()
+      vi.doUnmock('node:child_process')
+      vi.doUnmock('../codex-cli/command')
+    }
+  })
+
+  it('does not advise "run codex login" for a source home it merely could not read', async () => {
+    vi.resetModules()
+    authFaults.reset()
+
+    const sourceHome = join(testState.fakeHomeDir, '.codex')
+    const sourceAuthPath = join(sourceHome, 'auth.json')
+    realWriteFileSync(sourceAuthPath, authJsonFor('imported@example.com'), 'utf-8')
+    authFaults.deny(sourceAuthPath)
+
+    vi.doMock('node:child_process', () => ({ execFileSync: vi.fn(), spawn: vi.fn() }))
+    vi.doMock('../codex-cli/command', () => ({ resolveCodexCommand: () => 'codex' }))
+
+    try {
+      const { CodexAccountService } = await import('./service')
+      const service = new CodexAccountService(
+        createStore(createSettings()) as never,
+        createRateLimits() as never,
+        createRuntimeHome() as never
+      )
+
+      // Before the fix this reported "No Codex credentials found … Run `codex
+      // login` into this directory first" — advice to redo a login that had
+      // already succeeded.
+      const rejection = service.addAccountFromHome(sourceHome)
+      await expect(rejection).rejects.toBeInstanceOf(await importTemporarilyUnavailableError())
+      await expect(rejection).rejects.not.toThrow(/Run `codex login`/)
+    } finally {
+      authFaults.reset()
+      vi.doUnmock('node:child_process')
+      vi.doUnmock('../codex-cli/command')
+    }
+  })
+
+  it('still reports a genuinely empty source home as having no credentials', async () => {
+    vi.resetModules()
+    authFaults.reset()
+
+    const sourceHome = join(testState.fakeHomeDir, 'empty-codex-home')
+    vi.doMock('node:child_process', () => ({ execFileSync: vi.fn(), spawn: vi.fn() }))
+    vi.doMock('../codex-cli/command', () => ({ resolveCodexCommand: () => 'codex' }))
+
+    try {
+      const { CodexAccountService } = await import('./service')
+      const service = new CodexAccountService(
+        createStore(createSettings()) as never,
+        createRateLimits() as never,
+        createRuntimeHome() as never
+      )
+
+      await expect(service.addAccountFromHome(sourceHome)).rejects.toThrow(
+        /No Codex credentials found/
+      )
+    } finally {
+      vi.doUnmock('node:child_process')
+      vi.doUnmock('../codex-cli/command')
+    }
+  })
+})

--- a/src/shared/definitive-filesystem-absence.ts
+++ b/src/shared/definitive-filesystem-absence.ts
@@ -1,0 +1,17 @@
+/**
+ * The single errno allowlist for "this path is definitively not there".
+ *
+ * `existsSync` returns `false` for `ENOENT` and for `EPERM`, `EACCES`, `EBUSY`,
+ * `EIO`, `UNKNOWN` and every unrecognised code alike, and a `catch` returning a
+ * default does the same. Callers that act on absence — deleting a mirror,
+ * overwriting a config, clearing a credential — must be able to tell the two
+ * apart, and they must all agree on where the line is, so this lives in one
+ * place rather than being re-derived per lane.
+ *
+ * An unknown code is never absence. Mapping the unknown to a verdict is the
+ * category error this predicate exists to prevent.
+ */
+export function isDefinitiveAbsence(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | null)?.code
+  return code === 'ENOENT' || code === 'ENOTDIR'
+}


### PR DESCRIPTION
## ELI5

You sign in to Codex. The login works — the credentials land on disk. But if a virus scanner or indexer has that file open for the half-second Orca goes to read it, Orca concludes the login failed and **deletes the account it just created**. You try again, and again.

## What Changed

Three reads on the Codex account-add path decided "there are no credentials here" from a read that had merely *failed*. `existsSync` returns `false` for `EPERM`, `EBUSY` and every unknown errno exactly as readily as for `ENOENT`, and a bare `readFileSync` throws the same shape whether the file is missing or locked.

| Site | Before | After |
|---|---|---|
| `service.ts` login verdict | `existsSync(authJsonPath)` | only a definitive `ENOENT`/`ENOTDIR` revokes the success verdict |
| `loadOAuthCredentials` | bare `readFileSync` | classifies; unreadable ⇒ `ManagedCodexHomeTemporarilyUnavailableError` |
| `importCodexAuthFromHome` | `existsSync` ⇒ "run `codex login` first" | that advice is now reserved for a real absence |

**And the part that makes it non-inert.** Classifying alone changes nothing, because `doAddAccount`'s `catch` deletes the managed home for *any* error. `removeManagedHomeUnlessUnproven` holds the rollback back when the failure is unproven — a kept home is a recoverable leak, a deleted one is permanent data loss.

The definitive-absence predicate moves to `src/shared/definitive-filesystem-absence.ts` so every lane reuses one errno allowlist instead of keeping its own copy. It lives in `src/shared` rather than beside the ownership gate because the CLI tsconfig project is an explicit allowlist that admits `src/main/codex` but not `src/main/codex-accounts`.

## Why

This is the same category error as #15046 and #15093, on the one path where the user is actively watching: a completed OAuth flow reported as a failure, with the credentials destroyed behind it. The user's natural response — sign in again — is the loop reported in STA-4422.

The login verdict deserves special note. The post-auth tree kill **only arms after the watcher has already observed new credential bytes** (`loginAuthChanged` requires a defined, non-null, changed read). So by the time that `existsSync` ran, the credentials had already been positively observed. It was re-confirming something already proven, and a lock at that instant threw the proof away.

Deliberately **not** here: the WSL lane (STA-4606), the shared config-mirror and resource-sync modules (STA-4737), and the remaining host-lane reads (STA-4735).

## Linked Issue

Fixes STA-4734.

Related: STA-4422 (the reported symptom), STA-4606, STA-4735, STA-4737.

## Visual Proof

N/A — no UI change. The user-visible difference is which error text appears and whether the account survives, both covered by tests.

## Testing

`src/main/codex-accounts/sta-4734-login-rollback-deletes-authenticated-home.test.ts` — 6 tests, 3 driving the fix and 3 anchoring it.

The fault rig models **one denial coherently**: a denied path fails `readFileSync` *and* reports `false` from `existsSync`. Faulting only one lets a test pass against code that still consults the other.

**Mutation-checked, not assumed:**

- Revert all three source changes ⇒ the 3 fix-driving tests go red, the 3 anchors stay green.
- Revert **only the rollback guard**, keeping the typed error ⇒ `expected [] to have a length of 1` — the home is still deleted. This is the check that proves the classification is not a call-site fix over a root that still destroys the data.

The anchors exist because "make the failure stop failing" is the easy wrong fix: a genuinely failed login still rolls the home back, a definitively absent `auth.json` after a tree kill still rejects, and a genuinely empty source home still reports "No Codex credentials found".

- 267/267 `src/main/codex-accounts` pass; 1069/1069 across `codex-accounts` + `codex`.
- `check-changed-code-quality.mjs`: 0 findings (code quality, type-aware, React Doctor).

- [x] Automated tests added
- [ ] Manual: not run. The trigger is a Windows file-denial race; the rig reproduces it deterministically and the earlier hardware work on this defect family (#15046, #15093) established that an ACL denial produces `EPERM` on these calls.

## Merge note

#15287 (STA-4737) touches the same predicate. Both PRs carry **byte-identical** copies of `src/shared/definitive-filesystem-absence.ts` and of the `host-codex-managed-home-ownership.ts` import change, so they merge cleanly in either order. Neither depends on the other.

(Rebased onto `main` after #15277 fixed an unrelated pre-existing typecheck failure.)

## AI Disclosure

N/A — internal.
