### PR TITLE
Fix skill install dialog overflow and simplify file summaries

### DIFF
--- a/src/renderer/src/components/skills/SkillInstallDialog.test.tsx
+++ b/src/renderer/src/components/skills/SkillInstallDialog.test.tsx
@@ -323,7 +323,7 @@ describe('SkillInstallDialog', () => {
     expect(screen.queryByText(char.repeat(64))).toBeNull()
     expect(screen.queryByText('Immutable version')).toBeNull()
     expect(screen.queryByText('0 scripts')).toBeNull()
-    expect(screen.getAllByText(/Instructions only/).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/^1 file$/).length).toBeGreaterThan(0)
   })
 
   it('warns about supporting files without blocking installation', async () => {
@@ -351,6 +351,8 @@ describe('SkillInstallDialog', () => {
     render(<SkillInstallDialog open onOpenChange={() => undefined} />)
 
     await inspectSkill()
+    expect(screen.getByText(/^2 files$/)).toBeTruthy()
+    expect(screen.queryByText(/supporting$/, { selector: 'span' })).toBeNull()
     expect(screen.getByText('Includes supporting files')).toBeTruthy()
     expect(screen.getByText(/include 1 file beyond SKILL.md/)).toBeTruthy()
     expect(screen.queryByRole('checkbox', { name: /I trust the sender/ })).toBeNull()

--- a/src/renderer/src/components/skills/SkillInstallDialog.test.tsx
+++ b/src/renderer/src/components/skills/SkillInstallDialog.test.tsx
@@ -281,6 +281,8 @@ describe('SkillInstallDialog', () => {
     const description = screen.getByText(sharedVersion.description)
     expect(description.className).toContain('line-clamp-1')
     expect(description.className).toContain('group-data-[state=open]/row:line-clamp-none')
+    expect(description.className).toContain('group-data-[state=open]/row:max-h-none')
+    expect(description.className).not.toContain('group-data-[state=open]/row:max-h-40')
   })
 
   // Why: "view the full skill contents" is the point of the row — the file list

--- a/src/renderer/src/components/skills/SkillPackageChecklist.tsx
+++ b/src/renderer/src/components/skills/SkillPackageChecklist.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle, ChevronRight } from 'lucide-react'
+import { ChevronRight } from 'lucide-react'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import { cn } from '@/lib/utils'
@@ -80,15 +80,7 @@ function ChecklistRow({
             {note ? (
               <span className="shrink-0 text-[11px] text-muted-foreground">{note}</span>
             ) : null}
-            <span
-              className={cn(
-                'inline-flex shrink-0 items-center gap-1 text-[11px] text-muted-foreground',
-                summary.risky && 'text-foreground'
-              )}
-            >
-              {summary.risky ? <AlertTriangle className="size-3" /> : null}
-              {summary.label}
-            </span>
+            <span className="shrink-0 text-[11px] text-muted-foreground">{summary.label}</span>
             <ChevronRight className="size-3.5 shrink-0 text-muted-foreground transition-transform group-data-[state=open]/row:rotate-90" />
           </CollapsibleTrigger>
         </div>

--- a/src/renderer/src/components/skills/SkillPackageChecklist.tsx
+++ b/src/renderer/src/components/skills/SkillPackageChecklist.tsx
@@ -72,7 +72,8 @@ function ChecklistRow({
           >
             <span className="min-w-0 flex-1">
               <span className="block truncate text-sm font-medium">{item.name}</span>
-              <span className="block line-clamp-1 max-h-5 overflow-hidden text-xs leading-5 text-muted-foreground transition-[max-height] duration-200 ease-out group-data-[state=open]/row:line-clamp-none group-data-[state=open]/row:max-h-40 motion-reduce:transition-none">
+              {/* Why: unclamped text must contribute its full height to avoid painting over the file list. */}
+              <span className="block line-clamp-1 max-h-5 overflow-hidden text-xs leading-5 break-words text-muted-foreground group-data-[state=open]/row:line-clamp-none group-data-[state=open]/row:max-h-none">
                 {description}
               </span>
             </span>

--- a/src/renderer/src/components/skills/skill-package-checklist-items.test.ts
+++ b/src/renderer/src/components/skills/skill-package-checklist-items.test.ts
@@ -94,30 +94,23 @@ describe('checklistItemsFromVersion', () => {
 })
 
 describe('checklistItemSummary', () => {
-  it('says once when nothing in the skill can run', () => {
+  it('keeps instruction-only and supporting-file summaries simple', () => {
     expect(checklistItemSummary([file('SKILL.md')])).toEqual({
-      label: '1 file · Instructions only',
-      risky: false
+      label: '1 file'
     })
-  })
-
-  it('flags supporting and runnable content for review', () => {
     expect(checklistItemSummary([file('SKILL.md'), file('references/guide.md')])).toEqual({
-      label: '2 files · 1 supporting',
-      risky: true
+      label: '2 files'
     })
-    expect(checklistItemSummary([file('SKILL.md'), file('scripts/setup.sh')])).toEqual({
-      label: '2 files · 1 runnable',
-      risky: true
-    })
-    expect(checklistItemSummary([file('bin/tool', true)]).risky).toBe(true)
   })
 
-  it('preserves binary classification in the row summary', () => {
+  it('keeps runnable and binary classifications out of the row summary', () => {
+    expect(checklistItemSummary([file('SKILL.md'), file('scripts/setup.sh')])).toEqual({
+      label: '2 files'
+    })
+    expect(checklistItemSummary([file('bin/tool', true)])).toEqual({ label: '1 file' })
     const binary = { ...file('assets/logo.png'), classification: 'binary' as const }
     expect(checklistItemSummary([file('SKILL.md'), binary])).toEqual({
-      label: '2 files · 1 binary',
-      risky: true
+      label: '2 files'
     })
   })
 })

--- a/src/renderer/src/components/skills/skill-package-checklist-items.ts
+++ b/src/renderer/src/components/skills/skill-package-checklist-items.ts
@@ -1,10 +1,5 @@
 import type { SkillCloudVersion } from '../../../../shared/skill-cloud-contract'
 import { fileCountLabel } from './skill-display-labels'
-import {
-  isSkillBinaryFile,
-  isSkillInstructionFile,
-  isSkillRunnableFile
-} from './skill-package-install-risk'
 
 export type SkillChecklistFile = {
   path: string
@@ -42,26 +37,9 @@ export function checklistItemsFromVersion(version: SkillCloudVersion): SkillChec
   ]
 }
 
-/** Row summary: how much is here, and what deserves extra review. */
+/** Row summary: a simple file count; detailed classifications live in the expanded list. */
 export function checklistItemSummary(files: readonly SkillChecklistFile[]): {
   label: string
-  risky: boolean
 } {
-  const additionalCount = files.filter((file) => !isSkillInstructionFile(file)).length
-  const runnableCount = files.filter(isSkillRunnableFile).length
-  const binaryCount = files.filter(isSkillBinaryFile).length
-  const labels: string[] = []
-  if (runnableCount) {
-    labels.push(`${runnableCount} runnable`)
-  }
-  if (binaryCount) {
-    labels.push(`${binaryCount} binary`)
-  }
-  if (!labels.length) {
-    labels.push(additionalCount ? `${additionalCount} supporting` : 'Instructions only')
-  }
-  return {
-    label: `${fileCountLabel(files.length)} · ${labels.join(' · ')}`,
-    risky: additionalCount > 0
-  }
+  return { label: fileCountLabel(files.length) }
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​14 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​17 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​35 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​29 |

<!-- /orca-pr-loc -->

## ELI5

Long skill descriptions could paint over the file list beneath them. Expanded descriptions now take up their full height, and the row summary is reduced to a plain file count.

## What Changed

- Let expanded skill descriptions contribute their full layout height and wrap long words.
- Show only the total file count in each skill row.
- Remove the caution icon and supporting/runnable/binary suffixes from the row summary.
- Keep file classifications in the expanded file list and the existing install warning.
- Add regression coverage for the layout class and simplified summaries.

## Why

The previous max-height remained active after the description was visually unclamped, so overflow could overlap the expanded file list. The extra `supporting` count and caution icon also confused users despite the detailed warning already appearing below.

## Linked Issue

N/A — user-reported UX bug.

## Visual Proof

Before: the user-provided screenshot showed description text overlapping the file list and a row summary reading `8 files · 7 supporting`.

After: validated in a running Orca build with a mock long-description, eight-file bundle. The description ended above all eight files, and the row summary reads only `8 files`. No new automated screenshot was captured after the user asked to stop Playwright validation.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Validated locally:

- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/skills/skill-package-checklist-items.test.ts src/renderer/src/components/skills/SkillInstallDialog.test.tsx` — 23 passed
- `pnpm run typecheck:web`
- Changed-file `oxlint --deny-warnings`
- `pnpm run build:electron-vite`

The final build is running for manual review.

## Review

Please focus on expanded-row layout and whether the file-count-only summary preserves the intended security disclosure in the warning and expanded file list.

## Agent skill upstream boundary

- [x] Not applicable; this renderer-only change copies or mechanically translates no upstream installer material.

## Notes

This is renderer-only presentation behavior. It does not change installation, filesystem, SSH, remote-wire, or platform-specific behavior.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (N/A: presentation-only)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (focused local checks pass; full CI will cover the repository)
