### PR TITLE
fix(ssh): feed the relay-withheld reattach tail into main's model behind an ingest fence (STA-4716)

### DIFF
--- a/src/main/ipc/pty-restore-record-seeding.test.ts
+++ b/src/main/ipc/pty-restore-record-seeding.test.ts
@@ -15,7 +15,9 @@ import {
   registerPtyHandlers,
   clearProviderPtyState,
   getPtyIdForPaneKey,
-  setLocalPtyProvider
+  registerSshPtyProvider,
+  setLocalPtyProvider,
+  unregisterSshPtyProvider
 } from './pty'
 
 vi.mock('electron', () => import('./pty-ipc-mock-registry').then((m) => m.electronModuleMock()))
@@ -125,33 +127,80 @@ describe('registerPtyHandlers', () => {
       { cwd: '/projects/legacy', oscLinks: undefined, preferProviderIfExisting: true }
     )
   })
+  // The relay's reattach replay is routed around main's model by construction (attach returns it as
+  // an RPC payload and deletes the still-queued bytes from the publish queue), so main is the only
+  // party that can put those bytes back. These cases pin who ingests what.
+  // Why a live ingest counter rather than an absent getPtyOutputSequence: a stub that reports 0 for
+  // every read makes every fence assertion below hold no matter when the fence was taken.
+  const replaySeedRuntime = (
+    handle: string,
+    overrides: Record<string, unknown> = {}
+  ): { runtime: Record<string, unknown>; ingest: { sequence: number } } => {
+    const ingest = { sequence: 3 }
+    return {
+      ingest,
+      runtime: {
+        setPtyController: vi.fn(),
+        noteTerminalSpawnCommand: vi.fn(),
+        seedHeadlessTerminal: vi.fn(),
+        hasHeadlessTerminal: vi.fn(() => false),
+        // Mirrors OrcaRuntimeService.appendHeadlessTerminalCatchUp: a fence that no longer matches
+        // the ingest sequence means live bytes already landed, so the older tail is refused.
+        appendHeadlessTerminalCatchUp: vi.fn(
+          (_ptyId: string, _data: string, fence: number) => fence === ingest.sequence
+        ),
+        getPtyOutputSequence: vi.fn(() => ingest.sequence),
+        onPtySpawned: vi.fn(),
+        onPtyData: vi.fn(() => {
+          ingest.sequence += 1
+        }),
+        onPtyExit: vi.fn(),
+        createPreAllocatedTerminalHandle: vi.fn(() => handle),
+        registerPreAllocatedHandleForPty: vi.fn(),
+        preAllocateHandleForPty: vi.fn(),
+        ...overrides
+      }
+    }
+  }
+
+  const replayReattachProvider = (
+    result: Record<string, unknown>,
+    onSpawn?: () => void
+  ): unknown => ({
+    spawn: vi.fn(async () => {
+      onSpawn?.()
+      return result
+    }),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(),
+    shutdown: vi.fn(),
+    sendSignal: vi.fn(),
+    getCwd: vi.fn(),
+    getInitialCwd: vi.fn(),
+    clearBuffer: vi.fn(),
+    acknowledgeDataEvent: vi.fn(),
+    hasChildProcesses: vi.fn(),
+    serialize: vi.fn(),
+    revive: vi.fn(),
+    getDefaultShell: vi.fn(),
+    getProfiles: vi.fn(),
+    onData: vi.fn(() => vi.fn()),
+    onReplay: vi.fn(() => vi.fn()),
+    onExit: vi.fn(() => vi.fn()),
+    listProcesses: vi.fn(async () => []),
+    getForegroundProcess: vi.fn(async () => null)
+  })
+
   it('seeds the headless emulator from an SSH relay reattach replay', async () => {
-    setLocalPtyProvider({
-      spawn: vi.fn(async () => ({
+    setLocalPtyProvider(
+      replayReattachProvider({
         id: 'pty-ssh-reattach',
         isReattach: true,
         replay: 'relay history\r\n'
-      })),
-      write: vi.fn(),
-      resize: vi.fn(),
-      kill: vi.fn(),
-      shutdown: vi.fn(),
-      onData: vi.fn(() => vi.fn()),
-      onExit: vi.fn(() => vi.fn()),
-      listProcesses: vi.fn(async () => []),
-      getForegroundProcess: vi.fn(async () => null)
-    } as never)
-    const runtime = {
-      setPtyController: vi.fn(),
-      noteTerminalSpawnCommand: vi.fn(),
-      seedHeadlessTerminal: vi.fn(),
-      onPtySpawned: vi.fn(),
-      onPtyData: vi.fn(),
-      onPtyExit: vi.fn(),
-      createPreAllocatedTerminalHandle: vi.fn(() => 'handle-ssh-reattach'),
-      registerPreAllocatedHandleForPty: vi.fn(),
-      preAllocateHandleForPty: vi.fn()
-    }
+      }) as never
+    )
+    const { runtime } = replaySeedRuntime('handle-ssh-reattach')
     registerPtyHandlers(mainWindow as never, runtime as never)
 
     await handlers.get('pty:spawn')!(null, { cols: 80, rows: 24 })
@@ -163,6 +212,296 @@ describe('registerPtyHandlers', () => {
       'relay history\r\n'
     )
   })
+
+  it('appends only the unseen replay suffix when the headless emulator already exists', async () => {
+    // The in-place reconnect: the emulator survives the transport, so the fresh-emulator seed
+    // no-ops and only the never-published tail may be written — re-seeding would duplicate the rest.
+    setLocalPtyProvider(
+      replayReattachProvider({
+        id: 'ssh:host-a@@pty-7',
+        isReattach: true,
+        replay: 'BEFORE-OUTAGE|DURING-OUTAGE',
+        replayUnseenChars: 'DURING-OUTAGE'.length
+      }) as never
+    )
+    const { runtime, ingest } = replaySeedRuntime('handle-ssh-catchup', {
+      hasHeadlessTerminal: vi.fn(() => true)
+    })
+    registerPtyHandlers(mainWindow as never, runtime as never)
+
+    const response = await handlers.get('pty:spawn')!(null, {
+      cols: 80,
+      rows: 24,
+      sessionId: 'ssh:host-a@@pty-7'
+    })
+
+    expect(runtime.seedHeadlessTerminal).not.toHaveBeenCalled()
+    // Third argument is the pre-attach ingest fence: the append is only ordered while nothing has
+    // been ingested since the attach was issued.
+    expect(runtime.appendHeadlessTerminalCatchUp).toHaveBeenCalledWith(
+      'ssh:host-a@@pty-7',
+      'DURING-OUTAGE',
+      ingest.sequence
+    )
+    expect(runtime.appendHeadlessTerminalCatchUp).toHaveReturnedWith(true)
+    // The relay's credit accounting is main's alone; the renderer must never arbitrate its paint on
+    // it, and no renderer type declares it.
+    expect((response as Record<string, unknown>).replayUnseenChars).toBeUndefined()
+  })
+
+  it('leaves the model untouched when the unseen length is unknown', async () => {
+    // A legacy relay omits replayUnseenChars. Absent must never be read as zero, and guessing the
+    // overlap by matching bytes would silently duplicate or drop a frame.
+    setLocalPtyProvider(
+      replayReattachProvider({
+        id: 'ssh:host-a@@pty-8',
+        isReattach: true,
+        replay: 'BEFORE-OUTAGE|DURING-OUTAGE'
+      }) as never
+    )
+    const { runtime } = replaySeedRuntime('handle-ssh-legacy', {
+      hasHeadlessTerminal: vi.fn(() => true)
+    })
+    registerPtyHandlers(mainWindow as never, runtime as never)
+
+    await handlers.get('pty:spawn')!(null, {
+      cols: 80,
+      rows: 24,
+      sessionId: 'ssh:host-a@@pty-8'
+    })
+
+    expect(runtime.appendHeadlessTerminalCatchUp).not.toHaveBeenCalled()
+    expect(runtime.seedHeadlessTerminal).not.toHaveBeenCalled()
+  })
+
+  it('skips the catch-up for a non-SSH pty id that reuses this handler', async () => {
+    // Folder-workspace and other remote-runtime panes share this branch; their replay never took
+    // the relay's around-the-model route, so appending it would duplicate bytes the model has.
+    setLocalPtyProvider(
+      replayReattachProvider({
+        id: 'daemon-pty-9',
+        isReattach: true,
+        replay: 'BEFORE-OUTAGE|DURING-OUTAGE',
+        replayUnseenChars: 'DURING-OUTAGE'.length
+      }) as never
+    )
+    const { runtime } = replaySeedRuntime('handle-daemon-reattach', {
+      hasHeadlessTerminal: vi.fn(() => true)
+    })
+    registerPtyHandlers(mainWindow as never, runtime as never)
+
+    await handlers.get('pty:spawn')!(null, { cols: 80, rows: 24, sessionId: 'daemon-pty-9' })
+
+    expect(runtime.appendHeadlessTerminalCatchUp).not.toHaveBeenCalled()
+  })
+
+  it('fences the catch-up on the sequence read before a direct reattach spawn', async () => {
+    // The other route to the same catch-up: no stable-pane owner, the session id alone drives the
+    // reattach. Its fence must be taken beside that spawn for the same reason.
+    const { runtime, ingest } = replaySeedRuntime('handle-ssh-direct-fence', {
+      hasHeadlessTerminal: vi.fn(() => true)
+    })
+    const sequenceAtAttach = ingest.sequence
+    setLocalPtyProvider(
+      replayReattachProvider(
+        {
+          id: 'ssh:host-a@@pty-10',
+          isReattach: true,
+          replay: 'BEFORE-OUTAGE|DURING-OUTAGE',
+          replayUnseenChars: 'DURING-OUTAGE'.length
+        },
+        () => {
+          ingest.sequence += 1
+        }
+      ) as never
+    )
+    registerPtyHandlers(mainWindow as never, runtime as never)
+
+    await handlers.get('pty:spawn')!(null, {
+      cols: 80,
+      rows: 24,
+      sessionId: 'ssh:host-a@@pty-10'
+    })
+
+    expect(runtime.appendHeadlessTerminalCatchUp).toHaveBeenCalledWith(
+      'ssh:host-a@@pty-10',
+      'DURING-OUTAGE',
+      sequenceAtAttach
+    )
+    expect(runtime.appendHeadlessTerminalCatchUp).toHaveReturnedWith(false)
+  })
+
+  it('fences the catch-up on the sequence read before a pre-adoption attach', async () => {
+    // The stable-pane reconnect adopts BEFORE the spawn body runs, with awaits in between: bytes the
+    // relay published after the attach can be ingested first, and the withheld tail predates them.
+    // Read the fence late and it equals the already-advanced sequence, so an out-of-order append
+    // looks legal; taken beside the attach it no longer matches and the runtime refuses.
+    const connectionId = 'ssh-catchup-fence'
+    const tabId = 'tab-catchup-fence'
+    const leafId = '55555555-5555-4555-8555-555555555555'
+    const paneKey = makePaneKey(tabId, leafId)
+    const worktreeId = 'repo-ssh::/remote/catchup-fence'
+    const ptyId = `ssh:${connectionId}@@relay-pty`
+    const { runtime, ingest } = replaySeedRuntime('handle-catchup-fence', {
+      hasHeadlessTerminal: vi.fn(() => true),
+      resolveTerminalPane: vi.fn(() => ({
+        handle: 'handle-catchup-fence',
+        tabId,
+        leafId,
+        ptyId,
+        worktreeId
+      })),
+      beginPtyRegistration: vi.fn(),
+      cancelPendingPtyRegistration: vi.fn(),
+      assertPtyRegistrationAllowed: vi.fn(),
+      registerPty: vi.fn(),
+      getDriver: vi.fn(() => ({ kind: 'host' }))
+    })
+    const sequenceAtAttach = ingest.sequence
+    registerSshPtyProvider(
+      connectionId,
+      replayReattachProvider(
+        {
+          id: ptyId,
+          isReattach: true,
+          replay: 'BEFORE-OUTAGE|DURING-OUTAGE',
+          replayUnseenChars: 'DURING-OUTAGE'.length
+        },
+        () => {
+          // Live bytes crossing the data socket while the attach RPC is in flight.
+          ingest.sequence += 1
+        }
+      ) as never
+    )
+
+    try {
+      registerPtyHandlers(mainWindow as never, runtime as never)
+
+      await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/remote/catchup-fence',
+        connectionId,
+        worktreeId,
+        tabId,
+        leafId,
+        env: {
+          ORCA_PANE_KEY: paneKey,
+          ORCA_TAB_ID: tabId,
+          ORCA_WORKTREE_ID: worktreeId
+        }
+      })
+
+      expect(runtime.appendHeadlessTerminalCatchUp).toHaveBeenCalledWith(
+        ptyId,
+        'DURING-OUTAGE',
+        sequenceAtAttach
+      )
+      expect(runtime.appendHeadlessTerminalCatchUp).toHaveReturnedWith(false)
+    } finally {
+      unregisterSshPtyProvider(connectionId)
+      clearProviderPtyState(ptyId)
+    }
+  })
+
+  it('omits the main-internal replay credit from a deduped pane spawn reply', async () => {
+    // The runtime pane create resolves the reservation; a pty:spawn racing it for the same pane
+    // returns that payload verbatim, so the strip has to sit at the resolve — a per-return-site
+    // strip leaves this route (and the next one added) publishing the field to the renderer.
+    const connectionId = 'ssh-dedupe-strip'
+    const tabId = 'tab-dedupe-strip'
+    const leafId = '66666666-6666-4666-8666-666666666666'
+    const paneKey = makePaneKey(tabId, leafId)
+    const worktreeId = 'repo-ssh::/remote/dedupe-strip'
+    const ptyId = `ssh:${connectionId}@@relay-pty-dedupe`
+    let controller: { spawn?: (opts: Record<string, unknown>) => Promise<unknown> } | null = null
+    const { runtime } = replaySeedRuntime('handle-dedupe-strip', {
+      setPtyController: vi.fn((next: typeof controller) => {
+        controller = next
+      }),
+      hasHeadlessTerminal: vi.fn(() => true),
+      resolveTerminalPane: vi.fn(() => ({
+        handle: 'handle-dedupe-strip',
+        tabId,
+        leafId,
+        ptyId,
+        worktreeId
+      })),
+      beginPtyRegistration: vi.fn(),
+      cancelPendingPtyRegistration: vi.fn(),
+      assertPtyRegistrationAllowed: vi.fn(),
+      registerPty: vi.fn(),
+      getDriver: vi.fn(() => ({ kind: 'host' }))
+    })
+    let releaseSpawn!: () => void
+    let spawnStarted!: () => void
+    const spawnGate = new Promise<void>((resolve) => {
+      releaseSpawn = resolve
+    })
+    const spawnEntered = new Promise<void>((resolve) => {
+      spawnStarted = resolve
+    })
+    const gatedSpawn = vi.fn(async () => {
+      spawnStarted()
+      await spawnGate
+      return {
+        id: ptyId,
+        isReattach: true,
+        replay: 'BEFORE-OUTAGE|DURING-OUTAGE',
+        replayUnseenChars: 'DURING-OUTAGE'.length
+      }
+    })
+    registerSshPtyProvider(connectionId, {
+      ...(replayReattachProvider({}) as Record<string, unknown>),
+      spawn: gatedSpawn
+    } as never)
+
+    try {
+      registerPtyHandlers(mainWindow as never, runtime as never)
+
+      const runtimeSpawn = controller!.spawn!({
+        cols: 80,
+        rows: 24,
+        cwd: '/remote/dedupe-strip',
+        connectionId,
+        worktreeId,
+        tabId,
+        leafId,
+        preAllocatedHandle: 'handle-dedupe-strip'
+      })
+      // The reservation exists once the provider spawn is in flight, so the racing IPC call below
+      // takes the dedupe early-return instead of starting a second spawn.
+      await spawnEntered
+      const dedupedSpawn = handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/remote/dedupe-strip',
+        connectionId,
+        worktreeId,
+        tabId,
+        leafId,
+        env: {
+          ORCA_PANE_KEY: paneKey,
+          ORCA_TAB_ID: tabId,
+          ORCA_WORKTREE_ID: worktreeId
+        }
+      })
+      releaseSpawn()
+      await runtimeSpawn
+      const deduped = (await dedupedSpawn) as Record<string, unknown>
+
+      // Proves this really is the forwarded reservation payload and not a fresh spawn result.
+      expect(gatedSpawn).toHaveBeenCalledTimes(1)
+      expect(deduped.id).toBe(ptyId)
+      expect(deduped.replay).toBe('BEFORE-OUTAGE|DURING-OUTAGE')
+      expect(deduped.isReattach).toBe(true)
+      expect('replayUnseenChars' in deduped).toBe(false)
+    } finally {
+      unregisterSshPtyProvider(connectionId)
+      clearProviderPtyState(ptyId)
+    }
+  })
+
   // STA repro (post-restart blind orchestrator): reattach restore payloads
   // arrive as spawn RPC results, never through onPtyData, so without record
   // seeding `terminal list` reported connected terminals with empty

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -96,6 +96,11 @@ import {
   isSshPtyNotFoundError
 } from '../providers/ssh-pty-errors'
 import { parseAppSshPtyId, toAppSshPtyId, toRelaySshPtyId } from '../providers/ssh-pty-id'
