### PR TITLE
feat(terminal): add a "Report mouse clicks & drags" toggle

### DIFF
--- a/src/renderer/src/components/settings/TerminalInteractionSection.tsx
+++ b/src/renderer/src/components/settings/TerminalInteractionSection.tsx
@@ -244,6 +244,47 @@ export function TerminalInteractionSection({
           </div>
         </SearchableSetting>
 
+        <SearchableSetting
+          title={translate(
+            'auto.components.settings.TerminalInteractionSection.reportMouseClicks.title',
+            'Report mouse clicks & drags'
+          )}
+          description={translate(
+            'auto.components.settings.TerminalInteractionSection.reportMouseClicks.description',
+            'Send clicks and drags to mouse-aware terminal apps. Turn off to always select text with the mouse; the scroll wheel still reports, and Alt-click forces a report.'
+          )}
+          keywords={[
+            'mouse',
+            'click',
+            'drag',
+            'report',
+            'reporting',
+            'selection',
+            'select',
+            'tui',
+            'iterm',
+            'tracking'
+          ]}
+        >
+          <SettingsSwitchRow
+            label={translate(
+              'auto.components.settings.TerminalInteractionSection.reportMouseClicks.title',
+              'Report mouse clicks & drags'
+            )}
+            description={translate(
+              'auto.components.settings.TerminalInteractionSection.reportMouseClicks.switch',
+              'Off keeps clicks and drags local for selection; the scroll wheel still reports, and Alt-click forces a report.'
+            )}
+            checked={settings.terminalReportMouseClicksAndDrags !== false}
+            onChange={() =>
+              updateSettings({
+                terminalReportMouseClicksAndDrags:
+                  settings.terminalReportMouseClicksAndDrags === false
+              })
+            }
+          />
+        </SearchableSetting>
+
         {matchesSettingsSearch(searchQuery, getTerminalRightClickToPasteSearchEntry()) ? (
           <SearchableSetting
             title={translate(

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.test.ts
@@ -203,6 +203,27 @@ describe('applyTerminalAppearance theme assignment', () => {
     expect(pane.terminal.options.fontWeightBold).toBe(800)
   })
 
+  it('requires Alt for mouse reports only when click/drag reporting is switched off', () => {
+    const pane = makePane(1)
+    const settings = getDefaultSettings('/tmp')
+
+    apply(pane, { ...settings, terminalReportMouseClicksAndDrags: false })
+    expect(pane.terminal.options.mouseEventsRequireAlt).toBe(true)
+
+    apply(pane, { ...settings, terminalReportMouseClicksAndDrags: true })
+    expect(pane.terminal.options.mouseEventsRequireAlt).toBe(false)
+  })
+
+  it('reports mouse clicks when the setting is absent (existing users see no change)', () => {
+    const pane = makePane(1)
+    const settings = getDefaultSettings('/tmp')
+    delete settings.terminalReportMouseClicksAndDrags
+
+    apply(pane, settings)
+
+    expect(pane.terminal.options.mouseEventsRequireAlt).toBe(false)
+  })
+
   it('still assigns a fresh theme when composed values actually change', () => {
     const pane = makePane(1)
     const settings = getDefaultSettings('/tmp')

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.ts
@@ -205,6 +205,9 @@ export function applyTerminalAppearance(
     )
     // Why only 'true': 'left'/'right' are handled in the keydown policy, which needs Option composable at the xterm level.
     pane.terminal.options.macOptionIsMeta = effectiveMacOptionAsAlt === 'true'
+    // Why default true: withholding click/drag reports is opt-in; xterm exempts the wheel, so scroll still reports.
+    pane.terminal.options.mouseEventsRequireAlt =
+      settings.terminalReportMouseClicksAndDrags === false
     // Why unconditional: the helper no-ops when addon state already matches, so this keeps new panes and live toggles in sync.
     manager.setPaneLigaturesEnabled(pane.id, ligaturesEnabled)
     const transport = paneTransports.get(pane.id)

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -10557,7 +10557,12 @@
         },
         "TerminalInteractionSection": {
           "567633ff50": "Right-click pastes the clipboard into the terminal. Control-click to open the context menu.",
-          "c64497148a": "Right-click pastes the clipboard. Control-click opens the context menu."
+          "c64497148a": "Right-click pastes the clipboard. Control-click opens the context menu.",
+          "reportMouseClicks": {
+            "title": "Report mouse clicks & drags",
+            "description": "Send clicks and drags to mouse-aware terminal apps. Turn off to always select text with the mouse; the scroll wheel still reports, and Alt-click forces a report.",
+            "switch": "Off keeps clicks and drags local for selection; the scroll wheel still reports, and Alt-click forces a report."
+          }
         },
         "MobileRelayStatusSection": {
           "registered": "Registered",

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -209,6 +209,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     terminalFastScrollSensitivity: 5,
     terminalTuiScrollSensitivity: 1,
     terminalTuiScrollSensitivityDefaultedToOne: true,
+    terminalReportMouseClicksAndDrags: true,
     // Why: "auto" uses WebGL when supported, falling back to DOM on renderer failure or software/unknown GPU.
     terminalGpuAcceleration: 'auto',
     // Why 'auto': enable ligatures only for known ligature fonts, never forced. Resolver in shared/terminal-ligatures.ts.

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -145,6 +145,10 @@ export type GlobalSettings = {
   terminalPaddingX?: number
   terminalPaddingY?: number
   terminalMouseHideWhileTyping?: boolean
+  /** When false, click/drag reports are withheld from mouse-aware TUIs so the
+   *  mouse always drives local selection; the scroll wheel still reports. Maps
+   *  to xterm's mouseEventsRequireAlt, so Alt still forces a report. */
+  terminalReportMouseClicksAndDrags?: boolean
   terminalWordSeparator?: string
   terminalCursorOpacity?: number
   terminalQuickCommands?: TerminalQuickCommand[]


### PR DESCRIPTION
## ELI5

When a terminal app like vim or tmux turns on mouse support, clicking and dragging gets sent to that app instead of selecting text. This adds a switch to turn that off, so the mouse always selects text — while the scroll wheel keeps working. It's the same idea as iTerm2's "Report mouse clicks & drags" setting.

## What Changed

- New terminal setting `terminalReportMouseClicksAndDrags` (default `true`, so nothing changes for existing users).
- When off, click/drag reports are withheld from mouse-aware TUIs and the mouse drives local text selection instead. The scroll wheel still reports, and Alt-click still forces a report.
- Added a "Report mouse clicks & drags" toggle in Terminal → Terminal Interaction settings.

## Why

Mouse-tracking TUIs capture every click and drag, so selecting text means remembering to hold a modifier. Turning reporting off makes selection the default gesture again without losing wheel scrolling in the same app.

The setting maps to xterm's existing `mouseEventsRequireAlt` option. xterm's mouse-report path exempts the wheel branch, so setting it suppresses click/drag reports while leaving wheel reports intact, and `_syncMouseModeState` re-enables local selection in that state. Orca already toggles this option transiently for link clicks, so the persistent baseline composes cleanly. Applied live to open panes through `applyTerminalAppearance`, so it takes effect without recreating terminals.

Known difference from iTerm2: `mouseEventsRequireAlt` still lets Alt force a report, whereas iTerm2's toggle is a hard "never." The Alt bypass is arguably a feature; exact parity would need filtering outgoing report bytes or an xterm patch.

## Linked Issue

Fixes #15367

## Visual Proof

<img width="1066" height="78" alt="image" src="https://github.com/user-attachments/assets/488bbeb0-ef31-41e3-8cf3-ff6203f8bf5d" />

The change adds one toggle row to Terminal → Terminal Interaction, below "Scroll Speed". Behaviorally, with the toggle off a plain click-drag selects text in a mouse-tracking TUI instead of being reported to it; the wheel still scrolls the TUI.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Added unit coverage in `terminal-appearance.test.ts` asserting the option mapping in `applyTerminalAppearance`: `false` → `mouseEventsRequireAlt === true`, `true` → `false`, and absent (existing users) → `false`. The wheel-exemption itself is xterm's own behavior and isn't re-tested here.

## AI Disclosure

Implemented with Claude Code (Anthropic Claude Opus).

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance.

- Cross-platform: renderer-side xterm option, no platform-specific code paths.
- Remote/SSH: no wire change — the option is applied client-side to the local xterm instance, nothing crosses the client/host boundary.
- Backwards compatibility: setting is optional and read as `=== false`, so absent means on; no migration needed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
