### PR TITLE
feat(sidebar): name the host when a delete batch collides on one id

### DIFF
--- a/src/renderer/src/components/sidebar/DeleteWorktreeDialog.test.tsx
+++ b/src/renderer/src/components/sidebar/DeleteWorktreeDialog.test.tsx
@@ -20,6 +20,10 @@ const mocks = vi.hoisted(() => {
     openSettingsTarget: vi.fn(),
     openSettingsPage: vi.fn(),
     settings: null,
+    sshTargetLabels: new Map<string, string>(),
+    sshConnectionStates: new Map(),
+    runtimeEnvironments: [] as { id: string; name: string }[],
+    runtimeStatusByEnvironmentId: new Map(),
     gitStatusByWorktree: {} as Record<string, { path: string; status: 'modified' }[]>,
     setGitStatus: vi.fn(),
     deleteStateByWorktreeId: {} as Record<
@@ -162,6 +166,10 @@ describe('DeleteWorktreeDialog lineage copy', () => {
     mocks.state.modalData = {}
     mocks.state.allWorktrees.mockReturnValue([])
     mocks.state.repos = []
+    mocks.state.sshTargetLabels = new Map()
+    mocks.state.sshConnectionStates = new Map()
+    mocks.state.runtimeEnvironments = []
+    mocks.state.runtimeStatusByEnvironmentId = new Map()
     mocks.state.worktreeLineageById = {}
     mocks.state.gitStatusByWorktree = {}
     mocks.state.deleteStateByWorktreeId = {}

--- a/src/renderer/src/components/sidebar/DeleteWorktreeDialog.test.tsx
+++ b/src/renderer/src/components/sidebar/DeleteWorktreeDialog.test.tsx
@@ -1,3 +1,7 @@
+// @vitest-environment happy-dom
+
+import '@testing-library/jest-dom/vitest'
+import { screen } from '@testing-library/react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import type { ButtonHTMLAttributes, ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -170,6 +174,7 @@ describe('DeleteWorktreeDialog lineage copy', () => {
     mocks.state.sshConnectionStates = new Map()
     mocks.state.runtimeEnvironments = []
     mocks.state.runtimeStatusByEnvironmentId = new Map()
+    document.body.innerHTML = ''
     mocks.state.worktreeLineageById = {}
     mocks.state.gitStatusByWorktree = {}
     mocks.state.deleteStateByWorktreeId = {}
@@ -177,7 +182,7 @@ describe('DeleteWorktreeDialog lineage copy', () => {
     vi.mocked(runWorktreeDeletesInParallel).mockResolvedValue([])
   })
 
-  it('previews the confirmed host row when workspace ids collide', async () => {
+  it('labels the confirmed single-host target when workspace ids collide', async () => {
     const local = {
       ...makeWorktree('shared', '/workspaces/local'),
       instanceId: 'local-instance',
@@ -194,13 +199,18 @@ describe('DeleteWorktreeDialog lineage copy', () => {
       worktreeId: ssh.id,
       worktreeDeleteIdentities: [{ id: ssh.id, instanceId: ssh.instanceId, hostId: ssh.hostId }]
     }
+    mocks.state.sshTargetLabels = new Map([['builder', 'Build server']])
     mocks.state.allWorktrees.mockReturnValue([local, ssh])
 
     const { default: DeleteWorktreeDialog } = await import('./DeleteWorktreeDialog')
     const markup = renderToStaticMarkup(<DeleteWorktreeDialog />)
+    document.body.innerHTML = markup
 
     expect(markup).toContain('SSH target')
     expect(markup).not.toContain('Local sibling')
+    expect(screen.getByRole('region')).toHaveAccessibleName(
+      'SSH target /workspaces/ssh Build server'
+    )
   })
 
   it('keeps Space safety-checked confirmation non-force', async () => {

--- a/src/renderer/src/components/sidebar/DeleteWorktreeDialog.tsx
+++ b/src/renderer/src/components/sidebar/DeleteWorktreeDialog.tsx
@@ -35,6 +35,7 @@ import { useConfirmedWorktreeDeleteTargets } from './use-confirmed-worktree-dele
 import { runLineageDeleteAll } from './delete-worktree-lineage-delete-all'
 import { runDialogForceDelete } from './delete-worktree-dialog-force-delete'
 import { getDeleteStateForWorktreeHost } from './worktree-delete-state-host-match'
+import { useSidebarHostScopeOptions } from './use-sidebar-host-scope-options'
 
 const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
   const activeModal = useAppStore((s) => s.activeModal)
@@ -49,7 +50,11 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
   const openSettingsTarget = useAppStore((s) => s.openSettingsTarget)
   const openSettingsPage = useAppStore((s) => s.openSettingsPage)
   const gitStatusByWorktree = useAppStore((s) => s.gitStatusByWorktree)
-
+  const { hostOptions } = useSidebarHostScopeOptions()
+  const hostLabelById = useMemo(
+    () => new Map(hostOptions.map((host) => [host.id, host.label])),
+    [hostOptions]
+  )
   const isOpen = activeModal === 'delete-worktree'
   const worktreeId = typeof modalData.worktreeId === 'string' ? modalData.worktreeId : ''
   const worktreeIds = useMemo(
@@ -373,6 +378,7 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
           isBatchDelete={isBatchDelete}
           worktree={worktree}
           worktrees={worktrees}
+          hostLabelById={hostLabelById}
           deleteStateByWorktreeId={deleteStateByWorktreeId}
           dirtyChangeCountsByWorktreeId={dirtyChangeCountsByWorktreeId}
         />

--- a/src/renderer/src/components/sidebar/DeleteWorktreeDialog.tsx
+++ b/src/renderer/src/components/sidebar/DeleteWorktreeDialog.tsx
@@ -378,6 +378,7 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
           isBatchDelete={isBatchDelete}
           worktree={worktree}
           worktrees={worktrees}
+          collisionWorktrees={allWorktrees}
           hostLabelById={hostLabelById}
           deleteStateByWorktreeId={deleteStateByWorktreeId}
           dirtyChangeCountsByWorktreeId={dirtyChangeCountsByWorktreeId}

--- a/src/renderer/src/components/sidebar/DeleteWorktreeTargetPreview.test.tsx
+++ b/src/renderer/src/components/sidebar/DeleteWorktreeTargetPreview.test.tsx
@@ -1,0 +1,55 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { DeleteWorktreeTargetPreview } from './DeleteWorktreeTargetPreview'
+import { getExecutionHostLabel } from '../../../../shared/execution-host'
+import type { Worktree } from '../../../../shared/worktree/types'
+
+function makeWorktree(id: string, displayName: string, hostId?: Worktree['hostId']): Worktree {
+  return {
+    id,
+    repoId: 'repo1',
+    path: `/work/${displayName}`,
+    head: 'abc123',
+    branch: 'main',
+    isBare: false,
+    isMainWorktree: false,
+    displayName,
+    ...(hostId ? { hostId } : {})
+  } as Worktree
+}
+
+function render(worktrees: readonly Worktree[]): string {
+  return renderToStaticMarkup(
+    <DeleteWorktreeTargetPreview
+      isBatchDelete={true}
+      worktree={null}
+      worktrees={worktrees}
+      deleteStateByWorktreeId={{}}
+      dirtyChangeCountsByWorktreeId={new Map()}
+    />
+  )
+}
+
+describe('DeleteWorktreeTargetPreview host labels', () => {
+  // Two hosts publish the same worktreeId, so name and path are identical in the batch —
+  // without the host there is nothing on screen distinguishing what is about to be destroyed.
+  it('names each host when the batch contains a same-id collision', () => {
+    const markup = render([
+      makeWorktree('shared', 'collide', 'local'),
+      makeWorktree('shared', 'collide', 'ssh:qa-linux-42')
+    ])
+
+    expect(markup).toContain(getExecutionHostLabel('local'))
+    expect(markup).toContain(getExecutionHostLabel('ssh:qa-linux-42'))
+  })
+
+  // Ordinary batches stay quiet: a host label on every row is noise, not information.
+  it('omits host labels when every row has a distinct id', () => {
+    const markup = render([
+      makeWorktree('one', 'alpha', 'local'),
+      makeWorktree('two', 'beta', 'ssh:qa-linux-42')
+    ])
+
+    expect(markup).not.toContain(getExecutionHostLabel('ssh:qa-linux-42'))
+  })
+})

--- a/src/renderer/src/components/sidebar/DeleteWorktreeTargetPreview.test.tsx
+++ b/src/renderer/src/components/sidebar/DeleteWorktreeTargetPreview.test.tsx
@@ -1,8 +1,31 @@
-import { renderToStaticMarkup } from 'react-dom/server'
-import { describe, expect, it } from 'vitest'
+// @vitest-environment happy-dom
+
+import '@testing-library/jest-dom/vitest'
+import { cleanup, render, screen, within } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
 import { DeleteWorktreeTargetPreview } from './DeleteWorktreeTargetPreview'
-import { getExecutionHostLabel } from '../../../../shared/execution-host'
+import { buildSidebarHostOptions } from './sidebar-host-options'
 import type { Worktree } from '../../../../shared/worktree/types'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
+
+function buildHostLabels(
+  hostLabelOverrides?: ReadonlyMap<ExecutionHostId, string>
+): ReadonlyMap<ExecutionHostId, string> {
+  return new Map(
+    buildSidebarHostOptions({
+      repos: [
+        { connectionId: 'qa-linux-42' },
+        { connectionId: null, executionHostId: 'runtime:runtime-7' }
+      ],
+      sshTargetLabels: new Map([['qa-linux-42', 'QA Linux']]),
+      settings: { activeRuntimeEnvironmentId: null },
+      runtimeEnvironments: [{ id: 'runtime-7', name: 'Build Mac' }],
+      hostLabelOverrides
+    }).map((host) => [host.id, host.label])
+  )
+}
+
+const savedHostLabels = buildHostLabels()
 
 function makeWorktree(id: string, displayName: string, hostId?: Worktree['hostId']): Worktree {
   return {
@@ -18,38 +41,109 @@ function makeWorktree(id: string, displayName: string, hostId?: Worktree['hostId
   } as Worktree
 }
 
-function render(worktrees: readonly Worktree[]): string {
-  return renderToStaticMarkup(
+function renderPreview(args: {
+  worktrees: readonly Worktree[]
+  worktree?: Worktree | null
+  isBatchDelete?: boolean
+  hostLabelById?: ReadonlyMap<ExecutionHostId, string>
+}): void {
+  render(
     <DeleteWorktreeTargetPreview
-      isBatchDelete={true}
-      worktree={null}
-      worktrees={worktrees}
+      isBatchDelete={args.isBatchDelete ?? true}
+      worktree={args.worktree ?? null}
+      worktrees={args.worktrees}
+      hostLabelById={args.hostLabelById ?? savedHostLabels}
       deleteStateByWorktreeId={{}}
       dirtyChangeCountsByWorktreeId={new Map()}
     />
   )
 }
 
-describe('DeleteWorktreeTargetPreview host labels', () => {
-  // Two hosts publish the same worktreeId, so name and path are identical in the batch —
-  // without the host there is nothing on screen distinguishing what is about to be destroyed.
-  it('names each host when the batch contains a same-id collision', () => {
-    const markup = render([
-      makeWorktree('shared', 'collide', 'local'),
-      makeWorktree('shared', 'collide', 'ssh:qa-linux-42')
-    ])
+afterEach(cleanup)
 
-    expect(markup).toContain(getExecutionHostLabel('local'))
-    expect(markup).toContain(getExecutionHostLabel('ssh:qa-linux-42'))
+describe('DeleteWorktreeTargetPreview host labels', () => {
+  it('binds saved SSH and runtime host names to their colliding batch rows', () => {
+    renderPreview({
+      worktrees: [
+        makeWorktree('shared', 'collide', 'ssh:qa-linux-42'),
+        makeWorktree('shared', 'collide', 'runtime:runtime-7')
+      ]
+    })
+
+    const sshRow = screen.getByRole('listitem', { name: /QA Linux/ })
+    const runtimeRow = screen.getByRole('listitem', { name: /Build Mac/ })
+    expect(sshRow).toHaveAccessibleName('collide /work/collide QA Linux')
+    expect(within(sshRow).getByText('QA Linux')).toBeVisible()
+    expect(within(sshRow).queryByText('Build Mac')).not.toBeInTheDocument()
+    expect(runtimeRow).toHaveAccessibleName('collide /work/collide Build Mac')
+    expect(within(runtimeRow).getByText('Build Mac')).toBeVisible()
+    expect(within(runtimeRow).queryByText('QA Linux')).not.toBeInTheDocument()
   })
 
-  // Ordinary batches stay quiet: a host label on every row is noise, not information.
-  it('omits host labels when every row has a distinct id', () => {
-    const markup = render([
-      makeWorktree('one', 'alpha', 'local'),
-      makeWorktree('two', 'beta', 'ssh:qa-linux-42')
-    ])
+  it('uses configured display-label overrides for colliding hosts', () => {
+    const worktrees = [
+      makeWorktree('shared', 'collide', 'ssh:qa-linux-42'),
+      makeWorktree('shared', 'collide', 'runtime:runtime-7')
+    ]
+    renderPreview({
+      worktrees,
+      hostLabelById: buildHostLabels(
+        new Map([
+          ['ssh:qa-linux-42', 'SSH override'],
+          ['runtime:runtime-7', 'Runtime override']
+        ])
+      )
+    })
 
-    expect(markup).not.toContain(getExecutionHostLabel('ssh:qa-linux-42'))
+    expect(screen.getByRole('listitem', { name: /SSH override/ })).toHaveTextContent('SSH override')
+    expect(screen.getByRole('listitem', { name: /Runtime override/ })).toHaveTextContent(
+      'Runtime override'
+    )
+  })
+
+  it('keeps an unqualified colliding target distinct from local', () => {
+    renderPreview({
+      worktrees: [makeWorktree('shared', 'collide'), makeWorktree('shared', 'collide', 'local')]
+    })
+
+    const unknownRow = screen.getByRole('listitem', { name: /Unknown host/ })
+    expect(within(unknownRow).getByText('Unknown host')).toBeVisible()
+    expect(screen.getAllByRole('listitem')).toHaveLength(2)
+  })
+
+  it('omits host metadata from every ordinary batch row', () => {
+    renderPreview({
+      worktrees: [
+        makeWorktree('one', 'alpha', 'local'),
+        makeWorktree('two', 'beta', 'ssh:qa-linux-42')
+      ]
+    })
+
+    const alphaRow = screen.getByRole('listitem', { name: 'alpha /work/alpha' })
+    const betaRow = screen.getByRole('listitem', { name: 'beta /work/beta' })
+    expect(within(alphaRow).queryByText(savedHostLabels.get('local')!)).not.toBeInTheDocument()
+    expect(within(betaRow).queryByText('QA Linux')).not.toBeInTheDocument()
+  })
+
+  it('includes the host in a colliding single target region and its accessible name', () => {
+    const sshWorktree = makeWorktree('shared', 'collide', 'ssh:qa-linux-42')
+    renderPreview({
+      isBatchDelete: false,
+      worktree: sshWorktree,
+      worktrees: [sshWorktree, makeWorktree('shared', 'collide', 'runtime:runtime-7')]
+    })
+
+    const target = screen.getByRole('region', { name: /QA Linux/ })
+    expect(target).toHaveAccessibleName('collide /work/collide QA Linux')
+    expect(within(target).getByText('QA Linux')).toBeVisible()
+  })
+
+  it('omits the host from an ordinary single target region', () => {
+    const sshWorktree = makeWorktree('one', 'alpha', 'ssh:qa-linux-42')
+    renderPreview({ isBatchDelete: false, worktree: sshWorktree, worktrees: [sshWorktree] })
+
+    const target = screen.getByRole('region', { name: 'alpha /work/alpha' })
+    expect(target).toHaveAccessibleName('alpha /work/alpha')
+    expect(within(target).queryByText('QA Linux')).not.toBeInTheDocument()
   })
 })

--- a/src/renderer/src/components/sidebar/DeleteWorktreeTargetPreview.test.tsx
+++ b/src/renderer/src/components/sidebar/DeleteWorktreeTargetPreview.test.tsx
@@ -43,6 +43,7 @@ function makeWorktree(id: string, displayName: string, hostId?: Worktree['hostId
 
 function renderPreview(args: {
   worktrees: readonly Worktree[]
+  collisionWorktrees?: readonly Worktree[]
   worktree?: Worktree | null
   isBatchDelete?: boolean
   hostLabelById?: ReadonlyMap<ExecutionHostId, string>
@@ -52,6 +53,7 @@ function renderPreview(args: {
       isBatchDelete={args.isBatchDelete ?? true}
       worktree={args.worktree ?? null}
       worktrees={args.worktrees}
+      collisionWorktrees={args.collisionWorktrees ?? args.worktrees}
       hostLabelById={args.hostLabelById ?? savedHostLabels}
       deleteStateByWorktreeId={{}}
       dirtyChangeCountsByWorktreeId={new Map()}
@@ -127,15 +129,18 @@ describe('DeleteWorktreeTargetPreview host labels', () => {
 
   it('includes the host in a colliding single target region and its accessible name', () => {
     const sshWorktree = makeWorktree('shared', 'collide', 'ssh:qa-linux-42')
+    const runtimeWorktree = makeWorktree('shared', 'unselected', 'runtime:runtime-7')
     renderPreview({
       isBatchDelete: false,
       worktree: sshWorktree,
-      worktrees: [sshWorktree, makeWorktree('shared', 'collide', 'runtime:runtime-7')]
+      worktrees: [sshWorktree],
+      collisionWorktrees: [sshWorktree, runtimeWorktree]
     })
 
     const target = screen.getByRole('region', { name: /QA Linux/ })
     expect(target).toHaveAccessibleName('collide /work/collide QA Linux')
     expect(within(target).getByText('QA Linux')).toBeVisible()
+    expect(screen.queryByText('unselected')).not.toBeInTheDocument()
   })
 
   it('omits the host from an ordinary single target region', () => {

--- a/src/renderer/src/components/sidebar/DeleteWorktreeTargetPreview.tsx
+++ b/src/renderer/src/components/sidebar/DeleteWorktreeTargetPreview.tsx
@@ -6,6 +6,7 @@ import { getWorktreeHostIdentity } from '../../../../shared/worktree/host-qualif
 import { DeleteWorktreeDirtyChangeHint } from './DeleteWorktreeDirtyChangeHint'
 import type { AppState } from '@/store/types'
 import { getDeleteStateForWorktreeHost } from './worktree-delete-state-host-match'
+import { getExecutionHostLabel, LOCAL_EXECUTION_HOST_ID } from '../../../../shared/execution-host'
 
 export function DeleteWorktreeTargetPreview({
   isBatchDelete,
@@ -20,6 +21,9 @@ export function DeleteWorktreeTargetPreview({
   deleteStateByWorktreeId: AppState['deleteStateByWorktreeId']
   dirtyChangeCountsByWorktreeId: ReadonlyMap<string, number>
 }): JSX.Element | null {
+  const collisionIds = new Set(
+    worktrees.map((item) => item.id).filter((id, index, ids) => ids.indexOf(id) !== index)
+  )
   if (isBatchDelete) {
     return (
       <ScrollArea className="max-h-48 rounded-md border border-border/70 bg-muted/35 text-xs">
@@ -35,6 +39,11 @@ export function DeleteWorktreeTargetPreview({
                   <div className="min-w-0 flex-1">
                     <div className="break-all font-medium text-foreground">{item.displayName}</div>
                     <div className="mt-0.5 break-all text-muted-foreground">{item.path}</div>
+                    {collisionIds.has(item.id) ? (
+                      <div className="mt-0.5 text-muted-foreground">
+                        {getExecutionHostLabel(item.hostId ?? LOCAL_EXECUTION_HOST_ID)}
+                      </div>
+                    ) : null}
                     <DeleteWorktreeDirtyChangeHint
                       changeCount={dirtyChangeCountsByWorktreeId.get(
                         item.hostId ? getWorktreeHostIdentity(item) : item.id
@@ -62,6 +71,11 @@ export function DeleteWorktreeTargetPreview({
     <div className="rounded-md border border-border/70 bg-muted/35 px-3 py-2 text-xs">
       <div className="break-all font-medium text-foreground">{worktree.displayName}</div>
       <div className="mt-1 break-all text-muted-foreground">{worktree.path}</div>
+      {worktrees.filter((item) => item.id === worktree.id).length > 1 ? (
+        <div className="mt-0.5 text-muted-foreground">
+          {getExecutionHostLabel(worktree.hostId ?? LOCAL_EXECUTION_HOST_ID)}
+        </div>
+      ) : null}
       <DeleteWorktreeDirtyChangeHint
         changeCount={dirtyChangeCountsByWorktreeId.get(
           worktree.hostId ? getWorktreeHostIdentity(worktree) : worktree.id

--- a/src/renderer/src/components/sidebar/DeleteWorktreeTargetPreview.tsx
+++ b/src/renderer/src/components/sidebar/DeleteWorktreeTargetPreview.tsx
@@ -1,4 +1,4 @@
-import type { JSX } from 'react'
+import { useId, type JSX } from 'react'
 import { LoaderCircle } from 'lucide-react'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import type { Worktree } from '../../../../shared/worktree/types'
@@ -6,42 +6,83 @@ import { getWorktreeHostIdentity } from '../../../../shared/worktree/host-qualif
 import { DeleteWorktreeDirtyChangeHint } from './DeleteWorktreeDirtyChangeHint'
 import type { AppState } from '@/store/types'
 import { getDeleteStateForWorktreeHost } from './worktree-delete-state-host-match'
-import { getExecutionHostLabel, LOCAL_EXECUTION_HOST_ID } from '../../../../shared/execution-host'
+import {
+  getExecutionHostLabel,
+  parseExecutionHostId,
+  type ExecutionHostId
+} from '../../../../shared/execution-host'
+import { translate } from '@/i18n/i18n'
+
+function getCollisionIds(worktrees: readonly Worktree[]): ReadonlySet<string> {
+  const seen = new Set<string>()
+  const collisions = new Set<string>()
+  for (const item of worktrees) {
+    if (seen.has(item.id)) {
+      collisions.add(item.id)
+    } else {
+      seen.add(item.id)
+    }
+  }
+  return collisions
+}
+
+function getTargetHostLabel(
+  worktree: Worktree,
+  hostLabelById: ReadonlyMap<ExecutionHostId, string>
+): string {
+  const hostId = parseExecutionHostId(worktree.hostId)?.id
+  return hostId
+    ? (hostLabelById.get(hostId) ?? getExecutionHostLabel(hostId))
+    : translate('components.workspace.cleanup.host.unknown', 'Unknown host')
+}
 
 export function DeleteWorktreeTargetPreview({
   isBatchDelete,
   worktree,
   worktrees,
+  hostLabelById,
   deleteStateByWorktreeId,
   dirtyChangeCountsByWorktreeId
 }: {
   isBatchDelete: boolean
   worktree: Worktree | null
   worktrees: readonly Worktree[]
+  hostLabelById: ReadonlyMap<ExecutionHostId, string>
   deleteStateByWorktreeId: AppState['deleteStateByWorktreeId']
   dirtyChangeCountsByWorktreeId: ReadonlyMap<string, number>
 }): JSX.Element | null {
-  const collisionIds = new Set(
-    worktrees.map((item) => item.id).filter((id, index, ids) => ids.indexOf(id) !== index)
-  )
+  const targetIdPrefix = useId()
+  const collisionIds = getCollisionIds(worktrees)
   if (isBatchDelete) {
     return (
       <ScrollArea className="max-h-48 rounded-md border border-border/70 bg-muted/35 text-xs">
-        <div className="space-y-1 px-3 py-2">
-          {worktrees.map((item) => {
+        <div className="space-y-1 px-3 py-2" role="list">
+          {worktrees.map((item, index) => {
             const itemDeleteState = getDeleteStateForWorktreeHost(item, deleteStateByWorktreeId)
+            const labelIds = {
+              name: `${targetIdPrefix}-${index}-name`,
+              path: `${targetIdPrefix}-${index}-path`,
+              host: `${targetIdPrefix}-${index}-host`
+            }
+            const showHost = collisionIds.has(item.id)
             return (
               <div
                 key={getWorktreeHostIdentity(item)}
+                role="listitem"
+                aria-labelledby={`${labelIds.name} ${labelIds.path}${showHost ? ` ${labelIds.host}` : ''}`}
                 className="min-w-0 border-b border-border/50 py-1 last:border-0"
               >
                 <div className="flex min-w-0 items-start gap-2">
                   <div className="min-w-0 flex-1">
-                    <div className="break-all font-medium text-foreground">{item.displayName}</div>
-                    <div className="mt-0.5 break-all text-muted-foreground">{item.path}</div>
-                    {collisionIds.has(item.id) ? (
-                      <div className="mt-0.5 text-muted-foreground">
-                        {getExecutionHostLabel(item.hostId ?? LOCAL_EXECUTION_HOST_ID)}
+                    <div id={labelIds.name} className="break-all font-medium text-foreground">
+                      {item.displayName}
+                    </div>
+                    <div id={labelIds.path} className="mt-0.5 break-all text-muted-foreground">
+                      {item.path}
+                    </div>
+                    {showHost ? (
+                      <div id={labelIds.host} className="mt-0.5 text-muted-foreground">
+                        {getTargetHostLabel(item, hostLabelById)}
                       </div>
                     ) : null}
                     <DeleteWorktreeDirtyChangeHint
@@ -67,13 +108,30 @@ export function DeleteWorktreeTargetPreview({
     )
   }
 
-  return worktree ? (
-    <div className="rounded-md border border-border/70 bg-muted/35 px-3 py-2 text-xs">
-      <div className="break-all font-medium text-foreground">{worktree.displayName}</div>
-      <div className="mt-1 break-all text-muted-foreground">{worktree.path}</div>
-      {worktrees.filter((item) => item.id === worktree.id).length > 1 ? (
-        <div className="mt-0.5 text-muted-foreground">
-          {getExecutionHostLabel(worktree.hostId ?? LOCAL_EXECUTION_HOST_ID)}
+  if (!worktree) {
+    return null
+  }
+  const labelIds = {
+    name: `${targetIdPrefix}-name`,
+    path: `${targetIdPrefix}-path`,
+    host: `${targetIdPrefix}-host`
+  }
+  const showHost = collisionIds.has(worktree.id)
+  return (
+    <div
+      role="region"
+      aria-labelledby={`${labelIds.name} ${labelIds.path}${showHost ? ` ${labelIds.host}` : ''}`}
+      className="rounded-md border border-border/70 bg-muted/35 px-3 py-2 text-xs"
+    >
+      <div id={labelIds.name} className="break-all font-medium text-foreground">
+        {worktree.displayName}
+      </div>
+      <div id={labelIds.path} className="mt-1 break-all text-muted-foreground">
+        {worktree.path}
+      </div>
+      {showHost ? (
+        <div id={labelIds.host} className="mt-0.5 text-muted-foreground">
+          {getTargetHostLabel(worktree, hostLabelById)}
         </div>
       ) : null}
       <DeleteWorktreeDirtyChangeHint
@@ -82,5 +140,5 @@ export function DeleteWorktreeTargetPreview({
         )}
       />
     </div>
-  ) : null
+  )
 }

--- a/src/renderer/src/components/sidebar/DeleteWorktreeTargetPreview.tsx
+++ b/src/renderer/src/components/sidebar/DeleteWorktreeTargetPreview.tsx
@@ -40,6 +40,7 @@ export function DeleteWorktreeTargetPreview({
   isBatchDelete,
   worktree,
   worktrees,
+  collisionWorktrees,
   hostLabelById,
   deleteStateByWorktreeId,
   dirtyChangeCountsByWorktreeId
@@ -47,12 +48,13 @@ export function DeleteWorktreeTargetPreview({
   isBatchDelete: boolean
   worktree: Worktree | null
   worktrees: readonly Worktree[]
+  collisionWorktrees: readonly Worktree[]
   hostLabelById: ReadonlyMap<ExecutionHostId, string>
   deleteStateByWorktreeId: AppState['deleteStateByWorktreeId']
   dirtyChangeCountsByWorktreeId: ReadonlyMap<string, number>
 }): JSX.Element | null {
   const targetIdPrefix = useId()
-  const collisionIds = getCollisionIds(worktrees)
+  const collisionIds = getCollisionIds(collisionWorktrees)
   if (isBatchDelete) {
     return (
       <ScrollArea className="max-h-48 rounded-md border border-border/70 bg-muted/35 text-xs">


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​173 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​172 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​92 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​81 |

<!-- /orca-pr-loc -->

## ELI5

If you batch-delete and two of the rows are the same workspace on two different machines, they showed the same name and the same path with nothing to tell them apart. Now each names its machine.

## What

`DeleteWorktreeTargetPreview` renders the execution host per row, gated on the batch actually containing a same-id collision. Covers the batch list and the single-target path.

The label is deliberately **not** unconditional — the sidebar's existing pattern only labels rows when hosts are genuinely mixed, and a chip on every row is noise rather than information.

## Test

Two cases: a same-id collision names both hosts; a batch of distinct ids shows no host label. Mutation-verified — forcing the collision branch off fails the first.
