### PR TITLE
fix(worktrees): honor absolute Linux worktree base paths for WSL repos (STA-4772)

### DIFF
--- a/src/main/ipc/worktree-logic-wsl.test.ts
+++ b/src/main/ipc/worktree-logic-wsl.test.ts
@@ -1,21 +1,28 @@
 import { win32 } from 'node:path'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { getWslHomeMock, parseWslPathMock } = vi.hoisted(() => ({
+const { getWslHomeMock, getWslHomeAsyncMock, parseWslPathMock } = vi.hoisted(() => ({
   getWslHomeMock: vi.fn(),
+  getWslHomeAsyncMock: vi.fn(),
   parseWslPathMock: vi.fn()
 }))
 
 vi.mock('../wsl', () => ({
   getWslHome: getWslHomeMock,
+  getWslHomeAsync: getWslHomeAsyncMock,
   parseWslPath: parseWslPathMock
 }))
 
-import { computeWorktreePath, getWorktreePathSettings } from './worktree-logic'
+import {
+  computeWorktreePath,
+  computeWorktreePathAsync,
+  getWorktreePathSettings
+} from './worktree-logic'
 
 describe('computeWorktreePath WSL layout', () => {
   beforeEach(() => {
     getWslHomeMock.mockReset()
+    getWslHomeAsyncMock.mockReset()
     parseWslPathMock.mockReset()
   })
 
@@ -69,6 +76,47 @@ describe('computeWorktreePath WSL layout', () => {
       '\\\\wsl.localhost\\Ubuntu\\home\\jin\\src\\.orca-worktrees\\feature'
     )
     expect(getWslHomeMock).not.toHaveBeenCalled()
+  })
+
+  it('honors a drvfs /mnt repo base path instead of mirroring it away', () => {
+    parseWslPathMock.mockReturnValue({
+      distro: 'Ubuntu',
+      linuxPath: '/home/jin/src/repo'
+    })
+    getWslHomeMock.mockReturnValue('\\\\wsl.localhost\\Ubuntu\\home\\jin')
+    const repo = {
+      path: '\\\\wsl.localhost\\Ubuntu\\home\\jin\\src\\repo',
+      worktreeBasePath: '/mnt/d/trees'
+    }
+
+    expect(
+      computeWorktreePath(
+        'feature',
+        repo.path,
+        getWorktreePathSettings(repo, { nestWorkspaces: false, workspaceDir: 'C:\\workspaces' })
+      )
+    ).toBe('\\\\wsl.localhost\\Ubuntu\\mnt\\d\\trees\\feature')
+  })
+
+  it('resolves the Linux repo base path identically through the async twin', async () => {
+    parseWslPathMock.mockReturnValue({
+      distro: 'Ubuntu',
+      linuxPath: '/home/jin/src/repo'
+    })
+    getWslHomeMock.mockReturnValue('\\\\wsl.localhost\\Ubuntu\\home\\jin')
+    getWslHomeAsyncMock.mockResolvedValue('\\\\wsl.localhost\\Ubuntu\\home\\jin')
+    const repo = {
+      path: '\\\\wsl.localhost\\Ubuntu\\home\\jin\\src\\repo',
+      worktreeBasePath: '/home/jin/src/.orca-worktrees'
+    }
+    const pathSettings = getWorktreePathSettings(repo, {
+      nestWorkspaces: false,
+      workspaceDir: 'C:\\workspaces'
+    })
+
+    await expect(computeWorktreePathAsync('feature', repo.path, pathSettings)).resolves.toBe(
+      computeWorktreePath('feature', repo.path, pathSettings)
+    )
   })
 
   it('honors a Linux repo base path even when the distro home lookup fails', () => {

--- a/src/main/ipc/worktree-logic-wsl.test.ts
+++ b/src/main/ipc/worktree-logic-wsl.test.ts
@@ -98,6 +98,47 @@ describe('computeWorktreePath WSL layout', () => {
     ).toBe('\\\\wsl.localhost\\Ubuntu\\mnt\\d\\trees\\feature')
   })
 
+  it('collapses dotted Linux repo base paths end to end', () => {
+    parseWslPathMock.mockReturnValue({
+      distro: 'Ubuntu',
+      linuxPath: '/home/jin/src/repo'
+    })
+    getWslHomeMock.mockReturnValue('\\\\wsl.localhost\\Ubuntu\\home\\jin')
+    const repo = {
+      path: '\\\\wsl.localhost\\Ubuntu\\home\\jin\\src\\repo',
+      worktreeBasePath: '/home/jin/src/../trees'
+    }
+
+    expect(
+      computeWorktreePath(
+        'feature',
+        repo.path,
+        getWorktreePathSettings(repo, { nestWorkspaces: false, workspaceDir: 'C:\\workspaces' })
+      )
+    ).toBe('\\\\wsl.localhost\\Ubuntu\\home\\jin\\trees\\feature')
+  })
+
+  it('still mirrors drive-letter repo base paths into the distro home', () => {
+    parseWslPathMock.mockReturnValue({
+      distro: 'Ubuntu',
+      linuxPath: '/home/jin/src/repo'
+    })
+    getWslHomeMock.mockReturnValue('\\\\wsl.localhost\\Ubuntu\\home\\jin')
+    const repo = {
+      path: '\\\\wsl.localhost\\Ubuntu\\home\\jin\\src\\repo',
+      worktreeBasePath: 'D:\\trees'
+    }
+
+    // Why: desktop drive roots keep WSL worktrees on the WSL filesystem by design.
+    expect(
+      computeWorktreePath(
+        'feature',
+        repo.path,
+        getWorktreePathSettings(repo, { nestWorkspaces: false, workspaceDir: 'C:\\workspaces' })
+      )
+    ).toBe('\\\\wsl.localhost\\Ubuntu\\home\\jin\\orca\\workspaces\\feature')
+  })
+
   it('resolves the Linux repo base path identically through the async twin', async () => {
     parseWslPathMock.mockReturnValue({
       distro: 'Ubuntu',

--- a/src/main/ipc/worktree-logic-wsl.test.ts
+++ b/src/main/ipc/worktree-logic-wsl.test.ts
@@ -22,6 +22,7 @@ import {
   buildKnownOrcaWorkspaceLayouts,
   classifyWorktreeOwnership
 } from '../../shared/worktree/ownership'
+import { relativePathInsideRoot } from '../../shared/cross-platform-path'
 import type { Repo } from '../../shared/repo-types'
 
 describe('computeWorktreePath WSL layout', () => {
@@ -168,15 +169,17 @@ describe('computeWorktreePath WSL layout', () => {
         repo.path,
         getWorktreePathSettings(repo, settings)
       )
+      const layouts = buildKnownOrcaWorkspaceLayouts({ ...settings, workspaceDirHistory: [] }, repo)
+      // Why containment, not just ownership: a regressed resolver lands in the
+      // ~/orca/workspaces mirror layout, which also classifies 'external'.
+      // layouts[0] is the repo-base layout — it is always pushed first.
+      expect(relativePathInsideRoot(layouts[0].path, createdPath)).not.toBeNull()
       expect(
         classifyWorktreeOwnership({
           repo,
           settings: { ...settings, workspaceDirHistory: [] },
           worktree: { path: createdPath, isMainWorktree: false },
-          knownOrcaLayouts: buildKnownOrcaWorkspaceLayouts(
-            { ...settings, workspaceDirHistory: [] },
-            repo
-          )
+          knownOrcaLayouts: layouts
         })
       ).toBe('external')
     }

--- a/src/main/ipc/worktree-logic-wsl.test.ts
+++ b/src/main/ipc/worktree-logic-wsl.test.ts
@@ -11,7 +11,7 @@ vi.mock('../wsl', () => ({
   parseWslPath: parseWslPathMock
 }))
 
-import { computeWorktreePath } from './worktree-logic'
+import { computeWorktreePath, getWorktreePathSettings } from './worktree-logic'
 
 describe('computeWorktreePath WSL layout', () => {
   beforeEach(() => {
@@ -47,6 +47,68 @@ describe('computeWorktreePath WSL layout', () => {
         workspaceDir: 'C:\\workspaces'
       })
     ).toBe(win32.join('C:\\workspaces', 'feature'))
+  })
+
+  it('honors an absolute Linux repo worktree base path inside the repo distro (STA-4772)', () => {
+    parseWslPathMock.mockReturnValue({
+      distro: 'Ubuntu',
+      linuxPath: '/home/jin/src/repo'
+    })
+    getWslHomeMock.mockReturnValue('\\\\wsl.localhost\\Ubuntu\\home\\jin')
+    const repo = {
+      path: '\\\\wsl.localhost\\Ubuntu\\home\\jin\\src\\repo',
+      worktreeBasePath: '/home/jin/src/.orca-worktrees'
+    }
+    const settings = { nestWorkspaces: false, workspaceDir: 'C:\\workspaces' }
+
+    expect(computeWorktreePath('feature', repo.path, getWorktreePathSettings(repo, settings))).toBe(
+      '\\\\wsl.localhost\\Ubuntu\\home\\jin\\src\\.orca-worktrees\\feature'
+    )
+    // Why repeat: cached follow-up calls must resolve identically to the first.
+    expect(computeWorktreePath('feature', repo.path, getWorktreePathSettings(repo, settings))).toBe(
+      '\\\\wsl.localhost\\Ubuntu\\home\\jin\\src\\.orca-worktrees\\feature'
+    )
+    expect(getWslHomeMock).not.toHaveBeenCalled()
+  })
+
+  it('honors a Linux repo base path even when the distro home lookup fails', () => {
+    parseWslPathMock.mockReturnValue({
+      distro: 'Ubuntu',
+      linuxPath: '/home/jin/src/repo'
+    })
+    getWslHomeMock.mockReturnValue(null)
+    const repo = {
+      path: '\\\\wsl.localhost\\Ubuntu\\home\\jin\\src\\repo',
+      worktreeBasePath: '/home/jin/trees'
+    }
+
+    expect(
+      computeWorktreePath(
+        'feature',
+        repo.path,
+        getWorktreePathSettings(repo, { nestWorkspaces: false, workspaceDir: 'C:\\workspaces' })
+      )
+    ).toBe('\\\\wsl.localhost\\Ubuntu\\home\\jin\\trees\\feature')
+  })
+
+  it('keeps relative repo base paths anchored to the WSL repo', () => {
+    parseWslPathMock.mockReturnValue({
+      distro: 'Ubuntu',
+      linuxPath: '/home/jin/src/repo'
+    })
+    getWslHomeMock.mockReturnValue('\\\\wsl.localhost\\Ubuntu\\home\\jin')
+    const repo = {
+      path: '\\\\wsl.localhost\\Ubuntu\\home\\jin\\src\\repo',
+      worktreeBasePath: '../worktrees'
+    }
+
+    expect(
+      computeWorktreePath(
+        'feature',
+        repo.path,
+        getWorktreePathSettings(repo, { nestWorkspaces: false, workspaceDir: 'C:\\workspaces' })
+      )
+    ).toBe('\\\\wsl.localhost\\Ubuntu\\home\\jin\\src\\worktrees\\feature')
   })
 
   it('uses an explicit WSL UNC workspace root without remapping it', () => {

--- a/src/main/ipc/worktree-logic-wsl.test.ts
+++ b/src/main/ipc/worktree-logic-wsl.test.ts
@@ -18,6 +18,11 @@ import {
   computeWorktreePathAsync,
   getWorktreePathSettings
 } from './worktree-logic'
+import {
+  buildKnownOrcaWorkspaceLayouts,
+  classifyWorktreeOwnership
+} from '../../shared/worktree/ownership'
+import type { Repo } from '../../shared/repo-types'
 
 describe('computeWorktreePath WSL layout', () => {
   beforeEach(() => {
@@ -137,6 +142,44 @@ describe('computeWorktreePath WSL layout', () => {
         getWorktreePathSettings(repo, { nestWorkspaces: false, workspaceDir: 'C:\\workspaces' })
       )
     ).toBe('\\\\wsl.localhost\\Ubuntu\\home\\jin\\orca\\workspaces\\feature')
+  })
+
+  it('classifies whatever creation produces for Linux bases, dotted or not', () => {
+    parseWslPathMock.mockReturnValue({
+      distro: 'Ubuntu',
+      linuxPath: '/home/jin/src/repo'
+    })
+    getWslHomeMock.mockReturnValue('\\\\wsl.localhost\\Ubuntu\\home\\jin')
+    const settings = { nestWorkspaces: true, workspaceDir: 'C:\\workspaces' }
+    for (const worktreeBasePath of ['/home/jin/trees', '/home/jin/src/../trees', '/mnt/d/trees']) {
+      const repo = {
+        id: 'r1',
+        path: '\\\\wsl.localhost\\Ubuntu\\home\\jin\\src\\repo',
+        displayName: 'repo',
+        badgeColor: '#000',
+        addedAt: 0,
+        kind: 'git',
+        worktreeBasePath
+      } as Repo
+      // Why: the resolver exists so these two layers agree; assert the
+      // invariant directly instead of two hardcoded strings that happen to match.
+      const createdPath = computeWorktreePath(
+        'feature',
+        repo.path,
+        getWorktreePathSettings(repo, settings)
+      )
+      expect(
+        classifyWorktreeOwnership({
+          repo,
+          settings: { ...settings, workspaceDirHistory: [] },
+          worktree: { path: createdPath, isMainWorktree: false },
+          knownOrcaLayouts: buildKnownOrcaWorkspaceLayouts(
+            { ...settings, workspaceDirHistory: [] },
+            repo
+          )
+        })
+      ).toBe('external')
+    }
   })
 
   it('resolves the Linux repo base path identically through the async twin', async () => {

--- a/src/main/ipc/worktree-logic.ts
+++ b/src/main/ipc/worktree-logic.ts
@@ -2,7 +2,7 @@ import { resolve, relative, isAbsolute, posix, sep, win32 } from 'node:path'
 import type { GlobalSettings, OrcaWorkspaceLayout } from '../../shared/global-settings-types'
 import type { Repo } from '../../shared/repo-types'
 import { isWindowsAbsolutePathLike, resolveRuntimePath } from '../../shared/cross-platform-path'
-import { isWslUncPath } from '../../shared/wsl-paths'
+import { isWslUncPath, resolveWslRepoWorktreeBasePath } from '../../shared/wsl-paths'
 import { splitWorktreeId } from '../../shared/worktree/id'
 import { replaceKnownEmojiWithShortcodes } from '../../shared/emoji-shortcode-catalog'
 import { getWslHome, getWslHomeAsync, parseWslPath } from '../wsl'
@@ -226,7 +226,11 @@ function getEffectiveWorktreeBasePath(
   repo: WorktreeBasePathRepo,
   settings: WorktreePathSettings
 ): string {
-  return getRepoWorktreeBasePath(repo) ?? settings.workspaceDir
+  const basePath = getRepoWorktreeBasePath(repo)
+  if (basePath === undefined) {
+    return settings.workspaceDir
+  }
+  return resolveWslRepoWorktreeBasePath(repo.path, basePath)
 }
 
 function getRepoWorktreeBasePath(repo: Pick<Repo, 'worktreeBasePath'>): string | undefined {

--- a/src/shared/worktree/ownership-worktree-base-path.test.ts
+++ b/src/shared/worktree/ownership-worktree-base-path.test.ts
@@ -102,6 +102,30 @@ describe('repo-specific worktree ownership layouts', () => {
     ).toBe('external')
   })
 
+  it('classifies worktrees under a dotted Linux base exactly where creation collapses it', () => {
+    const repo = makeRepo({
+      path: '\\\\wsl.localhost\\Ubuntu-24.04\\home\\jin\\src\\repo',
+      worktreeBasePath: '/home/jin/src/../.orca-worktrees'
+    })
+    const settings = makeSettings({ workspaceDir: 'C:\\global' })
+    const layouts = buildKnownOrcaWorkspaceLayouts(settings, repo)
+
+    expect(layouts[0]).toEqual({
+      path: '//wsl.localhost/Ubuntu-24.04/home/jin/.orca-worktrees',
+      nestWorkspaces: true
+    })
+    expect(
+      classifyWorktreeOwnership({
+        repo,
+        settings,
+        worktree: makeWorktree(
+          '\\\\wsl.localhost\\Ubuntu-24.04\\home\\jin\\.orca-worktrees\\repo\\feature'
+        ),
+        knownOrcaLayouts: layouts
+      })
+    ).toBe('external')
+  })
+
   it('includes relative global layouts for SSH repos without applying absolute desktop paths', () => {
     const repo = makeRepo({ path: '/remote/repo', connectionId: 'ssh-1' })
     const relativeSettings = makeSettings({ workspaceDir: '../worktrees' })

--- a/src/shared/worktree/ownership-worktree-base-path.test.ts
+++ b/src/shared/worktree/ownership-worktree-base-path.test.ts
@@ -78,6 +78,30 @@ describe('repo-specific worktree ownership layouts', () => {
     ).toBe('external')
   })
 
+  it('resolves an absolute Linux base path of a WSL repo into its distro layout (STA-4772)', () => {
+    const repo = makeRepo({
+      path: '\\\\wsl.localhost\\Ubuntu-24.04\\home\\jin\\src\\repo',
+      worktreeBasePath: '/home/jin/src/.orca-worktrees'
+    })
+    const settings = makeSettings({ workspaceDir: 'C:\\global' })
+    const layouts = buildKnownOrcaWorkspaceLayouts(settings, repo)
+
+    expect(layouts[0]).toEqual({
+      path: '//wsl.localhost/Ubuntu-24.04/home/jin/src/.orca-worktrees',
+      nestWorkspaces: true
+    })
+    expect(
+      classifyWorktreeOwnership({
+        repo,
+        settings,
+        worktree: makeWorktree(
+          '\\\\wsl.localhost\\Ubuntu-24.04\\home\\jin\\src\\.orca-worktrees\\repo\\feature'
+        ),
+        knownOrcaLayouts: layouts
+      })
+    ).toBe('external')
+  })
+
   it('includes relative global layouts for SSH repos without applying absolute desktop paths', () => {
     const repo = makeRepo({ path: '/remote/repo', connectionId: 'ssh-1' })
     const relativeSettings = makeSettings({ workspaceDir: '../worktrees' })

--- a/src/shared/worktree/ownership.ts
+++ b/src/shared/worktree/ownership.ts
@@ -6,7 +6,7 @@ import {
   relativePathInsideRoot,
   resolveRuntimePath
 } from '../cross-platform-path'
-import { parseWslUncPath } from '../wsl-paths'
+import { parseWslUncPath, resolveWslRepoWorktreeBasePath } from '../wsl-paths'
 import {
   isAgentScratchWorktreePath,
   type AgentScratchWorktreePathMatcher
@@ -87,10 +87,15 @@ function appendWorkspaceLayouts(
 }
 
 function getRepoWorktreeBasePath(
-  repo: Pick<Repo, 'worktreeBasePath'> | undefined
+  repo: Pick<Repo, 'path' | 'worktreeBasePath'> | undefined
 ): string | undefined {
   const trimmed = repo?.worktreeBasePath?.trim()
-  return trimmed || undefined
+  if (!repo || !trimmed) {
+    return undefined
+  }
+  // Why: creation resolves Linux base paths of WSL repos to their UNC form,
+  // so ownership layouts must match or those worktrees would never classify.
+  return resolveWslRepoWorktreeBasePath(repo.path, trimmed)
 }
 
 function resolveWorkspaceLayoutPath(repoPath: string, layoutPath: string): string {

--- a/src/shared/wsl-paths.test.ts
+++ b/src/shared/wsl-paths.test.ts
@@ -3,6 +3,7 @@ import {
   foldWslUncPathCaseInsensitiveParts,
   isWslUncPath,
   parseWslUncPath,
+  resolveWslRepoWorktreeBasePath,
   toWindowsWslPath
 } from './wsl-paths'
 
@@ -31,6 +32,42 @@ describe('wsl path helpers', () => {
     ['/mnt/C/Repo', '\\\\wsl.localhost\\Ubuntu\\mnt\\C\\Repo']
   ])('converts %s without folding case-sensitive Linux paths', (linuxPath, expected) => {
     expect(toWindowsWslPath(linuxPath, 'Ubuntu')).toBe(expected)
+  })
+})
+
+describe('resolveWslRepoWorktreeBasePath', () => {
+  const WSL_REPO = '\\\\wsl.localhost\\Ubuntu-24.04\\home\\jin\\src\\repo'
+
+  it('resolves an absolute Linux base path into the repo distro (STA-4772)', () => {
+    expect(resolveWslRepoWorktreeBasePath(WSL_REPO, '/home/jin/project/.orca-worktrees')).toBe(
+      '\\\\wsl.localhost\\Ubuntu-24.04\\home\\jin\\project\\.orca-worktrees'
+    )
+    expect(resolveWslRepoWorktreeBasePath('\\\\wsl$\\Debian\\srv\\repo', '/srv/trees')).toBe(
+      '\\\\wsl.localhost\\Debian\\srv\\trees'
+    )
+  })
+
+  it('maps drvfs base paths to their drive form', () => {
+    expect(resolveWslRepoWorktreeBasePath(WSL_REPO, '/mnt/d/trees')).toBe('D:\\trees')
+  })
+
+  it('keeps UNC, drive, and relative base paths untouched for WSL repos', () => {
+    expect(
+      resolveWslRepoWorktreeBasePath(WSL_REPO, '\\\\wsl.localhost\\Ubuntu-24.04\\home\\jin\\trees')
+    ).toBe('\\\\wsl.localhost\\Ubuntu-24.04\\home\\jin\\trees')
+    expect(resolveWslRepoWorktreeBasePath(WSL_REPO, '//wsl.localhost/Ubuntu-24.04/trees')).toBe(
+      '//wsl.localhost/Ubuntu-24.04/trees'
+    )
+    expect(resolveWslRepoWorktreeBasePath(WSL_REPO, 'D:\\trees')).toBe('D:\\trees')
+    expect(resolveWslRepoWorktreeBasePath(WSL_REPO, '../worktrees')).toBe('../worktrees')
+  })
+
+  it('never rewrites base paths of non-WSL repos', () => {
+    expect(resolveWslRepoWorktreeBasePath('C:\\src\\repo', '/home/jin/trees')).toBe(
+      '/home/jin/trees'
+    )
+    expect(resolveWslRepoWorktreeBasePath('/srv/repo', '/srv/trees')).toBe('/srv/trees')
+    expect(resolveWslRepoWorktreeBasePath('//server/share/repo', '/srv/trees')).toBe('/srv/trees')
   })
 })
 

--- a/src/shared/wsl-paths.test.ts
+++ b/src/shared/wsl-paths.test.ts
@@ -47,8 +47,22 @@ describe('resolveWslRepoWorktreeBasePath', () => {
     )
   })
 
-  it('maps drvfs base paths to their drive form', () => {
-    expect(resolveWslRepoWorktreeBasePath(WSL_REPO, '/mnt/d/trees')).toBe('D:\\trees')
+  it('keeps drvfs base paths on the distro UNC view so mirroring cannot discard them', () => {
+    expect(resolveWslRepoWorktreeBasePath(WSL_REPO, '/mnt/d/trees')).toBe(
+      '\\\\wsl.localhost\\Ubuntu-24.04\\mnt\\d\\trees'
+    )
+  })
+
+  it('collapses dot segments and trailing slashes so ownership layouts match creation', () => {
+    expect(resolveWslRepoWorktreeBasePath(WSL_REPO, '/home/jin/src/../trees')).toBe(
+      '\\\\wsl.localhost\\Ubuntu-24.04\\home\\jin\\trees'
+    )
+    expect(resolveWslRepoWorktreeBasePath(WSL_REPO, '/home/jin/./trees/')).toBe(
+      '\\\\wsl.localhost\\Ubuntu-24.04\\home\\jin\\trees'
+    )
+    expect(resolveWslRepoWorktreeBasePath(WSL_REPO, '/../..')).toBe(
+      '\\\\wsl.localhost\\Ubuntu-24.04\\'
+    )
   })
 
   it('keeps UNC, drive, and relative base paths untouched for WSL repos', () => {

--- a/src/shared/wsl-paths.ts
+++ b/src/shared/wsl-paths.ts
@@ -72,7 +72,11 @@ export function toWindowsWslPath(linuxPath: string, distro: string): string {
  *
  * Why not toWindowsWslPath: its /mnt/<drive> branch emits a drive-letter path,
  * which the workspace-mirroring heuristic reads as desktop-local and discards —
- * the very bug this resolves. drvfs bases stay on the distro UNC view instead.
+ * the very bug this resolves. drvfs bases stay on the distro UNC view instead,
+ * deliberately trading Windows-side throughput for a distro-addressable path
+ * that keeps terminals inside WSL. The single-leading-slash guard is also
+ * deliberate: multi-slash (//x) and backslash-rooted spellings are ambiguous
+ * with Windows UNC and drive-relative forms and keep their old behavior.
  * Dot segments collapse here because ownership layouts compare paths without
  * resolving them, so creation and classification must see the same spelling.
  */

--- a/src/shared/wsl-paths.ts
+++ b/src/shared/wsl-paths.ts
@@ -58,6 +58,26 @@ export function toWindowsWslPath(linuxPath: string, distro: string): string {
   return `\\\\wsl.localhost\\${distro}${linuxPath.replace(/\//g, '\\')}`
 }
 
+/**
+ * Resolve a repo-scoped worktree base path against the repo's own WSL distro.
+ *
+ * Why: project setup stores the value verbatim, and for a WSL-backed repo an
+ * absolute Linux path like /home/user/trees is the natural spelling of a
+ * location inside that distro. Windows path code reads it as drive-relative,
+ * so the WSL workspace-mirroring heuristic silently replaced it with
+ * ~/orca/workspaces (STA-4772). The repo path pins the distro, making the
+ * value unambiguous — translate it to its UNC form. Non-WSL repos and
+ * non-POSIX values (UNC, drive, relative) pass through untouched, so native
+ * Windows, macOS/Linux, and SSH base paths keep their meaning.
+ */
+export function resolveWslRepoWorktreeBasePath(repoPath: string, basePath: string): string {
+  const repoWsl = parseWslUncPath(repoPath)
+  if (!repoWsl || !/^\/(?!\/)/.test(basePath)) {
+    return basePath
+  }
+  return toWindowsWslPath(basePath, repoWsl.distro)
+}
+
 // Why: Windows folds the share (\\wsl$ aliases \\wsl.localhost), the distro, and
 // drvfs /mnt/<drive> tails case-insensitively; the rest of the Linux path is not.
 export function foldWslUncPathCaseInsensitiveParts(path: string): string | null {

--- a/src/shared/wsl-paths.ts
+++ b/src/shared/wsl-paths.ts
@@ -69,13 +69,35 @@ export function toWindowsWslPath(linuxPath: string, distro: string): string {
  * value unambiguous — translate it to its UNC form. Non-WSL repos and
  * non-POSIX values (UNC, drive, relative) pass through untouched, so native
  * Windows, macOS/Linux, and SSH base paths keep their meaning.
+ *
+ * Why not toWindowsWslPath: its /mnt/<drive> branch emits a drive-letter path,
+ * which the workspace-mirroring heuristic reads as desktop-local and discards —
+ * the very bug this resolves. drvfs bases stay on the distro UNC view instead.
+ * Dot segments collapse here because ownership layouts compare paths without
+ * resolving them, so creation and classification must see the same spelling.
  */
 export function resolveWslRepoWorktreeBasePath(repoPath: string, basePath: string): string {
   const repoWsl = parseWslUncPath(repoPath)
   if (!repoWsl || !/^\/(?!\/)/.test(basePath)) {
     return basePath
   }
-  return toWindowsWslPath(basePath, repoWsl.distro)
+  const collapsed = collapsePosixDotSegments(basePath)
+  return `\\\\wsl.localhost\\${repoWsl.distro}${collapsed === '/' ? '\\' : collapsed.replace(/\//g, '\\')}`
+}
+
+function collapsePosixDotSegments(absolutePosixPath: string): string {
+  const segments: string[] = []
+  for (const segment of absolutePosixPath.split('/')) {
+    if (!segment || segment === '.') {
+      continue
+    }
+    if (segment === '..') {
+      segments.pop()
+      continue
+    }
+    segments.push(segment)
+  }
+  return `/${segments.join('/')}`
 }
 
 // Why: Windows folds the share (\\wsl$ aliases \\wsl.localhost), the distro, and


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​298 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​296 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​60 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​55 |

<!-- /orca-pr-loc -->

## Summary

Fixes STA-4772: for a WSL-backed repository, a project-setup worktree base path written as an absolute Linux path (e.g. `/home/user/project/.orca-worktrees`) was accepted and reported ready, but worktree create silently ignored it and fell back to the default `~/orca/workspaces` mirror inside the distro. The equivalent `\\wsl.localhost\<distro>\...` UNC value worked.

### Root cause

`getWorktreePathSettings` merges the repo-level `worktreeBasePath` into `workspaceDir` before `computeWorkspaceRoot` runs. For a WSL repo, `shouldMirrorWorkspaceDirInsideWsl` treats any non-UNC "absolute" value as a desktop-local root that must be mirrored into `~/orca/workspaces` — and `win32.isAbsolute('/home/…')` is true, so an absolute Linux path was classified as a desktop root and silently discarded. No warning is surfaced anywhere on this path.

### Fix (create-time normalization)

New shared helper `resolveWslRepoWorktreeBasePath(repoPath, basePath)` in `src/shared/wsl-paths.ts`: when (and only when) the repo itself lives on a WSL UNC path and the configured base path is POSIX-absolute (single leading `/`), translate the base path onto that repo's distro UNC view (`\\wsl.localhost\<distro>\<path>`), collapsing dot segments. `/mnt/<drive>` bases deliberately stay on the distro UNC view rather than being remapped to a drive letter — a drive-letter result would re-trigger the desktop-mirroring heuristic that discards the base (found in review). Applied at the two resolution boundaries:

- `src/main/ipc/worktree-logic.ts` `getEffectiveWorktreeBasePath` — covers worktree create (local + remote), base-directory watch targets, trash sweep roots, name retirement, filesystem allowed roots, root preparation, and folder rename.
- `src/shared/worktree/ownership.ts` `getRepoWorktreeBasePath` — keeps `buildKnownOrcaWorkspaceLayouts` consistent with where creation actually places worktrees, so ownership classification matches.

Create-time (resolution-time) was chosen over save-time as the authoritative boundary because it also repairs already-persisted values, values arriving over the wire from older clients, and keeps the stored setting verbatim as the user typed it (no schema or wire change; the host that executes creation interprets the value).

Deliberately untouched:
- Native Windows repos (`C:\…`), macOS/Linux repos, and SSH repos never rewrite: normalization requires the repo path itself to be a WSL UNC path.
- UNC, drive-letter, `//`-rooted, and relative base values pass through unchanged.
- The global `workspaceDir` setting is not reinterpreted — only the repo-scoped base path, where the repo pins the distro and makes the value unambiguous.

## Reproduction evidence (real WSL, Windows 2, Ubuntu-24.04)

Product-level (installed Orca app, disposable repo via orca-cli):
1. `repo add` for `\\wsl.localhost\Ubuntu-24.04\home\neil\sta4772-repro\repo`, then `project setup-update --worktree-base-path /home/neil/sta4772-repro/.orca-worktrees` → stored verbatim, `setupState: ready`, no warning.
2. `worktree create` → created at `\\wsl.localhost\Ubuntu-24.04\home\neil\orca\workspaces\repo\linux-base-probe`, `warnings: []` — configured base silently ignored. **Bug confirmed.**
3. Same with the UNC base value → created at `…\sta4772-repro\.orca-worktrees\repo\unc-base-probe`. **UNC control honored.**

Source-level oracle (uncommitted scratch vitest against real `wsl.exe`, incl. a real `git worktree add` through the resolved path):
- baseline `1b5cc00870` (latest main): linux-base cases FAIL (resolve to `~/orca/workspaces`), UNC/native/POSIX/default PASS
- with this change: all 5 PASS (real git worktree created inside the configured Linux base)
- with this change reverted: identical baseline failures return

## Tests

- `src/shared/wsl-paths.test.ts` — unit coverage: Linux path → distro UNC (incl. legacy `\\wsl$` repos), `/mnt/<drive>` mapping, UNC/drive/relative passthrough, non-WSL repo passthrough (native Windows, POSIX, `//server/share`).
- `src/main/ipc/worktree-logic-wsl.test.ts` — create-path coverage: Linux base honored through `getWorktreePathSettings`, repeated calls stable, no dependence on the distro home lookup (first-fallback: `getWslHome` returning null no longer matters for configured bases), relative bases still anchored to the repo.
- `src/shared/worktree/ownership-worktree-base-path.test.ts` — ownership layout for a WSL repo with a Linux base path matches created worktree paths.

## Validation

- `pnpm run typecheck` clean; oxlint clean on changed files.
- Targeted vitest suites (wsl-paths, worktree-logic, ownership, trash, root-preparation, watch targets, retirement, allowed roots, local create flow, persistence/IPC setup): pass. `worktree-base-directory-watcher.test.ts` fails identically on unmodified main (pre-existing Windows failure).
- Native Windows golden E2E (`test:e2e:workspace-session-golden`): candidate and unmodified-baseline runs produce identical results on this machine (1 pass; the same two specs fail on both, worktree-create-switch with the harness error "seeded e2e worktrees did not load" — a pre-existing fixture seeding issue unrelated to this change, which only alters behavior when the repo path is a WSL UNC path and a POSIX-absolute repo base path is configured).

Linear: STA-4772.
