### PR TITLE
fix(workspace-cleanup): stop a wheel tick setting a filter, and land every filter patch

### DIFF
--- a/src/renderer/src/components/workspace-cleanup/use-workspace-cleanup-browse-state.test.tsx
+++ b/src/renderer/src/components/workspace-cleanup/use-workspace-cleanup-browse-state.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { create } from 'zustand'
+import type { AppState } from '@/store/types'
+import {
+  createWorkspaceCleanupBrowseSlice,
+  resetWorkspaceCleanupBrowsePersistTimer
+} from '@/store/slices/workspace-cleanup-browse'
+import { createDefaultWorkspaceCleanupBrowseState } from '../../../../shared/workspace-cleanup-browse-state'
+import { useWorkspaceCleanupBrowseState } from './use-workspace-cleanup-browse-state'
+import type { WorkspaceCleanupBrowseController } from './use-workspace-cleanup-browse-state'
+
+const store = create<AppState>()(
+  (...a) =>
+    ({
+      workspaceCleanupDismissals: {},
+      ...createWorkspaceCleanupBrowseSlice(...a)
+    }) as unknown as AppState
+)
+
+vi.mock('@/store', () => ({
+  useAppStore: <T,>(selector: (state: AppState) => T): T => store(selector)
+}))
+
+let root: Root | null = null
+let container: HTMLDivElement | null = null
+
+function mountController(): { current: WorkspaceCleanupBrowseController | null } {
+  const ref: { current: WorkspaceCleanupBrowseController | null } = { current: null }
+  function Probe(): null {
+    ref.current = useWorkspaceCleanupBrowseState()
+    return null
+  }
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  act(() => root!.render(<Probe />))
+  return ref
+}
+
+describe('useWorkspaceCleanupBrowseState', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    ;(globalThis as { window: unknown }).window = {
+      ...globalThis.window,
+      api: { ui: { set: vi.fn().mockResolvedValue(undefined) } }
+    }
+    store.setState({
+      workspaceCleanupBrowse: createDefaultWorkspaceCleanupBrowseState()
+    } as Partial<AppState>)
+  })
+
+  afterEach(() => {
+    if (root) {
+      act(() => root!.unmount())
+    }
+    root = null
+    container = null
+    document.body.replaceChildren()
+    resetWorkspaceCleanupBrowsePersistTimer()
+    vi.useRealTimers()
+  })
+
+  it('keeps both patches when two groups are written in one tick', () => {
+    const controller = mountController()
+
+    // Why one act(): a checkbox toggle writes several groups at once. Reading the
+    // rendered `browse` snapshot per call would make the second patch overwrite
+    // the first, which is what this asserts against.
+    act(() => {
+      controller.current!.patchFilters('activity', { idleMinDays: 20 })
+      controller.current!.patchFilters('size', { maxBytes: 500 })
+    })
+
+    const filters = store.getState().workspaceCleanupBrowse.filters
+    expect(filters.activity.idleMinDays).toBe(20)
+    expect(filters.size.maxBytes).toBe(500)
+  })
+
+  it('keeps both patches when the same group is written twice in one tick', () => {
+    const controller = mountController()
+
+    act(() => {
+      controller.current!.patchFilters('git', { minAhead: 2 })
+      controller.current!.patchFilters('git', { branchQuery: 'release' })
+    })
+
+    const git = store.getState().workspaceCleanupBrowse.filters.git
+    expect(git.minAhead).toBe(2)
+    expect(git.branchQuery).toBe('release')
+  })
+
+  it('flips sort direction against the latest state, not the rendered snapshot', () => {
+    const controller = mountController()
+
+    act(() => {
+      controller.current!.toggleSortField('size')
+      controller.current!.toggleSortField('size')
+    })
+
+    expect(store.getState().workspaceCleanupBrowse.sort).toEqual({
+      field: 'size',
+      direction: 'desc'
+    })
+  })
+})

--- a/src/renderer/src/components/workspace-cleanup/use-workspace-cleanup-browse-state.ts
+++ b/src/renderer/src/components/workspace-cleanup/use-workspace-cleanup-browse-state.ts
@@ -26,37 +26,42 @@ export function useWorkspaceCleanupBrowseState(): WorkspaceCleanupBrowseControll
   const browse = useAppStore((s) => s.workspaceCleanupBrowse)
   const updateBrowse = useAppStore((s) => s.updateWorkspaceCleanupBrowseState)
 
