### PR TITLE
fix(git): scope capability state to the distro that runs git

### DIFF
--- a/src/main/git/git-capability-state.test.ts
+++ b/src/main/git/git-capability-state.test.ts
@@ -31,6 +31,27 @@ describe('Git capability execution-host state', () => {
     )
   })
 
+  // A stale hint used to rename the host, filing results from the distro that ran
+  // git against one that never did.
+  it('files state against the distro in the cwd, not a hint naming another one', () => {
+    const cwd = String.raw`\\wsl.localhost\Ubuntu\home\user\repo`
+
+    expect(getLocalGitCapabilityCache({ cwd, wslDistro: 'Debian' })).toBe(
+      getLocalGitCapabilityCache({ cwd })
+    )
+    expect(getLocalGitCapabilityCache({ cwd, wslDistro: 'Debian' })).not.toBe(
+      getLocalGitCapabilityCache({ wslDistro: 'Debian' })
+    )
+  })
+
+  // Windows folds distro case, so two spellings of one distro sharing a cache is
+  // the difference between probing every capability once and probing it twice.
+  it('shares one cache across both UNC spellings of a distro', () => {
+    expect(
+      getLocalGitCapabilityCache({ cwd: String.raw`\\wsl.localhost\Ubuntu\home\u\repo` })
+    ).toBe(getLocalGitCapabilityCache({ cwd: String.raw`\\wsl$\ubuntu\home\u\other` }))
+  })
+
   it('shares one SSH provider lifetime without leaking into a replacement provider', () => {
     const provider = {}
     const replacementProvider = {}

--- a/src/main/git/git-capability-state.ts
+++ b/src/main/git/git-capability-state.ts
@@ -1,15 +1,15 @@
 import { GitCapabilityCache } from '../../shared/git-capability-cache'
-import { parseWslUncPath } from '../../shared/wsl-paths'
+import {
+  gitExecutionHostForTarget,
+  gitExecutionHostKey,
+  type GitExecutionHostTarget
+} from './git-execution-host'
 import {
   isWslLinkedWorktreeGitRoutingCandidate,
   prepareWslLinkedWorktreeGitRouting
 } from './wsl-linked-worktree-git-routing'
 
-type LocalGitCapabilityTarget = {
-  cwd?: string
-  wslDistro?: string
-  signal?: AbortSignal
-}
+type LocalGitCapabilityTarget = GitExecutionHostTarget & { signal?: AbortSignal }
 
 const localCapabilitiesByExecutionHost = new Map<string, GitCapabilityCache>()
 // Why: reconnecting creates a new provider, while concurrent IPC/runtime users
@@ -17,9 +17,7 @@ const localCapabilitiesByExecutionHost = new Map<string, GitCapabilityCache>()
 let sshCapabilitiesByProvider = new WeakMap<object, GitCapabilityCache>()
 
 function getLocalGitExecutionHostKey(target: LocalGitCapabilityTarget): string {
-  const wslDistro =
-    target.wslDistro ?? (target.cwd ? parseWslUncPath(target.cwd)?.distro : undefined)
-  return wslDistro ? `wsl:${wslDistro}` : 'local'
+  return gitExecutionHostKey(gitExecutionHostForTarget(target))
 }
 
 export function getLocalGitCapabilityCache(
@@ -47,13 +45,7 @@ export function withLocalGitCapabilityCacheForExecution<T>(
   }
   return prepareWslLinkedWorktreeGitRouting(target.cwd, target.wslDistro, {
     signal: target.signal
-  }).then((usesHostGit) =>
-    run(
-      getLocalGitCapabilityCache(
-        usesHostGit ? { cwd: target.cwd } : { cwd: target.cwd, wslDistro: target.wslDistro }
-      )
-    )
-  )
+  }).then((usesHostGit) => run(getLocalGitCapabilityCache({ ...target, usesHostGit })))
 }
 
 export function getSshGitCapabilityCache(provider: object): GitCapabilityCache {

--- a/src/main/git/git-execution-host.test.ts
+++ b/src/main/git/git-execution-host.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import { gitExecutionHostForTarget, gitExecutionHostKey } from './git-execution-host'
+
+const UNC_UBUNTU = String.raw`\\wsl.localhost\Ubuntu\home\user\repo`
+const UNC_DOLLAR_DEBIAN = String.raw`\\wsl$\Debian\home\user\repo`
+
+const keyFor = (target: Parameters<typeof gitExecutionHostForTarget>[0]): string =>
+  gitExecutionHostKey(gitExecutionHostForTarget(target))
+
+describe('gitExecutionHostForTarget', () => {
+  it('reads the distro out of either WSL UNC spelling', () => {
+    expect(gitExecutionHostForTarget({ cwd: UNC_UBUNTU })).toEqual({
+      kind: 'wsl',
+      distro: 'Ubuntu',
+      cwdLinuxPath: '/home/user/repo'
+    })
+    expect(gitExecutionHostForTarget({ cwd: UNC_DOLLAR_DEBIAN })).toEqual({
+      kind: 'wsl',
+      distro: 'Debian',
+      cwdLinuxPath: '/home/user/repo'
+    })
+  })
+
+  it('treats a plain path as native', () => {
+    expect(gitExecutionHostForTarget({ cwd: String.raw`C:\repo` })).toEqual({ kind: 'native' })
+    expect(gitExecutionHostForTarget({ cwd: '/home/user/repo' })).toEqual({ kind: 'native' })
+    expect(gitExecutionHostForTarget({})).toEqual({ kind: 'native' })
+  })
+
+  it('applies the hint only when the cwd cannot name a distro', () => {
+    expect(gitExecutionHostForTarget({ wslDistro: 'Ubuntu' })).toEqual({
+      kind: 'wsl',
+      distro: 'Ubuntu',
+      cwdLinuxPath: null
+    })
+    expect(gitExecutionHostForTarget({ cwd: String.raw`C:\repo`, wslDistro: 'Ubuntu' })).toEqual({
+      kind: 'wsl',
+      distro: 'Ubuntu',
+      cwdLinuxPath: null
+    })
+  })
+
+  // The precedence that matters: git runs where the cwd points, so a hint naming
+  // a different distro must not rename the host.
+  it('lets the cwd win over a hint that names a different distro', () => {
+    expect(gitExecutionHostForTarget({ cwd: UNC_UBUNTU, wslDistro: 'Debian' })).toEqual({
+      kind: 'wsl',
+      distro: 'Ubuntu',
+      cwdLinuxPath: '/home/user/repo'
+    })
+  })
+
+  // The one route that overrides the name: a prepared Windows-authored linked
+  // worktree runs git.exe on the host even though the caller still carries a hint.
+  it('reports native once the linked-worktree probe says git runs on the host', () => {
+    expect(
+      gitExecutionHostForTarget({
+        cwd: String.raw`C:\repo\linked`,
+        wslDistro: 'Ubuntu',
+        usesHostGit: true
+      })
+    ).toEqual({ kind: 'native' })
+    expect(
+      keyFor({ cwd: String.raw`C:\repo\linked`, wslDistro: 'Ubuntu', usesHostGit: true })
+    ).toBe(keyFor({}))
+  })
+
+  it('keys native hosts together and each distro apart', () => {
+    expect(keyFor({ cwd: '/repo-a' })).toBe(keyFor({ cwd: '/repo-b' }))
+    expect(keyFor({ cwd: UNC_UBUNTU })).toBe(keyFor({ wslDistro: 'Ubuntu' }))
+    expect(keyFor({ wslDistro: 'Ubuntu' })).not.toBe(keyFor({ wslDistro: 'Debian' }))
+    expect(keyFor({})).not.toBe(keyFor({ wslDistro: 'Ubuntu' }))
+  })
+
+  // Windows folds distro case, so two spellings of one distro must not each pay
+  // for its own capability probing.
+  it('keys both UNC spellings of one distro together while passing it through verbatim', () => {
+    expect(keyFor({ cwd: String.raw`\\wsl$\ubuntu\home\u\repo` })).toBe(keyFor({ cwd: UNC_UBUNTU }))
+    expect(keyFor({ wslDistro: 'UBUNTU' })).toBe(keyFor({ wslDistro: 'Ubuntu' }))
+    expect(gitExecutionHostForTarget({ wslDistro: 'UBUNTU' })).toMatchObject({ distro: 'UBUNTU' })
+  })
+})

--- a/src/main/git/git-execution-host.ts
+++ b/src/main/git/git-execution-host.ts
@@ -1,0 +1,61 @@
+import { parseWslUncPath } from '../../shared/wsl-paths'
+
+/**
+ * The host a git target names -- native, or a WSL distro.
+ *
+ * Why: several call sites derived this independently and two of them disagreed
+ * on precedence -- the runner routes by cwd, while capability state preferred
+ * the caller's `wslDistro` hint. A hint naming a different distro than the cwd
+ * then filed capability results against a host that never ran the command.
+ *
+ * Routing follows the cwd, so identity does too: a WSL UNC cwd names the distro
+ * that will run git, and the hint only applies when the cwd cannot name one.
+ *
+ * Why "names" rather than "runs": one route overrides the name, and it cannot be
+ * decided here. A Windows-authored linked worktree with a drive-letter cwd runs
+ * native git.exe even under a WSL hint, and only an async filesystem probe knows
+ * that (`usesHostGitForWslLinkedWorktree` in ./wsl-linked-worktree-git-routing).
+ * Callers on that path pass its answer as `usesHostGit` so the override still
+ * resolves here instead of being compensated for outside.
+ */
+
+export type GitExecutionHost =
+  | { kind: 'native' }
+  | { kind: 'wsl'; distro: string; cwdLinuxPath: string | null }
+
+export type GitExecutionHostTarget = {
+  cwd?: string
+  wslDistro?: string
+  /** Result of the linked-worktree routing probe: git.exe on the Windows host, not in WSL. */
+  usesHostGit?: boolean
+}
+
+/**
+ * Platform-agnostic: this reports the host a target *names*. Callers that only
+ * route on Windows apply that gate themselves, so a WSL-shaped target keeps one
+ * identity across platforms and unit tests do not depend on the host OS.
+ */
+export function gitExecutionHostForTarget(target: GitExecutionHostTarget): GitExecutionHost {
+  if (target.usesHostGit) {
+    return { kind: 'native' }
+  }
+  const cwdWsl = target.cwd ? parseWslUncPath(target.cwd) : null
+  const distro = cwdWsl?.distro ?? target.wslDistro
+  if (!distro) {
+    return { kind: 'native' }
+  }
+  // Why carry the parsed path: `resolveCommand` needs the guest-side cwd, and null
+  // (rather than '') is what distinguishes "the hint named the host" from "the cwd did".
+  return { kind: 'wsl', distro, cwdLinuxPath: cwdWsl?.linuxPath ?? null }
+}
+
+/**
+ * Why fold case: Windows treats WSL distro names case-insensitively (see
+ * `foldWslUncPathCaseInsensitiveParts`), so `\\wsl$\ubuntu` and
+ * `\\wsl.localhost\Ubuntu` are one host. Two keys would mean two capability
+ * caches re-probing the same distro. `GitExecutionHost.distro` stays verbatim
+ * because that is what `wsl.exe -d` receives.
+ */
+export function gitExecutionHostKey(host: GitExecutionHost): string {
+  return host.kind === 'wsl' ? `wsl:${host.distro.toLowerCase()}` : 'local'
+}

--- a/src/main/git/runner-wsl-direct-read.test.ts
+++ b/src/main/git/runner-wsl-direct-read.test.ts
@@ -279,7 +279,9 @@ describe('WSL direct Git reads', () => {
     })
   })
 
