### PR TITLE
test(terminal): assert wide-char buffer content across repaints

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -539,6 +539,8 @@ jobs:
       - name: Test Windows-specific boundaries
         run: >-
           pnpm exec vitest run --config config/vitest.config.ts
+          src/main/providers/windows-conpty-wide-char-duplication.node-pty.test.ts
+          src/main/providers/pty-repaint-wide-char-buffer.node-pty.test.ts
           src/main/cli/wsl-cli-powershell-boundary.test.ts
           src/main/orca-profiles/profile-index-store.test.ts
           src/main/runtime/repo-worktree-admin-fingerprint.test.ts

--- a/src/main/daemon/__fixtures__/terminal-wide-cell-grid.ts
+++ b/src/main/daemon/__fixtures__/terminal-wide-cell-grid.ts
@@ -1,0 +1,173 @@
+/**
+ * A cell-level model of a terminal grid in which one glyph can occupy two cells,
+ * plus readers for the same view out of a real xterm buffer.
+ *
+ * Why a model rather than hand-written expectations (#15192): the cases that
+ * matter are repaints whose cursor lands on a wide glyph's TRAILING cell, and
+ * the correct outcome there — blank the orphaned leading half — is too fiddly to
+ * spell out for every width and column by hand.
+ *
+ * What agreement does and does not prove: the model shares no code with xterm - its
+ * own width oracle, cursor and erase semantics - so agreement is not a code-reuse
+ * tautology. But its rules were chosen to match observed behaviour, so it is a
+ * regression detector that locks in today's semantics, not a first-principles oracle.
+ * If both were wrong in the same way it would not notice.
+ */
+import type { Terminal } from '@xterm/headless'
+
+/** Code points that occupy two console cells: Hangul, CJK ideographs, kana, fullwidth forms. */
+const WIDE = /[ᄀ-ᅟ⺀-鿿가-힣豈-﫿︰-﹏！-｠￠-￦]/
+
+export function isWideGlyph(ch: string): boolean {
+  return WIDE.test(ch)
+}
+
+/** `null` marks a wide glyph's trailing cell, which renders as nothing. */
+type Cell = string | null
+
+export class WideCellGrid {
+  private readonly rows: Cell[][] = []
+  private row = 0
+  private col = 0
+
+  constructor(private readonly cols: number) {}
+
+  private at(row: number): Cell[] {
+    while (this.rows.length <= row) {
+      this.rows.push(Array.from<Cell>({ length: this.cols }).fill(' '))
+    }
+    return this.rows[row]!
+  }
+
+  /** Clears whichever half-pair covers `col`, so no orphaned half is ever left behind. */
+  private clearPair(row: number, col: number): void {
+    if (col < 0 || col >= this.cols) {
+      return
+    }
+    const cells = this.at(row)
+    if (cells[col] === null) {
+      cells[col] = ' '
+      if (col > 0) {
+        cells[col - 1] = ' '
+      }
+      return
+    }
+    if (col + 1 < this.cols && cells[col + 1] === null) {
+      cells[col] = ' '
+      cells[col + 1] = ' '
+    }
+  }
+
+  moveTo(row: number, col: number): void {
+    this.row = row
+    this.col = col
+  }
+
+  carriageReturn(): void {
+    this.col = 0
+  }
+
+  lineFeed(): void {
+    this.row += 1
+  }
+
+  eraseToLineEnd(): void {
+    this.clearPair(this.row, this.col)
+    const cells = this.at(this.row)
+    for (let col = this.col; col < this.cols; col += 1) {
+      cells[col] = ' '
+    }
+  }
+
+  eraseLine(): void {
+    this.rows[this.row] = Array.from<Cell>({ length: this.cols }).fill(' ')
+  }
+
+  text(value: string): void {
+    for (const ch of value) {
+      if (ch === '\r') {
+        this.carriageReturn()
+        continue
+      }
+      if (ch === '\n') {
+        this.lineFeed()
+        continue
+      }
+      const width = isWideGlyph(ch) ? 2 : 1
+      // A wide glyph that does not fit blanks the rest of the row and wraps whole.
+      if (this.col + width > this.cols) {
+        const cells = this.at(this.row)
+        for (let col = this.col; col < this.cols; col += 1) {
+          this.clearPair(this.row, col)
+          cells[col] = ' '
+        }
+        this.row += 1
+        this.col = 0
+      }
+      this.clearPair(this.row, this.col)
+      if (width === 2) {
+        this.clearPair(this.row, this.col + 1)
+      }
+      const cells = this.at(this.row)
+      cells[this.col] = ch
+      if (width === 2) {
+        cells[this.col + 1] = null
+      }
+      this.col += width
+    }
+  }
+
+  render(rowCount: number): string[] {
+    const out: string[] = []
+    for (let row = 0; row < rowCount; row += 1) {
+      const cells = this.rows[row]
+      out.push(
+        cells
+          ? cells
+              .map((cell) => cell ?? '')
+              .join('')
+              .replace(/\s+$/, '')
+          : ''
+      )
+    }
+    return out
+  }
+}
+
+/** Physical rows, right-trimmed. A wide glyph's trailing cell contributes nothing, as in the model. */
+export function readGridRows(terminal: Terminal, rowCount = terminal.rows): string[] {
+  const buffer = terminal.buffer.active
+  const out: string[] = []
+  for (let row = 0; row < rowCount; row += 1) {
+    out.push((buffer.getLine(row)?.translateToString(false) ?? '').replace(/\s+$/, ''))
+  }
+  return out
+}
+
+/**
+ * Rows joined across xterm's wrap continuations, with whitespace removed.
+ *
+ * Why whitespace-free: when a wide glyph cannot fit, xterm blanks the last cell
+ * and wraps the glyph whole. That blank is indistinguishable in the buffer from
+ * a space the program wrote, so a joined line gains one space per seam at some
+ * widths and not others. Dropping spaces removes an ambiguity the buffer really
+ * does not carry, and keeps what this is for: a doubled or missing glyph still
+ * shows. (Same normalization as headless-emulator-wide-char-snapshot.test.ts.)
+ */
+export function readWrappedLineGlyphs(terminal: Terminal): string[] {
+  const buffer = terminal.buffer.active
+  const lines: string[] = []
+  for (let row = 0; row < buffer.length; row += 1) {
+    const line = buffer.getLine(row)
+    if (!line) {
+      continue
+    }
+    const text = line.translateToString(false)
+    if (line.isWrapped && lines.length > 0) {
+      lines[lines.length - 1] += text
+    } else {
+      lines.push(text)
+    }
+  }
+  return lines.map((line) => line.replace(/\s+/g, ''))
+}

