### PR TITLE
fix(remote): retire direct-SSH tabs on publisher retraction instead of snapshot absence (STA-4719)

### DIFF
--- a/src/renderer/src/hooks/remote-workspace-host-ack-ledger.ts
+++ b/src/renderer/src/hooks/remote-workspace-host-ack-ledger.ts
@@ -1,0 +1,294 @@
+import type { RemoteWorkspaceSnapshot } from '../../../shared/remote-workspace-types'
+import type { TerminalTab } from '../../../shared/terminal-tab-types'
+import { splitWorktreeId } from '../../../shared/worktree/id'
+
+/**
+ * What each CLIENT of a direct-SSH host has published about that host's tab list.
+ *
+ * There is no host authority to appeal to. `workspace.patch` is `{kind:'replace-session'}` over a
+ * namespace shared by every client of the host (src/relay/workspace-session-handler.ts:127-160), the
+ * relay stores the blob opaquely and only bumps a CAS counter, and each client exports just the
+ * worktrees whose repo it holds (src/main/ipc/remote-workspace.ts:59-70). So "the host stopped
+ * listing this tab" is really "the client that wrote last did not list it", and that is ambiguous in
+ * exactly the way the merge's comment describes: it can mean the writer closed the tab, or that the
+ * writer never knew about it.
+ *
+ * The two are byte-identical on the wire. A snapshot carries `revision`, but the relay enforces
+ * `baseRevision === current.revision` and publishes `current.revision + 1`, so the base is always
+ * `revision - 1` and says nothing; worse, the base is the writer's MAIN-process cache, which
+ * `handleRemoteWorkspaceNotification` updates synchronously while its renderer apply still lags
+ * (src/main/ipc/remote-workspace.ts:84). A stale writer therefore publishes a genuinely older tab
+ * list at a genuinely newer revision, and no field on `RemoteWorkspaceSnapshot` distinguishes that
+ * from a close.
+ *
+ * What IS decidable is who wrote it: `workspace.changed` carries `sourceClientId`, minted per
+ * process by the writing client and echoed by the relay since remote workspaces shipped. So this
+ * ledger records, per (target, publisher), the tab ids that publisher has itself listed. A tab may
+ * then be retired only when the SAME publisher that once listed it stops listing it — a retraction,
+ * which is positive evidence that the writer knew the tab and dropped it, rather than absence, which
+ * is not evidence at all. A publisher that never listed the tab can rewrite the namespace as often
+ * as it likes and never retire it.
+ *
+ * Consequences, all in the safe direction:
+ * - a pulled snapshot (`workspace.get`) has no publisher, so it can never retire anything;
+ * - a relay old enough to omit `sourceClientId` degrades to today's preserve-forever behaviour;
+ * - `CLIENT_ID` is per-process, so a peer restart forgets its listings and retirement waits for it
+ *   to publish again.
+ *
+ * The cost is a false negative: a peer that applies a tab and closes it without ever publishing it
+ * in between is not retractable, so the tab is preserved, re-uploaded and resurrected once before
+ * the peer's next publish makes it retractable. Closing that needs the closing client to publish the
+ * removal (a tombstone in `RemoteWorkspaceSession`), which is a change to what the host holds.
+ *
+ * Client-local by construction: `revision`, `namespace` and `sourceClientId` are already on the v1
+ * wire types, so nothing new crosses to the host and an old host is unaffected.
+ */
+export type RemoteWorkspaceHostAckedTab = {
+  /** Why: the path the publisher listed it under. An omission is only evidence while it still describes that path. */
+  worktreePath: string
+}
+
+/** One publisher's most recent listing, plus the ids it has dropped but not yet had retired. */
+export type RemoteWorkspacePublisherListing = {
+  revision: number
+  tabsById: Record<string, RemoteWorkspaceHostAckedTab>
+}
+
+export type RemoteWorkspaceHostAck = {
+  /** Why: the namespace is derived from host/port/user, so it changes when a target is repointed. Listings from a different namespace must never authorize a retirement. */
+  namespace: string
+  listingsByPublisherId: Record<string, RemoteWorkspacePublisherListing>
+}
+
+export type RemoteWorkspaceHostAckLedger = Record<string, RemoteWorkspaceHostAck>
+
+/** Why bounded: publisher ids are per-process, so a long-lived session would otherwise accumulate one entry per peer launch. */
+const MAX_TRACKED_PUBLISHERS = 8
+
+function listedPathsIn(snapshot: RemoteWorkspaceSnapshot): Set<string> {
+  return new Set(Object.keys(snapshot.session.tabsByWorktreePath ?? {}))
+}
+
+/**
+ * Tab ids this client holds under the given worktree paths.
+ *
+ * Scoped by path rather than flattening every worktree because `tabsByWorktree` spans every repo on
+ * every host, and the only ids this ledger can answer for are the ones its own target listed.
+ */
+function localTabIdsUnderPaths(
+  localTabsByWorktree: Readonly<Record<string, readonly TerminalTab[]>>,
+  worktreePaths: ReadonlySet<string>
+): Set<string> {
+  const tabIds = new Set<string>()
+  // Why keys and not entries: the tab arrays of unrelated worktrees are never even dereferenced.
+  for (const worktreeId of Object.keys(localTabsByWorktree)) {
+    const worktreePath = splitWorktreeId(worktreeId)?.worktreePath
+    if (!worktreePath || !worktreePaths.has(worktreePath)) {
+      continue
+    }
+    for (const tab of localTabsByWorktree[worktreeId] ?? []) {
+      tabIds.add(tab.id)
+    }
+  }
+  return tabIds
+}
+
+/**
+ * Carries forward the ids this publisher listed before but dropped now.
+ *
+ * Kept as standing candidates so an omission this client could not act on yet — the worktree was not
+ * in the target scope at the time, or the catalog had not resolved its path — delays retirement
+ * instead of disabling it for that id forever. Only while the publisher still describes the path the
+ * id was listed under and this client still holds the tab, so an old retraction cannot outlive the
+ * evidence for it.
+ */
+function standingCandidates(
+  previous: RemoteWorkspacePublisherListing | undefined,
+  listedPaths: ReadonlySet<string>,
+  localTabsByWorktree: Readonly<Record<string, readonly TerminalTab[]>>
+): Record<string, RemoteWorkspaceHostAckedTab> {
+  const carried: Record<string, RemoteWorkspaceHostAckedTab> = {}
+  const standing = Object.entries(previous?.tabsById ?? {}).filter(([, listed]) =>
+    listedPaths.has(listed.worktreePath)
+  )
+  if (standing.length === 0) {
+    // Why deferred: with nothing standing — the ordinary listing — no worktree is scanned at all.
+    return carried
+  }
+  const heldTabIds = localTabIdsUnderPaths(
+    localTabsByWorktree,
+    new Set(standing.map(([, listed]) => listed.worktreePath))
+  )
+  for (const [tabId, listed] of standing) {
+    if (heldTabIds.has(tabId)) {
+      carried[tabId] = listed
+    }
+  }
+  return carried
+}
+
+function withPublisherCap(
+  listings: Record<string, RemoteWorkspacePublisherListing>
+): Record<string, RemoteWorkspacePublisherListing> {
+  const publisherIds = Object.keys(listings)
+  if (publisherIds.length <= MAX_TRACKED_PUBLISHERS) {
+    return listings
+  }
+  const kept = publisherIds
+    .sort((a, b) => listings[b].revision - listings[a].revision)
+    .slice(0, MAX_TRACKED_PUBLISHERS)
+  return Object.fromEntries(kept.map((publisherId) => [publisherId, listings[publisherId]]))
+}
+
+/**
+ * Folds a host listing into the ledger, attributed to the client that published it.
+ *
+ * `publisherId` is `workspace.changed`'s `sourceClientId`. A listing with no publisher — a
+ * `workspace.get` pull, or this client's own push result — still resets the ledger when the
+ * namespace changes, but records nothing: an unattributed listing can never support a retraction.
+ *
+ * Monotonic per publisher: an arrival at or below that publisher's recorded revision is dropped.
+ * Snapshot applies are not revision-fenced (direct-ssh-reconnect-tokens.ts:73-84), so without this a
+ * late older listing would become the publisher's "latest" and silently discard what it listed in
+ * between. The documented relay-reset degradation follows: a reset moves the line backwards on
+ * purpose, and retirement stays off until the new line passes the old watermark.
+ *
+ * `localTabsByWorktree` is read only under the paths this target's own listings named, so a listing
+ * for one host never walks another host's repos.
+ */
+export function recordRemoteWorkspaceHostAck(
+  ledger: RemoteWorkspaceHostAckLedger,
+  targetId: string,
+  snapshot: RemoteWorkspaceSnapshot,
+  localTabsByWorktree: Readonly<Record<string, readonly TerminalTab[]>>,
+  publisherId: string | null | undefined
+): RemoteWorkspaceHostAckLedger {
+  const previous = ledger[targetId]
+  const sameLine = previous?.namespace === snapshot.namespace
+  if (!publisherId) {
+    return sameLine
+      ? ledger
+      : { ...ledger, [targetId]: { namespace: snapshot.namespace, listingsByPublisherId: {} } }
+  }
+  const previousListing = sameLine ? previous.listingsByPublisherId[publisherId] : undefined
+  if (previousListing && snapshot.revision <= previousListing.revision) {
+    return ledger
+  }
+  const listedPaths = listedPathsIn(snapshot)
+  const tabsById = standingCandidates(previousListing, listedPaths, localTabsByWorktree)
+  for (const [worktreePath, tabs] of Object.entries(snapshot.session.tabsByWorktreePath ?? {})) {
+    for (const tab of tabs) {
+      tabsById[tab.id] = { worktreePath }
+    }
+  }
+  return {
+    ...ledger,
+    [targetId]: {
+      namespace: snapshot.namespace,
+      listingsByPublisherId: withPublisherCap({
+        ...(sameLine ? previous.listingsByPublisherId : {}),
+        [publisherId]: { revision: snapshot.revision, tabsById }
+      })
+    }
+  }
+}
+
+export function clearRemoteWorkspaceHostAck(
+  ledger: RemoteWorkspaceHostAckLedger,
+  targetId: string
+): RemoteWorkspaceHostAckLedger {
+  if (!Object.hasOwn(ledger, targetId)) {
+    return ledger
+  }
+  const next = { ...ledger }
+  delete next[targetId]
+  return next
+}
+
+type HostRetiredTabSelection = {
+  ledger: RemoteWorkspaceHostAckLedger
+  targetId: string
+  snapshot: RemoteWorkspaceSnapshot
+  /** `workspace.changed`'s sourceClientId; absent for pulls, which can never retire anything. */
+  publisherId: string | null | undefined
+  localTabsByWorktree: Record<string, TerminalTab[]>
+  worktreeIds: ReadonlySet<string>
+}
+
+/**
+ * Local tab ids the publisher of this snapshot RETRACTED, grouped by the worktree that holds them.
+ *
+ * Grouped, and each (worktree, tab) copy judged on its own listing, so an id held under two worktree
+ * ids can only lose the copy under the path it was listed at.
+ *
+ * Every other shape of absence falls through to the merge's preserve rule:
+ *
+ * - the snapshot has no publisher, or one that never listed this id — absence by a client that does
+ *   not know the tab is not evidence about the tab. This is what makes a stale peer harmless: its
+ *   main-process cache CAS'd on a revision its renderer has not applied, so it republishes an older
+ *   tab list at a newer revision, and no id it never listed can be retracted by it;
+ * - a listing from another target or namespace — a repointed target has an unrelated revision line;
+ * - a revision at or below that publisher's watermark — out-of-order arrivals and relay resets prove
+ *   nothing;
+ * - the snapshot carries no entry for the worktree path the id was listed under — a publisher whose
+ *   repo set does not include that worktree strips the key on every push, so its listing is silent
+ *   about those tabs rather than empty.
+ *
+ * That list is exhaustive on purpose. Every LOCAL-state veto tried here was universally satisfied and
+ * left retirement inert, because the direct-SSH reconnect pass (retryDirectSshTargetPanes, run on
+ * every connected-authority transition AND at the end of every snapshot apply) touches every tab of
+ * the target: `pendingActivationSpawn` is stamped on every hydrated row, `directSshPaneRetryByTabId`
+ * gains an entry per tab (and `directSshLivePtyBindingByTabId` once each pane settles), and
+ * `tab.generation` is bumped past whatever any publisher listed. None of them is evidence anyway —
+ * they describe this client's pty plumbing, not whether the publisher knew the tab and dropped it,
+ * which is the only question that separates "the host retired this" from "a peer does not know
+ * about it".
+ *
+ * `generation` in particular is NOT comparable across publishers: each client bumps its own copy on
+ * every local pane retry without the peer ever seeing it, so `local > listed` says nothing about tab
+ * identity. Tab ids carry that on their own — they are UUIDs and `createTab` mints a fresh one rather
+ * than accept a colliding hint (terminals.ts:1318-1327) — so an id the publisher listed and this
+ * client still holds is the same tab, and the publisher's retraction is about exactly it.
+ */
+export function selectHostRetiredTabIdsByWorktree({
+  ledger,
+  targetId,
+  snapshot,
+  publisherId,
+  localTabsByWorktree,
+  worktreeIds
+}: HostRetiredTabSelection): Map<string, Set<string>> {
+  const retiredByWorktreeId = new Map<string, Set<string>>()
+  const entry = ledger[targetId]
+  if (!publisherId || !entry || entry.namespace !== snapshot.namespace) {
+    return retiredByWorktreeId
+  }
+  const listing = entry.listingsByPublisherId[publisherId]
+  if (!listing || snapshot.revision <= listing.revision) {
+    return retiredByWorktreeId
+  }
+  const listedPaths = listedPathsIn(snapshot)
+  const publishedTabIds = new Set(
+    Object.values(snapshot.session.tabsByWorktreePath ?? {}).flatMap((tabs) =>
+      tabs.map((tab) => tab.id)
+    )
+  )
+  for (const worktreeId of worktreeIds) {
+    const worktreePath = splitWorktreeId(worktreeId)?.worktreePath
+    if (!worktreePath || !listedPaths.has(worktreePath)) {
+      continue
+    }
+    const retired = new Set<string>()
+    for (const tab of localTabsByWorktree[worktreeId] ?? []) {
+      const listed = listing.tabsById[tab.id]
+      if (!listed || listed.worktreePath !== worktreePath || publishedTabIds.has(tab.id)) {
+        continue
+      }
+      retired.add(tab.id)
+    }
+    if (retired.size > 0) {
+      retiredByWorktreeId.set(worktreeId, retired)
+    }
+  }
+  return retiredByWorktreeId
+}

