### PR TITLE
fix(tests): worktree-shared-directories fails on Windows — os.devNull is not a valid git config path (#15409)

### DIFF
--- a/src/main/git/worktree-shared-directories.test.ts
+++ b/src/main/git/worktree-shared-directories.test.ts
@@ -1,8 +1,8 @@
 import { execFileSync } from 'node:child_process'
 import { lstatSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
-import { devNull, tmpdir } from 'node:os'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   clearConfiguredWorktreeSharedDirectoriesCacheForTests,
   getConfiguredWorktreeSharedDirectories,
@@ -16,14 +16,25 @@ import {
 import { assertWorktreeCleanForRemoval } from './worktree'
 import { getStatus } from './status'
 
+// Isolate git config with real empty files. os.devNull resolves to a
+// Windows device path Git rejects as a config path ("fatal: unable to
+// access '//./nul': Invalid argument") — every git call in this file
+// failed on Windows while CI's Linux/macOS runners accepted /dev/null
+// and stayed green (#15409).
+const configDir = mkdtempSync(join(tmpdir(), 'orca-git-config-'))
+const emptyGlobalConfig = join(configDir, 'global.gitconfig')
+const emptySystemConfig = join(configDir, 'system.gitconfig')
+writeFileSync(emptyGlobalConfig, '')
+writeFileSync(emptySystemConfig, '')
+
 const git = (args: string[], cwd: string): void => {
   execFileSync('git', args, {
     cwd,
     stdio: 'ignore',
     env: {
       ...process.env,
-      GIT_CONFIG_GLOBAL: devNull,
-      GIT_CONFIG_SYSTEM: devNull
+      GIT_CONFIG_GLOBAL: emptyGlobalConfig,
+      GIT_CONFIG_SYSTEM: emptySystemConfig
     }
   })
 }
@@ -50,8 +61,12 @@ describe('resolveWorktreeSharedDirectories', () => {
   })
 
   afterEach(() => {
-    warn.mockRestore()
-    rmSync(repo, { recursive: true, force: true })
+    warn?.mockRestore?.()
+    if (repo) rmSync(repo, { recursive: true, force: true })
+  })
+
+  afterAll(() => {
+    rmSync(configDir, { recursive: true, force: true })
   })
 
   it('returns gitignored directories listed under worktree.sharedDirectories', async () => {


### PR DESCRIPTION
Closes #15409.

## The breakage, per the issue's isolation table

The file's git helper pointed `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` at `os.devNull` to isolate config. On Windows that constant is a device path (`\\.\nul`) which Git for Windows normalizes to `//./nul` and **rejects** — `fatal: unable to access '//./nul': Invalid argument` — so every `git` call in the file failed and **15 of its 19 tests went red**. On Linux/macOS the same constant is `/dev/null`, which Git accepts, so CI stayed green and hid the breakage since the file landed (#10459).

## The fix

The two variables now point at **real empty files in a temp directory** — the approach the issue notes other suites already use, valid on every platform and Git version. The `afterEach` also guards the `warn.mockRestore()`/repo teardown that threw the secondary `TypeError: Cannot read properties of undefined (reading 'mockRestore')` whenever `beforeEach` died at its first `git` call, plus an `afterAll` cleans the config dir.

## Verification

Run on the exact platform that was broken — Windows 11 + Git for Windows (the issue's repro command): **19/19 passing** where 15 previously failed.