### PR TITLE
fix(windows): treat existing WSL Codex runtime home as ready on EISDIR mkdir

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -39,6 +39,7 @@ import {
   writeFileAtomically,
   writeFileAtomicallyIfUnchanged
 } from './fs-utils'
+import { ensureWslRuntimeHomeDirectory } from './wsl-runtime-home-directory'
 import {
   getOrcaManagedCodexHomePath,
   getOrcaUserDataPath,
@@ -1069,7 +1070,7 @@ export class CodexRuntimeHomeService {
     }
     this.wslRuntimeHomePathByDistro.set(distro, runtimeHomePath)
 
-    mkdirSync(runtimeHomePath, { recursive: true })
+    ensureWslRuntimeHomeDirectory(runtimeHomePath)
     this.safeMigrateLegacyWslActiveHomePointer(distro, runtimeHomePath)
     this.seedWslRuntimeHome(runtimeHomePath, activeAccount, distro)
 

--- a/src/main/codex-accounts/wsl-runtime-home-directory.test.ts
+++ b/src/main/codex-accounts/wsl-runtime-home-directory.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import type * as NodeFs from 'node:fs'
+import type * as NodeChildProcess from 'node:child_process'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const fsMock = vi.hoisted(() => ({
+  mkdirSync: vi.fn(),
+  statSync: vi.fn()
+}))
+const execMock = vi.hoisted(() => ({ execFileSync: vi.fn() }))
+const actualFs = vi.hoisted(() => ({
+  mkdirSync: undefined as undefined | NodeFs['mkdirSync'],
+  statSync: undefined as undefined | NodeFs['statSync']
+}))
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFs>()
+  actualFs.mkdirSync = actual.mkdirSync
+  actualFs.statSync = actual.statSync
+  fsMock.mkdirSync.mockImplementation(actual.mkdirSync)
+  fsMock.statSync.mockImplementation(actual.statSync)
+  return { ...actual, mkdirSync: fsMock.mkdirSync, statSync: fsMock.statSync }
+})
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeChildProcess>()
+  execMock.execFileSync.mockImplementation(actual.execFileSync)
+  return { ...actual, execFileSync: execMock.execFileSync }
+})
+
+import { ensureWslRuntimeHomeDirectory } from './wsl-runtime-home-directory'
+
+describe('ensureWslRuntimeHomeDirectory', () => {
+  let dir: string | undefined
+
+  beforeEach(() => {
+    fsMock.mkdirSync.mockImplementation(actualFs.mkdirSync!)
+    fsMock.statSync.mockImplementation(actualFs.statSync!)
+    execMock.execFileSync.mockReset()
+  })
+
+  afterEach(() => {
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true })
+      dir = undefined
+    }
+  })
+
+  it('returns when the path is already a directory', () => {
+    dir = mkdtempSync(join(tmpdir(), 'orca-wsl-runtime-home-'))
+    fsMock.mkdirSync.mockClear()
+    ensureWslRuntimeHomeDirectory(dir)
+    expect(fsMock.mkdirSync).not.toHaveBeenCalled()
+    expect(execMock.execFileSync).not.toHaveBeenCalled()
+  })
+
+  it('creates a missing directory', () => {
+    dir = mkdtempSync(join(tmpdir(), 'orca-wsl-runtime-home-'))
+    const target = join(dir, 'codex-runtime-home', 'home')
+    ensureWslRuntimeHomeDirectory(target)
+    expect(fsMock.mkdirSync).toHaveBeenCalledWith(target, { recursive: true })
+    expect(execMock.execFileSync).not.toHaveBeenCalled()
+  })
+
+  it('treats EISDIR as success when a later stat sees a directory', () => {
+    dir = mkdtempSync(join(tmpdir(), 'orca-wsl-runtime-home-'))
+    const error = Object.assign(new Error('EISDIR: illegal operation on a directory, mkdir'), {
+      code: 'EISDIR'
+    })
+    fsMock.statSync
+      .mockImplementationOnce(() => {
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+      })
+      .mockImplementationOnce(() => ({ isDirectory: () => true }) as NodeFs.Stats)
+    fsMock.mkdirSync.mockImplementation(() => {
+      throw error
+    })
+    expect(() => ensureWslRuntimeHomeDirectory(dir as string)).not.toThrow()
+    expect(execMock.execFileSync).not.toHaveBeenCalled()
+  })
+
+  it('creates a WSL UNC home via wsl.exe when host mkdir throws EISDIR', () => {
+    const unc =
+      '\\\\wsl.localhost\\Ubuntu-24.04\\home\\alice\\.local\\share\\orca\\codex-runtime-home\\home'
+    const error = Object.assign(new Error('EISDIR: illegal operation on a directory, mkdir'), {
+      code: 'EISDIR'
+    })
+    fsMock.statSync.mockImplementation(() => {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    })
+    fsMock.mkdirSync.mockImplementation(() => {
+      throw error
+    })
+    execMock.execFileSync.mockReturnValue(Buffer.from(''))
+
+    ensureWslRuntimeHomeDirectory(unc)
+
+    expect(execMock.execFileSync).toHaveBeenCalledWith(
+      'wsl.exe',
+      [
+        '-d',
+        'Ubuntu-24.04',
+        '--exec',
+        'mkdir',
+        '-p',
+        '--',
+        '/home/alice/.local/share/orca/codex-runtime-home/home'
+      ],
+      { stdio: ['ignore', 'pipe', 'pipe'], timeout: 10_000 }
+    )
+  })
+
+  it('rethrows when mkdir fails on a non-UNC path that is not a directory', () => {
+    dir = mkdtempSync(join(tmpdir(), 'orca-wsl-runtime-home-'))
+    const target = join(dir, 'not-a-dir')
+    writeFileSync(target, 'file')
+    const error = Object.assign(new Error('EACCES'), { code: 'EACCES' })
+    fsMock.mkdirSync.mockImplementation(() => {
+      throw error
+    })
+    expect(() => ensureWslRuntimeHomeDirectory(target)).toThrow(error)
+    expect(execMock.execFileSync).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/codex-accounts/wsl-runtime-home-directory.ts
+++ b/src/main/codex-accounts/wsl-runtime-home-directory.ts
@@ -1,0 +1,36 @@
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, statSync } from 'node:fs'
+import { buildWslExecArgs } from '../../shared/wsl-login-shell-command'
+import { parseWslUncPath } from '../../shared/wsl-paths'
+
+function isDirectory(path: string): boolean {
+  try {
+    return statSync(path).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+/** Why: host Node mkdir on \\wsl.localhost UNC throws EISDIR when the guest dir exists or 9P is mid-attach (#15441). */
+export function ensureWslRuntimeHomeDirectory(runtimeHomePath: string): void {
+  if (isDirectory(runtimeHomePath)) {
+    return
+  }
+
+  try {
+    mkdirSync(runtimeHomePath, { recursive: true })
+  } catch (error) {
+    if (isDirectory(runtimeHomePath)) {
+      return
+    }
+    const parsed = parseWslUncPath(runtimeHomePath)
+    if (!parsed) {
+      throw error
+    }
+    execFileSync(
+      'wsl.exe',
+      buildWslExecArgs(parsed.distro, ['mkdir', '-p', '--', parsed.linuxPath]),
+      { stdio: ['ignore', 'pipe', 'pipe'], timeout: 10_000 }
+    )
+  }
+}


### PR DESCRIPTION
## Summary
Windows Orca creates the WSL Codex runtime home with host `fs.mkdirSync(..., { recursive: true })` on a `\\wsl.localhost\...` UNC path. When that guest directory already exists — or 9P is mid-attach after `wsl --terminate` — Node throws `EISDIR` and Orca shows a blocking dialog.

Fixes #15441.

## Change
- Stat first and return if the path is already a directory.
- On `mkdir` failure, treat a subsequent directory stat as success.
- If the path is still missing and is a WSL UNC path, create it with `wsl.exe --exec mkdir -p` instead of walking the UNC share root.

## Test plan
- [x] Unit tests for skip-if-exists, EISDIR-already-dir, UNC `wsl.exe` fallback, and non-UNC rethrow
- [ ] Open a WSL Codex pane on Windows 11 + Ubuntu-24.04 when `~/.local/share/orca/codex-runtime-home/home` already exists — no EISDIR dialog
- [ ] Repeat after enabling WSL terminate / `wsl --terminate Ubuntu-24.04` and immediately launching Codex