### PR TITLE
fix(worktrees): honor the per-host workspace directory when resolving worktree paths

### DIFF
--- a/src/main/ipc/worktree-base-directory-watch-targets.ts
+++ b/src/main/ipc/worktree-base-directory-watch-targets.ts
@@ -19,7 +19,7 @@ import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
 import {
   computeWorkspaceRoot,
   getWorktreePathSettings,
-  hasRepoWorktreeBasePath
+  hasConfiguredWorktreeBasePath
 } from './worktree-logic'
 import { shouldEmitBoundedWarning } from './bounded-warning-dedupe'
 import { resolveWorktreeCommonGitDirectory } from './worktree-common-git-directory'
@@ -102,12 +102,13 @@ function isRuntimePathAbsoluteForRepo(repoPath: string, pathValue: string): bool
 
 function getBaseWatchLayout(
   repo: Repo,
-  pathSettings: Pick<GlobalSettings, 'workspaceDir' | 'nestWorkspaces'>,
+  settings: GlobalSettings,
   connectionId: string | undefined
 ): { workspaceRoot: string; nestWorkspaces: boolean } {
+  const pathSettings = getWorktreePathSettings(repo, settings)
   if (
     connectionId &&
-    !hasRepoWorktreeBasePath(repo) &&
+    !hasConfiguredWorktreeBasePath(repo, settings) &&
     isRuntimePathAbsoluteForRepo(repo.path, pathSettings.workspaceDir)
   ) {
     // Why: SSH creates default worktrees beside the remote repo when the
@@ -127,8 +128,7 @@ async function maybeAddBaseTarget(
   settings: GlobalSettings,
   connectionId?: string
 ): Promise<void> {
-  const pathSettings = getWorktreePathSettings(repo, settings)
-  const { workspaceRoot, nestWorkspaces } = getBaseWatchLayout(repo, pathSettings, connectionId)
+  const { workspaceRoot, nestWorkspaces } = getBaseWatchLayout(repo, settings, connectionId)
   // Why: WSL UNC roots are unreliable for native watching; avoid project-level polling.
   if (isWslUncPath(workspaceRoot) || isWslUncPath(repo.path)) {
     const key = `${repo.id}:${workspaceRoot}`

--- a/src/main/ipc/worktree-logic.test.ts
+++ b/src/main/ipc/worktree-logic.test.ts
@@ -12,6 +12,7 @@ import {
   computeWorkspaceRoot,
   getWorktreeCreationLayout,
   getWorktreePathSettings,
+  hasConfiguredWorktreeBasePath,
   shouldSetDisplayName,
   mergeWorktree,
   parseWorktreeId,
@@ -712,5 +713,93 @@ describe('isOrphanCompatiblePreflightError', () => {
     })
 
     expect(isOrphanCompatiblePreflightError(error)).toBe(false)
+  })
+})
+
+describe('host-scoped worktree base paths', () => {
+  const HOST_BASE_PATH = '/remote/home/.orca/workspaces'
+  const settings = {
+    nestWorkspaces: false,
+    workspaceDir: '/local/workspaces',
+    hostSettingOverrides: {
+      'ssh:ssh-1': { defaultWorktreeLocation: HOST_BASE_PATH }
+    }
+  } as const
+  const remoteRepo = { path: '/remote/repo', connectionId: 'ssh-1' }
+
+  it('applies the host default to every repo on that host', () => {
+    expect(getWorktreePathSettings(remoteRepo, settings).workspaceDir).toBe(HOST_BASE_PATH)
+    expect(getWorktreeCreationLayout(remoteRepo, settings)).toEqual({
+      path: HOST_BASE_PATH,
+      nestWorkspaces: false
+    })
+  })
+
+  it('lets a repo base path win over the host default', () => {
+    const repo = { ...remoteRepo, worktreeBasePath: '../custom' }
+    expect(getWorktreePathSettings(repo, settings).workspaceDir).toBe('../custom')
+  })
+
+  it('leaves repos on other hosts on the client default', () => {
+    expect(
+      getWorktreePathSettings({ path: '/other/repo', connectionId: 'ssh-2' }, settings).workspaceDir
+    ).toBe('/local/workspaces')
+    expect(getWorktreePathSettings({ path: '/projects/repo' }, settings).workspaceDir).toBe(
+      '/local/workspaces'
+    )
+  })
+
+  it('applies a local host default to local repos', () => {
+    const localSettings = {
+      nestWorkspaces: false,
+      workspaceDir: '/local/workspaces',
+      hostSettingOverrides: { local: { defaultWorktreeLocation: '/local/elsewhere' } }
+    } as const
+    expect(getWorktreePathSettings({ path: '/projects/repo' }, localSettings).workspaceDir).toBe(
+      '/local/elsewhere'
+    )
+  })
+
+  it('keeps an absolute host default on the SSH path instead of a repo-qualified sibling', () => {
+    expect(
+      computeRemoteWorktreePath(
+        'feature',
+        remoteRepo.path,
+        getWorktreePathSettings(remoteRepo, settings),
+        { useConfiguredAbsolutePath: hasConfiguredWorktreeBasePath(remoteRepo, settings) }
+      )
+    ).toBe('/remote/home/.orca/workspaces/feature')
+
+    expect(
+      computeRemoteWorktreePath(
+        'feature',
+        remoteRepo.path,
+        getWorktreePathSettings(remoteRepo, { ...settings, nestWorkspaces: true }),
+        { useConfiguredAbsolutePath: hasConfiguredWorktreeBasePath(remoteRepo, settings) }
+      )
+    ).toBe('/remote/home/.orca/workspaces/repo/feature')
+  })
+
+  it('still qualifies SSH siblings when only the client default is set', () => {
+    const clientOnly = { nestWorkspaces: false, workspaceDir: '/local/workspaces' }
+    expect(hasConfiguredWorktreeBasePath(remoteRepo, clientOnly)).toBe(false)
+    expect(
+      computeRemoteWorktreePath(
+        'feature',
+        remoteRepo.path,
+        getWorktreePathSettings(remoteRepo, clientOnly),
+        { useConfiguredAbsolutePath: hasConfiguredWorktreeBasePath(remoteRepo, clientOnly) }
+      )
+    ).toBe('/remote/repo-feature')
+  })
+
+  it('treats a blank host default as unset', () => {
+    const blank = {
+      nestWorkspaces: false,
+      workspaceDir: '/local/workspaces',
+      hostSettingOverrides: { 'ssh:ssh-1': { defaultWorktreeLocation: '   ' } }
+    } as const
+    expect(hasConfiguredWorktreeBasePath(remoteRepo, blank)).toBe(false)
+    expect(getWorktreePathSettings(remoteRepo, blank).workspaceDir).toBe('/local/workspaces')
   })
 })

--- a/src/main/ipc/worktree-logic.ts
+++ b/src/main/ipc/worktree-logic.ts
@@ -3,12 +3,20 @@ import type { GlobalSettings, OrcaWorkspaceLayout } from '../../shared/global-se
 import type { Repo } from '../../shared/repo-types'
 import { isWindowsAbsolutePathLike, resolveRuntimePath } from '../../shared/cross-platform-path'
 import { isWslUncPath, resolveWslRepoWorktreeBasePath } from '../../shared/wsl-paths'
+import { getRepoExecutionHostId } from '../../shared/execution-host'
+import { getHostSettingOverride } from '../../shared/host-setting-overrides'
 import { splitWorktreeId } from '../../shared/worktree/id'
 import { replaceKnownEmojiWithShortcodes } from '../../shared/emoji-shortcode-catalog'
 import { getWslHome, getWslHomeAsync, parseWslPath } from '../wsl'
 
 type WorktreePathSettings = Pick<GlobalSettings, 'nestWorkspaces' | 'workspaceDir'>
-type WorktreeBasePathRepo = Pick<Repo, 'path' | 'worktreeBasePath'>
+/** Resolving a base path also consults the repo's execution host, so callers pass
+ *  the host overrides alongside the client defaults. */
+type WorktreeBasePathSettings = WorktreePathSettings & Pick<GlobalSettings, 'hostSettingOverrides'>
+type WorktreeBasePathRepo = Pick<
+  Repo,
+  'path' | 'worktreeBasePath' | 'connectionId' | 'executionHostId'
+>
 
 export {
   computeBranchName,
@@ -180,7 +188,7 @@ export function computeRemoteWorktreePath(
 
 export function getWorktreePathSettings(
   repo: WorktreeBasePathRepo,
-  settings: WorktreePathSettings
+  settings: WorktreeBasePathSettings
 ): WorktreePathSettings {
   return {
     nestWorkspaces: settings.nestWorkspaces,
@@ -190,7 +198,7 @@ export function getWorktreePathSettings(
 
 export function getWorktreeCreationLayout(
   repo: WorktreeBasePathRepo,
-  settings: WorktreePathSettings
+  settings: WorktreeBasePathSettings
 ): OrcaWorkspaceLayout {
   return {
     path: getEffectiveWorktreeBasePath(repo, settings),
@@ -198,8 +206,18 @@ export function getWorktreeCreationLayout(
   }
 }
 
-export function hasRepoWorktreeBasePath(repo: Pick<Repo, 'worktreeBasePath'>): boolean {
-  return getRepoWorktreeBasePath(repo) !== undefined
+/** True when the effective base path was configured for the repo's own filesystem —
+ *  per repo, or scoped to its execution host. An absolute value is then a path on
+ *  that host rather than the desktop client's default, so SSH can honor it instead
+ *  of falling back to a repo-qualified sibling. */
+export function hasConfiguredWorktreeBasePath(
+  repo: WorktreeBasePathRepo,
+  settings: Pick<GlobalSettings, 'hostSettingOverrides'>
+): boolean {
+  return (
+    getRepoWorktreeBasePath(repo) !== undefined ||
+    getHostWorktreeBasePath(repo, settings) !== undefined
+  )
 }
 
 function getRuntimePathOps(
@@ -224,9 +242,11 @@ function isWorkspaceDirRelativeToRepo(repoPath: string, workspaceDir: string): b
 
 function getEffectiveWorktreeBasePath(
   repo: WorktreeBasePathRepo,
-  settings: WorktreePathSettings
+  settings: WorktreeBasePathSettings
 ): string {
-  const basePath = getRepoWorktreeBasePath(repo)
+  // Why the host default gets the same WSL resolution: it is a configured path just
+  // like the repo one, so a POSIX-absolute value must land inside the distro too.
+  const basePath = getRepoWorktreeBasePath(repo) ?? getHostWorktreeBasePath(repo, settings)
   if (basePath === undefined) {
     return settings.workspaceDir
   }
@@ -236,6 +256,14 @@ function getEffectiveWorktreeBasePath(
 function getRepoWorktreeBasePath(repo: Pick<Repo, 'worktreeBasePath'>): string | undefined {
   const trimmed = repo.worktreeBasePath?.trim()
   return trimmed || undefined
+}
+
+/** The host-scoped default for every repo on the repo's execution host. */
+function getHostWorktreeBasePath(
+  repo: Pick<Repo, 'connectionId' | 'executionHostId'>,
+  settings: Pick<GlobalSettings, 'hostSettingOverrides'>
+): string | undefined {
+  return getHostSettingOverride(settings, getRepoExecutionHostId(repo), 'defaultWorktreeLocation')
 }
 
 function shouldMirrorWorkspaceDirInsideWsl(repoPath: string, workspaceDir: string): boolean {

--- a/src/main/ipc/worktree-logic.ts
+++ b/src/main/ipc/worktree-logic.ts
@@ -212,7 +212,7 @@ export function getWorktreeCreationLayout(
  *  of falling back to a repo-qualified sibling. */
 export function hasConfiguredWorktreeBasePath(
   repo: WorktreeBasePathRepo,
-  settings: Pick<GlobalSettings, 'hostSettingOverrides'>
+  settings: WorktreeBasePathSettings
 ): boolean {
   return (
     getRepoWorktreeBasePath(repo) !== undefined ||

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -83,7 +83,7 @@ import {
   ensurePathWithinWorkspace,
   getWorktreeCreationLayout,
   getWorktreePathSettings,
-  hasRepoWorktreeBasePath,
+  hasConfiguredWorktreeBasePath,
   shouldSetDisplayName,
   mergeWorktree
 } from './worktree-logic'
@@ -1653,7 +1653,7 @@ export async function createRemoteWorktree(
       repo.path,
       worktreePathSettings,
       {
-        useConfiguredAbsolutePath: hasRepoWorktreeBasePath(repo)
+        useConfiguredAbsolutePath: hasConfiguredWorktreeBasePath(repo, settings)
       }
     )
     if (!(await remotePathExists(fsProvider, remotePath))) {

--- a/src/main/worktree-name-retirement.test.ts
+++ b/src/main/worktree-name-retirement.test.ts
@@ -15,6 +15,11 @@ import {
 const FIRST = MARINE_CREATURES[0].toLowerCase()
 const SECOND = MARINE_CREATURES[1].toLowerCase()
 
+type RetirementSettings = Pick<
+  GlobalSettings,
+  'workspaceDir' | 'nestWorkspaces' | 'hostSettingOverrides'
+>
+
 const makeRepo = (id: string, path: string): Repo =>
   ({ id, path, displayName: id, badgeColor: '', addedAt: 0 }) as Repo
 
@@ -105,6 +110,37 @@ describe('getRetiredNameRegistryForRepo', () => {
       }
     )
     expect(pathReads.filter((id) => id.startsWith('peer-'))).toEqual([])
+  })
+
+  it('re-derives the namespace when only the host default moves the workspace root', async () => {
+    // Why SSH repos: the on-disk backfill returns null for non-local hosts, so both the
+    // subject and the peer resolve their namespace through the memoized collision key —
+    // the path a stale cache key actually corrupts.
+    const store = storeOf({ 'repo-a': [FIRST], 'repo-b': [SECOND] })
+    const repos = [
+      { ...makeRepo('repo-a', '/repos/a/repo'), connectionId: 'ssh-1' } as Repo,
+      { ...makeRepo('repo-b', '/repos/b/repo'), connectionId: 'ssh-1' } as Repo
+    ]
+    const clientDefaultOnly: RetirementSettings = {
+      workspaceDir: '/workspaces',
+      nestWorkspaces: false
+    }
+    const sharedHostRoot: RetirementSettings = {
+      ...clientDefaultOnly,
+      hostSettingOverrides: { 'ssh:ssh-1': { defaultWorktreeLocation: '/shared/worktrees' } }
+    }
+
+    // An absolute client default is dropped on SSH, so each repo gets its own sibling root.
+    expect(await getRetiredNameRegistryForRepo(store, repos[1], repos, clientDefaultOnly)).toEqual({
+      exhaustedTiers: 0,
+      names: [SECOND]
+    })
+
+    // Only the host default changed, and it collapses both repos into one root. A key blind
+    // to it would serve the previous per-repo namespaces from cache and miss the sharing.
+    expect(
+      [...(await getRetiredNameRegistryForRepo(store, repos[1], repos, sharedHostRoot)).names].sort()
+    ).toEqual([FIRST, SECOND].sort())
   })
 
   it('reports nothing for a folder workspace, which has no generated worktree names', async () => {

--- a/src/main/worktree-name-retirement.ts
+++ b/src/main/worktree-name-retirement.ts
@@ -18,7 +18,7 @@ import {
   computeRemoteWorktreePath,
   computeWorktreePathAsync,
   getWorktreePathSettings,
-  hasRepoWorktreeBasePath
+  hasConfiguredWorktreeBasePath
 } from './ipc/worktree-logic'
 import { worktreePathComparisonKey } from './ipc/worktree-path-comparison'
 import {
@@ -46,7 +46,10 @@ type RetirementWriteStore = {
   mergeRetiredWorktreeNamesForNamespace?(namespaceKey: string, names: Iterable<string>): boolean
   getSshTarget?: SshTargetLookup
 }
-type RetirementPathSettings = Pick<GlobalSettings, 'nestWorkspaces' | 'workspaceDir'>
+type RetirementPathSettings = Pick<
+  GlobalSettings,
+  'nestWorkspaces' | 'workspaceDir' | 'hostSettingOverrides'
+>
 
 /** Only canonical generator output is persisted. Collision retries advance canonical tiers, so a
  *  repeat-suffixed path can never be generated again and needs no permanent registry entry. */
@@ -68,7 +71,7 @@ async function getRetirementProbePath(
   const pathSettings = getWorktreePathSettings(repo, settings)
   return repo.connectionId
     ? computeRemoteWorktreePath(RETIREMENT_PROBE_NAME, repo.path, pathSettings, {
-        useConfiguredAbsolutePath: hasRepoWorktreeBasePath(repo)
+        useConfiguredAbsolutePath: hasConfiguredWorktreeBasePath(repo, settings)
       })
     : computeWorktreePathAsync(RETIREMENT_PROBE_NAME, repo.path, pathSettings)
 }
@@ -83,7 +86,7 @@ export function getRemoteRetirementNamespaceKey(
   }
   const pathSettings = getWorktreePathSettings(repo, settings)
   const probePath = computeRemoteWorktreePath(RETIREMENT_PROBE_NAME, repo.path, pathSettings, {
-    useConfiguredAbsolutePath: hasRepoWorktreeBasePath(repo)
+    useConfiguredAbsolutePath: hasConfiguredWorktreeBasePath(repo, settings)
   })
   return retirementNamespaceKey(retirementHostIdentity(repo, lookupSshTarget), probePath)
 }

--- a/src/main/worktree-name-retirement.ts
+++ b/src/main/worktree-name-retirement.ts
@@ -110,8 +110,10 @@ async function getRetirementCollisionKey(
   const cacheKey = [
     hostIdentity,
     repo.path,
-    repo.worktreeBasePath ?? '',
-    settings.workspaceDir,
+    // Why the effective base and not `repo.worktreeBasePath`: a host-scoped default
+    // feeds the probe path too, so a key blind to it hands the repo the namespace of
+    // whatever root the host pointed at before.
+    getWorktreePathSettings(repo, settings).workspaceDir,
     settings.nestWorkspaces ? 'nested' : 'flat'
   ].join('\u0000')
   const cached = collisionKeyCache.get(cacheKey)

--- a/src/main/worktree-root-preparation.ts
+++ b/src/main/worktree-root-preparation.ts
@@ -5,7 +5,10 @@ import { getRepoExecutionHostId, LOCAL_EXECUTION_HOST_ID } from '../shared/execu
 import { isFolderRepo } from '../shared/repo-kind'
 import { computeWorkspaceRoot, getWorktreePathSettings } from './ipc/worktree-logic'
 
-type WorktreeRootPreparationSettings = Pick<GlobalSettings, 'workspaceDir' | 'nestWorkspaces'>
+type WorktreeRootPreparationSettings = Pick<
+  GlobalSettings,
+  'workspaceDir' | 'nestWorkspaces' | 'hostSettingOverrides'
+>
 type WorktreeRootPreparationStore = {
   getSettings: () => WorktreeRootPreparationSettings
   getRepos: () => Repo[]

--- a/src/main/worktree-trash.test.ts
+++ b/src/main/worktree-trash.test.ts
@@ -196,6 +196,12 @@ describe('collectWorktreeTrashSweepRoots', () => {
     ).toEqual([])
   })
 
+  it('skips runtime-owned repos, which carry no connectionId', () => {
+    expect(
+      collectWorktreeTrashSweepRoots([repo({ executionHostId: 'runtime:env-1' })], settings)
+    ).toEqual([])
+  })
+
   it('skips WSL repos that cannot create host trash', () => {
     const originalPlatform = process.platform
     Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })

--- a/src/main/worktree-trash.ts
+++ b/src/main/worktree-trash.ts
@@ -7,6 +7,7 @@ import { lstat, mkdir, readdir, rename, rmdir } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { removeHostTree } from './host-tree-removal'
 import { isFolderRepo } from '../shared/repo-kind'
+import { getRepoExecutionHostId, LOCAL_EXECUTION_HOST_ID } from '../shared/execution-host'
 import { computeWorkspaceRoot, getWorktreePathSettings } from './ipc/worktree-logic'
 import type { GlobalSettings } from '../shared/global-settings-types'
 import type { Repo } from '../shared/repo-types'
@@ -160,7 +161,14 @@ export function collectWorktreeTrashSweepRoots(
 ): string[] {
   const roots = new Set<string>()
   for (const repo of repos) {
-    if (repo.connectionId || isFolderRepo(repo) || parseWslPath(repo.path)) {
+    // Why the execution host and not `connectionId`: a runtime-owned repo carries
+    // `executionHostId` with no `connectionId`, so a connectionId check calls it local
+    // and sweeps a path that belongs to another machine.
+    if (
+      getRepoExecutionHostId(repo) !== LOCAL_EXECUTION_HOST_ID ||
+      isFolderRepo(repo) ||
+      parseWslPath(repo.path)
+    ) {
       continue
     }
     try {

--- a/src/main/worktree-trash.ts
+++ b/src/main/worktree-trash.ts
@@ -156,7 +156,7 @@ async function collectExistingTrashRoots(workspaceRoots: readonly string[]): Pro
 /** Workspace roots of local git repos — the only places Orca creates worktree trash. */
 export function collectWorktreeTrashSweepRoots(
   repos: readonly Repo[],
-  settings: Pick<GlobalSettings, 'workspaceDir' | 'nestWorkspaces'>
+  settings: Pick<GlobalSettings, 'workspaceDir' | 'nestWorkspaces' | 'hostSettingOverrides'>
 ): string[] {
   const roots = new Set<string>()
   for (const repo of repos) {

--- a/src/renderer/src/components/settings/RepositoryWorktreeDefaultsSection.tsx
+++ b/src/renderer/src/components/settings/RepositoryWorktreeDefaultsSection.tsx
@@ -8,6 +8,7 @@ import { RepoSettingsDraftInput } from './RepositorySettingsDraftInput'
 import { SearchableSetting } from './SearchableSetting'
 import { translate } from '@/i18n/i18n'
 import { getRepoExecutionHostId } from '../../../../shared/execution-host'
+import { getEffectiveHostSetting } from '../../../../shared/host-setting-overrides'
 import {
   effectiveExternalWorktreeVisibility,
   isLegacyRepoForExternalWorktreeVisibility
@@ -19,7 +20,10 @@ type RepositoryWorktreeDefaultsUpdate = Pick<Repo, 'worktreeBasePath' | 'worktre
 
 type RepositoryWorktreeDefaultsSectionProps = {
   repo: Repo
-  settings: Pick<GlobalSettings, 'workspaceDir' | 'worktreeVisibilityDefaults'> | null
+  settings: Pick<
+    GlobalSettings,
+    'workspaceDir' | 'worktreeVisibilityDefaults' | 'hostSettingOverrides'
+  > | null
   updateRepo: (
     repoId: string,
     updates: Partial<RepositoryWorktreeDefaultsUpdate>
@@ -182,7 +186,12 @@ export function RepositoryWorktreeDefaultsSection({
         <RepoSettingsDraftInput
           repoId={repo.id}
           storeValue={repo.worktreeBasePath ?? ''}
-          placeholder={settings?.workspaceDir ?? ''}
+          placeholder={getEffectiveHostSetting(
+            settings,
+            getRepoExecutionHostId(repo),
+            'defaultWorktreeLocation',
+            settings?.workspaceDir ?? ''
+          )}
           onTextChange={() => {}}
           onBlur={(e) => {
             const worktreeBasePath = e.currentTarget.value.trim() || undefined

--- a/src/shared/worktree/configured-worktree-base-path.ts
+++ b/src/shared/worktree/configured-worktree-base-path.ts
@@ -21,6 +21,12 @@ export function resolveWorkspaceLayoutPath(repoPath: string, layoutPath: string)
     : resolveRuntimePath(repoPath, layoutPath)
 }
 
+/** Resolves one configured base path against the repo: a POSIX-absolute value on a
+ *  WSL repo lands inside the distro, and a relative one resolves from the repo root. */
+export function resolveConfiguredWorktreeBasePath(repoPath: string, configured: string): string {
+  return resolveWorkspaceLayoutPath(repoPath, resolveWslRepoWorktreeBasePath(repoPath, configured))
+}
+
 /**
  * Why: the per-project worktree base (#1846) is an explicit statement that a
  * directory holds this project's workspaces, so it outranks the path
@@ -33,6 +39,5 @@ export function resolveConfiguredWorktreeBasePaths(
   if (!repo || !configured) {
     return []
   }
-  const runtimeBase = resolveWslRepoWorktreeBasePath(repo.path, configured)
-  return [resolveWorkspaceLayoutPath(repo.path, runtimeBase)]
+  return [resolveConfiguredWorktreeBasePath(repo.path, configured)]
 }

--- a/src/shared/worktree/ownership-worktree-base-path.test.ts
+++ b/src/shared/worktree/ownership-worktree-base-path.test.ts
@@ -173,6 +173,33 @@ describe('repo-specific worktree ownership layouts', () => {
     ).toBe('external')
   })
 
+  it('includes the host-scoped layout so SSH worktrees under it stay Orca-owned', () => {
+    const settings = makeSettings({
+      workspaceDir: '/local/worktrees',
+      hostSettingOverrides: {
+        'ssh:ssh-1': { defaultWorktreeLocation: '/remote/home/.orca/workspaces' }
+      }
+    })
+    const repo = makeRepo({ path: '/remote/repo', connectionId: 'ssh-1' })
+
+    expect(buildKnownOrcaWorkspaceLayouts(settings, repo)).toContainEqual({
+      path: '/remote/home/.orca/workspaces',
+      nestWorkspaces: true
+    })
+    expect(
+      buildKnownOrcaWorkspaceLayouts(
+        settings,
+        makeRepo({ path: '/other/repo', connectionId: 'ssh-2' })
+      ).some((layout) => layout.path === '/remote/home/.orca/workspaces')
+    ).toBe(false)
+    expect(
+      buildKnownOrcaWorkspaceLayouts(
+        settings,
+        makeRepo({ path: '/remote/repo', connectionId: 'ssh-1', worktreeBasePath: '../custom' })
+      )[0]
+    ).toEqual({ path: '/remote/custom', nestWorkspaces: true })
+  })
+
   it('includes relative global layouts for SSH repos without applying absolute desktop paths', () => {
     const repo = makeRepo({ path: '/remote/repo', connectionId: 'ssh-1' })
     const relativeSettings = makeSettings({ workspaceDir: '../worktrees' })

--- a/src/shared/worktree/ownership-worktree-base-path.test.ts
+++ b/src/shared/worktree/ownership-worktree-base-path.test.ts
@@ -200,6 +200,22 @@ describe('repo-specific worktree ownership layouts', () => {
     ).toEqual({ path: '/remote/custom', nestWorkspaces: true })
   })
 
+  it('keeps the absolute client layout away from runtime-owned repos', () => {
+    // Why this repo shape: a runtime-owned repo carries `executionHostId` and no
+    // `connectionId`, so a connectionId-only locality check calls it local.
+    const settings = makeSettings({
+      workspaceDir: '/local/worktrees',
+      hostSettingOverrides: {
+        'runtime:env-1': { defaultWorktreeLocation: '/remote/home/.orca/workspaces' }
+      }
+    })
+    const repo = makeRepo({ path: '/remote/repo', executionHostId: 'runtime:env-1' })
+
+    expect(buildKnownOrcaWorkspaceLayouts(settings, repo)).toEqual([
+      { path: '/remote/home/.orca/workspaces', nestWorkspaces: true }
+    ])
+  })
+
   it('includes relative global layouts for SSH repos without applying absolute desktop paths', () => {
     const repo = makeRepo({ path: '/remote/repo', connectionId: 'ssh-1' })
     const relativeSettings = makeSettings({ workspaceDir: '../worktrees' })

--- a/src/shared/worktree/ownership.ts
+++ b/src/shared/worktree/ownership.ts
@@ -16,7 +16,7 @@ import {
   type WorktreeVisibilitySourceMatcher
 } from './visibility-sources'
 import { isLegacyRepoForExternalWorktreeVisibility } from '../external-worktree-visibility'
-import { getRepoExecutionHostId } from '../execution-host'
+import { getRepoExecutionHostId, LOCAL_EXECUTION_HOST_ID } from '../execution-host'
 import { getHostSettingOverride } from '../host-setting-overrides'
 import { shouldShowWorktree } from '../worktree-visibility-resolution'
 import type { GlobalSettings, OrcaWorkspaceLayout } from '../global-settings-types'
@@ -102,10 +102,19 @@ function appendWorkspaceLayouts(
 }
 
 function shouldIncludeWorkspaceLayout(
-  repo: Pick<Repo, 'path' | 'connectionId'> | undefined,
+  repo: Pick<Repo, 'path' | 'connectionId' | 'executionHostId'> | undefined,
   layoutPath: string
 ): boolean {
-  return !repo?.connectionId || !isRuntimePathAbsoluteForRepo(repo.path, layoutPath)
+  if (!repo) {
+    return true
+  }
+  // Why the execution host and not `connectionId`: a runtime-owned repo carries
+  // `executionHostId` with no `connectionId`, so a connectionId check calls it local
+  // and hands it the desktop's absolute workspace root as a known Orca layout.
+  return (
+    getRepoExecutionHostId(repo) === LOCAL_EXECUTION_HOST_ID ||
+    !isRuntimePathAbsoluteForRepo(repo.path, layoutPath)
+  )
 }
 
 function buildWslWorkspaceLayouts(

--- a/src/shared/worktree/ownership.ts
+++ b/src/shared/worktree/ownership.ts
@@ -2,6 +2,7 @@ import { normalizeRuntimePathForComparison, relativePathInsideRoot } from '../cr
 import { parseWslUncPath } from '../wsl-paths'
 import {
   isRuntimePathAbsoluteForRepo,
+  resolveConfiguredWorktreeBasePath,
   resolveConfiguredWorktreeBasePaths,
   resolveWorkspaceLayoutPath
 } from './configured-worktree-base-path'
@@ -15,6 +16,8 @@ import {
   type WorktreeVisibilitySourceMatcher
 } from './visibility-sources'
 import { isLegacyRepoForExternalWorktreeVisibility } from '../external-worktree-visibility'
+import { getRepoExecutionHostId } from '../execution-host'
+import { getHostSettingOverride } from '../host-setting-overrides'
 import { shouldShowWorktree } from '../worktree-visibility-resolution'
 import type { GlobalSettings, OrcaWorkspaceLayout } from '../global-settings-types'
 import type { Repo } from '../repo-types'
@@ -30,12 +33,30 @@ export {
 export { shouldShowWorktree } from '../worktree-visibility-resolution'
 
 export function buildKnownOrcaWorkspaceLayouts(
-  settings: Pick<GlobalSettings, 'workspaceDir' | 'nestWorkspaces' | 'workspaceDirHistory'>,
-  repo?: Pick<Repo, 'path' | 'connectionId' | 'worktreeBasePath'>
+  settings: Pick<
+    GlobalSettings,
+    'workspaceDir' | 'nestWorkspaces' | 'workspaceDirHistory' | 'hostSettingOverrides'
+  >,
+  repo?: Pick<Repo, 'path' | 'connectionId' | 'executionHostId' | 'worktreeBasePath'>
 ): OrcaWorkspaceLayout[] {
   const layouts: OrcaWorkspaceLayout[] = []
   for (const basePath of resolveConfiguredWorktreeBasePaths(repo)) {
     layouts.push({ path: basePath, nestWorkspaces: settings.nestWorkspaces })
+  }
+  if (repo) {
+    // Why unconditional, unlike the client default below: a host-scoped root names
+    // a path on the repo's own host, so an absolute value is not a desktop-only path.
+    const hostBasePath = getHostSettingOverride(
+      settings,
+      getRepoExecutionHostId(repo),
+      'defaultWorktreeLocation'
+    )
+    if (hostBasePath) {
+      layouts.push({
+        path: resolveConfiguredWorktreeBasePath(repo.path, hostBasePath),
+        nestWorkspaces: settings.nestWorkspaces
+      })
+    }
   }
   if (settings.workspaceDir && shouldIncludeWorkspaceLayout(repo, settings.workspaceDir)) {
     layouts.push({


### PR DESCRIPTION
## ELI5

Settings → Workspace Directory lets you say "put worktrees here", and it has an "Apply to: \<host\>" picker so a remote SSH machine can use a different folder than your laptop. That picker saved your answer and then nobody ever read it back, so worktrees kept going wherever the laptop default said. On SSH that is especially visible: an absolute laptop path is deliberately ignored on a remote host, so creation falls back to dropping the worktree next to the repo — `~/milvus` + a workspace named `test` becomes `~/milvus-test`. This PR makes the saved per-host answer actually be the answer.

## What Changed

- `getWorktreePathSettings()` / `getWorktreeCreationLayout()` now resolve `repo.worktreeBasePath ?? host override ?? client default` instead of skipping the middle step. The host is `getRepoExecutionHostId(repo)`, so a repo only ever picks up the override belonging to the machine it lives on.
- `hasRepoWorktreeBasePath()` becomes `hasConfiguredWorktreeBasePath(repo, settings)`, which is also true for a host-scoped value. This is what opens `useConfiguredAbsolutePath` on the SSH create path, so an absolute host-scoped root is honored rather than treated as a desktop-only path and replaced by the repo-qualified sibling.
- The worktree base-directory watcher applies the same rule, so the watcher watches the directory creation actually writes to.
- `buildKnownOrcaWorkspaceLayouts()` includes the host-scoped root, so worktrees under it are recognized as Orca-owned even without creation metadata. It is added unconditionally, unlike the client default, which is skipped for SSH repos when absolute — a host-scoped root names a path on the repo's own host, so being absolute is expected there.
- The per-repository "Worktree Location" field now shows the effective host default as its placeholder instead of always showing the client default.

No new settings, no schema change, no new user-facing strings. `hostSettingOverrides` is optional on `GlobalSettings`, so profiles that never touched the picker resolve exactly as before.

## Why

`src/shared/host-setting-overrides.ts` already documents this key as the fix for the exact situation it does not currently handle:

> `defaultWorktreeLocation`: the host's root worktree directory; a remote SSH/runtime host has a different filesystem layout than the local Mac, so the client `workspaceDir` default cannot apply unchanged.

The setting, its persistence, its scope picker and its unit tests all exist. Only the read side in path resolution was missing, which makes a visible control silently inert — worse than not offering it. Wiring the existing key in is a smaller and more honest change than adding another setting.

The alternative available today is the per-repository "Worktree Location" field. It works, but it has to be repeated for every project on a host and new projects do not inherit it, which is precisely the gap a host-scoped default exists to close.

## Linked Issue

Fixes #15320

## Visual Proof

No before/after screenshots: this change has no layout, color, spacing or component change. The only rendered difference is the placeholder text inside the existing "Worktree Location" input on a repository's settings pane, which now reads the host default (e.g. `../.orca/workspaces`) instead of the client default (e.g. `/Users/me/.orca/workspaces`) for a repo on a host that has an override. Everything else about this PR is where files land on disk.

## Testing

- [x] I manually tested these changes locally (reproduced the bug on a real macOS -> Linux SSH pair; see below)
- [x] Automated tests added/updated, or explained why not below

Automated (`src/main/ipc/worktree-logic.test.ts`, `src/shared/worktree/ownership-worktree-base-path.test.ts`):

- host default applies to a repo on that host, and to the recorded creation layout
- a per-repo base path still wins over the host default
- a repo on a different host, and a repo with no host, stay on the client default
- a `local`-scoped override applies to local repos
- an absolute host default survives on the SSH path (`/remote/home/.orca/workspaces/feature`, and `/remote/home/.orca/workspaces/repo/feature` nested) instead of falling back to a sibling
- with only a client default set, the SSH sibling fallback still produces `/remote/repo-feature` — the pre-existing behavior this PR must not disturb
- a blank/whitespace host override is treated as unset
- the host-scoped root is in the known-Orca layout list, is not leaked to repos on other hosts, and does not displace a per-repo override

Manual: reproduced the original symptom on a real macOS client → Linux SSH host pair before the change. With the client default at an absolute macOS path and `../.orca/workspaces` set on the SSH host scope, creating a workspace named `test` in `~/milvus` produced `/home/me/milvus-test`. The per-repo "Worktree Location" workaround was the only thing that moved it.

Suite runs: `pnpm lint` and `pnpm typecheck` pass. The 6 test files covering the touched modules pass, as do all 65 test files that import any touched module (1993 tests). The full `pnpm test` run reports 23 failures across 13 files on this machine, all in unrelated areas (Electron browser cookie import, PTY subprocess env, shell startup, ssh2 host-key store, WSL exec separator). Checked out plain `main` (`2f0f9a8a39`) in the same tree and ran exactly those 13 files: the same 23 tests fail there, so they are pre-existing on this machine and not from these commits.

Platforms exercised by the automated tests: POSIX and Windows-style paths both, since path resolution branches on path flavor. I have not run the packaged app on Windows.

## AI Disclosure

Written with Claude Opus 5 via Claude Code. The bug was found while configuring a real macOS → Linux SSH setup, and every code path claimed above was read before the change was made.

## Review

- **Cross-platform**: no new path construction. Resolution keeps flowing through `computeWorkspaceRoot()` / `resolveRuntimePath()`, which already pick the win32 or posix flavor from the path shape; tests cover a Windows-style repo path with a Windows-style relative base. The WSL mirroring branch is untouched — it triggers on a WSL repo path with an absolute non-UNC base, and a host-scoped value reaches it the same way the client default does.
- **SSH / remote / local**: this is the SSH path's bug, and the sibling fallback for the unconfigured case is covered by a test so it cannot silently regress. Local repos are affected only when a `local`-scoped override exists, which previously had no effect either. One known limit, unchanged by this PR: a remote Orca runtime resolves worktree paths from its own settings store, so a client-side override for a `runtime:` host still does not reach it. The SSH case reported in the issue runs in the client's main process and is fully covered.
- **Backwards compatibility**: `hostSettingOverrides` is optional and absent in existing profiles, so `getHostSettingOverride()` returns `undefined` and every fallback chain collapses to its previous form. Existing worktrees are never moved; only newly created ones use the new root.
- **Agents / integrations / git providers**: nothing here is agent-, integration- or provider-specific. No git command changed, so there is no git-version boundary to consider.
- **Performance**: one object lookup per resolution (`hostSettingOverrides?.[hostId]?.[key]`), on paths that already do filesystem and git work. `getBaseWatchLayout()` moved its `getWorktreePathSettings()` call inward rather than adding one.
- **Security**: no new IPC surface, no new persisted field, no user input newly reaching a shell or filesystem call. A host-scoped base path lands in the same resolution and root-registration code the per-repo base path already used.
- **UI**: one placeholder value; no new strings, so no localization catalog change.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Behavior precedence after this change, unchanged except for the middle term: per-repo "Worktree Location" → per-host "Workspace Directory" → client "Workspace Directory".

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — `pnpm lint` and `pnpm typecheck` pass locally. For tests, see the Testing section: the touched files and every test file importing a touched module pass; the full suite has unrelated failures on this machine. `pnpm build` not run locally.

## Author

- X / Twitter:
