### PR TITLE
fix(tabs): keep an open diff focused while agents stream (STA-4697)

### DIFF
--- a/src/renderer/src/runtime/web-runtime-session.ts
+++ b/src/renderer/src/runtime/web-runtime-session.ts
@@ -527,11 +527,15 @@ export async function createWebRuntimeSessionBrowserTab(args: {
         if (
           state.activeBrowserTabIdByWorktree === previousState.activeBrowserTabIdByWorktree &&
           state.activeFileIdByWorktree === previousState.activeFileIdByWorktree &&
+          // Why: resolveWebSessionVisibleTabId now reads group state, so a group-only focus move
+          // must re-evaluate it.
+          state.activeGroupIdByWorktree === previousState.activeGroupIdByWorktree &&
           state.activeTabIdByWorktree === previousState.activeTabIdByWorktree &&
           state.activeTabType === previousState.activeTabType &&
           state.activeTabTypeByWorktree === previousState.activeTabTypeByWorktree &&
           state.activeWorktreeId === previousState.activeWorktreeId &&
           state.activeWorkspaceExecutionHostId === previousState.activeWorkspaceExecutionHostId &&
+          state.groupsByWorktree === previousState.groupsByWorktree &&
           state.unifiedTabsByWorktree === previousState.unifiedTabsByWorktree
         ) {
           return

--- a/src/renderer/src/runtime/web-session-focus-intent-visible-tab.test.ts
+++ b/src/renderer/src/runtime/web-session-focus-intent-visible-tab.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from 'vitest'
+import { resolveWebSessionVisibleTabId } from './web-session-focus-intent'
+import {
+  toVisibleTabType,
+  type Tab,
+  type TabContentType,
+  type TabGroup
+} from '../../../shared/tab-types'
+import { makeState, WT } from './web-session-tabs-sync-test-harness'
+
+const GROUP_A = 'group-a'
+const GROUP_B = 'group-b'
+
+function tab(overrides: Partial<Tab> & Pick<Tab, 'id' | 'entityId' | 'contentType'>): Tab {
+  return {
+    groupId: GROUP_A,
+    worktreeId: WT,
+    label: overrides.id,
+    sortOrder: 0,
+    ...overrides
+  } as Tab
+}
+
+function group(overrides: Partial<TabGroup> & Pick<TabGroup, 'id'>): TabGroup {
+  return {
+    worktreeId: WT,
+    activeTabId: null,
+    tabOrder: [],
+    ...overrides
+  }
+}
+
+describe('resolveWebSessionVisibleTabId — grouped state is authoritative', () => {
+  // Why: the bug. Diff tabs carry contentType 'diff' while the coarse address says 'editor'.
+  it.each<TabContentType>(['diff', 'conflict-review', 'check-details'])(
+    'resolves a focused %s tab instead of returning null',
+    (contentType) => {
+      const visible = tab({ id: 'tab-1', entityId: 'file-1', contentType })
+      const state = makeState({
+        unifiedTabsByWorktree: { [WT]: [visible] },
+        groupsByWorktree: {
+          [WT]: [group({ id: GROUP_A, activeTabId: 'tab-1', tabOrder: ['tab-1'] })]
+        },
+        activeGroupIdByWorktree: { [WT]: GROUP_A },
+        activeTabType: 'editor',
+        activeTabTypeByWorktree: { [WT]: 'editor' },
+        activeFileIdByWorktree: { [WT]: 'file-1' }
+      })
+
+      expect(resolveWebSessionVisibleTabId(state, WT)).toBe('tab-1')
+    }
+  )
+
+  it('returns the group active tab, not the tab the stale coarse address names', () => {
+    const shown = tab({ id: 'tab-shown', entityId: 'file-shown', contentType: 'editor' })
+    const stale = tab({ id: 'tab-stale', entityId: 'file-stale', contentType: 'editor' })
+    const state = makeState({
+      unifiedTabsByWorktree: { [WT]: [stale, shown] },
+      groupsByWorktree: {
+        [WT]: [
+          group({ id: GROUP_A, activeTabId: 'tab-shown', tabOrder: ['tab-stale', 'tab-shown'] })
+        ]
+      },
+      activeGroupIdByWorktree: { [WT]: GROUP_A },
+      activeTabType: 'editor',
+      activeTabTypeByWorktree: { [WT]: 'editor' },
+      // Why: activateTab writes group state only, so the legacy address lags behind.
+      activeFileIdByWorktree: { [WT]: 'file-stale' }
+    })
+
+    expect(resolveWebSessionVisibleTabId(state, WT)).toBe('tab-shown')
+  })
+
+  // Why: copyUnifiedTabToGroup duplicates contentType + entityId into another group, so a plain
+  // array scan can return the background copy and drag group focus to it.
+  it('prefers the active group copy when one entity exists in two split groups', () => {
+    const background = tab({
+      id: 'tab-bg',
+      entityId: 'file-1',
+      contentType: 'diff',
+      groupId: GROUP_A
+    })
+    const focused = tab({ id: 'tab-fg', entityId: 'file-1', contentType: 'diff', groupId: GROUP_B })
+    const state = makeState({
+      // Why: background copy first — array order must not decide.
+      unifiedTabsByWorktree: { [WT]: [background, focused] },
+      groupsByWorktree: {
+        [WT]: [
+          group({ id: GROUP_A, activeTabId: 'tab-bg', tabOrder: ['tab-bg'] }),
+          group({ id: GROUP_B, activeTabId: 'tab-fg', tabOrder: ['tab-fg'] })
+        ]
+      },
+      activeGroupIdByWorktree: { [WT]: GROUP_B },
+      activeTabType: 'editor',
+      activeTabTypeByWorktree: { [WT]: 'editor' },
+      activeFileIdByWorktree: { [WT]: 'file-1' }
+    })
+
+    expect(resolveWebSessionVisibleTabId(state, WT)).toBe('tab-fg')
+  })
+
+  // Why: a focused empty split must not resolve into some other group. This pins the contract
+  // only — it does NOT claim empty-split focus survives reconciliation (see plan scope boundary).
+  it('returns null for a focused empty split rather than a background tab', () => {
+    const background = tab({
+      id: 'tab-bg',
+      entityId: 'file-1',
+      contentType: 'editor',
+      groupId: GROUP_A
+    })
+    const state = makeState({
+      unifiedTabsByWorktree: { [WT]: [background] },
+      groupsByWorktree: {
+        [WT]: [
+          group({ id: GROUP_A, activeTabId: 'tab-bg', tabOrder: ['tab-bg'] }),
+          group({ id: GROUP_B, activeTabId: null, tabOrder: [] })
+        ]
+      },
+      activeGroupIdByWorktree: { [WT]: GROUP_B },
+      // Why: plain 'editor' — a diff here would already return null pre-fix, making this vacuous.
+      activeTabType: 'editor',
+      activeTabTypeByWorktree: { [WT]: 'editor' },
+      activeFileIdByWorktree: { [WT]: 'file-1' }
+    })
+
+    expect(resolveWebSessionVisibleTabId(state, WT)).toBeNull()
+  })
+
+  it('ignores a tab whose groupId disagrees with the active group', () => {
+    const mismatched = tab({
+      id: 'tab-1',
+      entityId: 'file-1',
+      contentType: 'diff',
+      groupId: GROUP_B
+    })
+    const state = makeState({
+      unifiedTabsByWorktree: { [WT]: [mismatched] },
+      groupsByWorktree: {
+        [WT]: [group({ id: GROUP_A, activeTabId: 'tab-1', tabOrder: ['tab-1'] })]
+      },
+      activeGroupIdByWorktree: { [WT]: GROUP_A }
+    })
+
+    expect(resolveWebSessionVisibleTabId(state, WT)).toBeNull()
+  })
+
+  // Why: reconcile replaces a local tab with a mirrored one under a new id; focus must follow the
+  // entity instead of being dropped (which would hand activation to the snapshot).
+  it('follows the entity when the visible tab is rematerialized under a new id', () => {
+    const local = tab({ id: 'local-editor', entityId: '/repo/index.html', contentType: 'editor' })
+    const mirrored = tab({ id: 'host-editor', entityId: '/repo/index.html', contentType: 'editor' })
+    const state = makeState({
+      unifiedTabsByWorktree: { [WT]: [local] },
+      groupsByWorktree: {
+        [WT]: [group({ id: GROUP_A, activeTabId: 'local-editor', tabOrder: ['local-editor'] })]
+      },
+      activeGroupIdByWorktree: { [WT]: GROUP_A }
+    })
+
+    // Why: the post-materialization tab set no longer contains the local id.
+    expect(resolveWebSessionVisibleTabId(state, WT, [mirrored])).toBe('host-editor')
+  })
+
+  it('does not follow a rematerialized entity into a different group', () => {
+    const local = tab({ id: 'local-editor', entityId: '/repo/index.html', contentType: 'editor' })
+    const elsewhere = tab({
+      id: 'host-editor',
+      entityId: '/repo/index.html',
+      contentType: 'editor',
+      groupId: GROUP_B
+    })
+    const state = makeState({
+      unifiedTabsByWorktree: { [WT]: [local] },
+      groupsByWorktree: {
+        [WT]: [group({ id: GROUP_A, activeTabId: 'local-editor', tabOrder: ['local-editor'] })]
+      },
+      activeGroupIdByWorktree: { [WT]: GROUP_A }
+    })
+
+    expect(resolveWebSessionVisibleTabId(state, WT, [elsewhere])).toBeNull()
+  })
+
+  it('falls back to the first group when the active group id is stale', () => {
+    const visible = tab({ id: 'tab-1', entityId: 'file-1', contentType: 'diff' })
+    const state = makeState({
+      unifiedTabsByWorktree: { [WT]: [visible] },
+      groupsByWorktree: {
+        [WT]: [group({ id: GROUP_A, activeTabId: 'tab-1', tabOrder: ['tab-1'] })]
+      },
+      activeGroupIdByWorktree: { [WT]: 'group-that-no-longer-exists' }
+    })
+
+    expect(resolveWebSessionVisibleTabId(state, WT)).toBe('tab-1')
+  })
+})
+
+describe('resolveWebSessionVisibleTabId — no-group compatibility path', () => {
+  it('resolves a diff through the projection when there are no group records', () => {
+    const visible = tab({ id: 'tab-1', entityId: 'file-1', contentType: 'diff' })
+    const state = makeState({
+      unifiedTabsByWorktree: { [WT]: [visible] },
+      groupsByWorktree: {},
+      activeTabType: 'editor',
+      activeTabTypeByWorktree: { [WT]: 'editor' },
+      activeFileIdByWorktree: { [WT]: 'file-1' }
+    })
+
+    expect(resolveWebSessionVisibleTabId(state, WT)).toBe('tab-1')
+  })
+
+  it('keeps remembered-terminal behaviour when there are no group records', () => {
+    const terminal = tab({ id: 'term-1', entityId: 'term-1', contentType: 'terminal' })
+    const state = makeState({
+      unifiedTabsByWorktree: { [WT]: [terminal] },
+      groupsByWorktree: {},
+      activeTabType: 'terminal',
+      activeTabTypeByWorktree: { [WT]: 'terminal' },
+      activeTabIdByWorktree: { [WT]: 'term-1' }
+    })
+
+    expect(resolveWebSessionVisibleTabId(state, WT)).toBe('term-1')
+  })
+
+  it('does not match a browser tab against an editor coarse address', () => {
+    const browser = tab({ id: 'tab-1', entityId: 'ws-1', contentType: 'browser' })
+    const state = makeState({
+      unifiedTabsByWorktree: { [WT]: [browser] },
+      groupsByWorktree: {},
+      activeTabType: 'editor',
+      activeTabTypeByWorktree: { [WT]: 'editor' },
+      activeFileIdByWorktree: { [WT]: 'ws-1' }
+    })
+
+    expect(resolveWebSessionVisibleTabId(state, WT)).toBeNull()
+  })
+})
+
+describe('toVisibleTabType', () => {
+  it('collapses every editor-family kind and preserves the rest', () => {
+    expect(toVisibleTabType('editor')).toBe('editor')
+    expect(toVisibleTabType('diff')).toBe('editor')
+    expect(toVisibleTabType('conflict-review')).toBe('editor')
+    expect(toVisibleTabType('check-details')).toBe('editor')
+    expect(toVisibleTabType('terminal')).toBe('terminal')
+    expect(toVisibleTabType('browser')).toBe('browser')
+    expect(toVisibleTabType('simulator')).toBe('simulator')
+  })
+})

--- a/src/renderer/src/runtime/web-session-focus-intent.ts
+++ b/src/renderer/src/runtime/web-session-focus-intent.ts
@@ -10,6 +10,7 @@
 // snapshots, unlike a transient per-snapshot flag).
 
 import { webSessionIntentOwnerKey, type WebSessionIntentOwner } from './web-session-intent-owner'
+import { toVisibleTabType } from '../../../shared/tab-types'
 import type { AppState } from '../store/types'
 
 export type WebSessionFocusIntent = {
@@ -24,10 +25,12 @@ type WebSessionVisibleTabState = Pick<
   AppState,
   | 'activeBrowserTabIdByWorktree'
   | 'activeFileIdByWorktree'
+  | 'activeGroupIdByWorktree'
   | 'activeTabIdByWorktree'
   | 'activeTabType'
   | 'activeTabTypeByWorktree'
   | 'activeWorktreeId'
+  | 'groupsByWorktree'
   | 'unifiedTabsByWorktree'
 >
 
@@ -36,6 +39,42 @@ export function resolveWebSessionVisibleTabId(
   worktreeId: string,
   tabs = state.unifiedTabsByWorktree?.[worktreeId] ?? []
 ): string | null {
+  // Why: the coarse (activeTabType, entityId) address inverts a many-to-one projection and cannot
+  // tell editor-family kinds apart; group state is what is actually on screen.
+  const groups = state.groupsByWorktree?.[worktreeId] ?? []
+  if (groups.length > 0) {
+    const activeGroupId = state.activeGroupIdByWorktree?.[worktreeId] ?? null
+    const activeGroup =
+      (activeGroupId ? groups.find((group) => group.id === activeGroupId) : null) ?? groups[0]
+    // Why: authoritative that nothing is visible too — never resolve into an unfocused group.
+    if (activeGroup?.activeTabId == null) {
+      return null
+    }
+    const activeTabId = activeGroup.activeTabId
+    const direct = tabs.find((tab) => tab.id === activeTabId && tab.groupId === activeGroup.id)
+    if (direct) {
+      return direct.id
+    }
+    // Why: reconcile can rematerialize the visible tab under a new id (local -> mirrored), so
+    // follow its entity rather than dropping focus. Stays inside the group to avoid a pane jump.
+    const previous = (state.unifiedTabsByWorktree?.[worktreeId] ?? []).find(
+      (tab) => tab.id === activeTabId
+    )
+    if (!previous) {
+      return null
+    }
+    const previousType = toVisibleTabType(previous.contentType)
+    return (
+      tabs.find(
+        (tab) =>
+          tab.groupId === activeGroup.id &&
+          tab.entityId === previous.entityId &&
+          toVisibleTabType(tab.contentType) === previousType
+      )?.id ?? null
+    )
+  }
+
+  // Why: no group records at all (fresh slice, or first remote reconcile before groups exist).
   const currentType =
     state.activeTabTypeByWorktree?.[worktreeId] ??
     (state.activeWorktreeId === worktreeId ? state.activeTabType : null)
@@ -50,7 +89,9 @@ export function resolveWebSessionVisibleTabId(
         ? state.activeFileIdByWorktree?.[worktreeId]
         : null
   return (
-    tabs.find((tab) => tab.contentType === currentType && tab.entityId === entityId)?.id ?? null
+    tabs.find(
+      (tab) => toVisibleTabType(tab.contentType) === currentType && tab.entityId === entityId
+    )?.id ?? null
   )
 }
 

--- a/src/renderer/src/runtime/web-session-tabs-sync-diff-focus-steal.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync-diff-focus-steal.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { toWebTerminalSurfaceTabId } from '../../../shared/terminal-surface-id'
+import type { Tab } from '../../../shared/tab-types'
+import { applyWebSessionTabsSnapshot, type WebSessionTabsSyncState } from './web-session-tabs-sync'
+import {
+  ENV,
+  LEAF_ID,
+  NOW,
+  WT,
+  makeSnapshot,
+  makeState,
+  resetWebSessionTabsSyncTestState
+} from './web-session-tabs-sync-test-harness'
+
+vi.mock('../store', () => ({
+  useAppStore: {
+    setState: vi.fn()
+  }
+}))
+
+const HOST_GROUP = 'host-group-1'
+const DIFF_TAB_ID = 'local-diff-tab'
+const DIFF_FILE_ID = `${WT}::diff::unstaged::src/example.ts`
+
+function diffTab(): Tab {
+  return {
+    id: DIFF_TAB_ID,
+    entityId: DIFF_FILE_ID,
+    groupId: HOST_GROUP,
+    worktreeId: WT,
+    contentType: 'diff',
+    label: 'example.ts',
+    customLabel: null,
+    color: null,
+    sortOrder: 1,
+    createdAt: NOW,
+    isPreview: false,
+    isPinned: false
+  }
+}
+
+function mirroredTerminalTab(terminalTabId: string): Tab {
+  return {
+    id: terminalTabId,
+    entityId: terminalTabId,
+    groupId: HOST_GROUP,
+    worktreeId: WT,
+    contentType: 'terminal',
+    label: 'codex [working]',
+    customLabel: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: NOW,
+    isPreview: false,
+    isPinned: false
+  }
+}
+
+// Why: STA-4697. An agent status echo republishes the snapshot every turn; the diff tab must
+// keep activation instead of falling through to the mirrored terminal.
+describe('applyWebSessionTabsSnapshot — diff tab focus', () => {
+  beforeEach(resetWebSessionTabsSyncTestState)
+
+  it('does not let a terminal status echo steal activation from an open diff', () => {
+    const terminalTabId = toWebTerminalSurfaceTabId('host-tab-1')
+    const state = makeState({
+      activeTabType: 'editor',
+      activeTabTypeByWorktree: { [WT]: 'editor' },
+      activeFileId: DIFF_FILE_ID,
+      activeFileIdByWorktree: { [WT]: DIFF_FILE_ID },
+      tabsByWorktree: {
+        [WT]: [
+          {
+            id: terminalTabId,
+            ptyId: 'remote:web-env-1@@terminal-1',
+            worktreeId: WT,
+            title: 'codex [working]',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: NOW
+          }
+        ]
+      },
+      unifiedTabsByWorktree: { [WT]: [mirroredTerminalTab(terminalTabId), diffTab()] },
+      tabBarOrderByWorktree: { [WT]: [terminalTabId, DIFF_TAB_ID] },
+      groupsByWorktree: {
+        [WT]: [
+          {
+            id: HOST_GROUP,
+            worktreeId: WT,
+            // Why: the diff is what the user is looking at.
+            activeTabId: DIFF_TAB_ID,
+            // Why: the mirrored terminal must share the group, or the membership guard in the
+            // group writers masks the steal and this test passes pre-fix.
+            tabOrder: [terminalTabId, DIFF_TAB_ID],
+            recentTabIds: [terminalTabId, DIFF_TAB_ID]
+          }
+        ]
+      },
+      activeGroupIdByWorktree: { [WT]: HOST_GROUP }
+    })
+
+    const statusEcho = makeSnapshot(
+      [
+        {
+          type: 'terminal',
+          id: `host-tab-1::${LEAF_ID}`,
+          title: 'codex [thinking]',
+          parentTabId: 'host-tab-1',
+          leafId: LEAF_ID,
+          isActive: true,
+          status: 'ready',
+          terminal: 'terminal-1'
+        }
+      ],
+      {
+        activeTabId: `host-tab-1::${LEAF_ID}`,
+        activeTabType: 'terminal',
+        tabGroups: [{ id: HOST_GROUP, activeTabId: 'host-tab-1', tabOrder: ['host-tab-1'] }]
+      }
+    )
+
+    const patch = applyWebSessionTabsSnapshot(
+      state,
+      statusEcho,
+      ENV,
+      NOW + 10
+    ) as Partial<WebSessionTabsSyncState>
+
+    const nextGroups = patch.groupsByWorktree?.[WT] ?? state.groupsByWorktree[WT]
+    const activeGroupId = patch.activeGroupIdByWorktree?.[WT] ?? state.activeGroupIdByWorktree[WT]
+    const nextTabs = patch.unifiedTabsByWorktree?.[WT] ?? state.unifiedTabsByWorktree[WT]
+
+    expect(nextGroups?.find((group) => group.id === HOST_GROUP)?.activeTabId).toBe(DIFF_TAB_ID)
+    expect(activeGroupId).toBe(HOST_GROUP)
+    // Why: the reported symptom left the tab present but deactivated.
+    expect(nextTabs?.some((tab) => tab.id === DIFF_TAB_ID)).toBe(true)
+  })
+})

--- a/src/renderer/src/store/slices/tabs.ts
+++ b/src/renderer/src/store/slices/tabs.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines -- Why: split-tab group state updates layout, focus, and tab membership atomically in one slice to avoid split-brain. */
 import type { StateCreator } from 'zustand'
 import type { AppState } from '../types'
+import { toVisibleTabType } from '../../../../shared/tab-types'
 import type {
   Tab,
   TabContentType,
@@ -413,13 +414,6 @@ function collapseGroupLayout(
       [worktreeId]: siblingId ?? fallbackGroupId ?? activeGroupIdByWorktree[worktreeId]
     }
   }
-}
-
-function toVisibleTabType(contentType: TabContentType): WorkspaceVisibleTabType {
-  if (contentType === 'browser' || contentType === 'terminal' || contentType === 'simulator') {
-    return contentType
-  }
-  return 'editor'
 }
 
 function deriveActiveSurfaceForWorktree(

--- a/src/renderer/src/store/slices/worktrees/listing/worktree-catalog-visibility.ts
+++ b/src/renderer/src/store/slices/worktrees/listing/worktree-catalog-visibility.ts
@@ -1,5 +1,4 @@
 import { catalogRowsEqual } from '../../worktree-catalog-reconciliation'
-import type { WorkspaceVisibleTabType } from '../../../../../../shared/tab-types'
 import type { DetectedWorktreeListResult, Worktree } from '../../../../../../shared/worktree/types'
 
 export function areWorktreesEqual(current: Worktree[] | undefined, next: Worktree[]): boolean {
@@ -17,13 +16,6 @@ export function areDetectedWorktreeResultsEqual(
     current.source === next.source &&
     catalogRowsEqual(current.worktrees, next.worktrees)
   )
-}
-
-export function toVisibleTabType(contentType: string): WorkspaceVisibleTabType {
-  if (contentType === 'browser' || contentType === 'terminal' || contentType === 'simulator') {
-    return contentType
-  }
-  return 'editor'
 }
 
 export function toVisibleWorktree(

--- a/src/renderer/src/store/slices/worktrees/session/active-worktree-surface.ts
+++ b/src/renderer/src/store/slices/worktrees/session/active-worktree-surface.ts
@@ -1,6 +1,6 @@
 import type { AppState } from '../../../types'
 import type { WorkspaceVisibleTabType } from '../../../../../../shared/tab-types'
-import { toVisibleTabType } from '../listing/worktree-catalog-visibility'
+import { toVisibleTabType } from '../../../../../../shared/tab-types'
 
 export function resolveActivatedWorktreeSurface(
   s: AppState,

--- a/src/shared/tab-types.ts
+++ b/src/shared/tab-types.ts
@@ -27,6 +27,15 @@ export type TabContentType =
 export type WorkspaceVisibleTabType = 'terminal' | 'editor' | 'browser' | 'simulator'
 export type CtrlTabOrderMode = 'mru' | 'sequential'
 
+// Why: many-to-one — every editor-family kind collapses to 'editor'. Never invert it by equality;
+// resolve the concrete tab and project forward instead.
+export function toVisibleTabType(contentType: TabContentType): WorkspaceVisibleTabType {
+  if (contentType === 'browser' || contentType === 'terminal' || contentType === 'simulator') {
+    return contentType
+  }
+  return 'editor'
+}
+
 export type Tab = {
   id: string // UUID for terminals, filePath for editors (preserves current convention)
   entityId: string // ID of the backing content (terminal tab ID, file path, browser workspace ID)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​388 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​388 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​57 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​40 |

<!-- /orca-pr-loc -->

## ELI5

Open a diff while an agent is running and the diff would flash up, then the app would jump back to the terminal. The diff tab stayed in the tab bar, just not selected — so clicking more files piled up dead tabs.

The code that decides "which tab is the user looking at?" was asking the wrong question. It only knew a coarse answer — "an editor" — and then went hunting for a tab whose type was literally `editor`. A diff tab's type is `diff`, so the hunt always failed, and "I found nothing" is the same signal the reconciler uses for "nothing to preserve, go ahead and pick a terminal."

Now it just asks the tab groups what is on screen, which is the thing that actually knows.

## What Changed

`resolveWebSessionVisibleTabId` no longer inverts the coarse address. When group records exist:

1. Resolve the active group (`activeGroupIdByWorktree`, else `groups[0]` — the existing recovery in `deriveActiveSurfaceForWorktree`)
2. A focused **empty** group returns `null` — authoritative that nothing is visible, rather than resolving into some other group
3. Otherwise the group's `activeTabId`, validated with `tab.groupId === activeGroup.id`
4. If that id is gone, follow the **entity within the same group** — reconcile rematerializes local tabs as mirrored ones under new ids
5. The coarse address is consulted only when there are **zero** group records, and now projects through `toVisibleTabType` instead of comparing exactly

Two supporting changes:

- `web-runtime-session.ts` — the browser-create focus guard's change filter now observes `groupsByWorktree` / `activeGroupIdByWorktree`, which the resolver newly reads. Without this a group-only focus move returns early and never re-evaluates.
- First commit moves the canonical `toVisibleTabType` beside the two unions it maps between and drops the two copies already identical to it.

## Why

`toVisibleTabType` is many-to-one: `editor | diff | conflict-review | check-details` all collapse to `'editor'`, and `activeTabType` is produced by it. Inverting that by equality is wrong in principle — `'diff'` is just the instance that bit. Fixing only the comparison would leave the inversion in place, so the resolver now works forward from concrete group state.

That also makes it immune to a real drift: `activateTab` writes group state only, while `setActiveFile` / `setActiveTabType` write the legacy records separately, so the two disagree transiently in ordinary flows.

**Pre-existing, not a regression.** The guard was introduced 2026-06-15 by #5435 (`413fb31ab5`) matching `contentType === 'editor'` — blind to diff tabs from day one, which is a little ironic given #5435 is the focus-steal fix this guard's comment cites. #13876 (`70ad65fc94`, 08-12) hoisted it and preserved the blindness. Present in `v1.4.184`. No cherry-pick: the 08-15 release shipped as v1.4.183 with v1.4.184 on top, and no release-prep branch or RC is in flight.

**Reachability.** On `main` the reducer is reached only via `refreshWebRuntimeSessionTabsSnapshot`, gated on a bound `activeRuntimeEnvironmentId` — so remote / SSH / paired / headless-serve workspaces can hit this on shipped builds. The report came from an adhoc build of a side branch that adds a second, ungated caller, which is why it reproduced on a plain local workspace there.

## Deliberately not in this PR

- **Focused empty splits.** Broken today (the resolver returns a background group's tab and reconciliation follows it) and still broken after (it returns `null` and a terminal wins). Preserving them needs a tagged focus result, both callers, and group/layout preservation in the reconciler's group rebuild — an unreserved empty client group is discarded during rebuild regardless of what the resolver returns.
- **Simulator coarse type.** Simulators get strictly better here — the tab is no longer stolen — but `activeTabType` still reports `'terminal'` on a terminal echo, exactly as today, because `currentVisibleTabTypeStillValid` has no simulator branch. Fixing that goes with unifying the third `toVisibleTabType` copy.

## Linked Issue

STA-4697

## Visual Proof

`N/A` — reproducing the symptom live needs a bound runtime environment plus agents actively streaming, which does not survive a screenshot. The behavior is pinned by an end-to-end test instead: against the pre-fix resolver it fails with `expected 'web-terminal-host-tab-1' to be 'local-diff-tab'`, which is precisely the reported symptom (diff replaced by the terminal, tab retained).

## Testing

macOS.

- `vitest run --config config/vitest.config.ts src/renderer/src/runtime src/renderer/src/store/slices` — **374 files, 3473 tests passed.**
- **Red-before-green, measured, not assumed:** reverted the resolver body and re-ran. **8 of 12** new unit tests go red; the 4 that stay green are property tests and are labeled as such in the file rather than counted as regression coverage. The end-to-end test fails pre-fix with the assertion quoted above.
- `pnpm typecheck` — exit 0, and **proven live**: injecting `const x: number = "s"` produced `TS2322`, then reverted. This repo prints nothing on success, so a silent pass is otherwise indistinguishable from a dead gate.
- `oxfmt --check` — clean, echoed 8 files so the list actually arrived.
- `pnpm lint` — exit 0.

The full-suite run earned its keep: it caught a regression that static review missed. When a local editor tab is rematerialized as a mirrored tab under a new id, the group's pre-reconcile `activeTabId` no longer resolves, so focus was dropped and the snapshot took over — breaking `does not let stale browser intent override a newer editor selection`. Step 4 above fixes it, pinned by two tests (follows the entity; does *not* follow it across groups).

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

- **Cross-platform**: no platform-conditional code; entity and worktree ids are opaque strings here.
- **Remote SSH**: this *is* the remote path. No RPC param, stream opcode, or published-content change — purely client-side reconciliation, so no wire-compatibility work is required.
- **Folder workspaces**: keyed by the same generic `worktreeId` throughout.
- **Backwards compatibility**: no persisted-state or schema change. The no-group path preserves today's behavior for fresh slices and the first remote reconcile.
- **Performance**: strictly less work in the common case — a group lookup and one `find` instead of scanning for a type/entity match.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @BrennanKB5
