### PR TITLE
fix(codex): stop rebuilding shared Codex state from a read that failed (STA-4823)

### DIFF
--- a/src/main/agent-hooks/hooks-json-read.ts
+++ b/src/main/agent-hooks/hooks-json-read.ts
@@ -1,4 +1,5 @@
-import { existsSync, readFileSync } from 'node:fs'
+import { readFileSync } from 'node:fs'
+import { isDefinitiveAbsence } from '../../shared/definitive-filesystem-absence'
 import type { HooksConfig } from './installer-utils'
 
 export function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -26,16 +27,17 @@ export function parseHooksJsonText(raw: string): HooksConfig | null {
 // bytes it was derived from; the raw snapshot and the parse must come from one
 // read or a concurrent save can slip between them unnoticed.
 export function readHooksJsonWithRaw(configPath: string): HooksJsonSnapshot {
-  if (!existsSync(configPath)) {
-    return { raw: null, config: {} }
-  }
-  let raw: string
+  // Why: the read arm below already separates "no hooks configured" from "could
+  // not read", but the `existsSync` arm in front of it did not — it returned a
+  // VALID EMPTY config for a file that merely could not be opened, and the
+  // installer then wrote generated hooks over it. One read classifies both, and
+  // closes the TOCTOU window between the two calls.
   try {
-    raw = readFileSync(configPath, 'utf-8')
-  } catch {
-    return { raw: null, config: null }
+    const raw = readFileSync(configPath, 'utf-8')
+    return { raw, config: parseHooksJsonText(raw) }
+  } catch (error) {
+    return isDefinitiveAbsence(error) ? { raw: null, config: {} } : { raw: null, config: null }
   }
-  return { raw, config: parseHooksJsonText(raw) }
 }
 
 export function readHooksJson(configPath: string): HooksConfig | null {

--- a/src/main/codex/codex-config-mirror.ts
+++ b/src/main/codex/codex-config-mirror.ts
@@ -160,10 +160,10 @@ function syncSystemConfigIntoManagedCodexHomeUnsafe(
 ): CodexConfigMirrorResult {
   const systemConfigPath = join(systemHomePath, 'config.toml')
   const runtimeConfigPath = join(runtimeHomePath, 'config.toml')
-  // Why: `existsSync` answered `false` for a locked file exactly as for an absent
-  // one, so a held handle on the RUNTIME config read as "no runtime config yet"
-  // and the fresh-mirror branch below overwrote it wholesale. Neither side may
-  // be acted on unless it was actually observed.
+  // Why: `existsSync` collapses an indeterminate probe into the same `false` as
+  // absence, so a transiently unavailable RUNTIME config could reach the fresh
+  // mirror after the path recovered. Neither side may be acted on unless it was
+  // actually observed.
   const systemConfigObservation = observeAgentStateFile(systemConfigPath)
   if (systemConfigObservation.kind === 'indeterminate') {
     return { status: 'refused-indeterminate', error: systemConfigObservation.error }

--- a/src/main/codex/codex-pane-account-registry-mutations.test.ts
+++ b/src/main/codex/codex-pane-account-registry-mutations.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { CodexPaneAccountRegistryMutations } from './codex-pane-account-registry-mutations'
+import type { CodexPaneAccountRegistryFile } from './codex-pane-account-registry-types'
+
+const EXISTING = {
+  selectionKey: 'host',
+  accountId: 'account-1',
+  homeRoute: 'account-home'
+} as const
+
+const SPAWNED = {
+  selectionKey: 'host',
+  accountId: 'account-2',
+  homeRoute: 'account-home'
+} as const
+
+function parseRegistry(serialized: string): CodexPaneAccountRegistryFile {
+  return JSON.parse(serialized) as CodexPaneAccountRegistryFile
+}
+
+describe('CodexPaneAccountRegistryMutations', () => {
+  beforeEach(() => vi.useFakeTimers())
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it('retries a one-shot spawn record and merges it with the recovered file', async () => {
+    let readable = false
+    let persisted = JSON.stringify({ version: 2, panes: { existing: EXISTING } })
+    const write = vi.fn((registry: CodexPaneAccountRegistryFile) => {
+      persisted = JSON.stringify(registry)
+      return true
+    })
+    const mutations = new CodexPaneAccountRegistryMutations({
+      read: () => (readable ? parseRegistry(persisted) : null),
+      write
+    })
+
+    mutations.record('spawned', SPAWNED)
+    expect(write).not.toHaveBeenCalled()
+
+    readable = true
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(parseRegistry(persisted).panes).toEqual({ existing: EXISTING, spawned: SPAWNED })
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('bounds automatic retries but keeps the pending mutation for a later read', async () => {
+    let readable = false
+    let persisted = JSON.stringify({ version: 2, panes: { existing: EXISTING } })
+    const read = vi.fn(() => (readable ? parseRegistry(persisted) : null))
+    const write = vi.fn((registry: CodexPaneAccountRegistryFile) => {
+      persisted = JSON.stringify(registry)
+      return true
+    })
+    const mutations = new CodexPaneAccountRegistryMutations({ read, write })
+
+    mutations.record('spawned', SPAWNED)
+    await vi.advanceTimersByTimeAsync(120_000)
+
+    expect(read).toHaveBeenCalledTimes(5)
+    expect(vi.getTimerCount()).toBe(0)
+
+    readable = true
+    mutations.flush()
+    expect(parseRegistry(persisted).panes.spawned).toEqual(SPAWNED)
+  })
+
+  it('retries durability after a write failure even when the cached value now matches', async () => {
+    const registry = parseRegistry(JSON.stringify({ version: 2, panes: { existing: EXISTING } }))
+    const write = vi.fn().mockReturnValueOnce(false).mockReturnValueOnce(true)
+    const mutations = new CodexPaneAccountRegistryMutations({ read: () => registry, write })
+
+    mutations.record('spawned', SPAWNED)
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(write).toHaveBeenCalledTimes(2)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/src/main/codex/codex-pane-account-registry-mutations.test.ts
+++ b/src/main/codex/codex-pane-account-registry-mutations.test.ts
@@ -80,4 +80,16 @@ describe('CodexPaneAccountRegistryMutations', () => {
     expect(write).toHaveBeenCalledTimes(2)
     expect(vi.getTimerCount()).toBe(0)
   })
+
+  it('retries a failed reconciliation write without a pending pane mutation', async () => {
+    const registry = parseRegistry(JSON.stringify({ version: 2, panes: { existing: EXISTING } }))
+    const write = vi.fn().mockReturnValueOnce(false).mockReturnValueOnce(true)
+    const mutations = new CodexPaneAccountRegistryMutations({ read: () => registry, write })
+
+    mutations.persistReconciliation(registry, true)
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(write).toHaveBeenCalledTimes(2)
+    expect(vi.getTimerCount()).toBe(0)
+  })
 })

--- a/src/main/codex/codex-pane-account-registry-mutations.ts
+++ b/src/main/codex/codex-pane-account-registry-mutations.ts
@@ -34,7 +34,7 @@ export class CodexPaneAccountRegistryMutations {
   }
 
   flush(): void {
-    if (this.pending.size === 0) {
+    if (this.pending.size === 0 && !this.needsPersistence) {
       this.clearRetryState()
       return
     }

--- a/src/main/codex/codex-pane-account-registry-mutations.ts
+++ b/src/main/codex/codex-pane-account-registry-mutations.ts
@@ -1,0 +1,157 @@
+import type {
+  CodexPaneAccountRecord,
+  CodexPaneAccountRegistryFile
+} from './codex-pane-account-registry-types'
+
+// Why: bounds both crash-leaked disk records and mutations retained while the file is unavailable.
+const MAX_TRACKED_PANES = 2000
+const RETRY_DELAYS_MS = [100, 1_000, 5_000, 30_000] as const
+
+type MutationStoreDependencies = {
+  read: () => CodexPaneAccountRegistryFile | null
+  write: (registry: CodexPaneAccountRegistryFile) => boolean
+}
+
+export class CodexPaneAccountRegistryMutations {
+  private readonly pending = new Map<string, CodexPaneAccountRecord | null>()
+  private retryTimer: ReturnType<typeof setTimeout> | null = null
+  private retryAttempt = 0
+  private needsPersistence = false
+
+  constructor(private readonly dependencies: MutationStoreDependencies) {}
+
+  record(ptyId: string, record: CodexPaneAccountRecord | null): void {
+    this.pending.delete(ptyId)
+    this.pending.set(ptyId, record)
+    if (this.pending.size > MAX_TRACKED_PANES) {
+      const oldestPtyId = this.pending.keys().next().value
+      if (typeof oldestPtyId === 'string') {
+        this.pending.delete(oldestPtyId)
+        console.warn('[codex-pane-accounts] Dropped oldest pending registry mutation at capacity')
+      }
+    }
+    this.flush()
+  }
+
+  flush(): void {
+    if (this.pending.size === 0) {
+      this.clearRetryState()
+      return
+    }
+    const registry = this.dependencies.read()
+    if (!registry) {
+      this.scheduleRetry()
+      return
+    }
+    let changed = false
+    for (const [ptyId, record] of this.pending) {
+      changed = applyMutation(registry, ptyId, record) || changed
+    }
+    trimRegistry(registry)
+    if ((changed || this.needsPersistence) && !this.dependencies.write(registry)) {
+      this.needsPersistence = true
+      this.scheduleRetry()
+      return
+    }
+    this.needsPersistence = false
+    this.pending.clear()
+    this.clearRetryState()
+  }
+
+  getPendingRegistry(): CodexPaneAccountRegistryFile | null {
+    if (this.pending.size === 0) {
+      return null
+    }
+    const registry: CodexPaneAccountRegistryFile = { version: 2, panes: {} }
+    for (const [ptyId, record] of this.pending) {
+      applyMutation(registry, ptyId, record)
+    }
+    return registry
+  }
+
+  persistReconciliation(registry: CodexPaneAccountRegistryFile, changed: boolean): void {
+    if (!changed) {
+      return
+    }
+    if (!this.dependencies.write(registry)) {
+      this.needsPersistence = true
+      this.scheduleRetry()
+      return
+    }
+    this.needsPersistence = false
+    this.pending.clear()
+    this.clearRetryState()
+  }
+
+  reset(): void {
+    this.needsPersistence = false
+    this.pending.clear()
+    this.clearRetryState()
+  }
+
+  private scheduleRetry(): void {
+    if (this.retryTimer || this.retryAttempt >= RETRY_DELAYS_MS.length) {
+      return
+    }
+    this.retryTimer = setTimeout(() => {
+      this.retryTimer = null
+      this.flush()
+    }, RETRY_DELAYS_MS[this.retryAttempt])
+    this.retryAttempt += 1
+    this.retryTimer.unref?.()
+  }
+
+  private clearRetryState(): void {
+    if (this.retryTimer) {
+      clearTimeout(this.retryTimer)
+      this.retryTimer = null
+    }
+    this.retryAttempt = 0
+  }
+}
+
+function applyMutation(
+  registry: CodexPaneAccountRegistryFile,
+  ptyId: string,
+  record: CodexPaneAccountRecord | null
+): boolean {
+  if (!record) {
+    if (!(ptyId in registry.panes)) {
+      return false
+    }
+    delete registry.panes[ptyId]
+    return true
+  }
+  const existing = registry.panes[ptyId]
+  if (recordsEqual(existing, record)) {
+    return false
+  }
+  registry.panes[ptyId] = record
+  return true
+}
+
+function recordsEqual(
+  left: CodexPaneAccountRecord | undefined,
+  right: CodexPaneAccountRecord
+): boolean {
+  return (
+    left?.selectionKey === right.selectionKey &&
+    left.accountId === right.accountId &&
+    left.homeRoute === right.homeRoute &&
+    left.shellStartupHomeOverride?.home === right.shellStartupHomeOverride?.home &&
+    left.shellStartupHomeOverride?.shell === right.shellStartupHomeOverride?.shell &&
+    left.shellStartupHomeOverride?.configHome === right.shellStartupHomeOverride?.configHome &&
+    left.shellStartupHomeOverride?.codexHome === right.shellStartupHomeOverride?.codexHome &&
+    left.environmentHomeOverride?.codexHome === right.environmentHomeOverride?.codexHome
+  )
+}
+
+function trimRegistry(registry: CodexPaneAccountRegistryFile): void {
+  const trackedPtyIds = Object.keys(registry.panes)
+  if (trackedPtyIds.length <= MAX_TRACKED_PANES) {
+    return
+  }
+  for (const staleId of trackedPtyIds.slice(0, trackedPtyIds.length - MAX_TRACKED_PANES)) {
+    delete registry.panes[staleId]
+  }
+}

--- a/src/main/codex/codex-pane-account-registry-types.ts
+++ b/src/main/codex/codex-pane-account-registry-types.ts
@@ -1,0 +1,29 @@
+import type {
+  CodexEnvironmentHomeOverride,
+  CodexShellStartupHomeOverride
+} from './codex-real-home-path'
+
+export type CodexPaneHomeRoute =
+  | 'real-home'
+  | 'shared-home'
+  | 'account-home'
+  | 'custom-home'
+  | 'wsl-home'
+
+export type CodexPaneAccountRecord = {
+  /** 'host' or 'wsl:<distro>' — the selection lane this pane launched from. */
+  selectionKey: string
+  /** Managed account id, or null for the system-default account. */
+  accountId: string | null
+  /** Absent only on records written before route provenance was introduced. */
+  homeRoute?: CodexPaneHomeRoute
+  /** Rechecked when CODEX_HOME came from process-global shell startup. */
+  shellStartupHomeOverride?: CodexShellStartupHomeOverride
+  /** Rechecked after restart when CODEX_HOME came from the process environment. */
+  environmentHomeOverride?: CodexEnvironmentHomeOverride
+}
+
+export type CodexPaneAccountRegistryFile = {
+  version: 2
+  panes: Record<string, CodexPaneAccountRecord>
+}

--- a/src/main/codex/codex-pane-account-registry.ts
+++ b/src/main/codex/codex-pane-account-registry.ts
@@ -1,4 +1,5 @@
 import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import { isDefinitiveAbsence } from '../../shared/definitive-filesystem-absence'
 import { dirname, join } from 'node:path'
 import { getOrcaUserDataPath } from './codex-home-paths'
 import type {
@@ -51,20 +52,45 @@ function getRegistryPath(): string {
   return join(getOrcaUserDataPath(), 'codex-pane-accounts.json')
 }
 
-function readRegistry(): RegistryFile {
+/**
+ * `null` means the registry could not be READ. That is not the same as "no
+ * panes are attributed", and it must never be cached: the old `catch { return
+ * null }` collapsed both into an empty registry, so one unreadable read erased
+ * every pane's account attribution AND pinned that erasure in `cachedRegistry`
+ * for the rest of the process, surviving the file becoming readable again.
+ */
+function readRegistryOrNull(): RegistryFile | null {
   if (cachedRegistry) {
     return cachedRegistry
   }
-  cachedRegistry = parseRegistry(readRegistryFile())
+  let rawRegistry: string
+  try {
+    rawRegistry = readFileSync(getRegistryPath(), 'utf-8')
+  } catch (error) {
+    if (!isDefinitiveAbsence(error)) {
+      return null
+    }
+    cachedRegistry = parseRegistry(null)
+    return cachedRegistry
+  }
+  // Why: a corrupt registry still degrades to empty and IS cached — rebuilding
+  // unparseable state is the intent, and re-reading it every call would only
+  // repeat the parse failure.
+  cachedRegistry = parseRegistry(parseRegistryJson(rawRegistry))
   return cachedRegistry
 }
 
-function readRegistryFile(): unknown {
+function parseRegistryJson(rawRegistry: string): unknown {
   try {
-    return JSON.parse(readFileSync(getRegistryPath(), 'utf-8'))
+    return JSON.parse(rawRegistry)
   } catch {
     return null
   }
+}
+
+/** Read-only callers: an unreadable registry reports no attribution, uncached. */
+function readRegistry(): RegistryFile {
+  return readRegistryOrNull() ?? { version: 2, panes: {} }
 }
 
 function parseRegistry(parsed: unknown): RegistryFile {
@@ -162,7 +188,13 @@ function writeRegistry(registry: RegistryFile): void {
  * Records the account a PTY launched under. Pass null to forget a pinned pane.
  */
 export function recordCodexPaneAccount(ptyId: string, record: CodexPaneAccountRecord | null): void {
-  const registry = readRegistry()
+  // Why: every write below persists the whole registry. Deriving it from an
+  // empty stand-in because the real one could not be read would drop every
+  // other pane's attribution on disk. Skip; the next record retries.
+  const registry = readRegistryOrNull()
+  if (!registry) {
+    return
+  }
   if (!record) {
     if (!(ptyId in registry.panes)) {
       return
@@ -279,7 +311,13 @@ export function hasRecordedManagedHostCodexPane(): boolean {
 
 /** Drops records whose daemon PTYs are authoritatively absent. */
 export function reconcileCodexPaneAccountsWithLivePtys(livePtyIds: readonly string[]): void {
-  const registry = readRegistry()
+  // Why: this deletes every pane not in the live list. Against an empty stand-in
+  // it is a no-op, but the write it guards would still persist that stand-in
+  // over the real file, so refuse rather than reconcile a registry nobody read.
+  const registry = readRegistryOrNull()
+  if (!registry) {
+    return
+  }
   const livePtyIdSet = new Set(livePtyIds)
   let changed = false
   for (const ptyId of Object.keys(registry.panes)) {

--- a/src/main/codex/codex-pane-account-registry.ts
+++ b/src/main/codex/codex-pane-account-registry.ts
@@ -2,10 +2,21 @@ import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node
 import { isDefinitiveAbsence } from '../../shared/definitive-filesystem-absence'
 import { dirname, join } from 'node:path'
 import { getOrcaUserDataPath } from './codex-home-paths'
+import { CodexPaneAccountRegistryMutations } from './codex-pane-account-registry-mutations'
+import type {
+  CodexPaneAccountRecord,
+  CodexPaneAccountRegistryFile,
+  CodexPaneHomeRoute
+} from './codex-pane-account-registry-types'
 import type {
   CodexEnvironmentHomeOverride,
   CodexShellStartupHomeOverride
 } from './codex-real-home-path'
+
+export type {
+  CodexPaneAccountRecord,
+  CodexPaneHomeRoute
+} from './codex-pane-account-registry-types'
 
 /**
  * Remembers which Codex account each live PTY was launched under.
@@ -17,36 +28,7 @@ import type {
  * the old account and the user is stuck there with no prompt to escape it.
  */
 
-export type CodexPaneHomeRoute =
-  | 'real-home'
-  | 'shared-home'
-  | 'account-home'
-  | 'custom-home'
-  | 'wsl-home'
-
-export type CodexPaneAccountRecord = {
-  /** 'host' or 'wsl:<distro>' — the selection lane this pane launched from. */
-  selectionKey: string
-  /** Managed account id, or null for the system-default account. */
-  accountId: string | null
-  /** Absent only on records written before route provenance was introduced. */
-  homeRoute?: CodexPaneHomeRoute
-  /** Rechecked when CODEX_HOME came from process-global shell startup. */
-  shellStartupHomeOverride?: CodexShellStartupHomeOverride
-  /** Rechecked after restart when CODEX_HOME came from the process environment. */
-  environmentHomeOverride?: CodexEnvironmentHomeOverride
-}
-
-type RegistryFile = {
-  version: 2
-  panes: Record<string, CodexPaneAccountRecord>
-}
-
-// Why: bounds a file that only shrinks when Orca observes a PTY exit; a crash
-// mid-session would otherwise leak an entry per terminal, forever.
-const MAX_TRACKED_PANES = 2000
-
-let cachedRegistry: RegistryFile | null = null
+let cachedRegistry: CodexPaneAccountRegistryFile | null = null
 
 function getRegistryPath(): string {
   return join(getOrcaUserDataPath(), 'codex-pane-accounts.json')
@@ -59,7 +41,7 @@ function getRegistryPath(): string {
  * every pane's account attribution AND pinned that erasure in `cachedRegistry`
  * for the rest of the process, surviving the file becoming readable again.
  */
-function readRegistryOrNull(): RegistryFile | null {
+function readRegistryOrNull(): CodexPaneAccountRegistryFile | null {
   if (cachedRegistry) {
     return cachedRegistry
   }
@@ -89,16 +71,32 @@ function parseRegistryJson(rawRegistry: string): unknown {
 }
 
 /** Read-only callers: an unreadable registry reports no attribution, uncached. */
-function readRegistry(): RegistryFile {
+function readRegistry(): CodexPaneAccountRegistryFile {
+  mutations.flush()
+  if (!cachedRegistry) {
+    const pendingRegistry = mutations.getPendingRegistry()
+    if (pendingRegistry) {
+      return pendingRegistry
+    }
+  }
   return readRegistryOrNull() ?? { version: 2, panes: {} }
 }
 
-function parseRegistry(parsed: unknown): RegistryFile {
-  const empty: RegistryFile = { version: 2, panes: {} }
+function readRegistryOrThrow(): CodexPaneAccountRegistryFile {
+  mutations.flush()
+  const registry = readRegistryOrNull()
+  if (!registry) {
+    throw new Error('Codex pane account registry could not be read')
+  }
+  return registry
+}
+
+function parseRegistry(parsed: unknown): CodexPaneAccountRegistryFile {
+  const empty: CodexPaneAccountRegistryFile = { version: 2, panes: {} }
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
     return empty
   }
-  const panes = (parsed as Partial<RegistryFile>).panes
+  const panes = (parsed as Partial<CodexPaneAccountRegistryFile>).panes
   if (!panes || typeof panes !== 'object' || Array.isArray(panes)) {
     return empty
   }
@@ -164,7 +162,7 @@ function isPaneHomeRoute(value: unknown): value is CodexPaneHomeRoute {
   )
 }
 
-function writeRegistry(registry: RegistryFile): void {
+function writeRegistry(registry: CodexPaneAccountRegistryFile): boolean {
   const registryPath = getRegistryPath()
   const temporaryPath = `${registryPath}.${process.pid}.tmp`
   try {
@@ -174,6 +172,7 @@ function writeRegistry(registry: RegistryFile): void {
       mode: 0o600
     })
     renameSync(temporaryPath, registryPath)
+    return true
   } catch (error) {
     // Why: this record only powers a restart hint; losing it must never break a
     // terminal spawn or a PTY teardown — including when the cleanup itself fails.
@@ -181,68 +180,23 @@ function writeRegistry(registry: RegistryFile): void {
     try {
       rmSync(temporaryPath, { force: true })
     } catch {}
+    return false
   }
 }
+
+const mutations = new CodexPaneAccountRegistryMutations({
+  read: readRegistryOrNull,
+  write: writeRegistry
+})
 
 /**
  * Records the account a PTY launched under. Pass null to forget a pinned pane.
  */
 export function recordCodexPaneAccount(ptyId: string, record: CodexPaneAccountRecord | null): void {
-  // Why: every write below persists the whole registry. Deriving it from an
-  // empty stand-in because the real one could not be read would drop every
-  // other pane's attribution on disk. Skip; the next record retries.
-  const registry = readRegistryOrNull()
-  if (!registry) {
-    return
-  }
-  if (!record) {
-    if (!(ptyId in registry.panes)) {
-      return
-    }
-    delete registry.panes[ptyId]
-    writeRegistry(registry)
-    return
-  }
-  const existing = registry.panes[ptyId]
-  if (
-    existing?.selectionKey === record.selectionKey &&
-    existing.accountId === record.accountId &&
-    existing.homeRoute === record.homeRoute &&
-    shellStartupHomeOverridesEqual(
-      existing.shellStartupHomeOverride,
-      record.shellStartupHomeOverride
-    ) &&
-    environmentHomeOverridesEqual(existing.environmentHomeOverride, record.environmentHomeOverride)
-  ) {
-    return
-  }
-  registry.panes[ptyId] = record
-  const trackedPtyIds = Object.keys(registry.panes)
-  if (trackedPtyIds.length > MAX_TRACKED_PANES) {
-    for (const staleId of trackedPtyIds.slice(0, trackedPtyIds.length - MAX_TRACKED_PANES)) {
-      delete registry.panes[staleId]
-    }
-  }
-  writeRegistry(registry)
-}
-
-function environmentHomeOverridesEqual(
-  left: CodexEnvironmentHomeOverride | undefined,
-  right: CodexEnvironmentHomeOverride | undefined
-): boolean {
-  return left?.codexHome === right?.codexHome
-}
-
-function shellStartupHomeOverridesEqual(
-  left: CodexShellStartupHomeOverride | undefined,
-  right: CodexShellStartupHomeOverride | undefined
-): boolean {
-  return (
-    left?.home === right?.home &&
-    left?.shell === right?.shell &&
-    left?.configHome === right?.configHome &&
-    left?.codexHome === right?.codexHome
-  )
+  // Why: the spawn attribution is one-shot. Retain it while the registry is
+  // unreadable, then merge it with the recovered file instead of dropping it
+  // or rebuilding from an empty stand-in.
+  mutations.record(ptyId, record)
 }
 
 /**
@@ -275,7 +229,7 @@ export function isCodexPaneHomeRouteProvenAwayFromSharedHome(
  * answers for a launch that never happened once the user edits those settings.
  */
 export function listRecordedCodexPaneLanes(ptyIds: readonly string[]): Record<string, string> {
-  const registry = readRegistry()
+  const registry = readRegistryOrThrow()
   const lanesByPtyId: Record<string, string> = {}
   for (const ptyId of ptyIds) {
     const record = registry.panes[ptyId]
@@ -284,6 +238,21 @@ export function listRecordedCodexPaneLanes(ptyIds: readonly string[]): Record<st
     }
   }
   return lanesByPtyId
+}
+
+/** Reads restart-authoritative records without mapping an unavailable file to no attribution. */
+export function listRecordedCodexPaneAccounts(
+  ptyIds: readonly string[]
+): ReadonlyMap<string, CodexPaneAccountRecord> {
+  const registry = readRegistryOrThrow()
+  const records = new Map<string, CodexPaneAccountRecord>()
+  for (const ptyId of ptyIds) {
+    const record = registry.panes[ptyId]
+    if (record) {
+      records.set(ptyId, record)
+    }
+  }
+  return records
 }
 
 /** True when a retained host pane may still read the retired shared CODEX_HOME. */
@@ -314,6 +283,7 @@ export function reconcileCodexPaneAccountsWithLivePtys(livePtyIds: readonly stri
   // Why: this deletes every pane not in the live list. Against an empty stand-in
   // it is a no-op, but the write it guards would still persist that stand-in
   // over the real file, so refuse rather than reconcile a registry nobody read.
+  mutations.flush()
   const registry = readRegistryOrNull()
   if (!registry) {
     return
@@ -326,13 +296,12 @@ export function reconcileCodexPaneAccountsWithLivePtys(livePtyIds: readonly stri
       changed = true
     }
   }
-  if (changed) {
-    writeRegistry(registry)
-  }
+  mutations.persistReconciliation(registry, changed)
 }
 
 export const _internals = {
   resetCache: (): void => {
     cachedRegistry = null
+    mutations.reset()
   }
 }

--- a/src/main/codex/codex-real-home-hook-install.test.ts
+++ b/src/main/codex/codex-real-home-hook-install.test.ts
@@ -372,6 +372,23 @@ describe('ensureRealHomeCodexHookState (install)', () => {
 })
 
 describe('ensureRealHomeCodexHookState (opt-out sweep)', () => {
+  it('keeps the managed lane when hooks.json cannot be read', () => {
+    mkdirSync(getRealHooksJsonPath())
+
+    expect(ensureRealHomeCodexHookState({ hooksEnabled: false, userDataPath: userDataDir })).toBe(
+      'unavailable'
+    )
+  })
+
+  it('keeps the managed lane when hooks.json is malformed', () => {
+    writeFileSync(getRealHooksJsonPath(), '{ not json', 'utf-8')
+
+    expect(ensureRealHomeCodexHookState({ hooksEnabled: false, userDataPath: userDataDir })).toBe(
+      'unavailable'
+    )
+    expect(readFileSync(getRealHooksJsonPath(), 'utf-8')).toBe('{ not json')
+  })
+
   it('rebases trust when a user appended hooks after Orca installed', () => {
     grantSucceeds()
     const before = { type: 'command', command: 'before.sh' }

--- a/src/main/codex/codex-real-home-hook-install.ts
+++ b/src/main/codex/codex-real-home-hook-install.ts
@@ -274,7 +274,12 @@ function sweepRealHomeCodexHook(): RealHomeCodexHookLane {
   // Why: single read — the pre-write generation guard must compare against
   // the exact bytes this sweep's parse came from.
   const { raw: previousRaw, config } = readHooksJsonWithRaw(hooksJsonPath)
-  if (!config?.hooks || previousRaw === null) {
+  if (!config) {
+    // Why: a failed or malformed read proves no cleanup; keep the managed lane
+    // until a later pass can inspect and remove the real-home entry.
+    return 'unavailable'
+  }
+  if (!config.hooks || previousRaw === null) {
     return 'removed'
   }
   const isManagedCommand = createManagedCommandMatcher(getCodexManagedScriptFileName())

--- a/src/main/codex/codex-stale-pane-accounts.ts
+++ b/src/main/codex/codex-stale-pane-accounts.ts
@@ -2,7 +2,7 @@ import type { GlobalSettings } from '../../shared/global-settings-types'
 import { getSelectedCodexAccountIdForTarget } from '../codex-accounts/runtime-selection'
 import {
   forgetCodexPaneAccount,
-  getCodexPaneAccount,
+  listRecordedCodexPaneAccounts,
   type CodexPaneHomeRoute
 } from './codex-pane-account-registry'
 
@@ -23,8 +23,9 @@ export function listStaleCodexPanes(args: {
   activeHostHomeRoute?: CodexPaneHomeRoute
 }): StaleCodexPane[] {
   const stalePanes: StaleCodexPane[] = []
+  const records = listRecordedCodexPaneAccounts(args.ptyIds)
   for (const ptyId of args.ptyIds) {
-    const record = getCodexPaneAccount(ptyId)
+    const record = records.get(ptyId)
     if (!record) {
       continue
     }

--- a/src/main/codex/codex-trust-grant-ledger.ts
+++ b/src/main/codex/codex-trust-grant-ledger.ts
@@ -1,4 +1,5 @@
-import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import { mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import { isDefinitiveAbsence } from '../../shared/definitive-filesystem-absence'
 import { dirname, join } from 'node:path'
 import { getOrcaManagedCodexHomePath } from './codex-home-paths'
 import { normalizeCodexProjectPathForLookup } from './config-toml-trust'
@@ -40,13 +41,22 @@ export function getCodexTrustGrantHomeKey(runtimeHomePath: string): string {
   return normalizeCodexProjectPathForLookup(runtimeHomePath)
 }
 
-function readLedgerFile(ledgerPath: string): CodexTrustGrantLedgerFile {
+/**
+ * `null` means the ledger could not be READ, which is different from an absent
+ * or corrupt one. A write derived from `empty` persists a file containing only
+ * the home being written, destroying every other home's grants — so the write
+ * paths refuse on `null` while the read path keeps degrading.
+ */
+function readLedgerFileOrNull(ledgerPath: string): CodexTrustGrantLedgerFile | null {
   const empty: CodexTrustGrantLedgerFile = { version: 1, homes: {} }
-  if (!existsSync(ledgerPath)) {
-    return empty
+  let rawLedger: string
+  try {
+    rawLedger = readFileSync(ledgerPath, 'utf-8')
+  } catch (error) {
+    return isDefinitiveAbsence(error) ? empty : null
   }
   try {
-    const parsed: unknown = JSON.parse(readFileSync(ledgerPath, 'utf-8'))
+    const parsed: unknown = JSON.parse(rawLedger)
     if (
       !parsed ||
       typeof parsed !== 'object' ||
@@ -65,6 +75,11 @@ function readLedgerFile(ledgerPath: string): CodexTrustGrantLedgerFile {
     // block hook install.
     return empty
   }
+}
+
+/** Corrupt or absent still degrades to empty — rebuilding those IS the intent. */
+function readLedgerFile(ledgerPath: string): CodexTrustGrantLedgerFile {
+  return readLedgerFileOrNull(ledgerPath) ?? { version: 1, homes: {} }
 }
 
 function persistLedgerFile(ledgerPath: string, file: CodexTrustGrantLedgerFile): void {
@@ -94,7 +109,13 @@ export function writeCodexTrustGrantLedgerHome(
   home: CodexTrustGrantLedgerHome,
   ledgerPath = getCodexTrustGrantLedgerPath()
 ): void {
-  const file = readLedgerFile(ledgerPath)
+  const file = readLedgerFileOrNull(ledgerPath)
+  if (!file) {
+    // Why: writing a file derived from `empty` would drop every other home's
+    // grants, and those homes would then be re-prompted for trust they had
+    // already granted. Skip this write; the next grant retries.
+    return
+  }
   file.homes[getCodexTrustGrantHomeKey(runtimeHomePath)] = home
   persistLedgerFile(ledgerPath, file)
 }

--- a/src/main/codex/config-settings-baseline.ts
+++ b/src/main/codex/config-settings-baseline.ts
@@ -1,4 +1,5 @@
 import { existsSync, writeFileSync } from 'node:fs'
+import { isDefinitiveAbsence } from '../../shared/definitive-filesystem-absence'
 import { join } from 'node:path'
 import { readAgentStateFileSync, readAgentStateJsonFileSync } from '../agent-state-file-reader'
 
@@ -20,11 +21,39 @@ type StoredSettingsBaseline = {
   conflicts?: Record<string, CodexSettingsConflict>
 }
 
-export function readCodexSettingsBaseline(runtimeHomePath: string): CodexSettingsBaseline | null {
+/**
+ * Why callers need three answers, not two: the baseline records what Orca last
+ * mirrored, so `null` drives "there is nothing to compare against, bootstrap
+ * one". For a file that merely could not be READ, bootstrapping overwrites the
+ * record of a change the user made inside Codex, and the next mirror pass then
+ * writes the old value back over their edit. Absent and unparseable still map
+ * to `absent` — rebuilding those is the intent.
+ */
+export type CodexSettingsBaselineObservation =
+  | { kind: 'present'; baseline: CodexSettingsBaseline }
+  | { kind: 'absent' }
+  | { kind: 'indeterminate' }
+
+export function observeCodexSettingsBaseline(
+  runtimeHomePath: string
+): CodexSettingsBaselineObservation {
   const baselinePath = getCodexSettingsBaselinePath(runtimeHomePath)
-  if (!existsSync(baselinePath)) {
-    return null
+  const baseline = readParsedCodexSettingsBaseline(baselinePath)
+  if (baseline === 'unreadable') {
+    return { kind: 'indeterminate' }
   }
+  return baseline ? { kind: 'present', baseline } : { kind: 'absent' }
+}
+
+/** Absent and unreadable both collapse to `null`; use the observation to tell them apart. */
+export function readCodexSettingsBaseline(runtimeHomePath: string): CodexSettingsBaseline | null {
+  const observation = observeCodexSettingsBaseline(runtimeHomePath)
+  return observation.kind === 'present' ? observation.baseline : null
+}
+
+function readParsedCodexSettingsBaseline(
+  baselinePath: string
+): CodexSettingsBaseline | null | 'unreadable' {
   try {
     const parsed: unknown = readAgentStateJsonFileSync(baselinePath)
     if (!isStoredSettingsBaseline(parsed)) {
@@ -46,9 +75,16 @@ export function readCodexSettingsBaseline(runtimeHomePath: string): CodexSetting
       }
     }
     return { settings, conflicts }
-  } catch {
-    return null
+  } catch (error) {
+    // Why: a malformed baseline is still `null` — resetting corrupt state is the
+    // intent, and only a read that FAILED must be preserved.
+    return isDefinitiveAbsence(error) || isMalformedBaselineError(error) ? null : 'unreadable'
   }
+}
+
+/** Why: `readAgentStateJsonFileSync` throws for a parse failure and for a size cap alike. */
+function isMalformedBaselineError(error: unknown): boolean {
+  return error instanceof SyntaxError
 }
 
 export function writeCodexSettingsBaseline(

--- a/src/main/codex/config-settings-baseline.ts
+++ b/src/main/codex/config-settings-baseline.ts
@@ -1,5 +1,6 @@
 import { existsSync, writeFileSync } from 'node:fs'
 import { isDefinitiveAbsence } from '../../shared/definitive-filesystem-absence'
+import { JsonTextStructureCapacityError } from '../../shared/json-text-structure-limit'
 import { join } from 'node:path'
 import { readAgentStateFileSync, readAgentStateJsonFileSync } from '../agent-state-file-reader'
 
@@ -82,9 +83,9 @@ function readParsedCodexSettingsBaseline(
   }
 }
 
-/** Why: `readAgentStateJsonFileSync` throws for a parse failure and for a size cap alike. */
+/** Why: a fully read baseline that exceeds JSON structure limits is corrupt state, not a failed read. */
 function isMalformedBaselineError(error: unknown): boolean {
-  return error instanceof SyntaxError
+  return error instanceof SyntaxError || error instanceof JsonTextStructureCapacityError
 }
 
 export function writeCodexSettingsBaseline(

--- a/src/main/codex/config-settings-baseline.ts
+++ b/src/main/codex/config-settings-baseline.ts
@@ -1,6 +1,7 @@
-import { existsSync, writeFileSync } from 'node:fs'
+import { writeFileSync } from 'node:fs'
 import { isDefinitiveAbsence } from '../../shared/definitive-filesystem-absence'
 import { JsonTextStructureCapacityError } from '../../shared/json-text-structure-limit'
+import { NodeFileReadTooLargeError } from '../../shared/node-bounded-file-reader'
 import { join } from 'node:path'
 import { readAgentStateFileSync, readAgentStateJsonFileSync } from '../agent-state-file-reader'
 
@@ -77,15 +78,19 @@ function readParsedCodexSettingsBaseline(
     }
     return { settings, conflicts }
   } catch (error) {
-    // Why: a malformed baseline is still `null` — resetting corrupt state is the
-    // intent, and only a read that FAILED must be preserved.
-    return isDefinitiveAbsence(error) || isMalformedBaselineError(error) ? null : 'unreadable'
+    // Why: invalid baseline state is still `null` — resetting it is the intent,
+    // and only a read that FAILED must be preserved.
+    return isDefinitiveAbsence(error) || isRebuildableBaselineError(error) ? null : 'unreadable'
   }
 }
 
-/** Why: a fully read baseline that exceeds JSON structure limits is corrupt state, not a failed read. */
-function isMalformedBaselineError(error: unknown): boolean {
-  return error instanceof SyntaxError || error instanceof JsonTextStructureCapacityError
+/** Why: known-present baseline state outside its parse/capacity contract is rebuildable, not unreadable. */
+function isRebuildableBaselineError(error: unknown): boolean {
+  return (
+    error instanceof SyntaxError ||
+    error instanceof JsonTextStructureCapacityError ||
+    error instanceof NodeFileReadTooLargeError
+  )
 }
 
 export function writeCodexSettingsBaseline(
@@ -101,8 +106,17 @@ export function writeCodexSettingsBaseline(
   }
   const baselinePath = getCodexSettingsBaselinePath(runtimeHomePath)
   const serialized = `${JSON.stringify(file, null, 2)}\n`
+  let existing: string | null = null
+  try {
+    existing = readAgentStateFileSync(baselinePath)
+  } catch (error) {
+    // Why: only absence or known-invalid derived state may authorize replacement.
+    if (!isDefinitiveAbsence(error) && !isRebuildableBaselineError(error)) {
+      throw error
+    }
+  }
   // Why: launch prep runs repeatedly; byte-identical baselines should not churn disk metadata.
-  if (existsSync(baselinePath) && readAgentStateFileSync(baselinePath) === serialized) {
+  if (existing === serialized) {
     return
   }
   writeFileSync(baselinePath, serialized, { encoding: 'utf-8', mode: 0o600 })

--- a/src/main/codex/config-settings-baseline.ts
+++ b/src/main/codex/config-settings-baseline.ts
@@ -24,12 +24,10 @@ type StoredSettingsBaseline = {
 }
 
 /**
- * Why callers need three answers, not two: the baseline records what Orca last
- * mirrored, so `null` drives "there is nothing to compare against, bootstrap
- * one". For a file that merely could not be READ, bootstrapping overwrites the
- * record of a change the user made inside Codex, and the next mirror pass then
- * writes the old value back over their edit. Absent and unparseable still map
- * to `absent` — rebuilding those is the intent.
+ * Why callers need three answers, not two: without a readable baseline,
+ * promotion cannot distinguish an in-Codex edit from Orca's last mirror. An
+ * unreadable baseline must stall that mirror; absent and unparseable still map
+ * to `absent` because rebuilding those is the intent.
  */
 export type CodexSettingsBaselineObservation =
   | { kind: 'present'; baseline: CodexSettingsBaseline }

--- a/src/main/codex/config-settings-baseline.ts
+++ b/src/main/codex/config-settings-baseline.ts
@@ -120,7 +120,7 @@ export function writeCodexSettingsBaseline(
   writeFileSync(baselinePath, serialized, { encoding: 'utf-8', mode: 0o600 })
 }
 
-function getCodexSettingsBaselinePath(runtimeHomePath: string): string {
+export function getCodexSettingsBaselinePath(runtimeHomePath: string): string {
   return join(runtimeHomePath, SETTINGS_BASELINE_FILE)
 }
 

--- a/src/main/codex/config-settings-promotion.ts
+++ b/src/main/codex/config-settings-promotion.ts
@@ -14,7 +14,7 @@ import {
 import { parseTomlKeyPath, parseTomlTableHeaderPath } from './config-toml-key-path'
 import { tuiStructuredKey, upsertPromotedSettingsInContent } from './codex-config-settings-upsert'
 import {
-  readCodexSettingsBaseline,
+  observeCodexSettingsBaseline,
   writeCodexSettingsBaseline,
   type CodexSettingsBaseline,
   type CodexSettingsConflict
@@ -163,6 +163,13 @@ export function snapshotCodexRuntimeSettingsBaseline(
   runtimeHomePath = getOrcaManagedCodexHomePath(),
   conflicts: ReadonlyMap<string, CodexSettingsConflict> = new Map()
 ): void {
+  // Why: overwriting a baseline that could not be read records whatever the
+  // runtime config says now as "Orca wrote this", so an edit the user made
+  // inside Codex since the last pass is reclassified and never promoted again.
+  // Absent and malformed are still rebuilt — that is what this function is for.
+  if (observeCodexSettingsBaseline(runtimeHomePath).kind === 'indeterminate') {
+    return
+  }
   try {
     const runtimeTomlPath = join(runtimeHomePath, 'config.toml')
     // Why: record an empty baseline even for a missing runtime config, so Codex's first write still diffs and promotes.
@@ -235,10 +242,17 @@ function promoteCodexRuntimeSettingsToSystemUnsafe(
     throw runtimeTomlObservation.error
   }
   // Why: without a baseline, a stale runtime value looks like a fresh in-Codex change; skip until the mirror writes one.
-  const baseline = readCodexSettingsBaseline(runtimeHomePath)
-  if (!baseline) {
+  const baselineObservation = observeCodexSettingsBaseline(runtimeHomePath)
+  if (baselineObservation.kind === 'indeterminate') {
+    // Why: an empty plan here lets the mirror proceed and write the system value
+    // back over an in-Codex edit this baseline would have identified. The caller
+    // turns a throw into the existing stall-and-retry null.
+    throw new Error('Codex settings baseline could not be read')
+  }
+  if (baselineObservation.kind === 'absent') {
     return emptyPromotionPlan()
   }
+  const baseline = baselineObservation.baseline
   const runtimeValues = readPromotedSettingValues(runtimeTomlPath)
   const systemValues = readPromotedSettingValues(systemTomlPath)
   const updates = new Map<string, string>()

--- a/src/main/codex/config-settings-promotion.ts
+++ b/src/main/codex/config-settings-promotion.ts
@@ -163,13 +163,6 @@ export function snapshotCodexRuntimeSettingsBaseline(
   runtimeHomePath = getOrcaManagedCodexHomePath(),
   conflicts: ReadonlyMap<string, CodexSettingsConflict> = new Map()
 ): void {
-  // Why: overwriting a baseline that could not be read records whatever the
-  // runtime config says now as "Orca wrote this", so an edit the user made
-  // inside Codex since the last pass is reclassified and never promoted again.
-  // Absent and malformed are still rebuilt — that is what this function is for.
-  if (observeCodexSettingsBaseline(runtimeHomePath).kind === 'indeterminate') {
-    return
-  }
   try {
     const runtimeTomlPath = join(runtimeHomePath, 'config.toml')
     // Why: record an empty baseline even for a missing runtime config, so Codex's first write still diffs and promotes.
@@ -274,10 +267,10 @@ function promoteCodexRuntimeSettingsToSystemUnsafe(
   const writeTarget = resolvePromotionWriteTarget(systemTomlPath)
   // Why: a dangling symlink may target an unmade dir tree; create its real parent so the atomic temp write has a home.
   mkdirSync(dirname(writeTarget.path), { recursive: true, mode: 0o700 })
-  // Why: this is the user's real ~/.codex/config.toml, and `existsSync` reading
-  // `false` for a locked file sent it down the reconstruct branch below, which
-  // replaces the canonical config with settings derived from Orca's runtime
-  // copy. One read replaces the old existsSync + read pair and its TOCTOU gap.
+  // Why: this is the user's real ~/.codex/config.toml, and an indeterminate
+  // existence probe sent it down the reconstruct branch below, which replaces
+  // the canonical config with settings derived from Orca's runtime copy. One
+  // read replaces the old existsSync + read pair and its TOCTOU gap.
   // The indeterminate arm is a backstop rather than the live guard: an
   // unreadable system config already refused in readPromotedSettingValues,
   // because `writeTarget.path` always resolves to the same file as

--- a/src/main/codex/config-sync-stall.test.ts
+++ b/src/main/codex/config-sync-stall.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
   getCodexConfigSyncStatus,
+  reportCodexConfigSyncOutcome,
   resetCodexConfigSyncStallLatchForTests
 } from './config-sync-stall'
 import { syncSystemConfigIntoManagedCodexHome } from './codex-config-mirror'
@@ -161,6 +162,19 @@ describe('reportCodexConfigSyncOutcome', () => {
     const stallLogs = warn.mock.calls.filter((call) => String(call[0]).includes('stalled'))
     expect(stallLogs).toHaveLength(1)
     expect(String(stallLogs[0]?.[0])).toContain('unreadable-source')
+  })
+
+  it('names the managed config when that is the unreadable file', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    writeFileSync(systemConfigPath(), 'model = "gpt-5"\n', 'utf-8')
+    mkdirSync(runtimeConfigPath())
+
+    reportCodexConfigSyncOutcome(homes.runtimeHomePath, getCodexConfigSyncStatus(homes))
+
+    const message = String(warn.mock.calls[0]?.[0])
+    expect(message).toContain(runtimeConfigPath())
+    expect(message).not.toContain(systemConfigPath())
+    expect(message).toContain('The managed config must be readable before settings can sync.')
   })
 
   it('clears a stall without claiming the source became readable', () => {

--- a/src/main/codex/config-sync-stall.test.ts
+++ b/src/main/codex/config-sync-stall.test.ts
@@ -8,6 +8,7 @@ import {
   resetCodexConfigSyncStallLatchForTests
 } from './config-sync-stall'
 import { syncSystemConfigIntoManagedCodexHome } from './codex-config-mirror'
+import { getCodexSettingsBaselinePath } from './config-settings-baseline'
 
 let root: string
 let homes: { runtimeHomePath: string; systemHomePath: string }
@@ -67,6 +68,20 @@ describe('getCodexConfigSyncStatus', () => {
     writeFileSync(runtimeConfigPath(), 'model = "runtime-model"\n', 'utf-8')
 
     expect(getCodexConfigSyncStatus(homes).reason).toBe('unreadable-source')
+  })
+
+  it('reports a stall when the settings baseline cannot be read', () => {
+    writeFileSync(systemConfigPath(), 'model = "gpt-5"\n', 'utf-8')
+    writeFileSync(runtimeConfigPath(), 'model = "gpt-5"\n', 'utf-8')
+    const baselinePath = getCodexSettingsBaselinePath(homes.runtimeHomePath)
+    mkdirSync(baselinePath)
+
+    expect(getCodexConfigSyncStatus(homes)).toEqual({
+      state: 'stalled',
+      reason: 'managed-home-unavailable',
+      systemConfigPath: systemConfigPath(),
+      managedStatePath: baselinePath
+    })
   })
 
   it('stays synced before the runtime config exists, since nothing can fall behind yet', () => {
@@ -174,7 +189,7 @@ describe('reportCodexConfigSyncOutcome', () => {
     const message = String(warn.mock.calls[0]?.[0])
     expect(message).toContain(runtimeConfigPath())
     expect(message).not.toContain(systemConfigPath())
-    expect(message).toContain('The managed config must be readable before settings can sync.')
+    expect(message).toContain('The managed state must be readable before settings can sync.')
   })
 
   it('clears a stall without claiming the source became readable', () => {

--- a/src/main/codex/config-sync-stall.ts
+++ b/src/main/codex/config-sync-stall.ts
@@ -1,6 +1,5 @@
-import { existsSync } from 'node:fs'
 import { join } from 'node:path'
-import { readAgentStateFileSync } from '../agent-state-file-reader'
+import { observeAgentStateFile, observeResolvedPathEntry } from './codex-path-observation'
 import { getOrcaManagedCodexHomePath, getSystemCodexHomePath } from './codex-home-paths'
 import type { CodexSettingsPromotionHomes } from './config-settings-promotion'
 import type {
@@ -28,20 +27,28 @@ export function getCodexConfigSyncStatus(
   const runtimeConfigPath = join(homes.runtimeHomePath, 'config.toml')
   // Why: a stall only withholds settings once a managed runtime config exists;
   // without one the mirror seeds it and there is nothing yet to fall behind.
-  if (!existsSync(runtimeConfigPath)) {
+  // But `existsSync` said "no runtime config" for one that was merely locked,
+  // and this function then reported `synced` while the mirror was refusing —
+  // telling the user their edits had been applied when nothing had run.
+  const runtimeConfigObservation = observeResolvedPathEntry(runtimeConfigPath)
+  if (runtimeConfigObservation.kind === 'absent') {
     return { state: 'synced', reason: null, systemConfigPath }
   }
-  if (!existsSync(systemConfigPath)) {
+  if (runtimeConfigObservation.kind === 'indeterminate') {
+    // Why: the managed home is what could not be read, so say that rather than
+    // borrowing a source-side reason and blaming the wrong path.
+    return { state: 'stalled', reason: 'managed-home-unavailable', systemConfigPath }
+  }
+  const systemConfigObservation = observeAgentStateFile(systemConfigPath)
+  if (systemConfigObservation.kind === 'absent') {
     return { state: 'stalled', reason: 'missing-source', systemConfigPath }
   }
-  let rawSystemConfig: string
-  try {
-    rawSystemConfig = readAgentStateFileSync(systemConfigPath)
-  } catch {
+  if (systemConfigObservation.kind === 'indeterminate') {
     // Why: the mirror aborts on an unreadable source too, so report the stall
     // rather than claiming a sync that cannot happen.
     return { state: 'stalled', reason: 'unreadable-source', systemConfigPath }
   }
+  const rawSystemConfig = systemConfigObservation.value
   if (rawSystemConfig.trim() === '') {
     return { state: 'stalled', reason: 'blank-source', systemConfigPath }
   }

--- a/src/main/codex/config-sync-stall.ts
+++ b/src/main/codex/config-sync-stall.ts
@@ -94,6 +94,12 @@ export function reportCodexConfigSyncOutcome(
     return
   }
   stalledHomes.set(runtimeHomePath, status.reason)
+  if (status.reason === 'managed-home-unavailable') {
+    console.warn(
+      `[codex-config] Config sync stalled (${status.reason}): ${join(runtimeHomePath, 'config.toml')} is unusable, so ${runtimeHomePath} keeps its last synced settings. The managed config must be readable before settings can sync.`
+    )
+    return
+  }
   console.warn(
     `[codex-config] Config sync stalled (${status.reason}): ${status.systemConfigPath} is unusable, so ${runtimeHomePath} keeps its last synced settings. Edits to the source will not apply until it is readable.`
   )

--- a/src/main/codex/config-sync-stall.ts
+++ b/src/main/codex/config-sync-stall.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path'
-import { observeAgentStateFile, observeResolvedPathEntry } from './codex-path-observation'
+import { observeAgentStateFile } from './codex-path-observation'
 import { getOrcaManagedCodexHomePath, getSystemCodexHomePath } from './codex-home-paths'
 import type { CodexSettingsPromotionHomes } from './config-settings-promotion'
 import type {
@@ -30,7 +30,7 @@ export function getCodexConfigSyncStatus(
   // But `existsSync` said "no runtime config" for one that was merely locked,
   // and this function then reported `synced` while the mirror was refusing —
   // telling the user their edits had been applied when nothing had run.
-  const runtimeConfigObservation = observeResolvedPathEntry(runtimeConfigPath)
+  const runtimeConfigObservation = observeAgentStateFile(runtimeConfigPath)
   if (runtimeConfigObservation.kind === 'absent') {
     return { state: 'synced', reason: null, systemConfigPath }
   }

--- a/src/main/codex/config-sync-stall.ts
+++ b/src/main/codex/config-sync-stall.ts
@@ -1,6 +1,10 @@
 import { join } from 'node:path'
 import { observeAgentStateFile } from './codex-path-observation'
 import { getOrcaManagedCodexHomePath, getSystemCodexHomePath } from './codex-home-paths'
+import {
+  getCodexSettingsBaselinePath,
+  observeCodexSettingsBaseline
+} from './config-settings-baseline'
 import type { CodexSettingsPromotionHomes } from './config-settings-promotion'
 import type {
   CodexConfigSyncStallReason,
@@ -37,7 +41,21 @@ export function getCodexConfigSyncStatus(
   if (runtimeConfigObservation.kind === 'indeterminate') {
     // Why: the managed home is what could not be read, so say that rather than
     // borrowing a source-side reason and blaming the wrong path.
-    return { state: 'stalled', reason: 'managed-home-unavailable', systemConfigPath }
+    return {
+      state: 'stalled',
+      reason: 'managed-home-unavailable',
+      systemConfigPath,
+      managedStatePath: runtimeConfigPath
+    }
+  }
+  const baselineObservation = observeCodexSettingsBaseline(homes.runtimeHomePath)
+  if (baselineObservation.kind === 'indeterminate') {
+    return {
+      state: 'stalled',
+      reason: 'managed-home-unavailable',
+      systemConfigPath,
+      managedStatePath: getCodexSettingsBaselinePath(homes.runtimeHomePath)
+    }
   }
   const systemConfigObservation = observeAgentStateFile(systemConfigPath)
   if (systemConfigObservation.kind === 'absent') {
@@ -95,8 +113,9 @@ export function reportCodexConfigSyncOutcome(
   }
   stalledHomes.set(runtimeHomePath, status.reason)
   if (status.reason === 'managed-home-unavailable') {
+    const managedStatePath = status.managedStatePath ?? join(runtimeHomePath, 'config.toml')
     console.warn(
-      `[codex-config] Config sync stalled (${status.reason}): ${join(runtimeHomePath, 'config.toml')} is unusable, so ${runtimeHomePath} keeps its last synced settings. The managed config must be readable before settings can sync.`
+      `[codex-config] Config sync stalled (${status.reason}): ${managedStatePath} is unusable, so ${runtimeHomePath} keeps its last synced settings. The managed state must be readable before settings can sync.`
     )
     return
   }

--- a/src/main/codex/config-sync-stall.ts
+++ b/src/main/codex/config-sync-stall.ts
@@ -27,9 +27,9 @@ export function getCodexConfigSyncStatus(
   const runtimeConfigPath = join(homes.runtimeHomePath, 'config.toml')
   // Why: a stall only withholds settings once a managed runtime config exists;
   // without one the mirror seeds it and there is nothing yet to fall behind.
-  // But `existsSync` said "no runtime config" for one that was merely locked,
-  // and this function then reported `synced` while the mirror was refusing —
-  // telling the user their edits had been applied when nothing had run.
+  // But `existsSync` never proved the config readable, so this function could
+  // report `synced` while the mirror refused its content read — telling the
+  // user their edits had been applied when nothing had run.
   const runtimeConfigObservation = observeAgentStateFile(runtimeConfigPath)
   if (runtimeConfigObservation.kind === 'absent') {
     return { state: 'synced', reason: null, systemConfigPath }

--- a/src/main/codex/config-toml-trust.ts
+++ b/src/main/codex/config-toml-trust.ts
@@ -383,7 +383,11 @@ export function upsertProjectTrustLevel(
   projectPath: string,
   trustLevel: CodexProjectTrustLevel
 ): void {
-  const existing = existsSync(configPath) ? readTomlFile(configPath) : ''
+  const observation = observe(() => readTomlFile(configPath))
+  if (observation.kind === 'indeterminate') {
+    throw observation.error
+  }
+  const existing = observation.kind === 'present' ? observation.value : ''
   const updated = upsertProjectTrustLevelInContent(existing, projectPath, trustLevel)
   if (updated === existing) {
     return

--- a/src/main/codex/config-toml-trust.ts
+++ b/src/main/codex/config-toml-trust.ts
@@ -12,6 +12,7 @@ import {
 import { basename, dirname, join, posix as pathPosix, win32 as pathWin32 } from 'node:path'
 import { createHash, randomUUID } from 'node:crypto'
 import { renameFileWithWindowsRetry } from '../codex-accounts/fs-utils'
+import { observe } from './codex-path-observation'
 import { foldWslUncPathCaseInsensitiveParts } from '../../shared/wsl-paths'
 import { writeRollingFileBackup } from '../rolling-file-backup'
 import {
@@ -337,7 +338,17 @@ export function upsertHookTrustEntries(
   configPath: string,
   entries: readonly CodexTrustEntry[]
 ): void {
-  const existing = existsSync(configPath) ? readTomlFile(configPath) : ''
+  // Why: `existsSync` answered `false` for a locked config exactly as for an
+  // absent one, so `existing` became '' and the upsert below rebuilt the file
+  // from the trust entries alone — replacing the user's model, provider, MCP
+  // servers, approvals and comments with a trust-only stub. Only a definitive
+  // absence may seed from empty; every caller in hook-service already turns a
+  // throw here into "trust entries could not be written. Run /hooks in Codex".
+  const observation = observe(() => readTomlFile(configPath))
+  if (observation.kind === 'indeterminate') {
+    throw observation.error
+  }
+  const existing = observation.kind === 'present' ? observation.value : ''
   const updated = upsertHookTrustEntriesInContent(existing, entries)
   if (updated === existing) {
     return

--- a/src/main/codex/config-toml-trust.ts
+++ b/src/main/codex/config-toml-trust.ts
@@ -338,12 +338,10 @@ export function upsertHookTrustEntries(
   configPath: string,
   entries: readonly CodexTrustEntry[]
 ): void {
-  // Why: `existsSync` answered `false` for a locked config exactly as for an
-  // absent one, so `existing` became '' and the upsert below rebuilt the file
-  // from the trust entries alone — replacing the user's model, provider, MCP
-  // servers, approvals and comments with a trust-only stub. Only a definitive
-  // absence may seed from empty; every caller in hook-service already turns a
-  // throw here into "trust entries could not be written. Run /hooks in Codex".
+  // Why: `existsSync` collapses an indeterminate probe into the same `false` as
+  // absence. If the path recovers before the write, rebuilding from '' replaces
+  // the user's model, provider, MCP servers, approvals and comments with a
+  // trust-only stub. Only a definitive absence may seed from empty.
   const observation = observe(() => readTomlFile(configPath))
   if (observation.kind === 'indeterminate') {
     throw observation.error

--- a/src/main/codex/hook-service-user-hook-mirroring.test.ts
+++ b/src/main/codex/hook-service-user-hook-mirroring.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import type * as Os from 'node:os'
 import { join } from 'node:path'
 import { upsertHookTrustEntriesInContent } from './config-toml-trust'
@@ -32,6 +32,36 @@ import { CodexHookService } from './hook-service'
 
 const homes = setupCodexHookHomes(homedirMock, getPathMock)
 
+function seedSystemUserHook(command: string): {
+  systemHooksPath: string
+  managedHooksPath: string
+} {
+  const systemCodexHome = join(homes.tmpHome, '.codex')
+  const systemHooksPath = join(systemCodexHome, 'hooks.json')
+  mkdirSync(systemCodexHome, { recursive: true })
+  writeFileSync(
+    systemHooksPath,
+    `${JSON.stringify({ hooks: { Stop: [{ hooks: [{ type: 'command', command }] }] } })}\n`,
+    'utf-8'
+  )
+  writeFileSync(join(systemCodexHome, 'config.toml'), 'model = "system-model"\n', 'utf-8')
+  return {
+    systemHooksPath,
+    managedHooksPath: join(homes.userDataDir, 'codex-runtime-home', 'home', 'hooks.json')
+  }
+}
+
+function readRuntimeHookCommands(managedHooksPath: string): string[] {
+  const runtime = JSON.parse(readFileSync(managedHooksPath, 'utf-8')) as {
+    hooks: Record<string, { hooks?: { command?: string }[] }[]>
+  }
+  return Object.values(runtime.hooks).flatMap((definitions) =>
+    definitions.flatMap(
+      (definition) => definition.hooks?.flatMap((hook) => hook.command ?? []) ?? []
+    )
+  )
+}
+
 function markHookTrustDisabled(toml: string, header: string): string {
   const headerIndex = toml.indexOf(header)
   expect(headerIndex).not.toBe(-1)
@@ -43,6 +73,48 @@ function markHookTrustDisabled(toml: string, header: string): string {
 }
 
 describe('CodexHookService', () => {
+  it('preserves mirrored user hooks when the system hooks file cannot be read', () => {
+    const service = new CodexHookService()
+    const { systemHooksPath, managedHooksPath } = seedSystemUserHook('user-hook')
+    expect(service.install().state).toBe('installed')
+    const systemBefore = readFileSync(systemHooksPath, 'utf-8')
+    const before = readFileSync(managedHooksPath, 'utf-8')
+
+    rmSync(systemHooksPath)
+    mkdirSync(systemHooksPath)
+
+    for (const retry of [() => service.install(), () => service.refreshRuntimeUserHooks()]) {
+      expect(retry()).toMatchObject({
+        state: 'error',
+        detail: 'Could not read system Codex hooks.json'
+      })
+      expect(readFileSync(managedHooksPath, 'utf-8')).toBe(before)
+    }
+
+    rmSync(systemHooksPath, { recursive: true })
+    writeFileSync(systemHooksPath, systemBefore, 'utf-8')
+    expect(service.install().state).toBe('installed')
+    expect(readRuntimeHookCommands(managedHooksPath)).toContain('user-hook')
+  })
+
+  it.each(['absent', 'malformed'] as const)(
+    'rebuilds mirrored user hooks when the system source is %s',
+    (sourceState) => {
+      const service = new CodexHookService()
+      const { systemHooksPath, managedHooksPath } = seedSystemUserHook('stale-user-hook')
+      expect(service.install().state).toBe('installed')
+
+      if (sourceState === 'absent') {
+        rmSync(systemHooksPath)
+      } else {
+        writeFileSync(systemHooksPath, '{ not json', 'utf-8')
+      }
+
+      expect(service.install().state).toBe('installed')
+      expect(readRuntimeHookCommands(managedHooksPath)).not.toContain('stale-user-hook')
+    }
+  )
+
   it('mirrors trusted system user hook approvals into the runtime CODEX_HOME', () => {
     const systemCodexHome = join(homes.tmpHome, '.codex')
     const systemHooksPath = join(systemCodexHome, 'hooks.json')

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -299,13 +299,18 @@ function getRuntimeHooksWithSystemUserHooks(
 ): {
   hooks: Record<string, HookDefinition[]>
   trustEntries: MirroredRuntimeUserHookTrustEntry[]
-} {
+} | null {
   const systemConfigPath = getSystemConfigPath()
   if (systemConfigPath === runtimeConfigPath) {
     return { hooks: { ...runtimeHooks }, trustEntries: [] }
   }
 
-  const systemConfig = readHooksJson(systemConfigPath)
+  const { raw: systemRaw, config: systemConfig } = readHooksJsonWithRaw(systemConfigPath)
+  if (!systemConfig && systemRaw === null) {
+    // Why: rebuilding from an unreadable source drops the last-known user hooks
+    // from the managed runtime; let launch prep retry without changing it.
+    return null
+  }
   if (!systemConfig?.hooks) {
     return { hooks: {}, trustEntries: [] }
   }
@@ -1284,6 +1289,15 @@ export class CodexHookService {
     const isManagedCommand = createManagedCommandMatcher(getCodexManagedScriptFileName())
     const command = getManagedCommand(scriptPath)
     const hookPlan = getRuntimeHooksWithSystemUserHooks(config.hooks, isManagedCommand, configPath)
+    if (!hookPlan) {
+      return {
+        agent: 'codex',
+        state: 'error',
+        configPath,
+        managedHooksPresent: false,
+        detail: 'Could not read system Codex hooks.json'
+      }
+    }
     const nextHooks = hookPlan.hooks
     const managedEvents = new Set<string>(CODEX_EVENTS)
 
@@ -1534,6 +1548,15 @@ export class CodexHookService {
 
     const isManagedCommand = createManagedCommandMatcher(getCodexManagedScriptFileName())
     const hookPlan = getRuntimeHooksWithSystemUserHooks(config.hooks, isManagedCommand, configPath)
+    if (!hookPlan) {
+      return {
+        agent: 'codex',
+        state: 'error',
+        configPath,
+        managedHooksPresent: false,
+        detail: 'Could not read system Codex hooks.json'
+      }
+    }
     config.hooks = hookPlan.hooks
     writeCodexHooksJson(configPath, hookPlan.hooks)
 

--- a/src/main/codex/sta-4823-shared-state-survives-a-failed-read.test.ts
+++ b/src/main/codex/sta-4823-shared-state-survives-a-failed-read.test.ts
@@ -3,6 +3,7 @@ import type * as NodeFs from 'node:fs'
 import type * as NodeOs from 'node:os'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import type { CodexTrustEntry } from './config-toml-trust'
 
 // STA-4823: six shared Codex state files were rebuilt, erased or reported as
 // healthy after a read that had merely failed. Every one is reachable on the
@@ -124,7 +125,8 @@ vi.mock('node:os', async () => {
 
 const realFs = await vi.importActual<typeof NodeFs>('node:fs')
 
-const { upsertHookTrustEntries, readHookTrustEntries } = await import('./config-toml-trust')
+const { upsertHookTrustEntries, upsertProjectTrustLevel, readHookTrustEntries } =
+  await import('./config-toml-trust')
 const {
   writeCodexTrustGrantLedgerHome,
   readCodexTrustGrantLedgerHome,
@@ -190,11 +192,12 @@ describe('STA-4823 D29 — an unreadable config.toml must not become a trust-onl
       sourcePath: '/tmp/hooks.json',
       eventLabel: 'stop',
       groupIndex: 0,
-      hookIndex: 0,
+      handlerIndex: 0,
+      command: 'orca hook',
       trustedHash: 'sha256:x',
       enabled: true
     }
-  ]
+  ] satisfies readonly CodexTrustEntry[]
 
   it('refuses the write rather than rebuilding the file from the trust entries alone', () => {
     const configPath = join(runtimeHomePath, 'config.toml')
@@ -203,7 +206,7 @@ describe('STA-4823 D29 — an unreadable config.toml must not become a trust-onl
 
     // Every hook-service caller already turns this throw into "trust entries
     // could not be written. Run /hooks in Codex to approve."
-    expect(() => upsertHookTrustEntries(configPath, ENTRY as never)).toThrow('EPERM')
+    expect(() => upsertHookTrustEntries(configPath, ENTRY)).toThrow('EPERM')
 
     // Before the fix, existsSync said the file was gone, `existing` became '',
     // and the upsert wrote a config containing ONLY the trust table — the
@@ -216,9 +219,26 @@ describe('STA-4823 D29 — an unreadable config.toml must not become a trust-onl
 
     // Why: seeding from empty is correct for a genuine absence, and is how a
     // fresh managed home gets its trust entries at all.
-    upsertHookTrustEntries(configPath, ENTRY as never)
+    upsertHookTrustEntries(configPath, ENTRY)
 
     expect(readHookTrustEntries(configPath).size).toBeGreaterThan(0)
+  })
+
+  it('also refuses a project-trust write when the existing config cannot be read', () => {
+    const configPath = join(runtimeHomePath, 'config.toml')
+    realFs.writeFileSync(configPath, USER_CONFIG, 'utf-8')
+    denials.denyExistence(configPath)
+
+    expect(() => upsertProjectTrustLevel(configPath, '/tmp/project', 'trusted')).toThrow('EPERM')
+    expect(realFs.readFileSync(configPath, 'utf-8')).toBe(USER_CONFIG)
+  })
+
+  it('still seeds project trust when config.toml is genuinely absent', () => {
+    const configPath = join(runtimeHomePath, 'config.toml')
+
+    upsertProjectTrustLevel(configPath, '/tmp/project', 'trusted')
+
+    expect(realFs.readFileSync(configPath, 'utf-8')).toContain('trust_level = "trusted"')
   })
 })
 
@@ -327,6 +347,15 @@ describe('STA-4823 D26 — an unreadable settings baseline must not be overwritt
     // anchor still means something when the fix is reverted.
     expect(JSON.parse(realFs.readFileSync(baselinePath(), 'utf-8'))).toMatchObject({ version: 2 })
   })
+
+  it('still replaces a fully-read baseline rejected by the JSON structure limit', () => {
+    realFs.writeFileSync(baselinePath(), '['.repeat(129), 'utf-8')
+    realFs.writeFileSync(join(runtimeHomePath, 'config.toml'), 'model = "m"\n', 'utf-8')
+
+    snapshotCodexRuntimeSettingsBaseline(runtimeHomePath)
+
+    expect(JSON.parse(realFs.readFileSync(baselinePath(), 'utf-8'))).toMatchObject({ version: 2 })
+  })
 })
 
 describe('STA-4823 D15 — the sync status must not report synced while the mirror refuses', () => {
@@ -342,6 +371,17 @@ describe('STA-4823 D15 — the sync status must not report synced while the mirr
     // and this returned `synced` — telling the user their edits had been
     // applied while nothing had run.
     expect(status).toMatchObject({ state: 'stalled', reason: 'managed-home-unavailable' })
+  })
+
+  it('reports the managed home as unavailable when only its content read is denied', () => {
+    const runtimeConfigPath = join(runtimeHomePath, 'config.toml')
+    realFs.writeFileSync(runtimeConfigPath, 'model = "m"\n', 'utf-8')
+    realFs.writeFileSync(join(systemHome(), 'config.toml'), 'model = "s"\n', 'utf-8')
+    denials.denyReads(runtimeConfigPath)
+
+    expect(
+      getCodexConfigSyncStatus({ runtimeHomePath, systemHomePath: systemHome() })
+    ).toMatchObject({ state: 'stalled', reason: 'managed-home-unavailable' })
   })
 
   it('still reports synced when no runtime config exists yet', () => {

--- a/src/main/codex/sta-4823-shared-state-survives-a-failed-read.test.ts
+++ b/src/main/codex/sta-4823-shared-state-survives-a-failed-read.test.ts
@@ -26,12 +26,20 @@ const denials = vi.hoisted(() => {
       state.readOnlyPaths.add(path)
     },
     /**
-     * `existsSync` reports false and content reads throw, but `statSync` and the
-     * atomic replace still work. This is the shape that actually loses data: the
-     * caller concludes "no file here", builds fresh content, and the rename
-     * lands because rename needs permission on the DIRECTORY, not the target.
-     * Guarding the write as well would let a test pass because the write failed
-     * rather than because the fix refused.
+     * `existsSync` reports false while the path is still there, and the write
+     * still lands.
+     *
+     * MEASURED, and not what I first assumed: a file-permission denial does NOT
+     * produce this. `chmod 000` on macOS and `icacls /deny (R)` on Windows both
+     * leave `existsSync` TRUE, leave `stat`/`lstat` succeeding, and fail only
+     * the content read (EACCES / EPERM errno -4048). The shape modelled here is
+     * the UNC / `\\wsl$` transport, where an unreachable distro reports errno
+     * `UNKNOWN` at every level and `existsSync` folds that to false.
+     *
+     * The distinction decides what the guard is worth: under a permission denial
+     * the pre-fix code already failed safe, because `existsSync` was true so it
+     * took the read branch and threw. Only a transport that lies about existence
+     * reaches the rebuild-from-empty path.
      */
     denyExistence(path: string): void {
       state.existenceDeniedPaths.add(path)

--- a/src/main/codex/sta-4823-shared-state-survives-a-failed-read.test.ts
+++ b/src/main/codex/sta-4823-shared-state-survives-a-failed-read.test.ts
@@ -1,0 +1,412 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as NodeFs from 'node:fs'
+import type * as NodeOs from 'node:os'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// STA-4823: six shared Codex state files were rebuilt, erased or reported as
+// healthy after a read that had merely failed. Every one is reachable on the
+// host lane; the WSL-specific half of the catalogue stays in STA-4606.
+
+const denials = vi.hoisted(() => {
+  const state = {
+    paths: new Set<string>(),
+    readOnlyPaths: new Set<string>(),
+    existenceDeniedPaths: new Set<string>(),
+    deny(path: string): void {
+      state.paths.add(path)
+    },
+    /**
+     * Content reads fail but `existsSync` still says the file is there — the
+     * shape a Windows sharing violation takes, as distinct from `deny`, which
+     * models an ACL denial where `existsSync` itself reports false.
+     */
+    denyReads(path: string): void {
+      state.readOnlyPaths.add(path)
+    },
+    /**
+     * `existsSync` reports false and content reads throw, but `statSync` and the
+     * atomic replace still work. This is the shape that actually loses data: the
+     * caller concludes "no file here", builds fresh content, and the rename
+     * lands because rename needs permission on the DIRECTORY, not the target.
+     * Guarding the write as well would let a test pass because the write failed
+     * rather than because the fix refused.
+     */
+    denyExistence(path: string): void {
+      state.existenceDeniedPaths.add(path)
+    },
+    release(path: string): void {
+      state.paths.delete(path)
+    },
+    reset(): void {
+      state.paths.clear()
+      state.readOnlyPaths.clear()
+      state.existenceDeniedPaths.clear()
+    },
+    check(target: unknown, syscall: string, readOnly = false): void {
+      if (typeof target !== 'string') {
+        return
+      }
+      const readDenied =
+        readOnly && (state.readOnlyPaths.has(target) || state.existenceDeniedPaths.has(target))
+      if (!state.paths.has(target) && !readDenied) {
+        return
+      }
+      const error: NodeJS.ErrnoException = new Error(
+        `EPERM: operation not permitted, ${syscall} '${target}'`
+      )
+      error.code = 'EPERM'
+      error.errno = -4048
+      error.syscall = syscall
+      error.path = target
+      throw error
+    }
+  }
+  return state
+})
+
+// One denial modelled coherently: a denied path throws from every read AND
+// reports false from existsSync. Faulting one but not another lets a test pass
+// against code that still consults the one left healthy.
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFs>()
+  const guard = (fn: unknown, syscall: string): unknown => {
+    const original = fn as (...args: unknown[]) => unknown
+    const wrapped = (...args: unknown[]): unknown => {
+      denials.check(args[0], syscall)
+      return original(...args)
+    }
+    return Object.assign(wrapped, original)
+  }
+  const patched: Record<string, unknown> = {
+    ...actual,
+    readFileSync: Object.assign((...args: unknown[]): unknown => {
+      denials.check(args[0], 'read', true)
+      return (actual.readFileSync as (...a: unknown[]) => unknown)(...args)
+    }, actual.readFileSync),
+    // Why: the size-capped agent-state reader opens with `openSync`, so leaving
+    // it unguarded makes a denial invisible to every config/baseline read. Guard
+    // it for READ intent only — a write opens 'w'/'wx'/'a', and the atomic
+    // replace those writes perform must stay healthy (see `deny` above).
+    openSync: Object.assign((...args: unknown[]): unknown => {
+      const flags = args[1]
+      const isRead = flags === undefined || (typeof flags === 'string' && flags.startsWith('r'))
+      if (isRead) {
+        denials.check(args[0], 'open', true)
+      }
+      return (actual.openSync as (...a: unknown[]) => unknown)(...args)
+    }, actual.openSync),
+    statSync: guard(actual.statSync, 'stat'),
+    lstatSync: guard(actual.lstatSync, 'lstat'),
+    existsSync: Object.assign(
+      (...args: unknown[]): boolean =>
+        typeof args[0] === 'string' &&
+        (denials.paths.has(args[0]) || denials.existenceDeniedPaths.has(args[0]))
+          ? false
+          : actual.existsSync(args[0] as string),
+      actual.existsSync
+    )
+  }
+  return { ...patched, default: patched }
+})
+
+const { getPathMock, homedirMock } = vi.hoisted(() => ({
+  getPathMock: vi.fn<(name: string) => string>(),
+  homedirMock: vi.fn<() => string>()
+}))
+
+vi.mock('electron', () => ({ app: { getPath: getPathMock } }))
+
+vi.mock('node:os', async () => {
+  const actual = await vi.importActual<typeof NodeOs>('node:os')
+  return { ...actual, homedir: homedirMock }
+})
+
+const realFs = await vi.importActual<typeof NodeFs>('node:fs')
+
+const { upsertHookTrustEntries, readHookTrustEntries } = await import('./config-toml-trust')
+const {
+  writeCodexTrustGrantLedgerHome,
+  readCodexTrustGrantLedgerHome,
+  getCodexTrustGrantLedgerPath
+} = await import('./codex-trust-grant-ledger')
+const { readHooksJson } = await import('../agent-hooks/hooks-json-read')
+const { snapshotCodexRuntimeSettingsBaseline } = await import('./config-settings-promotion')
+const { getCodexConfigSyncStatus } = await import('./config-sync-stall')
+const paneRegistry = await import('./codex-pane-account-registry')
+
+let fakeHomeDir: string
+let userDataDir: string
+let runtimeHomePath: string
+let previousUserDataPath: string | undefined
+
+const systemHome = (): string => join(fakeHomeDir, '.codex')
+const baselinePath = (): string => join(runtimeHomePath, '.orca-config-settings-baseline.json')
+
+beforeEach(() => {
+  denials.reset()
+  fakeHomeDir = realFs.mkdtempSync(join(tmpdir(), 'orca-sta4823-home-'))
+  userDataDir = realFs.mkdtempSync(join(tmpdir(), 'orca-sta4823-data-'))
+  runtimeHomePath = join(userDataDir, 'codex-runtime-home', 'home')
+  previousUserDataPath = process.env.ORCA_USER_DATA_PATH
+  process.env.ORCA_USER_DATA_PATH = userDataDir
+  homedirMock.mockReturnValue(fakeHomeDir)
+  getPathMock.mockImplementation((name: string) => {
+    if (name === 'userData') {
+      return userDataDir
+    }
+    throw new Error(`unexpected app.getPath(${name})`)
+  })
+  realFs.mkdirSync(runtimeHomePath, { recursive: true })
+  realFs.mkdirSync(systemHome(), { recursive: true })
+  paneRegistry._internals.resetCache()
+})
+
+afterEach(() => {
+  denials.reset()
+  paneRegistry._internals.resetCache()
+  realFs.rmSync(fakeHomeDir, { recursive: true, force: true })
+  realFs.rmSync(userDataDir, { recursive: true, force: true })
+  if (previousUserDataPath === undefined) {
+    delete process.env.ORCA_USER_DATA_PATH
+  } else {
+    process.env.ORCA_USER_DATA_PATH = previousUserDataPath
+  }
+  vi.clearAllMocks()
+})
+
+describe('STA-4823 D29 — an unreadable config.toml must not become a trust-only stub', () => {
+  const USER_CONFIG = [
+    'model = "gpt-5.1-codex-max"',
+    'model_provider = "openai"',
+    '',
+    '# my notes',
+    '[mcp_servers.local]',
+    'command = "run-me"',
+    ''
+  ].join('\n')
+  const ENTRY = [
+    {
+      sourcePath: '/tmp/hooks.json',
+      eventLabel: 'stop',
+      groupIndex: 0,
+      hookIndex: 0,
+      trustedHash: 'sha256:x',
+      enabled: true
+    }
+  ]
+
+  it('refuses the write rather than rebuilding the file from the trust entries alone', () => {
+    const configPath = join(runtimeHomePath, 'config.toml')
+    realFs.writeFileSync(configPath, USER_CONFIG, 'utf-8')
+    denials.denyExistence(configPath)
+
+    // Every hook-service caller already turns this throw into "trust entries
+    // could not be written. Run /hooks in Codex to approve."
+    expect(() => upsertHookTrustEntries(configPath, ENTRY as never)).toThrow('EPERM')
+
+    // Before the fix, existsSync said the file was gone, `existing` became '',
+    // and the upsert wrote a config containing ONLY the trust table — the
+    // user's model, provider, MCP servers and comments all discarded.
+    expect(realFs.readFileSync(configPath, 'utf-8')).toBe(USER_CONFIG)
+  })
+
+  it('still seeds a config.toml that does not exist yet', () => {
+    const configPath = join(runtimeHomePath, 'config.toml')
+
+    // Why: seeding from empty is correct for a genuine absence, and is how a
+    // fresh managed home gets its trust entries at all.
+    upsertHookTrustEntries(configPath, ENTRY as never)
+
+    expect(readHookTrustEntries(configPath).size).toBeGreaterThan(0)
+  })
+})
+
+describe('STA-4823 D30 — an unreadable trust-grant ledger must not be rewritten from empty', () => {
+  const OTHER_HOME = '/some/other/managed/home'
+
+  function seedLedgerWithAnotherHome(): string {
+    const ledgerPath = getCodexTrustGrantLedgerPath()
+    writeCodexTrustGrantLedgerHome(
+      OTHER_HOME,
+      { entries: { 'a:b': { trustedHash: 'sha256:other' } } } as never,
+      ledgerPath
+    )
+    return ledgerPath
+  }
+
+  it('skips the write instead of dropping every other home', () => {
+    const ledgerPath = seedLedgerWithAnotherHome()
+    const before = realFs.readFileSync(ledgerPath, 'utf-8')
+    denials.deny(ledgerPath)
+
+    writeCodexTrustGrantLedgerHome(
+      runtimeHomePath,
+      { entries: { 'c:d': { trustedHash: 'sha256:mine' } } } as never,
+      ledgerPath
+    )
+
+    // Before the fix the read degraded to an empty ledger and the write
+    // persisted a file holding only this home, so every other home lost its
+    // grants and would be re-prompted for trust it had already given.
+    expect(realFs.readFileSync(ledgerPath, 'utf-8')).toBe(before)
+  })
+
+  it('still records a home when the ledger is readable', () => {
+    const ledgerPath = seedLedgerWithAnotherHome()
+
+    // Why: the anchor. Refusing whenever a read fails would stop the ledger
+    // ever recording a grant.
+    writeCodexTrustGrantLedgerHome(
+      runtimeHomePath,
+      { entries: { 'c:d': { trustedHash: 'sha256:mine' } } } as never,
+      ledgerPath
+    )
+
+    expect(readCodexTrustGrantLedgerHome(runtimeHomePath, ledgerPath)).not.toBeNull()
+    expect(readCodexTrustGrantLedgerHome(OTHER_HOME, ledgerPath)).not.toBeNull()
+  })
+})
+
+describe('STA-4823 D33 — an unreadable hooks.json is not an empty hooks.json', () => {
+  it('reports a failed read as unknown rather than as no hooks configured', () => {
+    const hooksPath = join(runtimeHomePath, 'hooks.json')
+    realFs.writeFileSync(hooksPath, JSON.stringify({ hooks: { Stop: [] } }), 'utf-8')
+    denials.deny(hooksPath)
+
+    // The read arm already returned null for a failed read; the existsSync arm
+    // in front of it returned a VALID EMPTY config, and the installer then
+    // wrote generated hooks over the user's file.
+    expect(readHooksJson(hooksPath)).toBeNull()
+  })
+
+  it('still reports a genuinely absent hooks.json as an empty config', () => {
+    // Why: absence really does mean "no hooks configured", and the installer
+    // depends on that to seed one.
+    expect(readHooksJson(join(runtimeHomePath, 'hooks.json'))).toEqual({})
+  })
+})
+
+describe('STA-4823 D26 — an unreadable settings baseline must not be overwritten', () => {
+  function seedBaseline(): string {
+    realFs.writeFileSync(
+      baselinePath(),
+      `${JSON.stringify({ version: 2, settings: { model: 'old-model' } })}\n`,
+      'utf-8'
+    )
+    return realFs.readFileSync(baselinePath(), 'utf-8')
+  }
+
+  it('leaves the record alone so the pending edit can still be promoted', () => {
+    const before = seedBaseline()
+    realFs.writeFileSync(
+      join(runtimeHomePath, 'config.toml'),
+      'model = "edited-in-codex"\n',
+      'utf-8'
+    )
+    denials.deny(baselinePath())
+
+    snapshotCodexRuntimeSettingsBaseline(runtimeHomePath)
+
+    // Before the fix this recorded "edited-in-codex" as Orca's own write, so
+    // the user's in-Codex change was never promoted and the next mirror pass
+    // wrote the old value back over it.
+    expect(realFs.readFileSync(baselinePath(), 'utf-8')).toBe(before)
+  })
+
+  it('still replaces a baseline that is present but malformed', () => {
+    realFs.writeFileSync(baselinePath(), '{ not json', 'utf-8')
+    realFs.writeFileSync(join(runtimeHomePath, 'config.toml'), 'model = "m"\n', 'utf-8')
+
+    // Why: a corrupt baseline carries no information and resetting it IS the
+    // intent. Only the unreadable case may be preserved, or a user is wedged
+    // on a broken file forever.
+    snapshotCodexRuntimeSettingsBaseline(runtimeHomePath)
+
+    // Asserted against the file rather than the new observation API, so this
+    // anchor still means something when the fix is reverted.
+    expect(JSON.parse(realFs.readFileSync(baselinePath(), 'utf-8'))).toMatchObject({ version: 2 })
+  })
+})
+
+describe('STA-4823 D15 — the sync status must not report synced while the mirror refuses', () => {
+  it('reports the managed home as unavailable when its config cannot be read', () => {
+    const runtimeConfigPath = join(runtimeHomePath, 'config.toml')
+    realFs.writeFileSync(runtimeConfigPath, 'model = "m"\n', 'utf-8')
+    realFs.writeFileSync(join(systemHome(), 'config.toml'), 'model = "s"\n', 'utf-8')
+    denials.deny(runtimeConfigPath)
+
+    const status = getCodexConfigSyncStatus({ runtimeHomePath, systemHomePath: systemHome() })
+
+    // Before the fix existsSync reported the locked runtime config as absent
+    // and this returned `synced` — telling the user their edits had been
+    // applied while nothing had run.
+    expect(status).toMatchObject({ state: 'stalled', reason: 'managed-home-unavailable' })
+  })
+
+  it('still reports synced when no runtime config exists yet', () => {
+    realFs.writeFileSync(join(systemHome(), 'config.toml'), 'model = "s"\n', 'utf-8')
+
+    // Why: with no managed config the mirror seeds one; there is nothing to
+    // have fallen behind, and warning here would fire on every fresh install.
+    expect(
+      getCodexConfigSyncStatus({ runtimeHomePath, systemHomePath: systemHome() })
+    ).toMatchObject({ state: 'synced', reason: null })
+  })
+})
+
+describe('STA-4823 D31 — an unreadable pane registry must not erase every attribution', () => {
+  const PANE = 'pty-1'
+  const OTHER_PANE = 'pty-2'
+  const registryPath = (): string => join(userDataDir, 'codex-pane-accounts.json')
+
+  function seedTwoAttributedPanes(): void {
+    paneRegistry.recordCodexPaneAccount(PANE, {
+      selectionKey: 'host',
+      accountId: 'account-1',
+      homeRoute: 'account-home'
+    } as never)
+    paneRegistry.recordCodexPaneAccount(OTHER_PANE, {
+      selectionKey: 'host',
+      accountId: 'account-2',
+      homeRoute: 'account-home'
+    } as never)
+    paneRegistry._internals.resetCache()
+  }
+
+  it('does not persist an empty registry over the real one', () => {
+    seedTwoAttributedPanes()
+    const before = realFs.readFileSync(registryPath(), 'utf-8')
+    denials.deny(registryPath())
+
+    paneRegistry.recordCodexPaneAccount('pty-3', {
+      selectionKey: 'host',
+      accountId: 'account-3',
+      homeRoute: 'account-home'
+    } as never)
+
+    // Before the fix the read degraded to an empty registry and this write
+    // persisted it, dropping every other pane's account attribution on disk.
+    expect(realFs.readFileSync(registryPath(), 'utf-8')).toBe(before)
+  })
+
+  it('does not cache the erasure, so attribution returns when the file does', () => {
+    seedTwoAttributedPanes()
+    denials.deny(registryPath())
+
+    expect(paneRegistry.getCodexPaneAccount(PANE)).toBeNull()
+
+    denials.release(registryPath())
+
+    // THE CACHE is the second half of this defect: one unreadable read used to
+    // pin the empty registry in memory for the rest of the process, so the
+    // attribution never came back even after the file did.
+    expect(paneRegistry.getCodexPaneAccount(PANE)).toMatchObject({ accountId: 'account-1' })
+  })
+
+  it('still reports no attribution when the registry genuinely does not exist', () => {
+    // Why: a fresh install has no registry, and that really is "no panes are
+    // attributed". Refusing here would make every first launch look degraded.
+    expect(paneRegistry.getCodexPaneAccount(PANE)).toBeNull()
+  })
+})

--- a/src/main/codex/sta-4823-shared-state-survives-a-failed-read.test.ts
+++ b/src/main/codex/sta-4823-shared-state-survives-a-failed-read.test.ts
@@ -133,6 +133,8 @@ const {
   getCodexTrustGrantLedgerPath
 } = await import('./codex-trust-grant-ledger')
 const { readHooksJson } = await import('../agent-hooks/hooks-json-read')
+const { MAX_AGENT_STATE_FILE_BYTES } = await import('../agent-state-file-reader')
+const { observeCodexSettingsBaseline } = await import('./config-settings-baseline')
 const { snapshotCodexRuntimeSettingsBaseline } = await import('./config-settings-promotion')
 const { getCodexConfigSyncStatus } = await import('./config-sync-stall')
 const paneRegistry = await import('./codex-pane-account-registry')
@@ -355,6 +357,25 @@ describe('STA-4823 D26 — an unreadable settings baseline must not be overwritt
     snapshotCodexRuntimeSettingsBaseline(runtimeHomePath)
 
     expect(JSON.parse(realFs.readFileSync(baselinePath(), 'utf-8'))).toMatchObject({ version: 2 })
+  })
+
+  it('rebuilds an oversized baseline previously produced from a bounded runtime config', () => {
+    const escapedValue = '\\'.repeat(MAX_AGENT_STATE_FILE_BYTES / 2 + 64)
+    const oversizedRuntimeConfig = `model = "${escapedValue}"\n`
+    expect(Buffer.byteLength(oversizedRuntimeConfig)).toBeLessThan(MAX_AGENT_STATE_FILE_BYTES)
+    realFs.writeFileSync(join(runtimeHomePath, 'config.toml'), oversizedRuntimeConfig, 'utf-8')
+
+    snapshotCodexRuntimeSettingsBaseline(runtimeHomePath)
+    expect(realFs.statSync(baselinePath()).size).toBeGreaterThan(MAX_AGENT_STATE_FILE_BYTES)
+    expect(observeCodexSettingsBaseline(runtimeHomePath)).toEqual({ kind: 'absent' })
+
+    realFs.writeFileSync(join(runtimeHomePath, 'config.toml'), 'model = "recovered"\n', 'utf-8')
+    snapshotCodexRuntimeSettingsBaseline(runtimeHomePath)
+
+    expect(realFs.statSync(baselinePath()).size).toBeLessThan(MAX_AGENT_STATE_FILE_BYTES)
+    expect(JSON.parse(realFs.readFileSync(baselinePath(), 'utf-8'))).toMatchObject({
+      settings: { model: '"recovered"' }
+    })
   })
 })
 

--- a/src/main/codex/sta-4823-shared-state-survives-a-failed-read.test.ts
+++ b/src/main/codex/sta-4823-shared-state-survives-a-failed-read.test.ts
@@ -3,11 +3,12 @@ import type * as NodeFs from 'node:fs'
 import type * as NodeOs from 'node:os'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { syncSystemConfigIntoManagedCodexHome } from './codex-config-mirror'
 import type { CodexTrustEntry } from './config-toml-trust'
 
 // STA-4823: six shared Codex state files were rebuilt, erased or reported as
-// healthy after a read that had merely failed. Every one is reachable on the
-// host lane; the WSL-specific half of the catalogue stays in STA-4606.
+// healthy after a read that had merely failed. Host permission failures drive
+// four; the other guards cover transient transport and observation races.
 
 const denials = vi.hoisted(() => {
   const state = {
@@ -18,9 +19,8 @@ const denials = vi.hoisted(() => {
       state.paths.add(path)
     },
     /**
-     * Content reads fail but `existsSync` still says the file is there — the
-     * shape a Windows sharing violation takes, as distinct from `deny`, which
-     * models an ACL denial where `existsSync` itself reports false.
+     * Content reads fail but `existsSync` and metadata reads still succeed —
+     * the measured host permission/sharing-denial shape.
      */
     denyReads(path: string): void {
       state.readOnlyPaths.add(path)
@@ -33,8 +33,9 @@ const denials = vi.hoisted(() => {
      * produce this. `chmod 000` on macOS and `icacls /deny (R)` on Windows both
      * leave `existsSync` TRUE, leave `stat`/`lstat` succeeding, and fail only
      * the content read (EACCES / EPERM errno -4048). The shape modelled here is
-     * the UNC / `\\wsl$` transport, where an unreachable distro reports errno
-     * `UNKNOWN` at every level and `existsSync` folds that to false.
+     * a transient transport failure: a UNC / `\\wsl$` probe reports errno
+     * `UNKNOWN`, `existsSync` folds it to false, and the transport recovers
+     * before the following write.
      *
      * The distinction decides what the guard is worth: under a permission denial
      * the pre-fix code already failed safe, because `existsSync` was true so it
@@ -46,6 +47,8 @@ const denials = vi.hoisted(() => {
     },
     release(path: string): void {
       state.paths.delete(path)
+      state.readOnlyPaths.delete(path)
+      state.existenceDeniedPaths.delete(path)
     },
     reset(): void {
       state.paths.clear()
@@ -268,7 +271,7 @@ describe('STA-4823 D30 — an unreadable trust-grant ledger must not be rewritte
   it('skips the write instead of dropping every other home', () => {
     const ledgerPath = seedLedgerWithAnotherHome()
     const before = realFs.readFileSync(ledgerPath, 'utf-8')
-    denials.deny(ledgerPath)
+    denials.denyReads(ledgerPath)
 
     writeCodexTrustGrantLedgerHome(
       runtimeHomePath,
@@ -317,7 +320,7 @@ describe('STA-4823 D33 — an unreadable hooks.json is not an empty hooks.json',
   })
 })
 
-describe('STA-4823 D26 — an unreadable settings baseline must not be overwritten', () => {
+describe('STA-4823 D26 — an unreadable settings baseline must stall the mirror', () => {
   function seedBaseline(): string {
     realFs.writeFileSync(
       baselinePath(),
@@ -327,20 +330,29 @@ describe('STA-4823 D26 — an unreadable settings baseline must not be overwritt
     return realFs.readFileSync(baselinePath(), 'utf-8')
   }
 
-  it('leaves the record alone so the pending edit can still be promoted', () => {
+  it('preserves the pending runtime edit until the baseline can be read', () => {
     const before = seedBaseline()
-    realFs.writeFileSync(
-      join(runtimeHomePath, 'config.toml'),
-      'model = "edited-in-codex"\n',
-      'utf-8'
-    )
-    denials.deny(baselinePath())
+    const runtimeConfigPath = join(runtimeHomePath, 'config.toml')
+    realFs.writeFileSync(runtimeConfigPath, 'model = "edited-in-codex"\n', 'utf-8')
+    realFs.writeFileSync(join(systemHome(), 'config.toml'), 'model = "old-model"\n', 'utf-8')
+    denials.denyReads(baselinePath())
+
+    syncSystemConfigIntoManagedCodexHome({ runtimeHomePath, systemHomePath: systemHome() })
+
+    // Before the fix the failed baseline read became "no baseline", promotion
+    // returned an empty plan, and the mirror wrote the old system value over
+    // the pending in-Codex edit.
+    expect(realFs.readFileSync(runtimeConfigPath, 'utf-8')).toContain('edited-in-codex')
+    expect(realFs.readFileSync(baselinePath(), 'utf-8')).toBe(before)
+  })
+
+  it('does not replace a baseline after an indeterminate existence probe', () => {
+    const before = seedBaseline()
+    realFs.writeFileSync(join(runtimeHomePath, 'config.toml'), 'model = "edited"\n', 'utf-8')
+    denials.denyExistence(baselinePath())
 
     snapshotCodexRuntimeSettingsBaseline(runtimeHomePath)
 
-    // Before the fix this recorded "edited-in-codex" as Orca's own write, so
-    // the user's in-Codex change was never promoted and the next mirror pass
-    // wrote the old value back over it.
     expect(realFs.readFileSync(baselinePath(), 'utf-8')).toBe(before)
   })
 
@@ -396,9 +408,9 @@ describe('STA-4823 D15 — the sync status must not report synced while the mirr
 
     const status = getCodexConfigSyncStatus({ runtimeHomePath, systemHomePath: systemHome() })
 
-    // Before the fix existsSync reported the locked runtime config as absent
-    // and this returned `synced` — telling the user their edits had been
-    // applied while nothing had run.
+    // Before the fix existsSync collapsed this failed observation into absence
+    // and returned `synced` — telling the user their edits had been applied
+    // while nothing had run.
     expect(status).toMatchObject({ state: 'stalled', reason: 'managed-home-unavailable' })
   })
 
@@ -446,7 +458,7 @@ describe('STA-4823 D31 — an unreadable pane registry must not erase every attr
   it('does not persist an empty registry over the real one', () => {
     seedTwoAttributedPanes()
     const before = realFs.readFileSync(registryPath(), 'utf-8')
-    denials.deny(registryPath())
+    denials.denyReads(registryPath())
 
     paneRegistry.recordCodexPaneAccount('pty-3', {
       selectionKey: 'host',
@@ -461,7 +473,7 @@ describe('STA-4823 D31 — an unreadable pane registry must not erase every attr
 
   it('does not cache the erasure, so attribution returns when the file does', () => {
     seedTwoAttributedPanes()
-    denials.deny(registryPath())
+    denials.denyReads(registryPath())
 
     expect(paneRegistry.getCodexPaneAccount(PANE)).toBeNull()
 

--- a/src/main/codex/sta-4823-shared-state-survives-a-failed-read.test.ts
+++ b/src/main/codex/sta-4823-shared-state-survives-a-failed-read.test.ts
@@ -4,6 +4,7 @@ import type * as NodeOs from 'node:os'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { syncSystemConfigIntoManagedCodexHome } from './codex-config-mirror'
+import { listStaleCodexPanes } from './codex-stale-pane-accounts'
 import type { CodexTrustEntry } from './config-toml-trust'
 
 // STA-4823: six shared Codex state files were rebuilt, erased or reported as
@@ -455,7 +456,7 @@ describe('STA-4823 D31 — an unreadable pane registry must not erase every attr
     paneRegistry._internals.resetCache()
   }
 
-  it('does not persist an empty registry over the real one', () => {
+  it('preserves existing records and retries the one-shot spawn mutation', () => {
     seedTwoAttributedPanes()
     const before = realFs.readFileSync(registryPath(), 'utf-8')
     denials.denyReads(registryPath())
@@ -469,6 +470,12 @@ describe('STA-4823 D31 — an unreadable pane registry must not erase every attr
     // Before the fix the read degraded to an empty registry and this write
     // persisted it, dropping every other pane's account attribution on disk.
     expect(realFs.readFileSync(registryPath(), 'utf-8')).toBe(before)
+
+    denials.release(registryPath())
+    expect(paneRegistry.getCodexPaneAccount('pty-3')).toMatchObject({ accountId: 'account-3' })
+    paneRegistry._internals.resetCache()
+    expect(paneRegistry.getCodexPaneAccount(PANE)).toMatchObject({ accountId: 'account-1' })
+    expect(paneRegistry.getCodexPaneAccount('pty-3')).toMatchObject({ accountId: 'account-3' })
   })
 
   it('does not cache the erasure, so attribution returns when the file does', () => {
@@ -476,6 +483,12 @@ describe('STA-4823 D31 — an unreadable pane registry must not erase every attr
     denials.denyReads(registryPath())
 
     expect(paneRegistry.getCodexPaneAccount(PANE)).toBeNull()
+    expect(() =>
+      listStaleCodexPanes({
+        ptyIds: [PANE],
+        settings: { activeCodexManagedAccountId: 'account-2' } as never
+      })
+    ).toThrow('registry could not be read')
 
     denials.release(registryPath())
 

--- a/src/main/ipc/codex-config-sync.test.ts
+++ b/src/main/ipc/codex-config-sync.test.ts
@@ -21,6 +21,7 @@ vi.mock('node:os', async (importOriginal) => {
 
 import { registerCodexConfigSyncHandlers } from './codex-config-sync'
 import type { CodexConfigSyncStatus } from '../../shared/codex-config-sync-types'
+import { getCodexSettingsBaselinePath } from '../codex/config-settings-baseline'
 
 let root: string
 
@@ -76,6 +77,22 @@ describe('codexConfigSync:status handler', () => {
       state: 'synced',
       reason: null,
       systemConfigPath: join(root, '.codex', 'config.toml')
+    })
+  })
+
+  it('reports a stall when the selected home baseline cannot be read', () => {
+    const perAccountHome = join(root, 'codex-accounts', 'acct-1', 'home')
+    mkdirSync(perAccountHome, { recursive: true })
+    writeFileSync(join(perAccountHome, 'config.toml'), 'model = "runtime-model"\n', 'utf-8')
+    writeFileSync(join(root, '.codex', 'config.toml'), 'model = "system-model"\n', 'utf-8')
+    const baselinePath = getCodexSettingsBaselinePath(perAccountHome)
+    mkdirSync(baselinePath)
+
+    expect(invokeHandler(perAccountHome)).toEqual({
+      state: 'stalled',
+      reason: 'managed-home-unavailable',
+      systemConfigPath: join(root, '.codex', 'config.toml'),
+      managedStatePath: baselinePath
     })
   })
 

--- a/src/shared/codex-config-sync-types.ts
+++ b/src/shared/codex-config-sync-types.ts
@@ -13,4 +13,10 @@ export type CodexConfigSyncStallReason =
 
 export type CodexConfigSyncStatus =
   | { state: 'synced'; reason: null; systemConfigPath: string }
-  | { state: 'stalled'; reason: CodexConfigSyncStallReason; systemConfigPath: string }
+  | {
+      state: 'stalled'
+      reason: CodexConfigSyncStallReason
+      systemConfigPath: string
+      /** Optional for compatibility with status producers that cannot resolve the managed path. */
+      managedStatePath?: string
+    }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​737 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​736 |
| Prod | 14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​494 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​142 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​352 |

<!-- /orca-pr-loc -->

## ELI5

Orca now treats a failed read as “unknown,” not “missing.” A transient filesystem or transport failure can no longer authorize a rebuild, destructive write, cached erasure, or healthy sync result; genuine absence and malformed state still recover as intended.

## What Changed

| Defect | Host trigger after measurement | Fix |
|---|---|---|
| **D15 — sync status** | **Live:** a content read fails after metadata succeeds, but status reported `synced` | Observe the bounded content read and report the existing managed-home-unavailable state |
| **D26 — settings baseline** | **Live:** promotion/mirror loses an unreadable baseline, returns an empty plan, and can overwrite a pending runtime edit | Preserve indeterminate baselines across snapshot and promotion; rebuild only absent or known-invalid state |
| **D30 — trust-grant ledger** | **Live:** an unreadable ledger becomes empty and the next write drops other homes’ grants | Refuse the write until the existing ledger can be read |
| **D31 — pane attribution** | **Live:** an unreadable registry becomes a cached/persisted empty registry | Do not cache or persist stand-in state; retain one-shot mutations and retry bounded persistence after recovery |
| **D29 — `config.toml` trust upsert** | **Host-lane insurance:** requires an indeterminate existence observation to be folded into absence | Seed only after definitive `ENOENT`/`ENOTDIR`; propagate every other read failure |
| **D33 — `hooks.json` observation** | **Host-lane insurance:** likewise requires the existence probe to hide a present file | Use one classified content read and return unknown for indeterminate failures |

### Permission-denial correction

An ordinary permission denial cannot reach D29’s rebuild-from-empty branch. On macOS, `chmod 000` leaves `existsSync` true and `stat`/`lstat` successful before `readFileSync` fails with `EACCES` (`-13`); on Windows, `icacls /deny USER:(R)` produces the same metadata shape before the content read fails with `EPERM` (`-4048`). Pre-fix D29 therefore took the read branch, threw, and the hook-service caller reported that trust entries could not be written—no trust-only stub was produced.

D29 and D33 remain conservative insurance for indeterminate existence/transport states. The host defects that survive the measurement are D15, D26, D30, and D31. D26’s live failure is the promotion/mirror path; its snapshot path was already fail-safe for the measured permission-denial shape.

### Pane-attribution durability

One-shot pane attribution updates are now retained while the registry is unreadable and merged after recovery. Automatic retries are bounded to 2,000 pending mutations and delays of 100 ms, 1 s, 5 s, and 30 s; the timer is unreferenced, and failed reconciliation-only writes also retry rather than silently canceling themselves.

### Sync-health parity

The final review found that an unreadable D26 baseline safely stopped promotion/mirroring but could still report `synced`. Health now observes that baseline too, reuses the existing managed-home-unavailable reason, and includes an optional managed-state path so diagnostics name the file that actually failed; the optional field preserves compatibility with existing status consumers.

## Linked Issue

Fixes STA-4823. The transport-specific follow-up remains in STA-4606.

## Visual Proof

Final-head (`02990b36f1`) isolated Electron startup via Playwright CDP: correct branch/worktree identity, zero console errors, and no secrets or unrelated workspace state. The filesystem-denial path has no bespoke rendered control, so this proves clean startup rather than the main-process failure path itself.

![startup-full-window.png](https://github.com/user-attachments/assets/6ee4f733-0bae-4ef6-89e9-c1444a15c36c)

## Testing

The focused STA regression file has 20 cases, with four additional pane-registry retry cases and two baseline-health status/IPC cases. The mutation matrix was rerun against each guard rather than inferred from the happy-path suite:

| Reverted behavior | Mutation result |
|---|---|
| D15 content observation | unreadable managed config incorrectly reports healthy |
| D26 tri-state baseline/promotion | pending runtime edit is lost or baseline is replaced |
| D30 ledger guard | unrelated homes’ grants are dropped |
| D31 registry guards | attribution is cached/persisted as erased |
| D29 definitive-absence guard | `denyExistence` rebuilds from trust entries alone; ordinary content denial remains fail-safe pre-fix |
| D33 definitive-absence guard | `denyExistence` reports a present file as valid empty config; ordinary content denial remains unknown pre-fix |
| Reconciliation persistence gate | failed reconciliation writes only once instead of retrying |
| Baseline health observation | mirror refusal remains safe but status/IPC incorrectly report `synced` |

- Requested main suites after the final fix: **175 files passed, 1 skipped; 1,787 tests passed, 12 skipped** across `src/main/codex`, `src/main/codex-accounts`, and `src/main/agent-hooks`.
- Including the sync-status IPC suite: **176 files passed, 1 skipped; 1,792 tests passed, 12 skipped**.
- Codex-focused readiness run: **106 files passed, 1 skipped; 1,117 tests passed, 6 skipped**.
- Renderer stale-pane coverage: **4 files / 71 tests passed**.
- Node 24 typecheck, changed-code quality, max-lines ratchet, oxfmt, and diff checks passed.
- CI passed, including all Node 24/26 test shards and Windows packaging.
- macOS and Windows permission behavior was measured directly as described above.

- [x] Automated tests added
- [x] Manual final-head Electron startup validation

## AI Disclosure

N/A — internal.
