### PR TITLE
fix(shell): carry a WSL pane's shell across relay revive and stop forking to probe zsh emulation (STA-4682)

### DIFF
--- a/src/main/__fixtures__/shell-wrapper-snapshots/daemon-zsh-zprofile.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/daemon-zsh-zprofile.txt
@@ -18,7 +18,7 @@ if [[ -f "$_orca_home/.zprofile" ]]; then
   unset _orca_wrapper_zdotdir
 fi
 
-if [[ -f "$_orca_home/.zprofile" ]] && [[ -o ksharrays || -o shwordsplit || -o shglob ]]; then
+if [[ -f "$_orca_home/.zprofile" ]] && [[ -o ksharrays || -o shwordsplit || -o shglob ]] 2>/dev/null; then
   case "$(emulate 2>/dev/null)" in
     sh|ksh)
       export ZDOTDIR="$_orca_home"

--- a/src/main/__fixtures__/shell-wrapper-snapshots/daemon-zsh-zprofile.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/daemon-zsh-zprofile.txt
@@ -18,7 +18,7 @@ if [[ -f "$_orca_home/.zprofile" ]]; then
   unset _orca_wrapper_zdotdir
 fi
 
-if [[ -f "$_orca_home/.zprofile" ]]; then
+if [[ -f "$_orca_home/.zprofile" ]] && [[ -o ksharrays || -o shwordsplit || -o shglob ]]; then
   case "$(emulate 2>/dev/null)" in
     sh|ksh)
       export ZDOTDIR="$_orca_home"

--- a/src/main/__fixtures__/shell-wrapper-snapshots/daemon-zsh-zshenv.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/daemon-zsh-zshenv.txt
@@ -82,7 +82,7 @@ __orca_resolve_user_config_dir "${_orca_discovered_zdotdir:-${_orca_user_zdotdir
 export ORCA_ORIG_ZDOTDIR="$_orca_resolved_config_dir"
 unset _orca_user_zdotdir _orca_zshenv_source_dir _orca_discovered_zdotdir
 
-if [[ -n "${_orca_zshenv_path:-}" ]] && [[ -o ksharrays || -o shwordsplit || -o shglob ]]; then
+if [[ -n "${_orca_zshenv_path:-}" ]] && [[ -o ksharrays || -o shwordsplit || -o shglob ]] 2>/dev/null; then
   case "$(emulate 2>/dev/null)" in
     sh|ksh)
       export ZDOTDIR="$ORCA_ORIG_ZDOTDIR"

--- a/src/main/__fixtures__/shell-wrapper-snapshots/daemon-zsh-zshenv.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/daemon-zsh-zshenv.txt
@@ -82,7 +82,7 @@ __orca_resolve_user_config_dir "${_orca_discovered_zdotdir:-${_orca_user_zdotdir
 export ORCA_ORIG_ZDOTDIR="$_orca_resolved_config_dir"
 unset _orca_user_zdotdir _orca_zshenv_source_dir _orca_discovered_zdotdir
 
-if [[ -n "${_orca_zshenv_path:-}" ]]; then
+if [[ -n "${_orca_zshenv_path:-}" ]] && [[ -o ksharrays || -o shwordsplit || -o shglob ]]; then
   case "$(emulate 2>/dev/null)" in
     sh|ksh)
       export ZDOTDIR="$ORCA_ORIG_ZDOTDIR"

--- a/src/main/__fixtures__/shell-wrapper-snapshots/daemon-zsh-zshrc.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/daemon-zsh-zshrc.txt
@@ -18,6 +18,6 @@ if [[ "$_orca_home" != "$ZDOTDIR" && -o interactive && -f "$_orca_home/.zshrc" ]
   unset _orca_wrapper_zdotdir
 fi
 
-if [[ ! -o login || "$(emulate 2>/dev/null)" != zsh ]]; then
+if [[ ! -o login ]] || { [[ -o ksharrays || -o shwordsplit || -o shglob ]] && [[ "$(emulate 2>/dev/null)" != zsh ]]; }; then
   (( ${+functions[__orca_shell_epilogue]} )) && __orca_shell_epilogue
 fi

--- a/src/main/__fixtures__/shell-wrapper-snapshots/daemon-zsh-zshrc.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/daemon-zsh-zshrc.txt
@@ -18,6 +18,6 @@ if [[ "$_orca_home" != "$ZDOTDIR" && -o interactive && -f "$_orca_home/.zshrc" ]
   unset _orca_wrapper_zdotdir
 fi
 
-if [[ ! -o login ]] || { [[ -o ksharrays || -o shwordsplit || -o shglob ]] && [[ "$(emulate 2>/dev/null)" != zsh ]]; }; then
+if [[ ! -o login ]] || { [[ -o ksharrays || -o shwordsplit || -o shglob ]] 2>/dev/null && [[ "$(emulate 2>/dev/null)" != zsh ]]; }; then
   (( ${+functions[__orca_shell_epilogue]} )) && __orca_shell_epilogue
 fi

--- a/src/main/__fixtures__/shell-wrapper-snapshots/local-zsh-zprofile.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/local-zsh-zprofile.txt
@@ -18,7 +18,7 @@ if [[ -f "$_orca_home/.zprofile" ]]; then
   unset _orca_wrapper_zdotdir
 fi
 
-if [[ -f "$_orca_home/.zprofile" ]] && [[ -o ksharrays || -o shwordsplit || -o shglob ]]; then
+if [[ -f "$_orca_home/.zprofile" ]] && [[ -o ksharrays || -o shwordsplit || -o shglob ]] 2>/dev/null; then
   case "$(emulate 2>/dev/null)" in
     sh|ksh)
       export ZDOTDIR="$_orca_home"

--- a/src/main/__fixtures__/shell-wrapper-snapshots/local-zsh-zprofile.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/local-zsh-zprofile.txt
@@ -18,7 +18,7 @@ if [[ -f "$_orca_home/.zprofile" ]]; then
   unset _orca_wrapper_zdotdir
 fi
 
-if [[ -f "$_orca_home/.zprofile" ]]; then
+if [[ -f "$_orca_home/.zprofile" ]] && [[ -o ksharrays || -o shwordsplit || -o shglob ]]; then
   case "$(emulate 2>/dev/null)" in
     sh|ksh)
       export ZDOTDIR="$_orca_home"

--- a/src/main/__fixtures__/shell-wrapper-snapshots/local-zsh-zshenv.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/local-zsh-zshenv.txt
@@ -82,7 +82,7 @@ __orca_resolve_user_config_dir "${_orca_discovered_zdotdir:-${_orca_user_zdotdir
 export ORCA_ORIG_ZDOTDIR="$_orca_resolved_config_dir"
 unset _orca_user_zdotdir _orca_zshenv_source_dir _orca_discovered_zdotdir
 
-if [[ -n "${_orca_zshenv_path:-}" ]] && [[ -o ksharrays || -o shwordsplit || -o shglob ]]; then
+if [[ -n "${_orca_zshenv_path:-}" ]] && [[ -o ksharrays || -o shwordsplit || -o shglob ]] 2>/dev/null; then
   case "$(emulate 2>/dev/null)" in
     sh|ksh)
       export ZDOTDIR="$ORCA_ORIG_ZDOTDIR"

