### PR TITLE
fix(project-groups): route group rename/delete by owning host

### DIFF
--- a/src/renderer/src/store/slices/repos-project-groups-delete.test.ts
+++ b/src/renderer/src/store/slices/repos-project-groups-delete.test.ts
@@ -112,17 +112,18 @@ describe('project group deletion store routing', () => {
       result: { deleted: false },
       _meta: { runtimeId: 'runtime-remote' }
     })
+    const remoteOwnedGroup: ProjectGroup = { ...projectGroup, executionHostId: 'runtime:env-1' }
     const groupedRepo = { ...remoteRepo, projectGroupId: projectGroup.id }
     const store = createTestStore()
     store.setState({
       settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
-      projectGroups: [projectGroup],
+      projectGroups: [remoteOwnedGroup],
       repos: [groupedRepo]
     })
 
     await expect(store.getState().deleteProjectGroup(projectGroup.id)).resolves.toBe(false)
 
-    expect(store.getState().projectGroups).toEqual([projectGroup])
+    expect(store.getState().projectGroups).toEqual([remoteOwnedGroup])
     expect(store.getState().repos).toEqual([groupedRepo])
     expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
       selector: 'env-1',

--- a/src/renderer/src/store/slices/repos-project-groups-host-routing.test.ts
+++ b/src/renderer/src/store/slices/repos-project-groups-host-routing.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createTestStore } from './store-test-helpers'
+import type { ProjectGroup } from '../../../../shared/project-group-types'
+import {
+  createCompatibleRuntimeStatusResponseIfNeeded,
+  type RuntimeEnvironmentCallRequest
+} from '../../runtime/runtime-compatibility-test-fixture'
+import { clearRuntimeCompatibilityCacheForTests } from '../../runtime/runtime-rpc-client'
+
+const baseGroup: ProjectGroup = {
+  id: 'group-1',
+  name: 'Platform',
+  parentPath: null,
+  parentGroupId: null,
+  createdFrom: 'manual',
+  tabOrder: 0,
+  isCollapsed: false,
+  color: null,
+  createdAt: 1,
+  updatedAt: 1
+}
+
+const localGroup: ProjectGroup = { ...baseGroup, executionHostId: 'local' }
+const remoteGroup: ProjectGroup = {
+  ...baseGroup,
+  id: 'group-remote',
+  executionHostId: 'runtime:env-1'
+}
+
+const projectGroupsUpdate = vi.fn()
+const projectGroupsDelete = vi.fn()
+const runtimeEnvironmentCall = vi.fn()
+const runtimeEnvironmentTransportCall = vi.fn()
+
+beforeEach(() => {
+  clearRuntimeCompatibilityCacheForTests()
+  projectGroupsUpdate.mockReset()
+  projectGroupsDelete.mockReset()
+  runtimeEnvironmentCall.mockReset()
+  runtimeEnvironmentTransportCall.mockReset()
+  runtimeEnvironmentTransportCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
+    return createCompatibleRuntimeStatusResponseIfNeeded(args) ?? runtimeEnvironmentCall(args)
+  })
+  vi.stubGlobal('window', {
+    api: {
+      repos: { remove: vi.fn() },
+      projectGroups: { update: projectGroupsUpdate, delete: projectGroupsDelete },
+      runtimeEnvironments: { call: runtimeEnvironmentTransportCall }
+    }
+  })
+})
+
+describe('project group writes route by owning host', () => {
+  it('deletes a local group locally while a runtime environment is focused', async () => {
+    projectGroupsDelete.mockResolvedValue(true)
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      projectGroups: [localGroup]
+    })
+
+    await expect(store.getState().deleteProjectGroup(localGroup.id)).resolves.toBe(true)
+
+    expect(projectGroupsDelete).toHaveBeenCalledWith({ groupId: localGroup.id })
+    expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
+    expect(store.getState().projectGroups).toEqual([])
+  })
+
+  it('renames a local group locally while a runtime environment is focused', async () => {
+    projectGroupsUpdate.mockResolvedValue({ ...localGroup, name: 'Renamed' })
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      projectGroups: [localGroup]
+    })
+
+    await expect(
+      store.getState().updateProjectGroup(localGroup.id, { name: 'Renamed' })
+    ).resolves.toBe(true)
+
+    expect(projectGroupsUpdate).toHaveBeenCalledWith({
+      groupId: localGroup.id,
+      updates: { name: 'Renamed' }
+    })
+    expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
+    expect(store.getState().projectGroups).toMatchObject([{ name: 'Renamed' }])
+  })
+
+  it('deletes a runtime-owned group on its own host while local is focused', async () => {
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-delete-group',
+      ok: true,
+      result: { deleted: true },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: null } as never,
+      projectGroups: [remoteGroup]
+    })
+
+    await expect(store.getState().deleteProjectGroup(remoteGroup.id)).resolves.toBe(true)
+
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-1',
+      method: 'projectGroup.delete',
+      params: { groupId: remoteGroup.id },
+      timeoutMs: 15_000
+    })
+    expect(projectGroupsDelete).not.toHaveBeenCalled()
+    expect(store.getState().projectGroups).toEqual([])
+  })
+
+  it('keeps using the focused host for groups with no recorded owner', async () => {
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-delete-group',
+      ok: true,
+      result: { deleted: true },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      projectGroups: [baseGroup]
+    })
+
+    await expect(store.getState().deleteProjectGroup(baseGroup.id)).resolves.toBe(true)
+
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-1',
+      method: 'projectGroup.delete',
+      params: { groupId: baseGroup.id },
+      timeoutMs: 15_000
+    })
+    expect(projectGroupsDelete).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/store/slices/repos-project-groups-host-routing.test.ts
+++ b/src/renderer/src/store/slices/repos-project-groups-host-routing.test.ts
@@ -111,6 +111,31 @@ describe('project group writes route by owning host', () => {
     expect(store.getState().projectGroups).toEqual([])
   })
 
