### PR TITLE
fix(codex): avoid duplicate Windows profile hooks

### DIFF
--- a/src/main/codex-accounts/runtime-home-real-home-lane-routing.test.ts
+++ b/src/main/codex-accounts/runtime-home-real-home-lane-routing.test.ts
@@ -280,6 +280,11 @@ describe('CodexRuntimeHomeService', () => {
       'account-pane': { selectionKey: 'host', accountId: 'account-1', homeRoute: 'account-home' },
       'unowned-pane': { selectionKey: 'host', accountId: 'account-2', homeRoute: 'account-home' },
       'real-pane': { selectionKey: 'host', accountId: null, homeRoute: 'real-home' },
+      'workspace-real-pane': {
+        selectionKey: 'host',
+        accountId: null,
+        homeRoute: 'workspace-real-home'
+      },
       'wsl-pane': { selectionKey: 'wsl:Ubuntu', accountId: null, homeRoute: 'wsl-home' }
     })
     const settings = createSettings({
@@ -298,6 +303,7 @@ describe('CodexRuntimeHomeService', () => {
         'account-pane',
         'unowned-pane',
         'real-pane',
+        'workspace-real-pane',
         'wsl-pane',
         'unknown-pane'
       ])

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -66,7 +66,10 @@ import {
   type CodexAccountSelectionTarget
 } from './runtime-selection'
 import { getDefaultWslDistro, getWslHome } from '../wsl'
-import { hasCustomCodexHomeOverrideForLaunch } from '../codex/codex-real-home-path'
+import {
+  hasCustomCodexHomeOverrideForLaunch,
+  isWindowsSystemCodexHomeWorkspace
+} from '../codex/codex-real-home-path'
 import {
   hasCompletedCodexSessionBackfillMarker,
   invalidateCodexSessionBackfillMarker
@@ -236,7 +239,7 @@ export class CodexRuntimeHomeService {
   prepareForCodexLaunch(
     target?: CodexAccountSelectionTarget,
     launchEnv?: NodeJS.ProcessEnv,
-    options?: { unavailableManagedHomePath?: string }
+    options?: { unavailableManagedHomePath?: string; workspacePath?: string }
   ): string | null {
     if (target?.runtime === 'wsl') {
       const wslTarget = this.resolveWslDefaultTarget(target)
@@ -258,7 +261,7 @@ export class CodexRuntimeHomeService {
       // Why: only an untrusted home clears the selection; fall through to the
       // system default without injecting a path Orca cannot prove it owns.
     }
-    if (this.isHostSystemDefaultRealHome(launchEnv)) {
+    if (this.isHostSystemDefaultRealHome(launchEnv, options?.workspacePath)) {
       // Why: the system default runs Codex on the user's own ~/.codex.
       // Returning null tells the PTY/env layer to inject no managed CODEX_HOME;
       // the retired mirror is refreshed only for pre-rollout PTYs.
@@ -676,22 +679,27 @@ export class CodexRuntimeHomeService {
   }
 
   // Why: real-home routing applies only to the host system-default selection.
-  // Managed accounts run in their own homes; Windows (no shell-startup probe)
-  // and custom CODEX_HOMEs stay on the mirror until cleanup can be tracked
-  // across old homes.
-  isHostSystemDefaultRealHomeSelected(launchEnv?: NodeJS.ProcessEnv): boolean {
+  // Managed accounts and custom CODEX_HOMEs stay isolated. Windows normally
+  // stays mirrored because PowerShell startup files cannot be inspected, except
+  // when its native .codex would also be rediscovered as the project layer.
+  isHostSystemDefaultRealHomeSelected(
+    launchEnv?: NodeJS.ProcessEnv,
+    workspacePath?: string
+  ): boolean {
     const settings = this.store.getSettings()
     if (
       normalizeCodexRuntimeSelection(settings).host !== null ||
-      !isShellStartupEnvProbeSupported()
+      (!isShellStartupEnvProbeSupported() && !isWindowsSystemCodexHomeWorkspace(workspacePath))
     ) {
       return false
     }
     return !hasCustomCodexHomeOverrideForLaunch(launchEnv)
   }
 
-  isHostSystemDefaultRealHome(launchEnv?: NodeJS.ProcessEnv): boolean {
-    return this.isHostSystemDefaultRealHomeSelected(launchEnv) && this.realHomeLaneGate()
+  isHostSystemDefaultRealHome(launchEnv?: NodeJS.ProcessEnv, workspacePath?: string): boolean {
+    return (
+      this.isHostSystemDefaultRealHomeSelected(launchEnv, workspacePath) && this.realHomeLaneGate()
+    )
   }
 
   reconcileLegacySharedHomeForRetainedPanes(): void {

--- a/src/main/codex-accounts/runtime-home-windows-profile-ownership.test.ts
+++ b/src/main/codex-accounts/runtime-home-windows-profile-ownership.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest'
+import { dirname, join } from 'node:path'
 import type { GlobalSettings } from '../../shared/global-settings-types'
+import { getSystemCodexHomePath } from '../codex/codex-home-paths'
 import { CodexRuntimeHomeService } from './runtime-home-service'
 
 const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
@@ -30,6 +32,32 @@ describe('Windows System Default Codex home ownership', () => {
       })
     ).toBe(false)
     expect(service.isHostSystemDefaultSessionMigrationEligible()).toBe(true)
+  })
+
+  it('uses the real home only when the Windows workspace would rediscover it', () => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    delete process.env.CODEX_HOME
+    delete process.env.ORCA_CODEX_HOME
+
+    const service = Object.create(CodexRuntimeHomeService.prototype) as CodexRuntimeHomeService
+    Object.defineProperty(service, 'store', { value: createStore() })
+    service.setRealHomeLaneGate(() => true)
+    const userProfile = dirname(getSystemCodexHomePath())
+
+    expect(service.isHostSystemDefaultRealHomeSelected(undefined, userProfile)).toBe(true)
+    expect(service.isHostSystemDefaultRealHome(undefined, userProfile)).toBe(true)
+    expect(
+      service.isHostSystemDefaultRealHomeSelected(undefined, join(userProfile, 'project'))
+    ).toBe(false)
+    expect(
+      service.isHostSystemDefaultRealHomeSelected(
+        { CODEX_HOME: join(userProfile, 'custom-codex-home') },
+        userProfile
+      )
+    ).toBe(false)
+
+    service.setRealHomeLaneGate(() => false)
+    expect(service.isHostSystemDefaultRealHome(undefined, userProfile)).toBe(false)
   })
 })
 

--- a/src/main/codex/codex-pane-account-registry.ts
+++ b/src/main/codex/codex-pane-account-registry.ts
@@ -18,6 +18,7 @@ import type {
 
 export type CodexPaneHomeRoute =
   | 'real-home'
+  | 'workspace-real-home'
   | 'shared-home'
   | 'account-home'
   | 'custom-home'
@@ -131,6 +132,7 @@ function isPaneAccountRecord(value: unknown): value is CodexPaneAccountRecord {
 function isPaneHomeRoute(value: unknown): value is CodexPaneHomeRoute {
   return (
     value === 'real-home' ||
+    value === 'workspace-real-home' ||
     value === 'shared-home' ||
     value === 'account-home' ||
     value === 'custom-home' ||
@@ -227,11 +229,16 @@ export function getCodexPaneAccount(ptyId: string): CodexPaneAccountRecord | nul
   return readRegistry().panes[ptyId] ?? null
 }
 
-/** `custom-home` stays conservative because it can mask a non-comparable shared-home route. */
+/** Workspace-scoped real homes are concrete even though they are not globally comparable. */
 export function isCodexPaneHomeRouteProvenAwayFromSharedHome(
   route: CodexPaneHomeRoute | undefined
 ): boolean {
-  return route === 'real-home' || route === 'account-home' || route === 'wsl-home'
+  return (
+    route === 'real-home' ||
+    route === 'workspace-real-home' ||
+    route === 'account-home' ||
+    route === 'wsl-home'
+  )
 }
 
 /**
@@ -274,6 +281,13 @@ export function hasRecordedManagedHostCodexPane(): boolean {
         record.homeRoute === 'shared-home' ||
         record.homeRoute === 'custom-home' ||
         (record.homeRoute === 'account-home' && record.accountId !== null))
+  )
+}
+
+/** True when a retained host pane still depends on workspace-scoped real-home hooks. */
+export function hasRecordedWorkspaceRealHomeCodexPane(): boolean {
+  return Object.values(readRegistry().panes).some(
+    (record) => record.selectionKey === 'host' && record.homeRoute === 'workspace-real-home'
   )
 }
 

--- a/src/main/codex/codex-pane-launch-account.test.ts
+++ b/src/main/codex/codex-pane-launch-account.test.ts
@@ -150,6 +150,23 @@ describe('resolveCodexPaneLaunchAccount', () => {
     ).toEqual({ selectionKey: 'host', accountId: null, homeRoute: 'real-home' })
   })
 
+  it('records a workspace-scoped real home separately from the global route', () => {
+    expect(
+      resolveCodexPaneLaunchAccount({
+        pinnedByResume: false,
+        launchCodexHomePath: null,
+        workspaceScopedRealHome: true,
+        systemCodexHomePath: SYSTEM_HOME,
+        settings: settings({ host: null }),
+        target: { runtime: 'host' }
+      })
+    ).toEqual({
+      selectionKey: 'host',
+      accountId: null,
+      homeRoute: 'workspace-real-home'
+    })
+  })
+
   it('refuses to attribute a resume home no account owns', () => {
     expect(
       resolveCodexPaneLaunchAccount({

--- a/src/main/codex/codex-pane-launch-account.ts
+++ b/src/main/codex/codex-pane-launch-account.ts
@@ -33,6 +33,7 @@ export function resolveCodexPaneLaunchAccount(args: {
   pinnedByResume: boolean
   launchCodexHomePath: string | null
   recordComparableHomeRoute?: boolean
+  workspaceScopedRealHome?: boolean
   shellStartupHomeOverride?: CodexShellStartupHomeOverride
   environmentHomeOverride?: CodexEnvironmentHomeOverride
   systemCodexHomePath: string
@@ -42,9 +43,11 @@ export function resolveCodexPaneLaunchAccount(args: {
   const selectionKey = getCodexSelectionLaneKey(args.target)
   const resolvedHomeRoute = resolveCodexPaneHomeRoute(args)
   const homeRoute =
-    args.recordComparableHomeRoute === false && resolvedHomeRoute === 'shared-home'
-      ? 'custom-home'
-      : resolvedHomeRoute
+    args.workspaceScopedRealHome && resolvedHomeRoute === 'real-home'
+      ? 'workspace-real-home'
+      : args.recordComparableHomeRoute === false && resolvedHomeRoute === 'shared-home'
+        ? 'custom-home'
+        : resolvedHomeRoute
   if (!args.pinnedByResume) {
     return {
       selectionKey,

--- a/src/main/codex/codex-real-home-path.ts
+++ b/src/main/codex/codex-real-home-path.ts
@@ -1,4 +1,5 @@
 import { resolve } from 'node:path'
+import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
 import { getSystemCodexHomePath } from './codex-home-paths'
 import { readShellStartupEnvVar } from '../pty/shell-startup-env'
 
@@ -37,6 +38,24 @@ export function hasCustomCodexHomeOverride(env: NodeJS.ProcessEnv = process.env)
 
 export function hasCustomCodexHomeOverrideForLaunch(launchEnv?: NodeJS.ProcessEnv): boolean {
   return getCustomCodexHomeOverrideForLaunch(launchEnv) !== null
+}
+
+/**
+ * True when Codex would rediscover the native user home as a project layer.
+ *
+ * Why Windows-only: that platform normally stays on Orca's managed home because
+ * PowerShell startup files cannot be inspected. If the workspace itself owns
+ * the native .codex directory, the managed mirror and project layer otherwise
+ * register the same user hooks twice (#15292).
+ */
+export function isWindowsSystemCodexHomeWorkspace(workspacePath?: string): boolean {
+  if (process.platform !== 'win32' || !workspacePath) {
+    return false
+  }
+  return (
+    normalizeRuntimePathForComparison(resolve(workspacePath, '.codex')) ===
+    normalizeRuntimePathForComparison(getSystemCodexHomePath())
+  )
 }
 
 export function getCustomCodexHomeOverrideForLaunch(

--- a/src/main/codex/codex-stale-pane-accounts.test.ts
+++ b/src/main/codex/codex-stale-pane-accounts.test.ts
@@ -9,6 +9,7 @@ import {
   getCodexPaneAccount,
   hasRecordedLegacySharedCodexPane,
   hasRecordedManagedHostCodexPane,
+  hasRecordedWorkspaceRealHomeCodexPane,
   isCodexPaneHomeRouteProvenAwayFromSharedHome,
   reconcileCodexPaneAccountsWithLivePtys,
   recordCodexPaneAccount
@@ -50,6 +51,7 @@ afterEach(() => {
 describe('codex pane account registry', () => {
   it.each([
     ['real-home', true],
+    ['workspace-real-home', true],
     ['account-home', true],
     ['wsl-home', true],
     ['shared-home', false],
@@ -170,6 +172,26 @@ describe('codex pane account registry', () => {
     })
 
     expect(hasRecordedManagedHostCodexPane()).toBe(true)
+  })
+
+  it('keeps real-home hooks only while a workspace-scoped host pane is retained', () => {
+    recordCodexPaneAccount('pty-workspace-real', {
+      selectionKey: 'host',
+      accountId: null,
+      homeRoute: 'workspace-real-home'
+    })
+    recordCodexPaneAccount('pty-wsl-workspace-real', {
+      selectionKey: 'wsl:Ubuntu',
+      accountId: null,
+      homeRoute: 'workspace-real-home'
+    })
+
+    expect(hasRecordedWorkspaceRealHomeCodexPane()).toBe(true)
+    expect(hasRecordedLegacySharedCodexPane()).toBe(false)
+    expect(hasRecordedManagedHostCodexPane()).toBe(false)
+
+    forgetCodexPaneAccount('pty-workspace-real')
+    expect(hasRecordedWorkspaceRealHomeCodexPane()).toBe(false)
   })
 
   it('drops leaked records that are absent from the authoritative daemon inventory', () => {
@@ -373,6 +395,23 @@ describe('listStaleCodexPanes', () => {
         ptyIds: ['pty-1'],
         settings: settingsWithSelection(null),
         activeHostHomeRoute: 'real-home'
+      })
+    ).toEqual([])
+  })
+
+  it('does not compare a workspace-scoped real home with the global host route', () => {
+    recordCodexPaneAccount('pty-1', {
+      selectionKey: 'host',
+      accountId: null,
+      homeRoute: 'workspace-real-home'
+    })
+    _internals.resetCache()
+
+    expect(
+      listStaleCodexPanes({
+        ptyIds: ['pty-1'],
+        settings: settingsWithSelection(null),
+        activeHostHomeRoute: 'shared-home'
       })
     ).toEqual([])
   })

--- a/src/main/codex/codex-stale-pane-accounts.ts
+++ b/src/main/codex/codex-stale-pane-accounts.ts
@@ -36,6 +36,7 @@ export function listStaleCodexPanes(args: {
       record.selectionKey === 'host' &&
       record.homeRoute !== undefined &&
       record.homeRoute !== 'custom-home' &&
+      record.homeRoute !== 'workspace-real-home' &&
       args.activeHostHomeRoute !== undefined &&
       record.homeRoute !== args.activeHostHomeRoute
     const accountChanged = record.accountId !== activeAccountId

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -44,6 +44,7 @@ import {
   type CodexPaneHomeRoute,
   getCodexPaneAccount,
   hasRecordedManagedHostCodexPane,
+  hasRecordedWorkspaceRealHomeCodexPane,
   isCodexPaneHomeRouteProvenAwayFromSharedHome,
   reconcileCodexPaneAccountsWithLivePtys
 } from './codex/codex-pane-account-registry'
@@ -987,7 +988,10 @@ function startTerminalRuntimeStartupServices(): WindowsDesktopStartupServices {
         macosLoginSessionWatch: process.platform === 'darwin' && !isServeMode
       })
       // Why: a retained shell keeps its launch-time Codex home even when the current routing lane changes.
-      if (codexRuntimeHome && hasRecordedManagedHostCodexPane()) {
+      if (
+        codexRuntimeHome &&
+        (hasRecordedManagedHostCodexPane() || hasRecordedWorkspaceRealHomeCodexPane())
+      ) {
         const livePtyIds = await listLiveDaemonPtyIds()
         if (livePtyIds) {
           reconcileCodexPaneAccountsWithLivePtys(livePtyIds)
@@ -1063,6 +1067,8 @@ function prepareCodexRuntimeHomeForLaunch(
   launchEnv?: NodeJS.ProcessEnv,
   launchContext?: CodexHomeLaunchContext
 ): string | null {
+  const codexWorkspacePath =
+    launchContext?.launchAgent === 'codex' ? launchContext.workspacePath : undefined
   if (
     target?.runtime !== 'wsl' &&
     launchContext?.launchAgent === 'codex' &&
@@ -1078,7 +1084,7 @@ function prepareCodexRuntimeHomeForLaunch(
   const ensureRealHomeHooksIfSelected = (): boolean => {
     if (
       target?.runtime === 'wsl' ||
-      !codexRuntimeHome!.isHostSystemDefaultRealHomeSelected(launchEnv)
+      !codexRuntimeHome!.isHostSystemDefaultRealHomeSelected(launchEnv, codexWorkspacePath)
     ) {
       return false
     }
@@ -1097,7 +1103,8 @@ function prepareCodexRuntimeHomeForLaunch(
   // the fallbacks below all key off `null`, which means "system default", so
   // swallowing the refusal would launch the wrong account (#STA-4422).
   let runtimeHomePath = codexRuntimeHome!.prepareForCodexLaunch(target, launchEnv, {
-    unavailableManagedHomePath: launchContext?.unavailableManagedHomePath
+    unavailableManagedHomePath: launchContext?.unavailableManagedHomePath,
+    workspacePath: codexWorkspacePath
   })
   if (runtimeHomePath === null && !realHomeHooksPrepared) {
     // Why: launch prep can reject an untrusted managed home and clear its
@@ -1106,7 +1113,8 @@ function prepareCodexRuntimeHomeForLaunch(
     realHomeHooksPrepared = ensureRealHomeHooksIfSelected()
     if (realHomeHooksPrepared) {
       runtimeHomePath = codexRuntimeHome!.prepareForCodexLaunch(target, launchEnv, {
-        unavailableManagedHomePath: launchContext?.unavailableManagedHomePath
+        unavailableManagedHomePath: launchContext?.unavailableManagedHomePath,
+        workspacePath: codexWorkspacePath
       })
     }
   }
@@ -2487,7 +2495,7 @@ void app.whenReady().then(async () => {
   setSystemCodexHomeHookSweepSuppressed(
     () =>
       codexRuntimeHome !== null &&
-      codexRuntimeHome.isHostSystemDefaultRealHome() &&
+      (codexRuntimeHome.isHostSystemDefaultRealHome() || hasRecordedWorkspaceRealHomeCodexPane()) &&
       isAgentStatusHooksEnabled(store?.getSettings())
   )
   codexSessionMigration = createCodexSessionMigrationScheduler({
@@ -2934,7 +2942,10 @@ void app.whenReady().then(async () => {
     console.warn('[worktrees] Failed to sweep leftover worktree directories:', error)
   })
   nativeTheme.themeSource = store.getSettings().theme ?? 'system'
-  if (codexRuntimeHome.isHostSystemDefaultRealHomeSelected()) {
+  if (
+    codexRuntimeHome.isHostSystemDefaultRealHomeSelected() ||
+    hasRecordedWorkspaceRealHomeCodexPane()
+  ) {
     // Why: establish capability before managed-hook reconciliation so an
     // incapable host re-arms and completes the legacy real-home sweep now.
     ensureRealHomeCodexHookState({

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -225,6 +225,7 @@ import { ensureCodexStateDbBackfillRecoveryStarted } from '../codex/codex-state-
 import {
   environmentCodexHomeOverrideContextsEqual,
   getCustomCodexHomeOverrideForLaunch,
+  isWindowsSystemCodexHomeWorkspace,
   shellStartupCodexHomeOverrideContextsEqual
 } from '../codex/codex-real-home-path'
 import type { CodexSessionResumePreparation } from '../codex/codex-session-resume-home'
@@ -1489,6 +1490,7 @@ function recordCodexPaneAccountForSpawn(args: {
   pinnedByResume: boolean
   launchCodexHomePath: string | null
   launchEnv?: NodeJS.ProcessEnv
+  workspacePath?: string
   target: CodexAccountSelectionTarget
   settings: GlobalSettings | undefined
 }): void {
@@ -1527,6 +1529,10 @@ function recordCodexPaneAccountForSpawn(args: {
             recheckableEnvironmentOverride !== undefined) &&
             (customHomeOverride?.source !== 'shell-startup' ||
               recheckableShellStartupOverride !== undefined)),
+        workspaceScopedRealHome:
+          args.target.runtime === 'host' &&
+          args.launchCodexHomePath === null &&
+          isWindowsSystemCodexHomeWorkspace(args.workspacePath),
         shellStartupHomeOverride: args.pinnedByResume ? undefined : recheckableShellStartupOverride,
         environmentHomeOverride: args.pinnedByResume ? undefined : recheckableEnvironmentOverride,
         systemCodexHomePath: getSystemCodexHomePath(),
@@ -5335,6 +5341,7 @@ export function registerPtyHandlers(
           pinnedByResume: codexResumeHomeSelected,
           launchCodexHomePath: selectedCodexHomePath,
           launchEnv: args.env,
+          workspacePath: cwd,
           target: codexSelectionTarget,
           settings: getSettings?.()
         })
@@ -6897,6 +6904,7 @@ export function registerPtyHandlers(
           pinnedByResume: codexResumeHomeSelected,
           launchCodexHomePath: selectedCodexHomePath,
           launchEnv: baseEnv,
+          workspacePath: cwd,
           target: codexSelectionTarget,
           settings: getSettings?.()
         })


### PR DESCRIPTION
## ELI5

When Codex starts from the Windows user profile, the same `.codex/hooks.json` can be discovered twice: once through Orca's managed user-hook mirror and again as the workspace's project hooks.

This change detects that exact collision and launches the system-default Codex account against its native home. Codex then recognizes the workspace `.codex` directory as `CODEX_HOME` and does not load it again as a project layer.

## What Changed

- Detect when a Windows workspace's `.codex` directory is the native system Codex home.
- Route only that exact host system-default case through Orca's existing real-home hook lane.
- Keep managed accounts, custom `CODEX_HOME`, subprojects, WSL, macOS, and Linux behavior unchanged.
- Record the route as `workspace-real-home` so retained panes:
  - do not produce incorrect stale-account prompts;
  - keep their real-home hook repaired and protected across app restarts;
  - allow normal managed-home cleanup after the retained pane exits.
- Add coverage for Windows routing, pane attribution, retained-hook lifecycle, and stale-pane comparison.

## Why

Issue #15292 reports 34 hooks instead of the expected 21 when Codex starts in the Windows user profile.

The duplicate is caused by the same physical `.codex` directory participating in two configuration layers. Fixing the routing collision is safer than deduplicating hook definitions by content because independently configured hooks may intentionally be identical.

The new route is deliberately narrow: it applies only when the workspace `.codex` path exactly matches the native Windows system Codex home.

## Linked Issue

Fixes #15292

## Visual Proof

N/A — this changes main-process Codex home routing and hook discovery, with no Orca UI change.

Behavior was verified with the real `codex-cli 0.147.0` `hooks/list` RPC in an isolated Windows profile:

| Mode | User hooks | Project hooks | Total | SessionStart | Stop |
| --- | ---: | ---: | ---: | ---: | ---: |
| Before: managed mirror | 2 | 1 | 3 | 1 | 2 |
| After: native real home | 2 | 0 | 2 | 1 | 1 |

The duplicated Stop hook is removed while the Orca SessionStart hook remains installed exactly once.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Verified on Windows:

- Real `codex-cli 0.147.0` isolated-profile A/B using `hooks/list`
- Targeted Vitest suites: 6 passed
  - 78 tests passed
  - 6 platform-specific tests skipped
- Full TypeScript project typecheck passed
- Node TypeScript typecheck passed
- Changed-file oxlint passed
- Reliability gates passed
- Max-lines ratchet passed
- Desktop build chain passed, including relay, CLI, Electron/Vite, bundled skill
  verification, and web projection
- `git diff --check` passed

## Review

Suggested review focus:

- The exact Windows system-home workspace predicate
- Preservation of custom `CODEX_HOME`, managed-account, and WSL routing
- `workspace-real-home` retained-pane lifecycle and cleanup behavior

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- The complete `pnpm lint` command reaches and passes oxlint, native/type-aware audits, reliability gates, and max-lines checks, then stops because three generated skill-manifest files are stale on the current upstream `main`. The same failure was reproduced on a clean upstream checkout.
- The full test suite is not clean on this workstation because the optional Windows native module could not be rebuilt without the Visual Studio C++ toolchain, with additional existing WSL/symlink/watcher failures reproduced against clean `main`. The  focused suites covering this change pass.
- No hook contents, credentials, or user configuration are included.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: N/A