### PR TITLE
docs(readme): sync Korean README's Android install guide link

### DIFF
--- a/docs/readme/README.ko.md
+++ b/docs/readme/README.ko.md
@@ -230,7 +230,7 @@ yay -S stably-orca-bin
 데스크톱 앱과 페어링해 휴대폰에서 에이전트를 모니터링하고 조종하세요.
 
 - **iOS:** [App Store에서 다운로드](https://apps.apple.com/us/app/orca-ide/id6766130217) 또는 [TestFlight 참여](https://testflight.apple.com/join/YjeGMQBA)
-- **Android:** [APK 0.0.43 다운로드](https://github.com/stablyai/orca/releases/download/mobile-android-v0.0.43/app-release.apk)
+- **Android:** [APK 0.0.43 다운로드](https://github.com/stablyai/orca/releases/download/mobile-android-v0.0.43/app-release.apk) · [설치 가이드](https://www.onorca.dev/docs/android-apk)
 
 ---
 


### PR DESCRIPTION
## ELI5

The English README links an install guide next to the Android APK download. The Korean README only has the download link — this adds the missing guide link so Korean readers get the same information.

## What Changed

`docs/readme/README.ko.md` line 233: added `· [설치 가이드](https://www.onorca.dev/docs/android-apk)` after the existing APK download link, matching the English README's line 233.

## Why

#14978 (merged 2026-08-17) added the install guide link to the English README's mobile companion section. The Korean README's last full sync was #14124 (2026-08-12), before that change, so it drifted out of sync on this one line.

## Linked Issue

No open issue for this — found while scanning for translation drift; docs-only, no code change.

## Visual Proof

N/A — Markdown text only.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

No tests applicable (documentation-only change). Verified by diffing against the current English README's equivalent line and confirming the Korean README's other Android/iOS mentions (the top badge table, line 39) are already in sync — only this one line had drifted.

## AI Disclosure

Found and drafted with Claude (Anthropic) assistance, reviewed before submission.

## Review

Single-line, docs-only change. No code, tests, or other translations touched.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A) — docs only
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — N/A, markdown only
