### PR TITLE
test(wsl): account for the route quarantine in stalled-mount tests

### DIFF
--- a/src/main/ai-vault/session-scanner-index-cache-wsl-stall.test.ts
+++ b/src/main/ai-vault/session-scanner-index-cache-wsl-stall.test.ts
@@ -57,20 +57,17 @@ function servingHandle(body: string) {
   }
 }
 
-// A timed-out stall quarantines the route, so the next read is refused until the
-// window lapses. Waiting it out is what a real caller does; resetting the gate here
-// would skip the very admission the recovery assertions depend on.
-async function lapseRouteQuarantine(): Promise<void> {
-  await vi.advanceTimersByTimeAsync(WSL_TRANSCRIPT_FS_ROUTE_QUARANTINE_BASE_MS + 1)
-}
-
+// A result that lands past the deadline never lifts the route quarantine, so
+// recovery waits out the back-off window the same way production does.
 async function releaseAndSettle(): Promise<void> {
   releaseStall?.()
   releaseStall = undefined
-  await vi.advanceTimersByTimeAsync(0)
+  await vi.advanceTimersByTimeAsync(WSL_TRANSCRIPT_FS_ROUTE_QUARANTINE_BASE_MS)
 }
 
 beforeEach(() => {
+  // blockedRoutes is persistent gate state: a prior stall must not quarantine
+  // this test's route.
   resetWslTranscriptFsGateForTests()
   resetCodexSessionIndexTitleCacheForTests()
   clearKimiSessionIndexCache()
@@ -79,7 +76,8 @@ beforeEach(() => {
   mocks.readFile.mockReset()
   mocks.stat.mockResolvedValue(INDEX_STATS)
   releaseStall = undefined
-  vi.useFakeTimers()
+  // performance.now drives the route quarantine clock, so it must be faked too.
+  vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date', 'performance'] })
 })
 
 afterEach(async () => {
@@ -97,7 +95,6 @@ describe('memoized WSL session indexes under a stalled mount', () => {
     expect(_hasCodexSessionIndexTitleCacheEntryForTest(CODEX_HOME)).toBe(false)
 
     await releaseAndSettle()
-    await lapseRouteQuarantine()
     mocks.open.mockResolvedValue(
       servingHandle(`${JSON.stringify({ id: SESSION_ID, thread_name: 'Ship the gate' })}\n`)
     )
@@ -117,7 +114,6 @@ describe('memoized WSL session indexes under a stalled mount', () => {
     expect(hasKimiSessionIndexCacheEntryForTests(KIMI_INDEX)).toBe(false)
 
     await releaseAndSettle()
-    await lapseRouteQuarantine()
     mocks.open.mockResolvedValue(
       servingHandle(`${JSON.stringify({ sessionId: SESSION_ID, workDir: '/repo/app' })}\n`)
     )

--- a/src/main/ai-vault/session-scanner-index-cache-wsl-stall.test.ts
+++ b/src/main/ai-vault/session-scanner-index-cache-wsl-stall.test.ts
@@ -27,8 +27,10 @@ import {
 } from './session-scanner-kimi-paths'
 import { readJsonObjectIfExists } from './session-scanner-values'
 import {
+  WSL_TRANSCRIPT_FS_ROUTE_QUARANTINE_BASE_MS,
   WSL_TRANSCRIPT_FS_SCAN_TIMEOUT_MS,
-  WslTranscriptFsError
+  WslTranscriptFsError,
+  resetWslTranscriptFsGateForTests
 } from '../native-chat/wsl-transcript-fs-gate'
 
 // Identity must not change between the refused and the recovered read, or the
@@ -55,6 +57,13 @@ function servingHandle(body: string) {
   }
 }
 
+// A timed-out stall quarantines the route, so the next read is refused until the
+// window lapses. Waiting it out is what a real caller does; resetting the gate here
+// would skip the very admission the recovery assertions depend on.
+async function lapseRouteQuarantine(): Promise<void> {
+  await vi.advanceTimersByTimeAsync(WSL_TRANSCRIPT_FS_ROUTE_QUARANTINE_BASE_MS + 1)
+}
+
 async function releaseAndSettle(): Promise<void> {
   releaseStall?.()
   releaseStall = undefined
@@ -62,6 +71,7 @@ async function releaseAndSettle(): Promise<void> {
 }
 
 beforeEach(() => {
+  resetWslTranscriptFsGateForTests()
   resetCodexSessionIndexTitleCacheForTests()
   clearKimiSessionIndexCache()
   mocks.stat.mockReset()
@@ -87,6 +97,7 @@ describe('memoized WSL session indexes under a stalled mount', () => {
     expect(_hasCodexSessionIndexTitleCacheEntryForTest(CODEX_HOME)).toBe(false)
 
     await releaseAndSettle()
+    await lapseRouteQuarantine()
     mocks.open.mockResolvedValue(
       servingHandle(`${JSON.stringify({ id: SESSION_ID, thread_name: 'Ship the gate' })}\n`)
     )
@@ -106,6 +117,7 @@ describe('memoized WSL session indexes under a stalled mount', () => {
     expect(hasKimiSessionIndexCacheEntryForTests(KIMI_INDEX)).toBe(false)
 
     await releaseAndSettle()
+    await lapseRouteQuarantine()
     mocks.open.mockResolvedValue(
       servingHandle(`${JSON.stringify({ sessionId: SESSION_ID, workDir: '/repo/app' })}\n`)
     )

--- a/src/main/ai-vault/session-scanner-parse-wsl-stall.test.ts
+++ b/src/main/ai-vault/session-scanner-parse-wsl-stall.test.ts
@@ -20,8 +20,10 @@ import {
   resetSessionParseCacheForTests
 } from './session-scanner-parse-cache'
 import {
+  WSL_TRANSCRIPT_FS_ROUTE_QUARANTINE_BASE_MS,
   WSL_TRANSCRIPT_FS_SCAN_TIMEOUT_MS,
-  WslTranscriptFsError
+  WslTranscriptFsError,
+  resetWslTranscriptFsGateForTests
 } from '../native-chat/wsl-transcript-fs-gate'
 
 type ReadResult = { bytesRead: number; buffer: Buffer }
@@ -77,6 +79,13 @@ function candidate(path: string, bytes: Buffer, mtimeMs: number): SessionFileCan
   }
 }
 
+// A timed-out stall quarantines the route, so the next read is refused until the
+// window lapses. Waiting it out is what a real caller does; resetting the gate here
+// would skip the very admission the recovery assertions depend on.
+async function lapseRouteQuarantine(): Promise<void> {
+  await vi.advanceTimersByTimeAsync(WSL_TRANSCRIPT_FS_ROUTE_QUARANTINE_BASE_MS + 1)
+}
+
 async function releaseAndSettle(): Promise<void> {
   releaseStall?.()
   releaseStall = undefined
@@ -84,6 +93,7 @@ async function releaseAndSettle(): Promise<void> {
 }
 
 beforeEach(() => {
+  resetWslTranscriptFsGateForTests()
   resetSessionParseCacheForTests()
   mocks.open.mockReset()
   mocks.readdir.mockReset()
@@ -143,6 +153,7 @@ describe('AI Vault session parse with a stalled WSL transcript body read', () =>
     await refused
 
     await releaseAndSettle()
+    await lapseRouteQuarantine()
     mocks.open.mockResolvedValue(servingHandle(grown))
     const recovered = await parseAgentSessionFileCached(candidate(STALLED_PATH, grown, 2), 'linux')
 

--- a/src/main/ai-vault/session-scanner-parse-wsl-stall.test.ts
+++ b/src/main/ai-vault/session-scanner-parse-wsl-stall.test.ts
@@ -79,27 +79,25 @@ function candidate(path: string, bytes: Buffer, mtimeMs: number): SessionFileCan
   }
 }
 
-// A timed-out stall quarantines the route, so the next read is refused until the
-// window lapses. Waiting it out is what a real caller does; resetting the gate here
-// would skip the very admission the recovery assertions depend on.
-async function lapseRouteQuarantine(): Promise<void> {
-  await vi.advanceTimersByTimeAsync(WSL_TRANSCRIPT_FS_ROUTE_QUARANTINE_BASE_MS + 1)
-}
-
+// A result that lands past the deadline never lifts the route quarantine, so
+// recovery waits out the back-off window the same way production does.
 async function releaseAndSettle(): Promise<void> {
   releaseStall?.()
   releaseStall = undefined
-  await vi.advanceTimersByTimeAsync(0)
+  await vi.advanceTimersByTimeAsync(WSL_TRANSCRIPT_FS_ROUTE_QUARANTINE_BASE_MS)
 }
 
 beforeEach(() => {
+  // blockedRoutes is persistent gate state: a prior stall must not quarantine
+  // this test's route.
   resetWslTranscriptFsGateForTests()
   resetSessionParseCacheForTests()
   mocks.open.mockReset()
   mocks.readdir.mockReset()
   mocks.readdir.mockResolvedValue([])
   releaseStall = undefined
-  vi.useFakeTimers()
+  // performance.now drives the route quarantine clock, so it must be faked too.
+  vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date', 'performance'] })
 })
 
 afterEach(async () => {
@@ -153,7 +151,6 @@ describe('AI Vault session parse with a stalled WSL transcript body read', () =>
     await refused
 
     await releaseAndSettle()
-    await lapseRouteQuarantine()
     mocks.open.mockResolvedValue(servingHandle(grown))
     const recovered = await parseAgentSessionFileCached(candidate(STALLED_PATH, grown, 2), 'linux')
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​22 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## ELI5

Orca now "quarantines" a WSL folder for a few seconds after a read hangs, so it stops hammering a stuck drive. Four tests were written before that rule existed and still expected the very next read to work instantly, so they failed. They now wait out the short cool-off, like a real caller does — and they clean up after themselves so one test's stall can't break the next one.

## What Changed

Test-only, two files (`session-scanner-index-cache-wsl-stall.test.ts`, `session-scanner-parse-wsl-stall.test.ts`):

1. `releaseAndSettle()` advances by `WSL_TRANSCRIPT_FS_ROUTE_QUARANTINE_BASE_MS` instead of `0`.
2. `resetWslTranscriptFsGateForTests()` runs first in `beforeEach`.
3. `vi.useFakeTimers({ toFake: [..., 'performance'] })`, since `performance.now` drives the quarantine clock.

## Why

#15381 added a route-level quarantine (`wsl-transcript-fs-route-quarantine.ts`): a timed-out task blocks new admissions on that route for a back-off window, so the next real task probes recovery instead of hammering a hung mount. Deliberate — but `main` is currently **red** because of two test-side gaps it exposed:

**1. In-test recovery is refused.** Each failing test stalls a read, advances past `WSL_TRANSCRIPT_FS_SCAN_TIMEOUT_MS`, then re-reads expecting success. A result landing past the deadline never lifts the quarantine, so that second read hits `routeIsBlocked()` → `wsl-transcript-fs-gate.ts:338` rejects `WslTranscriptFsError('unavailable')`.

**2. Quarantine state leaked across tests.** `blockedRoutes` is module-level and no test cleared it. Every path in both files sits on one route (`wsl.localhost/ubuntu`), so `surfaces a refused optional JSON enrichment` quarantined the route and the *next* test — `still degrades a missing optional JSON file to null` — failed without ever stalling anything.

**This is the fix #15381 already shipped elsewhere.** That PR applied the same three edits to `session-scanner-core-parser-wsl-stall.test.ts`, `session-scanner-discovery-wsl-gate.test.ts`, and `opencode-usage/scanner-wsl-gate.test.ts`, and simply missed these two files. This PR adopts that established shape verbatim — same `releaseAndSettle` wait, same `beforeEach` reset, same `toFake` list, same rationale comments — rather than inventing a parallel idiom.

Production behavior is unchanged and correct as designed: the cache eviction these tests are really about still happens; only the immediate re-read is deferred by the back-off. A real WSL user sees refusals for the window, then recovery.

## Testing

`main` is red before this change and green after — not introduced by any open PR:

- #15381 was **merged with these same four shards already failing**: `tests node 24 6/16`, `24 14/16`, `26 6/16`, `26 14/16`, plus `verify`.
- Reproduced on a clean branch off `a3f3a74dcf`: `4 failed | 2 passed`. After this change: `6 passed`.

Each edit verified load-bearing by reverting it independently:

| Arm | Result |
| :--- | :--- |
| `releaseAndSettle` back to advancing `0` | 3 failed / 6 |
| no `beforeEach` gate reset | 2 failed / 6 |
| plain `vi.useFakeTimers()` | 6 passed / 6 |
| this change | 6 passed / 6 |

Reported honestly: the explicit `toFake` is **not** load-bearing today — vitest's default already fakes `performance`. It is kept because the sibling suites carry it and it stops a future default change from silently unfaking the quarantine clock.

Neighbouring suites sharing the gate, lane pool, process client, and route machinery: **80 files / 527 tests pass** (`src/main/native-chat/wsl-transcript*`, `src/main/ai-vault`, `src/main/opencode-usage/scanner-wsl-gate.test.ts`).

The one stalled-mount test that already passed — `refuses the stalled candidate and still parses a sibling on a healthy distro` — is deliberately untouched: it reads a *different* route, which is why the quarantine never blocked it, and it doubles as proof the quarantine stays route-scoped.

`pnpm typecheck` passes.

## Visual Proof

N/A — test-only change, no UI surface.

## Notes

No change to `wsl-transcript-fs-route-quarantine.ts` or the gate. If the intended contract were instead "a released stall lifts the quarantine immediately", the fix would belong in `liftRouteQuarantine` call sites — but the sibling suites #15381 did update encode the wait-it-out behavior, so this reads as intended.

## Checklist

- [x] Focused on unbreaking `main`
- [x] Explained what changed and why
- [x] Test-only; no production behavior change
- [x] Verified the tests fail without each load-bearing edit

## Author

- @BrennanKB5
