### PR TITLE
fix(codex): resolve family slugs to seeded effort ceilings

### DIFF
--- a/src/main/runtime/rpc/methods/orchestration-worker-launch-preferences.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-launch-preferences.test.ts
@@ -104,6 +104,28 @@ describe('orchestration worker launch preferences', () => {
     }
   })
 
+  it.each([
+    {
+      model: 'luna',
+      accepted: ['minimal', 'low', 'medium', 'high', 'xhigh', 'max'],
+      rejected: ['ultra']
+    },
+    { model: 'Luna', accepted: ['max'], rejected: ['ultra'] },
+    { model: 'sol', accepted: ['ultra'], rejected: ['future-effort'] },
+    { model: 'terra', accepted: ['ultra'], rejected: ['future-effort'] }
+  ])('applies the seeded Codex ceiling to family slug $model', ({ model, accepted, rejected }) => {
+    for (const effortValue of accepted) {
+      expect(
+        resolveWorkerLaunchPreferences({ agent: 'codex', model, effort: effortValue }).preferences
+      ).toEqual({ model, effort: effortValue })
+    }
+    for (const effortValue of rejected) {
+      expect(() =>
+        resolveWorkerLaunchPreferences({ agent: 'codex', model, effort: effortValue })
+      ).toThrow(`does not support effort ${effortValue}`)
+    }
+  })
+
   it('rejects effort without a model', () => {
     expect(() => resolveWorkerLaunchPreferences({ agent: 'codex', effort: 'high' })).toThrow(
       '--effort requires --model'

--- a/src/shared/agent-session-option-catalog-claude-codex.ts
+++ b/src/shared/agent-session-option-catalog-claude-codex.ts
@@ -216,9 +216,24 @@ export const CODEX_SESSION_OPTION_CATALOG: AgentSessionOptionCatalog = {
   // Why: Codex model access depends on auth. Keep this seed short and allow
   // unknown persisted ids to pass through instead of claiming a complete list.
   models: [
-    { id: 'gpt-5.6-sol', label: 'GPT-5.6 Sol', options: [codexEffort('ultra')] },
-    { id: 'gpt-5.6-terra', label: 'GPT-5.6 Terra', options: [codexEffort('ultra')] },
-    { id: 'gpt-5.6-luna', label: 'GPT-5.6 Luna', options: [codexEffort('max')] },
+    {
+      id: 'gpt-5.6-sol',
+      label: 'GPT-5.6 Sol',
+      aliases: ['sol'],
+      options: [codexEffort('ultra')]
+    },
+    {
+      id: 'gpt-5.6-terra',
+      label: 'GPT-5.6 Terra',
+      aliases: ['terra'],
+      options: [codexEffort('ultra')]
+    },
+    {
+      id: 'gpt-5.6-luna',
+      label: 'GPT-5.6 Luna',
+      aliases: ['luna'],
+      options: [codexEffort('max')]
+    },
     { id: 'gpt-5.5', label: 'GPT-5.5', options: [codexEffort('xhigh')] },
     {
       id: 'gpt-5.2-codex',

--- a/src/shared/agent-session-option-catalog-types.ts
+++ b/src/shared/agent-session-option-catalog-types.ts
@@ -50,6 +50,9 @@ export type CatalogModel = {
   label: string
   description?: string
   isDefault?: boolean
+  // Why: worker-start and pickers receive family slugs (`luna`) while the seed
+  // stores the full CLI id (`gpt-5.6-luna`).
+  aliases?: readonly string[]
   options: CatalogOption[]
 }
 

--- a/src/shared/agent-session-option-catalog.test.ts
+++ b/src/shared/agent-session-option-catalog.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { getAgentSessionOptionCatalog, mergeCatalogModels } from './agent-session-option-catalog'
+import {
+  findCatalogModel,
+  getAgentSessionOptionCatalog,
+  mergeCatalogModels
+} from './agent-session-option-catalog'
 import { resolveAgentSessionOptionLaunch } from './agent-session-option-launch'
 import {
   resolveNativeChatSessionOptionDefaults,
@@ -139,6 +143,54 @@ describe('agent session option catalog', () => {
       model: 'gpt-5.3-codex',
       effort: 'high',
       fastMode: true
+    })
+  })
+
+  it('resolves Codex family slugs to the seeded model without rewriting launch ids', () => {
+    const catalog = getAgentSessionOptionCatalog('codex')!
+    expect(findCatalogModel(catalog, 'luna')?.id).toBe('gpt-5.6-luna')
+    expect(findCatalogModel(catalog, 'SOL')?.id).toBe('gpt-5.6-sol')
+    expect(findCatalogModel(catalog, 'Terra')?.id).toBe('gpt-5.6-terra')
+    expect(findCatalogModel(catalog, 'GPT-5.6-Luna')?.id).toBe('gpt-5.6-luna')
+    expect(findCatalogModel(catalog, 'mystery-model')).toBeUndefined()
+    expect(
+      findCatalogModel(
+        {
+          ...catalog,
+          models: [
+            { id: 'gpt-5.6-luna', label: 'Luna', aliases: ['luna'], options: [] },
+            { id: 'gpt-5.7-luna', label: 'Luna 5.7', aliases: ['luna'], options: [] }
+          ]
+        },
+        'luna'
+      )
+    ).toBeUndefined()
+
+    expect(
+      resolveAgentSessionOptionLaunch('codex', { model: 'luna', effort: 'max' }, [], false)
+    ).toEqual({
+      args: ['-m', 'luna', '-c', 'model_reasoning_effort=max'],
+      appliedValues: { model: 'luna', effort: 'max' }
+    })
+    expect(
+      resolveAgentSessionOptionLaunch('codex', { model: 'sol', effort: 'ultra' }, [], false)
+    ).toEqual({
+      args: ['-m', 'sol', '-c', 'model_reasoning_effort=ultra'],
+      appliedValues: { model: 'sol', effort: 'ultra' }
+    })
+  })
+
+  it('keeps Codex seed aliases when discovery overlays a matching full id', () => {
+    const seed = getAgentSessionOptionCatalog('codex')!.models
+    const merged = mergeCatalogModels(seed, [
+      { id: 'gpt-5.6-luna', label: 'GPT-5.6 Luna (live)', options: [] }
+    ])
+    expect(
+      findCatalogModel({ ...getAgentSessionOptionCatalog('codex')!, models: merged }, 'luna')
+    ).toMatchObject({
+      id: 'gpt-5.6-luna',
+      label: 'GPT-5.6 Luna (live)',
+      aliases: ['luna']
     })
   })
 

--- a/src/shared/agent-session-option-catalog.ts
+++ b/src/shared/agent-session-option-catalog.ts
@@ -44,7 +44,22 @@ export function findCatalogModel(
   catalog: AgentSessionOptionCatalog,
   modelId: string
 ): CatalogModel | undefined {
-  return catalog.models.find((model) => model.id === modelId)
+  const exact = catalog.models.find((model) => model.id === modelId)
+  if (exact) {
+    return exact
+  }
+  const normalized = modelId.trim().toLowerCase()
+  if (!normalized) {
+    return undefined
+  }
+  const caseInsensitive = catalog.models.filter((model) => model.id.toLowerCase() === normalized)
+  if (caseInsensitive.length === 1) {
+    return caseInsensitive[0]
+  }
+  const aliasMatches = catalog.models.filter((model) =>
+    model.aliases?.some((alias) => alias.toLowerCase() === normalized)
+  )
+  return aliasMatches.length === 1 ? aliasMatches[0] : undefined
 }
 
 export function findCatalogOption(

--- a/src/shared/native-chat-session-option-state.test.ts
+++ b/src/shared/native-chat-session-option-state.test.ts
@@ -55,6 +55,8 @@ describe('matchNativeChatCatalogModelId', () => {
       'sonnet'
     )
     expect(matchNativeChatCatalogModelId(CODEX_SESSION_OPTION_CATALOG, 'gpt-5.5')).toBe('gpt-5.5')
+    expect(matchNativeChatCatalogModelId(CODEX_SESSION_OPTION_CATALOG, 'luna')).toBe('gpt-5.6-luna')
+    expect(matchNativeChatCatalogModelId(CODEX_SESSION_OPTION_CATALOG, 'Sol')).toBe('gpt-5.6-sol')
   })
 
   it('returns null for unrecognized reports', () => {

--- a/src/shared/native-chat-session-option-state.ts
+++ b/src/shared/native-chat-session-option-state.ts
@@ -1,7 +1,8 @@
 import type { AgentType } from './agent-status-types'
-import type {
-  CatalogMidSessionApply,
-  AgentSessionOptionCatalog
+import {
+  findCatalogModel,
+  type CatalogMidSessionApply,
+  type AgentSessionOptionCatalog
 } from './agent-session-option-catalog'
 import type { SessionOptionValue, SessionOptionValueSource } from './native-chat-session-options'
 
@@ -150,13 +151,13 @@ export function matchNativeChatCatalogModelId(
   catalog: AgentSessionOptionCatalog,
   reported: string
 ): string | null {
+  const catalogMatch = findCatalogModel(catalog, reported)
+  if (catalogMatch) {
+    return catalogMatch.id
+  }
   const normalized = reported.trim().toLowerCase()
   if (!normalized) {
     return null
-  }
-  const exact = catalog.models.find((model) => model.id.toLowerCase() === normalized)
-  if (exact) {
-    return exact.id
   }
   const byLabel = catalog.models.find((model) => model.label.toLowerCase() === normalized)
   if (byLabel) {


### PR DESCRIPTION
## ELI5

Orca keeps a small list of which thinking-effort levels each Codex model allows. People often start a worker with the short name `luna` instead of `gpt-5.6-luna`. Orca treated that short name as an unknown model and capped it at Extra high, so `max` was rejected even though Luna actually supports it. This PR makes those family nicknames use the same effort list as the full model name.

## What Changed

- Codex seed rows for Sol, Terra, and Luna now declare their family slugs (`sol`, `terra`, `luna`).
- Catalog lookup matches a unique alias (and case-insensitive ids) so worker-start and native-chat pickers validate against the seeded ceiling.
- The model id sent to Codex is unchanged: `--model luna` still launches `-m luna`.
- Luna stays capped at `max`. Codex's own catalog does not advertise `ultra` for Luna; Sol/Terra already go to `ultra` from #14281.

## Why

On current main, `gpt-5.6-luna --effort max` already works after #14281, but that fix is not in 1.4.184 and it still missed the short-name path. `worker-start --model luna --effort max` hit the unknown-model fallback (`xhigh`) and threw `does not support effort max`. Users hit that from the original #14506 repro and from native chat.

## Linked Issue

Fixes #14506
Related: #15307

## Visual Proof

Local `pnpm dev` on this branch. After switching the Codex session to Luna Max, the pane reported `Model changed to gpt-5.6-luna max` and the status line showed `gpt-5.6-luna max`. The session accepted the turn instead of rejecting the effort.

## Testing

Reviewer steps:

1. `vitest run src/shared/agent-session-option-catalog.test.ts src/shared/native-chat-session-option-state.test.ts src/main/runtime/rpc/methods/orchestration-worker-launch-preferences.test.ts`
2. `worker-start --agent codex --model luna --effort max` against a running Orca — should no longer fail catalog validation.
3. Same command with `--effort ultra` should still fail for Luna.
4. `gpt-5.6-luna --effort max` should continue to work.

Ran locally (macOS): those three test files (46 tests) and oxlint on the touched files. Manual check in the local Electron dev app: Luna Max applied and the session ran. Not re-run on Linux/Windows/SSH: lookup is a shared, host-side string match with no platform or wire change.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Implemented with Grok 4.6: investigation against Codex 0.147.0 `models.json`, the local patch, tests, and this PR text. Reviewed and driven by the contributor.

## Review

Agent code-review summary:

- **Security**: no new inputs parsed; effort is still a bounded string checked against the catalog allow-list.
- **Cross-platform (macOS/Linux/Windows)**: shared catalog lookup only; no platform-dependent paths or shortcuts.
- **Remote SSH / backwards compatibility**: no wire change. Validation still runs on the host over the existing optional model/effort fields. Older hosts keep rejecting `max` with the same error; newer hosts accept family slugs. No new opcodes or schema fields. Optional `aliases` on a catalog model is ignored by older readers.
- **Agents/integrations**: Codex catalog only. Claude/Grok/Gemini catalogs unchanged.
- **Mobile**: native-chat matcher now resolves `luna` to the seeded row; no mobile-only UI.
- **Performance**: one extra linear scan of the small seed list on launch-preference resolve.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Unknown model ids still use the conservative `xhigh` ceiling from #14281. This does not fetch Codex's live `models.json`; that remains a separate discovery path (#13183) and a better long-term follow-up for `worker-start`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter:
