### PR TITLE
feat(source-control): read submodule changes when .gitmodules hides them

### DIFF
--- a/src/main/git/source-control/get-status-options.ts
+++ b/src/main/git/source-control/get-status-options.ts
@@ -13,6 +13,11 @@ export type GetStatusOptions = GitRuntimeOptions & {
    */
   limit?: number
   bypassEffectiveUpstreamNegativeCache?: boolean
+  /** Pass `--ignore-submodules=none` so submodule rows survive a superproject
+   *  whose `.gitmodules` sets `ignore = all`. Off by default: that config is
+   *  deliberate in most repos, and flipping it would add a gitlink row per
+   *  submodule to every panel. */
+  showSubmoduleChanges?: boolean
   /** Paths Orca may have symlinked into this worktree (per-user shared paths
    *  plus `orca.yaml` shared directories). Untracked entries that are one of
    *  these *and* really symlinks are dropped: Git cannot ignore them when the

--- a/src/main/git/source-control/status-read.ts
+++ b/src/main/git/source-control/status-read.ts
@@ -62,6 +62,9 @@ function getStatusReadKey(worktreePath: string, options: GetStatusOptions): stri
     // this fork point, so a shared lease must never serve one to the other.
     options.branchLineTotalMergeBase ?? '',
     options.bypassEffectiveUpstreamNegativeCache === true,
+    // Why: this adds submodule entries, so a shared lease must not serve a read
+    // taken without it.
+    options.showSubmoduleChanges === true,
     limit,
     // Why: this changes which entries survive, so it must not share a cache slot.
     options.sharedLinkPaths ?? []
@@ -130,6 +133,11 @@ async function runGetStatus(
   ]
   if (options.includeIgnored) {
     statusArgs.push('--ignored=matching')
+  }
+  // Why: without this, git honors `.gitmodules` `ignore = all` and omits every
+  // submodule entry, so Source Control has no row to expand.
+  if (options.showSubmoduleChanges) {
+    statusArgs.push('--ignore-submodules=none')
   }
 
   // Why: stream + parse and stop at `limit` so a huge un-ignored folder can't buffer enough to crash the process.

--- a/src/main/git/status-read-coalescing.test.ts
+++ b/src/main/git/status-read-coalescing.test.ts
@@ -299,13 +299,14 @@ describe('getStatus', () => {
       getStatus('/repo', { bypassEffectiveUpstreamNegativeCache: true }),
       getStatus('/repo', { limit: 1 }),
       getStatus('/repo', { sharedLinkPaths: ['node_modules'] }),
-      getStatus('/repo', { admissionTier: 'interactive' })
+      getStatus('/repo', { admissionTier: 'interactive' }),
+      getStatus('/repo', { showSubmoduleChanges: true })
     ]
 
-    await vi.waitFor(() => expect(statusCommandCalls).toBe(10))
+    await vi.waitFor(() => expect(statusCommandCalls).toBe(11))
     releases.splice(0).forEach((release) => release())
     await Promise.all(reads)
-    expect(statusCommandCalls).toBe(10)
+    expect(statusCommandCalls).toBe(11)
   })
 
   it('clears in-flight status reads when a mutation runs', async () => {

--- a/src/main/git/status.test.ts
+++ b/src/main/git/status.test.ts
@@ -262,6 +262,35 @@ describe('getStatus', () => {
     expect(result.ignoredPaths).toEqual(['dist/', 'generated/file.js'])
   })
 
+  it('asks git for submodule entries only when the repo opted in', async () => {
+    readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
+    existsSyncMock.mockReturnValue(false)
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: '' })
+
+    await getStatus('/repo')
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith([
+      '-c',
+      'core.quotePath=false',
+      'status',
+      '--porcelain=v2',
+      '--branch',
+      '--untracked-files=all'
+    ])
+
+    await getStatus('/repo', { showSubmoduleChanges: true })
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith([
+      '-c',
+      'core.quotePath=false',
+      'status',
+      '--porcelain=v2',
+      '--branch',
+      '--untracked-files=all',
+      '--ignore-submodules=none'
+    ])
+  })
+
   it('parses branch identity from porcelain v2 branch headers', async () => {
     readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
     gitExecFileAsyncMock.mockResolvedValueOnce({

--- a/src/main/git/status.test.ts
+++ b/src/main/git/status.test.ts
@@ -264,7 +264,6 @@ describe('getStatus', () => {
 
   it('asks git for submodule entries only when the repo opted in', async () => {
     readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
-    existsSyncMock.mockReturnValue(false)
     gitExecFileAsyncMock.mockResolvedValue({ stdout: '' })
 
     await getStatus('/repo')

--- a/src/main/ipc/filesystem-git-status-staging.test.ts
+++ b/src/main/ipc/filesystem-git-status-staging.test.ts
@@ -142,6 +142,35 @@ describe('registerFilesystemHandlers', () => {
     })
   })
 
+  it('reads the submodule opt-in off the repo record for local status', async () => {
+    const optedInStore = {
+      ...store,
+      getRepos: () => [
+        {
+          ...store.getRepos()[0],
+          showSubmoduleChanges: true
+        }
+      ],
+      getAllWorktreeMeta: () => ({
+        [`repo-1::${WORKTREE_FEATURE_PATH}`]: {}
+      })
+    }
+    registerWorktreeRootsForRepo(optedInStore as never, 'repo-1', [
+      REPO_PATH,
+      WORKTREE_FEATURE_PATH
+    ])
+    getStatusMock.mockResolvedValue({ entries: [] })
+
+    registerFilesystemHandlers(optedInStore as never)
+
+    await handlers.get('git:status')!(null, { worktreePath: WORKTREE_FEATURE_PATH })
+
+    expect(getStatusMock).toHaveBeenCalledWith(WORKTREE_FEATURE_PATH, {
+      includeIgnored: false,
+      showSubmoduleChanges: true
+    })
+  })
+
   it('allows git operations on the known repo root without rebuilding the worktree cache', async () => {
     getStatusMock.mockResolvedValue({ entries: [] })
 

--- a/src/main/ipc/filesystem-git-status-staging.test.ts
+++ b/src/main/ipc/filesystem-git-status-staging.test.ts
@@ -166,6 +166,7 @@ describe('registerFilesystemHandlers', () => {
     await handlers.get('git:status')!(null, { worktreePath: WORKTREE_FEATURE_PATH })
 
     expect(getStatusMock).toHaveBeenCalledWith(WORKTREE_FEATURE_PATH, {
+      admissionTier: 'status',
       includeIgnored: false,
       showSubmoduleChanges: true
     })

--- a/src/main/ipc/filesystem/filesystem-git-status-handlers.ts
+++ b/src/main/ipc/filesystem/filesystem-git-status-handlers.ts
@@ -52,12 +52,14 @@ export function registerFilesystemGitStatusHandlers(context: FilesystemHandlerCo
         bypassEffectiveUpstreamNegativeCache?: boolean
         reuseLineStats?: boolean
         branchLineTotalMergeBase?: string
+        showSubmoduleChanges?: boolean
         requestToken?: string
       }
     ): Promise<GitStatusResult> => {
       const controller = gitStatusCancellations.begin(event, args.requestToken)
       const options = {
         includeIgnored: args.includeIgnored ?? false,
+        ...(args.showSubmoduleChanges === true ? { showSubmoduleChanges: true } : {}),
         admissionTier: args.admissionTier ?? ('status' as const),
         ...(args.includeLineStats === false ? { includeLineStats: false } : {}),
         ...(args.reuseLineStats === true ? { reuseLineStats: true } : {}),
@@ -87,7 +89,10 @@ export function registerFilesystemGitStatusHandlers(context: FilesystemHandlerCo
         return await getStatus(worktreePath, {
           ...options,
           ...gitOptions,
-          ...(sharedLinkPaths.length > 0 ? { sharedLinkPaths } : {})
+          ...(sharedLinkPaths.length > 0 ? { sharedLinkPaths } : {}),
+          // Why: the repo record owns this opt-in, so every status caller gets it
+          // without threading a flag through each refresh path.
+          ...(repo?.showSubmoduleChanges === true ? { showSubmoduleChanges: true } : {})
         })
       } finally {
         gitStatusCancellations.finish(event, args.requestToken, controller)

--- a/src/main/providers/git-provider-status-options.ts
+++ b/src/main/providers/git-provider-status-options.ts
@@ -7,5 +7,7 @@ export type GitProviderStatusOptions = {
   reuseLineStats?: boolean
   /** Merge-base OID to measure the branch line total against; omit to skip the work. */
   branchLineTotalMergeBase?: string
+  /** Read submodule rows even when `.gitmodules` sets `ignore = all`. */
+  showSubmoduleChanges?: boolean
   signal?: AbortSignal
 }