+  it('keeps the focused host when one group id exists on two hosts', async () => {
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-delete-group',
+      ok: true,
+      result: { deleted: true },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    const collidingRemoteGroup: ProjectGroup = { ...localGroup, executionHostId: 'runtime:env-1' }
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      projectGroups: [localGroup, collidingRemoteGroup]
+    })
+
+    await expect(store.getState().deleteProjectGroup(localGroup.id)).resolves.toBe(true)
+
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-1',
+      method: 'projectGroup.delete',
+      params: { groupId: localGroup.id },
+      timeoutMs: 15_000
+    })
+    expect(projectGroupsDelete).not.toHaveBeenCalled()
+  })
+
   it('keeps using the focused host for groups with no recorded owner', async () => {
     runtimeEnvironmentCall.mockResolvedValue({
       id: 'rpc-delete-group',

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -1567,6 +1567,32 @@ function settingsForRepoOwner(
   return state.settings
 }
 
+function settingsForProjectGroupOwner(
+  state: Pick<AppState, 'projectGroups' | 'settings'>,
+  groupId: string
+) {
+  const group = state.projectGroups.find((entry) => entry.id === groupId)
+  if (!group) {
+    return state.settings
+  }
+  if (!group.executionHostId && !group.connectionId) {
+    return state.settings
+  }
+  const parsed = parseExecutionHostId(getProjectGroupHostId(group))
+  if (parsed?.kind === 'runtime') {
+    return state.settings
+      ? { ...state.settings, activeRuntimeEnvironmentId: parsed.environmentId }
+      : ({ activeRuntimeEnvironmentId: parsed.environmentId } as AppState['settings'])
+  }
+  if (
+    (parsed?.kind === 'local' || parsed?.kind === 'ssh') &&
+    state.settings?.activeRuntimeEnvironmentId
+  ) {
+    return { ...state.settings, activeRuntimeEnvironmentId: null }
+  }
+  return state.settings
+}
+
 function getFolderWorkspacePathStatusScopeKey(request: FolderWorkspacePathStatusRequest): string {
   if (request.scope === 'project-group') {
     return `project-group:${request.projectGroupId}`
@@ -2992,8 +3018,8 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
 
   updateProjectGroup: async (groupId, updates) => {
     try {
-      // Why: project groups are focused-host-scoped by design; all CRUD routes by the focused host and the list is replaced, not merged.
-      const target = getActiveRuntimeTarget(get().settings)
+      // Why: the sidebar lists groups from every host, so the focused host may not own this one.
+      const target = getActiveRuntimeTarget(settingsForProjectGroupOwner(get(), groupId))
       const updated =
         target.kind === 'local'
           ? await window.api.projectGroups.update({ groupId, updates })
@@ -3022,8 +3048,8 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
 
   deleteProjectGroup: async (groupId) => {
     try {
-      // Why: project groups are focused-host-scoped by design (see updateProjectGroup).
-      const target = getActiveRuntimeTarget(get().settings)
+      // Why: groups are routed by their owning host, not the focused one (see updateProjectGroup).
+      const target = getActiveRuntimeTarget(settingsForProjectGroupOwner(get(), groupId))
       const deleted =
         target.kind === 'local'
           ? await window.api.projectGroups.delete({ groupId })

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -1571,10 +1571,14 @@ function settingsForProjectGroupOwner(
   state: Pick<AppState, 'projectGroups' | 'settings'>,
   groupId: string
 ) {
-  const group = state.projectGroups.find((entry) => entry.id === groupId)
-  if (!group) {
+  // Why: the catalog keys groups by [host, id], so one id can sit on several hosts.
+  // Ambiguous ownership keeps the focused host rather than guessing a row.
+  const matches = state.projectGroups.filter((entry) => entry.id === groupId)
+  const hostIds = new Set(matches.map(getProjectGroupHostId))
+  if (hostIds.size !== 1) {
     return state.settings
   }
+  const [group] = matches
   if (!group.executionHostId && !group.connectionId) {
     return state.settings
   }


### PR DESCRIPTION
## Summary

Renaming or deleting a project group fails whenever the focused runtime host is not the host that owns the group. The common case: with a runtime environment focused, deleting a **local** project group shows `Failed to delete group — Something went wrong while deleting the group. No projects were removed.`, and the group can never be removed. The mirror case (local focused, runtime-owned group) fails the same way. Rename fails identically, but silently — `updateProjectGroup` returns `false` with no toast.

Repro:

1. With **Local** focused, create a project group.
2. Switch the focused host to a runtime environment.
3. Right-click the local group → Delete group → confirm.
4. Error toast, group still there. It stays unremovable until the focused host is switched back.

Root cause — the read path and the write path disagree about scope:

- **Reads are all-host.** `fetchProjectGroupsForAllHosts` fetches local *and* every runtime environment, and `mergeFetchedProjectGroupsForHost` preserves groups whose host is not the one currently being fetched. Every group carries its owner in `executionHostId`. The sidebar deliberately shows groups from hosts other than the focused one — `fetchProjectGroupsForAllHosts` is annotated with exactly that intent.
- **Writes were focused-host.** `updateProjectGroup` / `deleteProjectGroup` routed through `getActiveRuntimeTarget(get().settings)`, ignoring `executionHostId`. The write went to a host that had never stored the group, which returns `deleted: false` / `group: null` — surfaced as `group-delete-failed`, or swallowed for rename.

The `// Why: project groups are focused-host-scoped by design ... the list is replaced, not merged` comments on those two functions predate all-host loading and no longer describe the code.

Fix: route both writes by the group's owning host through a new `settingsForProjectGroupOwner`, mirroring the existing `settingsForRepoOwner`. Groups with neither `executionHostId` nor `connectionId` keep the previous focused-host behavior, so a partially-hydrated store cannot change routing.

## Screenshots

No visual change — the fix is store routing. Recording below shows the bug being reproduced on `main`: a local project group is deleted while a runtime environment is focused, and the delete is rejected.

The app UI in the recording is Chinese. The toast reads "Failed to delete group / Something went wrong while deleting the group. No projects were removed." — `groupDeleteFailed` / `groupDeleteFailedDesc`.

https://github.com/user-attachments/assets/b96066ae-6e1f-41a6-99ae-21780853ae4d

## Testing

- [x] `pnpm lint` — passes.
- [x] `pnpm typecheck` — passes.
- [x] `pnpm test` — 56,304 passed. 19 failures in 13 files, all pre-existing on this machine and unrelated to this change (real-git, PTY, shell-startup and WSL suites). Verified by running that same 13-file set on the branch and on clean `origin/main`: main fails 15, the branch fails 8, and no file fails on the branch that passes on main. This machine runs Node v26.7.0 while the repo pins Node 24, which is the likely cause.
- [x] `pnpm build` — passes.
- [x] Added tests that would catch this regression.

The full renderer store suite (`src/renderer/src/store/slices/`, 267 files / 2,674 tests) passes.

New `repos-project-groups-host-routing.test.ts` covers four cases: a local group deleted and renamed while a runtime environment is focused (must go to local IPC), a runtime-owned group deleted while local is focused (must go to that environment's RPC), and an owner-less group still following the focused host. All three routing tests were confirmed to fail without the fix and pass with it.

One existing case in `repos-project-groups-delete.test.ts` asserted the buggy routing (an owner-less group sent to `env-1`). Its actual subject is the remote response shape, so the fixture group is now tagged `executionHostId: 'runtime:env-1'` and every assertion is unchanged.

## AI Review Report

Reviewed with Claude Code. What it checked and found:

- **Cross-platform (macOS / Linux / Windows):** nothing platform-dependent is touched — no shortcuts, labels, path building, shell invocation, or Electron platform APIs. This is renderer store routing over ids already in state, identical on all three.
- **SSH / remote / local:** the main risk area. `getProjectGroupHostId` resolves an SSH group through `connectionId` to `ssh:<target>`; SSH-backed groups live in the local store, so they correctly route to local IPC — the same conclusion `settingsForRepoOwner` reaches for SSH repos. Runtime-owned groups route to their own environment. Checked against all three branches of `parseExecutionHostId`.
- **Backward compatibility:** the `!executionHostId && !connectionId` early return preserves today's behavior for any group not yet tagged by a fetch, and is covered by a test.
- **Performance:** one `Array.find` over `projectGroups` per rename/delete — user-initiated, not a hot path.
- **Provider / agent neutrality:** nothing provider- or agent-specific.
- **Flagged and fixed during review:** `updateProjectGroup` now passes the owner target into `projectGroupWithFetchedOwner`, which also removes a latent mislabel — a rename issued while a runtime was focused used to re-stamp a local group's `executionHostId` with that runtime.
- **Pre-existing limitation, deliberately unchanged:** `deleteProjectGroup` clears the whole subtree from renderer state but issues a single host call, so a group tree spanning two hosts would leave the other host's children behind. That predates this PR; the fix at least guarantees the targeted group reaches the host that owns it.

## Security Audit

No new input handling, command execution, path handling, auth, secrets, or dependency surface. The change only selects which already-registered transport — local IPC or an existing runtime RPC target — receives a `groupId` that is already in renderer state. Both endpoints keep their own validation (`parseProjectGroupIpcArgs` on the IPC side). `parseExecutionHostId` rejects a malformed host id and the helper then falls back to the focused host rather than fabricating a target, so a corrupted `executionHostId` cannot redirect a write to an arbitrary environment. No IPC surface added or widened.

## Notes

- The group catalog keys rows by `[host, id]`, so one id can exist on several hosts. Ownership is resolved only when every row sharing the id agrees on one host; a split id keeps the focused host rather than guessing, matching the fallback `getFolderWorkspaceHostId` already uses. The state updates inside `updateProjectGroup` / `deleteProjectGroup` still match by id alone — that predates this PR, and threading host identity through them would pull in the dialog and drag call sites, so it is left for a follow-up.
- `updateFolderWorkspace` / `deleteFolderWorkspace` still route by focused host and are reachable from the same all-host sidebar, so they can fail the same way. Left out to keep this PR on one topic — happy to follow up in a separate PR.
