### PR TITLE
test(relay): pin folder-workspace PTY cwd across paired and SSH topologies (STA-4746)

### DIFF
--- a/src/relay/pty-handler-folder-workspace-cwd.test.ts
+++ b/src/relay/pty-handler-folder-workspace-cwd.test.ts
@@ -39,7 +39,8 @@ const WORKTREE_ID = 'repo-1::/srv/repo'
 // Why (STA-4746): the report claimed the relay derives a PTY's cwd by splitting
 // ORCA_WORKTREE_ID on `::`, so a `folder:<uuid>` workspace fell back to $HOME.
 // The relay has always taken cwd from the request instead; these pin that
-// contract so a future refactor cannot introduce the reported bug.
+// contract so a future refactor cannot introduce the reported bug. Production
+// request construction is covered end to end by tests/e2e/sta4746-*.spec.ts.
 describe('relay PTY spawn cwd for folder workspaces', () => {
   let dispatcher: MockDispatcher
   let handler: PtyHandler

--- a/src/relay/pty-handler-folder-workspace-cwd.test.ts
+++ b/src/relay/pty-handler-folder-workspace-cwd.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+
+const { mockPtySpawn, mockPtyInstance, mockCreateShellPromptReadinessProbe } = vi.hoisted(() => ({
+  mockPtySpawn: vi.fn(),
+  mockCreateShellPromptReadinessProbe: vi.fn(),
+  mockPtyInstance: {
+    pid: process.pid,
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(),
+    clear: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn()
+  }
+}))
+
+vi.mock('node-pty', () => ({ spawn: mockPtySpawn }))
+vi.mock('../main/pty/posix-pty-process-groups', () => ({
+  forceKillPosixPtyProcessGroups: vi.fn((_pid: number, fallback: () => void) => fallback())
+}))
+vi.mock('../main/shell-prompt-readiness-probe', () => ({
+  createShellPromptReadinessProbe: mockCreateShellPromptReadinessProbe
+}))
+
+import type { PtyHandler } from './pty-handler'
+import {
+  beginPtyHandlerTest,
+  createPtyRequestHelpers,
+  endPtyHandlerTest
+} from './pty-handler-test-harness'
+import type { MockDispatcher } from './pty-handler-test-harness'
+
+const FOLDER_WORKSPACE_ID = 'folder:b1706d92-9d05-4932-8360-01e00b54305a'
+const FOLDER_PATH = '/opt/tiger/workspace'
+const WORKTREE_ID = 'repo-1::/srv/repo'
+
+// Why (STA-4746): the report claimed the relay derives a PTY's cwd by splitting
+// ORCA_WORKTREE_ID on `::`, so a `folder:<uuid>` workspace fell back to $HOME.
+// The relay has always taken cwd from the request instead; these pin that
+// contract so a future refactor cannot introduce the reported bug.
+describe('relay PTY spawn cwd for folder workspaces', () => {
+  let dispatcher: MockDispatcher
+  let handler: PtyHandler
+  let originalPlatform: PropertyDescriptor | undefined
+
+  const { spawnPty } = createPtyRequestHelpers(() => dispatcher)
+
+  beforeEach(() => {
+    ;({ dispatcher, handler, originalPlatform } = beginPtyHandlerTest({
+      mockPtySpawn,
+      mockPtyInstance,
+      mockCreateShellPromptReadinessProbe
+    }))
+  })
+
+  afterEach(async () => {
+    await endPtyHandlerTest(handler, originalPlatform)
+  })
+
+  function spawnedCwd(): string | undefined {
+    return mockPtySpawn.mock.calls.at(-1)?.[2]?.cwd
+  }
+
+  it('spawns a folder-workspace PTY in the requested workspace path', async () => {
+    await spawnPty({
+      cwd: FOLDER_PATH,
+      worktreeId: FOLDER_WORKSPACE_ID,
+      env: {
+        ORCA_WORKSPACE_ID: FOLDER_WORKSPACE_ID,
+        ORCA_WORKTREE_ID: FOLDER_WORKSPACE_ID,
+        ORCA_WORKSPACE_ROOT: FOLDER_PATH
+      }
+    })
+    expect(spawnedCwd()).toBe(FOLDER_PATH)
+  })
+
+  it('spawns a folder-workspace PTY in the requested path with no ORCA_WORKSPACE_ROOT', async () => {
+    await spawnPty({
+      cwd: FOLDER_PATH,
+      worktreeId: FOLDER_WORKSPACE_ID,
+      env: { ORCA_WORKTREE_ID: FOLDER_WORKSPACE_ID }
+    })
+    expect(spawnedCwd()).toBe(FOLDER_PATH)
+  })
+
+  it('keeps worktree-style ids on the request cwd, not the id-derived path', async () => {
+    await spawnPty({
+      cwd: '/srv/repo/packages/app',
+      worktreeId: WORKTREE_ID,
+      env: { ORCA_WORKTREE_ID: WORKTREE_ID }
+    })
+    expect(spawnedCwd()).toBe('/srv/repo/packages/app')
+  })
+
+  it('honours a legacy client that sends only env.ORCA_WORKTREE_ID', async () => {
+    // Why: clients before the `worktreeId` spawn param (<= 1.4.184) carried the
+    // workspace id in env only. cwd has always been an explicit request field.
+    await spawnPty({
+      cwd: FOLDER_PATH,
+      env: {
+        ORCA_WORKTREE_ID: FOLDER_WORKSPACE_ID,
+        ORCA_WORKSPACE_ROOT: FOLDER_PATH
+      }
+    })
+    expect(spawnedCwd()).toBe(FOLDER_PATH)
+  })
+
+  it('falls back to the default cwd only when the request carries none', async () => {
+    // Why: ORCA_WORKSPACE_ROOT is a client-supplied path and is deliberately not
+    // promoted to a cwd fallback — the relay would be trusting an unvalidated
+    // remote path for a request that named no working directory at all.
+    await spawnPty({
+      env: {
+        ORCA_WORKTREE_ID: FOLDER_WORKSPACE_ID,
+        ORCA_WORKSPACE_ROOT: FOLDER_PATH
+      }
+    })
+    expect(spawnedCwd()).not.toBe(FOLDER_PATH)
+    expect(spawnedCwd()).toBe(process.env.HOME)
+  })
+})

--- a/src/relay/pty-handler-folder-workspace-cwd.test.ts
+++ b/src/relay/pty-handler-folder-workspace-cwd.test.ts
@@ -25,6 +25,7 @@ vi.mock('../main/shell-prompt-readiness-probe', () => ({
 }))
 
 import type { PtyHandler } from './pty-handler'
+import { resolveDefaultCwd } from './pty-shell-utils'
 import {
   beginPtyHandlerTest,
   createPtyRequestHelpers,
@@ -36,11 +37,8 @@ const FOLDER_WORKSPACE_ID = 'folder:b1706d92-9d05-4932-8360-01e00b54305a'
 const FOLDER_PATH = '/opt/tiger/workspace'
 const WORKTREE_ID = 'repo-1::/srv/repo'
 
-// Why (STA-4746): the report claimed the relay derives a PTY's cwd by splitting
-// ORCA_WORKTREE_ID on `::`, so a `folder:<uuid>` workspace fell back to $HOME.
-// The relay has always taken cwd from the request instead; these pin that
-// contract so a future refactor cannot introduce the reported bug. Production
-// request construction is covered end to end by tests/e2e/sta4746-*.spec.ts.
+// Why (STA-4746): pins that the relay reads cwd from the request, never from
+// parsing ORCA_WORKTREE_ID. Request construction: tests/e2e/sta4746-*.spec.ts.
 describe('relay PTY spawn cwd for folder workspaces', () => {
   let dispatcher: MockDispatcher
   let handler: PtyHandler
@@ -119,6 +117,8 @@ describe('relay PTY spawn cwd for folder workspaces', () => {
       }
     })
     expect(spawnedCwd()).not.toBe(FOLDER_PATH)
-    expect(spawnedCwd()).toBe(process.env.HOME)
+    // Why computed: the harness pins platform to linux, but HOME is unset on
+    // some CI images, where the default falls through to homedir().
+    expect(spawnedCwd()).toBe(resolveDefaultCwd(process.env, 'linux'))
   })
 })

--- a/tests/e2e/helpers/sta4746-cwd-probe.ts
+++ b/tests/e2e/helpers/sta4746-cwd-probe.ts
@@ -2,13 +2,19 @@ import { expect } from '@stablyai/playwright-test'
 import type { Page } from '@stablyai/playwright-test'
 
 import { stripAnsiEscapeSequences } from '../../../src/shared/ansi-escape-sequences'
-import { getTerminalContent } from './terminal'
+import { ensureTerminalVisible } from './store'
+import {
+  focusActiveTerminalInput,
+  getTerminalContent,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager
+} from './terminal'
 
 export const STA4746_PROBE = 'STA4746PROBE'
 
 // Why `;;`: values are absolute paths, so a separator that cannot appear in one
-// keeps parsing exact. `toContain` on a whole path would accept a sibling
-// directory that merely has the expected path as a prefix.
+// keeps parsing exact — a substring match would accept a sibling directory that
+// merely has the expected path as a prefix.
 const FIELD_SEPARATOR = ';;'
 // Why a terminating field: a narrow terminal wraps the probe line, so a read can
 // catch it half-rendered. Refusing anything without `end=1` keeps a truncated
@@ -16,6 +22,11 @@ const FIELD_SEPARATOR = ';;'
 const END_FIELD = 'end'
 
 export type Sta4746Probe = Record<string, string>
