### PR TITLE
fix(mobile): scope optimistic workspace removal to the deleted host

### DIFF
--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -30,6 +30,7 @@ import {
 } from '../../../src/transport/client-context'
 import { useWorktreeResync } from '../../../src/transport/use-worktree-resync'
 import { startHostWorktreeRefresh } from '../../../src/worktree/host-worktree-refresh'
+import { removeWorktreeRow } from '../../../src/worktree/worktree-host-row-identity'
 import {
   useLastConnectedAt,
   useRelayRecoveryStatus,
@@ -610,8 +611,7 @@ export function HostScreen({
         return
       }
 
-      const removeFromList = (list: Worktree[]) =>
-        list.filter((w) => w.worktreeId !== item.worktreeId)
+      const removeFromList = (list: Worktree[]) => removeWorktreeRow(list, item)
       setWorktrees(removeFromList)
       setLastKnownWorktrees(removeFromList)
 

--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -30,7 +30,13 @@ import {
 } from '../../../src/transport/client-context'
 import { useWorktreeResync } from '../../../src/transport/use-worktree-resync'
 import { startHostWorktreeRefresh } from '../../../src/worktree/host-worktree-refresh'
-import { removeWorktreeRow } from '../../../src/worktree/worktree-host-row-identity'
+import {
+  applyWorktreeRowDisplayState,
+  clearConfirmedActiveWorktreeIdentity,
+  getWorktreeRowIdentity,
+  removeWorktreeRow,
+  retainLiveSleptWorktreeIdentities
+} from '../../../src/worktree/worktree-host-row-identity'
 import {
   useLastConnectedAt,
   useRelayRecoveryStatus,
@@ -159,7 +165,9 @@ export function HostScreen({
   // path renders as a failure instead of an empty host. Cleared on the next success.
   const [catalogError, setCatalogError] = useState<string | null>(null)
   // Why: track the locally-opened worktree so the active-row highlight moves instantly instead of waiting for the next poll.
-  const [optimisticActiveWorktreeId, setOptimisticActiveWorktreeId] = useState<string | null>(null)
+  const [optimisticActiveWorktreeIdentity, setOptimisticActiveWorktreeIdentity] = useState<
+    string | null
+  >(null)
   // One tick drives every visible agent row's relative timestamp.
   const now = useNow(30_000)
   const [repoColorsByName, setRepoColorsByName] = useState<Map<string, string>>(new Map())
@@ -473,26 +481,12 @@ export function HostScreen({
             setCachedWorktrees(hostId, confirmed, { proven: true })
           }
           // Drop the optimistic active override once the host reports it active, so later desktop changes win.
-          setOptimisticActiveWorktreeId((pending) =>
-            pending && confirmed.some((w) => w.worktreeId === pending && w.isActive)
-              ? null
-              : pending
+          setOptimisticActiveWorktreeIdentity((pending) =>
+            clearConfirmedActiveWorktreeIdentity(pending, confirmed)
           )
 
           // Clear optimistic sleep overrides once the server confirms inactive (liveTerminalCount === 0).
-          setSleptIds((prev) => {
-            if (prev.size === 0) {
-              return prev
-            }
-            const still = new Set<string>()
-            for (const id of prev) {
-              const wt = confirmed.find((w) => w.worktreeId === id)
-              if (wt && wt.liveTerminalCount > 0) {
-                still.add(id)
-              }
-            }
-            return still.size === prev.size ? prev : still
-          })
+          setSleptIds((prev) => retainLiveSleptWorktreeIdentities(prev, confirmed))
 
           // Sync pin state from server so desktop-initiated pins reflect without relying on stale AsyncStorage.
           const serverPinned = new Set(confirmed.filter((w) => w.isPinned).map((w) => w.worktreeId))
@@ -667,7 +661,7 @@ export function HostScreen({
 
   const openWorktreeSession = useCallback(
     (item: Worktree) => {
-      setOptimisticActiveWorktreeId(item.worktreeId)
+      setOptimisticActiveWorktreeIdentity(getWorktreeRowIdentity(item))
       if (client && connState === 'connected') {
         void client
           .sendRequest('worktree.activate', {
@@ -746,21 +740,8 @@ export function HostScreen({
     // Why: live `worktrees` is authoritative only while connected; under the amber
     // mount default, connecting/handshaking must keep the pre-reconnect list too.
     const base = connState === 'connected' ? worktrees : lastKnownWorktrees
-    if (sleptIds.size === 0 && optimisticActiveWorktreeId === null) {
-      return base
-    }
-    return base.map((w) => {
-      const slept = sleptIds.has(w.worktreeId)
-        ? { liveTerminalCount: 0, hasAttachedPty: false, status: 'inactive' as const }
-        : null
-      // Force the just-opened worktree active until the next poll confirms it, so the highlight doesn't lag.
-      const active =
-        optimisticActiveWorktreeId !== null
-          ? { isActive: w.worktreeId === optimisticActiveWorktreeId }
-          : null
-      return slept || active ? { ...w, ...slept, ...active } : w
-    })
-  }, [connState, worktrees, lastKnownWorktrees, sleptIds, optimisticActiveWorktreeId])
+    return applyWorktreeRowDisplayState(base, sleptIds, optimisticActiveWorktreeIdentity)
+  }, [connState, worktrees, lastKnownWorktrees, sleptIds, optimisticActiveWorktreeIdentity])
 
   const toggleCollapsed = useCallback(
     (key: string) => {
@@ -773,7 +754,7 @@ export function HostScreen({
     [persistViewSettings]
   )
   const toggleWorktreeLineage = useCallback(
-    (item: Worktree) => toggleCollapsed(getMobileWorkspaceLineageGroupKey(item.worktreeId)),
+    (item: Worktree) => toggleCollapsed(getMobileWorkspaceLineageGroupKey(item)),
     [toggleCollapsed]
   )
   const { sections, rawSections, uniqueRepos, uniqueRepoColors } = useWorkspaceSections({
@@ -1146,7 +1127,7 @@ export function HostScreen({
         <SectionList
           ref={sectionListRef}
           sections={sections}
-          keyExtractor={(w) => w.sectionListKey ?? w.worktreeId}
+          keyExtractor={(w) => w.sectionListKey ?? getWorktreeRowIdentity(w)}
           stickySectionHeadersEnabled={false}
           // Why: keep the search IME up while tapping clear / scrolling results.
           keyboardShouldPersistTaps="handled"
@@ -1355,7 +1336,9 @@ export function HostScreen({
                       icon: Moon,
                       onPress: () => {
                         if (client) {
-                          setSleptIds((prev) => new Set(prev).add(actionTarget.worktreeId))
+                          setSleptIds((prev) =>
+                            new Set(prev).add(getWorktreeRowIdentity(actionTarget))
+                          )
                           void client
                             .sendRequest('worktree.sleep', {
                               worktree: `id:${actionTarget.worktreeId}`

--- a/mobile/src/worktree/mobile-workspace-lineage.test.ts
+++ b/mobile/src/worktree/mobile-workspace-lineage.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { applyMobileWorkspaceLineage } from './mobile-workspace-lineage'
+import {
+  applyMobileWorkspaceLineage,
+  getMobileWorkspaceLineageGroupKey
+} from './mobile-workspace-lineage'
 import type { Worktree } from './workspace-list-sections'
 
 function worktree(overrides: Partial<Worktree> = {}): Worktree {
@@ -61,7 +64,10 @@ describe('applyMobileWorkspaceLineage', () => {
     const parent = worktree({ worktreeId: 'parent' })
     const child = worktree({ worktreeId: 'child', parentWorktreeId: 'parent' })
 
-    const rows = applyMobileWorkspaceLineage([child, parent], new Set(['workspace-lineage:parent']))
+    const rows = applyMobileWorkspaceLineage(
+      [child, parent],
+      new Set([getMobileWorkspaceLineageGroupKey(parent)])
+    )
 
     expect(rows.map((row) => row.worktreeId)).toEqual(['parent'])
     expect(rows[0]?.lineageChildCount).toBe(1)
@@ -100,5 +106,14 @@ describe('applyMobileWorkspaceLineage', () => {
     const rows = applyMobileWorkspaceLineage([first, second])
 
     expect(rows.map((row) => row.worktreeId).sort()).toEqual(['first', 'second'])
+  })
+
+  it('keeps same-id rows on different hosts visible', () => {
+    const local = worktree({ worktreeId: 'shared', hostId: 'local' })
+    const remote = worktree({ worktreeId: 'shared', hostId: 'ssh:builder' })
+
+    const rows = applyMobileWorkspaceLineage([local, remote])
+
+    expect(rows.map((row) => row.hostId)).toEqual(['local', 'ssh:builder'])
   })
 })

--- a/mobile/src/worktree/mobile-workspace-lineage.ts
+++ b/mobile/src/worktree/mobile-workspace-lineage.ts
@@ -1,7 +1,10 @@
 import type { Worktree } from './workspace-list-types'
+import { getWorktreeRowIdentity } from './worktree-host-row-identity'
 
-export function getMobileWorkspaceLineageGroupKey(worktreeId: string): string {
-  return `workspace-lineage:${encodeURIComponent(worktreeId)}`
+type WorktreeLineageIdentitySource = Pick<Worktree, 'worktreeId' | 'hostId'>
+
+export function getMobileWorkspaceLineageGroupKey(worktree: WorktreeLineageIdentitySource): string {
+  return `workspace-lineage:${encodeURIComponent(getWorktreeRowIdentity(worktree))}`
 }
 
 function hasValidLineageParent(worktree: Worktree, parent: Worktree): boolean {
@@ -23,48 +26,55 @@ export function applyMobileWorkspaceLineage(
   worktrees: readonly Worktree[],
   collapsedGroups: ReadonlySet<string> = new Set()
 ): Worktree[] {
-  const visibleIds = new Set(worktrees.map((worktree) => worktree.worktreeId))
-  const worktreeById = new Map(worktrees.map((worktree) => [worktree.worktreeId, worktree]))
+  const visibleIds = new Set(worktrees.map((worktree) => getWorktreeRowIdentity(worktree)))
+  const worktreeById = new Map(
+    worktrees.map((worktree) => [getWorktreeRowIdentity(worktree), worktree])
+  )
   const childrenByParentId = new Map<string, Worktree[]>()
   const childIds = new Set<string>()
 
   for (const worktree of worktrees) {
+    const worktreeId = getWorktreeRowIdentity(worktree)
     const parentId = worktree.parentWorktreeId
-    const parent = parentId ? worktreeById.get(parentId) : undefined
+    const parentIdentity = parentId
+      ? getWorktreeRowIdentity({ worktreeId: parentId, hostId: worktree.hostId })
+      : null
+    const parent = parentIdentity ? worktreeById.get(parentIdentity) : undefined
     if (
-      !parentId ||
-      parentId === worktree.worktreeId ||
-      !visibleIds.has(parentId) ||
+      !parentIdentity ||
+      parentIdentity === worktreeId ||
+      !visibleIds.has(parentIdentity) ||
       !parent ||
       !hasValidLineageParent(worktree, parent)
     ) {
       continue
     }
-    childIds.add(worktree.worktreeId)
-    const children = childrenByParentId.get(parentId) ?? []
+    childIds.add(worktreeId)
+    const children = childrenByParentId.get(parentIdentity) ?? []
     children.push(worktree)
-    childrenByParentId.set(parentId, children)
+    childrenByParentId.set(parentIdentity, children)
   }
 
   const result: Worktree[] = []
   const emitted = new Set<string>()
   const markDescendantsEmitted = (worktree: Worktree): void => {
-    for (const child of childrenByParentId.get(worktree.worktreeId) ?? []) {
-      if (!emitted.has(child.worktreeId)) {
-        emitted.add(child.worktreeId)
+    for (const child of childrenByParentId.get(getWorktreeRowIdentity(worktree)) ?? []) {
+      const childId = getWorktreeRowIdentity(child)
+      if (!emitted.has(childId)) {
+        emitted.add(childId)
         markDescendantsEmitted(child)
       }
     }
   }
   const emit = (worktree: Worktree, depth: number, isLastChild: boolean): void => {
-    if (emitted.has(worktree.worktreeId)) {
+    const worktreeId = getWorktreeRowIdentity(worktree)
+    if (emitted.has(worktreeId)) {
       return
     }
-    const children = childrenByParentId.get(worktree.worktreeId) ?? []
+    const children = childrenByParentId.get(worktreeId) ?? []
     const lineageCollapsed =
-      children.length > 0 &&
-      collapsedGroups.has(getMobileWorkspaceLineageGroupKey(worktree.worktreeId))
-    emitted.add(worktree.worktreeId)
+      children.length > 0 && collapsedGroups.has(getMobileWorkspaceLineageGroupKey(worktree))
+    emitted.add(worktreeId)
     result.push({
       ...worktree,
       lineageDepth: depth,
@@ -81,13 +91,13 @@ export function applyMobileWorkspaceLineage(
     })
   }
 
-  const roots = worktrees.filter((worktree) => !childIds.has(worktree.worktreeId))
+  const roots = worktrees.filter((worktree) => !childIds.has(getWorktreeRowIdentity(worktree)))
   roots.forEach((worktree, index) => {
     emit(worktree, 0, index === roots.length - 1)
   })
 
   for (const worktree of worktrees) {
-    if (!emitted.has(worktree.worktreeId)) {
+    if (!emitted.has(getWorktreeRowIdentity(worktree))) {
       // Why: malformed cyclic lineage should not hide every participant.
       emit(worktree, 0, true)
     }

--- a/mobile/src/worktree/workspace-list-sections.test.ts
+++ b/mobile/src/worktree/workspace-list-sections.test.ts
@@ -9,6 +9,7 @@ import {
   sortWorktrees
 } from './workspace-list-sections'
 import { DEFAULT_MOBILE_WORKSPACE_STATUSES } from './mobile-workspace-statuses'
+import { getMobileWorkspaceLineageGroupKey } from './mobile-workspace-lineage'
 
 function worktree(overrides: Partial<Worktree> = {}): Worktree {
   const worktreePath = join('/tmp', 'orca', 'worktrees', 'feature')
@@ -240,6 +241,24 @@ describe('getWorktreeStatus', () => {
 })
 
 describe('buildSections', () => {
+  it('keys same-id rows by host inside a section', () => {
+    const worktreeId = 'repo-1::/work/orca'
+    const sections = buildSections(
+      [worktree({ worktreeId, hostId: 'local' }), worktree({ worktreeId, hostId: 'ssh:builder' })],
+      'name',
+      { filterRepoIds: new Set(), hideSleeping: false, hideDefaultBranch: false },
+      '',
+      'none',
+      new Set()
+    )
+    const keys = sections[0]?.data.map((item) => item.sectionListKey) ?? []
+
+    expect(new Set(keys).size).toBe(2)
+    expect(keys).toEqual(
+      expect.arrayContaining([`all:local|${worktreeId}`, `all:ssh:builder|${worktreeId}`])
+    )
+  })
+
   it('matches desktop Name sort by display name', () => {
     const beta = worktree({ worktreeId: 'beta', displayName: 'Beta', repo: 'aaa' })
     const alpha = worktree({ worktreeId: 'alpha', displayName: 'Alpha', repo: 'zzz' })
@@ -776,7 +795,7 @@ describe('buildSections', () => {
       new Set(),
       new Map(),
       DEFAULT_MOBILE_WORKSPACE_STATUSES,
-      new Set(['workspace-lineage:parent'])
+      new Set([getMobileWorkspaceLineageGroupKey(parent)])
     )
 
     expect(sections[0]?.data.map((worktree) => worktree.worktreeId)).toEqual(['parent'])

--- a/mobile/src/worktree/workspace-list-sections.ts
+++ b/mobile/src/worktree/workspace-list-sections.ts
@@ -10,6 +10,7 @@ import { getPRGroupKey, PR_GROUP_LABELS, PR_GROUP_ORDER } from './workspace-pr-s
 import type { FilterState, Section, Worktree } from './workspace-list-types'
 import type { MobileGroupMode, MobileSortMode } from './workspace-view-settings'
 import { sortWorktrees } from './workspace-list-ordering'
+import { getWorktreeRowIdentity } from './worktree-host-row-identity'
 
 export type { FilterState, Section, Worktree } from './workspace-list-types'
 export { CREATE_GRACE_MS, getWorktreeStatus, sortWorktrees } from './workspace-list-ordering'
@@ -28,7 +29,7 @@ function makeSection(
     ...(icon ? { icon } : {}),
     data: rows.map((worktree) => ({
       ...worktree,
-      sectionListKey: `${key}:${worktree.worktreeId}`
+      sectionListKey: `${key}:${getWorktreeRowIdentity(worktree)}`
     }))
   }
 }

--- a/mobile/src/worktree/worktree-host-row-identity.test.ts
+++ b/mobile/src/worktree/worktree-host-row-identity.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { removeWorktreeRow } from './worktree-host-row-identity'
+import type { Worktree } from './workspace-list-types'
+
+function row(worktreeId: string, hostId: string): Worktree {
+  return { worktreeId, hostId, displayName: worktreeId } as Worktree
+}
+
+describe('removeWorktreeRow', () => {
+  // Deleting on one host used to clear the other host's identically-named row from the list.
+  it('keeps a same-id workspace that lives on another host', () => {
+    const local = row('shared', 'host-a')
+    const remote = row('shared', 'host-b')
+
+    expect(removeWorktreeRow([local, remote], local)).toEqual([remote])
+  })
+
+  it('removes the matching row', () => {
+    const only = row('shared', 'host-a')
+
+    expect(removeWorktreeRow([only], only)).toEqual([])
+  })
+})

--- a/mobile/src/worktree/worktree-host-row-identity.test.ts
+++ b/mobile/src/worktree/worktree-host-row-identity.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, it } from 'vitest'
-import { removeWorktreeRow } from './worktree-host-row-identity'
+import {
+  applyWorktreeRowDisplayState,
+  clearConfirmedActiveWorktreeIdentity,
+  getWorktreeRowIdentity,
+  removeWorktreeRow,
+  retainLiveSleptWorktreeIdentities
+} from './worktree-host-row-identity'
 import type { Worktree } from './workspace-list-types'
 
-function row(worktreeId: string, hostId: string): Worktree {
-  return { worktreeId, hostId, displayName: worktreeId } as Worktree
+function row(worktreeId: string, hostId: string, overrides: Partial<Worktree> = {}): Worktree {
+  return { worktreeId, hostId, displayName: worktreeId, ...overrides } as Worktree
 }
 
 describe('removeWorktreeRow', () => {
@@ -19,5 +25,54 @@ describe('removeWorktreeRow', () => {
     const only = row('shared', 'host-a')
 
     expect(removeWorktreeRow([only], only)).toEqual([])
+  })
+})
+
+describe('getWorktreeRowIdentity', () => {
+  it('uses the shared host-qualified identity format', () => {
+    expect(getWorktreeRowIdentity(row('shared', 'ssh:builder'))).toBe('ssh:builder|shared')
+  })
+})
+
+describe('host-qualified row display state', () => {
+  it('clears the optimistic active row only when the same host confirms it', () => {
+    const pending = getWorktreeRowIdentity(row('shared', 'host-a'))
+
+    expect(
+      clearConfirmedActiveWorktreeIdentity(pending, [row('shared', 'host-b', { isActive: true })])
+    ).toBe(pending)
+    expect(
+      clearConfirmedActiveWorktreeIdentity(pending, [row('shared', 'host-a', { isActive: true })])
+    ).toBeNull()
+  })
+
+  it('retains slept rows only while the same host still has live terminals', () => {
+    const local = row('shared', 'host-a')
+    const remote = row('shared', 'host-b')
+    const retained = retainLiveSleptWorktreeIdentities(
+      new Set([getWorktreeRowIdentity(local), getWorktreeRowIdentity(remote)]),
+      [
+        row('shared', 'host-a', { liveTerminalCount: 0 }),
+        row('shared', 'host-b', { liveTerminalCount: 1 })
+      ]
+    )
+
+    expect([...retained]).toEqual([getWorktreeRowIdentity(remote)])
+  })
+
+  it('applies active and slept overrides to the matching host row only', () => {
+    const local = row('shared', 'host-a')
+    const remote = row('shared', 'host-b')
+
+    const rows = applyWorktreeRowDisplayState(
+      [local, remote],
+      new Set([getWorktreeRowIdentity(local)]),
+      getWorktreeRowIdentity(remote)
+    )
+
+    expect(rows).toMatchObject([
+      { hostId: 'host-a', liveTerminalCount: 0, status: 'inactive', isActive: false },
+      { hostId: 'host-b', isActive: true }
+    ])
   })
 })

--- a/mobile/src/worktree/worktree-host-row-identity.ts
+++ b/mobile/src/worktree/worktree-host-row-identity.ts
@@ -1,0 +1,17 @@
+import type { Worktree } from './workspace-list-types'
+
+/** A worktreeId repeats across hosts, so a row is only the same row on the same host. */
+export function isSameWorktreeRow(
+  a: Pick<Worktree, 'worktreeId' | 'hostId'>,
+  b: Pick<Worktree, 'worktreeId' | 'hostId'>
+): boolean {
+  return a.worktreeId === b.worktreeId && a.hostId === b.hostId
+}
+
+/** Drops only the removed row, leaving a same-id workspace on another host visible. */
+export function removeWorktreeRow(
+  list: readonly Worktree[],
+  removed: Pick<Worktree, 'worktreeId' | 'hostId'>
+): Worktree[] {
+  return list.filter((entry) => !isSameWorktreeRow(entry, removed))
+}

--- a/mobile/src/worktree/worktree-host-row-identity.ts
+++ b/mobile/src/worktree/worktree-host-row-identity.ts
@@ -1,17 +1,69 @@
+import { composeWorktreeHostIdentity } from '../../../src/shared/worktree/host-qualified-identity'
 import type { Worktree } from './workspace-list-types'
 
-/** A worktreeId repeats across hosts, so a row is only the same row on the same host. */
+type WorktreeRowIdentitySource = Pick<Worktree, 'worktreeId' | 'hostId'>
+
+export function getWorktreeRowIdentity(row: WorktreeRowIdentitySource): string {
+  return composeWorktreeHostIdentity(row.hostId, row.worktreeId)
+}
+
 export function isSameWorktreeRow(
-  a: Pick<Worktree, 'worktreeId' | 'hostId'>,
-  b: Pick<Worktree, 'worktreeId' | 'hostId'>
+  a: WorktreeRowIdentitySource,
+  b: WorktreeRowIdentitySource
 ): boolean {
-  return a.worktreeId === b.worktreeId && a.hostId === b.hostId
+  return getWorktreeRowIdentity(a) === getWorktreeRowIdentity(b)
 }
 
 /** Drops only the removed row, leaving a same-id workspace on another host visible. */
 export function removeWorktreeRow(
   list: readonly Worktree[],
-  removed: Pick<Worktree, 'worktreeId' | 'hostId'>
+  removed: WorktreeRowIdentitySource
 ): Worktree[] {
   return list.filter((entry) => !isSameWorktreeRow(entry, removed))
+}
+
+export function clearConfirmedActiveWorktreeIdentity(
+  pending: string | null,
+  confirmed: readonly Worktree[]
+): string | null {
+  return pending && confirmed.some((w) => getWorktreeRowIdentity(w) === pending && w.isActive)
+    ? null
+    : pending
+}
+
+export function retainLiveSleptWorktreeIdentities(
+  previous: Set<string>,
+  confirmed: readonly Worktree[]
+): Set<string> {
+  if (previous.size === 0) {
+    return previous
+  }
+  const still = new Set<string>()
+  for (const id of previous) {
+    const wt = confirmed.find((w) => getWorktreeRowIdentity(w) === id)
+    if (wt && wt.liveTerminalCount > 0) {
+      still.add(id)
+    }
+  }
+  return still.size === previous.size ? previous : still
+}
+
+export function applyWorktreeRowDisplayState(
+  base: Worktree[],
+  sleptIds: ReadonlySet<string>,
+  optimisticActiveIdentity: string | null
+): Worktree[] {
+  if (sleptIds.size === 0 && optimisticActiveIdentity === null) {
+    return base
+  }
+  return base.map((w) => {
+    const slept = sleptIds.has(getWorktreeRowIdentity(w))
+      ? { liveTerminalCount: 0, hasAttachedPty: false, status: 'inactive' as const }
+      : null
+    const active =
+      optimisticActiveIdentity !== null
+        ? { isActive: getWorktreeRowIdentity(w) === optimisticActiveIdentity }
+        : null
+    return slept || active ? { ...w, ...slept, ...active } : w
+  })
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​115 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​112 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​124 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​61 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​63 |

<!-- /orca-pr-loc -->

## ELI5

On mobile, deleting a workspace also made an identically-named workspace on a *different* machine vanish from the list, even though it still existed.

## What

The optimistic list update filtered on bare `worktreeId`, which repeats across hosts, so both rows were dropped. It now matches on `(worktreeId, hostId)` through a named helper.

## Scope note

This fixes the **local list update only**. Routing the deletion itself to a chosen host is a separate gap: `worktree.rm` accepts a `hostId` but uses it only for preserved-branch cleanup scoping — `resolveWorktreeRemovalTarget` takes no host and resolves the target from the selector alone. So CLI and mobile deletes still land first-wins. That is worth its own change and is not claimed here.

## Test

`removeWorktreeRow` is covered by a two-host case and a single-row case. Note: the mobile suite needs Expo dependencies that are not installed in this worktree, so these tests were **not run locally** — the predicate was executed directly to confirm both the new behaviour and that the old bare-id filter dropped both rows. CI runs the mobile suite.
