### PR TITLE
fix(mobile): honor pinned workspace display preference

### DIFF
--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -75,6 +75,7 @@ import {
 import {
   applyDesktopViewSettings,
   groupModeToDesktop,
+  loadDesktopWorkspaceSettings,
   type MobileGroupMode,
   type MobileSortMode,
   type MobileViewState,
@@ -176,6 +177,7 @@ export function HostScreen({
     alwaysShowDefaultBranch: true
   })
   const [groupMode, setGroupMode] = useState<MobileGroupMode>('repo')
+  const [showPinnedWorktreesInGroups, setShowPinnedWorktreesInGroups] = useState(false)
   const [workspaceStatuses, setWorkspaceStatuses] = useState<readonly WorkspaceStatusDefinition[]>(
     DEFAULT_MOBILE_WORKSPACE_STATUSES
   )
@@ -307,19 +309,15 @@ export function HostScreen({
       return
     }
     const requestClient = client
-    const requestHostId = hostId
-    try {
-      const response = await requestClient.sendRequest('ui.get')
-      if (clientRef.current !== requestClient || hostId !== requestHostId || !response.ok) {
-        return
-      }
-      const ui = ((response as RpcSuccess).result as { ui?: WorkspaceViewSettings }).ui
-      if (!ui) {
-        return
-      }
-      applyViewState(applyDesktopViewSettings(viewStateRef.current, ui))
-    } catch {
-      // Transient transport failure; retry on the next focus/connect.
+    const settings = await loadDesktopWorkspaceSettings(requestClient)
+    if (clientRef.current !== requestClient) {
+      return
+    }
+    if (settings.ui) {
+      applyViewState(applyDesktopViewSettings(viewStateRef.current, settings.ui))
+    }
+    if (settings.showPinnedWorktreesInGroups !== undefined) {
+      setShowPinnedWorktreesInGroups(settings.showPinnedWorktreesInGroups)
     }
   }, [client, connState, hostId, applyViewState])
 
@@ -331,6 +329,7 @@ export function HostScreen({
   useEffect(() => {
     setHostName('')
     setError('')
+    setShowPinnedWorktreesInGroups(false)
     setRepoColorsByName(new Map())
     setRepoIconsByName(new Map())
     repoMetadataFetchedAtRef.current = 0
@@ -786,7 +785,8 @@ export function HostScreen({
     repoIdsByName,
     repoColorsByName,
     collapsedGroups,
-    workspaceStatuses
+    workspaceStatuses,
+    showPinnedWorktreesInGroups
   })
   const existingWorktreePaths = useMemo(() => worktrees.map((w) => w.path), [worktrees])
 

--- a/mobile/src/worktree/use-workspace-sections.ts
+++ b/mobile/src/worktree/use-workspace-sections.ts
@@ -26,6 +26,7 @@ export function useWorkspaceSections(args: {
   repoColorsByName: Map<string, string>
   collapsedGroups: Set<string>
   workspaceStatuses: readonly WorkspaceStatusDefinition[]
+  showPinnedWorktreesInGroups: boolean
 }): {
   sections: Section[]
   rawSections: Section[]
@@ -42,7 +43,8 @@ export function useWorkspaceSections(args: {
     repoIdsByName,
     repoColorsByName,
     collapsedGroups,
-    workspaceStatuses
+    workspaceStatuses,
+    showPinnedWorktreesInGroups
   } = args
 
   const uniqueRepos = useMemo(() => {
@@ -74,7 +76,8 @@ export function useWorkspaceSections(args: {
         pinnedIds,
         repoIdsByName,
         workspaceStatuses,
-        collapsedGroups
+        collapsedGroups,
+        showPinnedWorktreesInGroups
       ),
     [
       displayWorktrees,
@@ -85,7 +88,8 @@ export function useWorkspaceSections(args: {
       pinnedIds,
       repoIdsByName,
       workspaceStatuses,
-      collapsedGroups
+      collapsedGroups,
+      showPinnedWorktreesInGroups
     ]
   )
 

--- a/mobile/src/worktree/workspace-list-sections.test.ts
+++ b/mobile/src/worktree/workspace-list-sections.test.ts
@@ -670,7 +670,7 @@ describe('buildSections', () => {
     expect(sections[0]?.data.map((worktree) => worktree.worktreeId)).toEqual(['progress'])
   })
 
-  it('keeps pinned worktrees in their canonical status group like desktop', () => {
+  it('shows pinned worktrees in one location by default like desktop', () => {
     const pinned = worktree({
       worktreeId: 'pinned',
       workspaceStatus: 'in-progress',
@@ -689,9 +689,59 @@ describe('buildSections', () => {
     )
 
     expect(withoutSectionListKeys(sections)).toEqual([
-      { key: 'pinned', title: 'Pinned', icon: 'pin', data: [pinned] },
-      { key: 'workspace-status:in-progress', title: 'In progress', data: [pinned] }
+      { key: 'pinned', title: 'Pinned', icon: 'pin', data: [pinned] }
     ])
+  })
+
+  it.each([
+    ['none', 'all'],
+    ['repo', 'repo:repo-1'],
+    ['workspaceStatus', 'workspace-status:in-progress'],
+    ['prStatus', 'pr:in-progress']
+  ] as const)('duplicates pinned worktrees in %s only when enabled', (groupMode, groupKey) => {
+    const pinned = worktree({ worktreeId: 'pinned', isPinned: true })
+    const defaultSections = buildSections(
+      [pinned],
+      'manual',
+      { filterRepoIds: new Set(), hideSleeping: false, hideDefaultBranch: false },
+      '',
+      groupMode,
+      new Set(),
+      new Map([['orca', 'repo-1']]),
+      DEFAULT_MOBILE_WORKSPACE_STATUSES
+    )
+    const sections = buildSections(
+      [pinned],
+      'manual',
+      { filterRepoIds: new Set(), hideSleeping: false, hideDefaultBranch: false },
+      '',
+      groupMode,
+      new Set(),
+      new Map([['orca', 'repo-1']]),
+      DEFAULT_MOBILE_WORKSPACE_STATUSES,
+      new Set(),
+      true
+    )
+
+    expect(defaultSections.map((section) => section.key)).toEqual(['pinned'])
+    expect(sections.map((section) => section.key)).toEqual(['pinned', groupKey])
+    expect(sections[1]?.data.map((item) => item.worktreeId)).toEqual(['pinned'])
+  })
+
+  it('removes optimistic local pins from All by default', () => {
+    const pinned = worktree({ worktreeId: 'locally-pinned' })
+    const unpinned = worktree({ worktreeId: 'unpinned' })
+    const sections = buildSections(
+      [pinned, unpinned],
+      'manual',
+      { filterRepoIds: new Set(), hideSleeping: false, hideDefaultBranch: false },
+      '',
+      'none',
+      new Set(['locally-pinned'])
+    )
+
+    expect(sections[0]?.data.map((item) => item.worktreeId)).toEqual(['locally-pinned'])
+    expect(sections[1]?.data.map((item) => item.worktreeId)).toEqual(['unpinned'])
   })
 
   it('renders one sorted All section when grouping is off like desktop', () => {

--- a/mobile/src/worktree/workspace-list-sections.ts
+++ b/mobile/src/worktree/workspace-list-sections.ts
@@ -128,15 +128,16 @@ export function buildSections(
   pinnedIds: Set<string>,
   repoIdsByName: ReadonlyMap<string, string> = new Map(),
   workspaceStatuses: readonly WorkspaceStatusDefinition[] = DEFAULT_MOBILE_WORKSPACE_STATUSES,
-  collapsedGroups: ReadonlySet<string> = new Set()
+  collapsedGroups: ReadonlySet<string> = new Set(),
+  showPinnedWorktreesInGroups = false
 ): Section[] {
   const filtered = filterWorktrees(worktrees, filters, search)
   const sorted = sortWorktrees(filtered, sortMode)
 
   const pinned = sorted.filter((w) => isWorktreePinned(w, pinnedIds))
-  // Why: desktop treats Pinned as an overlay. Keeping pinned rows in canonical
-  // groups preserves exact cross-surface order and literal section counts.
-  const canonicalGroupWorktrees = sorted
+  const canonicalGroupWorktrees = showPinnedWorktreesInGroups
+    ? sorted
+    : sorted.filter((w) => !isWorktreePinned(w, pinnedIds))
 
   const sections: Section[] = []
   if (pinned.length > 0) {

--- a/mobile/src/worktree/workspace-view-settings.test.ts
+++ b/mobile/src/worktree/workspace-view-settings.test.ts
@@ -1,9 +1,11 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { DEFAULT_MOBILE_WORKSPACE_STATUSES } from './mobile-workspace-statuses'
 import {
   applyDesktopViewSettings,
+  getShowPinnedWorktreesInGroups,
   groupModeFromDesktop,
   groupModeToDesktop,
+  loadDesktopWorkspaceSettings,
   sortModeFromDesktop,
   type MobileViewState,
   type WorkspaceViewSettings
@@ -39,6 +41,35 @@ describe('sort mode mapping', () => {
     expect(sortModeFromDesktop('smart')).toBe('smart')
     expect(sortModeFromDesktop(undefined)).toBeNull()
     expect(sortModeFromDesktop('bogus' as never)).toBeNull()
+  })
+})
+
+describe('pinned workspace display preference', () => {
+  it('defaults missing and older-host settings to one location', () => {
+    expect(getShowPinnedWorktreesInGroups(undefined)).toBe(false)
+    expect(getShowPinnedWorktreesInGroups({})).toBe(false)
+  })
+
+  it('duplicates pinned workspaces only when explicitly enabled', () => {
+    expect(getShowPinnedWorktreesInGroups({ showPinnedWorktreesInGroups: false })).toBe(false)
+    expect(getShowPinnedWorktreesInGroups({ showPinnedWorktreesInGroups: true })).toBe(true)
+  })
+
+  it('loads the preference when the view settings request fails', async () => {
+    const sendRequest = vi.fn(async (method: string) => {
+      if (method === 'ui.get') {
+        throw new Error('unavailable')
+      }
+      return {
+        ok: true,
+        result: { settings: { showPinnedWorktreesInGroups: true } }
+      } as never
+    })
+
+    await expect(loadDesktopWorkspaceSettings({ sendRequest })).resolves.toEqual({
+      ui: undefined,
+      showPinnedWorktreesInGroups: true
+    })
   })
 })
 

--- a/mobile/src/worktree/workspace-view-settings.ts
+++ b/mobile/src/worktree/workspace-view-settings.ts
@@ -4,6 +4,7 @@
 // or filter change on the phone show up on desktop and vice-versa.
 
 import type { WorkspaceStatusDefinition } from '../../../src/shared/worktree/types'
+import type { RpcClient } from '../transport/rpc-client'
 import { coerceMobileWorkspaceStatuses } from './mobile-workspace-statuses'
 
 export type MobileGroupMode = 'none' | 'workspaceStatus' | 'repo' | 'prStatus'
@@ -20,6 +21,35 @@ export type WorkspaceViewSettings = {
   filterRepoIds?: string[]
   collapsedGroups?: string[]
   workspaceStatuses?: WorkspaceStatusDefinition[]
+}
+
+export type WorkspaceDisplaySettings = {
+  showPinnedWorktreesInGroups?: boolean
+}
+
+export function getShowPinnedWorktreesInGroups(
+  settings: WorkspaceDisplaySettings | null | undefined
+): boolean {
+  return settings?.showPinnedWorktreesInGroups === true
+}
+
+export async function loadDesktopWorkspaceSettings(
+  client: Pick<RpcClient, 'sendRequest'>
+): Promise<{
+  ui?: WorkspaceViewSettings
+  showPinnedWorktreesInGroups?: boolean
+}> {
+  const [uiResponse, settingsResponse] = await Promise.all([
+    client.sendRequest('ui.get').catch(() => null),
+    client.sendRequest('settings.get').catch(() => null)
+  ])
+  const ui = uiResponse?.ok ? (uiResponse.result as { ui?: WorkspaceViewSettings }).ui : undefined
+  const showPinnedWorktreesInGroups = settingsResponse?.ok
+    ? getShowPinnedWorktreesInGroups(
+        (settingsResponse.result as { settings?: WorkspaceDisplaySettings }).settings
+      )
+    : undefined
+  return { ui, showPinnedWorktreesInGroups }
 }
 
 const GROUP_TO_DESKTOP: Record<MobileGroupMode, NonNullable<WorkspaceViewSettings['groupBy']>> = {

--- a/mobile/src/worktree/workspace-view-settings.ts
+++ b/mobile/src/worktree/workspace-view-settings.ts
@@ -27,12 +27,14 @@ export type WorkspaceDisplaySettings = {
   showPinnedWorktreesInGroups?: boolean
 }
 
+/** Normalizes the optional desktop preference, defaulting missing or invalid values to false. */
 export function getShowPinnedWorktreesInGroups(
   settings: WorkspaceDisplaySettings | null | undefined
 ): boolean {
   return settings?.showPinnedWorktreesInGroups === true
 }
 
+/** Loads view and display settings independently so older hosts can return either payload. */
 export async function loadDesktopWorkspaceSettings(
   client: Pick<RpcClient, 'sendRequest'>
 ): Promise<{

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -1757,6 +1757,10 @@ describe('OrcaRuntimeService.dedupeWorktreeCreate', () => {
 
 describe('OrcaRuntimeService', () => {
   it('projects runtime-backed settings to paired clients', () => {
+    expect(new OrcaRuntimeService(store).getClientSettings()).toMatchObject({
+      showPinnedWorktreesInGroups: false
+    })
+
     const terminalQuickCommands = [
       {
         id: 'review',
@@ -1773,6 +1777,7 @@ describe('OrcaRuntimeService', () => {
         ...store.getSettings(),
         experimentalNewWorktreeCardStyle: true,
         compactWorktreeCards: true,
+        showPinnedWorktreesInGroups: true,
         minimaxGroupId: 'group-42',
         minimaxUsageModels: 'general,abab6.5',
         terminalQuickCommands
@@ -1783,6 +1788,7 @@ describe('OrcaRuntimeService', () => {
       worktreeVisibilityDefaults: { external: 'hide' },
       experimentalNewWorktreeCardStyle: true,
       compactWorktreeCards: true,
+      showPinnedWorktreesInGroups: true,
       minimaxGroupId: 'group-42',
       minimaxUsageModels: 'general,abab6.5'
     })

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1344,6 +1344,7 @@ type RuntimeStore = {
     githubProjects?: GlobalSettings['githubProjects']
     experimentalNewWorktreeCardStyle?: GlobalSettings['experimentalNewWorktreeCardStyle']
     compactWorktreeCards?: GlobalSettings['compactWorktreeCards']
+    showPinnedWorktreesInGroups?: GlobalSettings['showPinnedWorktreesInGroups']
     minimaxGroupId?: GlobalSettings['minimaxGroupId']
     minimaxUsageModels?: GlobalSettings['minimaxUsageModels']
     prBotAuthorOverrides?: GlobalSettings['prBotAuthorOverrides']
@@ -3867,6 +3868,7 @@ export class OrcaRuntimeService {
     | 'githubProjects'
     | 'experimentalNewWorktreeCardStyle'
     | 'compactWorktreeCards'
+    | 'showPinnedWorktreesInGroups'
     | 'minimaxGroupId'
     | 'minimaxUsageModels'
     | 'prBotAuthorOverrides'
@@ -3895,6 +3897,7 @@ export class OrcaRuntimeService {
       githubProjects: settings.githubProjects,
       experimentalNewWorktreeCardStyle: settings.experimentalNewWorktreeCardStyle === true,
       compactWorktreeCards: settings.compactWorktreeCards === true,
+      showPinnedWorktreesInGroups: settings.showPinnedWorktreesInGroups === true,
       minimaxGroupId: settings.minimaxGroupId ?? '',
       minimaxUsageModels: settings.minimaxUsageModels ?? 'general',
       prBotAuthorOverrides: settings.prBotAuthorOverrides ?? [],


### PR DESCRIPTION
## ELI5

Desktop normally shows a pinned workspace only once, in the Pinned section. Mobile kept showing that same workspace again in All or another selected group. This change makes mobile follow the desktop preference, including its opt-in mode for showing pinned workspaces in both places.

## What Changed

- Expose `showPinnedWorktreesInGroups` through the paired-client settings projection.
- Load mobile view state and the pinned display preference independently so either RPC can succeed on its own.
- Default missing or older-host settings to the desktop's single-location behavior.
- Thread the preference through the mobile workspace section builder.
- Apply the same policy to persisted server pins and optimistic local pins.
- Cover All, repository, workspace-status, and PR-status grouping modes.

## Why

Mobile originally implemented Pinned as an unconditional overlay. Desktop later added `showPinnedWorktreesInGroups`, defaulting to single-location display, but mobile never consumed that global setting. The result was presentation-policy drift between the two clients.

The response field is optional and normalized to `false`, so new mobile clients remain compatible with older hosts and old clients safely ignore the additional settings field.

## Linked Issue

Fixes #15494

## Visual Proof

Android dev-client proof using the same pinned-display preference consumed by the section builder. The before image forces the compatibility preference on (`showPinnedWorktreesInGroups=true`); the after image uses the default single-location behavior (`false`).

| Before: pinned workspace is duplicated in its repo group | After: pinned workspace appears only in Pinned |
| --- | --- |
| ![Before: duplicate pinned workspace](https://github.com/user-attachments/assets/8eb89fdc-3c3a-431c-8cc0-038719359a01) | ![After: single pinned workspace](https://github.com/user-attachments/assets/1f813666-109e-4cf1-bcec-979a2aa95dc0) |

## Testing

- Android emulator manual test: default `false` shows the pinned workspace only once; compatibility mode `true` shows it under both Pinned and its repo group.
- Current PR head `pnpm lint`: passed.
- Current PR head `pnpm typecheck`: passed.
- Current PR head `pnpm test`: 5,993 files passed, 34 skipped; 56,319 tests passed, 194 skipped.
- Current PR head `pnpm build`: desktop, relay, CLI, Electron, and web stages passed. The root command reaches `build:native` and hits the unchanged pnpm launcher issue that passes the macOS pnpm executable to Node.
- Direct native build/verification commands passed, including 92 Swift tests.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

<!-- Internal contributor; intentionally left blank per template guidance. -->

## Review

Independent agent review reported no findings. It explicitly checked mixed-version wire compatibility, stale host/client responses, optimistic and server pins, all grouping modes, local/folder/SSH workspace behavior, cross-platform impact, performance, and basic security. The change adds no platform-specific paths, commands, providers, or hot-loop network work; settings requests occur on the existing focus/connect sync path.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- Security: no new authority or writable RPC surface; the added setting is read-only client projection data.
- Cross-platform: shared TypeScript behavior with no OS-specific paths or shortcuts.
- Remote/SSH: the preference comes from the paired runtime and defaults safely when an older host omits it.
- Performance: one existing settings request is added to the focus/connect sync and runs in parallel with `ui.get`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] Required local checks completed: lint, typecheck, and test pass; desktop and direct native builds pass; the known root native-launcher baseline exception is documented above

## Author

- X / Twitter: @GhostFlying