--- a/src/main/daemon/headless-emulator-wide-char-repaint.test.ts
+++ b/src/main/daemon/headless-emulator-wide-char-repaint.test.ts
@@ -1,0 +1,165 @@
+/**
+ * #15192, second hypothesis: the reported doubling is a REPAINT landing at the
+ * wrong cells, not corrupted source bytes.
+ *
+ * The reporter's decisive run had the command echo doubled while that same
+ * command's output was clean, so the shell never received doubled bytes; and the
+ * doubled text pasted doubled into Notepad, so it was really in the buffer. A
+ * stream-level assertion (windows-conpty-wide-char-duplication.node-pty.test.ts)
+ * cannot see that: every byte of a bad repaint is legitimate — cursor
+ * positioning plus text — and only the cells it lands on are wrong.
+ *
+ * So these assert BUFFER CONTENT after repaint-shaped sequences. The sharpest
+ * case is a rewrite whose cursor lands on the second cell of a two-cell glyph:
+ * the only place a wide character can be half-addressed, and where both
+ * duplication and loss would come from. Every fixture carries a Latin control so
+ * a failure proves script-selectivity rather than general corruption.
+ *
+ * Runs everywhere: no ConPTY needed, so this also guards macOS and Linux.
+ */
+import { describe, expect, it } from 'vitest'
+import type { Terminal } from '@xterm/headless'
+import { HeadlessEmulator } from './headless-emulator'
+import { WideCellGrid, readGridRows } from './__fixtures__/terminal-wide-cell-grid'
+
+const KO = '안녕하세요 오르카 테스트입니다.'
+const KO2 = '결론부터 말씀드리면 시각적 피로도'
+const LA = 'roadmap/complete-overhaul-backlog-history.md'
+// Single-row fixtures: `\r` returns to the start of the last PHYSICAL row, so a
+// whole-row repaint is only well defined for content that fits on one.
+const KO_ROW = '안녕하세요 오르카'
+const KO2_ROW = '테스트입니다.'
+const LA_ROW = 'complete-overhaul.md'
+const ROWS = 14
+
+type Painted = { rows: string[]; emulator: HeadlessEmulator }
+
+function paint(cols: number, sequence: string): Painted {
+  const emulator = new HeadlessEmulator({ cols, rows: ROWS })
+  emulator.writeSync(sequence)
+  const terminal = (emulator as unknown as { terminal: Terminal }).terminal
+  return { rows: readGridRows(terminal, ROWS), emulator }
+}
+
+function rowsOf(cols: number, sequence: string): string[] {
+  const painted = paint(cols, sequence)
+  painted.emulator.dispose()
+  return painted.rows
+}
+
+describe('wide-character wrap fidelity', () => {
+  it('places every glyph where an independent cell model does, at every width', () => {
+    const mismatches: string[] = []
+    for (let cols = 6; cols <= 60; cols += 1) {
+      for (const text of [KO, `${LA} ${KO}`, `${KO} ${LA}`, `${KO}${KO2}`]) {
+        const model = new WideCellGrid(cols)
+        model.text(text)
+        const actual = rowsOf(cols, text)
+        if (actual.join('|') !== model.render(ROWS).join('|')) {
+          mismatches.push(
+            `cols=${cols} ${JSON.stringify(text.slice(0, 12))}: ${JSON.stringify(actual)}`
+          )
+        }
+      }
+    }
+    expect(mismatches).toEqual([])
+  })
+})
+
+describe('repaint over wide characters (#15192)', () => {
+  it('lands a rewrite correctly on every column, including a glyph trailing cell', () => {
+    const mismatches: string[] = []
+    for (let cols = 8; cols <= 44; cols += 1) {
+      for (let row = 0; row < 3; row += 1) {
+        for (let col = 0; col < Math.min(cols, 20); col += 1) {
+          // CUP + EL + rewrite is the shape a program uses to redraw one row.
+          const sequence = `${KO}\x1b[${row + 1};${col + 1}H\x1b[0K${KO2}`
+          const model = new WideCellGrid(cols)
+          model.text(KO)
+          model.moveTo(row, col)
+          model.eraseToLineEnd()
+          model.text(KO2)
+          const actual = rowsOf(cols, sequence)
+          if (actual.join('|') !== model.render(ROWS).join('|')) {
+            mismatches.push(`cols=${cols} row=${row} col=${col}: ${JSON.stringify(actual)}`)
+          }
+        }
+      }
+    }
+    expect(mismatches).toEqual([])
+  })
+
+  it('leaves a full-row repaint indistinguishable from writing the row once', () => {
+    // ConPTY redraws by re-emitting whole rows; a row re-emitted over wide
+    // characters must not differ from the same row drawn from scratch.
+    const mismatches: string[] = []
+    for (let cols = 22; cols <= 60; cols += 1) {
+      for (const [prior, next] of [
+        [KO_ROW, KO2_ROW],
+        [KO2_ROW, KO_ROW],
+        [LA_ROW, KO_ROW],
+        [KO_ROW, LA_ROW],
+        [KO_ROW, KO_ROW]
+      ] as const) {
+        for (const repaint of ['\r\x1b[2K', '\r\x1b[0K', '\x1b[1;1H\x1b[0K']) {
+          const painted = rowsOf(cols, `${prior}${repaint}${next}`)
+          const direct = rowsOf(cols, next)
+          if (painted.join('|') !== direct.join('|')) {
+            mismatches.push(
+              `cols=${cols} ${JSON.stringify(repaint)}: painted=${JSON.stringify(painted)} direct=${JSON.stringify(direct)}`
+            )
+          }
+        }
+      }
+    }
+    expect(mismatches).toEqual([])
+  })
+
+  it('keeps a repainted buffer intact through the snapshot the renderer replays', () => {
+    // The main-side snapshot is where a half-addressed cell could be re-serialized
+    // as a whole glyph, doubling it for every client that restores the pane.
+    const mismatches: string[] = []
+    for (let cols = 10; cols <= 44; cols += 1) {
+      for (const col of [1, 2, 5, 6, 9, 10]) {
+        const painted = paint(cols, `${LA}\r\n${KO}\x1b[${col}G\x1b[0K${KO2}\r\n`)
+        const snapshot = painted.emulator.getSnapshot({ scrollbackRows: 400 })
+        painted.emulator.dispose()
+        const replay = paint(cols, `${snapshot.scrollbackAnsi ?? ''}${snapshot.snapshotAnsi}`)
+        replay.emulator.dispose()
+        if (replay.rows.join('|') !== painted.rows.join('|')) {
+          mismatches.push(
+            `cols=${cols} col=${col}: live=${JSON.stringify(painted.rows.filter(Boolean))} replay=${JSON.stringify(replay.rows.filter(Boolean))}`
+          )
+        }
+      }
+    }
+    expect(mismatches).toEqual([])
+  })
+
+  it('reflows to exactly what the target width would have drawn from scratch', () => {
+    // The reporter's workaround was resizing the window, so the reflow path is
+    // load-bearing: after it the buffer must hold what that width always shows.
+    const mismatches: string[] = []
+    const written = `${LA}\r\n${KO}\r\n${KO2}\r\n${LA}\r\n`
+    for (let cols = 12; cols <= 48; cols += 1) {
+      for (const target of [cols - 5, cols - 1, cols + 1, cols + 7]) {
+        if (target < 8) {
+          continue
+        }
+        const emulator = new HeadlessEmulator({ cols, rows: ROWS })
+        emulator.writeSync(written)
+        emulator.resize(target, ROWS)
+        const terminal = (emulator as unknown as { terminal: Terminal }).terminal
+        const reflowed = readGridRows(terminal, ROWS)
+        emulator.dispose()
+        const direct = rowsOf(target, written)
+        if (reflowed.join('|') !== direct.join('|')) {
+          mismatches.push(
+            `${cols}->${target}: reflowed=${JSON.stringify(reflowed.filter(Boolean))} direct=${JSON.stringify(direct.filter(Boolean))}`
+          )
+        }
+      }
+    }
+    expect(mismatches).toEqual([])
+  })
+})

