### PR TITLE
fix(native-chat): retire optimistic echoes the agent absorbed as a continuation

### DIFF
--- a/mobile/src/session/mobile-native-chat-pending-retirement.test.ts
+++ b/mobile/src/session/mobile-native-chat-pending-retirement.test.ts
@@ -60,6 +60,33 @@ describe('selectGluedPendingIds', () => {
     expect(retiredIds(messages, pending)).toEqual(['p1', 'p2'])
   })
 
+  // `first\` + Enter is a newline request to the agent TUI, not a submit, so the
+  // next send lands in the SAME turn with the backslash dropped. The echo keeps
+  // a character the transcript row never has.
+  it('retires a pair whose first send ended in a continuation backslash', () => {
+    const messages = [
+      assistantTurn('m1', 'ready', 1000),
+      userTurn('m2', 'run the tests\nagain', 5000)
+    ]
+    const pending = [pendingSend('p1', 'run the tests\\', 'm1'), pendingSend('p2', 'again', 'm1')]
+    expect(retiredIds(messages, pending)).toEqual(['p1', 'p2'])
+  })
+
+  it('retires a lone continuation echo absorbed into a longer turn', () => {
+    const messages = [
+      assistantTurn('m1', 'ready', 1000),
+      userTurn('m2', 'run the tests\nfrom another client', 5000)
+    ]
+    const pending = [pendingSend('p1', 'run the tests\\', 'm1')]
+    expect(retiredIds(messages, pending)).toEqual(['p1'])
+  })
+
+  it('keeps a continuation echo when a later row only shares its prefix', () => {
+    const messages = [assistantTurn('m1', 'ready', 1000), userTurn('m2', 'history repeats', 5000)]
+    const pending = [pendingSend('p1', 'hi\\', 'm1')]
+    expect(retiredIds(messages, pending)).toEqual([])
+  })
+
   it('retires three collapsed prompts in one row', () => {
     const messages = [assistantTurn('m1', 'ready', 1000), userTurn('m2', 'one two three', 5000)]
     const pending = [

--- a/mobile/src/session/mobile-native-chat-pending-retirement.ts
+++ b/mobile/src/session/mobile-native-chat-pending-retirement.ts
@@ -1,3 +1,4 @@
+import { nativeChatContinuationSendText } from '../../../src/shared/native-chat-continuation-send'
 import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
 import {
   countImageSourceTurnsAfter,
@@ -17,7 +18,7 @@ const NO_PENDING_IDS: ReadonlySet<string> = new Set()
 export const GLUE_SLIDE_BUDGET = 8
 
 type UserTurn = { index: number; text: string }
-type GlueSegment = { text: string; tail: number } | null
+type GlueSegment = { text: string; tail: number; continuation: boolean } | null
 
 /** Pending ids represented by post-send transcript rows that glued adjacent sends. */
 export function selectGluedPendingIds(
@@ -26,7 +27,9 @@ export function selectGluedPendingIds(
   excludedPendingIds: ReadonlySet<string> = NO_PENDING_IDS
 ): ReadonlySet<string> {
   const retired = new Set<string>()
-  if (pending.length < 2) {
+  // A continuation send never submitted, so its row is the only thing that can
+  // retire it — it does not need a partner to be represented.
+  if (pending.length < 2 && !pending.some((item) => nativeChatContinuationSendText(item.text))) {
     return retired
   }
   const messageIndexById = new Map<string, number>()
@@ -39,7 +42,8 @@ export function selectGluedPendingIds(
     }
   }
   const segments: GlueSegment[] = pending.map((item) => {
-    const text = normalizeReconcileText(item.text)
+    const continuation = nativeChatContinuationSendText(item.text)
+    const text = continuation ?? normalizeReconcileText(item.text)
     const tail =
       item.baselineTailMessageId === null
         ? -1
@@ -50,7 +54,7 @@ export function selectGluedPendingIds(
       text === '' ||
       tail === null
       ? null
-      : { text, tail }
+      : { text, tail, continuation: continuation !== null }
   })
 
   // Barriers preserve original adjacency after exact landings retire.
@@ -65,7 +69,7 @@ export function selectGluedPendingIds(
     }
     let cursor = runStart
     for (const turn of turns) {
-      if (cursor >= runEnd - 1) {
+      if (cursor >= runEnd) {
         break
       }
       // A send that can never match must not freeze the run behind it. One
@@ -77,7 +81,7 @@ export function selectGluedPendingIds(
       let budget = runEnd - runStart + GLUE_SLIDE_BUDGET
       let start = cursor
       let matched = 0
-      for (; start <= runEnd - 2 && budget > 0; start++) {
+      for (; start <= runEnd - 1 && budget > 0; start++) {
         const attempt = matchGluedRun(turn, segments, start, runEnd)
         budget -= attempt.inspected
         matched = attempt.matched
@@ -98,7 +102,9 @@ export function selectGluedPendingIds(
   return retired
 }
 
-/** Length of the exact glued run at `start`, plus the segments it had to read. */
+/** Length of the run at `start` this turn represents, plus the segments it had
+ *  to read. A run ends either by consuming the whole turn (glue) or at a
+ *  continuation send, which left the input line open for text sent elsewhere. */
 function matchGluedRun(
   turn: UserTurn,
   segments: readonly GlueSegment[],
@@ -107,6 +113,7 @@ function matchGluedRun(
 ): { matched: number; inspected: number } {
   let at = 0
   let matched = 0
+  let opened = 0
   let inspected = 0
   for (let index = start; index < end; index++) {
     const segment = segments[index]!
@@ -114,22 +121,27 @@ function matchGluedRun(
     // Every send carries its OWN boundary: a row that already existed when this
     // send was issued can never be part of its echo, however well it reads.
     if (turn.index <= segment.tail) {
-      return { matched: 0, inspected }
+      return { matched: opened, inspected }
     }
     if (at > 0 && turn.text[at] === SPACE) {
       at += 1
     }
     if (!turn.text.startsWith(segment.text, at)) {
-      return { matched: 0, inspected }
+      return { matched: opened, inspected }
     }
     at += segment.text.length
     matched += 1
+    // Stop on the separator the TUI's continuation newline normalizes to, so a
+    // longer unrelated turn cannot swallow a send ("hi" ↛ "history").
+    if (segment.continuation && (at === turn.text.length || turn.text[at] === SPACE)) {
+      opened = matched
+    }
     if (at === turn.text.length) {
       // A lone exact match is an ordinary landing, which the count pass owns.
-      return { matched: matched > 1 ? matched : 0, inspected }
+      return { matched: matched > 1 ? matched : opened, inspected }
     }
   }
-  return { matched: 0, inspected }
+  return { matched: opened, inspected }
 }
 
 /** Retires exact and glued transcript landings while preserving pending order. */

--- a/src/renderer/src/components/native-chat/native-chat-pending-occurrence.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending-occurrence.ts
@@ -1,3 +1,4 @@
+import { nativeChatContinuationSendText } from '../../../../shared/native-chat-continuation-send'
 import {
   normalizeNativeChatUserText,
   normalizedNativeChatUserMessageText
@@ -153,6 +154,41 @@ export function countLeadingPendingTextsGluedToUserText(
   return 0
 }
 
+/**
+ * How many leading pending texts a row absorbed because the last of them ended
+ * in a continuation backslash. That send never submitted, so unlike glue the row
+ * need not be consumed — the rest of it was typed where this queue cannot see.
+ * The run still stops on the separator the TUI's newline normalizes to, so a
+ * longer unrelated row cannot swallow a send ("hi" ↛ "history").
+ */
+function countLeadingPendingTextsOpeningUserText(
+  pieces: readonly { text: string; continuation: boolean }[],
+  userText: string
+): number {
+  let cursor = 0
+  let opened = 0
+  for (let index = 0; index < pieces.length; index += 1) {
+    const piece = pieces[index]
+    if (!piece?.text) {
+      return opened
+    }
+    if (userText.startsWith(piece.text, cursor)) {
+      cursor += piece.text.length
+    } else if (index > 0 && userText.startsWith(` ${piece.text}`, cursor)) {
+      cursor += piece.text.length + 1
+    } else {
+      return opened
+    }
+    if (piece.continuation && (cursor === userText.length || userText[cursor] === ' ')) {
+      opened = index + 1
+    }
+    if (cursor === userText.length) {
+      return opened
+    }
+  }
+  return opened
+}
+
 /** A transcript row a glue match may consume, carrying the send boundaries it
  *  satisfies — this matcher has no clock of its own. */
 export type NativeChatGluedUserRow = {
@@ -173,13 +209,18 @@ export function selectPendingIndicesRepresentedByUserRows(
   rows: readonly NativeChatGluedUserRow[]
 ): Set<number> {
   const represented = new Set<number>()
-  if (pending.length < 2 || rows.length === 0) {
+  const remaining = pending.map((entry, index) => {
+    const continuation = nativeChatContinuationSendText(entry.text)
+    return {
+      index,
+      text: continuation ?? normalizeNativeChatPendingText(entry.text),
+      continuation: continuation !== null
+    }
+  })
+  // A continuation send can be represented on its own: it cannot be a turn.
+  if (rows.length === 0 || (pending.length < 2 && !remaining.some((entry) => entry.continuation))) {
     return represented
   }
-  const remaining = pending.map((entry, index) => ({
-    index,
-    text: normalizeNativeChatPendingText(entry.text)
-  }))
   for (const row of rows) {
     const open: typeof remaining = []
     for (const entry of remaining) {
@@ -197,11 +238,14 @@ export function selectPendingIndicesRepresentedByUserRows(
       open.map((entry) => entry.text),
       row.text
     )
-    // Why: gluedCount === 1 is an exact match — leave it to occurrence counting.
-    if (gluedCount < 2) {
+    // Why: gluedCount === 1 is an exact match — leave it to occurrence counting,
+    // unless the send held the input line open, which no exact key can match.
+    const matched =
+      gluedCount >= 2 ? gluedCount : countLeadingPendingTextsOpeningUserText(open, row.text)
+    if (matched === 0) {
       continue
     }
-    for (let i = 0; i < gluedCount; i += 1) {
+    for (let i = 0; i < matched; i += 1) {
       const entry = open[i]
       if (!entry) {
         continue

--- a/src/renderer/src/components/native-chat/native-chat-pending.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.test.ts
@@ -300,6 +300,90 @@ describe('glued rapid sends', () => {
     expect(prunePendingSends(pending, advancedGlueTranscript('hi there'))).toEqual(pending)
   })
 
+  // A draft ending in `\` is a newline request to the agent TUI, not a submit:
+  // measured against Claude Code v2.1.234, `first\` + CR leaves the input open
+  // with the backslash dropped, so the next send lands in the SAME turn
+  // ("first\nsecond"). The echo keeps the backslash the transcript never has.
+  it('retires a pair whose first send ended in a continuation backslash', () => {
+    const pending = [gluePending('p1', 'tell me a joke\\'), gluePending('p2', 'continue')]
+
+    expect(prunePendingSends(pending, advancedGlueTranscript('tell me a joke\ncontinue'))).toEqual(
+      []
+    )
+  })
+
+  it('hides a continuation-backslash pair as soon as its glued row lands', () => {
+    const pending = [gluePending('p1', 'tell me a joke\\'), gluePending('p2', 'continue')]
+
+    expect(pendingSendsAsMessages(pending, glueTranscript('tell me a joke\ncontinue'))).toEqual([])
+  })
+
+  // The observed report: the rest of the turn was finished somewhere this queue
+  // cannot see (another client, or typed into the pane), so the echo is alone.
+  it('retires a lone continuation echo absorbed into a longer turn', () => {
+    const pending = [gluePending('p1', 'tell me a joke\\')]
+
+    expect(
+      prunePendingSends(pending, advancedGlueTranscript('tell me a joke\nabout cats'))
+    ).toEqual([])
+  })
+
+  it('keeps a continuation echo when a later row only shares its prefix', () => {
+    const pending = [gluePending('p1', 'hi\\')]
+
+    expect(prunePendingSends(pending, advancedGlueTranscript('history repeats'))).toEqual(pending)
+  })
+
+  it('retires a continuation echo the user then submitted on its own', () => {
+    // `\` + Enter, then Enter again on the empty line it opened.
+    const pending = [gluePending('p1', 'tell me a joke\\')]
+
+    expect(prunePendingSends(pending, advancedGlueTranscript('tell me a joke'))).toEqual([])
+  })
+
+  it('retires a pair when only the last of several backslashes was eaten', () => {
+    const pending = [gluePending('p1', 'tell me a joke\\\\'), gluePending('p2', 'continue')]
+
+    expect(
+      prunePendingSends(pending, advancedGlueTranscript('tell me a joke\\\ncontinue'))
+    ).toEqual([])
+  })
+
+  it('retires a run of three sends chained by continuations', () => {
+    const pending = [
+      gluePending('p1', 'first\\'),
+      gluePending('p2', 'second\\'),
+      gluePending('p3', 'third')
+    ]
+
+    expect(prunePendingSends(pending, advancedGlueTranscript('first\nsecond\nthird'))).toEqual([])
+  })
+
+  it('retires the reported prompt, whose text is not Latin', () => {
+    const pending = [
+      gluePending('p1', '사양을 올리는게 가능해? 이건 과금의 영역아니야?\\'),
+      gluePending('p2', '일단 퀵하게 되는 버전으로 반영되어야할거같아')
+    ]
+
+    expect(
+      prunePendingSends(
+        pending,
+        advancedGlueTranscript(
+          '사양을 올리는게 가능해? 이건 과금의 영역아니야?\n일단 퀵하게 되는 버전으로 반영되어야할거같아'
+        )
+      )
+    ).toEqual([])
+  })
+
+  it('keeps a continuation echo the row breaks mid-word', () => {
+    // The run must stop on the separator the TUI's newline normalizes to.
+    const pending = [gluePending('p1', 'tell me a jo\\')]
+
+    expect(prunePendingSends(pending, advancedGlueTranscript('tell me a joke about cats'))).toEqual(
+      pending
+    )
+  })
+
   it('keeps a queued pair when an earlier turn splits across it (#14406 regression)', () => {
     // The row predates both sends: "run the tests"+"again" only looks glued.
     const pending = [pendingOf('p1', 'run the tests'), pendingOf('p2', 'again')]

--- a/src/renderer/src/components/native-chat/native-chat-pending.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.ts
@@ -3,6 +3,7 @@
 // user turn lands in the transcript. Kept separate from the view so the prune
 // rule (match on normalized user-message content) is unit-testable without React.
 
+import { nativeChatContinuationSendText } from '../../../../shared/native-chat-continuation-send'
 import type { NativeChatMessage } from '../../../../shared/native-chat-types'
 import { setBoundedScopeCacheEntry } from './native-chat-composer-scope-cache'
 import type { NativeChatLaunchPrompt } from '@/lib/native-chat-launch-prompt'
@@ -146,7 +147,9 @@ function gluedCandidateRows(
   )
   // Glue needs a run of 2+ sends, so a lone queued echo — by far the common
   // case while an agent streams — skips the per-send boundary scans entirely.
-  if (!oldest || newer.length === 0) {
+  // A lone continuation send is the exception: it never submitted, so its row
+  // is the only thing that can ever retire it.
+  if (!oldest || (newer.length === 0 && nativeChatContinuationSendText(oldest.text) === null)) {
     return []
   }
   const newerRowIds = newer.map(

--- a/src/shared/native-chat-continuation-send.ts
+++ b/src/shared/native-chat-continuation-send.ts
@@ -1,0 +1,15 @@
+import { normalizeNativeChatUserText } from './native-chat-image-transcript-markers'
+
+/**
+ * The text a send left sitting on the agent's input line, or null when it was an
+ * ordinary submit.
+ *
+ * A draft ending in `\` — a stray keystroke as often as a deliberate one — is
+ * taken by the agent TUI as a newline rather than Enter: over a pty, `foo\` + CR
+ * drops one trailing backslash, opens a new input line and submits nothing, so
+ * the turn that eventually lands only STARTS with this send ("foo\nbar"). Its
+ * optimistic echo can therefore never equal a transcript turn.
+ */
+export function nativeChatContinuationSendText(text: string): string | null {
+  return text.endsWith('\\') ? normalizeNativeChatUserText(text.slice(0, -1)) : null
+}


### PR DESCRIPTION
## ELI5

If you finish a message with a backslash and press Enter, the agent does not send
it — it treats the backslash as "give me another line" and waits. Your text stays
in its input box. When you type the rest and press Enter, the agent sends both
lines as one message. Orca had already drawn a grey bubble for that first Enter,
and it never matches the single message that eventually arrives, so the bubble
stays at the bottom of the chat under replies that came later. It looks like the
conversation reordered itself.

## What Changed

A send whose draft ends in `\` is now understood as leaving the agent's input
line open, so its bubble is matched on the draft minus that backslash, and a run
of bubbles may end at such a send without having to account for the whole
transcript row.

- `src/shared/native-chat-continuation-send.ts` (new, 15 lines) — names the rule
  once so desktop and mobile share it.
- `native-chat-pending-occurrence.ts` — glue matching compares against the
  backslash-stripped text and can stop at a continuation send.
- `native-chat-pending.ts` — a lone continuation send now gets candidate rows;
  before, a single queued bubble skipped the scan entirely.
- `mobile-native-chat-pending-retirement.ts` — the same two rules on the mobile
  queue.

Exact-match and occurrence semantics are untouched. Every new retirement route is
additive, so an agent that submits a trailing backslash literally still retires
through the existing exact key.

## Why

Measured against Claude Code 2.1.234 over a pty, writing exactly the bytes
`buildNativeChatPasteBytes` + `NATIVE_CHAT_SUBMIT` produce:

```
write "probe-line-one\"          write "\r"
write "probe-line-two say OK"    write "\r"
```

Two sends, one transcript turn: `"probe-line-one\nprobe-line-two say OK"`. The
trailing backslash is dropped, a newline takes its place, and the first send never
became a turn of its own.

The bubble is then unmatchable: the content key holds `text:probe-line-one\`, and
the glue matcher requires the row to start with that same backslash. Bubbles render
after the transcript regardless of timestamp, so it sits below later turns until
eight further sends push it out of the pane cache.

The backslash does not have to be deliberate — in the report behind this it was a
typo — which is what makes it reachable by ordinary use.

### Relationship to open work in this area

#15032 keys the echo cache on `paneKey + agent + conversationId` so a replaced
conversation's echoes become unreachable. This is a different failure: the
conversation is never replaced, the key is unchanged and the echo stays reachable —
it simply can never match. I checked out that branch and ran these tests there;
they fail identically.

Most of the change lands in `native-chat-pending-occurrence.ts`, which #15032 does
not touch. It does add three lines to `native-chat-pending.ts`, so it will want a
rebase after #15032 and #13513 land — happy to sequence it behind them.

## Linked Issue

Fixes #15288

## Visual Proof

One run from each side, same two sends, a fresh pane each time so the bubble cache
starts empty. Top is without the change, bottom with it.

![before-after.png](https://github.com/user-attachments/assets/2ac444ed-94b2-400c-a360-1018e1ac5b83)

The same pair as a 63s recording:

https://github.com/user-attachments/assets/09502e61-5c14-47da-8ae3-1c74c019df84

## Testing

Platform: macOS 25.6. Not exercised on Linux, Windows or SSH — the change is pure
string comparison in the renderer and mobile queue with no platform branch and no
transcript I/O, so there is nothing platform-specific to exercise.

**Reproduce by hand:** open native chat on a Claude pane, type any sentence ending
in `\` and press Enter, then type the rest and press Enter. Before this change the
first bubble stays at the bottom under the reply; after it, both retire when the
turn lands.

**Repeatability.** The trigger is not intermittent: the same two sends over a pty
five times in a row produced the same transcript every time, and two earlier probes
(one trailing backslash, then two) behave the same — 7 of 7. In the app, three runs
before the change and three after, asserted against the rendered DOM rather than by
eye:

| | reply present | bubble present | bubble below the reply |
|---|---|---|---|
| before, 3 runs | yes | yes | yes |
| after, 3 runs | yes | no | no |

**Automated.** Seven desktop cases fail on unmodified `main` and pass here: a pair;
the pair hidden as soon as the glued row lands; a lone send finished elsewhere; a
lone send the user then submitted from the line it opened; several trailing
backslashes of which only the last is eaten; three sends chained by continuations;
and the reported prompt, whose text is not Latin. Two guards stay green throughout —
a send is not retired by a row that merely shares its prefix (`hi\` against
`history repeats`), and a run that would break mid-word is left alone. Mobile
carries the same three shapes.

`src/renderer` + `src/shared`: 29,230 passed. Mobile `src/session`: 1,215 passed.
The suite was run ten times consecutively with identical results; the tests are pure
functions with no clock or network.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Claude Opus was used throughout: to read the surrounding code, to drive the pty and
app measurements quoted above, and to draft the code and tests. Every measurement in
this description was produced by running it, and I checked the numbers and the diff
before opening this.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Security** — no new input path; the change only compares text already held in
  the renderer.
- **Cross-platform** — pure string logic, no platform branch.
- **Remote SSH** — the comparison runs on whatever transcript the client already
  has; no host-side behaviour changes.
- **Mobile** — same rule applied to the mobile queue, with tests.
- **Backwards compatibility** — additive only; existing exact-match and occurrence
  paths are unchanged, so a transcript that already matched still matches.
- **Performance** — one extra `endsWith` per queued send, and the lone-send scan
  only runs when a trailing backslash is present.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test` pass locally
