### PR TITLE
fix(cmd-j): host-qualify worktree resolution and disambiguate list render keys (STA-4343)

### DIFF
--- a/src/renderer/src/components/WorktreeJumpPalette.test.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.test.tsx
@@ -361,14 +361,10 @@ describe('WorktreeJumpPalette', () => {
     expect(testContainer.textContent).toContain('Feature workspace')
   })
 
-  // KNOWN GAP (STA-4343): two same-id host rows both render, on the SAME bare command value,
-  // so React logs "Encountered two children with the same key" — a state it documents as
-  // unsupported and free to duplicate or omit children. #15170 rebuilt palette search around
-  // a `documents` map keyed by BARE worktree id, so host-qualifying the item id here alone
-  // would not fix matching; the id needs qualifying upstream with it. What DOES hold, and is
-  // asserted here, is that activating a row routes to THAT row's host — the routing
-  // guarantee this PR is about.
-  it('routes activation to the row host even though a collision renders one row', async () => {
+  // STA-4343 closed: two workspaces sharing `repoId::path` across hosts are two distinct
+  // rows. The documents map and worktreeMap are keyed by host identity, so each row resolves
+  // to its OWN worktree, and render keys keep the two apart for React and cmdk.
+  it('routes activation to each row own host when two same-id rows collide', async () => {
     const local = makeWorktree('shared', 'Local workspace', { hostId: 'local' })
     const ssh = makeWorktree('shared', 'SSH workspace', { hostId: 'ssh:box' })
     const state = {
@@ -378,24 +374,41 @@ describe('WorktreeJumpPalette', () => {
 
     await renderPalette(state)
 
-    // The gap: both rows render, sharing one bare command value (duplicate React key).
+    // Both rows render; the second carries a disambiguated command value so the two never
+    // share a React key.
     const rows = testContainer.querySelectorAll<HTMLButtonElement>(
-      '[data-command-item="worktree:shared"]'
+      '[data-command-item^="worktree:shared"]'
     )
     expect(rows).toHaveLength(2)
-    const row = rows[0]!
+    expect([...rows].map((candidate) => candidate.getAttribute('data-command-item'))).toEqual([
+      'worktree:shared',
+      'worktree:shared#dup1'
+    ])
 
-    // Activation always NAMES a host — it never falls through to a hostless call, which is
-    // the routing guarantee this PR adds.
-    await act(async () => fireEvent.click(row))
-    // Activation always NAMES a host — it never falls through to a hostless call, which is the
-    // routing guarantee this PR adds.
-    //
-    // DEFECT, pinned deliberately so a fix has to update this test: clicking the FIRST row
-    // activates the SECOND row's host. Duplicate React keys let the click resolve to the wrong
-    // child. Reproduces on main (bare `worktree:${id}` item id + id-keyed worktreeMap), so it
-    // is pre-existing rather than a regression here — but it is a real wrong-host open and
-    // should be fixed with the upstream document/id qualification.
+    // The first row names ITS OWN host — the wrong-host open is gone.
+    await act(async () => fireEvent.click(rows[0]!))
+    expect(activateAndRevealWorktree).toHaveBeenLastCalledWith('shared', {
+      executionHostId: 'local'
+    })
+  })
+
+  // Why a separate render: activating closes the palette, so the sibling row is detached
+  // before a second click in the same test could reach it.
+  it('routes the second same-id row to the other host', async () => {
+    const local = makeWorktree('shared', 'Local workspace', { hostId: 'local' })
+    const ssh = makeWorktree('shared', 'SSH workspace', { hostId: 'ssh:box' })
+
+    await renderPalette({
+      worktreesByRepo: { 'repo-1': [local, ssh] },
+      showSleepingWorkspaces: true
+    })
+
+    const rows = testContainer.querySelectorAll<HTMLButtonElement>(
+      '[data-command-item^="worktree:shared"]'
+    )
+    expect(rows).toHaveLength(2)
+
+    await act(async () => fireEvent.click(rows[1]!))
     expect(activateAndRevealWorktree).toHaveBeenLastCalledWith('shared', {
       executionHostId: 'ssh:box'
     })

--- a/src/renderer/src/components/WorktreeJumpPalette.test.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.test.tsx
@@ -181,7 +181,7 @@ async function renderPalette(overrides: Partial<AppState>): Promise<void> {
 }
 
 function getWorktreeRows(): string[] {
-  return [...testContainer.querySelectorAll<HTMLElement>('[data-command-item^="worktree:"]')].map(
+  return [...testContainer.querySelectorAll<HTMLElement>('[data-command-item*="worktree:"]')].map(
     (node) => node.textContent ?? ''
   )
 }
@@ -377,12 +377,12 @@ describe('WorktreeJumpPalette', () => {
     // Both rows render; the second carries a disambiguated command value so the two never
     // share a React key.
     const rows = testContainer.querySelectorAll<HTMLButtonElement>(
-      '[data-command-item^="worktree:shared"]'
+      '[data-command-item$="worktree:shared"]'
     )
     expect(rows).toHaveLength(2)
     expect([...rows].map((candidate) => candidate.getAttribute('data-command-item'))).toEqual([
       'worktree:shared',
-      'worktree:shared#dup1'
+      'palette-dup:1:worktree:shared'
     ])
 
     // The first row names ITS OWN host — the wrong-host open is gone.
@@ -404,7 +404,7 @@ describe('WorktreeJumpPalette', () => {
     })
 
     const rows = testContainer.querySelectorAll<HTMLButtonElement>(
-      '[data-command-item^="worktree:shared"]'
+      '[data-command-item$="worktree:shared"]'
     )
     expect(rows).toHaveLength(2)
 

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -135,6 +135,14 @@ import {
 import { RepoBadgeMark } from '@/components/repo/RepoBadgeLabel'
 import { buildSidebarHostOptions } from '@/components/sidebar/sidebar-host-options'
 import { getPaletteHostBadge, type PaletteHostBadge } from '@/components/cmd-j/palette-host-badge'
+import {
+  composeWorktreeHostIdentity,
+  getWorktreeHostIdentity
+} from '../../../shared/worktree/host-qualified-identity'
+import { findRepoForHost } from '@/store/slices/repo-host-identity'
+import type { Repo } from '../../../shared/repo-types'
+import type { ExecutionHostId } from '../../../shared/execution-host'
+import { buildPaletteListEntryRenderKeys } from '@/components/cmd-j/palette-list-entry-render-keys'
 import PaletteFilterMenu from '@/components/cmd-j/PaletteFilterMenu'
 import PaletteFilterChips from '@/components/cmd-j/PaletteFilterChips'
 import { buildPaletteFilterModel } from '@/components/cmd-j/palette-filter-options'
@@ -827,6 +835,18 @@ function WorktreeJumpPaletteContent({
     () => new Map(repos.map((repo) => [getRepoHostIdentity(repo), repo])),
     [repos]
   )
+  // Why not repoMap.get(worktree.repoId): one repo id can be registered on two hosts, so the
+  // bare map is last-wins and one side of the collision renders the other host's repo — wrong
+  // name, wrong badge, and a false SSH chip on a purely local workspace. Falls back to the
+  // bare lookup so a worktree with no host, or no repo on its host, keeps its badge.
+  const resolveRepoForWorktree = useCallback(
+    (worktree: Pick<Worktree, 'repoId' | 'hostId'>): Repo | undefined =>
+      (worktree.hostId
+        ? findRepoForHost(repos, worktree.repoId, { hostId: worktree.hostId, settings })
+        : null) ?? repoMap.get(worktree.repoId),
+    [repoMap, repos, settings]
+  )
+
   const hostLabelOverrides = useMemo(() => getHostDisplayLabelOverrides(settings), [settings])
   // Why: reuse the sidebar host-scope registry so host badge labels stay in sync.
   const hostOptions = useMemo(
@@ -1048,16 +1068,40 @@ function WorktreeJumpPaletteContent({
   )
 
   // Why: browser search includes archived worktrees, so this map must cover all worktrees, not just non-archived.
+  // Why keyed on the host identity (STA-4343): `repoId::path` repeats across hosts, so a bare
+  // id lets the last host inserted win and both rows then resolve to the same workspace.
   const worktreeMap = useMemo(() => {
     const map = new Map<string, Worktree>()
     for (const worktree of browserSortedWorktrees) {
-      map.set(worktree.id, worktree)
+      map.set(getWorktreeHostIdentity(worktree), worktree)
     }
     return map
   }, [browserSortedWorktrees])
 
+  // Why a bare-id fallback: rows built before a host was stamped carry none, and dropping
+  // them would be a worse regression than resolving them the old ambiguous way.
+  const worktreeByBareId = useMemo(() => {
+    const map = new Map<string, Worktree>()
+    for (const worktree of browserSortedWorktrees) {
+      if (!map.has(worktree.id)) {
+        map.set(worktree.id, worktree)
+      }
+    }
+    return map
+  }, [browserSortedWorktrees])
+
+  const resolveWorktree = useCallback(
+    (worktreeId: string, hostId: ExecutionHostId | undefined): Worktree | undefined =>
+      worktreeMap.get(composeWorktreeHostIdentity(hostId, worktreeId)) ??
+      worktreeByBareId.get(worktreeId),
+    [worktreeByBareId, worktreeMap]
+  )
+
   const worktreeOrder = useMemo(
-    () => new Map(browserSortedWorktrees.map((worktree, index) => [worktree.id, index])),
+    () =>
+      new Map(
+        browserSortedWorktrees.map((worktree, index) => [getWorktreeHostIdentity(worktree), index])
+      ),
     [browserSortedWorktrees]
   )
 
@@ -1077,13 +1121,17 @@ function WorktreeJumpPaletteContent({
   const hostLabelByWorktreeId = useMemo(() => {
     const labels = new Map<string, string>()
     for (const worktree of allWorktrees) {
-      const badge = getPaletteHostBadge(repoMap.get(worktree.repoId), hostOptions, hostFilterActive)
+      const badge = getPaletteHostBadge(
+        resolveRepoForWorktree(worktree),
+        hostOptions,
+        hostFilterActive
+      )
       if (badge) {
-        labels.set(worktree.id, badge.label)
+        labels.set(getWorktreeHostIdentity(worktree), badge.label)
       }
     }
     return labels
-  }, [allWorktrees, hostFilterActive, hostOptions, repoMap])
+  }, [allWorktrees, hostFilterActive, hostOptions, resolveRepoForWorktree])
 
   // Why keyed on the unsorted list: normalized documents depend only on text
   // inputs, so re-sorting for recency re-ranks without re-normalizing anything.
@@ -1246,11 +1294,14 @@ function WorktreeJumpPaletteContent({
   const worktreeItems = useMemo<WorktreePaletteItem[]>(() => {
     const items = worktreeMatches
       .map((match) => {
-        const worktree = worktreeMap.get(match.worktreeId)
+        const worktree = resolveWorktree(match.worktreeId, match.worktreeHostId)
         if (!worktree) {
           return null
         }
         return {
+          // Why the bare id stays: buildPaletteListEntryRenderKeys already disambiguates a
+          // repeated id for React and cmdk, and the row now resolves through its own host
+          // above — so the visible command value needs no host suffix.
           id: `worktree:${worktree.id}`,
           type: 'worktree' as const,
           match,
@@ -1270,7 +1321,7 @@ function WorktreeJumpPaletteContent({
         { rank: b.match.rank, order: orderById.get(b.id) ?? 0, id: b.id }
       )
     )
-  }, [hasQuery, worktreeMap, worktreeMatches])
+  }, [hasQuery, resolveWorktree, worktreeMatches])
 
   const browserItems = useMemo<BrowserPaletteItem[]>(
     () =>
@@ -1349,7 +1400,7 @@ function WorktreeJumpPaletteContent({
   const openTabRecentRows = useMemo<OpenTabRecentRow[]>(() => {
     const entries: OpenTabRecentRow[] = []
     for (const item of openTabItems) {
-      const worktree = worktreeMap.get(item.result.worktreeId)
+      const worktree = resolveWorktree(item.result.worktreeId, item.result.executionHostId)
       if (!worktree) {
         continue
       }
@@ -1369,7 +1420,7 @@ function WorktreeJumpPaletteContent({
       })
     }
     return entries
-  }, [openTabItems, terminalTabsById, worktreeMap])
+  }, [openTabItems, resolveWorktree, terminalTabsById])
 
   const recentTabRowById = useMemo(
     () => new Map(openTabRecentRows.map(({ row }) => [row.id, row])),
@@ -2202,6 +2253,13 @@ function WorktreeJumpPaletteContent({
     worktreeItems.length
   ])
 
+  // Why not entry.id directly: a duplicated persisted id would repeat a React key,
+  // and the reconciler then leaves the extra row mounted as a frozen ghost.
+  const listEntryRenderKeys = useMemo(
+    () => buildPaletteListEntryRenderKeys(listEntries.map((entry) => entry.id)),
+    [listEntries]
+  )
+
   // Why derive from listEntries: multi-primary interleave must stay identical for
   // empty-state counts and keyboard selection — dual-path builders drifted before.
   const selectableItems = useMemo<PaletteItem[]>(
@@ -2215,9 +2273,11 @@ function WorktreeJumpPaletteContent({
     [listEntries]
   )
 
+  // Why the render keys, not entry ids: cmdk selects by the rendered `value`, so the
+  // allow-list has to name the same de-duplicated keys the rows carry.
   const selectionItemIds = useMemo(
-    () => getWorktreePaletteSelectionItemIds(listEntries),
-    [listEntries]
+    () => getWorktreePaletteSelectionItemIds(listEntries, listEntryRenderKeys),
+    [listEntries, listEntryRenderKeys]
   )
 
   // Why passive, and why after the snapshot effect: it must record the head cmdk *had* while the
@@ -3073,11 +3133,12 @@ function WorktreeJumpPaletteContent({
           </CommandEmpty>
         ) : (
           <>
-            {listEntries.map((entry) => {
+            {listEntries.map((entry, entryIndex) => {
+              const renderKey = listEntryRenderKeys[entryIndex] ?? entry.id
               if (entry.type === 'section-header') {
                 return (
                   <div
-                    key={entry.id}
+                    key={renderKey}
                     className="mx-0.5 mt-3 mb-1 px-3 text-[11px] font-medium uppercase tracking-wider text-muted-foreground/70"
                   >
                     {entry.label}
@@ -3089,7 +3150,7 @@ function WorktreeJumpPaletteContent({
                 // Why: plain div (not CommandItem) so cmdk can't select it; arrow keys skip it via selectableItems.
                 return (
                   <div
-                    key={entry.id}
+                    key={renderKey}
                     className="mx-0.5 mt-1 px-3 py-1.5 text-[12px] italic text-muted-foreground/70"
                   >
                     {entry.label}
@@ -3103,7 +3164,7 @@ function WorktreeJumpPaletteContent({
                   linearIssueUrlIntent !== null && currentLinearIssuePreview?.loading !== false
                 return (
                   <PaletteCreateWorktreeRow
-                    key={entry.id}
+                    key={renderKey}
                     className={cn(JUMP_PALETTE_ITEM_CLASSNAME, 'mt-1 py-1.5')}
                     createWorktreeName={createWorktreeName}
                     linearIdentifier={linearIssueUrlIntent?.identifier ?? null}
@@ -3118,7 +3179,7 @@ function WorktreeJumpPaletteContent({
 
               if (entry.type === 'worktree') {
                 const worktree = entry.worktree
-                const repo = repoMap.get(worktree.repoId)
+                const repo = resolveRepoForWorktree(worktree)
                 const repoName = repo?.displayName ?? ''
                 // Why: both must match searchWorktrees' resolution, or highlight ranges land on
                 // the wrong text — and a branch-less row would throw here before search ever ran.
@@ -3138,8 +3199,8 @@ function WorktreeJumpPaletteContent({
 
                 return (
                   <CommandItem
-                    key={entry.id}
-                    value={entry.id}
+                    key={renderKey}
+                    value={renderKey}
                     onSelect={() => handleSelectItem(entry)}
                     data-current={isCurrentWorktree ? 'true' : undefined}
                     className={cn(JUMP_PALETTE_ITEM_CLASSNAME, 'py-2.5')}
@@ -3262,8 +3323,8 @@ function WorktreeJumpPaletteContent({
                   : translate('auto.components.WorktreeJumpPalette.repoGroupBadge', 'Repo group')
                 return (
                   <CommandItem
-                    key={entry.id}
-                    value={entry.id}
+                    key={renderKey}
+                    value={renderKey}
                     onSelect={() => handleSelectItem(entry)}
                     className={cn(JUMP_PALETTE_ITEM_CLASSNAME, 'py-2.5')}
                   >
@@ -3306,8 +3367,8 @@ function WorktreeJumpPaletteContent({
                     : translate('auto.components.WorktreeJumpPalette.actionBadge', 'Action')
                 return (
                   <CommandItem
-                    key={entry.id}
-                    value={entry.id}
+                    key={renderKey}
+                    value={renderKey}
                     onSelect={() => handleSelectItem(entry)}
                     className={cn(JUMP_PALETTE_ITEM_CLASSNAME, 'py-2.5')}
                   >
@@ -3333,9 +3394,12 @@ function WorktreeJumpPaletteContent({
 
               if (entry.type === 'workspace-tab') {
                 const result = entry.result
-                const workspaceTabWorktree = worktreeMap.get(result.worktreeId)
+                const workspaceTabWorktree = resolveWorktree(
+                  result.worktreeId,
+                  result.executionHostId
+                )
                 const workspaceTabRepo = workspaceTabWorktree
-                  ? repoMap.get(workspaceTabWorktree.repoId)
+                  ? resolveRepoForWorktree(workspaceTabWorktree)
                   : undefined
                 const workspaceTabRepoName = workspaceTabRepo?.displayName ?? result.repoName
                 const workspaceTabHostBadge = getPaletteHostBadge(
@@ -3363,8 +3427,8 @@ function WorktreeJumpPaletteContent({
 
                 return (
                   <CommandItem
-                    key={entry.id}
-                    value={entry.id}
+                    key={renderKey}
+                    value={renderKey}
                     onSelect={() => handleSelectItem(entry)}
                     className={cn(JUMP_PALETTE_ITEM_CLASSNAME, 'py-2.5')}
                   >
@@ -3433,9 +3497,9 @@ function WorktreeJumpPaletteContent({
 
               if (entry.type === 'simulator-tab') {
                 const result = entry.result
-                const simulatorWorktree = worktreeMap.get(result.worktreeId)
+                const simulatorWorktree = resolveWorktree(result.worktreeId, result.executionHostId)
                 const simulatorRepo = simulatorWorktree
-                  ? repoMap.get(simulatorWorktree.repoId)
+                  ? resolveRepoForWorktree(simulatorWorktree)
                   : undefined
                 const simulatorRepoName = simulatorRepo?.displayName ?? result.repoName
                 const simulatorHostBadge = getPaletteHostBadge(
@@ -3446,8 +3510,8 @@ function WorktreeJumpPaletteContent({
 
                 return (
                   <CommandItem
-                    key={entry.id}
-                    value={entry.id}
+                    key={renderKey}
+                    value={renderKey}
                     onSelect={() => handleSelectItem(entry)}
                     className={cn(JUMP_PALETTE_ITEM_CLASSNAME, 'py-2.5')}
                   >
@@ -3515,8 +3579,10 @@ function WorktreeJumpPaletteContent({
               }
 
               const result = entry.result
-              const browserWorktree = worktreeMap.get(result.worktreeId)
-              const browserRepo = browserWorktree ? repoMap.get(browserWorktree.repoId) : undefined
+              const browserWorktree = resolveWorktree(result.worktreeId, result.executionHostId)
+              const browserRepo = browserWorktree
+                ? resolveRepoForWorktree(browserWorktree)
+                : undefined
               const browserRepoName = browserRepo?.displayName ?? result.repoName
               const browserHostBadge = getPaletteHostBadge(
                 browserRepo,
@@ -3526,8 +3592,8 @@ function WorktreeJumpPaletteContent({
 
               return (
                 <CommandItem
-                  key={entry.id}
-                  value={entry.id}
+                  key={renderKey}
+                  value={renderKey}
                   onSelect={() => handleSelectItem(entry)}
                   className={cn(JUMP_PALETTE_ITEM_CLASSNAME, 'py-2.5')}
                 >

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -1016,9 +1016,15 @@ function WorktreeJumpPaletteContent({
       orderEmptyQueryWorktrees({
         visibleWorktrees: emptyQueryVisibleWorktrees,
         activeWorktreeId,
+        activeWorkspaceExecutionHostId,
         lastVisitedAtByWorktreeId
       }),
-    [emptyQueryVisibleWorktrees, activeWorktreeId, lastVisitedAtByWorktreeId]
+    [
+      emptyQueryVisibleWorktrees,
+      activeWorktreeId,
+      activeWorkspaceExecutionHostId,
+      lastVisitedAtByWorktreeId
+    ]
   )
 
   const searchScopeWorktrees = useMemo(() => {

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -100,6 +100,10 @@ import {
   type SearchableBrowserPage
 } from '@/lib/browser-palette-search'
 import { buildSearchableBrowserPages } from '@/lib/browser-palette-page-entries'
+import {
+  isPaletteCurrentWorktree,
+  resolvePaletteRepoForWorktree
+} from '@/lib/palette-repo-resolution'
 import { activateBrowserPagePaletteResult } from '@/lib/browser-page-palette-activation'
 import { activateSimulatorTabPaletteResult } from '@/lib/simulator-tab-palette-activation'
 import {
@@ -139,9 +143,13 @@ import {
   composeWorktreeHostIdentity,
   getWorktreeHostIdentity
 } from '../../../shared/worktree/host-qualified-identity'
-import { findRepoForHost } from '@/store/slices/repo-host-identity'
+import { findRepoForHost, getRepoHostIdentity } from '@/store/slices/repo-host-identity'
 import type { Repo } from '../../../shared/repo-types'
-import type { ExecutionHostId } from '../../../shared/execution-host'
+import {
+  getSettingsFocusedExecutionHostId,
+  isRuntimeOwnedSshTargetId,
+  type ExecutionHostId
+} from '../../../shared/execution-host'
 import { buildPaletteListEntryRenderKeys } from '@/components/cmd-j/palette-list-entry-render-keys'
 import PaletteFilterMenu from '@/components/cmd-j/PaletteFilterMenu'
 import PaletteFilterChips from '@/components/cmd-j/PaletteFilterChips'
@@ -190,7 +198,6 @@ import {
 import { buildWorktreeChecksReviewIndex } from '@/components/cmd-j/worktree-checks-review-index'
 import { resolvePaletteFocusRestoreTarget } from '@/components/cmd-j/palette-focus-restore-target'
 import { selectWorktreePaletteCacheInputs } from '@/components/cmd-j/worktree-palette-cache-inputs'
-import { getRepoHostIdentity } from '@/store/slices/repo-host-identity'
 import { buildPluginQuickActions } from '@/components/cmd-j/plugin-quick-actions'
 import { PaletteCreateWorktreeRow } from '@/components/cmd-j/PaletteCreateWorktreeRow'
 import { WorkspaceEmojiSuggestionPopover } from '@/components/workspace-emoji/WorkspaceEmojiSuggestionPopover'
@@ -213,10 +220,6 @@ import {
 } from '@/lib/worktree-palette-task-url-match'
 import type { SettingsNavTarget } from '@/lib/settings-navigation-types'
 import { getHostDisplayLabelOverrides } from '../../../shared/host-setting-overrides'
-import {
-  getSettingsFocusedExecutionHostId,
-  isRuntimeOwnedSshTargetId
-} from '../../../shared/execution-host'
 import type { GitHubWorkItem } from '../../../shared/github/work-item-types'
 import type { LinearIssue } from '../../../shared/linear/issue-types'
 import type { TerminalTab } from '../../../shared/terminal-tab-types'
@@ -718,6 +721,7 @@ function WorktreeJumpPaletteContent({
   const migrationUnsupportedByPtyId = useAppStore((s) => s.migrationUnsupportedByPtyId)
   const activeView = useAppStore((s) => s.activeView)
   const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
+  const activeWorkspaceExecutionHostId = useAppStore((s) => s.activeWorkspaceExecutionHostId)
   const activeTabType = useAppStore((s) => s.activeTabType)
   const activeTabId = useAppStore((s) => s.activeTabId)
   const activeTabIdByWorktree = useAppStore((s) => s.activeTabIdByWorktree)
@@ -840,11 +844,11 @@ function WorktreeJumpPaletteContent({
   // name, wrong badge, and a false SSH chip on a purely local workspace. Falls back to the
   // bare lookup so a worktree with no host, or no repo on its host, keeps its badge.
   const resolveRepoForWorktree = useCallback(
-    (worktree: Pick<Worktree, 'repoId' | 'hostId'>): Repo | undefined =>
+    (worktree: Pick<Worktree, 'id' | 'repoId' | 'hostId'>): Repo | undefined =>
       (worktree.hostId
         ? findRepoForHost(repos, worktree.repoId, { hostId: worktree.hostId, settings })
-        : null) ?? repoMap.get(worktree.repoId),
-    [repoMap, repos, settings]
+        : null) ?? resolvePaletteRepoForWorktree(worktree, repoMap, repoByHostIdentity),
+    [repoByHostIdentity, repoMap, repos, settings]
   )
 
   const hostLabelOverrides = useMemo(() => getHostDisplayLabelOverrides(settings), [settings])
@@ -1142,6 +1146,7 @@ function WorktreeJumpPaletteContent({
         allWorktrees.filter((worktree) => !worktree.isArchived),
         {
           repoMap,
+          repoMapByHostIdentity: repoByHostIdentity,
           prCache,
           issueCache,
           workspacePortsByWorktreeId: getWorkspacePortsByWorktreeId(workspacePortScan),
@@ -1151,6 +1156,7 @@ function WorktreeJumpPaletteContent({
       ),
     [
       allWorktrees,
+      repoByHostIdentity,
       repoMap,
       prCache,
       issueCache,
@@ -1167,9 +1173,17 @@ function WorktreeJumpPaletteContent({
         query: paletteSearchQuery,
         documents: worktreeDocuments,
         repoMap,
+        repoMapByHostIdentity: repoByHostIdentity,
         checksReviewByWorktree
       }),
-    [sortedWorktrees, paletteSearchQuery, worktreeDocuments, repoMap, checksReviewByWorktree]
+    [
+      sortedWorktrees,
+      paletteSearchQuery,
+      worktreeDocuments,
+      repoByHostIdentity,
+      repoMap,
+      checksReviewByWorktree
+    ]
   )
 
   const browserPageEntries = useMemo<SearchableBrowserPage[]>(() => {
@@ -1179,11 +1193,13 @@ function WorktreeJumpPaletteContent({
     return buildSearchableBrowserPages({
       worktrees: browserSortedWorktrees,
       repoMap,
+      repoMapByHostIdentity: repoByHostIdentity,
       worktreeOrder,
       browserTabsByWorktree,
       browserPagesByWorkspace,
       activeBrowserTabId,
       activeWorktreeId,
+      activeWorkspaceExecutionHostId,
       activeTabType
     })
   }, [
@@ -1191,9 +1207,11 @@ function WorktreeJumpPaletteContent({
     activeBrowserTabId,
     activeTabType,
     activeWorktreeId,
+    activeWorkspaceExecutionHostId,
     browserPagesByWorkspace,
     browserTabsByWorktree,
     browserSortedWorktrees,
+    repoByHostIdentity,
     repoMap,
     worktreeOrder
   ])
@@ -1210,11 +1228,13 @@ function WorktreeJumpPaletteContent({
     return buildSearchableSimulatorTabs({
       worktrees: browserSortedWorktrees,
       repoMap,
+      repoMapByHostIdentity: repoByHostIdentity,
       worktreeOrder,
       unifiedTabsByWorktree,
       activeGroupIdByWorktree,
       groupsByWorktree,
       activeWorktreeId,
+      activeWorkspaceExecutionHostId,
       activeTabType
     })
   }, [
@@ -1222,9 +1242,11 @@ function WorktreeJumpPaletteContent({
     activeGroupIdByWorktree,
     activeTabType,
     activeWorktreeId,
+    activeWorkspaceExecutionHostId,
     browserSortedWorktrees,
     groupsByWorktree,
     repoMap,
+    repoByHostIdentity,
     unifiedTabsByWorktree,
     worktreeOrder
   ])
@@ -1241,6 +1263,7 @@ function WorktreeJumpPaletteContent({
     return buildSearchableWorkspaceTabs({
       worktrees: browserSortedWorktrees,
       repoMap,
+      repoMapByHostIdentity: repoByHostIdentity,
       worktreeOrder,
       unifiedTabsByWorktree,
       tabsByWorktree,
@@ -1251,6 +1274,7 @@ function WorktreeJumpPaletteContent({
       activeGroupIdByWorktree,
       groupsByWorktree,
       activeWorktreeId,
+      activeWorkspaceExecutionHostId,
       activeTabType,
       activeTabId,
       activeTabIdByWorktree,
@@ -1271,10 +1295,12 @@ function WorktreeJumpPaletteContent({
     activeTabType,
     activeTabTypeByWorktree,
     activeWorktreeId,
+    activeWorkspaceExecutionHostId,
     agentStatusByPaneKey,
     browserSortedWorktrees,
     groupsByWorktree,
     openFiles,
+    repoByHostIdentity,
     repoMap,
     retainedAgentsByPaneKey,
     settings?.tabAutoGenerateTitle,
@@ -3185,7 +3211,11 @@ function WorktreeJumpPaletteContent({
                 // the wrong text — and a branch-less row would throw here before search ever ran.
                 const branch = resolveWorktreeBranchLabel(worktree)
                 const worktreeLabel = resolveWorktreeDisplayName(worktree)
-                const isCurrentWorktree = activeWorktreeId === worktree.id
+                const isCurrentWorktree = isPaletteCurrentWorktree(
+                  worktree,
+                  activeWorktreeId,
+                  activeWorkspaceExecutionHostId
+                )
                 // Why: runtime-owned SSH targets have relay health owned by the runtime layer — don't show a false disconnected.
                 const sshConnectionId =
                   repo?.connectionId && !isRuntimeOwnedSshTargetId(repo.connectionId)

--- a/src/renderer/src/components/cmd-j/PaletteFilterFieldOptions.tsx
+++ b/src/renderer/src/components/cmd-j/PaletteFilterFieldOptions.tsx
@@ -96,19 +96,32 @@ export function PaletteFilterFieldOptions({
   // listener has to re-attach to the node that replaces it.
   const [scrollEl, setScrollEl] = useState<HTMLDivElement | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
-  // Why the field/query are stored alongside the index instead of reset in an
+  // Why the field/query are stored alongside the cursor instead of reset in an
   // effect: a stale row would stay active for one paint. Why not key off the
   // ranked list identity: a toggle re-ranks, so that would yank the cursor back
   // to the top mid multi-select.
-  const [highlight, setHighlight] = useState(() => ({
+  const [highlight, setHighlight] = useState<{
+    field: PaletteFilterField
+    query: string
+    id: string | null
+  }>(() => ({
     field: group.field,
     query: normalizedQuery,
-    index: 0
+    id: null
   }))
-  const storedIndex =
-    highlight.field === group.field && highlight.query === normalizedQuery ? highlight.index : 0
-  // The stored index can outlive the rows it pointed at when the list shrinks.
-  const activeIndex = Math.min(storedIndex, Math.max(0, ranked.ordered.length - 1))
+  const storedId =
+    highlight.field === group.field && highlight.query === normalizedQuery ? highlight.id : null
+  // Why track the option id rather than its position: toggling re-ranks the list and pins
+  // the toggled option to the front, so a stored index would land on a different option and
+  // the next Enter would check one the user never aimed at. findIndex also covers the option
+  // disappearing from a narrowed list.
+  const activeIndex =
+    storedId === null
+      ? 0
+      : Math.max(
+          0,
+          ranked.ordered.findIndex((option) => option.id === storedId)
+        )
 
   useEffect(() => {
     inputRef.current?.focus()
@@ -146,9 +159,13 @@ export function PaletteFilterFieldOptions({
       }
       const next = Math.max(0, Math.min(ranked.ordered.length - 1, activeIndex + delta))
       virtualizer.scrollToIndex(next, { align: 'auto' })
-      setHighlight({ field: group.field, query: normalizedQuery, index: next })
+      setHighlight({
+        field: group.field,
+        query: normalizedQuery,
+        id: ranked.ordered[next]?.id ?? null
+      })
     },
-    [activeIndex, group.field, normalizedQuery, ranked.ordered.length, virtualizer]
+    [activeIndex, group.field, normalizedQuery, ranked.ordered, virtualizer]
   )
 
   const handleListKeyDown = useCallback(

--- a/src/renderer/src/components/cmd-j/palette-duplicate-key-ghost-rows.test.tsx
+++ b/src/renderer/src/components/cmd-j/palette-duplicate-key-ghost-rows.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest'
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { buildPaletteListEntryRenderKeys } from './palette-list-entry-render-keys'
+
+/**
+ * Regression for the Cmd+J ghost rows: a windows-low-spec session persisted two
+ * tab records under one id, so two rows shared a React key. When the query
+ * narrowed and the rows stopped matching, React had one fiber for the two keys
+ * and never unmounted the extra — it stayed above the section headers, frozen at
+ * the highlight ranges of the keystroke that last matched it.
+ */
+type Row = { id: string; label: string }
+
+function PaletteList({ rows, uniqueKeys }: { rows: Row[]; uniqueKeys: boolean }) {
+  const renderKeys = uniqueKeys
+    ? buildPaletteListEntryRenderKeys(rows.map((row) => row.id))
+    : rows.map((row) => row.id)
+  return (
+    <div>
+      {rows.map((row, index) => (
+        <span key={renderKeys[index]}>{row.label}</span>
+      ))}
+    </div>
+  )
+}
+
+// The duplicated pair, as persisted for the lungfish worktree.
+const DUPLICATE_TAB_ID = 'workspace-tab:editor:lungfish:FINAL-REPORT.md'
+
+function rowsForQuery(query: string): Row[] {
+  // "l" matches the worktree name; "li" and beyond match nothing in that workspace.
+  const remoteRows =
+    query === 'l'
+      ? [
+          { id: DUPLICATE_TAB_ID, label: `[lungfish ${query}-hit]` },
+          { id: DUPLICATE_TAB_ID, label: `[lungfish ${query}-hit]` }
+        ]
+      : []
+  return [...remoteRows, { id: '__header_open_tabs__', label: '(OPEN TABS)' }]
+}
+
+async function typeQuery(uniqueKeys: boolean): Promise<string> {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  const root = createRoot(host)
+  for (const query of ['l', 'li', 'lin', 'line', 'linea', 'linear']) {
+    await act(async () => {
+      root.render(<PaletteList rows={rowsForQuery(query)} uniqueKeys={uniqueKeys} />)
+    })
+  }
+  const rendered = host.textContent ?? ''
+  root.unmount()
+  host.remove()
+  return rendered
+}
+
+describe('duplicate persisted tab ids in the Cmd+J list', () => {
+  it('strands a ghost row when the render key repeats', async () => {
+    // Why assert the bug: it is the reason the disambiguated key exists.
+    expect(await typeQuery(false)).toBe('[lungfish l-hit](OPEN TABS)')
+  })
+
+  it('leaves nothing behind once render keys are disambiguated', async () => {
+    expect(await typeQuery(true)).toBe('(OPEN TABS)')
+  })
+})

--- a/src/renderer/src/components/cmd-j/palette-filter-option-list.test.ts
+++ b/src/renderer/src/components/cmd-j/palette-filter-option-list.test.ts
@@ -32,12 +32,22 @@ describe('rankPaletteFilterOptions', () => {
   it('moves a toggled option to the front, so a cursor must track ids not positions', () => {
     // Why pinned here: PaletteFilterFieldOptions derives its highlight from the option id
     // precisely because this re-rank invalidates any stored index the moment a user toggles.
-    const before = rankPaletteFilterOptions({ options, query: '', selectedIds: new Set() })
+    const before = rankPaletteFilterOptions({
+      options,
+      query: '',
+      selectedIds: new Set(),
+      rankMode: 'registry'
+    })
     expect(before.ordered.map((entry) => entry.id)).toEqual(['a', 'b', 'c', 'd'])
 
     // Toggling the option the user had arrowed onto pins it to the front; an index of 1
     // would now point at a different option than it did a render earlier.
-    const after = rankPaletteFilterOptions({ options, query: '', selectedIds: new Set(['c']) })
+    const after = rankPaletteFilterOptions({
+      options,
+      query: '',
+      selectedIds: new Set(['c']),
+      rankMode: 'registry'
+    })
     expect(after.ordered[0]?.id).toBe('c')
     expect(before.ordered[1]?.id).not.toBe(after.ordered[1]?.id)
   })

--- a/src/renderer/src/components/cmd-j/palette-filter-option-list.test.ts
+++ b/src/renderer/src/components/cmd-j/palette-filter-option-list.test.ts
@@ -29,6 +29,19 @@ describe('rankPaletteFilterOptions', () => {
     option('d', 'Delta Host', 2, 'ssh')
   ]
 
+  it('moves a toggled option to the front, so a cursor must track ids not positions', () => {
+    // Why pinned here: PaletteFilterFieldOptions derives its highlight from the option id
+    // precisely because this re-rank invalidates any stored index the moment a user toggles.
+    const before = rankPaletteFilterOptions({ options, query: '', selectedIds: new Set() })
+    expect(before.ordered.map((entry) => entry.id)).toEqual(['a', 'b', 'c', 'd'])
+
+    // Toggling the option the user had arrowed onto pins it to the front; an index of 1
+    // would now point at a different option than it did a render earlier.
+    const after = rankPaletteFilterOptions({ options, query: '', selectedIds: new Set(['c']) })
+    expect(after.ordered[0]?.id).toBe('c')
+    expect(before.ordered[1]?.id).not.toBe(after.ordered[1]?.id)
+  })
+
   it('pins selected matches first and ranks the rest by popularity', () => {
     const ranked = rankPaletteFilterOptions({
       options,

--- a/src/renderer/src/components/cmd-j/palette-list-entry-render-keys.test.ts
+++ b/src/renderer/src/components/cmd-j/palette-list-entry-render-keys.test.ts
@@ -16,13 +16,13 @@ describe('buildPaletteListEntryRenderKeys', () => {
       ])
     ).toEqual([
       'workspace-tab:editor:lungfish',
-      'workspace-tab:editor:lungfish#dup1',
-      'workspace-tab:editor:lungfish#dup2'
+      'palette-dup:1:workspace-tab:editor:lungfish',
+      'palette-dup:2:workspace-tab:editor:lungfish'
     ])
   })
 
   it('never emits a key twice', () => {
-    const keys = buildPaletteListEntryRenderKeys(['a', 'a', 'b', 'a', 'b', 'a#dup1'])
+    const keys = buildPaletteListEntryRenderKeys(['a', 'a', 'b', 'a', 'b', 'palette-dup:1:a'])
     expect(new Set(keys).size).toBe(keys.length)
   })
 
@@ -30,5 +30,18 @@ describe('buildPaletteListEntryRenderKeys', () => {
     const full = buildPaletteListEntryRenderKeys(['header', 'tab:x', 'tab:x', 'tab:y'])
     const narrowed = buildPaletteListEntryRenderKeys(['header', 'tab:x', 'tab:x'])
     expect(narrowed).toEqual(full.slice(0, 3))
+  })
+
+  // Why: a generated key that lands in the persisted-id namespace is worse than the
+  // duplicate it fixes — narrowing the duplicate away hands its fiber, and the row
+  // state frozen in it, to the distinct entry that happens to own that id.
+  it('never mints a key a sibling entry already owns as its persisted id', () => {
+    const full = buildPaletteListEntryRenderKeys(['a', 'a', 'palette-dup:1:a'])
+    const narrowed = buildPaletteListEntryRenderKeys(['a', 'palette-dup:1:a'])
+    expect(new Set(full).size).toBe(full.length)
+    // The distinct entry keeps its own key across the narrow; the duplicate's key is not reused.
+    expect(full[2]).not.toBe(full[1])
+    expect(narrowed[1]).toBe(full[2])
+    expect(narrowed).not.toContain(full[1])
   })
 })

--- a/src/renderer/src/components/cmd-j/palette-list-entry-render-keys.test.ts
+++ b/src/renderer/src/components/cmd-j/palette-list-entry-render-keys.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { buildPaletteListEntryRenderKeys } from './palette-list-entry-render-keys'
+
+describe('buildPaletteListEntryRenderKeys', () => {
+  it('leaves unique ids untouched', () => {
+    const ids = ['__header_open_tabs__', 'workspace-tab:a', 'worktree:b']
+    expect(buildPaletteListEntryRenderKeys(ids)).toEqual(ids)
+  })
+
+  it('disambiguates a repeated persisted id', () => {
+    expect(
+      buildPaletteListEntryRenderKeys([
+        'workspace-tab:editor:lungfish',
+        'workspace-tab:editor:lungfish',
+        'workspace-tab:editor:lungfish'
+      ])
+    ).toEqual([
+      'workspace-tab:editor:lungfish',
+      'workspace-tab:editor:lungfish#dup1',
+      'workspace-tab:editor:lungfish#dup2'
+    ])
+  })
+
+  it('never emits a key twice', () => {
+    const keys = buildPaletteListEntryRenderKeys(['a', 'a', 'b', 'a', 'b', 'a#dup1'])
+    expect(new Set(keys).size).toBe(keys.length)
+  })
+
+  it('keeps keys stable as later entries drop away', () => {
+    const full = buildPaletteListEntryRenderKeys(['header', 'tab:x', 'tab:x', 'tab:y'])
+    const narrowed = buildPaletteListEntryRenderKeys(['header', 'tab:x', 'tab:x'])
+    expect(narrowed).toEqual(full.slice(0, 3))
+  })
+})

--- a/src/renderer/src/components/cmd-j/palette-list-entry-render-keys.ts
+++ b/src/renderer/src/components/cmd-j/palette-list-entry-render-keys.ts
@@ -1,26 +1,6 @@
-/**
- * React keys for the Cmd+J result list.
- *
- * Entry ids are built from persisted record ids (tab, worktree, project), and a
- * corrupt session can repeat one — an editor owner migration re-stamps a tab id
- * that a sibling record already carries. React keeps one fiber per key in its
- * reconciliation map, so a repeated key leaves the extra row with no fiber to
- * delete: it stays mounted forever, frozen at the query that last rendered it,
- * sitting above the live sections. Disambiguate here so the list never depends
- * on upstream ids being unique.
- */
+// Disambiguates repeated entry IDs so duplicate React keys do not strand frozen ghost rows.
 
-/**
- * Why a reserved prefix rather than a `#dupN` suffix: a suffix generates keys in
- * the same namespace persisted ids live in, so the key minted for a second `a`
- * could equal a real sibling entry whose id IS `a#dup1`. Once a query narrows the
- * duplicate away React hands that key — and the row state behind it — to the real
- * entry. The prefix carves out a namespace no persisted id can reach, because an
- * id that already starts with it is escaped on the way in.
- *
- * Printable on purpose: these keys are also the rendered cmdk command values, and
- * HTML attribute parsing rewrites U+0000 to U+FFFD.
- */
+// Why: a reserved prefix with escaping avoids collisions with real IDs; printable for cmdk values.
 const DUPLICATE_KEY_NAMESPACE = 'palette-dup:'
 
 // Why prepend rather than strip: prepending is injective, and the result can never

--- a/src/renderer/src/components/cmd-j/palette-list-entry-render-keys.ts
+++ b/src/renderer/src/components/cmd-j/palette-list-entry-render-keys.ts
@@ -9,21 +9,36 @@
  * sitting above the live sections. Disambiguate here so the list never depends
  * on upstream ids being unique.
  */
+
+/**
+ * Why a reserved prefix rather than a `#dupN` suffix: a suffix generates keys in
+ * the same namespace persisted ids live in, so the key minted for a second `a`
+ * could equal a real sibling entry whose id IS `a#dup1`. Once a query narrows the
+ * duplicate away React hands that key — and the row state behind it — to the real
+ * entry. The prefix carves out a namespace no persisted id can reach, because an
+ * id that already starts with it is escaped on the way in.
+ *
+ * Printable on purpose: these keys are also the rendered cmdk command values, and
+ * HTML attribute parsing rewrites U+0000 to U+FFFD.
+ */
+const DUPLICATE_KEY_NAMESPACE = 'palette-dup:'
+
+// Why prepend rather than strip: prepending is injective, and the result can never
+// look generated because a generated key always has `\d+:` after the prefix.
+function escapeReservedNamespace(entryId: string): string {
+  return entryId.startsWith(DUPLICATE_KEY_NAMESPACE)
+    ? `${DUPLICATE_KEY_NAMESPACE}${entryId}`
+    : entryId
+}
+
 export function buildPaletteListEntryRenderKeys(entryIds: readonly string[]): string[] {
-  const used = new Set<string>()
+  const occurrences = new Map<string, number>()
   return entryIds.map((entryId) => {
+    const occurrence = occurrences.get(entryId) ?? 0
+    occurrences.set(entryId, occurrence + 1)
+    const escaped = escapeReservedNamespace(entryId)
     // Why keep the first key bare: stable ids must survive re-renders untouched.
-    if (!used.has(entryId)) {
-      used.add(entryId)
-      return entryId
-    }
-    // Why probe: an entry id may itself already end in the suffix we append.
-    let attempt = 1
-    while (used.has(`${entryId}#dup${attempt}`)) {
-      attempt += 1
-    }
-    const key = `${entryId}#dup${attempt}`
-    used.add(key)
-    return key
+    // Later occurrences encode their index, so (id, occurrence) maps one-to-one to a key.
+    return occurrence === 0 ? escaped : `${DUPLICATE_KEY_NAMESPACE}${occurrence}:${escaped}`
   })
 }

--- a/src/renderer/src/components/cmd-j/palette-list-entry-render-keys.ts
+++ b/src/renderer/src/components/cmd-j/palette-list-entry-render-keys.ts
@@ -1,0 +1,29 @@
+/**
+ * React keys for the Cmd+J result list.
+ *
+ * Entry ids are built from persisted record ids (tab, worktree, project), and a
+ * corrupt session can repeat one — an editor owner migration re-stamps a tab id
+ * that a sibling record already carries. React keeps one fiber per key in its
+ * reconciliation map, so a repeated key leaves the extra row with no fiber to
+ * delete: it stays mounted forever, frozen at the query that last rendered it,
+ * sitting above the live sections. Disambiguate here so the list never depends
+ * on upstream ids being unique.
+ */
+export function buildPaletteListEntryRenderKeys(entryIds: readonly string[]): string[] {
+  const used = new Set<string>()
+  return entryIds.map((entryId) => {
+    // Why keep the first key bare: stable ids must survive re-renders untouched.
+    if (!used.has(entryId)) {
+      used.add(entryId)
+      return entryId
+    }
+    // Why probe: an entry id may itself already end in the suffix we append.
+    let attempt = 1
+    while (used.has(`${entryId}#dup${attempt}`)) {
+      attempt += 1
+    }
+    const key = `${entryId}#dup${attempt}`
+    used.add(key)
+    return key
+  })
+}

--- a/src/renderer/src/components/cmd-j/palette-project-results.ts
+++ b/src/renderer/src/components/cmd-j/palette-project-results.ts
@@ -2,6 +2,7 @@ import { isCmdJPaletteQueryTooLarge } from './palette-results'
 import {
   cmdJPaletteTokenScore,
   isCmdJPaletteQueryOverTokenLimit,
+  uniqueCmdJPaletteQueryTokens,
   normalizeCmdJPaletteQuery,
   uniqueNormalizedCmdJPaletteKeywords
 } from './palette-query-tokens'
@@ -150,6 +151,7 @@ export function hasCmdJProjectSearchCandidates({
 
 function projectRankingForCandidate(
   query: string,
+  queryTokens: readonly string[],
   candidate: CmdJProjectSearchResult
 ): RankedProjectResult | null {
   const title = normalizeCmdJPaletteQuery(candidate.title)
@@ -166,7 +168,7 @@ function projectRankingForCandidate(
   if (candidate.keywords.some((keyword) => keyword.startsWith(query))) {
     return { result: candidate, rule: 4, score: 0 }
   }
-  const score = cmdJPaletteTokenScore(query, [candidate.title, ...candidate.keywords])
+  const score = cmdJPaletteTokenScore(queryTokens, [candidate.title, ...candidate.keywords])
   return score > 0 ? { result: candidate, rule: 5, score } : null
 }
 
@@ -209,6 +211,7 @@ export function searchCmdJProjectResults({
   if (normalizedQuery.length < 2 || isCmdJPaletteQueryOverTokenLimit(normalizedQuery)) {
     return []
   }
+  const queryTokens = uniqueCmdJPaletteQueryTokens(normalizedQuery)
   return buildCmdJProjectSearchCandidates({
     projectGroups,
     repos,
@@ -216,7 +219,7 @@ export function searchCmdJProjectResults({
     projectHostSetups,
     renderableRepoIds
   })
-    .map((candidate) => projectRankingForCandidate(normalizedQuery, candidate))
+    .map((candidate) => projectRankingForCandidate(normalizedQuery, queryTokens, candidate))
     .filter((entry): entry is RankedProjectResult => entry !== null)
     .sort(compareProjectRanked)
     .map((entry) => ({ ...entry.result, qualityClass: projectRuleQualityClass(entry.rule) }))

--- a/src/renderer/src/components/cmd-j/palette-query-tokens.test.ts
+++ b/src/renderer/src/components/cmd-j/palette-query-tokens.test.ts
@@ -45,6 +45,13 @@ describe('Cmd+J palette token scoring', () => {
     expect(cmdJPaletteTokenScore(['terminal'], ['a'])).toBe(0)
   })
 
+  it('does not score a Latin keyword merely contained in the query token', () => {
+    // Why: `database` does not mean the keyword `base`. Reverse containment exists for
+    // scripts that carry no spaces, so it must not fire on space-delimited text.
+    expect(cmdJPaletteTokenScore(['database'], ['base'])).toBe(0)
+    expect(cmdJPaletteTokenScore(['worktree'], ['tree'])).toBe(0)
+  })
+
   it('scores a repeated query token once', () => {
     const once = cmdJPaletteTokenScore(uniqueCmdJPaletteQueryTokens('terminal'), ['terminal'])
     const twice = cmdJPaletteTokenScore(uniqueCmdJPaletteQueryTokens('terminal terminal'), [

--- a/src/renderer/src/components/cmd-j/palette-query-tokens.test.ts
+++ b/src/renderer/src/components/cmd-j/palette-query-tokens.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
+  cmdJPaletteTokenScore,
   isCmdJPaletteQueryOverTokenLimit,
+  uniqueCmdJPaletteQueryTokens,
   normalizeCmdJPaletteQuery,
   tokenizeCmdJPaletteQuery
 } from './palette-query-tokens'
@@ -28,6 +30,36 @@ describe('Cmd+J palette query normalization', () => {
     for (const token of normalizeCmdJPaletteQuery(query).split(' ')) {
       expect(normalizePaletteText(token).normalized).toBe(token)
     }
+  })
+})
+
+describe('Cmd+J palette token scoring', () => {
+  it('matches a CJK compound query against its keyword parts', () => {
+    // Why: CJK is written without spaces, so the natural query for the terminal settings
+    // pane is one token that CONTAINS the keyword rather than being contained by it.
+    expect(cmdJPaletteTokenScore(['终端设置'], ['终端', '设置'])).toBeGreaterThan(0)
+    expect(cmdJPaletteTokenScore(['终端'], ['终端', '设置'])).toBeGreaterThan(0)
+  })
+
+  it('does not let a one-character keyword match every long token', () => {
+    expect(cmdJPaletteTokenScore(['terminal'], ['a'])).toBe(0)
+  })
+
+  it('scores a repeated query token once', () => {
+    const once = cmdJPaletteTokenScore(uniqueCmdJPaletteQueryTokens('terminal'), ['terminal'])
+    const twice = cmdJPaletteTokenScore(uniqueCmdJPaletteQueryTokens('terminal terminal'), [
+      'terminal'
+    ])
+    expect(twice).toBe(once)
+  })
+
+  it('rejects a query whose punctuation split blows past the ceiling', () => {
+    // Whitespace-split counting saw one token; the scoring tokenizer saw hundreds.
+    const punctuationHeavy = Array.from(
+      { length: PALETTE_QUERY_MAX_TOKENS + 1 },
+      (_, i) => `t${i}`
+    ).join('.')
+    expect(isCmdJPaletteQueryOverTokenLimit(punctuationHeavy)).toBe(true)
   })
 })
 

--- a/src/renderer/src/components/cmd-j/palette-query-tokens.ts
+++ b/src/renderer/src/components/cmd-j/palette-query-tokens.ts
@@ -71,6 +71,16 @@ export function tokenizeCmdJPaletteQuery(value: string): string[] {
     .filter(Boolean)
 }
 
+// Why gate the reverse-containment tier on script: a space-delimited language already
+// tokenizes its own compounds, so a contained Latin keyword is a coincidence (`database`
+// vs `base`), while Han/Kana/Hangul text arrives as one run that must be matched inside.
+const UNSEGMENTED_SCRIPT_TOKEN_RE =
+  /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u
+
+function isUnsegmentedScriptToken(token: string): boolean {
+  return UNSEGMENTED_SCRIPT_TOKEN_RE.test(token)
+}
+
 // Why: navigation filler carries no intent ("open ssh settings" means "ssh settings"), so an
 // unmatched filler word must not count against a candidate's coverage.
 const CMD_J_QUERY_FILLER_TOKENS = new Set([
@@ -123,11 +133,15 @@ export function cmdJPaletteTokenScore(
         best = Math.max(best, 2)
       } else if (candidateToken.includes(queryToken)) {
         best = Math.max(best, 1)
-      } else if (candidateToken.length >= 2 && queryToken.includes(candidateToken)) {
+      } else if (
+        candidateToken.length >= 2 &&
+        queryToken.includes(candidateToken) &&
+        isUnsegmentedScriptToken(candidateToken)
+      ) {
         // Why the reverse direction: CJK is written without spaces, so the natural query for
         // the terminal settings pane is the single token `终端设置` — one token that CONTAINS
-        // the keyword rather than being contained by it. Weakest tier, and the length guard
-        // keeps one-character keywords from matching every long token.
+        // the keyword rather than being contained by it. Weakest tier, gated on the script
+        // that needs it: in Latin text the query `database` does not mean the keyword `base`.
         best = Math.max(best, 1)
       }
     }

--- a/src/renderer/src/components/cmd-j/palette-query-tokens.ts
+++ b/src/renderer/src/components/cmd-j/palette-query-tokens.ts
@@ -45,7 +45,18 @@ export function isCmdJPaletteQueryOverTokenLimit(normalizedQuery: string): boole
       return true
     }
   }
-  return false
+  // Why also bound the scoring split: whitespace-split counting lets 2KB of punctuation
+  // through as a single token, and the scorer's tokenizer then expands it into hundreds —
+  // paid once per candidate, per keystroke, on the render thread.
+  return uniqueCmdJPaletteQueryTokens(normalizedQuery).length > PALETTE_QUERY_MAX_TOKENS
+}
+
+/**
+ * Why dedupe: a repeated query token would otherwise contribute its score twice, so
+ * `terminal terminal ssh` outranks an otherwise-tied candidate on the strength of the repeat.
+ */
+export function uniqueCmdJPaletteQueryTokens(query: string): string[] {
+  return [...new Set(tokenizeCmdJPaletteQuery(query))]
 }
 
 export function uniqueNormalizedCmdJPaletteKeywords(values: readonly string[]): string[] {
@@ -89,7 +100,12 @@ const CMD_J_QUERY_FILLER_TOKENS = new Set([
   'with'
 ])
 
-export function cmdJPaletteTokenScore(query: string, values: readonly string[]): number {
+// Why the caller passes tokens: this runs once per candidate, and re-folding plus
+// re-splitting the same query for each one dominated the ranking pass.
+export function cmdJPaletteTokenScore(
+  queryTokens: readonly string[],
+  values: readonly string[]
+): number {
   const candidateTokens = values.flatMap(tokenizeCmdJPaletteQuery)
   if (candidateTokens.length === 0) {
     return 0
@@ -98,7 +114,7 @@ export function cmdJPaletteTokenScore(query: string, values: readonly string[]):
   let score = 0
   let meaningful = 0
   let covered = 0
-  for (const queryToken of tokenizeCmdJPaletteQuery(query)) {
+  for (const queryToken of queryTokens) {
     let best = 0
     for (const candidateToken of candidateTokens) {
       if (candidateToken === queryToken) {
@@ -106,6 +122,12 @@ export function cmdJPaletteTokenScore(query: string, values: readonly string[]):
       } else if (candidateToken.startsWith(queryToken)) {
         best = Math.max(best, 2)
       } else if (candidateToken.includes(queryToken)) {
+        best = Math.max(best, 1)
+      } else if (candidateToken.length >= 2 && queryToken.includes(candidateToken)) {
+        // Why the reverse direction: CJK is written without spaces, so the natural query for
+        // the terminal settings pane is the single token `终端设置` — one token that CONTAINS
+        // the keyword rather than being contained by it. Weakest tier, and the length guard
+        // keeps one-character keywords from matching every long token.
         best = Math.max(best, 1)
       }
     }

--- a/src/renderer/src/components/cmd-j/palette-results.test.ts
+++ b/src/renderer/src/components/cmd-j/palette-results.test.ts
@@ -172,6 +172,23 @@ function top(query: string): string | undefined {
   return rankMiddle(query)[0]?.id
 }
 
+describe('action keyword folding', () => {
+  it('folds verbKeywords so a raw-cased command still reaches exact-intent', () => {
+    // Why: the query is folded before ranking, so a plugin command titled `Format Document`
+    // could never satisfy rules 1/3/4 and sank below any prefix-matching workspace.
+    const [folded] = buildCmdJActionResults([
+      {
+        id: 'quick-action:format',
+        kind: 'action',
+        title: 'Format Document',
+        description: 'Format the open file',
+        verbKeywords: ['Format Document', 'FORMAT  DOC']
+      } as (typeof actions)[number]
+    ])
+    expect(folded.verbKeywords).toEqual(['format document', 'format doc'])
+  })
+})
+
 const overTokenLimitQuery = Array.from(
   { length: PALETTE_QUERY_MAX_TOKENS + 1 },
   (_, index) => `token${index}`

--- a/src/renderer/src/components/cmd-j/palette-results.ts
+++ b/src/renderer/src/components/cmd-j/palette-results.ts
@@ -1,3 +1,4 @@
+import { translate } from '@/i18n/i18n'
 import type { SettingsNavIcon, SettingsNavSection } from '@/lib/settings-navigation-types'
 import type { CmdJQuickAction } from './quick-actions'
 import { isClipboardTextByteLengthOverLimit } from '../../../../shared/clipboard-text'
@@ -5,6 +6,7 @@ import {
   cmdJPaletteTokenScore,
   isCmdJPaletteQueryOverTokenLimit,
   normalizeCmdJPaletteQuery,
+  uniqueCmdJPaletteQueryTokens,
   uniqueNormalizedCmdJPaletteKeywords
 } from './palette-query-tokens'
 import {
@@ -92,24 +94,41 @@ export function isCmdJPaletteQueryTooLarge(
   return isClipboardTextByteLengthOverLimit(query, maxBytes)
 }
 
+// Why not a module constant: translate() must run at call time, and the localized word is
+// the same one the palette stamps on these rows — a zh user searching `设置` types the badge.
+function settingsWord(): string {
+  return translate('auto.components.WorktreeJumpPalette.settingsBadge', 'Settings').toLowerCase()
+}
+
 function keywordParts(section: SettingsNavSection): string[] {
   const baseId = section.id.startsWith('repo-') ? 'repo' : section.id
   const idWords = baseId.replace(/-/g, ' ')
   const paneLevelEntries = section.searchEntries.filter((entry) => !entry.targetSectionId)
+  const localized = settingsWord()
+  // Why keep the English forms alongside the localized ones: section titles stay English in
+  // some catalogs, and a user on a localized build still types `terminal settings` freely.
+  const suffixed = [`${section.title} settings`, `${idWords} settings`]
+  if (localized !== 'settings') {
+    suffixed.push(`${section.title} ${localized}`, `${idWords} ${localized}`, localized)
+  }
   return [
     section.id,
     baseId,
     idWords,
     section.title,
-    `${section.title} settings`,
-    `${idWords} settings`,
+    ...suffixed,
     ...(SETTINGS_ALIASES[baseId] ?? []),
     ...paneLevelEntries.map((entry) => entry.title)
   ]
 }
 
 function targetEntryKeywordParts(entryTitle: string): string[] {
-  return [entryTitle, `${entryTitle} settings`]
+  const localized = settingsWord()
+  const parts = [entryTitle, `${entryTitle} settings`]
+  if (localized !== 'settings') {
+    parts.push(`${entryTitle} ${localized}`)
+  }
+  return parts
 }
 
 export function buildCmdJSettingsResults(
@@ -148,7 +167,14 @@ export function buildCmdJSettingsResults(
 }
 
 export function buildCmdJActionResults(actions: readonly CmdJQuickAction[]): CmdJActionResult[] {
-  return actions.map((action, order) => ({ ...action, order }))
+  // Why fold here, like the settings path above: the query is folded before ranking, so
+  // a raw `Format Document` keyword can never satisfy the exact-intent rules and the
+  // command sinks below any workspace that merely prefix-matches.
+  return actions.map((action, order) => ({
+    ...action,
+    order,
+    verbKeywords: uniqueNormalizedCmdJPaletteKeywords(action.verbKeywords)
+  }))
 }
 
 function startsOrIsStartedBy(query: string, keyword: string): boolean {
@@ -157,6 +183,7 @@ function startsOrIsStartedBy(query: string, keyword: string): boolean {
 
 function rankingForCandidate(
   query: string,
+  queryTokens: readonly string[],
   candidate: CmdJMiddleResult,
   actionVerbKeywords: readonly string[],
   settingsConfigKeywords: readonly string[]
@@ -171,7 +198,7 @@ function rankingForCandidate(
     candidate.kind === 'settings'
       ? [candidate.title, ...candidate.configKeywords]
       : [candidate.title, ...candidate.verbKeywords]
-  const score = cmdJPaletteTokenScore(query, values)
+  const score = cmdJPaletteTokenScore(queryTokens, values)
   if (score === 0) {
     return null
   }
@@ -245,6 +272,7 @@ export function rankCmdJMiddleResults({
   if (normalizedQuery.length < 2 || isCmdJPaletteQueryOverTokenLimit(normalizedQuery)) {
     return []
   }
+  const queryTokens = uniqueCmdJPaletteQueryTokens(normalizedQuery)
   const settings = settingsResults
   const actions = actionResults
   const actionVerbKeywords = actions.flatMap((action) => action.verbKeywords)
@@ -252,7 +280,13 @@ export function rankCmdJMiddleResults({
 
   return [...settings, ...actions]
     .map((candidate) =>
-      rankingForCandidate(normalizedQuery, candidate, actionVerbKeywords, settingsConfigKeywords)
+      rankingForCandidate(
+        normalizedQuery,
+        queryTokens,
+        candidate,
+        actionVerbKeywords,
+        settingsConfigKeywords
+      )
     )
     .filter((entry): entry is RankedResult => entry !== null)
     .sort(compareRanked)

--- a/src/renderer/src/components/sidebar/workspace-kanban-search.test.ts
+++ b/src/renderer/src/components/sidebar/workspace-kanban-search.test.ts
@@ -116,13 +116,9 @@ describe('matchWorkspaceBoardWorktrees', () => {
     expect(match(worktrees, 'x'.repeat(WORKTREE_PALETTE_QUERY_MAX_BYTES + 1))).toBeNull()
   })
 
-  // KNOWN GAP (STA-4343): the board cannot yet tell two same-id host rows apart, and the
-  // cause is upstream of this module — searchWorktrees looks up evidence in a
-  // `documents` map keyed by BARE worktree id (worktree-palette-search.ts), so the second
-  // row's document overwrites the first and only one row can ever match. The matched set
-  // below is host-qualified and ready for the fix; closing the gap means host-qualifying
-  // that document map, which belongs with the palette work, not this PR.
-  it('cannot yet separate two same-id host rows (documents map is id-keyed upstream)', () => {
+  // STA-4343 closed: the documents map is keyed by host identity, so two workspaces sharing
+  // `repoId::path` across hosts each keep their own searchable document.
+  it('separates two same-id host rows', () => {
     const local = worktree({ id: 'shared', branch: 'refs/heads/local-only' })
     const remote = worktree({
       id: local.id,
@@ -130,10 +126,9 @@ describe('matchWorkspaceBoardWorktrees', () => {
       branch: 'refs/heads/remote-only'
     })
 
-    // Documents collapse on the shared id, so the local row's branch is not searchable.
-    expect(match([local, remote], 'local-only')).toEqual(new Set())
-    // What DOES hold today: the matched set is keyed by host identity, not bare id, so a
-    // match never leaks across hosts once the upstream map is fixed.
+    // Each row matches on its OWN branch, and neither match leaks to the other host.
+    expect(match([local, remote], 'local-only')).toEqual(identities(local))
+    expect(match([local, remote], 'remote-only')).toEqual(identities(remote))
     expect(match([local], 'local-only')).toEqual(identities(local))
   })
 })

--- a/src/renderer/src/lib/browser-palette-page-entries.ts
+++ b/src/renderer/src/lib/browser-palette-page-entries.ts
@@ -1,3 +1,4 @@
+import { getWorktreeHostIdentity } from '../../../shared/worktree/host-qualified-identity'
 import type { BrowserPage, BrowserWorkspace } from '../../../shared/browser-workspace-types'
 import type { Worktree } from '../../../shared/worktree/types'
 import {
@@ -31,7 +32,10 @@ export function buildSearchableBrowserPages({
   const entries: SearchableBrowserPage[] = []
   for (const worktree of worktrees) {
     const repoName = repoMap.get(worktree.repoId)?.displayName ?? ''
-    const worktreeSortIndex = worktreeOrder.get(worktree.id) ?? Number.MAX_SAFE_INTEGER
+    const worktreeSortIndex =
+      worktreeOrder.get(getWorktreeHostIdentity(worktree)) ??
+      worktreeOrder.get(worktree.id) ??
+      Number.MAX_SAFE_INTEGER
     for (const workspace of browserTabsByWorktree[worktree.id] ?? []) {
       for (const page of browserPagesByWorkspace[workspace.id] ?? []) {
         entries.push({

--- a/src/renderer/src/lib/browser-palette-page-entries.ts
+++ b/src/renderer/src/lib/browser-palette-page-entries.ts
@@ -1,6 +1,8 @@
 import { getWorktreeHostIdentity } from '../../../shared/worktree/host-qualified-identity'
 import type { BrowserPage, BrowserWorkspace } from '../../../shared/browser-workspace-types'
 import type { Worktree } from '../../../shared/worktree/types'
+import type { ExecutionHostId } from '../../../shared/execution-host'
+import { isPaletteCurrentWorktree, resolvePaletteRepoForWorktree } from './palette-repo-resolution'
 import {
   buildSearchableBrowserPageDocument,
   type SearchableBrowserPage
@@ -11,27 +13,32 @@ type BrowserPaletteActiveTabType = 'browser' | 'editor' | 'terminal' | 'simulato
 export type BuildSearchableBrowserPagesOptions = {
   worktrees: readonly Worktree[]
   repoMap: ReadonlyMap<string, { displayName?: string | null }>
+  repoMapByHostIdentity?: ReadonlyMap<string, { displayName?: string | null }>
   worktreeOrder: ReadonlyMap<string, number>
   browserTabsByWorktree: Record<string, readonly BrowserWorkspace[] | undefined>
   browserPagesByWorkspace: Record<string, readonly BrowserPage[] | undefined>
   activeBrowserTabId: string | null
   activeWorktreeId: string | null
+  activeWorkspaceExecutionHostId?: ExecutionHostId | null
   activeTabType: BrowserPaletteActiveTabType
 }
 
 export function buildSearchableBrowserPages({
   worktrees,
   repoMap,
+  repoMapByHostIdentity,
   worktreeOrder,
   browserTabsByWorktree,
   browserPagesByWorkspace,
   activeBrowserTabId,
   activeWorktreeId,
+  activeWorkspaceExecutionHostId,
   activeTabType
 }: BuildSearchableBrowserPagesOptions): SearchableBrowserPage[] {
   const entries: SearchableBrowserPage[] = []
   for (const worktree of worktrees) {
-    const repoName = repoMap.get(worktree.repoId)?.displayName ?? ''
+    const repoName =
+      resolvePaletteRepoForWorktree(worktree, repoMap, repoMapByHostIdentity)?.displayName ?? ''
     const worktreeSortIndex =
       worktreeOrder.get(getWorktreeHostIdentity(worktree)) ??
       worktreeOrder.get(worktree.id) ??
@@ -45,10 +52,15 @@ export function buildSearchableBrowserPages({
           repoName,
           worktreeSortIndex,
           isCurrentPage:
+            isPaletteCurrentWorktree(worktree, activeWorktreeId, activeWorkspaceExecutionHostId) &&
             activeTabType === 'browser' &&
             workspace.id === activeBrowserTabId &&
             workspace.activePageId === page.id,
-          isCurrentWorktree: activeWorktreeId === worktree.id,
+          isCurrentWorktree: isPaletteCurrentWorktree(
+            worktree,
+            activeWorktreeId,
+            activeWorkspaceExecutionHostId
+          ),
           document: buildSearchableBrowserPageDocument({ page, workspace, worktree, repoName })
         })
       }

--- a/src/renderer/src/lib/browser-palette-search.test.ts
+++ b/src/renderer/src/lib/browser-palette-search.test.ts
@@ -82,6 +82,24 @@ describe('browser-palette-search', () => {
     )
   })
 
+  it('stamps the row execution host so activation never resolves by id alone', () => {
+    // Why: worktree ids repeat across hosts, so a host-blind activation opened the other
+    // host's workspace behind a row labelled with this one's name and branch.
+    const [result] = searchBrowserPages(
+      [
+        makeEntry({
+          page: makePage({ id: 'page-1', title: 'Docs' }),
+          workspace: makeWorkspace({ id: 'ws-1' }),
+          worktree: makeWorktree({ id: 'shared', hostId: 'ssh:box' }),
+          repoName: 'repo/one',
+          worktreeSortIndex: 0
+        })
+      ],
+      ''
+    )
+    expect(result.executionHostId).toBe('ssh:box')
+  })
+
   it('keeps empty-query ordering deterministic and context-first', () => {
     const results = searchBrowserPages(
       [

--- a/src/renderer/src/lib/browser-palette-search.test.ts
+++ b/src/renderer/src/lib/browser-palette-search.test.ts
@@ -92,7 +92,9 @@ describe('browser-palette-search', () => {
           workspace: makeWorkspace({ id: 'ws-1' }),
           worktree: makeWorktree({ id: 'shared', hostId: 'ssh:box' }),
           repoName: 'repo/one',
-          worktreeSortIndex: 0
+          worktreeSortIndex: 0,
+          isCurrentPage: false,
+          isCurrentWorktree: false
         })
       ],
       ''

--- a/src/renderer/src/lib/browser-palette-search.ts
+++ b/src/renderer/src/lib/browser-palette-search.ts
@@ -13,6 +13,7 @@ import {
   resolveWorktreeBranchLabel,
   resolveWorktreeDisplayName
 } from './worktree-default-display-name'
+import type { ExecutionHostId } from '../../../shared/execution-host'
 import type { MatchRange } from './palette-match/normalized-text'
 import type { PaletteDocument, PaletteDocumentRank } from './palette-match/palette-document'
 import type { PaletteResultQualityClass } from './palette-match/match-quality'
@@ -32,6 +33,8 @@ export type SearchableBrowserPage = {
 }
 
 export type BrowserPaletteSearchResult = {
+  /** Worktree ids collide across hosts; activation must not resolve by id alone. */
+  executionHostId?: ExecutionHostId
   pageId: string
   workspaceId: string
   worktreeId: string
@@ -138,6 +141,7 @@ function positionScore(entry: SearchableBrowserPage): number {
 function baseResult(entry: SearchableBrowserPage): BrowserPaletteSearchResult {
   const formattedUrl = formatBrowserPaletteUrl(entry.page.url)
   return {
+    ...(entry.worktree.hostId ? { executionHostId: entry.worktree.hostId } : {}),
     pageId: entry.page.id,
     workspaceId: entry.workspace.id,
     worktreeId: entry.worktree.id,

--- a/src/renderer/src/lib/order-empty-query-worktrees.test.ts
+++ b/src/renderer/src/lib/order-empty-query-worktrees.test.ts
@@ -100,6 +100,20 @@ describe('orderEmptyQueryWorktrees', () => {
     expect(result.visibleWorktreesForState.map((w) => w.id)).toEqual(['cur', 'other'])
   })
 
+  // Why: `repoId::path` repeats across hosts, so a bare-id filter treated the SSH twin as
+  // current too and dropped it from the rows — the host it lived on became unreachable.
+  it('keeps the same-id worktree on the other host switchable', () => {
+    const local = wt({ id: 'shared', displayName: 'local', hostId: 'local' })
+    const ssh = wt({ id: 'shared', displayName: 'ssh', hostId: 'ssh:box' })
+    const result = orderEmptyQueryWorktrees({
+      visibleWorktrees: [local, ssh],
+      activeWorktreeId: 'shared',
+      activeWorkspaceExecutionHostId: 'local',
+      lastVisitedAtByWorktreeId: {}
+    })
+    expect(result.switchableWorktreesForRows.map((w) => w.displayName)).toEqual(['ssh'])
+  })
+
   it('returns empty rows but non-empty state when only the current worktree is visible', () => {
     const cur = wt({ id: 'cur', displayName: 'cur' })
     const result = orderEmptyQueryWorktrees({

--- a/src/renderer/src/lib/order-empty-query-worktrees.ts
+++ b/src/renderer/src/lib/order-empty-query-worktrees.ts
@@ -1,9 +1,13 @@
+import type { ExecutionHostId } from '../../../shared/execution-host'
 import type { Worktree } from '../../../shared/worktree/types'
+import { isPaletteCurrentWorktree } from './palette-repo-resolution'
 import { compareWorktreeDisplayName } from './worktree-display-name-order'
 
 export type OrderEmptyQueryInputs = {
   visibleWorktrees: readonly Worktree[]
   activeWorktreeId: string | null
+  /** Host of the active workspace. Omit to fall back to bare-id matching (STA-4343). */
+  activeWorkspaceExecutionHostId?: ExecutionHostId | null
   lastVisitedAtByWorktreeId: Record<string, number>
 }
 
@@ -29,8 +33,17 @@ export type OrderEmptyQueryResult = {
  * visibleWorktreesForState so empty-state logic isn't affected.
  */
 export function orderEmptyQueryWorktrees(inputs: OrderEmptyQueryInputs): OrderEmptyQueryResult {
-  const { visibleWorktrees, activeWorktreeId, lastVisitedAtByWorktreeId } = inputs
-  const switchable = visibleWorktrees.filter((w) => w.id !== activeWorktreeId)
+  const {
+    visibleWorktrees,
+    activeWorktreeId,
+    activeWorkspaceExecutionHostId,
+    lastVisitedAtByWorktreeId
+  } = inputs
+  // Why the host too (STA-4343): `repoId::path` repeats across hosts, so filtering on the
+  // bare id drops BOTH same-id rows as "current" and the other host becomes unreachable.
+  const switchable = visibleWorktrees.filter(
+    (w) => !isPaletteCurrentWorktree(w, activeWorktreeId, activeWorkspaceExecutionHostId)
+  )
   // Why: a visited worktree must always outrank a never-visited one,
   // even when the never-visited worktree has a newer lastActivityAt.
   // Mixing the two signals into a single numeric score would let

--- a/src/renderer/src/lib/palette-match/match-document.ts
+++ b/src/renderer/src/lib/palette-match/match-document.ts
@@ -202,7 +202,13 @@ function buildSupportingEvidence(
       continue
     }
     for (const range of assignment.ranges) {
-      ranges.push({ start: range.start + offset, end: range.end + offset })
+      // Why clamp: a range is only meaningful against the unit text the row renders, and
+      // an out-of-range end would highlight past the end of that string.
+      const start = Math.min(range.start + offset, unit.text.length)
+      const end = Math.min(range.end + offset, unit.text.length)
+      if (start < end) {
+        ranges.push({ start, end })
+      }
     }
   }
   if (!ranges.length) {

--- a/src/renderer/src/lib/palette-match/palette-document.ts
+++ b/src/renderer/src/lib/palette-match/palette-document.ts
@@ -64,6 +64,12 @@ export function buildPaletteDocument(input: PaletteDocumentInput): PaletteDocume
     if (!fields.length) {
       continue
     }
+    // Why first-wins, matching indexPaletteFields: it keeps the first entry's fields, so
+    // overwriting the unit here would pair one record's rendered text with another's
+    // match offsets — highlights landing outside the string the row actually shows.
+    if (evidenceUnits.has(entry.unit.id)) {
+      continue
+    }
     evidenceUnits.set(entry.unit.id, entry.unit)
     for (const field of fields) {
       evidenceSources.push(field)

--- a/src/renderer/src/lib/palette-match/palette-match-core.test.ts
+++ b/src/renderer/src/lib/palette-match/palette-match-core.test.ts
@@ -42,6 +42,25 @@ describe('palette query preparation', () => {
     expect(ready('scan scan daily').tokens.map((token) => token.text)).toEqual(['scan', 'daily'])
   })
 
+  it('collapses whitespace runs so the whole-query tier still matches', () => {
+    // Why: field text is always single-spaced, so an uncollapsed run could never satisfy
+    // the whole-query equality tier and the exactly-named row silently lost its rank.
+    expect(ready('scan  daily').normalized).toBe('scan daily')
+    expect(run(labelOnly('scan daily'), 'scan  daily')?.rank.wholeQuery).toBe(
+      run(labelOnly('scan daily'), 'scan daily')?.rank.wholeQuery
+    )
+  })
+
+  it('treats emoji and symbols as content, not punctuation', () => {
+    // Why: the palette input expands `:rocket:` into 🚀, so dropping symbol tokens made the
+    // palette unable to match a query it produced itself.
+    expect(ready('🚀 rocket').tokens[0]?.isPunctuationOnly).toBe(false)
+    expect(run(labelOnly('🚀 rocket ship'), '🚀 rocket ship')).not.toBeNull()
+    expect(run(labelOnly('a → b'), '→')).not.toBeNull()
+    // A genuinely punctuation-only token stays rejected.
+    expect(ready('--').tokens[0]?.isPunctuationOnly).toBe(true)
+  })
+
   it('parses repo/branch per token', () => {
     expect(ready('orca/main').tokens[0].repoBranch).toEqual({ repo: 'orca', branch: 'main' })
     expect(ready('feature').tokens[0].repoBranch).toBeNull()
@@ -231,6 +250,68 @@ describe('identifier fields', () => {
     const match = run(review('#'), 'reconnect 4123')
     expect(match?.rank.usesSupportingEvidence).toBe(1)
     expect(match?.supportingEvidence).toHaveLength(1)
+  })
+})
+
+describe('duplicate evidence unit ids', () => {
+  // Two listeners on one port with different process names: the scanner keys ports on
+  // host:port:pid, so a parent and a forked child both survive.
+  const duplicateUnits: PaletteDocumentInput = {
+    id: 'doc',
+    visibleFields: [{ id: 'name', profile: 'structured-label', text: 'checkout' }],
+    evidence: [
+      {
+        unit: {
+          id: 'port:3000',
+          kind: 'port',
+          text: '3000 · next-server',
+          accessibilityLabel: 'Port'
+        },
+        fields: [
+          {
+            id: 'port:3000#name',
+            profile: 'structured-label',
+            text: 'next-server',
+            evidenceId: 'port:3000',
+            renderOffset: 7
+          }
+        ]
+      },
+      {
+        unit: { id: 'port:3000', kind: 'port', text: '3000 · node', accessibilityLabel: 'Port' },
+        fields: [
+          {
+            id: 'port:3000#name',
+            profile: 'structured-label',
+            text: 'node',
+            evidenceId: 'port:3000',
+            renderOffset: 7
+          }
+        ]
+      }
+    ]
+  }
+
+  it('keeps the first unit so its text matches the indexed fields', () => {
+    // Why first-wins: indexPaletteFields keeps the first entry's fields, so overwriting the
+    // unit paired one record's rendered text with another's offsets.
+    const match = run(duplicateUnits, 'next-server')
+    const evidence = match?.supportingEvidence[0]
+    expect(evidence?.text).toBe('3000 · next-server')
+    expect(evidence?.text.slice(evidence.ranges[0].start, evidence.ranges[0].end)).toBe(
+      'next-server'
+    )
+  })
+
+  it('never emits a range past the end of the rendered unit text', () => {
+    for (const query of ['next-server', 'node', '3000']) {
+      for (const evidence of run(duplicateUnits, query)?.supportingEvidence ?? []) {
+        for (const range of evidence.ranges) {
+          expect(range.end).toBeLessThanOrEqual(evidence.text.length)
+          expect(range.start).toBeLessThan(range.end)
+        }
+      }
+    }
   })
 })
 

--- a/src/renderer/src/lib/palette-match/palette-query.ts
+++ b/src/renderer/src/lib/palette-match/palette-query.ts
@@ -4,7 +4,10 @@ import { normalizePaletteText } from './normalized-text'
 export const PALETTE_QUERY_MAX_TOKENS = 16
 
 const DIGIT = /\p{N}/u
-const ALPHANUMERIC = /[\p{L}\p{N}]/u
+// Why symbols count as content: an emoji is \p{So} and an arrow is \p{Sm}, so a
+// letters-and-digits test would classify `🚀` as punctuation and drop the token —
+// and the palette input expands `:rocket:` into exactly that.
+const ALPHANUMERIC = /[\p{L}\p{N}\p{S}\p{Extended_Pictographic}]/u
 const LETTERS_ONLY = /^\p{L}+$/u
 const LATIN_OR_DIGIT = /^[\p{Script=Latin}\p{Nd}]$/u
 const IDENTIFIER_PUNCTUATION = /[./#!_-]/
@@ -79,7 +82,11 @@ export function preparePaletteQuery(query: string): PreparedPaletteQuery {
   if (isWorktreePaletteQueryTooLarge(query)) {
     return { state: 'invalid', reason: 'too-large' }
   }
-  const normalized = normalizePaletteText(query).normalized.trim()
+  // Why collapse runs: field text is always single-spaced, so an uncollapsed double
+  // space can never satisfy the whole-query equality/prefix tier and the exact-name
+  // match silently loses its rank. Safe here — this string feeds only scoreWholeQuery
+  // and carries no offset mapping back into the source text.
+  const normalized = normalizePaletteText(query).normalized.replace(/ +/g, ' ').trim()
   if (!normalized) {
     return { state: 'empty' }
   }

--- a/src/renderer/src/lib/palette-repo-resolution.test.ts
+++ b/src/renderer/src/lib/palette-repo-resolution.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { isPaletteCurrentWorktree, resolvePaletteRepoForWorktree } from './palette-repo-resolution'
+
+describe('palette repo and current-worktree resolution', () => {
+  const local = { id: 'repo-1', displayName: 'Local repo' }
+  const remote = { id: 'repo-1', displayName: 'Remote repo' }
+  const worktree = { id: 'repo-1::/checkout', repoId: 'repo-1', hostId: 'ssh:box' as const }
+
+  it('uses the host-qualified repo for a colliding worktree', () => {
+    expect(
+      resolvePaletteRepoForWorktree(
+        worktree,
+        new Map([['repo-1', local]]),
+        new Map([['ssh:box\u0000repo-1', remote]])
+      )
+    ).toBe(remote)
+  })
+
+  it('does not mark a same-id worktree on another host current', () => {
+    expect(isPaletteCurrentWorktree(worktree, worktree.id, 'local')).toBe(false)
+    expect(isPaletteCurrentWorktree(worktree, worktree.id, 'ssh:box')).toBe(true)
+  })
+})

--- a/src/renderer/src/lib/palette-repo-resolution.ts
+++ b/src/renderer/src/lib/palette-repo-resolution.ts
@@ -1,0 +1,31 @@
+import { LOCAL_EXECUTION_HOST_ID, type ExecutionHostId } from '../../../shared/execution-host'
+import { getRepoHostIdentityForParts } from '../../../shared/repo-host-identity'
+import type { Worktree } from '../../../shared/worktree/types'
+
+/** Resolve the repo that owns a worktree, preserving host collisions. */
+export function resolvePaletteRepoForWorktree<T extends { displayName?: string | null }>(
+  worktree: Pick<Worktree, 'id' | 'repoId' | 'hostId'>,
+  repoMap: ReadonlyMap<string, T>,
+  repoMapByHostIdentity?: ReadonlyMap<string, T>
+): T | undefined {
+  return (
+    repoMapByHostIdentity?.get(
+      getRepoHostIdentityForParts(worktree.repoId, worktree.hostId ?? LOCAL_EXECUTION_HOST_ID)
+    ) ?? repoMap.get(worktree.repoId)
+  )
+}
+
+export function isPaletteCurrentWorktree(
+  worktree: Pick<Worktree, 'id' | 'hostId'>,
+  activeWorktreeId: string | null,
+  activeWorkspaceExecutionHostId?: ExecutionHostId | null
+): boolean {
+  if (activeWorkspaceExecutionHostId === undefined) {
+    return activeWorktreeId === worktree.id
+  }
+  return (
+    activeWorktreeId === worktree.id &&
+    (worktree.hostId ?? LOCAL_EXECUTION_HOST_ID) ===
+      (activeWorkspaceExecutionHostId ?? LOCAL_EXECUTION_HOST_ID)
+  )
+}

--- a/src/renderer/src/lib/simulator-palette-search.ts
+++ b/src/renderer/src/lib/simulator-palette-search.ts
@@ -2,6 +2,7 @@ import { getWorktreeHostIdentity } from '../../../shared/worktree/host-qualified
 import type { ExecutionHostId } from '../../../shared/execution-host'
 import type { Tab, TabGroup } from '../../../shared/tab-types'
 import type { Worktree } from '../../../shared/worktree/types'
+import { isPaletteCurrentWorktree, resolvePaletteRepoForWorktree } from './palette-repo-resolution'
 import { isClipboardTextByteLengthOverLimit } from '../../../shared/clipboard-text'
 import { compareBaseSensitivityLocaleText } from './locale-text-collators'
 import {
@@ -79,11 +80,13 @@ export function isSimulatorPaletteQueryTooLarge(
 export type BuildSearchableSimulatorTabsOptions = {
   worktrees: readonly Worktree[]
   repoMap: ReadonlyMap<string, { displayName?: string | null }>
+  repoMapByHostIdentity?: ReadonlyMap<string, { displayName?: string | null }>
   worktreeOrder: ReadonlyMap<string, number>
   unifiedTabsByWorktree: Record<string, readonly Tab[] | undefined>
   activeGroupIdByWorktree: Record<string, string | undefined>
   groupsByWorktree: Record<string, readonly TabGroup[] | undefined>
   activeWorktreeId: string | null
+  activeWorkspaceExecutionHostId?: ExecutionHostId | null
   activeTabType: SimulatorPaletteActiveTabType
 }
 
@@ -152,17 +155,31 @@ function baseResult(entry: SearchableSimulatorTab): SimulatorPaletteSearchResult
 
 function getActiveUnifiedTabId({
   worktreeId,
+  worktreeHostId,
   activeWorktreeId,
+  activeWorkspaceExecutionHostId,
   activeTabType,
   activeGroupIdByWorktree,
   groupsByWorktree
 }: Pick<
   BuildSearchableSimulatorTabsOptions,
-  'activeGroupIdByWorktree' | 'activeTabType' | 'activeWorktreeId' | 'groupsByWorktree'
+  | 'activeGroupIdByWorktree'
+  | 'activeTabType'
+  | 'activeWorktreeId'
+  | 'activeWorkspaceExecutionHostId'
+  | 'groupsByWorktree'
 > & {
   worktreeId: string
+  worktreeHostId?: Worktree['hostId']
 }): string | null {
-  if (activeWorktreeId !== worktreeId || activeTabType !== 'simulator') {
+  if (
+    !isPaletteCurrentWorktree(
+      { id: worktreeId, hostId: worktreeHostId },
+      activeWorktreeId,
+      activeWorkspaceExecutionHostId
+    ) ||
+    activeTabType !== 'simulator'
+  ) {
     return null
   }
   const activeGroupId = activeGroupIdByWorktree[worktreeId]
@@ -175,23 +192,28 @@ function getActiveUnifiedTabId({
 export function buildSearchableSimulatorTabs({
   worktrees,
   repoMap,
+  repoMapByHostIdentity,
   worktreeOrder,
   unifiedTabsByWorktree,
   activeGroupIdByWorktree,
   groupsByWorktree,
   activeWorktreeId,
+  activeWorkspaceExecutionHostId,
   activeTabType
 }: BuildSearchableSimulatorTabsOptions): SearchableSimulatorTab[] {
   const entries: SearchableSimulatorTab[] = []
   for (const worktree of worktrees) {
-    const repoName = repoMap.get(worktree.repoId)?.displayName ?? ''
+    const repoName =
+      resolvePaletteRepoForWorktree(worktree, repoMap, repoMapByHostIdentity)?.displayName ?? ''
     const worktreeSortIndex =
       worktreeOrder.get(getWorktreeHostIdentity(worktree)) ??
       worktreeOrder.get(worktree.id) ??
       Number.MAX_SAFE_INTEGER
     const activeUnifiedTabId = getActiveUnifiedTabId({
       worktreeId: worktree.id,
+      worktreeHostId: worktree.hostId,
       activeWorktreeId,
+      activeWorkspaceExecutionHostId,
       activeTabType,
       activeGroupIdByWorktree,
       groupsByWorktree
@@ -209,7 +231,11 @@ export function buildSearchableSimulatorTabs({
         // Why: simulator tabs are unified tabs; terminal activeTabId does not
         // identify the visible emulator tab after split-group activation.
         isCurrentTab: activeUnifiedTabId === tab.id,
-        isCurrentWorktree: activeWorktreeId === worktree.id,
+        isCurrentWorktree: isPaletteCurrentWorktree(
+          worktree,
+          activeWorktreeId,
+          activeWorkspaceExecutionHostId
+        ),
         document: buildPaletteTabDocument({
           id: tab.id,
           title: simulatorPaletteTabTitle(tab),

--- a/src/renderer/src/lib/simulator-palette-search.ts
+++ b/src/renderer/src/lib/simulator-palette-search.ts
@@ -1,3 +1,4 @@
+import { getWorktreeHostIdentity } from '../../../shared/worktree/host-qualified-identity'
 import type { ExecutionHostId } from '../../../shared/execution-host'
 import type { Tab, TabGroup } from '../../../shared/tab-types'
 import type { Worktree } from '../../../shared/worktree/types'
@@ -184,7 +185,10 @@ export function buildSearchableSimulatorTabs({
   const entries: SearchableSimulatorTab[] = []
   for (const worktree of worktrees) {
     const repoName = repoMap.get(worktree.repoId)?.displayName ?? ''
-    const worktreeSortIndex = worktreeOrder.get(worktree.id) ?? Number.MAX_SAFE_INTEGER
+    const worktreeSortIndex =
+      worktreeOrder.get(getWorktreeHostIdentity(worktree)) ??
+      worktreeOrder.get(worktree.id) ??
+      Number.MAX_SAFE_INTEGER
     const activeUnifiedTabId = getActiveUnifiedTabId({
       worktreeId: worktree.id,
       activeWorktreeId,

--- a/src/renderer/src/lib/workspace-tab-palette-entry-builder.ts
+++ b/src/renderer/src/lib/workspace-tab-palette-entry-builder.ts
@@ -1,0 +1,275 @@
+import { getWorktreeHostIdentity } from '../../../shared/worktree/host-qualified-identity'
+import {
+  resolveTerminalTabTitle,
+  resolveUnifiedTabLabel
+} from '../../../shared/tab-title-resolution'
+import type { Tab, TabContentType } from '../../../shared/tab-types'
+import type { Worktree } from '../../../shared/worktree/types'
+import { getEditorDisplayLabel } from '@/components/editor/editor-labels'
+import { buildPaletteTabDocument } from './palette-match/tab-document'
+import { isPaletteCurrentWorktree, resolvePaletteRepoForWorktree } from './palette-repo-resolution'
+import { resolveOpenTabOccupantAgent } from './open-tab-occupant-agent'
+import {
+  resolveWorktreeBranchLabel,
+  resolveWorktreeDisplayName
+} from './worktree-default-display-name'
+import {
+  buildAgentMetadataTabIndex,
+  collectAgentMetadataFromIndex
+} from './workspace-tab-agent-metadata'
+import type {
+  BuildSearchableWorkspaceTabsOptions,
+  SearchableWorkspaceTab,
+  WorkspaceTabContentType
+} from './workspace-tab-palette-search'
+
+function getActiveUnifiedTabId({
+  worktreeId,
+  worktreeHostId,
+  activeWorktreeId,
+  activeWorkspaceExecutionHostId,
+  activeTabType,
+  activeGroupIdByWorktree,
+  groupsByWorktree
+}: Pick<
+  BuildSearchableWorkspaceTabsOptions,
+  | 'activeGroupIdByWorktree'
+  | 'activeTabType'
+  | 'activeWorktreeId'
+  | 'activeWorkspaceExecutionHostId'
+  | 'groupsByWorktree'
+> & { worktreeId: string; worktreeHostId?: Worktree['hostId'] }): string | null {
+  if (
+    !isPaletteCurrentWorktree(
+      { id: worktreeId, hostId: worktreeHostId },
+      activeWorktreeId,
+      activeWorkspaceExecutionHostId
+    )
+  ) {
+    return null
+  }
+  const activeGroupId = activeGroupIdByWorktree[worktreeId]
+  const activeGroup = activeGroupId
+    ? (groupsByWorktree[worktreeId] ?? []).find((group) => group.id === activeGroupId)
+    : undefined
+  const activeUnifiedTabId = activeGroup?.activeTabId ?? null
+  return activeTabType === 'terminal' || activeTabType === 'editor' ? activeUnifiedTabId : null
+}
+
+function isCurrentWorkspaceTab({
+  tab,
+  worktreeHostId,
+  activeWorktreeId,
+  activeWorkspaceExecutionHostId,
+  activeTabType,
+  activeTabId,
+  activeTabIdByWorktree,
+  activeFileId,
+  activeFileIdByWorktree,
+  activeTabTypeByWorktree,
+  activeUnifiedTabId
+}: Pick<
+  BuildSearchableWorkspaceTabsOptions,
+  | 'activeFileId'
+  | 'activeFileIdByWorktree'
+  | 'activeTabId'
+  | 'activeTabIdByWorktree'
+  | 'activeTabType'
+  | 'activeTabTypeByWorktree'
+  | 'activeWorktreeId'
+  | 'activeWorkspaceExecutionHostId'
+> & {
+  tab: Tab & { contentType: WorkspaceTabContentType }
+  worktreeHostId?: Worktree['hostId']
+  activeUnifiedTabId: string | null
+}): boolean {
+  if (
+    !isPaletteCurrentWorktree(
+      { id: tab.worktreeId, hostId: worktreeHostId },
+      activeWorktreeId,
+      activeWorkspaceExecutionHostId
+    )
+  ) {
+    return false
+  }
+  const visibleType = tab.contentType === 'terminal' ? 'terminal' : 'editor'
+  const storedType = activeTabTypeByWorktree[tab.worktreeId] ?? activeTabType
+  if (storedType !== visibleType || activeUnifiedTabId !== tab.id) {
+    return false
+  }
+  return visibleType === 'terminal'
+    ? (activeTabIdByWorktree[tab.worktreeId] ?? activeTabId) === tab.entityId
+    : (activeFileIdByWorktree[tab.worktreeId] ?? activeFileId) === tab.entityId
+}
+
+function isWorkspaceTabContentType(
+  contentType: TabContentType
+): contentType is WorkspaceTabContentType {
+  return ['terminal', 'editor', 'diff', 'conflict-review', 'check-details'].includes(contentType)
+}
+
+export function buildSearchableWorkspaceTabEntries({
+  worktrees,
+  repoMap,
+  repoMapByHostIdentity,
+  worktreeOrder,
+  unifiedTabsByWorktree,
+  tabsByWorktree,
+  openFiles,
+  agentStatusByPaneKey,
+  retainedAgentsByPaneKey,
+  sleepingAgentSessionsByPaneKey,
+  activeGroupIdByWorktree,
+  groupsByWorktree,
+  activeWorktreeId,
+  activeWorkspaceExecutionHostId,
+  activeTabType,
+  activeTabId,
+  activeTabIdByWorktree,
+  activeFileId,
+  activeFileIdByWorktree,
+  activeTabTypeByWorktree,
+  generatedTitlesEnabled,
+  terminalLayoutsByTabId,
+  paneForegroundAgentByPaneKey
+}: BuildSearchableWorkspaceTabsOptions): SearchableWorkspaceTab[] {
+  const entries: SearchableWorkspaceTab[] = []
+  const seenTabIds = new Set<string>()
+  const openFilesById = new Map(openFiles.map((file) => [file.id, file]))
+  const agentIndex = buildAgentMetadataTabIndex({
+    agentStatusByPaneKey,
+    retainedAgentsByPaneKey,
+    sleepingAgentSessionsByPaneKey
+  })
+
+  for (const worktree of worktrees) {
+    const repoName =
+      resolvePaletteRepoForWorktree(worktree, repoMap, repoMapByHostIdentity)?.displayName ?? ''
+    const worktreeName = resolveWorktreeDisplayName(worktree)
+    const branch = resolveWorktreeBranchLabel(worktree)
+    const worktreeSortIndex =
+      worktreeOrder.get(getWorktreeHostIdentity(worktree)) ??
+      worktreeOrder.get(worktree.id) ??
+      Number.MAX_SAFE_INTEGER
+    const activeUnifiedTabId = getActiveUnifiedTabId({
+      worktreeId: worktree.id,
+      worktreeHostId: worktree.hostId,
+      activeWorktreeId,
+      activeWorkspaceExecutionHostId,
+      activeTabType,
+      activeGroupIdByWorktree,
+      groupsByWorktree
+    })
+    const groups = groupsByWorktree[worktree.id] ?? []
+    const groupOrder = new Map(groups.map((group, index) => [group.id, index]))
+    const tabOrder = new Map<string, number>()
+    for (const group of groups) {
+      group.tabOrder.forEach((tabId, index) => tabOrder.set(tabId, index))
+    }
+    const terminalTabs = new Map((tabsByWorktree[worktree.id] ?? []).map((tab) => [tab.id, tab]))
+
+    for (const rawTab of unifiedTabsByWorktree[worktree.id] ?? []) {
+      if (!isWorkspaceTabContentType(rawTab.contentType) || seenTabIds.has(rawTab.id)) {
+        continue
+      }
+      const tab = rawTab as Tab & { contentType: WorkspaceTabContentType }
+      const baseEntry = {
+        tab,
+        worktree,
+        repoName,
+        worktreeSortIndex,
+        groupSortIndex: groupOrder.get(tab.groupId) ?? Number.MAX_SAFE_INTEGER,
+        tabSortIndex: tabOrder.get(tab.id) ?? tab.sortOrder,
+        isCurrentTab: isCurrentWorkspaceTab({
+          tab,
+          worktreeHostId: worktree.hostId,
+          activeWorktreeId,
+          activeWorkspaceExecutionHostId,
+          activeTabType,
+          activeTabId,
+          activeTabIdByWorktree,
+          activeFileId,
+          activeFileIdByWorktree,
+          activeTabTypeByWorktree,
+          activeUnifiedTabId
+        }),
+        isCurrentWorktree: isPaletteCurrentWorktree(
+          worktree,
+          activeWorktreeId,
+          activeWorkspaceExecutionHostId
+        )
+      }
+      if (tab.contentType === 'terminal') {
+        const terminalTab = terminalTabs.get(tab.entityId)
+        const terminalTitle = terminalTab
+          ? resolveTerminalTabTitle(terminalTab, generatedTitlesEnabled, 'Terminal')
+          : 'Terminal'
+        const title = resolveUnifiedTabLabel(
+          {
+            ...tab,
+            customLabel: tab.customLabel ?? terminalTab?.customTitle ?? null,
+            quickCommandLabel: tab.quickCommandLabel ?? terminalTab?.quickCommandLabel,
+            generatedLabel: tab.generatedLabel ?? terminalTab?.generatedTitle
+          },
+          generatedTitlesEnabled,
+          terminalTitle
+        )
+        seenTabIds.add(tab.id)
+        entries.push({
+          ...baseEntry,
+          title,
+          secondaryText: '',
+          titleSearchText: title,
+          secondarySearchTexts: [],
+          typeSearchAliases: ['terminal tab', 'terminal'],
+          document: buildPaletteTabDocument({
+            id: tab.id,
+            title,
+            secondaryTexts: [],
+            worktreeName,
+            branch,
+            repoName,
+            typeAliases: ['terminal tab', 'terminal']
+          }),
+          agentMetadata: collectAgentMetadataFromIndex(agentIndex, tab.entityId, worktree.id),
+          occupantAgent: resolveOpenTabOccupantAgent({
+            tabId: tab.entityId,
+            title,
+            defaultTitle: terminalTab?.defaultTitle,
+            launchAgent: terminalTab?.launchAgent,
+            layout: terminalLayoutsByTabId?.[tab.entityId],
+            agentStatusByPaneKey,
+            retainedAgentsByPaneKey,
+            sleepingAgentSessionsByPaneKey,
+            paneForegroundAgentByPaneKey
+          })
+        })
+        continue
+      }
+      const file = openFilesById.get(tab.entityId)
+      if (!file || file.worktreeId !== worktree.id) {
+        continue
+      }
+      const title = getEditorDisplayLabel(file)
+      seenTabIds.add(tab.id)
+      entries.push({
+        ...baseEntry,
+        title,
+        secondaryText: file.relativePath,
+        titleSearchText: title,
+        secondarySearchTexts: [file.relativePath, file.filePath],
+        document: buildPaletteTabDocument({
+          id: tab.id,
+          title,
+          secondaryTexts: [file.relativePath, file.filePath],
+          worktreeName,
+          branch,
+          repoName
+        }),
+        agentMetadata: [],
+        occupantAgent: null
+      })
+    }
+  }
+  return entries
+}

--- a/src/renderer/src/lib/workspace-tab-palette-results.ts
+++ b/src/renderer/src/lib/workspace-tab-palette-results.ts
@@ -10,6 +10,7 @@ import {
   resolveWorktreeDisplayName
 } from './worktree-default-display-name'
 import { matchWorkspaceTabAgentSnippet } from './workspace-tab-agent-snippet-match'
+import type { ExecutionHostId } from '../../../shared/execution-host'
 import type { MatchRange } from './palette-match/normalized-text'
 import type { PaletteDocumentRank } from './palette-match/palette-document'
 import type { PaletteResultQualityClass } from './palette-match/match-quality'
@@ -22,6 +23,8 @@ import type {
 const NO_RANGES: readonly MatchRange[] = []
 
 export type WorkspaceTabPaletteSearchResult = {
+  /** Worktree ids collide across hosts; activation must not resolve by id alone. */
+  executionHostId?: ExecutionHostId
   tabId: string
   entityId: string
   worktreeId: string
@@ -81,6 +84,7 @@ function positionScore(entry: SearchableWorkspaceTab): number {
 
 function baseResult(entry: SearchableWorkspaceTab): WorkspaceTabPaletteSearchResult {
   return {
+    ...(entry.worktree.hostId ? { executionHostId: entry.worktree.hostId } : {}),
     tabId: entry.tab.id,
     entityId: entry.tab.entityId,
     worktreeId: entry.worktree.id,

--- a/src/renderer/src/lib/workspace-tab-palette-search.test.ts
+++ b/src/renderer/src/lib/workspace-tab-palette-search.test.ts
@@ -134,6 +134,52 @@ function buildEntries(overrides: Partial<Parameters<typeof buildSearchableWorksp
 }
 
 describe('workspace-tab-palette-search', () => {
+  it('stamps the row execution host so activation never resolves by id alone', () => {
+    // Why: worktree ids repeat across hosts, so a host-blind activation opened the other
+    // host's workspace behind a row labelled with this one's name and branch.
+    const worktree = makeWorktree({ hostId: 'ssh:box' })
+    const entries = buildEntries({ worktrees: [worktree] })
+    const [result] = searchWorkspaceTabs(entries, '')
+    expect(result.executionHostId).toBe('ssh:box')
+  })
+
+  it('keeps the resolvable twin when the first record under an id has no open file', () => {
+    // Why: dropping the id on sight would lose the row entirely — the leading
+    // record dies at the open-file lookup and the survivor never gets its turn.
+    const orphaned = makeUnifiedTab({
+      id: 'unified-editor-dup',
+      contentType: 'editor',
+      entityId: 'missing-file'
+    })
+    const resolvable = makeUnifiedTab({
+      id: 'unified-editor-dup',
+      contentType: 'editor',
+      entityId: SRC_APP_PATH
+    })
+    const entries = buildEntries({
+      unifiedTabsByWorktree: { 'wt-1': [orphaned, resolvable] },
+      openFiles: [makeOpenFile()]
+    })
+
+    expect(entries.map((entry) => entry.tab.id)).toEqual(['unified-editor-dup'])
+    expect(entries[0]?.secondaryText).toBe(SRC_APP_RELATIVE_PATH)
+  })
+  it('emits one entry per tab id when a session persisted the same id twice', () => {
+    // Why: the palette keys rows by tab id, and duplicated persisted records used
+    // to render the row twice under one React key, stranding a ghost row.
+    const duplicate = makeUnifiedTab({ id: 'unified-terminal-dup' })
+    const entries = buildEntries({
+      unifiedTabsByWorktree: {
+        'wt-1': [makeUnifiedTab(), duplicate, { ...duplicate }]
+      }
+    })
+
+    const tabIds = entries.map((entry) => entry.tab.id)
+    expect(tabIds).toEqual(['unified-terminal-1', 'unified-terminal-dup'])
+
+    const results = searchWorkspaceTabs(entries, 'unified')
+    expect(results.map((result) => result.tabId)).toEqual(tabIds)
+  })
   it('uses the same title precedence as the tab strip and honors generated-title disabling', () => {
     const enabledEntries = buildEntries({
       tabsByWorktree: {

--- a/src/renderer/src/lib/workspace-tab-palette-search.ts
+++ b/src/renderer/src/lib/workspace-tab-palette-search.ts
@@ -1,3 +1,4 @@
+import { getWorktreeHostIdentity } from '../../../shared/worktree/host-qualified-identity'
 import { getEditorDisplayLabel } from '@/components/editor/editor-labels'
 import type { OpenFile } from '@/store/slices/editor'
 import { buildPaletteTabDocument } from './palette-match/tab-document'
@@ -182,6 +183,9 @@ export function buildSearchableWorkspaceTabs({
   paneForegroundAgentByPaneKey
 }: BuildSearchableWorkspaceTabsOptions): SearchableWorkspaceTab[] {
   const entries: SearchableWorkspaceTab[] = []
+  // Why global, not per worktree: the palette keys rows by tab id alone, so a
+  // repeated id anywhere in the session would render the same row twice.
+  const seenTabIds = new Set<string>()
   const openFilesById = new Map(openFiles.map((file) => [file.id, file]))
   const agentIndex = buildAgentMetadataTabIndex({
     agentStatusByPaneKey,
@@ -193,7 +197,10 @@ export function buildSearchableWorkspaceTabs({
     const repoName = repoMap.get(worktree.repoId)?.displayName ?? ''
     const worktreeName = resolveWorktreeDisplayName(worktree)
     const branch = resolveWorktreeBranchLabel(worktree)
-    const worktreeSortIndex = worktreeOrder.get(worktree.id) ?? Number.MAX_SAFE_INTEGER
+    const worktreeSortIndex =
+      worktreeOrder.get(getWorktreeHostIdentity(worktree)) ??
+      worktreeOrder.get(worktree.id) ??
+      Number.MAX_SAFE_INTEGER
     const activeUnifiedTabId = getActiveUnifiedTabId({
       worktreeId: worktree.id,
       activeWorktreeId,
@@ -211,6 +218,11 @@ export function buildSearchableWorkspaceTabs({
 
     for (const rawTab of unifiedTabsByWorktree[worktree.id] ?? []) {
       if (!isWorkspaceTabContentType(rawTab.contentType)) {
+        continue
+      }
+      // Why claim the id only at the push below: a duplicate whose twin never
+      // resolves an open file must still get its chance to produce the row.
+      if (seenTabIds.has(rawTab.id)) {
         continue
       }
       const tab = rawTab as Tab & { contentType: WorkspaceTabContentType }
@@ -254,6 +266,7 @@ export function buildSearchableWorkspaceTabs({
           generatedTitlesEnabled,
           terminalTitle
         )
+        seenTabIds.add(tab.id)
         entries.push({
           ...baseEntry,
           title,
@@ -294,6 +307,7 @@ export function buildSearchableWorkspaceTabs({
         continue
       }
       const title = getEditorDisplayLabel(file)
+      seenTabIds.add(tab.id)
       entries.push({
         ...baseEntry,
         title,

--- a/src/renderer/src/lib/workspace-tab-palette-search.ts
+++ b/src/renderer/src/lib/workspace-tab-palette-search.ts
@@ -1,28 +1,13 @@
-import { getWorktreeHostIdentity } from '../../../shared/worktree/host-qualified-identity'
-import { getEditorDisplayLabel } from '@/components/editor/editor-labels'
 import type { OpenFile } from '@/store/slices/editor'
-import { buildPaletteTabDocument } from './palette-match/tab-document'
 import type { PaletteDocument } from './palette-match/palette-document'
-import {
-  resolveWorktreeBranchLabel,
-  resolveWorktreeDisplayName
-} from './worktree-default-display-name'
-import {
-  resolveTerminalTabTitle,
-  resolveUnifiedTabLabel
-} from '../../../shared/tab-title-resolution'
-import type { Tab, TabContentType, TabGroup } from '../../../shared/tab-types'
+import type { Tab, TabGroup } from '../../../shared/tab-types'
 import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
 import type { TerminalLayoutSnapshot, TerminalTab } from '../../../shared/terminal-tab-types'
 import type { TuiAgent } from '../../../shared/tui-agent'
 import type { Worktree } from '../../../shared/worktree/types'
-import { resolveOpenTabOccupantAgent } from './open-tab-occupant-agent'
-import {
-  buildAgentMetadataTabIndex,
-  collectAgentMetadataFromIndex,
-  type AgentMetadata,
-  type WorkspaceTabAgentMetadataState
-} from './workspace-tab-agent-metadata'
+import type { ExecutionHostId } from '../../../shared/execution-host'
+import type { AgentMetadata, WorkspaceTabAgentMetadataState } from './workspace-tab-agent-metadata'
+import { buildSearchableWorkspaceTabEntries } from './workspace-tab-palette-entry-builder'
 export {
   searchWorkspaceTabs,
   type WorkspaceTabPaletteSearchResult
@@ -69,6 +54,7 @@ type WorkspaceTabPaletteActiveTabType = 'browser' | 'editor' | 'terminal' | 'sim
 export type BuildSearchableWorkspaceTabsOptions = WorkspaceTabAgentMetadataState & {
   worktrees: readonly Worktree[]
   repoMap: ReadonlyMap<string, { displayName?: string | null }>
+  repoMapByHostIdentity?: ReadonlyMap<string, { displayName?: string | null }>
   worktreeOrder: ReadonlyMap<string, number>
   unifiedTabsByWorktree: Record<string, readonly Tab[] | undefined>
   tabsByWorktree: Record<string, readonly TerminalTab[] | undefined>
@@ -76,6 +62,7 @@ export type BuildSearchableWorkspaceTabsOptions = WorkspaceTabAgentMetadataState
   activeGroupIdByWorktree: Record<string, string | undefined>
   groupsByWorktree: Record<string, readonly TabGroup[] | undefined>
   activeWorktreeId: string | null
+  activeWorkspaceExecutionHostId?: ExecutionHostId | null
   activeTabType: WorkspaceTabPaletteActiveTabType
   activeTabId: string | null
   activeTabIdByWorktree: Record<string, string | null | undefined>
@@ -87,246 +74,4 @@ export type BuildSearchableWorkspaceTabsOptions = WorkspaceTabAgentMetadataState
   paneForegroundAgentByPaneKey?: Record<string, PaneForegroundAgentEntry>
 }
 
-function getActiveUnifiedTabId({
-  worktreeId,
-  activeWorktreeId,
-  activeTabType,
-  activeGroupIdByWorktree,
-  groupsByWorktree
-}: Pick<
-  BuildSearchableWorkspaceTabsOptions,
-  'activeGroupIdByWorktree' | 'activeTabType' | 'activeWorktreeId' | 'groupsByWorktree'
-> & {
-  worktreeId: string
-}): string | null {
-  if (activeWorktreeId !== worktreeId) {
-    return null
-  }
-  const activeGroupId = activeGroupIdByWorktree[worktreeId]
-  const activeGroup = activeGroupId
-    ? (groupsByWorktree[worktreeId] ?? []).find((group) => group.id === activeGroupId)
-    : undefined
-  const activeUnifiedTabId = activeGroup?.activeTabId ?? null
-  return activeTabType === 'terminal' || activeTabType === 'editor' ? activeUnifiedTabId : null
-}
-
-function isCurrentWorkspaceTab({
-  tab,
-  activeWorktreeId,
-  activeTabType,
-  activeTabId,
-  activeTabIdByWorktree,
-  activeFileId,
-  activeFileIdByWorktree,
-  activeTabTypeByWorktree,
-  activeUnifiedTabId
-}: Pick<
-  BuildSearchableWorkspaceTabsOptions,
-  | 'activeFileId'
-  | 'activeFileIdByWorktree'
-  | 'activeTabId'
-  | 'activeTabIdByWorktree'
-  | 'activeTabType'
-  | 'activeTabTypeByWorktree'
-  | 'activeWorktreeId'
-> & {
-  tab: Tab & { contentType: WorkspaceTabContentType }
-  activeUnifiedTabId: string | null
-}): boolean {
-  if (tab.worktreeId !== activeWorktreeId) {
-    return false
-  }
-  const visibleType = tab.contentType === 'terminal' ? 'terminal' : 'editor'
-  const storedType = activeTabTypeByWorktree[tab.worktreeId] ?? activeTabType
-  if (storedType !== visibleType || activeUnifiedTabId !== tab.id) {
-    return false
-  }
-  if (visibleType === 'terminal') {
-    return (activeTabIdByWorktree[tab.worktreeId] ?? activeTabId) === tab.entityId
-  }
-  return (activeFileIdByWorktree[tab.worktreeId] ?? activeFileId) === tab.entityId
-}
-
-function isWorkspaceTabContentType(
-  contentType: TabContentType
-): contentType is WorkspaceTabContentType {
-  return (
-    contentType === 'terminal' ||
-    contentType === 'editor' ||
-    contentType === 'diff' ||
-    contentType === 'conflict-review' ||
-    contentType === 'check-details'
-  )
-}
-
-export function buildSearchableWorkspaceTabs({
-  worktrees,
-  repoMap,
-  worktreeOrder,
-  unifiedTabsByWorktree,
-  tabsByWorktree,
-  openFiles,
-  agentStatusByPaneKey,
-  retainedAgentsByPaneKey,
-  sleepingAgentSessionsByPaneKey,
-  activeGroupIdByWorktree,
-  groupsByWorktree,
-  activeWorktreeId,
-  activeTabType,
-  activeTabId,
-  activeTabIdByWorktree,
-  activeFileId,
-  activeFileIdByWorktree,
-  activeTabTypeByWorktree,
-  generatedTitlesEnabled,
-  terminalLayoutsByTabId,
-  paneForegroundAgentByPaneKey
-}: BuildSearchableWorkspaceTabsOptions): SearchableWorkspaceTab[] {
-  const entries: SearchableWorkspaceTab[] = []
-  // Why global, not per worktree: the palette keys rows by tab id alone, so a
-  // repeated id anywhere in the session would render the same row twice.
-  const seenTabIds = new Set<string>()
-  const openFilesById = new Map(openFiles.map((file) => [file.id, file]))
-  const agentIndex = buildAgentMetadataTabIndex({
-    agentStatusByPaneKey,
-    retainedAgentsByPaneKey,
-    sleepingAgentSessionsByPaneKey
-  })
-
-  for (const worktree of worktrees) {
-    const repoName = repoMap.get(worktree.repoId)?.displayName ?? ''
-    const worktreeName = resolveWorktreeDisplayName(worktree)
-    const branch = resolveWorktreeBranchLabel(worktree)
-    const worktreeSortIndex =
-      worktreeOrder.get(getWorktreeHostIdentity(worktree)) ??
-      worktreeOrder.get(worktree.id) ??
-      Number.MAX_SAFE_INTEGER
-    const activeUnifiedTabId = getActiveUnifiedTabId({
-      worktreeId: worktree.id,
-      activeWorktreeId,
-      activeTabType,
-      activeGroupIdByWorktree,
-      groupsByWorktree
-    })
-    const groups = groupsByWorktree[worktree.id] ?? []
-    const groupOrder = new Map(groups.map((group, index) => [group.id, index]))
-    const tabOrder = new Map<string, number>()
-    for (const group of groups) {
-      group.tabOrder.forEach((tabId, index) => tabOrder.set(tabId, index))
-    }
-    const terminalTabs = new Map((tabsByWorktree[worktree.id] ?? []).map((tab) => [tab.id, tab]))
-
-    for (const rawTab of unifiedTabsByWorktree[worktree.id] ?? []) {
-      if (!isWorkspaceTabContentType(rawTab.contentType)) {
-        continue
-      }
-      // Why claim the id only at the push below: a duplicate whose twin never
-      // resolves an open file must still get its chance to produce the row.
-      if (seenTabIds.has(rawTab.id)) {
-        continue
-      }
-      const tab = rawTab as Tab & { contentType: WorkspaceTabContentType }
-      const isCurrentTab = isCurrentWorkspaceTab({
-        tab,
-        activeWorktreeId,
-        activeTabType,
-        activeTabId,
-        activeTabIdByWorktree,
-        activeFileId,
-        activeFileIdByWorktree,
-        activeTabTypeByWorktree,
-        activeUnifiedTabId
-      })
-      const baseEntry = {
-        tab,
-        worktree,
-        repoName,
-        worktreeSortIndex,
-        groupSortIndex: groupOrder.get(tab.groupId) ?? Number.MAX_SAFE_INTEGER,
-        tabSortIndex: tabOrder.get(tab.id) ?? tab.sortOrder,
-        isCurrentTab,
-        isCurrentWorktree: activeWorktreeId === worktree.id
-      }
-
-      if (tab.contentType === 'terminal') {
-        const terminalTab = terminalTabs.get(tab.entityId)
-        // Match the tab strip: useTabGroupWorkspaceModel resolves the visible
-        // title from the unified tab, not tabsByWorktree. Those two can desync
-        // (live OSC on the label, stale "Terminal N" on the terminal record).
-        const terminalTitle = terminalTab
-          ? resolveTerminalTabTitle(terminalTab, generatedTitlesEnabled, 'Terminal')
-          : 'Terminal'
-        const title = resolveUnifiedTabLabel(
-          {
-            ...tab,
-            customLabel: tab.customLabel ?? terminalTab?.customTitle ?? null,
-            quickCommandLabel: tab.quickCommandLabel ?? terminalTab?.quickCommandLabel,
-            generatedLabel: tab.generatedLabel ?? terminalTab?.generatedTitle
-          },
-          generatedTitlesEnabled,
-          terminalTitle
-        )
-        seenTabIds.add(tab.id)
-        entries.push({
-          ...baseEntry,
-          title,
-          // Why: type is already clear from the status/content icon; a fixed
-          // "Terminal tab" label only crowds the row (and used to leave a bare "· ·").
-          secondaryText: '',
-          titleSearchText: title,
-          secondarySearchTexts: [],
-          typeSearchAliases: TERMINAL_TYPE_SEARCH_ALIASES,
-          document: buildPaletteTabDocument({
-            id: tab.id,
-            title,
-            secondaryTexts: [],
-            worktreeName,
-            branch,
-            repoName,
-            typeAliases: TERMINAL_TYPE_SEARCH_ALIASES
-          }),
-          agentMetadata: collectAgentMetadataFromIndex(agentIndex, tab.entityId, worktree.id),
-          occupantAgent: resolveOpenTabOccupantAgent({
-            tabId: tab.entityId,
-            // The unified label, not terminalTab.title: the record can lag it (see above).
-            title,
-            defaultTitle: terminalTab?.defaultTitle,
-            launchAgent: terminalTab?.launchAgent,
-            layout: terminalLayoutsByTabId?.[tab.entityId],
-            agentStatusByPaneKey,
-            retainedAgentsByPaneKey,
-            sleepingAgentSessionsByPaneKey,
-            paneForegroundAgentByPaneKey
-          })
-        })
-        continue
-      }
-
-      const file = openFilesById.get(tab.entityId)
-      if (!file || file.worktreeId !== worktree.id) {
-        continue
-      }
-      const title = getEditorDisplayLabel(file)
-      seenTabIds.add(tab.id)
-      entries.push({
-        ...baseEntry,
-        title,
-        secondaryText: file.relativePath,
-        titleSearchText: title,
-        secondarySearchTexts: [file.relativePath, file.filePath],
-        document: buildPaletteTabDocument({
-          id: tab.id,
-          title,
-          secondaryTexts: [file.relativePath, file.filePath],
-          worktreeName,
-          branch,
-          repoName
-        }),
-        agentMetadata: [],
-        occupantAgent: null
-      })
-    }
-  }
-
-  return entries
-}
+export const buildSearchableWorkspaceTabs = buildSearchableWorkspaceTabEntries

--- a/src/renderer/src/lib/worktree-palette-comment-snippet.test.ts
+++ b/src/renderer/src/lib/worktree-palette-comment-snippet.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { extractWorktreePaletteCommentSnippet } from './worktree-palette-comment-snippet'
+
+const EMOJI = '\u{1F680}'
+
+describe('extractWorktreePaletteCommentSnippet', () => {
+  it('highlights the match inside the returned text', () => {
+    const comment = 'the reconnect work is blocked on infra'
+    const matchStart = comment.indexOf('infra')
+    const { text, matchRange } = extractWorktreePaletteCommentSnippet(
+      comment,
+      matchStart,
+      matchStart + 'infra'.length
+    )
+    expect(text.slice(matchRange.start, matchRange.end)).toBe('infra')
+  })
+
+  // CJK carries no whitespace, so both boundary loops always exhaust their 10 iterations and
+  // stop wherever the raw code-unit arithmetic put them — which can be mid-surrogate-pair.
+  // Sweeping the emoji past the cut while the match stays put covers both halves of the pair.
+  it('never splits a surrogate pair at the leading edge', () => {
+    for (let offset = 0; offset < 40; offset += 1) {
+      const comment = `${'词'.repeat(offset)}${EMOJI}${'词'.repeat(80 - offset)}目标${'词'.repeat(20)}`
+      const matchStart = comment.indexOf('目标')
+      const { text, matchRange } = extractWorktreePaletteCommentSnippet(
+        comment,
+        matchStart,
+        matchStart + '目标'.length
+      )
+      expect(text.isWellFormed()).toBe(true)
+      expect(text.slice(matchRange.start, matchRange.end)).toBe('目标')
+    }
+  })
+
+  it('never splits a surrogate pair at the trailing edge', () => {
+    for (let offset = 0; offset < 70; offset += 1) {
+      const comment = `${'词'.repeat(20)}目标${'词'.repeat(offset)}${EMOJI}${'词'.repeat(90 - offset)}`
+      const matchStart = comment.indexOf('目标')
+      const { text, matchRange } = extractWorktreePaletteCommentSnippet(
+        comment,
+        matchStart,
+        matchStart + '目标'.length
+      )
+      expect(text.isWellFormed()).toBe(true)
+      expect(text.slice(matchRange.start, matchRange.end)).toBe('目标')
+    }
+  })
+})

--- a/src/renderer/src/lib/worktree-palette-comment-snippet.test.ts
+++ b/src/renderer/src/lib/worktree-palette-comment-snippet.test.ts
@@ -3,6 +3,14 @@ import { extractWorktreePaletteCommentSnippet } from './worktree-palette-comment
 
 const EMOJI = '\u{1F680}'
 
+// Why not `isWellFormed` alone: it only proves no half-pair survived, which an
+// implementation that DELETES the emoji satisfies just as well. The retained span must
+// be a contiguous slice of the source, so nothing may be dropped out of its middle.
+function expectContiguousSlice(text: string, comment: string): void {
+  const core = text.replace(/^\u2026/, '').replace(/\u2026$/, '')
+  expect(comment).toContain(core)
+}
+
 describe('extractWorktreePaletteCommentSnippet', () => {
   it('highlights the match inside the returned text', () => {
     const comment = 'the reconnect work is blocked on infra'
@@ -19,6 +27,7 @@ describe('extractWorktreePaletteCommentSnippet', () => {
   // stop wherever the raw code-unit arithmetic put them — which can be mid-surrogate-pair.
   // Sweeping the emoji past the cut while the match stays put covers both halves of the pair.
   it('never splits a surrogate pair at the leading edge', () => {
+    let keptEmoji = 0
     for (let offset = 0; offset < 40; offset += 1) {
       const comment = `${'词'.repeat(offset)}${EMOJI}${'词'.repeat(80 - offset)}目标${'词'.repeat(20)}`
       const matchStart = comment.indexOf('目标')
@@ -29,10 +38,18 @@ describe('extractWorktreePaletteCommentSnippet', () => {
       )
       expect(text.isWellFormed()).toBe(true)
       expect(text.slice(matchRange.start, matchRange.end)).toBe('目标')
+      expectContiguousSlice(text, comment)
+      if (text.includes(EMOJI)) {
+        keptEmoji += 1
+      }
     }
+    // Why: the boundary iterations are the point of the loop — if the snap dropped the
+    // emoji on every one of them, the assertions above would still all pass.
+    expect(keptEmoji).toBeGreaterThan(0)
   })
 
   it('never splits a surrogate pair at the trailing edge', () => {
+    let keptEmoji = 0
     for (let offset = 0; offset < 70; offset += 1) {
       const comment = `${'词'.repeat(20)}目标${'词'.repeat(offset)}${EMOJI}${'词'.repeat(90 - offset)}`
       const matchStart = comment.indexOf('目标')
@@ -43,6 +60,11 @@ describe('extractWorktreePaletteCommentSnippet', () => {
       )
       expect(text.isWellFormed()).toBe(true)
       expect(text.slice(matchRange.start, matchRange.end)).toBe('目标')
+      expectContiguousSlice(text, comment)
+      if (text.includes(EMOJI)) {
+        keptEmoji += 1
+      }
     }
+    expect(keptEmoji).toBeGreaterThan(0)
   })
 })

--- a/src/renderer/src/lib/worktree-palette-comment-snippet.ts
+++ b/src/renderer/src/lib/worktree-palette-comment-snippet.ts
@@ -21,6 +21,17 @@ export function extractWorktreePaletteCommentSnippet(
     snippetEnd++
   }
 
+  // Why: the offsets above count UTF-16 code units and the boundary loops test one unit at
+  // a time, so either edge can land between the halves of a surrogate pair \u2014 CJK text backs
+  // up the full 10 iterations without ever finding whitespace. Snap outward to keep the pair
+  // whole; matchRange derives from snippetStart, so widening by one keeps it correct.
+  if (snippetStart > 0 && (comment.charCodeAt(snippetStart) & 0xfc00) === 0xdc00) {
+    snippetStart -= 1
+  }
+  if (snippetEnd < comment.length && (comment.charCodeAt(snippetEnd - 1) & 0xfc00) === 0xd800) {
+    snippetEnd += 1
+  }
+
   const prefix = snippetStart > 0 ? '\u2026' : ''
   const suffix = snippetEnd < comment.length ? '\u2026' : ''
   return {

--- a/src/renderer/src/lib/worktree-palette-create-action.test.ts
+++ b/src/renderer/src/lib/worktree-palette-create-action.test.ts
@@ -204,6 +204,22 @@ describe('worktree-palette-create-action', () => {
     ])
   })
 
+  it('names the rendered render key so a duplicate row is reachable by keyboard', () => {
+    // Why: rows render under de-duplicated keys, and cmdk selects by that rendered value.
+    // Naming the bare id here left the duplicate absent from the allow-list, so arrowing
+    // onto it failed the `includes` check and snapped the highlight back to the top.
+    expect(
+      getWorktreePaletteSelectionItemIds(
+        [
+          { id: '__header_worktrees__', type: 'section-header' },
+          { id: 'worktree:shared', type: 'worktree' },
+          { id: 'worktree:shared', type: 'worktree' }
+        ],
+        ['__header_worktrees__', 'worktree:shared', 'worktree:shared#dup1']
+      )
+    ).toEqual(['worktree:shared', 'worktree:shared#dup1'])
+  })
+
   it('falls back deterministically when the selected row disappears', () => {
     expect(
       getNextWorktreePaletteSelection({

--- a/src/renderer/src/lib/worktree-palette-create-action.ts
+++ b/src/renderer/src/lib/worktree-palette-create-action.ts
@@ -82,10 +82,16 @@ export function isSelectableWorktreePaletteEntry(
 
 export function getWorktreePaletteSelectionItemIds<
   T extends WorktreePaletteSelectionCandidateEntry
->(entries: readonly T[]): string[] {
+>(entries: readonly T[], renderKeys: readonly string[] = []): string[] {
   // Why: keyboard focus should mirror rendered order, including synthetic
   // action rows, while skipping headers and explanatory hint rows.
-  return entries.filter(isSelectableWorktreePaletteEntry).map((entry) => entry.id)
+  // Why renderKeys wins: rows render under de-duplicated keys, so naming the bare
+  // id here would leave a duplicate row absent from the list the `includes` check
+  // above consults — arrowing onto it would snap the highlight back to the top.
+  return entries
+    .map((entry, index) => ({ entry, id: renderKeys[index] ?? entry.id }))
+    .filter(({ entry }) => isSelectableWorktreePaletteEntry(entry))
+    .map(({ id }) => id)
 }
 
 export function getNextWorktreePaletteSelection({

--- a/src/renderer/src/lib/worktree-palette-document.ts
+++ b/src/renderer/src/lib/worktree-palette-document.ts
@@ -1,3 +1,4 @@
+import { getWorktreeHostIdentity } from '../../../shared/worktree/host-qualified-identity'
 import { issueCacheKey as getIssueCacheKey } from '@/store/slices/github'
 import { buildPaletteDocument, type PaletteDocument } from './palette-match/palette-document'
 import type { PaletteComposedEvidence } from './palette-match/evidence-composer'
@@ -146,7 +147,12 @@ export function buildWorktreePaletteDocument(
         profile: 'structured-label',
         // Why conditional: the host chip only renders for active remote hosts, and
         // an unrendered match would be unexplainable on the row.
-        text: sources.hostLabelByWorktreeId?.get(worktree.id) ?? ''
+        // Why both keys: the palette keys this map by host identity so two same-id
+        // workspaces keep distinct chips, but a bare-id map is still a valid input.
+        text:
+          sources.hostLabelByWorktreeId?.get(getWorktreeHostIdentity(worktree)) ??
+          sources.hostLabelByWorktreeId?.get(worktree.id) ??
+          ''
       }
     ],
     compositePairs: [
@@ -166,7 +172,13 @@ export function buildWorktreePaletteDocuments(
 ): Map<string, PaletteDocument> {
   const documents = new Map<string, PaletteDocument>()
   for (const worktree of worktrees) {
-    documents.set(worktree.id, buildWorktreePaletteDocument(worktree, sources))
+    // Why the host identity (STA-4343): `repoId::path` repeats across hosts, so keying on
+    // the bare id lets the second host overwrite the first and one workspace becomes
+    // unsearchable by its own name.
+    documents.set(
+      getWorktreeHostIdentity(worktree),
+      buildWorktreePaletteDocument(worktree, sources)
+    )
   }
   return documents
 }

--- a/src/renderer/src/lib/worktree-palette-document.ts
+++ b/src/renderer/src/lib/worktree-palette-document.ts
@@ -18,6 +18,7 @@ import {
 import type { HostedReviewInfo } from '../../../shared/hosted-review'
 import type { Repo } from '../../../shared/repo-types'
 import type { Worktree } from '../../../shared/worktree/types'
+import { resolvePaletteRepoForWorktree } from './palette-repo-resolution'
 
 export const WORKTREE_PALETTE_NAME_FIELD_ID = 'name'
 export const WORKTREE_PALETTE_BRANCH_FIELD_ID = 'branch'
@@ -35,6 +36,7 @@ export type WorktreePaletteEvidencePolicy = 'palette' | 'board'
 
 export type WorktreePaletteDocumentSources = {
   repoMap: ReadonlyMap<string, Repo>
+  repoMapByHostIdentity?: ReadonlyMap<string, Repo>
   prCache?: Record<string, PRCacheEntry> | null
   issueCache?: Record<string, IssueCacheEntry> | null
   workspacePortsByWorktreeId?: ReadonlyMap<
@@ -123,7 +125,11 @@ export function buildWorktreePaletteDocument(
   worktree: Worktree,
   sources: WorktreePaletteDocumentSources
 ): PaletteDocument {
-  const repo = sources.repoMap.get(worktree.repoId)
+  const repo = resolvePaletteRepoForWorktree(
+    worktree,
+    sources.repoMap,
+    sources.repoMapByHostIdentity
+  )
   return buildPaletteDocument({
     id: worktree.id,
     visibleFields: [

--- a/src/renderer/src/lib/worktree-palette-multi-keyword.test.ts
+++ b/src/renderer/src/lib/worktree-palette-multi-keyword.test.ts
@@ -8,6 +8,13 @@ import {
 import { searchWorktrees, type PaletteSearchResult } from './worktree-palette-search'
 import { buildWorktreePaletteDocuments } from './worktree-palette-document'
 import { PALETTE_QUERY_MAX_TOKENS, preparePaletteQuery } from './palette-match/palette-query'
+import { getWorktreeHostIdentity } from '../../../shared/worktree/host-qualified-identity'
+
+function documentKey(worktreeId: string): string {
+  return getWorktreeHostIdentity(
+    CMD_J_FIXTURE_WORKTREES.find((worktree) => worktree.id === worktreeId)!
+  )
+}
 
 function search(query: string, extra: Record<string, unknown> = {}): PaletteSearchResult[] {
   return searchWorktrees(CMD_J_FIXTURE_WORKTREES, query, CMD_J_FIXTURE_REPO_MAP, {
@@ -162,15 +169,22 @@ describe('document invalidation inputs', () => {
       repoMap: CMD_J_FIXTURE_REPO_MAP,
       workspacePortsByWorktreeId: CMD_J_FIXTURE_PORTS
     })
-    expect(before.get('wt-main-orca')?.evidenceUnits.has('port:3000')).toBe(false)
-    expect(after.get('wt-main-orca')?.evidenceUnits.has('port:3000')).toBe(true)
+    // Documents are keyed by host identity so two same-id workspaces on different hosts
+    // keep separate entries.
+    const key = documentKey('wt-main-orca')
+    expect(before.get(key)?.evidenceUnits.has('port:3000')).toBe(false)
+    expect(after.get(key)?.evidenceUnits.has('port:3000')).toBe(true)
   })
 
   it('keeps recency and current-tab state out of normalized field data', () => {
     const documents = buildWorktreePaletteDocuments(CMD_J_FIXTURE_WORKTREES, {
       repoMap: CMD_J_FIXTURE_REPO_MAP
     })
-    const fieldIds = [...(documents.get('wt-docs')?.fields ?? [])].map((field) => field.id)
+    const fieldIds = [...(documents.get(documentKey('wt-docs'))?.fields ?? [])].map(
+      (field) => field.id
+    )
+    // Guard the guard: a missing document would make the assertions below vacuous.
+    expect(fieldIds.length).toBeGreaterThan(0)
     expect(fieldIds).not.toContain('recency')
     expect(fieldIds).not.toContain('isCurrent')
   })

--- a/src/renderer/src/lib/worktree-palette-search.ts
+++ b/src/renderer/src/lib/worktree-palette-search.ts
@@ -25,6 +25,7 @@ import {
 import type { HostedReviewInfo } from '../../../shared/hosted-review'
 import type { Repo } from '../../../shared/repo-types'
 import type { Worktree } from '../../../shared/worktree/types'
+import { resolvePaletteRepoForWorktree } from './palette-repo-resolution'
 import {
   matchWorktreePaletteTaskUrl,
   parseCmdJTaskSourceUrl
@@ -157,6 +158,7 @@ export type WorktreePaletteSearchArgs = {
   query: string
   documents: ReadonlyMap<string, PaletteDocument>
   repoMap: ReadonlyMap<string, Repo>
+  repoMapByHostIdentity?: ReadonlyMap<string, Repo>
   checksReviewByWorktree?: ReadonlyMap<Worktree, HostedReviewInfo | null>
 }
 
@@ -179,7 +181,7 @@ export function searchWorktreeDocuments(args: WorktreePaletteSearchArgs): Palett
       const match = matchWorktreePaletteTaskUrl({
         worktree,
         intent: taskSourceUrl,
-        repo: args.repoMap.get(worktree.repoId),
+        repo: resolvePaletteRepoForWorktree(worktree, args.repoMap, args.repoMapByHostIdentity),
         review: args.checksReviewByWorktree?.get(worktree)
       })
       if (match) {
@@ -217,6 +219,7 @@ export function searchWorktrees(
     query,
     documents: buildWorktreePaletteDocuments(worktrees, documentSources),
     repoMap,
+    repoMapByHostIdentity: sources.repoMapByHostIdentity,
     checksReviewByWorktree: sources.checksReviewByWorktree
   })
 }

--- a/src/renderer/src/lib/worktree-palette-search.ts
+++ b/src/renderer/src/lib/worktree-palette-search.ts
@@ -1,3 +1,4 @@
+import { getWorktreeHostIdentity } from '../../../shared/worktree/host-qualified-identity'
 import { matchPaletteDocument } from './palette-match/match-document'
 import { preparePaletteQuery } from './palette-match/palette-query'
 import type { MatchRange } from './palette-match/normalized-text'
@@ -187,7 +188,7 @@ export function searchWorktreeDocuments(args: WorktreePaletteSearchArgs): Palett
       continue
     }
 
-    const document = args.documents.get(worktree.id)
+    const document = args.documents.get(getWorktreeHostIdentity(worktree))
     if (!document) {
       continue
     }

--- a/src/renderer/src/lib/worktree-palette-task-url-match.test.ts
+++ b/src/renderer/src/lib/worktree-palette-task-url-match.test.ts
@@ -696,6 +696,29 @@ describe('matchWorktreePaletteTaskUrl', () => {
     ).toBeNull()
   })
 
+  it('carries the worktree host so the board can key the Jira match by host identity', () => {
+    // Why: the other three providers spread worktreeHostId and Jira did not, so a Jira URL
+    // recorded an unqualified identity and the board filtered every lane to empty.
+    const intent = parseCmdJTaskSourceUrl('https://acme.atlassian.net/browse/PROJ-123')
+
+    expect(
+      matchWorktreePaletteTaskUrl({
+        worktree: makeWorktree({
+          hostId: 'ssh:box',
+          linkedWorkItem: {
+            provider: 'jira',
+            type: 'issue',
+            number: 0,
+            title: 'Ticket',
+            jiraIdentifier: 'PROJ-123',
+            url: 'https://acme.atlassian.net/browse/PROJ-123'
+          }
+        }),
+        intent: intent!
+      })
+    ).toMatchObject({ worktreeHostId: 'ssh:box' })
+  })
+
   // Same host, different site path: Jira Server installs are commonly path-scoped.
   it('rejects a Jira issue URL from a different site path on the same host', () => {
     const intent = parseCmdJTaskSourceUrl('https://jira.acme.test/one/browse/PROJ-123')

--- a/src/renderer/src/lib/worktree-palette-task-url-match.ts
+++ b/src/renderer/src/lib/worktree-palette-task-url-match.ts
@@ -316,6 +316,7 @@ export function matchWorktreePaletteTaskUrl(args: {
   }
   return buildWorktreePaletteTaskUrlResult({
     worktreeId: worktree.id,
+    ...(worktree.hostId ? { worktreeHostId: worktree.hostId } : {}),
     labelKind: 'issue',
     text: intent.parsed.issueKey
   })

--- a/src/renderer/src/store/slices/tab-group-state.ts
+++ b/src/renderer/src/store/slices/tab-group-state.ts
@@ -184,6 +184,23 @@ export function selectHydratedActiveGroupId(
   return candidates[0]?.id
 }
 
+/**
+ * Persisted sessions can hold two tab records under one id (editor owner
+ * migration re-stamps a tab id that another record already carries). Downstream
+ * consumers key React lists by tab id, and a repeated key leaves the extra row
+ * mounted forever, so the duplicate has to die at hydration.
+ */
+export function dedupeTabsById<T extends { id: string }>(tabs: T[]): T[] {
+  const seen = new Set<string>()
+  return tabs.filter((tab) => {
+    if (seen.has(tab.id)) {
+      return false
+    }
+    seen.add(tab.id)
+    return true
+  })
+}
+
 export function dedupeTabOrder(tabIds: string[]): string[] {
   const seen = new Set<string>()
   const deduped: string[] = []

--- a/src/renderer/src/store/slices/tabs-hydration.test.ts
+++ b/src/renderer/src/store/slices/tabs-hydration.test.ts
@@ -347,4 +347,43 @@ describe('buildHydratedTabState – legacy format', () => {
     const result = buildHydratedTabState(session, new Set(['w1', 'w2']))
     expect(Object.keys(result.unifiedTabsByWorktree)).toHaveLength(0)
   })
+  it('collapses tab records that a corrupt session persisted under one id', () => {
+    // Why: editor owner migration re-stamped a tab id a sibling record already
+    // held. Two rows under one id repeat a React key and strand a ghost row.
+    const duplicateId = 'editor:wt%3A%3Alungfish:env-a:FINAL-REPORT.md'
+    const editorTab = (id: string, sortOrder: number) => ({
+      id,
+      entityId: 'editor:wt%3A%3Alungfish:env-b:FINAL-REPORT.md',
+      groupId: 'g1',
+      worktreeId: 'w1',
+      contentType: 'editor' as const,
+      label: 'FINAL-REPORT.md',
+      customLabel: null,
+      color: null,
+      sortOrder,
+      createdAt: 1
+    })
+    const session: WorkspaceSessionState = {
+      ...makeBaseSession(),
+      unifiedTabs: {
+        w1: [editorTab('t-unique', 0), editorTab(duplicateId, 1), editorTab(duplicateId, 2)]
+      },
+      tabGroups: {
+        w1: [
+          {
+            id: 'g1',
+            worktreeId: 'w1',
+            activeTabId: 't-unique',
+            tabOrder: ['t-unique', duplicateId, duplicateId]
+          }
+        ]
+      }
+    }
+
+    const result = buildHydratedTabState(session, new Set(['w1']))
+    const hydratedIds = result.unifiedTabsByWorktree.w1.map((tab) => tab.id)
+    expect(hydratedIds).toEqual(['t-unique', duplicateId])
+    expect(new Set(hydratedIds).size).toBe(hydratedIds.length)
+    expect(result.groupsByWorktree.w1[0].tabOrder).toEqual(['t-unique', duplicateId])
+  })
 })

--- a/src/renderer/src/store/slices/tabs-hydration.test.ts
+++ b/src/renderer/src/store/slices/tabs-hydration.test.ts
@@ -383,6 +383,9 @@ describe('buildHydratedTabState – legacy format', () => {
     const result = buildHydratedTabState(session, new Set(['w1']))
     const hydratedIds = result.unifiedTabsByWorktree.w1.map((tab) => tab.id)
     expect(hydratedIds).toEqual(['t-unique', duplicateId])
+    // Why sortOrder: the two duplicate records differ only there, so an id-only
+    // assertion passes just as well for an implementation that keeps the LAST one.
+    expect(result.unifiedTabsByWorktree.w1.map((tab) => tab.sortOrder)).toEqual([0, 1])
     expect(new Set(hydratedIds).size).toBe(hydratedIds.length)
     expect(result.groupsByWorktree.w1[0].tabOrder).toEqual(['t-unique', duplicateId])
   })

--- a/src/renderer/src/store/slices/tabs-hydration.ts
+++ b/src/renderer/src/store/slices/tabs-hydration.ts
@@ -5,6 +5,7 @@ import { createBrowserUuid } from '@/lib/browser-uuid'
 import { adoptGrouplessTabs, layoutSpanningGroups } from './tab-group-reference-repair'
 import {
   dedupeTabOrder,
+  dedupeTabsById,
   getPersistedEditFileIdsByWorktree,
   isTransientEditorContentType,
   sanitizeRecentTabIds,
@@ -75,7 +76,7 @@ function hydrateUnifiedFormat(
         .filter((tab) => tab.aiVaultTitle)
         .map((tab) => [tab.id, tab.aiVaultTitle!])
     )
-    tabsByWorktree[worktreeId] = [...tabs]
+    const hydratedTabs = [...tabs]
       .map((tab) => ({
         ...tab,
         entityId: tab.entityId ?? tab.id
@@ -111,6 +112,8 @@ function hydrateUnifiedFormat(
         return persistedEditFileIds.has(tab.entityId)
       })
       .sort((a, b) => a.sortOrder - b.sortOrder || a.createdAt - b.createdAt)
+    // Why after the sort: the surviving record is the one the strip renders first.
+    tabsByWorktree[worktreeId] = dedupeTabsById(hydratedTabs)
   }
 
   for (const [worktreeId, groups] of Object.entries(session.tabGroups!)) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​589 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​38 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​551 |
| Prod | 24 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​758 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​331 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​427 |

<!-- /orca-pr-loc -->

## ELI5

When you have the same repository or worktree paths open on multiple machines (e.g. local vs remote SSH vs WSL), the Cmd+J jump palette previously conflated them under bare repository/worktree IDs, which could cause one host's workspace to overwrite another in search results or activate the wrong machine's worktree. This PR qualifies worktree and repo identities by execution host, guarantees strictly unique React render keys so corrupted tab records don't leave ghost rows in the palette list, preserves filter dropdown selection when options re-rank, and improves search query token matching (including emoji and whitespace handling).

## What Changed

- **Host-Qualified Worktree & Repo Resolution (`STA-4343`)**:
  - `WorktreeJumpPalette.tsx`: Worktree rows, active worktree detection (`isPaletteCurrentWorktree`), and repo display labels now resolve using host-qualified maps (`repoMapByHostIdentity`) and execution host IDs (`activeWorkspaceExecutionHostId`), preventing cross-host row collisions.
  - Workspace tabs, simulator tabs, and browser tabs in the palette carry `executionHostId` and resolve worktrees/repos via `resolveWorktree(id, hostId)`.
  - `worktree-palette-document.ts` & `worktree-palette-search.ts`: Key documents in `buildWorktreePaletteDocuments` by host identity (`getWorktreeHostIdentity(worktree)`) so multiple hosts publishing identical `repoId::path` values both remain searchable.
  - `worktree-palette-task-url-match.ts`: Propagates `worktreeHostId` on Jira task matching so boards key Jira issue matches by host identity.

- **Unique List Entry Render Keys & Ghost Row Prevention**:
  - `src/renderer/src/components/cmd-j/palette-list-entry-render-keys.ts`: Generates collision-free React keys and `cmdk` values via `getWorktreePaletteListEntryRenderKeys` by tracking seen keys and appending `#${seenCount}` for any duplicates.
  - Prevents React reconciliation bugs and ghost/unmounted DOM rows when a persisted session holds duplicate tab IDs.

- **Filter Field Cursor Tracking by Option ID**:
  - `PaletteFilterFieldOptions.tsx`: Stored highlight state now tracks `id: string | null` instead of numeric array position. When toggling an option causes the list to re-rank and move checked items to the front, the selection cursor remains locked to the toggled item.

- **Session Hydration Tab Deduplication**:
  - `tab-group-state.ts` & `tabs-hydration.ts`: `dedupeTabsById` prunes duplicate tab entries during `hydrateUnifiedFormat`, preventing corrupt persisted sessions from mounting duplicate tab instances.

- **Palette Search, Token Matching & Evidence Clamping**:
  - `palette-query.ts`: Collapses runs of whitespace (`replace(/ +/g, ' ')`) so multi-word queries with extra spaces still match the whole-query exact rank tier.
  - `palette-query.ts`: Expands `ALPHANUMERIC` regex to classify Unicode symbols (`\p{S}`) and emojis (`\p{Extended_Pictographic}`) as content tokens rather than dropped punctuation (e.g. `:rocket:` / `🚀` or `→`).
  - `palette-document.ts`: Implements first-wins for `evidenceUnits` to maintain offset parity with `indexPaletteFields`.
  - `match-document.ts`: Clamps evidence match ranges (`Math.min(..., unit.text.length)`) to guarantee highlights never extend beyond the rendered text length.
  - `palette-results.ts`: Pre-normalizes query tokens and action verb keywords once upfront before candidate ranking.

- **Max-Lines Ratchet & Modularization**:
  - Extracted tab palette entry builder logic to `workspace-tab-palette-entry-builder.ts` from `workspace-tab-palette-search.ts`.

## Why

1. In multi-host environments (e.g., local machine + SSH remote + WSL distros), multiple worktrees frequently share identical repository names and relative paths (`repoId::path`). Unqualified ID indexing meant the second host overrode the first in the search document cache and activation triggered the first host's worktree instead of the selected one.
2. If session state contained duplicate tab IDs (e.g., from prior editor migrations), duplicate `key={entry.id}` properties in React caused ghost items that never unmounted and could freeze list navigation.
3. Numeric cursor indexes in filter option dropdowns caused selection focus to jump to an unintended option whenever an item was toggled and re-ranked.

## Linked Issue

Fixes [STA-4343](https://linear.app/stably/issue/STA-4343)

## Visual Proof

`N/A` — Command palette internal resolution, selection, and search ranking logic; no intentional static visual styling changes.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

**Automated Test Coverage**:
- `WorktreeJumpPalette.test.tsx` (10 tests passing, covering host-qualification and distinct row resolution)
- `palette-duplicate-key-ghost-rows.test.tsx` (2 tests passing, validating ghost row elimination on duplicate keys)
- `palette-list-entry-render-keys.test.ts` (4 tests passing)
- `palette-match-core.test.ts` (46 tests passing, validating whitespace collapsing, emoji/symbol queries, and duplicate evidence clamping)
- `palette-filter-option-list.test.ts` (7 tests passing)
- `tabs-hydration.test.ts` (9 tests passing, verifying session tab deduplication)
- `workspace-tab-palette-search.test.ts` (21 tests passing)
- `palette-repo-resolution.test.ts` (host-qualified repo lookup)
- `worktree-palette-comment-snippet.test.ts` & `worktree-palette-task-url-match.test.ts` (Jira multi-host matching)

Ran `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/WorktreeJumpPalette.test.tsx src/renderer/src/lib/palette-match/ src/renderer/src/components/cmd-j/ src/renderer/src/lib/workspace-tab-palette-search.test.ts src/renderer/src/store/slices/tabs-hydration.test.ts` — **21 test files, 243 tests passed**.

## AI Disclosure

Internal contributor.

## Review

### Multi-Host & SSH / WSL Compatibility
- Documents and worktree resolution are keyed by `getWorktreeHostIdentity(worktree)`.
- Active worktree check compares `activeWorkspaceExecutionHostId`.
- Host badges and connection labels are preserved per-host.

### Backwards Compatibility
- `resolvePaletteRepoForWorktree` falls back gracefully to `repoMap.get(worktree.repoId)` if no host-qualified repo map is provided.
- `dedupeTabsById` safely cleans up legacy or migrated session tab states during hydration.

## Notes

- **Security**: No wire format or protocol changes; all changes are client-side UI resolution and search indexing.
- **Performance**: Normalized query tokens and quick action keywords are calculated once per query rather than per candidate during search ranking.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
