### PR TITLE
fix(browser): grant storage-access so requestStorageAccess() stops rejecting

### DIFF
--- a/src/main/browser/anti-detection.test.ts
+++ b/src/main/browser/anti-detection.test.ts
@@ -101,7 +101,7 @@ describe('ANTI_DETECTION_SCRIPT', () => {
   })
 
   it.each(['geolocation', 'idle-detection', 'midi', 'storage-access'])(
-    'preserves the native denied state for %s',
+    'passes non-intercepted permission queries through to the native state for %s',
     async (name) => {
       const context = createContext({
         nativeNotificationPermission: 'denied',

--- a/src/main/browser/browser-session-permission-policy.ts
+++ b/src/main/browser/browser-session-permission-policy.ts
@@ -15,8 +15,9 @@ const AUTO_GRANTED_BROWSER_PERMISSIONS = new Set([
   'pointerLock',
   // Orca allows unpartitioned third-party cookies, so cross-site frames already send them; denying
   // this only rejected the API and burned the caller's user gesture. Not cookies-only: the same
-  // permission also unpartitions localStorage/IndexedDB for requestStorageAccess({localStorage:
-  // true}), which Chrome equally grants under this cookie policy. Electron has no auto-grant, so
+  // permission also hands requestStorageAccess({localStorage: true}) a handle onto unpartitioned
+  // localStorage/IndexedDB, though ambient globals stay partitioned. Chrome grants the same
+  // permission under the same cookie policy, so this is parity. Electron has no auto-grant, so
   // the embedder must answer, and check must agree with request or compliant sites fall back to
   // the gesture path. Revisit if Orca ever gains a cookie or storage-partitioning control: Electron
   // never writes the STORAGE_ACCESS content setting, so the promise would resolve while access

--- a/src/main/browser/browser-session-permission-policy.ts
+++ b/src/main/browser/browser-session-permission-policy.ts
@@ -14,14 +14,15 @@ const AUTO_GRANTED_BROWSER_PERMISSIONS = new Set([
   // otherwise unactionable denial for immersive browser apps.
   'pointerLock',
   // Orca allows unpartitioned third-party cookies, so cross-site frames already send them; denying
-  // this only rejected the API and consumed the caller's user gesture. Not cookies-only, though:
-  // the same permission also lifts third-party partitioning for localStorage/IndexedDB, which
-  // Chrome equally grants under this cookie policy. Electron has no auto-grant, so the embedder
-  // must answer, and check must agree with request. Revisit if Orca ever gains a cookie or
-  // storage-partitioning control.
+  // this only rejected the API and burned the caller's user gesture. Not cookies-only: the same
+  // permission also unpartitions localStorage/IndexedDB for requestStorageAccess({localStorage:
+  // true}), which Chrome equally grants under this cookie policy. Electron has no auto-grant, so
+  // the embedder must answer, and check must agree with request or compliant sites fall back to
+  // the gesture path. Revisit if Orca ever gains a cookie or storage-partitioning control: Electron
+  // never writes the STORAGE_ACCESS content setting, so the promise would resolve while access
+  // stayed blocked, and sites that reload on success would loop.
   'storage-access'
 ])
-
 // 'top-level-storage-access' is deliberately absent: Chromium gates requestStorageAccessFor() on
 // Related Website Sets rather than cookie policy, and Orca has no such source, so the rationale
 // above does not transfer to it.

--- a/src/main/browser/browser-session-permission-policy.ts
+++ b/src/main/browser/browser-session-permission-policy.ts
@@ -13,10 +13,12 @@ const AUTO_GRANTED_BROWSER_PERMISSIONS = new Set([
   // Chromium still requires user activation, so this only removes Orca's
   // otherwise unactionable denial for immersive browser apps.
   'pointerLock',
-  // This session allows unpartitioned third-party cookies, so a cross-site frame already reads and
-  // writes them anyway; gating this protects nothing, and denying it consumed the caller's user
-  // gesture. Electron builds neither Chrome's activation gate nor its auto-grant, so the embedder
-  // must answer and check must agree with request. Revisit if Orca ever blocks third-party cookies.
+  // Orca allows unpartitioned third-party cookies, so cross-site frames already send them; denying
+  // this only rejected the API and consumed the caller's user gesture. Not cookies-only, though:
+  // the same permission also lifts third-party partitioning for localStorage/IndexedDB, which
+  // Chrome equally grants under this cookie policy. Electron has no auto-grant, so the embedder
+  // must answer, and check must agree with request. Revisit if Orca ever gains a cookie or
+  // storage-partitioning control.
   'storage-access'
 ])
 

--- a/src/main/browser/browser-session-permission-policy.ts
+++ b/src/main/browser/browser-session-permission-policy.ts
@@ -19,9 +19,10 @@ const AUTO_GRANTED_BROWSER_PERMISSIONS = new Set([
   // localStorage/IndexedDB, though ambient globals stay partitioned. Chrome grants the same
   // permission under the same cookie policy, so this is parity. Electron has no auto-grant, so
   // the embedder must answer, and check must agree with request or compliant sites fall back to
-  // the gesture path. Revisit if Orca ever gains a cookie or storage-partitioning control: Electron
-  // never writes the STORAGE_ACCESS content setting, so the promise would resolve while access
-  // stayed blocked, and sites that reload on success would loop.
+  // the gesture path. Revisit if Orca ever gains a cookie or storage-partitioning control: the
+  // handle is gated separately and would survive, but Electron never writes the STORAGE_ACCESS
+  // content setting, so cookie access would stay blocked while the promise still resolved — and
+  // sites that reload on success would loop.
   'storage-access'
 ])
 // 'top-level-storage-access' is deliberately absent: Chromium gates requestStorageAccessFor() on

--- a/src/main/browser/browser-session-permission-policy.ts
+++ b/src/main/browser/browser-session-permission-policy.ts
@@ -14,17 +14,15 @@ const AUTO_GRANTED_BROWSER_PERMISSIONS = new Set([
   // otherwise unactionable denial for immersive browser apps.
   'pointerLock',
   // This session allows unpartitioned third-party cookies, so a cross-site frame already reads and
-  // writes them at the network layer. Gating storage-access therefore grants no protection and only
-  // breaks sites that take the API's failure path. Chrome resolves requestStorageAccess() without a
-  // prompt under the same cookie policy; Electron has no such fast path and forwards the request to
-  // the embedder, so the embedder supplies it. Revisit if Orca ever blocks third-party cookies.
+  // writes them anyway; gating this protects nothing, and denying it consumed the caller's user
+  // gesture. Electron builds neither Chrome's activation gate nor its auto-grant, so the embedder
+  // must answer and check must agree with request. Revisit if Orca ever blocks third-party cookies.
   'storage-access'
-  // 'top-level-storage-access' is deliberately ABSENT. requestStorageAccessFor() is a different
-  // platform decision: Chromium requires a primary main frame plus transient activation and then
-  // consults Related Website Sets, granting only a non-service member of the same set. It has no
-  // "third-party cookies already allowed" auto-grant, so the rationale above does not transfer, and
-  // Orca has no Related Website Sets source to reproduce the rule. Denying is the honest answer.
 ])
+
+// 'top-level-storage-access' is deliberately absent: Chromium gates requestStorageAccessFor() on
+// Related Website Sets rather than cookie policy, and Orca has no such source, so the rationale
+// above does not transfer to it.
 
 export function isAutoGrantedBrowserSessionPermission(permission: string): boolean {
   return AUTO_GRANTED_BROWSER_PERMISSIONS.has(permission)

--- a/src/main/browser/browser-session-permission-policy.ts
+++ b/src/main/browser/browser-session-permission-policy.ts
@@ -12,7 +12,18 @@ const AUTO_GRANTED_BROWSER_PERMISSIONS = new Set([
   'persistent-storage',
   // Chromium still requires user activation, so this only removes Orca's
   // otherwise unactionable denial for immersive browser apps.
-  'pointerLock'
+  'pointerLock',
+  // This session allows unpartitioned third-party cookies, so a cross-site frame already reads and
+  // writes them at the network layer. Gating storage-access therefore grants no protection and only
+  // breaks sites that take the API's failure path. Chrome resolves requestStorageAccess() without a
+  // prompt under the same cookie policy; Electron has no such fast path and forwards the request to
+  // the embedder, so the embedder supplies it. Revisit if Orca ever blocks third-party cookies.
+  'storage-access'
+  // 'top-level-storage-access' is deliberately ABSENT. requestStorageAccessFor() is a different
+  // platform decision: Chromium requires a primary main frame plus transient activation and then
+  // consults Related Website Sets, granting only a non-service member of the same set. It has no
+  // "third-party cookies already allowed" auto-grant, so the rationale above does not transfer, and
+  // Orca has no Related Website Sets source to reproduce the rule. Denying is the honest answer.
 ])
 
 export function isAutoGrantedBrowserSessionPermission(permission: string): boolean {

--- a/src/main/browser/browser-session-registry.persistence.test.ts
+++ b/src/main/browser/browser-session-registry.persistence.test.ts
@@ -547,6 +547,20 @@ describe('BrowserSessionRegistry persistence', () => {
     expect(checkHandler(null, 'persistent-storage', '')).toBe(true)
     expect(checkHandler(null, 'geolocation', '')).toBe(false)
     expect(checkHandler(null, 'media', '', { mediaType: 'video' })).toBe(true)
+
+    // Why: this session allows unpartitioned third-party cookies, so a cross-site frame already has
+    // the access requestStorageAccess() would grant. Denying it protected nothing and only broke
+    // sites taking the API's failure path. Red before the grant landed.
+    requestHandler(guestWc, 'storage-access', permissionCallback)
+    await vi.waitFor(() => expect(permissionCallback.mock.calls.at(-1)).toEqual([true]))
+    expect(checkHandler(null, 'storage-access', '')).toBe(true)
+
+    // Why: requestStorageAccessFor() is a different platform decision — Chromium consults Related
+    // Website Sets and has no third-party-cookie auto-grant, and Orca has no such data source. This
+    // pins the deliberate denial so a future blanket widening of the allow-set fails loudly.
+    requestHandler(guestWc, 'top-level-storage-access', permissionCallback)
+    await vi.waitFor(() => expect(permissionCallback.mock.calls.at(-1)).toEqual([false]))
+    expect(checkHandler(null, 'top-level-storage-access', '')).toBe(false)
     expect(defaultSession.setDisplayMediaRequestHandler).toHaveBeenCalled()
     const displayMediaHandler = defaultSession.setDisplayMediaRequestHandler.mock.calls[0][0]
     const displayMediaCallback = vi.fn()

--- a/src/main/browser/browser-session-registry.persistence.test.ts
+++ b/src/main/browser/browser-session-registry.persistence.test.ts
@@ -552,15 +552,21 @@ describe('BrowserSessionRegistry persistence', () => {
     // the access requestStorageAccess() would grant. Denying it protected nothing and only broke
     // sites taking the API's failure path. Red before the grant landed.
     requestHandler(guestWc, 'storage-access', permissionCallback)
-    await vi.waitFor(() => expect(permissionCallback.mock.calls.at(-1)).toEqual([true]))
+    expect(permissionCallback).toHaveBeenLastCalledWith(true)
     expect(checkHandler(null, 'storage-access', '')).toBe(true)
 
     // Why: requestStorageAccessFor() is a different platform decision — Chromium consults Related
     // Website Sets and has no third-party-cookie auto-grant, and Orca has no such data source. This
     // pins the deliberate denial so a future blanket widening of the allow-set fails loudly.
     requestHandler(guestWc, 'top-level-storage-access', permissionCallback)
-    await vi.waitFor(() => expect(permissionCallback.mock.calls.at(-1)).toEqual([false]))
+    expect(permissionCallback).toHaveBeenLastCalledWith(false)
     expect(checkHandler(null, 'top-level-storage-access', '')).toBe(false)
+
+    // Why: the reported symptom was a user-visible denial notice, so pin the notified list here —
+    // storage-access must no longer raise one, while the deliberate top-level denial still does.
+    expect(
+      browserManagerNotifyPermissionDeniedMock.mock.calls.map(([args]) => args.permission)
+    ).toEqual(['geolocation', 'top-level-storage-access'])
     expect(defaultSession.setDisplayMediaRequestHandler).toHaveBeenCalled()
     const displayMediaHandler = defaultSession.setDisplayMediaRequestHandler.mock.calls[0][0]
     const displayMediaCallback = vi.fn()

--- a/src/main/browser/browser-session-registry.test.ts
+++ b/src/main/browser/browser-session-registry.test.ts
@@ -250,8 +250,8 @@ describe('BrowserSessionRegistry', () => {
   })
 
   it('auto-grants storage-access for isolated partitions', () => {
-    // Why: the isolated twin every other entry in this set already has — dropping it would make
-    // storage-access the sole exception.
+    // Why: mirrors the pointerLock precedent directly above — the default-partition suite does not
+    // reach this install path.
     browserSessionRegistry.createProfile('isolated', 'Storage Access Test')
     const mockSession = sessionFromPartitionMock.mock.results[0]?.value
     const requestHandler = mockSession.setPermissionRequestHandler.mock.calls[0][0]

--- a/src/main/browser/browser-session-registry.test.ts
+++ b/src/main/browser/browser-session-registry.test.ts
@@ -249,6 +249,23 @@ describe('BrowserSessionRegistry', () => {
     expect(checkHandler(null, 'pointerLock', '', {})).toBe(true)
   })
 
+  it('auto-grants storage-access for isolated partitions', () => {
+    // Why: verify the parallel fix to the default partition — isolated and imported profiles
+    // install policies through a different call site and must answer storage-access identically.
+    browserSessionRegistry.createProfile('isolated', 'Storage Access Test')
+    const mockSession = sessionFromPartitionMock.mock.results[0]?.value
+    const requestHandler = mockSession.setPermissionRequestHandler.mock.calls[0][0]
+    const checkHandler = mockSession.setPermissionCheckHandler.mock.calls[0][0]
+    const callback = vi.fn()
+    const guestWc = { id: 7, getURL: vi.fn(() => 'https://example.com/') }
+
+    requestHandler(guestWc, 'storage-access', callback, {})
+
+    expect(callback).toHaveBeenCalledWith(true)
+    expect(checkHandler(null, 'storage-access', '', {})).toBe(true)
+    expect(checkHandler(null, 'top-level-storage-access', '', {})).toBe(false)
+  })
+
   it('routes media permission requests through macOS TCC for isolated partitions', async () => {
     // Why: verify the parallel fix to the default partition — isolated/imported
     // profiles must also defer media permission checks to macOS instead of

--- a/src/main/browser/browser-session-registry.test.ts
+++ b/src/main/browser/browser-session-registry.test.ts
@@ -250,8 +250,8 @@ describe('BrowserSessionRegistry', () => {
   })
 
   it('auto-grants storage-access for isolated partitions', () => {
-    // Why: verify the parallel fix to the default partition — isolated and imported profiles
-    // install policies through a different call site and must answer storage-access identically.
+    // Why: the isolated twin every other entry in this set already has — dropping it would make
+    // storage-access the sole exception.
     browserSessionRegistry.createProfile('isolated', 'Storage Access Test')
     const mockSession = sessionFromPartitionMock.mock.results[0]?.value
     const requestHandler = mockSession.setPermissionRequestHandler.mock.calls[0][0]


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​38 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​37 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​15 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​14 |

<!-- /orca-pr-loc -->

## ELI5

Websites sometimes have to ask the browser "may I use my own cookies and storage here?" Orca answered "no" to every site, every time, with no way for the user to say otherwise — and each refusal also burned the click the site was holding. Orca now answers yes, matching what Chrome answers under the same cookie settings.

## What Changed

- `storage-access` added to `AUTO_GRANTED_BROWSER_PERMISSIONS`, with a comment tying the grant to the conditions it depends on.
- `top-level-storage-access` deliberately left **out**, with a comment explaining why, and a test pinning the denial.
- Tests pin the grant on both the default and isolated-profile install paths, and pin that the user-visible denial notice stops firing.

## Why

`AUTO_GRANTED_BROWSER_PERMISSIONS` omitted `storage-access`, and `installBrowserSessionPartitionPolicies` denies anything not in that set. So every `document.requestStorageAccess()` in the embedded browser was refused, on every site. It was not silent: each refusal raised a user-facing notice — `https://www.google.com asked for storage-access, and Orca denied it.` — that the user had no way to act on. Worse, per the Storage Access API contract a **rejection consumes the caller's transient activation**, so Orca was also burning the user gesture the site was holding for whatever it meant to do next.

Note the shape of the bug: with **no** handler installed at all, Electron grants `storage-access` and defaults the check handler to true. Orca's deny-by-default installer had regressed this permission *below* Electron's own default.

The obvious objection is that granting it unconditionally is a privacy hole. For cookies, that objection assumes Orca blocks third-party cookies. **It does not** — nothing in `src/` blocks or partitions third-party cookies and no Chromium switch touches cookie policy, so Electron's default applies to every browser partition. This was confirmed at runtime, not just from source: a cross-site iframe read its `SameSite=None; Secure` cookie and sent it on a credentialed fetch **before** `requestStorageAccess()` was ever called, in builds both with and without this change.

Being precise about the blast radius, since it is wider than cookies alone: third-party **storage** partitioning is enabled by default and is independent of cookie policy, and the same permission lifts it for `localStorage`, IndexedDB, CacheStorage and friends when a site asks via the dictionary form, `requestStorageAccess({localStorage: true})` — Orca's handler sees only the permission name, never the call shape, so one grant covers both. So the frame does not "already have" everything this grants. It is still the right answer, because Chrome grants this same permission automatically under this same cookie policy — this is Chrome parity, not a widening past it. The comment records the conditions that would invalidate the reasoning.

### Why `top-level-storage-access` stays denied

These are not one decision. `requestStorageAccessFor()` becomes a distinct `TOP_LEVEL_STORAGE_ACCESS` request, which Chromium gates on **Related Website Sets** membership rather than on cookie policy — a permissive cookie setting never grants it there, it only ever acts as a veto. Orca has no Related Website Sets source, so granting it symmetrically would invent a permissive answer to a question the platform answers restrictively. It stays denied, deliberately and visibly, and a test pins it.

## Scope

This does **not** fix Google sign-in. That was a separate defect (#15216, fixed by #15221) where Orca cancelled its own navigations; sign-in completes end to end with this denial still in place, verified. This PR fixes an independent bug found while investigating that one.

## Testing

Unit coverage drives the **real handlers** installed by `installBrowserSessionPartitionPolicies`, not the pure predicate:

- `storage-access` granted through both the request and check handlers, on the default partition **and** on the isolated-profile path (`createProfile`), mirroring the `pointerLock` precedent — the default-partition suite does not reach that install path. Both verified red with the grant removed.
- The user-visible symptom is pinned: the denial-notification list is asserted *after* the new requests, so a regression that re-denied `storage-access` fails. Verified red pre-fix, in isolation.
- `top-level-storage-access` denied through both handlers. Green before and after **by design** — a pinning test, not evidence of this change, and not counted as such.

781/781 pass across `src/main/browser`; typecheck, oxlint and oxfmt clean.

**Empirical verification** (see QA comment below): in an isolated Orca dev instance, a genuinely cross-site iframe with a proven user gesture. Without the grant, `requestStorageAccess()` rejects with `NotAllowedError` and Orca raises its denial banner; with it, the promise resolves and no banner appears. This refutes the objection that Orca's handler is never consulted — the promise's resolution is live. It does **not** show that Chromium's cookie-unlocking plumbing is wired in Electron; that plumbing is moot here because third-party cookies already flow, which is exactly what the tripwire in the comment guards.

## Platform

The policy is pure and has no platform-specific behaviour, so macOS, Windows and Linux behave identically; the only platform branch in the permission path is macOS TCC media handling, which returns before the allow-set is consulted. Permission handlers are installed per-session in the host process and are not part of any client/host wire contract, so there is no remote or mixed-version surface.


