### PR TITLE
perf(browser): dispatch coordinate pointer input in process instead of one subprocess per event

### DIFF
--- a/src/main/browser/agent-browser-bridge-command-transport.test.ts
+++ b/src/main/browser/agent-browser-bridge-command-transport.test.ts
@@ -116,12 +116,11 @@ describe('AgentBrowserBridge', () => {
     expect((snapshotCall![1] as string[])[cdpIdx + 1]).toBe('9222')
 
     await bridge.click('@e1')
-    await bridge.mouseMove(10, 20)
     await bridge.setOffline('on')
     await bridge.consoleLog()
     await bridge.exec('get title')
 
-    for (const command of ['click', 'mouse', 'set', 'console', 'get']) {
+    for (const command of ['click', 'set', 'console', 'get']) {
       const call = execFileMock.mock.calls.find((candidate: unknown[]) =>
         (candidate[1] as string[]).includes(command)
       )

--- a/src/main/browser/agent-browser-bridge-pointer-input.test.ts
+++ b/src/main/browser/agent-browser-bridge-pointer-input.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const { execFileMock, webContentsFromIdMock, existsSyncMock, readFileSyncMock, stdinWrites } =
+  vi.hoisted(() => ({
+    execFileMock: vi.fn(),
+    webContentsFromIdMock: vi.fn(),
+    existsSyncMock: vi.fn(() => false),
+    readFileSyncMock: vi.fn(() => Buffer.from('')),
+    stdinWrites: [] as string[]
+  }))
+
+vi.mock('child_process', () => ({ execFile: execFileMock }))
+vi.mock('fs', () => ({
+  existsSync: existsSyncMock,
+  readFileSync: readFileSyncMock,
+  accessSync: vi.fn(),
+  chmodSync: vi.fn(),
+  constants: { X_OK: 1 }
+}))
+vi.mock('os', () => ({ platform: () => 'darwin', arch: () => 'arm64' }))
+vi.mock('electron', () => {
+  return {
+    app: { getPath: vi.fn(() => '/app'), getAppPath: vi.fn(() => '/project'), isPackaged: false },
+    webContents: { fromId: webContentsFromIdMock }
+  }
+})
+const { CdpWsProxyMock } = vi.hoisted(() => {
+  const instances: unknown[] = []
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const MockClass = vi.fn().mockImplementation(function (this: any, _wc: unknown) {
+    this._wc = _wc
+    this.start = vi.fn(async () => 'ws://127.0.0.1:9222')
+    this.stop = vi.fn(async () => {})
+    this.getPort = vi.fn(() => 9222)
+    instances.push(this)
+  })
+  return { CdpWsProxyMock: Object.assign(MockClass, { instances }) }
+})
+
+vi.mock('./cdp-ws-proxy', () => ({
+  CdpWsProxy: CdpWsProxyMock
+}))
+
+import { AgentBrowserBridge } from './agent-browser-bridge'
+import {
+  mockBrowserManager,
+  mockWebContents,
+  overrideBridgeWebContentsLookup,
+  resetAgentBrowserBridgeMocks,
+  type MockWebContents
+} from './agent-browser-bridge-test-harness'
+
+overrideBridgeWebContentsLookup(AgentBrowserBridge.prototype, webContentsFromIdMock)
+
+function mouseEventCalls(wc: MockWebContents): [string, Record<string, unknown>][] {
+  return wc.debugger.sendCommand.mock.calls.filter(
+    (call) => call[0] === 'Input.dispatchMouseEvent'
+  ) as [string, Record<string, unknown>][]
+}
+
+async function flushPendingDispatch(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe('AgentBrowserBridge pointer input', () => {
+  let bridge: AgentBrowserBridge
+  let wc: MockWebContents
+
+  beforeEach(() => {
+    resetAgentBrowserBridgeMocks({
+      webContentsFromIdMock,
+      existsSyncMock,
+      readFileSyncMock,
+      stdinWrites,
+      cdpWsProxyInstances: CdpWsProxyMock.instances
+    })
+    bridge = new AgentBrowserBridge(mockBrowserManager())
+    bridge.setActiveTab(100)
+    wc = mockWebContents(100)
+    wc.debugger.sendCommand.mockResolvedValue({})
+    webContentsFromIdMock.mockImplementation((id: number) => (id === 100 ? wc : null))
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.useRealTimers()
+  })
+
+  it('dispatches mouse moves over CDP without spawning agent-browser', async () => {
+    await expect(bridge.mouseMove(10, 20, undefined, 'tab-1')).resolves.toEqual({ moved: true })
+
+    expect(execFileMock).not.toHaveBeenCalled()
+    expect(mouseEventCalls(wc)).toEqual([
+      ['Input.dispatchMouseEvent', { type: 'mouseMoved', x: 10, y: 20, button: 'none', buttons: 0 }]
+    ])
+  })
+
+  it('presses at the position of the preceding mouse move', async () => {
+    await bridge.mouseMove(10, 20, undefined, 'tab-1')
+    await expect(bridge.mouseDown('left', undefined, 'tab-1')).resolves.toEqual({ pressed: true })
+
+    expect(wc.focus).toHaveBeenCalled()
+    expect(mouseEventCalls(wc)[1]?.[1]).toEqual({
+      type: 'mousePressed',
+      x: 10,
+      y: 20,
+      button: 'left',
+      buttons: 1,
+      clickCount: 1
+    })
+  })
+
+  it('releases the held button and clears it from the buttons mask', async () => {
+    await bridge.mouseMove(10, 20, undefined, 'tab-1')
+    await bridge.mouseDown('left', undefined, 'tab-1')
+    await expect(bridge.mouseUp(undefined, undefined, 'tab-1')).resolves.toEqual({
+      released: true
+    })
+
+    expect(mouseEventCalls(wc)[2]?.[1]).toEqual({
+      type: 'mouseReleased',
+      x: 10,
+      y: 20,
+      button: 'left',
+      buttons: 0,
+      clickCount: 1
+    })
+  })
+
+  it('reports a second click at the same point inside the interval as clickCount 2', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+
+    await bridge.mouseMove(10, 20, undefined, 'tab-1')
+    await bridge.mouseDown('left', undefined, 'tab-1')
+    await bridge.mouseUp('left', undefined, 'tab-1')
+    vi.setSystemTime(1_200)
+    await bridge.mouseDown('left', undefined, 'tab-1')
+    await bridge.mouseUp('left', undefined, 'tab-1')
+
+    const presses = mouseEventCalls(wc).filter((call) => call[1].type === 'mousePressed')
+    expect(presses[0]?.[1]).toMatchObject({ clickCount: 1 })
+    expect(presses[1]?.[1]).toMatchObject({ clickCount: 2 })
+    const releases = mouseEventCalls(wc).filter((call) => call[1].type === 'mouseReleased')
+    expect(releases[1]?.[1]).toMatchObject({ clickCount: 2 })
+  })
+
+  it('resets the click count when the pointer moved away or the interval elapsed', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+
+    await bridge.mouseMove(10, 20, undefined, 'tab-1')
+    await bridge.mouseDown('left', undefined, 'tab-1')
+    await bridge.mouseUp('left', undefined, 'tab-1')
+    await bridge.mouseMove(200, 20, undefined, 'tab-1')
+    await bridge.mouseDown('left', undefined, 'tab-1')
+    await bridge.mouseUp('left', undefined, 'tab-1')
+    vi.setSystemTime(2_000)
+    await bridge.mouseDown('left', undefined, 'tab-1')
+
+    const presses = mouseEventCalls(wc).filter((call) => call[1].type === 'mousePressed')
+    expect(presses.map((call) => call[1].clickCount)).toEqual([1, 1, 1])
+  })
+
+  it('dispatches wheel deltas at the tracked pointer position', async () => {
+    await bridge.mouseMove(50, 60, undefined, 'tab-1')
+    await expect(bridge.mouseWheel(120, 5, undefined, 'tab-1')).resolves.toEqual({
+      scrolled: true,
+      deltaX: 5,
+      deltaY: 120
+    })
+
+    expect(execFileMock).not.toHaveBeenCalled()
+    expect(mouseEventCalls(wc)[1]?.[1]).toEqual({
+      type: 'mouseWheel',
+      x: 50,
+      y: 60,
+      deltaX: 5,
+      deltaY: 120,
+      buttons: 0
+    })
+  })
+
+  it('passes back and forward buttons through instead of coercing them to left', async () => {
+    await bridge.mouseDown('back', undefined, 'tab-1')
+    await bridge.mouseUp('back', undefined, 'tab-1')
+
+    expect(mouseEventCalls(wc)[0]?.[1]).toMatchObject({
+      type: 'mousePressed',
+      button: 'back',
+      buttons: 8
+    })
+    expect(mouseEventCalls(wc)[1]?.[1]).toMatchObject({
+      type: 'mouseReleased',
+      button: 'back',
+      buttons: 0
+    })
+  })
+
+  it('rejects non-finite coordinates and deltas instead of dispatching them', async () => {
+    await expect(bridge.mouseMove(Number.NaN, 20, undefined, 'tab-1')).rejects.toMatchObject({
+      code: 'browser_error'
+    })
+    await expect(bridge.mouseWheel(Infinity, 0, undefined, 'tab-1')).rejects.toMatchObject({
+      code: 'browser_error'
+    })
+    expect(mouseEventCalls(wc)).toHaveLength(0)
+  })
+
+  it('surfaces an un-awaited dispatch failure on the next pointer event', async () => {
+    wc.debugger.sendCommand.mockRejectedValueOnce(new Error('target crashed'))
+
+    await expect(bridge.mouseMove(10, 20, undefined, 'tab-1')).resolves.toEqual({ moved: true })
+    await flushPendingDispatch()
+
+    await expect(bridge.mouseMove(11, 21, undefined, 'tab-1')).rejects.toMatchObject({
+      code: 'browser_error',
+      message: expect.stringContaining('target crashed')
+    })
+    await expect(bridge.mouseMove(12, 22, undefined, 'tab-1')).resolves.toEqual({ moved: true })
+  })
+
+  it('awaits the renderer ack and rejects in place when ORCA_BROWSER_INPUT_AWAIT_ACK=1', async () => {
+    vi.stubEnv('ORCA_BROWSER_INPUT_AWAIT_ACK', '1')
+    wc.debugger.sendCommand.mockRejectedValueOnce(new Error('target crashed'))
+
+    await expect(bridge.mouseMove(10, 20, undefined, 'tab-1')).rejects.toThrow('target crashed')
+  })
+
+  it('tracks pointer position per tab', async () => {
+    const otherWc = mockWebContents(101)
+    otherWc.debugger.sendCommand.mockResolvedValue({})
+    webContentsFromIdMock.mockImplementation((id: number) =>
+      id === 100 ? wc : id === 101 ? otherWc : null
+    )
+    bridge = new AgentBrowserBridge(
+      mockBrowserManager(
+        new Map([
+          ['tab-1', 100],
+          ['tab-2', 101]
+        ])
+      )
+    )
+
+    await bridge.mouseMove(10, 20, undefined, 'tab-1')
+    await bridge.mouseMove(30, 40, undefined, 'tab-2')
+    await bridge.mouseDown('left', undefined, 'tab-1')
+
+    const press = mouseEventCalls(wc).find((call) => call[1].type === 'mousePressed')
+    expect(press?.[1]).toMatchObject({ x: 10, y: 20 })
+  })
+
+  it('releases the debugger lease only after an in-flight dispatch settles', async () => {
+    let attached = false
+    wc.debugger.isAttached.mockImplementation(() => attached)
+    wc.debugger.attach.mockImplementation(() => {
+      attached = true
+    })
+    wc.debugger.detach.mockImplementation(() => {
+      attached = false
+    })
+    let resolveDispatch!: () => void
+    wc.debugger.sendCommand.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveDispatch = resolve
+      })
+    )
+
+    await bridge.mouseMove(10, 20, undefined, 'tab-1')
+    expect(wc.debugger.detach).not.toHaveBeenCalled()
+
+    resolveDispatch()
+    await flushPendingDispatch()
+    expect(wc.debugger.detach).toHaveBeenCalled()
+  })
+
+  it('drops empty command queues after pointer dispatch finishes', async () => {
+    await bridge.mouseMove(10, 20, undefined, 'tab-1')
+
+    expect(
+      (bridge as unknown as { commandQueues: Map<string, unknown[]> }).commandQueues.size
+    ).toBe(0)
+    expect((bridge as unknown as { processingQueues: Set<string> }).processingQueues.size).toBe(0)
+  })
+})