--- a/src/main/__fixtures__/shell-wrapper-snapshots/local-zsh-zshenv.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/local-zsh-zshenv.txt
@@ -82,7 +82,7 @@ __orca_resolve_user_config_dir "${_orca_discovered_zdotdir:-${_orca_user_zdotdir
 export ORCA_ORIG_ZDOTDIR="$_orca_resolved_config_dir"
 unset _orca_user_zdotdir _orca_zshenv_source_dir _orca_discovered_zdotdir
 
-if [[ -n "${_orca_zshenv_path:-}" ]]; then
+if [[ -n "${_orca_zshenv_path:-}" ]] && [[ -o ksharrays || -o shwordsplit || -o shglob ]]; then
   case "$(emulate 2>/dev/null)" in
     sh|ksh)
       export ZDOTDIR="$ORCA_ORIG_ZDOTDIR"

--- a/src/main/__fixtures__/shell-wrapper-snapshots/local-zsh-zshrc.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/local-zsh-zshrc.txt
@@ -18,6 +18,6 @@ if [[ "$_orca_home" != "$ZDOTDIR" && -o interactive && -f "$_orca_home/.zshrc" ]
   unset _orca_wrapper_zdotdir
 fi
 
-if [[ ! -o login || "$(emulate 2>/dev/null)" != zsh ]]; then
+if [[ ! -o login ]] || { [[ -o ksharrays || -o shwordsplit || -o shglob ]] && [[ "$(emulate 2>/dev/null)" != zsh ]]; }; then
   (( ${+functions[__orca_shell_epilogue]} )) && __orca_shell_epilogue
 fi

--- a/src/main/__fixtures__/shell-wrapper-snapshots/local-zsh-zshrc.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/local-zsh-zshrc.txt
@@ -18,6 +18,6 @@ if [[ "$_orca_home" != "$ZDOTDIR" && -o interactive && -f "$_orca_home/.zshrc" ]
   unset _orca_wrapper_zdotdir
 fi
 
-if [[ ! -o login ]] || { [[ -o ksharrays || -o shwordsplit || -o shglob ]] && [[ "$(emulate 2>/dev/null)" != zsh ]]; }; then
+if [[ ! -o login ]] || { [[ -o ksharrays || -o shwordsplit || -o shglob ]] 2>/dev/null && [[ "$(emulate 2>/dev/null)" != zsh ]]; }; then
   (( ${+functions[__orca_shell_epilogue]} )) && __orca_shell_epilogue
 fi

--- a/src/main/__fixtures__/shell-wrapper-snapshots/relay-zsh-zprofile.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/relay-zsh-zprofile.txt
@@ -18,7 +18,7 @@ if [[ -f "$_orca_home/.zprofile" ]]; then
   unset _orca_wrapper_zdotdir
 fi
 
-if [[ -f "$_orca_home/.zprofile" ]] && [[ -o ksharrays || -o shwordsplit || -o shglob ]]; then
+if [[ -f "$_orca_home/.zprofile" ]] && [[ -o ksharrays || -o shwordsplit || -o shglob ]] 2>/dev/null; then
   case "$(emulate 2>/dev/null)" in
     sh|ksh)
       export ZDOTDIR="$_orca_home"

--- a/src/main/__fixtures__/shell-wrapper-snapshots/relay-zsh-zprofile.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/relay-zsh-zprofile.txt
@@ -18,7 +18,7 @@ if [[ -f "$_orca_home/.zprofile" ]]; then
   unset _orca_wrapper_zdotdir
 fi
 
-if [[ -f "$_orca_home/.zprofile" ]]; then
+if [[ -f "$_orca_home/.zprofile" ]] && [[ -o ksharrays || -o shwordsplit || -o shglob ]]; then
   case "$(emulate 2>/dev/null)" in
     sh|ksh)
       export ZDOTDIR="$_orca_home"

--- a/src/main/__fixtures__/shell-wrapper-snapshots/relay-zsh-zshenv.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/relay-zsh-zshenv.txt
@@ -29,7 +29,7 @@ export ORCA_ORIG_ZDOTDIR="$_orca_resolved_config_dir"
 __orca_resolve_user_config_dir "${ZDOTDIR:-${ORCA_ORIG_ZDOTDIR:-$HOME}}"
 export ORCA_USER_ZDOTDIR="$_orca_resolved_config_dir"
 
-if [[ -f "$ORCA_ORIG_ZDOTDIR/.zshenv" ]] && [[ -o ksharrays || -o shwordsplit || -o shglob ]]; then
+if [[ -f "$ORCA_ORIG_ZDOTDIR/.zshenv" ]] && [[ -o ksharrays || -o shwordsplit || -o shglob ]] 2>/dev/null; then
   case "$(emulate 2>/dev/null)" in
     sh|ksh)
       export ZDOTDIR="$ORCA_USER_ZDOTDIR"

--- a/src/main/__fixtures__/shell-wrapper-snapshots/relay-zsh-zshenv.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/relay-zsh-zshenv.txt
@@ -29,7 +29,7 @@ export ORCA_ORIG_ZDOTDIR="$_orca_resolved_config_dir"
 __orca_resolve_user_config_dir "${ZDOTDIR:-${ORCA_ORIG_ZDOTDIR:-$HOME}}"
 export ORCA_USER_ZDOTDIR="$_orca_resolved_config_dir"
 
-if [[ -f "$ORCA_ORIG_ZDOTDIR/.zshenv" ]]; then
+if [[ -f "$ORCA_ORIG_ZDOTDIR/.zshenv" ]] && [[ -o ksharrays || -o shwordsplit || -o shglob ]]; then
   case "$(emulate 2>/dev/null)" in
     sh|ksh)
       export ZDOTDIR="$ORCA_USER_ZDOTDIR"

--- a/src/main/__fixtures__/shell-wrapper-snapshots/relay-zsh-zshrc.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/relay-zsh-zshrc.txt
@@ -18,6 +18,6 @@ if [[ -o interactive && -f "$_orca_home/.zshrc" ]]; then
   unset _orca_wrapper_zdotdir
 fi
 
-if [[ ! -o login ]] || { [[ -o ksharrays || -o shwordsplit || -o shglob ]] && [[ "$(emulate 2>/dev/null)" != zsh ]]; }; then
+if [[ ! -o login ]] || { [[ -o ksharrays || -o shwordsplit || -o shglob ]] 2>/dev/null && [[ "$(emulate 2>/dev/null)" != zsh ]]; }; then
   (( ${+functions[__orca_shell_epilogue]} )) && __orca_shell_epilogue
 fi

--- a/src/main/__fixtures__/shell-wrapper-snapshots/relay-zsh-zshrc.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/relay-zsh-zshrc.txt
@@ -18,6 +18,6 @@ if [[ -o interactive && -f "$_orca_home/.zshrc" ]]; then
   unset _orca_wrapper_zdotdir
 fi
 