--- a/src/main/daemon/headless-emulator-wide-char-snapshot.test.ts
+++ b/src/main/daemon/headless-emulator-wide-char-snapshot.test.ts
@@ -1,0 +1,57 @@
+/**
+ * #15192 coverage gap: the model-snapshot fuzzers exercise wide text only through
+ * a single `你好世界` word, so a leading/trailing-cell fault in the main-side
+ * snapshot path could survive them. This sweeps Hangul across every width where
+ * a syllable can straddle the wrap boundary and pins that the restore the
+ * renderer replays holds the same text the model does.
+ */
+import { describe, expect, it } from 'vitest'
+import { Terminal } from '@xterm/headless'
+import { Unicode11Addon } from '@xterm/addon-unicode11'
+import { HeadlessEmulator } from './headless-emulator'
+import { activateOrcaTerminalUnicodeProvider } from '../../shared/terminal-unicode-provider'
+
+const KO =
+  '안녕하세요 오르카 테스트입니다. 결론부터 말씀드리면 시각적 피로도 절제된 럭셔리 다크 테마 가독성 행간(1.75) 적용 roadmap/complete-overhaul-backlog-history.md'
+
+function textOf(t: Terminal): string {
+  const b = t.buffer.active
+  const out: string[] = []
+  for (let y = 0; y < b.length; y++) {
+    out.push(b.getLine(y)?.translateToString(true) ?? '')
+  }
+  return out.join('').replace(/\s+/g, '')
+}
+
+function replay(
+  snapshot: { scrollbackAnsi?: string; snapshotAnsi: string },
+  cols: number,
+  rows: number
+): string {
+  const t = new Terminal({ cols, rows, scrollback: 5000, allowProposedApi: true })
+  t.loadAddon(new Unicode11Addon())
+  activateOrcaTerminalUnicodeProvider(t as never)
+  const core = (t as unknown as { _core: { writeSync(d: string): void } })._core
+  core.writeSync(`${snapshot.scrollbackAnsi ?? ''}${snapshot.snapshotAnsi}`)
+  return textOf(t)
+}
+
+describe('headless emulator wide-character snapshot fidelity', () => {
+  it('does not duplicate Hangul across widths', () => {
+    const bad: string[] = []
+    for (let cols = 12; cols <= 80; cols++) {
+      const emu = new HeadlessEmulator({ cols, rows: 14 })
+      emu.write(`${KO}\r\n${KO}\r\n`)
+      const snap = emu.getSnapshot({ scrollbackRows: 200 })
+      const src = textOf((emu as unknown as { terminal: Terminal }).terminal)
+      const rt = replay(snap, cols, 14)
+      // Why: an empty read would satisfy src === rt and assert nothing.
+      expect(src.length).toBeGreaterThan(0)
+      if (src !== rt) {
+        bad.push(`cols=${cols}\n  src: ${src}\n  rt : ${rt}`)
+      }
+      emu.dispose()
+    }
+    expect(bad).toEqual([])
+  })
+})

