### PR TITLE
feat(plugins): add forge provider plugin extension point

### DIFF
--- a/src/main/gitea/client.test.ts
+++ b/src/main/gitea/client.test.ts
@@ -13,6 +13,7 @@ import {
   getGiteaAuthStatus,
   getGiteaPullRequestForBranch,
   getGiteaPullRequestForBranchOrThrow,
+  isGiteaTokenVerifiedAtBase,
   normalizeGiteaApiBaseUrl
 } from './client'
 import { _resetGiteaRepoRefCache } from './repository-ref'
@@ -396,6 +397,23 @@ describe('Gitea client', () => {
       tokenConfigured: true
     })
     expect(String(fetchMock.mock.calls[0]?.[0])).toBe('https://git.example.com/api/v1/user')
+  })
+
+  it('verifies a token against a specific base URL via /user', async () => {
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) =>
+      Response.json({ login: 'gitea-user' })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(isGiteaTokenVerifiedAtBase('https://git.example.com/api/v1')).resolves.toBe(true)
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe('https://git.example.com/api/v1/user')
+  })
+
+  it('reports an unauthenticated token when /user is rejected', async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 401 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(isGiteaTokenVerifiedAtBase('https://git.example.com/api/v1')).resolves.toBe(false)
   })
 
   it('cancels unread error-response bodies so bundled undici cannot crash on socket close', async () => {

--- a/src/main/gitea/client.ts
+++ b/src/main/gitea/client.ts
@@ -214,6 +214,13 @@ export async function getGiteaAuthStatus(): Promise<GiteaAuthStatus> {
   }
 }
 
+export async function isGiteaTokenVerifiedAtBase(baseUrl: string): Promise<boolean> {
+  const user = await requestJsonAtBase<{ login?: string | null }>(baseUrl, '/user', {
+    timeoutMs: 4000
+  })
+  return user !== null
+}
+
 export async function getGiteaPullRequest(
   repoPath: string,
   prNumber: number,

--- a/src/main/ipc/hosted-review.ts
+++ b/src/main/ipc/hosted-review.ts
@@ -6,6 +6,11 @@ import type {
   HostedReviewCreationEligibilityArgs,
   HostedReviewForBranchArgs
 } from '../../shared/hosted-review'
+import type {
+  ApproveHostedReviewInput,
+  CommentHostedReviewInput,
+  MergeHostedReviewInput
+} from '../../shared/hosted-review-actions'
 import type { Repo } from '../../shared/repo-types'
 import type { Store } from '../persistence'
 import type { StatsCollector } from '../stats/collector'
@@ -15,6 +20,11 @@ import {
 } from '../source-control/hosted-review-creation'
 import { createStackedHostedReview } from '../source-control/stacked-hosted-review-creation'
 import { getHostedReviewForBranch } from '../source-control/hosted-review'
+import {
+  commentOnHostedReview,
+  mergeHostedReview,
+  approveHostedReview
+} from '../source-control/hosted-review-actions'
 import { resolveRegisteredWorktreePath } from './registered-worktree-roots-cache'
 import { listRepoWorktrees } from '../repo-worktrees'
 import { getLocalProjectWorktreeGitOptions } from '../project-runtime-git-options'
@@ -202,4 +212,31 @@ export function registerHostedReviewHandlers(store: Store, stats: StatsCollector
       return result
     }
   )
+
+  ipcMain.handle('hostedReview:merge', async (_event, args: MergeHostedReviewInput) => {
+    const repo = assertRegisteredRepo(args.repoPath, store)
+    return mergeHostedReview({
+      ...args,
+      repoPath: repo.path,
+      connectionId: repo.connectionId ?? null
+    })
+  })
+
+  ipcMain.handle('hostedReview:comment', async (_event, args: CommentHostedReviewInput) => {
+    const repo = assertRegisteredRepo(args.repoPath, store)
+    return commentOnHostedReview({
+      ...args,
+      repoPath: repo.path,
+      connectionId: repo.connectionId ?? null
+    })
+  })
+
+  ipcMain.handle('hostedReview:approve', async (_event, args: ApproveHostedReviewInput) => {
+    const repo = assertRegisteredRepo(args.repoPath, store)
+    return approveHostedReview({
+      ...args,
+      repoPath: repo.path,
+      connectionId: repo.connectionId ?? null
+    })
+  })
 }

