### PR TITLE
fix(git): back off host probes a wedged runtime never answers

### DIFF
--- a/src/main/git/git-host-probe-breaker.test.ts
+++ b/src/main/git/git-host-probe-breaker.test.ts
@@ -9,10 +9,13 @@ import {
   GIT_HOST_PROBE_BASE_COOLDOWN_MS,
   GIT_HOST_PROBE_HEALTHY_CONCURRENCY,
   GIT_HOST_PROBE_MAX_COOLDOWN_MS,
+  GIT_HOST_PROBE_SLOT_STALE_MS,
+  GIT_HOST_PROBE_STREAK_DECAY_MS,
   gitProbeHostKey,
   isGitHostProbeBlockedError,
   runGuardedGitHostProbe
 } from './git-host-probe-breaker'
+import { MAX_TRACKED_GIT_PROBE_HOSTS } from './git-host-probe-state'
 
 const isUnavailable = (error: unknown): boolean =>
   error instanceof Error && /timed out/i.test(error.message)
@@ -48,6 +51,16 @@ async function probeOnce(
   }
 }
 
+/** The text a later triage reads out of a log; it must describe what happened. */
+async function blockedMessage(hostKey: string): Promise<string> {
+  try {
+    await runGuardedGitHostProbe(hostKey, async () => 'unused', isUnavailable)
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error)
+  }
+  throw new Error('expected the probe to be blocked')
+}
+
 describe('git host probe breaker', () => {
   beforeEach(() => {
     _resetGitHostProbeBreaker()
@@ -63,7 +76,12 @@ describe('git host probe breaker', () => {
 
   it('scopes state to the runtime that executes git, never globally', () => {
     expect(gitProbeHostKey({})).toBe('native')
-    expect(gitProbeHostKey({ wslDistro: 'Ubuntu-24.04' })).toBe('wsl:Ubuntu-24.04')
+    // Case-folded: wsl.exe matches distro names case-insensitively, so one
+    // distro spelled two ways must not split into two half-blind budgets.
+    expect(gitProbeHostKey({ wslDistro: 'Ubuntu-24.04' })).toBe('wsl:ubuntu-24.04')
+    expect(gitProbeHostKey({ wslDistro: 'ubuntu-24.04' })).toBe(
+      gitProbeHostKey({ wslDistro: 'Ubuntu-24.04' })
+    )
     expect(gitProbeHostKey({ connectionId: 'ssh-1', connectionGeneration: 3 })).toBe('ssh:ssh-1:3')
     // A reconnect mints a new key, so a fresh transport never serves the old
     // one's cooldown.
@@ -144,7 +162,7 @@ describe('git host probe breaker', () => {
     expect(await trialProbe).toBe('answered')
   })
 
-  it('serializes and sheds once a host has failed twice, but never before', async () => {
+  it('serializes once a host has failed twice, and answers the overflow rather than failing it', async () => {
     const first = deferred<string>()
     const second = deferred<string>()
 
@@ -157,16 +175,160 @@ describe('git host probe breaker', () => {
     expect(await healthyA).toBe('unavailable')
     expect(await healthyB).toBe('unavailable')
 
-    // Degraded: a second concurrent probe is shed instead of queued.
+    // Degraded: the overflow waits for the outstanding probe instead of being
+    // told the host failed. Two timeouts are not yet proof that it is wedged,
+    // and the trial that is running may be about to disprove it.
     const held = deferred<string>()
     const outstanding = probeOnce('wsl:Ubuntu', () => held.promise)
     await Promise.resolve()
-    const shedRun = vi.fn(async () => 'unused')
-    expect(await probeOnce('wsl:Ubuntu', shedRun)).toBe('blocked')
-    expect(shedRun).not.toHaveBeenCalled()
+    const queuedRun = vi.fn(async () => 'git@github.com:acme/orca.git')
+    const queued = probeOnce('wsl:Ubuntu', queuedRun)
+    await Promise.resolve()
+    expect(queuedRun).not.toHaveBeenCalled()
+    expect(_getGitHostProbeState('wsl:Ubuntu')?.inFlight).toBe(1)
 
     held.resolve('git@github.com:acme/orca.git')
     expect(await outstanding).toBe('answered')
+    expect(await queued).toBe('answered')
+    expect(queuedRun).toHaveBeenCalledTimes(1)
+  })
+
+  it('never turns a burst on a host with a clean budget into a failure', async () => {
+    // Every local repo shares the `native` key, and a cold multi-worktree start
+    // fires one hosted-review lookup per card at once.
+    const gates = Array.from({ length: 100 }, () => deferred<string>())
+    const probes = gates.map((gate) => probeOnce('native', () => gate.promise))
+    await Promise.resolve()
+    for (const gate of gates) {
+      gate.resolve('git@github.com:acme/orca.git')
+    }
+    expect(await Promise.all(probes)).toEqual(gates.map(() => 'answered'))
+    expect(_getGitHostProbeState('native')).toBeNull()
+  })
+
+  it('recovers after the system clock steps backwards mid-cooldown', async () => {
+    const wedged = async (): Promise<string> => {
+      throw timeout()
+    }
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      await probeOnce('wsl:Ubuntu', wedged)
+    }
+    expect(await probeOnce('wsl:Ubuntu', wedged)).toBe('blocked')
+
+    // NTP step, VM snapshot restore, dual-boot RTC fix: the cooldown deadline is
+    // absolute, so an unclamped one strands the host for the size of the jump —
+    // and no probe is left to earn the success that is the only way back.
+    vi.setSystemTime(Date.now() - 60 * 60_000)
+    const trial = vi.fn(async () => 'git@github.com:acme/orca.git')
+    expect(await probeOnce('wsl:Ubuntu', trial)).toBe('answered')
+    expect(trial).toHaveBeenCalledTimes(1)
+  })
+
+  it('reclaims the slot of a probe that never settles', async () => {
+    const wedged = async (): Promise<string> => {
+      throw timeout()
+    }
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      expect(await probeOnce('wsl:Ubuntu', wedged)).toBe('unavailable')
+    }
+    // Degraded to a single slot, and this probe never gives it back.
+    void runGuardedGitHostProbe('wsl:Ubuntu', () => new Promise<string>(() => {}), isUnavailable)
+    await Promise.resolve()
+    expect(_getGitHostProbeState('wsl:Ubuntu')?.inFlight).toBe(1)
+
+    vi.setSystemTime(Date.now() + GIT_HOST_PROBE_SLOT_STALE_MS + 1)
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      expect(await probeOnce('wsl:Ubuntu', wedged)).toBe('unavailable')
+    }
+    // Back at the degraded ceiling: the abandoned slot must not still hold it.
+    expect(_getGitHostProbeState('wsl:Ubuntu')?.inFlight).toBe(0)
+    const trial = vi.fn(async () => 'git@github.com:acme/orca.git')
+    expect(await probeOnce('wsl:Ubuntu', trial)).toBe('answered')
+    expect(trial).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops counting failures a suspend apart as one consecutive streak', async () => {
+    const wedged = async (): Promise<string> => {
+      throw timeout()
+    }
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      expect(await probeOnce('wsl:Ubuntu', wedged)).toBe('unavailable')
+    }
+    expect(_getGitHostProbeState('wsl:Ubuntu')?.consecutiveUnavailable).toBe(2)
+
+    // Two probes stranded across a laptop suspend both fire their deadline on
+    // resume; hours later they say nothing about the host as it is now.
+    vi.setSystemTime(Date.now() + GIT_HOST_PROBE_STREAK_DECAY_MS + 1)
+    const held = deferred<string>()
+    const outstanding = probeOnce('wsl:Ubuntu', () => held.promise)
+    await Promise.resolve()
+    let concurrentOutcome: string | null = null
+    const concurrent = probeOnce('wsl:Ubuntu', async () => 'git@github.com:acme/orca.git').then(
+      (outcome) => {
+        concurrentOutcome = outcome
+      }
+    )
+    await vi.advanceTimersByTimeAsync(0)
+    expect(concurrentOutcome).toBe('answered')
+
+    held.resolve('git@github.com:acme/orca.git')
+    expect(await outstanding).toBe('answered')
+    await concurrent
+  })
+
+  it('keeps an open breaker while reconnect churn mints new host keys', async () => {
+    const wedged = async (): Promise<string> => {
+      throw timeout()
+    }
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      await probeOnce('wsl:Ubuntu', wedged)
+    }
+    const blockedUntilMs = _getGitHostProbeState('wsl:Ubuntu')?.blockedUntilMs ?? 0
+    expect(blockedUntilMs).toBeGreaterThan(Date.now())
+
+    // A relay flap that strands one probe leaves an entry nothing can forget, so
+    // churn alone must not evict the state holding the storm back.
+    for (let flap = 0; flap < MAX_TRACKED_GIT_PROBE_HOSTS * 2; flap += 1) {
+      await probeOnce(`ssh:relay-${flap}:0`, wedged)
+    }
+    expect(_getGitHostProbeState('wsl:Ubuntu')?.blockedUntilMs).toBe(blockedUntilMs)
+    const spawn = vi.fn(async () => 'git@github.com:acme/orca.git')
+    expect(await probeOnce('wsl:Ubuntu', spawn)).toBe('blocked')
+    expect(spawn).not.toHaveBeenCalled()
+  })
+
+  it('retires the earlier generation of a reconnecting SSH host', async () => {
+    const wedged = async (): Promise<string> => {
+      throw timeout()
+    }
+    await probeOnce('ssh:relay-1:0', wedged)
+    expect(_getGitHostProbeState('ssh:relay-1:0')?.consecutiveUnavailable).toBe(1)
+
+    await probeOnce('ssh:relay-1:1', async () => 'git@github.com:acme/orca.git')
+    expect(_getGitHostProbeState('ssh:relay-1:0')).toBeNull()
+  })
+
+  it('says why a probe was shed rather than asserting failures that did not happen', async () => {
+    const wedged = async (): Promise<string> => {
+      throw timeout()
+    }
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      await probeOnce('wsl:Ubuntu', wedged)
+    }
+    expect(await blockedMessage('wsl:Ubuntu')).toBe(
+      'Git host wsl:Ubuntu did not answer 3 consecutive probes; suppressed for ~30s.'
+    )
+
+    vi.setSystemTime(Date.now() + GIT_HOST_PROBE_BASE_COOLDOWN_MS)
+    const trial = deferred<string>()
+    const trialProbe = probeOnce('wsl:Ubuntu', () => trial.promise)
+    await Promise.resolve()
+    expect(await blockedMessage('wsl:Ubuntu')).toBe(
+      'Git host wsl:Ubuntu did not answer 3 consecutive probes; shed while the trial probe deciding whether it is back is outstanding.'
+    )
+
+    trial.resolve('git@github.com:acme/orca.git')
+    expect(await trialProbe).toBe('answered')
   })
 
   it('caps healthy concurrency and queues the overflow rather than failing it', async () => {

--- a/src/main/git/git-host-probe-breaker.test.ts
+++ b/src/main/git/git-host-probe-breaker.test.ts
@@ -1,0 +1,250 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearCrashBreadcrumbsForTest,
+  getCrashBreadcrumbSnapshot
+} from '../crash-reporting/crash-breadcrumb-store'
+import {
+  _getGitHostProbeState,
+  _resetGitHostProbeBreaker,
+  GIT_HOST_PROBE_BASE_COOLDOWN_MS,
+  GIT_HOST_PROBE_HEALTHY_CONCURRENCY,
+  GIT_HOST_PROBE_MAX_COOLDOWN_MS,
+  gitProbeHostKey,
+  isGitHostProbeBlockedError,
+  runGuardedGitHostProbe
+} from './git-host-probe-breaker'
+
+const isUnavailable = (error: unknown): boolean =>
+  error instanceof Error && /timed out/i.test(error.message)
+
+function timeout(): Error {
+  return new Error('wsl.exe timed out.')
+}
+
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (error: unknown) => void
+} {
+  let resolve: (value: T) => void = () => {}
+  let reject: (error: unknown) => void = () => {}
+  const promise = new Promise<T>((settle, fail) => {
+    resolve = settle
+    reject = fail
+  })
+  return { promise, resolve, reject }
+}
+
+/** Drives one probe to a settled outcome and reports whether it ran at all. */
+async function probeOnce(
+  hostKey: string,
+  run: () => Promise<string>
+): Promise<'answered' | 'unavailable' | 'blocked'> {
+  try {
+    await runGuardedGitHostProbe(hostKey, run, isUnavailable)
+    return 'answered'
+  } catch (error) {
+    return isGitHostProbeBlockedError(error) ? 'blocked' : 'unavailable'
+  }
+}
+
+describe('git host probe breaker', () => {
+  beforeEach(() => {
+    _resetGitHostProbeBreaker()
+    clearCrashBreadcrumbsForTest()
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000_000)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    _resetGitHostProbeBreaker()
+  })
+
+  it('scopes state to the runtime that executes git, never globally', () => {
+    expect(gitProbeHostKey({})).toBe('native')
+    expect(gitProbeHostKey({ wslDistro: 'Ubuntu-24.04' })).toBe('wsl:Ubuntu-24.04')
+    expect(gitProbeHostKey({ connectionId: 'ssh-1', connectionGeneration: 3 })).toBe('ssh:ssh-1:3')
+    // A reconnect mints a new key, so a fresh transport never serves the old
+    // one's cooldown.
+    expect(gitProbeHostKey({ connectionId: 'ssh-1', connectionGeneration: 4 })).not.toBe(
+      gitProbeHostKey({ connectionId: 'ssh-1', connectionGeneration: 3 })
+    )
+  })
+
+  it('leaves a single failure alone so a cold host is not punished for a blip', async () => {
+    const run = vi.fn(async () => {
+      throw timeout()
+    })
+    expect(await probeOnce('wsl:Ubuntu', run)).toBe('unavailable')
+
+    const ok = vi.fn(async () => 'git@github.com:acme/orca.git')
+    expect(await probeOnce('wsl:Ubuntu', ok)).toBe('answered')
+    expect(ok).toHaveBeenCalledTimes(1)
+    expect(_getGitHostProbeState('wsl:Ubuntu')).toBeNull()
+  })
+
+  it('opens after three consecutive unanswered probes and stops spawning', async () => {
+    const run = vi.fn(async () => {
+      throw timeout()
+    })
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      expect(await probeOnce('wsl:Ubuntu', run)).toBe('unavailable')
+    }
+    expect(run).toHaveBeenCalledTimes(3)
+
+    for (let poll = 0; poll < 50; poll += 1) {
+      expect(await probeOnce('wsl:Ubuntu', run)).toBe('blocked')
+    }
+    expect(run).toHaveBeenCalledTimes(3)
+  })
+
+  it('escalates the cooldown per failed trial and caps it', async () => {
+    const run = async (): Promise<string> => {
+      throw timeout()
+    }
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      await probeOnce('wsl:Ubuntu', run)
+    }
+
+    const cooldowns: number[] = []
+    for (let trial = 0; trial < 4; trial += 1) {
+      const state = _getGitHostProbeState('wsl:Ubuntu')
+      cooldowns.push((state?.blockedUntilMs ?? 0) - Date.now())
+      vi.setSystemTime(state?.blockedUntilMs ?? 0)
+      expect(await probeOnce('wsl:Ubuntu', run)).toBe('unavailable')
+    }
+
+    expect(cooldowns).toEqual([
+      GIT_HOST_PROBE_BASE_COOLDOWN_MS,
+      GIT_HOST_PROBE_BASE_COOLDOWN_MS * 2,
+      GIT_HOST_PROBE_MAX_COOLDOWN_MS,
+      GIT_HOST_PROBE_MAX_COOLDOWN_MS
+    ])
+  })
+
+  it('admits exactly one trial probe once the cooldown expires', async () => {
+    const run = vi.fn(async () => {
+      throw timeout()
+    })
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      await probeOnce('wsl:Ubuntu', run)
+    }
+    run.mockClear()
+
+    const trial = deferred<string>()
+    vi.setSystemTime(Date.now() + GIT_HOST_PROBE_BASE_COOLDOWN_MS)
+    const trialProbe = probeOnce('wsl:Ubuntu', () => trial.promise)
+    await Promise.resolve()
+
+    expect(await probeOnce('wsl:Ubuntu', run)).toBe('blocked')
+    expect(run).not.toHaveBeenCalled()
+
+    trial.resolve('git@github.com:acme/orca.git')
+    expect(await trialProbe).toBe('answered')
+  })
+
+  it('serializes and sheds once a host has failed twice, but never before', async () => {
+    const first = deferred<string>()
+    const second = deferred<string>()
+
+    // Healthy: concurrent probes run side by side.
+    const healthyA = probeOnce('wsl:Ubuntu', () => first.promise)
+    const healthyB = probeOnce('wsl:Ubuntu', () => second.promise)
+    await Promise.resolve()
+    first.reject(timeout())
+    second.reject(timeout())
+    expect(await healthyA).toBe('unavailable')
+    expect(await healthyB).toBe('unavailable')
+
+    // Degraded: a second concurrent probe is shed instead of queued.
+    const held = deferred<string>()
+    const outstanding = probeOnce('wsl:Ubuntu', () => held.promise)
+    await Promise.resolve()
+    const shedRun = vi.fn(async () => 'unused')
+    expect(await probeOnce('wsl:Ubuntu', shedRun)).toBe('blocked')
+    expect(shedRun).not.toHaveBeenCalled()
+
+    held.resolve('git@github.com:acme/orca.git')
+    expect(await outstanding).toBe('answered')
+  })
+
+  it('caps healthy concurrency and queues the overflow rather than failing it', async () => {
+    const gates = Array.from({ length: GIT_HOST_PROBE_HEALTHY_CONCURRENCY + 3 }, () =>
+      deferred<string>()
+    )
+    const started: number[] = []
+    const probes = gates.map((gate, index) =>
+      probeOnce('native', () => {
+        started.push(index)
+        return gate.promise
+      })
+    )
+    await Promise.resolve()
+
+    expect(started).toHaveLength(GIT_HOST_PROBE_HEALTHY_CONCURRENCY)
+    for (const gate of gates) {
+      gate.resolve('git@github.com:acme/orca.git')
+    }
+    expect(await Promise.all(probes)).toEqual(gates.map(() => 'answered'))
+    expect(started).toHaveLength(gates.length)
+  })
+
+  it('treats a host answering "no such remote" as proof it is alive', async () => {
+    const missing = async (): Promise<string> => {
+      throw new Error("fatal: No such remote 'origin'")
+    }
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      expect(await probeOnce('wsl:Ubuntu', missing)).toBe('unavailable')
+    }
+    expect(_getGitHostProbeState('wsl:Ubuntu')).toBeNull()
+  })
+
+  it('keeps a wedged distro from gating a different host', async () => {
+    const run = async (): Promise<string> => {
+      throw timeout()
+    }
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      await probeOnce('wsl:Ubuntu', run)
+    }
+    expect(await probeOnce('wsl:Ubuntu', run)).toBe('blocked')
+
+    const native = vi.fn(async () => 'git@github.com:acme/orca.git')
+    expect(await probeOnce('native', native)).toBe('answered')
+    expect(await probeOnce('ssh:conn-1:0', native)).toBe('answered')
+    expect(native).toHaveBeenCalledTimes(2)
+  })
+
+  it('leaves a durable breadcrumb for the outage and for the recovery', async () => {
+    const wedged = async (): Promise<string> => {
+      throw timeout()
+    }
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      await probeOnce('wsl:Ubuntu', wedged)
+    }
+
+    const opened = getCrashBreadcrumbSnapshot().filter(
+      (crumb) => crumb.name === 'git_host_probe_breaker_open'
+    )
+    expect(opened).toHaveLength(1)
+    expect(opened[0]?.data).toMatchObject({ host: 'wsl:Ubuntu', unansweredProbes: 3 })
+
+    // A wedged host must not turn one breadcrumb per failure into the noise it
+    // was meant to explain.
+    for (let trial = 0; trial < 6; trial += 1) {
+      vi.setSystemTime(Date.now() + GIT_HOST_PROBE_MAX_COOLDOWN_MS)
+      await probeOnce('wsl:Ubuntu', wedged)
+    }
+    expect(
+      getCrashBreadcrumbSnapshot().filter((crumb) => crumb.name.startsWith('git_host_probe')).length
+    ).toBeLessThanOrEqual(3)
+
+    vi.setSystemTime(Date.now() + GIT_HOST_PROBE_MAX_COOLDOWN_MS)
+    expect(await probeOnce('wsl:Ubuntu', async () => 'git@github.com:acme/orca.git')).toBe(
+      'answered'
+    )
+    expect(
+      getCrashBreadcrumbSnapshot().some((crumb) => crumb.name === 'git_host_probe_recovered')
+    ).toBe(true)
+  })
+})

