### PR TITLE
fix(relay): make sustained producer loss visible instead of a single line

### DIFF
--- a/src/relay/dispatcher-producer-loss-observability.test.ts
+++ b/src/relay/dispatcher-producer-loss-observability.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { RelayDispatcher } from './dispatcher'
+
+// Why these bounds: a 20KB frame exceeds the 16KB producer frame capacity, so each notify
+// is dropped over-capacity rather than queued — the storm shape this summary exists for.
+function makeSaturatedDispatcher(): { dispatcher: RelayDispatcher; stderr: string[] } {
+  const stderr: string[] = []
+  vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
+    stderr.push(String(chunk))
+    return true
+  })
+  const dispatcher = new RelayDispatcher(() => true, {
+    writableHighWaterMark: () => 16384,
+    writableLength: () => 0,
+    close: () => {}
+  })
+  return { dispatcher, stderr }
+}
+
+const flood = { events: ['x'.repeat(20_000)] }
+
+describe('relay producer loss observability', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('summarises a sustained drop storm instead of logging only the first frame', () => {
+    vi.useFakeTimers()
+    const { dispatcher, stderr } = makeSaturatedDispatcher()
+
+    for (let i = 0; i < 5; i += 1) {
+      dispatcher.notify('fs.changed', flood)
+    }
+    const beforeSummary = stderr.filter((line) => line.includes('Producer loss')).length
+
+    // Why advance past the interval: summaries are emitted from the drop path, so a later
+    // drop is what publishes the window — no timer fires on its own.
+    vi.advanceTimersByTime(11_000)
+    dispatcher.notify('fs.changed', flood)
+
+    const summaries = stderr.filter((line) => line.includes('Producer loss'))
+    expect(beforeSummary).toBe(0)
+    expect(summaries).toHaveLength(1)
+    expect(summaries[0]).toMatch(/\d+ dropped \(\d+B\)/)
+    dispatcher.dispose()
+  })
+
+  it('counts admission vetoes, which are otherwise filtered out with no trace', () => {
+    vi.useFakeTimers()
+    const { dispatcher, stderr } = makeSaturatedDispatcher()
+
+    // Veto every pty.data publication: pre-fix this filtered silently.
+    dispatcher.registerPtyDataPublicationAdmission(() => false)
+    for (let i = 0; i < 3; i += 1) {
+      dispatcher.notify('pty.data', { id: 'pty-1', data: 'x' })
+    }
+
+    vi.advanceTimersByTime(11_000)
+    dispatcher.notify('pty.data', { id: 'pty-1', data: 'x' })
+
+    const summaries = stderr.filter((line) => line.includes('Producer loss'))
+    expect(summaries).toHaveLength(1)
+    expect(summaries[0]).toMatch(/[1-9]\d* vetoed by admission/)
+    dispatcher.dispose()
+  })
+})