--- a/src/renderer/src/hooks/remote-workspace-host-tab-retirement.test.ts
+++ b/src/renderer/src/hooks/remote-workspace-host-tab-retirement.test.ts
@@ -1,0 +1,745 @@
+/**
+ * Where the merge's "preserve anything the host does not list" trade is finally resolved.
+ *
+ * mergeDirectSshRemoteWorkspaceSession has one bit of evidence per tab — is it in THIS snapshot? —
+ * and has to answer two questions with it: has the host ever been told about this tab, and does it
+ * still hold it? It preserves, which keeps a locally created tab alive but also keeps a tab another
+ * client closed (and re-uploads it, since patches are replace-session, resurrecting it host-side).
+ *
+ * Absence itself can never separate the two: the namespace is SHARED, every client rewrites the
+ * whole file from whatever its renderer last knew, and the relay pins baseRevision to revision - 1,
+ * so "closed" and "the writer never knew" are byte-identical snapshots.
+ *
+ * The disambiguator is therefore RETRACTION, not absence: `workspace.changed` names the client that
+ * wrote the listing, and a tab may only be removed when the SAME client that once listed it stops
+ * listing it. A publisher that never listed the tab — the stale peer, the peer with a narrower repo
+ * set, an unattributed pull — can rewrite the namespace forever without retiring anything.
+ */
+import { describe, expect, it } from 'vitest'
+import { getDefaultWorkspaceSession } from '../../../shared/constants'
+import type { RemoteWorkspaceSnapshot } from '../../../shared/remote-workspace-types'
+import type { Tab } from '../../../shared/tab-types'
+import type { TerminalTab } from '../../../shared/terminal-tab-types'
+import type { WorkspaceSessionState } from '../../../shared/workspace-session-state-types'
+import {
+  recordRemoteWorkspaceHostAck,
+  selectHostRetiredTabIdsByWorktree,
+  type RemoteWorkspaceHostAckLedger
+} from './remote-workspace-host-ack-ledger'
+import { retireHostClosedTabsFromSession } from './remote-workspace-host-tab-retirement'
+
+const TARGET_ID = 'ssh-target-1'
+const PEER = 'peer-client-1'
+const NAMESPACE = 'namespace-1'
+const PATH = '/srv/proj/bug-cats'
+const WORKTREE = `repo-1::${PATH}`
+const OTHER_PATH = '/srv/proj/dogs'
+const OTHER_WORKTREE = `repo-2::${OTHER_PATH}`
+
+function terminalTab(id: string, overrides: Partial<TerminalTab> = {}): TerminalTab {
+  return {
+    id,
+    ptyId: `pty-${id}`,
+    worktreeId: WORKTREE,
+    title: id,
+    customTitle: null,
+    color: null,
+    isPinned: false,
+    sortOrder: 0,
+    createdAt: 1,
+    ...overrides
+  }
+}
+
+function unifiedTab(entityId: string, groupId = 'group-1'): Tab {
+  return {
+    id: `unified-${entityId}`,
+    entityId,
+    groupId,
+    worktreeId: WORKTREE,
+    contentType: 'terminal',
+    label: entityId,
+    customLabel: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1,
+    isPinned: false
+  }
+}
+
+function session(overrides: Partial<WorkspaceSessionState> = {}): WorkspaceSessionState {
+  return {
+    ...getDefaultWorkspaceSession(),
+    activeWorktreeId: WORKTREE,
+    activeWorkspaceKey: `worktree:${WORKTREE}`,
+    activeTabId: 'agent',
+    tabsByWorktree: {
+      [WORKTREE]: [terminalTab('agent'), terminalTab('closed-elsewhere')]
+    },
+    terminalLayoutsByTabId: {
+      agent: {
+        root: { type: 'leaf', leafId: 'leaf-agent' },
+        ptyIdsByLeafId: {},
+        activeLeafId: 'leaf-agent',
+        expandedLeafId: null
+      },
+      'closed-elsewhere': {
+        root: { type: 'leaf', leafId: 'leaf-closed' },
+        ptyIdsByLeafId: { 'leaf-closed': 'pty-closed-elsewhere' },
+        activeLeafId: 'leaf-closed',
+        expandedLeafId: null
+      }
+    },
+    activeTabIdByWorktree: { [WORKTREE]: 'closed-elsewhere' },
+    remoteSessionIdsByTabId: {
+      agent: 'remote-agent',
+      'closed-elsewhere': 'remote-closed'
+    },
+    unifiedTabs: {
+      [WORKTREE]: [unifiedTab('agent'), unifiedTab('closed-elsewhere', 'group-2')]
+    },
+    tabGroups: {
+      [WORKTREE]: [
+        {
+          id: 'group-1',
+          worktreeId: WORKTREE,
+          tabOrder: ['unified-agent'],
+          activeTabId: 'unified-agent'
+        },
+        {
+          id: 'group-2',
+          worktreeId: WORKTREE,
+          tabOrder: ['unified-closed-elsewhere'],
+          activeTabId: 'unified-closed-elsewhere'
+        }
+      ]
+    },
+    tabGroupLayouts: {
+      [WORKTREE]: {
+        type: 'split',
+        direction: 'vertical',
+        first: { type: 'leaf', groupId: 'group-1' },
+        second: { type: 'leaf', groupId: 'group-2' },
+        ratio: 0.5
+      }
+    },
+    activeGroupIdByWorktree: { [WORKTREE]: 'group-2' },
+    ...overrides
+  }
+}
+
+function snapshot(
+  revision: number,
+  tabsByPath: Record<string, { id: string; generation?: number }[]>,
+  options: { namespace?: string } = {}
+): RemoteWorkspaceSnapshot {
+  return {
+    namespace: options.namespace ?? NAMESPACE,
+    revision,
+    updatedAt: revision,
+    schemaVersion: 1,
+    session: {
+      activeWorktreePath: PATH,
+      activeTabId: null,
+      tabsByWorktreePath: Object.fromEntries(
+        Object.entries(tabsByPath).map(([worktreePath, tabs]) => [
+          worktreePath,
+          tabs.map((tab) => ({
+            id: tab.id,
+            worktreePath,
+            ptyId: `pty-${tab.id}`,
+            title: tab.id,
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            ...(tab.generation === undefined ? {} : { generation: tab.generation })
+          }))
+        ])
+      ),
+      terminalLayoutsByTabId: {}
+    }
+  }
+}
+
+type ObserveOptions = {
+  targetId?: string
+  publisherId?: string | null
+}
+
+/** What the ssh slice does on every host listing: fold it in under its publisher, bounded by the tabs still held here. */
+function observe(
+  ledger: RemoteWorkspaceHostAckLedger,
+  next: RemoteWorkspaceSnapshot,
+  current: WorkspaceSessionState,
+  options: ObserveOptions = {}
+): RemoteWorkspaceHostAckLedger {
+  return recordRemoteWorkspaceHostAck(
+    ledger,
+    options.targetId ?? TARGET_ID,
+    next,
+    current.tabsByWorktree,
+    options.publisherId === undefined ? PEER : options.publisherId
+  )
+}
+
+type RetireOptions = {
+  worktreeIds?: ReadonlySet<string>
+  publisherId?: string | null
+}
+
+/** The composition the apply path runs: select against pre-merge local state, then subtract. */
+function retire(
+  current: WorkspaceSessionState,
+  ledger: RemoteWorkspaceHostAckLedger,
+  next: RemoteWorkspaceSnapshot,
+  options: RetireOptions = {}
+): { retiredTabIds: string[]; session: WorkspaceSessionState } {
+  const worktreeIds = options.worktreeIds ?? new Set([WORKTREE])
+  const retiredTabIdsByWorktreeId = selectHostRetiredTabIdsByWorktree({
+    ledger,
+    targetId: TARGET_ID,
+    snapshot: next,
+    publisherId: options.publisherId === undefined ? PEER : options.publisherId,
+    localTabsByWorktree: current.tabsByWorktree,
+    worktreeIds
+  })
+  return {
+    retiredTabIds: [...retiredTabIdsByWorktreeId.values()].flatMap((ids) => [...ids]),
+    session: retireHostClosedTabsFromSession(current, retiredTabIdsByWorktreeId)
+  }
+}
+
+const peerListedBoth = observe(
+  {},
+  snapshot(5, { [PATH]: [{ id: 'agent' }, { id: 'closed-elsewhere' }] }),
+  session()
+)
+
+describe('retiring tabs the host positively closed', () => {
+  it('removes the whole tab model for a tab the publisher listed at rev 5 and dropped at rev 6', () => {
+    const { session: next } = retire(
+      session(),
+      peerListedBoth,
+      snapshot(6, { [PATH]: [{ id: 'agent' }] })
+    )
+
+    expect(next.tabsByWorktree[WORKTREE].map((tab) => tab.id)).toEqual(['agent'])
+    // Why all of these: pruning tabsByWorktree alone leaves an unpaintable row in the tab bar that
+    // projectWorktreeTabModelReconciliation then re-adopts.
+    expect(next.unifiedTabs?.[WORKTREE]?.map((tab) => tab.entityId)).toEqual(['agent'])
+    expect(next.tabGroups?.[WORKTREE]?.map((group) => group.id)).toEqual(['group-1'])
+    expect(next.tabGroupLayouts?.[WORKTREE]).toEqual({
+      type: 'leaf',
+      groupId: 'group-1'
+    })
+    expect(next.terminalLayoutsByTabId['closed-elsewhere']).toBeUndefined()
+    expect(next.remoteSessionIdsByTabId?.['closed-elsewhere']).toBeUndefined()
+  })
+
+  it('keeps a tab the publisher never listed, even in the same snapshot', () => {
+    // The upload-pending tab: `setup` was created locally after the rev-5 listing, so no peer has
+    // ever listed it and its absence at rev 6 means "never uploaded", not "retired".
+    const current = session({
+      tabsByWorktree: {
+        [WORKTREE]: [terminalTab('agent'), terminalTab('setup')]
+      }
+    })
+
+    const { session: next } = retire(
+      current,
+      peerListedBoth,
+      snapshot(6, { [PATH]: [{ id: 'agent' }] })
+    )
+
+    expect(next.tabsByWorktree[WORKTREE].map((tab) => tab.id)).toEqual(['agent', 'setup'])
+  })
+
+  it('keeps the tab when the snapshot is older than the publisher watermark', () => {
+    // Snapshot applies are not revision-fenced, so an out-of-order arrival is normal and its
+    // omissions prove nothing.
+    const { session: next } = retire(
+      session(),
+      peerListedBoth,
+      snapshot(4, { [PATH]: [{ id: 'agent' }] })
+    )
+
+    expect(next.tabsByWorktree[WORKTREE].map((tab) => tab.id)).toContain('closed-elsewhere')
+  })
+
+  it('keeps the tab after a relay reset moves the revision line backwards', () => {
+    const acked = observe(
+      {},
+      snapshot(9, { [PATH]: [{ id: 'agent' }, { id: 'closed-elsewhere' }] }),
+      session()
+    )
+
+    const { session: next } = retire(session(), acked, snapshot(1, { [PATH]: [{ id: 'agent' }] }))
+
+    expect(next.tabsByWorktree[WORKTREE].map((tab) => tab.id)).toContain('closed-elsewhere')
+  })
+
+  it('retires it even though a local pane retry bumped the generation past the listed one', () => {
+    // generation is a per-CLIENT counter: retryDirectSshTerminalPanes bumps it on every reconnect
+    // without the peer ever seeing it, so `local > listed` is not a comparison of like quantities and
+    // is true for essentially every tab after the retry pass. Tab identity is carried by the id
+    // alone, which createTab mints fresh rather than reuse, so the retraction is about this tab.
+    const respawned = session({
+      tabsByWorktree: {
+        [WORKTREE]: [terminalTab('agent'), terminalTab('closed-elsewhere', { generation: 4 })]
+      }
+    })
+    const listedAtGeneration2 = observe(
+      {},
+      snapshot(5, { [PATH]: [{ id: 'agent' }, { id: 'closed-elsewhere', generation: 2 }] }),
+      respawned
+    )
+
+    const { session: next } = retire(
+      respawned,
+      listedAtGeneration2,
+      snapshot(6, { [PATH]: [{ id: 'agent' }] })
+    )
+
+    expect(next.tabsByWorktree[WORKTREE].map((tab) => tab.id)).toEqual(['agent'])
+  })
+
+  it('still retires a hydrated row, which session hydration always marks pendingActivationSpawn', () => {
+    // The flag is stamped on every restored row, so treating it as "created locally, never uploaded"
+    // would veto every tab and leave this inert. The retraction is what distinguishes them.
+    const current = session({
+      tabsByWorktree: {
+        [WORKTREE]: [
+          terminalTab('agent', { pendingActivationSpawn: true }),
+          terminalTab('closed-elsewhere', { pendingActivationSpawn: true })
+        ]
+      }
+    })
+
+    const { session: next } = retire(
+      current,
+      peerListedBoth,
+      snapshot(6, { [PATH]: [{ id: 'agent' }] })
+    )
+
+    expect(next.tabsByWorktree[WORKTREE].map((tab) => tab.id)).toEqual(['agent'])
+  })
+
+  it('never lets one target listing authorize a retirement under another', () => {
+    const listedForOtherTarget = observe(
+      {},
+      snapshot(5, { [PATH]: [{ id: 'agent' }, { id: 'closed-elsewhere' }] }),
+      session(),
+      { targetId: 'ssh-target-2' }
+    )
+
+    const { session: next } = retire(
+      session(),
+      listedForOtherTarget,
+      snapshot(6, { [PATH]: [{ id: 'agent' }] })
+    )
+
+    expect(next.tabsByWorktree[WORKTREE].map((tab) => tab.id)).toContain('closed-elsewhere')
+  })
+
+  it('never lets a listing from another namespace authorize a retirement', () => {
+    // A repointed target keeps its id but gets a new namespace, so its revision line is unrelated.
+    const { session: next } = retire(
+      session(),
+      peerListedBoth,
+      snapshot(6, { [PATH]: [{ id: 'agent' }] }, { namespace: 'namespace-2' })
+    )
+
+    expect(next.tabsByWorktree[WORKTREE].map((tab) => tab.id)).toContain('closed-elsewhere')
+  })
+
+  it('leaves worktrees outside the target scope untouched', () => {
+    const current = session({
+      tabsByWorktree: {
+        [WORKTREE]: [terminalTab('agent')],
+        [OTHER_WORKTREE]: [terminalTab('closed-elsewhere', { worktreeId: OTHER_WORKTREE })]
+      }
+    })
+
+    const { retiredTabIds, session: next } = retire(
+      current,
+      peerListedBoth,
+      snapshot(6, { [PATH]: [{ id: 'agent' }] })
+    )
+
+    expect(retiredTabIds).toEqual([])
+    expect(next.tabsByWorktree[OTHER_WORKTREE].map((tab) => tab.id)).toEqual(['closed-elsewhere'])
+  })
+
+  it('retires only the copy under the path the publisher listed the id at', () => {
+    // A worktree rename can leave the same id under two keys with different per-copy evidence. Each
+    // copy is judged on its own listing, so the copy the publisher never listed under stays and the
+    // duplicate-repair pass converges it; retiring it here would delete the wrong pane.
+    const current = session({
+      tabsByWorktree: {
+        [WORKTREE]: [terminalTab('agent'), terminalTab('closed-elsewhere')],
+        [OTHER_WORKTREE]: [terminalTab('closed-elsewhere', { worktreeId: OTHER_WORKTREE })]
+      }
+    })
+
+    const { session: next } = retire(
+      current,
+      peerListedBoth,
+      snapshot(6, { [PATH]: [{ id: 'agent' }], [OTHER_PATH]: [] }),
+      { worktreeIds: new Set([WORKTREE, OTHER_WORKTREE]) }
+    )
+
+    expect(next.tabsByWorktree[WORKTREE].map((tab) => tab.id)).toEqual(['agent'])
+    expect(next.tabsByWorktree[OTHER_WORKTREE].map((tab) => tab.id)).toEqual(['closed-elsewhere'])
+  })
+
+  it('keeps the second copy when the snapshot never describes its worktree', () => {
+    // The path guard decides retirability, so the grouping pass has to honour it too: a holder the
+    // writer never described is one it could not have listed tabs for.
+    const current = session({
+      tabsByWorktree: {
+        [WORKTREE]: [terminalTab('agent'), terminalTab('closed-elsewhere')],
+        [OTHER_WORKTREE]: [terminalTab('closed-elsewhere', { worktreeId: OTHER_WORKTREE })]
+      }
+    })
+
+    const { session: next } = retire(
+      current,
+      peerListedBoth,
+      snapshot(6, { [PATH]: [{ id: 'agent' }] }),
+      { worktreeIds: new Set([WORKTREE, OTHER_WORKTREE]) }
+    )
+
+    expect(next.tabsByWorktree[WORKTREE].map((tab) => tab.id)).toEqual(['agent'])
+    expect(next.tabsByWorktree[OTHER_WORKTREE].map((tab) => tab.id)).toEqual(['closed-elsewhere'])
+  })
+
+  it('leaves a pinned tab in place', () => {
+    // A pin is the local user's explicit "do not take this away from me", and retirement is the one
+    // close gesture they did not ask for. The trade is that the resurrection loop stays open for
+    // pinned tabs, which is exactly today's behaviour rather than a regression.
+    const pinned = session({
+      tabsByWorktree: {
+        [WORKTREE]: [terminalTab('agent'), terminalTab('closed-elsewhere', { isPinned: true })]
+      }
+    })
+
+    const { session: next } = retire(
+      pinned,
+      peerListedBoth,
+      snapshot(6, { [PATH]: [{ id: 'agent' }] })
+    )
+
+    expect(next.tabsByWorktree[WORKTREE].map((tab) => tab.id)).toContain('closed-elsewhere')
+  })
+
+  it('re-derives the active tab when the retired one was active', () => {
+    const { session: next } = retire(
+      session(),
+      peerListedBoth,
+      snapshot(6, { [PATH]: [{ id: 'agent' }] })
+    )
+
+    expect(next.activeTabIdByWorktree?.[WORKTREE]).toBe('agent')
+    expect(next.activeGroupIdByWorktree?.[WORKTREE]).toBe('group-1')
+  })
+
+  it('kills nothing: retirement returns a session and no pty list', () => {
+    // The closing client already killed the pty; if that failed, the process may have been rebound
+    // by another client, so this path must never issue a kill.
+    const result = retireHostClosedTabsFromSession(
+      session(),
+      new Map([[WORKTREE, new Set(['closed-elsewhere'])]])
+    )
+
+    expect('ptyIdsToKill' in result).toBe(false)
+  })
+})
+
+describe('guards against peers that never knew about the tab', () => {
+  it('keeps every tab under a worktree the retiring snapshot does not describe', () => {
+    // A peer of the same host that holds only repo-1 exports only /srv/proj/bug-cats, and because
+    // workspace.patch is replace-session over the shared namespace its push strips the dogs key on
+    // EVERY write. Reading that as "the host retired those tabs" deletes live panes whose remote
+    // ptys this path deliberately does not kill, orphaning the processes.
+    const current = session({
+      tabsByWorktree: {
+        [WORKTREE]: [terminalTab('agent')],
+        [OTHER_WORKTREE]: [
+          terminalTab('dogs-build', { worktreeId: OTHER_WORKTREE }),
+          terminalTab('dogs-agent', { worktreeId: OTHER_WORKTREE })
+        ]
+      }
+    })
+    const listed = observe(
+      {},
+      snapshot(5, {
+        [PATH]: [{ id: 'agent' }],
+        [OTHER_PATH]: [{ id: 'dogs-build' }, { id: 'dogs-agent' }]
+      }),
+      current
+    )
+
+    const { retiredTabIds, session: next } = retire(
+      current,
+      listed,
+      snapshot(6, { [PATH]: [{ id: 'agent' }] }),
+      { worktreeIds: new Set([WORKTREE, OTHER_WORKTREE]) }
+    )
+
+    expect(retiredTabIds).toEqual([])
+    expect(next.tabsByWorktree[OTHER_WORKTREE].map((tab) => tab.id)).toEqual([
+      'dogs-build',
+      'dogs-agent'
+    ])
+  })
+
+  it('still retires the last tab of a worktree the peer describes as empty', () => {
+    // The guard is about the KEY, not the tabs under it: closing the last tab leaves the worktree in
+    // tabsByWorktree with an empty array, so the export still carries the path.
+    const current = session({
+      tabsByWorktree: {
+        [WORKTREE]: [terminalTab('agent')],
+        [OTHER_WORKTREE]: [terminalTab('dogs-build', { worktreeId: OTHER_WORKTREE })]
+      }
+    })
+    const listed = observe(
+      {},
+      snapshot(5, { [PATH]: [{ id: 'agent' }], [OTHER_PATH]: [{ id: 'dogs-build' }] }),
+      current
+    )
+
+    const { session: next } = retire(
+      current,
+      listed,
+      snapshot(6, { [PATH]: [{ id: 'agent' }], [OTHER_PATH]: [] }),
+      { worktreeIds: new Set([WORKTREE, OTHER_WORKTREE]) }
+    )
+
+    expect(next.tabsByWorktree[OTHER_WORKTREE]).toEqual([])
+  })
+
+  it('keeps a standing retraction the target scope could not act on yet', () => {
+    // The worktree was not in scope when the peer dropped the id (catalog not resolved yet), so the
+    // omission is carried forward and the next one still retires it, rather than being forgotten.
+    const current = session()
+    const afterMissedScope = observe(
+      peerListedBoth,
+      snapshot(6, { [PATH]: [{ id: 'agent' }] }),
+      current
+    )
+    const { retiredTabIds: missed } = retire(
+      current,
+      peerListedBoth,
+      snapshot(6, { [PATH]: [{ id: 'agent' }] }),
+      { worktreeIds: new Set() }
+    )
+    expect(missed).toEqual([])
+
+    const { session: next } = retire(
+      current,
+      afterMissedScope,
+      snapshot(7, { [PATH]: [{ id: 'agent' }] })
+    )
+
+    expect(next.tabsByWorktree[WORKTREE].map((tab) => tab.id)).toEqual(['agent'])
+  })
+
+  it('keeps the tab when a DIFFERENT client publishes the omitting snapshot', () => {
+    // The stale-peer case in miniature: another client of the same host CAS'd on a revision its
+    // renderer has not applied, so it rewrites the shared namespace from an older tab list. It never
+    // listed this id, so its omission is not a retraction.
+    const { retiredTabIds, session: next } = retire(
+      session(),
+      peerListedBoth,
+      snapshot(6, { [PATH]: [{ id: 'agent' }] }),
+      { publisherId: 'peer-client-2' }
+    )
+
+    expect(retiredTabIds).toEqual([])
+    expect(next.tabsByWorktree[WORKTREE].map((tab) => tab.id)).toContain('closed-elsewhere')
+  })
+
+  it('keeps the tab when the snapshot has no publisher at all', () => {
+    // workspace.get pulls, and relays too old to echo sourceClientId: nobody to attribute the
+    // omission to, so it degrades to the merge's preserve rule.
+    const { session: next } = retire(
+      session(),
+      peerListedBoth,
+      snapshot(6, { [PATH]: [{ id: 'agent' }] }),
+      { publisherId: null }
+    )
+
+    expect(next.tabsByWorktree[WORKTREE].map((tab) => tab.id)).toContain('closed-elsewhere')
+  })
+
+  it('records nothing for an unattributed listing, so it cannot seed a later retraction', () => {
+    const current = session()
+    const pulled = observe(
+      {},
+      snapshot(5, { [PATH]: [{ id: 'agent' }, { id: 'closed-elsewhere' }] }),
+      current,
+      { publisherId: null }
+    )
+
+    const { session: next } = retire(current, pulled, snapshot(6, { [PATH]: [{ id: 'agent' }] }))
+
+    expect(next.tabsByWorktree[WORKTREE].map((tab) => tab.id)).toContain('closed-elsewhere')
+  })
+
+  it('drops the standing candidate when the peer stops describing its worktree', () => {
+    const current = session({
+      tabsByWorktree: {
+        [WORKTREE]: [terminalTab('agent')],
+        [OTHER_WORKTREE]: [terminalTab('dogs-build', { worktreeId: OTHER_WORKTREE })]
+      }
+    })
+    const listed = observe(
+      {},
+      snapshot(5, { [PATH]: [{ id: 'agent' }], [OTHER_PATH]: [{ id: 'dogs-build' }] }),
+      current
+    )
+    const afterNarrowPeer = observe(listed, snapshot(6, { [PATH]: [{ id: 'agent' }] }), current)
+
+    expect(
+      afterNarrowPeer[TARGET_ID]?.listingsByPublisherId[PEER]?.tabsById['dogs-build']
+    ).toBeUndefined()
+  })
+
+  it('keeps the local active worktree selected when a peer closes its last tab', () => {
+    // Closing the last surface normally lands the user on the home screen. That is a navigation the
+    // local user asked for; a peer's close is not.
+    const current = session({
+      tabsByWorktree: { [WORKTREE]: [terminalTab('closed-elsewhere')] },
+      unifiedTabs: { [WORKTREE]: [unifiedTab('closed-elsewhere', 'group-2')] },
+      tabGroups: {
+        [WORKTREE]: [
+          {
+            id: 'group-2',
+            worktreeId: WORKTREE,
+            tabOrder: ['unified-closed-elsewhere'],
+            activeTabId: 'unified-closed-elsewhere'
+          }
+        ]
+      },
+      activeWorkspaceExecutionHostId: 'ssh:host-1'
+    })
+
+    const { session: next } = retire(current, peerListedBoth, snapshot(6, { [PATH]: [] }))
+
+    expect(next.tabsByWorktree[WORKTREE]).toEqual([])
+    expect(next.activeWorktreeId).toBe(WORKTREE)
+    expect(next.activeWorkspaceKey).toBe(`worktree:${WORKTREE}`)
+    expect(next.activeWorkspaceExecutionHostId).toBe('ssh:host-1')
+  })
+})
+
+describe('the publisher listing ledger itself', () => {
+  it("ignores a listing at or below that publisher's recorded revision", () => {
+    // Snapshot applies are not revision-fenced, so a late older listing must not become that
+    // publisher's "latest" and discard what it listed in between.
+    const current = session()
+    const atNine = observe(
+      {},
+      snapshot(9, { [PATH]: [{ id: 'agent' }, { id: 'closed-elsewhere' }] }),
+      current
+    )
+
+    const late = observe(atNine, snapshot(7, { [PATH]: [{ id: 'agent' }] }), current)
+
+    expect(late).toBe(atNine)
+    expect(late[TARGET_ID]?.listingsByPublisherId[PEER]?.revision).toBe(9)
+    expect(
+      late[TARGET_ID]?.listingsByPublisherId[PEER]?.tabsById['closed-elsewhere']?.worktreePath
+    ).toBe(PATH)
+  })
+
+  it("tracks publishers independently, so one peer's revision cannot fence another's", () => {
+    const current = session()
+    const twoPeers = observe(
+      observe({}, snapshot(9, { [PATH]: [{ id: 'agent' }, { id: 'closed-elsewhere' }] }), current),
+      snapshot(10, { [PATH]: [{ id: 'agent' }] }),
+      current,
+      { publisherId: 'peer-client-2' }
+    )
+
+    expect(twoPeers[TARGET_ID]?.listingsByPublisherId[PEER]?.revision).toBe(9)
+    expect(twoPeers[TARGET_ID]?.listingsByPublisherId['peer-client-2']?.revision).toBe(10)
+    // peer-client-2 never listed the id, so its omission retires nothing.
+    expect(
+      retire(current, twoPeers, snapshot(11, { [PATH]: [{ id: 'agent' }] }), {
+        publisherId: 'peer-client-2'
+      }).retiredTabIds
+    ).toEqual([])
+  })
+
+  it('rebuilds from scratch when the namespace changes', () => {
+    const current = session()
+    const repointed = observe(
+      peerListedBoth,
+      snapshot(1, { [PATH]: [{ id: 'agent' }] }, { namespace: 'namespace-2' }),
+      current
+    )
+
+    expect(repointed[TARGET_ID]?.namespace).toBe('namespace-2')
+    expect(repointed[TARGET_ID]?.listingsByPublisherId[PEER]?.revision).toBe(1)
+    expect(
+      repointed[TARGET_ID]?.listingsByPublisherId[PEER]?.tabsById['closed-elsewhere']
+    ).toBeUndefined()
+  })
+
+  it('reads only the worktrees this target listed', () => {
+    // tabsByWorktree spans every repo on every host; an ack for one target must not walk another's.
+    let unrelatedReads = 0
+    const current = session({
+      tabsByWorktree: Object.defineProperties(
+        { [WORKTREE]: [terminalTab('agent'), terminalTab('closed-elsewhere')] },
+        {
+          [OTHER_WORKTREE]: {
+            enumerable: true,
+            get: () => {
+              unrelatedReads += 1
+              return []
+            }
+          }
+        }
+      ) as WorkspaceSessionState['tabsByWorktree']
+    })
+
+    observe(peerListedBoth, snapshot(6, { [PATH]: [{ id: 'agent' }] }), current)
+
+    expect(unrelatedReads).toBe(0)
+  })
+
+  it('bounds itself to a fixed number of publishers, keeping the freshest', () => {
+    // Publisher ids are minted per process, so a long session facing restarting peers would
+    // otherwise accumulate one entry per peer launch.
+    const current = session()
+    let ledger: RemoteWorkspaceHostAckLedger = {}
+    for (let index = 0; index < 12; index += 1) {
+      ledger = observe(ledger, snapshot(index + 1, { [PATH]: [{ id: 'agent' }] }), current, {
+        publisherId: `peer-${index}`
+      })
+    }
+
+    const publisherIds = Object.keys(ledger[TARGET_ID]?.listingsByPublisherId ?? {})
+    expect(publisherIds).toHaveLength(8)
+    expect(publisherIds).toContain('peer-11')
+    expect(publisherIds).not.toContain('peer-0')
+  })
+
+  it('forgets a standing candidate this client no longer holds', () => {
+    // Bounds the ledger: once the tab is gone from local state nothing can retire it.
+    const withoutClosed = session({ tabsByWorktree: { [WORKTREE]: [terminalTab('agent')] } })
+
+    const pruned = observe(
+      peerListedBoth,
+      snapshot(6, { [PATH]: [{ id: 'agent' }] }),
+      withoutClosed
+    )
+
+    expect(Object.keys(pruned[TARGET_ID]?.listingsByPublisherId[PEER]?.tabsById ?? {})).toEqual([
+      'agent'
+    ])
+  })
+})

