### PR TITLE
fix(github-projects): keep empty user/label lists last when sorting DESC

### DIFF
--- a/src/shared/github/project-group-sort.test.ts
+++ b/src/shared/github/project-group-sort.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import { sortRows } from './project-group-sort'
+import type { GitHubProjectRow, GitHubProjectTable } from './project-types'
+
+const USERS_FIELD = { id: 'f1', name: 'Assignees', kind: 'users' } as never
+
+function tableSortedBy(direction: 'ASC' | 'DESC'): GitHubProjectTable {
+  return {
+    selectedView: { groupByFields: [], sortByFields: [{ field: USERS_FIELD, direction }] }
+  } as unknown as GitHubProjectTable
+}
+
+function rowWithUsers(id: string, logins: string[] | null, position: number): GitHubProjectRow {
+  return {
+    id,
+    position,
+    fieldValuesByFieldId: logins
+      ? { f1: { kind: 'users', fieldId: 'f1', users: logins.map((login) => ({ login })) } }
+      : {}
+  } as unknown as GitHubProjectRow
+}
+
+const ids = (rows: GitHubProjectRow[]): string[] => rows.map((row) => row.id)
+
+describe('sortRows', () => {
+  // An unset field reaches the comparator two ways: absent from fieldValuesByFieldId,
+  // or present with an empty list once every user drops out of normalization. Both
+  // read as "unassigned", so both must sort the same way.
+  it('keeps an empty user list last in both directions', () => {
+    const rows = [
+      rowWithUsers('assigned', ['alice'], 1),
+      rowWithUsers('empty-list', [], 2),
+      rowWithUsers('no-value', null, 3)
+    ]
+
+    expect(ids(sortRows(tableSortedBy('ASC'), rows))).toEqual([
+      'assigned',
+      'empty-list',
+      'no-value'
+    ])
+    expect(ids(sortRows(tableSortedBy('DESC'), rows))).toEqual([
+      'assigned',
+      'empty-list',
+      'no-value'
+    ])
+  })
+
+  it('still reverses populated values when sorting DESC', () => {
+    const rows = [
+      rowWithUsers('alice', ['alice'], 1),
+      rowWithUsers('carol', ['carol'], 2),
+      rowWithUsers('bob', ['bob'], 3),
+      rowWithUsers('empty-list', [], 4)
+    ]
+
+    expect(ids(sortRows(tableSortedBy('ASC'), rows))).toEqual([
+      'alice',
+      'bob',
+      'carol',
+      'empty-list'
+    ])
+    expect(ids(sortRows(tableSortedBy('DESC'), rows))).toEqual([
+      'carol',
+      'bob',
+      'alice',
+      'empty-list'
+    ])
+  })
+
+  it('falls through to position when both rows are unassigned', () => {
+    const rows = [
+      rowWithUsers('second', [], 2),
+      rowWithUsers('first', [], 1),
+      rowWithUsers('third', null, 3)
+    ]
+
+    expect(ids(sortRows(tableSortedBy('DESC'), rows))).toEqual(['first', 'second', 'third'])
+  })
+})