-  it('leaves override-less WSL UNC routing on its existing non-login shell', async () => {
+  // The cwd already names Ubuntu, so an explicit opt-in used to be ignored purely
+  // because the caller had no `wslDistro` to repeat it with.
+  it('takes the shell-free route for an override-less WSL UNC cwd', async () => {
     await withPlatform('win32', async () => {
       seedWslGitReadEnvironmentForTests(DISTRO, LOGIN_ENVIRONMENT)
       succeedExecFile()
@@ -289,7 +291,10 @@ describe('WSL direct Git reads', () => {
         preferWslDirectGit: true
       })
 
-      expect(execFileMock.mock.calls[0]?.[1]?.slice(3, 5)).toEqual(['bash', '-c'])
+      const argv = execFileMock.mock.calls[0]?.[1] as string[]
+      expect(argv.slice(0, 4)).toEqual(['-d', DISTRO, '--exec', '/usr/bin/env'])
+      expect(argv).toContain(LOGIN_ENVIRONMENT.gitPath)
+      expect(argv).not.toContain('bash')
     })
   })
 

--- a/src/main/git/runner-wsl-execution-mode.test.ts
+++ b/src/main/git/runner-wsl-execution-mode.test.ts
@@ -1,0 +1,148 @@
+import { EventEmitter } from 'node:events'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { execFileMock, execFileSyncMock, spawnMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+  execFileSyncMock: vi.fn(),
+  spawnMock: vi.fn()
+}))
+
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock,
+  execFileSync: execFileSyncMock,
+  spawn: spawnMock
+}))
+vi.mock('../observability/instrumentation', () => ({
+  withGitSpan: (_attributes: unknown, run: () => unknown) => run()
+}))
+vi.mock('../diagnostics/main-thread-churn-probe', () => ({ recordSubprocessSpawn: vi.fn() }))
+
+import { gitExecFileAsync } from './runner'
+import {
+  resetWslGitReadEnvironmentForTests,
+  seedWslGitReadEnvironmentForTests
+} from './wsl-git-read-environment'
+import { resetWslLinkedWorktreeGitRoutingForTests } from './wsl-linked-worktree-git-routing'
+
+const WSL_CWD = String.raw`\\wsl.localhost\Ubuntu\home\user\repo`
+const UBUNTU_ENVIRONMENT = {
+  gitPath: '/usr/bin/git',
+  home: '/home/user',
+  path: '/ubuntu/bin:/usr/bin'
+}
+const DEBIAN_ENVIRONMENT = {
+  gitPath: '/opt/debian/git',
+  home: '/home/other',
+  path: '/debian/bin:/usr/bin'
+}
+
+async function withWin32<T>(run: () => Promise<T>): Promise<T> {
+  const original = process.platform
+  Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+  try {
+    return await run()
+  } finally {
+    Object.defineProperty(process, 'platform', { configurable: true, value: original })
+  }
+}
+
+async function argvFor(
+  args: string[],
+  options: { cwd: string; wslDistro?: string }
+): Promise<string[]> {
+  execFileMock.mockClear()
+  await gitExecFileAsync(args, options)
+  return execFileMock.mock.calls.at(-1)?.[1] as string[]
+}
+
+describe('WSL git execution mode', () => {
+  beforeEach(() => {
+    execFileMock.mockReset()
+    resetWslGitReadEnvironmentForTests()
+    resetWslLinkedWorktreeGitRoutingForTests()
+    execFileMock.mockImplementation((_binary, _args, _options, callback) => {
+      callback?.(null, '', '')
+      return new EventEmitter()
+    })
+  })
+
+  // The load-bearing premise of keying capability state off the cwd: the runner
+  // executes where the cwd points. Both the distro flag and the guest environment
+  // must come from Ubuntu even though the caller named Debian.
+  it('runs a read in the cwd distro, with that distro environment, despite a conflicting hint', async () => {
+    await withWin32(async () => {
+      seedWslGitReadEnvironmentForTests('Ubuntu', UBUNTU_ENVIRONMENT)
+      seedWslGitReadEnvironmentForTests('Debian', DEBIAN_ENVIRONMENT)
+
+      const argv = await argvFor(['rev-parse', '--show-toplevel'], {
+        cwd: WSL_CWD,
+        wslDistro: 'Debian'
+      })
+
+      expect(argv.slice(0, 2)).toEqual(['-d', 'Ubuntu'])
+      expect(argv).toContain(UBUNTU_ENVIRONMENT.gitPath)
+      expect(argv).toContain(`PATH=${UBUNTU_ENVIRONMENT.path}`)
+      expect(argv).not.toContain(DEBIAN_ENVIRONMENT.gitPath)
+      expect(argv).not.toContain(`PATH=${DEBIAN_ENVIRONMENT.path}`)
+      expect(argv.join(' ')).toContain('/home/user/repo')
+    })
+  })
+
+  // A write can never take the shell-free read route, so the same assertion holds
+  // whether or not the environment probe has resolved.
+  it('runs a write in the cwd distro despite a conflicting hint', async () => {
+    await withWin32(async () => {
+      seedWslGitReadEnvironmentForTests('Ubuntu', UBUNTU_ENVIRONMENT)
+      seedWslGitReadEnvironmentForTests('Debian', DEBIAN_ENVIRONMENT)
+
+      const argv = await argvFor(['commit', '-m', 'x'], { cwd: WSL_CWD, wslDistro: 'Debian' })
+
+      expect(argv.slice(0, 2)).toEqual(['-d', 'Ubuntu'])
+      expect(argv.at(-1)).toContain('/home/user/repo')
+    })
+  })
+
+  // A read no longer needs the caller to repeat what the cwd already says.
+  it('gives a read the same shell-free route with or without the hint', async () => {
+    await withWin32(async () => {
+      seedWslGitReadEnvironmentForTests('Ubuntu', UBUNTU_ENVIRONMENT)
+
+      const withoutHint = await argvFor(['rev-parse', '--show-toplevel'], { cwd: WSL_CWD })
+      const withHint = await argvFor(['rev-parse', '--show-toplevel'], {
+        cwd: WSL_CWD,
+        wslDistro: 'Ubuntu'
+      })
+
+      expect(withoutHint.slice(2, 4)).toEqual(['--exec', '/usr/bin/env'])
+      expect(withoutHint).toEqual(withHint)
+    })
+  })
+
+  /**
+   * Characterization, not endorsement: a write still picks its shell from the
+   * presence of `wslDistro`, which carries no routing information once the cwd
+   * names the distro. Left as-is here because flipping it decides whether every
+   * WSL write gets the user's PATH and ssh-agent -- a change that needs its own
+   * PR and real-Windows evidence. This pins today's behavior as a parity anchor.
+   */
+  it('still picks a write shell from the hint rather than the host', async () => {
+    await withWin32(async () => {
+      seedWslGitReadEnvironmentForTests('Ubuntu', UBUNTU_ENVIRONMENT)
+
+      const withoutHint = await argvFor(['commit', '-m', 'x'], { cwd: WSL_CWD })
+      const withHint = await argvFor(['commit', '-m', 'x'], {
+        cwd: WSL_CWD,
+        wslDistro: 'Ubuntu'
+      })
+
+      // No hint: a bare non-login shell -- no ~/.profile, so no user PATH and no
+      // ssh-agent, which an authenticated push needs.
+      expect(withoutHint.slice(2, 5)).toEqual(['--exec', 'bash', '-c'])
+      expect(withoutHint.at(-1)).not.toContain('getent passwd')
+
+      // Same command, same host, one optional field later: the user's login shell.
+      expect(withHint.slice(2, 5)).toEqual(['--exec', 'sh', '-lc'])
+      expect(withHint.at(-1)).toContain('getent passwd')
+    })
+  })
+})

