### PR TITLE
fix(terminal): expire the app-wide WebGL DOM suggestion at recovery boundaries

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-rendering-control.ts
+++ b/src/renderer/src/lib/pane-manager/pane-rendering-control.ts
@@ -3,6 +3,7 @@ import { safeFit } from './pane-tree-ops'
 import {
   attachWebgl,
   clearTerminalWebglAttachBackoff,
+  clearTerminalWebglRendererSuggestion,
   disposeWebgl,
   isPaneWebglContextLost,
   markComplexScriptOutput,
@@ -76,6 +77,11 @@ export function resumePaneRendering(
   if (retentionOwner) {
     releaseHiddenWebglRetention(retentionOwner)
   }
+  // Why before the loop: the app-wide "auto" DOM suggestion outranks every
+  // per-pane latch, so leaving it set would make the retries below no-ops. One
+  // pane's attach still re-sets it for the rest of this resume, keeping a host
+  // that genuinely cannot do WebGL to a single probe per boundary.
+  clearTerminalWebglRendererSuggestion()
   for (const pane of panes) {
     // Why: resume (worktree foreground, window wake) is the WebGL retry
     // boundary — Chromium may have restored the GPU process since a context

--- a/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
@@ -41,6 +41,17 @@ export function resetTerminalWebglSuggestion(): void {
   resetTerminalWebglAutoDecision()
 }
 
+export function clearTerminalWebglRendererSuggestion(): void {
+  // Why: the suggestion cannot tell a host that can never do WebGL from a GPU
+  // process that was restarting for one attach. Latched for the app's lifetime
+  // it outranks every per-pane latch, so each pane that re-attaches afterwards
+  // silently falls to the DOM renderer — with no latch of its own to show why,
+  // and no resize or worktree switch able to undo it. Expire it at the same
+  // recovery boundaries the per-pane failure latch uses. The cached auto
+  // decision survives: re-probing it would burn a context.
+  suggestedRendererType = undefined
+}
+
 export function clearTerminalWebglAttachBackoff(pane: ManagedPaneInternal): void {
   pane.webglAttachFailedSinceRecovery = false
 }

--- a/src/renderer/src/lib/pane-manager/terminal-webgl-suggestion-recovery.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-webgl-suggestion-recovery.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ManagedPaneInternal } from './pane-manager-types'
+import { attachWebgl, resetTerminalWebglSuggestion } from './pane-webgl-renderer'
+import { notifyPaneFitSucceeded } from './pane-fit-webgl-attach-signal'
+import { resumePaneRendering, suspendPaneRendering } from './pane-rendering-control'
+
+// xterm's WebglAddon throws this when getContext('webgl2') returns null — the
+// state a restarting GPU process presents for the seconds it is unavailable.
+let webglAvailable = true
+
+function createAutoPane(id: number): ManagedPaneInternal {
+  const leafId = `2222222${id}-2222-4222-8222-222222222222` as never
+  const rect = { width: 800, height: 400 }
+  return {
+    id,
+    leafId,
+    stablePaneId: leafId,
+    terminal: {
+      cols: 80,
+      rows: 24,
+      refresh: vi.fn(),
+      blur: vi.fn(),
+      loadAddon: vi.fn(() => {
+        if (!webglAvailable) {
+          throw new Error('WebGL2 not supported null')
+        }
+      })
+    } as never,
+    container: { dataset: {}, getBoundingClientRect: () => rect } as never,
+    xtermContainer: { getBoundingClientRect: () => rect } as never,
+    // 'auto' is the shipped default, and the only mode the suggestion gates.
+    terminalGpuAcceleration: 'auto',
+    gpuRenderingEnabled: true,
+    webglAttachmentDeferred: false,
+    webglDisabledAfterContextLoss: false,
+    hasComplexScriptOutput: false,
+    webglAddon: null,
+    ligaturesAddon: null,
+    fitResizeObserver: null,
+    pendingObservedFitRafId: null,
+    pendingWebglRefreshRafId: null,
+    fitAddon: { proposeDimensions: vi.fn(() => ({ cols: 80, rows: 23 })), fit: vi.fn() } as never,
+    searchAddon: {} as never,
+    serializeAddon: {} as never,
+    unicode11Addon: {} as never,
+    webLinksAddon: {} as never,
+    compositionHandler: null,
+    pendingSplitScrollState: null,
+    debugLabel: null
+  } as never
+}
+
+describe('auto-mode WebGL suggestion expires at recovery boundaries', () => {
+  beforeEach(() => {
+    webglAvailable = true
+    resetTerminalWebglSuggestion()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(16)
+      return 1
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('restores WebGL after a transient outage that failed one attach', () => {
+    const pane = createAutoPane(1)
+    attachWebgl(pane)
+    expect(pane.webglAddon).not.toBeNull()
+
+    // Backgrounded, then foregrounded while the GPU process is restarting.
+    suspendPaneRendering([pane])
+    webglAvailable = false
+    resumePaneRendering([pane])
+    expect(pane.webglAddon).toBeNull()
+
+    // The GPU is healthy again; the next foreground must not still be on DOM.
+    webglAvailable = true
+    suspendPaneRendering([pane])
+    resumePaneRendering([pane])
+
+    expect(pane.webglAddon).not.toBeNull()
+  })
+
+  it('does not strand panes that never saw the failing attach', () => {
+    // The regression this guards: one pane's transient failure used to pin the
+    // app-wide suggestion to 'dom', so every worktree went DOM-rendered — one
+    // at a time as the user visited it — for the rest of the app session.
+    const failing = createAutoPane(1)
+    webglAvailable = false
+    attachWebgl(failing)
+    webglAvailable = true
+
+    const untouched = createAutoPane(2)
+    suspendPaneRendering([untouched])
+    resumePaneRendering([untouched])
+
+    expect(untouched.webglAddon).not.toBeNull()
+  })
+
+  it('keeps a host that cannot do WebGL to one probe per boundary', () => {
+    // Why this stays: retrying every pane on a WebGL-less host burns a canvas
+    // and a full-stack warning each. The first failure still governs the rest
+    // of the resume — only its lifetime shrinks to the boundary.
+    const panes = [createAutoPane(1), createAutoPane(2), createAutoPane(3)]
+    webglAvailable = false
+
+    suspendPaneRendering(panes)
+    resumePaneRendering(panes)
+
+    const attempts = panes.filter(
+      (pane) => vi.mocked(pane.terminal.loadAddon).mock.calls.length > 0
+    )
+    expect(attempts).toHaveLength(1)
+    expect(panes.every((pane) => pane.webglAddon === null)).toBe(true)
+  })
+
+  it('leaves the suggestion in force between recovery boundaries', () => {
+    // A fit is not a recovery boundary: a resize must not re-probe a GPU that
+    // just refused an attach, or every title change retries context creation.
+    const failing = createAutoPane(1)
+    webglAvailable = false
+    attachWebgl(failing)
+    webglAvailable = true
+
+    const sibling = createAutoPane(2)
+    notifyPaneFitSucceeded(sibling)
+
+    expect(sibling.webglAddon).toBeNull()
+  })
+})


### PR DESCRIPTION
## What

One failed WebGL attach in `auto` mode — the shipped default — sets the module-global `suggestedRendererType` to `'dom'`. Nothing clears it for the rest of the app session except the user toggling the GPU setting.

It also outranks every per-pane latch. `shouldUseTerminalWebgl()` returns `false`, so `attachWebgl()` early-returns and disposes **without setting a latch of its own**.

## Impact

A transient GPU-process restart during a single worktree switch degrades **every pane that re-attaches afterwards** to the DOM renderer — one worktree at a time as the user visits them — long after the GPU recovered.

Simulated against the real modules:

```
1. baseline               A=WebGL      B=WebGL      C=WebGL
2. A backgrounded         A=DOM        B=WebGL      C=WebGL
3. switch back, GPU down  A=DOM        B=WebGL      C=WebGL   <-- one failed attach
4. GPU HEALTHY AGAIN
5. resize A               A=DOM
6. switch away+back to A  A=DOM
7. visit B, then C        A=DOM        B=DOM        C=DOM
8. latches on A: {"failed":false,"lost":false,"deferred":false}
```

Line 8 is the part that makes this hard to diagnose in the field: the stranded panes carry **no latch at all**, so nothing in the rendering diagnostics explains why they are on the DOM renderer. Neither a resize nor a worktree switch recovers them — only an app restart or a GPU-setting toggle.

DOM-rendered cells are also 5.4% wider than WebGL ones (8.43px vs 8.00px measured at the default SF Mono / 14px / weight 500), so a degraded pane silently fits a different column count than its neighbours.

## Why it is the same bug that was already fixed once

The comment above the per-pane latch records this exact failure mode:

> A module-global latch here previously let ONE pane's failure strand every other pane on the DOM renderer until the next boundary.

`suggestedRendererType` **is** that latch, still present — and worse, because no boundary clears it at all.

## Fix

Expire the suggestion where the per-pane failure latch already expires: at rendering resume.

The anti-thrash property the suggestion exists for is preserved. Within a single resume the first pane's failure re-sets it for the remaining panes, so a host that genuinely cannot do WebGL is probed **once per boundary**, not once per pane. Only its lifetime shrinks, from the app session to the boundary.

`resetTerminalWebglAutoDecision()` is deliberately not called — re-probing the platform decision burns a WebGL context.

## Tests

`terminal-webgl-suggestion-recovery.test.ts`, driving the real `attachWebgl` / `shouldUseTerminalWebgl` / `resumePaneRendering` / fit-attach path:

- restores WebGL after a transient outage that failed one attach
- does not strand panes that never saw the failing attach
- keeps a host that cannot do WebGL to one probe per boundary *(pins the preserved behaviour)*
- leaves the suggestion in force between recovery boundaries *(a fit is not a boundary)*

**Acceptance gate:** 2 of the 4 fail against unmodified `main` and pass with the fix. The other 2 pin behaviour that must not change and pass on both sides.

## Verification

- `src/renderer/src/lib/pane-manager/` — 735 passed, 1 skipped
- `pnpm typecheck` — exit 0
- `oxlint` — exit 0
- changed-code quality + type-aware + React Doctor — 0 new findings across 3 files

## Not this PR

This came out of the STA-4042 terminal-bold investigation but **is not that bug** — a renderer swap changes cell width, not glyph weight (+0.4% ink, where a real bold face is +44.7%). Filed separately on its own merits.

## Why a recovery boundary rather than an app-session latch

The suggestion encodes "one failed attach means this host cannot do WebGL." That inference holds where a renderer attaches once per surface and keeps it for the session — nothing re-attaches afterwards to disagree, so the latch never gets a chance to be wrong.

Orca is built the other way round on purpose:

- `tryRetainHiddenPanesWebgl` caps retained hidden contexts at `MAX_RETAINED_HIDDEN_WEBGL_CONTEXTS = 6`, so backgrounding a worktree past that cap **disposes** its panes' contexts
- `resumePaneRendering` **re-attaches** on every worktree foreground and window wake

Re-attach is Orca's common path, not a rare one. That changes the blast radius entirely: instead of gating a handful of newly created surfaces, the latch gates every existing pane on every worktree switch for the rest of the app session. A GPU process unavailable for a few seconds becomes a permanent, silent, app-wide downgrade.

Any renderer-failure state that outlives the surface it was observed on has to answer "what re-evaluates this?" — and for an app that tears contexts down and rebuilds them on visibility changes, the honest answer is the visibility change itself. The narrower claim the observation actually supports is "WebGL was unavailable *at that moment*", which is what a recovery boundary expresses.

This codebase already reached that conclusion once. `webglAttachFailedSinceRecovery` exists precisely because a module-global latch "let ONE pane's failure strand every other pane on the DOM renderer," and it is cleared at rendering resume. `suggestedRendererType` is the remaining half of that conversion — and because it outranks the per-pane latch, it currently makes that latch's retry unreachable.

## Possible follow-up (not in this PR)

`resumePaneRendering` attempts the attach without first checking that the pane has a live box and the window has focus. Context creation is most likely to fail in exactly that state, so a cheap visibility/focus precondition would avoid spending a failure at all, rather than recovering from one. Left out here to keep this change to the latch's lifetime.
