### PR TITLE
feat(right-sidebar): show the active workspace's linked task in a Task panel

### DIFF
--- a/src/main/persistence/applying-settings/ui-selection-normalization.ts
+++ b/src/main/persistence/applying-settings/ui-selection-normalization.ts
@@ -68,7 +68,8 @@ export function normalizeRightSidebarTab(tab: unknown): PersistedState['ui']['ri
     tab === 'pr-checks' ||
     tab === 'source-control' ||
     tab === 'checks' ||
-    tab === 'ports'
+    tab === 'ports' ||
+    tab === 'task'
   ) {
     return tab
   }

--- a/src/main/runtime/rpc/methods/client-ui-schemas.ts
+++ b/src/main/runtime/rpc/methods/client-ui-schemas.ts
@@ -48,7 +48,8 @@ const STATIC_RIGHT_SIDEBAR_TABS = [
   'pr-checks',
   'source-control',
   'checks',
-  'ports'
+  'ports',
+  'task'
 ] as const
 // Plugin panels are open-ended `plugin:<publisher>.<id>/<panel>` keys, so the
 // schema validates their shape rather than enumerating them.

--- a/src/renderer/src/components/github-item-dialog/load-item-details/github-item-dialog-types.ts
+++ b/src/renderer/src/components/github-item-dialog/load-item-details/github-item-dialog-types.ts
@@ -16,6 +16,9 @@ export type GitHubItemDialogProps = {
   sourceContext?: TaskSourceContext | null
   initialTab?: ItemDialogTab
   backLabel?: string
+  /** 'panel' drops the page chrome that has no meaning inside a sidebar panel:
+   *  the back affordance and the start-workspace CTA. */
+  variant?: 'page' | 'panel'
   /** Called when the user clicks the primary CTA to start work from this item. */
   onUse: (item: GitHubWorkItem) => void
   onReviewRequestsChange?: (

--- a/src/renderer/src/components/github-item-dialog/open-dialog/github-item-dialog-issue-header.tsx
+++ b/src/renderer/src/components/github-item-dialog/open-dialog/github-item-dialog-issue-header.tsx
@@ -30,6 +30,7 @@ import { WorkItemIssueSourceIndicator } from './work-item-issue-source-indicator
 export function GitHubItemDialogIssueHeader({
   workItem,
   backLabel,
+  embedded,
   onClose,
   linkCopied,
   setLinkCopyButtonRef,
@@ -44,6 +45,8 @@ export function GitHubItemDialogIssueHeader({
 }: {
   workItem: GitHubWorkItem
   backLabel: string
+  /** Rendered inside a sidebar panel: no back affordance, no workspace CTA. */
+  embedded: boolean
   onClose: () => void
   linkCopied: boolean
   setLinkCopyButtonRef: (node: HTMLButtonElement | null) => void
@@ -64,18 +67,22 @@ export function GitHubItemDialogIssueHeader({
     <>
       <div className="flex-none border-b border-border/60 bg-muted/30 px-6 py-2.5">
         <div className="flex items-center gap-2 text-[13px] text-muted-foreground">
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={onClose}
-            className="-ml-2 h-7 gap-1 px-2 text-muted-foreground hover:text-foreground"
-            aria-label={backLabel}
-          >
-            <ChevronLeft className="size-4" />
-            {backLabel}
-          </Button>
-          <span className="text-border">·</span>
+          {embedded ? null : (
+            <>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={onClose}
+                className="-ml-2 h-7 gap-1 px-2 text-muted-foreground hover:text-foreground"
+                aria-label={backLabel}
+              >
+                <ChevronLeft className="size-4" />
+                {backLabel}
+              </Button>
+              <span className="text-border">·</span>
+            </>
+          )}
           {ownerRepo ? (
             <>
               <span className="truncate">
@@ -142,70 +149,72 @@ export function GitHubItemDialogIssueHeader({
             <span className="break-words">{workItem.title}</span>
             <span className="ml-2 font-light text-muted-foreground">#{workItem.number}</span>
           </h1>
-          <div className="flex shrink-0 items-center gap-2">
-            {/* Why: Orca's signature affordance — keep primary so it stands out against GitHub's familiar surface. */}
-            {issueAttachedWorkspace ? (
-              <DropdownMenu modal={false}>
-                <ButtonGroup>
-                  <Button
-                    type="button"
-                    size="sm"
-                    onClick={() => handleOpenOrUseIssueWorkspace(workItem)}
-                    className="gap-1.5 whitespace-nowrap"
-                    aria-label={translate(
-                      'auto.components.GitHubItemDialog.84855fedd0',
-                      'Open workspace attached to issue'
-                    )}
-                  >
-                    {translate('auto.components.GitHubItemDialog.726db41722', 'Open workspace')}
-                    <ArrowRight className="size-3.5" />
-                  </Button>
-                  <DropdownMenuTrigger asChild>
+          {embedded ? null : (
+            <div className="flex shrink-0 items-center gap-2">
+              {/* Why: Orca's signature affordance — keep primary so it stands out against GitHub's familiar surface. */}
+              {issueAttachedWorkspace ? (
+                <DropdownMenu modal={false}>
+                  <ButtonGroup>
                     <Button
                       type="button"
-                      size="icon-sm"
+                      size="sm"
+                      onClick={() => handleOpenOrUseIssueWorkspace(workItem)}
+                      className="gap-1.5 whitespace-nowrap"
                       aria-label={translate(
-                        'auto.components.GitHubItemDialog.fe6ff12dc2',
-                        'More issue workspace actions'
+                        'auto.components.GitHubItemDialog.84855fedd0',
+                        'Open workspace attached to issue'
                       )}
                     >
-                      <ChevronDown className="size-3.5" />
+                      {translate('auto.components.GitHubItemDialog.726db41722', 'Open workspace')}
+                      <ArrowRight className="size-3.5" />
                     </Button>
-                  </DropdownMenuTrigger>
-                </ButtonGroup>
-                <DropdownMenuContent align="end">
-                  <DropdownMenuItem onSelect={() => onUse(workItem)}>
-                    <Plus className="size-4" />
-                    {translate(
-                      'auto.components.GitHubItemDialog.36182aa57f',
-                      'Start new workspace'
-                    )}
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onSelect={() => window.api.shell.openUrl(workItem.url)}>
-                    <ExternalLink className="size-4" />
-                    {translate('auto.components.GitHubItemDialog.3fdf777817', 'Open on GitHub')}
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            ) : (
-              <Button
-                type="button"
-                size="sm"
-                onClick={() => onUse(workItem)}
-                className="gap-1.5 whitespace-nowrap"
-                aria-label={translate(
-                  'auto.components.GitHubItemDialog.0ab4664a8b',
-                  'Start workspace from issue'
-                )}
-              >
-                {translate(
-                  'auto.components.GitHubItemDialog.0ab4664a8b',
-                  'Start workspace from issue'
-                )}
-                <ArrowRight className="size-3.5" />
-              </Button>
-            )}
-          </div>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        type="button"
+                        size="icon-sm"
+                        aria-label={translate(
+                          'auto.components.GitHubItemDialog.fe6ff12dc2',
+                          'More issue workspace actions'
+                        )}
+                      >
+                        <ChevronDown className="size-3.5" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                  </ButtonGroup>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem onSelect={() => onUse(workItem)}>
+                      <Plus className="size-4" />
+                      {translate(
+                        'auto.components.GitHubItemDialog.36182aa57f',
+                        'Start new workspace'
+                      )}
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onSelect={() => window.api.shell.openUrl(workItem.url)}>
+                      <ExternalLink className="size-4" />
+                      {translate('auto.components.GitHubItemDialog.3fdf777817', 'Open on GitHub')}
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              ) : (
+                <Button
+                  type="button"
+                  size="sm"
+                  onClick={() => onUse(workItem)}
+                  className="gap-1.5 whitespace-nowrap"
+                  aria-label={translate(
+                    'auto.components.GitHubItemDialog.0ab4664a8b',
+                    'Start workspace from issue'
+                  )}
+                >
+                  {translate(
+                    'auto.components.GitHubItemDialog.0ab4664a8b',
+                    'Start workspace from issue'
+                  )}
+                  <ArrowRight className="size-3.5" />
+                </Button>
+              )}
+            </div>
+          )}
         </div>
         <div className="mt-3 flex flex-wrap items-center gap-2 text-[13px] text-muted-foreground">
           <span

--- a/src/renderer/src/components/github-item-dialog/open-dialog/github-item-dialog.tsx
+++ b/src/renderer/src/components/github-item-dialog/open-dialog/github-item-dialog.tsx
@@ -25,6 +25,7 @@ export default function GitHubItemDialog({
   sourceContext,
   initialTab,
   backLabel = 'Back',
+  variant = 'page',
   projectOrigin,
   onUse,
   onReviewRequestsChange,
@@ -146,6 +147,7 @@ export default function GitHubItemDialog({
         <GitHubItemDialogIssueHeader
           workItem={workItem}
           backLabel={backLabel}
+          embedded={variant === 'panel'}
           onClose={onClose}
           linkCopied={linkCopied}
           setLinkCopyButtonRef={setLinkCopyButtonRef}

--- a/src/renderer/src/components/pull-request-page/page-types.ts
+++ b/src/renderer/src/components/pull-request-page/page-types.ts
@@ -34,6 +34,9 @@ export type PullRequestPageProps = {
     reviewRequests: GitHubAssignableUser[]
   ) => void
   onClose: () => void
+  /** 'panel' drops the page chrome that has no meaning inside a sidebar panel:
+   *  the back affordance and the start-workspace CTA. */
+  variant?: 'page' | 'panel'
   /** Optional Project-origin context; when set, slug-addressed IPCs route writes to the row's repo instead of `repoPath` (both may be set — slug wins for writes). */
   projectOrigin?: PullRequestPageProjectOrigin
 }

--- a/src/renderer/src/components/pull-request-page/page/header.tsx
+++ b/src/renderer/src/components/pull-request-page/page/header.tsx
@@ -31,6 +31,7 @@ export function PullRequestPageHeader({
   workItem,
   displayWorkItem,
   backLabel,
+  embedded,
   onClose,
   linkCopied,
   setLinkCopyButtonRef,
@@ -45,6 +46,8 @@ export function PullRequestPageHeader({
   workItem: GitHubWorkItem
   displayWorkItem: GitHubWorkItem | null
   backLabel: string
+  /** Rendered inside a sidebar panel: no back affordance, no workspace CTA. */
+  embedded: boolean
   onClose: () => void
   linkCopied: boolean
   setLinkCopyButtonRef: (node: HTMLButtonElement | null) => void
@@ -68,18 +71,22 @@ export function PullRequestPageHeader({
       {/* Row 1: page header strip — breadcrumb-style row mirroring Primer canvas-subtle */}
       <div className="flex-none border-b border-border/60 bg-muted/30 px-6 py-2.5">
         <div className="flex items-center gap-2 text-[13px] text-muted-foreground">
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={onClose}
-            className="-ml-2 h-7 gap-1 px-2 text-muted-foreground hover:text-foreground"
-            aria-label={backLabel}
-          >
-            <ChevronLeft className="size-4" />
-            {backLabel}
-          </Button>
-          <span className="text-muted-foreground/40">·</span>
+          {embedded ? null : (
+            <>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={onClose}
+                className="-ml-2 h-7 gap-1 px-2 text-muted-foreground hover:text-foreground"
+                aria-label={backLabel}
+              >
+                <ChevronLeft className="size-4" />
+                {backLabel}
+              </Button>
+              <span className="text-muted-foreground/40">·</span>
+            </>
+          )}
           {ownerRepo ? (
             <>
               <span className="truncate">
@@ -149,58 +156,63 @@ export function PullRequestPageHeader({
               #{workItem.number}
             </span>
           </h1>
-          <div className="flex shrink-0 items-center gap-2">
-            {/* Why: Orca's signature affordance — keep primary so it stands out against GitHub's familiar surface. */}
-            <DropdownMenu modal={false}>
-              <ButtonGroup>
-                <Button
-                  type="button"
-                  onClick={onOpenOrUsePR}
-                  className="w-[180px] justify-center gap-1.5 whitespace-nowrap"
-                  aria-label={
-                    hasAttachedWorkspace
-                      ? translate(
-                          'auto.components.PullRequestPage.a459866967',
-                          'Resume workspace attached to PR'
-                        )
-                      : translate(
-                          'auto.components.PullRequestPage.25690a3855',
-                          'Start workspace from PR'
-                        )
-                  }
-                >
-                  {hasAttachedWorkspace
-                    ? translate('auto.components.PullRequestPage.c9e7094a7b', 'Resume workspace')
-                    : translate('auto.components.PullRequestPage.71a3c0f9d2', 'Start workspace')}
-                  <ArrowRight className="size-4" />
-                </Button>
-                <DropdownMenuTrigger asChild>
+          {embedded ? null : (
+            <div className="flex shrink-0 items-center gap-2">
+              {/* Why: Orca's signature affordance — keep primary so it stands out against GitHub's familiar surface. */}
+              <DropdownMenu modal={false}>
+                <ButtonGroup>
                   <Button
                     type="button"
-                    size="icon"
-                    aria-label={translate(
-                      'auto.components.PullRequestPage.57c13a5aa4',
-                      'More PR workspace actions'
-                    )}
+                    onClick={onOpenOrUsePR}
+                    className="w-[180px] justify-center gap-1.5 whitespace-nowrap"
+                    aria-label={
+                      hasAttachedWorkspace
+                        ? translate(
+                            'auto.components.PullRequestPage.a459866967',
+                            'Resume workspace attached to PR'
+                          )
+                        : translate(
+                            'auto.components.PullRequestPage.25690a3855',
+                            'Start workspace from PR'
+                          )
+                    }
                   >
-                    <ChevronDown className="size-4" />
+                    {hasAttachedWorkspace
+                      ? translate('auto.components.PullRequestPage.c9e7094a7b', 'Resume workspace')
+                      : translate('auto.components.PullRequestPage.71a3c0f9d2', 'Start workspace')}
+                    <ArrowRight className="size-4" />
                   </Button>
-                </DropdownMenuTrigger>
-              </ButtonGroup>
-              <DropdownMenuContent align="end">
-                {hasAttachedWorkspace ? (
-                  <DropdownMenuItem onSelect={onUseWorkItem}>
-                    <Plus className="size-4" />
-                    {translate('auto.components.PullRequestPage.1a2570e18e', 'Start new workspace')}
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      type="button"
+                      size="icon"
+                      aria-label={translate(
+                        'auto.components.PullRequestPage.57c13a5aa4',
+                        'More PR workspace actions'
+                      )}
+                    >
+                      <ChevronDown className="size-4" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                </ButtonGroup>
+                <DropdownMenuContent align="end">
+                  {hasAttachedWorkspace ? (
+                    <DropdownMenuItem onSelect={onUseWorkItem}>
+                      <Plus className="size-4" />
+                      {translate(
+                        'auto.components.PullRequestPage.1a2570e18e',
+                        'Start new workspace'
+                      )}
+                    </DropdownMenuItem>
+                  ) : null}
+                  <DropdownMenuItem onSelect={() => window.api.shell.openUrl(workItem.url)}>
+                    <ExternalLink className="size-4" />
+                    {translate('auto.components.PullRequestPage.8ecda455a0', 'Open on GitHub')}
                   </DropdownMenuItem>
-                ) : null}
-                <DropdownMenuItem onSelect={() => window.api.shell.openUrl(workItem.url)}>
-                  <ExternalLink className="size-4" />
-                  {translate('auto.components.PullRequestPage.8ecda455a0', 'Open on GitHub')}
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          )}
         </div>
         <div className="mt-4 flex flex-wrap items-center gap-x-2.5 gap-y-2 text-[13px] text-muted-foreground">
           <span

--- a/src/renderer/src/components/pull-request-page/page/surface.tsx
+++ b/src/renderer/src/components/pull-request-page/page/surface.tsx
@@ -42,6 +42,7 @@ export default function PullRequestPage({
   sourceContext,
   initialTab,
   backLabel = 'Pull requests',
+  variant = 'page',
   projectOrigin,
   onUse,
   onReviewRequestsChange,
@@ -316,6 +317,7 @@ export default function PullRequestPage({
         workItem={workItem}
         displayWorkItem={displayWorkItem}
         backLabel={backLabel}
+        embedded={variant === 'panel'}
         onClose={onClose}
         linkCopied={linkCopied}
         setLinkCopyButtonRef={setLinkCopyButtonRef}

--- a/src/renderer/src/components/right-sidebar/TaskPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/TaskPanel.tsx
@@ -1,0 +1,88 @@
+import { useMemo } from 'react'
+import { ExternalLink } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import CommentMarkdown from '@/components/sidebar/CommentMarkdown'
+import { openHttpLink } from '@/lib/http-link-routing'
+import { useActiveWorktree } from '@/store/selectors'
+import { translate } from '@/i18n/i18n'
+import { resolveWorkspaceLinkedTask } from './workspace-linked-task'
+import { useWorkspaceLinkedTaskDetail } from './use-workspace-linked-task-detail'
+import { WORKSPACE_LINKED_TASK_PROVIDER_LABELS } from './workspace-linked-task-labels'
+
+export default function TaskPanel(): React.JSX.Element {
+  const worktree = useActiveWorktree()
+  const task = useMemo(() => resolveWorkspaceLinkedTask(worktree), [worktree])
+  const detail = useWorkspaceLinkedTaskDetail(task)
+
+  if (!task) {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center p-6 text-center text-sm text-muted-foreground">
+        {translate(
+          'auto.components.rightSidebar.TaskPanel.unlinked',
+          'This workspace is not linked to a task.'
+        )}
+      </div>
+    )
+  }
+
+  const providerLabel = WORKSPACE_LINKED_TASK_PROVIDER_LABELS[task.provider]
+  const openLabel = translate('auto.components.rightSidebar.TaskPanel.openExternal', 'Open task')
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
+      <div className="border-b border-border px-4 py-3">
+        <div className="flex items-start gap-2">
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <span className="font-medium text-foreground">{task.reference}</span>
+              <span aria-hidden="true">·</span>
+              <span className="truncate">{providerLabel}</span>
+              {detail.state ? (
+                <>
+                  <span aria-hidden="true">·</span>
+                  <span className="truncate capitalize">{detail.state}</span>
+                </>
+              ) : null}
+            </div>
+            <div className="mt-1 text-sm leading-5 font-medium break-words text-foreground">
+              {detail.title ||
+                translate('auto.components.rightSidebar.TaskPanel.untitled', 'Untitled task')}
+            </div>
+          </div>
+          {detail.url ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  onClick={() => void openHttpLink(detail.url)}
+                  aria-label={openLabel}
+                >
+                  <ExternalLink className="size-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">{openLabel}</TooltipContent>
+            </Tooltip>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="scrollbar-sleek min-h-0 flex-1 overflow-y-auto px-4 py-3">
+        {detail.description ? (
+          <CommentMarkdown content={detail.description} variant="compact" />
+        ) : (
+          <div className="text-xs leading-5 text-muted-foreground">
+            {detail.loading
+              ? translate('auto.components.rightSidebar.TaskPanel.loading', 'Loading task details.')
+              : translate(
+                  'auto.components.rightSidebar.TaskPanel.descriptionUnavailable',
+                  'No description is available here yet. Open the task to read it in full.'
+                )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/right-sidebar/TaskPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/TaskPanel.tsx
@@ -1,19 +1,48 @@
-import { useMemo } from 'react'
-import { ExternalLink } from 'lucide-react'
-import { Button } from '@/components/ui/button'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import CommentMarkdown from '@/components/sidebar/CommentMarkdown'
-import { openHttpLink } from '@/lib/http-link-routing'
-import { useActiveWorktree } from '@/store/selectors'
+import { useCallback, useMemo } from 'react'
+import { lazyWithRetry as lazy } from '@/lib/lazy-with-retry'
+import { useActiveWorktree, useRepoById } from '@/store/selectors'
 import { translate } from '@/i18n/i18n'
+import type { GitHubWorkItem } from '../../../../shared/github/work-item-types'
 import { resolveWorkspaceLinkedTask } from './workspace-linked-task'
-import { useWorkspaceLinkedTaskDetail } from './use-workspace-linked-task-detail'
-import { WORKSPACE_LINKED_TASK_PROVIDER_LABELS } from './workspace-linked-task-labels'
+import { TaskPanelLinkedItemCard } from './task-panel-linked-item-card'
 
+const PullRequestPage = lazy(() => import('@/components/PullRequestPage'))
+const GitHubItemDialog = lazy(() => import('@/components/GitHubItemDialog'))
+
+/** The active workspace's linked work item, shown next to the work.
+ *
+ *  Why route to the provider's own detail view rather than render the item
+ *  again: those views already own hydration, comments and edits. They are page
+ *  surfaces, so the panel asks for their `panel` variant and the sidebar applies
+ *  a width floor for this tab; below it the title column collapses next to the
+ *  fixed-width workspace CTA. */
 export default function TaskPanel(): React.JSX.Element {
   const worktree = useActiveWorktree()
   const task = useMemo(() => resolveWorkspaceLinkedTask(worktree), [worktree])
-  const detail = useWorkspaceLinkedTaskDetail(task)
+  const repo = useRepoById(task?.repoId ?? null)
+  // Why: the panel lives inside the workspace the item is already linked to, so
+  // "start work from this item" and "go back" have nothing to do here.
+  const noop = useCallback(() => {}, [])
+
+  const workItem = useMemo<GitHubWorkItem | null>(() => {
+    if (!task || task.provider !== 'github') {
+      return null
+    }
+    // Why: a seed, not a fetched item. The view's own details read replaces every
+    // field; `number` and `type` are what steer the lookup.
+    return {
+      id: `workspace-linked-task:${task.repoId ?? ''}:${task.type}:${task.number}`,
+      type: task.type === 'pr' ? 'pr' : 'issue',
+      number: task.number,
+      title: task.title,
+      state: 'open',
+      url: task.url,
+      labels: [],
+      updatedAt: '',
+      author: null,
+      repoId: task.repoId ?? ''
+    }
+  }, [task])
 
   if (!task) {
     return (
@@ -26,63 +55,33 @@ export default function TaskPanel(): React.JSX.Element {
     )
   }
 
-  const providerLabel = WORKSPACE_LINKED_TASK_PROVIDER_LABELS[task.provider]
-  const openLabel = translate('auto.components.rightSidebar.TaskPanel.openExternal', 'Open task')
+  if (!workItem) {
+    return <TaskPanelLinkedItemCard task={task} />
+  }
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
-      <div className="border-b border-border px-4 py-3">
-        <div className="flex items-start gap-2">
-          <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-              <span className="font-medium text-foreground">{task.reference}</span>
-              <span aria-hidden="true">·</span>
-              <span className="truncate">{providerLabel}</span>
-              {detail.state ? (
-                <>
-                  <span aria-hidden="true">·</span>
-                  <span className="truncate capitalize">{detail.state}</span>
-                </>
-              ) : null}
-            </div>
-            <div className="mt-1 text-sm leading-5 font-medium break-words text-foreground">
-              {detail.title ||
-                translate('auto.components.rightSidebar.TaskPanel.untitled', 'Untitled task')}
-            </div>
-          </div>
-          {detail.url ? (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-xs"
-                  onClick={() => void openHttpLink(detail.url)}
-                  aria-label={openLabel}
-                >
-                  <ExternalLink className="size-3.5" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">{openLabel}</TooltipContent>
-            </Tooltip>
-          ) : null}
-        </div>
-      </div>
-
-      <div className="scrollbar-sleek min-h-0 flex-1 overflow-y-auto px-4 py-3">
-        {detail.description ? (
-          <CommentMarkdown content={detail.description} variant="compact" />
-        ) : (
-          <div className="text-xs leading-5 text-muted-foreground">
-            {detail.loading
-              ? translate('auto.components.rightSidebar.TaskPanel.loading', 'Loading task details.')
-              : translate(
-                  'auto.components.rightSidebar.TaskPanel.descriptionUnavailable',
-                  'No description is available here yet. Open the task to read it in full.'
-                )}
-          </div>
-        )}
-      </div>
+      {workItem.type === 'pr' ? (
+        <PullRequestPage
+          workItem={workItem}
+          repoPath={repo?.path ?? null}
+          repoId={task.repoId ?? null}
+          sourceContext={task.sourceContext}
+          variant="panel"
+          onUse={noop}
+          onClose={noop}
+        />
+      ) : (
+        <GitHubItemDialog
+          workItem={workItem}
+          repoPath={repo?.path ?? null}
+          repoId={task.repoId ?? null}
+          sourceContext={task.sourceContext}
+          variant="panel"
+          onUse={noop}
+          onClose={noop}
+        />
+      )}
     </div>
   )
 }

--- a/src/renderer/src/components/right-sidebar/activity-bar-buttons.tsx
+++ b/src/renderer/src/components/right-sidebar/activity-bar-buttons.tsx
@@ -25,6 +25,8 @@ export type ActivityBarItem = {
   folderOnly?: boolean
   /** When true, shown only for worktrees that belong to an SSH repo. */
   sshOnly?: boolean
+  /** When true, shown only while the active workspace has a linked work item. */
+  linkedTaskOnly?: boolean
   /** Host-owned health indicator; plugin content cannot style this chrome. */
   statusIndicator?: CheckStatus
 }

--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -10,9 +10,9 @@ import { ActivityBarButton } from './activity-bar-buttons'
 import { getActiveChecksStatus } from './active-checks-status'
 import { useShortcutLabel } from '@/hooks/useShortcutLabel'
 import {
-  RIGHT_SIDEBAR_MIN_WIDTH,
   clampRightSidebarPanelWidth,
-  computeMaxRightSidebarPanelWidth
+  computeMaxRightSidebarPanelWidth,
+  getRightSidebarTabFloorWidth
 } from './right-sidebar-width'
 import { translate } from '@/i18n/i18n'
 import { RightSidebarPanelContent } from './right-sidebar-panel-content'
@@ -62,15 +62,16 @@ function RightSidebarInner(): React.JSX.Element {
   const activityBarSideWidth = activityBarPosition === 'side' ? ACTIVITY_BAR_SIDE_WIDTH : 0
   const windowWidth = useWindowWidth()
   const maxWidth = computeMaxRightSidebarPanelWidth(windowWidth, activityBarSideWidth)
+  const tabFloorWidth = getRightSidebarTabFloorWidth(effectiveTab)
   const renderedRightSidebarWidth = clampRightSidebarPanelWidth(
-    rightSidebarWidth,
+    Math.max(rightSidebarWidth, tabFloorWidth),
     windowWidth,
     activityBarSideWidth
   )
   const { containerRef, onResizeStart } = useSidebarResize<HTMLDivElement>({
     isOpen: rightSidebarOpen,
     width: renderedRightSidebarWidth,
-    minWidth: RIGHT_SIDEBAR_MIN_WIDTH,
+    minWidth: tabFloorWidth,
     maxWidth,
     deltaSign: -1,
     renderedExtraWidth: activityBarSideWidth,

--- a/src/renderer/src/components/right-sidebar/right-sidebar-activity-visibility.test.ts
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-activity-visibility.test.ts
@@ -27,6 +27,7 @@ const items: ActivityBarItem[] = [
     gitOnly: true
   },
   { id: 'ports', icon: Files, title: 'Ports', shortcut: '', sshOnly: true },
+  { id: 'task', icon: Files, title: 'Task', shortcut: '', linkedTaskOnly: true },
   // Plugin panels carry no visibility flags, so they show in every context.
   {
     id: 'plugin:orca-samples.my-plugin/dashboard',
@@ -42,7 +43,8 @@ describe('getVisibleRightSidebarActivityItems', () => {
       getVisibleRightSidebarActivityItems(items, {
         isFolder: false,
         isFolderWorkspace: false,
-        isSshRepo: false
+        isSshRepo: false,
+        hasLinkedTask: false
       }).map((item) => item.id)
     ).toEqual(['explorer', 'source-control', 'plugin:orca-samples.my-plugin/dashboard'])
 
@@ -50,7 +52,8 @@ describe('getVisibleRightSidebarActivityItems', () => {
       getVisibleRightSidebarActivityItems(items, {
         isFolder: false,
         isFolderWorkspace: false,
-        isSshRepo: true
+        isSshRepo: true,
+        hasLinkedTask: false
       }).map((item) => item.id)
     ).toEqual(['explorer', 'source-control', 'ports', 'plugin:orca-samples.my-plugin/dashboard'])
   })
@@ -60,7 +63,8 @@ describe('getVisibleRightSidebarActivityItems', () => {
       getVisibleRightSidebarActivityItems(items, {
         isFolder: true,
         isFolderWorkspace: true,
-        isSshRepo: true
+        isSshRepo: true,
+        hasLinkedTask: false
       }).map((item) => item.id)
     ).toEqual([
       'explorer',
@@ -74,8 +78,37 @@ describe('getVisibleRightSidebarActivityItems', () => {
       getVisibleRightSidebarActivityItems(items, {
         isFolder: true,
         isFolderWorkspace: false,
-        isSshRepo: true
+        isSshRepo: true,
+        hasLinkedTask: false
       }).map((item) => item.id)
     ).toEqual(['explorer', 'ports', 'plugin:orca-samples.my-plugin/dashboard'])
+  })
+
+  it('shows Task only while the active workspace has a linked work item', () => {
+    expect(
+      getVisibleRightSidebarActivityItems(items, {
+        isFolder: false,
+        isFolderWorkspace: false,
+        isSshRepo: false,
+        hasLinkedTask: true
+      }).map((item) => item.id)
+    ).toEqual(['explorer', 'source-control', 'task', 'plugin:orca-samples.my-plugin/dashboard'])
+  })
+
+  it('shows Task for a folder workspace with a linked work item', () => {
+    expect(
+      getVisibleRightSidebarActivityItems(items, {
+        isFolder: true,
+        isFolderWorkspace: true,
+        isSshRepo: false,
+        hasLinkedTask: true
+      }).map((item) => item.id)
+    ).toEqual([
+      'explorer',
+      'workspaces',
+      'pr-checks',
+      'task',
+      'plugin:orca-samples.my-plugin/dashboard'
+    ])
   })
 })

--- a/src/renderer/src/components/right-sidebar/right-sidebar-activity-visibility.ts
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-activity-visibility.ts
@@ -4,16 +4,18 @@ type RightSidebarActivityVisibilityState = {
   isFolder: boolean
   isFolderWorkspace: boolean
   isSshRepo: boolean
+  hasLinkedTask: boolean
 }
 
 export function getVisibleRightSidebarActivityItems(
   items: ActivityBarItem[],
-  { isFolder, isFolderWorkspace, isSshRepo }: RightSidebarActivityVisibilityState
+  { isFolder, isFolderWorkspace, isSshRepo, hasLinkedTask }: RightSidebarActivityVisibilityState
 ): ActivityBarItem[] {
   return items.filter(
     (item) =>
       (!item.gitOnly || !isFolder) &&
       (!item.folderOnly || isFolderWorkspace) &&
-      (!item.sshOnly || isSshRepo)
+      (!item.sshOnly || isSshRepo) &&
+      (!item.linkedTaskOnly || hasLinkedTask)
   )
 }

--- a/src/renderer/src/components/right-sidebar/right-sidebar-effective-tab.test.ts
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-effective-tab.test.ts
@@ -104,4 +104,29 @@ describe('resolveRightSidebarEffectiveTab', () => {
       })
     ).toThrow('at least one visible tab')
   })
+
+  it('falls back to a visible tab when a persisted Task route loses its linked item', () => {
+    // Why: the Task tab hides itself for a workspace with no linked work item.
+    // Switching to such a workspace must render a visible tab rather than an
+    // empty panel, and must not overwrite the stored route.
+    expect(
+      resolveRightSidebarEffectiveTab({
+        normalizedActiveTab: 'task',
+        visibleItems: gitVisibleItems,
+        activeFolderWorkspaceKey: null,
+        rememberedFolderTab: null
+      })
+    ).toBe('explorer')
+  })
+
+  it('keeps the Task route while the active workspace still has a linked item', () => {
+    expect(
+      resolveRightSidebarEffectiveTab({
+        normalizedActiveTab: 'task',
+        visibleItems: [...gitVisibleItems, { id: 'task' }],
+        activeFolderWorkspaceKey: null,
+        rememberedFolderTab: null
+      })
+    ).toBe('task')
+  })
 })

--- a/src/renderer/src/components/right-sidebar/right-sidebar-panel-content.tsx
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-panel-content.tsx
@@ -10,6 +10,7 @@ const PortsPanel = lazy(() => import('./PortsPanel'))
 const AiVaultPanel = lazy(() => import('./AiVaultPanel'))
 const FolderWorkspaceWorktreesPanel = lazy(() => import('./FolderWorkspaceWorktreesPanel'))
 const FolderWorkspacePrChecksPanel = lazy(() => import('./FolderWorkspacePrChecksPanel'))
+const TaskPanel = lazy(() => import('./TaskPanel'))
 const PluginPanel = lazy(() => import('./PluginPanel'))
 
 type RightSidebarPanelContentProps = {
@@ -40,6 +41,7 @@ export function RightSidebarPanelContent({
             isVisible={rightSidebarOpen && effectiveTab === 'pr-checks'}
           />
         )}
+        {effectiveTab === 'task' && <TaskPanel />}
         {/* Plugin-contributed tabs route by key prefix; the panel itself
             handles plugins that have since been uninstalled or disabled.
             Why key: switching plugin tabs must remount the sandboxed iframe —

--- a/src/renderer/src/components/right-sidebar/right-sidebar-width.test.ts
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-width.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from 'vitest'
 import {
   RIGHT_SIDEBAR_ABSOLUTE_FALLBACK_MAX_WIDTH,
   RIGHT_SIDEBAR_MIN_WIDTH,
+  RIGHT_SIDEBAR_TASK_TAB_MIN_WIDTH,
   clampRightSidebarPanelWidth,
-  computeMaxRightSidebarPanelWidth
+  computeMaxRightSidebarPanelWidth,
+  getRightSidebarTabFloorWidth
 } from './right-sidebar-width'
 
 describe('right sidebar rendered width', () => {
@@ -23,6 +25,28 @@ describe('right sidebar rendered width', () => {
   it('uses the fallback max outside DOM environments', () => {
     expect(computeMaxRightSidebarPanelWidth(null, 40)).toBe(
       RIGHT_SIDEBAR_ABSOLUTE_FALLBACK_MAX_WIDTH
+    )
+  })
+})
+
+describe('getRightSidebarTabFloorWidth', () => {
+  it('gives the Task panel the room its provider detail view needs', () => {
+    expect(getRightSidebarTabFloorWidth('task')).toBe(RIGHT_SIDEBAR_TASK_TAB_MIN_WIDTH)
+  })
+
+  it('leaves every other tab on the shared minimum', () => {
+    expect(getRightSidebarTabFloorWidth('explorer')).toBe(RIGHT_SIDEBAR_MIN_WIDTH)
+    expect(getRightSidebarTabFloorWidth('source-control')).toBe(RIGHT_SIDEBAR_MIN_WIDTH)
+    expect(getRightSidebarTabFloorWidth('plugin:acme.tools/dashboard')).toBe(
+      RIGHT_SIDEBAR_MIN_WIDTH
+    )
+  })
+
+  it('keeps the floor inside the window budget on a narrow window', () => {
+    // Why: the floor is a wish, not a guarantee. A narrow window keeps its
+    // non-sidebar area rather than letting the panel push it off screen.
+    expect(clampRightSidebarPanelWidth(getRightSidebarTabFloorWidth('task'), 700, 0)).toBeLessThan(
+      RIGHT_SIDEBAR_TASK_TAB_MIN_WIDTH
     )
   })
 })

--- a/src/renderer/src/components/right-sidebar/right-sidebar-width.ts
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-width.ts
@@ -1,4 +1,15 @@
+import type { ActiveRightSidebarTab } from '../../../../shared/ui-chrome-types'
+
 export const RIGHT_SIDEBAR_MIN_WIDTH = 220
+/** Width the Task panel needs before the provider detail view stops squeezing:
+ *  below this the title column collapses next to the fixed-width workspace CTA. */
+export const RIGHT_SIDEBAR_TASK_TAB_MIN_WIDTH = 560
+
+/** Per-tab floor applied at render time only, so a tab that needs room gets it
+ *  without rewriting the width the user chose for every other tab. */
+export function getRightSidebarTabFloorWidth(tab: ActiveRightSidebarTab): number {
+  return tab === 'task' ? RIGHT_SIDEBAR_TASK_TAB_MIN_WIDTH : RIGHT_SIDEBAR_MIN_WIDTH
+}
 export const RIGHT_SIDEBAR_MIN_NON_SIDEBAR_AREA = 320
 export const RIGHT_SIDEBAR_ABSOLUTE_FALLBACK_MAX_WIDTH = 2000
 

--- a/src/renderer/src/components/right-sidebar/task-panel-linked-item-card.tsx
+++ b/src/renderer/src/components/right-sidebar/task-panel-linked-item-card.tsx
@@ -1,0 +1,84 @@
+import { ExternalLink } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import CommentMarkdown from '@/components/sidebar/CommentMarkdown'
+import { openHttpLink } from '@/lib/http-link-routing'
+import { translate } from '@/i18n/i18n'
+import type { WorkspaceLinkedTask } from './workspace-linked-task'
+import { WORKSPACE_LINKED_TASK_PROVIDER_LABELS } from './workspace-linked-task-labels'
+import { useWorkspaceLinkedTaskDetail } from './use-workspace-linked-task-detail'
+
+/** Fallback surface for providers whose detail view the panel does not host yet.
+ *  Shows what the workspace stored plus whatever the provider cache holds, so
+ *  the item is always identifiable and reachable. */
+export function TaskPanelLinkedItemCard({
+  task
+}: {
+  task: WorkspaceLinkedTask
+}): React.JSX.Element {
+  const detail = useWorkspaceLinkedTaskDetail(task)
+  const providerLabel = WORKSPACE_LINKED_TASK_PROVIDER_LABELS[task.provider]
+  const openLabel = translate('auto.components.rightSidebar.TaskPanel.openExternal', 'Open task')
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
+      <div className="border-b border-border px-4 py-3">
+        <div className="flex items-start gap-2">
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <span className="font-medium text-foreground">{task.reference}</span>
+              <span aria-hidden="true">·</span>
+              <span className="truncate">{providerLabel}</span>
+              {detail.state ? (
+                <>
+                  <span aria-hidden="true">·</span>
+                  <span className="truncate capitalize">{detail.state}</span>
+                </>
+              ) : null}
+            </div>
+            <div className="mt-1 text-sm leading-5 font-medium break-words text-foreground">
+              {detail.title ||
+                translate('auto.components.rightSidebar.TaskPanel.untitled', 'Untitled task')}
+            </div>
+          </div>
+          {detail.url ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  onClick={() => void openHttpLink(detail.url)}
+                  aria-label={openLabel}
+                >
+                  <ExternalLink className="size-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">{openLabel}</TooltipContent>
+            </Tooltip>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="scrollbar-sleek min-h-0 flex-1 overflow-y-auto px-4 py-3">
+        {detail.description ? (
+          <CommentMarkdown content={detail.description} variant="compact" />
+        ) : (
+          <div className="text-xs leading-5 text-muted-foreground">
+            {detail.loading
+              ? translate('auto.components.rightSidebar.TaskPanel.loading', 'Loading task details.')
+              : detail.detailsLoaded
+                ? translate(
+                    'auto.components.rightSidebar.TaskPanel.descriptionEmpty',
+                    'This task has no description.'
+                  )
+                : translate(
+                    'auto.components.rightSidebar.TaskPanel.descriptionUnavailable',
+                    'No description is readable here for this provider yet. Open the task to read it in full.'
+                  )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/right-sidebar/use-right-sidebar-activity-items.ts
+++ b/src/renderer/src/components/right-sidebar/use-right-sidebar-activity-items.ts
@@ -1,10 +1,11 @@
 import { useMemo } from 'react'
-import { Plug, Files, GitBranch, ListChecks, Workflow } from 'lucide-react'
+import { ClipboardList, Plug, Files, GitBranch, ListChecks, Workflow } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { useRepoById } from '@/store/selectors'
 import { isFolderRepo } from '../../../../shared/repo-kind'
 import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
 import { getVisibleRightSidebarActivityItems } from './right-sidebar-activity-visibility'
+import { hasWorkspaceLinkedTask } from './workspace-linked-task'
 import { getPluginPanelActivityItems } from './plugin-panel-activity-items'
 import {
   collectInstalledPluginTabKeys,
@@ -45,6 +46,9 @@ export function useRightSidebarActivityItems({
   const isFolderWorkspace = activeWorkspaceScope?.type === 'folder'
   const isFolder = isFolderWorkspace || (activeRepo ? isFolderRepo(activeRepo) : false)
   const isSshRepo = Boolean(activeRepo?.connectionId)
+  // Why: the workspace's own link decides this, not the Tasks page selection, so
+  // a workspace linked to a Jira issue never shows another provider's item.
+  const hasLinkedTask = hasWorkspaceLinkedTask(activeWorktree)
   const pluginSystemEnabled = useAppStore((s) => s.settings?.pluginSystemEnabled === true)
   const pluginPanels = usePluginPanels()
   const visiblePluginPanels = useMemo(
@@ -105,6 +109,13 @@ export function useRightSidebarActivityItems({
         gitOnly: true
       },
       {
+        id: 'task',
+        icon: ClipboardList,
+        title: translate('auto.components.right.sidebar.index.linkedTask', 'Task'),
+        shortcut: '',
+        linkedTaskOnly: true
+      },
+      {
         id: 'ports',
         icon: Plug,
         title: translate('auto.components.right.sidebar.index.441733b630', 'Ports'),
@@ -130,9 +141,10 @@ export function useRightSidebarActivityItems({
       getVisibleRightSidebarActivityItems(activityItems, {
         isFolder,
         isFolderWorkspace,
-        isSshRepo
+        isSshRepo,
+        hasLinkedTask
       }),
-    [activityItems, isFolder, isFolderWorkspace, isSshRepo]
+    [activityItems, hasLinkedTask, isFolder, isFolderWorkspace, isSshRepo]
   )
 
   const activeFolderWorkspaceKey = isFolderWorkspace ? (activeWorktreeId ?? null) : null

--- a/src/renderer/src/components/right-sidebar/use-workspace-linked-task-detail.ts
+++ b/src/renderer/src/components/right-sidebar/use-workspace-linked-task-detail.ts
@@ -1,7 +1,5 @@
 import { useEffect, useRef } from 'react'
 import { useAppStore } from '@/store'
-import { useRepoById } from '@/store/selectors'
-import { issueCacheKey as getIssueCacheKey } from '@/store/slices/github'
 import type { WorkspaceLinkedTask } from './workspace-linked-task'
 
 export type WorkspaceLinkedTaskDetail = {
@@ -9,43 +7,28 @@ export type WorkspaceLinkedTaskDetail = {
   title: string
   /** Best known URL: the provider's own, falling back to the stored one. */
   url: string
-  /** Provider-native state label, when the provider cache holds one. */
+  /** Provider-native state label, when the provider answered with one. */
   state: string | null
-  /** Markdown body, when the provider cache holds one. */
+  /** Markdown body, when the provider answered with one. */
   description: string | null
   /** True while the first read for a rich provider has not answered yet. */
   loading: boolean
+  /** True once a provider answered for this item, even with an empty body.
+   *  Separates "this item has no description" from "no description is readable
+   *  here", which are different things to tell the user. */
+  detailsLoaded: boolean
 }
 
-/** Reads the linked item's detail out of the caches the app already fills.
+/** Detail for the providers the panel renders itself, i.e. everything except
+ *  GitHub, which routes to its own detail view.
  *
- *  Why cache-only: the panel adds no provider transport of its own. GitHub
- *  issues and Linear issues are already cached per workspace for the sidebar
- *  card, so their body renders for free; the other providers show the stored
- *  reference and title, which is enough to identify the item and open it. */
+ *  Linear answers from the cache the sidebar card already fills. Jira and GitLab
+ *  fall back to what the workspace stored until their detail views are hosted in
+ *  the panel too. */
 export function useWorkspaceLinkedTaskDetail(
   task: WorkspaceLinkedTask | null
 ): WorkspaceLinkedTaskDetail {
-  const repoId = task?.repoId ?? null
-  const repo = useRepoById(repoId)
-  const settings = useAppStore((s) => s.settings)
-  const fetchIssue = useAppStore((s) => s.fetchIssue)
   const fetchLinearIssue = useAppStore((s) => s.fetchLinearIssue)
-
-  const wantsGitHubIssue = task?.provider === 'github' && task.type === 'issue'
-  const issueKey =
-    wantsGitHubIssue && repo
-      ? getIssueCacheKey(
-          repo.path,
-          repo.id,
-          task.number,
-          settings,
-          repo.connectionId,
-          repo.executionHostId,
-          true
-        )
-      : ''
-  const issueEntry = useAppStore((s) => (issueKey ? s.issueCache[issueKey] : undefined))
 
   const linearIdentifier = task?.provider === 'linear' ? (task.linearIdentifier ?? null) : null
   // Why: the 'all::' scope is what the sidebar card reads, because the issue may
@@ -56,64 +39,33 @@ export function useWorkspaceLinkedTaskDetail(
   const linearFallbackEntry = useAppStore((s) =>
     linearIdentifier ? s.linearIssueCache[linearIdentifier] : undefined
   )
-
-  // Why: one read per item when the panel opens on an empty cache. The card's
-  // own refresh path only runs while issue decorations are enabled, so without
-  // this the panel would sit on a stored title for users who turned them off.
-  const requestedRef = useRef<string | null>(null)
-  const repoPath = repo?.path ?? null
-  const taskNumber = task?.number ?? null
-  const hasIssueEntry = issueEntry !== undefined
   const hasLinearEntry = linearEntry !== undefined || linearFallbackEntry !== undefined
+
+  // Why: one read per identifier when the panel opens on an empty cache. The
+  // card's own refresh path only runs while issue decorations are enabled, so
+  // without this the panel would sit on a stored title for users who disabled them.
+  const requestedLinearRef = useRef<string | null>(null)
   useEffect(() => {
-    if (wantsGitHubIssue && repoPath && repoId && taskNumber !== null && !hasIssueEntry) {
-      const requestKey = `github ${repoId} ${taskNumber}`
-      if (requestedRef.current !== requestKey) {
-        requestedRef.current = requestKey
-        void fetchIssue(repoPath, taskNumber, { repoId })
-      }
+    if (!linearIdentifier || hasLinearEntry || requestedLinearRef.current === linearIdentifier) {
       return
     }
-    if (linearIdentifier && !hasLinearEntry) {
-      const requestKey = `linear ${linearIdentifier}`
-      if (requestedRef.current !== requestKey) {
-        requestedRef.current = requestKey
-        void fetchLinearIssue(linearIdentifier)
-      }
-    }
-  }, [
-    fetchIssue,
-    fetchLinearIssue,
-    hasIssueEntry,
-    hasLinearEntry,
-    linearIdentifier,
-    repoId,
-    repoPath,
-    taskNumber,
-    wantsGitHubIssue
-  ])
+    requestedLinearRef.current = linearIdentifier
+    void fetchLinearIssue(linearIdentifier)
+  }, [fetchLinearIssue, hasLinearEntry, linearIdentifier])
 
-  const issue = issueEntry?.data ?? null
   const linearIssue = (linearEntry ?? linearFallbackEntry)?.data ?? null
   const storedTitle = task?.title ?? ''
   const storedUrl = task?.url ?? ''
 
-  if (issue) {
-    return {
-      title: issue.title || storedTitle,
-      url: issue.url || storedUrl,
-      state: issue.state,
-      description: issue.description ?? null,
-      loading: false
-    }
-  }
   if (linearIssue) {
+    const description = linearIssue.description ?? null
     return {
       title: linearIssue.title || storedTitle,
       url: linearIssue.url || storedUrl,
       state: linearIssue.state.name,
-      description: linearIssue.description ?? null,
-      loading: false
+      description: description && description.trim().length > 0 ? description : null,
+      loading: false,
+      detailsLoaded: true
     }
   }
   return {
@@ -121,8 +73,7 @@ export function useWorkspaceLinkedTaskDetail(
     url: storedUrl,
     state: null,
     description: null,
-    loading: Boolean(
-      wantsGitHubIssue ? !hasIssueEntry : linearIdentifier !== null && !hasLinearEntry
-    )
+    loading: linearIdentifier !== null && !hasLinearEntry,
+    detailsLoaded: false
   }
 }

--- a/src/renderer/src/components/right-sidebar/use-workspace-linked-task-detail.ts
+++ b/src/renderer/src/components/right-sidebar/use-workspace-linked-task-detail.ts
@@ -1,0 +1,128 @@
+import { useEffect, useRef } from 'react'
+import { useAppStore } from '@/store'
+import { useRepoById } from '@/store/selectors'
+import { issueCacheKey as getIssueCacheKey } from '@/store/slices/github'
+import type { WorkspaceLinkedTask } from './workspace-linked-task'
+
+export type WorkspaceLinkedTaskDetail = {
+  /** Best known title: the provider's own, falling back to the stored one. */
+  title: string
+  /** Best known URL: the provider's own, falling back to the stored one. */
+  url: string
+  /** Provider-native state label, when the provider cache holds one. */
+  state: string | null
+  /** Markdown body, when the provider cache holds one. */
+  description: string | null
+  /** True while the first read for a rich provider has not answered yet. */
+  loading: boolean
+}
+
+/** Reads the linked item's detail out of the caches the app already fills.
+ *
+ *  Why cache-only: the panel adds no provider transport of its own. GitHub
+ *  issues and Linear issues are already cached per workspace for the sidebar
+ *  card, so their body renders for free; the other providers show the stored
+ *  reference and title, which is enough to identify the item and open it. */
+export function useWorkspaceLinkedTaskDetail(
+  task: WorkspaceLinkedTask | null
+): WorkspaceLinkedTaskDetail {
+  const repoId = task?.repoId ?? null
+  const repo = useRepoById(repoId)
+  const settings = useAppStore((s) => s.settings)
+  const fetchIssue = useAppStore((s) => s.fetchIssue)
+  const fetchLinearIssue = useAppStore((s) => s.fetchLinearIssue)
+
+  const wantsGitHubIssue = task?.provider === 'github' && task.type === 'issue'
+  const issueKey =
+    wantsGitHubIssue && repo
+      ? getIssueCacheKey(
+          repo.path,
+          repo.id,
+          task.number,
+          settings,
+          repo.connectionId,
+          repo.executionHostId,
+          true
+        )
+      : ''
+  const issueEntry = useAppStore((s) => (issueKey ? s.issueCache[issueKey] : undefined))
+
+  const linearIdentifier = task?.provider === 'linear' ? (task.linearIdentifier ?? null) : null
+  // Why: the 'all::' scope is what the sidebar card reads, because the issue may
+  // belong to a different Linear workspace than the selected one.
+  const linearEntry = useAppStore((s) =>
+    linearIdentifier ? s.linearIssueCache[`all::${linearIdentifier}`] : undefined
+  )
+  const linearFallbackEntry = useAppStore((s) =>
+    linearIdentifier ? s.linearIssueCache[linearIdentifier] : undefined
+  )
+
+  // Why: one read per item when the panel opens on an empty cache. The card's
+  // own refresh path only runs while issue decorations are enabled, so without
+  // this the panel would sit on a stored title for users who turned them off.
+  const requestedRef = useRef<string | null>(null)
+  const repoPath = repo?.path ?? null
+  const taskNumber = task?.number ?? null
+  const hasIssueEntry = issueEntry !== undefined
+  const hasLinearEntry = linearEntry !== undefined || linearFallbackEntry !== undefined
+  useEffect(() => {
+    if (wantsGitHubIssue && repoPath && repoId && taskNumber !== null && !hasIssueEntry) {
+      const requestKey = `github ${repoId} ${taskNumber}`
+      if (requestedRef.current !== requestKey) {
+        requestedRef.current = requestKey
+        void fetchIssue(repoPath, taskNumber, { repoId })
+      }
+      return
+    }
+    if (linearIdentifier && !hasLinearEntry) {
+      const requestKey = `linear ${linearIdentifier}`
+      if (requestedRef.current !== requestKey) {
+        requestedRef.current = requestKey
+        void fetchLinearIssue(linearIdentifier)
+      }
+    }
+  }, [
+    fetchIssue,
+    fetchLinearIssue,
+    hasIssueEntry,
+    hasLinearEntry,
+    linearIdentifier,
+    repoId,
+    repoPath,
+    taskNumber,
+    wantsGitHubIssue
+  ])
+
+  const issue = issueEntry?.data ?? null
+  const linearIssue = (linearEntry ?? linearFallbackEntry)?.data ?? null
+  const storedTitle = task?.title ?? ''
+  const storedUrl = task?.url ?? ''
+
+  if (issue) {
+    return {
+      title: issue.title || storedTitle,
+      url: issue.url || storedUrl,
+      state: issue.state,
+      description: issue.description ?? null,
+      loading: false
+    }
+  }
+  if (linearIssue) {
+    return {
+      title: linearIssue.title || storedTitle,
+      url: linearIssue.url || storedUrl,
+      state: linearIssue.state.name,
+      description: linearIssue.description ?? null,
+      loading: false
+    }
+  }
+  return {
+    title: storedTitle,
+    url: storedUrl,
+    state: null,
+    description: null,
+    loading: Boolean(
+      wantsGitHubIssue ? !hasIssueEntry : linearIdentifier !== null && !hasLinearEntry
+    )
+  }
+}

--- a/src/renderer/src/components/right-sidebar/workspace-linked-task-labels.ts
+++ b/src/renderer/src/components/right-sidebar/workspace-linked-task-labels.ts
@@ -1,0 +1,12 @@
+import type { WorkspaceLinkedTask } from './workspace-linked-task'
+
+/** Provider names are brand names, so they stay untranslated. */
+export const WORKSPACE_LINKED_TASK_PROVIDER_LABELS: Record<
+  WorkspaceLinkedTask['provider'],
+  string
+> = {
+  github: 'GitHub',
+  gitlab: 'GitLab',
+  linear: 'Linear',
+  jira: 'Jira'
+}

--- a/src/renderer/src/components/right-sidebar/workspace-linked-task.test.ts
+++ b/src/renderer/src/components/right-sidebar/workspace-linked-task.test.ts
@@ -138,3 +138,70 @@ describe('formatWorkspaceLinkedTaskReference', () => {
     ).toBe('#4')
   })
 })
+
+describe('resolveWorkspaceLinkedTask repo context', () => {
+  it("falls back to the workspace's repo when the stored link records none", () => {
+    // Why: links created from a task source carry title and URL but no repoId,
+    // and without a repo there is no path to read the item's details against.
+    const task = resolveWorkspaceLinkedTask(
+      links({
+        repoId: 'repo-1',
+        linkedWorkItem: {
+          provider: 'github',
+          type: 'pr',
+          number: 493,
+          title: 'Release R14 scheduling start',
+          url: 'https://github.com/acme/app/pull/493'
+        },
+        linkedTaskSourceContext: {
+          kind: 'task-source',
+          provider: 'github',
+          projectId: 'github:acme/app',
+          hostId: 'local',
+          repoId: 'repo-from-source'
+        }
+      })
+    )
+    expect(task?.repoId).toBe('repo-1')
+  })
+
+  it('prefers the repo the link itself recorded', () => {
+    const task = resolveWorkspaceLinkedTask(
+      links({
+        repoId: 'repo-1',
+        linkedWorkItem: {
+          provider: 'github',
+          type: 'issue',
+          number: 7,
+          title: 'Linked issue',
+          url: 'https://github.com/acme/other/issues/7',
+          repoId: 'repo-on-link'
+        }
+      })
+    )
+    expect(task?.repoId).toBe('repo-on-link')
+  })
+
+  it('falls back to the source context repo when the workspace has none', () => {
+    const task = resolveWorkspaceLinkedTask({
+      linkedIssue: null,
+      linkedPR: null,
+      linkedLinearIssue: null,
+      linkedWorkItem: {
+        provider: 'github',
+        type: 'issue',
+        number: 9,
+        title: 'Linked issue',
+        url: 'https://github.com/acme/app/issues/9'
+      },
+      linkedTaskSourceContext: {
+        kind: 'task-source',
+        provider: 'github',
+        projectId: 'github:acme/app',
+        hostId: 'local',
+        repoId: 'repo-from-source'
+      }
+    } as Parameters<typeof resolveWorkspaceLinkedTask>[0])
+    expect(task?.repoId).toBe('repo-from-source')
+  })
+})

--- a/src/renderer/src/components/right-sidebar/workspace-linked-task.test.ts
+++ b/src/renderer/src/components/right-sidebar/workspace-linked-task.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest'
+import type { Worktree } from '../../../../shared/worktree/types'
+import {
+  formatWorkspaceLinkedTaskReference,
+  hasWorkspaceLinkedTask,
+  resolveWorkspaceLinkedTask
+} from './workspace-linked-task'
+
+type LinkFields = Parameters<typeof resolveWorkspaceLinkedTask>[0]
+
+function links(overrides: Partial<Worktree>): LinkFields {
+  return {
+    repoId: 'repo-1',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    ...overrides
+  } as LinkFields
+}
+
+describe('resolveWorkspaceLinkedTask', () => {
+  it('returns null when the workspace has no link', () => {
+    expect(resolveWorkspaceLinkedTask(links({}))).toBeNull()
+    expect(hasWorkspaceLinkedTask(links({}))).toBe(false)
+    expect(resolveWorkspaceLinkedTask(null)).toBeNull()
+  })
+
+  it('resolves the stored work item with its own provider, not the repo provider', () => {
+    const task = resolveWorkspaceLinkedTask(
+      links({
+        // A GitHub repo whose workspace is linked to a Jira issue: the panel must
+        // render Jira, so the provider comes from the link and never from the repo.
+        linkedIssue: 41,
+        linkedWorkItem: {
+          provider: 'jira',
+          type: 'issue',
+          number: 7,
+          title: 'Ship the task panel',
+          url: 'https://example.atlassian.net/browse/PROJ-7',
+          jiraIdentifier: 'PROJ-7'
+        },
+        linkedTaskSourceContext: null
+      })
+    )
+    expect(task).toMatchObject({
+      provider: 'jira',
+      reference: 'PROJ-7',
+      title: 'Ship the task panel',
+      url: 'https://example.atlassian.net/browse/PROJ-7'
+    })
+  })
+
+  it('carries the link source context so the item is read on the right account', () => {
+    const sourceContext: NonNullable<Worktree['linkedTaskSourceContext']> = {
+      kind: 'task-source',
+      provider: 'linear',
+      projectId: 'project-1',
+      hostId: 'local'
+    }
+    const task = resolveWorkspaceLinkedTask(
+      links({
+        linkedWorkItem: {
+          provider: 'linear',
+          type: 'issue',
+          number: 31,
+          title: 'Linked issue',
+          url: 'https://linear.app/acme/issue/ENG-31',
+          linearIdentifier: 'ENG-31'
+        },
+        linkedTaskSourceContext: sourceContext
+      })
+    )
+    expect(task?.sourceContext).toBe(sourceContext)
+  })
+
+  it('falls back to the flat link fields for workspaces linked by number', () => {
+    expect(resolveWorkspaceLinkedTask(links({ linkedIssue: 15318 }))).toMatchObject({
+      provider: 'github',
+      type: 'issue',
+      number: 15318,
+      reference: '#15318',
+      title: '',
+      url: '',
+      repoId: 'repo-1'
+    })
+    expect(resolveWorkspaceLinkedTask(links({ linkedPR: 12 }))).toMatchObject({
+      provider: 'github',
+      type: 'pr',
+      number: 12
+    })
+    expect(resolveWorkspaceLinkedTask(links({ linkedGitLabMR: 12 }))).toMatchObject({
+      provider: 'gitlab',
+      type: 'mr',
+      reference: '!12'
+    })
+    expect(resolveWorkspaceLinkedTask(links({ linkedGitLabIssue: 12 }))).toMatchObject({
+      provider: 'gitlab',
+      type: 'issue',
+      reference: '#12'
+    })
+    expect(resolveWorkspaceLinkedTask(links({ linkedLinearIssue: 'ENG-31' }))).toMatchObject({
+      provider: 'linear',
+      reference: 'ENG-31',
+      linearIdentifier: 'ENG-31'
+    })
+  })
+
+  it('prefers the stored work item over a stale flat field', () => {
+    const task = resolveWorkspaceLinkedTask(
+      links({
+        linkedIssue: 41,
+        linkedWorkItem: {
+          provider: 'github',
+          type: 'issue',
+          number: 42,
+          title: 'Current link',
+          url: 'https://github.com/acme/app/issues/42'
+        }
+      })
+    )
+    expect(task?.number).toBe(42)
+  })
+})
+
+describe('formatWorkspaceLinkedTaskReference', () => {
+  it('keeps the GitLab merge request sigil distinct from the issue sigil', () => {
+    expect(formatWorkspaceLinkedTaskReference({ provider: 'gitlab', type: 'mr', number: 9 })).toBe(
+      '!9'
+    )
+    expect(
+      formatWorkspaceLinkedTaskReference({ provider: 'gitlab', type: 'issue', number: 9 })
+    ).toBe('#9')
+  })
+
+  it('falls back to the number when a provider identifier was never stored', () => {
+    expect(
+      formatWorkspaceLinkedTaskReference({ provider: 'linear', type: 'issue', number: 4 })
+    ).toBe('#4')
+  })
+})

--- a/src/renderer/src/components/right-sidebar/workspace-linked-task.ts
+++ b/src/renderer/src/components/right-sidebar/workspace-linked-task.ts
@@ -40,8 +40,14 @@ export function formatWorkspaceLinkedTaskReference(
 
 function fromLinkedWorkItem(
   item: WorkspaceLinkedItem,
-  sourceContext: TaskSourceContext | null
+  sourceContext: TaskSourceContext | null,
+  workspaceRepoId: string | undefined
 ): WorkspaceLinkedTask {
+  // Why: the link does not always record a repo. Items linked through a task
+  // source carry the repo on the source context instead, and older links carry
+  // it nowhere at all. Without a repo the panel has no path to read details
+  // against, so fall back to the workspace's own repo before giving up.
+  const repoId = item.repoId ?? workspaceRepoId ?? sourceContext?.repoId ?? undefined
   return {
     provider: item.provider,
     type: item.type,
@@ -51,7 +57,7 @@ function fromLinkedWorkItem(
     url: item.url,
     ...(item.linearIdentifier ? { linearIdentifier: item.linearIdentifier } : {}),
     ...(item.jiraIdentifier ? { jiraIdentifier: item.jiraIdentifier } : {}),
-    ...(item.repoId ? { repoId: item.repoId } : {}),
+    ...(repoId ? { repoId } : {}),
     sourceContext
   }
 }
@@ -84,10 +90,11 @@ export function resolveWorkspaceLinkedTask(
   }
   const sourceContext = worktree.linkedTaskSourceContext ?? null
   if (worktree.linkedWorkItem) {
-    return fromLinkedWorkItem(worktree.linkedWorkItem, sourceContext)
+    return fromLinkedWorkItem(worktree.linkedWorkItem, sourceContext, worktree.repoId)
   }
   const legacy = ((): Omit<WorkspaceLinkedTask, 'reference' | 'sourceContext'> | null => {
-    const base = { title: '', url: '', ...(worktree.repoId ? { repoId: worktree.repoId } : {}) }
+    const repoId = worktree.repoId ?? sourceContext?.repoId ?? undefined
+    const base = { title: '', url: '', ...(repoId ? { repoId } : {}) }
     if (worktree.linkedIssue !== null && worktree.linkedIssue !== undefined) {
       return { provider: 'github', type: 'issue', number: worktree.linkedIssue, ...base }
     }

--- a/src/renderer/src/components/right-sidebar/workspace-linked-task.ts
+++ b/src/renderer/src/components/right-sidebar/workspace-linked-task.ts
@@ -1,0 +1,126 @@
+import type { TaskSourceContext } from '../../../../shared/task-source-context'
+import type { WorkspaceLinkedItem, Worktree } from '../../../../shared/worktree/types'
+
+/** The active workspace's linked work item, in the shape the Task panel renders.
+ *  Provider-neutral: every built-in task provider resolves to this identity and
+ *  the panel decides per provider how much detail it can show. */
+export type WorkspaceLinkedTask = {
+  provider: WorkspaceLinkedItem['provider']
+  type: WorkspaceLinkedItem['type']
+  number: number
+  /** Provider-native label: `#42`, `!42`, `ENG-31`, `PROJ-7`. */
+  reference: string
+  /** Stored title. Empty when only a legacy flat link field is present. */
+  title: string
+  /** Stored URL. Empty when only a legacy flat link field is present. */
+  url: string
+  linearIdentifier?: string
+  jiraIdentifier?: string
+  /** Repo the GitHub/GitLab number belongs to, when the link recorded one. */
+  repoId?: string
+  /** The account the item must be read on. Null means the selected provider. */
+  sourceContext: TaskSourceContext | null
+}
+
+export function formatWorkspaceLinkedTaskReference(
+  item: Pick<WorkspaceLinkedItem, 'provider' | 'type' | 'number' | 'linearIdentifier'> &
+    Partial<Pick<WorkspaceLinkedItem, 'jiraIdentifier'>>
+): string {
+  if (item.provider === 'linear') {
+    return item.linearIdentifier ?? `#${item.number}`
+  }
+  if (item.provider === 'jira') {
+    return item.jiraIdentifier ?? `#${item.number}`
+  }
+  // Why: GitLab prints merge requests as `!<iid>` and issues as `#<iid>`, and the
+  // two share an iid space per project, so dropping the sigil would make an MR and
+  // an issue with the same iid read identically.
+  return item.provider === 'gitlab' && item.type === 'mr' ? `!${item.number}` : `#${item.number}`
+}
+
+function fromLinkedWorkItem(
+  item: WorkspaceLinkedItem,
+  sourceContext: TaskSourceContext | null
+): WorkspaceLinkedTask {
+  return {
+    provider: item.provider,
+    type: item.type,
+    number: item.number,
+    reference: formatWorkspaceLinkedTaskReference(item),
+    title: item.title,
+    url: item.url,
+    ...(item.linearIdentifier ? { linearIdentifier: item.linearIdentifier } : {}),
+    ...(item.jiraIdentifier ? { jiraIdentifier: item.jiraIdentifier } : {}),
+    ...(item.repoId ? { repoId: item.repoId } : {}),
+    sourceContext
+  }
+}
+
+/** Resolves the linked item from the workspace's OWN link fields.
+ *
+ *  Why not the Tasks page selection: a workspace linked to a Jira issue must
+ *  render that issue even while the Tasks page last showed a GitHub item.
+ *
+ *  `linkedWorkItem` wins because it is the only field carrying provider, title
+ *  and URL together. The flat fields are the fallback for workspaces linked
+ *  before that field existed, or linked by number from the meta dialog: they
+ *  identify the item well enough to fetch it, and the panel fills the title and
+ *  URL in from the provider cache. */
+export function resolveWorkspaceLinkedTask(
+  worktree: Pick<
+    Worktree,
+    | 'linkedWorkItem'
+    | 'linkedTaskSourceContext'
+    | 'linkedIssue'
+    | 'linkedPR'
+    | 'linkedLinearIssue'
+    | 'linkedGitLabMR'
+    | 'linkedGitLabIssue'
+    | 'repoId'
+  > | null
+): WorkspaceLinkedTask | null {
+  if (!worktree) {
+    return null
+  }
+  const sourceContext = worktree.linkedTaskSourceContext ?? null
+  if (worktree.linkedWorkItem) {
+    return fromLinkedWorkItem(worktree.linkedWorkItem, sourceContext)
+  }
+  const legacy = ((): Omit<WorkspaceLinkedTask, 'reference' | 'sourceContext'> | null => {
+    const base = { title: '', url: '', ...(worktree.repoId ? { repoId: worktree.repoId } : {}) }
+    if (worktree.linkedIssue !== null && worktree.linkedIssue !== undefined) {
+      return { provider: 'github', type: 'issue', number: worktree.linkedIssue, ...base }
+    }
+    if (worktree.linkedPR !== null && worktree.linkedPR !== undefined) {
+      return { provider: 'github', type: 'pr', number: worktree.linkedPR, ...base }
+    }
+    if (worktree.linkedGitLabMR !== null && worktree.linkedGitLabMR !== undefined) {
+      return { provider: 'gitlab', type: 'mr', number: worktree.linkedGitLabMR, ...base }
+    }
+    if (worktree.linkedGitLabIssue !== null && worktree.linkedGitLabIssue !== undefined) {
+      return { provider: 'gitlab', type: 'issue', number: worktree.linkedGitLabIssue, ...base }
+    }
+    if (worktree.linkedLinearIssue) {
+      // Why: the flat Linear field stores the identifier (`ENG-31`), not a
+      // number. Number stays 0 : the identifier is what every Linear read uses.
+      return {
+        provider: 'linear',
+        type: 'issue',
+        number: 0,
+        linearIdentifier: worktree.linkedLinearIssue,
+        ...base
+      }
+    }
+    return null
+  })()
+  if (!legacy) {
+    return null
+  }
+  return { ...legacy, reference: formatWorkspaceLinkedTaskReference(legacy), sourceContext }
+}
+
+export function hasWorkspaceLinkedTask(
+  worktree: Parameters<typeof resolveWorkspaceLinkedTask>[0]
+): boolean {
+  return resolveWorkspaceLinkedTask(worktree) !== null
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -12154,7 +12154,8 @@
             "fc3095d2ed": "explorer",
             "aiVaultSessionHistory": "Agents",
             "folderWorkspaces": "Attached worktrees",
-            "parentPrChecks": "PR Checks"
+            "parentPrChecks": "PR Checks",
+            "linkedTask": "Task"
           },
           "right": {
             "panel": {
@@ -15506,6 +15507,13 @@
           "actionsUnavailable": "Plugin actions are not available in this client.",
           "messageTooLarge": "Message exceeds the size limit.",
           "tooManyRequests": "Too many requests."
+        },
+        "TaskPanel": {
+          "unlinked": "This workspace is not linked to a task.",
+          "openExternal": "Open task",
+          "untitled": "Untitled task",
+          "loading": "Loading task details.",
+          "descriptionUnavailable": "No description is available here yet. Open the task to read it in full."
         }
       },
       "link": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -15513,7 +15513,8 @@
           "openExternal": "Open task",
           "untitled": "Untitled task",
           "loading": "Loading task details.",
-          "descriptionUnavailable": "No description is available here yet. Open the task to read it in full."
+          "descriptionUnavailable": "No description is readable here for this provider yet. Open the task to read it in full.",
+          "descriptionEmpty": "This task has no description."
         }
       },
       "link": {

--- a/src/renderer/src/store/right-sidebar-route.ts
+++ b/src/renderer/src/store/right-sidebar-route.ts
@@ -46,7 +46,8 @@ export function normalizeRightSidebarRoute(
     tab === 'pr-checks' ||
     tab === 'source-control' ||
     tab === 'checks' ||
-    tab === 'ports'
+    tab === 'ports' ||
+    tab === 'task'
   ) {
     return {
       rightSidebarTab: tab,

--- a/src/shared/ui-chrome-types.ts
+++ b/src/shared/ui-chrome-types.ts
@@ -90,6 +90,7 @@ export type RightSidebarTab =
   | 'source-control'
   | 'checks'
   | 'ports'
+  | 'task'
   // Plugin-contributed panels are keyed `plugin:<pluginId>/<panelId>` so the
   // static union stays closed while plugin tabs remain type-representable.
   | `plugin:${string}`


### PR DESCRIPTION
## ELI5

A workspace already knows which issue or PR it was created from. The right sidebar shows you everything about the code (files, diff, checks, agents) but not that item, so reading the acceptance criteria means leaving the workspace for the Tasks page. This adds a **Task** tab to the right sidebar that shows the linked item next to the work, by rendering the provider's own detail view inside the panel rather than a second, poorer copy of it. The tab only appears when the active workspace actually has a linked item.

## What Changed

**The tab**

- `'task'` added to `RightSidebarTab` (`src/shared/ui-chrome-types.ts`) and to the three places that enumerate the static tabs: the client UI RPC schema, persisted-settings normalization, and the renderer route normalizer.
- New `linkedTaskOnly` visibility flag on `ActivityBarItem`, filtered in `getVisibleRightSidebarActivityItems` next to the existing `gitOnly` / `folderOnly` / `sshOnly`. The Task item declares it, so the tab hides itself when the active workspace has no linked item, and a persisted `task` route then falls back to a visible tab through the existing `resolveRightSidebarEffectiveTab` rather than painting an empty panel.

**Resolution (provider-neutral)**

- `workspace-linked-task.ts`: resolves the item from the workspace's own link. `linkedWorkItem` first, falling back to the flat per-provider fields for workspaces linked before that field existed. It formats the provider-native reference (`#42`, `!42` for a GitLab MR, `ENG-31`, `PROJ-7`), and it resolves the repo the read needs: the link's own `repoId`, then the workspace's repo, then the source context's. That last part matters because **a link created from a task source carries no `repoId`**, which is the common case today.

**Rendering: the provider's view, not a new one**

- `TaskPanel.tsx` routes a GitHub PR to `PullRequestPage` and a GitHub issue to `GitHubItemDialog`, both with a new `variant: 'panel'` that drops the two affordances a panel must not show: the back navigation, and the start-workspace CTA (the panel lives inside the workspace that item is already linked to). Everything else those views own comes along: details hydration with the source-scoped cache key, comments, status / assignees / labels editing, activity.
- Other providers render a compact card (reference, provider, state, description from the cache the sidebar card already fills for Linear, link out) until their detail views are hosted in the panel too. That is the only rendering this PR adds, and it is a fallback.

**Room for the view**

- `getRightSidebarTabFloorWidth` gives the Task tab a **560px floor at render time only**. It never rewrites the width the user chose, which comes straight back on every other tab, and it stays inside the window budget through the existing `clampRightSidebarPanelWidth`, so a narrow window keeps its non-sidebar area.
- 560 is measured, not guessed. At the 350px default the title column collapses to one or two characters per line next to the fixed `w-[180px]` CTA; 460 reads but still wraps the title over six lines; 560 is the first comfortable width. Screenshots of 350 and 460 are below.

## Why

The link is already stored on the workspace (`linkedWorkItem` / `linkedTaskSourceContext`, plus the flat per-provider fields), the detail views already exist, and `pr-checks` already proves provider-derived data earns a right-sidebar tab. What was missing is seeing the item next to the diff, the terminals and the agents. Every round trip to the Tasks page costs the whole workspace context, several times a day.

Two deliberate choices:

- Resolution comes from the workspace's own link, never from the Tasks page selection, so a workspace linked to a Jira issue cannot render a GitHub item.
- The panel hosts the provider's view instead of re-rendering the item. A compact re-render was the first attempt here; it duplicated hydration and could never show comments or edits without reimplementing them.

## Linked Issue

Fixes #15318

Per the maintainer comment on that issue, this is the provider-generic Task panel, distinct from #12693's Linear-specific request.

## Visual Proof

Same window, same workspace, same linked issue (#15318 itself, read live through `gh`) in all shots.

**BEFORE** (`main`): the workspace carries a linked issue and the activity bar has nowhere to show it.

![before](https://raw.githubusercontent.com/ScopeaFrance/orca/assets/task-panel-screenshots/before-window.png)

**AFTER**: the Task tab hosts the provider detail view: breadcrumb, title, state, author, status / assignees / labels, full body. No back affordance, no start-workspace CTA. The user's persisted width here is 350; the tab's floor renders it at 560.

![after](https://raw.githubusercontent.com/ScopeaFrance/orca/assets/task-panel-screenshots/after-window.png)

**AFTER, workspace with no linked item**: the tab hides itself and the sidebar falls back to a visible tab. This shot is deliberately identical to BEFORE, which is the point: with nothing linked, nothing changes.

![after, no linked item](https://raw.githubusercontent.com/ScopeaFrance/orca/assets/task-panel-screenshots/after-no-linked-item-window.png)

**Why the width floor exists**: the same view at the 350px default, and at 460.

![squeezed at 350](https://raw.githubusercontent.com/ScopeaFrance/orca/assets/task-panel-screenshots/squeezed-at-350.png)

![at 460](https://raw.githubusercontent.com/ScopeaFrance/orca/assets/task-panel-screenshots/width-460.png)

## Testing

Linux (Ubuntu 24.04, Wayland), local git workspace, GitHub provider.

- `pnpm lint` passes. `pnpm typecheck` passes. `pnpm build` passes.
- `pnpm test`: green except 19 files that fail identically on a pristine `main` in this environment (locale-dependent `toLocaleString` assertions under `fr_FR`, plus keychain and WSL specs). Verified by diffing the failing set before and after the change: identical.
- Unit tests added for the resolution (including the repo fallbacks and the reference sigils), the tab visibility flag, the width floor and its window clamp, and the routing fallback when a persisted `task` route loses its linked item.
- Driven in the real app through the Electron E2E harness against issue #15318 with a live `gh` read, at 350 / 460 / 560 / 700 to establish the floor, and with the link cleared to confirm the tab disappears.
- Also exercised manually against a GitHub PR link on a private repo, which is how the missing-`repoId` and empty-body cases surfaced.

Cross-cutting notes:

- No platform-specific code, no keyboard shortcut registered (the tab follows `workspaces` and `pr-checks`, which also ship without one), no new IPC and no new provider transport.
- SSH/remote: the panel adds no read of its own; the hosted views resolve their own host context as they do on the Tasks page. Not exercised against a live SSH host.
- Folder workspaces: resolution reads the same normalized worktree projection folder workspaces produce, so a folder workspace with a linked task gets the tab.
- Provider-neutral where it counts: resolution and visibility have no provider branches beyond the reference sigil; only the rendering choice is per provider, behind an explicit check.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Written with Claude Code (Claude Opus 5), reviewed and tested by me.

## Review

Code review summary from the agent, against the areas the template asks about:

- **Cross-platform**: no platform branches, no path handling, no accelerators. Renderer chrome plus two conditionals in existing headers.
- **SSH / remote / local**: no new transport. The `panel` variant changes what the hosted views render, never how they read.
- **Agents / integrations / git providers**: GitHub routes to its own views; Linear, Jira and GitLab keep a provider-neutral fallback card rather than a GitHub-shaped one. Nothing assumes a provider is connected.
- **Performance**: the panel is lazy-loaded like every other tab; the hosted views reuse the same SWR details cache the Tasks page fills, so opening the tab for an item already read paints from cache. Nothing runs while the tab is not the effective tab. The width floor is a render-time `Math.max`, no extra state.
- **UI quality**: tokens and shadcn primitives only in the new fallback card; the hosted views are unchanged apart from omitting two affordances. Verified in light and dark at 350 / 460 / 560 / 700.
- **Security**: read paths only, no new IPC surface, no credential handling, no URL construction (the link out uses the provider's own URL).
- **Backwards compatibility**: a persisted `task` tab normalizes like any other static tab and older clients already fall back to Explorer for unknown values. `variant` defaults to `'page'`, so every existing call site of both views is untouched.

Known limitation, stated rather than hidden: the two `variant: 'panel'` conditionals live in shared headers. If you would rather express this as a layout prop, a context, or a separate embedded wrapper, say so and I will move it.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Follow-ups deliberately out of scope here, happy to take them in this PR if you prefer:

- Host `LinearIssueWorkspace`, `JiraIssueWorkspace` and `GitLabItemDialog` in the panel the same way, replacing the fallback card. I did not include them because I cannot exercise those providers end to end.
- A keyboard shortcut for the tab.
- Remembering a per-tab width instead of a floor, if a fixed floor feels too opinionated.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck` and `pnpm build` pass locally; `pnpm test` passes except the 19 environment-dependent files documented under Testing, which fail identically on a pristine `main` here

## Author

- X / Twitter:
