### PR TITLE
fix(tabs): stop split workspaces multiplying columns on return

### DIFF
--- a/src/renderer/src/runtime/web-session-tabs-sync-layout-duplicate-groups.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync-layout-duplicate-groups.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+import type { Tab, TabGroup } from '../../../shared/tab-types'
+import { applyWebSessionTabsSnapshot, type WebSessionTabsSyncState } from './web-session-tabs-sync'
+import {
+  ENV,
+  NOW,
+  WT,
+  makeSnapshot,
+  makeState,
+  resetWebSessionTabsSyncTestState
+} from './web-session-tabs-sync-test-harness'
+
+vi.mock('../store', () => ({
+  useAppStore: {
+    setState: vi.fn()
+  }
+}))
+
+const LOCAL_GROUP_ID = 'local-group-1'
+
+function localEditorTab(): Tab {
+  return {
+    id: 'local-editor-tab',
+    entityId: '/repo/NOTES.md',
+    groupId: LOCAL_GROUP_ID,
+    worktreeId: WT,
+    contentType: 'editor',
+    label: 'NOTES.md',
+    customLabel: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: NOW,
+    isPreview: false,
+    isPinned: false
+  }
+}
+
+function localGroup(): TabGroup {
+  return {
+    id: LOCAL_GROUP_ID,
+    worktreeId: WT,
+    activeTabId: 'local-editor-tab',
+    tabOrder: ['local-editor-tab'],
+    recentTabIds: ['local-editor-tab']
+  }
+}
+
+function stateWithLocalGroup(): WebSessionTabsSyncState {
+  return makeState({
+    unifiedTabsByWorktree: { [WT]: [localEditorTab()] },
+    groupsByWorktree: { [WT]: [localGroup()] },
+    activeGroupIdByWorktree: { [WT]: LOCAL_GROUP_ID },
+    layoutByWorktree: { [WT]: { type: 'leaf', groupId: LOCAL_GROUP_ID } }
+  })
+}
+
+// Host group whose tabs are absent from this snapshot: the host names groups but
+// publishes no layout for them, which is the shape that used to duplicate leaves.
+function snapshotWithUnmappedHostGroup(): ReturnType<typeof makeSnapshot> {
+  return makeSnapshot([], {
+    activeGroupId: 'host-group-1',
+    activeTabId: null,
+    tabGroups: [{ id: 'host-group-1', activeTabId: 'host-tab-1', tabOrder: ['host-tab-1'] }]
+  })
+}
+
+function collectLeafGroupIds(layout: unknown, out: string[] = []): string[] {
+  const node = layout as { type: string; groupId?: string; first?: unknown; second?: unknown }
+  if (!node) {
+    return out
+  }
+  if (node.type === 'leaf') {
+    out.push(node.groupId!)
+    return out
+  }
+  collectLeafGroupIds(node.first, out)
+  collectLeafGroupIds(node.second, out)
+  return out
+}
+
+describe('applyWebSessionTabsSnapshot layout composition', () => {
+  beforeEach(resetWebSessionTabsSyncTestState)
+
+  it('never places one tab group in two layout leaves', () => {
+    const patch = applyWebSessionTabsSnapshot(
+      stateWithLocalGroup(),
+      snapshotWithUnmappedHostGroup(),
+      ENV,
+      NOW
+    ) as Partial<WebSessionTabsSyncState>
+
+    const leaves = collectLeafGroupIds(
+      patch.layoutByWorktree?.[WT] ?? { type: 'leaf', groupId: LOCAL_GROUP_ID }
+    )
+    expect(leaves).toEqual([LOCAL_GROUP_ID])
+  })
+
+  it('does not grow the layout when the same snapshot is applied twice', () => {
+    let state = stateWithLocalGroup()
+    for (let i = 0; i < 3; i++) {
+      resetWebSessionTabsSyncTestState()
+      const patch = applyWebSessionTabsSnapshot(
+        state,
+        snapshotWithUnmappedHostGroup(),
+        ENV,
+        NOW
+      ) as Partial<WebSessionTabsSyncState>
+      state = { ...state, ...patch }
+    }
+
+    expect(collectLeafGroupIds(state.layoutByWorktree[WT])).toEqual([LOCAL_GROUP_ID])
+  })
+})

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -1663,6 +1663,24 @@ function pruneTabGroupLayout(
   return first ?? second
 }
 
