### PR TITLE
feat: add Qoder CLI (qodercli) as a supported TuiAgent

### DIFF
--- a/src/main/agent-hooks/managed-agent-hook-registry.ts
+++ b/src/main/agent-hooks/managed-agent-hook-registry.ts
@@ -10,6 +10,7 @@ import { cursorHookService } from '../cursor/hook-service'
 import { devinHookService } from '../devin/hook-service'
 import { droidHookService } from '../droid/hook-service'
 import { geminiHookService } from '../gemini/hook-service'
+import { qoderHookService } from '../qoder/hook-service'
 import { grokHookService } from '../grok/hook-service'
 import { hermesHookService } from '../hermes/hook-service'
 import { kimiHookService } from '../kimi/hook-service'
@@ -25,6 +26,7 @@ export const MANAGED_AGENT_HOOK_INSTALLERS: readonly ManagedAgentHookInstaller[]
   ['openclaude', () => openClaudeHookService.install()],
   ['codex', () => codexHookService.install()],
   ['gemini', () => geminiHookService.install()],
+  ['qoder', () => qoderHookService.install()],
   ['antigravity', () => antigravityHookService.install()],
   ['amp', () => ampHookService.install()],
   ['cursor', () => cursorHookService.install()],
@@ -48,6 +50,7 @@ export const MANAGED_AGENT_HOOK_SCRIPT_REFRESHERS: readonly ManagedAgentHookScri
   ['openclaude', () => openClaudeHookService.refreshManagedScripts()],
   ['codex', () => codexHookService.refreshManagedScripts()],
   ['gemini', () => geminiHookService.refreshManagedScripts()],
+  ['qoder', () => qoderHookService.refreshManagedScripts()],
   ['antigravity', () => antigravityHookService.refreshManagedScripts()],
   ['cursor', () => cursorHookService.refreshManagedScripts()],
   ['droid', () => droidHookService.refreshManagedScripts()],