--- a/src/main/git/git-host-probe-breaker.ts
+++ b/src/main/git/git-host-probe-breaker.ts
@@ -1,0 +1,310 @@
+import {
+  recordCoalescedDurableCrashBreadcrumb,
+  recordDurableCrashBreadcrumb
+} from '../crash-reporting/durable-crash-breadcrumb'
+
+/**
+ * Per-host admission control for the git host probes behind forge detection
+ * (crash f2521868).
+ *
+ * Why: the remote-URL probe's deadline makes a wedged call *settle* rather than
+ * hang, so the in-flight coalescer drops its entry and the very next poll
+ * re-issues — at whatever concurrency the pollers happen to have. In the
+ * reported hour that was 431 calls, 414 of them dying on the deadline, peaking
+ * at 15 concurrent `wsl.exe` children whose contention stretched a 30s deadline
+ * into a 120s span, so the storm fed itself and never recovered. Nothing here
+ * changes how a probe is run; it decides how hard a host that is not answering
+ * may still be pushed, and it always keeps a way back.
+ *
+ * State is scoped to the host that executes git — the native host, one WSL
+ * distro, one SSH connection generation — so a dead distro can never gate the
+ * repos of a host that is fine.
+ */
+
+/**
+ * One unanswered probe is a blip: a cold WSL interop call, a dropped relay
+ * frame. Two means the host has spent a minute answering nothing, so stop
+ * fanning out. Three means it is wedged, and probing it on demand only feeds
+ * the loop. Tripping any earlier would punish WSL's genuinely slow cold start,
+ * which is exactly when a user opening Orca deserves a real answer.
+ */
+export const GIT_HOST_PROBE_SERIALIZE_AFTER = 2
+export const GIT_HOST_PROBE_OPEN_AFTER = 3
+
+/**
+ * The incident peaked at 15 concurrent children, so a ceiling only bounds
+ * anything if it sits under that. A burst wider than this queues rather than
+ * fails — on a healthy host each probe is a sub-second config read, so the
+ * waves cost far less than one contended spawn. A degraded host gets one slot.
+ */
+export const GIT_HOST_PROBE_HEALTHY_CONCURRENCY = 8
+
+/**
+ * A probe costs one full deadline, so retrying sooner than that spends more
+ * wall time inside the host than outside it. The ceiling is the longest span a
+ * single wedged call was observed to hold the host: past that, waiting longer
+ * buys no further idle time and only delays an unattended recovery.
+ */
+export const GIT_HOST_PROBE_BASE_COOLDOWN_MS = 30_000
+export const GIT_HOST_PROBE_MAX_COOLDOWN_MS = 120_000
+
+/** Past this the fan-out is pathological; shed rather than buffer it. */
+const MAX_QUEUED_PER_HOST = 64
+/** Reconnect churn mints a key per SSH generation, so bound retained hosts. */
+const MAX_TRACKED_HOSTS = 64
+/** A two-hour outage must still be legible in a 30-entry breadcrumb ring. */
+const STILL_OPEN_BREADCRUMB_INTERVAL_MS = 5 * 60_000
+/** Keeps `2 ** openCount` away from Infinity on a host down for days. */
+const MAX_COOLDOWN_DOUBLINGS = 20
+
+type HostProbeState = {
+  consecutiveUnavailable: number
+  openCount: number
+  blockedUntilMs: number
+  inFlight: number
+  queued: number
+  waiters: (() => void)[]
+  reportedOpen: boolean
+}
+
+type Admission = 'closed' | 'half-open' | 'blocked' | 'queue'
+
+export type GitHostProbeBlockedError = Error & { gitHostProbeBlocked: true }
+
+export type GitProbeHostParts = {
+  connectionId?: string | null
+  connectionGeneration?: number
+  wslDistro?: string
+}
+
+const hostStates = new Map<string, HostProbeState>()
+
+/** Scopes probe state to the runtime that actually executes git. */
+export function gitProbeHostKey(parts: GitProbeHostParts): string {
+  if (parts.connectionId) {
+    // Why: a reconnect retires the failing transport, so the new generation is a
+    // new key and starts trusted instead of serving out the old one's cooldown.
+    return `ssh:${parts.connectionId}:${parts.connectionGeneration ?? 0}`
+  }
+  return parts.wslDistro ? `wsl:${parts.wslDistro}` : 'native'
+}
+
+export function isGitHostProbeBlockedError(error: unknown): error is GitHostProbeBlockedError {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    (error as { gitHostProbeBlocked?: unknown }).gitHostProbeBlocked === true
+  )
+}
+
+/**
+ * Runs `probe` under this host's failure budget. `isUnavailableError` decides
+ * which rejections are the host failing to answer — anything else, including a
+ * repo saying it has no such remote, is proof the host is alive and clears the
+ * budget. Rejects without running `probe` when the host is being backed off.
+ */
+export async function runGuardedGitHostProbe<T>(
+  hostKey: string,
+  probe: () => Promise<T>,
+  isUnavailableError: (error: unknown) => boolean
+): Promise<T> {
+  const state = getHostState(hostKey)
+  const halfOpen = await admit(hostKey, state)
+  try {
+    const result = await probe()
+    recordAnswered(hostKey, state)
+    return result
+  } catch (error) {
+    if (isUnavailableError(error)) {
+      recordUnavailable(hostKey, state, halfOpen)
+    } else {
+      recordAnswered(hostKey, state)
+    }
+    throw error
+  } finally {
+    release(hostKey, state)
+  }
+}
+
+/** Resolves to true when this probe is the trial that decides whether the host is back. */
+async function admit(hostKey: string, state: HostProbeState): Promise<boolean> {
+  for (;;) {
+    const decision = tryAdmit(state)
+    if (decision === 'blocked') {
+      throw createBlockedError(hostKey, state)
+    }
+    if (decision !== 'queue') {
+      return decision === 'half-open'
+    }
+    if (state.queued >= MAX_QUEUED_PER_HOST) {
+      throw createBlockedError(hostKey, state)
+    }
+    state.queued += 1
+    try {
+      await new Promise<void>((wake) => state.waiters.push(wake))
+    } finally {
+      state.queued -= 1
+    }
+  }
+}
+
+function tryAdmit(state: HostProbeState): Admission {
+  const now = Date.now()
+  if (state.blockedUntilMs > now) {
+    return 'blocked'
+  }
+  if (state.blockedUntilMs > 0) {
+    // Cooled down: exactly one trial probe gets to decide, alone.
+    if (state.inFlight > 0) {
+      return 'blocked'
+    }
+    state.inFlight += 1
+    return 'half-open'
+  }
+  const ceiling =
+    state.consecutiveUnavailable >= GIT_HOST_PROBE_SERIALIZE_AFTER
+      ? 1
+      : GIT_HOST_PROBE_HEALTHY_CONCURRENCY
+  if (state.inFlight >= ceiling) {
+    // Why: a caller queued behind a probe that is already failing would wait a
+    // whole deadline to learn what shedding tells it now, and its poll returns.
+    return ceiling === 1 ? 'blocked' : 'queue'
+  }
+  state.inFlight += 1
+  return 'closed'
+}
+
+function recordAnswered(hostKey: string, state: HostProbeState): void {
+  const unansweredProbes = state.consecutiveUnavailable
+  const wasOpen = state.reportedOpen
+  state.consecutiveUnavailable = 0
+  state.openCount = 0
+  state.blockedUntilMs = 0
+  state.reportedOpen = false
+  if (wasOpen) {
+    recordDurableCrashBreadcrumb('git_host_probe_recovered', { host: hostKey, unansweredProbes })
+  }
+}
+
+function recordUnavailable(hostKey: string, state: HostProbeState, halfOpen: boolean): void {
+  state.consecutiveUnavailable += 1
+  if (halfOpen) {
+    openBreaker(hostKey, state)
+    return
+  }
+  // Why: probes admitted before the breaker opened settle together, and letting
+  // each escalate would jump straight to the ceiling on the first failure wave.
+  if (state.blockedUntilMs > 0 || state.consecutiveUnavailable < GIT_HOST_PROBE_OPEN_AFTER) {
+    return
+  }
+  openBreaker(hostKey, state)
+}
+
+function openBreaker(hostKey: string, state: HostProbeState): void {
+  state.openCount += 1
+  state.blockedUntilMs = Date.now() + cooldownMs(state.openCount)
+  const data = {
+    host: hostKey,
+    unansweredProbes: state.consecutiveUnavailable,
+    cooldownMs: state.blockedUntilMs - Date.now()
+  }
+  if (!state.reportedOpen) {
+    state.reportedOpen = true
+    recordDurableCrashBreadcrumb('git_host_probe_breaker_open', data)
+    return
+  }
+  recordCoalescedDurableCrashBreadcrumb({
+    name: 'git_host_probe_breaker_still_open',
+    data,
+    coalesceKey: `git-host-probe:${hostKey}`,
+    minIntervalMs: STILL_OPEN_BREADCRUMB_INTERVAL_MS
+  })
+}
+
+function cooldownMs(openCount: number): number {
+  const doublings = Math.min(Math.max(0, openCount - 1), MAX_COOLDOWN_DOUBLINGS)
+  return Math.min(GIT_HOST_PROBE_BASE_COOLDOWN_MS * 2 ** doublings, GIT_HOST_PROBE_MAX_COOLDOWN_MS)
+}
+
+function release(hostKey: string, state: HostProbeState): void {
+  state.inFlight -= 1
+  const waiters = state.waiters.splice(0)
+  for (const wake of waiters) {
+    wake()
+  }
+  // Why: a host with nothing left to remember costs nothing to forget, which is
+  // what keeps the healthy case from retaining an entry per repo host forever.
+  if (hostStates.get(hostKey) === state && isForgettable(state)) {
+    hostStates.delete(hostKey)
+  }
+}
+
+function isForgettable(state: HostProbeState): boolean {
+  return isIdle(state) && state.consecutiveUnavailable === 0 && state.blockedUntilMs === 0
+}
+
+function isIdle(state: HostProbeState): boolean {
+  return state.inFlight === 0 && state.queued === 0 && state.waiters.length === 0
+}
+
+function createBlockedError(hostKey: string, state: HostProbeState): GitHostProbeBlockedError {
+  const remainingMs = state.blockedUntilMs - Date.now()
+  const message =
+    remainingMs > 0
+      ? `Git host ${hostKey} did not answer ${state.consecutiveUnavailable} consecutive probes; suppressed for ~${Math.ceil(remainingMs / 1000)}s.`
+      : `Git host ${hostKey} did not answer ${state.consecutiveUnavailable} consecutive probes; shed while an earlier probe is still outstanding.`
+  return Object.assign(new Error(message), { gitHostProbeBlocked: true as const })
+}
+
+function getHostState(hostKey: string): HostProbeState {
+  const existing = hostStates.get(hostKey)
+  if (existing) {
+    return existing
+  }
+  const state: HostProbeState = {
+    consecutiveUnavailable: 0,
+    openCount: 0,
+    blockedUntilMs: 0,
+    inFlight: 0,
+    queued: 0,
+    waiters: [],
+    reportedOpen: false
+  }
+  hostStates.set(hostKey, state)
+  evictIdleHostStates()
+  return state
+}
+
+function evictIdleHostStates(): void {
+  if (hostStates.size <= MAX_TRACKED_HOSTS) {
+    return
+  }
+  for (const [key, state] of hostStates) {
+    if (hostStates.size <= MAX_TRACKED_HOSTS) {
+      return
+    }
+    // Never drop a host with live slot accounting; its release would orphan.
+    if (isIdle(state)) {
+      hostStates.delete(key)
+    }
+  }
+}
+
+/** @internal — tests only. */
+export function _resetGitHostProbeBreaker(): void {
+  hostStates.clear()
+}
+
+/** @internal — tests only. */
+export function _getGitHostProbeState(
+  hostKey: string
+): { consecutiveUnavailable: number; blockedUntilMs: number; inFlight: number } | null {
+  const state = hostStates.get(hostKey)
+  return state
+    ? {
+        consecutiveUnavailable: state.consecutiveUnavailable,
+        blockedUntilMs: state.blockedUntilMs,
+        inFlight: state.inFlight
+      }
+    : null
+}

