### PR TITLE
test(terminal): pin the mobile view stream's presence-release invariant

### DIFF
--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -16341,6 +16341,12 @@ export class OrcaRuntimeService {
     }
   }
 
+  // Ordering rule for every `inner.set` below: write mobileSubscribers before this
+  // method's first await. The mobile view streams await this call and cannot release
+  // presence afterwards — a (ptyId, clientId) release there would delete a reconnect
+  // replacement's record — so they rely on their teardown landing after the write.
+  // Yield before any of these writes and a torn-down subscribe strands a phantom
+  // subscriber. Pinned by rpc/terminal-subscribe-mobile-presence-release.test.ts.
   private async handleMobileSubscribeInternal(
     ptyId: string,
     clientId: string,

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -3357,6 +3357,12 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
       // Server-side auto-fit: resize PTY to phone dims before serializing scrollback
       try {
         if (isMobile && clientId) {
+          // Why no presence release on the `closed` path below, unlike the lease-only
+          // sibling: handleMobileSubscribe writes mobileSubscribers before its first
+          // await, so a cleanup that wins this race always runs after the write and
+          // removes it. Releasing here would instead delete a reconnect replacement's
+          // (ptyId, clientId) record — the hazard the lease-only note describes.
+          // Pinned by terminal-subscribe-mobile-presence-release.test.ts.
           await runtime.handleMobileSubscribe(ptyId, clientId, params.viewport)
         } else if (clientId && params.viewport) {
           // Why: legacy subscribe records geometry without taking ownership; only an explicit activity/claim frame may suppress the host.

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -3361,11 +3361,13 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
       try {
         if (isMobile && clientId) {
           // Why no presence release on the `closed` path below, unlike the lease-only
-          // sibling: both of handleMobileSubscribeInternal's presence writes (fresh
-          // subscribe and resubscribe-grace) land before its first await, so a cleanup
-          // that wins this race always runs after the write and removes it. Releasing
-          // here would instead delete a reconnect replacement's (ptyId, clientId)
-          // record — the hazard the lease-only note describes.
+          // sibling: every presence write in handleMobileSubscribeInternal lands before
+          // its first await (see the ordering rule on that method), so a cleanup that
+          // wins this race always runs after the write and removes it. Releasing here
+          // would instead delete a reconnect replacement's (ptyId, clientId) record —
+          // the hazard the lease-only note describes. Presence only: the in-flight
+          // phone-fit still settles after teardown, and under an indefinite
+          // mobileAutoRestoreFitMs its override is held for the desktop Restore button.
           // Pinned by terminal-subscribe-mobile-presence-release.test.ts.
           await runtime.handleMobileSubscribe(ptyId, clientId, params.viewport)
         } else if (clientId && params.viewport) {

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -2602,6 +2602,9 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           }
 
           if (isMobile && request.client?.id) {
+            // Why detachStream's release suffices and no release belongs on the
+            // early-return below: same presence-write-before-first-await invariant as the
+            // single view stream — see the note on its handleMobileSubscribe call.
             await runtime.handleMobileSubscribe(ptyId, request.client.id, request.viewport)
           } else if (request.client?.id && request.viewport) {
             // Why: subscribe records this stream's geometry and cleanup key but doesn't claim ownership; activity frames claim later.
@@ -3358,10 +3361,11 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
       try {
         if (isMobile && clientId) {
           // Why no presence release on the `closed` path below, unlike the lease-only
-          // sibling: handleMobileSubscribe writes mobileSubscribers before its first
-          // await, so a cleanup that wins this race always runs after the write and
-          // removes it. Releasing here would instead delete a reconnect replacement's
-          // (ptyId, clientId) record — the hazard the lease-only note describes.
+          // sibling: both of handleMobileSubscribeInternal's presence writes (fresh
+          // subscribe and resubscribe-grace) land before its first await, so a cleanup
+          // that wins this race always runs after the write and removes it. Releasing
+          // here would instead delete a reconnect replacement's (ptyId, clientId)
+          // record — the hazard the lease-only note describes.
           // Pinned by terminal-subscribe-mobile-presence-release.test.ts.
           await runtime.handleMobileSubscribe(ptyId, clientId, params.viewport)
         } else if (clientId && params.viewport) {

--- a/src/main/runtime/rpc/terminal-subscribe-mobile-presence-release.test.ts
+++ b/src/main/runtime/rpc/terminal-subscribe-mobile-presence-release.test.ts
@@ -7,12 +7,23 @@ import { createSubscriptionRegistryDouble } from './subscription-registry-test-d
 
 // Why: the presence map has no accessor — the runtime exposes only the driver it derives.
 type PresenceInternals = {
-  mobileSubscribers: Map<string, Map<string, unknown>>
+  mobileSubscribers: Map<string, Map<string, { viewport: { cols: number; rows: number } | null }>>
+  pendingSoftLeavers: Map<string, unknown>
 }
 
+const internalsOf = (runtime: OrcaRuntimeService): PresenceInternals =>
+  runtime as unknown as PresenceInternals
+
 const presenceOf = (runtime: OrcaRuntimeService, ptyId: string): string[] => [
-  ...((runtime as unknown as PresenceInternals).mobileSubscribers.get(ptyId)?.keys() ?? [])
+  ...(internalsOf(runtime).mobileSubscribers.get(ptyId)?.keys() ?? [])
 ]
+
+const viewportOf = (
+  runtime: OrcaRuntimeService,
+  ptyId: string,
+  clientId: string
+): { cols: number; rows: number } | null | undefined =>
+  internalsOf(runtime).mobileSubscribers.get(ptyId)?.get(clientId)?.viewport
 
 const VIEWPORT = { cols: 40, rows: 20 }
 
@@ -33,19 +44,19 @@ const subscribeRequest: RpcRequest = {
  * that touches `mobileSubscribers` is the production implementation; only the PTY,
  * scrollback and graph lookups are doubled.
  */
-const createViewStreamRuntime = (real: OrcaRuntimeService, calls: string[]): OrcaRuntimeService => {
+const createViewStreamRuntime = (
+  real: OrcaRuntimeService,
+  observed: { presenceAtUnsubscribe: string[] | null }
+): OrcaRuntimeService => {
   const registry = createSubscriptionRegistryDouble()
   return {
     getRuntimeId: () => 'test-runtime',
     resolveLeafForHandle: vi.fn().mockReturnValue({ ptyId: 'pty-1' }),
-    handleMobileSubscribe: async (ptyId: string, clientId: string, viewport?: typeof VIEWPORT) => {
-      calls.push('subscribe:enter')
-      const result = await real.handleMobileSubscribe(ptyId, clientId, viewport)
-      calls.push('subscribe:exit')
-      return result
-    },
+    handleMobileSubscribe: (ptyId: string, clientId: string, viewport?: typeof VIEWPORT) =>
+      real.handleMobileSubscribe(ptyId, clientId, viewport),
     handleMobileUnsubscribe: (ptyId: string, clientId: string) => {
-      calls.push('unsubscribe')
+      // The whole invariant in one reading: what the teardown sees when it runs.
+      observed.presenceAtUnsubscribe = presenceOf(real, ptyId)
       real.handleMobileUnsubscribe(ptyId, clientId)
     },
     getDriver: (ptyId: string) => real.getDriver(ptyId),
@@ -75,22 +86,30 @@ const createViewStreamRuntime = (real: OrcaRuntimeService, calls: string[]): Orc
   } as unknown as OrcaRuntimeService
 }
 
+const dispatchTornDownSubscribe = async (
+  real: OrcaRuntimeService
+): Promise<{ presenceAtUnsubscribe: string[] | null }> => {
+  const observed: { presenceAtUnsubscribe: string[] | null } = { presenceAtUnsubscribe: null }
+  const dispatcher = new RpcDispatcher({
+    runtime: createViewStreamRuntime(real, observed),
+    methods: TERMINAL_METHODS
+  })
+  await dispatcher.dispatchStreaming(subscribeRequest, vi.fn(), {
+    connectionId: 'conn-phone',
+    sendBinary: vi.fn(),
+    registerBinaryStreamHandler: vi.fn(() => vi.fn())
+  })
+  return observed
+}
+
 describe('mobile view stream presence release', () => {
-  it('leaves no mobile presence when subscription cleanup wins the awaited subscribe', async () => {
+  it('leaves no presence when cleanup wins a fresh awaited subscribe', async () => {
     const real = new OrcaRuntimeService()
-    const calls: string[] = []
-    const runtime = createViewStreamRuntime(real, calls)
-    const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
 
-    await dispatcher.dispatchStreaming(subscribeRequest, vi.fn(), {
-      connectionId: 'conn-phone',
-      sendBinary: vi.fn(),
-      registerBinaryStreamHandler: vi.fn(() => vi.fn())
-    })
+    const observed = await dispatchTornDownSubscribe(real)
 
-    // The teardown lands inside the awaited subscribe, not before it — so the
-    // release it performs is the one that survives.
-    expect(calls).toEqual(['subscribe:enter', 'unsubscribe', 'subscribe:exit'])
+    // The teardown lands after the presence write, so its release is the one that survives.
+    expect(observed.presenceAtUnsubscribe).toEqual(['phone-1'])
     expect(presenceOf(real, 'pty-1')).toEqual([])
     // The soft-leave grace holds driver=mobile briefly, then releases the input lock.
     await vi.waitFor(() => expect(real.getDriver('pty-1')).toEqual({ kind: 'idle' }), {
@@ -98,31 +117,58 @@ describe('mobile view stream presence release', () => {
     })
   })
 
-  it('records mobile presence before its first await so a concurrent unsubscribe wins', async () => {
+  it('leaves no presence when cleanup wins a resubscribe-grace subscribe', async () => {
+    const real = new OrcaRuntimeService()
+    // Arm the soft-leaver so the subscribe takes the resubscribe-grace branch — the one a
+    // phone hits on background→foreground or a reconnect inside the 250ms window.
+    await real.handleMobileSubscribe('pty-1', 'phone-1', VIEWPORT)
+    real.handleMobileUnsubscribe('pty-1', 'phone-1')
+    expect(internalsOf(real).pendingSoftLeavers.has('pty-1')).toBe(true)
+
+    const observed = await dispatchTornDownSubscribe(real)
+
+    expect(observed.presenceAtUnsubscribe).toEqual(['phone-1'])
+    expect(presenceOf(real, 'pty-1')).toEqual([])
+    await vi.waitFor(() => expect(real.getDriver('pty-1')).toEqual({ kind: 'idle' }), {
+      timeout: 3000
+    })
+  })
+
+  it('records presence before the first await on both subscribe branches', async () => {
     const real = new OrcaRuntimeService()
 
-    const subscribing = real.handleMobileSubscribe('pty-1', 'phone-1', VIEWPORT)
+    // Fresh-subscribe branch.
+    const fresh = real.handleMobileSubscribe('pty-1', 'phone-1', VIEWPORT)
     // This is what makes the view branch's missing release harmless: the phone-fit
     // await happens after the map write, never before it.
     expect(presenceOf(real, 'pty-1')).toEqual(['phone-1'])
-
     real.handleMobileUnsubscribe('pty-1', 'phone-1')
     expect(presenceOf(real, 'pty-1')).toEqual([])
-
-    await subscribing
+    await fresh
     expect(presenceOf(real, 'pty-1')).toEqual([])
+
+    // Resubscribe-grace branch — same ordering, separate code path.
+    await real.handleMobileSubscribe('pty-2', 'phone-1', VIEWPORT)
+    real.handleMobileUnsubscribe('pty-2', 'phone-1')
+    const grace = real.handleMobileSubscribe('pty-2', 'phone-1', VIEWPORT)
+    expect(presenceOf(real, 'pty-2')).toEqual(['phone-1'])
+    real.handleMobileUnsubscribe('pty-2', 'phone-1')
+    expect(presenceOf(real, 'pty-2')).toEqual([])
+    await grace
+    expect(presenceOf(real, 'pty-2')).toEqual([])
   })
 
-  it('cannot distinguish a superseded handler from its replacement by (ptyId, clientId)', async () => {
+  it('cannot tell a late release apart from the record that replaced it', async () => {
     const real = new OrcaRuntimeService()
 
     await real.handleMobileSubscribe('pty-1', 'phone-1', VIEWPORT)
     real.handleMobileUnsubscribe('pty-1', 'phone-1')
     await real.handleMobileSubscribe('pty-1', 'phone-1', { cols: 41, rows: 21 })
-    expect(presenceOf(real, 'pty-1')).toEqual(['phone-1'])
+    // The record under (ptyId, clientId) is the later handler's, not a revival of the first.
+    expect(viewportOf(real, 'pty-1', 'phone-1')).toEqual({ cols: 41, rows: 21 })
 
-    // A superseded handler copying the lease-only guard would run exactly this and
-    // strand the replacement's live stream with no presence and a mobile driver.
+    // Presence is keyed only by (ptyId, clientId), so a superseded handler copying the
+    // lease-only guard runs exactly this and strands a live stream with no presence.
     real.handleMobileUnsubscribe('pty-1', 'phone-1')
     expect(presenceOf(real, 'pty-1')).toEqual([])
     expect(real.getDriver('pty-1')).toEqual({ kind: 'mobile', clientId: 'phone-1' })

--- a/src/main/runtime/rpc/terminal-subscribe-mobile-presence-release.test.ts
+++ b/src/main/runtime/rpc/terminal-subscribe-mobile-presence-release.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from 'vitest'
+import { OrcaRuntimeService } from '../orca-runtime'
+import type { RpcRequest } from './core'
+import { RpcDispatcher } from './dispatcher'
+import { TERMINAL_METHODS } from './methods/terminal'
+import { createSubscriptionRegistryDouble } from './subscription-registry-test-double'
+
+// Why: the presence map has no accessor — the runtime exposes only the driver it derives.
+type PresenceInternals = {
+  mobileSubscribers: Map<string, Map<string, unknown>>
+}
+
+const presenceOf = (runtime: OrcaRuntimeService, ptyId: string): string[] => [
+  ...((runtime as unknown as PresenceInternals).mobileSubscribers.get(ptyId)?.keys() ?? [])
+]
+
+const VIEWPORT = { cols: 40, rows: 20 }
+
+const subscribeRequest: RpcRequest = {
+  id: 'req-1',
+  authToken: 'tok',
+  method: 'terminal.subscribe',
+  params: {
+    terminal: 'terminal-1',
+    client: { id: 'phone-1', type: 'mobile' },
+    viewport: VIEWPORT,
+    capabilities: { terminalBinaryStream: 1 }
+  }
+}
+
+/**
+ * Real presence methods behind the stubs the binary view stream needs. Everything
+ * that touches `mobileSubscribers` is the production implementation; only the PTY,
+ * scrollback and graph lookups are doubled.
+ */
+const createViewStreamRuntime = (real: OrcaRuntimeService, calls: string[]): OrcaRuntimeService => {
+  const registry = createSubscriptionRegistryDouble()
+  return {
+    getRuntimeId: () => 'test-runtime',
+    resolveLeafForHandle: vi.fn().mockReturnValue({ ptyId: 'pty-1' }),
+    handleMobileSubscribe: async (ptyId: string, clientId: string, viewport?: typeof VIEWPORT) => {
+      calls.push('subscribe:enter')
+      const result = await real.handleMobileSubscribe(ptyId, clientId, viewport)
+      calls.push('subscribe:exit')
+      return result
+    },
+    handleMobileUnsubscribe: (ptyId: string, clientId: string) => {
+      calls.push('unsubscribe')
+      real.handleMobileUnsubscribe(ptyId, clientId)
+    },
+    getDriver: (ptyId: string) => real.getDriver(ptyId),
+    registerRemoteTerminalViewSubscriber: () => () => {},
+    requestRendererTerminalTabMount: () => false,
+    getRendererTerminalSerializerGeneration: () => 0,
+    waitForRendererTerminalSerializer: async () => false,
+    getPtyOutputSequence: () => 0,
+    replaceHeadlessTerminalFromRendererSnapshotForRecovery: () => {},
+    serializeRendererTerminalBuffer: async () => null,
+    hasHeadlessTerminalState: () => true,
+    subscribeToTerminalData: vi.fn(() => vi.fn()),
+    readTerminal: vi.fn().mockResolvedValue({ tail: [], truncated: false }),
+    serializeTerminalBuffer: vi.fn().mockResolvedValue({ data: 'x', cols: 80, rows: 24, seq: 4 }),
+    getTerminalSize: vi.fn().mockReturnValue({ cols: 80, rows: 24 }),
+    getMobileDisplayMode: vi.fn().mockReturnValue('auto'),
+    getLayout: vi.fn().mockReturnValue({ seq: 1 }),
+    isTerminalAlternateScreen: vi.fn().mockReturnValue(false),
+    subscribeToTerminalResize: vi.fn().mockReturnValue(vi.fn()),
+    subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
+    registerSubscriptionCleanup: vi.fn(registry.registerSubscriptionCleanup),
+    registerOwnedSubscriptionCleanup: vi.fn(registry.registerOwnedSubscriptionCleanup),
+    cleanupSubscription: vi.fn(registry.cleanupSubscription),
+    // Why: what graph churn really does to the subscribe exit-waiter — see
+    // markGraphUnavailable / markRendererReloading, which reject every outstanding waiter.
+    waitForTerminal: vi.fn(() => Promise.reject(new Error('terminal_handle_stale')))
+  } as unknown as OrcaRuntimeService
+}
+
+describe('mobile view stream presence release', () => {
+  it('leaves no mobile presence when subscription cleanup wins the awaited subscribe', async () => {
+    const real = new OrcaRuntimeService()
+    const calls: string[] = []
+    const runtime = createViewStreamRuntime(real, calls)
+    const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+
+    await dispatcher.dispatchStreaming(subscribeRequest, vi.fn(), {
+      connectionId: 'conn-phone',
+      sendBinary: vi.fn(),
+      registerBinaryStreamHandler: vi.fn(() => vi.fn())
+    })
+
+    // The teardown lands inside the awaited subscribe, not before it — so the
+    // release it performs is the one that survives.
+    expect(calls).toEqual(['subscribe:enter', 'unsubscribe', 'subscribe:exit'])
+    expect(presenceOf(real, 'pty-1')).toEqual([])
+    // The soft-leave grace holds driver=mobile briefly, then releases the input lock.
+    await vi.waitFor(() => expect(real.getDriver('pty-1')).toEqual({ kind: 'idle' }), {
+      timeout: 3000
+    })
+  })
+
+  it('records mobile presence before its first await so a concurrent unsubscribe wins', async () => {
+    const real = new OrcaRuntimeService()
+
+    const subscribing = real.handleMobileSubscribe('pty-1', 'phone-1', VIEWPORT)
+    // This is what makes the view branch's missing release harmless: the phone-fit
+    // await happens after the map write, never before it.
+    expect(presenceOf(real, 'pty-1')).toEqual(['phone-1'])
+
+    real.handleMobileUnsubscribe('pty-1', 'phone-1')
+    expect(presenceOf(real, 'pty-1')).toEqual([])
+
+    await subscribing
+    expect(presenceOf(real, 'pty-1')).toEqual([])
+  })
+
+  it('cannot distinguish a superseded handler from its replacement by (ptyId, clientId)', async () => {
+    const real = new OrcaRuntimeService()
+
+    await real.handleMobileSubscribe('pty-1', 'phone-1', VIEWPORT)
+    real.handleMobileUnsubscribe('pty-1', 'phone-1')
+    await real.handleMobileSubscribe('pty-1', 'phone-1', { cols: 41, rows: 21 })
+    expect(presenceOf(real, 'pty-1')).toEqual(['phone-1'])
+
+    // A superseded handler copying the lease-only guard would run exactly this and
+    // strand the replacement's live stream with no presence and a mobile driver.
+    real.handleMobileUnsubscribe('pty-1', 'phone-1')
+    expect(presenceOf(real, 'pty-1')).toEqual([])
+    expect(real.getDriver('pty-1')).toEqual({ kind: 'mobile', clientId: 'phone-1' })
+  })
+})

--- a/src/main/runtime/rpc/terminal-subscribe-mobile-presence-release.test.ts
+++ b/src/main/runtime/rpc/terminal-subscribe-mobile-presence-release.test.ts
@@ -8,8 +8,10 @@ import { createSubscriptionRegistryDouble } from './subscription-registry-test-d
 // Why: the presence map has no accessor — the runtime exposes only the driver it derives.
 type PresenceInternals = {
   mobileSubscribers: Map<string, Map<string, { viewport: { cols: number; rows: number } | null }>>
-  pendingSoftLeavers: Map<string, unknown>
+  pendingSoftLeavers: Map<string, { clientId: string }>
 }
+
+type Observed = { presenceAtUnsubscribe: string[] | null; tookGraceBranch: boolean }
 
 const internalsOf = (runtime: OrcaRuntimeService): PresenceInternals =>
   runtime as unknown as PresenceInternals
@@ -46,14 +48,20 @@ const subscribeRequest: RpcRequest = {
  */
 const createViewStreamRuntime = (
   real: OrcaRuntimeService,
-  observed: { presenceAtUnsubscribe: string[] | null }
+  observed: Observed
 ): OrcaRuntimeService => {
   const registry = createSubscriptionRegistryDouble()
   return {
     getRuntimeId: () => 'test-runtime',
     resolveLeafForHandle: vi.fn().mockReturnValue({ ptyId: 'pty-1' }),
-    handleMobileSubscribe: (ptyId: string, clientId: string, viewport?: typeof VIEWPORT) =>
-      real.handleMobileSubscribe(ptyId, clientId, viewport),
+    handleMobileSubscribe: (ptyId: string, clientId: string, viewport?: typeof VIEWPORT) => {
+      // Why read it here and not before dispatch: the soft-leave timer is real and
+      // unfaked, so a slow dispatch would expire it and silently downgrade the
+      // resubscribe-grace case into a duplicate of the fresh-subscribe one.
+      observed.tookGraceBranch =
+        internalsOf(real).pendingSoftLeavers.get(ptyId)?.clientId === clientId
+      return real.handleMobileSubscribe(ptyId, clientId, viewport)
+    },
     handleMobileUnsubscribe: (ptyId: string, clientId: string) => {
       // The whole invariant in one reading: what the teardown sees when it runs.
       observed.presenceAtUnsubscribe = presenceOf(real, ptyId)
@@ -86,10 +94,8 @@ const createViewStreamRuntime = (
   } as unknown as OrcaRuntimeService
 }
 
-const dispatchTornDownSubscribe = async (
-  real: OrcaRuntimeService
-): Promise<{ presenceAtUnsubscribe: string[] | null }> => {
-  const observed: { presenceAtUnsubscribe: string[] | null } = { presenceAtUnsubscribe: null }
+const dispatchTornDownSubscribe = async (real: OrcaRuntimeService): Promise<Observed> => {
+  const observed: Observed = { presenceAtUnsubscribe: null, tookGraceBranch: false }
   const dispatcher = new RpcDispatcher({
     runtime: createViewStreamRuntime(real, observed),
     methods: TERMINAL_METHODS
@@ -102,12 +108,17 @@ const dispatchTornDownSubscribe = async (
   return observed
 }
 
+// Division of labour: the two handler cases pin the end-to-end outcome for the graph-churn
+// trigger, whose teardown is delivered a fixed two microtasks deep — so they only fire once a
+// presence write slips past that. The direct case below is the minimal-delta guard: it catches
+// a single-tick yield, which other teardown triggers can deliver arbitrarily early.
 describe('mobile view stream presence release', () => {
   it('leaves no presence when cleanup wins a fresh awaited subscribe', async () => {
     const real = new OrcaRuntimeService()
 
     const observed = await dispatchTornDownSubscribe(real)
 
+    expect(observed.tookGraceBranch).toBe(false)
     // The teardown lands after the presence write, so its release is the one that survives.
     expect(observed.presenceAtUnsubscribe).toEqual(['phone-1'])
     expect(presenceOf(real, 'pty-1')).toEqual([])
@@ -127,6 +138,7 @@ describe('mobile view stream presence release', () => {
 
     const observed = await dispatchTornDownSubscribe(real)
 
+    expect(observed.tookGraceBranch).toBe(true)
     expect(observed.presenceAtUnsubscribe).toEqual(['phone-1'])
     expect(presenceOf(real, 'pty-1')).toEqual([])
     await vi.waitFor(() => expect(real.getDriver('pty-1')).toEqual({ kind: 'idle' }), {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​188 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​188 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​18 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​18 |

<!-- /orca-pr-loc -->

## ELI5

A phone-side terminal stream tells the desktop "a phone is watching this terminal". When that stream is torn down mid-setup, we need to be sure the "a phone is watching" flag doesn't get left behind — otherwise the desktop thinks a phone still owns the terminal.

I was asked to fix a suspected leak here. I measured it against the real code instead of a stub, and **the leak does not exist** — and the "obvious" fix would have created a worse bug. So this PR adds the tests that prove the current behaviour is correct and pins the invariant it silently depends on, plus comments so nobody removes it by accident.

## What Changed

- **New test** `src/main/runtime/rpc/terminal-subscribe-mobile-presence-release.test.ts` — four cases driven through the real `terminal.subscribe` handler and the **real** `OrcaRuntimeService` presence methods (only PTY, scrollback and graph lookups are doubled).
- **Comments only** in `src/main/runtime/rpc/methods/terminal.ts` (the binary VIEW stream's `handleMobileSubscribe` call and the multiplexed stream's identical call) and on `handleMobileSubscribeInternal` in `src/main/runtime/orca-runtime.ts`, naming the ordering rule at both the readers and the writer.

No behavioural change. No wire change. No runtime change.

## Why

### The report

The binary mobile VIEW stream awaits the subscribe and returns without releasing presence:

```ts
await runtime.handleMobileSubscribe(ptyId, clientId, params.viewport)
if (closed) { return }
```

Its lease-only sibling releases presence in the same situation and carries a comment naming the hazard exactly ("a disconnect can win the awaited subscribe and resurrect mobile presence after cleanup already released it"). A prior probe measured, with a **test double** for `handleMobileSubscribe`, the call order:

```
[ "UNSUBSCRIBE-presence-removed", "SUBSCRIBE-presence-added" ]
```

i.e. a phantom mobile subscriber on a PTY with no stream — which would keep the driver `mobile` and block desktop writes (`terminal_mobile_driver_active`).

### What the real runtime actually does — NOT REPRODUCED

The double pushed its "presence added" marker **after** an artificial `await`. The production method does the opposite: `handleMobileSubscribeInternal` writes `mobileSubscribers` **synchronously, before** its first await (the `enqueueLayout` phone-fit) — at *both* of its write sites, the fresh-subscribe branch and the resubscribe-grace branch. Measured with the real methods wired into the real handler, with `waitForTerminal` rejecting `terminal_handle_stale` (what `markGraphUnavailable` / `markRendererReloading` really do):

```
presence observed by the teardown: [ "phone-1" ]   <- cleanup ran AFTER the write
presence after the dispatch:       []
driver at +60ms:                   { kind: "mobile" }   <- soft-leave grace
driver at +400ms:                  { kind: "idle" }     <- grace expired, input lock released
```

Teardown always lands after the map write, so the cleanup's `handleMobileUnsubscribe` is the last writer. Presence ends empty and the driver settles to `idle`. There is no phantom subscriber and no stuck `mobile` driver.

Static confirmation of why the other interleaving is unreachable in the view stream: there is **no statement-level `await`** between `registerOwnedSubscriptionCleanup` (`terminal.ts:3146`) and `await runtime.handleMobileSubscribe` (`:3366`). Every path that can set `closed` — the exit-waiter's `.catch`, a replacement registration, connection teardown, `terminal.unsubscribe` — needs a yield point to run, and there is none. So `closed` is always `false` when the subscribe begins.

### Why the "obvious" fix would be a regression

Copying the lease-only guard here is actively wrong, exactly as its comment warns. Mobile presence is keyed only by `(ptyId, clientId)`, and a reconnect rebinds the same `${terminal}:${clientId}` subscription id (STA-4510). Measured:

```
record under (pty-1, phone-1) after the replacement subscribes: viewport { cols: 41, rows: 21 }
                                                                ^ the later handler's, not a revival
after a superseded handler runs the lease-only release:         presence []
driver:                                                         { kind: "mobile", clientId: "phone-1" }
```

A superseded handler resuming from its awaited subscribe cannot tell its own record from its replacement's, so the release would strand a **live** phone stream with no presence record while leaving the driver `mobile` — desktop still blocked, and the last-leaver restore path gone. Strictly worse than the reported symptom.

`SubscriptionRegistration` exposes only `releaseIfCurrent()` and no ownership predicate, and its map entry is deleted a microtask after an ordinary self-teardown — so "am I still registered?" cannot stand in for "was I superseded?". A safely-guarded release genuinely is not available without new runtime API.

### So why change anything

The correctness here rests entirely on an undocumented, incidental ordering inside a different file, at two write sites, relied on by three call sites. Add one `await` before either `inner.set` in `handleMobileSubscribeInternal` and the view branches resurrect presence permanently, because they have no release and cannot safely have one. Nothing tested that. These tests do, and they fail loudly if either site moves.

The durable fix, if that invariant ever has to break, is presence-ownership identity (a token returned by `handleMobileSubscribe`, or a per-`(ptyId, clientId)` generation) so a superseded handler can release only its own record. That is a runtime API change for a bug that does not currently exist, so it is deliberately **not** in this PR.

## Linked Issue

No GitHub issue — this came from a Discord report (dragonfire1119, iOS TestFlight 0.0.43/0.0.44) triaged into a coordinator evidence pack. The nearest related ticket for the take-back symptom is STA-4163 / #14321, which this PR does **not** claim to fix.

Fixes #N/A

## Visual Proof

`N/A` — no UI or interaction change. The diff is three comments plus a new test file.

## Testing

```
npx vitest run --config config/vitest.config.ts \
  src/main/runtime/rpc/terminal-subscribe-mobile-presence-release.test.ts
```

### RED — mutation proof, both write sites

There is no "before the fix" state (there is no bug), so the tests are validated by mutation: inject the yield that would make the reported defect real, before each of `handleMobileSubscribeInternal`'s presence writes.

**Mutation A — fresh-subscribe branch** (`orca-runtime.ts:16406`), `await new Promise((r) => setTimeout(r, 0))`:

```
 FAIL  > leaves no presence when cleanup wins a fresh awaited subscribe
 AssertionError: expected [] to deeply equal [ 'phone-1' ]
 - Expected
 + Received
 - [
 -   "phone-1",
 - ]
 + []
  ❯ terminal-subscribe-mobile-presence-release.test.ts:112:44
       expect(observed.presenceAtUnsubscribe).toEqual(['phone-1'])

 Test Files  1 failed (1)
      Tests  2 failed | 2 passed (4)
```

**Mutation B — resubscribe-grace branch** (`orca-runtime.ts:16370`), same yield:

```
 FAIL  > leaves no presence when cleanup wins a resubscribe-grace subscribe
 AssertionError: expected [] to deeply equal [ 'phone-1' ]
  ❯ terminal-subscribe-mobile-presence-release.test.ts:130:44

 FAIL  > records presence before the first await on both subscribe branches
 AssertionError: expected [] to deeply equal [ 'phone-1' ]
  ❯ terminal-subscribe-mobile-presence-release.test.ts:154:39

 Test Files  1 failed (1)
      Tests  2 failed | 2 passed (4)
```

`presenceAtUnsubscribe = []` means the teardown ran **before** the presence write and released nothing, so the completed subscribe leaves a permanent phantom mobile subscriber on a stream whose cleanup already ran. That is the reported defect, reproduced only under mutation — which is the point.

**Sensitivity, stated precisely.** The two handler-driven cases pin the end-to-end outcome for the graph-churn trigger, whose teardown is delivered a fixed two microtasks deep (`Promise.reject → .then → .catch`). A *one-tick* yield (`await Promise.resolve()`) therefore still lands ahead of it and those two stay green; only the macrotask mutations above red them. The direct case (`records presence before the first await on both subscribe branches`) is the minimal-delta guard — it reds on a single-tick yield at either write site, which matters because other teardown triggers (connection close, replacement registration, `terminal.unsubscribe`) can deliver cleanup at arbitrary depth. This division of labour is now stated in the test file rather than left implicit.

### Review passes

Two independent review passes ran against this branch; both are folded in.

- **Pass 1** found the pin had a hole: only the fresh-subscribe write was covered, and a yield in the *resubscribe-grace* branch — the one a phone actually takes on background→foreground and on reconnect inside the 250 ms window — left every test green while producing a real phantom subscriber. Fixed by adding the grace case and by asserting what the teardown observes instead of a microtask-order call triple.
- **Pass 2** found that case could silently degrade: the soft-leave timer is real and unfaked, so a slow dispatch would expire it and quietly re-run the fresh branch under the grace test's name. Fixed by recording which branch was actually taken, read at the subscribe call. It also noted the ordering rule was documented only at the readers, so it now sits on `handleMobileSubscribeInternal` itself (covering all four of its presence writes), where an editor adding an await would see it.

### GREEN — mutations reverted, current `main` behaviour

```
 ✓ src/main/runtime/rpc/terminal-subscribe-mobile-presence-release.test.ts (4 tests)
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

### Neighbours still green

```
npx vitest run --config config/vitest.config.ts \
  src/main/runtime/rpc/terminal-subscribe-mobile-presence-release.test.ts \
  src/main/runtime/rpc/terminal-subscribe-lease-only.test.ts \
  src/main/runtime/rpc/terminal-subscribe-reconnect-rebind.test.ts \
  src/main/runtime/rpc/terminal-subscribe-ownership.test.ts \
  src/main/runtime/rpc/terminal-multiplex-subscribe-slot-recovery.test.ts

 Test Files  5 passed (5)
      Tests  15 passed (15)
```

`npx oxlint` clean on both touched files; `oxfmt` applied. Full typecheck deliberately not run (repo guidance for this workstream).

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Platforms: main-process logic, exercised on macOS. The code path is platform-independent (no shell, path, or OS API involvement).

### Explicitly out of scope

Presence and driver are what this PR pins. Measured on unmutated code, the torn-down subscribe **does** leave `layouts[ptyId] = {kind:'phone'}` and `terminalFitOverrides[ptyId] = {mode:'mobile-fit'}` behind with zero subscribers, because the phone-fit `enqueueLayout` is still in flight when the teardown lands and the default auto-restore preference is the "Indefinite" hold (`getAutoRestoreFitMs() == null`), which by design waits for the desktop banner's Restore. Desktop writes are **not** blocked (driver is `idle`), but the terminal stays phone-fitted for a stream that never started. That is a separate question from the presence race and is reported separately rather than folded in.

## AI Disclosure

Claude Opus 5 via Claude Code.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Security** — no new inputs, no auth or ACL surface, no data leaves the process. The test reaches `mobileSubscribers` through a documented test-only cast, mirroring the existing pattern (the runtime deliberately exposes no accessor).
- **Cross-platform (Linux / Windows / macOS)** — no shell, path, key, or OS API involvement. Pure main-process promise ordering.
- **Remote SSH** — none. `handleMobileSubscribe` is host-local presence bookkeeping over a `ptyId`; SSH and folder-workspace hosts run the identical code with no path assumptions.
- **Mobile (iOS + Android)** — no client-visible change. No frame, opcode, or JSON field added, removed, or reordered; behaviour is byte-identical for every shipped client on both platforms.
- **Backwards compatibility** — nothing a client and host exchange is touched, so `docs/reference/remote-wire-compatibility.md` does not apply. Mixed-version pairs are unaffected.
- **Performance** — zero runtime cost; the only shipped change is three comments. The new tests add ~0.6s (two `vi.waitFor`s over the 250 ms soft-leave grace, polled rather than slept).
- **Scope** — does not touch the exit-waiter wiring at `terminal.ts:2978 / 3105 / 3171` (owned by a separate PR on this file), and does not touch PR #15355 or its restore-path publication fix.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — targeted vitest + oxlint run locally; full typecheck/build left to CI per workstream guidance

## Author

- X / Twitter: @BrennanKB5

