### PR TITLE
fix(ssh): kill the relay daemon before discarding its socket

### DIFF
--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -77,7 +77,10 @@ import {
 import { detectRemoteHostPlatform } from './ssh-remote-platform-detection'
 import { powerShellCommand, powerShellLiteral, powerShellNativeArg } from './ssh-remote-powershell'
 import { relaySocketNameForInstanceId } from './ssh-relay-instance-id'
-import { terminateRelaySocketHolderScript } from './ssh-relay-socket-termination'
+import {
+  RELAY_SOCKET_HOLDER_UNKNOWN_MARKER,
+  terminateRelaySocketHolderScript
+} from './ssh-relay-socket-termination'
 import { isSshSessionLimitError } from './ssh-session-limit-error'
 import {
   isWindowsRelayPipePath,
@@ -1443,7 +1446,7 @@ async function launchRelay(
         // Why: kill the daemon before dropping its socket — the socket path is the only
         // handle left on a detached relay, so unlinking first strands it and every PTY it
         // owns with nothing able to reach or reap them (#8585).
-        await execCommand(
+        const cleanupOutput = await execCommand(
           conn,
           terminateRelaySocketHolderScript(shellEscape(sockFile), shellEscape(sockName)).join('\n'),
           { signal }
@@ -1451,8 +1454,16 @@ async function launchRelay(
           if (isUnconfirmedSshCommandTermination(cleanupErr)) {
             throw cleanupErr
           }
+          return ''
         })
         signal?.throwIfAborted()
+        if (cleanupOutput.includes(RELAY_SOCKET_HOLDER_UNKNOWN_MARKER)) {
+          // Why: the socket is kept on purpose, so the fresh launch below may hit
+          // EADDRINUSE and refuse rather than orphan a daemon that is still live (#8585).
+          console.warn(
+            '[ssh-relay] Host has neither lsof nor pgrep; kept the relay socket so a live daemon stays reachable'
+          )
+        }
       }
     }
   } catch (err) {

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -77,6 +77,7 @@ import {
 import { detectRemoteHostPlatform } from './ssh-remote-platform-detection'
 import { powerShellCommand, powerShellLiteral, powerShellNativeArg } from './ssh-remote-powershell'
 import { relaySocketNameForInstanceId } from './ssh-relay-instance-id'
+import { terminateRelaySocketHolderScript } from './ssh-relay-socket-termination'
 import { isSshSessionLimitError } from './ssh-session-limit-error'
 import {
   isWindowsRelayPipePath,
@@ -1439,14 +1440,18 @@ async function launchRelay(
           '[ssh-relay] Socket reconnect failed, launching fresh relay:',
           err instanceof Error ? err.message : String(err)
         )
-        // Why: stale socket from a crashed relay — remove it so the fresh launch can bind at the same path.
-        await execCommand(conn, `rm -f ${shellEscape(sockFile)}`, { signal }).catch(
-          (cleanupErr) => {
-            if (isUnconfirmedSshCommandTermination(cleanupErr)) {
-              throw cleanupErr
-            }
+        // Why: kill the daemon before dropping its socket — the socket path is the only
+        // handle left on a detached relay, so unlinking first strands it and every PTY it
+        // owns with nothing able to reach or reap them (#8585).
+        await execCommand(
+          conn,
+          terminateRelaySocketHolderScript(shellEscape(sockFile), shellEscape(sockName)).join('\n'),
+          { signal }
+        ).catch((cleanupErr) => {
+          if (isUnconfirmedSshCommandTermination(cleanupErr)) {
+            throw cleanupErr
           }
-        )
+        })
         signal?.throwIfAborted()
       }
     }

--- a/src/main/ssh/ssh-relay-reset.test.ts
+++ b/src/main/ssh/ssh-relay-reset.test.ts
@@ -12,12 +12,13 @@ vi.mock('./ssh-relay-deploy-helpers', () => ({
 import { forceStopRelayForTarget } from './ssh-relay-reset'
 import { execCommand } from './ssh-relay-deploy-helpers'
 import { relaySocketNameForInstanceId } from './ssh-relay-instance-id'
+import { RELAY_SOCKET_HOLDER_UNKNOWN_MARKER } from './ssh-relay-socket-termination'
 import type { SshConnection } from './ssh-connection'
 
 const TARGET_PID = '11111'
 const UNRELATED_PID = '22222'
 
-type LsofMode = 'match' | 'empty'
+type HolderProbeMode = 'match' | 'empty' | 'absent'
 
 function writeExecutable(filePath: string, body: string): void {
   writeFileSync(filePath, `#!/bin/sh\n${body}\n`, { mode: 0o755 })
@@ -47,25 +48,29 @@ async function capturedResetScript(): Promise<string> {
   return vi.mocked(execCommand).mock.lastCall?.[1] ?? ''
 }
 
-async function runResetScript(lsofMode: LsofMode): Promise<{
+async function runResetScript(mode: HolderProbeMode): Promise<{
   killCalls: string[]
   pgrepCalls: string[]
   socketExists: boolean
+  stdout: string
 }> {
   const script = await capturedResetScript()
   const home = mkdtempSync(join(tmpdir(), 'orca-'))
   const binDir = join(home, 'bin')
+  // Why: an empty PATH entry is how 'absent' models a host that ships neither tool.
+  const emptyBinDir = join(home, 'empty-bin')
   const socketDir = join(home, '.orca-remote')
   const socketPath = join(socketDir, relaySocketNameForInstanceId('ssh-1'))
   const killLog = join(home, 'kill.log')
   const pgrepLog = join(home, 'pgrep.log')
   mkdirSync(binDir)
+  mkdirSync(emptyBinDir)
   mkdirSync(socketDir, { recursive: true })
   writeFileSync(killLog, '')
   writeFileSync(pgrepLog, '')
 
   const lsofBody =
-    lsofMode === 'empty'
+    mode === 'empty'
       ? 'exit 1'
       : `case " $* " in
   *" -a "*) printf '%s\\n' "$TARGET_PID" ;;
@@ -82,7 +87,7 @@ printf '%s\\n' "$TARGET_PID"`
   const server = createServer()
   try {
     await listenOnSocket(server, socketPath)
-    execFileSync(
+    const stdout = execFileSync(
       '/bin/sh',
       [
         '-c',
@@ -96,7 +101,7 @@ eval "$RESET_SCRIPT"`
           ...process.env,
           HOME: home,
           KILL_LOG: killLog,
-          PATH: `${binDir}${delimiter}${process.env.PATH ?? ''}`,
+          PATH: mode === 'absent' ? emptyBinDir : `${binDir}${delimiter}${process.env.PATH ?? ''}`,
           PGREP_LOG: pgrepLog,
           RESET_SCRIPT: script,
           TARGET_PID,
@@ -107,7 +112,8 @@ eval "$RESET_SCRIPT"`
     return {
       killCalls: readFileSync(killLog, 'utf8').split('\n').filter(Boolean),
       pgrepCalls: readFileSync(pgrepLog, 'utf8').split('\n').filter(Boolean),
-      socketExists: existsSync(socketPath)
+      socketExists: existsSync(socketPath),
+      stdout: stdout.toString()
     }
   } finally {
     await closeServer(server)
@@ -153,6 +159,19 @@ describe('forceStopRelayForTarget', () => {
       expect(result.killCalls).toEqual([`-TERM ${TARGET_PID}`, `-KILL ${TARGET_PID}`])
       expect(result.pgrepCalls).toEqual(['called'])
       expect(result.socketExists).toBe(false)
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'keeps the socket when the host has neither lsof nor pgrep',
+    async () => {
+      const result = await runResetScript('absent')
+
+      // Why (#8585): unlinking a socket whose holder we could not even look up strands the
+      // daemon just as the old code did; keeping it leaves GC and a later reset able to find it.
+      expect(result.killCalls).toEqual([])
+      expect(result.socketExists).toBe(true)
+      expect(result.stdout).toContain(RELAY_SOCKET_HOLDER_UNKNOWN_MARKER)
     }
   )
 })

--- a/src/main/ssh/ssh-relay-reset.ts
+++ b/src/main/ssh/ssh-relay-reset.ts
@@ -2,6 +2,7 @@ import type { SshConnection } from './ssh-connection'
 import { shellEscape } from './ssh-connection-utils'
 import { execCommand } from './ssh-relay-deploy-helpers'
 import { relaySocketNameForInstanceId } from './ssh-relay-instance-id'
+import { terminateRelaySocketHolderScript } from './ssh-relay-socket-termination'
 
 export async function forceStopRelayForTarget(
   conn: SshConnection,
@@ -13,24 +14,10 @@ export async function forceStopRelayForTarget(
     `sock_name=${escapedSockName}`,
     'base="${HOME}/.orca-remote"',
     'if [ -d "$base" ]; then',
+    // Why: glob every version dir — an older generation's daemon keeps running
+    // under its own install dir and only its socket name identifies it.
     '  for sock in "$base"/relay-*/"$sock_name" "$base"/"$sock_name"; do',
-    '    [ -S "$sock" ] || continue',
-    '    pid=""',
-    // Why: lsof ORs selectors by default; -a prevents reset from targeting
-    // every Unix-socket holder instead of only the per-relay socket (#8762).
-    '    if command -v lsof >/dev/null 2>&1; then',
-    '      pid=$(lsof -t -a -U "$sock" 2>/dev/null | tr "\\n" " ")',
-    '    fi',
-    '    if [ -z "$pid" ] && command -v pgrep >/dev/null 2>&1; then',
-    '      pid=$(pgrep -f "$sock_name" 2>/dev/null | ' +
-      'awk -v self="$$" -v parent="$PPID" \'$1 != self && $1 != parent\' | tr "\\n" " ")',
-    '    fi',
-    '    if [ -n "$pid" ]; then',
-    '      kill -TERM $pid 2>/dev/null || true',
-    '      sleep 0.2',
-    '      kill -KILL $pid 2>/dev/null || true',
-    '    fi',
-    '    rm -f "$sock"',
+    ...terminateRelaySocketHolderScript('"$sock"', '"$sock_name"').map((line) => `    ${line}`),
     '  done',
     'fi'
   ].join('\n')

--- a/src/main/ssh/ssh-relay-socket-termination.test.ts
+++ b/src/main/ssh/ssh-relay-socket-termination.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
-import { terminateRelaySocketHolderScript } from './ssh-relay-socket-termination'
+import {
+  RELAY_SOCKET_HOLDER_UNKNOWN_MARKER,
+  terminateRelaySocketHolderScript
+} from './ssh-relay-socket-termination'
 
 function script(sockExpr = '"$sock"', pgrepExpr = '"$sock_name"'): string {
   return terminateRelaySocketHolderScript(sockExpr, pgrepExpr).join('\n')
@@ -33,6 +36,15 @@ describe('terminateRelaySocketHolderScript', () => {
     expect(generated).toContain("rm -f '/home/u/.orca-remote/relay-0.1.0+abc/relay-1234.sock'")
     // Why: `pgrep -f` takes an ERE, so the versioned path's `+` would read as a quantifier.
     expect(generated).toContain("pgrep -f 'relay-1234.sock'")
+  })
+
+  it('gates the unlink behind a holder lookup the host can actually run', () => {
+    const generated = script()
+
+    // Why (#8585): with neither lsof nor pgrep the holder is unknown, and unlinking blind
+    // strands the daemon exactly as the pre-fix code did.
+    expect(generated.indexOf('if [ -n "$probed" ]; then')).toBeLessThan(generated.indexOf('rm -f'))
+    expect(generated).toContain(`echo ${RELAY_SOCKET_HOLDER_UNKNOWN_MARKER}`)
   })
 
   it('skips a path that is not a socket', () => {

--- a/src/main/ssh/ssh-relay-socket-termination.test.ts
+++ b/src/main/ssh/ssh-relay-socket-termination.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import { terminateRelaySocketHolderScript } from './ssh-relay-socket-termination'
+
+function script(sockExpr = '"$sock"', pgrepExpr = '"$sock_name"'): string {
+  return terminateRelaySocketHolderScript(sockExpr, pgrepExpr).join('\n')
+}
+
+describe('terminateRelaySocketHolderScript', () => {
+  it('kills the socket holder before unlinking the socket', () => {
+    const generated = script()
+
+    // Why (#8585): the socket path is the only handle on a detached relay — unlink
+    // first and the daemon plus its PTYs leak with nothing able to find them again.
+    expect(generated.indexOf('kill -TERM')).toBeLessThan(generated.indexOf('rm -f'))
+    expect(generated).toContain('kill -KILL $pid')
+  })
+
+  it('scopes lsof to the one relay socket', () => {
+    // Why (#8762): lsof ORs its selectors, so -a is what keeps this off unrelated holders.
+    expect(script()).toContain('lsof -t -a -U "$sock"')
+  })
+
+  it('accepts a literal socket path and a separate pgrep pattern', () => {
+    const generated = script(
+      "'/home/u/.orca-remote/relay-0.1.0+abc/relay-1234.sock'",
+      "'relay-1234.sock'"
+    )
+
+    expect(generated).toContain(
+      "if [ -S '/home/u/.orca-remote/relay-0.1.0+abc/relay-1234.sock' ]; then"
+    )
+    expect(generated).toContain("rm -f '/home/u/.orca-remote/relay-0.1.0+abc/relay-1234.sock'")
+    // Why: `pgrep -f` takes an ERE, so the versioned path's `+` would read as a quantifier.
+    expect(generated).toContain("pgrep -f 'relay-1234.sock'")
+  })
+
+  it('skips a path that is not a socket', () => {
+    expect(script()).toContain('if [ -S "$sock" ]; then')
+  })
+})

--- a/src/main/ssh/ssh-relay-socket-termination.ts
+++ b/src/main/ssh/ssh-relay-socket-termination.ts
@@ -1,0 +1,38 @@
+/**
+ * Kill whatever process still holds a relay socket, then unlink the socket.
+ *
+ * Why kill before unlink: the socket file is the only handle anything keeps on a
+ * detached relay — GC probes for `relay-*.sock` and reset globs the same name.
+ * Unlinking first strands the daemon (and every PTY/agent it owns) with nothing
+ * left that can reach or reap it (#8585).
+ *
+ * `sockExpr` and `pgrepPatternExpr` are shell expressions the caller has already
+ * quoted, so this works for both a loop variable and a literal path. Keep the
+ * pgrep pattern to the socket basename: `pgrep -f` takes an ERE, and a full
+ * versioned path (`relay-0.1.0+<hash>`) would have its `+` read as a quantifier.
+ */
+export function terminateRelaySocketHolderScript(
+  sockExpr: string,
+  pgrepPatternExpr: string
+): string[] {
+  return [
+    `if [ -S ${sockExpr} ]; then`,
+    '  pid=""',
+    // Why: lsof ORs selectors by default; -a keeps this to the one relay socket
+    // instead of every Unix-socket holder on the host (#8762).
+    '  if command -v lsof >/dev/null 2>&1; then',
+    `    pid=$(lsof -t -a -U ${sockExpr} 2>/dev/null | tr "\\n" " ")`,
+    '  fi',
+    '  if [ -z "$pid" ] && command -v pgrep >/dev/null 2>&1; then',
+    `    pid=$(pgrep -f ${pgrepPatternExpr} 2>/dev/null | ` +
+      'awk -v self="$$" -v parent="$PPID" \'$1 != self && $1 != parent\' | tr "\\n" " ")',
+    '  fi',
+    '  if [ -n "$pid" ]; then',
+    '    kill -TERM $pid 2>/dev/null || true',
+    '    sleep 0.2',
+    '    kill -KILL $pid 2>/dev/null || true',
+    '  fi',
+    `  rm -f ${sockExpr}`,
+    'fi'
+  ]
+}

--- a/src/main/ssh/ssh-relay-socket-termination.ts
+++ b/src/main/ssh/ssh-relay-socket-termination.ts
@@ -1,5 +1,9 @@
+// Emitted when neither lsof nor pgrep exists, so the socket is kept rather than unlinked.
+export const RELAY_SOCKET_HOLDER_UNKNOWN_MARKER = 'ORCA-RELAY-HOLDER-UNKNOWN'
+
 /**
- * Kill whatever process still holds a relay socket, then unlink the socket.
+ * Kill whatever process still holds a relay socket, then unlink the socket — unless the
+ * host offers no way to look the holder up, in which case the socket is kept.
  *
  * Why kill before unlink: the socket file is the only handle anything keeps on a
  * detached relay — GC probes for `relay-*.sock` and reset globs the same name.
@@ -18,12 +22,15 @@ export function terminateRelaySocketHolderScript(
   return [
     `if [ -S ${sockExpr} ]; then`,
     '  pid=""',
+    '  probed=""',
     // Why: lsof ORs selectors by default; -a keeps this to the one relay socket
     // instead of every Unix-socket holder on the host (#8762).
     '  if command -v lsof >/dev/null 2>&1; then',
+    '    probed=1',
     `    pid=$(lsof -t -a -U ${sockExpr} 2>/dev/null | tr "\\n" " ")`,
     '  fi',
     '  if [ -z "$pid" ] && command -v pgrep >/dev/null 2>&1; then',
+    '    probed=1',
     `    pid=$(pgrep -f ${pgrepPatternExpr} 2>/dev/null | ` +
       'awk -v self="$$" -v parent="$PPID" \'$1 != self && $1 != parent\' | tr "\\n" " ")',
     '  fi',
@@ -32,7 +39,14 @@ export function terminateRelaySocketHolderScript(
     '    sleep 0.2',
     '    kill -KILL $pid 2>/dev/null || true',
     '  fi',
-    `  rm -f ${sockExpr}`,
+    // Why: with neither lsof nor pgrep the holder is unknown, and unlinking blind recreates
+    // the orphan this guards against; keeping the socket leaves the daemon reachable, and a
+    // fresh relay's own EADDRINUSE probe unlinks it if it really is stale.
+    '  if [ -n "$probed" ]; then',
+    `    rm -f ${sockExpr}`,
+    '  else',
+    `    echo ${RELAY_SOCKET_HOLDER_UNKNOWN_MARKER}`,
+    '  fi',
     'fi'
   ]
 }

--- a/src/main/ssh/ssh-relay-stale-socket-cleanup.test.ts
+++ b/src/main/ssh/ssh-relay-stale-socket-cleanup.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: { getAppPath: () => '/mock/app' }
+}))
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn().mockReturnValue(true),
+  readFileSync: vi.fn().mockReturnValue('0.1.0+abcdef012345')
+}))
+
+vi.mock('./relay-protocol', () => ({
+  RELAY_VERSION: '0.1.0',
+  RELAY_REMOTE_DIR: '.orca-remote',
+  parseUnameToRelayPlatform: vi.fn((os: string, arch: string) => {
+    const normalizedOs = os.toLowerCase()
+    const normalizedArch = arch.toLowerCase()
+    const relayArch = normalizedArch === 'arm64' || normalizedArch === 'aarch64' ? 'arm64' : 'x64'
+    if (normalizedOs === 'windows' || normalizedOs === 'win32') {
+      return `win32-${relayArch}`
+    }
+    if (normalizedOs === 'darwin') {
+      return `darwin-${relayArch}`
+    }
+    if (normalizedOs === 'linux') {
+      return `linux-${relayArch}`
+    }
+    return null
+  }),
+  RELAY_SENTINEL: 'ORCA-RELAY v0.1.0 READY\n',
+  RELAY_SENTINEL_TIMEOUT_MS: 10_000
+}))
+
+vi.mock('./ssh-relay-deploy-helpers', () => ({
+  uploadDirectory: vi.fn().mockResolvedValue(undefined),
+  waitForSentinel: vi.fn().mockResolvedValue({
+    write: vi.fn(),
+    onData: vi.fn(),
+    onClose: vi.fn()
+  }),
+  isUnconfirmedSshCommandTermination: (error: unknown) =>
+    error instanceof Error &&
+    (error as Error & { sshChannelCloseConfirmed?: boolean }).sshChannelCloseConfirmed === false,
+  execCommand: vi.fn().mockResolvedValue('__ORCA_REMOTE_PLATFORM__ Linux x86_64')
+}))
+
+vi.mock('./ssh-remote-node-resolution', () => ({
+  resolveRemoteNodePath: vi.fn().mockResolvedValue('/usr/bin/node')
+}))
+
+vi.mock('./ssh-relay-versioned-install', () => ({
+  readLocalFullVersion: vi.fn().mockReturnValue('0.1.0+abcdef012345'),
+  computeRemoteRelayDir: (home: string, v: string) => `${home}/.orca-remote/relay-${v}`,
+  isRelayAlreadyInstalled: vi.fn().mockResolvedValue(true),
+  finalizeInstall: vi.fn().mockResolvedValue(undefined),
+  abandonInstall: vi.fn().mockResolvedValue(undefined),
+  gcOldRelayVersions: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('./ssh-relay-install-lock', () => ({
+  acquireInstallLock: vi.fn().mockResolvedValue(undefined),
+  RELAY_INSTALL_LOCK_NAME: '.install-lock'
+}))
+
+vi.mock('./ssh-relay-repair-lock', () => ({
+  tryAcquireRelayRepairLock: vi.fn().mockResolvedValue('acquired')
+}))
+
+vi.mock('./ssh-connection-utils', () => ({
+  shellEscape: (s: string) => `'${s}'`,
+  createSshOperationAbortError: () =>
+    Object.assign(new Error('SSH operation was cancelled'), {
+      name: 'AbortError'
+    })
+}))
+
+import { deployAndLaunchRelay } from './ssh-relay-deploy'
+import { execCommand, waitForSentinel } from './ssh-relay-deploy-helpers'
+import { resolveRemoteNodePath } from './ssh-remote-node-resolution'
+import { isRelayAlreadyInstalled } from './ssh-relay-versioned-install'
+import { acquireInstallLock } from './ssh-relay-install-lock'
+import type { SshConnection } from './ssh-connection'
+
+function makeMockConnection(): SshConnection {
+  return {
+    canRunConcurrentExecCommands: vi.fn().mockReturnValue(true),
+    exec: vi.fn().mockResolvedValue({
+      on: vi.fn(),
+      stderr: { on: vi.fn() },
+      stdin: {},
+      stdout: { on: vi.fn() },
+      close: vi.fn()
+    }),
+    sftp: vi.fn().mockResolvedValue({
+      mkdir: vi.fn((_p: string, cb: (err: Error | null) => void) => cb(null)),
+      createWriteStream: vi.fn().mockReturnValue({
+        on: vi.fn((_event: string, cb: () => void) => {
+          if (_event === 'close') {
+            setTimeout(cb, 0)
+          }
+        }),
+        end: vi.fn()
+      }),
+      end: vi.fn()
+    })
+  } as unknown as SshConnection
+}
+
+describe('stale relay socket cleanup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(execCommand).mockReset().mockResolvedValue('__ORCA_REMOTE_PLATFORM__ Linux x86_64')
+    vi.mocked(waitForSentinel).mockReset().mockResolvedValue({
+      write: vi.fn(),
+      onData: vi.fn(),
+      onClose: vi.fn()
+    })
+    vi.mocked(resolveRemoteNodePath).mockReset().mockResolvedValue('/usr/bin/node')
+    vi.mocked(isRelayAlreadyInstalled).mockReset().mockResolvedValue(true)
+    vi.mocked(acquireInstallLock).mockReset().mockResolvedValue(undefined)
+  })
+
+  it('kills the daemon holding a stale relay socket before unlinking it', async () => {
+    const conn = makeMockConnection()
+    // A live socket whose --connect handshake fails: the deploy discards this socket.
+    vi.mocked(waitForSentinel).mockRejectedValueOnce(new Error('stale relay reconnect failed'))
+    vi.mocked(execCommand).mockImplementation((_conn, command) => {
+      if (command.includes('uname')) {
+        return Promise.resolve('__ORCA_REMOTE_PLATFORM__ Linux x86_64')
+      }
+      if (command.trim() === 'echo $HOME') {
+        return Promise.resolve('/home/user')
+      }
+      if (command.includes('ORCA-NATIVE-DEPS')) {
+        return Promise.resolve('ORCA-NATIVE-DEPS-OK')
+      }
+      if (command.includes('echo ALIVE')) {
+        return Promise.resolve('ALIVE')
+      }
+      if (command.includes('require("net")')) {
+        return Promise.resolve('READY')
+      }
+      return Promise.resolve('')
+    })
+
+    await deployAndLaunchRelay(conn)
+
+    const cleanup = vi
+      .mocked(execCommand)
+      .mock.calls.map(([, command]) => command)
+      .find((command) => command.includes('rm -f'))
+    expect(cleanup).toBeDefined()
+    expect(cleanup).toContain('lsof -t -a -U')
+    expect(cleanup).toContain('kill -TERM $pid')
+    // Why (#8585): unlinking first strands the daemon and every PTY it owns — the
+    // socket path is the only handle GC and reset have on it.
+    expect(cleanup?.indexOf('kill -TERM')).toBeLessThan(cleanup?.indexOf('rm -f') ?? -1)
+  })
+})

--- a/src/main/ssh/ssh-relay-stale-socket-cleanup.test.ts
+++ b/src/main/ssh/ssh-relay-stale-socket-cleanup.test.ts
@@ -79,6 +79,7 @@ import { execCommand, waitForSentinel } from './ssh-relay-deploy-helpers'
 import { resolveRemoteNodePath } from './ssh-remote-node-resolution'
 import { isRelayAlreadyInstalled } from './ssh-relay-versioned-install'
 import { acquireInstallLock } from './ssh-relay-install-lock'
+import { RELAY_SOCKET_HOLDER_UNKNOWN_MARKER } from './ssh-relay-socket-termination'
 import type { SshConnection } from './ssh-connection'
 
 function makeMockConnection(): SshConnection {
@@ -106,6 +107,28 @@ function makeMockConnection(): SshConnection {
   } as unknown as SshConnection
 }
 
+function routeRemoteCommand(command: string, cleanupOutput = ''): Promise<string> | null {
+  if (command.includes('uname')) {
+    return Promise.resolve('__ORCA_REMOTE_PLATFORM__ Linux x86_64')
+  }
+  if (command.trim() === 'echo $HOME') {
+    return Promise.resolve('/home/user')
+  }
+  if (command.includes('ORCA-NATIVE-DEPS')) {
+    return Promise.resolve('ORCA-NATIVE-DEPS-OK')
+  }
+  if (command.includes('echo ALIVE')) {
+    return Promise.resolve('ALIVE')
+  }
+  if (command.includes('require("net")')) {
+    return Promise.resolve('READY')
+  }
+  if (command.includes('rm -f')) {
+    return Promise.resolve(cleanupOutput)
+  }
+  return null
+}
+
 describe('stale relay socket cleanup', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -124,24 +147,9 @@ describe('stale relay socket cleanup', () => {
     const conn = makeMockConnection()
     // A live socket whose --connect handshake fails: the deploy discards this socket.
     vi.mocked(waitForSentinel).mockRejectedValueOnce(new Error('stale relay reconnect failed'))
-    vi.mocked(execCommand).mockImplementation((_conn, command) => {
-      if (command.includes('uname')) {
-        return Promise.resolve('__ORCA_REMOTE_PLATFORM__ Linux x86_64')
-      }
-      if (command.trim() === 'echo $HOME') {
-        return Promise.resolve('/home/user')
-      }
-      if (command.includes('ORCA-NATIVE-DEPS')) {
-        return Promise.resolve('ORCA-NATIVE-DEPS-OK')
-      }
-      if (command.includes('echo ALIVE')) {
-        return Promise.resolve('ALIVE')
-      }
-      if (command.includes('require("net")')) {
-        return Promise.resolve('READY')
-      }
-      return Promise.resolve('')
-    })
+    vi.mocked(execCommand).mockImplementation((_conn, command) =>
+      routeRemoteCommand(command) ?? Promise.resolve('')
+    )
 
     await deployAndLaunchRelay(conn)
 
@@ -155,5 +163,22 @@ describe('stale relay socket cleanup', () => {
     // Why (#8585): unlinking first strands the daemon and every PTY it owns — the
     // socket path is the only handle GC and reset have on it.
     expect(cleanup?.indexOf('kill -TERM')).toBeLessThan(cleanup?.indexOf('rm -f') ?? -1)
+  })
+
+  it('reports the kept socket when the host cannot look the holder up', async () => {
+    const conn = makeMockConnection()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.mocked(waitForSentinel).mockRejectedValueOnce(new Error('stale relay reconnect failed'))
+    vi.mocked(execCommand).mockImplementation(
+      (_conn, command) =>
+        routeRemoteCommand(command, RELAY_SOCKET_HOLDER_UNKNOWN_MARKER) ?? Promise.resolve('')
+    )
+
+    await deployAndLaunchRelay(conn)
+
+    // Why (#8585): the socket survives on purpose, so the operator needs to know why a
+    // relaunch here can fail on EADDRINUSE instead of silently orphaning the daemon.
+    expect(warn.mock.calls.flat().join(' ')).toContain('kept the relay socket')
+    warn.mockRestore()
   })
 })


### PR DESCRIPTION
## ELI5

When Orca can't reattach to a relay it left running on an SSH host, it deletes the relay's socket file and starts a new one. But the old relay process keeps running — with all your terminals and agents inside it. And because the socket file was the only way to find that process, nothing can ever reach it or clean it up again. It just sits there eating memory until the host reboots.

This makes Orca kill the old relay *before* deleting its socket.

## What Changed

- New `ssh-relay-socket-termination.ts`: one builder for the "find whatever holds this socket, kill it, then unlink" shell sequence.
- `ssh-relay-deploy.ts`: on a failed `--connect`, terminate the socket holder before `rm -f` instead of only unlinking.
- `ssh-relay-reset.ts`: uses the same builder (behavior unchanged — it already did kill-then-unlink; this just stops the two paths from drifting).
- The unlink is gated on a holder lookup that actually ran. A host with neither `lsof` nor `pgrep` keeps its socket instead, and `launchRelay` logs why. Keeping it is enough: a replacement relay hits `EADDRINUSE`, probe-connects, and refuses to start rather than stealing the path from a live daemon — while a genuinely stale socket is unlinked by that same probe.

The pgrep fallback is deliberately given the socket **basename**, not the full path: `pgrep -f` takes an ERE, and a versioned install dir (`relay-0.1.0+<hash>`) would have its `+` parsed as a quantifier and never match.

POSIX hosts only — the Windows named-pipe launch path returns earlier and is untouched.

## Why

`launchRelay` probes for a live socket and tries `--connect` to preserve PTY state across restarts. When that handshake fails it assumes a stale socket from a crashed relay, unlinks it, and launches fresh. But the relay is detached (`nohup`, and with `--grace-time 0` it never self-exits), so a *live* daemon whose `--connect` failed for any other reason survives the unlink — and both mechanisms that could reap it are keyed on the socket file that just got deleted:

- version-dir GC decides a dir is reclaimable via `ls relay-*.sock` (`hasLiveRelaySocket`)
- Reset Relay finds the PID via `lsof -t -a -U "$sock"` after globbing `"$base"/relay-*/"$sock_name"`

So after the unlink, the daemon and every PTY/agent under it are unreachable and unreapable for the life of the host. Killing before unlinking costs nothing — the client is discarding that socket either way, so those sessions are already lost — and it turns a permanent leak into a clean teardown.

## Linked Issue

Fixes #8585

## Visual Proof

`N/A` — no UI or interaction change. The behavior is a remote process teardown; evidence is in Testing below.

## Testing

Automated (`src/main/ssh`):

- `ssh-relay-socket-termination.test.ts` — kill precedes unlink, `lsof -a` scoping is preserved, literal-path/basename parameterization, and the unlink stays behind the "a lookup actually ran" gate.
- `ssh-relay-stale-socket-cleanup.test.ts` — drives `deployAndLaunchRelay` through a live-socket + failed-handshake reconnect and asserts the cleanup command kills before it unlinks; a second case asserts the kept-socket warning when the script reports an unknown holder.
- `ssh-relay-reset.test.ts` — executes the generated script against a real unix socket with faked `lsof`/`pgrep`/`kill`; extended with a mode where neither binary is on `PATH`, asserting no `kill` runs and the socket survives.

Manual — because the script-executing tests are `skipIf(win32)` and I develop on Windows, I ran the generated shell in a real POSIX shell (WSL Ubuntu 24.04 and 22.04) against a Python process holding a real `AF_UNIX` socket:

| Scenario | Result |
| --- | --- |
| `lsof` present | daemon killed, socket removed |
| `lsof` returns nothing (pgrep fallback) | daemon killed, socket removed |
| Reset across two version dirs + a second target's socket | both same-name relays killed; the other target's relay and socket untouched |
| Neither `lsof` nor `pgrep` on `PATH` | daemon left alive, socket kept, unknown-holder marker emitted |

Checks run locally on Windows: `pnpm typecheck` (pass), `oxlint` repo-wide (pass), `audit:code-quality:native` and `audit:code-quality:type-aware` (pass), `check:max-lines-ratchet` (pass), `check:reliability-gates` (pass), `verify:localization-catalog` / `verify:localization-coverage` (pass), `vitest run src/main/ssh` (23 failed files — **identical to the same run on a clean `main` checkout**; all pre-existing Windows-environment failures, none in the touched files). `verify:skill-bundle-manifest` and `verify:localization-extraction` also fail identically on clean `main` here. `pnpm build` not run locally — leaving that to CI. All of the above were re-run on 323c00921 after the review fix; the `src/main/ssh` failure count is unchanged at 23, and the three touched files are green on their own (8 passed, 3 POSIX-only cases skipped on Windows and covered by the WSL run above).

Platforms actually exercised: Windows (host, unit tests) + Linux via WSL (generated shell). Not exercised: macOS, and a real remote SSH host.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Written with Claude Code (Claude Opus 5). The diagnosis came from a live reproduction on my own SSH host; I reviewed and verified every change.

## Review

Two related leaks I found while reproducing this, deliberately **not** in this PR because they need a maintainer's call on policy:

1. **Old-generation relays after an app update.** This is what I actually hit. A new Orca release installs to a new version dir and launches a relay there; the previous version's daemon keeps running in its own dir with its socket intact, so GC's liveness probe returns ALIVE and refuses to reclaim the dir — forever. On my host that left three relays alive at once (two orphans at 5d8h uptime holding 5 `codex` processes, plus the current one). Reset Relay *can* reach them since its glob covers every version dir, but nothing does it automatically. Reaping a live older-generation relay is a policy decision (another client may legitimately be attached), so it wants its own discussion — related: #11943, #12895.
2. **Leases stuck in `detached`.** `reattachKnownPtys` treats an identity mismatch as `continue` without marking the lease expired, so those leases are retried on every reconnect and never cleared. I had 5 sitting for 33–58 hours.

Happy to follow up on either if you'd like them addressed.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Security: narrows rather than widens what gets killed — the `-a` selector scoping from #8762 is carried over verbatim, and both socket path and pgrep pattern go through `shellEscape`. Cross-platform: POSIX-only path; Windows unaffected. Remote SSH: this *is* the SSH path. Backwards compatibility: no wire or protocol change; the client only sends a different cleanup command. Performance: one extra remote command, and only on a reconnect that already failed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — see Testing for exactly what ran locally and what I left to CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