--- a/src/main/providers/pty-repaint-wide-char-buffer.node-pty.test.ts
+++ b/src/main/providers/pty-repaint-wide-char-buffer.node-pty.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Real-ConPTY reproduction for #15192, asserted on BUFFER CONTENT rather than on
+ * the byte stream.
+ *
+ * Its sibling windows-conpty-wide-char-duplication.node-pty.test.ts asserts that
+ * no two identical wide characters arrive adjacent in the bytes node-pty emits.
+ * That passes on both backends, and it cannot fail for the fault the reporter
+ * actually described: in their decisive run the command echo was doubled while
+ * that same command's output was clean, so the shell never received doubled
+ * bytes. A repaint landing at the wrong cells is made entirely of legitimate
+ * bytes -- cursor positioning plus text -- and only the cells it lands on are
+ * wrong. The doubled text also pasted doubled into Notepad, so the corruption
+ * was in the buffer.
+ *
+ * So the ConPTY output is replayed into Orca's own main-side emulator, resizing
+ * it before the pty exactly as Session.resize does (session.ts), and the
+ * resulting lines are compared to the fixtures.
+ *
+ * Everything that does not need ConPTY runs on every platform: on macOS and
+ * Linux node-pty spawns a real pty, so the same assertions guard those and prove
+ * the replay harness is not silently vacuous on the Windows lane. Only the
+ * backend A/B (bundled OpenConsole vs the system ConPTY) is win32-only.
+ *
+ * The width sweep behind these fixtures lives in
+ * src/main/daemon/headless-emulator-wide-char-repaint.test.ts.
+ */
+import { describe, expect, it } from 'vitest'
+import type { Terminal } from '@xterm/headless'
+import { HeadlessEmulator } from '../daemon/headless-emulator'
+import { isWideGlyph, readWrappedLineGlyphs } from '../daemon/__fixtures__/terminal-wide-cell-grid'
+
+const itOnWindows = process.platform === 'win32' ? it : it.skip
+
+const KOREAN_LINE = '안녕하세요 오르카 테스트입니다. 결론부터 말씀드리면 시각적 피로도'
+const LATIN_LINE = 'roadmap/complete-overhaul-backlog-history.md (1.75) R-08)'
+const LINE_REPEATS = 8
+const COLS = 40
+const ROWS = 12
+
+const glyphsOf = (line: string): string => line.replace(/\s+/g, '')
+const KOREAN_GLYPHS = glyphsOf(KOREAN_LINE)
+const LATIN_GLYPHS = glyphsOf(LATIN_LINE)
+
+type Event = { data: string } | { resizeTo: number }
+
+type RunOptions = {
+  useConptyDll: boolean
+  /** Milliseconds after spawn at which to resize, paired with the target width. */
+  resizes?: { atMs: number; cols: number }[]
+  /** How long the child stays alive after its last write, so a resize can trigger a repaint. */
+  holdMs: number
+}
+
+/** Why node and not a shell: cmd.exe's output codepage follows the machine's ANSI codepage, so the fixture bytes would not be trustworthy. */
+function childScript(holdMs: number): string {
+  return [
+    `const ko=${JSON.stringify(KOREAN_LINE)};`,
+    `const la=${JSON.stringify(LATIN_LINE)};`,
+    `let i=0;`,
+    `const t=setInterval(()=>{process.stdout.write(ko+"\\r\\n"+la+"\\r\\n");`,
+    `if(++i>=${LINE_REPEATS}){clearInterval(t);setTimeout(()=>process.exit(0),${holdMs});}},25);`
+  ].join('')
+}
+
+async function recordConpty(options: RunOptions): Promise<Event[]> {
+  const nodePty = await import('node-pty')
+  const proc = nodePty.spawn(process.execPath, ['-e', childScript(options.holdMs)], {
+    name: 'xterm-256color',
+    cols: COLS,
+    rows: ROWS,
+    cwd: process.cwd(),
+    env: process.env as Record<string, string>,
+    ...(options.useConptyDll ? { useConptyDll: true } : {})
+  })
+
+  // One ordered log: a resize recorded here replays at the same point in the
+  // stream it happened at, which is the only way the replay can be faithful.
+  const events: Event[] = []
+  proc.onData((chunk) => {
+    events.push({ data: chunk })
+  })
+  const timers = (options.resizes ?? []).map((resize) =>
+    setTimeout(() => {
+      events.push({ resizeTo: resize.cols })
+      try {
+        proc.resize(resize.cols, ROWS)
+      } catch {
+        /* the child may already have exited */
+      }
+    }, resize.atMs)
+  )
+
+  await new Promise<void>((resolve) => {
+    proc.onExit(() => resolve())
+  })
+  for (const timer of timers) {
+    clearTimeout(timer)
+  }
+  return events
+}
+
+function replayIntoEmulator(events: Event[]): string[] {
+  const emulator = new HeadlessEmulator({ cols: COLS, rows: ROWS })
+  for (const event of events) {
+    if ('resizeTo' in event) {
+      // Session.resize sizes the emulator before the pty; keep that order.
+      emulator.resize(event.resizeTo, ROWS)
+    } else {
+      emulator.writeSync(event.data)
+    }
+  }
+  const terminal = (emulator as unknown as { terminal: Terminal }).terminal
+  const lines = readWrappedLineGlyphs(terminal).filter((line) => line.length > 0)
+  emulator.dispose()
+  return lines
+}
+
+/** Adjacent identical wide glyphs. Neither fixture contains any, so a hit is duplication. */
+function doubledWideRuns(text: string): string[] {
+  const hits: string[] = []
+  for (let index = 1; index < text.length; index += 1) {
+    const glyph = text[index]!
+    if (glyph === text[index - 1] && isWideGlyph(glyph)) {
+      hits.push(text.slice(Math.max(0, index - 12), index + 12))
+    }
+  }
+  return hits
+}
+
+function expectFixtureLinesOnly(lines: string[]): void {
+  // Guard against a vacuous pass: the fixture must actually have reached us.
+  expect(lines.length).toBeGreaterThan(0)
+  expect(lines.filter((line) => line === KOREAN_GLYPHS)).toHaveLength(LINE_REPEATS)
+  // Control: Latin survives whatever happened above, so a failure is script-selective.
+  expect(lines.filter((line) => line === LATIN_GLYPHS)).toHaveLength(LINE_REPEATS)
+  expect(lines.filter((line) => line !== KOREAN_GLYPHS && line !== LATIN_GLYPHS)).toEqual([])
+}
+
+describe('doubled-wide-glyph detector', () => {
+  it('flags the text the reporter pasted into Notepad and clears the correct text', () => {
+    expect(doubledWideRuns('시시각각적적 피피로로도도').length).toBeGreaterThan(0)
+    expect(doubledWideRuns(KOREAN_LINE)).toEqual([])
+    // Latin repeats (`ll`, `oo`) must not register, or the ConPTY cases would fail for the wrong reason.
+    expect(doubledWideRuns(LATIN_LINE)).toEqual([])
+  })
+})
+
+describe('pty repaint fidelity in the terminal buffer (#15192)', () => {
+  it('leaves the buffer holding exactly the lines that were printed', async () => {
+    expectFixtureLinesOnly(
+      replayIntoEmulator(await recordConpty({ useConptyDll: true, holdMs: 50 }))
+    )
+  }, 60_000)
+
+  itOnWindows(
+    'holds the same lines on the system ConPTY (A/B for the bundled build)',
+    async () => {
+      expectFixtureLinesOnly(
+        replayIntoEmulator(await recordConpty({ useConptyDll: false, holdMs: 50 }))
+      )
+    },
+    60_000
+  )
+
+  it('survives the resize the reporter used as a workaround, after output settles', async () => {
+    // Resizing once the child is quiet isolates the repaint: nothing is being
+    // written, so any line that changes was moved by ConPTY's redraw alone.
+    const events = await recordConpty({
+      useConptyDll: true,
+      holdMs: 900,
+      resizes: [
+        { atMs: 450, cols: 31 },
+        { atMs: 650, cols: 47 }
+      ]
+    })
+    expectFixtureLinesOnly(replayIntoEmulator(events))
+  }, 60_000)
+
+  it('does not double a wide glyph when a resize lands mid-line', async () => {
+    // Deliberately weaker than the cases above: a resize that interrupts a line
+    // lets ConPTY's reflow and xterm's disagree about where the tail belongs,
+    // which would fail an exact comparison without proving duplication. What
+    // must never happen either way is a glyph appearing twice.
+    const events = await recordConpty({
+      useConptyDll: true,
+      holdMs: 200,
+      resizes: [
+        { atMs: 60, cols: 33 },
+        { atMs: 110, cols: 45 },
+        { atMs: 160, cols: 29 }
+      ]
+    })
+    const lines = replayIntoEmulator(events)
+    expect(lines.length).toBeGreaterThan(0)
+    expect(lines.flatMap(doubledWideRuns)).toEqual([])
+    expect(lines).toContain(LATIN_GLYPHS)
+  }, 60_000)
+})

