### PR TITLE
fix(terminal): require a proven exit before retiring a subscription's lease

### DIFF
--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -35328,7 +35328,10 @@ export class OrcaRuntimeService {
   private isPtyKnownExited(ptyId: string): boolean {
     const pty = this.ptysById.get(ptyId)
     if (pty) {
-      return !pty.connected
+      // Why: `!connected` is an inference, not proof. The liveness sweep clears it with no
+      // exit code for every PTY of a dropped relay, so reading that as an exit retires the
+      // lease of a process still running on the host — 'unknown' must keep watching.
+      return getPtyTerminalState(pty) === 'exited'
     }
     return this.getLeavesForPty(ptyId).some((leaf) => getTerminalState(leaf) === 'exited')
   }

--- a/src/main/runtime/rpc/terminal-subscribe-relay-drop-lease-survival.test.ts
+++ b/src/main/runtime/rpc/terminal-subscribe-relay-drop-lease-survival.test.ts
@@ -1,0 +1,118 @@
+// Why: the stale-handle survival suite doubles subscribeToPtyExit, so it pins the wiring but
+// not the predicate that decides whether a PTY counts as exited. This wires that one call to
+// a real OrcaRuntimeService, because a relay drop reaches the phone through the predicate.
+import { describe, expect, it, vi } from 'vitest'
+import { OrcaRuntimeService } from '../orca-runtime'
+import type { RpcRequest } from './core'
+import { RpcDispatcher } from './dispatcher'
+import { TERMINAL_METHODS } from './methods/terminal'
+import { createSubscriptionRegistryDouble } from './subscription-registry-test-double'
+
+const PTY_ID = 'pty-1'
+
+const subscriptionCases = [
+  {
+    name: 'lease-only',
+    params: {
+      terminal: 'terminal-1',
+      client: { id: 'phone-1', type: 'mobile' },
+      capabilities: { terminalBinaryStream: 1, mobileInputLeaseOnly: 1 }
+    }
+  },
+  {
+    name: 'legacy JSON',
+    params: { terminal: 'terminal-1', client: { id: 'desktop-1', type: 'desktop' } }
+  },
+  {
+    name: 'binary',
+    params: {
+      terminal: 'terminal-1',
+      client: { id: 'phone-1', type: 'mobile' },
+      capabilities: { terminalBinaryStream: 1 }
+    }
+  }
+] as const
+
+type PtyInternals = {
+  recordPtyWorktree: (ptyId: string, worktreeId: string, state?: { connected?: boolean }) => unknown
+  ptysById: Map<string, { connected: boolean; lastExitCode: number | null }>
+}
+
+/** A PTY whose relay dropped: connection lost, no exit code, process possibly still running. */
+function makeRelayDroppedRuntime(): OrcaRuntimeService {
+  const real = new OrcaRuntimeService()
+  const internals = real as unknown as PtyInternals
+  internals.recordPtyWorktree(PTY_ID, 'wt-1', { connected: true })
+  const pty = internals.ptysById.get(PTY_ID)!
+  pty.connected = false
+  expect(pty.lastExitCode).toBeNull()
+  return real
+}
+
+function createRuntime(real: OrcaRuntimeService): {
+  registry: ReturnType<typeof createSubscriptionRegistryDouble>
+  runtime: OrcaRuntimeService
+} {
+  const registry = createSubscriptionRegistryDouble()
+  const runtime = {
+    getRuntimeId: () => 'test-runtime',
+    requestRendererTerminalTabMount: () => false,
+    resolveLeafForHandle: vi.fn().mockReturnValue({ ptyId: PTY_ID }),
+    handleMobileSubscribe: vi.fn().mockResolvedValue(true),
+    handleMobileUnsubscribe: vi.fn(),
+    registerRemoteTerminalViewSubscriber: vi.fn(() => vi.fn()),
+    subscribeToTerminalData: vi.fn(() => vi.fn()),
+    readTerminal: vi.fn().mockResolvedValue({ tail: [], truncated: false }),
+    serializeTerminalBuffer: vi
+      .fn()
+      .mockResolvedValue({ data: 'snapshot', cols: 80, rows: 24, seq: 1 }),
+    getTerminalSize: vi.fn().mockReturnValue({ cols: 80, rows: 24 }),
+    getMobileDisplayMode: vi.fn().mockReturnValue('auto'),
+    getLayout: vi.fn().mockReturnValue({ seq: 1 }),
+    isTerminalAlternateScreen: vi.fn().mockReturnValue(false),
+    subscribeToTerminalResize: vi.fn(() => vi.fn()),
+    subscribeToFitOverrideChanges: vi.fn(() => vi.fn()),
+    registerSubscriptionCleanup: vi.fn(registry.registerSubscriptionCleanup),
+    registerOwnedSubscriptionCleanup: vi.fn(registry.registerOwnedSubscriptionCleanup),
+    cleanupSubscription: vi.fn(registry.cleanupSubscription),
+    waitForTerminal: vi.fn(() => Promise.reject(new Error('unexpected handle waiter'))),
+    // The one call under test: the real exit predicate, not a double's opinion of it.
+    subscribeToPtyExit: (ptyId: string, listener: () => void) =>
+      real.subscribeToPtyExit(ptyId, listener)
+  } as unknown as OrcaRuntimeService
+  return { registry, runtime }
+}
+
+function makeRequest(params: unknown): RpcRequest {
+  return { id: 'req-1', authToken: 'tok', method: 'terminal.subscribe', params }
+}
+
+describe('terminal subscribe when the relay dropped without an exit code', () => {
+  it.each(subscriptionCases)(
+    'does not end $name for a process that may still be running',
+    async ({ params }) => {
+      const real = makeRelayDroppedRuntime()
+      const { registry, runtime } = createRuntime(real)
+      const messages: string[] = []
+      const types = (): unknown[] => messages.map((message) => JSON.parse(message).result?.type)
+
+      void new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+        .dispatchStreaming(makeRequest(params), (message) => messages.push(message), {
+          connectionId: 'conn-1',
+          sendBinary: vi.fn(),
+          registerBinaryStreamHandler: vi.fn(() => vi.fn())
+        })
+        .catch(() => undefined)
+
+      const subscriptionId = `terminal-1:${params.client.id}`
+      await vi.waitFor(() => expect(registry.peekCleanup(subscriptionId)).toBeDefined())
+      expect(types()).not.toContain('end')
+
+      // The host comes back and reports the real exit; only now may the lease retire.
+      real.onPtyExit(PTY_ID, 0)
+
+      await vi.waitFor(() => expect(registry.peekCleanup(subscriptionId)).toBeUndefined())
+      expect(types()).toContain('end')
+    }
+  )
+})

--- a/src/main/runtime/terminal-pty-exit-waiter.test.ts
+++ b/src/main/runtime/terminal-pty-exit-waiter.test.ts
@@ -4,6 +4,7 @@ import { OrcaRuntimeService } from './orca-runtime'
 type RuntimeInternals = {
   recordPtyWorktree: (ptyId: string, worktreeId: string, state?: { connected?: boolean }) => unknown
   ptyExitListenersByPtyId: Map<string, Set<unknown>>
+  ptysById: Map<string, { connected: boolean; lastExitCode: number | null }>
 }
 
 function internals(runtime: OrcaRuntimeService): RuntimeInternals {
@@ -54,5 +55,58 @@ describe('PTY exit subscription', () => {
 
     expect(listener).toHaveBeenCalledOnce()
     expect(internals(runtime).ptyExitListenersByPtyId.has('pty-1')).toBe(false)
+  })
+})
+
+// Why: the liveness sweep clears `connected` with no exit code for every PTY behind a
+// dropped relay, so a record in that state is a lost connection to a process that may
+// still be running. Reading it as an exit retires a live lease and emits `end`, which the
+// phone rearms against three times and then locks the composer on "Waiting for terminal…".
+describe('PTY exit subscription demands proof of exit, not loss of connection', () => {
+  function dropTheConnection(runtime: OrcaRuntimeService): void {
+    const pty = internals(runtime).ptysById.get('pty-1')!
+    pty.connected = false
+    // Precondition: onPtyExit is the only writer of lastExitCode, and it never ran.
+    expect(pty.lastExitCode).toBeNull()
+  }
+
+  it('does not fire for a disconnected PTY that never reported an exit code', () => {
+    const runtime = new OrcaRuntimeService()
+    registerLivePty(runtime)
+    dropTheConnection(runtime)
+    const listener = vi.fn()
+
+    runtime.subscribeToPtyExit('pty-1', listener)
+
+    expect(listener).not.toHaveBeenCalled()
+    expect(internals(runtime).ptyExitListenersByPtyId.get('pty-1')).toHaveLength(1)
+  })
+
+  it('still fires once the host comes back and reports the real exit', () => {
+    const runtime = new OrcaRuntimeService()
+    registerLivePty(runtime)
+    dropTheConnection(runtime)
+    const listener = vi.fn()
+
+    runtime.subscribeToPtyExit('pty-1', listener)
+    expect(listener).not.toHaveBeenCalled()
+
+    // Why: subscribing during the outage must not cost the subscriber the later exit.
+    runtime.onPtyExit('pty-1', 0)
+
+    expect(listener).toHaveBeenCalledOnce()
+  })
+
+  it('fires immediately for a disconnected PTY that did report an exit code', () => {
+    const runtime = new OrcaRuntimeService()
+    registerLivePty(runtime)
+    const pty = internals(runtime).ptysById.get('pty-1')!
+    pty.connected = false
+    pty.lastExitCode = 0
+    const listener = vi.fn()
+
+    runtime.subscribeToPtyExit('pty-1', listener)
+
+    expect(listener).toHaveBeenCalledOnce()
   })
 })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​172 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​172 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |

