### PR TITLE
Fix WSL stall tests to reset gate state and fake performance timer

### DIFF
--- a/src/main/ai-vault/session-scanner-index-cache-wsl-stall.test.ts
+++ b/src/main/ai-vault/session-scanner-index-cache-wsl-stall.test.ts
@@ -27,6 +27,8 @@ import {
 } from './session-scanner-kimi-paths'
 import { readJsonObjectIfExists } from './session-scanner-values'
 import {
+  resetWslTranscriptFsGateForTests,
+  WSL_TRANSCRIPT_FS_ROUTE_QUARANTINE_BASE_MS,
   WSL_TRANSCRIPT_FS_SCAN_TIMEOUT_MS,
   WslTranscriptFsError
 } from '../native-chat/wsl-transcript-fs-gate'
@@ -55,13 +57,18 @@ function servingHandle(body: string) {
   }
 }
 
+// A result that lands past the deadline never lifts the route quarantine, so
+// recovery waits out the back-off window the same way production does.
 async function releaseAndSettle(): Promise<void> {
   releaseStall?.()
   releaseStall = undefined
-  await vi.advanceTimersByTimeAsync(0)
+  await vi.advanceTimersByTimeAsync(WSL_TRANSCRIPT_FS_ROUTE_QUARANTINE_BASE_MS)
 }
 
 beforeEach(() => {
+  // blockedRoutes is persistent gate state: a prior stall must not quarantine
+  // this test's route.
+  resetWslTranscriptFsGateForTests()
   resetCodexSessionIndexTitleCacheForTests()
   clearKimiSessionIndexCache()
   mocks.stat.mockReset()
@@ -69,7 +76,8 @@ beforeEach(() => {
   mocks.readFile.mockReset()
   mocks.stat.mockResolvedValue(INDEX_STATS)
   releaseStall = undefined
-  vi.useFakeTimers()
+  // performance.now drives the route quarantine clock, so it must be faked too.
+  vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date', 'performance'] })
 })
 
 afterEach(async () => {

--- a/src/main/ai-vault/session-scanner-opencode-sources-wsl-stall.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sources-wsl-stall.test.ts
@@ -20,7 +20,10 @@ vi.mock('./session-scanner-opencode-sqlite-worker-spawn', () => ({
 }))
 
 import { opencodeDiscoveries } from './session-scanner-opencode-sources'
-import { WSL_TRANSCRIPT_FS_SCAN_TIMEOUT_MS } from '../native-chat/wsl-transcript-fs-gate'
+import {
+  resetWslTranscriptFsGateForTests,
+  WSL_TRANSCRIPT_FS_SCAN_TIMEOUT_MS
+} from '../native-chat/wsl-transcript-fs-gate'
 
 let releaseStall: (() => void) | undefined
 
@@ -39,6 +42,7 @@ function stalls(): Promise<never> {
 }
 
 beforeEach(() => {
+  resetWslTranscriptFsGateForTests()
   mocks.readdir.mockReset()
   mocks.stat.mockReset()
   releaseStall = undefined

--- a/src/main/ai-vault/session-scanner-parse-wsl-stall.test.ts
+++ b/src/main/ai-vault/session-scanner-parse-wsl-stall.test.ts
@@ -20,6 +20,8 @@ import {
   resetSessionParseCacheForTests
 } from './session-scanner-parse-cache'
 import {
+  resetWslTranscriptFsGateForTests,
+  WSL_TRANSCRIPT_FS_ROUTE_QUARANTINE_BASE_MS,
   WSL_TRANSCRIPT_FS_SCAN_TIMEOUT_MS,
   WslTranscriptFsError
 } from '../native-chat/wsl-transcript-fs-gate'
@@ -77,19 +79,25 @@ function candidate(path: string, bytes: Buffer, mtimeMs: number): SessionFileCan
   }
 }
 
+// A result that lands past the deadline never lifts the route quarantine, so
+// recovery waits out the back-off window the same way production does.
 async function releaseAndSettle(): Promise<void> {
   releaseStall?.()
   releaseStall = undefined
-  await vi.advanceTimersByTimeAsync(0)
+  await vi.advanceTimersByTimeAsync(WSL_TRANSCRIPT_FS_ROUTE_QUARANTINE_BASE_MS)
 }
 
 beforeEach(() => {
+  // blockedRoutes is persistent gate state: a prior stall must not quarantine
+  // this test's route.
+  resetWslTranscriptFsGateForTests()
   resetSessionParseCacheForTests()
   mocks.open.mockReset()
   mocks.readdir.mockReset()
   mocks.readdir.mockResolvedValue([])
   releaseStall = undefined
-  vi.useFakeTimers()
+  // performance.now drives the route quarantine clock, so it must be faked too.
+  vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date', 'performance'] })
 })
 
 afterEach(async () => {

--- a/src/main/ai-vault/session-title-file-reader-wsl-stall.test.ts
+++ b/src/main/ai-vault/session-title-file-reader-wsl-stall.test.ts
@@ -24,7 +24,10 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { readAiVaultSessionTitlesFromFiles } from './session-title-file-reader'
 import { resetSessionParseCacheForTests } from './session-scanner-parse-cache'
-import { WSL_TRANSCRIPT_FS_SCAN_TIMEOUT_MS } from '../native-chat/wsl-transcript-fs-gate'
+import {
+  resetWslTranscriptFsGateForTests,
+  WSL_TRANSCRIPT_FS_SCAN_TIMEOUT_MS
+} from '../native-chat/wsl-transcript-fs-gate'
 
 let releaseStall: (() => void) | undefined
 let tempRoot: string | undefined
@@ -47,6 +50,7 @@ function userRecord(sessionId: string, text: string): string {
 }
 
 beforeEach(async () => {
+  resetWslTranscriptFsGateForTests()
   resetSessionParseCacheForTests()
   mocks.lstat.mockReset()
   releaseStall = undefined

--- a/src/main/native-chat/transcript-read-cache-wsl-stall.test.ts
+++ b/src/main/native-chat/transcript-read-cache-wsl-stall.test.ts
@@ -24,12 +24,16 @@ import {
   clearNativeChatTranscriptCache,
   readNativeChatTranscriptCached
 } from './transcript-read-cache'
-import { WSL_TRANSCRIPT_FS_EXACT_TIMEOUT_MS } from './wsl-transcript-fs-gate'
+import {
+  resetWslTranscriptFsGateForTests,
+  WSL_TRANSCRIPT_FS_EXACT_TIMEOUT_MS
+} from './wsl-transcript-fs-gate'
 
 const SLOW_MESSAGE =
   'WSL transcript files are temporarily unavailable because filesystem access is taking too long. Try again shortly or restart Orca if the issue continues.'
 
 beforeEach(() => {
+  resetWslTranscriptFsGateForTests()
   mocks.resolve.mockReset()
   mocks.stat.mockReset()
   mocks.read.mockReset()

--- a/src/main/native-chat/transcript-reader-wsl-stall.test.ts
+++ b/src/main/native-chat/transcript-reader-wsl-stall.test.ts
@@ -11,7 +11,10 @@ vi.mock('node:fs/promises', async (importOriginal) => ({
 }))
 
 import { readNativeChatTranscript } from './transcript-reader'
-import { WSL_TRANSCRIPT_FS_EXACT_TIMEOUT_MS } from './wsl-transcript-fs-gate'
+import {
+  resetWslTranscriptFsGateForTests,
+  WSL_TRANSCRIPT_FS_EXACT_TIMEOUT_MS
+} from './wsl-transcript-fs-gate'
 
 const SLOW_MESSAGE =
   'WSL transcript files are temporarily unavailable because filesystem access is taking too long. Try again shortly or restart Orca if the issue continues.'
@@ -43,6 +46,7 @@ function handleServing(body: Buffer, delayMs = 0) {
 }
 
 beforeEach(() => {
+  resetWslTranscriptFsGateForTests()
   mocks.open.mockReset()
 })
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​24 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## Problem

WSL stall tests fail because gate state persists across test runs. One test's stall quarantine blocks the next test. Also, `performance.now()` isn't faked, so quarantine timeouts don't work in tests.

## Solution

Reset gate state before each test and fake the performance timer. Advance fake timers by the full back-off duration instead of zero.

## Changes

- Call `resetWslTranscriptFsGateForTests()` in each test's `beforeEach()`
- Add `'performance'` to `vi.useFakeTimers()` config to fake the timer
- Update `releaseAndSettle()` to advance by `WSL_TRANSCRIPT_FS_ROUTE_QUARANTINE_BASE_MS`
- Add explanatory comments on gate state and timer requirements