### PR TITLE
test(terminal): pin the two conditions that keep macOS period substitution out

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-ime-forwarder-space-claim.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-forwarder-space-claim.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment happy-dom
+/**
+ * Pins the two properties that keep #11504 from firing, because neither is a decision anyone
+ * made and both are one refactor away from being undone.
+ *
+ * macOS rewrites a double space into ". " and hands the period to the pty. Orca is not immune to
+ * that - a plain Chromium textarea in the Electron version this repo pins does substitute, and
+ * `spellcheck="false"` does not prevent it. What prevents it is that the forwarder claims a plain
+ * space keydown and then empties the helper textarea, so the text system never sees the preceding
+ * word the rule keys on.
+ *
+ * Both halves are needed. Before 01bcc8dca24 the claim predicate excluded space, letters and
+ * digits, the field accumulated, and the substitution fired on real hardware. That commit widened
+ * the predicate for unrelated reasons - IME commit survival and kitty encoding - and suppressed
+ * this as a side effect it never mentions.
+ *
+ * So this file does not test the substitution, which cannot be produced in a unit environment. It
+ * tests the two conditions measured to suppress it, so narrowing either one fails here rather
+ * than in a Korean user's shell.
+ */
+import { Terminal } from '@xterm/xterm'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { installTerminalImeNativeTextForwarder } from './terminal-ime-native-text-forwarder'
+
+function open() {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const terminal = new Terminal()
+  terminal.open(container)
+  const textarea = terminal.textarea!
+  const forwarder = installTerminalImeNativeTextForwarder({
+    terminalElement: terminal.element,
+    isComposing: () => false,
+    sendInput: (data) => terminal.input(data),
+    getKittyKeyboardFlags: () => 0
+  })
+  // Wired the way the pane lifecycle wires it: a claimed key must not also reach xterm's encoder.
+  terminal.attachCustomKeyEventHandler((event) => !forwarder.claimKeyEvent(event))
+  const emitted: string[] = []
+  terminal.onData((d) => emitted.push(d))
+  return { emitted, terminal, textarea, forwarder, container }
+}
+
+function makeKeydown(init: {
+  key: string
+  code: string
+  keyCode: number
+  ctrlKey?: boolean
+}): KeyboardEvent {
+  return new KeyboardEvent('keydown', { ...init, bubbles: true, cancelable: true })
+}
+
+function keydown(
+  textarea: HTMLTextAreaElement,
+  init: { key: string; code: string; keyCode: number }
+) {
+  const event = makeKeydown(init)
+  textarea.dispatchEvent(event)
+  return event
+}
+
+function commit(textarea: HTMLTextAreaElement, data: string) {
+  textarea.value += data
+  textarea.dispatchEvent(new InputEvent('input', { data, inputType: 'insertText', bubbles: true }))
+}
+
+describe('#11504 suppression rests on claiming space and emptying the field', () => {
+  let panes: ReturnType<typeof open>[] = []
+
+  beforeEach(() => {
+    panes = []
+    // Why: happy-dom has no canvas, and the renderer measures text on open().
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      measureText: () => ({ width: 10 })
+    } as unknown as CanvasRenderingContext2D)
+  })
+
+  afterEach(() => {
+    for (const pane of panes) {
+      pane.forwarder.dispose()
+      pane.terminal.dispose()
+      pane.container.remove()
+    }
+    vi.restoreAllMocks()
+    document.body.replaceChildren()
+  })
+
+  function pane() {
+    const created = open()
+    panes.push(created)
+    return created
+  }
+
+  // Why space specifically: it is the character the substitution rule triggers on, and it is the
+  // one the pre-01bcc8dca24 predicate explicitly excluded.
+  it('claims a plain space keydown', () => {
+    const p = pane()
+    expect(p.forwarder.claimKeyEvent(makeKeydown({ key: ' ', code: 'Space', keyCode: 32 }))).toBe(
+      true
+    )
+  })
+
+  it('claims a plain letter keydown', () => {
+    const p = pane()
+    expect(p.forwarder.claimKeyEvent(makeKeydown({ key: 'a', code: 'KeyA', keyCode: 65 }))).toBe(
+      true
+    )
+  })
+
+  // The second half: a claimed key must leave the field empty, or the text system reads a word
+  // before the space and substitutes.
+  it('leaves the helper textarea empty after a claimed commit, so no word precedes the space', () => {
+    const p = pane()
+    keydown(p.textarea, { key: 'a', code: 'KeyA', keyCode: 65 })
+    commit(p.textarea, 'a')
+    keydown(p.textarea, { key: 'b', code: 'KeyB', keyCode: 66 })
+    commit(p.textarea, 'b')
+    keydown(p.textarea, { key: ' ', code: 'Space', keyCode: 32 })
+    commit(p.textarea, ' ')
+
+    expect(p.emitted.join('')).toBe('ab ')
+    expect(p.textarea.value).toBe('')
+  })
+
+  // A control chord is deliberately not claimed - that path belongs to xterm's encoder - so this
+  // asserts the exclusions that exist on purpose still hold.
+  it('does not claim a control chord', () => {
+    const p = pane()
+    expect(
+      p.forwarder.claimKeyEvent(makeKeydown({ key: 'c', code: 'KeyC', keyCode: 67, ctrlKey: true }))
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-ime-native-text-forwarder.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-native-text-forwarder.ts
@@ -110,6 +110,12 @@ function isNativeTextKeydown(event: ImeNativeTextKeyEvent, compositionActive: bo
     !event.ctrlKey &&
     !event.altKey &&
     !event.metaKey &&
+    // Space and letters must stay eligible. Claiming them is what blanks the helper textarea
+    // before macOS can read a preceding word, which is the only thing suppressing #11504 - the
+    // system rewriting a double space into ". " and handing the period to the pty. That
+    // suppression is a side effect of this predicate rather than a decision, so narrowing it
+    // back toward punctuation would return the bug. Pinned by
+    // terminal-ime-forwarder-space-claim.test.ts.
     event.key.length === 1 &&
     // Composing keystrokes already belong to xterm's composition helper.
     event.isComposing !== true &&
@@ -349,7 +355,10 @@ export function installTerminalImeNativeTextForwarder(args: {
       settleCommit(commit, null)
     }
     event.stopImmediatePropagation()
-    // Clear the helper textarea so the committed text doesn't accumulate.
+    // Clear the helper textarea so the committed text doesn't accumulate. Also load-bearing:
+    // macOS decides an automatic period substitution from the characters already in the field,
+    // so emptying it is what keeps #11504 from firing. Measured - with this line removed and
+    // everything else held constant, `hi` + two spaces reaches the pty as `hi. `.
     if (event.target instanceof HTMLTextAreaElement) {
       event.target.value = ''
     }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​133 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​133 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 |

<!-- /orca-pr-loc -->

Refs #11504. **Tests and comments only — no behaviour change.**

## The situation

macOS rewrites a double space into `". "` and hands the period to the pty. #11504 reported exactly that, and it reproduced on hardware at v1.4.161.

It does **not** reproduce today. But Orca is not immune — it is protected by accident.

Measured on a real Mac with synthetic CGEvents and the pty bytes hexdumped:

```
Orca 1.4.184           h i SPACE SPACE  ->  6869 2020 0a   "hi  "   no period
plain Chromium textarea, same Electron  ->  "hi. "
native NSTextView control, same keys    ->  "hi. "
```

So the platform substitutes, the harness is sound, and something in Orca is stopping it. Also worth recording: **`spellcheck="false"` does not block it** — xterm's attributes were never the protection.

## What is actually protecting us

Two things, neither of them deliberate:

1. The forwarder **claims a plain space keydown**.
2. A claimed commit **empties the helper textarea**, so the text system never reads the word preceding the space.

Proven causally — same configuration, blanking as the only variable, alternating runs:

```
no blanking  ->  "hi. "        blanked  ->  "hi  "
```

## Why this needs pinning

Before `01bcc8dca24` the claim predicate was `isAsciiPunctuationKey`, commented as printable ASCII *"excluding space (0x20), digits and letters"*. Space was never claimed, the field accumulated, and the substitution fired.

`01bcc8dca24` widened it to every single-character key **for unrelated reasons** — IME commit survival and kitty encoding. It never mentions #11504, and the blanking comment is about *accumulation*.

The predicate already declines on ctrl/alt/meta and during composition. Narrowing it further is a natural thing for future IME work to do, and nothing today would notice that #11504 came back.

## What this adds

- Four tests pinning both halves.
- A comment on the predicate and on the blanking, each saying what depends on them.

It does **not** test the substitution itself — a unit environment cannot produce it. It tests the two conditions measured to suppress it.

## Non-vacuous, verified

| mutant | result |
| --- | --- |
| predicate narrowed back toward punctuation | **3 of 4 fail** |
| blanking removed | **1 of 4 fails** |

Full `terminal-pane` suite: 3,672 passing.

## Why not the real fix

The deliberate fix — opting Orca out of `NSAutomaticPeriodSubstitutionEnabled` in its own defaults domain — exists and works, but it is **app-wide**: AppKit offers no per-field or per-`webContents` scope for this rule, and it latches at process start so it cannot be a setting. It would disable double-space→period in every Orca text field, including the issue editors and agent chat inputs.

That is a real regression for prose typing, in exchange for a symptom that does not currently occur. The trade is not worth it while the accidental protection holds — but the protection should be guarded rather than left to luck, which is what this does.