--- a/src/renderer/src/hooks/remote-workspace-host-tab-retirement.ts
+++ b/src/renderer/src/hooks/remote-workspace-host-tab-retirement.ts
@@ -19,9 +19,19 @@ import { closeTerminalTabInWorkspaceSession } from '../../../shared/workspace-se
  * pin wins. The cost is that the resurrection loop stays open for pinned tabs — they are preserved
  * and re-uploaded exactly as before this change, which is today's behaviour rather than a regression.
  */
+export type HostTabRetirementObserver = {
+  /**
+   * Fires once per tab the primitive REALLY removed, so the caller can run the same renderer-side
+   * sweep a local close runs. A pinned refusal and an id this session never held are both skipped:
+   * sweeping either would drop agent status for a tab that is still on screen.
+   */
+  onTabRetired?: (tabId: string, worktreeId: string) => void
+}
+
 export function retireHostClosedTabsFromSession(
   session: WorkspaceSessionState,
-  retiredTabIdsByWorktreeId: ReadonlyMap<string, ReadonlySet<string>>
+  retiredTabIdsByWorktreeId: ReadonlyMap<string, ReadonlySet<string>>,
+  observer?: HostTabRetirementObserver
 ): WorkspaceSessionState {
   if (retiredTabIdsByWorktreeId.size === 0) {
     return session
@@ -32,7 +42,11 @@ export function retireHostClosedTabsFromSession(
       // Why ptyIdsToKill is discarded: the client that closed the tab already killed the pty, and if
       // that kill failed the process is one another client may have rebound. Retirement removes a
       // tab from this client's model; it never kills anything on the host.
-      next = closeTerminalTabInWorkspaceSession(next, worktreeId, tabId).session
+      const closeResult = closeTerminalTabInWorkspaceSession(next, worktreeId, tabId)
+      next = closeResult.session
+      if (closeResult.closed) {
+        observer?.onTabRetired?.(tabId, worktreeId)
+      }
     }
   }
   // Why the workspace identity is restored: closing the last surface of the active worktree clears

--- a/src/renderer/src/hooks/remote-workspace-host-tab-retirement.ts
+++ b/src/renderer/src/hooks/remote-workspace-host-tab-retirement.ts
@@ -1,0 +1,50 @@
+import type { WorkspaceSessionState } from '../../../shared/workspace-session-state-types'
+import { closeTerminalTabInWorkspaceSession } from '../../../shared/workspace-session-terminal-tab-close'
+
+/**
+ * Removes tabs whose publisher retracted them (see selectHostRetiredTabIdsByWorktree) from a merged
+ * session.
+ *
+ * Runs AFTER the merge, never inside it: the merge's preserve rule stays the fallback for every tab
+ * with no acknowledgement, and only a retired id is subtracted from its result.
+ *
+ * Reuses the shared close primitive so the whole tab model goes — terminal row, unified tab, group
+ * membership, group layout, layouts, remote session id, sleeping agents, active surface. Pruning
+ * `tabsByWorktree` alone would leave an unpaintable row in the tab bar that
+ * projectWorktreeTabModelReconciliation then re-adopts.
+ *
+ * Pinned tabs survive: the primitive refuses to close them (workspace-session-terminal-tab-close
+ * .ts:161-163) and this path does not override that. A pin is the local user's explicit "do not take
+ * this away from me", and retirement is the one close gesture the local user did not ask for, so the
+ * pin wins. The cost is that the resurrection loop stays open for pinned tabs — they are preserved
+ * and re-uploaded exactly as before this change, which is today's behaviour rather than a regression.
+ */
+export function retireHostClosedTabsFromSession(
+  session: WorkspaceSessionState,
+  retiredTabIdsByWorktreeId: ReadonlyMap<string, ReadonlySet<string>>
+): WorkspaceSessionState {
+  if (retiredTabIdsByWorktreeId.size === 0) {
+    return session
+  }
+  let next = session
+  for (const [worktreeId, tabIds] of retiredTabIdsByWorktreeId) {
+    for (const tabId of tabIds) {
+      // Why ptyIdsToKill is discarded: the client that closed the tab already killed the pty, and if
+      // that kill failed the process is one another client may have rebound. Retirement removes a
+      // tab from this client's model; it never kills anything on the host.
+      next = closeTerminalTabInWorkspaceSession(next, worktreeId, tabId).session
+    }
+  }
+  // Why the workspace identity is restored: closing the last surface of the active worktree clears
+  // these three so a user-initiated close lands on the home screen. A peer's close is not a
+  // navigation the local user asked for, and the worktree they are standing in still exists.
+  if (session.activeWorktreeId != null && next.activeWorktreeId == null) {
+    next = {
+      ...next,
+      activeWorktreeId: session.activeWorktreeId,
+      activeWorkspaceKey: session.activeWorkspaceKey,
+      activeWorkspaceExecutionHostId: session.activeWorkspaceExecutionHostId
+    }
+  }
+  return next
+}

--- a/src/renderer/src/hooks/remote-workspace-snapshot-apply.ts
+++ b/src/renderer/src/hooks/remote-workspace-snapshot-apply.ts
@@ -16,6 +16,8 @@ import {
   mergeDirectSshRemoteWorkspaceSession,
   uniqueWorktreeIdByPath
 } from './remote-workspace-session-merge'
+import { selectHostRetiredTabIdsByWorktree } from './remote-workspace-host-ack-ledger'
+import { retireHostClosedTabsFromSession } from './remote-workspace-host-tab-retirement'
 
 const REMOTE_WORKSPACE_SNAPSHOT_WRITE_SUPPRESS_MS = 1_000
 const SNAPSHOT_TERMINAL_RECONNECT_TIMEOUT_MS = 30_000
@@ -35,6 +37,8 @@ type RemoteWorkspaceSnapshotApplyInput = {
   isPreparationTokenCurrent: (token: DirectSshPreparationToken) => boolean
   waitForWorkspaceSessionReady: () => Promise<boolean>
   finalizeHydratedTerminals: (authority: DirectSshAuthority) => number
+  /** `workspace.changed`'s sourceClientId: which client wrote this listing. Absent for pulls. */
+  publisherClientId?: string | null
 }
 
 function exactTargetWorktreeIds(state: AppState, authority: DirectSshAuthority): Set<string> {
@@ -81,7 +85,8 @@ export async function applyDirectSshRemoteWorkspaceSnapshot({
   isArrivalCurrent,
   isPreparationTokenCurrent,
   waitForWorkspaceSessionReady,
-  finalizeHydratedTerminals
+  finalizeHydratedTerminals,
+  publisherClientId
 }: RemoteWorkspaceSnapshotApplyInput): Promise<void> {
   const { authority } = token
   if (!isArrivalCurrent(authority.targetId, arrival)) {
@@ -111,12 +116,34 @@ export async function applyDirectSshRemoteWorkspaceSnapshot({
   const remoteSession = importRemoteWorkspaceSession(snapshot.session, {
     resolveWorktreeId: uniqueWorktreeIdByPath(worktreeIds)
   })
-  const merged = mergeDirectSshRemoteWorkspaceSession(
-    buildWorkspaceSessionPayload(state),
-    remoteSession,
-    worktreeIds,
-    state.tabsByWorktree,
-    currentRecoveryTabIds(state, authority, worktreeIds)
+  // Why the ids are selected BEFORE the merge: the merge is what preserves a host-unknown tab, so
+  // afterwards absence and preservation are indistinguishable again. Read against pre-merge local
+  // state, an id here means the client publishing this snapshot once listed the tab and now does not.
+  //
+  // What makes that safe is the retraction rule alone (see selectHostRetiredTabIdsByWorktree): only a
+  // publisher that itself listed the id, under a path it still describes, can drop it. No local-pty
+  // predicate is consulted, deliberately — this apply ends by running finalizeHydratedTerminals,
+  // which is retryDirectSshTargetPanes (useIpcEvents.ts:731-733), so by the time the next snapshot
+  // arrives every tab of the target has a retry entry and a bumped generation (and a live binding
+  // once its pane settles). Any veto built on those is satisfied by every tab and silently disables
+  // retirement.
+  const retiredTabIdsByWorktreeId = selectHostRetiredTabIdsByWorktree({
+    ledger: state.remoteWorkspaceHostAckByTargetId,
+    targetId: authority.targetId,
+    snapshot,
+    publisherId: publisherClientId,
+    localTabsByWorktree: state.tabsByWorktree,
+    worktreeIds
+  })
+  const merged = retireHostClosedTabsFromSession(
+    mergeDirectSshRemoteWorkspaceSession(
+      buildWorkspaceSessionPayload(state),
+      remoteSession,
+      worktreeIds,
+      state.tabsByWorktree,
+      currentRecoveryTabIds(state, authority, worktreeIds)
+    ),
+    retiredTabIdsByWorktreeId
   )
   if (!isArrivalCurrent(authority.targetId, arrival) || !isPreparationTokenCurrent(token)) {
     return
@@ -130,6 +157,9 @@ export async function applyDirectSshRemoteWorkspaceSnapshot({
       replaceWorkspaceKeys
     })
     currentStore.hydrateTabsSession(merged, { replaceWorkspaceKeys })
+    // Why after hydrate: this listing is now what its publisher is known to hold, so a LATER listing
+    // from the SAME publisher is what its omissions are judged against.
+    currentStore.recordRemoteWorkspaceHostAck(authority.targetId, snapshot, publisherClientId)
     // Why: direct SSH snapshots project terminal state only; global editor/browser hydration would reset unrelated hosts.
     currentStore.markRemoteWorkspaceHydrated(authority.targetId)
     currentStore.setRemoteWorkspaceSyncStatus(authority.targetId, {

--- a/src/renderer/src/hooks/remote-workspace-snapshot-apply.ts
+++ b/src/renderer/src/hooks/remote-workspace-snapshot-apply.ts
@@ -18,6 +18,7 @@ import {
 } from './remote-workspace-session-merge'
 import { selectHostRetiredTabIdsByWorktree } from './remote-workspace-host-ack-ledger'
 import { retireHostClosedTabsFromSession } from './remote-workspace-host-tab-retirement'
+import { sweepRetiredTerminalTabState } from '../store/slices/retired-terminal-tab-state-sweep'
 
 const REMOTE_WORKSPACE_SNAPSHOT_WRITE_SUPPRESS_MS = 1_000
 const SNAPSHOT_TERMINAL_RECONNECT_TIMEOUT_MS = 30_000
@@ -135,6 +136,9 @@ export async function applyDirectSshRemoteWorkspaceSnapshot({
     localTabsByWorktree: state.tabsByWorktree,
     worktreeIds
   })
+  // Why collected: a peer's close owes the tab the same renderer-side sweep a local closeTab runs.
+  // Only ids the primitive really removed land here, so a pinned tab keeps its agent status.
+  const retiredWorktreeIdByTabId = new Map<string, string>()
   const merged = retireHostClosedTabsFromSession(
     mergeDirectSshRemoteWorkspaceSession(
       buildWorkspaceSessionPayload(state),
@@ -143,7 +147,8 @@ export async function applyDirectSshRemoteWorkspaceSnapshot({
       state.tabsByWorktree,
       currentRecoveryTabIds(state, authority, worktreeIds)
     ),
-    retiredTabIdsByWorktreeId
+    retiredTabIdsByWorktreeId,
+    { onTabRetired: (tabId, worktreeId) => retiredWorktreeIdByTabId.set(tabId, worktreeId) }
   )
   if (!isArrivalCurrent(authority.targetId, arrival) || !isPreparationTokenCurrent(token)) {
     return
@@ -157,6 +162,11 @@ export async function applyDirectSshRemoteWorkspaceSnapshot({
       replaceWorkspaceKeys
     })
     currentStore.hydrateTabsSession(merged, { replaceWorkspaceKeys })
+    // Why here: the retired tabs are out of tabsByWorktree now (the completed-orphan sweep is defined
+    // against that), and snapshotApplyDepth still suppresses the store writes from re-publishing.
+    for (const [tabId, worktreeId] of retiredWorktreeIdByTabId) {
+      sweepRetiredTerminalTabState(currentStore, tabId, worktreeId)
+    }
     // Why after hydrate: this listing is now what its publisher is known to hold, so a LATER listing
     // from the SAME publisher is what its omissions are judged against.
     currentStore.recordRemoteWorkspaceHostAck(authority.targetId, snapshot, publisherClientId)

--- a/src/renderer/src/hooks/remote-workspace-snapshot-local-tab-survival.test.ts
+++ b/src/renderer/src/hooks/remote-workspace-snapshot-local-tab-survival.test.ts
@@ -443,3 +443,71 @@ describe('direct-SSH snapshot apply keeps local state the host has not seen', ()
     expect(Object.keys(payload.remoteSessionIdsByTabId ?? {})).not.toContain('closed-elsewhere')
   })
 })
+
+/**
+ * Retirement removes the tab from the session model, which is only half of what a close owes it.
+ * The renderer keeps per-tab maps outside that model — agentStatusByPaneKey above all — and the
+ * sidebar's live index buckets a non-'done' entry whose tab id it cannot find under the entry's own
+ * worktree, so a survivor renders as a live agent row for a tab that no longer exists, and clicking
+ * it cannot clear it (WorktreeCardAgents bails when the row already sits on its own worktree).
+ *
+ * A BACKGROUND pane is the case that has no other cleanup: its status is written straight from the
+ * hook stream whether or not the pane is mounted, so no pty-exit or unmount handler ever clears it.
+ */
+describe('a peer-retired tab leaves no renderer state behind', () => {
+  const PANE_KEY = 'closed-elsewhere:leaf-1'
+
+  async function seedRetiredTabWithLiveAgent(store: TestStore): Promise<void> {
+    seedCatalog(store)
+    store.getState().setActiveWorktree(WORKTREE_ID)
+    await applySnapshot(store, snapshot(1, ['agent', 'closed-elsewhere']), PEER)
+    store
+      .getState()
+      .setAgentStatus(PANE_KEY, { state: 'working', prompt: 'pnpm install', agentType: 'claude' })
+    expect(store.getState().agentStatusByPaneKey[PANE_KEY]?.state).toBe('working')
+  }
+
+  it('drops the agent status of the tab the peer closed', async () => {
+    const store = createTestStore()
+    await seedRetiredTabWithLiveAgent(store)
+
+    await applySnapshot(store, snapshot(2, ['agent']), PEER)
+
+    expect(tabIdsOf(store)).toEqual(['agent'])
+    expect(
+      Object.keys(store.getState().agentStatusByPaneKey).filter((key) =>
+        key.startsWith('closed-elsewhere:')
+      ),
+      'a live agent row outlived the tab a peer closed, and the sidebar has no way to clear it'
+    ).toEqual([])
+  })
+
+  it('keeps the agent status of a pinned tab, which retirement refuses to close', async () => {
+    // The pin is the local user's explicit "do not take this away from me", so the primitive refuses
+    // the close and the tab stays on screen — sweeping its state would blank a live agent row.
+    const store = createTestStore()
+    seedCatalog(store)
+    store.getState().setActiveWorktree(WORKTREE_ID)
+    await applySnapshot(store, snapshot(1, ['agent']), PEER)
+    // Why created here rather than taken from the snapshot: pinning is a unified-tab gesture, and the
+    // create path is what mints the unified row (a host listing projects terminal rows only).
+    const setup = spawnLocalTab(store, 'setup')
+    store.getState().setAgentStatus(`${setup.id}:leaf-1`, {
+      state: 'working',
+      prompt: 'pnpm install',
+      agentType: 'claude'
+    })
+    store.getState().pinTab(setup.id)
+    // The peer listing it is what makes its next omission a retraction, so retirement is decided and
+    // only the pin stops it.
+    await applySnapshot(store, snapshot(2, ['agent', 'setup']), PEER)
+
+    await applySnapshot(store, snapshot(3, ['agent']), PEER)
+
+    expect(tabIdsOf(store)).toContain('setup')
+    expect(
+      store.getState().agentStatusByPaneKey[`${setup.id}:leaf-1`]?.state,
+      'a pinned tab that was never retired lost its agent status'
+    ).toBe('working')
+  })
+})

--- a/src/renderer/src/hooks/remote-workspace-snapshot-local-tab-survival.test.ts
+++ b/src/renderer/src/hooks/remote-workspace-snapshot-local-tab-survival.test.ts
@@ -15,19 +15,31 @@ import { describe, expect, it, vi } from 'vitest'
 import type * as AgentStatusModule from '@/lib/agent-status'
 import type { RemoteWorkspaceSnapshot } from '../../../shared/remote-workspace-types'
 import type { DirectSshAuthority, SshProviderEpoch } from '../../../shared/ssh-types'
+import { toAppSshPtyId } from '../../../shared/ssh-pty-id'
+import type { TerminalTab } from '../../../shared/terminal-tab-types'
+import { buildWorkspaceSessionPayload } from '../lib/workspace-session'
 import { createTestStore, makeWorktree } from '../store/slices/store-test-helpers'
 import { applyDirectSshRemoteWorkspaceSnapshot } from './remote-workspace-snapshot-apply'
 import type { DirectSshSnapshotApplyToken } from './direct-ssh-reconnect-coordinator-types'
 
-vi.mock('sonner', () => ({ toast: { info: vi.fn(), success: vi.fn(), error: vi.fn() } }))
+vi.mock('sonner', () => ({
+  toast: { info: vi.fn(), success: vi.fn(), error: vi.fn() }
+}))
 vi.mock('@/lib/agent-status', async (importOriginal) => {
   const actual = await importOriginal<typeof AgentStatusModule>()
-  return { ...actual, detectAgentStatusFromTitle: vi.fn().mockReturnValue(null) }
+  return {
+    ...actual,
+    detectAgentStatusFromTitle: vi.fn().mockReturnValue(null)
+  }
 })
 
 const TARGET_ID = 'ssh-target-1'
 const PATH = '/srv/proj/bug-cats'
 const WORKTREE_ID = `repoA::${PATH}`
+const OTHER_PATH = '/srv/proj/dogs'
+const OTHER_WORKTREE_ID = `repoB::${OTHER_PATH}`
+/** The other client of this host, as workspace.changed names it. */
+const PEER = 'peer-client-1'
 
 const authority: DirectSshAuthority = {
   targetId: TARGET_ID,
@@ -46,13 +58,31 @@ function token(snapshotRevision: number): DirectSshSnapshotApplyToken {
   }
 }
 
+function ptyIdOf(tabId: string): string {
+  return toAppSshPtyId(TARGET_ID, `relay-${tabId}`)
+}
+
+function remoteTabs(worktreePath: string, tabIds: readonly string[]) {
+  return tabIds.map((tabId, index) => ({
+    id: tabId,
+    worktreePath,
+    ptyId: ptyIdOf(tabId),
+    title: `Terminal ${index + 1}`,
+    customTitle: null,
+    color: null,
+    sortOrder: index,
+    createdAt: index + 1
+  }))
+}
+
 function snapshot(
   revision: number,
   tabIds: readonly string[],
-  options: { activeWorktreePath?: string | null } = {}
+  options: { activeWorktreePath?: string | null; otherTabIds?: readonly string[] } = {}
 ): RemoteWorkspaceSnapshot {
   const activeWorktreePath =
     options.activeWorktreePath === undefined ? PATH : options.activeWorktreePath
+  const allTabIds = [...tabIds, ...(options.otherTabIds ?? [])]
   return {
     namespace: 'workspace',
     revision,
@@ -62,21 +92,20 @@ function snapshot(
       activeWorktreePath,
       activeTabId: tabIds[0] ?? null,
       tabsByWorktreePath: {
-        [PATH]: tabIds.map((tabId, index) => ({
-          id: tabId,
-          worktreePath: PATH,
-          ptyId: `pty-${tabId}`,
-          title: `Terminal ${index + 1}`,
-          customTitle: null,
-          color: null,
-          sortOrder: index,
-          createdAt: index + 1
-        }))
+        [PATH]: remoteTabs(PATH, tabIds),
+        // Why omitted rather than empty when undefined: a peer that does not hold repoB strips the
+        // key entirely, which is the case the path guard has to tell apart from a close.
+        ...(options.otherTabIds
+          ? { [OTHER_PATH]: remoteTabs(OTHER_PATH, options.otherTabIds) }
+          : {})
       },
       terminalLayoutsByTabId: {},
-      activeWorktreePathsOnShutdown: [],
+      // Why production-shaped: a real host lists the worktrees that were open at shutdown and real
+      // ssh:<target>@@<relay-id> session ids, which is what makes hydration seed the reconnect
+      // ledgers for every listed tab. A fixture with those empty hides whether the veto is inert.
+      activeWorktreePathsOnShutdown: [PATH, ...(options.otherTabIds ? [OTHER_PATH] : [])],
       activeTabIdByWorktreePath: { [PATH]: tabIds[0] ?? null },
-      remoteSessionIdsByTabId: Object.fromEntries(tabIds.map((id) => [id, `pty-${id}`])),
+      remoteSessionIdsByTabId: Object.fromEntries(allTabIds.map((id) => [id, ptyIdOf(id)])),
       lastVisitedAtByWorktreePath: { [PATH]: revision },
       defaultTerminalTabsAppliedByWorktreePath: { [PATH]: true }
     }
@@ -85,7 +114,12 @@ function snapshot(
 
 type TestStore = ReturnType<typeof createTestStore>
 
-async function applySnapshot(store: TestStore, snap: RemoteWorkspaceSnapshot): Promise<void> {
+/** `publisherClientId` is what useIpcEvents forwards from workspace.changed's sourceClientId. */
+async function applySnapshot(
+  store: TestStore,
+  snap: RemoteWorkspaceSnapshot,
+  publisherClientId?: string | null
+): Promise<void> {
   await applyDirectSshRemoteWorkspaceSnapshot({
     store,
     snapshot: snap,
@@ -94,7 +128,12 @@ async function applySnapshot(store: TestStore, snap: RemoteWorkspaceSnapshot): P
     isArrivalCurrent: () => true,
     isPreparationTokenCurrent: () => true,
     waitForWorkspaceSessionReady: async () => true,
-    finalizeHydratedTerminals: () => 0
+    // Why the real action: useIpcEvents wires this callback to retryDirectSshTargetPanes
+    // (useIpcEvents.ts:731-733 -> direct-ssh-reconnect-coordinator.ts:270), and the apply runs it at
+    // the end of every snapshot, so in production the reconnect ledgers are populated for every tab
+    // of the target before the next snapshot arrives. A stub here hides that entirely.
+    finalizeHydratedTerminals: (auth) => store.getState().retryDirectSshTargetPanes(auth),
+    publisherClientId
   })
 }
 
@@ -108,6 +147,14 @@ function seedCatalog(store: TestStore): void {
           path: PATH,
           hostId: `ssh:${TARGET_ID}`
         } as never)
+      ],
+      repoB: [
+        makeWorktree({
+          id: OTHER_WORKTREE_ID,
+          repoId: 'repoB',
+          path: OTHER_PATH,
+          hostId: `ssh:${TARGET_ID}`
+        } as never)
       ]
     },
     repos: [
@@ -118,12 +165,55 @@ function seedCatalog(store: TestStore): void {
         badgeColor: '#000',
         addedAt: 0,
         connectionId: TARGET_ID
+      } as never,
+      {
+        id: 'repoB',
+        path: '/srv/proj-dogs',
+        displayName: 'Dogs',
+        badgeColor: '#000',
+        addedAt: 0,
+        connectionId: TARGET_ID
       } as never
     ],
+    // Why connected: retryDirectSshTargetPanes is a no-op under a non-current authority, and the
+    // production apply always runs it under the connected one.
+    sshConnectionStates: new Map([
+      [
+        TARGET_ID,
+        {
+          status: 'connected',
+          providerEpoch: authority.providerEpoch,
+          connectionGeneration: authority.connectionGeneration
+        } as never
+      ]
+    ]),
     reconnectPersistedTerminals: (async () => {}) as never,
+    // Why: worktree activation revalidates PR state, which reaches window.api in this bare store.
+    refreshGitHubForWorktreeIfStale: (() => {}) as never,
+    // Why: spawning a pane bumps worktree activity, which reaches window.api in this bare store.
+    bumpWorktreeActivity: (() => {}) as never,
     markRemoteWorkspaceHydrated: (() => {}) as never,
     setRemoteWorkspaceSyncStatus: (() => {}) as never
   })
+}
+
+function tabIdsOf(store: TestStore): string[] {
+  return (store.getState().tabsByWorktree[WORKTREE_ID] ?? []).map((tab) => tab.id)
+}
+
+function otherTabIdsOf(store: TestStore): string[] {
+  return (store.getState().tabsByWorktree[OTHER_WORKTREE_ID] ?? []).map((tab) => tab.id)
+}
+
+/**
+ * The ordinary create-a-tab-while-connected flow: the user opens a tab and its pane spawns a remote
+ * pty. Both are real store actions — nothing seeds the direct-SSH reconnect ledgers, because on this
+ * path nothing ever does.
+ */
+function spawnLocalTab(store: TestStore, tabId: string): TerminalTab {
+  const tab = store.getState().createTab(WORKTREE_ID, undefined, undefined, { id: tabId })
+  store.getState().updateTabPtyId(tab.id, ptyIdOf(tab.id))
+  return tab
 }
 
 /** A tab the user created locally whose upload has not landed yet. */
@@ -205,5 +295,151 @@ describe('direct-SSH snapshot apply keeps local state the host has not seen', ()
     const tabIds = (store.getState().tabsByWorktree[WORKTREE_ID] ?? []).map((tab) => tab.id)
     expect(tabIds).toEqual([...new Set(tabIds)])
     expect(tabIds.filter((id) => id === 'setup')).toHaveLength(1)
+  })
+
+  it('drops a tab another client closed once that client stops listing it', async () => {
+    // The other half of the same ambiguity. The peer listed both tabs, then listed only one: that is
+    // a RETRACTION by the client that wrote both listings, not mere absence. Preserving it forever
+    // also re-uploads it, and because patches are replace-session the tab comes back on the host and
+    // on the client that closed it.
+    const store = createTestStore()
+    seedCatalog(store)
+    store.getState().setActiveWorktree(WORKTREE_ID)
+    await applySnapshot(store, snapshot(1, ['agent', 'closed-elsewhere']), PEER)
+    expect(tabIdsOf(store)).toEqual(['agent', 'closed-elsewhere'])
+    // The state production is actually in when the retraction arrives: the apply's retry pass has
+    // given the tab a pending retry and bumped its generation past anything the peer listed. Both
+    // are per-client pty bookkeeping, so neither may veto the peer's retraction.
+    expect(store.getState().directSshPaneRetryByTabId).toHaveProperty('closed-elsewhere')
+    expect(
+      store.getState().tabsByWorktree[WORKTREE_ID]?.find((tab) => tab.id === 'closed-elsewhere')
+        ?.generation
+    ).toBe(1)
+
+    await applySnapshot(store, snapshot(2, ['agent']), PEER)
+
+    expect(tabIdsOf(store), 'a tab closed on another client survived the next snapshot').toEqual([
+      'agent'
+    ])
+  })
+
+  it('retires the closed tab and keeps the upload-pending one from the same snapshot', async () => {
+    const store = createTestStore()
+    seedCatalog(store)
+    store.getState().setActiveWorktree(WORKTREE_ID)
+    await applySnapshot(store, snapshot(1, ['agent', 'closed-elsewhere']), PEER)
+    addLocalTab(store, 'setup')
+
+    await applySnapshot(store, snapshot(2, ['agent']), PEER)
+
+    expect(tabIdsOf(store)).toContain('setup')
+    expect(tabIdsOf(store)).not.toContain('closed-elsewhere')
+  })
+
+  it('keeps every tab of a worktree a peer with a narrower repo set omits', async () => {
+    // The namespace is shared by every client of the host and workspace.patch is replace-session, so
+    // a peer that holds repoA but not repoB strips the repoB key on EVERY push. Reading that as
+    // "the host retired those tabs" deletes live panes whose ptys this path deliberately never
+    // kills, orphaning the remote processes.
+    const store = createTestStore()
+    seedCatalog(store)
+    store.getState().setActiveWorktree(WORKTREE_ID)
+    await applySnapshot(store, snapshot(1, ['agent'], { otherTabIds: ['dogs-build'] }), PEER)
+    expect(otherTabIdsOf(store)).toEqual(['dogs-build'])
+
+    await applySnapshot(store, snapshot(2, ['agent']), PEER)
+
+    expect(otherTabIdsOf(store), 'a peer that does not hold repoB retired its tabs').toEqual([
+      'dogs-build'
+    ])
+  })
+
+  it('keeps a tab created here while connected when a stale peer rewrites the namespace', async () => {
+    // The reviewer's repro, driven through the real create-a-tab path. The peer's MAIN-process cache
+    // already holds the revision carrying `setup` — that is what it CAS'd on — while its renderer
+    // apply still lags, so it republishes an older tab list at a newer revision. The tab has a
+    // mounted pane and a running remote pty; nothing about the peer's write is evidence about it.
+    const store = createTestStore()
+    seedCatalog(store)
+    store.getState().setActiveWorktree(WORKTREE_ID)
+    await applySnapshot(store, snapshot(1, ['agent']), PEER)
+
+    const setup = spawnLocalTab(store, 'setup')
+    // The create path seeds no reconnect ledger for the new tab, while the apply's retry pass has
+    // already seeded one for every host-listed tab — which is exactly why a ledger-shaped veto is
+    // both useless here and universal there.
+    expect(store.getState().directSshPaneRetryByTabId).not.toHaveProperty(setup.id)
+    expect(store.getState().directSshLivePtyBindingByTabId).not.toHaveProperty(setup.id)
+    expect(store.getState().directSshPaneRetryByTabId).toHaveProperty('agent')
+    // The host itself now lists `setup` at rev 2 — the harder case, since even a full host listing
+    // is unattributed and so can never be retracted by a peer that never wrote it.
+    store.getState().recordRemoteWorkspaceHostAck(TARGET_ID, snapshot(2, ['agent', 'setup']), null)
+
+    await applySnapshot(store, snapshot(3, ['agent']), PEER)
+
+    expect(tabIdsOf(store), 'a live locally created pane was retired').toContain(setup.id)
+    expect(
+      store.getState().lastKnownRelayPtyIdByTabId[setup.id],
+      "the apply dropped this client's claim on a running remote process"
+    ).toBe(ptyIdOf(setup.id))
+  })
+
+  it('never retires it however often that peer republishes without it', async () => {
+    // Not a delay: a publisher that never listed the id has nothing to retract, so repeating the
+    // stale write cannot wear the guard down.
+    const store = createTestStore()
+    seedCatalog(store)
+    store.getState().setActiveWorktree(WORKTREE_ID)
+    await applySnapshot(store, snapshot(1, ['agent']), PEER)
+    const setup = spawnLocalTab(store, 'setup')
+
+    await applySnapshot(store, snapshot(2, ['agent']), PEER)
+    await applySnapshot(store, snapshot(3, ['agent']), PEER)
+    await applySnapshot(store, snapshot(4, ['agent']), PEER)
+
+    expect(tabIdsOf(store)).toContain(setup.id)
+  })
+
+  it('retires that same tab once the peer has listed it and then drops it', async () => {
+    // The guard delays retirement to the point where there IS evidence: the peer applies this
+    // client's upload, republishes with `setup` in it, and only its next omission is a retraction.
+    const store = createTestStore()
+    seedCatalog(store)
+    store.getState().setActiveWorktree(WORKTREE_ID)
+    await applySnapshot(store, snapshot(1, ['agent']), PEER)
+    const setup = spawnLocalTab(store, 'setup')
+    await applySnapshot(store, snapshot(2, ['agent', 'setup']), PEER)
+    expect(tabIdsOf(store)).toContain(setup.id)
+
+    await applySnapshot(store, snapshot(3, ['agent']), PEER)
+
+    expect(tabIdsOf(store)).toEqual(['agent'])
+  })
+
+  it('ignores an unattributed snapshot, which is what a workspace.get pull is', async () => {
+    const store = createTestStore()
+    seedCatalog(store)
+    store.getState().setActiveWorktree(WORKTREE_ID)
+    await applySnapshot(store, snapshot(1, ['agent', 'closed-elsewhere']), PEER)
+
+    await applySnapshot(store, snapshot(2, ['agent']))
+
+    expect(tabIdsOf(store)).toContain('closed-elsewhere')
+  })
+
+  it('keeps the retired tab out of the next uploaded payload', async () => {
+    const store = createTestStore()
+    seedCatalog(store)
+    store.getState().setActiveWorktree(WORKTREE_ID)
+    await applySnapshot(store, snapshot(1, ['agent', 'closed-elsewhere']), PEER)
+
+    await applySnapshot(store, snapshot(2, ['agent']), PEER)
+
+    // Guards the resurrection loop: whatever survives here is what the next persist pushes back.
+    const payload = buildWorkspaceSessionPayload(store.getState())
+    expect(payload.tabsByWorktree[WORKTREE_ID]?.map((tab) => tab.id)).not.toContain(
+      'closed-elsewhere'
+    )
+    expect(Object.keys(payload.remoteSessionIdsByTabId ?? {})).not.toContain('closed-elsewhere')
   })
 })

--- a/src/renderer/src/hooks/remote-workspace-target-sync.test.ts
+++ b/src/renderer/src/hooks/remote-workspace-target-sync.test.ts
@@ -121,6 +121,8 @@ function appState(overrides: Record<string, unknown> = {}): AppState {
     hydrateBrowserSession: vi.fn(),
     markRemoteWorkspaceHydrated: vi.fn(),
     setRemoteWorkspaceSyncStatus: vi.fn(),
+    remoteWorkspaceHostAckByTargetId: {},
+    recordRemoteWorkspaceHostAck: vi.fn(),
     reconnectPersistedTerminals: vi.fn(async () => {}),
     ...overrides
   } as unknown as AppState
@@ -213,6 +215,28 @@ describe('createRemoteWorkspaceTargetSync', () => {
     expect(harness.setForConnectedTargets).toHaveBeenCalledOnce()
     expect(harness.setForConnectedTargets).toHaveBeenCalledWith(
       expect.objectContaining({ hydratedTargetIds: ['target-a'] })
+    )
+  })
+
+  it('records the publisher of an unsolicited snapshot, and nobody for a pull', async () => {
+    // Only the client that wrote a listing can retract it, so the identity has to reach the ledger.
+    // A pull has no publisher and therefore can never authorize a retirement.
+    const state = appState()
+    const pulled = snapshot(7, { '/remote/work': [] })
+    const harness = createHarness(state, async () => pulled)
+
+    await harness.sync.syncAfterConnect(token())
+    await harness.sync.applyUnsolicitedSnapshot('target-a', snapshot(8, {}), 'peer-client-1')
+
+    expect(state.recordRemoteWorkspaceHostAck).toHaveBeenCalledWith(
+      'target-a',
+      expect.objectContaining({ revision: 7 }),
+      undefined
+    )
+    expect(state.recordRemoteWorkspaceHostAck).toHaveBeenCalledWith(
+      'target-a',
+      expect.objectContaining({ revision: 8 }),
+      'peer-client-1'
     )
   })
 

--- a/src/renderer/src/hooks/remote-workspace-target-sync.ts
+++ b/src/renderer/src/hooks/remote-workspace-target-sync.ts
@@ -44,7 +44,11 @@ export type RemoteWorkspaceTargetSyncDeps = {
 
 export type RemoteWorkspaceTargetSync = {
   syncAfterConnect: (token: DirectSshPreparationToken) => Promise<void>
-  applyUnsolicitedSnapshot: (targetId: string, snapshot: RemoteWorkspaceSnapshot) => Promise<void>
+  applyUnsolicitedSnapshot: (
+    targetId: string,
+    snapshot: RemoteWorkspaceSnapshot,
+    publisherClientId?: string | null
+  ) => Promise<void>
   stop: () => void
 }
 
@@ -211,7 +215,10 @@ export function createRemoteWorkspaceTargetSync(
 
   const applyUnsolicitedSnapshot = async (
     targetId: string,
-    snapshot: RemoteWorkspaceSnapshot
+    snapshot: RemoteWorkspaceSnapshot,
+    // Why threaded rather than derived: only the client that wrote a listing can retract it, and
+    // this is the one place that identity is available (pulls have none and so retire nothing).
+    publisherClientId?: string | null
   ): Promise<void> => {
     const arrival = beginArrival(targetId)
     const authority = deps.getCurrentAuthority(targetId)
@@ -240,7 +247,8 @@ export function createRemoteWorkspaceTargetSync(
         isArrivalCurrent,
         isPreparationTokenCurrent: deps.isPreparationTokenCurrent,
         waitForWorkspaceSessionReady,
-        finalizeHydratedTerminals: deps.finalizeHydratedTerminals
+        finalizeHydratedTerminals: deps.finalizeHydratedTerminals,
+        publisherClientId
       })
     }
   }

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -3127,8 +3127,10 @@ export function useIpcEvents(): void {
             if (event.sourceClientId && clientId && event.sourceClientId === clientId) {
               return
             }
+            // Why sourceClientId reaches the apply: a snapshot can only retire a tab its own
+            // publisher once listed, so absence from a peer that never knew the tab is inert.
             await remoteWorkspaceTargetSync
-              ?.applyUnsolicitedSnapshot(event.targetId, event.snapshot)
+              ?.applyUnsolicitedSnapshot(event.targetId, event.snapshot, event.sourceClientId)
               .catch((err) => {
                 useAppStore.getState().setRemoteWorkspaceSyncStatus(event.targetId, {
                   phase: 'error',

--- a/src/renderer/src/store/slices/retired-terminal-tab-state-sweep.ts
+++ b/src/renderer/src/store/slices/retired-terminal-tab-state-sweep.ts
@@ -1,0 +1,43 @@
+import type { AppState } from '../types'
+import { forgetAgentHibernationTabOutput } from '@/lib/agent-hibernation-output-activity'
+import { forgetForegroundTerminalTabs } from '@/lib/foreground-terminal-tabs'
+import { forgetAgentStartupDeliveriesForTabs } from '@/lib/agent-startup-delivery-guards'
+// Why: the store-free registry (not terminal-parked-tab-watchers, which imports @/store) so a slice can import this module during its own evaluation.
+import { retireParkedTerminalTab } from '@/components/terminal-pane/terminal-parked-watcher-registry'
+
+export type RetiredTerminalTabSweepActions = Pick<
+  AppState,
+  'dropAgentStatusByTabPrefix' | 'clearPaneForegroundAgentByTabPrefix'
+>
+
+/**
+ * Every renderer-side map a retired terminal tab leaves behind that no `set()` on the session model
+ * reaches: two suppressor-aware store actions plus three module-level registries.
+ *
+ * One unit with two callers on purpose. `closeTab` grew this list inline, so the peer-retirement path
+ * (remote-workspace-host-tab-retirement) removed a tab through the pure session transform and swept
+ * none of it — a background pane's `agentStatusByPaneKey` row outlived its tab and kept rendering a
+ * live sidebar agent row that nothing could clear. A second copy of the list is how that recurs.
+ *
+ * Must run AFTER the tab is out of `tabsByWorktree`: dropAgentStatusByTabPrefix's completed-orphan
+ * sweep is defined as "keyed under a tab id this worktree no longer has".
+ */
+export function sweepRetiredTerminalTabState(
+  actions: RetiredTerminalTabSweepActions,
+  tabId: string,
+  worktreeId?: string | null
+): void {
+  // Why: idempotent, and retirement has no earlier hook — closeTab still revokes these before its own
+  // provider teardown, where the ordering against pty exit is load-bearing.
+  retireParkedTerminalTab(tabId)
+  // Why: sweep tab agent status through its suppressor-aware removal path.
+  // Why the worktree: Pi can leave a completed row keyed under an already-missing tab id; passing it sweeps that orphan while preserving active pre-render child rows.
+  actions.dropAgentStatusByTabPrefix(tabId, worktreeId ? { worktreeId } : undefined)
+  // Why: retired pane keys never recur, so stranded foreground entries would accumulate for the renderer's whole lifetime.
+  actions.clearPaneForegroundAgentByTabPrefix(tabId)
+  // Why: retirement permanently retires the tab's panes (a reopen mints a fresh leafId), so drop hibernation output epochs to keep the module map from growing forever.
+  forgetAgentHibernationTabOutput(tabId)
+  // Why: same rationale — retired tab ids never recur, so drop the foreground last-seen and consumed agent-startup delivery guards.
+  forgetForegroundTerminalTabs([tabId])
+  forgetAgentStartupDeliveriesForTabs([tabId])
+}

--- a/src/renderer/src/store/slices/ssh-target-cleanup.ts
+++ b/src/renderer/src/store/slices/ssh-target-cleanup.ts
@@ -2,6 +2,7 @@ import type { AppState } from '../types'
 import type { SshConnectionState, SshTarget } from '../../../../shared/ssh-types'
 import { parseAppSshPtyId } from '../../../../shared/ssh-pty-id'
 import { resolveDirectSshTargetScope } from '../../lib/direct-ssh-target-scope'
+import { clearRemoteWorkspaceHostAck } from '../../hooks/remote-workspace-host-ack-ledger'
 
 export function sshConnectionStatesEqual(
   a: SshConnectionState | undefined,
@@ -209,6 +210,8 @@ export function buildRemovedSshTargetCleanupPatch(
   const nextHydrated = new Set(state.remoteWorkspaceHydratedTargetIds)
   const removedHydrated = nextHydrated.delete(targetId)
   const removedSyncStatus = Object.hasOwn(state.remoteWorkspaceSyncStatusByTargetId, targetId)
+  const nextHostAck = clearRemoteWorkspaceHostAck(state.remoteWorkspaceHostAckByTargetId, targetId)
+  const removedHostAck = nextHostAck !== state.remoteWorkspaceHostAckByTargetId
   const removedPortForwards = Object.hasOwn(state.portForwardsByConnection, targetId)
   const removedDetectedPorts = Object.hasOwn(state.detectedPortsByConnection, targetId)
   const nextSyncStatus = { ...state.remoteWorkspaceSyncStatusByTargetId }
@@ -227,6 +230,7 @@ export function buildRemovedSshTargetCleanupPatch(
     removedLabel ||
     removedHydrated ||
     removedSyncStatus ||
+    removedHostAck ||
     removedPortForwards ||
     removedDetectedPorts ||
     tabPtyState.changed ||
@@ -249,6 +253,7 @@ export function buildRemovedSshTargetCleanupPatch(
     ...(removedLabel ? { sshTargetLabels: nextLabels } : {}),
     ...(removedHydrated ? { remoteWorkspaceHydratedTargetIds: nextHydrated } : {}),
     ...(removedSyncStatus ? { remoteWorkspaceSyncStatusByTargetId: nextSyncStatus } : {}),
+    ...(removedHostAck ? { remoteWorkspaceHostAckByTargetId: nextHostAck } : {}),
     ...(removedPortForwards ? { portForwardsByConnection: nextPortForwards } : {}),
     ...(removedDetectedPorts ? { detectedPortsByConnection: nextDetectedPorts } : {}),
     ...(tabPtyState.changed

--- a/src/renderer/src/store/slices/ssh.test.ts
+++ b/src/renderer/src/store/slices/ssh.test.ts
@@ -80,6 +80,26 @@ describe('createSshSlice', () => {
         [targetId]: { phase: 'offline' },
         [otherTargetId]: { phase: 'synced' }
       },
+      remoteWorkspaceHostAckByTargetId: {
+        [targetId]: {
+          namespace: 'ns-removed',
+          listingsByPublisherId: {
+            'peer-1': {
+              revision: 3,
+              tabsById: { 'tab-ssh': { worktreePath: '/remote/ssh' } }
+            }
+          }
+        },
+        [otherTargetId]: {
+          namespace: 'ns-other',
+          listingsByPublisherId: {
+            'peer-2': {
+              revision: 4,
+              tabsById: { 'tab-other': { worktreePath: '/remote/other' } }
+            }
+          }
+        }
+      },
       portForwardsByConnection: {
         [targetId]: [
           {
@@ -172,6 +192,9 @@ describe('createSshSlice', () => {
     expect(state.sshTargetLabels.has(targetId)).toBe(false)
     expect(state.remoteWorkspaceHydratedTargetIds.has(targetId)).toBe(false)
     expect(state.remoteWorkspaceSyncStatusByTargetId[targetId]).toBeUndefined()
+    // Why it must go with the rest: a revision from a target's previous host must never authorize
+    // retiring a live tab after the target is re-added.
+    expect(state.remoteWorkspaceHostAckByTargetId[targetId]).toBeUndefined()
     expect(state.portForwardsByConnection[targetId]).toBeUndefined()
     expect(state.detectedPortsByConnection[targetId]).toBeUndefined()
     expect(state.sshCredentialQueue.map((req) => req.targetId)).toEqual([otherTargetId])
@@ -205,6 +228,10 @@ describe('createSshSlice', () => {
     expect(state.sshTargetLabels.get(otherTargetId)).toBe('Other target')
     expect(state.remoteWorkspaceHydratedTargetIds.has(otherTargetId)).toBe(true)
     expect(state.remoteWorkspaceSyncStatusByTargetId[otherTargetId]).toEqual({ phase: 'synced' })
+    expect(
+      state.remoteWorkspaceHostAckByTargetId[otherTargetId]?.listingsByPublisherId['peer-2']
+        ?.revision
+    ).toBe(4)
     expect(state.portForwardsByConnection[otherTargetId]).toHaveLength(1)
     expect(state.detectedPortsByConnection[otherTargetId]).toHaveLength(1)
     expect(state.tabsByWorktree[otherWorktreeId][0]?.ptyId).toBe(otherPtyId)

--- a/src/renderer/src/store/slices/ssh.ts
+++ b/src/renderer/src/store/slices/ssh.ts
@@ -6,6 +6,12 @@ import type {
   EnrichedDetectedPort,
   SshTarget
 } from '../../../../shared/ssh-types'
+import type { RemoteWorkspaceSnapshot } from '../../../../shared/remote-workspace-types'
+import {
+  clearRemoteWorkspaceHostAck,
+  recordRemoteWorkspaceHostAck,
+  type RemoteWorkspaceHostAckLedger
+} from '../../hooks/remote-workspace-host-ack-ledger'
 import {
   buildRemovedSshTargetCleanupPatch,
   sshConnectionStatesEqual,
@@ -44,6 +50,9 @@ export type SshSlice = {
   sshTargetsHydrated: boolean
   remoteWorkspaceHydratedTargetIds: Set<string>
   remoteWorkspaceSyncStatusByTargetId: Record<string, RemoteWorkspaceSyncStatus>
+  /** What each CLIENT of a host has itself published about that host's tab list. Lets a snapshot
+   * retire a tab its publisher once listed, without letting a peer that never knew the tab delete it. */
+  remoteWorkspaceHostAckByTargetId: RemoteWorkspaceHostAckLedger
   sshCredentialQueue: SshCredentialRequest[]
   /** Incremented when an SSH target transitions to 'connected'. Allows
    * components like the file explorer to re-trigger data loads that failed
@@ -65,6 +74,11 @@ export type SshSlice = {
   markRemoteWorkspaceHydrated: (targetId: string) => void
   clearRemoteWorkspaceHydrated: (targetId: string) => void
   setRemoteWorkspaceSyncStatus: (targetId: string, status: RemoteWorkspaceSyncStatus) => void
+  recordRemoteWorkspaceHostAck: (
+    targetId: string,
+    snapshot: RemoteWorkspaceSnapshot,
+    publisherClientId: string | null | undefined
+  ) => void
   enqueueSshCredentialRequest: (req: SshCredentialRequest) => void
   removeSshCredentialRequest: (requestId: string) => void
   setPortForwards: (targetId: string, forwards: PortForwardEntry[]) => void
@@ -89,6 +103,7 @@ export const createSshSlice: StateCreator<AppState, [], [], SshSlice> = (set) =>
   sshTargetsHydrated: false,
   remoteWorkspaceHydratedTargetIds: new Set(),
   remoteWorkspaceSyncStatusByTargetId: {},
+  remoteWorkspaceHostAckByTargetId: {},
   sshCredentialQueue: [],
   sshConnectedGeneration: 0,
   portForwardsByConnection: {},
@@ -145,7 +160,15 @@ export const createSshSlice: StateCreator<AppState, [], [], SshSlice> = (set) =>
     set((s) => {
       const next = new Set(s.remoteWorkspaceHydratedTargetIds)
       next.delete(targetId)
-      return { remoteWorkspaceHydratedTargetIds: next }
+      // Why the listings go too: they are keyed by target but only meaningful for one namespace/
+      // authority, and a stale revision from a previous one must never authorize retiring a live tab.
+      return {
+        remoteWorkspaceHydratedTargetIds: next,
+        remoteWorkspaceHostAckByTargetId: clearRemoteWorkspaceHostAck(
+          s.remoteWorkspaceHostAckByTargetId,
+          targetId
+        )
+      }
     }),
   setRemoteWorkspaceSyncStatus: (targetId, status) =>
     set((s) => ({
@@ -153,6 +176,19 @@ export const createSshSlice: StateCreator<AppState, [], [], SshSlice> = (set) =>
         ...s.remoteWorkspaceSyncStatusByTargetId,
         [targetId]: status
       }
+    })),
+  recordRemoteWorkspaceHostAck: (targetId, snapshot, publisherClientId) =>
+    set((s) => ({
+      remoteWorkspaceHostAckByTargetId: recordRemoteWorkspaceHostAck(
+        s.remoteWorkspaceHostAckByTargetId,
+        targetId,
+        snapshot,
+        // Why the whole map and not a flattened id set: bounding the ledger only needs the worktrees
+        // this target's own listings named, and the ledger reads exactly those — flattening here
+        // would walk every repo on every host on every listing.
+        s.tabsByWorktree,
+        publisherClientId
+      )
     })),
   enqueueSshCredentialRequest: (req) =>
     set((s) => ({ sshCredentialQueue: [...s.sshCredentialQueue, req] })),

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -49,10 +49,8 @@ import { WINDOWS_GIT_BASH_SHELL } from '../../../../shared/windows-terminal-shel
 import type { AgentStartedTelemetry } from '../../lib/worktree-startup-payload'
 import type { AiVaultSessionTitle } from '../../../../shared/ai-vault-session-title'
 import { scheduleRuntimeGraphSync } from '@/runtime/sync-runtime-graph'
-import { forgetAgentHibernationTabOutput } from '@/lib/agent-hibernation-output-activity'
-import { forgetForegroundTerminalTabs } from '@/lib/foreground-terminal-tabs'
 import { terminalLayoutEqual } from '@/lib/terminal-layout-equality'
-import { forgetAgentStartupDeliveriesForTabs } from '@/lib/agent-startup-delivery-guards'
+import { sweepRetiredTerminalTabState } from './retired-terminal-tab-state-sweep'
 import { clearTransientTerminalState, emptyLayoutSnapshot } from './terminal-helpers'
 import {
   collectReleasedLeafIds,
@@ -1830,19 +1828,8 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
           : {})
       }
     })
-    // Why: sweep tab agent status through its suppressor-aware removal path.
-    // Why: Pi can leave a completed row keyed under an already-missing tab id; pass the worktree to sweep that orphan while preserving active pre-render child rows.
-    get().dropAgentStatusByTabPrefix(
-      tabId,
-      closingWorktreeId ? { worktreeId: closingWorktreeId } : undefined
-    )
-    // Why: retired pane keys never recur, so stranded foreground entries would accumulate for the renderer's whole lifetime.
-    get().clearPaneForegroundAgentByTabPrefix(tabId)
-    // Why: closing a tab permanently retires its panes (reopen mints a fresh leafId), so drop hibernation output epochs to keep the module map from growing forever.
-    forgetAgentHibernationTabOutput(tabId)
-    // Why: same rationale — retired tab ids never recur, so drop the foreground last-seen and consumed agent-startup delivery guards.
-    forgetForegroundTerminalTabs([tabId])
-    forgetAgentStartupDeliveriesForTabs([tabId])
+    // Why shared with peer retirement: every path that removes a tab owes it the same sweep, and a second copy of the list is how one path silently misses a new entry.
+    sweepRetiredTerminalTabState(get(), tabId, closingWorktreeId)
     for (const tabs of Object.values(get().unifiedTabsByWorktree)) {
       const workspaceItem = tabs.find(
         (entry) => entry.contentType === 'terminal' && entry.entityId === tabId


### PR DESCRIPTION
## ELI5

Say you have Orca open on your laptop **and** your desktop, both connected to the same server. You close a terminal tab on the laptop. The desktop should notice and close it too — but it didn't. Worse, the desktop would re-upload the tab, making it pop back up on the laptop.

Here's why. The two machines share one list of tabs on the server. The desktop looked at the list, didn't find the tab, and had to decide what that meant. And "not in the list" means two completely different things:

- **"It was closed."** → should disappear here too.
- **"Nobody's told the server about it yet."** → a brand-new tab still uploading. Deleting that would kill a live terminal and the program running in it.

You genuinely cannot tell those apart from absence alone, so the safe guess was always "keep it" — which is why closed tabs came back.

The fix is to stop reading silence and start watching **who wrote the list**. Every update already carries a stamp saying which machine wrote it. So now we remember what each machine has said. If the same machine that previously said *"I have tab X"* later writes a list without X, that's it **taking X back** — a real close, and we act on it. If a machine never mentioned X, its silence tells us nothing and we leave X alone.

Like this: if the friend who told you they're bringing cake later sends a list with no cake, the cake is off. If a stranger sends a list with no cake, you've learned nothing about the cake.

**What you might notice:**
- Closing a tab on one machine now actually closes it on the other, instead of it bouncing back.
- The first close after either machine restarts still won't sync — a fresh machine hasn't told us anything yet, so it gets the benefit of the doubt. It syncs from then on.
- Pinned tabs are left alone on purpose.
- The remote program is never killed. If the other machine's cleanup didn't land, it keeps running on the server rather than being cut off.
- Closing this way is permanent — same as closing it yourself. Scrollback and layout for that tab go with it, and there's no undo.

---
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1117 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1100 |
| Prod | 9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​507 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​28 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​479 |

<!-- /orca-pr-loc -->

Resolves [STA-4719](https://linear.app/stably/issue/STA-4719). Follow-up from #14844.

## Problem

`mergeDirectSshRemoteWorkspaceSession` preserves host-unknown local tabs to protect pending uploads. Its own comment names the trade it accepts: *"absence cannot distinguish 'never uploaded' from 'closed by another client on this host'"*, so a tab closed elsewhere survives here until that client's snapshot is applied — and gets re-uploaded, resurrecting it on the host.

## Root cause

Snapshot-absence was overloaded as a proxy for two different facts. The fix is to stop inferring from absence and use a positive signal.

## Fix: retraction, not absence

`workspace.changed` already carries `sourceClientId` (on the wire since #1876). The ledger is now keyed per (target, publisher) and records what each *client* of the host has itself listed. A tab is retired only when **the same publisher that once listed it stops listing it** — a retraction, which is positive evidence that the writer knew the tab and dropped it. Absence from a publisher that never listed the id is structurally inert, however many times it republishes.

Nothing new crosses the wire; the renderer reads a field that has always been there. An old relay yields no publisher and retires nothing. The ledger is memory-only and client-local.

### Why not the alternatives

- **Direct staleness detection is not decidable from the wire.** `RemoteWorkspaceSnapshot` carries only `{namespace, revision, updatedAt, schemaVersion, session}`. The relay CAS rejects unless `baseRevision === current.revision` and publishes `current.revision + 1`, so the base is *always* `revision - 1` and carries zero information — and it is the writer's main-process cache, not the base its renderer built the session from. "Peer closed T" and "peer never knew T" produce byte-identical wire output.
- **"Omission persists across K revisions"** only delays a wrong deletion. A stale peer that publishes twice still retires a live pane. It is a probability knob, not a discriminator.

## Two failure modes this had to survive

Both were found by review and both end in live panes being retired with their remote ptys **not** killed — orphaned processes, the exact invariant the merge's preserve rule exists to protect.

1. **A peer with a narrower repo set.** The namespace is shared by every client of the host, and each client exports only the worktrees whose repo it holds, so a peer deterministically strips whole worktree keys on every push. Closed by a per-worktree-path guard: only retire ids under a path the retiring snapshot still describes, with a per-tab `listed.worktreePath` match. Fails closed on a missing or unparseable path.
2. **The main-cache-ahead-of-renderer race.** `handleRemoteWorkspaceNotification` updates the peer's main cache synchronously while its renderer apply lags, so the peer CAS-es on a revision it never applied and republishes an older tab list at a newer revision. Closed by the retraction rule itself: the peer never *listed* the locally created tab, so it cannot retract it.

## A note on the two rejected guards

Earlier iterations added a local liveness veto. Both settings were wrong, in opposite directions, and both were hidden by an unrealistic fixture:

- keyed on the direct-SSH **retry-lease** ledgers → empty for a tab created while already connected → live panes retired;
- keyed on `terminalTabHasReconnectablePty` → `hydrateTabsSession` + `reconnectPersistedTerminals` stamp it on essentially every host-listed tab → retirement never fired at all.

Both are gone. No local-state predicate participates in the decision, and the selector's docblock says why: the direct-SSH reconnect pass (`retryDirectSshTargetPanes`, run at the end of every snapshot apply) touches every tab of the target, so any veto built on that state is universally satisfied and silently disables the feature. The remaining conditions — publisher identity, target, namespace, strict revision, per-worktree-path — are all statements about the publisher's own evidence, and the retry pass does not write to the ledger.

## Tests

The fixture now routes `finalizeHydratedTerminals` through the real `retryDirectSshTargetPanes`, matching production, so tests exercise the state the app is actually in. Both directions are proven through the real `applyDirectSshRemoteWorkspaceSnapshot` path with no `store.setState` seeding of ledgers:

- **fires** — a tab a publisher listed and then dropped is retired;
- **preserves** — rev1 `['agent']`, `setup` created locally while connected via the real create path, stale peer republishing `['agent']` at revs 3–6 ⇒ `setup` survives every time.

Fails closed on unattributed pull, namespace change, non-monotonic revision, missing ledger entry, and stripped path key. Folder workspaces unaffected (scoped to `gitWorktreeIds`, same `splitWorktreeId` the export uses). 3540 tests pass across `src/renderer/src/{hooks,store}`.

## Known residual (documented in the module)

If a peer applies a tab and closes it *without ever publishing a listing containing it*, the retraction is unobservable and the tab is preserved and re-uploaded once, until that peer's next publish makes it retractable. It converges and is never wrong. Closing it needs the closing client to publish the removal — an optional tombstone map on `RemoteWorkspaceSession` (additive-safe, since the relay stores the session blob opaquely) — i.e. a change to what the host holds, not a client-local signal.

