### PR TITLE
refactor(runtime): name every mobile-session close outcome so the tombstone decision is explicit (STA-4718)

### DIFF
--- a/src/main/runtime/mobile-session-tab-close-outcome.ts
+++ b/src/main/runtime/mobile-session-tab-close-outcome.ts
@@ -1,0 +1,58 @@
+import type { RuntimeMobileSessionTabCloseResult } from '../../shared/runtime-types'
+import type { ClientSessionTabSelectionStore } from './client-session-tab-selection'
+
+// Why: a selection tombstone (ClientSessionTabSelectionStore.forgetTabs) is not a
+// hint — it filters the tab out of every snapshot published to that client, and
+// only activating the tab clears it. So it is a claim that the host itself
+// authoritatively retired the tab while its own published snapshot still lists
+// it. Claiming that for a close the host merely asked someone else to perform
+// would hide a still-live tab from a paired client with no recovery path.
+// Hence the three outcome classes below, one constructor each.
+
+// Why: declared, never assigned — the brand exists only in the type system, so
+// no new field reaches mixed-version clients over the RPC wire.
+declare const mobileSessionTabCloseOutcomeBrand: unique symbol
+
+// Why: the required brand makes a bare `{ closed: true }` unassignable, forcing
+// every close return site to name which outcome class it is.
+export type MobileSessionTabCloseOutcome = RuntimeMobileSessionTabCloseResult & {
+  readonly [mobileSessionTabCloseOutcomeBrand]: never
+}
+
+type MobileSessionTabCloseRefusalReason = NonNullable<
+  RuntimeMobileSessionTabCloseResult['refusalReason']
+>
+
+// Why: the host tore the tab down (or verified its teardown) itself, so it may
+// tombstone the client's selection. The tombstone is written here, not by the
+// caller, so this outcome's name and its effect cannot drift apart.
+export function committedMobileSessionTabClose(
+  selections: Pick<ClientSessionTabSelectionStore, 'forgetTabs'>,
+  worktreeId: string,
+  closedTabIds: readonly string[]
+): MobileSessionTabCloseOutcome {
+  selections.forgetTabs(worktreeId, closedTabIds)
+  return { closed: true } as MobileSessionTabCloseOutcome
+}
+
+// Why: the close was handed to the renderer over a fire-and-forget notifier that
+// carries no acknowledgement. The renderer may legitimately decline it — an
+// unresolvable worktree route, or a pinned-tab confirm the user cancels — so the
+// host does not know the tab retired and must not tombstone it.
+export function delegatedMobileSessionTabClose(): MobileSessionTabCloseOutcome {
+  return { closed: true } as MobileSessionTabCloseOutcome
+}
+
+// Why: `snapshotRepublished` tells the client to restore its pruned mirror, so it
+// is passed explicitly per site — some refusals deliberately skip the republish.
+export function refusedMobileSessionTabClose(
+  refusalReason: MobileSessionTabCloseRefusalReason,
+  options: { snapshotRepublished?: boolean } = {}
+): MobileSessionTabCloseOutcome {
+  return {
+    closed: true,
+    refused: true,
+    refusalReason,
+    ...(options.snapshotRepublished ? { snapshotRepublished: true as const } : {})
+  } as MobileSessionTabCloseOutcome
+}

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -32539,6 +32539,69 @@ describe('OrcaRuntimeService', () => {
     expect(getSession().terminalLayoutsByTabId['host-tab']).toBeDefined()
   })
 
