### PR TITLE
fix(runtime): clear stale mobile ws fallback port

### DIFF
--- a/src/main/runtime/rpc/ws-fallback-port-store.test.ts
+++ b/src/main/runtime/rpc/ws-fallback-port-store.test.ts
@@ -2,7 +2,11 @@ import { mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { readWsFallbackPort, writeWsFallbackPort } from './ws-fallback-port-store'
+import {
+  clearWsFallbackPort,
+  readWsFallbackPort,
+  writeWsFallbackPort
+} from './ws-fallback-port-store'
 
 function makeUserDataPath(): string {
   return mkdtempSync(join(tmpdir(), 'ws-fallback-port-test-'))
@@ -30,6 +34,15 @@ describe('ws-fallback-port-store', () => {
     const userDataPath = makeUserDataPath()
     writeWsFallbackPort(userDataPath, 0)
     writeWsFallbackPort(userDataPath, 70000)
+    expect(readWsFallbackPort(userDataPath)).toBeUndefined()
+  })
+
+  it('clears a persisted fallback port', () => {
+    const userDataPath = makeUserDataPath()
+    writeWsFallbackPort(userDataPath, 54321)
+
+    clearWsFallbackPort(userDataPath)
+
     expect(readWsFallbackPort(userDataPath)).toBeUndefined()
   })
 })

--- a/src/main/runtime/rpc/ws-fallback-port-store.ts
+++ b/src/main/runtime/rpc/ws-fallback-port-store.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync } from 'node:fs'
+import { readFileSync, unlinkSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 // Why: when the preferred WS port is taken (second Orca instance), the OS
@@ -41,5 +41,13 @@ export function writeWsFallbackPort(userDataPath: string, port: number): void {
   } catch {
     // Why: persistence is best-effort — failing to record the port must not
     // break transport startup; the cost is a re-pair after the next restart.
+  }
+}
+
+export function clearWsFallbackPort(userDataPath: string): void {
+  try {
+    unlinkSync(join(userDataPath, FALLBACK_PORT_FILE))
+  } catch {
+    // Missing or undeletable state must not break transport startup.
   }
 }

--- a/src/main/runtime/runtime-rpc-websocket-bind-host.test.ts
+++ b/src/main/runtime/runtime-rpc-websocket-bind-host.test.ts
@@ -7,6 +7,7 @@ import WebSocket from 'ws'
 import { OrcaRuntimeService } from './orca-runtime'
 import { OrcaRuntimeRpcServer } from './runtime-rpc'
 import { WebSocketTransport } from './rpc/ws-transport'
+import { readWsFallbackPort, writeWsFallbackPort } from './rpc/ws-fallback-port-store'
 import { DeviceRegistry } from './device-registry'
 import { DEVICE_REGISTRY_FILENAME } from './mobile-pairing-files'
 
@@ -49,6 +50,53 @@ describe('OrcaRuntimeRpcServer WebSocket bind host (STA-2370)', () => {
       expect(new URL(server.getWebSocketEndpoint()!).hostname).toBe('127.0.0.1')
     } finally {
       await server.stop()
+    }
+  })
+
+  it('clears a persisted fallback after it fails and the default port binds', async () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
+    const preferredHolder = new WebSocketTransport({ host: '127.0.0.1', port: 0 })
+    const fallbackHolder = new WebSocketTransport({ host: '127.0.0.1', port: 0 })
+    await preferredHolder.start()
+    await fallbackHolder.start()
+    const preferredPort = preferredHolder.resolvedPort
+    const fallbackPort = fallbackHolder.resolvedPort
+    await preferredHolder.stop()
+    await fallbackHolder.stop()
+    writeWsFallbackPort(userDataPath, fallbackPort)
+
+    const transportPrototype = WebSocketTransport.prototype as unknown as {
+      tryListen(port: number): Promise<void>
+    }
+    const realTryListen = transportPrototype.tryListen
+    const tryListenSpy = vi.spyOn(transportPrototype, 'tryListen').mockImplementation(function (
+      port: number
+    ) {
+      if (port === fallbackPort) {
+        return Promise.reject(
+          Object.assign(new Error('listen EACCES'), {
+            code: 'EACCES',
+            syscall: 'listen',
+            port
+          })
+        )
+      }
+      return realTryListen.call(this, port)
+    })
+    const server = new OrcaRuntimeRpcServer({
+      runtime: new OrcaRuntimeService(),
+      userDataPath,
+      enableWebSocket: true,
+      wsPort: preferredPort
+    })
+
+    try {
+      await server.start()
+      expect(wsTransportOf(server)?.resolvedPort).toBe(preferredPort)
+      expect(readWsFallbackPort(userDataPath)).toBeUndefined()
+    } finally {
+      await server.stop()
+      tryListenSpy.mockRestore()
     }
   })
 

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -19,7 +19,11 @@ import { fingerprintAuthenticatedPairingCredential } from './rpc/orchestration-m
 import type { RpcMessageContext, RpcTransport } from './rpc/transport'
 import { UnixSocketTransport } from './rpc/unix-socket-transport'
 import { WebSocketTransport } from './rpc/ws-transport'
