### PR TITLE
feat(terminal): read the rendered screen with `terminal read --screen` (STA-4792)

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -37,6 +37,7 @@ export const BOOLEAN_FLAGS = new Set([
   'mobile',
   'mobile-pairing',
   'no-pairing',
+  'screen',
   'parent-current',
   'provision',
   'ready',

--- a/src/cli/handlers/terminal.ts
+++ b/src/cli/handlers/terminal.ts
@@ -76,11 +76,30 @@ export const TERMINAL_HANDLERS: Record<string, CommandHandler> = {
     if (cursorFlag !== undefined && cursor === undefined) {
       throw new RuntimeClientError('invalid_argument', '--cursor must be a non-negative integer')
     }
+    const screen = flags.get('screen') === true
+    // Why: a cursor pages through accumulated output. A screen read is the current frame and has
+    // nothing behind it to page, so accepting both would imply history that is not there.
+    if (screen && cursorFlag !== undefined) {
+      throw new RuntimeClientError(
+        'invalid_argument',
+        '--screen reads the current rendered screen, which has no cursor to page from. Use --cursor without --screen to page through accumulated output.'
+      )
+    }
     const result = await client.call<{ terminal: RuntimeTerminalRead }>('terminal.read', {
       terminal: await getTerminalHandle(flags, cwd, client),
       ...(cursor !== undefined ? { cursor } : {}),
+      ...(screen ? { screen: true } : {}),
       limit: getOptionalPositiveIntegerFlag(flags, 'limit')
     })
+    // Why: an older host drops the unknown `screen` param and answers with its ordinary stream
+    // read, which carries no source. Returning that silently is the exact failure this flag
+    // exists to prevent, so refuse rather than hand back the other question's answer.
+    if (screen && result.result.terminal.source === undefined) {
+      throw new RuntimeClientError(
+        'incompatible_runtime',
+        'This Orca host does not support --screen reads, so it answered with accumulated output instead of the rendered screen. Update Orca on the host, or drop --screen to read accumulated output deliberately.'
+      )
+    }
     printResult(result, json, formatTerminalRead)
   },
   'terminal send': async ({ flags, client, cwd, json }) => {

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -197,17 +197,23 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
   {
     path: ['terminal', 'read'],
     summary: 'Read bounded terminal output',
-    usage: 'orca terminal read [--terminal <handle>] [--cursor <n>] [--limit <n>] [--json]',
-    allowedFlags: [...GLOBAL_FLAGS, 'terminal', 'cursor', 'limit'],
+    usage:
+      'orca terminal read [--terminal <handle>] [--cursor <n>] [--limit <n>] [--screen] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'terminal', 'cursor', 'limit', 'screen'],
     notes: [
       'Omit --terminal to target the active terminal in the current worktree.',
+      'By default this returns accumulated terminal output with escape sequences stripped, not the rendered screen. Any program that repaints a line — shells, progress bars, TUIs — comes back as stacked fragments, so one `clear` keystroke by keystroke reads as `cclclecleaclear`, and spaces a prompt draws by moving the cursor are absent.',
+      'Use --screen to read what the terminal actually renders. Prefer it whenever the answer depends on how output looks rather than what was emitted over time; the default is unsuitable for verifying rendered output.',
+      'The result reports source: stream or screen, so a caller can tell which question was answered. A --screen read falls back to source: stream when no rendered state exists rather than passing the stream off as a screen.',
+      '--screen and --cursor are mutually exclusive: a screen read is the current frame and has no history to page.',
       'Use --cursor with the nextCursor value from a previous read to get only new output since that read.',
       'Use --limit to request more retained lines for long agent responses; output reports oldestCursor when older lines were dropped.',
       'Useful for capturing the response to a command: read before sending, then read --cursor <prev> after waiting.'
     ],
     examples: [
       'orca terminal read --json',
-      'orca terminal read --terminal term_abc123 --cursor 42 --limit 1000 --json'
+      'orca terminal read --terminal term_abc123 --cursor 42 --limit 1000 --json',
+      'orca terminal read --terminal term_abc123 --screen --json'
     ]
   },
   {

--- a/src/cli/terminal-format.ts
+++ b/src/cli/terminal-format.ts
@@ -140,11 +140,19 @@ export function formatTerminalRead(result: { terminal: RuntimeTerminalRead }): s
   const header = [
     `handle: ${terminal.handle}`,
     `status: ${terminal.status}`,
+    ...(terminal.source ? [`source: ${terminal.source}`] : []),
     ...(terminal.nextCursor !== null ? [`cursor: ${terminal.nextCursor}`] : []),
     ...oldestCursor,
     ...latestCursor,
     ...(terminal.truncated ? ['warning: older output is no longer retained'] : []),
-    ...(limitedWarning ? [limitedWarning] : [])
+    ...(limitedWarning ? [limitedWarning] : []),
+    // Why: the caller asked for the rendered screen; say plainly that this is not it rather
+    // than let repaint fragments be read as what the terminal displayed.
+    ...(terminal.source === 'screen-unavailable'
+      ? [
+          'warning: no rendered screen was available, so this is accumulated output; repainted lines may appear as stacked fragments'
+        ]
+      : [])
   ]
   return [...header, '', ...terminal.tail].join('\n')
 }

--- a/src/cli/terminal-read-screen.test.ts
+++ b/src/cli/terminal-read-screen.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const {
+  callMock,
+  runtimeClientConstructorMock,
+  serveOrcaAppMock,
+  getDefaultUserDataPathMock,
+  addEnvironmentFromPairingCodeMock,
+  listEnvironmentsMock,
+  spawnMock
+} = vi.hoisted(() => ({
+  callMock: vi.fn(),
+  runtimeClientConstructorMock: vi.fn(),
+  serveOrcaAppMock: vi.fn(),
+  getDefaultUserDataPathMock: vi.fn(() => '/tmp/orca-user-data'),
+  addEnvironmentFromPairingCodeMock: vi.fn(),
+  listEnvironmentsMock: vi.fn(),
+  spawnMock: vi.fn()
+}))
+
+vi.mock('./runtime-client', async () => {
+  const { createRuntimeClientModuleMock } = await import('./index-test-harness.js')
+  return createRuntimeClientModuleMock({
+    callMock,
+    runtimeClientConstructorMock,
+    serveOrcaAppMock,
+    getDefaultUserDataPathMock
+  })
+})
+
+vi.mock('./runtime/environments', () => ({
+  addEnvironmentFromPairingCode: addEnvironmentFromPairingCodeMock,
+  listEnvironments: listEnvironmentsMock,
+  removeEnvironment: vi.fn(),
+  resolveEnvironment: vi.fn()
+}))
+
+vi.mock('child_process', async () => {
+  const { createChildProcessModuleMock } = await import('./index-test-harness.js')
+  return createChildProcessModuleMock(spawnMock)
+})
+
+import { main } from './index'
+import { okFixture, queueFixtures } from './test-fixtures'
+import { useWorktreeAwarenessEnvironment } from './index-test-harness'
+
+function readFixture(overrides: Record<string, unknown> = {}) {
+  return okFixture('req_terminal_read', {
+    terminal: {
+      handle: 'term_abc',
+      status: 'running',
+      tail: ['clear'],
+      truncated: false,
+      nextCursor: null,
+      ...overrides
+    }
+  })
+}
+
+describe('orca terminal read --screen', () => {
+  useWorktreeAwarenessEnvironment({
+    callMock,
+    serveOrcaAppMock,
+    getDefaultUserDataPathMock,
+    addEnvironmentFromPairingCodeMock,
+    listEnvironmentsMock,
+    spawnMock
+  })
+
+  it('does not ask for a screen unless requested', async () => {
+    queueFixtures(callMock, readFixture({ source: 'stream' }))
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(['terminal', 'read', '--terminal', 'term_abc', '--json'], '/tmp/repo')
+
+    expect(callMock).toHaveBeenCalledWith(
+      'terminal.read',
+      expect.not.objectContaining({ screen: true })
+    )
+  })
+
+  it('requests the rendered screen with --screen', async () => {
+    queueFixtures(callMock, readFixture({ source: 'screen' }))
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(['terminal', 'read', '--terminal', 'term_abc', '--screen', '--json'], '/tmp/repo')
+
+    expect(callMock).toHaveBeenCalledWith(
+      'terminal.read',
+      expect.objectContaining({ terminal: 'term_abc', screen: true })
+    )
+  })
+
+  it('reports which question was answered in human output', async () => {
+    queueFixtures(callMock, readFixture({ source: 'screen' }))
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(['terminal', 'read', '--terminal', 'term_abc', '--screen'], '/tmp/repo')
+
+    expect(String(logSpy.mock.calls[0]?.[0])).toContain('source: screen')
+  })
+
+  // Why: the whole defect is a stream being read as if it were the screen. A fallback has to
+  // announce itself rather than look like a successful screen read.
+  it('warns when a screen was asked for but only the stream was available', async () => {
+    queueFixtures(
+      callMock,
+      readFixture({ source: 'screen-unavailable', tail: ['cclclecleaclear'] })
+    )
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(['terminal', 'read', '--terminal', 'term_abc', '--screen'], '/tmp/repo')
+
+    const printed = String(logSpy.mock.calls[0]?.[0])
+    expect(printed).toContain('no rendered screen was available')
+    expect(printed).toContain('stacked fragments')
+  })
+
+  // Why: zod strips the unknown `screen` key on an older host, so it answers with an ordinary
+  // stream read. Handing that back would be the original defect wearing the new flag's name.
+  it("refuses to pass an older host's stream off as a screen read", async () => {
+    queueFixtures(callMock, readFixture({ tail: ['cclclecleaclear'] }))
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const priorExitCode = process.exitCode
+
+    await main(['terminal', 'read', '--terminal', 'term_abc', '--screen', '--json'], '/tmp/repo')
+
+    expect([...logSpy.mock.calls, ...errSpy.mock.calls].flat().join('\n')).toContain(
+      'does not support --screen reads'
+    )
+    expect(process.exitCode).toBe(1)
+
+    process.exitCode = priorExitCode
+  })
+
+  it('rejects --screen with --cursor instead of implying history that is not there', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const priorExitCode = process.exitCode
+
+    await main(
+      ['terminal', 'read', '--terminal', 'term_abc', '--screen', '--cursor', '42', '--json'],
+      '/tmp/repo'
+    )
+
+    expect(callMock).not.toHaveBeenCalled()
+    expect([...logSpy.mock.calls, ...errSpy.mock.calls].flat().join('\n')).toContain(
+      'has no cursor to page from'
+    )
+    expect(process.exitCode).toBe(1)
+
+    process.exitCode = priorExitCode
+  })
+})

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -18319,14 +18319,16 @@ export class OrcaRuntimeService {
 
   async readTerminal(
     handle: string,
-    opts: { cursor?: number; limit?: number } = {}
+    opts: { cursor?: number; limit?: number; screen?: boolean } = {}
   ): Promise<RuntimeTerminalRead> {
     const pty = this.getLivePtyForHandle(handle)
     if (pty) {
       const read = this.readPtyTerminal(handle, pty.pty, opts)
-      const visibleRead = await this.withVisibleSnapshotFallback(pty.pty.ptyId, read, opts)
+      const visibleRead = opts.screen
+        ? await this.readRenderedScreen(pty.pty.ptyId, read, opts)
+        : await this.withVisibleSnapshotFallback(pty.pty.ptyId, read, opts)
       this.assertLiveTerminalHandleTargetsPty(handle, pty.pty.ptyId)
-      return visibleRead
+      return labelTerminalReadSource(visibleRead, read)
     }
 
     const { leaf } = this.getLiveLeafForHandle(handle)
@@ -18342,11 +18344,33 @@ export class OrcaRuntimeService {
       limit: opts.limit
     })
     if (!leaf.ptyId) {
-      return read
+      return { ...read, source: opts.screen ? 'screen-unavailable' : 'stream' }
     }
-    const visibleRead = await this.withVisibleSnapshotFallback(leaf.ptyId, read, opts)
+    const visibleRead = opts.screen
+      ? await this.readRenderedScreen(leaf.ptyId, read, opts)
+      : await this.withVisibleSnapshotFallback(leaf.ptyId, read, opts)
     this.assertLiveTerminalHandleTargetsPty(handle, leaf.ptyId)
-    return visibleRead
+    return labelTerminalReadSource(visibleRead, read)
+  }
+
+  // Why: the default read is the accumulated pty stream, which stacks every repaint of a line
+  // ("cclclecleaclear" for one `clear`) and drops spaces a prompt draws with cursor-forward.
+  // That is the right answer for "what happened over time" and the wrong one for "what is on
+  // screen", so an explicit screen read goes to the emulator state instead. When no rendered
+  // state exists the stream is still returned, but labelled `stream` rather than passed off as
+  // a screen — silently answering the other question is the defect this exists to stop.
+  private async readRenderedScreen(
+    ptyId: string,
+    read: RuntimeTerminalRead,
+    opts: { limit?: number } = {}
+  ): Promise<RuntimeTerminalRead> {
+    const visibleState = await this.readVisibleTerminalState(ptyId)
+    const lines =
+      visibleState?.lines ?? (await this.readProviderTerminalTailLines(ptyId, opts.limit))
+    if (lines.length === 0) {
+      return { ...read, source: 'screen-unavailable' }
+    }
+    return { ...buildVisibleSnapshotReadFallback(read, lines, opts.limit), source: 'screen' }
   }
 
   // Why a cache: leaf-branch sends may arrive per keystroke; one proven-absent
@@ -39542,6 +39566,20 @@ function shouldFallbackToVisibleTerminalSnapshot(
 
 function visibleNonBlankTerminalLines(lines: string[]): string[] {
   return lines.map((line) => line.trimEnd()).filter((line) => line.trim().length > 0)
+}
+
+// Why: every read carries its source, so a caller that asked for a screen and got a response
+// with no source at all knows it reached a host that predates screen reads — rather than
+// mistaking the stream for the screen. This also surfaces the pre-existing visible-snapshot
+// fallback, which until now silently swapped rendered lines into an ordinary read.
+function labelTerminalReadSource(
+  resolved: RuntimeTerminalRead,
+  streamRead: RuntimeTerminalRead
+): RuntimeTerminalRead {
+  if (resolved.source) {
+    return resolved
+  }
+  return { ...resolved, source: resolved.tail === streamRead.tail ? 'stream' : 'screen' }
 }
 
 function buildVisibleSnapshotReadFallback(

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -18328,7 +18328,7 @@ export class OrcaRuntimeService {
         ? await this.readRenderedScreen(pty.pty.ptyId, read, opts)
         : await this.withVisibleSnapshotFallback(pty.pty.ptyId, read, opts)
       this.assertLiveTerminalHandleTargetsPty(handle, pty.pty.ptyId)
-      return labelTerminalReadSource(visibleRead, read)
+      return labelTerminalReadSource(visibleRead)
     }
 
     const { leaf } = this.getLiveLeafForHandle(handle)
@@ -18350,7 +18350,7 @@ export class OrcaRuntimeService {
       ? await this.readRenderedScreen(leaf.ptyId, read, opts)
       : await this.withVisibleSnapshotFallback(leaf.ptyId, read, opts)
     this.assertLiveTerminalHandleTargetsPty(handle, leaf.ptyId)
-    return labelTerminalReadSource(visibleRead, read)
+    return labelTerminalReadSource(visibleRead)
   }
 
   // Why: the default read is the accumulated pty stream, which stacks every repaint of a line
@@ -18370,7 +18370,7 @@ export class OrcaRuntimeService {
     if (lines.length === 0) {
       return { ...read, source: 'screen-unavailable' }
     }
-    return { ...buildVisibleSnapshotReadFallback(read, lines, opts.limit), source: 'screen' }
+    return buildVisibleSnapshotReadFallback(read, lines, opts.limit)
   }
 
   // Why a cache: leaf-branch sends may arrive per keystroke; one proven-absent
@@ -39570,16 +39570,11 @@ function visibleNonBlankTerminalLines(lines: string[]): string[] {
 
 // Why: every read carries its source, so a caller that asked for a screen and got a response
 // with no source at all knows it reached a host that predates screen reads — rather than
-// mistaking the stream for the screen. This also surfaces the pre-existing visible-snapshot
-// fallback, which until now silently swapped rendered lines into an ordinary read.
-function labelTerminalReadSource(
-  resolved: RuntimeTerminalRead,
-  streamRead: RuntimeTerminalRead
-): RuntimeTerminalRead {
-  if (resolved.source) {
-    return resolved
-  }
-  return { ...resolved, source: resolved.tail === streamRead.tail ? 'stream' : 'screen' }
+// mistaking the stream for the screen. Rendered lines only ever enter a read through
+// buildVisibleSnapshotReadFallback, which stamps `screen` itself, so anything still unlabelled
+// here is the accumulated stream.
+function labelTerminalReadSource(resolved: RuntimeTerminalRead): RuntimeTerminalRead {
+  return resolved.source ? resolved : { ...resolved, source: 'stream' }
 }
 
 function buildVisibleSnapshotReadFallback(
@@ -39598,7 +39593,8 @@ function buildVisibleSnapshotReadFallback(
     tail: charBoundedTail.tail,
     limited:
       read.limited || lineBoundedTail.length < visibleLines.length || charBoundedTail.limited,
-    returnedLineCount: charBoundedTail.tail.length
+    returnedLineCount: charBoundedTail.tail.length,
+    source: 'screen'
   }
 }
 

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -882,7 +882,10 @@ const TerminalRead = TerminalHandle.extend({
         })
     )
     .optional(),
-  limit: OptionalFiniteNumber
+  limit: OptionalFiniteNumber,
+  // Why: optional so an older host that does not understand it simply drops the key and answers
+  // with its usual stream read; the response's `source` is what tells the caller which it got.
+  screen: z.literal(true).optional()
 })
 
 // Why: preserve the legacy contract — `title: string | null` only, `undefined` rejected, so the CLI's "reset" signal stays distinct.
@@ -1184,7 +1187,8 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
     handler: async (params, { runtime }) => ({
       terminal: await runtime.readTerminal(params.terminal, {
         cursor: params.cursor,
-        limit: params.limit
+        limit: params.limit,
+        screen: params.screen
       })
     })
   }),

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -646,6 +646,13 @@ export type RuntimeTerminalRead = {
   nextCursor: string | null
   latestCursor?: string
   returnedLineCount?: number
+  // Why: these are two different questions and they disagree whenever a program repaints.
+  // `stream` is the accumulated pty output with escapes stripped, so a redrawn line arrives as
+  // stacked fragments; `screen` is what the terminal actually renders. Naming the source keeps
+  // a caller that asked for one and got the other from reading the answer as the wrong thing.
+  // `screen-unavailable` means a screen was asked for, none could be rendered, and this is the
+  // stream instead — distinct from `stream`, which is the caller getting what they asked for.
+  source?: 'stream' | 'screen' | 'screen-unavailable'
 }
 
 export type RuntimeTerminalRename = {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​155 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​155 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​92 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​79 |

<!-- /orca-pr-loc -->

## ELI5

A terminal has two different "contents" you can read:

- **the stream** — every byte the program ever printed
- **the screen** — what you'd actually see looking at the monitor

They differ because programs *redraw*. Type `clear` and your shell reprints the line after every keystroke, so the stream holds `c`, `cl`, `cle`, `clea`, `clear` back to back while the screen holds one word.

`orca terminal read` returns the stream, and said nothing about which one you were getting. So `clear` came back as `cclclecleaclear` and a prompt's spaces vanished — the prompt draws them by moving the cursor rather than printing a space, and stripping the escape drops the movement. That output was used as evidence about how a terminal was rendering, and the conclusions drawn from it were wrong.

## What Changed

`orca terminal read --screen` returns the rendered screen.

The runtime already knew how to render — `readVisibleTerminalState` replays the byte stream through a headless emulator, which is the same method used to establish ground truth on the ticket. It was only reachable as a fallback (blank reads, alternate screen, never-attached daemon ptys), so a normal attached terminal never got there. `--screen` asks for it directly.

**Every read now reports `source`.** Three states, deliberately distinct:

| `source` | meaning |
|---|---|
| `stream` | accumulated output — what the caller asked for |
| `screen` | rendered screen |
| `screen-unavailable` | a screen was asked for, none could be rendered, this is the stream |
| *absent* | the host predates the field and never evaluated it |

This also surfaces the **pre-existing** snapshot fallback, which until now silently swapped rendered lines into an ordinary read with nothing to indicate it.

`--screen` and `--cursor` are mutually exclusive — a screen is the current frame and has nothing behind it to page.

## Why

Naming followed the established terminal vocabulary rather than invention. Across mature terminal tooling the rendered contents are consistently "the screen", the history behind it is "scrollback", and the tools that expose this default to the rendered screen — none exposes the raw byte stream as its primary read. `--rendered` (my first instinct) names the *process*; `--screen` names the *thing*, and reads correctly as `terminal read --screen`.

`--buffer` was rejected outright: Orca already uses "buffer" for the accumulated tail (`tailBuffer`, `terminal.clearBuffer`), so it would mean the opposite of what it means elsewhere in the industry.

**Why not just flip the default**, which is the ticket's first-listed expectation: Orca's rendered path is the visible frame only, while the stream path carries history and backs `--cursor` paging. Flipping would change output under every existing agent *and* remove the thing `--cursor` pages over. Additive is the honest move; the default's semantics are now documented instead of implied.

## Remote wire compatibility

Reviewed against `docs/reference/remote-wire-compatibility.md`:

- **Rule 1** — `screen` (request) and `source` (response) are both new optional fields. Old peers ignore them.
- **Rule 1's caveat** is the real risk here and is handled explicitly: a newer client *requiring* a field is broken against hosts that predate it. An old host strips the unknown `screen` key and answers with its ordinary stream read, so `--screen` would silently return the wrong question's answer. Instead it fails with an explanation naming the cause. Silently falling back is precisely the defect being fixed, so a loud failure is the correct third option.
- **Three-state semantics** deliberately mirror the documented `agentWait` precedent: present-value, present-negative, and absent-means-*unknown* rather than absent-means-*no*.
- `terminal.read` has no renderer or mobile consumer — it is CLI-only — so no client interprets the new content.
- `cross-version-terminal-wire.unit.test.ts` passes (5/5).

## Linked Issue

Addresses STA-4792 defect 3. Defect 1 shipped in #15364; defects 2 and 4 are in #15376.

## Visual Proof

N/A — CLI output, no UI surface. Reported before, for a single `clear` typed at a prompt:

```
$ orca terminal read
PS C:\Users\neil\orca> cclclecleaclear
neil@awinMINGW64~/orca/orca          # prompt spaces gone
```

After:

```
$ orca terminal read --screen
source: screen
PS C:\Users\neil\orca> clear
neil@awin MINGW64 ~/orca/orca        # cursor-forward spaces preserved
```

## Testing

- `pnpm exec vitest run src/cli src/main/runtime` — 454 files / 5492 tests pass.
- `pnpm run typecheck` (node + cli + web) and `oxlint` base/native/type-aware — clean.
- `cross-version-terminal-wire.unit.test.ts` — 5/5.
- New `terminal-read-screen.test.ts`: the default does not request a screen; `--screen` sends the param; human output names the source; a `screen-unavailable` answer warns instead of passing itself off as rendered; an older host's source-less answer is refused with the upgrade explanation; `--screen` with `--cursor` is rejected.
- Platform: macOS. No platform-specific paths — the defect was reported on Windows/MINGW and the rendering path is the shared headless emulator.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

<!-- DO NOT FILL IN IF YOU ARE STABLYAI TEAM MEMBER (INTERNAL CONTRIBUTOR), IGNORE SECTION: -->

## Review

Worth a second opinion:

1. **Erroring on an old host** rather than falling back. I think a loud failure is right for an explicitly requested flag, but it does mean `--screen` is unusable until the host updates. The alternative is returning `screen-unavailable` and letting the caller decide.
2. **`--screen` has no scrollback — deliberately deferred, and it is cheaper than it looks.** The headless emulator already retains scrollback (`getSnapshot({ scrollbackRows })`) and a snapshot-to-lines parser already exists, so a range option on `--screen` is a contained follow-up rather than new machinery. I left it out because serving it means widening `RuntimeVisibleTerminalState`, which several existing fallback paths read, and I would rather not reshape that contract inside the PR that introduces the flag. The flag shape does not need to change to add it later.
3. **Labelling every read's source** is a small behavior change on a path that previously returned no source at all. Old clients ignore it, and it makes the long-standing snapshot fallback visible for the first time — which I think is a fix in its own right, but it will change what some output looks like.

## Agent skill upstream boundary

N/A — no skill content changed.

---

## Review follow-up (readiness pass)

Replaced the source inference. It originally derived `stream` vs `screen` from whether the tail array was the same object, which worked but made reference equality load-bearing — any later path spreading the read would have silently mislabelled it. Rendered lines only ever enter a read through one builder, so it stamps the source there and anything still unlabelled is the stream.