-if [[ ! -o login || "$(emulate 2>/dev/null)" != zsh ]]; then
+if [[ ! -o login ]] || { [[ -o ksharrays || -o shwordsplit || -o shglob ]] && [[ "$(emulate 2>/dev/null)" != zsh ]]; }; then
   (( ${+functions[__orca_shell_epilogue]} )) && __orca_shell_epilogue
 fi

--- a/src/main/daemon/shell-ready.test.ts
+++ b/src/main/daemon/shell-ready.test.ts
@@ -508,7 +508,12 @@ describePosix('daemon shell-ready launch config', () => {
     expectFinalZdotdirRestoreContext(zshenv)
     // Why the emulation probe: sh/ksh emulation makes zsh read $HOME/.zlogin
     // rather than the wrapper's, so the epilogue has to run from here instead.
-    expect(zshrc).toContain('if [[ ! -o login || "$(emulate 2>/dev/null)" != zsh ]]; then')
+    // Why the option test in front of it: the probe forks, and all-off proves
+    // zsh emulation without one.
+    expect(zshrc).toContain(
+      'if [[ ! -o login ]] || { [[ -o ksharrays || -o shwordsplit || -o shglob ]] && ' +
+        '[[ "$(emulate 2>/dev/null)" != zsh ]]; }; then'
+    )
     expect(zshrc).toContain('(( ${+functions[__orca_shell_epilogue]} )) && __orca_shell_epilogue')
   })
 

