### PR TITLE
fix(terminal): make remote-host take-back release the phone-fit lock

### DIFF
--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -16771,8 +16771,10 @@ export class OrcaRuntimeService {
   // Returns the post-condition "no fit-override remains held" (#7588): `true`
   // when it cleared a held override OR nothing was held to begin with, `false`
   // only when a restore was attempted and the resize failed (override rolled
-  // back, still held). reclaimTerminalForDesktop gates its driver/mode
-  // transitions on this; other callers ignore it.
+  // back, still held). Informational for every caller today —
+  // reclaimTerminalForDesktop deliberately does NOT gate on it, because an
+  // explicit take-back must drop the lock even when the resize cannot
+  // converge. Do not reinstate a convergence gate there.
   async applyMobileDisplayMode(ptyId: string): Promise<boolean> {
     const mode = this.getMobileDisplayMode(ptyId)
     const inner = this.mobileSubscribers.get(ptyId)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -15941,7 +15941,10 @@ export class OrcaRuntimeService {
       // in passive desktop-watch mode.
       this.setMobileDisplayMode(ptyId, 'auto')
       if (this.hasRemoteDesktopLayoutState(ptyId)) {
-        return this.applyRemoteDesktopLayout(ptyId)
+        // Why: the lock is already released above, so this re-layout is
+        // best-effort. Reporting its `ok` would tell the desktop "nothing was
+        // reclaimed" and cost the caller its post-take-back refit and focus.
+        await this.applyRemoteDesktopLayout(ptyId)
       }
       return true
     }
@@ -15957,14 +15960,14 @@ export class OrcaRuntimeService {
         clearTimeout(softLeaver.timer)
         this.pendingSoftLeavers.delete(ptyId)
       }
-      const priorDriver = this.getDriver(ptyId)
+      // Why: applyRemoteDesktopLayout no-ops while the driver still reads mobile.
       this.setDriver(ptyId, { kind: 'idle' })
-      const converged = await this.applyRemoteDesktopLayout(ptyId)
-      if (!converged) {
-        this.setDriver(ptyId, priorDriver)
-        return false
-      }
-      this.setDriver(ptyId, { kind: 'desktop' })
+      // Why: best-effort, like the local held branch below. A host whose resize
+      // keeps failing (dropped SSH/WSL provider, exited PTY) would otherwise
+      // roll the lock back and leave the banner stranded, making every retry a
+      // no-op — the one branch that broke this method's release guarantee.
+      await this.applyRemoteDesktopLayout(ptyId)
+      this.releaseDesktopTakeBack(ptyId)
       this.setMobileDisplayMode(ptyId, 'auto')
       return true
     }

--- a/src/main/runtime/remote-desktop-driver.test.ts
+++ b/src/main/runtime/remote-desktop-driver.test.ts
@@ -545,7 +545,7 @@ describe('remote desktop viewer width driver', () => {
     await expect(runtime.reclaimTerminalForDesktop('pty-1')).resolves.toBe(true)
 
     expect(runtime.getTerminalFitOverride('pty-1')).toBeNull()
-    expect(runtime.getDriver('pty-1').kind).not.toBe('mobile')
+    expect(runtime.getDriver('pty-1')).toEqual({ kind: 'desktop' })
     expect(fitOverrideEvents.slice(notifierBefore).some((e) => e.mode === 'desktop-fit')).toBe(true)
     // A second click must not be needed, and must stay idempotent.
     await expect(runtime.reclaimTerminalForDesktop('pty-1')).resolves.toBe(false)

--- a/src/main/runtime/remote-desktop-driver.test.ts
+++ b/src/main/runtime/remote-desktop-driver.test.ts
@@ -84,11 +84,16 @@ function createRuntime(mobileAutoRestoreFitMs: number | null = 5_000) {
   const resizeCalls: { ptyId: string; cols: number; rows: number }[] = []
   const driverEvents: { ptyId: string; driver: { kind: string; clientId?: string } }[] = []
   const fitOverrideEvents: { ptyId: string; mode: string; cols: number; rows: number }[] = []
+  let resizeSucceeds = true
   runtime.setPtyController({
     write: () => true,
     kill: () => true,
     getForegroundProcess: async () => null,
     resize: (ptyId, cols, rows) => {
+      // Why: the production controller returns false when the provider throws — a dropped SSH/WSL provider or an exited PTY.
+      if (!resizeSucceeds) {
+        return false
+      }
       resizeCalls.push({ ptyId, cols, rows })
       ptySizes.set(ptyId, { cols, rows })
       return true
@@ -116,7 +121,10 @@ function createRuntime(mobileAutoRestoreFitMs: number | null = 5_000) {
     runtime,
     driverEvents,
     fitOverrideEvents,
-    resizeCalls
+    resizeCalls,
+    setResizeSucceeds: (next: boolean) => {
+      resizeSucceeds = next
+    }
   }
 }
 
@@ -518,5 +526,44 @@ describe('remote desktop viewer width driver', () => {
     // A fresh viewer on the same id re-establishes suppression cleanly (no stale set).
     await runtime.updateRemoteDesktopViewer('pty-1', 'sub-B', 'viewer-B', 100, 40)
     expect(runtime.isPtyResizeDrivenRemotely('pty-1')).toBe(true)
+  })
+
+  it('held phone-fit take-back releases the lock when the remote reclaim resize fails', async () => {
+    // Why: the local held branch releases unconditionally (mobile-presence-lock.test.ts scenario 4).
+    // The remote branch rolled the lock back instead, so the banner survived and every retry was a no-op.
+    const { runtime, fitOverrideEvents, setResizeSucceeds } = createRuntime(null)
+    await runtime.updateRemoteDesktopViewer('pty-1', 'sub-A', 'viewer-A', 100, 30)
+    await runtime.handleMobileSubscribe('pty-1', 'phone-A', { cols: 45, rows: 20 })
+    await runtime.unregisterRemoteDesktopViewer('pty-1', 'sub-A')
+    runtime.onClientDisconnected('phone-A')
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(runtime.getTerminalFitOverride('pty-1')).toMatchObject({ mode: 'mobile-fit' })
+
+    setResizeSucceeds(false)
+    const notifierBefore = fitOverrideEvents.length
+
+    await expect(runtime.reclaimTerminalForDesktop('pty-1')).resolves.toBe(true)
+
+    expect(runtime.getTerminalFitOverride('pty-1')).toBeNull()
+    expect(runtime.getDriver('pty-1').kind).not.toBe('mobile')
+    expect(fitOverrideEvents.slice(notifierBefore).some((e) => e.mode === 'desktop-fit')).toBe(true)
+    // A second click must not be needed, and must stay idempotent.
+    await expect(runtime.reclaimTerminalForDesktop('pty-1')).resolves.toBe(false)
+  })
+
+  it('driving take-back reports success when the trailing remote layout cannot converge', async () => {
+    // Why: the lock is already released here, so returning false told the desktop renderer
+    // "nothing was reclaimed" and it skipped the post-take-back refit and focus.
+    const { runtime, setResizeSucceeds } = createRuntime()
+    await runtime.updateRemoteDesktopViewer('pty-1', 'sub-A', 'viewer-A', 100, 30)
+    await runtime.handleMobileSubscribe('pty-1', 'phone-A', { cols: 45, rows: 20 })
+    expect(runtime.getDriver('pty-1')).toEqual({ kind: 'mobile', clientId: 'phone-A' })
+
+    setResizeSucceeds(false)
+
+    await expect(runtime.reclaimTerminalForDesktop('pty-1')).resolves.toBe(true)
+
+    expect(runtime.getDriver('pty-1')).toEqual({ kind: 'desktop' })
+    expect(runtime.getTerminalFitOverride('pty-1')).toBeNull()
   })
 })

--- a/src/main/runtime/remote-desktop-driver.test.ts
+++ b/src/main/runtime/remote-desktop-driver.test.ts
@@ -566,4 +566,27 @@ describe('remote desktop viewer width driver', () => {
     expect(runtime.getDriver('pty-1')).toEqual({ kind: 'desktop' })
     expect(runtime.getTerminalFitOverride('pty-1')).toBeNull()
   })
+
+  it('take-back during the resubscribe grace still resizes the PTY off the phone grid', async () => {
+    // Why: both take-back tests above force the resize to fail, so nothing pinned that a
+    // converging remote reclaim reaches the host. A phone that unsubscribes cleanly holds
+    // driver=mobile for the 250ms resubscribe grace, and applyRemoteDesktopLayout no-ops on
+    // a mobile driver — so without the idle flip the lock drops and `true` is still reported
+    // while the PTY stays stranded at the phone grid.
+    const { runtime, resizeCalls } = createRuntime(null)
+    await runtime.updateRemoteDesktopViewer('pty-1', 'sub-A', 'viewer-A', 100, 30)
+    await runtime.handleMobileSubscribe('pty-1', 'phone-A', { cols: 45, rows: 20 })
+    runtime.handleMobileUnsubscribe('pty-1', 'phone-A')
+    // Inside the grace window on purpose: the driver still reads mobile here.
+    expect(runtime.getDriver('pty-1')).toEqual({ kind: 'mobile', clientId: 'phone-A' })
+    expect(runtime.getTerminalFitOverride('pty-1')).toMatchObject({ mode: 'mobile-fit' })
+    const resizesBefore = resizeCalls.length
+
+    await expect(runtime.reclaimTerminalForDesktop('pty-1')).resolves.toBe(true)
+
+    expect(runtime.getTerminalFitOverride('pty-1')).toBeNull()
+    expect(runtime.getDriver('pty-1')).toEqual({ kind: 'desktop' })
+    expect(resizeCalls.slice(resizesBefore)).toContainEqual({ ptyId: 'pty-1', cols: 100, rows: 30 })
+    expect(runtime.getTerminalSize('pty-1')).toEqual({ cols: 100, rows: 30 })
+  })
 })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​71 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​70 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​15 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 |

<!-- /orca-pr-loc -->

## ELI5

When your phone borrows a terminal, the desktop shows a banner with **"Take back this terminal" / "Take back all terminals"**. On a remote (SSH) host, if the resize that hands the terminal back to the desktop fails, the old code put the phone's lock *back on* and reported failure — so the banner never went away and clicking it again did nothing, forever. Now the take-back always releases, exactly like it already does on a local workspace.

## What Changed

`OrcaRuntimeService.reclaimTerminalForDesktop` — the two branches that run on a host with remote-desktop layout state (i.e. every SSH / remote-runtime terminal the desktop is streaming):

1. **Held phone-fit + remote layout state** — no longer rolls the driver back and returns `false` when `applyRemoteDesktopLayout` doesn't converge. The remote re-layout is now best-effort and the branch ends in `releaseDesktopTakeBack(ptyId)`, the same helper the local held branch uses, so the lock drops and a `desktop-fit` fit-override event is emitted on both channels.
2. **Active mobile subscriber + remote layout state** — no longer returns the trailing layout's `ok`. The lock is already released at that point, so it returns `true`.

Test-only: `remote-desktop-driver.test.ts`'s harness gains a `setResizeSucceeds` toggle (mirroring `mobile-presence-lock.test.ts`) plus the two regression tests.

No wire, IPC, RPC, or renderer changes.

## Why

`reclaimTerminalForDesktop`'s own contract comment says:

> explicit desktop take-back is a user command to reclaim input control NOW. […] this gesture **ALWAYS** drops the presence lock and banner. "Take back all terminals" reclaims several PTYs at once; a background pane whose desktop resize can't converge must not strand its banner on the other terminals. […] Returns `true` whenever there was a lock to reclaim, `false` only when there was nothing to reclaim.

Two existing tests pin that guarantee for the **local** paths:

- `mobile-presence-lock.test.ts` scenario 4 — *"held restore with a failing resize still releases and clears the override"*
- `mobile-presence-lock.test.ts` scenario 5 — *"active-subscriber take-back with a failing resize still releases the lock"* (comment: `"take back all terminals" guarantee`)

The **remote** branch was the one place that violated it. `applyRemoteDesktopLayout` returns `enqueueLayout(...).ok`, which is `false` when `ptyController.resize` returns `false` — and the production controller (`src/main/ipc/pty.ts:5924`) returns `false` whenever `getProviderForPty(ptyId).resize(...)` throws (dropped SSH/WSL provider, exited PTY, unknown id). On that path the branch restored the prior driver and returned `false`, leaving `terminalFitOverrides` populated. The renderer's banner keys off exactly that override (`getFitOverrideForPty(ptyId)?.mode === 'mobile-fit'`, `TerminalPane.tsx:3270`), so the banner stayed up and every retry re-entered the same branch and failed the same way.

The sibling (active-subscriber) branch already released the lock but returned the layout's `ok`. That value is the renderer's `restored` flag: `restorePaneTerminalFit` / `restoreAllTerminalFits` (`TerminalPane.tsx:2636-2667`) only call `scheduleRestoredTerminalRefit()` and `pane.terminal.focus()` when it's `true`, and `restoreTerminalFitsToDesktop` folds the batch with `results.some(Boolean)`. A remote take-back that had genuinely released was reporting "nothing was reclaimed" and skipping the desktop's refit + refocus.

### What this is *not*

- **Not GH #14321 / STA-4163.** That is a repaint bug: the phone leaves normally, geometry restores, and the buffer doesn't repaint until a scroll/resize. Here the reclaim itself is refused — the lock and the phone-fit override survive and the PTY is never resized at all. Different failure, different fix.
- **Not the "phantom mobile subscriber" lead.** Measured against the real `OrcaRuntimeService`: with presence registered and the stream gone, `reclaimTerminalForDesktop` still returns `true`, flips the driver to `desktop`, clears the override, and restores desktop dims. Phantom presence does not defeat take-back.

## Linked Issue

Fixes #

<!-- No issue filed for this specific defect; surfaced from a Discord report ("Take back all terminals from mobile doesn't work on the orca mac app either") while triaging GH #14321. -->

## Visual Proof

Captured. A QA pass staged the failing PTY resize behind a marker file, drove a real remote held phone-fit in an isolated Electron instance, and captured before/after of **Restore this terminal**: on `main` the banner stayed and `restoreTerminalFit` returned false on every retry; on this branch one click cleared the overlay, emptied the fit override, and set the driver to desktop. Screenshots are attached in a PR comment.

(The earlier `N/A — not stageable as a clean before/after` claim was wrong: the before-state is reachable by injecting the resize failure, which is what the QA pass did.)

## Testing

Main-process suite, run in this worktree.

**RED (before the fix)** — `npx vitest run --config config/vitest.config.ts src/main/runtime/remote-desktop-driver.test.ts`

```
 ❯ src/main/runtime/remote-desktop-driver.test.ts (24 tests | 2 failed) 107ms
     × held phone-fit take-back releases the lock when the remote reclaim resize fails 11ms
     × driving take-back reports success when the trailing remote layout cannot converge 1ms

 FAIL  ... > held phone-fit take-back releases the lock when the remote reclaim resize fails
 AssertionError: expected false to be true // Object.is equality
 ❯ src/main/runtime/remote-desktop-driver.test.ts:545:61
     545|     await expect(runtime.reclaimTerminalForDesktop('pty-1')).resolves.…

 FAIL  ... > driving take-back reports success when the trailing remote layout cannot converge
 AssertionError: expected false to be true // Object.is equality
 ❯ src/main/runtime/remote-desktop-driver.test.ts:564:61
     564|     await expect(runtime.reclaimTerminalForDesktop('pty-1')).resolves.…

 Test Files  1 failed (1)
      Tests  2 failed | 22 passed (24)
```

Direct state probe of the same pre-fit scenario against the real runtime (scratch, not committed) — held override survives the take-back and a second click is still a no-op:

```
held:  { size: {45,20}, driver: {kind:'idle'}, override: {mode:'mobile-fit',cols:45,rows:20},
         owners: null, hostReclaimTarget: {cols:150,rows:40} }
after: { restored: false, size: {45,20}, driver: {kind:'idle'},
         override: {mode:'mobile-fit',cols:45,rows:20} }   <-- banner stranded
restored2: false                                           <-- clicking again: still nothing
```

**GREEN (after the fix)** — `npx vitest run --config config/vitest.config.ts src/main/runtime/remote-desktop-driver.test.ts src/main/runtime/mobile-presence-lock.test.ts src/main/runtime/mobile-subscribe-integration.test.ts`

```
 Test Files  3 passed (3)
      Tests  110 passed | 2 skipped (112)
```

Adjacent suites, also green after the change:

```
src/main/runtime/fit-override-integration.test.ts
src/main/runtime/graph-sync-mobile-snapshot-gating.test.ts                  26 passed (2 files)
src/main/ipc/runtime.test.ts
src/main/runtime/rpc/terminal-geometry-stale-handle.test.ts
src/main/runtime/rpc/terminal-send.test.ts                                  43 passed (3 files)
src/renderer/src/components/terminal-pane/terminal-fit-restore.test.ts
src/renderer/src/components/terminal-pane/pty-connection-terminal-input-gating.test.ts  29 passed (2 files)
```

`npx oxfmt --check` and `npx oxlint` clean on both changed files.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Not manually tested: the failing branch needs a host whose `ptyController.resize` throws (a dropped SSH/WSL provider or an exited PTY) at the moment of take-back, which I could not stage reliably. The regression tests drive the real `OrcaRuntimeService` through that exact controller failure.

## AI Disclosure

Claude Opus 5 (Claude Code).

## Review

**Security** — no new inputs, no permission or auth surface, no new IPC/RPC method or parameter. The change only removes a rollback and a `return false`.

**Cross-platform (macOS / Linux / Windows)** — no platform branches, no paths, no shortcuts, no shell invocation. The failure mode it fixes is *more* likely on Windows/WSL, where a provider restart makes `resize` throw.

**Remote SSH** — this is the SSH/remote-host path. `hasRemoteDesktopLayoutState` is true exactly when the host has a remote-desktop viewer/owner or a retained host-reclaim target, i.e. when the desktop is streaming that PTY from a remote runtime. Both edited branches only run there; local workspaces keep the identical code path they had. The trailing `applyRemoteDesktopLayout` still runs (and is still awaited), so a converging reclaim behaves exactly as before — the existing remote tests, including *"applies the latest viewer width when the host takes back from a phone"* and *"preserves indefinite phone-fit after the last desktop viewer leaves"*, are unchanged and green.

**Folder workspaces vs git worktrees** — not workspace-shaped; the code is keyed by `ptyId` only.

**Mobile** — the phone's contract is unchanged. `applyMobileDisplayMode` still emits its `resized` frame, and the mobile display mode is still reset to `'auto'` so the phone re-fits on its next subscribe. No mobile build change and no mobile test touched.

**Backwards compatibility / remote wire** — nothing crossing the wire changed: no RPC params, no stream opcodes, no new published field. `terminal.restoreFit`'s response shape (`{ restored: boolean }`) is unchanged; only the value it carries in a case that previously reported a failure it had already half-committed. An old client paired with a new host now gets `restored: true` where it used to get `false` and do nothing — strictly the improvement. A new client against an old host is unaffected (the old host keeps its old behaviour).

**Performance** — one fewer branch and one fewer `setDriver` call on the failure path; the success path is byte-for-byte the same work.

## Agent skill upstream boundary

- [x] Not applicable.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (CI will cover; `oxfmt`/`oxlint` and the affected suites run locally — a full typecheck was explicitly out of scope for this task)

## Author

- X / Twitter: @BrennanKB5


## Review updates

**`b94fce5dc8` — pin the converging remote take-back resize.** Both original tests force
`setResizeSucceeds(false)`, so nothing pinned that a *converging* remote reclaim still reaches
the host. Deleting `setDriver(ptyId, { kind: 'idle' })` from the held branch left all 24 tests
green even though `applyRemoteDesktopLayout` no-ops while the driver reads `mobile` — the
host-side resize silently became a no-op. Added `'take-back during the resubscribe grace still
resizes the PTY off the phone grid'`, which takes the terminal back inside the 250 ms soft-leave
window (driver still `mobile`, subscriber already gone) and asserts the PTY actually resizes to
desktop dims.

Mutation-tested (baseline 25/25): dropping `releaseDesktopTakeBack` is caught by 2 tests,
returning `false` from the held branch by 3, returning the layout's `ok` from the driving branch
by 1, dropping the `idle` flip by 1, re-ordering release ahead of the layout by 2, dropping the
`result.ok` guard that preserves the host reclaim target by 2, and swapping in `origin/main`'s
runtime wholesale by 2 — confirming the tests are not vacuous. Whole `src/main/runtime`
(4661 tests): green apart from an orchestration perf-budget test unrelated to terminal fit.

### Follow-up, deliberately not fixed here

The held branch keeps the presence lock across the awaited `applyRemoteDesktopLayout`. A phone
that resubscribes inside that window takes the driver, and the trailing `releaseDesktopTakeBack`
stomps it back to `desktop` — an active mobile subscriber driving the PTY with no presence
banner on either side. This is pre-existing (`main` stomps too) and self-corrects on the phone's
next subscribe cycle, but "Take back all terminals" runs reclaims concurrently and widens the
window.

Releasing before the layout is *not* the fix: `applyLayout` already deletes the fit override for
every non-phone target, so on the converging path `releaseDesktopTakeBack` emits nothing and the
layout's own event is the single authoritative one — carrying the real dims while the renderer
still holds the phone grid as its prior. That pairing is what arms the direct-resize rescue in
`desktop-fit-fallback.ts` (`stuckAtPriorGrid && cols > 0`). Releasing first splits the prior and
the dims across two events and disarms it. A correct fix keeps the layout as the sole emitter on
success and emits the repair only on failure, which is a design change beyond this PR's scope.

