### PR TITLE
fix(source-control): recover commit ref badges on Git before 2.43

### DIFF
--- a/docs/reference/git-compatibility.md
+++ b/docs/reference/git-compatibility.md
@@ -40,6 +40,7 @@ authority.
 | `for-each-ref-exclude`  | Exclude remote HEAD before the output limit       | Request extra refs, then filter remote HEAD in Orca                                     |
 | `merge-tree-write-tree` | Derive real-merge conflicts and no-op tree proofs | Omit the conflict summary and keep conservative branch cleanup behavior before Git 2.38 |
 | `merge-tree-merge-base` | Supply the already-resolved merge base            | Use the older two-commit `merge-tree --write-tree` form                                 |
+| `log-decorate-placeholder` | `%(decorate:…)` commit decorations separated by a control character | Probe the decoration field for the verbatim placeholder Git before 2.43 prints, then re-read the log with `%D` and cache the capability as unsupported |
 
 ## Why Not `simple-git`
 

--- a/src/main/git/history.test.ts
+++ b/src/main/git/history.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { clearGitCapabilityStateForTests } from './git-capability-state'
+import { getHistory } from './history'
+import { gitExecFileAsync } from './runner'
+
+vi.mock('./runner', () => ({
+  gitExecFileAsync: vi.fn()
+}))
+
+const gitExecFileAsyncMock = vi.mocked(gitExecFileAsync)
+const HEAD_OID = 'a'.repeat(40)
+const ECHOED_PLACEHOLDER = '%(decorate:prefix=,suffix=,separator=\x1f)'
+
+function logFormatsFromCalls(): string[] {
+  return gitExecFileAsyncMock.mock.calls
+    .filter(([args]) => args[0] === 'log')
+    .map(([args]) => args.find((arg) => arg.startsWith('--format=')) ?? '')
+}
+
+describe('getHistory', () => {
+  beforeEach(() => {
+    gitExecFileAsyncMock.mockReset()
+    clearGitCapabilityStateForTests()
+    // Why: emulate Git before 2.43, which echoes the decorate placeholder and exits zero.
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      const command = args[0]
+      if (command === 'rev-parse' && args.includes('--symbolic-full-name')) {
+        return { stdout: 'refs/heads/feature\n', stderr: '' }
+      }
+      if (command === 'rev-parse') {
+        return { stdout: `${HEAD_OID}\n`, stderr: '' }
+      }
+      if (command === 'symbolic-ref') {
+        return { stdout: 'feature\n', stderr: '' }
+      }
+      if (command === 'for-each-ref') {
+        return { stdout: '\n', stderr: '' }
+      }
+      if (command === 'log') {
+        const format = args.find((arg) => arg.startsWith('--format=')) ?? ''
+        const decorations = format.includes('%(decorate:')
+          ? ECHOED_PLACEHOLDER
+          : 'HEAD -> refs/heads/feature'
+        const record = [
+          HEAD_OID,
+          'Ada',
+          'ada@example.com',
+          '1700000000',
+          '1700000000',
+          '',
+          decorations,
+          'feat: add graph'
+        ].join('\n')
+        return { stdout: `${record}\0`, stderr: '' }
+      }
+      throw new Error(`unexpected git command: ${args.join(' ')}`)
+    })
+  })
+
+  it('recovers decorations through the local capability cache', async () => {
+    const result = await getHistory('/repo')
+
+    expect(result.items[0]?.references?.map((ref) => ref.name)).toEqual(['feature'])
+    expect(logFormatsFromCalls()).toHaveLength(2)
+  })
+
+  it('probes the placeholder once per execution host', async () => {
+    await getHistory('/repo')
+    gitExecFileAsyncMock.mockClear()
+
+    const result = await getHistory('/other-worktree')
+
+    expect(result.items[0]?.references?.map((ref) => ref.name)).toEqual(['feature'])
+    expect(logFormatsFromCalls()).toHaveLength(1)
+    expect(logFormatsFromCalls()[0]).not.toContain('%(decorate:')
+  })
+})

--- a/src/main/git/history.ts
+++ b/src/main/git/history.ts
@@ -1,5 +1,6 @@
 import type { GitHistoryOptions, GitHistoryResult } from '../../shared/git-history'
 import { loadGitHistoryFromExecutor } from '../../shared/git-history'
