### PR TITLE
feat(dashboard): add a keyboard shortcut to toggle the Agent Dashboard

### DIFF
--- a/src/main/browser/browser-guest-shortcut-dispatch.ts
+++ b/src/main/browser/browser-guest-shortcut-dispatch.ts
@@ -180,6 +180,8 @@ export function forwardGuestShortcutInput(
     renderer.send('ui:openWorkspaceBoard')
   } else if (action?.type === 'openTasks') {
     renderer.send('ui:openTasks')
+  } else if (action?.type === 'toggleAgentDashboard') {
+    renderer.send('ui:toggleAgentDashboard')
   } else if (action?.type === 'openSettings') {
     renderer.send('ui:openSettings')
   } else if (action?.type === 'forceReload') {

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -733,6 +733,9 @@ export function createMainWindow(
       case 'openTasks':
         mainWindow.webContents.send('ui:openTasks')
         return
+      case 'toggleAgentDashboard':
+        mainWindow.webContents.send('ui:toggleAgentDashboard')
+        return
       case 'switchRecentTab':
         mainWindow.webContents.send('ui:switchRecentTab')
         return

--- a/src/preload/api/ui-command-event-api.ts
+++ b/src/preload/api/ui-command-event-api.ts
@@ -58,6 +58,7 @@ export type UiCommandEventApi = {
   onDeleteCurrentWorkspace: (callback: () => void) => () => void
   onOpenWorkspaceBoard: (callback: () => void) => () => void
   onOpenTasks: (callback: () => void) => () => void
+  onToggleAgentDashboard: (callback: () => void) => () => void
   onJumpToWorktreeIndex: (callback: (index: number) => void) => () => void
   onJumpToTabIndex: (callback: (index: number) => void) => () => void
   onWorktreeHistoryNavigate: (callback: (direction: 'back' | 'forward') => void) => () => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3779,6 +3779,11 @@ const api = {
       ipcRenderer.on('ui:openTasks', listener)
       return () => ipcRenderer.removeListener('ui:openTasks', listener)
     },
+    onToggleAgentDashboard: (callback: () => void): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent) => callback()
+      ipcRenderer.on('ui:toggleAgentDashboard', listener)
+      return () => ipcRenderer.removeListener('ui:toggleAgentDashboard', listener)
+    },
     onJumpToWorktreeIndex: (callback: (index: number) => void): (() => void) => {
       const listener = (_event: Electron.IpcRendererEvent, index: number) => callback(index)
       ipcRenderer.on('ui:jumpToWorktreeIndex', listener)

--- a/src/renderer/src/components/settings/ShortcutsPane.tsx
+++ b/src/renderer/src/components/settings/ShortcutsPane.tsx
@@ -73,6 +73,9 @@ export function ShortcutsPane(): React.JSX.Element {
       ] as const
     })
   )
+  const agentDashboardEnabled = useAppStore(
+    (state) => state.settings?.experimentalAgentDashboardPopout === true
+  )
   const mountedRef = useMountedRef()
   const [errors, setErrors] = useState<Partial<Record<KeybindingActionId, string>>>({})
   const [recordingActionId, setRecordingActionId] = useState<KeybindingActionId | null>(null)
@@ -134,11 +137,13 @@ export function ShortcutsPane(): React.JSX.Element {
         platform,
         managedBrowserCreationEnabled,
         mobileEmulatorCreationEnabled,
+        agentDashboardEnabled,
         settingsSearchQuery: searchQuery,
         shortcutQuery,
         shortcutFilter
       }),
     [
+      agentDashboardEnabled,
       conflictByAction,
       groups,
       keybindings,

--- a/src/renderer/src/components/settings/shortcut-groups.test.ts
+++ b/src/renderer/src/components/settings/shortcut-groups.test.ts
@@ -29,6 +29,16 @@ describe('shortcut groups', () => {
     )
   })
 