--- a/src/main/git/git-host-probe-breaker.ts
+++ b/src/main/git/git-host-probe-breaker.ts
@@ -2,6 +2,14 @@ import {
   recordCoalescedDurableCrashBreadcrumb,
   recordDurableCrashBreadcrumb
 } from '../crash-reporting/durable-crash-breadcrumb'
+import {
+  evictIdleGitProbeHostStates,
+  forgetRetiredSshGitProbeGenerations,
+  gitProbeHostStates as hostStates,
+  isForgettableGitProbeHost,
+  type GitProbeHostState,
+  type GitProbeSlot
+} from './git-host-probe-state'
 
 /**
  * Per-host admission control for the git host probes behind forge detection
@@ -48,26 +56,38 @@ export const GIT_HOST_PROBE_HEALTHY_CONCURRENCY = 8
 export const GIT_HOST_PROBE_BASE_COOLDOWN_MS = 30_000
 export const GIT_HOST_PROBE_MAX_COOLDOWN_MS = 120_000
 
-/** Past this the fan-out is pathological; shed rather than buffer it. */
-const MAX_QUEUED_PER_HOST = 64
-/** Reconnect churn mints a key per SSH generation, so bound retained hosts. */
-const MAX_TRACKED_HOSTS = 64
+/**
+ * Every guarded probe carries its own deadline, but nothing here can prove it,
+ * and at the degraded ceiling of one slot a probe that never settled would
+ * block its host for the life of the process — the exact defect
+ * `coalesced-probe.ts` already had to fix once. Reclaim a slot past the longest
+ * a single guarded region can legitimately run: a 5s routing probe, a 30s
+ * deadline, and a 30s direct-WSL fallback retry, with room to spare.
+ */
+export const GIT_HOST_PROBE_SLOT_STALE_MS = 180_000
+
+/**
+ * "Consecutive" has to mean "within one episode". Two deadline kills either
+ * side of a laptop suspend say nothing about the host now, and with no decay
+ * they would pin it at the degraded ceiling until some probe ran alone. Sized
+ * like the cooldown cap: past one full backoff interval a stale blip has had
+ * every chance to repeat.
+ */
+export const GIT_HOST_PROBE_STREAK_DECAY_MS = 120_000
+
+/** Past this a *failing* host's backlog is pathological; shed rather than buffer it. */
+const MAX_QUEUED_PER_FAILING_HOST = 64
 /** A two-hour outage must still be legible in a 30-entry breadcrumb ring. */
 const STILL_OPEN_BREADCRUMB_INTERVAL_MS = 5 * 60_000
 /** Keeps `2 ** openCount` away from Infinity on a host down for days. */
 const MAX_COOLDOWN_DOUBLINGS = 20
 