-import { readWsFallbackPort, writeWsFallbackPort } from './rpc/ws-fallback-port-store'
+import {
+  clearWsFallbackPort,
+  readWsFallbackPort,
+  writeWsFallbackPort
+} from './rpc/ws-fallback-port-store'
 import type { WebSocket } from 'ws'
 import { DeviceRegistry, type DeviceEntry, type DeviceScope } from './device-registry'
 import { loadOrCreateE2EEKeypair, type E2EEKeypair } from './e2ee-keypair'
@@ -1185,15 +1189,22 @@ export class OrcaRuntimeRpcServer {
         this.pairingInitializationFailure = null
         try {
           const host = this.resolveInitialWebSocketBindHost()
+          const persistedFallbackPort =
+            this.wsPort !== 0 ? readWsFallbackPort(this.userDataPath) : undefined
           const { transport, endpoint } = await this.startWebSocketTransport({
             host,
             port: this.wsPort,
             preferPinnedPort: this.preferPinnedWsPort,
             // Why: stable fallback port across restarts keeps paired devices' endpoints valid (STA-1511); wsPort 0 = random (E2E).
-            ...(this.wsPort !== 0 ? { fallbackPort: readWsFallbackPort(this.userDataPath) } : {})
+            ...(this.wsPort !== 0 ? { fallbackPort: persistedFallbackPort } : {})
           })
-          if (this.wsPort !== 0 && transport.resolvedPort !== this.wsPort) {
-            writeWsFallbackPort(this.userDataPath, transport.resolvedPort)
+          if (this.wsPort !== 0) {
+            if (transport.resolvedPort !== this.wsPort) {
+              writeWsFallbackPort(this.userDataPath, transport.resolvedPort)
+            } else if (persistedFallbackPort !== undefined && !this.preferPinnedWsPort) {
+              // Why: a failed persisted fallback is already unreachable; retaining it would make the endpoint flip back to that stale port on a later launch.
+              clearWsFallbackPort(this.userDataPath)
+            }
           }
           activeTransports.push(transport)
           transportsMeta.push({ kind: 'websocket', endpoint })


### PR DESCRIPTION
## Summary

On Windows, Orca could alternate between a stale mobile WebSocket fallback port and the default port after restarts, disconnecting paired devices.

This change removes the stale fallback after it fails and the default port successfully binds.

## What Changed

- Clear `mobile-ws-fallback-port.json` after persisted fallback recovery fails.
- Preserve pinned `serve --port` behavior.
- Add startup regression coverage for the Windows reserved-port scenario.
- Add fallback-store deletion coverage.

## Why

A failed fallback bind leaves the old fallback file in place.

The next launch retries that stale port first, causing the advertised mobile endpoint to flip between ports.

## Linked Issue

Fixes #15490

## Visual Proof

N/A — no UI or interaction layout changes.

## Testing

- [x] Regression test failed before the fix because the stale fallback remained persisted.
- [x] Affected test files pass serially: 20 tests passed.
- [x] Targeted Oxlint passed.
- [x] Commit hooks passed Oxlint and formatting.
- [ ] Full `pnpm typecheck` — exceeded the local Windows timeout without diagnostics.
- [ ] Full CI checks will provide additional coverage.

Tested on Windows.

No SSH, remote-runtime, mobile UI, or provider-specific behavior was changed.

## AI Disclosure

Codex was used for investigation, implementation, regression testing, and verification.

## Review

- Root cause was reproduced with a failing startup-level regression test.
- The fix is scoped to fallback-port persistence and does not alter transport candidate ordering.
- Pinned server ports remain authoritative.
- File deletion remains best-effort and cannot prevent transport startup.

## Agent Skill Upstream Boundary

- [x] Not applicable.

## Notes

- **Security impact:** None identified.
- **Cross-platform impact:** The persistence behavior is platform-neutral; it specifically addresses Windows reserved-port failures.
- **Remote and SSH impact:** None.
- **Backwards compatibility:** Existing valid fallback ports continue to be preferred when bindable.
- **Performance impact:** Negligible.

## Checklist

- [x] This PR is small and focused.
- [x] I explained what changed and why.
- [x] No visual changes require screenshots.
- [x] Self-reviewed for correctness, security, and performance.
- [x] Cross-platform and compatibility impact considered.
- [ ] Full `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` completed locally.

## Author

- X / Twitter: @siddqamar_ai