### PR TITLE
fix(cli): route --host runtime:<id> to that server instead of answering locally

### DIFF
--- a/src/cli/execution-host-flag.test.ts
+++ b/src/cli/execution-host-flag.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const { listEnvironmentsMock, resolveEnvironmentMock, getDefaultUserDataPathMock } = vi.hoisted(
+  () => ({
+    listEnvironmentsMock: vi.fn(),
+    resolveEnvironmentMock: vi.fn(),
+    getDefaultUserDataPathMock: vi.fn(() => '/tmp/orca-user-data')
+  })
+)
+
+vi.mock('./runtime/environments', () => ({
+  addEnvironmentFromPairingCode: vi.fn(),
+  listEnvironments: listEnvironmentsMock,
+  removeEnvironment: vi.fn(),
+  resolveEnvironment: resolveEnvironmentMock
+}))
+
+vi.mock('./runtime-client', () => ({
+  getDefaultUserDataPath: getDefaultUserDataPathMock
+}))
+
+import {
+  hostFilterMatchesHostId,
+  parseHostFlag,
+  resolveHostFlagEnvironmentId
+} from './execution-host-flag'
+import { parseExecutionHostId } from '../shared/execution-host'
+
+const NO_SELECTION = { pairingCode: null, environmentSelector: null }
+
+function flags(entries: Record<string, string | boolean>): Map<string, string | boolean> {
+  return new Map(Object.entries(entries))
+}
+
+function environment(id: string, name = id) {
+  return { id, name }
+}
+
+describe('parseHostFlag', () => {
+  it('returns undefined when --host is absent', () => {
+    expect(parseHostFlag(flags({}))).toBeUndefined()
+  })
+
+  it('rejects a --host flag with no value', () => {
+    expect(() => parseHostFlag(flags({ host: true }))).toThrow('Missing value for --host')
+  })
+
+  it.each(['runtime:', 'ssh:', 'nonsense'])('rejects the unparseable host id %s', (value) => {
+    expect(() => parseHostFlag(flags({ host: value }))).toThrow(`Invalid --host value: ${value}`)
+  })
+
+  it('parses the three supported host kinds', () => {
+    expect(parseHostFlag(flags({ host: 'local' }))?.kind).toBe('local')
+    expect(parseHostFlag(flags({ host: 'ssh:box-1' }))?.kind).toBe('ssh')
+    expect(parseHostFlag(flags({ host: 'runtime:env-1' }))).toEqual({
+      kind: 'runtime',
+      id: 'runtime:env-1',
+      environmentId: 'env-1'
+    })
+  })
+})
+
+describe('resolveHostFlagEnvironmentId', () => {
+  it('keeps the current connection for local and ssh hosts', async () => {
+    await expect(
+      resolveHostFlagEnvironmentId(flags({ host: 'local' }), NO_SELECTION)
+    ).resolves.toBe(null)
+    await expect(
+      resolveHostFlagEnvironmentId(flags({ host: 'ssh:box-1' }), NO_SELECTION)
+    ).resolves.toBe(null)
+    expect(listEnvironmentsMock).not.toHaveBeenCalled()
+  })
+
+  it('routes a paired runtime host to that environment', async () => {
+    listEnvironmentsMock.mockReturnValue([environment('env-1', 'gpu')])
+
+    await expect(
+      resolveHostFlagEnvironmentId(flags({ host: 'runtime:env-1' }), NO_SELECTION)
+    ).resolves.toBe('env-1')
+  })
+
+  it('rejects a runtime host id that no paired environment owns', async () => {
+    listEnvironmentsMock.mockReturnValue([environment('env-1', 'gpu')])
+
+    await expect(
+      resolveHostFlagEnvironmentId(flags({ host: 'runtime:env-missing' }), NO_SELECTION)
+    ).rejects.toThrow('no paired environment has id env-missing')
+  })
+
+  it('matches by environment id only, never by environment name', async () => {
+    listEnvironmentsMock.mockReturnValue([environment('env-1', 'gpu')])
+
+    await expect(
+      resolveHostFlagEnvironmentId(flags({ host: 'runtime:gpu' }), NO_SELECTION)
+    ).rejects.toThrow('no paired environment has id gpu')
+  })
+
+  it('decodes percent-encoded environment ids', async () => {
+    listEnvironmentsMock.mockReturnValue([environment('env one')])
+
+    await expect(
+      resolveHostFlagEnvironmentId(flags({ host: 'runtime:env%20one' }), NO_SELECTION)
+    ).resolves.toBe('env one')
+  })
+
+  it('refuses a runtime host alongside --pairing-code', async () => {
+    listEnvironmentsMock.mockReturnValue([environment('env-1')])
+
+    await expect(
+      resolveHostFlagEnvironmentId(flags({ host: 'runtime:env-1' }), {
+        pairingCode: 'orca://pair?x',
+        environmentSelector: null
+      })
+    ).rejects.toThrow('not both')
+  })
+
+  it('refuses a runtime host that disagrees with --environment', async () => {
+    listEnvironmentsMock.mockReturnValue([environment('env-1')])
+    resolveEnvironmentMock.mockReturnValue(environment('env-2'))
+
+    await expect(
+      resolveHostFlagEnvironmentId(flags({ host: 'runtime:env-1' }), {
+        pairingCode: null,
+        environmentSelector: 'other'
+      })
+    ).rejects.toThrow('name different Orca servers')
+  })
+
+  it('accepts --environment naming the same server as the runtime host', async () => {
+    listEnvironmentsMock.mockReturnValue([environment('env-1', 'gpu')])
+    resolveEnvironmentMock.mockReturnValue(environment('env-1', 'gpu'))
+
+    await expect(
+      resolveHostFlagEnvironmentId(flags({ host: 'runtime:env-1' }), {
+        pairingCode: null,
+        environmentSelector: 'gpu'
+      })
+    ).resolves.toBe('env-1')
+  })
+})
+
+describe('hostFilterMatchesHostId', () => {
+  const runtimeHost = parseExecutionHostId('runtime:env-1')!
+  const localHost = parseExecutionHostId('local')!
+  const sshHost = parseExecutionHostId('ssh:box-1')!
+
+  it('matches the identical host id', () => {
+    expect(hostFilterMatchesHostId(runtimeHost, 'runtime:env-1')).toBe(true)
+    expect(hostFilterMatchesHostId(localHost, 'local')).toBe(true)
+    expect(hostFilterMatchesHostId(sshHost, 'ssh:box-1')).toBe(true)
+  })
+
+  it('treats the routed runtime own local rows as that runtime', () => {
+    expect(hostFilterMatchesHostId(runtimeHost, 'local')).toBe(true)
+  })
+
+  it('does not widen local or ssh filters', () => {
+    expect(hostFilterMatchesHostId(localHost, 'runtime:env-1')).toBe(false)
+    expect(hostFilterMatchesHostId(sshHost, 'local')).toBe(false)
+  })
+
+  it('does not match a different runtime host', () => {
+    expect(hostFilterMatchesHostId(runtimeHost, 'runtime:env-2')).toBe(false)
+    expect(hostFilterMatchesHostId(runtimeHost, null)).toBe(false)
+  })
+})

