### PR TITLE
perf(browser): send one atomic mouseClick on the legacy remote pane

### DIFF
--- a/src/renderer/src/components/browser-pane/stream-remote/remote-browser-click-dispatch.ts
+++ b/src/renderer/src/components/browser-pane/stream-remote/remote-browser-click-dispatch.ts
@@ -7,9 +7,24 @@ import type {
 
 const CALL_OPTIONS = { timeoutMs: 15_000, suppressFeatureInteraction: true }
 
-// Why one atomic mouseClick when the pair is a plain click: the move/down/up chain costs three
-// serialized round trips, visibly hovers on the way, and can miss small controls. Drags and
-// modified clicks still need the chain, which is also the fallback for hosts predating mouseClick.
+type RemoteBrowserClickParams = { worktree: string; page: string }
+
+async function moveRemoteBrowserPointer(
+  target: RemoteBrowserRuntimeTarget,
+  params: RemoteBrowserClickParams,
+  point: { x: number; y: number }
+): Promise<void> {
+  await callRuntimeRpc(
+    target,
+    'browser.mouseMove',
+    { ...params, x: point.x, y: point.y },
+    CALL_OPTIONS
+  )
+}
+
+// Why one atomic mouseClick when the pair is a plain click: press/release in one host-side call
+// halves the round trips and cannot miss a small control between them. Drags and modified clicks
+// still need the chain, which is also the fallback for hosts predating mouseClick.
 export async function sendRemoteBrowserClick({
   target,
   params,
@@ -19,7 +34,7 @@ export async function sendRemoteBrowserClick({
   onAtomicClickUnsupported
 }: {
   target: RemoteBrowserRuntimeTarget
-  params: { worktree: string; page: string }
+  params: RemoteBrowserClickParams
   press: RemoteBrowserPressState
   release: RemoteBrowserPressState
   preferAtomicClick: boolean
@@ -27,6 +42,10 @@ export async function sendRemoteBrowserClick({
 }): Promise<void> {
   if (preferAtomicClick) {
     try {
+      // Why the move first: the host's mouseClick dispatches only mousePressed/mouseReleased, so
+      // without it the page never applies :hover — a hover-revealed control is hit-tested while it
+      // is still hidden, and the press and release land on different elements.
+      await moveRemoteBrowserPointer(target, params, release.point)
       await callRuntimeRpc(
         target,
         'browser.mouseClick',
@@ -41,25 +60,43 @@ export async function sendRemoteBrowserClick({
       onAtomicClickUnsupported()
     }
   }
-  await callRuntimeRpc(
-    target,
-    'browser.mouseMove',
-    { ...params, x: press.point.x, y: press.point.y },
-    CALL_OPTIONS
-  )
+  await sendRemoteBrowserPressHold({ target, params, press })
+  await sendRemoteBrowserHeldRelease({ target, params, press, release })
+}
+
+// Puts the remote button down at the press point, for a press the user is still holding.
+export async function sendRemoteBrowserPressHold({
+  target,
+  params,
+  press
+}: {
+  target: RemoteBrowserRuntimeTarget
+  params: RemoteBrowserClickParams
+  press: RemoteBrowserPressState
+}): Promise<void> {
+  await moveRemoteBrowserPointer(target, params, press.point)
   await callRuntimeRpc(
     target,
     'browser.mouseDown',
     { ...params, button: press.button },
     CALL_OPTIONS
   )
+}
+
+// Releases a button that is already down remotely, moving first when the release point moved.
+export async function sendRemoteBrowserHeldRelease({
+  target,
+  params,
+  press,
+  release
+}: {
+  target: RemoteBrowserRuntimeTarget
+  params: RemoteBrowserClickParams
+  press: RemoteBrowserPressState
+  release: RemoteBrowserPressState
+}): Promise<void> {
   if (press.point.x !== release.point.x || press.point.y !== release.point.y) {
-    await callRuntimeRpc(
-      target,
-      'browser.mouseMove',
-      { ...params, x: release.point.x, y: release.point.y },
-      CALL_OPTIONS
-    )
+    await moveRemoteBrowserPointer(target, params, release.point)
   }
   await callRuntimeRpc(
     target,

--- a/src/renderer/src/components/browser-pane/stream-remote/remote-browser-click-dispatch.ts
+++ b/src/renderer/src/components/browser-pane/stream-remote/remote-browser-click-dispatch.ts
@@ -1,0 +1,70 @@
+import { callRuntimeRpc } from '@/runtime/runtime-rpc-client'
+import { isRemoteBrowserMethodUnsupportedError } from './remote-browser-stream-errors'
+import type {
+  RemoteBrowserPressState,
+  RemoteBrowserRuntimeTarget
+} from './remote-browser-page-input-model'
+
+const CALL_OPTIONS = { timeoutMs: 15_000, suppressFeatureInteraction: true }
+
+// Why one atomic mouseClick when the pair is a plain click: the move/down/up chain costs three
+// serialized round trips, visibly hovers on the way, and can miss small controls. Drags and
+// modified clicks still need the chain, which is also the fallback for hosts predating mouseClick.
+export async function sendRemoteBrowserClick({
+  target,
+  params,
+  press,
+  release,
+  preferAtomicClick,
+  onAtomicClickUnsupported
+}: {
+  target: RemoteBrowserRuntimeTarget
+  params: { worktree: string; page: string }
+  press: RemoteBrowserPressState
+  release: RemoteBrowserPressState
+  preferAtomicClick: boolean
+  onAtomicClickUnsupported: () => void
+}): Promise<void> {
+  if (preferAtomicClick) {
+    try {
+      await callRuntimeRpc(
+        target,
+        'browser.mouseClick',
+        { ...params, x: release.point.x, y: release.point.y, button: release.button },
+        CALL_OPTIONS
+      )
+      return
+    } catch (error) {
+      if (!isRemoteBrowserMethodUnsupportedError(error)) {
+        throw error
+      }
+      onAtomicClickUnsupported()
+    }
+  }
+  await callRuntimeRpc(
+    target,
+    'browser.mouseMove',
+    { ...params, x: press.point.x, y: press.point.y },
+    CALL_OPTIONS
+  )
+  await callRuntimeRpc(
+    target,
+    'browser.mouseDown',
+    { ...params, button: press.button },
+    CALL_OPTIONS
+  )
+  if (press.point.x !== release.point.x || press.point.y !== release.point.y) {
+    await callRuntimeRpc(
+      target,
+      'browser.mouseMove',
+      { ...params, x: release.point.x, y: release.point.y },
+      CALL_OPTIONS
+    )
+  }
+  await callRuntimeRpc(
+    target,
+    'browser.mouseUp',
+    { ...params, button: release.button },
+    CALL_OPTIONS
+  )
+}

--- a/src/renderer/src/components/browser-pane/stream-remote/remote-browser-page-input-model.test.ts
+++ b/src/renderer/src/components/browser-pane/stream-remote/remote-browser-page-input-model.test.ts
@@ -3,9 +3,20 @@ import {
   buildRemoteContextMenuExpression,
   getPositiveFiniteNumber,
   getRemoteBrowserMouseButton,
+  hasRemoteBrowserClickModifier,
+  isSimpleRemoteBrowserClick,
   readRemoteContextMenuResult,
-  readRemoteCssViewportSize
+  readRemoteCssViewportSize,
+  type RemoteBrowserPressState
 } from './remote-browser-page-input-model'
+
+const press: RemoteBrowserPressState = {
+  environmentId: 'env-1',
+  pageId: 'page-1',
+  button: 'left',
+  point: { x: 100, y: 100 },
+  modified: false
+}
 
 describe('remote browser page input model', () => {
   it('maps mouse buttons and rejects unknown codes', () => {
@@ -13,6 +24,25 @@ describe('remote browser page input model', () => {
     expect(getRemoteBrowserMouseButton(1)).toBe('middle')
     expect(getRemoteBrowserMouseButton(2)).toBe('right')
     expect(getRemoteBrowserMouseButton(3)).toBeNull()
+  })
+
+  it('treats only jitter-sized, unmodified, same-target pairs as a simple click', () => {
+    expect(isSimpleRemoteBrowserClick(press, { ...press, point: { x: 102, y: 102 } })).toBe(true)
+    expect(isSimpleRemoteBrowserClick(press, { ...press, point: { x: 108, y: 100 } })).toBe(false)
+    expect(isSimpleRemoteBrowserClick(press, { ...press, button: 'middle' })).toBe(false)
+    expect(isSimpleRemoteBrowserClick(press, { ...press, modified: true })).toBe(false)
+    expect(isSimpleRemoteBrowserClick({ ...press, modified: true }, press)).toBe(false)
+    expect(isSimpleRemoteBrowserClick(press, { ...press, pageId: 'page-2' })).toBe(false)
+    expect(isSimpleRemoteBrowserClick(press, { ...press, environmentId: 'env-2' })).toBe(false)
+  })
+
+  it('reads any held modifier as semantics-changing', () => {
+    const plain = { altKey: false, ctrlKey: false, metaKey: false, shiftKey: false }
+    expect(hasRemoteBrowserClickModifier(plain)).toBe(false)
+    expect(hasRemoteBrowserClickModifier({ ...plain, metaKey: true })).toBe(true)
+    expect(hasRemoteBrowserClickModifier({ ...plain, ctrlKey: true })).toBe(true)
+    expect(hasRemoteBrowserClickModifier({ ...plain, altKey: true })).toBe(true)
+    expect(hasRemoteBrowserClickModifier({ ...plain, shiftKey: true })).toBe(true)
   })
 
   it('accepts only positive finite numbers', () => {

--- a/src/renderer/src/components/browser-pane/stream-remote/remote-browser-page-input-model.ts
+++ b/src/renderer/src/components/browser-pane/stream-remote/remote-browser-page-input-model.ts
@@ -84,6 +84,47 @@ export function getRemoteBrowserMouseButton(button: number): 'left' | 'middle' |
   return null
 }
 
+export type RemoteBrowserPressState = {
+  environmentId: string
+  pageId: string
+  button: 'left' | 'middle'
+  point: RemoteBrowserImagePoint
+  modified: boolean
+}
+
+// Mouse jitter inside a press; wider slop would swallow short intentional drags.
+const REMOTE_BROWSER_CLICK_SLOP_PX = 3
+
+export function hasRemoteBrowserClickModifier(event: {
+  altKey: boolean
+  ctrlKey: boolean
+  metaKey: boolean
+  shiftKey: boolean
+}): boolean {
+  return event.altKey || event.ctrlKey || event.metaKey || event.shiftKey
+}
+
+// Why: only a same-target, unmodified, non-drag pair is reproducible as one atomic browser.mouseClick;
+// modifiers change activation semantics and the move/down/up chain carries none of them.
+export function isSimpleRemoteBrowserClick(
+  press: RemoteBrowserPressState,
+  release: RemoteBrowserPressState
+): boolean {
+  if (
+    press.environmentId !== release.environmentId ||
+    press.pageId !== release.pageId ||
+    press.button !== release.button ||
+    press.modified ||
+    release.modified
+  ) {
+    return false
+  }
+  return (
+    Math.hypot(release.point.x - press.point.x, release.point.y - press.point.y) <=
+    REMOTE_BROWSER_CLICK_SLOP_PX
+  )
+}
+
 export function buildRemoteContextMenuExpression(x: number, y: number): string {
   return `(() => {
     const target = document.elementFromPoint(${JSON.stringify(x)}, ${JSON.stringify(y)});

--- a/src/renderer/src/components/browser-pane/stream-remote/remote-browser-page-input-model.ts
+++ b/src/renderer/src/components/browser-pane/stream-remote/remote-browser-page-input-model.ts
@@ -92,6 +92,24 @@ export type RemoteBrowserPressState = {
   modified: boolean
 }
 
+// A press held this long is an interaction in its own right (long-press menu, hold-to-repeat,
+// drag-start affordance, :active feedback), so the button goes down on the page now instead of
+// waiting for a release that would compress the whole hold into one instantaneous click.
+export const REMOTE_BROWSER_PRESS_HOLD_MS = 350
+
+export type PendingRemoteBrowserPress = {
+  press: RemoteBrowserPressState
+  target: RemoteBrowserRuntimeTarget
+  operationToken: RemoteBrowserOperationToken
+  pointerId: number
+  pressedAt: number
+  holdTimer: number | null
+  // Set when the hold put the button down remotely; the release then only has to lift it.
+  holdDispatched: boolean
+  // Drops the press, releasing the remote button first when the hold already put it down.
+  abandon: () => void
+}
+
 // Mouse jitter inside a press; wider slop would swallow short intentional drags.
 const REMOTE_BROWSER_CLICK_SLOP_PX = 3
 

--- a/src/renderer/src/components/browser-pane/stream-remote/remote-browser-page-input-model.ts
+++ b/src/renderer/src/components/browser-pane/stream-remote/remote-browser-page-input-model.ts
@@ -97,6 +97,11 @@ export type RemoteBrowserPressState = {
 // waiting for a release that would compress the whole hold into one instantaneous click.
 export const REMOTE_BROWSER_PRESS_HOLD_MS = 350
 
+// Backstop for a press whose hold never armed the button (a suspended or throttled renderer can
+// stall the hold timer): past this it is stale, and replaying it would fabricate a press the user
+// never made at coordinates the page has since scrolled away from.
+export const REMOTE_BROWSER_PRESS_MAX_AGE_MS = 5_000
+
 export type PendingRemoteBrowserPress = {
   press: RemoteBrowserPressState
   target: RemoteBrowserRuntimeTarget

--- a/src/renderer/src/components/browser-pane/stream-remote/remote-browser-page-pane.tsx
+++ b/src/renderer/src/components/browser-pane/stream-remote/remote-browser-page-pane.tsx
@@ -96,8 +96,10 @@ export function RemoteBrowserPagePane({
   const {
     enqueueRemoteInput,
     clearPendingRemoteWheel,
+    clearPendingRemotePress,
     resetRemoteInputQueue,
     pendingRemoteWheelRef,
+    pendingPressRef,
     remoteWheelFrameRef,
     remoteWheelInFlightRef
   } = useRemoteBrowserPageInputQueue()
@@ -131,6 +133,7 @@ export function RemoteBrowserPagePane({
     setPaneNotice,
     setPaneBusy,
     clearPendingRemoteWheel,
+    clearPendingRemotePress,
     resetRemoteInputQueue
   })
 
@@ -216,7 +219,8 @@ export function RemoteBrowserPagePane({
     isCurrentRemoteOperationToken,
     closeMissingRemotePage,
     scheduleRemoteTabInfoRefresh,
-    setPaneNotice
+    setPaneNotice,
+    pendingPressRef
   })
 
   useRemoteBrowserPageWheel({

--- a/src/renderer/src/components/browser-pane/stream-remote/remote-browser-page-pane.tsx
+++ b/src/renderer/src/components/browser-pane/stream-remote/remote-browser-page-pane.tsx
@@ -211,6 +211,7 @@ export function RemoteBrowserPagePane({
     remoteCssViewportSizeRef,
     remoteViewportSizeRef,
     frameMetadata,
+    frameUrl,
     runtimeTarget,
     lifecycle,
     runtimeWorktree,

--- a/src/renderer/src/components/browser-pane/stream-remote/remote-browser-page-pane.tsx
+++ b/src/renderer/src/components/browser-pane/stream-remote/remote-browser-page-pane.tsx
@@ -199,6 +199,7 @@ export function RemoteBrowserPagePane({
     getRemoteImagePoint,
     handleRemotePointerDown,
     handleRemotePointerUp,
+    handleRemotePointerCancel,
     handleRemoteScreenshotKeyDown
   } = useRemoteBrowserPageInput({
     busy,
@@ -344,6 +345,7 @@ export function RemoteBrowserPagePane({
         onReconnect={reconnectRemoteStream}
         handleRemotePointerDown={handleRemotePointerDown}
         handleRemotePointerUp={handleRemotePointerUp}
+        handleRemotePointerCancel={handleRemotePointerCancel}
         handleRemoteContextMenu={handleRemoteContextMenu}
         handleRemoteScreenshotKeyDown={handleRemoteScreenshotKeyDown}
       />

--- a/src/renderer/src/components/browser-pane/stream-remote/remote-browser-page-viewport.tsx
+++ b/src/renderer/src/components/browser-pane/stream-remote/remote-browser-page-viewport.tsx
@@ -47,6 +47,7 @@ export function RemoteBrowserPageViewport({
   onReconnect,
   handleRemotePointerDown,
   handleRemotePointerUp,
+  handleRemotePointerCancel,
   handleRemoteContextMenu,
   handleRemoteScreenshotKeyDown
 }: {
@@ -70,6 +71,7 @@ export function RemoteBrowserPageViewport({
   onReconnect: () => void
   handleRemotePointerDown: (event: React.PointerEvent<HTMLImageElement>) => void
   handleRemotePointerUp: (event: React.PointerEvent<HTMLImageElement>) => void
+  handleRemotePointerCancel: () => void
   handleRemoteContextMenu: (event: React.MouseEvent<HTMLImageElement>) => void
   handleRemoteScreenshotKeyDown: (event: React.KeyboardEvent<HTMLImageElement>) => void
 }): React.JSX.Element {
@@ -106,6 +108,7 @@ export function RemoteBrowserPageViewport({
           className="absolute top-0 left-0 max-w-none cursor-default bg-white outline-none"
           onPointerDown={handleRemotePointerDown}
           onPointerUp={handleRemotePointerUp}
+          onPointerCancel={handleRemotePointerCancel}
           onContextMenu={handleRemoteContextMenu}
           onKeyDown={handleRemoteScreenshotKeyDown}
           draggable={false}

--- a/src/renderer/src/components/browser-pane/stream-remote/remote-browser-stream-errors.ts
+++ b/src/renderer/src/components/browser-pane/stream-remote/remote-browser-stream-errors.ts
@@ -56,6 +56,12 @@ export function isRemoteBrowserPageMissingError(error: unknown): boolean {
   return isRemoteBrowserPageMissingCode(readErrorCode(error))
 }
 
+// Why: a host predating an RPC answers `method_not_found` before dispatch, so nothing happened on
+// the page and the legacy call sequence can be retried in its place.
+export function isRemoteBrowserMethodUnsupportedError(error: unknown): boolean {
+  return readErrorCode(error) === 'method_not_found'
+}
+
 // Why: restart retries must stop for failures the host cannot recover from on its own; anything
 // else is unproven and must keep retrying rather than strand the pane with a dead subscription.
 export function isPermanentRemoteBrowserStreamFailure(error: unknown): boolean {

--- a/src/renderer/src/components/browser-pane/stream-remote/use-remote-browser-page-input.test.ts
+++ b/src/renderer/src/components/browser-pane/stream-remote/use-remote-browser-page-input.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { renderHook } from '@testing-library/react'
 
 const mocks = vi.hoisted(() => ({
@@ -17,8 +17,12 @@ vi.mock('@/runtime/runtime-rpc-client', () => ({
   callRuntimeRpc: mocks.callRuntimeRpc
 }))
 
-import { useRemoteBrowserPageInput } from './use-remote-browser-page-input'
+import {
+  useRemoteBrowserPageInput,
+  useRemoteBrowserPageInputQueue
+} from './use-remote-browser-page-input'
 import type { RemoteBrowserStreamLifecycle } from './remote-browser-stream-lifecycle'
+import { REMOTE_BROWSER_PRESS_HOLD_MS } from './remote-browser-page-input-model'
 
 const VIEWPORT = { width: 800, height: 600 }
 
@@ -27,6 +31,7 @@ function pointerEvent(
     clientX: number
     clientY: number
     button: number
+    pointerId: number
     altKey: boolean
     ctrlKey: boolean
     metaKey: boolean
@@ -37,6 +42,7 @@ function pointerEvent(
     clientX: 100,
     clientY: 100,
     button: 0,
+    pointerId: 1,
     altKey: false,
     ctrlKey: false,
     metaKey: false,
@@ -48,6 +54,8 @@ function pointerEvent(
 
 function renderInput(): {
   input: ReturnType<typeof useRemoteBrowserPageInput>
+  clearPendingRemotePress: () => void
+  unmount: () => void
   settle: () => Promise<void>
 } {
   const image = document.createElement('img')
@@ -55,8 +63,10 @@ function renderInput(): {
   viewport.getBoundingClientRect = () =>
     ({ left: 0, top: 0, width: VIEWPORT.width, height: VIEWPORT.height }) as DOMRect
   const pending: Promise<void>[] = []
-  const { result } = renderHook(() =>
-    useRemoteBrowserPageInput({
+  // The pane's own composition: the queue hook owns the pending-press ref the input hook fills.
+  const { result, unmount } = renderHook(() => {
+    const queue = useRemoteBrowserPageInputQueue()
+    const input = useRemoteBrowserPageInput({
       busy: false,
       imageRef: { current: image },
       remoteViewportRef: { current: viewport },
@@ -67,7 +77,7 @@ function renderInput(): {
       lifecycle: { tokens: { remotePage: 'page-1' } } as unknown as RemoteBrowserStreamLifecycle,
       runtimeWorktree: 'wt-1',
       enqueueRemoteInput: (operation) => {
-        const next = operation()
+        const next = queue.enqueueRemoteInput(operation)
         pending.push(next)
         return next
       },
@@ -80,11 +90,15 @@ function renderInput(): {
       isCurrentRemoteOperationToken: () => true,
       closeMissingRemotePage: vi.fn(),
       scheduleRemoteTabInfoRefresh: vi.fn(),
-      setPaneNotice: vi.fn()
+      setPaneNotice: vi.fn(),
+      pendingPressRef: queue.pendingPressRef
     })
-  )
+    return { input, clearPendingRemotePress: queue.clearPendingRemotePress }
+  })
   return {
-    input: result.current,
+    input: result.current.input,
+    clearPendingRemotePress: result.current.clearPendingRemotePress,
+    unmount,
     settle: async () => {
       await Promise.all(pending)
     }
@@ -99,6 +113,10 @@ describe('remote browser pointer input', () => {
   beforeEach(() => {
     mocks.callRuntimeRpc.mockReset()
     mocks.callRuntimeRpc.mockResolvedValue({})
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('hovers the click point, then sends one atomic mouseClick for a press and release at the same point', async () => {
@@ -204,6 +222,74 @@ describe('remote browser pointer input', () => {
 
     expect(calledMethods()).toEqual(['browser.mouseMove', 'browser.mouseClick'])
     expect(mocks.callRuntimeRpc.mock.calls[1][2]).toMatchObject({ button: 'middle' })
+  })
+
+  it('puts the button down while a press is still held, and the release only lifts it', async () => {
+    vi.useFakeTimers()
+    const { input, settle } = renderInput()
+    input.handleRemotePointerDown(pointerEvent({ clientX: 100, clientY: 100 }))
+    await vi.advanceTimersByTimeAsync(REMOTE_BROWSER_PRESS_HOLD_MS + 10)
+
+    // The page must see the button go down during the hold, or long-press and hold-to-repeat
+    // affordances never fire and the pane shows no :active feedback.
+    expect(calledMethods()).toEqual(['browser.mouseMove', 'browser.mouseDown'])
+    expect(mocks.callRuntimeRpc.mock.calls[0][2]).toMatchObject({ x: 100, y: 100 })
+
+    input.handleRemotePointerUp(pointerEvent({ clientX: 140, clientY: 130 }))
+    await settle()
+
+    expect(calledMethods()).toEqual([
+      'browser.mouseMove',
+      'browser.mouseDown',
+      'browser.mouseMove',
+      'browser.mouseUp'
+    ])
+    expect(mocks.callRuntimeRpc.mock.calls[2][2]).toMatchObject({ x: 140, y: 130 })
+  })
+
+  it('still sends the atomic click when the press releases before the hold threshold', async () => {
+    vi.useFakeTimers()
+    const { input, settle } = renderInput()
+    input.handleRemotePointerDown(pointerEvent())
+    await vi.advanceTimersByTimeAsync(REMOTE_BROWSER_PRESS_HOLD_MS - 50)
+    input.handleRemotePointerUp(pointerEvent())
+    await settle()
+    await vi.advanceTimersByTimeAsync(REMOTE_BROWSER_PRESS_HOLD_MS)
+
+    expect(calledMethods()).toEqual(['browser.mouseMove', 'browser.mouseClick'])
+  })
+
+  it('lifts a held button when the press is cancelled', async () => {
+    vi.useFakeTimers()
+    const { input, settle } = renderInput()
+    input.handleRemotePointerDown(pointerEvent())
+    await vi.advanceTimersByTimeAsync(REMOTE_BROWSER_PRESS_HOLD_MS + 10)
+    input.handleRemotePointerCancel()
+    await settle()
+
+    expect(calledMethods()).toEqual(['browser.mouseMove', 'browser.mouseDown', 'browser.mouseUp'])
+  })
+
+  it('lifts a held button when the pane identity changes under it', async () => {
+    vi.useFakeTimers()
+    const { input, clearPendingRemotePress, settle } = renderInput()
+    input.handleRemotePointerDown(pointerEvent())
+    await vi.advanceTimersByTimeAsync(REMOTE_BROWSER_PRESS_HOLD_MS + 10)
+    clearPendingRemotePress()
+    await settle()
+
+    expect(calledMethods()).toEqual(['browser.mouseMove', 'browser.mouseDown', 'browser.mouseUp'])
+  })
+
+  it('lifts a held button when the pane unmounts mid-hold', async () => {
+    vi.useFakeTimers()
+    const { input, unmount, settle } = renderInput()
+    input.handleRemotePointerDown(pointerEvent())
+    await vi.advanceTimersByTimeAsync(REMOTE_BROWSER_PRESS_HOLD_MS + 10)
+    unmount()
+    await settle()
+
+    expect(calledMethods()).toEqual(['browser.mouseMove', 'browser.mouseDown', 'browser.mouseUp'])
   })
 
   it('leaves right-button presses to the context-menu path', async () => {

--- a/src/renderer/src/components/browser-pane/stream-remote/use-remote-browser-page-input.test.ts
+++ b/src/renderer/src/components/browser-pane/stream-remote/use-remote-browser-page-input.test.ts
@@ -22,7 +22,10 @@ import {
   useRemoteBrowserPageInputQueue
 } from './use-remote-browser-page-input'
 import type { RemoteBrowserStreamLifecycle } from './remote-browser-stream-lifecycle'
-import { REMOTE_BROWSER_PRESS_HOLD_MS } from './remote-browser-page-input-model'
+import {
+  REMOTE_BROWSER_PRESS_HOLD_MS,
+  REMOTE_BROWSER_PRESS_MAX_AGE_MS
+} from './remote-browser-page-input-model'
 
 const VIEWPORT = { width: 800, height: 600 }
 
@@ -54,7 +57,9 @@ function pointerEvent(
 
 function renderInput(): {
   input: ReturnType<typeof useRemoteBrowserPageInput>
+  image: HTMLImageElement
   clearPendingRemotePress: () => void
+  paintNextFrame: () => void
   unmount: () => void
   settle: () => Promise<void>
 } {
@@ -63,8 +68,11 @@ function renderInput(): {
   viewport.getBoundingClientRect = () =>
     ({ left: 0, top: 0, width: VIEWPORT.width, height: VIEWPORT.height }) as DOMRect
   const pending: Promise<void>[] = []
+  // The screencast mints one blob URL per painted frame.
+  let frameUrl = 'blob:remote-frame-1'
+  let paintedFrames = 1
   // The pane's own composition: the queue hook owns the pending-press ref the input hook fills.
-  const { result, unmount } = renderHook(() => {
+  const { result, rerender, unmount } = renderHook(() => {
     const queue = useRemoteBrowserPageInputQueue()
     const input = useRemoteBrowserPageInput({
       busy: false,
@@ -73,6 +81,7 @@ function renderInput(): {
       remoteCssViewportSizeRef: { current: VIEWPORT },
       remoteViewportSizeRef: { current: null },
       frameMetadata: null,
+      frameUrl,
       runtimeTarget: () => ({ kind: 'environment', environmentId: 'env-1' }),
       lifecycle: { tokens: { remotePage: 'page-1' } } as unknown as RemoteBrowserStreamLifecycle,
       runtimeWorktree: 'wt-1',
@@ -97,7 +106,13 @@ function renderInput(): {
   })
   return {
     input: result.current.input,
+    image,
     clearPendingRemotePress: result.current.clearPendingRemotePress,
+    paintNextFrame: () => {
+      paintedFrames += 1
+      frameUrl = `blob:remote-frame-${paintedFrames}`
+      rerender()
+    },
     unmount,
     settle: async () => {
       await Promise.all(pending)
@@ -290,6 +305,73 @@ describe('remote browser pointer input', () => {
     await settle()
 
     expect(calledMethods()).toEqual(['browser.mouseMove', 'browser.mouseDown', 'browser.mouseUp'])
+  })
+
+  it('captures the pointer so a release outside the frame still reaches the press', () => {
+    const { input, image } = renderInput()
+    const setPointerCapture = vi.fn()
+    Object.assign(image, { setPointerCapture })
+    input.handleRemotePointerDown(pointerEvent({ pointerId: 7 }))
+
+    expect(setPointerCapture).toHaveBeenCalledWith(7)
+  })
+
+  it('drops a press whose pointer left the frame instead of replaying it later', async () => {
+    const { input, image, settle } = renderInput()
+    input.handleRemotePointerDown(pointerEvent({ clientX: 100, clientY: 100 }))
+    // Capture is unavailable here (happy-dom), which is exactly when the gesture can end off-frame.
+    image.dispatchEvent(new Event('pointerleave'))
+    // A later unrelated gesture — begun outside the frame — releases over it.
+    input.handleRemotePointerUp(pointerEvent({ clientX: 300, clientY: 260 }))
+    await settle()
+
+    expect(calledMethods()).toEqual([])
+  })
+
+  it('drops a press left behind by a frame that lost focus', async () => {
+    const { input, image, settle } = renderInput()
+    input.handleRemotePointerDown(pointerEvent({ clientX: 100, clientY: 100 }))
+    image.dispatchEvent(new Event('blur'))
+    input.handleRemotePointerUp(pointerEvent({ clientX: 300, clientY: 260 }))
+    await settle()
+
+    expect(calledMethods()).toEqual([])
+  })
+
+  it('ignores a release from a different pointer and keeps the press for its own', async () => {
+    const { input, settle } = renderInput()
+    input.handleRemotePointerDown(pointerEvent({ pointerId: 4, clientX: 100, clientY: 100 }))
+    input.handleRemotePointerUp(pointerEvent({ pointerId: 9, clientX: 300, clientY: 260 }))
+    await settle()
+
+    expect(calledMethods()).toEqual([])
+
+    input.handleRemotePointerUp(pointerEvent({ pointerId: 4, clientX: 101, clientY: 101 }))
+    await settle()
+
+    expect(calledMethods()).toEqual(['browser.mouseMove', 'browser.mouseClick'])
+  })
+
+  it('does not replay a press older than the age cap', async () => {
+    vi.useFakeTimers()
+    const { input, settle } = renderInput()
+    input.handleRemotePointerDown(pointerEvent({ clientX: 100, clientY: 100 }))
+    // Clock only: a stalled renderer is exactly the case where the hold timer never ran.
+    vi.setSystemTime(Date.now() + REMOTE_BROWSER_PRESS_MAX_AGE_MS + 1_000)
+    input.handleRemotePointerUp(pointerEvent({ clientX: 101, clientY: 101 }))
+    await settle()
+
+    expect(calledMethods()).toEqual([])
+  })
+
+  it('keeps a press alive across painted frames', async () => {
+    const { input, paintNextFrame, settle } = renderInput()
+    input.handleRemotePointerDown(pointerEvent({ clientX: 100, clientY: 100 }))
+    paintNextFrame()
+    input.handleRemotePointerUp(pointerEvent({ clientX: 101, clientY: 101 }))
+    await settle()
+
+    expect(calledMethods()).toEqual(['browser.mouseMove', 'browser.mouseClick'])
   })
 
   it('leaves right-button presses to the context-menu path', async () => {

--- a/src/renderer/src/components/browser-pane/stream-remote/use-remote-browser-page-input.test.ts
+++ b/src/renderer/src/components/browser-pane/stream-remote/use-remote-browser-page-input.test.ts
@@ -179,6 +179,25 @@ describe('remote browser pointer input', () => {
     expect(calledMethods()).toEqual([])
   })
 
+  it('drops a release whose button differs from the recorded press', async () => {
+    const { input, settle } = renderInput()
+    input.handleRemotePointerDown(pointerEvent({ button: 1 }))
+    input.handleRemotePointerUp(pointerEvent({ button: 0 }))
+    await settle()
+
+    expect(calledMethods()).toEqual([])
+  })
+
+  it('sends a middle click atomically', async () => {
+    const { input, settle } = renderInput()
+    input.handleRemotePointerDown(pointerEvent({ button: 1 }))
+    input.handleRemotePointerUp(pointerEvent({ button: 1 }))
+    await settle()
+
+    expect(calledMethods()).toEqual(['browser.mouseClick'])
+    expect(mocks.callRuntimeRpc.mock.calls[0][2]).toMatchObject({ button: 'middle' })
+  })
+
   it('leaves right-button presses to the context-menu path', async () => {
     const { input, settle } = renderInput()
     input.handleRemotePointerDown(pointerEvent({ button: 2 }))

--- a/src/renderer/src/components/browser-pane/stream-remote/use-remote-browser-page-input.test.ts
+++ b/src/renderer/src/components/browser-pane/stream-remote/use-remote-browser-page-input.test.ts
@@ -1,0 +1,190 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const mocks = vi.hoisted(() => ({
+  callRuntimeRpc: vi.fn()
+}))
+
+vi.mock('@/runtime/runtime-rpc-client', () => ({
+  RuntimeRpcCallError: class RuntimeRpcCallError extends Error {
+    code: string
+    constructor(code: string) {
+      super(code)
+      this.code = code
+    }
+  },
+  callRuntimeRpc: mocks.callRuntimeRpc
+}))
+
+import { useRemoteBrowserPageInput } from './use-remote-browser-page-input'
+import type { RemoteBrowserStreamLifecycle } from './remote-browser-stream-lifecycle'
+
+const VIEWPORT = { width: 800, height: 600 }
+
+function pointerEvent(
+  overrides: Partial<{
+    clientX: number
+    clientY: number
+    button: number
+    altKey: boolean
+    ctrlKey: boolean
+    metaKey: boolean
+    shiftKey: boolean
+  }> = {}
+): React.PointerEvent<HTMLImageElement> {
+  return {
+    clientX: 100,
+    clientY: 100,
+    button: 0,
+    altKey: false,
+    ctrlKey: false,
+    metaKey: false,
+    shiftKey: false,
+    preventDefault: () => {},
+    ...overrides
+  } as unknown as React.PointerEvent<HTMLImageElement>
+}
+
+function renderInput(): {
+  input: ReturnType<typeof useRemoteBrowserPageInput>
+  settle: () => Promise<void>
+} {
+  const image = document.createElement('img')
+  const viewport = document.createElement('div')
+  viewport.getBoundingClientRect = () =>
+    ({ left: 0, top: 0, width: VIEWPORT.width, height: VIEWPORT.height }) as DOMRect
+  const pending: Promise<void>[] = []
+  const { result } = renderHook(() =>
+    useRemoteBrowserPageInput({
+      busy: false,
+      imageRef: { current: image },
+      remoteViewportRef: { current: viewport },
+      remoteCssViewportSizeRef: { current: VIEWPORT },
+      remoteViewportSizeRef: { current: null },
+      frameMetadata: null,
+      runtimeTarget: () => ({ kind: 'environment', environmentId: 'env-1' }),
+      lifecycle: { tokens: { remotePage: 'page-1' } } as unknown as RemoteBrowserStreamLifecycle,
+      runtimeWorktree: 'wt-1',
+      enqueueRemoteInput: (operation) => {
+        const next = operation()
+        pending.push(next)
+        return next
+      },
+      createRemoteOperationToken: () => ({
+        tabId: 'tab-1',
+        environmentId: 'env-1',
+        remotePageId: 'page-1',
+        generation: 1
+      }),
+      isCurrentRemoteOperationToken: () => true,
+      closeMissingRemotePage: vi.fn(),
+      scheduleRemoteTabInfoRefresh: vi.fn(),
+      setPaneNotice: vi.fn()
+    })
+  )
+  return {
+    input: result.current,
+    settle: async () => {
+      await Promise.all(pending)
+    }
+  }
+}
+
+function calledMethods(): string[] {
+  return mocks.callRuntimeRpc.mock.calls.map((call) => call[1] as string)
+}
+
+describe('remote browser pointer input', () => {
+  beforeEach(() => {
+    mocks.callRuntimeRpc.mockReset()
+    mocks.callRuntimeRpc.mockResolvedValue({})
+  })
+
+  it('sends one atomic mouseClick for a press and release at the same point', async () => {
+    const { input, settle } = renderInput()
+    input.handleRemotePointerDown(pointerEvent({ clientX: 120, clientY: 90 }))
+    input.handleRemotePointerUp(pointerEvent({ clientX: 121, clientY: 91 }))
+    await settle()
+
+    expect(calledMethods()).toEqual(['browser.mouseClick'])
+    expect(mocks.callRuntimeRpc.mock.calls[0][2]).toEqual({
+      worktree: 'wt-1',
+      page: 'page-1',
+      x: 121,
+      y: 91,
+      button: 'left'
+    })
+  })
+
+  it('keeps the move/down/move/up chain for a drag', async () => {
+    const { input, settle } = renderInput()
+    input.handleRemotePointerDown(pointerEvent({ clientX: 100, clientY: 100 }))
+    input.handleRemotePointerUp(pointerEvent({ clientX: 300, clientY: 260 }))
+    await settle()
+
+    expect(calledMethods()).toEqual([
+      'browser.mouseMove',
+      'browser.mouseDown',
+      'browser.mouseMove',
+      'browser.mouseUp'
+    ])
+    expect(mocks.callRuntimeRpc.mock.calls[0][2]).toMatchObject({ x: 100, y: 100 })
+    expect(mocks.callRuntimeRpc.mock.calls[2][2]).toMatchObject({ x: 300, y: 260 })
+  })
+
+  it('keeps the legacy chain for modified clicks, which carry no modifiers today', async () => {
+    const { input, settle } = renderInput()
+    input.handleRemotePointerDown(pointerEvent({ shiftKey: true }))
+    input.handleRemotePointerUp(pointerEvent({ shiftKey: true }))
+    await settle()
+
+    expect(calledMethods()).toEqual(['browser.mouseMove', 'browser.mouseDown', 'browser.mouseUp'])
+  })
+
+  it('falls back to the chain on hosts without mouseClick and stops re-probing them', async () => {
+    mocks.callRuntimeRpc.mockImplementation(async (_target, method: string) => {
+      if (method === 'browser.mouseClick') {
+        throw Object.assign(new Error('Unknown method'), { code: 'method_not_found' })
+      }
+      return {}
+    })
+    const { input, settle } = renderInput()
+    input.handleRemotePointerDown(pointerEvent())
+    input.handleRemotePointerUp(pointerEvent())
+    await settle()
+
+    expect(calledMethods()).toEqual([
+      'browser.mouseClick',
+      'browser.mouseMove',
+      'browser.mouseDown',
+      'browser.mouseUp'
+    ])
+
+    mocks.callRuntimeRpc.mockClear()
+    input.handleRemotePointerDown(pointerEvent())
+    input.handleRemotePointerUp(pointerEvent())
+    await settle()
+
+    expect(calledMethods()).toEqual(['browser.mouseMove', 'browser.mouseDown', 'browser.mouseUp'])
+  })
+
+  it('sends nothing for a release whose press was cancelled or never recorded', async () => {
+    const { input, settle } = renderInput()
+    input.handleRemotePointerDown(pointerEvent())
+    input.handleRemotePointerCancel()
+    input.handleRemotePointerUp(pointerEvent())
+    await settle()
+
+    expect(calledMethods()).toEqual([])
+  })
+
+  it('leaves right-button presses to the context-menu path', async () => {
+    const { input, settle } = renderInput()
+    input.handleRemotePointerDown(pointerEvent({ button: 2 }))
+    input.handleRemotePointerUp(pointerEvent({ button: 2 }))
+    await settle()
+
+    expect(calledMethods()).toEqual([])
+  })
+})

--- a/src/renderer/src/components/browser-pane/stream-remote/use-remote-browser-page-input.test.ts
+++ b/src/renderer/src/components/browser-pane/stream-remote/use-remote-browser-page-input.test.ts
@@ -101,14 +101,21 @@ describe('remote browser pointer input', () => {
     mocks.callRuntimeRpc.mockResolvedValue({})
   })
 
-  it('sends one atomic mouseClick for a press and release at the same point', async () => {
+  it('hovers the click point, then sends one atomic mouseClick for a press and release at the same point', async () => {
     const { input, settle } = renderInput()
     input.handleRemotePointerDown(pointerEvent({ clientX: 120, clientY: 90 }))
     input.handleRemotePointerUp(pointerEvent({ clientX: 121, clientY: 91 }))
     await settle()
 
-    expect(calledMethods()).toEqual(['browser.mouseClick'])
+    // The move is what applies :hover before the press hit-test; the host's mouseClick sends none.
+    expect(calledMethods()).toEqual(['browser.mouseMove', 'browser.mouseClick'])
     expect(mocks.callRuntimeRpc.mock.calls[0][2]).toEqual({
+      worktree: 'wt-1',
+      page: 'page-1',
+      x: 121,
+      y: 91
+    })
+    expect(mocks.callRuntimeRpc.mock.calls[1][2]).toEqual({
       worktree: 'wt-1',
       page: 'page-1',
       x: 121,
@@ -155,6 +162,7 @@ describe('remote browser pointer input', () => {
     await settle()
 
     expect(calledMethods()).toEqual([
+      'browser.mouseMove',
       'browser.mouseClick',
       'browser.mouseMove',
       'browser.mouseDown',
@@ -194,8 +202,8 @@ describe('remote browser pointer input', () => {
     input.handleRemotePointerUp(pointerEvent({ button: 1 }))
     await settle()
 
-    expect(calledMethods()).toEqual(['browser.mouseClick'])
-    expect(mocks.callRuntimeRpc.mock.calls[0][2]).toMatchObject({ button: 'middle' })
+    expect(calledMethods()).toEqual(['browser.mouseMove', 'browser.mouseClick'])
+    expect(mocks.callRuntimeRpc.mock.calls[1][2]).toMatchObject({ button: 'middle' })
   })
 
   it('leaves right-button presses to the context-menu path', async () => {

--- a/src/renderer/src/components/browser-pane/stream-remote/use-remote-browser-page-input.ts
+++ b/src/renderer/src/components/browser-pane/stream-remote/use-remote-browser-page-input.ts
@@ -6,6 +6,7 @@ import {
   getRemoteBrowserKeypressKey
 } from './remote-browser-keyboard'
 import { isRemoteBrowserPageMissingError } from './remote-browser-stream-errors'
+import { sendRemoteBrowserClick } from './remote-browser-click-dispatch'
 import type { RemoteBrowserStreamLifecycle } from './remote-browser-stream-lifecycle'
 import type {
   RemoteBrowserOperationToken,
@@ -15,8 +16,11 @@ import type { BrowserScreencastFrameMetadata } from '../../../../../shared/brows
 import {
   getPositiveFiniteNumber,
   getRemoteBrowserMouseButton,
+  hasRemoteBrowserClickModifier,
+  isSimpleRemoteBrowserClick,
   type PendingRemoteBrowserWheel,
   type RemoteBrowserPaneNotice,
+  type RemoteBrowserPressState,
   type RemoteBrowserRuntimeTarget
 } from './remote-browser-page-input-model'
 
@@ -101,8 +105,14 @@ export function useRemoteBrowserPageInput({
   }) => { x: number; y: number } | null
   handleRemotePointerDown: (event: React.PointerEvent<HTMLImageElement>) => void
   handleRemotePointerUp: (event: React.PointerEvent<HTMLImageElement>) => void
+  handleRemotePointerCancel: () => void
   handleRemoteScreenshotKeyDown: (event: React.KeyboardEvent<HTMLImageElement>) => void
 } {
+  const pendingPressRef = useRef<RemoteBrowserPressState | null>(null)
+  // Hosts predating browser.mouseClick answer method_not_found; remember per environment so the
+  // legacy chain is not re-probed on every click.
+  const mouseClickUnsupportedEnvironmentRef = useRef<string | null>(null)
+
   const getRemoteImagePoint = useCallback(
     (event: { clientX: number; clientY: number }): { x: number; y: number } | null => {
       const image = imageRef.current
@@ -132,6 +142,8 @@ export function useRemoteBrowserPageInput({
     [frameMetadata, imageRef, remoteCssViewportSizeRef, remoteViewportRef, remoteViewportSizeRef]
   )
 
+  // Why the press is held until release: a plain click then costs one atomic browser.mouseClick
+  // instead of four serialized round trips, and only the release proves it was not a drag.
   const handleRemotePointerDown = (event: React.PointerEvent<HTMLImageElement>): void => {
     if (busy) {
       return
@@ -139,52 +151,33 @@ export function useRemoteBrowserPageInput({
     const target = runtimeTarget()
     const pageId = lifecycle.tokens.remotePage
     const image = imageRef.current
-    const operationToken = pageId ? createRemoteOperationToken(pageId) : null
     const point = getRemoteImagePoint(event)
     const button = getRemoteBrowserMouseButton(event.button)
     if (button === 'right') {
       return
     }
-    if (!target || !pageId || !image || !operationToken || !point || !button) {
+    if (!target || !pageId || !image || !point || !button) {
       return
     }
     event.preventDefault()
     image.focus()
     setPaneNotice(null)
-    enqueueRemoteInput(async () => {
-      if (!isCurrentRemoteOperationToken(operationToken)) {
-        return
-      }
-      try {
-        const params = { worktree: runtimeWorktree, page: pageId }
-        await callRuntimeRpc(
-          target,
-          'browser.mouseMove',
-          { ...params, x: point.x, y: point.y },
-          { timeoutMs: 15_000, suppressFeatureInteraction: true }
-        )
-        await callRuntimeRpc(
-          target,
-          'browser.mouseDown',
-          { ...params, button },
-          { timeoutMs: 15_000, suppressFeatureInteraction: true }
-        )
-      } catch (error) {
-        if (isCurrentRemoteOperationToken(operationToken)) {
-          if (isRemoteBrowserPageMissingError(error)) {
-            closeMissingRemotePage(pageId)
-            return
-          }
-          setPaneNotice({
-            kind: 'consequence',
-            text: error instanceof Error ? error.message : 'Remote mouse input failed.'
-          })
-        }
-      }
-    })
+    pendingPressRef.current = {
+      environmentId: target.environmentId,
+      pageId,
+      button,
+      point,
+      modified: hasRemoteBrowserClickModifier(event)
+    }
+  }
+
+  const handleRemotePointerCancel = (): void => {
+    pendingPressRef.current = null
   }
 
   const handleRemotePointerUp = (event: React.PointerEvent<HTMLImageElement>): void => {
+    const press = pendingPressRef.current
+    pendingPressRef.current = null
     if (busy) {
       return
     }
@@ -196,29 +189,38 @@ export function useRemoteBrowserPageInput({
     if (button === 'right') {
       return
     }
-    if (!target || !pageId || !operationToken || !point || !button) {
+    if (!press || !target || !pageId || !operationToken || !point || !button) {
+      return
+    }
+    const release: RemoteBrowserPressState = {
+      environmentId: target.environmentId,
+      pageId,
+      button,
+      point,
+      modified: hasRemoteBrowserClickModifier(event)
+    }
+    if (press.environmentId !== release.environmentId || press.pageId !== release.pageId) {
       return
     }
     event.preventDefault()
     setPaneNotice(null)
+    const atomic = isSimpleRemoteBrowserClick(press, release)
     enqueueRemoteInput(async () => {
       if (!isCurrentRemoteOperationToken(operationToken)) {
         return
       }
       try {
-        const params = { worktree: runtimeWorktree, page: pageId }
-        await callRuntimeRpc(
+        await sendRemoteBrowserClick({
           target,
-          'browser.mouseMove',
-          { ...params, x: point.x, y: point.y },
-          { timeoutMs: 15_000, suppressFeatureInteraction: true }
-        )
-        await callRuntimeRpc(
-          target,
-          'browser.mouseUp',
-          { ...params, button },
-          { timeoutMs: 15_000, suppressFeatureInteraction: true }
-        )
+          params: { worktree: runtimeWorktree, page: pageId },
+          press,
+          release,
+          preferAtomicClick:
+            atomic && mouseClickUnsupportedEnvironmentRef.current !== target.environmentId,
+          onAtomicClickUnsupported: () => {
+            mouseClickUnsupportedEnvironmentRef.current = target.environmentId
+          }
+        })
         scheduleRemoteTabInfoRefresh(operationToken, 250)
       } catch (error) {
         if (isCurrentRemoteOperationToken(operationToken)) {
@@ -291,6 +293,7 @@ export function useRemoteBrowserPageInput({
     getRemoteImagePoint,
     handleRemotePointerDown,
     handleRemotePointerUp,
+    handleRemotePointerCancel,
     handleRemoteScreenshotKeyDown
   }
 }

--- a/src/renderer/src/components/browser-pane/stream-remote/use-remote-browser-page-input.ts
+++ b/src/renderer/src/components/browser-pane/stream-remote/use-remote-browser-page-input.ts
@@ -199,7 +199,13 @@ export function useRemoteBrowserPageInput({
       point,
       modified: hasRemoteBrowserClickModifier(event)
     }
-    if (press.environmentId !== release.environmentId || press.pageId !== release.pageId) {
+    // Why drop instead of replay: an incoherent pair (page swapped, or a second button pressed
+    // before this release) would put a button down that nothing releases.
+    if (
+      press.environmentId !== release.environmentId ||
+      press.pageId !== release.pageId ||
+      press.button !== release.button
+    ) {
       return
     }
     event.preventDefault()

--- a/src/renderer/src/components/browser-pane/stream-remote/use-remote-browser-page-input.ts
+++ b/src/renderer/src/components/browser-pane/stream-remote/use-remote-browser-page-input.ts
@@ -81,6 +81,7 @@ export function useRemoteBrowserPageInput({
   remoteCssViewportSizeRef,
   remoteViewportSizeRef,
   frameMetadata,
+  frameUrl,
   runtimeTarget,
   lifecycle,
   runtimeWorktree,
@@ -98,6 +99,7 @@ export function useRemoteBrowserPageInput({
   remoteCssViewportSizeRef: React.MutableRefObject<RemoteBrowserViewportSize | null>
   remoteViewportSizeRef: React.MutableRefObject<RemoteBrowserViewportSize | null>
   frameMetadata: BrowserScreencastFrameMetadata | null
+  frameUrl: string | null
   runtimeTarget: () => RemoteBrowserRuntimeTarget | null
   lifecycle: RemoteBrowserStreamLifecycle
   runtimeWorktree: string
@@ -154,6 +156,7 @@ export function useRemoteBrowserPageInput({
     useRemoteBrowserPagePress({
       busy,
       imageRef,
+      frameUrl,
       getRemoteImagePoint,
       runtimeTarget,
       lifecycle,

--- a/src/renderer/src/components/browser-pane/stream-remote/use-remote-browser-page-input.ts
+++ b/src/renderer/src/components/browser-pane/stream-remote/use-remote-browser-page-input.ts
@@ -6,7 +6,7 @@ import {
   getRemoteBrowserKeypressKey
 } from './remote-browser-keyboard'
 import { isRemoteBrowserPageMissingError } from './remote-browser-stream-errors'
-import { sendRemoteBrowserClick } from './remote-browser-click-dispatch'
+import { useRemoteBrowserPagePress } from './use-remote-browser-page-press'
 import type { RemoteBrowserStreamLifecycle } from './remote-browser-stream-lifecycle'
 import type {
   RemoteBrowserOperationToken,
@@ -15,25 +15,25 @@ import type {
 import type { BrowserScreencastFrameMetadata } from '../../../../../shared/browser-screencast-protocol'
 import {
   getPositiveFiniteNumber,
-  getRemoteBrowserMouseButton,
-  hasRemoteBrowserClickModifier,
-  isSimpleRemoteBrowserClick,
+  type PendingRemoteBrowserPress,
   type PendingRemoteBrowserWheel,
   type RemoteBrowserPaneNotice,
-  type RemoteBrowserPressState,
   type RemoteBrowserRuntimeTarget
 } from './remote-browser-page-input-model'
 
 export function useRemoteBrowserPageInputQueue(): {
   enqueueRemoteInput: (operation: () => Promise<void>) => Promise<void>
   clearPendingRemoteWheel: () => void
+  clearPendingRemotePress: () => void
   resetRemoteInputQueue: () => void
   pendingRemoteWheelRef: React.MutableRefObject<PendingRemoteBrowserWheel | null>
+  pendingPressRef: React.MutableRefObject<PendingRemoteBrowserPress | null>
   remoteWheelFrameRef: React.MutableRefObject<number | null>
   remoteWheelInFlightRef: React.MutableRefObject<boolean>
 } {
   const remoteInputQueueRef = useRef<Promise<unknown>>(Promise.resolve())
   const pendingRemoteWheelRef = useRef<PendingRemoteBrowserWheel | null>(null)
+  const pendingPressRef = useRef<PendingRemoteBrowserPress | null>(null)
   const remoteWheelFrameRef = useRef<number | null>(null)
   const remoteWheelInFlightRef = useRef(false)
 
@@ -56,11 +56,19 @@ export function useRemoteBrowserPageInputQueue(): {
     }
   }, [])
 
+  // The press owns how it ends (a hold that already put the remote button down must lift it), so
+  // this only asks it to; the pane's identity-change reset reaches it through here.
+  const clearPendingRemotePress = useCallback((): void => {
+    pendingPressRef.current?.abandon()
+  }, [])
+
   return {
     enqueueRemoteInput,
     clearPendingRemoteWheel,
+    clearPendingRemotePress,
     resetRemoteInputQueue,
     pendingRemoteWheelRef,
+    pendingPressRef,
     remoteWheelFrameRef,
     remoteWheelInFlightRef
   }
@@ -81,7 +89,8 @@ export function useRemoteBrowserPageInput({
   isCurrentRemoteOperationToken,
   closeMissingRemotePage,
   scheduleRemoteTabInfoRefresh,
-  setPaneNotice
+  setPaneNotice,
+  pendingPressRef
 }: {
   busy: boolean
   imageRef: React.RefObject<HTMLImageElement | null>
@@ -98,6 +107,7 @@ export function useRemoteBrowserPageInput({
   closeMissingRemotePage: (remotePageId?: string | null) => void
   scheduleRemoteTabInfoRefresh: (token: RemoteBrowserOperationToken, delayMs?: number) => void
   setPaneNotice: (notice: RemoteBrowserPaneNotice | null) => void
+  pendingPressRef: React.MutableRefObject<PendingRemoteBrowserPress | null>
 }): {
   getRemoteImagePoint: (event: {
     clientX: number
@@ -108,11 +118,6 @@ export function useRemoteBrowserPageInput({
   handleRemotePointerCancel: () => void
   handleRemoteScreenshotKeyDown: (event: React.KeyboardEvent<HTMLImageElement>) => void
 } {
-  const pendingPressRef = useRef<RemoteBrowserPressState | null>(null)
-  // Hosts predating browser.mouseClick answer method_not_found; remember per environment so the
-  // legacy chain is not re-probed on every click.
-  const mouseClickUnsupportedEnvironmentRef = useRef<string | null>(null)
-
   const getRemoteImagePoint = useCallback(
     (event: { clientX: number; clientY: number }): { x: number; y: number } | null => {
       const image = imageRef.current
@@ -143,105 +148,24 @@ export function useRemoteBrowserPageInput({
   )
 
   // Why the press is held until release: a plain click then costs one atomic browser.mouseClick
-  // instead of four serialized round trips, and only the release proves it was not a drag.
-  const handleRemotePointerDown = (event: React.PointerEvent<HTMLImageElement>): void => {
-    if (busy) {
-      return
-    }
-    const target = runtimeTarget()
-    const pageId = lifecycle.tokens.remotePage
-    const image = imageRef.current
-    const point = getRemoteImagePoint(event)
-    const button = getRemoteBrowserMouseButton(event.button)
-    if (button === 'right') {
-      return
-    }
-    if (!target || !pageId || !image || !point || !button) {
-      return
-    }
-    event.preventDefault()
-    image.focus()
-    setPaneNotice(null)
-    pendingPressRef.current = {
-      environmentId: target.environmentId,
-      pageId,
-      button,
-      point,
-      modified: hasRemoteBrowserClickModifier(event)
-    }
-  }
-
-  const handleRemotePointerCancel = (): void => {
-    pendingPressRef.current = null
-  }
-
-  const handleRemotePointerUp = (event: React.PointerEvent<HTMLImageElement>): void => {
-    const press = pendingPressRef.current
-    pendingPressRef.current = null
-    if (busy) {
-      return
-    }
-    const target = runtimeTarget()
-    const pageId = lifecycle.tokens.remotePage
-    const operationToken = pageId ? createRemoteOperationToken(pageId) : null
-    const point = getRemoteImagePoint(event)
-    const button = getRemoteBrowserMouseButton(event.button)
-    if (button === 'right') {
-      return
-    }
-    if (!press || !target || !pageId || !operationToken || !point || !button) {
-      return
-    }
-    const release: RemoteBrowserPressState = {
-      environmentId: target.environmentId,
-      pageId,
-      button,
-      point,
-      modified: hasRemoteBrowserClickModifier(event)
-    }
-    // Why drop instead of replay: an incoherent pair (page swapped, or a second button pressed
-    // before this release) would put a button down that nothing releases.
-    if (
-      press.environmentId !== release.environmentId ||
-      press.pageId !== release.pageId ||
-      press.button !== release.button
-    ) {
-      return
-    }
-    event.preventDefault()
-    setPaneNotice(null)
-    const atomic = isSimpleRemoteBrowserClick(press, release)
-    enqueueRemoteInput(async () => {
-      if (!isCurrentRemoteOperationToken(operationToken)) {
-        return
-      }
-      try {
-        await sendRemoteBrowserClick({
-          target,
-          params: { worktree: runtimeWorktree, page: pageId },
-          press,
-          release,
-          preferAtomicClick:
-            atomic && mouseClickUnsupportedEnvironmentRef.current !== target.environmentId,
-          onAtomicClickUnsupported: () => {
-            mouseClickUnsupportedEnvironmentRef.current = target.environmentId
-          }
-        })
-        scheduleRemoteTabInfoRefresh(operationToken, 250)
-      } catch (error) {
-        if (isCurrentRemoteOperationToken(operationToken)) {
-          if (isRemoteBrowserPageMissingError(error)) {
-            closeMissingRemotePage(pageId)
-            return
-          }
-          setPaneNotice({
-            kind: 'consequence',
-            text: error instanceof Error ? error.message : 'Remote mouse input failed.'
-          })
-        }
-      }
+  // instead of four serialized round trips, and only the release proves it was not a drag — while a
+  // press held past the threshold puts the button down without waiting for one.
+  const { handleRemotePointerDown, handleRemotePointerUp, handleRemotePointerCancel } =
+    useRemoteBrowserPagePress({
+      busy,
+      imageRef,
+      getRemoteImagePoint,
+      runtimeTarget,
+      lifecycle,
+      runtimeWorktree,
+      enqueueRemoteInput,
+      createRemoteOperationToken,
+      isCurrentRemoteOperationToken,
+      closeMissingRemotePage,
+      scheduleRemoteTabInfoRefresh,
+      setPaneNotice,
+      pendingPressRef
     })
-  }
 
   const handleRemoteScreenshotKeyDown = (event: React.KeyboardEvent<HTMLImageElement>): void => {
     if (isEditableKeyboardTarget(event.target)) {

--- a/src/renderer/src/components/browser-pane/stream-remote/use-remote-browser-page-lifecycle.ts
+++ b/src/renderer/src/components/browser-pane/stream-remote/use-remote-browser-page-lifecycle.ts
@@ -30,6 +30,7 @@ export function useRemoteBrowserPageLifecycle({
   setPaneNotice,
   setPaneBusy,
   clearPendingRemoteWheel,
+  clearPendingRemotePress,
   resetRemoteInputQueue
 }: {
   browserTab: BrowserPageState
@@ -39,6 +40,7 @@ export function useRemoteBrowserPageLifecycle({
   setPaneNotice: (notice: RemoteBrowserPaneNotice | null) => void
   setPaneBusy: (busy: boolean) => void
   clearPendingRemoteWheel: () => void
+  clearPendingRemotePress: () => void
   resetRemoteInputQueue: () => void
 }) {
   const [frameUrl, setFrameUrl] = useState<string | null>(null)
@@ -214,13 +216,15 @@ export function useRemoteBrowserPageLifecycle({
   }, [clearPendingRemoteWheel, lifecycle])
 
   useEffect(() => {
-    // Why: only reset frame/wheel on identity change; bumping the stream/operation generations here races the streaming effect and wedges the pane.
+    // Why: only reset frame/wheel/press on identity change; bumping the stream/operation generations here races the streaming effect and wedges the pane.
     lifecycle.forgetStreamViewportSize()
     clearPendingRemoteWheel()
+    clearPendingRemotePress()
     clearStreamFrame()
   }, [
     activeRuntimeEnvironmentId,
     browserTab.id,
+    clearPendingRemotePress,
     clearPendingRemoteWheel,
     clearStreamFrame,
     lifecycle

--- a/src/renderer/src/components/browser-pane/stream-remote/use-remote-browser-page-press.ts
+++ b/src/renderer/src/components/browser-pane/stream-remote/use-remote-browser-page-press.ts
@@ -12,6 +12,7 @@ import {
   hasRemoteBrowserClickModifier,
   isSimpleRemoteBrowserClick,
   REMOTE_BROWSER_PRESS_HOLD_MS,
+  REMOTE_BROWSER_PRESS_MAX_AGE_MS,
   type PendingRemoteBrowserPress,
   type RemoteBrowserImagePoint,
   type RemoteBrowserPaneNotice,
@@ -25,6 +26,7 @@ import {
 export function useRemoteBrowserPagePress({
   busy,
   imageRef,
+  frameUrl,
   getRemoteImagePoint,
   runtimeTarget,
   lifecycle,
@@ -39,6 +41,7 @@ export function useRemoteBrowserPagePress({
 }: {
   busy: boolean
   imageRef: React.RefObject<HTMLImageElement | null>
+  frameUrl: string | null
   getRemoteImagePoint: (event: {
     clientX: number
     clientY: number
@@ -197,6 +200,14 @@ export function useRemoteBrowserPagePress({
         }
       }
     }
+    // Why capture: without it a release outside the <img> never arrives, so the press would sit
+    // here until some unrelated later pointerup replayed it as a press the user never made.
+    try {
+      image.setPointerCapture(event.pointerId)
+    } catch {
+      // Detached image or a runtime without capture: the leave/blur handlers bound below are the
+      // fallback that bounds the press instead.
+    }
     pendingPressRef.current = pending
     pending.holdTimer = window.setTimeout(() => {
       pending.holdTimer = null
@@ -211,6 +222,11 @@ export function useRemoteBrowserPagePress({
   const handleRemotePointerUp = (event: React.PointerEvent<HTMLImageElement>): void => {
     const pending = pendingPressRef.current
     if (!pending) {
+      return
+    }
+    // A second pointer (touch/pen) must not consume this press. Mice share one pointerId, so the
+    // stray-pointerup case is bounded by capture, the leave/blur handlers, and the age cap.
+    if (pending.pointerId !== event.pointerId) {
       return
     }
     takePendingPress(pending)
@@ -251,7 +267,7 @@ export function useRemoteBrowserPagePress({
       return
     }
     const operationToken = createRemoteOperationToken(pageId)
-    if (!operationToken) {
+    if (!operationToken || Date.now() - pending.pressedAt > REMOTE_BROWSER_PRESS_MAX_AGE_MS) {
       return
     }
     const press = pending.press
@@ -278,6 +294,27 @@ export function useRemoteBrowserPagePress({
       }
     })
   }
+
+  // A pointer that leaves the frame (when capture was refused) or a frame that loses focus ends the
+  // gesture as far as this pane can tell. Keyed on whether a frame exists, not on which one: the
+  // screencast mints a new frameUrl per frame, and re-running this per frame would tear down the
+  // press mid-gesture.
+  const hasRemoteFrame = frameUrl !== null
+  useEffect(() => {
+    const image = imageRef.current
+    if (!image || !hasRemoteFrame) {
+      return
+    }
+    const abandonPendingPress = (): void => {
+      pendingPressRef.current?.abandon()
+    }
+    image.addEventListener('pointerleave', abandonPendingPress)
+    image.addEventListener('blur', abandonPendingPress)
+    return () => {
+      image.removeEventListener('pointerleave', abandonPendingPress)
+      image.removeEventListener('blur', abandonPendingPress)
+    }
+  }, [hasRemoteFrame, imageRef, pendingPressRef])
 
   // A pane torn down mid-hold would otherwise leave the remote button down for good.
   useEffect(

--- a/src/renderer/src/components/browser-pane/stream-remote/use-remote-browser-page-press.ts
+++ b/src/renderer/src/components/browser-pane/stream-remote/use-remote-browser-page-press.ts
@@ -1,0 +1,291 @@
+import { useCallback, useEffect, useRef } from 'react'
+import { isRemoteBrowserPageMissingError } from './remote-browser-stream-errors'
+import {
+  sendRemoteBrowserClick,
+  sendRemoteBrowserHeldRelease,
+  sendRemoteBrowserPressHold
+} from './remote-browser-click-dispatch'
+import type { RemoteBrowserStreamLifecycle } from './remote-browser-stream-lifecycle'
+import type { RemoteBrowserOperationToken } from './remote-browser-stream-tokens'
+import {
+  getRemoteBrowserMouseButton,
+  hasRemoteBrowserClickModifier,
+  isSimpleRemoteBrowserClick,
+  REMOTE_BROWSER_PRESS_HOLD_MS,
+  type PendingRemoteBrowserPress,
+  type RemoteBrowserImagePoint,
+  type RemoteBrowserPaneNotice,
+  type RemoteBrowserPressState,
+  type RemoteBrowserRuntimeTarget
+} from './remote-browser-page-input-model'
+
+// Owns one press at a time: a quick press becomes an atomic click on release, a held press puts the
+// button down while the user is still holding, and every way a press can end without a usable
+// release drops it — releasing the remote button first if the hold already put one down.
+export function useRemoteBrowserPagePress({
+  busy,
+  imageRef,
+  getRemoteImagePoint,
+  runtimeTarget,
+  lifecycle,
+  runtimeWorktree,
+  enqueueRemoteInput,
+  createRemoteOperationToken,
+  isCurrentRemoteOperationToken,
+  closeMissingRemotePage,
+  scheduleRemoteTabInfoRefresh,
+  setPaneNotice,
+  pendingPressRef
+}: {
+  busy: boolean
+  imageRef: React.RefObject<HTMLImageElement | null>
+  getRemoteImagePoint: (event: {
+    clientX: number
+    clientY: number
+  }) => RemoteBrowserImagePoint | null
+  runtimeTarget: () => RemoteBrowserRuntimeTarget | null
+  lifecycle: RemoteBrowserStreamLifecycle
+  runtimeWorktree: string
+  enqueueRemoteInput: (operation: () => Promise<void>) => Promise<void>
+  createRemoteOperationToken: (remotePageId?: string | null) => RemoteBrowserOperationToken | null
+  isCurrentRemoteOperationToken: (token: RemoteBrowserOperationToken) => boolean
+  closeMissingRemotePage: (remotePageId?: string | null) => void
+  scheduleRemoteTabInfoRefresh: (token: RemoteBrowserOperationToken, delayMs?: number) => void
+  setPaneNotice: (notice: RemoteBrowserPaneNotice | null) => void
+  pendingPressRef: React.MutableRefObject<PendingRemoteBrowserPress | null>
+}): {
+  handleRemotePointerDown: (event: React.PointerEvent<HTMLImageElement>) => void
+  handleRemotePointerUp: (event: React.PointerEvent<HTMLImageElement>) => void
+  handleRemotePointerCancel: () => void
+} {
+  // Hosts predating browser.mouseClick answer method_not_found; remember per environment so the
+  // legacy chain is not re-probed on every click.
+  const mouseClickUnsupportedEnvironmentRef = useRef<string | null>(null)
+
+  const reportRemoteInputFailure = useCallback(
+    (token: RemoteBrowserOperationToken, pageId: string, error: unknown): void => {
+      if (!isCurrentRemoteOperationToken(token)) {
+        return
+      }
+      if (isRemoteBrowserPageMissingError(error)) {
+        closeMissingRemotePage(pageId)
+        return
+      }
+      setPaneNotice({
+        kind: 'consequence',
+        text: error instanceof Error ? error.message : 'Remote mouse input failed.'
+      })
+    },
+    [closeMissingRemotePage, isCurrentRemoteOperationToken, setPaneNotice]
+  )
+
+  const takePendingPress = useCallback(
+    (pending: PendingRemoteBrowserPress): void => {
+      if (pendingPressRef.current === pending) {
+        pendingPressRef.current = null
+      }
+      if (pending.holdTimer !== null) {
+        window.clearTimeout(pending.holdTimer)
+        pending.holdTimer = null
+      }
+    },
+    [pendingPressRef]
+  )
+
+  const releaseHeldPress = useCallback(
+    (pending: PendingRemoteBrowserPress, release: RemoteBrowserPressState): void => {
+      // Why no operation-token guard here: the remote button is already down, and a guard that
+      // drops this release strands it for the life of the page.
+      void enqueueRemoteInput(async () => {
+        try {
+          await sendRemoteBrowserHeldRelease({
+            target: pending.target,
+            params: { worktree: runtimeWorktree, page: pending.press.pageId },
+            press: pending.press,
+            release
+          })
+        } catch (error) {
+          reportRemoteInputFailure(pending.operationToken, pending.press.pageId, error)
+        }
+      })
+    },
+    [enqueueRemoteInput, reportRemoteInputFailure, runtimeWorktree]
+  )
+
+  const dispatchPressHold = useCallback(
+    (pending: PendingRemoteBrowserPress): void => {
+      if (pendingPressRef.current !== pending || pending.holdDispatched) {
+        return
+      }
+      // The hold outlived the identity it was pressed against; a button down on another page is
+      // worse than a hold that never arrives.
+      if (
+        lifecycle.tokens.remotePage !== pending.press.pageId ||
+        runtimeTarget()?.environmentId !== pending.press.environmentId
+      ) {
+        takePendingPress(pending)
+        return
+      }
+      // Marked before the queued call runs so a release enqueued behind it always lifts this button.
+      pending.holdDispatched = true
+      void enqueueRemoteInput(async () => {
+        if (!isCurrentRemoteOperationToken(pending.operationToken)) {
+          return
+        }
+        try {
+          await sendRemoteBrowserPressHold({
+            target: pending.target,
+            params: { worktree: runtimeWorktree, page: pending.press.pageId },
+            press: pending.press
+          })
+        } catch (error) {
+          reportRemoteInputFailure(pending.operationToken, pending.press.pageId, error)
+        }
+      })
+    },
+    [
+      enqueueRemoteInput,
+      isCurrentRemoteOperationToken,
+      lifecycle,
+      pendingPressRef,
+      reportRemoteInputFailure,
+      runtimeTarget,
+      runtimeWorktree,
+      takePendingPress
+    ]
+  )
+
+  const handleRemotePointerDown = (event: React.PointerEvent<HTMLImageElement>): void => {
+    if (busy) {
+      return
+    }
+    const target = runtimeTarget()
+    const pageId = lifecycle.tokens.remotePage
+    const image = imageRef.current
+    const point = getRemoteImagePoint(event)
+    const button = getRemoteBrowserMouseButton(event.button)
+    if (button === 'right') {
+      return
+    }
+    const operationToken = pageId ? createRemoteOperationToken(pageId) : null
+    if (!target || !pageId || !image || !point || !button || !operationToken) {
+      return
+    }
+    // A press still pending here never got its release, so it can only be stale.
+    pendingPressRef.current?.abandon()
+    event.preventDefault()
+    image.focus()
+    setPaneNotice(null)
+    const pending: PendingRemoteBrowserPress = {
+      press: {
+        environmentId: target.environmentId,
+        pageId,
+        button,
+        point,
+        modified: hasRemoteBrowserClickModifier(event)
+      },
+      target,
+      operationToken,
+      pointerId: event.pointerId,
+      pressedAt: Date.now(),
+      holdTimer: null,
+      holdDispatched: false,
+      abandon: () => {
+        takePendingPress(pending)
+        if (pending.holdDispatched) {
+          releaseHeldPress(pending, pending.press)
+        }
+      }
+    }
+    pendingPressRef.current = pending
+    pending.holdTimer = window.setTimeout(() => {
+      pending.holdTimer = null
+      dispatchPressHold(pending)
+    }, REMOTE_BROWSER_PRESS_HOLD_MS)
+  }
+
+  const handleRemotePointerCancel = (): void => {
+    pendingPressRef.current?.abandon()
+  }
+
+  const handleRemotePointerUp = (event: React.PointerEvent<HTMLImageElement>): void => {
+    const pending = pendingPressRef.current
+    if (!pending) {
+      return
+    }
+    takePendingPress(pending)
+    const target = runtimeTarget()
+    const pageId = lifecycle.tokens.remotePage
+    const point = getRemoteImagePoint(event)
+    const button = getRemoteBrowserMouseButton(event.button)
+    // Why drop instead of replay: an incoherent pair (page swapped, or a second button pressed
+    // before this release) would put a button down that nothing releases. A hold already put one
+    // down, so that one is still lifted, at the point it was pressed.
+    if (
+      busy ||
+      !target ||
+      !pageId ||
+      !point ||
+      !button ||
+      button === 'right' ||
+      target.environmentId !== pending.press.environmentId ||
+      pageId !== pending.press.pageId ||
+      button !== pending.press.button
+    ) {
+      if (pending.holdDispatched) {
+        releaseHeldPress(pending, pending.press)
+      }
+      return
+    }
+    const release: RemoteBrowserPressState = {
+      environmentId: target.environmentId,
+      pageId,
+      button,
+      point,
+      modified: hasRemoteBrowserClickModifier(event)
+    }
+    event.preventDefault()
+    setPaneNotice(null)
+    if (pending.holdDispatched) {
+      releaseHeldPress(pending, release)
+      return
+    }
+    const operationToken = createRemoteOperationToken(pageId)
+    if (!operationToken) {
+      return
+    }
+    const press = pending.press
+    const atomic = isSimpleRemoteBrowserClick(press, release)
+    void enqueueRemoteInput(async () => {
+      if (!isCurrentRemoteOperationToken(operationToken)) {
+        return
+      }
+      try {
+        await sendRemoteBrowserClick({
+          target,
+          params: { worktree: runtimeWorktree, page: pageId },
+          press,
+          release,
+          preferAtomicClick:
+            atomic && mouseClickUnsupportedEnvironmentRef.current !== target.environmentId,
+          onAtomicClickUnsupported: () => {
+            mouseClickUnsupportedEnvironmentRef.current = target.environmentId
+          }
+        })
+        scheduleRemoteTabInfoRefresh(operationToken, 250)
+      } catch (error) {
+        reportRemoteInputFailure(operationToken, pageId, error)
+      }
+    })
+  }
+
+  // A pane torn down mid-hold would otherwise leave the remote button down for good.
+  useEffect(
+    () => () => {
+      pendingPressRef.current?.abandon()
+    },
+    [pendingPressRef]
+  )
+
+  return { handleRemotePointerDown, handleRemotePointerUp, handleRemotePointerCancel }
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​416 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​415 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​560 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​105 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​455 |

<!-- /orca-pr-loc -->

Adopts the atomic `browser.mouseClick` RPC on the desktop's legacy screenshot-streamed remote-browser pane, replacing the four serialized RPCs previously issued per click (mouseMove+mouseDown on pointerdown, mouseMove+mouseUp on pointerup). Mirrors the decision logic mobile already uses, with a `method_not_found` fallback to the legacy chain cached per environment for old hosts.

Also fixes two press-lifecycle hazards: a cancelled/incoherent press no longer strands a pressed button on the remote page, and clicks whose press/release buttons differ are dropped.

Notes:
- Addresses the STA-4752 input-latency report for viewers on the legacy path (mobile/web/old hosts). The client-hosted path (STA-4150) is unaffected — it has no input forwarding.
- Intentionally not part of the STA-4150 stack: it targets main's `stream-remote/` pane layout, which the stack's lineage predates.
- No wire changes: `browser.mouseClick` is a pre-existing host method already used by mobile clients.
- Tests: 94 tests in `stream-remote/` pass including new click-vs-drag decision coverage (non-vacuity verified by forcing the atomic path off); typecheck and changed-code gates clean.
- Known follow-up (deliberate): press-and-hold no longer shows a held state remotely (the click lands at release); pointer released outside the frame drops the drag instead of stranding a stuck button — `setPointerCapture` on pointerdown would recover the drag and is left as a surgical follow-up.