### PR TITLE
test(runtime): abort after the platform submit delay in the cancellation-during-verification test

### DIFF
--- a/src/main/runtime/agent-prompt-submission-runtime.test.ts
+++ b/src/main/runtime/agent-prompt-submission-runtime.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { AGENT_PROMPT_BRACKETED_PASTE_END } from '../../shared/agent-prompt-injection'
+import {
+  AGENT_PROMPT_BRACKETED_PASTE_END,
+  AGENT_PROMPT_SUBMIT_DELAY_MS
+} from '../../shared/agent-prompt-injection'
 import { OrcaRuntimeService } from './orca-runtime'
 import { makeStore } from './runtime-rpc-worktree-store-fixtures'
 
@@ -673,7 +676,8 @@ describe('agent prompt submission runtime', () => {
     })
     const rejected = expect(submission).rejects.toThrow('request_aborted')
 
-    await vi.advanceTimersByTimeAsync(500)
+    // Why: the settle delay is platform-dependent (1_500 on Windows); a hardcoded 500 aborts before the Enter there.
+    await vi.advanceTimersByTimeAsync(AGENT_PROMPT_SUBMIT_DELAY_MS)
     controller.abort()
     await vi.runAllTimersAsync()
 


### PR DESCRIPTION
## ELI5

One of the #14962 tests waits "500ms" before cancelling a prompt submission, because on Linux/macOS that is exactly how long Orca waits before pressing Enter. On Windows, Orca waits 1.5s (ConPTY renders pastes more slowly), so the test cancels *before* Enter ever happens and fails on every Windows machine. The fix makes the test wait the platform's actual delay instead of a hardcoded number.

## What Changed

- `src/main/runtime/agent-prompt-submission-runtime.test.ts`: the `does not send another Enter after cancellation during verification` test now advances fake timers by `AGENT_PROMPT_SUBMIT_DELAY_MS` (imported from `src/shared/agent-prompt-injection.ts`, which the file already imports from) instead of a hardcoded `500`, with a one-line why-comment. No product code is touched.

## Why

`AGENT_PROMPT_SUBMIT_DELAY_MS` is platform-dependent: 500 by default, 1_500 on Windows (`WINDOWS_AGENT_PROMPT_SUBMIT_DELAY_MS`, introduced in #9925 because ConPTY renders long bracketed pastes slowly). The hardcoded `500` matches only the non-Windows value, so on Windows the abort lands during *settlement* — before the single Enter — instead of during *verification*:

- the assertion `writes.filter(d => d === '\r')).toHaveLength(1)` sees 0 writes and the test fails deterministically on every Windows checkout of `main` (reproduced with Node 22.22.2 and 24.19.0);
- even if it passed, the test would silently duplicate its sibling `does not send delayed Enter after cancellation during settlement`, leaving the cancellation-during-verification path uncovered on the platform with the larger delay.

Advancing by the platform constant aborts after the Enter on every platform, which is the scenario the test's name promises. PR CI runs the vitest suites on Ubuntu only, which is why this was never caught there.

## Linked Issue

Fixes #15498

## Visual Proof

N/A — test-only change; no UI, behavior, or product-code change.

## Testing

Windows 11 (packaged-source checkout of this branch):

- `vitest run --config config/vitest.config.ts src/main/runtime/agent-prompt-submission-runtime.test.ts src/main/runtime/agent-prompt-submission-verification.test.ts` — **41/41 pass on Node 24.19.0 and Node 22.22.2** (before this change: 40/41, the cancellation-during-verification test failing with `expected [] to have a length of 1 but got +0`).
- `oxlint`, `audit:code-quality:native`, `audit:code-quality:type-aware`, `check:max-lines-ratchet`, `pnpm typecheck` — all pass.
- Not run locally: `verify:skill-bundle-manifest` (fails identically on a clean tree in this environment, unrelated to this diff), full `pnpm test` and `pnpm build` — CI covers those; the diff is confined to one test file.
- On Linux/macOS the change is behavior-neutral: `AGENT_PROMPT_SUBMIT_DELAY_MS` is 500 there, the exact value previously hardcoded (CI will confirm).

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below — the change *is* the test; it restores the intended Windows coverage.

## AI Disclosure

Investigated and authored with Claude Code (Fable 5), supervised and reviewed by me.

## Review

- **Cross-platform**: the point of the change — the test now follows the platform constant; neutral on Linux/macOS (500 there), fixes Windows (1_500).
- **SSH/remote, wire compatibility, mobile**: untouched; test-only diff.
- **Agents/integrations**: none affected; the suite uses a mocked PTY controller.
- **Performance**: fake timers — no wall-clock change on non-Windows; on Windows the test now exercises the intended path.
- **Security**: none.
- **UI**: none.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance — considered above; test-only diff.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — see Testing for exactly what ran locally

## Author

- X / Twitter: @EnricoPin
