### PR TITLE
Preserve exact linked tasks in automations

### DIFF
--- a/src/cli/handlers/automations.ts
+++ b/src/cli/handlers/automations.ts
@@ -15,6 +15,8 @@ import {
 } from '../../shared/task-source-context'
 import type { ProjectHostSetup } from '../../shared/project-types'
 import type { TuiAgent } from '../../shared/tui-agent'
+import { normalizeWorkspaceLinkedItem } from '../../shared/workspace-linked-item'
+import type { WorkspaceLinkedItem } from '../../shared/worktree/types'
 import {
   DEFAULT_AUTOMATION_PRECHECK_TIMEOUT_SECONDS,
   MAX_AUTOMATION_PRECHECK_TIMEOUT_SECONDS
@@ -322,6 +324,35 @@ function getSourceContextFlag(
   return sourceContext
 }
 
+function getLinkedTaskFlag(
+  flags: Map<string, string | boolean>
+): WorkspaceLinkedItem | null | undefined {
+  if (!flags.has('linked-task')) {
+    return undefined
+  }
+  const value = flags.get('linked-task')
+  if (typeof value !== 'string') {
+    throw new RuntimeClientError(
+      'invalid_argument',
+      '--linked-task requires a JSON work item or null'
+    )
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(value)
+  } catch {
+    throw new RuntimeClientError('invalid_argument', '--linked-task must be valid JSON')
+  }
+  if (parsed === null) {
+    return null
+  }
+  const linkedTask = normalizeWorkspaceLinkedItem(parsed)
+  if (!linkedTask) {
+    throw new RuntimeClientError('invalid_argument', '--linked-task is not a valid work item')
+  }
+  return linkedTask
+}
+
 function getWorkspaceModeFlag(
   flags: Map<string, string | boolean>
 ): 'existing' | 'new_per_run' | undefined {
@@ -440,6 +471,7 @@ export const AUTOMATION_HANDLERS: Record<string, CommandHandler> = {
     }
     const target = await resolveDefaultTarget(flags, cwd, client)
     const sourceContext = getSourceContextFlag(flags)
+    const linkedTask = getLinkedTaskFlag(flags)
     const workspaceMode =
       getWorkspaceModeFlag(flags) ?? (target.workspace ? 'existing' : 'new_per_run')
     const result = await client.call<{ automation: Automation }>('automation.create', {
@@ -449,6 +481,7 @@ export const AUTOMATION_HANDLERS: Record<string, CommandHandler> = {
       agentId: getProviderFlag(flags),
       ...(target.runContext ? { runContext: target.runContext } : {}),
       ...(sourceContext !== undefined ? { sourceContext } : {}),
+      ...(linkedTask !== undefined ? { linkedTask } : {}),
       repo: target.repo,
       workspace: target.workspace,
       workspaceMode,
@@ -465,6 +498,7 @@ export const AUTOMATION_HANDLERS: Record<string, CommandHandler> = {
     const target = await getExplicitTarget(flags, cwd, client)
     const schedule = getScheduleFlag(flags, false)
     const sourceContext = getSourceContextFlag(flags)
+    const linkedTask = getLinkedTaskFlag(flags)
     const result = await client.call<{ automation: Automation }>('automation.update', {
       id: getRequiredStringFlag(flags, 'id'),
       updates: {
@@ -474,6 +508,7 @@ export const AUTOMATION_HANDLERS: Record<string, CommandHandler> = {
         agentId: getOptionalProviderFlag(flags),
         ...(target.runContext ? { runContext: target.runContext } : {}),
         ...(sourceContext !== undefined ? { sourceContext } : {}),
+        ...(linkedTask !== undefined ? { linkedTask } : {}),
         repo: target.repo,
         workspace: target.workspace,
         workspaceMode: getWorkspaceModeFlag(flags),

--- a/src/cli/index-automation-source-context.test.ts
+++ b/src/cli/index-automation-source-context.test.ts
@@ -104,6 +104,59 @@ describe('orca cli worktree awareness', () => {
     )
   })
 
+  it('passes an exact linked task separately from its source context', async () => {
+    const sourceContext = {
+      kind: 'task-source',
+      provider: 'github',
+      projectId: 'github:aprudkin/aimem',
+      hostId: 'local',
+      providerIdentity: { provider: 'github', owner: 'aprudkin', repo: 'aimem' }
+    }
+    const linkedTask = {
+      provider: 'github',
+      type: 'issue',
+      number: 814,
+      title: 'Disposable routing probe',
+      url: 'https://github.com/aprudkin/aimem/issues/814'
+    }
+    queueFixtures(
+      callMock,
+      okFixture('req_automation_create', {
+        automation: { id: 'auto-1', name: 'Task review' }
+      })
+    )
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(
+      [
+        'automations',
+        'create',
+        '--name',
+        'Task review',
+        '--trigger',
+        'daily',
+        '--prompt',
+        'Resolve the linked task',
+        '--provider',
+        'codex',
+        '--repo',
+        'id:repo-target',
+        '--source-context',
+        JSON.stringify(sourceContext),
+        '--linked-task',
+        JSON.stringify(linkedTask),
+        '--json'
+      ],
+      '/tmp/repo'
+    )
+
+    expect(callMock).toHaveBeenNthCalledWith(
+      1,
+      'automation.create',
+      expect.objectContaining({ sourceContext: expect.objectContaining(sourceContext), linkedTask })
+    )
+  })
+
   it('clears automation source context on edit with null', async () => {
     queueFixtures(
       callMock,

--- a/src/cli/index-automation-source-context.test.ts
+++ b/src/cli/index-automation-source-context.test.ts
@@ -180,6 +180,29 @@ describe('orca cli worktree awareness', () => {
     )
   })
 
+  it('clears an automation linked task on edit with null', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_edit', {
+        automation: { id: 'auto-1', name: 'Task review' }
+      })
+    )
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(['automations', 'edit', 'auto-1', '--linked-task', 'null', '--json'], '/tmp/repo')
+
+    expect(callMock).toHaveBeenNthCalledWith(
+      1,
+      'automation.update',
+      expect.objectContaining({
+        id: 'auto-1',
+        updates: expect.objectContaining({
+          linkedTask: null
+        })
+      })
+    )
+  })
+
   it('rejects invalid automation source context JSON before calling the runtime', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})

--- a/src/cli/specs/automations.test.ts
+++ b/src/cli/specs/automations.test.ts
@@ -1,0 +1,20 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { printHelp } from '../help'
+import { AUTOMATION_COMMAND_SPECS } from './automations'
+
+describe('automation command help', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it.each([
+    ['create', '--linked-task <json>'],
+    ['edit', '--linked-task <json|null>']
+  ])('advertises linked-task for automations %s', (command, expectedUsage) => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    printHelp(AUTOMATION_COMMAND_SPECS, ['automations', command])
+
+    expect(String(log.mock.calls[0]?.[0])).toContain(expectedUsage)
+  })
+})

--- a/src/cli/specs/automations.ts
+++ b/src/cli/specs/automations.ts
@@ -8,6 +8,7 @@ const AUTOMATION_TARGET_FLAGS = [
   'host',
   'project-host-setup',
   'source-context',
+  'linked-task',
   'workspace-mode',
   'base-branch'
 ]
@@ -58,6 +59,7 @@ export const AUTOMATION_COMMAND_SPECS: CommandSpec[] = [
       'Use --project with --host, or --project-host-setup, to run on a specific project host setup.',
       '--host runtime:<environment-id> targets that paired Orca server; use the id from `orca environment list`, not the environment name.',
       'Use --source-context with a JSON TaskSourceContext when task/provider data should come from a specific host/account; pass null on edit to clear it.',
+      'Use --linked-task with a JSON work item to preserve the exact external task separately from its source context; pass null on edit to clear it.',
       'Use --workspace to run in an existing worktree; otherwise the automation creates a new worktree per run.',
       'Use --precheck to run a bounded command before scheduled runs; exit code 0 continues, anything else records a skipped run.',
       'Use --reuse-session only with existing-workspace automations to submit later runs to the previous live automation session when it is still available. Use --fresh-session to disable reuse.'

--- a/src/cli/specs/automations.ts
+++ b/src/cli/specs/automations.ts
@@ -42,7 +42,7 @@ export const AUTOMATION_COMMAND_SPECS: CommandSpec[] = [
     path: ['automations', 'create'],
     summary: 'Create a scheduled Orca automation',
     usage:
-      'orca automations create --name <name> --trigger <preset|cron|rrule> --prompt <text> --provider <agent> [--precheck <command>] [--repo <selector>|--workspace <selector>|--project <id> [--host <id>]|--project-host-setup <id>] [--json]',
+      'orca automations create --name <name> --trigger <preset|cron|rrule> --prompt <text> --provider <agent> [--precheck <command>] [--repo <selector>|--workspace <selector>|--project <id> [--host <id>]|--project-host-setup <id>] [--linked-task <json>] [--json]',
     allowedFlags: [
       ...GLOBAL_FLAGS,
       'name',
@@ -73,7 +73,8 @@ export const AUTOMATION_COMMAND_SPECS: CommandSpec[] = [
   {
     path: ['automations', 'edit'],
     summary: 'Edit an Orca automation',
-    usage: 'orca automations edit <id> [--name <name>] [--trigger <preset|cron|rrule>] [--json]',
+    usage:
+      'orca automations edit <id> [--name <name>] [--trigger <preset|cron|rrule>] [--linked-task <json|null>] [--json]',
     allowedFlags: [
       ...GLOBAL_FLAGS,
       'id',

--- a/src/main/automations/headless-workspace-create.test.ts
+++ b/src/main/automations/headless-workspace-create.test.ts
@@ -103,4 +103,40 @@ describe('headless automation workspace create args', () => {
 
     expect(args.setupDecision).toBe('skip')
   })
+
+  it('links the exact external task when creating a new workspace', () => {
+    const sourceContext = {
+      kind: 'task-source' as const,
+      provider: 'github' as const,
+      projectId: 'github:aprudkin/aimem',
+      hostId: 'local' as const,
+      providerIdentity: { provider: 'github' as const, owner: 'aprudkin', repo: 'aimem' }
+    }
+    const linkedTask = {
+      provider: 'github' as const,
+      type: 'issue' as const,
+      number: 814,
+      title: 'Disposable routing probe',
+      url: 'https://github.com/aprudkin/aimem/issues/814'
+    }
+    const newerTask = {
+      ...linkedTask,
+      number: 815,
+      url: 'https://github.com/aprudkin/aimem/issues/815'
+    }
+    const args = buildHeadlessAutomationWorktreeCreateArgs({
+      automation: { ...automation, sourceContext, linkedTask: newerTask },
+      run: {
+        id: 'run-1',
+        title: 'Task review run',
+        scheduledFor: Date.UTC(2026, 0, 2, 3, 4, 5),
+        sourceContext,
+        linkedTask
+      },
+      repo
+    })
+
+    expect(args.linkedWorkItem).toEqual(linkedTask)
+    expect(args.linkedTaskSourceContext).toEqual(sourceContext)
+  })
 })

--- a/src/main/automations/headless-workspace-create.ts
+++ b/src/main/automations/headless-workspace-create.ts
@@ -3,7 +3,10 @@ import { buildAutomationWorkspaceProvenance } from '../../shared/automation-work
 import type { Repo } from '../../shared/repo-types'
 import type { OrcaRuntimeService } from '../runtime/orca-runtime'
 
-type HeadlessAutomationRunForWorkspace = Pick<AutomationRun, 'id' | 'title' | 'scheduledFor'>
+type HeadlessAutomationRunForWorkspace = Pick<
+  AutomationRun,
+  'id' | 'title' | 'scheduledFor' | 'sourceContext' | 'linkedTask'
+>
 type RuntimeCreateManagedWorktreeArgs = Parameters<OrcaRuntimeService['createManagedWorktree']>[0]
 
 export function buildHeadlessAutomationWorkspaceName(
@@ -32,6 +35,10 @@ export function buildHeadlessAutomationWorktreeCreateArgs({
   repo: Repo
   createdAt?: number
 }): RuntimeCreateManagedWorktreeArgs {
+  const linkedTask = Object.hasOwn(run, 'linkedTask') ? run.linkedTask : automation.linkedTask
+  const sourceContext = Object.hasOwn(run, 'sourceContext')
+    ? run.sourceContext
+    : automation.sourceContext
   return {
     repoSelector: repo.id,
     name: buildHeadlessAutomationWorkspaceName(run.title, run.scheduledFor),
@@ -41,6 +48,8 @@ export function buildHeadlessAutomationWorktreeCreateArgs({
     createdWithAgent: automation.agentId,
     startupAgent: automation.agentId,
     startupPrompt: automation.prompt,
+    linkedWorkItem: linkedTask ?? undefined,
+    linkedTaskSourceContext: linkedTask ? (sourceContext ?? undefined) : undefined,
     telemetrySource: 'unknown',
     automationProvenance: buildAutomationWorkspaceProvenance(automation, run, repo, createdAt)
   }

--- a/src/main/persistence-automations.test.ts
+++ b/src/main/persistence-automations.test.ts
@@ -282,6 +282,13 @@ describe('Store', () => {
   it('snapshots automation contexts onto runs', async () => {
     const store = await createStore()
     store.addRepo(makeRepo({ upstream: { owner: 'stablyai', repo: 'orca' } }))
+    const linkedTask = {
+      provider: 'github' as const,
+      type: 'issue' as const,
+      number: 814,
+      title: 'Disposable routing probe',
+      url: 'https://github.com/stablyai/orca/issues/814'
+    }
     const automation = store.createAutomation({
       name: 'Nightly',
       prompt: 'Run checks',
@@ -291,17 +298,24 @@ describe('Store', () => {
       workspaceId: 'wt1',
       timezone: 'UTC',
       rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
-      dtstart: new Date('2026-05-13T00:00:00Z').getTime()
+      dtstart: new Date('2026-05-13T00:00:00Z').getTime(),
+      linkedTask
     })
 
     const run = store.createAutomationRun(automation, new Date('2026-05-13T09:00:00Z').getTime())
-    store.updateAutomation(automation.id, { sourceContext: null, runContext: null })
+    store.updateAutomation(automation.id, {
+      sourceContext: null,
+      linkedTask: null,
+      runContext: null
+    })
 
     expect(run.runContext).toEqual(automation.runContext)
     expect(run.sourceContext).toEqual(automation.sourceContext)
+    expect(run.linkedTask).toEqual(linkedTask)
     expect(store.listAutomationRuns(automation.id)[0]).toMatchObject({
       runContext: automation.runContext,
-      sourceContext: automation.sourceContext
+      sourceContext: automation.sourceContext,
+      linkedTask
     })
   })
 

--- a/src/main/persistence/scheduling-automations/automation-definition-operations.ts
+++ b/src/main/persistence/scheduling-automations/automation-definition-operations.ts
@@ -7,6 +7,7 @@ import type {
 import type { PersistedState } from '../../../shared/persisted-state-types'
 import { normalizeAutomationPrecheck } from '../../../shared/automation-precheck'
 import { nextAutomationOccurrenceAfter } from '../../../shared/automation-schedules'
+import { isWorkspaceLinkedItemSourceContextMatch } from '../../../shared/workspace-linked-item-source-context'
 import type { StoreOwnedPersistedState } from '../loading-store/store-owned-state'
 import {
   getAutomationContextsForRepo,
@@ -36,6 +37,13 @@ export function createAutomation(
   const executionTargetType = repo?.connectionId ? 'ssh' : 'local'
   const schedulerOwner = getAutomationSchedulerOwner(repo)
   const contexts = getAutomationContextsForRepo(repo, operations.state.projectHostSetups ?? [])
+  const sourceContext = input.sourceContext ?? contexts.sourceContext
+  if (
+    input.linkedTask &&
+    (!sourceContext || !isWorkspaceLinkedItemSourceContextMatch(input.linkedTask, sourceContext))
+  ) {
+    throw new Error('Linked task and source context identities must match.')
+  }
   const automation: Automation = {
     id: randomUUID(),
     name: input.name.trim() || 'Untitled automation',
@@ -43,7 +51,8 @@ export function createAutomation(
     precheck: normalizeAutomationPrecheck(input.precheck),
     agentId: input.agentId,
     runContext: input.runContext ?? contexts.runContext,
-    sourceContext: input.sourceContext ?? contexts.sourceContext,
+    sourceContext,
+    linkedTask: input.linkedTask ?? null,
     projectId: input.projectId,
     executionTargetType,
     executionTargetId: executionTargetType === 'ssh' ? (repo?.connectionId ?? '') : 'local',
@@ -96,6 +105,20 @@ export function updateAutomation(
   const dtstart = updates.dtstart ?? current.dtstart
   const scheduleChanged = updates.rrule !== undefined || updates.dtstart !== undefined
   const workspaceMode = updates.workspaceMode ?? current.workspaceMode
+  const sourceContext = Object.hasOwn(definedUpdates, 'sourceContext')
+    ? (definedUpdates.sourceContext ?? null)
+    : updates.projectId !== undefined
+      ? contexts.sourceContext
+      : (current.sourceContext ?? contexts.sourceContext)
+  const linkedTask = Object.hasOwn(definedUpdates, 'linkedTask')
+    ? (definedUpdates.linkedTask ?? null)
+    : (current.linkedTask ?? null)
+  if (
+    linkedTask &&
+    (!sourceContext || !isWorkspaceLinkedItemSourceContextMatch(linkedTask, sourceContext))
+  ) {
+    throw new Error('Linked task and source context identities must match.')
+  }
   const updated: Automation = {
     ...current,
     ...definedUpdates,
@@ -109,11 +132,8 @@ export function updateAutomation(
       : updates.projectId !== undefined
         ? contexts.runContext
         : (current.runContext ?? contexts.runContext),
-    sourceContext: Object.hasOwn(definedUpdates, 'sourceContext')
-      ? (definedUpdates.sourceContext ?? null)
-      : updates.projectId !== undefined
-        ? contexts.sourceContext
-        : (current.sourceContext ?? contexts.sourceContext),
+    sourceContext,
+    linkedTask,
     executionTargetType,
     executionTargetId: executionTargetType === 'ssh' ? (repo?.connectionId ?? '') : 'local',
     schedulerOwner,

--- a/src/main/persistence/scheduling-automations/automation-run-operations.ts
+++ b/src/main/persistence/scheduling-automations/automation-run-operations.ts
@@ -59,6 +59,7 @@ export function createAutomationRun(
     runNumber,
     runContext: automation.runContext ?? null,
     sourceContext: automation.sourceContext ?? null,
+    linkedTask: automation.linkedTask ?? null,
     title: `${automation.name} run ${runNumber}`,
     scheduledFor,
     status: 'pending',

--- a/src/main/runtime/orca-runtime-automations.test.ts
+++ b/src/main/runtime/orca-runtime-automations.test.ts
@@ -71,6 +71,34 @@ const existingAutomation = {
 } satisfies Automation
 
 describe('OrcaRuntimeService automation methods', () => {
+  it('forwards linked task create, edit, and clear mutations to persistence', async () => {
+    const linkedTask = {
+      provider: 'github' as const,
+      type: 'issue' as const,
+      number: 814,
+      title: 'Disposable routing probe',
+      url: 'https://github.com/aprudkin/aimem/issues/814'
+    }
+    const store = makeStore([existingAutomation])
+    const runtime = new OrcaRuntimeService(store as never)
+
+    await runtime.createAutomation({
+      name: 'Task review',
+      prompt: 'Resolve task',
+      agentId: 'codex',
+      repo: 'repo-1',
+      linkedTask,
+      rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
+      dtstart: 1
+    })
+    await runtime.updateAutomation('auto-1', { linkedTask })
+    await runtime.updateAutomation('auto-1', { linkedTask: null })
+
+    expect(store.createAutomation).toHaveBeenCalledWith(expect.objectContaining({ linkedTask }))
+    expect(store.updateAutomation).toHaveBeenNthCalledWith(1, 'auto-1', { linkedTask })
+    expect(store.updateAutomation).toHaveBeenNthCalledWith(2, 'auto-1', { linkedTask: null })
+  })
+
   it('creates repo-scoped automations through the shared store', async () => {
     const store = makeStore()
     const runtime = new OrcaRuntimeService(store as never)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -4065,6 +4065,7 @@ export class OrcaRuntimeService {
       agentId: input.agentId,
       runContext: input.runContext,
       sourceContext: input.sourceContext,
+      linkedTask: input.linkedTask,
       projectId: target.projectId,
       workspaceMode: target.workspaceMode,
       workspaceId: target.workspaceId,
@@ -4102,6 +4103,9 @@ export class OrcaRuntimeService {
     }
     if (hasRuntimeAutomationUpdateValue(updates, 'sourceContext')) {
       patch.sourceContext = updates.sourceContext
+    }
+    if (hasRuntimeAutomationUpdateValue(updates, 'linkedTask')) {
+      patch.linkedTask = updates.linkedTask
     }
     if (hasRuntimeAutomationUpdateValue(updates, 'baseBranch')) {
       patch.baseBranch = updates.baseBranch

--- a/src/main/runtime/rpc/methods/automations.test.ts
+++ b/src/main/runtime/rpc/methods/automations.test.ts
@@ -133,6 +133,41 @@ describe('automation RPC methods', () => {
     ).resolves.toMatchObject({ ok: false, error: { code: 'invalid_argument' } })
   })
 
+  it('rejects a linked task whose provider differs from its source context', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      createAutomation: vi.fn()
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: AUTOMATION_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('automation.create', {
+        name: 'Mismatched task',
+        prompt: 'Run',
+        agentId: 'codex',
+        sourceContext: {
+          kind: 'task-source',
+          provider: 'github',
+          projectId: 'github:aprudkin/aimem',
+          hostId: 'local'
+        },
+        linkedTask: {
+          provider: 'gitlab',
+          type: 'issue',
+          number: 814,
+          title: 'Wrong provider',
+          url: 'https://gitlab.example.test/group/project/-/issues/814'
+        },
+        repo: 'repo-1',
+        rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
+        dtstart: 1
+      })
+    )
+
+    expect(response).toMatchObject({ ok: false, error: { code: 'invalid_argument' } })
+    expect(runtime.createAutomation).not.toHaveBeenCalled()
+  })
+
   it('preserves null baseBranch update values through the RPC boundary', async () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',

--- a/src/main/runtime/rpc/methods/automations.ts
+++ b/src/main/runtime/rpc/methods/automations.ts
@@ -6,6 +6,8 @@ import {
 } from '../../../../shared/automation-precheck'
 import { normalizeExecutionHostId } from '../../../../shared/execution-host'
 import type { TaskProviderIdentity as SharedTaskProviderIdentity } from '../../../../shared/task-source-context'
+import { WorkspaceLinkedItemSchema } from '../../../../shared/workspace-linked-item-schema'
+import { isWorkspaceLinkedItemSourceContextMatch } from '../../../../shared/workspace-linked-item-source-context'
 import { isTuiAgent } from '../../../../shared/tui-agent-config'
 import { defineMethod, type RpcMethod } from '../core'
 import {
@@ -79,6 +81,27 @@ const TaskSourceContext = z
   .optional()
   .nullable()
 
+const LinkedTask = WorkspaceLinkedItemSchema.optional().nullable()
+
+function assertLinkedTaskSourceMatch(
+  value: {
+    linkedTask?: z.infer<typeof WorkspaceLinkedItemSchema> | null
+    sourceContext?: z.infer<typeof TaskSourceContext> | null
+  },
+  ctx: z.RefinementCtx
+): void {
+  if (
+    value.linkedTask &&
+    value.sourceContext &&
+    !isWorkspaceLinkedItemSourceContextMatch(value.linkedTask, value.sourceContext)
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'Linked task and source context identities must match'
+    })
+  }
+}
+
 const WorkspaceRunContext = z
   .object({
     kind: z.literal('workspace-run'),
@@ -99,46 +122,52 @@ const AutomationRuns = z.object({
   automationId: OptionalString
 })
 
-const AutomationCreate = z.object({
-  name: requiredString('Missing automation name'),
-  prompt: requiredString('Missing automation prompt'),
-  precheck: AutomationPrecheck,
-  agentId: TuiAgent,
-  runContext: WorkspaceRunContext,
-  sourceContext: TaskSourceContext,
-  repo: OptionalString,
-  workspace: OptionalString,
-  workspaceMode: AutomationWorkspaceMode,
-  baseBranch: OptionalPlainString,
-  setupDecision: SetupDecision,
-  reuseSession: OptionalBoolean,
-  timezone: OptionalString,
-  rrule: AutomationSchedule,
-  dtstart: requiredNumber('Missing trigger start time'),
-  enabled: OptionalBoolean,
-  missedRunGraceMinutes: OptionalPositiveInt
-})
+const AutomationCreate = z
+  .object({
+    name: requiredString('Missing automation name'),
+    prompt: requiredString('Missing automation prompt'),
+    precheck: AutomationPrecheck,
+    agentId: TuiAgent,
+    runContext: WorkspaceRunContext,
+    sourceContext: TaskSourceContext,
+    linkedTask: LinkedTask,
+    repo: OptionalString,
+    workspace: OptionalString,
+    workspaceMode: AutomationWorkspaceMode,
+    baseBranch: OptionalPlainString,
+    setupDecision: SetupDecision,
+    reuseSession: OptionalBoolean,
+    timezone: OptionalString,
+    rrule: AutomationSchedule,
+    dtstart: requiredNumber('Missing trigger start time'),
+    enabled: OptionalBoolean,
+    missedRunGraceMinutes: OptionalPositiveInt
+  })
+  .superRefine(assertLinkedTaskSourceMatch)
 
-const AutomationUpdateFields = z.object({
-  name: OptionalString,
-  prompt: OptionalString,
-  precheck: AutomationPrecheck,
-  agentId: TuiAgent.optional(),
-  runContext: WorkspaceRunContext,
-  sourceContext: TaskSourceContext,
-  repo: OptionalString,
-  workspace: OptionalString,
-  workspaceMode: AutomationWorkspaceMode,
-  // Why: update patches distinguish omitted from null so callers can clear a saved base branch.
-  baseBranch: OptionalNullablePlainString,
-  setupDecision: SetupDecision,
-  reuseSession: OptionalBoolean,
-  timezone: OptionalString,
-  rrule: AutomationSchedule.optional(),
-  dtstart: requiredNumber('Missing trigger start time').optional(),
-  enabled: OptionalBoolean,
-  missedRunGraceMinutes: OptionalPositiveInt
-})
+const AutomationUpdateFields = z
+  .object({
+    name: OptionalString,
+    prompt: OptionalString,
+    precheck: AutomationPrecheck,
+    agentId: TuiAgent.optional(),
+    runContext: WorkspaceRunContext,
+    sourceContext: TaskSourceContext,
+    linkedTask: LinkedTask,
+    repo: OptionalString,
+    workspace: OptionalString,
+    workspaceMode: AutomationWorkspaceMode,
+    // Why: update patches distinguish omitted from null so callers can clear a saved base branch.
+    baseBranch: OptionalNullablePlainString,
+    setupDecision: SetupDecision,
+    reuseSession: OptionalBoolean,
+    timezone: OptionalString,
+    rrule: AutomationSchedule.optional(),
+    dtstart: requiredNumber('Missing trigger start time').optional(),
+    enabled: OptionalBoolean,
+    missedRunGraceMinutes: OptionalPositiveInt
+  })
+  .superRefine(assertLinkedTaskSourceMatch)
 
 const AutomationUpdate = z.object({
   id: requiredString('Missing automation id'),

--- a/src/renderer/src/hooks/useAutomationDispatchEvents.ts
+++ b/src/renderer/src/hooks/useAutomationDispatchEvents.ts
@@ -250,6 +250,12 @@ export function useAutomationDispatchEvents(): void {
           }
 
           const automationWorkspaceCreateRequestId = createBrowserUuid()
+          const linkedTask = Object.hasOwn(run, 'linkedTask')
+            ? run.linkedTask
+            : automation.linkedTask
+          const linkedTaskSourceContext = Object.hasOwn(run, 'sourceContext')
+            ? run.sourceContext
+            : automation.sourceContext
           const createResult =
             automation.workspaceMode === 'new_per_run'
               ? await useAppStore.getState().createWorktree(
@@ -286,7 +292,9 @@ export function useAutomationDispatchEvents(): void {
                       automationRunId: run.id,
                       dispatchToken,
                       createRequestId: automationWorkspaceCreateRequestId
-                    }
+                    },
+                    linkedWorkItem: linkedTask ?? null,
+                    linkedTaskSourceContext: linkedTask ? (linkedTaskSourceContext ?? null) : null
                   }
                 )
               : null

--- a/src/shared/automations-types.ts
+++ b/src/shared/automations-types.ts
@@ -1,6 +1,7 @@
 import type { TuiAgent } from './tui-agent'
 import type { SetupDecision } from './worktree/create-types'
 import type { TaskSourceContext, WorkspaceRunContext } from './task-source-context'
+import type { WorkspaceLinkedItem } from './worktree/types'
 
 export type AutomationWorkspaceMode = 'existing' | 'new_per_run'
 export type AutomationExecutionTargetType = 'local' | 'ssh'
@@ -103,6 +104,7 @@ export type Automation = {
   /** Why: task/provider data can come from a different host/account than the
    *  workspace run target, so automations persist it separately. */
   sourceContext?: TaskSourceContext | null
+  linkedTask?: WorkspaceLinkedItem | null
   /** @deprecated Legacy repo-id compatibility field. New code should persist
    *  runContext and use getAutomationRunRepoId() for fallback reads. */
   projectId: string
@@ -131,6 +133,7 @@ export type AutomationRun = {
   automationId: string
   runContext?: WorkspaceRunContext | null
   sourceContext?: TaskSourceContext | null
+  linkedTask?: WorkspaceLinkedItem | null
   title: string
   scheduledFor: number
   status: AutomationRunStatus
@@ -165,6 +168,7 @@ export type AutomationCreateInput = {
   agentId: TuiAgent
   runContext?: WorkspaceRunContext | null
   sourceContext?: TaskSourceContext | null
+  linkedTask?: WorkspaceLinkedItem | null
   /** @deprecated Legacy repo-id compatibility field required for older stored
    *  automations and clients. Pair it with runContext for new writes. */
   projectId: string
@@ -189,6 +193,7 @@ export type AutomationUpdateInput = Partial<
     | 'agentId'
     | 'runContext'
     | 'sourceContext'
+    | 'linkedTask'
     | 'projectId'
     | 'workspaceMode'
     | 'workspaceId'


### PR DESCRIPTION
## ELI5

An automation can now remember the exact issue or task it was created for, not only the repository that contains it. A run keeps that identity even if the automation is edited later.

## What Changed

- Persist an exact linked work item separately from repo-level `TaskSourceContext`.
- Expose `--linked-task <json|null>` for create/edit, including explicit clearing.
- Reject provider/source mismatches at the runtime boundary.
- Snapshot task identity into runs and use the snapshot for renderer and headless workspace creation.
- Preserve create/edit/clear semantics across the runtime boundary.

## Why

Repository source context is not sufficient to identify the exact task that triggered an automation. Keeping the linked task as a separate optional value prevents later edits from changing the provenance of an existing run and lets workspace creation retain exact task metadata.

## Linked Issue

External tracker: https://github.com/aprudkin/aimem/issues/802

## Visual Proof

N/A — this is a CLI/runtime/persistence contract change with no UI layout change.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated

Verified locally:

- focused automation suite: 119/119 PASS before review follow-up
- CLI regression suite after review follow-up: 5/5 PASS
- `pnpm run lint`: PASS
- `pnpm run typecheck`: PASS
- full suite: 56,142 PASS; 8 unrelated environment/timing failures, all relevant failed groups independently characterized (84/84 non-environmental reruns PASS; inherited-Orca-env group PASS 24/24 after exact env scrub; generated-checkout scanner group PASS 4/4 with its generated checkout temporarily moved and restored)
- desktop build, relay, CLI, renderer, and web verification: PASS
- native macOS build: blocked before project compilation by the local Swift/CommandLineTools linker (`PackageDescription` undefined symbols)

Local runtime note: the repository requests Node 24; verification ran on Node 26.7.0 with pnpm 10.24.0.

## AI Disclosure

OpenAI Codex was used to implement and verify this change. CodeRabbit review feedback was incorporated.

## Review

The linked-task field remains optional for mixed-version compatibility. Run-level metadata takes precedence; fallback to the automation definition is used only when the run fields are absent.

## Agent skill upstream boundary

- [x] Not applicable; this change copies or mechanically translates no upstream skill-installer material.

## Notes

No secret material or complete environment snapshots are persisted. The change is data-only across existing automation boundaries and does not alter platform paths, SSH transport, shortcuts, or UI behavior.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` all pass locally (see exact environment-limited results above)

## Author

- GitHub: @aprudkin
