### PR TITLE
fix(agent-hooks): stop backgrounded Claude sessions posting a stale pane key (STA-4769)

### DIFF
--- a/src/main/claude/hook-service.test.ts
+++ b/src/main/claude/hook-service.test.ts
@@ -444,6 +444,44 @@ describe('backgrounded-session pane guard (#9236)', () => {
     expect(script.indexOf('printf "{}\\n"')).toBeLessThan(script.indexOf('CLAUDE_JOB_DIR'))
   })
 
+  // Why not skipped as unreachable: a backgrounded session's statusline IS invoked, inside the
+  // worker (ancestry terminates at the daemon, never at a pane), carrying the same stale key.
+  it('guards the statusline too, on both branches', () => {
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')!
+    for (const target of ['darwin', 'win32'] as const) {
+      const tmpHome = mkdtempSync(join(tmpdir(), `orca-claude-sl-${target}-`))
+      Object.defineProperty(process, 'platform', { value: target, configurable: true })
+      vi.stubEnv('HOME', tmpHome)
+      vi.stubEnv('USERPROFILE', tmpHome)
+      try {
+        expect(new ClaudeHookService().install().state).toBe('installed')
+        const script = readFileSync(
+          join(
+            tmpHome,
+            '.orca',
+            'agent-hooks',
+            target === 'win32' ? 'claude-statusline.cmd' : 'claude-statusline.sh'
+          ),
+          'utf-8'
+        )
+        const guard = script
+          .split(target === 'win32' ? '\r\n' : '\n')
+          .find((line) => line.includes('CLAUDE_JOB_DIR'))
+        expect(guard).toBeDefined()
+        // Why: the guard is worthless if it runs after the post it is meant to prevent.
+        expect(script.indexOf('CLAUDE_JOB_DIR')).toBeLessThan(script.indexOf('curl'))
+        if (target === 'win32') {
+          // Why: a worker is outside an Orca pane, where reading stdin to EOF never returns (#11549).
+          expect(guard).not.toContain(WINDOWS_HOOK_STDIN_DRAIN_LABEL)
+        }
+      } finally {
+        Object.defineProperty(process, 'platform', platform)
+        vi.unstubAllEnvs()
+        rmSync(tmpHome, { recursive: true, force: true })
+      }
+    }
+  })
+
   it('exits rather than draining stdin on Windows, where a worker has no Orca pane', () => {
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')!
     const tmpHome = mkdtempSync(join(tmpdir(), 'orca-claude-bg-'))

--- a/src/main/claude/hook-service.test.ts
+++ b/src/main/claude/hook-service.test.ts
@@ -16,6 +16,7 @@ vi.mock('electron', () => ({
 
 import type { SFTPWrapper } from 'ssh2'
 import { createManagedCommandMatcher } from '../agent-hooks/installer-utils'
+import { WINDOWS_HOOK_STDIN_DRAIN_LABEL } from '../agent-hooks/hook-stdin-contract'
 import { ClaudeHookService } from './hook-service'
 import { getWindowsManagedLifecycleHook, OPENCLAUDE_HOOK_SETTINGS } from './hook-settings'
 
@@ -424,6 +425,45 @@ describe('ClaudeHookService.install', () => {
       }
     }
   )
+})
+
+describe('backgrounded-session pane guard (#9236)', () => {
+  // Why: a `--bg` / `/background` worker runs under the shared daemon and inherits the
+  // env of whichever pane started that daemon, so ORCA_PANE_KEY names a pane the session
+  // does not run in. CLAUDE_JOB_DIR is set only in those workers, so it is the signal to
+  // decline rather than post a pane identity the worker cannot prove is current.
+  it('declines to post from a daemon worker, before spawning curl', async () => {
+    const { sftp, fs } = createFakeSftp()
+    expect((await new ClaudeHookService().installRemote(sftp, '/home/dev')).state).toBe('installed')
+    const script = fs.files.get('/home/dev/.orca/agent-hooks/claude-hook.sh')!
+
+    expect(script).toContain('if [ -n "$CLAUDE_JOB_DIR" ]; then')
+    // Why: the guard is worthless if it runs after the post it is meant to prevent.
+    expect(script.indexOf('CLAUDE_JOB_DIR')).toBeLessThan(script.indexOf('curl'))
+    // Why: neutral JSON still has to reach a permission hook that fails closed (#14818).
+    expect(script.indexOf('printf "{}\\n"')).toBeLessThan(script.indexOf('CLAUDE_JOB_DIR'))
+  })
+
+  it('exits rather than draining stdin on Windows, where a worker has no Orca pane', () => {
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')!
+    const tmpHome = mkdtempSync(join(tmpdir(), 'orca-claude-bg-'))
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    vi.stubEnv('HOME', tmpHome)
+    vi.stubEnv('USERPROFILE', tmpHome)
+    try {
+      expect(new ClaudeHookService().install().state).toBe('installed')
+      const script = readFileSync(join(tmpHome, '.orca', 'agent-hooks', 'claude-hook.cmd'), 'utf-8')
+      const guard = script.split('\r\n').find((line) => line.includes('CLAUDE_JOB_DIR'))
+      expect(guard).toBe('if not "%CLAUDE_JOB_DIR%"=="" exit /b 0')
+      // Why: the drain parks in more.com, and a daemon worker is exactly the
+      // abandoned-stdin case #11549 guards against — it must never route there.
+      expect(guard).not.toContain(WINDOWS_HOOK_STDIN_DRAIN_LABEL)
+    } finally {
+      Object.defineProperty(process, 'platform', platform)
+      vi.unstubAllEnvs()
+      rmSync(tmpHome, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('ClaudeHookService.installRemote', () => {

--- a/src/main/claude/hook-service.ts
+++ b/src/main/claude/hook-service.ts
@@ -72,6 +72,11 @@ function getManagedScript(
       // Why (#11549): the env guards must outrank the Devin skip — the Devin skip parks in more.com,
       // and outside an Orca pane the caller can abandon stdin, so more.com never returns.
       ...buildWindowsHookEnvironmentGuardLines(),
+      // Why: a backgrounded session runs in a daemon worker that inherited the dispatching
+      // pane's env, so ORCA_PANE_KEY names a pane this session does not run in (#9236).
+      // Why exit, not the drain label: the drain parks in more.com and a worker is outside
+      // an Orca pane — the abandoned-stdin hang #11549 guards against.
+      'if not "%CLAUDE_JOB_DIR%"=="" exit /b 0',
       ...(options.skipWhenDevinImportsClaude
         ? [
             // Why: Devin imports .claude hooks by default; skip Orca's managed hook there so status posts stay attributed to Devin.
@@ -99,6 +104,11 @@ function getManagedScript(
           'fi'
         ]
       : []),
+    // Why: a backgrounded session runs in a daemon worker that inherited the dispatching
+    // pane's env, so ORCA_PANE_KEY names a pane this session does not run in (#9236).
+    'if [ -n "$CLAUDE_JOB_DIR" ]; then',
+    '  exit 0',
+    'fi',
     // Why: refresh endpoint coordinates for PTYs surviving an Orca restart.
     // Why: suppress parse errors so they neither leak nor trip outer set -e.
     'if [ -n "$ORCA_AGENT_HOOK_ENDPOINT" ] && [ -r "$ORCA_AGENT_HOOK_ENDPOINT" ]; then',

--- a/src/main/claude/statusline-script.ts
+++ b/src/main/claude/statusline-script.ts
@@ -19,6 +19,11 @@ export function getManagedStatusLineScript(target: 'local' | 'posix' = 'local'):
     return [
       '@echo off',
       'setlocal',
+      // Why: a backgrounded session's statusline runs in a daemon worker that inherited the
+      // dispatching pane's env, so ORCA_PANE_KEY names a pane it does not run in (#9236).
+      // Why exit, not the drain label: a worker is outside an Orca pane, so reading stdin to
+      // EOF can block forever (#11549). This gates before stdin is owned, per that contract.
+      'if not "%CLAUDE_JOB_DIR%"=="" exit /b 0',
       // Why: pane key is static PTY env (the endpoint file never sets it), so it can gate before stdin is consumed.
       `if "%ORCA_PANE_KEY%"=="" goto :${WINDOWS_HOOK_STDIN_DRAIN_LABEL}`,
       // Why: current keys end in a UUID; replacing the legacy delimiter also keeps surviving numeric-pane keys filename-safe.
@@ -86,6 +91,12 @@ export function getManagedStatusLineScript(target: 'local' | 'posix' = 'local'):
     'done',
     'payload=${payload%?}',
     'if [ -z "$payload" ]; then',
+    '  exit 0',
+    'fi',
+    // Why: a backgrounded session's statusline runs in a daemon worker that inherited the
+    // dispatching pane's env, so ORCA_PANE_KEY names a pane it does not run in (#9236).
+    // Placed after capture: POSIX hooks own stdin first, or the agent sees EPIPE (#8110).
+    'if [ -n "$CLAUDE_JOB_DIR" ]; then',
     '  exit 0',
     'fi',
     // Why: rate_limits appears only for Claude.ai-subscriber sessions after the first API response; skip the post (and its curl spawn) otherwise.


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​78 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​78 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​21 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​21 |

<!-- /orca-pr-loc -->

## ELI5

If you background a Claude session, it runs inside a shared helper process that was started by whatever terminal happened to use it first. That helper hands the session the *first* terminal's identity, so the backgrounded session's status lands on a stranger's sidebar row and keeps overwriting it. This teaches the hook to notice it's in that situation and stay quiet, because a backgrounded session doesn't belong to any pane.

## What Changed

One guard in the Claude managed hook script, both branches of `src/main/claude/hook-service.ts`: if `CLAUDE_JOB_DIR` is set, exit without posting.

## Why

A session started with `claude --bg` or `/background` runs in a worker under the shared daemon. That worker inherits the environment of whichever pane first started the daemon — **not** the pane that dispatched it. Reproduced in an isolated `CLAUDE_CONFIG_DIR`:

```
pid 60709  (worker running the session dispatched from pane B)
  ORCA_PANE_KEY=PANE-A-AAAA      <- pane B's session, pane A's key
```

Process tree is `claude daemon run` (ppid 1) → `bg-pty-host` → worker, detached from every pane's PTY. It also inherits pane A's `ORCA_WORKTREE_ID`, so events file under the wrong workspace too.

**Captured on the wire**, not inferred — three sessions on one daemon, posting to a throwaway listener:

| session | dispatched from | posted |
|---|---|---|
| `5b0c7d88` | pane A (started the daemon) | `paneKey=BG-PANE-A wt=WT-A` ✓ |
| `de34110c` | pane B | `paneKey=BG-PANE-A wt=WT-A` ✗ |
| `9bdb77f8` | non-daemon | `paneKey=FG-PANE-Z wt=WT-Z` ✓ |

Arm B's `SessionStart`, `UserPromptSubmit` and `Stop` all posted pane A's identity. That is the reported symptom: two sessions collapsing onto one row across different worktrees.

**It fails silently and successfully.** The script re-sources `$ORCA_AGENT_HOOK_ENDPOINT`, so port and token self-heal and the POST lands — while the pane key has no refresh path and stays wrong. Nothing errors anywhere.

### Why `CLAUDE_JOB_DIR`, and why not the alternatives

Five discriminators were measured on a real rig. Four are unusable:

| candidate | discriminates? | cost/event | Windows |
|---|---|---|---|
| **`CLAUDE_JOB_DIR`** | **yes**, measured both ways | **0 subprocesses** | **works** |
| ancestry walk | yes | ~9 ms, 2 spawns | dead — no `ps` |
| POSIX session id | yes, structurally | ~38 ms on macOS | dead — no `ps` |
| controlling tty | **no** — foreground reads `??` too | — | — |
| hook payload field | **no** — field-for-field identical | — | — |

The payload was diffed field by field between a backgrounded and a non-daemon session: `cwd`, `hook_event_name`, `permission_mode`, `prompt` identical; `transcript_path` differs only in the session-id filename component, both under the ordinary `projects/<encoded-cwd>/` directory. **Fields present only in one: none.** So there is nothing to key on at ingest without a script change.

`CLAUDE_JOB_DIR` is present in the worker, absent from the foreground — and independently confirmed absent from **all 68 live Claude sessions** on this machine. It costs one shell variable test.

### Why decline rather than post without a pane key

There is no third option. `normalizeHookPayload` (`src/shared/agent-hook-listener.ts:4404`) rejects an empty or absent `paneKey` outright, and `AgentHookEventPayload.paneKey` is a required `string` — there is no "session exists but has no pane" representation. Posting with the key omitted is identical in effect to declining, minus a wasted round trip per event. A backgrounded session genuinely has no pane; attributing it to nothing is correct, and attributing it to a stranger is the bug.

The shape already exists one branch above: the `DEVIN_PROJECT_DIR` early-`exit 0`.

### The Windows placement is deliberate

The guard sits with the environment guards and uses `exit /b 0` rather than jumping to the stdin-drain label. The drain parks in `more.com`, and the comment at that site records why the env guards must outrank the Devin skip: "outside an Orca pane the caller can abandon stdin, so more.com never returns." A daemon worker is outside an Orca pane by definition — precisely the #11549 hang. Backgrounded sessions on Windows use the same daemon architecture over named pipes, so this branch is load-bearing, not theoretical.

## Linked Issue

Fixes #9236
Closes STA-4769 — that ticket asks to "reland the intended background-session fix" from #14615. There is nothing to reland: #14615 was foreground-only, built on a daemon premise that does not reproduce, and had no background-session handling. This PR is that fix, written from the mechanism that does reproduce.

Note that #9236's stated mechanism — that Claude Code hosts *foreground TUI* sessions under a shared daemon — does not reproduce. Foreground panes are direct children of their own pane's shell with a correct pane key (68 distinct keys, zero collisions across the live fleet). The reporter observed a real failure and generalised the mechanism too far. #15295 reverts the fix built on that premise; this PR fixes the mechanism that actually reproduces.

## Visual Proof

`N/A` — the visible effect is the *absence* of a spurious status row. A before/after would be a sidebar row that stops being overwritten by an unrelated session, which cannot be captured meaningfully in a still. The wire capture above is the evidence.

## Testing

Two tests added, both proven to observe their own failure — removing the guards turns both red, restoring them turns both green:

- `declines to post from a daemon worker, before spawning curl` — asserts the guard exists **and** precedes the `curl` it is meant to prevent, **and** that neutral JSON is still emitted first for permission hooks that fail closed (#14818). Ordering is the whole point; a guard after the post is worthless.
- `exits rather than draining stdin on Windows, where a worker has no Orca pane` — pins the exact `exit /b 0` form and asserts it does **not** route to the drain label.

The Windows test stubs `process.platform` so it **actually executes** rather than being `skipIf`-gated like the file's other Windows assertions. Those skip on Linux CI and would never have run.

Gates: `pnpm typecheck` exit 0; `vitest` over `src/main/claude` + `src/main/agent-hooks` — **96 files, 927 passed**, 7 skipped; `oxfmt --check` clean on both changed files.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

- **Cross-platform**: both script branches covered. macOS/Linux via the POSIX script, Windows via the `.cmd`. No `ps` dependency, which is what ruled out the alternatives.
- **Remote SSH**: closed for free — the hook script runs on the host that owns the PTY, so the variable is set by the same process on the same host. No wire change.
- **Backwards compatibility**: no wire, schema, or persisted-state change. Behaviour for foreground panes is byte-identical.
- **Performance**: one shell variable test; strictly less work when it fires.
- **Known limitation**: the guard depends on an upstream variable name. If it were renamed the guard would silently stop working — but it **fails open**, back to today's behaviour, never worse. An upstream request for a payload-level `jobId`/`kind` would retire the dependency; drafted separately.
- **`statusline-script.ts` is guarded too** — I had assumed a status line was a TUI concern and therefore unreachable for a backgrounded session. That was wrong, and measuring it corrected me. It *is* invoked inside the worker, with no client ever attached, and its ancestry terminates at the daemon rather than at any pane:

  ```
  statusline pid=41746 <- claude bg-spare <- claude bg-pty-host <- claude daemon
  CLAUDE_JOB_DIR=/tmp/.../jobs/f1f9edd2
  ```

  A second session dispatched from a different pane saw the *first* pane's `ORCA_PANE_KEY` alongside its own correct session id — so this file was a live second producer of the same bug. Same guard, same placement reasoning: `exit /b 0` before stdin is owned on Windows, after capture on POSIX (exiting mid-write there surfaces as EPIPE the agent can see, #8110).
- **Pre-existing, deliberately not touched**: the statusline's own `ORCA_PANE_KEY` gate jumps to the stdin-drain label, which by the #11549 contract is the shape to avoid for a guard meaning "no Orca pane". That predates this PR and changing it belongs in its own change.
- **Adjacent weakness, not fixed here**: `server.ts:2170` takes `worktreeId` straight from the post with no validation, while `tabId` two lines above *is* derived from the parsed pane key. The same asymmetry exists in `normalizeHookBodyPaneKeyAlias`, which rewrites `paneKey` and `tabId` to the current owner and leaves `worktreeId` as posted. This guard removes the *proven* producer of a wrong `worktreeId`; I could **not** prove the alias path can cross worktrees, so I'd call the remainder a consistency fix on principle rather than a confirmed live bug. Worth its own small change, not urgent.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @BrennanKB5


