### PR TITLE
fix(worktree): let a configured worktree base outrank a built-in visibility source (#15232)

### DIFF
--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -81,6 +81,7 @@ import {
   createWorktreeVisibilitySourceMatcher,
   resolveCustomWorktreeVisibilitySources
 } from '../../shared/worktree/visibility-sources'
+import { resolveConfiguredWorktreeBasePaths } from '../../shared/worktree/configured-worktree-base-path'
 import {
   assertWorktreeCleanForRemoval,
   forceDeleteLocalBranch,
@@ -885,7 +886,8 @@ function buildDetectedGitWorktrees(
   )
   const worktreeVisibilitySourceMatcher = createWorktreeVisibilitySourceMatcher(
     [repo.path, ...liveWorktrees.map((worktree) => worktree.path)],
-    resolveCustomWorktreeVisibilitySources(repo, settings.worktreeVisibilityDefaults)
+    resolveCustomWorktreeVisibilitySources(repo, settings.worktreeVisibilityDefaults),
+    resolveConfiguredWorktreeBasePaths(repo)
   )
   const detected = liveWorktrees.map((gitWorktree) => {
     const worktreeId = `${repo.id}::${gitWorktree.path}`
@@ -1037,7 +1039,8 @@ function buildFolderDetectedWorktrees(store: Store, repo: Repo): DetectedWorktre
   const worktrees = listFolderWorkspaces(store, repo)
   const worktreeVisibilitySourceMatcher = createWorktreeVisibilitySourceMatcher(
     [repo.path, ...worktrees.map((worktree) => worktree.path)],
-    resolveCustomWorktreeVisibilitySources(repo, settings.worktreeVisibilityDefaults)
+    resolveCustomWorktreeVisibilitySources(repo, settings.worktreeVisibilityDefaults),
+    resolveConfiguredWorktreeBasePaths(repo)
   )
   return worktrees.map((worktree) =>
     toDetectedWorktree({
@@ -1122,7 +1125,8 @@ function buildDisconnectedDetectedWorktrees(
   const settings = store.getSettings()
   const worktreeVisibilitySourceMatcher = createWorktreeVisibilitySourceMatcher(
     [repo.path, ...worktrees.map((worktree) => worktree.path)],
-    resolveCustomWorktreeVisibilitySources(repo, settings.worktreeVisibilityDefaults)
+    resolveCustomWorktreeVisibilitySources(repo, settings.worktreeVisibilityDefaults),
+    resolveConfiguredWorktreeBasePaths(repo)
   )
   const detected = worktrees.map((worktree) => {
     const meta = store.getWorktreeMeta(worktree.id)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -612,6 +612,7 @@ import {
   resolveCustomWorktreeVisibilitySources,
   type WorktreeVisibilitySourceMatcher
 } from '../../shared/worktree/visibility-sources'
+import { resolveConfiguredWorktreeBasePaths } from '../../shared/worktree/configured-worktree-base-path'
 import {
   BROWSER_HEADLESS_RUNTIME_CAPABILITY,
   BROWSER_CERTIFICATE_TRUST_RUNTIME_CAPABILITY,
@@ -23325,7 +23326,8 @@ export class OrcaRuntimeService {
       const repoOwnerCount = store.getRepos().filter((candidate) => candidate.id === repo.id).length
       const matcher = createWorktreeVisibilitySourceMatcher(
         [repo.path, ...worktrees.map((worktree) => worktree.path)],
-        resolveCustomWorktreeVisibilitySources(repo, visibilityDefaults)
+        resolveCustomWorktreeVisibilitySources(repo, visibilityDefaults),
+        resolveConfiguredWorktreeBasePaths(repo)
       )
       const detected = worktrees.map((worktree) =>
         this.toRuntimeDetectedWorktree(
@@ -23354,7 +23356,8 @@ export class OrcaRuntimeService {
     }
     const worktreeVisibilitySourceMatcher = createWorktreeVisibilitySourceMatcher(
       [repo.path, ...scan.worktrees.map((worktree) => worktree.path)],
-      resolveCustomWorktreeVisibilitySources(repo, visibilityDefaults)
+      resolveCustomWorktreeVisibilitySources(repo, visibilityDefaults),
+      resolveConfiguredWorktreeBasePaths(repo)
     )
     const expectedHostId = getRepoExecutionHostId(repo)
     const repoOwnerCount = store.getRepos().filter((candidate) => candidate.id === repo.id).length
@@ -23466,7 +23469,8 @@ export class OrcaRuntimeService {
           repo.id,
           createWorktreeVisibilitySourceMatcher(
             [repo.path, ...(checkoutPathsByRepoId.get(repo.id) ?? [])],
-            resolveCustomWorktreeVisibilitySources(repo, visibilityDefaults)
+            resolveCustomWorktreeVisibilitySources(repo, visibilityDefaults),
+            resolveConfiguredWorktreeBasePaths(repo)
           )
         ])
     )

--- a/src/renderer/src/components/sidebar/WorktreeVisibilitySourceList.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeVisibilitySourceList.test.tsx
@@ -5,6 +5,7 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ReactNode } from 'react'
 import type { Repo } from '../../../../shared/repo-types'
+import type { DetectedWorktree } from '../../../../shared/worktree/types'
 import WorktreeVisibilitySourceList from './WorktreeVisibilitySourceList'
 
 vi.mock('@/components/ui/tooltip', () => ({
@@ -28,6 +29,43 @@ afterEach(() => {
 })
 
 describe('WorktreeVisibilitySourceList', () => {
+  it('counts a configured built-in base as another external location', () => {
+    const repo: Repo = {
+      id: 'repo-1',
+      path: '/repo',
+      displayName: 'orca',
+      badgeColor: '#000000',
+      addedAt: 0,
+      worktreeBasePath: '.claude/worktrees'
+    }
+    const worktrees = [
+      {
+        path: '/repo/.claude/worktrees/review',
+        selectedCheckout: false,
+        ownership: 'external'
+      },
+      { path: '/outside/review', selectedCheckout: false, ownership: 'external' }
+    ] as DetectedWorktree[]
+
+    act(() => {
+      root.render(
+        <WorktreeVisibilitySourceList
+          repo={repo}
+          worktrees={worktrees}
+          disabled={false}
+          onAdd={async () => 'added'}
+          onRemove={async () => {}}
+          onToggle={async () => {}}
+        />
+      )
+    })
+
+    expect(container.querySelector('[data-source-row="built-in:claude"]')?.textContent).toContain(
+      '0 found'
+    )
+    expect(container.querySelector('[data-source-row="other"]')?.textContent).toContain('2 found')
+  })
+
   it('offers a reset when a project override already matches the global value', async () => {
     const onUseDefault = vi.fn()
     const repo: Repo = {

--- a/src/renderer/src/components/sidebar/WorktreeVisibilitySourceList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeVisibilitySourceList.tsx
@@ -22,6 +22,7 @@ import {
   resolveCustomWorktreeVisibilitySources,
   type WorktreeVisibilitySourceMatch
 } from '../../../../shared/worktree/visibility-sources'
+import { resolveConfiguredWorktreeBasePaths } from '../../../../shared/worktree/configured-worktree-base-path'
 import {
   effectiveExternalWorktreeVisibility,
   isLegacyRepoForExternalWorktreeVisibility
@@ -187,7 +188,8 @@ export default function WorktreeVisibilitySourceList({
     () =>
       createWorktreeVisibilitySourceMatcher(
         [...(repo ? [repo.path] : []), ...worktrees.map((worktree) => worktree.path)],
-        customSources
+        customSources,
+        resolveConfiguredWorktreeBasePaths(repo)
       ),
     [customSources, repo, worktrees]
   )

--- a/src/shared/agent-scratch-worktrees.test.ts
+++ b/src/shared/agent-scratch-worktrees.test.ts
@@ -12,22 +12,23 @@ describe('isAgentScratchWorktreePath', () => {
     expect(
       isAgentScratchWorktreePath(
         repoPath,
-        '/Users/dev/app/.claude/worktrees/agent-a04ccaaa55ddadb91'
+        '/Users/dev/app/.claude/worktrees/agent-a04ccaaa55ddadb91',
+        []
       )
     ).toBe(true)
   })
 
   it('matches gsd parallel-agent workspaces', () => {
     expect(
-      isAgentScratchWorktreePath(repoPath, '/Users/dev/app/.gsd-workspaces/phase-1-subagent-2')
+      isAgentScratchWorktreePath(repoPath, '/Users/dev/app/.gsd-workspaces/phase-1-subagent-2', [])
     ).toBe(true)
   })
 
   it('matches scratch worktrees created from a linked checkout', () => {
-    const matchesAgentScratch = createAgentScratchWorktreePathMatcher([
-      repoPath,
-      '/Users/dev/orca/workspaces/app/feature-x'
-    ])
+    const matchesAgentScratch = createAgentScratchWorktreePathMatcher(
+      [repoPath, '/Users/dev/orca/workspaces/app/feature-x'],
+      []
+    )
 
     expect(
       matchesAgentScratch(
@@ -43,7 +44,8 @@ describe('isAgentScratchWorktreePath', () => {
     expect(
       isAgentScratchWorktreePath(
         'C:\\Users\\dev\\app',
-        'c:\\USERS\\dev\\app\\.Claude\\Worktrees\\agent-a04ccaaa'
+        'c:\\USERS\\dev\\app\\.Claude\\Worktrees\\agent-a04ccaaa',
+        []
       )
     ).toBe(true)
   })
@@ -52,54 +54,69 @@ describe('isAgentScratchWorktreePath', () => {
     expect(
       isAgentScratchWorktreePath(
         '//wsl$/Ubuntu/home/dev/app',
-        '//wsl.localhost/Ubuntu/home/dev/app/.claude/worktrees/agent-a04ccaaa'
+        '//wsl.localhost/Ubuntu/home/dev/app/.claude/worktrees/agent-a04ccaaa',
+        []
       )
     ).toBe(true)
   })
 
   it('preserves case-sensitive POSIX and WSL tool segments', () => {
     expect(
-      isAgentScratchWorktreePath(repoPath, '/Users/dev/app/.Claude/Worktrees/agent-a04ccaaa')
+      isAgentScratchWorktreePath(repoPath, '/Users/dev/app/.Claude/Worktrees/agent-a04ccaaa', [])
     ).toBe(false)
     expect(
       isAgentScratchWorktreePath(
         '//wsl.localhost/Ubuntu/home/dev/app',
-        '//wsl.localhost/ubuntu/home/dev/app/.Claude/Worktrees/agent-a04ccaaa'
+        '//wsl.localhost/ubuntu/home/dev/app/.Claude/Worktrees/agent-a04ccaaa',
+        []
       )
     ).toBe(false)
   })
 
   it('requires the tool directory at the repo root', () => {
     expect(
-      isAgentScratchWorktreePath(repoPath, '/Users/dev/app/.claude/other/worktrees/agent-1')
+      isAgentScratchWorktreePath(repoPath, '/Users/dev/app/.claude/other/worktrees/agent-1', [])
     ).toBe(false)
     expect(
-      isAgentScratchWorktreePath(repoPath, '/Users/dev/app/packages/demo/.claude/worktrees/agent-1')
+      isAgentScratchWorktreePath(
+        repoPath,
+        '/Users/dev/app/packages/demo/.claude/worktrees/agent-1',
+        []
+      )
     ).toBe(false)
-    expect(isAgentScratchWorktreePath(repoPath, '/Users/dev/app/.gsd-workspaces')).toBe(false)
+    expect(isAgentScratchWorktreePath(repoPath, '/Users/dev/app/.gsd-workspaces', [])).toBe(false)
   })
 
   it('does not match undotted claude directories', () => {
-    expect(isAgentScratchWorktreePath(repoPath, '/Users/dev/app/claude/worktrees/agent-1')).toBe(
-      false
-    )
+    expect(
+      isAgentScratchWorktreePath(repoPath, '/Users/dev/app/claude/worktrees/agent-1', [])
+    ).toBe(false)
   })
 
   it('does not inherit a scratch classification from the repo parent path', () => {
     expect(
       isAgentScratchWorktreePath(
         '/Users/dev/.claude/worktrees/app',
-        '/Users/dev/.claude/worktrees/app/manual/feature-x'
+        '/Users/dev/.claude/worktrees/app/manual/feature-x',
+        []
       )
     ).toBe(false)
   })
 
   it('does not match user worktree conventions', () => {
-    expect(isAgentScratchWorktreePath(repoPath, '/Users/dev/app/.worktrees/feature-x')).toBe(false)
+    expect(isAgentScratchWorktreePath(repoPath, '/Users/dev/app/.worktrees/feature-x', [])).toBe(
+      false
+    )
     expect(
-      isAgentScratchWorktreePath('/Users/dev/app', '/Users/dev/.superset/worktrees/app/fix-notes')
+      isAgentScratchWorktreePath(
+        '/Users/dev/app',
+        '/Users/dev/.superset/worktrees/app/fix-notes',
+        []
+      )
     ).toBe(false)
-    expect(isAgentScratchWorktreePath('/Users/dev/app', '/orca/workspaces/app/feature')).toBe(false)
+    expect(isAgentScratchWorktreePath('/Users/dev/app', '/orca/workspaces/app/feature', [])).toBe(
+      false
+    )
   })
 })
 

--- a/src/shared/agent-scratch-worktrees.ts
+++ b/src/shared/agent-scratch-worktrees.ts
@@ -14,20 +14,32 @@ const AGENT_SCRATCH_PATH_PREFIXES: readonly (readonly string[])[] = [
 export type AgentScratchWorktreePathMatcher = (worktreePath: string) => boolean
 
 export function createAgentScratchWorktreeSourceMatcher(
-  checkoutPaths: readonly string[]
+  checkoutPaths: readonly string[],
+  configuredWorktreeBasePaths: readonly string[] = []
 ): WorktreeVisibilitySourceMatcher {
-  return createWorktreeVisibilitySourceMatcher(checkoutPaths)
+  return createWorktreeVisibilitySourceMatcher(checkoutPaths, [], configuredWorktreeBasePaths)
 }
 
 export function createAgentScratchWorktreePathMatcher(
-  checkoutPaths: readonly string[]
+  checkoutPaths: readonly string[],
+  configuredWorktreeBasePaths: readonly string[] = []
 ): AgentScratchWorktreePathMatcher {
-  const classify = createAgentScratchWorktreeSourceMatcher(checkoutPaths)
+  const classify = createAgentScratchWorktreeSourceMatcher(
+    checkoutPaths,
+    configuredWorktreeBasePaths
+  )
   return (worktreePath) => classify(worktreePath)?.kind === 'built-in'
 }
 
-export function isAgentScratchWorktreePath(repoPath: string, worktreePath: string): boolean {
-  return createAgentScratchWorktreePathMatcher([repoPath])(worktreePath)
+export function isAgentScratchWorktreePath(
+  repoPath: string,
+  worktreePath: string,
+  configuredWorktreeBasePaths: readonly string[] = []
+): boolean {
+  return createAgentScratchWorktreePathMatcher(
+    [repoPath],
+    configuredWorktreeBasePaths
+  )(worktreePath)
 }
 
 /** Why: agent CLIs also mint whole scratch *repos* under these containers; a

--- a/src/shared/agent-scratch-worktrees.ts
+++ b/src/shared/agent-scratch-worktrees.ts
@@ -15,14 +15,14 @@ export type AgentScratchWorktreePathMatcher = (worktreePath: string) => boolean
 
 export function createAgentScratchWorktreeSourceMatcher(
   checkoutPaths: readonly string[],
-  configuredWorktreeBasePaths: readonly string[] = []
+  configuredWorktreeBasePaths: readonly string[]
 ): WorktreeVisibilitySourceMatcher {
   return createWorktreeVisibilitySourceMatcher(checkoutPaths, [], configuredWorktreeBasePaths)
 }
 
 export function createAgentScratchWorktreePathMatcher(
   checkoutPaths: readonly string[],
-  configuredWorktreeBasePaths: readonly string[] = []
+  configuredWorktreeBasePaths: readonly string[]
 ): AgentScratchWorktreePathMatcher {
   const classify = createAgentScratchWorktreeSourceMatcher(
     checkoutPaths,
@@ -34,7 +34,7 @@ export function createAgentScratchWorktreePathMatcher(
 export function isAgentScratchWorktreePath(
   repoPath: string,
   worktreePath: string,
-  configuredWorktreeBasePaths: readonly string[] = []
+  configuredWorktreeBasePaths: readonly string[]
 ): boolean {
   return createAgentScratchWorktreePathMatcher(
     [repoPath],

--- a/src/shared/worktree/configured-worktree-base-path.ts
+++ b/src/shared/worktree/configured-worktree-base-path.ts
@@ -5,6 +5,7 @@ import {
   resolveRuntimePath
 } from '../cross-platform-path'
 import type { Repo } from '../repo-types'
+import { resolveWslRepoWorktreeBasePath } from '../wsl-paths'
 
 export function isRuntimePathAbsoluteForRepo(repoPath: string, layoutPath: string): boolean {
   const pathFlavor =
@@ -29,5 +30,9 @@ export function resolveConfiguredWorktreeBasePaths(
   repo: Pick<Repo, 'path' | 'worktreeBasePath'> | undefined
 ): string[] {
   const configured = repo?.worktreeBasePath?.trim()
-  return repo && configured ? [resolveWorkspaceLayoutPath(repo.path, configured)] : []
+  if (!repo || !configured) {
+    return []
+  }
+  const runtimeBase = resolveWslRepoWorktreeBasePath(repo.path, configured)
+  return [resolveWorkspaceLayoutPath(repo.path, runtimeBase)]
 }

--- a/src/shared/worktree/configured-worktree-base-path.ts
+++ b/src/shared/worktree/configured-worktree-base-path.ts
@@ -1,0 +1,33 @@
+import {
+  isRuntimePathAbsolute,
+  isWindowsAbsolutePathLike,
+  normalizeRuntimePathSeparators,
+  resolveRuntimePath
+} from '../cross-platform-path'
+import type { Repo } from '../repo-types'
+
+export function isRuntimePathAbsoluteForRepo(repoPath: string, layoutPath: string): boolean {
+  const pathFlavor =
+    isWindowsAbsolutePathLike(repoPath) || isWindowsAbsolutePathLike(layoutPath)
+      ? 'windows'
+      : 'posix'
+  return isRuntimePathAbsolute(layoutPath, pathFlavor)
+}
+
+export function resolveWorkspaceLayoutPath(repoPath: string, layoutPath: string): string {
+  return isRuntimePathAbsoluteForRepo(repoPath, layoutPath)
+    ? normalizeRuntimePathSeparators(layoutPath)
+    : resolveRuntimePath(repoPath, layoutPath)
+}
+
+/**
+ * Why: the per-project worktree base (#1846) is an explicit statement that a
+ * directory holds this project's workspaces, so it outranks the path
+ * heuristics that classify directories on their name alone (#15232).
+ */
+export function resolveConfiguredWorktreeBasePaths(
+  repo: Pick<Repo, 'path' | 'worktreeBasePath'> | undefined
+): string[] {
+  const configured = repo?.worktreeBasePath?.trim()
+  return repo && configured ? [resolveWorkspaceLayoutPath(repo.path, configured)] : []
+}

--- a/src/shared/worktree/ownership-configured-base-visibility.test.ts
+++ b/src/shared/worktree/ownership-configured-base-visibility.test.ts
@@ -166,6 +166,17 @@ describe('a configured worktree base that collides with a built-in visibility so
       visible: true
     })
   })
+
+  it('keeps the configured base external when workspace nesting is flat', () => {
+    const repo = makeRepo({ worktreeBasePath: '.claude/worktrees' })
+
+    expect(
+      detect(repo, configuredBaseWorktree, makeSettings({ nestWorkspaces: false }))
+    ).toMatchObject({
+      ownership: 'external',
+      visible: true
+    })
+  })
 })
 
 describe('agent scratch stays hidden for repos that did not configure that base (#9388)', () => {

--- a/src/shared/worktree/ownership-configured-base-visibility.test.ts
+++ b/src/shared/worktree/ownership-configured-base-visibility.test.ts
@@ -151,11 +151,38 @@ describe('a configured worktree base that collides with a built-in visibility so
     })
 
     expect(
-      detect(repo, String.raw`F:\GitHub\OrbisCXM\.claude\worktrees\OrbisCXM\squash`)
+      detect(repo, String.raw`f:\github\ORBISCXM\.claude\worktrees\OrbisCXM\squash`)
     ).toMatchObject({
       ownership: 'external',
       visible: true
     })
+  })
+
+  it('matches configured bases across Windows UNC casing and separators', () => {
+    const repo = makeRepo({
+      path: String.raw`\\BuildHost\Share\OrbisCXM`,
+      worktreeBasePath: String.raw`.claude\worktrees`
+    })
+
+    expect(
+      detect(repo, '//buildhost/share/orbiscxm/.claude/worktrees/OrbisCXM/squash')
+    ).toMatchObject({ ownership: 'external', visible: true })
+  })
+
+  it('resolves a relative configured base on the SSH execution host', () => {
+    const repo = makeRepo({
+      path: '/remote/OrbisCXM',
+      connectionId: 'ssh-1',
+      worktreeBasePath: '.claude/worktrees'
+    })
+
+    const detected = detect(repo, '/remote/OrbisCXM/.claude/worktrees/review')
+
+    expect(detected).toMatchObject({
+      ownership: 'external',
+      visible: true
+    })
+    expect(detected.visibilitySource).toBeUndefined()
   })
 
   it('resolves an absolute configured base that matches a built-in source', () => {
@@ -183,9 +210,12 @@ describe('agent scratch stays hidden for repos that did not configure that base 
   const scratchWorktree = '/repos/OrbisCXM/.claude/worktrees/OrbisCXM/agent-a04ccaaa'
 
   it('hides an unconfigured .claude/worktrees checkout', () => {
-    expect(detect(makeRepo(), scratchWorktree)).toMatchObject({
+    const detected = detect(makeRepo(), scratchWorktree)
+
+    expect(detected).toMatchObject({
       ownership: 'agent-scratch',
-      visible: false
+      visible: false,
+      visibilitySource: { kind: 'built-in', id: 'claude' }
     })
   })
 

--- a/src/shared/worktree/ownership-configured-base-visibility.test.ts
+++ b/src/shared/worktree/ownership-configured-base-visibility.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from 'vitest'
+import type { GlobalSettings } from '../global-settings-types'
+import type { Repo } from '../repo-types'
+import type { Worktree } from './types'
+import { resolveConfiguredWorktreeBasePaths } from './configured-worktree-base-path'
+import { createWorktreeVisibilitySourceMatcher } from './visibility-sources'
+import {
+  buildKnownOrcaWorkspaceLayouts,
+  classifyWorktreeOwnership,
+  toDetectedWorktree,
+  EXTERNAL_WORKTREE_VISIBILITY_ROLLOUT_AT
+} from './ownership'
+
+function makeRepo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    id: 'repo-1',
+    path: '/repos/OrbisCXM',
+    displayName: 'OrbisCXM',
+    badgeColor: '#000',
+    addedAt: EXTERNAL_WORKTREE_VISIBILITY_ROLLOUT_AT + 1,
+    kind: 'git',
+    externalWorktreeVisibility: 'show',
+    ...overrides
+  }
+}
+
+function makeWorktree(path: string): Worktree {
+  return {
+    id: `repo-1::${path}`,
+    repoId: 'repo-1',
+    path,
+    head: 'abc',
+    branch: 'refs/heads/feature',
+    isBare: false,
+    isMainWorktree: false,
+    displayName: 'feature',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    linkedGitLabMR: null,
+    linkedGitLabIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    workspaceStatus: 'todo'
+  }
+}
+
+function makeSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings {
+  return {
+    workspaceDir: '/orca/workspaces',
+    nestWorkspaces: true,
+    workspaceDirHistory: [],
+    ...overrides
+  } as GlobalSettings
+}
+
+function detect(repo: Repo, path: string, settings = makeSettings()) {
+  return toDetectedWorktree({
+    repo,
+    settings,
+    worktree: makeWorktree(path),
+    knownOrcaLayouts: buildKnownOrcaWorkspaceLayouts(settings, repo)
+  })
+}
+
+describe('a configured worktree base that collides with a built-in visibility source (#15232)', () => {
+  const configuredBaseWorktree = '/repos/OrbisCXM/.claude/worktrees/OrbisCXM/squash-migrations'
+  const tempScratchpadWorktree = '/tmp/claude/abc/scratchpad/sonda-voter'
+
+  it('classifies a plain git worktree in the configured base as external, not agent scratch', () => {
+    const repo = makeRepo({ worktreeBasePath: '.claude/worktrees' })
+    const settings = makeSettings()
+
+    expect(
+      classifyWorktreeOwnership({
+        repo,
+        settings,
+        worktree: makeWorktree(configuredBaseWorktree),
+        knownOrcaLayouts: buildKnownOrcaWorkspaceLayouts(settings, repo)
+      })
+    ).toBe('external')
+  })
+
+  it('shows identically-provenanced worktrees the same way wherever they live', () => {
+    const repo = makeRepo({ worktreeBasePath: '.claude/worktrees' })
+
+    expect(detect(repo, tempScratchpadWorktree)).toMatchObject({
+      ownership: 'external',
+      visible: true
+    })
+    expect(detect(repo, configuredBaseWorktree)).toMatchObject({
+      ownership: 'external',
+      visible: true
+    })
+  })
+
+  it('does not attribute the configured base to the built-in source row', () => {
+    const repo = makeRepo({ worktreeBasePath: '.claude/worktrees' })
+
+    expect(detect(repo, configuredBaseWorktree).visibilitySource).toBeUndefined()
+  })
+
+  it('hands the configured base to the project external-worktree setting', () => {
+    const repo = makeRepo({
+      worktreeBasePath: '.claude/worktrees',
+      externalWorktreeVisibility: 'hide',
+      worktreeVisibilitySourcePreferences: { builtIn: { claude: 'show' } }
+    })
+
+    // The built-in source no longer covers this directory, so its preference
+    // stops applying here and the ordinary external-worktree policy governs.
+    expect(detect(repo, configuredBaseWorktree)).toMatchObject({
+      ownership: 'external',
+      visible: false
+    })
+    expect(detect(repo, tempScratchpadWorktree).visible).toBe(false)
+  })
+
+  it('still lets the built-in preference govern other checkouts scratch dirs', () => {
+    const repo = makeRepo({
+      worktreeBasePath: '.claude/worktrees',
+      externalWorktreeVisibility: 'hide',
+      worktreeVisibilitySourcePreferences: { builtIn: { claude: 'show' } }
+    })
+    const linkedCheckout = '/orca/workspaces/OrbisCXM/feature-x'
+    const settings = makeSettings()
+
+    expect(
+      toDetectedWorktree({
+        repo,
+        settings,
+        worktree: makeWorktree(`${linkedCheckout}/.claude/worktrees/agent-a04ccaaa`),
+        knownOrcaLayouts: buildKnownOrcaWorkspaceLayouts(settings, repo),
+        worktreeVisibilitySourceMatcher: createWorktreeVisibilitySourceMatcher(
+          [repo.path, linkedCheckout],
+          [],
+          resolveConfiguredWorktreeBasePaths(repo)
+        )
+      })
+    ).toMatchObject({ ownership: 'agent-scratch', visible: true })
+  })
+
+  it('resolves a Windows-style configured base against the repo root', () => {
+    const repo = makeRepo({
+      path: String.raw`F:\GitHub\OrbisCXM`,
+      worktreeBasePath: String.raw`.claude\worktrees`
+    })
+
+    expect(
+      detect(repo, String.raw`F:\GitHub\OrbisCXM\.claude\worktrees\OrbisCXM\squash`)
+    ).toMatchObject({
+      ownership: 'external',
+      visible: true
+    })
+  })
+
+  it('resolves an absolute configured base that matches a built-in source', () => {
+    const repo = makeRepo({ worktreeBasePath: '/repos/OrbisCXM/.claude/worktrees' })
+
+    expect(detect(repo, configuredBaseWorktree)).toMatchObject({
+      ownership: 'external',
+      visible: true
+    })
+  })
+})
+
+describe('agent scratch stays hidden for repos that did not configure that base (#9388)', () => {
+  const scratchWorktree = '/repos/OrbisCXM/.claude/worktrees/OrbisCXM/agent-a04ccaaa'
+
+  it('hides an unconfigured .claude/worktrees checkout', () => {
+    expect(detect(makeRepo(), scratchWorktree)).toMatchObject({
+      ownership: 'agent-scratch',
+      visible: false
+    })
+  })
+
+  it('hides it when the configured base points somewhere else', () => {
+    const repo = makeRepo({ worktreeBasePath: '../worktrees' })
+
+    expect(detect(repo, scratchWorktree)).toMatchObject({
+      ownership: 'agent-scratch',
+      visible: false
+    })
+  })
+
+  it('hides scratch nested under a linked checkout even with a configured base', () => {
+    const repo = makeRepo({ worktreeBasePath: '.claude/worktrees' })
+    const linkedCheckout = '/orca/workspaces/OrbisCXM/feature-x'
+    const settings = makeSettings()
+
+    expect(
+      toDetectedWorktree({
+        repo,
+        settings,
+        worktree: makeWorktree(`${linkedCheckout}/.claude/worktrees/agent-a04ccaaa`),
+        knownOrcaLayouts: buildKnownOrcaWorkspaceLayouts(settings, repo),
+        worktreeVisibilitySourceMatcher: createWorktreeVisibilitySourceMatcher(
+          [repo.path, linkedCheckout],
+          [],
+          resolveConfiguredWorktreeBasePaths(repo)
+        )
+      })
+    ).toMatchObject({ ownership: 'agent-scratch', visible: false })
+  })
+
+  it('hides scratch when the configured base only contains the scratch root', () => {
+    for (const worktreeBasePath of ['.', '..', '../worktrees/..']) {
+      expect(detect(makeRepo({ worktreeBasePath }), scratchWorktree)).toMatchObject({
+        ownership: 'agent-scratch',
+        visible: false
+      })
+    }
+  })
+
+  it('exempts only the built-in root the configured base points at', () => {
+    const repo = makeRepo({ worktreeBasePath: '.claude/worktrees' })
+    const settings = makeSettings()
+    // A checkout inside the configured base keeps its own scratch dir hidden.
+    const nestedCheckout = '/repos/OrbisCXM/.claude/worktrees/OrbisCXM/nested'
+
+    expect(
+      toDetectedWorktree({
+        repo,
+        settings,
+        worktree: makeWorktree(`${nestedCheckout}/.claude/worktrees/agent-a04ccaaa`),
+        knownOrcaLayouts: buildKnownOrcaWorkspaceLayouts(settings, repo),
+        worktreeVisibilitySourceMatcher: createWorktreeVisibilitySourceMatcher(
+          [repo.path, nestedCheckout],
+          [],
+          resolveConfiguredWorktreeBasePaths(repo)
+        )
+      })
+    ).toMatchObject({ ownership: 'agent-scratch', visible: false })
+  })
+
+  it('hides the other built-in source inside a repo that configured only the claude one', () => {
+    const repo = makeRepo({ worktreeBasePath: '.claude/worktrees' })
+
+    expect(detect(repo, '/repos/OrbisCXM/.gsd-workspaces/phase-1')).toMatchObject({
+      ownership: 'agent-scratch',
+      visible: false
+    })
+  })
+})

--- a/src/shared/worktree/ownership-worktree-base-path.test.ts
+++ b/src/shared/worktree/ownership-worktree-base-path.test.ts
@@ -30,6 +30,34 @@ function makeSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings {
 }
 
 describe('repo-specific worktree ownership layouts', () => {
+  it('lets an explicitly configured Claude base outrank the built-in scratch path', () => {
+    const repo = makeRepo({ worktreeBasePath: '.claude/worktrees' })
+    const settings = makeSettings()
+    const worktree = makeWorktree('/projects/a/repo/.claude/worktrees/repo/feature')
+
+    expect(
+      classifyWorktreeOwnership({
+        repo,
+        settings,
+        worktree,
+        knownOrcaLayouts: buildKnownOrcaWorkspaceLayouts(settings, repo)
+      })
+    ).toBe('external')
+  })
+
+  it('keeps the same path classified as scratch without the explicit base', () => {
+    const repo = makeRepo()
+    const settings = makeSettings()
+    expect(
+      classifyWorktreeOwnership({
+        repo,
+        settings,
+        worktree: makeWorktree('/projects/a/repo/.claude/worktrees/repo/feature'),
+        knownOrcaLayouts: buildKnownOrcaWorkspaceLayouts(settings, repo)
+      })
+    ).toBe('agent-scratch')
+  })
+
   it('resolves the same relative base path from each repo root', () => {
     const settings = makeSettings()
     const repoA = makeRepo({ path: '/projects/a/repo', worktreeBasePath: '../worktrees' })

--- a/src/shared/worktree/ownership-worktree-base-path.test.ts
+++ b/src/shared/worktree/ownership-worktree-base-path.test.ts
@@ -154,6 +154,25 @@ describe('repo-specific worktree ownership layouts', () => {
     ).toBe('external')
   })
 
+  it('preserves mixed-case WSL paths while resolving the configured base', () => {
+    const repo = makeRepo({
+      path: '\\\\wsl.localhost\\Ubuntu-24.04\\home\\Dev\\Repo',
+      worktreeBasePath: '/home/Dev/Repo/.claude/worktrees'
+    })
+    const settings = makeSettings({ workspaceDir: 'C:\\global' })
+
+    expect(
+      classifyWorktreeOwnership({
+        repo,
+        settings,
+        worktree: makeWorktree(
+          '\\\\wsl.localhost\\Ubuntu-24.04\\home\\Dev\\Repo\\.claude\\worktrees\\feature'
+        ),
+        knownOrcaLayouts: buildKnownOrcaWorkspaceLayouts(settings, repo)
+      })
+    ).toBe('external')
+  })
+
   it('includes relative global layouts for SSH repos without applying absolute desktop paths', () => {
     const repo = makeRepo({ path: '/remote/repo', connectionId: 'ssh-1' })
     const relativeSettings = makeSettings({ workspaceDir: '../worktrees' })

--- a/src/shared/worktree/ownership.test.ts
+++ b/src/shared/worktree/ownership.test.ts
@@ -507,10 +507,10 @@ describe('agent scratch worktrees', () => {
           isMainWorktree: false
         }),
         knownOrcaLayouts: buildKnownOrcaWorkspaceLayouts(settings, repo),
-        agentScratchWorktreePathMatcher: createAgentScratchWorktreePathMatcher([
-          repo.path,
-          linkedCheckoutPath
-        ])
+        agentScratchWorktreePathMatcher: createAgentScratchWorktreePathMatcher(
+          [repo.path, linkedCheckoutPath],
+          []
+        )
       })
     ).toBe('agent-scratch')
   })

--- a/src/shared/worktree/ownership.ts
+++ b/src/shared/worktree/ownership.ts
@@ -1,12 +1,10 @@
+import { normalizeRuntimePathForComparison, relativePathInsideRoot } from '../cross-platform-path'
+import { parseWslUncPath } from '../wsl-paths'
 import {
-  isRuntimePathAbsolute,
-  isWindowsAbsolutePathLike,
-  normalizeRuntimePathForComparison,
-  normalizeRuntimePathSeparators,
-  relativePathInsideRoot,
-  resolveRuntimePath
-} from '../cross-platform-path'
-import { parseWslUncPath, resolveWslRepoWorktreeBasePath } from '../wsl-paths'
+  isRuntimePathAbsoluteForRepo,
+  resolveConfiguredWorktreeBasePaths,
+  resolveWorkspaceLayoutPath
+} from './configured-worktree-base-path'
 import {
   isAgentScratchWorktreePath,
   type AgentScratchWorktreePathMatcher
@@ -36,12 +34,8 @@ export function buildKnownOrcaWorkspaceLayouts(
   repo?: Pick<Repo, 'path' | 'connectionId' | 'worktreeBasePath'>
 ): OrcaWorkspaceLayout[] {
   const layouts: OrcaWorkspaceLayout[] = []
-  const repoBasePath = getRepoWorktreeBasePath(repo)
-  if (repo && repoBasePath) {
-    layouts.push({
-      path: resolveWorkspaceLayoutPath(repo.path, repoBasePath),
-      nestWorkspaces: settings.nestWorkspaces
-    })
+  for (const basePath of resolveConfiguredWorktreeBasePaths(repo)) {
+    layouts.push({ path: basePath, nestWorkspaces: settings.nestWorkspaces })
   }
   if (settings.workspaceDir && shouldIncludeWorkspaceLayout(repo, settings.workspaceDir)) {
     layouts.push({
@@ -86,32 +80,6 @@ function appendWorkspaceLayouts(
   }
 }
 
-function getRepoWorktreeBasePath(
-  repo: Pick<Repo, 'path' | 'worktreeBasePath'> | undefined
-): string | undefined {
-  const trimmed = repo?.worktreeBasePath?.trim()
-  if (!repo || !trimmed) {
-    return undefined
-  }
-  // Why: creation resolves Linux base paths of WSL repos to their UNC form,
-  // so ownership layouts must match or those worktrees would never classify.
-  return resolveWslRepoWorktreeBasePath(repo.path, trimmed)
-}
-
-function resolveWorkspaceLayoutPath(repoPath: string, layoutPath: string): string {
-  return isRuntimePathAbsoluteForRepo(repoPath, layoutPath)
-    ? normalizeRuntimePathSeparators(layoutPath)
-    : resolveRuntimePath(repoPath, layoutPath)
-}
-
-function isRuntimePathAbsoluteForRepo(repoPath: string, layoutPath: string): boolean {
-  const pathFlavor =
-    isWindowsAbsolutePathLike(repoPath) || isWindowsAbsolutePathLike(layoutPath)
-      ? 'windows'
-      : 'posix'
-  return isRuntimePathAbsolute(layoutPath, pathFlavor)
-}
-
 function shouldIncludeWorkspaceLayout(
   repo: Pick<Repo, 'path' | 'connectionId'> | undefined,
   layoutPath: string
@@ -154,11 +122,16 @@ export function classifyWorktreeOwnership(args: {
   }
 
   // Why: sub-agent scratch worktrees (e.g. .claude/worktrees) are tool
-  // plumbing, not workspaces; classify before layout heuristics (#9388).
+  // plumbing, not workspaces; classify before layout heuristics (#9388). Both
+  // matchers exempt a base this project explicitly configured (#15232).
   if (
     args.worktreeVisibilitySourceMatcher?.(args.worktree.path)?.kind === 'built-in' ||
     (args.agentScratchWorktreePathMatcher?.(args.worktree.path) ??
-      isAgentScratchWorktreePath(args.repo.path, args.worktree.path))
+      isAgentScratchWorktreePath(
+        args.repo.path,
+        args.worktree.path,
+        resolveConfiguredWorktreeBasePaths(args.repo)
+      ))
   ) {
     return 'agent-scratch'
   }
@@ -193,7 +166,8 @@ export function toDetectedWorktree(args: {
     args.worktreeVisibilitySourceMatcher ??
     createWorktreeVisibilitySourceMatcher(
       [args.repo.path],
-      resolveCustomWorktreeVisibilitySources(args.repo, args.settings.worktreeVisibilityDefaults)
+      resolveCustomWorktreeVisibilitySources(args.repo, args.settings.worktreeVisibilityDefaults),
+      resolveConfiguredWorktreeBasePaths(args.repo)
     )
   const visibilitySource = sourceMatcher(args.worktree.path)
   const ownership = classifyWorktreeOwnership({

--- a/src/shared/worktree/ownership.ts
+++ b/src/shared/worktree/ownership.ts
@@ -136,6 +136,15 @@ export function classifyWorktreeOwnership(args: {
     return 'agent-scratch'
   }
 
+  if (
+    resolveConfiguredWorktreeBasePaths(args.repo).some(
+      (basePath) => relativePathInsideRoot(basePath, args.worktree.path) !== null
+    )
+  ) {
+    // Why: an explicit project base is trusted even when global workspace nesting is flat.
+    return 'external'
+  }
+
   if (isUnderFlatOrUntrustedOrcaRoot(args.worktree.path, args.knownOrcaLayouts)) {
     return 'unknown-legacy'
   }

--- a/src/shared/worktree/visibility-sources.test.ts
+++ b/src/shared/worktree/visibility-sources.test.ts
@@ -69,6 +69,16 @@ describe('worktree visibility sources', () => {
     expect(classify('/repo/.gsd-workspaces/phase-1')).toEqual({ kind: 'built-in', id: 'gsd' })
   })
 
+  it('preserves WSL path casing when a configured base supersedes a built-in root', () => {
+    const classify = createWorktreeVisibilitySourceMatcher(
+      ['//wsl$/Ubuntu/home/Dev/repo'],
+      [],
+      ['//wsl.localhost/Ubuntu/home/Dev/repo/.claude/worktrees']
+    )
+
+    expect(classify('//wsl.localhost/Ubuntu/home/Dev/repo/.claude/worktrees/review')).toBeNull()
+  })
+
   it('keeps a built-in root a base merely contains', () => {
     for (const configuredBase of ['/repo', '/']) {
       const classify = createWorktreeVisibilitySourceMatcher(['/repo'], [], [configuredBase])

--- a/src/shared/worktree/visibility-sources.test.ts
+++ b/src/shared/worktree/visibility-sources.test.ts
@@ -79,6 +79,19 @@ describe('worktree visibility sources', () => {
     }
   })
 
+  it('keeps sibling scratch under a built-in root a nested base does not contain', () => {
+    const classify = createWorktreeVisibilitySourceMatcher(
+      ['/repo'],
+      [],
+      ['/repo/.claude/worktrees/OrbisCXM']
+    )
+    expect(classify('/repo/.claude/worktrees/Other/agent-1')).toEqual({
+      kind: 'built-in',
+      id: 'claude'
+    })
+    expect(classify('/repo/.claude/worktrees/OrbisCXM/agent-1')).toBeNull()
+  })
+
   it('lets a custom source claim a configured base the built-in released', () => {
     const classify = createWorktreeVisibilitySourceMatcher(
       ['/repo'],

--- a/src/shared/worktree/visibility-sources.test.ts
+++ b/src/shared/worktree/visibility-sources.test.ts
@@ -26,7 +26,7 @@ function repo(overrides: Partial<Repo> = {}): Repo {
 
 describe('worktree visibility sources', () => {
   it('classifies each built-in independently across linked checkouts', () => {
-    const classify = createWorktreeVisibilitySourceMatcher(['/repo', '/worktrees/feature'])
+    const classify = createWorktreeVisibilitySourceMatcher(['/repo', '/worktrees/feature'], [], [])
     expect(classify('/repo/.claude/worktrees/review')).toEqual({
       kind: 'built-in',
       id: 'claude'
@@ -41,7 +41,8 @@ describe('worktree visibility sources', () => {
   it('matches custom descendants with Windows and WSL comparison semantics', () => {
     const windows = createWorktreeVisibilitySourceMatcher(
       [],
-      [{ id: 'team', rootPath: 'C:\\Users\\Dev\\Team' }]
+      [{ id: 'team', rootPath: 'C:\\Users\\Dev\\Team' }],
+      []
     )
     expect(windows('c:\\users\\dev\\team\\feature')).toEqual({
       kind: 'custom',
@@ -50,7 +51,8 @@ describe('worktree visibility sources', () => {
 
     const wsl = createWorktreeVisibilitySourceMatcher(
       [],
-      [{ id: 'linux', rootPath: '//wsl$/Ubuntu/home/dev/team' }]
+      [{ id: 'linux', rootPath: '//wsl$/Ubuntu/home/dev/team' }],
+      []
     )
     expect(wsl('//wsl.localhost/Ubuntu/home/dev/team/feature')).toEqual({
       kind: 'custom',
@@ -114,7 +116,8 @@ describe('worktree visibility sources', () => {
   it('gives built-ins precedence over overlapping custom roots', () => {
     const classify = createWorktreeVisibilitySourceMatcher(
       ['/repo'],
-      [{ id: 'overlap', rootPath: '/repo/.claude/worktrees' }]
+      [{ id: 'overlap', rootPath: '/repo/.claude/worktrees' }],
+      []
     )
     expect(classify('/repo/.claude/worktrees/review')).toEqual({
       kind: 'built-in',
@@ -128,7 +131,8 @@ describe('worktree visibility sources', () => {
       Array.from({ length: 32 }, (_, index) => ({
         id: `custom-${index}`,
         rootPath: `/custom/${index}`
-      }))
+      })),
+      []
     )
     const normalize = vi.spyOn(String.prototype, 'normalize')
 
@@ -192,7 +196,8 @@ describe('worktree visibility sources', () => {
       const current = repo({ path: checkout })
       const classify = createWorktreeVisibilitySourceMatcher(
         [checkout],
-        resolveCustomWorktreeVisibilitySources(current, defaults)
+        resolveCustomWorktreeVisibilitySources(current, defaults),
+        []
       )
       expect(classify('/srv/global-worktrees/feature')).toEqual({
         kind: 'custom',

--- a/src/shared/worktree/visibility-sources.test.ts
+++ b/src/shared/worktree/visibility-sources.test.ts
@@ -59,6 +59,35 @@ describe('worktree visibility sources', () => {
     expect(wsl('//wsl.localhost/Ubuntu/home/Dev/team/feature')).toBeNull()
   })
 
+  it('yields a built-in root to a worktree base the project configured there', () => {
+    const classify = createWorktreeVisibilitySourceMatcher(
+      ['/repo'],
+      [],
+      ['/repo/.claude/worktrees']
+    )
+    expect(classify('/repo/.claude/worktrees/review')).toBeNull()
+    expect(classify('/repo/.gsd-workspaces/phase-1')).toEqual({ kind: 'built-in', id: 'gsd' })
+  })
+
+  it('keeps a built-in root a base merely contains', () => {
+    for (const configuredBase of ['/repo', '/']) {
+      const classify = createWorktreeVisibilitySourceMatcher(['/repo'], [], [configuredBase])
+      expect(classify('/repo/.claude/worktrees/review')).toEqual({
+        kind: 'built-in',
+        id: 'claude'
+      })
+    }
+  })
+
+  it('lets a custom source claim a configured base the built-in released', () => {
+    const classify = createWorktreeVisibilitySourceMatcher(
+      ['/repo'],
+      [{ id: 'overlap', rootPath: '/repo/.claude/worktrees' }],
+      ['/repo/.claude/worktrees']
+    )
+    expect(classify('/repo/.claude/worktrees/review')).toEqual({ kind: 'custom', id: 'overlap' })
+  })
+
   it('gives built-ins precedence over overlapping custom roots', () => {
     const classify = createWorktreeVisibilitySourceMatcher(
       ['/repo'],

--- a/src/shared/worktree/visibility-sources.test.ts
+++ b/src/shared/worktree/visibility-sources.test.ts
@@ -138,6 +138,20 @@ describe('worktree visibility sources', () => {
     normalize.mockRestore()
   })
 
+  it('normalizes each candidate once when a configured base supersedes a built-in root', () => {
+    const classify = createWorktreeVisibilitySourceMatcher(
+      ['/repo'],
+      [],
+      ['/repo/.claude/worktrees']
+    )
+    const normalize = vi.spyOn(String.prototype, 'normalize')
+
+    classify('/repo/.claude/worktrees/review')
+
+    expect(normalize).toHaveBeenCalledTimes(1)
+    normalize.mockRestore()
+  })
+
   it('migrates the optional legacy agent policy lazily for both built-ins', () => {
     const legacy = repo({ agentWorktreeVisibility: 'show' })
     expect(effectiveBuiltInWorktreeSourceVisibility(legacy, 'claude')).toBe('show')

--- a/src/shared/worktree/visibility-sources.ts
+++ b/src/shared/worktree/visibility-sources.ts
@@ -135,8 +135,8 @@ function createDescendantMatcher(rootPath: string): (normalizedCandidate: string
  */
 export function createWorktreeVisibilitySourceMatcher(
   checkoutPaths: readonly string[],
-  customSources: readonly CustomWorktreeVisibilitySource[] = [],
-  configuredWorktreeBasePaths: readonly string[] = []
+  customSources: readonly CustomWorktreeVisibilitySource[],
+  configuredWorktreeBasePaths: readonly string[]
 ): WorktreeVisibilitySourceMatcher {
   const checkoutPathKeys = new Set(checkoutPaths.map(normalizeRuntimePathForComparison))
   const customMatchers = customSources.map(({ id, rootPath }) => ({

--- a/src/shared/worktree/visibility-sources.ts
+++ b/src/shared/worktree/visibility-sources.ts
@@ -1,6 +1,5 @@
 import {
   createNormalizedPathInsideOrEqualMatcher,
-  isPathInsideOrEqual,
   isRuntimePathAbsolute,
   normalizeRuntimePathForComparison
 } from '../cross-platform-path'
@@ -145,14 +144,16 @@ export function createWorktreeVisibilitySourceMatcher(
     matches: createDescendantMatcher(rootPath)
   }))
   const configuredBases = configuredWorktreeBasePaths.map((basePath) => ({
-    path: basePath,
+    key: normalizeRuntimePathForComparison(basePath),
     contains: createNormalizedPathInsideOrEqualMatcher(basePath)
   }))
   // Why: only a base pointing at or inside the matched root counts. A base of
   // `.` or `..` merely contains the root and must not exempt it (#9388).
   const isSupersededByConfiguredBase = (sourceRootKey: string, candidateKey: string): boolean =>
     configuredBases.some(
-      (base) => base.contains(candidateKey) && isPathInsideOrEqual(sourceRootKey, base.path)
+      (base) =>
+        base.contains(candidateKey) &&
+        (base.key === sourceRootKey || base.key.startsWith(`${sourceRootKey}/`))
     )
   return (worktreePath) => {
     const normalizedCandidate = normalizeRuntimePathForComparison(worktreePath)

--- a/src/shared/worktree/visibility-sources.ts
+++ b/src/shared/worktree/visibility-sources.ts
@@ -1,5 +1,6 @@
 import {
   createNormalizedPathInsideOrEqualMatcher,
+  isPathInsideOrEqual,
   isRuntimePathAbsolute,
   normalizeRuntimePathForComparison
 } from '../cross-platform-path'
@@ -130,13 +131,24 @@ function createDescendantMatcher(rootPath: string): (normalizedCandidate: string
 
 export function createWorktreeVisibilitySourceMatcher(
   checkoutPaths: readonly string[],
-  customSources: readonly CustomWorktreeVisibilitySource[] = []
+  customSources: readonly CustomWorktreeVisibilitySource[] = [],
+  configuredWorktreeBasePaths: readonly string[] = []
 ): WorktreeVisibilitySourceMatcher {
   const checkoutPathKeys = new Set(checkoutPaths.map(normalizeRuntimePathForComparison))
   const customMatchers = customSources.map(({ id, rootPath }) => ({
     id,
     matches: createDescendantMatcher(rootPath)
   }))
+  const configuredBases = configuredWorktreeBasePaths.map((basePath) => ({
+    path: basePath,
+    contains: createNormalizedPathInsideOrEqualMatcher(basePath)
+  }))
+  // Why: only a base pointing at or inside the matched root counts. A base of
+  // `.` or `..` merely contains the root and must not exempt it (#9388).
+  const isSupersededByConfiguredBase = (sourceRootKey: string, candidateKey: string): boolean =>
+    configuredBases.some(
+      (base) => base.contains(candidateKey) && isPathInsideOrEqual(sourceRootKey, base.path)
+    )
   return (worktreePath) => {
     const normalizedCandidate = normalizeRuntimePathForComparison(worktreePath)
     const segments = normalizedCandidate.split('/')
@@ -150,7 +162,13 @@ export function createWorktreeVisibilitySourceMatcher(
         const checkoutPathKey = /^[a-z]:$/i.test(checkoutPath)
           ? `${checkoutPath}/`
           : checkoutPath || '/'
-        if (checkoutPathKeys.has(checkoutPathKey)) {
+        if (
+          checkoutPathKeys.has(checkoutPathKey) &&
+          !isSupersededByConfiguredBase(
+            segments.slice(0, index + prefix.length).join('/'),
+            normalizedCandidate
+          )
+        ) {
           return { kind: 'built-in', id: source.id }
         }
       }

--- a/src/shared/worktree/visibility-sources.ts
+++ b/src/shared/worktree/visibility-sources.ts
@@ -129,6 +129,11 @@ function createDescendantMatcher(rootPath: string): (normalizedCandidate: string
     normalizedCandidate !== normalizedRoot && matchesInsideOrEqual(normalizedCandidate)
 }
 
+/**
+ * Precondition: `configuredWorktreeBasePaths` are already resolved and free of
+ * `.`/`..` segments — pass them through `resolveConfiguredWorktreeBasePaths`,
+ * since a raw `.claude/worktrees/.` compares unequal and would not supersede.
+ */
 export function createWorktreeVisibilitySourceMatcher(
   checkoutPaths: readonly string[],
   customSources: readonly CustomWorktreeVisibilitySource[] = [],


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​492 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​30 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​462 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​125 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​58 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​67 |

<!-- /orca-pr-loc -->
Fixes #15232.

## Problem and deterministic reproduction

On `origin/main` at `59892a2f`, a project configured with `worktreeBasePath: '.claude/worktrees'` still lost to the generic Claude scratch-path heuristic. A plain external `git worktree add` under that explicit base was classified as `agent-scratch`, attributed to the built-in `claude` visibility source, and hidden. The same repo's external worktree elsewhere was visible. A second repo with no configured base correctly kept `.claude/worktrees` hidden, preserving #9388.

The focused oracle is:

```powershell
pnpm exec vitest run --config config/vitest.config.ts `
  src/shared/worktree/ownership-worktree-base-path.test.ts `
  -t "lets an explicitly configured Claude base outrank the built-in scratch path"
```

| Revision | Result |
|---|---|
| Baseline reproduction `221b8daf54` | fails: `agent-scratch` |
| Candidate `d604bc56e9` | passes: external and visible |
| Candidate with the precedence guard reverted | fails again: `agent-scratch` |
| Candidate restored byte-for-byte | passes |

## Root cause and fix

The ownership classifier checked built-in source matches before configured workspace layouts, and visibility separately honored the source attribution before ownership. A renderer-only show override therefore cannot fix the authoritative result.

The matcher now receives the repo's configured worktree bases and lets an explicit base supersede a matching **built-in** scratch source only when that base is inside the matched source root for that same repo. Ownership and visibility use the same decision. Required arguments prevent a caller from silently omitting the invariant.

This keeps the boundary narrow:

- Project A configuring `.claude/worktrees` sees plain external worktrees there as externally owned.
- Project B without that configuration still hides the same conventional scratch path.
- A broad base such as `.` or `..` does not unhide nested scratch.
- A configured sub-base does not unhide siblings under the same scratch root.
- Strong Orca creation metadata still wins.
- Custom visibility sources and their counts retain their existing behavior.
- Linked checkouts, flat layouts, folder-workspace callers, SSH-relative paths, Windows drive/UNC case normalization, and WSL case-sensitive paths are covered.

No Git command, provider-specific behavior, RPC field, or stream shape changes. Git 2.25 compatibility and mixed client/server wire compatibility are therefore unchanged.

### Alternatives rejected

- **Renderer-only show override:** ownership/source data and visibility counts would remain wrong.
- **New global precedence rung:** broader state and call-site churn for a collision the existing matcher can resolve locally.
- **Configuration warning/rejection:** `.claude/worktrees` is a valid explicit base; rejecting it preserves the bug instead of honoring user intent.
- **Unhide every path contained by a broad configured base:** would regress #9388 and expose unrelated scratch worktrees.

## Physical Windows + WSL Electron evidence

A fresh isolated dev profile (`ORCA_DEV_USER_DATA_PATH`) and unique CDP port were used on this physical Windows host. All fixtures were created with the real Git binary and no Orca metadata. The live renderer bridge returned:

```json
[
  {"name":"configured-hidden","ownership":"external","visible":true,"source":null},
  {"name":"outside-visible","ownership":"external","visible":true,"source":null},
  {"name":"negative-hidden","ownership":"agent-scratch","visible":false,"source":{"kind":"built-in","id":"claude"}},
  {"name":"WslMixedVisible","ownership":"external","visible":true,"source":null}
]
```

The sidebar visibly showed `configured-hidden`, `outside-visible`, and mixed-case WSL worktree `WslMixedVisible`; `negative-hidden` was absent. The visibility dialog showed Claude `0 found`, Other locations `2 found`, Hidden `0`. Restarting the same isolated profile produced the identical DOM and classifications. The WSL fixture used `\\wsl.localhost\Ubuntu-24.04\tmp\OrcaGh15232\MixedCaseRepo` with WSL Git 2.43, specifically exercising key-vs-raw case handling.

## Validation

- Focused candidate suites: **58/58 passed** across five ownership, visibility-source, scratch-source, IPC, and visibility-dialog files.
- `pnpm typecheck`: passed.
- `pnpm build`: passed, including desktop and native build.
- `git diff --check origin/main...HEAD`: passed.
- Full `pnpm lint`: oxlint, native/type-aware audits, reliability gates, max-lines, and bundled-guide verification passed; the command exits only on three untouched stale generated skill registry artifacts (`current-manifest.json`, `snapshot-registry.json`, `release-mapping.json`). They were not regenerated or committed as unrelated churn.
- Broad `pnpm test` is not usable as a product oracle on this host because unchanged main produces hundreds of watcher/symlink/environment/timing failures; focused suites and the mutation-proven oracle are clean.
- Two final fresh OpenCode reviews were clean: MiMo V2.5 Free and Nemotron 3 Ultra Free. Earlier review feedback added a plain-repo source assertion plus SSH-relative, Windows drive, and UNC coverage.

Remaining live gap: no physical SSH server E2E was available. SSH and folder-workspace behavior is covered at the pure classification boundary and introduces no wire or execution-host changes. GitHub CI is the final gate; this PR must not be merged until required checks are green.