<!-- /orca-pr-loc -->

## What changed

One predicate. `isPtyKnownExited` treated a PTY record as exited whenever `connected` was false:

```ts
private isPtyKnownExited(ptyId: string): boolean {
  const pty = this.ptysById.get(ptyId)
  if (pty) {
    return !pty.connected                                                    // infers
  }
  return this.getLeavesForPty(ptyId).some((l) => getTerminalState(l) === 'exited')  // proves
}
```

The leaf fallback demands proof — `getTerminalState` returns `'exited'` only once `lastExitCode` is set. The PTY path infers it from disconnection, and that is the path that runs whenever a record exists. This makes both demand the same proof, reusing the runtime's existing three-valued discriminator.

## Why it matters

`onPtyExit` is the only writer of `lastExitCode`. The liveness sweep clears `connected` **with no exit code** for every PTY behind a dropped relay, so that state means "lost the connection to a process that may still be running on the host" — not "the process exited".

Reading it as an exit makes `subscribeToPtyExit` fire its listener synchronously at subscribe time. `watchSubscriptionLifetime` then retires the lease and emits `end` for a live terminal. Mobile reads `end` as "PTY gone" and rearms; after `MAX_REARM_ATTEMPTS = 3` it stops and leaves the composer on "Waiting for terminal…", recovering only when a replacement handle arrives — which never comes, because the PTY is alive and its handle is unchanged.