--- a/src/cli/execution-host-flag.test.ts
+++ b/src/cli/execution-host-flag.test.ts
@@ -121,9 +121,32 @@ describe('resolveHostFlagEnvironmentId', () => {
     await expect(
       resolveHostFlagEnvironmentId(flags({ host: 'runtime:env-1' }), {
         pairingCode: null,
-        environmentSelector: 'other'
+        environmentSelector: { value: 'other', label: '--environment' }
       })
     ).rejects.toThrow('name different Orca servers')
+  })
+
+  it('names the ambient variable when ORCA_ENVIRONMENT is the conflicting selector', async () => {
+    listEnvironmentsMock.mockReturnValue([environment('env-1')])
+    resolveEnvironmentMock.mockReturnValue(environment('env-2'))
+
+    await expect(
+      resolveHostFlagEnvironmentId(flags({ host: 'runtime:env-1' }), {
+        pairingCode: null,
+        environmentSelector: { value: 'staging', label: 'ORCA_ENVIRONMENT' }
+      })
+    ).rejects.toThrow('ORCA_ENVIRONMENT staging name different Orca servers')
+  })
+
+  it('hands an agent the known environment ids to retry with', async () => {
+    listEnvironmentsMock.mockReturnValue([environment('env-1', 'gpu')])
+
+    await expect(
+      resolveHostFlagEnvironmentId(flags({ host: 'runtime:gpu' }), NO_SELECTION)
+    ).rejects.toMatchObject({
+      code: 'invalid_argument',
+      data: { knownEnvironments: [{ id: 'env-1', name: 'gpu' }] }
+    })
   })
 
   it('accepts --environment naming the same server as the runtime host', async () => {
@@ -133,7 +156,7 @@ describe('resolveHostFlagEnvironmentId', () => {
     await expect(
       resolveHostFlagEnvironmentId(flags({ host: 'runtime:env-1' }), {
         pairingCode: null,
-        environmentSelector: 'gpu'
+        environmentSelector: { value: 'gpu', label: '--environment' }
       })
     ).resolves.toBe('env-1')
   })

--- a/src/cli/execution-host-flag.ts
+++ b/src/cli/execution-host-flag.ts
@@ -1,0 +1,90 @@
+import {
+  LOCAL_EXECUTION_HOST_ID,
+  normalizeExecutionHostId,
+  parseExecutionHostId,
+  type ParsedExecutionHost
+} from '../shared/execution-host'
+import { RuntimeClientError } from './runtime/types'
+
+export type HostFlagRoutingSelection = {
+  pairingCode: string | null
+  environmentSelector: string | null
+}
+
+export function parseHostFlag(
+  flags: Map<string, string | boolean>
+): ParsedExecutionHost | undefined {
+  if (!flags.has('host')) {
+    return undefined
+  }
+  const raw = flags.get('host')
+  if (typeof raw !== 'string' || raw.length === 0) {
+    throw new RuntimeClientError('invalid_argument', 'Missing value for --host')
+  }
+  const parsed = parseExecutionHostId(raw)
+  if (!parsed) {
+    throw new RuntimeClientError(
+      'invalid_argument',
+      `Invalid --host value: ${raw}. Expected local, ssh:<target-id>, or runtime:<environment-id>.`
+    )
+  }
+  return parsed
+}
+
+// Why: `runtime:<environment-id>` ids are minted by this machine's pairing store, so they
+// only name a machine relative to it. Filtering or mutating the locally connected runtime
+// with one answers for the wrong host, and an id that matches nothing is indistinguishable
+// from a real host with no rows — so resolve the id here and send the command to it.
+export async function resolveHostFlagEnvironmentId(
+  flags: Map<string, string | boolean>,
+  selection: HostFlagRoutingSelection
+): Promise<string | null> {
+  const host = parseHostFlag(flags)
+  if (host?.kind !== 'runtime') {
+    return null
+  }
+  const [{ listEnvironments, resolveEnvironment }, { getDefaultUserDataPath }] = await Promise.all([
+    import('./runtime/environments.js'),
+    import('./runtime-client.js')
+  ])
+  const userDataPath = getDefaultUserDataPath()
+  const environment = listEnvironments(userDataPath).find(
+    (candidate) => candidate.id === host.environmentId
+  )
+  if (!environment) {
+    throw new RuntimeClientError(
+      'invalid_argument',
+      `Unknown Orca server in --host ${host.id}: no paired environment has id ${host.environmentId}. Run \`orca environment list\` to see paired servers, or pass --host local.`
+    )
+  }
+  if (selection.pairingCode) {
+    throw new RuntimeClientError(
+      'invalid_argument',
+      `--host ${host.id} already selects a paired Orca server; use either --host runtime:<id> or --pairing-code, not both.`
+    )
+  }
+  if (selection.environmentSelector) {
+    const selected = resolveEnvironment(userDataPath, selection.environmentSelector)
+    if (selected.id !== environment.id) {
+      throw new RuntimeClientError(
+        'invalid_argument',
+        `--host ${host.id} and --environment ${selection.environmentSelector} name different Orca servers.`
+      )
+    }
+  }
+  return environment.id
+}
+
+// Why: a runtime stamps its own setups `local` when they were made on the box and
+// `runtime:<id>` when a paired client made them. Once --host routed the command to that
+// runtime both spellings mean the same machine, so a host filter has to accept both.
+export function hostFilterMatchesHostId(
+  filter: ParsedExecutionHost,
+  candidateHostId: string | null | undefined
+): boolean {
+  const candidate = normalizeExecutionHostId(candidateHostId)
+  if (candidate === filter.id) {
+    return true
+  }
+  return filter.kind === 'runtime' && candidate === LOCAL_EXECUTION_HOST_ID
+}

--- a/src/cli/execution-host-flag.ts
+++ b/src/cli/execution-host-flag.ts
@@ -8,7 +8,9 @@ import { RuntimeClientError } from './runtime/types'
 
 export type HostFlagRoutingSelection = {
   pairingCode: string | null
-  environmentSelector: string | null
+  // Why: an ambient ORCA_ENVIRONMENT counts as a selection too, so carry the label to
+  // name the real source in the conflict message.
+  environmentSelector: { value: string; label: string } | null
 }
 
 export function parseHostFlag(
@@ -48,13 +50,23 @@ export async function resolveHostFlagEnvironmentId(
     import('./runtime-client.js')
   ])
   const userDataPath = getDefaultUserDataPath()
-  const environment = listEnvironments(userDataPath).find(
-    (candidate) => candidate.id === host.environmentId
-  )
+  const known = listEnvironments(userDataPath)
+  const environment = known.find((candidate) => candidate.id === host.environmentId)
   if (!environment) {
+    // Why: `runtime:<id>` is a host id that also appears in stored rows, so it resolves by id
+    // only — unlike --environment, which also accepts a name. Say so, and hand back the ids an
+    // agent can retry with instead of making it scrape the sentence.
     throw new RuntimeClientError(
       'invalid_argument',
-      `Unknown Orca server in --host ${host.id}: no paired environment has id ${host.environmentId}. Run \`orca environment list\` to see paired servers, or pass --host local.`
+      `Unknown Orca server in --host ${host.id}: no paired environment has id ${host.environmentId}. --host runtime:<id> matches environment ids only, never names. Run \`orca environment list\` to see paired servers, or pass --host local.`,
+      {
+        knownEnvironments: known.map((candidate) => ({ id: candidate.id, name: candidate.name })),
+        nextSteps: [
+          'Run `orca environment list` to see paired Orca servers.',
+          'Use the environment id, not its name: --host runtime:<environment-id>.',
+          'Use --host local to target this machine.'
+        ]
+      }
     )
   }
   if (selection.pairingCode) {
@@ -64,11 +76,11 @@ export async function resolveHostFlagEnvironmentId(
     )
   }
   if (selection.environmentSelector) {
-    const selected = resolveEnvironment(userDataPath, selection.environmentSelector)
+    const selected = resolveEnvironment(userDataPath, selection.environmentSelector.value)
     if (selected.id !== environment.id) {
       throw new RuntimeClientError(
         'invalid_argument',
-        `--host ${host.id} and --environment ${selection.environmentSelector} name different Orca servers.`
+        `--host ${host.id} and ${selection.environmentSelector.label} ${selection.environmentSelector.value} name different Orca servers.`
       )
     }
   }

--- a/src/cli/handlers/project.ts
+++ b/src/cli/handlers/project.ts
@@ -10,6 +10,7 @@ import type {
   ProjectHostSetupUpdateArgs,
   ProjectHostSetupUpdateResult
 } from '../../shared/project-types'
+import type { ExecutionHostId } from '../../shared/execution-host'
 import type { RepoKind } from '../../shared/repo-types'
 import type { CommandHandler } from '../dispatch'
 import {
@@ -21,9 +22,18 @@ import {
   formatProjectList,
   printResult
 } from '../format'
+import { hostFilterMatchesHostId, parseHostFlag } from '../execution-host-flag'
 import { getOptionalStringFlag, getRequiredStringFlag } from '../flags'
 import { resolveRepoPathArgument } from '../repo-path-arguments'
 import { RuntimeClientError } from '../runtime-client'
+
+function getRequiredHostId(flags: Map<string, string | boolean>): ExecutionHostId {
+  const host = parseHostFlag(flags)
+  if (!host) {
+    throw new RuntimeClientError('invalid_argument', 'Missing required --host')
+  }
+  return host.id
+}
 
 function getOptionalRepoKind(flags: Map<string, string | boolean>): RepoKind | undefined {
   const kind = getOptionalStringFlag(flags, 'kind')
@@ -43,12 +53,12 @@ export const PROJECT_HANDLERS: Record<string, CommandHandler> = {
   },
   'project setups': async ({ flags, client, json }) => {
     const projectFilter = getOptionalStringFlag(flags, 'project')
-    const hostFilter = getOptionalStringFlag(flags, 'host')
+    const hostFilter = parseHostFlag(flags)
     const result = await client.call<{ setups: ProjectHostSetup[] }>('projectHostSetup.list')
     const setups = result.result.setups.filter(
       (setup) =>
         (projectFilter === undefined || setup.projectId === projectFilter) &&
-        (hostFilter === undefined || setup.hostId === hostFilter)
+        (hostFilter === undefined || hostFilterMatchesHostId(hostFilter, setup.hostId))
     )
     printResult({ ...result, result: { setups } }, json, formatProjectHostSetupList)
   },
@@ -56,7 +66,7 @@ export const PROJECT_HANDLERS: Record<string, CommandHandler> = {
     const rawPath = getRequiredStringFlag(flags, 'path')
     const args: ProjectHostSetupExistingFolderArgs = {
       projectId: getRequiredStringFlag(flags, 'project'),
-      hostId: getRequiredStringFlag(flags, 'host') as ProjectHostSetupExistingFolderArgs['hostId'],
+      hostId: getRequiredHostId(flags),
       path: resolveRepoPathArgument(rawPath, cwd, client.isRemote, 'Remote project setup'),
       kind: getOptionalRepoKind(flags),
       displayName: getOptionalStringFlag(flags, 'display-name')
@@ -71,7 +81,7 @@ export const PROJECT_HANDLERS: Record<string, CommandHandler> = {
     const rawDestination = getRequiredStringFlag(flags, 'destination')
     const args: ProjectHostSetupCloneArgs = {
       projectId: getRequiredStringFlag(flags, 'project'),
-      hostId: getRequiredStringFlag(flags, 'host') as ProjectHostSetupCloneArgs['hostId'],
+      hostId: getRequiredHostId(flags),
       url: getRequiredStringFlag(flags, 'url'),
       destination: resolveRepoPathArgument(
         rawDestination,
@@ -91,7 +101,7 @@ export const PROJECT_HANDLERS: Record<string, CommandHandler> = {
     const path = getOptionalStringFlag(flags, 'path')
     const args: ProjectHostSetupCreateArgs = {
       projectId: getRequiredStringFlag(flags, 'project'),
-      hostId: getRequiredStringFlag(flags, 'host') as ProjectHostSetupCreateArgs['hostId'],
+      hostId: getRequiredHostId(flags),
       setupId: getOptionalStringFlag(flags, 'setup-id'),
       path:
         path === undefined

--- a/src/cli/index-automation-target.test.ts
+++ b/src/cli/index-automation-target.test.ts
@@ -181,6 +181,7 @@ describe('orca cli worktree awareness', () => {
       '/tmp/repo'
     )
 
+    expect(runtimeClientConstructorMock).toHaveBeenCalledWith(null, 'gpu')
     expect(callMock).toHaveBeenNthCalledWith(1, 'projectHostSetup.list')
     expect(callMock).toHaveBeenNthCalledWith(
       2,

--- a/src/cli/index-automation-target.test.ts
+++ b/src/cli/index-automation-target.test.ts
@@ -42,7 +42,7 @@ vi.mock('child_process', async () => {
 
 import { main } from './index'
 import { buildWorktree, okFixture, queueFixtures, worktreeListFixture } from './test-fixtures'
-import { useWorktreeAwarenessEnvironment } from './index-test-harness'
+import { pairRuntimeEnvironment, useWorktreeAwarenessEnvironment } from './index-test-harness'
 
 describe('orca cli worktree awareness', () => {
   useWorktreeAwarenessEnvironment({
@@ -123,6 +123,7 @@ describe('orca cli worktree awareness', () => {
   })
 
   it('resolves project and host flags for automation create', async () => {
+    pairRuntimeEnvironment(listEnvironmentsMock, 'gpu')
     queueFixtures(
       callMock,
       okFixture('req_project_setups', {

--- a/src/cli/index-project-setup.test.ts
+++ b/src/cli/index-project-setup.test.ts
@@ -149,6 +149,48 @@ describe('orca cli worktree awareness', () => {
     expect(logSpy.mock.calls[0]?.[0]).toContain('setup-local')
   })
 
+  it('keeps --host local a filter on the selected environment rather than a second selector', async () => {
+    pairRuntimeEnvironment(listEnvironmentsMock, 'prod')
+    queueFixtures(
+      callMock,
+      okFixture('req_project_setups', {
+        setups: [
+          {
+            id: 'setup-on-box',
+            projectId: 'github:stablyai/orca',
+            hostId: 'local',
+            repoId: 'repo-on-box',
+            path: '/srv/orca',
+            displayName: 'Orca',
+            setupState: 'ready',
+            setupMethod: 'legacy-repo',
+            createdAt: 1,
+            updatedAt: 1
+          },
+          {
+            id: 'setup-by-client',
+            projectId: 'github:stablyai/orca',
+            hostId: 'runtime:prod',
+            repoId: 'repo-by-client',
+            path: '/srv/orca-2',
+            displayName: 'Orca',
+            setupState: 'ready',
+            setupMethod: 'legacy-repo',
+            createdAt: 1,
+            updatedAt: 1
+          }
+        ]
+      })
+    )
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(['project', 'setups', '--environment', 'prod', '--host', 'local'], '/tmp/repo')
+
+    expect(runtimeClientConstructorMock).toHaveBeenCalledWith(undefined, 'prod')
+    expect(logSpy.mock.calls[0]?.[0]).toContain('setup-on-box')
+    expect(logSpy.mock.calls[0]?.[0]).not.toContain('setup-by-client')
+  })
+
   it('rejects a runtime host id that no paired server owns instead of answering empty', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
@@ -157,9 +199,11 @@ describe('orca cli worktree awareness', () => {
     await main(['project', 'setups', '--host', 'runtime:not-a-real-env', '--json'], '/tmp/repo')
 
     expect(callMock).not.toHaveBeenCalled()
-    expect([...logSpy.mock.calls, ...errSpy.mock.calls].flat().join('\n')).toContain(
-      'no paired environment has id not-a-real-env'
-    )
+    const printed = [...logSpy.mock.calls, ...errSpy.mock.calls].flat().join('\n')
+    expect(printed).toContain('no paired environment has id not-a-real-env')
+    // An agent reads the code and the retry candidates, not the prose.
+    expect(JSON.parse(printed).error.code).toBe('invalid_argument')
+    expect(JSON.parse(printed).error.data.knownEnvironments).toEqual([])
     expect(process.exitCode).toBe(1)
 
     process.exitCode = priorExitCode

--- a/src/cli/index-project-setup.test.ts
+++ b/src/cli/index-project-setup.test.ts
@@ -43,7 +43,7 @@ vi.mock('child_process', async () => {
 
 import { main } from './index'
 import { okFixture, queueFixtures } from './test-fixtures'
-import { useWorktreeAwarenessEnvironment } from './index-test-harness'
+import { pairRuntimeEnvironment, useWorktreeAwarenessEnvironment } from './index-test-harness'
 
 describe('orca cli worktree awareness', () => {
   useWorktreeAwarenessEnvironment({
@@ -103,7 +103,8 @@ describe('orca cli worktree awareness', () => {
     expect(callMock).toHaveBeenCalledWith('project.list')
   })
 
-  it('filters project host setups locally after fetching setup compatibility state', async () => {
+  it('routes a runtime host filter to that paired server and keeps its own local rows', async () => {
+    pairRuntimeEnvironment(listEnvironmentsMock, 'gpu')
     queueFixtures(
       callMock,
       okFixture('req_project_setups', {
@@ -142,9 +143,62 @@ describe('orca cli worktree awareness', () => {
       '/tmp/repo'
     )
 
+    expect(runtimeClientConstructorMock).toHaveBeenCalledWith(null, 'gpu')
     expect(callMock).toHaveBeenCalledWith('projectHostSetup.list')
     expect(logSpy.mock.calls[0]?.[0]).toContain('setup-remote')
-    expect(logSpy.mock.calls[0]?.[0]).not.toContain('setup-local')
+    expect(logSpy.mock.calls[0]?.[0]).toContain('setup-local')
+  })
+
+  it('rejects a runtime host id that no paired server owns instead of answering empty', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const priorExitCode = process.exitCode
+
+    await main(['project', 'setups', '--host', 'runtime:not-a-real-env', '--json'], '/tmp/repo')
+
+    expect(callMock).not.toHaveBeenCalled()
+    expect([...logSpy.mock.calls, ...errSpy.mock.calls].flat().join('\n')).toContain(
+      'no paired environment has id not-a-real-env'
+    )
+    expect(process.exitCode).toBe(1)
+
+    process.exitCode = priorExitCode
+  })
+
+  it('rejects a malformed --host value before contacting any runtime', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const priorExitCode = process.exitCode
+
+    await main(['project', 'setups', '--host', 'runtime:', '--json'], '/tmp/repo')
+
+    expect(callMock).not.toHaveBeenCalled()
+    expect([...logSpy.mock.calls, ...errSpy.mock.calls].flat().join('\n')).toContain(
+      'Invalid --host value: runtime:'
+    )
+    expect(process.exitCode).toBe(1)
+
+    process.exitCode = priorExitCode
+  })
+
+  it('refuses a runtime host id alongside an unrelated --pairing-code connection', async () => {
+    pairRuntimeEnvironment(listEnvironmentsMock, 'gpu')
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const priorExitCode = process.exitCode
+
+    await main(
+      ['project', 'setups', '--host', 'runtime:gpu', '--pairing-code', 'remote-runtime', '--json'],
+      '/tmp/repo'
+    )
+
+    expect(callMock).not.toHaveBeenCalled()
+    expect([...logSpy.mock.calls, ...errSpy.mock.calls].flat().join('\n')).toContain(
+      'use either --host runtime:<id> or --pairing-code, not both'
+    )
+    expect(process.exitCode).toBe(1)
+
+    process.exitCode = priorExitCode
   })
 
   it('sets up an existing project folder with a path resolved against the local cli cwd', async () => {
@@ -213,6 +267,7 @@ describe('orca cli worktree awareness', () => {
   })
 
   it('rejects remote project setup relative paths instead of resolving against client cwd', async () => {
+    pairRuntimeEnvironment(listEnvironmentsMock, 'gpu')
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     const priorExitCode = process.exitCode
@@ -227,8 +282,6 @@ describe('orca cli worktree awareness', () => {
         'runtime:gpu',
         '--path',
         './orca',
-        '--pairing-code',
-        'remote-runtime',
         '--json'
       ],
       '/tmp/repo'
@@ -377,6 +430,7 @@ describe('orca cli worktree awareness', () => {
   })
 
   it('creates independent project host setup metadata through the project-first runtime API', async () => {
+    pairRuntimeEnvironment(listEnvironmentsMock, 'gpu')
     queueFixtures(
       callMock,
       okFixture('req_project_setup_create', {

--- a/src/cli/index-test-harness.ts
+++ b/src/cli/index-test-harness.ts
@@ -83,6 +83,31 @@ export async function createChildProcessModuleMock(spawnMock: Mock) {
   }
 }
 
+/** Registers a paired environment so `--host runtime:<id>` routes there instead of being rejected. */
+export function pairRuntimeEnvironment(listEnvironmentsMock: Mock, id: string, name = id): void {
+  listEnvironmentsMock.mockReturnValue([
+    {
+      id,
+      name,
+      createdAt: 1,
+      updatedAt: 1,
+      lastUsedAt: null,
+      runtimeId: null,
+      endpoints: [
+        {
+          id: `ws-${id}`,
+          kind: 'websocket',
+          label: 'WebSocket',
+          endpoint: 'ws://127.0.0.1:6768',
+          deviceToken: 'token',
+          publicKeyB64: 'pk'
+        }
+      ],
+      preferredEndpointId: `ws-${id}`
+    }
+  ])
+}
+
 /** Installs the env-var save/restore + mock-reset hooks shared by the CLI worktree-awareness suites. */
 export function useWorktreeAwarenessEnvironment(mocks: WorktreeAwarenessMocks): void {
   const originalTerminalHandle = process.env.ORCA_TERMINAL_HANDLE

--- a/src/cli/index-worktree-create-target.test.ts
+++ b/src/cli/index-worktree-create-target.test.ts
@@ -42,7 +42,7 @@ vi.mock('child_process', async () => {
 
 import { main } from './index'
 import { buildWorktree, okFixture, queueFixtures, worktreeListFixture } from './test-fixtures'
-import { useWorktreeAwarenessEnvironment } from './index-test-harness'
+import { pairRuntimeEnvironment, useWorktreeAwarenessEnvironment } from './index-test-harness'
 
 describe('orca cli worktree awareness', () => {
   useWorktreeAwarenessEnvironment({
@@ -86,6 +86,7 @@ describe('orca cli worktree awareness', () => {
   })
 
   it('resolves project and host flags to the matching repo for worktree.create', async () => {
+    pairRuntimeEnvironment(listEnvironmentsMock, 'gpu')
     queueFixtures(
       callMock,
       okFixture('req_project_setups', {

--- a/src/cli/index-worktree-create-target.test.ts
+++ b/src/cli/index-worktree-create-target.test.ts
@@ -141,6 +141,7 @@ describe('orca cli worktree awareness', () => {
       '/tmp/repo'
     )
 
+    expect(runtimeClientConstructorMock).toHaveBeenCalledWith(null, 'gpu')
     expect(callMock).toHaveBeenNthCalledWith(1, 'projectHostSetup.list')
     expect(callMock).toHaveBeenNthCalledWith(2, 'worktree.create', {
       repo: 'id:repo-gpu',

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -92,11 +92,20 @@ export async function main(
     const environmentSelector = ignoreRemoteSelection ? null : parsed.flags.get('environment')
     // Why: --host runtime:<id> names a paired server, not a filter over this
     // runtime's rows, so it has to pick the connection before the client exists.
+    // An ambient ORCA_ENVIRONMENT is checked for disagreement too — silently
+    // retargeting a mutation to another server is the bug this flag already had.
+    // An ambient pairing code cannot be resolved to an id to compare, so the
+    // explicit flag simply wins there.
     const hostEnvironmentId = ignoreRemoteSelection
       ? null
       : await resolveHostFlagEnvironmentId(parsed.flags, {
           pairingCode: typeof pairingCode === 'string' ? pairingCode : null,
-          environmentSelector: typeof environmentSelector === 'string' ? environmentSelector : null
+          environmentSelector:
+            typeof environmentSelector === 'string'
+              ? { value: environmentSelector, label: '--environment' }
+              : process.env.ORCA_ENVIRONMENT
+                ? { value: process.env.ORCA_ENVIRONMENT, label: 'ORCA_ENVIRONMENT' }
+                : null
         })
     // Why: pass `null` (not `undefined`) when remote selection is suppressed
     // so the RuntimeClient default parameter does not re-activate the

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -9,6 +9,7 @@ import {
   validateCommandAndFlags
 } from './args'
 import { dispatch } from './dispatch'
+import { resolveHostFlagEnvironmentId } from './execution-host-flag'
 import { reportCliError } from './format'
 import { printHelp } from './help'
 import type { RuntimeClient } from './runtime-client'
@@ -89,10 +90,25 @@ export async function main(
     const ignoreRemoteSelection = shouldIgnoreRemoteSelection(parsed.commandPath)
     const pairingCode = ignoreRemoteSelection ? null : parsed.flags.get('pairing-code')
     const environmentSelector = ignoreRemoteSelection ? null : parsed.flags.get('environment')
+    // Why: --host runtime:<id> names a paired server, not a filter over this
+    // runtime's rows, so it has to pick the connection before the client exists.
+    const hostEnvironmentId = ignoreRemoteSelection
+      ? null
+      : await resolveHostFlagEnvironmentId(parsed.flags, {
+          pairingCode: typeof pairingCode === 'string' ? pairingCode : null,
+          environmentSelector: typeof environmentSelector === 'string' ? environmentSelector : null
+        })
     // Why: pass `null` (not `undefined`) when remote selection is suppressed
     // so the RuntimeClient default parameter does not re-activate the
     // ORCA_PAIRING_CODE / ORCA_ENVIRONMENT env-var fallback for commands
     // that must run locally (environment / serve).
+    const suppressed = ignoreRemoteSelection ? null : undefined
+    // An explicit --host runtime:<id> outranks an ambient pairing code or environment.
+    const remotePairingCode =
+      hostEnvironmentId !== null ? null : typeof pairingCode === 'string' ? pairingCode : suppressed
+    const remoteEnvironment =
+      hostEnvironmentId ??
+      (typeof environmentSelector === 'string' ? environmentSelector : suppressed)
     let client: RuntimeClient | undefined
     await dispatch(parsed.commandPath, {
       flags: parsed.flags,
@@ -101,12 +117,8 @@ export async function main(
         client ??= new RuntimeClientClass(
           undefined,
           undefined,
-          typeof pairingCode === 'string' ? pairingCode : ignoreRemoteSelection ? null : undefined,
-          typeof environmentSelector === 'string'
-            ? environmentSelector
-            : ignoreRemoteSelection
-              ? null
-              : undefined
+          remotePairingCode,
+          remoteEnvironment
         )
         return client
       },

--- a/src/cli/runtime-client-deferral.test.ts
+++ b/src/cli/runtime-client-deferral.test.ts
@@ -48,22 +48,26 @@ describe('RuntimeClient module-graph deferral', () => {
     process.exitCode = 0
   })
 
-  // Why: the whole point of the change. These five modules load on EVERY
+  // Why: the whole point of the change. These six modules load on EVERY
   // invocation, so a value-import of the barrel from any of them drags the
   // RuntimeClient graph (zod, ws, tweetnacl) back onto the --help path.
-  it.each(['args.ts', 'flags.ts', 'dispatch.ts', 'format.ts', 'selectors.ts'])(
-    '%s imports error classes from ./runtime/types, not the barrel',
-    (file) => {
-      const source = readFileSync(join(CLI_DIR, file), 'utf8')
-      const valueImports = source
-        .split('\n')
-        .filter((line) => line.startsWith('import ') && line.includes("'./runtime-client'"))
-      for (const line of valueImports) {
-        expect(line, `${file}: "${line}" must be type-only`).toMatch(/^import type /)
-      }
-      expect(source).toContain("} from './runtime/types'")
+  it.each([
+    'args.ts',
+    'flags.ts',
+    'dispatch.ts',
+    'format.ts',
+    'selectors.ts',
+    'execution-host-flag.ts'
+  ])('%s imports error classes from ./runtime/types, not the barrel', (file) => {
+    const source = readFileSync(join(CLI_DIR, file), 'utf8')
+    const valueImports = source
+      .split('\n')
+      .filter((line) => line.startsWith('import ') && line.includes("'./runtime-client'"))
+    for (const line of valueImports) {
+      expect(line, `${file}: "${line}" must be type-only`).toMatch(/^import type /)
     }
-  )
+    expect(source).toContain("} from './runtime/types'")
+  })
 
   it('index.ts has no eager value-import of the runtime client', () => {
     const source = readFileSync(join(CLI_DIR, 'index.ts'), 'utf8')

--- a/src/cli/specs/automations.ts
+++ b/src/cli/specs/automations.ts
@@ -56,6 +56,7 @@ export const AUTOMATION_COMMAND_SPECS: CommandSpec[] = [
       'Trigger accepts hourly, daily, weekdays, weekly, a 5-field cron expression, or an RRULE string.',
       'When --repo is omitted, the CLI uses the enclosing Orca worktree when one can be resolved from cwd.',
       'Use --project with --host, or --project-host-setup, to run on a specific project host setup.',
+      '--host runtime:<environment-id> targets that paired Orca server; the id must appear in `orca environment list`.',
       'Use --source-context with a JSON TaskSourceContext when task/provider data should come from a specific host/account; pass null on edit to clear it.',
       'Use --workspace to run in an existing worktree; otherwise the automation creates a new worktree per run.',
       'Use --precheck to run a bounded command before scheduled runs; exit code 0 continues, anything else records a skipped run.',

--- a/src/cli/specs/automations.ts
+++ b/src/cli/specs/automations.ts
@@ -56,7 +56,7 @@ export const AUTOMATION_COMMAND_SPECS: CommandSpec[] = [
       'Trigger accepts hourly, daily, weekdays, weekly, a 5-field cron expression, or an RRULE string.',
       'When --repo is omitted, the CLI uses the enclosing Orca worktree when one can be resolved from cwd.',
       'Use --project with --host, or --project-host-setup, to run on a specific project host setup.',
-      '--host runtime:<environment-id> targets that paired Orca server; the id must appear in `orca environment list`.',
+      '--host runtime:<environment-id> targets that paired Orca server; use the id from `orca environment list`, not the environment name.',
       'Use --source-context with a JSON TaskSourceContext when task/provider data should come from a specific host/account; pass null on edit to clear it.',
       'Use --workspace to run in an existing worktree; otherwise the automation creates a new worktree per run.',
       'Use --precheck to run a bounded command before scheduled runs; exit code 0 continues, anything else records a skipped run.',

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -111,6 +111,7 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
       'By default, Orca records the new worktree as a child of the caller context when it can infer one from the Orca terminal or current directory.',
       'If --repo is omitted, Orca infers the repo from the current Orca-managed worktree.',
       'Use --project with --host to create on a ready project host setup without spelling the backing repo id.',
+      '--host runtime:<environment-id> creates on that paired Orca server; the id must appear in `orca environment list`.',
       'For related work, use the inferred parent or pass --parent-worktree active, folder:<id>, or worktree:<worktreeId> to make the relationship explicit. Worktree ids are the full <repo-id>::<path> values returned by `orca worktree list --json`.',
       'Use --no-parent when the new worktree should be independent of the current context.',
       '--no-parent only affects Orca lineage; omit --base-branch to use the repo default base, or pass the default base ref explicitly for independent top-level work.',

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -111,7 +111,7 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
       'By default, Orca records the new worktree as a child of the caller context when it can infer one from the Orca terminal or current directory.',
       'If --repo is omitted, Orca infers the repo from the current Orca-managed worktree.',
       'Use --project with --host to create on a ready project host setup without spelling the backing repo id.',
-      '--host runtime:<environment-id> creates on that paired Orca server; the id must appear in `orca environment list`.',
+      '--host runtime:<environment-id> creates on that paired Orca server; use the id from `orca environment list`, not the environment name.',
       'For related work, use the inferred parent or pass --parent-worktree active, folder:<id>, or worktree:<worktreeId> to make the relationship explicit. Worktree ids are the full <repo-id>::<path> values returned by `orca worktree list --json`.',
       'Use --no-parent when the new worktree should be independent of the current context.',
       '--no-parent only affects Orca lineage; omit --base-branch to use the repo default base, or pass the default base ref explicitly for independent top-level work.',
@@ -125,7 +125,7 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
     examples: [
       'orca worktree create --name agent-task --agent codex --prompt "hi" --json',
       'orca worktree create --repo id:<repoId> --name related-task --json',
-      'orca worktree create --project github:stablyai/orca --host runtime:gpu --name benchmark --json',
+      'orca worktree create --project github:stablyai/orca --host runtime:03ef704c-b180-4b10-998d-e28fbd5de9a3 --name benchmark --json',
       'orca worktree create --repo id:<repoId> --name linear-task --linear-issue https://linear.app/stably/issue/STA-335/test-issue --json',
       'orca worktree create --repo id:<repoId> --name agent-task --agent codex --prompt "hi" --json',
       'orca worktree create --repo id:<repoId> --name folder-child --parent-worktree folder:<folderId> --json',

--- a/src/cli/specs/project.ts
+++ b/src/cli/specs/project.ts
@@ -14,11 +14,16 @@ export const PROJECT_COMMAND_SPECS: CommandSpec[] = [
     summary: 'List project host setups',
     usage: 'orca project setups [--project <id>] [--host <host-id>] [--json]',
     allowedFlags: [...GLOBAL_FLAGS, 'project', 'host'],
-    notes: ['A setup means a project is available on a host at a concrete filesystem path.'],
+    notes: [
+      'A setup means a project is available on a host at a concrete filesystem path.',
+      '--host runtime:<environment-id> runs the command on that paired Orca server instead of filtering this runtime; unknown environment ids are rejected rather than answered with an empty list.',
+      'Run `orca environment list` to see the environment ids that runtime:<environment-id> accepts.'
+    ],
     examples: [
       'orca project setups',
       'orca project setups --project github:stablyai/orca',
-      'orca project setups --host local'
+      'orca project setups --host local',
+      'orca project setups --host runtime:03ef704c-b180-4b10-998d-e28fbd5de9a3'
     ]
   },
   {
@@ -29,6 +34,7 @@ export const PROJECT_COMMAND_SPECS: CommandSpec[] = [
     allowedFlags: [...GLOBAL_FLAGS, 'project', 'host', 'path', 'kind', 'display-name'],
     notes: [
       'For remote runtimes, --path must be an absolute path on the remote server.',
+      '--host runtime:<environment-id> targets that paired Orca server; the id must appear in `orca environment list`.',
       'SSH targets are set up through the desktop UI because the desktop client owns SSH connections.'
     ],
     examples: [
@@ -44,6 +50,7 @@ export const PROJECT_COMMAND_SPECS: CommandSpec[] = [
     allowedFlags: [...GLOBAL_FLAGS, 'project', 'host', 'url', 'destination', 'display-name'],
     notes: [
       'For remote runtimes, --destination must be an absolute parent directory on the remote server.',
+      '--host runtime:<environment-id> targets that paired Orca server; the id must appear in `orca environment list`.',
       'SSH targets are cloned through the desktop UI because the desktop client owns SSH connections.'
     ],
     examples: [
@@ -71,6 +78,7 @@ export const PROJECT_COMMAND_SPECS: CommandSpec[] = [
     ],
     notes: [
       'Creates setup metadata without registering a repo compatibility record.',
+      '--host runtime:<environment-id> targets that paired Orca server; the id must appear in `orca environment list`.',
       'Use setup-existing-folder when Orca should import and manage an actual checkout path now.'
     ],
     examples: [

--- a/src/cli/specs/project.ts
+++ b/src/cli/specs/project.ts
@@ -17,7 +17,8 @@ export const PROJECT_COMMAND_SPECS: CommandSpec[] = [
     notes: [
       'A setup means a project is available on a host at a concrete filesystem path.',
       '--host runtime:<environment-id> runs the command on that paired Orca server instead of filtering this runtime; unknown environment ids are rejected rather than answered with an empty list.',
-      'Run `orca environment list` to see the environment ids that runtime:<environment-id> accepts.'
+      'Run `orca environment list` to see the environment ids that runtime:<environment-id> accepts. It matches ids only, never environment names.',
+      "A routed --host runtime:<id> also lists that server's own local-stamped setups, because both spellings name the machine the command reached."
     ],
     examples: [
       'orca project setups',
@@ -34,12 +35,12 @@ export const PROJECT_COMMAND_SPECS: CommandSpec[] = [
     allowedFlags: [...GLOBAL_FLAGS, 'project', 'host', 'path', 'kind', 'display-name'],
     notes: [
       'For remote runtimes, --path must be an absolute path on the remote server.',
-      '--host runtime:<environment-id> targets that paired Orca server; the id must appear in `orca environment list`.',
+      '--host runtime:<environment-id> targets that paired Orca server; use the id from `orca environment list`, not the environment name.',
       'SSH targets are set up through the desktop UI because the desktop client owns SSH connections.'
     ],
     examples: [
       'orca project setup-existing-folder --project github:stablyai/orca --host local --path ~/orca',
-      'orca project setup-existing-folder --project github:stablyai/orca --host runtime:gpu --path /home/me/orca --kind git --json'
+      'orca project setup-existing-folder --project github:stablyai/orca --host runtime:03ef704c-b180-4b10-998d-e28fbd5de9a3 --path /home/me/orca --kind git --json'
     ]
   },
   {
@@ -50,12 +51,12 @@ export const PROJECT_COMMAND_SPECS: CommandSpec[] = [
     allowedFlags: [...GLOBAL_FLAGS, 'project', 'host', 'url', 'destination', 'display-name'],
     notes: [
       'For remote runtimes, --destination must be an absolute parent directory on the remote server.',
-      '--host runtime:<environment-id> targets that paired Orca server; the id must appear in `orca environment list`.',
+      '--host runtime:<environment-id> targets that paired Orca server; use the id from `orca environment list`, not the environment name.',
       'SSH targets are cloned through the desktop UI because the desktop client owns SSH connections.'
     ],
     examples: [
       'orca project setup-clone --project github:stablyai/orca --host local --url https://github.com/stablyai/orca.git --destination ~/src',
-      'orca project setup-clone --project github:stablyai/orca --host runtime:gpu --url https://github.com/stablyai/orca.git --destination /srv --json'
+      'orca project setup-clone --project github:stablyai/orca --host runtime:03ef704c-b180-4b10-998d-e28fbd5de9a3 --url https://github.com/stablyai/orca.git --destination /srv --json'
     ]
   },
   {
@@ -78,11 +79,11 @@ export const PROJECT_COMMAND_SPECS: CommandSpec[] = [
     ],
     notes: [
       'Creates setup metadata without registering a repo compatibility record.',
-      '--host runtime:<environment-id> targets that paired Orca server; the id must appear in `orca environment list`.',
+      '--host runtime:<environment-id> targets that paired Orca server; use the id from `orca environment list`, not the environment name.',
       'Use setup-existing-folder when Orca should import and manage an actual checkout path now.'
     ],
     examples: [
-      'orca project setup-create --project github:stablyai/orca --host runtime:gpu --state setting-up --method provisioned --json'
+      'orca project setup-create --project github:stablyai/orca --host runtime:03ef704c-b180-4b10-998d-e28fbd5de9a3 --state setting-up --method provisioned --json'
     ]
   },
   {

--- a/src/cli/worktree-project-target.ts
+++ b/src/cli/worktree-project-target.ts
@@ -1,4 +1,6 @@
+import { normalizeExecutionHostId, type ParsedExecutionHost } from '../shared/execution-host'
 import type { ProjectHostSetup } from '../shared/project-types'
+import { hostFilterMatchesHostId, parseHostFlag } from './execution-host-flag'
 import type { RuntimeClient } from './runtime-client'
 import { RuntimeClientError } from './runtime-client'
 
@@ -48,34 +50,44 @@ export async function resolveProjectCreateRepoSelector(
   return (await resolveProjectCreateTarget(flags, client))?.repoSelector
 }
 
+// Why: the routed runtime can hold both an exact `runtime:<id>` row and a `local` row for the
+// same project; the exact stamp is the one the caller named, so it wins the selection.
+function findReadySetupOnHost(
+  setups: readonly ProjectHostSetup[],
+  projectId: string | undefined,
+  host: ParsedExecutionHost | undefined
+): ProjectHostSetup | undefined {
+  const candidates = setups.filter((candidate) => candidate.projectId === projectId)
+  if (!host) {
+    return candidates[0]
+  }
+  return (
+    candidates.find((candidate) => normalizeExecutionHostId(candidate.hostId) === host.id) ??
+    candidates.find((candidate) => hostFilterMatchesHostId(host, candidate.hostId))
+  )
+}
+
 export async function resolveProjectCreateTarget(
   flags: Map<string, string | boolean>,
   client: RuntimeClient
 ): Promise<ProjectCreateTarget | undefined> {
   const projectHostSetupId = getPresentStringFlag(flags, 'project-host-setup')
   const projectId = getPresentStringFlag(flags, 'project')
-  const hostId = getPresentStringFlag(flags, 'host')
-  if (!projectHostSetupId && !projectId && !hostId) {
+  const host = parseHostFlag(flags)
+  if (!projectHostSetupId && !projectId && !host) {
     return undefined
   }
   const result = await client.call<{ setups: ProjectHostSetup[] }>('projectHostSetup.list')
-  const setup = result.result.setups.find((candidate) => {
-    if (candidate.setupState !== 'ready') {
-      return false
-    }
-    if (projectHostSetupId) {
-      return candidate.id === projectHostSetupId
-    }
-    return (
-      candidate.projectId === projectId && (hostId === undefined || candidate.hostId === hostId)
-    )
-  })
+  const ready = result.result.setups.filter((candidate) => candidate.setupState === 'ready')
+  const setup = projectHostSetupId
+    ? ready.find((candidate) => candidate.id === projectHostSetupId)
+    : findReadySetupOnHost(ready, projectId, host)
   if (!setup) {
     throw new RuntimeClientError(
       'invalid_argument',
       projectHostSetupId
         ? `Project host setup is not ready or was not found: ${projectHostSetupId}`
-        : `Project is not set up on the selected host: ${projectId}${hostId ? ` on ${hostId}` : ''}`
+        : `Project is not set up on the selected host: ${projectId}${host ? ` on ${host.id}` : ''}`
     )
   }
   return {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​315 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​20 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​295 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​212 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​31 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​181 |

<!-- /orca-pr-loc -->

## ELI5

`orca ... --host runtime:<id>` looked like "do this on that Orca server". It wasn't — it was a filter applied to whatever runtime the CLI was already talking to, which is normally your own machine. So a real server id and a typo'd one both came back `ok: true` with an empty list, and a clone aimed at a remote server landed in the caller's own worktree.

## What Changed

`--host` is now resolved **before** the runtime client is constructed (`src/cli/index.ts`), by a new `src/cli/execution-host-flag.ts`:

- **Unparseable host ids are rejected.** `--host runtime:`, `--host ssh:`, `--host nonsense` fail with `invalid_argument` and never reach a runtime.
- **`runtime:<environment-id>` is resolved against the paired-environment store.** An id no paired environment owns is rejected:
  `Unknown Orca server in --host runtime:xyz: no paired environment has id xyz. Run 'orca environment list' ...`
  Matching is by environment **id** only — names are not accepted, since `runtime:<id>` is minted from the id.
- **A known id selects that environment as the connection.** The command runs on that server, so `_meta.runtimeId` is the server's, `client.isRemote` is true (remote path validation now applies), and mutations land there. Combining it with `--pairing-code`, or with an `--environment` naming a different server, is an error.
- **Once routed, a host filter also accepts that runtime's `local`-stamped rows.** A runtime stamps setups `local` when they were created on the box and `runtime:<id>` when a paired client created them; both name the machine we are now connected to. For *selection* (`worktree create` / `automations create` via `--project` + `--host`) an exact `runtime:<id>` match still wins over a `local` row.

Applies to every command that takes `--host`: `project setups`, `project setup-existing-folder`, `project setup-clone`, `project setup-create`, `worktree create`, `automations create/edit`. Command notes and `agent-context` schema text updated to describe the routing.

## Why

`runtime:<environment-id>` ids are minted by `addEnvironmentFromPairingCode` as a client-local `randomUUID()`. They only name a machine *relative to this machine's pairing store*, so they are meaningless as a filter over the locally connected runtime's rows — and there is no runtime RPC that can tell the CLI whether such a host exists. That is exactly why an empty result was ambiguous.

The desktop already routes by host id (`getProjectSetupRuntimeTarget(args.hostId)` in `store/slices/repos.ts` picks the environment target from the `runtime:` prefix). This makes the CLI agree with the client that already gets it right, rather than inventing a third interpretation.

Both defects the report asked for are covered by the one rule: unknown runtime ids are rejected instead of returning empty-success, and `--host runtime:` is routed rather than silently falling back to local.

## Linked Issue

N/A — reported directly; happy to file and link a tracking issue if preferred.

## Visual Proof

N/A — CLI-only change, no UI surface.

### Before

```
$ orca project setups --host runtime:<real-env-id>
{"ok":true,"result":{"setups":[]},"_meta":{"runtimeId":"<LOCAL runtime>"}}

$ orca project setups --host runtime:<nonexistent-id>
{"ok":true,"result":{"setups":[]},"_meta":{"runtimeId":"<LOCAL runtime>"}}
```

### After

```
$ orca project setups --host runtime:<real-env-id>
# connects to that server; _meta.runtimeId is the server's

$ orca project setups --host runtime:<nonexistent-id>
invalid_argument: Unknown Orca server in --host runtime:<nonexistent-id>:
no paired environment has id <nonexistent-id>. Run `orca environment list`
to see paired servers, or pass --host local.

$ orca project setups --host runtime:
invalid_argument: Invalid --host value: runtime:. Expected local,
ssh:<target-id>, or runtime:<environment-id>.
```

## Testing

- `pnpm exec vitest run --config config/vitest.config.ts src/cli` — 86 files / 840 tests pass.
- `pnpm run typecheck`, `oxlint` (base + code-quality native + type-aware), max-lines ratchet — clean.
- New `src/cli/execution-host-flag.test.ts` (18 tests) covers parsing, id-not-name resolution, percent-encoded ids, `--pairing-code` / `--environment` conflicts, and the local/runtime filter equivalence.
- New `index-project-setup.test.ts` cases assert the unknown-id rejection, the malformed-value rejection, and that neither reaches the runtime (`callMock` not called).
- The existing "rejects remote project setup relative paths" case no longer needs a hand-fed `--pairing-code`: routing alone now makes the connection remote, which is the behavior change in miniature.
- Platform: exercised on macOS. No platform-specific code paths; the resolution reads the same environment store the client already reads on all platforms.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

<!-- DO NOT FILL IN IF YOU ARE STABLYAI TEAM MEMBER (INTERNAL CONTRIBUTOR), IGNORE SECTION: -->

## Review

Two judgment calls worth a second opinion:

1. **Routing vs. rejecting.** The report offered either. I routed, because the desktop already does and because rejecting would leave `--host runtime:` with no way to do the thing it looks like it does. The cost is that `--host` now influences *which machine* a command runs on, not just what it filters.
2. **The `local` ⇔ `runtime:<id>` equivalence after routing.** This mirrors `setupWithFetchedOwner`. Without it, `--host runtime:X` would miss setups created on X itself. Exact matches still take precedence in selection so a `local` row cannot shadow the named one.

## Agent skill upstream boundary

N/A — no skill content changed.


---

## Review round (Sol + Grok)

Two independent frontier-model reviews. What they found and what I did:

**Fixed in `378221b`:**
- **Ambient `ORCA_ENVIRONMENT` was not conflict-checked** (Grok, confirmed). `ORCA_ENVIRONMENT=staging orca ... --host runtime:<prod-id>` silently routed to prod, while the `--environment staging` flag spelling errored. Same intent, different outcome. Now both are checked. An ambient pairing code still loses to the explicit flag, because it can't be resolved to an id to compare — noted in the code.
- **Four documented examples used `--host runtime:gpu`** (Grok, confirmed). `gpu` is an environment *name*; matching is id-only, so every one of those documented commands would now be rejected. Replaced with an id and the specs now say outright that names are not accepted.
- **`--json` errors weren't machine-recoverable** (Grok). The unknown-id error now carries `error.data.knownEnvironments` plus `nextSteps`, matching the existing `unknownFlagData` convention. Kept the `invalid_argument` code for consistency with how an unknown `--environment` already fails.
- **Missing coverage on the mutating paths** (Grok, confirmed). `worktree create` and `automations create` asserted RPC args but never that the command actually reached the remote — a regression that stayed local would have passed. Both now assert the routed connection, plus a `--environment X --host local` filter-only case and `error.code`/`error.data` assertions.

**Fixed in `8879bb0` (found while verifying):** `execution-host-flag.ts` is now a sixth module on the `--help` path, but the `runtime-client-deferral` guard only pinned five. Added it, and verified the assertion actually fails when the import is flipped to the barrel.

**Refuted:** Sol reported that the new static import drags `zod` onto the `--help` path. It does not. `runtime/types` reaches `runtime-rpc-envelope` only through `import type`/`export type` (erased), `orchestration-compatibility-evidence` has no imports at all, and `runtime/types` was *already* eager via `args.ts`. Measured the eager graph directly: 54 modules, bare deps `node:fs, node:os, node:path`, no zod/ws/tweetnacl.

**Accepted as a known limitation, follow-up filed as #15366:** both reviewers flagged that a `runtime:<id>` stamp is client-minted, so (a) two clients paired with the same server stamp rows with different ids and don't see each other's, and (b) the CLI running *on* a paired server rejects an id that appears in its own rows. Both predate this PR — the old behavior was to silently answer for the wrong machine, which is strictly worse. The real fix is to normalize the stamp at the source (the runtime persisting `local` for its own disk) rather than widen the client-side filter, which would break the nested-pairing case. That's a main-process data-model change and out of scope here — filed as #15366 with the two-client and server-side-lookup cases written up.

**Also out of scope:** the CLI does not capability-gate `projectHostSetup.*` the way the renderer does with `assertProjectHostSetupRuntimeCapability`. That gap already exists on the `--environment` path; it should be closed once for both, not bolted onto the `--host` path.
