### PR TITLE
fix(agent-catalog): update outdated Claude Code doc links

### DIFF
--- a/src/renderer/src/lib/agent-catalog.tsx
+++ b/src/renderer/src/lib/agent-catalog.tsx
@@ -48,13 +48,13 @@ export const getAgentCatalog = createLocalizedCatalog((): AgentCatalogEntry[] =>
     id: 'claude',
     label: translate('auto.lib.agent.catalog.0708ed89f1', 'Claude'),
     cmd: 'claude',
-    homepageUrl: 'https://docs.anthropic.com/claude/docs/claude-code'
+    homepageUrl: 'https://code.claude.com/docs'
   },
   {
     id: 'claude-agent-teams',
     label: translate('auto.lib.agent.catalog.bf53f09bf8', 'Claude Agent Teams'),
     cmd: getTuiAgentLaunchCommand(TUI_AGENT_CONFIG['claude-agent-teams'], getCatalogPlatform()),
-    homepageUrl: 'https://code.claude.com/docs/agent-teams'
+    homepageUrl: 'https://code.claude.com/docs/en/agent-teams'
   },
   {
     id: 'openclaude',


### PR DESCRIPTION
## ELI5

Two "learn more" links for Claude agents in the catalog pointed to old doc pages. This updates them to the current ones.

## What Changed

Updated two `homepageUrl` doc links in `src/renderer/src/lib/agent-catalog.tsx`:

- `claude` → `https://code.claude.com/docs` (was the legacy `https://docs.anthropic.com/claude/docs/claude-code`, which now redirects)
- `claude-agent-teams` → `https://code.claude.com/docs/en/agent-teams` (added the missing `/en` locale segment)

## Why

The old URLs redirect or 404, giving users a poor experience when opening agent documentation. These are the current canonical URLs.

## Linked Issue

Fixes #15386

## Visual Proof

N/A — only the target of two external documentation links changed; there is no visual or interaction change in the UI itself.

## Testing

Static string change to two URLs; verified the new URLs resolve to the correct docs pages. No code paths or behavior altered.

- [x] I manually tested these changes locally
- [ ] Automated tests added/updated, or explained why not below — N/A; a doc-URL constant change has no meaningful unit under test.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No impact on Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, backwards compatibility, or performance — the change is limited to two external URL strings.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
