### PR TITLE
fix(package): keep cached dev Electron bundles out of app.asar

### DIFF
--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -129,6 +129,9 @@ module.exports = {
     '!out/**/*.test.js',
     // Why: Vite's manifest is only used to project the paired web client.
     '!out/renderer/.vite{,/**/*}',
+    // Why: out/electron-dev caches `pnpm dev`'s per-branch Electron.app copies (~270MB each).
+    // CI never creates it, but packaging on a machine that has run dev would pack them all.
+    '!out/electron-dev{,/**/*}',
     '!electron.vite.config.{js,ts,mjs,cjs}',
     '!{.eslintcache,eslint.config.mjs,.prettierignore,.prettierrc.yaml,CHANGELOG.md,README.md}',
     '!{.env,.env.*,.npmrc,pnpm-lock.yaml}',

--- a/config/scripts/electron-builder-config.test.mjs
+++ b/config/scripts/electron-builder-config.test.mjs
@@ -75,6 +75,25 @@ describe('electron-builder config', () => {
     expect(packs('out/main/examples/index.js')).toBe(true)
   })
 
+  // Why: out/electron-dev holds `pnpm dev`'s cached Electron.app copies (~270MB per branch).
+  // CI never creates it, so only a local package would have hit this -- silently, as bulk.
+  it('keeps cached dev Electron bundles out of app.asar', () => {
+    const matcher = new FileMatcher('/app', '/dest', (value) => value, electronBuilderConfig.files)
+    matcher.prependPattern('**/*')
+    const isPacked = matcher.createFilter()
+    const packs = (repoPath) => isPacked(join('/app', repoPath), { isDirectory: () => false })
+
+    for (const devBundlePath of [
+      'out/electron-dev/1a2b3c4d5e6f/Orca: dev.app/Contents/MacOS/Electron',
+      'out/electron-dev/1a2b3c4d5e6f/orca-dev-electron-app.json'
+    ]) {
+      expect(packs(devBundlePath)).toBe(false)
+    }
+    // The real build outputs sit beside it under out/ and must still ship.
+    expect(packs('out/main/index.js')).toBe(true)
+    expect(packs('out/renderer/index.html')).toBe(true)
+  })
+
   it('keeps runtime resources available through extraResources', () => {
     const bundledPluginResources = expect.objectContaining({
       from: 'resources/plugins/launch',


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​19 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​19 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |

<!-- /orca-pr-loc -->

## ELI5

`pnpm dev` leaves a ~270MB copy of Electron.app in `out/electron-dev` for every branch you build. If you packaged the app on that same machine, all of those copies got stuffed into the shipped `app.asar`. One line tells electron-builder to skip that directory.

## What Changed

- `config/electron-builder.config.cjs`: added `'!out/electron-dev{,/**/*}'` to `files`.
- `config/scripts/electron-builder-config.test.mjs`: a matcher-driven test that dev bundle paths are excluded while `out/main` and `out/renderer` still pack.

## Why

`files` is an all-negation list, so electron-builder's default `**/*` packs anything without an explicit `!` entry. `out/` is gitignored, but electron-builder globs the filesystem, not git — so `out/electron-dev/<hash>/Orca: dev.app/**` was fair game.

This is the same shape as the `examples/` miss that shipped `hostile-panel` in 1.4.160-rc.3, which is why the test drives the real `FileMatcher` instead of pinning the pattern string: asserting the glob exists cannot prove it excludes the tree.

**Release builds were never affected** — CI runners never run `pnpm dev`, so `out/electron-dev` does not exist there. The exposure is local packaging only (`pnpm build:mac` / `build:unpack` on a dev machine), where it showed up as silent bulk rather than a failure.

Noticed while reviewing #15247, which prunes stale bundles from that same directory and so already shrank the worst case.

## Linked Issue

No separate issue — follow-up to #15247.

## Visual Proof

N/A — packaging input filter only. No runtime code, UI, or user-visible behavior changes.

## Testing

`pnpm exec vitest run config/scripts/electron-builder-config.test.mjs` → 34 passed.

Mutation-verified: with the `!out/electron-dev{,/**/*}` line removed, the new test fails; restored, it passes. Without that step the test would pass either way.

Also clean: `oxlint`, `oxfmt --check`, `check:max-lines-ratchet`.

Not run locally: a full `pnpm build:mac`. The assertion is on electron-builder's own `FileMatcher` with the real config, which is the component that decides packing.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below