-type HostProbeState = {
-  consecutiveUnavailable: number
-  openCount: number
-  blockedUntilMs: number
-  inFlight: number
-  queued: number
-  waiters: (() => void)[]
-  reportedOpen: boolean
-}
+type BlockReason = 'cooling-down' | 'trial-outstanding' | 'queue-full'
 
-type Admission = 'closed' | 'half-open' | 'blocked' | 'queue'
+type Admission =
+  | { kind: 'admitted'; slot: GitProbeSlot; halfOpen: boolean }
+  | { kind: 'blocked'; reason: BlockReason }
+  | { kind: 'queue' }
 
 export type GitHostProbeBlockedError = Error & { gitHostProbeBlocked: true }
 
@@ -77,8 +97,6 @@ export type GitProbeHostParts = {
   wslDistro?: string
 }
 
-const hostStates = new Map<string, HostProbeState>()
-
 /** Scopes probe state to the runtime that actually executes git. */
 export function gitProbeHostKey(parts: GitProbeHostParts): string {
   if (parts.connectionId) {
@@ -86,7 +104,10 @@ export function gitProbeHostKey(parts: GitProbeHostParts): string {
     // new key and starts trusted instead of serving out the old one's cooldown.
     return `ssh:${parts.connectionId}:${parts.connectionGeneration ?? 0}`
   }
-  return parts.wslDistro ? `wsl:${parts.wslDistro}` : 'native'
+  // Why lowercased: wsl.exe matches distro names case-insensitively, so a UNC
+  // path spelled `ubuntu` and a hint spelled `Ubuntu` are one host and must
+  // share one budget rather than splitting it into two half-blind ones.
+  return parts.wslDistro ? `wsl:${parts.wslDistro.toLowerCase()}` : 'native'
 }
 
 export function isGitHostProbeBlockedError(error: unknown): error is GitHostProbeBlockedError {
@@ -109,7 +130,7 @@ export async function runGuardedGitHostProbe<T>(
   isUnavailableError: (error: unknown) => boolean
 ): Promise<T> {
   const state = getHostState(hostKey)
-  const halfOpen = await admit(hostKey, state)
+  const { slot, halfOpen } = await admit(hostKey, state)
   try {
     const result = await probe()
     recordAnswered(hostKey, state)
@@ -122,22 +143,29 @@ export async function runGuardedGitHostProbe<T>(
     }
     throw error
   } finally {
-    release(hostKey, state)
+    release(hostKey, state, slot)
   }
 }
 
-/** Resolves to true when this probe is the trial that decides whether the host is back. */
-async function admit(hostKey: string, state: HostProbeState): Promise<boolean> {
+/** Waits for a slot, and reports whether this probe is the trial deciding if the host is back. */
+async function admit(
+  hostKey: string,
+  state: GitProbeHostState
+): Promise<{ slot: GitProbeSlot; halfOpen: boolean }> {
   for (;;) {
     const decision = tryAdmit(state)
-    if (decision === 'blocked') {
-      throw createBlockedError(hostKey, state)
+    if (decision.kind === 'admitted') {
+      return decision
     }
-    if (decision !== 'queue') {
-      return decision === 'half-open'
+    if (decision.kind === 'blocked') {
+      throw createBlockedError(hostKey, state, decision.reason)
     }
-    if (state.queued >= MAX_QUEUED_PER_HOST) {
-      throw createBlockedError(hostKey, state)
+    // Why: only a host that is already failing gets its backlog bounded. Shedding
+    // a caller on a host with a clean budget invents a failure that never
+    // happened, and waiters cost nothing but ordering while every slot ahead of
+    // them is deadline-bounded.
+    if (state.consecutiveUnavailable > 0 && state.queued >= MAX_QUEUED_PER_FAILING_HOST) {
+      throw createBlockedError(hostKey, state, 'queue-full')
     }
     state.queued += 1
     try {
@@ -148,33 +176,75 @@ async function admit(hostKey: string, state: HostProbeState): Promise<boolean> {
   }
 }
 
-function tryAdmit(state: HostProbeState): Admission {
+function tryAdmit(state: GitProbeHostState): Admission {
   const now = Date.now()
+  repairClockAnomalies(state, now)
+  reclaimStaleSlots(state, now)
   if (state.blockedUntilMs > now) {
-    return 'blocked'
+    return { kind: 'blocked', reason: 'cooling-down' }
   }
   if (state.blockedUntilMs > 0) {
     // Cooled down: exactly one trial probe gets to decide, alone.
-    if (state.inFlight > 0) {
-      return 'blocked'
+    if (state.inFlight.size > 0) {
+      return { kind: 'blocked', reason: 'trial-outstanding' }
     }
-    state.inFlight += 1
-    return 'half-open'
+    return { kind: 'admitted', slot: occupySlot(state, now), halfOpen: true }
+  }
+  if (
+    state.consecutiveUnavailable > 0 &&
+    now - state.lastUnavailableAtMs > GIT_HOST_PROBE_STREAK_DECAY_MS
+  ) {
+    state.consecutiveUnavailable = 0
   }
   const ceiling =
     state.consecutiveUnavailable >= GIT_HOST_PROBE_SERIALIZE_AFTER
       ? 1
       : GIT_HOST_PROBE_HEALTHY_CONCURRENCY
-  if (state.inFlight >= ceiling) {
-    // Why: a caller queued behind a probe that is already failing would wait a
-    // whole deadline to learn what shedding tells it now, and its poll returns.
-    return ceiling === 1 ? 'blocked' : 'queue'
+  if (state.inFlight.size >= ceiling) {
+    // Why queue rather than shed: the breaker has not concluded anything yet at
+    // this rung, so a synthetic failure here would report a host outage that the
+    // very next release may disprove. The wait is bounded — one deadline, after
+    // which the host has either answered or opened the breaker.
+    return { kind: 'queue' }
   }
-  state.inFlight += 1
-  return 'closed'
+  return { kind: 'admitted', slot: occupySlot(state, now), halfOpen: false }
 }
 
-function recordAnswered(hostKey: string, state: HostProbeState): void {
+/**
+ * Why: every deadline here is an absolute wall-clock stamp, so a backwards step
+ * — NTP correction, VM snapshot restore, a dual-boot RTC fix — would otherwise
+ * strand a host for the length of the jump, far past the documented cap, with
+ * no probe admitted to earn the success that is the only way back.
+ */
+function repairClockAnomalies(state: GitProbeHostState, now: number): void {
+  if (state.blockedUntilMs - now > GIT_HOST_PROBE_MAX_COOLDOWN_MS) {
+    state.blockedUntilMs = now
+  }
+  if (state.lastUnavailableAtMs > now) {
+    state.lastUnavailableAtMs = now
+  }
+  for (const slot of state.inFlight) {
+    if (slot.admittedAtMs > now) {
+      slot.admittedAtMs = now
+    }
+  }
+}
+
+function reclaimStaleSlots(state: GitProbeHostState, now: number): void {
+  for (const slot of state.inFlight) {
+    if (now - slot.admittedAtMs > GIT_HOST_PROBE_SLOT_STALE_MS) {
+      state.inFlight.delete(slot)
+    }
+  }
+}
+
+function occupySlot(state: GitProbeHostState, now: number): GitProbeSlot {
+  const slot: GitProbeSlot = { admittedAtMs: now }
+  state.inFlight.add(slot)
+  return slot
+}
+
+function recordAnswered(hostKey: string, state: GitProbeHostState): void {
   const unansweredProbes = state.consecutiveUnavailable
   const wasOpen = state.reportedOpen
   state.consecutiveUnavailable = 0
@@ -186,8 +256,9 @@ function recordAnswered(hostKey: string, state: HostProbeState): void {
   }
 }
 
-function recordUnavailable(hostKey: string, state: HostProbeState, halfOpen: boolean): void {
+function recordUnavailable(hostKey: string, state: GitProbeHostState, halfOpen: boolean): void {
   state.consecutiveUnavailable += 1
+  state.lastUnavailableAtMs = Date.now()
   if (halfOpen) {
     openBreaker(hostKey, state)
     return
@@ -200,7 +271,7 @@ function recordUnavailable(hostKey: string, state: HostProbeState, halfOpen: boo
   openBreaker(hostKey, state)
 }
 
-function openBreaker(hostKey: string, state: HostProbeState): void {
+function openBreaker(hostKey: string, state: GitProbeHostState): void {
   state.openCount += 1
   state.blockedUntilMs = Date.now() + cooldownMs(state.openCount)
   const data = {
@@ -226,68 +297,63 @@ function cooldownMs(openCount: number): number {
   return Math.min(GIT_HOST_PROBE_BASE_COOLDOWN_MS * 2 ** doublings, GIT_HOST_PROBE_MAX_COOLDOWN_MS)
 }
 
-function release(hostKey: string, state: HostProbeState): void {
-  state.inFlight -= 1
+function release(hostKey: string, state: GitProbeHostState, slot: GitProbeSlot): void {
+  // Why delete rather than decrement: a slot reclaimed as stale is already gone,
+  // and its late release must not hand the host a phantom free slot.
+  state.inFlight.delete(slot)
   const waiters = state.waiters.splice(0)
   for (const wake of waiters) {
     wake()
   }
   // Why: a host with nothing left to remember costs nothing to forget, which is
   // what keeps the healthy case from retaining an entry per repo host forever.
-  if (hostStates.get(hostKey) === state && isForgettable(state)) {
+  if (hostStates.get(hostKey) === state && isForgettableGitProbeHost(state)) {
     hostStates.delete(hostKey)
   }
 }
 
-function isForgettable(state: HostProbeState): boolean {
-  return isIdle(state) && state.consecutiveUnavailable === 0 && state.blockedUntilMs === 0
+function createBlockedError(
+  hostKey: string,
+  state: GitProbeHostState,
+  reason: BlockReason
+): GitHostProbeBlockedError {
+  return Object.assign(new Error(`Git host ${hostKey} ${describeBlock(state, reason)}`), {
+    gitHostProbeBlocked: true as const
+  })
 }
 
-function isIdle(state: HostProbeState): boolean {
-  return state.inFlight === 0 && state.queued === 0 && state.waiters.length === 0
+/** Why: this text is the breadcrumb a later triage reads, so it must not claim failures that did not happen. */
+function describeBlock(state: GitProbeHostState, reason: BlockReason): string {
+  const unanswered = `did not answer ${state.consecutiveUnavailable} consecutive probes`
+  if (reason === 'cooling-down') {
+    const remainingMs = Math.max(0, state.blockedUntilMs - Date.now())
+    return `${unanswered}; suppressed for ~${Math.ceil(remainingMs / 1000)}s.`
+  }
+  if (reason === 'trial-outstanding') {
+    return `${unanswered}; shed while the trial probe deciding whether it is back is outstanding.`
+  }
+  return `${unanswered} and has ${state.queued} more queued; shed to bound the backlog.`
 }
 
-function createBlockedError(hostKey: string, state: HostProbeState): GitHostProbeBlockedError {
-  const remainingMs = state.blockedUntilMs - Date.now()
-  const message =
-    remainingMs > 0
-      ? `Git host ${hostKey} did not answer ${state.consecutiveUnavailable} consecutive probes; suppressed for ~${Math.ceil(remainingMs / 1000)}s.`
-      : `Git host ${hostKey} did not answer ${state.consecutiveUnavailable} consecutive probes; shed while an earlier probe is still outstanding.`
-  return Object.assign(new Error(message), { gitHostProbeBlocked: true as const })
-}
-
-function getHostState(hostKey: string): HostProbeState {
+function getHostState(hostKey: string): GitProbeHostState {
   const existing = hostStates.get(hostKey)
   if (existing) {
     return existing
   }
-  const state: HostProbeState = {
+  const state: GitProbeHostState = {
     consecutiveUnavailable: 0,
+    lastUnavailableAtMs: 0,
     openCount: 0,
     blockedUntilMs: 0,
-    inFlight: 0,
+    inFlight: new Set(),
     queued: 0,
     waiters: [],
     reportedOpen: false
   }
+  forgetRetiredSshGitProbeGenerations(hostKey)
   hostStates.set(hostKey, state)
-  evictIdleHostStates()
+  evictIdleGitProbeHostStates()
   return state
-}
-
-function evictIdleHostStates(): void {
-  if (hostStates.size <= MAX_TRACKED_HOSTS) {
-    return
-  }
-  for (const [key, state] of hostStates) {
-    if (hostStates.size <= MAX_TRACKED_HOSTS) {
-      return
-    }
-    // Never drop a host with live slot accounting; its release would orphan.
-    if (isIdle(state)) {
-      hostStates.delete(key)
-    }
-  }
 }
 
 /** @internal — tests only. */
@@ -304,7 +370,7 @@ export function _getGitHostProbeState(
     ? {
         consecutiveUnavailable: state.consecutiveUnavailable,
         blockedUntilMs: state.blockedUntilMs,
-        inFlight: state.inFlight
+        inFlight: state.inFlight.size
       }
     : null
 }

--- a/src/main/git/git-host-probe-state.ts
+++ b/src/main/git/git-host-probe-state.ts
@@ -1,0 +1,90 @@
+/**
+ * The retained per-host state behind `git-host-probe-breaker`, plus the rules
+ * for forgetting it.
+ *
+ * Why separate: retention is where this can fail silently. An open breaker is
+ * the *oldest* surviving entry — a healthy host is deleted the moment its last
+ * probe releases and re-inserted at the end — so an eviction pass that walks
+ * insertion order drops exactly the state that is holding a storm back.
+ */
+
+export type GitProbeSlot = { admittedAtMs: number }
+
+export type GitProbeHostState = {
+  consecutiveUnavailable: number
+  lastUnavailableAtMs: number
+  openCount: number
+  blockedUntilMs: number
+  inFlight: Set<GitProbeSlot>
+  queued: number
+  waiters: (() => void)[]
+  reportedOpen: boolean
+}
+
+/** Reconnect churn mints a key per SSH generation, so bound retained hosts. */
+export const MAX_TRACKED_GIT_PROBE_HOSTS = 64
+
+export const gitProbeHostStates = new Map<string, GitProbeHostState>()
+
+function isIdleGitProbeHost(state: GitProbeHostState): boolean {
+  return state.inFlight.size === 0 && state.queued === 0 && state.waiters.length === 0
+}
+
+export function isForgettableGitProbeHost(state: GitProbeHostState): boolean {
+  return (
+    isIdleGitProbeHost(state) && state.consecutiveUnavailable === 0 && state.blockedUntilMs === 0
+  )
+}
+
+/**
+ * Why: every relay flap mints `ssh:<id>:<generation+1>`, and a flap that left
+ * one failed probe behind leaves a permanently unforgettable entry. Retiring the
+ * older generations of the same connection removes the map's only growth source,
+ * so churn cannot crowd out a host that is actually wedged.
+ */
+export function forgetRetiredSshGitProbeGenerations(hostKey: string): void {
+  const generationAt = hostKey.lastIndexOf(':')
+  if (!hostKey.startsWith('ssh:') || generationAt <= 'ssh'.length) {
+    return
+  }
+  const connectionPrefix = hostKey.slice(0, generationAt + 1)
+  for (const [key, state] of gitProbeHostStates) {
+    // Why the digit test: a connection id may itself contain `:`, so a prefix
+    // match alone would let `ssh:a:0` retire the unrelated host `ssh:a:b:0`.
+    if (
+      key !== hostKey &&
+      key.startsWith(connectionPrefix) &&
+      /^\d+$/.test(key.slice(connectionPrefix.length)) &&
+      isIdleGitProbeHost(state)
+    ) {
+      gitProbeHostStates.delete(key)
+    }
+  }
+}
+
+/**
+ * Drops the least informative entries first: a host with nothing to remember,
+ * then one whose cooldown has already lapsed. Only when every tracked host is
+ * mid-outage does this fall back to dropping one that is still cooling down —
+ * bounded memory has to win somewhere, and there the re-probe is one host wide.
+ */
+export function evictIdleGitProbeHostStates(now: number = Date.now()): void {
+  if (gitProbeHostStates.size <= MAX_TRACKED_GIT_PROBE_HOSTS) {
+    return
+  }
+  evictWhere((state) => state.consecutiveUnavailable === 0 && state.blockedUntilMs === 0)
+  evictWhere((state) => state.blockedUntilMs <= now)
+  evictWhere(() => true)
+}
+
+function evictWhere(shouldEvict: (state: GitProbeHostState) => boolean): void {
+  for (const [key, state] of gitProbeHostStates) {
+    if (gitProbeHostStates.size <= MAX_TRACKED_GIT_PROBE_HOSTS) {
+      return
+    }
+    // Why never a live entry: its release would orphan the slot accounting.
+    if (isIdleGitProbeHost(state) && shouldEvict(state)) {
+      gitProbeHostStates.delete(key)
+    }
+  }
+}

--- a/src/main/git/remote-url-probe-wedged-host-backoff.test.ts
+++ b/src/main/git/remote-url-probe-wedged-host-backoff.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getSshGitProviderMock, gitExecFileAsyncMock } = vi.hoisted(() => ({
+  getSshGitProviderMock: vi.fn(),
+  gitExecFileAsyncMock: vi.fn()
+}))
+
+vi.mock('../providers/ssh-git-dispatch', () => ({
+  getSshGitProvider: getSshGitProviderMock,
+  getSshGitProviderGeneration: () => 0,
+  SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE: 'SSH Git provider unavailable'
+}))
+
+vi.mock('./runner', () => ({ gitExecFileAsync: gitExecFileAsyncMock }))
+
+import {
+  _resetGitHostProbeBreaker,
+  GIT_HOST_PROBE_HEALTHY_CONCURRENCY
+} from './git-host-probe-breaker'
+import {
+  assertRemoteUrlReadable,
+  isTransientGitProbeError,
+  readRemoteUrl,
+  REMOTE_URL_PROBE_TIMEOUT_MS
+} from './remote-url-probe'
+
+/**
+ * Crash f2521868: a wedged WSL distro answered nothing for two hours while every
+ * git-backed panel stayed stale. In the final hour that cost 431 `git remote
+ * get-url` calls, 414 of them dying on the deadline, peaking at 15 concurrent
+ * `wsl.exe` children — and it got worse over time, because each probe settles on
+ * its deadline, so the in-flight coalescer drops it and the next poll re-issues.
+ */
+const WEDGED_DISTRO = 'Ubuntu-24.04'
+const WSL_REPO = `\\\\wsl$\\${WEDGED_DISTRO}\\home\\dev\\orca`
+const POLL_INTERVAL_MS = 10_000
+const INCIDENT_WINDOW_MS = 60 * 60_000
+const REPORTED_PEAK_CONCURRENCY = 15
+
+let virtualNowMs = 0
+
+function advanceTo(nextMs: number): void {
+  virtualNowMs = nextMs
+  vi.setSystemTime(virtualNowMs)
+}
+
+function wslTimeout(): Error {
+  return new Error('Error: wsl.exe timed out.')
+}
+
+/** Every spawn burns its full deadline, which is what the report recorded. */
+function wedgeHost(spawns: number[]): void {
+  gitExecFileAsyncMock.mockImplementation(async () => {
+    spawns.push(virtualNowMs)
+    advanceTo(virtualNowMs + REMOTE_URL_PROBE_TIMEOUT_MS)
+    throw wslTimeout()
+  })
+}
+
+async function pollWslRepo(): Promise<'answered' | 'unavailable'> {
+  try {
+    await assertRemoteUrlReadable({ repoPath: WSL_REPO, wslDistro: WEDGED_DISTRO })
+    return 'answered'
+  } catch {
+    return 'unavailable'
+  }
+}
+
+describe('remote URL probe against a wedged host (crash f2521868)', () => {
+  beforeEach(() => {
+    getSshGitProviderMock.mockReset()
+    gitExecFileAsyncMock.mockReset()
+    _resetGitHostProbeBreaker()
+    vi.useFakeTimers()
+    advanceTo(1_700_000_000_000)
+  })
+
+  it('stops hammering a wedged distro, then fully restores it on one success', async () => {
+    const spawns: number[] = []
+    wedgeHost(spawns)
+
+    const startedAtMs = virtualNowMs
+    while (virtualNowMs - startedAtMs < INCIDENT_WINDOW_MS) {
+      const pollStartedAtMs = virtualNowMs
+      expect(await pollWslRepo()).toBe('unavailable')
+      // A blocked poll costs nothing, so the next one lands on its own cadence.
+      advanceTo(Math.max(virtualNowMs, pollStartedAtMs + POLL_INTERVAL_MS))
+    }
+
+    // The report's hour was 431 calls; a poll every 10s over the same hour now
+    // spawns 27, because the backoff converges to one deadline per 150s.
+    expect(spawns.length).toBe(27)
+
+    const spawnsInBucket = (bucket: number): number =>
+      spawns.filter(
+        (at) =>
+          at >= startedAtMs + bucket * 10 * 60_000 && at < startedAtMs + (bucket + 1) * 10 * 60_000
+      ).length
+    // The report's buckets escalated (44 -> 68 -> 125) before the user gave up.
+    // "problem infinitly repeat" is disproved by a tail no worse than the head.
+    expect([0, 1, 2, 3, 4, 5].map(spawnsInBucket)).toEqual([7, 4, 4, 4, 4, 4])
+
+    // Recovery is unattended: no restart, no user action, just the host answering.
+    gitExecFileAsyncMock.mockReset()
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: 'git@github.com:acme/orca.git\n' })
+    advanceTo(virtualNowMs + 2 * 60_000)
+    expect(await pollWslRepo()).toBe('answered')
+
+    gitExecFileAsyncMock.mockClear()
+    for (let poll = 0; poll < 5; poll += 1) {
+      expect(await pollWslRepo()).toBe('answered')
+    }
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(5)
+  })
+
+  it('collapses the fan-out the report peaked at, and restores it after recovery', async () => {
+    let concurrent = 0
+    let peakConcurrent = 0
+    const outstanding: (() => void)[] = []
+    gitExecFileAsyncMock.mockImplementation(async () => {
+      concurrent += 1
+      peakConcurrent = Math.max(peakConcurrent, concurrent)
+      await new Promise<void>((resume) => outstanding.push(resume))
+      concurrent -= 1
+      throw wslTimeout()
+    })
+
+    const firstWave = Array.from({ length: REPORTED_PEAK_CONCURRENCY }, () => pollWslRepo())
+    await vi.advanceTimersByTimeAsync(0)
+    expect(peakConcurrent).toBe(GIT_HOST_PROBE_HEALTHY_CONCURRENCY)
+    while (outstanding.length > 0) {
+      outstanding.pop()?.()
+      await vi.advanceTimersByTimeAsync(0)
+    }
+    expect(await Promise.all(firstWave)).toEqual(firstWave.map(() => 'unavailable'))
+    // Every later probe in the wave was serialized behind the failing host.
+    expect(peakConcurrent).toBe(GIT_HOST_PROBE_HEALTHY_CONCURRENCY)
+
+    const spawns: number[] = []
+    wedgeHost(spawns)
+    const secondWave = Array.from({ length: REPORTED_PEAK_CONCURRENCY }, () => pollWslRepo())
+    expect(await Promise.all(secondWave)).toEqual(secondWave.map(() => 'unavailable'))
+    expect(spawns).toEqual([])
+
+    gitExecFileAsyncMock.mockReset()
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: 'git@github.com:acme/orca.git\n' })
+    advanceTo(virtualNowMs + 5 * 60_000)
+    expect(await pollWslRepo()).toBe('answered')
+
+    gitExecFileAsyncMock.mockClear()
+    const healthyWave = Array.from({ length: REPORTED_PEAK_CONCURRENCY }, () => pollWslRepo())
+    expect(await Promise.all(healthyWave)).toEqual(healthyWave.map(() => 'answered'))
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(REPORTED_PEAK_CONCURRENCY)
+  })
+
+  it('keeps the wedged distro from gating repos on hosts that are answering', async () => {
+    const spawns: number[] = []
+    wedgeHost(spawns)
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      expect(await pollWslRepo()).toBe('unavailable')
+    }
+    spawns.length = 0
+    expect(await pollWslRepo()).toBe('unavailable')
+    expect(spawns).toEqual([])
+
+    // A native repo, and a repo on a different distro, still probe immediately.
+    gitExecFileAsyncMock.mockReset()
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: 'git@github.com:acme/orca.git\n' })
+    await expect(readRemoteUrl({ repoPath: 'C:/repos/orca' }, 'origin')).resolves.toContain(
+      'github.com'
+    )
+    await expect(
+      readRemoteUrl(
+        { repoPath: '\\\\wsl$\\Debian\\home\\dev\\orca', wslDistro: 'Debian' },
+        'origin'
+      )
+    ).resolves.toContain('github.com')
+  })
+
+  it('reports a suppressed probe as unavailable, never as a cacheable answer', async () => {
+    const spawns: number[] = []
+    wedgeHost(spawns)
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      await pollWslRepo()
+    }
+
+    await expect(
+      readRemoteUrl({ repoPath: WSL_REPO, wslDistro: WEDGED_DISTRO }, 'origin')
+    ).rejects.toSatisfy(isTransientGitProbeError)
+  })
+})

--- a/src/main/git/remote-url-probe-wedged-host-backoff.test.ts
+++ b/src/main/git/remote-url-probe-wedged-host-backoff.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { getSshGitProviderMock, gitExecFileAsyncMock } = vi.hoisted(() => ({
   getSshGitProviderMock: vi.fn(),
@@ -14,6 +14,7 @@ vi.mock('../providers/ssh-git-dispatch', () => ({
 vi.mock('./runner', () => ({ gitExecFileAsync: gitExecFileAsyncMock }))
 
 import {
+  _getGitHostProbeState,
   _resetGitHostProbeBreaker,
   GIT_HOST_PROBE_HEALTHY_CONCURRENCY
 } from './git-host-probe-breaker'
@@ -23,6 +24,10 @@ import {
   readRemoteUrl,
   REMOTE_URL_PROBE_TIMEOUT_MS
 } from './remote-url-probe'
+import {
+  resetWslLinkedWorktreeGitRoutingForTests,
+  seedWslLinkedWorktreeGitRoutingForTests
+} from './wsl-linked-worktree-git-routing'
 
 /**
  * Crash f2521868: a wedged WSL distro answered nothing for two hours while every
@@ -32,6 +37,7 @@ import {
  * its deadline, so the in-flight coalescer drops it and the next poll re-issues.
  */
 const WEDGED_DISTRO = 'Ubuntu-24.04'
+const WEDGED_HOST_KEY = 'wsl:ubuntu-24.04'
 const WSL_REPO = `\\\\wsl$\\${WEDGED_DISTRO}\\home\\dev\\orca`
 const POLL_INTERVAL_MS = 10_000
 const INCIDENT_WINDOW_MS = 60 * 60_000
@@ -71,8 +77,14 @@ describe('remote URL probe against a wedged host (crash f2521868)', () => {
     getSshGitProviderMock.mockReset()
     gitExecFileAsyncMock.mockReset()
     _resetGitHostProbeBreaker()
+    resetWslLinkedWorktreeGitRoutingForTests()
     vi.useFakeTimers()
     advanceTo(1_700_000_000_000)
+  })
+
+  afterEach(() => {
+    resetWslLinkedWorktreeGitRoutingForTests()
+    vi.useRealTimers()
   })
 
   it('stops hammering a wedged distro, then fully restores it on one success', async () => {
@@ -187,5 +199,41 @@ describe('remote URL probe against a wedged host (crash f2521868)', () => {
     await expect(
       readRemoteUrl({ repoPath: WSL_REPO, wslDistro: WEDGED_DISTRO }, 'origin')
     ).rejects.toSatisfy(isTransientGitProbeError)
+  })
+  /**
+   * A Windows-drive worktree linked into a WSL repo carries the distro as a hint
+   * but runs *host* git, so keying the probe by the hint would let its instant
+   * successes reset the wedged distro's streak on every poll — the breaker would
+   * never open and the storm would be back at full width.
+   */
+  it('keys a Windows-drive linked worktree to the host git that actually runs it', async () => {
+    const linkedWorktree = 'C:\\worktrees\\orca'
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    try {
+      seedWslLinkedWorktreeGitRoutingForTests(linkedWorktree)
+      const spawns: number[] = []
+      gitExecFileAsyncMock.mockImplementation(async (_args: string[], options: { cwd: string }) => {
+        if (options.cwd === linkedWorktree) {
+          return { stdout: 'git@github.com:acme/orca.git\n' }
+        }
+        spawns.push(virtualNowMs)
+        advanceTo(virtualNowMs + REMOTE_URL_PROBE_TIMEOUT_MS)
+        throw wslTimeout()
+      })
+
+      for (let cycle = 0; cycle < 20; cycle += 1) {
+        await expect(
+          readRemoteUrl({ repoPath: linkedWorktree, wslDistro: WEDGED_DISTRO }, 'origin')
+        ).resolves.toContain('github.com')
+        expect(await pollWslRepo()).toBe('unavailable')
+        advanceTo(virtualNowMs + POLL_INTERVAL_MS)
+      }
+
+      expect(_getGitHostProbeState(WEDGED_HOST_KEY)?.blockedUntilMs).toBeGreaterThan(virtualNowMs)
+      expect(spawns.length).toBeLessThanOrEqual(GIT_HOST_PROBE_HEALTHY_CONCURRENCY)
+    } finally {
+      Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+    }
   })
 })

--- a/src/main/git/remote-url-probe.test.ts
+++ b/src/main/git/remote-url-probe.test.ts
@@ -7,11 +7,13 @@ const { getSshGitProviderMock, gitExecFileAsyncMock } = vi.hoisted(() => ({
 
 vi.mock('../providers/ssh-git-dispatch', () => ({
   getSshGitProvider: getSshGitProviderMock,
+  getSshGitProviderGeneration: () => 0,
   SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE: 'SSH Git provider unavailable'
 }))
 
 vi.mock('./runner', () => ({ gitExecFileAsync: gitExecFileAsyncMock }))
 
+import { _resetGitHostProbeBreaker } from './git-host-probe-breaker'
 import {
   assertRemoteUrlReadable,
   isTransientGitProbeError,
@@ -23,6 +25,7 @@ describe('remote URL probe', () => {
   beforeEach(() => {
     getSshGitProviderMock.mockReset()
     gitExecFileAsyncMock.mockReset()
+    _resetGitHostProbeBreaker()
   })
 
   it('bounds local and WSL remote reads with the shared timeout', async () => {

--- a/src/main/git/remote-url-probe.ts
+++ b/src/main/git/remote-url-probe.ts
@@ -11,6 +11,10 @@ import {
 } from './git-host-probe-breaker'
 import { gitExecFileAsync } from './runner'
 import { isStableMissingGitRemoteError } from './stable-missing-git-remote-error'
+import {
+  isWslLinkedWorktreeGitRoutingCandidate,
+  prepareWslLinkedWorktreeGitRouting
+} from './wsl-linked-worktree-git-routing'
 
 /**
  * The `git remote get-url` probe every forge integration runs to decide whether
@@ -33,12 +37,28 @@ export type RemoteUrlProbeContext = {
 }
 
 /**
- * Which host executes this probe. A repo reached over a `\wsl$` UNC path names
- * its distro nowhere else, and keying it as the native host would let a dead
- * distro back off the probes of local repos that are answering fine.
+ * Which host executes this probe, resolved the way the runner resolves routing
+ * rather than from the caller's hint alone.
+ *
+ * Why it has to match: a Windows-drive worktree linked into a WSL repo carries a
+ * `wslDistro` but runs *host* git, and a `\wsl$` UNC cwd names its distro
+ * nowhere else. Key either one wrong and the budget is silently useless — the
+ * linked worktree's instant successes would reset the wedged distro's streak on
+ * every poll, so the breaker could never open.
  */
-function localProbeHostKey(context: RemoteUrlProbeContext): string {
-  const wslDistro = context.wslDistro ?? parseWslUncPath(context.repoPath)?.distro
+async function localProbeHostKey(context: RemoteUrlProbeContext): Promise<string> {
+  if (
+    isWslLinkedWorktreeGitRoutingCandidate(context.repoPath, context.wslDistro) &&
+    (await prepareWslLinkedWorktreeGitRouting(context.repoPath, context.wslDistro))
+  ) {
+    return gitProbeHostKey({})
+  }
+  // Why the cwd first: `resolveCommand` reads the cwd's distro before the hint,
+  // so identity follows execution. Why the platform gate: off Windows nothing is
+  // routed into WSL, and a literal `//wsl$/x` directory is an ordinary path.
+  const cwdDistro =
+    process.platform === 'win32' ? parseWslUncPath(context.repoPath)?.distro : undefined
+  const wslDistro = cwdDistro ?? context.wslDistro
   return gitProbeHostKey(wslDistro ? { wslDistro } : {})
 }
 
@@ -71,7 +91,7 @@ export async function readRemoteUrl(
     )
   }
   return runGuardedGitHostProbe(
-    localProbeHostKey(context),
+    await localProbeHostKey(context),
     async () => {
       const { stdout } = await gitExecFileAsync(['remote', 'get-url', remoteName], {
         cwd: context.repoPath,

--- a/src/main/git/remote-url-probe.ts
+++ b/src/main/git/remote-url-probe.ts
@@ -1,7 +1,14 @@
+import { parseWslUncPath } from '../../shared/wsl-paths'
 import {
   getSshGitProvider,
+  getSshGitProviderGeneration,
   SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE
 } from '../providers/ssh-git-dispatch'
+import {
+  gitProbeHostKey,
+  isGitHostProbeBlockedError,
+  runGuardedGitHostProbe
+} from './git-host-probe-breaker'
 import { gitExecFileAsync } from './runner'
 import { isStableMissingGitRemoteError } from './stable-missing-git-remote-error'
 
@@ -25,27 +32,56 @@ export type RemoteUrlProbeContext = {
   wslDistro?: string
 }
 
+/**
+ * Which host executes this probe. A repo reached over a `\wsl$` UNC path names
+ * its distro nowhere else, and keying it as the native host would let a dead
+ * distro back off the probes of local repos that are answering fine.
+ */
+function localProbeHostKey(context: RemoteUrlProbeContext): string {
+  const wslDistro = context.wslDistro ?? parseWslUncPath(context.repoPath)?.distro
+  return gitProbeHostKey(wslDistro ? { wslDistro } : {})
+}
+
 /** Reads a remote URL, or null when the repo's SSH runtime is not connected. */
 export async function readRemoteUrl(
   context: RemoteUrlProbeContext,
   remoteName: string
 ): Promise<string | null> {
   if (context.connectionId) {
-    const provider = getSshGitProvider(context.connectionId)
+    const connectionId = context.connectionId
+    const provider = getSshGitProvider(connectionId)
     if (!provider) {
+      // Costs no git, so there is nothing here for the host's budget to learn.
       return null
     }
-    const { stdout } = await provider.exec(['remote', 'get-url', remoteName], context.repoPath, {
-      signal: AbortSignal.timeout(REMOTE_URL_PROBE_TIMEOUT_MS)
-    })
-    return stdout
+    return runGuardedGitHostProbe(
+      gitProbeHostKey({
+        connectionId,
+        connectionGeneration: getSshGitProviderGeneration(connectionId)
+      }),
+      async () => {
+        const { stdout } = await provider.exec(
+          ['remote', 'get-url', remoteName],
+          context.repoPath,
+          { signal: AbortSignal.timeout(REMOTE_URL_PROBE_TIMEOUT_MS) }
+        )
+        return stdout
+      },
+      isTransientGitProbeError
+    )
   }
-  const { stdout } = await gitExecFileAsync(['remote', 'get-url', remoteName], {
-    cwd: context.repoPath,
-    timeout: REMOTE_URL_PROBE_TIMEOUT_MS,
-    ...(context.wslDistro ? { wslDistro: context.wslDistro } : {})
-  })
-  return stdout
+  return runGuardedGitHostProbe(
+    localProbeHostKey(context),
+    async () => {
+      const { stdout } = await gitExecFileAsync(['remote', 'get-url', remoteName], {
+        cwd: context.repoPath,
+        timeout: REMOTE_URL_PROBE_TIMEOUT_MS,
+        ...(context.wslDistro ? { wslDistro: context.wslDistro } : {})
+      })
+      return stdout
+    },
+    isTransientGitProbeError
+  )
 }
 
 const TRANSIENT_PROBE_PATTERNS = [
@@ -62,6 +98,11 @@ const TRANSIENT_PROBE_PATTERNS = [
  * report it as "no review": it is an unavailable result, not a negative one.
  */
 export function isTransientGitProbeError(error: unknown): boolean {
+  // Why: a probe the host's failure budget refused never reached the host, so it
+  // stands in for exactly the deadline kill it was issued instead of.
+  if (isGitHostProbeBlockedError(error)) {
+    return true
+  }
   // Why: an abort — this probe's deadline, or a caller cancelling — carries no
   // message a pattern could match, but it is the emptiest answer of all.
   if (


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​654 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​654 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​538 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​527 |

<!-- /orca-pr-loc -->

## What

Crash report **f2521868** (v1.4.184, Windows, WSL Ubuntu-24.04). In the hour before the user force-killed the app: **431** `git remote get-url` calls, **414** of them dying on the 30s deadline, peaking at **15 concurrent `wsl.exe`** children with a max span of 120s. It ran for two hours and got *worse* over time (44 → 68 → **125** → 73 → 59 → 32 slow calls per 10-minute bucket). The renderer stayed healthy; every git-backed panel was permanently stale. The user's own note: *"session restored problem infinitly repeat"*.

### Why it never recovered

`REMOTE_URL_PROBE_TIMEOUT_MS` is 30s, so a wedged host makes the probe **settle**, not hang. `runCoalescedProbe` only joins an *in-flight* probe, so the entry is deleted in its `finally` and `PROBE_COALESCE_STALE_MS` never trips. The next poll re-issues immediately. There was no negative cache, no circuit breaker, and nothing bounding concurrency — so the loop fed itself: more spawns → more contention → each 30s deadline stretched toward 120s → more overlap.

## The fix

Per-host admission control in a new `src/main/git/git-host-probe-breaker.ts`, consulted from `readRemoteUrl` — the single function every forge-identity probe funnels through (`remote-ref-probe-cache`, `github-repository-identity`, `gitlab-project-ref-resolution`, `hosted-review`), covering native, WSL and SSH/relay in one place. **The git call itself is unchanged.**

A three-rung ladder on *consecutive transient failures*. A stable answer — including a repo reporting no such remote — is proof the host is alive and clears the whole budget. "Consecutive" means within one episode: a streak decays after 120s, so two failures either side of a laptop suspend are not counted together.

| streak | behaviour | why that rung |
| --- | --- | --- |
| 1 | nothing changes | a blip: cold WSL interop, one dropped relay frame. Zero happy-path cost. |
| 2 | ceiling drops 8 → 1, overflow **queues behind the single slot** | the host has burned 60s answering nothing, so stop fanning out — but two timeouts are not yet proof it is wedged, so the overflow waits for the trial rather than being told about an outage that has not been established |
| 3 | breaker **opens** | wedged; probing on demand only feeds the loop |

**Backoff:** `30s × 2^(opens−1)`, capped at **120s**. 30s is one probe deadline — retrying sooner spends more wall time inside the host than outside it. 120s is the longest span a single wedged call was observed to hold the host in this report; past that, waiting buys no further idle time and only delays recovery. Neither is a permanent give-up.

**Host scoping** (never global): `native` | `wsl:<distro>` | `ssh:<connectionId>:<generation>`. The key is derived from the route the runner will actually take, not from the caller's hint: a Windows-drive worktree linked into a WSL repo runs *host* git and is keyed `native`; a `\\wsl$\…` UNC cwd names its distro and wins over the hint, the way `resolveCommand` reads it; off Windows nothing routes into WSL. Distro names are case-folded because `wsl.exe` matches them case-insensitively. An SSH reconnect bumps the generation, which is a new key, so a fresh transport never serves the old one's cooldown, and the older generations of that connection are retired so churn cannot grow the state map.

**Recovery** is unattended and needs no restart: one answer resets streak, open count and deadline. Worst case is one cap interval.

**Visibility.** The user in this report had no idea why every panel was stale. Transitions leave durable crash breadcrumbs — `git_host_probe_breaker_open`, `git_host_probe_breaker_still_open` (coalesced on a 5-minute floor so a two-hour outage is still legible in a 30-entry ring), `git_host_probe_recovered`. Individual failures log nothing.

## Fix evidence

### Simulated incident — `remote-url-probe-wedged-host-backoff.test.ts`

A wedged distro, every spawn burning its full 30s deadline, polled every 10s for a simulated hour:

| | reported incident | with this change |
| --- | ---: | ---: |
| spawns in the hour | **431** | **27** |
| per-10-min buckets | 44, 68, 125, 73, 59, 32 | **7, 4, 4, 4, 4, 4** |
| peak concurrency | 15 | 8 healthy → **1** degraded → **0** open |

The escalating shape is gone; it converges to one deadline per 150s and stays there. A single success then restores full speed — five polls afterward issue five spawns.

A 15-wide burst (the report's peak) against an already-failing host issues **zero** spawns. After recovery, the same 15-wide burst issues all 15 again.

### Real `wsl.exe` on Windows 11, Ubuntu-24.04 (the report's distro)

```
HEALTHY_SERIAL_MS       [89,76,87,80,81,85,72,72]   breaker state: null (nothing retained)
BURST15_UNGUARDED_MS 268  GUARDED_MS 248
BURST15_UNGUARDED_MS 235  GUARDED_MS 276
BURST15_UNGUARDED_MS 253  GUARDED_MS 266
COLD_START_PROBE_MS     1331   (after `wsl --terminate Ubuntu-24.04`)   state: null
```

A 15-wide burst — wider than the ceiling of 8 — is **within noise of unguarded**, three rounds each way: `wsl.exe` spawn cost already serializes these harder than the ceiling does. A genuinely cold distro answers in 1.3s, 22× inside the deadline, and leaves no failure state — which is precisely why rung 1 must be free.

A **nonexistent distro** fails in ~35ms with a non-transient error, so the breaker correctly stays out of it (`state: null`): a fast, cheap, deterministic failure is not a storm, and backing it off would only delay a distro that is about to come online.

### Gates

Re-run on macOS after the adversarial-review fixes:

```
$ pnpm vitest run --config config/vitest.config.ts \
    src/main/git/git-host-probe-breaker.test.ts \
    src/main/git/remote-url-probe.test.ts \
    src/main/git/remote-url-probe-wedged-host-backoff.test.ts
 Test Files  3 passed (3)
      Tests  29 passed (29)

$ pnpm vitest run --config config/vitest.config.ts src/main/git src/main/github \
    src/main/gitlab src/main/source-control src/main/azure-devops src/main/gitea src/main/bitbucket
 Test Files  185 passed | 2 skipped (187)
      Tests  2043 passed | 4 skipped (2047)

$ pnpm run typecheck        # clean, no output
$ pnpm exec oxlint          # clean, no output
$ pnpm run check:max-lines-ratchet
max-lines ratchet OK — 188 grandfathered suppression(s), no new bypasses.
$ pnpm run audit:code-quality:native    # clean
$ pnpm run audit:code-quality:type-aware # clean
$ pnpm run check:reliability-gates
Reliability gate manifest check passed for 85 gate(s).
$ pnpm dlx knip@5.88.1 --config config/knip.json   # no new unused/duplicate exports
```

The earlier Windows run of this branch reported `8 failed | 151 passed` in `src/main/git`; those 32 failures were real-git and symlink-privilege environment failures on that machine (`Command failed: git init`, `EPERM: symlink`) and did not reproduce on macOS or in CI. All 60 GitHub Actions checks on this PR are green.

## ELI5

Orca keeps asking each of your repos "who hosts you?" by running a tiny `git` command. On Windows that means starting `wsl.exe`. If WSL gets stuck, that command doesn't fail — it just sits there for 30 seconds and then gets killed.

The old code treated that like any other finished answer: it threw it away and asked again. And again. Fifteen questions at a time, none of them ever answered, for two hours — each one making the next one slower, until the user killed the app.

Now Orca notices. One bad answer is forgiven; WSL is genuinely slow when it wakes up. Two, and it stops asking fifteen questions at once and asks one. Three, and it stops asking for half a minute, then a minute, then settles at asking once every two minutes — *forever, but gently*. The moment WSL replies even once, everything snaps back to normal instantly. Nobody has to restart anything, and if it ever happens again the crash report says so in plain words.

## Trade-offs

- **A burst wider than 8 queues.** Measured as within noise on real WSL (above), because process spawn already dominates. On a host where probes are much slower than spawn setup, a fan-out over many *distinct* repos would take two waves instead of one. Callers queue rather than fail, so nothing is lost — only ordered. This is the one thing that could make a healthy host marginally slower, and it's the reason the ceiling is 8 rather than something tight.
- **A degraded host serializes concurrent probes.** After two consecutive failures the ceiling is one slot and the overflow waits rather than failing: at that rung the breaker has concluded nothing yet, and the running trial may be about to disprove the failure. The wait is bounded by one deadline, after which the host has either answered (everyone proceeds) or the breaker has opened (everyone is refused immediately, with a reason). Only once the breaker is **open** does a probe get refused without running, and only a host that has already failed has its queue depth capped at 64.
- **Worst-case staleness on a wedged host is one cap interval (120s)** after the host recovers, if no other probe happens to land. Bounded, unattended, no restart. Tightening the cap would speed recovery at the cost of more spawns during the outage.
- **Blocked probes surface as transient/unavailable**, exactly like the deadline kill they stand in for, so no caller can cache them as an answer. `isTransientGitProbeError` recognises them, which is what keeps `hosted-review` on its failure path and the ref caches from publishing a false negative.
- **Not covered:** git calls outside `readRemoteUrl`. A wedged host still costs each of those one deadline. Gating them would mean shedding user-initiated git, which is a different and much riskier decision. `readRemoteUrl` is where the report's storm actually lived.
- **A never-settling probe** would have pinned its host forever, so a slot is reclaimed 180s after admission — comfortably past the longest a single guarded region can legitimately run (a 5s routing probe, a 30s deadline, and a 30s direct-WSL fallback retry). The abandoned probe's own result still counts when it eventually settles; only its slot is returned early.

## Limitations

Written to be read as a list of things this does **not** do.

**Scope.** The breaker guards `readRemoteUrl` only. Every other git call against the same wedged host — status polling, upstream checks, history — still pays a full deadline each, unbounded and uncoalesced. The incident's total `wsl.exe` pressure is reduced, not eliminated, and a user on a wedged distro can still see a slowdown after this fix.

**Recovery depends on callers.** Nothing inside the module schedules a retry. Recovery works only because every consumer treats a transient/blocked probe as uncacheable (`remote-ref-probe-cache` returns null without publishing, `github-repository-identity` caches only a stable missing remote, `hosted-review` throws to stay on its failure path), so the next poll re-enters and becomes the half-open trial. If a future caller ever starts caching a transient result, recovery stalls silently: there is no watchdog and no timer in the breaker itself.

**A half-wedged host is not defended.** A host that alternates failure and success never accumulates a streak of three, so a 50%-wedged host keeps storming at full width. That is the deliberate design — a stable answer is proof the host is alive — but it is a real gap. `TRANSIENT_PROBE_PATTERNS` is also narrow: a WSL failure whose text is not literally `timed out` / `ETIMEDOUT` / `ECONNRESET` / `EPIPE` / `connection …` counts as an answer and clears the entire budget.

**The `native` bucket covers every local repo.** One repo on a dead network mount or an unmounted external drive produces `timed out` errors filed under `native` and, at three consecutive occurrences, backs off the user's healthy local repos too. In practice interleaved successes keep the streak from accumulating, and the streak now decays after 120s, but nothing in the design prevents it.

**One guarded probe can hold a degraded host longer than one deadline.** `gitExecFileAsync` may spend up to 5s in `prepareWslLinkedWorktreeGitRouting` and then retry the direct-WSL fallback with a second full timeout, so ~65s inside a single guarded region is possible. Everything else on that host is serialized behind it for that span. The 180s slot-reclamation bound is sized above this, which also means a genuinely hung probe is tolerated for up to 180s before its slot is returned.

**Queue fairness is unspecified.** `release` wakes all waiters at once and `tryAdmit` admits fresh arrivals without consulting `queued`, so a queued caller can lose repeatedly to newcomers under sustained load, and there is no per-caller deadline on the wait — a queued caller inherits the wall time of the probes ahead of it. No deadlock is possible (waiters are only enqueued while a slot is occupied, and every in-flight probe releases and wakes them), but a wave of many slow-but-succeeding probes on one key could push a queued caller past `PROBE_COALESCE_STALE_MS` (60s), at which point the coalescer above abandons and re-issues while the abandoned probe still holds a slot. I could not construct a realistic workload that reaches this; it is unverified residual risk, not a demonstrated defect.

**Wake-up cost is O(waiters) per release.** With the healthy queue now unbounded, a very wide burst re-wakes every waiter on each release. At a few hundred waiters this is microseconds of closure calls; it is not free, and it is the price of never converting a healthy host's overflow into a failure.

**Clock handling is a clamp, not a monotonic source.** Cooldowns still use `Date.now()`. A backwards step is now repaired on read (a deadline further out than the 120s cap is pulled back to now), but a *forward* step simply expires a cooldown early, and the module has no `performance.now()` baseline.

**Process-global state.** `gitProbeHostStates` is module-level. Only the probe suites call `_resetGitHostProbeBreaker`, so a future test elsewhere that produces three consecutive transient-shaped failures could gate later tests in the same file with no obvious signal.

**Not re-verified by this review.** The Windows `wsl.exe` measurements in the evidence section above (`HEALTHY_SERIAL_MS`, the BURST15 rounds, the 1331ms cold start, the ~35ms nonexistent-distro failure) and the claim that the 32 failures in the original Windows run were pre-existing were taken on the author's machine and could not be reproduced during review, which ran on macOS. Everything under "Gates" was re-run.

**Eviction still has a floor.** If all 64 tracked hosts are simultaneously mid-outage, the third eviction pass drops one that is still cooling down — bounded memory has to win somewhere. That host is then re-probed at full width once. In the reported configuration this needs 64 concurrently-wedged distinct hosts.

## Adversarial review

Three independent reviewers audited this branch — none of them the author. Lenses: field-report fidelity (does the fix actually change the reported failure), self-inflicted denial of service (can the guard strand a host that is fine), state retention and eviction, non-monotonic time, concurrency and lost wake-ups, and evidence honesty (does the diagnostic text match what happened). They returned **ten blocking findings** (three of which are the same queue-overflow defect, found independently by all three). I rejected none: every one describes a real defect, and all ten are fixed in `27fdeba`, each with a regression test that I verified fails when the corresponding guard is disabled. One *sub-claim* inside one finding is wrong and is called out below; the finding it sits in is still real.

The notable ones:

- **A backwards clock step stranded the host permanently.** `blockedUntilMs` is an absolute `Date.now()` deadline with no upper clamp. An NTP step correction, VM snapshot restore or dual-boot RTC fix left every later admission on the `blocked` branch for the length of the jump — hours or days, not the documented 120s — and because recovery is entirely success-driven, no probe could run to produce the success that clears it. Exactly the outcome the PR exists to prevent. Fixed by repairing a deadline further out than the cap on read.
- **The host key did not match the route, which silently disabled the fix.** The key came from `wslDistro` / the UNC path, but `gitExecFileAsync` routes a Windows-drive worktree linked into a WSL repo to **host git**. Those instant successes were filed under `wsl:<distro>` and reset the wedged distro's streak on every poll, so on a mixed layout the breaker never opened at all. Reproduced against the real `readRemoteUrl` before the fix: 20 interleaved poll cycles, 20 spawns on the wedged host, breaker state still `null`. The PR body previously claimed this case was only a mislabelled breadcrumb; that was wrong and the text is corrected above. The key is now derived from the same routing decision the runner makes. The reviewer also claimed the inverse case (a `\\wsl$` UNC path with no `wslDistro`) runs native git — that part is **incorrect**: `resolveCommand` routes on the cwd regardless of the hint, so a UNC cwd does execute in the distro. The only real defect in that direction was the missing platform gate, which is fixed.
- **Queue overflow was shed as a host failure on hosts with no failures.** `MAX_QUEUED_PER_HOST = 64` on top of a ceiling of 8 meant caller 73+ received a `GitHostProbeBlockedError` that `isTransientGitProbeError` reports as unavailable, even with `consecutiveUnavailable === 0`. Reachable: `hosted-review` issues an uncoalesced `assertRemoteUrlReadable` per branch, the per-card refresh runs on mount and on every `visibilitychange`, and every local repo shares the single `native` key. Now only a host that has actually failed has its backlog bounded.
- **The serialize rung failed probes on a host that had merely timed out twice**, and a shed reached neither `recordAnswered` nor `recordUnavailable`, so the rung sustained itself while one slow probe held the single slot. Downstream, `hosted-review-branch-cache` turns that into a 60s → 15min lookup backoff. The overflow queues now.
- **Eviction deleted the open breaker first.** A healthy host is deleted on release and re-inserted at the end of the `Map`, so a host with retained failure state is always the *oldest* entry — and `evictIdleHostStates` walked insertion order. A reviewer reproduced the wedged distro being evicted at flap 63 of SSH reconnect churn, after which the still-wedged host was probed again immediately. Eviction now drops the least informative entry first, and an SSH connection's retired generations are pruned at the source.
- **No bound on an in-flight slot.** A probe that never settled would pin the degraded ceiling of one for the life of the process — the same defect `coalesced-probe.ts` was written to fix, reintroduced. Neither reviewer could construct a live hang (both call paths carry a deadline), so this is defence in depth rather than a demonstrated bug, but the guard is what keeps any future hang from turning into "this host is dead forever".
- **`consecutiveUnavailable` never decayed**, so two failures a laptop-suspend apart still counted as consecutive and pinned the host at the degraded ceiling. It now decays after 120s.
- **The shed message asserted failures that never happened** — verbatim, "Git host native did not answer 0 consecutive probes". It now names the reason.

Also fixed while in there, from the reviewers' non-blocking notes: `parseWslUncPath` had no platform guard (a literal `//wsl$/x` directory off Windows was keyed as a distro), and host keys were not case-folded, so one distro spelled two ways split into two half-blind budgets.

Retention moved into a new `git-host-probe-state.ts` — it is where this fails silently, and the eviction ordering only makes sense next to the forgetting rules. No `max-lines` suppression was added or bumped.

## Relation to the #15039–#15257 stack

**Complementary, not overlapping. Based on `main`, not stacked** — #15039 is already merged, and #15060 / #15257 touch `runner.ts`, `wsl-git-read-environment.ts` and `wsl-direct-git-read-commands.ts`. This PR touches `remote-url-probe.ts` and adds two new files. No textual conflict, and neither branch depends on the other.

That stack fixes what a git call *returns* (argv mangling through `--exec`, the login-shell banner landing on stdout, and #15257 removing the shell from reads entirely, which should cut per-call cost materially). This PR fixes how often Orca is willing to *make* a call that never returns. A perfectly correct, shell-free probe against a wedged or absent distro still burns its full deadline, and before this change Orca would retry that forever at unbounded concurrency.

Incidental confirmation from the real-WSL run above: on stock Ubuntu 24.04 the probe came back as

```
To run a command as administrator (user "root"), use "sudo <command>".
See "man sudo_root" for details.

git@github.com:acme/orca.git
```

— a live reproduction of exactly the banner contamination #15060/#15257 fix, observed on `main` while validating this change. Both fixes are needed: that one makes the answer correct, this one stops the retry storm when there is no answer at all.