+function dropTabGroupLayoutGroups(
+  layout: TabGroupLayoutNode | null,
+  excludedGroupIds: ReadonlySet<string>
+): TabGroupLayoutNode | null {
+  if (!layout) {
+    return null
+  }
+  if (layout.type === 'leaf') {
+    return excludedGroupIds.has(layout.groupId) ? null : layout
+  }
+  const first = dropTabGroupLayoutGroups(layout.first, excludedGroupIds)
+  const second = dropTabGroupLayoutGroups(layout.second, excludedGroupIds)
+  if (first && second) {
+    return { ...layout, first, second }
+  }
+  return first ?? second
+}
+
 function appendTabGroupLayout(
   first: TabGroupLayoutNode | null,
   second: TabGroupLayoutNode | null
@@ -1673,11 +1691,18 @@ function appendTabGroupLayout(
   if (!second) {
     return first
   }
+  // Why: a group already placed by `first` must not gain a second leaf — two
+  // leaves for one group render the same tab strip in two columns, and each
+  // later snapshot appends another copy.
+  const appended = dropTabGroupLayoutGroups(second, collectLayoutGroupIds(first))
+  if (!appended) {
+    return first
+  }
   return {
     type: 'split',
     direction: 'horizontal',
     first,
-    second
+    second: appended
   }
 }
 

--- a/src/renderer/src/store/slices/tabs-hydration-group-validation.test.ts
+++ b/src/renderer/src/store/slices/tabs-hydration-group-validation.test.ts
@@ -213,4 +213,40 @@ describe('buildHydratedTabState referential repair', () => {
 
     expect(leafGroupIds(result.layoutByWorktree.w1)).toEqual(['g1', 'g2'])
   })
+
+  it('collapses a persisted layout that repeats one group across leaves', () => {
+    const result = buildHydratedTabState(
+      {
+        ...makeBaseSession(),
+        unifiedTabs: { w1: [tab('t1', 'g1', 0), tab('t2', 'g2', 1)] },
+        tabGroups: {
+          w1: [
+            { id: 'g1', worktreeId: 'w1', activeTabId: 't1', tabOrder: ['t1'] },
+            { id: 'g2', worktreeId: 'w1', activeTabId: 't2', tabOrder: ['t2'] }
+          ]
+        },
+        tabGroupLayouts: {
+          w1: {
+            type: 'split',
+            direction: 'horizontal',
+            first: { type: 'leaf', groupId: 'g1' },
+            second: {
+              type: 'split',
+              direction: 'horizontal',
+              first: { type: 'leaf', groupId: 'g1' },
+              second: {
+                type: 'split',
+                direction: 'horizontal',
+                first: { type: 'leaf', groupId: 'g2' },
+                second: { type: 'leaf', groupId: 'g1' }
+              }
+            }
+          }
+        }
+      },
+      new Set(['w1'])
+    )
+
+    expect(leafGroupIds(result.layoutByWorktree.w1)).toEqual(['g1', 'g2'])
+  })
 })

--- a/src/renderer/src/store/slices/tabs-hydration.ts
+++ b/src/renderer/src/store/slices/tabs-hydration.ts
@@ -19,16 +19,31 @@ type HydratedTabState = {
   layoutByWorktree: Record<string, TabGroupLayoutNode>
 }
 
