### PR TITLE
feat(tabs): expose Move Tab to Split as keybindable commands

### DIFF
--- a/src/renderer/src/app-shell/app-command-handlers.ts
+++ b/src/renderer/src/app-shell/app-command-handlers.ts
@@ -5,8 +5,13 @@ import { requestScrollToCurrentWorkspaceRevealAndRename } from '@/lib/scroll-to-
 import { showTerminalShortcutCaptureNotification } from '@/lib/terminal-shortcut-capture-notification'
 import { shouldShowWorktreeHistoryControls } from '../lib/titlebar-worktree-history-controls'
 import { TOGGLE_WORKSPACE_BOARD_EVENT } from '../components/sidebar/useWorkspaceBoardPanel'
+import {
+  canMoveActiveTabToNewPaneColumn,
+  moveActiveTabToNewPaneColumn
+} from '../components/tab-bar/tab-move-to-pane-column'
 import { useAppStore } from '../store'
 import type { usePluginCommands } from '@/store/plugin-panels'
+import type { TabSplitDirection } from '../store/slices/tabs'
 import { isGitRepoKind } from '../../../shared/repo-kind'
 import type {
   KeybindingActionId,
@@ -112,6 +117,14 @@ export function createAppCommandHandlers(
     run()
     return true
   }
+  // Why: an unmovable tab (alone in its group) must not swallow the chord — fall through instead.
+  const claimMoveTabToSplit = (
+    actionId: KeybindingActionId,
+    direction: TabSplitDirection
+  ): boolean =>
+    workspaceChromeActive && !floatingWorkspaceFocused && canMoveActiveTabToNewPaneColumn()
+      ? claim(actionId, () => moveActiveTabToNewPaneColumn(direction))
+      : false
   const revealRightSidebarTab = (
     actionId: KeybindingActionId,
     tab: Parameters<AppShortcutActions['setRightSidebarTab']>[0]
@@ -179,6 +192,10 @@ export function createAppCommandHandlers(
         return claim('tab.rename', () => store.setRenamingTabId(store.activeTabId!))
       }
     ],
+    ['tab.moveToSplitRight', () => claimMoveTabToSplit('tab.moveToSplitRight', 'right')],
+    ['tab.moveToSplitLeft', () => claimMoveTabToSplit('tab.moveToSplitLeft', 'left')],
+    ['tab.moveToSplitUp', () => claimMoveTabToSplit('tab.moveToSplitUp', 'up')],
+    ['tab.moveToSplitDown', () => claimMoveTabToSplit('tab.moveToSplitDown', 'down')],
     [
       'workspace.rename',
       () => {

--- a/src/renderer/src/components/tab-bar/tab-move-to-pane-column.test.ts
+++ b/src/renderer/src/components/tab-bar/tab-move-to-pane-column.test.ts
@@ -1,7 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useAppStore } from '../../store'
 import type { Tab } from '../../../../shared/tab-types'
-import { canMoveTabToNewPaneColumn, moveTabToNewPaneColumn } from './tab-move-to-pane-column'
+import {
+  canMoveActiveTabToNewPaneColumn,
+  canMoveTabToNewPaneColumn,
+  findActiveTabForPaneColumnMove,
+  moveActiveTabToNewPaneColumn,
+  moveTabToNewPaneColumn
+} from './tab-move-to-pane-column'
 
 const WT = 'wt-1'
 
@@ -103,6 +109,37 @@ describe('tab-move-to-pane-column', () => {
       tabId: 'tab-b',
       targetGroupId: 'group-1',
       splitDirection: 'right'
+    })
+  })
+
+  it('resolves the active tab and its group for command-driven moves', () => {
+    useAppStore.setState({ activeTabId: 'tab-b' })
+
+    expect(findActiveTabForPaneColumnMove(useAppStore.getState())).toEqual({
+      unifiedTabId: 'tab-b',
+      groupId: 'group-1'
+    })
+    expect(canMoveActiveTabToNewPaneColumn()).toBe(true)
+  })
+
+  it('resolves nothing when the active tab belongs to another worktree', () => {
+    useAppStore.setState({ activeTabId: 'tab-from-elsewhere' })
+
+    expect(findActiveTabForPaneColumnMove(useAppStore.getState())).toBeNull()
+    expect(canMoveActiveTabToNewPaneColumn()).toBe(false)
+    expect(moveActiveTabToNewPaneColumn('right')).toBe(false)
+  })
+
+  it('moves the active tab in the requested direction', () => {
+    const dropUnifiedTab = vi.fn(() => true)
+    useAppStore.setState({ activeTabId: 'tab-b', dropUnifiedTab } as Partial<
+      ReturnType<typeof useAppStore.getState>
+    >)
+
+    expect(moveActiveTabToNewPaneColumn('down')).toBe(true)
+    expect(dropUnifiedTab).toHaveBeenCalledWith('tab-b', {
+      groupId: 'group-1',
+      splitDirection: 'down'
     })
   })
 

