### PR TITLE
fix(cmd-j): give the tab-results mock entries their occupant agent

### DIFF
--- a/src/renderer/src/components/tab-bar/TabBarCreateEntry.tab-results.test.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntry.tab-results.test.tsx
@@ -78,6 +78,7 @@ const tabSearchMock = vi.hoisted(() => {
               branch: 'main',
               repoName: 'octo/rocket'
             }),
+            occupantAgent: null,
             agentMetadata: [],
             isCurrentTab: false,
             isCurrentWorktree: true


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## ELI5

`main` is red again, the same way it was in #15207: a required field was added to a type, one test fixture was missed, and every open PR now fails typecheck.

## What Changed

`TabBarCreateEntry.tab-results.test.tsx`'s hoisted `useOpenTabSearch` mock builds `SearchableWorkspaceTab` entries. It now sets `occupantAgent: null`, matching the sibling fixture in the same file (line 142) and `workspace-tab-palette-search.ts:312`.

## Why

`occupantAgent: TuiAgent | null` is required on `SearchableWorkspaceTab` (`workspace-tab-palette-search.ts:57`), but this mock never got it:

```
TabBarCreateEntry.tab-results.test.tsx(51,9): error TS2322: ...
  Property 'occupantAgent' is missing in type '{ tab: ...; }' but required in type 'SearchableWorkspaceTab'.
```

Reproduced on a pristine `origin/main` checkout with no other changes, so this is not from any open PR — every PR merging against `main` inherits it.

This is the **second** occurrence of this exact pattern in as many days; #15207 was `document` on the same type, in the same file. Per-PR CI cannot see it, because each contributing PR is green on its own.

## Linked Issue

No issue — found while getting CI green on unrelated PRs.

## Visual Proof

`N/A` — test-fixture-only change, no product behavior touched.

## Testing

macOS. Verified the failure reproduces on pristine `origin/main` (`fc8b92e507a`), then that this commit clears it.

| check | before | after |
|---|---|---|
| `tsc --noEmit -p config/tsconfig.tc.web.json` | 1 error | clean |
| `vitest run src/renderer/src/components/tab-bar/` | fails to typecheck | 49 files, 391 passed |

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

Fixture-only. No production source touched, so no cross-platform, SSH/remote, mobile, wire-compatibility or performance surface.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

Worth adding a post-merge typecheck/test job on `main`. Two independently-green PRs that break each other are invisible to per-PR CI, and this is the second time in two days that it has taken down every open PR until someone happened to notice.

## AI Disclosure

Claude Opus.
