### PR TITLE
ci(e2e): keep the relay version markers in the e2e build artifact

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -86,6 +86,10 @@ jobs:
         with:
           name: e2e-build-out
           path: out/
+          # Why: build-relay.mjs writes each relay's marker as `out/relay/<platform>/.version`,
+          # and upload-artifact drops dotfiles by default — consumers then fail SSH specs with
+          # "local relay build is missing its version marker".
+          include-hidden-files: true
           retention-days: 1
           if-no-files-found: error
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 |

<!-- /orca-pr-loc -->

## ELI5

CI builds the SSH relay, then zips it up and hands it to the test jobs. The zip step silently drops files whose names start with a dot — and the relay's version stamp is called `.version`. So the tests got a relay with no version stamp and refused to start it. One line of config.

## What Changed

Adds `include-hidden-files: true` to the `e2e-build-out` artifact upload in `.github/workflows/e2e.yml`. That is the only artifact upload in the repo that carries `out/` after a relay build.

## Why

`config/scripts/build-relay.mjs:141` and `:169` write each relay's marker as `out/relay/<platform>/.version`. `actions/upload-artifact` excludes hidden files unless told otherwise, and the build log states it plainly:

```
Built relay for linux-x64 → out/relay/linux-x64/relay.js
...
##[group]Run actions/upload-artifact@v7
  include-hidden-files: false
```

So every consumer that downloads `e2e-build-out` and actually starts a relay fails:

```
Error occurred in handler for 'ssh:connect':
  Orca's local relay build is missing its version marker at
  out/relay/linux-x64/.version.
  This usually indicates a packaging or build problem; reinstall Orca.
```

**Why this stayed hidden.** The sharded `e2e` lane never sets `ORCA_E2E_SSH_DOCKER`, so its SSH specs skip themselves and never touch the relay. The `changed e2e specs` lane *does* set it whenever a changed spec needs Docker SSH. The failure therefore only appears on PRs that touch SSH-adjacent code — where it looks like the PR's fault. It is not; the relay builds correctly every time, and only its marker goes missing in transit.

Observed on PR #15295, where five SSH specs failed with this error across two independent runs — identical output both times, so not a flake:

- `pty-input-write-queue-ssh.spec.ts`
- `ssh-cold-activation-restore.spec.ts` (×2)
- `ssh-docker-reconnect-pane-restore.spec.ts`
- `ssh-terminal-window-wake-stale-grid-repro.spec.ts`

## Linked Issue

No issue filed — found while diagnosing a CI failure on #15295.

## Visual Proof

`N/A` — CI configuration only, no product surface.

## Testing

- Verified the premise directly in the build job log of run `32122779703`: the relay builds all seven targets successfully, and the upload step reports `include-hidden-files: false`.
- Verified the marker really is a dotfile at `config/scripts/build-relay.mjs:141` and `:169`.
- Confirmed the artifact download itself succeeds (41.5 MB, digest verified) — the file is missing from the archive, not lost in transit.
- Confirmed this is the only `upload-artifact` in the repo that carries `out/` after a relay build, so no sibling call site needs the same flag.
- Structurally validated the edit: `include-hidden-files` sits at the same indent as its `with:` siblings.

The real verification is this PR's own CI: it does not touch SSH-adjacent code, so its `changed e2e specs` lane will not exercise a relay. Confirmation comes from rerunning #15295 on top of this change, which I will do once this lands.

- [x] I manually tested these changes locally
- [ ] Automated tests added/updated, or explained why not below

No test added: this is a workflow-level flag with no unit-testable surface, and the assertion that would prove it lives in CI itself.

## Review

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

- **Cross-platform**: the marker is written for all six relay targets plus the WSL hook relay, so all were affected equally; the fix covers all of them.
- **Security**: `out/` is build output only; no credentials or dotfile secrets exist there. The flag widens the artifact to hidden files under a build directory, nothing else.
- **Performance**: adds a handful of tiny files to a 41 MB artifact.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @BrennanKB5