+import {
+  applySshReattachReplayModelCatchUp,
+  capturePtyModelIngestFence,
+  type PtyModelIngestFence
+} from './ssh-reattach-replay-model-catchup'
 import { createPtySpawnTiming } from './pty-spawn-timing'
 import {
   isSafePtySessionId,
@@ -670,19 +675,31 @@ function rejectPaneSpawnReservation(
   }
 }
 
+// Why here: relay credit accounting is main's business alone, and dedupe waiters forward the
+// resolved reservation payload verbatim to the renderer — stripping at each return site instead
+// leaves the next early-return free to leak it again.
+function stripMainInternalSpawnFields<T extends Partial<PtySpawnResult>>(response: T): T {
+  if (response.replayUnseenChars === undefined) {
+    return response
+  }
+  const { replayUnseenChars: _mainInternal, ...rest } = response
+  return rest as T
+}
+
 function resolvePaneSpawnReservation<T extends PaneSpawnReservationResult>(
   paneKey: string | null | undefined,
   reservation: PaneSpawnReservation | null | undefined,
   response: T
 ): T {
+  const stripped = stripMainInternalSpawnFields(response)
   if (!reservation) {
-    return response
+    return stripped
   }
-  reservation.resolve(response)
+  reservation.resolve(stripped)
   if (paneKey) {
     clearPaneSpawnReservation(paneKey, reservation)
   }
-  return response
+  return stripped
 }
 
 type StablePaneOwner = {
@@ -698,6 +715,8 @@ type StablePaneOwner = {
 type StablePaneAdoption = {
   result: PtySpawnResult
   owner: StablePaneOwner
+  /** Pre-attach model fence, minted beside the attach RPC; shared adopters consume it once. */
+  modelIngestFence: PtyModelIngestFence | null
   materialized?: true
 } | null
 const stablePaneAdoptionsByOwnerKey = new Map<string, Promise<StablePaneAdoption>>()
@@ -837,6 +856,15 @@ type StablePaneSpawnContext = {
   connectionId?: string | null
   resolveOwner?: () => StablePaneOwner | null
   onFreshSpawn?: (result: PtySpawnResult) => void
+  /** Fence subject for the non-owner spawn below, which may still come back as a reattach. */
+  expectedPtyId?: string
+}
+
+/** Every attach that can produce a relay replay returns its pre-attach fence beside the result. */
+type StablePaneAttachOutcome = {
+  result: PtySpawnResult
+  owner: StablePaneOwner | null
+  modelIngestFence: PtyModelIngestFence | null
 }
 
 function stablePanePersistenceFence(
@@ -882,9 +910,12 @@ function persistAdmittedStablePaneBinding(args: {
 
 async function attachStablePaneOwner(
   args: StablePaneSpawnContext & { owner: StablePaneOwner }
-): Promise<{ result: PtySpawnResult; owner: StablePaneOwner } | null> {
+): Promise<(StablePaneAttachOutcome & { owner: StablePaneOwner }) | null> {
   const { owner, provider, runtime, spawnOptions } = args
   let result: PtySpawnResult
+  // Why on this line: this spawn IS the reattach whose replay bypasses the model, so the fence must
+  // predate it — read after the await, live bytes have already advanced it and it proves nothing.
+  const modelIngestFence = capturePtyModelIngestFence(runtime, owner.ptyId)
   try {
     result = await provider.spawn({
       ...spawnOptions,
@@ -946,21 +977,22 @@ async function attachStablePaneOwner(
   ) {
     throw new Error('terminal_pane_owner_changed')
   }
-  return { result, owner }
+  return { result, owner, modelIngestFence }
 }
 
-async function spawnForStablePane(
-  args: StablePaneSpawnContext
-): Promise<{ result: PtySpawnResult; owner: StablePaneOwner | null }> {
+async function spawnForStablePane(args: StablePaneSpawnContext): Promise<StablePaneAttachOutcome> {
   if (args.owner) {
     const attached = await attachStablePaneOwner({ ...args, owner: args.owner })
     if (attached) {
       return attached
     }
   }
+  // Why fenced too: with no stable-pane owner a plain spawn carrying sessionId is still the SSH
+  // reattach, and its replay is withheld from the model exactly the same way.
+  const modelIngestFence = capturePtyModelIngestFence(args.runtime, args.expectedPtyId)
   const result = await args.provider.spawn(args.spawnOptions)
   args.onFreshSpawn?.(result)
-  return { result, owner: null }
+  return { result, owner: null, modelIngestFence }
 }
 
 function settlePendingPaneSerializer(paneKey: string, gen: number): boolean {
@@ -4473,6 +4505,9 @@ export function registerPtyHandlers(
           ...(owner.incarnationId ? { incarnationId: owner.incarnationId } : {})
         },
         owner,
+        // Why never fenced: this pane's attach was another spawn's, and that spawn already owns the
+        // one chance to ingest its withheld tail — a second append would duplicate it.
+        modelIngestFence: null,
         materialized: true as const
       }
     }
@@ -6141,6 +6176,11 @@ export function registerPtyHandlers(
       // before they existed, so the claim must not erase what the pane may
       // have scanned from those bytes live.
       let snapshotKittyFlagsCoverReconciledSeq = true
+      // Why hoisted: the reattach replay catch-up may only append to the model when NOTHING was
+      // ingested during the attach RPC — the withheld tail predates any such bytes, so appending it
+      // behind them would garble the emulator rather than merely leave it stale. Minted beside the
+      // attach itself (see capturePtyModelIngestFence), never re-read down here.
+      let modelIngestFence: PtyModelIngestFence | null = null
       let preparedProvisionalExecutionContext = false
       let releaseWorktreeSpawn: (() => void) | undefined
       try {
@@ -6737,6 +6777,7 @@ export function registerPtyHandlers(
                 owner: stablePaneOwnerCandidate,
                 worktreeId: args.worktreeId,
                 connectionId: args.connectionId,
+                ...(expectedPtyId ? { expectedPtyId } : {}),
                 resolveOwner: () =>
                   resolveStablePaneOwner(
                     runtime,
@@ -6748,6 +6789,9 @@ export function registerPtyHandlers(
               })
           result = stablePaneSpawn.result
           stablePaneOwner = stablePaneSpawn.owner
+          // Why carried rather than read here: the pre-adopted branch attached long before this
+          // line, with awaits in between during which live bytes can advance the counter.
+          modelIngestFence = stablePaneSpawn.modelIngestFence
           if (
             stablePaneOwner &&
             isMintedSessionId &&
@@ -6999,6 +7043,7 @@ export function registerPtyHandlers(
 
         // Why: seed the headless emulator before registerPty so concurrent live PTY data lands on top of the seed, not replacing it (mobile keeps the daemon-restored scrollback).
         // Skip when the renderer will be authoritative — its xterm buffer is richer than the daemon snapshot.
+        let seededHeadlessFromReplay = false
         if (runtime && !rendererPreSignaled && !rendererAlreadyRegistered) {
           const snapshotSeedSize =
             typeof result.snapshotCols === 'number' && typeof result.snapshotRows === 'number'
@@ -7038,9 +7083,27 @@ export function registerPtyHandlers(
             // Why: the relay reattach replay is the one restore main never ingests, so without
             // this seed its model is a mere suffix of what the renderer painted — and a later
             // park-reveal would outrank the fuller relay replay with that fragment.
-            runtime.seedHeadlessTerminal(result.id, result.replay)
+            // Why probed rather than just called: seedHeadlessTerminal no-ops on an existing
+            // emulator, and an emulator that survived an in-place reconnect needs the unseen
+            // suffix appended below instead — only a fresh one ends up holding exactly this replay.
+            seededHeadlessFromReplay = !runtime.hasHeadlessTerminal(result.id)
+            if (seededHeadlessFromReplay) {
+              runtime.seedHeadlessTerminal(result.id, result.replay)
+            }
           }
         }
+        // Why here and not in the provider: only main owns the model, and only main knows whether
+        // the seed above already ingested this replay. Without this the model stays stale by the
+        // outage and every later park-reveal repaints that stale frame.
+        applySshReattachReplayModelCatchUp({
+          runtime,
+          ptyId: result.id,
+          isReattach: result.isReattach === true,
+          replay: result.replay,
+          replayUnseenChars: result.replayUnseenChars,
+          seededFromReplay: seededHeadlessFromReplay,
+          modelIngestFence
+        })
         if (
           typeof args.worktreeId === 'string' &&
           args.worktreeId.length > 0 &&
@@ -7154,6 +7217,8 @@ export function registerPtyHandlers(
           }
         }
         const response = {
+          // Why no replayUnseenChars strip here: resolvePaneSpawnReservation drops main-internal
+          // fields on every reply path, including dedupe early-returns this literal never reaches.
           ...result,
           // Why both or neither: a pane can only adopt proven kitty flags together
           // with the sequence boundary they describe.

--- a/src/main/ipc/ssh-reattach-replay-model-catchup.test.ts
+++ b/src/main/ipc/ssh-reattach-replay-model-catchup.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi, type Mock } from 'vitest'
+import {
+  applySshReattachReplayModelCatchUp,
+  capturePtyModelIngestFence
+} from './ssh-reattach-replay-model-catchup'
+
+const catchUpRuntime = (): {
+  hasHeadlessTerminal: (ptyId: string) => boolean
+  appendHeadlessTerminalCatchUp: Mock<(ptyId: string, data: string, fence: number) => boolean>
+} => ({
+  hasHeadlessTerminal: () => true,
+  appendHeadlessTerminalCatchUp: vi.fn((_ptyId: string, _data: string, _fence: number) => true)
+})
+
+const attachArgs = (
+  runtime: ReturnType<typeof catchUpRuntime>,
+  fence: ReturnType<typeof capturePtyModelIngestFence>
+): Parameters<typeof applySshReattachReplayModelCatchUp>[0] => ({
+  runtime,
+  ptyId: 'ssh:host-a@@pty-1',
+  isReattach: true,
+  replay: 'BEFORE|DURING',
+  replayUnseenChars: 'DURING'.length,
+  seededFromReplay: false,
+  modelIngestFence: fence
+})
+
+describe('applySshReattachReplayModelCatchUp', () => {
+  it('ingests the withheld tail once per attach, even when adopters share it', () => {
+    // Deduped stable-pane adoptions hand one attach result to several callers; the second must not
+    // re-append the tail the first already ingested.
+    const runtime = catchUpRuntime()
+    const fence = capturePtyModelIngestFence(
+      { getPtyOutputSequence: () => 12 },
+      'ssh:host-a@@pty-1'
+    )
+
+    expect(applySshReattachReplayModelCatchUp(attachArgs(runtime, fence))).toBe(true)
+    expect(applySshReattachReplayModelCatchUp(attachArgs(runtime, fence))).toBe(false)
+    expect(runtime.appendHeadlessTerminalCatchUp).toHaveBeenCalledTimes(1)
+    expect(runtime.appendHeadlessTerminalCatchUp).toHaveBeenCalledWith(
+      'ssh:host-a@@pty-1',
+      'DURING',
+      12
+    )
+  })
+
+  it('refuses a fence minted for a different pty', () => {
+    // A fresh spawn after a failed adoption returns a different id; that attach never withheld this
+    // tail, so its fence proves nothing about this model.
+    const runtime = catchUpRuntime()
+    const fence = capturePtyModelIngestFence({ getPtyOutputSequence: () => 4 }, 'ssh:host-a@@pty-9')
+
+    expect(applySshReattachReplayModelCatchUp(attachArgs(runtime, fence))).toBe(false)
+    expect(runtime.appendHeadlessTerminalCatchUp).not.toHaveBeenCalled()
+  })
+
+  it('refuses when no fence was minted beside the attach', () => {
+    const runtime = catchUpRuntime()
+
+    expect(applySshReattachReplayModelCatchUp(attachArgs(runtime, null))).toBe(false)
+    expect(runtime.appendHeadlessTerminalCatchUp).not.toHaveBeenCalled()
+  })
+})
+
+describe('capturePtyModelIngestFence', () => {
+  it('refuses to invent a sequence a runtime cannot report', () => {
+    // Reading absence as 0 would let the very first live byte pass the fence check.
+    expect(capturePtyModelIngestFence({}, 'ssh:host-a@@pty-1')).toBeNull()
+    expect(capturePtyModelIngestFence(undefined, 'ssh:host-a@@pty-1')).toBeNull()
+    expect(capturePtyModelIngestFence({ getPtyOutputSequence: () => 0 }, undefined)).toBeNull()
+    expect(
+      capturePtyModelIngestFence({ getPtyOutputSequence: () => 0 }, 'ssh:host-a@@pty-1')
+    ).toEqual({ ptyId: 'ssh:host-a@@pty-1', sequence: 0 })
+  })
+})

--- a/src/main/ipc/ssh-reattach-replay-model-catchup.ts
+++ b/src/main/ipc/ssh-reattach-replay-model-catchup.ts
@@ -1,0 +1,101 @@
+import { parseAppSshPtyId } from '../providers/ssh-pty-id'
+
+type HeadlessCatchUpRuntime = {
+  hasHeadlessTerminal: (ptyId: string) => boolean
+  appendHeadlessTerminalCatchUp: (
+    ptyId: string,
+    data: string,
+    ingestedSequenceFence: number
+  ) => boolean
+}
+
+/**
+ * The model's ingest sequence as it stood immediately BEFORE an attach RPC was issued.
+ *
+ * Only `capturePtyModelIngestFence`, called on the line before the `provider.spawn` that produces
+ * the replay, may mint one; it then travels WITH the attach result so no later reader can mistake a
+ * post-attach sequence (already advanced by live bytes) for a pre-attach one.
+ */
+export type PtyModelIngestFence = {
+  readonly ptyId: string
+  readonly sequence: number
+  /** Why mutable: deduped adoptions hand one attach result to several callers; the tail is theirs once. */
+  consumed?: boolean
+}
+
+/** MUST be called on the line before the attach RPC — a fence read after it proves nothing. */
+export function capturePtyModelIngestFence(
+  runtime: { getPtyOutputSequence?: (ptyId: string) => number } | null | undefined,
+  ptyId: string | undefined
+): PtyModelIngestFence | null {
+  if (!ptyId) {
+    return null
+  }
+  // Why not `?? 0`: a runtime that cannot report its ingest sequence cannot prove ordering either.
+  const sequence = runtime?.getPtyOutputSequence?.(ptyId)
+  return typeof sequence === 'number' ? { ptyId, sequence } : null
+}
+
+/**
+ * Close the one hole in main's terminal model: the relay's reattach replay.
+ *
+ * Every other SSH byte enters the model through acceptPtyData, but attach hands its replay to the
+ * client as an RPC payload AND deletes the still-queued bytes from the publish queue, so those
+ * bytes never reach main at all. Appending that exact suffix here keeps the model from drifting
+ * permanently short — which is what made a later park-reveal repaint a frame stale by the outage,
+ * and what made the reconnect paint gate read `alternateScreen` off a model that never saw the
+ * app leave the alternate screen.
+ *
+ * DELIBERATELY NOT a coverage proof, and nothing downstream is told it is: `replayUnseenChars`
+ * names what THIS attach withholds, not what the whole tail-from-spawn replay contains, so bytes an
+ * earlier attach dropped or bytes that predate this emulator stay unaccounted. Sizing the overlap by
+ * matching bytes is deliberately not attempted either: repeated TUI frames alias, so a near-miss
+ * silently duplicates or drops a frame.
+ *
+ * Returns whether a catch-up write was issued (the seed above, or a fully-delivered replay, needs
+ * none).
+ */
+export function applySshReattachReplayModelCatchUp(args: {
+  runtime: HeadlessCatchUpRuntime | null | undefined
+  ptyId: string
+  isReattach: boolean
+  replay: string | undefined
+  replayUnseenChars: number | undefined
+  /** The fresh-emulator seed above already wrote this exact replay (post-relaunch attach). */
+  seededFromReplay: boolean
+  /**
+   * The fence minted beside the attach RPC that produced `replay`. The withheld tail predates every
+   * byte the relay published after that RPC, so the append is only ordered while nothing has been
+   * ingested since; a missing fence — no attach of ours, or a deduped one already ingested — can
+   * never be proven and refuses.
+   */
+  modelIngestFence: PtyModelIngestFence | null | undefined
+}): boolean {
+  const unseen = args.replayUnseenChars
+  const fence = args.modelIngestFence
+  if (
+    !args.isReattach ||
+    !args.replay ||
+    args.seededFromReplay ||
+    !args.runtime ||
+    unseen === undefined ||
+    unseen <= 0 ||
+    unseen > args.replay.length ||
+    !fence ||
+    fence.consumed === true ||
+    fence.ptyId !== args.ptyId
+  ) {
+    return false
+  }
+  // Why gated on the SSH id: folder-workspace and other remote-runtime PTYs reuse this handler, and
+  // their replay never took the relay's around-the-model route.
+  if (parseAppSshPtyId(args.ptyId) === null || !args.runtime.hasHeadlessTerminal(args.ptyId)) {
+    return false
+  }
+  fence.consumed = true
+  return args.runtime.appendHeadlessTerminalCatchUp(
+    args.ptyId,
+    args.replay.slice(-unseen),
+    fence.sequence
+  )
+}

--- a/src/main/providers/pty-spawn-result.ts
+++ b/src/main/providers/pty-spawn-result.ts
@@ -64,6 +64,10 @@ export type PtySpawnResult = {
   /** Buffered output returned by relay pty.attach. Unlike snapshot, this is
    *  incremental scrollback and must not clear the terminal before replay. */
   replay?: string
+  /** Main-internal: trailing code units of `replay` that THIS attach withheld from
+   *  the modeled stream, so main can append exactly them to its headless model.
+   *  Absent means unknown and must never be read as zero. Never sent to the renderer. */
+  replayUnseenChars?: number
   /** True when the caller requested reattach (sessionId was provided) but the
    *  relay PTY was gone (grace window elapsed). The renderer uses this to show
    *  a brief "Session expired — new shell started" message. */

--- a/src/main/providers/ssh-pty-session-reattach.ts
+++ b/src/main/providers/ssh-pty-session-reattach.ts
@@ -21,6 +21,8 @@ import type { SshPtyReceivingActivationLease } from './ssh-pty-notification-rout
 
 export type SshPtyAttachResult = {
   replay?: string
+  /** Trailing code units of `replay` this attach withheld from the modeled stream. */
+  replayUnseenChars?: number
   incarnationId?: PtyIncarnationId
   sourceRecovery?: PtySourceRecoveryResult
   sourceActivation?: PtySourceReceivingActivation
@@ -41,6 +43,7 @@ export function parseSshPtyAttachResult(value: unknown): SshPtyAttachResult {
   }
   const result = value as {
     replay?: unknown
+    replayUnseenChars?: unknown
     incarnationId?: unknown
     sourceRecovery?: unknown
     sourceActivation?: unknown
@@ -48,6 +51,14 @@ export function parseSshPtyAttachResult(value: unknown): SshPtyAttachResult {
   if (result.replay !== undefined && typeof result.replay !== 'string') {
     throw new Error('Invalid SSH PTY attach replay')
   }
+  // Why dropped rather than rejected: a nonsense count from an old/odd relay must degrade to
+  // "coverage unknown", which is the legacy behavior, not fail the whole reattach.
+  const replayUnseenChars =
+    typeof result.replay === 'string' &&
+    nonNegativeInteger(result.replayUnseenChars) &&
+    Number(result.replayUnseenChars) <= result.replay.length
+      ? Number(result.replayUnseenChars)
+      : undefined
   if (result.incarnationId !== undefined && !isPtyIncarnationId(result.incarnationId)) {
     // Why: a present-but-invalid identity cannot safely fence delayed exits from a reused relay id.
     throw new Error('Invalid SSH PTY attach incarnation')
@@ -66,6 +77,7 @@ export function parseSshPtyAttachResult(value: unknown): SshPtyAttachResult {
   }
   return {
     ...(typeof result.replay === 'string' ? { replay: result.replay } : {}),
+    ...(replayUnseenChars === undefined ? {} : { replayUnseenChars }),
     ...(isPtyIncarnationId(result.incarnationId) ? { incarnationId: result.incarnationId } : {}),
     ...(sourceRecovery ? { sourceRecovery } : {}),
     ...(activation ? { sourceActivation: activation } : {})
@@ -214,6 +226,9 @@ export async function reattachSshPtySession(args: {
       id: toAppSshPtyId(args.connectionId, relaySessionId),
       isReattach: true,
       ...(attachResult.replay ? { replay: attachResult.replay } : {}),
+      ...(attachResult.replay && attachResult.replayUnseenChars !== undefined
+        ? { replayUnseenChars: attachResult.replayUnseenChars }
+        : {}),
       ...(attachResult.incarnationId ? { incarnationId: attachResult.incarnationId } : {}),
       ...(attachResult.sourceRecovery ? { sourceRecovery: attachResult.sourceRecovery } : {}),
       ...(attachResult.sourceActivation ? { sourceActivation: attachResult.sourceActivation } : {}),

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -11254,6 +11254,70 @@ describe('OrcaRuntimeService', () => {
     expect(snapshot?.cwd).toBe('/projects/restored')
   })
 
+  // The SSH relay's reattach replay never passes through acceptPtyData, and seedHeadlessTerminal
+  // refuses an existing emulator, so an in-place reconnect leaves the model short by the outage
+  // forever without this append.
+  it('appends an SSH reattach catch-up onto the existing headless emulator', async () => {
+    const runtime = createRuntime()
+    syncSinglePty(runtime, 'pty-1')
+    runtime.onPtyData('pty-1', 'before outage\r\n', 100)
+    const fence = runtime.getPtyOutputSequence('pty-1')
+
+    expect(runtime.hasHeadlessTerminal('pty-1')).toBe(true)
+    expect(runtime.appendHeadlessTerminalCatchUp('pty-1', 'during outage\r\n', fence)).toBe(true)
+
+    const snapshot = await runtime.serializeMainTerminalBuffer('pty-1', { scrollbackRows: 100 })
+    expect(snapshot?.data).toContain('before outage')
+    expect(snapshot?.data).toContain('during outage')
+  })
+
+  it('refuses an SSH reattach catch-up once live bytes were ingested past the fence', () => {
+    // The withheld tail predates whatever the relay published after it; appending it behind newer
+    // bytes would garble the emulator instead of merely leaving the model stale.
+    const runtime = createRuntime()
+    syncSinglePty(runtime, 'pty-1')
+    runtime.onPtyData('pty-1', 'before outage\r\n', 100)
+    const fence = runtime.getPtyOutputSequence('pty-1')
+    runtime.onPtyData('pty-1', 'raced past the attach\r\n', 101)
+
+    expect(runtime.appendHeadlessTerminalCatchUp('pty-1', 'during outage\r\n', fence)).toBe(false)
+  })
+
+  it('refuses an SSH reattach catch-up when no headless emulator exists', () => {
+    const runtime = createRuntime()
+    syncSinglePty(runtime, 'pty-1')
+
+    expect(runtime.hasHeadlessTerminal('pty-1')).toBe(false)
+    // Why false and not a lazy create: the caller must fall back to a seed, which owns the
+    // dimensions and the "this is the whole buffer" semantics an append cannot claim.
+    expect(
+      runtime.appendHeadlessTerminalCatchUp(
+        'pty-1',
+        'during outage\r\n',
+        runtime.getPtyOutputSequence('pty-1')
+      )
+    ).toBe(false)
+  })
+
+  it('keeps an SSH reattach catch-up free of live-output side effects', async () => {
+    const runtime = createRuntime()
+    syncSinglePty(runtime, 'pty-1')
+    runtime.onPtyData('pty-1', 'before outage\r\n', 100)
+    const before = (await runtime.listTerminals()).terminals[0]
+
+    // Historical bytes: no waiters, no transcript tail, no lastOutputAt bump, no query replies.
+    runtime.appendHeadlessTerminalCatchUp(
+      'pty-1',
+      'during outage\x1b[?62;c\r\n',
+      runtime.getPtyOutputSequence('pty-1')
+    )
+    await runtime.serializeMainTerminalBuffer('pty-1', { scrollbackRows: 100 })
+    const after = (await runtime.listTerminals()).terminals[0]
+
+    expect(typeof before.lastOutputAt).toBe('number')
+    expect(after.lastOutputAt).toBe(before.lastOutputAt)
+  })
+
   it('adopts OSC7 host metadata from seeded headless terminal scrollback', async () => {
     const runtime = createRuntime()
     syncSinglePty(runtime, 'pty-1')

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -12663,6 +12663,54 @@ export class OrcaRuntimeService {
       })
   }
 
+  /** Whether a headless emulator already backs this PTY — the seed/catch-up fork. */
+  hasHeadlessTerminal(ptyId: string): boolean {
+    return this.headlessTerminals.has(ptyId)
+  }
+
+  /**
+   * Append bytes the model never accepted onto the EXISTING headless emulator.
+   *
+   * Why separate from seedHeadlessTerminal: that one refuses when an emulator exists (re-seeding
+   * duplicates every byte), which is always the case on an in-place SSH reconnect — yet the relay's
+   * reattach replay is routed around acceptPtyData, so without this the model stays short by the
+   * outage forever. Seed semantics on purpose: no forwardQueryReplies (historical queries must
+   * answer no one), no renderer projection (the renderer paints this same tail itself), no
+   * waiters/transcripts/lastOutputAt (these are historical bytes, not fresh activity).
+   *
+   * `ingestedSequenceFence` is the ingest sequence the caller read BEFORE the attach: the withheld
+   * tail predates everything published after it, so appending it once live bytes have already been
+   * ingested would garble the emulator instead of merely leaving it stale. onPtyData advances that
+   * counter synchronously at ingestion, so an unmoved fence also covers writes still queued on the
+   * chain.
+   *
+   * Returns false when there is no emulator to append to (the caller can fall back to a seed) or
+   * when the fence moved.
+   */
+  appendHeadlessTerminalCatchUp(
+    ptyId: string,
+    data: string,
+    ingestedSequenceFence: number
+  ): boolean {
+    if (!data || this.getPtyOutputSequence(ptyId) !== ingestedSequenceFence) {
+      return false
+    }
+    const state = this.headlessTerminals.get(ptyId)
+    if (!state) {
+      return false
+    }
+    this.recordOsc7MetadataForPty(ptyId, data)
+    this.recordRecentPtyOutputForPathProvenance(ptyId, data)
+    state.writeChain = state.writeChain
+      .then(async () => {
+        await state.emulator.write(data)
+      })
+      .catch(() => {
+        // Best-effort: live data keeps populating the emulator even if the catch-up write fails.
+      })
+    return true
+  }
+
   // Why: reattach/cold-restore/replay payloads arrive as spawn RPC results and
   // never pass through onPtyData, so after a relaunch the records backing
   // `terminal list`/`terminal read` stayed blank while the session was alive.

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -2501,6 +2501,9 @@ export class SshRelaySession {
         return
       }
       if (!recoveryRequest && !targetedDeliveryRecovery) {
+        // Why no model catch-up here: this limb runs only when sourceRecoveryRequest returned
+        // undefined, i.e. the owner has no outputFlowControl — which is exactly when the relay is in
+        // legacy fan-out and can never name an unseen count. There is nothing provable to ingest.
         this.forwardReattachReplay(appPtyId, attachResult.replay ?? '')
       }
       sourceActivationLease?.commit()

--- a/src/relay/pty-handler-attach-replay.test.ts
+++ b/src/relay/pty-handler-attach-replay.test.ts
@@ -204,6 +204,85 @@ describe('PtyHandler', () => {
     expect(result).toEqual({ incarnationId: spawn.incarnationId })
   })
 
+  // The attach replay is handed to the client AND deleted from the publish queue, so those bytes
+  // never reach the client's terminal model through the normal delivery. Naming how many trailing
+  // code units that is lets the client put them back instead of guessing at the overlap.
+  // The acknowledgement predicate this stubs out is covered against the real credit ledger in
+  // relay-pty-source-delivery-acknowledged.test.ts; here it is only a delegation boundary.
+  const attachWithQueuedOutput = async (
+    publicationOverrides: Record<string, unknown>
+  ): Promise<Record<string, unknown>> => {
+    let dataCallback: ((data: string) => void) | undefined
+    mockPtySpawn.mockReturnValue({
+      ...mockPtyInstance,
+      onData: vi.fn((cb: (data: string) => void) => {
+        dataCallback = cb
+      }),
+      onExit: vi.fn()
+    })
+    await spawnPty()
+    const publish = vi.fn().mockReturnValueOnce(true).mockReturnValue(false)
+    handler.setSourcePublication({
+      activate: vi.fn(() => 'existing'),
+      accepts: vi.fn(() => true),
+      publish,
+      dispose: vi.fn(),
+      ...publicationOverrides
+    } as never)
+    dataCallback!('delivered before the blip')
+    vi.advanceTimersByTime(8)
+    // The transport dies here: publishing fails, so these bytes stay queued and are exactly the
+    // suffix of the replay the consumer's model never sees.
+    dataCallback!('|never published')
+    vi.advanceTimersByTime(8)
+    return (await attachPty({
+      id: 'pty-1',
+      requireReplay: true,
+      suppressReplayNotification: true
+    })) as unknown as Record<string, unknown>
+  }
+
+  it('reports the pending output chars dropped at attach so the client can reconcile its model', async () => {
+    const result = await attachWithQueuedOutput({
+      deliveryFullyAcknowledged: vi.fn(() => true)
+    })
+
+    expect(result.replay).toBe('delivered before the blip|never published')
+    expect(result.replayUnseenChars).toBe('|never published'.length)
+    expect((result.replay as string).slice(-(result.replayUnseenChars as number))).toBe(
+      '|never published'
+    )
+  })
+
+  it('omits the unseen count when the delivery has bytes it cannot prove arrived', async () => {
+    // An unacked in-flight tail is missing from the consumer's model too, and it is never resent —
+    // the relay cannot name how much, so it must say nothing rather than under-report.
+    const result = await attachWithQueuedOutput({
+      deliveryFullyAcknowledged: vi.fn(() => false)
+    })
+
+    expect(result.replay).toBe('delivered before the blip|never published')
+    expect(result.replayUnseenChars).toBeUndefined()
+  })
+
+  it('omits the unseen count for a spawn-time replay with no source delivery', async () => {
+    let dataCallback: ((data: string) => void) | undefined
+    mockPtySpawn.mockReturnValue({
+      ...mockPtyInstance,
+      onData: vi.fn((cb: (data: string) => void) => {
+        dataCallback = cb
+      }),
+      onExit: vi.fn()
+    })
+    const spawn = await spawnPty()
+    dataCallback!('buffered output')
+
+    const result = await attachPty({ id: 'pty-1', suppressReplayNotification: true })
+
+    // Legacy fan-out has no acknowledgements at all, so nothing here is provable.
+    expect(result).toEqual({ incarnationId: spawn.incarnationId, replay: 'buffered output' })
+  })
+
   it('requires restore when the V1 pending-send recovery fence expires', async () => {
     const spawn = await spawnPty()
     const waitForPendingSend = vi.fn().mockResolvedValue(false)

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -1728,6 +1728,7 @@ export class PtyHandler {
   ): Promise<{
     incarnationId: string
     replay?: string
+    replayUnseenChars?: number
     sourceRecovery?: PtySourceRecoveryResult
     sourceActivation?: PtySourceReceivingActivation
   }> {
@@ -1814,6 +1815,7 @@ export class PtyHandler {
     // Why: retain replay buffers so later restarts receive full history.
     const replay = managed.buffered.read()
     if (replay) {
+      const replayUnseenChars = this.replayUnseenChars(id, replay, activation)
       // Why: drop pending batched bytes already in the replay buffer so attach doesn't render them twice.
       this.pendingOutputByPty.delete(id)
       this.clearOutputFlushTimerIfIdle()
@@ -1822,6 +1824,7 @@ export class PtyHandler {
         return {
           incarnationId: managed.incarnationId,
           replay,
+          ...(replayUnseenChars === undefined ? {} : { replayUnseenChars }),
           ...(sourceActivation ? { sourceActivation } : {})
         }
       }
@@ -1831,6 +1834,30 @@ export class PtyHandler {
       incarnationId: managed.incarnationId,
       ...(sourceActivation ? { sourceActivation } : {})
     }
+  }
+
+  /**
+   * How many trailing code units of `replay` THIS attach withholds from the modeled stream, or
+   * undefined when the relay cannot name that number exactly.
+   *
+   * Scope, stated narrowly on purpose: only the still-queued bytes deleted just below qualify.
+   * emitIngressData appends the same string to the replay buffer and to the publish queue in one
+   * step, and the queue drains strictly from the front, so the queue is a contiguous code-unit
+   * suffix of the replay. It is the consumer's exact gap only when the surviving delivery has
+   * acknowledged everything it received (an unacked in-flight tail died in the socket and is never
+   * resent — unbounded and unnameable) and only when it IS the surviving delivery ('opened' means a
+   * fresh ledger whose zeroed counters say nothing about what the dead one lost). Legacy fan-out has
+   * no acks at all, so it never qualifies. This says nothing about bytes an EARLIER attach dropped.
+   */
+  private replayUnseenChars(id: string, replay: string, activation: unknown): number | undefined {
+    if (activation !== 'existing' || !this.sourcePublication?.deliveryFullyAcknowledged(id)) {
+      return undefined
+    }
+    const pendingChars = (this.pendingOutputByPty.get(id) ?? []).reduce(
+      (total, pending) => total + pending.data.length,
+      0
+    )
+    return pendingChars <= replay.length ? pendingChars : undefined
   }
 
   private writeData(params: Record<string, unknown>): void {

--- a/src/relay/relay-pty-source-delivery-acknowledged.test.ts
+++ b/src/relay/relay-pty-source-delivery-acknowledged.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import type { PtySourceDeliveryIdentity } from '../shared/pty-source-credit-contract'
+import { RelayPtySourceCreditLedger } from './pty-source-credit-ledger'
+import { ptySourceDeliveryFullyAcknowledged } from './relay-pty-source-output'
+import type { SshPtyConsumerSessionAdapter } from './ssh-pty-consumer-session-adapter'
+
+const IDENTITY: PtySourceDeliveryIdentity = {
+  id: 'pty-1',
+  providerGeneration: 1,
+  clientGeneration: 2,
+  ownerGeneration: 3,
+  ptyIncarnation: 'incarnation-1',
+  deliveryToken: 'token-1'
+}
+
+// Why the REAL ledger and not a snapshot literal: the whole point of the predicate is which of the
+// three frontiers it reads, and only the ledger's own send/ack machinery moves them apart.
+function ledgerSession(ledger: RelayPtySourceCreditLedger): SshPtyConsumerSessionAdapter {
+  return {
+    sourceDeliverySnapshotIfKnown: (identity: PtySourceDeliveryIdentity) =>
+      ledger.snapshotIfKnown(identity)
+  } as unknown as SshPtyConsumerSessionAdapter
+}
+
+function append(ledger: RelayPtySourceCreditLedger, data: string): void {
+  const start = ledger.snapshot(IDENTITY).receivedEndSu
+  ledger.append(IDENTITY, {
+    spanId: `span-${start}`,
+    data,
+    displayStart: start,
+    displayEnd: start + data.length,
+    splittable: true,
+    transform: { transformed: false, rawLengthSu: data.length, scalarSafe: true }
+  })
+}
+
+const record = { identity: IDENTITY, restoreRequired: false, rotationPending: false }
+
+describe('ptySourceDeliveryFullyAcknowledged', () => {
+  it('refuses a delivery whose committed send was never acknowledged', () => {
+    // The outage itself: commitSend fires on SINK settlement, so these bytes went into a socket
+    // that may already be dying. They are never resent (reserveNextSend resumes from sentEndSu), so
+    // the consumer's model is short by an amount the relay cannot name.
+    const ledger = new RelayPtySourceCreditLedger()
+    ledger.open(IDENTITY, 1024)
+    append(ledger, 'lost in the socket')
+    ledger.commitSend(ledger.reserveNextSend(IDENTITY)!)
+
+    const snapshot = ledger.snapshot(IDENTITY)
+    expect(snapshot.sentEndSu).toBe(snapshot.receivedEndSu)
+    expect(snapshot.creditedEndSu).toBe(0)
+    expect(ptySourceDeliveryFullyAcknowledged(ledgerSession(ledger), record)).toBe(false)
+  })
+
+  it('accepts only once the consumer has credited everything the delivery received', () => {
+    const ledger = new RelayPtySourceCreditLedger()
+    ledger.open(IDENTITY, 1024)
+    append(ledger, 'delivered')
+    ledger.commitSend(ledger.reserveNextSend(IDENTITY)!)
+    ledger.acknowledge(IDENTITY, {
+      id: IDENTITY.id,
+      clientGeneration: IDENTITY.clientGeneration,
+      ownerGeneration: IDENTITY.ownerGeneration,
+      deliveryToken: IDENTITY.deliveryToken,
+      creditedEndSu: 'delivered'.length
+    })
+
+    expect(ptySourceDeliveryFullyAcknowledged(ledgerSession(ledger), record)).toBe(true)
+
+    // Fresh source that has not even been reserved yet is equally unproven.
+    append(ledger, ' and more')
+    expect(ptySourceDeliveryFullyAcknowledged(ledgerSession(ledger), record)).toBe(false)
+  })
+
+  it('refuses an unknown, restoring or rotating delivery', () => {
+    const ledger = new RelayPtySourceCreditLedger()
+    expect(ptySourceDeliveryFullyAcknowledged(ledgerSession(ledger), record)).toBe(false)
+
+    ledger.open(IDENTITY, 1024)
+    expect(
+      ptySourceDeliveryFullyAcknowledged(ledgerSession(ledger), {
+        ...record,
+        restoreRequired: true
+      })
+    ).toBe(false)
+    expect(
+      ptySourceDeliveryFullyAcknowledged(ledgerSession(ledger), {
+        ...record,
+        rotationPending: true
+      })
+    ).toBe(false)
+    expect(ptySourceDeliveryFullyAcknowledged(ledgerSession(ledger), undefined)).toBe(false)
+  })
+})

--- a/src/relay/relay-pty-source-output.ts
+++ b/src/relay/relay-pty-source-output.ts
@@ -22,6 +22,31 @@ export function ptySourceDeliveryClosed(
   return !state || state === 'closed' || state === 'closing'
 }
 
+/**
+ * Whether the CONSUMER has acknowledged every source unit this delivery ever received.
+ *
+ * Why creditedEndSu and not sentEndSu: `sentEndSu` advances in commitPtySourceSend on SINK
+ * settlement — bytes written into a socket that may already be dying, never acked, never applied to
+ * the consumer's model. Only `creditedEndSu` is the consumer's own frontier, so only
+ * `creditedEndSu === receivedEndSu` proves the consumer holds everything (it also implies nothing is
+ * unsent, since creditedEndSu <= sentEndSu <= receivedEndSu).
+ *
+ * This is the precondition that makes the still-queued, never-published bytes the EXACT gap in the
+ * consumer's model. A false costs nothing; a wrong true would duplicate or drop a frame.
+ */
+export function ptySourceDeliveryFullyAcknowledged(
+  session: SshPtyConsumerSessionAdapter,
+  record:
+    | Pick<RelayPtySourceDeliveryRecord, 'identity' | 'restoreRequired' | 'rotationPending'>
+    | undefined
+): boolean {
+  if (!record || record.restoreRequired || record.rotationPending) {
+    return false
+  }
+  const snapshot = session.sourceDeliverySnapshotIfKnown(record.identity)
+  return snapshot?.state === 'active' && snapshot.creditedEndSu === snapshot.receivedEndSu
+}
+
 export function appendPtySourceOutput(
   session: SshPtyConsumerSessionAdapter,
   record: RelayPtySourceDeliveryRecord,

--- a/src/relay/relay-pty-source-publication.ts
+++ b/src/relay/relay-pty-source-publication.ts
@@ -26,6 +26,7 @@ import {
   appendPtySourceOutput,
   projectPtySourceOutputToLegacy,
   ptySourceDeliveryClosed,
+  ptySourceDeliveryFullyAcknowledged,
   type RelayPtySourceOutput
 } from './relay-pty-source-output'
 import type { SshPtyConsumerSessionAdapter } from './ssh-pty-consumer-session-adapter'
@@ -88,7 +89,7 @@ export class RelayPtySourcePublication {
       current?.clientId === context.clientId &&
       !current.restoreRequired &&
       current.sourceExitState !== 'pending' &&
-      this.deliveryClosedUnderRecord(current)
+      ptySourceDeliveryClosed(this.session, current.identity)
     ) {
       // Why: a canceled delivery can never resume as 'existing'; retire it so re-attach opens fresh.
       this.sender.wakeSendWaiters(current)
@@ -196,6 +197,9 @@ export class RelayPtySourcePublication {
 
   accepts = (id: string): boolean => this.deliveries.has(id)
 
+  deliveryFullyAcknowledged = (id: string): boolean =>
+    ptySourceDeliveryFullyAcknowledged(this.session, this.deliveries.get(id))
+
   receivingActivation(id: string, clientId: number): PtySourceReceivingActivation | undefined {
     const record = this.deliveries.get(id)
     return record?.clientId === clientId && !record.restoreRequired
@@ -219,7 +223,7 @@ export class RelayPtySourcePublication {
     }
     if (!output.sourceAccepted && !appendPtySourceOutput(this.session, record, output)) {
       this.counters.appendDenied++
-      if (this.deliveryClosedUnderRecord(record)) {
+      if (ptySourceDeliveryClosed(this.session, record.identity)) {
         this.sender.wakeSendWaiters(record)
         this.deliveries.delete(id)
         // Why: deferred — publish() can run inside flushPendingOutput's captured-queue drain,
@@ -273,10 +277,6 @@ export class RelayPtySourcePublication {
   dispose = (): void => {
     this.legacyExits.clear()
     this.sender.dispose()
-  }
-
-  private deliveryClosedUnderRecord(record: RelayPtySourceDeliveryRecord): boolean {
-    return ptySourceDeliveryClosed(this.session, record.identity)
   }
 
   private registerActivationSettlement(

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -8460,7 +8460,8 @@ export function connectPanePty(
               // Why after the snapshot: painting the model discards the replay, but the app's kitty
               // pushes during the outage exist ONLY there. Snapshot first for the pre-outage
               // baseline, then the replay layers the outage on top — otherwise Option/Alt chords
-              // encode against a stale flag stack.
+              // encode against a stale flag stack. scanReplay applies pushes as idempotent sets, so
+              // re-scanning bytes main's model already ingested cannot grow the mirrored stack.
               kittyKeyboardModes.scanReplay(connectResult.replay)
             }
             // Why shared: park+reveal of an alt-screen TUI needs the same


### PR DESCRIPTION
## ELI5

When you're working on a server over SSH and the connection blips, the server has been holding on to some terminal output for you. On reconnect it hands that backlog over — but it hands it **straight to your screen**, skipping the app's own memory of what the terminal looks like.

So the screen is fine, but the memory is now behind by however long the blip lasted. Anything that reads from memory instead of your screen — tab previews, the phone app, the web view — shows a slightly stale picture.

This teaches the server to also say: *"by the way, N characters went to the screen and never reached your memory."* The app then feeds exactly those N characters into its memory, so the two agree again.

There's a safety catch. If any newer output arrived while we were asking, we skip the whole thing rather than paste old text on top of newer text — a stale picture is annoying, a scrambled one is worse. We check that *before* asking, and the check can only be read at the right moment by construction, so a future change can't accidentally read it too late.

**Being straight about the scope:** this does **not** fix the whole original complaint. The bug report was about output lost when a connection dies mid-send, and that's a different pipe with its own recovery path that already exists. What this fixes is a real but narrower leak: output the server deliberately holds back when you reattach, which nothing else was ever going to recover.

**What you might notice:** after a reconnect, previews and your phone show the current screen instead of one that's a few seconds old. If anything about the situation is uncertain, it behaves exactly like today.

---
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​676 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​24 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​652 |
| Prod | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​306 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​289 |

<!-- /orca-pr-loc -->

Resolves [STA-4716](https://linear.app/stably/issue/STA-4716) partially — see "What this does not fix". Follow-up from #14844.

## Problem

Every SSH reattach replay is routed around main's model by construction. On attach the relay returns its retained tail as a payload addressed at the renderer **and deletes the still-queued bytes from the publish queue** (`pendingOutputByPty.delete(id)`), so those bytes never reach main's model at all. Main forwards the payload verbatim. The one place main tries to close the loop — `seedHeadlessTerminal` — is fresh-emulator-only by design, so it helps after an app relaunch and never after a network blip.

## Fix

The relay now reports how many trailing code units an attach withheld from the modeled stream (`replayUnseenChars`), and main appends exactly that suffix into its own headless model. The renderer is untouched.

Three things worth reviewing closely:

**1. The acknowledgement predicate reads the consumer's frontier, not the transport's.** `ptySourceDeliveryFullyAcknowledged` compares `creditedEndSu === receivedEndSu`. Comparing `sentEndSu` instead — "the relay handed bytes to the transport" — would count bytes that died in a dying socket as acknowledged, which is precisely the outage this ticket is about. `advanceCredit` is the sole writer of `creditedEndSu` and is reachable only from a real consumer ACK; the ledger's own `maybeClose` uses the same pair.

**2. An ingest fence prevents an out-of-order append.** The relay response frame and a following `pty.data` frame can arrive in one socket read, so main can ingest newer bytes before the spawn continuation runs; appending the older withheld tail behind them would turn a merely-stale model into a corrupt one. The fence is minted on the statement immediately before `provider.spawn` and carried with the attach result, so reading it late is structurally impossible rather than merely avoided. It is single-use and refuses rather than inventing a sequence when the runtime cannot report one. This also closes two latent double-append holes: the `materialized` adoption branch, and deduped adopters awaiting one shared adoption promise.

**3. `replayUnseenChars` is stripped at one chokepoint.** It is relay-internal and must not reach the renderer. The strip happens where the pane-spawn reservation is resolved — `reservation.resolve` appears exactly once in the file — rather than at each return site, so the two dedupe early-returns cannot leak it.

## What this does NOT fix

The ticket's headline symptom is unchanged, and I'd rather say so than imply otherwise.

Bytes committed into a dying socket advance `sentEndSu`, are never credited, and are not resent by this change. Recovering those is the job of delivery rotation, which already exists (`createReplacementDeliveryRecord` rewinds `sentEndSu` to the client's checkpoint and re-hands the retained spans). This PR closes a different, real hole: bytes the relay *drops at attach*, which nothing else can recover.

An earlier iteration of this work carried a `modelCoversReplay` flag that gated the renderer's alt-screen paint. It was removed. The honest claim the relay can make is "this attach withheld N trailing code units"; the flag asserted "main's model holds every byte of this tail-from-spawn replay", which is not the same — the replay predates the delivery and can contain bytes an earlier attach dropped or bytes predating a lazily-created emulator. Rather than keep a flag asserting a proof it does not have, only the action the proof justifies was kept. As a result `ssh-reattach-model-restore.ts`, `pty-transport*` and preload are byte-identical to main and #14844's paint decision is unchanged.

## Note for whoever picks up the residual

`docs/reference/ssh-reconnect-source-recovery.md` recommends a transport generation on the client record so a reconnect takes `rotateDelivery` instead of `'existing'`. **That recommendation rests on a false premise.** It states a reconnect calls `Dispatcher.setWrite`, reusing the primary clientId — but `setWrite` has no production callers at all, only three test files. In production every SSH reconnect is a fresh `relay.js --connect` bridge over a new socket, admitted as a *new* dispatcher client, so `activate()` already takes the rotation branch. The `'existing'` result is a *second* attach on the same connection, where a transport generation would be identical and discriminate nothing.

Worth filing separately (found while checking the above, unrelated to this PR): a first-attach-after-reconnect that carries no `sourceRecovery` currently destroys a healthy delivery via `requireRestore` and surfaces as `SSH_SESSION_EXPIRED`. ~10 lines in `relay-pty-source-publication.ts`.

## Tests

New `relay-pty-source-delivery-acknowledged.test.ts` drives the **real** `RelayPtySourceCreditLedger` (open → append → reserveNextSend → commitSend with the ack withheld); reverting the predicate to the old counters fails it. Fence-ordering tests advance the sequence from inside the mocked spawn and assert the catch-up is refused; they fail against a late-read implementation. 7986 tests pass across `src/main/{ipc,providers,ssh}`, `src/relay` and `orca-runtime.test.ts`.

