### PR TITLE
fix(git): stop isolating git config through os.devNull on Windows

### DIFF
--- a/src/main/git/worktree-shared-directories.test.ts
+++ b/src/main/git/worktree-shared-directories.test.ts
@@ -1,8 +1,8 @@
 import { execFileSync } from 'node:child_process'
 import { lstatSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
-import { devNull, tmpdir } from 'node:os'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   clearConfiguredWorktreeSharedDirectoriesCacheForTests,
   getConfiguredWorktreeSharedDirectories,
@@ -16,14 +16,29 @@ import {
 import { assertWorktreeCleanForRemoval } from './worktree'
 import { getStatus } from './status'
 
+// Why empty files rather than os.devNull: on Windows that constant is `\\.\nul`, and Git
+// rejects it as a config path — `fatal: unable to access '//./nul': Invalid argument` — so every
+// git call in this file failed there and 15 of its 19 tests went red. POSIX resolves the same
+// constant to /dev/null, which Git accepts, so CI never saw it. Empty files are portable, and are
+// how skill-git-tree-identity and skill-windows-workspace already isolate git config.
+const gitConfigRoot = mkdtempSync(join(tmpdir(), 'orca-shared-dirs-gitconfig-'))
+const emptyGlobalGitConfig = join(gitConfigRoot, 'global.gitconfig')
+const emptySystemGitConfig = join(gitConfigRoot, 'system.gitconfig')
+writeFileSync(emptyGlobalGitConfig, '')
+writeFileSync(emptySystemGitConfig, '')
+
+afterAll(() => {
+  rmSync(gitConfigRoot, { recursive: true, force: true })
+})
+
 const git = (args: string[], cwd: string): void => {
   execFileSync('git', args, {
     cwd,
     stdio: 'ignore',
     env: {
       ...process.env,
-      GIT_CONFIG_GLOBAL: devNull,
-      GIT_CONFIG_SYSTEM: devNull
+      GIT_CONFIG_GLOBAL: emptyGlobalGitConfig,
+      GIT_CONFIG_SYSTEM: emptySystemGitConfig
     }
   })
 }

--- a/src/main/git/worktree-shared-directories.test.ts
+++ b/src/main/git/worktree-shared-directories.test.ts
@@ -2,7 +2,7 @@ import { execFileSync } from 'node:child_process'
 import { lstatSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   clearConfiguredWorktreeSharedDirectoriesCacheForTests,
   getConfiguredWorktreeSharedDirectories,
@@ -20,26 +20,41 @@ import { getStatus } from './status'
 // it as a config path — `fatal: unable to access '//./nul': Invalid argument`. POSIX resolves it
 // to /dev/null, which Git accepts, so this only ever failed on Windows. Empty files are portable,
 // and are how skill-git-tree-identity and skill-windows-workspace already isolate git config.
+//
+// Why process.env and not only the helper below: resolveWorktreeSharedDirectories runs its own
+// `git check-ignore` through the production runner, which inherits process.env. Overriding just
+// the setup helper left the code under test reading the host's real config, so a developer with
+// `core.excludesFile` set saw a fixture that is not gitignored come back as ignored.
 const gitConfigRoot = mkdtempSync(join(tmpdir(), 'orca-shared-dirs-gitconfig-'))
 const emptyGlobalGitConfig = join(gitConfigRoot, 'global.gitconfig')
-const emptySystemGitConfig = join(gitConfigRoot, 'system.gitconfig')
 writeFileSync(emptyGlobalGitConfig, '')
-writeFileSync(emptySystemGitConfig, '')
+
+let previousGitConfigGlobal: string | undefined
+let previousGitConfigNosystem: string | undefined
+
+beforeAll(() => {
+  previousGitConfigGlobal = process.env.GIT_CONFIG_GLOBAL
+  previousGitConfigNosystem = process.env.GIT_CONFIG_NOSYSTEM
+  process.env.GIT_CONFIG_GLOBAL = emptyGlobalGitConfig
+  process.env.GIT_CONFIG_NOSYSTEM = '1'
+})
 
 afterAll(() => {
+  restoreEnv('GIT_CONFIG_GLOBAL', previousGitConfigGlobal)
+  restoreEnv('GIT_CONFIG_NOSYSTEM', previousGitConfigNosystem)
   rmSync(gitConfigRoot, { recursive: true, force: true })
 })
 
+function restoreEnv(key: string, previous: string | undefined): void {
+  if (previous === undefined) {
+    delete process.env[key]
+    return
+  }
+  process.env[key] = previous
+}
+
 const git = (args: string[], cwd: string): void => {
-  execFileSync('git', args, {
-    cwd,
-    stdio: 'ignore',
-    env: {
-      ...process.env,
-      GIT_CONFIG_GLOBAL: emptyGlobalGitConfig,
-      GIT_CONFIG_SYSTEM: emptySystemGitConfig
-    }
-  })
+  execFileSync('git', args, { cwd, stdio: 'ignore' })
 }
 
 describe('resolveWorktreeSharedDirectories', () => {

--- a/src/main/git/worktree-shared-directories.test.ts
+++ b/src/main/git/worktree-shared-directories.test.ts
@@ -16,11 +16,10 @@ import {
 import { assertWorktreeCleanForRemoval } from './worktree'
 import { getStatus } from './status'
 
-// Why empty files rather than os.devNull: on Windows that constant is `\\.\nul`, and Git
-// rejects it as a config path — `fatal: unable to access '//./nul': Invalid argument` — so every
-// git call in this file failed there and 15 of its 19 tests went red. POSIX resolves the same
-// constant to /dev/null, which Git accepts, so CI never saw it. Empty files are portable, and are
-// how skill-git-tree-identity and skill-windows-workspace already isolate git config.
+// Why empty files rather than os.devNull: that constant is `\\.\nul` on win32, and Git rejects
+// it as a config path — `fatal: unable to access '//./nul': Invalid argument`. POSIX resolves it
+// to /dev/null, which Git accepts, so this only ever failed on Windows. Empty files are portable,
+// and are how skill-git-tree-identity and skill-windows-workspace already isolate git config.
 const gitConfigRoot = mkdtempSync(join(tmpdir(), 'orca-shared-dirs-gitconfig-'))
 const emptyGlobalGitConfig = join(gitConfigRoot, 'global.gitconfig')
 const emptySystemGitConfig = join(gitConfigRoot, 'system.gitconfig')


### PR DESCRIPTION
## ELI5

A test file told Git "read your settings from the throwaway file", using Node's name for that file.
On Windows that name is a special device path Git refuses to open, so every Git command in the file
died and 15 of its 19 tests failed. On Linux and macOS the same name is `/dev/null`, which Git is
happy with — which is why CI has never noticed. This points at two real empty files instead, which
every platform accepts.

## What Changed

`worktree-shared-directories.test.ts` no longer passes `os.devNull` as `GIT_CONFIG_GLOBAL` /
`GIT_CONFIG_SYSTEM`. It creates two empty config files in a temp directory and points at those,
removing them in `afterAll`.

## Why

`os.devNull` is `\\.\nul` on win32 and `/dev/null` everywhere else. Git for Windows normalizes the
first to `//./nul` and refuses it:

```
fatal: unable to access '//./nul': Invalid argument
```

`stdio: 'ignore'` hid that, so the visible symptom was `Command failed: git init -q -b main` plus a
`TypeError: Cannot read properties of undefined (reading 'mockRestore')` — the latter downstream,
since `beforeEach` throws before `warn` is ever assigned.

Isolating the variable on one machine, same repo, only the env changed:

| # | `GIT_CONFIG_GLOBAL` / `GIT_CONFIG_SYSTEM` | `git init -q -b main` |
|---|---|---|
| A | unset | pass |
| B | `os.devNull` → `\\.\nul` | **fail** |
| C | `NUL` | pass |
| D | `/dev/null` | pass |

Only B fails, so this is the constant rather than the machine, the profile path, or Git being
generally unhappy. Running the same probe under WSL on that machine — where `os.devNull` is
`/dev/null` — passes, which is the other half of the platform split and the reason 16 green CI shards
never caught it. Present since the file was added on 2026-07-28 (#10459).

Empty files are what `skill-git-tree-identity.test.ts` and `skill-windows-workspace.integration.test.ts`
already do, so this follows an existing convention rather than inventing one. No other file in the
repo pairs `os.devNull` with `GIT_CONFIG_*`, so the change is contained to this one.

## Second defect in the same file: the isolation never reached the code under test

Raised by CodeRabbit on #15590 and relayed by @kaluli123123 — credit theirs, reproduction and fix mine.

The per-call override on the `git()` helper only covered the setup commands.
`resolveWorktreeSharedDirectories` reaches git on its own, through `checkIgnoredPaths` ->
`gitExecFileAsync`, and `GitRuntimeOptions` carries only `wslDistro` and `signal` — no env — so that
runner inherits `process.env` and read the host's real global config.

Injecting a synthetic host config whose `core.excludesFile` ignores a fixture the suite expects to be
tracked (into the vitest process only, never the real global config):

```
+ [
+   "shared-but-tracked",
+ ]
 ❯ expect(await resolveWorktreeSharedDirectories(repo)).toEqual([])
 Tests  1 failed | 18 skipped (19)
```

Fixed by setting `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_NOSYSTEM` on `process.env` for the file and
restoring in `afterAll`, the way `git-handler-pull-reconciliation.test.ts` already does. That covers
the code under test as well as the setup, so the per-call override is gone.

Kept in this PR rather than split out: same file, same defect class, and this PR had no human review
yet, so there was nothing to disturb. One review instead of two.

## Linked Issue

Fixes #15409

## Visual Proof

`N/A` — test-only change, no user-facing surface.

## Testing

Windows 11 Pro (26200), Git for Windows 2.54.0, Node 24.15.0, on `main` at `c22803051`:

| | before | after |
|---|---|---|
| `worktree-shared-directories.test.ts`, clean environment | 15 failed / 4 passed | **19 passed** |
| same, with a host `core.excludesFile` injected | 1 failed (after the devNull fix alone) | **19 passed** |

`pnpm typecheck` exits 0. `oxlint` on the changed file exits 0, as does
`pnpm run check:max-lines-ratchet`.

Full `pnpm lint` and `pnpm test` cannot complete on a stock Windows checkout for reasons that predate
this change and are tracked separately: #14479 (`core.autocrlf` breaks `verify:skill-bundle-manifest`),
#15200 (a forward-slash assertion breaks `generate-bundled-skill-guides.test.mjs`), and
`ensure-native-runtime` refusing to start without Visual Studio Build Tools. CI covers all of those
on Linux.

- [x] I manually tested these changes locally
- [ ] Automated tests added/updated, or explained why not below

No new test. What this fixes *is* the test file — 15 of its cases go from red to green on Windows,
which is the regression signal. A test asserting "git accepts our config path" would only restate
what those 19 cases already exercise on every platform.

## AI Disclosure

Claude Opus 5 via Claude Code was used to find the failure, isolate the cause, verify both platform
halves, and write the fix.

## Review

- **Security**: none. A test-only change swapping one config path for another; no production code
  path, no new input, no argv construction.
- **Cross-platform**: this is the point of the change. Empty files work identically on macOS, Linux
  and Windows; the previous value only worked on the first two. Verified on Windows, and the Linux
  half verified under WSL.
- **Remote SSH / local**: untouched. This runs in-process in the test harness and issues no remote
  work.
- **Agents and integrations**: untouched, and provider-neutral — nothing here is agent-specific or
  git-provider-specific.
- **Performance**: two empty files written once per module load, removed in `afterAll`. Nothing in a
  hot path.
- **UI quality**: N/A — no UI.
- **Backwards compatibility**: no contract changes; the file exercises the same behavior it did
  before, on one more platform.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance — covered under **Review** above; mobile is untouched.

One caveat worth stating: I verified the Windows half against Git 2.54.0 only. If an older Git for
Windows within the project's 2.25 baseline happens to accept `\\.\nul`, the failure would be
version-dependent rather than universal. The fix is the same either way, since real empty files work
on every version and platform.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — `typecheck` and the affected suite locally; `lint`/`test` blocked on Windows by the pre-existing issues named under Testing, so CI covers them

## Author

@JahyunBaek — no X account.
