### PR TITLE
fix(agent-status): stop an idle title retiring a pane pending a human answer

### DIFF
--- a/src/main/runtime/mobile-agent-status-permission-renewal.test.ts
+++ b/src/main/runtime/mobile-agent-status-permission-renewal.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+import { OrcaRuntimeService } from './orca-runtime'
+import { AGENT_STATUS_STALE_AFTER_MS, type AgentStatusEntry } from '../../shared/agent-status-types'
+
+// Timings below are the measured deltas from a real `claude` 2.1.234 parked on a
+// Write permission prompt (epoch ms, one capture of two with identical structure):
+//   ...900370  PreToolUse Write
+//   ...900382  title "◐ Claude Code" → "✳ Claude Code"    settle, working→idle
+//   ...900421  PermissionRequest Write                     the hook Orca reports as `waiting`
+//   ...900544  title → "✳ probe2.txt Write tool file"      same idle class, last write
+//   then 31s of silence with the prompt still up.
+// The trailing same-class repaint is the whole defect: it advances lastOscTitleEpochMs
+// past a hook that is still current, while lastAgentStatusRichInvalidatedAtEpochMs (which
+// moves only on a class change) stays at the settle.
+const SETTLE_AFTER_HOOK_MS = -39
+const TRAILING_TITLE_AFTER_HOOK_MS = 123
+
+// Private by design — the projection has no public entry point, and testing it through a
+// full session.tabs publication would bury the one decision this suite is about.
+type TitleRenewal = (
+  status: AgentStatusEntry | null,
+  pty: unknown,
+  options?: { preserveQuestionUnderShellTitle?: boolean }
+) => AgentStatusEntry | null
+
+function renewFromPtyTitle(): TitleRenewal {
+  const runtime = new OrcaRuntimeService()
+  const renew = (runtime as unknown as { renewMobileAgentStatusFromPtyTitle: TitleRenewal })
+    .renewMobileAgentStatusFromPtyTitle
+  return (status, pty, options) => renew.call(runtime, status, pty, options ?? {})
+}
+
+function claudeStatus(state: AgentStatusEntry['state'], updatedAt: number): AgentStatusEntry {
+  return {
+    state,
+    prompt: 'Use the Write tool to create probe2.txt',
+    updatedAt,
+    stateStartedAt: updatedAt,
+    agentType: 'claude',
+    paneKey: 'tab-1:leaf-1',
+    terminalTitle: '✳ probe2.txt Write tool file',
+    stateHistory: []
+  }
+}
+
+/** The PTY as it stands once Claude has raised the prompt and gone quiet. */
+function parkedOnPromptPty(hookAt: number): unknown {
+  return {
+    ptyId: 'pty-1',
+    lastAgentStatus: 'idle',
+    lastOscTitle: '✳ probe2.txt Write tool file',
+    lastOscTitleEpochMs: hookAt + TRAILING_TITLE_AFTER_HOOK_MS,
+    lastAgentStatusRichInvalidatedAtEpochMs: hookAt + SETTLE_AFTER_HOOK_MS,
+    lastAgentStatusStartedAtEpochMs: hookAt + SETTLE_AFTER_HOOK_MS,
+    title: '✳ probe2.txt Write tool file',
+    worktreeId: 'wt-1'
+  }
+}
+
+describe('mobile/paired projection for a pane pending a human answer', () => {
+  // Why both names: Claude's PermissionRequest normalizes to `waiting`, not `blocked`
+  // (agent-hook-listener normalizeClaudeEvent), so a guard written against `blocked`
+  // alone passes its own tests and still misses every Claude permission prompt.
+  it.each(['waiting', 'blocked'] as const)(
+    'keeps a fresh `%s` instead of publishing a title-derived done',
+    (state) => {
+      const hookAt = Date.now()
+      const out = renewFromPtyTitle()(claudeStatus(state, hookAt), parkedOnPromptPty(hookAt), {
+        preserveQuestionUnderShellTitle: true
+      })
+      expect(out?.state).toBe(state)
+    }
+  )
+
+  // Why: the guard is bounded by freshness, or an agent killed while parked on a prompt
+  // would hold the card open forever instead of decaying like any other abandoned row.
+  it('still lets the title retire a `waiting` older than the stale boundary', () => {
+    const hookAt = Date.now() - AGENT_STATUS_STALE_AFTER_MS - 1
+    const out = renewFromPtyTitle()(claudeStatus('waiting', hookAt), parkedOnPromptPty(hookAt), {
+      preserveQuestionUnderShellTitle: true
+    })
+    expect(out?.state).toBe('done')
+  })
+
+  // Why: proves the guard is scoped to pending-answer states rather than switching off
+  // title renewal wholesale — an idle title must still retire a stale spinner (#1437).
+  it('still lets an idle title retire a fresh `working`', () => {
+    const hookAt = Date.now()
+    const out = renewFromPtyTitle()(claudeStatus('working', hookAt), parkedOnPromptPty(hookAt), {
+      preserveQuestionUnderShellTitle: true
+    })
+    expect(out?.state).toBe('done')
+  })
+
+  // Why: an idle title is the ABSENCE of activity evidence, so it cannot outrank the hook.
+  // A `working` title is positive evidence the agent resumed, which does — otherwise a
+  // finished turn's question card would linger into the next working interval (#11761).
+  it('still lets a working title retire a fresh `waiting`', () => {
+    const hookAt = Date.now()
+    const workingTitlePty = {
+      ...(parkedOnPromptPty(hookAt) as Record<string, unknown>),
+      lastAgentStatus: 'working',
+      lastOscTitle: '⠋ Claude'
+    }
+    const out = renewFromPtyTitle()(claudeStatus('waiting', hookAt), workingTitlePty, {
+      preserveQuestionUnderShellTitle: true
+    })
+    expect(out?.state).toBe('working')
+  })
+})

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -33407,6 +33407,25 @@ export class OrcaRuntimeService {
     if (!status || !pty) {
       return status
     }
+    // Why: pending a human answer is hook-only evidence an idle title cannot renew. A title
+    // reads `permission` only from a vendor glyph or a synthesized `<Agent> - action required`
+    // label, and SYNTHETIC_AGENT_TITLE_PROFILES has no Claude entry (OpenCode opts out), so
+    // `titleConfirmsState` below is unreachable for them. Timestamps can't arbitrate either:
+    // lastAgentStatusRichInvalidatedAtEpochMs moves only on a status-CLASS change while
+    // lastOscTitleEpochMs moves on EVERY write, so Claude's one same-class repaint ~123ms
+    // after PermissionRequest pushed title evidence past a still-current hook and published
+    // `done` — retiring the card while the user was still being asked.
+    // Only under an `idle` title: idle is the ABSENCE of activity evidence, but a `working`
+    // title (agent resumed) or a null/shell/identity-only one (agent released the pane)
+    // contradicts the hook and must still retire the row and its stale question (#11761).
+    // Both names: Claude's PermissionRequest normalizes to `waiting`, not `blocked`.
+    if (
+      (status.state === 'waiting' || status.state === 'blocked') &&
+      pty.lastAgentStatus === 'idle' &&
+      Date.now() - status.updatedAt <= AGENT_STATUS_STALE_AFTER_MS
+    ) {
+      return status
+    }
     if (
       options.preserveQuestionUnderShellTitle &&
       status.interactivePrompt != null &&


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​110 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​110 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​19 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​19 |

<!-- /orca-pr-loc -->

## ELI5

Claude asks you to approve something. Its terminal title stops spinning and settles. Orca's phone/paired-client projection reads that settled title, decides the pane is finished, and publishes `done` — which is the state that **retires the card**. So on your phone the pane goes quiet and looks complete while Claude is still waiting for your answer, for as long as you take to answer it.

## What Changed

19 lines in `renewMobileAgentStatusFromPtyTitle` (`src/main/runtime/orca-runtime.ts`): a fresh hook `waiting`/`blocked` under an **idle** title is non-renewable and returned as-is.

## Why

Captured against real `claude` 2.1.234, reproduced 2/2, with a scratch `HOME`/`CLAUDE_CONFIG_DIR` and every `ORCA_*` var stripped so the probe could not post into a live Orca:

```
…900370  PreToolUse Write                             (hook)
…900382  title "◐ Claude Code" → "✳ Claude Code"      SETTLE   (+12ms)
…900421  PermissionRequest → `waiting`                (+39ms)
…900544  title → "✳ probe2.txt Write tool file"       (+123ms AFTER the hook)
   …     31.3s of silence, prompt still on screen
```

Three facts combine, and the fix targets the first because the other two are not fixable here:

1. **A title can never say "permission" for Claude.** `SYNTHETIC_AGENT_TITLE_PROFILES` covers eight agents and has **no Claude entry**; OpenCode opts out. So `titleConfirmsState` is structurally unreachable for them.
2. **A spinner glyph outranks the keyword anyway** — `containsAgentSpinnerGlyph → 'working'` runs ten lines before the `'action required' | 'permission' | 'waiting'` check.
3. **The timestamps cannot arbitrate.** `lastAgentStatusRichInvalidatedAtEpochMs` moves only on a status-**class** change; `lastOscTitleEpochMs` moves on **every** write. Claude's single same-class repaint 123ms after the hook pushes title evidence past a still-current hook status.

The title then goes silent — measured at **85.2s** and **31.3s** parked with **zero** writes — so the wrong verdict is frozen for the whole time the user is being asked. Not a race: deterministic, both runs.

Also checked and ruled out: the `Notification` at +6s does **not** rescue it. It normalizes to `null`, mints no row, and never advances `updatedAt`.

### Two things worth reviewing closely

**The guard is deliberately narrowed to an `idle` title.** The unnarrowed version — "fresh `waiting`/`blocked` is non-renewable, full stop" — broke three existing tests in `orca-runtime-hook-agent-status-projection.test.ts` (#11761), and those tests are right. They cover the inverse defect: once the agent visibly resumes or releases the pane, a stale `waiting` and its `interactivePrompt` must be retired or a finished turn's question card lingers into the next turn. An **idle** title is the *absence* of activity evidence, which is consistent with waiting on a human; a **working** title is positive evidence the agent resumed, and a null/shell/identity-only one is positive evidence it left. Those two must still retire the row. The freshness bound is there so an agent killed while parked still decays instead of holding the card open forever.

**Both state names.** Claude's `PermissionRequest` normalizes to **`waiting`, not `blocked`** — a guard written against `blocked` alone would miss the captured case entirely while every test passed.

**Placement.** The guard sits in `renewMobileAgentStatusFromPtyTitle` rather than in `buildPtyMobileAgentStatus`, because that function has **two** callers: `orca-runtime.ts:33598` (the captured path) and `:33254` (the renderer-published `tab.agentStatus` path), both passing the same options and carrying the identical exposure. Guarding only the first would have been a half-fix.

## Linked Issue

No issue filed — found while sweeping the agent-status pipeline for verified defects.

## Visual Proof

`N/A` — the visible effect is a card that *stops* disappearing. A before/after would be a phone screenshot of an absent row, which carries less than the captured timeline and the red/green matrix above.

## Testing

New suite `mobile-agent-status-permission-renewal.test.ts`, 5 cases, driving the **real** `renewMobileAgentStatusFromPtyTitle` on a real `OrcaRuntimeService` with the deltas measured from the capture (settle at hook−39ms, repaint at hook+123ms).

**Proven red.** Against `origin/main`: **2 failed / 3 passed**, both `expected 'done' to be …`. On the branch: **5 passed**. Verified in a clean detached worktree at this commit, not by report.

The 3 that pass in both directions are guardrails, not filler:
- stale `waiting` past the stale boundary → still retires (proves the freshness bound is live)
- fresh `working` under an idle title → still retires (proves title renewal is not switched off wholesale, #1437)
- fresh `waiting` under a **working** title → still retires (pins the narrowing, and is the case that caught the first, over-broad attempt)

Gates, all re-run independently: `pnpm typecheck` exit 0, zero `error TS` — and proven load-bearing by planting `const x: number = "s"` in the new file and seeing TS2322, then reverting. `vitest src/main/runtime` — **363 files, 4579 passed**, 9 skipped, 0 failed. The three #11761 tests: **18 passed**. `oxfmt --check` clean; `oxlint` exit 0, also proven not-dead by planting a duplicate declaration. `check:max-lines-ratchet` OK with no new suppression.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

- **Reported, not fixed here**: `hostAgentStatusPiercesClientAuthority` (`web-session-tabs-sync.ts:1114`) is `entry.state === 'blocked' || entry.interactivePrompt != null` — so a Claude permission, being `waiting`, does not pierce the client authority fence either. Same `waiting`/`blocked` gap, different seam, deserves its own evidence and its own change. A sweep of the adjacent sites found `worktree-agent-rows.ts:240`, `useDashboardSnapshot.ts:82` and `AgentMapWorktreeRingNode.tsx:306` already include `waiting`; `AgentStateDot.tsx:119` omits it deliberately for visual distinction.
- **Cross-platform / SSH**: no platform-conditional code; the projection is shared.
- **Backwards compatibility**: no wire, schema, or persisted-state change. The only behaviour change is that a pane pending a human answer keeps its state instead of being published as `done`.
- **Performance**: two comparisons on a path that already reads both fields.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @BrennanKB5