--- a/src/relay/dispatcher.ts
+++ b/src/relay/dispatcher.ts
@@ -99,11 +99,20 @@ type PreparedRelayFrame = Readonly<{
 // grow it inside one generation — cap it well above the fixed relay method vocabulary.
 const DROPPED_NOTIFICATION_LOG_KEY_LIMIT = 64
 
+// Why: the per-key first-occurrence line is deliberately one-shot, so a sustained storm
+// would otherwise log once and look identical to a single blip. Summaries are emitted from
+// the drop path itself rather than a timer, so they cost nothing while traffic is healthy.
+const DROPPED_NOTIFICATION_SUMMARY_INTERVAL_MS = 10_000
+
 const RESPONSE_OVER_CAPACITY_MESSAGE = 'Relay response exceeded the bounded transport capacity'
 
 type DroppedProducerNotificationLog = {
   generation: number
   loggedKeys: Set<string>
+  droppedFrames: number
+  droppedBytes: number
+  vetoedFrames: number
+  lastSummaryAt: number
 }
 
 type PendingRelayRequest = {
@@ -656,24 +665,72 @@ export class RelayDispatcher {
 
   // Why: one line per generation, method and drop reason — a flooding producer retries every batch and would
   // spam stderr, but a transient queue-full drop must not consume the slot a real over-capacity drop needs.
+  // Why a per-generation record: client ids are reused across reconnects, so counters and
+  // logged keys must reset when the generation turns over or a new client inherits stale totals.
+  private producerNotificationLog(client: RelayClient): DroppedProducerNotificationLog {
+    let log = client.droppedNotificationLog
+    if (!log || log.generation !== client.generation) {
+      log = {
+        generation: client.generation,
+        loggedKeys: new Set(),
+        droppedFrames: 0,
+        droppedBytes: 0,
+        vetoedFrames: 0,
+        lastSummaryAt: Date.now()
+      }
+      client.droppedNotificationLog = log
+    }
+    return log
+  }
+
   private logDroppedProducerNotification(client: RelayClient, method: string, bytes: number): void {
     const capacity = client.writer.producerFrameCapacity
     const overCapacity = bytes > capacity
     const key = `${method}:${overCapacity ? 'over-capacity' : 'queue-full'}`
-    let log = client.droppedNotificationLog
-    if (!log || log.generation !== client.generation) {
-      log = { generation: client.generation, loggedKeys: new Set() }
-      client.droppedNotificationLog = log
+    const log = this.producerNotificationLog(client)
+    log.droppedFrames += 1
+    log.droppedBytes += bytes
+    if (!log.loggedKeys.has(key) && log.loggedKeys.size < DROPPED_NOTIFICATION_LOG_KEY_LIMIT) {
+      log.loggedKeys.add(key)
+      process.stderr.write(
+        overCapacity
+          ? `[relay] Dropped ${method} (${bytes}B > producer frame capacity ${capacity}B)\n`
+          : `[relay] Dropped ${method} (${bytes}B, producer queue full; frame capacity ${capacity}B)\n`
+      )
     }
-    if (log.loggedKeys.has(key) || log.loggedKeys.size >= DROPPED_NOTIFICATION_LOG_KEY_LIMIT) {
+    this.flushProducerLossSummary(client, log)
+  }
+
+  // Why: an admission veto silently filters a frame out of the client list, and in legacy
+  // (non-credit) mode that is real loss with no other trace. Counting is enough — vetoes are
+  // routine while a delivery retires, so a line per veto would drown the signal.
+  private recordPtyDataAdmissionVeto(clientId: number): void {
+    const client = this.clients.get(clientId)
+    if (!client) {
       return
     }
-    log.loggedKeys.add(key)
+    const log = this.producerNotificationLog(client)
+    log.vetoedFrames += 1
+    this.flushProducerLossSummary(client, log)
+  }
+
+  private flushProducerLossSummary(client: RelayClient, log: DroppedProducerNotificationLog): void {
+    const now = Date.now()
+    const elapsed = now - log.lastSummaryAt
+    if (elapsed < DROPPED_NOTIFICATION_SUMMARY_INTERVAL_MS) {
+      return
+    }
+    if (log.droppedFrames === 0 && log.vetoedFrames === 0) {
+      return
+    }
     process.stderr.write(
-      overCapacity
-        ? `[relay] Dropped ${method} (${bytes}B > producer frame capacity ${capacity}B)\n`
-        : `[relay] Dropped ${method} (${bytes}B, producer queue full; frame capacity ${capacity}B)\n`
+      `[relay] Producer loss on client ${this.clientKey(client)} over ${elapsed}ms: ` +
+        `${log.droppedFrames} dropped (${log.droppedBytes}B), ${log.vetoedFrames} vetoed by admission\n`
     )
+    log.droppedFrames = 0
+    log.droppedBytes = 0
+    log.vetoedFrames = 0
+    log.lastSummaryAt = now
   }
 
   notifyClient(clientId: number, method: string, params?: Record<string, unknown>): void {
@@ -1212,11 +1269,17 @@ export class RelayDispatcher {
     return Array.from(this.clients.values()).filter((client) => !client.closed)
   }
 
+  // Why count here: every veto path — publish-time client filtering and the drain-time
+  // isStillAdmitted recheck — resolves through this one predicate.
   private admitsPtyDataPublication(
     clientId: number,
     params: Readonly<Record<string, unknown>>
   ): boolean {
-    return this.ptyDataPublicationAdmission?.(clientId, params) ?? true
+    const admitted = this.ptyDataPublicationAdmission?.(clientId, params) ?? true
+    if (!admitted) {
+      this.recordPtyDataAdmissionVeto(clientId)
+    }
+    return admitted
   }
 
   private activeClientKeys(): string[] {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​67 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​67 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​73 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​63 |

<!-- /orca-pr-loc -->

## ELI5

When the relay has to throw away terminal output, it says so **once** and then goes quiet. So a storm that drops thousands of frames looks exactly like a single hiccup. And there's a second way frames vanish — an admission veto — that says nothing at all.

This keeps the existing one-shot detail line and adds a periodic summary: how many frames were dropped, how many bytes, and how many were vetoed.

## What Changed

- `logDroppedProducerNotification` still logs the first `method:reason` per client generation, and now also accumulates `droppedFrames` / `droppedBytes`.
- New counter for admission vetoes, incremented at `admitsPtyDataPublication` — the single predicate **every** veto path resolves through, including the drain-time `isStillAdmitted` recheck. One chokepoint instead of touching each filter site.
- `flushProducerLossSummary` emits an aggregate at most every 10s per client generation, then resets the window.

## Why

Two distinct losses were near-invisible:

1. **Rate-limited drop logging.** One line per `method:{over-capacity|queue-full}` per generation, capped by `DROPPED_NOTIFICATION_LOG_KEY_LIMIT`. A sustained storm logs once.
2. **The admission veto logged nothing.** Frames are filtered out of the client list before enqueue, and `isStillAdmitted` can discard an already-queued frame at drain time. In credit mode that surfaces as a settle failure and a safe rollback; in **legacy mode it is silent loss**.

This is the concrete observability gap that let a wrong root cause survive days of STA-4510 investigation — the logs could not distinguish "dropped a burst" from "delivered fine".

Two deliberate design choices:

- **Emitted from the loss path, not a timer.** Healthy traffic pays nothing, and no interval can outlive the dispatcher.
- **Counters are per client generation.** Client ids are reused across reconnects, so a new generation must not inherit stale totals.

Vetoes are counted rather than logged individually because they are routine while a delivery retires — a line per veto would drown the signal.

## Linked Issue

Fixes STA-4572

## Visual Proof

`N/A` — no UI surface. This is relay stderr diagnostics.

## Testing

- Full relay suite: **135 files / 1400 tests pass.**
- `pnpm tc` exit 0 (exit code checked, not just output). `oxfmt` + `oxlint` clean.

New `dispatcher-producer-loss-observability.test.ts`, both cases mutation-verified:

| mutation | caught by |
|---|---|
| summary emission removed | both tests |
| veto counting removed at the predicate | "counts admission vetoes, which are otherwise filtered out with no trace" |

The first version of the drop-storm test was wrong and I caught it before committing: a bare `() => false` sink never actually dropped anything, so the test passed for the wrong reason. It now uses the established bounded-sink shape where a 20KB frame exceeds the 16KB producer frame capacity, which is the real over-capacity path.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

- **No behavior change to delivery.** Nothing about what is dropped, vetoed, or delivered changes — only what is reported. The existing one-shot line is preserved so current log-scraping still matches.
- **Cost when healthy:** two integer increments on a path that only runs when a frame is already being lost.
- **Backwards compatibility:** no wire change, no protocol change.
- Found during STA-4510 (#14992). Deliberately kept out of that PR and filed separately.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @BrennanKB5