--- a/src/shared/github/project-group-sort.test.ts
+++ b/src/shared/github/project-group-sort.test.ts
@@ -23,9 +23,6 @@ function rowWithUsers(id: string, logins: string[] | null, position: number): Gi
 const ids = (rows: GitHubProjectRow[]): string[] => rows.map((row) => row.id)
 
 describe('sortRows', () => {
-  // An unset field reaches the comparator two ways: absent from fieldValuesByFieldId,
-  // or present with an empty list once every user drops out of normalization. Both
-  // read as "unassigned", so both must sort the same way.
   it('keeps an empty user list last in both directions', () => {
     const rows = [
       rowWithUsers('assigned', ['alice'], 1),

--- a/src/shared/github/project-group-sort.ts
+++ b/src/shared/github/project-group-sort.ts
@@ -184,10 +184,7 @@ function compareSort(a: GitHubProjectRow, b: GitHubProjectRow, sort: GitHubProje
   } else if (aValue.kind === 'users' && bValue.kind === 'users') {
     const aLogin = aValue.users[0]?.login ?? ''
     const bLogin = bValue.users[0]?.login ?? ''
-    // Why: return before the DESC flip below so an empty list sorts last in both
-    // directions, matching the missing-value case above. A field can hold an empty
-    // list once every user drops out of normalization, and the two ways of being
-    // unset must not land at opposite ends of the same sort.
+    // Return before the DESC flip so an empty list sorts last in both directions.
     if (!aLogin && !bLogin) {
       return 0
     }

--- a/src/shared/github/project-group-sort.ts
+++ b/src/shared/github/project-group-sort.ts
@@ -184,27 +184,33 @@ function compareSort(a: GitHubProjectRow, b: GitHubProjectRow, sort: GitHubProje
   } else if (aValue.kind === 'users' && bValue.kind === 'users') {
     const aLogin = aValue.users[0]?.login ?? ''
     const bLogin = bValue.users[0]?.login ?? ''
+    // Why: return before the DESC flip below so an empty list sorts last in both
+    // directions, matching the missing-value case above. A field can hold an empty
+    // list once every user drops out of normalization, and the two ways of being
+    // unset must not land at opposite ends of the same sort.
     if (!aLogin && !bLogin) {
-      cmp = 0
-    } else if (!aLogin) {
-      cmp = 1
-    } else if (!bLogin) {
-      cmp = -1
-    } else {
-      cmp = aLogin.localeCompare(bLogin)
+      return 0
     }
+    if (!aLogin) {
+      return 1
+    }
+    if (!bLogin) {
+      return -1
+    }
+    cmp = aLogin.localeCompare(bLogin)
   } else if (aValue.kind === 'labels' && bValue.kind === 'labels') {
     const aName = aValue.labels[0]?.name ?? ''
     const bName = bValue.labels[0]?.name ?? ''
     if (!aName && !bName) {
-      cmp = 0
-    } else if (!aName) {
-      cmp = 1
-    } else if (!bName) {
-      cmp = -1
-    } else {
-      cmp = aName.localeCompare(bName)
+      return 0
     }
+    if (!aName) {
+      return 1
+    }
+    if (!bName) {
+      return -1
+    }
+    cmp = aName.localeCompare(bName)
   } else {
     // Why: unknown sort-field kind — ignore this sort field and fall through
     // to tie-breaks (and eventually row.position).


### PR DESCRIPTION
## ELI5

In the Projects table, sorting by Assignees descending could throw some unassigned rows to the *top*, above rows that actually have an assignee — while other unassigned rows stayed at the bottom. Now unassigned always sits at the bottom, whichever way you sort.

## What Changed

`compareSort` in `src/shared/github/project-group-sort.ts`. The `users` and `labels` branches now return early for an empty list instead of setting `cmp`, so the result skips the direction flip — matching how a missing value is already handled two blocks above.

Ordering of populated values, including the DESC reversal, is untouched.

Also adds `project-group-sort.test.ts`; the module had no test file.

## Why

A row with **no value** for the sort field is handled by returning before the direction flip, so it sorts last either way:

```ts
if (!aValue) return 1
if (!bValue) return -1
...
return sort.direction === 'DESC' ? -cmp : cmp
```

The `users` and `labels` branches express the same "empty goes last" idea as `cmp = 1`, which then *does* get negated by that last line. So a field that is present but holds an empty list sorts last ascending and **first** descending:

```
ASC    alice  bob  carol  empty-list  no-value
DESC   empty-list  carol  bob  alice  no-value
```

Both `empty-list` and `no-value` read as unassigned to the user, so descending splits them across opposite ends of the table and floats one above rows that actually have a value.

An empty list is reachable rather than theoretical — `project-view.ts` builds users from the API and drops anything `normalizeUser` rejects:

```ts
const users = (raw.users?.nodes ?? []).map(normalizeUser).filter((u) => u !== null)
return { kind: 'users', fieldId, users }
```

A field whose users all fail to normalize yields `users: []`, not a missing value. Labels are built the same way.

Returning early was chosen over negating the missing-value case because "empties last regardless of direction" is the convention the existing code already implements, and it is what GitHub Projects itself does.

## Linked Issue

Fixes #15358

## Visual Proof

`N/A` — no UI or styling change. The behavior change is row order in the Projects table, which the before/after in **Why** shows directly and the new tests assert.

## Testing

Reviewer steps: `npx vitest run --config config/vitest.config.ts src/shared/github/project-group-sort.test.ts`

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

| check | result |
|---|---|
| `vitest src/shared/github/project-group-sort.test.ts` | 3 passed |
| `vitest src/shared/github/` | 9 files, 31 passed |
| `oxlint` (changed files) | clean, exit 0 |
| `oxfmt --check` (changed files) | correct format |
| `check:max-lines-ratchet` | OK — no new bypasses |

Two of the three new tests fail on current `main`, for the right reason:

```
AssertionError: expected [ 'empty-list', 'carol', 'bob', …(1) ]
              to deeply equal [ 'carol', 'bob', 'alice', …(1) ]
```

The third (position tie-break) passes either way and is there as a guard.

Platforms: this is pure shared sorting logic with no platform-dependent code, so it behaves identically on macOS / Linux / Windows and over SSH. Verified on macOS.

## AI Disclosure

Claude Opus 4.5 was used to locate the bug, write the fix and tests, and draft this PR.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Security, remote/SSH, mobile, backwards compatibility, performance: no impact. `sortRows` is pure and runs client-side over already-fetched rows; nothing crosses the wire, no persisted shape changes, and the comparator does the same amount of work. `mobile/` consumes this module through a re-export rather than a copy, so the mobile Projects view picks up the same fix with no separate change.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
  - Ran the targeted equivalents above rather than the full suites; leaving the full runs to CI.