@@ -63,6 +66,7 @@ export const MANAGED_AGENT_HOOK_REMOVERS: readonly ManagedAgentHookRemover[] = [
   ['openclaude', () => openClaudeHookService.remove()],
   ['codex', () => codexHookService.remove()],
   ['gemini', () => geminiHookService.remove()],
+  ['qoder', () => qoderHookService.remove()],
   ['antigravity', () => antigravityHookService.remove()],
   ['amp', () => ampHookService.remove()],
   ['cursor', () => cursorHookService.remove()],
@@ -80,6 +84,7 @@ export const MANAGED_AGENT_HOOK_STATUS_READERS: readonly ManagedAgentHookStatusR
   ['openclaude', () => openClaudeHookService.getStatus()],
   ['codex', () => codexHookService.getStatus()],
   ['gemini', () => geminiHookService.getStatus()],
+  ['qoder', () => qoderHookService.getStatus()],
   ['antigravity', () => antigravityHookService.getStatus()],
   ['amp', () => ampHookService.getStatus()],
   ['cursor', () => cursorHookService.getStatus()],

--- a/src/main/agent-hooks/remote-hook-service-installers.test.ts
+++ b/src/main/agent-hooks/remote-hook-service-installers.test.ts
@@ -13,6 +13,7 @@ import { DroidHookService, droidHookService } from '../droid/hook-service'
 import { CursorHookService, cursorHookService } from '../cursor/hook-service'
 import { CommandCodeHookService, commandCodeHookService } from '../command-code/hook-service'
 import { GeminiHookService, geminiHookService } from '../gemini/hook-service'
+import { qoderHookService } from '../qoder/hook-service'
 import { AntigravityHookService, antigravityHookService } from '../antigravity/hook-service'
 import { AmpHookService, ampHookService } from '../amp/hook-service'
 import { ClaudeHookService, claudeHookService } from '../claude/hook-service'
@@ -683,6 +684,7 @@ describe('remote hook service installers', () => {
       ['openclaude', openClaudeHookService],
       ['codex', codexHookService],
       ['gemini', geminiHookService],
+      ['qoder', qoderHookService],
       ['antigravity', antigravityHookService],
       ['amp', ampHookService],
       ['cursor', cursorHookService],

--- a/src/main/agent-hooks/remote-managed-hook-installers.ts
+++ b/src/main/agent-hooks/remote-managed-hook-installers.ts
@@ -4,6 +4,7 @@ import { ampHookService } from '../amp/hook-service'
 import { claudeHookService } from '../claude/hook-service'
 import { codexHookService } from '../codex/hook-service'
 import { geminiHookService } from '../gemini/hook-service'
+import { qoderHookService } from '../qoder/hook-service'
 import { antigravityHookService } from '../antigravity/hook-service'
 import { cursorHookService } from '../cursor/hook-service'
 import { commandCodeHookService } from '../command-code/hook-service'
@@ -55,6 +56,7 @@ const REMOTE_MANAGED_HOOK_INSTALLERS: readonly RemoteManagedHookInstaller[] = [
       )
   ],
   ['gemini', (sftp, remoteHome) => geminiHookService.installRemote(sftp, remoteHome)],
+  ['qoder', (sftp, remoteHome) => qoderHookService.installRemote(sftp, remoteHome)],
   ['antigravity', (sftp, remoteHome) => antigravityHookService.installRemote(sftp, remoteHome)],
   ['amp', (sftp, remoteHome) => ampHookService.installRemote(sftp, remoteHome)],
   ['cursor', (sftp, remoteHome) => cursorHookService.installRemote(sftp, remoteHome)],

--- a/src/main/agent-trust-presets.ts
+++ b/src/main/agent-trust-presets.ts
@@ -5,7 +5,7 @@ import { writeFileAtomically } from './codex-accounts/fs-utils'
 import { getOrcaManagedCodexHomePath } from './codex/codex-home-paths'
 import { upsertProjectTrustLevel } from './codex/config-toml-trust'
 
-export type AgentTrustPreset = 'cursor' | 'copilot' | 'codex'
+export type AgentTrustPreset = 'cursor' | 'copilot' | 'codex' | 'qoder'
 
 /**
  * Pre-mark a workspace as trusted for cursor-agent, GitHub Copilot CLI, or
@@ -115,6 +115,24 @@ export function markCodexProjectTrusted(workspacePath: string): void {
   // Why: Orca-launched Codex runs with an Orca-owned CODEX_HOME, so the trust
   // preset must also update the runtime config Codex will actually read.
   upsertProjectTrustLevel(join(getOrcaManagedCodexHomePath(), 'config.toml'), absPath, 'trusted')
+}
+
+/**
+ * Qoder CLI keeps a workspace-local trust marker at `<workspace>/.trusted`
+ * (verified empirically: launching qodercli in a directory containing an
+ * empty `.trusted` file skips the "Trust folder" menu entirely).
+ */
+export function markQoderWorkspaceTrusted(workspacePath: string): void {
+  const absPath = canonicalize(workspacePath)
+  if (!absPath) {
+    return
+  }
+  const trustFile = join(absPath, '.trusted')
+  if (existsSync(trustFile)) {
+    return
+  }
+  // Why: an empty marker is all qodercli reads — no payload contract.
+  writeFileAtomically(trustFile, '')
 }
 
 function resolveCodexProjectTrustRoot(workspacePath: string): string {

--- a/src/main/ipc/agent-trust.ts
+++ b/src/main/ipc/agent-trust.ts
@@ -3,7 +3,8 @@ import {
   type AgentTrustPreset,
   markCodexProjectTrusted,
   markCopilotFolderTrusted,
-  markCursorWorkspaceTrusted
+  markCursorWorkspaceTrusted,
+  markQoderWorkspaceTrusted
 } from '../agent-trust-presets'
 import { markRemoteAgentWorkspaceTrusted } from '../remote-agent-trust-presets'
 
@@ -43,6 +44,8 @@ export function registerAgentTrustHandlers(): void {
           markCopilotFolderTrusted(args.workspacePath)
         } else if (args.preset === 'codex') {
           markCodexProjectTrusted(args.workspacePath)
+        } else if (args.preset === 'qoder') {
+          markQoderWorkspaceTrusted(args.workspacePath)
         }
       } catch {
         // Best-effort: see Why above. The user can still accept the trust

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -125,7 +125,8 @@ import { createWorktreeCreateTimingRecorder } from '../worktree-create-timing'
 import {
   markCodexProjectTrusted,
   markCopilotFolderTrusted,
-  markCursorWorkspaceTrusted
+  markCursorWorkspaceTrusted,
+  markQoderWorkspaceTrusted
 } from '../agent-trust-presets'
 import {
   getLocalProjectGitExecOptions,
@@ -312,6 +313,8 @@ async function spawnLocalStartupAndSetupTerminals(args: {
           markCopilotFolderTrusted(worktree.path)
         } else if (preset === 'codex') {
           markCodexProjectTrusted(worktree.path)
+        } else if (preset === 'qoder') {
+          markQoderWorkspaceTrusted(worktree.path)
         }
       } catch {
         // Best-effort: launch still proceeds and the agent can ask interactively.

--- a/src/main/qoder/hook-service.test.ts
+++ b/src/main/qoder/hook-service.test.ts
@@ -15,7 +15,7 @@ vi.mock('electron', () => ({
   }
 }))
 
-vi.mock('os', async (importOriginal) => {
+vi.mock('node:os', async (importOriginal) => {
   const actual = await importOriginal<typeof osModule>()
   return {
     ...actual,
@@ -133,18 +133,27 @@ describe('QoderHookService', () => {
   it('remove() strips managed hooks and leaves user hooks untouched', () => {
     const configDir = join(homeDir, '.qoder')
     mkdirSync(configDir, { recursive: true })
+    // Why: self-contained fixture so this test passes on its own, not just after install().
+    writeFileSync(
+      join(configDir, 'settings.json'),
+      JSON.stringify(
+        {
+          hooks: {
+            UserPromptSubmit: [
+              {
+                hooks: [{ type: 'command', command: 'echo user-prompt' }]
+              }
+            ]
+          }
+        },
+        null,
+        2
+      )
+    )
     const service = new QoderHookService()
     service.install()
     const configWithManaged = JSON.parse(readFileSync(join(configDir, 'settings.json'), 'utf8'))
     expect(configWithManaged.hooks.PreToolUse).toHaveLength(1)
-
-    // Add a user hook back in, then remove managed hooks.
-    const config = JSON.parse(readFileSync(join(configDir, 'settings.json'), 'utf8'))
-    config.hooks.UserPromptSubmit = [
-      { hooks: [{ type: 'command', command: 'echo user-prompt' }] },
-      ...config.hooks.UserPromptSubmit
-    ]
-    writeFileSync(join(configDir, 'settings.json'), JSON.stringify(config, null, 2))
 
     const status = service.remove()
     const after = JSON.parse(readFileSync(join(configDir, 'settings.json'), 'utf8'))

--- a/src/main/qoder/hook-service.test.ts
+++ b/src/main/qoder/hook-service.test.ts
@@ -1,0 +1,158 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type * as osModule from 'node:os'
+
+const { getPathMock, homedirMock } = vi.hoisted(() => ({
+  getPathMock: vi.fn<(name: string) => string>(),
+  homedirMock: vi.fn<() => string>()
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: getPathMock
+  }
+}))
+
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof osModule>()
+  return {
+    ...actual,
+    homedir: homedirMock
+  }
+})
+
+import { QoderHookService } from './hook-service'
+
+describe('QoderHookService', () => {
+  let homeDir: string
+  let userDataDir: string
+
+  beforeAll(() => {
+    homeDir = mkdtempSync(join(tmpdir(), 'orca-qoder-home-'))
+    userDataDir = mkdtempSync(join(tmpdir(), 'orca-qoder-userdata-'))
+    homedirMock.mockReturnValue(homeDir)
+    getPathMock.mockImplementation((name: string) => {
+      if (name === 'userData') {
+        return userDataDir
+      }
+      throw new Error(`unexpected getPath(${name})`)
+    })
+  })
+
+  afterAll(() => {
+    rmSync(homeDir, { recursive: true, force: true })
+    rmSync(userDataDir, { recursive: true, force: true })
+  })
+
+  it('installs managed hooks into Claude-compatible events and preserves user hooks', () => {
+    const configDir = join(homeDir, '.qoder')
+    mkdirSync(configDir, { recursive: true })
+    writeFileSync(
+      join(configDir, 'settings.json'),
+      JSON.stringify(
+        {
+          hooks: {
+            PostToolUse: [
+              {
+                matcher: '*',
+                hooks: [{ type: 'command', command: 'echo user-post-tool' }]
+              }
+            ]
+          }
+        },
+        null,
+        2
+      )
+    )
+
+    const status = new QoderHookService().install()
+    const config = JSON.parse(readFileSync(join(configDir, 'settings.json'), 'utf8'))
+
+    expect(status.state).toBe('installed')
+    expect(Object.keys(config.hooks).sort()).toEqual([
+      'PostToolUse',
+      'PostToolUseFailure',
+      'PreToolUse',
+      'SessionStart',
+      'Stop',
+      'UserPromptSubmit'
+    ])
+    // Why: user-authored hooks survive alongside the managed entry.
+    const postToolCommands = config.hooks.PostToolUse.flatMap(
+      (definition: { hooks?: { command: string }[] }) =>
+        (definition.hooks ?? []).map((hook) => hook.command)
+    )
+    expect(postToolCommands).toEqual(['echo user-post-tool', expect.stringContaining('qoder-hook')])
+    expect(status.configPath).toBe(join(homeDir, '.qoder', 'settings.json'))
+  })
+
+  it('sweeps stale managed hooks from dropped event buckets on reinstall', () => {
+    const configDir = join(homeDir, '.qoder')
+    mkdirSync(configDir, { recursive: true })
+    const managedHookFileName = process.platform === 'win32' ? 'qoder-hook.cmd' : 'qoder-hook.sh'
+    const staleManagedHookPath =
+      process.platform === 'win32'
+        ? `C:\\Users\\ramzi\\.orca\\agent-hooks\\${managedHookFileName}`
+        : `/Users/ramzi/.orca/agent-hooks/${managedHookFileName}`
+    const staleManagedCommand =
+      process.platform === 'win32'
+        ? staleManagedHookPath
+        : `if [ -x '${staleManagedHookPath}' ]; then /bin/sh '${staleManagedHookPath}'; fi`
+    writeFileSync(
+      join(configDir, 'settings.json'),
+      JSON.stringify(
+        {
+          hooks: {
+            SessionStart: [
+              {
+                hooks: [{ type: 'command', command: staleManagedCommand }]
+              }
+            ],
+            SessionEnd: [
+              {
+                hooks: [{ type: 'command', command: staleManagedCommand }]
+              }
+            ]
+          }
+        },
+        null,
+        2
+      )
+    )
+
+    const status = new QoderHookService().install()
+    const config = JSON.parse(readFileSync(join(configDir, 'settings.json'), 'utf8'))
+
+    expect(status.state).toBe('installed')
+    expect(config.hooks.SessionEnd).toBeUndefined()
+    expect(config.hooks.SessionStart).toHaveLength(1)
+  })
+
+  it('remove() strips managed hooks and leaves user hooks untouched', () => {
+    const configDir = join(homeDir, '.qoder')
+    mkdirSync(configDir, { recursive: true })
+    const service = new QoderHookService()
+    service.install()
+    const configWithManaged = JSON.parse(readFileSync(join(configDir, 'settings.json'), 'utf8'))
+    expect(configWithManaged.hooks.PreToolUse).toHaveLength(1)
+
+    // Add a user hook back in, then remove managed hooks.
+    const config = JSON.parse(readFileSync(join(configDir, 'settings.json'), 'utf8'))
+    config.hooks.UserPromptSubmit = [
+      { hooks: [{ type: 'command', command: 'echo user-prompt' }] },
+      ...config.hooks.UserPromptSubmit
+    ]
+    writeFileSync(join(configDir, 'settings.json'), JSON.stringify(config, null, 2))
+
+    const status = service.remove()
+    const after = JSON.parse(readFileSync(join(configDir, 'settings.json'), 'utf8'))
+
+    expect(status.state).toBe('not_installed')
+    expect(after.hooks.UserPromptSubmit).toEqual([
+      { hooks: [{ type: 'command', command: 'echo user-prompt' }] }
+    ])
+    expect(after.hooks.PreToolUse).toBeUndefined()
+  })
+})

--- a/src/main/qoder/hook-service.ts
+++ b/src/main/qoder/hook-service.ts
@@ -68,8 +68,8 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
       'if defined ORCA_AGENT_HOOK_ENDPOINT if exist "%ORCA_AGENT_HOOK_ENDPOINT%" call "%ORCA_AGENT_HOOK_ENDPOINT%" 2>nul',
       ...buildWindowsHookEnvironmentGuardLines(),
       buildWindowsAgentHookPostCommand('qoder'),
-      'exit /b 0',
       ...buildWindowsHookStdinDrainEpilogue(),
+      'exit /b 0',
       ''
     ].join('\r\n')
   }

--- a/src/main/qoder/hook-service.ts
+++ b/src/main/qoder/hook-service.ts
@@ -1,0 +1,313 @@
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import type { SFTPWrapper } from 'ssh2'
+import type { AgentHookInstallState, AgentHookInstallStatus } from '../../shared/agent-hook-types'
+import {
+  buildManagedCommandHook,
+  createManagedCommandMatcher,
+  buildWindowsAgentHookPostCommand,
+  getSharedManagedScriptPath,
+  readHooksJson,
+  removeManagedCommands,
+  wrapPosixHookCommand,
+  wrapWindowsHookCommand,
+  writeHooksJson,
+  writeManagedScript,
+  type HookDefinition
+} from '../agent-hooks/installer-utils'
+import { refreshManagedScriptIfPresent } from '../agent-hooks/managed-hook-script-refresh'
+import {
+  readHooksJsonRemote,
+  writeHooksJsonRemote,
+  writeManagedScriptRemote
+} from '../agent-hooks/installer-utils-remote'
+import {
+  buildPosixHookPayloadCapture,
+  buildWindowsHookEnvironmentGuardLines,
+  buildWindowsHookStdinDrainEpilogue
+} from '../agent-hooks/hook-stdin-contract'
+
+// Why: qoder emits Claude-compatible hook events (PreToolUse/PostToolUse/
+// PostToolUseFailure/SessionStart/UserPromptSubmit/Stop), so Orca's Claude
+// normalizer consumes the payloads as-is.
+const QODER_EVENTS = [
+  'SessionStart',
+  'UserPromptSubmit',
+  'Stop',
+  'PostToolUseFailure',
+  'PreToolUse',
+  'PostToolUse'
+] as const
+
+function getConfigPath(): string {
+  return join(homedir(), '.qoder', 'settings.json')
+}
+
+function getManagedScriptFileName(): string {
+  return process.platform === 'win32' ? 'qoder-hook.cmd' : 'qoder-hook.sh'
+}
+
+function getManagedScriptPath(): string {
+  return getSharedManagedScriptPath(getManagedScriptFileName())
+}
+
+function getManagedCommand(scriptPath: string): string {
+  return process.platform === 'win32'
+    ? wrapWindowsHookCommand(scriptPath)
+    : wrapPosixHookCommand(scriptPath)
+}
+
+function getManagedScript(target: 'local' | 'posix' = 'local'): string {
+  if (target === 'local' && process.platform === 'win32') {
+    return [
+      '@echo off',
+      'setlocal',
+      // Why: emit `{}` first so qoder never stalls parsing stdout, even if the guards below exit early.
+      'echo {}',
+      // Why: source the endpoint file so a surviving PTY reaches the current server. See claude/hook-service.ts.
+      'if defined ORCA_AGENT_HOOK_ENDPOINT if exist "%ORCA_AGENT_HOOK_ENDPOINT%" call "%ORCA_AGENT_HOOK_ENDPOINT%" 2>nul',
+      ...buildWindowsHookEnvironmentGuardLines(),
+      buildWindowsAgentHookPostCommand('qoder'),
+      'exit /b 0',
+      ...buildWindowsHookStdinDrainEpilogue(),
+      ''
+    ].join('\r\n')
+  }
+
+  return [
+    '#!/bin/sh',
+    // Why: emit `{}` first so qoder never stalls parsing stdout, even if the guards below exit early.
+    'printf "{}\\n"',
+    ...buildPosixHookPayloadCapture(),
+    // Why: source refreshes endpoint coords so a PTY surviving an Orca restart keeps reporting. See claude/hook-service.ts.
+    'if [ -n "$ORCA_AGENT_HOOK_ENDPOINT" ] && [ -r "$ORCA_AGENT_HOOK_ENDPOINT" ]; then',
+    '  . "$ORCA_AGENT_HOOK_ENDPOINT" 2>/dev/null || :',
+    'fi',
+    'if [ -z "$ORCA_AGENT_HOOK_PORT" ] || [ -z "$ORCA_AGENT_HOOK_TOKEN" ] || [ -z "$ORCA_PANE_KEY" ]; then',
+    '  exit 0',
+    'fi',
+    // Why: worktreeId embeds a path, so post form fields, not hand-built JSON that breaks on quotes/newlines.
+    // Why: pipe payload via curl stdin (`payload@-`) so large tool output stays off the command line (EDR false positives).
+    'printf \'%s\' "$payload" | curl -sS -X POST "http://127.0.0.1:${ORCA_AGENT_HOOK_PORT}/hook/qoder" \\',
+    '  --connect-timeout 0.5 --max-time 1.5 \\',
+    '  -H "Content-Type: application/x-www-form-urlencoded" \\',
+    '  -H "X-Orca-Agent-Hook-Token: ${ORCA_AGENT_HOOK_TOKEN}" \\',
+    '  --data-urlencode "paneKey=${ORCA_PANE_KEY}" \\',
+    '  --data-urlencode "tabId=${ORCA_TAB_ID}" \\',
+    '  --data-urlencode "launchToken=${ORCA_AGENT_LAUNCH_TOKEN}" \\',
+    '  --data-urlencode "worktreeId=${ORCA_WORKTREE_ID}" \\',
+    '  --data-urlencode "env=${ORCA_AGENT_HOOK_ENV}" \\',
+    '  --data-urlencode "version=${ORCA_AGENT_HOOK_VERSION}" \\',
+    '  --data-urlencode "payload@-" >/dev/null 2>&1 || true',
+    'exit 0',
+    ''
+  ].join('\n')
+}
+
+export class QoderHookService {
+  async refreshManagedScripts(): Promise<void> {
+    await refreshManagedScriptIfPresent(getManagedScriptPath(), getManagedScript())
+  }
+
+  getStatus(): AgentHookInstallStatus {
+    const configPath = getConfigPath()
+    const scriptPath = getManagedScriptPath()
+    const config = readHooksJson(configPath)
+    if (!config) {
+      return {
+        agent: 'qoder',
+        state: 'error',
+        configPath,
+        managedHooksPresent: false,
+        detail: 'Could not parse Qoder settings.json'
+      }
+    }
+
+    const command = getManagedCommand(scriptPath)
+    const missing: string[] = []
+    let presentCount = 0
+    for (const eventName of QODER_EVENTS) {
+      const definitions = Array.isArray(config.hooks?.[eventName]) ? config.hooks![eventName]! : []
+      const hasCommand = definitions.some((definition) =>
+        (definition.hooks ?? []).some((hook) => hook.command === command)
+      )
+      if (hasCommand) {
+        presentCount += 1
+      } else {
+        missing.push(eventName)
+      }
+    }
+    const managedHooksPresent = presentCount > 0
+    let state: AgentHookInstallState
+    let detail: string | null
+    if (missing.length === 0) {
+      state = 'installed'
+      detail = null
+    } else if (presentCount === 0) {
+      state = 'not_installed'
+      detail = null
+    } else {
+      state = 'partial'
+      detail = `Managed hook missing for events: ${missing.join(', ')}`
+    }
+    return { agent: 'qoder', state, configPath, managedHooksPresent, detail }
+  }
+
+  install(): AgentHookInstallStatus {
+    const configPath = getConfigPath()
+    const scriptPath = getManagedScriptPath()
+    const config = readHooksJson(configPath)
+    if (!config) {
+      return {
+        agent: 'qoder',
+        state: 'error',
+        configPath,
+        managedHooksPresent: false,
+        detail: 'Could not parse Qoder settings.json'
+      }
+    }
+
+    const command = getManagedCommand(scriptPath)
+    const nextHooks = { ...config.hooks }
+
+    // Why: match by filename not exact command, so installs sweep stale entries instead of duplicating them.
+    const isManagedCommand = createManagedCommandMatcher(getManagedScriptFileName())
+
+    const managedEvents = new Set<string>(QODER_EVENTS)
+
+    // Why: sweep managed entries from dropped event buckets so stale hooks don't keep firing.
+    for (const [eventName, definitions] of Object.entries(nextHooks)) {
+      if (managedEvents.has(eventName)) {
+        continue
+      }
+      if (!Array.isArray(definitions)) {
+        continue
+      }
+      const cleaned = removeManagedCommands(definitions, isManagedCommand)
+      if (cleaned.length === 0) {
+        delete nextHooks[eventName]
+      } else {
+        nextHooks[eventName] = cleaned
+      }
+    }
+
+    for (const eventName of QODER_EVENTS) {
+      const current = Array.isArray(nextHooks[eventName]) ? nextHooks[eventName] : []
+      const cleaned = removeManagedCommands(current, isManagedCommand)
+      const definition: HookDefinition = {
+        // Why: qoder's hook timeout unit is seconds, matching Claude-compatible hooks.
+        hooks: [buildManagedCommandHook(command)]
+      }
+      nextHooks[eventName] = [...cleaned, definition]
+    }
+
+    config.hooks = nextHooks
+    writeManagedScript(scriptPath, getManagedScript())
+    writeHooksJson(configPath, config)
+    return this.getStatus()
+  }
+
+  // POSIX-only remote install mirroring GeminiHookService.installRemote; the managed script/JSON shape must match local install() or remote panes report a different status.
+  async installRemote(sftp: SFTPWrapper, remoteHome: string): Promise<AgentHookInstallStatus> {
+    const remoteConfigPath = `${remoteHome.replace(/\/$/, '')}/.qoder/settings.json`
+    const remoteScriptPath = `${remoteHome.replace(/\/$/, '')}/.orca/agent-hooks/qoder-hook.sh`
+    try {
+      const config = await readHooksJsonRemote(sftp, remoteConfigPath)
+      if (!config) {
+        return {
+          agent: 'qoder',
+          state: 'error',
+          configPath: remoteConfigPath,
+          managedHooksPresent: false,
+          detail: 'Could not parse remote Qoder settings.json'
+        }
+      }
+
+      const command = wrapPosixHookCommand(remoteScriptPath)
+      const nextHooks = { ...config.hooks }
+      const isManagedCommand = createManagedCommandMatcher('qoder-hook.sh')
+      const managedEvents = new Set<string>(QODER_EVENTS)
+
+      for (const [eventName, definitions] of Object.entries(nextHooks)) {
+        if (managedEvents.has(eventName)) {
+          continue
+        }
+        if (!Array.isArray(definitions)) {
+          continue
+        }
+        const cleaned = removeManagedCommands(definitions, isManagedCommand)
+        if (cleaned.length === 0) {
+          delete nextHooks[eventName]
+        } else {
+          nextHooks[eventName] = cleaned
+        }
+      }
+
+      for (const eventName of QODER_EVENTS) {
+        const current = Array.isArray(nextHooks[eventName]) ? nextHooks[eventName] : []
+        const cleaned = removeManagedCommands(current, isManagedCommand)
+        const definition: HookDefinition = {
+          hooks: [buildManagedCommandHook(command)]
+        }
+        nextHooks[eventName] = [...cleaned, definition]
+      }
+      config.hooks = nextHooks
+
+      // Why: write the script before settings.json so an interrupted install never points at a missing script.
+      // Why: SSH remotes always use POSIX `.sh` paths even when Orca runs on Windows.
+      await writeManagedScriptRemote(sftp, remoteScriptPath, getManagedScript('posix'))
+      await writeHooksJsonRemote(sftp, remoteConfigPath, config)
+
+      return {
+        agent: 'qoder',
+        state: 'installed',
+        configPath: remoteConfigPath,
+        managedHooksPresent: true,
+        detail: null
+      }
+    } catch (err) {
+      return {
+        agent: 'qoder',
+        state: 'error',
+        configPath: remoteConfigPath,
+        managedHooksPresent: false,
+        detail: err instanceof Error ? err.message : String(err)
+      }
+    }
+  }
+
+  remove(): AgentHookInstallStatus {
+    const configPath = getConfigPath()
+    const config = readHooksJson(configPath)
+    if (!config) {
+      return {
+        agent: 'qoder',
+        state: 'error',
+        configPath,
+        managedHooksPresent: false,
+        detail: 'Could not parse Qoder settings.json'
+      }
+    }
+
+    const nextHooks = { ...config.hooks }
+    // Why: match by filename so remove() sweeps stale entries even after the script path moved.
+    const isManagedCommand = createManagedCommandMatcher(getManagedScriptFileName())
+    for (const [eventName, definitions] of Object.entries(nextHooks)) {
+      // Why: fail open on malformed (non-array) entries so a broken user config never blocks uninstall.
+      if (!Array.isArray(definitions)) {
+        continue
+      }
+      const cleaned = removeManagedCommands(definitions, isManagedCommand)
+      if (cleaned.length === 0) {
+        delete nextHooks[eventName]
+      } else {
+        nextHooks[eventName] = cleaned
+      }
+    }
+    config.hooks = nextHooks
+    writeHooksJson(configPath, config)
+    return this.getStatus()
+  }
+}
+
+export const qoderHookService = new QoderHookService()

--- a/src/main/remote-agent-trust-presets.ts
+++ b/src/main/remote-agent-trust-presets.ts
@@ -26,6 +26,8 @@ export async function markRemoteAgentWorkspaceTrusted(args: {
     await markRemoteCursorWorkspaceTrusted(fsProvider, home, workspacePath)
   } else if (args.preset === 'copilot') {
     await markRemoteCopilotFolderTrusted(fsProvider, home, workspacePath)
+  } else if (args.preset === 'qoder') {
+    await markRemoteQoderWorkspaceTrusted(fsProvider, workspacePath)
   }
 }
 
@@ -145,4 +147,18 @@ async function markRemoteCopilotFolderTrusted(
   config.trustedFolders = [...existing.filter((entry) => typeof entry === 'string'), workspacePath]
   await fsProvider.createDir(configDir)
   await fsProvider.writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`)
+}
+
+// Why: qodercli reads a workspace-local `.trusted` marker; mirror the local
+// preset by writing an empty marker on the remote checkout root.
+async function markRemoteQoderWorkspaceTrusted(
+  fsProvider: IFilesystemProvider,
+  workspacePath: string
+): Promise<void> {
+  const trustPath = `${workspacePath.replace(/\/$/, '')}/.trusted`
+  try {
+    await fsProvider.writeFile(trustPath, '')
+  } catch {
+    // Best-effort: the user can accept the remote trust prompt manually.
+  }
 }

--- a/src/main/remote-agent-trust-presets.ts
+++ b/src/main/remote-agent-trust-presets.ts
@@ -3,6 +3,7 @@ import { upsertProjectTrustLevelInContent } from './codex/config-toml-trust'
 import { getActiveMultiplexer } from './ipc/ssh'
 import { getSshFilesystemProvider } from './providers/ssh-filesystem-dispatch'
 import type { IFilesystemProvider } from './providers/types'
+import path from 'node:path'
 import {
   isWindowsAbsolutePathLike,
   normalizeRuntimePathSeparators
@@ -13,9 +14,20 @@ export async function markRemoteAgentWorkspaceTrusted(args: {
   connectionId: string
   workspacePath: string
 }): Promise<void> {
-  const home = await resolveRemoteHome(args.connectionId)
   const fsProvider = getSshFilesystemProvider(args.connectionId)
-  if (!home || !fsProvider) {
+  if (!fsProvider) {
+    return
+  }
+
+  // Why: qoder only needs the workspace filesystem, not the user home.
+  if (args.preset === 'qoder') {
+    const workspacePath = await canonicalizeRemoteWorkspacePath(fsProvider, args.workspacePath)
+    await markRemoteQoderWorkspaceTrusted(fsProvider, workspacePath)
+    return
+  }
+
+  const home = await resolveRemoteHome(args.connectionId)
+  if (!home) {
     return
   }
 
@@ -26,8 +38,6 @@ export async function markRemoteAgentWorkspaceTrusted(args: {
     await markRemoteCursorWorkspaceTrusted(fsProvider, home, workspacePath)
   } else if (args.preset === 'copilot') {
     await markRemoteCopilotFolderTrusted(fsProvider, home, workspacePath)
-  } else if (args.preset === 'qoder') {
-    await markRemoteQoderWorkspaceTrusted(fsProvider, workspacePath)
   }
 }
 
@@ -155,7 +165,13 @@ async function markRemoteQoderWorkspaceTrusted(
   fsProvider: IFilesystemProvider,
   workspacePath: string
 ): Promise<void> {
-  const trustPath = `${workspacePath.replace(/\/$/, '')}/.trusted`
+  const trustPath = path.posix.join(workspacePath.replace(/\/$/, ''), '.trusted')
+  try {
+    await fsProvider.stat(trustPath)
+    return // already exists
+  } catch {
+    // doesn't exist, proceed
+  }
   try {
     await fsProvider.writeFile(trustPath, '')
   } catch {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -565,7 +565,8 @@ import { detectInstalledAgentsWithShellPathHydration, detectRemoteAgents } from 
 import {
   markCodexProjectTrusted,
   markCopilotFolderTrusted,
-  markCursorWorkspaceTrusted
+  markCursorWorkspaceTrusted,
+  markQoderWorkspaceTrusted
 } from '../agent-trust-presets'
 import { markRemoteAgentWorkspaceTrusted } from '../remote-agent-trust-presets'
 import { applyAgentStatusHooksEnabled } from '../agent-hooks/managed-agent-hook-controls'
@@ -23369,6 +23370,8 @@ export class OrcaRuntimeService {
         markCopilotFolderTrusted(workspacePath)
       } else if (preset === 'codex') {
         markCodexProjectTrusted(workspacePath)
+      } else if (preset === 'qoder') {
+        markQoderWorkspaceTrusted(workspacePath)
       }
     } catch {
       // Best-effort: the user can still accept the agent trust prompt manually.

--- a/src/preload/api/agent-status-api.ts
+++ b/src/preload/api/agent-status-api.ts
@@ -42,7 +42,7 @@ export type AgentStatusApi = {
 
 export type AgentTrustApi = {
   markTrusted: (args: {
-    preset: 'cursor' | 'copilot' | 'codex'
+    preset: 'cursor' | 'copilot' | 'codex' | 'qoder'
     workspacePath: string
     connectionId?: string
   }) => Promise<void>

--- a/src/renderer/src/lib/agent-catalog.tsx
+++ b/src/renderer/src/lib/agent-catalog.tsx
@@ -279,6 +279,13 @@ export const getAgentCatalog = createLocalizedCatalog((): AgentCatalogEntry[] =>
     homepageUrl: 'https://github.com/QwenLM/qwen-code'
   },
   {
+    id: 'qoder',
+    label: translate('auto.lib.agent.catalog.qoder_label', 'Qoder'),
+    cmd: 'qodercli',
+    faviconDomain: 'qoder.com',
+    homepageUrl: 'https://www.qoder.com/'
+  },
+  {
     id: 'rovo',
     label: translate('auto.lib.agent.catalog.4e63c7b956', 'Rovo Dev'),
     cmd: 'rovo',

--- a/src/renderer/src/lib/agent-status.ts
+++ b/src/renderer/src/lib/agent-status.ts
@@ -126,6 +126,7 @@ const ICONABLE_AGENT_TYPES: Record<TuiAgent, true> = {
   kimi: true,
   'mistral-vibe': true,
   'qwen-code': true,
+  qoder: true,
   rovo: true,
   hermes: true,
   openclaw: true,

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2664,7 +2664,8 @@ function normalizeClaudeSubagentLifecycleEvent(
   state: HookListenerState,
   eventName: 'SubagentStart' | 'SubagentStop' | 'TeammateIdle',
   paneKey: string,
-  hookPayload: Record<string, unknown>
+  hookPayload: Record<string, unknown>,
+  source: AgentHookSource = 'claude'
 ): ParsedAgentStatusPayload | null {
   const lifecycleField = eventName === 'TeammateIdle' ? 'teammate_name' : 'agent_id'
   const lifecycleId = readString(hookPayload, lifecycleField)
@@ -2743,7 +2744,7 @@ function normalizeClaudeSubagentLifecycleEvent(
     // Why: a restored-only ending proves no lead boundary, and an unmatched restored sibling proves no current liveness; persist the roster transition without publishing fresh work or completion.
     state.claudeUnconfirmedRestoredStatusPaneKeys.add(paneKey)
   }
-  return buildClaudeCachedLeadStatusPayload(state, eventName, paneKey, hookPayload, {
+  return buildClaudeCachedLeadStatusPayload(state, eventName, paneKey, hookPayload, source, {
     workingChildEvidence,
     endedChildWork,
     endedRuntimeChildWork
@@ -2885,6 +2886,7 @@ function buildClaudeCachedLeadStatusPayload(
   eventName: unknown,
   paneKey: string,
   hookPayload: Record<string, unknown>,
+  source: AgentHookSource = 'claude',
   evidence: {
     workingChildEvidence?: boolean
     endedChildWork?: boolean
@@ -2904,7 +2906,7 @@ function buildClaudeCachedLeadStatusPayload(
       return null
     }
   }
-  return buildClaudeStatusPayload(state, eventName, '', paneKey, hookPayload, {
+  return buildClaudeStatusPayload(state, eventName, '', paneKey, hookPayload, source, {
     stateName: resolveClaudePaneState(state, paneKey, {
       state: leadState,
       interrupted: lead?.interrupted
@@ -2921,7 +2923,8 @@ function normalizeClaudeEvent(
   eventName: unknown,
   promptText: string,
   paneKey: string,
-  hookPayload: Record<string, unknown>
+  hookPayload: Record<string, unknown>,
+  source: AgentHookSource = 'claude'
 ): ParsedAgentStatusPayload | null {
   const eventAgentId = readString(hookPayload, 'agent_id')
   if (
@@ -2929,7 +2932,7 @@ function normalizeClaudeEvent(
     eventName === 'SubagentStop' ||
     eventName === 'TeammateIdle'
   ) {
-    return normalizeClaudeSubagentLifecycleEvent(state, eventName, paneKey, hookPayload)
+    return normalizeClaudeSubagentLifecycleEvent(state, eventName, paneKey, hookPayload, source)
   }
   if (eventName === 'SessionStart') {
     // Why: SessionStart is the only signal a resumed session emits before its first prompt
@@ -2954,7 +2957,7 @@ function normalizeClaudeEvent(
     state.claudeRunningNonAgentTaskPaneKeys.delete(paneKey)
     state.claudeActiveSessionCronPaneKeys.delete(paneKey)
     state.claudeLeadStateByPaneKey.set(paneKey, { state: 'done' })
-    return buildClaudeStatusPayload(state, eventName, promptText, paneKey, hookPayload, {
+    return buildClaudeStatusPayload(state, eventName, promptText, paneKey, hookPayload, source, {
       stateName: 'done',
       updateToolSnapshot: true,
       sessionBoundary: true
@@ -3034,7 +3037,7 @@ function normalizeClaudeEvent(
     eventToolUseId !== undefined &&
     eventToolUseId !== previousLead.waitingToolUseId
   if (isParallelSiblingCompletionDuringQuestion) {
-    return buildClaudeCachedLeadStatusPayload(state, eventName, paneKey, hookPayload)
+    return buildClaudeCachedLeadStatusPayload(state, eventName, paneKey, hookPayload, source)
   }
 
   // Why: subagent/teammate events carry `agent_id` (lead's don't); child tool activity keeps its row live but must not become the lead's state or overwrite its tool/prompt caches (a live card would vanish).
@@ -3058,7 +3061,7 @@ function normalizeClaudeEvent(
   if (subagentOriginId) {
     const lead = state.claudeLeadStateByPaneKey.get(paneKey)
     if (lead?.state !== 'waiting' || lead.waitingAgentId !== subagentOriginId) {
-      return buildClaudeCachedLeadStatusPayload(state, eventName, paneKey, hookPayload, {
+      return buildClaudeCachedLeadStatusPayload(state, eventName, paneKey, hookPayload, source, {
         workingChildEvidence: true
       })
     }
@@ -3068,7 +3071,7 @@ function normalizeClaudeEvent(
       eventToolUseId !== undefined &&
       eventToolUseId !== lead.waitingToolUseId
     if (isParallelSiblingCompletionDuringChildQuestion) {
-      return buildClaudeCachedLeadStatusPayload(state, eventName, paneKey, hookPayload, {
+      return buildClaudeCachedLeadStatusPayload(state, eventName, paneKey, hookPayload, source, {
         workingChildEvidence: true
       })
     }
@@ -3076,7 +3079,7 @@ function normalizeClaudeEvent(
     // Restore the stashed lead state, not this child's 'working': the lead may already be done, and the done-gate never upgrades working back to done once the roster drains.
     const restored = lead.stateBeforeWait ?? { state: 'working' as const }
     state.claudeLeadStateByPaneKey.set(paneKey, restored)
-    return buildClaudeStatusPayload(state, eventName, promptText, paneKey, hookPayload, {
+    return buildClaudeStatusPayload(state, eventName, promptText, paneKey, hookPayload, source, {
       stateName: resolveClaudePaneState(state, paneKey, restored),
       updateToolSnapshot: true,
       interrupted: restored.interrupted,
@@ -3086,7 +3089,7 @@ function normalizeClaudeEvent(
 
   // Why: lead events never carry agent_id; even a child missed by lifecycle tracking cannot own the lead turn or its background-work evidence.
   if (eventAgentId && !isWaitingInducing) {
-    return buildClaudeCachedLeadStatusPayload(state, eventName, paneKey, hookPayload, {
+    return buildClaudeCachedLeadStatusPayload(state, eventName, paneKey, hookPayload, source, {
       workingChildEvidence: claudeRosterHasRuntimeWorkingSubagent(
         state.claudeSubagentRosterByPaneKey.get(paneKey)
       )
@@ -3163,7 +3166,7 @@ function normalizeClaudeEvent(
     state.claudeUnconfirmedRestoredStatusPaneKeys.add(paneKey)
   }
 
-  return buildClaudeStatusPayload(state, eventName, promptText, paneKey, hookPayload, {
+  return buildClaudeStatusPayload(state, eventName, promptText, paneKey, hookPayload, source, {
     stateName: effectiveState,
     updateToolSnapshot: true,
     interrupted,
@@ -3177,6 +3180,7 @@ function buildClaudeStatusPayload(
   promptText: string,
   paneKey: string,
   hookPayload: Record<string, unknown>,
+  source: AgentHookSource,
   options: {
     stateName: AgentStatusState
     updateToolSnapshot: boolean
@@ -3187,8 +3191,8 @@ function buildClaudeStatusPayload(
 ): ParsedAgentStatusPayload | null {
   // Why: child-driven refreshes are roster bookkeeping, not lead tool activity; read the cached snapshot without merging so they can't clear a live AskUserQuestion card or clobber the tool preview.
   const snapshot = options.updateToolSnapshot
-    ? resolveToolState(state, paneKey, extractToolFields('claude', eventName, hookPayload), {
-        resetOnNewTurn: isNewTurnEvent('claude', eventName)
+    ? resolveToolState(state, paneKey, extractToolFields(source, eventName, hookPayload), {
+        resetOnNewTurn: isNewTurnEvent(source, eventName)
       })
     : (state.lastToolByPaneKey.get(paneKey) ?? {})
 
@@ -3198,9 +3202,9 @@ function buildClaudeStatusPayload(
     state: options.stateName,
     // Why: only lead-origin events may reset the prompt cache; a child-driven refresh must not blank the lead's prompt label.
     prompt: resolvePrompt(state, paneKey, promptText, {
-      resetOnNewTurn: options.updateToolSnapshot && isNewTurnEvent('claude', eventName)
+      resetOnNewTurn: options.updateToolSnapshot && isNewTurnEvent(source, eventName)
     }),
-    agentType: 'claude',
+    agentType: source,
     toolName: snapshot.toolName,
     toolInput: snapshot.toolInput,
     interactivePrompt: snapshot.interactivePrompt,
@@ -4514,7 +4518,14 @@ export function normalizeHookPayload(
       break
     case 'qoder':
       // Why: qoder emits Claude-compatible hooks (PreToolUse/PostToolUse/SessionStart/UserPromptSubmit/Stop).
-      payload = normalizeClaudeEvent(state, eventName, promptText, paneKey, hookPayloadRecord)
+      payload = normalizeClaudeEvent(
+        state,
+        eventName,
+        promptText,
+        paneKey,
+        hookPayloadRecord,
+        'qoder'
+      )
       break
     case 'antigravity':
       if (isNewTurnEvent('antigravity', eventName)) {

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2516,6 +2516,9 @@ function isNewTurnEvent(source: AgentHookSource, eventName: unknown): boolean {
     case 'devin':
       // Why: SessionStart is handled by an early return in normalizeDevinEvent, so UserPromptSubmit is Devin's real new-turn boundary here.
       return eventName === 'UserPromptSubmit'
+    case 'qoder':
+      // Why: qoder emits Claude-compatible hooks; SessionStart and UserPromptSubmit are its new-turn boundaries.
+      return eventName === 'SessionStart' || eventName === 'UserPromptSubmit'
   }
 }
 
@@ -2607,6 +2610,9 @@ function extractToolFields(
     case 'hermes':
       return extractHermesToolFields(eventName, hookPayload)
     case 'devin':
+      return extractClaudeToolFields(eventName, hookPayload)
+    // Why: qoder emits Claude-compatible payload fields (tool_name/tool_input).
+    case 'qoder':
       return extractClaudeToolFields(eventName, hookPayload)
   }
 }
@@ -4506,6 +4512,10 @@ export function normalizeHookPayload(
     case 'gemini':
       payload = normalizeGeminiEvent(state, eventName, promptText, paneKey, hookPayloadRecord)
       break
+    case 'qoder':
+      // Why: qoder emits Claude-compatible hooks (PreToolUse/PostToolUse/SessionStart/UserPromptSubmit/Stop).
+      payload = normalizeClaudeEvent(state, eventName, promptText, paneKey, hookPayloadRecord)
+      break
     case 'antigravity':
       if (isNewTurnEvent('antigravity', eventName)) {
         resolvedPromptText =
@@ -4685,6 +4695,7 @@ export const HOOK_SOURCE_BY_PATHNAME: Readonly<Record<string, AgentHookSource>> 
   '/hook/claude': 'claude',
   '/hook/codex': 'codex',
   '/hook/gemini': 'gemini',
+  '/hook/qoder': 'qoder',
   '/hook/antigravity': 'antigravity',
   '/hook/amp': 'amp',
   '/hook/opencode': 'opencode',

--- a/src/shared/agent-hook-relay.ts
+++ b/src/shared/agent-hook-relay.ts
@@ -38,6 +38,7 @@ const AGENT_HOOK_SOURCES = [
   'claude',
   'codex',
   'gemini',
+  'qoder',
   'antigravity',
   'amp',
   'opencode',

--- a/src/shared/agent-hook-types.ts
+++ b/src/shared/agent-hook-types.ts
@@ -8,6 +8,7 @@ export const AGENT_HOOK_TARGETS = [
   'openclaude',
   'codex',
   'gemini',
+  'qoder',
   'antigravity',
   'amp',
   'cursor',

--- a/src/shared/agent-kind.ts
+++ b/src/shared/agent-kind.ts
@@ -42,6 +42,7 @@ const TUI_AGENT_KIND_BY_AGENT = {
   kimi: 'kimi',
   'mistral-vibe': 'mistral-vibe',
   'qwen-code': 'qwen-code',
+  qoder: 'qoder',
   rovo: 'rovo',
   hermes: 'hermes',
   openclaw: 'openclaw',

--- a/src/shared/agent-process-recognition.ts
+++ b/src/shared/agent-process-recognition.ts
@@ -95,7 +95,7 @@ function agentForNormalizedProcess(normalized: string): TuiAgent | undefined {
   }
   // Why: qodercli's versioned binary (`qodercli-<version>`) is what node-pty can report when launched without the `qodercli` symlink.
   if (normalized.startsWith('qodercli-')) {
-    return PROCESS_TO_AGENT.get('qoder')
+    return PROCESS_TO_AGENT.get('qodercli')
   }
   return undefined
 }

--- a/src/shared/agent-process-recognition.ts
+++ b/src/shared/agent-process-recognition.ts
@@ -93,6 +93,10 @@ function agentForNormalizedProcess(normalized: string): TuiAgent | undefined {
   if (normalized.startsWith('grok-')) {
     return PROCESS_TO_AGENT.get('grok')
   }
+  // Why: qodercli's versioned binary (`qodercli-<version>`) is what node-pty can report when launched without the `qodercli` symlink.
+  if (normalized.startsWith('qodercli-')) {
+    return PROCESS_TO_AGENT.get('qoder')
+  }
   return undefined
 }
 

--- a/src/shared/agent-session-resume.ts
+++ b/src/shared/agent-session-resume.ts
@@ -6,6 +6,7 @@ export const RESUMABLE_TUI_AGENTS = [
   'claude',
   'codex',
   'gemini',
+  'qoder',
   'antigravity',
   'opencode',
   'pi',
@@ -200,6 +201,11 @@ export function extractAgentProviderSession(
       const id = readSessionId(payload, ['session_id'])
       return id ? { key: 'session_id', id } : null
     }
+    // Why: qoder posts Claude-compatible hooks carrying `session_id` (e.g. session_<uuid>).
+    case 'qoder': {
+      const id = readSessionId(payload, ['session_id'])
+      return id ? withTranscriptPath({ key: 'session_id', id }, payload) : null
+    }
     case 'antigravity': {
       const id = readSessionId(payload, ['conversationId'])
       return id ? { key: 'conversation_id', id } : null
@@ -252,6 +258,8 @@ export function getAgentResumeArgv(
       return providerSession.key === 'session_id' ? ['codex', 'resume', id] : null
     case 'gemini':
       return providerSession.key === 'session_id' ? ['gemini', '--resume', id] : null
+    case 'qoder':
+      return providerSession.key === 'session_id' ? ['qodercli', '--resume', id] : null
     case 'antigravity':
       return providerSession.key === 'conversation_id' ? ['agy', '--conversation', id] : null
     case 'opencode':

--- a/src/shared/agent-type-label.ts
+++ b/src/shared/agent-type-label.ts
@@ -24,7 +24,8 @@ const WELL_KNOWN_LABELS: Record<string, string> = {
   devin: 'Devin',
   ante: 'Ante',
   trae: 'Trae',
-  kimi: 'Kimi'
+  kimi: 'Kimi',
+  qoder: 'Qoder'
 }
 
 export function formatAgentTypeLabel(agentType: AgentType | null | undefined): string {

--- a/src/shared/skills-cli-agent-keys.ts
+++ b/src/shared/skills-cli-agent-keys.ts
@@ -41,6 +41,7 @@ export const SKILLS_CLI_AGENT_KEY_BY_TUI_AGENT = {
   kimi: 'kimi-code-cli',
   'mistral-vibe': 'mistral-vibe',
   'qwen-code': 'qwen-code',
+  qoder: 'qoder',
   rovo: 'rovodev',
   hermes: 'hermes-agent',
   openclaw: 'openclaw',

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -92,6 +92,7 @@ export const AGENT_KIND_VALUES = [
   'kimi',
   'mistral-vibe',
   'qwen-code',
+  'qoder',
   'rovo',
   'hermes',
   'openclaw',

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -37,7 +37,7 @@ export type TuiAgentConfig = {
   /** Startup env var that seeds the input without submitting, for agents with no `--prefill`-style flag (e.g. pi); avoids the paste-after-ready race. */
   draftPromptEnvVar?: string
   /** Pre-write a trust artifact so the agent's first-launch "trust this folder?" menu doesn't consume the bracketed paste (see agent-trust-presets.ts). */
-  preflightTrust?: 'cursor' | 'copilot' | 'codex'
+  preflightTrust?: 'cursor' | 'copilot' | 'codex' | 'qoder'
   /** Agent-specific signal that the composer is ready for paste, stronger than the default quiet-render window. */
   draftPasteReadySignal?: DraftPasteReadySignal
   /** Hard deadline for the agent's composer readiness signal. */
@@ -333,6 +333,13 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
     expectedProcess: 'devin',
     // Why: `devin -- <prompt>` auto-submits immediately (docs.devin.ai/cli), so start the REPL with no argv prompt.
     promptInjectionMode: 'stdin-after-start'
+  },
+  qoder: {
+    detectCmd: 'qodercli',
+    launchCmd: 'qodercli',
+    expectedProcess: 'qodercli',
+    promptInjectionMode: 'flag-prompt-interactive',
+    preflightTrust: 'qoder'
   }
 }
 

--- a/src/shared/tui-agent-display-names.ts
+++ b/src/shared/tui-agent-display-names.ts
@@ -37,6 +37,7 @@ export const TUI_AGENT_DISPLAY_NAMES: Record<TuiAgent, string> = {
   kimi: 'Kimi',
   'mistral-vibe': 'Mistral Vibe',
   'qwen-code': 'Qwen Code',
+  qoder: 'Qoder',
   rovo: 'Rovo Dev',
   hermes: 'Hermes',
   openclaw: 'OpenClaw',

--- a/src/shared/tui-agent-permissions.ts
+++ b/src/shared/tui-agent-permissions.ts
@@ -9,6 +9,7 @@ export const YOLO_TUI_AGENT_ARGS: Partial<Record<TuiAgent, string>> = {
   openclaude: '--dangerously-skip-permissions',
   codex: '--dangerously-bypass-approvals-and-sandbox',
   gemini: '--yolo',
+  qoder: '--permission-mode bypass_permissions',
   antigravity: '--dangerously-skip-permissions',
   aider: '--yes-always',
   amp: '--dangerously-allow-all',

--- a/src/shared/tui-agent-selection.ts
+++ b/src/shared/tui-agent-selection.ts
@@ -36,6 +36,7 @@ export const TUI_AGENT_AUTO_PICK_ORDER = [
   'kimi',
   'mistral-vibe',
   'qwen-code',
+  'qoder',
   'rovo',
   'hermes',
   'devin',

--- a/src/shared/tui-agent.ts
+++ b/src/shared/tui-agent.ts
@@ -37,3 +37,4 @@ export type TuiAgent =
   | 'ante' // Ante (Antigma Labs)
   | 'trae' // Trae CLI
   | 'prime-agent' // Prime Agent (Prime Intellect)
+  | 'qoder' // Qoder CLI (qoder.com)


### PR DESCRIPTION
## Summary

Add first-class support for [Qoder CLI](https://www.qoder.com/) as an Orca `TuiAgent`.

### What's included

**Core agent support (`src/shared/`)**
- `TuiAgent` union + `TUI_AGENT_CONFIG` with `qodercli` detection, `--prompt-interactive` flag injection, and `--permission-mode bypass_permissions` yolo flag
- Agent process recognition (name + versioned binary prefix `qodercli-<version>`)
- Display name, telemetry agent kind, skills CLI key mapping, and agent picker catalog entry
- Auto-pick order placement

**Trust preflight (`src/main/agent-trust-presets.ts`)**
- Qoder CLI uses a workspace-local `.trusted` marker to skip its first-launch "Trust folder" menu
- Pre-write the marker at workspace creation, both local and remote (SSH)

**Hook integration for status tracking + session resume (`src/main/qoder/hook-service.ts` — new)**
- `QoderHookService` with Claude-compatible hook events (SessionStart, UserPromptSubmit, Stop, PreToolUse, PostToolUse, PostToolUseFailure)
- Managed hook install/remove/status/remote-SSH, registered in the managed-agent-hook-registry and remote-hook-service-installers
- `AgentHookSource` + `AgentHookTarget` registration; normalizer dispatch reuses the existing Claude normalizer
- `ResumableTuiAgent` + session extraction + `--resume` argv construction
- Hook-service test suite (user hook preservation, stale sweep, removal)

### Verification
- TypeScript typecheck: node / cli / web pass (no new errors)
- Test suites: 85+ tests pass across agent-hooks, agent-trust, session-resume, hook-listener, qoder hook-service
- End-to-end: `orca skills install --dry-run` emits `--agent qoder`; real install writes to `~/.qoder/skills/`
