### PR TITLE
fix(sidebar): keep launched Cursor agents visible under conversation titles

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -304,6 +304,54 @@ describe('buildTitleDerivedAgentRows', () => {
     expect(rows.map((row) => [row.agentType, row.state])).toEqual([['cursor', 'working']])
   })
 
+  // Why: cursor-agent replaces its native identity title with whatever conversation
+  // name it generated. Grok can keep a trailing " - grok" token; Cursor cannot,
+  // so the launched owner has to keep the sidebar row for any non-shell title.
+  it('keeps a launched Cursor pane visible under an arbitrary session title', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { launchAgent: 'cursor' })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: { 'tab-1': { 1: 'Rename the auth helper' } },
+      ptyIdsByTabId: { 'tab-1': ['pty-cursor'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+
+    expect(rows.map((row) => [row.agentType, row.state, row.entry.prompt])).toEqual([
+      ['cursor', 'idle', 'Cursor']
+    ])
+    expect(rows[0]?.entry.terminalTitle).toBe('Rename the auth helper')
+  })
+
+  it('does not keep a launched Cursor pane after the title returns to the shell', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { launchAgent: 'cursor', defaultTitle: 'Terminal 1' })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: { 'tab-1': { 1: 'zsh' } },
+      ptyIdsByTabId: { 'tab-1': ['pty-cursor'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+
+    expect(rows).toHaveLength(0)
+  })
+
+  it('does not invent a Cursor row from an arbitrary title without launch identity', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1')],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: { 'tab-1': { 1: 'Rename the auth helper' } },
+      ptyIdsByTabId: { 'tab-1': ['pty-anon'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+
+    expect(rows).toHaveLength(0)
+  })
+
   // #8940: an OpenCode pane's own task text must not hand the row to Claude Code.
   it('keeps an OpenCode-launched pane OpenCode across its own status frames', () => {
     const frames: [string, string][] = [

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -1,6 +1,7 @@
 import type { DashboardAgentRow } from '@/components/dashboard/useDashboardData'
 import { formatAgentTypeLabel, isClaudeManagementTitle } from '@/lib/agent-status'
 import { isCursorAgentTitle } from '../../../../shared/agent-title-core'
+import { isShellProcess } from '../../../../shared/agent-detection'
 import { classifyTitleActivity, resolveTitleActivityLabel } from '@/lib/pane-agent-evidence'
 import { tabHasLivePty } from '@/lib/tab-has-live-pty'
 import type {
@@ -149,11 +150,20 @@ function buildTitleDerivedAgentRow(args: {
   // Why (cursor): the native `cursor agent` literal is deliberately status-less so a
   // redraw cannot stomp hook state — but it still identifies a live pane, so the row
   // reads idle instead of vanishing (#10258).
-  const status = isClaudeAgentsTitle
+  const classifiedStatus = isClaudeAgentsTitle
     ? 'idle'
     : (classifyTitleActivity(title) ?? (isCursorAgentTitle(title) ? 'idle' : null))
-  const label = isClaudeAgentsTitle ? 'Claude Code' : resolveTitleActivityLabel(title)
-  if (!status || !label) {
+  const classifiedLabel = isClaudeAgentsTitle ? 'Claude Code' : resolveTitleActivityLabel(title)
+  // Why: Grok keeps identity because session titles still contain "grok". Cursor
+  // replaces the native identity title with an arbitrary conversation name that
+  // has no provider token, so the pane's known owner has to supply identity.
+  // Shell/default titles still mean exit — same gate as use-tab-agent — so this
+  // cannot mint a row from zsh.
+  const owner = args.ownerAgentType && args.ownerAgentType !== 'unknown' ? args.ownerAgentType : null
+  const ownerClaimsSessionTitle =
+    owner === 'cursor' && !titleShowsNoAgent(title, args.tab.defaultTitle)
+  const status = classifiedStatus ?? (ownerClaimsSessionTitle ? 'idle' : null)
+  if (!status || (!classifiedLabel && !ownerClaimsSessionTitle)) {
     return null
   }
   if (!isTerminalLeafId(args.leafId)) {
@@ -161,19 +171,23 @@ function buildTitleDerivedAgentRow(args: {
   }
   const paneKey = makePaneKey(args.tab.id, args.leafId)
   const orchestration = args.runtimeAgentOrchestrationByPaneKey?.[paneKey]
-  const titleAgentType = isClaudeAgentsTitle
-    ? 'claude'
-    : resolveTitleDerivedAgentType(title, label, args.ownerAgentType)
+  let titleAgentType: AgentType | null = null
+  if (classifiedLabel) {
+    titleAgentType = isClaudeAgentsTitle
+      ? 'claude'
+      : resolveTitleDerivedAgentType(title, classifiedLabel, args.ownerAgentType)
+  }
   // Why: a status frame proves activity, not identity, so the resolver drops it.
   // Hook-less agents over SSH (Codex, #8711; OpenCode's '. '/'* ' frames, #8940)
   // surface only decorated task titles; fall back to the pane's known owner instead
-  // of hiding the pane. Safe because the `!status || !label` gate above already
-  // rejects plain shell titles — this path must never manufacture a row from one.
-  const agentType = titleAgentType ?? args.ownerAgentType
+  // of hiding the pane. Safe because the gate above already rejects plain shell
+  // titles — this path must never manufacture a row from one.
+  const agentType = titleAgentType ?? owner
   if (!agentType) {
     return null
   }
-  const rowLabel = titleAgentType ? label : formatAgentTypeLabel(agentType)
+  const rowLabel =
+    titleAgentType && classifiedLabel ? classifiedLabel : formatAgentTypeLabel(agentType)
   const rowState = titleStatusToRowState(status)
   const secondary =
     status === 'permission' ? 'Needs input' : status === 'working' ? 'Running' : 'Idle'
@@ -272,6 +286,13 @@ export function resolveAgentTypeFromTerminalTitle(
         ownerAgentType
       ) ?? null)
     : null
+}
+
+// Why: matches use-tab-agent.titleShowsNoAgent so sidebar rows and tab-icon
+// identity agree on when a live title is just a shell / default prompt.
+function titleShowsNoAgent(title: string, defaultTitle?: string): boolean {
+  const trimmed = title.trim()
+  return trimmed.length > 0 && (isShellProcess(trimmed) || trimmed === defaultTitle?.trim())
 }
 
 function titleStatusToRowState(


### PR DESCRIPTION
## ELI5

If you start Cursor from Orca, the session is running, but it disappears from the left-hand Agents list as soon as Cursor names the chat. Orca now keeps that row for the whole session, and only hides it when the terminal is back at a shell prompt.

## What Changed

- Title-derived sidebar rows treat a Cursor-owned pane as still live when the OSC title is an arbitrary conversation name.
- Shell names (`zsh`, `bash`, …) and the tab's default Terminal title still mean the agent exited, matching `use-tab-agent`.
- Tests cover: any session title + `launchAgent: cursor` stays visible; `zsh` hides the row; the same title without launch identity does not invent a Cursor row.

## Why

#10258 kept panes whose title was the native `Cursor Agent` literal. cursor-agent then replaces that literal with a generated conversation name that has no provider token. Grok session titles still contain `grok`, so they stay classified; Cursor titles do not. Parsing one Cursor title format is the wrong fix — the conversation name is arbitrary.

## Linked Issue

Fixes #15335

## Visual Proof

N/A — sidebar row appears from existing title-derived classification. No new chrome. A launched Cursor pane whose title is an arbitrary conversation name now gets a Cursor row; previously that title classified as nothing.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Focused: `worktree-title-derived-agent-rows.test.ts`, `worktree-status.test.ts`, `worktree-status-spinner-launch-agent.test.ts` (56 tests passed).

Platforms: classification is on the OSC title string plus `launchAgent` (macOS / Linux / Windows / SSH identical). No desktop UI run of this checkout; live app is still installed 1.4.184.

## AI Disclosure

Implementation and write-up by Grok 4.6 (xAI) in a local coding-agent session.

## Review

### Agent code-review summary

- Cross-platform: matching is on the title string and tab `launchAgent`; no path or shortcut changes.
- SSH/remote: title-derived rows already run on the client that owns the pane; owner fallback uses the same single-leaf launchAgent gate as today, so a split cannot brand a sibling.
- Agent compatibility: Cursor-only owner fallback. Grok/Codex/OpenCode title identity is unchanged. A shell title still drops the row.
- Performance: one extra `isShellProcess` check on an existing title-derived path.
- UI: no new controls.
- Security: no new network, credentials, or command execution.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Focused unit tests passed locally. Full lint/typecheck/build not run on this checkout.

## Author

- X / Twitter:

Made with [Cursor](https://cursor.com)