+  it('returns a delegated close outcome with no selection tombstone when the renderer owns the outcome', async () => {
+    const { runtimeStore, getSession } = makeRuntimeStoreWithWorkspaceSession(
+      makeWorkspaceSessionWithHeadlessTerminal()
+    )
+    const kill = vi.fn(() => true)
+    const closeTerminal = vi.fn()
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    const forgetTabs = vi.spyOn(runtime['clientSessionTabSelections'], 'forgetTabs')
+    runtime.setPtyController({
+      write: () => true,
+      kill,
+      getForegroundProcess: async () => null,
+      listProcesses: async () => []
+    })
+    runtime.setNotifier({ closeTerminal } as never)
+    runtime.syncWindowGraph(1, {
+      tabs: [
+        {
+          tabId: 'host-tab',
+          worktreeId: TEST_WORKTREE_ID,
+          title: 'Pending Terminal',
+          activeLeafId: HEADLESS_LEAF_ID,
+          layout: null
+        }
+      ],
+      leaves: [],
+      mobileSessionTabs: [
+        {
+          worktree: TEST_WORKTREE_ID,
+          publicationEpoch: 'headless:pending',
+          snapshotVersion: 1,
+          activeGroupId: 'group-1',
+          activeTabId: `host-tab::${HEADLESS_LEAF_ID}`,
+          activeTabType: 'terminal',
+          tabs: [
+            {
+              type: 'terminal',
+              id: `host-tab::${HEADLESS_LEAF_ID}`,
+              parentTabId: 'host-tab',
+              leafId: HEADLESS_LEAF_ID,
+              title: 'Pending Terminal',
+              isActive: true
+            }
+          ]
+        }
+      ]
+    })
+
+    const result = await runtime.closeMobileSessionTab(
+      `id:${TEST_WORKTREE_ID}`,
+      `host-tab::${HEADLESS_LEAF_ID}`
+    )
+
+    // Why: a delegated close is handed to the renderer over a fire-and-forget
+    // notifier that may decline it, so tombstoning would hide a live tab from
+    // paired clients forever. Only a host-committed close may tombstone.
+    expect(result).toEqual({ closed: true })
+    expect(closeTerminal).toHaveBeenCalledWith('host-tab')
+    expect(forgetTabs).not.toHaveBeenCalled()
+    expect(kill).not.toHaveBeenCalled()
+    expect(getSession().tabsByWorktree[TEST_WORKTREE_ID]).toHaveLength(1)
+  })
+
   it('tears down a runtime pending shell the renderer never adopted on close', async () => {
     const { runtimeStore, getSession } = makeRuntimeStoreWithWorkspaceSession(
       makeWorkspaceSessionWithHeadlessTerminal()

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -458,7 +458,6 @@ import {
   type RuntimeMarkdownSaveTabResult,
   type RuntimeMobileSessionCreateTerminalResult,
   type RuntimeMobileSessionClientTab,
-  type RuntimeMobileSessionTabCloseResult,
   type RuntimeMobileSessionMarkdownTab,
   type RuntimeMobileSessionTabMove,
   type RuntimeMobileSessionTabMoveResult,
@@ -686,6 +685,12 @@ import {
   deriveClientSessionTabSelection,
   projectClientSessionTabSelection
 } from './client-session-tab-selection'
+import {
+  committedMobileSessionTabClose,
+  delegatedMobileSessionTabClose,
+  refusedMobileSessionTabClose,
+  type MobileSessionTabCloseOutcome
+} from './mobile-session-tab-close-outcome'
 import type {
   PtyProviderBufferSnapshot,
   IFilesystemProvider,
@@ -8979,7 +8984,7 @@ export class OrcaRuntimeService {
   async refuseUnattributedMobileSessionTabClose(
     worktreeSelector: string,
     tabId: string
-  ): Promise<RuntimeMobileSessionTabCloseResult> {
+  ): Promise<MobileSessionTabCloseOutcome> {
     const snapshot = await this.listMobileSessionTabs(worktreeSelector)
     const tabExists = snapshot.tabs.some(
       (candidate) =>
@@ -8993,12 +8998,9 @@ export class OrcaRuntimeService {
     // Why: a legacy client may already have hidden its mirror; a new snapshot
     // restores it without granting an unattributed request destructive authority.
     this.republishMobileSessionTabsSnapshot(snapshot.worktree)
-    return {
-      closed: true,
-      refused: true,
-      refusalReason: 'missing-intent',
+    return refusedMobileSessionTabClose('missing-intent', {
       snapshotRepublished: true
-    }
+    })
   }
 
   async closeMobileSessionTab(
@@ -9011,7 +9013,7 @@ export class OrcaRuntimeService {
       clientNavigationId?: string
       localPtyTeardownOwnedExternally?: boolean
     } = {}
-  ): Promise<RuntimeMobileSessionTabCloseResult> {
+  ): Promise<MobileSessionTabCloseOutcome> {
     const graphEpoch = options.clientNavigationId ? this.captureReadyGraphEpoch() : null
     const explicitWorktreeId = this.getValidatedExplicitWorktreeIdSelector(worktreeSelector)
     const worktreeId =
@@ -9026,24 +9028,18 @@ export class OrcaRuntimeService {
     if (options.reason !== undefined && options.reason !== 'user' && observedPtyIds === null) {
       // Why: keep-on-unknown must also restore the mirror the caller already pruned.
       this.republishMobileSessionTabsSnapshot(worktreeId)
-      return {
-        closed: true,
-        refused: true,
-        refusalReason: 'unknown-liveness',
-        ...(snapshot ? { snapshotRepublished: true as const } : {})
-      }
+      return refusedMobileSessionTabClose('unknown-liveness', {
+        snapshotRepublished: Boolean(snapshot)
+      })
     }
     if (
       options.expectedPublicationEpoch !== undefined &&
       snapshot?.publicationEpoch !== options.expectedPublicationEpoch
     ) {
       this.republishMobileSessionTabsSnapshot(worktreeId)
-      return {
-        closed: true,
-        refused: true,
-        refusalReason: 'stale-publication',
-        ...(snapshot ? { snapshotRepublished: true as const } : {})
-      }
+      return refusedMobileSessionTabClose('stale-publication', {
+        snapshotRepublished: Boolean(snapshot)
+      })
     }
     const tab =
       snapshot?.tabs.find((candidate) => candidate.id === tabId) ??
@@ -9068,19 +9064,18 @@ export class OrcaRuntimeService {
         )
       if (!terminalIncarnationMatches) {
         this.republishMobileSessionTabsSnapshot(worktreeId)
-        return {
-          closed: true,
-          refused: true,
-          refusalReason: 'stale-terminal',
+        return refusedMobileSessionTabClose('stale-terminal', {
           snapshotRepublished: true
-        }
+        })
       }
     }
     let closedSelectionTabIds = [tab.id]
-    const finishCommittedClose = (): RuntimeMobileSessionTabCloseResult => {
-      this.clientSessionTabSelections.forgetTabs(worktreeId, closedSelectionTabIds)
-      return { closed: true }
-    }
+    const finishCommittedClose = (): MobileSessionTabCloseOutcome =>
+      committedMobileSessionTabClose(
+        this.clientSessionTabSelections,
+        worktreeId,
+        closedSelectionTabIds
+      )
     if (tab.type === 'terminal') {
       const parentLeafCount = snapshot.tabs.filter(
         (candidate) => candidate.type === 'terminal' && candidate.parentTabId === tab.parentTabId
@@ -9132,21 +9127,14 @@ export class OrcaRuntimeService {
           }
           // Why: both markers are skew-safe; clients must restore a mirror only
           // when the host actually republished it, not for a dead leaf.
-          return {
-            closed: true,
-            refused: true,
-            refusalReason: 'live-host-pty',
-            ...(!addressedDeadLeaf ? { snapshotRepublished: true as const } : {})
-          }
+          return refusedMobileSessionTabClose('live-host-pty', {
+            snapshotRepublished: !addressedDeadLeaf
+          })
         }
         if (!closingWholeParent || this.tabs.has(tab.parentTabId)) {
           // Why: only the renderer may retire its own tab or split leaf; a
           // remote lifecycle echo must never cross that boundary into a kill.
-          return {
-            closed: true,
-            refused: true,
-            refusalReason: 'retirement-owner'
-          }
+          return refusedMobileSessionTabClose('retirement-owner')
         }
       }
       // Why: a runtime-owned headless tab is absent from renderer state, so the
@@ -9225,14 +9213,14 @@ export class OrcaRuntimeService {
           return finishCommittedClose()
         }
         this.notifier.closeTerminal(tab.parentTabId)
-        return { closed: true }
+        return delegatedMobileSessionTabClose()
       }
       // Why: paired web tab bars represent a split terminal with one local
       // parent tab id. Closing that parent should close the desktop tab, not
       // just whichever leaf happened to be first in the session snapshot.
       this.notifier.closeTerminal(tab.parentTabId)
       this.clearRuntimeSessionOwnershipForMobileTab(worktreeId, snapshot, tab.parentTabId)
-      return { closed: true }
+      return delegatedMobileSessionTabClose()
     } else if (tab.type === 'browser' && this.offscreenBrowserBackend) {
       // Why: headless browser tabs are offscreen WebContents with no renderer to
       // route closeSessionTab to. Close the page directly and drop it from the


### PR DESCRIPTION
## ELI5

When you close a terminal tab from your phone or from the web, the desktop app has three possible answers:

1. **"Done — I closed it myself."**
2. **"I asked the desktop window to close it, and I have no idea whether it actually did."**
3. **"No, I'm not doing that."**

Answer 1 had a proper name in the code. Answers 2 and 3 were anonymous — just bare little objects scattered across about eight places. Nothing said which of the three any given spot meant.

That matters because answer 1 does an extra bit of bookkeeping: it writes down "this tab is gone, stop showing it to that phone." Answers 2 and 3 deliberately *don't*. But since they had no name, nobody could tell whether that missing bookkeeping was a careful decision or a slip — and someone filed a bug report saying it was a slip.

**It wasn't.** Doing it there would have caused a real bug: the desktop is allowed to say "no" to a close (say, you cancelled the "this tab is still running something, really close it?" box). If we'd already written down "that tab is gone," your still-running terminal would disappear from your phone permanently, with no way to bring it back.

So this PR doesn't make the change the bug report asked for. It gives all three answers names, so nobody has to guess again.

**What you might notice:** nothing at all. Every one of those eight places produces exactly the same result as before, down to the order of the fields.

---
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​63 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​63 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​88 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​42 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​46 |

<!-- /orca-pr-loc -->

Relates to [STA-4718](https://linear.app/stably/issue/STA-4718). Follow-up from #13387.

## The ticket as filed is invalid — please read before reviewing

STA-4718 asks that two renderer-mediated close branches in `closeMobileSessionTab` (`orca-runtime.ts`, the two `return { closed: true }` sites) be routed through `finishCommittedClose()` so they record selection tombstones. **Doing that would introduce a bug.** This PR deliberately does not do it.

The omission is load-bearing. Both branches call `this.notifier.closeTerminal(...)`, which is declared `void` — fire-and-forget — and lands in the renderer as `closeTerminalTab(tabId, { skipRunningProcessConfirm: true })`. That renderer call can legitimately **decline** to close:

- no resolvable worktree route (`terminal-tab-actions.ts:85-88`), or
- a pinned tab with `confirmClosePinnedTab` on, which opens a modal the user can cancel (`terminal-tab-actions.ts:90-112`).

The host never learns the outcome. And a tombstone is not a passive "don't re-select" hint — `projectWithoutClosedClientSessionTabs` **filters the tab out of every snapshot published to that client**, and the only thing that clears one is `activate()` on that tab id, which a client cannot do for a tab it can no longer see. So tombstoning an uncommitted close would permanently hide a *live* terminal from a paired client, with no recovery path.

This is confirmed by history: `0e96b82e449` introduced `finishCommittedClose()`, converted the other branches to it, and deliberately left these two alone in the same diff — adding `expect(forgetTabs).not.toHaveBeenCalled()` to pin the behaviour. One of its sub-commits is literally "fix(mobile): avoid tombstones for uncommitted closes".

The residual symptom the ticket describes — a stale snapshot briefly re-selecting the tab — is real but self-healing, and on the delegated path it is *correct*: if the renderer refused, the tab really is still there.

## What this PR fixes instead

The real defect is narrower and is why the ticket got filed against correct code: `closeMobileSessionTab` has three distinct outcome classes — host-committed, delegated-to-renderer (outcome unknown), and refused — but only the committed one had a named constructor. The other two were bare object literals across ~8 return sites. Nothing at the type level or in review distinguished "I chose not to tombstone" from "I forgot to".

This adds named constructors for all three, so every return site declares its class and the deliberate no-tombstone decision is self-documenting.

## Behaviour preservation

Strictly behaviour-preserving; the existing tests are the guard and all pass unmodified.

- All 8 return sites produce byte-identical objects, including the four distinct `snapshotRepublished` conditionalities (`missing-intent`=true, `unknown-liveness`=`Boolean(snapshot)`, `stale-publication`=`Boolean(snapshot)`, `stale-terminal`=true, `live-host-pty`=`!addressedDeadLeaf`, `retirement-owner`=key absent). `refusedMobileSessionTabClose` spreads the key only when truthy, so no `snapshotRepublished: false` ever reaches the wire.
- `RuntimeMobileSessionTabCloseResult` is serialized to mixed-version clients over RPC, so the brand is type-only (`declare const … unique symbol`, never assigned) — `src/shared/runtime-types.ts` has zero diff.
- All four `expect(forgetTabs).not.toHaveBeenCalled()` assertions intact and unweakened.

## Tests

1183 pass in `orca-runtime.test.ts`, plus a new test asserting the delegated path still records no tombstone, phrased around the outcome class rather than the line number.

