### PR TITLE
docs(readme): add Android install guide link to README.ko.md

### DIFF
--- a/docs/readme/README.ko.md
+++ b/docs/readme/README.ko.md
@@ -230,7 +230,7 @@ yay -S stably-orca-bin
 데스크톱 앱과 페어링해 휴대폰에서 에이전트를 모니터링하고 조종하세요.
 
 - **iOS:** [App Store에서 다운로드](https://apps.apple.com/us/app/orca-ide/id6766130217) 또는 [TestFlight 참여](https://testflight.apple.com/join/YjeGMQBA)
-- **Android:** [APK 0.0.43 다운로드](https://github.com/stablyai/orca/releases/download/mobile-android-v0.0.43/app-release.apk)
+- **Android:** [APK 0.0.43 다운로드](https://github.com/stablyai/orca/releases/download/mobile-android-v0.0.43/app-release.apk) · [설치 가이드](https://www.onorca.dev/docs/android-apk)
 
 ---
 


### PR DESCRIPTION
## ELI5

The English README links an Android install guide next to the APK download button. The Korean README was missing that same link, so Korean readers didn't get the same pointer to setup help.

## What Changed

- Added `· [설치 가이드](https://www.onorca.dev/docs/android-apk)` after the Android APK download link in `docs/readme/README.ko.md`, matching the English README's wording and the "가이드" terminology already used elsewhere in the same file.

## Why

`#14978` added this install guide link to the English `README.md`. The Korean README was last fully synced in `#14124`, which merged before `#14978`, so it drifted out of sync on this one line.

## Linked Issue

Fixes #15395

## Visual Proof

N/A — Markdown-only text addition, no UI or rendering behavior change. Diffed directly against the equivalent line added to `README.md` in `#14978` to confirm identical wording and URL.

## Testing

- [x] I manually tested these changes locally
- [ ] Automated tests added/updated, or explained why not below

Doc-only single-line Markdown change; no source files were touched, so `pnpm lint` / `typecheck` / `test` / `build` have no relevant surface here. Verified by diffing the new line against `README.md`'s existing install-guide link and confirming the target URL resolves.

## AI Disclosure

Anthropic Claude (via an OpenClaw agent) was used to scan for README translation drift between `README.md` and `README.ko.md`, draft this fix, and open the PR. The diff was reviewed before submission.

## Review

- Security: no code paths touched.
- Cross-platform: Markdown text only; not platform-specific.
- SSH/remote: not applicable.
- Backwards compatibility: additive text only, no existing content removed or reworded.
- Performance: no runtime impact.

## Agent skill upstream boundary

- [x] Not applicable — this is an unrelated one-line README translation fix and does not touch skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Doc-only change; no security, cross-platform, remote SSH, mobile, backwards-compatibility, or performance surface.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — N/A, doc-only change with no source files touched

## Author

- X / Twitter: N/A
