### PR TITLE
fix(agent-hooks): stop untyped tool-hook agent_ids from minting phantom subagent rows

### DIFF
--- a/src/shared/agent-hook-listener-claude-subagents.test.ts
+++ b/src/shared/agent-hook-listener-claude-subagents.test.ts
@@ -306,6 +306,45 @@ describe('shared agent-hook-listener', () => {
       expect(idled?.payload.state).toBe('done')
     })
 
+    it('does not mint roster rows from tool-hook agent_ids without a SubagentStart', () => {
+      claudeEvent({ hook_event_name: 'UserPromptSubmit', prompt: 'dispatch workers' })
+      // Why: long-lived async agents emit non-stable agent_ids (no agent_type)
+      // on tool hooks; each one used to mint a phantom "Working - Agent" row
+      // until the 32-row cap silently hid real children.
+      for (const agentId of ['a5607a3521aa9a9ed', 'a92cd47f7566dec58', 'a60d222b0681b351b']) {
+        const tool = claudeEvent({
+          hook_event_name: 'PreToolUse',
+          agent_id: agentId,
+          tool_name: 'Bash',
+          tool_input: { command: 'sleep 5' }
+        })
+        expect(tool?.payload.subagents).toBeUndefined()
+      }
+      const post = claudeEvent({
+        hook_event_name: 'PostToolUse',
+        agent_id: 'ad3d02b0637f28744',
+        tool_name: 'Bash',
+        tool_input: { command: 'sleep 5' }
+      })
+      expect(post?.payload.subagents).toBeUndefined()
+
+      // a real child still appears and refreshes from its tool activity
+      claudeEvent({
+        hook_event_name: 'SubagentStart',
+        agent_id: 'a-real',
+        agent_type: 'Explore'
+      })
+      const refresh = claudeEvent({
+        hook_event_name: 'PostToolUse',
+        agent_id: 'a-real',
+        tool_name: 'Bash',
+        tool_input: { command: 'ls' }
+      })
+      expect(refresh?.payload.subagents).toEqual([
+        expect.objectContaining({ id: 'a-real', state: 'working', agentType: 'Explore' })
+      ])
+    })
+
     it('scopes subagent rosters per pane', () => {
       claudeEvent(
         { hook_event_name: 'SubagentStart', agent_id: 'a1', agent_type: 'general-purpose' },

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -36,6 +36,7 @@ import {
   idleClaudeTeammateByName,
   reapUnconfirmedRestoredClaudeSubagents,
   stopClaudeSubagent,
+  trackClaudeSubagentToolActivity,
   upsertWorkingClaudeSubagent,
   type ClaudeSubagentRoster
 } from './claude-subagent-roster'
@@ -3044,12 +3045,20 @@ function normalizeClaudeEvent(
       ? eventAgentId
       : undefined
   if (eventAgentId && (subagentOriginId || isWaitingInducing)) {
-    upsertWorkingClaudeSubagent(
-      getOrCreateClaudeSubagentRoster(state, paneKey),
-      eventAgentId,
-      { agentType: readString(hookPayload, 'agent_type') },
-      Date.now()
-    )
+    // Why: tool hooks refresh known children and may recover a start-less one
+    // only with agent_type (documented subagent context); untyped agent_ids
+    // are non-stable noise from long-lived async agents that minted phantom
+    // rows until the roster cap hid real children.
+    const agentType = readString(hookPayload, 'agent_type')
+    const roster = state.claudeSubagentRosterByPaneKey.get(paneKey)
+    if (roster || agentType !== undefined) {
+      trackClaudeSubagentToolActivity(
+        roster ?? getOrCreateClaudeSubagentRoster(state, paneKey),
+        eventAgentId,
+        { agentType },
+        Date.now()
+      )
+    }
   }
   if (subagentOriginId) {
     const lead = state.claudeLeadStateByPaneKey.get(paneKey)

--- a/src/shared/claude-subagent-roster.test.ts
+++ b/src/shared/claude-subagent-roster.test.ts
@@ -9,7 +9,9 @@ import {
   foldClaudeBackgroundTasksIntoRoster,
   idleClaudeTeammateByName,
   reapUnconfirmedRestoredClaudeSubagents,
+  refreshWorkingClaudeSubagent,
   stopClaudeSubagent,
+  trackClaudeSubagentToolActivity,
   upsertWorkingClaudeSubagent,
   type ClaudeSubagentRoster
 } from './claude-subagent-roster'
@@ -36,6 +38,59 @@ describe('claude-subagent-roster', () => {
     stopClaudeSubagent(roster, 'a1')
     expect(roster.size).toBe(0)
     expect(claudeRosterToSnapshots(roster)).toBeUndefined()
+  })
+
+  it('never mints a row for an unknown id on refresh', () => {
+    const roster: ClaudeSubagentRoster = new Map()
+    // Why: long-lived async agents emit non-stable agent_ids (no agent_type)
+    // on tool hooks; creating a row per id filled the roster cap with
+    // phantoms and silently dropped real children.
+    expect(refreshWorkingClaudeSubagent(roster, 'a-phantom', {})).toBe(false)
+    expect(roster.size).toBe(0)
+  })
+
+  it('refreshes a tracked child to working and merges its type', () => {
+    const roster: ClaudeSubagentRoster = new Map()
+    upsertWorkingClaudeSubagent(roster, 'areviewer-6d3cb5b5', {}, 100)
+    stopClaudeSubagent(roster, 'areviewer-6d3cb5b5')
+    expect(roster.get('areviewer-6d3cb5b5')).toMatchObject({ state: 'idle' })
+
+    expect(
+      refreshWorkingClaudeSubagent(roster, 'areviewer-6d3cb5b5', { agentType: 'Explore' })
+    ).toBe(true)
+    expect(roster.get('areviewer-6d3cb5b5')).toMatchObject({
+      state: 'working',
+      agentType: 'Explore'
+    })
+  })
+
+  it('never mints a row from an untyped tool-hook agent_id', () => {
+    const roster: ClaudeSubagentRoster = new Map()
+    upsertWorkingClaudeSubagent(roster, 'a-real', { agentType: 'Explore' }, 100)
+    // Why: long-lived async agents emit non-stable agent_ids without
+    // agent_type on tool calls; each one used to mint a phantom row until
+    // the cap silently dropped real children.
+    trackClaudeSubagentToolActivity(roster, 'a5607a3521aa9a9ed', {}, 200)
+    trackClaudeSubagentToolActivity(roster, 'a92cd47f7566dec58', {}, 201)
+    expect(roster.size).toBe(1)
+    expect(roster.has('a5607a3521aa9a9ed')).toBe(false)
+  })
+
+  it('recovers a start-less child from a typed tool hook', () => {
+    const roster: ClaudeSubagentRoster = new Map()
+    // Why: a real child whose SubagentStart was missed (Orca restart) still
+    // carries agent_type on its tool events — the only proof it is alive
+    // before the next lead-Stop fold.
+    trackClaudeSubagentToolActivity(
+      roster,
+      'a0000000000000001',
+      { agentType: 'general-purpose' },
+      200
+    )
+    expect(roster.get('a0000000000000001')).toMatchObject({
+      state: 'working',
+      agentType: 'general-purpose'
+    })
   })
 
   it('parks a teammate-shaped named agent as idle on stop', () => {

--- a/src/shared/claude-subagent-roster.ts
+++ b/src/shared/claude-subagent-roster.ts
@@ -60,6 +60,55 @@ export function isClaudeTeammateLifecycleId(id: string): boolean {
   return separator > 1 && id.startsWith('a') && /^[0-9a-f]+$/i.test(id.slice(separator + 1))
 }
 
+/** Refresh a tracked child from its own tool activity. Returns false for an
+ *  unknown id: tool hooks never mint rows — only SubagentStart, an
+ *  authoritative background_tasks fold, or a snapshot restore does — so
+ *  non-stable agent ids on long-lived async agents can't pile up phantom
+ *  entries that fill the roster cap and hide real children. */
+export function refreshWorkingClaudeSubagent(
+  roster: ClaudeSubagentRoster,
+  id: string,
+  fields: { agentType?: string; description?: string }
+): boolean {
+  const existing = roster.get(id)
+  if (!existing) {
+    return false
+  }
+  existing.state = 'working'
+  existing.agentType = fields.agentType ?? existing.agentType
+  existing.description = fields.description ?? existing.description
+  // Why: live activity proves the lifecycle stream owns this id again;
+  // background_tasks omission must stop reaping it (teammate-shaped ids
+  // never appear there). The fold re-tags its own recreations after this.
+  existing.backgroundTasksAuthoritative = undefined
+  // Why: the live event proves the agent process behind the restored row is
+  // still running it, so the liveness reap must stop treating it as a claim.
+  existing.restoredFromSnapshot = undefined
+  return true
+}
+
+/** Track a child observed on a tool hook (PreToolUse/PostToolUse family).
+ *  Refreshes a known id always; creates an unknown id only when the payload
+ *  carries an `agentType` — the documented subagent context, and the only
+ *  signal separating a real child whose SubagentStart was missed (Orca
+ *  restart) from the non-stable untyped agent_ids long-lived async agents
+ *  emit on tool calls, which used to mint dozens of phantom rows that filled
+ *  the roster cap and hid real children. */
+export function trackClaudeSubagentToolActivity(
+  roster: ClaudeSubagentRoster,
+  id: string,
+  fields: { agentType?: string; description?: string },
+  now: number
+): void {
+  if (refreshWorkingClaudeSubagent(roster, id, fields)) {
+    return
+  }
+  if (fields.agentType === undefined) {
+    return
+  }
+  upsertWorkingClaudeSubagent(roster, id, fields, now)
+}
+
 export function upsertWorkingClaudeSubagent(
   roster: ClaudeSubagentRoster,
   id: string,
@@ -69,18 +118,7 @@ export function upsertWorkingClaudeSubagent(
   if (id.length === 0 || id.length > CLAUDE_SUBAGENT_ID_MAX_LENGTH) {
     return
   }
-  const existing = roster.get(id)
-  if (existing) {
-    existing.state = 'working'
-    existing.agentType = fields.agentType ?? existing.agentType
-    existing.description = fields.description ?? existing.description
-    // Why: live activity proves the lifecycle stream owns this id again;
-    // background_tasks omission must stop reaping it (teammate-shaped ids
-    // never appear there). The fold re-tags its own recreations after this.
-    existing.backgroundTasksAuthoritative = undefined
-    // Why: the live event proves the agent process behind the restored row is
-    // still running it, so the liveness reap must stop treating it as a claim.
-    existing.restoredFromSnapshot = undefined
+  if (refreshWorkingClaudeSubagent(roster, id, fields)) {
     return
   }
   // Why: beyond the wire cap extra rows would be invisible anyway; idle

--- a/src/shared/claude-subagent-roster.ts
+++ b/src/shared/claude-subagent-roster.ts
@@ -61,10 +61,9 @@ export function isClaudeTeammateLifecycleId(id: string): boolean {
 }
 
 /** Refresh a tracked child from its own tool activity. Returns false for an
- *  unknown id: tool hooks never mint rows — only SubagentStart, an
- *  authoritative background_tasks fold, or a snapshot restore does — so
- *  non-stable agent ids on long-lived async agents can't pile up phantom
- *  entries that fill the roster cap and hide real children. */
+ *  unknown id — creation policy belongs to the caller (see
+ *  trackClaudeSubagentToolActivity), so untyped non-stable ids from
+ *  long-lived async agents can't mint phantom rows here. */
 export function refreshWorkingClaudeSubagent(
   roster: ClaudeSubagentRoster,
   id: string,


### PR DESCRIPTION
Fixes #15325.

## Problem

When a dispatched worker runs long-lived async background agents, the agent status tree accumulates dozens of phantom `Working - Agent` rows. Observed: 4 real async agents displayed as **32 roster entries** (the cap) — 30 of them phantom rows with no `agentType` and agent IDs that appear in no Claude Code transcript.

`normalizeClaudeEvent` upserted a roster row for **every** `PreToolUse`/`PostToolUse`/`PostToolUseFailure` payload carrying an `agent_id`, with no validation that the id corresponds to a real live agent. Long-lived async agents emit **non-stable, untyped** `agent_id` values on their tool hooks (one per ~20–90s), so each one minted a new phantom row. Reconciliation against `background_tasks` only runs on `Stop`/`StopFailure`, so a 10-minute worker turn accumulated phantoms for the whole turn — and once the 32-row cap filled, real agents starting later were silently dropped.

## Fix

Tool hooks now go through `trackClaudeSubagentToolActivity`:

- **Known id** → refresh (existing behavior: state back to working, type merged, restore/authoritative flags cleared).
- **Unknown id with `agent_type`** → create. `agent_type` is the documented subagent context and is present on every real child's tool events (verified in controlled repro), so this still recovers a start-less child whose `SubagentStart` was missed (e.g. Orca restart) — the behavior the old unconditional upsert existed to preserve.
- **Unknown id without `agent_type`** → dropped. These are the non-stable ids from long-lived async agents; nothing real is lost because `SubagentStart` and the lead-`Stop` `background_tasks` fold remain the authoritative creation paths.

`upsertWorkingClaudeSubagent` (used by `SubagentStart` and the fold) and the fold's teammate-shaped-id protections are unchanged.

## Test plan

- [x] New roster tests: refresh never mints; untyped tool-hook ids never mint; typed unknown ids still recover a start-less child; refresh flips an idle teammate row back to working and merges its type.
- [x] New listener test: a stream of untyped `PreToolUse`/`PostToolUse` `agent_id`s produces no subagent rows, while a real `SubagentStart` + tool activity still tracks and refreshes.
- [x] Existing listener/roster suites pass (`src/shared`, `src/main/agent-hooks`: 5788 passed; one unrelated `setup-agent-sequencing` timeout flake passes alone).
- [x] `pnpm run typecheck`, oxlint clean.
- [x] Manual hook-replay verification: replayed the exact bug-report event shape (4 real `SubagentStart`s + 30 untyped non-stable tool-hook ids + the real agents' own typed tool activity) through a real `AgentHookServer` HTTP instance, asserting on the persisted `last-status.json`. **Before the fix: 32 roster entries (cap hit, assertion fails). After the fix: exactly the 4 real agents, all typed and working.** See the verification comment for details.