### PR TITLE
fix(gitea): read live Windows env so packaged builds pick up setx tokens

### DIFF
--- a/src/main/gitea/client-windows-env.test.ts
+++ b/src/main/gitea/client-windows-env.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getRegistryKeyMock } = vi.hoisted(() => ({
+  getRegistryKeyMock: vi.fn()
+}))
+
+vi.mock('../windows-native-registry', () => ({
+  WINDOWS_REG_SZ: 1,
+  WINDOWS_REG_EXPAND_SZ: 2,
+  loadWindowsNativeRegistry: () => ({
+    HK: { LM: 1, CU: 2 },
+    getRegistryKey: getRegistryKeyMock
+  })
+}))
+
+import { getGiteaAuthStatus } from './client'
+
+const OLD_ENV = process.env
+const USER_ENVIRONMENT_KEY = 'Environment'
+const MACHINE_ENVIRONMENT_KEY = 'SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment'
+
+function registryStrings(values: Record<string, string>): Record<string, { type: number; value: string }> {
+  return Object.fromEntries(
+    Object.entries(values).map(([name, value]) => [name, { type: 1, value }])
+  )
+}
+
+describe('getGiteaAuthStatus Windows environment snapshot (#14740)', () => {
+  beforeEach(() => {
+    process.env = { ...OLD_ENV }
+    delete process.env.ORCA_GITEA_TOKEN
+    delete process.env.ORCA_GITEA_API_BASE_URL
+    getRegistryKeyMock.mockReset()
+    getRegistryKeyMock.mockReturnValue({})
+    vi.unstubAllGlobals()
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+  })
+
+  afterEach(() => {
+    process.env = OLD_ENV
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('authenticates with user-registry credentials when process.env still has Explorer-frozen values', async () => {
+    process.env.ORCA_GITEA_TOKEN = 'stale-explorer-token'
+    process.env.ORCA_GITEA_API_BASE_URL = 'https://stale.example.com'
+    getRegistryKeyMock.mockImplementation((root: number, key: string) => {
+      if (root === 2 && key === USER_ENVIRONMENT_KEY) {
+        return registryStrings({
+          ORCA_GITEA_TOKEN: 'current-gitea-token',
+          ORCA_GITEA_API_BASE_URL: 'https://gitea.example.com'
+        })
+      }
+      return {}
+    })
+
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      const authorization = (init?.headers as Record<string, string> | undefined)?.Authorization
+      if (
+        String(url) === 'https://gitea.example.com/api/v1/user' &&
+        authorization === 'token current-gitea-token'
+      ) {
+        return Response.json({ login: 'gitea-user' })
+      }
+      return Response.json({ message: 'unauthorized' }, { status: 401 })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(getGiteaAuthStatus()).resolves.toEqual({
+      configured: true,
+      authenticated: true,
+      account: 'gitea-user',
+      baseUrl: 'https://gitea.example.com/api/v1',
+      tokenConfigured: true
+    })
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe('https://gitea.example.com/api/v1/user')
+    expect((fetchMock.mock.calls[0]?.[1]?.headers as Record<string, string>).Authorization).toBe(
+      'token current-gitea-token'
+    )
+  })
+
+  it('does not consult the Windows registry outside win32', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('linux')
+    process.env.ORCA_GITEA_TOKEN = 'process-token'
+    process.env.ORCA_GITEA_API_BASE_URL = 'https://process.example.com'
+    getRegistryKeyMock.mockImplementation(() =>
+      registryStrings({
+        ORCA_GITEA_TOKEN: 'registry-token',
+        ORCA_GITEA_API_BASE_URL: 'https://registry.example.com'
+      })
+    )
+    const fetchMock = vi.fn(async () => Response.json({ login: 'process-user' }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(getGiteaAuthStatus()).resolves.toMatchObject({
+      authenticated: true,
+      baseUrl: 'https://process.example.com/api/v1'
+    })
+    expect(getRegistryKeyMock).not.toHaveBeenCalled()
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe('https://process.example.com/api/v1/user')
+    expect((fetchMock.mock.calls[0]?.[1]?.headers as Record<string, string>).Authorization).toBe(
+      'token process-token'
+    )
+  })
+
+  it('falls back to process.env when the native registry module cannot load', async () => {
+    getRegistryKeyMock.mockImplementation(() => {
+      throw new Error('native module unavailable')
+    })
+    process.env.ORCA_GITEA_TOKEN = 'stale-explorer-token'
+    process.env.ORCA_GITEA_API_BASE_URL = 'https://stale.example.com'
+    const fetchMock = vi.fn(async () => Response.json({ login: 'fallback-user' }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(getGiteaAuthStatus()).resolves.toMatchObject({
+      authenticated: true,
+      baseUrl: 'https://stale.example.com/api/v1'
+    })
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe('https://stale.example.com/api/v1/user')
+    expect((fetchMock.mock.calls[0]?.[1]?.headers as Record<string, string>).Authorization).toBe(
+      'token stale-explorer-token'
+    )
+  })
+
+  it('prefers the user Environment value over the machine Environment value', async () => {
+    process.env.ORCA_GITEA_TOKEN = 'stale-explorer-token'
+    process.env.ORCA_GITEA_API_BASE_URL = 'https://stale.example.com'
+    getRegistryKeyMock.mockImplementation((root: number, key: string) => {
+      if (root === 2 && key === USER_ENVIRONMENT_KEY) {
+        return registryStrings({
+          ORCA_GITEA_TOKEN: 'user-gitea-token',
+          ORCA_GITEA_API_BASE_URL: 'https://user.example.com'
+        })
+      }
+      if (root === 1 && key === MACHINE_ENVIRONMENT_KEY) {
+        return registryStrings({
+          ORCA_GITEA_TOKEN: 'machine-gitea-token',
+          ORCA_GITEA_API_BASE_URL: 'https://machine.example.com'
+        })
+      }
+      return {}
+    })
+    const fetchMock = vi.fn(async () => Response.json({ login: 'user-account' }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(getGiteaAuthStatus()).resolves.toMatchObject({
+      account: 'user-account',
+      baseUrl: 'https://user.example.com/api/v1'
+    })
+    expect((fetchMock.mock.calls[0]?.[1]?.headers as Record<string, string>).Authorization).toBe(
+      'token user-gitea-token'
+    )
+  })
+})

--- a/src/main/gitea/client-windows-env.test.ts
+++ b/src/main/gitea/client-windows-env.test.ts
@@ -1,16 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { getRegistryKeyMock } = vi.hoisted(() => ({
-  getRegistryKeyMock: vi.fn()
+const { getRegistryKeyMock, loadWindowsNativeRegistryMock } = vi.hoisted(() => ({
+  getRegistryKeyMock: vi.fn(),
+  loadWindowsNativeRegistryMock: vi.fn()
 }))
 
 vi.mock('../windows-native-registry', () => ({
   WINDOWS_REG_SZ: 1,
   WINDOWS_REG_EXPAND_SZ: 2,
-  loadWindowsNativeRegistry: () => ({
-    HK: { LM: 1, CU: 2 },
-    getRegistryKey: getRegistryKeyMock
-  })
+  loadWindowsNativeRegistry: () => loadWindowsNativeRegistryMock()
 }))
 
 import { getGiteaAuthStatus } from './client'
@@ -19,10 +17,31 @@ const OLD_ENV = process.env
 const USER_ENVIRONMENT_KEY = 'Environment'
 const MACHINE_ENVIRONMENT_KEY = 'SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment'
 
-function registryStrings(values: Record<string, string>): Record<string, { type: number; value: string }> {
+function registryStrings(
+  values: Record<string, string>
+): Record<string, { type: number; value: string }> {
   return Object.fromEntries(
     Object.entries(values).map(([name, value]) => [name, { type: 1, value }])
   )
+}
+
+type AuthFetchMock = ReturnType<
+  typeof vi.fn<(input: string, init?: RequestInit) => Promise<Response>>
+>
+
+function jsonUserFetch(login: string): AuthFetchMock {
+  return vi.fn<(input: string, init?: RequestInit) => Promise<Response>>(async () =>
+    Response.json({ login })
+  )
+}
+
+function requestUrl(fetchMock: AuthFetchMock): string {
+  return String(fetchMock.mock.calls[0]?.[0])
+}
+
+function requestAuthorization(fetchMock: AuthFetchMock): string | undefined {
+  const headers = fetchMock.mock.calls[0]?.[1]?.headers as Record<string, string> | undefined
+  return headers?.Authorization
 }
 
 describe('getGiteaAuthStatus Windows environment snapshot (#14740)', () => {
@@ -32,6 +51,11 @@ describe('getGiteaAuthStatus Windows environment snapshot (#14740)', () => {
     delete process.env.ORCA_GITEA_API_BASE_URL
     getRegistryKeyMock.mockReset()
     getRegistryKeyMock.mockReturnValue({})
+    loadWindowsNativeRegistryMock.mockReset()
+    loadWindowsNativeRegistryMock.mockImplementation(() => ({
+      HK: { LM: 1, CU: 2 },
+      getRegistryKey: getRegistryKeyMock
+    }))
     vi.unstubAllGlobals()
     vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
   })
@@ -55,16 +79,18 @@ describe('getGiteaAuthStatus Windows environment snapshot (#14740)', () => {
       return {}
     })
 
-    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
-      const authorization = (init?.headers as Record<string, string> | undefined)?.Authorization
-      if (
-        String(url) === 'https://gitea.example.com/api/v1/user' &&
-        authorization === 'token current-gitea-token'
-      ) {
-        return Response.json({ login: 'gitea-user' })
+    const fetchMock = vi.fn<(input: string, init?: RequestInit) => Promise<Response>>(
+      async (url, init) => {
+        const authorization = (init?.headers as Record<string, string> | undefined)?.Authorization
+        if (
+          String(url) === 'https://gitea.example.com/api/v1/user' &&
+          authorization === 'token current-gitea-token'
+        ) {
+          return Response.json({ login: 'gitea-user' })
+        }
+        return Response.json({ message: 'unauthorized' }, { status: 401 })
       }
-      return Response.json({ message: 'unauthorized' }, { status: 401 })
-    })
+    )
     vi.stubGlobal('fetch', fetchMock)
 
     await expect(getGiteaAuthStatus()).resolves.toEqual({
@@ -74,10 +100,8 @@ describe('getGiteaAuthStatus Windows environment snapshot (#14740)', () => {
       baseUrl: 'https://gitea.example.com/api/v1',
       tokenConfigured: true
     })
-    expect(String(fetchMock.mock.calls[0]?.[0])).toBe('https://gitea.example.com/api/v1/user')
-    expect((fetchMock.mock.calls[0]?.[1]?.headers as Record<string, string>).Authorization).toBe(
-      'token current-gitea-token'
-    )
+    expect(requestUrl(fetchMock)).toBe('https://gitea.example.com/api/v1/user')
+    expect(requestAuthorization(fetchMock)).toBe('token current-gitea-token')
   })
 
   it('does not consult the Windows registry outside win32', async () => {
@@ -90,7 +114,7 @@ describe('getGiteaAuthStatus Windows environment snapshot (#14740)', () => {
         ORCA_GITEA_API_BASE_URL: 'https://registry.example.com'
       })
     )
-    const fetchMock = vi.fn(async () => Response.json({ login: 'process-user' }))
+    const fetchMock = jsonUserFetch('process-user')
     vi.stubGlobal('fetch', fetchMock)
 
     await expect(getGiteaAuthStatus()).resolves.toMatchObject({
@@ -98,29 +122,47 @@ describe('getGiteaAuthStatus Windows environment snapshot (#14740)', () => {
       baseUrl: 'https://process.example.com/api/v1'
     })
     expect(getRegistryKeyMock).not.toHaveBeenCalled()
-    expect(String(fetchMock.mock.calls[0]?.[0])).toBe('https://process.example.com/api/v1/user')
-    expect((fetchMock.mock.calls[0]?.[1]?.headers as Record<string, string>).Authorization).toBe(
-      'token process-token'
-    )
+    expect(requestUrl(fetchMock)).toBe('https://process.example.com/api/v1/user')
+    expect(requestAuthorization(fetchMock)).toBe('token process-token')
   })
 
   it('falls back to process.env when the native registry module cannot load', async () => {
-    getRegistryKeyMock.mockImplementation(() => {
+    loadWindowsNativeRegistryMock.mockImplementation(() => {
       throw new Error('native module unavailable')
     })
     process.env.ORCA_GITEA_TOKEN = 'stale-explorer-token'
     process.env.ORCA_GITEA_API_BASE_URL = 'https://stale.example.com'
-    const fetchMock = vi.fn(async () => Response.json({ login: 'fallback-user' }))
+    const fetchMock = jsonUserFetch('fallback-user')
     vi.stubGlobal('fetch', fetchMock)
 
     await expect(getGiteaAuthStatus()).resolves.toMatchObject({
       authenticated: true,
       baseUrl: 'https://stale.example.com/api/v1'
     })
-    expect(String(fetchMock.mock.calls[0]?.[0])).toBe('https://stale.example.com/api/v1/user')
-    expect((fetchMock.mock.calls[0]?.[1]?.headers as Record<string, string>).Authorization).toBe(
-      'token stale-explorer-token'
-    )
+    expect(requestUrl(fetchMock)).toBe('https://stale.example.com/api/v1/user')
+    expect(requestAuthorization(fetchMock)).toBe('token stale-explorer-token')
+  })
+
+  it('uses machine Environment credentials when the user key omits them', async () => {
+    process.env.ORCA_GITEA_TOKEN = 'stale-explorer-token'
+    process.env.ORCA_GITEA_API_BASE_URL = 'https://stale.example.com'
+    getRegistryKeyMock.mockImplementation((root: number, key: string) => {
+      if (root === 1 && key === MACHINE_ENVIRONMENT_KEY) {
+        return registryStrings({
+          ORCA_GITEA_TOKEN: 'machine-gitea-token',
+          ORCA_GITEA_API_BASE_URL: 'https://machine.example.com'
+        })
+      }
+      return {}
+    })
+    const fetchMock = jsonUserFetch('machine-account')
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(getGiteaAuthStatus()).resolves.toMatchObject({
+      account: 'machine-account',
+      baseUrl: 'https://machine.example.com/api/v1'
+    })
+    expect(requestAuthorization(fetchMock)).toBe('token machine-gitea-token')
   })
 
   it('prefers the user Environment value over the machine Environment value', async () => {
@@ -141,15 +183,13 @@ describe('getGiteaAuthStatus Windows environment snapshot (#14740)', () => {
       }
       return {}
     })
-    const fetchMock = vi.fn(async () => Response.json({ login: 'user-account' }))
+    const fetchMock = jsonUserFetch('user-account')
     vi.stubGlobal('fetch', fetchMock)
 
     await expect(getGiteaAuthStatus()).resolves.toMatchObject({
       account: 'user-account',
       baseUrl: 'https://user.example.com/api/v1'
     })
-    expect((fetchMock.mock.calls[0]?.[1]?.headers as Record<string, string>).Authorization).toBe(
-      'token user-gitea-token'
-    )
+    expect(requestAuthorization(fetchMock)).toBe('token user-gitea-token')
   })
 })

--- a/src/main/gitea/client.ts
+++ b/src/main/gitea/client.ts
@@ -14,6 +14,7 @@ import {
   type HostedReviewExecutionOptions
 } from '../source-control/hosted-review-git-options'
 import { cancelUnreadResponseBody } from '../lib/unread-response-body'
+import { readGiteaAuthEnvValue } from './gitea-auth-env'
 
 const REQUEST_TIMEOUT_MS = 5000
 // Why: self-hosted Forgejo can take ~5s to serve one /pulls page (it loads
@@ -41,21 +42,16 @@ type RequestOptions = {
   timeoutMs?: number
 }
 
-function envValue(name: string): string | null {
-  const value = process.env[name]?.trim() ?? ''
-  return value.length > 0 ? value : null
-}
-
 export function normalizeGiteaApiBaseUrl(value: string): string {
   const trimmed = value.trim().replace(/\/+$/, '')
   return /\/api\/v1$/i.test(trimmed) ? trimmed : `${trimmed}/api/v1`
 }
 
 function getAuthConfig(): GiteaAuthConfig {
-  const apiBaseUrl = envValue('ORCA_GITEA_API_BASE_URL')
+  const apiBaseUrl = readGiteaAuthEnvValue('ORCA_GITEA_API_BASE_URL')
   return {
     apiBaseUrl: apiBaseUrl ? normalizeGiteaApiBaseUrl(apiBaseUrl) : null,
-    token: envValue('ORCA_GITEA_TOKEN')
+    token: readGiteaAuthEnvValue('ORCA_GITEA_TOKEN')
   }
 }
 

--- a/src/main/gitea/gitea-auth-env.ts
+++ b/src/main/gitea/gitea-auth-env.ts
@@ -1,0 +1,6 @@
+import { readWindowsRegistryEnvironmentValue } from '../windows-environment-registry'
+
+export function readGiteaAuthEnvValue(name: string): string | null {
+  const value = (readWindowsRegistryEnvironmentValue(name) ?? process.env[name])?.trim() ?? ''
+  return value.length > 0 ? value : null
+}

--- a/src/main/gitea/pull-request-creation.ts
+++ b/src/main/gitea/pull-request-creation.ts
@@ -11,13 +11,9 @@ import { readHostedPullRequestTemplate } from '../source-control/pull-request-te
 import { getGiteaPullRequestForBranch, invalidateGiteaPullRequestScanForRepo } from './client'
 import { mapGiteaPullRequest, type RawGiteaPullRequest } from './pull-request-mappers'
 import { getGiteaRepoRef, type GiteaRepoRef } from './repository-ref'
+import { readGiteaAuthEnvValue } from './gitea-auth-env'
 
 const CREATE_REQUEST_TIMEOUT_MS = 60_000
-
-function envValue(name: string): string | null {
-  const value = process.env[name]?.trim() ?? ''
-  return value.length > 0 ? value : null
-}
 
 function normalizeApiBaseUrl(value: string): string {
   const trimmed = value.trim().replace(/\/+$/, '')
@@ -25,16 +21,16 @@ function normalizeApiBaseUrl(value: string): string {
 }
 
 function configuredApiBaseUrl(repo: GiteaRepoRef): string {
-  const configured = envValue('ORCA_GITEA_API_BASE_URL')
+  const configured = readGiteaAuthEnvValue('ORCA_GITEA_API_BASE_URL')
   return configured ? normalizeApiBaseUrl(configured) : repo.apiBaseUrl
 }
 
 export function isGiteaReviewCreationAuthenticated(): boolean {
-  return envValue('ORCA_GITEA_TOKEN') !== null
+  return readGiteaAuthEnvValue('ORCA_GITEA_TOKEN') !== null
 }
 
 function authHeaders(): Record<string, string> {
-  const token = envValue('ORCA_GITEA_TOKEN')
+  const token = readGiteaAuthEnvValue('ORCA_GITEA_TOKEN')
   return token ? { Authorization: `token ${token}` } : {}
 }
 

--- a/src/main/windows-environment-registry.test.ts
+++ b/src/main/windows-environment-registry.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  __setWindowsEnvironmentRegistryLoaderForTests,
+  readWindowsRegistryEnvironmentValue
+} from './windows-environment-registry'
+
+const USER_ENVIRONMENT_KEY = 'Environment'
+const MACHINE_ENVIRONMENT_KEY = 'SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment'
+
+describe('readWindowsRegistryEnvironmentValue', () => {
+  afterEach(() => {
+    __setWindowsEnvironmentRegistryLoaderForTests()
+    vi.restoreAllMocks()
+  })
+
+  it('prefers the user Environment value over the machine value', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    const getRegistryKey = vi.fn((root: number, key: string) => {
+      if (root === 2 && key === USER_ENVIRONMENT_KEY) {
+        return { ORCA_GITEA_TOKEN: { type: 1, value: 'user-token' } }
+      }
+      if (root === 1 && key === MACHINE_ENVIRONMENT_KEY) {
+        return { ORCA_GITEA_TOKEN: { type: 1, value: 'machine-token' } }
+      }
+      return {}
+    })
+    __setWindowsEnvironmentRegistryLoaderForTests(() => ({
+      HK: { LM: 1, CU: 2 },
+      getRegistryKey
+    }))
+
+    expect(readWindowsRegistryEnvironmentValue('ORCA_GITEA_TOKEN')).toBe('user-token')
+    expect(getRegistryKey).toHaveBeenNthCalledWith(1, 2, USER_ENVIRONMENT_KEY)
+  })
+
+  it('uses the machine Environment value when the user key omits the name', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    __setWindowsEnvironmentRegistryLoaderForTests(() => ({
+      HK: { LM: 1, CU: 2 },
+      getRegistryKey: vi.fn((root: number, key: string) => {
+        if (root === 1 && key === MACHINE_ENVIRONMENT_KEY) {
+          return { orca_gitea_api_base_url: { type: 1, value: 'https://machine.example.com' } }
+        }
+        return {}
+      })
+    }))
+
+    expect(readWindowsRegistryEnvironmentValue('ORCA_GITEA_API_BASE_URL')).toBe(
+      'https://machine.example.com'
+    )
+  })
+
+  it('expands REG_EXPAND_SZ values from the process environment', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    const previousHost = process.env.ORCA_GITEA_HOST
+    process.env.ORCA_GITEA_HOST = 'gitea.example.com'
+    __setWindowsEnvironmentRegistryLoaderForTests(() => ({
+      HK: { LM: 1, CU: 2 },
+      getRegistryKey: vi.fn(() => ({
+        ORCA_GITEA_API_BASE_URL: { type: 2, value: 'https://%ORCA_GITEA_HOST%' }
+      }))
+    }))
+
+    try {
+      expect(readWindowsRegistryEnvironmentValue('ORCA_GITEA_API_BASE_URL')).toBe(
+        'https://gitea.example.com'
+      )
+    } finally {
+      if (previousHost === undefined) {
+        delete process.env.ORCA_GITEA_HOST
+      } else {
+        process.env.ORCA_GITEA_HOST = previousHost
+      }
+    }
+  })
+
+  it('returns null outside Windows without opening the registry', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('linux')
+    const getRegistryKey = vi.fn()
+    __setWindowsEnvironmentRegistryLoaderForTests(() => ({
+      HK: { LM: 1, CU: 2 },
+      getRegistryKey
+    }))
+
+    expect(readWindowsRegistryEnvironmentValue('ORCA_GITEA_TOKEN')).toBeNull()
+    expect(getRegistryKey).not.toHaveBeenCalled()
+  })
+
+  it('returns null when the optional native module cannot load', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    __setWindowsEnvironmentRegistryLoaderForTests(() => {
+      throw new Error('native module unavailable')
+    })
+
+    expect(readWindowsRegistryEnvironmentValue('ORCA_GITEA_TOKEN')).toBeNull()
+  })
+})

--- a/src/main/windows-environment-registry.ts
+++ b/src/main/windows-environment-registry.ts
@@ -1,0 +1,64 @@
+import { expandWindowsEnvironmentVariables } from '../shared/windows-environment-expansion'
+import {
+  loadWindowsNativeRegistry,
+  WINDOWS_REG_EXPAND_SZ,
+  WINDOWS_REG_SZ,
+  type WindowsNativeRegistryModule
+} from './windows-native-registry'
+
+const MACHINE_ENVIRONMENT_KEY = 'SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment'
+const USER_ENVIRONMENT_KEY = 'Environment'
+
+let windowsRegistryLoader = loadWindowsNativeRegistry
+
+function readNamedValue(
+  registry: WindowsNativeRegistryModule,
+  root: number,
+  key: string,
+  name: string
+): string | null {
+  try {
+    const values = registry.getRegistryKey(root, key)
+    if (!values || typeof values !== 'object') {
+      return null
+    }
+    const entry = Object.entries(values).find(
+      ([entryName]) => entryName.toLowerCase() === name.toLowerCase()
+    )?.[1]
+    if (
+      !entry ||
+      (entry.type !== WINDOWS_REG_SZ && entry.type !== WINDOWS_REG_EXPAND_SZ) ||
+      typeof entry.value !== 'string'
+    ) {
+      return null
+    }
+    return entry.type === WINDOWS_REG_EXPAND_SZ
+      ? expandWindowsEnvironmentVariables(entry.value, process.env)
+      : entry.value
+  } catch {
+    return null
+  }
+}
+
+// Why: packaged Windows apps inherit Explorer's snapshot; setx updates HKCU\Environment without refreshing it (#14740).
+export function readWindowsRegistryEnvironmentValue(name: string): string | null {
+  if (process.platform !== 'win32') {
+    return null
+  }
+  let registry: WindowsNativeRegistryModule
+  try {
+    registry = windowsRegistryLoader()
+  } catch {
+    return null
+  }
+  return (
+    readNamedValue(registry, registry.HK.CU, USER_ENVIRONMENT_KEY, name) ??
+    readNamedValue(registry, registry.HK.LM, MACHINE_ENVIRONMENT_KEY, name)
+  )
+}
+
+export function __setWindowsEnvironmentRegistryLoaderForTests(
+  loader?: () => WindowsNativeRegistryModule
+): void {
+  windowsRegistryLoader = loader ?? loadWindowsNativeRegistry
+}


### PR DESCRIPTION
Packaged Windows builds launched from Explorer keep a stale `process.env` snapshot. After `setx` updates `ORCA_GITEA_TOKEN` / `ORCA_GITEA_API_BASE_URL`, Gitea auth still used the old values, so the same machine that works in a terminal-started dev build fails when opened from Explorer.

On Windows, read the live user then machine Environment registry first, then fall back to `process.env`. Off Windows, or if the native registry module fails, keep the existing `process.env` path.

## Test
- RED: with a stale `process.env` token/URL and current values in a mocked user Environment registry, `GET /api/v1/user` used the stale snapshot.
- GREEN: those Windows registry cases pass; Linux no-op and fallback cases still pass.

Fixes #14740