This is the residual cause of the 0.0.44 permanent composer lock. A separate session reproduced that symptom independently, and the mechanism matches exactly: lease retired, `end` emitted, three rearms, locked.

After the change `'unknown'` keeps watching, the later real exit still fires the listener, and a subscription that outlives its PTY stays bounded by the connection abort that `watchSubscriptionLifetime` already registers.

## Scope

Both callers are inside `subscribeToPtyExit` — the subscribe-time fast path and the registration-race re-check. Both want proven-exited, so neither changes shape, and the predicate is private with no other callers. Nothing in #15463 is reverted or restructured.

## Retraction of the original framing

This PR previously proposed a different fix: a re-arm loop with 250ms→30s backoff wrapped around `waitForTerminal(..., { condition: 'exit' })`, plus handle rebinding through a new `resolveTerminalExitWatch`. **That approach is withdrawn.**

#15463 landed on `main` during review and fixes the same underlying defect by a better mechanism — `watchSubscriptionLifetime` subscribing on the stable `ptyId` and notified from `onPtyExit`, with no polling, no backoff, and no handle re-resolution. It deleted all three `waitForTerminal(params.terminal, { condition: 'exit' }).then/.catch(releaseIfCurrent)` call sites this PR used to rewrite, so the original change targeted code that no longer exists; carrying it forward would have reverted the better fix.

What survives is the one finding #15463 did not cover: that `!connected` is not proof of exit. #15463's own commit message states "absence must be proven, never inferred" — this completes that principle on the path it missed.

## Tests

Three new cases in `terminal-pty-exit-waiter.test.ts` against the real runtime, pinning both directions:

- disconnected with `lastExitCode` still null — the listener must **not** fire, and the subscription stays registered
- the host returns and `onPtyExit` lands — the listener **does** fire, so subscribing during the outage costs nothing
- disconnected **with** an exit code — fires immediately, unchanged

Both must-change cases fail against unfixed `main` (`2 failed | 4 passed`); the third passes either way as a regression guard.

`terminal-subscribe-relay-drop-lease-survival.test.ts` carries it to the wire across all three `terminal.subscribe` branches (lease-only, legacy JSON, binary). The existing stale-handle suite doubles `subscribeToPtyExit`, so it pins the wiring but not the predicate; this one delegates that single call to a real `OrcaRuntimeService` and asserts no `end` is emitted for a relay-dropped PTY, then that `end` does arrive once the real exit lands.

## Verification

- `src/main/runtime` — 370 files, 4664 passed, 9 skipped, 0 failed
- `typecheck:node` — exit 0, proven non-vacuous (injected a `TS2322` into the new test file, exit 1 naming that file, restored, exit 0)
- `oxfmt` and `oxlint` — clean