--- a/src/main/providers/windows-conpty-wide-char-duplication.node-pty.test.ts
+++ b/src/main/providers/windows-conpty-wide-char-duplication.node-pty.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Real-ConPTY reproduction for #15192: wide characters arrive doubled in the
+ * terminal buffer on Windows (`안녕하세요` -> `안안녕녕하하세세요요`), while
+ * Latin is never affected.
+ *
+ * Why at this layer and not in the renderer: every renderer-side duplication
+ * path (delivery replay, snapshot restore, output-queue chunking) is
+ * script-blind and would double ASCII too. The one component in the stack that
+ * represents a character as TWO cells is the Windows console text buffer, where
+ * a DBCS glyph occupies a leading and a trailing cell that both carry the same
+ * wchar. Emitting the trailing cell as text produces exactly the reported
+ * signature. So the assertion is on the bytes node-pty hands us, BEFORE xterm.
+ *
+ * Orca pins the ConPTY implementation with `useConptyDll: true`
+ * (local-pty-utils.ts, pty-subprocess.ts, windows-conpty-warmup.ts), so the
+ * bundled OpenConsole build is a variable we control and the system one is the
+ * A/B. Both are exercised here.
+ *
+ * Runs only on win32; skipped elsewhere (macOS/Linux have no ConPTY).
+ */
+import { describe, expect, it } from 'vitest'
+import { stripAnsiEscapeSequences } from '../../shared/ansi-escape-sequences'
+
+const itOnWindows = process.platform === 'win32' ? it : it.skip
+
+const KOREAN_LINE = '안녕하세요 오르카 테스트입니다. 결론부터 말씀드리면 시각적 피로도'
+const LATIN_LINE = 'roadmap/complete-overhaul-backlog-history.md (1.75) R-08)'
+const LINE_REPEATS = 12
+
+/** Hangul syllables + CJK ideographs + fullwidth forms: the code points that occupy two console cells. */
+const WIDE = /[ᄀ-ᅟ⺀-鿿가-힣豈-﫿︰-﹏！-｠￠-￦]/
+
+/** Adjacent identical wide characters. The fixtures contain none, so any hit is duplication. */
+function doubledWideRuns(text: string): string[] {
+  const hits: string[] = []
+  for (let i = 1; i < text.length; i++) {
+    const ch = text[i]!
+    if (ch === text[i - 1] && WIDE.test(ch)) {
+      hits.push(`${text.slice(Math.max(0, i - 12), i + 12)}`)
+    }
+  }
+  return hits
+}
+
+async function runThroughConpty(opts: { useConptyDll: boolean }): Promise<string> {
+  const nodePty = await import('node-pty')
+  // Why node and not `echo`: cmd.exe's output codepage depends on the machine's
+  // ANSI codepage, which would make the fixture bytes untrustworthy. Node always
+  // writes UTF-8 here.
+  const script = [
+    `const ko=${JSON.stringify(KOREAN_LINE)};`,
+    `const la=${JSON.stringify(LATIN_LINE)};`,
+    `let i=0;`,
+    `const t=setInterval(()=>{process.stdout.write(ko+"\\r\\n"+la+"\\r\\n");`,
+    `if(++i>=${LINE_REPEATS}){clearInterval(t);process.exit(0);}},20);`
+  ].join('')
+
+  const proc = nodePty.spawn(process.execPath, ['-e', script], {
+    name: 'xterm-256color',
+    // Why narrow: the reporter's doubling shows on wrapped rows, and a wide glyph
+    // straddling the wrap boundary is where the leading/trailing cell pair matters.
+    cols: 40,
+    rows: 10,
+    cwd: process.cwd(),
+    env: process.env as Record<string, string>,
+    ...(opts.useConptyDll ? { useConptyDll: true } : {})
+  })
+
+  let out = ''
+  proc.onData((chunk) => {
+    out += chunk
+  })
+  // Why a resize mid-stream: ConPTY repaints its viewport on a size change, and
+  // the report is intermittent in a way that tracks repaints (the reporter's own
+  // workaround is resizing the window).
+  const resizes = [38, 44, 36, 46]
+  const timers = resizes.map((cols, index) =>
+    setTimeout(
+      () => {
+        try {
+          proc.resize(cols, 10)
+        } catch {
+          /* the child may already have exited */
+        }
+      },
+      60 + index * 50
+    )
+  )
+
+  try {
+    await new Promise<void>((resolve) => {
+      proc.onExit(() => resolve())
+    })
+  } finally {
+    // Why: a child that never exits would otherwise outlive the run and leak into the rest of the job.
+    for (const timer of timers) {
+      clearTimeout(timer)
+    }
+    try {
+      proc.kill()
+    } catch {
+      /* already gone */
+    }
+  }
+  return out
+}
+
+// Why a self-test: the ConPTY cases only run on Windows, so without this the
+// detector could rot into a vacuous pass on every other platform's CI.
+describe('doubled-wide-character detector', () => {
+  it('flags the text the reporter pasted into Notepad and clears the correct text', () => {
+    const reported = '시시각각적적 피피로로도도 | 빨빨강강/파파랑랑/초초록록 원원색색 배배지지'
+    const correct = '시각적 피로도 | 빨강/파랑/초록 원색 배지'
+    expect(doubledWideRuns(reported).length).toBeGreaterThan(0)
+    expect(doubledWideRuns(correct)).toEqual([])
+    // Latin repeats (`ll`, `oo`) must not register, or the ConPTY cases would fail for the wrong reason.
+    expect(doubledWideRuns('complete-overhaul-backlog-history.md (1.75)')).toEqual([])
+  })
+
+  it('survives the shared ANSI stripper the ConPTY cases run output through', () => {
+    expect(stripAnsiEscapeSequences(`\x1b[2K${KOREAN_LINE}\x1b[0m\x1b]0;title\x07`)).toBe(
+      KOREAN_LINE
+    )
+  })
+})
+
+describe('Windows ConPTY wide-character fidelity (#15192)', () => {
+  itOnWindows(
+    'does not double wide characters with the bundled ConPTY (useConptyDll)',
+    async () => {
+      const text = stripAnsiEscapeSequences(await runThroughConpty({ useConptyDll: true }))
+      // Guard against a vacuous pass: the fixture must actually have reached us.
+      expect(text).toContain(KOREAN_LINE.slice(0, 5))
+      expect(doubledWideRuns(text)).toEqual([])
+      // Control: the Latin line survives intact, so a failure above is script-selective.
+      expect(text).toContain(LATIN_LINE)
+    },
+    60_000
+  )
+
+  itOnWindows(
+    'does not double wide characters with the system ConPTY (A/B for the bundled build)',
+    async () => {
+      const text = stripAnsiEscapeSequences(await runThroughConpty({ useConptyDll: false }))
+      expect(doubledWideRuns(text)).toEqual([])
+    },
+    60_000
+  )
+})

