### PR TITLE
fix(workspace-cleanup): require a host-qualified key for every candidate row

### DIFF
--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-candidate-list.test.tsx
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-candidate-list.test.tsx
@@ -43,6 +43,7 @@ describe('WorkspaceCleanupCandidateList', () => {
       root?.render(
         <WorkspaceCleanupCandidateList
           rows={rows}
+          getRowKey={(candidate) => candidate.worktreeId}
           scrollElement={null}
           renderRow={(candidate) => {
             rendered.push(candidate.worktreeId)
@@ -68,6 +69,7 @@ describe('WorkspaceCleanupCandidateList', () => {
       root?.render(
         <WorkspaceCleanupCandidateList
           rows={rows}
+          getRowKey={(candidate) => candidate.worktreeId}
           scrollElement={scrollElement}
           renderRow={(candidate) => <div key={candidate.worktreeId} data-testid="row" />}
         />
@@ -80,6 +82,40 @@ describe('WorkspaceCleanupCandidateList', () => {
     // the plain flow used below the threshold.
     expect(mounted).toBeLessThanOrEqual(rows.length)
     expect(windowed || mounted === 0).toBe(true)
+  })
+
+  it('keys windowed rows through getRowKey, so same-id hosts stay distinct', () => {
+    // Two hosts publish the same worktreeId; only the caller knows the host, so
+    // the list must ask for the key instead of reaching for the colliding id.
+    const rows = [
+      ...makeRows(WORKSPACE_CLEANUP_VIRTUALIZE_MIN_ROWS - 2),
+      makeCandidate({ worktreeId: 'shared', executionHostId: 'local' }),
+      makeCandidate({ worktreeId: 'shared', executionHostId: 'ssh:box' })
+    ]
+    const scrollElement = document.createElement('div')
+    const asked: string[] = []
+
+    act(() => {
+      root?.render(
+        <WorkspaceCleanupCandidateList
+          rows={rows}
+          getRowKey={(candidate) => {
+            const key = `${candidate.executionHostId ?? ''}|${candidate.worktreeId}`
+            asked.push(key)
+            return key
+          }}
+          scrollElement={scrollElement}
+          renderRow={(_candidate, index) => <div key={index} data-testid="row" />}
+        />
+      )
+    })
+
+    expect(asked.length).toBeGreaterThan(0)
+    expect(asked).toContain('local|shared')
+    expect(asked).toContain('ssh:box|shared')
+    expect(new Set(asked).size).toBe(
+      new Set(rows.map((r) => `${r.executionHostId ?? ''}|${r.worktreeId}`)).size
+    )
   })
 
   it('memoizes CandidateRow so unchanged rows skip re-render', () => {

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-candidate-list.tsx
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-candidate-list.tsx
@@ -24,6 +24,7 @@ const WORKSPACE_CLEANUP_ROW_OVERSCAN = 8
 export function WorkspaceCleanupCandidateList<Row extends WorkspaceCleanupListRow>({
   rows,
   renderRow,
+  getRowKey,
   estimatedRowHeight = WORKSPACE_CLEANUP_ROW_ESTIMATE_PX,
   // Why: a state-held element, not a ref — the ScrollArea viewport is not
   // attached when this component first mounts, so a ref would leave the
@@ -32,6 +33,10 @@ export function WorkspaceCleanupCandidateList<Row extends WorkspaceCleanupListRo
 }: {
   rows: readonly Row[]
   renderRow: (row: Row, index: number) => React.ReactNode
+  // Why: required — the same worktreeId exists on two hosts, so a row key must
+  // be host-qualified by the caller that knows the host. Omitting it is a
+  // compile error rather than a silent fall back to the colliding bare id.
+  getRowKey: (row: Row) => string
   estimatedRowHeight?: number
   scrollElement: HTMLDivElement | null
 }): React.JSX.Element {
@@ -45,7 +50,10 @@ export function WorkspaceCleanupCandidateList<Row extends WorkspaceCleanupListRo
     overscan: WORKSPACE_CLEANUP_ROW_OVERSCAN,
     // Why: stable worktree keys let the virtualizer carry row identity across
     // scan refreshes instead of remounting the window on every streamed row.
-    getItemKey: (index) => rows[index]?.worktreeId ?? index
+    getItemKey: (index) => {
+      const row = rows[index]
+      return row === undefined ? index : getRowKey(row)
+    }
   })
 
   if (!virtualize) {

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-confirm-remove.tsx
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-confirm-remove.tsx
@@ -140,6 +140,7 @@ export function WorkspaceCleanupConfirmRemove({
         <ScrollArea className="min-h-0 flex-1" viewportRef={setScrollElement}>
           <WorkspaceCleanupCandidateList
             rows={candidates}
+            getRowKey={getWorkspaceCleanupCandidateIdentity}
             scrollElement={scrollElement}
             estimatedRowHeight={CONFIRM_REMOVE_ROW_ESTIMATE_PX}
             renderRow={(candidate, index) => (

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-flat-list.test.tsx
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-flat-list.test.tsx
@@ -39,6 +39,7 @@ function renderRows(rows: readonly WorkspaceCleanupFacets[]): void {
     root?.render(
       <WorkspaceCleanupCandidateList
         rows={rows}
+        getRowKey={(row) => row.worktreeId}
         scrollElement={null}
         renderRow={(row, index) => (
           <CandidateRow

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-row-list.tsx
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-row-list.tsx
@@ -65,6 +65,7 @@ export function WorkspaceCleanupRowList(props: WorkspaceCleanupRowListState): Re
       ) : null}
       <WorkspaceCleanupCandidateList
         rows={rows}
+        getRowKey={(row) => row.identity}
         scrollElement={props.scrollElement}
         renderRow={(row, index) => (
           <CandidateRow


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​37 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​37 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​11 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 |

<!-- /orca-pr-loc -->

## ELI5

Two machines can hold the same workspace id. The cleanup dialog's scrolling list identified each row by that id alone, so the two collapsed into one entry.

## What

`WorkspaceCleanupCandidateList` keyed its virtualizer rows on bare `worktreeId`. `getRowKey` is now a **required** prop, supplied host-qualified by each caller.

An earlier attempt used an optional `identity?: string` field. One caller supplied it; the other passes raw candidates, which have no such field, so it silently fell back to the colliding id and the confirm-remove dialog stayed broken. Making the prop required turned that into a compile error — and immediately surfaced a third call site nobody had touched.

## Test

A two-host case asserts the list asks for a key per row and that same-id rows on different hosts stay distinct. Mutation-verified: reverting `getItemKey` to `rows[index]?.worktreeId` fails it with `expected 0 to be greater than 0`.
