### PR TITLE
fix(session): keep session state for worktrees hidden from the sidebar (#15227)

### DIFF
--- a/src/renderer/src/store/slices/degraded-repo-worktree-validity.ts
+++ b/src/renderer/src/store/slices/degraded-repo-worktree-validity.ts
@@ -8,7 +8,7 @@ type WorktreeValidityCatalog = {
   repos: readonly Pick<Repo, 'id'>[]
   worktreesByRepo: Readonly<Record<string, readonly Pick<Worktree, 'id'>[]>>
   detectedWorktreesByRepo?: Readonly<
-    Record<string, Pick<DetectedWorktreeListResult, 'authoritative'> | undefined>
+    Record<string, Pick<DetectedWorktreeListResult, 'authoritative' | 'worktrees'> | undefined>
   >
 }
 
@@ -60,9 +60,21 @@ export function buildValidWorktreeIdsForSessionHydration(
       .filter(([, detected]) => detected?.authoritative)
       .map(([repoId]) => repoId)
   )
+  // Why (#15227): worktreesByRepo is the sidebar catalog, which drops worktrees hidden by
+  // visibility settings; an authoritative scan still lists them. Detection, not display, is
+  // the existence signal — otherwise hiding a worktree reads as deleting it.
+  const authoritativelyDetectedWorktreeIds = new Set(
+    Object.values(detectedWorktreesByRepo).flatMap((detected) =>
+      detected?.authoritative ? detected.worktrees.map((worktree) => worktree.id) : []
+    )
+  )
 
   for (const worktreeId of persistedWorktreeIds) {
     if (validWorktreeIds.has(worktreeId) || parseWorkspaceKey(worktreeId)?.type === 'folder') {
+      continue
+    }
+    if (authoritativelyDetectedWorktreeIds.has(worktreeId)) {
+      validWorktreeIds.add(worktreeId)
       continue
     }
     const repoId = getRepoIdFromWorktreeId(worktreeId)

--- a/src/renderer/src/store/slices/hidden-worktree-session-hydration.test.ts
+++ b/src/renderer/src/store/slices/hidden-worktree-session-hydration.test.ts
@@ -1,0 +1,142 @@
+import { expect, it, vi } from 'vitest'
+import type * as AgentStatusModule from '@/lib/agent-status'
+import type { WorkspaceSessionState } from '../../../../shared/workspace-session-state-types'
+import type { DetectedWorktree } from '../../../../shared/worktree/types'
+import { getDefaultWorkspaceSession } from '../../../../shared/constants'
+
+vi.mock('sonner', () => ({ toast: { info: vi.fn(), success: vi.fn(), error: vi.fn() } }))
+vi.mock('@/lib/agent-status', async (importOriginal) => {
+  const actual = await importOriginal<typeof AgentStatusModule>()
+  return { ...actual, detectAgentStatusFromTitle: vi.fn().mockReturnValue(null) }
+})
+
+// @ts-expect-error -- mocked browser preload API
+globalThis.window = { api: {} }
+
+import { createTestStore, makeTab, makeWorktree, TEST_REPO } from './store-test-helpers'
+import { buildValidWorktreeIdsForSessionHydration } from './degraded-repo-worktree-validity'
+
+const CHECKOUT_ID = `${TEST_REPO.id}::/repo1`
+const HIDDEN_ID = `${TEST_REPO.id}::/repo1/.claude/worktrees/lane-a`
+const HIDDEN_TAB_ID = 'terminal-lane-a'
+
+function makeDetectedWorktree(
+  overrides: Partial<DetectedWorktree> & { id: string; path: string }
+): DetectedWorktree {
+  return {
+    ...makeWorktree({ id: overrides.id, repoId: TEST_REPO.id, path: overrides.path }),
+    ownership: 'agent-scratch',
+    selectedCheckout: false,
+    visible: false,
+    ...overrides
+  }
+}
+
+/** The catalog shape a repo with one visible checkout plus one hidden agent-scratch worktree
+ *  produces: `worktreesByRepo` carries only the visible rows, the authoritative scan carries both. */
+function seedHiddenWorktreeCatalog(store: ReturnType<typeof createTestStore>): void {
+  store.setState({
+    repos: [TEST_REPO],
+    worktreesByRepo: {
+      [TEST_REPO.id]: [makeWorktree({ id: CHECKOUT_ID, repoId: TEST_REPO.id, path: '/repo1' })]
+    },
+    detectedWorktreesByRepo: {
+      [TEST_REPO.id]: {
+        repoId: TEST_REPO.id,
+        authoritative: true,
+        source: 'git',
+        worktrees: [
+          makeDetectedWorktree({
+            id: CHECKOUT_ID,
+            path: '/repo1',
+            ownership: 'external',
+            selectedCheckout: true,
+            visible: true
+          }),
+          makeDetectedWorktree({ id: HIDDEN_ID, path: '/repo1/.claude/worktrees/lane-a' })
+        ]
+      }
+    }
+  })
+}
+
+function makeHiddenWorktreeSession(): WorkspaceSessionState {
+  return {
+    ...getDefaultWorkspaceSession(),
+    activeRepoId: TEST_REPO.id,
+    tabsByWorktree: {
+      [HIDDEN_ID]: [makeTab({ id: HIDDEN_TAB_ID, worktreeId: HIDDEN_ID, ptyId: 'pty-lane-a' })]
+    }
+  }
+}
+
+it('keeps a hidden worktree valid when the authoritative scan still lists it', () => {
+  const validWorktreeIds = buildValidWorktreeIdsForSessionHydration(
+    {
+      repos: [TEST_REPO],
+      worktreesByRepo: { [TEST_REPO.id]: [{ id: CHECKOUT_ID }] },
+      detectedWorktreesByRepo: {
+        [TEST_REPO.id]: {
+          authoritative: true,
+          worktrees: [
+            makeDetectedWorktree({ id: CHECKOUT_ID, path: '/repo1', visible: true }),
+            makeDetectedWorktree({ id: HIDDEN_ID, path: '/repo1/.claude/worktrees/lane-a' })
+          ]
+        }
+      }
+    },
+    [HIDDEN_ID]
+  )
+
+  expect([...validWorktreeIds]).toContain(HIDDEN_ID)
+})
+
+it('still treats a worktree the authoritative scan dropped as deleted', () => {
+  const validWorktreeIds = buildValidWorktreeIdsForSessionHydration(
+    {
+      repos: [TEST_REPO],
+      worktreesByRepo: { [TEST_REPO.id]: [{ id: CHECKOUT_ID }] },
+      detectedWorktreesByRepo: {
+        [TEST_REPO.id]: {
+          authoritative: true,
+          worktrees: [makeDetectedWorktree({ id: CHECKOUT_ID, path: '/repo1', visible: true })]
+        }
+      }
+    },
+    [HIDDEN_ID]
+  )
+
+  expect([...validWorktreeIds]).not.toContain(HIDDEN_ID)
+})
+
+it('restores terminal tabs of a worktree hidden from the sidebar (#15227)', () => {
+  const store = createTestStore()
+  seedHiddenWorktreeCatalog(store)
+  const session = makeHiddenWorktreeSession()
+
+  store.getState().hydrateWorkspaceSession(session)
+  store.getState().hydrateTabsSession(session)
+
+  const state = store.getState()
+  expect(state.tabsByWorktree[HIDDEN_ID]?.map((tab) => tab.id)).toEqual([HIDDEN_TAB_ID])
+})
+
+it('keeps a hidden worktree tab through a hydrate/persist round trip (#15227)', () => {
+  const firstStore = createTestStore()
+  seedHiddenWorktreeCatalog(firstStore)
+  const session = makeHiddenWorktreeSession()
+  firstStore.getState().hydrateWorkspaceSession(session)
+  firstStore.getState().hydrateTabsSession(session)
+
+  // Why: the write path replaces the persisted map wholesale, so a tab dropped during hydration
+  // is erased from disk by the next session write even though its PTY is still running.
+  const persisted = { ...session, tabsByWorktree: firstStore.getState().tabsByWorktree }
+  const restoredStore = createTestStore()
+  seedHiddenWorktreeCatalog(restoredStore)
+  restoredStore.getState().hydrateWorkspaceSession(persisted)
+  restoredStore.getState().hydrateTabsSession(persisted)
+
+  expect(restoredStore.getState().tabsByWorktree[HIDDEN_ID]?.map((tab) => tab.id)).toEqual([
+    HIDDEN_TAB_ID
+  ])
+})


### PR DESCRIPTION
Fixes #15227.

## Repro verdict: reproduced

Windows, dev build, isolated profile. A repo with one visible checkout plus a worktree created outside Orca (`git worktree add .claude/worktrees/lane-a`, classified `agent-scratch`, hidden by default), then `orca terminal create --worktree "path:…/lane-a"`.

Persisted session file (`profiles/local-default/orca-data.json`), polled every 2s:

```
before the fix
  t+12s  tabs for lane-a: 0
  t+14s  tabs for lane-a: 1     <- CLI create persisted
  …       tabs for lane-a: 1     (survives a clean window close; present in the shutdown snapshot)
  restart
  t+251s tabs for lane-a: 0     <- pruned during hydration of the new session
```

With the tab gone from the session, the PTY that the terminal daemon keeps alive comes back with no pane and no tab binding, which is what `buildPtyTerminalSummary` reports as `orphaned: true` (`src/main/runtime/orca-runtime.ts:34762` — `orphaned = !pty.tabId || !pane || pane.tabId !== pty.tabId`).

## Root cause

`buildValidWorktreeIdsForSessionHydration` (`src/renderer/src/store/slices/degraded-repo-worktree-validity.ts:34`) seeds "worktrees that still exist" from `worktreesByRepo`. That map is the **sidebar catalog**: `toVisibleWorktrees` (`src/renderer/src/store/slices/worktrees/listing/worktree-host-ownership.ts:108`) filters it to `worktree.visible`, so a hidden worktree is never in it. Every persisted key that is not in that set is then kept only when the repo cannot prove deletion — and a repo with a loaded catalog or an authoritative scan counts as proof. A hidden worktree therefore always fails the check, even though the authoritative scan literally just listed it.

Temporary instrumentation in the live app at the hydration site recorded exactly that:

```
persisted: ["…/testrepo/.claude/worktrees/lane-a"]
dropped:   ["…/testrepo/.claude/worktrees/lane-a"]
catalog (worktreesByRepo): ["…/testrepo"]                       <- hidden row filtered out
detected (authoritative):  ["…/testrepo", "…/testrepo/.claude/worktrees/lane-a"]  <- hidden row present
```

Blast radius: the predicate gates terminal, tab-group, editor and browser hydration (`terminals.ts:3825`, `tabs.ts:2039`, `hydrate-editor-session.ts:32`, `browser.ts:1705/1732`), and hydration runs both at startup and mid-session when a direct-SSH workspace snapshot is applied (`remote-workspace-snapshot-apply.ts:128`) — which is how the same prune shows up during normal running with no restart. Because the session write replaces the persisted map wholesale, the next debounced write erases the dropped keys from disk.

## The design question

The issue asks Orca to pick one: refuse to launch agents into worktrees it will not display, or keep their session state. **Keep the state.**

- Visibility is a listing preference, revocable at any time from the visibility dialog. It is presentation, not lifecycle; the workspace, its branch and its processes are unaffected by it.
- Refusing to launch would break a supported flow at its default setting — `.claude/worktrees` is hidden by default, and `orca terminal create --worktree path:…` is how fleets are driven.
- Hidden is not deleted, and Orca already knows the difference: the authoritative scan returns hidden rows, and every other purge path (the one-shot hydration purge in `fetch-all-worktrees.ts:175`, the diff purge in `useIpcEvents.ts`, `pruneLastVisitedTimestamps`) keys off detected rows rather than the visible catalog. This predicate was the outlier.

With the state kept there is no silent loss left: revealing the worktree shows the workspace with its terminals intact.

## The change

Treat any worktree returned by an authoritative scan as valid during session hydration, regardless of whether the sidebar displays it. A worktree the authoritative scan does **not** return is still pruned, so deleted worktrees keep getting reaped.

## Verification

New tests (`src/renderer/src/store/slices/hidden-worktree-session-hydration.test.ts`) drive the real store hydration with the catalog shape measured above.

```
$ npx vitest run --config config/vitest.config.ts src/renderer/src/store/slices/hidden-worktree-session-hydration.test.ts
before (predicate reverted):  Tests  3 failed | 1 passed (4)
after:                        Tests  4 passed (4)
```

The one test that passes either way is the guard that an authoritative scan which drops a worktree still prunes it.

Neighbouring suites: `store/slices/{terminals,tabs,browser,editor,worktrees}`, `degraded-repo-hydration`, and every `hydration` / `session-write` / `workspace-session` file — 116 files, 1245 tests, all passing. `tsc --noEmit -p config/tsconfig.tc.web.json`, `oxlint` (incl. type-aware and code-quality configs), `oxfmt --check`, reliability gates and the max-lines ratchet are clean.

Live re-run of the repro with the fix, same profile and same steps: after the restart the persisted session still holds the lane-a tabs, the store rehydrates them with their `ptyId` bindings, and revealing the worktree shows the workspace with its terminals.

Not verified: the `orphaned: true` → `false` transition end to end. The dev instance hosts its PTYs in-process, so the daemon-survives-restart half of the report could not be measured locally; the persistence half is measured, and the orphan flag is a direct function of the tab binding this restores.

No CSS or dynamically constructed Tailwind classes are touched, so the dev-build validation has no packaged-build blind spot here. No wire-format change: the fix is renderer-local state validity.

## End-to-end evidence with the terminal daemon kept alive

Fresh profile, fresh repo, hidden `.claude/worktrees/lane-a`, terminal created through `orca terminal create` with the renderer up, then the app process tree killed while the terminal daemon (its pid file names it) was left running, then relaunched:

| | persisted tabs after restart | `terminal switch <handle>` |
|---|---|---|
| main | `{}` — pruned at hydration | navigates to a **new** tab id; the original tab, its layout and its PTY binding are gone |
| this branch | the original tab id, with `tab.ptyId` and `terminalLayoutsByTabId[…].ptyIdsByLeafId` intact | navigates to the **original** tab id |

`orca terminal list` still reports `orphaned: true` for the surviving PTY in both cases until a pane actually mounts, and for a worktree hidden from the sidebar that means the user has to reveal it first. The difference this change makes is that after revealing it there is something to reveal: the workspace comes back with its terminals, bound to the PTYs that kept running. On main it comes back empty and the live PTY is only reachable by handle.

Reattaching an already-orphaned PTY — the ones a user has right now, whose tabs were destroyed by earlier runs — is not something this change can recover, and is the reclaim half tracked in #15313.