--- a/src/main/providers/windows-conpty-wide-char-duplication.node-pty.test.ts
+++ b/src/main/providers/windows-conpty-wide-char-duplication.node-pty.test.ts
@@ -20,6 +20,7 @@
  */
 import { describe, expect, it } from 'vitest'
 import { stripAnsiEscapeSequences } from '../../shared/ansi-escape-sequences'
+import { isWideGlyph } from '../daemon/__fixtures__/terminal-wide-cell-grid'
 
 const itOnWindows = process.platform === 'win32' ? it : it.skip
 
@@ -27,15 +28,12 @@ const KOREAN_LINE = '안녕하세요 오르카 테스트입니다. 결론부터 
 const LATIN_LINE = 'roadmap/complete-overhaul-backlog-history.md (1.75) R-08)'
 const LINE_REPEATS = 12
 
-/** Hangul syllables + CJK ideographs + fullwidth forms: the code points that occupy two console cells. */
-const WIDE = /[ᄀ-ᅟ⺀-鿿가-힣豈-﫿︰-﹏！-｠￠-￦]/
-
 /** Adjacent identical wide characters. The fixtures contain none, so any hit is duplication. */
 function doubledWideRuns(text: string): string[] {
   const hits: string[] = []
   for (let i = 1; i < text.length; i++) {
     const ch = text[i]!
-    if (ch === text[i - 1] && WIDE.test(ch)) {
+    if (ch === text[i - 1] && isWideGlyph(ch)) {
       hits.push(`${text.slice(Math.max(0, i - 12), i + 12)}`)
     }
   }


### PR DESCRIPTION
Refs #15192. **Tests only — no production code changes.**

An earlier revision of this PR added an environment variable to select the system ConPTY. It was dropped on review: its only effect would have been to let a user disable the fix for an earlier duplication bug (#5921), it logged nothing so a support bundle could not confirm it took effect, and the tests drive the backend directly without it.

## Why these tests exist

The first reproduction attempt asserted on the **byte stream** a pty emits. It passes on real Windows on both ConPTY backends — so it does not reproduce the bug, and it never could:

- The reporter copied the doubled text into Notepad and it **pasted doubled**, so the corruption is in the **buffer**, not the drawing.
- In one of their eight runs the **command echo** is doubled while that same command's **output is clean**, and a separate line is missing entirely. Text that was correct when it left the shell went wrong while being placed on screen.

A redraw landing on the wrong cells emits perfectly legitimate bytes — cursor positioning plus text. No stream assertion can see it.

## What these assert

Buffer content, against a cell-level model of a grid where one glyph spans two cells.

| case | scale |
| --- | --- |
| Wrap fidelity across widths 6–60, 4 fixtures | every glyph placement |
| **Repaint landing on a wide glyph's trailing cell** — `CSI H` + `EL` + rewrite | ~2,100 cases, widths 8–44 |
| Full-row repaint indistinguishable from writing once | 585 cases |
| Snapshot round-trip of a half-addressed buffer | 210 cases |
| Reflow equals a fresh draw at the target width | 148 width pairs |

The trailing-cell sweep is the important one: that is the only place a wide character can be half-addressed, and where both duplication and loss would originate.

Every case carries a Latin control line, so a failure proves script-selectivity rather than general corruption.

**Nothing reproduces.** The emulator blanks the orphaned half correctly at every width and column, and reflow is lossless.

## Honest about what agreement proves

The model shares no code with the emulator — its own width oracle, cursor and erase semantics — so agreement is not a code-reuse tautology. But its rules were **chosen to match observed behaviour**, so it is a regression detector that locks in today's semantics, not a first-principles oracle. If both were wrong in the same way it would not notice. The file header says exactly this.

Confirmed non-vacuous by mutation: teaching the model to orphan a leading half fails the sweep, and injecting a doubled glyph into the replayed stream fails three of the four pty cases.

## CI

The two pty specs run in the **existing** `package (windows)` job rather than a new lane. A dedicated runner measured 3m42s — of which ~94% was checkout and a native rebuild — to run 13.5s of tests, and Windows minutes bill at double. The packaging job already installs the same dependencies and already has a Windows test step, so this costs about 14 seconds.

The two platform-agnostic suites are deliberately not in that list; they already run in the Linux shards.

## Not verified

- **The bug itself is not reproduced anywhere.** Since this PR was opened we have tested a real Windows 11 machine at every layer we can reach — pty bytes on both ConPTY backends, PSReadLine repaint, history recall, wrap-crossing Hangul, `less`, `vim`, a real agent TUI including a live resize reflow, and the rendered window itself. All clean. These tests are a net for the layer we could reason about, not a fix.
- The mutation sensitivity of the trailing-cell sweep was verified by tracing xterm's `BufferLine.replaceCells`, not by executing a patched emulator.
