### PR TITLE
test(relay): stop port-scan fixtures colliding with the worker pid

### DIFF
--- a/src/relay/port-scan-handler.test.ts
+++ b/src/relay/port-scan-handler.test.ts
@@ -16,6 +16,19 @@ vi.mock('node:fs/promises', () => ({
 import { parseHexAddress, PortScanHandler } from './port-scan-handler'
 import { parseWindowsNetstatOutput, parseWindowsPowerShellPortRows } from './windows-port-scan'
 
+// The scanner skips any pid matching the relay process or its parent, so a fixture pid
+// range that covers the vitest worker's own pid silently drops the row and the assertion
+// sees no ports. Shift the whole range past a colliding pid so the walk stays hermetic.
+const MAX_FIXTURE_PIDS = 1_000
+
+const PID_BASE = (() => {
+  let base = 1_000
+  while ([process.pid, process.ppid].some((pid) => pid >= base && pid < base + MAX_FIXTURE_PIDS)) {
+    base += MAX_FIXTURE_PIDS
+  }
+  return base
+})()
+
 const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')
 
 beforeEach(() => {
@@ -83,7 +96,7 @@ function mockLinuxProcScan({
     throw new Error(`unexpected readFile: ${path}`)
   })
 
-  const pids = Array.from({ length: pidCount }, (_, index) => String(1_000 + index))
+  const pids = Array.from({ length: pidCount }, (_, index) => String(PID_BASE + index))
   const fds = Array.from({ length: fdCount }, (_, index) => String(index))
   readdirMock.mockImplementation(async (path: string) => {
     if (path === '/proc') {
@@ -133,9 +146,9 @@ describe('PortScanHandler Linux cancellation', () => {
     await expect(scan).rejects.toMatchObject({ name: 'AbortError' })
     expect(readdirMock).toHaveBeenCalledTimes(2)
     expect(readdirMock).toHaveBeenNthCalledWith(1, '/proc')
-    expect(readdirMock).toHaveBeenNthCalledWith(2, '/proc/1000/fd')
+    expect(readdirMock).toHaveBeenNthCalledWith(2, `/proc/${PID_BASE}/fd`)
     expect(readlinkMock).toHaveBeenCalledTimes(1)
-    expect(readlinkMock).toHaveBeenCalledWith('/proc/1000/fd/0')
+    expect(readlinkMock).toHaveBeenCalledWith(`/proc/${PID_BASE}/fd/0`)
   })
 
   it('preserves detected port results when the request stays live', async () => {
@@ -144,7 +157,7 @@ describe('PortScanHandler Linux cancellation', () => {
     await expect(
       capturePortDetectHandler()({}, requestContext(new AbortController().signal))
     ).resolves.toEqual({
-      ports: [{ host: '127.0.0.1', port: 3000, pid: 1_000, processName: 'node' }],
+      ports: [{ host: '127.0.0.1', port: 3000, pid: PID_BASE, processName: 'node' }],
       platform: 'linux'
     })
   })

--- a/src/relay/windows-port-scan.test.ts
+++ b/src/relay/windows-port-scan.test.ts
@@ -18,6 +18,23 @@ vi.mock('./relay-command-env', () => ({
 
 const { scanWindowsListeningPorts } = await import('./windows-port-scan')
 
+// The scanner drops any row whose pid is the relay process or its parent, so a fixture pid
+// that happens to match the vitest worker's own pid silently empties the result and the
+// assertion sees []. Shift off the literals only on collision, which keeps the readable
+// 1234/2468 in the normal case while staying hermetic.
+const SELF_PIDS = new Set([process.pid, process.ppid])
+
+function pidUnlikeSelf(seed: number): number {
+  let pid = seed
+  while (SELF_PIDS.has(pid)) {
+    pid += 1
+  }
+  return pid
+}
+
+const POWERSHELL_PID = pidUnlikeSelf(1234)
+const NETSTAT_PID = pidUnlikeSelf(2468)
+
 describe('scanWindowsListeningPorts', () => {
   beforeEach(() => {
     execFileAsyncMock.mockReset()
@@ -26,12 +43,17 @@ describe('scanWindowsListeningPorts', () => {
   it('bounds the PowerShell scan with the caller abort signal and timeout', async () => {
     const controller = new AbortController()
     execFileAsyncMock.mockResolvedValueOnce({
-      stdout: JSON.stringify({ host: '127.0.0.1', port: 5173, pid: 1234, processName: 'node' }),
+      stdout: JSON.stringify({
+        host: '127.0.0.1',
+        port: 5173,
+        pid: POWERSHELL_PID,
+        processName: 'node'
+      }),
       stderr: ''
     })
 
     await expect(scanWindowsListeningPorts(controller.signal)).resolves.toEqual([
-      { host: '127.0.0.1', port: 5173, pid: 1234, processName: 'node' }
+      { host: '127.0.0.1', port: 5173, pid: POWERSHELL_PID, processName: 'node' }
     ])
 
     expect(execFileAsyncMock).toHaveBeenCalledWith(
@@ -53,13 +75,13 @@ describe('scanWindowsListeningPorts', () => {
       .mockResolvedValueOnce({
         stdout: [
           '  Proto  Local Address          Foreign Address        State           PID',
-          '  TCP    0.0.0.0:3000           0.0.0.0:0              LISTENING       2468'
+          `  TCP    0.0.0.0:3000           0.0.0.0:0              LISTENING       ${NETSTAT_PID}`
         ].join('\r\n'),
         stderr: ''
       })
 
     await expect(scanWindowsListeningPorts(controller.signal)).resolves.toEqual([
-      { host: '0.0.0.0', port: 3000, pid: 2468 }
+      { host: '0.0.0.0', port: 3000, pid: NETSTAT_PID }
     ])
 
     expect(execFileAsyncMock).toHaveBeenLastCalledWith(


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​43 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​35 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## ELI5

Two port-scanner tests made up fake process IDs like 1234 and 2468. The scanner deliberately hides ports owned by its own process — so whenever the test runner happened to be handed one of those exact IDs, its own fixture row got hidden and the test failed for reasons that had nothing to do with the code. The fixtures now pick IDs the runner cannot own.

## What Changed

Test-only, two files:

- `src/relay/windows-port-scan.test.ts` — fixture pids via `pidUnlikeSelf(1234)` / `pidUnlikeSelf(2468)`.
- `src/relay/port-scan-handler.test.ts` — the `/proc` walk's pid range starts at a `PID_BASE` that cannot contain the worker pid.

The literals stay `1234` / `2468` / `1000` unless the running process owns one; only then do they shift.

## Why

Both scanners drop rows owned by the relay process or its parent:

- `windows-port-scan.ts:187-188` — `relayPid` / `relayParentPid`
- `port-scan-handler.ts:58-59` — same filter

The fixtures hardcoded pids, so a vitest worker assigned one of them had its own fixture row filtered out and the assertion saw an empty result. Nothing about the production path was wrong.

This is not theoretical — it fired in CI on #15405: `tests node 26 1/16` failed while `tests node 24 1/16` **passed on the identical SHA**. Same code, different pid, different outcome.

## Testing

Root cause reproduced exactly, then fixed:

| Scenario | Before | After |
| :--- | :--- | :--- |
| worker pid = 2468 (`windows-port-scan`) | FAIL — `expected [] to deeply equal [ { host: '0.0.0.0', …(2) } ]` | pass |
| worker pid = 1234 (`windows-port-scan`) | — | pass |
| worker pid = 1000 (`port-scan-handler`) | FAIL — `expected { ports: [], platform: 'linux' } to deeply equal { ports: [ { …(4) } ], …(1) }` | pass |
| worker pid = 1500 / 1999 (`port-scan-handler`) | — | pass |
| unforced | pass | pass |

The `expected []` message in the first row is character-for-character the failure CI produced, which is what confirms this is the actual cause rather than a plausible one.

`src/relay` suite: 1404 passed. Two `pty-handler` tests fail locally on macOS, but they fail identically with these changes reverted, so they are pre-existing and unrelated. `pnpm typecheck` passes.

## Visual Proof

N/A — test-only change, no UI surface.

## Notes

The sibling `port-scan-handler.test.ts` was not failing in CI yet; I probed it because it shares the self-pid filter, confirmed it fails the same way at pid 1000-1999, and fixed it here rather than waiting for it to fire on someone else's PR.

Deliberately not changed: the production self-pid filter. Hiding the relay's own ports is correct behavior; only the fixtures were unsound.

## Checklist

- [x] Focused on the flake
- [x] Root cause reproduced deterministically before fixing
- [x] Test-only; no production behavior change
- [x] Verified the tests fail without the fix and pass with it

## Author

- @BrennanKB5
