### PR TITLE
fix(orchestration): surface blocked Delivery backlogs

### DIFF
--- a/src/cli/specs/orchestration.ts
+++ b/src/cli/specs/orchestration.ts
@@ -84,6 +84,8 @@ export const ORCHESTRATION_COMMAND_SPECS: CommandSpec[] = [
       'orca orchestration check [--terminal <handle>] [--run <run_id>] [--ack <delivery_id>] [--unread | --peek | --all] [--types <type,...>] [--format] [--wait] [--timeout-ms <n>] [--retry-request <id>] [--json]\n' +
       "  default: return the bound Run's oldest unacknowledged FIFO batch.\n" +
       '  --ack: acknowledge the prior whole batch before checking/waiting.\n' +
+      '         A partial batch or unacknowledged replay returns a delivery_fifo_blocked warning\n' +
+      '         with blockedSince, pendingBehind, and the total unread count.\n' +
       '  --peek: return only unread messages without marking them read.\n' +
       '  --all: return every message for the handle; does not mark read.\n' +
       '  --wait: block until a matching message arrives or --timeout-ms expires.\n' +
@@ -108,7 +110,7 @@ export const ORCHESTRATION_COMMAND_SPECS: CommandSpec[] = [
     notes: [
       'On Windows PowerShell, quote comma-separated type filters, e.g. --types "worker_done,escalation".',
       '--format renders the returned rows as local text only; it never writes to another terminal.',
-      'A bound Run replays the same Delivery until --ack; process every message before acknowledging.'
+      'A bound Run replays the same Delivery until --ack; process every message before acknowledging. The first replay warns when that Delivery blocks the FIFO.'
     ]
   },
   {

--- a/src/main/runtime/orchestration-mailbox-notification-consistency.test.ts
+++ b/src/main/runtime/orchestration-mailbox-notification-consistency.test.ts
@@ -655,10 +655,29 @@ describe('orchestration notification mailbox consistency', () => {
     expect(pointerCount(harness.write)).toBe(0)
     expect(replayed.messages).toEqual([expect.objectContaining({ id: firstMessage.id })])
     expect(replayed.deliveryId).toBe(firstDelivery.deliveryId)
+    expect(replayed).toMatchObject({
+      replayed: true,
+      pendingBehind: 1,
+      mailboxUnreadCount: 2,
+      checkCountDiverged: true,
+      deliveryWarning: {
+        code: 'delivery_fifo_blocked',
+        requiredAction: 'acknowledge_delivery',
+        deliveryId: firstDelivery.deliveryId
+      }
+    })
+    expect(replayed.blockedSince).toEqual(expect.any(String))
 
     const next = await checkBoundMailbox(harness.runtime, { ack: firstDelivery.deliveryId! })
     expect(next.messages).toEqual([expect.objectContaining({ id: newerMessage.id })])
     expect(next.deliveryId).not.toBe(firstDelivery.deliveryId)
+    expect(next).toMatchObject({
+      replayed: false,
+      pendingBehind: 0,
+      mailboxUnreadCount: 1,
+      checkCountDiverged: false
+    })
+    expect(next.deliveryWarning).toBeUndefined()
     db.close()
   })
 

--- a/src/main/runtime/orchestration-mailbox-notification-test-harness.ts
+++ b/src/main/runtime/orchestration-mailbox-notification-test-harness.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { expect, vi } from 'vitest'
 import { ORCHESTRATION_CONTRACT_VERSION } from '../../shared/protocol-version'
+import type { OrchestrationDeliveryWarning } from '../../shared/orchestration-check-output'
 import type Database from '../sqlite/sync-database'
 import { OrcaRuntimeService } from './orca-runtime'
 import { OrchestrationDb } from './orchestration/db'
@@ -69,6 +70,12 @@ export type MailboxCheckResult = {
   count: number
   messages: unknown[]
   acknowledged?: string | null
+  replayed?: boolean
+  blockedSince?: string
+  pendingBehind?: number
+  mailboxUnreadCount?: number
+  checkCountDiverged?: boolean
+  deliveryWarning?: OrchestrationDeliveryWarning
 }
 
 export type MailboxCheckOptions = {

--- a/src/main/runtime/orchestration/db/runs/run-delivery.ts
+++ b/src/main/runtime/orchestration/db/runs/run-delivery.ts
@@ -38,6 +38,34 @@ export function getDeliveryMessages(this: OrchestrationDb, delivery: DeliveryRow
   )
 }
 
+function getRunDeliveryMailboxCounts(
+  db: OrchestrationDb,
+  runId: string,
+  deliveredCount: number
+): { mailboxUnreadCount: number; pendingBehind: number } {
+  const address = `run:${runId}`
+  const row = db.db
+    .prepare(
+      `SELECT COUNT(*) AS count FROM messages
+       WHERE run_id = ? AND to_handle = ? AND read = 0
+         AND delivery_contract = 'current_delivery'`
+    )
+    .get(runId, address) as { count: number }
+  const mailboxUnreadCount = row.count
+  return {
+    mailboxUnreadCount,
+    pendingBehind: Math.max(0, mailboxUnreadCount - deliveredCount)
+  }
+}
+
+export type RunDeliveryResult = {
+  delivery: DeliveryRow
+  messages: MessageRow[]
+  replayed: boolean
+  mailboxUnreadCount: number
+  pendingBehind: number
+}
+
 export function getOrCreateRunDelivery(
   this: OrchestrationDb,
   params: {
@@ -46,7 +74,7 @@ export function getOrCreateRunDelivery(
     limit?: number
     wakeTypes?: MessageType[]
   }
-): { delivery: DeliveryRow; messages: MessageRow[]; replayed: boolean } | undefined {
+): RunDeliveryResult | undefined {
   const limit = Math.min(
     Math.max(params.limit ?? ORCHESTRATION_DELIVERY_BATCH_LIMIT, 1),
     ORCHESTRATION_DELIVERY_BATCH_LIMIT
@@ -65,8 +93,14 @@ export function getOrCreateRunDelivery(
         )
       }
       const messages = this.getDeliveryMessages(existing)
+      const counts = getRunDeliveryMailboxCounts(this, params.runId, messages.length)
       this.db.exec('COMMIT')
-      return { delivery: exposeDeliveryTimestamps(existing), messages, replayed: true }
+      return {
+        delivery: exposeDeliveryTimestamps(existing),
+        messages,
+        replayed: true,
+        ...counts
+      }
     }
 
     const address = `run:${params.runId}`
@@ -114,8 +148,14 @@ export function getOrCreateRunDelivery(
         JSON.stringify(messages.map((message) => message.id))
       )
     const delivery = this.getDeliveryRaw(deliveryId) as DeliveryRow
+    const counts = getRunDeliveryMailboxCounts(this, params.runId, messages.length)
     this.db.exec('COMMIT')
-    return { delivery: exposeDeliveryTimestamps(delivery), messages, replayed: false }
+    return {
+      delivery: exposeDeliveryTimestamps(delivery),
+      messages,
+      replayed: false,
+      ...counts
+    }
   } catch (error) {
     this.db.exec('ROLLBACK')
     throw error

--- a/src/main/runtime/orchestration/orchestration-run-delivery-db.test.ts
+++ b/src/main/runtime/orchestration/orchestration-run-delivery-db.test.ts
@@ -51,6 +51,8 @@ describe('OrchestrationDb Run state', () => {
       expect(first?.messages[49].subject).toBe('message 49')
       expect(replay?.delivery.id).toBe(first?.delivery.id)
       expect(replay?.replayed).toBe(true)
+      expect(first).toMatchObject({ mailboxUnreadCount: 55, pendingBehind: 5 })
+      expect(replay).toMatchObject({ mailboxUnreadCount: 55, pendingBehind: 5 })
 
       d.acknowledgeRunDelivery({
         runId: run.id,

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -22,6 +22,7 @@ import {
   orchestrationSkillRecoveryData
 } from '../../../../shared/orchestration-rpc-contract'
 import { clampOrchestrationAskTimeoutMs } from '../../../../shared/orchestration-ask-timeout'
+import { buildOrchestrationDeliveryState } from '../../../../shared/orchestration-check-output'
 import { ORCHESTRATION_GATE_METHODS } from './orchestration-gates'
 import {
   resolveBareOrchestrationRecipient,
@@ -1009,6 +1010,15 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
             consumerGeneration: generation,
             wakeTypes
           })
+        const deliveryState = (current: NonNullable<ReturnType<typeof readDelivery>>) =>
+          buildOrchestrationDeliveryState({
+            deliveryId: current.delivery.id,
+            blockedSince: current.delivery.created_at,
+            deliveryCount: current.messages.length,
+            mailboxUnreadCount: current.mailboxUnreadCount,
+            pendingBehind: current.pendingBehind,
+            replayed: current.replayed
+          })
         let peeked = params.peek ? readPeek() : []
         if (params.peek && peeked.length > 0) {
           return peekResult(peeked)
@@ -1021,6 +1031,7 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
             messages: current.messages,
             count: current.messages.length,
             replayed: current.replayed,
+            ...deliveryState(current),
             acknowledged: acknowledged?.delivery.id ?? null,
             timedOut: false,
             cancelled: false,
@@ -1131,6 +1142,7 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
           messages: current?.messages ?? [],
           count: current?.messages.length ?? 0,
           replayed: current?.replayed ?? false,
+          ...(current ? deliveryState(current) : {}),
           acknowledged: acknowledged?.delivery.id ?? null,
           timedOut: false,
           cancelled: false,

--- a/src/shared/orchestration-check-output.test.ts
+++ b/src/shared/orchestration-check-output.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { prepareOrchestrationCheckOutput } from './orchestration-check-output'
+import {
+  buildOrchestrationDeliveryState,
+  formatOrchestrationCheckText,
+  prepareOrchestrationCheckOutput
+} from './orchestration-check-output'
 
 describe('prepareOrchestrationCheckOutput', () => {
   it('keeps mixed read-only mail safe and current Run replies executable', () => {
@@ -38,5 +42,82 @@ describe('prepareOrchestrationCheckOutput', () => {
       '[Inspection only: reply and acknowledgment are unavailable.]'
     )
     expect(prepared.formatted).not.toContain('unsafe stale formatter output')
+  })
+
+  it('warns on the first unacknowledged replay and exposes hidden backlog counts', () => {
+    const state = buildOrchestrationDeliveryState({
+      deliveryId: 'delivery_stuck',
+      blockedSince: '2026-08-17T10:00:00Z',
+      deliveryCount: 2,
+      mailboxUnreadCount: 26,
+      pendingBehind: 24,
+      replayed: true
+    })
+
+    expect(state).toMatchObject({
+      blockedSince: '2026-08-17T10:00:00Z',
+      pendingBehind: 24,
+      mailboxUnreadCount: 26,
+      checkCountDiverged: true,
+      deliveryWarning: {
+        code: 'delivery_fifo_blocked',
+        requiredAction: 'acknowledge_delivery',
+        deliveryId: 'delivery_stuck'
+      }
+    })
+    expect(
+      formatOrchestrationCheckText(
+        {
+          count: 2,
+          messages: [
+            { id: 'msg_1', from_handle: 'worker', subject: 'one' },
+            { id: 'msg_2', from_handle: 'worker', subject: 'two' }
+          ],
+          deliveryId: 'delivery_stuck',
+          ...state
+        },
+        'term_coord'
+      )
+    ).toContain(
+      '[ORCHESTRATION_WARNING delivery_fifo_blocked]\nDelivery delivery_stuck was replayed without acknowledgment.'
+    )
+  })
+
+  it('does not warn before a Delivery is replayed', () => {
+    expect(
+      buildOrchestrationDeliveryState({
+        deliveryId: 'delivery_new',
+        blockedSince: '2026-08-19T10:00:00Z',
+        deliveryCount: 1,
+        mailboxUnreadCount: 1,
+        pendingBehind: 0,
+        replayed: false
+      })
+    ).toEqual({
+      blockedSince: '2026-08-19T10:00:00Z',
+      pendingBehind: 0,
+      mailboxUnreadCount: 1,
+      checkCountDiverged: false
+    })
+  })
+
+  it('warns immediately when the Delivery count hides unread mail', () => {
+    expect(
+      buildOrchestrationDeliveryState({
+        deliveryId: 'delivery_partial',
+        blockedSince: '2026-08-19T10:00:00Z',
+        deliveryCount: 50,
+        mailboxUnreadCount: 55,
+        pendingBehind: 5,
+        replayed: false
+      })
+    ).toMatchObject({
+      checkCountDiverged: true,
+      deliveryWarning: {
+        code: 'delivery_fifo_blocked',
+        message:
+          'Delivery delivery_partial contains only part of the unread mailbox. 5 newer messages remain hidden behind this batch until it is acknowledged.'
+      }
+    })
   })
 })

--- a/src/shared/orchestration-check-output.ts
+++ b/src/shared/orchestration-check-output.ts
@@ -31,6 +31,21 @@ export type LegacyCompatibilityResult = {
   resumeCommand?: string
 }
 
+export type OrchestrationDeliveryWarning = {
+  code: 'delivery_fifo_blocked'
+  message: string
+  requiredAction: 'acknowledge_delivery'
+  deliveryId: string
+}
+
+export type OrchestrationDeliveryState = {
+  blockedSince: string
+  pendingBehind: number
+  mailboxUnreadCount: number
+  checkCountDiverged: boolean
+  deliveryWarning?: OrchestrationDeliveryWarning
+}
+
 export type OrchestrationCheckOutput = {
   messages: OrchestrationMessageSummary[]
   count: number
@@ -39,7 +54,48 @@ export type OrchestrationCheckOutput = {
   timedOut?: boolean
   cancelled?: boolean
   connectionLost?: boolean
+  blockedSince?: string
+  pendingBehind?: number
+  mailboxUnreadCount?: number
+  checkCountDiverged?: boolean
+  deliveryWarning?: OrchestrationDeliveryWarning
   legacyCompatibility?: LegacyCompatibilityResult
+}
+
+export function buildOrchestrationDeliveryState(params: {
+  deliveryId: string
+  blockedSince: string
+  deliveryCount: number
+  mailboxUnreadCount: number
+  pendingBehind: number
+  replayed: boolean
+}): OrchestrationDeliveryState {
+  const checkCountDiverged = params.deliveryCount !== params.mailboxUnreadCount
+  const state: OrchestrationDeliveryState = {
+    blockedSince: params.blockedSince,
+    pendingBehind: params.pendingBehind,
+    mailboxUnreadCount: params.mailboxUnreadCount,
+    checkCountDiverged
+  }
+  if (!params.replayed && !checkCountDiverged) {
+    return state
+  }
+  const warningReason = params.replayed
+    ? `Delivery ${params.deliveryId} was replayed without acknowledgment.`
+    : `Delivery ${params.deliveryId} contains only part of the unread mailbox.`
+  const blockedDescription =
+    params.pendingBehind === 0
+      ? 'No newer messages are waiting behind it yet.'
+      : `${params.pendingBehind} newer message${params.pendingBehind === 1 ? '' : 's'} remain hidden behind this batch until it is acknowledged.`
+  return {
+    ...state,
+    deliveryWarning: {
+      code: 'delivery_fifo_blocked',
+      message: `${warningReason} ${blockedDescription}`,
+      requiredAction: 'acknowledge_delivery',
+      deliveryId: params.deliveryId
+    }
+  }
 }
 
 export function formatMessageReadOnlyTag(
@@ -80,20 +136,21 @@ export function formatOrchestrationCheckText(
         : '[LEGACY COMPATIBILITY]\n'
     : ''
   const deliveryNotice = formatCurrentDeliveryNotice(prepared.legacyCompatibility?.currentDelivery)
+  const deliveryWarning = formatDeliveryWarning(prepared)
   if (prepared.formatted) {
-    return `${legacyHeader}${prepared.formatted}${deliveryNotice}`
+    return `${legacyHeader}${deliveryWarning}${prepared.formatted}${deliveryNotice}`
   }
   if (prepared.count === 0) {
     if (prepared.timedOut) {
-      return `${legacyHeader}Wait timed out; no messages were consumed.${deliveryNotice}`
+      return `${legacyHeader}${deliveryWarning}Wait timed out; no messages were consumed.${deliveryNotice}`
     }
     if (prepared.cancelled) {
       const cancelled = prepared.connectionLost
         ? 'Wait cancelled because the connection closed; no messages were consumed.'
         : 'Wait cancelled; no messages were consumed.'
-      return `${legacyHeader}${cancelled}${deliveryNotice}`
+      return `${legacyHeader}${deliveryWarning}${cancelled}${deliveryNotice}`
     }
-    return `${legacyHeader}No messages.${deliveryNotice}`
+    return `${legacyHeader}${deliveryWarning}No messages.${deliveryNotice}`
   }
   const rendered = prepared.messages
     .map(
@@ -105,7 +162,23 @@ export function formatOrchestrationCheckText(
     )
     .join('\n')
   const output = prepared.deliveryId ? `Delivery ${prepared.deliveryId}\n${rendered}` : rendered
-  return `${legacyHeader}${output}${deliveryNotice}`
+  return `${legacyHeader}${deliveryWarning}${output}${deliveryNotice}`
+}
+
+function formatDeliveryWarning(result: OrchestrationCheckOutput): string {
+  const warning = result.deliveryWarning
+  if (!warning) {
+    return ''
+  }
+  const pending = result.pendingBehind ?? 0
+  const unread = result.mailboxUnreadCount ?? result.count + pending
+  return (
+    `[ORCHESTRATION_WARNING ${warning.code}]\n` +
+    `${warning.message}\n` +
+    `blockedSince=${result.blockedSince ?? 'unknown'} pendingBehind=${pending} ` +
+    `checkCount=${result.count} mailboxUnreadCount=${unread}\n` +
+    `After processing this batch, acknowledge it with: orca orchestration check --ack ${warning.deliveryId}\n`
+  )
 }
 
 export function prepareOrchestrationCheckOutput<T extends OrchestrationCheckOutput>(


### PR DESCRIPTION
[CODEX_AUTHORED @ msg_6f767d368b78/delivery-fifo-guard]

## Outcome

REVIEW_READY — bound Run Delivery FIFO no longer hides an unacknowledged backlog silently.

## Contract

- Preserve at-least-once delivery and explicit ACK; do not auto-ack or skip messages.
- Expose `blockedSince`, `pendingBehind`, `mailboxUnreadCount`, and `checkCountDiverged` on Delivery checks.
- Emit typed `delivery_fifo_blocked` on the first unacknowledged replay (`N=1`) or immediately when the returned batch count differs from total unread mail.
- Show the same warning in JSON, local text/`--format`, and remote text paths.

## Behavioral oracle

The runtime test leaves the first Delivery unacknowledged, inserts a newer message, and checks again. It asserts replay identity plus `pendingBehind=1`, `mailboxUnreadCount=2`, `checkCountDiverged=true`, and the typed warning; ACK then exposes the successor with no warning.

## Verification

- `vitest`: 37 passed, 1 skipped across Delivery DB/state, mailbox runtime behavior, and delivery identity suites.
- `typecheck:node` and `typecheck:cli`: pass.
- changed-file `oxfmt --check` and `oxlint --deny-warnings`: pass.
- reliability manifest: 86 gates pass.
- max-lines ratchet and bundled skill guide verification: pass.
- `git diff --check`: pass.

## Environment boundary

`pnpm install --frozen-lockfile` downloaded the locked graph, but the optional `windows-native-registry` postinstall rebuild could not find Visual Studio. The target Vitest suites and all checks above executed successfully using the installed graph. The wrapper `check:code-quality:changed` is separately NOT_MEASURED because Node 24 on this host returned `spawnSync pnpm.cmd EINVAL`; its exact changed-file `oxlint` operation was run directly and passed.

No merge requested.