+import { withLocalGitCapabilityCacheForExecution } from './git-capability-state'
 import type { GitRuntimeOptions } from './git-runtime-options'
 import { gitOptionsForWorktree } from './git-runtime-options'
 import { gitExecFileAsync } from './runner'
@@ -8,9 +9,14 @@ export async function getHistory(
   worktreePath: string,
   options: GitHistoryOptions & GitRuntimeOptions = {}
 ): Promise<GitHistoryResult> {
-  return loadGitHistoryFromExecutor(
-    (args, cwd) => gitExecFileAsync(args, gitOptionsForWorktree(cwd, options)),
-    worktreePath,
-    options
+  return withLocalGitCapabilityCacheForExecution(
+    { cwd: worktreePath, wslDistro: options.wslDistro, signal: options.signal },
+    (capabilities) =>
+      loadGitHistoryFromExecutor(
+        (args, cwd) => gitExecFileAsync(args, gitOptionsForWorktree(cwd, options)),
+        worktreePath,
+        options,
+        capabilities
+      )
   )
 }

--- a/src/relay/git-handler.test.ts
+++ b/src/relay/git-handler.test.ts
@@ -299,8 +299,8 @@ describe('GitHandler', () => {
         worktreePath: tmpDir,
         limit: 10
       })) as {
-        items: { subject: string; displayId?: string }[]
-        currentRef?: { category?: string; revision?: string }
+        items: { subject: string; displayId?: string; references?: { name: string }[] }[]
+        currentRef?: { name?: string; category?: string; revision?: string }
         hasMore: boolean
         limit: number
       }
