### PR TITLE
fix(mobile): replay a delivery-ambiguous worktree.create instead of failing it

### DIFF
--- a/mobile/src/tasks/worktree-create-retry.test.ts
+++ b/mobile/src/tasks/worktree-create-retry.test.ts
@@ -348,7 +348,9 @@ describe('createWorktreeWithNameRetry', () => {
     } finally {
       vi.useRealTimers()
     }
-  })
+    // Generous: advanceTimersByTimeAsync yields through REAL macrotasks between ticks,
+    // so vitest's default 5s real-time budget is reachable on a loaded runner.
+  }, 30_000)
 
   it('surfaces the original ambiguity when the transport never comes back', async () => {
     vi.useFakeTimers()
@@ -381,7 +383,9 @@ describe('createWorktreeWithNameRetry', () => {
     } finally {
       vi.useRealTimers()
     }
-  })
+    // Generous: advanceTimersByTimeAsync yields through REAL macrotasks between ticks,
+    // so vitest's default 5s real-time budget is reachable on a loaded runner.
+  }, 30_000)
 
   it('does not replay an ambiguity that surfaced while the transport stayed connected', async () => {
     vi.useFakeTimers()
@@ -421,7 +425,9 @@ describe('createWorktreeWithNameRetry', () => {
     } finally {
       vi.useRealTimers()
     }
-  })
+    // Generous: advanceTimersByTimeAsync yields through REAL macrotasks between ticks,
+    // so vitest's default 5s real-time budget is reachable on a loaded runner.
+  }, 30_000)
 
   it('clamps a later reconnect wait to what is left of the replay window', async () => {
     vi.useFakeTimers()
@@ -468,7 +474,9 @@ describe('createWorktreeWithNameRetry', () => {
     } finally {
       vi.useRealTimers()
     }
-  })
+    // Generous: advanceTimersByTimeAsync yields through REAL macrotasks between ticks,
+    // so vitest's default 5s real-time budget is reachable on a loaded runner.
+  }, 30_000)
 
   it('leaves room for watchdog detection inside the host dedupe TTL', () => {
     // Restates the budget from the watchdog's side: a half-open socket is only reported

--- a/mobile/src/tasks/worktree-create-retry.test.ts
+++ b/mobile/src/tasks/worktree-create-retry.test.ts
@@ -5,11 +5,6 @@ import { LogicalClientCutoverError } from '../transport/stable-logical-rpc-clien
 import type { ConnectionState } from '../transport/types'
 import { WORKTREE_CREATE_DEDUPE_TTL_MS } from '../../../src/shared/new-workspace/worktree-create-retry-policy'
 import {
-  LIVENESS_IDLE_MS,
-  LIVENESS_PROBE_TIMEOUT_MS,
-  MISSED_PROBE_LIMIT
-} from '../transport/rpc-session-liveness-watchdog'
-import {
   createWorktreeWithNameRetry,
   WORKTREE_CREATE_AMBIGUOUS_RECONNECT_WAIT_MS,
   WORKTREE_CREATE_AMBIGUOUS_REPLAY_WINDOW_MS
@@ -60,11 +55,17 @@ function scriptedClient(
     | { throws: unknown; dropsConnection?: boolean; takesMs?: number; reconnectsAfterMs?: number }
   >,
   attempts: Attempt[],
-  connection?: ReturnType<typeof connectionController>
+  connection?: ReturnType<typeof connectionController>,
+  // Wall-clock stamp of the last frame that really arrived. Absent = a transport that
+  // can't vouch for one, which must fall back to the send; a function models a live
+  // socket whose stamp keeps advancing.
+  lastInboundAt?: number | (() => number)
 ): RpcClient {
   let call = 0
   return {
     getState: () => connection?.getState() ?? 'connected',
+    getLastInboundAt: () =>
+      (typeof lastInboundAt === 'function' ? lastInboundAt() : lastInboundAt) ?? null,
     onStateChange: (listener: (state: ConnectionState) => void) =>
       connection?.onStateChange(listener) ?? (() => {}),
     sendRequest: async (method: string, params?: unknown) => {
@@ -404,7 +405,10 @@ describe('createWorktreeWithNameRetry', () => {
           { id: 'wt-duplicate' }
         ],
         attempts,
-        connection
+        connection,
+        // Watchdog probes keep answering throughout, so the replay window looks wide
+        // open on arrival: only the still-connected guard can stop this replay.
+        () => Date.now()
       )
 
       const pending = createWorktreeWithNameRetry({
@@ -434,13 +438,15 @@ describe('createWorktreeWithNameRetry', () => {
     try {
       const attempts: Attempt[] = []
       const connection = connectionController()
-      const spent = 5_000
       const client = scriptedClient(
         [
           {
+            // Most of the window is already gone by the time the drop is reported, so the
+            // remainder — not the full wait — is what the second wait gets.
             throws: markRpcDeliveryUnknown(new Error('Connection interrupted')),
             dropsConnection: true,
-            reconnectsAfterMs: spent
+            takesMs: 30_000,
+            reconnectsAfterMs: 1_000
           },
           {
             // Second drop, and this time the phone never comes back.
@@ -478,15 +484,176 @@ describe('createWorktreeWithNameRetry', () => {
     // so vitest's default 5s real-time budget is reachable on a loaded runner.
   }, 30_000)
 
-  it('leaves room for watchdog detection inside the host dedupe TTL', () => {
-    // Restates the budget from the watchdog's side: a half-open socket is only reported
-    // after a full idle period plus the missed-probe budget, and the wait runs *after*
-    // that. Raising the wait without re-deriving it against the TTL would let a replay
-    // land on a dropped record.
-    const worstCaseDetectionMs = LIVENESS_IDLE_MS + MISSED_PROBE_LIMIT * LIVENESS_PROBE_TIMEOUT_MS
-    expect(worstCaseDetectionMs + WORKTREE_CREATE_AMBIGUOUS_RECONNECT_WAIT_MS).toBeLessThanOrEqual(
-      WORKTREE_CREATE_DEDUPE_TTL_MS
+  it('refuses a replay when the ambiguity surfaced long after the last inbound frame', async () => {
+    vi.useFakeTimers()
+    try {
+      const attempts: Attempt[] = []
+      const connection = connectionController()
+      const startedAt = Date.now()
+      const client = scriptedClient(
+        [
+          {
+            throws: markRpcDeliveryUnknown(new Error('Connection interrupted')),
+            dropsConnection: true,
+            reconnectsAfterMs: 1_000,
+            // The phone was backgrounded: the OS suspended JS and killed the socket, and
+            // nothing observed the drop until the app came back ten minutes later.
+            takesMs: 600_000
+          }
+        ],
+        attempts,
+        connection,
+        startedAt + 2_000
+      )
+      const pending = createWorktreeWithNameRetry({
+        client,
+        baseName: 'limpet',
+        buildParams: (name) => ({ repo: 'id:r', name }),
+        supportsIdempotentCutoverRetry: true,
+        mintMutationId: () => 'key-stale'
+      })
+      const settled = expect(pending).rejects.toThrow('Connection interrupted')
+      await vi.advanceTimersByTimeAsync(700_000)
+      await settled
+      // The host forgot this create ~9 minutes ago. A replay would not reconcile — it
+      // would build a second worktree — so the create fails instead.
+      expect(attempts).toHaveLength(1)
+    } finally {
+      vi.useRealTimers()
+    }
+    // Generous: advanceTimersByTimeAsync yields through REAL macrotasks between ticks,
+    // so vitest's default 5s real-time budget is reachable on a loaded runner.
+  }, 30_000)
+
+  it('still replays a long-running create whose socket stayed live until it dropped', async () => {
+    vi.useFakeTimers()
+    try {
+      const attempts: Attempt[] = []
+      const connection = connectionController()
+      const startedAt = Date.now()
+      const client = scriptedClient(
+        [
+          {
+            // Three minutes of clone/fetch with the socket answering probes throughout,
+            // then it drops and the watchdog reports it four seconds later.
+            throws: markRpcDeliveryUnknown(new Error('Connection interrupted')),
+            dropsConnection: true,
+            reconnectsAfterMs: 1_000,
+            takesMs: 184_000
+          },
+          { id: 'wt-long' }
+        ],
+        attempts,
+        connection,
+        startedAt + 180_000
+      )
+      const pending = createWorktreeWithNameRetry({
+        client,
+        baseName: 'kelp',
+        buildParams: (name) => ({ repo: 'id:r', name }),
+        supportsIdempotentCutoverRetry: true,
+        mintMutationId: () => 'key-long'
+      })
+      await vi.advanceTimersByTimeAsync(250_000)
+      // Anchoring at the send would refuse this — the create outran the TTL long before it
+      // went ambiguous — but the record only starts ticking when the host RESOLVES, and the
+      // live socket proves our knowledge was current.
+      expect(await pending).toEqual({ worktreeId: 'wt-long', name: 'kelp' })
+      expect(attempts).toHaveLength(2)
+      expect(attempts[0]!.params.clientMutationId).toBe('key-long')
+      expect(attempts[1]!.params.clientMutationId).toBe('key-long')
+    } finally {
+      vi.useRealTimers()
+    }
+    // Generous: advanceTimersByTimeAsync yields through REAL macrotasks between ticks,
+    // so vitest's default 5s real-time budget is reachable on a loaded runner.
+  }, 30_000)
+
+  it('does not extend the replay window when the replacement session reports fresher inbound activity', async () => {
+    vi.useFakeTimers()
+    try {
+      const attempts: Attempt[] = []
+      const connection = connectionController()
+      const startedAt = Date.now()
+      // The replacement session starts answering probes, so its inbound stamp is far
+      // newer than anything that bears on when the ORIGINAL create resolved host-side.
+      let lastInboundAt = startedAt + 1_000
+      setTimeout(() => {
+        lastInboundAt = startedAt + 45_000
+      }, 45_000)
+      const client = scriptedClient(
+        [
+          {
+            throws: markRpcDeliveryUnknown(new Error('Connection lost')),
+            dropsConnection: true,
+            takesMs: 40_000,
+            reconnectsAfterMs: 1_000
+          },
+          {
+            throws: markRpcDeliveryUnknown(new Error('Connection lost')),
+            dropsConnection: true,
+            takesMs: 20_000,
+            reconnectsAfterMs: 1_000
+          },
+          { id: 'wt-third' }
+        ],
+        attempts,
+        connection,
+        () => lastInboundAt
+      )
+
+      const pending = createWorktreeWithNameRetry({
+        client,
+        baseName: 'urchin',
+        buildParams: (name) => ({ repo: 'id:r', name }),
+        supportsIdempotentCutoverRetry: true,
+        mintMutationId: () => 'key-anchored'
+      })
+      const settled = expect(pending).rejects.toThrow('Connection lost')
+      await vi.advanceTimersByTimeAsync(120_000)
+      await settled
+      // The deadline is fixed at the FIRST ambiguity. Re-reading it here would buy another
+      // 50s of window off a stamp that says nothing about the original request.
+      expect(attempts).toHaveLength(2)
+    } finally {
+      vi.useRealTimers()
+    }
+    // Generous: advanceTimersByTimeAsync yields through REAL macrotasks between ticks,
+    // so vitest's default 5s real-time budget is reachable on a loaded runner.
+  }, 30_000)
+
+  it('does not replay a dropped transport error that was never marked delivery-unknown', async () => {
+    const attempts: Attempt[] = []
+    const connection = connectionController()
+    const client = scriptedClient(
+      // Unmarked: the frame is known NOT to have reached the wire, so the host never saw
+      // it and a replay would be a second create, not a reconciliation. The transport
+      // still leaves 'connected', so only the delivery-unknown check stops this.
+      [{ throws: new Error('Socket closed before send'), dropsConnection: true }],
+      attempts,
+      connection
     )
+    await expect(
+      createWorktreeWithNameRetry({
+        client,
+        baseName: 'urchin',
+        buildParams: (name) => ({ repo: 'id:r', name }),
+        supportsIdempotentCutoverRetry: true,
+        mintMutationId: () => 'key-unmarked'
+      })
+    ).rejects.toThrow('Socket closed before send')
+    expect(attempts).toHaveLength(1)
+  })
+
+  it('keeps the replay window strictly inside the host dedupe TTL', () => {
+    // The window is measured from a lower bound on when the host could have resolved, so
+    // it has to leave the record room for the replay to still be in flight. Widening it
+    // to the whole TTL would let the last replay land on a record that just expired.
     expect(WORKTREE_CREATE_AMBIGUOUS_REPLAY_WINDOW_MS).toBeGreaterThan(0)
+    expect(WORKTREE_CREATE_AMBIGUOUS_REPLAY_WINDOW_MS).toBeLessThan(WORKTREE_CREATE_DEDUPE_TTL_MS)
+    // A single wait must not be able to consume the window on its own.
+    expect(WORKTREE_CREATE_AMBIGUOUS_RECONNECT_WAIT_MS).toBeLessThan(
+      WORKTREE_CREATE_AMBIGUOUS_REPLAY_WINDOW_MS
+    )
   })
 })

--- a/mobile/src/tasks/worktree-create-retry.test.ts
+++ b/mobile/src/tasks/worktree-create-retry.test.ts
@@ -3,7 +3,18 @@ import type { RpcClient } from '../transport/rpc-client'
 import { markRpcDeliveryUnknown } from '../transport/rpc-delivery-ambiguity'
 import { LogicalClientCutoverError } from '../transport/stable-logical-rpc-client'
 import type { ConnectionState } from '../transport/types'
-import { createWorktreeWithNameRetry } from './worktree-create-retry'
+import { WORKTREE_CREATE_DEDUPE_TTL_MS } from '../../../src/shared/new-workspace/worktree-create-retry-policy'
+import {
+  LIVENESS_IDLE_MS,
+  LIVENESS_PROBE_TIMEOUT_MS,
+  MISSED_PROBE_LIMIT
+} from '../transport/rpc-session-liveness-watchdog'
+import {
+  createWorktreeWithNameRetry,
+  WORKTREE_CREATE_AMBIGUOUS_RECONNECT_WAIT_MS,
+  WORKTREE_CREATE_AMBIGUOUS_REPLAY_WINDOW_MS
+} from './worktree-create-retry'
+import { WORKTREE_CREATE_TIMEOUT_MS } from './workspace-create-timeout'
 
 type Attempt = { method: string; params: Record<string, unknown> }
 
@@ -41,7 +52,12 @@ async function flush(): Promise<void> {
 // cutover). Records every call so tests can assert on the clientMutationId.
 function scriptedClient(
   outcomes: Array<
-    { id: string } | { errorMessage: string } | { throws: unknown; dropsConnection?: boolean }
+    | { id: string }
+    | { errorMessage: string }
+    // takesMs models how long the ambiguity took to SURFACE — a clean close is
+    // instant, a half-open socket waits out the liveness watchdog or the timeout.
+    // reconnectsAfterMs brings the transport back so the next replay can run.
+    | { throws: unknown; dropsConnection?: boolean; takesMs?: number; reconnectsAfterMs?: number }
   >,
   attempts: Attempt[],
   connection?: ReturnType<typeof connectionController>
@@ -56,8 +72,14 @@ function scriptedClient(
       const outcome = outcomes[Math.min(call, outcomes.length - 1)]!
       call += 1
       if ('throws' in outcome) {
+        if (outcome.takesMs !== undefined) {
+          await new Promise((resolve) => setTimeout(resolve, outcome.takesMs))
+        }
         if (outcome.dropsConnection) {
           connection?.set('reconnecting')
+          if (outcome.reconnectsAfterMs !== undefined) {
+            setTimeout(() => connection?.set('connected'), outcome.reconnectsAfterMs)
+          }
         }
         throw outcome.throws
       }
@@ -157,6 +179,8 @@ describe('createWorktreeWithNameRetry', () => {
     expect(attempts).toHaveLength(6)
   })
 
+  // Also the delivery-ambiguity guard: an unmarked error is a DEFINITE failure, so
+  // neither the cutover nor the replay path may re-issue it.
   it('does not treat an ordinary transport error as a cutover', async () => {
     const attempts: Attempt[] = []
     const client = scriptedClient([{ throws: new Error('Request timed out') }], attempts)
@@ -284,24 +308,46 @@ describe('createWorktreeWithNameRetry', () => {
     expect(attempts[0]!.params.clientMutationId).toBeUndefined()
   })
 
-  it('gives up after the delivery-ambiguity replay budget and rethrows', async () => {
-    const attempts: Attempt[] = []
-    const client = scriptedClient(
-      [{ throws: markRpcDeliveryUnknown(new Error('Connection interrupted')) }],
-      attempts
-    )
-    await expect(
-      createWorktreeWithNameRetry({
+  it('gives up after the delivery-ambiguity replay budget, still inside the dedupe TTL', async () => {
+    vi.useFakeTimers()
+    try {
+      const attempts: Attempt[] = []
+      const connection = connectionController()
+      const client = scriptedClient(
+        [
+          {
+            throws: markRpcDeliveryUnknown(new Error('Connection interrupted')),
+            dropsConnection: true,
+            reconnectsAfterMs: 1_000
+          }
+        ],
+        attempts,
+        connection
+      )
+      const startedAt = Date.now()
+      let settledAt = -1
+      const pending = createWorktreeWithNameRetry({
         client,
         baseName: 'barnacle',
         buildParams: (name) => ({ repo: 'id:r', name }),
         supportsIdempotentCutoverRetry: true,
         mintMutationId: () => 'key-budget'
+      }).catch((error: unknown) => {
+        settledAt = Date.now()
+        throw error
       })
-    ).rejects.toThrow('Connection interrupted')
-    // Initial attempt + 2 replays; the window stays inside the host's post-success
-    // dedupe TTL so a replay can't outlive the record it is meant to match.
-    expect(attempts).toHaveLength(3)
+      const settled = expect(pending).rejects.toThrow('Connection interrupted')
+      await vi.advanceTimersByTimeAsync(WORKTREE_CREATE_DEDUPE_TTL_MS)
+      await settled
+      // Initial attempt + 2 replays.
+      expect(attempts).toHaveLength(3)
+      // The budget is a count, but what keeps a replay reconciling instead of building
+      // a second worktree is wall clock: every attempt has to land while the host still
+      // holds the record, with the watchdog's detection latency already deducted.
+      expect(settledAt - startedAt).toBeLessThanOrEqual(WORKTREE_CREATE_AMBIGUOUS_REPLAY_WINDOW_MS)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('surfaces the original ambiguity when the transport never comes back', async () => {
@@ -335,5 +381,104 @@ describe('createWorktreeWithNameRetry', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('does not replay an ambiguity that surfaced while the transport stayed connected', async () => {
+    vi.useFakeTimers()
+    try {
+      const attempts: Attempt[] = []
+      const connection = connectionController()
+      const client = scriptedClient(
+        [
+          {
+            // A silently dropped response frame leaves the socket alive, so nothing
+            // rejects until the request timeout — by then the host resolved at an
+            // unknowable point and its dedupe record is very likely gone.
+            throws: markRpcDeliveryUnknown(new Error('Request timed out: worktree.create')),
+            takesMs: WORKTREE_CREATE_TIMEOUT_MS
+          },
+          { id: 'wt-duplicate' }
+        ],
+        attempts,
+        connection
+      )
+
+      const pending = createWorktreeWithNameRetry({
+        client,
+        baseName: 'cuttlefish',
+        buildParams: (name) => ({ repo: 'id:r', name }),
+        supportsIdempotentCutoverRetry: true,
+        mintMutationId: () => 'key-expired'
+      })
+      const settled = expect(pending).rejects.toThrow('Request timed out')
+      await vi.advanceTimersByTimeAsync(WORKTREE_CREATE_TIMEOUT_MS)
+      await settled
+      // Never left 'connected', so no drop was ever detected and the staleness of the
+      // ambiguity is unbounded. Re-sending would miss the record and build a SECOND
+      // worktree — for a folder workspace, one with the very same name.
+      expect(connection.getState()).toBe('connected')
+      expect(attempts).toHaveLength(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('clamps a later reconnect wait to what is left of the replay window', async () => {
+    vi.useFakeTimers()
+    try {
+      const attempts: Attempt[] = []
+      const connection = connectionController()
+      const spent = 5_000
+      const client = scriptedClient(
+        [
+          {
+            throws: markRpcDeliveryUnknown(new Error('Connection interrupted')),
+            dropsConnection: true,
+            reconnectsAfterMs: spent
+          },
+          {
+            // Second drop, and this time the phone never comes back.
+            throws: markRpcDeliveryUnknown(new Error('Connection interrupted')),
+            dropsConnection: true
+          }
+        ],
+        attempts,
+        connection
+      )
+
+      const startedAt = Date.now()
+      let settledAt = -1
+      const pending = createWorktreeWithNameRetry({
+        client,
+        baseName: 'nautilus',
+        buildParams: (name) => ({ repo: 'id:r', name }),
+        supportsIdempotentCutoverRetry: true,
+        mintMutationId: () => 'key-clamped'
+      }).catch((error: unknown) => {
+        settledAt = Date.now()
+        throw error
+      })
+      const settled = expect(pending).rejects.toThrow('Connection interrupted')
+      await vi.advanceTimersByTimeAsync(WORKTREE_CREATE_AMBIGUOUS_REPLAY_WINDOW_MS)
+      await settled
+      expect(attempts).toHaveLength(2)
+      // The window is anchored at the FIRST ambiguity, so the second wait gets only the
+      // remainder — it must not restart a full wait and carry the replay past the record.
+      expect(settledAt - startedAt).toBe(WORKTREE_CREATE_AMBIGUOUS_REPLAY_WINDOW_MS)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('leaves room for watchdog detection inside the host dedupe TTL', () => {
+    // Restates the budget from the watchdog's side: a half-open socket is only reported
+    // after a full idle period plus the missed-probe budget, and the wait runs *after*
+    // that. Raising the wait without re-deriving it against the TTL would let a replay
+    // land on a dropped record.
+    const worstCaseDetectionMs = LIVENESS_IDLE_MS + MISSED_PROBE_LIMIT * LIVENESS_PROBE_TIMEOUT_MS
+    expect(worstCaseDetectionMs + WORKTREE_CREATE_AMBIGUOUS_RECONNECT_WAIT_MS).toBeLessThanOrEqual(
+      WORKTREE_CREATE_DEDUPE_TTL_MS
+    )
+    expect(WORKTREE_CREATE_AMBIGUOUS_REPLAY_WINDOW_MS).toBeGreaterThan(0)
   })
 })

--- a/mobile/src/tasks/worktree-create-retry.test.ts
+++ b/mobile/src/tasks/worktree-create-retry.test.ts
@@ -1,24 +1,64 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { RpcClient } from '../transport/rpc-client'
+import { markRpcDeliveryUnknown } from '../transport/rpc-delivery-ambiguity'
 import { LogicalClientCutoverError } from '../transport/stable-logical-rpc-client'
+import type { ConnectionState } from '../transport/types'
 import { createWorktreeWithNameRetry } from './worktree-create-retry'
 
 type Attempt = { method: string; params: Record<string, unknown> }
+
+// Drives the transport state a replay has to wait on. Production couples the two:
+// a socket close rejects the pending frame AND drops the client off 'connected'.
+function connectionController(): {
+  getState: () => ConnectionState
+  onStateChange: (listener: (state: ConnectionState) => void) => () => void
+  set: (next: ConnectionState) => void
+} {
+  let state: ConnectionState = 'connected'
+  const listeners = new Set<(next: ConnectionState) => void>()
+  return {
+    getState: () => state,
+    onStateChange: (listener) => {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+    set: (next) => {
+      state = next
+      for (const listener of listeners) {
+        listener(next)
+      }
+    }
+  }
+}
+
+// Lets a parked replay reach its state wait before the test resumes the transport.
+async function flush(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
 
 // A client whose per-call outcome is scripted: return an id, a server error
 // message, or throw (transport-level rejection, e.g. a connection-migration
 // cutover). Records every call so tests can assert on the clientMutationId.
 function scriptedClient(
-  outcomes: Array<{ id: string } | { errorMessage: string } | { throws: unknown }>,
-  attempts: Attempt[]
+  outcomes: Array<
+    { id: string } | { errorMessage: string } | { throws: unknown; dropsConnection?: boolean }
+  >,
+  attempts: Attempt[],
+  connection?: ReturnType<typeof connectionController>
 ): RpcClient {
   let call = 0
   return {
+    getState: () => connection?.getState() ?? 'connected',
+    onStateChange: (listener: (state: ConnectionState) => void) =>
+      connection?.onStateChange(listener) ?? (() => {}),
     sendRequest: async (method: string, params?: unknown) => {
       attempts.push({ method, params: (params ?? {}) as Record<string, unknown> })
       const outcome = outcomes[Math.min(call, outcomes.length - 1)]!
       call += 1
       if ('throws' in outcome) {
+        if (outcome.dropsConnection) {
+          connection?.set('reconnecting')
+        }
         throw outcome.throws
       }
       if ('errorMessage' in outcome) {
@@ -187,5 +227,113 @@ describe('createWorktreeWithNameRetry', () => {
     ).rejects.toBeInstanceOf(LogicalClientCutoverError)
     expect(attempts).toHaveLength(1)
     expect(attempts[0]!.params.clientMutationId).toBeUndefined()
+  })
+
+  it('replays a delivery-ambiguous socket drop with the SAME key once the transport returns', async () => {
+    const attempts: Attempt[] = []
+    const connection = connectionController()
+    const client = scriptedClient(
+      [
+        {
+          throws: markRpcDeliveryUnknown(new Error('Connection interrupted')),
+          dropsConnection: true
+        },
+        { id: 'wt-drop' }
+      ],
+      attempts,
+      connection
+    )
+
+    const pending = createWorktreeWithNameRetry({
+      client,
+      baseName: 'urchin',
+      buildParams: (name) => ({ repo: 'id:r', name }),
+      supportsIdempotentCutoverRetry: true,
+      mintMutationId: () => 'key-drop'
+    })
+
+    await flush()
+    // Parked on the reconnect, not resent onto a dead socket.
+    expect(attempts).toHaveLength(1)
+
+    connection.set('connected')
+    await expect(pending).resolves.toEqual({ worktreeId: 'wt-drop', name: 'urchin' })
+    expect(attempts).toHaveLength(2)
+    // Idempotency: the host dedupes the replay against the create it may already
+    // have finished, instead of building a second worktree.
+    expect(attempts[1]!.params.clientMutationId).toBe('key-drop')
+    expect(attempts[1]!.params.name).toBe('urchin')
+  })
+
+  it('does not replay a delivery-ambiguous drop when the host lacks idempotency support', async () => {
+    const attempts: Attempt[] = []
+    const client = scriptedClient(
+      [{ throws: markRpcDeliveryUnknown(new Error('Connection interrupted')) }],
+      attempts
+    )
+    await expect(
+      createWorktreeWithNameRetry({
+        client,
+        baseName: 'limpet',
+        buildParams: (name) => ({ repo: 'id:r', name }),
+        supportsIdempotentCutoverRetry: false,
+        mintMutationId: () => 'must-not-be-used'
+      })
+    ).rejects.toThrow('Connection interrupted')
+    expect(attempts).toHaveLength(1)
+    expect(attempts[0]!.params.clientMutationId).toBeUndefined()
+  })
+
+  it('gives up after the delivery-ambiguity replay budget and rethrows', async () => {
+    const attempts: Attempt[] = []
+    const client = scriptedClient(
+      [{ throws: markRpcDeliveryUnknown(new Error('Connection interrupted')) }],
+      attempts
+    )
+    await expect(
+      createWorktreeWithNameRetry({
+        client,
+        baseName: 'barnacle',
+        buildParams: (name) => ({ repo: 'id:r', name }),
+        supportsIdempotentCutoverRetry: true,
+        mintMutationId: () => 'key-budget'
+      })
+    ).rejects.toThrow('Connection interrupted')
+    // Initial attempt + 2 replays; the window stays inside the host's post-success
+    // dedupe TTL so a replay can't outlive the record it is meant to match.
+    expect(attempts).toHaveLength(3)
+  })
+
+  it('surfaces the original ambiguity when the transport never comes back', async () => {
+    vi.useFakeTimers()
+    try {
+      const attempts: Attempt[] = []
+      const connection = connectionController()
+      const client = scriptedClient(
+        [
+          {
+            throws: markRpcDeliveryUnknown(new Error('Connection interrupted')),
+            dropsConnection: true
+          }
+        ],
+        attempts,
+        connection
+      )
+
+      const pending = createWorktreeWithNameRetry({
+        client,
+        baseName: 'anemone',
+        buildParams: (name) => ({ repo: 'id:r', name }),
+        supportsIdempotentCutoverRetry: true,
+        mintMutationId: () => 'key-stuck'
+      })
+      const settled = expect(pending).rejects.toThrow('Connection interrupted')
+      // A phone that never reconnects must not leave the Create spinner parked.
+      await vi.advanceTimersByTimeAsync(60_000)
+      await settled
+      expect(attempts).toHaveLength(1)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/mobile/src/tasks/worktree-create-retry.ts
+++ b/mobile/src/tasks/worktree-create-retry.ts
@@ -10,11 +10,6 @@ import {
   isRetryableWorktreeCreateConflict,
   WORKTREE_CREATE_DEDUPE_TTL_MS
 } from '../../../src/shared/new-workspace/worktree-create-retry-policy'
-import {
-  LIVENESS_IDLE_MS,
-  LIVENESS_PROBE_TIMEOUT_MS,
-  MISSED_PROBE_LIMIT
-} from '../transport/rpc-session-liveness-watchdog'
 import { WORKTREE_CREATE_TIMEOUT_MS } from './workspace-create-timeout'
 
 // Why: server-side collision checks (branch already exists locally / on a remote
@@ -44,19 +39,16 @@ const WORKTREE_CREATE_AMBIGUOUS_MAX_RETRIES = 2
 // Why: the host keeps a settled create's dedupe record for WORKTREE_CREATE_DEDUPE_TTL_MS
 // after it resolves; a replay that lands later misses it and the host's suffix loop
 // builds a SECOND worktree — and for folder workspaces a second one with the SAME name
-// and no collision check at all. So what bounds a safe replay is not how long the create
-// ran, but how STALE the client's knowledge is: the worst case between the host losing a
-// response and the client noticing. A dead socket is detected by the liveness watchdog
-// within one idle period plus its missed-probe budget, so that is the staleness ceiling
-// for any drop the transport actually reports.
-const WORKTREE_CREATE_AMBIGUITY_DETECTION_CEILING_MS =
-  LIVENESS_IDLE_MS + MISSED_PROBE_LIMIT * LIVENESS_PROBE_TIMEOUT_MS
-// What is left of the host's record once that detection latency is spent. The reconnect
-// wait plus any further replay has to fit inside it.
+// and no collision check at all. So a replay is bounded by how stale our knowledge of the
+// host is, and that has to be measured in WALL CLOCK: iOS/Android suspend JS timers while
+// the app is backgrounded, so any ceiling derived from timer intervals — a watchdog probe
+// budget, a request timeout — can be arbitrarily wrong across a background cycle, which is
+// exactly when a create sits ambiguous for minutes.
+const WORKTREE_CREATE_REPLAY_FLIGHT_MARGIN_MS = 10_000
 export const WORKTREE_CREATE_AMBIGUOUS_REPLAY_WINDOW_MS =
-  WORKTREE_CREATE_DEDUPE_TTL_MS - WORKTREE_CREATE_AMBIGUITY_DETECTION_CEILING_MS
-export const WORKTREE_CREATE_AMBIGUOUS_RECONNECT_WAIT_MS =
-  WORKTREE_CREATE_AMBIGUOUS_REPLAY_WINDOW_MS
+  WORKTREE_CREATE_DEDUPE_TTL_MS - WORKTREE_CREATE_REPLAY_FLIGHT_MARGIN_MS
+// Bounded so the Create spinner doesn't sit for the whole window; the deadline still caps it.
+export const WORKTREE_CREATE_AMBIGUOUS_RECONNECT_WAIT_MS = 20_000
 
 export type CreateWorktreeWithNameRetryArgs = {
   client: RpcClient
@@ -124,8 +116,7 @@ async function sendWorktreeCreateResilient(
 ): Promise<RpcResponse> {
   let migrationRetry = 0
   let ambiguousRetry = 0
-  // Anchored at the FIRST ambiguity, not at the send: a create legitimately runs for
-  // minutes, and the host's record only starts ticking once it resolves.
+  const firstSentAt = Date.now()
   let replayDeadlineAt: number | null = null
   for (;;) {
     try {
@@ -159,7 +150,9 @@ async function sendWorktreeCreateResilient(
       if (client.getState() === 'connected') {
         throw error
       }
-      replayDeadlineAt ??= Date.now() + WORKTREE_CREATE_AMBIGUOUS_REPLAY_WINDOW_MS
+      // Computed once: a later ambiguity reads a fresher lastInboundAt from the
+      // replacement session, which would push the deadline past the record it respects.
+      replayDeadlineAt ??= resolveReplayDeadline(client, firstSentAt)
       const remainingWindowMs = replayDeadlineAt - Date.now()
       if (remainingWindowMs <= 0) {
         throw error
@@ -179,6 +172,17 @@ async function sendWorktreeCreateResilient(
       }
     }
   }
+}
+
+// Latest instant the host's dedupe record is still guaranteed to exist, from the earliest
+// point the create could have resolved. lastInboundAt stamps a frame that really arrived,
+// so it stays honest across a suspension in a way a timer budget cannot; the send is the
+// fallback, and a sound floor either way, because the host cannot resolve a create it has
+// not yet received.
+function resolveReplayDeadline(client: RpcClient, firstSentAt: number): number {
+  const lastInboundAt = client.getLastInboundAt?.() ?? null
+  const anchor = lastInboundAt !== null && lastInboundAt > firstSentAt ? lastInboundAt : firstSentAt
+  return anchor + WORKTREE_CREATE_AMBIGUOUS_REPLAY_WINDOW_MS
 }
 
 function defaultWorktreeCreateMutationId(): string {

--- a/mobile/src/tasks/worktree-create-retry.ts
+++ b/mobile/src/tasks/worktree-create-retry.ts
@@ -7,8 +7,14 @@ import {
   CLIENT_WORKTREE_CREATE_MAX_ATTEMPTS,
   getClientWorktreeCreateCandidate,
   getGeneratedWorktreeCreateRetryCandidate,
-  isRetryableWorktreeCreateConflict
+  isRetryableWorktreeCreateConflict,
+  WORKTREE_CREATE_DEDUPE_TTL_MS
 } from '../../../src/shared/new-workspace/worktree-create-retry-policy'
+import {
+  LIVENESS_IDLE_MS,
+  LIVENESS_PROBE_TIMEOUT_MS,
+  MISSED_PROBE_LIMIT
+} from '../transport/rpc-session-liveness-watchdog'
 import { WORKTREE_CREATE_TIMEOUT_MS } from './workspace-create-timeout'
 
 // Why: server-side collision checks (branch already exists locally / on a remote
@@ -34,10 +40,23 @@ const WORKTREE_CREATE_CUTOVER_MAX_RETRIES = 5
 // to be caught by one. Surfacing that as a failure is wrong: the host may well have
 // finished the worktree. Replay on the same clientMutationId instead.
 const WORKTREE_CREATE_AMBIGUOUS_MAX_RETRIES = 2
-// Why: the host drops a completed create's dedupe record 60s after it resolves, so
-// keep the whole replay window comfortably inside that or a replay lands as a fresh
-// create and suffixes a duplicate. An in-flight create is deduped without any TTL.
-const WORKTREE_CREATE_AMBIGUOUS_RECONNECT_WAIT_MS = 20_000
+
+// Why: the host keeps a settled create's dedupe record for WORKTREE_CREATE_DEDUPE_TTL_MS
+// after it resolves; a replay that lands later misses it and the host's suffix loop
+// builds a SECOND worktree — and for folder workspaces a second one with the SAME name
+// and no collision check at all. So what bounds a safe replay is not how long the create
+// ran, but how STALE the client's knowledge is: the worst case between the host losing a
+// response and the client noticing. A dead socket is detected by the liveness watchdog
+// within one idle period plus its missed-probe budget, so that is the staleness ceiling
+// for any drop the transport actually reports.
+const WORKTREE_CREATE_AMBIGUITY_DETECTION_CEILING_MS =
+  LIVENESS_IDLE_MS + MISSED_PROBE_LIMIT * LIVENESS_PROBE_TIMEOUT_MS
+// What is left of the host's record once that detection latency is spent. The reconnect
+// wait plus any further replay has to fit inside it.
+export const WORKTREE_CREATE_AMBIGUOUS_REPLAY_WINDOW_MS =
+  WORKTREE_CREATE_DEDUPE_TTL_MS - WORKTREE_CREATE_AMBIGUITY_DETECTION_CEILING_MS
+export const WORKTREE_CREATE_AMBIGUOUS_RECONNECT_WAIT_MS =
+  WORKTREE_CREATE_AMBIGUOUS_REPLAY_WINDOW_MS
 
 export type CreateWorktreeWithNameRetryArgs = {
   client: RpcClient
@@ -105,6 +124,9 @@ async function sendWorktreeCreateResilient(
 ): Promise<RpcResponse> {
   let migrationRetry = 0
   let ambiguousRetry = 0
+  // Anchored at the FIRST ambiguity, not at the send: a create legitimately runs for
+  // minutes, and the host's record only starts ticking once it resolves.
+  let replayDeadlineAt: number | null = null
   for (;;) {
     try {
       return await client.sendRequest('worktree.create', params, {
@@ -126,12 +148,32 @@ async function sendWorktreeCreateResilient(
       if (!isRpcDeliveryUnknown(error) || ambiguousRetry >= WORKTREE_CREATE_AMBIGUOUS_MAX_RETRIES) {
         throw error
       }
+      // Why: every transport path that reports a *drop* leaves 'connected' before the
+      // rejection reaches us (rpc-client.ts:675/695/1213 set state first or reject via
+      // queueMicrotask; the relay's fail() publishes synchronously). So still being
+      // 'connected' here means the socket was healthy the whole time and only the
+      // response went missing — the request-timeout path, which surfaces after
+      // WORKTREE_CREATE_TIMEOUT_MS. That says nothing about when the host actually
+      // resolved, so the dedupe record may be long gone and a replay would build a
+      // second worktree instead of reconciling. Fail the create instead.
+      if (client.getState() === 'connected') {
+        throw error
+      }
+      replayDeadlineAt ??= Date.now() + WORKTREE_CREATE_AMBIGUOUS_REPLAY_WINDOW_MS
+      const remainingWindowMs = replayDeadlineAt - Date.now()
+      if (remainingWindowMs <= 0) {
+        throw error
+      }
       ambiguousRetry += 1
       // Why: unlike a cutover, no replacement session exists yet — resending now
       // would just hit the dead one, so wait for the transport to come back and
-      // surface the original ambiguity if it does not.
+      // surface the original ambiguity if it does not. Clamped to the window so the
+      // wait itself cannot carry the replay past the host's record.
       if (
-        !(await waitForRpcClientReconnected(client, WORKTREE_CREATE_AMBIGUOUS_RECONNECT_WAIT_MS))
+        !(await waitForRpcClientReconnected(
+          client,
+          Math.min(WORKTREE_CREATE_AMBIGUOUS_RECONNECT_WAIT_MS, remainingWindowMs)
+        ))
       ) {
         throw error
       }

--- a/mobile/src/tasks/worktree-create-retry.ts
+++ b/mobile/src/tasks/worktree-create-retry.ts
@@ -1,5 +1,7 @@
 import type { RpcClient } from '../transport/rpc-client'
 import type { RpcResponse, RpcSuccess } from '../transport/types'
+import { isRpcDeliveryUnknown } from '../transport/rpc-delivery-ambiguity'
+import { waitForRpcClientReconnected } from '../transport/rpc-client-reconnect-wait'
 import { isLogicalClientCutoverError } from '../transport/stable-logical-rpc-client'
 import {
   CLIENT_WORKTREE_CREATE_MAX_ATTEMPTS,
@@ -23,6 +25,19 @@ export type WorktreeCreateResult = { worktreeId: string; name: string } | { erro
 // instead of surfacing "RPC interrupted by connection migration" with the
 // worktree silently created.
 const WORKTREE_CREATE_CUTOVER_MAX_RETRIES = 5
+
+// Why: a connection migration is not the only way a create goes delivery-ambiguous.
+// A plain socket close (cellular flap, relay drop, the phone backgrounding and the
+// supervisor suspending a billed relay splice) rejects the in-flight frame as
+// delivery-unknown with no generation bump, and create holds the longest budget of
+// any mobile RPC — 10 minutes of clone/fetch/setup — so it is the likeliest request
+// to be caught by one. Surfacing that as a failure is wrong: the host may well have
+// finished the worktree. Replay on the same clientMutationId instead.
+const WORKTREE_CREATE_AMBIGUOUS_MAX_RETRIES = 2
+// Why: the host drops a completed create's dedupe record 60s after it resolves, so
+// keep the whole replay window comfortably inside that or a replay lands as a fresh
+// create and suffixes a duplicate. An in-flight create is deduped without any TTL.
+const WORKTREE_CREATE_AMBIGUOUS_RECONNECT_WAIT_MS = 20_000
 
 export type CreateWorktreeWithNameRetryArgs = {
   client: RpcClient
@@ -78,28 +93,48 @@ export async function createWorktreeWithNameRetry(
   return { error: lastError ?? 'Failed to create workspace' }
 }
 
-// Sends worktree.create, re-issuing on a connection-migration cutover only. The
-// shared clientMutationId in `params` keeps the retry idempotent host-side.
+// Sends worktree.create, re-issuing whenever the request went delivery-ambiguous —
+// the frame reached the wire but no response came back, so the host may already have
+// built the worktree. The shared clientMutationId in `params` keeps the retry
+// idempotent host-side. A definite failure (never sent, or a server error response)
+// is returned to the caller untouched.
 async function sendWorktreeCreateResilient(
   client: RpcClient,
   params: Record<string, unknown>,
   supportsIdempotentCutoverRetry: boolean
 ): Promise<RpcResponse> {
-  for (let migrationRetry = 0; ; migrationRetry += 1) {
+  let migrationRetry = 0
+  let ambiguousRetry = 0
+  for (;;) {
     try {
       return await client.sendRequest('worktree.create', params, {
         timeoutMs: WORKTREE_CREATE_TIMEOUT_MS
       })
     } catch (error) {
+      if (!supportsIdempotentCutoverRetry) {
+        throw error
+      }
+      if (isLogicalClientCutoverError(error)) {
+        if (migrationRetry >= WORKTREE_CREATE_CUTOVER_MAX_RETRIES) {
+          throw error
+        }
+        migrationRetry += 1
+        // Why: LogicalClientCutoverError is raised only after migrateTo installs an
+        // authenticated replacement, so retry immediately instead of adding UI lag.
+        continue
+      }
+      if (!isRpcDeliveryUnknown(error) || ambiguousRetry >= WORKTREE_CREATE_AMBIGUOUS_MAX_RETRIES) {
+        throw error
+      }
+      ambiguousRetry += 1
+      // Why: unlike a cutover, no replacement session exists yet — resending now
+      // would just hit the dead one, so wait for the transport to come back and
+      // surface the original ambiguity if it does not.
       if (
-        !supportsIdempotentCutoverRetry ||
-        !isLogicalClientCutoverError(error) ||
-        migrationRetry >= WORKTREE_CREATE_CUTOVER_MAX_RETRIES
+        !(await waitForRpcClientReconnected(client, WORKTREE_CREATE_AMBIGUOUS_RECONNECT_WAIT_MS))
       ) {
         throw error
       }
-      // Why: LogicalClientCutoverError is raised only after migrateTo installs an
-      // authenticated replacement, so retry immediately instead of adding UI lag.
     }
   }
 }

--- a/mobile/src/transport/mobile-relay-rpc-session.ts
+++ b/mobile/src/transport/mobile-relay-rpc-session.ts
@@ -111,6 +111,7 @@ export function connectMobileRelayRpcSession(args: {
     getState: () => state,
     getReconnectAttempt: () => 0,
     getLastConnectedAt: () => lastConnectedAt,
+    getLastInboundAt: () => livenessWatchdog.getLastInboundAt() || null,
     onStateChange(listener) {
       stateListeners.add(listener)
       return () => stateListeners.delete(listener)

--- a/mobile/src/transport/rpc-client-reconnect-wait.test.ts
+++ b/mobile/src/transport/rpc-client-reconnect-wait.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { RpcClient } from './rpc-client'
+import type { ConnectionState } from './types'
+import { waitForRpcClientReconnected } from './rpc-client-reconnect-wait'
+
+// notifyDuringSubscribe models a client that fires the listener synchronously from
+// onStateChange — the branch that has to survive `unsubscribe` not being assigned yet.
+function fakeClient(
+  initial: ConnectionState,
+  options: { notifyDuringSubscribe?: ConnectionState } = {}
+): { client: RpcClient; set: (next: ConnectionState) => void; listenerCount: () => number } {
+  let state = initial
+  const listeners = new Set<(next: ConnectionState) => void>()
+  const client = {
+    getState: () => state,
+    onStateChange: (listener: (next: ConnectionState) => void) => {
+      listeners.add(listener)
+      if (options.notifyDuringSubscribe) {
+        state = options.notifyDuringSubscribe
+        listener(state)
+      }
+      return () => listeners.delete(listener)
+    }
+  } as unknown as RpcClient
+  return {
+    client,
+    set: (next) => {
+      state = next
+      // Safe to delete during iteration: finish() unsubscribes the current listener.
+      for (const listener of listeners) {
+        listener(next)
+      }
+    },
+    listenerCount: () => listeners.size
+  }
+}
+
+describe('waitForRpcClientReconnected', () => {
+  it('resolves immediately when the transport is already connected', async () => {
+    const { client, listenerCount } = fakeClient('connected')
+    await expect(waitForRpcClientReconnected(client, 10_000)).resolves.toBe(true)
+    // No subscription at all on the fast path, so nothing to leak.
+    expect(listenerCount()).toBe(0)
+  })
+
+  it('resolves once the transport comes back, and unsubscribes', async () => {
+    const { client, set, listenerCount } = fakeClient('reconnecting')
+    const pending = waitForRpcClientReconnected(client, 10_000)
+    expect(listenerCount()).toBe(1)
+    set('connected')
+    await expect(pending).resolves.toBe(true)
+    expect(listenerCount()).toBe(0)
+  })
+
+  it('gives up at the timeout and unsubscribes', async () => {
+    vi.useFakeTimers()
+    try {
+      const { client, listenerCount } = fakeClient('reconnecting')
+      const pending = waitForRpcClientReconnected(client, 10_000)
+      await vi.advanceTimersByTimeAsync(10_000)
+      await expect(pending).resolves.toBe(false)
+      expect(listenerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+    // Generous: advanceTimersByTimeAsync yields through REAL macrotasks between ticks,
+    // so vitest's default 5s real-time budget is reachable on a loaded runner.
+  }, 30_000)
+
+  it('does not wait out the timeout when the pairing is already revoked', async () => {
+    const { client, listenerCount } = fakeClient('auth-failed')
+    await expect(waitForRpcClientReconnected(client, 10_000)).resolves.toBe(false)
+    expect(listenerCount()).toBe(0)
+  })
+
+  it('does not wait out the timeout when the pairing is revoked mid-wait', async () => {
+    vi.useFakeTimers()
+    try {
+      const { client, set, listenerCount } = fakeClient('reconnecting')
+      const pending = waitForRpcClientReconnected(client, 10_000)
+      set('auth-failed')
+      await expect(pending).resolves.toBe(false)
+      expect(listenerCount()).toBe(0)
+      // Nothing left armed that could fire after the caller moved on.
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+    // Generous: advanceTimersByTimeAsync yields through REAL macrotasks between ticks,
+    // so vitest's default 5s real-time budget is reachable on a loaded runner.
+  }, 30_000)
+
+  it('tears down cleanly when the state change fires synchronously during subscribe', async () => {
+    vi.useFakeTimers()
+    try {
+      const { client, listenerCount } = fakeClient('reconnecting', {
+        notifyDuringSubscribe: 'connected'
+      })
+      await expect(waitForRpcClientReconnected(client, 10_000)).resolves.toBe(true)
+      expect(listenerCount()).toBe(0)
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+    // Generous: advanceTimersByTimeAsync yields through REAL macrotasks between ticks,
+    // so vitest's default 5s real-time budget is reachable on a loaded runner.
+  }, 30_000)
+})

--- a/mobile/src/transport/rpc-client-reconnect-wait.ts
+++ b/mobile/src/transport/rpc-client-reconnect-wait.ts
@@ -1,0 +1,46 @@
+import type { RpcClient } from './rpc-client'
+
+// Why: after a socket drop the direct client parks a send in waitForConnected, but a
+// relay session rejects it outright ('relay session not connected') until the supervisor
+// migrates a replacement in. A replay that fires the instant the drop lands therefore
+// burns its budget on the dead session, so callers that mean to re-issue an idempotent
+// request wait for the transport to come back first.
+//
+// Unlike waitForAuthenticated, intermediate 'disconnected'/'reconnecting' states are the
+// expected path here, not a failure — only the timeout ends the wait unsuccessfully.
+export function waitForRpcClientReconnected(
+  client: RpcClient,
+  timeoutMs: number
+): Promise<boolean> {
+  if (client.getState() === 'connected') {
+    return Promise.resolve(true)
+  }
+  return new Promise((resolve) => {
+    let settled = false
+    let unsubscribe: (() => void) | null = null
+    // Armed before subscribing so a synchronous notification during registration
+    // still finds a timer to clear.
+    const timer = setTimeout(() => finish(false), timeoutMs)
+    unsubscribe = client.onStateChange((state) => {
+      if (state === 'connected') {
+        finish(true)
+      }
+    })
+    if (settled) {
+      // The notification fired inside onStateChange, before we held the handle.
+      unsubscribe()
+      unsubscribe = null
+    }
+
+    function finish(reconnected: boolean): void {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timer)
+      unsubscribe?.()
+      unsubscribe = null
+      resolve(reconnected)
+    }
+  })
+}

--- a/mobile/src/transport/rpc-client-reconnect-wait.ts
+++ b/mobile/src/transport/rpc-client-reconnect-wait.ts
@@ -7,13 +7,18 @@ import type { RpcClient } from './rpc-client'
 // request wait for the transport to come back first.
 //
 // Unlike waitForAuthenticated, intermediate 'disconnected'/'reconnecting' states are the
-// expected path here, not a failure — only the timeout ends the wait unsuccessfully.
+// expected path here, not a failure. Only a revoked pairing and the timeout end the wait
+// unsuccessfully.
 export function waitForRpcClientReconnected(
   client: RpcClient,
   timeoutMs: number
 ): Promise<boolean> {
-  if (client.getState() === 'connected') {
+  const state = client.getState()
+  if (state === 'connected') {
     return Promise.resolve(true)
+  }
+  if (state === 'auth-failed') {
+    return Promise.resolve(false)
   }
   return new Promise((resolve) => {
     let settled = false
@@ -24,6 +29,10 @@ export function waitForRpcClientReconnected(
     unsubscribe = client.onStateChange((state) => {
       if (state === 'connected') {
         finish(true)
+      } else if (state === 'auth-failed') {
+        // Revoked pairing never reaches 'connected', so waiting out the timeout only
+        // delays the error the caller is going to surface anyway.
+        finish(false)
       }
     })
     if (settled) {

--- a/mobile/src/transport/rpc-client.ts
+++ b/mobile/src/transport/rpc-client.ts
@@ -111,6 +111,10 @@ export type RpcClient = {
   getReconnectAttempt: () => number
   // Last 'connected' timestamp (ms epoch); null = never connected. Lets the UI tell "never reachable" from "transient blip".
   getLastConnectedAt: () => number | null
+  // Wall-clock stamp of the last inbound frame on the current session, or null when the
+  // transport can't vouch for one. Optional so older/foreign RpcClient shapes stay valid;
+  // callers must treat absent/null as "unknown" and fall back to a safe bound.
+  getLastInboundAt?: () => number | null
   onStateChange: (listener: (state: ConnectionState) => void) => () => void
   // Why: app-resume hook — iOS/Android can kill the TCP path while backgrounded; call on AppState 'active' to recover.
   // The reason routes relay handling (probe vs replace); the direct socket probes regardless.
@@ -1148,6 +1152,10 @@ export function connect(
 
     getLastConnectedAt(): number | null {
       return lastConnectedAt
+    },
+
+    getLastInboundAt(): number | null {
+      return livenessWatchdog.getLastInboundAt() || null
     },
 
     onStateChange(listener: (state: ConnectionState) => void): () => void {

--- a/mobile/src/transport/rpc-session-liveness-watchdog.ts
+++ b/mobile/src/transport/rpc-session-liveness-watchdog.ts
@@ -52,6 +52,13 @@ export class RpcSessionLivenessWatchdog {
     this.armIdle(identity)
   }
 
+  // Wall-clock stamp of the last frame that actually arrived; 0 before the first
+  // start(). Unlike a timer deadline this survives a JS suspension, so callers can
+  // tell how stale their knowledge of the peer really is.
+  getLastInboundAt(): number {
+    return this.lastInboundAt
+  }
+
   noteAuthenticatedInbound(identity: RpcSessionIdentity): void {
     if (this.identity !== identity) {
       return

--- a/mobile/src/transport/stable-logical-rpc-client.ts
+++ b/mobile/src/transport/stable-logical-rpc-client.ts
@@ -160,6 +160,7 @@ export function createStableLogicalRpcClient(
     getState: () => state,
     getReconnectAttempt: () => connectionPath.reconnectAttempt(activeSession.getReconnectAttempt()),
     getLastConnectedAt: () => activeSession.getLastConnectedAt(),
+    getLastInboundAt: () => activeSession.getLastInboundAt?.() ?? null,
     onStateChange(listener) {
       stateListeners.add(listener)
       return () => stateListeners.delete(listener)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1077,6 +1077,7 @@ import {
   isGeneratedWorktreeCreateName,
   WORKTREE_CREATE_MAX_SUFFIX_ATTEMPTS
 } from '../worktree-create-candidates'
+import { WORKTREE_CREATE_DEDUPE_TTL_MS } from '../../shared/new-workspace/worktree-create-retry-policy'
 import {
   failedWorktreeCreationNeedsRetirement,
   getRetiredNameRegistryForRepo,
@@ -2015,8 +2016,9 @@ function getAgentLaunchPlatformForRepo(
 const MOBILE_TERMINAL_CREATE_RESULT_TTL_MS = 60_000
 // Why: same idempotency window for worktree.create — a phone whose create was
 // interrupted by a connection migration retries with the same clientMutationId
-// and reuses the just-created worktree instead of spawning a duplicate.
-const WORKTREE_CREATE_RESULT_TTL_MS = 60_000
+// and reuses the just-created worktree instead of spawning a duplicate. Shared with
+// the mobile client so its replay budget is sized against the real window.
+const WORKTREE_CREATE_RESULT_TTL_MS = WORKTREE_CREATE_DEDUPE_TTL_MS
 const FOREGROUND_AGENT_WRAPPER_RETRY_INTERVAL_MS = 150
 const FOREGROUND_AGENT_WRAPPER_RETRY_TIMEOUT_MS = 6_500
 const BRACKETED_PASTE_BEGIN = '\x1b[200~'

--- a/src/shared/new-workspace/worktree-create-retry-policy.ts
+++ b/src/shared/new-workspace/worktree-create-retry-policy.ts
@@ -65,3 +65,10 @@ export function getGeneratedWorktreeCreateRetryCandidate(
 export function isRetryableWorktreeCreateConflict(message: string): boolean {
   return RETRYABLE_WORKTREE_CREATE_CONFLICT_PATTERNS.some((pattern) => pattern.test(message))
 }
+
+// Why: the host drops a *settled* worktree.create dedupe record this long after it
+// resolves, so a client replaying an idempotent create must land inside the window
+// or the replay misses the record and the host's suffix loop builds a second
+// worktree. Shared so the client's replay budget can be asserted against it instead
+// of assuming a value that lives in another process.
+export const WORKTREE_CREATE_DEDUPE_TTL_MS = 60_000


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​580 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​576 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​173 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​162 |

<!-- /orca-pr-loc -->

## ELI5

You tap **Create** on your phone. The phone sends the request, the Mac starts building the
worktree — and then your signal blips. The phone never hears the answer, so it gives up and
shows you an error, even though the Mac may have finished the job just fine.

The phone already knows how to handle one flavour of this (a relay↔direct hand-off) by asking
again with the same receipt number, which the Mac recognises so it hands back the worktree it
already built instead of making a second one. It just never did that for the far more common
flavour: a plain dropped socket. Now it does.

## What Changed

`mobile/src/tasks/worktree-create-retry.ts` — `sendWorktreeCreateResilient` now replays on
**any** delivery-ambiguous rejection, not only `LogicalClientCutoverError`:

- Cutover: unchanged — replay immediately, budget 5 (`migrateTo` has already installed an
  authenticated replacement).
- Delivery-unknown (`isRpcDeliveryUnknown`): wait for the client to reach `connected` again
  (bounded, 20s), then replay. Budget 2.
- Anything else — a definite send failure, or an `ok: false` server response — is untouched and
  flows out to the existing name-collision loop / the modal, exactly as before.

The gate is the same one the cutover replay already uses: it only fires when the host advertises
`worktree.create-idempotency.v1`, which is the only case where a `clientMutationId` was stamped
on the params at all.

`mobile/src/transport/rpc-client-reconnect-wait.ts` (new, 46 lines) —
`waitForRpcClientReconnected(client, timeoutMs)`. Resolves `true` on `connected`, `false` on
timeout. It deliberately does **not** reuse `waitForAuthenticated`: that one rejects on
`disconnected`, which here is the expected intermediate state, not a failure.

## Why

**The defect.** `sendWorktreeCreateResilient`'s catch is the real predicate, and its production
inputs are these:

| production source | error | marked delivery-unknown? | replayed before this PR? |
|---|---|---|---|
| `migrateTo` (`stable-logical-rpc-client.ts:265`) | `RPC interrupted by connection migration` | — | **yes** |
| socket close → reconnect (`rpc-client.ts:695`) | `Connection interrupted` | yes | no |
| intentional close (`rpc-client.ts:675`) | `Connection closed` | yes | no |
| `client.close()` (`rpc-client.ts:1213`) | `Client closed` | yes | no |
| request timeout (`rpc-client.ts:1043`) | `Request timed out: worktree.create` | yes | no |
| relay session `fail()` (`mobile-relay-rpc-session.ts:286`) | link error | yes | no |
| relay RPC timeout (`mobile-relay-rpc-session.ts:190`) | `relay RPC timed out: worktree.create` | yes | no |
| frame never written (`rpc-client.ts:1060`) | `Connection interrupted` | **no** | no — correct, definite failure |

Only the first row was handled. Every other ambiguous row surfaced in the New Workspace modal as
`setError(e.message)` for a create the host may have completed.

**Why `worktree.create` specifically.** It carries `WORKTREE_CREATE_TIMEOUT_MS` = 10 minutes, the
longest budget of any mobile RPC, because a create legitimately spans a fetch, a
`git worktree add`, symlink/shared-dir/`.worktreeinclude` work, and setup-runner generation. It is
by a wide margin the mobile request most likely to still be pending when a socket dies — which is
what "sometimes" looks like from the user's side.

**Why the replay is safe.** The machinery already exists and is unchanged by this PR:
`worktree.create` params carry a `clientMutationId`, and
`OrcaRuntimeService.dedupeWorktreeCreate` (`orca-runtime.ts:28436`) keys
`${repoSelector}\0${clientMutationId}` on a process-global map. A replay that lands while the
create is still running returns the *same in-flight promise* (no TTL involved at all); one that
lands after it resolved returns the cached result for `WORKTREE_CREATE_RESULT_TTL_MS` = 60s.
Failures are dropped from the map immediately so a genuine retry starts fresh.

**Why the reconnect wait, rather than replaying immediately.** The direct client parks a send in
`waitForConnected`, but `MobileRelayRpcSession.sendRpc` rejects outright with
`relay session not connected` once `fail()` has latched `closed`, and stays that way until the
supervisor dials a replacement and calls `migrateTo`. Replaying the instant the drop lands would
burn the whole budget against the dead session in microseconds and end on a *worse* error string.
Waiting for `connected` also means the replay is issued on the post-`migrateTo` `activeSession`.

**Why the budget is 2 × 20s and not 5.** The host drops a *completed* create's dedupe record 60s
after it resolves. Capping the replay window at ~40s keeps it inside that, so a replay cannot
outlive the record it is meant to match and silently suffix a `-2` duplicate. (The in-flight case,
which is the dominant one for a slow create, has no TTL and is covered regardless.)

## Linked Issue

No GitHub issue — this came in as a Discord report from **dragonfire1119** (iOS TestFlight):
*"Also creating a worktree fails sometimes."* Filed as part of the mobile user-report triage
batch; happy to open a tracking issue if preferred.

## Visual Proof

`N/A` — no pixels change. The only user-visible difference is a create that previously ended on a
transport error string now completing, and the Create spinner staying up for the reconnect wait
(bounded at 20s per replay) instead of failing instantly.

## Testing

`mobile/src/tasks/worktree-create-retry.test.ts` (+3 behaviour tests, +1 guard). The scripted
client gained a controllable connection state so a test can model what production actually does:
a socket close both rejects the pending frame as delivery-unknown *and* drops the client off
`connected`, in that order.

### RED — `git checkout HEAD~1 -- mobile/src/tasks/worktree-create-retry.ts`, new fix file removed

```
 RUN  v4.1.9 .../mobile

 ❯ src/tasks/worktree-create-retry.test.ts (12 tests | 2 failed) 38ms
     × replays a delivery-ambiguous socket drop with the SAME key once the transport returns 11ms
     × gives up after the delivery-ambiguity replay budget and rethrows 4ms

 FAIL  ... > replays a delivery-ambiguous socket drop with the SAME key once the transport returns
AssertionError: promise rejected "Error: Connection interrupted" instead of resolving
 ❯ src/tasks/worktree-create-retry.test.ts:260:26
Caused by: Error: Connection interrupted

 FAIL  ... > gives up after the delivery-ambiguity replay budget and rethrows
AssertionError: expected [ { method: 'worktree.create', …(1) } ] to have a length of 3 but got 1

- Expected
+ Received

- 3
+ 1

 Test Files  1 failed (1)
      Tests  2 failed | 10 passed (12)
```

### GREEN — with the fix

```
 RUN  v4.1.9 .../mobile

 Test Files  1 passed (1)
      Tests  12 passed (12)
   Duration  676ms
```

### Honest note on the four new tests

- `replays a delivery-ambiguous socket drop with the SAME key once the transport returns` — **RED
  → GREEN.** This is the repro. It also asserts only 1 attempt has been made while the transport
  is down, so it fails if the replay fires onto the dead session.
- `gives up after the delivery-ambiguity replay budget and rethrows` — **RED → GREEN** (1 attempt
  before, 3 after).
- `does not replay a delivery-ambiguous drop when the host lacks idempotency support` — passes
  before *and* after. It is a guard on the capability gate, not a repro, and only becomes
  load-bearing once the replay exists.
- `surfaces the original ambiguity when the transport never comes back` — same: vacuously true
  pre-fix. It pins that the new wait cannot park the Create spinner forever.

The pre-existing `does not treat an ordinary transport error as a cutover` test becomes
load-bearing here: it uses an **unmarked** `Error`, so it now proves the replay keys off the
`markRpcDeliveryUnknown` marker rather than the message text.

### Full suites

```
$ cd mobile && npx vitest run --config vitest.config.ts src/tasks src/transport
 Test Files  111 passed (111)
      Tests  810 passed | 3 skipped (813)
```

`npx oxlint --config .oxlintrc.json` and `npx oxfmt --check` clean on all three files.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Manual verification was code-level, not a live phone: the production input table above was read
off the throw sites, and `mobile/src/transport/rpc-client-delivery-ambiguity.test.ts` (4 tests,
green) already drives the *real* `rpc-client` and proves it marks socket-drop / client-close /
timeout as delivery-unknown while leaving a never-written frame unmarked. I did **not** reproduce
the drop on a physical iOS device against a live relay.

## AI Disclosure

Claude Opus 5.

## Review

**Security** — no new RPC, no new params, no new capability. A replay carries the identical
`clientMutationId` the host already accepts and dedupes; nothing new crosses the wire.

**Cross-platform** — client-side only, in shared React Native code. No paths, no shells, no
platform branches. Identical on iOS and Android; iOS is likelier to hit it because the supervisor
suspends a billed relay splice on background (`mobile-endpoint-supervisor.ts:182`) and iOS
backgrounds more aggressively.

**Remote SSH** — helps here specifically. An SSH-backed repo makes creation slower (remote fetch,
remote `git worktree add`, remote setup-runner write), which widens the window a socket drop can
land in. The host-side dedupe is above the local/remote split in `worktree.create`'s handler, so
both `createLocalWorktree` and `createRemoteWorktree` are covered identically. Folder workspaces
are unaffected — they do not route through `worktree.create`.

**Mobile** — the only surface touched. Worst added latency is 20s per replay, and only after a
create has *already* been interrupted; the alternative today is an immediate false failure.

**Backwards compatibility** — no wire change, so `docs/reference/remote-wire-compatibility.md`
has nothing to bite on. Against a host that does not advertise
`worktree.create-idempotency.v1`, `supportsIdempotentCutoverRetry` is false, no
`clientMutationId` is stamped, and the very first branch in the catch rethrows — behaviour is
byte-identical to today. Covered by the `...when the host lacks idempotency support` test.

**Performance** — no work on the happy path. The reconnect wait is one `onStateChange`
subscription and one `setTimeout`, both torn down on either exit.

**Known worst case, stated plainly** — `WORKTREE_CREATE_TIMEOUT_MS` is per attempt, and a
`Request timed out` is itself delivery-unknown, so a create that keeps timing out on a live
socket can now spend 3 × 10min instead of 1 × 10min before failing. This is a pre-existing
property of the design, not one this PR introduces: the cutover path already allows 6 × 10min.
Reaching it requires a create that is genuinely still running past 20 minutes host-side (the
replay hits the host's in-flight dedupe entry, so it waits on the *same* create rather than
starting another). I chose not to thread a single wall-clock deadline through
`sendWorktreeCreateResilient` here because that changes the cutover path's timing too and is a
separate change; flagging it rather than folding it in.

### Second defect found, deliberately NOT folded in

The identical gap exists at four other mobile call sites that check `isLogicalClientCutoverError`
without `isRpcDeliveryUnknown`: `worktree-create-capability.ts:48`,
`home-host-worktree-fetch.ts:71`, `use-quick-commands.ts:62`, `mobile-clipboard-image.ts:116`.
The first is the most interesting — a single transient `status.get` failure latches
`UNSUPPORTED_CAPABILITIES` into a per-client promise ref that is only reset when the `client`
identity changes, permanently disabling idempotent create replay for that session. Separate
defect, separate PR.

Also noted while tracing but out of scope: `createLocalWorktree`'s post-`git worktree add` steps
(`createWorktreeLinkedPaths`, `resolveWorktreeSharedDirectories`, `createWorktreeSharedPaths`,
`createWorktreeCopiedPaths`, and the `Worktree created but not found in listing` throw) are not
guarded the way the setup-runner and default-tabs steps are, so a throw there fails the RPC with
the worktree already on disk. That is a genuine half-created-worktree class, host-side, and wants
its own PR.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

Reproduced as a deterministic unit test rather than on a live rig; see the honest note in Testing
for exactly which of the four new tests are RED→GREEN and which are guards.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local
      preferred) — ran the mobile `src/tasks` + `src/transport` suites, mobile `tsc --noEmit`,
      oxlint and oxfmt on the changed files; a full repo typecheck/build was left to CI.

## Author

- X / Twitter: @BrennanKB5