--- a/src/main/ipc/hosted-review.ts
+++ b/src/main/ipc/hosted-review.ts
@@ -102,6 +102,7 @@ export function registerHostedReviewHandlers(store: Store, stats: StatsCollector
       linkedBitbucketPR: args.linkedBitbucketPR ?? null,
       linkedAzureDevOpsPR: args.linkedAzureDevOpsPR ?? null,
       linkedGiteaPR: args.linkedGiteaPR ?? null,
+      linkedPluginReview: args.linkedPluginReview ?? null,
       currentHeadOid: args.currentHeadOid ?? null,
       ...(args.active === true ? { active: true } : {}),
       ...(Object.keys(localGitOptions).length > 0 ? { localGitExecOptions: localGitOptions } : {})

--- a/src/main/plugins/plugin-content-pack-registry.ts
+++ b/src/main/plugins/plugin-content-pack-registry.ts
@@ -7,6 +7,7 @@ import {
 import { PluginLanguagePackRegistry } from './plugin-language-pack-registry'
 import { PluginVmRecipeRegistry } from './plugin-vm-recipe-registry'
 import { PluginCommandRegistry } from './plugin-command-registry'
+import { PluginForgeProviderRegistry } from './plugin-forge-provider-registry'
 import { verifyInstructionalPluginContent } from './plugin-instructional-content-integrity'
 import type { KeybindingOverrides } from '../../shared/keybindings'
 
@@ -14,6 +15,7 @@ export class PluginContentPackRegistry {
   readonly languagePacks: PluginLanguagePackRegistry
   readonly vmRecipes: PluginVmRecipeRegistry
   readonly commands: PluginCommandRegistry
+  readonly forgeProviders: PluginForgeProviderRegistry
   private readonly activationErrors = new Map<string, string>()
 
   constructor(
@@ -25,6 +27,7 @@ export class PluginContentPackRegistry {
     this.languagePacks = new PluginLanguagePackRegistry(contentVerifier)
     this.vmRecipes = new PluginVmRecipeRegistry()
     this.commands = new PluginCommandRegistry()
+    this.forgeProviders = new PluginForgeProviderRegistry()
   }
 
   async reconcile(
@@ -72,8 +75,9 @@ export class PluginContentPackRegistry {
         !this.isKilled(plugin.pluginKey)
       const languagePacks = this.languagePacks.reconcile(discovered, approveAtomically)
       const vmRecipes = this.vmRecipes.reconcile(discovered, approveAtomically)
+      const forgeProviders = this.forgeProviders.reconcile(discovered, approveAtomically)
       this.commands.reconcile(discovered, approveAtomically, keybindings)
-      await Promise.all([languagePacks, vmRecipes])
+      await Promise.all([languagePacks, vmRecipes, forgeProviders])
 
       let foundNewError = false
       for (const pluginKey of approvedKeys) {
@@ -96,6 +100,7 @@ export class PluginContentPackRegistry {
 
   private registryError(pluginKey: string): string | null {
     return (
+      this.forgeProviders.error(pluginKey) ??
       this.languagePacks.error(pluginKey) ??
       this.vmRecipes.error(pluginKey) ??
       this.commands.error(pluginKey)

--- a/src/main/plugins/plugin-forge-provider-registry.test.ts
+++ b/src/main/plugins/plugin-forge-provider-registry.test.ts
@@ -259,4 +259,33 @@ describe('PluginForgeProviderRegistry', () => {
 
     expect(registry.getByProviderId('copyforge')?.copy?.providerName).toBe('Corp')
   })
+
+  it('loads action exports (mergeReview, commentReview, listIssues) when the module provides them', async () => {
+    const registry = new PluginForgeProviderRegistry()
+    const dir = pluginDirWithModule(
+      `${VALID_MODULE}\nexport async function mergeReview() { return { ok: true } }\nexport async function commentReview() { return { ok: true } }\nexport async function listIssues() { return { ok: true, issues: [] } }\n`
+    )
+    const plugin = pluginWith(
+      'acme.actions',
+      {
+        forgeProviders: [
+          {
+            id: 'actionsforge',
+            displayName: 'Actions',
+            hosts: ['git.example'],
+            modulePath: 'provider.mjs',
+            supportsReviewCreation: true
+          }
+        ]
+      },
+      dir
+    )
+
+    await registry.reconcile([plugin], () => true)
+
+    const provider = registry.getByProviderId('actionsforge')
+    expect(typeof provider?.mergeReview).toBe('function')
+    expect(typeof provider?.commentReview).toBe('function')
+    expect(typeof provider?.listIssues).toBe('function')
+  })
 })

--- a/src/main/plugins/plugin-forge-provider-registry.test.ts
+++ b/src/main/plugins/plugin-forge-provider-registry.test.ts
@@ -1,0 +1,262 @@
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import type { PluginManifest } from '../../shared/plugins/plugin-manifest'
+import { pluginManifestSchema } from '../../shared/plugins/plugin-manifest'
+import type { DiscoveredPlugin, ValidDiscoveredPlugin } from './plugin-discovery'
+import { PluginForgeProviderRegistry } from './plugin-forge-provider-registry'
+
+function pluginWith(
+  pluginKey: string,
+  contributes: { forgeProviders: PluginManifest['contributes']['forgeProviders'] },
+  rootDir: string
+): ValidDiscoveredPlugin {
+  return {
+    pluginKey,
+    rootDir,
+    manifest: pluginManifestSchema.parse({
+      manifestVersion: 1,
+      id: pluginKey.split('.')[1] ?? pluginKey,
+      publisher: pluginKey.split('.')[0] ?? 'test',
+      name: pluginKey,
+      version: '1.0.0',
+      engines: { orca: '>=1.0.0' },
+      pluginApi: 1,
+      contributes,
+      capabilities: []
+    }),
+    consentFingerprint: 'sha256-test',
+    contentHash: null,
+    isDev: true
+  }
+}
+
+const VALID_MODULE = `
+export async function resolveRepository() { return { owner: 'acme', repo: 'app' } }
+export async function getReviewForBranch() { return null }
+export async function getReviewByNumber() { return null }
+`
+
+function pluginDirWithModule(moduleSource: string): string {
+  const dir = mkdtempSync(join(tmpdir(), 'forge-provider-test-'))
+  writeFileSync(join(dir, 'provider.mjs'), moduleSource)
+  return dir
+}
+
+describe('PluginForgeProviderRegistry', () => {
+  it('loads approved plugin providers and exposes them for host lookup', async () => {
+    const registry = new PluginForgeProviderRegistry()
+    const dir = pluginDirWithModule(VALID_MODULE)
+    const plugin = pluginWith(
+      'acme.corpforge',
+      {
+        forgeProviders: [
+          {
+            id: 'corpforge',
+            displayName: 'Corp Forge',
+            hosts: ['git.corp.example'],
+            modulePath: 'provider.mjs',
+            supportsReviewCreation: true
+          }
+        ]
+      },
+      dir
+    )
+
+    await registry.reconcile([plugin], () => true)
+
+    expect(registry.list()).toHaveLength(1)
+    const entry = registry.findByHost('GIT.CORP.EXAMPLE')
+    expect(entry?.id).toBe('corpforge')
+    expect(entry?.provider.supportsReviewCreation).toBe(true)
+    expect(registry.getByProviderId('corpforge')?.id).toBe('corpforge')
+    expect(registry.error(plugin.pluginKey)).toBeNull()
+  })
+
+  it('rejects modules missing required exports with a load error', async () => {
+    const registry = new PluginForgeProviderRegistry()
+    const dir = pluginDirWithModule('export const resolveRepository = () => null\n')
+    const plugin = pluginWith(
+      'acme.broken',
+      {
+        forgeProviders: [
+          {
+            id: 'broken',
+            displayName: 'Broken',
+            hosts: ['git.example'],
+            modulePath: 'provider.mjs',
+            supportsReviewCreation: true
+          }
+        ]
+      },
+      dir
+    )
+
+    await registry.reconcile([plugin], () => true)
+
+    expect(registry.list()).toHaveLength(0)
+    expect(registry.error(plugin.pluginKey)).toContain('failed to load forge provider')
+  })
+
+  it('flags duplicate contribution ids across plugins', async () => {
+    const registry = new PluginForgeProviderRegistry()
+    const dirA = pluginDirWithModule(VALID_MODULE)
+    const dirB = pluginDirWithModule(VALID_MODULE)
+    const pluginA = pluginWith(
+      'acme.one',
+      {
+        forgeProviders: [
+          {
+            id: 'shared',
+            displayName: 'A',
+            hosts: ['a.example'],
+            modulePath: 'provider.mjs',
+            supportsReviewCreation: true
+          }
+        ]
+      },
+      dirA
+    )
+    const pluginB = pluginWith(
+      'acme.two',
+      {
+        forgeProviders: [
+          {
+            id: 'shared',
+            displayName: 'B',
+            hosts: ['b.example'],
+            modulePath: 'provider.mjs',
+            supportsReviewCreation: true
+          }
+        ]
+      },
+      dirB
+    )
+
+    await registry.reconcile([pluginA, pluginB], () => true)
+
+    expect(registry.list()).toHaveLength(1)
+    expect(registry.error(pluginB.pluginKey)).toContain('already claimed')
+    expect(registry.getByProviderId('shared')?.supportsReviewCreation).toBe(true)
+  })
+
+  it('keeps previews for unapproved plugins without loading them', async () => {
+    const registry = new PluginForgeProviderRegistry()
+    const dir = pluginDirWithModule(VALID_MODULE)
+    const plugin = pluginWith(
+      'acme.pending',
+      {
+        forgeProviders: [
+          {
+            id: 'pending',
+            displayName: 'Pending',
+            hosts: ['git.example'],
+            modulePath: 'provider.mjs',
+            supportsReviewCreation: true
+          }
+        ]
+      },
+      dir
+    )
+
+    await registry.reconcile([plugin], () => false)
+
+    expect(registry.list()).toHaveLength(0)
+    expect(registry.preview()).toHaveLength(1)
+    expect(registry.preview()[0]?.id).toBe('pending')
+  })
+
+  it('drops entries for a removed plugin', async () => {
+    const registry = new PluginForgeProviderRegistry()
+    const dir = pluginDirWithModule(VALID_MODULE)
+    const plugin = pluginWith(
+      'acme.gone',
+      {
+        forgeProviders: [
+          {
+            id: 'gone',
+            displayName: 'Gone',
+            hosts: ['git.example'],
+            modulePath: 'provider.mjs',
+            supportsReviewCreation: true
+          }
+        ]
+      },
+      dir
+    )
+
+    await registry.reconcile([plugin], () => true)
+    expect(registry.list()).toHaveLength(1)
+
+    registry.clearPlugin(plugin.pluginKey)
+    expect(registry.list()).toHaveLength(0)
+    expect(registry.findByHost('git.example')).toBeNull()
+  })
+
+  it('ignores plugins without forge provider contributions', async () => {
+    const registry = new PluginForgeProviderRegistry()
+    const plugin = pluginWith('acme.plain', { forgeProviders: [] }, join(tmpdir(), 'nowhere'))
+
+    await registry.reconcile([plugin], () => true)
+
+    expect(registry.list()).toHaveLength(0)
+    expect(registry.preview()).toHaveLength(0)
+  })
+
+  it('survives invalid discovered plugins in the candidate list', async () => {
+    const registry = new PluginForgeProviderRegistry()
+    const dir = pluginDirWithModule(VALID_MODULE)
+    const valid = pluginWith(
+      'acme.ok',
+      {
+        forgeProviders: [
+          {
+            id: 'ok',
+            displayName: 'OK',
+            hosts: ['git.example'],
+            modulePath: 'provider.mjs',
+            supportsReviewCreation: true
+          }
+        ]
+      },
+      dir
+    )
+    const invalid: DiscoveredPlugin = {
+      rootDir: join(tmpdir(), 'nope'),
+      error: 'missing orca-plugin.json',
+      isDev: false
+    }
+
+    await registry.reconcile([invalid, valid], () => true)
+
+    expect(registry.list()).toHaveLength(1)
+    expect(registry.findByHost('git.example')?.id).toBe('ok')
+  })
+
+  it('preserves the plugin-provided copy when the module exports one', async () => {
+    const registry = new PluginForgeProviderRegistry()
+    const dir = pluginDirWithModule(
+      `${VALID_MODULE}export const copy = { shortLabel: 'PR', reviewLabel: 'Review', titleLabel: 'Pull request', providerName: 'Corp', authInstruction: 'Set a token' }\n`
+    )
+    const plugin = pluginWith(
+      'acme.copy',
+      {
+        forgeProviders: [
+          {
+            id: 'copyforge',
+            displayName: 'Copy',
+            hosts: ['git.example'],
+            modulePath: 'provider.mjs',
+            supportsReviewCreation: true
+          }
+        ]
+      },
+      dir
+    )
+
+    await registry.reconcile([plugin], () => true)
+
+    expect(registry.getByProviderId('copyforge')?.copy?.providerName).toBe('Corp')
+  })
+})

--- a/src/main/plugins/plugin-forge-provider-registry.ts
+++ b/src/main/plugins/plugin-forge-provider-registry.ts
@@ -1,0 +1,202 @@
+import { pathToFileURL } from 'node:url'
+import { join } from 'node:path'
+import {
+  isInvalidDiscoveredPlugin,
+  type DiscoveredPlugin,
+  type ValidDiscoveredPlugin
+} from './plugin-discovery'
+import type { ForgeProvider } from '../source-control/forge-provider'
+
+/**
+ * A resolved forge provider contribution from a plugin.
+ * The module has been loaded and its exports validated.
+ */
+export type ResolvedPluginForgeProvider = {
+  pluginKey: string
+  contributionId: string
+  id: string
+  displayName: string
+  hosts: string[]
+  provider: ForgeProvider
+}
+
+export class PluginForgeProviderRegistry {
+  private active: ResolvedPluginForgeProvider[] = []
+  private readonly loadErrors = new Map<string, string>()
+  /** Resolved providers pending approval (available for preview via IPC). */
+  private previews: ResolvedPluginForgeProvider[] = []
+
+  list(): readonly ResolvedPluginForgeProvider[] {
+    return this.active
+  }
+
+  preview(): readonly ResolvedPluginForgeProvider[] {
+    return this.previews
+  }
+
+  error(pluginKey: string): string | null {
+    return this.loadErrors.get(pluginKey) ?? null
+  }
+
+  /**
+   * Reconcile plugin forge providers from discovered plugins.
+   * Loads modules for approved plugins; stores previews for all.
+   */
+  async reconcile(
+    discovered: readonly DiscoveredPlugin[],
+    isApproved: (plugin: ValidDiscoveredPlugin) => boolean
+  ): Promise<void> {
+    const candidates = discovered.filter(
+      (plugin): plugin is ValidDiscoveredPlugin =>
+        !isInvalidDiscoveredPlugin(plugin) && plugin.manifest.contributes.forgeProviders.length > 0
+    )
+    const resolved: ResolvedPluginForgeProvider[] = []
+    this.loadErrors.clear()
+
+    // First pass: validate ownership - no duplicate contribution ids across plugins
+    const seenIds = new Map<string, string>() // contributionId → pluginKey
+    for (const plugin of candidates) {
+      for (const contrib of plugin.manifest.contributes.forgeProviders) {
+        const existing = seenIds.get(contrib.id)
+        if (existing && existing !== plugin.pluginKey) {
+          this.loadErrors.set(
+            plugin.pluginKey,
+            `forge provider id "${contrib.id}" is already claimed by plugin "${existing}"`
+          )
+        }
+        seenIds.set(contrib.id, plugin.pluginKey)
+      }
+    }
+
+    // Second pass: load modules for approved plugins
+    for (const plugin of candidates) {
+      if (!isApproved(plugin) || this.loadErrors.has(plugin.pluginKey)) {
+        // Store previews for all candidates (for UI / settings)
+        continue
+      }
+      for (const contrib of plugin.manifest.contributes.forgeProviders) {
+        try {
+          const module = await loadPluginForgeProviderModule(plugin.rootDir, contrib.modulePath)
+          validateForgeProviderModule(module, contrib.id)
+          // Build the provider id as <contribution-id> — unique across builtins and plugins
+          const providerId = contrib.id
+          const provider: ForgeProvider & { displayName: string } = {
+            id: providerId,
+            displayName: contrib.displayName,
+            supportsReviewCreation: contrib.supportsReviewCreation,
+            // copy is optional; plugin can provide it
+            ...(module.copy !== undefined ? { copy: module.copy } : {}),
+            resolveRepository: module.resolveRepository,
+            ...(module.isAuthenticated !== undefined
+              ? { isAuthenticated: module.isAuthenticated }
+              : {}),
+            getReviewForBranch: module.getReviewForBranch,
+            getReviewByNumber: module.getReviewByNumber,
+            ...(module.createReview !== undefined ? { createReview: module.createReview } : {})
+          }
+          resolved.push({
+            pluginKey: plugin.pluginKey,
+            contributionId: contrib.id,
+            id: providerId,
+            displayName: contrib.displayName,
+            hosts: contrib.hosts,
+            provider
+          })
+        } catch (error) {
+          this.loadErrors.set(
+            plugin.pluginKey,
+            `failed to load forge provider "${contrib.id}": ${error instanceof Error ? error.message : String(error)}`
+          )
+        }
+      }
+    }
+
+    this.previews = candidates.flatMap((plugin) =>
+      plugin.manifest.contributes.forgeProviders.map(
+        (contrib): ResolvedPluginForgeProvider => ({
+          pluginKey: plugin.pluginKey,
+          contributionId: contrib.id,
+          id: contrib.id,
+          displayName: contrib.displayName,
+          hosts: contrib.hosts,
+          provider: null as unknown as ForgeProvider // not loaded yet
+        })
+      )
+    )
+    this.active = resolved
+  }
+
+  /**
+   * Find a plugin forge provider by matching host against a remote URL host.
+   * First matches by `hosts` array (exact host match, optionally with port).
+   */
+  findByHost(host: string): ResolvedPluginForgeProvider | null {
+    const normalizedHost = host.toLowerCase()
+    for (const entry of this.active) {
+      if (entry.hosts.some((h) => h.toLowerCase() === normalizedHost)) {
+        return entry
+      }
+    }
+    return null
+  }
+
+  getByProviderId(providerId: string): ForgeProvider | null {
+    const entry = this.active.find((e) => e.id === providerId)
+    return entry?.provider ?? null
+  }
+
+  clearPlugin(pluginKey: string): void {
+    this.active = this.active.filter((e) => e.pluginKey !== pluginKey)
+    this.previews = this.previews.filter((e) => e.pluginKey !== pluginKey)
+    this.loadErrors.delete(pluginKey)
+  }
+}
+
+/**
+ * Load a plugin forge provider module from disk using dynamic import().
+ * The module file path is relative to the plugin root directory.
+ */
+async function loadPluginForgeProviderModule(
+  pluginRoot: string,
+  modulePath: string
+): Promise<Record<string, unknown>> {
+  const absolutePath = join(pluginRoot, ...modulePath.split(/[\\/]/))
+  const entryUrl = pathToFileURL(absolutePath).href
+  const mod: Record<string, unknown> = await import(entryUrl)
+  // CJS interop: Node may expose module.exports as `default` only
+  if (
+    typeof mod.default === 'object' &&
+    mod.default !== null &&
+    Object.keys(mod).length <= 2 &&
+    'resolveRepository' in mod.default
+  ) {
+    return mod.default as Record<string, unknown>
+  }
+  return mod
+}
+
+/** Structural shape of a validated plugin forge provider module export. */
+type LoadedForgeProviderModule = {
+  resolveRepository: ForgeProvider['resolveRepository']
+  getReviewForBranch: ForgeProvider['getReviewForBranch']
+  getReviewByNumber: ForgeProvider['getReviewByNumber']
+  copy?: ForgeProvider['copy']
+  isAuthenticated?: ForgeProvider['isAuthenticated']
+  createReview?: ForgeProvider['createReview']
+}
+
+/**
+ * Validate that a loaded module exports the required ForgeProvider fields.
+ */
+function validateForgeProviderModule(
+  mod: Record<string, unknown>,
+  contributionId: string
+): asserts mod is LoadedForgeProviderModule {
+  const required = ['resolveRepository', 'getReviewForBranch', 'getReviewByNumber']
+  const missing = required.filter((key) => typeof mod[key] !== 'function')
+  if (missing.length > 0) {
+    throw new Error(
+      `forge provider "${contributionId}" module is missing required exports: ${missing.join(', ')}`
+    )
+  }
+}

--- a/src/main/plugins/plugin-forge-provider-registry.ts
+++ b/src/main/plugins/plugin-forge-provider-registry.ts
@@ -48,7 +48,9 @@ export class PluginForgeProviderRegistry {
   ): Promise<void> {
     const candidates = discovered.filter(
       (plugin): plugin is ValidDiscoveredPlugin =>
-        !isInvalidDiscoveredPlugin(plugin) && plugin.manifest.contributes.forgeProviders.length > 0
+        !isInvalidDiscoveredPlugin(plugin) &&
+        plugin.manifest.contributes.vmRecipes.length === 0 &&
+        plugin.manifest.contributes.forgeProviders.length > 0
     )
     const resolved: ResolvedPluginForgeProvider[] = []
     this.loadErrors.clear()
@@ -84,7 +86,6 @@ export class PluginForgeProviderRegistry {
             id: providerId,
             displayName: contrib.displayName,
             supportsReviewCreation: contrib.supportsReviewCreation,
-            // copy is optional; plugin can provide it
             ...(module.copy !== undefined ? { copy: module.copy } : {}),
             resolveRepository: module.resolveRepository,
             ...(module.isAuthenticated !== undefined
@@ -92,7 +93,14 @@ export class PluginForgeProviderRegistry {
               : {}),
             getReviewForBranch: module.getReviewForBranch,
             getReviewByNumber: module.getReviewByNumber,
-            ...(module.createReview !== undefined ? { createReview: module.createReview } : {})
+            ...(module.createReview !== undefined ? { createReview: module.createReview } : {}),
+            ...(module.mergeReview !== undefined ? { mergeReview: module.mergeReview } : {}),
+            ...(module.commentReview !== undefined ? { commentReview: module.commentReview } : {}),
+            ...(module.approveReview !== undefined ? { approveReview: module.approveReview } : {}),
+            ...(module.listReviewComments !== undefined
+              ? { listReviewComments: module.listReviewComments }
+              : {}),
+            ...(module.listIssues !== undefined ? { listIssues: module.listIssues } : {})
           }
           resolved.push({
             pluginKey: plugin.pluginKey,
@@ -183,6 +191,11 @@ type LoadedForgeProviderModule = {
   copy?: ForgeProvider['copy']
   isAuthenticated?: ForgeProvider['isAuthenticated']
   createReview?: ForgeProvider['createReview']
+  mergeReview?: ForgeProvider['mergeReview']
+  commentReview?: ForgeProvider['commentReview']
+  approveReview?: ForgeProvider['approveReview']
+  listReviewComments?: ForgeProvider['listReviewComments']
+  listIssues?: ForgeProvider['listIssues']
 }
 
 /**

--- a/src/main/plugins/plugin-list-projection.test.ts
+++ b/src/main/plugins/plugin-list-projection.test.ts
@@ -26,6 +26,7 @@ function serviceWith(
     worker?: ReturnType<PluginService['workerState']>
     vmRecipes?: ReturnType<PluginService['contentPacks']['vmRecipes']['preview']>
     commands?: ReturnType<PluginService['contentPacks']['commands']['preview']>
+    forgeProviders?: ReturnType<PluginService['contentPacks']['forgeProviders']['preview']>
   } = {}
 ): PluginService {
   return {
@@ -39,7 +40,8 @@ function serviceWith(
     activationError: () => null,
     contentPacks: {
       vmRecipes: { preview: () => options.vmRecipes ?? [] },
-      commands: { preview: () => options.commands ?? [] }
+      commands: { preview: () => options.commands ?? [] },
+      forgeProviders: { preview: () => options.forgeProviders ?? [] }
     }
   } as unknown as PluginService
 }

--- a/src/main/plugins/plugin-list-projection.ts
+++ b/src/main/plugins/plugin-list-projection.ts
@@ -71,6 +71,7 @@ export type PluginListEntry = {
     description?: string
     commands: { phase: 'create' | 'suspend' | 'resume' | 'destroy'; command: string }[]
   }[]
+  forgeProviders: { id: string; displayName: string; hosts: string[] }[]
   restarts: number
   blockedByKillList?: { reason: string; advisoryUrl?: string }
   source?: {
@@ -115,6 +116,7 @@ export async function buildPluginList(
           commands: [],
           hasWorker: false,
           vmRecipes: [],
+          forgeProviders: [],
           restarts: 0
         }
       }
@@ -152,6 +154,10 @@ export async function buildPluginList(
           isOfficialPluginIdentity(plugin.pluginKey) &&
           isOfficialMarketplaceGitSource(lockEntry.source.marketplace.url) &&
           isOfficialOrganizationGitSource(lockEntry.source.plugin.url))
+      const forgeProviders = service.contentPacks.forgeProviders
+        .preview()
+        .filter((fp) => fp.pluginKey === plugin.pluginKey)
+        .map((fp) => ({ id: fp.id, displayName: fp.displayName, hosts: fp.hosts }))
       return {
         pluginKey: plugin.pluginKey,
         consentFingerprint: plugin.consentFingerprint,
@@ -191,6 +197,7 @@ export async function buildPluginList(
           ...(recipe.description ? { description: recipe.description } : {}),
           commands: listPluginVmRecipeCommands(recipe)
         })),
+        forgeProviders,
         restarts: worker.restarts,
         ...(killListEntry
           ? {

--- a/src/main/plugins/plugin-service.ts
+++ b/src/main/plugins/plugin-service.ts
@@ -223,7 +223,6 @@ export class PluginService {
       !this.options.getPluginKillListEntry?.(plugin.pluginKey)
     )
   }
-
   workerState(pluginKey: string): { state: PluginRunState; restarts: number } {
     return this.workerController.state(pluginKey)
   }
@@ -296,8 +295,8 @@ export class PluginService {
       plugins: this.discovered,
       eventBus: this.eventBus,
       workerController: this.workerController,
-      isRuntimeApproved: (plugin) => this.isRuntimeApproved(plugin),
-      logWarning: (pluginKey, line) => this.logBuffer.append(pluginKey, 'warn', line)
+      isRuntimeApproved: (p) => this.isRuntimeApproved(p),
+      logWarning: (key, line) => this.logBuffer.append(key, 'warn', line)
     })
   }
 
@@ -323,9 +322,7 @@ export class PluginService {
     )
     bindPluginForgeProviderResolvers(this.contentPacks.forgeProviders)
     this.contentPacksReady = true
-    const nextSpecs = collectApprovedWorkerSpecs(this.discovered, (plugin) =>
-      this.isRuntimeApproved(plugin)
-    )
+    const nextSpecs = collectApprovedWorkerSpecs(this.discovered, this.isRuntimeApproved.bind(this))
     await this.workerController.reconcile(nextSpecs)
     this.notifyChanged(true)
   }

--- a/src/main/plugins/plugin-service.ts
+++ b/src/main/plugins/plugin-service.ts
@@ -38,6 +38,7 @@ import type { PluginChangeEvent } from '../../shared/plugins/plugin-change-event
 import { waitForPluginRefreshSettlement } from './plugin-refresh-settlement'
 import { assertPluginWorkerCommand } from './plugin-command-invocation'
 import { deliverPluginEvent } from './plugin-event-delivery'
+import { bindPluginForgeProviderResolvers } from '../source-control/plugin-forge-provider-bridge'
 
 export type { PluginRuntimeDelegate } from './plugin-host-service-bindings'
 export type { PluginLogLine } from './plugin-log-buffer'
@@ -167,6 +168,7 @@ export class PluginService {
       (plugin) => isPluginApproved(enabled, plugin, consentLists),
       this.options.getKeybindings?.()
     )
+    bindPluginForgeProviderResolvers(this.contentPacks.forgeProviders)
     this.contentPacksReady = true
     const nextSpecs = collectApprovedWorkerSpecs(next, (plugin) => this.isRuntimeApproved(plugin))
     // Notify before slow shutdown so feature-off unmounts panels immediately.
@@ -319,6 +321,7 @@ export class PluginService {
       (plugin) => this.activationState(plugin) === 'approved',
       this.options.getKeybindings?.()
     )
+    bindPluginForgeProviderResolvers(this.contentPacks.forgeProviders)
     this.contentPacksReady = true
     const nextSpecs = collectApprovedWorkerSpecs(this.discovered, (plugin) =>
       this.isRuntimeApproved(plugin)

--- a/src/main/provisioned-root-ssh-adoption.ts
+++ b/src/main/provisioned-root-ssh-adoption.ts
@@ -198,6 +198,9 @@ function buildProvisionedRootMeta(
       ? { linkedAzureDevOpsPR: args.linkedAzureDevOpsPR }
       : {}),
     ...(args.linkedGiteaPR !== undefined ? { linkedGiteaPR: args.linkedGiteaPR } : {}),
+    ...(args.linkedPluginReview !== undefined
+      ? { linkedPluginReview: args.linkedPluginReview }
+      : {}),
     ...(args.linkedWorkItem !== undefined ? { linkedWorkItem: args.linkedWorkItem } : {}),
     ...(args.linkedTaskSourceContext !== undefined
       ? { linkedTaskSourceContext: args.linkedTaskSourceContext }

--- a/src/main/runtime/rpc/methods/hosted-review.ts
+++ b/src/main/runtime/rpc/methods/hosted-review.ts
@@ -36,7 +36,7 @@ const HostedReviewCreationEligibility = z.object({
 const HostedReviewCreate = z.object({
   repo: requiredString('Missing repo selector'),
   worktree: z.string().min(1, 'Missing worktree selector').optional(),
-  provider: z.enum(['github', 'gitlab', 'bitbucket', 'azure-devops', 'gitea', 'unsupported']),
+  provider: z.string().min(1).max(64),
   base: requiredString('Missing base branch'),
   head: z.string().optional(),
   title: requiredString('Missing title'),

--- a/src/main/runtime/selected-review-branch.ts
+++ b/src/main/runtime/selected-review-branch.ts
@@ -36,11 +36,12 @@ export function getSelectedReviewBranch(
   if (typeof args.linkedGiteaPR === 'number') {
     return { provider: 'gitea', number: args.linkedGiteaPR }
   }
-  // Plugin provider: return the first entry from linkedPluginReview.
+  // Plugin provider: deterministic by sorted provider id, not insertion order.
   if (args.linkedPluginReview) {
-    const entries = Object.entries(args.linkedPluginReview)
-    if (entries.length > 0) {
-      return { provider: entries[0][0], number: entries[0][1] }
+    const sorted = Object.keys(args.linkedPluginReview).sort()
+    const providerId = sorted[0]
+    if (providerId) {
+      return { provider: providerId, number: args.linkedPluginReview[providerId]! }
     }
   }
   return null

--- a/src/main/runtime/selected-review-branch.ts
+++ b/src/main/runtime/selected-review-branch.ts
@@ -9,6 +9,7 @@ export type SelectedReviewBranchInput = {
   linkedBitbucketPR?: number | null
   linkedAzureDevOpsPR?: number | null
   linkedGiteaPR?: number | null
+  linkedPluginReview?: Record<string, number> | null
   pushTarget?: GitPushTarget
 }
 
@@ -34,6 +35,13 @@ export function getSelectedReviewBranch(
   }
   if (typeof args.linkedGiteaPR === 'number') {
     return { provider: 'gitea', number: args.linkedGiteaPR }
+  }
+  // Plugin provider: return the first entry from linkedPluginReview.
+  if (args.linkedPluginReview) {
+    const entries = Object.entries(args.linkedPluginReview)
+    if (entries.length > 0) {
+      return { provider: entries[0][0], number: entries[0][1] }
+    }
   }
   return null
 }
@@ -82,12 +90,14 @@ export function getSelectedReviewLookupHints(args: SelectedReviewBranchInput): {
   linkedBitbucketPR?: number | null
   linkedAzureDevOpsPR?: number | null
   linkedGiteaPR?: number | null
+  linkedPluginReview?: Record<string, number> | null
 } {
   return {
     linkedGitHubPR: args.linkedPR ?? null,
     linkedGitLabMR: args.linkedGitLabMR ?? null,
     linkedBitbucketPR: args.linkedBitbucketPR ?? null,
     linkedAzureDevOpsPR: args.linkedAzureDevOpsPR ?? null,
-    linkedGiteaPR: args.linkedGiteaPR ?? null
+    linkedGiteaPR: args.linkedGiteaPR ?? null,
+    linkedPluginReview: args.linkedPluginReview ?? null
   }
 }

--- a/src/main/source-control/forge-provider.ts
+++ b/src/main/source-control/forge-provider.ts
@@ -4,6 +4,18 @@ import type {
   HostedReviewInfo,
   HostedReviewProvider
 } from '../../shared/hosted-review'
+import type {
+  ApproveHostedReviewInput,
+  ApproveHostedReviewResult,
+  CommentHostedReviewInput,
+  CommentHostedReviewResult,
+  ListHostedReviewCommentsInput,
+  ListHostedReviewCommentsResult,
+  ListHostedReviewIssuesInput,
+  ListHostedReviewIssuesResult,
+  MergeHostedReviewInput,
+  MergeHostedReviewResult
+} from '../../shared/hosted-review-actions'
 import {
   getAzureDevOpsPullRequest,
   getAzureDevOpsPullRequestForBranchOrThrow,
@@ -17,11 +29,16 @@ import {
 } from '../bitbucket/client'
 import { createBitbucketPullRequest } from '../bitbucket/pull-request-creation'
 import {
+  getGiteaAuthStatus,
   getGiteaPullRequest,
   getGiteaPullRequestForBranchOrThrow,
-  getGiteaRepoSlug
+  getGiteaRepoSlug,
+  isGiteaTokenVerifiedAtBase
 } from '../gitea/client'
-import { createGiteaPullRequest } from '../gitea/pull-request-creation'
+import {
+  createGiteaPullRequest,
+  isGiteaReviewCreationAuthenticated
+} from '../gitea/pull-request-creation'
 import {
   createGitHubPullRequest,
   getGitHubPRLookupRateLimitBlock,
@@ -42,6 +59,7 @@ import {
   getHostedReviewLocalGitOptions,
   type HostedReviewExecutionOptions
 } from './hosted-review-git-options'
+import { resolvePluginForgeProvider } from './plugin-forge-provider-bridge'
 
 export type ForgeProviderId = Exclude<HostedReviewProvider, 'unsupported'>
 
@@ -63,6 +81,14 @@ export type ForgeReviewByNumberInput = ForgeProviderRepositoryContext & {
   number: number
 }
 
+export type ForgeProviderCopy = {
+  shortLabel: string
+  reviewLabel: string
+  titleLabel: string
+  providerName: string
+  authInstruction: string
+}
+
 export type ForgeProvider = {
   id: ForgeProviderId
   supportsReviewCreation: boolean
@@ -75,6 +101,13 @@ export type ForgeProvider = {
     connectionId?: string | null,
     options?: HostedReviewExecutionOptions
   ): Promise<CreateHostedReviewResult>
+  copy?: ForgeProviderCopy
+  isAuthenticated?(context: ForgeProviderRepositoryContext): Promise<boolean>
+  mergeReview?(input: MergeHostedReviewInput): Promise<MergeHostedReviewResult>
+  commentReview?(input: CommentHostedReviewInput): Promise<CommentHostedReviewResult>
+  approveReview?(input: ApproveHostedReviewInput): Promise<ApproveHostedReviewResult>
+  listReviewComments?(input: ListHostedReviewCommentsInput): Promise<ListHostedReviewCommentsResult>
+  listIssues?(input: ListHostedReviewIssuesInput): Promise<ListHostedReviewIssuesResult>
 }
 
 function hostedReviewExecutionArgs(
@@ -207,8 +240,6 @@ const bitbucketForgeProvider = {
       ...hostedReviewExecutionArgs(context)
     ),
   async getReviewForBranch(input) {
-    // Why: surface a real lookup failure so eligibility records `unavailable`
-    // instead of a false "No pull request found".
     const pr = await getBitbucketPullRequestForBranchOrThrow(
       input.repoPath,
       input.branch,
@@ -240,8 +271,6 @@ const azureDevOpsForgeProvider = {
       ...hostedReviewExecutionArgs(context)
     ),
   async getReviewForBranch(input) {
-    // Why: surface a real lookup failure so eligibility records `unavailable`
-    // instead of a false "No pull request found".
     const pr = await getAzureDevOpsPullRequestForBranchOrThrow(
       input.repoPath,
       input.branch,
@@ -266,11 +295,31 @@ const azureDevOpsForgeProvider = {
 const giteaForgeProvider = {
   id: 'gitea',
   supportsReviewCreation: true,
+  copy: {
+    shortLabel: 'PR',
+    reviewLabel: 'pull request',
+    titleLabel: 'Pull Request',
+    providerName: 'Gitea',
+    authInstruction: 'Set ORCA_GITEA_TOKEN'
+  },
+  async isAuthenticated(context) {
+    if (!isGiteaReviewCreationAuthenticated()) {
+      return false
+    }
+    const configuredBase = process.env.ORCA_GITEA_API_BASE_URL?.trim()
+    if (configuredBase) {
+      return (await getGiteaAuthStatus()).authenticated
+    }
+    const repo = await getGiteaRepoSlug(
+      context.repoPath,
+      context.connectionId,
+      ...hostedReviewExecutionArgs(context)
+    )
+    return repo ? isGiteaTokenVerifiedAtBase(repo.apiBaseUrl) : isGiteaReviewCreationAuthenticated()
+  },
   resolveRepository: (context) =>
     getGiteaRepoSlug(context.repoPath, context.connectionId, ...hostedReviewExecutionArgs(context)),
   async getReviewForBranch(input) {
-    // Why: surface a real lookup failure so eligibility records `unavailable`
-    // instead of a false "No pull request found".
     const pr = await getGiteaPullRequestForBranchOrThrow(
       input.repoPath,
       input.branch,
@@ -309,10 +358,17 @@ export function getForgeProviderById(id: ForgeProviderId): ForgeProvider {
 export async function getForgeProviderForRepository(
   context: ForgeProviderRepositoryContext
 ): Promise<ForgeProvider | null> {
-  for (const provider of FORGE_PROVIDERS) {
+  for (const provider of FORGE_PROVIDERS.slice(0, 4)) {
     if (await provider.resolveRepository(context)) {
       return provider
     }
+  }
+  const pluginProvider = await resolvePluginForgeProvider(context)
+  if (pluginProvider) {
+    return pluginProvider
+  }
+  if (await giteaForgeProvider.resolveRepository(context)) {
+    return giteaForgeProvider
   }
   return null
 }
@@ -322,3 +378,7 @@ export async function detectHostedReviewProvider(
 ): Promise<HostedReviewProvider> {
   return (await getForgeProviderForRepository(context))?.id ?? 'unsupported'
 }
+
+// Why: re-export the injected plugin forge provider accessors so consumers
+// (hosted-review-creation, plugin-service) import them from one place.
+export * from './plugin-forge-provider-bridge'

--- a/src/main/source-control/hosted-review-actions.ts
+++ b/src/main/source-control/hosted-review-actions.ts
@@ -1,0 +1,98 @@
+import type {
+  ApproveHostedReviewInput,
+  ApproveHostedReviewResult,
+  CommentHostedReviewInput,
+  CommentHostedReviewResult,
+  HostedReviewActionCapabilities,
+  ListHostedReviewCommentsInput,
+  ListHostedReviewCommentsResult,
+  ListHostedReviewIssuesInput,
+  ListHostedReviewIssuesResult,
+  MergeHostedReviewInput,
+  MergeHostedReviewResult
+} from '../../shared/hosted-review-actions'
+import { getPluginProviderById } from './plugin-forge-provider-bridge'
+
+/**
+ * Generic hosted-review action dispatch for forge providers.
+ * Plugin providers implement these via ForgeProvider optional methods;
+ * built-in providers keep their CLI/REST-specific paths elsewhere.
+ */
+
+function resolveActionProvider(provider: string): {
+  mergeReview?: (input: MergeHostedReviewInput) => Promise<MergeHostedReviewResult>
+  commentReview?: (input: CommentHostedReviewInput) => Promise<CommentHostedReviewResult>
+  approveReview?: (input: ApproveHostedReviewInput) => Promise<ApproveHostedReviewResult>
+  listReviewComments?: (
+    input: ListHostedReviewCommentsInput
+  ) => Promise<ListHostedReviewCommentsResult>
+  listIssues?: (input: ListHostedReviewIssuesInput) => Promise<ListHostedReviewIssuesResult>
+} {
+  return getPluginProviderById(provider) ?? {}
+}
+
+export function getHostedReviewActionCapabilities(
+  provider: string
+): HostedReviewActionCapabilities {
+  const actions = resolveActionProvider(provider)
+  return {
+    canMerge: typeof actions.mergeReview === 'function',
+    canComment: typeof actions.commentReview === 'function',
+    canApprove: typeof actions.approveReview === 'function',
+    canListIssues: typeof actions.listIssues === 'function'
+  }
+}
+
+export async function mergeHostedReview(
+  input: MergeHostedReviewInput
+): Promise<MergeHostedReviewResult> {
+  const action = resolveActionProvider(input.provider).mergeReview
+  if (!action) {
+    return {
+      ok: false,
+      code: 'unknown',
+      error: 'Merging reviews is not supported for this provider.'
+    }
+  }
+  return action(input)
+}
+
+export async function commentOnHostedReview(
+  input: CommentHostedReviewInput
+): Promise<CommentHostedReviewResult> {
+  const action = resolveActionProvider(input.provider).commentReview
+  if (!action) {
+    return { ok: false, code: 'unknown', error: 'Comments are not supported for this provider.' }
+  }
+  return action(input)
+}
+
+export async function approveHostedReview(
+  input: ApproveHostedReviewInput
+): Promise<ApproveHostedReviewResult> {
+  const action = resolveActionProvider(input.provider).approveReview
+  if (!action) {
+    return { ok: false, code: 'unknown', error: 'Approval is not supported for this provider.' }
+  }
+  return action(input)
+}
+
+export async function listHostedReviewComments(
+  input: ListHostedReviewCommentsInput
+): Promise<ListHostedReviewCommentsResult> {
+  const action = resolveActionProvider(input.provider).listReviewComments
+  if (!action) {
+    return { ok: false, code: 'unknown', error: 'Comments are not supported for this provider.' }
+  }
+  return action(input)
+}
+
+export async function listHostedReviewIssues(
+  input: ListHostedReviewIssuesInput
+): Promise<ListHostedReviewIssuesResult> {
+  const action = resolveActionProvider(input.provider).listIssues
+  if (!action) {
+    return { ok: false, code: 'unknown', error: 'Issues are not supported for this provider.' }
+  }
+  return action(input)
+}

--- a/src/main/source-control/hosted-review-actions.ts
+++ b/src/main/source-control/hosted-review-actions.ts
@@ -11,7 +11,10 @@ import type {
   MergeHostedReviewInput,
   MergeHostedReviewResult
 } from '../../shared/hosted-review-actions'
+import { getForgeProviderForRepository, type ForgeProvider } from './forge-provider'
 import { getPluginProviderById } from './plugin-forge-provider-bridge'
+
+const NO_ACTIONS: Partial<ForgeProvider> = {}
 
 /**
  * Generic hosted-review action dispatch for forge providers.
@@ -19,22 +22,23 @@ import { getPluginProviderById } from './plugin-forge-provider-bridge'
  * built-in providers keep their CLI/REST-specific paths elsewhere.
  */
 
-function resolveActionProvider(provider: string): {
-  mergeReview?: (input: MergeHostedReviewInput) => Promise<MergeHostedReviewResult>
-  commentReview?: (input: CommentHostedReviewInput) => Promise<CommentHostedReviewResult>
-  approveReview?: (input: ApproveHostedReviewInput) => Promise<ApproveHostedReviewResult>
-  listReviewComments?: (
-    input: ListHostedReviewCommentsInput
-  ) => Promise<ListHostedReviewCommentsResult>
-  listIssues?: (input: ListHostedReviewIssuesInput) => Promise<ListHostedReviewIssuesResult>
-} {
-  return getPluginProviderById(provider) ?? {}
+/**
+ * Resolve the plugin provider that owns a repo before dispatching an action,
+ * so a stale or crafted provider id cannot invoke a plugin on another forge.
+ */
+async function resolveActionProvider(
+  provider: string,
+  repoPath: string,
+  connectionId?: string | null
+): Promise<Partial<ForgeProvider>> {
+  const resolved = await getForgeProviderForRepository({ repoPath, connectionId })
+  return resolved && resolved.id === provider ? resolved : NO_ACTIONS
 }
 
 export function getHostedReviewActionCapabilities(
   provider: string
 ): HostedReviewActionCapabilities {
-  const actions = resolveActionProvider(provider)
+  const actions: Partial<ForgeProvider> = getPluginProviderById(provider) ?? NO_ACTIONS
   return {
     canMerge: typeof actions.mergeReview === 'function',
     canComment: typeof actions.commentReview === 'function',
@@ -46,7 +50,8 @@ export function getHostedReviewActionCapabilities(
 export async function mergeHostedReview(
   input: MergeHostedReviewInput
 ): Promise<MergeHostedReviewResult> {
-  const action = resolveActionProvider(input.provider).mergeReview
+  const actions = await resolveActionProvider(input.provider, input.repoPath, input.connectionId)
+  const action = actions.mergeReview
   if (!action) {
     return {
       ok: false,
@@ -60,7 +65,8 @@ export async function mergeHostedReview(
 export async function commentOnHostedReview(
   input: CommentHostedReviewInput
 ): Promise<CommentHostedReviewResult> {
-  const action = resolveActionProvider(input.provider).commentReview
+  const actions = await resolveActionProvider(input.provider, input.repoPath, input.connectionId)
+  const action = actions.commentReview
   if (!action) {
     return { ok: false, code: 'unknown', error: 'Comments are not supported for this provider.' }
   }
@@ -70,7 +76,8 @@ export async function commentOnHostedReview(
 export async function approveHostedReview(
   input: ApproveHostedReviewInput
 ): Promise<ApproveHostedReviewResult> {
-  const action = resolveActionProvider(input.provider).approveReview
+  const actions = await resolveActionProvider(input.provider, input.repoPath, input.connectionId)
+  const action = actions.approveReview
   if (!action) {
     return { ok: false, code: 'unknown', error: 'Approval is not supported for this provider.' }
   }
@@ -80,7 +87,8 @@ export async function approveHostedReview(
 export async function listHostedReviewComments(
   input: ListHostedReviewCommentsInput
 ): Promise<ListHostedReviewCommentsResult> {
-  const action = resolveActionProvider(input.provider).listReviewComments
+  const actions = await resolveActionProvider(input.provider, input.repoPath, input.connectionId)
+  const action = actions.listReviewComments
   if (!action) {
     return { ok: false, code: 'unknown', error: 'Comments are not supported for this provider.' }
   }
@@ -90,7 +98,8 @@ export async function listHostedReviewComments(
 export async function listHostedReviewIssues(
   input: ListHostedReviewIssuesInput
 ): Promise<ListHostedReviewIssuesResult> {
-  const action = resolveActionProvider(input.provider).listIssues
+  const actions = await resolveActionProvider(input.provider, input.repoPath, input.connectionId)
+  const action = actions.listIssues
   if (!action) {
     return { ok: false, code: 'unknown', error: 'Issues are not supported for this provider.' }
   }

--- a/src/main/source-control/hosted-review-creation.ts
+++ b/src/main/source-control/hosted-review-creation.ts
@@ -12,10 +12,7 @@ import {
   normalizeHostedReviewBaseRef,
   normalizeHostedReviewHeadRef
 } from '../../shared/hosted-review-refs'
-import {
-  supportsHostedReviewCreation,
-  type HostedReviewCreationProvider
-} from '../../shared/hosted-review-creation-providers'
+import { supportsHostedReviewCreation } from '../../shared/hosted-review-creation-providers'
 import { isAzureDevOpsReviewCreationAuthenticated } from '../azure-devops/pull-request-creation'
 import { isGiteaReviewCreationAuthenticated } from '../gitea/pull-request-creation'
 import { isBitbucketReviewCreationAuthenticated } from '../bitbucket/pull-request-creation'
@@ -38,7 +35,11 @@ import {
   release as releaseGlab
 } from '../gitlab/gl-utils'
 import { getSshGitProvider } from '../providers/ssh-git-dispatch'
-import { detectHostedReviewProvider, getForgeProviderForRepository } from './forge-provider'
+import {
+  detectHostedReviewProvider,
+  getForgeProviderForRepository,
+  getPluginProviderById
+} from './forge-provider'
 import { invalidateHostedReviewBranchCache } from './hosted-review-branch-cache'
 import { getHostedReviewForBranch } from './hosted-review'
 import {
@@ -270,6 +271,17 @@ function reviewCopy(provider: HostedReviewProvider): {
   providerName: string
   authInstruction: string
 } {
+  // Plugin provider metadata lookup (unknown provider id strings)
+  const pluginProvider = getPluginProviderById(provider)
+  if (pluginProvider?.copy) {
+    return {
+      shortLabel: pluginProvider.copy.shortLabel as 'PR' | 'MR',
+      reviewLabel: pluginProvider.copy.reviewLabel as 'pull request' | 'merge request',
+      providerName: pluginProvider.copy.providerName,
+      authInstruction: pluginProvider.copy.authInstruction
+    }
+  }
+
   if (provider === 'gitlab') {
     return {
       shortLabel: 'MR',
@@ -311,7 +323,7 @@ function reviewCopy(provider: HostedReviewProvider): {
 }
 
 async function isProviderAuthenticated(
-  provider: HostedReviewCreationProvider,
+  provider: HostedReviewProvider,
   repoPath: string,
   connectionId?: string | null,
   options: HostedReviewExecutionOptions = {}
@@ -329,6 +341,11 @@ async function isProviderAuthenticated(
     // Why: falling through to the GitHub check made Create PR unusable for
     // anyone with Bitbucket connected but no `gh auth login`.
     return isBitbucketReviewCreationAuthenticated()
+  }
+  // Plugin forge provider auth check (fallback for unknown providers)
+  const pluginProvider = getPluginProviderById(provider)
+  if (pluginProvider?.isAuthenticated) {
+    return pluginProvider.isAuthenticated({ repoPath, connectionId })
   }
   return isGitHubAuthenticated(repoPath, connectionId, options)
 }
@@ -563,7 +580,10 @@ export async function getHostedReviewCreationEligibility(
       nextAction: 'open_existing_review'
     }
   }
-  if (!supportsHostedReviewCreation(provider)) {
+  if (
+    !supportsHostedReviewCreation(provider) &&
+    !getPluginProviderById(provider as string)?.createReview
+  ) {
     return {
       ...baseResult,
       canCreate: false,
@@ -627,7 +647,10 @@ export async function createHostedReview(
   connectionId?: string | null,
   options: HostedReviewExecutionOptions = {}
 ): Promise<CreateHostedReviewResult> {
-  if (!supportsHostedReviewCreation(input.provider)) {
+  if (
+    !supportsHostedReviewCreation(input.provider) &&
+    !getPluginProviderById(input.provider)?.createReview
+  ) {
     return {
       ok: false,
       code: 'unsupported_provider',

--- a/src/main/source-control/hosted-review-creation.ts
+++ b/src/main/source-control/hosted-review-creation.ts
@@ -342,10 +342,14 @@ async function isProviderAuthenticated(
     // anyone with Bitbucket connected but no `gh auth login`.
     return isBitbucketReviewCreationAuthenticated()
   }
-  // Plugin forge provider auth check (fallback for unknown providers)
+  // Plugin forge provider auth check (fallback for unknown providers). A
+  // plugin without an auth hook opts out of the preflight — its own credentials
+  // (or none) are the contract, so never fall through to GitHub auth.
   const pluginProvider = getPluginProviderById(provider)
-  if (pluginProvider?.isAuthenticated) {
-    return pluginProvider.isAuthenticated({ repoPath, connectionId })
+  if (pluginProvider) {
+    return pluginProvider.isAuthenticated
+      ? pluginProvider.isAuthenticated({ repoPath, connectionId })
+      : true
   }
   return isGitHubAuthenticated(repoPath, connectionId, options)
 }

--- a/src/main/source-control/hosted-review.ts
+++ b/src/main/source-control/hosted-review.ts
@@ -61,7 +61,8 @@ export async function getHostedReviewForBranch(
     input.linkedGitLabMR == null &&
     input.linkedBitbucketPR == null &&
     input.linkedAzureDevOpsPR == null &&
-    input.linkedGiteaPR == null
+    input.linkedGiteaPR == null &&
+    (input.linkedPluginReview == null || Object.keys(input.linkedPluginReview).length === 0)
   ) {
     return null
   }

--- a/src/main/source-control/hosted-review.ts
+++ b/src/main/source-control/hosted-review.ts
@@ -27,7 +27,7 @@ function reviewLinkForProvider(
       return { linkedReviewNumber: input.linkedGiteaPR ?? null }
     default:
       // Plugin providers keep their own linked number outside the builtin fields.
-      return {}
+      return { linkedReviewNumber: input.linkedPluginReview?.[provider] ?? null }
   }
 }
 
@@ -42,6 +42,7 @@ export async function getHostedReviewForBranch(
     linkedBitbucketPR?: number | null
     linkedAzureDevOpsPR?: number | null
     linkedGiteaPR?: number | null
+    linkedPluginReview?: Record<string, number> | null
     currentHeadOid?: string | null
     /**
      * Set by surfaces that only ever render the selected worktree, which is the

--- a/src/main/source-control/hosted-review.ts
+++ b/src/main/source-control/hosted-review.ts
@@ -25,6 +25,9 @@ function reviewLinkForProvider(
       return { linkedReviewNumber: input.linkedAzureDevOpsPR ?? null }
     case 'gitea':
       return { linkedReviewNumber: input.linkedGiteaPR ?? null }
+    default:
+      // Plugin providers keep their own linked number outside the builtin fields.
+      return {}
   }
 }
 

--- a/src/main/source-control/plugin-forge-provider-bridge.test.ts
+++ b/src/main/source-control/plugin-forge-provider-bridge.test.ts
@@ -46,6 +46,11 @@ describe('hostFromRemoteUrl', () => {
     )
   })
 
+  it('normalizes default ports (443, 80) away via URL.host convention', () => {
+    expect(hostFromRemoteUrl('https://git.corp.example:443/acme/app.git')).toBe('git.corp.example')
+    expect(hostFromRemoteUrl('http://git.corp.example:80/acme/app.git')).toBe('git.corp.example')
+  })
+
   it('returns null for unparseable inputs', () => {
     expect(hostFromRemoteUrl('not a url')).toBeNull()
     expect(hostFromRemoteUrl('')).toBeNull()

--- a/src/main/source-control/plugin-forge-provider-bridge.test.ts
+++ b/src/main/source-control/plugin-forge-provider-bridge.test.ts
@@ -30,9 +30,20 @@ const hostRegistry = {
 
 describe('hostFromRemoteUrl', () => {
   it('parses https, ssh, and scp-like remote urls', () => {
-    expect(hostFromRemoteUrl('https://Git.Corp.Example:8443/acme/app.git')).toBe('git.corp.example')
+    expect(hostFromRemoteUrl('https://Git.Corp.Example:8443/acme/app.git')).toBe(
+      'git.corp.example:8443'
+    )
     expect(hostFromRemoteUrl('ssh://git@git.corp.example/acme/app.git')).toBe('git.corp.example')
     expect(hostFromRemoteUrl('git@git.corp.example:acme/app.git')).toBe('git.corp.example')
+  })
+
+  it('preserves explicit ports in scp-like remotes', () => {
+    expect(hostFromRemoteUrl('ssh://git@git.corp.example:2222/acme/app.git')).toBe(
+      'git.corp.example:2222'
+    )
+    expect(hostFromRemoteUrl('git@git.corp.example:2222:acme/app.git')).toBe(
+      'git.corp.example:2222'
+    )
   })
 
   it('returns null for unparseable inputs', () => {

--- a/src/main/source-control/plugin-forge-provider-bridge.test.ts
+++ b/src/main/source-control/plugin-forge-provider-bridge.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { ForgeProvider, ForgeProviderRepositoryContext } from './forge-provider'
+import {
+  bindPluginForgeProviderResolvers,
+  getPluginProviderByHost,
+  getPluginProviderById,
+  hostFromRemoteUrl,
+  resolvePluginForgeProvider
+} from './plugin-forge-provider-bridge'
+
+vi.mock('../git/remote-url-probe', () => ({
+  readRemoteUrl: vi.fn(async () => 'https://git.corp.example/acme/app.git')
+}))
+
+function provider(id: string): ForgeProvider {
+  return {
+    id,
+    supportsReviewCreation: true,
+    resolveRepository: vi.fn(async () => ({ owner: 'acme', repo: 'app' })),
+    getReviewForBranch: vi.fn(async () => null),
+    getReviewByNumber: vi.fn(async () => null)
+  }
+}
+
+const hostRegistry = {
+  getByProviderId: (id: string) => (id === 'corpforge' ? provider('corpforge') : null),
+  findByHost: (host: string) =>
+    host.toLowerCase() === 'git.corp.example' ? { provider: provider('corpforge') } : null
+}
+
+describe('hostFromRemoteUrl', () => {
+  it('parses https, ssh, and scp-like remote urls', () => {
+    expect(hostFromRemoteUrl('https://Git.Corp.Example:8443/acme/app.git')).toBe('git.corp.example')
+    expect(hostFromRemoteUrl('ssh://git@git.corp.example/acme/app.git')).toBe('git.corp.example')
+    expect(hostFromRemoteUrl('git@git.corp.example:acme/app.git')).toBe('git.corp.example')
+  })
+
+  it('returns null for unparseable inputs', () => {
+    expect(hostFromRemoteUrl('not a url')).toBeNull()
+    expect(hostFromRemoteUrl('')).toBeNull()
+  })
+})
+
+describe('bindPluginForgeProviderResolvers', () => {
+  it('routes provider-id lookups through the registry', () => {
+    bindPluginForgeProviderResolvers(hostRegistry)
+    expect(getPluginProviderById('corpforge')?.id).toBe('corpforge')
+    expect(getPluginProviderById('missing')).toBeNull()
+  })
+
+  it('routes host lookups through the registry case-insensitively', () => {
+    bindPluginForgeProviderResolvers(hostRegistry)
+    expect(getPluginProviderByHost('GIT.CORP.EXAMPLE')?.id).toBe('corpforge')
+    expect(getPluginProviderByHost('other.example')).toBeNull()
+  })
+
+  it('resolves a plugin provider only after confirming the repository', async () => {
+    const confirmed = {
+      getByProviderId: () => null,
+      findByHost: (host: string) =>
+        host.toLowerCase() === 'git.corp.example' ? { provider: provider('corpforge') } : null
+    }
+    bindPluginForgeProviderResolvers(confirmed)
+    const context = { repoPath: '/tmp/repo' } as ForgeProviderRepositoryContext
+    expect((await resolvePluginForgeProvider(context))?.id).toBe('corpforge')
+  })
+})

--- a/src/main/source-control/plugin-forge-provider-bridge.ts
+++ b/src/main/source-control/plugin-forge-provider-bridge.ts
@@ -3,20 +3,29 @@ import { readRemoteUrl } from '../git/remote-url-probe'
 
 // A minimal host parser for plugin provider remote matching.
 /**
- * Extract the host (hostname, lowercased) from any git remote URL form:
+ * Extract the host (hostname[:port], lowercased) from any git remote URL form:
  * https://host[:port]/path, ssh://git@host[:port]/path, git@host:path.
+ * Ports are preserved so a manifest host like `git.example:8443` matches
+ * exactly instead of colliding with the same hostname on the default port.
  */
 export function hostFromRemoteUrl(remoteUrl: string): string | null {
   const trimmed = remoteUrl.trim().replace(/^git\+/, '')
   if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) {
     try {
-      return new URL(trimmed).hostname.toLowerCase()
+      const url = new URL(trimmed)
+      const host = url.hostname.toLowerCase()
+      const port = url.port ? `:${url.port}` : ''
+      return `${host}${port}`
     } catch {
       return null
     }
   }
-  const scpLike = trimmed.match(/^(?:[^@/:]+@)?([^:\s/]+):/)
-  return scpLike ? scpLike[1]!.toLowerCase() : null
+  const scpLike = trimmed.match(/^(?:[^@/:]+@)?([^:\s/]+)(?::(\d+))?:/)
+  if (!scpLike) {
+    return null
+  }
+  const host = scpLike[1]!.toLowerCase()
+  return scpLike[2] ? `${host}:${scpLike[2]}` : host
 }
 
 export type PluginForgeProviderRegistryHandle = {

--- a/src/main/source-control/plugin-forge-provider-bridge.ts
+++ b/src/main/source-control/plugin-forge-provider-bridge.ts
@@ -1,0 +1,94 @@
+import type { ForgeProvider, ForgeProviderRepositoryContext } from './forge-provider'
+import { readRemoteUrl } from '../git/remote-url-probe'
+
+// A minimal host parser for plugin provider remote matching.
+/**
+ * Extract the host (hostname, lowercased) from any git remote URL form:
+ * https://host[:port]/path, ssh://git@host[:port]/path, git@host:path.
+ */
+export function hostFromRemoteUrl(remoteUrl: string): string | null {
+  const trimmed = remoteUrl.trim().replace(/^git\+/, '')
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) {
+    try {
+      return new URL(trimmed).hostname.toLowerCase()
+    } catch {
+      return null
+    }
+  }
+  const scpLike = trimmed.match(/^(?:[^@/:]+@)?([^:\s/]+):/)
+  return scpLike ? scpLike[1]!.toLowerCase() : null
+}
+
+export type PluginForgeProviderRegistryHandle = {
+  getByProviderId(id: string): ForgeProvider | null
+  findByHost(host: string): { provider: ForgeProvider } | null
+}
+
+/** Batch-set all three plugin forge provider resolvers from a registry handle. */
+export function bindPluginForgeProviderResolvers(
+  registry: PluginForgeProviderRegistryHandle
+): void {
+  setPluginProviderByIdResolver((providerId) => registry.getByProviderId(providerId))
+  setPluginProviderByHostResolver((host) => registry.findByHost(host)?.provider ?? null)
+  setPluginForgeProviderResolver(async (context) => {
+    const remoteUrl = await readRemoteUrl(
+      {
+        repoPath: context.repoPath,
+        connectionId: context.connectionId ?? null
+      },
+      'origin'
+    )
+    if (!remoteUrl) {
+      return null
+    }
+    const host = hostFromRemoteUrl(remoteUrl)
+    if (!host) {
+      return null
+    }
+    const entry = registry.findByHost(host)
+    if (!entry) {
+      return null
+    }
+    const resolved = await entry.provider.resolveRepository(context)
+    return resolved ? entry.provider : null
+  })
+}
+let pluginProviderById: (id: string) => ForgeProvider | null = () => null
+
+export function getPluginProviderById(id: string): ForgeProvider | null {
+  return pluginProviderById(id)
+}
+
+export function setPluginProviderByIdResolver(
+  resolver: (id: string) => ForgeProvider | null
+): void {
+  pluginProviderById = resolver
+}
+
+let pluginProviderByHost: (host: string) => ForgeProvider | null = () => null
+
+export function getPluginProviderByHost(host: string): ForgeProvider | null {
+  return pluginProviderByHost(host)
+}
+
+export function setPluginProviderByHostResolver(
+  resolver: (host: string) => ForgeProvider | null
+): void {
+  pluginProviderByHost = resolver
+}
+
+let pluginForgeProviderResolver: (
+  context: ForgeProviderRepositoryContext
+) => Promise<ForgeProvider | null> = async () => null
+
+export async function resolvePluginForgeProvider(
+  context: ForgeProviderRepositoryContext
+): Promise<ForgeProvider | null> {
+  return pluginForgeProviderResolver(context)
+}
+
+export function setPluginForgeProviderResolver(
+  resolver: (context: ForgeProviderRepositoryContext) => Promise<ForgeProvider | null>
+): void {
+  pluginForgeProviderResolver = resolver
+}

--- a/src/main/source-control/pull-request-linked-issue.ts
+++ b/src/main/source-control/pull-request-linked-issue.ts
@@ -17,8 +17,11 @@ function inferIssueProvider(
   meta: PullRequestLinkedIssueMeta,
   provider?: HostedReviewProvider | null
 ): 'github' | 'gitlab' | null {
-  if (provider === 'github' || provider === 'gitlab') {
-    return provider
+  if (provider === 'github') {
+    return 'github'
+  }
+  if (provider === 'gitlab') {
+    return 'gitlab'
   }
   if (provider) {
     return null

--- a/src/renderer/src/components/right-sidebar/parent-pr-checks-hosted-review-cache.ts
+++ b/src/renderer/src/components/right-sidebar/parent-pr-checks-hosted-review-cache.ts
@@ -70,6 +70,8 @@ function getLinkedReviewNumberForProvider(
       return worktree.linkedGiteaPR ?? null
     case 'unsupported':
       return null
+    default:
+      return null
   }
 }
 

--- a/src/renderer/src/components/right-sidebar/parent-pr-checks-hosted-review-cache.ts
+++ b/src/renderer/src/components/right-sidebar/parent-pr-checks-hosted-review-cache.ts
@@ -29,7 +29,8 @@ export function canUseParentPrChecksHostedReviewCacheEntry(
     worktree.linkedBitbucketPR ?? null,
     worktree.linkedAzureDevOpsPR ?? null,
     worktree.linkedGiteaPR ?? null,
-    { reviewHintKey: entry.linkedReviewHintKey }
+    { reviewHintKey: entry.linkedReviewHintKey },
+    worktree.linkedPluginReview ?? null
   )
   return display?.provider === review.provider && display.number === review.number
 }
@@ -71,7 +72,7 @@ function getLinkedReviewNumberForProvider(
     case 'unsupported':
       return null
     default:
-      return null
+      return worktree.linkedPluginReview?.[provider] ?? null
   }
 }
 

--- a/src/renderer/src/components/right-sidebar/parent-pr-checks-hosted-review-cache.ts
+++ b/src/renderer/src/components/right-sidebar/parent-pr-checks-hosted-review-cache.ts
@@ -82,6 +82,7 @@ function hasLinkedReview(worktree: Worktree): boolean {
     worktree.linkedGitLabMR != null ||
     worktree.linkedBitbucketPR != null ||
     worktree.linkedAzureDevOpsPR != null ||
-    worktree.linkedGiteaPR != null
+    worktree.linkedGiteaPR != null ||
+    (worktree.linkedPluginReview != null && Object.keys(worktree.linkedPluginReview).length > 0)
   )
 }

--- a/src/renderer/src/components/right-sidebar/parent-pr-checks-rows.ts
+++ b/src/renderer/src/components/right-sidebar/parent-pr-checks-rows.ts
@@ -120,7 +120,9 @@ function buildParentPrChecksRow(
     args.worktree.linkedGitLabMR ?? null,
     args.worktree.linkedBitbucketPR ?? null,
     args.worktree.linkedAzureDevOpsPR ?? null,
-    args.worktree.linkedGiteaPR ?? null
+    args.worktree.linkedGiteaPR ?? null,
+    undefined,
+    args.worktree.linkedPluginReview ?? null
   )
   const review = reviewSnapshot.review
   const status = classifyParentPrChecksRowStatus({
@@ -303,6 +305,7 @@ function hasLinkedReview(worktree: Worktree): boolean {
     worktree.linkedBitbucketPR ??
     worktree.linkedAzureDevOpsPR ??
     worktree.linkedGiteaPR ??
+    worktree.linkedPluginReview ??
     null
   )
 }
@@ -313,6 +316,7 @@ function getLinkedReviewHints(worktree: Worktree): Parameters<typeof linkedRevie
     linkedGitLabMR: worktree.linkedGitLabMR ?? null,
     linkedBitbucketPR: worktree.linkedBitbucketPR ?? null,
     linkedAzureDevOpsPR: worktree.linkedAzureDevOpsPR ?? null,
-    linkedGiteaPR: worktree.linkedGiteaPR ?? null
+    linkedGiteaPR: worktree.linkedGiteaPR ?? null,
+    linkedPluginReview: worktree.linkedPluginReview ?? null
   }
 }

--- a/src/renderer/src/components/right-sidebar/parent-pr-checks-rows.ts
+++ b/src/renderer/src/components/right-sidebar/parent-pr-checks-rows.ts
@@ -120,9 +120,7 @@ function buildParentPrChecksRow(
     args.worktree.linkedGitLabMR ?? null,
     args.worktree.linkedBitbucketPR ?? null,
     args.worktree.linkedAzureDevOpsPR ?? null,
-    args.worktree.linkedGiteaPR ?? null,
-    undefined,
-    args.worktree.linkedPluginReview ?? null
+    args.worktree.linkedGiteaPR ?? null
   )
   const review = reviewSnapshot.review
   const status = classifyParentPrChecksRowStatus({
@@ -305,7 +303,6 @@ function hasLinkedReview(worktree: Worktree): boolean {
     worktree.linkedBitbucketPR ??
     worktree.linkedAzureDevOpsPR ??
     worktree.linkedGiteaPR ??
-    worktree.linkedPluginReview ??
     null
   )
 }
@@ -316,7 +313,6 @@ function getLinkedReviewHints(worktree: Worktree): Parameters<typeof linkedRevie
     linkedGitLabMR: worktree.linkedGitLabMR ?? null,
     linkedBitbucketPR: worktree.linkedBitbucketPR ?? null,
     linkedAzureDevOpsPR: worktree.linkedAzureDevOpsPR ?? null,
-    linkedGiteaPR: worktree.linkedGiteaPR ?? null,
-    linkedPluginReview: worktree.linkedPluginReview ?? null
+    linkedGiteaPR: worktree.linkedGiteaPR ?? null
   }
 }

--- a/src/renderer/src/components/right-sidebar/source-control-created-review-link.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-created-review-link.ts
@@ -45,6 +45,9 @@ export function resolveCreatedHostedReviewLink(
     case 'unsupported':
       return { worktree: {}, lookup: {} }
     default:
-      return { worktree: { linkedPluginReview: { [provider]: number } }, lookup: {} }
+      return {
+        worktree: { linkedPluginReview: { [provider]: number } },
+        lookup: { linkedPluginReview: { [provider]: number } }
+      }
   }
 }

--- a/src/renderer/src/components/right-sidebar/source-control-created-review-link.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-created-review-link.ts
@@ -6,6 +6,8 @@ type WorktreeReviewLink = Partial<{
   linkedBitbucketPR: number
   linkedAzureDevOpsPR: number
   linkedGiteaPR: number
+  /** Plugin forge providers store their linked number per provider id. */
+  linkedPluginReview?: Record<string, number>
 }>
 
 type HostedReviewLookupLink = Partial<{
@@ -14,6 +16,7 @@ type HostedReviewLookupLink = Partial<{
   linkedBitbucketPR: number
   linkedAzureDevOpsPR: number
   linkedGiteaPR: number
+  linkedPluginReview?: Record<string, number>
 }>
 
 export type CreatedHostedReviewLink = {
@@ -41,5 +44,7 @@ export function resolveCreatedHostedReviewLink(
       return { worktree: { linkedBitbucketPR: number }, lookup: { linkedBitbucketPR: number } }
     case 'unsupported':
       return { worktree: {}, lookup: {} }
+    default:
+      return { worktree: { linkedPluginReview: { [provider]: number } }, lookup: {} }
   }
 }

--- a/src/renderer/src/components/right-sidebar/source-control/review/manual-review-url.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/review/manual-review-url.ts
@@ -188,6 +188,8 @@ export function buildSourceControlManualReviewUrl(input: ManualReviewUrlInput): 
         sourceRef: `refs/heads/${headBranch}`,
         targetRef: `refs/heads/${baseBranch}`
       })
+    default:
+      return null
     case 'gitea':
       return `${baseRepo.webBaseUrl}/compare/${encodeCompareRef(baseBranch)}...${encodeCompareRef(headBranch)}`
   }

--- a/src/renderer/src/components/settings/PluginMarketplaceBrowser.test.tsx
+++ b/src/renderer/src/components/settings/PluginMarketplaceBrowser.test.tsx
@@ -72,7 +72,8 @@ const preview: PluginMarketplaceHostInstallPreview = {
       languagePacks: [],
       keybindings: [],
       vmRecipes: [],
-      agents: []
+      agents: [],
+      forgeProviders: []
     },
     capabilities: [{ kind: 'workspace:read' }]
   }

--- a/src/renderer/src/components/sidebar/use-worktree-card-review-details.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-card-review-details.ts
@@ -106,13 +106,15 @@ export function useWorktreeCardReviewDetails({
     linkedGitLabMR !== null ||
     linkedBitbucketPR !== null ||
     linkedAzureDevOpsPR !== null ||
-    linkedGiteaPR !== null
+    linkedGiteaPR !== null ||
+    (worktree.linkedPluginReview != null && Object.keys(worktree.linkedPluginReview).length > 0)
   const hasLinkedReview =
     linkedGitHubPR !== null ||
     linkedGitLabMR !== null ||
     linkedBitbucketPR !== null ||
     linkedAzureDevOpsPR !== null ||
-    linkedGiteaPR !== null
+    linkedGiteaPR !== null ||
+    (worktree.linkedPluginReview != null && Object.keys(worktree.linkedPluginReview).length > 0)
   // Why: a newer hosted-review miss trusts the merged-PR cache only when the stored head proves it still describes the current commit.
   const cachedBranchPR = prCacheEntry?.data
   const cachedBranchPRFetchedAt = prCacheEntry?.fetchedAt

--- a/src/renderer/src/components/sidebar/use-worktree-card-review-details.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-card-review-details.ts
@@ -169,7 +169,8 @@ export function useWorktreeCardReviewDetails({
           ? ''
           : hostedReviewEntry?.linkedReviewHintKey,
       branchLookupGitHubPRNumber
-    }
+    },
+    worktree.linkedPluginReview ?? null
   )
 
   return {

--- a/src/renderer/src/components/sidebar/worktree-card-pr-display.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-pr-display.ts
@@ -26,6 +26,7 @@ type LinkedReviewNumbers = {
   linkedBitbucketPR: number | null
   linkedAzureDevOpsPR: number | null
   linkedGiteaPR: number | null
+  linkedPluginReview?: Record<string, number> | null
 }
 
 export type WorktreeCardPrDisplay =
@@ -61,7 +62,7 @@ function getLinkedReviewNumber(
     case 'gitea':
       return links.linkedGiteaPR
     default:
-      return null
+      return links.linkedPluginReview?.[provider] ?? null
   }
 }
 
@@ -87,14 +88,16 @@ export function getWorktreeCardPrDisplay(
   linkedBitbucketPR: number | null = null,
   linkedAzureDevOpsPR: number | null = null,
   linkedGiteaPR: number | null = null,
-  options: WorktreeCardPrDisplayOptions = {}
+  options: WorktreeCardPrDisplayOptions = {},
+  linkedPluginReview: Record<string, number> | null = null
 ): WorktreeCardPrDisplay | null {
   const links = {
     linkedPR,
     linkedGitLabMR,
     linkedBitbucketPR,
     linkedAzureDevOpsPR,
-    linkedGiteaPR
+    linkedGiteaPR,
+    linkedPluginReview
   }
   const hasLinkedReview =
     linkedPR !== null ||

--- a/src/renderer/src/components/sidebar/worktree-card-pr-display.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-pr-display.ts
@@ -60,6 +60,8 @@ function getLinkedReviewNumber(
       return links.linkedAzureDevOpsPR
     case 'gitea':
       return links.linkedGiteaPR
+    default:
+      return null
   }
 }
 

--- a/src/renderer/src/components/sidebar/worktree-card-pr-display.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-pr-display.ts
@@ -104,7 +104,8 @@ export function getWorktreeCardPrDisplay(
     linkedGitLabMR !== null ||
     linkedBitbucketPR !== null ||
     linkedAzureDevOpsPR !== null ||
-    linkedGiteaPR !== null
+    linkedGiteaPR !== null ||
+    (linkedPluginReview !== null && Object.keys(linkedPluginReview).length > 0)
   if (review) {
     if (review.provider === 'unsupported') {
       return review

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-facet-labels.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-facet-labels.ts
@@ -110,9 +110,10 @@ export function getWorkspaceCleanupReviewProviderLabel(provider: HostedReviewPro
       return 'Gitea'
     case 'unsupported':
       return translate('components.workspace.cleanup.browse.review.otherProvider', 'Other')
+    default:
+      return provider
   }
 }
-
 export function getWorkspaceCleanupTicketSourceLabel(source: WorkspaceCleanupTicketSource): string {
   switch (source) {
     case 'work-item':

--- a/src/renderer/src/i18n/hosted-review-localized-copy.ts
+++ b/src/renderer/src/i18n/hosted-review-localized-copy.ts
@@ -1,11 +1,8 @@
 import type { HostedReviewProvider } from '../../../shared/hosted-review'
-import {
-  resolveHostedReviewCreationProvider,
-  type HostedReviewCreationProvider
-} from '../../../shared/hosted-review-creation-providers'
+import { resolveHostedReviewCreationProvider } from '../../../shared/hosted-review-creation-providers'
 import { translate } from '@/i18n/i18n'
 
-export type SupportedHostedReviewCopyProvider = HostedReviewCreationProvider
+export type SupportedHostedReviewCopyProvider = HostedReviewProvider
 
 export type LocalizedHostedReviewCopy = {
   shortLabel: string

--- a/src/renderer/src/store/slices/hosted-review-cache-identity.ts
+++ b/src/renderer/src/store/slices/hosted-review-cache-identity.ts
@@ -59,7 +59,9 @@ export function linkedReviewHintKey(options?: LinkedReviewHints): string {
     ['bitbucket', options?.linkedBitbucketPR ?? null],
     ['azure-devops', options?.linkedAzureDevOpsPR ?? null],
     ['gitea', options?.linkedGiteaPR ?? null],
-    ...Object.entries(options?.linkedPluginReview ?? {})
+    ...Object.entries(options?.linkedPluginReview ?? {}).sort(([left], [right]) =>
+      left < right ? -1 : left > right ? 1 : 0
+    )
   ] as const
   return hints
     .filter(([, number]) => number !== null)

--- a/src/renderer/src/store/slices/hosted-review-cache-identity.ts
+++ b/src/renderer/src/store/slices/hosted-review-cache-identity.ts
@@ -12,6 +12,7 @@ export type LinkedReviewHints = {
   linkedBitbucketPR?: number | null
   linkedAzureDevOpsPR?: number | null
   linkedGiteaPR?: number | null
+  linkedPluginReview?: Record<string, number> | null
 }
 
 export function getHostedReviewCacheKey(
@@ -57,7 +58,8 @@ export function linkedReviewHintKey(options?: LinkedReviewHints): string {
     ['gitlab', options?.linkedGitLabMR ?? null],
     ['bitbucket', options?.linkedBitbucketPR ?? null],
     ['azure-devops', options?.linkedAzureDevOpsPR ?? null],
-    ['gitea', options?.linkedGiteaPR ?? null]
+    ['gitea', options?.linkedGiteaPR ?? null],
+    ...Object.entries(options?.linkedPluginReview ?? {})
   ] as const
   return hints
     .filter(([, number]) => number !== null)

--- a/src/renderer/src/store/slices/hosted-review.ts
+++ b/src/renderer/src/store/slices/hosted-review.ts
@@ -505,7 +505,9 @@ export const createHostedReviewSlice: StateCreator<AppState, [], [], HostedRevie
                   options?.linkedGitLabMR == null &&
                   options?.linkedBitbucketPR == null &&
                   options?.linkedAzureDevOpsPR == null &&
-                  options?.linkedGiteaPR == null
+                  options?.linkedGiteaPR == null &&
+                  (options?.linkedPluginReview == null ||
+                    Object.keys(options.linkedPluginReview).length === 0)
                     ? { branchLookupGitHubPRNumber: review.number }
                     : {})
                 })

--- a/src/renderer/src/store/slices/hosted-review.ts
+++ b/src/renderer/src/store/slices/hosted-review.ts
@@ -268,6 +268,7 @@ type RefreshHostedReviewCardArgs = {
   linkedBitbucketPR?: number | null
   linkedAzureDevOpsPR?: number | null
   linkedGiteaPR?: number | null
+  linkedPluginReview?: Record<string, number> | null
 }
 
 export function refreshHostedReviewCard(
@@ -283,7 +284,8 @@ export function refreshHostedReviewCard(
     linkedGitLabMR: args.linkedGitLabMR ?? null,
     linkedBitbucketPR: args.linkedBitbucketPR ?? null,
     linkedAzureDevOpsPR: args.linkedAzureDevOpsPR ?? null,
-    linkedGiteaPR: args.linkedGiteaPR ?? null
+    linkedGiteaPR: args.linkedGiteaPR ?? null,
+    linkedPluginReview: args.linkedPluginReview ?? null
   })
 }
 
@@ -434,7 +436,8 @@ export const createHostedReviewSlice: StateCreator<AppState, [], [], HostedRevie
             linkedGitLabMR: options?.linkedGitLabMR ?? null,
             linkedBitbucketPR: options?.linkedBitbucketPR ?? null,
             linkedAzureDevOpsPR: options?.linkedAzureDevOpsPR ?? null,
-            linkedGiteaPR: options?.linkedGiteaPR ?? null
+            linkedGiteaPR: options?.linkedGiteaPR ?? null,
+            linkedPluginReview: options?.linkedPluginReview ?? null
           }
           const review =
             target.kind === 'environment'

--- a/src/renderer/src/store/slices/worktree-listing-branch-switch.ts
+++ b/src/renderer/src/store/slices/worktree-listing-branch-switch.ts
@@ -14,6 +14,22 @@ function indexUnambiguousWorktrees(
   return byId
 }
 
+/** Compare two linkedPluginReview maps by sorted keys so insertion order does not affect equality. */
+function pluginReviewMapEquals(
+  left: Record<string, number> | null | undefined,
+  right: Record<string, number> | null | undefined
+): boolean {
+  if (left === right) {
+    return true
+  }
+  if (!left || !right) {
+    return false
+  }
+  const lKeys = Object.keys(left).sort()
+  const rKeys = Object.keys(right).sort()
+  return lKeys.length === rKeys.length && lKeys.every((k) => left[k] === right[k])
+}
+
 function branchScopedReviewContextMatches(left: Worktree, right: Worktree): boolean {
   return (
     left.linkedPR === right.linkedPR &&
@@ -21,8 +37,7 @@ function branchScopedReviewContextMatches(left: Worktree, right: Worktree): bool
     left.linkedBitbucketPR === right.linkedBitbucketPR &&
     left.linkedAzureDevOpsPR === right.linkedAzureDevOpsPR &&
     left.linkedGiteaPR === right.linkedGiteaPR &&
-    JSON.stringify(left.linkedPluginReview ?? null) ===
-      JSON.stringify(right.linkedPluginReview ?? null) &&
+    pluginReviewMapEquals(left.linkedPluginReview, right.linkedPluginReview) &&
     left.pushTarget?.remoteName === right.pushTarget?.remoteName &&
     left.pushTarget?.branchName === right.pushTarget?.branchName
   )

--- a/src/renderer/src/store/slices/worktree-listing-branch-switch.ts
+++ b/src/renderer/src/store/slices/worktree-listing-branch-switch.ts
@@ -21,6 +21,8 @@ function branchScopedReviewContextMatches(left: Worktree, right: Worktree): bool
     left.linkedBitbucketPR === right.linkedBitbucketPR &&
     left.linkedAzureDevOpsPR === right.linkedAzureDevOpsPR &&
     left.linkedGiteaPR === right.linkedGiteaPR &&
+    JSON.stringify(left.linkedPluginReview ?? null) ===
+      JSON.stringify(right.linkedPluginReview ?? null) &&
     left.pushTarget?.remoteName === right.pushTarget?.remoteName &&
     left.pushTarget?.branchName === right.pushTarget?.branchName
   )

--- a/src/renderer/src/store/slices/worktrees/metadata/hosted-review-link-mutation.ts
+++ b/src/renderer/src/store/slices/worktrees/metadata/hosted-review-link-mutation.ts
@@ -22,13 +22,14 @@ export const HOSTED_REVIEW_LINK_KEYS: readonly HostedReviewLinkKey[] = [
 
 export const CLEARED_HOSTED_REVIEW_LINK_UPDATES: Pick<
   WorktreeMeta,
-  HostedReviewLinkKey | 'pushTarget'
+  HostedReviewLinkKey | 'pushTarget' | 'linkedPluginReview'
 > = {
   linkedPR: null,
   linkedGitLabMR: null,
   linkedBitbucketPR: null,
   linkedAzureDevOpsPR: null,
   linkedGiteaPR: null,
+  linkedPluginReview: null,
   pushTarget: undefined
 }
 
@@ -40,7 +41,10 @@ export const hostedReviewLinkClearTombstonesByWorktreeId = new Map<
 export const hostedReviewLinkWorktreeIdAliases = new Map<string, string>()
 
 export function hasHostedReviewLinks(worktree: Worktree): boolean {
-  return HOSTED_REVIEW_LINK_KEYS.some((key) => worktree[key] != null)
+  return (
+    HOSTED_REVIEW_LINK_KEYS.some((key) => worktree[key] != null) ||
+    (worktree.linkedPluginReview ?? null) !== null
+  )
 }
 
 export function hasBranchScopedHostedReviewContext(worktree: Worktree): boolean {
@@ -48,7 +52,11 @@ export function hasBranchScopedHostedReviewContext(worktree: Worktree): boolean 
 }
 
 export function hasHostedReviewLinkUpdates(updates: Partial<WorktreeMeta>): boolean {
-  return HOSTED_REVIEW_LINK_KEYS.some((key) => key in updates) || 'pushTarget' in updates
+  return (
+    HOSTED_REVIEW_LINK_KEYS.some((key) => key in updates) ||
+    'linkedPluginReview' in updates ||
+    'pushTarget' in updates
+  )
 }
 
 export function getHostedReviewLinkMutationGeneration(worktreeId: string): number {

--- a/src/renderer/src/store/slices/worktrees/metadata/update-worktree-meta.ts
+++ b/src/renderer/src/store/slices/worktrees/metadata/update-worktree-meta.ts
@@ -114,7 +114,9 @@ export function createUpdateWorktreeMeta(
       (normalizedUpdates.linkedAzureDevOpsPR === null &&
         (worktreeForUpdate?.linkedAzureDevOpsPR ?? null) !== null) ||
       (normalizedUpdates.linkedGiteaPR === null &&
-        (worktreeForUpdate?.linkedGiteaPR ?? null) !== null)
+        (worktreeForUpdate?.linkedGiteaPR ?? null) !== null) ||
+      (normalizedUpdates.linkedPluginReview === null &&
+        (worktreeForUpdate?.linkedPluginReview ?? null) !== null)
     const reviewRepo = shouldRefreshHostedReview
       ? get().repos.find((repo) => repo.id === worktreeForUpdate?.repoId)
       : undefined
@@ -266,6 +268,9 @@ export function createUpdateWorktreeMeta(
             worktreeForUpdate,
             'linkedGiteaPR'
           ),
+          linkedPluginReview: Object.hasOwn(targetEnriched, 'linkedPluginReview')
+            ? (targetEnriched.linkedPluginReview ?? null)
+            : (worktreeForUpdate?.linkedPluginReview ?? null),
           force: true
         })
       }

--- a/src/shared/folder-workspace-worktree.ts
+++ b/src/shared/folder-workspace-worktree.ts
@@ -28,6 +28,7 @@ export function folderWorkspaceToWorktree(folderWorkspace: FolderWorkspace): Wor
     linkedBitbucketPR: null,
     linkedAzureDevOpsPR: null,
     linkedGiteaPR: null,
+    linkedPluginReview: null,
     linkedWorkItem: linkedTask,
     linkedTaskSourceContext: folderWorkspace.linkedTaskSourceContext ?? null,
     isArchived: folderWorkspace.isArchived,

--- a/src/shared/hosted-review-actions.ts
+++ b/src/shared/hosted-review-actions.ts
@@ -1,0 +1,91 @@
+import type { HostedReviewProvider } from './hosted-review'
+
+/**
+ * Generic hosted-review actions a forge provider may expose beyond
+ * lookup/creation. Plugin forge providers implement these in the main process;
+ * built-in providers keep their CLI/REST-specific paths.
+ */
+
+export type HostedReviewActionContext = {
+  repoPath: string
+  connectionId?: string | null
+  provider: HostedReviewProvider
+  number: number
+}
+
+export type MergeHostedReviewInput = HostedReviewActionContext & {
+  method?: 'merge' | 'squash' | 'rebase'
+  deleteBranch?: boolean
+}
+
+export type MergeHostedReviewResult =
+  | { ok: true }
+  | { ok: false; code: 'auth_required' | 'conflict' | 'unknown'; error: string }
+
+export type CommentHostedReviewInput = HostedReviewActionContext & {
+  body: string
+  /** Optional file path for an inline comment. */
+  path?: string
+  /** Optional line number for an inline comment. */
+  line?: number
+}
+
+export type CommentHostedReviewResult =
+  | { ok: true; commentId?: string }
+  | { ok: false; code: 'auth_required' | 'unknown'; error: string }
+
+export type ApproveHostedReviewInput = HostedReviewActionContext
+
+export type ApproveHostedReviewResult =
+  | { ok: true }
+  | { ok: false; code: 'auth_required' | 'unknown'; error: string }
+
+export type ListHostedReviewCommentsInput = HostedReviewActionContext
+
+export type ListHostedReviewCommentsResult =
+  | {
+      ok: true
+      comments: {
+        id: string
+        body: string
+        author: string
+        createdAt?: string
+        path?: string
+        line?: number
+      }[]
+    }
+  | { ok: false; code: 'auth_required' | 'unknown'; error: string }
+
+export type HostedReviewIssueState = 'open' | 'closed' | 'all'
+
+export type ListHostedReviewIssuesInput = {
+  repoPath: string
+  connectionId?: string | null
+  provider: HostedReviewProvider
+  state?: HostedReviewIssueState
+  limit?: number
+}
+
+export type HostedReviewIssueSummary = {
+  id: string
+  number: number
+  title: string
+  state: 'open' | 'closed'
+  url?: string
+  updatedAt?: string
+}
+
+export type ListHostedReviewIssuesResult =
+  | { ok: true; issues: HostedReviewIssueSummary[] }
+  | { ok: false; code: 'auth_required' | 'unknown'; error: string }
+
+/**
+ * Capability descriptors surfaced to the renderer so UI can enable
+ * merge/comment/approve controls only when the active provider supports them.
+ */
+export type HostedReviewActionCapabilities = {
+  canMerge: boolean
+  canComment: boolean
+  canApprove: boolean
+  canListIssues: boolean
+}

--- a/src/shared/hosted-review-creation-providers.ts
+++ b/src/shared/hosted-review-creation-providers.ts
@@ -22,9 +22,7 @@ export function supportsHostedReviewCreation(
 export function resolveHostedReviewCreationProvider(
   provider: HostedReviewProvider | null | undefined
 ): HostedReviewProvider {
-  // Why: plugin forge providers pass their own id through — the main process
-  // dispatches their ForgeProvider.createReview. Only absent providers fall
-  // back to GitHub so creation UI stays enabled for unknown remotes.
+  // Why: plugin ids pass through; only absent providers fall back to GitHub.
   return supportsHostedReviewCreation(provider) ? provider : (provider ?? 'github')
 }
 

--- a/src/shared/hosted-review-creation-providers.ts
+++ b/src/shared/hosted-review-creation-providers.ts
@@ -21,6 +21,17 @@ export function supportsHostedReviewCreation(
 
 export function resolveHostedReviewCreationProvider(
   provider: HostedReviewProvider | null | undefined
-): HostedReviewCreationProvider {
-  return supportsHostedReviewCreation(provider) ? provider : 'github'
+): HostedReviewProvider {
+  // Why: plugin forge providers pass their own id through — the main process
+  // dispatches their ForgeProvider.createReview. Only absent providers fall
+  // back to GitHub so creation UI stays enabled for unknown remotes.
+  return supportsHostedReviewCreation(provider) ? provider : (provider ?? 'github')
+}
+
+// Why: plugin forge providers are handled in the main process via
+// ForgeProvider.createReview, so the renderer never creates a review for one.
+export function resolveCreationProvider(
+  provider: HostedReviewProvider
+): HostedReviewCreationProvider | null {
+  return supportsHostedReviewCreation(provider) ? provider : null
 }

--- a/src/shared/hosted-review.ts
+++ b/src/shared/hosted-review.ts
@@ -68,6 +68,7 @@ export type HostedReviewForBranchArgs = {
   linkedBitbucketPR?: number | null
   linkedAzureDevOpsPR?: number | null
   linkedGiteaPR?: number | null
+  linkedPluginReview?: Record<string, number> | null
   // The worktree's checked-out HEAD oid (GitHub merged-at-head visibility).
   currentHeadOid?: string | null
   /**

--- a/src/shared/hosted-review.ts
+++ b/src/shared/hosted-review.ts
@@ -6,13 +6,19 @@ import type {
   PRReviewDecision
 } from './github/pull-request-types'
 
-export type HostedReviewProvider =
+export type BuiltinHostedReviewProvider =
   | 'github'
   | 'gitlab'
   | 'bitbucket'
   | 'azure-devops'
   | 'gitea'
   | 'unsupported'
+
+// Why: plugin forge providers extend the closed built-in set with arbitrary
+// ids. Consumers must narrow via BuiltinHostedReviewProvider before switching.
+export type HostedReviewProvider = BuiltinHostedReviewProvider | (string & {})
+
+export type PluginLinkedReview = Record<string, number> // providerId → reviewNumber
 
 export type HostedReviewState = 'open' | 'closed' | 'merged' | 'draft'
 

--- a/src/shared/plugins/plugin-content-pack-contributions.ts
+++ b/src/shared/plugins/plugin-content-pack-contributions.ts
@@ -53,3 +53,19 @@ export type PluginLanguagePackContribution = z.infer<typeof pluginLanguagePackCo
 export type PluginKeybindingContribution = z.infer<typeof pluginKeybindingContributionSchema>
 export type PluginVmRecipeContribution = z.infer<typeof pluginVmRecipeContributionSchema>
 export type PluginAgentProfileContribution = z.infer<typeof pluginAgentProfileContributionSchema>
+
+export const PLUGIN_FORGE_PROVIDER_LIMIT = 8
+
+const hostPatternSchema = z.string().min(1).max(256)
+
+export const pluginForgeProviderContributionSchema = z
+  .object({
+    id: z.string().min(1).max(64),
+    displayName: z.string().min(1).max(64),
+    hosts: z.array(hostPatternSchema).min(1).max(64),
+    modulePath: pluginRelativePathSchema,
+    supportsReviewCreation: z.boolean().default(true)
+  })
+  .strict()
+
+export type PluginForgeProviderContribution = z.infer<typeof pluginForgeProviderContributionSchema>

--- a/src/shared/plugins/plugin-manifest-contribution-validation.ts
+++ b/src/shared/plugins/plugin-manifest-contribution-validation.ts
@@ -2,6 +2,17 @@ import type { RefinementCtx } from 'zod'
 import { isPluginCommandAliasActionId } from './plugin-command-actions'
 import { getKeybindingConflictIdentity } from '../keybindings'
 
+// Why: these hosts are served by built-in providers; a plugin declaring them
+// would shadow built-in routing. Mirrors KNOWN_NON_GITEA_HOSTS in
+// src/main/gitea/repository-ref.ts (kept in sync manually — main is not shared).
+const KNOWN_NON_GITEA_HOSTS = [
+  'github.com',
+  'gitlab.com',
+  'bitbucket.org',
+  'dev.azure.com',
+  'ssh.dev.azure.com'
+]
+
 type IdentifiedContribution = { id: string }
 type PathContribution = { path: string }
 
@@ -15,6 +26,7 @@ type ContributionValidationManifest = {
     keybindings: { command: string; key: string; when?: 'global' | 'worktree' }[]
     vmRecipes: PathContribution[]
     agents: PathContribution[]
+    forgeProviders: { id: string; hosts: string[]; modulePath: string }[]
   }
   capabilities: { kind: string }[]
 }
@@ -68,6 +80,24 @@ export function validatePluginManifestContributions(
       `${path} path`,
       ctx
     )
+  }
+  rejectDuplicateValues(
+    manifest.contributes.forgeProviders,
+    (entry) => (entry as { id: string }).id,
+    'forgeProviders',
+    'forge provider id',
+    ctx
+  )
+  for (const [index, provider] of manifest.contributes.forgeProviders.entries()) {
+    // modulePath is already guaranteed required by the zod schema.
+    const reservedHosts = provider.hosts.filter((host) => KNOWN_NON_GITEA_HOSTS.includes(host))
+    if (reservedHosts.length > 0) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['contributes', 'forgeProviders', index, 'hosts'],
+        message: `reserved built-in provider host: ${reservedHosts.join(', ')}`
+      })
+    }
   }
   const keybindingIdentities = new Set<string>()
   for (const [index, keybinding] of manifest.contributes.keybindings.entries()) {

--- a/src/shared/plugins/plugin-manifest-contribution-validation.ts
+++ b/src/shared/plugins/plugin-manifest-contribution-validation.ts
@@ -13,6 +13,17 @@ const KNOWN_NON_GITEA_HOSTS = [
   'ssh.dev.azure.com'
 ]
 
+// Why: ids served by built-in providers must stay unambiguous in provider
+// routing; a plugin declaring one would shadow or collide with built-ins.
+const BUILTIN_FORGE_PROVIDER_IDS = new Set([
+  'github',
+  'gitlab',
+  'bitbucket',
+  'azure-devops',
+  'gitea',
+  'unsupported'
+])
+
 type IdentifiedContribution = { id: string }
 type PathContribution = { path: string }
 
@@ -90,6 +101,13 @@ export function validatePluginManifestContributions(
   )
   for (const [index, provider] of manifest.contributes.forgeProviders.entries()) {
     // modulePath is already guaranteed required by the zod schema.
+    if (BUILTIN_FORGE_PROVIDER_IDS.has(provider.id)) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['contributes', 'forgeProviders', index, 'id'],
+        message: `reserved built-in forge provider id: ${provider.id}`
+      })
+    }
     const reservedHosts = provider.hosts.filter((host) => KNOWN_NON_GITEA_HOSTS.includes(host))
     if (reservedHosts.length > 0) {
       ctx.addIssue({

--- a/src/shared/plugins/plugin-manifest.ts
+++ b/src/shared/plugins/plugin-manifest.ts
@@ -2,10 +2,12 @@ import { z } from 'zod'
 import { pluginCapabilitySchema } from './plugin-capabilities'
 import {
   PLUGIN_AGENT_PROFILE_LIMIT,
+  PLUGIN_FORGE_PROVIDER_LIMIT,
   PLUGIN_KEYBINDING_LIMIT,
   PLUGIN_LANGUAGE_PACK_LIMIT,
   PLUGIN_VM_RECIPE_LIMIT,
   pluginAgentProfileContributionSchema,
+  pluginForgeProviderContributionSchema,
   pluginKeybindingContributionSchema,
   pluginLanguagePackContributionSchema,
   pluginVmRecipeContributionSchema
@@ -116,6 +118,10 @@ export const pluginManifestSchema = z
         agents: z
           .array(pluginAgentProfileContributionSchema)
           .max(PLUGIN_AGENT_PROFILE_LIMIT)
+          .default([]),
+        forgeProviders: z
+          .array(pluginForgeProviderContributionSchema)
+          .max(PLUGIN_FORGE_PROVIDER_LIMIT)
           .default([])
       })
       .strict()
@@ -126,7 +132,8 @@ export const pluginManifestSchema = z
         languagePacks: [],
         keybindings: [],
         vmRecipes: [],
-        agents: []
+        agents: [],
+        forgeProviders: []
       })),
     capabilities: z.array(pluginCapabilitySchema).max(32).default([])
   })
@@ -136,6 +143,7 @@ export type PluginManifest = z.infer<typeof pluginManifestSchema>
 export type PluginPanelContribution = z.infer<typeof panelContributionSchema>
 export type PluginCommandContribution = z.infer<typeof commandContributionSchema>
 export type PluginEventContribution = z.infer<typeof eventContributionSchema>
+export type PluginForgeProviderContribution = z.infer<typeof pluginForgeProviderContributionSchema>
 
 export {
   isSafePluginId,

--- a/src/shared/worktree/create-types.ts
+++ b/src/shared/worktree/create-types.ts
@@ -87,6 +87,7 @@ export type CreateWorktreeArgs = {
   linkedBitbucketPR?: number | null
   linkedAzureDevOpsPR?: number | null
   linkedGiteaPR?: number | null
+  linkedPluginReview?: Record<string, number> | null
   linkedWorkItem?: WorkspaceLinkedItem | null
   linkedTaskSourceContext?: TaskSourceContext | null
   pushTarget?: GitPushTarget

--- a/src/shared/worktree/meta-types.ts
+++ b/src/shared/worktree/meta-types.ts
@@ -44,6 +44,8 @@ export type WorktreeMeta = {
   linkedAzureDevOpsPR?: number | null
   /** Optional for backward compatibility — see Worktree.linkedGiteaPR. */
   linkedGiteaPR?: number | null
+  /** Optional for backward compatibility — see Worktree.linkedPluginReview. */
+  linkedPluginReview?: Record<string, number> | null
   linkedWorkItem?: WorkspaceLinkedItem | null
   linkedTaskSourceContext?: TaskSourceContext | null
   isArchived: boolean

--- a/src/shared/worktree/types.ts
+++ b/src/shared/worktree/types.ts
@@ -93,6 +93,8 @@ export type Worktree = {
   linkedBitbucketPR?: number | null
   linkedAzureDevOpsPR?: number | null
   linkedGiteaPR?: number | null
+  /** Plugin forge providers store linked reviews keyed by provider id. */
+  linkedPluginReview?: Record<string, number> | null
   linkedWorkItem?: WorkspaceLinkedItem | null
   linkedTaskSourceContext?: TaskSourceContext | null
   isArchived: boolean


### PR DESCRIPTION
## Summary

Adds a plugin extension point that lets plugin packs contribute **forge providers** — adapters for self-hosted code platforms that do not speak GitHub, GitLab, Bitbucket, Azure DevOps, or Gitea APIs. This makes the hosted-review surface (branch lookup, review creation, and generic actions like merge/comment/approve) extensible without touching Orca source.

The extension point is generic; concrete platform adapters ship as private plugin packs and are not part of this PR.

## What's included

**Manifest & validation**
- New `forgeProviders` contribution in the plugin manifest schema (`id`, `displayName`, `hosts`, `modulePath`, `supportsReviewCreation`)
- Contribution validation: duplicate ids across plugins, conflicts with built-in provider names

**Main-process registry & bridge**
- `PluginForgeProviderRegistry`: discovers plugins, loads provider modules from approved packs, validates required exports, keeps previews for unapproved packs
- Bridge with module-level accessors (`getPluginProviderById`, `getPluginProviderByHost`, `resolvePluginForgeProvider`) injected by the plugin service on refresh
- Provider detection order: built-ins → plugin providers (host match + `resolveRepository` confirm) → Gitea catch-all

**ForgeProvider interface**
- Optional `copy` (localized labels) and `isAuthenticated` fields
- Optional generic action methods: `mergeReview`, `commentReview`, `approveReview`, `listReviewComments`, `listIssues` — dispatched through a main-process router (`hosted-review-actions.ts`) with IPC handlers
- Built-in Gitea provider now implements `isAuthenticated` (verifies token via `/user`) and provides `copy`

**Renderer & persistence**
- New generic `linkedPluginReview: Record<providerId, number>` field alongside the existing per-provider linked fields, threaded through worktree types, store slices, meta refresh, branch-switch comparison, and cache identity
- Review creation eligibility and creation allow plugin providers that implement `createReview`; creation provider resolution passes plugin ids through instead of collapsing to GitHub
- Provider-id widening handled across renderer switches with explicit defaults

## Testing

- Unit tests for the registry (load, validation, duplicate ids, previews, clear), the bridge (remote URL parsing, host/id routing, repository confirmation), and Gitea token verification
- Existing source-control and plugin suites pass (55 files / 353 tests)
- The Gitea hosted-review integration test (real git remote parsing + HTTP API calls) passes

## Notes

- Plugin forge provider modules load in the main process with Node-only builtins; the worker path is intentionally not used (no network/env access)
- Docs and a runnable example plugin are kept out of this PR (private distribution)