+
+function probeHead(phase: string): string {
+  // Trailing separator so phase `a` cannot match a probe for phase `a-b`.
+  return `${STA4746_PROBE}${FIELD_SEPARATOR}phase=${phase}${FIELD_SEPARATOR}`
+}
 
 export function sta4746ProbeCommand(phase: string, extra: Record<string, string> = {}): string {
   const fields: Record<string, string> = {
@@ -43,22 +54,25 @@ function parseProbeSegment(segment: string): Sta4746Probe {
   return fields
 }
 
-function findProbe(content: string, phase: string): Sta4746Probe | null {
-  const head = `${STA4746_PROBE}${FIELD_SEPARATOR}phase=${phase}`
-  // Why: xterm reflow leaves cursor-motion sequences inside the rendered row,
-  // so a wrapped path arrives as `<path>ESC[1BESC[29D` and exact compares fail.
+/** Parses one complete probe record out of raw terminal text, else null. */
+export function parseSta4746Probe(content: string, phase: string): Sta4746Probe | null {
+  const head = probeHead(phase)
+  const terminator = `${FIELD_SEPARATOR}${END_FIELD}=1`
   const stripped = stripAnsiEscapeSequences(content)
-  // Second pass with rows joined: a hard wrap can split the line into two rows.
+  // Second pass with rows joined: a hard wrap can split the record across rows.
   for (const candidate of [stripped, stripped.replaceAll('\n', '')]) {
     const start = candidate.lastIndexOf(head)
     if (start === -1) {
       continue
     }
-    const segment = candidate.slice(start).split('\n')[0] ?? ''
-    const fields = parseProbeSegment(segment)
-    if (fields[END_FIELD] === '1') {
-      return fields
+    // Bound at the record's own terminator. Without this the joined pass runs to
+    // end of buffer and can absorb `key=value` text from unrelated later rows.
+    const row = candidate.slice(start).split('\n')[0] ?? ''
+    const end = row.indexOf(terminator)
+    if (end === -1) {
+      continue
     }
+    return parseProbeSegment(row.slice(0, end + terminator.length))
   }
   return null
 }
@@ -68,7 +82,7 @@ export async function readSta4746Probe(page: Page, phase: string): Promise<Sta47
   await expect
     .poll(
       async () => {
-        probe = findProbe(await getTerminalContent(page, 12_000), phase)
+        probe = parseSta4746Probe(await getTerminalContent(page, 12_000), phase)
         return probe?.pwd ?? ''
       },
       { timeout: 90_000, message: `probe line for phase ${phase} never rendered` }
@@ -79,4 +93,57 @@ export async function readSta4746Probe(page: Page, phase: string): Promise<Sta47
   }
   console.log(`[sta4746] ${phase}: ${JSON.stringify(probe)}`)
   return probe
+}
+
+export type Sta4746ProbeRun = {
+  probe: Sta4746Probe
+  /** Caller closes this so phases do not accumulate PTYs on a shared app fixture. */
+  tabId: string
+}
+
+/**
+ * Opens a fresh terminal in `workspaceKey`, pins who owns its PTY, then probes.
+ * `expectedPtyOwner` is load-bearing: when hosts share a filesystem, a PTY
+ * spawned by the wrong host still satisfies every path assertion.
+ */
+export async function probeWorkspaceTerminal(args: {
+  page: Page
+  workspaceKey: string
+  phase: string
+  expectedPtyOwner: RegExp
+  extraFields?: Record<string, string>
+  suffixCommand?: string
+}): Promise<Sta4746ProbeRun> {
+  const { page, workspaceKey, phase, expectedPtyOwner } = args
+  const tabId = await page.evaluate((key) => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('Store unavailable')
+    }
+    store.getState().setActiveWorktree(key)
+    const tab = store.getState().createTab(key, undefined, undefined, { activate: true })
+    store.getState().setActiveTab(tab.id)
+    store.getState().setActiveTabType('terminal')
+    return tab.id
+  }, workspaceKey)
+  await ensureTerminalVisible(page, 45_000)
+  await waitForActiveTerminalManager(page, 60_000)
+  const ptyId = await waitForActivePanePtyId(page, 60_000)
+  expect(ptyId, `phase ${phase} did not get the expected PTY owner`).toMatch(expectedPtyOwner)
+  await focusActiveTerminalInput(page)
+  const command = sta4746ProbeCommand(phase, args.extraFields)
+  await page.keyboard.type(args.suffixCommand ? `${command}; ${args.suffixCommand}` : command)
+  await page.keyboard.press('Enter')
+  return { probe: await readSta4746Probe(page, phase), tabId }
+}
+
+export async function closeSta4746Tabs(page: Page, tabIds: readonly string[]): Promise<void> {
+  await page
+    .evaluate((ids) => {
+      const store = window.__store
+      for (const id of ids) {
+        store?.getState().closeTab(id)
+      }
+    }, tabIds)
+    .catch(() => undefined)
 }

--- a/tests/e2e/helpers/sta4746-cwd-probe.ts
+++ b/tests/e2e/helpers/sta4746-cwd-probe.ts
@@ -1,0 +1,64 @@
+import { expect } from '@stablyai/playwright-test'
+import type { Page } from '@stablyai/playwright-test'
+
+import { getTerminalContent } from './terminal'
+
+export const STA4746_PROBE = 'STA4746PROBE'
+
+// Why `;;`: values are absolute paths, so a separator that cannot appear in one
+// keeps parsing exact. `toContain` on a whole path would accept a sibling
+// directory that merely has the expected path as a prefix.
+const FIELD_SEPARATOR = ';;'
+
+export type Sta4746Probe = Record<string, string>
+
+export function sta4746ProbeCommand(phase: string, extra: Record<string, string> = {}): string {
+  const fields: Record<string, string> = {
+    pwd: '"$PWD"',
+    oldpwd: '"$OLDPWD"',
+    wt: '"$ORCA_WORKTREE_ID"',
+    root: '"$ORCA_WORKSPACE_ROOT"',
+    ...extra
+  }
+  const keys = Object.keys(fields)
+  const format = keys.map((key) => `${FIELD_SEPARATOR}${key}=%s`).join('')
+  const args = keys.map((key) => fields[key]).join(' ')
+  return `printf '${STA4746_PROBE}${FIELD_SEPARATOR}phase=${phase}${format}\\n' ${args}`
+}
+
+function parseProbeLine(line: string): Sta4746Probe {
+  const fields: Sta4746Probe = {}
+  for (const chunk of line.split(FIELD_SEPARATOR)) {
+    const separator = chunk.indexOf('=')
+    if (separator > 0) {
+      fields[chunk.slice(0, separator).trim()] = chunk.slice(separator + 1).trim()
+    }
+  }
+  return fields
+}
+
+export async function readSta4746Probe(page: Page, phase: string): Promise<Sta4746Probe> {
+  let probe: Sta4746Probe | null = null
+  await expect
+    .poll(
+      async () => {
+        const line = (await getTerminalContent(page, 12_000))
+          .split('\n')
+          .toReversed()
+          .find(
+            (candidate) =>
+              candidate.includes(`${STA4746_PROBE}${FIELD_SEPARATOR}phase=${phase}`) &&
+              !candidate.includes('printf')
+          )
+        probe = line ? parseProbeLine(line) : null
+        return probe?.pwd ?? ''
+      },
+      { timeout: 90_000, message: `probe line for phase ${phase} never rendered` }
+    )
+    .not.toBe('')
+  if (!probe) {
+    throw new Error(`probe for phase ${phase} did not parse`)
+  }
+  console.log(`[sta4746] ${phase}: ${JSON.stringify(probe)}`)
+  return probe
+}

--- a/tests/e2e/helpers/sta4746-cwd-probe.ts
+++ b/tests/e2e/helpers/sta4746-cwd-probe.ts
@@ -1,6 +1,7 @@
 import { expect } from '@stablyai/playwright-test'
 import type { Page } from '@stablyai/playwright-test'
 
+import { stripAnsiEscapeSequences } from '../../../src/shared/ansi-escape-sequences'
 import { getTerminalContent } from './terminal'
 
 export const STA4746_PROBE = 'STA4746PROBE'
@@ -9,6 +10,10 @@ export const STA4746_PROBE = 'STA4746PROBE'
 // keeps parsing exact. `toContain` on a whole path would accept a sibling
 // directory that merely has the expected path as a prefix.
 const FIELD_SEPARATOR = ';;'
+// Why a terminating field: a narrow terminal wraps the probe line, so a read can
+// catch it half-rendered. Refusing anything without `end=1` keeps a truncated
+// value from being asserted as the real cwd.
+const END_FIELD = 'end'
 
 export type Sta4746Probe = Record<string, string>
 
@@ -18,7 +23,8 @@ export function sta4746ProbeCommand(phase: string, extra: Record<string, string>
     oldpwd: '"$OLDPWD"',
     wt: '"$ORCA_WORKTREE_ID"',
     root: '"$ORCA_WORKSPACE_ROOT"',
-    ...extra
+    ...extra,
+    [END_FIELD]: '1'
   }
   const keys = Object.keys(fields)
   const format = keys.map((key) => `${FIELD_SEPARATOR}${key}=%s`).join('')
@@ -26,9 +32,9 @@ export function sta4746ProbeCommand(phase: string, extra: Record<string, string>
   return `printf '${STA4746_PROBE}${FIELD_SEPARATOR}phase=${phase}${format}\\n' ${args}`
 }
 
-function parseProbeLine(line: string): Sta4746Probe {
+function parseProbeSegment(segment: string): Sta4746Probe {
   const fields: Sta4746Probe = {}
-  for (const chunk of line.split(FIELD_SEPARATOR)) {
+  for (const chunk of segment.split(FIELD_SEPARATOR)) {
     const separator = chunk.indexOf('=')
     if (separator > 0) {
       fields[chunk.slice(0, separator).trim()] = chunk.slice(separator + 1).trim()
@@ -37,20 +43,32 @@ function parseProbeLine(line: string): Sta4746Probe {
   return fields
 }
 
+function findProbe(content: string, phase: string): Sta4746Probe | null {
+  const head = `${STA4746_PROBE}${FIELD_SEPARATOR}phase=${phase}`
+  // Why: xterm reflow leaves cursor-motion sequences inside the rendered row,
+  // so a wrapped path arrives as `<path>ESC[1BESC[29D` and exact compares fail.
+  const stripped = stripAnsiEscapeSequences(content)
+  // Second pass with rows joined: a hard wrap can split the line into two rows.
+  for (const candidate of [stripped, stripped.replaceAll('\n', '')]) {
+    const start = candidate.lastIndexOf(head)
+    if (start === -1) {
+      continue
+    }
+    const segment = candidate.slice(start).split('\n')[0] ?? ''
+    const fields = parseProbeSegment(segment)
+    if (fields[END_FIELD] === '1') {
+      return fields
+    }
+  }
+  return null
+}
+
 export async function readSta4746Probe(page: Page, phase: string): Promise<Sta4746Probe> {
   let probe: Sta4746Probe | null = null
   await expect
     .poll(
       async () => {
-        const line = (await getTerminalContent(page, 12_000))
-          .split('\n')
-          .toReversed()
-          .find(
-            (candidate) =>
-              candidate.includes(`${STA4746_PROBE}${FIELD_SEPARATOR}phase=${phase}`) &&
-              !candidate.includes('printf')
-          )
-        probe = line ? parseProbeLine(line) : null
+        probe = findProbe(await getTerminalContent(page, 12_000), phase)
         return probe?.pwd ?? ''
       },
       { timeout: 90_000, message: `probe line for phase ${phase} never rendered` }

--- a/tests/e2e/sta4746-folder-remote-cwd.spec.ts
+++ b/tests/e2e/sta4746-folder-remote-cwd.spec.ts
@@ -1,5 +1,4 @@
-import { mkdtempSync, mkdirSync } from 'node:fs'
-import { realpathSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, realpathSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 

--- a/tests/e2e/sta4746-folder-remote-cwd.spec.ts
+++ b/tests/e2e/sta4746-folder-remote-cwd.spec.ts
@@ -7,6 +7,9 @@ import { launchHeadlessPairedRuntimeHost } from './helpers/headless-paired-runti
 
 type RuntimeTerminalRead = { tail: string[] }
 
+// Why: this is the host-owned half of STA-4746 — the RPC a remote CLI or a
+// paired client sends to a windowless `orca serve`. The paired-client half is
+// tests/e2e/sta4746-paired-desktop-folder-cwd.spec.ts.
 test('STA-4746: folder-workspace terminal on a headless paired host', async () => {
   test.setTimeout(240_000)
   const host = await launchHeadlessPairedRuntimeHost()
@@ -14,57 +17,66 @@ test('STA-4746: folder-workspace terminal on a headless paired host', async () =
     const parent = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'sta4746-')))
     const folderPath = path.join(parent, 'workspace')
     mkdirSync(folderPath, { recursive: true })
+    // Why: a sibling that has folderPath as a prefix, so a substring match
+    // could not stand in for the exact-path assertions below.
+    mkdirSync(`${folderPath}-decoy`, { recursive: true })
 
     const group = await host.client.call<{ group: { id: string } }>('projectGroup.create', {
       name: 'sta4746-group',
       parentPath: parent
     })
-    const groupId = group.result.group.id
-
     const fw = await host.client.call<{ folderWorkspace: { id: string; folderPath: string } }>(
       'folderWorkspace.create',
-      { projectGroupId: groupId, name: 'sta4746-ws', folderPath }
+      { projectGroupId: group.result.group.id, name: 'sta4746-ws', folderPath }
     )
     const folderWorkspaceId = fw.result.folderWorkspace.id
-    console.log('[sta4746] folderWorkspace', JSON.stringify(fw.result.folderWorkspace))
+    expect(fw.result.folderWorkspace.folderPath).toBe(folderPath)
 
     const created = await host.client.call<{
       terminal: { handle: string; worktreeId: string; ptyId?: string }
     }>('terminal.create', { worktree: `folder:${folderWorkspaceId}` })
-    console.log('[sta4746] terminal', JSON.stringify(created.result.terminal))
+    const terminal = created.result.terminal
+    expect(terminal.worktreeId).toBe(`folder:${folderWorkspaceId}`)
+    // Why: pins that the host daemon owns this PTY under the folder scope,
+    // rather than a fallback owner satisfying the path assertion by luck.
+    expect(terminal.ptyId).toMatch(new RegExp(`^folder:${folderWorkspaceId}@@`))
 
-    const marker = 'STA4746PROBE'
+    const marker = 'STA4746HEADLESS'
     await host.client.call('terminal.send', {
-      terminal: created.result.terminal.handle,
-      text: `printf '${marker} pwd=%s wt=%s root=%s\\n' "$PWD" "$ORCA_WORKTREE_ID" "$ORCA_WORKSPACE_ROOT"`,
+      terminal: terminal.handle,
+      text: `printf '${marker};;pwd=%s;;wt=%s;;root=%s\\n' "$PWD" "$ORCA_WORKTREE_ID" "$ORCA_WORKSPACE_ROOT"`,
       enter: true
     })
 
-    let observed = ''
+    let fields: Record<string, string> = {}
     await expect
       .poll(
         async () => {
           const read = await host.client.call<{ terminal: RuntimeTerminalRead }>('terminal.read', {
-            terminal: created.result.terminal.handle,
+            terminal: terminal.handle,
             limit: 200
           })
-          const tail = read.result.terminal.tail.join('\n')
-          const line = tail
-            .split('\n')
+          const line = read.result.terminal.tail
             .toReversed()
-            .find((l) => l.includes(`${marker} pwd=`) && !l.includes('printf'))
-          observed = line ?? ''
-          return observed
+            .find(
+              (candidate) => candidate.includes(`${marker};;pwd=`) && !candidate.includes('printf')
+            )
+          fields = Object.fromEntries(
+            (line ?? '')
+              .split(';;')
+              .map((chunk) => chunk.split('='))
+              .filter((parts) => parts.length === 2)
+              .map(([key, value]) => [key.trim(), value.trim()])
+          )
+          return fields.pwd ?? ''
         },
         { timeout: 60_000 }
       )
       .not.toBe('')
 
-    console.log('[sta4746] OBSERVED:', observed)
-    console.log('[sta4746] EXPECTED pwd=', folderPath)
-    expect(observed).toContain(`pwd=${folderPath}`)
-    expect(observed).toContain(`root=${folderPath}`)
-    expect(observed).toContain(`wt=folder:${folderWorkspaceId}`)
+    expect(fields.pwd).toBe(folderPath)
+    expect(fields.root).toBe(folderPath)
+    expect(fields.wt).toBe(`folder:${folderWorkspaceId}`)
   } finally {
     await host.dispose()
   }

--- a/tests/e2e/sta4746-folder-remote-cwd.spec.ts
+++ b/tests/e2e/sta4746-folder-remote-cwd.spec.ts
@@ -2,6 +2,7 @@ import { mkdirSync, mkdtempSync, realpathSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 
+import { stripAnsiEscapeSequences } from '../../src/shared/ansi-escape-sequences'
 import { expect, test } from './helpers/orca-app'
 import { launchHeadlessPairedRuntimeHost } from './helpers/headless-paired-runtime-host'
 
@@ -44,7 +45,9 @@ test('STA-4746: folder-workspace terminal on a headless paired host', async () =
     const marker = 'STA4746HEADLESS'
     await host.client.call('terminal.send', {
       terminal: terminal.handle,
-      text: `printf '${marker};;pwd=%s;;wt=%s;;root=%s\\n' "$PWD" "$ORCA_WORKTREE_ID" "$ORCA_WORKSPACE_ROOT"`,
+      // `end=1` last: a wrapped row can be read half-rendered, and asserting a
+      // truncated path as the real cwd would be a false pass.
+      text: `printf '${marker};;pwd=%s;;wt=%s;;root=%s;;end=1\\n' "$PWD" "$ORCA_WORKTREE_ID" "$ORCA_WORKSPACE_ROOT"`,
       enter: true
     })
 
@@ -62,13 +65,13 @@ test('STA-4746: folder-workspace terminal on a headless paired host', async () =
               (candidate) => candidate.includes(`${marker};;pwd=`) && !candidate.includes('printf')
             )
           fields = Object.fromEntries(
-            (line ?? '')
+            stripAnsiEscapeSequences(line ?? '')
               .split(';;')
               .map((chunk) => chunk.split('='))
               .filter((parts) => parts.length === 2)
               .map(([key, value]) => [key.trim(), value.trim()])
           )
-          return fields.pwd ?? ''
+          return fields.end === '1' ? (fields.pwd ?? '') : ''
         },
         { timeout: 60_000 }
       )

--- a/tests/e2e/sta4746-folder-remote-cwd.spec.ts
+++ b/tests/e2e/sta4746-folder-remote-cwd.spec.ts
@@ -1,0 +1,72 @@
+import { mkdtempSync, mkdirSync } from 'node:fs'
+import { realpathSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { expect, test } from './helpers/orca-app'
+import { launchHeadlessPairedRuntimeHost } from './helpers/headless-paired-runtime-host'
+
+type RuntimeTerminalRead = { tail: string[] }
+
+test('STA-4746: folder-workspace terminal on a headless paired host', async () => {
+  test.setTimeout(240_000)
+  const host = await launchHeadlessPairedRuntimeHost()
+  try {
+    const parent = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'sta4746-')))
+    const folderPath = path.join(parent, 'workspace')
+    mkdirSync(folderPath, { recursive: true })
+
+    const group = await host.client.call<{ group: { id: string } }>('projectGroup.create', {
+      name: 'sta4746-group',
+      parentPath: parent
+    })
+    const groupId = group.result.group.id
+
+    const fw = await host.client.call<{ folderWorkspace: { id: string; folderPath: string } }>(
+      'folderWorkspace.create',
+      { projectGroupId: groupId, name: 'sta4746-ws', folderPath }
+    )
+    const folderWorkspaceId = fw.result.folderWorkspace.id
+    console.log('[sta4746] folderWorkspace', JSON.stringify(fw.result.folderWorkspace))
+
+    const created = await host.client.call<{
+      terminal: { handle: string; worktreeId: string; ptyId?: string }
+    }>('terminal.create', { worktree: `folder:${folderWorkspaceId}` })
+    console.log('[sta4746] terminal', JSON.stringify(created.result.terminal))
+
+    const marker = 'STA4746PROBE'
+    await host.client.call('terminal.send', {
+      terminal: created.result.terminal.handle,
+      text: `printf '${marker} pwd=%s wt=%s root=%s\\n' "$PWD" "$ORCA_WORKTREE_ID" "$ORCA_WORKSPACE_ROOT"`,
+      enter: true
+    })
+
+    let observed = ''
+    await expect
+      .poll(
+        async () => {
+          const read = await host.client.call<{ terminal: RuntimeTerminalRead }>('terminal.read', {
+            terminal: created.result.terminal.handle,
+            limit: 200
+          })
+          const tail = read.result.terminal.tail.join('\n')
+          const line = tail
+            .split('\n')
+            .toReversed()
+            .find((l) => l.includes(`${marker} pwd=`) && !l.includes('printf'))
+          observed = line ?? ''
+          return observed
+        },
+        { timeout: 60_000 }
+      )
+      .not.toBe('')
+
+    console.log('[sta4746] OBSERVED:', observed)
+    console.log('[sta4746] EXPECTED pwd=', folderPath)
+    expect(observed).toContain(`pwd=${folderPath}`)
+    expect(observed).toContain(`root=${folderPath}`)
+    expect(observed).toContain(`wt=folder:${folderWorkspaceId}`)
+  } finally {
+    await host.dispose()
+  }
+})

--- a/tests/e2e/sta4746-folder-remote-cwd.spec.ts
+++ b/tests/e2e/sta4746-folder-remote-cwd.spec.ts
@@ -1,10 +1,10 @@
-import { mkdirSync, mkdtempSync, realpathSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, realpathSync, rmSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 
-import { stripAnsiEscapeSequences } from '../../src/shared/ansi-escape-sequences'
-import { expect, test } from './helpers/orca-app'
 import { launchHeadlessPairedRuntimeHost } from './helpers/headless-paired-runtime-host'
+import { expect, test } from './helpers/orca-app'
+import { parseSta4746Probe, sta4746ProbeCommand } from './helpers/sta4746-cwd-probe'
 
 type RuntimeTerminalRead = { tail: string[] }
 
@@ -13,9 +13,11 @@ type RuntimeTerminalRead = { tail: string[] }
 // tests/e2e/sta4746-paired-desktop-folder-cwd.spec.ts.
 test('STA-4746: folder-workspace terminal on a headless paired host', async () => {
   test.setTimeout(240_000)
+  test.skip(process.platform === 'win32', 'The shell probe is POSIX-only')
+
+  const parent = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'sta4746-')))
   const host = await launchHeadlessPairedRuntimeHost()
   try {
-    const parent = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'sta4746-')))
     const folderPath = path.join(parent, 'workspace')
     mkdirSync(folderPath, { recursive: true })
     // Why: a sibling that has folderPath as a prefix, so a substring match
@@ -42,45 +44,28 @@ test('STA-4746: folder-workspace terminal on a headless paired host', async () =
     // rather than a fallback owner satisfying the path assertion by luck.
     expect(terminal.ptyId).toMatch(new RegExp(`^folder:${folderWorkspaceId}@@`))
 
-    const marker = 'STA4746HEADLESS'
+    const phase = 'headless-folder'
     await host.client.call('terminal.send', {
       terminal: terminal.handle,
-      // `end=1` last: a wrapped row can be read half-rendered, and asserting a
-      // truncated path as the real cwd would be a false pass.
-      text: `printf '${marker};;pwd=%s;;wt=%s;;root=%s;;end=1\\n' "$PWD" "$ORCA_WORKTREE_ID" "$ORCA_WORKSPACE_ROOT"`,
+      text: sta4746ProbeCommand(phase),
       enter: true
     })
 
-    let fields: Record<string, string> = {}
-    await expect
-      .poll(
-        async () => {
-          const read = await host.client.call<{ terminal: RuntimeTerminalRead }>('terminal.read', {
-            terminal: terminal.handle,
-            limit: 200
-          })
-          const line = read.result.terminal.tail
-            .toReversed()
-            .find(
-              (candidate) => candidate.includes(`${marker};;pwd=`) && !candidate.includes('printf')
-            )
-          fields = Object.fromEntries(
-            stripAnsiEscapeSequences(line ?? '')
-              .split(';;')
-              .map((chunk) => chunk.split('='))
-              .filter((parts) => parts.length === 2)
-              .map(([key, value]) => [key.trim(), value.trim()])
-          )
-          return fields.end === '1' ? (fields.pwd ?? '') : ''
-        },
-        { timeout: 60_000 }
-      )
-      .not.toBe('')
+    const readProbe = async (): Promise<Record<string, string> | null> => {
+      const read = await host.client.call<{ terminal: RuntimeTerminalRead }>('terminal.read', {
+        terminal: terminal.handle,
+        limit: 200
+      })
+      return parseSta4746Probe(read.result.terminal.tail.join('\n'), phase)
+    }
+    await expect.poll(async () => (await readProbe())?.pwd ?? '', { timeout: 60_000 }).not.toBe('')
 
-    expect(fields.pwd).toBe(folderPath)
-    expect(fields.root).toBe(folderPath)
-    expect(fields.wt).toBe(`folder:${folderWorkspaceId}`)
+    const probe = await readProbe()
+    expect(probe?.pwd).toBe(folderPath)
+    expect(probe?.root).toBe(folderPath)
+    expect(probe?.wt).toBe(`folder:${folderWorkspaceId}`)
   } finally {
     await host.dispose()
+    rmSync(parent, { recursive: true, force: true })
   }
 })

--- a/tests/e2e/sta4746-paired-desktop-folder-cwd.spec.ts
+++ b/tests/e2e/sta4746-paired-desktop-folder-cwd.spec.ts
@@ -1,0 +1,150 @@
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import type { Page } from '@stablyai/playwright-test'
+
+import { expect, test } from './helpers/orca-app'
+import {
+  createRuntimeDesktopPairingOffer,
+  launchPairedElectronClient
+} from './helpers/paired-electron-client'
+import { ensureTerminalVisible } from './helpers/store'
+import {
+  focusActiveTerminalInput,
+  getTerminalContent,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager
+} from './helpers/terminal'
+
+const PROBE = 'STA4746PAIRED'
+
+async function probeWorkspaceTerminal(
+  page: Page,
+  workspaceKey: string,
+  phase: string
+): Promise<string> {
+  await page.evaluate((key) => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('Store unavailable')
+    }
+    store.getState().setActiveWorktree(key)
+    const tab = store.getState().createTab(key, undefined, undefined, { activate: true })
+    store.getState().setActiveTab(tab.id)
+    store.getState().setActiveTabType('terminal')
+  }, workspaceKey)
+  await ensureTerminalVisible(page, 45_000)
+  await waitForActiveTerminalManager(page, 60_000)
+  await waitForActivePanePtyId(page, 60_000)
+  await focusActiveTerminalInput(page)
+  await page.keyboard.type(
+    `printf '${PROBE} phase=${phase} pwd=%s wt=%s root=%s\\n' "$PWD" "$ORCA_WORKTREE_ID" "$ORCA_WORKSPACE_ROOT"; touch ./${PROBE}-${phase}.marker`
+  )
+  await page.keyboard.press('Enter')
+  let observed = ''
+  await expect
+    .poll(
+      async () => {
+        const content = await getTerminalContent(page, 12_000)
+        observed =
+          content
+            .split('\n')
+            .toReversed()
+            .find(
+              (line) => line.includes(`${PROBE} phase=${phase} pwd=`) && !line.includes('printf')
+            )
+            ?.trim() ?? ''
+        return observed
+      },
+      { timeout: 60_000, message: `probe line for phase ${phase} never rendered` }
+    )
+    .not.toBe('')
+  console.log(`[sta4746-paired] ${phase}:`, observed)
+  return observed
+}
+
+test('STA-4746: paired desktop client lands a folder-workspace PTY on the host folder path @headful', async ({
+  orcaPage
+}, testInfo) => {
+  test.setTimeout(300_000)
+
+  const parent = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'sta4746-paired-')))
+  const folderPath = path.join(parent, 'workspace')
+  mkdirSync(folderPath, { recursive: true })
+
+  const hostWorktreeId = await orcaPage.evaluate(() => {
+    const state = window.__store?.getState()
+    const id = state?.activeWorktreeId
+    const active = state?.allWorktrees().find((candidate) => candidate.id === id)
+    if (!active) {
+      throw new Error('Headed host did not select its seeded worktree')
+    }
+    return active.id
+  })
+
+  const folderWorkspaceId = await orcaPage.evaluate(
+    async ({ parentPath, folderPath }) => {
+      const group = await window.api.projectGroups.create({
+        name: `sta4746-${Date.now()}`,
+        parentPath,
+        createdFrom: 'manual'
+      })
+      const workspace = await window.api.folderWorkspaces.create({
+        projectGroupId: group.id,
+        name: 'sta4746-ws',
+        folderPath
+      })
+      return workspace.id as string
+    },
+    { parentPath: parent, folderPath }
+  )
+  const workspaceKey = `folder:${folderWorkspaceId}`
+
+  const offer = await createRuntimeDesktopPairingOffer(orcaPage)
+  const client = await launchPairedElectronClient(offer, testInfo, 'sta4746-client')
+  try {
+    await expect
+      .poll(
+        () =>
+          client.page.evaluate(
+            (id) =>
+              (window.__store?.getState().folderWorkspaces ?? []).some(
+                (workspace) => workspace.id === id
+              ),
+            folderWorkspaceId
+          ),
+        { timeout: 60_000, message: 'client never mirrored the host folder workspace' }
+      )
+      .toBe(true)
+
+    // Primary: the paired CLIENT drives the terminal; the HOST owns the PTY.
+    const folderProbe = await probeWorkspaceTerminal(client.page, workspaceKey, 'client-folder')
+    expect(folderProbe).toContain(`pwd=${folderPath}`)
+    expect(folderProbe).toContain(`root=${folderPath}`)
+    expect(folderProbe).toContain(`wt=${workspaceKey}`)
+    // Independent filesystem signal: the marker landed in the folder path itself.
+    await expect
+      .poll(() => existsSync(path.join(folderPath, `${PROBE}-client-folder.marker`)), {
+        timeout: 30_000,
+        message: 'client folder-workspace PTY never wrote its marker into the folder path'
+      })
+      .toBe(true)
+
+    // Control: a normal git worktree over the same paired transport.
+    const worktreeProbe = await probeWorkspaceTerminal(
+      client.page,
+      hostWorktreeId,
+      'client-worktree'
+    )
+    expect(worktreeProbe).toContain(`wt=${hostWorktreeId}`)
+    expect(worktreeProbe).not.toContain(`pwd=${os.homedir()}\n`)
+
+    // Control: local-only on the host itself, same folder workspace.
+    const localProbe = await probeWorkspaceTerminal(orcaPage, workspaceKey, 'host-local-folder')
+    expect(localProbe).toContain(`pwd=${folderPath}`)
+    expect(localProbe).toContain(`root=${folderPath}`)
+  } finally {
+    await client.dispose()
+    rmSync(parent, { recursive: true, force: true })
+  }
+})

