### PR TITLE
fix(terminal): stop a Hangul-terminating digit being eaten as a candidate pick

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-ime-composition-tracker.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-composition-tracker.ts
@@ -7,7 +7,8 @@ export type TerminalImeCompositionTracker = IDisposable & {
    *  absorb the committing key's trailing press/release. */
   isCandidateKeyGuardActive: () => boolean
   /** True when the most recent preedit was Hangul, where a bare digit ends the
-   *  syllable as literal text instead of picking a candidate. */
+   *  syllable as literal text instead of picking a candidate. Expires with the
+   *  same staleness window as the other guards. */
   isHangulPreedit: () => boolean
 }
 
@@ -43,6 +44,14 @@ export function installTerminalImeCompositionTracker(
     (lastCompositionEventAt === null ||
       at - lastCompositionEventAt <= TERMINAL_IME_CANDIDATE_GUARD_STALE_COMPOSITION_EXPIRY_MS)
 
+  // Why time-bound: an engine switch (Hangul -> Pinyin) moves no DOM focus and
+  // the orphan-digit path emits no composition or input events, so a latched
+  // flag would disable the Pinyin candidate-digit guard for the whole session.
+  const isHangulPreeditAt = (at: number): boolean =>
+    hangulPreedit &&
+    lastCompositionEventAt !== null &&
+    at - lastCompositionEventAt <= TERMINAL_IME_CANDIDATE_GUARD_STALE_COMPOSITION_EXPIRY_MS
+
   const isCandidateKeyGuardActive = (): boolean => {
     const at = now()
     if (isActiveAt(at)) {
@@ -58,7 +67,7 @@ export function installTerminalImeCompositionTracker(
     return {
       isActive: () => active,
       isCandidateKeyGuardActive,
-      isHangulPreedit: () => hangulPreedit,
+      isHangulPreedit: () => isHangulPreeditAt(now()),
       dispose: () => undefined
     }
   }
@@ -68,6 +77,8 @@ export function installTerminalImeCompositionTracker(
     lastCompositionEventAt = now()
     compositionEndedAt = null
     sawEmptyCompositionUpdate = false
+    // Why safe: the following compositionupdate re-reads the preedit script.
+    hangulPreedit = false
   }
   const updateComposition = (event: Event): void => {
     lastCompositionEventAt = now()
@@ -118,7 +129,7 @@ export function installTerminalImeCompositionTracker(
   return {
     isActive: () => isActiveAt(now()),
     isCandidateKeyGuardActive,
-    isHangulPreedit: () => hangulPreedit,
+    isHangulPreedit: () => isHangulPreeditAt(now()),
     dispose: () => {
       terminalElement.removeEventListener('compositionstart', markActive, true)
       terminalElement.removeEventListener('compositionupdate', updateComposition, true)

--- a/src/renderer/src/components/terminal-pane/terminal-ime-composition-tracker.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-composition-tracker.ts
@@ -6,7 +6,14 @@ export type TerminalImeCompositionTracker = IDisposable & {
    *  IME-owned: during a live composition, and briefly after compositionend to
    *  absorb the committing key's trailing press/release. */
   isCandidateKeyGuardActive: () => boolean
+  /** True when the most recent preedit was Hangul, where a bare digit ends the
+   *  syllable as literal text instead of picking a candidate. */
+  isHangulPreedit: () => boolean
 }
+
+// Jamo, compatibility jamo, extended jamo, and precomposed syllables — every
+// form a Hangul preedit can take while a syllable is being assembled.
+const HANGUL_PREEDIT_PATTERN = /[ᄀ-ᇿ㄰-㆏ꥠ-꥿가-힣]/
 
 // Why: suppressed candidate keys are preventDefault-ed and fire no input
 // event, so a stale tracker (missed compositionend) has no natural unstick
@@ -26,6 +33,10 @@ export function installTerminalImeCompositionTracker(
   let lastCompositionEventAt: number | null = null
   let compositionEndedAt: number | null = null
   let sawEmptyCompositionUpdate = false
+  // Why the preedit and not compositionend data: a Pinyin IME's preedit is the
+  // Latin spelling it is picking candidates for, while its compositionend data
+  // is the committed Han text. Reading the commit would misclassify Pinyin.
+  let hangulPreedit = false
 
   const isActiveAt = (at: number): boolean =>
     active &&
@@ -47,6 +58,7 @@ export function installTerminalImeCompositionTracker(
     return {
       isActive: () => active,
       isCandidateKeyGuardActive,
+      isHangulPreedit: () => hangulPreedit,
       dispose: () => undefined
     }
   }
@@ -69,6 +81,7 @@ export function installTerminalImeCompositionTracker(
       sawEmptyCompositionUpdate = true
       return
     }
+    hangulPreedit = HANGUL_PREEDIT_PATTERN.test(event.data)
     active = true
   }
   const handleCompositionEnd = (): void => {
@@ -93,6 +106,7 @@ export function installTerminalImeCompositionTracker(
     lastCompositionEventAt = null
     compositionEndedAt = null
     sawEmptyCompositionUpdate = false
+    hangulPreedit = false
   }
 
   terminalElement.addEventListener('compositionstart', markActive, true)
@@ -104,6 +118,7 @@ export function installTerminalImeCompositionTracker(
   return {
     isActive: () => isActiveAt(now()),
     isCandidateKeyGuardActive,
+    isHangulPreedit: () => hangulPreedit,
     dispose: () => {
       terminalElement.removeEventListener('compositionstart', markActive, true)
       terminalElement.removeEventListener('compositionupdate', updateComposition, true)

--- a/src/renderer/src/components/terminal-pane/terminal-ime-hangul-terminating-digit.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-hangul-terminating-digit.test.ts
@@ -1,0 +1,138 @@
+// @vitest-environment happy-dom
+/**
+ * A digit that terminates a Hangul composition must reach the pty (#15299: typing `아1` in the
+ * integrated terminal on Wayland produces `아`).
+ *
+ * The Linux candidate-digit guards exist for Sogou/fcitx Pinyin, where a bare digit picks a
+ * numbered candidate and must never be typed (#7543, #8241). A Hangul engine has no numbered
+ * candidate list at all — its preedit is a syllable being assembled, and a digit always ends it
+ * and is literal text. Both guards key only off "an IME was recently involved", so once either
+ * window is open they eat the digit regardless of which engine opened it.
+ *
+ * Each case below opens one of those windows the way a Hangul engine does, then types the digit.
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  installTerminalImeCompositionTracker,
+  type TerminalImeCompositionTracker
+} from './terminal-ime-composition-tracker'
+import { createTerminalImeLinuxCandidateState } from './terminal-ime-linux-candidate-state'
+import {
+  shouldPreventDefaultTerminalImeCandidateKey,
+  shouldSuppressTerminalImeKeyboardEvent
+} from './xterm-bypass-policy'
+import { event } from './xterm-bypass-event-fixture'
+
+function dispatchComposition(element: HTMLElement, type: string, data: string): void {
+  const composition = new CompositionEvent(type, { bubbles: true })
+  Object.defineProperty(composition, 'data', { value: data })
+  element.dispatchEvent(composition)
+}
+
+function dispatchInput(element: HTMLElement, inputType: string, data: string | null): void {
+  const input = new InputEvent('input', { bubbles: true })
+  Object.defineProperty(input, 'inputType', { value: inputType })
+  Object.defineProperty(input, 'data', { value: data })
+  element.dispatchEvent(input)
+}
+
+/** The gate as `use-terminal-pane-lifecycle` assembles it for a Linux pane. */
+function suppressesDigit(
+  tracker: TerminalImeCompositionTracker,
+  orphanDigitGuardActive = false
+): boolean {
+  return shouldSuppressTerminalImeKeyboardEvent(
+    event({ type: 'keydown', key: '1', code: 'Digit1', keyCode: 49 }),
+    {
+      compositionActive: tracker.isActive(),
+      candidateKeyGuardActive: tracker.isCandidateKeyGuardActive(),
+      pendingCandidateKeyReleaseActive: false,
+      linuxOrphanCandidateDigitGuardActive: orphanDigitGuardActive,
+      hangulPreedit: tracker.isHangulPreedit(),
+      isMac: false,
+      isLinux: true
+    }
+  )
+}
+
+/** Drives a Hangul syllable into the tracker the way ibus reports one. */
+function composeHangulSyllable(terminalElement: HTMLElement): void {
+  dispatchComposition(terminalElement, 'compositionstart', '')
+  dispatchComposition(terminalElement, 'compositionupdate', '아')
+  dispatchInput(terminalElement, 'insertCompositionText', '아')
+  dispatchComposition(terminalElement, 'compositionupdate', '')
+  dispatchComposition(terminalElement, 'compositionend', '아')
+}
+
+describe('a digit that terminates a Hangul composition', () => {
+  it('survives the post-composition candidate window the ibus commit shape opens', () => {
+    const terminalElement = document.createElement('div')
+    document.body.appendChild(terminalElement)
+    const tracker = installTerminalImeCompositionTracker(terminalElement)
+
+    // ibus clears its preedit with an empty compositionupdate before committing, which is what
+    // arms the post-compositionend window. Under X11 a trailing `insertText` disarms it again
+    // (see the recorded ibus fixture); the Wayland ordering delivers the digit first.
+    composeHangulSyllable(terminalElement)
+
+    expect(tracker.isActive()).toBe(false)
+    expect(suppressesDigit(tracker)).toBe(false)
+
+    tracker.dispose()
+    terminalElement.remove()
+  })
+
+  it('survives the orphan-keyup window a compositor-grabbed Hangul keypress opens', () => {
+    let time = 1_000
+    const state = createTerminalImeLinuxCandidateState(() => time)
+    const terminalElement = document.createElement('div')
+    document.body.appendChild(terminalElement)
+    const tracker = installTerminalImeCompositionTracker(terminalElement)
+    composeHangulSyllable(terminalElement)
+
+    // The Wayland input method grabs the keyboard, so the jamo keydown never reaches the page;
+    // only the release does. That lone keyup is what `terminal-ime-linux-candidate-state` reads
+    // as "a legacy IME committed a single-letter preedit", arming the 1500ms digit window.
+    const jamoKeyup = event({ type: 'keyup', key: 'k', code: 'KeyK', keyCode: 75 })
+    state.observeKeyboardEvent(jamoKeyup, state.classifyKeyboardEvent(jamoKeyup))
+
+    time += 120
+    const digitKeydown = event({ type: 'keydown', key: '1', code: 'Digit1', keyCode: 49 })
+    // The orphan window itself still arms — it cannot see the composition. The policy is what
+    // declines to spend it on a digit that a Hangul preedit has already claimed as literal.
+    expect(state.classifyKeyboardEvent(digitKeydown).candidateDigitGuardActive).toBe(true)
+    expect(suppressesDigit(tracker, true)).toBe(false)
+    expect(
+      shouldPreventDefaultTerminalImeCandidateKey(digitKeydown, {
+        compositionActive: tracker.isActive(),
+        candidateKeyGuardActive: tracker.isCandidateKeyGuardActive(),
+        pendingCandidateKeyReleaseActive: false,
+        linuxOrphanCandidateDigitGuardActive: true,
+        hangulPreedit: tracker.isHangulPreedit(),
+        isMac: false,
+        isLinux: true
+      })
+    ).toBe(false)
+
+    tracker.dispose()
+    terminalElement.remove()
+  })
+
+  it('still lets a Pinyin preedit claim its numbered candidate digit', () => {
+    const terminalElement = document.createElement('div')
+    document.body.appendChild(terminalElement)
+    const tracker = installTerminalImeCompositionTracker(terminalElement)
+
+    // Sogou/fcitx Pinyin picks candidates by digit over a Latin preedit (#7543/#8241), and
+    // delivers the selector as a plain keydown. That must stay IME-owned.
+    dispatchComposition(terminalElement, 'compositionstart', '')
+    dispatchComposition(terminalElement, 'compositionupdate', 'nihao')
+    dispatchInput(terminalElement, 'insertCompositionText', 'nihao')
+
+    expect(tracker.isHangulPreedit()).toBe(false)
+    expect(suppressesDigit(tracker)).toBe(true)
+
+    tracker.dispose()
+    terminalElement.remove()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-ime-hangul-terminating-digit.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-hangul-terminating-digit.test.ts
@@ -4,24 +4,58 @@
  * integrated terminal on Wayland produces `아`).
  *
  * The Linux candidate-digit guards exist for Sogou/fcitx Pinyin, where a bare digit picks a
- * numbered candidate and must never be typed (#7543, #8241). A Hangul engine has no numbered
- * candidate list at all — its preedit is a syllable being assembled, and a digit always ends it
- * and is literal text. Both guards key only off "an IME was recently involved", so once either
- * window is open they eat the digit regardless of which engine opened it.
+ * numbered candidate and must never be typed (#7543, #8241). Only the orphan-keyup guard is at
+ * fault here: it arms off a lone letter keyup, cannot see which engine produced it, and spends
+ * its one suppression on the key that ends a Korean syllable. The composition-window guards stay
+ * as they are — ibus-hangul's Hanja lookup table does index candidates by digit, over a live
+ * preedit those guards already own.
  *
- * Each case below opens one of those windows the way a Hangul engine does, then types the digit.
+ * The composition shape below follows the recorded ibus-hangul trace
+ * (`__fixtures__/ibus-hangul-mixed-ascii-terminal-trace.json`): non-empty preedit updates, then
+ * compositionend, then the commit's own `insertText`. Neither recording leaves an empty
+ * compositionupdate standing before the digit, so the 250ms post-composition window never arms
+ * for this bug and no test may lean on it.
  */
 import { describe, expect, it } from 'vitest'
 import {
   installTerminalImeCompositionTracker,
+  TERMINAL_IME_CANDIDATE_GUARD_STALE_COMPOSITION_EXPIRY_MS,
   type TerminalImeCompositionTracker
 } from './terminal-ime-composition-tracker'
 import { createTerminalImeLinuxCandidateState } from './terminal-ime-linux-candidate-state'
 import {
   shouldPreventDefaultTerminalImeCandidateKey,
-  shouldSuppressTerminalImeKeyboardEvent
+  shouldSuppressTerminalImeKeyboardEvent,
+  type XtermImeKeyboardOptions
 } from './xterm-bypass-policy'
 import { event } from './xterm-bypass-event-fixture'
+
+type ImeHarness = {
+  tracker: TerminalImeCompositionTracker
+  element: HTMLElement
+  candidateState: ReturnType<typeof createTerminalImeLinuxCandidateState>
+  advance: (ms: number) => void
+  dispose: () => void
+}
+
+function installImeHarness(): ImeHarness {
+  let time = 1_000
+  const element = document.createElement('div')
+  document.body.appendChild(element)
+  const tracker = installTerminalImeCompositionTracker(element, { now: () => time })
+  return {
+    tracker,
+    element,
+    candidateState: createTerminalImeLinuxCandidateState(() => time),
+    advance: (ms) => {
+      time += ms
+    },
+    dispose: () => {
+      tracker.dispose()
+      element.remove()
+    }
+  }
+}
 
 function dispatchComposition(element: HTMLElement, type: string, data: string): void {
   const composition = new CompositionEvent(type, { bubbles: true })
@@ -36,103 +70,134 @@ function dispatchInput(element: HTMLElement, inputType: string, data: string | n
   element.dispatchEvent(input)
 }
 
-/** The gate as `use-terminal-pane-lifecycle` assembles it for a Linux pane. */
-function suppressesDigit(
-  tracker: TerminalImeCompositionTracker,
-  orphanDigitGuardActive = false
-): boolean {
-  return shouldSuppressTerminalImeKeyboardEvent(
-    event({ type: 'keydown', key: '1', code: 'Digit1', keyCode: 49 }),
-    {
-      compositionActive: tracker.isActive(),
-      candidateKeyGuardActive: tracker.isCandidateKeyGuardActive(),
-      pendingCandidateKeyReleaseActive: false,
-      linuxOrphanCandidateDigitGuardActive: orphanDigitGuardActive,
-      hangulPreedit: tracker.isHangulPreedit(),
-      isMac: false,
-      isLinux: true
-    }
+/** Drives a Hangul syllable into the tracker the way the recorded ibus trace reports one. */
+function composeHangulSyllable(element: HTMLElement): void {
+  dispatchComposition(element, 'compositionstart', '')
+  dispatchComposition(element, 'compositionupdate', '아')
+  dispatchInput(element, 'insertCompositionText', '아')
+  dispatchComposition(element, 'compositionend', '아')
+  dispatchInput(element, 'insertText', '아')
+}
+
+/**
+ * Arms the #8241 orphan-digit window the way the Wayland input-method grab does: it swallows the
+ * jamo keydown, so only the release reaches the page and reads as a legacy single-letter commit.
+ */
+function armOrphanCandidateDigitWindow(harness: ImeHarness): void {
+  const jamoKeyup = event({ type: 'keyup', key: 'k', code: 'KeyK', keyCode: 75 })
+  harness.candidateState.observeKeyboardEvent(
+    jamoKeyup,
+    harness.candidateState.classifyKeyboardEvent(jamoKeyup)
   )
 }
 
-/** Drives a Hangul syllable into the tracker the way ibus reports one. */
-function composeHangulSyllable(terminalElement: HTMLElement): void {
-  dispatchComposition(terminalElement, 'compositionstart', '')
-  dispatchComposition(terminalElement, 'compositionupdate', '아')
-  dispatchInput(terminalElement, 'insertCompositionText', '아')
-  dispatchComposition(terminalElement, 'compositionupdate', '')
-  dispatchComposition(terminalElement, 'compositionend', '아')
+const digitKeydown = event({ type: 'keydown', key: '1', code: 'Digit1', keyCode: 49 })
+
+/** The gate as `use-terminal-pane-lifecycle` assembles it for a Linux pane. */
+function imeKeyboardOptions(harness: ImeHarness): XtermImeKeyboardOptions {
+  return {
+    compositionActive: harness.tracker.isActive(),
+    candidateKeyGuardActive: harness.tracker.isCandidateKeyGuardActive(),
+    pendingCandidateKeyReleaseActive: false,
+    linuxOrphanCandidateDigitGuardActive:
+      harness.candidateState.classifyKeyboardEvent(digitKeydown).candidateDigitGuardActive,
+    hangulPreedit: harness.tracker.isHangulPreedit(),
+    isMac: false,
+    isLinux: true
+  }
+}
+
+function suppressesDigit(harness: ImeHarness): boolean {
+  return shouldSuppressTerminalImeKeyboardEvent(digitKeydown, imeKeyboardOptions(harness))
 }
 
 describe('a digit that terminates a Hangul composition', () => {
-  it('survives the post-composition candidate window the ibus commit shape opens', () => {
-    const terminalElement = document.createElement('div')
-    document.body.appendChild(terminalElement)
-    const tracker = installTerminalImeCompositionTracker(terminalElement)
-
-    // ibus clears its preedit with an empty compositionupdate before committing, which is what
-    // arms the post-compositionend window. Under X11 a trailing `insertText` disarms it again
-    // (see the recorded ibus fixture); the Wayland ordering delivers the digit first.
-    composeHangulSyllable(terminalElement)
-
-    expect(tracker.isActive()).toBe(false)
-    expect(suppressesDigit(tracker)).toBe(false)
-
-    tracker.dispose()
-    terminalElement.remove()
-  })
-
   it('survives the orphan-keyup window a compositor-grabbed Hangul keypress opens', () => {
-    let time = 1_000
-    const state = createTerminalImeLinuxCandidateState(() => time)
-    const terminalElement = document.createElement('div')
-    document.body.appendChild(terminalElement)
-    const tracker = installTerminalImeCompositionTracker(terminalElement)
-    composeHangulSyllable(terminalElement)
+    const harness = installImeHarness()
+    composeHangulSyllable(harness.element)
 
-    // The Wayland input method grabs the keyboard, so the jamo keydown never reaches the page;
-    // only the release does. That lone keyup is what `terminal-ime-linux-candidate-state` reads
-    // as "a legacy IME committed a single-letter preedit", arming the 1500ms digit window.
-    const jamoKeyup = event({ type: 'keyup', key: 'k', code: 'KeyK', keyCode: 75 })
-    state.observeKeyboardEvent(jamoKeyup, state.classifyKeyboardEvent(jamoKeyup))
+    // The bug is exclusively after the commit, on the orphan path: no composition window is open.
+    expect(harness.tracker.isActive()).toBe(false)
+    expect(harness.tracker.isCandidateKeyGuardActive()).toBe(false)
 
-    time += 120
-    const digitKeydown = event({ type: 'keydown', key: '1', code: 'Digit1', keyCode: 49 })
-    // The orphan window itself still arms — it cannot see the composition. The policy is what
-    // declines to spend it on a digit that a Hangul preedit has already claimed as literal.
-    expect(state.classifyKeyboardEvent(digitKeydown).candidateDigitGuardActive).toBe(true)
-    expect(suppressesDigit(tracker, true)).toBe(false)
+    armOrphanCandidateDigitWindow(harness)
+    harness.advance(120)
+
+    // The orphan window still arms — it cannot see the composition. The policy is what declines
+    // to spend it on a digit that a Hangul preedit has already claimed as literal text.
+    expect(imeKeyboardOptions(harness).linuxOrphanCandidateDigitGuardActive).toBe(true)
+    expect(suppressesDigit(harness)).toBe(false)
     expect(
-      shouldPreventDefaultTerminalImeCandidateKey(digitKeydown, {
-        compositionActive: tracker.isActive(),
-        candidateKeyGuardActive: tracker.isCandidateKeyGuardActive(),
-        pendingCandidateKeyReleaseActive: false,
-        linuxOrphanCandidateDigitGuardActive: true,
-        hangulPreedit: tracker.isHangulPreedit(),
-        isMac: false,
-        isLinux: true
-      })
+      shouldPreventDefaultTerminalImeCandidateKey(digitKeydown, imeKeyboardOptions(harness))
     ).toBe(false)
 
-    tracker.dispose()
-    terminalElement.remove()
+    harness.dispose()
+  })
+
+  it("stays literal across the commit's own insertText", () => {
+    const harness = installImeHarness()
+    composeHangulSyllable(harness.element)
+
+    // Both recordings deliver `insertText` for the committed syllable; on Wayland the digit can
+    // follow it, so the commit must not be read as "ordinary typing resumed".
+    expect(harness.tracker.isHangulPreedit()).toBe(true)
+
+    harness.dispose()
+  })
+
+  it('keeps the digit IME-owned while the Hangul preedit is still live', () => {
+    const harness = installImeHarness()
+    dispatchComposition(harness.element, 'compositionstart', '')
+    dispatchComposition(harness.element, 'compositionupdate', '아')
+    dispatchInput(harness.element, 'insertCompositionText', '아')
+
+    // ibus-hangul's Hanja conversion (Hanja key / F9) puts a numbered lookup table over a live
+    // Hangul preedit and its symbol table behaves the same, so digits are selectors there.
+    expect(harness.tracker.isHangulPreedit()).toBe(true)
+    expect(suppressesDigit(harness)).toBe(true)
+
+    harness.dispose()
+  })
+
+  it('stops claiming digits once the Hangul preedit has gone stale', () => {
+    const harness = installImeHarness()
+    composeHangulSyllable(harness.element)
+
+    // Switching engine (Hangul -> Pinyin) moves no DOM focus, and the #8241 orphan path emits no
+    // composition or input events at all, so only expiry can retire the Hangul classification.
+    harness.advance(TERMINAL_IME_CANDIDATE_GUARD_STALE_COMPOSITION_EXPIRY_MS + 1)
+    armOrphanCandidateDigitWindow(harness)
+
+    expect(harness.tracker.isHangulPreedit()).toBe(false)
+    expect(suppressesDigit(harness)).toBe(true)
+
+    harness.dispose()
+  })
+
+  it('re-reads the preedit script when the next composition starts', () => {
+    const harness = installImeHarness()
+    composeHangulSyllable(harness.element)
+    dispatchComposition(harness.element, 'compositionstart', '')
+
+    // compositionstart carries no data, so the classification cannot survive into a session that
+    // may belong to another engine; the following compositionupdate re-establishes it.
+    expect(harness.tracker.isHangulPreedit()).toBe(false)
+
+    harness.dispose()
   })
 
   it('still lets a Pinyin preedit claim its numbered candidate digit', () => {
-    const terminalElement = document.createElement('div')
-    document.body.appendChild(terminalElement)
-    const tracker = installTerminalImeCompositionTracker(terminalElement)
+    const harness = installImeHarness()
 
     // Sogou/fcitx Pinyin picks candidates by digit over a Latin preedit (#7543/#8241), and
     // delivers the selector as a plain keydown. That must stay IME-owned.
-    dispatchComposition(terminalElement, 'compositionstart', '')
-    dispatchComposition(terminalElement, 'compositionupdate', 'nihao')
-    dispatchInput(terminalElement, 'insertCompositionText', 'nihao')
+    dispatchComposition(harness.element, 'compositionstart', '')
+    dispatchComposition(harness.element, 'compositionupdate', 'nihao')
+    dispatchInput(harness.element, 'insertCompositionText', 'nihao')
 
-    expect(tracker.isHangulPreedit()).toBe(false)
-    expect(suppressesDigit(tracker)).toBe(true)
+    expect(harness.tracker.isHangulPreedit()).toBe(false)
+    expect(suppressesDigit(harness)).toBe(true)
 
-    tracker.dispose()
-    terminalElement.remove()
+    harness.dispose()
   })
 })

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -1053,6 +1053,7 @@ export function useTerminalPaneLifecycle({
             pendingCandidateKeyReleaseActive: pendingCandidateReleaseGuardActive,
             linuxOrphanCandidateDigitGuardActive:
               linuxCandidateClassification.candidateDigitGuardActive,
+            hangulPreedit: imeCompositionTracker.isHangulPreedit(),
             isMac,
             isLinux
           }

--- a/src/renderer/src/components/terminal-pane/xterm-bypass-policy.ts
+++ b/src/renderer/src/components/terminal-pane/xterm-bypass-policy.ts
@@ -50,6 +50,10 @@ export type XtermImeKeyboardOptions = {
   /** True for the narrow Linux path where the IME emits an orphaned letter
    *  keyup but no composition/input events before its candidate digit. */
   linuxOrphanCandidateDigitGuardActive?: boolean
+  /** True when the most recent preedit was Hangul. No Hangul engine indexes
+   *  candidates by digit over a Hangul preedit — the digit ends the syllable
+   *  and is literal text — so neither digit guard may claim it (#15299). */
+  hangulPreedit?: boolean
   // Required so no caller silently falls back to non-mac 229 suppression,
   // which re-swallows the first key after a macOS IME input-source switch.
   isMac: boolean
@@ -102,10 +106,18 @@ export function shouldSuppressTerminalImeKeyboardEvent(
     isMac,
     isLinux
   } = options
+  // Why both guards and not just the orphan one: a Hangul commit can leave either
+  // window open, and a digit is literal under both.
+  const digitIsLiteralHangulText =
+    options.hangulPreedit === true && isTerminalImeCandidateDigitKeyEvent(event)
   const suppressOrphanCandidateDigit =
-    isLinux && linuxOrphanCandidateDigitGuardActive && isTerminalImeCandidateDigitKeyEvent(event)
+    isLinux &&
+    linuxOrphanCandidateDigitGuardActive &&
+    isTerminalImeCandidateDigitKeyEvent(event) &&
+    !digitIsLiteralHangulText
   const suppressCandidateKey =
     isLinux &&
+    !digitIsLiteralHangulText &&
     (pendingCandidateKeyReleaseActive ||
       (candidateKeyGuardActive && isTerminalImeCandidateSelectionKeyEvent(event)) ||
       suppressOrphanCandidateDigit)
@@ -143,6 +155,9 @@ export function shouldPreventDefaultTerminalImeCandidateKey(
   // preventDefault — the candidate keydown would still fire a keypress and
   // write into the helper textarea, where a later 229 diff could flush the
   // leaked selector to the PTY.
+  if (options.hangulPreedit === true && isTerminalImeCandidateDigitKeyEvent(event)) {
+    return false
+  }
   return (
     event.type === 'keydown' &&
     options.isLinux &&

--- a/src/renderer/src/components/terminal-pane/xterm-bypass-policy.ts
+++ b/src/renderer/src/components/terminal-pane/xterm-bypass-policy.ts
@@ -50,9 +50,10 @@ export type XtermImeKeyboardOptions = {
   /** True for the narrow Linux path where the IME emits an orphaned letter
    *  keyup but no composition/input events before its candidate digit. */
   linuxOrphanCandidateDigitGuardActive?: boolean
-  /** True when the most recent preedit was Hangul. No Hangul engine indexes
-   *  candidates by digit over a Hangul preedit — the digit ends the syllable
-   *  and is literal text — so neither digit guard may claim it (#15299). */
+  /** True when the most recent preedit was Hangul, where a digit ends the
+   *  syllable and is literal text. Only the orphan-keyup guard is barred from
+   *  claiming it (#15299): ibus-hangul's Hanja lookup table does index by digit,
+   *  but only over a live preedit the composition guards already own. */
   hangulPreedit?: boolean
   // Required so no caller silently falls back to non-mac 229 suppression,
   // which re-swallows the first key after a macOS IME input-source switch.
@@ -93,6 +94,20 @@ function isXtermHandledKeyEvent(type: string): boolean {
   return type === 'keydown' || type === 'keyup'
 }
 
+/** Returns whether the Linux orphan-keyup window may claim this digit. */
+function claimsOrphanCandidateDigit(
+  event: XtermBypassEvent,
+  options: XtermImeKeyboardOptions
+): boolean {
+  return (
+    options.linuxOrphanCandidateDigitGuardActive === true &&
+    isTerminalImeCandidateDigitKeyEvent(event) &&
+    // Why: the orphan window arms off a bare keyup and cannot see which engine
+    // produced it, so a Hangul syllable's terminating digit must opt out.
+    options.hangulPreedit !== true
+  )
+}
+
 /** Returns whether xterm must not process an IME-owned keyboard event. */
 export function shouldSuppressTerminalImeKeyboardEvent(
   event: XtermBypassEvent,
@@ -102,25 +117,14 @@ export function shouldSuppressTerminalImeKeyboardEvent(
     compositionActive,
     candidateKeyGuardActive,
     pendingCandidateKeyReleaseActive,
-    linuxOrphanCandidateDigitGuardActive = false,
     isMac,
     isLinux
   } = options
-  // Why both guards and not just the orphan one: a Hangul commit can leave either
-  // window open, and a digit is literal under both.
-  const digitIsLiteralHangulText =
-    options.hangulPreedit === true && isTerminalImeCandidateDigitKeyEvent(event)
-  const suppressOrphanCandidateDigit =
-    isLinux &&
-    linuxOrphanCandidateDigitGuardActive &&
-    isTerminalImeCandidateDigitKeyEvent(event) &&
-    !digitIsLiteralHangulText
   const suppressCandidateKey =
     isLinux &&
-    !digitIsLiteralHangulText &&
     (pendingCandidateKeyReleaseActive ||
       (candidateKeyGuardActive && isTerminalImeCandidateSelectionKeyEvent(event)) ||
-      suppressOrphanCandidateDigit)
+      claimsOrphanCandidateDigit(event, options))
   if (event.type === 'keypress') {
     // Why: a suppressed candidate keydown is not preventDefault-ed by xterm,
     // so its native keypress still fires and _keyPress would forward the
@@ -155,15 +159,11 @@ export function shouldPreventDefaultTerminalImeCandidateKey(
   // preventDefault — the candidate keydown would still fire a keypress and
   // write into the helper textarea, where a later 229 diff could flush the
   // leaked selector to the PTY.
-  if (options.hangulPreedit === true && isTerminalImeCandidateDigitKeyEvent(event)) {
-    return false
-  }
   return (
     event.type === 'keydown' &&
     options.isLinux &&
     ((options.candidateKeyGuardActive && isTerminalImeCandidateSelectionKeyEvent(event)) ||
-      (options.linuxOrphanCandidateDigitGuardActive === true &&
-        isTerminalImeCandidateDigitKeyEvent(event)))
+      claimsOrphanCandidateDigit(event, options))
   )
 }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​203 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​203 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​48 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​42 |

<!-- /orca-pr-loc -->

Closes #15299 — a digit typed immediately after a Hangul syllable is dropped in the terminal on Wayland. Typing `아1` produces `아`. The syllable composes and commits correctly; **only the keystroke that ends it is lost.**

**Reproduced and fixed under measurement**, on Ubuntu 24.04 / GNOME Shell 46 / ibus-hangul 1.5.5, in a nested Wayland session with real key injection through the compositor.

| configuration | bytes at the pty |
| --- | --- |
| Wayland | `아\n` ×3 |
| Wayland + `--enable-wayland-ime --wayland-text-input-version=3` | `아\n` ×3 |
| **X11 control**, same machine and engine | `아1\n` ×3 |
| **GTK control** (gnome-text-editor, same Wayland session) | `아1` ×3 |

The compositor, the input method and the digit are all fine. Orca's terminal is the only thing that loses it.

## Why Wayland and not X11

The two paths deliver the digit differently, and the traces show it plainly.

**X11** — ibus-hangul swallows the digit into the preedit and commits `아1` as composition text:

```
keydown key="Process" code=Digit1 keyCode=229    <- consumed by the IME
compositionupdate data="아1"                      <- digit lives inside the preedit
compositionend    data="아1"
onData: "아1"
```

**Wayland** — it commits `아` and lets the digit through as an ordinary key. And the jamo before it arrive with **no keydown at all, only keyups**:

```
compositionupdate data="ㅇ" / beforeinput / input
keyup  key="d"  code=KeyD  keyCode=68  isComposing=true    <- NO matching keydown
compositionupdate data="아" / beforeinput / input
keyup  key="k"  code=KeyK  keyCode=75  isComposing=true    <- NO matching keydown
compositionend  data="아"
keydown key="1" code=Digit1 keyCode=49 isComposing=false   <- real key event
onData: "아"                                               <- digit gone
```

## Root cause

That orphaned keyup is what breaks it. `terminal-ime-linux-candidate-state.ts:175` sees a plain-letter keyup with no pending keydown for that `code` and arms a **1500 ms window** in which a bare digit is treated as a candidate selection — because a Pinyin engine indexes its candidate list by digit (#7543, #8241).

The digit lands microseconds later, inside that window, and is suppressed. The window disarms after **exactly one digit**, which is why the syllable survives and only the terminating key vanishes.

A Hangul engine has no numbered candidates over its preedit. The guard was spending its one suppression on a keystroke meant for the shell.

## The fix

The composition tracker records whether the current preedit is Hangul; the guard declines to claim a digit that preedit has already made literal.

**Read from `compositionupdate`, never `compositionend`** — a Pinyin preedit is the Latin spelling being narrowed while its commit is the Han text, so reading the commit would misclassify Pinyin and reopen the bugs the guard exists for. A test pins that. Space is untouched; only digits are reclassified.

## Two things the earlier draft of this PR got wrong

Both were corrected by the reproduction rather than by argument:

- **Only one guard is involved, not two.** The 250 ms post-composition guard never arms here — it requires an empty `compositionupdate`, and every update in this trace carries data (`ㅇ`, `아`, `아`). The orphan-keyup guard is solely responsible.
- **The "competing cause" is disproven.** The digit arrives as a real `keydown` with `keyCode 49` and `isComposing=false`, so xterm's `_keyDownSeen` check is never reached — Orca's policy suppresses the key before xterm's handler runs. That path is not what the reporter hits.

## Verification

**A/B/A on the reproducing machine:** unfixed drops the digit, this change preserves it, reverting drops it again — three runs each, deterministic.

The oracle is the literal byte stream: a `node` process on the pty echoes each line as hex, `ec9584 0a` broken versus `ec9584 31 0a` fixed. `terminal.onData` agrees independently. `orca terminal read` was deliberately **not** used — it accumulates the stream and stacks output, and would have shown a false result.

No regression: the X11 case still passes with the fix, and both existing `terminal-ibus-hangul-native.spec.ts` cases pass at 5 repetitions.

```
targeted              5 files /   71 tests passed
full terminal-pane  378 files / 3675 tests passed
```

`config/patches/` untouched — no xterm change was needed.

## Also cleared

**PR #14469 is not the cause**, contrary to the initial hypothesis. `resolveNonLatinControlChordInput` returns `null` unless `ctrlKey` is set, only claims `Key[A-Z]` codes, and requires a codepoint above `0x7f` — a bare `1` fails all three gates.

## Follow-up worth having

The reproduction harness exists and is reusable, but lives on a scratch machine rather than in the repo. It is the first setup we have that can drive a real IME through a real compositor, and three IME issues this week were unreproducible without one. Details are in the issue thread; the spec is injector-agnostic and parameterised by keys and expected text, so other IME bugs can reuse it unchanged.
