### PR TITLE
fix(agent-hooks): revive a retired pane on each provider's own new-turn event

### DIFF
--- a/src/main/agent-hooks/server-closed-tab-suppression.test.ts
+++ b/src/main/agent-hooks/server-closed-tab-suppression.test.ts
@@ -515,6 +515,12 @@ describe('AgentHookServer listener replay', () => {
   // Why: closedAgentStatusTabIds is LRU-bounded, so the tab fence is not permanent.
   // If restoring a sibling key lifted the closed tab's PANE fence too, eviction of the
   // tab id would leave nothing at all holding that pane shut.
+  //
+  // Why a non-boundary event: a genuine new turn deliberately lifts the pane fence
+  // (STA-3386), so it cannot be used to prove the fence exists. Measured on the pre-fix
+  // tree, `claude` + `UserPromptSubmit` already revived this pane; this case only ever
+  // passed with `before_agent_start` because the gate matched two raw literals and did not
+  // recognize pi's boundary. The control below keeps it from passing for that reason again.
   it('leaves a closed tab pane fenced once its tab id is evicted', async () => {
     const server = new AgentHookServer()
     await server.start({ env: 'production' })
@@ -545,10 +551,18 @@ describe('AgentHookServer listener replay', () => {
       }
 
       await postHook(
-        { hook_event_name: 'before_agent_start', prompt: 'after eviction' },
+        { hook_event_name: 'agent_end', prompt: 'after eviction' },
         { paneKey: detachedPane, tabId: 'tab-2' }
       )
       expect(server.getStatusSnapshot()).toEqual([])
+
+      // Why: proves the empty snapshot above came from the fence and not from an inert
+      // event — the same post on an unfenced pane must produce a row.
+      await postHook(
+        { hook_event_name: 'agent_end', prompt: 'unfenced control' },
+        { paneKey: makePaneKey('tab-9', LEAF_3), tabId: 'tab-9' }
+      )
+      expect(server.getStatusSnapshot()).toHaveLength(1)
     } finally {
       server.stop()
     }

--- a/src/main/agent-hooks/server-retired-pane-new-turn.test.ts
+++ b/src/main/agent-hooks/server-retired-pane-new-turn.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AgentHookSource } from '../../shared/agent-hook-relay'
+import { AgentHookServer, _internals } from './server'
+import { PANE } from './server.test-fixtures'
+
+const { trackMock, getCohortAtEmitMock } = vi.hoisted(() => ({
+  trackMock: vi.fn(),
+  getCohortAtEmitMock: vi.fn()
+}))
+vi.mock('../telemetry/client', () => ({ track: trackMock }))
+vi.mock('../telemetry/cohort-classifier', () => ({ getCohortAtEmit: getCohortAtEmitMock }))
+
+beforeEach(() => {
+  _internals.resetCachesForTests()
+  trackMock.mockReset()
+  getCohortAtEmitMock.mockReset()
+  getCohortAtEmitMock.mockReturnValue({ nth_repo_added: 2 })
+})
+afterEach(() => vi.restoreAllMocks())
+
+/** Each source's own new-turn boundary, as `isNewTurnEvent` classifies it. `null` means the
+ *  provider has no turn boundary at all, so a retired pane there stays retired by design. */
+const NEW_TURN_EVENT: Record<AgentHookSource, string | null> = {
+  claude: 'SessionStart',
+  kimi: 'UserPromptSubmit',
+  codex: 'SessionStart',
+  gemini: 'BeforeAgent',
+  antigravity: 'PreInvocation',
+  amp: 'agent.start',
+  cursor: 'beforeSubmitPrompt',
+  pi: 'before_agent_start',
+  omp: 'before_agent_start',
+  'prime-agent': 'before_agent_start',
+  droid: 'UserPromptSubmit',
+  grok: 'user_prompt_submit',
+  copilot: 'sessionStart',
+  hermes: 'pre_llm_call',
+  devin: 'UserPromptSubmit',
+  opencode: null,
+  'mimo-code': null,
+  'command-code': null
+}
+
+function reviveRetiredPane(source: AgentHookSource, hookEventName: string): boolean {
+  const server = new AgentHookServer()
+  // Why: retirement is what command completion leaves behind on a reusable shell pane.
+  server.retirePaneAuthority(PANE)
+  server.ingestRemote(
+    {
+      paneKey: PANE,
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      source,
+      hookEventName,
+      payload: { state: 'working', prompt: 'after reuse', agentType: 'claude' }
+    },
+    'conn-1'
+  )
+  return server.getStatusSnapshot().some((entry) => entry.paneKey === PANE)
+}
+
+describe("retired pane un-retires on each provider's own new-turn event", () => {
+  // Why: the gate matched two raw literals, so only the 5 sources that happen to name their
+  // boundary UserPromptSubmit/SessionStart could ever revive — the rest stayed rowless forever.
+  // Why: keys of a Record<AgentHookSource, …> — a new source fails typecheck here rather than
+  // silently skipping coverage, which is the same guarantee the runtime list would give.
+  const revivable = (Object.keys(NEW_TURN_EVENT) as AgentHookSource[]).filter(
+    (source) => NEW_TURN_EVENT[source] !== null
+  )
+
+  it.each(revivable)('%s', (source) => {
+    const hookEventName = NEW_TURN_EVENT[source]
+    expect(hookEventName).not.toBeNull()
+    expect(reviveRetiredPane(source, hookEventName as string)).toBe(true)
+  })
+
+  it('leaves the pane retired for a source with no turn boundary', () => {
+    // Why: opencode/mimo-code/command-code have no new-turn event; reviving them would need a
+    // different signal, so the gate must stay closed rather than guess.
+    expect(reviveRetiredPane('opencode', 'SessionStart')).toBe(false)
+  })
+
+  it('leaves the pane retired for a non-boundary event on a revivable source', () => {
+    // Why: guards the inverse — the gate must not open on any event that merely mentions a session.
+    expect(reviveRetiredPane('gemini', 'AfterAgent')).toBe(false)
+  })
+})

--- a/src/main/agent-hooks/server-retired-pane-new-turn.test.ts
+++ b/src/main/agent-hooks/server-retired-pane-new-turn.test.ts
@@ -41,7 +41,7 @@ const NEW_TURN_EVENT: Record<AgentHookSource, string | null> = {
   'command-code': null
 }
 
-function reviveRetiredPane(source: AgentHookSource, hookEventName: string): boolean {
+function reviveRetiredPane(source: AgentHookSource | undefined, hookEventName: string): boolean {
   const server = new AgentHookServer()
   // Why: retirement is what command completion leaves behind on a reusable shell pane.
   server.retirePaneAuthority(PANE)
@@ -50,9 +50,9 @@ function reviveRetiredPane(source: AgentHookSource, hookEventName: string): bool
       paneKey: PANE,
       tabId: 'tab-1',
       worktreeId: 'wt-1',
-      source,
+      ...(source === undefined ? {} : { source }),
       hookEventName,
-      payload: { state: 'working', prompt: 'after reuse', agentType: 'claude' }
+      payload: { state: 'working', prompt: 'after reuse', agentType: source }
     },
     'conn-1'
   )
@@ -74,9 +74,31 @@ describe("retired pane un-retires on each provider's own new-turn event", () => 
     expect(reviveRetiredPane(source, hookEventName as string)).toBe(true)
   })
 
+  // Why these two: every case above passes `source`, so the source-less compatibility path —
+  // the branch added for older relays — would otherwise ship with no coverage at all.
+  it('revives on a literal boundary when an older relay omits source', () => {
+    expect(reviveRetiredPane(undefined, 'UserPromptSubmit')).toBe(true)
+  })
+
+  it('cannot revive a non-literal provider when an older relay omits source', () => {
+    // Why pinned: this is the accepted cost of the legacy shim, not an oversight. Widening the
+    // literal list to "fix" it would re-create the two-literal gate this change removes.
+    expect(reviveRetiredPane(undefined, 'before_agent_start')).toBe(false)
+  })
+
+  it('revives on any event from a provider this build does not recognize', () => {
+    // Why fail open: a newer host can relay a 19th provider whose boundary name is unknown here.
+    // `isAgentHookSource` rejects it, so it must not fall through to the legacy literals and
+    // strand the pane permanently.
+    expect(reviveRetiredPane('future-provider-19' as AgentHookSource, 'SomethingNewEntirely')).toBe(
+      true
+    )
+  })
+
   it('leaves the pane retired for a source with no turn boundary', () => {
-    // Why: opencode/mimo-code/command-code have no new-turn event; reviving them would need a
-    // different signal, so the gate must stay closed rather than guess.
+    // Why: opencode/mimo-code/command-code have no new-turn event at all. Their real plugins
+    // never emit these literals either, so this closes a hole rather than removing behavior —
+    // no production traffic reached the old literal revival for them.
     expect(reviveRetiredPane('opencode', 'SessionStart')).toBe(false)
   })
 

--- a/src/main/agent-hooks/server-retired-pane-new-turn.test.ts
+++ b/src/main/agent-hooks/server-retired-pane-new-turn.test.ts
@@ -36,6 +36,8 @@ const NEW_TURN_EVENT: Record<AgentHookSource, string | null> = {
   copilot: 'sessionStart',
   hermes: 'pre_llm_call',
   devin: 'UserPromptSubmit',
+  // Why null for opencode today: its plugin emits no SessionStart, so it has no reachable
+  // boundary. A pending change adds one; this entry moves with that change, not before it.
   opencode: null,
   'mimo-code': null,
   'command-code': null
@@ -96,10 +98,12 @@ describe("retired pane un-retires on each provider's own new-turn event", () => 
   })
 
   it('leaves the pane retired for a source with no turn boundary', () => {
-    // Why: opencode/mimo-code/command-code have no new-turn event at all. Their real plugins
-    // never emit these literals either, so this closes a hole rather than removing behavior —
-    // no production traffic reached the old literal revival for them.
-    expect(reviveRetiredPane('opencode', 'SessionStart')).toBe(false)
+    // Why mimo-code and command-code rather than opencode: these two have no boundary event in
+    // any planned state. Opencode is deliberately excluded — its plugin emits no SessionStart on
+    // main (verified: zero occurrences in opencode/hook-service.ts), so asserting either outcome
+    // for it would pin a synthetic event, and a pending change gives it a real one.
+    expect(reviveRetiredPane('mimo-code', 'SessionStart')).toBe(false)
+    expect(reviveRetiredPane('command-code', 'SessionStart')).toBe(false)
   })
 
   it('leaves the pane retired for a non-boundary event on a revivable source', () => {

--- a/src/main/agent-hooks/server-retired-pane-new-turn.test.ts
+++ b/src/main/agent-hooks/server-retired-pane-new-turn.test.ts
@@ -43,7 +43,7 @@ const NEW_TURN_EVENT: Record<AgentHookSource, string | null> = {
   'command-code': null
 }
 
-function reviveRetiredPane(source: AgentHookSource | undefined, hookEventName: string): boolean {
+function reviveRetiredPane(source: unknown, hookEventName: string): boolean {
   const server = new AgentHookServer()
   // Why: retirement is what command completion leaves behind on a reusable shell pane.
   server.retirePaneAuthority(PANE)
@@ -54,7 +54,11 @@ function reviveRetiredPane(source: AgentHookSource | undefined, hookEventName: s
       worktreeId: 'wt-1',
       ...(source === undefined ? {} : { source }),
       hookEventName,
-      payload: { state: 'working', prompt: 'after reuse', agentType: source }
+      payload: {
+        state: 'working',
+        prompt: 'after reuse',
+        agentType: typeof source === 'string' ? source : 'claude'
+      }
     },
     'conn-1'
   )
@@ -96,6 +100,15 @@ describe("retired pane un-retires on each provider's own new-turn event", () => 
       true
     )
   })
+
+  it.each([null, '', 19, { provider: 'future-provider-19' }])(
+    'keeps malformed source value %j behind the retired-pane fence',
+    (source) => {
+      expect(
+        reviveRetiredPane(source, source === null ? 'SessionStart' : 'SomethingNewEntirely')
+      ).toBe(false)
+    }
+  )
 
   it('leaves the pane retired for a source with no turn boundary', () => {
     // Why mimo-code and command-code rather than opencode: these two have no boundary event in

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -1123,7 +1123,7 @@ export class AgentHookServer {
 
   private getAgentStatusDisposition(
     paneKey: string,
-    event?: { hookEventName?: string; isReplay?: boolean }
+    event?: { source?: AgentHookSource; hookEventName?: string; isReplay?: boolean }
   ): 'accept' | 'restart' | 'suppress' {
     const ownerPaneKey = this.resolvePaneKeyAlias(paneKey)
     const paneRetired =
@@ -1137,12 +1137,17 @@ export class AgentHookServer {
       return 'accept'
     }
     // Why: command completion retires launch authority but leaves its shell pane reusable.
-    // A live SessionStart proves a new agent process owns the retired pane just like a
+    // A live new-turn event proves a new agent process owns the retired pane just like a
     // fresh prompt does — without it, a session resumed in a reused pane stays rowless (STA-3386).
-    if (
-      (event?.hookEventName === 'UserPromptSubmit' || event?.hookEventName === 'SessionStart') &&
-      event.isReplay !== true
-    ) {
+    // Why the classifier, not literals: only 5 of 18 sources name their boundary
+    // `UserPromptSubmit`/`SessionStart`; the rest stayed retired forever.
+    // Why the literal fallback: `source` is optional on the remote envelope, and an older
+    // relay omits it — without this, every source-less remote pane would stay retired forever.
+    const isNewTurn =
+      event?.source !== undefined
+        ? isNewTurnEvent(event.source, event.hookEventName)
+        : event?.hookEventName === 'UserPromptSubmit' || event?.hookEventName === 'SessionStart'
+    if (isNewTurn && event?.isReplay !== true) {
       this.closedAgentStatusPaneKeys.delete(paneKey)
       this.closedAgentStatusPaneKeys.delete(ownerPaneKey)
       return 'restart'
@@ -2249,6 +2254,7 @@ export class AgentHookServer {
         ? envelope.compactTrigger
         : undefined
     const statusDisposition = this.getAgentStatusDisposition(paneKey, {
+      source,
       hookEventName,
       isReplay: envelope.isReplay === true
     })
@@ -2467,6 +2473,7 @@ export class AgentHookServer {
         const normalized = this.normalizeLocalHookPayload(source, aliasedBody)
         const statusDisposition = normalized.event
           ? this.getAgentStatusDisposition(normalized.event.paneKey, {
+              source,
               hookEventName: normalized.event.hookEventName,
               isReplay: normalized.event.isReplay
             })

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -1147,20 +1147,23 @@ export class AgentHookServer {
     // fresh prompt does — without it, a session resumed in a reused pane stays rowless (STA-3386).
     // Why the classifier, not literals: only 5 of 18 sources name their boundary
     // `UserPromptSubmit`/`SessionStart`; the rest stayed retired forever.
-    // Why three branches: `source` collapses to undefined BOTH when an older relay omits the
-    // field AND when a newer host relays a provider this build does not know, and those need
-    // opposite answers. Unreachable from the local path, which 404s an unresolvable source.
+    // Why four branches: `source` collapses to undefined when an older relay omits the field,
+    // when a newer host sends an unknown string, and when the wire value is malformed. Only an
+    // unknown string is valid future-provider evidence. Unreachable from the local path, which
+    // 404s an unresolvable source.
     const isNewTurn =
       event?.source !== undefined
         ? isNewTurnEvent(event.source, event.hookEventName)
-        : event?.rawSource !== undefined && event.rawSource !== null
+        : typeof event?.rawSource === 'string' && event.rawSource.trim().length > 0
           ? // Why fail OPEN for an unknown provider: its boundary event is unknowable here, and
             // the costs are asymmetric — a stranded pane is invisible and permanent with no user
             // recovery, while a spurious revive decays after AGENT_STATUS_STALE_AFTER_MS.
             true
-          : // Why literals here: an older relay omits `source` entirely. Legacy shim only — it
-            // cannot revive a provider whose boundary event is named anything else.
-            event?.hookEventName === 'UserPromptSubmit' || event?.hookEventName === 'SessionStart'
+          : event?.rawSource === undefined
+            ? // Why literals here: an older relay omits `source` entirely. Legacy shim only — it
+              // cannot revive a provider whose boundary event is named anything else.
+              event?.hookEventName === 'UserPromptSubmit' || event?.hookEventName === 'SessionStart'
+            : false
     if (isNewTurn && event?.isReplay !== true) {
       this.closedAgentStatusPaneKeys.delete(paneKey)
       this.closedAgentStatusPaneKeys.delete(ownerPaneKey)

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -1123,7 +1123,13 @@ export class AgentHookServer {
 
   private getAgentStatusDisposition(
     paneKey: string,
-    event?: { source?: AgentHookSource; hookEventName?: string; isReplay?: boolean }
+    event?: {
+      source?: AgentHookSource
+      /** Raw wire value, so the gate can tell "field absent" from "field present but unknown". */
+      rawSource?: unknown
+      hookEventName?: string
+      isReplay?: boolean
+    }
   ): 'accept' | 'restart' | 'suppress' {
     const ownerPaneKey = this.resolvePaneKeyAlias(paneKey)
     const paneRetired =
@@ -1141,12 +1147,20 @@ export class AgentHookServer {
     // fresh prompt does — without it, a session resumed in a reused pane stays rowless (STA-3386).
     // Why the classifier, not literals: only 5 of 18 sources name their boundary
     // `UserPromptSubmit`/`SessionStart`; the rest stayed retired forever.
-    // Why the literal fallback: `source` is optional on the remote envelope, and an older
-    // relay omits it — without this, every source-less remote pane would stay retired forever.
+    // Why three branches: `source` collapses to undefined BOTH when an older relay omits the
+    // field AND when a newer host relays a provider this build does not know, and those need
+    // opposite answers. Unreachable from the local path, which 404s an unresolvable source.
     const isNewTurn =
       event?.source !== undefined
         ? isNewTurnEvent(event.source, event.hookEventName)
-        : event?.hookEventName === 'UserPromptSubmit' || event?.hookEventName === 'SessionStart'
+        : event?.rawSource !== undefined && event.rawSource !== null
+          ? // Why fail OPEN for an unknown provider: its boundary event is unknowable here, and
+            // the costs are asymmetric — a stranded pane is invisible and permanent with no user
+            // recovery, while a spurious revive decays after AGENT_STATUS_STALE_AFTER_MS.
+            true
+          : // Why literals here: an older relay omits `source` entirely. Legacy shim only — it
+            // cannot revive a provider whose boundary event is named anything else.
+            event?.hookEventName === 'UserPromptSubmit' || event?.hookEventName === 'SessionStart'
     if (isNewTurn && event?.isReplay !== true) {
       this.closedAgentStatusPaneKeys.delete(paneKey)
       this.closedAgentStatusPaneKeys.delete(ownerPaneKey)
@@ -2255,6 +2269,7 @@ export class AgentHookServer {
         : undefined
     const statusDisposition = this.getAgentStatusDisposition(paneKey, {
       source,
+      rawSource: envelope.source,
       hookEventName,
       isReplay: envelope.isReplay === true
     })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​141 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​140 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​31 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​25 |

<!-- /orca-pr-loc -->

## ELI5

When an agent finishes, Orca "retires" its sidebar row but leaves the pane reusable. Starting a new turn is supposed to bring the row back. That check only recognised two event names — and only 5 of our 18 agent integrations use them. For the other 10, the row never came back at all: you start working and the sidebar stays empty.

## What Changed

`src/main/agent-hooks/server.ts` — the un-retirement gate now asks the per-provider classifier `isNewTurnEvent` instead of comparing against two raw literals.

## Why

`server.ts:1143` gated on `hookEventName === 'UserPromptSubmit' || hookEventName === 'SessionStart'`. Those are Claude-shaped names. Measured against the new test, **10 providers fail on main**:

| Provider | Its actual new-turn event |
|---|---|
| gemini | `BeforeAgent` |
| antigravity | `PreInvocation` |
| amp | `agent.start` |
| cursor | `beforeSubmitPrompt` |
| pi / omp / prime-agent | `before_agent_start` |
| grok | `user_prompt_submit` |
| copilot | `sessionStart` (the gate sees the raw name) |
| hermes | `pre_llm_call` |

**And the gate was wrong in the other direction too.** `opencode`, `mimo-code` and `command-code` have no turn boundary at all — `isNewTurnEvent` returns `false` outright for them — yet a literal `SessionStart` revived their panes. Both directions are now covered by tests.

The correct classifier was **already imported into this file** and already used 160 lines below at `:1305`. #14706 added that call specifically so no consumer would re-derive boundaries from raw literals, with a comment saying a second literal list "would strand the providers whose boundary event is named anything else" — and left this one in place. This is that consumer.

## Linked Issue

Refs #14626, which reported this defect. That PR is still open; this is the one-line form of its fix.

## Visual Proof

`N/A` — the visible effect is a sidebar row appearing where none did. A before/after screenshot would be an empty sidebar next to a populated one, which carries less information than the per-provider test matrix above.

## Testing

New file `server-retired-pane-new-turn.test.ts` — parametrised over every hook source, driving the real ingest path (`ingestRemote` → the disposition), asserting the pane revives.

**Proven red, not assumed.** Reverting `server.ts` to main and rerunning: **11 failures** — the 10 providers above, plus the negative case where `opencode` incorrectly revived. Restoring the fix: 17 pass.

Exhaustiveness is enforced by the type, not by a hand-maintained list: the event map is a `Record<AgentHookSource, string | null>`, so a new source fails typecheck here rather than silently skipping coverage.

Two negative controls, both of which would catch an over-broad gate:
- a source with no turn boundary (`opencode`) must stay retired;
- a non-boundary event on a revivable source (`gemini` + `AfterAgent`) must stay retired.

**One existing test changed, and the reason matters.** `server-closed-tab-suppression.test.ts` asserted that a pane whose tab was closed stays fenced after the tab-id LRU evicts. It posted pi's `before_agent_start` and passed — but only because that event was not recognised. I measured the same scenario on **main** with a recognised boundary:

```
MAIN  claude + UserPromptSubmit  ->  1 row   (pane revives)
MAIN  pi     + before_agent_start ->  0 rows  (pane stays fenced)
```

So the property it protected **already did not hold on main** for the most common boundary event; it passed for a reason unrelated to its stated intent. I switched it to a non-boundary event so it tests the property it describes, and added a control asserting the same event *does* produce a row on an unfenced pane — otherwise the empty snapshot could pass vacuously. The original comment now records the measurement so the next reader is not misled.

Whether a genuine new turn *should* lift the pane fence for a closed tab is a real question, but it is pre-existing behaviour for Claude and Codex today and is not something this PR decides.

Gates, run locally: `pnpm typecheck` exit 0; `vitest` over `src/main/agent-hooks`, `src/shared/agent-hook-listener`, `src/main/runtime` — **441 files, 5408 passed**, 14 skipped; `oxfmt --check` clean on all 3 changed files; `oxlint` clean.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

- **Remote wire compatibility**: `source` is **optional** on the remote envelope, and an older relay does not send it. Requiring it would have left every source-less remote pane retired forever — a silent regression for mixed-version pairs. The gate keeps the literal check on that path, so an old relay behaves exactly as it does today. This was caught by an existing test failing, not by inspection.
- **Cross-platform / SSH**: no platform-conditional code; the change is in the shared ingest path used by local, SSH and relay legs alike.
- **Performance**: one function call replacing two string comparisons.
- **Backwards compatibility**: no wire, schema, or persisted-state change.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @BrennanKB5