@@ -311,6 +311,8 @@ describe('GitHandler', () => {
       expect(result.items[0]?.displayId).toHaveLength(7)
       expect(result.hasMore).toBe(false)
       expect(result.limit).toBe(10)
+      // Why: decorations come from a post-2.25 log placeholder, so assert the refs the fallback recovers.
+      expect(result.items[0]?.references?.map((ref) => ref.name)).toContain(result.currentRef?.name)
     })
   })
 

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -424,10 +424,15 @@ export class GitHandler {
 
   private async history(params: Record<string, unknown>) {
     const worktreePath = params.worktreePath as string
-    return loadGitHistoryFromExecutor(this.git.bind(this), worktreePath, {
-      limit: typeof params.limit === 'number' ? params.limit : undefined,
-      baseRef: typeof params.baseRef === 'string' ? params.baseRef : null
-    })
+    return loadGitHistoryFromExecutor(
+      this.git.bind(this),
+      worktreePath,
+      {
+        limit: typeof params.limit === 'number' ? params.limit : undefined,
+        baseRef: typeof params.baseRef === 'string' ? params.baseRef : null
+      },
+      this.gitCapabilities
+    )
   }
 
   private async getDiff(params: Record<string, unknown>, context?: RequestContext) {

--- a/src/shared/git-binary-compatibility.test.ts
+++ b/src/shared/git-binary-compatibility.test.ts
@@ -15,6 +15,13 @@ import {
 } from './git-worktree-command-capabilities'
 import { gitCredentialPromptGuardEnv } from './git-credential-prompt-env'
 import {
+  GIT_HISTORY_COMMIT_FORMAT,
+  GIT_HISTORY_FALLBACK_COMMIT_FORMAT,
+  parseGitHistoryLog,
+  readGitHistoryDecorations
+} from './git-history-log-parser'
+import { hasUnsupportedLogDecorateEcho } from './git-log-decorate-capability'
+import {
   githubPullRequestHeadLocalRef,
   gitlabMergeRequestHeadLocalRef,
   reviewHeadRemoteRefComponent
@@ -174,6 +181,38 @@ describeBinaryCompatibility('real Git binary compatibility', () => {
         isUnsupportedMergeTreeMergeBaseError
       )
       await expect(runGit([...legacyArgs, head, head])).resolves.toBeDefined()
+    }
+  })
+
+  it('recovers commit decorations at the Git 2.43 placeholder boundary', async () => {
+    const logArgs = (format: string): string[] => [
+      'log',
+      `--format=${format}`,
+      '-z',
+      '--topo-order',
+      '--decorate=full',
+      '-n1'
+    ]
+
+    await runGit(['branch', '-f', 'compat-decorate'])
+    try {
+      const preferred = await runGit(logArgs(GIT_HISTORY_COMMIT_FORMAT))
+      expect(hasUnsupportedLogDecorateEcho(readGitHistoryDecorations(preferred.stdout))).toBe(
+        !supports(2, 43)
+      )
+      if (supports(2, 43)) {
+        expect(
+          parseGitHistoryLog(preferred.stdout)[0]?.references?.map((ref) => ref.name)
+        ).toContain('compat-decorate')
+      }
+
+      const fallback = await runGit(logArgs(GIT_HISTORY_FALLBACK_COMMIT_FORMAT))
+      expect(hasUnsupportedLogDecorateEcho(readGitHistoryDecorations(fallback.stdout))).toBe(false)
+      expect(parseGitHistoryLog(fallback.stdout)[0]?.references?.map((ref) => ref.name)).toContain(
+        'compat-decorate'
+      )
+    } finally {
+      await runGit(['branch', '-D', 'compat-decorate'])
     }
   })
 

--- a/src/shared/git-capability-cache.ts
+++ b/src/shared/git-capability-cache.ts
@@ -4,6 +4,7 @@ export const GIT_CAPABILITY_RETRY_INTERVAL_MS = 30 * 60_000
 
 export type GitCapability =
   | 'for-each-ref-exclude'
+  | 'log-decorate-placeholder'
   | 'merge-tree-merge-base'
   | 'merge-tree-write-tree'
   | 'rev-parse-path-format'

--- a/src/shared/git-history-log-parser.ts
+++ b/src/shared/git-history-log-parser.ts
@@ -1,10 +1,13 @@
 import type { GitHistoryItem, GitHistoryItemRef } from './git-history-types'
+import { GIT_LOG_DECORATE_PLACEHOLDER } from './git-log-decorate-capability'
 import { iterateNulDelimitedFields } from './nul-delimited-fields'
 
 const GIT_HISTORY_DECORATION_SEPARATOR = '\x1f'
 
-export const GIT_HISTORY_COMMIT_FORMAT =
-  '%H%n%aN%n%aE%n%at%n%ct%n%P%n%(decorate:prefix=,suffix=,separator=%x1f)%n%B'
+export const GIT_HISTORY_COMMIT_FORMAT = `%H%n%aN%n%aE%n%at%n%ct%n%P%n${GIT_LOG_DECORATE_PLACEHOLDER}%n%B`
+
+// Why: %D predates the placeholder but joins refs with commas, which ref names may contain.
+export const GIT_HISTORY_FALLBACK_COMMIT_FORMAT = '%H%n%aN%n%aE%n%at%n%ct%n%P%n%D%n%B'
 
 export function shortGitHash(hash: string): string {
   return hash.slice(0, 7)
@@ -23,9 +26,11 @@ function parseGitDecorationRefs(raw: string, revision: string): GitHistoryItemRe
   const refs: GitHistoryItemRef[] = []
   // Why: Git permits commas in ref names, so Orca's git log format uses a
   // control-character separator that Git ref names cannot contain.
+  // Why: %D joins refs with ", " and Git rejects spaces in ref names, so a comma
+  // inside a name cannot split it apart.
   const parts = raw.includes(GIT_HISTORY_DECORATION_SEPARATOR)
     ? raw.split(GIT_HISTORY_DECORATION_SEPARATOR)
-    : raw.split(',')
+    : raw.split(', ')
 
   for (const part of parts) {
     const ref = part.trim()
@@ -97,20 +102,29 @@ export function compareGitHistoryItemRefsByCategory(
   return categoryOrder || ref1.name.localeCompare(ref2.name)
 }
 
-export function parseGitHistoryLog(stdout: string): GitHistoryItem[] {
-  const items: GitHistoryItem[] = []
+function* iterateGitHistoryRecords(stdout: string): Generator<string[]> {
   for (const rawRecord of iterateNulDelimitedFields(stdout)) {
     const record = rawRecord.replace(/^\n+/, '')
     if (!record.trim()) {
       continue
     }
-
     const lines = record.split('\n')
-    const hash = lines[0]?.trim() ?? ''
-    if (!/^[0-9a-fA-F]{40,64}$/.test(hash)) {
+    if (!/^[0-9a-fA-F]{40,64}$/.test(lines[0]?.trim() ?? '')) {
       continue
     }
+    yield lines
+  }
+}
 
+// Why: the capability probe must read decorations only; commit messages are attacker text.
+export function readGitHistoryDecorations(stdout: string): string[] {
+  return [...iterateGitHistoryRecords(stdout)].map((lines) => lines[6] ?? '')
+}
+
+export function parseGitHistoryLog(stdout: string): GitHistoryItem[] {
+  const items: GitHistoryItem[] = []
+  for (const lines of iterateGitHistoryRecords(stdout)) {
+    const hash = lines[0]?.trim() ?? ''
     const authorName = lines[1] ?? ''
     const authorEmail = lines[2] ?? ''
     const authorDateSeconds = Number.parseInt(lines[3] ?? '', 10)

--- a/src/shared/git-history.test.ts
+++ b/src/shared/git-history.test.ts
@@ -5,6 +5,7 @@ import {
   loadGitHistoryFromExecutor,
   parseGitHistoryLog
 } from './git-history'
+import { GitCapabilityCache } from './git-capability-cache'
 import { GIT_HISTORY_COMMIT_FORMAT } from './git-history-log-parser'
 
 const HEAD_OID = 'a'.repeat(40)
@@ -114,6 +115,21 @@ describe('git history parsing', () => {
       ['refs/heads/feature', 'feature', 'branches'],
       ['refs/remotes/origin/feature', 'origin/feature', 'remote branches'],
       ['refs/tags/v1.0.0', 'v1.0.0', 'tags']
+    ])
+  })
+
+  it('keeps a comma inside a ref name whole in the %D fallback format', () => {
+    const stdout = logRecord({
+      hash: HEAD_OID,
+      decorations: 'HEAD -> refs/heads/a,refs/remotes/origin/release, refs/heads/main',
+      message: 'initial'
+    })
+
+    const [item] = parseGitHistoryLog(stdout)
+
+    expect(item?.references?.map((ref) => [ref.id, ref.category])).toEqual([
+      ['refs/heads/a,refs/remotes/origin/release', 'branches'],
+      ['refs/heads/main', 'branches']
     ])
   })
 
@@ -323,5 +339,161 @@ describe('symbolic full-name resolution', () => {
     const result = await loadGitHistoryFromExecutor(executor, '/repo', { baseRef: 'some-rev' })
 
     expect(result.baseRef).toMatchObject({ category: 'commits' })
+  })
+})
+
+describe('git log decorate placeholder compatibility', () => {
+  const UNEXPANDED_DECORATE_ECHO = `%(decorate:prefix=,suffix=,separator=${DECORATION_SEPARATOR})`
+
+  function createDecorateExecutor(supportsPlaceholder: boolean): {
+    executor: GitHistoryExecutor
+    logFormats: string[]
+  } {
+    const logFormats: string[] = []
+    const executor = vi.fn(async (args: string[]) => {
+      const command = args[0]
+      if (command === 'rev-parse' && args.includes('--symbolic-full-name')) {
+        return { stdout: 'refs/heads/feature\n' }
+      }
+      if (command === 'rev-parse') {
+        return { stdout: `${HEAD_OID}\n` }
+      }
+      if (command === 'symbolic-ref') {
+        return { stdout: 'feature\n' }
+      }
+      if (command === 'for-each-ref') {
+        return { stdout: '\n' }
+      }
+      if (command === 'log') {
+        const format = args.find((arg) => arg.startsWith('--format='))?.slice('--format='.length)
+        logFormats.push(format ?? '')
+        const usesPlaceholder = format?.includes('%(decorate:') ?? false
+        return {
+          stdout: logRecord({
+            hash: HEAD_OID,
+            decorations:
+              usesPlaceholder && !supportsPlaceholder
+                ? UNEXPANDED_DECORATE_ECHO
+                : 'HEAD -> refs/heads/feature',
+            message: 'feat: add graph'
+          })
+        }
+      }
+      throw new Error(`unexpected git command: ${args.join(' ')}`)
+    })
+    return { executor, logFormats }
+  }
+
+  it('recovers decorations when git echoes the unexpanded placeholder', async () => {
+    const { executor, logFormats } = createDecorateExecutor(false)
+
+    const result = await loadGitHistoryFromExecutor(executor, '/repo')
+
+    expect(result.items[0]?.references?.map((ref) => ref.name)).toEqual(['feature'])
+    expect(logFormats.some((format) => format.includes('%D'))).toBe(true)
+  })
+
+  it('keeps the placeholder format when git expands it', async () => {
+    const { executor, logFormats } = createDecorateExecutor(true)
+
+    const result = await loadGitHistoryFromExecutor(executor, '/repo')
+
+    expect(result.items[0]?.references?.map((ref) => ref.name)).toEqual(['feature'])
+    expect(logFormats).toHaveLength(1)
+    expect(logFormats[0]).toContain('%(decorate:')
+  })
+
+  it('does not downgrade modern git when a commit message carries the echoed placeholder', async () => {
+    const echoed = UNEXPANDED_DECORATE_ECHO
+    const logFormats: string[] = []
+    const executor = vi.fn(async (args: string[]) => {
+      const command = args[0]
+      if (command === 'rev-parse' && args.includes('--symbolic-full-name')) {
+        return { stdout: 'refs/heads/feature\n' }
+      }
+      if (command === 'rev-parse') {
+        return { stdout: `${HEAD_OID}\n` }
+      }
+      if (command === 'symbolic-ref') {
+        return { stdout: 'feature\n' }
+      }
+      if (command === 'for-each-ref') {
+        return { stdout: '\n' }
+      }
+      if (command === 'log') {
+        logFormats.push(args.find((arg) => arg.startsWith('--format=')) ?? '')
+        return {
+          stdout: logRecord({
+            hash: HEAD_OID,
+            decorations: 'HEAD -> refs/heads/feature',
+            message: `poison\n\n${echoed}`
+          })
+        }
+      }
+      throw new Error(`unexpected git command: ${args.join(' ')}`)
+    })
+
+    const capabilities = new GitCapabilityCache()
+    const result = await loadGitHistoryFromExecutor(executor, '/repo', {}, capabilities)
+
+    expect(logFormats).toHaveLength(1)
+    expect(logFormats[0]).toContain('%(decorate:')
+    expect(result.items[0]?.references?.map((ref) => ref.name)).toEqual(['feature'])
+  })
+
+  it('propagates a log failure instead of recording an unsupported placeholder', async () => {
+    const capabilities = new GitCapabilityCache()
+    const logFormats: string[] = []
+    const executor = vi.fn(async (args: string[]) => {
+      const command = args[0]
+      if (command === 'rev-parse' && args.includes('--symbolic-full-name')) {
+        return { stdout: 'refs/heads/feature\n' }
+      }
+      if (command === 'rev-parse') {
+        return { stdout: `${HEAD_OID}\n` }
+      }
+      if (command === 'symbolic-ref') {
+        return { stdout: 'feature\n' }
+      }
+      if (command === 'for-each-ref') {
+        return { stdout: '\n' }
+      }
+      if (command === 'log') {
+        logFormats.push(args.find((arg) => arg.startsWith('--format=')) ?? '')
+        throw new Error('fatal: unable to read the object store')
+      }
+      throw new Error(`unexpected git command: ${args.join(' ')}`)
+    })
+
+    await expect(loadGitHistoryFromExecutor(executor, '/repo', {}, capabilities)).rejects.toThrow(
+      'unable to read the object store'
+    )
+    expect(logFormats).toHaveLength(1)
+    expect(capabilities.shouldTry('log-decorate-placeholder')).toBe(true)
+  })
+
+  it('skips the placeholder probe on later loads for the same execution host', async () => {
+    const capabilities = new GitCapabilityCache()
+    const first = createDecorateExecutor(false)
+    await loadGitHistoryFromExecutor(first.executor, '/repo', {}, capabilities)
+
+    const second = createDecorateExecutor(false)
+    const result = await loadGitHistoryFromExecutor(second.executor, '/repo', {}, capabilities)
+
+    expect(result.items[0]?.references?.map((ref) => ref.name)).toEqual(['feature'])
+    expect(second.logFormats).toHaveLength(1)
+    expect(second.logFormats[0]).not.toContain('%(decorate:')
+  })
+
+  it('coalesces the placeholder probe across concurrent loads', async () => {
+    const capabilities = new GitCapabilityCache()
+    const { executor, logFormats } = createDecorateExecutor(false)
+
+    await Promise.all([
+      loadGitHistoryFromExecutor(executor, '/repo', {}, capabilities),
+      loadGitHistoryFromExecutor(executor, '/repo', {}, capabilities)
+    ])
+
+    expect(logFormats.filter((format) => format.includes('%(decorate:'))).toHaveLength(1)
   })
 })

--- a/src/shared/git-history.ts
+++ b/src/shared/git-history.ts
@@ -1,9 +1,13 @@
+import type { GitCapabilityCache } from './git-capability-cache'
 import {
   GIT_HISTORY_COMMIT_FORMAT,
+  GIT_HISTORY_FALLBACK_COMMIT_FORMAT,
   gitHistoryRefFromFullName,
   parseGitHistoryLog,
+  readGitHistoryDecorations,
   shortGitHash
 } from './git-history-log-parser'
+import { hasUnsupportedLogDecorateEcho } from './git-log-decorate-capability'
 import {
   GIT_HISTORY_DEFAULT_LIMIT,
   GIT_HISTORY_MAX_LIMIT,
@@ -164,10 +168,36 @@ async function resolveNamedRef(
   return revision ? gitHistoryRefFromFullName(fullName, normalized, revision) : undefined
 }
 
+async function readDecoratedLog(
+  readLog: (format: string) => Promise<string>,
+  capabilities?: GitCapabilityCache
+): Promise<string> {
+  const runPreferred = async (): Promise<string> => {
+    const stdout = await readLog(GIT_HISTORY_COMMIT_FORMAT)
+    if (!hasUnsupportedLogDecorateEcho(readGitHistoryDecorations(stdout))) {
+      return stdout
+    }
+    // Why: Git before 2.43 echoes the placeholder and exits zero, so refs need the %D format.
+    capabilities?.rememberUnsupported('log-decorate-placeholder')
+    return readLog(GIT_HISTORY_FALLBACK_COMMIT_FORMAT)
+  }
+  if (!capabilities) {
+    return runPreferred()
+  }
+  return capabilities.runWithFallback(
+    'log-decorate-placeholder',
+    runPreferred,
+    () => readLog(GIT_HISTORY_FALLBACK_COMMIT_FORMAT),
+    // Why: old Git echoes the placeholder and exits zero, so the echo above is the only rejection signal.
+    () => false
+  )
+}
+
 export async function loadGitHistoryFromExecutor(
   git: GitHistoryExecutor,
   cwd: string,
-  options: GitHistoryOptions = {}
+  options: GitHistoryOptions = {},
+  capabilities?: GitCapabilityCache
 ): Promise<GitHistoryResult> {
   const limit = clampHistoryLimit(options.limit)
   const headOid = await resolveCommit(git, cwd, 'HEAD')
@@ -206,17 +236,23 @@ export async function loadGitHistoryFromExecutor(
     }
   }
 
-  const { stdout } = await git(
-    [
-      'log',
-      `--format=${GIT_HISTORY_COMMIT_FORMAT}`,
-      '-z',
-      '--topo-order',
-      '--decorate=full',
-      `-n${limit + 1}`,
-      ...historyRevisions
-    ],
-    cwd
+  const stdout = await readDecoratedLog(
+    async (format) =>
+      (
+        await git(
+          [
+            'log',
+            `--format=${format}`,
+            '-z',
+            '--topo-order',
+            '--decorate=full',
+            `-n${limit + 1}`,
+            ...historyRevisions
+          ],
+          cwd
+        )
+      ).stdout,
+    capabilities
   )
   const parsed = parseGitHistoryLog(stdout)
   const items = parsed.slice(0, limit)

--- a/src/shared/git-log-decorate-capability.test.ts
+++ b/src/shared/git-log-decorate-capability.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import {
+  GIT_HISTORY_COMMIT_FORMAT,
+  GIT_HISTORY_FALLBACK_COMMIT_FORMAT,
+  parseGitHistoryLog,
+  readGitHistoryDecorations
+} from './git-history-log-parser'
+import {
+  GIT_LOG_DECORATE_PLACEHOLDER,
+  hasUnsupportedLogDecorateEcho
+} from './git-log-decorate-capability'
+
+const ECHOED_PLACEHOLDER = GIT_LOG_DECORATE_PLACEHOLDER.replace('%x1f', '\x1f')
+const DECORATION_FIELD_INDEX = 6
+
+function logRecord(decorations: string, message: string): string {
+  return `${['a'.repeat(40), 'Ada', 'ada@example.com', '1700000000', '1700000000', '', decorations, message].join('\n')}\0`
+}
+
+describe('git log decorate capability', () => {
+  it('places the decorations in the field the probe and parser read', () => {
+    expect(GIT_HISTORY_COMMIT_FORMAT.split('%n')[DECORATION_FIELD_INDEX]).toBe(
+      GIT_LOG_DECORATE_PLACEHOLDER
+    )
+    expect(GIT_HISTORY_FALLBACK_COMMIT_FORMAT.split('%n')[DECORATION_FIELD_INDEX]).toBe('%D')
+  })
+
+  it('reads the decoration field alone, never the commit message', () => {
+    const stdout = logRecord('HEAD -> refs/heads/main', `subject\n\n${ECHOED_PLACEHOLDER}\n`)
+
+    expect(readGitHistoryDecorations(stdout)).toEqual(['HEAD -> refs/heads/main'])
+  })
+
+  it('detects the placeholder old git prints instead of decorations', () => {
+    expect(
+      hasUnsupportedLogDecorateEcho(
+        readGitHistoryDecorations(logRecord(ECHOED_PLACEHOLDER, 'feat: x'))
+      )
+    ).toBe(true)
+    expect(hasUnsupportedLogDecorateEcho(['HEAD -> refs/heads/main', ECHOED_PLACEHOLDER])).toBe(
+      true
+    )
+  })
+
+  it('requires the decoration to be the placeholder rather than contain it', () => {
+    expect(hasUnsupportedLogDecorateEcho([`refs/heads/main${ECHOED_PLACEHOLDER}`])).toBe(false)
+    expect(hasUnsupportedLogDecorateEcho([`${ECHOED_PLACEHOLDER} refs/heads/main`])).toBe(false)
+  })
+
+  it('reports support for expanded, empty, and absent decorations', () => {
+    expect(hasUnsupportedLogDecorateEcho(['HEAD -> refs/heads/main'])).toBe(false)
+    expect(hasUnsupportedLogDecorateEcho([''])).toBe(false)
+    // Why: an empty repository yields no records, which must not read as unsupported.
+    expect(hasUnsupportedLogDecorateEcho([])).toBe(false)
+  })
+
+  it('ignores a commit message that reproduces the echoed placeholder', () => {
+    // Why: Git rejects NUL in messages but not the 0x1f the echo carries, so bodies are attacker text.
+    const stdout = logRecord('HEAD -> refs/heads/main', `poison\n\n${ECHOED_PLACEHOLDER}\n`)
+
+    expect(hasUnsupportedLogDecorateEcho(readGitHistoryDecorations(stdout))).toBe(false)
+    expect(parseGitHistoryLog(stdout)[0]?.message).toContain(ECHOED_PLACEHOLDER)
+  })
+})

--- a/src/shared/git-log-decorate-capability.ts
+++ b/src/shared/git-log-decorate-capability.ts
@@ -1,0 +1,8 @@
+// Why: %(decorate) arrived in Git 2.43; older binaries print the placeholder verbatim and exit zero.
+export const GIT_LOG_DECORATE_PLACEHOLDER = '%(decorate:prefix=,suffix=,separator=%x1f)'
+
+const UNEXPANDED_DECORATE_ECHO = GIT_LOG_DECORATE_PLACEHOLDER.replace('%x1f', '\x1f')
+
+export function hasUnsupportedLogDecorateEcho(decorations: readonly string[]): boolean {
+  return decorations.some((decoration) => decoration === UNEXPANDED_DECORATE_ECHO)
+}


### PR DESCRIPTION
## ELI5

Orca asks Git for each commit's branch/tag labels using a format placeholder that only exists in Git 2.43 and newer. On older Git the request comes back as the literal placeholder text instead of labels, so the Commits panel shows no branch pills at all. This asks the old way when the new way is not understood.

## What Changed

- Added `src/shared/git-log-decorate-capability.ts`: the `%(decorate:…)` placeholder is now defined once and re-used by the commit format, plus a narrow probe for the verbatim echo old Git prints.
- Added `GIT_HISTORY_FALLBACK_COMMIT_FORMAT` (`%D`) and a new `log-decorate-placeholder` capability.
- `parseGitDecorationRefs` now splits `%D` output on `", "` instead of `","`. Ref names cannot contain spaces, so this keeps a comma inside a name whole instead of turning it into extra pills.
- `loadGitHistoryFromExecutor` now re-reads the log with `%D` when it sees the echo, and records the result in `GitCapabilityCache` so later loads on the same execution host skip the probe.
- Wired the cache at both execution sites: `getHistory` (native/WSL) via `withLocalGitCapabilityCacheForExecution`, and the relay handler via its existing `gitCapabilities`. SSH forwards `git.history` to the relay, so it inherits the remote host's cache.
- Extended the real-binary compatibility contract with the Git 2.43 boundary, and documented the capability in `docs/reference/git-compatibility.md`.

## Why

`%(decorate:prefix=,suffix=,separator=%x1f)` was introduced in Git 2.43.0. Older Git prints it verbatim **and exits zero**, so nothing throws; `parseGitDecorationRefs` then drops the text and every commit ends up with `references: []`. Per-commit refs have no other source, so all branch, remote, and tag pills disappear while the graph still renders.

`docs/reference/git-compatibility.md` sets Git 2.25 as the baseline and requires post-baseline features to degrade safely behind `GitCapabilityCache`. This was the only such feature in the history path with no fallback and no capability entry, so 2.25.5 and 2.38.1 — two of the three versions in the PR CI matrix — silently lost every ref badge.

`%D` returns the same decorations on every supported version and the parser already had a comma-splitting path for it. It stays the fallback rather than the default because `%D` cannot represent ref names containing commas, which is why the placeholder was chosen in the first place.

## Linked Issue

Fixes #15507

## Visual Proof

Captured with the headless Electron E2E fixture on Git 2.41.0, in a worktree whose HEAD carries the branch `feat/decorate-badges` and the tag `v1.4.178`. Same repository, same viewport; the before shot runs with the probe disabled.

| Before | After |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/9eb3036e-4940-4508-8044-b272c1adec8d) | ![after](https://github.com/user-attachments/assets/accb5b64-c783-43a2-8a8a-c3baabf02a6f) |

Before, both commit rows render the subject alone with no ref pills. After, HEAD carries `feat/decorate-badges` and `v1.4.178` and the base commit carries `main`.

The lane color corrects itself too: `getLabelColorIdentifier` reads the current-branch color out of `references`, which was empty before.

## Testing

Verified on macOS with the Xcode Command Line Tools Git (2.41.0), which reproduces the bug directly, plus containerized Git binaries for both sides of the boundary.

- `src/shared/git-history.test.ts` — recovery through the fallback format, the placeholder path staying untouched on new Git, the cached later load skipping the probe, and probe coalescing across concurrent loads. All four fail on `main`.
- `src/shared/git-log-decorate-capability.test.ts` — format/probe share one placeholder definition, echo detection, and no false positive from a commit message that merely mentions the placeholder.
- `src/shared/git-binary-compatibility.test.ts` — new case asserting the echo appears exactly when the binary predates 2.43 and that `%D` recovers the refs. Ran the PR CI matrix locally against `alpine/git:edge-2.38.1` and `alpine/git:v2.49.1`; both green.
- `src/main/git/history.test.ts` (new) — the local wiring probes the placeholder once per execution host and serves later worktrees from the cache.
- `src/relay/git-handler.test.ts` — the relay `git.history` case now asserts the recovered refs instead of subjects alone.
- Measured `%D` separator and ref-name rules on real binaries: the separator is `", "`, Git rejects spaces in ref names, and a comma inside a name stays whole.
- Measured boundary, one container per version: 2.38.1 / 2.40.1 / 2.41.0 verbatim, 2.43.0 / 2.45.2 / 2.49.1 expanded.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Investigated and implemented with Claude Code (Claude Opus 5).

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Remaining test gap**: removing the cache argument at the relay call site alone is not caught by a test, because the uncached path still recovers the refs and the relay's Git executor is private. The local wiring is covered.

- **Cross-platform**: no platform-specific code; the probe reads command output only.
- **Remote SSH / relay**: the capability is scoped per execution host, so a modern local Git and an old remote Git do not contaminate each other. `git.history` params are unchanged, so there is no wire-compatibility impact.
- **Folder workspaces**: unchanged; the history loader is reached the same way.
- **Performance**: one extra `git log` on the first load for a host with old Git, then cached for `GIT_CAPABILITY_RETRY_INTERVAL_MS`. Modern Git pays nothing.
- **Backwards compatibility**: on Git 2.43+ the command sent is byte-identical to today's.
- **Probe scope**: the echo probe reads each record's decoration field only, never the commit message, so a message that reproduces the placeholder cannot downgrade a modern Git or poison the capability cache.
- **Ref names with commas**: the `%D` path splits on `", "`. Git rejects spaces in ref names, so a comma inside a name stays part of that name and cannot forge an extra branch or remote pill.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