--- a/src/renderer/src/components/tab-bar/tab-move-to-pane-column.ts
+++ b/src/renderer/src/components/tab-bar/tab-move-to-pane-column.ts
@@ -34,6 +34,39 @@ export function canMoveTabToNewPaneColumn(unifiedTabId: string, groupId: string)
   return canMoveTabToNewPaneColumnFromState(useAppStore.getState(), unifiedTabId, groupId)
 }
 
+type ActiveTabPaneColumnState = Pick<
+  ReturnType<typeof useAppStore.getState>,
+  'activeTabId' | 'activeWorktreeId' | 'unifiedTabsByWorktree'
+>
+
+// Why: the context menu carries the clicked tab, but a command only knows the active one.
+export function findActiveTabForPaneColumnMove(
+  state: ActiveTabPaneColumnState
+): { unifiedTabId: string; groupId: string } | null {
+  const { activeTabId, activeWorktreeId } = state
+  if (!activeTabId || !activeWorktreeId) {
+    return null
+  }
+  const tab = (state.unifiedTabsByWorktree[activeWorktreeId] ?? []).find(
+    (candidate) => candidate.id === activeTabId
+  )
+  return tab ? { unifiedTabId: tab.id, groupId: tab.groupId } : null
+}
+
+export function canMoveActiveTabToNewPaneColumn(): boolean {
+  const state = useAppStore.getState()
+  const target = findActiveTabForPaneColumnMove(state)
+  return (
+    target !== null &&
+    canMoveTabToNewPaneColumnFromState(state, target.unifiedTabId, target.groupId)
+  )
+}
+
+export function moveActiveTabToNewPaneColumn(direction: TabSplitDirection): boolean {
+  const target = findActiveTabForPaneColumnMove(useAppStore.getState())
+  return target === null ? false : moveTabToNewPaneColumn({ ...target, direction })
+}
+
 export function moveTabToNewPaneColumn(args: {
   unifiedTabId: string
   groupId: string

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -68,6 +68,10 @@ export type KeybindingActionId =
   | 'tab.closeAll'
   | 'tab.rename'
   | 'tab.reopenClosed'
+  | 'tab.moveToSplitRight'
+  | 'tab.moveToSplitLeft'
+  | 'tab.moveToSplitUp'
+  | 'tab.moveToSplitDown'
   | 'tab.nextSameType'
   | 'tab.previousSameType'
   | 'tab.nextAllTypes'
@@ -632,6 +636,38 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     scope: 'tabs',
     searchKeywords: ['shortcut', 'tab', 'reopen', 'restore', 'closed'],
     defaultBindings: platformBindings(['Mod+Shift+T'])
+  },
+  {
+    id: 'tab.moveToSplitRight',
+    title: 'Move tab to split right',
+    group: 'Tabs',
+    scope: 'tabs',
+    searchKeywords: ['shortcut', 'tab', 'split', 'move', 'right'],
+    defaultBindings: platformBindings([])
+  },
+  {
+    id: 'tab.moveToSplitLeft',
+    title: 'Move tab to split left',
+    group: 'Tabs',
+    scope: 'tabs',
+    searchKeywords: ['shortcut', 'tab', 'split', 'move', 'left'],
+    defaultBindings: platformBindings([])
+  },
+  {
+    id: 'tab.moveToSplitUp',
+    title: 'Move tab to split up',
+    group: 'Tabs',
+    scope: 'tabs',
+    searchKeywords: ['shortcut', 'tab', 'split', 'move', 'up'],
+    defaultBindings: platformBindings([])
+  },
+  {
+    id: 'tab.moveToSplitDown',
+    title: 'Move tab to split down',
+    group: 'Tabs',
+    scope: 'tabs',
+    searchKeywords: ['shortcut', 'tab', 'split', 'move', 'down'],
+    defaultBindings: platformBindings([])
   },
   {
     id: 'tab.nextSameType',


### PR DESCRIPTION
## ELI5

Orca can already move a tab into a split pane — you right-click the tab and pick "Move Tab to Split". But that is the only way to reach it. This PR registers the same action as a proper command, so it shows up in Settings > Shortcuts and the command palette, and you can give it whatever key you like. Nothing about the move itself changes.

## What Changed

- `src/shared/keybindings.ts` — four new commands in the Tabs group: `tab.moveToSplitRight` / `Left` / `Up` / `Down`, plus the matching `KeybindingActionId` entries. They ship with **no default binding**.
- `tab-move-to-pane-column.ts` — `findActiveTabForPaneColumnMove`, `canMoveActiveTabToNewPaneColumn`, `moveActiveTabToNewPaneColumn`. The context menu already carries the clicked tab; a command only knows the active one, so this resolves it from the active worktree. The existing `moveTabToNewPaneColumn` is untouched and still does the work.
- `app-command-handlers.ts` — four map entries and one helper. When the tab cannot move (it is alone in its group) the handler returns `false` so the chord falls through instead of being swallowed, matching the contract every other handler in that file follows.
- `tab-move-to-pane-column.test.ts` — three cases added (active tab resolution, active tab owned by another worktree, direction is honored).

## Why

Closes the gap #12083 and #10055 describe: `moveTabToNewPaneColumn` had no command id, so it could not be bound or invoked from the palette.

They ship unassigned on purpose. The action deserves a default, but the obvious chords are taken — `Mod+D` is already Split terminal right — and proposing one here would turn a small enable-it change into a keymap debate. Settings shows the four rows under **Unassigned** with **Conflicts 0**, so anyone can pick their own key today, and a default can land later as its own PR.

## Linked Issue

Fixes #12083
Also addresses #10055

## Visual Proof

No new UI is drawn. The four rows are rendered by the existing Shortcuts pane and the tab context menu is unchanged, so there is nothing to show side by side beyond the rows appearing in a list that already exists.

What does change is observable in Settings > Shortcuts. Searching "move tab to split" returns nothing on `main`; on this branch it returns four rows under Tabs, reported as **Unassigned 4** and **Conflicts 0** against the existing 127 shortcuts. I read those values off the built app rather than inferring them — see Testing.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Verified on macOS by running the built app against an isolated user-data dir and driving the renderer over CDP: the four commands appear in Settings > Shortcuts under Tabs, report as Unassigned, and register no conflicts against the existing 127 shortcuts.

```
pnpm lint       pass
pnpm typecheck  pass
pnpm test       pass for the touched suite (7/7)
pnpm build      pass
```

The full `pnpm test` run has 10 pre-existing failures on this machine — WSL-stall suites, a pty env-inheritance suite, and the cross-version wire harness, which needs release tags a shallow clone does not have. I confirmed they are unrelated by stashing this branch's changes and re-running the same files: identical failures.

Not verified: Linux and Windows. The change adds no platform-dependent code — no default bindings means no `metaKey`/`ctrlKey` handling, and matching stays inside the existing `keybindingMatchesAction` path.

## AI Disclosure

Written with Claude Code (Claude Opus 5). Design decisions, the unassigned-by-default call, and verification were reviewed by me.

## Review

- **Cross-platform**: no platform branches added. Bindings are empty for all three platforms via `platformBindings([])`, so no `CmdOrCtrl` accelerator or shortcut-label work is involved.
- **SSH / remote / folder workspaces**: the command reads renderer store state and calls the same `dropUnifiedTab` path the context menu uses. No new process, file, or network assumption. `mirrorWebRuntimeTabMove` keeps its existing role for the web runtime.
- **Remote wire compatibility**: nothing crosses the client/host wire; no RPC params, stream opcodes, or published content change.
- **Agents / integrations / git providers**: none touched.
- **Performance**: one `Array.find` over the active worktree's tabs per invocation, in a keyboard-event path. No hot-path work, no new subscriptions.
- **UI quality**: no new UI. The four rows are rendered by the existing Shortcuts pane; the context menu is unchanged.
- **Security**: no new IPC surface, no user input parsed, no privilege change.
- **i18n**: command titles are plain strings throughout `keybindings.ts` (`Close active tab`, `Split terminal right`), and `ShortcutCommandBlock` renders `item.title` directly rather than through `translate()`. These four follow that convention; the localization checks in `pnpm lint` pass.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No backwards-compatibility concern: adding action ids does not change stored keybinding overrides, and an override file that lacks these ids simply leaves them unassigned.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason — see Visual Proof: no new UI is drawn, and the observable difference is stated with the values read off the built app
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @hgijeon