+  // Why the updater form: a checkbox toggle writes several fields at once, so two
+  // patches can land in one tick. Reading `browse` from the render would make the
+  // second overwrite the first.
   const patchFilters = useCallback<WorkspaceCleanupBrowseController['patchFilters']>(
     (key, value) => {
-      const current = browse.filters[key]
-      const next =
-        typeof current === 'object' && current !== null
-          ? { ...current, ...(value as object) }
-          : value
-      // Cast: a computed key over a union widens the spread result past
-      // WorkspaceCleanupFilterState even though `key` is constrained to it.
-      const filters = { ...browse.filters, [key]: next } as WorkspaceCleanupFilterState
-      updateBrowse({ ...browse, filters })
+      updateBrowse((current) => {
+        const group = current.filters[key]
+        const next =
+          typeof group === 'object' && group !== null ? { ...group, ...(value as object) } : value
+        // Cast: a computed key over a union widens the spread result past
+        // WorkspaceCleanupFilterState even though `key` is constrained to it.
+        const filters = { ...current.filters, [key]: next } as WorkspaceCleanupFilterState
+        return { ...current, filters }
+      })
     },
-    [browse, updateBrowse]
+    [updateBrowse]
   )
 
   // Why: re-picking the active sort flips its direction.
   const toggleSortField = useCallback(
     (field: WorkspaceCleanupSortField) => {
-      const direction =
-        browse.sort.field === field && browse.sort.direction === 'asc' ? 'desc' : 'asc'
-      updateBrowse({ ...browse, sort: { field, direction } })
+      updateBrowse((current) => {
+        const direction =
+          current.sort.field === field && current.sort.direction === 'asc' ? 'desc' : 'asc'
+        return { ...current, sort: { field, direction } }
+      })
     },
-    [browse, updateBrowse]
+    [updateBrowse]
   )
 
   const clearFilters = useCallback(() => {
-    updateBrowse({
-      ...browse,
+    updateBrowse((current) => ({
+      ...current,
       filters: createDefaultWorkspaceCleanupFilterState()
-    })
-  }, [browse, updateBrowse])
+    }))
+  }, [updateBrowse])
 
   return {
     filters: browse.filters,

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-facet-controls.test.tsx
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-facet-controls.test.tsx
@@ -108,9 +108,32 @@ describe('workspace cleanup facet controls', () => {
     renderFacets(createDefaultWorkspaceCleanupFilterState(), onPatch)
 
     const input = control('Idle for at least') as HTMLInputElement | null
-    expect(input?.type).toBe('number')
     act(() => typeInto(input, '17'))
     expect(onPatch).toHaveBeenCalledWith('activity', { idleMinDays: 17 })
+  })
+
+  it('keeps every numeric threshold off type=number so a wheel tick cannot set it', () => {
+    // Why assert the type rather than dispatch a wheel event: the spinner is a
+    // Chromium behaviour happy-dom does not implement, so a dispatched wheel
+    // changes nothing here either way and the test would pass without the fix.
+    // The type is the property that makes the whole class impossible.
+    renderFacets(createDefaultWorkspaceCleanupFilterState(), createPatchMock())
+
+    const numericFacets = [
+      'Idle for at least',
+      'At least',
+      'At most',
+      'Commits ahead ≥',
+      'Commits behind ≥'
+    ]
+    const found = numericFacets
+      .map((label) => control(label) as HTMLInputElement | null)
+      .filter((input): input is HTMLInputElement => input !== null)
+    expect(found).toHaveLength(numericFacets.length)
+    for (const input of found) {
+      expect(input.type).toBe('text')
+      expect(input.inputMode).toBe('numeric')
+    }
   })
 
   it('multi-selects git states', () => {

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-facet-controls.tsx
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-facet-controls.tsx
@@ -139,10 +139,13 @@ export function FacetNumberField({
   return (
     <FacetField label={label}>
       <div className="flex items-center gap-1.5">
+        {/* Why text, not number: Chromium mutates a focused number input on every
+            wheel tick, which silently walked a threshold up inside the scrollable
+            facet panel. preventDefault would stop that but also stop the panel
+            scrolling, re-breaking #14629. */}
         <Input
-          type="number"
+          type="text"
           inputMode="numeric"
-          min={0}
           aria-label={label}
           value={value === null ? '' : String(value)}
           placeholder={placeholder}

--- a/src/renderer/src/store/slices/workspace-cleanup-browse.ts
+++ b/src/renderer/src/store/slices/workspace-cleanup-browse.ts
@@ -11,9 +11,14 @@ export const WORKSPACE_CLEANUP_BROWSE_PERSIST_DEBOUNCE_MS = 250
 
 let persistTimer: ReturnType<typeof setTimeout> | null = null
 
+/** Updater form exists so two patches in one tick cannot read the same stale snapshot. */
+export type WorkspaceCleanupBrowseUpdate =
+  | WorkspaceCleanupBrowseState
+  | ((current: WorkspaceCleanupBrowseState) => WorkspaceCleanupBrowseState)
+
 export type WorkspaceCleanupBrowseSlice = {
   workspaceCleanupBrowse: WorkspaceCleanupBrowseState
-  updateWorkspaceCleanupBrowseState: (next: WorkspaceCleanupBrowseState) => void
+  updateWorkspaceCleanupBrowseState: (next: WorkspaceCleanupBrowseUpdate) => void
 }
 
 export const createWorkspaceCleanupBrowseSlice: StateCreator<
@@ -25,7 +30,10 @@ export const createWorkspaceCleanupBrowseSlice: StateCreator<
   workspaceCleanupBrowse: createDefaultWorkspaceCleanupBrowseState(),
 
   updateWorkspaceCleanupBrowseState: (next) => {
-    set({ workspaceCleanupBrowse: next })
+    set((state) => ({
+      workspaceCleanupBrowse:
+        typeof next === 'function' ? next(state.workspaceCleanupBrowse) : next
+    }))
     if (persistTimer !== null) {
       clearTimeout(persistTimer)
     }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​132 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​131 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​38 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​22 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 |

<!-- /orca-pr-loc -->

## ELI5

You spun the scroll wheel over the workspace-cleanup filter panel. Your cursor happened to be over a number box you'd clicked into. The browser quietly counted that as "change this number", so a filter you never turned on started hiding 253 of your 799 workspaces — and it got saved. This stops the wheel from being able to do that.

## What Changed

- `FacetNumberField` renders `type="text" inputMode="numeric"` instead of `type="number"`. All five numeric facets (idle days, min/max size, ahead/behind) share this one field, so one change covers them.
- `patchFilters` now writes through a functional update against the latest store state instead of closing over the render's snapshot. `toggleSortField` and `clearFilters` had the same defect and are fixed with it.

## Why

**The wheel.** Chromium mutates a *focused* `<input type="number">` on every wheel tick. Before #14629 the facet panel could not scroll, so the natural response — put the cursor in the panel and spin — walked `activity.idleMinDays` up and persisted it. The filter bar did render "Showing 546 of 799" the whole time, so the effect was visible; what was missing was any attribution telling you which filter, or that it came from a previous session.

`preventDefault()` on a focused number input also stops the value changing, and I rejected it: `preventDefault` blocks the wheel's default action, which includes scrolling the nearest scrollable ancestor. It would re-break the panel scrolling #14629 just fixed, in exactly the gesture that caused this. A text input can't be wheel-mutated at all and keeps focus and scrolling intact. `parseWorkspaceCleanupFacetNumber` already parses strings and clamps negatives, so nothing downstream changes.

**The patch drop.** `patchFilters` read `browse` from the render, so two patches in the same tick both started from the same snapshot and the second overwrote the first. Nothing in today's UI writes two groups at once, so this is latent rather than user-visible — but the per-group apply checkboxes that follow write several fields per toggle, and this is the seam they'd land on.

## Linked Issue

Reported directly by @BrennanKB5 in-session with a screenshot of the 20-day filter applied on open. No tracking issue was filed; the design work is in `docs/workspace-cleanup-filter-apply-plan.md`.

## Visual Proof

`N/A` — no rendered change. The input looks and behaves identically for keyboard and mouse entry; only the wheel gesture's effect is removed, and the native spinner arrows go with it (deliberate: they were also a mis-click surface in a dense panel). The measurable behaviour is covered by tests below rather than a screenshot, since "a wheel no longer does something" does not photograph.

## Testing

Both new tests were confirmed to **fail against the unfixed source** before being kept — I reverted each source file, re-ran, saw red, and restored:

- `use-workspace-cleanup-browse-state.test.tsx` (new, 3 cases): two different groups patched in one tick both land; the same group patched twice in one tick keeps both fields; sort direction flips against latest state. All 3 red before the fix.
- `workspace-cleanup-facet-controls.test.tsx`: asserts every numeric facet is off `type="number"` and on `inputMode="numeric"`. Red before the fix.

On the wheel test specifically — I assert the input's *type* rather than dispatching a wheel event on purpose. The spinner is a Chromium behaviour happy-dom does not implement, so a dispatched wheel changes nothing in the test environment either way and such a test would pass without the fix. The type is the property that makes the class impossible; the comment in the test says so, so nobody later "improves" it into a vacuous one.

Gates run locally on the rebased branch: `pnpm typecheck`, `npx oxlint`, `pnpm lint:react-doctor:changed`, `pnpm verify:localization-catalog`, and the full workspace-cleanup suite (36 files, 248 tests) — all clean. No strings added or removed.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

Worth a look at the `type="number"` → `type="text"` trade specifically. It drops native `min={0}` enforcement; typing `-5` now yields `null` (filter off) rather than being blocked at the input, which I judged acceptable since the parser already clamped. If you'd rather keep the spinners, the alternative is a blur-on-wheel guard in the shared `Input` primitive — that would also cover the **8** other `type="number"` inputs across settings and SSH forms, which have the identical exposure and are deliberately out of scope here.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

- **Cross-platform:** the wheel behaviour is Chromium's, so the fix applies identically on macOS, Linux, and Windows. No platform branches.
- **SSH / remote:** filter state is renderer-local and persisted through the existing `ui.set` path; no wire change, no host involvement.
- **Backwards compatibility:** no schema or wire change. `patchFilters` keeps its signature; only its read is now functional.
- **Performance:** the functional update removes `browse` from the callback's dependency array, so `patchFilters` stops re-creating on every browse change.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test` pass locally

## Author

- X / Twitter: @BrennanKB5
