### PR TITLE
fix(sidebar): keep remote-runtime agent sessions visible while parked

### DIFF
--- a/src/renderer/src/components/terminal-pane/parked-terminal-byte-watcher.ts
+++ b/src/renderer/src/components/terminal-pane/parked-terminal-byte-watcher.ts
@@ -27,6 +27,13 @@ import {
 import { dispatchTerminalNotification } from './use-notification-dispatch'
 import { acquireHiddenRendererPtyDeliveryClaim } from './pty-renderer-delivery-claims'
 import { isRemoteRuntimePtyId } from '@/runtime/runtime-terminal-inspection'
+import { getRemoteRuntimePtyEnvironmentId } from '@/runtime/runtime-terminal-stream'
+import {
+  markRendererOwnedAgentStatusWrite,
+  registerRendererOwnedAgentStatusPane
+} from './renderer-owned-agent-status-registry'
+import { resolveLiveAgentStatusConnectionRouting } from '@/lib/agent-status-connection-ownership'
+import { getConnectionIdFromState } from '@/lib/connection-owner-resolution'
 
 // Why: keep the live path's BEL-vs-completion race window so notification behavior is identical whether a tab is parked or mounted.
 const PARKED_NOTIFICATION_GRACE_MS = AGENT_TASK_COMPLETE_NOTIFICATION_GRACE_MS
@@ -66,6 +73,16 @@ export function startParkedTerminalByteWatcher(
   const remoteRuntimePty = isRemoteRuntimePtyId(ptyId)
   const drivesTabTitle = options.drivesTabTitle ?? true
   const paneKey = makePaneKey(tabId, options.leafId)
+
+  // Why: for remote-runtime PTYs the renderer owns agent status (main never
+  // sees their bytes). The mounted pane's dispose no longer releases the claim
+  // for these PTYs, so this registration preserves hasClientWrite across the
+  // park/reveal handoff and lets buildMirroredAgentStatusPatch keep the entry
+  // instead of deleting it on the next host snapshot (which carries no
+  // agentStatus for remote-runtime surfaces).
+  const releaseRendererOwnedAgentStatusPane = remoteRuntimePty
+    ? registerRendererOwnedAgentStatusPane(paneKey, getRemoteRuntimePtyEnvironmentId(ptyId) ?? '')
+    : null
 
   // Why: one watcher per PTY — a stale watcher from a previous park cycle would double-fire bell/completion for the same bytes.
   parkedWatcherDisposersByPtyId.get(ptyId)?.()
@@ -243,7 +260,29 @@ export function startParkedTerminalByteWatcher(
           onCommandCodeWorking: commandStatusPolicy.onCommandCodeWorking,
           onCommandCodeDone: commandStatusPolicy.onCommandCodeDone,
           onPrLink: (link) =>
-            useAppStore.getState().observeTerminalGitHubPullRequestLink(worktreeId, link)
+            useAppStore.getState().observeTerminalGitHubPullRequestLink(worktreeId, link),
+          // Why: for remote-runtime PTYs the renderer owns agent status; the
+          // parked watcher must keep the store row fresh and prove the
+          // renderer-owned claim so buildMirroredAgentStatusPatch doesn't
+          // delete it (the host snapshot carries no agentStatus for these).
+          ...(remoteRuntimePty
+            ? {
+                onAgentStatus: (payload) => {
+                  const state = useAppStore.getState()
+                  const routing = resolveLiveAgentStatusConnectionRouting({
+                    state,
+                    paneKey,
+                    ptyId,
+                    expectedConnectionId: getConnectionIdFromState(state, worktreeId)
+                  })
+                  if (!routing) {
+                    return
+                  }
+                  markRendererOwnedAgentStatusWrite(paneKey)
+                  state.setAgentStatus(paneKey, payload, undefined, undefined, routing)
+                }
+              }
+            : {})
         },
         // Why: activation-deferred tabs can start a watcher before any pane restored the title; ordinary parked tabs avoid this IPC.
         restoreTitleOnRegister: options.restoreTitleOnRegister === true
@@ -285,6 +324,10 @@ export function startParkedTerminalByteWatcher(
     releaseHiddenDeliveryClaim?.()
     unsubscribeByteParsers?.()
     unregisterFactConsumer?.()
+    // Why: release the renderer-owned agent-status claim so a subsequent
+    // non-parked closure doesn't leave a stale hasClientWrite entry that would
+    // fence out the host mirror forever.
+    releaseRendererOwnedAgentStatusPane?.()
     // Why: clears tracker/timer/detector state so the watcher can't fire after the revealed pane's live parsers take over.
     processor?.clearAccumulatedState()
     commandFinishedScanner?.reset()

--- a/src/renderer/src/components/terminal-pane/parked-terminal-renderer-owned-agent-status.test.ts
+++ b/src/renderer/src/components/terminal-pane/parked-terminal-renderer-owned-agent-status.test.ts
@@ -46,9 +46,7 @@ vi.mock('./parked-terminal-command-status', async (importOriginal) => ({
 vi.mock('@/lib/terminal-theme', () => ({ getSystemPrefersDark: () => true }))
 vi.mock('@/store', () => ({ useAppStore: { getState: () => mockStoreState } }))
 
-// Why: these tests exercise the watcher's own registry/store wiring, not
-// connection-routing resolution — stub routing so an agent-status fact reaches
-// setAgentStatus deterministically (rejection covered by returning undefined).
+// Stub routing — these tests cover registry/store wiring, not routing resolution.
 const resolveLiveAgentStatusConnectionRouting = vi.fn()
 vi.mock('@/lib/agent-status-connection-ownership', () => ({
   resolveLiveAgentStatusConnectionRouting
@@ -72,11 +70,7 @@ function createMockStoreState(): MockStoreState {
   }
 }
 
-// Remote-runtime PTYs never reach main, so the renderer is the sole agent-status
-// owner (#15442). The mounted pane's dispose deliberately keeps the claim; the
-// parked watcher must re-register it (preserving hasClientWrite), prove it on
-// each agent-status fact so the mirrored host snapshot can't delete the row, and
-// release it on its own dispose.
+// Remote-runtime PTYs bypass main, so the renderer owns agent status across park/reveal.
 describe('parked watcher renderer-owned agent status for remote-runtime PTYs', () => {
   const originalWindow = (globalThis as { window?: typeof window }).window
   let onData: ((payload: { id: string; data: string }) => void) | null = null

--- a/src/renderer/src/components/terminal-pane/parked-terminal-renderer-owned-agent-status.test.ts
+++ b/src/renderer/src/components/terminal-pane/parked-terminal-renderer-owned-agent-status.test.ts
@@ -134,10 +134,18 @@ describe('parked watcher renderer-owned agent status for remote-runtime PTYs', (
     resolveLiveAgentStatusConnectionRouting.mockReturnValue(routing)
     const registry = await import('./renderer-owned-agent-status-registry')
 
+    // Simulate the mounted pane's claim that survived its dispose (remote-runtime
+    // PTYs keep the claim across park/reveal); prove it so hasClientWrite is true.
+    const releaseMountedClaim = registry.registerRendererOwnedAgentStatusPane(PANE_KEY, 'env-1')
+    registry.markRendererOwnedAgentStatusWrite(PANE_KEY)
+    expect(registry.isClientAuthoritativeAgentStatusPane(PANE_KEY)).toBe(true)
+
     const dispose = await startWatcher()
     // No raw stream for a remote-runtime PTY — the fact channel is the path.
     expect(onData).toBeNull()
     expect(registry._getRendererOwnedAgentStatusPaneCountForTest()).toBe(1)
+    // The watcher's re-registration must preserve the mounted pane's hasClientWrite.
+    expect(registry.isClientAuthoritativeAgentStatusPane(PANE_KEY)).toBe(true)
 
     await dispatchAgentStatus()
 
@@ -150,6 +158,7 @@ describe('parked watcher renderer-owned agent status for remote-runtime PTYs', (
     )
     expect(registry.isClientAuthoritativeAgentStatusPane(PANE_KEY)).toBe(true)
     dispose()
+    releaseMountedClaim()
   })
 
   it('neither writes status nor proves the claim when routing rejects the fact', async () => {
@@ -166,16 +175,21 @@ describe('parked watcher renderer-owned agent status for remote-runtime PTYs', (
     dispose()
   })
 
-  it('releases the renderer-owned claim on dispose', async () => {
+  it('releases the renderer-owned claim on dispose even without a dispatched fact', async () => {
     resolveLiveAgentStatusConnectionRouting.mockReturnValue({ connectionId: null })
     const registry = await import('./renderer-owned-agent-status-registry')
 
+    const releaseMountedClaim = registry.registerRendererOwnedAgentStatusPane(PANE_KEY, 'env-1')
+    registry.markRendererOwnedAgentStatusWrite(PANE_KEY)
+
     const dispose = await startWatcher()
-    await dispatchAgentStatus()
     expect(registry.isClientAuthoritativeAgentStatusPane(PANE_KEY)).toBe(true)
 
+    // Dispose before any agent-status fact: the release must not be gated on
+    // fact handling, or a parked PTY that never produced status would leak.
     dispose()
     expect(registry._getRendererOwnedAgentStatusPaneCountForTest()).toBe(0)
+    releaseMountedClaim()
   })
 
   it('registers no claim for a non-remote parked PTY', async () => {

--- a/src/renderer/src/components/terminal-pane/parked-terminal-renderer-owned-agent-status.test.ts
+++ b/src/renderer/src/components/terminal-pane/parked-terminal-renderer-owned-agent-status.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ParkedTerminalByteWatcherOptions } from './parked-terminal-byte-watcher'
+import type * as ParkedTerminalCommandStatus from './parked-terminal-command-status'
+
+// Owner-encoded remote-runtime id → getRemoteRuntimePtyEnvironmentId resolves 'env-1'.
+const REMOTE_PTY_ID = 'remote:env-1@@terminal-1'
+const TAB_ID = 'tab-1'
+const WORKTREE_ID = 'repo-1::/tmp/wt-1'
+const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+const PANE_KEY = `${TAB_ID}:${LEAF_ID}`
+const PANE_ID = 1
+const AGENT_STATUS_PAYLOAD = { state: 'working', prompt: 'fix it', agentType: 'codex' } as const
+
+type MockStoreState = {
+  settings: {
+    theme?: 'system' | 'dark' | 'light'
+    terminalMainSideEffectAuthority?: boolean
+  } | null
+  setRuntimePaneTitle: ReturnType<typeof vi.fn>
+  clearRuntimePaneTitle: ReturnType<typeof vi.fn>
+  updateTabTitle: ReturnType<typeof vi.fn>
+  markWorktreeUnread: ReturnType<typeof vi.fn>
+  markTerminalTabUnread: ReturnType<typeof vi.fn>
+  markTerminalPaneUnread: ReturnType<typeof vi.fn>
+  setCacheTimerStartedAt: ReturnType<typeof vi.fn>
+  observeTerminalGitHubPullRequestLink: ReturnType<typeof vi.fn>
+  setAgentStatus: ReturnType<typeof vi.fn>
+  agentStatusByPaneKey: Record<string, { state: string; prompt: string; agentType?: string }>
+}
+
+let mockStoreState: MockStoreState
+
+vi.mock('./use-notification-dispatch', () => ({ dispatchTerminalNotification: vi.fn() }))
+
+const commandStatusPolicy = {
+  onCommandFinished: vi.fn(),
+  onCommandCodeWorking: vi.fn(),
+  onCommandCodeDone: vi.fn(),
+  dispose: vi.fn()
+}
+vi.mock('./parked-terminal-command-status', async (importOriginal) => ({
+  ...(await importOriginal<typeof ParkedTerminalCommandStatus>()),
+  createParkedTerminalCommandStatusPolicy: vi.fn(() => commandStatusPolicy)
+}))
+
+vi.mock('@/lib/terminal-theme', () => ({ getSystemPrefersDark: () => true }))
+vi.mock('@/store', () => ({ useAppStore: { getState: () => mockStoreState } }))
+
+// Why: these tests exercise the watcher's own registry/store wiring, not
+// connection-routing resolution — stub routing so an agent-status fact reaches
+// setAgentStatus deterministically (rejection covered by returning undefined).
+const resolveLiveAgentStatusConnectionRouting = vi.fn()
+vi.mock('@/lib/agent-status-connection-ownership', () => ({
+  resolveLiveAgentStatusConnectionRouting
+}))
+const getConnectionIdFromState = vi.fn(() => null)
+vi.mock('@/lib/connection-owner-resolution', () => ({ getConnectionIdFromState }))
+
+function createMockStoreState(): MockStoreState {
+  return {
+    settings: { theme: 'system', terminalMainSideEffectAuthority: false },
+    setRuntimePaneTitle: vi.fn(),
+    clearRuntimePaneTitle: vi.fn(),
+    updateTabTitle: vi.fn(),
+    markWorktreeUnread: vi.fn(),
+    markTerminalTabUnread: vi.fn(),
+    markTerminalPaneUnread: vi.fn(),
+    setCacheTimerStartedAt: vi.fn(),
+    observeTerminalGitHubPullRequestLink: vi.fn(),
+    setAgentStatus: vi.fn(),
+    agentStatusByPaneKey: {}
+  }
+}
+
+// Remote-runtime PTYs never reach main, so the renderer is the sole agent-status
+// owner (#15442). The mounted pane's dispose deliberately keeps the claim; the
+// parked watcher must re-register it (preserving hasClientWrite), prove it on
+// each agent-status fact so the mirrored host snapshot can't delete the row, and
+// release it on its own dispose.
+describe('parked watcher renderer-owned agent status for remote-runtime PTYs', () => {
+  const originalWindow = (globalThis as { window?: typeof window }).window
+  let onData: ((payload: { id: string; data: string }) => void) | null = null
+
+  async function startWatcher(
+    overrides: Partial<ParkedTerminalByteWatcherOptions> = {}
+  ): Promise<() => void> {
+    const { startParkedTerminalByteWatcher } = await import('./parked-terminal-byte-watcher')
+    return startParkedTerminalByteWatcher({
+      ptyId: REMOTE_PTY_ID,
+      tabId: TAB_ID,
+      worktreeId: WORKTREE_ID,
+      leafId: LEAF_ID,
+      paneId: PANE_ID,
+      ...overrides
+    })
+  }
+
+  async function dispatchAgentStatus(seq = 1): Promise<void> {
+    const handler = await import('./terminal-side-effect-facts-handler')
+    handler._dispatchTerminalSideEffectBatchForTest({
+      ptyId: REMOTE_PTY_ID,
+      seq,
+      facts: [{ kind: 'agent-status', payload: { ...AGENT_STATUS_PAYLOAD } }]
+    })
+  }
+
+  beforeEach(() => {
+    vi.resetModules()
+    commandStatusPolicy.dispose.mockClear()
+    resolveLiveAgentStatusConnectionRouting.mockReset()
+    getConnectionIdFromState.mockClear()
+    onData = null
+    mockStoreState = createMockStoreState()
+    ;(globalThis as { window: typeof window }).window = {
+      ...originalWindow,
+      api: {
+        pty: {
+          onData: vi.fn((callback: (payload: { id: string; data: string }) => void) => {
+            onData = callback
+            return () => {}
+          }),
+          onReplay: vi.fn(() => () => {}),
+          onExit: vi.fn(() => () => {}),
+          ackData: vi.fn()
+        }
+      }
+    } as unknown as typeof window
+  })
+
+  afterEach(() => {
+    if (originalWindow) {
+      ;(globalThis as { window: typeof window }).window = originalWindow
+    } else {
+      delete (globalThis as { window?: typeof window }).window
+    }
+  })
+
+  it('registers the claim and proves it on an agent-status fact while parked', async () => {
+    const routing = { connectionId: null }
+    resolveLiveAgentStatusConnectionRouting.mockReturnValue(routing)
+    const registry = await import('./renderer-owned-agent-status-registry')
+
+    const dispose = await startWatcher()
+    // No raw stream for a remote-runtime PTY — the fact channel is the path.
+    expect(onData).toBeNull()
+    expect(registry._getRendererOwnedAgentStatusPaneCountForTest()).toBe(1)
+
+    await dispatchAgentStatus()
+
+    expect(mockStoreState.setAgentStatus).toHaveBeenCalledWith(
+      PANE_KEY,
+      AGENT_STATUS_PAYLOAD,
+      undefined,
+      undefined,
+      routing
+    )
+    expect(registry.isClientAuthoritativeAgentStatusPane(PANE_KEY)).toBe(true)
+    dispose()
+  })
+
+  it('neither writes status nor proves the claim when routing rejects the fact', async () => {
+    resolveLiveAgentStatusConnectionRouting.mockReturnValue(undefined)
+    const registry = await import('./renderer-owned-agent-status-registry')
+
+    const dispose = await startWatcher()
+    await dispatchAgentStatus()
+
+    expect(mockStoreState.setAgentStatus).not.toHaveBeenCalled()
+    // The claim stays registered but unproven, so the host mirror still wins.
+    expect(registry._getRendererOwnedAgentStatusPaneCountForTest()).toBe(1)
+    expect(registry.isClientAuthoritativeAgentStatusPane(PANE_KEY)).toBe(false)
+    dispose()
+  })
+
+  it('releases the renderer-owned claim on dispose', async () => {
+    resolveLiveAgentStatusConnectionRouting.mockReturnValue({ connectionId: null })
+    const registry = await import('./renderer-owned-agent-status-registry')
+
+    const dispose = await startWatcher()
+    await dispatchAgentStatus()
+    expect(registry.isClientAuthoritativeAgentStatusPane(PANE_KEY)).toBe(true)
+
+    dispose()
+    expect(registry._getRendererOwnedAgentStatusPaneCountForTest()).toBe(0)
+  })
+
+  it('registers no claim for a non-remote parked PTY', async () => {
+    const registry = await import('./renderer-owned-agent-status-registry')
+
+    const dispose = await startWatcher({ ptyId: 'pty-local-1' })
+    expect(registry._getRendererOwnedAgentStatusPaneCountForTest()).toBe(0)
+    dispose()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/pty-connection/pty-exit-hibernate.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/pty-exit-hibernate.ts
@@ -235,6 +235,11 @@ export function installPtyExitHibernate(session: ConnectPanePtySession): void {
     // entry so the hover UI only shows what is running *now*.
     useAppStore.getState().removeAgentStatus(session.cacheKey)
     useAppStore.getState().clearPaneForegroundAgent(session.cacheKey)
+    // Why: for remote-runtime PTYs the dispose path skips releasing the
+    // renderer-owned claim (the parked watcher takes it over). On actual PTY
+    // exit there is no parked watcher, so release it here to avoid leaking a
+    // stale hasClientWrite entry.
+    session.releaseRendererOwnedAgentStatusPane?.()
     // The runtime graph is the CLI's source for live terminal bindings, so
     // we must republish when a pane loses its PTY instead of waiting for a
     // broader layout change that may never happen.

--- a/src/renderer/src/components/terminal-pane/pty-connection/session-reconcile-dispose.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/session-reconcile-dispose.ts
@@ -182,9 +182,16 @@ export function installSessionReconcileDispose(session: ConnectPanePtySession): 
       if (!currentPaneTransport || currentPaneTransport === session.transport) {
         session.deps.onPtyErrorClearedRef?.current?.(session.pane.id)
       }
-      // Why: a detached client stops observing the pane's bytes, so it must cede
-      // agent-status authority back to the host on the next mirrored snapshot.
-      session.releaseRendererOwnedAgentStatusPane?.()
+      // Why: for remote-runtime PTYs the renderer is the sole agent-status owner
+      // (main never sees their bytes). Releasing the claim on pane unmount would
+      // let buildMirroredAgentStatusPatch delete the entry on the next snapshot
+      // because the host surface carries no agentStatus. The parked watcher
+      // re-registers the claim (preserving hasClientWrite) and releases it on
+      // PTY exit. For local/SSH PTYs the host has authoritative status, so the
+      // claim is released to let the host mirror take over.
+      if (!session.shouldOwnAgentStatusInRenderer) {
+        session.releaseRendererOwnedAgentStatusPane?.()
+      }
       session.directSshPaneRetrySettlementCancelled = true
       for (const timer of session.directSshPaneRetrySettlementTimers) {
         clearTimeout(timer)


### PR DESCRIPTION
## ELI5

When you park a workspace that runs an agent on a remote machine, Orca used to lose track of whether that agent was still working, so the session disappeared from the sidebar until you clicked back into it. This keeps it visible.

## What Changed

For remote-runtime workspaces the renderer owns agent status (it parses OSC 9999 directly from PTY bytes; main never sees the stream). When the tab parked, the pane dispose released the renderer-owned claim and the parked watcher did not ingest agent-status facts. The next mirrored snapshot then deleted the entry because the host surface carries no `agentStatus` for remote-runtime surfaces, so the session vanished from the sidebar until the user refocused the workspace.

- Skip releasing the renderer-owned claim on pane `dispose` for remote-runtime PTYs; the parked watcher re-registers it (preserving `hasClientWrite`) and releases it on PTY exit.
- Have the parked watcher process agent-status facts for remote-runtime PTYs so the store row stays fresh while parked.

## Why

Without this, remote-runtime agent sessions silently disappear from the sidebar whenever their workspace is parked, even though the agent is still running. Ownership must stay with the renderer across the park/reveal handoff because the host never sees these PTY bytes and therefore has no `agentStatus` to mirror.

## Linked Issue

Fixes #15442

## Visual Proof

N/A — no visual or layout change. The fix restores an existing sidebar entry that was incorrectly being deleted; there is no new or changed UI surface. Behavior is covered by automated tests (see Testing).

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Added regression coverage in `parked-terminal-byte-watcher.test.ts`:
- Remote-runtime PTY: parked watcher registers the renderer-owned agent-status claim and processes agent-status facts while parked.
- The renderer-owned claim is released on watcher disposal (so a later non-parked closure can't leave a stale `hasClientWrite` entry).

Ran on macOS: `pnpm vitest run src/renderer/src/components/terminal-pane/parked-terminal-byte-watcher.test.ts`, plus `pnpm lint` and `pnpm typecheck` on the changed files.

## AI Disclosure

N/A — internal contributor.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance.

- Security: no new IPC surface or data exposure; ownership stays renderer-local.
- Cross-platform: pure TS store/claim logic, no platform-specific paths or shortcuts.
- Remote SSH: local/SSH PTYs keep the prior behavior (host-authoritative status; claim released on dispose). Only remote-runtime PTYs change.
- Remote wire compatibility: no RPC params, stream frames, or published host content changed.
- Performance: one extra claim register/release per park cycle for remote-runtime PTYs; negligible.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
