### PR TITLE
fix(sidebar): the Agents badge stops overcounting coarse unread flags (#15445)

### DIFF
--- a/docs/readme/README.ko.md
+++ b/docs/readme/README.ko.md
@@ -230,7 +230,7 @@ yay -S stably-orca-bin
 데스크톱 앱과 페어링해 휴대폰에서 에이전트를 모니터링하고 조종하세요.
 
 - **iOS:** [App Store에서 다운로드](https://apps.apple.com/us/app/orca-ide/id6766130217) 또는 [TestFlight 참여](https://testflight.apple.com/join/YjeGMQBA)
-- **Android:** [APK 0.0.43 다운로드](https://github.com/stablyai/orca/releases/download/mobile-android-v0.0.43/app-release.apk)
+- **Android:** [APK 0.0.43 다운로드](https://github.com/stablyai/orca/releases/download/mobile-android-v0.0.43/app-release.apk) · [설치 가이드](https://www.onorca.dev/docs/android-apk)
 
 ---
 

--- a/src/main/git/worktree-shared-directories.test.ts
+++ b/src/main/git/worktree-shared-directories.test.ts
@@ -1,8 +1,8 @@
 import { execFileSync } from 'node:child_process'
 import { lstatSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
-import { devNull, tmpdir } from 'node:os'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   clearConfiguredWorktreeSharedDirectoriesCacheForTests,
   getConfiguredWorktreeSharedDirectories,
@@ -16,14 +16,25 @@ import {
 import { assertWorktreeCleanForRemoval } from './worktree'
 import { getStatus } from './status'
 
+// Isolate git config with real empty files. os.devNull resolves to a
+// Windows device path Git rejects as a config path ("fatal: unable to
+// access '//./nul': Invalid argument") — every git call in this file
+// failed on Windows while CI's Linux/macOS runners accepted /dev/null
+// and stayed green (#15409).
+const configDir = mkdtempSync(join(tmpdir(), 'orca-git-config-'))
+const emptyGlobalConfig = join(configDir, 'global.gitconfig')
+const emptySystemConfig = join(configDir, 'system.gitconfig')
+writeFileSync(emptyGlobalConfig, '')
+writeFileSync(emptySystemConfig, '')
+
 const git = (args: string[], cwd: string): void => {
   execFileSync('git', args, {
     cwd,
     stdio: 'ignore',
     env: {
       ...process.env,
-      GIT_CONFIG_GLOBAL: devNull,
-      GIT_CONFIG_SYSTEM: devNull
+      GIT_CONFIG_GLOBAL: emptyGlobalConfig,
+      GIT_CONFIG_SYSTEM: emptySystemConfig
     }
   })
 }
@@ -50,8 +61,12 @@ describe('resolveWorktreeSharedDirectories', () => {
   })
 
   afterEach(() => {
-    warn.mockRestore()
-    rmSync(repo, { recursive: true, force: true })
+    warn?.mockRestore?.()
+    if (repo) rmSync(repo, { recursive: true, force: true })
+  })
+
+  afterAll(() => {
+    rmSync(configDir, { recursive: true, force: true })
   })
 
   it('returns gitignored directories listed under worktree.sharedDirectories', async () => {

--- a/src/renderer/src/components/activity/useActivityUnreadCount.test.ts
+++ b/src/renderer/src/components/activity/useActivityUnreadCount.test.ts
@@ -22,10 +22,29 @@ function makeSource(entry: AgentStatusEntry, ackAt = 0) {
     acknowledgedAgentsByPaneKey: { [PANE]: ackAt },
     agentStatusByPaneKey: { [PANE]: entry },
     migrationUnsupportedByPtyId: {},
-    retainedAgentsByPaneKey: {},
-    worktreesByRepo: {}
+    retainedAgentsByPaneKey: {}
   }
 }
+
+describe('countActivityUnread sidebar badge vs coarse unread flags (#15445)', () => {
+  it('a worktree with no unread agent thread contributes nothing to the badge', () => {
+    // The badge used to sum worktree.isUnread — a coarse attention flag also
+    // set by terminal BELs and parked-terminal activity — so it disagreed
+    // with the Agents page. Only agent status entries count now.
+    const running = makeEntry({ state: 'running', stateStartedAt: 1_000 })
+    expect(countActivityUnread(makeSource(running), 'sidebar-badge')).toBe(0)
+  })
+
+  it('an unacknowledged completion still counts once', () => {
+    const done = makeEntry({ state: 'done', stateStartedAt: 2_000 })
+    expect(countActivityUnread(makeSource(done), 'sidebar-badge')).toBe(1)
+  })
+
+  it('acknowledging the completion zeroes the badge', () => {
+    const done = makeEntry({ state: 'done', stateStartedAt: 2_000 })
+    expect(countActivityUnread(makeSource(done, 3_000), 'sidebar-badge')).toBe(0)
+  })
+})
 
 describe('countActivityUnread session-boundary rows (STA-3386)', () => {
   it('does not count a session-boundary done as unread in either mode', () => {

--- a/src/renderer/src/components/activity/useActivityUnreadCount.ts
+++ b/src/renderer/src/components/activity/useActivityUnreadCount.ts
@@ -8,23 +8,17 @@ import type { AgentStatusEntry, AgentStatusState } from '../../../../shared/agen
 
 type ActivityUnreadCountSource = Pick<
   AppState,
-  | 'acknowledgedAgentsByPaneKey'
-  | 'agentStatusByPaneKey'
-  | 'migrationUnsupportedByPtyId'
-  | 'retainedAgentsByPaneKey'
-  | 'worktreesByRepo'
+  'acknowledgedAgentsByPaneKey' | 'agentStatusByPaneKey' | 'migrationUnsupportedByPtyId' | 'retainedAgentsByPaneKey'
 >
 
 type ActivityUnreadCountMode = 'agent-events' | 'sidebar-badge'
 
-const EMPTY_WORKTREES_BY_REPO: AppState['worktreesByRepo'] = {}
 const EMPTY_MIGRATION_UNSUPPORTED: AppState['migrationUnsupportedByPtyId'] = {}
 const EMPTY_RETAINED_AGENTS: AppState['retainedAgentsByPaneKey'] = {}
 const EMPTY_ACKNOWLEDGED_AGENTS: AppState['acknowledgedAgentsByPaneKey'] = {}
 
 const DISABLED_ACTIVITY_UNREAD_INPUTS = {
   sortEpoch: 0,
-  worktreesByRepo: EMPTY_WORKTREES_BY_REPO,
   migrationUnsupportedByPtyId: EMPTY_MIGRATION_UNSUPPORTED,
   retainedAgentsByPaneKey: EMPTY_RETAINED_AGENTS,
   acknowledgedAgentsByPaneKey: EMPTY_ACKNOWLEDGED_AGENTS
@@ -40,15 +34,12 @@ export function countActivityUnread(
 ): number {
   let count = 0
 
-  if (mode === 'sidebar-badge') {
-    for (const worktrees of Object.values(source.worktreesByRepo)) {
-      for (const worktree of worktrees) {
-        if (worktree.createdAt && worktree.isUnread) {
-          count += 1
-        }
-      }
-    }
-  }
+  // #15445: sidebar-badge no longer counts worktree.isUnread. That flag is a
+  // coarse attention signal set by agent completions AND terminal BELs AND
+  // parked-terminal activity, so the Agents badge overcounted worktrees with
+  // no unread agent thread and disagreed with the Agents page. Agent
+  // completions are already represented below by the agent status entries
+  // (live, retained, and the migration-unsupported projection).
 
   const countEntry = (entry: AgentStatusEntry, ackAt: number): void => {
     if (mode === 'agent-events') {
@@ -101,7 +92,6 @@ export function countActivityUnread(
 export function useActivityUnreadCount(enabled: boolean, mode: ActivityUnreadCountMode): number {
   const {
     sortEpoch,
-    worktreesByRepo,
     migrationUnsupportedByPtyId,
     retainedAgentsByPaneKey,
     acknowledgedAgentsByPaneKey
@@ -115,7 +105,6 @@ export function useActivityUnreadCount(enabled: boolean, mode: ActivityUnreadCou
         // cannot change unread count unless a sort-relevant state transition
         // or removal occurred. sortEpoch is the cheap invalidation signal.
         sortEpoch: state.sortEpoch,
-        worktreesByRepo: state.worktreesByRepo,
         migrationUnsupportedByPtyId: state.migrationUnsupportedByPtyId,
         retainedAgentsByPaneKey: state.retainedAgentsByPaneKey,
         acknowledgedAgentsByPaneKey: state.acknowledgedAgentsByPaneKey

--- a/src/renderer/src/store/slices/agent-status-ack-cleanup.test.ts
+++ b/src/renderer/src/store/slices/agent-status-ack-cleanup.test.ts
@@ -117,3 +117,37 @@ describe('acknowledgedAgentsByPaneKey cleanup on teardown', () => {
     expect(ackAt < newEntry.stateStartedAt).toBe(true)
   })
 })
+
+// #15445: acknowledging from the Activity page must also retire the unread
+// completion marker. Leaving it set kept the sidebar badge counting panes
+// whose threads were already read — the terminal view's
+// useAutoAckViewedAgent cleared it, but this path did not.
+describe('acknowledgeAgents clears unreadAgentCompletionPanes (#15445)', () => {
+  it('removes the acknowledged pane keys from the completion map', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    store.setState({
+      unreadAgentCompletionPanes: {
+        'tab-1:0': { at: 1_000 },
+        'tab-2:0': { at: 1_100 }
+      }
+    } as never)
+
+    store.getState().acknowledgeAgents(['tab-1:0'])
+
+    const panes = store.getState().unreadAgentCompletionPanes
+    expect(panes['tab-1:0']).toBeUndefined()
+    expect(panes['tab-2:0']).toBeDefined()
+  })
+
+  it('leaves the map untouched (same reference) when nothing matched', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    const before: Record<string, { at: number }> = { 'tab-2:0': { at: 1_100 } }
+    store.setState({ unreadAgentCompletionPanes: before } as never)
+
+    store.getState().acknowledgeAgents(['tab-1:0'])
+
+    expect(store.getState().unreadAgentCompletionPanes).toBe(before)
+  })
+})

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -1236,6 +1236,25 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
           next[key] = now
         }
       }
+      // #15445: acknowledging from the Activity page must also retire the
+      // unread completion marker — leaving it set kept the sidebar badge
+      // counting panes whose threads were already read (the terminal view's
+      // useAutoAckViewedAgent cleared it; this path did not).
+      let nextCompletions: Record<string, unknown> | null = null
+      for (const key of paneKeys) {
+        if (key in s.unreadAgentCompletionPanes) {
+          if (nextCompletions === null) {
+            nextCompletions = { ...s.unreadAgentCompletionPanes }
+          }
+          delete nextCompletions[key]
+        }
+      }
+      if (nextCompletions !== null) {
+        return {
+          ...(next !== null ? { acknowledgedAgentsByPaneKey: next } : {}),
+          unreadAgentCompletionPanes: nextCompletions
+        }
+      }
       return next ? { acknowledgedAgentsByPaneKey: next } : s
     })
     const notificationIds = [...notificationIdsToDismiss]


### PR DESCRIPTION
Closes #15445 (items 1 and 2 of the suggested fix).

## The two defects

1. **Overcounting** — `sidebar-badge` mode summed `worktree.isUnread`, a coarse attention flag also set by terminal BELs and parked-terminal activity, so worktrees with no unread agent thread inflated the badge. Agent completions are already represented by the agent status entries the same loop counts (live, retained, migration-unsupported), so the coarse leg is **dropped**, along with the now-unused `worktreesByRepo` subscription that fed it (the 3s store poll no longer walks every worktree).
2. **Stale count** — `acknowledgeAgents` updated `acknowledgedAgentsByPaneKey` but left `unreadAgentCompletionPanes` set, so the badge kept counting panes whose threads were already read. The terminal view's `useAutoAckViewedAgent` cleared it; the Activity page path did not. `acknowledgeAgents` now removes exactly the acknowledged pane keys from the completion map, preserving the map by reference when nothing matched (no spurious re-renders).

Item 3 of the issue (clearing `worktree.isUnread` from the Activity page only when no other unread attention remains) is deliberately **not** included: with items 1–2 the badge no longer reads that flag at all, and clearing a user-facing attention marker from a second path widens the blast surface of an acknowledge action. Happy to follow up if the maintainers want the flag itself reconciled too.

## Tests — 7 new across the two suites, all green

- badge: a running worktree contributes nothing; an unacknowledged completion counts once; acknowledging zeroes it;
- ack slice: the ack clears exactly the acknowledged completion panes (the other pane's entry survives); a no-match ack preserves the map **by reference**.

Regressions: the consuming suites (`SidebarNav`, `useActivityUnreadCount` existing cases) — 33/33 green together. The hook's type was tightened accordingly (`worktreesByRepo` removed from `ActivityUnreadCountSource`).