### PR TITLE
fix(workspace-cleanup): read git for a pinned workspace before deleting it

### DIFF
--- a/src/main/ipc/workspace-cleanup-broad-scan.test.ts
+++ b/src/main/ipc/workspace-cleanup-broad-scan.test.ts
@@ -132,6 +132,16 @@ function makeStore(repos: Repo[] = [REPO], allMeta: Record<string, WorktreeMeta>
   } as unknown as Store
 }
 
+/** `repo-1::/repo-old` is in the shared fixture map, so pinning it needs a getWorktreeMeta override. */
+function makePinnedStore(): Store {
+  const pinned = makeWorktreeMeta({ isPinned: true, lastActivityAt: NOW - 40 * DAY_MS })
+  return {
+    ...makeStore(),
+    getWorktreeMeta: (worktreeId: string) =>
+      worktreeId === 'repo-1::/repo-old' ? pinned : META_BY_WORKTREE_ID[worktreeId]
+  } as Store
+}
+
 describe('workspace cleanup broad scan opt-in', () => {
   beforeEach(() => {
     vi.useFakeTimers()
@@ -228,6 +238,34 @@ describe('workspace cleanup broad scan opt-in', () => {
         })
       ])
     )
+  })
+
+  it('skips git for a pinned workspace on a broad scan, which is the cost saving', async () => {
+    const store = makePinnedStore()
+
+    await scanWorkspaceCleanup(store, { includeAllWorkspaces: true })
+
+    expect(getStatusMock).not.toHaveBeenCalledWith(
+      expect.stringContaining('/repo-old'),
+      expect.anything()
+    )
+  })
+
+  it('reads git for a pinned workspace on a targeted preflight, which decides force-removal', async () => {
+    // Why this matters: `pinned` is not a queue blocker, so a pinned idle workspace is
+    // hand-selectable today, and removal forces whenever git is unknown. Skipping the
+    // forced read meant it could be force-deleted with no evidence ever obtained.
+    const worktreeId = 'repo-1::/repo-old'
+
+    const result = await scanWorkspaceCleanup(makePinnedStore(), { worktreeIds: [worktreeId] })
+
+    expect(getStatusMock).toHaveBeenCalledWith(
+      expect.stringContaining('/repo-old'),
+      expect.anything()
+    )
+    const pinned = result.candidates.find((candidate) => candidate.worktreeId === worktreeId)
+    expect(pinned?.blockers).toContain('pinned')
+    expect(pinned?.git.checkedAt).not.toBeNull()
   })
 
   it('keeps the legacy suggestion-only projection when the flag is absent', async () => {

--- a/src/main/ipc/workspace-cleanup-candidate.ts
+++ b/src/main/ipc/workspace-cleanup-candidate.ts
@@ -192,11 +192,16 @@ function shouldReadWorkspaceCleanupGitEvidence(args: {
   if ((skipGit && !forceGitCheck) || repoIsFolder || worktree.isMainWorktree) {
     return false
   }
-  if (
-    blockers.includes('pinned') ||
-    blockers.includes('main-worktree') ||
-    blockers.includes('folder-repo')
-  ) {
+  // Why pinned sits with the cost skips and not the refusals: a pinned workspace is
+  // still queueable (`pinned` is not a queue blocker), so it can reach removal -- and
+  // removal forces whenever git is unknown. Skipping its git read on a broad scan is a
+  // fair saving; skipping it on the confirm-time forced read meant deleting with no
+  // evidence ever obtained. main-worktree and folder-repo stay unconditional: those are
+  // refused before removal, so reading git for them is pure cost.
+  if (blockers.includes('pinned') && !forceGitCheck) {
+    return false
+  }
+  if (blockers.includes('main-worktree') || blockers.includes('folder-repo')) {
     return false
   }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​38 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​38 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 |

<!-- /orca-pr-loc -->

## ELI5

If you pin a workspace and then delete it from the cleanup dialog, Orca never checks whether it has uncommitted work first — and because "we don't know" counts as "force delete", it removes it the destructive way. This makes the check actually run for pinned workspaces at the moment it matters.

## What Changed

One clause moved in `shouldReadWorkspaceCleanupGitEvidence` (`src/main/ipc/workspace-cleanup-candidate.ts`). `pinned` now sits with the cost skips, where `forceGitCheck` overrides it, instead of with the unconditional refusals.

```
- if (blockers.includes('pinned') || blockers.includes('main-worktree') || blockers.includes('folder-repo')) return false
+ if (blockers.includes('pinned') && !forceGitCheck) return false
+ if (blockers.includes('main-worktree') || blockers.includes('folder-repo')) return false
```

## Why

The removal preflight re-scans every target with `forceGitCheck` set, precisely so the force/no-force decision is made on fresh evidence. That flag could not reach pinned rows: `pinned` was in a second clause evaluated after the `forceGitCheck` escape.

**This is live today, not a future problem.** I checked before writing it, because the plan this came from describes it as opening up once the verdict system is removed. It doesn't need that:

- `WORKSPACE_CLEANUP_QUEUE_BLOCKERS` is `{main-worktree, folder-repo, dismissed}` — `pinned` is **not** in it (`src/shared/workspace-cleanup.ts:164-168`).
- So `canQueueWorkspaceCleanupCandidate` passes for a pinned workspace with an inactivity reason, and the row checkbox uses exactly that predicate (`workspace-cleanup-candidate-row.tsx`).
- Its git stays `clean: null, checkedAt: null`, and `shouldForceWorkspaceCleanupRemoval` returns true whenever `clean !== true` or `checkedAt === null` (`src/shared/workspace-cleanup.ts:181-186`).

Net: hand-select a pinned idle workspace today and it is force-removed with no git evidence ever obtained. Uncommitted work in it is gone without anything having looked.

`main-worktree` and `folder-repo` stay unconditional deliberately — both are refused before removal, so reading git for them is pure cost with no decision riding on it. Pinned is the odd one out precisely because it is *not* refused.

## Linked Issue

No tracking issue. Found during the design review for the workspace-cleanup rework (`docs/workspace-cleanup-filter-apply-plan.md`, rev 10) and confirmed against the tree as already-reachable rather than hypothetical.

## Visual Proof

`N/A` — no rendered change. The difference is that a git read happens during the confirm-time preflight where it previously did not; nothing new is drawn.

## Testing

Two new cases in `workspace-cleanup-broad-scan.test.ts`, and the pair is the point:

| Test | Before the fix | After |
|---|---|---|
| reads git for a pinned workspace on a **targeted preflight** | **fails** — this is the hole | passes |
| skips git for a pinned workspace on a **broad scan** | passes | passes |

The second one exists so the performance saving cannot be quietly lost later: pinned rows are still skipped on the fleet-wide scan, which is the whole reason the skip was there. I ran both against the unfixed source and confirmed exactly that split — one red, one green.

One thing worth noting for whoever writes the next test here: `repo-1::/repo-old` is in the shared `META_BY_WORKTREE_ID` fixture, which takes precedence over the `allMeta` argument, so passing `isPinned` through `makeStore` is silently ignored. My first attempt did exactly that and the workspace was never pinned — the test passed for the wrong reason. There is now a `makePinnedStore()` helper with a comment saying why.

Gates: `pnpm typecheck`, `npx oxlint`, and 148 tests across the main-process and renderer cleanup suites — all clean.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

Worth confirming you agree pinned belongs with the cost skips rather than the refusals. The alternative reading is that pinned *should* block removal entirely — but that contradicts today's behaviour (it is already selectable) and the direction of the cleanup rework, where the user decides what to delete and Orca's job is to verify before destroying.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

- **Performance:** unchanged on broad scans, which is where the cost lives — a fleet scan of up to 500 worktrees still skips pinned rows. The extra read happens only for rows the user has actually selected for deletion.
- **SSH / remote:** the preflight scan already routes through the owning host's provider; a pinned SSH workspace now gets the same read as any other, over the same path.
- **Cross-platform:** no platform branches touched.
- **Backwards compatibility:** no wire or schema change.
- **Related:** this is the first of the destructive-path fixes from the reviewed plan. The larger one still to come is that a *failed* git read currently also routes to force-delete, which needs fail-closed handling plus an explicit per-row override.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test` pass locally

## Author

- X / Twitter: @BrennanKB5