+/** Drops leaves whose group is gone, and repeat leaves for a group already
+ *  placed earlier in the tree — one column per group is the render invariant,
+ *  and a repeated leaf paints the same tab strip in every one of its columns. */
 export function pruneTabGroupLayoutForGroups(
   root: TabGroupLayoutNode,
   validGroupIds: Set<string>
 ): TabGroupLayoutNode | null {
+  return pruneLayoutNodeForGroups(root, validGroupIds, new Set())
+}
+
+function pruneLayoutNodeForGroups(
+  root: TabGroupLayoutNode,
+  validGroupIds: Set<string>,
+  placedGroupIds: Set<string>
+): TabGroupLayoutNode | null {
   if (root.type === 'leaf') {
-    return validGroupIds.has(root.groupId) ? root : null
+    if (!validGroupIds.has(root.groupId) || placedGroupIds.has(root.groupId)) {
+      return null
+    }
+    placedGroupIds.add(root.groupId)
+    return root
   }
 
-  const first = pruneTabGroupLayoutForGroups(root.first, validGroupIds)
-  const second = pruneTabGroupLayoutForGroups(root.second, validGroupIds)
+  const first = pruneLayoutNodeForGroups(root.first, validGroupIds, placedGroupIds)
+  const second = pruneLayoutNodeForGroups(root.second, validGroupIds, placedGroupIds)
 
   if (first === null) {
     return second

--- a/src/renderer/src/store/slices/tabs-model-reconciliation.test.ts
+++ b/src/renderer/src/store/slices/tabs-model-reconciliation.test.ts
@@ -108,6 +108,69 @@ describe('TabsSlice', () => {
       expect(result.renderableTabCount).toBe(1)
     })
 
+    // A session mirrored from a runtime host used to append a fresh leaf for a
+    // group the layout already held, so returning to a split workspace showed the
+    // same tab strip in several columns. Reconciliation collapses the repeats.
+    it('collapses a layout that repeats one group across leaves', () => {
+      const groupId = 'g-1'
+      store.setState({
+        unifiedTabsByWorktree: {
+          [WT]: [
+            {
+              id: 'terminal-1',
+              entityId: 'terminal-1',
+              groupId,
+              worktreeId: WT,
+              contentType: 'terminal',
+              label: 'Terminal 1',
+              customLabel: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1
+            }
+          ]
+        },
+        tabsByWorktree: {
+          [WT]: [
+            {
+              id: 'terminal-1',
+              ptyId: 'pty-1',
+              worktreeId: WT,
+              title: 'Terminal 1',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1
+            }
+          ]
+        },
+        ptyIdsByTabId: { 'terminal-1': ['pty-1'] },
+        groupsByWorktree: {
+          [WT]: [
+            { id: groupId, worktreeId: WT, activeTabId: 'terminal-1', tabOrder: ['terminal-1'] }
+          ]
+        },
+        activeGroupIdByWorktree: { [WT]: groupId },
+        layoutByWorktree: {
+          [WT]: {
+            type: 'split',
+            direction: 'horizontal',
+            first: { type: 'leaf', groupId },
+            second: {
+              type: 'split',
+              direction: 'horizontal',
+              first: { type: 'leaf', groupId },
+              second: { type: 'leaf', groupId }
+            }
+          }
+        }
+      })
+
+      store.getState().reconcileWorktreeTabModel(WT)
+
+      expect(store.getState().layoutByWorktree[WT]).toEqual({ type: 'leaf', groupId })
+    })
+
     it('keeps simulator tabs because they reconnect their own backing stream', () => {
       const terminalGroupId = 'g-terminal'
       const simulatorGroupId = 'g-simulator'


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​212 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​212 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​44 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​40 |

<!-- /orca-pr-loc -->

## Problem

Split a workspace into two panes, switch to another workspace, come back — the workspace returns as three or four columns that all show the *same* tab (the one from the left pane), with the other tabs pushed out of view. Closing a tab collapses everything back to a single pane.

## Cause

For a workspace mirrored from a runtime host, `applyWebSessionTabsSnapshot` composes the layout as `host layout + local-only groups`:

```ts
const hostBaseLayout = hostLayout ?? (hostHasGroups ? defaultLeafLayout : null)
const fallbackLayout = appendTabGroupLayout(hostBaseLayout, localExtraLayout)
```

When the host names tab groups but publishes no `tabGroupLayout` of its own, the base is the synthetic `defaultLeafLayout` — a leaf for `nextActiveGroupId`. That id is usually one of the *local-only* groups, and the local-only groups are exactly what `localExtraLayout` appends. So the composed tree ends up holding **two leaves for one group**.

Each leaf renders its own `TabGroupPanel`, so one group paints two identical tab strips — and because the grown layout becomes the input to the next snapshot, every further snapshot appends another copy (2 → 3 → 4 leaves). Switching away from the workspace and back re-runs the sync, which is why the split "multiplies" on return.

## Fix

- `appendTabGroupLayout` drops any leaf whose group the base layout already places, so one group can never occupy two columns.
- Layout pruning (used by session hydration and by worktree reconciliation on every activation) also collapses repeat leaves, so a layout already corrupted on disk heals on the next activation instead of rendering N copies of one group.

## Tests

- `web-session-tabs-sync-layout-duplicate-groups.test.ts` — new. Fails on `main`: one snapshot yields a duplicated leaf, three snapshots yield four leaves for a single group.
- `tabs-hydration-group-validation.test.ts` — hydration collapses a persisted layout that repeats one group.
- `tabs-model-reconciliation.test.ts` — reconciliation collapses a repeated-group layout on activation.

Full `src/renderer/src/runtime`, `store/slices`, `components/tab-group`, `components/terminal{,-pane}` and `lib` suites pass (11,648 tests), plus `typecheck`, `oxlint`, changed-code quality gates, and the max-lines ratchet.

## Visual proof

Real Orca (Electron, dev build), same flow both times: put the workspace into the corrupted layout the sync produces, switch to another workspace, switch back.


![split-duplication-before-after.png](https://github.com/user-attachments/assets/68c03ef4-fe9d-4bfc-8642-7858ddd6d266)