+  it('exposes the agent dashboard toggle as a customizable Global row', () => {
+    const global = groupDefinitions([]).find((group) => group.title === 'Global')
+
+    expect(global?.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'dashboard.toggle', title: 'Toggle Agent Dashboard' })
+      ])
+    )
+  })
+
   it('reports a plugin default that shadows a built-in shortcut', () => {
     const command: ActivePluginCommand = {
       pluginKey: 'orca-samples.tasks',

--- a/src/renderer/src/components/settings/shortcut-row-visibility.test.ts
+++ b/src/renderer/src/components/settings/shortcut-row-visibility.test.ts
@@ -16,6 +16,30 @@ function creationGroup(): ShortcutGroup {
   return { title: 'Tabs', items }
 }
 
+function globalGroup(): ShortcutGroup {
+  const items = (['workspace.openBoard', 'dashboard.toggle'] as const).map((actionId) => {
+    const definition = getKeybindingDefinition(actionId)
+    if (!definition) {
+      throw new Error(`Missing keybinding definition: ${actionId}`)
+    }
+    return definition
+  })
+  return { title: 'Global', items }
+}
+
+const baseOptions = {
+  keybindings: {},
+  conflictByAction: new Map(),
+  terminalShortcutPolicy: 'orca-first',
+  platform: 'darwin',
+  managedBrowserCreationEnabled: false,
+  mobileEmulatorCreationEnabled: false,
+  agentDashboardEnabled: false,
+  settingsSearchQuery: '',
+  shortcutQuery: '',
+  shortcutFilter: 'all'
+} as const
+
 describe('buildShortcutRowVisibility', () => {
   it('hides client-impossible creation shortcuts without hiding terminal or markdown', () => {
     const result = buildShortcutRowVisibility({
@@ -26,6 +50,7 @@ describe('buildShortcutRowVisibility', () => {
       platform: 'darwin',
       managedBrowserCreationEnabled: false,
       mobileEmulatorCreationEnabled: false,
+      agentDashboardEnabled: false,
       settingsSearchQuery: '',
       shortcutQuery: '',
       shortcutFilter: 'all'
@@ -34,6 +59,23 @@ describe('buildShortcutRowVisibility', () => {
     expect(result.shortcutRows.map((row) => row.item.id)).toEqual([
       'tab.newTerminal',
       'tab.newMarkdown'
+    ])
+  })
+
+  it('hides the agent dashboard toggle while its experiment is off', () => {
+    const hidden = buildShortcutRowVisibility({ ...baseOptions, groups: [globalGroup()] })
+
+    expect(hidden.shortcutRows.map((row) => row.item.id)).toEqual(['workspace.openBoard'])
+
+    const shown = buildShortcutRowVisibility({
+      ...baseOptions,
+      groups: [globalGroup()],
+      agentDashboardEnabled: true
+    })
+
+    expect(shown.shortcutRows.map((row) => row.item.id)).toEqual([
+      'workspace.openBoard',
+      'dashboard.toggle'
     ])
   })
 })

--- a/src/renderer/src/components/settings/shortcut-row-visibility.ts
+++ b/src/renderer/src/components/settings/shortcut-row-visibility.ts
@@ -24,6 +24,7 @@ export function buildShortcutRowVisibility(options: {
   platform: NodeJS.Platform
   managedBrowserCreationEnabled: boolean
   mobileEmulatorCreationEnabled: boolean
+  agentDashboardEnabled: boolean
   settingsSearchQuery: string
   shortcutQuery: string
   shortcutFilter: ShortcutFilter
@@ -39,7 +40,9 @@ export function buildShortcutRowVisibility(options: {
       .filter(
         (item) =>
           (options.managedBrowserCreationEnabled || item.id !== 'tab.newBrowser') &&
-          (options.mobileEmulatorCreationEnabled || item.id !== 'tab.newSimulator')
+          (options.mobileEmulatorCreationEnabled || item.id !== 'tab.newSimulator') &&
+          // Why: the toggle is inert while the experiment is off, so binding it here would silently do nothing.
+          (options.agentDashboardEnabled || item.id !== 'dashboard.toggle')
       )
       .map((item) => {
         const effective = getEffectiveKeybindingsForDefinition(

--- a/src/renderer/src/hooks/useIpcEvents-agent-dashboard-shortcut.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents-agent-dashboard-shortcut.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest'
+import { toggleAgentDashboardFromShortcut } from './useIpcEvents'
+
+function makeState(
+  overrides: {
+    activeView?: string
+    experimentEnabled?: boolean
+    mode?: 'in-window' | 'popout'
+    drawerOpen?: boolean
+  } = {}
+) {
+  return {
+    activeView: overrides.activeView ?? 'terminal',
+    settings: {
+      experimentalAgentDashboardPopout: overrides.experimentEnabled ?? true,
+      experimentalAgentDashboardMode: overrides.mode ?? 'in-window'
+    },
+    agentDashboardDrawerOpen: overrides.drawerOpen ?? false,
+    setSidebarOpen: vi.fn(),
+    setAgentDashboardDrawerOpen: vi.fn()
+  }
+}
+
+describe('toggleAgentDashboardFromShortcut', () => {
+  it('stays inert while the Agent Dashboard experiment is off', () => {
+    const state = makeState({ experimentEnabled: false })
+    const openPopout = vi.fn()
+
+    toggleAgentDashboardFromShortcut(state as never, openPopout)
+
+    expect(openPopout).not.toHaveBeenCalled()
+    expect(state.setAgentDashboardDrawerOpen).not.toHaveBeenCalled()
+    expect(state.setSidebarOpen).not.toHaveBeenCalled()
+  })
+
+  it('stays inert in the Settings view', () => {
+    const state = makeState({ activeView: 'settings' })
+    const openPopout = vi.fn()
+
+    toggleAgentDashboardFromShortcut(state as never, openPopout)
+
+    expect(openPopout).not.toHaveBeenCalled()
+    expect(state.setAgentDashboardDrawerOpen).not.toHaveBeenCalled()
+  })
+
+  it('opens the pop-out window in popout mode without touching the drawer', () => {
+    const state = makeState({ mode: 'popout' })
+    const openPopout = vi.fn()
+
+    toggleAgentDashboardFromShortcut(state as never, openPopout)
+
+    expect(openPopout).toHaveBeenCalledOnce()
+    expect(state.setAgentDashboardDrawerOpen).not.toHaveBeenCalled()
+    expect(state.setSidebarOpen).not.toHaveBeenCalled()
+  })
+
+  it('reveals the sidebar when opening the in-window drawer', () => {
+    const state = makeState({ drawerOpen: false })
+
+    toggleAgentDashboardFromShortcut(state as never, vi.fn())
+
+    expect(state.setSidebarOpen).toHaveBeenCalledWith(true)
+    expect(state.setAgentDashboardDrawerOpen).toHaveBeenCalledWith(true)
+  })
+
+  it('leaves the sidebar alone when closing the in-window drawer', () => {
+    // Why: forcing the sidebar open on close would re-reveal a panel the user
+    // just dismissed, and the drawer's own collapse effect would fight it.
+    const state = makeState({ drawerOpen: true })
+
+    toggleAgentDashboardFromShortcut(state as never, vi.fn())
+
+    expect(state.setAgentDashboardDrawerOpen).toHaveBeenCalledWith(false)
+    expect(state.setSidebarOpen).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -1423,6 +1423,33 @@ export function useIpcEvents(): void {
       )
     }
 
+    if (window.api.ui.onToggleAgentDashboard) {
+      unsubs.push(
+        window.api.ui.onToggleAgentDashboard(() => {
+          const store = useAppStore.getState()
+          // Why: mirror the sidebar entry's gate — the chord must stay inert while
+          // the experiment is off, so a stale binding cannot open a hidden surface.
+          if (
+            store.activeView === 'settings' ||
+            store.settings?.experimentalAgentDashboardPopout !== true
+          ) {
+            return
+          }
+          if (store.settings.experimentalAgentDashboardMode === 'popout') {
+            void window.api.dashboard.openPopout()
+            return
+          }
+          const nextOpen = !store.agentDashboardDrawerOpen
+          // Why: the drawer lives beside the sidebar and self-closes when the
+          // sidebar collapses, so opening it has to reveal the sidebar first.
+          if (nextOpen) {
+            store.setSidebarOpen(true)
+          }
+          store.setAgentDashboardDrawerOpen(nextOpen)
+        })
+      )
+    }
+
     unsubs.push(
       window.api.ui.onOpenTasks(() => {
         const store = useAppStore.getState()

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -509,6 +509,39 @@ export function openNewWorkspaceFromShortcut(
   state.openModal('new-workspace-composer', buildNewWorkspaceShortcutModalData(state))
 }
 
+export function toggleAgentDashboardFromShortcut(
+  state: Pick<
+    AppState,
+    | 'activeView'
+    | 'settings'
+    | 'agentDashboardDrawerOpen'
+    | 'setSidebarOpen'
+    | 'setAgentDashboardDrawerOpen'
+  >,
+  openPopout: () => void
+): void {
+  // Why: mirror the sidebar entry's gate — the chord must stay inert while the
+  // experiment is off, so a stale binding cannot open a hidden surface.
+  if (
+    state.activeView === 'settings' ||
+    state.settings?.experimentalAgentDashboardPopout !== true
+  ) {
+    return
+  }
+  if (state.settings.experimentalAgentDashboardMode === 'popout') {
+    openPopout()
+    return
+  }
+  const nextOpen = !state.agentDashboardDrawerOpen
+  // Why: the drawer lives beside the sidebar and self-closes when the sidebar
+  // collapses, so opening it has to reveal the sidebar first. Closing must not,
+  // or dismissing the drawer would force the sidebar back open.
+  if (nextOpen) {
+    state.setSidebarOpen(true)
+  }
+  state.setAgentDashboardDrawerOpen(nextOpen)
+}
+
 export function resolveBrowserSessionTabTarget(
   state: Pick<AppState, 'browserTabsByWorktree' | 'unifiedTabsByWorktree'>,
   worktreeId: string,
@@ -1426,26 +1459,9 @@ export function useIpcEvents(): void {
     if (window.api.ui.onToggleAgentDashboard) {
       unsubs.push(
         window.api.ui.onToggleAgentDashboard(() => {
-          const store = useAppStore.getState()
-          // Why: mirror the sidebar entry's gate — the chord must stay inert while
-          // the experiment is off, so a stale binding cannot open a hidden surface.
-          if (
-            store.activeView === 'settings' ||
-            store.settings?.experimentalAgentDashboardPopout !== true
-          ) {
-            return
-          }
-          if (store.settings.experimentalAgentDashboardMode === 'popout') {
+          toggleAgentDashboardFromShortcut(useAppStore.getState(), () => {
             void window.api.dashboard.openPopout()
-            return
-          }
-          const nextOpen = !store.agentDashboardDrawerOpen
-          // Why: the drawer lives beside the sidebar and self-closes when the
-          // sidebar collapses, so opening it has to reveal the sidebar first.
-          if (nextOpen) {
-            store.setSidebarOpen(true)
-          }
-          store.setAgentDashboardDrawerOpen(nextOpen)
+          })
         })
       )
     }

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2843,6 +2843,7 @@ function createWebUiApi(): NonNullable<Partial<PreloadApi>['ui']> {
     onOpenNewWorkspace: () => noopUnsubscribe,
     onDeleteCurrentWorkspace: () => noopUnsubscribe,
     onOpenWorkspaceBoard: () => noopUnsubscribe,
+    onToggleAgentDashboard: () => noopUnsubscribe,
     onJumpToWorktreeIndex: () => noopUnsubscribe,
     onJumpToTabIndex: () => noopUnsubscribe,
     onWorktreeHistoryNavigate: () => noopUnsubscribe,

--- a/src/shared/keybindings-unassigned-actions.test.ts
+++ b/src/shared/keybindings-unassigned-actions.test.ts
@@ -100,6 +100,38 @@ describe('keybindings', () => {
     )
   })
 
+  it('keeps the agent dashboard toggle unassigned until users customize it', () => {
+    const platforms: readonly KeybindingPlatform[] = ['darwin', 'linux', 'win32']
+
+    for (const platform of platforms) {
+      expect(getEffectiveKeybindingsForAction('dashboard.toggle', platform)).toEqual([])
+    }
+
+    const binding = {
+      key: 'd',
+      code: 'KeyD',
+      control: true,
+      meta: false,
+      alt: true,
+      shift: false
+    }
+
+    expect(keybindingMatchesAction('dashboard.toggle', binding, 'linux')).toBe(false)
+    expect(
+      keybindingMatchesAction('dashboard.toggle', binding, 'linux', {
+        'dashboard.toggle': ['Mod+Alt+D']
+      })
+    ).toBe(true)
+
+    const definition = getKeybindingDefinition('dashboard.toggle')
+    expect(definition?.title).toBe('Toggle Agent Dashboard')
+    expect(definition?.group).toBe('Global')
+    expect(definition?.allowInTerminal).toBe(true)
+    expect(definition?.searchKeywords).toEqual(
+      expect.arrayContaining(['agent', 'dashboard', 'kanban', 'toggle', 'open', 'close'])
+    )
+  })
+
   it('keeps the quick commands menu toggle unassigned until users customize it', () => {
     const platforms: readonly KeybindingPlatform[] = ['darwin', 'linux', 'win32']
 

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -40,6 +40,7 @@ export type KeybindingActionId =
   | 'workspace.selectByIndex'
   | 'voice.dictation'
   | 'view.tasks'
+  | 'dashboard.toggle'
   | 'sidebar.left.toggle'
   | 'sidebar.right.toggle'
   | 'sidebar.explorer.toggle'
@@ -313,6 +314,28 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
       'close'
     ],
     // Why: configurable but unbound by default, to not take a global chord from terminal/browser/editor users.
+    defaultBindings: platformBindings([]),
+    allowInTerminal: true
+  },
+  {
+    id: 'dashboard.toggle',
+    title: 'Toggle Agent Dashboard',
+    group: 'Global',
+    scope: 'global',
+    searchKeywords: [
+      'shortcut',
+      'global',
+      'agent',
+      'agents',
+      'dashboard',
+      'kanban',
+      'board',
+      'toggle',
+      'open',
+      'close'
+    ],
+    // Why: configurable but unbound by default, matching workspace.openBoard — an
+    // experimental surface must not claim a global chord from terminal users.
     defaultBindings: platformBindings([]),
     allowInTerminal: true
   },

--- a/src/shared/window-shortcut-policy-agent-dashboard.test.ts
+++ b/src/shared/window-shortcut-policy-agent-dashboard.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getWindowShortcutActionId,
+  resolveWindowShortcutAction
+} from './window-shortcut-policy'
+
+const input = {
+  code: 'KeyD',
+  key: 'd',
+  meta: false,
+  control: true,
+  alt: true,
+  shift: false
+}
+
+describe('agent dashboard toggle shortcut', () => {
+  it('stays unbound until a user assigns a chord', () => {
+    expect(resolveWindowShortcutAction(input, 'linux')).toBeNull()
+  })
+
+  it('resolves a custom binding to the dashboard toggle', () => {
+    expect(
+      resolveWindowShortcutAction(input, 'linux', { 'dashboard.toggle': ['Mod+Alt+D'] })
+    ).toEqual({ type: 'toggleAgentDashboard' })
+  })
+
+  it('still resolves while a terminal owns focus under terminal-first', () => {
+    // Why: the action sets allowInTerminal, and the premise of the feature is that
+    // the chord reaches the dashboard even when a PTY would otherwise claim keys.
+    expect(
+      resolveWindowShortcutAction(
+        input,
+        'linux',
+        { 'dashboard.toggle': ['Mod+Alt+D'] },
+        { context: 'terminal', terminalShortcutPolicy: 'terminal-first' }
+      )
+    ).toEqual({ type: 'toggleAgentDashboard' })
+  })
+
+  it('maps the action back to its keybinding id', () => {
+    expect(getWindowShortcutActionId({ type: 'toggleAgentDashboard' })).toBe('dashboard.toggle')
+  })
+})

--- a/src/shared/window-shortcut-policy.test.ts
+++ b/src/shared/window-shortcut-policy.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest'
 import {
-  getWindowShortcutActionId,
   isRecentTabSwitcherCommitRelease,
   isWindowShortcutModifierChord,
   matchesRecentTabSwitcherChord,
@@ -376,23 +375,6 @@ describe('resolveWindowShortcutAction', () => {
         overrides
       )
     ).toEqual({ type: 'openTasks' })
-  })
-
-  it('leaves the agent dashboard toggle unbound by default but resolves a custom binding', () => {
-    const input = {
-      code: 'KeyD',
-      key: 'd',
-      meta: false,
-      control: true,
-      alt: true,
-      shift: false
-    }
-
-    expect(resolveWindowShortcutAction(input, 'linux')).toBeNull()
-    expect(
-      resolveWindowShortcutAction(input, 'linux', { 'dashboard.toggle': ['Mod+Alt+D'] })
-    ).toEqual({ type: 'toggleAgentDashboard' })
-    expect(getWindowShortcutActionId({ type: 'toggleAgentDashboard' })).toBe('dashboard.toggle')
   })
 
   it('leaves workspace delete unbound by default but honors custom terminal-active bindings', () => {

--- a/src/shared/window-shortcut-policy.test.ts
+++ b/src/shared/window-shortcut-policy.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  getWindowShortcutActionId,
   isRecentTabSwitcherCommitRelease,
   isWindowShortcutModifierChord,
   matchesRecentTabSwitcherChord,
@@ -375,6 +376,23 @@ describe('resolveWindowShortcutAction', () => {
         overrides
       )
     ).toEqual({ type: 'openTasks' })
+  })
+
+  it('leaves the agent dashboard toggle unbound by default but resolves a custom binding', () => {
+    const input = {
+      code: 'KeyD',
+      key: 'd',
+      meta: false,
+      control: true,
+      alt: true,
+      shift: false
+    }
+
+    expect(resolveWindowShortcutAction(input, 'linux')).toBeNull()
+    expect(
+      resolveWindowShortcutAction(input, 'linux', { 'dashboard.toggle': ['Mod+Alt+D'] })
+    ).toEqual({ type: 'toggleAgentDashboard' })
+    expect(getWindowShortcutActionId({ type: 'toggleAgentDashboard' })).toBe('dashboard.toggle')
   })
 
   it('leaves workspace delete unbound by default but honors custom terminal-active bindings', () => {

--- a/src/shared/window-shortcut-policy.ts
+++ b/src/shared/window-shortcut-policy.ts
@@ -41,6 +41,7 @@ export type WindowShortcutAction =
   | { type: 'deleteCurrentWorkspace' }
   | { type: 'openWorkspaceBoard' }
   | { type: 'openTasks' }
+  | { type: 'toggleAgentDashboard' }
   | { type: 'switchRecentTab' }
   | { type: 'jumpToWorktreeIndex'; index: number }
   | { type: 'jumpToTabIndex'; index: number }
@@ -251,6 +252,10 @@ export function resolveWindowShortcutAction(
     return { type: 'openTasks' }
   }
 
+  if (actionMatches('dashboard.toggle', input, platform, keybindings, options)) {
+    return { type: 'toggleAgentDashboard' }
+  }
+
   if (actionMatches('tab.previousRecent', input, platform, keybindings, options)) {
     return { type: 'switchRecentTab' }
   }
@@ -324,6 +329,8 @@ export function getWindowShortcutActionId(action: WindowShortcutAction): Keybind
       return 'workspace.openBoard'
     case 'openTasks':
       return 'view.tasks'
+    case 'toggleAgentDashboard':
+      return 'dashboard.toggle'
     case 'switchRecentTab':
       return 'tab.previousRecent'
     case 'worktreeHistoryNavigate':


### PR DESCRIPTION
## ELI5

The Agent Dashboard could only be opened by clicking its sidebar row. This adds a shortcut command for it, so you can assign a chord in Settings → Shortcuts and toggle the board from the keyboard — including while a terminal, editor, or browser tab has focus.

## What Changed

- `src/shared/keybindings.ts`: new `dashboard.toggle` action, titled `Toggle Agent Dashboard`, in the existing `Global` group. `allowInTerminal: true`, and no default binding.
- `src/shared/window-shortcut-policy.ts`: resolves the chord to a new `toggleAgentDashboard` action, and maps it back in `getWindowShortcutActionId`. Resolving in the main process is what lets the chord land while a PTY, Monaco, or browser guest owns focus.
- `src/main/window/createMainWindow.ts`: dispatches `ui:toggleAgentDashboard`.
- `src/main/browser/browser-guest-shortcut-dispatch.ts`: the same branch for browser guests, which have their own dispatch path.
- `src/preload/index.ts` and `src/preload/api/ui-command-event-api.ts`: the `onToggleAgentDashboard` bridge.
- `src/renderer/src/web/web-preload-api.ts`: a noop for the paired-web renderer, which has no Electron IPC.
- `src/renderer/src/hooks/useIpcEvents.ts`: the handler, placed beside the existing `onOpenWorkspaceBoard` one. Its body lives in an exported `toggleAgentDashboardFromShortcut`, following `openNewWorkspaceFromShortcut` in the same file, so the gating is unit-testable.

Pure addition — no deletions, and no existing shortcut changes behavior. Roughly two thirds of the diff is tests.

## Why

`AgentDashboardSidebarEntry` was the only way in, so a board people open constantly had no keyboard path.

Three decisions worth a reviewer's attention:

**Unbound by default.** Every nearby chord is either taken or valuable to terminal users, so shipping a default would be the first thing to push back on. `workspace.openBoard` already carries the comment explaining this posture, and #14240 shipped the same way. The row is discoverable in Settings → Shortcuts and the user assigns it. If you would rather ship a default chord, name it and I will add it plus the conflict-table coverage.

**Fails closed while the experiment is off.** The handler checks `experimentalAgentDashboardPopout` before acting. Without that, a binding assigned while the experiment was enabled would keep opening a surface the user had since turned off.

**Opening reveals the sidebar first.** The drawer sits beside the sidebar, and `src/renderer/src/components/sidebar/index.tsx` closes it whenever the sidebar collapses — so toggling without `setSidebarOpen(true)` opened it and immediately self-closed it. The call runs only on the opening transition, so closing does not force the sidebar open. Popout mode routes to `window.api.dashboard.openPopout()` instead, matching the sidebar entry.

The handler reads the same two settings flags as the sidebar entry rather than importing that component into a hook, which would invert the renderer layering. The cost is a one-flag duplication, noted in a comment.

Scope is the toggle only. The in-board navigation shortcuts #12886 also asks for — moving between cards, acting on the focused one — need their own focus-management design and are left for a follow-up.

## Linked Issue

Partially addresses #12886 — this is the toggle half; in-board navigation shortcuts are not included, so the issue should stay open.

## Visual Proof

`Settings → Shortcuts`, searching `dashboard`, on the packaged **v1.4.183** and on this branch.

| Before | After |
| --- | --- |
| <img width="1385" height="664" alt="image" src="https://github.com/user-attachments/assets/c177b0cb-f499-4b79-8718-0041fe79d5d1" /> | <img width="1426" height="662" alt="image" src="https://github.com/user-attachments/assets/08c8f464-e4d5-4359-9ce7-fb7aa96191e9" /> |
| `0 / 123` — `No shortcuts match those filters.` | `1 / 124` — `Toggle Agent Dashboard` under **Global** |

What the After pane shows:

- **`Unassigned 1`, `Modified 0`** — the action ships with no binding, as described above. The row is there to be assigned, not pre-claimed.
- **`Conflicts 0`** — nothing collides with an existing chord.
- The command count moves `123 → 124`: one action added, none replaced.

There is no other visual change. The row is rendered by the existing shortcut catalog with no new markup, and a test pins it so it cannot silently disappear.

## Testing

Manually tested on macOS against a dev build of this branch, walking the steps below. The Settings row appears under Global, is assignable, and reports no conflict — see Visual Proof.

Steps to reproduce, with the Agent Dashboard experiment enabled and a chord assigned to **Toggle Agent Dashboard** in Settings → Shortcuts → Global:

1. Press it with focus in the workspace — the drawer opens and the sidebar reveals.
2. Press it again — the drawer closes and the sidebar stays as it was.
3. Press it with focus inside a terminal pane, then inside a browser tab — it still toggles, and the terminal receives no stray keystroke.
4. Switch the dashboard to Pop-out mode and press it — the pop-out window opens instead.
5. Turn the experiment off and press it — nothing happens.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Added:

- `src/shared/window-shortcut-policy-agent-dashboard.test.ts` — unbound by default, resolves once bound, still resolves under `{ context: 'terminal', terminalShortcutPolicy: 'terminal-first' }`, and the reverse `getWindowShortcutActionId` mapping holds.
- `src/shared/keybindings-unassigned-actions.test.ts` — unbound on `darwin`, `linux`, and `win32`; bindable via override; title, `Global` group, and `allowInTerminal` pinned.
- `src/renderer/src/components/settings/shortcut-groups.test.ts` — the action surfaces as a customizable Global row.
- `src/renderer/src/hooks/useIpcEvents-agent-dashboard-shortcut.test.ts` — the handler's gating and branching: inert with the experiment off, inert in Settings, pop-out mode opens the window without touching the drawer, opening reveals the sidebar, closing leaves it alone.

Every new test fails without its fix:

- Replacing the resolver's `actionMatches('dashboard.toggle', …)` guard with `false` → `× resolves a custom binding to the dashboard toggle` and `× still resolves while a terminal owns focus under terminal-first` (2 failed | 2 passed).
- Giving the definition `defaultBindings: platformBindings(['Mod+Alt+D'])` → `× keeps the agent dashboard toggle unassigned until users customize it` (1 failed | 15 passed).
- Dropping the experiment gate → `× stays inert while the Agent Dashboard experiment is off` (1 failed | 4 passed).
- Making `setSidebarOpen(true)` unconditional → `× leaves the sidebar alone when closing the in-window drawer` (1 failed | 4 passed).

Full checks, macOS:

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm build` — clean
- `pnpm test` — `1 failed | 54598 passed | 183 skipped`

### CI failures that are not this PR

`src/shared/startup-shell-portability.live-shell.test.ts` → `'zsh' > clears even when 'test' is aliased away in an interactive shell`. It passes in isolation on both this branch and `origin/main` (171 passed, 16 skipped, both runs), so it is a pre-existing flake in a test that spawns real interactive shells under full-suite parallelism. This diff touches keybinding resolution and IPC routing only and cannot influence shell startup dialect selection.

## AI Disclosure

Authored and reviewed with AI assistance, via the omp CLI.

## Review

Self-reviewed with the same agent over the full diff. Two defects were found and fixed before this was opened:

- The first version toggled the drawer regardless of `experimentalAgentDashboardPopout`, which would open a surface the user had disabled.
- The first version toggled without opening the sidebar, so the existing collapse effect closed the drawer immediately after it opened.

Also checked: no chord is stolen on upgrade, since an unbound action cannot collide in `findKeybindingConflictsForDefinitions`; the browser-guest branch is present, without which the chord would silently no-op while a browser tab had focus; and the web renderer gets the bridge noop rather than an undefined call.

Both CodeRabbit nitpicks are addressed in a follow-up commit:

- **Terminal-context coverage.** The resolver test now asserts the chord under `{ context: 'terminal', terminalShortcutPolicy: 'terminal-first' }`, mirroring the adjacent `workspace.delete` test. That is the behaviour this PR's premise rests on, and it was the one claim without a test.
- **Testable gating.** The handler body moved into an exported `toggleAgentDashboardFromShortcut`, following `openNewWorkspaceFromShortcut` in the same file, so the experiment gate and the pop-out/drawer branching are unit-tested directly instead of only reasoned about.

The resolver test moved to its own `window-shortcut-policy-agent-dashboard.test.ts` rather than growing `window-shortcut-policy.test.ts` past the 800-line `max-lines` gate, matching how `keybindings-*.test.ts` is already split.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

- **Security.** `ui:toggleAgentDashboard` is a main → renderer notification with no payload, following `ui:openWorkspaceBoard`. No renderer → main channel, no `invoke`, no reply path, no parsing, no shell or filesystem or network call, no new dependency. The renderer handler fails closed on a disabled experiment.
- **Cross-platform.** No hardcoded `metaKey`. The binding is a platform-agnostic `Mod+` chord resolved by the existing `keybindingMatchesAction`, and labels come from the shared formatter, so the `⌘`/`⇧` versus `Ctrl+`/`Shift+` split is inherited rather than reimplemented. The unbound assertion runs on all three platforms. Manually exercised on macOS only.
- **Remote SSH.** Shortcut resolution and dispatch are local to the desktop window; nothing crosses the SSH or relay transport. The dashboard content itself is unchanged.
- **Mobile.** Untouched. The mobile client has no keybinding registry, and `web-preload-api.ts` receives a noop bridge so the paired-web renderer cannot call into missing IPC.
- **Backwards compatibility.** Pure addition. No action id renamed, so no stored user keybinding is invalidated. Shipping unbound means no existing chord changes meaning after upgrade.
- **Performance.** One extra `actionMatches` call in the main-process resolver chain, positioned after the existing checks, reached only on modifier chords. The renderer subscribes one IPC listener at mount and disposes it with the existing `unsubs` teardown.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)


