### PR TITLE
feat(workspaces): terminal groups — extra terminal/agent cards on a project's existing checkout

### DIFF
--- a/src/cli/handlers/worktree.ts
+++ b/src/cli/handlers/worktree.ts
@@ -237,6 +237,7 @@ export const WORKTREE_HANDLERS: Record<string, CommandHandler> = {
       linkedIssue: getOptionalNumberFlag(flags, 'issue'),
       ...linearIssueLink,
       comment: getOptionalStringFlag(flags, 'comment'),
+      ...(flags.get('terminal-group') === true ? { terminalGroup: true } : {}),
       runHooks: flags.get('run-hooks') === true,
       activate,
       // Why: the CLI pairs as a runtime device but is not a viewer, so caller-scoped

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -86,7 +86,7 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
     path: ['worktree', 'create'],
     summary: 'Create a new Orca-managed worktree',
     usage:
-      'orca worktree create --name <name> [--repo <selector>|--project <id> [--host <host-id>]|--project-host-setup <id>] [--agent <id>] [--prompt <text>] [--setup run|skip|inherit] [--base-branch <ref>] [--issue <number>] [--linear-issue <identifier-or-url>] [--comment <text>] [--parent-worktree <selector>] [--no-parent] [--run-hooks] [--activate] [--json]',
+      'orca worktree create --name <name> [--repo <selector>|--project <id> [--host <host-id>]|--project-host-setup <id>] [--terminal-group] [--agent <id>] [--prompt <text>] [--setup run|skip|inherit] [--base-branch <ref>] [--issue <number>] [--linear-issue <identifier-or-url>] [--comment <text>] [--parent-worktree <selector>] [--no-parent] [--run-hooks] [--activate] [--json]',
     allowedFlags: [
       ...GLOBAL_FLAGS,
       'repo',
@@ -94,6 +94,7 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
       'host',
       'project-host-setup',
       'name',
+      'terminal-group',
       'agent',
       'prompt',
       'base-branch',
@@ -108,6 +109,7 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
     ],
     notes: [
       'This creates a new checkout. For a fresh agent in an existing worktree, use `orca terminal create --worktree active --command "codex"` instead.',
+      'Pass --terminal-group for terminals and agents on the project checkout without a new worktree: no branch, no base ref, and no source-control surfaces. Folder projects already work this way, so the flag is a no-op there.',
       'By default, Orca records the new worktree as a child of the caller context when it can infer one from the Orca terminal or current directory.',
       'If --repo is omitted, Orca infers the repo from the current Orca-managed worktree.',
       'Use --project with --host to create on a ready project host setup without spelling the backing repo id.',
@@ -124,6 +126,7 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
     ],
     examples: [
       'orca worktree create --name agent-task --agent codex --prompt "hi" --json',
+      'orca worktree create --repo id:<repoId> --name servers --terminal-group --json',
       'orca worktree create --repo id:<repoId> --name related-task --json',
       'orca worktree create --project github:stablyai/orca --host runtime:03ef704c-b180-4b10-998d-e28fbd5de9a3 --name benchmark --json',
       'orca worktree create --repo id:<repoId> --name linear-task --linear-issue https://linear.app/stably/issue/STA-335/test-issue --json',

--- a/src/main/ipc/worktrees-terminal-groups.test.ts
+++ b/src/main/ipc/worktrees-terminal-groups.test.ts
@@ -1,0 +1,258 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  listWorktreesMock,
+  addWorktreeMock,
+  removeWorktreeMock,
+  getLocalPtyProviderMock,
+  killAllProcessesForWorktreeMock,
+  clearProviderPtyStateMock
+} from './worktrees-test-module-mocks'
+import {
+  handlers,
+  ipcEvent,
+  mainWindow,
+  setupWorktreeHandlers,
+  store
+} from './worktrees-test-harness'
+import type { WorktreeRuntimeStub } from './worktrees-test-runtime-stub'
+import type { ProviderRequestId } from '../../shared/detected-worktree-provider-contract'
+import type { Worktree } from '../../shared/worktree/types'
+
+vi.mock('electron', async () =>
+  (await import('./worktrees-test-module-mocks')).electronModuleMock()
+)
+vi.mock('../git/worktree', async () =>
+  (await import('./worktrees-test-module-mocks')).gitWorktreeModuleMock()
+)
+vi.mock('../git/runner', async () =>
+  (await import('./worktrees-test-module-mocks')).gitRunnerModuleMock()
+)
+vi.mock('../git/repo', async () =>
+  (await import('./worktrees-test-module-mocks')).gitRepoModuleMock()
+)
+vi.mock('../git/git-username', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  resolveLocalGitUsername: (await import('./worktrees-test-module-mocks'))
+    .resolveLocalGitUsernameMock
+}))
+vi.mock('../github/client', async () =>
+  (await import('./worktrees-test-module-mocks')).githubClientModuleMock()
+)
+vi.mock('../source-control/hosted-review', async () =>
+  (await import('./worktrees-test-module-mocks')).hostedReviewModuleMock()
+)
+vi.mock('../providers/ssh-git-dispatch', async () =>
+  (await import('./worktrees-test-module-mocks')).sshGitDispatchModuleMock()
+)
+vi.mock('../providers/ssh-filesystem-dispatch', async () =>
+  (await import('./worktrees-test-module-mocks')).sshFilesystemDispatchModuleMock()
+)
+vi.mock('./worktree-symlinks', async () =>
+  (await import('./worktrees-test-module-mocks')).worktreeSymlinksModuleMock()
+)
+vi.mock('./ssh', async () => (await import('./worktrees-test-module-mocks')).sshModuleMock())
+vi.mock('../hooks', async () => (await import('./worktrees-test-module-mocks')).hooksModuleMock())
+vi.mock('../setup-runner-script-text', async (importOriginal) =>
+  (await import('./worktrees-test-module-mocks')).setupRunnerScriptTextModuleMock(
+    (await importOriginal()) as Record<string, unknown>
+  )
+)
+vi.mock('../worktree-runner-script', async (importOriginal) =>
+  (await import('./worktrees-test-module-mocks')).worktreeRunnerScriptModuleMock(
+    (await importOriginal()) as Record<string, unknown>
+  )
+)
+vi.mock('../effective-hook-config', async (importOriginal) =>
+  (await import('./worktrees-test-module-mocks')).effectiveHookConfigModuleMock(
+    (await importOriginal()) as Record<string, unknown>
+  )
+)
+vi.mock('../setup-hook-env-vars', async (importOriginal) =>
+  (await import('./worktrees-test-module-mocks')).setupHookEnvVarsModuleMock(
+    (await importOriginal()) as Record<string, unknown>
+  )
+)
+vi.mock('./worktree-logic', async (importOriginal) =>
+  (await import('./worktrees-test-module-mocks')).worktreeLogicModuleMock(
+    (await importOriginal()) as Record<string, unknown>
+  )
+)
+vi.mock('../terminal-history-deletion', async () =>
+  (await import('./worktrees-test-module-mocks')).terminalHistoryDeletionModuleMock()
+)
+vi.mock('../ports/advertised-url-watcher', async () =>
+  (await import('./worktrees-test-module-mocks')).advertisedUrlWatcherModuleMock()
+)
+vi.mock('../workspace-cleanup-scan-snapshot', async () =>
+  (await import('./worktrees-test-module-mocks')).workspaceCleanupScanSnapshotModuleMock()
+)
+vi.mock('../workspace-space-analysis-snapshot', async () =>
+  (await import('./worktrees-test-module-mocks')).workspaceSpaceAnalysisSnapshotModuleMock()
+)
+vi.mock('../workspace-cleanup-removal-snapshot-prune', async () =>
+  (await import('./worktrees-test-module-mocks')).workspaceCleanupRemovalSnapshotPruneModuleMock()
+)
+vi.mock('../runtime/worktree-teardown', async () =>
+  (await import('./worktrees-test-module-mocks')).worktreeTeardownModuleMock()
+)
+vi.mock('./pty', async () => (await import('./worktrees-test-module-mocks')).ptyModuleMock())
+
+describe('git project terminal groups', () => {
+  let runtimeStub: WorktreeRuntimeStub
+
+  beforeEach(() => {
+    runtimeStub = setupWorktreeHandlers()
+  })
+
+  function makeWorktreeMeta(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+      displayName: '',
+      comment: '',
+      linkedIssue: null,
+      linkedPR: null,
+      linkedLinearIssue: null,
+      isArchived: false,
+      isUnread: false,
+      isPinned: false,
+      sortOrder: 0,
+      lastActivityAt: 0,
+      ...overrides
+    }
+  }
+
+  it('creates a terminal group on a git repo without git worktree add', async () => {
+    store.setWorktreeMeta.mockImplementation((_worktreeId, meta) =>
+      makeWorktreeMeta(meta as Record<string, unknown>)
+    )
+
+    const result = (await handlers['worktrees:create'](null, {
+      repoId: 'repo-1',
+      name: 'servers',
+      terminalGroup: true,
+      createdWithAgent: 'codex'
+    })) as { worktree: Worktree }
+
+    expect(addWorktreeMock).not.toHaveBeenCalled()
+    expect(result.worktree).toEqual(
+      expect.objectContaining({
+        id: expect.stringMatching(/^repo-1::\/workspace\/repo::workspace:[0-9a-f-]{36}$/),
+        repoId: 'repo-1',
+        // The group runs in the project checkout, so it has no branch and no worktree of its own.
+        path: '/workspace/repo',
+        branch: '',
+        head: '',
+        isMainWorktree: false,
+        displayName: 'servers',
+        createdWithAgent: 'codex'
+      })
+    )
+    expect(mainWindow.webContents.send).toHaveBeenCalledWith('worktrees:changed', {
+      repoId: 'repo-1'
+    })
+  })
+
+  it('lists a git repo terminal group alongside its checkouts', async () => {
+    const terminalGroupId =
+      'repo-1::/workspace/repo::workspace:11111111-1111-4111-8111-111111111111'
+    const meta = makeWorktreeMeta({
+      instanceId: '11111111-1111-4111-8111-111111111111',
+      projectId: 'repo:repo-1',
+      hostId: 'local',
+      projectHostSetupId: 'repo-1',
+      displayName: 'servers',
+      orcaCreatedAt: 5,
+      createdAt: 5
+    })
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/repo',
+        head: 'abc',
+        branch: 'main',
+        isBare: false,
+        isMainWorktree: true
+      }
+    ])
+    store.getAllWorktreeMeta.mockReturnValue({ [terminalGroupId]: meta })
+    store.getWorktreeMeta.mockImplementation((worktreeId: string) =>
+      worktreeId === terminalGroupId ? meta : undefined
+    )
+
+    const listed = (await handlers['worktrees:list'](null, { repoId: 'repo-1' })) as Worktree[]
+
+    expect(listed).toEqual([
+      expect.objectContaining({ id: 'repo-1::/workspace/repo', branch: 'main' }),
+      expect.objectContaining({
+        id: terminalGroupId,
+        repoId: 'repo-1',
+        path: '/workspace/repo',
+        displayName: 'servers',
+        branch: '',
+        head: '',
+        isMainWorktree: false
+      })
+    ])
+  })
+
+  it('keeps a terminal group in the detected listing, which purges every id it omits', async () => {
+    const terminalGroupId =
+      'repo-1::/workspace/repo::workspace:22222222-2222-4222-8222-222222222222'
+    const meta = makeWorktreeMeta({
+      instanceId: '22222222-2222-4222-8222-222222222222',
+      projectId: 'repo:repo-1',
+      hostId: 'local',
+      projectHostSetupId: 'repo-1',
+      displayName: 'research',
+      orcaCreatedAt: 5
+    })
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/repo',
+        head: 'abc',
+        branch: 'main',
+        isBare: false,
+        isMainWorktree: true
+      }
+    ])
+    store.getAllWorktreeMeta.mockReturnValue({ [terminalGroupId]: meta })
+    store.getWorktreeMeta.mockImplementation((worktreeId: string) =>
+      worktreeId === terminalGroupId ? meta : undefined
+    )
+
+    const result = (await handlers['worktrees:listDetected'](ipcEvent, {
+      providerRequestId: 'request-1' as ProviderRequestId,
+      repoId: 'repo-1',
+      executionHostId: 'local'
+    })) as { result: { authoritative: boolean; worktrees: { id: string; visible: boolean }[] } }
+
+    expect(result.result.authoritative).toBe(true)
+    expect(result.result.worktrees).toContainEqual(
+      expect.objectContaining({ id: terminalGroupId, visible: true })
+    )
+  })
+
+  // A terminal group's path IS the project checkout, so routing it down the git removal path would
+  // run `git worktree remove` (or an orphan-directory cleanup) against the user's main clone.
+  it('removes a git repo terminal group without touching git or disk', async () => {
+    const ptyProvider = {} as never
+    const worktreeId = 'repo-1::/workspace/repo::workspace:33333333-3333-4333-8333-333333333333'
+    getLocalPtyProviderMock.mockReturnValue(ptyProvider)
+
+    await handlers['worktrees:remove'](null, { worktreeId })
+
+    expect(removeWorktreeMock).not.toHaveBeenCalled()
+    expect(listWorktreesMock).not.toHaveBeenCalled()
+    expect(killAllProcessesForWorktreeMock).toHaveBeenCalledWith(worktreeId, {
+      runtime: runtimeStub,
+      resolvedWorktreeId: worktreeId,
+      localProvider: ptyProvider,
+      onPtyStopped: clearProviderPtyStateMock
+    })
+    expect(killAllProcessesForWorktreeMock.mock.invocationCallOrder[0]).toBeLessThan(
+      store.removeWorktreeMeta.mock.invocationCallOrder[0]
+    )
+    expect(store.removeWorktreeMeta).toHaveBeenCalledWith(worktreeId, 'local')
+    expect(mainWindow.webContents.send).toHaveBeenCalledWith('worktrees:changed', {
+      repoId: 'repo-1'
+    })
+  })
+})

