### PR TITLE
fix(worktrees): detect git D/F ref conflicts before create (STA-4762)

### DIFF
--- a/src/main/git/branch-ref-conflict.test.ts
+++ b/src/main/git/branch-ref-conflict.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  branchRefDirectoryConflictKind,
   buildBranchRefConflictArgv,
   classifyBranchRefDirectoryConflict,
-  formatBranchConflictMessage
+  formatBranchConflictMessage,
+  isUnsuffixableBranchConflict
 } from './branch-ref-conflict'
 
 function refs(...shortNames: string[]): string {
@@ -93,6 +95,29 @@ describe('classifyBranchRefDirectoryConflict', () => {
   })
 })
 
+describe('branchRefDirectoryConflictKind / isUnsuffixableBranchConflict', () => {
+  it('marks a blocking prefix unsuffixable and a nested ref suffixable', () => {
+    const blocked = branchRefDirectoryConflictKind({ direction: 'file', existingBranch: 'release' })
+    const nested = branchRefDirectoryConflictKind({
+      direction: 'directory',
+      existingBranch: 'feature/x'
+    })
+
+    expect(blocked).toBe('local-ref-prefix')
+    expect(nested).toBe('local-directory')
+    // `release` blocks `release/1.0-2` exactly as it blocks `release/1.0`, so retrying is futile.
+    expect(isUnsuffixableBranchConflict(blocked)).toBe(true)
+    // `feature/x` does not block `feature-2`, so the suffix loop should keep going.
+    expect(isUnsuffixableBranchConflict(nested)).toBe(false)
+  })
+
+  it('never stops the loop for exact, remote, or absent conflicts', () => {
+    expect(isUnsuffixableBranchConflict('local')).toBe(false)
+    expect(isUnsuffixableBranchConflict('remote')).toBe(false)
+    expect(isUnsuffixableBranchConflict(null)).toBe(false)
+  })
+})
+
 describe('formatBranchConflictMessage', () => {
   it('keeps the existing wording for exact local and remote conflicts', () => {
     expect(formatBranchConflictMessage('feature/foo', 'local', 'branch name')).toBe(
@@ -107,6 +132,14 @@ describe('formatBranchConflictMessage', () => {
     expect(formatBranchConflictMessage('feature/foo', 'local')).toBe(
       'Branch "feature/foo" already exists locally.'
     )
+  })
+
+  it('tells the user a blocking prefix cannot be suffixed away', () => {
+    const message = formatBranchConflictMessage('release/1.0', 'local-ref-prefix', 'worktree name')
+
+    expect(message).toContain('is a prefix of it')
+    expect(message).toContain('no suffix avoids it')
+    expect(message).not.toContain('already exists')
   })
 
   it('does not claim a directory conflict already exists', () => {

--- a/src/main/git/branch-ref-conflict.test.ts
+++ b/src/main/git/branch-ref-conflict.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildBranchRefConflictArgv,
+  classifyBranchRefDirectoryConflict,
+  formatBranchConflictMessage
+} from './branch-ref-conflict'
+
+function refs(...shortNames: string[]): string {
+  return shortNames.map((name) => `refs/heads/${name}`).join('\n')
+}
+
+describe('buildBranchRefConflictArgv', () => {
+  it('probes the name itself plus every proper prefix, longest first', () => {
+    expect(buildBranchRefConflictArgv('team/a/b/c')).toEqual([
+      'for-each-ref',
+      '--format=%(refname)',
+      'refs/heads/team/a/b/c',
+      'refs/heads/team/a/b',
+      'refs/heads/team/a',
+      'refs/heads/team'
+    ])
+  })
+
+  it('probes only the name itself for a flat branch', () => {
+    expect(buildBranchRefConflictArgv('feature')).toEqual([
+      'for-each-ref',
+      '--format=%(refname)',
+      'refs/heads/feature'
+    ])
+  })
+
+  it('never emits an argument git could read as an option', () => {
+    for (const arg of buildBranchRefConflictArgv('release/1.0').slice(2)) {
+      expect(arg.startsWith('refs/heads/')).toBe(true)
+    }
+  })
+})
+
+describe('classifyBranchRefDirectoryConflict', () => {
+  it('reports a directory conflict when refs nest under the requested name', () => {
+    expect(classifyBranchRefDirectoryConflict('feature', refs('feature/tti_fix_1440'))).toEqual({
+      direction: 'directory',
+      existingBranch: 'feature/tti_fix_1440'
+    })
+  })
+
+  it('reports a file conflict when a shorter ref blocks the requested name', () => {
+    expect(classifyBranchRefDirectoryConflict('release/1.0', refs('release'))).toEqual({
+      direction: 'file',
+      existingBranch: 'release'
+    })
+  })
+
+  it('matches a blocking prefix at any depth', () => {
+    expect(classifyBranchRefDirectoryConflict('team/a/b/c', refs('team/a'))).toEqual({
+      direction: 'file',
+      existingBranch: 'team/a'
+    })
+  })
+
+  it('ignores siblings the over-matching prefix patterns drag in', () => {
+    // Probing `release/1.0` also returns `release/2.0` via the `refs/heads/release` pattern.
+    expect(classifyBranchRefDirectoryConflict('release/1.0', refs('release/2.0'))).toBeNull()
+  })
+
+  it('does not treat a name-sharing sibling as a conflict', () => {
+    expect(classifyBranchRefDirectoryConflict('feature', refs('featurex', 'feature2/z'))).toBeNull()
+  })
+
+  it('returns null for empty output', () => {
+    expect(classifyBranchRefDirectoryConflict('feature', '')).toBeNull()
+  })
+
+  it('does not classify the exact ref as a directory conflict', () => {
+    // The exact case is a plain `local` conflict the caller detects first.
+    expect(classifyBranchRefDirectoryConflict('feature/x', refs('feature/x'))).toBeNull()
+  })
+
+  it('prefers the blocking shorter ref over a nested one', () => {
+    expect(
+      classifyBranchRefDirectoryConflict('release/1.0', refs('release/1.0/hotfix', 'release'))
+    ).toEqual({ direction: 'file', existingBranch: 'release' })
+  })
+
+  it('tolerates CRLF output and ignores non-branch lines', () => {
+    expect(
+      classifyBranchRefDirectoryConflict(
+        'feature',
+        'refs/tags/feature/x\r\nrefs/heads/feature/x\r\n'
+      )
+    ).toEqual({ direction: 'directory', existingBranch: 'feature/x' })
+  })
+})
+
+describe('formatBranchConflictMessage', () => {
+  it('keeps the existing wording for exact local and remote conflicts', () => {
+    expect(formatBranchConflictMessage('feature/foo', 'local', 'branch name')).toBe(
+      'Branch "feature/foo" already exists locally. Pick a different branch name.'
+    )
+    expect(formatBranchConflictMessage('feature/foo', 'remote', 'worktree name')).toBe(
+      'Branch "feature/foo" already exists on a remote. Pick a different worktree name.'
+    )
+  })
+
+  it('omits the advice clause when no subject is given', () => {
+    expect(formatBranchConflictMessage('feature/foo', 'local')).toBe(
+      'Branch "feature/foo" already exists locally.'
+    )
+  })
+
+  it('does not claim a directory conflict already exists', () => {
+    const message = formatBranchConflictMessage('feature', 'local-directory', 'worktree name')
+
+    expect(message).toBe(
+      'Branch "feature" conflicts with an existing branch name in this repo. Git cannot store both. Pick a different worktree name.'
+    )
+    expect(message).not.toContain('already exists')
+  })
+})

--- a/src/main/git/branch-ref-conflict.test.ts
+++ b/src/main/git/branch-ref-conflict.test.ts
@@ -139,7 +139,15 @@ describe('formatBranchConflictMessage', () => {
 
     expect(message).toContain('is a prefix of it')
     expect(message).toContain('no suffix avoids it')
+    expect(message).toContain('Rename or delete the existing branch')
+    expect(message).toContain('pick a different worktree name.')
     expect(message).not.toContain('already exists')
+  })
+
+  it('falls back to "branch name" for the runtime path that passes no subject', () => {
+    expect(formatBranchConflictMessage('release/1.0', 'local-ref-prefix')).toContain(
+      'pick a different branch name.'
+    )
   })
 
   it('does not claim a directory conflict already exists', () => {

--- a/src/main/git/branch-ref-conflict.ts
+++ b/src/main/git/branch-ref-conflict.ts
@@ -137,7 +137,7 @@ export function formatBranchConflictMessage(
   if (kind === 'local-ref-prefix') {
     // Why: no suffix escapes this one, so "pick a different name" alone is a
     // dead end — the user has to deal with the branch that is in the way.
-    return `Branch "${branchName}" conflicts with an existing branch that is a prefix of it. Git cannot store both, and no suffix avoids it. Rename or delete the existing branch, or pick a different branch name.`
+    return `Branch "${branchName}" conflicts with an existing branch that is a prefix of it. Git cannot store both, and no suffix avoids it. Rename or delete the existing branch, or pick a different ${subject ?? 'branch name'}.`
   }
   if (kind === 'local-directory') {
     // Why: "already exists" would be a lie. No ref has this exact name; the name

--- a/src/main/git/branch-ref-conflict.ts
+++ b/src/main/git/branch-ref-conflict.ts
@@ -1,0 +1,114 @@
+// Git stores refs as files under `.git/refs`, so `feature` and `feature/x` can
+// never both exist: one name would have to be a file and a directory at once.
+// Creating the second one fails with `cannot lock ref ... exists`. This module
+// detects that collision before a create runs, so worktree creation can suffix
+// the name (or explain itself) instead of surfacing raw git text.
+
+const REFS_HEADS = 'refs/heads/'
+
+export type BranchConflictKind = 'local' | 'local-directory' | 'remote'
+
+/**
+ * Which side of the directory/file rule blocks the name.
+ *
+ * - `directory`: existing refs nest *under* the requested name (`feature/x`
+ *   blocks `feature`).
+ * - `file`: an existing ref is a path *prefix* of the requested name
+ *   (`release` blocks `release/1.0`).
+ */
+export type BranchRefDirectoryConflict = {
+  direction: 'directory' | 'file'
+  /** The existing branch responsible for the collision. */
+  existingBranch: string
+}
+
+/** Proper `/`-prefixes of a branch name, longest first: `a/b/c` -> [`a/b`, `a`]. */
+function properBranchPrefixes(branchName: string): string[] {
+  const segments = branchName.split('/')
+  const prefixes: string[] = []
+  for (let count = segments.length - 1; count > 0; count -= 1) {
+    prefixes.push(segments.slice(0, count).join('/'))
+  }
+  return prefixes
+}
+
+/**
+ * `for-each-ref` argv listing every local ref that could collide with
+ * `branchName` under git's directory/file rule.
+ *
+ * A `for-each-ref` pattern matches a ref completely *or* up to a `/` boundary,
+ * so `refs/heads/feature` returns both `refs/heads/feature` and
+ * `refs/heads/feature/x` while never matching `refs/heads/featurex`. One
+ * invocation therefore covers both directions: the requested name's own pattern
+ * finds refs nested under it, and each proper-prefix pattern finds a shorter ref
+ * blocking it.
+ *
+ * Safe for git 2.25 — multi-pattern `for-each-ref` long predates the baseline.
+ * Every argument is `refs/heads/`-prefixed, so a branch name can never be read
+ * as an option, and `check-ref-format` has already rejected the glob characters
+ * (`*?[\`) that would otherwise make these patterns match too much.
+ */
+export function buildBranchRefConflictArgv(branchName: string): string[] {
+  return [
+    'for-each-ref',
+    '--format=%(refname)',
+    `${REFS_HEADS}${branchName}`,
+    ...properBranchPrefixes(branchName).map((prefix) => `${REFS_HEADS}${prefix}`)
+  ]
+}
+
+/**
+ * Classify `buildBranchRefConflictArgv` output. Returns null when `branchName`
+ * is creatable.
+ *
+ * The prefix patterns deliberately over-match — probing `release/1.0` also
+ * returns unrelated siblings like `release/2.0` — so a prefix only counts when
+ * the returned ref equals it exactly.
+ */
+export function classifyBranchRefDirectoryConflict(
+  branchName: string,
+  stdout: string
+): BranchRefDirectoryConflict | null {
+  const prefixes = new Set(properBranchPrefixes(branchName))
+  const nestedPrefix = `${branchName}/`
+  let nestedConflict: BranchRefDirectoryConflict | null = null
+
+  for (const line of stdout.split(/\r?\n/)) {
+    const refName = line.trim()
+    if (!refName.startsWith(REFS_HEADS)) {
+      continue
+    }
+    const shortRef = refName.slice(REFS_HEADS.length)
+    // A shorter ref blocking us is reported first: it is the more specific
+    // finding, and unlike the nested case no suffix of `branchName` can avoid it.
+    if (prefixes.has(shortRef)) {
+      return { direction: 'file', existingBranch: shortRef }
+    }
+    if (!nestedConflict && shortRef.startsWith(nestedPrefix)) {
+      nestedConflict = { direction: 'directory', existingBranch: shortRef }
+    }
+  }
+
+  return nestedConflict
+}
+
+/**
+ * The user-facing reason a branch name is unavailable. Shared by the local, WSL,
+ * SSH, and runtime create flows so all four report a collision identically.
+ *
+ * `subject` names the field the user should change; the runtime create path
+ * omits it and reports the bare reason.
+ */
+export function formatBranchConflictMessage(
+  branchName: string,
+  kind: BranchConflictKind,
+  subject?: string
+): string {
+  const advice = subject ? ` Pick a different ${subject}.` : ''
+  if (kind === 'local-directory') {
+    // Why: "already exists" would be a lie. No ref has this exact name; the name
+    // is unusable because git cannot nest it against a ref that does exist.
+    return `Branch "${branchName}" conflicts with an existing branch name in this repo. Git cannot store both.${advice}`
+  }
+  return `Branch "${branchName}" already exists ${kind === 'local' ? 'locally' : 'on a remote'}.${advice}`
+}

--- a/src/main/git/branch-ref-conflict.ts
+++ b/src/main/git/branch-ref-conflict.ts
@@ -6,7 +6,27 @@
 
 const REFS_HEADS = 'refs/heads/'
 
-export type BranchConflictKind = 'local' | 'local-directory' | 'remote'
+export type BranchConflictKind = 'local' | 'local-directory' | 'local-ref-prefix' | 'remote'
+
+/**
+ * Conflict kinds no suffix can escape, so a create loop should stop retrying
+ * instead of burning every candidate.
+ *
+ * Suffixes are appended to the last segment of the branch name, which leaves
+ * every proper prefix intact: if `release` blocks `release/1.0`, it blocks
+ * `release/1.0-2` through `release/1.0-100` too. Retrying is provably futile,
+ * and over SSH each attempt costs several remote round trips.
+ */
+export function isUnsuffixableBranchConflict(kind: BranchConflictKind | null): boolean {
+  return kind === 'local-ref-prefix'
+}
+
+/** Map a detected directory/file collision onto the conflict kind callers switch on. */
+export function branchRefDirectoryConflictKind(
+  conflict: BranchRefDirectoryConflict
+): BranchConflictKind {
+  return conflict.direction === 'file' ? 'local-ref-prefix' : 'local-directory'
+}
 
 /**
  * Which side of the directory/file rule blocks the name.
@@ -42,6 +62,15 @@ function properBranchPrefixes(branchName: string): string[] {
  * invocation therefore covers both directions: the requested name's own pattern
  * finds refs nested under it, and each proper-prefix pattern finds a shorter ref
  * blocking it.
+ *
+ * Known limitation: `for-each-ref` matches ref names byte-for-byte, while the
+ * ref *store* on macOS/Windows is usually case-insensitive and may normalize
+ * unicode. So `Feature/x` blocking `feature`, or an NFC ref blocking an NFD
+ * name, is not detected here and still reaches git. `--ignore-case` is
+ * deliberately not used: on a case-sensitive volume git genuinely allows both
+ * `feature` and `Feature/x`, so it would block names git accepts — a false
+ * positive, which is worse than the raw error this misses. Those cases fail
+ * exactly as they do today.
  *
  * Safe for git 2.25 — multi-pattern `for-each-ref` long predates the baseline.
  * Every argument is `refs/heads/`-prefixed, so a branch name can never be read
@@ -105,6 +134,11 @@ export function formatBranchConflictMessage(
   subject?: string
 ): string {
   const advice = subject ? ` Pick a different ${subject}.` : ''
+  if (kind === 'local-ref-prefix') {
+    // Why: no suffix escapes this one, so "pick a different name" alone is a
+    // dead end — the user has to deal with the branch that is in the way.
+    return `Branch "${branchName}" conflicts with an existing branch that is a prefix of it. Git cannot store both, and no suffix avoids it. Rename or delete the existing branch, or pick a different branch name.`
+  }
   if (kind === 'local-directory') {
     // Why: "already exists" would be a lie. No ref has this exact name; the name
     // is unusable because git cannot nest it against a ref that does exist.

--- a/src/main/git/repo.test.ts
+++ b/src/main/git/repo.test.ts
@@ -589,3 +589,101 @@ describe('getRemoteCount', () => {
     expect(count).toBe(0)
   })
 })
+
+describe('getBranchConflictKind — git directory/file ref conflicts (STA-4762)', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(tmpdir(), 'orca-repo-test-'))
+    initRepo(tmpDir)
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  /**
+   * Ground truth: does the user's real git binary refuse to create this branch?
+   * Every conflict assertion below is paired with this so the test cannot pass
+   * by asserting a rule git does not actually enforce.
+   */
+  function gitRefusesBranch(branchName: string): boolean {
+    try {
+      git(tmpDir, ['branch', branchName, 'refs/heads/main'])
+      git(tmpDir, ['branch', '-D', branchName])
+      return false
+    } catch {
+      return true
+    }
+  }
+
+  it('detects a nested ref blocking a shorter name (feature/x exists, create feature)', async () => {
+    git(tmpDir, ['branch', 'feature/tti_fix_1440'])
+
+    expect(gitRefusesBranch('feature')).toBe(true)
+    expect(await getBranchConflictKind(tmpDir, 'feature', 'origin/main')).toBe('local-directory')
+  })
+
+  it('detects a flat ref blocking a nested name (release exists, create release/1.0)', async () => {
+    git(tmpDir, ['branch', 'release'])
+
+    expect(gitRefusesBranch('release/1.0')).toBe(true)
+    expect(await getBranchConflictKind(tmpDir, 'release/1.0', 'origin/main')).toBe(
+      'local-directory'
+    )
+  })
+
+  it('detects a blocking prefix several segments up', async () => {
+    git(tmpDir, ['branch', 'team'])
+
+    expect(gitRefusesBranch('team/a/b/c')).toBe(true)
+    expect(await getBranchConflictKind(tmpDir, 'team/a/b/c', 'origin/main')).toBe('local-directory')
+  })
+
+  it('detects conflicts against packed refs', async () => {
+    git(tmpDir, ['branch', 'feature/packed'])
+    git(tmpDir, ['pack-refs', '--all'])
+
+    expect(gitRefusesBranch('feature')).toBe(true)
+    expect(await getBranchConflictKind(tmpDir, 'feature', 'origin/main')).toBe('local-directory')
+  })
+
+  it('still reports an exact collision as a plain local conflict', async () => {
+    git(tmpDir, ['branch', 'feature/x'])
+
+    expect(await getBranchConflictKind(tmpDir, 'feature/x', 'origin/main')).toBe('local')
+  })
+
+  it('leaves creatable names alone', async () => {
+    git(tmpDir, ['branch', 'feature/x'])
+    git(tmpDir, ['branch', 'release/1.0'])
+
+    for (const candidate of ['feature/y', 'featurex', 'feature2/z', 'release/1.0-2', 'rel']) {
+      expect(gitRefusesBranch(candidate)).toBe(false)
+      expect(await getBranchConflictKind(tmpDir, candidate, 'origin/main')).toBeNull()
+    }
+  })
+
+  it('lets the create flow suffix past a directory conflict, as it already does for exact ones', async () => {
+    git(tmpDir, ['branch', 'feature/tti_fix_1440'])
+
+    // Mirrors the worktree-create suffix loop: advance while a conflict is reported.
+    let candidate = 'feature'
+    for (
+      let suffix = 2;
+      (await getBranchConflictKind(tmpDir, candidate, 'origin/main')) !== null;
+    ) {
+      candidate = `feature-${suffix}`
+      suffix += 1
+    }
+
+    expect(candidate).toBe('feature-2')
+    expect(gitRefusesBranch(candidate)).toBe(false)
+  })
+
+  it('does not report a conflict when the probe cannot run', async () => {
+    expect(
+      await getBranchConflictKind(path.join(tmpDir, 'does-not-exist'), 'feature', 'origin/main')
+    ).toBeNull()
+  })
+})

--- a/src/main/git/repo.test.ts
+++ b/src/main/git/repo.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 
+import { isUnsuffixableBranchConflict } from './branch-ref-conflict'
 import {
   buildSearchBaseRefsArgv,
   getDefaultBaseRef,
@@ -629,7 +630,7 @@ describe('getBranchConflictKind — git directory/file ref conflicts (STA-4762)'
 
     expect(gitRefusesBranch('release/1.0')).toBe(true)
     expect(await getBranchConflictKind(tmpDir, 'release/1.0', 'origin/main')).toBe(
-      'local-directory'
+      'local-ref-prefix'
     )
   })
 
@@ -637,7 +638,9 @@ describe('getBranchConflictKind — git directory/file ref conflicts (STA-4762)'
     git(tmpDir, ['branch', 'team'])
 
     expect(gitRefusesBranch('team/a/b/c')).toBe(true)
-    expect(await getBranchConflictKind(tmpDir, 'team/a/b/c', 'origin/main')).toBe('local-directory')
+    expect(await getBranchConflictKind(tmpDir, 'team/a/b/c', 'origin/main')).toBe(
+      'local-ref-prefix'
+    )
   })
 
   it('detects conflicts against packed refs', async () => {
@@ -679,6 +682,27 @@ describe('getBranchConflictKind — git directory/file ref conflicts (STA-4762)'
 
     expect(candidate).toBe('feature-2')
     expect(gitRefusesBranch(candidate)).toBe(false)
+  })
+
+  it('reports a blocking prefix as unsuffixable, because git refuses every suffix', async () => {
+    git(tmpDir, ['branch', 'release'])
+
+    // Ground truth: no candidate the suffix loop can generate escapes `release`.
+    for (const candidate of ['release/1.0', 'release/1.0-2', 'release/1.0-100']) {
+      expect(gitRefusesBranch(candidate)).toBe(true)
+      expect(
+        isUnsuffixableBranchConflict(await getBranchConflictKind(tmpDir, candidate, 'origin/main'))
+      ).toBe(true)
+    }
+  })
+
+  it('reports a nested ref as suffixable, because a suffix does escape it', async () => {
+    git(tmpDir, ['branch', 'feature/tti_fix_1440'])
+
+    expect(
+      isUnsuffixableBranchConflict(await getBranchConflictKind(tmpDir, 'feature', 'origin/main'))
+    ).toBe(false)
+    expect(gitRefusesBranch('feature-2')).toBe(false)
   })
 
   it('does not report a conflict when the probe cannot run', async () => {

--- a/src/main/git/repo.ts
+++ b/src/main/git/repo.ts
@@ -11,6 +11,7 @@ import { toWindowsWslPath } from '../wsl'
 import { buildHostedRemoteCommitUrl, buildHostedRemoteFileUrl } from './hosted-remote-url'
 import { getLocalGitCapabilityCache } from './git-capability-state'
 import {
+  branchRefDirectoryConflictKind,
   buildBranchRefConflictArgv,
   classifyBranchRefDirectoryConflict,
   type BranchConflictKind
@@ -1000,19 +1001,20 @@ export type { BranchConflictKind }
  * Failures are swallowed: a probe that cannot run must not block a create that
  * git may well accept.
  */
-async function hasLocalRefDirectoryConflict(
+async function getLocalRefDirectoryConflictKind(
   path: string,
   branchName: string,
   options: LocalGitExecOptions
-): Promise<boolean> {
+): Promise<BranchConflictKind | null> {
   try {
     const { stdout } = await gitExecFileAsync(
       buildBranchRefConflictArgv(branchName),
       gitExecOptions(path, options)
     )
-    return classifyBranchRefDirectoryConflict(branchName, stdout) !== null
+    const conflict = classifyBranchRefDirectoryConflict(branchName, stdout)
+    return conflict ? branchRefDirectoryConflictKind(conflict) : null
   } catch {
-    return false
+    return null
   }
 }
 
@@ -1025,8 +1027,9 @@ export async function getBranchConflictKind(
   if (await hasGitRefAsync(path, `refs/heads/${branchName}`, options)) {
     return 'local'
   }
-  if (await hasLocalRefDirectoryConflict(path, branchName, options)) {
-    return 'local-directory'
+  const directoryConflictKind = await getLocalRefDirectoryConflictKind(path, branchName, options)
+  if (directoryConflictKind) {
+    return directoryConflictKind
   }
 
   try {

--- a/src/main/git/repo.ts
+++ b/src/main/git/repo.ts
@@ -10,6 +10,11 @@ import { parseWslUncPath } from '../../shared/wsl-paths'
 import { toWindowsWslPath } from '../wsl'
 import { buildHostedRemoteCommitUrl, buildHostedRemoteFileUrl } from './hosted-remote-url'
 import { getLocalGitCapabilityCache } from './git-capability-state'
+import {
+  buildBranchRefConflictArgv,
+  classifyBranchRefDirectoryConflict,
+  type BranchConflictKind
+} from './branch-ref-conflict'
 
 type LocalGitExecOptions = {
   wslDistro?: string
@@ -987,7 +992,29 @@ async function hasGitRefAsync(
   }
 }
 
-export type BranchConflictKind = 'local' | 'remote'
+export type { BranchConflictKind }
+
+/**
+ * Detect a git directory/file ref collision (`feature` vs `feature/x`) that
+ * would make `git worktree add -b` fail with raw `cannot lock ref` text.
+ * Failures are swallowed: a probe that cannot run must not block a create that
+ * git may well accept.
+ */
+async function hasLocalRefDirectoryConflict(
+  path: string,
+  branchName: string,
+  options: LocalGitExecOptions
+): Promise<boolean> {
+  try {
+    const { stdout } = await gitExecFileAsync(
+      buildBranchRefConflictArgv(branchName),
+      gitExecOptions(path, options)
+    )
+    return classifyBranchRefDirectoryConflict(branchName, stdout) !== null
+  } catch {
+    return false
+  }
+}
 
 export async function getBranchConflictKind(
   path: string,
@@ -997,6 +1024,9 @@ export async function getBranchConflictKind(
 ): Promise<BranchConflictKind | null> {
   if (await hasGitRefAsync(path, `refs/heads/${branchName}`, options)) {
     return 'local'
+  }
+  if (await hasLocalRefDirectoryConflict(path, branchName, options)) {
+    return 'local-directory'
   }
 
   try {

--- a/src/main/ipc/workspace-create-error-classifier.test.ts
+++ b/src/main/ipc/workspace-create-error-classifier.test.ts
@@ -34,6 +34,13 @@ describe('classifyWorkspaceCreateError', () => {
     expect(classifyWorkspaceCreateError(err)).toBe('path_collision')
   })
 
+  it('buckets a directory/file ref-conflict throw as path_collision', () => {
+    const err = new Error(
+      'Branch "feature" conflicts with an existing branch name in this repo. Git cannot store both. Pick a different worktree name.'
+    )
+    expect(classifyWorkspaceCreateError(err)).toBe('path_collision')
+  })
+
   it('buckets an existing-PR collision throw as path_collision', () => {
     const err = new Error('Branch "feature/foo" already has PR #42. Pick a different branch name.')
     expect(classifyWorkspaceCreateError(err)).toBe('path_collision')

--- a/src/main/ipc/workspace-create-error-classifier.ts
+++ b/src/main/ipc/workspace-create-error-classifier.ts
@@ -23,6 +23,9 @@ export function classifyWorkspaceCreateError(error: unknown): WorkspaceCreateErr
     return 'base_ref_missing'
   }
   if (
+    // Narrow anchor for the directory/file ref collision (`feature` vs
+    // `feature/x`): a name collision, not a git execution failure.
+    text.includes('conflicts with an existing branch name') ||
     text.includes('already exists locally') ||
     text.includes('already exists on a remote') ||
     text.includes('already exists. pick') ||

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -33,6 +33,12 @@ import {
   resolveDefaultBaseRefViaExec,
   resolveDefaultBaseRefWithLocalGit
 } from '../git/repo'
+import {
+  buildBranchRefConflictArgv,
+  classifyBranchRefDirectoryConflict,
+  formatBranchConflictMessage,
+  type BranchConflictKind
+} from '../git/branch-ref-conflict'
 import { resolveLocalGitUsername, getSshGitUsername } from '../git/git-username'
 import { hasCommitObjectViaGitExec } from '../git/commit-object-ref'
 import { resolveWorktreeCreateBase } from '../worktree-create-base'
@@ -843,14 +849,31 @@ async function hasSshLocalBranchConflict(
   }
 }
 
+/** SSH counterpart of the local directory/file ref probe; see branch-ref-conflict.ts. */
+async function hasSshLocalRefDirectoryConflict(
+  provider: SshGitProvider,
+  repoPath: string,
+  branchName: string
+): Promise<boolean> {
+  try {
+    const { stdout } = await provider.exec(buildBranchRefConflictArgv(branchName), repoPath)
+    return classifyBranchRefDirectoryConflict(branchName, stdout) !== null
+  } catch {
+    return false
+  }
+}
+
 async function getSshBranchConflictKind(
   provider: SshGitProvider,
   repoPath: string,
   branchName: string,
   allowedBaseRef: string
-): Promise<'local' | 'remote' | null> {
+): Promise<BranchConflictKind | null> {
   if (await hasSshLocalBranchConflict(provider, repoPath, branchName)) {
     return 'local'
+  }
+  if (await hasSshLocalRefDirectoryConflict(provider, repoPath, branchName)) {
+    return 'local-directory'
   }
   return (await hasSshRemoteBranchConflict(provider, repoPath, branchName, allowedBaseRef))
     ? 'remote'
@@ -919,7 +942,7 @@ function isMatchingSelectedGitHubPr(
 }
 
 function isAllowedPushTargetRemoteConflict(
-  conflictKind: 'local' | 'remote' | null,
+  conflictKind: BranchConflictKind | null,
   branchName: string,
   args: SelectedReviewBranchInput
 ): boolean {
@@ -1557,7 +1580,7 @@ export async function createRemoteWorktree(
   let checkoutExistingBranch = false
   let remotePath = ''
   let selectedExistingLocalBranchName: string | null = null
-  let lastBranchConflictKind: 'local' | 'remote' | null = null
+  let lastBranchConflictKind: BranchConflictKind | null = null
   let remotePathResolved = false
   const shouldRetireGeneratedName =
     args.nameWasGenerated === true && isGeneratedWorktreeCreateName(sanitizedName)
@@ -1634,7 +1657,7 @@ export async function createRemoteWorktree(
   if (!remotePathResolved) {
     if (lastBranchConflictKind) {
       throw new Error(
-        `Branch "${branchName}" already exists ${lastBranchConflictKind === 'local' ? 'locally' : 'on a remote'}. Pick a different ${branchConflictSubject}.`
+        formatBranchConflictMessage(branchName, lastBranchConflictKind, branchConflictSubject)
       )
     }
     throw new Error(
@@ -2132,7 +2155,7 @@ export async function createLocalWorktree(
   let resolved = false
   let checkoutExistingBranch = false
   let selectedExistingLocalBranchName: string | null = null
-  let lastBranchConflictKind: 'local' | 'remote' | null = null
+  let lastBranchConflictKind: BranchConflictKind | null = null
   let lastExistingPR: Awaited<ReturnType<typeof getPRForBranch>> | null = null
   let lastExistingReviewNumber: number | null = null
   const shouldRetireGeneratedName =
@@ -2265,7 +2288,7 @@ export async function createLocalWorktree(
     }
     if (lastBranchConflictKind) {
       throw new Error(
-        `Branch "${branchName}" already exists ${lastBranchConflictKind === 'local' ? 'locally' : 'on a remote'}. Pick a different ${branchConflictSubject}.`
+        formatBranchConflictMessage(branchName, lastBranchConflictKind, branchConflictSubject)
       )
     }
     throw new Error(

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -34,9 +34,11 @@ import {
   resolveDefaultBaseRefWithLocalGit
 } from '../git/repo'
 import {
+  branchRefDirectoryConflictKind,
   buildBranchRefConflictArgv,
   classifyBranchRefDirectoryConflict,
   formatBranchConflictMessage,
+  isUnsuffixableBranchConflict,
   type BranchConflictKind
 } from '../git/branch-ref-conflict'
 import { resolveLocalGitUsername, getSshGitUsername } from '../git/git-username'
@@ -850,16 +852,17 @@ async function hasSshLocalBranchConflict(
 }
 
 /** SSH counterpart of the local directory/file ref probe; see branch-ref-conflict.ts. */
-async function hasSshLocalRefDirectoryConflict(
+async function getSshLocalRefDirectoryConflictKind(
   provider: SshGitProvider,
   repoPath: string,
   branchName: string
-): Promise<boolean> {
+): Promise<BranchConflictKind | null> {
   try {
     const { stdout } = await provider.exec(buildBranchRefConflictArgv(branchName), repoPath)
-    return classifyBranchRefDirectoryConflict(branchName, stdout) !== null
+    const conflict = classifyBranchRefDirectoryConflict(branchName, stdout)
+    return conflict ? branchRefDirectoryConflictKind(conflict) : null
   } catch {
-    return false
+    return null
   }
 }
 
@@ -872,8 +875,13 @@ async function getSshBranchConflictKind(
   if (await hasSshLocalBranchConflict(provider, repoPath, branchName)) {
     return 'local'
   }
-  if (await hasSshLocalRefDirectoryConflict(provider, repoPath, branchName)) {
-    return 'local-directory'
+  const directoryConflictKind = await getSshLocalRefDirectoryConflictKind(
+    provider,
+    repoPath,
+    branchName
+  )
+  if (directoryConflictKind) {
+    return directoryConflictKind
   }
   return (await hasSshRemoteBranchConflict(provider, repoPath, branchName, allowedBaseRef))
     ? 'remote'
@@ -1637,6 +1645,9 @@ export async function createRemoteWorktree(
         ? await getSelectedHostedReviewForBranch(repo, branchName, args).catch(() => null)
         : null
       if (!selectedReview?.matchesSelected) {
+        if (isUnsuffixableBranchConflict(lastBranchConflictKind)) {
+          break
+        }
         continue
       }
       lastBranchConflictKind = null
@@ -2246,6 +2257,9 @@ export async function createLocalWorktree(
       }
     }
     if (lastBranchConflictKind) {
+      if (isUnsuffixableBranchConflict(lastBranchConflictKind)) {
+        break
+      }
       continue
     }
 

--- a/src/main/ipc/worktrees-ssh-branch-conflict-suffixing.test.ts
+++ b/src/main/ipc/worktrees-ssh-branch-conflict-suffixing.test.ts
@@ -250,6 +250,63 @@ describe('registerWorktreeHandlers', () => {
     )
   })
 
+  it('stops retrying immediately when an existing ref is a prefix of the requested branch', async () => {
+    // STA-4762: `release` blocks `release/1.0`, `release/1.0-2`, ... `release/1.0-100`.
+    // Suffixing is provably futile, and over SSH each attempt costs several remote round trips.
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/repo',
+      displayName: 'ssh',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1',
+      worktreeBaseRef: 'origin/main'
+    }
+    const provider = {
+      exec: vi.fn().mockImplementation(async (args: string[]) => {
+        if (args[0] === 'remote') {
+          return { stdout: 'origin\n', stderr: '' }
+        }
+        if (args[0] === 'for-each-ref') {
+          return args.some((arg) => arg.startsWith('refs/heads/'))
+            ? { stdout: 'refs/heads/release\n', stderr: '' }
+            : { stdout: '', stderr: '' }
+        }
+        if (args[0] === 'rev-parse') {
+          throw new Error('missing local branch')
+        }
+        return { stdout: '', stderr: '' }
+      }),
+      fetchRemoteTrackingRef: vi.fn().mockResolvedValue(undefined),
+      addWorktree: vi.fn().mockResolvedValue(undefined),
+      removeWorktree: vi.fn().mockResolvedValue(undefined),
+      listWorktrees: vi.fn().mockResolvedValue([])
+    }
+    const mux = {
+      request: vi.fn().mockResolvedValue(undefined),
+      notify: vi.fn()
+    }
+    store.getRepos.mockReturnValue([repo])
+    store.getRepo.mockReturnValue(repo)
+    getSshGitProviderMock.mockReturnValue(provider)
+    getActiveMultiplexerMock.mockReturnValue(mux)
+
+    await expect(
+      handlers['worktrees:create'](null, {
+        repoId: 'repo-ssh',
+        name: 'release-1-0',
+        branchNameOverride: 'release/1.0'
+      })
+    ).rejects.toThrow(/no suffix avoids it/)
+
+    expect(provider.addWorktree).not.toHaveBeenCalled()
+    // The loop must bail on the first candidate, not grind through all 100.
+    const refProbes = provider.exec.mock.calls.filter(
+      (call) => (call[0] as string[])[0] === 'for-each-ref'
+    )
+    expect(refProbes.length).toBeLessThan(5)
+  })
+
   it('suffixes SSH worktree creation when a nested local ref blocks the requested branch', async () => {
     // STA-4762: refs/heads/feature/tti_fix_1440 makes `feature` uncreatable; without
     // detection the SSH flow surfaced raw `cannot lock ref` text from git.

--- a/src/main/ipc/worktrees-ssh-branch-conflict-suffixing.test.ts
+++ b/src/main/ipc/worktrees-ssh-branch-conflict-suffixing.test.ts
@@ -250,6 +250,65 @@ describe('registerWorktreeHandlers', () => {
     )
   })
 
+  it('suffixes SSH worktree creation when a nested local ref blocks the requested branch', async () => {
+    // STA-4762: refs/heads/feature/tti_fix_1440 makes `feature` uncreatable; without
+    // detection the SSH flow surfaced raw `cannot lock ref` text from git.
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/repo',
+      displayName: 'ssh',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1',
+      worktreeBaseRef: 'origin/main'
+    }
+    const provider = {
+      exec: vi.fn().mockImplementation(async (args: string[]) => {
+        if (args[0] === 'remote') {
+          return { stdout: 'origin\n', stderr: '' }
+        }
+        if (args[0] === 'for-each-ref') {
+          return args.includes('refs/heads/feature')
+            ? { stdout: 'refs/heads/feature/tti_fix_1440\n', stderr: '' }
+            : { stdout: '', stderr: '' }
+        }
+        if (args[0] === 'rev-parse') {
+          throw new Error('missing local branch')
+        }
+        return { stdout: '', stderr: '' }
+      }),
+      fetchRemoteTrackingRef: vi.fn().mockResolvedValue(undefined),
+      addWorktree: vi.fn().mockResolvedValue(undefined),
+      removeWorktree: vi.fn().mockResolvedValue(undefined),
+      listWorktrees: vi.fn().mockResolvedValue([
+        {
+          path: '/remote/repo-feature-2',
+          head: 'abc123',
+          branch: 'refs/heads/feature-2',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ])
+    }
+    const mux = {
+      request: vi.fn().mockResolvedValue(undefined),
+      notify: vi.fn()
+    }
+    store.getRepos.mockReturnValue([repo])
+    store.getRepo.mockReturnValue(repo)
+    getSshGitProviderMock.mockReturnValue(provider)
+    getActiveMultiplexerMock.mockReturnValue(mux)
+
+    await handlers['worktrees:create'](null, { repoId: 'repo-ssh', name: 'feature' })
+
+    expect(provider.addWorktree).toHaveBeenCalledWith(
+      '/remote/repo',
+      'feature-2',
+      '/remote/repo-feature-2',
+      { base: 'origin/main' }
+    )
+  })
+
   it('suffixes SSH worktree creation when a slashed remote owns the requested branch', async () => {
     const repo = {
       id: 'repo-ssh',

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -991,6 +991,7 @@ import type {
   UpdateProjectItemFieldArgs,
   UpdatePullRequestBySlugArgs
 } from '../../shared/github/project-request-types'
+import { formatBranchConflictMessage, type BranchConflictKind } from '../git/branch-ref-conflict'
 import {
   getBaseRefDefault,
   getDefaultRemote,
@@ -24343,7 +24344,7 @@ export class OrcaRuntimeService {
     let branchName = ''
     let checkoutExistingBranch = false
     let selectedExistingLocalBranchName: string | null = null
-    let branchConflictKind: 'local' | 'remote' | null = null
+    let branchConflictKind: BranchConflictKind | null = null
     let worktreePath = ''
     let worktreePathResolved = false
     const shouldRetireGeneratedName =
@@ -24470,9 +24471,7 @@ export class OrcaRuntimeService {
     }
     if (!worktreePathResolved) {
       if (branchConflictKind) {
-        throw new Error(
-          `Branch "${branchName}" already exists ${branchConflictKind === 'local' ? 'locally' : 'on a remote'}.`
-        )
+        throw new Error(formatBranchConflictMessage(branchName, branchConflictKind))
       }
       throw new Error(
         `Could not find an available worktree path for "${sanitizedName}". Pick a different worktree name.`

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -991,7 +991,11 @@ import type {
   UpdateProjectItemFieldArgs,
   UpdatePullRequestBySlugArgs
 } from '../../shared/github/project-request-types'
-import { formatBranchConflictMessage, type BranchConflictKind } from '../git/branch-ref-conflict'
+import {
+  formatBranchConflictMessage,
+  isUnsuffixableBranchConflict,
+  type BranchConflictKind
+} from '../git/branch-ref-conflict'
 import {
   getBaseRefDefault,
   getDefaultRemote,
@@ -24440,6 +24444,9 @@ export class OrcaRuntimeService {
           }
         }
         if (branchConflictKind) {
+          if (isUnsuffixableBranchConflict(branchConflictKind)) {
+            break
+          }
           continue
         }
       }

--- a/src/main/runtime/selected-review-branch.ts
+++ b/src/main/runtime/selected-review-branch.ts
@@ -1,6 +1,7 @@
 import type { GitPushTarget } from '../../shared/worktree/types'
 import type { ForgeProviderId } from '../source-control/forge-provider'
 import type { getPRForBranch } from '../github/client'
+import type { BranchConflictKind } from '../git/branch-ref-conflict'
 
 export type SelectedReviewBranchInput = {
   branchNameOverride?: string
@@ -65,7 +66,7 @@ export function isMatchingSelectedGitHubPr(
 }
 
 export function isAllowedPushTargetRemoteConflict(
-  conflictKind: 'local' | 'remote' | null,
+  conflictKind: BranchConflictKind | null,
   branchName: string,
   args: SelectedReviewBranchInput
 ): boolean {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​406 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​406 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​240 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​228 |

<!-- /orca-pr-loc -->

## Summary

**STA-4746 is invalid — on current `main` and on the reported v1.4.184. This PR contains no production change**, only the regression coverage that proves it and guards the contract.

The report claimed that in a paired/remote setup a folder workspace (`ORCA_WORKTREE_ID=folder:<uuid>`) makes the relay spawn its PTY in a fallback cwd, because "relay cwd resolution only consults `ORCA_WORKTREE_ID`, parses it as `repoId::path`, and never falls back to `ORCA_WORKSPACE_ROOT`."

That is not how the relay resolves cwd. `PtyHandler.spawnAfterAdmission` takes cwd from the spawn request (`params.cwd`); `splitWorktreeId(worktreeId)` feeds only the `beginPtyCreation` admission key. The client side already resolves `folder:<uuid>` through `resolveTerminalStartupCwdForWorkspace` → `store.getFolderWorkspace(id).folderPath`.

## What actually produces the reported symptom

On every POSIX relay branch the host's **login** startup chain runs after the PTY is placed, so a remote startup file that `cd`s wins *after* the shell already started in the workspace root. Two mechanisms get there:

- zsh and other POSIX shells launch with `POSIX_LOGIN_ARGS = ['-l']` (`src/relay/pty-shell-launch.ts:12`), so `/etc/profile`, `/etc/profile.d/*` and `~/.zprofile` are sourced.
- bash is normally *wrapped* (`--rcfile`, not `-l`), but the relay's own wrapper explicitly sources `/etc/profile`, then `~/.bash_profile` / `~/.bash_login` / `~/.profile` (`src/relay/pty-shell-overlay-wrappers.ts:63-70`).

That is exactly the reporter's own evidence:

```
OLDPWD=/opt/tiger/workspace          # shell started here
PWD=/opt/tiger/rh2/rh2/init          # then cd'd away
```

`OLDPWD` is only ever set by `cd`. Phase B of the SSH spec reproduces that byte-shape by adding one `/etc/profile.d` entry to the container. Phase C shows the same `cd` moves a plain `repoId::/path` git worktree identically, so this mechanism is not folder-specific. That establishes a non-folder-specific cause for the reported signature; combined with the topology table below finding no folder-specific defect, it is why this closes as invalid.

## Evidence (all on clean `main` @ 1b5cc00870)

| Topology | Result |
|---|---|
| Headed paired desktop server + paired desktop client (primary) | folder PTY lands on host `folderPath`; filesystem marker written into `folderPath`; git-worktree + host-local controls green |
| Headless `orca serve` paired host | `terminal.create(folder:<uuid>)` → `pwd == folderPath` |
| Real Docker SSH relay (`~/.orca-remote/relay-0.1.0+…`) | shell `$PWD` **and** remote `/proc/<pid>/cwd` both == folder path |

## Version oracle

The cwd-resolution logic is behaviourally identical at `v1.4.184`: `src/shared/terminal-startup-cwd.ts` and `src/shared/workspace-scope.ts` differ only by import-path moves (`shared/worktree-id` → `shared/worktree/id`, `shared/types` → `shared/folder-workspace-types`), and `src/relay/pty-handler.ts` still takes cwd from `params.cwd`. Those files carry unrelated changes since the tag — the equivalence claim is about the cwd path, not the whole diff. v1.4.184 also did not send `worktreeId` as a spawn param at all (added later in `ssh-pty-spawn-request.ts` for shell-history isolation), so the relay could not have derived cwd from it there either. Nothing was "already fixed".

Separately, on node-pty's POSIX implementation a nonexistent cwd makes the child exit 1 rather than silently inheriting the parent's cwd (`node_modules/node-pty/src/unix/pty.cc`), ruling out the "fell back to the container's CMD directory" mechanism as well. Windows uses a different spawn path and was not measured.

## Why the proposed fix is not implemented

The proposed `ORCA_WORKSPACE_ROOT` fallback would change nothing for the reporter — cwd is already correct at spawn — and it would make the relay adopt an unvalidated client-supplied path for a request that named no working directory.

`cwd` is optional on the wire (`PtySpawnOptions.cwd`, `src/main/providers/pty-provider-contract.ts:42`), and the relay's default-cwd branch exists for requests that genuinely name none. But every relay-bound caller for a folder workspace resolves a path first via `resolveTerminalStartupCwdForWorkspace`; the one in-repo caller that can omit `cwd` (`codex-detached-pane-restart.ts:210`) is local-only and never reaches the relay. So the fallback has no relay caller to serve, and promoting an env var into it would only widen what the relay trusts.

## Coverage added

- `src/relay/pty-handler-folder-workspace-cwd.test.ts` — 5 deterministic cases: folder id honours request cwd, folder id with **no** `ORCA_WORKSPACE_ROOT`, worktree-id precedence unchanged, **legacy/mixed-version client** (env-only `ORCA_WORKTREE_ID`), and the default-cwd fallback pinned to *not* adopt `ORCA_WORKSPACE_ROOT`.
- `tests/e2e/sta4746-folder-remote-cwd.spec.ts` — headless paired `orca serve` host.
- `tests/e2e/sta4746-paired-desktop-folder-cwd.spec.ts` — headed paired desktop server + client (`@headful`), with git-worktree and local-only controls.
- `tests/e2e/sta4746-ssh-folder-cwd.spec.ts` — real Docker SSH relay, 3 phases (clean / login-profile cd / git-worktree control), gated on `ORCA_E2E_SSH_DOCKER=1` like the sibling docker specs.

**Guard is non-vacuous:** injecting the alleged id-derived cwd into `pty-handler.ts` turns 4 of the 5 relay cases red; reverting the injection returns 5/5 green.

## Commands

```
npx vitest run --config config/vitest.config.ts src/relay/pty-handler-folder-workspace-cwd.test.ts
npx playwright test tests/e2e/sta4746-folder-remote-cwd.spec.ts --config tests/playwright.config.ts --project electron-headless
npx playwright test tests/e2e/sta4746-paired-desktop-folder-cwd.spec.ts --config tests/playwright.config.ts --project electron-headful
ORCA_E2E_SSH_DOCKER=1 npx playwright test tests/e2e/sta4746-ssh-folder-cwd.spec.ts --config tests/playwright.config.ts --project electron-headless
```

## Gaps

CI runs all three specs on Linux runners (the changed-e2e job picked them up and all 3 passed), and the SSH phases were additionally exercised against a Linux container from a macOS host. Windows and WSL hosts were not exercised.

Closes STA-4746 as invalid.