--- a/src/main/daemon/shell-ready.test.ts
+++ b/src/main/daemon/shell-ready.test.ts
@@ -511,7 +511,7 @@ describePosix('daemon shell-ready launch config', () => {
     // Why the option test in front of it: the probe forks, and all-off proves
     // zsh emulation without one.
     expect(zshrc).toContain(
-      'if [[ ! -o login ]] || { [[ -o ksharrays || -o shwordsplit || -o shglob ]] && ' +
+      'if [[ ! -o login ]] || { [[ -o ksharrays || -o shwordsplit || -o shglob ]] 2>/dev/null && ' +
         '[[ "$(emulate 2>/dev/null)" != zsh ]]; }; then'
     )
     expect(zshrc).toContain('(( ${+functions[__orca_shell_epilogue]} )) && __orca_shell_epilogue')

--- a/src/main/providers/local-pty-shell-ready-wrapper-generation.test.ts
+++ b/src/main/providers/local-pty-shell-ready-wrapper-generation.test.ts
@@ -259,7 +259,7 @@ describePosix('local PTY shell-ready launch config', () => {
     // Why the option test in front of it: the probe forks, and all-off proves
     // zsh emulation without one.
     expect(zshrc).toContain(
-      'if [[ ! -o login ]] || { [[ -o ksharrays || -o shwordsplit || -o shglob ]] && ' +
+      'if [[ ! -o login ]] || { [[ -o ksharrays || -o shwordsplit || -o shglob ]] 2>/dev/null && ' +
         '[[ "$(emulate 2>/dev/null)" != zsh ]]; }; then'
     )
     expect(zshrc).toContain('(( ${+functions[__orca_shell_epilogue]} )) && __orca_shell_epilogue')

--- a/src/main/providers/local-pty-shell-ready-wrapper-generation.test.ts
+++ b/src/main/providers/local-pty-shell-ready-wrapper-generation.test.ts
@@ -256,7 +256,12 @@ describePosix('local PTY shell-ready launch config', () => {
     expectFinalZdotdirRestoreContext(zshenv)
     // Why the emulation probe: sh/ksh emulation makes zsh read $HOME/.zlogin
     // rather than the wrapper's, so the epilogue has to run from here instead.
-    expect(zshrc).toContain('if [[ ! -o login || "$(emulate 2>/dev/null)" != zsh ]]; then')
+    // Why the option test in front of it: the probe forks, and all-off proves
+    // zsh emulation without one.
+    expect(zshrc).toContain(
+      'if [[ ! -o login ]] || { [[ -o ksharrays || -o shwordsplit || -o shglob ]] && ' +
+        '[[ "$(emulate 2>/dev/null)" != zsh ]]; }; then'
+    )
     expect(zshrc).toContain('(( ${+functions[__orca_shell_epilogue]} )) && __orca_shell_epilogue')
     expect(zlogin).toContain('(( ${+functions[__orca_shell_epilogue]} )) && __orca_shell_epilogue')
   })

--- a/src/main/shell-templates.ts
+++ b/src/main/shell-templates.ts
@@ -111,8 +111,14 @@ export { BASH_PROMPT_COMMAND_COMPOSITION_BLOCK } from './bash-prompt-command-com
  * answer. OR, not AND, so the only way past it is to enter emulation and then
  * unset all three; every real `emulate sh`/`emulate ksh` sets them. A false
  * positive costs exactly the fork this saves.
+ *
+ * Why `2>/dev/null`: `[[ -o <unknown> ]]` prints `no such option` to stderr and
+ * returns false rather than aborting, so on a zsh too old for one of these
+ * names the only symptom would be that text in the user's pane. All three
+ * predate every zsh Orca supports, so this is belt and braces, not a fallback.
  */
-export const ZSH_BOURNE_EMULATION_OPTION_HINT = '[[ -o ksharrays || -o shwordsplit || -o shglob ]]'
+export const ZSH_BOURNE_EMULATION_OPTION_HINT =
+  '[[ -o ksharrays || -o shwordsplit || -o shglob ]] 2>/dev/null'
 
 /**
  * Hands the pane back to the user unwrapped when zsh has entered sh/ksh

--- a/src/main/shell-templates.ts
+++ b/src/main/shell-templates.ts
@@ -94,6 +94,27 @@ __orca_resolve_inherited_config_dir() {
 export { BASH_PROMPT_COMMAND_COMPOSITION_BLOCK } from './bash-prompt-command-composition'
 
 /**
+ * Fork-free precondition for the `$(emulate)` probe: options that both
+ * `emulate sh` and `emulate ksh` turn on, so all-off proves zsh emulation.
+ *
+ * Why: the probe is a command substitution, which forks a zsh carrying every
+ * function, alias and completion the user's config has loaded by that point —
+ * the most expensive line in the wrapper, and one every zsh pane pays now that
+ * wrapping widened to all of them. Measured on zsh 5.9 / macOS, 150 login
+ * startups per arm, with a user .zshenv + .zprofile + .zshrc present: 9.97
+ * ms/run unwrapped, 14.20 ms/run wrapped, 12.27 ms/run wrapped once these three
+ * probes are skipped — about half of what wrapping costs.
+ *
+ * Why a hint in front of the real probe and not a replacement for it: these
+ * options say nothing about `emulation`, which is what zsh's `sourcehome()`
+ * branches on, so a config that sets one by hand must still get the exact
+ * answer. OR, not AND, so the only way past it is to enter emulation and then
+ * unset all three; every real `emulate sh`/`emulate ksh` sets them. A false
+ * positive costs exactly the fork this saves.
+ */
+export const ZSH_BOURNE_EMULATION_OPTION_HINT = '[[ -o ksharrays || -o shwordsplit || -o shglob ]]'
+
+/**
  * Hands the pane back to the user unwrapped when zsh has entered sh/ksh
  * emulation, and stops reading the rest of the current wrapper file.
  *
@@ -118,12 +139,14 @@ export { BASH_PROMPT_COMMAND_COMPOSITION_BLOCK } from './bash-prompt-command-com
  * anything that had already entered emulation (a system /etc/zshenv or
  * /etc/zprofile) would have hidden this very file too. The only thing that can
  * have entered emulation by this line is the user file this file just sourced.
+ *
+ * Why ZSH_BOURNE_EMULATION_OPTION_HINT gates it further: see that constant.
  */
 export function getZshEmulationDegradeBlock(options: {
   userZdotdirExpression: string
   sourcedUserFileTest: string
 }): string {
-  return `if [[ ${options.sourcedUserFileTest} ]]; then
+  return `if [[ ${options.sourcedUserFileTest} ]] && ${ZSH_BOURNE_EMULATION_OPTION_HINT}; then
   case "$(emulate 2>/dev/null)" in
     sh|ksh)
       export ZDOTDIR=${options.userZdotdirExpression}

--- a/src/main/zsh-scoped-histfile.live-shell.test.ts
+++ b/src/main/zsh-scoped-histfile.live-shell.test.ts
@@ -17,7 +17,7 @@
  * Orca would not wrap cannot pass here by construction.
  */
 import { execFileSync, spawnSync } from 'node:child_process'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
@@ -278,11 +278,11 @@ describe('worktree-scoped HISTFILE survives zsh startup', () => {
   })
 })
 
-describe('the wrapper survives a hostile user zsh config', () => {
-  const PROBE =
-    'echo "RESULT=$HISTFILE"; print -r -- "ZDOTDIR=[$ZDOTDIR]"; ' +
-    'print -r -- "ORCA_HISTFILE=[${ORCA_HISTFILE:-unset}]"'
+const PROBE =
+  'echo "RESULT=$HISTFILE"; print -r -- "ZDOTDIR=[$ZDOTDIR]"; ' +
+  'print -r -- "ORCA_HISTFILE=[${ORCA_HISTFILE:-unset}]"'
 
+describe('the wrapper survives a hostile user zsh config', () => {
   // Why both forms: `REPLY` is zsh's shared scratch global, and the two ways a
   // user config constrains it fail differently. `typeset -r` makes the
   // wrapper's first assignment fatal and prints into the pane; `typeset -i`
@@ -340,6 +340,65 @@ describe('the wrapper survives a hostile user zsh config', () => {
       // Nothing this pane spawns may inherit a history path no wrapper file
       // will ever consume.
       expect(wrapped).toContain('ORCA_HISTFILE=[unset]')
+    })
+  })
+})
+
+/**
+ * Records every argument-less `emulate` — i.e. exactly the wrapper's emulation
+ * probe, and not the epilogue's `emulate -L zsh` — into a file the test reads.
+ *
+ * Why a shadowing function and not a timing assertion: the cost being removed
+ * is a fork, and a fork is countable where milliseconds are flaky. Placed in
+ * the user .zshenv so it is defined before all three probe sites.
+ */
+function probeCounterConfig(logPath: string): string {
+  return [
+    'emulate() {',
+    `  (( $# == 0 )) && print -r -- probe >> ${JSON.stringify(logPath)}`,
+    '  builtin emulate "$@"',
+    '}'
+  ].join('\n')
+}
+
+const probeCount = (logPath: string): number =>
+  existsSync(logPath) ? readFileSync(logPath, 'utf8').split('\n').filter(Boolean).length : 0
+
+describe('the emulation probe forks only when it can change the answer', () => {
+  itWithZsh('never forks for a pane whose config stays in zsh emulation', () => {
+    withTempHome((home) => {
+      const scoped = join(home, 'orca-history', 'zsh_history')
+      const log = join(home, 'probe.log')
+      const { launch, env } = launchPlainHistoryPane(home, scoped)
+      // All three probe sites are gated on having sourced the matching user
+      // file, so every one of them has to exist for this to mean anything.
+      writeFileSync(join(home, '.zshenv'), probeCounterConfig(log))
+      writeFileSync(join(home, '.zprofile'), '')
+      writeFileSync(join(home, '.zshrc'), '')
+
+      const output = runZshCapturingStderr(launch.args ?? ['-l'], env, PROBE)
+
+      expect(probeCount(log)).toBe(0)
+      // The pane still has to work: the saving is a fork, not a feature.
+      expect(histfileOf(output)).toBe(scoped)
+      expect(output).toContain(`ZDOTDIR=[${home}]`)
+    })
+  })
+
+  // Why kept exact rather than replaced by the option test: those options say
+  // nothing about `emulation`, which is what zsh's sourcehome() branches on.
+  itWithZsh('still forks to get the exact answer once a Bourne option is set', () => {
+    withTempHome((home) => {
+      const scoped = join(home, 'orca-history', 'zsh_history')
+      const log = join(home, 'probe.log')
+      const { launch, env } = launchPlainHistoryPane(home, scoped)
+      writeFileSync(join(home, '.zshenv'), `${probeCounterConfig(log)}\nsetopt shwordsplit\n`)
+
+      const output = runZshCapturingStderr(launch.args ?? ['-l'], env, PROBE)
+
+      expect(probeCount(log)).toBeGreaterThan(0)
+      // shwordsplit alone is not emulation, so the pane stays wrapped.
+      expect(histfileOf(output)).toBe(scoped)
     })
   })
 })

--- a/src/main/zsh-startup-wrapper-builder.ts
+++ b/src/main/zsh-startup-wrapper-builder.ts
@@ -28,6 +28,7 @@ import {
   getZshShellReadyMarkerRegistrationBlock,
   getZshStartupFileSourceBlock,
   SHELL_STARTUP_IDENTITY_MARKER_BLOCK,
+  ZSH_BOURNE_EMULATION_OPTION_HINT,
   ZSH_FEATURE_CHANNEL_BLOCK,
   ZSH_HISTFILE_RESTORE_BLOCK,
   ZSH_INHERITED_CONFIG_DIR_RESOLVER_BLOCK,
@@ -216,8 +217,13 @@ const EPILOGUE_CALL = '(( ${+functions[__orca_shell_epilogue]} )) && __orca_shel
  * beats not running it at all. An older zsh whose `emulate` has no query form
  * prints nothing, fails the comparison, and runs it here too; the epilogue's
  * once-flag makes the later .zlogin call a no-op.
+ *
+ * Of the wrapper's three emulation probes this is the costliest — it forks a
+ * zsh that has just finished loading the user's whole .zshrc — so
+ * ZSH_BOURNE_EMULATION_OPTION_HINT skips it for any shell not in Bourne
+ * emulation. Braces because `A || B && C` groups as `(A || B) && C` in a shell.
  */
-const ZSHRC_EPILOGUE_INVOCATION = `if [[ ! -o login || "$(emulate 2>/dev/null)" != zsh ]]; then
+const ZSHRC_EPILOGUE_INVOCATION = `if [[ ! -o login ]] || { ${ZSH_BOURNE_EMULATION_OPTION_HINT} && [[ "$(emulate 2>/dev/null)" != zsh ]]; }; then
   ${EPILOGUE_CALL}
 fi`
 

--- a/src/relay/pty-handler-revive.test.ts
+++ b/src/relay/pty-handler-revive.test.ts
@@ -567,6 +567,64 @@ describe('PtyHandler', () => {
       })
     })
 
+    // Why: this field is replayed from state the relay hands a client and takes
+    // back unvalidated, and it lands in argv.
+    it('drops an over-long distro name rather than passing it to wsl.exe', async () => {
+      const state = JSON.stringify([
+        {
+          id: 'pty-11',
+          pid: process.pid,
+          cols: 80,
+          rows: 24,
+          cwd: 'C:\\repo',
+          shellOverride: 'wsl.exe',
+          terminalWindowsWslDistro: 'U'.repeat(257)
+        }
+      ])
+      const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+      try {
+        await dispatcher.callRequest('pty.revive', { state })
+      } finally {
+        killSpy.mockRestore()
+      }
+
+      const [shell, args] = mockPtySpawn.mock.calls[0] as [string, string[]]
+      expect(shell).toBe('wsl.exe')
+      expect(args).toEqual([])
+    })
+
+    // Why: the override's whole point is that the pane keeps its own shell, so a
+    // shell that no longer exists must cost that pane and nothing else.
+    it('skips a pane whose overridden shell can no longer spawn, keeping the batch', async () => {
+      const state = JSON.stringify([
+        {
+          id: 'pty-12',
+          pid: process.pid,
+          cols: 80,
+          rows: 24,
+          cwd: 'C:\\repo',
+          shellOverride: 'wsl.exe'
+        },
+        { id: 'pty-13', pid: process.pid, cols: 80, rows: 24, cwd: 'C:\\repo' }
+      ])
+      mockPtySpawn.mockImplementationOnce(() => {
+        throw new Error('spawn wsl.exe ENOENT')
+      })
+      const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+      try {
+        await dispatcher.callRequest('pty.revive', { state })
+      } finally {
+        killSpy.mockRestore()
+      }
+
+      // The second entry still revived, and no other shell stood in for the first.
+      expect(mockPtySpawn).toHaveBeenCalledTimes(2)
+      const live = (await dispatcher.callRequest('pty.serialize', {
+        ids: ['pty-12', 'pty-13']
+      })) as string
+      expect(JSON.parse(live).map((entry: { id: string }) => entry.id)).toEqual(['pty-13'])
+    })
+
     it('degrades one entry with an unsupported override without failing the batch', async () => {
       const state = JSON.stringify([
         {

--- a/src/relay/pty-handler-revive.test.ts
+++ b/src/relay/pty-handler-revive.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { existsSync, rmSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { hashWorktreeId } from '../main/terminal-history-id'
 
 const { mockPtySpawn, mockPtyInstance, mockCreateShellPromptReadinessProbe } = vi.hoisted(() => ({
   mockPtySpawn: vi.fn(),
@@ -479,5 +483,111 @@ describe('PtyHandler', () => {
         expectedTabId: 'tab-other'
       })
     ).rejects.toThrow('PTY "pty-1" not found')
+  })
+
+  describe('a Windows relay reviving a WSL pane', () => {
+    const worktreeId = 'r::/remote/wsl-worktree'
+    const historyFile = join(
+      homedir(),
+      '.orca-remote',
+      'terminal-history',
+      `${hashWorktreeId(worktreeId)}-bash_history`
+    )
+    let previousPlatform: PropertyDescriptor | undefined
+
+    beforeEach(() => {
+      previousPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    })
+
+    afterEach(() => {
+      if (previousPlatform) {
+        Object.defineProperty(process, 'platform', previousPlatform)
+      }
+      rmSync(historyFile, { force: true })
+    })
+
+    /** Spawn a WSL pane, serialize it, then revive it into a fresh handler. */
+    async function reviveWslPane(): Promise<void> {
+      await dispatcher.callRequest('pty.spawn', {
+        cols: 80,
+        rows: 24,
+        shellOverride: 'wsl.exe',
+        terminalWindowsWslDistro: 'Ubuntu',
+        worktreeId,
+        historyIsolationEnabled: true
+      })
+      const state = (await dispatcher.callRequest('pty.serialize', { ids: ['pty-1'] })) as string
+
+      await handler.dispose({ waitForPhysicalExit: false })
+      mockPtySpawn.mockClear()
+      rmSync(historyFile, { force: true })
+      dispatcher = createMockDispatcher()
+      handler = new PtyHandler(dispatcher as unknown as RelayDispatcher)
+
+      const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+      try {
+        await dispatcher.callRequest('pty.revive', { state })
+      } finally {
+        killSpy.mockRestore()
+      }
+    }
+
+    // The #15236 gap: revive called resolveDefaultShell() and ignored the
+    // entry's override, so a restarted relay silently handed the user a
+    // PowerShell pane where a WSL one had been.
+    it('relaunches wsl.exe in the pane\u2019s own distro instead of the host default shell', async () => {
+      await reviveWslPane()
+
+      const [shell, args] = mockPtySpawn.mock.calls[0] as [string, string[]]
+      expect(shell).toBe('wsl.exe')
+      expect(args).toEqual(['-d', 'Ubuntu'])
+    })
+
+    it('scopes HISTFILE past the wsl.exe wrapper and carries it over WSLENV', async () => {
+      await reviveWslPane()
+
+      const spawnEnv = mockPtySpawn.mock.calls[0][2]?.env as Record<string, string>
+      expect(spawnEnv.HISTFILE?.endsWith(`${hashWorktreeId(worktreeId)}-bash_history`)).toBe(true)
+      expect(spawnEnv.WSLENV?.split(':')).toContain('HISTFILE')
+      // Deletion is unchanged because the file still lives on the relay host.
+      expect(existsSync(historyFile)).toBe(true)
+    })
+
+    // Why: a revived pane is serialized again on the next restart, so dropping
+    // the override there is the same defect one reconnect later.
+    it('keeps the override across a second serialize/revive round trip', async () => {
+      await reviveWslPane()
+
+      const state = (await dispatcher.callRequest('pty.serialize', { ids: ['pty-1'] })) as string
+
+      expect(JSON.parse(state)[0]).toMatchObject({
+        shellOverride: 'wsl.exe',
+        terminalWindowsWslDistro: 'Ubuntu'
+      })
+    })
+
+    it('degrades one entry with an unsupported override without failing the batch', async () => {
+      const state = JSON.stringify([
+        {
+          id: 'pty-9',
+          pid: process.pid,
+          cols: 80,
+          rows: 24,
+          cwd: 'C:\\repo',
+          shellOverride: 'nc.exe'
+        },
+        { id: 'pty-10', pid: process.pid, cols: 80, rows: 24, cwd: 'C:\\repo' }
+      ])
+      const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+      try {
+        await dispatcher.callRequest('pty.revive', { state })
+      } finally {
+        killSpy.mockRestore()
+      }
+
+      expect(mockPtySpawn).toHaveBeenCalledTimes(2)
+      expect(mockPtySpawn.mock.calls.map(([shell]) => shell)).not.toContain('nc.exe')
+    })
   })
 })

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -164,6 +164,10 @@ type ManagedPty = {
   terminalHandle?: string
   explicitTerm?: string
   shellPath?: string
+  /** The raw client-requested shell override, kept so revive can re-resolve it on this host. */
+  shellOverride?: string
+  /** Requested WSL distro; only meaningful when the override launched wsl.exe. */
+  wslDistro?: string
   shellCwd?: string
   shellPathEnv?: string
   envToDelete: string[]
@@ -313,6 +317,19 @@ function resolvePtyShellOverride(shellOverride: string): string {
   return resolveWindowsGitBashShellPath(shellOverride) ?? shellOverride
 }
 
+/**
+ * Same bounds as a fresh spawn, but one unusable entry may not fail the whole
+ * revive batch — an override this host no longer allows degrades that single
+ * pane to the default shell instead of throwing away every other pane's state.
+ */
+function resolveRevivedShellOverride(shellOverride: string): string {
+  try {
+    return resolvePtyShellOverride(shellOverride)
+  } catch {
+    return ''
+  }
+}
+
 type PtyProcessSummary = {
   id: string
   incarnationId: string
@@ -340,6 +357,13 @@ type SerializedPtyEntry = {
   gitCredentialPromptGuarded?: boolean
   /** Optional for state serialized by relays predating scoped history. */
   historyIsolationEnabled?: boolean
+  /**
+   * The shell override this pane was spawned with, re-resolved (and re-bounded)
+   * on revive. Optional: state from a relay predating it revives the host
+   * default shell, which is what those relays did anyway.
+   */
+  shellOverride?: string
+  terminalWindowsWslDistro?: string
   agentSessionOwners?: AgentSessionOwnerBinding[]
 }
 
@@ -1666,6 +1690,10 @@ export class PtyHandler {
       gitCredentialPromptGuarded,
       ...(historyIsolationEnabled ? { historyIsolationEnabled: true } : {}),
       shellPath: shell,
+      // Why the resolved one gates it: on a POSIX relay an override is rejected
+      // outright, and storing one revive would only reject again is noise.
+      ...(resolvedShellOverride ? { shellOverride } : {}),
+      ...(terminalWindowsWslDistro ? { wslDistro: terminalWindowsWslDistro } : {}),
       shellCwd: cwd,
       shellPathEnv: spawnEnv.PATH,
       ownerBackend: resolvePtyOwnerBackend({
@@ -2103,6 +2131,10 @@ export class PtyHandler {
         envToDelete: managed.envToDelete,
         gitCredentialPromptGuarded: managed.gitCredentialPromptGuarded,
         ...(managed.historyIsolationEnabled ? { historyIsolationEnabled: true } : {}),
+        // Why serialized: revive re-spawns the shell, and without these a WSL
+        // pane came back as the host default shell in another distro's history.
+        ...(managed.shellOverride ? { shellOverride: managed.shellOverride } : {}),
+        ...(managed.wslDistro ? { terminalWindowsWslDistro: managed.wslDistro } : {}),
         ...(managed.terminalHandle ? { terminalHandle: managed.terminalHandle } : {})
       })
     }
@@ -2165,7 +2197,11 @@ export class PtyHandler {
     }
     // Why: serialized state may come from an older/untrusted client; reapply fresh-spawn bounds.
     const envToDelete = sanitizeEnvToDelete(entry.envToDelete)
-    const shell = resolveDefaultShell()
+    const shellOverride = typeof entry.shellOverride === 'string' ? entry.shellOverride.trim() : ''
+    const resolvedShellOverride = resolveRevivedShellOverride(shellOverride)
+    const shell = resolvedShellOverride || resolveDefaultShell()
+    const terminalWindowsWslDistro =
+      typeof entry.terminalWindowsWslDistro === 'string' ? entry.terminalWindowsWslDistro : null
     const historyIsolationEnabled = entry.historyIsolationEnabled === true
     const spawnEnv = this.buildSpawnEnv(
       revivedEnv,
@@ -2179,17 +2215,25 @@ export class PtyHandler {
     ) {
       injectRelayFishHistoryEnv(spawnEnv, entry.worktreeId)
     }
-    // No WSL branch on purpose: revive re-spawns the host default shell rather
-    // than the entry's stored override, so this env matches the shell it launches.
+    // Mirrors spawn: the entry's override is what gets re-launched, so a WSL
+    // pane needs the same guest-visible HISTFILE and the same WSLENV carrier.
+    const wslShell = isRelayWslShell(shell)
     if (historyIsolationEnabled && entry.worktreeId) {
-      injectRelayHistoryEnv(spawnEnv, entry.worktreeId, shell)
+      const historyRoot = injectRelayHistoryEnv(spawnEnv, entry.worktreeId, shell, {
+        wsl: wslShell
+      })
+      if (wslShell && historyRoot) {
+        addWslEnvKeys(spawnEnv, ['HISTFILE'])
+      }
     }
     // Why: revive lacks the original launch command, so reuse the fresh-spawn guard decision (legacy defaults to unguarded).
     const gitCredentialPromptGuarded = entry.gitCredentialPromptGuarded === true
     if (gitCredentialPromptGuarded) {
       Object.assign(spawnEnv, gitCredentialPromptGuardEnv(spawnEnv, process.platform))
     }
-    const shellLaunch = getRelayShellLaunchConfig(shell, spawnEnv)
+    const shellLaunch = getRelayShellLaunchConfig(shell, spawnEnv, process.platform, {
+      terminalWindowsWslDistro
+    })
     const term = ptyMod.spawn(shell, shellLaunch.args, {
       name: spawnEnv.TERM ?? 'xterm-256color',
       cols: entry.cols,
@@ -2219,9 +2263,15 @@ export class PtyHandler {
       envToDelete,
       gitCredentialPromptGuarded,
       ...(historyIsolationEnabled ? { historyIsolationEnabled: true } : {}),
+      shellPath: shell,
+      // Why re-stored: a revived pane can be serialized again, and losing the
+      // override on the second round trip is the same bug one restart later.
+      ...(resolvedShellOverride ? { shellOverride } : {}),
+      ...(terminalWindowsWslDistro ? { wslDistro: terminalWindowsWslDistro } : {}),
       ownerBackend: resolvePtyOwnerBackend({
         platform: process.platform,
-        shellPath: shell
+        shellPath: shell,
+        wslDistro: terminalWindowsWslDistro
       }),
       ...(entry.terminalHandle ? { terminalHandle: entry.terminalHandle } : {})
     })

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -318,6 +318,18 @@ function resolvePtyShellOverride(shellOverride: string): string {
 }
 
 /**
+ * Longest WSL distro name revive will carry into `wsl.exe -d <name>`.
+ *
+ * Why bounded here and not at spawn: spawn's value is a live RPC parameter,
+ * while this one is replayed from state the relay hands a client and takes back
+ * unvalidated. It reaches an argv, not a shell, so an over-long name costs a
+ * failed spawn rather than anything worse -- but revive's whole job here is to
+ * re-apply fresh-spawn bounds, and an unbounded value had no business in it.
+ * Real distro names are registry keys, far below this.
+ */
+const MAX_REVIVED_WSL_DISTRO_LENGTH = 256
+
+/**
  * Same bounds as a fresh spawn, but one unusable entry may not fail the whole
  * revive batch — an override this host no longer allows degrades that single
  * pane to the default shell instead of throwing away every other pane's state.
@@ -2201,7 +2213,10 @@ export class PtyHandler {
     const resolvedShellOverride = resolveRevivedShellOverride(shellOverride)
     const shell = resolvedShellOverride || resolveDefaultShell()
     const terminalWindowsWslDistro =
-      typeof entry.terminalWindowsWslDistro === 'string' ? entry.terminalWindowsWslDistro : null
+      typeof entry.terminalWindowsWslDistro === 'string' &&
+      entry.terminalWindowsWslDistro.length <= MAX_REVIVED_WSL_DISTRO_LENGTH
+        ? entry.terminalWindowsWslDistro
+        : null
     const historyIsolationEnabled = entry.historyIsolationEnabled === true
     const spawnEnv = this.buildSpawnEnv(
       revivedEnv,
@@ -2234,18 +2249,34 @@ export class PtyHandler {
     const shellLaunch = getRelayShellLaunchConfig(shell, spawnEnv, process.platform, {
       terminalWindowsWslDistro
     })
-    const term = ptyMod.spawn(shell, shellLaunch.args, {
-      name: spawnEnv.TERM ?? 'xterm-256color',
-      cols: entry.cols,
-      rows: entry.rows,
-      cwd: entry.cwd,
-      // Why: no provider-delivered command is waiting for a ready marker.
-      env: {
-        ...spawnEnv,
-        [SHELL_STARTUP_FEATURE_ENV]: '',
-        ...shellLaunch.env
+    let term: IPty
+    try {
+      term = ptyMod.spawn(shell, shellLaunch.args, {
+        name: spawnEnv.TERM ?? 'xterm-256color',
+        cols: entry.cols,
+        rows: entry.rows,
+        cwd: entry.cwd,
+        // Why: no provider-delivered command is waiting for a ready marker.
+        env: {
+          ...spawnEnv,
+          [SHELL_STARTUP_FEATURE_ENV]: '',
+          ...shellLaunch.env
+        }
+      })
+    } catch (error) {
+      // Why skip rather than retry the host default shell: the stored override
+      // names a shell that existed at serialize time and may not now (an
+      // uninstalled WSL takes wsl.exe with it), and substituting a different
+      // shell is the defect this override exists to fix -- its args and its
+      // history env are built for the shell that is gone. Dropping one pane is
+      // the honest outcome; letting the throw escape the revive loop would cost
+      // every later entry its state too. The worktree-removal fence throws
+      // before this, outside reviveEntry, so it stays a hard failure.
+      if (!resolvedShellOverride) {
+        throw error
       }
-    })
+      return
+    }
     this.wireAndStore({
       id: entry.id,
       incarnationId: randomUUID(),


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​253 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​16 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​237 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​135 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​19 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​116 |

<!-- /orca-pr-loc -->

## ELI5

Two leftovers from the history-isolation work.

**One.** On a Windows remote host, opening a WSL terminal gets you that worktree's own shell history. Restart the relay and the pane comes back — but as PowerShell, not WSL, with the wrong history. Revive was re-launching the machine's default shell instead of the shell the pane was actually running. Now it remembers.

**Two.** Orca's zsh wrapper asks the shell "are you pretending to be `sh`?" three times during startup. Asking costs a fork of a zsh that already has your whole config loaded — the most expensive thing the wrapper does, and since wrapping widened to every zsh pane, every pane pays it. There's a way to rule the answer out for free, so now Orca only asks when the free check can't settle it.

## What Changed

**Relay revive keeps the pane's shell (`src/relay/pty-handler.ts`)**

- `SerializedPtyEntry` gains optional `shellOverride` and `terminalWindowsWslDistro`; `ManagedPty` gains the fields behind them, and `serialize()` emits them.
- `reviveEntry()` re-resolves the stored override through `resolvePtyShellOverride` — the *same* allowlist a fresh spawn applies, because revive state is untrusted — and falls back to `resolveDefaultShell()` when there is none.
- The WSL history branch that spawn got in #15236 is now mirrored on revive: guest-visible `/mnt/<drive>/…` `HISTFILE` plus `HISTFILE` on `WSLENV`. The distro reaches `getRelayShellLaunchConfig` and `resolvePtyOwnerBackend`, and the revived `ManagedPty` re-stores the fields so the *second* serialize/revive round trip does not lose them.
- `resolveRevivedShellOverride` swallows the rejection rather than rethrowing: `revive` loops over entries, so one stale override must not throw away every other pane's state.

**The emulation probe stops forking (`src/main/shell-templates.ts`, `src/main/zsh-startup-wrapper-builder.ts`)**

- New `ZSH_BOURNE_EMULATION_OPTION_HINT` — `[[ -o ksharrays || -o shwordsplit || -o shglob ]] 2>/dev/null` — in front of all three `$(emulate 2>/dev/null)` sites: the two degrade blocks (`.zshenv`, `.zprofile`) and the `.zshrc` epilogue invocation.
- Nine generated lines change across all three transports (local, daemon, relay). Nothing else in any wrapper file moves.

**Hardening from the readiness review (second commit)**

- `2>/dev/null` on the option test. `[[ -o <unknown> ]]` prints `no such option` to **stderr** and returns false rather than aborting, so a zsh lacking one of these names would put that text in the user's pane. All three predate every supported zsh; the suppression costs nothing and deletes the class.
- `terminalWindowsWslDistro` is length-bounded on the revive read. It is the one field this PR newly routes from replayed, unvalidated state into an argv, and `reviveEntry`'s stated job is re-applying fresh-spawn bounds.
- A pane whose overridden shell can no longer spawn is **skipped** rather than allowed to throw out of the revive loop and cost every later entry its state. Skipped, not fallen back to the host default shell: substituting a shell is the defect the override exists to fix, and both the args (`-d <distro>`) and the history env (`/mnt/<drive>/…`) are built for the shell that is gone. The worktree-removal fence throws *before* this, outside `reviveEntry`, so it stays a hard failure.

## Why

STA-4682's two continuous-readiness residuals — the ones the ticket's last comment says to reuse this tracker for.

**Revive.** #15236 scoped WSL history on spawn and said so explicitly in its own "Not covered" section: *"A revived 'WSL pane' is not running WSL at all today — that is a separate, larger bug (it would need the shell override serialized into the revive state)."* That is this. The user-visible defect is bigger than history: the pane silently changes shell class on a relay restart. Serializing the override fixes the shell, and fixing the shell is what makes the history injection correct — the env now matches the shell that actually launches, which is the property the old code preserved by *not* injecting.

**The probe.** #15258's own blast-radius section priced the change: *"those panes now source four small generated files and run one function. A login zsh additionally forks once for `$(emulate)` … and once more per user `.zshenv`/`.zprofile` that actually exists."* That was an acceptable price for a few percent of panes and a worse one for all of them. `$( )` forks the *current* zsh, so the `.zshrc` probe — which runs after the user's whole `.zshrc` has loaded — is the most expensive line in the wrapper.

**Why a hint in front of the exact probe rather than replacing it.** `emulate sh` and `emulate ksh` both turn on `KSH_ARRAYS`, `SH_WORD_SPLIT` and `SH_GLOB`, so all-three-off rules emulation out for free. But those options say nothing about `emulation`, which is what zsh's `sourcehome()` actually branches on — a config that sets one by hand is not in emulation and must still get the real answer. So the hint only ever *skips* the fork, never answers in its place. It is `||`, not `&&`: the only way past it is to enter emulation and then unset all three. A false positive costs exactly the fork this saves.

## Linked Issue

STA-4682 — https://linear.app/stably/issue/STA-4682

Fixes #

## Visual Proof

`N/A` — no UI surface. Shell environment plumbing on the relay host and generated shell startup files.

## Testing

**Automated** — `src/relay/pty-handler-revive.test.ts` (4 new, win32-simulated): revive relaunches `wsl.exe` with `['-d','Ubuntu']` instead of the default shell; `HISTFILE` is worktree-scoped and `WSLENV` carries it; the override survives a second serialize round trip; one entry with a rejected override degrades without failing the batch. **Three of the four fail on `main`**; the fourth is a regression guard.

`src/main/zsh-scoped-histfile.live-shell.test.ts` (2 new, real zsh): a user `.zshenv` shadows `emulate` with a function that logs every arg-less call — the wrapper's probe, and not the epilogue's `emulate -L zsh`. An ordinary pane records **zero** probes and still ends with the scoped `HISTFILE`; a pane whose config runs `setopt shwordsplit` records **more than zero**, proving the exact probe still runs when the hint can't rule emulation out. The first **fails on `main`** (3 probes).

The pre-existing degrade matrix (`emulate sh`/`emulate ksh` from `.zshenv`, `emulate sh` from `.zprofile`, `emulate sh` from `.zshrc`) is the net for false negatives and is unchanged and green.

**Measured, zsh 5.9 / macOS**, 150 login startups per arm against the real generated wrapper files, with a user `.zshenv` + `.zprofile` + `.zshrc` present:

| | ms/run |
| :--- | ---: |
| unwrapped | 9.97 |
| wrapped, before | 14.20 |
| wrapped, after | 12.27 |

Re-measured through a **pty** — what a pane actually is — median of 25 x 3 rounds, because `$( )` forks the current shell and a pty-attached zsh is a heavier thing to fork: **13.2 unwrapped, 16.1 before, 14.6 after.** Same shape, on the arm panes actually run in.

**Manual, real Windows + WSL** (`awin`, over the Orca remote server; distros `Ubuntu-24.04`, `Sta4593-Federated`). Reproduced the exact env the revive path now emits — `HISTFILE=/mnt/c/Users/neil/.orca-remote/terminal-history/<name>` with `WSLENV=HISTFILE`, launched as `wsl.exe -d Ubuntu-24.04 --exec bash -lc …`:

- guest sees `GUEST_HISTFILE=[/mnt/c/Users/neil/.orca-remote/terminal-history/…]`
- guest reads the host-created file (`READ_OK`) and appends to it (`APPEND_OK`)
- the Windows side then reads back both lines — same file, so the existing host-side unlink remains the working deletion counterpart for a revived pane exactly as for a spawned one

A separate assertion pins `toLinuxPath('C:\Users\neil\.orca-remote\…')` to the byte-identical path proved above, so what the code generates is what was tested on the host.

Two more revive tests cover the hardening: an over-long distro name is dropped rather than passed to `wsl.exe`, and a pane whose shell fails to spawn is skipped while the rest of the batch revives. Both **fail without their guard**. The seven-case real-zsh behavior matrix (`emulate sh`/`ksh` from `.zshenv`, `.zprofile`, `.zshrc`, plus `setopt shwordsplit` and `setopt ksharrays` as false-positive probes) was re-run against the generated wrappers and is **byte-identical to `main`** on every row.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Commands: `npx tsc --noEmit -p config/tsconfig.node.json`, `npx oxlint`, `npx oxfmt --check`, and `npx vitest run src/main src/relay src/shared` — **30,066 passed, 0 failed, 180 skipped**.

One sweep also tripped `updater.startup-scheduling` and an 800-case fuzz in `terminal-output-frame-chunks-equivalence`; both pass 30/30 twice in isolation and neither is touched here.

Not tested: a live relay restart on a Windows host with an open WSL pane. That needs a Windows relay reached over SSH from a second machine, and the revive path is unit-tested with a simulated platform instead.

## AI Disclosure

Claude Opus.

## Review

### Remote wire compatibility

`shellOverride` and `terminalWindowsWslDistro` are **new optional fields on an existing JSON payload** — Rule 1 of `docs/reference/remote-wire-compatibility.md`. No opcode, no RPC signature change, no `RUNTIME_PROTOCOL_VERSION` bump.

The reader treats both as optional and falls back to today's behavior, which is what Rule 1 requires: state serialized by a relay that predates the fields revives `resolveDefaultShell()`, exactly as every relay does on `main`. State written by a new relay and handed to an older one has the extra keys stripped, with the same result. Neither side ever *requires* the field.

`ORCA_SHELL_FEATURES` and the wrapper files never cross the wire at all — the wrapper is regenerated on launch by whichever host runs the shell.

### Cross-platform

- The revive change is inert off win32: `resolvePtyShellOverride` returns `''` for any non-win32 platform, so a POSIX relay revives the default shell as before. `isRelayWslShell` is already gated on win32.
- The wrapper change is zsh-only and platform-independent; bash and fish generation is untouched, and the bash rcfile has no `$(emulate)`.
- Windows/PowerShell panes are unaffected.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

### Follow-up filed

A prototype showed the wrapper can collapse from four generated files to a single `.zshenv` that hands `ZDOTDIR` back immediately and defers Orca's work to a `precmd` hook, taking the residual overhead to +0.2 ms and making the `/etc/zshrc` HISTFILE clobber structurally unreachable rather than something to repair. That is a large change to the highest-blast-radius path here and needs the live-shell suite ported to a pty harness first, so it is STA-4786, not this PR.

## Notes

- **Security** — the revived shell is not taken on trust: it goes through the same `ALLOWED_WINDOWS_SHELL_OVERRIDES` gate as a fresh spawn, and the raw client token is stored rather than the resolved path, so Git Bash is re-resolved against *this* host instead of replaying a path a client supplied. The history file is created with the unchanged `O_NOFOLLOW`/`lstat`/`fstat` checks; only the exported string differs for WSL.
- **Backwards compatibility** — a wrapper dir written by an older build keeps working; the hint is a pure addition to three `if` conditions and every other generated byte is identical (snapshot-proven across all three transports).
- **Degradation** — a user who sets one of the three Bourne options by hand pays exactly the fork they pay today and gets the identical answer; there is no behavior difference, only a cost difference.
- **Performance** — the revive path adds one regex and one env write for WSL panes only. The wrapper change removes up to three forks per zsh pane and adds up to three `[[ -o … ]]` tests.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