--- a/tests/e2e/sta4746-paired-desktop-folder-cwd.spec.ts
+++ b/tests/e2e/sta4746-paired-desktop-folder-cwd.spec.ts
@@ -8,21 +8,25 @@ import {
   createRuntimeDesktopPairingOffer,
   launchPairedElectronClient
 } from './helpers/paired-electron-client'
+import {
+  readSta4746Probe,
+  sta4746ProbeCommand,
+  STA4746_PROBE,
+  type Sta4746Probe
+} from './helpers/sta4746-cwd-probe'
 import { ensureTerminalVisible } from './helpers/store'
 import {
   focusActiveTerminalInput,
-  getTerminalContent,
   waitForActivePanePtyId,
   waitForActiveTerminalManager
 } from './helpers/terminal'
 
-const PROBE = 'STA4746PAIRED'
-
 async function probeWorkspaceTerminal(
   page: Page,
   workspaceKey: string,
-  phase: string
-): Promise<string> {
+  phase: string,
+  expectedPtyOwner: RegExp
+): Promise<Sta4746Probe> {
   await page.evaluate((key) => {
     const store = window.__store
     if (!store) {
@@ -35,32 +39,17 @@ async function probeWorkspaceTerminal(
   }, workspaceKey)
   await ensureTerminalVisible(page, 45_000)
   await waitForActiveTerminalManager(page, 60_000)
-  await waitForActivePanePtyId(page, 60_000)
+  const ptyId = await waitForActivePanePtyId(page, 60_000)
+  // Why: host and client share one filesystem in this harness, so a
+  // client-local fallback would satisfy every path assertion. Pin the owner so
+  // the run proves the HOST spawned the PTY.
+  expect(ptyId, `phase ${phase} did not get the expected PTY owner`).toMatch(expectedPtyOwner)
   await focusActiveTerminalInput(page)
   await page.keyboard.type(
-    `printf '${PROBE} phase=${phase} pwd=%s wt=%s root=%s\\n' "$PWD" "$ORCA_WORKTREE_ID" "$ORCA_WORKSPACE_ROOT"; touch ./${PROBE}-${phase}.marker`
+    `${sta4746ProbeCommand(phase)}; touch ./${STA4746_PROBE}-${phase}.marker`
   )
   await page.keyboard.press('Enter')
-  let observed = ''
-  await expect
-    .poll(
-      async () => {
-        const content = await getTerminalContent(page, 12_000)
-        observed =
-          content
-            .split('\n')
-            .toReversed()
-            .find(
-              (line) => line.includes(`${PROBE} phase=${phase} pwd=`) && !line.includes('printf')
-            )
-            ?.trim() ?? ''
-        return observed
-      },
-      { timeout: 60_000, message: `probe line for phase ${phase} never rendered` }
-    )
-    .not.toBe('')
-  console.log(`[sta4746-paired] ${phase}:`, observed)
-  return observed
+  return readSta4746Probe(page, phase)
 }
 
 test('STA-4746: paired desktop client lands a folder-workspace PTY on the host folder path @headful', async ({
@@ -72,14 +61,14 @@ test('STA-4746: paired desktop client lands a folder-workspace PTY on the host f
   const folderPath = path.join(parent, 'workspace')
   mkdirSync(folderPath, { recursive: true })
 
-  const hostWorktreeId = await orcaPage.evaluate(() => {
+  const hostWorktree = await orcaPage.evaluate(() => {
     const state = window.__store?.getState()
     const id = state?.activeWorktreeId
     const active = state?.allWorktrees().find((candidate) => candidate.id === id)
     if (!active) {
       throw new Error('Headed host did not select its seeded worktree')
     }
-    return active.id
+    return { id: active.id, path: active.path }
   })
 
   const folderWorkspaceId = await orcaPage.evaluate(
@@ -118,13 +107,18 @@ test('STA-4746: paired desktop client lands a folder-workspace PTY on the host f
       .toBe(true)
 
     // Primary: the paired CLIENT drives the terminal; the HOST owns the PTY.
-    const folderProbe = await probeWorkspaceTerminal(client.page, workspaceKey, 'client-folder')
-    expect(folderProbe).toContain(`pwd=${folderPath}`)
-    expect(folderProbe).toContain(`root=${folderPath}`)
-    expect(folderProbe).toContain(`wt=${workspaceKey}`)
+    const folderProbe = await probeWorkspaceTerminal(
+      client.page,
+      workspaceKey,
+      'client-folder',
+      /^remote:[^@]+@@/
+    )
+    expect(folderProbe.pwd).toBe(folderPath)
+    expect(folderProbe.root).toBe(folderPath)
+    expect(folderProbe.wt).toBe(workspaceKey)
     // Independent filesystem signal: the marker landed in the folder path itself.
     await expect
-      .poll(() => existsSync(path.join(folderPath, `${PROBE}-client-folder.marker`)), {
+      .poll(() => existsSync(path.join(folderPath, `${STA4746_PROBE}-client-folder.marker`)), {
         timeout: 30_000,
         message: 'client folder-workspace PTY never wrote its marker into the folder path'
       })
@@ -133,16 +127,23 @@ test('STA-4746: paired desktop client lands a folder-workspace PTY on the host f
     // Control: a normal git worktree over the same paired transport.
     const worktreeProbe = await probeWorkspaceTerminal(
       client.page,
-      hostWorktreeId,
-      'client-worktree'
+      hostWorktree.id,
+      'client-worktree',
+      /^remote:[^@]+@@/
     )
-    expect(worktreeProbe).toContain(`wt=${hostWorktreeId}`)
-    expect(worktreeProbe).not.toContain(`pwd=${os.homedir()}\n`)
+    expect(worktreeProbe.wt).toBe(hostWorktree.id)
+    expect(worktreeProbe.pwd).toBe(hostWorktree.path)
+    expect(worktreeProbe.root).toBe('')
 
     // Control: local-only on the host itself, same folder workspace.
-    const localProbe = await probeWorkspaceTerminal(orcaPage, workspaceKey, 'host-local-folder')
-    expect(localProbe).toContain(`pwd=${folderPath}`)
-    expect(localProbe).toContain(`root=${folderPath}`)
+    const localProbe = await probeWorkspaceTerminal(
+      orcaPage,
+      workspaceKey,
+      'host-local-folder',
+      /^folder:[^@]+@@/
+    )
+    expect(localProbe.pwd).toBe(folderPath)
+    expect(localProbe.root).toBe(folderPath)
   } finally {
     await client.dispose()
     rmSync(parent, { recursive: true, force: true })

--- a/tests/e2e/sta4746-paired-desktop-folder-cwd.spec.ts
+++ b/tests/e2e/sta4746-paired-desktop-folder-cwd.spec.ts
@@ -1,101 +1,73 @@
 import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import type { Page } from '@stablyai/playwright-test'
 
 import { expect, test } from './helpers/orca-app'
 import {
   createRuntimeDesktopPairingOffer,
-  launchPairedElectronClient
+  launchPairedElectronClient,
+  type PairedElectronClient
 } from './helpers/paired-electron-client'
 import {
-  readSta4746Probe,
-  sta4746ProbeCommand,
+  closeSta4746Tabs,
+  probeWorkspaceTerminal,
   STA4746_PROBE,
   type Sta4746Probe
 } from './helpers/sta4746-cwd-probe'
-import { ensureTerminalVisible } from './helpers/store'
-import {
-  focusActiveTerminalInput,
-  waitForActivePanePtyId,
-  waitForActiveTerminalManager
-} from './helpers/terminal'
-
-async function probeWorkspaceTerminal(
-  page: Page,
-  workspaceKey: string,
-  phase: string,
-  expectedPtyOwner: RegExp
-): Promise<Sta4746Probe> {
-  await page.evaluate((key) => {
-    const store = window.__store
-    if (!store) {
-      throw new Error('Store unavailable')
-    }
-    store.getState().setActiveWorktree(key)
-    const tab = store.getState().createTab(key, undefined, undefined, { activate: true })
-    store.getState().setActiveTab(tab.id)
-    store.getState().setActiveTabType('terminal')
-  }, workspaceKey)
-  await ensureTerminalVisible(page, 45_000)
-  await waitForActiveTerminalManager(page, 60_000)
-  const ptyId = await waitForActivePanePtyId(page, 60_000)
-  // Why: host and client share one filesystem in this harness, so a
-  // client-local fallback would satisfy every path assertion. Pin the owner so
-  // the run proves the HOST spawned the PTY.
-  expect(ptyId, `phase ${phase} did not get the expected PTY owner`).toMatch(expectedPtyOwner)
-  await focusActiveTerminalInput(page)
-  await page.keyboard.type(
-    `${sta4746ProbeCommand(phase)}; touch ./${STA4746_PROBE}-${phase}.marker`
-  )
-  await page.keyboard.press('Enter')
-  return readSta4746Probe(page, phase)
-}
 
 test('STA-4746: paired desktop client lands a folder-workspace PTY on the host folder path @headful', async ({
   orcaPage
 }, testInfo) => {
   test.setTimeout(300_000)
+  test.skip(process.platform === 'win32', 'The shell probe is POSIX-only')
 
   const parent = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'sta4746-paired-')))
   const folderPath = path.join(parent, 'workspace')
-  mkdirSync(folderPath, { recursive: true })
-
-  const hostWorktree = await orcaPage.evaluate(() => {
-    const state = window.__store?.getState()
-    const id = state?.activeWorktreeId
-    const active = state?.allWorktrees().find((candidate) => candidate.id === id)
-    if (!active) {
-      throw new Error('Headed host did not select its seeded worktree')
-    }
-    return { id: active.id, path: active.path }
-  })
-
-  const folderWorkspaceId = await orcaPage.evaluate(
-    async ({ parentPath, folderPath }) => {
-      const group = await window.api.projectGroups.create({
-        name: `sta4746-${Date.now()}`,
-        parentPath,
-        createdFrom: 'manual'
-      })
-      const workspace = await window.api.folderWorkspaces.create({
-        projectGroupId: group.id,
-        name: 'sta4746-ws',
-        folderPath
-      })
-      return workspace.id as string
-    },
-    { parentPath: parent, folderPath }
-  )
-  const workspaceKey = `folder:${folderWorkspaceId}`
-
-  const offer = await createRuntimeDesktopPairingOffer(orcaPage)
-  const client = await launchPairedElectronClient(offer, testInfo, 'sta4746-client')
+  let client: PairedElectronClient | null = null
+  const hostTabIds: string[] = []
+  const clientTabIds: string[] = []
   try {
+    mkdirSync(folderPath, { recursive: true })
+
+    const hostWorktree = await orcaPage.evaluate(() => {
+      const state = window.__store?.getState()
+      const id = state?.activeWorktreeId
+      const active = state?.allWorktrees().find((candidate) => candidate.id === id)
+      if (!active) {
+        throw new Error('Headed host did not select its seeded worktree')
+      }
+      return { id: active.id, path: active.path }
+    })
+
+    const folderWorkspaceId = await orcaPage.evaluate(
+      async ({ parentPath, folderPath }) => {
+        const group = await window.api.projectGroups.create({
+          name: `sta4746-${Date.now()}`,
+          parentPath,
+          createdFrom: 'manual'
+        })
+        const workspace = await window.api.folderWorkspaces.create({
+          projectGroupId: group.id,
+          name: 'sta4746-ws',
+          folderPath
+        })
+        return workspace.id as string
+      },
+      { parentPath: parent, folderPath }
+    )
+    const workspaceKey = `folder:${folderWorkspaceId}`
+
+    const offer = await createRuntimeDesktopPairingOffer(orcaPage)
+    client = await launchPairedElectronClient(offer, testInfo, 'sta4746-client')
+    const pairedClient = client
+    // Why the exact environment id: `remote:<anything>@@` would also accept a
+    // PTY owned by some other runtime this client happens to know about.
+    const remoteOwner = new RegExp(`^remote:${pairedClient.environmentId}@@`)
+
     await expect
       .poll(
         () =>
-          client.page.evaluate(
+          pairedClient.page.evaluate(
             (id) =>
               (window.__store?.getState().folderWorkspaces ?? []).some(
                 (workspace) => workspace.id === id
@@ -106,13 +78,20 @@ test('STA-4746: paired desktop client lands a folder-workspace PTY on the host f
       )
       .toBe(true)
 
+    const probeOnClient = async (key: string, phase: string): Promise<Sta4746Probe> => {
+      const run = await probeWorkspaceTerminal({
+        page: pairedClient.page,
+        workspaceKey: key,
+        phase,
+        expectedPtyOwner: remoteOwner,
+        suffixCommand: `touch ./${STA4746_PROBE}-${phase}.marker`
+      })
+      clientTabIds.push(run.tabId)
+      return run.probe
+    }
+
     // Primary: the paired CLIENT drives the terminal; the HOST owns the PTY.
-    const folderProbe = await probeWorkspaceTerminal(
-      client.page,
-      workspaceKey,
-      'client-folder',
-      /^remote:[^@]+@@/
-    )
+    const folderProbe = await probeOnClient(workspaceKey, 'client-folder')
     expect(folderProbe.pwd).toBe(folderPath)
     expect(folderProbe.root).toBe(folderPath)
     expect(folderProbe.wt).toBe(workspaceKey)
@@ -125,27 +104,27 @@ test('STA-4746: paired desktop client lands a folder-workspace PTY on the host f
       .toBe(true)
 
     // Control: a normal git worktree over the same paired transport.
-    const worktreeProbe = await probeWorkspaceTerminal(
-      client.page,
-      hostWorktree.id,
-      'client-worktree',
-      /^remote:[^@]+@@/
-    )
+    const worktreeProbe = await probeOnClient(hostWorktree.id, 'client-worktree')
     expect(worktreeProbe.wt).toBe(hostWorktree.id)
     expect(worktreeProbe.pwd).toBe(hostWorktree.path)
     expect(worktreeProbe.root).toBe('')
 
     // Control: local-only on the host itself, same folder workspace.
-    const localProbe = await probeWorkspaceTerminal(
-      orcaPage,
+    const localRun = await probeWorkspaceTerminal({
+      page: orcaPage,
       workspaceKey,
-      'host-local-folder',
-      /^folder:[^@]+@@/
-    )
-    expect(localProbe.pwd).toBe(folderPath)
-    expect(localProbe.root).toBe(folderPath)
+      phase: 'host-local-folder',
+      expectedPtyOwner: new RegExp(`^folder:${folderWorkspaceId}@@`)
+    })
+    hostTabIds.push(localRun.tabId)
+    expect(localRun.probe.pwd).toBe(folderPath)
+    expect(localRun.probe.root).toBe(folderPath)
   } finally {
-    await client.dispose()
+    await closeSta4746Tabs(orcaPage, hostTabIds)
+    if (client) {
+      await closeSta4746Tabs(client.page, clientTabIds)
+      await client.dispose()
+    }
     rmSync(parent, { recursive: true, force: true })
   }
 })

--- a/tests/e2e/sta4746-ssh-folder-cwd.spec.ts
+++ b/tests/e2e/sta4746-ssh-folder-cwd.spec.ts
@@ -1,3 +1,5 @@
+import type { Page } from '@stablyai/playwright-test'
+
 import { connectDockerSshRelayTarget } from './helpers/docker-ssh-relay-connection'
 import {
   cleanupDockerSshRelayTarget,
@@ -7,26 +9,31 @@ import {
   type DockerSshRelayTarget
 } from './helpers/docker-ssh-relay-target'
 import { test, expect } from './helpers/orca-app'
+import {
+  readSta4746Probe,
+  sta4746ProbeCommand,
+  type Sta4746Probe
+} from './helpers/sta4746-cwd-probe'
 import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
 import {
   focusActiveTerminalInput,
-  getTerminalContent,
   waitForActivePanePtyId,
   waitForActiveTerminalManager
 } from './helpers/terminal'
-import type { Page } from '@stablyai/playwright-test'
 
 const RUN_DOCKER_SSH = process.env.ORCA_E2E_SSH_DOCKER === '1'
 const REMOTE_FOLDER_PARENT = '/srv/sta4746'
 const REMOTE_FOLDER_PATH = `${REMOTE_FOLDER_PARENT}/workspace`
 const REMOTE_PROFILE_CD_PATH = `${REMOTE_FOLDER_PARENT}/container-init`
-const PROBE = 'STA4746SSH'
+// Why: the profile script records where each login shell *started*, before it
+// cd's. That is independent of OLDPWD, which a test could otherwise inherit.
+const REMOTE_PRE_CD_LOG = `${REMOTE_FOLDER_PARENT}/pre-cd.log`
 
 async function probeWorkspaceTerminal(
   page: Page,
   workspaceKey: string,
   phase: string
-): Promise<string> {
+): Promise<Sta4746Probe> {
   await page.evaluate((key) => {
     const store = window.__store
     if (!store) {
@@ -39,38 +46,22 @@ async function probeWorkspaceTerminal(
   }, workspaceKey)
   await ensureTerminalVisible(page, 45_000)
   await waitForActiveTerminalManager(page, 60_000)
-  await waitForActivePanePtyId(page, 60_000)
+  const ptyId = await waitForActivePanePtyId(page, 60_000)
+  // Why: a local-provider fallback would satisfy every path assertion below,
+  // because the container paths do not exist on the client. Pin the owner.
+  expect(ptyId, `phase ${phase} did not get an SSH-owned PTY`).toMatch(/^ssh:[^@]+@@/)
   await focusActiveTerminalInput(page)
-  await page.keyboard.type(
-    `printf '${PROBE} phase=${phase} pwd=%s oldpwd=%s wt=%s root=%s\\n' "$PWD" "$OLDPWD" "$ORCA_WORKTREE_ID" "$ORCA_WORKSPACE_ROOT"`
-  )
+  // `readlink /proc/$$/cwd` is the kernel's answer for this exact shell, so it
+  // is a second signal that cannot agree with $PWD by construction.
+  await page.keyboard.type(sta4746ProbeCommand(phase, { selfcwd: '"$(readlink /proc/$$/cwd)"' }))
   await page.keyboard.press('Enter')
-  let observed = ''
-  await expect
-    .poll(
-      async () => {
-        const content = await getTerminalContent(page, 12_000)
-        observed =
-          content
-            .split('\n')
-            .toReversed()
-            .find(
-              (line) => line.includes(`${PROBE} phase=${phase} pwd=`) && !line.includes('printf')
-            )
-            ?.trim() ?? ''
-        return observed
-      },
-      { timeout: 90_000, message: `probe line for phase ${phase} never rendered` }
-    )
-    .not.toBe('')
-  console.log(`[sta4746-ssh] ${phase}:`, observed)
-  return observed
+  return readSta4746Probe(page, phase)
 }
 
 test.describe('STA-4746 SSH relay folder workspace cwd', () => {
   test.skip(!RUN_DOCKER_SSH, 'Set ORCA_E2E_SSH_DOCKER=1 to run the Docker SSH relay repro')
 
-  test('relay honours the folder-workspace path; a login-profile cd is the only thing that moves it', async ({
+  test('relay honours the folder-workspace path; a login-profile cd is what moves it', async ({
     orcaPage: page
   }, testInfo) => {
     test.setTimeout(420_000)
@@ -122,39 +113,44 @@ test.describe('STA-4746 SSH relay folder workspace cwd', () => {
 
       // Phase A — clean remote login profile. The relay must land in the folder path.
       const clean = await probeWorkspaceTerminal(page, workspaceKey, 'clean-folder')
-      expect(clean).toContain(`pwd=${REMOTE_FOLDER_PATH}`)
-      expect(clean).toContain(`root=${REMOTE_FOLDER_PATH}`)
-      expect(clean).toContain(`wt=${workspaceKey}`)
+      expect(clean.pwd).toBe(REMOTE_FOLDER_PATH)
+      expect(clean.selfcwd).toBe(REMOTE_FOLDER_PATH)
+      expect(clean.root).toBe(REMOTE_FOLDER_PATH)
+      expect(clean.wt).toBe(workspaceKey)
 
-      // Independent signal: the real process cwd on the remote host.
-      const cleanRemoteCwds = execDockerSshRelayTargetControlCommand(
-        target,
-        `for p in $(pgrep -x bash 2>/dev/null); do d=$(readlink /proc/$p/cwd 2>/dev/null); [ -n "$d" ] && echo "$d"; done | sort -u`
-      )
-      console.log(`[sta4746-ssh] remote bash cwds (clean):\n${cleanRemoteCwds}`)
-      expect(cleanRemoteCwds).toContain(REMOTE_FOLDER_PATH)
-
-      // Phase B — the relay spawns POSIX *login* shells, so a remote /etc/profile.d
-      // entry that cd's wins over the spawn cwd. This is the STA-4746 reporter's
-      // exact signature (PWD=<other>, OLDPWD=<workspace>), with no Orca defect.
+      // Phase B — the relay spawns POSIX *login* shells, so a remote
+      // /etc/profile.d entry that cd's wins over the spawn cwd. This is the
+      // STA-4746 reporter's exact signature, with no Orca defect involved.
       execDockerSshRelayTargetControlCommand(
         target,
-        `printf 'cd ${REMOTE_PROFILE_CD_PATH}\\n' > /etc/profile.d/99-sta4746-cd.sh`
+        `printf 'printf "%%s\\\\n" "$PWD" >> ${REMOTE_PRE_CD_LOG}\\ncd ${REMOTE_PROFILE_CD_PATH}\\n' > /etc/profile.d/99-sta4746-cd.sh`
       )
       const profiled = await probeWorkspaceTerminal(page, workspaceKey, 'profile-cd-folder')
-      expect(profiled).toContain(`pwd=${REMOTE_PROFILE_CD_PATH}`)
-      expect(profiled).toContain(`oldpwd=${REMOTE_FOLDER_PATH}`)
-      expect(profiled).toContain(`root=${REMOTE_FOLDER_PATH}`)
+      expect(profiled.pwd).toBe(REMOTE_PROFILE_CD_PATH)
+      expect(profiled.selfcwd).toBe(REMOTE_PROFILE_CD_PATH)
+      expect(profiled.oldpwd).toBe(REMOTE_FOLDER_PATH)
+      expect(profiled.root).toBe(REMOTE_FOLDER_PATH)
+      const folderPreCd = execDockerSshRelayTargetControlCommand(
+        target,
+        `tail -n 1 ${REMOTE_PRE_CD_LOG}`
+      )
+      expect(folderPreCd.trim()).toBe(REMOTE_FOLDER_PATH)
 
-      // Phase C — the same login-profile cd moves a plain git worktree too, so the
-      // symptom is not specific to `folder:<uuid>` workspace ids.
+      // Phase C — the same login-profile cd moves a plain git worktree too, so
+      // the symptom is not specific to `folder:<uuid>` workspace ids.
       const profiledWorktree = await probeWorkspaceTerminal(
         page,
         gitWorktreeKey,
         'profile-cd-worktree'
       )
-      expect(profiledWorktree).toContain(`pwd=${REMOTE_PROFILE_CD_PATH}`)
-      expect(profiledWorktree).toContain(`oldpwd=${DOCKER_SSH_RELAY_REMOTE_REPO_PATH}`)
+      expect(profiledWorktree.pwd).toBe(REMOTE_PROFILE_CD_PATH)
+      expect(profiledWorktree.oldpwd).toBe(DOCKER_SSH_RELAY_REMOTE_REPO_PATH)
+      expect(profiledWorktree.root).toBe('')
+      const worktreePreCd = execDockerSshRelayTargetControlCommand(
+        target,
+        `tail -n 1 ${REMOTE_PRE_CD_LOG}`
+      )
+      expect(worktreePreCd.trim()).toBe(DOCKER_SSH_RELAY_REMOTE_REPO_PATH)
     } finally {
       cleanupDockerSshRelayTarget(target)
     }

--- a/tests/e2e/sta4746-ssh-folder-cwd.spec.ts
+++ b/tests/e2e/sta4746-ssh-folder-cwd.spec.ts
@@ -1,0 +1,162 @@
+import { connectDockerSshRelayTarget } from './helpers/docker-ssh-relay-connection'
+import {
+  cleanupDockerSshRelayTarget,
+  DOCKER_SSH_RELAY_REMOTE_REPO_PATH,
+  execDockerSshRelayTargetControlCommand,
+  startDockerSshRelayTarget,
+  type DockerSshRelayTarget
+} from './helpers/docker-ssh-relay-target'
+import { test, expect } from './helpers/orca-app'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import {
+  focusActiveTerminalInput,
+  getTerminalContent,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager
+} from './helpers/terminal'
+import type { Page } from '@stablyai/playwright-test'
+
+const RUN_DOCKER_SSH = process.env.ORCA_E2E_SSH_DOCKER === '1'
+const REMOTE_FOLDER_PARENT = '/srv/sta4746'
+const REMOTE_FOLDER_PATH = `${REMOTE_FOLDER_PARENT}/workspace`
+const REMOTE_PROFILE_CD_PATH = `${REMOTE_FOLDER_PARENT}/container-init`
+const PROBE = 'STA4746SSH'
+
+async function probeWorkspaceTerminal(
+  page: Page,
+  workspaceKey: string,
+  phase: string
+): Promise<string> {
+  await page.evaluate((key) => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('Store unavailable')
+    }
+    store.getState().setActiveWorktree(key)
+    const tab = store.getState().createTab(key, undefined, undefined, { activate: true })
+    store.getState().setActiveTab(tab.id)
+    store.getState().setActiveTabType('terminal')
+  }, workspaceKey)
+  await ensureTerminalVisible(page, 45_000)
+  await waitForActiveTerminalManager(page, 60_000)
+  await waitForActivePanePtyId(page, 60_000)
+  await focusActiveTerminalInput(page)
+  await page.keyboard.type(
+    `printf '${PROBE} phase=${phase} pwd=%s oldpwd=%s wt=%s root=%s\\n' "$PWD" "$OLDPWD" "$ORCA_WORKTREE_ID" "$ORCA_WORKSPACE_ROOT"`
+  )
+  await page.keyboard.press('Enter')
+  let observed = ''
+  await expect
+    .poll(
+      async () => {
+        const content = await getTerminalContent(page, 12_000)
+        observed =
+          content
+            .split('\n')
+            .toReversed()
+            .find(
+              (line) => line.includes(`${PROBE} phase=${phase} pwd=`) && !line.includes('printf')
+            )
+            ?.trim() ?? ''
+        return observed
+      },
+      { timeout: 90_000, message: `probe line for phase ${phase} never rendered` }
+    )
+    .not.toBe('')
+  console.log(`[sta4746-ssh] ${phase}:`, observed)
+  return observed
+}
+
+test.describe('STA-4746 SSH relay folder workspace cwd', () => {
+  test.skip(!RUN_DOCKER_SSH, 'Set ORCA_E2E_SSH_DOCKER=1 to run the Docker SSH relay repro')
+
+  test('relay honours the folder-workspace path; a login-profile cd is the only thing that moves it', async ({
+    orcaPage: page
+  }, testInfo) => {
+    test.setTimeout(420_000)
+    let target: DockerSshRelayTarget | null = null
+    try {
+      target = startDockerSshRelayTarget(testInfo)
+      execDockerSshRelayTargetControlCommand(
+        target,
+        `mkdir -p ${REMOTE_FOLDER_PATH} ${REMOTE_PROFILE_CD_PATH}`
+      )
+      await waitForSessionReady(page)
+      await waitForActiveWorktree(page)
+      const connected = await connectDockerSshRelayTarget(page, target)
+      const connectionId = connected.targetId
+      const gitWorktreeKey = connected.worktreeId
+
+      const folderWorkspaceId = await page.evaluate(
+        async ({ connectionId, parentPath, folderPath }) => {
+          const group = await window.api.projectGroups.create({
+            name: `sta4746-${Date.now()}`,
+            parentPath,
+            connectionId,
+            createdFrom: 'manual'
+          })
+          const workspace = await window.api.folderWorkspaces.create({
+            projectGroupId: group.id,
+            name: 'sta4746-ws',
+            folderPath,
+            connectionId
+          })
+          return workspace.id as string
+        },
+        { connectionId, parentPath: REMOTE_FOLDER_PARENT, folderPath: REMOTE_FOLDER_PATH }
+      )
+      const workspaceKey = `folder:${folderWorkspaceId}`
+      await expect
+        .poll(
+          async () =>
+            page.evaluate(
+              (id) =>
+                (window.__store?.getState().folderWorkspaces ?? []).some(
+                  (workspace) => workspace.id === id
+                ),
+              folderWorkspaceId
+            ),
+          { timeout: 30_000, message: 'folder workspace never landed in the renderer store' }
+        )
+        .toBe(true)
+
+      // Phase A — clean remote login profile. The relay must land in the folder path.
+      const clean = await probeWorkspaceTerminal(page, workspaceKey, 'clean-folder')
+      expect(clean).toContain(`pwd=${REMOTE_FOLDER_PATH}`)
+      expect(clean).toContain(`root=${REMOTE_FOLDER_PATH}`)
+      expect(clean).toContain(`wt=${workspaceKey}`)
+
+      // Independent signal: the real process cwd on the remote host.
+      const cleanRemoteCwds = execDockerSshRelayTargetControlCommand(
+        target,
+        `for p in $(pgrep -x bash 2>/dev/null); do d=$(readlink /proc/$p/cwd 2>/dev/null); [ -n "$d" ] && echo "$d"; done | sort -u`
+      )
+      console.log(`[sta4746-ssh] remote bash cwds (clean):\n${cleanRemoteCwds}`)
+      expect(cleanRemoteCwds).toContain(REMOTE_FOLDER_PATH)
+
+      // Phase B — the relay spawns POSIX *login* shells, so a remote /etc/profile.d
+      // entry that cd's wins over the spawn cwd. This is the STA-4746 reporter's
+      // exact signature (PWD=<other>, OLDPWD=<workspace>), with no Orca defect.
+      execDockerSshRelayTargetControlCommand(
+        target,
+        `printf 'cd ${REMOTE_PROFILE_CD_PATH}\\n' > /etc/profile.d/99-sta4746-cd.sh`
+      )
+      const profiled = await probeWorkspaceTerminal(page, workspaceKey, 'profile-cd-folder')
+      expect(profiled).toContain(`pwd=${REMOTE_PROFILE_CD_PATH}`)
+      expect(profiled).toContain(`oldpwd=${REMOTE_FOLDER_PATH}`)
+      expect(profiled).toContain(`root=${REMOTE_FOLDER_PATH}`)
+
+      // Phase C — the same login-profile cd moves a plain git worktree too, so the
+      // symptom is not specific to `folder:<uuid>` workspace ids.
+      const profiledWorktree = await probeWorkspaceTerminal(
+        page,
+        gitWorktreeKey,
+        'profile-cd-worktree'
+      )
+      expect(profiledWorktree).toContain(`pwd=${REMOTE_PROFILE_CD_PATH}`)
+      expect(profiledWorktree).toContain(`oldpwd=${DOCKER_SSH_RELAY_REMOTE_REPO_PATH}`)
+    } finally {
+      cleanupDockerSshRelayTarget(target)
+    }
+  })
+})

--- a/tests/e2e/sta4746-ssh-folder-cwd.spec.ts
+++ b/tests/e2e/sta4746-ssh-folder-cwd.spec.ts
@@ -1,5 +1,3 @@
-import type { Page } from '@stablyai/playwright-test'
-
 import { connectDockerSshRelayTarget } from './helpers/docker-ssh-relay-connection'
 import {
   cleanupDockerSshRelayTarget,
@@ -10,62 +8,30 @@ import {
 } from './helpers/docker-ssh-relay-target'
 import { test, expect } from './helpers/orca-app'
 import {
-  readSta4746Probe,
-  sta4746ProbeCommand,
+  closeSta4746Tabs,
+  probeWorkspaceTerminal,
   type Sta4746Probe
 } from './helpers/sta4746-cwd-probe'
-import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
-import {
-  focusActiveTerminalInput,
-  waitForActivePanePtyId,
-  waitForActiveTerminalManager
-} from './helpers/terminal'
+import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
 
 const RUN_DOCKER_SSH = process.env.ORCA_E2E_SSH_DOCKER === '1'
 const REMOTE_FOLDER_PARENT = '/srv/sta4746'
 const REMOTE_FOLDER_PATH = `${REMOTE_FOLDER_PARENT}/workspace`
 const REMOTE_PROFILE_CD_PATH = `${REMOTE_FOLDER_PARENT}/container-init`
 // Why: the profile script records where each login shell *started*, before it
-// cd's. That is independent of OLDPWD, which a test could otherwise inherit.
+// cd's. That is independent of OLDPWD, which could otherwise be inherited.
 const REMOTE_PRE_CD_LOG = `${REMOTE_FOLDER_PARENT}/pre-cd.log`
-
-async function probeWorkspaceTerminal(
-  page: Page,
-  workspaceKey: string,
-  phase: string
-): Promise<Sta4746Probe> {
-  await page.evaluate((key) => {
-    const store = window.__store
-    if (!store) {
-      throw new Error('Store unavailable')
-    }
-    store.getState().setActiveWorktree(key)
-    const tab = store.getState().createTab(key, undefined, undefined, { activate: true })
-    store.getState().setActiveTab(tab.id)
-    store.getState().setActiveTabType('terminal')
-  }, workspaceKey)
-  await ensureTerminalVisible(page, 45_000)
-  await waitForActiveTerminalManager(page, 60_000)
-  const ptyId = await waitForActivePanePtyId(page, 60_000)
-  // Why: a local-provider fallback would satisfy every path assertion below,
-  // because the container paths do not exist on the client. Pin the owner.
-  expect(ptyId, `phase ${phase} did not get an SSH-owned PTY`).toMatch(/^ssh:[^@]+@@/)
-  await focusActiveTerminalInput(page)
-  // `readlink /proc/$$/cwd` is the kernel's answer for this exact shell, so it
-  // is a second signal that cannot agree with $PWD by construction.
-  await page.keyboard.type(sta4746ProbeCommand(phase, { selfcwd: '"$(readlink /proc/$$/cwd)"' }))
-  await page.keyboard.press('Enter')
-  return readSta4746Probe(page, phase)
-}
 
 test.describe('STA-4746 SSH relay folder workspace cwd', () => {
   test.skip(!RUN_DOCKER_SSH, 'Set ORCA_E2E_SSH_DOCKER=1 to run the Docker SSH relay repro')
+  test.skip(process.platform === 'win32', 'Probes and the Docker target are POSIX-only')
 
   test('relay honours the folder-workspace path; a login-profile cd is what moves it', async ({
     orcaPage: page
   }, testInfo) => {
     test.setTimeout(420_000)
     let target: DockerSshRelayTarget | null = null
+    const tabIds: string[] = []
     try {
       target = startDockerSshRelayTarget(testInfo)
       execDockerSshRelayTargetControlCommand(
@@ -77,6 +43,23 @@ test.describe('STA-4746 SSH relay folder workspace cwd', () => {
       const connected = await connectDockerSshRelayTarget(page, target)
       const connectionId = connected.targetId
       const gitWorktreeKey = connected.worktreeId
+      // Why the exact id: `ssh:<anything>@@` would also accept a second target
+      // that happens to expose the same paths.
+      const sshOwner = new RegExp(`^ssh:${connectionId}@@`)
+
+      const probe = async (workspaceKey: string, phase: string): Promise<Sta4746Probe> => {
+        const run = await probeWorkspaceTerminal({
+          page,
+          workspaceKey,
+          phase,
+          expectedPtyOwner: sshOwner,
+          // The kernel's answer for this exact shell — a second signal that
+          // cannot agree with $PWD by construction.
+          extraFields: { selfcwd: '"$(readlink /proc/$$/cwd)"' }
+        })
+        tabIds.push(run.tabId)
+        return run.probe
+      }
 
       const folderWorkspaceId = await page.evaluate(
         async ({ connectionId, parentPath, folderPath }) => {
@@ -112,46 +95,40 @@ test.describe('STA-4746 SSH relay folder workspace cwd', () => {
         .toBe(true)
 
       // Phase A — clean remote login profile. The relay must land in the folder path.
-      const clean = await probeWorkspaceTerminal(page, workspaceKey, 'clean-folder')
+      const clean = await probe(workspaceKey, 'clean-folder')
       expect(clean.pwd).toBe(REMOTE_FOLDER_PATH)
       expect(clean.selfcwd).toBe(REMOTE_FOLDER_PATH)
       expect(clean.root).toBe(REMOTE_FOLDER_PATH)
       expect(clean.wt).toBe(workspaceKey)
 
-      // Phase B — the relay spawns POSIX *login* shells, so a remote
-      // /etc/profile.d entry that cd's wins over the spawn cwd. This is the
-      // STA-4746 reporter's exact signature, with no Orca defect involved.
+      // Phase B — the host's login startup chain runs after the PTY is placed
+      // (zsh gets `-l`; bash's relay wrapper sources /etc/profile itself, see
+      // src/relay/pty-shell-overlay-wrappers.ts). A `cd` there therefore wins,
+      // producing the STA-4746 reporter's signature with no Orca defect.
       execDockerSshRelayTargetControlCommand(
         target,
         `printf 'printf "%%s\\\\n" "$PWD" >> ${REMOTE_PRE_CD_LOG}\\ncd ${REMOTE_PROFILE_CD_PATH}\\n' > /etc/profile.d/99-sta4746-cd.sh`
       )
-      const profiled = await probeWorkspaceTerminal(page, workspaceKey, 'profile-cd-folder')
+      const profiled = await probe(workspaceKey, 'profile-cd-folder')
       expect(profiled.pwd).toBe(REMOTE_PROFILE_CD_PATH)
       expect(profiled.selfcwd).toBe(REMOTE_PROFILE_CD_PATH)
       expect(profiled.oldpwd).toBe(REMOTE_FOLDER_PATH)
       expect(profiled.root).toBe(REMOTE_FOLDER_PATH)
-      const folderPreCd = execDockerSshRelayTargetControlCommand(
-        target,
-        `tail -n 1 ${REMOTE_PRE_CD_LOG}`
-      )
-      expect(folderPreCd.trim()).toBe(REMOTE_FOLDER_PATH)
+      expect(
+        execDockerSshRelayTargetControlCommand(target, `tail -n 1 ${REMOTE_PRE_CD_LOG}`).trim()
+      ).toBe(REMOTE_FOLDER_PATH)
 
       // Phase C — the same login-profile cd moves a plain git worktree too, so
       // the symptom is not specific to `folder:<uuid>` workspace ids.
-      const profiledWorktree = await probeWorkspaceTerminal(
-        page,
-        gitWorktreeKey,
-        'profile-cd-worktree'
-      )
+      const profiledWorktree = await probe(gitWorktreeKey, 'profile-cd-worktree')
       expect(profiledWorktree.pwd).toBe(REMOTE_PROFILE_CD_PATH)
       expect(profiledWorktree.oldpwd).toBe(DOCKER_SSH_RELAY_REMOTE_REPO_PATH)
       expect(profiledWorktree.root).toBe('')
-      const worktreePreCd = execDockerSshRelayTargetControlCommand(
-        target,
-        `tail -n 1 ${REMOTE_PRE_CD_LOG}`
-      )
-      expect(worktreePreCd.trim()).toBe(DOCKER_SSH_RELAY_REMOTE_REPO_PATH)
+      expect(
+        execDockerSshRelayTargetControlCommand(target, `tail -n 1 ${REMOTE_PRE_CD_LOG}`).trim()
+      ).toBe(DOCKER_SSH_RELAY_REMOTE_REPO_PATH)
     } finally {
+      await closeSta4746Tabs(page, tabIds)
       cleanupDockerSshRelayTarget(target)
     }
   })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​609 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​609 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## Summary

**STA-4746 is invalid — on current `main` and on the reported v1.4.184. This PR contains no production change**, only the regression coverage that proves it and guards the contract.

The report claimed that in a paired/remote setup a folder workspace (`ORCA_WORKTREE_ID=folder:<uuid>`) makes the relay spawn its PTY in a fallback cwd, because "relay cwd resolution only consults `ORCA_WORKTREE_ID`, parses it as `repoId::path`, and never falls back to `ORCA_WORKSPACE_ROOT`."

That is not how the relay resolves cwd. `PtyHandler.spawnAfterAdmission` takes cwd from the spawn request (`params.cwd`); `splitWorktreeId(worktreeId)` feeds only the `beginPtyCreation` admission key. The client side already resolves `folder:<uuid>` through `resolveTerminalStartupCwdForWorkspace` → `store.getFolderWorkspace(id).folderPath`.

## What actually produces the reported symptom

On every POSIX relay branch the host's **login** startup chain runs after the PTY is placed, so a remote startup file that `cd`s wins *after* the shell already started in the workspace root. Two mechanisms get there:

- zsh and other POSIX shells launch with `POSIX_LOGIN_ARGS = ['-l']` (`src/relay/pty-shell-launch.ts:12`), so `/etc/profile`, `/etc/profile.d/*` and `~/.zprofile` are sourced.
- bash is normally *wrapped* (`--rcfile`, not `-l`), but the relay's own wrapper explicitly sources `/etc/profile`, then `~/.bash_profile` / `~/.bash_login` / `~/.profile` (`src/relay/pty-shell-overlay-wrappers.ts:63-70`).

That is exactly the reporter's own evidence:

```
OLDPWD=/opt/tiger/workspace          # shell started here
PWD=/opt/tiger/rh2/rh2/init          # then cd'd away
```

`OLDPWD` is only ever set by `cd`. Phase B of the SSH spec reproduces that byte-shape by adding one `/etc/profile.d` entry to the container. Phase C shows the same `cd` moves a plain `repoId::/path` git worktree identically, so this mechanism is not folder-specific. That establishes a non-folder-specific cause for the reported signature; combined with the topology table below finding no folder-specific defect, it is why this closes as invalid.

## Evidence (all on clean `main` @ 1b5cc00870)

| Topology | Result |
|---|---|
| Headed paired desktop server + paired desktop client (primary) | folder PTY lands on host `folderPath`; filesystem marker written into `folderPath`; git-worktree + host-local controls green |
| Headless `orca serve` paired host | `terminal.create(folder:<uuid>)` → `pwd == folderPath` |
| Real Docker SSH relay (`~/.orca-remote/relay-0.1.0+…`) | shell `$PWD` **and** remote `/proc/<pid>/cwd` both == folder path |

## Version oracle

The cwd-resolution logic is behaviourally identical at `v1.4.184`: `src/shared/terminal-startup-cwd.ts` and `src/shared/workspace-scope.ts` differ only by import-path moves (`shared/worktree-id` → `shared/worktree/id`, `shared/types` → `shared/folder-workspace-types`), and `src/relay/pty-handler.ts` still takes cwd from `params.cwd`. Those files carry unrelated changes since the tag — the equivalence claim is about the cwd path, not the whole diff. v1.4.184 also did not send `worktreeId` as a spawn param at all (added later in `ssh-pty-spawn-request.ts` for shell-history isolation), so the relay could not have derived cwd from it there either. Nothing was "already fixed".

Separately, on node-pty's POSIX implementation a nonexistent cwd makes the child exit 1 rather than silently inheriting the parent's cwd (`node_modules/node-pty/src/unix/pty.cc`), ruling out the "fell back to the container's CMD directory" mechanism as well. Windows uses a different spawn path and was not measured.

## Why the proposed fix is not implemented

The proposed `ORCA_WORKSPACE_ROOT` fallback would change nothing for the reporter — cwd is already correct at spawn — and it would make the relay adopt an unvalidated client-supplied path for a request that named no working directory.

`cwd` is optional on the wire (`PtySpawnOptions.cwd`, `src/main/providers/pty-provider-contract.ts:42`), and the relay's default-cwd branch exists for requests that genuinely name none. But every relay-bound caller for a folder workspace resolves a path first via `resolveTerminalStartupCwdForWorkspace`; the one in-repo caller that can omit `cwd` (`codex-detached-pane-restart.ts:210`) is local-only and never reaches the relay. So the fallback has no relay caller to serve, and promoting an env var into it would only widen what the relay trusts.

## Coverage added

- `src/relay/pty-handler-folder-workspace-cwd.test.ts` — 5 deterministic cases: folder id honours request cwd, folder id with **no** `ORCA_WORKSPACE_ROOT`, worktree-id precedence unchanged, **legacy/mixed-version client** (env-only `ORCA_WORKTREE_ID`), and the default-cwd fallback pinned to *not* adopt `ORCA_WORKSPACE_ROOT`.
- `tests/e2e/sta4746-folder-remote-cwd.spec.ts` — headless paired `orca serve` host.
- `tests/e2e/sta4746-paired-desktop-folder-cwd.spec.ts` — headed paired desktop server + client (`@headful`), with git-worktree and local-only controls.
- `tests/e2e/sta4746-ssh-folder-cwd.spec.ts` — real Docker SSH relay, 3 phases (clean / login-profile cd / git-worktree control), gated on `ORCA_E2E_SSH_DOCKER=1` like the sibling docker specs.

**Guard is non-vacuous:** injecting the alleged id-derived cwd into `pty-handler.ts` turns 4 of the 5 relay cases red; reverting the injection returns 5/5 green.

## Commands

```
npx vitest run --config config/vitest.config.ts src/relay/pty-handler-folder-workspace-cwd.test.ts
npx playwright test tests/e2e/sta4746-folder-remote-cwd.spec.ts --config tests/playwright.config.ts --project electron-headless
npx playwright test tests/e2e/sta4746-paired-desktop-folder-cwd.spec.ts --config tests/playwright.config.ts --project electron-headful
ORCA_E2E_SSH_DOCKER=1 npx playwright test tests/e2e/sta4746-ssh-folder-cwd.spec.ts --config tests/playwright.config.ts --project electron-headless
```

## Gaps

CI runs all three specs on Linux runners (the changed-e2e job picked them up and all 3 passed), and the SSH phases were additionally exercised against a Linux container from a macOS host. Windows and WSL hosts were not exercised.

Closes STA-4746 as invalid.

