### PR TITLE
test(e2e): update stale E2E test contracts and fake Codex fixtures

### DIFF
--- a/tests/e2e/completed-worker-retirement-resume.spec.ts
+++ b/tests/e2e/completed-worker-retirement-resume.spec.ts
@@ -8,6 +8,7 @@ import {
 import {
   cleanupCompletedWorkerFixture,
   clearCompletedWorkerLedger,
+  completedWorkerFakeCodexCommand,
   completedWorkerLaunchEnv,
   listRuntimeTerminals,
   readCompletedWorkerDispatchCapability,
@@ -45,12 +46,13 @@ for (const closeMode of ['terminal-close-cli', 'worker-release'] as const) {
     await ensureTerminalVisible(orcaPage)
     await waitForActiveTerminalManager(orcaPage)
     await waitForActivePanePtyId(orcaPage)
-    await orcaPage.evaluate(async () => {
+    await orcaPage.evaluate(async (agentCommand) => {
       await window.__store?.getState().updateSettings({
+        agentCmdOverrides: { codex: agentCommand },
         disabledTuiAgents: [],
         terminalHiddenViewParking: false
       })
-    })
+    }, completedWorkerFakeCodexCommand)
 
     const userDataDir = await electronApp.evaluate(({ app }) => app.getPath('userData'))
     const isolatedHome = await electronApp.evaluate(({ app }) => app.getPath('home'))

--- a/tests/e2e/helpers/completed-worker-retirement-fixture.ts
+++ b/tests/e2e/helpers/completed-worker-retirement-fixture.ts
@@ -19,6 +19,10 @@ import type {
 
 const fakeCliDir = mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-retired-worker-'))
 const lifecycleLedgerPath = path.join(fakeCliDir, 'codex-lifecycle.jsonl')
+export const completedWorkerFakeCodexCommand = path.join(
+  fakeCliDir,
+  process.platform === 'win32' ? 'codex.cmd' : 'codex'
+)
 const fakeCodexSource = `
 const { appendFileSync } = require('node:fs')
 const ledger = process.env.ORCA_E2E_CODEX_LIFECYCLE_LEDGER
@@ -37,7 +41,8 @@ process.stdin.on('data', (chunk) => {
     append({ event: 'normal-exit' })
     process.exit(0)
   }
-  if (input.includes('\\r')) process.stdout.write('ACK\\n')
+  // Mirror Codex's post-paste cursor marker so settled prompt delivery can finish.
+  if (input.includes('\\r')) process.stdout.write('\\x1b[?25hACK\\n')
 })
 process.stdin.resume()
 setInterval(() => {}, 60_000)

--- a/tests/e2e/orchestration-legacy-worker-missing-terminal-recovery.spec.ts
+++ b/tests/e2e/orchestration-legacy-worker-missing-terminal-recovery.spec.ts
@@ -24,6 +24,7 @@ const PROVIDER_SESSION_ID = 'e2e-missing-legacy-worker'
 const fakeCliDir = mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-missing-legacy-worker-'))
 const spawnLedgerPath = path.join(fakeCliDir, 'spawn.jsonl')
 const interruptionLedgerPath = path.join(fakeCliDir, 'interruption.jsonl')
+const fakeCodexCommand = path.join(fakeCliDir, process.platform === 'win32' ? 'codex.cmd' : 'codex')
 const fakeCodexSource = `
 const { appendFileSync } = require('node:fs')
 function appendLedger(envName, event) {
@@ -47,7 +48,7 @@ process.stdin.on('data', (chunk) => {
   }
   if (!acknowledged && input.includes('\\r')) {
     acknowledged = true
-    process.stdout.write('ACK\\n')
+    process.stdout.write('\\x1b[?25hACK\\n')
   }
 })
 for (const signal of ['SIGINT', 'SIGHUP', 'SIGTERM']) {
@@ -200,6 +201,11 @@ test('a missing legacy worker cannot spawn a replacement during restart recovery
     firstApp = first.app
     const worktreeId = await attachRepoAndOpenTerminal(first.page, repoPath)
     await waitForSessionReady(first.page)
+    await first.page.evaluate(async (agentCommand) => {
+      await window.__store?.getState().updateSettings({
+        agentCmdOverrides: { codex: agentCommand }
+      })
+    }, fakeCodexCommand)
     await ensureTerminalVisible(first.page)
     await getActiveTabId(first.page)
     await waitForActivePanePtyId(first.page)

--- a/tests/e2e/orchestration-legacy-worker-restart-recovery.spec.ts
+++ b/tests/e2e/orchestration-legacy-worker-restart-recovery.spec.ts
@@ -31,6 +31,7 @@ const spawnLedgerPath = path.join(fakeCliDir, 'spawn.jsonl')
 const interruptionLedgerPath = path.join(fakeCliDir, 'interruption.jsonl')
 const authorityLedgerPath = path.join(fakeCliDir, 'authority.jsonl')
 const lifecycleLedgerPath = path.join(fakeCliDir, 'lifecycle.jsonl')
+const fakeCodexCommand = path.join(fakeCliDir, process.platform === 'win32' ? 'codex.cmd' : 'codex')
 const fakeCodexSource = `
 const { appendFileSync } = require('node:fs')
 const { spawnSync } = require('node:child_process')
@@ -90,7 +91,7 @@ process.stdin.on('data', (chunk) => {
   }
   if (!acknowledged && input.includes('\\r')) {
     acknowledged = true
-    process.stdout.write('ACK\\n')
+    process.stdout.write('\\x1b[?25hACK\\n')
   }
   const legacyCompletion = input.match(/ORCA_E2E_RUN_LEGACY_DONE:([A-Za-z0-9+/=]+)/)
   if (!lifecycleSent && legacyCompletion) {
@@ -414,6 +415,11 @@ for (const contractVersion of [LEGACY_CONTRACT_VERSION, CURRENT_CONTRACT_VERSION
       firstApp = first.app
       const worktreeId = await attachRepoAndOpenTerminal(first.page, repoPath)
       await waitForSessionReady(first.page)
+      await first.page.evaluate(async (agentCommand) => {
+        await window.__store?.getState().updateSettings({
+          agentCmdOverrides: { codex: agentCommand }
+        })
+      }, fakeCodexCommand)
       await ensureTerminalVisible(first.page)
       const coordinatorTabId = await getActiveTabId(first.page)
       expect(coordinatorTabId).toBeTruthy()

--- a/tests/e2e/orchestration-worker-settlement-release-cli.spec.ts
+++ b/tests/e2e/orchestration-worker-settlement-release-cli.spec.ts
@@ -12,9 +12,14 @@ import type { RuntimeTerminalListResult, RuntimeTerminalRead } from '../../src/s
 const fakeCliDir = mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-settlement-release-'))
 const cliLedgerPath = path.join(fakeCliDir, 'cli.jsonl')
 const cliEntry = path.join(process.cwd(), 'out', 'cli', 'index.js')
+const fakeCodexCommand = path.join(fakeCliDir, process.platform === 'win32' ? 'codex.cmd' : 'codex')
 const fakeCodexSource = `
 const { appendFileSync } = require('node:fs')
 const { spawnSync } = require('node:child_process')
+if (process.argv.slice(2).includes('app-server')) {
+  process.stderr.write("error: unrecognized subcommand 'app-server'\\n")
+  process.exit(2)
+}
 let capability = null
 let acknowledged = false
 process.stdout.write('\\u001b]0;Codex Ready\\u0007OpenAI Codex\\nmodel: e2e\\ndirectory: e2e\\n')
@@ -23,7 +28,7 @@ process.stdin.on('data', (chunk) => {
   capability ||= input.match(/--dispatch-capability (dcap_[A-Za-z0-9_-]+)/)?.[1] || null
   if (!acknowledged && input.includes('\\r')) {
     acknowledged = true
-    process.stdout.write('ACK\\n')
+    process.stdout.write('\\x1b[?25hACK\\n')
   }
   const encoded = input.match(/ORCA_E2E_WORKER_DONE:([A-Za-z0-9+/=]+)/)?.[1]
   if (!encoded || !capability) return
@@ -121,6 +126,11 @@ test('compiled CLI rejects false completion then reconciles the dead retained wo
   test.setTimeout(180_000)
   rmSync(cliLedgerPath, { force: true })
   await waitForSessionReady(orcaPage)
+  await orcaPage.evaluate(async (agentCommand) => {
+    await window.__store?.getState().updateSettings({
+      agentCmdOverrides: { codex: agentCommand }
+    })
+  }, fakeCodexCommand)
   const worktreeId = await waitForActiveWorktree(orcaPage)
   await ensureTerminalVisible(orcaPage)
   await waitForActivePanePtyId(orcaPage)

--- a/tests/e2e/workspace-board-lane-virtualization.spec.ts
+++ b/tests/e2e/workspace-board-lane-virtualization.spec.ts
@@ -278,7 +278,7 @@ test.describe('Workspace board lane virtualization', () => {
     const sourceCard = board
       .locator('[data-workspace-status="state-20"] [data-workspace-board-card-id]')
       .first()
-    const sourceId = await sourceCard.getAttribute('data-workspace-board-card-id')
+    const sourceId = await sourceCard.getAttribute('data-workspace-board-worktree-id')
     const sourceBox = await sourceCard.boundingBox()
     const targetBox = await finalLane
       .locator('[data-workspace-board-lane-scroll]')

--- a/tests/e2e/workspace-space-git-status.spec.ts
+++ b/tests/e2e/workspace-space-git-status.spec.ts
@@ -133,23 +133,7 @@ test.describe('Workspace Space git status checks', () => {
         { testRepoPath, worktreePaths: registeredWorktreePaths }
       )
 
-      await expect
-        .poll(
-          () =>
-            orcaPage.evaluate(() => {
-              const state = window.__store?.getState()
-              if (!state?.workspaceSpaceAnalysis) {
-                return 60
-              }
-              return state.workspaceSpaceAnalysis.worktrees.filter(
-                (row) => state.gitStatusByWorktree[row.worktreeId] === undefined
-              ).length
-            }),
-          { timeout: 30_000 }
-        )
-        .toBe(0)
-
-      await expect(orcaPage.getByText('Keep: git not checked')).toHaveCount(0)
+      await expect(orcaPage.getByText('Keep: git not checked')).toHaveCount(0, { timeout: 30_000 })
     } finally {
       for (const worktreePath of worktreePaths) {
         try {

--- a/tests/e2e/worktree-lifecycle.spec.ts
+++ b/tests/e2e/worktree-lifecycle.spec.ts
@@ -34,9 +34,11 @@ import {
 } from './helpers/store'
 import { clickFileInExplorer, openFileExplorer } from './helpers/file-explorer'
 
+type CreatedWorktreeTarget = { id: string; executionHostId: string | null }
+
 async function createIsolatedWorktree(
   page: Parameters<typeof getActiveWorktreeId>[0]
-): Promise<string> {
+): Promise<CreatedWorktreeTarget> {
   const name = `e2e-lifecycle-${Date.now()}`
   return page.evaluate(async (worktreeName) => {
     const store = window.__store
@@ -59,32 +61,32 @@ async function createIsolatedWorktree(
 
     const result = await state.createWorktree(activeWorktree.repoId, worktreeName)
     await state.fetchWorktrees(activeWorktree.repoId)
-    return result.worktree.id
+    return { id: result.worktree.id, executionHostId: result.worktree.hostId ?? null }
   }, name)
 }
 
 async function removeWorktreeViaStore(
   page: Parameters<typeof getActiveWorktreeId>[0],
-  worktreeId: string
+  target: CreatedWorktreeTarget
 ): Promise<{ ok: boolean; error?: string }> {
-  return page.evaluate(async (id) => {
+  return page.evaluate(async (removalTarget) => {
     const store = window.__store
     if (!store) {
       return { ok: false as const, error: 'store unavailable' }
     }
 
-    const result = await store.getState().removeWorktree(id, true)
+    const result = await store.getState().removeWorktree(removalTarget, true)
     return result
-  }, worktreeId)
+  }, target)
 }
 
 test.describe('Worktree Lifecycle', () => {
   // Why: `createIsolatedWorktree` materializes a real on-disk worktree in the
   // worker-scoped seed repo. If a mid-test assertion fails, that branch +
   // working directory leaks across subsequent tests in the same worker. Track
-  // the ID here and best-effort remove it in afterEach so fixture state stays
+  // the removal target here and best-effort remove it in afterEach so fixture state stays
   // clean even when a test aborts before its own cleanup runs.
-  let createdWorktreeId: string | null = null
+  let createdWorktreeTarget: CreatedWorktreeTarget | null = null
 
   test.beforeEach(async ({ orcaPage }) => {
     await waitForSessionReady(orcaPage)
@@ -93,19 +95,19 @@ test.describe('Worktree Lifecycle', () => {
   })
 
   test.afterEach(async ({ orcaPage }) => {
-    if (!createdWorktreeId) {
+    if (!createdWorktreeTarget) {
       return
     }
-    const idToClean = createdWorktreeId
-    createdWorktreeId = null
+    const targetToClean = createdWorktreeTarget
+    createdWorktreeTarget = null
     await orcaPage
-      .evaluate(async (id) => {
+      .evaluate(async (target) => {
         try {
-          await window.__store?.getState().removeWorktree(id, true)
+          await window.__store?.getState().removeWorktree(target, true)
         } catch {
           /* best-effort cleanup */
         }
-      }, idToClean)
+      }, targetToClean)
       .catch(() => undefined)
   })
 
@@ -118,8 +120,8 @@ test.describe('Worktree Lifecycle', () => {
   }) => {
     const originalWorktreeId = await waitForActiveWorktree(orcaPage)
 
-    createdWorktreeId = await createIsolatedWorktree(orcaPage)
-    const newWorktreeId = createdWorktreeId
+    createdWorktreeTarget = await createIsolatedWorktree(orcaPage)
+    const newWorktreeId = createdWorktreeTarget.id
     await switchToWorktree(orcaPage, newWorktreeId)
     await expect
       .poll(async () => getActiveWorktreeId(orcaPage), { timeout: 10_000 })
@@ -158,10 +160,10 @@ test.describe('Worktree Lifecycle', () => {
       .poll(async () => getActiveWorktreeId(orcaPage), { timeout: 10_000 })
       .toBe(originalWorktreeId)
 
-    const result = await removeWorktreeViaStore(orcaPage, newWorktreeId)
+    const result = await removeWorktreeViaStore(orcaPage, createdWorktreeTarget)
     expect(result.ok).toBe(true)
     // Successful removal — afterEach hook no longer needs to clean this up.
-    createdWorktreeId = null
+    createdWorktreeTarget = null
 
     // Tabs / open files / browser tabs keyed by the removed worktree must all
     // be dropped. A regression that leaves any of these behind will show up


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​57 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​42 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​15 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## Summary

Updates stale E2E test contracts and fake Codex test fixtures across scheduled CI suites:

- **`workspace-board-lane-virtualization.spec.ts`**: Read `data-workspace-board-worktree-id` instead of host-qualified card identity `data-workspace-board-card-id` for the status oracle.
- **`workspace-space-git-status.spec.ts`**: Wait for `Keep: git not checked` badge removal rather than querying obsolete global status map `gitStatusByWorktree`.
- **`worktree-lifecycle.spec.ts`**: Pass `{ id, executionHostId }` removal target to `store.removeWorktree` to match current host-qualified signature.
- **Fake Codex fixtures** (`completed-worker-retirement-fixture.ts`, `completed-worker-retirement-resume.spec.ts`, `orchestration-legacy-worker-missing-terminal-recovery.spec.ts`, `orchestration-legacy-worker-restart-recovery.spec.ts`, `orchestration-worker-settlement-release-cli.spec.ts`):
  - Explicitly select fake Codex executable via `agentCmdOverrides`.
  - Emit current prompt-settlement marker (`\x1b[?25hACK`).
  - Reject unsupported `app-server` probes in settlement test fixture.

## Validation

- `pnpm exec oxfmt --check ...` passed.
- `pnpm exec oxlint ... --deny-warnings` passed.