### PR TITLE
fix(macos): opt Orca out of AppKit automatic period substitution

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -4,6 +4,7 @@ import { isAbsolute, join } from 'node:path'
 import os from 'node:os'
 import { app, BrowserWindow, dialog, ipcMain, nativeTheme, powerMonitor, type Tray } from 'electron'
 import { initTccPromptNotice, stopTccPromptNotice } from './macos-tcc-prompt-notice'
+import { disableMacAutomaticPeriodSubstitution } from './macos-automatic-period-substitution'
 import { electronApp, is } from '@electron-toolkit/utils'
 import {
   Store,
@@ -2182,6 +2183,8 @@ function shouldSuppressCodexAutoApprovalSyntheticTitleFromHook(args: {
 
 void app.whenReady().then(async () => {
   logStartupMilestone('app-ready')
+  // Why: before any window exists, so the first terminal never inherits the substitution (#11504).
+  disableMacAutomaticPeriodSubstitution()
   installMainThreadHangWatchdog({ userDataPath: getCanonicalUserDataPath() })
   const hangDetection = consumeHangDetectionMarker(
     hangDetectionMarkerPath(getCanonicalUserDataPath())

--- a/src/main/macos-automatic-period-substitution.test.ts
+++ b/src/main/macos-automatic-period-substitution.test.ts
@@ -1,0 +1,69 @@
+import { systemPreferences } from 'electron'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  AUTOMATIC_PERIOD_SUBSTITUTION_KEY,
+  disableMacAutomaticPeriodSubstitution
+} from './macos-automatic-period-substitution'
+
+vi.mock('electron', () => ({ systemPreferences: { setUserDefault: vi.fn() } }))
+
+// #11504: on m4air (macOS 26.5.2, packaged build, global preference on) typing `a b <space>
+// <space>` in a terminal put `["a","b"," ",". "]` on the PTY. With this override written to
+// Orca's own defaults domain the same keystrokes put `["a","b"," "," "]` there — no period.
+// Sealed at .tmp/ime-handoff/swarm-scratch/wave27-11504fix/.
+describe('disableMacAutomaticPeriodSubstitution', () => {
+  beforeEach(() => {
+    vi.mocked(systemPreferences.setUserDefault).mockReset()
+  })
+
+  it('writes the app-domain override on macOS', () => {
+    const setUserDefault = vi.fn()
+
+    expect(disableMacAutomaticPeriodSubstitution({ platform: 'darwin', setUserDefault })).toBe(true)
+    expect(setUserDefault).toHaveBeenCalledWith(AUTOMATIC_PERIOD_SUBSTITUTION_KEY, 'boolean', false)
+  })
+
+  // Why: startup calls this with no options, so Electron delegation is the path that actually ships.
+  it('writes through systemPreferences when no writer is injected', () => {
+    expect(disableMacAutomaticPeriodSubstitution({ platform: 'darwin' })).toBe(true)
+    expect(systemPreferences.setUserDefault).toHaveBeenCalledWith(
+      AUTOMATIC_PERIOD_SUBSTITUTION_KEY,
+      'boolean',
+      false
+    )
+  })
+
+  // The other direction of #11504: suppress the substitution the OS invents, and nothing else.
+  // Quote and dash substitution stay as the user set them, and a period the user types is never
+  // routed through here at all — it reaches the PTY as an ordinary keystroke
+  // (terminal-stock-composition.issue-11504-macos-period-substitution.test.ts pins that arm).
+  it('disables period substitution only', () => {
+    const setUserDefault = vi.fn()
+
+    disableMacAutomaticPeriodSubstitution({ platform: 'darwin', setUserDefault })
+
+    expect(setUserDefault.mock.calls).toEqual([
+      [AUTOMATIC_PERIOD_SUBSTITUTION_KEY, 'boolean', false]
+    ])
+  })
+
+  it.each(['win32', 'linux'] as const)('does not touch defaults on %s', (platform) => {
+    const setUserDefault = vi.fn()
+
+    expect(disableMacAutomaticPeriodSubstitution({ platform, setUserDefault })).toBe(false)
+    expect(setUserDefault).not.toHaveBeenCalled()
+  })
+
+  it('survives a failing preferences write', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const setUserDefault = vi.fn(() => {
+      throw new Error('defaults unavailable')
+    })
+
+    expect(disableMacAutomaticPeriodSubstitution({ platform: 'darwin', setUserDefault })).toBe(
+      false
+    )
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+})

--- a/src/main/macos-automatic-period-substitution.ts
+++ b/src/main/macos-automatic-period-substitution.ts
@@ -1,0 +1,43 @@
+import { systemPreferences } from 'electron'
+
+/**
+ * macOS "Add period with double-space" (`NSAutomaticPeriodSubstitutionEnabled`, on by default)
+ * is applied by AppKit's text input system. Native terminals never join that system; Chromium
+ * text fields do, so xterm's helper textarea inherits it and a double space arrives as `". "` —
+ * a period nobody typed, handed straight to the PTY (#11504).
+ *
+ * Chromium answers AppKit for quote and dash substitution and defaults both off (`boolForKey:`
+ * on an unset `WebAutomatic*` key), which is why those never leak. It declares no period accessor
+ * at all — "period" does not appear in render_widget_host_view_cocoa.mm — so AppKit applies that
+ * one without asking, and this user default is the only lever. There is no per-field or
+ * per-webContents opt-out to prefer over it.
+ *
+ * Writing the key into Orca's own defaults domain overrides the global value for this app alone
+ * and leaves the user's system-wide setting untouched. It necessarily covers every Orca text
+ * field, not only terminals — AppKit offers no narrower scope.
+ */
+export const AUTOMATIC_PERIOD_SUBSTITUTION_KEY = 'NSAutomaticPeriodSubstitutionEnabled'
+
+export type DisableMacAutomaticPeriodSubstitutionOptions = {
+  platform?: NodeJS.Platform
+  setUserDefault?: (key: string, type: 'boolean', value: boolean) => void
+}
+
+/** Returns whether the app-domain override was written. No-op off macOS. */
+export function disableMacAutomaticPeriodSubstitution({
+  platform = process.platform,
+  setUserDefault = (key, type, value) => systemPreferences.setUserDefault(key, type, value)
+}: DisableMacAutomaticPeriodSubstitutionOptions = {}): boolean {
+  if (platform !== 'darwin') {
+    return false
+  }
+
+  try {
+    setUserDefault(AUTOMATIC_PERIOD_SUBSTITUTION_KEY, 'boolean', false)
+    return true
+  } catch (error) {
+    // Why: a preferences write is never worth failing startup over.
+    console.warn('Failed to disable macOS automatic period substitution', error)
+    return false
+  }
+}

--- a/src/main/macos-automatic-period-substitution.ts
+++ b/src/main/macos-automatic-period-substitution.ts
@@ -15,6 +15,16 @@ import { systemPreferences } from 'electron'
  * Writing the key into Orca's own defaults domain overrides the global value for this app alone
  * and leaves the user's system-wide setting untouched. It necessarily covers every Orca text
  * field, not only terminals — AppKit offers no narrower scope.
+ *
+ * Why not the field-level opt-out: xterm already sets `autocorrect="off"` on its helper textarea,
+ * and the substitution still fired on the Chromium we pin. That attribute reaches AppKit through
+ * quote, dash and text-replacement selectors only; the shipped framework binary declares no
+ * period selector at all. Nor is a focus-scoped write viable — AppKit latches the value at first
+ * read, and a later removeUserDefault does not bring the behaviour back in the same process.
+ *
+ * If this is ever reverted, remove the key as well. AppKit reads the app's plist, not our code,
+ * so a bare revert leaves the override in place permanently with nothing left to explain it —
+ * which is how this fix was lost once already.
  */
 export const AUTOMATIC_PERIOD_SUBSTITUTION_KEY = 'NSAutomaticPeriodSubstitutionEnabled'
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​69 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​69 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​56 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​56 |

<!-- /orca-pr-loc -->

Closes #11504. **This is a straight restore of `6a9ba6918f5`**, which shipped, was verified on macOS 26.5.2, and was then reverted as collateral.

## The bug

macOS *"Add period with double-space"* is **on by default** and applied by AppKit's text input system. Native terminals never join that system; Chromium text fields do — so the terminal's helper textarea inherits it, and a double space arrives as `". "`. A period nobody typed, handed straight to the pty.

Confirmed independently: **Terminal.app, iTerm2, Ghostty and Warp all ignore this.** Orca was the only one reacting.

## Why this lever and not a narrower one

**The field-level opt-out does not cover this rule, and that is measured rather than assumed.** xterm already sets `autocorrect="off"` on its helper textarea, and the substitution fired anyway on the Chromium this repo pins (Electron 43.1.0 / Chrome 150.0.7871.47), captured at the pty:

```
default unset    ->  ... 20 2e 20 0a     (space period space)
default written  ->  ... 20 20 0a        (two spaces)
re-armed         ->  period returns
```

Checking the shipped framework binary rather than months-old upstream source: it declares `isAutomaticQuoteSubstitutionEnabled`, `isAutomaticDashSubstitutionEnabled` and `isAutomaticTextReplacementEnabled`, and **no period selector at all**. `autocorrect` has three channels into AppKit and period is not one of them. AppKit's own Substitutions menu has no period item either.

A focus-scoped write — set it when a terminal focuses, clear it otherwise — was tried previously and does not work: **AppKit latches the value at first read**, and a later `removeUserDefault` does not restore the behaviour in the same process. It would switch off at the first terminal and never come back.

So the app-domain default is the only opt-out AppKit exposes for this rule.

Writing the key into **Orca's own defaults domain** overrides the global value for this app alone. Verified with a literal `defaults read`:

```
BUNDLE_ID=com.stablyai.orca
BEFORE: does not exist        BEFORE_GLOBAL: 1
AFTER:  0 (boolean)           AFTER_GLOBAL:  1
```

The user's system-wide setting is untouched.

## The blast radius, stated plainly

It covers **every Orca text field**, not only terminals. Double-space will stop inserting a period in the Linear and Jira issue editors, the GitLab item dialog, the feedback dialog, the new-workspace composer, and agent chat inputs.

Two things narrow it, and one does not:

- **Quotes, dashes and text replacements are unaffected** — separate keys, and Chromium already answers AppKit for all three, so they were **already off** in those fields. This removes one behaviour, not a feature set.
- The flip side worth saying: period was therefore the *only* substitution still reaching those fields, so afterwards they have none.
- **It cannot be a setting.** AppKit latches at process start, so any toggle would be restart-required — clunky for a typing convenience.

## Why it went missing

It rode in the branch that returned IME composition ownership to xterm (#13128). That branch was reverted (#13282) for **two unrelated regressions**:

- full-width CJK punctuation arriving as ASCII — `，` as `,`, `。` as `.`
- the Korean preedit becoming invisible, so users typed blind

Neither had anything to do with this file. It is main-process only — three lines in `index.ts` plus a 43-line module — and touches no composition code, no forwarder, and no renderer. It was collateral.

The issue was closed as completed at the time and never reopened, so the fix has been absent since 2026-08-08 while the issue read as fixed.

## Scope

```
src/main/index.ts                                +3
src/main/macos-automatic-period-substitution.ts  +43
src/main/macos-automatic-period-substitution.test.ts
```

Called before any window exists, so the first terminal never inherits the substitution. No-op off macOS. A failed preferences write warns and continues — this is never worth failing startup over.

Dropped from the original commit: a renderer test for the stock composition path, which the revert removed along with that architecture.

## Tests

6 passing, covering the darwin/non-darwin split, the exact key and value written, and the throwing-write path.

## Not verified

**Not re-verified on hardware by me.** The original commit recorded a live check on macOS 26.5.2 — with the preference on, `a b space space` reached the pty as `. `; with the fix, two spaces, and a typed period still gets through.

Worth noting the bug does **not** currently reproduce on 1.4.185, most likely because the native-text forwarder blanks the helper textarea after every commit, so AppKit never sees the preceding word and never decides to substitute. That masking is incidental, undocumented until today, and would disappear the moment anyone removes the blanking — which has been proposed more than once. This fix removes the dependency on that accident.
