### PR TITLE
fix(rpc): answer every request when a param schema throws (STA-4818)

### DIFF
--- a/src/main/runtime/rpc/dispatcher-error-response.ts
+++ b/src/main/runtime/rpc/dispatcher-error-response.ts
@@ -22,16 +22,26 @@ export function invalidArgumentResponse(
   )
 }
 
+// Why: one definition of "this error already carries a caller-facing validation message", shared
+// with the param-parsing guard so a thrown ZodError reads the same wherever it surfaced.
+export function validationErrorMessage(error: unknown): string | null {
+  if (error instanceof ZodError) {
+    return formatZodError(error)
+  }
+  if (error instanceof InvalidArgumentError) {
+    return error.message
+  }
+  return null
+}
+
 export function mapDispatcherError(
   request: RpcRequest,
   meta: RpcEnvelopeMeta,
   error: unknown
 ): RpcResponse {
-  if (error instanceof ZodError) {
-    return invalidArgumentResponse(request, meta, formatZodError(error))
-  }
-  if (error instanceof InvalidArgumentError) {
-    return invalidArgumentResponse(request, meta, error.message)
+  const validationMessage = validationErrorMessage(error)
+  if (validationMessage !== null) {
+    return invalidArgumentResponse(request, meta, validationMessage)
   }
   if (request.method.startsWith('browser.')) {
     return mapBrowserError(request.id, meta, error)

--- a/src/main/runtime/rpc/dispatcher-param-parsing.ts
+++ b/src/main/runtime/rpc/dispatcher-param-parsing.ts
@@ -5,7 +5,7 @@ import {
   type RpcRequest,
   type RpcResponse
 } from './core'
-import { invalidArgumentResponse } from './dispatcher-error-response'
+import { invalidArgumentResponse, validationErrorMessage } from './dispatcher-error-response'
 
 export type ParsedRpcParams =
   | { value: unknown; error?: undefined }
@@ -29,6 +29,12 @@ export function parseRpcParams(
   try {
     result = method.params.safeParse(rawParams)
   } catch (error) {
+    // Why: a schema that throws a ZodError or InvalidArgumentError already said what is wrong —
+    // report that verbatim, or the caller loses the diagnostic it would have had via safeParse.
+    const validationMessage = validationErrorMessage(error)
+    if (validationMessage !== null) {
+      return { error: invalidArgumentResponse(request, meta, validationMessage) }
+    }
     const detail = error instanceof Error ? error.message : String(error)
     console.error(`[rpc] Param schema for ${request.method} threw during validation:`, error)
     return {

--- a/src/main/runtime/rpc/dispatcher-param-parsing.ts
+++ b/src/main/runtime/rpc/dispatcher-param-parsing.ts
@@ -14,8 +14,8 @@ export type ParsedRpcParams =
 // Why: STA-4818 — both dispatch entry points call this *outside* their own try, so a validator that
 // throws instead of adding an issue used to escape as a rejected dispatch promise; the streaming
 // transports then emitted zero reply frames and hung the caller. Every param schema funnels through
-// here, so guarding the throw once answers the request on every transport. The throw is still logged
-// because a non-total validator is a programmer error, not an expected outcome.
+// here, so guarding the throw once answers the request on every transport. An unexpected throw is
+// still logged, because a non-total validator is a programmer error, not an expected outcome.
 export function parseRpcParams(
   request: RpcRequest,
   method: RpcAnyMethod,

--- a/src/main/runtime/rpc/dispatcher-param-parsing.ts
+++ b/src/main/runtime/rpc/dispatcher-param-parsing.ts
@@ -1,0 +1,46 @@
+import {
+  formatZodError,
+  type RpcAnyMethod,
+  type RpcEnvelopeMeta,
+  type RpcRequest,
+  type RpcResponse
+} from './core'
+import { invalidArgumentResponse } from './dispatcher-error-response'
+
+export type ParsedRpcParams =
+  | { value: unknown; error?: undefined }
+  | { value?: undefined; error: RpcResponse }
+
+// Why: STA-4818 — both dispatch entry points call this *outside* their own try, so a validator that
+// throws instead of adding an issue used to escape as a rejected dispatch promise; the streaming
+// transports then emitted zero reply frames and hung the caller. Every param schema funnels through
+// here, so guarding the throw once answers the request on every transport. The throw is still logged
+// because a non-total validator is a programmer error, not an expected outcome.
+export function parseRpcParams(
+  request: RpcRequest,
+  method: RpcAnyMethod,
+  meta: RpcEnvelopeMeta
+): ParsedRpcParams {
+  if (method.params === null) {
+    return { value: undefined }
+  }
+  const rawParams = request.params ?? {}
+  let result: ReturnType<typeof method.params.safeParse>
+  try {
+    result = method.params.safeParse(rawParams)
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error)
+    console.error(`[rpc] Param schema for ${request.method} threw during validation:`, error)
+    return {
+      error: invalidArgumentResponse(
+        request,
+        meta,
+        `Invalid params for ${request.method}: ${detail}`
+      )
+    }
+  }
+  if (!result.success) {
+    return { error: invalidArgumentResponse(request, meta, formatZodError(result.error)) }
+  }
+  return { value: result.data }
+}

--- a/src/main/runtime/rpc/dispatcher-schema-throw-reply-contract.test.ts
+++ b/src/main/runtime/rpc/dispatcher-schema-throw-reply-contract.test.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import { RpcDispatcher } from './dispatcher'
 import { defineMethod, defineStreamingMethod, InvalidArgumentError, type RpcRequest } from './core'
 import { ALL_RPC_METHODS } from './methods'
+import { parseRpcParams } from './dispatcher-param-parsing'
 import type { OrcaRuntimeService } from '../orca-runtime'
 
 function makeRuntime(): OrcaRuntimeService {
@@ -141,12 +142,6 @@ describe('RpcDispatcher reply contract when a param schema throws', () => {
     })
   }
 
-  it('exercises the computer methods through the real registry', () => {
-    const names = new Set(ALL_RPC_METHODS.map((method) => method.name))
-    expect(names.has('computer.pressKey')).toBe(true)
-    expect(names.has('computer.hotkey')).toBe(true)
-  })
-
   for (const method of [
     'orchestration.throwingSchema',
     'orchestration.throwingStreamingSchema'
@@ -227,6 +222,43 @@ describe('RpcDispatcher reply contract when a param schema throws', () => {
     const response = await dispatcher.dispatch(makeRequest(method, {}))
 
     expect(response).toMatchObject({ ok: false, error: { code: 'invalid_argument', message } })
+  })
+
+  // Why: the guard answers the caller, but it cannot tell anyone a schema went non-total — it just
+  // logs. This is the gate: every registered param schema must reach a verdict on hostile input
+  // without throwing. It is what would have caught STA-4818 the day pressKey was written.
+  it('has no param schema that throws on hostile input', () => {
+    const payloads: unknown[] = [
+      {},
+      undefined,
+      null,
+      [],
+      42,
+      'x',
+      { key: null, app: null, text: null, value: null },
+      { key: 42, app: 42, text: 42, value: 42 },
+      { key: [], app: [], text: [], value: [] },
+      { key: {}, app: {}, text: {}, value: {} }
+    ]
+    const logged = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const nonTotal = new Set<string>()
+    try {
+      for (const method of ALL_RPC_METHODS) {
+        for (const params of payloads) {
+          logged.mockClear()
+          parseRpcParams({ id: 'sweep', authToken: 'tok', method: method.name, params }, method, {
+            runtimeId: 'test-runtime'
+          })
+          if (logged.mock.calls.length > 0) {
+            nonTotal.add(method.name)
+          }
+        }
+      }
+    } finally {
+      logged.mockRestore()
+    }
+
+    expect([...nonTotal].sort()).toEqual([])
   })
 
   it('still reports unknown methods as method_not_found with exactly one reply', async () => {

--- a/src/main/runtime/rpc/dispatcher-schema-throw-reply-contract.test.ts
+++ b/src/main/runtime/rpc/dispatcher-schema-throw-reply-contract.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
 import { RpcDispatcher } from './dispatcher'
-import { defineMethod, defineStreamingMethod, type RpcRequest } from './core'
+import { defineMethod, defineStreamingMethod, InvalidArgumentError, type RpcRequest } from './core'
 import { ALL_RPC_METHODS } from './methods'
 import type { OrcaRuntimeService } from '../orca-runtime'
 
@@ -32,6 +32,10 @@ const ThrowingParams = z.object({ key: z.string().optional() }).superRefine((val
   ;(value.key as string).trim()
 })
 
+// Why: a second, independent way a param schema throws — zod rejects an async refinement during a
+// synchronous safeParse, so this is not specific to a validator forgetting a type check.
+const AsyncParams = z.object({ key: z.string() }).refine(async () => true)
+
 const SYNTHETIC_METHODS = [
   defineMethod({
     name: 'orchestration.throwingSchema',
@@ -44,6 +48,27 @@ const SYNTHETIC_METHODS = [
     handler: async (_params, _ctx, emit) => {
       emit({ ok: true })
     }
+  }),
+  defineMethod({
+    name: 'orchestration.asyncSchema',
+    params: AsyncParams,
+    handler: () => ({ ok: true })
+  }),
+  defineMethod({
+    name: 'orchestration.zodThrowingSchema',
+    params: z
+      .object({})
+      .transform(() =>
+        z.object({ title: z.string().min(1, 'Title is required') }).parse({ title: '' })
+      ),
+    handler: () => ({ ok: true })
+  }),
+  defineMethod({
+    name: 'orchestration.invalidArgumentSchema',
+    params: z.object({}).transform(() => {
+      throw new InvalidArgumentError('Schema rejected the payload')
+    }),
+    handler: () => ({ ok: true })
   })
 ]
 
@@ -174,6 +199,34 @@ describe('RpcDispatcher reply contract when a param schema throws', () => {
     } finally {
       logged.mockRestore()
     }
+  })
+
+  it('emits exactly one invalid_argument reply when a schema needs async parsing', async () => {
+    const logged = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      const replies = await collectStreamingReplies(
+        new RpcDispatcher({ runtime: makeRuntime(), methods: SYNTHETIC_METHODS }),
+        makeRequest('orchestration.asyncSchema', { key: 'ok' })
+      )
+
+      expect(replies).toHaveLength(1)
+      expect(replies[0]).toMatchObject({ ok: false, error: { code: 'invalid_argument' } })
+    } finally {
+      logged.mockRestore()
+    }
+  })
+
+  // Why: a schema can throw an error that already carries the right message. Prefixing it with
+  // generic guard text would leave the caller worse off than a plain safeParse failure.
+  it.each([
+    ['orchestration.zodThrowingSchema', 'Title is required'],
+    ['orchestration.invalidArgumentSchema', 'Schema rejected the payload']
+  ])("reports %s's own validation message verbatim", async (method, message) => {
+    const dispatcher = new RpcDispatcher({ runtime: makeRuntime(), methods: SYNTHETIC_METHODS })
+
+    const response = await dispatcher.dispatch(makeRequest(method, {}))
+
+    expect(response).toMatchObject({ ok: false, error: { code: 'invalid_argument', message } })
   })
 
   it('still reports unknown methods as method_not_found with exactly one reply', async () => {

--- a/src/main/runtime/rpc/dispatcher-schema-throw-reply-contract.test.ts
+++ b/src/main/runtime/rpc/dispatcher-schema-throw-reply-contract.test.ts
@@ -238,7 +238,13 @@ describe('RpcDispatcher reply contract when a param schema throws', () => {
       { key: null, app: null, text: null, value: null },
       { key: 42, app: 42, text: 42, value: 42 },
       { key: [], app: [], text: [], value: [] },
-      { key: {}, app: {}, text: {}, value: {} }
+      { key: {}, app: {}, text: {}, value: {} },
+      // Why: a refinement that derefs one field only when a SIBLING is valid — the shape of
+      // validateComputerTarget — is invisible to all-absent and all-invalid payloads alike. One
+      // field present and the rest absent is the payload that trips it.
+      ...['app', 'key', 'text', 'value', 'id', 'worktree', 'session'].map((field) => ({
+        [field]: 'x'
+      }))
     ]
     const logged = vi.spyOn(console, 'error').mockImplementation(() => {})
     const nonTotal = new Set<string>()

--- a/src/main/runtime/rpc/dispatcher-schema-throw-reply-contract.test.ts
+++ b/src/main/runtime/rpc/dispatcher-schema-throw-reply-contract.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+import { RpcDispatcher } from './dispatcher'
+import { defineMethod, defineStreamingMethod, type RpcRequest } from './core'
+import { ALL_RPC_METHODS } from './methods'
+import type { OrcaRuntimeService } from '../orca-runtime'
+
+function makeRuntime(): OrcaRuntimeService {
+  return { getRuntimeId: () => 'test-runtime' } as OrcaRuntimeService
+}
+
+function makeRequest(method: string, params?: unknown): RpcRequest {
+  return { id: 'req-1', authToken: 'tok', method, params }
+}
+
+async function collectStreamingReplies(
+  dispatcher: RpcDispatcher,
+  request: RpcRequest
+): Promise<unknown[]> {
+  const replies: string[] = []
+  // Why: the production WebSocket call site fires this with `void`, so a rejection here is an
+  // unhandled rejection and the caller waits forever. Assert it settles, then count the frames.
+  await expect(
+    dispatcher.dispatchStreaming(request, (response) => replies.push(response))
+  ).resolves.toBeUndefined()
+  return replies.map((reply) => JSON.parse(reply) as unknown)
+}
+
+// Why: a validator that throws instead of adding an issue — the structural class STA-4818 belongs
+// to, kept independent of the computer schemas so the dispatcher guard is covered on its own.
+const ThrowingParams = z.object({ key: z.string().optional() }).superRefine((value) => {
+  ;(value.key as string).trim()
+})
+
+const SYNTHETIC_METHODS = [
+  defineMethod({
+    name: 'orchestration.throwingSchema',
+    params: ThrowingParams,
+    handler: () => ({ ok: true })
+  }),
+  defineStreamingMethod({
+    name: 'orchestration.throwingStreamingSchema',
+    params: ThrowingParams,
+    handler: async (_params, _ctx, emit) => {
+      emit({ ok: true })
+    }
+  })
+]
+
+describe('RpcDispatcher reply contract when a param schema throws', () => {
+  for (const method of ['computer.pressKey', 'computer.hotkey'] as const) {
+    // The exact payload from STA-4818.
+    it(`emits exactly one invalid_argument reply for ${method} with no params (streaming transport)`, async () => {
+      const replies = await collectStreamingReplies(
+        new RpcDispatcher({ runtime: makeRuntime() }),
+        makeRequest(method, {})
+      )
+
+      expect(replies).toHaveLength(1)
+      expect(replies[0]).toMatchObject({
+        id: 'req-1',
+        ok: false,
+        error: {
+          code: 'invalid_argument',
+          message: expect.stringMatching(/^Missing /)
+        }
+      })
+    })
+
+    it(`returns invalid_argument for ${method} with no params (one-shot transport)`, async () => {
+      const dispatcher = new RpcDispatcher({ runtime: makeRuntime() })
+
+      const response = await dispatcher.dispatch(makeRequest(method, {}))
+
+      expect(response).toMatchObject({
+        id: 'req-1',
+        ok: false,
+        error: {
+          code: 'invalid_argument',
+          message: expect.stringMatching(/^Missing /)
+        }
+      })
+    })
+
+    // Why: a bare dispatcher guard would surface the raw TypeError here instead of naming the
+    // flag the caller forgot, so this is what keeps the validators themselves total.
+    it(`names the absent key for ${method} when only key is missing`, async () => {
+      const dispatcher = new RpcDispatcher({ runtime: makeRuntime() })
+
+      const response = await dispatcher.dispatch(makeRequest(method, { app: 'Finder' }))
+
+      expect(response).toMatchObject({
+        ok: false,
+        error: { code: 'invalid_argument', message: 'Missing key' }
+      })
+    })
+
+    it(`keeps reporting the ${method} shape hint for a present but wrong key`, async () => {
+      const dispatcher = new RpcDispatcher({ runtime: makeRuntime() })
+      const wrongKey = method === 'computer.pressKey' ? 'CmdOrCtrl+V' : 'Return'
+
+      const response = await dispatcher.dispatch(
+        makeRequest(method, { app: 'Finder', key: wrongKey })
+      )
+
+      expect(response).toMatchObject({
+        ok: false,
+        error: {
+          code: 'invalid_argument',
+          message:
+            method === 'computer.pressKey'
+              ? expect.stringContaining('Press-key accepts one key only')
+              : expect.stringContaining('Hotkey requires a modifier and one key')
+        }
+      })
+    })
+  }
+
+  it('exercises the computer methods through the real registry', () => {
+    const names = new Set(ALL_RPC_METHODS.map((method) => method.name))
+    expect(names.has('computer.pressKey')).toBe(true)
+    expect(names.has('computer.hotkey')).toBe(true)
+  })
+
+  for (const method of [
+    'orchestration.throwingSchema',
+    'orchestration.throwingStreamingSchema'
+  ] as const) {
+    it(`emits exactly one invalid_argument reply when ${method}'s schema throws`, async () => {
+      const logged = vi.spyOn(console, 'error').mockImplementation(() => {})
+      try {
+        const replies = await collectStreamingReplies(
+          new RpcDispatcher({
+            runtime: makeRuntime(),
+            methods: SYNTHETIC_METHODS
+          }),
+          makeRequest(method, {})
+        )
+
+        expect(replies).toHaveLength(1)
+        expect(replies[0]).toMatchObject({
+          id: 'req-1',
+          ok: false,
+          error: {
+            code: 'invalid_argument',
+            message: expect.stringContaining(`Invalid params for ${method}`)
+          }
+        })
+        // Why: the guard answers the caller without hiding the programmer error from the host log.
+        expect(logged).toHaveBeenCalledWith(
+          expect.stringContaining(`Param schema for ${method} threw`),
+          expect.any(TypeError)
+        )
+      } finally {
+        logged.mockRestore()
+      }
+    })
+  }
+
+  it('returns invalid_argument from the one-shot path when a schema throws', async () => {
+    const logged = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      const dispatcher = new RpcDispatcher({
+        runtime: makeRuntime(),
+        methods: SYNTHETIC_METHODS
+      })
+
+      const response = await dispatcher.dispatch(makeRequest('orchestration.throwingSchema', {}))
+
+      expect(response).toMatchObject({
+        ok: false,
+        error: { code: 'invalid_argument' }
+      })
+    } finally {
+      logged.mockRestore()
+    }
+  })
+
+  it('still reports unknown methods as method_not_found with exactly one reply', async () => {
+    const replies = await collectStreamingReplies(
+      new RpcDispatcher({ runtime: makeRuntime(), methods: SYNTHETIC_METHODS }),
+      makeRequest('nope.missing', {})
+    )
+
+    expect(replies).toHaveLength(1)
+    expect(replies[0]).toMatchObject({ error: { code: 'method_not_found' } })
+  })
+
+  it('still runs the handler when a throwing-shaped schema accepts the params', async () => {
+    const dispatcher = new RpcDispatcher({
+      runtime: makeRuntime(),
+      methods: SYNTHETIC_METHODS
+    })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('orchestration.throwingSchema', { key: 'ok' })
+    )
+
+    expect(response).toMatchObject({ ok: true, result: { ok: true } })
+  })
+})

--- a/src/main/runtime/rpc/dispatcher.ts
+++ b/src/main/runtime/rpc/dispatcher.ts
@@ -1,6 +1,5 @@
 import {
   buildRegistry,
-  formatZodError,
   isStreamingMethod,
   type RpcAnyMethod,
   type RpcEnvelopeMeta,
@@ -24,7 +23,8 @@ import { orchestrationMigrationFence } from './orchestration-contract-fence'
 import { recordRuntimeFeatureInteraction } from './runtime-feature-interaction'
 import { OrchestrationLegacyCompatibility } from './orchestration-legacy-compatibility'
 import type { RpcDispatchStreamingOptions } from './dispatcher-stream-options'
-import { invalidArgumentResponse, mapDispatcherError } from './dispatcher-error-response'
+import { mapDispatcherError } from './dispatcher-error-response'
+import { parseRpcParams } from './dispatcher-param-parsing'
 
 export type DispatcherOptions = { runtime: OrcaRuntimeService; methods?: readonly RpcAnyMethod[] }
 
@@ -61,7 +61,7 @@ export class RpcDispatcher {
       return migrationFence
     }
 
-    const parsedParams = this.parseParams(request, method, meta)
+    const parsedParams = parseRpcParams(request, method, meta)
     if (parsedParams.error) {
       return parsedParams.error
     }
@@ -163,7 +163,7 @@ export class RpcDispatcher {
       return
     }
 
-    const parsedParams = this.parseParams(request, method, meta)
+    const parsedParams = parseRpcParams(request, method, meta)
     if (parsedParams.error) {
       reply(JSON.stringify(parsedParams.error))
       return
@@ -280,24 +280,6 @@ export class RpcDispatcher {
     } catch (error) {
       reply(JSON.stringify(mapDispatcherError(request, meta, error)))
     }
-  }
-
-  private parseParams(
-    request: RpcRequest,
-    method: RpcAnyMethod,
-    meta: RpcEnvelopeMeta
-  ): { value: unknown; error?: undefined } | { value?: undefined; error: RpcResponse } {
-    if (method.params === null) {
-      return { value: undefined }
-    }
-    const rawParams = request.params ?? {}
-    const result = method.params.safeParse(rawParams)
-    if (!result.success) {
-      return {
-        error: invalidArgumentResponse(request, meta, formatZodError(result.error))
-      }
-    }
-    return { value: result.data }
   }
 
   private meta(): RpcEnvelopeMeta {

--- a/src/main/runtime/runtime-rpc-schema-throw-reply-parity.test.ts
+++ b/src/main/runtime/runtime-rpc-schema-throw-reply-parity.test.ts
@@ -126,4 +126,34 @@ describe('RPC reply contract when a param schema throws', () => {
       error: { code: 'internal_error', message: 'pre-dispatch failure' }
     })
   })
+  // Why: admitLongPoll reserves a capacity slot and registerWebSocketDispatchAbort registers a
+  // controller, both BEFORE the try whose finally releases them. A throw in that window used to
+  // strand the caller AND leak the slot forever, so repeated failures would eventually make every
+  // terminal.wait / orchestration.ask return runtime_busy against a cap that never drains.
+  it('releases the long-poll slot when the acquire window throws', async () => {
+    const { server, deviceToken } = makeServer()
+    const ws = {
+      get readyState(): number {
+        throw new Error('socket went away')
+      },
+      on: () => {},
+      off: () => {}
+    } as unknown as Parameters<(typeof server)['handleWebSocketMessage']>[4]
+    const before = server['activeLongPolls']
+    const replies: string[] = []
+
+    void server['handleWebSocketMessage'](
+      // terminal.wait is a long-poll class, so a slot is reserved before the throw.
+      JSON.stringify({ id: 'ws-1', method: 'terminal.wait', deviceToken, params: {} }),
+      (response) => replies.push(response),
+      () => {},
+      undefined,
+      ws
+    )
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(unhandled).toEqual([])
+    expect(replies).toHaveLength(1)
+    expect(server['activeLongPolls']).toBe(before)
+  })
 })

--- a/src/main/runtime/runtime-rpc-schema-throw-reply-parity.test.ts
+++ b/src/main/runtime/runtime-rpc-schema-throw-reply-parity.test.ts
@@ -95,4 +95,35 @@ describe('RPC reply contract when a param schema throws', () => {
       })
     }
   }
+  // Why: the WebSocket handler is fired with `void`, so anything throwing BEFORE the dispatcher's
+  // own try — not just a param schema — would strand the caller with zero frames. STA-4818 removed
+  // one such trigger; this pins the transport guarantee that outlives any single trigger.
+  // Limit worth knowing: the error frame is built from the runtime's id, so a runtime service that
+  // is itself broken cannot be answered. Every step on this path reads an already-resolved field.
+  it('still replies once when dispatch throws before its own try block', async () => {
+    const { server, deviceToken } = makeServer()
+    Object.defineProperty(server, 'dispatcher', {
+      value: {
+        dispatchStreaming: () => {
+          throw new Error('pre-dispatch failure')
+        }
+      }
+    })
+    const replies: string[] = []
+
+    void server['handleWebSocketMessage'](
+      JSON.stringify({ id: 'ws-1', method: 'status.get', deviceToken, params: {} }),
+      (response) => replies.push(response),
+      () => {}
+    )
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(unhandled).toEqual([])
+    expect(replies).toHaveLength(1)
+    expect(JSON.parse(replies[0])).toMatchObject({
+      id: 'ws-1',
+      ok: false,
+      error: { code: 'internal_error', message: 'pre-dispatch failure' }
+    })
+  })
 })

--- a/src/main/runtime/runtime-rpc-schema-throw-reply-parity.test.ts
+++ b/src/main/runtime/runtime-rpc-schema-throw-reply-parity.test.ts
@@ -10,14 +10,20 @@ import type { OrcaRuntimeService } from './orca-runtime'
 // reply on every transport, not a silent hang plus an unhandled rejection.
 const THROWING_PARAM_METHODS = ['computer.pressKey', 'computer.hotkey'] as const
 
+// Only an *absent* `key` reaches the refinement as undefined: when the property is present but
+// invalid, `requiredString`'s transform still puts '' in the parsed object. The present-but-invalid
+// rows guard that boundary, so a change to `requiredString` that starts dropping the key is caught.
+const KEY_PAYLOADS = [
+  { label: 'no params', params: {} },
+  { label: 'an absent key', params: { app: 'Finder' } },
+  { label: 'an empty key', params: { app: 'Finder', key: '' } },
+  { label: 'a non-string key', params: { app: 'Finder', key: 42 } }
+] as const
+
 function makeServer(): { server: OrcaRuntimeRpcServer; deviceToken: string } {
   const userDataPath = mkdtempSync(join(tmpdir(), 'orca-rpc-schema-throw-'))
   const runtime = { getRuntimeId: () => 'test-runtime' } as OrcaRuntimeService
-  const server = new OrcaRuntimeRpcServer({
-    runtime,
-    userDataPath,
-    enableWebSocket: false
-  })
+  const server = new OrcaRuntimeRpcServer({ runtime, userDataPath, enableWebSocket: false })
   server['deviceRegistry'] = new DeviceRegistry(userDataPath)
   // Why: computer.* is off the mobile allowlist; runtime-scope pairings reach it.
   const device = server['deviceRegistry']!.addDevice('desktop', 'runtime')
@@ -40,50 +46,47 @@ describe('RPC reply contract when a param schema throws', () => {
   })
 
   for (const method of THROWING_PARAM_METHODS) {
-    it(`replies once with invalid_argument over WebSocket for ${method} with a missing key`, async () => {
-      const { server, deviceToken } = makeServer()
-      const replies: string[] = []
+    for (const { label, params } of KEY_PAYLOADS) {
+      it(`replies once with invalid_argument over WebSocket for ${method} with ${label}`, async () => {
+        const { server, deviceToken } = makeServer()
+        const replies: string[] = []
 
-      // Why: mirrors the production call site, which fires this off with `void`.
-      await server['handleWebSocketMessage'](
-        JSON.stringify({ id: 'ws-1', method, deviceToken, params: {} }),
-        (response) => replies.push(response),
-        () => {}
-      )
-      await new Promise((resolve) => setImmediate(resolve))
+        // Why: production fires this with `void` and never awaits it, so a rejection here is an
+        // unhandled rejection and the caller waits for its own timeout. Reproduce that exactly.
+        void server['handleWebSocketMessage'](
+          JSON.stringify({ id: 'ws-1', method, deviceToken, params }),
+          (response) => replies.push(response),
+          () => {}
+        )
+        await new Promise((resolve) => setTimeout(resolve, 0))
 
-      expect(replies).toHaveLength(1)
-      expect(JSON.parse(replies[0])).toMatchObject({
-        id: 'ws-1',
-        ok: false,
-        error: { code: 'invalid_argument' }
-      })
-      expect(unhandled).toEqual([])
-    })
-
-    it(`matches the unix-socket reply for ${method} with a missing key`, async () => {
-      const { server, deviceToken } = makeServer()
-      const wsReplies: string[] = []
-      await server['handleWebSocketMessage'](
-        JSON.stringify({ id: 'req-1', method, deviceToken, params: {} }),
-        (response) => wsReplies.push(response),
-        () => {}
-      )
-
-      const socketResponse = await server['handleMessage'](
-        JSON.stringify({
-          id: 'req-1',
-          method,
-          authToken: server['authToken'],
-          params: {}
+        expect(unhandled).toEqual([])
+        expect(replies).toHaveLength(1)
+        expect(JSON.parse(replies[0])).toMatchObject({
+          id: 'ws-1',
+          ok: false,
+          error: { code: 'invalid_argument' }
         })
-      )
-
-      expect(socketResponse).toMatchObject({
-        ok: false,
-        error: { code: 'invalid_argument' }
       })
-      expect(socketResponse).toEqual(JSON.parse(wsReplies[0]))
-    })
+
+      it(`matches the unix-socket reply for ${method} with ${label}`, async () => {
+        const { server, deviceToken } = makeServer()
+        const wsReplies: string[] = []
+        await server['handleWebSocketMessage'](
+          JSON.stringify({ id: 'req-1', method, deviceToken, params }),
+          (response) => wsReplies.push(response),
+          () => {}
+        )
+
+        // Why: main answered this one `internal_error` via the socket transport's `.catch`,
+        // so parity is the assertion that matters, not just "some error came back".
+        const socketResponse = await server['handleMessage'](
+          JSON.stringify({ id: 'req-1', method, authToken: server['authToken'], params })
+        )
+
+        expect(socketResponse).toMatchObject({ ok: false, error: { code: 'invalid_argument' } })
+        expect(socketResponse).toEqual(JSON.parse(wsReplies[0]))
+      })
+    }
   }
 })

--- a/src/main/runtime/runtime-rpc-schema-throw-reply-parity.test.ts
+++ b/src/main/runtime/runtime-rpc-schema-throw-reply-parity.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync } from 'node:fs'
+import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
@@ -20,8 +20,11 @@ const KEY_PAYLOADS = [
   { label: 'a non-string key', params: { app: 'Finder', key: 42 } }
 ] as const
 
+const userDataPaths: string[] = []
+
 function makeServer(): { server: OrcaRuntimeRpcServer; deviceToken: string } {
   const userDataPath = mkdtempSync(join(tmpdir(), 'orca-rpc-schema-throw-'))
+  userDataPaths.push(userDataPath)
   const runtime = { getRuntimeId: () => 'test-runtime' } as OrcaRuntimeService
   const server = new OrcaRuntimeRpcServer({ runtime, userDataPath, enableWebSocket: false })
   server['deviceRegistry'] = new DeviceRegistry(userDataPath)
@@ -43,6 +46,9 @@ describe('RPC reply contract when a param schema throws', () => {
 
   afterEach(() => {
     process.off('unhandledRejection', onUnhandled)
+    while (userDataPaths.length > 0) {
+      rmSync(userDataPaths.pop()!, { recursive: true, force: true })
+    }
   })
 
   for (const method of THROWING_PARAM_METHODS) {

--- a/src/main/runtime/runtime-rpc-schema-throw-reply-parity.test.ts
+++ b/src/main/runtime/runtime-rpc-schema-throw-reply-parity.test.ts
@@ -1,0 +1,89 @@
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { OrcaRuntimeRpcServer } from './runtime-rpc'
+import { DeviceRegistry } from './device-registry'
+import type { OrcaRuntimeService } from './orca-runtime'
+
+// STA-4818: a param schema that throws must still produce exactly one structured
+// reply on every transport, not a silent hang plus an unhandled rejection.
+const THROWING_PARAM_METHODS = ['computer.pressKey', 'computer.hotkey'] as const
+
+function makeServer(): { server: OrcaRuntimeRpcServer; deviceToken: string } {
+  const userDataPath = mkdtempSync(join(tmpdir(), 'orca-rpc-schema-throw-'))
+  const runtime = { getRuntimeId: () => 'test-runtime' } as OrcaRuntimeService
+  const server = new OrcaRuntimeRpcServer({
+    runtime,
+    userDataPath,
+    enableWebSocket: false
+  })
+  server['deviceRegistry'] = new DeviceRegistry(userDataPath)
+  // Why: computer.* is off the mobile allowlist; runtime-scope pairings reach it.
+  const device = server['deviceRegistry']!.addDevice('desktop', 'runtime')
+  return { server, deviceToken: device.token }
+}
+
+describe('RPC reply contract when a param schema throws', () => {
+  const unhandled: unknown[] = []
+  const onUnhandled = (reason: unknown): void => {
+    unhandled.push(reason)
+  }
+
+  beforeEach(() => {
+    unhandled.length = 0
+    process.on('unhandledRejection', onUnhandled)
+  })
+
+  afterEach(() => {
+    process.off('unhandledRejection', onUnhandled)
+  })
+
+  for (const method of THROWING_PARAM_METHODS) {
+    it(`replies once with invalid_argument over WebSocket for ${method} with a missing key`, async () => {
+      const { server, deviceToken } = makeServer()
+      const replies: string[] = []
+
+      // Why: mirrors the production call site, which fires this off with `void`.
+      await server['handleWebSocketMessage'](
+        JSON.stringify({ id: 'ws-1', method, deviceToken, params: {} }),
+        (response) => replies.push(response),
+        () => {}
+      )
+      await new Promise((resolve) => setImmediate(resolve))
+
+      expect(replies).toHaveLength(1)
+      expect(JSON.parse(replies[0])).toMatchObject({
+        id: 'ws-1',
+        ok: false,
+        error: { code: 'invalid_argument' }
+      })
+      expect(unhandled).toEqual([])
+    })
+
+    it(`matches the unix-socket reply for ${method} with a missing key`, async () => {
+      const { server, deviceToken } = makeServer()
+      const wsReplies: string[] = []
+      await server['handleWebSocketMessage'](
+        JSON.stringify({ id: 'req-1', method, deviceToken, params: {} }),
+        (response) => wsReplies.push(response),
+        () => {}
+      )
+
+      const socketResponse = await server['handleMessage'](
+        JSON.stringify({
+          id: 'req-1',
+          method,
+          authToken: server['authToken'],
+          params: {}
+        })
+      )
+
+      expect(socketResponse).toMatchObject({
+        ok: false,
+        error: { code: 'invalid_argument' }
+      })
+      expect(socketResponse).toEqual(JSON.parse(wsReplies[0]))
+    })
+  }
+})

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -1727,6 +1727,20 @@ export class OrcaRuntimeRpcServer {
         registerBinaryStreamHandler: (streamId, handler) =>
           this.registerBinaryStreamHandler(connectionId, streamId, handler)
       })
+    } catch (error) {
+      // Why: this handler is fired with `void` (see onText), so without this catch a throw before
+      // the dispatcher's own try becomes an unhandled rejection and the client gets zero frames and
+      // hangs until its own timeout (STA-4818). Mirrors the unix socket's `.catch`, which has to
+      // re-parse the raw message to recover an id; here request.id is already in scope.
+      reply(
+        JSON.stringify(
+          this.buildError(
+            request.id,
+            'internal_error',
+            error instanceof Error ? error.message : String(error)
+          )
+        )
+      )
     } finally {
       abortRegistration?.dispose()
       this.releaseLongPoll(longPoll)

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -1678,8 +1678,50 @@ export class OrcaRuntimeRpcServer {
       return
     }
 
-    const abortRegistration = ws ? this.registerWebSocketDispatchAbort(ws) : null
+    // Why: names the slot we actually hold. admitLongPoll only increments when it returns null, so
+    // releasing on the rejection path would free someone else's slot.
+    const heldLongPoll = longPoll
+    let abortRegistration: ReturnType<typeof this.registerWebSocketDispatchAbort> | null = null
 
+    try {
+      abortRegistration = ws ? this.registerWebSocketDispatchAbort(ws) : null
+      await this.dispatchAuthenticatedWebSocketRequest(request, reply, sendBinary, device, token, {
+        ws,
+        authenticatedSocket,
+        abortRegistration
+      })
+    } catch (error) {
+      // Why: this handler is fired with `void` (see onText), so an escape here becomes an unhandled
+      // rejection and the client gets zero frames and hangs until its own timeout (STA-4818). The
+      // try opens at the acquisition so the finally always releases what was taken.
+      reply(
+        JSON.stringify(
+          this.buildError(
+            request.id,
+            'internal_error',
+            error instanceof Error ? error.message : String(error)
+          )
+        )
+      )
+    } finally {
+      abortRegistration?.dispose()
+      this.releaseLongPoll(heldLongPoll)
+    }
+  }
+
+  private async dispatchAuthenticatedWebSocketRequest(
+    request: RpcRequest,
+    reply: (response: string) => void,
+    sendBinary: (response: Uint8Array<ArrayBufferLike>) => boolean | void,
+    device: DeviceEntry,
+    token: string,
+    context: {
+      ws?: WebSocket
+      authenticatedSocket?: AuthenticatedMobileSocket
+      abortRegistration: { signal: AbortSignal; dispose: () => void } | null
+    }
+  ): Promise<void> {
+    const { ws, authenticatedSocket, abortRegistration } = context
     // Why: older pairings may lack scope metadata, so stamp the authenticated scope onto status.get.
     const replyForRequest =
       request.method === 'status.get'
@@ -1711,40 +1753,21 @@ export class OrcaRuntimeRpcServer {
               )
           }
         : undefined
-    try {
-      await this.dispatcher.dispatchStreaming(request, replyForRequest, {
-        // Why: the validated credential preserves existing federation ownership without trusting request fields.
-        authenticatedCallerFingerprint: fingerprintAuthenticatedPairingCredential(token),
-        connectionId,
-        clientId: token,
-        pairedDeviceId: device.deviceId,
-        // Why: gates the mobile-only payload diet so full-screen web/desktop clients aren't truncated.
-        clientKind: device.scope,
-        clientCapabilities: authenticatedSocket?.clientCapabilities,
-        pairing: pairingContext,
-        signal: abortRegistration?.signal,
-        sendBinary,
-        registerBinaryStreamHandler: (streamId, handler) =>
-          this.registerBinaryStreamHandler(connectionId, streamId, handler)
-      })
-    } catch (error) {
-      // Why: this handler is fired with `void` (see onText), so without this catch a throw before
-      // the dispatcher's own try becomes an unhandled rejection and the client gets zero frames and
-      // hangs until its own timeout (STA-4818). Mirrors the unix socket's `.catch`, which has to
-      // re-parse the raw message to recover an id; here request.id is already in scope.
-      reply(
-        JSON.stringify(
-          this.buildError(
-            request.id,
-            'internal_error',
-            error instanceof Error ? error.message : String(error)
-          )
-        )
-      )
-    } finally {
-      abortRegistration?.dispose()
-      this.releaseLongPoll(longPoll)
-    }
+    await this.dispatcher.dispatchStreaming(request, replyForRequest, {
+      // Why: the validated credential preserves existing federation ownership without trusting request fields.
+      authenticatedCallerFingerprint: fingerprintAuthenticatedPairingCredential(token),
+      connectionId,
+      clientId: token,
+      pairedDeviceId: device.deviceId,
+      // Why: gates the mobile-only payload diet so full-screen web/desktop clients aren't truncated.
+      clientKind: device.scope,
+      clientCapabilities: authenticatedSocket?.clientCapabilities,
+      pairing: pairingContext,
+      signal: abortRegistration?.signal,
+      sendBinary,
+      registerBinaryStreamHandler: (streamId, handler) =>
+        this.registerBinaryStreamHandler(connectionId, streamId, handler)
+    })
   }
 
   private buildError(id: string, code: string, message: string): RpcResponse {

--- a/src/shared/computer-use-key-spec.test.ts
+++ b/src/shared/computer-use-key-spec.test.ts
@@ -53,4 +53,19 @@ describe('computer-use key specs', () => {
       expected
     )
   })
+
+  // STA-4818: these run inside zod superRefine, where a throw escapes safeParse.
+  it('stays total for absent and non-string input', () => {
+    for (const value of [undefined, null, 42, {}, ['Return']]) {
+      expect(computerUsePressKeyValidationMessage(value)).toEqual(
+        expect.stringContaining('Press-key accepts one key only')
+      )
+      expect(computerUseHotkeyValidationMessage(value)).toEqual(
+        expect.stringContaining('Hotkey requires a modifier and one key')
+      )
+      expect(computerUseClickModifiersValidationMessage(value)).toEqual(
+        expect.stringContaining('Click modifiers accept modifier keys only')
+      )
+    }
+  })
 })

--- a/src/shared/computer-use-key-spec.ts
+++ b/src/shared/computer-use-key-spec.ts
@@ -20,7 +20,13 @@ const PRESS_KEY_HINT =
 const CLICK_MODIFIERS_HINT =
   'Click modifiers accept modifier keys only, e.g. CmdOrCtrl or CmdOrCtrl+Shift.'
 
-export function computerUseHotkeyValidationMessage(key: string): string | null {
+// Why: these run inside zod superRefine, where a throw escapes safeParse and strands the RPC
+// caller with zero reply frames (STA-4818). A failed field-level check leaves the value absent,
+// so they must stay total over unknown input and report the hint instead.
+export function computerUseHotkeyValidationMessage(key: unknown): string | null {
+  if (typeof key !== 'string') {
+    return HOTKEY_HINT
+  }
   const parts = key.split('+').map((part) => part.trim())
   if (parts.length < 2 || parts.some((part) => part.length === 0)) {
     return HOTKEY_HINT
@@ -40,7 +46,10 @@ export function computerUseHotkeyValidationMessage(key: string): string | null {
   return null
 }
 
-export function computerUsePressKeyValidationMessage(key: string): string | null {
+export function computerUsePressKeyValidationMessage(key: unknown): string | null {
+  if (typeof key !== 'string') {
+    return PRESS_KEY_HINT
+  }
   const trimmed = key.trim()
   if (trimmed.length === 0) {
     return PRESS_KEY_HINT
@@ -51,7 +60,10 @@ export function computerUsePressKeyValidationMessage(key: string): string | null
   return null
 }
 
-export function computerUseClickModifiersValidationMessage(modifiers: string): string | null {
+export function computerUseClickModifiersValidationMessage(modifiers: unknown): string | null {
+  if (typeof modifiers !== 'string') {
+    return CLICK_MODIFIERS_HINT
+  }
   const parts = modifiers.split('+').map((part) => part.trim())
   if (
     parts.length === 0 ||


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​466 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​466 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​144 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​51 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​93 |

<!-- /orca-pr-loc -->

Fixes STA-4818.

## Problem

`computer.pressKey` and `computer.hotkey` with an absent `key` produced **zero reply frames** on the WebSocket/relay transport. The caller hung until its own timeout and the main process took an unhandled rejection. On the unix socket the same throw surfaced as a misleading `internal_error`.

Reproduced on `origin/main` (41c4d8e8a8) through the real dispatcher and the real WebSocket reply callback, firing `handleWebSocketMessage` the way production does (`void`, never awaited), using the exact payloads from the ticket:

```
{"id":"1","method":"computer.pressKey","params":{}}  -> TypeError: Cannot read properties of undefined (reading 'trim')
{"id":"1","method":"computer.hotkey","params":{}}    -> TypeError: Cannot read properties of undefined (reading 'split')
```

The baseline failure is the unhandled `TypeError` itself plus an empty reply list — not merely a rejected promise the test chose to await.

## Mechanism

zod v4 still runs the object-level `superRefine` after a field-level check has already failed. The refinement then called `computerUsePressKeyValidationMessage(undefined)`, which threw out of `safeParse`. Param parsing runs *outside* the surrounding `try` in both `dispatch` and `dispatchStreaming`, so the throw escaped as a rejected dispatch promise — and the WebSocket call site invokes `handleWebSocketMessage` with a fire-and-forget `void`, so nothing replied.

Worth pinning precisely, because it narrows the blast radius: the refinement sees `undefined` **only when the property is absent**. When `key` is present but invalid (`''`, `42`, `null`), `requiredString`'s transform still puts `''` into the parsed object, so those payloads never threw. The regression test covers both sides of that boundary.

## Fix

Two changes, each independently load-bearing (verified by reverting one at a time):

1. **Boundary — `dispatcher-param-parsing.ts`.** Param parsing moves out of `RpcDispatcher` into its own module where `safeParse` is guarded; a throw answers with `invalid_argument`. This is the single funnel both entry points already call, so every transport and every future throwing validator is covered without moving control flow or risking a double reply. The throw is still `console.error`-logged, because a non-total validator is a programmer error, not an expected outcome. (The extraction also keeps `dispatcher.ts` under the 300-line cap.)
2. **Diagnostics — total validators.** The three shared computer-use key validators accept `unknown` and return their hint instead of throwing, so an absent key still reports `Missing key` rather than raw TypeError text. `computerUseClickModifiersValidationMessage` was only total by accident of a sibling field being declared `z.string().optional()`; making it total removes that cross-file coupling.

### Rejected alternatives

- **Moving param parsing inside the existing `try`.** In `dispatch` that catch runs `mapDispatcherError`, which falls through to `mapRuntimeError` and returns `runtime_error` for a `TypeError` — the wrong code for a parameter failure, and one that reads as a transient host fault rather than "fix your flags". (`internal_error` is what the unix socket wrapper's outer `.catch` produces today when `dispatch` rejects outright; verified by executing both.) In `dispatchStreaming` the parse sits before the streaming/non-streaming split, so it would need a restructure of both methods.
- **Fixing only the two validators.** Leaves the structural hole: the next throwing refine reproduces the identical hang.

### Review rounds

Three independent Codex `gpt-5.6-luna` reviewers (boundary / oracle / surface) ran against this branch. Two proven findings, both fixed here:

- The guard wrapped *every* caught throw in `Invalid params for <method>: <detail>`, so a schema that throws a `ZodError` (e.g. `.parse()` inside a transform) reported a JSON-serialized issue array instead of `Title is required`. `validationErrorMessage` now holds the single definition of "this error already carries a caller-facing message", shared with `mapDispatcherError`. The generic prefix and the log survive for genuinely unexpected throws.
- The rejected-alternative rationale above named the wrong error code; corrected.

The oracle reviewer independently reproduced the baseline, re-ran the revert oracle both directions, and mutation-tested the new suite (guard returning `internal_error`, guard re-throwing, guard double-replying, validator returning `null` for non-strings, swapped hints) — all five mutants caught. The surface reviewer found no proven finding across callers, mixed-version clients, security of the echoed detail, and the platform matrix.

## Validation

- Deterministic red on `origin/main`, green on this branch, for both transports. Baseline fails on exactly the absent-key rows and passes the present-but-invalid rows, matching the mechanism above.
- Revert oracle: dropping the dispatcher guard fails only the synthetic throwing-schema tests; dropping validator totality fails only the diagnostics/parity tests. Non-overlapping, so neither half is decorative.
- `src/main/runtime/rpc/**`, `src/main/computer/**`, `src/shared/computer-use-key-spec.test.ts`, CLI computer flags: 189 files / 1589 tests pass. `tsc --noEmit` clean. `check:code-quality:changed` clean.

## Surface notes

No wire change: `invalid_argument` is the code every param failure already uses, so mixed-version clients need nothing new. Unknown methods, the migration fence, cancellation, streaming emits, and transport teardown are untouched. The relay/plugin-host dispatcher (`src/relay/dispatcher.ts`) was audited — it already wraps handler invocation in try/catch and always sends a response, so it has no equivalent hole. The change is platform-agnostic and touches no path, shell, or keyboard handling.