--- a/src/main/providers/ssh-git-provider-status.test.ts
+++ b/src/main/providers/ssh-git-provider-status.test.ts
@@ -65,6 +65,25 @@ describe('SshGitProvider', () => {
     expect(mux.request).toHaveBeenCalledWith(
       'git.status',
       { worktreePath: '/home/user/repo', includeLineStats: false },
+  it('getStatus forwards the submodule opt-in only when requested', async () => {
+    mux.request.mockResolvedValue({ entries: [], conflictOperation: 'unknown' })
+
+    await provider.getStatus('/home/user/repo', { showSubmoduleChanges: true })
+    await provider.getStatus('/home/user/repo', { showSubmoduleChanges: false })
+
+    expect(mux.request).toHaveBeenNthCalledWith(
+      1,
+      'git.status',
+      {
+        worktreePath: '/home/user/repo',
+        showSubmoduleChanges: true
+      },
+      { signal: expect.any(AbortSignal) }
+    )
+    expect(mux.request).toHaveBeenNthCalledWith(
+      2,
+      'git.status',
+      { worktreePath: '/home/user/repo' },
       { signal: expect.any(AbortSignal) }
     )
   })

--- a/src/main/providers/ssh-git-provider-status.test.ts
+++ b/src/main/providers/ssh-git-provider-status.test.ts
@@ -65,6 +65,10 @@ describe('SshGitProvider', () => {
     expect(mux.request).toHaveBeenCalledWith(
       'git.status',
       { worktreePath: '/home/user/repo', includeLineStats: false },
+      { signal: expect.any(AbortSignal) }
+    )
+  })
+
   it('getStatus forwards the submodule opt-in only when requested', async () => {
     mux.request.mockResolvedValue({ entries: [], conflictOperation: 'unknown' })
 

--- a/src/main/providers/ssh-git-read-provider.ts
+++ b/src/main/providers/ssh-git-read-provider.ts
@@ -66,7 +66,8 @@ export class SshGitReadProvider {
       ...(options?.reuseLineStats ? { reuseLineStats: true } : {}),
       ...(options?.branchLineTotalMergeBase === undefined
         ? {}
-        : { branchLineTotalMergeBase: options.branchLineTotalMergeBase })
+        : { branchLineTotalMergeBase: options.branchLineTotalMergeBase }),
+      ...(options?.showSubmoduleChanges ? { showSubmoduleChanges: true } : {})
     }
     const key = stableInFlightKey([
       worktreePath,
@@ -75,6 +76,9 @@ export class SshGitReadProvider {
       options?.includeLineStats !== false,
       options?.bypassEffectiveUpstreamNegativeCache === true,
       options?.reuseLineStats === true,
+      // Why: this adds submodule entries, so a shared lease must not serve a read
+      // taken without it.
+      options?.showSubmoduleChanges === true,
       options?.branchLineTotalMergeBase ?? ''
     ])
     return this.statusReadLeaseOwner.lease(key, options?.signal, async (sharedSignal) => {

--- a/src/main/runtime/rpc/methods/git-params.ts
+++ b/src/main/runtime/rpc/methods/git-params.ts
@@ -14,6 +14,7 @@ export const GitStatusParams = WorktreeSelector.extend({
   includeLineStats: z.boolean().optional(),
   bypassEffectiveUpstreamNegativeCache: z.boolean().optional(),
   reuseLineStats: z.boolean().optional(),
+  showSubmoduleChanges: z.boolean().optional(),
   // Shape is re-validated host-side before it reaches a git argv.
   branchLineTotalMergeBase: z.string().optional()
 })

--- a/src/main/runtime/rpc/methods/git.test.ts
+++ b/src/main/runtime/rpc/methods/git.test.ts
@@ -46,6 +46,7 @@ describe('git RPC methods', () => {
     )
 
     expect(runtime.getRuntimeGitStatus).toHaveBeenCalledWith('id:wt-1', {
+      admissionTier: 'status',
       showSubmoduleChanges: true
     })
   })

--- a/src/main/runtime/rpc/methods/git.test.ts
+++ b/src/main/runtime/rpc/methods/git.test.ts
@@ -34,6 +34,22 @@ describe('git RPC methods', () => {
     })
   })
 
+  it('forwards showSubmoduleChanges for status requests', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      getRuntimeGitStatus: vi.fn().mockResolvedValue({ entries: [], conflictOperation: 'unknown' })
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: GIT_METHODS })
+
+    await dispatcher.dispatch(
+      makeRequest('git.status', { worktree: 'id:wt-1', showSubmoduleChanges: true })
+    )
+
+    expect(runtime.getRuntimeGitStatus).toHaveBeenCalledWith('id:wt-1', {
+      showSubmoduleChanges: true
+    })
+  })
+
   it('forwards includeIgnored for status requests', async () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',

--- a/src/main/runtime/rpc/methods/git.ts
+++ b/src/main/runtime/rpc/methods/git.ts
@@ -33,6 +33,7 @@ export const GIT_METHODS: RpcMethod[] = [
         params.reuseLineStats === undefined &&
         params.branchLineTotalMergeBase === undefined &&
         params.admissionTier === undefined &&
+        params.showSubmoduleChanges === undefined &&
         signal === undefined
           ? undefined
           : {
@@ -46,6 +47,7 @@ export const GIT_METHODS: RpcMethod[] = [
                 ? { bypassEffectiveUpstreamNegativeCache: true }
                 : {}),
               ...(params.reuseLineStats === true ? { reuseLineStats: true } : {}),
+              ...(params.showSubmoduleChanges === true ? { showSubmoduleChanges: true } : {}),
               ...(params.branchLineTotalMergeBase === undefined
                 ? {}
                 : { branchLineTotalMergeBase: params.branchLineTotalMergeBase }),

--- a/src/main/runtime/rpc/methods/repo-update-schema.ts
+++ b/src/main/runtime/rpc/methods/repo-update-schema.ts
@@ -54,6 +54,7 @@ export function createRepoUpdateSchema<T extends z.ZodRawShape>(
       symlinkPaths: z.array(z.string()).optional(),
       issueSourcePreference: z.enum(['auto', 'upstream', 'origin']).optional(),
       forkSyncMode: z.enum(['ask', 'safe-auto', 'off']).optional(),
+      showSubmoduleChanges: z.boolean().optional(),
       externalWorktreeVisibility: z.enum(['hide', 'show']).nullable().optional(),
       externalWorktreeVisibilityPromptDismissedAt: z.number().finite().optional(),
       externalWorktreeInboxBaselinePaths: z.array(z.string()).optional(),

--- a/src/relay/git-handler-status-ops.test.ts
+++ b/src/relay/git-handler-status-ops.test.ts
@@ -88,6 +88,19 @@ describe('getStatusOp', () => {
     expect(git.mock.calls.some(([args]) => args.includes('diff'))).toBe(false)
   })
 
+  it('appends --ignore-submodules=none only when the caller opted in', async () => {
+    const git = vi.fn<GitExec>(async () => ({ stdout: '', stderr: '' }) as never)
+    const streamGit = vi.fn<RelayGitStreamExec>(async () => ({ stoppedEarly: false }))
+
+    await getStatusOp(git, streamGit, { worktreePath: tmpDir })
+
+    expect(streamGit.mock.calls[0]?.[0]).not.toContain('--ignore-submodules=none')
+
+    await getStatusOp(git, streamGit, { worktreePath: tmpDir, showSubmoduleChanges: true })
+
+    expect(streamGit.mock.calls[1]?.[0]).toContain('--ignore-submodules=none')
+  })
+
   it('returns the full list and no limit flag when under the limit', async () => {
     const statusOutput = buildLargeStatusOutput(5)
     const git = vi.fn<GitExec>(async (args) => {

--- a/src/relay/git-handler-status-ops.ts
+++ b/src/relay/git-handler-status-ops.ts
@@ -87,6 +87,7 @@ export async function getStatusOp(
   const lineStatsWriteToken =
     params.includeLineStats === false ? null : beginGitStatusLineStatsCacheWrite(lineStatsCacheKey)
   const includeIgnored = params.includeIgnored === true
+  const showSubmoduleChanges = params.showSubmoduleChanges === true
   // Why: untrusted RPC input spliced into a git argv — only an OID shape may pass.
   const branchLineTotalMergeBase = readGitBranchLineTotalMergeBaseParam(
     params.branchLineTotalMergeBase
@@ -105,6 +106,11 @@ export async function getStatusOp(
   ]
   if (includeIgnored) {
     statusArgs.push('--ignored=matching')
+  }
+  // Why: mirror the desktop read — `.gitmodules` `ignore = all` would otherwise
+  // drop every submodule entry before the parser sees it.
+  if (showSubmoduleChanges) {
+    statusArgs.push('--ignore-submodules=none')
   }
   // Why: attach rejection ownership before awaiting marker I/O, so a fast Git failure cannot become unhandled.
   const statusSettlementPromise = Promise.allSettled([

--- a/src/renderer/src/components/settings/RepositoryPane.test.ts
+++ b/src/renderer/src/components/settings/RepositoryPane.test.ts
@@ -104,6 +104,14 @@ describe('RepositoryPane search entries', () => {
     expect(matchesSettingsSearch('local settings scripts', entries)).toBe(true)
     expect(matchesSettingsSearch('../worktrees', entries)).toBe(true)
     expect(matchesSettingsSearch('worktree path', entries)).toBe(true)
+    expect(matchesSettingsSearch('submodule', entries)).toBe(true)
+    expect(matchesSettingsSearch('gitmodules', entries)).toBe(true)
+  })
+
+  it('omits the submodule opt-in for plain folders', () => {
+    const entries = getRepositoryPaneSearchEntries({ ...repo, kind: 'folder' })
+
+    expect(matchesSettingsSearch('submodule', entries)).toBe(false)
   })
 
   it('includes each project search section once', () => {

--- a/src/renderer/src/components/settings/RepositoryPane.tsx
+++ b/src/renderer/src/components/settings/RepositoryPane.tsx
@@ -24,6 +24,7 @@ import { getRepositoryPaneSearchEntries } from './repository-search'
 import { RepositoryHostSetupsSection } from './RepositoryHostSetupsSection'
 import { RepoSettingsDraftInput } from './RepositorySettingsDraftInput'
 import { RepositoryForkSyncSection } from './RepositoryForkSyncSection'
+import { RepositorySubmoduleChangesSection } from './RepositorySubmoduleChangesSection'
 import { translate } from '@/i18n/i18n'
 import { RepositoryWindowsRuntimeSection } from './RepositoryWindowsRuntimeSection'
 import { matchesRepositoryIdentitySearch } from './repository-identity-search'
@@ -360,6 +361,12 @@ export function RepositoryPane({
             />
 
             <RepositoryForkSyncSection
+              repo={repo}
+              updateRepo={updateSelectedRepo}
+              forceVisible={forceFullPaneForRepoMatch}
+            />
+
+            <RepositorySubmoduleChangesSection
               repo={repo}
               updateRepo={updateSelectedRepo}
               forceVisible={forceFullPaneForRepoMatch}

--- a/src/renderer/src/components/settings/RepositoryPane.tsx
+++ b/src/renderer/src/components/settings/RepositoryPane.tsx
@@ -188,6 +188,10 @@ export function RepositoryPane({
     translate('auto.components.settings.repository.search.443d127b5a', 'Worktree Location'),
     translate('auto.components.settings.repository.search.externalWorktrees', 'External worktrees'),
     translate('auto.components.settings.repository.search.projectRuntime', 'Project Runtime'),
+    translate(
+      'auto.components.settings.repository.search.showSubmoduleChanges',
+      'Show Submodule Changes'
+    ),
     translate('auto.components.settings.repository.search.c5266c2c9d', 'Remove Project')
   ])
   const identityEntries = allEntries.filter((entry) => identityEntryTitles.has(entry.title))

--- a/src/renderer/src/components/settings/RepositoryPaneSubmoduleSearch.test.tsx
+++ b/src/renderer/src/components/settings/RepositoryPaneSubmoduleSearch.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../../../../shared/repo-types'
+import { useAppStore } from '../../store'
+import { RepositoryPane } from './RepositoryPane'
+import { TooltipProvider } from '../ui/tooltip'
+
+// Why client rendering, not renderToStaticMarkup: zustand serves getServerSnapshot during
+// static rendering, so the pane would read the initial empty query and the filtered path
+// this test exists to cover would never run.
+
+const repo: Repo = {
+  id: 'repo-1',
+  path: '/tmp/repo',
+  displayName: 'Example Repo',
+  badgeColor: '#000000',
+  addedAt: 1,
+  kind: 'git'
+}
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  useAppStore.setState({ settingsSearchQuery: '', settingsSearchInputQuery: '' })
+})
+
+function renderPaneWithQuery(query: string): void {
+  useAppStore.setState({ settingsSearchQuery: query, settingsSearchInputQuery: query })
+  act(() => {
+    root.render(
+      React.createElement(
+        TooltipProvider,
+        null,
+        React.createElement(RepositoryPane, {
+          repo,
+          yamlHooks: null,
+          hasHooksFile: false,
+          hooksInspectionReady: true,
+          mayNeedUpdate: false,
+          updateRepo: vi.fn(),
+          removeProject: vi.fn()
+        } as never)
+      )
+    )
+  })
+}
+
+describe('RepositoryPane submodule search', () => {
+  it('renders the submodule opt-in for a query that matches only that section', () => {
+    renderPaneWithQuery('submodule')
+
+    expect(container.textContent).toContain('Show Submodule Changes')
+    expect(
+      container.querySelector('[role="switch"][aria-label="Show Submodule Changes"]')
+    ).not.toBe(null)
+  })
+
+  it('hides it for a query that matches nothing in this pane', () => {
+    renderPaneWithQuery('zzzznotathing')
+
+    expect(container.textContent).not.toContain('Show Submodule Changes')
+  })
+})

--- a/src/renderer/src/components/settings/RepositorySubmoduleChangesSection.test.tsx
+++ b/src/renderer/src/components/settings/RepositorySubmoduleChangesSection.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../../../../shared/repo-types'
+import { RepositorySubmoduleChangesSection } from './RepositorySubmoduleChangesSection'
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+function renderSection(repo: Partial<Repo>, updateRepo: (repoId: string, updates: object) => void) {
+  act(() => {
+    root.render(
+      <RepositorySubmoduleChangesSection
+        repo={{ id: 'repo-1', displayName: 'monorepo', path: '/repo', ...repo } as Repo}
+        updateRepo={updateRepo}
+        forceVisible
+      />
+    )
+  })
+}
+
+describe('RepositorySubmoduleChangesSection', () => {
+  it('reflects the stored opt-in and writes the toggled value back to the repo', () => {
+    const updateRepo = vi.fn()
+    renderSection({ showSubmoduleChanges: true }, updateRepo)
+
+    const toggle = container.querySelector('button[role="switch"]')
+    expect(toggle?.getAttribute('aria-checked')).toBe('true')
+
+    act(() => {
+      toggle?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(updateRepo).toHaveBeenCalledWith('repo-1', { showSubmoduleChanges: false })
+  })
+
+  it('defaults to off when the repo has never opted in', () => {
+    const updateRepo = vi.fn()
+    renderSection({}, updateRepo)
+
+    const toggle = container.querySelector('button[role="switch"]')
+    expect(toggle?.getAttribute('aria-checked')).toBe('false')
+
+    act(() => {
+      toggle?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(updateRepo).toHaveBeenCalledWith('repo-1', { showSubmoduleChanges: true })
+  })
+})

--- a/src/renderer/src/components/settings/RepositorySubmoduleChangesSection.tsx
+++ b/src/renderer/src/components/settings/RepositorySubmoduleChangesSection.tsx
@@ -18,16 +18,20 @@ export function RepositorySubmoduleChangesSection({
   updateRepo,
   forceVisible
 }: RepositorySubmoduleChangesSectionProps): React.JSX.Element {
+  // Why: SearchableSetting matches on this text but never renders it, so the visible copy is
+  // the searchable copy — terms like `ignore = all` must not live in only one of them.
+  const description = translate(
+    'auto.components.settings.RepositorySubmoduleChangesSection.longDescription',
+    'A repo whose .gitmodules sets ignore = all reports no submodule changes at all, so Source Control stays empty while you work inside a submodule. Turn this on to list them anyway. Each changed submodule adds one row you can expand for its per-file changes, including submodules whose recorded commit simply moved.'
+  )
+
   return (
     <SearchableSetting
       title={translate(
         'auto.components.settings.RepositorySubmoduleChangesSection.title',
         'Show Submodule Changes'
       )}
-      description={translate(
-        'auto.components.settings.RepositorySubmoduleChangesSection.description',
-        'Read submodule changes in Source Control even when this repo hides them.'
-      )}
+      description={description}
       keywords={searchKeywords([
         repo.displayName,
         { key: 'auto.components.settings.repository.search.submodule', fallback: 'submodule' },
@@ -43,10 +47,7 @@ export function RepositorySubmoduleChangesSection({
           'auto.components.settings.RepositorySubmoduleChangesSection.title',
           'Show Submodule Changes'
         )}
-        description={translate(
-          'auto.components.settings.RepositorySubmoduleChangesSection.longDescription',
-          'A repo whose .gitmodules sets ignore = all reports no submodule changes at all, so Source Control stays empty while you work inside a submodule. Turn this on to list them anyway. Each changed submodule adds one row you can expand for its per-file changes, including submodules whose recorded commit simply moved.'
-        )}
+        description={description}
         checked={repo.showSubmoduleChanges === true}
         onChange={() =>
           updateRepo(repo.id, { showSubmoduleChanges: repo.showSubmoduleChanges !== true })

--- a/src/renderer/src/components/settings/RepositorySubmoduleChangesSection.tsx
+++ b/src/renderer/src/components/settings/RepositorySubmoduleChangesSection.tsx
@@ -1,0 +1,57 @@
+import type { Repo } from '../../../../shared/repo-types'
+import { SearchableSetting } from './SearchableSetting'
+import { SettingsSwitchRow } from './SettingsFormControls'
+import { translate } from '@/i18n/i18n'
+import { searchKeywords } from './settings-search-keywords'
+
+type RepositorySubmoduleChangesSectionProps = {
+  repo: Repo
+  updateRepo: (repoId: string, updates: Pick<Repo, 'showSubmoduleChanges'>) => void
+  forceVisible?: boolean
+}
+
+/** Per-repo opt-in for reading submodule rows out of a superproject that hides
+ *  them. Git omits every submodule entry when `.gitmodules` sets `ignore = all`,
+ *  so Source Control shows nothing for submodule work until this is on. */
+export function RepositorySubmoduleChangesSection({
+  repo,
+  updateRepo,
+  forceVisible
+}: RepositorySubmoduleChangesSectionProps): React.JSX.Element {
+  return (
+    <SearchableSetting
+      title={translate(
+        'auto.components.settings.RepositorySubmoduleChangesSection.title',
+        'Show Submodule Changes'
+      )}
+      description={translate(
+        'auto.components.settings.RepositorySubmoduleChangesSection.description',
+        'Read submodule changes in Source Control even when this repo hides them.'
+      )}
+      keywords={searchKeywords([
+        repo.displayName,
+        { key: 'auto.components.settings.repository.search.submodule', fallback: 'submodule' },
+        { key: 'auto.components.settings.repository.search.submodules', fallback: 'submodules' },
+        { key: 'auto.components.settings.repository.search.gitmodules', fallback: 'gitmodules' },
+        { key: 'auto.components.settings.repository.search.monorepo', fallback: 'monorepo' },
+        { key: 'auto.components.settings.repository.search.gitlink', fallback: 'gitlink' }
+      ])}
+      forceVisible={forceVisible}
+    >
+      <SettingsSwitchRow
+        label={translate(
+          'auto.components.settings.RepositorySubmoduleChangesSection.title',
+          'Show Submodule Changes'
+        )}
+        description={translate(
+          'auto.components.settings.RepositorySubmoduleChangesSection.longDescription',
+          'A repo whose .gitmodules sets ignore = all reports no submodule changes at all, so Source Control stays empty while you work inside a submodule. Turn this on to list them anyway. Each changed submodule adds one row you can expand for its per-file changes, including submodules whose recorded commit simply moved.'
+        )}
+        checked={repo.showSubmoduleChanges === true}
+        onChange={() =>
+          updateRepo(repo.id, { showSubmoduleChanges: repo.showSubmoduleChanges !== true })
+        }
+      />
+    </SearchableSetting>
+  )
+}

--- a/src/renderer/src/components/settings/repository-search.ts
+++ b/src/renderer/src/components/settings/repository-search.ts
@@ -120,6 +120,43 @@ export function getRepositoryPaneSearchEntries(
           }
         ]
       : []),
+    ...(isFolder
+      ? []
+      : [
+          {
+            title: translate(
+              'auto.components.settings.repository.search.showSubmoduleChanges',
+              'Show Submodule Changes'
+            ),
+            description: translate(
+              'auto.components.settings.repository.search.showSubmoduleChangesDescription',
+              'Read submodule changes in Source Control even when this repo hides them.'
+            ),
+            keywords: [
+              repo.displayName,
+              ...translateSearchKeyword(
+                'auto.components.settings.repository.search.submodule',
+                'submodule'
+              ),
+              ...translateSearchKeyword(
+                'auto.components.settings.repository.search.submodules',
+                'submodules'
+              ),
+              ...translateSearchKeyword(
+                'auto.components.settings.repository.search.gitmodules',
+                'gitmodules'
+              ),
+              ...translateSearchKeyword(
+                'auto.components.settings.repository.search.monorepo',
+                'monorepo'
+              ),
+              ...translateSearchKeyword(
+                'auto.components.settings.repository.search.gitlink',
+                'gitlink'
+              )
+            ]
+          }
+        ]),
     ...(isFolder || !isLocalWindowsProject
       ? []
       : [

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -9960,7 +9960,9 @@
             "projectRuntime": "Project Runtime",
             "projectRuntimeDescription": "Choose whether this project runs on Windows or WSL.",
             "externalWorktrees": "External worktrees",
-            "externalWorktreesDescription": "Override whether worktrees created outside Orca appear for this project."
+            "externalWorktreesDescription": "Override whether worktrees created outside Orca appear for this project.",
+            "showSubmoduleChanges": "Show Submodule Changes",
+            "showSubmoduleChangesDescription": "Read submodule changes in Source Control even when this repo hides them."
           }
         },
         "runtime": {
@@ -11550,6 +11552,11 @@
         },
         "NativeChatSupportedAgents": {
           "label": "Supported agents:"
+        },
+        "RepositorySubmoduleChangesSection": {
+          "title": "Show Submodule Changes",
+          "description": "Read submodule changes in Source Control even when this repo hides them.",
+          "longDescription": "A repo whose .gitmodules sets ignore = all reports no submodule changes at all, so Source Control stays empty while you work inside a submodule. Turn this on to list them anyway. Each changed submodule adds one row you can expand for its per-file changes, including submodules whose recorded commit simply moved."
         }
       },
       "right": {

--- a/src/renderer/src/runtime/runtime-git-status-client.ts
+++ b/src/renderer/src/runtime/runtime-git-status-client.ts
@@ -17,6 +17,7 @@ export async function getRuntimeGitStatus(
     bypassEffectiveUpstreamNegativeCache?: boolean
     reuseLineStats?: boolean
     branchLineTotalMergeBase?: string
+    showSubmoduleChanges?: boolean
     signal?: AbortSignal
   }
 ): Promise<GitStatusResult> {
@@ -32,6 +33,8 @@ export async function getRuntimeGitStatus(
   const branchLineTotalArgs = options?.branchLineTotalMergeBase
     ? { branchLineTotalMergeBase: options.branchLineTotalMergeBase }
     : {}
+  // Why: the repo opted in, so every transport must ask git for submodule rows.
+  const submoduleChangeArgs = options?.showSubmoduleChanges ? { showSubmoduleChanges: true } : {}
   if (target.kind === 'local' || !context.worktreeId) {
     return callLocalGitStatus(
       {
@@ -42,7 +45,8 @@ export async function getRuntimeGitStatus(
         ...includeLineStatsArgs,
         ...upstreamCacheBypassArgs,
         ...lineStatsReuseArgs,
-        ...branchLineTotalArgs
+        ...branchLineTotalArgs,
+        ...submoduleChangeArgs
       },
       options?.signal
     )
@@ -57,7 +61,8 @@ export async function getRuntimeGitStatus(
       ...includeLineStatsArgs,
       ...upstreamCacheBypassArgs,
       ...lineStatsReuseArgs,
-      ...branchLineTotalArgs
+      ...branchLineTotalArgs,
+      ...submoduleChangeArgs
     },
     {
       timeoutMs: 15_000,

--- a/src/shared/repo-types.ts
+++ b/src/shared/repo-types.ts
@@ -72,6 +72,12 @@ export type Repo = {
   forkSyncMode?: ForkSyncMode
   /** Canonical identity for the repo remote Orca should use for provider-level grouping. */
   gitRemoteIdentity?: GitRemoteIdentity | null
+  /** Reads submodule rows into Source Control even when the superproject's
+   *  `.gitmodules` sets `ignore = all`, which otherwise hides every submodule
+   *  from `git status`. Opt-in per repo: repos set `ignore = all` on purpose to
+   *  keep gitlink bumps out of `git commit -a`, so the default must not change
+   *  what `git status` reports. */
+  showSubmoduleChanges?: boolean
   /** Controls whether worktrees Orca did not create appear in the sidebar. */
   externalWorktreeVisibility?: ExternalWorktreeVisibility
   /** True when the repo predates hidden-by-default external worktrees. */


### PR DESCRIPTION
## ELI5

If a repo tells Git "ignore my submodules", Orca's Source Control panel shows nothing while
you work inside a submodule — no rows, no diffs, as if the repo were clean. This adds a
per-project switch that tells Git to report them anyway. It's off by default, so nothing
changes for anyone who doesn't turn it on.

## What Changed

- `GetStatusOptions` gains `showSubmoduleChanges`. When set, the status read appends
  `--ignore-submodules=none`; the flag is also part of the status read cache key, so
  toggling it can't be served a stale lease taken without it.
- The same option is plumbed through every status transport: the `git:status` IPC args, the
  SSH provider request (and its in-flight lease key), the relay `getStatusOp` handler, and
  the `git.status` RPC params, so a remote host builds the identical argv.
- New per-repo record field `showSubmoduleChanges`, resolved in the `git:status` handler
  next to `sharedLinkPaths` — so every existing status caller (Source Control, sidebar
  change counts, checks) picks it up with no signature churn.
- New Settings → Project section "Show Submodule Changes" (default off), registered in
  `getRepositoryPaneSearchEntries` so it is reachable from settings search (and excluded for
  plain-folder projects).

## Why

A superproject whose `.gitmodules` sets `ignore = all` reports **no** submodule entries from
`git status`, so there is no gitlink row for Orca's existing submodule support to attach to —
the expandable rows, the lazy `git.submoduleStatus` read, and the in-submodule diff routing
in `loadDiff` all work, they just never get invoked. Reproduced on a superproject with 67
submodules:

```
$ git status --porcelain=v2                        # what Orca reads today
? some-untracked-dir/

$ git status --porcelain=v2 --ignore-submodules=none
1 .M SC.. ... callfire
...all 67
```

Why opt-in rather than always-on: `ignore = all` is usually deliberate — it keeps gitlink
pointer bumps out of root-level `git status` so `git commit -a` can't sweep them up. Turning
it on globally would add a gitlink row per submodule to every panel for repos that asked Git
to hide exactly those rows. The alternative workaround, `git config submodule.<name>.ignore
none`, weakens that guarantee for every other tool the user runs (terminal Git, IDEs).

Scope note: resolution reads the **local** repo record, mirroring how `sharedLinkPaths` works
in this handler today. SSH- and runtime-hosted repo records are not consulted yet, so the
option there must come from the caller — the transports carry it, and wiring remote record
resolution is a natural follow-up if you want it in this PR instead.

## Linked Issue

Fixes #15427

Related, no file overlap: #13102 (nested repo discovery — its submodule change-count
breakdown reads 0 for the same reason, so this feeds it), #13989 (independent nested repos,
explicitly no `.gitmodules`), #11673 (bulk submodule operations).

## Visual Proof

Same superproject (2 submodules, `.gitmodules` sets `ignore = all`), one file modified and one
file added inside `service-a`. Identical crop so the two tab cleanly.

**BEFORE** — "No changes on this branch / This workspace is clean and this branch has no changes
ahead of main", while `service-a` has a modified `index.ts` and an untracked `src/`.
<img width="724" height="860" alt="before-source-control" src="https://github.com/user-attachments/assets/16f8f70f-c261-4f2b-9e27-097b2a768bf7" />


**AFTER** — `CHANGES 1` → `service-a` (labelled "Stage inside submodule"), expanding to
`index.ts +1 −1 (M)` and `helper.ts +1 (U)`.
<img width="724" height="860" alt="after-source-control" src="https://github.com/user-attachments/assets/9ee0e3ff-8b25-43c6-83dd-88d08a08c97e" />


**Setting** — Settings → Project → Show Submodule Changes, off and on.
<img width="1620" height="200" alt="settings-submodule-off" src="https://github.com/user-attachments/assets/0fb2ca33-0401-4530-846c-1a294189c3fa" />
<img width="1620" height="200" alt="settings-submodule-on" src="https://github.com/user-attachments/assets/6dfd7968-5fe7-4eda-9ef0-008cc8569ae0" />


## Testing

Repro: clone any superproject whose `.gitmodules` sets `ignore = all` for its submodules (or
add `ignore = all` to an existing one), edit a file inside a submodule, and open Source
Control — the panel is empty. Turn on Settings → Project → **Show Submodule Changes** and the
submodule appears as an expandable row with its per-file changes.

Verified end to end in a dev build on macOS: toggling the setting persisted
`showSubmoduleChanges: true` onto the repo record, the panel refreshed on its next poll without
a restart, and the submodule row expanded to its per-file changes.

Platforms: manually tested on macOS (local repo). Not manually exercised on Linux/Windows/SSH
— the change adds one Git argv token and one boolean through existing plumbing, with relay
parity covered by tests rather than by hand.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Added: status argv on/off, status read lease isolation (the option must not share a slot),
relay `getStatusOp` argv parity, `git.status` RPC forwarding, SSH provider request forwarding,
repo-record resolution in the `git:status` handler, and the settings toggle round-trip.

Rebased onto `7f6cf271` (main had moved 913 commits across two rebases; `status.ts` was split
into `git/source-control/*` and the `git:status` handler moved to
`ipc/filesystem/filesystem-git-status-handlers.ts`, so the change was re-applied to their new
homes rather than line-merged).

`pnpm lint` passes.

`pnpm typecheck` and `pnpm build` currently **fail on this branch and on pristine `main`
alike**, with the same error in a file this branch does not touch:

    src/main/worktree-create-preparation.ts(66,35): error TS2304: Cannot find name 'staleCleanupInFlight'

I verified that by checking out `upstream/main` with this branch absent and getting the
identical failure, so it is not from this change. `pnpm build` fails at its typecheck step for
the same reason.

`pnpm test` reports `12 failed | 69049 passed | 296 skipped` across 7 files. Running those same
7 files on pristine `main` fails all 7 with the identical 12 failures — `codex-fetcher-pty-settle`,
a test that executes the machine's real `/opt/homebrew/bin/fish`, the `cross-version-wire`
suites, and `structured-tui-transcript-catchup`. Everything touching this change passes: 1209
tests across the status read, lease isolation, relay parity, RPC forwarding, SSH provider,
IPC repo-record resolution, and the settings sections.

Note the local runs are on Node 26 while `package.json` pins `engines.node: 24`, so CI may
differ; every `pnpm` invocation printed an unsupported-engine warning.

## AI Disclosure

Written with Claude Code (Claude Opus 5). All code was reviewed by the author before pushing.

## Review

Cross-platform: the change adds the literal token `--ignore-submodules=none` to an existing
argv and a boolean through existing option objects — no paths, no shell, no platform-specific
behavior. WSL direct-read routing is untouched.

Remote/SSH: the relay handler mirrors the desktop argv and reads the param with the same
`=== true` narrowing used for `includeIgnored`, so untrusted RPC input cannot inject argv.
The SSH provider adds the flag to its in-flight lease key so an opted-in read is never served
a cached non-submodule result.

Performance: no extra Git invocations. `--ignore-submodules=none` makes Git stat submodule
worktrees it would otherwise skip, which is why this is opt-in and per repo; entry counts stay
bounded by the existing `DEFAULT_GIT_STATUS_LIMIT` cap and the existing
`submoduleTruncated` placeholder.

Security: no new IPC surface, no new filesystem reads, no user-controlled string reaches an
argv — the flag is a fixed literal gated by a boolean.

Existing git controls: this surfaces rows into the pane's existing submodule handling rather
than adding control logic — children inside a submodule are already non-stageable
(`isStageableStatusEntry` rejects `submoduleRoot`), unstage/discard are already blocked for
submodule rows, and submodule push rejections already get a dedicated message. Worth calling
out explicitly: a submodule row whose recorded commit moved **is** stageable and is therefore
included in "Stage All". In a repo that set `ignore = all` specifically to keep gitlink bumps
out of `git commit -a`, opting in re-exposes those bumps to Stage All inside Orca — which is
why this is per repo and off by default. Say the word if you would rather Stage All skipped
gitlink-only rows when the repo hides submodules; that is a behavior change to existing
semantics, so I left it alone.

Backwards compatibility: the field is optional and absent on existing persisted repo records,
which read as off, so behavior is unchanged until a user opts in. An older relay simply never
receives the param.

## Agent skill upstream boundary

- [x] Not applicable.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint` passes; `pnpm typecheck`/`pnpm build` fail on an upstream error that reproduces on pristine `main`, and `pnpm test` has only the 7 pre-existing failing files documented above (identical on `main`)

## Author

<!-- X / Twitter handle omitted; happy to add it if you would like it credited. -->


