### PR TITLE
fix(shell): content-address shell-ready wrapper trees so builds stop clobbering each other

### DIFF
--- a/src/main/daemon/daemon-bash-wrapper-osc133-fixture.ts
+++ b/src/main/daemon/daemon-bash-wrapper-osc133-fixture.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared harness for exercising the daemon's generated bash rcfile against a real
+ * interactive bash, and asserting the OSC 133 command lifecycle it must emit.
+ *
+ * Why its own module: both the launch-config suite and the bash-wrapper suite
+ * need it, and duplicating a live-shell harness invites the two copies to drift.
+ */
+import { spawnSync } from 'node:child_process'
+import { join } from 'node:path'
+import { writeFileSync } from 'node:fs'
+import { expect } from 'vitest'
+
+export function runInteractiveBashRcfile(rcfileContent: string, tempDir: string): string {
+  const rcfile = join(tempDir, 'bash-osc133-rcfile')
+  writeFileSync(rcfile, rcfileContent)
+
+  const result = spawnSync(
+    'bash',
+    ['-lc', 'bash --noprofile --rcfile "$1" -i 2>&1', 'bash', rcfile],
+    {
+      input: 'true\nfalse\nexit 0\n',
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        HOME: tempDir,
+        ORCA_SHELL_FEATURES: 'ready',
+        TERM: process.env.TERM || 'xterm'
+      },
+      timeout: 5000
+    }
+  )
+
+  expect(result.error).toBeUndefined()
+  expect(result.status).toBe(0)
+  return result.stdout
+}
+
+export function expectBashOsc133Lifecycle(output: string): void {
+  const oscA = '\x1b]133;A\x07'
+  const oscC = '\x1b]133;C\x07'
+  const oscD = '\x1b]133;D;'
+  const firstPromptMarker = output.indexOf(oscA)
+
+  expect(firstPromptMarker).toBeGreaterThanOrEqual(0)
+  expect(output.slice(0, firstPromptMarker)).not.toContain(oscC)
+  expect(output.slice(0, firstPromptMarker)).not.toContain(oscD)
+  expect(output).toContain(`${oscD}0\x07${oscA}`)
+  expect(output).toContain(`${oscD}1\x07${oscA}`)
+  expect(output.split(oscC)).toHaveLength(4)
+  expect(output.split(oscD)).toHaveLength(3)
+}

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -240,6 +240,9 @@ export class DaemonServer {
     this.onAuthenticatedClientPair = opts.onAuthenticatedClientPair ?? (() => {})
     this.host = new TerminalHost({
       spawnSubprocess: opts.spawnSubprocess,
+      // Why a closure: this.log is assigned after this constructor call, and the
+      // callback only fires once a session is live.
+      reportReadinessEvent: (event, details) => this.log.log(event, details),
       // Why host-level and not the attach callback: a session whose client transport already dropped
       // has no attachment left to fire exit bookkeeping, and the daemon must still notice it can idle.
       onSessionReaped: (sessionId) => {

--- a/src/main/daemon/daemon-shell-ready-wrapper-fileset.ts
+++ b/src/main/daemon/daemon-shell-ready-wrapper-fileset.ts
@@ -1,0 +1,24 @@
+/**
+ * The wrapper files the daemon launches shells with, built against a
+ * caller-supplied root so the tree can be content-addressed (see
+ * shell-ready-wrapper-store.ts).
+ */
+import { join } from 'node:path'
+import { ZSH_WRAPPER_DIR_MARKER_CONTENT, ZSH_WRAPPER_DIR_MARKER_FILE } from '../shell-templates'
+import type { ShellWrapperFile } from '../shell-wrapper-file-writer'
+import { buildZshStartupWrapperFiles } from '../zsh-startup-wrapper-builder'
+import { getDaemonBashShellReadyRcfileContent } from './daemon-bash-shell-ready-rcfile'
+import { getDaemonZshWrapperSpec } from './daemon-zsh-shell-ready-wrapper-spec'
+
+export function buildDaemonShellReadyWrapperFiles(root: string): readonly ShellWrapperFile[] {
+  const zshDir = join(root, 'zsh')
+  const zsh = buildZshStartupWrapperFiles(getDaemonZshWrapperSpec(zshDir))
+  return [
+    [join(zshDir, '.zshenv'), zsh.zshenv],
+    [join(zshDir, '.zprofile'), zsh.zprofile],
+    [join(zshDir, '.zshrc'), zsh.zshrc],
+    [join(zshDir, '.zlogin'), zsh.zlogin],
+    [join(zshDir, ZSH_WRAPPER_DIR_MARKER_FILE), ZSH_WRAPPER_DIR_MARKER_CONTENT],
+    [join(root, 'bash', 'rcfile'), getDaemonBashShellReadyRcfileContent()]
+  ]
+}

--- a/src/main/daemon/daemon-shell-ready-wrapper-fileset.ts
+++ b/src/main/daemon/daemon-shell-ready-wrapper-fileset.ts
@@ -1,7 +1,7 @@
 /**
  * The wrapper files the daemon launches shells with, built against a
  * caller-supplied root so the tree can be content-addressed (see
- * shell-ready-wrapper-store.ts).
+ * shell-wrapper-content-address.ts).
  */
 import { join } from 'node:path'
 import { ZSH_WRAPPER_DIR_MARKER_CONTENT, ZSH_WRAPPER_DIR_MARKER_FILE } from '../shell-templates'

--- a/src/main/daemon/session-options.ts
+++ b/src/main/daemon/session-options.ts
@@ -12,6 +12,9 @@ export type SessionOptions = {
   subprocess: SubprocessHandle
   shellReadySupported: boolean
   shellReadyTimeoutMs?: number
+  /** Reports a readiness outcome worth diagnosing to the daemon's file log.
+   *  Why not console: the detached daemon runs with stdio 'ignore'. */
+  reportReadinessEvent?: (event: string, details: Record<string, unknown>) => void
   historySeedChunks?: readonly string[]
   scrollback?: number
   wslDistro?: string

--- a/src/main/daemon/session-shell-ready-barrier.ts
+++ b/src/main/daemon/session-shell-ready-barrier.ts
@@ -15,6 +15,7 @@ import {
 } from '../shell-prompt-readiness-probe'
 import type { HeadlessEmulator } from './headless-emulator'
 import type { SubprocessHandle } from './session-subprocess-handle'
+import { basename } from 'node:path'
 import type { ShellReadyState } from './types'
 
 const SHELL_READY_TIMEOUT_MS = 15_000
@@ -30,6 +31,10 @@ export type SessionShellReadyBarrierDeps = {
   installDeviceAttributesFilter(): void
   releaseDeviceAttributesFilter(): void
   acceptStartupIngress(data: string): void
+  /** Reports a readiness outcome worth diagnosing. Why injected rather than
+   *  console: the daemon runs detached with stdio 'ignore', so console output
+   *  goes nowhere -- the only durable sink is the daemon's NDJSON file log. */
+  reportReadinessEvent?(event: string, details: Record<string, unknown>): void
 }
 
 /** The startup gate every byte of PTY output passes through: it strips the shell-ready marker, holds
@@ -183,20 +188,30 @@ export class SessionShellReadyBarrier {
     this.postReadyFlushGate.arm(postMarkerBytesObserved)
   }
 
+  /** Why the shell basename and not its path: the path can carry a home dir, and
+   *  the basename is all a diagnosis needs. The session id is already logged by
+   *  the daemon's session lifecycle events, so it is only correlation here. */
+  private reportReadiness(event: string, details: Record<string, unknown>): void {
+    const shellPath = this.deps.subprocess.shellPath
+    this.deps.reportReadinessEvent?.(event, {
+      sessionId: this.deps.sessionId,
+      shell: shellPath ? basename(shellPath) : 'unknown',
+      ...details
+    })
+  }
+
   private onShellReadyTimeout(): void {
     this.readyTimer = null
     if (this._state !== 'pending') {
       return
     }
-    // Why log: this path costs every startup command the full timeout, and it
-    // used to fail silently -- a wrapper that never emits the marker looked
+    // Why report: this path costs every startup command the full timeout, and it
+    // used to fail silently -- a wrapper that never emits the marker looks
     // identical to a slow shell. Name the shell so the next report can be
     // diagnosed from the log alone.
-    console.warn(
-      `[Session] ${this.deps.sessionId}: shell-ready marker never arrived within ` +
-        `${this.deps.shellReadyTimeoutMs ?? SHELL_READY_TIMEOUT_MS}ms for shell ` +
-        `${this.deps.subprocess.shellPath ?? 'unknown'}; delivering the startup command blind.`
-    )
+    this.reportReadiness('shell-ready-timeout', {
+      timeoutMs: this.deps.shellReadyTimeoutMs ?? SHELL_READY_TIMEOUT_MS
+    })
     this._state = 'timed_out'
     this.disposePromptReadinessProbe()
     this.releaseDeviceAttributes()
@@ -208,9 +223,8 @@ export class SessionShellReadyBarrier {
     if (this._state !== 'pending') {
       return
     }
-    console.warn(
-      `[Session] ${this.deps.sessionId}: shell-ready wrapper was replaced before its marker; releasing at the identified shell prompt. OSC 133 integration may be unavailable.`
-    )
+    // Same sink as the timeout above: console goes nowhere in the detached daemon.
+    this.reportReadiness('shell-ready-wrapper-replaced', {})
     this.releaseHeldBytes()
     this.transitionToReady(true)
     this.releaseDeviceAttributes()

--- a/src/main/daemon/session-shell-ready-barrier.ts
+++ b/src/main/daemon/session-shell-ready-barrier.ts
@@ -193,11 +193,18 @@ export class SessionShellReadyBarrier {
    *  the daemon's session lifecycle events, so it is only correlation here. */
   private reportReadiness(event: string, details: Record<string, unknown>): void {
     const shellPath = this.deps.subprocess.shellPath
-    this.deps.reportReadinessEvent?.(event, {
-      sessionId: this.deps.sessionId,
-      shell: shellPath ? basename(shellPath) : 'unknown',
-      ...details
-    })
+    try {
+      this.deps.reportReadinessEvent?.(event, {
+        sessionId: this.deps.sessionId,
+        shell: shellPath ? basename(shellPath) : 'unknown',
+        ...details
+      })
+    } catch {
+      // Why swallow: this runs before the state transition that releases held
+      // PTY bytes and flushes queued stdin, and the ready timer is already
+      // cleared. A throwing sink must never strand the barrier in `pending`
+      // with nothing left to wake it -- diagnostics cannot break the terminal.
+    }
   }
 
   private onShellReadyTimeout(): void {

--- a/src/main/daemon/session-shell-ready-barrier.ts
+++ b/src/main/daemon/session-shell-ready-barrier.ts
@@ -188,6 +188,15 @@ export class SessionShellReadyBarrier {
     if (this._state !== 'pending') {
       return
     }
+    // Why log: this path costs every startup command the full timeout, and it
+    // used to fail silently -- a wrapper that never emits the marker looked
+    // identical to a slow shell. Name the shell so the next report can be
+    // diagnosed from the log alone.
+    console.warn(
+      `[Session] ${this.deps.sessionId}: shell-ready marker never arrived within ` +
+        `${this.deps.shellReadyTimeoutMs ?? SHELL_READY_TIMEOUT_MS}ms for shell ` +
+        `${this.deps.subprocess.shellPath ?? 'unknown'}; delivering the startup command blind.`
+    )
     this._state = 'timed_out'
     this.disposePromptReadinessProbe()
     this.releaseDeviceAttributes()

--- a/src/main/daemon/session.test.ts
+++ b/src/main/daemon/session.test.ts
@@ -114,9 +114,11 @@ describe('Session', () => {
     }
     ownerBackend?: 'posix-pty' | 'windows-conpty' | 'windows-wsl'
     wslDistro?: string
+    reportReadinessEvent?: (event: string, details: Record<string, unknown>) => void
   }): Session {
     session = new Session({
       sessionId: 'test-session',
+      ...(opts?.reportReadinessEvent ? { reportReadinessEvent: opts.reportReadinessEvent } : {}),
       cols: opts?.cols ?? 80,
       rows: opts?.rows ?? 24,
       ...(opts?.launchAgent ? { launchAgent: opts.launchAgent } : {}),
@@ -562,6 +564,27 @@ describe('Session', () => {
 
       expect(session.shellState).toBe('timed_out' satisfies ShellReadyState)
       expect(subprocess.written).toEqual(['waiting input'])
+    })
+
+    // Why this matters: the detached daemon runs with stdio 'ignore', so a
+    // console.warn here reaches nobody. This path costs every startup command
+    // the full timeout, and diagnosing it from a silent log is what made the
+    // original report expensive -- so it has to reach the daemon's file log.
+    it('reports the timeout to the daemon log rather than the void', () => {
+      const events: { event: string; details: Record<string, unknown> }[] = []
+      createSession({
+        shellReadySupported: true,
+        reportReadinessEvent: (event, details) => events.push({ event, details })
+      })
+
+      vi.advanceTimersByTime(15_000)
+
+      expect(events).toHaveLength(1)
+      expect(events[0]?.event).toBe('shell-ready-timeout')
+      expect(events[0]?.details).toMatchObject({ sessionId: 'test-session', timeoutMs: 15_000 })
+      // Why a basename: the shell path can carry a home dir, and the basename is
+      // all a diagnosis needs.
+      expect(String(events[0]?.details.shell)).not.toContain('/')
     })
 
     it('honors a shorter shell-ready timeout for Codex startup sessions', () => {

--- a/src/main/daemon/session.test.ts
+++ b/src/main/daemon/session.test.ts
@@ -587,6 +587,24 @@ describe('Session', () => {
       expect(String(events[0]?.details.shell)).not.toContain('/')
     })
 
+    // Why: the report runs before the transition that releases held PTY bytes and
+    // flushes queued stdin, and the ready timer is already cleared by then. A
+    // throwing sink must not leave the barrier stuck in `pending` forever.
+    it('still releases the barrier when the diagnostic sink throws', () => {
+      createSession({
+        shellReadySupported: true,
+        reportReadinessEvent: () => {
+          throw new Error('log sink unavailable')
+        }
+      })
+      session.write('waiting input')
+
+      vi.advanceTimersByTime(15_000)
+
+      expect(session.shellState).toBe('timed_out' satisfies ShellReadyState)
+      expect(subprocess.written).toEqual(['waiting input'])
+    })
+
     it('honors a shorter shell-ready timeout for Codex startup sessions', () => {
       createSession({ shellReadySupported: true, shellReadyTimeoutMs: 300 })
       session.write('codex\n')

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -66,6 +66,7 @@ export class Session {
       subprocess: this.subprocess,
       responderParser: this.output.responderParser,
       shellReadySupported: opts.shellReadySupported,
+      ...(opts.reportReadinessEvent ? { reportReadinessEvent: opts.reportReadinessEvent } : {}),
       shellReadyTimeoutMs: opts.shellReadyTimeoutMs,
       installDeviceAttributesFilter: () => this.output.installDeviceAttributesFilter(),
       releaseDeviceAttributesFilter: () => this.output.releaseDeviceAttributesFilter(),

--- a/src/main/daemon/shell-ready-bash-wrapper.test.ts
+++ b/src/main/daemon/shell-ready-bash-wrapper.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import type * as DaemonBashRcfileModule from './daemon-bash-shell-ready-rcfile'
+import {
+  OVERLAY_ONLY_FEATURES,
+  STARTUP_COMMAND_FEATURES
+} from '../shell-startup-launch-intent-fixtures'
+import {
+  expectBashOsc133Lifecycle,
+  runInteractiveBashRcfile
+} from './daemon-bash-wrapper-osc133-fixture'
+// Why resolved rather than hardcoded: the wrapper tree is content-addressed.
+import { getShellReadyWrapperRoot } from './shell-ready'
+
+async function importFreshShellReady() {
+  vi.resetModules()
+  const module = await import('./shell-ready')
+  return {
+    ...module,
+    getShellReadyLaunchConfig: (shell: string) =>
+      module.getShellLaunchConfig(shell, STARTUP_COMMAND_FEATURES),
+    getMarkerlessShellLaunchConfig: (shell: string) =>
+      module.getShellLaunchConfig(shell, OVERLAY_ONLY_FEATURES)
+  }
+}
+
+async function importFreshDaemonBashRcfile(): Promise<typeof DaemonBashRcfileModule> {
+  vi.resetModules()
+  return import('./daemon-bash-shell-ready-rcfile')
+}
+
+const describePosix = process.platform === 'win32' ? describe.skip : describe
+const hasBash = process.platform !== 'win32' && spawnSync('bash', ['--version']).status === 0
+const itWithBash = hasBash ? it : it.skip
+
+// Split out of shell-ready.test.ts, which sits at the max-lines cap for tests.
+describePosix('daemon shell-ready bash wrapper', () => {
+  let userDataPath: string
+  let previousUserDataPath: string | undefined
+
+  beforeEach(() => {
+    previousUserDataPath = process.env.ORCA_USER_DATA_PATH
+    userDataPath = mkdtempSync(join(tmpdir(), 'daemon-shell-ready-bash-test-'))
+    process.env.ORCA_USER_DATA_PATH = userDataPath
+  })
+
+  afterEach(() => {
+    if (previousUserDataPath === undefined) {
+      delete process.env.ORCA_USER_DATA_PATH
+    } else {
+      process.env.ORCA_USER_DATA_PATH = previousUserDataPath
+    }
+    rmSync(userDataPath, { recursive: true, force: true })
+    vi.restoreAllMocks()
+  })
+
+  // Why: regression guard for issue #2422 — bash wrapper must emit OSC 133 C/D so SSH sessions clear stale 'working' agent rows.
+  it('emits OSC 133 C/D markers in the daemon bash wrapper', async () => {
+    const { getShellReadyLaunchConfig } = await importFreshShellReady()
+
+    getShellReadyLaunchConfig('/bin/zsh')
+    getShellReadyLaunchConfig('/bin/bash')
+
+    // Why .zshenv: the zsh markers live in the epilogue, behind `markers`.
+    const zshrc = readFileSync(join(getShellReadyWrapperRoot(), 'zsh', '.zshenv'), 'utf8')
+    const bashRc = readFileSync(join(getShellReadyWrapperRoot(), 'bash', 'rcfile'), 'utf8')
+
+    expect(bashRc).toContain('printf "\\033]133;D;%s\\007"')
+    expect(bashRc).toContain('printf "\\033]777;orca-shell-start:%s\\007" "$$"')
+    expect(bashRc).toContain('printf "\\033]133;C\\007"')
+    expect(bashRc).toContain('__orca_prepend_prompt_command "__orca_osc133_precmd"')
+    expect(bashRc).toContain('__orca_append_prompt_command "__orca_osc133_epilogue"')
+    // DEBUG is armed after PROMPT_COMMAND setup so rcfile commands aren't seen as foreground; lastIndexOf skips the epilogue's re-arm.
+    expect(bashRc.lastIndexOf("trap '__orca_osc133_preexec' DEBUG")).toBeGreaterThan(
+      bashRc.indexOf('__orca_append_prompt_command "__orca_osc133_epilogue"')
+    )
+    expect(zshrc).toContain('printf "\\033]133;D;%s\\007"')
+    expect(zshrc).toContain('printf "\\033]133;C\\007"')
+  })
+
+  itWithBash(
+    'runs the daemon bash wrapper without fake C/D markers before the first prompt',
+    async () => {
+      const { getDaemonBashShellReadyRcfileContent } = await importFreshDaemonBashRcfile()
+
+      const output = runInteractiveBashRcfile(getDaemonBashShellReadyRcfileContent(), userDataPath)
+
+      expectBashOsc133Lifecycle(output)
+    }
+  )
+
+  itWithBash(
+    'preserves prompt hooks and existing DEBUG traps without fake command markers',
+    async () => {
+      const { getDaemonBashShellReadyRcfileContent } = await importFreshDaemonBashRcfile()
+      writeFileSync(
+        join(userDataPath, '.bash_profile'),
+        [
+          'PROMPT_COMMAND=\'AFTER_FIRST_PROMPT=1; printf "PROMPT_HOOK\\n"\'',
+          'trap \'if [[ -n "${AFTER_FIRST_PROMPT:-}" ]]; then\n  printf "USER_DEBUG_AFTER\\n"\nfi\' DEBUG'
+        ].join('\n')
+      )
+
+      const output = runInteractiveBashRcfile(getDaemonBashShellReadyRcfileContent(), userDataPath)
+
+      expect(output).toContain('PROMPT_HOOK')
+      expect(output).toContain('USER_DEBUG_AFTER')
+      expectBashOsc133Lifecycle(output)
+    }
+  )
+
+  itWithBash(
+    'still emits 133;C when bash-preexec re-arms the DEBUG trap at first prompt',
+    async () => {
+      const { getDaemonBashShellReadyRcfileContent } = await importFreshDaemonBashRcfile()
+      // Minimal bash-preexec imitation: re-arms its own DEBUG trap from PROMPT_COMMAND at first prompt, silencing Orca's trap.
+      writeFileSync(
+        join(userDataPath, '.bash_profile'),
+        [
+          'preexec_functions=()',
+          '__bp_preexec_invoke_exec() {',
+          '  [[ -n "${__bp_interactive_mode:-}" ]] || return',
+          '  __bp_interactive_mode=""',
+          '  local f',
+          '  for f in "${preexec_functions[@]}"; do "$f" "$BASH_COMMAND"; done',
+          '}',
+          "__bp_arm() { __bp_interactive_mode=1; trap '__bp_preexec_invoke_exec' DEBUG; }",
+          'PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND;}__bp_arm"'
+        ].join('\n')
+      )
+
+      const output = runInteractiveBashRcfile(getDaemonBashShellReadyRcfileContent(), userDataPath)
+
+      expectBashOsc133Lifecycle(output)
+    }
+  )
+
+  itWithBash(
+    'dispatches a non-empty preexec_functions against the real command, not Orca hooks',
+    async () => {
+      const { getDaemonBashShellReadyRcfileContent } = await importFreshDaemonBashRcfile()
+      // Why: the epilogue chains bash-preexec's re-armed DEBUG trap, so a real preexec callback must fire against the user's command.
+      writeFileSync(
+        join(userDataPath, '.bash_profile'),
+        [
+          'preexec_functions=(__user_preexec)',
+          '__user_preexec() { printf \'USER_PREEXEC:%s\\n\' "$1"; }',
+          '__bp_inside=0',
+          '__bp_last_hist=""',
+          '__bp_preexec_invoke_exec() {',
+          '  (( __bp_inside > 0 )) && return',
+          '  [[ -n "${__bp_interactive_mode:-}" ]] || return',
+          '  local __bp_inside=1',
+          '  local this_command',
+          '  this_command="$(builtin history 1)"',
+          '  this_command="${this_command#"${this_command%%[![:space:]]*}"}"',
+          '  this_command="${this_command#* }"',
+          '  this_command="${this_command#"${this_command%%[![:space:]]*}"}"',
+          '  [[ -n "$this_command" && "$this_command" != "$__bp_last_hist" ]] || return',
+          '  __bp_last_hist="$this_command"',
+          '  __bp_interactive_mode=""',
+          '  local f',
+          '  for f in "${preexec_functions[@]}"; do "$f" "$this_command"; done',
+          '}',
+          "__bp_arm() { set -o functrace; __bp_interactive_mode=1; trap '__bp_preexec_invoke_exec' DEBUG; }",
+          'PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND;}__bp_arm"'
+        ].join('\n')
+      )
+
+      const output = runInteractiveBashRcfile(getDaemonBashShellReadyRcfileContent(), userDataPath)
+
+      expectBashOsc133Lifecycle(output)
+      expect(output).toContain('USER_PREEXEC:true')
+      expect(output).toContain('USER_PREEXEC:false')
+      expect(output).not.toContain('USER_PREEXEC:__orca_osc133')
+      expect(output).not.toContain('USER_PREEXEC:__bp_')
+    }
+  )
+
+  itWithBash('normalizes array PROMPT_COMMAND hooks so bash 3.2 still runs cleanup', async () => {
+    const { getDaemonBashShellReadyRcfileContent } = await importFreshDaemonBashRcfile()
+    writeFileSync(
+      join(userDataPath, '.bash_profile'),
+      'PROMPT_COMMAND=(\'printf "PROMPT_ARRAY_A\\n"\' \'printf "PROMPT_ARRAY_B\\n";  \')\n'
+    )
+
+    const output = runInteractiveBashRcfile(getDaemonBashShellReadyRcfileContent(), userDataPath)
+
+    expect(output.split('PROMPT_ARRAY_A')).toHaveLength(4)
+    expect(output.split('PROMPT_ARRAY_B')).toHaveLength(4)
+    expectBashOsc133Lifecycle(output)
+  })
+})

--- a/src/main/daemon/shell-ready.test.ts
+++ b/src/main/daemon/shell-ready.test.ts
@@ -17,6 +17,8 @@ import {
   scanShellStartupOutput
 } from '../shell-startup-output-scanner'
 import { HeadlessEmulator } from './headless-emulator'
+// Why resolved rather than hardcoded: the wrapper tree is content-addressed.
+import { getShellReadyWrapperRoot } from './shell-ready'
 
 async function importFreshShellReady() {
   vi.resetModules()
@@ -226,7 +228,7 @@ describePosix('daemon shell-ready launch config', () => {
     const { getShellReadyLaunchConfig } = await importFreshShellReady()
 
     const config = getShellReadyLaunchConfig('/bin/bash')
-    const rcfile = join(userDataPath, 'shell-ready', 'bash', 'rcfile')
+    const rcfile = join(getShellReadyWrapperRoot(), 'bash', 'rcfile')
 
     expect(config.args).toEqual(['--rcfile', rcfile])
     expect(existsSync(rcfile)).toBe(true)
@@ -234,7 +236,7 @@ describePosix('daemon shell-ready launch config', () => {
 
   it('rewrites wrappers when a long-lived daemon finds a missing rcfile', async () => {
     const { getShellReadyLaunchConfig } = await importFreshShellReady()
-    const rcfile = join(userDataPath, 'shell-ready', 'bash', 'rcfile')
+    const rcfile = join(getShellReadyWrapperRoot(), 'bash', 'rcfile')
 
     getShellReadyLaunchConfig('/bin/bash')
     rmSync(rcfile)
@@ -250,8 +252,8 @@ describePosix('daemon shell-ready launch config', () => {
     const config = getShellReadyLaunchConfig('/bin/zsh')
 
     expect(config.args).toEqual(['-l'])
-    expect(config.env.ZDOTDIR).toBe(join(userDataPath, 'shell-ready', 'zsh'))
-    expect(existsSync(join(userDataPath, 'shell-ready', 'zsh', '.zshenv'))).toBe(true)
+    expect(config.env.ZDOTDIR).toBe(join(getShellReadyWrapperRoot(), 'zsh'))
+    expect(existsSync(join(getShellReadyWrapperRoot(), 'zsh', '.zshenv'))).toBe(true)
   })
 
   it('extends the startup barrier to fish so launch commands queue until the prompt', async () => {
@@ -492,10 +494,10 @@ describePosix('daemon shell-ready launch config', () => {
 
     getShellReadyLaunchConfig('/bin/zsh')
 
-    const zshenv = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshenv'), 'utf8')
-    const zprofile = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zprofile'), 'utf8')
-    const zshrc = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshrc'), 'utf8')
-    const zlogin = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zlogin'), 'utf8')
+    const zshenv = readFileSync(join(getShellReadyWrapperRoot(), 'zsh', '.zshenv'), 'utf8')
+    const zprofile = readFileSync(join(getShellReadyWrapperRoot(), 'zsh', '.zprofile'), 'utf8')
+    const zshrc = readFileSync(join(getShellReadyWrapperRoot(), 'zsh', '.zshrc'), 'utf8')
+    const zlogin = readFileSync(join(getShellReadyWrapperRoot(), 'zsh', '.zlogin'), 'utf8')
     expect(zshenv).toContain('__orca_resolve_inherited_config_dir "${ORCA_ORIG_ZDOTDIR:-$HOME}"')
     expect(zshenv).toContain('printf "\\033]777;orca-shell-start:%s\\007" "$$"')
     expect(zshenv).toContain('"$_orca_resolved_config_dir" == */shell-ready/zsh ]]; then')
@@ -519,7 +521,7 @@ describePosix('daemon shell-ready launch config', () => {
 
     // Why .zshenv: the widget registration lives in the epilogue, which .zlogin
     // (login) and .zshrc (non-login) both call exactly once.
-    const zshenv = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshenv'), 'utf8')
+    const zshenv = readFileSync(join(getShellReadyWrapperRoot(), 'zsh', '.zshenv'), 'utf8')
     expect(zshenv).toContain('zle -N zle-line-init __orca_prompt_mark')
     expect(zshenv).toContain('__orca_prev_line_init_fn="${widgets[zle-line-init]#user:}"')
     expect(zshenv).toContain('printf "\\033]777;orca-shell-ready\\007"')
@@ -644,9 +646,9 @@ describePosix('daemon shell-ready launch config', () => {
 
     // Why one file: every restore now lives in the single epilogue in .zshenv,
     // which .zshrc and .zlogin each invoke on their own startup path.
-    const zshrc = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshenv'), 'utf8')
+    const zshrc = readFileSync(join(getShellReadyWrapperRoot(), 'zsh', '.zshenv'), 'utf8')
     const zlogin = zshrc
-    const bashRc = readFileSync(join(userDataPath, 'shell-ready', 'bash', 'rcfile'), 'utf8')
+    const bashRc = readFileSync(join(getShellReadyWrapperRoot(), 'bash', 'rcfile'), 'utf8')
     const restoreLine =
       '[[ -n "${ORCA_OPENCODE_CONFIG_DIR:-}" ]] && export OPENCODE_CONFIG_DIR="${ORCA_OPENCODE_CONFIG_DIR}"'
     const mimoRestoreLine =
@@ -692,8 +694,8 @@ describePosix('daemon shell-ready launch config', () => {
     getShellReadyLaunchConfig('/bin/bash')
 
     // Why .zshenv: the zsh markers live in the epilogue, behind `markers`.
-    const zshrc = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshenv'), 'utf8')
-    const bashRc = readFileSync(join(userDataPath, 'shell-ready', 'bash', 'rcfile'), 'utf8')
+    const zshrc = readFileSync(join(getShellReadyWrapperRoot(), 'zsh', '.zshenv'), 'utf8')
+    const bashRc = readFileSync(join(getShellReadyWrapperRoot(), 'bash', 'rcfile'), 'utf8')
 
     expect(bashRc).toContain('printf "\\033]133;D;%s\\007"')
     expect(bashRc).toContain('printf "\\033]777;orca-shell-start:%s\\007" "$$"')
@@ -912,7 +914,7 @@ describePosix('daemon shell-ready launch config', () => {
 
     getShellReadyLaunchConfig('/bin/zsh')
 
-    const zshenv = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshenv'), 'utf8')
+    const zshenv = readFileSync(join(getShellReadyWrapperRoot(), 'zsh', '.zshenv'), 'utf8')
 
     expect(zshenv).toContain('unset ZDOTDIR')
     expect(zshenv).toContain('__orca_resolve_inherited_config_dir "${ORCA_ZSHENV')
@@ -928,7 +930,7 @@ describePosix('daemon shell-ready launch config', () => {
 
     getShellReadyLaunchConfig('/bin/zsh')
 
-    const zshenv = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshenv'), 'utf8')
+    const zshenv = readFileSync(join(getShellReadyWrapperRoot(), 'zsh', '.zshenv'), 'utf8')
 
     // Save spawn-env value before sourcing user .zshenv
     expect(zshenv).toContain('_orca_user_zdotdir="$_orca_resolved_config_dir"')

--- a/src/main/daemon/shell-ready.test.ts
+++ b/src/main/daemon/shell-ready.test.ts
@@ -3,7 +3,6 @@ import { spawnSync } from 'node:child_process'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
-import type * as DaemonBashRcfileModule from './daemon-bash-shell-ready-rcfile'
 import {
   OVERLAY_ONLY_FEATURES,
   STARTUP_COMMAND_FEATURES
@@ -32,14 +31,7 @@ async function importFreshShellReady() {
   }
 }
 
-async function importFreshDaemonBashRcfile(): Promise<typeof DaemonBashRcfileModule> {
-  vi.resetModules()
-  return import('./daemon-bash-shell-ready-rcfile')
-}
-
 const describePosix = process.platform === 'win32' ? describe.skip : describe
-const hasBash = process.platform !== 'win32' && spawnSync('bash', ['--version']).status === 0
-const itWithBash = hasBash ? it : it.skip
 const hasZsh = process.platform !== 'win32' && spawnSync('zsh', ['--version']).status === 0
 const itWithZsh = hasZsh ? it : it.skip
 const FISH = resolveFishBinary()
@@ -138,46 +130,6 @@ async function runInteractiveZshRc(args: {
   clearTimeout(deadline)
   proc.kill()
   return output
-}
-
-function runInteractiveBashRcfile(rcfileContent: string, tempDir: string): string {
-  const rcfile = join(tempDir, 'bash-osc133-rcfile')
-  writeFileSync(rcfile, rcfileContent)
-
-  const result = spawnSync(
-    'bash',
-    ['-lc', 'bash --noprofile --rcfile "$1" -i 2>&1', 'bash', rcfile],
-    {
-      input: 'true\nfalse\nexit 0\n',
-      encoding: 'utf8',
-      env: {
-        ...process.env,
-        HOME: tempDir,
-        ORCA_SHELL_FEATURES: 'ready',
-        TERM: process.env.TERM || 'xterm'
-      },
-      timeout: 5000
-    }
-  )
-
-  expect(result.error).toBeUndefined()
-  expect(result.status).toBe(0)
-  return result.stdout
-}
-
-function expectBashOsc133Lifecycle(output: string): void {
-  const oscA = '\x1b]133;A\x07'
-  const oscC = '\x1b]133;C\x07'
-  const oscD = '\x1b]133;D;'
-  const firstPromptMarker = output.indexOf(oscA)
-
-  expect(firstPromptMarker).toBeGreaterThanOrEqual(0)
-  expect(output.slice(0, firstPromptMarker)).not.toContain(oscC)
-  expect(output.slice(0, firstPromptMarker)).not.toContain(oscD)
-  expect(output).toContain(`${oscD}0\x07${oscA}`)
-  expect(output).toContain(`${oscD}1\x07${oscA}`)
-  expect(output.split(oscC)).toHaveLength(4)
-  expect(output.split(oscD)).toHaveLength(3)
 }
 
 function expectZdotdirSourceContext(content: string, fileName: '.zprofile' | '.zshrc' | '.zlogin') {
@@ -684,143 +636,6 @@ describePosix('daemon shell-ready launch config', () => {
       expect(wrapperFile).not.toContain('ORCA_PRIME_AGENT_STATUS_EXTENSION')
       expect(wrapperFile).not.toContain('command prime-agent --extension')
     }
-  })
-
-  // Why: regression guard for issue #2422 — bash wrapper must emit OSC 133 C/D so SSH sessions clear stale 'working' agent rows.
-  it('emits OSC 133 C/D markers in the daemon bash wrapper', async () => {
-    const { getShellReadyLaunchConfig } = await importFreshShellReady()
-
-    getShellReadyLaunchConfig('/bin/zsh')
-    getShellReadyLaunchConfig('/bin/bash')
-
-    // Why .zshenv: the zsh markers live in the epilogue, behind `markers`.
-    const zshrc = readFileSync(join(getShellReadyWrapperRoot(), 'zsh', '.zshenv'), 'utf8')
-    const bashRc = readFileSync(join(getShellReadyWrapperRoot(), 'bash', 'rcfile'), 'utf8')
-
-    expect(bashRc).toContain('printf "\\033]133;D;%s\\007"')
-    expect(bashRc).toContain('printf "\\033]777;orca-shell-start:%s\\007" "$$"')
-    expect(bashRc).toContain('printf "\\033]133;C\\007"')
-    expect(bashRc).toContain('__orca_prepend_prompt_command "__orca_osc133_precmd"')
-    expect(bashRc).toContain('__orca_append_prompt_command "__orca_osc133_epilogue"')
-    // DEBUG is armed after PROMPT_COMMAND setup so rcfile commands aren't seen as foreground; lastIndexOf skips the epilogue's re-arm.
-    expect(bashRc.lastIndexOf("trap '__orca_osc133_preexec' DEBUG")).toBeGreaterThan(
-      bashRc.indexOf('__orca_append_prompt_command "__orca_osc133_epilogue"')
-    )
-    expect(zshrc).toContain('printf "\\033]133;D;%s\\007"')
-    expect(zshrc).toContain('printf "\\033]133;C\\007"')
-  })
-
-  itWithBash(
-    'runs the daemon bash wrapper without fake C/D markers before the first prompt',
-    async () => {
-      const { getDaemonBashShellReadyRcfileContent } = await importFreshDaemonBashRcfile()
-
-      const output = runInteractiveBashRcfile(getDaemonBashShellReadyRcfileContent(), userDataPath)
-
-      expectBashOsc133Lifecycle(output)
-    }
-  )
-
-  itWithBash(
-    'preserves prompt hooks and existing DEBUG traps without fake command markers',
-    async () => {
-      const { getDaemonBashShellReadyRcfileContent } = await importFreshDaemonBashRcfile()
-      writeFileSync(
-        join(userDataPath, '.bash_profile'),
-        [
-          'PROMPT_COMMAND=\'AFTER_FIRST_PROMPT=1; printf "PROMPT_HOOK\\n"\'',
-          'trap \'if [[ -n "${AFTER_FIRST_PROMPT:-}" ]]; then\n  printf "USER_DEBUG_AFTER\\n"\nfi\' DEBUG'
-        ].join('\n')
-      )
-
-      const output = runInteractiveBashRcfile(getDaemonBashShellReadyRcfileContent(), userDataPath)
-
-      expect(output).toContain('PROMPT_HOOK')
-      expect(output).toContain('USER_DEBUG_AFTER')
-      expectBashOsc133Lifecycle(output)
-    }
-  )
-
-  itWithBash(
-    'still emits 133;C when bash-preexec re-arms the DEBUG trap at first prompt',
-    async () => {
-      const { getDaemonBashShellReadyRcfileContent } = await importFreshDaemonBashRcfile()
-      // Minimal bash-preexec imitation: re-arms its own DEBUG trap from PROMPT_COMMAND at first prompt, silencing Orca's trap.
-      writeFileSync(
-        join(userDataPath, '.bash_profile'),
-        [
-          'preexec_functions=()',
-          '__bp_preexec_invoke_exec() {',
-          '  [[ -n "${__bp_interactive_mode:-}" ]] || return',
-          '  __bp_interactive_mode=""',
-          '  local f',
-          '  for f in "${preexec_functions[@]}"; do "$f" "$BASH_COMMAND"; done',
-          '}',
-          "__bp_arm() { __bp_interactive_mode=1; trap '__bp_preexec_invoke_exec' DEBUG; }",
-          'PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND;}__bp_arm"'
-        ].join('\n')
-      )
-
-      const output = runInteractiveBashRcfile(getDaemonBashShellReadyRcfileContent(), userDataPath)
-
-      expectBashOsc133Lifecycle(output)
-    }
-  )
-
-  itWithBash(
-    'dispatches a non-empty preexec_functions against the real command, not Orca hooks',
-    async () => {
-      const { getDaemonBashShellReadyRcfileContent } = await importFreshDaemonBashRcfile()
-      // Why: the epilogue chains bash-preexec's re-armed DEBUG trap, so a real preexec callback must fire against the user's command.
-      writeFileSync(
-        join(userDataPath, '.bash_profile'),
-        [
-          'preexec_functions=(__user_preexec)',
-          '__user_preexec() { printf \'USER_PREEXEC:%s\\n\' "$1"; }',
-          '__bp_inside=0',
-          '__bp_last_hist=""',
-          '__bp_preexec_invoke_exec() {',
-          '  (( __bp_inside > 0 )) && return',
-          '  [[ -n "${__bp_interactive_mode:-}" ]] || return',
-          '  local __bp_inside=1',
-          '  local this_command',
-          '  this_command="$(builtin history 1)"',
-          '  this_command="${this_command#"${this_command%%[![:space:]]*}"}"',
-          '  this_command="${this_command#* }"',
-          '  this_command="${this_command#"${this_command%%[![:space:]]*}"}"',
-          '  [[ -n "$this_command" && "$this_command" != "$__bp_last_hist" ]] || return',
-          '  __bp_last_hist="$this_command"',
-          '  __bp_interactive_mode=""',
-          '  local f',
-          '  for f in "${preexec_functions[@]}"; do "$f" "$this_command"; done',
-          '}',
-          "__bp_arm() { set -o functrace; __bp_interactive_mode=1; trap '__bp_preexec_invoke_exec' DEBUG; }",
-          'PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND;}__bp_arm"'
-        ].join('\n')
-      )
-
-      const output = runInteractiveBashRcfile(getDaemonBashShellReadyRcfileContent(), userDataPath)
-
-      expectBashOsc133Lifecycle(output)
-      expect(output).toContain('USER_PREEXEC:true')
-      expect(output).toContain('USER_PREEXEC:false')
-      expect(output).not.toContain('USER_PREEXEC:__orca_osc133')
-      expect(output).not.toContain('USER_PREEXEC:__bp_')
-    }
-  )
-
-  itWithBash('normalizes array PROMPT_COMMAND hooks so bash 3.2 still runs cleanup', async () => {
-    const { getDaemonBashShellReadyRcfileContent } = await importFreshDaemonBashRcfile()
-    writeFileSync(
-      join(userDataPath, '.bash_profile'),
-      'PROMPT_COMMAND=(\'printf "PROMPT_ARRAY_A\\n"\' \'printf "PROMPT_ARRAY_B\\n";  \')\n'
-    )
-
-    const output = runInteractiveBashRcfile(getDaemonBashShellReadyRcfileContent(), userDataPath)
-
-    expect(output.split('PROMPT_ARRAY_A')).toHaveLength(4)
-    expect(output.split('PROMPT_ARRAY_B')).toHaveLength(4)
-    expectBashOsc133Lifecycle(output)
   })
 
   it('preserves a real inherited ZDOTDIR as ORCA_ORIG_ZDOTDIR', async () => {

--- a/src/main/daemon/shell-ready.ts
+++ b/src/main/daemon/shell-ready.ts
@@ -7,46 +7,52 @@ import {
   isPowerShellExecutableName
 } from '../powershell-osc133-bootstrap'
 import { getFishCodexShellLaunchPreflight } from '../pty/codex-shell-launch-preflight'
-import {
-  getFishShellReadyInitCommand,
-  ZSH_WRAPPER_DIR_MARKER_CONTENT,
-  ZSH_WRAPPER_DIR_MARKER_FILE
-} from '../shell-templates'
+import { getFishShellReadyInitCommand } from '../shell-templates'
 import {
   encodeShellStartupFeatures,
   SHELL_STARTUP_FEATURE_ENV,
   type ShellStartupFeature
 } from '../shell-startup-features'
+import { resolveShellWrapperRoot } from '../shell-wrapper-content-address'
 import { writeShellWrapperFiles } from '../shell-wrapper-file-writer'
+import { buildDaemonShellReadyWrapperFiles } from './daemon-shell-ready-wrapper-fileset'
 import {
   resolveInheritedZdotdir,
   resolveInheritedZshenvSourceDir
 } from '../zsh-wrapper-dir-ownership'
-import { buildZshStartupWrapperFiles } from '../zsh-startup-wrapper-builder'
 import { SHELL_READY_MARKER } from './daemon-shell-ready-marker'
-import { getDaemonBashShellReadyRcfileContent } from './daemon-bash-shell-ready-rcfile'
-import { getDaemonZshWrapperSpec } from './daemon-zsh-shell-ready-wrapper-spec'
 
 const ORCA_USER_DATA_PATH_ENV = 'ORCA_USER_DATA_PATH'
 
-let didEnsureShellReadyWrappers = false
-
-function getShellReadyWrapperRoot(): string {
+function getShellReadyWrapperBaseDir(): string {
   const userDataPath = process.env[ORCA_USER_DATA_PATH_ENV]
-  // Why: older/test launchers may not seed ORCA_USER_DATA_PATH. Keep a
-  // fallback so daemon startup does not fail before the parent can be fixed.
-  return join(userDataPath || tmpdir(), userDataPath ? 'shell-ready' : 'orca-shell-ready')
+  // Why a base dir of its own rather than the legacy `shell-ready/`: daemons of
+  // older builds still write that path unconditionally, so leaving it to them
+  // keeps this build's content-addressed trees out of their reach.
+  // Why the tmpdir fallback: older/test launchers may not seed
+  // ORCA_USER_DATA_PATH, and daemon startup must not fail before the parent can
+  // be fixed.
+  return join(userDataPath || tmpdir(), userDataPath ? 'shell-wrappers' : 'orca-shell-wrappers')
+}
+
+// Why memoized and keyed on the base dir: the digest is stable for a given base
+// dir, every shell launch asks for it, and the key self-invalidates if
+// ORCA_USER_DATA_PATH is ever re-pointed mid-process.
+let cachedShellReadyWrapperRoot: { baseDir: string; root: string } | null = null
+
+export function getShellReadyWrapperRoot(): string {
+  const baseDir = getShellReadyWrapperBaseDir()
+  if (cachedShellReadyWrapperRoot?.baseDir !== baseDir) {
+    cachedShellReadyWrapperRoot = {
+      baseDir,
+      root: resolveShellWrapperRoot(baseDir, buildDaemonShellReadyWrapperFiles)
+    }
+  }
+  return cachedShellReadyWrapperRoot.root
 }
 
 function getRequiredShellReadyWrapperPaths(root = getShellReadyWrapperRoot()): string[] {
-  return [
-    join(root, 'zsh', '.zshenv'),
-    join(root, 'zsh', '.zprofile'),
-    join(root, 'zsh', '.zshrc'),
-    join(root, 'zsh', '.zlogin'),
-    join(root, 'zsh', ZSH_WRAPPER_DIR_MARKER_FILE),
-    join(root, 'bash', 'rcfile')
-  ]
+  return buildDaemonShellReadyWrapperFiles(root).map(([path]) => path)
 }
 
 // Why non-empty and not just present: a partial write leaves a zero-byte
@@ -66,31 +72,23 @@ function ensureShellReadyWrappers(): boolean {
   if (process.platform === 'win32') {
     return false
   }
-  if (didEnsureShellReadyWrappers && shellReadyWrappersExist()) {
-    return true
-  }
-  didEnsureShellReadyWrappers = true
-
   const root = getShellReadyWrapperRoot()
-  const zshDir = join(root, 'zsh')
-  const zsh = buildZshStartupWrapperFiles(getDaemonZshWrapperSpec(zshDir))
-
-  const written = writeShellWrapperFiles(
-    [
-      [join(zshDir, '.zshenv'), zsh.zshenv],
-      [join(zshDir, '.zprofile'), zsh.zprofile],
-      [join(zshDir, '.zshrc'), zsh.zshrc],
-      [join(zshDir, '.zlogin'), zsh.zlogin],
-      [join(zshDir, ZSH_WRAPPER_DIR_MARKER_FILE), ZSH_WRAPPER_DIR_MARKER_CONTENT],
-      [join(root, 'bash', 'rcfile'), getDaemonBashShellReadyRcfileContent()]
-    ],
-    '[daemon/shell-ready]'
-  )
-  if (!written || !shellReadyWrappersExist()) {
-    // Why reset: the next launch retries instead of trusting a half-written tree.
-    didEnsureShellReadyWrappers = false
-    return false
+  // Why existence alone decides, with no per-process flag: the root is keyed by
+  // a hash of the exact bytes we would write, so a tree that is present and
+  // non-empty is a tree this build wrote. Rewriting it would replace a live file
+  // on the terminal-spawn path for no gain.
+  if (!shellReadyWrappersExist()) {
+    const written = writeShellWrapperFiles(
+      buildDaemonShellReadyWrapperFiles(root),
+      '[daemon/shell-ready]'
+    )
+    if (!written || !shellReadyWrappersExist()) {
+      // Why no flag to reset: the next launch re-checks the files themselves, so
+      // a half-written tree is retried without any extra bookkeeping.
+      return false
+    }
   }
+
   return true
 }
 

--- a/src/main/daemon/shell-ready.ts
+++ b/src/main/daemon/shell-ready.ts
@@ -31,7 +31,9 @@ function getShellReadyWrapperBaseDir(): string {
   // keeps this build's content-addressed trees out of their reach.
   // Why the tmpdir fallback: older/test launchers may not seed
   // ORCA_USER_DATA_PATH, and daemon startup must not fail before the parent can
-  // be fixed.
+  // be fixed. It is dev/test-only -- daemon-init always passes the real path --
+  // which matters because the presence check is size-only, so a complete tree
+  // pre-planted under a shared /tmp would be trusted rather than overwritten.
   return join(userDataPath || tmpdir(), userDataPath ? 'shell-wrappers' : 'orca-shell-wrappers')
 }
 

--- a/src/main/daemon/terminal-host-options.ts
+++ b/src/main/daemon/terminal-host-options.ts
@@ -23,6 +23,10 @@ export type TerminalHostOptions = {
   }) => SubprocessHandle | Promise<SubprocessHandle>
   // Why: login-session death detection (#7936) needs subprocess exits even when no client is attached.
   onSessionReaped?: (sessionId: string) => void
+  /** Reports a shell-readiness outcome worth diagnosing. Why threaded rather
+   *  than console: the detached daemon runs with stdio 'ignore', so the only
+   *  durable sink is its NDJSON file log. */
+  reportReadinessEvent?: (event: string, details: Record<string, unknown>) => void
   // Why: graceful shutdown checkpoints must finish in-process before teardown.
   onFinalCheckpoint?: (
     sessionId: string,

--- a/src/main/daemon/terminal-host-readiness-reporting.test.ts
+++ b/src/main/daemon/terminal-host-readiness-reporting.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SubprocessHandle } from './session-subprocess-handle'
+import { TerminalHost } from './terminal-host'
+
+/**
+ * Why this test exists: the shell-ready barrier used to report a timeout with
+ * console.warn, and the daemon is spawned detached with stdio 'ignore', so that
+ * output reached nobody. The diagnostic looked present in code and was absent in
+ * production. Asserting it at the barrier alone would not have caught that --
+ * the callback has to survive every hop out to the daemon's file log.
+ */
+function createSubprocess(): SubprocessHandle & { exit: () => void } {
+  let onExit: ((code: number) => void) | null = null
+  return {
+    pid: 4242,
+    shellPath: '/opt/homebrew/bin/zsh',
+    getForegroundProcess: () => 'zsh',
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(),
+    forceKill: vi.fn(),
+    signal: vi.fn(),
+    onData: () => {},
+    onExit: (listener) => {
+      onExit = listener
+    },
+    dispose: vi.fn(),
+    exit: () => onExit?.(0)
+  } as SubprocessHandle & { exit: () => void }
+}
+
+describe('TerminalHost readiness reporting', () => {
+  let host: TerminalHost
+  let subprocess: ReturnType<typeof createSubprocess> | undefined
+  const events: { event: string; details: Record<string, unknown> }[] = []
+  const spawnSubprocess = vi.fn(() => {
+    subprocess = createSubprocess()
+    return subprocess
+  })
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    events.length = 0
+    spawnSubprocess.mockClear()
+    host = new TerminalHost({
+      spawnSubprocess,
+      reportReadinessEvent: (event, details) => events.push({ event, details })
+    })
+  })
+
+  afterEach(async () => {
+    subprocess?.exit()
+    await host.dispose()
+    vi.useRealTimers()
+  })
+
+  it('delivers a shell-ready timeout out to the daemon log sink', async () => {
+    await host.createOrAttach({
+      sessionId: 'session-readiness',
+      cols: 80,
+      rows: 24,
+      streamClient: { onData: vi.fn(), onExit: vi.fn() },
+      shellReadySupported: true
+    })
+
+    vi.advanceTimersByTime(15_000)
+
+    expect(events.map((entry) => entry.event)).toContain('shell-ready-timeout')
+    const timeout = events.find((entry) => entry.event === 'shell-ready-timeout')
+    expect(timeout?.details).toMatchObject({ sessionId: 'session-readiness', timeoutMs: 15_000 })
+    // Why a basename: the shell path can carry a home dir, and the daemon log is
+    // documented to hold terse fields only.
+    expect(timeout?.details.shell).toBe('zsh')
+  })
+})

--- a/src/main/daemon/terminal-host-session-create.ts
+++ b/src/main/daemon/terminal-host-session-create.ts
@@ -22,6 +22,7 @@ type TerminalHostSessionCreateDependencies = {
   onDeadSessionRemoved: (sessionId: string) => void
   onSessionCreated: (sessionId: string, generation: string | undefined, isAlive: boolean) => void
   onSessionExit: (sessionId: string, generation: string | undefined) => void
+  reportReadinessEvent?: (event: string, details: Record<string, unknown>) => void
 }
 
 export async function createOrAttachTerminalSession(
@@ -121,6 +122,7 @@ async function spawnAndPublishSession(
     ...(opts.startupIngress ? { startupIngress: opts.startupIngress } : {}),
     wslDistro,
     onExit: () => deps.onSessionExit(opts.sessionId, opts.agentSessionGeneration),
+    ...(deps.reportReadinessEvent ? { reportReadinessEvent: deps.reportReadinessEvent } : {}),
     ...(opts.shellReadyTimeoutMs !== undefined
       ? { shellReadyTimeoutMs: opts.shellReadyTimeoutMs }
       : {})

--- a/src/main/daemon/terminal-host.ts
+++ b/src/main/daemon/terminal-host.ts
@@ -51,6 +51,7 @@ export class TerminalHost {
   private killedTombstones: TerminalHostTombstones
   private spawnSubprocess: TerminalHostOptions['spawnSubprocess']
   private onSessionReaped: TerminalHostOptions['onSessionReaped']
+  private reportReadinessEvent: TerminalHostOptions['reportReadinessEvent']
   private onFinalCheckpoint: TerminalHostOptions['onFinalCheckpoint']
   private maxTombstones: number
   private creationFenced = false
@@ -61,6 +62,7 @@ export class TerminalHost {
   constructor(opts: TerminalHostOptions) {
     this.spawnSubprocess = opts.spawnSubprocess
     this.onSessionReaped = opts.onSessionReaped
+    this.reportReadinessEvent = opts.reportReadinessEvent
     this.onFinalCheckpoint = opts.onFinalCheckpoint
     this.maxTombstones = opts.maxTombstones ?? DEFAULT_MAX_TOMBSTONES
     this.killedTombstones = new TerminalHostTombstones(this.maxTombstones)
@@ -110,6 +112,9 @@ export class TerminalHost {
             onDeadSessionRemoved: (sessionId) => this.agentSessionGenerations.forget(sessionId),
             onSessionCreated: (sessionId, generation, isAlive) =>
               this.agentSessionGenerations.remember(sessionId, generation, isAlive),
+            ...(this.reportReadinessEvent
+              ? { reportReadinessEvent: this.reportReadinessEvent }
+              : {}),
             onSessionExit: (sessionId, generation) => {
               this.agentSessionOwners.release(sessionId, generation)
               this.agentSessionGenerations.forget(sessionId, generation)

--- a/src/main/ipc/pty-hidden-at-spawn-mark.test.ts
+++ b/src/main/ipc/pty-hidden-at-spawn-mark.test.ts
@@ -5,6 +5,9 @@ import { setupPtyIpcSuite } from './pty-ipc-test-harness'
 import { isHiddenRendererPty } from './pty-hidden-delivery-gate'
 import { OrcaRuntimeService } from '../runtime/orca-runtime'
 import { registerPtyHandlers } from './pty'
+import { join } from 'node:path'
+// Why resolved rather than hardcoded: the wrapper tree is content-addressed.
+import { getShellReadyWrapperRoot } from '../providers/local-pty-shell-ready-wrapper-root'
 
 vi.mock('electron', () => import('./pty-ipc-mock-registry').then((m) => m.electronModuleMock()))
 vi.mock('fs', () => import('./pty-ipc-mock-registry').then((m) => m.fsModuleMock()))
@@ -414,7 +417,7 @@ describe('registerPtyHandlers', () => {
             ORCA_OPENCODE_CONFIG_DIR: '/tmp/orca-opencode-config',
             // No `ready`: the fallback shell carries an overlay, not a startup command.
             ORCA_SHELL_FEATURES: 'overlay,history,markers',
-            ZDOTDIR: '/tmp/orca-user-data/shell-ready/zsh'
+            ZDOTDIR: join(getShellReadyWrapperRoot(), 'zsh')
           })
         })
       )

--- a/src/main/ipc/pty-listener-teardown-and-orphans.test.ts
+++ b/src/main/ipc/pty-listener-teardown-and-orphans.test.ts
@@ -9,6 +9,9 @@ import { posixOnlyIt, makeDisposable } from './pty-ipc-test-constants'
 import { setupPtyIpcSuite } from './pty-ipc-test-harness'
 import * as livePtyGate from '../claude-accounts/live-pty-gate'
 import { registerPtyHandlers, setLocalPtyProvider, getLocalPtyProvider } from './pty'
+import { join } from 'node:path'
+// Why resolved rather than hardcoded: the wrapper tree is content-addressed.
+import { getShellReadyWrapperRoot } from '../providers/local-pty-shell-ready-wrapper-root'
 
 vi.mock('electron', () => import('./pty-ipc-mock-registry').then((m) => m.electronModuleMock()))
 vi.mock('fs', () => import('./pty-ipc-mock-registry').then((m) => m.fsModuleMock()))
@@ -87,7 +90,7 @@ describe('registerPtyHandlers', () => {
             SHELL: '/bin/zsh',
             ORCA_OPENCODE_CONFIG_DIR: '/tmp/orca-opencode-config',
             ORCA_SHELL_FEATURES: 'overlay,history,markers',
-            ZDOTDIR: '/tmp/orca-user-data/shell-ready/zsh'
+            ZDOTDIR: join(getShellReadyWrapperRoot(), 'zsh')
           })
         })
       )

--- a/src/main/ipc/pty-login-shell-startup-commands.test.ts
+++ b/src/main/ipc/pty-login-shell-startup-commands.test.ts
@@ -9,6 +9,9 @@ import { setupPtyIpcSuite } from './pty-ipc-test-harness'
 import { userInfo } from 'node:os'
 import { resetMacosLoginShellPreflightForTests } from '../providers/macos-tcc-login-shell'
 import { registerPtyHandlers } from './pty'
+import { join } from 'node:path'
+// Why resolved rather than hardcoded: the wrapper tree is content-addressed.
+import { getShellReadyWrapperRoot } from '../providers/local-pty-shell-ready-wrapper-root'
 
 vi.mock('electron', () => import('./pty-ipc-mock-registry').then((m) => m.electronModuleMock()))
 vi.mock('fs', () => import('./pty-ipc-mock-registry').then((m) => m.fsModuleMock()))
@@ -120,7 +123,7 @@ describe('registerPtyHandlers', () => {
       expect(args).toEqual(['-l'])
       expect(options.env.OPENCODE_CONFIG_DIR).toBe('/tmp/orca-opencode-config')
       expect(options.env.ORCA_OPENCODE_CONFIG_DIR).toBe('/tmp/orca-opencode-config')
-      expect(options.env.ZDOTDIR).toBe('/tmp/orca-user-data/shell-ready/zsh')
+      expect(options.env.ZDOTDIR).toBe(join(getShellReadyWrapperRoot(), 'zsh'))
       expect(options.env.ORCA_SHELL_FEATURES).not.toContain('ready')
     } finally {
       Object.defineProperty(process, 'platform', {
@@ -161,7 +164,7 @@ describe('registerPtyHandlers', () => {
       expect(options.env.PI_CODING_AGENT_DIR).toBe('/tmp/user-pi-agent')
       expect(options.env.ORCA_PI_CODING_AGENT_DIR).toBeUndefined()
       expect(options.env.ORCA_PI_SOURCE_AGENT_DIR).toBe('/tmp/user-pi-agent')
-      expect(options.env.ZDOTDIR).toBe('/tmp/orca-user-data/shell-ready/zsh')
+      expect(options.env.ZDOTDIR).toBe(join(getShellReadyWrapperRoot(), 'zsh'))
       expect(options.env.ORCA_SHELL_FEATURES).not.toContain('ready')
     } finally {
       Object.defineProperty(process, 'platform', {

--- a/src/main/ipc/pty-wsl-cwd-validation.test.ts
+++ b/src/main/ipc/pty-wsl-cwd-validation.test.ts
@@ -8,6 +8,9 @@ import {
 import { setupPtyIpcSuite } from './pty-ipc-test-harness'
 import { _setWslCachesForTests } from '../wsl'
 import { registerPtyHandlers } from './pty'
+import { join } from 'node:path'
+// Why resolved rather than hardcoded: the wrapper tree is content-addressed.
+import { getShellReadyWrapperRoot } from '../providers/local-pty-shell-ready-wrapper-root'
 
 vi.mock('electron', () => import('./pty-ipc-mock-registry').then((m) => m.electronModuleMock()))
 vi.mock('fs', () => import('./pty-ipc-mock-registry').then((m) => m.fsModuleMock()))
@@ -351,7 +354,7 @@ describe('registerPtyHandlers', () => {
       })
       expect(shell).toBe('/bin/zsh')
       expect(args).toEqual(['-l'])
-      expect(options.env.ZDOTDIR).toBe('/tmp/orca-user-data/shell-ready/zsh')
+      expect(options.env.ZDOTDIR).toBe(join(getShellReadyWrapperRoot(), 'zsh'))
       expect(options.env.ORCA_ORIG_ZDOTDIR).toBe(process.env.HOME)
     } finally {
       Object.defineProperty(process, 'platform', {

--- a/src/main/providers/__tests__/shell-ready-framework/shell-script-test.ts
+++ b/src/main/providers/__tests__/shell-ready-framework/shell-script-test.ts
@@ -5,6 +5,7 @@ import { spawnSync } from 'node:child_process'
 import { getShellLaunchConfig } from '../../local-pty-shell-ready'
 import { selectShellStartupFeatures } from '../../../shell-startup-features'
 import { escapeRegex } from '../../../../shared/string-utils'
+import { getShellReadyWrapperRoot } from '../../local-pty-shell-ready-wrapper-root'
 
 const RUN_MARKER = /^[ \t]*#[ \t]*Run:.*$/m
 
@@ -144,7 +145,11 @@ function normalizeOutput(
     return output
   }
 
-  const wrapperDir = join(ctx.userDataPath, 'shell-ready', ctx.shellName)
+  // Why resolved rather than rebuilt: the wrapper tree is content-addressed, so
+  // rebuilding it from userDataPath yields a directory that never appears in the
+  // output and the placeholder silently stops substituting -- which would bake a
+  // machine-specific, hash-bearing path into the next inline snapshot.
+  const wrapperDir = join(getShellReadyWrapperRoot(), ctx.shellName)
 
   const paths: { path: string; placeholder: string }[] = [
     { path: wrapperDir, placeholder: '<WRAPPER_DIR>' },

--- a/src/main/providers/local-pty-shell-ready-bash-rcfile.ts
+++ b/src/main/providers/local-pty-shell-ready-bash-rcfile.ts
@@ -8,7 +8,7 @@ import { BASH_PROMPT_COMMAND_COMPOSITION_BLOCK } from '../bash-prompt-command-co
 import { getPosixOmpShellWrapper } from '../pty/omp-shell-wrapper'
 import { getPosixCodexShellLaunchPreflight } from '../pty/codex-shell-launch-preflight'
 import { BASH_FEATURE_CHANNEL_BLOCK, SHELL_STARTUP_IDENTITY_MARKER_BLOCK } from '../shell-templates'
-import { SHELL_READY_MARKER_ESCAPED } from './local-pty-shell-ready-wrapper-root'
+import { SHELL_READY_MARKER_ESCAPED } from './local-pty-shell-ready-marker'
 
 export function getBashShellReadyRcfileContent(): string {
   return `# Orca bash shell-ready wrapper

--- a/src/main/providers/local-pty-shell-ready-marker.ts
+++ b/src/main/providers/local-pty-shell-ready-marker.ts
@@ -1,0 +1,8 @@
+/**
+ * The marker the local shell-ready wrappers emit once startup files finish.
+ *
+ * Why its own module: the wrapper file-set builder needs it, and so do the
+ * rcfile templates that builder pulls in. Keeping it as a leaf lets the wrapper
+ * root import the builder (to hash it) without a cycle.
+ */
+export const SHELL_READY_MARKER_ESCAPED = '\\033]777;orca-shell-ready\\007'

--- a/src/main/providers/local-pty-shell-ready-wrapper-fileset.ts
+++ b/src/main/providers/local-pty-shell-ready-wrapper-fileset.ts
@@ -1,7 +1,7 @@
 /**
  * The wrapper files main's local PTY path launches shells with, built against a
  * caller-supplied root so the tree can be content-addressed (see
- * shell-ready-wrapper-store.ts).
+ * shell-wrapper-content-address.ts).
  */
 import { ZSH_WRAPPER_DIR_MARKER_CONTENT, ZSH_WRAPPER_DIR_MARKER_FILE } from '../shell-templates'
 import type { ShellWrapperFile } from '../shell-wrapper-file-writer'
@@ -31,6 +31,11 @@ export function getLocalZshWrapperSpec(zshDir: string): ZshStartupWrapperSpec {
   }
 }
 
+// Why `/` concatenation rather than path.join: these paths are baked into
+// .zshenv as a shell literal and handed to bash as `--rcfile`, and the launch
+// config builds the matching values the same way (local-pty-shell-ready.ts).
+// path.join would emit backslashes on Windows, where a shell literal reads them
+// as escapes -- and would desync the written path from the launched one.
 export function buildLocalShellReadyWrapperFiles(root: string): readonly ShellWrapperFile[] {
   const zshDir = `${root}/zsh`
   const zsh = buildZshStartupWrapperFiles(getLocalZshWrapperSpec(zshDir))

--- a/src/main/providers/local-pty-shell-ready-wrapper-fileset.ts
+++ b/src/main/providers/local-pty-shell-ready-wrapper-fileset.ts
@@ -1,0 +1,45 @@
+/**
+ * The wrapper files main's local PTY path launches shells with, built against a
+ * caller-supplied root so the tree can be content-addressed (see
+ * shell-ready-wrapper-store.ts).
+ */
+import { ZSH_WRAPPER_DIR_MARKER_CONTENT, ZSH_WRAPPER_DIR_MARKER_FILE } from '../shell-templates'
+import type { ShellWrapperFile } from '../shell-wrapper-file-writer'
+import {
+  buildZshStartupWrapperFiles,
+  type ZshStartupWrapperSpec
+} from '../zsh-startup-wrapper-builder'
+import { getBashShellReadyRcfileContent } from './local-pty-shell-ready-bash-rcfile'
+import { SHELL_READY_MARKER_ESCAPED } from './local-pty-shell-ready-marker'
+
+export function getLocalZshWrapperSpec(zshDir: string): ZshStartupWrapperSpec {
+  return {
+    headerLabel: 'Orca zsh shell-ready wrapper',
+    zshDir,
+    zshenvStrategy: 'discover-user-zdotdir',
+    readyMarkerEscaped: SHELL_READY_MARKER_ESCAPED,
+    osc133CommandMarkers: true,
+    skipUserZshrcWhenHomeIsWrapperDir: true,
+    overlayRestoreComment:
+      "# Why: ~/.zshrc can export the user's default OpenCode config after spawn.",
+    restores: {
+      agentTeamsPath: true,
+      remoteCliBinDir: false,
+      codexHome: true,
+      codexLaunchPreflight: true
+    }
+  }
+}
+
+export function buildLocalShellReadyWrapperFiles(root: string): readonly ShellWrapperFile[] {
+  const zshDir = `${root}/zsh`
+  const zsh = buildZshStartupWrapperFiles(getLocalZshWrapperSpec(zshDir))
+  return [
+    [`${zshDir}/.zshenv`, zsh.zshenv],
+    [`${zshDir}/.zprofile`, zsh.zprofile],
+    [`${zshDir}/.zshrc`, zsh.zshrc],
+    [`${zshDir}/.zlogin`, zsh.zlogin],
+    [`${zshDir}/${ZSH_WRAPPER_DIR_MARKER_FILE}`, ZSH_WRAPPER_DIR_MARKER_CONTENT],
+    [`${root}/bash/rcfile`, getBashShellReadyRcfileContent()]
+  ]
+}

--- a/src/main/providers/local-pty-shell-ready-wrapper-generation.test.ts
+++ b/src/main/providers/local-pty-shell-ready-wrapper-generation.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { spawnSync } from 'node:child_process'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import {
   describePosix,
   importFreshLocalPtyShellReady,
@@ -13,8 +13,56 @@ import {
 import { getBashShellReadyRcfileContent } from './local-pty-shell-ready-bash-rcfile'
 import { getZshShellReadyWrapperFiles } from './local-pty-shell-ready-wrapper-generation'
 import { makeUserZdotdir } from '../zsh-user-config-dir-fixture'
+// Why resolved rather than hardcoded: the wrapper tree is content-addressed.
+import { getShellReadyWrapperRoot } from './local-pty-shell-ready-wrapper-root'
 
 restoreUserDataPathAfterEach()
+
+describe('ensureShellReadyWrappersAt', () => {
+  // Why: rewriting a byte-identical tree replaces a live file on the terminal
+  // spawn path for no gain -- and on Windows that is precisely the collision an
+  // indexer or antivirus turns into a failed write. The tree is
+  // content-addressed, so its presence already proves this build wrote it.
+  it('does not rewrite a tree that is already present', async () => {
+    const userData = mkdtempSync(join(tmpdir(), 'orca-warm-tree-'))
+    try {
+      setTestUserDataPath(userData)
+      const generation = await import('./local-pty-shell-ready-wrapper-generation')
+      const { getShellReadyWrapperRoot: resolveRoot } =
+        await import('./local-pty-shell-ready-wrapper-root')
+      expect(generation.ensureShellReadyWrappersAt()).toBe(true)
+      const rcfile = join(resolveRoot(), 'bash', 'rcfile')
+      const firstWrite = statSync(rcfile).mtimeMs
+
+      generation.ensureShellReadyWrappersAt()
+      vi.resetModules()
+      const fresh = await import('./local-pty-shell-ready-wrapper-generation')
+      fresh.ensureShellReadyWrappersAt()
+
+      expect(statSync(rcfile).mtimeMs).toBe(firstWrite)
+    } finally {
+      rmSync(userData, { recursive: true, force: true })
+    }
+  })
+
+  it('regenerates a tree whose files went missing', async () => {
+    const userData = mkdtempSync(join(tmpdir(), 'orca-missing-tree-'))
+    try {
+      setTestUserDataPath(userData)
+      const generation = await import('./local-pty-shell-ready-wrapper-generation')
+      const { getShellReadyWrapperRoot: resolveRoot } =
+        await import('./local-pty-shell-ready-wrapper-root')
+      generation.ensureShellReadyWrappersAt()
+      const rcfile = join(resolveRoot(), 'bash', 'rcfile')
+      rmSync(rcfile)
+
+      expect(generation.ensureShellReadyWrappersAt()).toBe(true)
+      expect(existsSync(rcfile)).toBe(true)
+    } finally {
+      rmSync(userData, { recursive: true, force: true })
+    }
+  })
+})
 
 describe('shell-ready wrapper root resolution', () => {
   // Why: daemon-entry fork is plain Node (no electron), so the wrapper root resolves from ORCA_USER_DATA_PATH, not app.getPath.
@@ -24,7 +72,7 @@ describe('shell-ready wrapper root resolution', () => {
       setTestUserDataPath(root)
       const { getShellReadyLaunchConfig } = await importFreshLocalPtyShellReady()
       const config = getShellReadyLaunchConfig('/bin/zsh')
-      expect(config.env.ZDOTDIR).toBe(`${root}/shell-ready/zsh`)
+      expect(config.env.ZDOTDIR).toBe(join(getShellReadyWrapperRoot(), 'zsh'))
     } finally {
       rmSync(root, { recursive: true, force: true })
     }
@@ -240,10 +288,10 @@ describePosix('local PTY shell-ready launch config', () => {
 
     getShellReadyLaunchConfig('/bin/zsh')
 
-    const zshenv = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshenv'), 'utf8')
-    const zprofile = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zprofile'), 'utf8')
-    const zshrc = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshrc'), 'utf8')
-    const zlogin = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zlogin'), 'utf8')
+    const zshenv = readFileSync(join(getShellReadyWrapperRoot(), 'zsh', '.zshenv'), 'utf8')
+    const zprofile = readFileSync(join(getShellReadyWrapperRoot(), 'zsh', '.zprofile'), 'utf8')
+    const zshrc = readFileSync(join(getShellReadyWrapperRoot(), 'zsh', '.zshrc'), 'utf8')
+    const zlogin = readFileSync(join(getShellReadyWrapperRoot(), 'zsh', '.zlogin'), 'utf8')
     expect(zshenv).toContain('__orca_resolve_inherited_config_dir "${ORCA_ORIG_ZDOTDIR:-$HOME}"')
     expect(zshenv).toContain('printf "\\033]777;orca-shell-start:%s\\007" "$$"')
     expect(zshenv).toContain('"$_orca_resolved_config_dir" == */shell-ready/zsh ]]; then')
@@ -268,7 +316,7 @@ describePosix('local PTY shell-ready launch config', () => {
 
     // Why .zshenv: the widget registration lives in the epilogue, which .zlogin
     // (login) and .zshrc (non-login) both call exactly once.
-    const zshenv = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshenv'), 'utf8')
+    const zshenv = readFileSync(join(getShellReadyWrapperRoot(), 'zsh', '.zshenv'), 'utf8')
     expect(zshenv).toContain('zle -N zle-line-init __orca_prompt_mark')
     expect(zshenv).toContain('__orca_prev_line_init_fn="${widgets[zle-line-init]#user:}"')
     expect(zshenv).toContain('printf "\\033]777;orca-shell-ready\\007"')
@@ -276,7 +324,7 @@ describePosix('local PTY shell-ready launch config', () => {
     expect(zshenv).not.toContain('add-zle-hook-widget line-init')
     // Why: re-source guard — skip re-capturing when already the bound widget so the prior chain survives a second source.
     expect(zshenv).toContain('== "user:__orca_prompt_mark"')
-    expect(readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zlogin'), 'utf8')).toContain(
+    expect(readFileSync(join(getShellReadyWrapperRoot(), 'zsh', '.zlogin'), 'utf8')).toContain(
       '__orca_shell_epilogue'
     )
   })
@@ -288,7 +336,7 @@ describePosix('local PTY shell-ready launch config', () => {
 
     // Why one file: every restore now lives in the single epilogue in .zshenv,
     // which .zshrc and .zlogin each invoke on their own startup path.
-    const zshrc = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshenv'), 'utf8')
+    const zshrc = readFileSync(join(getShellReadyWrapperRoot(), 'zsh', '.zshenv'), 'utf8')
     const zlogin = zshrc
     const bashRc = getBashShellReadyRcfileContent()
     const restoreLine =
@@ -515,7 +563,7 @@ describePosix('local PTY shell-ready launch config', () => {
 
     getShellReadyLaunchConfig('/bin/zsh')
 
-    const zshenv = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshenv'), 'utf8')
+    const zshenv = readFileSync(join(getShellReadyWrapperRoot(), 'zsh', '.zshenv'), 'utf8')
 
     expect(zshenv).toContain('unset ZDOTDIR')
     expect(zshenv).toContain(
@@ -535,7 +583,7 @@ describePosix('local PTY shell-ready launch config', () => {
 
     getShellReadyLaunchConfig('/bin/zsh')
 
-    const zshenv = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshenv'), 'utf8')
+    const zshenv = readFileSync(join(getShellReadyWrapperRoot(), 'zsh', '.zshenv'), 'utf8')
 
     // Save spawn-env value before sourcing user .zshenv
     expect(zshenv.indexOf('_orca_user_zdotdir="$_orca_resolved_config_dir"')).toBeLessThan(
@@ -552,7 +600,7 @@ describePosix('local PTY shell-ready launch config', () => {
 
     getShellReadyLaunchConfig('/bin/zsh')
 
-    const zshenv = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshenv'), 'utf8')
+    const zshenv = readFileSync(join(getShellReadyWrapperRoot(), 'zsh', '.zshenv'), 'utf8')
 
     // Why: derive wrapper dir from %x, not env $ZDOTDIR — zsh corrupts non-ASCII usernames in its 0x84-0x9D token range.
     expect(zshenv).toContain('_orca_wrapper_zdotdir_self="${${(%):-%x}:h}"')
@@ -567,7 +615,7 @@ describePosix('local PTY shell-ready launch config', () => {
       'if [[ -n "${_orca_wrapper_zdotdir_self:-}" && -f "${_orca_wrapper_zdotdir_self:-}/.zshenv" ]]; then\n' +
         '  export ZDOTDIR="${_orca_wrapper_zdotdir_self:-}"\n' +
         'else\n' +
-        `  export ZDOTDIR='${join(userDataPath, 'shell-ready', 'zsh')}'\n` +
+        `  export ZDOTDIR='${join(getShellReadyWrapperRoot(), 'zsh')}'\n` +
         'fi'
     )
     // Capture must happen before the wrapper unsets ZDOTDIR to source user files.

--- a/src/main/providers/local-pty-shell-ready-wrapper-generation.ts
+++ b/src/main/providers/local-pty-shell-ready-wrapper-generation.ts
@@ -6,38 +6,17 @@
  */
 import {
   buildZshStartupWrapperFiles,
-  type ZshStartupWrapperFiles,
-  type ZshStartupWrapperSpec
+  type ZshStartupWrapperFiles
 } from '../zsh-startup-wrapper-builder'
 import { writeShellWrapperFiles } from '../shell-wrapper-file-writer'
-import { ZSH_WRAPPER_DIR_MARKER_CONTENT, ZSH_WRAPPER_DIR_MARKER_FILE } from '../shell-templates'
-import { getBashShellReadyRcfileContent } from './local-pty-shell-ready-bash-rcfile'
+import {
+  buildLocalShellReadyWrapperFiles,
+  getLocalZshWrapperSpec
+} from './local-pty-shell-ready-wrapper-fileset'
 import {
   getShellReadyWrapperRoot,
-  shellReadyWrappersExist,
-  SHELL_READY_MARKER_ESCAPED
+  shellReadyWrappersExist
 } from './local-pty-shell-ready-wrapper-root'
-
-let didEnsureShellReadyWrappers = false
-
-function getLocalZshWrapperSpec(zshDir: string): ZshStartupWrapperSpec {
-  return {
-    headerLabel: 'Orca zsh shell-ready wrapper',
-    zshDir,
-    zshenvStrategy: 'discover-user-zdotdir',
-    readyMarkerEscaped: SHELL_READY_MARKER_ESCAPED,
-    osc133CommandMarkers: true,
-    skipUserZshrcWhenHomeIsWrapperDir: true,
-    overlayRestoreComment:
-      "# Why: ~/.zshrc can export the user's default OpenCode config after spawn.",
-    restores: {
-      agentTeamsPath: true,
-      remoteCliBinDir: false,
-      codexHome: true,
-      codexLaunchPreflight: true
-    }
-  }
-}
 
 export function getZshShellReadyWrapperFiles(): ZshStartupWrapperFiles {
   return buildZshStartupWrapperFiles(getLocalZshWrapperSpec(`${getShellReadyWrapperRoot()}/zsh`))
@@ -45,30 +24,19 @@ export function getZshShellReadyWrapperFiles(): ZshStartupWrapperFiles {
 
 /** True when every wrapper file is present and non-empty afterwards. */
 export function ensureShellReadyWrappersAt(root = getShellReadyWrapperRoot()): boolean {
-  if (didEnsureShellReadyWrappers && shellReadyWrappersExist(root)) {
-    return true
+  // Why existence alone decides, with no per-process flag: the root is keyed by
+  // a hash of the exact bytes we would write, so a tree that is present and
+  // non-empty is a tree this build wrote. Rewriting it would replace a live file
+  // on the terminal-spawn path for no gain.
+  if (!shellReadyWrappersExist(root)) {
+    const written = writeShellWrapperFiles(buildLocalShellReadyWrapperFiles(root), '[shell-ready]')
+    if (!written || !shellReadyWrappersExist(root)) {
+      // Why no flag to reset: the next launch re-checks the files themselves, so
+      // a half-written tree is retried without any extra bookkeeping.
+      return false
+    }
   }
-  didEnsureShellReadyWrappers = true
 
-  const zshDir = `${root}/zsh`
-  const zsh = buildZshStartupWrapperFiles(getLocalZshWrapperSpec(zshDir))
-
-  const written = writeShellWrapperFiles(
-    [
-      [`${zshDir}/.zshenv`, zsh.zshenv],
-      [`${zshDir}/.zprofile`, zsh.zprofile],
-      [`${zshDir}/.zshrc`, zsh.zshrc],
-      [`${zshDir}/.zlogin`, zsh.zlogin],
-      [`${zshDir}/${ZSH_WRAPPER_DIR_MARKER_FILE}`, ZSH_WRAPPER_DIR_MARKER_CONTENT],
-      [`${root}/bash/rcfile`, getBashShellReadyRcfileContent()]
-    ],
-    '[shell-ready]'
-  )
-  if (!written || !shellReadyWrappersExist(root)) {
-    // Why reset: the next launch retries instead of trusting a half-written tree.
-    didEnsureShellReadyWrappers = false
-    return false
-  }
   return true
 }
 

--- a/src/main/providers/local-pty-shell-ready-wrapper-root.ts
+++ b/src/main/providers/local-pty-shell-ready-wrapper-root.ts
@@ -3,26 +3,45 @@
  * wrappers emit — the shared contract between wrapper generation and shell launch.
  */
 import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { statSync } from 'node:fs'
-import { ZSH_WRAPPER_DIR_MARKER_FILE } from '../shell-templates'
+import { resolveShellWrapperRoot } from '../shell-wrapper-content-address'
+import { buildLocalShellReadyWrapperFiles } from './local-pty-shell-ready-wrapper-fileset'
 
-export const SHELL_READY_MARKER_ESCAPED = '\\033]777;orca-shell-ready\\007'
+export { SHELL_READY_MARKER_ESCAPED } from './local-pty-shell-ready-marker'
+
+export function getShellReadyWrapperBaseDir(): string {
+  // Why: bundled into the daemon fork (no electron), so read ORCA_USER_DATA_PATH rather than electron's userData; main and the fork both set it to the same path.
+  // Why a truthiness test rather than `??`: a set-but-empty ORCA_USER_DATA_PATH
+  // would leave a relative base dir, and the pruner recursively removes
+  // directories under it -- that must never resolve against the process cwd.
+  const userDataPath = process.env.ORCA_USER_DATA_PATH
+  // Why not the legacy `shell-ready/`: daemons of older builds still write that
+  // path unconditionally, so this build's trees live out of their reach. Why the
+  // fallback is namespaced: os.tmpdir() is a shared world-writable /tmp on
+  // Linux, where a generic name is one any local user can pre-create and own --
+  // and then swap the .zshrc that ZDOTDIR points at.
+  return userDataPath ? join(userDataPath, 'shell-wrappers') : join(tmpdir(), 'orca-shell-wrappers')
+}
+
+// Why memoized: the digest is stable for a given base dir and every shell launch
+// asks for it. Why keyed on the base dir rather than a bare flag: it
+// self-invalidates if ORCA_USER_DATA_PATH is ever re-pointed mid-process.
+let cachedShellReadyWrapperRoot: { baseDir: string; root: string } | null = null
 
 export function getShellReadyWrapperRoot(): string {
-  // Why: bundled into the daemon fork (no electron), so read ORCA_USER_DATA_PATH rather than electron's userData; main and the fork both set it to the same path.
-  const userDataPath = process.env.ORCA_USER_DATA_PATH ?? tmpdir()
-  return `${userDataPath}/shell-ready`
+  const baseDir = getShellReadyWrapperBaseDir()
+  if (cachedShellReadyWrapperRoot?.baseDir !== baseDir) {
+    cachedShellReadyWrapperRoot = {
+      baseDir,
+      root: resolveShellWrapperRoot(baseDir, buildLocalShellReadyWrapperFiles)
+    }
+  }
+  return cachedShellReadyWrapperRoot.root
 }
 
 export function getRequiredShellReadyWrapperPaths(root = getShellReadyWrapperRoot()): string[] {
-  return [
-    `${root}/zsh/.zshenv`,
-    `${root}/zsh/.zprofile`,
-    `${root}/zsh/.zshrc`,
-    `${root}/zsh/.zlogin`,
-    `${root}/zsh/${ZSH_WRAPPER_DIR_MARKER_FILE}`,
-    `${root}/bash/rcfile`
-  ]
+  return buildLocalShellReadyWrapperFiles(root).map(([path]) => path)
 }
 
 /**

--- a/src/main/providers/local-pty-shell-ready-wrapper-root.ts
+++ b/src/main/providers/local-pty-shell-ready-wrapper-root.ts
@@ -20,8 +20,12 @@ function getShellReadyWrapperBaseDir(): string {
   // Why not the legacy `shell-ready/`: daemons of older builds still write that
   // path unconditionally, so this build's trees live out of their reach. Why the
   // fallback is namespaced: os.tmpdir() is a shared world-writable /tmp on
-  // Linux, where a generic name is one any local user can pre-create and own --
-  // and then swap the .zshrc that ZDOTDIR points at.
+  // Linux, where a generic name is one any local user can pre-create and own.
+  // Note the presence check is size-only, so a complete tree pre-planted under
+  // that fallback would be trusted rather than overwritten. Production never
+  // reaches it -- ORCA_USER_DATA_PATH is seeded before anything spawns and the
+  // daemon fork inherits it -- so this stays a documented trust boundary rather
+  // than an ownership check on the spawn path.
   return userDataPath ? join(userDataPath, 'shell-wrappers') : join(tmpdir(), 'orca-shell-wrappers')
 }
 

--- a/src/main/providers/local-pty-shell-ready-wrapper-root.ts
+++ b/src/main/providers/local-pty-shell-ready-wrapper-root.ts
@@ -10,11 +10,12 @@ import { buildLocalShellReadyWrapperFiles } from './local-pty-shell-ready-wrappe
 
 export { SHELL_READY_MARKER_ESCAPED } from './local-pty-shell-ready-marker'
 
-export function getShellReadyWrapperBaseDir(): string {
+// Module-private, matching the daemon's twin: nothing outside needs the base.
+function getShellReadyWrapperBaseDir(): string {
   // Why: bundled into the daemon fork (no electron), so read ORCA_USER_DATA_PATH rather than electron's userData; main and the fork both set it to the same path.
   // Why a truthiness test rather than `??`: a set-but-empty ORCA_USER_DATA_PATH
-  // would leave a relative base dir, and the pruner recursively removes
-  // directories under it -- that must never resolve against the process cwd.
+  // would leave a relative base dir, so wrapper trees would be written under
+  // whatever the process cwd happens to be.
   const userDataPath = process.env.ORCA_USER_DATA_PATH
   // Why not the legacy `shell-ready/`: daemons of older builds still write that
   // path unconditionally, so this build's trees live out of their reach. Why the

--- a/src/main/providers/local-pty-shell-ready-zsh-zdotdir-discovery.test.ts
+++ b/src/main/providers/local-pty-shell-ready-zsh-zdotdir-discovery.test.ts
@@ -10,6 +10,8 @@ import {
   restoreUserDataPathAfterEach,
   setTestUserDataPath
 } from './local-pty-shell-ready-test-harness'
+// Why resolved rather than hardcoded: the wrapper tree is content-addressed.
+import { getShellReadyWrapperRoot } from './local-pty-shell-ready-wrapper-root'
 
 restoreUserDataPathAfterEach()
 
@@ -99,7 +101,12 @@ path=(/custom/bin $path)
         delete cleanEnv.ZDOTDIR
         delete cleanEnv.ORCA_ORIG_ZDOTDIR
         delete cleanEnv.USER_ZSHRC_LOADED
-        cleanEnv.ZDOTDIR = join(movedUserData, 'shell-ready', 'zsh')
+        // Why the prefix swap: the tree is content-addressed under the user data
+        // dir, so the relocated ZDOTDIR has to follow the resolved root.
+        cleanEnv.ZDOTDIR = join(
+          getShellReadyWrapperRoot().replace(userDataPath, movedUserData),
+          'zsh'
+        )
 
         // Cover both the WSL login shell (`exec zsh -l`) and the non-login local-pane flow so both restore paths stay pinned.
         for (const args of [['-i'], ['-l', '-i']] as const) {
@@ -146,7 +153,12 @@ path=(/custom/bin $path)
         delete cleanEnv.ZDOTDIR
         delete cleanEnv.ORCA_ORIG_ZDOTDIR
         delete cleanEnv.USER_ZSHRC_LOADED
-        cleanEnv.ZDOTDIR = join(nonAsciiUserData, 'shell-ready', 'zsh')
+        // Why the prefix swap: the tree is content-addressed under the user data
+        // dir, so the relocated ZDOTDIR has to follow the resolved root.
+        cleanEnv.ZDOTDIR = join(
+          getShellReadyWrapperRoot().replace(userDataPath, nonAsciiUserData),
+          'zsh'
+        )
 
         for (const args of [['-i'], ['-l', '-i']] as const) {
           const result = spawnSync(

--- a/src/main/providers/local-pty-shell-ready-zsh-zdotdir-normalization.test.ts
+++ b/src/main/providers/local-pty-shell-ready-zsh-zdotdir-normalization.test.ts
@@ -3,6 +3,8 @@ import { spawnSync } from 'node:child_process'
 import { tmpdir } from 'node:os'
 import { join, dirname } from 'node:path'
 import { mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from 'node:fs'
+// Why resolved rather than hardcoded: the wrapper tree is content-addressed.
+import { getShellReadyWrapperRoot } from './local-pty-shell-ready-wrapper-root'
 import {
   describeIfZsh,
   describePosix,
@@ -243,7 +245,7 @@ describePosix('live zsh subprocess tests', () => {
       const { getShellReadyLaunchConfig } = await importFreshLocalPtyShellReady()
       getShellReadyLaunchConfig('/bin/zsh')
 
-      const zshenv = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshenv'), 'utf8')
+      const zshenv = readFileSync(join(getShellReadyWrapperRoot(), 'zsh', '.zshenv'), 'utf8')
 
       // Verify wrapper checks the resolved source root is non-empty before sourcing
       expect(zshenv).toContain('if [[ -n "${_orca_zshenv_source_dir:-}"')

--- a/src/main/providers/windows-shell-args.test.ts
+++ b/src/main/providers/windows-shell-args.test.ts
@@ -5,6 +5,8 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { buildWslInteractiveLoginShellCommand } from '../../shared/wsl-login-shell-command'
 import { resolveSetupRunnerCommand } from '../../shared/setup-runner-command'
 import { resolveWindowsShellLaunchArgs } from './windows-shell-args'
+// Why resolved rather than hardcoded: the wrapper tree is content-addressed.
+import { getShellReadyWrapperRoot } from './local-pty-shell-ready-wrapper-root'
 
 const CODEX_LAUNCH_PREFLIGHT = 'C:\\Program Files\\Orca\\orca.exe'
 const CMD_CODEX_LAUNCH_PREFLIGHT =
@@ -378,14 +380,14 @@ describe('resolveWindowsShellLaunchArgs', () => {
     )
 
     expect(result.shellArgs).toEqual(expectedWslArgs('/mnt/c/Users/alice/code'))
-    expect(existsSync(join(userDataPath, 'shell-ready', 'bash', 'rcfile'))).toBe(true)
-    expect(existsSync(join(userDataPath, 'shell-ready', 'zsh', '.zshenv'))).toBe(true)
+    expect(existsSync(join(getShellReadyWrapperRoot(), 'bash', 'rcfile'))).toBe(true)
+    expect(existsSync(join(getShellReadyWrapperRoot(), 'zsh', '.zshenv'))).toBe(true)
 
     // Why: typed OMP keeps its existing shell integration, while typed Prime
     // commands must reach the user's binary without Orca rewriting argv.
-    const bashRcfile = readFileSync(join(userDataPath, 'shell-ready', 'bash', 'rcfile'), 'utf8')
+    const bashRcfile = readFileSync(join(getShellReadyWrapperRoot(), 'bash', 'rcfile'), 'utf8')
     // Why .zshenv: the omp wrapper is part of the epilogue defined there.
-    const zshEnv = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshenv'), 'utf8')
+    const zshEnv = readFileSync(join(getShellReadyWrapperRoot(), 'zsh', '.zshenv'), 'utf8')
     for (const wrapperFile of [bashRcfile, zshEnv]) {
       expect(wrapperFile).toContain('command omp --extension "${ORCA_OMP_STATUS_EXTENSION}" "$@"')
       expect(wrapperFile).toContain('omp() { __orca_omp "$@"; }')

--- a/src/main/pty/wsl-orca-env.test.ts
+++ b/src/main/pty/wsl-orca-env.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest'
+import { isAbsolute } from 'node:path'
+import { getShellReadyWrapperRoot } from '../providers/local-pty-shell-ready-wrapper-root'
 import {
   SETUP_AGENT_SEQUENCE_STARTUP_COMMAND_ENV,
   SETUP_AGENT_SEQUENCE_STARTUP_SCRIPT_ENV
@@ -15,7 +17,23 @@ describe('addOrcaWslInteropEnv', () => {
 
     addOrcaWslInteropEnv(env)
 
-    expect(env.WSLENV).toBe('ORCA_TERMINAL_HANDLE/u')
+    expect(env.WSLENV).toBe('ORCA_TERMINAL_HANDLE/u:ORCA_SHELL_READY_ROOT/p')
+  })
+
+  // Why this is published at all: the wrapper tree is content-addressed, so the
+  // in-guest login script cannot rebuild its path from ORCA_USER_DATA_PATH -- it
+  // cannot derive the hash segment. Without this the guest finds no wrapper and
+  // every WSL pane launches unwrapped: no ready marker, so every startup command
+  // waits out the full readiness timeout.
+  it('publishes the resolved wrapper root path-translated for the guest', () => {
+    const env: Record<string, string> = {}
+
+    addOrcaWslInteropEnv(env)
+
+    expect(env.ORCA_SHELL_READY_ROOT).toBe(getShellReadyWrapperRoot())
+    expect(isAbsolute(env.ORCA_SHELL_READY_ROOT as string)).toBe(true)
+    // /p, not /u: the guest reads a Windows path through /mnt/c.
+    expect(env.WSLENV?.split(':')).toContain('ORCA_SHELL_READY_ROOT/p')
   })
 
   it('imports setup-gated startup env into WSL without path translation', () => {
@@ -27,6 +45,7 @@ describe('addOrcaWslInteropEnv', () => {
     addOrcaWslInteropEnv(env)
 
     expect(env.WSLENV?.split(':')).toEqual([
+      'ORCA_SHELL_READY_ROOT/p',
       `${SETUP_AGENT_SEQUENCE_STARTUP_COMMAND_ENV}/u`,
       `${SETUP_AGENT_SEQUENCE_STARTUP_SCRIPT_ENV}/u`
     ])
@@ -39,7 +58,7 @@ describe('addOrcaWslInteropEnv', () => {
 
     addOrcaWslInteropEnv(env)
 
-    expect(env.WSLENV).toBe('FOO/u:ORCA_TERMINAL_HANDLE/u:BAR/p')
+    expect(env.WSLENV).toBe('FOO/u:ORCA_TERMINAL_HANDLE/u:BAR/p:ORCA_SHELL_READY_ROOT/p')
   })
 
   it('marks OMP status and hook env for Windows to WSL import', () => {
@@ -178,7 +197,7 @@ describe('addOrcaWslInteropEnv', () => {
 
     addOrcaWslInteropEnv(env)
 
-    expect(env.WSLENV).toBe('ORCA_WORKSPACE_NAME/u')
+    expect(env.WSLENV).toBe('ORCA_SHELL_READY_ROOT/p:ORCA_WORKSPACE_NAME/u')
   })
 
   it('does not register setup vars that are absent from the env', () => {
@@ -186,7 +205,7 @@ describe('addOrcaWslInteropEnv', () => {
 
     addOrcaWslInteropEnv(env)
 
-    expect(env.WSLENV).toBe('ORCA_TERMINAL_HANDLE/u')
+    expect(env.WSLENV).toBe('ORCA_TERMINAL_HANDLE/u:ORCA_SHELL_READY_ROOT/p')
   })
 
   it('marks the WSL hook relay version for import on relay spawn envs', () => {
@@ -194,7 +213,7 @@ describe('addOrcaWslInteropEnv', () => {
       ORCA_WSL_HOOK_RELAY_VERSION: '0.1.0+abc'
     }
     addOrcaWslInteropEnv(env)
-    expect(env.WSLENV).toBe('ORCA_WSL_HOOK_RELAY_VERSION/u')
+    expect(env.WSLENV).toBe('ORCA_SHELL_READY_ROOT/p:ORCA_WSL_HOOK_RELAY_VERSION/u')
   })
 
   it('crosses a guest-side OpenCode config overlay untranslated (/u)', () => {

--- a/src/main/pty/wsl-orca-env.ts
+++ b/src/main/pty/wsl-orca-env.ts
@@ -8,6 +8,7 @@ import {
   SETUP_AGENT_SEQUENCE_STARTUP_COMMAND_ENV,
   SETUP_AGENT_SEQUENCE_STARTUP_SCRIPT_ENV
 } from '../../shared/setup-agent-sequencing'
+import { getShellReadyWrapperRoot } from '../providers/local-pty-shell-ready-wrapper-root'
 
 const WSLENV_ENTRY_SEPARATOR = ':'
 
@@ -61,6 +62,11 @@ export function addWorktreeSetupWslInteropEnv(env: Record<string, string | undef
 }
 
 export function addOrcaWslInteropEnv(env: Record<string, string>): void {
+  // Why set here: every WSL spawn path funnels through this helper, and the
+  // in-guest login script needs the resolved wrapper root. Windows/WSL wrappers
+  // are always the local file set -- windows-shell-args.ts is shared by the
+  // in-process provider and the daemon spawner, so both resolve the same tree.
+  env.ORCA_SHELL_READY_ROOT = getShellReadyWrapperRoot()
   // Why: the endpoint is a Windows path (/p-translated so the guest reads it
   // via /mnt/c) until the WSL hook relay reports the guest home — then it is
   // already a guest-side POSIX path and must cross untranslated.
@@ -76,6 +82,9 @@ export function addOrcaWslInteropEnv(env: Record<string, string>): void {
   const passthroughEntries = [
     'ORCA_TERMINAL_HANDLE/u',
     'ORCA_USER_DATA_PATH/p',
+    // Why /p: the guest reads the content-addressed wrapper tree through /mnt/c,
+    // and it cannot derive the hash segment from ORCA_USER_DATA_PATH alone.
+    'ORCA_SHELL_READY_ROOT/p',
     'ORCA_CLI_COMMAND/u',
     'ORCA_PANE_KEY/u',
     'ORCA_TAB_ID/u',

--- a/src/main/shell-wrapper-content-address.test.ts
+++ b/src/main/shell-wrapper-content-address.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import { mkdtempSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, sep } from 'node:path'
+import {
+  resolveShellWrapperRoot,
+  type ShellWrapperFileBuilder
+} from './shell-wrapper-content-address'
+import { writeShellWrapperFiles } from './shell-wrapper-file-writer'
+
+function builderFor(marker: string): ShellWrapperFileBuilder {
+  // Why the root is embedded: mirrors .zshenv, the one wrapper file that names
+  // its own tree. The digest must stay stable despite it.
+  return (root) => [
+    [join(root, 'zsh', '.zshrc'), `zshrc ${marker} root=${root}`],
+    [join(root, 'bash', 'rcfile'), `rcfile ${marker}`]
+  ]
+}
+
+function makeBase(): string {
+  return mkdtempSync(join(tmpdir(), 'orca-wrapper-address-'))
+}
+
+describe('resolveShellWrapperRoot', () => {
+  it('gives builds with different wrapper contents different trees', () => {
+    const base = makeBase()
+    expect(resolveShellWrapperRoot(base, builderFor('ORCA_SHELL_READY_MARKER'))).not.toEqual(
+      resolveShellWrapperRoot(base, builderFor('ORCA_SHELL_FEATURES'))
+    )
+  })
+
+  it('is stable for identical contents', () => {
+    const base = makeBase()
+    expect(resolveShellWrapperRoot(base, builderFor('a'))).toEqual(
+      resolveShellWrapperRoot(base, builderFor('a'))
+    )
+  })
+
+  // Why: `*/shell-ready/zsh` globs baked into the wrapper scripts, plus TS
+  // guards, detect a self-referential ZDOTDIR by this exact suffix. Losing it
+  // makes a wrapper source itself until zsh hits its recursion limit.
+  it('keeps the zsh dir ending in /shell-ready/zsh', () => {
+    const root = resolveShellWrapperRoot(makeBase(), builderFor('a'))
+    // Compare in POSIX form: the guards match a POSIX suffix, and the value they
+    // see is built with POSIX concatenation regardless of the host separator.
+    expect(join(root, 'zsh').split(sep).join('/').endsWith('/shell-ready/zsh')).toBe(true)
+  })
+
+  it('lets two contracts coexist instead of clobbering each other', () => {
+    const base = makeBase()
+    const oldBuild = builderFor('old')
+    const newBuild = builderFor('new')
+    const oldRoot = resolveShellWrapperRoot(base, oldBuild)
+    const newRoot = resolveShellWrapperRoot(base, newBuild)
+
+    writeShellWrapperFiles(oldBuild(oldRoot), '[test]')
+    writeShellWrapperFiles(newBuild(newRoot), '[test]')
+
+    // The regression: the second writer used to overwrite the first writer's
+    // file in place, leaving the first build launching shells it cannot read.
+    expect(readFileSync(join(oldRoot, 'bash', 'rcfile'), 'utf8')).toBe('rcfile old')
+    expect(readFileSync(join(newRoot, 'bash', 'rcfile'), 'utf8')).toBe('rcfile new')
+  })
+
+  // Why: older builds still write the unversioned `<userData>/shell-ready/` tree
+  // and long-lived daemons launch shells from it. Addressing by content has to
+  // land somewhere that cannot collide with it.
+  it('never resolves onto the legacy unversioned tree', () => {
+    const userData = makeBase()
+    const root = resolveShellWrapperRoot(join(userData, 'shell-wrappers'), builderFor('a'))
+    expect(root.startsWith(join(userData, 'shell-wrappers') + sep)).toBe(true)
+    expect(root).not.toEqual(join(userData, 'shell-ready'))
+  })
+})

--- a/src/main/shell-wrapper-content-address.ts
+++ b/src/main/shell-wrapper-content-address.ts
@@ -1,0 +1,57 @@
+/**
+ * Decides where a generated shell wrapper tree lives, by hashing its contents.
+ *
+ * Why: every writer that shares a userData dir -- main's local PTY path, the
+ * daemon fork, and the daemons of other builds that outlive the app that
+ * spawned them -- wrote one fixed `shell-ready/` tree. Last writer won, and the
+ * guard only re-checked that the files were present, never that they were this
+ * build's. A daemon whose spawn env no longer agreed with the wrapper on disk
+ * then kept launching shells it could not read: the ready marker never fired
+ * and every startup command waited out the full readiness timeout, silently.
+ *
+ * Naming the directory after a hash of its own contents makes that impossible:
+ * different bytes are a different directory, so "present" means "written by
+ * this build" again. Writing stays in shell-wrapper-file-writer.ts.
+ *
+ * Why nothing here collects old trees: a tree is ~48KB and a new one appears
+ * only when the wrapper templates themselves change, so an install accrues a
+ * couple of megabytes a year against a userData directory that runs to tens of
+ * gigabytes. Reclaiming that is not worth putting an `rm -rf` on the
+ * terminal-spawn path.
+ */
+import { createHash } from 'node:crypto'
+import { join } from 'node:path'
+import type { ShellWrapperFile } from './shell-wrapper-file-writer'
+
+/** Builds the wrapper set for a tree rooted at `root`, as the writer takes it. */
+export type ShellWrapperFileBuilder = (root: string) => readonly ShellWrapperFile[]
+
+// Why a placeholder root: .zshenv bakes in the tree path, so hashing against the
+// real root would make the digest depend on the very path it is choosing. A
+// fixed stand-in keeps it stable across machines and user data dirs while still
+// covering every difference that matters.
+//
+// Note this string is itself part of the digest, because it appears in the baked
+// content. Renaming it re-keys every tree -- which costs one extra ~48KB
+// directory per install and nothing else, so it is not worth normalizing out.
+const HASH_PROBE_ROOT = '/__orca_shell_wrapper_root__'
+const ROOT_HASH_LENGTH = 16
+// Why the hash sits ABOVE this leaf rather than below it: ZDOTDIR
+// self-reference guards -- in TS and as `*/shell-ready/zsh` globs baked into
+// the wrapper scripts -- match on that exact suffix. Without it a wrapper
+// sources itself and zsh dies with "job table full or recursion limit
+// exceeded". `<base>/<hash>/shell-ready/zsh` leaves every guard intact and
+// keeps older builds able to recognize a newer build's dir.
+const WRAPPER_ROOT_LEAF = 'shell-ready'
+
+export function resolveShellWrapperRoot(baseDir: string, build: ShellWrapperFileBuilder): string {
+  const digest = createHash('sha256')
+  for (const [path, content] of build(HASH_PROBE_ROOT)) {
+    // Relative, so the digest does not vary with the base dir it is naming.
+    digest.update(path.slice(HASH_PROBE_ROOT.length))
+    digest.update('\0')
+    digest.update(content)
+    digest.update('\0')
+  }
+  return join(baseDir, digest.digest('hex').slice(0, ROOT_HASH_LENGTH), WRAPPER_ROOT_LEAF)
+}

--- a/src/main/shell-wrapper-content-address.ts
+++ b/src/main/shell-wrapper-content-address.ts
@@ -34,6 +34,12 @@ export type ShellWrapperFileBuilder = (root: string) => readonly ShellWrapperFil
 // Note this string is itself part of the digest, because it appears in the baked
 // content. Renaming it re-keys every tree -- which costs one extra ~48KB
 // directory per install and nothing else, so it is not worth normalizing out.
+//
+// The digest therefore covers the probe build, not the literal bytes on disk.
+// That holds only while the sole path-dependent thing in a wrapper is the root
+// itself. A future template that varies on something else about its location
+// would need that input folded in here, or two genuinely different trees would
+// collide on one directory.
 const HASH_PROBE_ROOT = '/__orca_shell_wrapper_root__'
 const ROOT_HASH_LENGTH = 16
 // Why the hash sits ABOVE this leaf rather than below it: ZDOTDIR

--- a/src/main/shell-wrapper-generated-file-snapshot.test.ts
+++ b/src/main/shell-wrapper-generated-file-snapshot.test.ts
@@ -10,7 +10,10 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { ensureShellReadyWrappersAt } from './providers/local-pty-shell-ready-wrapper-generation'
-import { getShellLaunchConfig as getDaemonShellLaunchConfig } from './daemon/shell-ready'
+import {
+  getShellLaunchConfig as getDaemonShellLaunchConfig,
+  getShellReadyWrapperRoot as getDaemonShellReadyWrapperRoot
+} from './daemon/shell-ready'
 import { ensureOverlayRestoreWrappers } from '../relay/pty-shell-overlay-wrappers'
 import { getShellLaunchConfig as getLocalShellLaunchConfig } from './providers/local-pty-shell-ready'
 import { selectShellStartupFeatures } from './shell-startup-features'
@@ -125,7 +128,7 @@ describePosix('generated shell wrapper files', () => {
   it('daemon wrappers', async () => {
     process.env.ORCA_USER_DATA_PATH = root
     getDaemonShellLaunchConfig('/bin/zsh', STARTUP_COMMAND_FEATURES)
-    await expectWrapperFiles('daemon', join(root, 'shell-ready'))
+    await expectWrapperFiles('daemon', getDaemonShellReadyWrapperRoot())
   })
 
   it('relay overlay wrappers', async () => {
@@ -146,7 +149,7 @@ describePosix('generated shell wrapper files', () => {
         process.env.ORCA_USER_DATA_PATH = root
         getDaemonShellLaunchConfig('/bin/zsh', STARTUP_COMMAND_FEATURES)
       },
-      (): string => join(root, 'shell-ready')
+      (): string => getDaemonShellReadyWrapperRoot()
     ],
     ['relay', (): void => void ensureOverlayRestoreWrappers(root), (): string => root]
   ])('%s wrappers write no shell global outside Orca’s namespace', (_transport, generate, dir) => {

--- a/src/shared/wsl-login-shell-command.test.ts
+++ b/src/shared/wsl-login-shell-command.test.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from 'node:child_process'
+import { execFileSync, spawnSync } from 'node:child_process'
 import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -156,9 +156,7 @@ describe('wsl login shell command helpers', () => {
     // Why the captured form: an interactive login shell also prints the distro's
     // rc/motd to stdout (stock Ubuntu ships a sudo hint), so a raw login-shell
     // read cannot be compared byte-for-byte on a real distro.
-    const captured = buildWslCapturedLoginShellCommand(
-      'orca_value=ok; printf "<%s>" "$orca_value"'
-    )
+    const captured = buildWslCapturedLoginShellCommand('orca_value=ok; printf "<%s>" "$orca_value"')
 
     expect(
       captured.readStdout(
@@ -307,5 +305,37 @@ describe('wsl login shell command helpers', () => {
     expect(command).toContain('export ZDOTDIR="${_orca_shell_ready_root}/zsh"')
     expect(command).toContain('exec "$_orca_wsl_shell" -l')
     expectValidShSyntax(command)
+  })
+})
+
+describe('in-guest wrapper root resolution', () => {
+  // Why this test exists: the wrapper tree is content-addressed, so its path
+  // carries a hash the guest cannot derive. A previous revision of this script
+  // rebuilt the root as `${ORCA_USER_DATA_PATH}/shell-ready`, which stopped
+  // matching -- every WSL pane then fell through to an unwrapped `exec $shell -l`
+  // and silently lost the ready marker, OSC 133, and the launch preflight.
+  it('prefers the host-published root over the legacy user-data guess', () => {
+    const script = buildWslInteractiveLoginShellCommand()
+    expect(script).toContain('if [ -n "${ORCA_SHELL_READY_ROOT:-}" ]; then')
+    expect(script).toContain('_orca_shell_ready_root="${ORCA_SHELL_READY_ROOT%/}"')
+    // The legacy branch must remain reachable only as a fallback, so an older
+    // host that exports just ORCA_USER_DATA_PATH still wraps its shells.
+    expect(script).toContain('elif [ -n "${ORCA_USER_DATA_PATH:-}" ]; then')
+  })
+
+  it('resolves the published root ahead of the legacy path under a real shell', () => {
+    const script = buildWslInteractiveLoginShellCommand()
+    // Run only the root-resolution prologue, then report what it picked.
+    const prologue = script.split('_orca_wsl_shell_name=')[0] as string
+    const probe = [
+      'ORCA_SHELL_READY_ROOT=/mnt/c/ud/shell-wrappers/deadbeefdeadbeef/shell-ready',
+      'ORCA_USER_DATA_PATH=/mnt/c/ud',
+      'export ORCA_SHELL_READY_ROOT ORCA_USER_DATA_PATH',
+      prologue,
+      'printf "%s" "$_orca_shell_ready_root"'
+    ].join('\n')
+    const result = spawnSync('sh', ['-c', probe], { encoding: 'utf8' })
+    expect(result.status).toBe(0)
+    expect(result.stdout).toBe('/mnt/c/ud/shell-wrappers/deadbeefdeadbeef/shell-ready')
   })
 })

--- a/src/shared/wsl-login-shell-command.ts
+++ b/src/shared/wsl-login-shell-command.ts
@@ -114,7 +114,13 @@ export function buildWslInteractiveLoginShellCommand(): string {
     '  _orca_wsl_shell=/bin/sh',
     'fi',
     '_orca_shell_ready_root=""',
-    'if [ -n "${ORCA_USER_DATA_PATH:-}" ]; then',
+    // Why the explicit root first: the wrapper tree is content-addressed, so its
+    // path carries a hash the guest cannot derive. The host publishes the
+    // resolved root and WSLENV /p-translates it. The ORCA_USER_DATA_PATH branch
+    // stays as the fallback for an older host that exports only that.
+    'if [ -n "${ORCA_SHELL_READY_ROOT:-}" ]; then',
+    '  _orca_shell_ready_root="${ORCA_SHELL_READY_ROOT%/}"',
+    'elif [ -n "${ORCA_USER_DATA_PATH:-}" ]; then',
     '  _orca_shell_ready_root="${ORCA_USER_DATA_PATH%/}/shell-ready"',
     'fi',
     '_orca_wsl_shell_name=$(basename "$_orca_wsl_shell" | tr "[:upper:]" "[:lower:]")',


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​572 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​236 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​336 |
| Prod | 18 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​363 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​112 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​251 |

<!-- /orca-pr-loc -->

## Symptom

New terminals show a live shell prompt but ignore input for ~15s before the agent (or setup script) launches. It looks like a hung pane; it is actually a startup command sitting in a queue. Restarting Orca does not clear it, and neither does downgrading.

## Root cause

Startup commands are held until the shell emits the OSC 777 ready marker. If the marker never arrives, delivery falls back to `SHELL_READY_TIMEOUT_MS` (15s). Only *stdin* is gated, so the prompt renders normally at ~0.7s -- which is why this reads as "unresponsive terminal" rather than "slow launch".

The marker goes missing because every writer sharing a userData dir writes **one fixed `shell-ready/` tree**: main's local PTY path, the daemon fork, and the daemons of *other builds*, which outlive the app that spawned them. Last writer wins. And the guard only re-checks that the files **exist**, never that they are this build's:

```ts
if (didEnsureShellReadyWrappers && shellReadyWrappersExist()) return
```

So a daemon whose spawn env no longer agrees with the wrapper on disk keeps launching shells it cannot read -- permanently, with no log line.

**This is not confined to machines running dev builds.** The five live daemons on the machine this was found on spanned app versions 1.4.181-1.4.185, all from the same installed `/Applications/Orca.app` across auto-updates. Wrapper content changed 15 times in the last 12 months. Any release that changes it, with an older daemon still alive, reproduces this — and the user cannot recover by restarting, because the daemon is not restarted with the app.

Measured: **15.17s** from `terminal create` to the command running, against **1.10s** once the tree matched. 15.17s is the 15,000ms timeout.

## Fix

Name each wrapper tree after a hash of its own contents: `<userData>/shell-wrappers/<hash>/shell-ready/`. Different bytes are a different directory, so no writer can overwrite another's contract, and the existence check becomes *correct* rather than a bug — a tree that is present is a tree this build wrote.

Two deliberate constraints:

- **The hash sits ABOVE the `shell-ready` leaf.** ZDOTDIR self-reference guards — in TS, and as `*/shell-ready/zsh` globs baked into the wrapper scripts — match that exact suffix; losing it makes a wrapper source itself until zsh dies with "recursion limit exceeded". `<hash>/shell-ready/zsh` keeps every one of them intact.
- **A separate `shell-wrappers/` base dir.** Older daemons still write `shell-ready/` unconditionally, so this keeps these trees out of their reach — including during the upgrade that ships this.

Writing itself is unchanged: it stays in the existing `shell-wrapper-file-writer.ts`. This only decides placement.

**Nothing collects old trees, deliberately.** A tree is ~48KB and a new one appears only when the wrapper templates change, so an install accrues a couple of MB a year against a userData dir that runs to tens of GB. An earlier revision had a 30-day pruner; it reclaimed ~0.008% of userData and cost the only `rm -rf` in the change (on the terminal-spawn path), a `utimes` per launch, a liveness stamp, a symlink guard, a filename pattern, and a flag in both ensure paths — and it produced most of the defects review found. It is gone. If reclaiming trees is ever worth it, it belongs wherever userData is already garbage-collected.

Two things ride along because they are the same bug:

- **WSL.** The in-guest login script rebuilds the root from `ORCA_USER_DATA_PATH`, which cannot carry a hash. Without a fix, every WSL pane falls through to an unwrapped `exec "$shell" -l` and silently loses the ready marker, OSC 133, the identity marker, the OMP wrapper, and the Codex preflight. The host now publishes the resolved root as `ORCA_SHELL_READY_ROOT` over WSLENV `/p`; the legacy branch stays as a fallback for an older host.
- **The barrier now reports readiness failures to the daemon's file log.** It failed completely silently, which is what made this expensive to diagnose. Note the daemon runs detached with stdio `ignore`, so a `console.warn` there reaches nobody — an earlier revision of this PR made exactly that mistake and claimed the fix; the event is now threaded to the NDJSON logger, with the shell recorded as a basename.

## Verification

- 30,036 tests pass. The single failure is a pre-existing flake in `worktree-base-directory-poller.test.ts` (watcher-based, passes alone, file untouched by this PR).
- **Generated wrapper content is byte-identical to main** — same sha256 on every file with generators bundled from separate refs; snapshots untouched. This moves trees without altering a line of shell script.
- Verified by execution, not review: the suffix guards match under real zsh and bash (including with every ZDOTDIR variable forced at the wrapper dir, so only the in-script globs stand between zsh and recursion); the marker fires from the hashed path (zsh +0.12s, bash +0.82s); two contracts coexist in either write order; a warm tree is never rewritten; and running `main`'s guest script against a hashed tree reproduces the WSL failure this fixes.

Four rounds of adversarial review against the readiness checklist informed the shape above; the largest single outcome was deleting the pruner.

## Follow-ups (not in this PR)

- `SessionShellReadyBarrier`'s fallback probe is inert for this failure class: `shell-prompt-readiness-probe.ts` bails without a shell pid, and that pid only arrives via the identity marker the same mismatch suppresses, so both signals die together. Fixing it means sourcing the pid from the pty foreground process group.
- The wrapper path has three independent consumers (local, daemon, in-guest WSL) plus suffix-matching guards embedded in shell-script text. That coupling is what made the WSL break possible and predates this change; untangling it is its own piece of work.
- The relay keys its wrapper tree at a single fixed `~/.orca-relay/shell-ready` with non-atomic writes. It validates content, so it lacks the existence-only bug — but after this ships, local terminals are protected from clobbering and relay ones are not.

