### PR TITLE
fix(terminal): bound the aggregated PTY error surface so recurring near-duplicate errors can't grow it without limit

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-error-accumulation.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-error-accumulation.test.ts
@@ -75,6 +75,14 @@ describe('appendTerminalErrorMessage', () => {
     expect(accumulated).not.toContain('14:32:00.')
   })
 
+  it('#15241: bounds a single oversized first message, not just repeated appends', () => {
+    const oversizedFirstMessage = Array.from({ length: 30 }, (_, i) => `line ${i}`).join('\n')
+    const accumulated = appendTerminalErrorMessage(null, oversizedFirstMessage)
+    expect(accumulated.split('\n').length).toBe(20)
+    expect(accumulated).toContain('line 29')
+    expect(accumulated).not.toContain('line 9\n')
+  })
+
   it('#15241: keeps only the most recent lines once the cap is exceeded', () => {
     let accumulated: string | null = null
     for (let i = 0; i < 25; i++) {

--- a/src/renderer/src/components/terminal-pane/terminal-error-accumulation.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-error-accumulation.test.ts
@@ -60,6 +60,29 @@ describe('appendTerminalErrorMessage', () => {
     )
   })
 
+  it('#15241: bounds growth when a recurring error carries a changing timestamp', () => {
+    let accumulated: string | null = null
+    for (let i = 0; i < 500; i++) {
+      accumulated = appendTerminalErrorMessage(
+        accumulated,
+        `Remote terminal write failed at 14:32:${String(i).padStart(2, '0')}.`
+      )
+    }
+    // Why: none of these 500 messages are exact repeats (the timestamp differs each time),
+    // so containsWholeLineRun never matches — without a cap this grows to 500 lines/~21KB.
+    expect(accumulated?.split('\n').length).toBe(20)
+    expect(accumulated).toContain('14:32:499')
+    expect(accumulated).not.toContain('14:32:00.')
+  })
+
+  it('#15241: keeps only the most recent lines once the cap is exceeded', () => {
+    let accumulated: string | null = null
+    for (let i = 0; i < 25; i++) {
+      accumulated = appendTerminalErrorMessage(accumulated, `error ${i}`)
+    }
+    expect(accumulated).toBe(Array.from({ length: 20 }, (_, i) => `error ${i + 5}`).join('\n'))
+  })
+
   it('stays a newline-joined string the toast can still filter per line', () => {
     const accumulated = appendTerminalErrorMessage(
       appendTerminalErrorMessage(null, 'SSH connection failed: host unreachable'),

--- a/src/renderer/src/components/terminal-pane/terminal-error-accumulation.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-error-accumulation.ts
@@ -13,10 +13,31 @@ function containsWholeLineRun(accumulated: string, message: string): boolean {
   )
 }
 
-/** Appends an error to the aggregated surface, keeping the first occurrence of an already-present message. */
+// Why (#15241): a recurring error that differs slightly each time (embedded timestamp, port,
+// attempt count) never matches containsWholeLineRun's exact-content check, so it kept
+// appending forever — a real ~3.4GB renderer leak from one flaky/reconnecting transport.
+// Bound the surface to the most recent lines so both the string size and the cost of each
+// `${accumulated}\n${message}` copy stay O(MAX_ACCUMULATED_LINES) instead of O(n)/O(n²).
+const MAX_ACCUMULATED_LINES = 20
+
+function truncateToMostRecentLines(value: string): string {
+  const lines = value.split('\n')
+  return lines.length > MAX_ACCUMULATED_LINES
+    ? lines.slice(lines.length - MAX_ACCUMULATED_LINES).join('\n')
+    : value
+}
+
+/**
+ * Appends an error to the aggregated surface, keeping the first occurrence of an
+ * already-present message. Bounded to the most recent MAX_ACCUMULATED_LINES lines so a
+ * recurring near-duplicate error (see #15241) can't grow the surface without bound.
+ */
 export function appendTerminalErrorMessage(accumulated: string | null, message: string): string {
   if (!accumulated) {
     return message
   }
-  return containsWholeLineRun(accumulated, message) ? accumulated : `${accumulated}\n${message}`
+  if (containsWholeLineRun(accumulated, message)) {
+    return accumulated
+  }
+  return truncateToMostRecentLines(`${accumulated}\n${message}`)
 }

--- a/src/renderer/src/components/terminal-pane/terminal-error-accumulation.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-error-accumulation.ts
@@ -34,7 +34,7 @@ function truncateToMostRecentLines(value: string): string {
  */
 export function appendTerminalErrorMessage(accumulated: string | null, message: string): string {
   if (!accumulated) {
-    return message
+    return truncateToMostRecentLines(message)
   }
   if (containsWholeLineRun(accumulated, message)) {
     return accumulated


### PR DESCRIPTION
## ELI5

A terminal pane on a flaky connection (like a reconnecting SSH link) keeps surfacing the "same" error over and over, but each occurrence differs slightly (timestamp, port, attempt count). Orca was appending every one of these forever instead of capping them, so a long-lived pane on a bad connection could grow its error string — and the memory/CPU behind it — without limit.

## What Changed

`appendTerminalErrorMessage` (`terminal-error-accumulation.ts`) now bounds the aggregated error surface to the most recent 20 lines. Once exceeded, the oldest lines are dropped.

## Why

Traced from #15241. The existing dedup (`containsWholeLineRun`) only catches an **exact** repeat of a message. Real-world recurring errors (e.g. from a flaky transport) almost always carry a changing timestamp/port/attempt count, so they never match and the string grows by one line per occurrence forever. Each append is `${accumulated}\n${message}`, an O(n) copy, so the cost compounds to O(n²) over the pane's lifetime — matching the issue's report of sustained high CPU alongside multi-GB RSS growth from one long-lived pane.

Bounding to the most recent N lines fixes both: the string can't grow past a fixed size, and each append's copy cost is now O(1) relative to pane lifetime instead of O(n).

## Linked Issue

Fixes #15241 (partially — see Review)

## Visual Proof

N/A — internal string-accumulation logic, no UI change.

## Testing

- [ ] I manually tested these changes locally (no manual repro attempted — this is pure logic with a deterministic unit reproduction, see below)
- [x] Automated tests added/updated, or explained why not below

Added a regression test that appends 500 near-duplicate errors (only the timestamp differs) and confirms the surface is bounded to 20 lines and keeps the most recent ones. Without the fix this reproduces the unbounded growth exactly as reported (verified: 500 lines / ~21KB before this change). Added a second test confirming the surface keeps the most recent lines, not the oldest, once the cap is exceeded. Added a third test (from CodeRabbit's review) confirming a single oversized *first* message is also capped, not just repeated appends onto an existing surface. All existing dedup tests (exact repeat, multi-line repeat, per-line dedup) still pass unchanged. Ran the full `terminal-error-accumulation.test.ts` and `TerminalErrorToast.test.ts` suites (44 passed), `pnpm run typecheck`, and `oxlint` — all clean.

## AI Disclosure

This fix and its regression tests were developed with Claude (Anthropic) assistance: root-cause analysis, implementation, and test verification were done in an AI-assisted session, then reviewed before submission.

## Review

This PR addresses only root cause #1 from #15241 (unbounded PTY-error string growth), which the issue identifies as the broadest-applicability leak. Two other things the issue reported are **not** covered here, to keep this PR small and focused:
- Root cause #2: `waitForStableStartupGrid`'s tick loop can spin indefinitely via `requestAnimationFrame` when a readiness gate never resolves — a separate mechanism in `terminal-startup-grid-settle.ts` / `pty-connection.ts`.
- The secondary leak: `recoveryTimestampsByTabId` / `recoveryGenerationByTabId` in `terminal-pane-recovery.ts` are never cleared on tab close outside tests.

Happy to follow up with a second PR for either if useful.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A) — pure string logic, no OS-specific path
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — ran targeted lint/typecheck/test as above; did not run full `pnpm build`