--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -34,6 +34,7 @@ import {
   gitCredentialPromptGuardEnv
 } from '../../shared/git-credential-prompt-env'
 import { getSpawnArgsForWindows, isWindowsBatchScript, resolveWindowsCommand } from '../win32-utils'
+import { gitExecutionHostForTarget } from './git-execution-host'
 import { isWslDirectGitReadCommand } from './wsl-direct-git-read-commands'
 import {
   buildWslCapturedLoginShellCommand,
@@ -325,12 +326,11 @@ function resolveCommand(
 
   // Why: global gh callers (rate_limit, listAccessibleProjects) have no cwd to derive a distro from; a distro hint still routes through wsl.exe.
   // TODO(wsl-default-distro): no default-distro setting yet, so override-less global gh callers fall back to host gh.exe (ENOENT on WSL-only installs).
-  const cwdWsl = cwd ? parseWslPath(cwd) : null
-  const wsl: WslPathInfo | null =
-    cwdWsl ?? (wslDistroOverride ? { distro: wslDistroOverride, linuxPath: '' } : null)
-  if (!wsl) {
+  const host = gitExecutionHostForTarget({ cwd, wslDistro: wslDistroOverride })
+  if (host.kind !== 'wsl') {
     return { binary: command, args, cwd, wsl: null, wslMode: null }
   }
+  const wsl: WslPathInfo = { distro: host.distro, linuxPath: host.cwdLinuxPath ?? '' }
 
   const translatedArgs = translateArgsForWsl(args)
   // Why: env on wsl.exe stays Windows-side (WSLENV forwards only named vars), so the locale must ride the command string (issue #7808).
@@ -339,7 +339,7 @@ function resolveCommand(
   // Why: shell-escape each arg to prevent word splitting / glob expansion inside the bash -c string.
   const escapedArgs = translatedArgs.map(quotePosixShell)
   // Why: prepend `cd <linuxPath> &&` for a UNC cwd; skip it when only a distro override was given (global gh needs no cwd).
-  const linuxCwd = cwdWsl?.linuxPath ?? (cwd && wslDistroOverride ? translateArgForWsl(cwd) : null)
+  const linuxCwd = host.cwdLinuxPath ?? (cwd && wslDistroOverride ? translateArgForWsl(cwd) : null)
   const shellCmd = linuxCwd
     ? `cd ${quotePosixShell(linuxCwd)} && ${localePrefix}${escapedCommand} ${escapedArgs.join(' ')}`
     : `${localePrefix}${escapedCommand} ${escapedArgs.join(' ')}`
@@ -434,7 +434,8 @@ function wslDistroForCommand(cwd: string | undefined, override?: string): string
   if (process.platform !== 'win32') {
     return null
   }
-  return (cwd ? parseWslPath(cwd)?.distro : undefined) ?? override ?? null
+  const host = gitExecutionHostForTarget({ cwd, wslDistro: override })
+  return host.kind === 'wsl' ? host.distro : null
 }
 
 function resolveGitCommand(
@@ -447,25 +448,26 @@ function resolveGitCommand(
     // Why: WSL Git resolves a Windows-authored linked-worktree pointer relative to cwd.
     return { binary: 'git', args, cwd: options.cwd, wsl: null, wslMode: null }
   }
-  if (!forceLoginShell && shouldAttemptWslDirectGit(args, options)) {
-    const distro = wslDistroForCommand(options.cwd, options.wslDistro)
-    const environment = distro ? peekWslGitReadEnvironment(distro) : undefined
+  // Why the host and not `options.wslDistro`: a WSL UNC cwd already names the distro
+  // that will run git, so whether the caller also passed a hint must not decide
+  // which environment the read gets.
+  const distro = forceLoginShell ? null : wslDistroForCommand(options.cwd, options.wslDistro)
+  if (distro && shouldAttemptWslDirectGit(args, options)) {
+    const environment = peekWslGitReadEnvironment(distro)
     if (environment) {
       return resolveCommand('git', args, options.cwd, options.wslDistro, {
         wslGitReadEnvironment: environment,
         env: options.env
       })
     }
-    if (distro) {
-      void getWslGitReadEnvironment(distro)
-    }
+    void getWslGitReadEnvironment(distro)
   }
   return resolveGitCommandWithoutProbe(args, options, captureLoginShellOutput)
 }
 
+/** Whether the command class and env are safe for the shell-free route; the caller supplies the host. */
 function shouldAttemptWslDirectGit(args: string[], options: GitExecOptions): boolean {
   return Boolean(
-    process.platform === 'win32' &&
     // Why either: callers can still opt in explicitly, but a plain read no
     // longer has to -- it needs nothing the login shell provides, and routing
     // it through one is what exposes callers to the shell's rc output.
@@ -474,8 +476,7 @@ function shouldAttemptWslDirectGit(args: string[], options: GitExecOptions): boo
     !Object.entries(options.env ?? {}).some(
       ([key, value]) =>
         key.startsWith('GIT_') && key !== 'GIT_OPTIONAL_LOCKS' && value !== process.env[key]
-    ) &&
-    options.wslDistro
+    )
   )
 }
 
@@ -2001,15 +2002,19 @@ export function translateWslOutputPaths(
   originalCwd: string,
   options: { wslDistro?: string } = {}
 ): string {
-  const wsl = parseWslPath(originalCwd)
-  const distro = wsl?.distro ?? options.wslDistro
-  if (!distro) {
+  const host = gitExecutionHostForTarget({
+    // Why the gate: off Windows a literal `//wsl$/x` is an ordinary directory whose
+    // git output needs no rewrite, though an explicit distro hint still does.
+    cwd: process.platform === 'win32' ? originalCwd : undefined,
+    wslDistro: options.wslDistro
+  })
+  if (host.kind !== 'wsl') {
     return output
   }
 
   // Rewrite absolute Linux paths in structured git output (e.g. "worktree /home/user/repo/feature") to Windows UNC.
   return output.replace(/(?<=worktree )(\/.+)$/gm, (_match, linuxPath: string) =>
-    toWindowsWslPath(linuxPath, distro)
+    toWindowsWslPath(linuxPath, host.distro)
   )
 }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​258 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​256 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​93 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​35 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​58 |

<!-- /orca-pr-loc -->

## ELI5

Orca can run git in three different places: on Windows directly, inside a WSL distro, or over SSH. Before running a command it has to answer "which one?", and it also remembers what each host's git can do (which flags it supports) so it doesn't re-check every time.

The problem: it answered that question in several places, and they could disagree. If a call pointed at a folder inside distro **A** but also carried a leftover hint saying **B**, git ran in **A** — but everything Orca learned about git got written down under **B**. Later calls that really were in **B** then trusted notes taken on a completely different machine.

This makes one function the answer to "which host?", and points the runner, the notes, and the output translation at it.

## Root cause

Independent derivations of the execution host, with two different precedence orders:

| site | precedence | used for |
|---|---|---|
| `runner.ts:wslDistroForCommand` | **cwd** ?? hint | picking the direct-read environment |
| `runner.ts:resolveCommand` | **cwd** ?? hint | routing (`wsl.exe -d`, guest cwd) |
| `runner.ts:translateWslOutputPaths` | **cwd** ?? hint | rewriting guest paths in git output |
| `git-capability-state.ts:getLocalGitExecutionHostKey` | **hint** ?? cwd | capability cache key |

Routing follows the cwd, because `resolveCommand` reads `parseWslPath(cwd)` before it looks at the override. Capability state preferred the override. They agree in every case *except* a cwd and hint naming different distros — and there they disagree silently, which is the shape AGENTS.md calls out:

> Scope capability state to the host that executes Git: native, WSL distro, SSH provider, or relay connection.

A capability probed against the distro in the cwd was filed under the hinted one, so a later call genuinely on the hinted distro reused a result from a host that never ran the probe. Git versions differ per distro (`docs/reference/git-compatibility.md`), so this can hand a caller a "supported" verdict for a flag its actual git does not have.

## Fix

`git-execution-host.ts` owns the derivation. Precedence follows execution: the cwd wins; the hint applies only when the cwd cannot name a distro. All four sites above now go through it.

One route overrides the *name* of the host and cannot be decided synchronously: a prepared Windows-authored linked worktree runs native `git.exe` even under a WSL hint (`usesHostGitForWslLinkedWorktree`). That answer is now passed in as `usesHostGit` and resolved inside the owner, rather than being compensated for by the caller stripping the hint before calling in. The module docblock says explicitly that it reports the host a target *names*, and points at the probe that overrides it.

Three behavior changes ride along, each with a mutation-checked test:

**1. Capability keying for a mismatched cwd + hint.** The original fix. Reverting the precedence fails exactly four tests (two key-shape, two runner-level argv) and nothing else.

**2. The shell-free WSL read route no longer requires the caller to repeat what the cwd already says.** `shouldAttemptWslDirectGit` ended in `&& options.wslDistro`, so a read with a WSL UNC cwd and no hint fell back to `bash -c` — and an explicit `preferWslDirectGit: true` was *ignored outright* on that path. There was a test pinning that (`leaves override-less WSL UNC routing on its existing non-login shell`); it pinned the defect and is now flipped, with a comment saying why. The distro was always available: `wslDistroForCommand(cwd, hint)` on the very next line already returned it.

**3. The capability key folds distro case.** Windows treats `\\wsl$\ubuntu` and `\\wsl.localhost\Ubuntu` as one host (`foldWslUncPathCaseInsensitiveParts` in `src/shared/wsl-paths.ts` says so). Before, the key interpolated the raw string, so two spellings of one distro got two `GitCapabilityCache` instances, each independently probing `rev-parse --path-format`, `worktree list -z`, `merge-tree --write-tree` and `for-each-ref --exclude` and eating the failure before falling back. That is duplicated `wsl.exe` spawns on exactly the path the sibling probe-storm work (#15293) is trying to quiet. `GitExecutionHost.distro` stays verbatim, because that is what `wsl.exe -d` receives.

## What this does NOT change (deliberate)

`runner-wsl-execution-mode.test.ts` characterizes a remaining defect without fixing it: a **write** still picks its shell from whether `wslDistro` was populated, not from the host and command class.

```
NO wslDistro : ["-d","Ubuntu","--exec","bash","-c", "cd '/home/user/repo' && ... git commit -m x"]
WITH wslDistro: ["-d","Ubuntu","--exec","sh","-lc", "...getent passwd... exec $shell -ilc ..."]
```

The distro is `Ubuntu` in both — derived from the cwd. So `wslDistro` carries no routing information here; its only effect is to flip login shell vs bare `bash -c`. A write on the no-hint path therefore runs with no `~/.profile`, no user PATH, and no ssh-agent, which an authenticated push needs.

The test uses a **write** deliberately. An earlier draft asserted this with `rev-parse`, which is now an always-read command: once the WSL read-environment probe resolves, a read takes the shell-free route and the `sh -lc` assertion stops holding. That version only passed because `beforeEach` reset the probe cache, so it pinned a cold-start artifact. A write can never take the read route, so the assertion is cache-independent — and it is the case the rationale is actually about.

Fixing it is not in scope here because flipping it decides whether every WSL write gets the user's PATH and ssh-agent. That needs its own PR and real-Windows evidence.

## Relationship to #15039 / #15040 / #15060 / #15257

**All of these have now merged.** An earlier revision of this description described them as open and sequenced work behind them; that was written against a base from before they landed and was wrong.

| PR | state | note |
|---|---|---|
| #15039 | **MERGED** | `6e8da1df8d9` |
| #15040 | **CLOSED** | content landed as **#15290**, `3a9f40ed709` |
| #15060 | **MERGED** | `b7f2e177121` |
| #15257 | **MERGED** | `6efd4061dc4` |

#15257 auto-classified reads (`options.preferWslDirectGit || isWslDirectGitReadCommand(args)`) but left the trailing `&& options.wslDistro`, so it moved the *command-class* decision off the caller while leaving the *host* decision on the caller. That residue is what change 2 above removes. Collapsing the write-side shell choice onto (host, command class) is unblocked today — it is not waiting on anything.

## Testing

Rebased onto `1be6a035b9e` and re-verified there:

- `src/main/git` + `src/main/github`: **1578 passed, 4 skipped, 0 failed** (145 files).
- `pnpm run typecheck` exit 0 · `pnpm exec oxlint` exit 0 · `audit:code-quality:native` exit 0 · `audit:code-quality:type-aware` exit 0 · `check:reliability-gates` OK (85 gates) · `check:max-lines-ratchet` OK (188 grandfathered, **no new bypasses**) · `oxfmt --check` clean.
- Whole-repo `src/main` + `src/shared` on this macOS machine: 13 failures across 10 files, none in `src/main/git`. Re-running those 10 files directly narrowed it to 9 failures in 6 files; the other 4 files pass in isolation and fail only under full-suite load. Those same 9 tests fail identically, by name, on a clean `origin/main` worktree run side by side. All are timing-sensitive (fs watchers, SFTP abort races, retention caps) and pre-existing.

Mutation checks (each reverts one part of the fix and re-runs all 84 `src/main/git` files):

| mutation | fails |
|---|---|
| precedence back to `hint ?? cwd` | `lets the cwd win over a hint that names a different distro`, `files state against the distro in the cwd, not a hint naming another one`, `runs a read in the cwd distro, with that distro environment, despite a conflicting hint`, `runs a write in the cwd distro despite a conflicting hint` |
| restore `&& options.wslDistro` | `takes the shell-free route for an override-less WSL UNC cwd`, `gives a read the same shell-free route with or without the hint` |
| drop `.toLowerCase()` from the key | `keys both UNC spellings of one distro together while passing it through verbatim`, `shares one cache across both UNC spellings of a distro` |

## Limitations

**All verification was on macOS. There is no Windows or WSL host in this environment.** Every WSL claim here is from code reading and from tests that force `process.platform = 'win32'` and mock `child_process`. An earlier revision of this description quoted real `wsl.exe` measurements (git 2.43.0 in 82ms, a `sudo_root` banner on the login-shell route, absent-distro fast-fail); those were **not** reproducible here and are not repeated as evidence.

**The mismatched cwd+hint scenario has not been observed in the field.** It was confirmed reachable by reading `project-runtime-git-options.ts` and `local-project-runtime-resolution.ts`, not from a crash report.

**Change 2 is a real behavior change on Windows that no Windows machine has run.** Reads with a WSL UNC cwd and no `wslDistro` now take the shell-free `/usr/bin/env … git` route instead of `bash -c`, once the read-environment probe has resolved for that distro. It degrades safely by construction — a non-zero exit from the direct route re-runs through `resolveGitCommandWithoutProbe` and can disable the route for that distro (`invalidateMissingDirectWslGit` / `disableDirectWslGitAfterSuccessfulFallback`) — but the first-run path is untested on real hardware.

**Not every derivation of the git execution host is unified, despite this PR's framing.** Four sites in `src/main/git` are. At least three more survive and were deliberately left alone:

- `src/main/runtime/orca-runtime.ts:getCanonicalFetchKey` keys `wsl:${gitOptions.wslDistro} : 'local'` — hint-only, same key vocabulary — and then runs `gitExecFileAsync` cwd-first. A UNC `repoPath` with no hint is filed under `local`. This is a live latent mis-keying of the in-flight-fetch dedup key, out of this diff.
- `src/main/github/conflict-summary-cache.ts:getConflictSummaryGitRuntimeKey` returns `wsl:${wslDistro}` ignoring cwd. Safe today only because `repoPath` is also part of the composite key and therefore pins the host.
- `src/main/gitlab/gitlab-known-host-probe.ts` is hint-only; it has no cwd, so it is defensible.

**`translateWslOutputPaths` keeps its own `win32` gate** rather than relying on the owner's platform-agnostic answer. Off Windows a literal `//wsl$/x` directory is an ordinary path whose git output must not be rewritten. The gate is now expressed by passing `cwd: undefined` off `win32`, so the derivation is still shared, but the platform knowledge is still duplicated at the call site.

**`gitExecutionHostForTarget` is not platform-gated.** On Linux/macOS a directory literally named `//wsl$/X/...` keys as `wsl:X` rather than `local`. This matches the key function it replaced exactly, and is unreachable via the project-runtime hint (`resolveProjectExecutionRuntime` returns `host` for `appPlatform !== 'win32'`), but the key is still not strictly "the host that executes git" off Windows.

**No capability state is persisted anywhere**, so no migration is needed or missing. `GitCapabilityCache` is three in-memory maps and `localCapabilitiesByExecutionHost` is a module-level `Map`; a restart starts empty. Both the precedence change and the case fold therefore only affect keys within a single process run.

**No wire, RPC or IPC surface changed.** All touched files are under `src/main/git`. The relay's per-handler `GitCapabilityCache` (`src/relay/git-handler.ts`) and the SSH-provider-keyed cache are untouched, and neither is WSL-aware, so a mixed-version client/host pair sees nothing new.

**Key collision was checked and is impossible for reachable shapes.** `local` can never equal `wsl:${distro}`; a distro literally named `local` keys as `wsl:local`. Nothing routes SSH- or relay-executed git through `getLocalGitCapabilityCache`.

**CI needed one re-run for an unrelated flake, and hit a different one before that.** On the pre-rebase head, shard `tests node 24 4/16` failed in `src/main/native-chat/transcript-watch-liveness.test.ts:181` — an fs-watcher timing test with no git dependency and a prior deflake commit (#14335). On the first post-rebase run, shard `2/16` failed in `src/main/browser/browser-cookie-import-partition.electron.test.ts:188` with `XIO: fatal IO error 2 ... on X server ":99"` and a dbus connect failure, i.e. the Xvfb display died under the Electron fixture. Neither file imports anything from `src/main/git`. Re-running the failed jobs turned the run green with no code change, which is what a flake looks like — but it also means these two shards have passed once each rather than repeatedly.

## Adversarial review

Three independent adversarial reviewers went over this branch before merge. Lenses: (a) does the new abstraction actually own what it claims to own, and what still bypasses it; (b) do the added tests discriminate — mutation-testing each assertion rather than trusting a green run; (c) mergeability, cross-platform reachability, cache-key collision/fragmentation, and whether the PR description matches the code and the current state of `main`.

They returned **11 blocking findings** (3 major, 8 minor). All were fixed; none were rejected. The notable ones:

- **The branch did not merge.** `mergeable=CONFLICTING`. It was based on a merge-base from before #15060 and #15257 landed, and the import block collided. Resolving it by taking the branch's whole `runner.ts` silently reverts #15257 and fails 12 tests. Fixed by rebasing onto `origin/main`, keeping both imports.
- **The abstraction was built and then not applied where it would have mattered.** `shouldAttemptWslDirectGit` still ended in `&& options.wslDistro`, so the hint-less WSL callers the description named as the victims were still excluded by the raw optional field. One reviewer demonstrated it: same host, same argv, same distro, shell-free vs `bash -c` decided purely by the presence of an optional field. Fixed (change 2), and the test that pinned the old behavior was flipped.
- **The description was materially stale.** It listed #15060 and #15257 as open and sequenced follow-up work behind them; both had merged. A reviewer would have concluded the opt-in root cause was handled elsewhere and stopped looking. Rewritten above.
- **The runner-level tests did not pin the fix's load-bearing premise.** The added routing test compared `{cwd: Ubuntu}` against `{cwd: Ubuntu, wslDistro: 'Ubuntu'}` — matching distros — so it passed unchanged under a hint-first mutation. Replaced with an assertion that seeds *distinguishable* read environments for Ubuntu and Debian and checks both the `-d` flag and the guest `gitPath`/`PATH` for a deliberately mismatched hint.
- **The characterization test pinned a cold-cache artifact.** It used `rev-parse`, which after #15257 takes the shell-free route once the probe resolves; it only passed because `beforeEach` reset the cache. Switched to a write.
- **The key fragmented one host into two caches.** Raw distro interpolation, while Windows folds distro case. Fixed (change 3).
- **The "single owner" did not model the linked-worktree host-git route**, and its docblock contradicted itself ("actually runs git" vs "the host a target *names*"). Fixed by moving the override inside as `usesHostGit` and rewriting the docblock.
- **`resolveCommand` and `translateWslOutputPaths` still derived the host themselves.** Both migrated; `GitExecutionHost` now carries the parsed guest path so `resolveCommand` can consume it.

