### PR TITLE
fix(workspaces): re-seed a terminal when an emptied workspace is opened

### DIFF
--- a/src/renderer/src/components/editor/check-annotation-open.test.ts
+++ b/src/renderer/src/components/editor/check-annotation-open.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  activateAndRevealWorktree: vi.fn(),
+  state: {
+    worktreesByRepo: { 'repo-1': [{ id: 'wt-1', repoId: 'repo-1', path: '/repo/wt' }] },
+    openFile: vi.fn(),
+    setPendingEditorReveal: vi.fn()
+  }
+}))
+
+vi.mock('@/store', () => ({ useAppStore: { getState: () => mocks.state } }))
+vi.mock('@/lib/worktree-activation', () => ({
+  activateAndRevealWorktree: mocks.activateAndRevealWorktree
+}))
+vi.mock('@/lib/language-detect', () => ({ detectLanguage: () => 'typescript' }))
+
+import { openAnnotationLocation } from './check-annotation-open'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+describe('openAnnotationLocation', () => {
+  it('activates as a surface-providing caller before opening the editor', () => {
+    vi.stubGlobal('requestAnimationFrame', vi.fn().mockReturnValue(1))
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+
+    openAnnotationLocation({
+      worktreeId: 'wt-1',
+      path: 'src/a.ts',
+      line: 3,
+      revealRafRef: { current: null },
+      revealInnerRafRef: { current: null }
+    })
+
+    // Why: the annotation's editor file is the surface — the jump must not re-seed
+    // a shell into a workspace whose last terminal the user closed.
+    expect(mocks.activateAndRevealWorktree).toHaveBeenCalledWith('wt-1', {
+      providesInitialSurface: true
+    })
+    expect(mocks.state.openFile).toHaveBeenCalledWith(
+      expect.objectContaining({ worktreeId: 'wt-1', relativePath: 'src/a.ts' }),
+      { forceContentReload: true }
+    )
+  })
+
+  it('does not activate when the worktree is unknown', () => {
+    openAnnotationLocation({
+      worktreeId: 'missing',
+      path: 'src/a.ts',
+      line: 3,
+      revealRafRef: { current: null },
+      revealInnerRafRef: { current: null }
+    })
+
+    expect(mocks.activateAndRevealWorktree).not.toHaveBeenCalled()
+    expect(mocks.state.openFile).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/editor/check-annotation-open.ts
+++ b/src/renderer/src/components/editor/check-annotation-open.ts
@@ -30,7 +30,7 @@ export function openAnnotationLocation(params: {
 
   // Why: reuse the shared activation path so an annotation jump lands in the
   // same history stack as sidebar, palette, and terminal-link navigation.
-  activateAndRevealWorktree(worktreeId)
+  activateAndRevealWorktree(worktreeId, { providesInitialSurface: true })
 
   store.openFile(
     {

--- a/src/renderer/src/components/feature-wall/FeatureWallBrowserAction.tsx
+++ b/src/renderer/src/components/feature-wall/FeatureWallBrowserAction.tsx
@@ -37,7 +37,7 @@ export function BrowserAction(props: { done: boolean }): React.JSX.Element {
       return
     }
     closeModal()
-    activateAndRevealWorktree(targetWorktree.id)
+    activateAndRevealWorktree(targetWorktree.id, { providesInitialSurface: true })
     const state = useAppStore.getState()
     // Why: open the browser into the worktree's active group so it lands beside
     // the user's current work rather than spawning a detached surface.

--- a/src/renderer/src/components/right-sidebar/PortsPanel.test.tsx
+++ b/src/renderer/src/components/right-sidebar/PortsPanel.test.tsx
@@ -350,7 +350,10 @@ describe('PortsPanel runtime routing', () => {
     ).resolves.toEqual({ ok: true })
 
     expect(activateAndRevealWorktreeMock).toHaveBeenCalledTimes(2)
-    expect(activateAndRevealWorktreeMock).toHaveBeenCalledWith('repo::/workspace/app')
+    // Why: the browser tab is the surface — port opens must not re-seed a shell.
+    expect(activateAndRevealWorktreeMock).toHaveBeenCalledWith('repo::/workspace/app', {
+      providesInitialSurface: true
+    })
     expect(runtimeEnvironmentCall.mock.calls.map((call) => call[0].method)).toEqual([
       'status.get',
       'browser.tabCreate',

--- a/src/renderer/src/components/sidebar/delete-worktree-flow.test.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-flow.test.ts
@@ -32,6 +32,8 @@ const mocks = vi.hoisted(() => {
       }
     }),
     openModal: vi.fn(),
+    setRightSidebarTab: vi.fn(),
+    setRightSidebarOpen: vi.fn(),
     removeWorktree: vi.fn().mockResolvedValue({ ok: true }),
     gitStatusByWorktree: {} as Record<string, unknown[]>,
     deleteStateByWorktreeId: {} as Record<
@@ -344,6 +346,27 @@ describe('delete worktree flow', () => {
       )
       expect(onDeleted).toHaveBeenCalledWith([{ id: 'wt-1', executionHostId: null }])
     })
+  })
+
+  it('opens the diff without re-seeding a shell when View changes is clicked', async () => {
+    mocks.state.settings = { skipDeleteWorktreeConfirm: true }
+    mocks.state.removeWorktree.mockResolvedValueOnce({ ok: false, error: 'changed files' })
+    setWorktrees([{ id: 'wt-1', displayName: 'one' }])
+
+    expect(runWorktreeBatchDelete(['wt-1'])).toBe(true)
+
+    await vi.waitFor(() => expect(showDeleteWorktreeFailureToast).toHaveBeenCalled())
+    const toastOptions = vi.mocked(showDeleteWorktreeFailureToast).mock.calls[0]?.[0]
+    toastOptions?.onViewChanges()
+
+    // Why: the Source Control panel is the surface; seeding a shell would repopulate a
+    // workspace the user is trying to delete and erase its closed-last-terminal tombstone.
+    const { activateAndRevealWorktree } = await import('@/lib/worktree-activation')
+    expect(activateAndRevealWorktree).toHaveBeenCalledWith('wt-1', {
+      providesInitialSurface: true
+    })
+    expect(mocks.state.setRightSidebarTab).toHaveBeenCalledWith('source-control')
+    expect(mocks.state.setRightSidebarOpen).toHaveBeenCalledWith(true)
   })
 
   it('does not offer force delete for a locked worktree', async () => {

--- a/src/renderer/src/components/sidebar/run-worktree-delete-with-toast.ts
+++ b/src/renderer/src/components/sidebar/run-worktree-delete-with-toast.ts
@@ -13,7 +13,12 @@ function viewWorktreeDiff(
   worktreeId: string,
   executionHostId: WorktreeRemovalTarget['executionHostId']
 ): void {
-  activateAndRevealWorktree(worktreeId, executionHostId ? { executionHostId } : {})
+  // The Source Control panel is the requested surface — don't re-seed a shell in a
+  // workspace the user is trying to delete.
+  activateAndRevealWorktree(worktreeId, {
+    providesInitialSurface: true,
+    ...(executionHostId ? { executionHostId } : {})
+  })
   const state = useAppStore.getState()
   state.setRightSidebarTab('source-control')
   state.setRightSidebarOpen(true)

--- a/src/renderer/src/components/terminal-pane/terminal-file-open-routing.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-file-open-routing.ts
@@ -29,8 +29,9 @@ function openHtmlFileInBrowser(filePath: string, worktreeId: string): void {
   const store = useAppStore.getState()
   if (worktreeId) {
     // Why: following an HTML file link changes which worktree is foregrounded,
-    // so it must record a history visit before opening the browser tab.
-    activateAndRevealWorktree(worktreeId)
+    // so it must record a history visit before opening the browser tab — but the
+    // browser tab is the surface, so an emptied workspace must not gain a shell.
+    activateAndRevealWorktree(worktreeId, { providesInitialSurface: true })
   }
   const fileUrl = absolutePathToFileUri(filePath)
   const title = filePath.split(/[/\\]/).pop() ?? filePath
@@ -208,10 +209,9 @@ export function openDetectedFilePath(
 
     const store = useAppStore.getState()
     if (worktreeId) {
-      // Why: terminal file links can jump across worktrees. Reusing the shared
-      // activation path keeps those jumps in the same history stack as sidebar
-      // and palette navigation before the editor opens the destination file.
-      activateAndRevealWorktree(worktreeId)
+      // Why: cross-worktree file links share the activation history stack with sidebar and
+      // palette navigation, but the editor file is the surface — don't seed a shell.
+      activateAndRevealWorktree(worktreeId, { providesInitialSurface: true })
     }
 
     const language = detectLanguage(mappedFilePath)

--- a/src/renderer/src/components/terminal-pane/terminal-link-file-open-routing.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-file-open-routing.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
+import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { openDetectedFilePath } from './terminal-link-handlers'
 import { createTerminalLinkTestDoubles } from './terminal-link-handlers-test-fixtures'
 import {
@@ -58,6 +59,11 @@ describe('handleOscLink', () => {
       expect.objectContaining({ title: 'report.html', activate: true })
     )
     expect(openFilePathMock).not.toHaveBeenCalled()
+    // Why: the browser tab is the surface — activation must not re-seed a shell into a
+    // workspace whose last terminal the user closed.
+    expect(activateAndRevealWorktree).toHaveBeenCalledWith('wt-1', {
+      providesInitialSurface: true
+    })
   })
 
   it('also opens local .htm paths in Orca browser tabs with the platform modifier', async () => {
@@ -96,6 +102,10 @@ describe('handleOscLink', () => {
       matchLength: 0
     })
     expect(openFilePathMock).not.toHaveBeenCalled()
+    // Why: the editor file is the surface — the cross-worktree jump must not add a shell.
+    expect(activateAndRevealWorktree).toHaveBeenCalledWith('wt-1', {
+      providesInitialSurface: true
+    })
   })
 
   it('preserves explicit column for Orca opens from :line:column links', async () => {

--- a/src/renderer/src/components/terminal/initial-terminal-wiring.test.ts
+++ b/src/renderer/src/components/terminal/initial-terminal-wiring.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+// Why: Terminal.tsx is the passive half of the closed-last-terminal contract — it must keep
+// honouring the tombstone while explicit activation re-seeds. Mounting a 2892-line component
+// to prove that costs far more than it returns, and the e2e that covers it only runs when an
+// e2e spec changes. Assert the wiring as source text instead, the same way app-startup-routing
+// and the startup ordering tests pin call order they cannot cheaply execute.
+const TERMINAL_PATH = 'src/renderer/src/components/Terminal.tsx'
+
+function readSource(relativePath: string): string {
+  return readFileSync(join(process.cwd(), relativePath), 'utf8')
+}
+
+describe('Terminal auto-create wiring', () => {
+  const source = readSource(TERMINAL_PATH)
+
+  it('derives the tombstone from the active worktree row', () => {
+    expect(source).toContain('Object.hasOwn(tabsByWorktree, activeWorktreeId)')
+  })
+
+  it('passes that derivation into shouldAutoCreateInitialTerminal', () => {
+    // Why: the regression #14590 fixed is re-introduced by dropping this second argument, and a
+    // literal here would pin nothing — it has to be the identifier the effect actually derives.
+    // Exactly one call site: a second (flagless) call could otherwise hide behind this one.
+    expect(
+      source.split('shouldAutoCreateInitialTerminal(').length - 1,
+      'expected exactly one shouldAutoCreateInitialTerminal call in Terminal.tsx'
+    ).toBe(1)
+    expect(source).toContain(
+      'shouldAutoCreateInitialTerminal(renderableTabCount, activeWorktreeHasTerminalState)'
+    )
+  })
+
+  it('keeps that derivation in the effect dependencies', () => {
+    // Why: without the dep the effect never re-runs when the row appears or disappears.
+    // Anchored to the neighbouring dep so a stray trailing comma elsewhere can't satisfy it.
+    expect(source).toContain('activeWorktreeId,\n    activeWorktreeHasTerminalState,')
+  })
+})

--- a/src/renderer/src/lib/fix-checks-agent-launch.test.ts
+++ b/src/renderer/src/lib/fix-checks-agent-launch.test.ts
@@ -156,6 +156,25 @@ describe('startFixChecksAgent', () => {
     mocks.resolveSourceControlLaunchPlatform.mockReturnValue('darwin')
   })
 
+  it('activates the attached workspace as a surface-providing caller', async () => {
+    const { startFixChecksAgent } = await import('./fix-checks-agent-launch')
+
+    await expect(
+      startFixChecksAgent({
+        repoId: 'repo-1',
+        worktreeId: 'wt-1',
+        basePrompt: 'Fix checks',
+        launchSource: 'task_page'
+      })
+    ).resolves.toBe(true)
+
+    // Why: launchAgentInNewTab creates the surface; without the opt-out, activation would
+    // also re-seed a shell in a closed-last-terminal workspace.
+    expect(mocks.activateAndRevealWorktree).toHaveBeenCalledWith('wt-1', {
+      providesInitialSurface: true
+    })
+  })
+
   it('fails without launching when the requested worktree is missing', async () => {
     const { startFixChecksAgent } = await import('./fix-checks-agent-launch')
 

--- a/src/renderer/src/lib/fix-checks-agent-launch.ts
+++ b/src/renderer/src/lib/fix-checks-agent-launch.ts
@@ -186,7 +186,8 @@ export async function startFixChecksAgent(args: StartFixChecksAgentArgs): Promis
       toast.error(agentArgsPlan.error)
       return false
     }
-    if (!activateAndRevealWorktree(targetWorktreeId)) {
+    // launchAgentInNewTab below creates the surface; seeding here would add a stray shell.
+    if (!activateAndRevealWorktree(targetWorktreeId, { providesInitialSurface: true })) {
       toast.error(
         translate(
           'auto.lib.fix.checks.agent.launch.03c1d61f83',

--- a/src/renderer/src/lib/workspace-port-actions.ts
+++ b/src/renderer/src/lib/workspace-port-actions.ts
@@ -124,7 +124,9 @@ export async function openWorkspacePortInBrowser(args: {
   if (!worktreeId) {
     return { ok: false, reason: 'No workspace selected for the browser.' }
   }
-  activateAndRevealWorktree(worktreeId)
+  // Why: the browser tab opened below is this jump's surface; seeding a shell would add a
+  // PTY the user never asked for in a workspace whose last terminal they closed.
+  activateAndRevealWorktree(worktreeId, { providesInitialSurface: true })
   if (args.runtimeTarget.kind === 'environment') {
     try {
       await assertRuntimeEnvironmentCapability(

--- a/src/renderer/src/lib/worktree-activation-emptied-workspace-reseed.test.ts
+++ b/src/renderer/src/lib/worktree-activation-emptied-workspace-reseed.test.ts
@@ -1,0 +1,256 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useAppStore } from '@/store'
+import { activateAndRevealFolderWorkspace, activateAndRevealWorktree } from './worktree-activation'
+import { ensureWorktreeHasInitialTerminal } from './worktree-initial-terminal-seeding'
+import { folderWorkspaceKey } from '../../../shared/workspace-scope'
+import { toSshExecutionHostId } from '../../../shared/execution-host'
+import {
+  makeCreatedAgentWorktree as makeWorktree,
+  seedEmptyActivatableWorktree
+} from '@/lib/worktree-activation-created-agent-test-state'
+
+const initialAppStoreState = useAppStore.getState()
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  useAppStore.setState(initialAppStoreState, true)
+})
+
+/** The state a workspace lands in once its last terminal is closed: the row survives as an
+ *  explicit empty list rather than disappearing. */
+function seedClosedLastTerminal(worktreeId: string): void {
+  useAppStore.setState({ tabsByWorktree: { [worktreeId]: [] } })
+  const { renderableTabCount } = useAppStore.getState().reconcileWorktreeTabModel(worktreeId)
+  expect(renderableTabCount).toBe(0)
+}
+
+describe('activating a workspace whose last terminal was closed', () => {
+  it('re-seeds a terminal when the workspace is opened from elsewhere', () => {
+    const worktree = makeWorktree()
+    seedEmptyActivatableWorktree(worktree)
+    seedClosedLastTerminal(worktree.id)
+
+    const result = activateAndRevealWorktree(worktree.id, { notifyHostRuntime: false })
+
+    expect(result).not.toBe(false)
+    expect(result === false ? null : result.primaryTabId).toBeTruthy()
+    expect(useAppStore.getState().tabsByWorktree[worktree.id]).toHaveLength(1)
+  })
+
+  // Why: hydration restores an emptied workspace as active, so the user is already looking at the
+  // blank pane when they click its row. Suppressing the re-seed there strands them on the bug.
+  it('re-seeds when the restored active workspace is reopened on the same host', () => {
+    const worktree = makeWorktree()
+    seedEmptyActivatableWorktree(worktree)
+    seedClosedLastTerminal(worktree.id)
+    useAppStore.setState({
+      activeWorktreeId: worktree.id,
+      activeWorkspaceExecutionHostId: 'local',
+      activeView: 'terminal'
+    })
+
+    activateAndRevealWorktree(worktree.id, {
+      executionHostId: 'local',
+      notifyHostRuntime: false
+    })
+
+    expect(useAppStore.getState().tabsByWorktree[worktree.id]).toHaveLength(1)
+  })
+
+  // Why: entry points disagree about whether to pass a host for the same local workspace — the
+  // sidebar derives 'local', the Cmd+J palette passes nothing. Re-seeding no longer reads the
+  // host at all; this guards against reintroducing a host-sensitive carve-out.
+  it('re-seeds identically whether or not the caller passes an execution host', () => {
+    for (const opts of [{}, { executionHostId: 'local' as const }]) {
+      const worktree = makeWorktree()
+      seedEmptyActivatableWorktree(worktree)
+      seedClosedLastTerminal(worktree.id)
+      useAppStore.setState({
+        activeWorktreeId: worktree.id,
+        activeWorkspaceExecutionHostId: 'local',
+        activeView: 'terminal'
+      })
+
+      activateAndRevealWorktree(worktree.id, { ...opts, notifyHostRuntime: false })
+
+      expect(useAppStore.getState().tabsByWorktree[worktree.id]).toHaveLength(1)
+    }
+  })
+
+  // Why: terminal file links and check annotations activate only to route history before they
+  // open an editor tab. Seeding there hands the user a shell they never asked for and erases the
+  // tombstone permanently. See terminal-file-open-routing.ts and check-annotation-open.ts.
+  it('leaves the row empty when the caller opens its own surface', () => {
+    const worktree = makeWorktree()
+    seedEmptyActivatableWorktree(worktree)
+    seedClosedLastTerminal(worktree.id)
+
+    const result = activateAndRevealWorktree(worktree.id, {
+      providesInitialSurface: true,
+      notifyHostRuntime: false
+    })
+
+    expect(result).not.toBe(false)
+    expect(result === false ? null : result.primaryTabId).toBeNull()
+    expect(useAppStore.getState().tabsByWorktree[worktree.id]).toEqual([])
+  })
+
+  it('leaves the row empty for startup hydration, which never opts into re-seeding', () => {
+    const worktree = makeWorktree()
+    seedEmptyActivatableWorktree(worktree)
+    seedClosedLastTerminal(worktree.id)
+
+    const tabId = ensureWorktreeHasInitialTerminal(useAppStore.getState(), worktree.id)
+
+    expect(tabId).toBeNull()
+    expect(useAppStore.getState().tabsByWorktree[worktree.id]).toEqual([])
+  })
+
+  // Why: this passes ahead of the tombstone check — a renderable browser tab short-circuits
+  // `shouldAutoCreateInitialTerminal` — so it guards `renderableTabCount`, not the re-seed flag.
+  it('does not add a terminal to a workspace that still renders a browser tab', () => {
+    const worktree = makeWorktree()
+    seedEmptyActivatableWorktree(worktree)
+    seedClosedLastTerminal(worktree.id)
+    useAppStore.setState({
+      browserTabsByWorktree: {
+        [worktree.id]: [
+          {
+            id: 'browser-1',
+            worktreeId: worktree.id,
+            url: 'https://example.com',
+            title: 'example',
+            sortOrder: 0,
+            createdAt: 1
+          }
+        ]
+      },
+      unifiedTabsByWorktree: {
+        [worktree.id]: [
+          {
+            id: 'browser-1',
+            entityId: 'browser-1',
+            groupId: 'group-1',
+            worktreeId: worktree.id,
+            contentType: 'browser',
+            label: 'example',
+            customLabel: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1
+          }
+        ]
+      },
+      groupsByWorktree: {
+        [worktree.id]: [
+          {
+            id: 'group-1',
+            worktreeId: worktree.id,
+            activeTabId: 'browser-1',
+            tabOrder: ['browser-1']
+          }
+        ]
+      },
+      activeGroupIdByWorktree: { [worktree.id]: 'group-1' }
+    } as unknown as Partial<ReturnType<typeof useAppStore.getState>>)
+    expect(
+      useAppStore.getState().reconcileWorktreeTabModel(worktree.id).renderableTabCount
+    ).toBeGreaterThan(0)
+
+    activateAndRevealWorktree(worktree.id, { notifyHostRuntime: false })
+
+    expect(useAppStore.getState().tabsByWorktree[worktree.id]).toEqual([])
+  })
+})
+
+const FOLDER_ID = 'folder-1'
+const FOLDER_KEY = folderWorkspaceKey(FOLDER_ID)
+const SSH_HOST_ID = toSshExecutionHostId('conn-1')
+
+/** One folder id resolves to a different `FolderWorkspace` per host while both share a single
+ *  `tabsByWorktree[FOLDER_KEY]` row. */
+function seedEmptiedFolderWorkspaceOnTwoHosts(): void {
+  const base = {
+    id: FOLDER_ID,
+    projectGroupId: 'group-1',
+    name: 'notes',
+    linkedTask: null,
+    comment: '',
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0
+  }
+  useAppStore.setState({
+    folderWorkspaces: [
+      { ...base, folderPath: '/local/notes', executionHostId: 'local' },
+      // Why: an SSH host, not a runtime one — runtime-owned workspaces return early from
+      // `ensureWorktreeHasInitialTerminal` because the host owns terminal creation.
+      { ...base, folderPath: '/remote/notes', executionHostId: SSH_HOST_ID, connectionId: 'conn-1' }
+    ],
+    activeView: 'terminal',
+    tabsByWorktree: { [FOLDER_KEY]: [] },
+    unifiedTabsByWorktree: {},
+    groupsByWorktree: {},
+    getFreshFolderWorkspacePathStatus: () => ({ exists: true }),
+    markWorktreeVisited: vi.fn(),
+    recordWorktreeVisit: vi.fn(),
+    revealWorktreeInSidebar: vi.fn()
+  } as unknown as Partial<ReturnType<typeof useAppStore.getState>>)
+  expect(useAppStore.getState().reconcileWorktreeTabModel(FOLDER_KEY).renderableTabCount).toBe(0)
+}
+
+describe('activating a folder workspace whose last terminal was closed', () => {
+  it('re-seeds a terminal when the workspace is opened', () => {
+    seedEmptiedFolderWorkspaceOnTwoHosts()
+
+    const result = activateAndRevealFolderWorkspace(FOLDER_ID, { executionHostId: 'local' })
+
+    expect(result).not.toBe(false)
+    expect(useAppStore.getState().tabsByWorktree[FOLDER_KEY]).toHaveLength(1)
+  })
+
+  it('re-seeds when the restored active folder workspace is reopened on the same host', () => {
+    seedEmptiedFolderWorkspaceOnTwoHosts()
+    useAppStore.setState({
+      activeWorktreeId: FOLDER_KEY,
+      activeWorkspaceExecutionHostId: 'local'
+    })
+
+    activateAndRevealFolderWorkspace(FOLDER_ID, { executionHostId: 'local' })
+
+    expect(useAppStore.getState().tabsByWorktree[FOLDER_KEY]).toHaveLength(1)
+  })
+
+  // Why: the opt-out must mean the same thing on both workspace shapes, or routing a
+  // file link through a folder workspace would silently regress to seeding a shell.
+  it('leaves the row empty when the caller opens its own surface', () => {
+    seedEmptiedFolderWorkspaceOnTwoHosts()
+
+    const result = activateAndRevealFolderWorkspace(FOLDER_ID, {
+      executionHostId: 'local',
+      providesInitialSurface: true
+    })
+
+    expect(result).not.toBe(false)
+    expect(result === false ? null : result.primaryTabId).toBeNull()
+    expect(useAppStore.getState().tabsByWorktree[FOLDER_KEY]).toEqual([])
+  })
+
+  // Why: this asserts the row is re-seeded, NOT that the tab lands on the requested host.
+  // getFolderWorkspaceConnectionId is host-blind (folder-workspace-connection.ts:68 takes the
+  // first id match), so the created tab resolves local even here. That defect is pre-existing —
+  // it reproduces with no row at all, on the ordinary auto-create path — and is out of scope.
+  it('re-seeds the shared row when opening the same folder id on a different host', () => {
+    seedEmptiedFolderWorkspaceOnTwoHosts()
+    useAppStore.setState({
+      activeWorktreeId: FOLDER_KEY,
+      activeWorkspaceExecutionHostId: 'local'
+    })
+
+    const result = activateAndRevealFolderWorkspace(FOLDER_ID, { executionHostId: SSH_HOST_ID })
+
+    expect(result).not.toBe(false)
+    expect(useAppStore.getState().tabsByWorktree[FOLDER_KEY]).toHaveLength(1)
+  })
+})

--- a/src/renderer/src/lib/worktree-activation-store-contract.ts
+++ b/src/renderer/src/lib/worktree-activation-store-contract.ts
@@ -63,4 +63,10 @@ export type WorktreeActivationStore = Partial<WorktreeRuntimeOwnerState> & {
 export type InitialTerminalOptions = {
   activateCreatedTabs?: boolean
   backendStartupTerminalSpawned?: boolean
+  /** Why: an explicit empty terminal row is a "user closed the last tab" tombstone. Startup
+   *  hydration honours it through Terminal.tsx's passive auto-create (which never calls this
+   *  function), but opening the workspace on purpose (sidebar, palette, automation "Resume
+   *  workspace", wake) has to hand back a usable surface. Activation sets this unless the
+   *  caller says it provides its own surface; background worktree creation leaves it unset. */
+  reseedEmptiedWorkspace?: boolean
 }

--- a/src/renderer/src/lib/worktree-activation-surface-caller-wiring.test.ts
+++ b/src/renderer/src/lib/worktree-activation-surface-caller-wiring.test.ts
@@ -1,0 +1,59 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { join, relative, sep } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+// Why: `providesInitialSurface: true` is invisible to behavior tests — every opted-out caller
+// still works with the flag deleted, it just re-seeds a shell the user never asked for in a
+// closed-last-terminal workspace. Three review rounds each found a missed caller, so this is
+// the census: activation callers that open their own surface (editor, browser, diff, agent tab)
+// must appear here, and adding or removing an opt-out anywhere must update this list.
+const SURFACE_PROVIDING_CALLERS = [
+  'src/renderer/src/components/editor/check-annotation-open.ts',
+  'src/renderer/src/components/feature-wall/FeatureWallBrowserAction.tsx',
+  'src/renderer/src/components/sidebar/run-worktree-delete-with-toast.ts',
+  'src/renderer/src/components/terminal-pane/terminal-file-open-routing.ts',
+  'src/renderer/src/lib/fix-checks-agent-launch.ts',
+  'src/renderer/src/lib/workspace-port-actions.ts'
+]
+
+// The activation seam itself: declares the option and forwards it into the tombstone gate.
+const SEAM_FILES = ['src/renderer/src/lib/worktree-activation.ts']
+
+function listSourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      return listSourceFiles(fullPath)
+    }
+    if (!/\.(ts|tsx)$/.test(entry.name) || /\.test\.(ts|tsx)$/.test(entry.name)) {
+      return []
+    }
+    return [fullPath]
+  })
+}
+
+// Why: bound to an actual activation call so a comment or dead code containing the flag
+// text cannot satisfy the census, and a variable-valued flag cannot hide in it. Comments
+// are stripped first — commenting the flag out in place must fail this test.
+const ACTIVATION_CALL_WITH_OPT_OUT =
+  /activateAndReveal(?:Worktree|FolderWorkspace|Workspace)\((?:[^()]|\([^()]*\))*?providesInitialSurface: true/
+
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1')
+}
+
+describe('providesInitialSurface caller wiring', () => {
+  it.each(SURFACE_PROVIDING_CALLERS)('%s opts out of tombstone re-seeding', (relativePath) => {
+    const source = stripComments(readFileSync(join(process.cwd(), relativePath), 'utf8'))
+    expect(source).toMatch(ACTIVATION_CALL_WITH_OPT_OUT)
+  })
+
+  it('the census matches every mention under src/', () => {
+    const root = join(process.cwd(), 'src')
+    const mentions = listSourceFiles(root)
+      .filter((filePath) => readFileSync(filePath, 'utf8').includes('providesInitialSurface'))
+      .map((filePath) => relative(process.cwd(), filePath).split(sep).join('/'))
+      .sort()
+    expect(mentions).toEqual([...SURFACE_PROVIDING_CALLERS, ...SEAM_FILES].sort())
+  })
+})

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -45,7 +45,8 @@ export type ActivateAndRevealResult = {
 
 function ensureFolderWorkspaceInitialTerminal(
   folderWorkspace: FolderWorkspace,
-  startup?: WorktreeStartupPayload
+  startup?: WorktreeStartupPayload,
+  providesInitialSurface?: boolean
 ): string | null {
   const state = useAppStore.getState()
   const workspaceKey = folderWorkspaceKey(folderWorkspace.id)
@@ -55,7 +56,8 @@ function ensureFolderWorkspaceInitialTerminal(
     startup,
     undefined,
     undefined,
-    undefined
+    undefined,
+    { reseedEmptiedWorkspace: providesInitialSurface !== true }
   )
   return primaryTabId
 }
@@ -67,6 +69,8 @@ export function activateAndRevealFolderWorkspace(
     startup?: WorktreeStartupPayload
     runtimeEnvironmentId?: string | null
     executionHostId?: ExecutionHostId
+    /** See activateAndRevealWorktree — same contract for folder workspaces. */
+    providesInitialSurface?: boolean
   }
 ): ActivateAndRevealResult | false {
   const state = useAppStore.getState()
@@ -117,7 +121,11 @@ export function activateAndRevealFolderWorkspace(
     state.recordWorktreeVisit(workspaceKey)
   }
   resumeSleepingAgentSessionsForWorktree(workspaceKey)
-  const primaryTabId = ensureFolderWorkspaceInitialTerminal(folderWorkspace, opts?.startup)
+  const primaryTabId = ensureFolderWorkspaceInitialTerminal(
+    folderWorkspace,
+    opts?.startup,
+    opts?.providesInitialSurface
+  )
 
   if (opts?.sidebarRevealBehavior) {
     state.revealWorktreeInSidebar(workspaceKey, { behavior: opts.sidebarRevealBehavior })
@@ -141,6 +149,12 @@ export function activateAndRevealWorktree(
     revealInSidebar?: boolean
     executionHostId?: ExecutionHostId
     backendStartupTerminalSpawned?: boolean
+    /** Set by callers that navigate here only to open their own non-terminal surface
+     *  (an editor file, a diff). Activation then leaves a closed-last-terminal workspace
+     *  empty instead of adding a shell the user never asked for. Caveat: on a
+     *  runtime-owned workspace with a live web session the host owns terminal creation,
+     *  so ensureWebRuntimeWorktreeTerminalAfterWake may still seed one (matches main). */
+    providesInitialSurface?: boolean
   }
 ): ActivateAndRevealResult | false {
   const state = useAppStore.getState()
@@ -192,6 +206,8 @@ export function activateAndRevealWorktree(
   }
 
   // Why: sleeping destroys the local PTY but preserves the provider session id, so waking should restore those CLI sessions automatically.
+  // Ordering is load-bearing: resuming synchronously creates the session's tab first, so the
+  // seeding below sees a renderable surface and doesn't add a bare shell next to it.
   resumeSleepingAgentSessionsForWorktree(worktreeId)
 
   // 4. Ensure a focusable surface exists for externally-created worktrees
@@ -202,7 +218,10 @@ export function activateAndRevealWorktree(
     opts?.setup,
     opts?.issueCommand,
     opts?.defaultTabs,
-    opts?.backendStartupTerminalSpawned ? { backendStartupTerminalSpawned: true } : undefined
+    {
+      ...(opts?.backendStartupTerminalSpawned ? { backendStartupTerminalSpawned: true } : {}),
+      reseedEmptiedWorkspace: opts?.providesInitialSurface !== true
+    }
   )
   if (primaryTabId && opts?.initialCwd) {
     useAppStore.getState().queueTabInitialCwd(primaryTabId, opts.initialCwd)
@@ -252,7 +271,7 @@ export function activateAndRevealWorktree(
  */
 export function activateAndRevealWorkspace(
   workspaceId: string,
-  opts?: { executionHostId?: ExecutionHostId }
+  opts?: { executionHostId?: ExecutionHostId; providesInitialSurface?: boolean }
 ): ActivateAndRevealResult | false {
   const workspaceScope = parseWorkspaceKey(workspaceId)
   if (workspaceScope?.type === 'folder') {

--- a/src/renderer/src/lib/worktree-initial-terminal-seeding.ts
+++ b/src/renderer/src/lib/worktree-initial-terminal-seeding.ts
@@ -112,9 +112,21 @@ export function ensureWorktreeHasInitialTerminal(
   }
 
   const hasExplicitLaunchWork = Boolean(sequencedStartup || setup || issueCommand)
+  // Why: only startup hydration honours the closed-last-tab tombstone. Every explicit
+  // activation (sidebar, palette, automation resume, wake) re-seeds a surface instead,
+  // because closing the last terminal normally deactivates the workspace too
+  // (terminal-tab-actions.ts closeTerminalTab, plus leaveWorktreeIfEmpty for split-group
+  // closes) — so reaching here through an activation means the user asked for it back.
+  // The paths that do leave it active stay safe: a runtime-owned close returns before that
+  // deactivation, but while that session is live the host owns terminal creation and this
+  // bails out above; an editor/browser survivor keeps renderableTabCount non-zero, so no
+  // terminal is added; and closeTabPreservingPty (use-terminal-pane-lifecycle.ts) skips both
+  // deactivation hooks for pane moves and retirement, where re-seeding is the wanted outcome.
+  const shouldHonourClosedTerminalTombstone =
+    Object.hasOwn(store.tabsByWorktree, worktreeId) && opts?.reseedEmptiedWorkspace !== true
   const shouldAutoCreate = shouldAutoCreateInitialTerminal(
     renderableTabCount,
-    Object.hasOwn(store.tabsByWorktree, worktreeId)
+    shouldHonourClosedTerminalTombstone
   )
   const shouldCreateForExplicitWork = renderableTabCount === 0 && hasExplicitLaunchWork
   if (!shouldAutoCreate && !shouldCreateForExplicitWork) {

--- a/src/renderer/src/store/slices/terminals-explicit-empty-hydration.test.ts
+++ b/src/renderer/src/store/slices/terminals-explicit-empty-hydration.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { getDefaultWorkspaceSession } from '../../../../shared/constants'
 import { folderWorkspaceKey } from '../../../../shared/workspace-scope'
 import { createTestStore, makeWorktree, seedStore } from './store-test-helpers'
+import { shouldAutoCreateInitialTerminal } from '@/components/terminal/initial-terminal'
 
 vi.mock('sonner', () => ({ toast: { info: vi.fn(), success: vi.fn(), error: vi.fn() } }))
 vi.mock('@/runtime/sync-runtime-graph', () => ({ scheduleRuntimeGraphSync: vi.fn() }))
@@ -48,5 +49,37 @@ describe('explicit empty terminal hydration', () => {
     )
 
     expect(store.getState().tabsByWorktree).toEqual({ [workspaceKey]: [] })
+  })
+})
+
+// Why: this is the half of PR #15513's contract that activation must NOT undo — hydration restores
+// an emptied workspace as active, and the passive auto-create effect has to leave it alone. The
+// end-to-end pin is tests/e2e/terminal-tab-close-restart-persistence.spec.ts, which only runs when
+// an e2e spec changes, so assert the same decision here against a really-hydrated session.
+describe('hydrated active workspace with a terminal tombstone', () => {
+  it('reports no auto-create for the restored active worktree', () => {
+    const store = createTestStore()
+    const worktreeId = 'repo1::/wt-1'
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: worktreeId, repoId: 'repo1', path: '/wt-1' })]
+      }
+    })
+
+    store.getState().hydrateWorkspaceSession({
+      ...getDefaultWorkspaceSession(),
+      activeRepoId: 'repo1',
+      activeWorktreeId: worktreeId,
+      tabsByWorktree: { [worktreeId]: [] }
+    })
+
+    const state = store.getState()
+    expect(state.activeWorktreeId).toBe(worktreeId)
+    expect(state.tabsByWorktree[worktreeId]).toEqual([])
+    const { renderableTabCount } = state.reconcileWorktreeTabModel(worktreeId)
+    // The exact inputs Terminal.tsx's auto-create effect feeds shouldAutoCreateInitialTerminal.
+    expect(renderableTabCount).toBe(0)
+    expect(Object.hasOwn(state.tabsByWorktree, worktreeId)).toBe(true)
+    expect(shouldAutoCreateInitialTerminal(renderableTabCount, true)).toBe(false)
   })
 })

--- a/tests/e2e/completed-worker-retirement-resume.unit.test.ts
+++ b/tests/e2e/completed-worker-retirement-resume.unit.test.ts
@@ -559,7 +559,7 @@ describe('completed background-worker retirement resume matrix', () => {
     const restartAfterRetirement = persistAndParseCurrentSession()
     await hydrateSession(restartAfterRetirement)
 
-    // Case 8: first activation preserves explicit retirement and cannot resurrect authority.
+    // Case 8: first activation hands back a bare terminal and cannot resurrect authority.
     const beforeActivation = useAppStore.getState()
     expect(beforeActivation.everActivatedWorktreeIds.has(WORKTREE_ID)).toBe(false)
     expect(beforeActivation.agentStatusByPaneKey[ORIGINAL_PANE_KEY]).toBeUndefined()
@@ -572,10 +572,13 @@ describe('completed background-worker retirement resume matrix', () => {
     expect(activationResult).not.toBe(false)
     const activated = useAppStore.getState()
 
-    expect(activated.tabsByWorktree[WORKTREE_ID]).toEqual([])
+    const replacementTabs = activated.tabsByWorktree[WORKTREE_ID] ?? []
+    expect(replacementTabs).toHaveLength(1)
+    expect(replacementTabs[0]?.id).not.toBe(ORIGINAL_TAB_ID)
     expect(activated.terminalLayoutsByTabId[ORIGINAL_TAB_ID]).toBeUndefined()
     expect(activated.ptyIdsByTabId[ORIGINAL_TAB_ID]).toBeUndefined()
     expectCanaryUnchanged()
+    // Required invariant: explicit completion plus retirement must revoke provider-resume authority.
     expect(Object.keys(activated.pendingStartupByTabId)).toHaveLength(0)
     expect(Object.keys(activated.automaticAgentResumeClaimsByTabId)).toHaveLength(0)
   })

--- a/tests/e2e/terminal-tab-close-restart-persistence.spec.ts
+++ b/tests/e2e/terminal-tab-close-restart-persistence.spec.ts
@@ -11,6 +11,7 @@ import {
   waitForSessionReady
 } from './helpers/store'
 import { attachRepoAndOpenTerminal, createRestartSession } from './helpers/orca-restart'
+import { worktreeRowSurface } from './worktree-row-locators'
 import { RuntimeClient } from '../../src/cli/runtime/client'
 import { RuntimeRpcFailureError } from '../../src/cli/runtime/types'
 import type {
@@ -149,6 +150,18 @@ test('durable whole-tab close removes a split tab across restart', async (// oxl
       worktree: `id:${worktreeId}`
     })
     expect(afterRestart.result.terminals).toEqual([])
+
+    // Why: the tombstone only binds passive hydration. Clicking the sidebar row is the
+    // user asking for the workspace back, so explicit activation must re-seed a fresh
+    // terminal instead of leaving the blank tab bar that regressed in #14590.
+    await worktreeRowSurface(secondLaunch.page, worktreeId).click()
+    await expect
+      .poll(() => getWorktreeTabs(secondLaunch.page, worktreeId), {
+        message: 'Explicit sidebar activation did not re-seed a terminal tab'
+      })
+      .toHaveLength(1)
+    const reseededTabs = await getWorktreeTabs(secondLaunch.page, worktreeId)
+    expect(reseededTabs[0]?.id).not.toBe(closedTabId)
   } finally {
     if (firstApp) {
       await session.close(firstApp)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​524 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​521 |
| Prod | 9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​62 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​45 |

<!-- /orca-pr-loc -->

## Bug

Waking a sleeping/emptied workspace, or clicking automations' **Resume workspace**, opened a blank tab bar — you had to press `+` manually. Regression from #14590 (2eb3e11327), which made an explicit empty `tabsByWorktree[id] = []` row a durable "user closed the last tab" tombstone. That was correct for the restart path, but the same gate sat in `ensureWorktreeHasInitialTerminal`, which every explicit activation runs.

## Design

The tombstone now binds only **passive** paths; **explicit activation re-seeds by default**:

- Startup hydration and `Terminal.tsx`'s passive auto-create honour the tombstone — closing the last tab and restarting still leaves the workspace empty (#14590's guarantee, unchanged, pinned by the extended e2e).
- Explicit activation (sidebar click, Cmd+J, keyboard cycle, nav history, automations resume, wake, delete-focus, …) re-seeds a terminal. Closing the last terminal normally deactivates the workspace too, so reaching activation means the user asked for it back.
- Callers that activate **only as a prelude to opening their own surface** pass `providesInitialSurface: true`: HTML/file links from terminals (browser + editor), check annotations, workspace port browser opens, Feature Wall browser action, failed-delete "View changes" (Source Control panel), and Fix Checks (agent tab). The option is plumbed through `activateAndRevealWorkspace`/`activateAndRevealFolderWorkspace` so folder workspaces share the same contract.

### Why opt-out polarity (and not "activation never seeds")

This PR went through three review rounds because surface-providing callers were discovered one at a time. Two independent full call-site censuses (~48 worktree + 6 folder production sites) now agree: ~40 callers mean "reopen this workspace" and want seeding; 7 call sites provide their own surface; the rest target a validated existing tab and short-circuit on `renderableTabCount > 0` either way.

The polarity stays opt-out because the failure modes are asymmetric:

- `providesInitialSurface: true` reproduces **main's exact behavior** at a call site (a never-opened workspace still auto-creates; only the tombstone is honoured). A future surface caller that forgets the flag degrades to the stray-shell behavior main has always had for never-opened workspaces — visible immediately to whoever writes it.
- Inverting to opt-in would require migrating ~40 reopen callers, and a future reopen caller that forgot the flag would silently reproduce this exact blank-workspace bug, only for users who ever closed their last terminal.

What actually kept this from converging was not the polarity but that **nothing enforced the classification**: deleting every opt-out left the suite green. `worktree-activation-surface-caller-wiring.test.ts` now holds the census — it asserts each classified caller passes the flag *and* that no unclassified file mentions it, so adding or removing an opt-out anywhere under src/ forces a conscious update. The two callers reviewers found last round (failed-delete "View changes", Fix Checks) are fixed and behaviorally pinned in `delete-worktree-flow.test.ts` and `fix-checks-agent-launch.test.ts`.

## Verification

- Unit: 90 tests across the 10 affected vitest files (plus the extended e2e spec), including new folder-workspace opt-out coverage and mock-args assertions for the file-open, Fix Checks, View-changes, port-open, and annotation callers.
- E2E (`terminal-tab-close-restart-persistence.spec.ts`, extended): durable close → restart → tab bar stays empty (tombstone), then a real sidebar-row click re-seeds a fresh terminal (the original bug). Passed locally against the real app with real restarts.
- Live dev build (CDP): closed the last tab through the tab's close button (row became `[]`, workspace deactivated), clicked the sidebar row, and verified "Terminal 1" visibly remounted with a live shell.
- `typecheck`, `check:code-quality:changed`, `check:react-doctor:changed` all pass.

## Known pre-existing issues, out of scope (verified to reproduce on main without this PR)

- `getFolderWorkspaceConnectionId` is host-blind (`folder-workspace-connection.ts:68`): an SSH folder sharing an id with a local one gets a local PTY (reproduces with no row at all). This PR's re-seeding makes that path reachable one more way.
- Runtime-owned workspaces with a live web session seed via `ensureWebRuntimeWorktreeTerminalAfterWake` regardless of `providesInitialSurface` — the host owns terminal creation there; matches main, now called out in the option's JSDoc. Runtime-owned **folder** workspaces still open blank (the wake helper is never called for them).
- Activation before startup hydration loses the seeded tab (hydration installs `tabsByWorktree` wholesale).
- A direct-SSH snapshot merge can silently drop a not-yet-uploaded empty row (`remote-workspace-session-merge.ts`), losing the tombstone across reconnect.

## External review rounds

**Round 1 — three Codex CLI passes** (session headers reported `gpt-5.6-luna`; a bogus-model probe returned a 400 while this name was accepted, so the name is a real routable model — attribution beyond that is not corroborable from this repo). Lenses: seam-correctness adversarial, test-integrity, independent call-site census. Seam and census: no findings. Test-integrity found:

- **Fixed (P1):** `PortsPanel.test.tsx` had a stale assertion (`toHaveBeenCalledWith(worktreeId)` without the opt-out arg) that failed after the workspace-port caller change — reproduced, updated.
- **Hardened (P2):** census assertion bound to a real `activateAndReveal*` call; `Terminal.tsx` wiring test asserts exactly one `shouldAutoCreateInitialTerminal` call site; behavioral test added for `check-annotation-open.ts`.

**Round 2 — three more Codex CLI passes plus one Claude Opus pass** (fresh-eyes full diff, races/interleavings, user-flow semantics, holistic + honesty audit). Races and UX: no findings (both traced full call chains, including notification/CLI/deep-link/palette/delete-successor flows and remote-snapshot interleavings). Fresh-eyes reported four P1s; all four were **refuted on validation**: three were stale-base diff artifacts (commits that landed on main after this branch's merge-base misread as reverts — this PR touches only `src/renderer` and `tests/`), and the fourth (FeatureWall "no group after last-tab close") is contradicted by `tabs.ts` (the sole group survives a last-tab close) and is behavior-identical to main in any case. The Opus pass found **no correctness findings** and independently re-verified the call-site census (47 + 6 production sites, no missed surface caller), every claim in the seeding safety comment, and the commit messages. Its precision findings, applied here:

- PR-body test count corrected (was overstated as "97 unit tests").
- Census comment-stripping added, so commenting the flag out in place now fails the census (mutation-checked against `FeatureWallBrowserAction.tsx`, the one census-only-pinned caller); sweep widened from the renderer tree to all of `src/`.
- Merged a stacked pair of `// Why:` comments in `terminal-file-open-routing.ts`.
- Accepted limitation, restated precisely: the census forces conscious updates when flag usage changes anywhere under `src/`, but cannot detect a brand-new surface-opening caller that never mentions the flag; a string literal containing the flag text inside a call's argument list could also still satisfy it. The failure mode of a miss remains main's long-standing stray-shell behavior, not a new bug class.