--- a/src/main/browser/agent-browser-bridge-pointer-input.test.ts
+++ b/src/main/browser/agent-browser-bridge-pointer-input.test.ts
@@ -198,6 +198,62 @@ describe('AgentBrowserBridge pointer input', () => {
     })
   })
 
+  it('keeps the remaining held button active after a chorded release', async () => {
+    await bridge.mouseDown('left', undefined, 'tab-1')
+    await bridge.mouseDown('right', undefined, 'tab-1')
+    await bridge.mouseUp('left', undefined, 'tab-1')
+    await bridge.mouseUp(undefined, undefined, 'tab-1')
+
+    const releases = mouseEventCalls(wc).filter((call) => call[1].type === 'mouseReleased')
+    expect(releases[0]?.[1]).toMatchObject({ button: 'left', buttons: 2 })
+    expect(releases[1]?.[1]).toMatchObject({ button: 'right', buttons: 0 })
+  })
+
+  it('restores pointer state after an un-awaited press failure', async () => {
+    wc.debugger.sendCommand.mockRejectedValueOnce(new Error('target crashed'))
+
+    await bridge.mouseDown('left', undefined, 'tab-1')
+    await flushPendingDispatch()
+    await expect(bridge.mouseDown('left', undefined, 'tab-1')).rejects.toMatchObject({
+      code: 'browser_error'
+    })
+    await bridge.mouseMove(10, 20, undefined, 'tab-1')
+
+    expect(mouseEventCalls(wc).at(-1)?.[1]).toMatchObject({
+      type: 'mouseMoved',
+      button: 'none',
+      buttons: 0
+    })
+  })
+
+  it('lets a release retry succeed after an un-awaited release failure', async () => {
+    await bridge.mouseDown('left', undefined, 'tab-1')
+    wc.debugger.sendCommand.mockRejectedValueOnce(new Error('target crashed'))
+    await bridge.mouseUp(undefined, undefined, 'tab-1')
+    await flushPendingDispatch()
+    await expect(bridge.mouseUp(undefined, undefined, 'tab-1')).rejects.toMatchObject({
+      code: 'browser_error'
+    })
+    await bridge.mouseUp(undefined, undefined, 'tab-1')
+
+    const releases = mouseEventCalls(wc).filter((call) => call[1].type === 'mouseReleased')
+    expect(releases.at(-1)?.[1]).toMatchObject({ button: 'left', buttons: 0 })
+  })
+
+  it('restores pointer state when an awaited dispatch rejects', async () => {
+    vi.stubEnv('ORCA_BROWSER_INPUT_AWAIT_ACK', '1')
+    wc.debugger.sendCommand.mockRejectedValueOnce(new Error('target crashed'))
+
+    await expect(bridge.mouseDown('left', undefined, 'tab-1')).rejects.toThrow('target crashed')
+    await bridge.mouseMove(10, 20, undefined, 'tab-1')
+
+    expect(mouseEventCalls(wc).at(-1)?.[1]).toMatchObject({
+      type: 'mouseMoved',
+      button: 'none',
+      buttons: 0
+    })
+  })
+
   it('rejects non-finite coordinates and deltas instead of dispatching them', async () => {
     await expect(bridge.mouseMove(Number.NaN, 20, undefined, 'tab-1')).rejects.toMatchObject({
       code: 'browser_error'

--- a/src/main/browser/agent-browser-bridge.ts
+++ b/src/main/browser/agent-browser-bridge.ts
@@ -9,11 +9,13 @@ import { captureFullPageScreenshot } from './cdp-screenshot'
 import { acquireElectronDebugger, type ElectronDebuggerLease } from './electron-debugger-lease'
 import {
   assertFinitePointerValues,
+  cdpPointerButtonFromMask,
   cdpPointerButtonMask,
   cdpPointerStateFor,
   dispatchCdpPointerEvent,
   normalizeCdpPointerButton,
   releaseLeaseAfterPointerDispatch,
+  snapshotCdpPointerState,
   trackCdpClickCount,
   type CdpPointerState
 } from './cdp-pointer-input'
@@ -1119,15 +1121,21 @@ export class AgentBrowserBridge {
         assertFinitePointerValues({ x, y })
         const { webContents: wc, state, lease } = this.resolvePointerDispatchTarget(target)
         try {
+          const revert = snapshotCdpPointerState(state)
           state.x = x
           state.y = y
-          await dispatchCdpPointerEvent(state, wc, {
-            type: 'mouseMoved',
-            x,
-            y,
-            button: state.button,
-            buttons: state.buttons
-          })
+          await dispatchCdpPointerEvent(
+            state,
+            wc,
+            {
+              type: 'mouseMoved',
+              x,
+              y,
+              button: state.button,
+              buttons: state.buttons
+            },
+            revert
+          )
           return { moved: true }
         } finally {
           releaseLeaseAfterPointerDispatch(state, lease)
@@ -1145,18 +1153,24 @@ export class AgentBrowserBridge {
         const { webContents: wc, state, lease } = this.resolvePointerDispatchTarget(target)
         try {
           wc.focus()
+          const revert = snapshotCdpPointerState(state)
           const cdpButton = normalizeCdpPointerButton(button)
           state.button = cdpButton
           state.buttons |= cdpPointerButtonMask(cdpButton)
           state.clickCount = trackCdpClickCount(state, cdpButton)
-          await dispatchCdpPointerEvent(state, wc, {
-            type: 'mousePressed',
-            x: state.x,
-            y: state.y,
-            button: cdpButton,
-            buttons: state.buttons,
-            clickCount: state.clickCount
-          })
+          await dispatchCdpPointerEvent(
+            state,
+            wc,
+            {
+              type: 'mousePressed',
+              x: state.x,
+              y: state.y,
+              button: cdpButton,
+              buttons: state.buttons,
+              clickCount: state.clickCount
+            },
+            revert
+          )
           return { pressed: true }
         } finally {
           releaseLeaseAfterPointerDispatch(state, lease)
@@ -1243,19 +1257,27 @@ export class AgentBrowserBridge {
       async (_sessionName, target) => {
         const { webContents: wc, state, lease } = this.resolvePointerDispatchTarget(target)
         try {
+          const revert = snapshotCdpPointerState(state)
           const cdpButton = normalizeCdpPointerButton(
             button ?? (state.button === 'none' ? undefined : state.button)
           )
           state.buttons &= ~cdpPointerButtonMask(cdpButton)
-          state.button = 'none'
-          await dispatchCdpPointerEvent(state, wc, {
-            type: 'mouseReleased',
-            x: state.x,
-            y: state.y,
-            button: cdpButton,
-            buttons: state.buttons,
-            clickCount: state.clickCount
-          })
+          // Why: a chorded release keeps the remaining held button addressable by a
+          // later unqualified mouseUp instead of defaulting back to left.
+          state.button = cdpPointerButtonFromMask(state.buttons)
+          await dispatchCdpPointerEvent(
+            state,
+            wc,
+            {
+              type: 'mouseReleased',
+              x: state.x,
+              y: state.y,
+              button: cdpButton,
+              buttons: state.buttons,
+              clickCount: state.clickCount
+            },
+            revert
+          )
           return { released: true }
         } finally {
           releaseLeaseAfterPointerDispatch(state, lease)
@@ -1281,14 +1303,19 @@ export class AgentBrowserBridge {
           const deltaX = dx ?? 0
           // Why: dispatch at the tracked pointer position so the scrollable under the
           // cursor scrolls; the subprocess path always dispatched wheel at (0,0).
-          await dispatchCdpPointerEvent(state, wc, {
-            type: 'mouseWheel',
-            x: state.x,
-            y: state.y,
-            deltaX,
-            deltaY: dy,
-            buttons: state.buttons
-          })
+          await dispatchCdpPointerEvent(
+            state,
+            wc,
+            {
+              type: 'mouseWheel',
+              x: state.x,
+              y: state.y,
+              deltaX,
+              deltaY: dy,
+              buttons: state.buttons
+            },
+            snapshotCdpPointerState(state)
+          )
           return { scrolled: true, deltaX, deltaY: dy }
         } finally {
           releaseLeaseAfterPointerDispatch(state, lease)

--- a/src/main/browser/agent-browser-bridge.ts
+++ b/src/main/browser/agent-browser-bridge.ts
@@ -6,7 +6,17 @@ import { platform, arch } from 'node:os'
 import { app, type WebContents } from 'electron'
 import { CdpWsProxy } from './cdp-ws-proxy'
 import { captureFullPageScreenshot } from './cdp-screenshot'
-import { acquireElectronDebugger } from './electron-debugger-lease'
+import { acquireElectronDebugger, type ElectronDebuggerLease } from './electron-debugger-lease'
+import {
+  assertFinitePointerValues,
+  cdpPointerButtonMask,
+  cdpPointerStateFor,
+  dispatchCdpPointerEvent,
+  normalizeCdpPointerButton,
+  releaseLeaseAfterPointerDispatch,
+  trackCdpClickCount,
+  type CdpPointerState
+} from './cdp-pointer-input'
 import type { BrowserManager } from './browser-manager'
 import { BrowserError } from './cdp-bridge'
 import type {
@@ -1079,25 +1089,81 @@ export class AgentBrowserBridge {
 
   // ── Mouse commands ──
 
+  // Why: coordinate pointer input needs no accessibility snapshot, so it dispatches over
+  // the Electron debugger directly instead of paying a subprocess spawn per event.
+  private resolvePointerDispatchTarget(target: ResolvedBrowserCommandTarget): {
+    webContents: Electron.WebContents
+    state: CdpPointerState
+    lease: ElectronDebuggerLease
+  } {
+    const wc = this.getWebContents(target.webContentsId)
+    if (!wc || wc.isDestroyed()) {
+      throw new BrowserError(
+        'browser_tab_not_found',
+        `Browser page ${target.browserPageId} is no longer available`
+      )
+    }
+    return { webContents: wc, state: cdpPointerStateFor(wc), lease: acquireElectronDebugger(wc) }
+  }
+
   async mouseMove(
     x: number,
     y: number,
     worktreeId?: string,
     browserPageId?: string
   ): Promise<unknown> {
-    return this.enqueueTargetedCommand(worktreeId, browserPageId, async (sessionName) => {
-      return await this.execAgentBrowser(sessionName, ['mouse', 'move', String(x), String(y)])
-    })
+    return this.enqueueTargetedCommand(
+      worktreeId,
+      browserPageId,
+      async (_sessionName, target) => {
+        assertFinitePointerValues({ x, y })
+        const { webContents: wc, state, lease } = this.resolvePointerDispatchTarget(target)
+        try {
+          state.x = x
+          state.y = y
+          await dispatchCdpPointerEvent(state, wc, {
+            type: 'mouseMoved',
+            x,
+            y,
+            button: state.button,
+            buttons: state.buttons
+          })
+          return { moved: true }
+        } finally {
+          releaseLeaseAfterPointerDispatch(state, lease)
+        }
+      },
+      { ensureSession: false }
+    )
   }
 
   async mouseDown(button?: string, worktreeId?: string, browserPageId?: string): Promise<unknown> {
-    return this.enqueueTargetedCommand(worktreeId, browserPageId, async (sessionName) => {
-      const args = ['mouse', 'down']
-      if (button) {
-        args.push(button)
-      }
-      return await this.execAgentBrowser(sessionName, args)
-    })
+    return this.enqueueTargetedCommand(
+      worktreeId,
+      browserPageId,
+      async (_sessionName, target) => {
+        const { webContents: wc, state, lease } = this.resolvePointerDispatchTarget(target)
+        try {
+          wc.focus()
+          const cdpButton = normalizeCdpPointerButton(button)
+          state.button = cdpButton
+          state.buttons |= cdpPointerButtonMask(cdpButton)
+          state.clickCount = trackCdpClickCount(state, cdpButton)
+          await dispatchCdpPointerEvent(state, wc, {
+            type: 'mousePressed',
+            x: state.x,
+            y: state.y,
+            button: cdpButton,
+            buttons: state.buttons,
+            clickCount: state.clickCount
+          })
+          return { pressed: true }
+        } finally {
+          releaseLeaseAfterPointerDispatch(state, lease)
+        }
+      },
+      { ensureSession: false }
+    )
   }
 
   async mouseClick(
@@ -1171,13 +1237,32 @@ export class AgentBrowserBridge {
   }
 
   async mouseUp(button?: string, worktreeId?: string, browserPageId?: string): Promise<unknown> {
-    return this.enqueueTargetedCommand(worktreeId, browserPageId, async (sessionName) => {
-      const args = ['mouse', 'up']
-      if (button) {
-        args.push(button)
-      }
-      return await this.execAgentBrowser(sessionName, args)
-    })
+    return this.enqueueTargetedCommand(
+      worktreeId,
+      browserPageId,
+      async (_sessionName, target) => {
+        const { webContents: wc, state, lease } = this.resolvePointerDispatchTarget(target)
+        try {
+          const cdpButton = normalizeCdpPointerButton(
+            button ?? (state.button === 'none' ? undefined : state.button)
+          )
+          state.buttons &= ~cdpPointerButtonMask(cdpButton)
+          state.button = 'none'
+          await dispatchCdpPointerEvent(state, wc, {
+            type: 'mouseReleased',
+            x: state.x,
+            y: state.y,
+            button: cdpButton,
+            buttons: state.buttons,
+            clickCount: state.clickCount
+          })
+          return { released: true }
+        } finally {
+          releaseLeaseAfterPointerDispatch(state, lease)
+        }
+      },
+      { ensureSession: false }
+    )
   }
 
   async mouseWheel(
@@ -1186,13 +1271,31 @@ export class AgentBrowserBridge {
     worktreeId?: string,
     browserPageId?: string
   ): Promise<unknown> {
-    return this.enqueueTargetedCommand(worktreeId, browserPageId, async (sessionName) => {
-      const args = ['mouse', 'wheel', String(dy)]
-      if (dx != null) {
-        args.push(String(dx))
-      }
-      return await this.execAgentBrowser(sessionName, args)
-    })
+    return this.enqueueTargetedCommand(
+      worktreeId,
+      browserPageId,
+      async (_sessionName, target) => {
+        assertFinitePointerValues({ dy, ...(dx == null ? {} : { dx }) })
+        const { webContents: wc, state, lease } = this.resolvePointerDispatchTarget(target)
+        try {
+          const deltaX = dx ?? 0
+          // Why: dispatch at the tracked pointer position so the scrollable under the
+          // cursor scrolls; the subprocess path always dispatched wheel at (0,0).
+          await dispatchCdpPointerEvent(state, wc, {
+            type: 'mouseWheel',
+            x: state.x,
+            y: state.y,
+            deltaX,
+            deltaY: dy,
+            buttons: state.buttons
+          })
+          return { scrolled: true, deltaX, deltaY: dy }
+        } finally {
+          releaseLeaseAfterPointerDispatch(state, lease)
+        }
+      },
+      { ensureSession: false }
+    )
   }
 
   // ── Find (semantic locators) ──

--- a/src/main/browser/cdp-pointer-input.ts
+++ b/src/main/browser/cdp-pointer-input.ts
@@ -37,6 +37,27 @@ export function cdpPointerButtonMask(button: CdpPointerButton): number {
   return 1
 }
 
+// Why: after releasing one of several held buttons, an unqualified mouseUp must keep
+// referring to a button that is actually still down instead of defaulting to left.
+export function cdpPointerButtonFromMask(buttons: number): 'none' | CdpPointerButton {
+  if ((buttons & 1) !== 0) {
+    return 'left'
+  }
+  if ((buttons & 2) !== 0) {
+    return 'right'
+  }
+  if ((buttons & 4) !== 0) {
+    return 'middle'
+  }
+  if ((buttons & 8) !== 0) {
+    return 'back'
+  }
+  if ((buttons & 16) !== 0) {
+    return 'forward'
+  }
+  return 'none'
+}
+
 type LastPointerClick = {
   button: CdpPointerButton
   x: number
@@ -76,6 +97,18 @@ export function cdpPointerStateFor(webContents: WebContents): CdpPointerState {
     pointerStates.set(webContents, state)
   }
   return state
+}
+
+export type CdpPointerSnapshot = Pick<
+  CdpPointerState,
+  'x' | 'y' | 'button' | 'buttons' | 'clickCount' | 'lastClick'
+>
+
+// Why: callers mutate pointer state before dispatching; a failed dispatch must put the
+// pre-dispatch state back or later events carry buttons that were never pressed.
+export function snapshotCdpPointerState(state: CdpPointerState): CdpPointerSnapshot {
+  const { x, y, button, buttons, clickCount, lastClick } = state
+  return { x, y, button, buttons, clickCount, lastClick }
 }
 
 // Why: a second press at the same spot inside the double-click interval must report the
@@ -122,21 +155,33 @@ export type CdpPointerEventParams = {
 export function dispatchCdpPointerEvent(
   state: CdpPointerState,
   webContents: WebContents,
-  params: CdpPointerEventParams
+  params: CdpPointerEventParams,
+  revert: CdpPointerSnapshot
 ): Promise<void> {
   const failure = state.lastError
   if (failure !== null) {
     state.lastError = null
+    // Why: this command's own mutations never dispatch either -- rewind them before
+    // surfacing the previous failure so a retry starts from reality.
+    Object.assign(state, revert)
     throw new BrowserError('browser_error', `The previous pointer event failed: ${failure}`)
   }
   const sent = webContents.debugger.sendCommand('Input.dispatchMouseEvent', params)
   if (awaitPointerAck()) {
-    return sent.then(() => undefined)
+    return sent.then(
+      () => undefined,
+      (error: unknown) => {
+        Object.assign(state, revert)
+        throw error
+      }
+    )
   }
   state.pending = sent.then(
     () => undefined,
     (error: unknown) => {
       state.lastError = error instanceof Error ? error.message : String(error)
+      // Why: the rejected command dispatched nothing, so the pre-dispatch state is reality.
+      Object.assign(state, revert)
     }
   )
   return Promise.resolve()

--- a/src/main/browser/cdp-pointer-input.ts
+++ b/src/main/browser/cdp-pointer-input.ts
@@ -1,0 +1,161 @@
+import type { WebContents } from 'electron'
+import { BrowserError } from './cdp-bridge'
+import type { ElectronDebuggerLease } from './electron-debugger-lease'
+
+// Why: restores await-the-renderer-ack for debugging — see dispatchCdpPointerEvent.
+function awaitPointerAck(): boolean {
+  return process.env.ORCA_BROWSER_INPUT_AWAIT_ACK === '1'
+}
+
+const MULTI_CLICK_INTERVAL_MS = 500
+const MULTI_CLICK_SLOP_PX = 2
+
+export type CdpPointerButton = 'left' | 'middle' | 'right' | 'back' | 'forward'
+
+// Why: unlike element clicks, coordinate down/up must carry X1/X2 buttons through — the
+// helper dispatched them as real back/forward presses, and coercing them to left would
+// click whatever sits under the pointer.
+export function normalizeCdpPointerButton(button?: string): CdpPointerButton {
+  return button === 'middle' || button === 'right' || button === 'back' || button === 'forward'
+    ? button
+    : 'left'
+}
+
+export function cdpPointerButtonMask(button: CdpPointerButton): number {
+  if (button === 'right') {
+    return 2
+  }
+  if (button === 'middle') {
+    return 4
+  }
+  if (button === 'back') {
+    return 8
+  }
+  if (button === 'forward') {
+    return 16
+  }
+  return 1
+}
+
+type LastPointerClick = {
+  button: CdpPointerButton
+  x: number
+  y: number
+  at: number
+  count: number
+}
+
+export type CdpPointerState = {
+  x: number
+  y: number
+  button: 'none' | CdpPointerButton
+  buttons: number
+  clickCount: number
+  lastClick: LastPointerClick | null
+  pending: Promise<void> | null
+  lastError: string | null
+}
+
+// Why: keyed by the WebContents itself so per-tab pointer state can never leak across
+// tabs and dies with the tab instead of needing teardown hooks.
+const pointerStates = new WeakMap<WebContents, CdpPointerState>()
+
+export function cdpPointerStateFor(webContents: WebContents): CdpPointerState {
+  let state = pointerStates.get(webContents)
+  if (!state) {
+    state = {
+      x: 0,
+      y: 0,
+      button: 'none',
+      buttons: 0,
+      clickCount: 1,
+      lastClick: null,
+      pending: null,
+      lastError: null
+    }
+    pointerStates.set(webContents, state)
+  }
+  return state
+}
+
+// Why: a second press at the same spot inside the double-click interval must report the
+// next clickCount or Chromium never fires dblclick. Cycles 1, 2, 3, 1 like a real mouse.
+export function trackCdpClickCount(state: CdpPointerState, button: CdpPointerButton): number {
+  const now = Date.now()
+  const previous = state.lastClick
+  const repeated =
+    previous !== null &&
+    previous.button === button &&
+    Math.abs(previous.x - state.x) <= MULTI_CLICK_SLOP_PX &&
+    Math.abs(previous.y - state.y) <= MULTI_CLICK_SLOP_PX &&
+    now - previous.at <= MULTI_CLICK_INTERVAL_MS
+  const count = repeated ? (previous.count >= 3 ? 1 : previous.count + 1) : 1
+  state.lastClick = { button, x: state.x, y: state.y, at: now, count }
+  return count
+}
+
+// Why: an un-awaited dispatch would report success and park Chromium's invalid-params
+// error on a later event; reject non-finite coordinates and deltas up front instead.
+export function assertFinitePointerValues(values: Record<string, number>): void {
+  for (const [name, value] of Object.entries(values)) {
+    if (!Number.isFinite(value)) {
+      throw new BrowserError('browser_error', `Pointer input requires a finite ${name}`)
+    }
+  }
+}
+
+export type CdpPointerEventParams = {
+  type: 'mouseMoved' | 'mousePressed' | 'mouseReleased' | 'mouseWheel'
+  x: number
+  y: number
+  button?: string
+  buttons?: number
+  clickCount?: number
+  deltaX?: number
+  deltaY?: number
+}
+
+// Why: awaiting sendCommand awaits the renderer's frame-bound ack — ~16ms on a watched
+// tab, ~1s on an unwatched one, which also spaces clicks too far apart for dblclick. The
+// event is dispatched in order regardless, so we return once it is written and surface a
+// late failure on the caller's next pointer event instead of swallowing it.
+export function dispatchCdpPointerEvent(
+  state: CdpPointerState,
+  webContents: WebContents,
+  params: CdpPointerEventParams
+): Promise<void> {
+  const failure = state.lastError
+  if (failure !== null) {
+    state.lastError = null
+    throw new BrowserError('browser_error', `The previous pointer event failed: ${failure}`)
+  }
+  const sent = webContents.debugger.sendCommand('Input.dispatchMouseEvent', params)
+  if (awaitPointerAck()) {
+    return sent.then(() => undefined)
+  }
+  state.pending = sent.then(
+    () => undefined,
+    (error: unknown) => {
+      state.lastError = error instanceof Error ? error.message : String(error)
+    }
+  )
+  return Promise.resolve()
+}
+
+// Why: releasing the debugger lease before an un-awaited dispatch settles could detach
+// the debugger out from under the in-flight event.
+export function releaseLeaseAfterPointerDispatch(
+  state: CdpPointerState,
+  lease: ElectronDebuggerLease
+): void {
+  const pending = state.pending
+  state.pending = null
+  if (pending) {
+    void pending.then(
+      () => lease.release(),
+      () => lease.release()
+    )
+    return
+  }
+  lease.release()
+}


### PR DESCRIPTION
## ELI5

Moving the mouse in the remote browser pane launches a whole new process on the host for every wiggle, click and scroll tick -- about 160ms each, and a click is four of them. This makes the runtime deliver mouse events the same fast way it already delivers taps from the mobile app: directly, in process. A click drops from ~640ms to ~1.5ms, and double-click works through the pane for the first time.

## What Changed

`mouseMove` / `mouseDown` / `mouseUp` / `mouseWheel` no longer go through `execAgentBrowser` (an `execFile` of the agent-browser helper per event) -- they dispatch `Input.dispatchMouseEvent` over the electron debugger, the way `mouseClick` has done since it was added for mobile. A new `cdp-pointer-input.ts` module tracks per-tab pointer state (position, held-buttons mask, click cadence) in a WeakMap keyed by the WebContents, so state dies with the tab.

Element-ref commands (`click --element`, `snapshot`, ...) are untouched, they genuinely need the helper's snapshot state.

Two deliberate design points worth flagging up front:

- dispatch doesn't await the renderer's ack by default. The ack for mouse events is frame-bound: ~16ms on a tab someone is watching, ~1s per event on a tab whose renderer idles at 1Hz b/c nothing subscribes to its screencast -- and at 1Hz two clicks can never land inside the 500ms double-click interval, so awaiting costs correctness as well as latency. Events are still written to the debugger in call order, a late dispatch failure comes back as a `browser_error` on the caller's next pointer event instead of being swallowed, and the debugger lease is held until the in-flight command settles. `ORCA_BROWSER_INPUT_AWAIT_ACK=1` restores the waiting behavior if you'd rather have the strict semantics.
- clickCount is tracked (1 -> 2 -> 3 -> 1 for repeated presses within 500ms / 2px), where the helper hardcoded `clickCount: 1`. Double-click through the remote pane -- select a word, open a file from a list -- was previously impossible to express at all.

## Why

Measured on the same host, same dev build, main vs this branch (loopback, p50, n=25):

| | main | this PR |
|---|---|---|
| `browser.mouseMove` | 160 ms | 0.5 ms |
| `browser.mouseWheel` | 160 ms | 0.4 ms |
| one scroll notch (move+wheel, serialized) | 320 ms | 0.7 ms |
| one click (move+down+move+up -- what BrowserPane sends) | 637 ms | 1.5 ms |

`browser.eval` measures 0.4-0.5ms on the same socket, so the transport was never the cost. Both ends serialize input (`enqueueRemoteInput` on the client, the per-session command queue on the server), which means the per-event cost multiplies into every gesture -- this is most of "the remote pane feels laggy". The helper was only translating these events into `Input.dispatchMouseEvent` calls of its own, so no behavior actually depended on the subprocess.

## Callouts

Some deltas from the helper path, all deliberate, listed so nothing is surprising in review:

- result shapes are byte-identical to the shipped helper's (checked by running the pinned agent-browser 0.27 binary): `{moved:true}`, `{pressed:true}`, `{released:true}`, `{scrolled:true,deltaX,deltaY}`. No wire or schema change, so mixed-version pairs just get a faster server (checked against `docs/reference/remote-wire-compatibility.md` -- nothing there applies).
- success now means 'dispatched', not 'renderer processed it' (see above). In practice a read through the same pipeline lands after the input -- measured 20/20 clicks and 10/10 typed strings visible to an immediately-following `browser.eval`, no sleep -- but that ordering is measured, not contractual.
- wheel dispatches at the tracked pointer position. The helper dispatched wheel at (0,0) regardless of any preceding `mouse move` (the CLI never passes x/y), so inner scrollables under the cursor never scrolled and whatever sat at the top-left corner did. Both panes (desktop and mobile) send `mouseMove` before every wheel, so interactive scrolling gets strictly better; headless automation that relied on the (0,0) targeting would notice.
- two clicks at the same point within 500ms now produce a real `dblclick` with `detail: 2`, as a physical mouse would. The old path physically couldn't produce sub-500ms pairs (4x160ms per click), so nothing existing can have depended on fast pairs staying `detail: 1` -- but newly-fast CLI scripting that double-invokes a control in <500ms will now look like a double-click to the page, b/c it is one.
- `button: 'back'` / `'forward'` pass through as real X1/X2 presses with the right buttons-mask bits, as the helper dispatched them. (The element-click path's existing left-coercion is untouched.)
- `mouseUp` with no button releases the held button; the helper always released `left`, which left a right-button press stuck forever. Both panes always pass the button, so only CLI/RPC callers see this.
- non-finite coordinates/deltas are rejected up front (`browser_error`) -- an un-awaited dispatch would otherwise report success and park chromium's invalid-params error on a later event.
- `wc.focus()` on mouseDown mirrors what `mouseClick` already does. The helper never focused anything, so relative to the old down/up path this widens the focus surface the same way every mobile tap already does -- flagging for coordination with #10875/#11732 (agent-input focus stealing), which this PR neither fixes nor worsens beyond the established precedent.
- when the automation-visibility feature swaps the pane's guest WebContents, pointer state resets with it -- equivalent to today, where that swap restarted the helper and dropped its mouse state. Both panes send a `mouseMove` before any down/up/wheel in the same serialized queue, which re-establishes position.

## Linked Issue

Fixes #15308

## Visual Proof

Before/after recordings attached here -- the same click / double-click / scroll sequence driven through the exact RPCs the pane sends, at human cadence, recorded from the screencast frames the pane receives. Before is current main, after is this branch: same 1680px scrolled, but before crawls and never fires dblclick; after is instant, fires `dblclick`, and selects the word.

https://github.com/user-attachments/assets/0ef010e0-a41e-47f7-8795-ae6218e1cb39

https://github.com/user-attachments/assets/3a154b6d-8113-4323-9d0a-b6cc652ce197

## Testing

- `pnpm exec vitest run --config config/vitest.config.ts src/main/browser/` -- the whole directory passes, including the new `agent-browser-bridge-pointer-input.test.ts` (13 tests: CDP payloads for move/down/up/wheel, position tracking, per-tab state isolation, clickCount escalation and reset, back/forward passthrough, non-finite rejection, deferred-failure surfacing, ack-await mode, lease release ordering, queue cleanup).
- `pnpm run typecheck`, `pnpm exec oxlint`, `pnpm run check:code-quality:changed`, `pnpm run check:max-lines-ratchet` -- all clean.
- Live verification on a headless linux serve host (source build of this branch, real E2EE pairing transport): a 24-check input-fidelity suite passes 24/24 -- click, double-click (fires `dblclick` and selects a word), right-click (`contextmenu`), drag-selection across a text span, plus the keyboard checks. The same suite on a main build of the same base fails both double-click checks. Latency numbers above were taken on the same rig, main vs branch.
- Platforms actually tested: linux headless serve. I'd expect macOS/Windows impact to be limited to the dispatch mechanism those platforms already use for `mouseClick` on every mobile tap, but I haven't run them myself.
- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Built with Claude Code (Fable 5). It started as a hand-validated patch prototype running against a remote runtime I use daily; all the numbers here come from scripted probes against real instances (including the main-branch baseline, same host and build), and claims about the helper's current behavior were re-checked by running the pinned agent-browser 0.27 binary directly. I reviewed the diff before submitting.

## Notes

Security: no new inputs parsed beyond a finiteness check, RPC surface and schemas unchanged. Cross-platform: the electron debugger dispatch path is the same one `mouseClick` uses on all three platforms. Remote/SSH: no wire change, server-side speedup only. Performance: hot path loses a subprocess spawn per event, nothing new beyond a small per-tab state object.

## Review

Adversarially reviewed with independent agent passes before submission: correctness (races, debugger-lease lifetimes, event ordering, per-tab state isolation), cross-platform (the dispatch path is the one `mouseClick` already uses on macOS/Windows/Linux; no platform-conditional code added), remote/SSH and mixed versions (no wire or schema change; result shapes byte-compared against the shipped helper binary), agent/integration compatibility (element-ref commands untouched; helper fallback preserved), performance (removes a subprocess spawn per event from the hot path), and basic security (no new parsed inputs, no new surface). Findings that survived review are disclosed in Callouts above.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