--- a/src/main/ipc/worktrees-windows.test.ts
+++ b/src/main/ipc/worktrees-windows.test.ts
@@ -165,6 +165,7 @@ describe('registerWorktreeHandlers – Windows path handling', () => {
     getProjectHostSetups: vi.fn(),
     getSettings: vi.fn(),
     getWorktreeMeta: vi.fn(),
+    getAllWorktreeMeta: vi.fn(),
     setWorktreeMeta: vi.fn(),
     removeWorktreeMeta: vi.fn(),
     addRetiredWorktreeName: vi.fn(),
@@ -209,6 +210,7 @@ describe('registerWorktreeHandlers – Windows path handling', () => {
     store.getProjectHostSetups.mockReset()
     store.getSettings.mockReset()
     store.getWorktreeMeta.mockReset()
+    store.getAllWorktreeMeta.mockReset()
     store.setWorktreeMeta.mockReset()
     store.removeWorktreeMeta.mockReset()
     store.addRetiredWorktreeName.mockReset()
@@ -251,6 +253,7 @@ describe('registerWorktreeHandlers – Windows path handling', () => {
     })
     resolveSetupRunnerShellMock.mockReturnValue(undefined)
     store.getWorktreeMeta.mockReturnValue(undefined)
+    store.getAllWorktreeMeta.mockReturnValue({})
     store.getRetiredWorktreeNameRegistry.mockReturnValue({ exhaustedTiers: 0, names: [] })
     store.setWorktreeMeta.mockReturnValue({})
     resolveLocalGitUsernameMock.mockResolvedValue('')

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -243,8 +243,15 @@ import { DEFAULT_WORKSPACE_STATUS_ID } from '../../shared/workspace-statuses'
 import {
   FOLDER_WORKSPACE_INSTANCE_SEPARATOR,
   getRepoIdFromWorktreeId,
-  getWorktreePathBasenameFromId
+  getWorktreePathBasenameFromId,
+  isWorkspaceInstanceWorktreeId
 } from '../../shared/worktree/id'
+import {
+  buildWorkspaceInstanceWorktreeId,
+  getProjectCheckoutWorktreeId,
+  getWorkspaceInstanceIdentity,
+  isWorkspaceInstanceWorktreeIdForRepo
+} from '../../shared/workspace-instance-worktree'
 import { prefetchWorktreeCreateBase } from '../worktree-create-base-prefetch'
 import {
   getLocalProjectGitExecOptions,
@@ -786,6 +793,11 @@ type SshWorktreeMetaIndex = Map<string, SshWorktreeMetaCandidate[]>
 function createSshWorktreeMetaIndex(entries: [string, WorktreeMeta][]): SshWorktreeMetaIndex {
   const index: SshWorktreeMetaIndex = new Map()
   for (const [worktreeId, meta] of entries) {
+    // Why: a workspace-instance id carries a suffix the git-worktree synthesizer would read as a
+    // directory, yielding a row whose path is not the checkout. Those rows are built from meta instead.
+    if (isWorkspaceInstanceWorktreeId(worktreeId)) {
+      continue
+    }
     let parsed: { repoId: string; worktreePath: string }
     try {
       parsed = parseWorktreeId(worktreeId)
@@ -835,7 +847,8 @@ function synthesizeSshGitWorktree(repo: Repo, path: string, meta: WorktreeMeta):
 function listDisconnectedSshWorktrees(
   store: Store,
   repo: Repo,
-  metaIndex: SshWorktreeMetaIndex
+  metaIndex: SshWorktreeMetaIndex,
+  metaSnapshot?: Record<string, WorktreeMeta>
 ): ReturnType<typeof mergeWorktree>[] {
   const byWorktreeId = new Map<string, ReturnType<typeof mergeWorktree>>()
   const expectedHostId = getRepoExecutionHostId(repo)
@@ -868,7 +881,8 @@ function listDisconnectedSshWorktrees(
     byWorktreeId.delete(worktree.id)
     byWorktreeId.set(worktree.id, worktree)
   }
-  return [...byWorktreeId.values()]
+  // Terminal groups need no scan to describe them — a disconnected host must keep publishing them.
+  return [...byWorktreeId.values(), ...listTerminalGroupWorkspaces(store, repo, metaSnapshot)]
 }
 
 function buildDetectedGitWorktrees(
@@ -927,21 +941,13 @@ function stampAndMergeVisibleDetectedWorktree(
   return mergeWorktree(repo.id, detected, meta, repo.displayName)
 }
 
-function getFolderWorkspaceRootId(repo: Repo): string {
-  return `${repo.id}::${repo.path}`
-}
-
-function getFolderWorkspaceInstanceId(repo: Repo, instanceId: string): string {
-  return `${getFolderWorkspaceRootId(repo)}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}${instanceId}`
-}
-
-function getFolderWorkspaceInstanceIdentity(repo: Repo, worktreeId: string): string {
-  const prefix = `${getFolderWorkspaceRootId(repo)}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}`
-  return worktreeId.startsWith(prefix) ? worktreeId.slice(prefix.length) : randomUUID()
+/** Mints one for a legacy row that predates instance stamping. */
+function getWorkspaceInstanceIdentityOrNew(repo: Repo, worktreeId: string): string {
+  return getWorkspaceInstanceIdentity(repo, worktreeId) ?? randomUUID()
 }
 
 function isFolderWorkspaceIdForRepo(repo: Repo, worktreeId: string): boolean {
-  const rootId = getFolderWorkspaceRootId(repo)
+  const rootId = getProjectCheckoutWorktreeId(repo)
   return (
     worktreeId === rootId ||
     worktreeId.startsWith(`${rootId}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}`)
@@ -962,7 +968,7 @@ function mergeFolderWorkspace(repo: Repo, worktreeId: string, meta: WorktreeMeta
     head: '',
     branch: '',
     isBare: false,
-    isMainWorktree: worktreeId === getFolderWorkspaceRootId(repo),
+    isMainWorktree: worktreeId === getProjectCheckoutWorktreeId(repo),
     displayName: meta.displayName || repo.displayName,
     comment: meta.comment || '',
     linkedIssue: meta.linkedIssue ?? null,
@@ -997,7 +1003,7 @@ function mergeFolderWorkspace(repo: Repo, worktreeId: string, meta: WorktreeMeta
 }
 
 function listFolderWorkspaces(store: Store, repo: Repo): Worktree[] {
-  const rootId = getFolderWorkspaceRootId(repo)
+  const rootId = getProjectCheckoutWorktreeId(repo)
   const allMeta = store.getAllWorktreeMeta()
   const ids = Object.keys(allMeta).filter((worktreeId) =>
     isFolderWorkspaceIdForRepo(repo, worktreeId)
@@ -1015,7 +1021,7 @@ function listFolderWorkspaces(store: Store, repo: Repo): Worktree[] {
           ? existing
           : store.setWorktreeMeta(worktreeId, {
               instanceId:
-                existing?.instanceId ?? getFolderWorkspaceInstanceIdentity(repo, worktreeId),
+                existing?.instanceId ?? getWorkspaceInstanceIdentityOrNew(repo, worktreeId),
               ...ownershipUpdates,
               ...(existing ? {} : { displayName: repo.displayName, lastActivityAt: Date.now() })
             })
@@ -1066,14 +1072,90 @@ function listVisibleFolderWorkspaces(store: Store, repo: Repo): Worktree[] {
     })
 }
 
-function createFolderWorkspace(
+/**
+ * Terminal groups: a git project's extra workspace instances on its main checkout. They never come
+ * from `git worktree list`, so they are appended to the scan instead of filtered out of it — and
+ * unlike a folder project, the root row here is a real worktree the scan already published.
+ */
+function listTerminalGroupWorkspaces(
+  store: Store,
+  repo: Repo,
+  // Why: `worktrees:listAll` fans out over every repo, so the multi-MB meta map is read once by the
+  // caller and threaded through instead of re-materialized per repo.
+  metaSnapshot?: Record<string, WorktreeMeta>
+): Worktree[] {
+  if (isFolderRepo(repo)) {
+    return []
+  }
+  const expectedHostId = getRepoExecutionHostId(repo)
+  const repoOwnerCount = store.getRepos().filter((candidate) => candidate.id === repo.id).length
+  const allMeta = metaSnapshot ?? store.getAllWorktreeMeta()
+  return Object.keys(allMeta)
+    .filter((worktreeId) => {
+      if (!isWorkspaceInstanceWorktreeIdForRepo(repo, worktreeId)) {
+        return false
+      }
+      // Why: one repo id can be registered on several execution hosts; never republish another host's rows.
+      const meta = allMeta[worktreeId]
+      return meta?.hostId ? meta.hostId === expectedHostId : repoOwnerCount <= 1
+    })
+    .map((worktreeId) => {
+      const existing = allMeta[worktreeId]
+      const ownershipUpdates = getProjectHostSetupMetaUpdates(store, repo, existing)
+      const meta =
+        existing?.instanceId && Object.keys(ownershipUpdates).length === 0
+          ? existing
+          : store.setWorktreeMeta(worktreeId, {
+              instanceId:
+                existing?.instanceId ?? getWorkspaceInstanceIdentityOrNew(repo, worktreeId),
+              ...ownershipUpdates
+            })
+      return mergeFolderWorkspace(repo, worktreeId, meta)
+    })
+    .sort((a, b) => (b.createdAt ?? b.lastActivityAt) - (a.createdAt ?? a.lastActivityAt))
+}
+
+/**
+ * Terminal groups must ride along on the detected listing too: an authoritative refresh purges every
+ * known worktree id it does not report, which would reap their tabs and sessions.
+ */
+function buildTerminalGroupDetectedWorktrees(store: Store, repo: Repo): DetectedWorktree[] {
+  const settings = store.getSettings()
+  return listTerminalGroupWorkspaces(store, repo).map((worktree) =>
+    toDetectedWorktree({
+      repo,
+      worktree,
+      meta: store.getWorktreeMeta(worktree.id),
+      settings,
+      knownOrcaLayouts: [],
+      isLegacyRepoForVisibility: true
+    })
+  )
+}
+
+function listVisibleRepoWorktrees(
+  store: Store,
+  repo: Repo,
+  gitWorktrees: GitWorktreeInfo[],
+  metaSnapshot?: Record<string, WorktreeMeta>
+): Worktree[] {
+  return [
+    ...buildDetectedGitWorktrees(store, repo, gitWorktrees)
+      .filter((worktree) => worktree.visible)
+      .map((worktree) => stampAndMergeVisibleDetectedWorktree(store, repo, worktree)),
+    ...listTerminalGroupWorkspaces(store, repo, metaSnapshot)
+  ]
+}
+
+/** Creates a card that shares the project's checkout: a folder-project workspace or a git-project terminal group. */
+function createWorkspaceInstance(
   args: CreateWorktreeArgsWithSystemProvenance,
   repo: Repo,
   store: Store
 ): CreateWorktreeResult {
   const now = Date.now()
   const instanceId = randomUUID()
-  const worktreeId = getFolderWorkspaceInstanceId(repo, instanceId)
+  const worktreeId = buildWorkspaceInstanceWorktreeId(repo, instanceId)
   const meta = store.setWorktreeMeta(worktreeId, {
     instanceId,
     ...(store.getProjectHostSetups
@@ -1306,7 +1388,10 @@ async function listDetectedWorktreesForCapturedRepo(
       repoId: repo.id,
       authoritative: true,
       source: 'git',
-      worktrees: buildDetectedGitWorktrees(store, repo, gitWorktrees)
+      worktrees: [
+        ...buildDetectedGitWorktrees(store, repo, gitWorktrees),
+        ...buildTerminalGroupDetectedWorktrees(store, repo)
+      ]
     }
   } catch (err) {
     const aborted = abortedResult()
@@ -1877,8 +1962,11 @@ export function registerWorktreeHandlers(
 
   ipcMain.handle('worktrees:listAll', async () => {
     const repos = store.getRepos()
+    // Why one read for the whole fan-out: this map is multi-MB on heavy installs, and both the SSH
+    // fallback index and every repo's terminal groups are derived from it.
+    const allWorktreeMeta = store.getAllWorktreeMeta()
     const sshWorktreeMetaIndex = repos.some((repo) => repo.connectionId)
-      ? createSshWorktreeMetaIndex(Object.entries(store.getAllWorktreeMeta()))
+      ? createSshWorktreeMetaIndex(Object.entries(allWorktreeMeta))
       : new Map()
 
     // Why: each local repo listing can spawn `git worktree list`; cap fan-out so large fleets don't start unbounded subprocesses.
@@ -1896,7 +1984,7 @@ export function registerWorktreeHandlers(
               `${repo.connectionId}:${repo.id}`,
               `[worktrees] SSH git provider unavailable; skipping worktree list for repo "${repo.displayName}" (${repo.id}) at ${repo.path} on connection ${repo.connectionId}`
             )
-            return listDisconnectedSshWorktrees(store, repo, sshWorktreeMetaIndex)
+            return listDisconnectedSshWorktrees(store, repo, sshWorktreeMetaIndex, allWorktreeMeta)
           }
           loggedUnavailableSshGitProviders.delete(`${repo.connectionId}:${repo.id}`)
           try {
@@ -1908,7 +1996,7 @@ export function registerWorktreeHandlers(
               `[worktrees] failed to list worktrees for repo "${repo.displayName}" (${repo.id}) at ${repo.path}`,
               err
             )
-            return listDisconnectedSshWorktrees(store, repo, sshWorktreeMetaIndex)
+            return listDisconnectedSshWorktrees(store, repo, sshWorktreeMetaIndex, allWorktreeMeta)
           }
         } else {
           const scan = await listDetectedGitWorktrees(store, repo)
@@ -1920,9 +2008,7 @@ export function registerWorktreeHandlers(
           pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees)
         }
         loggedWorktreeListFailures.delete(`${repo.id}:${repo.path}`)
-        return buildDetectedGitWorktrees(store, repo, gitWorktrees)
-          .filter((worktree) => worktree.visible)
-          .map((worktree) => stampAndMergeVisibleDetectedWorktree(store, repo, worktree))
+        return listVisibleRepoWorktrees(store, repo, gitWorktrees, allWorktreeMeta)
       } catch (err) {
         warnOnce(
           loggedWorktreeListFailures,
@@ -1992,9 +2078,7 @@ export function registerWorktreeHandlers(
         pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees)
       }
       loggedWorktreeListFailures.delete(`${repo.id}:${repo.path}`)
-      return buildDetectedGitWorktrees(store, repo, gitWorktrees)
-        .filter((worktree) => worktree.visible)
-        .map((worktree) => stampAndMergeVisibleDetectedWorktree(store, repo, worktree))
+      return listVisibleRepoWorktrees(store, repo, gitWorktrees)
     } catch (err) {
       warnOnce(
         loggedWorktreeListFailures,
@@ -2099,6 +2183,10 @@ export function registerWorktreeHandlers(
       for (const worktreeId of worktreeIds) {
         const meta = typeof worktreeId === 'string' ? allMeta[worktreeId] : undefined
         if (!meta || getRepoIdFromWorktreeId(worktreeId) !== repo.id) {
+          continue
+        }
+        // Why: a terminal group's meta IS the workspace record, not a checkout row — no remote scan can retire one.
+        if (isWorkspaceInstanceWorktreeId(worktreeId)) {
           continue
         }
         // An unhosted meta belongs to this repo's only owner; a foreign hostId needs that host's own scan.
@@ -2266,11 +2354,13 @@ export function registerWorktreeHandlers(
           automationProvenance
         }
 
+        // A terminal group shares the project checkout, so it takes the folder path even on a git repo.
+        const sharesCheckout = isFolderRepo(repo) || args.terminalGroup === true
         let result: CreateWorktreeResult
         try {
           // Why: wrap only the helpers; the pre-validation throws above are IPC-shape bugs, not the git/filesystem failures the funnel tracks.
-          result = isFolderRepo(repo)
-            ? createFolderWorkspace(createArgs, repo, store)
+          result = sharesCheckout
+            ? createWorkspaceInstance(createArgs, repo, store)
             : repo.connectionId
               ? await createRemoteWorktree(createArgs, repo, store, mainWindow)
               : await createLocalWorktree(createArgs, repo, store, mainWindow, runtime)
@@ -2289,13 +2379,11 @@ export function registerWorktreeHandlers(
         track('workspace_created', {
           source,
           from_existing_branch:
-            !isFolderRepo(repo) &&
-            typeof args.baseBranch === 'string' &&
-            args.baseBranch.length > 0,
+            !sharesCheckout && typeof args.baseBranch === 'string' && args.baseBranch.length > 0,
           ...getCohortAtEmit()
         })
 
-        if (isFolderRepo(repo)) {
+        if (sharesCheckout) {
           notifyWorktreesChanged(mainWindow, repo.id)
         }
 
@@ -2491,8 +2579,10 @@ export function registerWorktreeHandlers(
       const removal = (async (): Promise<RemoveWorktreeResult> => {
         // Why: worktree.create is traced; delete freezes were invisible without a matching worktree.remove parent span.
         return withWorktreeSpan({ stage: 'remove', path: worktreePath }, async () => {
-          if (isFolderRepo(repo)) {
-            if (args.worktreeId === getFolderWorkspaceRootId(repo)) {
+          // A git project's terminal groups share its checkout, so they take the same
+          // metadata-only teardown — never `git worktree remove` against the main checkout.
+          if (isFolderRepo(repo) || isWorkspaceInstanceWorktreeId(args.worktreeId)) {
+            if (args.worktreeId === getProjectCheckoutWorktreeId(repo)) {
               throw new Error(
                 'Cannot delete the project root workspace. Remove the folder project instead.'
               )
@@ -3195,7 +3285,7 @@ export function registerWorktreeHandlers(
 
       const forget = (async (): Promise<RemoveWorktreeResult> => {
         const isFolderRootOf = (candidate: Repo): boolean =>
-          isFolderRepo(candidate) && args.worktreeId === getFolderWorkspaceRootId(candidate)
+          isFolderRepo(candidate) && args.worktreeId === getProjectCheckoutWorktreeId(candidate)
         const fallbackRepos = args.hostId
           ? store
               .getRepos()

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -41530,6 +41530,43 @@ describe('OrcaRuntimeService', () => {
     expect(listWorktrees).toHaveBeenCalledTimes(1)
   })
 
+  // `orca worktree ps` and `orca terminal create --worktree` both read the resolved catalog, so a
+  // terminal group only reaches the CLI if the git scan's rows are joined by its meta-backed row.
+  it('lists a git project terminal group next to its checkouts', async () => {
+    const terminalGroupId = `${TEST_REPO_ID}::${TEST_REPO_PATH}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}44444444-4444-4444-8444-444444444444`
+    const metaById: Record<string, WorktreeMeta> = {
+      ...store.getAllWorktreeMeta(),
+      [terminalGroupId]: makeWorktreeMeta({
+        instanceId: '44444444-4444-4444-8444-444444444444',
+        displayName: 'servers'
+      })
+    }
+    vi.mocked(listWorktrees).mockClear()
+    vi.mocked(listWorktrees).mockResolvedValue([makeWorktreeInfo(TEST_REPO_PATH)])
+    const runtime = new OrcaRuntimeService({
+      ...store,
+      getAllWorktreeMeta: () => metaById,
+      getWorktreeMeta: (id: string) => metaById[id],
+      setWorktreeMeta: (id: string, meta: Partial<WorktreeMeta>) => {
+        metaById[id] = { ...(metaById[id] ?? makeWorktreeMeta()), ...meta }
+        return metaById[id]
+      }
+    } as never)
+
+    const listed = await runtime.listManagedWorktrees(`id:${TEST_REPO_ID}`)
+
+    expect(listed.worktrees).toContainEqual(
+      expect.objectContaining({
+        id: terminalGroupId,
+        repoId: TEST_REPO_ID,
+        path: TEST_REPO_PATH,
+        displayName: 'servers',
+        branch: '',
+        isMainWorktree: false
+      })
+    )
+  })
+
   it('bounds repeated detected worktree scans across the reported 15-repo shape', async () => {
     vi.mocked(listWorktrees).mockReset()
     const repos = Array.from({ length: 15 }, (_, index) => ({

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -503,9 +503,11 @@ import {
   FOLDER_WORKSPACE_INSTANCE_SEPARATOR,
   WORKTREE_ID_SEPARATOR,
   getRepoIdFromWorktreeId,
+  isWorkspaceInstanceWorktreeId,
   splitWorktreeId,
   splitWorktreeIdForFilesystem
 } from '../../shared/worktree/id'
+import { isWorkspaceInstanceWorktreeIdForRepo } from '../../shared/workspace-instance-worktree'
 import {
   getProjectIdForProviderIdentity,
   getProjectHostSetupForRepo,
@@ -2498,6 +2500,37 @@ function listRuntimeFolderWorkspaces(
       hostId: repoOwnerCount === 1 ? (meta.hostId ?? expectedHostId) : expectedHostId
     }
   })
+}
+
+/**
+ * A git project's terminal groups: extra workspace instances on its main checkout. `git worktree
+ * list` cannot describe them, so they are appended to every scan rather than filtered out of one.
+ */
+function listRuntimeTerminalGroups(
+  store: Pick<RuntimeStore, 'getAllWorktreeMeta' | 'setWorktreeMeta'>,
+  repo: Repo,
+  // Why: the resolution pass fans out over every repo, so it reads the meta map once and threads
+  // the snapshot through instead of re-materializing it per repo.
+  metaSnapshot?: Record<string, WorktreeMeta>
+): Worktree[] {
+  if (isFolderRepo(repo)) {
+    return []
+  }
+  const allMeta = metaSnapshot ?? store.getAllWorktreeMeta()
+  return Object.keys(allMeta)
+    .filter((worktreeId) => isWorkspaceInstanceWorktreeIdForRepo(repo, worktreeId))
+    .map((worktreeId) => {
+      const existing = allMeta[worktreeId]
+      const meta = existing?.instanceId
+        ? existing
+        : store.setWorktreeMeta(worktreeId, {
+            instanceId: getRuntimeFolderWorkspaceInstanceIdentity(repo, worktreeId)
+          })
+      return mergeRuntimeFolderWorkspace(repo, worktreeId, meta)
+    })
+    .sort((left, right) => {
+      return (right.createdAt ?? right.lastActivityAt) - (left.createdAt ?? left.lastActivityAt)
+    })
 }
 
 function parseExactWorktreeIdSelector(selector: string): RuntimeWorktreeRemovalTarget | null {
@@ -23223,11 +23256,19 @@ export class OrcaRuntimeService {
       }
       return applyMetadataFallbackVisibility(detectedWorktree)
     })
+    // Why: an authoritative listing is proof of absence for everything it omits — callers purge
+    // renderer state and sweep PTYs against it, so terminal groups have to ride along.
+    const terminalGroups = listRuntimeTerminalGroups(store, repo).map((worktree) =>
+      this.toRuntimeDetectedWorktree(repo, worktree)
+    )
     return {
       repoId: repo.id,
       authoritative: scan.ok,
       source: scan.ok ? 'git' : 'metadata-fallback',
-      worktrees: projectResolvedWorktreeLineage(detected, store.getAllWorktreeLineage?.() ?? {})
+      worktrees: projectResolvedWorktreeLineage(
+        [...detected, ...terminalGroups],
+        store.getAllWorktreeLineage?.() ?? {}
+      )
     }
   }
 
@@ -24046,6 +24087,8 @@ export class OrcaRuntimeService {
     workspaceStatus?: string
     manualOrder?: number
     sparseCheckout?: { directories: string[]; presetId?: string }
+    /** Terminal group on the project's existing checkout; ignored by folder projects. */
+    terminalGroup?: boolean
     pushTarget?: GitPushTarget
     runHooks?: boolean
     activate?: boolean
@@ -24110,7 +24153,8 @@ export class OrcaRuntimeService {
         draftStartup?.agent ??
         (requestedAgentEnabled ? requestedAgent : undefined))
     const effectiveDraftPaste = args.startupDraftPaste ?? draftStartup?.draftPaste
-    if (isFolderRepo(repo)) {
+    // A terminal group shares the project checkout, so a git repo takes the folder path too.
+    if (isFolderRepo(repo) || args.terminalGroup === true) {
       const now = Date.now()
       const settings = createSettings
       const instanceId = randomUUID()
@@ -26794,7 +26838,9 @@ export class OrcaRuntimeService {
             warning: `Project ${removalTarget.repoId} is no longer tracked, so ${removalTarget.path} was forgotten without deleting the directory or its Git worktree registration.`
           }
         }
-        if (isFolderRepo(repo)) {
+        // A git project's terminal groups share its checkout, so they take the same metadata-only
+        // teardown — never `git worktree remove` against the main checkout.
+        if (isFolderRepo(repo) || isWorkspaceInstanceWorktreeId(removalTarget.id)) {
           if (removalTarget.id === getRuntimeFolderWorkspaceRootId(repo)) {
             throw new Error(
               'Cannot delete the project root workspace. Remove the folder project instead.'
@@ -31834,16 +31880,36 @@ export class OrcaRuntimeService {
     )
     const deps = this.repoWorktreeRowDeps()
     const perRepoWorktrees = await Promise.all(
-      repos.map(
-        async (repo) =>
-          await resolveRepoWorktreeRows(
-            deps,
-            repo,
-            metaById,
-            projectRuntimeByRepoId,
-            repoOwnerCounts.get(repo.id) ?? 1
-          )
-      )
+      repos.map(async (repo) => {
+        const rows = await resolveRepoWorktreeRows(
+          deps,
+          repo,
+          metaById,
+          projectRuntimeByRepoId,
+          repoOwnerCounts.get(repo.id) ?? 1
+        )
+        // Why: a git project's terminal groups live on its main checkout, so `git worktree list`
+        // never reports them — they are appended from meta, mirroring the folder-workspace rows.
+        const terminalGroups = listRuntimeTerminalGroups(this.requireStore(), repo, metaById).map(
+          (worktree) => ({
+            ...worktree,
+            hostId: worktree.hostId ?? getRepoExecutionHostId(repo),
+            parentWorktreeId: null,
+            childWorktreeIds: [],
+            lineage: null,
+            git: {
+              path: worktree.path,
+              head: worktree.head,
+              branch: worktree.branch,
+              isBare: worktree.isBare,
+              isMainWorktree: worktree.isMainWorktree
+            },
+            displayName: worktree.displayName,
+            comment: worktree.comment
+          })
+        )
+        return terminalGroups.length > 0 ? [...rows, ...terminalGroups] : rows
+      })
     )
     const lineageById = this.store?.getAllWorktreeLineage?.() ?? {}
     const worktrees = perRepoWorktrees.flatMap((rows) =>

--- a/src/main/runtime/rpc/methods/worktree-create-args.ts
+++ b/src/main/runtime/rpc/methods/worktree-create-args.ts
@@ -25,6 +25,7 @@ export function buildManagedWorktreeCreateArgs(
     baseBranch: params.baseBranch,
     compareBaseRef: params.compareBaseRef,
     branchNameOverride: params.branchNameOverride,
+    ...(params.terminalGroup === true ? { terminalGroup: true } : {}),
     linkedIssue: params.linkedIssue,
     linkedPR: params.linkedPR,
     linkedLinearIssue: params.linkedLinearIssue,

--- a/src/main/runtime/rpc/methods/worktree-create-schemas.ts
+++ b/src/main/runtime/rpc/methods/worktree-create-schemas.ts
@@ -31,6 +31,8 @@ export const WorktreeCreate = z
     baseBranch: OptionalString,
     compareBaseRef: OptionalString,
     branchNameOverride: OptionalString,
+    /** Create a terminal group on the project's checkout instead of a worktree. Older hosts ignore it. */
+    terminalGroup: OptionalBoolean,
     linkedIssue: TriStateLinkedIssue,
     linkedPR: TriStateLinkedIssue,
     linkedLinearIssue: z.string().optional(),

--- a/src/renderer/src/app-shell/AppRootSurfaces.tsx
+++ b/src/renderer/src/app-shell/AppRootSurfaces.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from 'react'
+import NewTerminalGroupDialog from '../components/sidebar/NewTerminalGroupDialog'
 import { lazyWithRetry as lazy } from '@/lib/lazy-with-retry'
 import { translate } from '@/i18n/i18n'
 import { RecoverableRenderErrorBoundary } from '../components/error-boundaries/RecoverableRenderErrorBoundary'
@@ -191,6 +192,14 @@ export function AppRootSurfaces(props: {
           </ModalBoundary>
         ) : null}
         {/* Why: Settings can start Add Project without Sidebar, so its handoff dialogs must share the root host. */}
+        {activeModal === 'new-terminal-group' ? (
+          <ModalBoundary
+            boundaryId="modal.new-terminal-group"
+            resetKey={activeModal === 'new-terminal-group'}
+          >
+            <NewTerminalGroupDialog />
+          </ModalBoundary>
+        ) : null}
         {activeModal === 'confirm-non-git-folder' ? (
           <ModalBoundary boundaryId="modal.confirm-non-git-folder" resetKey>
             <NonGitFolderDialog />

--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -39,7 +39,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
-import { isFolderRepo } from '../../../../shared/repo-kind'
+import { sharesProjectCheckout } from '../../../../shared/workspace-instance-worktree'
 import { githubProjectHost } from '../../../../shared/github/project-identity'
 import HostedReviewActions from './HostedReviewActions'
 import { GitHubPRStackMap, type GitHubPRStackMapNavigationModifiers } from './GitHubPRStackMap'
@@ -740,7 +740,7 @@ export default function ChecksPanel(): React.JSX.Element {
     }
   }
 
-  const isFolder = repo ? isFolderRepo(repo) : false
+  const isFolder = sharesProjectCheckout(repo, activeWorktreeId)
   const prCacheKey =
     repo && branch
       ? getGitHubPRCacheKey(

--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -3,6 +3,7 @@ import { PanelRight } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { cn } from '@/lib/utils'
 import { useSidebarResize } from '@/hooks/useSidebarResize'
+
 import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '@/components/ui/tooltip'
 import { ContextMenu, ContextMenuTrigger } from '@/components/ui/context-menu'
 import { getTopActivityBarLayout } from './activity-bar-overflow'

--- a/src/renderer/src/components/right-sidebar/source-control/listing/use-worktree-context.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/listing/use-worktree-context.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import { sharesProjectCheckout } from '../../../../../../shared/workspace-instance-worktree'
 import { getConnectionId } from '@/lib/connection-context'
 import { getLocalProjectExecutionRuntimeContext } from '@/lib/local-preflight-context'
 import { getRepoOwnerRoutedSettings } from '@/lib/repo-runtime-owner'
@@ -10,7 +11,6 @@ import { getGitHubPRCacheKey } from '@/store/slices/github-cache-key'
 import { getHostedReviewCacheKey } from '@/store/slices/hosted-review'
 import type { GitBranchChangeEntry } from '../../../../../../shared/git-diff-compare-types'
 import type { GitStatusEntry } from '../../../../../../shared/git-status-types'
-import { isFolderRepo } from '../../../../../../shared/repo-kind'
 import { selectReviewCacheData, selectReviewCacheEntry } from '../../review-cache-entry-selection'
 
 const EMPTY_GIT_STATUS_ENTRIES: GitStatusEntry[] = []
@@ -124,7 +124,7 @@ export function useSourceControlWorktreeContext() {
   const activeRepoRuntimeEnvironmentId = activeRepoSettings?.activeRuntimeEnvironmentId ?? null
   const rightSidebarOpen = useAppStore((s) => s.rightSidebarOpen)
 
-  const isFolder = activeRepo ? isFolderRepo(activeRepo) : false
+  const isFolder = sharesProjectCheckout(activeRepo, activeWorktreeId)
   const worktreePath = activeWorktree?.path ?? null
   const activeConnectionId = activeWorktreeId
     ? (getConnectionId(activeWorktreeId) ?? activeRepoConnectionId)

--- a/src/renderer/src/components/right-sidebar/use-right-sidebar-activity-items.ts
+++ b/src/renderer/src/components/right-sidebar/use-right-sidebar-activity-items.ts
@@ -1,8 +1,8 @@
 import { useMemo } from 'react'
+import { sharesProjectCheckout } from '../../../../shared/workspace-instance-worktree'
 import { Plug, Files, GitBranch, ListChecks, Workflow } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { useRepoById } from '@/store/selectors'
-import { isFolderRepo } from '../../../../shared/repo-kind'
 import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
 import { getVisibleRightSidebarActivityItems } from './right-sidebar-activity-visibility'
 import { getPluginPanelActivityItems } from './plugin-panel-activity-items'
@@ -43,7 +43,7 @@ export function useRightSidebarActivityItems({
   const activeRepo = useRepoById(activeWorktree?.repoId ?? null)
   const activeWorkspaceScope = parseWorkspaceKey(activeWorktreeId ?? '')
   const isFolderWorkspace = activeWorkspaceScope?.type === 'folder'
-  const isFolder = isFolderWorkspace || (activeRepo ? isFolderRepo(activeRepo) : false)
+  const isFolder = isFolderWorkspace || sharesProjectCheckout(activeRepo, activeWorktreeId)
   const isSshRepo = Boolean(activeRepo?.connectionId)
   const pluginSystemEnabled = useAppStore((s) => s.settings?.pluginSystemEnabled === true)
   const pluginPanels = usePluginPanels()

--- a/src/renderer/src/components/sidebar/DeleteWorktreeDialog.tsx
+++ b/src/renderer/src/components/sidebar/DeleteWorktreeDialog.tsx
@@ -23,10 +23,10 @@ import { DeleteWorktreeWarningPanels } from './DeleteWorktreeWarningPanels'
 import { persistDeleteWorktreeConfirmSkipPreference } from './delete-worktree-preference-toast'
 import { getDeleteWorktreeDirtyChangeCounts } from './delete-worktree-dirty-change-counts'
 import {
-  countFolderWorkspaceDeletes,
+  countCheckoutPreservingDeletes,
   getDeleteWorktreeDialogCopy,
   getDeleteWorktreeLineageDialogCopy,
-  isFolderWorkspaceDelete as getIsFolderWorkspaceDelete
+  preservesCheckoutOnDelete
 } from './delete-worktree-dialog-copy'
 import { translate } from '@/i18n/i18n'
 import type { WorktreeRemovalTarget } from '../../../../shared/worktree/removal'
@@ -112,17 +112,17 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
   }, [allWorktrees, worktreeDeleteIdentities, worktreeIds])
   const repoMap = useMemo(() => new Map(repos.map((repo) => [repo.id, repo])), [repos])
   const isBatchDelete = worktreeIds.length > 1
-  const isFolderWorkspaceDelete = !isBatchDelete && getIsFolderWorkspaceDelete(repoMap, worktree)
-  const folderWorkspaceDeleteCount = useMemo(
-    () => countFolderWorkspaceDeletes(repoMap, worktrees),
+  const preservesCheckout = !isBatchDelete && preservesCheckoutOnDelete(repoMap, worktree)
+  const checkoutPreservingDeleteCount = useMemo(
+    () => countCheckoutPreservingDeletes(repoMap, worktrees),
     [repoMap, worktrees]
   )
   const deleteCopy = getDeleteWorktreeDialogCopy({
     isBatchDelete,
     worktree,
     worktreeCount: worktrees.length,
-    folderWorkspaceDeleteCount,
-    isFolderWorkspaceDelete
+    checkoutPreservingDeleteCount,
+    preservesCheckout
   })
   const deleteStateByWorktreeId = useAppStore((s) => s.deleteStateByWorktreeId)
   const lineageDelete = useMemo(
@@ -141,14 +141,14 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
   const hasLineageChildren = childWorkspaceCount > 0
   const canDeleteAllLineage =
     !isMainWorktree && !isBatchDelete && lineageDelete.deleteAllTargets.length > 1
-  const lineageFolderWorkspaceDeleteCount = useMemo(
-    () => countFolderWorkspaceDeletes(repoMap, lineageDelete.deleteAllTargets),
+  const lineageCheckoutPreservingDeleteCount = useMemo(
+    () => countCheckoutPreservingDeletes(repoMap, lineageDelete.deleteAllTargets),
     [lineageDelete.deleteAllTargets, repoMap]
   )
   const lineageDeleteCopy = getDeleteWorktreeLineageDialogCopy({
     childWorkspaceCount,
     deleteTargetCount: lineageDelete.deleteAllTargets.length,
-    folderWorkspaceDeleteCount: lineageFolderWorkspaceDeleteCount
+    checkoutPreservingDeleteCount: lineageCheckoutPreservingDeleteCount
   })
   const allowSkipConfirm =
     !isBatchDelete && modalData.allowSkipConfirm !== false && childWorkspaceCount === 0

--- a/src/renderer/src/components/sidebar/NewTerminalGroupDialog.test.tsx
+++ b/src/renderer/src/components/sidebar/NewTerminalGroupDialog.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment happy-dom
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../../../../shared/repo-types'
+import type { Worktree } from '../../../../shared/worktree/types'
+
+const mocks = vi.hoisted(() => ({
+  createTerminalGroup: vi.fn(),
+  closeModal: vi.fn(),
+  activateAndRevealWorktree: vi.fn(),
+  repo: null as Repo | null
+}))
+
+const state = {
+  activeModal: 'new-terminal-group',
+  modalData: { repoId: 'repo-1' },
+  closeModal: mocks.closeModal,
+  createTerminalGroup: mocks.createTerminalGroup,
+  detectedAgentIds: null,
+  settings: null
+}
+
+vi.mock('@/store', () => ({
+  useAppStore: Object.assign((selector: (value: typeof state) => unknown) => selector(state), {
+    getState: () => state
+  })
+}))
+
+vi.mock('@/store/selectors', () => ({ useRepoById: () => mocks.repo }))
+vi.mock('@/i18n/i18n', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  translate: (_key: string, fallback: string, values?: Record<string, unknown>) =>
+    values
+      ? fallback.replace(/\{\{value(\d)\}\}/g, (_match, index) => String(values[`value${index}`]))
+      : fallback
+}))
+vi.mock('@/lib/worktree-activation', () => ({
+  activateAndRevealWorktree: mocks.activateAndRevealWorktree
+}))
+vi.mock('@/lib/local-preflight-context', () => ({
+  getLocalProjectExecutionRuntimeContext: () => undefined
+}))
+vi.mock('@/components/agent/AgentCombobox', () => ({ default: () => null }))
+
+import NewTerminalGroupDialog from './NewTerminalGroupDialog'
+
+const createdWorktree = {
+  id: 'repo-1::/workspace/repo::workspace:11111111-1111-4111-8111-111111111111',
+  repoId: 'repo-1',
+  path: '/workspace/repo'
+} as Worktree
+
+beforeEach(() => {
+  mocks.repo = {
+    id: 'repo-1',
+    path: '/workspace/repo',
+    displayName: 'orca',
+    badgeColor: '#000',
+    addedAt: 0
+  } as Repo
+  mocks.createTerminalGroup.mockReset().mockResolvedValue(createdWorktree)
+  mocks.closeModal.mockReset()
+  mocks.activateAndRevealWorktree.mockReset().mockReturnValue({ primaryTabId: 'tab-1' })
+  ;(window as unknown as { api: Record<string, unknown> }).api = {}
+})
+
+afterEach(() => cleanup())
+
+describe('NewTerminalGroupDialog', () => {
+  it('states that the group reuses the project checkout rather than creating a worktree', () => {
+    render(<NewTerminalGroupDialog />)
+
+    expect(screen.getByText(/No new worktree, no branch/)).toBeTruthy()
+    expect(screen.getByText(/orca/)).toBeTruthy()
+  })
+
+  it('creates the group with the typed name and closes', async () => {
+    render(<NewTerminalGroupDialog />)
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'servers' } })
+    fireEvent.click(screen.getByText('Create group'))
+
+    await waitFor(() => {
+      expect(mocks.createTerminalGroup).toHaveBeenCalledWith({
+        repoId: 'repo-1',
+        name: 'servers',
+        telemetrySource: 'sidebar'
+      })
+    })
+    await waitFor(() => expect(mocks.closeModal).toHaveBeenCalled())
+  })
+
+  it('surfaces a create failure instead of closing', async () => {
+    mocks.createTerminalGroup.mockRejectedValue(new Error('runtime_unavailable'))
+    render(<NewTerminalGroupDialog />)
+
+    fireEvent.click(screen.getByText('Create group'))
+
+    await waitFor(() => expect(screen.getByText('runtime_unavailable')).toBeTruthy())
+    expect(mocks.closeModal).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/sidebar/NewTerminalGroupDialog.tsx
+++ b/src/renderer/src/components/sidebar/NewTerminalGroupDialog.tsx
@@ -1,0 +1,188 @@
+import React, { useCallback, useId, useMemo, useState } from 'react'
+import { useAppStore } from '@/store'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import AgentCombobox from '@/components/agent/AgentCombobox'
+import { getAgentCatalog } from '@/lib/agent-catalog'
+import { getAgentLaunchPlatformForRepo } from '@/lib/agent-launch-platform'
+import { getLocalProjectExecutionRuntimeContext } from '@/lib/local-preflight-context'
+import { useRepoById } from '@/store/selectors'
+import { filterEnabledTuiAgents } from '../../../../shared/tui-agent-selection'
+import { getExecutionHostLabel, getRepoExecutionHostId } from '../../../../shared/execution-host'
+import type { TuiAgent } from '../../../../shared/tui-agent'
+import { translate } from '@/i18n/i18n'
+import { submitTerminalGroupCreate } from './new-terminal-group-submit'
+
+type NewTerminalGroupModalData = {
+  repoId?: string
+}
+
+export default function NewTerminalGroupDialog(): React.JSX.Element | null {
+  const visible = useAppStore((s) => s.activeModal === 'new-terminal-group')
+  const modalData = useAppStore((s) => s.modalData as NewTerminalGroupModalData | undefined)
+  const closeModal = useAppStore((s) => s.closeModal)
+  const repoId = modalData?.repoId ?? null
+
+  if (!visible || !repoId) {
+    return null
+  }
+
+  return <NewTerminalGroupDialogBody repoId={repoId} onClose={closeModal} />
+}
+
+function NewTerminalGroupDialogBody({
+  repoId,
+  onClose
+}: {
+  repoId: string
+  onClose: () => void
+}): React.JSX.Element | null {
+  const repo = useRepoById(repoId)
+  const settings = useAppStore((s) => s.settings)
+  const createTerminalGroup = useAppStore((s) => s.createTerminalGroup)
+  const detectedAgentIds = useAppStore((s) => s.detectedAgentIds)
+  const [name, setName] = useState('')
+  const [agent, setAgent] = useState<TuiAgent | null>(null)
+  const [creating, setCreating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const nameId = useId()
+
+  const agents = useMemo(() => {
+    const enabledIds = new Set(
+      filterEnabledTuiAgents(
+        getAgentCatalog().map((entry) => entry.id),
+        settings?.disabledTuiAgents
+      )
+    )
+    const detected = detectedAgentIds === null ? null : new Set(detectedAgentIds)
+    return getAgentCatalog().filter(
+      (entry) => enabledIds.has(entry.id) && (detected === null || detected.has(entry.id))
+    )
+  }, [detectedAgentIds, settings?.disabledTuiAgents])
+
+  const handleCreate = useCallback(async (): Promise<void> => {
+    if (!repo || creating) {
+      return
+    }
+    setCreating(true)
+    setError(null)
+    try {
+      await submitTerminalGroupCreate({
+        repo,
+        name,
+        agent,
+        platform: getAgentLaunchPlatformForRepo(
+          repo,
+          repo.connectionId
+            ? undefined
+            : getLocalProjectExecutionRuntimeContext(useAppStore.getState(), repoId)
+        ),
+        agentCmdOverrides: settings?.agentCmdOverrides,
+        terminalWindowsShell: settings?.terminalWindowsShell,
+        createTerminalGroup: (input) =>
+          createTerminalGroup({ ...input, telemetrySource: 'sidebar' }),
+        onOpenChange: (open) => {
+          if (!open) {
+            onClose()
+          }
+        }
+      })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setCreating(false)
+    }
+  }, [
+    agent,
+    createTerminalGroup,
+    creating,
+    name,
+    onClose,
+    repo,
+    repoId,
+    settings?.agentCmdOverrides,
+    settings?.terminalWindowsShell
+  ])
+
+  if (!repo) {
+    return null
+  }
+
+  const hostLabel = getExecutionHostLabel(getRepoExecutionHostId(repo))
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader className="gap-1">
+          <DialogTitle className="text-base font-semibold">
+            {translate(
+              'auto.components.sidebar.NewTerminalGroupDialog.title',
+              'New terminal group'
+            )}
+          </DialogTitle>
+          <DialogDescription>
+            {translate(
+              'auto.components.sidebar.NewTerminalGroupDialog.description',
+              'Terminals and agents that run in {{value0}} on {{value1}}. No new worktree, no branch.',
+              { value0: repo.displayName, value1: hostLabel }
+            )}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor={nameId}>
+              {translate('auto.components.sidebar.NewTerminalGroupDialog.nameLabel', 'Name')}
+            </Label>
+            <Input
+              id={nameId}
+              value={name}
+              autoFocus
+              placeholder={translate(
+                'auto.components.sidebar.NewTerminalGroupDialog.namePlaceholder',
+                'servers, research, scripts…'
+              )}
+              onChange={(event) => setName(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' && !creating) {
+                  event.preventDefault()
+                  void handleCreate()
+                }
+              }}
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label>
+              {translate('auto.components.sidebar.NewTerminalGroupDialog.agentLabel', 'Agent')}
+            </Label>
+            <AgentCombobox
+              agents={agents}
+              value={agent}
+              onValueChange={setAgent}
+              allowBlankTerminal
+              allowNarrowTrigger
+              triggerClassName="h-9 w-full min-w-0 border-input text-sm focus:border-ring focus:ring-[3px] focus:ring-ring/50"
+            />
+          </div>
+          {error ? <p className="text-xs text-destructive">{error}</p> : null}
+        </div>
+        <DialogFooter>
+          <Button type="button" variant="ghost" onClick={onClose} disabled={creating}>
+            {translate('auto.components.sidebar.NewTerminalGroupDialog.cancel', 'Cancel')}
+          </Button>
+          <Button type="button" onClick={() => void handleCreate()} disabled={creating}>
+            {translate('auto.components.sidebar.NewTerminalGroupDialog.create', 'Create group')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -223,6 +223,15 @@ const WorktreeList = React.memo(function WorktreeList({
     [openModal]
   )
 
+
+  const handleCreateTerminalGroup = useCallback(
+    (projectId: string) => {
+      openModal('new-terminal-group', { repoId: projectId })
+    },
+    [openModal]
+  )
+
+
   useSidebarRevealRequests({
     groupBy,
     renderedSidebarRowKeys: rowModel.renderedSidebarRowKeys,
@@ -302,6 +311,7 @@ const WorktreeList = React.memo(function WorktreeList({
         handleRenameProjectGroup={projectGroupDialogs.handleRenameProjectGroup}
         handleDeleteProjectGroup={projectGroupDialogs.handleDeleteProjectGroup}
         handleCreateFolderWorkspace={handleCreateFolderWorkspace}
+        handleCreateTerminalGroup={handleCreateTerminalGroup}
         activeModal={activeModal}
         pendingRevealWorktree={pendingRevealWorktree}
         pendingRevealSidebarRow={pendingRevealSidebarRow}

--- a/src/renderer/src/components/sidebar/delete-worktree-dialog-copy.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-dialog-copy.ts
@@ -1,47 +1,47 @@
-import { isFolderRepo } from '../../../../shared/repo-kind'
+import { sharesProjectCheckout } from '../../../../shared/workspace-instance-worktree'
 import type { Repo } from '../../../../shared/repo-types'
 import type { Worktree } from '../../../../shared/worktree/types'
 
-type WorktreeRepoRef = Pick<Worktree, 'repoId'>
+type WorktreeRepoRef = Pick<Worktree, 'id' | 'repoId'>
 
-export function isFolderWorkspaceDelete(
+/** Deleting a folder workspace or a terminal group drops the Orca record only — no git, no disk. */
+export function preservesCheckoutOnDelete(
   repoMap: ReadonlyMap<string, Repo>,
   worktree: WorktreeRepoRef | null | undefined
 ): boolean {
   if (!worktree) {
     return false
   }
-  const repo = repoMap.get(worktree.repoId)
-  return repo ? isFolderRepo(repo) : false
+  return sharesProjectCheckout(repoMap.get(worktree.repoId), worktree.id)
 }
 
-export function countFolderWorkspaceDeletes(
+export function countCheckoutPreservingDeletes(
   repoMap: ReadonlyMap<string, Repo>,
   worktrees: readonly WorktreeRepoRef[]
 ): number {
-  return worktrees.filter((item) => isFolderWorkspaceDelete(repoMap, item)).length
+  return worktrees.filter((item) => preservesCheckoutOnDelete(repoMap, item)).length
 }
 
 export function getDeleteWorktreeDialogCopy(args: {
   isBatchDelete: boolean
   worktree: Pick<Worktree, 'displayName'> | null
   worktreeCount: number
-  folderWorkspaceDeleteCount: number
-  isFolderWorkspaceDelete: boolean
+  checkoutPreservingDeleteCount: number
+  preservesCheckout: boolean
 }): {
   targetLabel: string | undefined
   targetClassName: string
   descriptionSuffix: string
   mainWorktreeBlocker: string
 } {
-  const allFolderWorkspaceDeletes =
+  const allCheckoutPreservingDeletes =
     args.isBatchDelete &&
     args.worktreeCount > 0 &&
-    args.folderWorkspaceDeleteCount === args.worktreeCount
-  const mixedFolderWorkspaceDeletes =
+    args.checkoutPreservingDeleteCount === args.worktreeCount
+  const mixedCheckoutPreservingDeletes =
     args.isBatchDelete &&
-    args.folderWorkspaceDeleteCount > 0 &&
-    args.folderWorkspaceDeleteCount < args.worktreeCount
+    args.checkoutPreservingDeleteCount > 0 &&
+    args.checkoutPreservingDeleteCount < args.worktreeCount
   return {
     targetLabel: args.isBatchDelete
       ? `${args.worktreeCount} workspaces`
@@ -50,15 +50,15 @@ export function getDeleteWorktreeDialogCopy(args: {
       ? 'font-medium text-foreground'
       : 'break-all font-medium text-foreground',
     descriptionSuffix: args.isBatchDelete
-      ? allFolderWorkspaceDeletes
+      ? allCheckoutPreservingDeletes
         ? 'from Orca. Project folders on disk will not be deleted.'
-        : mixedFolderWorkspaceDeletes
+        : mixedCheckoutPreservingDeletes
           ? 'from Orca. Git worktrees will also be removed from git and disk; folder workspaces will only remove the Orca workspace entry.'
           : 'from git and delete their workspace folders.'
-      : args.isFolderWorkspaceDelete
+      : args.preservesCheckout
         ? 'from Orca. The project folder on disk will not be deleted.'
         : 'from git and delete its workspace folder.',
-    mainWorktreeBlocker: args.isFolderWorkspaceDelete
+    mainWorktreeBlocker: args.preservesCheckout
       ? 'Remove the folder project instead of deleting this workspace.'
       : 'Git does not allow removing the main worktree.'
   }
@@ -67,24 +67,25 @@ export function getDeleteWorktreeDialogCopy(args: {
 export function getDeleteWorktreeLineageDialogCopy(args: {
   childWorkspaceCount: number
   deleteTargetCount: number
-  folderWorkspaceDeleteCount: number
+  checkoutPreservingDeleteCount: number
 }): {
   childTargetLabel: string
   descriptionSuffix: string
 } {
-  const allFolderWorkspaceDeletes =
-    args.deleteTargetCount > 0 && args.folderWorkspaceDeleteCount === args.deleteTargetCount
-  const mixedFolderWorkspaceDeletes =
-    args.folderWorkspaceDeleteCount > 0 && args.folderWorkspaceDeleteCount < args.deleteTargetCount
+  const allCheckoutPreservingDeletes =
+    args.deleteTargetCount > 0 && args.checkoutPreservingDeleteCount === args.deleteTargetCount
+  const mixedCheckoutPreservingDeletes =
+    args.checkoutPreservingDeleteCount > 0 &&
+    args.checkoutPreservingDeleteCount < args.deleteTargetCount
 
   return {
     childTargetLabel:
       args.childWorkspaceCount === 1
         ? '1 child workspace'
         : `${args.childWorkspaceCount} child workspaces`,
-    descriptionSuffix: allFolderWorkspaceDeletes
+    descriptionSuffix: allCheckoutPreservingDeletes
       ? 'from Orca. Project folders on disk will not be deleted.'
-      : mixedFolderWorkspaceDeletes
+      : mixedCheckoutPreservingDeletes
         ? 'from Orca. Git worktrees will also be removed from git and disk; folder workspaces will only remove the Orca workspace entry.'
         : 'from git and delete their workspace folders.'
   }

--- a/src/renderer/src/components/sidebar/delete-worktree-dirty-change-counts.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-dirty-change-counts.ts
@@ -1,7 +1,7 @@
 import type { Repo } from '../../../../shared/repo-types'
 import type { Worktree } from '../../../../shared/worktree/types'
 import type { WorktreeDeleteState } from '../../store/slices/worktree-helpers'
-import { isFolderWorkspaceDelete } from './delete-worktree-dialog-copy'
+import { preservesCheckoutOnDelete } from './delete-worktree-dialog-copy'
 import { getDeleteStateForWorktreeHost } from './worktree-delete-state-host-match'
 import { getWorktreeHostIdentity } from '../../../../shared/worktree/host-qualified-identity'
 
@@ -20,7 +20,7 @@ export function getDeleteWorktreeDirtyChangeCounts({
 }): Map<string, number> {
   const result = new Map<string, number>()
   for (const item of deleteTargets) {
-    if (item.isMainWorktree || isFolderWorkspaceDelete(repoMap, item)) {
+    if (item.isMainWorktree || preservesCheckoutOnDelete(repoMap, item)) {
       continue
     }
     const resultKey = item.hostId ? getWorktreeHostIdentity(item) : item.id

--- a/src/renderer/src/components/sidebar/new-terminal-group-submit.test.ts
+++ b/src/renderer/src/components/sidebar/new-terminal-group-submit.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Worktree } from '../../../../shared/worktree/types'
+
+const mocks = vi.hoisted(() => ({
+  activateAndRevealWorktree: vi.fn(),
+  ensureAgentStartupInTerminal: vi.fn()
+}))
+
+vi.mock('@/lib/worktree-activation', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return { ...actual, activateAndRevealWorktree: mocks.activateAndRevealWorktree }
+})
+
+vi.mock('@/lib/new-workspace', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return { ...actual, ensureAgentStartupInTerminal: mocks.ensureAgentStartupInTerminal }
+})
+
+import { resolveTerminalGroupName, submitTerminalGroupCreate } from './new-terminal-group-submit'
+
+const repo = {
+  id: 'repo-1',
+  displayName: 'orca',
+  path: '/workspace/repo',
+  connectionId: null
+}
+
+const createdWorktree = {
+  id: 'repo-1::/workspace/repo::workspace:11111111-1111-4111-8111-111111111111',
+  repoId: 'repo-1',
+  path: '/workspace/repo'
+} as Worktree
+
+beforeEach(() => {
+  mocks.activateAndRevealWorktree.mockReset().mockReturnValue({ primaryTabId: 'tab-1' })
+  mocks.ensureAgentStartupInTerminal.mockReset()
+  ;(window as unknown as { api: Record<string, unknown> }).api = {}
+})
+
+describe('resolveTerminalGroupName', () => {
+  it('falls back to a project-derived label instead of an empty card', () => {
+    expect(resolveTerminalGroupName('  servers ', 'orca')).toBe('servers')
+    expect(resolveTerminalGroupName('   ', 'orca')).toBe('orca terminals')
+  })
+})
+
+describe('submitTerminalGroupCreate', () => {
+  it('creates the group and reveals it without an agent startup', async () => {
+    const createTerminalGroup = vi.fn().mockResolvedValue(createdWorktree)
+
+    const created = await submitTerminalGroupCreate({
+      repo,
+      name: 'servers',
+      agent: null,
+      platform: 'darwin',
+      createTerminalGroup,
+      onOpenChange: vi.fn()
+    })
+
+    expect(created).toBe(true)
+    expect(createTerminalGroup).toHaveBeenCalledWith({ repoId: 'repo-1', name: 'servers' })
+    expect(mocks.activateAndRevealWorktree).toHaveBeenCalledWith(createdWorktree.id, {})
+  })
+
+  it('launches the selected agent in the new group', async () => {
+    const createTerminalGroup = vi.fn().mockResolvedValue(createdWorktree)
+
+    await submitTerminalGroupCreate({
+      repo,
+      name: 'research',
+      agent: 'codex',
+      platform: 'darwin',
+      createTerminalGroup,
+      onOpenChange: vi.fn()
+    })
+
+    const [, options] = mocks.activateAndRevealWorktree.mock.calls[0]
+    expect(options.startup).toMatchObject({
+      launchAgent: 'codex',
+      telemetry: expect.objectContaining({ launch_source: 'sidebar', request_kind: 'new' })
+    })
+    expect(options.startup.command).toContain('codex')
+  })
+
+  it('keeps the dialog open when creation returns nothing', async () => {
+    const onOpenChange = vi.fn()
+
+    const created = await submitTerminalGroupCreate({
+      repo,
+      name: 'servers',
+      agent: null,
+      platform: 'darwin',
+      createTerminalGroup: vi.fn().mockResolvedValue(null),
+      onOpenChange
+    })
+
+    expect(created).toBe(false)
+    expect(onOpenChange).not.toHaveBeenCalled()
+    expect(mocks.activateAndRevealWorktree).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/sidebar/new-terminal-group-submit.ts
+++ b/src/renderer/src/components/sidebar/new-terminal-group-submit.ts
@@ -1,0 +1,141 @@
+import { ensureAgentStartupInTerminal } from '@/lib/new-workspace'
+import { createBrowserUuid } from '@/lib/browser-uuid'
+import { buildAgentStartupPlan } from '@/lib/tui-agent-startup'
+import { tuiAgentToAgentKind } from '@/lib/telemetry'
+import { activateAndRevealWorktree } from '@/lib/worktree-activation'
+import { TUI_AGENT_CONFIG } from '../../../../shared/tui-agent-config'
+import { repoIsRemote } from '../../../../shared/agent-launch-remote'
+import { resolveLocalWindowsAgentStartupShell } from '../../../../shared/windows-terminal-shell'
+import type { Repo } from '../../../../shared/repo-types'
+import type { TuiAgent } from '../../../../shared/tui-agent'
+import type { Worktree } from '../../../../shared/worktree/types'
+import type { LaunchSource } from '../../../../shared/telemetry-events'
+
+export type TerminalGroupLaunchRepo = Pick<Repo, 'id' | 'displayName' | 'path' | 'connectionId'>
+
+type SubmitTerminalGroupCreateParams = {
+  repo: TerminalGroupLaunchRepo
+  name: string
+  agent: TuiAgent | null
+  /** Repo-scoped launch platform, resolved by the caller from the project's execution host. */
+  platform: NodeJS.Platform
+  agentCmdOverrides?: Record<string, string>
+  agentArgs?: string | null
+  agentEnv?: Record<string, string>
+  terminalWindowsShell?: string | null
+  launchSource?: LaunchSource
+  createTerminalGroup: (input: { repoId: string; name: string }) => Promise<Worktree | null>
+  onOpenChange: (open: boolean) => void
+}
+
+/** Falls back to a project-derived label so an unnamed group never lands as an empty card. */
+export function resolveTerminalGroupName(name: string, repoDisplayName: string): string {
+  return name.trim() || `${repoDisplayName} terminals`
+}
+
+async function preflightTerminalGroupAgentTrust(args: {
+  agent: TuiAgent | null
+  workspacePath: string
+  connectionId?: string | null
+}): Promise<void> {
+  if (!args.agent || !window.api.agentTrust?.markTrusted) {
+    return
+  }
+  const preflight = TUI_AGENT_CONFIG[args.agent].preflightTrust
+  if (!preflight || !args.workspacePath) {
+    return
+  }
+  try {
+    await window.api.agentTrust.markTrusted({
+      preset: preflight,
+      workspacePath: args.workspacePath,
+      ...(args.connectionId ? { connectionId: args.connectionId } : {})
+    })
+  } catch {
+    // Best-effort: the user can still accept the agent trust prompt manually.
+  }
+}
+
+export async function submitTerminalGroupCreate({
+  repo,
+  name,
+  agent,
+  platform,
+  agentCmdOverrides,
+  agentArgs,
+  agentEnv,
+  terminalWindowsShell,
+  launchSource = 'sidebar',
+  createTerminalGroup,
+  onOpenChange
+}: SubmitTerminalGroupCreateParams): Promise<boolean> {
+  const isRemote = repoIsRemote(repo)
+  const startupPlan = agent
+    ? buildAgentStartupPlan({
+        agent,
+        prompt: '',
+        cmdOverrides: agentCmdOverrides ?? {},
+        agentArgs,
+        agentEnv,
+        platform,
+        shell: resolveLocalWindowsAgentStartupShell({
+          platform,
+          isRemote,
+          terminalWindowsShell
+        }),
+        isRemote,
+        allowEmptyPromptLaunch: true
+      })
+    : null
+
+  const worktree = await createTerminalGroup({
+    repoId: repo.id,
+    name: resolveTerminalGroupName(name, repo.displayName)
+  })
+  if (!worktree) {
+    return false
+  }
+  // The group runs in the project checkout, so trust is granted for that path.
+  await preflightTerminalGroupAgentTrust({
+    agent,
+    workspacePath: worktree.path,
+    connectionId: repo.connectionId
+  })
+  if (startupPlan && !startupPlan.launchToken) {
+    // Why: delayed delivery must target the exact pane spawned from this queued
+    // startup, so both halves share one renderer-session token.
+    startupPlan.launchToken = createBrowserUuid()
+  }
+  const startup =
+    agent && startupPlan
+      ? {
+          command: startupPlan.launchCommand,
+          ...(startupPlan.env ? { env: startupPlan.env } : {}),
+          launchConfig: startupPlan.launchConfig,
+          ...(startupPlan.launchToken ? { launchToken: startupPlan.launchToken } : {}),
+          launchAgent: agent,
+          ...(startupPlan.sessionOptions ? { sessionOptions: startupPlan.sessionOptions } : {}),
+          telemetry: {
+            agent_kind: tuiAgentToAgentKind(agent),
+            launch_source: launchSource,
+            request_kind: 'new' as const
+          }
+        }
+      : undefined
+  onOpenChange(false)
+  try {
+    const activation = activateAndRevealWorktree(worktree.id, startup ? { startup } : {})
+    if (startupPlan?.followupPrompt && activation !== false) {
+      void ensureAgentStartupInTerminal({
+        worktreeId: worktree.id,
+        primaryTabId: activation.primaryTabId,
+        startup: startupPlan
+      })
+    }
+  } catch (error) {
+    // Why: creation already succeeded. Do not leave the completed create modal
+    // open if the follow-up reveal/startup path hits a transient issue.
+    console.error('Failed to activate terminal group after create:', error)
+  }
+  return true
+}

--- a/src/renderer/src/components/sidebar/use-delete-worktree-status-hydration.ts
+++ b/src/renderer/src/components/sidebar/use-delete-worktree-status-hydration.ts
@@ -9,7 +9,7 @@ import type { Worktree } from '../../../../shared/worktree/types'
 import type { GitStatusResult } from '../../../../shared/git-status-types'
 import { parseExecutionHostId } from '../../../../shared/execution-host'
 import { getWorktreeHostIdentity } from '../../../../shared/worktree/host-qualified-identity'
-import { isFolderWorkspaceDelete } from './delete-worktree-dialog-copy'
+import { preservesCheckoutOnDelete } from './delete-worktree-dialog-copy'
 
 const EMPTY_STATUS_BY_IDENTITY = new Map<string, GitStatusResult['entries']>()
 
@@ -40,7 +40,10 @@ export function useDeleteWorktreeStatusHydration({
     }
     const gitStatusByWorktree = useAppStore.getState().gitStatusByWorktree
     const targets = deleteTargets.filter(
-      (target) => !target.isMainWorktree && !isFolderWorkspaceDelete(repoMap, target)
+      (target) =>
+        !target.isMainWorktree &&
+        !preservesCheckoutOnDelete(repoMap, target) &&
+        gitStatusByWorktree[target.id] === undefined
     )
     const controller = new AbortController()
     for (const target of targets) {

--- a/src/renderer/src/components/sidebar/use-worktree-card-review-details.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-card-review-details.ts
@@ -5,7 +5,7 @@ import { issueCacheKey as getIssueCacheKey } from '@/store/slices/github'
 import { getHostedReviewCacheKey } from '@/store/slices/hosted-review'
 import { hostedReviewInfoFromGitHubPRInfo } from '../../../../shared/hosted-review-github'
 import type { HostedReviewInfo } from '../../../../shared/hosted-review'
-import { isFolderRepo } from '../../../../shared/repo-kind'
+import { sharesProjectCheckout } from '../../../../shared/workspace-instance-worktree'
 import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
 import {
   getWorktreeCardPrDisplay,
@@ -31,7 +31,7 @@ export function useWorktreeCardReviewDetails({
   const workspaceScope = parseWorkspaceKey(worktree.id)
   const folderWorkspaceId =
     workspaceScope?.type === 'folder' ? workspaceScope.folderWorkspaceId : null
-  const isFolder = repo ? isFolderRepo(repo) : folderWorkspaceId !== null
+  const isFolder = sharesProjectCheckout(repo, worktree.id) || folderWorkspaceId !== null
   // Why: project groups gate folder workspaces, so folder paths stay hidden from identity surfaces until that capability exists.
   const hasProjectGroups = projectGroups.length > 0
   const branchIdentityDisplay = !isFolder && branch.length > 0 ? branch : undefined

--- a/src/renderer/src/components/sidebar/worktree-list/rows/repo-header-project-actions.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/repo-header-project-actions.tsx
@@ -8,7 +8,8 @@ import {
   Plus,
   Shapes,
   SlidersHorizontal,
-  Trash2
+  Trash2,
+  SquareTerminal
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -65,6 +66,7 @@ export type RepoHeaderProjectActions = {
   onRemoveProjectFromGroup: (repo: Repo) => void
   onRemoveProject: (repo: Repo) => void
   onCreateForRepo: (projectId: string) => void
+  onCreateTerminalGroup: (projectId: string) => void
 }
 
 export function RepoHeaderProjectActionsMenu({
@@ -132,6 +134,16 @@ export function RepoHeaderProjectActionsMenu({
           <DropdownMenuItem onSelect={() => actions.onOpenWorktreeVisibility(repo)}>
             <Eye className="size-3.5" />
             {getWorktreeVisibilityMenuLabel(repo, actions.getWorktreeVisibilityDefaults(repo))}
+          </DropdownMenuItem>
+        ) : null}
+        {/* Folder projects already work this way, so the entry is git-only. */}
+        {isGitRepoKind(repo) ? (
+          <DropdownMenuItem onSelect={() => actions.onCreateTerminalGroup(repo.id)}>
+            <SquareTerminal className="size-3.5" />
+            {translate(
+              'auto.components.sidebar.WorktreeList.newTerminalGroup',
+              'New terminal group'
+            )}
           </DropdownMenuItem>
         ) : null}
         <DropdownMenuItem onSelect={() => actions.onCreateGroupFromRepo(repo)}>

--- a/src/renderer/src/components/sidebar/worktree-list/viewport/viewport-props.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/viewport/viewport-props.ts
@@ -50,6 +50,7 @@ export type VirtualizedWorktreeViewportProps = {
   handleRenameProjectGroup: (groupId: string, currentName: string) => void
   handleDeleteProjectGroup: (groupId: string, groupName: string) => void
   handleCreateFolderWorkspace: (projectGroup: ProjectGroup) => void
+  handleCreateTerminalGroup: (projectId: string) => void
   activeModal: string
   pendingRevealWorktree: PendingSidebarWorktreeReveal | null
   pendingRevealSidebarRow: PendingSidebarRowReveal | null

--- a/src/renderer/src/components/sidebar/worktree-list/viewport/virtual-row-context.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/viewport/virtual-row-context.ts
@@ -98,7 +98,8 @@ export function buildWorktreeVirtualRowContext(args: BuildArgs): WorktreeVirtual
         onMoveProjectToGroup: props.handleMoveProjectToGroup,
         onRemoveProjectFromGroup: props.handleRemoveProjectFromGroup,
         onRemoveProject: props.handleRemoveProject,
-        onCreateForRepo: props.handleCreateForRepo
+        onCreateForRepo: props.handleCreateForRepo,
+        onCreateTerminalGroup: props.handleCreateTerminalGroup
       },
       onRenameProjectGroup: props.handleRenameProjectGroup,
       onDeleteProjectGroup: props.handleDeleteProjectGroup,

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5334,7 +5334,8 @@
           "groupDeleteFailedDesc": "Something went wrong while deleting the group. No projects were removed.",
           "failedNestWorkspace": "Failed to nest workspace",
           "sidebarRowMissing": "Target no longer exists",
-          "failedUnnestWorkspace": "Failed to unnest workspace"
+          "failedUnnestWorkspace": "Failed to unnest workspace",
+          "newTerminalGroup": "New terminal group"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "Cancel",
@@ -5919,6 +5920,15 @@
         },
         "WorktreeListScrollToTopButton": {
           "jumpToTop": "Jump to top"
+        },
+        "NewTerminalGroupDialog": {
+          "title": "New terminal group",
+          "description": "Terminals and agents that run in {{value0}} on {{value1}}. No new worktree, no branch.",
+          "nameLabel": "Name",
+          "namePlaceholder": "servers, research, scripts…",
+          "agentLabel": "Agent",
+          "cancel": "Cancel",
+          "create": "Create group"
         },
         "WorktreeVisibilitySourceList": {
           "claude": "Claude Code",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -4624,7 +4624,8 @@
           "hostDisconnected": "Desconectado",
           "failedNestWorkspace": "No se pudo anidar el espacio de trabajo",
           "sidebarRowMissing": "El destino ya no existe",
-          "failedUnnestWorkspace": "Error al expandir el espacio de trabajo"
+          "failedUnnestWorkspace": "Error al expandir el espacio de trabajo",
+          "newTerminalGroup": "Nuevo grupo de terminales"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "Cancelar",
@@ -5148,6 +5149,15 @@
           "3b7ea51793": "Borrar búsqueda",
           "7f1c2e94a5": "El texto de búsqueda es demasiado largo: el tablero no está filtrado",
           "9a4d0f6b21": "Demasiado largo"
+        },
+        "NewTerminalGroupDialog": {
+          "title": "Nuevo grupo de terminales",
+          "description": "Terminales y agentes que se ejecutan en {{value0}} en {{value1}}. Sin worktree nuevo, sin rama.",
+          "nameLabel": "Nombre",
+          "namePlaceholder": "servidores, investigación, scripts…",
+          "agentLabel": "Agente",
+          "cancel": "Cancelar",
+          "create": "Crear grupo"
         }
       },
       "shared": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -4605,7 +4605,8 @@
           "hostDisconnected": "切断済み",
           "failedNestWorkspace": "ワークスペースをネストできませんでした",
           "sidebarRowMissing": "対象はもう存在しません",
-          "failedUnnestWorkspace": "ワークスペースの展開に失敗しました"
+          "failedUnnestWorkspace": "ワークスペースの展開に失敗しました",
+          "newTerminalGroup": "新しいターミナルグループ"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "キャンセル",
@@ -5148,6 +5149,15 @@
           "3b7ea51793": "検索をクリア",
           "7f1c2e94a5": "検索テキストが長すぎます — ボードは絞り込まれていません",
           "9a4d0f6b21": "長すぎます"
+        },
+        "NewTerminalGroupDialog": {
+          "title": "新しいターミナルグループ",
+          "description": "{{value1}} 上の {{value0}} で実行されるターミナルと Agent。新しいワークツリーもブランチも作成しません。",
+          "nameLabel": "名前",
+          "namePlaceholder": "servers、research、scripts…",
+          "agentLabel": "Agent",
+          "cancel": "キャンセル",
+          "create": "グループを作成"
         }
       },
       "shared": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -4607,7 +4607,8 @@
           "hostDisconnected": "연결 끊김",
           "failedNestWorkspace": "워크스페이스를 중첩하지 못했습니다",
           "sidebarRowMissing": "대상이 더 이상 존재하지 않습니다",
-          "failedUnnestWorkspace": "워크트리 펼치기 실패"
+          "failedUnnestWorkspace": "워크트리 펼치기 실패",
+          "newTerminalGroup": "새 터미널 그룹"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "취소",
@@ -5150,6 +5151,15 @@
           "3b7ea51793": "검색 지우기",
           "7f1c2e94a5": "검색어가 너무 깁니다 — 보드가 필터링되지 않았습니다",
           "9a4d0f6b21": "너무 김"
+        },
+        "NewTerminalGroupDialog": {
+          "title": "새 터미널 그룹",
+          "description": "{{value1}}의 {{value0}}에서 실행되는 터미널과 agent입니다. 새 워크트리나 브랜치를 만들지 않습니다.",
+          "nameLabel": "이름",
+          "namePlaceholder": "servers, research, scripts…",
+          "agentLabel": "agent",
+          "cancel": "취소",
+          "create": "그룹 만들기"
         }
       },
       "shared": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -4617,7 +4617,8 @@
           "hostDisconnected": "已断开连接",
           "failedNestWorkspace": "无法嵌套工作区",
           "sidebarRowMissing": "目标不再存在",
-          "failedUnnestWorkspace": "展开工作区失败"
+          "failedUnnestWorkspace": "展开工作区失败",
+          "newTerminalGroup": "新建终端组"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "取消",
@@ -5160,6 +5161,15 @@
           "3b7ea51793": "清除搜索",
           "7f1c2e94a5": "搜索文本过长 — 看板未被筛选",
           "9a4d0f6b21": "过长"
+        },
+        "NewTerminalGroupDialog": {
+          "title": "新建终端组",
+          "description": "在 {{value1}} 上的 {{value0}} 中运行的终端和代理。不创建新的工作树，也不创建分支。",
+          "nameLabel": "名称",
+          "namePlaceholder": "servers、research、scripts…",
+          "agentLabel": "代理",
+          "cancel": "取消",
+          "create": "创建组"
         }
       },
       "shared": {

--- a/src/renderer/src/lib/right-sidebar-visibility.ts
+++ b/src/renderer/src/lib/right-sidebar-visibility.ts
@@ -1,5 +1,5 @@
 import type { AppState } from '@/store/types'
-import { isFolderRepo } from '../../../shared/repo-kind'
+import { sharesProjectCheckout } from '../../../shared/workspace-instance-worktree'
 
 type ActiveView = AppState['activeView']
 
@@ -43,7 +43,7 @@ export function rightSidebarShowsPullRequestData(
   const activeRepo = activeWorktree
     ? state.repos.find((repo) => repo.id === activeWorktree.repoId)
     : null
-  if (!activeRepo || isFolderRepo(activeRepo)) {
+  if (!activeRepo || sharesProjectCheckout(activeRepo, state.activeWorktreeId)) {
     return false
   }
 

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -815,6 +815,7 @@ export type UISlice = {
     | 'feature-wall'
     | 'feature-tips'
     | 'new-workspace-composer'
+    | 'new-terminal-group'
     | 'confirm-orca-yaml-hooks'
   modalData: Record<string, unknown>
   openModal: (modal: UISlice['activeModal'], data?: Record<string, unknown>) => void

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -1,4 +1,5 @@
 import type { WorkspaceKey } from '../../../../shared/folder-workspace-types'
+import type { TerminalGroupCreateArgs } from './worktrees/create/terminal-group-args'
 import type { TuiAgent } from '../../../../shared/tui-agent'
 import type { WorkspaceSource as WorkspaceCreateTelemetrySource } from '../../../../shared/workspace-source'
 import type {
@@ -223,6 +224,8 @@ export type WorktreeSlice = {
       }
     }
   ) => Promise<CreateWorktreeResult>
+  /** Create a terminal group on the project's existing checkout. No branch, no base ref, no setup hooks. */
+  createTerminalGroup: (args: TerminalGroupCreateArgs) => Promise<Worktree | null>
   /** Register an in-flight background creation and make it the active surface. */
   beginPendingWorktreeCreation: (entry: PendingWorktreeCreation) => void
   /** Merge a status patch into an existing pending entry. */

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -17,6 +17,7 @@ import {
 } from './worktrees/metadata/worktree-base-status'
 import { createPrefetchWorktreeCreateBase } from './worktrees/create/prefetch-worktree-create-base'
 import { createCreateWorktree } from './worktrees/create/create-worktree'
+import { createCreateTerminalGroup } from './worktrees/create/create-terminal-group'
 import {
   createBeginPendingWorktreeCreation,
   createRemovePendingWorktreeCreation,
@@ -86,6 +87,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
   updateWorktreeRemoteBranchConflict: createUpdateWorktreeRemoteBranchConflict(set, get),
   prefetchWorktreeCreateBase: createPrefetchWorktreeCreateBase(set, get),
   createWorktree: createCreateWorktree(set, get),
+  createTerminalGroup: createCreateTerminalGroup(set, get),
   beginPendingWorktreeCreation: createBeginPendingWorktreeCreation(set, get),
   updatePendingWorktreeCreation: createUpdatePendingWorktreeCreation(set, get),
   removePendingWorktreeCreation: createRemovePendingWorktreeCreation(set, get),

--- a/src/renderer/src/store/slices/worktrees/create/create-terminal-group.ts
+++ b/src/renderer/src/store/slices/worktrees/create/create-terminal-group.ts
@@ -1,0 +1,85 @@
+import type { WorktreeSlice } from '../../worktree-helpers'
+import type { WorktreeSliceGet, WorktreeSliceSet } from '../listing/worktree-slice-types'
+import {
+  assertRuntimeEnvironmentCapability,
+  callRuntimeRpc,
+  getActiveRuntimeTarget
+} from '../../../../runtime/runtime-rpc-client'
+import { WORKTREE_TERMINAL_GROUP_RUNTIME_CAPABILITY } from '../../../../../../shared/protocol-version'
+import {
+  getProjectHostSetupForRepoHost,
+  repoHostId,
+  withRepoHostOwnership
+} from '../listing/worktree-host-ownership'
+import { settingsForRepoOwner } from '../listing/worktree-owner-settings'
+
+export function createCreateTerminalGroup(
+  set: WorktreeSliceSet,
+  get: WorktreeSliceGet
+): WorktreeSlice['createTerminalGroup'] {
+  return async ({ repoId, name, telemetrySource }) => {
+    // Why no branch/base/setup args: a terminal group runs in the project's existing checkout, so
+    // none of the git create path applies — and none of its name-collision retries do either.
+    const createArgs = {
+      repoId,
+      name,
+      terminalGroup: true,
+      ...(telemetrySource ? { telemetrySource } : {}),
+      // Why: manual sort is user-authored order; stamp new workspaces at the top rather than relying on sortOrder fallback.
+      ...(get().sortBy === 'manual' ? { manualOrder: Date.now() } : {})
+    }
+    try {
+      const target = getActiveRuntimeTarget(settingsForRepoOwner(get(), repoId))
+      if (target.kind === 'environment') {
+        // Why: a host that drops `terminalGroup` would create a real worktree and branch instead.
+        await assertRuntimeEnvironmentCapability(
+          target.environmentId,
+          WORKTREE_TERMINAL_GROUP_RUNTIME_CAPABILITY,
+          'Update the remote runtime to create terminal groups'
+        )
+      }
+      const result =
+        target.kind === 'local'
+          ? await window.api.worktrees.create(createArgs)
+          : await callRuntimeRpc<Awaited<ReturnType<typeof window.api.worktrees.create>>>(
+              target,
+              'worktree.create',
+              {
+                repo: repoId,
+                name,
+                terminalGroup: true,
+                ...(telemetrySource ? { telemetrySource } : {}),
+                ...(createArgs.manualOrder !== undefined
+                  ? { manualOrder: createArgs.manualOrder }
+                  : {})
+              }
+            )
+      // Why: worktrees.onChanged can add this workspace before this callback runs; appending blindly would duplicate it.
+      set((s) => {
+        const hostId = repoHostId(s, repoId)
+        const created = withRepoHostOwnership(
+          result.worktree,
+          hostId,
+          getProjectHostSetupForRepoHost(s, repoId, hostId)
+        )
+        const current = s.worktreesByRepo[repoId] ?? []
+        const alreadyPresent = current.some((worktree) => worktree.id === created.id)
+        return {
+          worktreesByRepo: {
+            ...s.worktreesByRepo,
+            [repoId]: alreadyPresent
+              ? current.map((worktree) =>
+                  worktree.id === created.id ? { ...worktree, ...created } : worktree
+                )
+              : [...current, created]
+          },
+          sortEpoch: s.sortEpoch + 1
+        }
+      })
+      return result.worktree
+    } catch (err) {
+      console.error('Failed to create terminal group:', err)
+      throw err
+    }
+  }
+}

--- a/src/renderer/src/store/slices/worktrees/create/terminal-group-args.ts
+++ b/src/renderer/src/store/slices/worktrees/create/terminal-group-args.ts
@@ -1,0 +1,7 @@
+import type { WorkspaceSource } from '../../../../../../shared/workspace-source'
+
+export type TerminalGroupCreateArgs = {
+  repoId: string
+  name: string
+  telemetrySource?: WorkspaceSource
+}

--- a/src/shared/protocol-version.ts
+++ b/src/shared/protocol-version.ts
@@ -55,6 +55,9 @@ export const ORCHESTRATION_CONTRACT_VERSION = 1 as const
 export const ORCHESTRATION_CONTRACT_RUNTIME_CAPABILITY = 'orchestration.contract.v1' as const
 export const FOLDER_WORKSPACE_PATH_STATUS_RUNTIME_CAPABILITY =
   'folder-workspace.path-status.v1' as const
+// Why a capability rather than a plain optional field: a host that drops `terminalGroup` would
+// silently create a real worktree and branch instead, so the client must not send it blind.
+export const WORKTREE_TERMINAL_GROUP_RUNTIME_CAPABILITY = 'worktree.terminal-group.v1' as const
 export const LINEAR_ISSUE_ATTRIBUTE_FILTER_RUNTIME_CAPABILITY =
   'linear.issue-attribute-filter.v1' as const
 // Why: signals the host exposes the Agent Session History scanner over RPC
@@ -131,6 +134,7 @@ export const RUNTIME_CAPABILITIES = [
   WORKSPACE_RUN_CONTEXT_RUNTIME_CAPABILITY,
   WORKTREE_LINKED_WORK_ITEM_CONTEXT_RUNTIME_CAPABILITY,
   FOLDER_WORKSPACE_PATH_STATUS_RUNTIME_CAPABILITY,
+  WORKTREE_TERMINAL_GROUP_RUNTIME_CAPABILITY,
   LINEAR_ISSUE_ATTRIBUTE_FILTER_RUNTIME_CAPABILITY,
   AI_VAULT_RUNTIME_CAPABILITY,
   AI_VAULT_SESSION_TITLES_RUNTIME_CAPABILITY,

--- a/src/shared/workspace-instance-worktree.test.ts
+++ b/src/shared/workspace-instance-worktree.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildWorkspaceInstanceWorktreeId,
+  getProjectCheckoutWorktreeId,
+  getWorkspaceInstanceIdentity,
+  isTerminalGroupWorktreeId,
+  isWorkspaceInstanceWorktreeIdForRepo,
+  sharesProjectCheckout
+} from './workspace-instance-worktree'
+import { isWorkspaceInstanceWorktreeId } from './worktree/id'
+
+const UUID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const gitRepo = { id: 'repo-1', path: '/workspace/repo', kind: 'git' as const }
+const folderRepo = { id: 'repo-2', path: '/workspace/folder', kind: 'folder' as const }
+
+describe('workspace instance ids', () => {
+  it('builds an instance id under the project checkout row', () => {
+    expect(getProjectCheckoutWorktreeId(gitRepo)).toBe('repo-1::/workspace/repo')
+    expect(buildWorkspaceInstanceWorktreeId(gitRepo, UUID)).toBe(
+      `repo-1::/workspace/repo::workspace:${UUID}`
+    )
+  })
+
+  it('recognizes only the uuid-suffixed shape', () => {
+    expect(isWorkspaceInstanceWorktreeId(buildWorkspaceInstanceWorktreeId(gitRepo, UUID))).toBe(
+      true
+    )
+    expect(isWorkspaceInstanceWorktreeId('repo-1::/workspace/repo')).toBe(false)
+    // A directory literally named `::workspace:not-a-uuid` must not read as an instance.
+    expect(isWorkspaceInstanceWorktreeId('repo-1::/workspace/repo::workspace:nope')).toBe(false)
+  })
+
+  it('scopes instance ids to the owning repo and checkout path', () => {
+    const id = buildWorkspaceInstanceWorktreeId(gitRepo, UUID)
+    expect(isWorkspaceInstanceWorktreeIdForRepo(gitRepo, id)).toBe(true)
+    expect(isWorkspaceInstanceWorktreeIdForRepo(folderRepo, id)).toBe(false)
+    expect(
+      isWorkspaceInstanceWorktreeIdForRepo({ id: 'repo-1', path: '/workspace/other' }, id)
+    ).toBe(false)
+  })
+
+  it('extracts the instance identity, or null for a foreign id', () => {
+    expect(
+      getWorkspaceInstanceIdentity(gitRepo, buildWorkspaceInstanceWorktreeId(gitRepo, UUID))
+    ).toBe(UUID)
+    expect(getWorkspaceInstanceIdentity(gitRepo, 'repo-1::/workspace/repo')).toBeNull()
+  })
+})
+
+describe('sharesProjectCheckout', () => {
+  it('covers every folder-project workspace', () => {
+    expect(sharesProjectCheckout(folderRepo, getProjectCheckoutWorktreeId(folderRepo))).toBe(true)
+    expect(
+      sharesProjectCheckout(folderRepo, buildWorkspaceInstanceWorktreeId(folderRepo, UUID))
+    ).toBe(true)
+  })
+
+  it('covers a git project only for its terminal groups', () => {
+    expect(sharesProjectCheckout(gitRepo, getProjectCheckoutWorktreeId(gitRepo))).toBe(false)
+    expect(sharesProjectCheckout(gitRepo, buildWorkspaceInstanceWorktreeId(gitRepo, UUID))).toBe(
+      true
+    )
+  })
+
+  it('falls back to the id shape when the repo row is unknown', () => {
+    expect(sharesProjectCheckout(null, buildWorkspaceInstanceWorktreeId(gitRepo, UUID))).toBe(true)
+    expect(sharesProjectCheckout(null, 'repo-1::/workspace/repo')).toBe(false)
+    expect(sharesProjectCheckout(null, null)).toBe(false)
+  })
+})
+
+describe('isTerminalGroupWorktreeId', () => {
+  it('names the git-project case only — a folder project calls the same shape a workspace', () => {
+    const gitInstance = buildWorkspaceInstanceWorktreeId(gitRepo, UUID)
+    const folderInstance = buildWorkspaceInstanceWorktreeId(folderRepo, UUID)
+    expect(isTerminalGroupWorktreeId(gitRepo, gitInstance)).toBe(true)
+    expect(isTerminalGroupWorktreeId(folderRepo, folderInstance)).toBe(false)
+    expect(isTerminalGroupWorktreeId(gitRepo, getProjectCheckoutWorktreeId(gitRepo))).toBe(false)
+  })
+})

--- a/src/shared/workspace-instance-worktree.ts
+++ b/src/shared/workspace-instance-worktree.ts
@@ -1,0 +1,75 @@
+import type { Repo } from './repo-types'
+import { isFolderRepo } from './repo-kind'
+import {
+  FOLDER_WORKSPACE_INSTANCE_SEPARATOR,
+  WORKTREE_ID_SEPARATOR,
+  isWorkspaceInstanceWorktreeId
+} from './worktree/id'
+
+/**
+ * A *workspace instance* is a card that shares its project's existing checkout instead of owning
+ * one. Folder projects have always worked this way (every card points at the same directory); a
+ * git project gets them as **terminal groups** — extra terminal/agent cards on the main checkout,
+ * with no worktree and no branch of their own.
+ *
+ * Both wear the same id shape, so one predicate answers "does this card own a checkout?" for the
+ * git surfaces (source control, PRs, branch actions) that must degrade for either.
+ */
+export type WorkspaceInstanceRepo = Pick<Repo, 'id' | 'path'>
+
+/** Row that owns the project's checkout: the folder root, or a git project's main worktree. */
+export function getProjectCheckoutWorktreeId(repo: WorkspaceInstanceRepo): string {
+  return `${repo.id}${WORKTREE_ID_SEPARATOR}${repo.path}`
+}
+
+export function buildWorkspaceInstanceWorktreeId(
+  repo: WorkspaceInstanceRepo,
+  instanceId: string
+): string {
+  return `${getProjectCheckoutWorktreeId(repo)}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}${instanceId}`
+}
+
+export function isWorkspaceInstanceWorktreeIdForRepo(
+  repo: WorkspaceInstanceRepo,
+  worktreeId: string
+): boolean {
+  return (
+    worktreeId.startsWith(
+      `${getProjectCheckoutWorktreeId(repo)}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}`
+    ) && isWorkspaceInstanceWorktreeId(worktreeId)
+  )
+}
+
+export function getWorkspaceInstanceIdentity(
+  repo: WorkspaceInstanceRepo,
+  worktreeId: string
+): string | null {
+  if (!isWorkspaceInstanceWorktreeIdForRepo(repo, worktreeId)) {
+    return null
+  }
+  return worktreeId.slice(
+    `${getProjectCheckoutWorktreeId(repo)}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}`.length
+  )
+}
+
+/** A terminal group is a workspace instance on a git project — folder projects call theirs workspaces. */
+export function isTerminalGroupWorktreeId(
+  repo: Pick<Repo, 'kind'> | null | undefined,
+  worktreeId: string
+): boolean {
+  return Boolean(repo) && !isFolderRepo(repo!) && isWorkspaceInstanceWorktreeId(worktreeId)
+}
+
+/**
+ * True when the workspace has no checkout of its own, so every git surface must degrade: the whole
+ * of a folder project, and a git project's terminal groups.
+ */
+export function sharesProjectCheckout(
+  repo: Pick<Repo, 'kind'> | null | undefined,
+  worktreeId: string | null | undefined
+): boolean {
+  if (repo && isFolderRepo(repo)) {
+    return true
+  }
+  return typeof worktreeId === 'string' && isWorkspaceInstanceWorktreeId(worktreeId)
+}

--- a/src/shared/worktree/create-types.ts
+++ b/src/shared/worktree/create-types.ts
@@ -77,6 +77,9 @@ export type CreateWorktreeArgs = {
   branchNameOverride?: string
   setupDecision?: SetupDecision
   sparseCheckout?: CreateSparseCheckoutRequest
+  /** Create a terminal group on the project's existing checkout instead of a new worktree.
+   *  Ignored by folder projects, whose every workspace already works that way. */
+  terminalGroup?: boolean
   linkedIssue?: number
   linkedPR?: number
   linkedLinearIssue?: string

--- a/src/shared/worktree/id.ts
+++ b/src/shared/worktree/id.ts
@@ -12,6 +12,11 @@ const FOLDER_WORKSPACE_INSTANCE_SUFFIX = new RegExp(
   `${FOLDER_WORKSPACE_INSTANCE_SEPARATOR.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[0-9a-f-]{36}$`
 )
 
+/** `<repoId>::<path>::workspace:<uuid>` — a workspace that shares another row's checkout. */
+export function isWorkspaceInstanceWorktreeId(worktreeId: string): boolean {
+  return FOLDER_WORKSPACE_INSTANCE_SUFFIX.test(worktreeId)
+}
+
 export function getRepoIdFromWorktreeId(worktreeId: string): string {
   const separatorIdx = worktreeId.indexOf(WORKTREE_ID_SEPARATOR)
   return separatorIdx === -1 ? worktreeId : worktreeId.slice(0, separatorIdx)


### PR DESCRIPTION
Lets a git project have N terminal/agent cards that share its existing checkout, without creating a worktree. Folder projects have always worked this way (every workspace points at the same directory); this brings the same capability to git projects as **terminal groups** — e.g. a "servers" card with dev processes, a "research" card with an agent answering questions about the code, a "scripts" card — none of which need branch isolation.

## How it works

- A terminal group is a *workspace instance*: a card whose id suffixes the project checkout (`<repoId>::<path>::workspace:<uuid>`), reusing the identity scheme folder workspaces already ship. `sharesProjectCheckout()` in `shared/workspace-instance-worktree.ts` is the one predicate every surface asks.
- **Create** from the project's "..." menu ("New terminal group": name + optional agent) or `orca worktree create --terminal-group`. The runtime skips the whole git create path — no branch, no `git worktree add`, no setup-hook name-collision retries.
- **Every git surface degrades explicitly** on these cards: source control, checks and PR lookups hide; the delete dialog promises no disk removal and routes around `git worktree remove` (deleting one drops the Orca record only); workspace cleanup never lists one because deleting it frees nothing.
- Restart-safe: instances are rebuilt from persisted meta on load and in `worktree.ps` / mobile inventory (`git worktree list` cannot describe them, so the runtime appends them from meta — same as folder workspaces).

## Wire compatibility

`terminalGroup` is a new optional field on `worktree.create`. A remote host that predates it would silently create a real worktree and branch, so the renderer gates the RPC behind a runtime capability and asks the user to update the host instead (`WORKTREE_TERMINAL_GROUP_RUNTIME_CAPABILITY`).

## Verification

- Tests at each layer: the shared instance-id predicate, IPC create/list/detected-purge/remove (proving `git worktree add`/`remove` are never called and removal only drops meta), the dialog + submit flow via RTL, and runtime row resolution.
- Full typecheck (node/cli/web), lint, and localization checks green; strings localized in en/es/ja/ko/zh.
- Rebased onto current `main` (post `shared/types` barrel removal and the worktrees/WorktreeList/persistence splits) — the feature lives in the new module layout: the slice action is `store/slices/worktrees/create/create-terminal-group.ts`, the menu item in `worktree-list/rows/repo-header-project-actions.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)