### PR TITLE
fix(runtime): stamp a runtime's own project setups as local, and report remote status about the remote (STA-4792)

### DIFF
--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -177,6 +177,9 @@ function localCliErrorData(error: unknown, context: CliErrorContext): unknown {
 
 export function formatCliStatus(status: CliStatusResult): string {
   return [
+    ...(status.target && status.target.kind === 'environment'
+      ? [`target: environment ${status.target.environment}`]
+      : []),
     `appRunning: ${status.app.running}`,
     `pid: ${status.app.pid ?? 'none'}`,
     `desktopWindowStatus: ${status.app.desktopWindowStatus ?? 'unknown'}`,

--- a/src/cli/handlers/project.ts
+++ b/src/cli/handlers/project.ts
@@ -12,7 +12,7 @@ import type {
 } from '../../shared/project-types'
 import type { ExecutionHostId } from '../../shared/execution-host'
 import type { RepoKind } from '../../shared/repo-types'
-import type { CommandHandler } from '../dispatch'
+import type { CommandHandler, HandlerContext } from '../dispatch'
 import {
   formatProjectHostSetupCreateResult,
   formatProjectHostSetupDeleteResult,
@@ -25,7 +25,33 @@ import {
 import { hostFilterMatchesHostId, parseHostFlag } from '../execution-host-flag'
 import { getOptionalStringFlag, getRequiredStringFlag } from '../flags'
 import { resolveRepoPathArgument } from '../repo-path-arguments'
-import { RuntimeClientError } from '../runtime-client'
+import { RuntimeClientError, type RuntimeRpcSuccess } from '../runtime-client'
+
+// Why: an Orca server that predates project host setup answers `method_not_found`, which reads
+// as an Orca bug rather than a version gap — and since --host runtime:<id> now routes these
+// commands to that server, a client can reach an older host without meaning to. The desktop
+// already names this case; match it instead of surfacing the raw dispatcher error.
+async function callProjectHostSetup<TResult>(
+  client: HandlerContext['client'],
+  method: string,
+  params?: unknown
+): Promise<RuntimeRpcSuccess<TResult>> {
+  try {
+    // Why: forward the exact arity the caller used; passing an explicit undefined would change
+    // the request shape for the no-params methods.
+    return params === undefined
+      ? await client.call<TResult>(method)
+      : await client.call<TResult>(method, params)
+  } catch (error) {
+    if (error instanceof RuntimeClientError && error.code === 'method_not_found') {
+      throw new RuntimeClientError(
+        'incompatible_runtime',
+        'This Orca server does not support project host setup yet. Update Orca on the server and try again.'
+      )
+    }
+    throw error
+  }
+}
 
 function getRequiredHostId(flags: Map<string, string | boolean>): ExecutionHostId {
   const host = parseHostFlag(flags)
@@ -54,7 +80,10 @@ export const PROJECT_HANDLERS: Record<string, CommandHandler> = {
   'project setups': async ({ flags, client, json }) => {
     const projectFilter = getOptionalStringFlag(flags, 'project')
     const hostFilter = parseHostFlag(flags)
-    const result = await client.call<{ setups: ProjectHostSetup[] }>('projectHostSetup.list')
+    const result = await callProjectHostSetup<{ setups: ProjectHostSetup[] }>(
+      client,
+      'projectHostSetup.list'
+    )
     const setups = result.result.setups.filter(
       (setup) =>
         (projectFilter === undefined || setup.projectId === projectFilter) &&
@@ -71,7 +100,8 @@ export const PROJECT_HANDLERS: Record<string, CommandHandler> = {
       kind: getOptionalRepoKind(flags),
       displayName: getOptionalStringFlag(flags, 'display-name')
     }
-    const result = await client.call<{ result: ProjectHostSetupResult }>(
+    const result = await callProjectHostSetup<{ result: ProjectHostSetupResult }>(
+      client,
       'projectHostSetup.setupExistingFolder',
       args
     )
@@ -91,7 +121,8 @@ export const PROJECT_HANDLERS: Record<string, CommandHandler> = {
       ),
       displayName: getOptionalStringFlag(flags, 'display-name')
     }
-    const result = await client.call<{ result: ProjectHostSetupResult }>(
+    const result = await callProjectHostSetup<{ result: ProjectHostSetupResult }>(
+      client,
       'projectHostSetup.clone',
       args
     )
@@ -114,7 +145,8 @@ export const PROJECT_HANDLERS: Record<string, CommandHandler> = {
       setupState: getOptionalSetupState(flags),
       setupMethod: getOptionalIndependentSetupMethod(flags)
     }
-    const result = await client.call<{ result: ProjectHostSetupCreateResult }>(
+    const result = await callProjectHostSetup<{ result: ProjectHostSetupCreateResult }>(
+      client,
       'projectHostSetup.create',
       args
     )
@@ -137,14 +169,16 @@ export const PROJECT_HANDLERS: Record<string, CommandHandler> = {
         setupMethod: getOptionalSetupMethod(flags)
       }
     }
-    const result = await client.call<{ result: ProjectHostSetupUpdateResult }>(
+    const result = await callProjectHostSetup<{ result: ProjectHostSetupUpdateResult }>(
+      client,
       'projectHostSetup.update',
       args
     )
     printResult(result, json, formatProjectHostSetupUpdateResult)
   },
   'project setup-delete': async ({ flags, client, json }) => {
-    const result = await client.call<{ result: ProjectHostSetupDeleteResult }>(
+    const result = await callProjectHostSetup<{ result: ProjectHostSetupDeleteResult }>(
+      client,
       'projectHostSetup.delete',
       {
         setupId: getRequiredStringFlag(flags, 'setup')

--- a/src/cli/index-project-setup.test.ts
+++ b/src/cli/index-project-setup.test.ts
@@ -191,6 +191,28 @@ describe('orca cli worktree awareness', () => {
     expect(logSpy.mock.calls[0]?.[0]).not.toContain('setup-by-client')
   })
 
+  // Why: --host runtime:<id> routes to a paired server, so an older one is reachable without the
+  // caller meaning to. A raw method_not_found reads as an Orca bug rather than a version gap.
+  it('names the version gap when the server predates project host setup', async () => {
+    pairRuntimeEnvironment(listEnvironmentsMock, 'old-server')
+    const { RuntimeClientError } = await import('./runtime/types.js')
+    callMock.mockRejectedValueOnce(
+      new RuntimeClientError('method_not_found', 'Unknown method: projectHostSetup.list')
+    )
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const priorExitCode = process.exitCode
+
+    await main(['project', 'setups', '--host', 'runtime:old-server', '--json'], '/tmp/repo')
+
+    const printed = [...logSpy.mock.calls, ...errSpy.mock.calls].flat().join('\n')
+    expect(printed).toContain('does not support project host setup yet')
+    expect(printed).not.toContain('Unknown method')
+    expect(process.exitCode).toBe(1)
+
+    process.exitCode = priorExitCode
+  })
+
   it('rejects a runtime host id that no paired server owns instead of answering empty', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})

--- a/src/cli/index-project-setup.test.ts
+++ b/src/cli/index-project-setup.test.ts
@@ -408,6 +408,71 @@ describe('orca cli worktree awareness', () => {
     }
   )
 
+  // Why: STA-4792 defect 2. `--host runtime:<id>` used to leave the client local, so a Windows
+  // destination fell into resolve(cwd, ...) and became a literal directory next to the caller.
+  // Routing makes the client remote, which is what sends the path through untouched.
+  it('sends a windows destination to the routed host instead of joining it to the local cwd', async () => {
+    pairRuntimeEnvironment(listEnvironmentsMock, 'awin')
+    queueFixtures(
+      callMock,
+      okFixture('req_project_setup_clone', {
+        result: {
+          project: {
+            id: 'github:stablyai/orca',
+            displayName: 'Orca',
+            badgeColor: '#7c3aed',
+            sourceRepoIds: [],
+            createdAt: 1,
+            updatedAt: 1
+          },
+          setup: {
+            id: 'setup-awin',
+            projectId: 'github:stablyai/orca',
+            hostId: 'local',
+            repoId: 'repo-awin',
+            path: 'C:\\orca-probe\\orca',
+            displayName: 'Orca',
+            setupState: 'ready',
+            setupMethod: 'cloned',
+            createdAt: 1,
+            updatedAt: 1
+          },
+          repo: {
+            id: 'repo-awin',
+            path: 'C:\\orca-probe\\orca',
+            displayName: 'Orca',
+            badgeColor: '#7c3aed',
+            addedAt: 1
+          }
+        }
+      })
+    )
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(
+      [
+        'project',
+        'setup-clone',
+        '--project',
+        'github:stablyai/orca',
+        '--host',
+        'runtime:awin',
+        '--url',
+        'https://github.com/stablyai/orca.git',
+        '--destination',
+        'C:\\orca-probe',
+        '--json'
+      ],
+      '/Users/nwparker/orca/workspaces/orca/IME-koko'
+    )
+
+    expect(runtimeClientConstructorMock).toHaveBeenCalledWith(null, 'awin')
+    expect(callMock).toHaveBeenCalledWith(
+      'projectHostSetup.clone',
+      expect.objectContaining({ destination: 'C:\\orca-probe' })
+    )
+  })
+
   it('updates project host setup metadata through the project-first runtime API', async () => {
     queueFixtures(
       callMock,

--- a/src/cli/runtime-client.test.ts
+++ b/src/cli/runtime-client.test.ts
@@ -216,6 +216,7 @@ describe.skipIf(process.platform === 'win32')('RuntimeClient', () => {
     const status = await client.getCliStatus()
 
     expect(status.result).toEqual({
+      target: { kind: 'local' },
       app: {
         running: false,
         pid: null

--- a/src/cli/runtime/client.ts
+++ b/src/cli/runtime/client.ts
@@ -8,7 +8,7 @@ import {
 import { parsePairingCode, type PairingOffer } from '../../shared/pairing'
 import { launchOrcaApp } from './launch'
 import { getDefaultUserDataPath, readMetadata } from './metadata'
-import { getCliStatus, resolveDesktopWindowStatus } from './status'
+import { getCliStatus, projectRemoteAppStatus } from './status'
 import { sendRequest } from './transport'
 import { RuntimeClientError, RuntimeRpcFailureError, type RuntimeRpcSuccess } from './types'
 import { markEnvironmentUsed, resolveEnvironmentPairingOffer } from './environments'
@@ -159,18 +159,11 @@ export class RuntimeClient {
         id: response.id,
         ok: true,
         result: {
-          // Why: remote status proves the paired runtime is reachable, not
-          // that this client machine has a local Orca desktop process.
-          app: {
-            running: false,
-            pid: null,
-            // Why: reuse the shared resolver so remote status honors the same
-            // authoritativeWindowId fallback as local status for old runtimes.
-            ...(() => {
-              const desktopWindowStatus = resolveDesktopWindowStatus(response.result)
-              return desktopWindowStatus ? { desktopWindowStatus } : {}
-            })()
+          target: {
+            kind: 'environment',
+            environment: this.environmentSelector ?? 'pairing-code'
           },
+          app: projectRemoteAppStatus(response.result),
           runtime: {
             state: graphState === 'ready' ? 'ready' : 'graph_not_ready',
             reachable: true,

--- a/src/cli/runtime/status.test.ts
+++ b/src/cli/runtime/status.test.ts
@@ -118,6 +118,16 @@ describe('projectRemoteAppStatus', () => {
     })
   })
 
+  // Why: the SSH host-passthrough answers for the Orca host the caller reached, and used to
+  // claim running:true unconditionally. Both transports now share this projection.
+  it('does not claim a desktop app for a headless serve on any transport', () => {
+    expect(projectRemoteAppStatus(remoteStatus({ desktopWindowStatus: 'openable' }))).toEqual({
+      running: false,
+      pid: null,
+      desktopWindowStatus: 'openable'
+    })
+  })
+
   it('never reports a remote pid', () => {
     expect(
       projectRemoteAppStatus(remoteStatus({ desktopWindowStatus: 'available' })).pid

--- a/src/cli/runtime/status.test.ts
+++ b/src/cli/runtime/status.test.ts
@@ -4,7 +4,9 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import { getRuntimeMetadataPath } from '../../shared/runtime-bootstrap'
+import type { RuntimeStatus } from '../../shared/runtime-types'
 import { RuntimeClient } from './client'
+import { projectRemoteAppStatus } from './status'
 
 const servers = new Set<ReturnType<typeof createServer>>()
 const sockets = new Set<Socket>()
@@ -72,5 +74,53 @@ describe.skipIf(process.platform === 'win32')('CLI runtime status', () => {
       runtimeId: 'runtime-legacy',
       state: 'ready'
     })
+  })
+})
+
+describe('projectRemoteAppStatus', () => {
+  function remoteStatus(overrides: Partial<RuntimeStatus> = {}): RuntimeStatus {
+    return {
+      runtimeId: 'remote-runtime',
+      graphStatus: 'ready',
+      authoritativeWindowId: null,
+      ...overrides
+    } as RuntimeStatus
+  }
+
+  // STA-4792 defect 4: the reported output was running:false alongside desktopWindowStatus
+  // 'available', while the target's GUI was demonstrably up.
+  it('reports the target app as running when a renderer owns the graph there', () => {
+    expect(projectRemoteAppStatus(remoteStatus({ desktopWindowStatus: 'available' }))).toEqual({
+      running: true,
+      pid: null,
+      desktopWindowStatus: 'available'
+    })
+  })
+
+  it.each(['openable', 'initializing', 'blocked'] as const)(
+    'does not claim a running desktop for window status %s',
+    (desktopWindowStatus) => {
+      expect(projectRemoteAppStatus(remoteStatus({ desktopWindowStatus })).running).toBe(false)
+    }
+  )
+
+  // A headless `serve` reports no window at all.
+  it('reports not running when the target has no desktop window status', () => {
+    expect(projectRemoteAppStatus(remoteStatus())).toEqual({ running: false, pid: null })
+  })
+
+  // Why: old runtimes predate the explicit status but a positive window id still proves a window.
+  it('honors the authoritativeWindowId fallback for older runtimes', () => {
+    expect(projectRemoteAppStatus(remoteStatus({ authoritativeWindowId: 3 }))).toEqual({
+      running: true,
+      pid: null,
+      desktopWindowStatus: 'available'
+    })
+  })
+
+  it('never reports a remote pid', () => {
+    expect(
+      projectRemoteAppStatus(remoteStatus({ desktopWindowStatus: 'available' })).pid
+    ).toBeNull()
   })
 })

--- a/src/cli/runtime/status.ts
+++ b/src/cli/runtime/status.ts
@@ -75,6 +75,20 @@ export async function getCliStatus(
   }
 }
 
+// Why: a paired server's status describes THAT machine, so `app` must too. `available` is the
+// only desktop-window status that requires a live renderer owning the graph, which makes it the
+// signal separating a real desktop app from a headless `serve`. Reporting running:false here
+// while echoing the target's desktopWindowStatus is what made a remote GUI run look headless
+// (STA-4792 defect 4). The remote pid is not knowable from status.get, so it stays null.
+export function projectRemoteAppStatus(status: RuntimeStatus): CliStatusResult['app'] {
+  const desktopWindowStatus = resolveDesktopWindowStatus(status)
+  return {
+    running: desktopWindowStatus === 'available',
+    pid: null,
+    ...(desktopWindowStatus ? { desktopWindowStatus } : {})
+  }
+}
+
 export function resolveDesktopWindowStatus(
   status: RuntimeStatus
 ): CliStatusResult['app']['desktopWindowStatus'] {
@@ -92,7 +106,7 @@ function buildCliStatusResponse(result: CliStatusResult): RuntimeRpcSuccess<CliS
   return {
     id: 'local-status',
     ok: true,
-    result,
+    result: { target: { kind: 'local' }, ...result },
     _meta: {
       runtimeId: result.runtime.runtimeId ?? 'none'
     }

--- a/src/cli/runtime/status.ts
+++ b/src/cli/runtime/status.ts
@@ -2,7 +2,13 @@ import type { CliStatusResult, RuntimeStatus } from '../../shared/runtime-types'
 import { findTransport } from '../../shared/runtime-bootstrap'
 import { tryReadMetadata } from './metadata'
 import { sendRequest } from './transport'
+import {
+  projectRemoteAppStatus,
+  resolveDesktopWindowStatus
+} from '../../shared/cli-app-status-projection'
 import { RuntimeRpcFailureError, type RuntimeRpcSuccess } from './types'
+
+export { projectRemoteAppStatus, resolveDesktopWindowStatus }
 
 export async function getCliStatus(
   userDataPath: string
@@ -73,33 +79,6 @@ export async function getCliStatus(
       }
     })
   }
-}
-
-// Why: a paired server's status describes THAT machine, so `app` must too. `available` is the
-// only desktop-window status that requires a live renderer owning the graph, which makes it the
-// signal separating a real desktop app from a headless `serve`. Reporting running:false here
-// while echoing the target's desktopWindowStatus is what made a remote GUI run look headless
-// (STA-4792 defect 4). The remote pid is not knowable from status.get, so it stays null.
-export function projectRemoteAppStatus(status: RuntimeStatus): CliStatusResult['app'] {
-  const desktopWindowStatus = resolveDesktopWindowStatus(status)
-  return {
-    running: desktopWindowStatus === 'available',
-    pid: null,
-    ...(desktopWindowStatus ? { desktopWindowStatus } : {})
-  }
-}
-
-export function resolveDesktopWindowStatus(
-  status: RuntimeStatus
-): CliStatusResult['app']['desktopWindowStatus'] {
-  if (status.desktopWindowStatus) {
-    return status.desktopWindowStatus
-  }
-  // Why: older desktop runtimes predate the explicit status but a positive
-  // Electron id still proves that a real window owns the graph.
-  return status.authoritativeWindowId !== null && status.authoritativeWindowId > 0
-    ? 'available'
-    : undefined
 }
 
 function buildCliStatusResponse(result: CliStatusResult): RuntimeRpcSuccess<CliStatusResult> {

--- a/src/cli/worktree-project-target.ts
+++ b/src/cli/worktree-project-target.ts
@@ -77,7 +77,20 @@ export async function resolveProjectCreateTarget(
   if (!projectHostSetupId && !projectId && !host) {
     return undefined
   }
-  const result = await client.call<{ setups: ProjectHostSetup[] }>('projectHostSetup.list')
+  let result: Awaited<ReturnType<typeof client.call<{ setups: ProjectHostSetup[] }>>>
+  try {
+    result = await client.call<{ setups: ProjectHostSetup[] }>('projectHostSetup.list')
+  } catch (error) {
+    // Why: --host runtime:<id> routes here, so an older server is reachable without the caller
+    // meaning to; name the version gap rather than surfacing a raw method_not_found.
+    if (error instanceof RuntimeClientError && error.code === 'method_not_found') {
+      throw new RuntimeClientError(
+        'incompatible_runtime',
+        'This Orca server does not support project host setup yet. Update Orca on the server and try again.'
+      )
+    }
+    throw error
+  }
   const ready = result.result.setups.filter((candidate) => candidate.setupState === 'ready')
   const setup = projectHostSetupId
     ? ready.find((candidate) => candidate.id === projectHostSetupId)

--- a/src/main/__fixtures__/shell-wrapper-snapshots/README.md
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/README.md
@@ -5,11 +5,11 @@ Generated test fixtures. **Do not edit by hand.**
 Each `.txt` here is the byte-exact content of one shell startup file Orca writes
 into a pane's wrapper `ZDOTDIR`, captured per transport:
 
-| | |
-| :--- | :--- |
-| `local-*` | local PTY |
+|            |                   |
+| :--------- | :---------------- |
+| `local-*`  | local PTY         |
 | `daemon-*` | daemon / SSH host |
-| `relay-*` | relay overlay |
+| `relay-*`  | relay overlay     |
 
 Owned by [`../../shell-wrapper-generated-file-snapshot.test.ts`](../../shell-wrapper-generated-file-snapshot.test.ts),
 which drives the real wrapper entry points, reads the files back off disk and

--- a/src/main/codex/codex-trust-grant-host.test.ts
+++ b/src/main/codex/codex-trust-grant-host.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-
 const { execFileSyncMock, resolveCodexCommandMock } = vi.hoisted(() => ({
   execFileSyncMock: vi.fn(),
   resolveCodexCommandMock: vi.fn()

--- a/src/main/local-worktree-filesystem-wsl-banner.wsl.test.ts
+++ b/src/main/local-worktree-filesystem-wsl-banner.wsl.test.ts
@@ -27,11 +27,7 @@ async function wsl(command: string, ...args: string[]): Promise<string> {
 async function readThroughRawLoginShell(linuxPath: string): Promise<string> {
   const { stdout } = await execFileAsync(
     'wsl.exe',
-    buildWslExecArgs(DISTRO, [
-      'sh',
-      '-lc',
-      buildWslLoginShellCommand(`cat -- '${linuxPath}'`)
-    ]),
+    buildWslExecArgs(DISTRO, ['sh', '-lc', buildWslLoginShellCommand(`cat -- '${linuxPath}'`)]),
     { encoding: 'utf-8', timeout: 30000 }
   )
   return stdout
@@ -71,13 +67,17 @@ describe.skipIf(!runRealWsl)('WSL worktree reads carry no shell chatter', () => 
   it.each([
     ['dir', 'directory'],
     ['file.txt', 'file']
-  ])('stats %s as a usable type, not shell chatter', async (entry, expectedType) => {
-    const { statPath } = getLocalWorktreePathAccess({ wslDistro: DISTRO })
+  ])(
+    'stats %s as a usable type, not shell chatter',
+    async (entry, expectedType) => {
+      const { statPath } = getLocalWorktreePathAccess({ wslDistro: DISTRO })
 
-    const stat = (await statPath(unc(`${fixtureRoot}/${entry}`))) as { type: string }
+      const stat = (await statPath(unc(`${fixtureRoot}/${entry}`))) as { type: string }
 
-    expect(stat.type).toBe(expectedType)
-  }, 60_000)
+      expect(stat.type).toBe(expectedType)
+    },
+    60_000
+  )
 
   it('still reports a missing path as ENOENT', async () => {
     const { statPath } = getLocalWorktreePathAccess({ wslDistro: DISTRO })

--- a/src/main/local-worktree-filesystem.test.ts
+++ b/src/main/local-worktree-filesystem.test.ts
@@ -167,9 +167,7 @@ describe('local worktree filesystem runtime access', () => {
       )
       const removeArgs = execFileMock.mock.calls[2]?.[1] as string[]
       expect(removeArgs.at(-1)).toContain('rm -rf --')
-      expect(removeArgs.at(-1)).toContain(
-        String.raw`rm -rf -- '/mnt/c/Users/me/repo feature'`
-      )
+      expect(removeArgs.at(-1)).toContain(String.raw`rm -rf -- '/mnt/c/Users/me/repo feature'`)
       expect(rmMock).not.toHaveBeenCalled()
     })
   })

--- a/src/main/providers/local-pty-provider-windows-shell-launch.test.ts
+++ b/src/main/providers/local-pty-provider-windows-shell-launch.test.ts
@@ -519,7 +519,14 @@ describe('LocalPtyProvider', () => {
 
       expect(spawnMock).toHaveBeenCalledWith(
         'wsl.exe',
-        ['-d', 'Ubuntu', '--exec', 'sh', '-c', expect.stringContaining("cd '/home/jin/repo/subdir'")],
+        [
+          '-d',
+          'Ubuntu',
+          '--exec',
+          'sh',
+          '-c',
+          expect.stringContaining("cd '/home/jin/repo/subdir'")
+        ],
         expect.objectContaining({ cwd: expect.any(String) })
       )
     })

--- a/src/main/runtime/rpc/methods/project-host-setup-self-host-stamp.test.ts
+++ b/src/main/runtime/rpc/methods/project-host-setup-self-host-stamp.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { PROJECT_RUNTIME_METHODS } from './project-runtime-rpc-methods'
+
+// Why: a paired client addresses this runtime as `runtime:<its own env id>`. Persisting that
+// verbatim hides the row from every other client and defeats the (projectId, hostId) duplicate
+// check, so the request's host id has to be re-spelled as this machine's own `local`.
+function parseParams(methodName: string, params: unknown): { hostId: string } {
+  const method = PROJECT_RUNTIME_METHODS.find((candidate) => candidate.name === methodName)
+  if (!method?.params) {
+    throw new Error(`Missing params schema for ${methodName}`)
+  }
+  return method.params.parse(params) as { hostId: string }
+}
+
+const CREATING_METHODS = [
+  {
+    name: 'projectHostSetup.setupExistingFolder',
+    base: { projectId: 'github:stablyai/orca', path: '/srv/orca' }
+  },
+  {
+    name: 'projectHostSetup.clone',
+    base: {
+      projectId: 'github:stablyai/orca',
+      url: 'https://github.com/stablyai/orca.git',
+      destination: '/srv'
+    }
+  },
+  { name: 'projectHostSetup.create', base: { projectId: 'github:stablyai/orca' } }
+] as const
+
+describe('project host setup self-host stamp', () => {
+  it.each(CREATING_METHODS)('$name stores a caller runtime id as local', ({ name, base }) => {
+    const parsed = parseParams(name, { ...base, hostId: 'runtime:c0ffee-env-id' })
+
+    expect(parsed.hostId).toBe('local')
+  })
+
+  it.each(CREATING_METHODS)('$name leaves an explicit local host alone', ({ name, base }) => {
+    expect(parseParams(name, { ...base, hostId: 'local' }).hostId).toBe('local')
+  })
+
+  // Why: ssh targets are a different machine from the runtime handling the call, so they must
+  // keep their own identity — only `runtime:` means "you".
+  it.each(CREATING_METHODS)('$name preserves an ssh host', ({ name, base }) => {
+    expect(parseParams(name, { ...base, hostId: 'ssh:box-1' }).hostId).toBe('ssh:box-1')
+  })
+
+  it.each(CREATING_METHODS)('$name still rejects an unparseable host', ({ name, base }) => {
+    expect(() => parseParams(name, { ...base, hostId: 'nonsense' })).toThrow()
+    expect(() => parseParams(name, { ...base, hostId: 'runtime:' })).toThrow()
+  })
+
+  // Two clients paired with the same server now converge on one row instead of one each.
+  it('collapses two different clients onto the same host id', () => {
+    const fromClientA = parseParams('projectHostSetup.create', {
+      projectId: 'github:stablyai/orca',
+      hostId: 'runtime:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+    })
+    const fromClientB = parseParams('projectHostSetup.create', {
+      projectId: 'github:stablyai/orca',
+      hostId: 'runtime:bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+    })
+
+    expect(fromClientA.hostId).toBe(fromClientB.hostId)
+  })
+})

--- a/src/main/runtime/rpc/methods/project-runtime-rpc-methods.ts
+++ b/src/main/runtime/rpc/methods/project-runtime-rpc-methods.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod'
-import { normalizeExecutionHostId } from '../../../../shared/execution-host'
+import {
+  LOCAL_EXECUTION_HOST_ID,
+  normalizeExecutionHostId,
+  parseExecutionHostId
+} from '../../../../shared/execution-host'
 import { defineMethod, type RpcMethod } from '../core'
 import { OptionalString, requiredString } from '../schemas'
 import { projectRepoResultVisibilityForClient } from '../repo-visibility-projection'
@@ -11,17 +15,27 @@ const ProjectProviderIdentity = z.object({
   host: OptionalString
 })
 
+// Why: `runtime:<environment-id>` ids are minted by the calling client's own pairing store
+// (addEnvironmentFromPairingCode -> randomUUID), so they name a machine only relative to that
+// client. A client sending one to this runtime is addressing *us*, and runtimes do not proxy
+// these calls onward, so the host it names is this machine. Persisting the caller's id verbatim
+// makes one machine look like a different host to every other client, hides its rows from them,
+// and defeats the (projectId, hostId) duplicate check. Store our own spelling instead: `local`.
+// Rows written before this normalization keep their client-minted stamp; readers still project
+// `local` back to `runtime:<their-id>`, so the client-visible model is unchanged.
+const RequestedHostId = requiredString('Missing host ID').transform((value, ctx) => {
+  const hostId = normalizeExecutionHostId(value)
+  if (!hostId) {
+    ctx.addIssue({ code: 'custom', message: 'Invalid host ID' })
+    return z.NEVER
+  }
+  return parseExecutionHostId(hostId)?.kind === 'runtime' ? LOCAL_EXECUTION_HOST_ID : hostId
+})
+
 const ProjectHostSetupExistingFolder = z.object({
   projectId: requiredString('Missing project ID'),
   projectProviderIdentity: ProjectProviderIdentity.optional(),
-  hostId: requiredString('Missing host ID').transform((value, ctx) => {
-    const hostId = normalizeExecutionHostId(value)
-    if (!hostId) {
-      ctx.addIssue({ code: 'custom', message: 'Invalid host ID' })
-      return z.NEVER
-    }
-    return hostId
-  }),
+  hostId: RequestedHostId,
   path: requiredString('Missing project path'),
   kind: z.enum(['git', 'folder']).optional(),
   displayName: OptionalString,
@@ -31,14 +45,7 @@ const ProjectHostSetupExistingFolder = z.object({
 const ProjectHostSetupClone = z.object({
   projectId: requiredString('Missing project ID'),
   projectProviderIdentity: ProjectProviderIdentity.optional(),
-  hostId: requiredString('Missing host ID').transform((value, ctx) => {
-    const hostId = normalizeExecutionHostId(value)
-    if (!hostId) {
-      ctx.addIssue({ code: 'custom', message: 'Invalid host ID' })
-      return z.NEVER
-    }
-    return hostId
-  }),
+  hostId: RequestedHostId,
   url: requiredString('Missing clone URL'),
   destination: requiredString('Missing clone destination'),
   displayName: OptionalString
@@ -59,14 +66,7 @@ const ProjectUpdate = z.object({
 
 const ProjectHostSetupCreate = z.object({
   projectId: requiredString('Missing project ID'),
-  hostId: requiredString('Missing host ID').transform((value, ctx) => {
-    const hostId = normalizeExecutionHostId(value)
-    if (!hostId) {
-      ctx.addIssue({ code: 'custom', message: 'Invalid host ID' })
-      return z.NEVER
-    }
-    return hostId
-  }),
+  hostId: RequestedHostId,
   setupId: OptionalString,
   path: OptionalString,
   kind: z.enum(['git', 'folder']).optional(),

--- a/src/main/ssh/ssh-remote-orca-cli.ts
+++ b/src/main/ssh/ssh-remote-orca-cli.ts
@@ -1,4 +1,5 @@
 import type { CliStatusResult, RuntimeStatus } from '../../shared/runtime-types'
+import { projectRemoteAppStatus } from '../../shared/cli-app-status-projection'
 import { randomUUID } from 'node:crypto'
 import type { RuntimeOrchestrationEnvelope } from '../../shared/runtime-rpc-envelope'
 import { readOrchestrationCompatibilityEvidence } from '../../shared/orchestration-compatibility-evidence'
@@ -171,11 +172,12 @@ async function dispatchRemoteCli(
       }
       const status = response.result as RuntimeStatus
       const cliStatus: CliStatusResult = {
-        app: {
-          running: true,
-          pid: null,
-          ...(status.desktopWindowStatus ? { desktopWindowStatus: status.desktopWindowStatus } : {})
-        },
+        target: { kind: 'environment', environment: 'ssh' },
+        // Why: this answers for the Orca host the caller reached over SSH, not for the caller's
+        // machine. It used to report running:true unconditionally, which claimed a desktop app
+        // even for a headless `serve`; share the same projection the paired-server path uses so
+        // both transports answer the question the same way (STA-4792 defect 4).
+        app: projectRemoteAppStatus(status),
         runtime: {
           state: status.graphStatus === 'ready' ? 'ready' : 'graph_not_ready',
           reachable: true,

--- a/src/shared/cli-app-status-projection.ts
+++ b/src/shared/cli-app-status-projection.ts
@@ -1,0 +1,29 @@
+import type { CliStatusResult, RuntimeStatus } from './runtime-types'
+
+export function resolveDesktopWindowStatus(
+  status: RuntimeStatus
+): CliStatusResult['app']['desktopWindowStatus'] {
+  if (status.desktopWindowStatus) {
+    return status.desktopWindowStatus
+  }
+  // Why: older desktop runtimes predate the explicit status but a positive
+  // Electron id still proves that a real window owns the graph.
+  return status.authoritativeWindowId !== null && status.authoritativeWindowId > 0
+    ? 'available'
+    : undefined
+}
+
+// Why: a status fetched from another machine describes THAT machine, so `app` must too.
+// `available` is the only desktop-window status that requires a live renderer owning the graph,
+// which makes it the signal separating a real desktop app from a headless `serve`. Reporting a
+// fixed running value while echoing the target's own window status produces a self-contradictory
+// result, and readers acted on it — a remote GUI run was written off as headless (STA-4792).
+// A pid is not knowable across the boundary, so it stays null.
+export function projectRemoteAppStatus(status: RuntimeStatus): CliStatusResult['app'] {
+  const desktopWindowStatus = resolveDesktopWindowStatus(status)
+  return {
+    running: desktopWindowStatus === 'available',
+    pid: null,
+    ...(desktopWindowStatus ? { desktopWindowStatus } : {})
+  }
+}

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -105,8 +105,13 @@ export type CliRuntimeState =
   | 'stale_bootstrap'
 
 export type CliStatusResult = {
+  // Why: every field below describes ONE machine. When the CLI targets a paired server the
+  // whole result is about that server, and callers were reading `app` as if it described their
+  // own laptop. Naming the subject removes the ambiguity; absent means local.
+  target?: { kind: 'local' } | { kind: 'environment'; environment: string }
   app: {
     running: boolean
+    // Null whenever the pid is not knowable, which includes every remote target.
     pid: number | null
     desktopWindowStatus?: RuntimeDesktopWindowStatus
   }

--- a/src/shared/wsl-exec-mode-separator.test.ts
+++ b/src/shared/wsl-exec-mode-separator.test.ts
@@ -85,7 +85,7 @@ describe('wsl.exe mode separator', () => {
   it('sees a `--` separator split across lines by the formatter', () => {
     // Why: the guard once matched line-by-line and was blind to this exact shape,
     // which is how every multi-element argv array in this repo is formatted.
-    const formatted = ["args: [", "  '-d',", "  distro,", "  '--',", "  'bash'", "]"].join('\n')
+    const formatted = ['args: [', "  '-d',", '  distro,', "  '--',", "  'bash'", ']'].join('\n')
 
     expect(ARGV_FORM.test(codeText(formatted))).toBe(true)
   })

--- a/src/shared/wsl-login-shell-command.test.ts
+++ b/src/shared/wsl-login-shell-command.test.ts
@@ -156,9 +156,7 @@ describe('wsl login shell command helpers', () => {
     // Why the captured form: an interactive login shell also prints the distro's
     // rc/motd to stdout (stock Ubuntu ships a sudo hint), so a raw login-shell
     // read cannot be compared byte-for-byte on a real distro.
-    const captured = buildWslCapturedLoginShellCommand(
-      'orca_value=ok; printf "<%s>" "$orca_value"'
-    )
+    const captured = buildWslCapturedLoginShellCommand('orca_value=ok; printf "<%s>" "$orca_value"')
 
     expect(
       captured.readStdout(


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​239 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​23 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​216 |
| Prod | 9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​137 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​65 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​72 |

<!-- /orca-pr-loc -->

## ELI5

Two bugs, and here is exactly when you hit each one.

### Bug 1 — the server stores *your laptop's private nickname* for itself

When you pair with a remote Orca server, your machine invents a random id for it (`randomUUID()`, `runtime-environment-store.ts:70`). That id only means anything on your machine. When you then set a project up on that server, the server wrote **your** random id into its own records as the name of the machine the project lives on.

**You hit this when:**

1. **You re-pair the same server.** `orca environment rm awin` and add it back — after a reinstall, a rotated pairing code, or moving machines — mints a *fresh* random id. The server's existing rows still carry the old one. Ask it what's set up and your own projects look absent, so you set them up again and end up with two entries pointing at the same folder on disk.
2. **You use a second machine.** Laptop and desktop both paired to the same box. Whichever set the project up owns the stamp; the other doesn't recognize it and creates its own.
3. **You run the CLI on the server itself** (directly, or through the SSH host passthrough), where the rows carry an id that machine's own pairing store has never seen.

The symptom is `Project is not set up on the selected host` for a project that is plainly checked out there — or two setups for one directory.

**Fix:** the server now records its own machine as `local`. Clients already translate that back to their own name for it on read, so nothing looks different — they just finally agree.

### Bug 2 — asking about a remote server answered about *your laptop*

**You hit this when** you run something on a paired machine and then check whether its GUI was up:

```
$ orca --environment awin status --json
app.running: false, pid: null, desktopWindowStatus: "available"
```

`running: false` described *your laptop* having no local Orca. Every other field described `awin`. So the same object says "no app" and "a desktop window is available" at once. On this ticket that reading cost real work: a UI test run was written off as headless and nearly discarded, while the window was up the whole time.

**Fix:** `app` now describes whichever machine you asked about, and the result says which machine that is.

## What Changed

### 1. A runtime stamps its own project setups `local` (#15366)

`projectHostSetup.setupExistingFolder` / `clone` / `create` persisted the caller's `hostId` verbatim. Those `runtime:<environment-id>` values are minted by the calling client's own pairing store (`addEnvironmentFromPairingCode` → `randomUUID()`), so they name a machine only relative to that client.

The request reached this runtime and runtimes do not proxy these calls onward, so the host it names is *us*. Re-spelled as `local` at the RPC boundary (`RequestedHostId`).

`ssh:` hosts are untouched — those genuinely are a different machine from the runtime handling the call. Only `runtime:` means "you".

### 2. `status --environment <name>` reports on the environment (STA-4792 defect 4)

The remote branch of `getCliStatus` hardcoded `app.running: false, pid: null`, meaning "this client machine has no local desktop process" — while `runtime.*`, `graph.*` and `desktopWindowStatus` in the same object all described the target.

`app` now describes the target, via a named `projectRemoteAppStatus`. `available` is the only desktop-window status that requires a live renderer owning the graph, so it's the signal separating a real desktop from a headless `serve`. Remote pid isn't knowable from `status.get`, so it stays `null`.

`CliStatusResult` also gained an optional `target`, so the output names its own subject and human output prints `target: environment <name>`.

### 3. Regression test for STA-4792 defect 2

Not a fix — #15364's routing already resolved it, because a routed client is remote and `resolveRepoPathArgument` then passes `C:\...` through instead of `resolve(cwd, ...)`-ing it into a literal local directory. The test pins the exact reported invocation.

## Why

Both are the same bug shape: a value that only means something relative to the observer, stored or reported as if it were absolute.

For the stamp, the alternative was to keep widening the *reader* (the CLI already carries a compensating `local` ⇔ `runtime:<id>` match from #15364). That doesn't converge — a blanket "any `runtime:*` means me" is wrong for a server that is itself paired onward, and it can't fix the duplicate-row problem, which is a write-side check. Fixing the write is the narrower and more correct move.

Two premises I verified before choosing it, both load-bearing:
- **Desktop IPC rejects `runtime:` hosts** outright ("Runtime hosts must be set up through the runtime projectHostSetup.setupExistingFolder RPC", `src/main/ipc/repos.ts`). So a `runtime:*` row can only arrive from a paired client addressing this runtime — it never denotes a third machine.
- **Setup ids embed the hostId** (`${projectId}::${hostId}`). Backfilling old rows would rewrite their ids and every reference to them, which is why this deliberately does not migrate.

## Linked Issue

Fixes #15366. Addresses defects 2 and 4 of STA-4792 (defect 1 shipped in #15364; defect 3, `terminal read`, is separate and not in this PR).

## Visual Proof

N/A — CLI/runtime behavior, no UI surface.

Reported before, on `--environment awin status --json`:

```
app.running: false, pid: null, desktopWindowStatus: "available"
```

self-contradictory, and it led to discarding a valid GUI test run as headless. After: `running: true` with `target: {kind: "environment", environment: "awin"}`.

## Testing

- `pnpm exec vitest run src/cli src/main/runtime/rpc` — 257 files / 2339 tests pass.
- `pnpm run typecheck` (node + cli + web) and `oxlint` base/native/type-aware — clean.
- New `project-host-setup-self-host-stamp.test.ts`: all three creating methods map a caller `runtime:` id to `local`, leave `local` alone, preserve `ssh:`, still reject unparseable ids, and two different client ids now converge on one host id.
- New `projectRemoteAppStatus` tests: `available` → running, each of `openable`/`initializing`/`blocked` → not running, absent status (headless serve) → not running, `authoritativeWindowId` fallback honored for old runtimes, pid always null.
- Platform: macOS. No platform-specific paths; the defect-2 test uses Windows-shaped paths explicitly.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

<!-- DO NOT FILL IN IF YOU ARE STABLYAI TEAM MEMBER (INTERNAL CONTRIBUTOR), IGNORE SECTION: -->

## Review

Worth a look:

1. **No migration is deliberate, and it bounds the fix.** Rows written before this keep their client-minted stamp, so the compensating reader logic stays for now, and the duplicate-row convergence only holds once *both* writes happen on an upgraded host — a pre-existing `runtime:<A>` row plus a fresh `local` write from B still produces two rows for one checkout. Backfilling would fix that but means rewriting setup ids, since ids embed the host id. If you'd rather clean the data, that's a separate change.
2. **`available` as the proxy for "desktop app running".** On macOS an app with all windows closed reports `openable`, so this will say `running: false` for it. I judged that better than the previous unconditional `false`, and it directly answers the question that cost time here ("did this run exercise the renderer?"). Open to a stricter signal if one exists.
3. **Known adjacent inconsistency, left alone:** the SSH-relay status path (`src/main/ssh/ssh-remote-orca-cli.ts`) hardcodes the *opposite*, `app.running: true`, regardless of whether a window exists. Same defect class, different transport, and the resolver lives in `src/cli` so sharing it means moving it. Happy to do it here or separately.

## Agent skill upstream boundary

N/A — no skill content changed.

---

## Review follow-ups (readiness pass)

**Fixed here:**
- **SSH host passthrough reported the opposite hardcode.** `ssh-remote-orca-cli.ts` answered `app.running: true` unconditionally for the Orca host reached over SSH, claiming a desktop app even for a headless `serve` — the same defect as defect 4, one transport over. The projection moved to `src/shared/cli-app-status-projection.ts` and both transports now share it.
- **A raw `method_not_found` on project host setup.** Since `--host runtime:<id>` routes these commands to a paired server, a client can reach a server that predates project host setup without meaning to. That surfaced the dispatcher's `Unknown method: projectHostSetup.list`, which reads as an Orca bug; the CLI now names the version gap the way the desktop already does. This closes the capability-gate gap noted in review without an extra preflight round trip.

**Attempted and reverted, deliberately:** making the persistence duplicate check treat `local` and `runtime:*` as one machine, so a legacy client-minted row would block a duplicate. The self-host assumption is sound at the RPC boundary — a `runtime:` host there names the runtime being addressed — but false in the store, which also records independent provisioning metadata for machines that are *not* itself. An existing test (`creates independent project host setup records for provisioning flows`) covers exactly that case and failed, correctly. Duplicate convergence therefore stays bounded to rows written after the normalization, as described above.

