### PR TITLE
fix(sidebar): render folder workspaces under every Group by mode (#15362)

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -35,6 +35,7 @@ import { useSidebarWorktreeSelection } from './worktree-list/navigation/use-sele
 import { useSidebarWorktreeSortOrder } from './worktree-list/listing/use-sort-order'
 import { useVisibleSidebarWorktrees } from './worktree-list/listing/use-visible-worktrees'
 import { useWorktreeStatusMutations } from './worktree-list/drag/use-status-mutations'
+import { shouldFiltersHideAllRows } from './sidebar-empty-state-gate'
 
 type WorktreeListProps = {
   scrollOffsetRef: React.MutableRefObject<number>
@@ -126,7 +127,9 @@ const WorktreeList = React.memo(function WorktreeList({
     workspaceStatuses,
     settings,
     projectGroups,
-    projectGrouping
+    projectGrouping,
+    folderWorkspaces,
+    defaultHostId
   })
   const visibleScope = useSidebarHostVisibleScope({
     filterState,
@@ -233,11 +236,13 @@ const WorktreeList = React.memo(function WorktreeList({
     clearFilters
   })
 
-  const filtersHideAllRows =
-    hasFilters &&
-    visibleWorktrees.length === 0 &&
-    rowModel.placeholderRepoIds.size === 0 &&
-    externalWorktreeCards.importedWorktreesByRepo.size === 0
+  const filtersHideAllRows = shouldFiltersHideAllRows({
+    hasFilters,
+    visibleWorktreeCount: visibleWorktrees.length,
+    visibleFolderWorkspaceCount: visibleScope.visibleFolderWorkspacesForRows.length,
+    placeholderRepoCount: rowModel.placeholderRepoIds.size,
+    importedWorktreeCardCount: externalWorktreeCards.importedWorktreesByRepo.size
+  })
   // Why: when active filters hide every row, the Clear Filters empty state must win over Project Group headers.
   if (rowModel.rows.length === 0 || filtersHideAllRows) {
     return <SidebarWorktreeListEmptyState hasFilters={hasFilters} onClearFilters={clearFilters} />

--- a/src/renderer/src/components/sidebar/folder-workspace-host-id.ts
+++ b/src/renderer/src/components/sidebar/folder-workspace-host-id.ts
@@ -1,0 +1,21 @@
+import { toSshExecutionHostId, type ExecutionHostId } from '../../../../shared/execution-host'
+import type { FolderWorkspace } from '../../../../shared/folder-workspace-types'
+import type { ProjectGroup } from '../../../../shared/project-group-types'
+
+/**
+ * Which host section a folder workspace's row belongs to.
+ *
+ * Single source of truth: header counting, host bucketing and reveal all resolve
+ * the host through here. Two resolvers that drift is how folder workspaces went
+ * missing from the sidebar in the first place (#15362). Deliberately distinct
+ * from the host *filter* resolver, which also consults executionHostId — this
+ * one must match where the row actually renders.
+ */
+export function getFolderWorkspaceHostId(
+  folderWorkspace: Pick<FolderWorkspace, 'connectionId'>,
+  projectGroup: Pick<ProjectGroup, 'connectionId'>,
+  defaultHostId: ExecutionHostId
+): ExecutionHostId {
+  const connectionId = folderWorkspace.connectionId ?? projectGroup.connectionId
+  return connectionId ? toSshExecutionHostId(connectionId) : defaultHostId
+}

--- a/src/renderer/src/components/sidebar/host-section-folder-workspace-counts.test.ts
+++ b/src/renderer/src/components/sidebar/host-section-folder-workspace-counts.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest'
+import type { ProjectGroup } from '../../../../shared/project-group-types'
+import type { Repo } from '../../../../shared/repo-types'
+import type { Worktree } from '../../../../shared/worktree/types'
+import type { Row } from './worktree-list/grouping/row-types'
+import { addHostSectionRows, type HostSectionOption } from './host-section-rows'
+
+const LOCAL_REPO: Repo = {
+  id: 'local-repo',
+  path: '/local-repo',
+  displayName: 'Local',
+  badgeColor: '#000000',
+  addedAt: 0
+}
+
+const LOCAL_WORKTREE: Worktree = {
+  id: 'local-worktree',
+  repoId: LOCAL_REPO.id,
+  path: '/local-repo/worktree',
+  branch: 'refs/heads/main',
+  head: 'abc123',
+  isBare: false,
+  isMainWorktree: false,
+  linkedIssue: null,
+  linkedPR: null,
+  linkedLinearIssue: null,
+  isArchived: false,
+  comment: '',
+  isUnread: false,
+  isPinned: false,
+  displayName: 'Local worktree',
+  sortOrder: 0,
+  lastActivityAt: 0
+}
+
+const HOSTS: HostSectionOption[] = [
+  { id: 'local', kind: 'local', label: 'Local', detail: 'This computer', health: 'local' },
+  { id: 'ssh:builder', kind: 'ssh', label: 'Builder', detail: 'SSH', health: 'available' }
+]
+
+const LOCAL_ROW: Extract<Row, { type: 'item' }> = {
+  type: 'item',
+  rowKey: 'local-worktree',
+  sectionKey: 'all',
+  worktree: LOCAL_WORKTREE,
+  repo: LOCAL_REPO,
+  depth: 0,
+  groupDepth: 0,
+  lineageTrail: [],
+  isLastLineageChild: true,
+  lineageChildCount: 0
+}
+
+const PROJECT_GROUP: ProjectGroup = {
+  id: 'group-1',
+  name: 'Remote folder',
+  parentPath: '/srv/project',
+  connectionId: 'builder',
+  parentGroupId: null,
+  createdFrom: 'manual',
+  tabOrder: 0,
+  isCollapsed: false,
+  color: null,
+  createdAt: 1,
+  updatedAt: 1
+}
+
+const FOLDER_ROW: Extract<Row, { type: 'folder-workspace' }> = {
+  type: 'folder-workspace',
+  key: 'folder-workspace:folder-1',
+  folderWorkspace: {
+    id: 'folder-1',
+    projectGroupId: PROJECT_GROUP.id,
+    name: 'Remote folder workspace',
+    folderPath: '/srv/project',
+    connectionId: 'builder',
+    linkedTask: null,
+    comment: '',
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 1,
+    createdAt: 1,
+    updatedAt: 1
+  },
+  projectGroup: PROJECT_GROUP,
+  depth: 0,
+  groupDepth: 0
+}
+
+function hostCounts(rows: readonly Row[]) {
+  return addHostSectionRows({
+    rows,
+    hostOptions: HOSTS,
+    workspaceHostScope: 'all',
+    defaultHostId: 'local'
+  })
+    .filter((row) => row.type === 'host-header')
+    .map(({ hostId, count }) => ({ hostId, count }))
+}
+
+describe('folder workspace host counts', () => {
+  it('counts an expanded folder workspace row', () => {
+    expect(hostCounts([LOCAL_ROW, FOLDER_ROW])).toEqual([
+      { hostId: 'local', count: 1 },
+      { hostId: 'ssh:builder', count: 1 }
+    ])
+  })
+
+  it('counts a collapsed folder-only lane from its header', () => {
+    const collapsedLane: Extract<Row, { type: 'header' }> = {
+      type: 'header',
+      key: 'workspace-status:in-progress',
+      label: 'In progress',
+      count: 1,
+      tone: 'text-foreground',
+      hostWorktreeCounts: new Map([['ssh:builder', 1]]),
+      hostWorktreeIds: new Map([['ssh:builder', []]])
+    }
+
+    expect(hostCounts([collapsedLane, LOCAL_ROW])).toEqual([
+      { hostId: 'local', count: 1 },
+      { hostId: 'ssh:builder', count: 1 }
+    ])
+  })
+})

--- a/src/renderer/src/components/sidebar/host-section-rows.ts
+++ b/src/renderer/src/components/sidebar/host-section-rows.ts
@@ -81,29 +81,32 @@ function getFallbackHost(hostId: ExecutionHostId): HostSectionOption {
   }
 }
 
-function countWorktreeRows(rows: readonly Row[]): number {
+function countWorkspaceRows(rows: readonly Row[]): number {
   // Why: a collapsed repo group contributes a header row but no item rows;
   // fall back to the header's own count so the host badge doesn't read 0
   // while a visibly populated project sits right under it.
   let count = 0
   const seenWorktreeIds = new Set<string>()
   let pendingHeader: Extract<Row, { type: 'header' }> | null = null
-  let pendingHeaderHadItems = false
+  let pendingHeaderHadWorkspaces = false
   const flushHeader = (): void => {
-    if (pendingHeader && !pendingHeaderHadItems) {
+    if (pendingHeader && !pendingHeaderHadWorkspaces) {
       if (pendingHeader.worktreeIds) {
+        const headerWorktreeIds = new Set(pendingHeader.worktreeIds)
         for (const worktreeId of pendingHeader.worktreeIds) {
           if (!seenWorktreeIds.has(worktreeId)) {
             count += 1
             seenWorktreeIds.add(worktreeId)
           }
         }
+        // Folder workspaces contribute to the header count but have no worktree id.
+        count += Math.max(0, pendingHeader.count - headerWorktreeIds.size)
       } else {
         count += pendingHeader.count
       }
     }
     pendingHeader = null
-    pendingHeaderHadItems = false
+    pendingHeaderHadWorkspaces = false
   }
   for (const row of rows) {
     if (row.type === 'header') {
@@ -116,7 +119,12 @@ function countWorktreeRows(rows: readonly Row[]): number {
         count += 1
         seenWorktreeIds.add(row.worktree.id)
       }
-      pendingHeaderHadItems = pendingHeader !== null
+      pendingHeaderHadWorkspaces = pendingHeader !== null
+      continue
+    }
+    if (row.type === 'folder-workspace') {
+      count += 1
+      pendingHeaderHadWorkspaces = pendingHeader !== null
     }
   }
   flushHeader()
@@ -289,7 +297,7 @@ export function addHostSectionRows(args: {
       compatibility: host.compatibility,
       connectionStatus: host.connectionStatus,
       collapsed,
-      count: countWorktreeRows(hostRows)
+      count: countWorkspaceRows(hostRows)
     })
     if (!collapsed) {
       result.push(...hostRows)

--- a/src/renderer/src/components/sidebar/host-section-rows.ts
+++ b/src/renderer/src/components/sidebar/host-section-rows.ts
@@ -11,10 +11,9 @@ import {
 import type { ExecutionHostHealth } from '../../../../shared/execution-host-registry'
 import type { RuntimeCompatVerdict } from '../../../../shared/protocol-compat'
 import type { SshConnectionStatus } from '../../../../shared/ssh-types'
-import type { FolderWorkspace } from '../../../../shared/folder-workspace-types'
-import type { ProjectGroup } from '../../../../shared/project-group-types'
 import type { Repo } from '../../../../shared/repo-types'
 import type { Row } from './worktree-list/grouping/row-types'
+import { getFolderWorkspaceHostId } from './folder-workspace-host-id'
 
 export type HostHeaderRow = {
   type: 'host-header'
@@ -54,19 +53,6 @@ function getRepoHostId(
     return getRepoExecutionHostId(repo)
   }
   return defaultHostId
-}
-
-function getSshHostId(connectionId: string): ExecutionHostId {
-  return `ssh:${encodeURIComponent(connectionId)}` as ExecutionHostId
-}
-
-function getFolderWorkspaceHostId(
-  folderWorkspace: Pick<FolderWorkspace, 'connectionId'>,
-  projectGroup: Pick<ProjectGroup, 'connectionId'>,
-  defaultHostId: ExecutionHostId
-): ExecutionHostId {
-  const connectionId = folderWorkspace.connectionId ?? projectGroup.connectionId
-  return connectionId ? getSshHostId(connectionId) : defaultHostId
 }
 
 function getRowHostId(row: Row, defaultHostId: ExecutionHostId): ExecutionHostId | null {

--- a/src/renderer/src/components/sidebar/sidebar-empty-state-gate.test.ts
+++ b/src/renderer/src/components/sidebar/sidebar-empty-state-gate.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { shouldFiltersHideAllRows } from './sidebar-empty-state-gate'
+
+const NOTHING_ELSE = {
+  visibleWorktreeCount: 0,
+  placeholderRepoCount: 0,
+  importedWorktreeCardCount: 0
+}
+
+describe('Clear Filters empty state', () => {
+  it('does not replace a folder-only sidebar when a filter is active', () => {
+    // The reported symptom reached by a second path: with any filter active
+    // (host scope counts), a folder-only account saw Clear Filters instead of
+    // its workspaces — under every Group by mode, including Project.
+    expect(
+      shouldFiltersHideAllRows({
+        ...NOTHING_ELSE,
+        hasFilters: true,
+        visibleFolderWorkspaceCount: 1
+      })
+    ).toBe(false)
+  })
+
+  it('still wins when filters hid every row kind', () => {
+    expect(
+      shouldFiltersHideAllRows({
+        ...NOTHING_ELSE,
+        hasFilters: true,
+        visibleFolderWorkspaceCount: 0
+      })
+    ).toBe(true)
+  })
+
+  it('never wins without active filters', () => {
+    expect(
+      shouldFiltersHideAllRows({
+        ...NOTHING_ELSE,
+        hasFilters: false,
+        visibleFolderWorkspaceCount: 0
+      })
+    ).toBe(false)
+  })
+
+  it('defers to worktrees, placeholders and imported cards as before', () => {
+    for (const key of [
+      'visibleWorktreeCount',
+      'placeholderRepoCount',
+      'importedWorktreeCardCount'
+    ] as const) {
+      expect(
+        shouldFiltersHideAllRows({
+          ...NOTHING_ELSE,
+          hasFilters: true,
+          visibleFolderWorkspaceCount: 0,
+          [key]: 1
+        })
+      ).toBe(false)
+    }
+  })
+})

--- a/src/renderer/src/components/sidebar/sidebar-empty-state-gate.ts
+++ b/src/renderer/src/components/sidebar/sidebar-empty-state-gate.ts
@@ -1,0 +1,24 @@
+/**
+ * Whether active filters have hidden every sidebar row, so the Clear Filters
+ * empty state should win over any remaining headers.
+ *
+ * Split out of WorktreeList so the row kinds it counts are testable: folder
+ * workspaces were missing from this gate, which meant an account whose only
+ * workspaces were folder workspaces lost them to the empty state as soon as any
+ * filter — including host scope — was active (#15362).
+ */
+export function shouldFiltersHideAllRows(counts: {
+  hasFilters: boolean
+  visibleWorktreeCount: number
+  visibleFolderWorkspaceCount: number
+  placeholderRepoCount: number
+  importedWorktreeCardCount: number
+}): boolean {
+  return (
+    counts.hasFilters &&
+    counts.visibleWorktreeCount === 0 &&
+    counts.visibleFolderWorkspaceCount === 0 &&
+    counts.placeholderRepoCount === 0 &&
+    counts.importedWorktreeCardCount === 0
+  )
+}

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.folder-workspace-lanes.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.folder-workspace-lanes.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it } from 'vitest'
+import { buildRows } from './build-rows'
+import { getFolderWorkspaceLaneKey } from './folder-workspace-lanes'
+import { getPRGroupKey, getPRLaneKey } from './group-keys'
+import type { Row, WorktreeGroupBy } from './row-types'
+import { repo, worktree } from '../../worktree-list-groups-test-fixtures'
+import type { FolderWorkspace } from '../../../../../../shared/folder-workspace-types'
+import type { ProjectGroup } from '../../../../../../shared/project-group-types'
+import type { Repo } from '../../../../../../shared/repo-types'
+import type { ExecutionHostId } from '../../../../../../shared/execution-host'
+
+const GROUP: ProjectGroup = {
+  id: 'group-1',
+  name: 'Multi-repo Group',
+  parentPath: '/tmp/parent',
+  parentGroupId: null,
+  createdFrom: 'folder-scan',
+  tabOrder: 0,
+  isCollapsed: false,
+  color: null,
+  createdAt: 1,
+  updatedAt: 1
+}
+
+function makeFolderWorkspace(overrides: Partial<FolderWorkspace> = {}): FolderWorkspace {
+  return {
+    id: 'fw-1',
+    projectGroupId: GROUP.id,
+    name: 'Folder workspace',
+    folderPath: '/tmp/parent',
+    linkedTask: null,
+    comment: '',
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 1,
+    lastActivityAt: 1,
+    createdAt: 1,
+    updatedAt: 1,
+    workspaceStatus: 'in-progress',
+    ...overrides
+  }
+}
+
+const GROUPED_REPO: Repo = { ...repo, projectGroupId: GROUP.id }
+
+function buildSidebarRows(options: {
+  groupBy: WorktreeGroupBy
+  folderWorkspaces?: readonly FolderWorkspace[]
+  projectGroups?: readonly ProjectGroup[]
+  worktrees?: (typeof worktree)[]
+  collapsedGroups?: Set<string>
+}): Row[] {
+  const worktrees = options.worktrees ?? [worktree]
+  return buildRows(
+    options.groupBy,
+    worktrees,
+    new Map([[GROUPED_REPO.id, GROUPED_REPO]]),
+    null,
+    options.collapsedGroups ?? new Set<string>(),
+    undefined,
+    undefined,
+    'manual',
+    {},
+    new Map(worktrees.map((entry) => [entry.id, entry])),
+    false,
+    undefined,
+    options.projectGroups ?? [GROUP],
+    new Set(),
+    new Map(),
+    new Map(),
+    [],
+    undefined,
+    options.folderWorkspaces ?? [makeFolderWorkspace()]
+  )
+}
+
+function folderRows(rows: Row[]): Extract<Row, { type: 'folder-workspace' }>[] {
+  return rows.filter(
+    (row): row is Extract<Row, { type: 'folder-workspace' }> => row.type === 'folder-workspace'
+  )
+}
+
+const ALL_GROUP_BY: WorktreeGroupBy[] = ['repo', 'workspace-status', 'pr-status', 'none']
+
+describe('folder workspaces render under every Group by mode', () => {
+  // The three non-repo arms are the acceptance evidence; the repo arm is a
+  // deliberate no-regression guard that also passed before the fix.
+  for (const groupBy of ALL_GROUP_BY) {
+    it(`emits the folder-workspace row when groupBy is ${groupBy}`, () => {
+      expect(folderRows(buildSidebarRows({ groupBy }))).toHaveLength(1)
+    })
+  }
+
+  it('does not duplicate the row under repo grouping', () => {
+    const rows = buildSidebarRows({ groupBy: 'repo' })
+    expect(folderRows(rows).map((row) => row.key)).toEqual(['folder-workspace:fw-1'])
+  })
+})
+
+describe('a folder workspace can be the only member of a lane', () => {
+  it('creates its status lane with no worktrees present', () => {
+    const rows = buildSidebarRows({ groupBy: 'workspace-status', worktrees: [] })
+    expect(folderRows(rows)).toHaveLength(1)
+    const header = rows.find((row) => row.type === 'header')
+    expect(header).toBeDefined()
+    expect(header && 'count' in header ? header.count : null).toBe(1)
+  })
+
+  it('renders in flat mode with no worktrees present', () => {
+    // Pre-fix the whole All section was gated on naturalWorktrees.length > 0,
+    // so a folder-only account saw nothing at all.
+    const rows = buildSidebarRows({ groupBy: 'none', worktrees: [] })
+    expect(folderRows(rows)).toHaveLength(1)
+  })
+})
+
+describe('lane assignment', () => {
+  it('routes to the same PR lane as a worktree with no PR', () => {
+    const laneKey = getFolderWorkspaceLaneKey(
+      { folderWorkspace: makeFolderWorkspace(), projectGroup: GROUP },
+      'pr-status',
+      []
+    )
+    const noPrWorktreeLane = getPRLaneKey(
+      getPRGroupKey(worktree, new Map([[GROUPED_REPO.id, GROUPED_REPO]]), null)
+    )
+    expect(laneKey).toBe(noPrWorktreeLane)
+  })
+})
+
+describe('ordering', () => {
+  const ordered = [
+    makeFolderWorkspace({ id: 'fw-low', name: 'Low', sortOrder: 1 }),
+    makeFolderWorkspace({ id: 'fw-high', name: 'High', sortOrder: 9 })
+  ]
+
+  // Both emitters are covered: grouped lanes and the separate flat-mode path.
+  for (const groupBy of ['workspace-status', 'none'] as WorktreeGroupBy[]) {
+    it(`orders by manualOrder then sortOrder under ${groupBy}`, () => {
+      const rows = buildSidebarRows({ groupBy, folderWorkspaces: ordered })
+      expect(folderRows(rows).map((row) => row.folderWorkspace.id)).toEqual(['fw-high', 'fw-low'])
+    })
+
+    it(`prefers manualOrder over sortOrder under ${groupBy}`, () => {
+      const rows = buildSidebarRows({
+        groupBy,
+        folderWorkspaces: [
+          makeFolderWorkspace({ id: 'fw-low', name: 'Low', sortOrder: 9, manualOrder: 1 }),
+          makeFolderWorkspace({ id: 'fw-high', name: 'High', sortOrder: 1, manualOrder: 9 })
+        ]
+      })
+      expect(folderRows(rows).map((row) => row.folderWorkspace.id)).toEqual(['fw-high', 'fw-low'])
+    })
+  }
+})
+
+describe('membership is decided once, not per mode', () => {
+  // Negative arm alone is vacuous (zero rows either way pre-fix), so it is
+  // paired with an explicitly non-repo positive arm.
+  it('renders nothing when the owning project group is not visible', () => {
+    const rows = buildSidebarRows({ groupBy: 'workspace-status', projectGroups: [] })
+    expect(folderRows(rows)).toHaveLength(0)
+  })
+
+  it('renders under a non-repo mode when the owning group is visible', () => {
+    const rows = buildSidebarRows({ groupBy: 'workspace-status' })
+    expect(folderRows(rows)).toHaveLength(1)
+  })
+
+  it('keeps archived folder workspaces behaving identically in every mode', () => {
+    const archived = [makeFolderWorkspace({ isArchived: true })]
+    const counts = ALL_GROUP_BY.map(
+      (groupBy) => folderRows(buildSidebarRows({ groupBy, folderWorkspaces: archived })).length
+    )
+    // Parity with today's behaviour: nothing filters folder workspaces by
+    // isArchived, so a mode must not be the thing that hides one.
+    expect(counts).toEqual([1, 1, 1, 1])
+  })
+})
+
+describe('host bookkeeping for lanes containing folder workspaces', () => {
+  const SSH_HOST = 'ssh:target-1' as ExecutionHostId
+
+  it('scopes a collapsed folder-only lane header to its host', () => {
+    const sshGroup: ProjectGroup = { ...GROUP, connectionId: 'target-1' }
+    const rows = buildRows(
+      'workspace-status',
+      [],
+      new Map(),
+      null,
+      new Set(['workspace-status:in-progress']),
+      undefined,
+      undefined,
+      'manual',
+      {},
+      new Map(),
+      false,
+      undefined,
+      [sshGroup],
+      new Set(),
+      new Map(),
+      new Map(),
+      [],
+      undefined,
+      [makeFolderWorkspace()]
+    )
+    const header = rows.find((row) => row.type === 'header')
+    expect(header).toBeDefined()
+    const counts = header && 'hostWorktreeCounts' in header ? header.hostWorktreeCounts : undefined
+    // Undefined counts render globally, which is exactly the pre-fix bug.
+    expect(counts).toBeDefined()
+    expect(counts?.get(SSH_HOST)).toBe(1)
+  })
+
+  it('gives a folder-only host an explicit empty id array', () => {
+    const sshGroup: ProjectGroup = { ...GROUP, connectionId: 'target-1' }
+    const rows = buildRows(
+      'workspace-status',
+      [],
+      new Map(),
+      null,
+      new Set(),
+      undefined,
+      undefined,
+      'manual',
+      {},
+      new Map(),
+      false,
+      undefined,
+      [sshGroup],
+      new Set(),
+      new Map(),
+      new Map(),
+      [],
+      undefined,
+      [makeFolderWorkspace()]
+    )
+    const header = rows.find((row) => row.type === 'header')
+    const ids = header && 'hostWorktreeIds' in header ? header.hostWorktreeIds : undefined
+    // The key must exist even though folder workspaces contribute no worktree
+    // ids, or the host-section fallback leaks the global id list into it.
+    expect(ids?.has(SSH_HOST)).toBe(true)
+    expect(ids?.get(SSH_HOST)).toEqual([])
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.ts
@@ -14,8 +14,8 @@ import { ALL_GROUP_KEY, ALL_GROUP_META } from './group-keys'
 import { appendOrderedGroups } from './group-sections'
 import type { SectionAppendContext } from './group-sections'
 import {
-  getHostWorktreeCounts,
-  getHostWorktreeIds,
+  getLaneHostWorktreeCounts,
+  getLaneHostWorktreeIds,
   getMixedWorktreeHostContextLabels
 } from './host-labels'
 import { buildProjectGroupingIndex } from './project-grouping'
@@ -23,7 +23,15 @@ import type { ProjectGroupingModel } from './project-grouping'
 import { appendProjectGroupSections } from './project-group-sections'
 import { getPinnedSectionWorktrees } from '../../pinned-section-worktrees'
 import { emitPinnedGroup } from './pinned-group-rows'
-import { appendWorktreeRows, buildPendingCreationRow } from './row-builders'
+import {
+  appendWorktreeRows,
+  buildFolderWorkspaceRow,
+  buildPendingCreationRow
+} from './row-builders'
+import {
+  compareFolderWorkspacesForDisplay,
+  getRenderableFolderWorkspaces
+} from './folder-workspace-lanes'
 import { getPinnedWorktreeDisplayPolicy } from './row-types'
 import type {
   ImportedWorktreesCardCandidate,
@@ -65,6 +73,9 @@ export function buildRows(
 ): Row[] {
   const result: Row[] = []
   const projectIndex = buildProjectGroupingIndex(projectGrouping)
+  // Membership is decided once, above the groupBy switch: every mode renders the
+  // same set of folder workspaces and only chooses where they land (#15362).
+  const renderableFolderWorkspaces = getRenderableFolderWorkspaces(folderWorkspaces, projectGroups)
   const cyclicLineageIds = nestLineage
     ? getCyclicProjectedWorktreeLineageIds(lineageById, worktreeMap)
     : new Set<string>()
@@ -124,16 +135,28 @@ export function buildRows(
     cyclicLineageIds
   )
   if (groupBy === 'none') {
-    if (naturalWorktrees.length > 0) {
+    // Why folder workspaces gate this too: an account with only folder
+    // workspaces rendered nothing at all in flat mode before (#15362).
+    if (naturalWorktrees.length > 0 || renderableFolderWorkspaces.length > 0) {
       result.push({
         type: 'header',
         key: ALL_GROUP_KEY,
         label: ALL_GROUP_META.label,
-        count: naturalWorktrees.length,
+        count: naturalWorktrees.length + renderableFolderWorkspaces.length,
         tone: ALL_GROUP_META.tone,
         icon: ALL_GROUP_META.icon,
-        hostWorktreeCounts: getHostWorktreeCounts(naturalWorktrees, repoMap, defaultHostId),
-        hostWorktreeIds: getHostWorktreeIds(naturalWorktrees, repoMap, defaultHostId),
+        hostWorktreeCounts: getLaneHostWorktreeCounts(
+          naturalWorktrees,
+          renderableFolderWorkspaces,
+          repoMap,
+          defaultHostId
+        ),
+        hostWorktreeIds: getLaneHostWorktreeIds(
+          naturalWorktrees,
+          renderableFolderWorkspaces,
+          repoMap,
+          defaultHostId
+        ),
         worktreeIds: naturalWorktrees.map((worktree) => worktree.id)
       })
       if (!collapsedGroups.has(ALL_GROUP_KEY)) {
@@ -145,6 +168,11 @@ export function buildRows(
           hostContextLabelByWorktreeIdentity: mixedWorktreeHostContextLabels,
           cyclicLineageIds
         })
+        for (const pair of [...renderableFolderWorkspaces].sort((left, right) =>
+          compareFolderWorkspacesForDisplay(left.folderWorkspace, right.folderWorkspace)
+        )) {
+          result.push(buildFolderWorkspaceRow(pair, 0))
+        }
       }
     }
     return result
@@ -163,7 +191,8 @@ export function buildRows(
     newExternalWorktreesInboxByRepo,
     pendingByRepo,
     repoOrder,
-    projectOrderBy
+    projectOrderBy,
+    folderWorkspaces: renderableFolderWorkspaces
   })
 
   const sectionContext: SectionAppendContext = {
@@ -196,7 +225,7 @@ export function buildRows(
   appendProjectGroupSections(sectionContext, {
     orderedGroups,
     projectGroups,
-    folderWorkspaces,
+    folderWorkspaces: renderableFolderWorkspaces,
     projectOrderBy,
     repoOrder
   })

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/folder-workspace-lanes.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/folder-workspace-lanes.ts
@@ -1,0 +1,77 @@
+import type { FolderWorkspace } from '../../../../../../shared/folder-workspace-types'
+import type { ProjectGroup } from '../../../../../../shared/project-group-types'
+import type { WorkspaceStatusDefinition } from '../../../../../../shared/worktree/types'
+import {
+  getWorkspaceStatus,
+  getWorkspaceStatusGroupKey
+} from '../../../../../../shared/workspace-statuses'
+import { ALL_GROUP_KEY, getPRLaneKey } from './group-keys'
+import type { WorktreeGroupBy } from './row-types'
+
+/** A folder workspace paired with the project group that owns it. The pair is
+ *  carried through grouping because FolderWorkspaceRow needs a non-optional
+ *  ProjectGroup and the section emitters have no owner resolver. */
+export type RenderableFolderWorkspace = {
+  folderWorkspace: FolderWorkspace
+  projectGroup: ProjectGroup
+}
+
+/**
+ * The single place that decides which folder workspaces can render.
+ *
+ * Why one place: membership used to be computed inside the repo-grouping branch,
+ * so every other Group by mode dropped folder workspaces entirely (#15362).
+ * Modes may choose a lane; they may never subtract from this list.
+ */
+export function getRenderableFolderWorkspaces(
+  folderWorkspaces: readonly FolderWorkspace[],
+  projectGroups: readonly ProjectGroup[]
+): RenderableFolderWorkspace[] {
+  const projectGroupsById = new Map(projectGroups.map((group) => [group.id, group]))
+  const renderable: RenderableFolderWorkspace[] = []
+  for (const folderWorkspace of folderWorkspaces) {
+    const projectGroup = projectGroupsById.get(folderWorkspace.projectGroupId)
+    // A group filtered out for host visibility legitimately hides its workspaces.
+    if (!projectGroup?.parentPath) {
+      continue
+    }
+    renderable.push({ folderWorkspace, projectGroup })
+  }
+  return renderable
+}
+
+/**
+ * Which lane a folder workspace belongs to, per Group by mode.
+ *
+ * Deliberately exhaustive with no `default:` so a new WorktreeGroupBy variant is
+ * a compile error here rather than a silent fall-through that hides folder
+ * workspaces again. Total by construction: a folder workspace always gets a lane.
+ */
+export function getFolderWorkspaceLaneKey(
+  pair: RenderableFolderWorkspace,
+  groupBy: Exclude<WorktreeGroupBy, 'repo'>,
+  workspaceStatuses: readonly WorkspaceStatusDefinition[]
+): string {
+  switch (groupBy) {
+    case 'workspace-status':
+      return getWorkspaceStatusGroupKey(getWorkspaceStatus(pair.folderWorkspace, workspaceStatuses))
+    case 'pr-status':
+      // Why in-progress: a folder workspace has no branch or repo, so it can
+      // never resolve a PR. getPRGroupKey returns this same lane for any
+      // worktree without one, so the two stay consistent.
+      return getPRLaneKey('in-progress')
+    case 'none':
+      return ALL_GROUP_KEY
+  }
+}
+
+/** Sidebar display order: user-authored order first, then name. Mirrors the rule
+ *  the project-group emitter has always used, so lanes and groups agree. */
+export function compareFolderWorkspacesForDisplay(
+  left: FolderWorkspace,
+  right: FolderWorkspace
+): number {
+  const leftOrder = left.manualOrder ?? left.sortOrder
+  const rightOrder = right.manualOrder ?? right.sortOrder
+  return rightOrder - leftOrder || left.name.localeCompare(right.name)
+}

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/group-keys.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/group-keys.ts
@@ -21,6 +21,12 @@ export type PRGroupKey = 'done' | 'in-review' | 'in-progress' | 'closed'
 
 export const PR_GROUP_ORDER: PRGroupKey[] = ['done', 'in-review', 'in-progress', 'closed']
 
+/** Section key for a PR lane. Shared so worktree and folder-workspace bucketing
+ *  cannot drift onto different prefixes. */
+export function getPRLaneKey(prGroup: PRGroupKey): string {
+  return `pr:${prGroup}`
+}
+
 export const PR_GROUP_META: Record<
   PRGroupKey,
   {

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/group-sections.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/group-sections.ts
@@ -8,10 +8,15 @@ import {
 } from '../../workspace-status'
 import { PROJECT_GROUP_META, PR_GROUP_META } from './group-keys'
 import type { PRGroupKey } from './group-keys'
-import { getHostWorktreeCounts, getHostWorktreeIds, getMixedHostContextLabels } from './host-labels'
+import {
+  getLaneHostWorktreeCounts,
+  getLaneHostWorktreeIds,
+  getMixedHostContextLabels
+} from './host-labels'
 import type { OrderedGroupEntry, ProjectGroupingIndex } from './project-grouping'
 import {
   appendWorktreeRows,
+  buildFolderWorkspaceRow,
   buildImportedWorktreesCardRow,
   buildNewExternalWorktreesInboxRow,
   buildPendingCreationRow
@@ -71,6 +76,7 @@ export function appendOrderedGroups(
   for (const [key, group] of groupsToAppend) {
     const isCollapsed = collapsedGroups.has(key)
     const repo = group.repo
+    const folderPairs = group.folderWorkspaces ?? []
     const header =
       groupBy === 'repo'
         ? {
@@ -95,11 +101,21 @@ export function appendOrderedGroups(
                 type: 'header' as const,
                 key,
                 label: definition?.label ?? workspaceStatus,
-                count: group.items.length,
+                count: group.items.length + folderPairs.length,
                 tone: meta.tone,
                 icon: meta.icon,
-                hostWorktreeCounts: getHostWorktreeCounts(group.items, repoMap, defaultHostId),
-                hostWorktreeIds: getHostWorktreeIds(group.items, repoMap, defaultHostId),
+                hostWorktreeCounts: getLaneHostWorktreeCounts(
+                  group.items,
+                  folderPairs,
+                  repoMap,
+                  defaultHostId
+                ),
+                hostWorktreeIds: getLaneHostWorktreeIds(
+                  group.items,
+                  folderPairs,
+                  repoMap,
+                  defaultHostId
+                ),
                 worktreeIds: group.items.map((worktree) => worktree.id)
               }
             })()
@@ -110,11 +126,21 @@ export function appendOrderedGroups(
                 type: 'header' as const,
                 key,
                 label: meta.label,
-                count: group.items.length,
+                count: group.items.length + folderPairs.length,
                 tone: meta.tone,
                 icon: meta.icon,
-                hostWorktreeCounts: getHostWorktreeCounts(group.items, repoMap, defaultHostId),
-                hostWorktreeIds: getHostWorktreeIds(group.items, repoMap, defaultHostId),
+                hostWorktreeCounts: getLaneHostWorktreeCounts(
+                  group.items,
+                  folderPairs,
+                  repoMap,
+                  defaultHostId
+                ),
+                hostWorktreeIds: getLaneHostWorktreeIds(
+                  group.items,
+                  folderPairs,
+                  repoMap,
+                  defaultHostId
+                ),
                 worktreeIds: group.items.map((worktree) => worktree.id)
               }
             })()
@@ -171,6 +197,9 @@ export function appendOrderedGroups(
         hostContextLabelByWorktreeIdentity,
         cyclicLineageIds
       })
+      for (const pair of folderPairs) {
+        result.push(buildFolderWorkspaceRow(pair, projectGroupDepth))
+      }
     }
   }
 }

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/host-labels.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/host-labels.ts
@@ -8,6 +8,8 @@ import {
 import type { ExecutionHostId } from '../../../../../../shared/execution-host'
 import { getWorktreeHostIdentity } from '../../../../../../shared/worktree/host-qualified-identity'
 import type { ProjectGroupingIndex, WorktreeGroupEntry } from './project-grouping'
+import { getFolderWorkspaceHostId } from '../../folder-workspace-host-id'
+import type { RenderableFolderWorkspace } from './folder-workspace-lanes'
 
 function getRepoHostLabel(
   repoId: string,
@@ -108,6 +110,58 @@ export function getHostWorktreeIds(
     const ids = idsByHost.get(hostId) ?? []
     ids.push(worktree.id)
     idsByHost.set(hostId, ids)
+  }
+  return idsByHost
+}
+
+/**
+ * Host counts for a lane that may contain folder workspaces as well as worktrees.
+ *
+ * Why not getHostWorktreeCounts alone: it returns undefined for an empty
+ * worktree list, and a header with undefined counts is treated as global. A lane
+ * whose only members are folder workspaces would therefore render outside its
+ * host section (#15362).
+ */
+export function getLaneHostWorktreeCounts(
+  worktrees: readonly Worktree[],
+  folderWorkspaces: readonly RenderableFolderWorkspace[],
+  repoMap: Map<string, Repo>,
+  defaultHostId: ExecutionHostId
+): Map<ExecutionHostId, number> | undefined {
+  if (worktrees.length === 0 && folderWorkspaces.length === 0) {
+    return undefined
+  }
+  const counts = getHostWorktreeCounts(worktrees, repoMap, defaultHostId) ?? new Map()
+  for (const { folderWorkspace, projectGroup } of folderWorkspaces) {
+    const hostId = getFolderWorkspaceHostId(folderWorkspace, projectGroup, defaultHostId)
+    counts.set(hostId, (counts.get(hostId) ?? 0) + 1)
+  }
+  return counts
+}
+
+/**
+ * Host-scoped worktree ids for a lane that may contain folder workspaces.
+ *
+ * Folder workspaces are not worktrees, so they contribute no ids — but their
+ * host must still get an explicit empty array, or the host-section fallbacks
+ * treat the missing key as "unscoped" and leak the global worktree ids into
+ * that section.
+ */
+export function getLaneHostWorktreeIds(
+  worktrees: readonly Worktree[],
+  folderWorkspaces: readonly RenderableFolderWorkspace[],
+  repoMap: Map<string, Repo>,
+  defaultHostId: ExecutionHostId
+): Map<ExecutionHostId, string[]> | undefined {
+  if (worktrees.length === 0 && folderWorkspaces.length === 0) {
+    return undefined
+  }
+  const idsByHost = getHostWorktreeIds(worktrees, repoMap, defaultHostId) ?? new Map()
+  for (const { folderWorkspace, projectGroup } of folderWorkspaces) {
+    const hostId = getFolderWorkspaceHostId(folderWorkspace, projectGroup, defaultHostId)
+    if (!idsByHost.has(hostId)) {
+      idsByHost.set(hostId, [])
+    }
   }
   return idsByHost
 }

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/project-group-sections.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/project-group-sections.ts
@@ -1,4 +1,7 @@
-import type { FolderWorkspace } from '../../../../../../shared/folder-workspace-types'
+import {
+  compareFolderWorkspacesForDisplay,
+  type RenderableFolderWorkspace
+} from './folder-workspace-lanes'
 import type { ProjectGroup } from '../../../../../../shared/project-group-types'
 import type { ProjectOrderBy } from '../../../../../../shared/ui-chrome-types'
 import { getEffectiveProjectGroupManualRank } from '../../../../../../shared/project-groups'
@@ -11,13 +14,14 @@ import {
   recentRankForEntry,
   withRepoSectionDisplayLabels
 } from './section-order'
+import { buildFolderWorkspaceRow } from './row-builders'
 
 export function appendProjectGroupSections(
   ctx: SectionAppendContext,
   args: {
     orderedGroups: OrderedGroupEntry[]
     projectGroups: readonly ProjectGroup[]
-    folderWorkspaces: readonly FolderWorkspace[]
+    folderWorkspaces: readonly RenderableFolderWorkspace[]
     projectOrderBy: ProjectOrderBy
     repoOrder: Map<string, number> | undefined
   }
@@ -51,22 +55,19 @@ export function appendProjectGroupSections(
   }
 
   const projectGroupsById = new Map(projectGroups.map((group) => [group.id, group]))
-  const folderWorkspacesByProjectGroupId = new Map<string, FolderWorkspace[]>()
-  for (const workspace of folderWorkspaces) {
-    const group = projectGroupsById.get(workspace.projectGroupId)
-    if (!group?.parentPath) {
-      continue
-    }
-    const list = folderWorkspacesByProjectGroupId.get(workspace.projectGroupId) ?? []
-    list.push(workspace)
-    folderWorkspacesByProjectGroupId.set(workspace.projectGroupId, list)
+  // Membership already decided by getRenderableFolderWorkspaces in buildRows, so
+  // repo grouping no longer owns the filter — it only groups and orders (#15362).
+  const folderWorkspacesByProjectGroupId = new Map<string, RenderableFolderWorkspace[]>()
+  for (const pair of folderWorkspaces) {
+    const groupId = pair.folderWorkspace.projectGroupId
+    const list = folderWorkspacesByProjectGroupId.get(groupId) ?? []
+    list.push(pair)
+    folderWorkspacesByProjectGroupId.set(groupId, list)
   }
   for (const list of folderWorkspacesByProjectGroupId.values()) {
-    list.sort((left, right) => {
-      const leftOrder = left.manualOrder ?? left.sortOrder
-      const rightOrder = right.manualOrder ?? right.sortOrder
-      return rightOrder - leftOrder || left.name.localeCompare(right.name)
-    })
+    list.sort((left, right) =>
+      compareFolderWorkspacesForDisplay(left.folderWorkspace, right.folderWorkspace)
+    )
   }
   const childGroupsByParentId = new Map<string | null, ProjectGroup[]>()
   for (const group of projectGroups) {
@@ -107,15 +108,8 @@ export function appendProjectGroupSections(
       projectGroupDepth: depth
     })
     if (!collapsedGroups.has(key)) {
-      for (const folderWorkspace of folderWorkspacesByProjectGroupId.get(projectGroup.id) ?? []) {
-        result.push({
-          type: 'folder-workspace',
-          key: `folder-workspace:${folderWorkspace.id}`,
-          folderWorkspace,
-          projectGroup,
-          depth: 0,
-          groupDepth: depth + 1
-        })
+      for (const pair of folderWorkspacesByProjectGroupId.get(projectGroup.id) ?? []) {
+        result.push(buildFolderWorkspaceRow(pair, depth + 1))
       }
       appendOrderedGroups(ctx, withRepoSectionDisplayLabels(repoEntries), depth + 1)
       for (const childGroup of childGroups) {

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/project-grouping.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/project-grouping.ts
@@ -1,6 +1,7 @@
 import type { Project, ProjectHostSetup } from '../../../../../../shared/project-types'
 import type { Repo } from '../../../../../../shared/repo-types'
 import type { Worktree } from '../../../../../../shared/worktree/types'
+import type { RenderableFolderWorkspace } from './folder-workspace-lanes'
 import { toSshExecutionHostId } from '../../../../../../shared/execution-host'
 import { parseWslUncPath } from '../../../../../../shared/wsl-paths'
 import {
@@ -20,6 +21,9 @@ export type WorktreeGroupEntry = {
   items: Worktree[]
   repo?: Repo
   repoIds: Set<string>
+  /** Folder workspaces bucketed into this lane under non-repo grouping. Carries
+   *  the owning group because FolderWorkspaceRow requires a non-optional one. */
+  folderWorkspaces?: RenderableFolderWorkspace[]
 }
 
 export type ProjectGroupingIndex = {

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/row-builders.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/row-builders.ts
@@ -5,7 +5,9 @@ import { getWorktreeHostIdentity } from '../../../../../../shared/worktree/host-
 import { isValidResolvedWorktreeLineageEdge } from '../../../../../../shared/resolved-worktree-lineage'
 import { getProjectedWorktreeLineage } from '../../worktree-lineage-projection'
 import { getWorktreeLineageGroupKey } from './group-keys'
+import type { RenderableFolderWorkspace } from './folder-workspace-lanes'
 import type {
+  FolderWorkspaceRow,
   ImportedWorktreesCardCandidate,
   ImportedWorktreesCardRow,
   NewExternalWorktreesInboxCandidate,
@@ -238,5 +240,21 @@ export function appendWorktreeRows(
         emit(worktree, 0, [], true)
       }
     }
+  }
+}
+
+/** The one folder-workspace row constructor, shared by the project-group,
+ *  grouped-lane and flat emitters so their rows cannot diverge. */
+export function buildFolderWorkspaceRow(
+  pair: RenderableFolderWorkspace,
+  groupDepth: number
+): FolderWorkspaceRow {
+  return {
+    type: 'folder-workspace',
+    key: `folder-workspace:${pair.folderWorkspace.id}`,
+    folderWorkspace: pair.folderWorkspace,
+    projectGroup: pair.projectGroup,
+    depth: 0,
+    groupDepth
   }
 }

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/worktree-grouping.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/worktree-grouping.ts
@@ -120,7 +120,8 @@ export function buildOrderedGroups(args: {
         })
       }
       const group = grouped.get(key)!
-      group.folderWorkspaces = [...(group.folderWorkspaces ?? []), pair]
+      group.folderWorkspaces ??= []
+      group.folderWorkspaces.push(pair)
     }
     for (const group of grouped.values()) {
       group.folderWorkspaces?.sort((left, right) =>

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/worktree-grouping.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/worktree-grouping.ts
@@ -2,8 +2,18 @@ import type { Repo } from '../../../../../../shared/repo-types'
 import type { ProjectOrderBy } from '../../../../../../shared/ui-chrome-types'
 import type { WorkspaceStatusDefinition, Worktree } from '../../../../../../shared/worktree/types'
 import type { AppState } from '../../../../store/types'
-import { getWorkspaceStatus, getWorkspaceStatusGroupKey } from '../../workspace-status'
-import { PR_GROUP_META, PR_GROUP_ORDER, getPRGroupKey } from './group-keys'
+import {
+  getWorkspaceStatus,
+  getWorkspaceStatusFromGroupKey,
+  getWorkspaceStatusGroupKey
+} from '../../workspace-status'
+import {
+  compareFolderWorkspacesForDisplay,
+  getFolderWorkspaceLaneKey,
+  type RenderableFolderWorkspace
+} from './folder-workspace-lanes'
+import { PR_GROUP_META, PR_GROUP_ORDER, getPRGroupKey, getPRLaneKey } from './group-keys'
+import type { PRGroupKey } from './group-keys'
 import { addRepoIdToGroup, getProjectGroupingForRepo } from './project-grouping'
 import type {
   OrderedGroupEntry,
@@ -17,6 +27,22 @@ import type {
   WorktreeGroupBy
 } from './row-types'
 import { getManualOrderAnchorRepo, sortProjectEntries } from './section-order'
+
+/** Lane label for a lane a folder workspace opened before any worktree did. */
+function getLaneLabelForKey(
+  key: string,
+  groupBy: Exclude<WorktreeGroupBy, 'repo'>,
+  workspaceStatuses: readonly WorkspaceStatusDefinition[]
+): string {
+  if (groupBy === 'workspace-status') {
+    const status = getWorkspaceStatusFromGroupKey(key, workspaceStatuses)
+    return workspaceStatuses.find((entry) => entry.id === status)?.label ?? status ?? key
+  }
+  if (groupBy === 'pr-status') {
+    return PR_GROUP_META[key.replace(/^pr:/, '') as PRGroupKey].label
+  }
+  return key
+}
 
 /** Buckets worktrees into their sections and returns them in render order. */
 export function buildOrderedGroups(args: {
@@ -33,6 +59,7 @@ export function buildOrderedGroups(args: {
   pendingByRepo: ReadonlyMap<string, PendingCreationRef[]>
   repoOrder: Map<string, number> | undefined
   projectOrderBy: ProjectOrderBy
+  folderWorkspaces?: readonly RenderableFolderWorkspace[]
 }): OrderedGroupEntry[] {
   const {
     groupBy,
@@ -47,7 +74,8 @@ export function buildOrderedGroups(args: {
     newExternalWorktreesInboxByRepo,
     pendingByRepo,
     repoOrder,
-    projectOrderBy
+    projectOrderBy,
+    folderWorkspaces = []
   } = args
 
   const grouped = new Map<string, WorktreeGroupEntry>()
@@ -67,7 +95,7 @@ export function buildOrderedGroups(args: {
         workspaceStatuses.find((status) => status.id === workspaceStatus)?.label ?? workspaceStatus
     } else {
       const prGroup = getPRGroupKey(w, repoMap, prCache, settings)
-      key = `pr:${prGroup}`
+      key = getPRLaneKey(prGroup)
       label = PR_GROUP_META[prGroup].label
     }
     if (!grouped.has(key)) {
@@ -76,6 +104,29 @@ export function buildOrderedGroups(args: {
     const group = grouped.get(key)!
     group.items.push(w)
     addRepoIdToGroup(group, w.repoId)
+  }
+  // Why: folder workspaces are not worktrees, so they never appear in the loop
+  // above. Bucketing them here — and creating the lane when no worktree opened
+  // one — is what lets a folder workspace be the sole occupant of a lane (#15362).
+  if (groupBy !== 'repo') {
+    for (const pair of folderWorkspaces) {
+      const key = getFolderWorkspaceLaneKey(pair, groupBy, workspaceStatuses)
+      if (!grouped.has(key)) {
+        grouped.set(key, {
+          label: getLaneLabelForKey(key, groupBy, workspaceStatuses),
+          items: [],
+          repo: undefined,
+          repoIds: new Set()
+        })
+      }
+      const group = grouped.get(key)!
+      group.folderWorkspaces = [...(group.folderWorkspaces ?? []), pair]
+    }
+    for (const group of grouped.values()) {
+      group.folderWorkspaces?.sort((left, right) =>
+        compareFolderWorkspacesForDisplay(left.folderWorkspace, right.folderWorkspace)
+      )
+    }
   }
   if (groupBy === 'repo') {
     for (const repoId of placeholderRepoIds) {

--- a/src/renderer/src/components/sidebar/worktree-list/listing/use-collapsed-groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/use-collapsed-groups.ts
@@ -8,6 +8,9 @@ import { PINNED_GROUP_KEY, getLineageGroupKey } from '../grouping/group-keys'
 import type { PinnedWorktreeDisplayPolicy, WorktreeGroupBy } from '../grouping/row-types'
 import type { ProjectGroupingModel } from '../grouping/project-grouping'
 import { getGroupKeysForWorktree } from '../grouping/worktree-group-keys'
+import { getFolderWorkspaceRevealGroupKeys } from '../navigation/folder-reveal'
+import type { FolderWorkspace } from '../../../../../../shared/folder-workspace-types'
+import type { ExecutionHostId } from '../../../../../../shared/execution-host'
 import { isPinnedSectionWorktree } from '../../pinned-section-worktrees'
 import { getWorktreeLineageAncestors } from '../../worktree-lineage-projection'
 
@@ -26,6 +29,8 @@ export function useEffectiveCollapsedGroups(args: {
   settings: AppState['settings']
   projectGroups: readonly ProjectGroup[]
   projectGrouping: ProjectGroupingModel
+  folderWorkspaces: readonly FolderWorkspace[]
+  defaultHostId: ExecutionHostId
 }): Set<string> {
   const {
     collapsedGroups,
@@ -40,7 +45,9 @@ export function useEffectiveCollapsedGroups(args: {
     workspaceStatuses,
     settings,
     projectGroups,
-    projectGrouping
+    projectGrouping,
+    folderWorkspaces,
+    defaultHostId
   } = args
   return useMemo(() => {
     if (!agentSendTargetWorktreeId) {
@@ -48,7 +55,22 @@ export function useEffectiveCollapsedGroups(args: {
     }
     const targetWorktree = worktreeMap.get(agentSendTargetWorktreeId)
     if (!targetWorktree) {
-      return collapsedGroups
+      // Why: folder workspaces are absent from worktreeMap, so without this the
+      // agent-send picker could never open the section hiding one (#15362).
+      const folderKeys = getFolderWorkspaceRevealGroupKeys(
+        agentSendTargetWorktreeId,
+        folderWorkspaces,
+        projectGroups,
+        { groupBy, workspaceStatuses, defaultHostId }
+      )
+      if (folderKeys.length === 0) {
+        return collapsedGroups
+      }
+      const nextForFolder = new Set(collapsedGroups)
+      for (const groupKey of folderKeys) {
+        nextForFolder.delete(groupKey)
+      }
+      return nextForFolder
     }
     const next = new Set(collapsedGroups)
     if (
@@ -92,6 +114,8 @@ export function useEffectiveCollapsedGroups(args: {
     settings,
     workspaceStatuses,
     worktreeLineageById,
-    worktreeMap
+    worktreeMap,
+    folderWorkspaces,
+    defaultHostId
   ])
 }

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/folder-reveal.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/folder-reveal.test.ts
@@ -119,3 +119,39 @@ describe('worktree list folder reveal', () => {
     ).toEqual([getProjectGroupHeaderKey(root.id), getProjectGroupHeaderKey(child.id)])
   })
 })
+
+describe('reveal keys under non-repo grouping', () => {
+  const group = makeProjectGroup({ id: 'group-child', connectionId: 'target-1' })
+  const folderWorkspace = makeFolderWorkspace({ workspaceStatus: 'in-progress' })
+  const workspaceKey = folderWorkspaceKey(folderWorkspace.id)
+
+  it('returns the status lane key so a collapsed lane can be expanded', () => {
+    // Pre-fix only project-group headers came back, and those do not exist
+    // under status grouping, so the reveal could never expand the lane.
+    const keys = getFolderWorkspaceRevealGroupKeys(workspaceKey, [folderWorkspace], [group], {
+      groupBy: 'workspace-status',
+      workspaceStatuses: [],
+      defaultHostId: 'local'
+    })
+    expect(keys).toContain('workspace-status:in-progress')
+  })
+
+  it('returns the host key so a collapsed host can be expanded too', () => {
+    const keys = getFolderWorkspaceRevealGroupKeys(workspaceKey, [folderWorkspace], [group], {
+      groupBy: 'workspace-status',
+      workspaceStatuses: [],
+      defaultHostId: 'local'
+    })
+    expect(keys).toContain('host:ssh:target-1')
+  })
+
+  it('still returns project-group keys under repo grouping', () => {
+    const keys = getFolderWorkspaceRevealGroupKeys(workspaceKey, [folderWorkspace], [group], {
+      groupBy: 'repo',
+      workspaceStatuses: [],
+      defaultHostId: 'local'
+    })
+    expect(keys).toContain(getProjectGroupHeaderKey(group.id))
+    expect(keys.some((key) => key.startsWith('workspace-status:'))).toBe(false)
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/folder-reveal.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/folder-reveal.ts
@@ -1,10 +1,13 @@
 import type { FolderWorkspace } from '../../../../../../shared/folder-workspace-types'
 import type { ProjectGroup } from '../../../../../../shared/project-group-types'
-import type { Worktree } from '../../../../../../shared/worktree/types'
-import type { ExecutionHostId } from '../../../../../../shared/execution-host'
+import type { WorkspaceStatusDefinition, Worktree } from '../../../../../../shared/worktree/types'
 import { folderWorkspaceToWorktree } from '../../../../../../shared/folder-workspace-worktree'
 import { parseWorkspaceKey } from '../../../../../../shared/workspace-scope'
 import { getProjectGroupHeaderKey } from '../grouping/group-keys'
+import type { ExecutionHostId } from '../../../../../../shared/execution-host'
+import { getFolderWorkspaceLaneKey } from '../grouping/folder-workspace-lanes'
+import type { WorktreeGroupBy } from '../grouping/row-types'
+import { getFolderWorkspaceHostId } from '../../folder-workspace-host-id'
 
 function findFolderWorkspaceByKey(
   worktreeId: string,
@@ -57,7 +60,12 @@ export function sidebarWorkspaceStillExists(
 export function getFolderWorkspaceRevealGroupKeys(
   worktreeId: string,
   folderWorkspaces: readonly FolderWorkspace[],
-  projectGroups: readonly ProjectGroup[]
+  projectGroups: readonly ProjectGroup[],
+  options?: {
+    groupBy?: WorktreeGroupBy
+    workspaceStatuses?: readonly WorkspaceStatusDefinition[]
+    defaultHostId?: ExecutionHostId
+  }
 ): string[] {
   const folderWorkspace = findFolderWorkspaceByKey(worktreeId, folderWorkspaces)
   if (!folderWorkspace) {
@@ -76,6 +84,25 @@ export function getFolderWorkspaceRevealGroupKeys(
     }
     keys.unshift(getProjectGroupHeaderKey(group.id))
     groupId = group.parentGroupId
+  }
+
+  // Under non-repo grouping the project-group headers above do not exist, so the
+  // lane and host headers are the ones actually hiding the row (#15362). Lane
+  // keys come from the same function grouping uses, so the two cannot disagree.
+  const owningGroup = groupsById.get(folderWorkspace.projectGroupId)
+  if (options?.groupBy && options.groupBy !== 'repo' && owningGroup) {
+    keys.push(
+      getFolderWorkspaceLaneKey(
+        { folderWorkspace, projectGroup: owningGroup },
+        options.groupBy,
+        options.workspaceStatuses ?? []
+      )
+    )
+  }
+  if (owningGroup && options?.defaultHostId) {
+    keys.push(
+      `host:${getFolderWorkspaceHostId(folderWorkspace, owningGroup, options.defaultHostId)}`
+    )
   }
   return keys
 }

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/pending-reveal-inputs.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/pending-reveal-inputs.ts
@@ -60,7 +60,12 @@ export function expandGroupsForWorktreeReveal(
   const folderGroupKeys = getFolderWorkspaceRevealGroupKeys(
     worktreeId,
     args.folderWorkspaces,
-    args.projectGroups
+    args.projectGroups,
+    {
+      groupBy: args.groupBy,
+      workspaceStatuses: args.workspaceStatuses,
+      defaultHostId: args.defaultHostId
+    }
   )
   if (folderGroupKeys.length > 0) {
     for (const groupKey of folderGroupKeys) {

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/render-row-lookup.folder-workspace.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/render-row-lookup.folder-workspace.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import type { FolderWorkspace } from '../../../../../../shared/folder-workspace-types'
+import type { ProjectGroup } from '../../../../../../shared/project-group-types'
+import { folderWorkspaceKey } from '../../../../../../shared/workspace-scope'
+import type { RenderRow } from '../listing/render-row'
+import { findPreferredRenderRowIndexForWorktreeIdentity } from './render-row-lookup'
+
+const FOLDER_WORKSPACE: FolderWorkspace = {
+  id: 'fw-1',
+  projectGroupId: 'group-1',
+  name: 'Folder workspace',
+  folderPath: '/tmp/parent',
+  linkedTask: null,
+  comment: '',
+  isArchived: false,
+  isUnread: false,
+  isPinned: false,
+  sortOrder: 1,
+  lastActivityAt: 1,
+  createdAt: 1,
+  updatedAt: 1
+}
+
+const PROJECT_GROUP: ProjectGroup = {
+  id: 'group-1',
+  name: 'Group',
+  parentPath: '/tmp/parent',
+  parentGroupId: null,
+  createdFrom: 'folder-scan',
+  tabOrder: 0,
+  isCollapsed: false,
+  color: null,
+  createdAt: 1,
+  updatedAt: 1
+}
+
+describe('host-qualified reveal lookup finds folder workspaces', () => {
+  it('returns the folder row index instead of -1', () => {
+    // Reveal requests for the current workspace carry executionHostId, which
+    // routes here. A walker that only knows item rows returned -1 and the
+    // reveal silently never completed (#15362).
+    const rows: RenderRow[] = [
+      {
+        type: 'folder-workspace',
+        key: `folder-workspace:${FOLDER_WORKSPACE.id}`,
+        folderWorkspace: FOLDER_WORKSPACE,
+        projectGroup: PROJECT_GROUP,
+        depth: 0,
+        groupDepth: 0
+      } as RenderRow
+    ]
+
+    const index = findPreferredRenderRowIndexForWorktreeIdentity(
+      rows,
+      { id: folderWorkspaceKey(FOLDER_WORKSPACE.id), hostId: undefined },
+      'single-location'
+    )
+
+    expect(index).toBe(0)
+  })
+
+  it('does not match a different folder workspace', () => {
+    const rows: RenderRow[] = [
+      {
+        type: 'folder-workspace',
+        key: 'folder-workspace:other',
+        folderWorkspace: { ...FOLDER_WORKSPACE, id: 'other' },
+        projectGroup: PROJECT_GROUP,
+        depth: 0,
+        groupDepth: 0
+      } as RenderRow
+    ]
+
+    expect(
+      findPreferredRenderRowIndexForWorktreeIdentity(
+        rows,
+        { id: folderWorkspaceKey(FOLDER_WORKSPACE.id), hostId: undefined },
+        'single-location'
+      )
+    ).toBe(-1)
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/render-row-lookup.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/render-row-lookup.ts
@@ -109,6 +109,14 @@ export function findPreferredRenderRowIndexForWorktreeIdentity(
   let fallbackIndex = -1
   for (let index = 0; index < renderRows.length; index++) {
     const row = renderRows[index]
+    // Why: host-qualified reveals are emitted for folder workspaces too, and a
+    // walker that only knows item rows returns -1 so the reveal never lands.
+    if (row.type === 'folder-workspace') {
+      if (folderWorkspaceKey(row.folderWorkspace.id) === worktree.id) {
+        return index
+      }
+      continue
+    }
     const itemRows = row.type === 'lineage-group' ? row.rows : row.type === 'item' ? [row] : []
     const itemRow = itemRows.find(
       (candidate) => getWorktreeHostIdentity(candidate.worktree) === identity


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​551 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​551 |
| Prod | 17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​450 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​79 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​371 |

<!-- /orca-pr-loc -->

## ELI5

If you use a folder workspace on a multi-repo project group, it only showed up in the sidebar when "Group by" was set to Project. Switch to Status, PR status or None and it silently disappeared. Now it shows up in all of them.

## What Changed

Folder-workspace rows were emitted in exactly one place — inside the repo-grouping branch of `buildRows` — so every other Group by mode dropped them.

**Membership is now decided once, above the `groupBy` switch**; a mode only chooses which *lane* a workspace lands in, never whether it exists. Lane assignment is an exhaustive `WorktreeGroupBy` switch with **no `default:` clause**, so adding a fifth grouping mode is a compile error here instead of silently re-introducing this bug.

Placement per mode:

| Mode | Placement |
| --- | --- |
| Project | unchanged — nested under its project group |
| Status | its own `workspaceStatus` lane |
| PR status | the same lane no-PR worktrees already land in |
| None | the flat All lane |

The drop-site sweep found four more paths where the same row kind went missing. All are fixed here because this change makes folder-only non-repo results ordinary:

- **Flat mode** gated its entire section on worktree count, so an account with *only* folder workspaces rendered nothing at all.
- **Host sections**: a collapsed folder-only lane header rendered globally instead of under its host, because an empty worktree list yields undefined host counts. Host id maps now carry explicit empty arrays so the host fallback cannot leak global worktree ids into a section.
- **Reveal** resolved folder workspaces to project-group header keys only, so revealing one inside a collapsed lane never expanded it and retried out. Reveal now reuses the *same* lane function as grouping (so the two cannot disagree), expands the host header, and covers the agent-send path and the host-qualified row lookup.
- **The Clear Filters empty state** ignored folder workspaces, so a folder-only account lost them whenever any filter was active — host scope counts as one. **This one reproduces on `main` today, including under Project grouping.**

Two behaviours are deliberately left alone, and both are pinned by tests:

- **Archived** folder workspaces are still not filtered. Nothing filters them today, so they already render under Project grouping. Filtering them only in the new lanes would make membership mode-dependent — exactly the defect being removed — and filtering them everywhere would change behaviour users see today.
- **Pinned** folder workspaces still render in their natural lane rather than the Pinned section. After this change that is now uniform across all modes, matching what Project grouping already did. The Pinned-section gap is separate; follow-up below.

## Why

`AGENTS.md` says all changes must consider folder workspaces as well as git worktrees. This is one of the spots that predates that rule, and the shape of it is the reason it stayed hidden: membership was computed inside a mode branch, so each new grouping mode forgot the second workspace kind by default. Hoisting membership above the switch and making the mode switch exhaustive fixes the instance *and* the class.

**This is not a regression.** The `groupBy !== 'repo'` gate landed in #2866 (2026-05-27), two weeks *before* folder workspaces existed. #5172 (2026-06-11) then added folder-workspace emission *below* that gate, unreachable for non-repo grouping from its very first commit. `workspaceStatus` has been on `FolderWorkspace` since day one and status grouping shipped 2026-05-14, so the data was always there — only the wiring was missing.

Bisect hazard for reviewers: `build-rows.ts` looks like August code, but that is only the #14486 module split out of `worktree-list-groups.ts`. `git log --follow` bottoms out at the split; the logic is byte-for-byte the June original.

## Linked Issue

Fixes #15362

## Visual Proof

**Outstanding — needs an Electron session.** This is a real UI change and the template requires before/after. I could not capture it in this pass: Electron validation here runs through the `$electron` skill, which is user-invoked only, so I could not self-drive a capture. Happy to attach a before/after the moment someone runs it.

In the meantime the behaviour is pinned by unit-level evidence with proven pre-fix differentials, described below.

## Testing

Four new/extended suites. What matters is not that they pass, but that each was **run against pre-fix source and observed to fail** — a test that cannot fail measures nothing:

| Suite | Red pre-fix | Notes |
| --- | --- | --- |
| `build-rows.folder-workspace-lanes.test.ts` | **13 of 17** | 4 that pass pre-fix are deliberate no-regression guards, see below |
| `folder-reveal.test.ts` (extended) | **2 of 3** | 3rd is the repo-grouping guard |
| `render-row-lookup.folder-workspace.test.ts` | **1 of 2** | 2nd is a negative guard |
| `sidebar-empty-state-gate.test.ts` | n/a (new module) | verified load-bearing: deleting the folder clause turns it red |

The four intentionally-passing entries are guards, not evidence: the `repo` arm of the parametrized test, the repo no-duplication guard, the host-filtered negative arm, and a pure lane-key assertion. They are labelled as such in the test file so nobody later mistakes them for acceptance coverage.

Coverage includes: all four Group by modes; a folder workspace as the *sole* occupant of a status lane; a folder-only account in flat mode; ordering across **both** emitters (grouped lanes and the separate flat path); host placement for a *collapsed* folder-only lane; explicit empty `hostWorktreeIds`; archived parity across all four modes; and no duplication under Project grouping.

- [x] Automated tests added/updated
- [ ] I manually tested these changes locally — **not done**, see Visual Proof

`pnpm typecheck` (web) and the `oxlint` code-quality gate are clean locally.

**One honest caveat on the local suite:** the full sidebar run reported 23 failing tests, but this machine was at load average 119–172 with other worktrees running vitest concurrently. Every named failure was re-run individually at `--maxWorkers=1` and passed — including `WorktreeList.folder-workspace-rows.test.ts` (5/5), the existing suite covering exactly these rows. Two others (`WorktreeCard.lineage`, `WorktreeCard.pinned-repo-icon`) were confirmed failing on **pristine `main`** with none of this branch's changes present, so they are pre-existing and untouched here. CI is the real gate.

## Review

Platform/compat notes: renderer-only change. No RPC params, stream opcodes, or published host content are touched, so there is no remote wire-compatibility surface. No new platform-dependent behaviour, no Git invocations, no provider-specific logic. SSH/remote folder workspaces are covered — the host resolver is now centralised in one function shared by header counting and reveal, so the two cannot drift.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

Follow-ups deliberately **not** bundled here, to keep this focused:

1. **Pinned section** — a pinned folder workspace never reaches the Pinned lane, because `emitPinnedGroup` only receives worktrees. Pre-existing and orthogonal.
2. **Lineage-derived PR lanes** — folder workspaces land in the no-PR lane. Deriving a real PR lane from lineage would need four caches threaded into `buildRows`, well beyond this fix.
3. **Host resolver divergence** — `getFolderWorkspaceHostId` ignores `executionHostId` while the host *filter* resolver prefers it, so a runtime-hosted folder workspace passes the filter but buckets under the default host. Pre-existing; this change surfaces it in more modes without causing it.
4. **Archived asymmetry** — archived worktrees are dropped upstream; archived folder workspaces are not.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached — **outstanding**, see Visual Proof
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `pnpm typecheck` and lint pass locally; CI covers the rest

## Author

- X / Twitter: @BrennanKB5
