### PR TITLE
fix(terminal): keep a cold-parked pane's runtime-graph leaf while its PTY lives (STA-2854)

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-parked-pty-watcher.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-parked-pty-watcher.ts
@@ -34,14 +34,20 @@ export function startParkedPtyWatcher(args: {
   const state = useAppStore.getState()
   const ptyId = pane.ptyId
   // Why: the tab model can change after the park decision, and legacy leaf ids make pane keys throw.
+  // Why: the pane's primary exit handler is gone from unmount and this sidecar
+  // arrives a passive effect later, so an exit landing in between is buffered
+  // and replayed to nobody. Registering would pin a dead PTY as a live parked
+  // owner, and the runtime graph publishes its leaf on exactly that claim.
+  if (ptyId && !entry.disposersByPtyId.has(ptyId) && hasPreHandlerPtyExit(ptyId)) {
+    // Mirror handlePtyExit's first act: no live pane will ever overwrite this
+    // slot, so leaving it would strand a dead pane's last title (a 'working'
+    // agent title pins worktree status) until reveal or close.
+    state.clearRuntimePaneTitle(tab.id, pane.paneId)
+    return
+  }
   if (
     !ptyId ||
     entry.disposersByPtyId.has(ptyId) ||
-    // Why: the pane's primary exit handler is gone from unmount and this
-    // sidecar arrives a passive effect later, so an exit landing in between is
-    // buffered and replayed to nobody. Registering here would pin a dead PTY as
-    // a live parked owner, and the runtime graph would publish its leaf.
-    hasPreHandlerPtyExit(ptyId) ||
     !isTerminalLeafId(pane.leafId) ||
     !isParkRestorableTerminalPty(ptyId, worktreeId, restorePolicy)
   ) {

--- a/src/renderer/src/components/terminal-pane/terminal-parked-pty-watcher.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-parked-pty-watcher.ts
@@ -4,7 +4,7 @@ import { useAppStore } from '@/store'
 import { closeTerminalTab } from '../terminal/terminal-tab-actions'
 import { startParkedTerminalByteWatcher } from './parked-terminal-byte-watcher'
 import { subscribeToPtyExit } from './pty-dispatcher'
-import { discardPreHandlerPtyState } from './pty-pre-handler-buffer'
+import { discardPreHandlerPtyState, hasPreHandlerPtyExit } from './pty-pre-handler-buffer'
 import { detachTerminalLayoutLeaf } from './terminal-layout-leaf-detach'
 import {
   isParkRestorableTerminalPty,
@@ -37,6 +37,11 @@ export function startParkedPtyWatcher(args: {
   if (
     !ptyId ||
     entry.disposersByPtyId.has(ptyId) ||
+    // Why: the pane's primary exit handler is gone from unmount and this
+    // sidecar arrives a passive effect later, so an exit landing in between is
+    // buffered and replayed to nobody. Registering here would pin a dead PTY as
+    // a live parked owner, and the runtime graph would publish its leaf.
+    hasPreHandlerPtyExit(ptyId) ||
     !isTerminalLeafId(pane.leafId) ||
     !isParkRestorableTerminalPty(ptyId, worktreeId, restorePolicy)
   ) {

--- a/src/renderer/src/components/terminal-pane/terminal-parked-tab-watchers.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-parked-tab-watchers.test.ts
@@ -247,6 +247,9 @@ describe('terminal-parked-tab-watchers', () => {
 
     expect(startParkedTerminalByteWatcher).not.toHaveBeenCalled()
     expect(collectParkedTerminalWatcherPtyIds().has(PTY_ID)).toBe(false)
+    // No live pane will ever overwrite this slot again, so a stranded
+    // 'working' title would pin worktree status forever.
+    expect(mockStoreState.clearRuntimePaneTitle).toHaveBeenCalledWith(TAB_ID, 1)
   })
 
   it('starts a fact watcher for snapshot-capable paired PTYs', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-parked-tab-watchers.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-parked-tab-watchers.test.ts
@@ -48,8 +48,12 @@ vi.mock('./pty-dispatcher', () => ({
 
 const consumePreHandlerPtyState = vi.fn()
 vi.mock('./pty-pre-handler-buffer', () => ({
-  discardPreHandlerPtyState: (ptyId: string) => consumePreHandlerPtyState(ptyId)
+  discardPreHandlerPtyState: (ptyId: string) => consumePreHandlerPtyState(ptyId),
+  hasPreHandlerPtyExit: (ptyId: string) => unownedExitPtyIds.has(ptyId)
 }))
+
+/** PTYs whose exit was delivered with no owning handler — the park handoff gap. */
+const unownedExitPtyIds = new Set<string>()
 
 type CloseTerminalTabOptions = {
   captureRecentlyClosed?: boolean
@@ -110,6 +114,7 @@ import {
   captureParkedTerminalPaneCandidates,
   disposeParkedTerminalWatchersForPtyIds,
   disposeParkedTerminalWatchersForWorktree,
+  collectParkedTerminalWatcherPtyIds,
   getParkedTerminalWatcherTabIds,
   pruneParkedTerminalWatchers,
   shouldDeferParkedPtyExitTabClose,
@@ -164,6 +169,7 @@ describe('terminal-parked-tab-watchers', () => {
   })
 
   afterEach(() => {
+    unownedExitPtyIds.clear()
     // Module-level registries persist across tests; clear them through the
     // public prune path so each test starts from an empty parked state.
     pruneParkedTerminalWatchers(new Set())
@@ -227,6 +233,20 @@ describe('terminal-parked-tab-watchers', () => {
     // Why: the tab is still tracked as parked so debug introspection
     // (window.__terminalParkingDebug) reflects every parked tab.
     expect(getParkedTerminalWatcherTabIds()).toEqual([TAB_ID])
+  })
+
+  it('never starts a watcher for a PTY that exited into the park handoff gap', () => {
+    // The pane's primary exit handler is gone from unmount and this sidecar
+    // arrives a passive effect later, so an exit landing between them is
+    // buffered and replayed to nobody. Registering anyway would make the
+    // registry claim a dead PTY is a live parked owner, and the runtime graph
+    // publishes its leaf on exactly that claim (STA-2854).
+    unownedExitPtyIds.add(PTY_ID)
+    capturePanes([{ ptyId: PTY_ID, paneId: 1, leafId: LEAF_ID, drivesTabTitle: true }])
+    syncParked({ tabs: [{ id: TAB_ID, ptyId: PTY_ID }] })
+
+    expect(startParkedTerminalByteWatcher).not.toHaveBeenCalled()
+    expect(collectParkedTerminalWatcherPtyIds().has(PTY_ID)).toBe(false)
   })
 
   it('starts a fact watcher for snapshot-capable paired PTYs', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-parked-tab-watchers.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-parked-tab-watchers.ts
@@ -33,6 +33,7 @@ import {
 // Why: re-export so callers keep one import surface; the registry split only breaks the store-slice import cycle.
 export {
   captureParkedTerminalPaneCandidates,
+  collectParkedTerminalWatcherPtyIds,
   disposeAllParkedTerminalWatchers,
   disposeRemovedWorktreeParkedTerminalWatchers,
   disposeParkedTerminalWatchersForPtyIds,

--- a/src/renderer/src/components/terminal-pane/terminal-parked-watcher-registry.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-parked-watcher-registry.ts
@@ -105,15 +105,18 @@ export function collectParkedTerminalWatcherPtyIds(): Set<string> {
   return ptyIds
 }
 
-/** Pane ids the live pane used, by leaf, so a parked leaf publishes the
- *  identity main routes split/close/pane-key actions through instead of a
- *  fabricated ordinal. */
-export function getParkedTerminalPaneIdsByLeafId(tabId: string): Map<string, number> {
-  const paneIds = new Map<string, number>()
-  for (const pane of capturedPanesByTabId.get(tabId)?.panes ?? []) {
-    paneIds.set(pane.leafId, pane.paneId)
-  }
-  return paneIds
+/**
+ * Pane ids the parked watchers are actually using, by PTY.
+ *
+ * Read from the watcher entry rather than the unmount capture: a parked tab
+ * whose layout gains a leaf gets a watcher from the layout-derived fallback,
+ * which the capture never learns about. The entry covers both, so a parked leaf
+ * publishes the identity main routes split/close and the paneKey fallback
+ * through, and indexes the runtime-title slot the watcher writes — instead of a
+ * fabricated ordinal that can name a pane PaneManager already retired.
+ */
+export function getParkedTerminalWatcherPaneIdsByPtyId(tabId: string): Map<string, number> {
+  return new Map(parkedWatchersByTabId.get(tabId)?.paneIdByPtyId ?? [])
 }
 
 export function disposeParkedTabWatchers(tabId: string): void {

--- a/src/renderer/src/components/terminal-pane/terminal-parked-watcher-registry.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-parked-watcher-registry.ts
@@ -7,7 +7,7 @@
  * mid-evaluation. Keeping the maps and pure disposal here lets the slice
  * import cycle-free, mirroring how pty-dispatcher exports its handler maps.
  */
-import { discardPreHandlerPtyState } from './pty-pre-handler-buffer'
+import { discardPreHandlerPtyState, hasPreHandlerPtyExit } from './pty-pre-handler-buffer'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 
 export type ParkedTerminalPaneCapture = {
@@ -73,8 +73,21 @@ export function isTerminalTabParked(tabId: string): boolean {
  * teardown — so this is the renderer's proof that an unmounted pane's PTY is
  * still alive, which the runtime graph needs to keep publishing its leaf
  * (STA-2854: a dropped leaf orphans every paired subscriber of that terminal).
+ *
+ * Read `disposersByPtyId`, never `paneIdByPtyId`: exit and per-PTY disposal
+ * delete only the disposer and deliberately keep the pane-id slot so the dead
+ * leaf's runtime title can still be cleared.
+ *
+ * The unowned-exit guard closes the park handoff gap: the pane's primary exit
+ * handler is gone from unmount, and the watcher's sidecar is installed a
+ * passive-effect later, so an exit landing in between is buffered and replayed
+ * to nobody. Publishing on watcher presence alone would then advertise a dead
+ * PTY as a live leaf until reveal or close.
  */
 export function hasParkedTerminalWatcherForPty(ptyId: string): boolean {
+  if (hasPreHandlerPtyExit(ptyId)) {
+    return false
+  }
   for (const entry of parkedWatchersByTabId.values()) {
     if (entry.disposersByPtyId.has(ptyId)) {
       return true

--- a/src/renderer/src/components/terminal-pane/terminal-parked-watcher-registry.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-parked-watcher-registry.ts
@@ -8,6 +8,7 @@
  * import cycle-free, mirroring how pty-dispatcher exports its handler maps.
  */
 import { discardPreHandlerPtyState, hasPreHandlerPtyExit } from './pty-pre-handler-buffer'
+import { parseRemoteRuntimePtyId } from '../../../../shared/remote-runtime-pty-id'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 
 export type ParkedTerminalPaneCapture = {
@@ -68,32 +69,51 @@ export function isTerminalTabParked(tabId: string): boolean {
 }
 
 /**
- * Whether a live parked watcher is observing this PTY. Watchers start when a
- * pane parks and are disposed on reveal, tab close, PTY exit, and worktree
- * teardown — so this is the renderer's proof that an unmounted pane's PTY is
- * still alive, which the runtime graph needs to keep publishing its leaf
- * (STA-2854: a dropped leaf orphans every paired subscriber of that terminal).
+ * PTYs a live parked watcher owns, and can therefore prove are still alive.
+ * The runtime graph needs this to keep publishing an unmounted pane's leaf
+ * (STA-2854: a dropped leaf invalidates the terminal handle every paired
+ * subscriber of that terminal is bound to).
  *
- * Read `disposersByPtyId`, never `paneIdByPtyId`: exit and per-PTY disposal
+ * Built in one pass and reused for a whole publication: the caller checks it
+ * once per saved leaf across every tab of every worktree, so a per-PTY scan of
+ * the registry would be quadratic in a large workspace. Parked tabs are NOT
+ * bounded by the hot-retain limits — those bound what stays warm, not what
+ * parks — so this can legitimately hold thousands of entries.
+ *
+ * Reads `disposersByPtyId`, never `paneIdByPtyId`: exit and per-PTY disposal
  * delete only the disposer and deliberately keep the pane-id slot so the dead
  * leaf's runtime title can still be cleared.
  *
- * The unowned-exit guard closes the park handoff gap: the pane's primary exit
- * handler is gone from unmount, and the watcher's sidecar is installed a
- * passive-effect later, so an exit landing in between is buffered and replayed
- * to nobody. Publishing on watcher presence alone would then advertise a dead
- * PTY as a live leaf until reveal or close.
+ * Excludes remote-runtime PTYs (detected through the store-free shared id
+ * module — this file must stay importable from a store slice). startParkedPtyWatcher installs no PTY-exit
+ * subscription for them, and the parked fact stream carries no exit fact, so
+ * their disposer outlives the terminal and proves nothing about liveness.
+ *
+ * Also excludes a PTY holding an unowned buffered exit. startParkedPtyWatcher
+ * refuses to register one, so this only catches an exit that raced an existing
+ * registration; keeping the check here costs one lookup per watched PTY.
  */
-export function hasParkedTerminalWatcherForPty(ptyId: string): boolean {
-  if (hasPreHandlerPtyExit(ptyId)) {
-    return false
-  }
+export function collectParkedTerminalWatcherPtyIds(): Set<string> {
+  const ptyIds = new Set<string>()
   for (const entry of parkedWatchersByTabId.values()) {
-    if (entry.disposersByPtyId.has(ptyId)) {
-      return true
+    for (const ptyId of entry.disposersByPtyId.keys()) {
+      if (parseRemoteRuntimePtyId(ptyId) === null && !hasPreHandlerPtyExit(ptyId)) {
+        ptyIds.add(ptyId)
+      }
     }
   }
-  return false
+  return ptyIds
+}
+
+/** Pane ids the live pane used, by leaf, so a parked leaf publishes the
+ *  identity main routes split/close/pane-key actions through instead of a
+ *  fabricated ordinal. */
+export function getParkedTerminalPaneIdsByLeafId(tabId: string): Map<string, number> {
+  const paneIds = new Map<string, number>()
+  for (const pane of capturedPanesByTabId.get(tabId)?.panes ?? []) {
+    paneIds.set(pane.leafId, pane.paneId)
+  }
+  return paneIds
 }
 
 export function disposeParkedTabWatchers(tabId: string): void {

--- a/src/renderer/src/components/terminal-pane/terminal-parked-watcher-registry.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-parked-watcher-registry.ts
@@ -67,6 +67,22 @@ export function isTerminalTabParked(tabId: string): boolean {
   return (parkedWatchersByTabId.get(tabId)?.disposersByPtyId.size ?? 0) > 0
 }
 
+/**
+ * Whether a live parked watcher is observing this PTY. Watchers start when a
+ * pane parks and are disposed on reveal, tab close, PTY exit, and worktree
+ * teardown — so this is the renderer's proof that an unmounted pane's PTY is
+ * still alive, which the runtime graph needs to keep publishing its leaf
+ * (STA-2854: a dropped leaf orphans every paired subscriber of that terminal).
+ */
+export function hasParkedTerminalWatcherForPty(ptyId: string): boolean {
+  for (const entry of parkedWatchersByTabId.values()) {
+    if (entry.disposersByPtyId.has(ptyId)) {
+      return true
+    }
+  }
+  return false
+}
+
 export function disposeParkedTabWatchers(tabId: string): void {
   const entry = parkedWatchersByTabId.get(tabId)
   if (!entry) {

--- a/src/renderer/src/runtime/sync-runtime-graph-parked-leaf.test.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph-parked-leaf.test.ts
@@ -25,10 +25,7 @@ import {
   bufferPreHandlerPtyExit,
   clearPreHandlerPtyState
 } from '@/components/terminal-pane/pty-pre-handler-buffer'
-import {
-  capturedPanesByTabId,
-  parkedWatchersByTabId
-} from '@/components/terminal-pane/terminal-parked-watcher-registry'
+import { parkedWatchersByTabId } from '@/components/terminal-pane/terminal-parked-watcher-registry'
 import { setRuntimeGraphStoreStateGetter, setRuntimeGraphSyncEnabled } from './sync-runtime-graph'
 
 const LEAF = '22222222-2222-4222-8222-222222222222'
@@ -95,11 +92,11 @@ function parkedState(
 }
 
 /** Installs the exact registry state the park wiring leaves behind on unmount. */
-function installParkedWatcher(ptyId: string): void {
+function installParkedWatcher(ptyId: string, paneId = 1): void {
   parkedWatchersByTabId.set(TAB_ID, {
     worktreeId: 'wt-1',
     tabPtyId: ptyId,
-    paneIdByPtyId: new Map([[ptyId, 1]]),
+    paneIdByPtyId: new Map([[ptyId, paneId]]),
     disposersByPtyId: new Map([[ptyId, () => {}]])
   })
 }
@@ -113,7 +110,6 @@ afterEach(() => {
   setRuntimeGraphSyncEnabled(false)
   setRuntimeGraphStoreStateGetter(null)
   parkedWatchersByTabId.clear()
-  capturedPanesByTabId.clear()
   clearPreHandlerPtyState(PARKED_PTY)
   vi.mocked(getEagerPtyBufferHandle).mockReturnValue(undefined)
   vi.useRealTimers()
@@ -216,19 +212,34 @@ describe('syncRuntimeGraph cold-parked tabs', () => {
     expect(graph.leaves).not.toContainEqual(expect.objectContaining({ tabId: TAB_ID }))
   })
 
-  it('publishes the pane id the live pane used, not a positional ordinal', async () => {
+  it('publishes the pane id the watcher uses, not a positional ordinal', async () => {
     // PaneManager retires a closed pane's id without renumbering, and main
-    // routes split/close and the paneKey fallback through this value.
-    installParkedWatcher(PARKED_PTY)
-    capturedPanesByTabId.set(TAB_ID, {
-      worktreeId: 'wt-1',
-      panes: [{ ptyId: PARKED_PTY, paneId: 7, leafId: LEAF, drivesTabTitle: true }]
-    })
+    // routes split/close and the paneKey fallback through this value. Sourced
+    // from the watcher entry, so a leaf the unmount capture never saw — one the
+    // layout gained while parked — is still named correctly.
+    installParkedWatcher(PARKED_PTY, 7)
 
     const graph = await captureGraph()
 
     expect(graph.leaves).toContainEqual(
       expect.objectContaining({ tabId: TAB_ID, leafId: LEAF, paneRuntimeId: 7 })
+    )
+  })
+
+  it("publishes the parked pane's runtime title instead of discarding it", async () => {
+    // The parked byte watcher keeps writing this slot and main prefers
+    // leaf.paneTitle over its own older lastOscTitle, so publishing null pins a
+    // parked agent pane to a stale title for as long as it stays parked.
+    installParkedWatcher(PARKED_PTY, 7)
+    setRuntimeGraphStoreStateGetter(() => ({
+      ...parkedState(),
+      runtimePaneTitlesByTabId: { [TAB_ID]: { 7: 'codex [working]' } }
+    }))
+
+    const graph = await captureGraph({ seedState: false })
+
+    expect(graph.leaves).toContainEqual(
+      expect.objectContaining({ leafId: LEAF, paneTitle: 'codex [working]' })
     )
   })
 

--- a/src/renderer/src/runtime/sync-runtime-graph-parked-leaf.test.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph-parked-leaf.test.ts
@@ -25,7 +25,10 @@ import {
   bufferPreHandlerPtyExit,
   clearPreHandlerPtyState
 } from '@/components/terminal-pane/pty-pre-handler-buffer'
-import { parkedWatchersByTabId } from '@/components/terminal-pane/terminal-parked-watcher-registry'
+import {
+  capturedPanesByTabId,
+  parkedWatchersByTabId
+} from '@/components/terminal-pane/terminal-parked-watcher-registry'
 import { setRuntimeGraphStoreStateGetter, setRuntimeGraphSyncEnabled } from './sync-runtime-graph'
 
 const LEAF = '22222222-2222-4222-8222-222222222222'
@@ -64,17 +67,30 @@ function parkedTab(): TerminalTab {
   } as TerminalTab
 }
 
-function parkedState(): AppState {
+function parkedState(
+  ptyIdsByLeafId: Record<string, string> = { [LEAF]: PARKED_PTY },
+  activeLeafId: string = LEAF
+): AppState {
+  const leafIds = Object.keys(ptyIdsByLeafId)
+  const root = leafIds.slice(1).reduce<Record<string, unknown>>(
+    (first, leafId) => ({
+      type: 'split',
+      direction: 'horizontal',
+      first,
+      second: { type: 'leaf', leafId }
+    }),
+    { type: 'leaf', leafId: leafIds[0] }
+  )
   return makeState({
     tabsByWorktree: { 'wt-1': [parkedTab()] } as AppState['tabsByWorktree'],
     terminalLayoutsByTabId: {
       [TAB_ID]: {
-        root: { type: 'leaf', leafId: LEAF },
-        activeLeafId: LEAF,
+        root,
+        activeLeafId,
         expandedLeafId: null,
-        ptyIdsByLeafId: { [LEAF]: PARKED_PTY }
+        ptyIdsByLeafId
       }
-    } as AppState['terminalLayoutsByTabId']
+    } as unknown as AppState['terminalLayoutsByTabId']
   })
 }
 
@@ -97,18 +113,25 @@ afterEach(() => {
   setRuntimeGraphSyncEnabled(false)
   setRuntimeGraphStoreStateGetter(null)
   parkedWatchersByTabId.clear()
+  capturedPanesByTabId.clear()
   clearPreHandlerPtyState(PARKED_PTY)
   vi.mocked(getEagerPtyBufferHandle).mockReturnValue(undefined)
   vi.useRealTimers()
   vi.unstubAllGlobals()
 })
 
-async function captureGraph(): Promise<RuntimeSyncWindowGraph> {
+async function captureGraph(
+  options: { seedState?: boolean } = {}
+): Promise<RuntimeSyncWindowGraph> {
   vi.useFakeTimers()
   const syncWindowGraph = vi.fn().mockResolvedValue(undefined)
   vi.stubGlobal('window', { api: { runtime: { syncWindowGraph } } })
   vi.stubGlobal('HTMLElement', class HTMLElement {})
-  setRuntimeGraphStoreStateGetter(() => parkedState())
+  // Why opt-out: a case that needs a non-default layout installs its own getter
+  // before calling in, and must not have it overwritten here.
+  if (options.seedState !== false) {
+    setRuntimeGraphStoreStateGetter(() => parkedState())
+  }
   setRuntimeGraphSyncEnabled(true)
   await vi.advanceTimersByTimeAsync(20)
   await flushMicrotasks()
@@ -173,5 +196,57 @@ describe('syncRuntimeGraph cold-parked tabs', () => {
     const graph = await captureGraph()
 
     expect(graph.leaves).not.toContainEqual(expect.objectContaining({ tabId: TAB_ID }))
+  })
+
+  it('excludes a remote-runtime PTY, whose parked watcher never sees an exit', async () => {
+    // startParkedPtyWatcher installs no exit subscription for remote: PTYs and
+    // the parked fact stream carries no exit fact, so a surviving disposer is
+    // not evidence the remote terminal is still alive.
+    const remotePtyId = 'remote:env-1@@term_remote'
+    parkedWatchersByTabId.set(TAB_ID, {
+      worktreeId: 'wt-1',
+      tabPtyId: remotePtyId,
+      paneIdByPtyId: new Map([[remotePtyId, 1]]),
+      disposersByPtyId: new Map([[remotePtyId, () => {}]])
+    })
+    setRuntimeGraphStoreStateGetter(() => parkedState({ [LEAF]: remotePtyId }))
+
+    const graph = await captureGraph({ seedState: false })
+
+    expect(graph.leaves).not.toContainEqual(expect.objectContaining({ tabId: TAB_ID }))
+  })
+
+  it('publishes the pane id the live pane used, not a positional ordinal', async () => {
+    // PaneManager retires a closed pane's id without renumbering, and main
+    // routes split/close and the paneKey fallback through this value.
+    installParkedWatcher(PARKED_PTY)
+    capturedPanesByTabId.set(TAB_ID, {
+      worktreeId: 'wt-1',
+      panes: [{ ptyId: PARKED_PTY, paneId: 7, leafId: LEAF, drivesTabTitle: true }]
+    })
+
+    const graph = await captureGraph()
+
+    expect(graph.leaves).toContainEqual(
+      expect.objectContaining({ tabId: TAB_ID, leafId: LEAF, paneRuntimeId: 7 })
+    )
+  })
+
+  it('does not name an active leaf this publication is not sending', async () => {
+    // Partial coverage is legitimate: one leaf's watcher can be disposed while a
+    // sibling stays parked, and the saved activeLeafId may be the dropped one.
+    const otherLeaf = '33333333-3333-4333-8333-333333333333'
+    const otherPty = 'wt-1::/tmp/wt@@other-parked-pty'
+    installParkedWatcher(PARKED_PTY)
+    setRuntimeGraphStoreStateGetter(() =>
+      parkedState({ [LEAF]: PARKED_PTY, [otherLeaf]: otherPty }, otherLeaf)
+    )
+
+    const graph = await captureGraph({ seedState: false })
+
+    expect(graph.tabs).toContainEqual(
+      expect.objectContaining({ tabId: TAB_ID, activeLeafId: LEAF })
+    )
+    expect(graph.leaves).not.toContainEqual(expect.objectContaining({ leafId: otherLeaf }))
   })
 })

--- a/src/renderer/src/runtime/sync-runtime-graph-parked-leaf.test.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph-parked-leaf.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Cold-parked tabs keep their runtime-graph leaf while their PTY is alive.
+ *
+ * Why this matters beyond the host UI (STA-2854): the graph leaf is what mints
+ * the terminal handle a paired client's stream is bound to. Publishing only
+ * mounted panes meant a host that merely stopped *displaying* a terminal
+ * invalidated that handle, stalling a remote viewer who was actively driving it.
+ *
+ * The liveness proof is the parked watcher, which the park wiring starts on
+ * unmount and disposes on reveal, tab close, PTY exit, and worktree teardown —
+ * so a dead terminal still drops out of the graph.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { RuntimeSyncWindowGraph } from '../../../shared/runtime-types'
+import type { AppState } from '../store/types'
+import type { TerminalTab } from '../../../shared/terminal-tab-types'
+
+vi.mock('@/components/terminal-pane/pty-dispatcher', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return { ...actual, getEagerPtyBufferHandle: vi.fn(() => undefined) }
+})
+
+import { getEagerPtyBufferHandle } from '@/components/terminal-pane/pty-dispatcher'
+import { parkedWatchersByTabId } from '@/components/terminal-pane/terminal-parked-watcher-registry'
+import { setRuntimeGraphStoreStateGetter, setRuntimeGraphSyncEnabled } from './sync-runtime-graph'
+
+const LEAF = '22222222-2222-4222-8222-222222222222'
+const PARKED_PTY = 'wt-1::/tmp/wt@@parked-pty'
+const TAB_ID = 'parked-tab-1'
+
+function makeState(overrides: Partial<AppState> = {}): AppState {
+  return {
+    tabsByWorktree: {},
+    terminalLayoutsByTabId: {} as AppState['terminalLayoutsByTabId'],
+    runtimePaneTitlesByTabId: {} as AppState['runtimePaneTitlesByTabId'],
+    groupsByWorktree: {},
+    activeGroupIdByWorktree: {},
+    layoutByWorktree: {},
+    unifiedTabsByWorktree: {},
+    tabBarOrderByWorktree: {},
+    activeFileId: null,
+    activeFileIdByWorktree: {},
+    openFiles: [],
+    editorDrafts: {},
+    activeTabId: null,
+    ...overrides
+  } as AppState
+}
+
+function parkedTab(): TerminalTab {
+  return {
+    id: TAB_ID,
+    ptyId: PARKED_PTY,
+    worktreeId: 'wt-1',
+    title: 'agent',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1
+  } as TerminalTab
+}
+
+function parkedState(): AppState {
+  return makeState({
+    tabsByWorktree: { 'wt-1': [parkedTab()] } as AppState['tabsByWorktree'],
+    terminalLayoutsByTabId: {
+      [TAB_ID]: {
+        root: { type: 'leaf', leafId: LEAF },
+        activeLeafId: LEAF,
+        expandedLeafId: null,
+        ptyIdsByLeafId: { [LEAF]: PARKED_PTY }
+      }
+    } as AppState['terminalLayoutsByTabId']
+  })
+}
+
+/** Installs the exact registry state the park wiring leaves behind on unmount. */
+function installParkedWatcher(ptyId: string): void {
+  parkedWatchersByTabId.set(TAB_ID, {
+    worktreeId: 'wt-1',
+    tabPtyId: ptyId,
+    paneIdByPtyId: new Map([[ptyId, 1]]),
+    disposersByPtyId: new Map([[ptyId, () => {}]])
+  })
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+afterEach(() => {
+  setRuntimeGraphSyncEnabled(false)
+  setRuntimeGraphStoreStateGetter(null)
+  parkedWatchersByTabId.clear()
+  vi.mocked(getEagerPtyBufferHandle).mockReturnValue(undefined)
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+})
+
+async function captureGraph(): Promise<RuntimeSyncWindowGraph> {
+  vi.useFakeTimers()
+  const syncWindowGraph = vi.fn().mockResolvedValue(undefined)
+  vi.stubGlobal('window', { api: { runtime: { syncWindowGraph } } })
+  vi.stubGlobal('HTMLElement', class HTMLElement {})
+  setRuntimeGraphStoreStateGetter(() => parkedState())
+  setRuntimeGraphSyncEnabled(true)
+  await vi.advanceTimersByTimeAsync(20)
+  await flushMicrotasks()
+  expect(syncWindowGraph).toHaveBeenCalledTimes(1)
+  return syncWindowGraph.mock.calls[0]?.[0] as RuntimeSyncWindowGraph
+}
+
+describe('syncRuntimeGraph cold-parked tabs', () => {
+  it('publishes a parked tab leaf while a parked watcher still owns its PTY', async () => {
+    installParkedWatcher(PARKED_PTY)
+
+    const graph = await captureGraph()
+
+    expect(graph.leaves).toContainEqual(
+      expect.objectContaining({ tabId: TAB_ID, leafId: LEAF, ptyId: PARKED_PTY })
+    )
+    expect(graph.tabs).toContainEqual(expect.objectContaining({ tabId: TAB_ID }))
+  })
+
+  it('drops the leaf once the watcher is disposed (reveal, close, PTY exit, teardown)', async () => {
+    const graph = await captureGraph()
+
+    expect(graph.leaves).not.toContainEqual(expect.objectContaining({ tabId: TAB_ID }))
+    expect(graph.tabs).not.toContainEqual(expect.objectContaining({ tabId: TAB_ID }))
+  })
+
+  it('does not publish a stale saved PTY that no watcher owns', async () => {
+    // The tab is parked, but the layout binding points at a PTY the park wiring
+    // never watched — ptyIdsByLeafId is merged and never pruned, so a stale
+    // binding must not resurrect a leaf.
+    installParkedWatcher('wt-1::/tmp/wt@@some-other-pty')
+
+    const graph = await captureGraph()
+
+    expect(graph.leaves).not.toContainEqual(expect.objectContaining({ tabId: TAB_ID }))
+  })
+})

--- a/src/renderer/src/runtime/sync-runtime-graph-parked-leaf.test.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph-parked-leaf.test.ts
@@ -21,6 +21,10 @@ vi.mock('@/components/terminal-pane/pty-dispatcher', async (importOriginal) => {
 })
 
 import { getEagerPtyBufferHandle } from '@/components/terminal-pane/pty-dispatcher'
+import {
+  bufferPreHandlerPtyExit,
+  clearPreHandlerPtyState
+} from '@/components/terminal-pane/pty-pre-handler-buffer'
 import { parkedWatchersByTabId } from '@/components/terminal-pane/terminal-parked-watcher-registry'
 import { setRuntimeGraphStoreStateGetter, setRuntimeGraphSyncEnabled } from './sync-runtime-graph'
 
@@ -93,6 +97,7 @@ afterEach(() => {
   setRuntimeGraphSyncEnabled(false)
   setRuntimeGraphStoreStateGetter(null)
   parkedWatchersByTabId.clear()
+  clearPreHandlerPtyState(PARKED_PTY)
   vi.mocked(getEagerPtyBufferHandle).mockReturnValue(undefined)
   vi.useRealTimers()
   vi.unstubAllGlobals()
@@ -128,6 +133,35 @@ describe('syncRuntimeGraph cold-parked tabs', () => {
 
     expect(graph.leaves).not.toContainEqual(expect.objectContaining({ tabId: TAB_ID }))
     expect(graph.tabs).not.toContainEqual(expect.objectContaining({ tabId: TAB_ID }))
+  })
+
+  // Why these two cases exist: `paneIdByPtyId` and `tabPtyId` both survive the
+  // states below, so a predicate reading either one would pass every other test
+  // here while publishing a dead terminal.
+  it('drops the leaf when per-PTY disposal leaves only the pane-id slot behind', async () => {
+    // Exactly what handlePtyExit and disposeParkedTerminalWatchersForPtyIds
+    // leave: the disposer is gone, the pane-id slot and tabPtyId remain.
+    parkedWatchersByTabId.set(TAB_ID, {
+      worktreeId: 'wt-1',
+      tabPtyId: PARKED_PTY,
+      paneIdByPtyId: new Map([[PARKED_PTY, 1]]),
+      disposersByPtyId: new Map()
+    })
+
+    const graph = await captureGraph()
+
+    expect(graph.leaves).not.toContainEqual(expect.objectContaining({ tabId: TAB_ID }))
+  })
+
+  it('drops the leaf when the PTY exited into the park handoff gap', async () => {
+    // The watcher entry looks live, but the exit arrived while no handler owned
+    // the PTY, so it was buffered and the watcher's sidecar never saw it.
+    installParkedWatcher(PARKED_PTY)
+    bufferPreHandlerPtyExit(PARKED_PTY, 0)
+
+    const graph = await captureGraph()
+
+    expect(graph.leaves).not.toContainEqual(expect.objectContaining({ tabId: TAB_ID }))
   })
 
   it('does not publish a stale saved PTY that no watcher owns', async () => {

--- a/src/renderer/src/runtime/sync-runtime-graph.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph.ts
@@ -6,7 +6,10 @@ import {
 } from '@/components/terminal-pane/layout-serialization'
 import { warnTerminalLifecycleAnomaly } from '@/components/terminal-pane/terminal-lifecycle-diagnostics'
 import { getEagerPtyBufferHandle } from '@/components/terminal-pane/pty-dispatcher'
-import { hasParkedTerminalWatcherForPty } from '@/components/terminal-pane/terminal-parked-watcher-registry'
+import {
+  collectParkedTerminalWatcherPtyIds,
+  getParkedTerminalPaneIdsByLeafId
+} from '@/components/terminal-pane/terminal-parked-watcher-registry'
 import { createBrowserUuid } from '@/lib/browser-uuid'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import { resolveLeafIdForManager } from '@/lib/pane-manager/pane-key-resolution'
@@ -797,6 +800,9 @@ async function syncRuntimeGraph(): Promise<void> {
   // pane is unmounted but a parked watcher still owns the PTY. Dropping their
   // leaf invalidates the terminal handle every paired subscriber is bound to,
   // stalling a remotely-driven terminal the host merely stopped displaying.
+  // Built once for the whole publication; a per-leaf registry scan would be
+  // quadratic across a many-worktree workspace.
+  const parkedWatcherPtyIds = collectParkedTerminalWatcherPtyIds()
   for (const [worktreeId, tabs] of Object.entries(state.tabsByWorktree)) {
     for (const tab of tabs) {
       const layout = state.terminalLayoutsByTabId[tab.id]
@@ -812,17 +818,26 @@ async function syncRuntimeGraph(): Promise<void> {
           typeof ptyId === 'string' &&
           ptyId.length > 0 &&
           isTerminalLeafId(leafId) &&
-          (Boolean(getEagerPtyBufferHandle(ptyId)) || hasParkedTerminalWatcherForPty(ptyId))
+          (Boolean(getEagerPtyBufferHandle(ptyId)) || parkedWatcherPtyIds.has(ptyId))
       )
       if (liveLeaves.length === 0) {
         continue
       }
       const title = resolveRuntimeTerminalTitle(tab, generatedTitlesEnabled)
+      // Why: partial coverage is legitimate — one leaf's watcher can be disposed
+      // while its siblings stay parked — so a saved activeLeafId that did not
+      // survive the filter would name a leaf this publication never sends.
+      const publishedLeafIds = new Set(liveLeaves.map(([leafId]) => leafId))
+      const savedActiveLeafId = layout?.activeLeafId
+      const parkedPaneIdsByLeafId = getParkedTerminalPaneIdsByLeafId(tab.id)
       graph.tabs.push({
         tabId: tab.id,
         worktreeId,
         title,
-        activeLeafId: layout?.activeLeafId ?? liveLeaves[0][0],
+        activeLeafId:
+          savedActiveLeafId && publishedLeafIds.has(savedActiveLeafId)
+            ? savedActiveLeafId
+            : liveLeaves[0][0],
         layout: resolveTerminalLayoutRoot({
           authoritativeRoot: layout?.root,
           leafIds: liveLeaves.map(([leafId]) => leafId),
@@ -837,7 +852,11 @@ async function syncRuntimeGraph(): Promise<void> {
           tabId: tab.id,
           worktreeId,
           leafId,
-          paneRuntimeId: index + 1,
+          // Why the capture wins: PaneManager ids are allocated monotonically and
+          // closing a pane retires its id without renumbering, so an ordinal can
+          // name a pane that no longer exists — and main routes split/close and
+          // the paneKey fallback through this value.
+          paneRuntimeId: parkedPaneIdsByLeafId.get(leafId) ?? index + 1,
           ptyId,
           paneTitle: null,
           title

--- a/src/renderer/src/runtime/sync-runtime-graph.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph.ts
@@ -8,7 +8,7 @@ import { warnTerminalLifecycleAnomaly } from '@/components/terminal-pane/termina
 import { getEagerPtyBufferHandle } from '@/components/terminal-pane/pty-dispatcher'
 import {
   collectParkedTerminalWatcherPtyIds,
-  getParkedTerminalPaneIdsByLeafId
+  getParkedTerminalWatcherPaneIdsByPtyId
 } from '@/components/terminal-pane/terminal-parked-watcher-registry'
 import { createBrowserUuid } from '@/lib/browser-uuid'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
@@ -829,7 +829,8 @@ async function syncRuntimeGraph(): Promise<void> {
       // survive the filter would name a leaf this publication never sends.
       const publishedLeafIds = new Set(liveLeaves.map(([leafId]) => leafId))
       const savedActiveLeafId = layout?.activeLeafId
-      const parkedPaneIdsByLeafId = getParkedTerminalPaneIdsByLeafId(tab.id)
+      const parkedPaneIdsByPtyId = getParkedTerminalWatcherPaneIdsByPtyId(tab.id)
+      const parkedPaneTitles = state.runtimePaneTitlesByTabId[tab.id] ?? {}
       graph.tabs.push({
         tabId: tab.id,
         worktreeId,
@@ -848,17 +849,22 @@ async function syncRuntimeGraph(): Promise<void> {
         })
       })
       liveLeaves.forEach(([leafId, ptyId], index) => {
+        // Why the watcher's id wins: PaneManager ids are allocated monotonically
+        // and closing a pane retires its id without renumbering, so an ordinal
+        // can name a pane that no longer exists — and main routes split/close and
+        // the paneKey fallback through this value.
+        const parkedPaneId = parkedPaneIdsByPtyId.get(ptyId)
         graph.leaves.push({
           tabId: tab.id,
           worktreeId,
           leafId,
-          // Why the capture wins: PaneManager ids are allocated monotonically and
-          // closing a pane retires its id without renumbering, so an ordinal can
-          // name a pane that no longer exists — and main routes split/close and
-          // the paneKey fallback through this value.
-          paneRuntimeId: parkedPaneIdsByLeafId.get(leafId) ?? index + 1,
+          paneRuntimeId: parkedPaneId ?? index + 1,
           ptyId,
-          paneTitle: null,
+          // Why not null: the parked byte watcher keeps writing this pane's
+          // runtime title, and main prefers leaf.paneTitle over its own older
+          // lastOscTitle. Dropping it would pin a parked agent pane to a stale
+          // title for as long as it stays parked.
+          paneTitle: (parkedPaneId === undefined ? null : parkedPaneTitles[parkedPaneId]) ?? null,
           title
         })
       })

--- a/src/renderer/src/runtime/sync-runtime-graph.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph.ts
@@ -6,6 +6,7 @@ import {
 } from '@/components/terminal-pane/layout-serialization'
 import { warnTerminalLifecycleAnomaly } from '@/components/terminal-pane/terminal-lifecycle-diagnostics'
 import { getEagerPtyBufferHandle } from '@/components/terminal-pane/pty-dispatcher'
+import { hasParkedTerminalWatcherForPty } from '@/components/terminal-pane/terminal-parked-watcher-registry'
 import { createBrowserUuid } from '@/lib/browser-uuid'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import { resolveLeafIdForManager } from '@/lib/pane-manager/pane-key-resolution'
@@ -792,6 +793,10 @@ async function syncRuntimeGraph(): Promise<void> {
   }
 
   // Why: inactive automation tabs never mount a TerminalPane; publish their leaf+ptyId from persisted layout (gated on a live buffer) or the live PTY looks orphaned.
+  // Cold-parked tabs are the same shape with a different liveness proof: their
+  // pane is unmounted but a parked watcher still owns the PTY. Dropping their
+  // leaf invalidates the terminal handle every paired subscriber is bound to,
+  // stalling a remotely-driven terminal the host merely stopped displaying.
   for (const [worktreeId, tabs] of Object.entries(state.tabsByWorktree)) {
     for (const tab of tabs) {
       const layout = state.terminalLayoutsByTabId[tab.id]
@@ -807,7 +812,7 @@ async function syncRuntimeGraph(): Promise<void> {
           typeof ptyId === 'string' &&
           ptyId.length > 0 &&
           isTerminalLeafId(leafId) &&
-          Boolean(getEagerPtyBufferHandle(ptyId))
+          (Boolean(getEagerPtyBufferHandle(ptyId)) || hasParkedTerminalWatcherForPty(ptyId))
       )
       if (liveLeaves.length === 0) {
         continue

--- a/tests/e2e/host-cold-park-remote-subscriber.unit.test.ts
+++ b/tests/e2e/host-cold-park-remote-subscriber.unit.test.ts
@@ -1,0 +1,494 @@
+/**
+ * STA-2854 validation oracle (validation-only; no product change).
+ *
+ * Report: a host's renderer cold-parking policy ignores remote subscribers, so
+ * a pane a paired client is actively viewing is unmounted 30s after it goes
+ * locally hidden; reconnect remounts it without resetting the hidden clock, so
+ * it re-parks immediately and the client never recovers.
+ *
+ * The report is two separable claims, so this file asserts them separately:
+ *
+ *   A. RENDERER POLICY — does host-local cold parking still ignore an active
+ *      remote subscriber, and does a background (remote-subscribe-driven)
+ *      mount still inherit a stale hidden clock?
+ *   B. AUTHORITATIVE STREAM — does a parked host pane actually destroy the
+ *      remote subscriber's stream, its input path, or its reconnect?
+ *
+ * B is modelled at the strictest possible park: a runtime with NO authoritative
+ * window at all. That is strictly more unmounted than a cold-parked pane, so a
+ * green B proves renderer parking cannot be the boundary that breaks the stream.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import { OrcaRuntimeService } from '../../src/main/runtime/orca-runtime'
+import { RpcDispatcher } from '../../src/main/runtime/rpc/dispatcher'
+import type { RpcRequest } from '../../src/main/runtime/rpc/core'
+import { TERMINAL_METHODS } from '../../src/main/runtime/rpc/methods/terminal'
+import {
+  TerminalStreamOpcode,
+  decodeTerminalStreamFrame,
+  decodeTerminalStreamText,
+  encodeTerminalStreamFrame,
+  encodeTerminalStreamJson,
+  encodeTerminalStreamText
+} from '../../src/shared/terminal-stream-protocol'
+import {
+  TERMINAL_TAB_COLD_PARK_DELAY_MS,
+  TERMINAL_TAB_HOT_RETAIN_LIMIT,
+  canParkTerminalTabRenderer,
+  selectColdParkedTerminalTabs
+} from '../../src/renderer/src/components/terminal-pane/terminal-hidden-view-parking'
+import { buildTerminalTabColdParkCandidates } from '../../src/renderer/src/components/terminal-pane/terminal-tab-park-candidates'
+import { createTerminalTabActivationOrder } from '../../src/renderer/src/components/terminal-pane/terminal-tab-activation-order'
+import type { TerminalTab } from '../../src/shared/terminal-tab-types'
+
+const WORKTREE_ID = 'repo-1::/tmp/wt'
+/** Host-owned, snapshot-backed local daemon PTY: the exact shape the report's
+ *  host had (a local pane a paired client was watching). */
+const ptyIdFor = (n: number): string => `${WORKTREE_ID}@@aaaaaaa${n}`
+const SUBSCRIBED_TAB_ID = 'tab-remote-viewed'
+const MARKER_BEFORE_PARK = 'STA2854-BEFORE-PARK'
+const MARKER_AFTER_PARK = 'STA2854-AFTER-PARK'
+const MARKER_AFTER_RECONNECT = 'STA2854-AFTER-RECONNECT'
+const CLIENT_INPUT = 'echo STA2854-INPUT\r'
+
+// ---------------------------------------------------------------------------
+// A. Host renderer cold-park policy (pure, explicit clock — no timers)
+// ---------------------------------------------------------------------------
+
+function tabModel(id: string, ptyId: string): TerminalTab {
+  return { id, ptyId, generation: 1 } as unknown as TerminalTab
+}
+
+/** The report's topology, shrunk to the smallest set that still evicts:
+ *  hot-retain limit + 1 hidden host tabs, one of them remotely subscribed. */
+function hiddenHostTabs(): TerminalTab[] {
+  const tabs: TerminalTab[] = [tabModel(SUBSCRIBED_TAB_ID, ptyIdFor(0))]
+  for (let i = 1; i <= TERMINAL_TAB_HOT_RETAIN_LIMIT + 1; i += 1) {
+    tabs.push(tabModel(`tab-${i}`, ptyIdFor(i)))
+  }
+  return tabs
+}
+
+describe('STA-2854 A: host cold-park policy vs an active remote subscriber', () => {
+  it('parks a locally hidden host pane that a remote client is actively viewing', () => {
+    const tabs = hiddenHostTabs()
+    const hiddenSinceByTabId = new Map<string, number>()
+    const activationOrder = createTerminalTabActivationOrder()
+    const t0 = 1_000_000
+
+    // Pass 1: the host user switches away — every tab starts its hidden clock.
+    buildTerminalTabColdParkCandidates({
+      terminalTabs: tabs,
+      assignments: new Map(),
+      isWorktreeActive: false,
+      activeTerminalTabId: null,
+      portalTabIds: new Set(),
+      shouldMeasureHiddenWorktree: false,
+      hiddenSinceByTabId,
+      activationOrder,
+      nowMs: t0
+    })
+    expect(hiddenSinceByTabId.get(SUBSCRIBED_TAB_ID)).toBe(t0)
+
+    // Pass 2: exactly the cold-park hysteresis later. The remote client has
+    // been driving this tab the whole time; the policy has no input for that.
+    const nowMs = t0 + TERMINAL_TAB_COLD_PARK_DELAY_MS
+    const candidates = buildTerminalTabColdParkCandidates({
+      terminalTabs: tabs,
+      assignments: new Map(),
+      isWorktreeActive: false,
+      activeTerminalTabId: null,
+      portalTabIds: new Set(),
+      shouldMeasureHiddenWorktree: false,
+      hiddenSinceByTabId,
+      activationOrder,
+      nowMs
+    })
+    const subscribedCandidate = candidates.find((c) => c.id === SUBSCRIBED_TAB_ID)!
+
+    expect(
+      canParkTerminalTabRenderer({
+        worktreeId: WORKTREE_ID,
+        terminalTab: subscribedCandidate,
+        pendingStartupByTabId: {},
+        parkingEnabled: true,
+        nowMs
+      })
+    ).toBe(true)
+
+    const parked = selectColdParkedTerminalTabs({
+      worktreeId: WORKTREE_ID,
+      terminalTabs: candidates,
+      pendingStartupByTabId: {},
+      parkingEnabled: true,
+      nowMs
+    })
+    // Eligible AND actually evicted: it is outside the hot-retain set.
+    expect(parked.has(SUBSCRIBED_TAB_ID)).toBe(true)
+
+    // Negative control: local visibility is the only thing that saves it.
+    const visibleCandidate = { ...subscribedCandidate, isVisible: true, hiddenSinceMs: null }
+    expect(
+      canParkTerminalTabRenderer({
+        worktreeId: WORKTREE_ID,
+        terminalTab: visibleCandidate,
+        pendingStartupByTabId: {},
+        parkingEnabled: true,
+        nowMs
+      })
+    ).toBe(false)
+  })
+
+  it('does not reset the hidden clock when a remote subscribe background-mounts the tab', () => {
+    const tabs = hiddenHostTabs()
+    const hiddenSinceByTabId = new Map<string, number>()
+    const activationOrder = createTerminalTabActivationOrder()
+    const t0 = 1_000_000
+
+    buildTerminalTabColdParkCandidates({
+      terminalTabs: tabs,
+      assignments: new Map(),
+      isWorktreeActive: false,
+      activeTerminalTabId: null,
+      portalTabIds: new Set(),
+      shouldMeasureHiddenWorktree: false,
+      hiddenSinceByTabId,
+      activationOrder,
+      nowMs: t0
+    })
+
+    // Hours pass with the host untouched, then the client reconnects and the
+    // host renderer background-mounts the tab. A background mount never makes
+    // the tab locally visible, so it re-enters the candidate list with its
+    // original hidden stamp — already past the hysteresis on the first pass.
+    const remountNowMs = t0 + 4 * 60 * 60_000
+    const candidates = buildTerminalTabColdParkCandidates({
+      terminalTabs: tabs,
+      assignments: new Map(),
+      isWorktreeActive: false,
+      activeTerminalTabId: null,
+      portalTabIds: new Set(),
+      shouldMeasureHiddenWorktree: false,
+      hiddenSinceByTabId,
+      activationOrder,
+      nowMs: remountNowMs
+    })
+    const subscribedCandidate = candidates.find((c) => c.id === SUBSCRIBED_TAB_ID)!
+    expect(subscribedCandidate.hiddenSinceMs).toBe(t0)
+    expect(remountNowMs - subscribedCandidate.hiddenSinceMs!).toBeGreaterThan(
+      TERMINAL_TAB_COLD_PARK_DELAY_MS
+    )
+    expect(
+      selectColdParkedTerminalTabs({
+        worktreeId: WORKTREE_ID,
+        terminalTabs: candidates,
+        pendingStartupByTabId: {},
+        parkingEnabled: true,
+        nowMs: remountNowMs
+      }).has(SUBSCRIBED_TAB_ID)
+    ).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// B. Authoritative host stream across the strictest possible park
+// ---------------------------------------------------------------------------
+
+type RuntimeInternals = {
+  recordPtyWorktree: (
+    ptyId: string,
+    worktreeId: string,
+    state?: { connected?: boolean; connectionId?: string | null }
+  ) => unknown
+  issuePtyHandle: (pty: unknown) => string
+}
+
+function internals(runtime: OrcaRuntimeService): RuntimeInternals {
+  return runtime as unknown as RuntimeInternals
+}
+
+/** Host-side provider: a local daemon session whose data events are gated on
+ *  attach, exactly like the real daemon boundary. Never renderer-gated. */
+function createHostProvider() {
+  const ptyId = ptyIdFor(0)
+  // Faithful to the report: the host pane WAS mounted (provider attached),
+  // then went locally hidden and cold-parked.
+  const session = { cols: 120, rows: 40, attached: true, screen: '' }
+  const attachCalls: string[] = []
+  const writes: [string, string][] = []
+  let runtime: OrcaRuntimeService | null = null
+  const controller = {
+    write: (id: string, text: string) => {
+      writes.push([id, text])
+      return true
+    },
+    kill: () => true,
+    getForegroundProcess: async () => null,
+    listProcesses: async () => [
+      { id: ptyId, cwd: '/tmp/wt', worktreeId: WORKTREE_ID, title: '', cols: 120, rows: 40 }
+    ],
+    // A parked pane has no renderer serializer — this is the park, expressed
+    // at the only boundary main can observe it from.
+    hasRendererSerializer: () => false,
+    getSize: () => ({ cols: session.cols, rows: session.rows }),
+    resize: () => true,
+    attach: async (id: string) => {
+      attachCalls.push(id)
+      session.attached = true
+      return true
+    },
+    serializeProviderBuffer: async () => ({
+      data: session.screen,
+      cols: session.cols,
+      rows: session.rows,
+      seq: 0,
+      source: 'headless' as const
+    })
+  }
+  return {
+    ptyId,
+    controller,
+    attachCalls,
+    writes,
+    session,
+    bind(target: OrcaRuntimeService) {
+      runtime = target
+    },
+    emitData(data: string): boolean {
+      if (!session.attached) {
+        return false
+      }
+      session.screen += data
+      runtime?.onPtyData(ptyId, data, Date.now())
+      return true
+    }
+  }
+}
+
+function startMultiplex(runtime: OrcaRuntimeService, connectionId: string) {
+  const messages: { result?: { type?: string; streamId?: number | null } }[] = []
+  const binaryFrames: Uint8Array<ArrayBufferLike>[] = []
+  const handlers = new Map<
+    number,
+    (frame: NonNullable<ReturnType<typeof decodeTerminalStreamFrame>>) => void
+  >()
+  const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+  const request: RpcRequest = {
+    id: `req-${connectionId}`,
+    authToken: 'tok',
+    method: 'terminal.multiplex',
+    params: {}
+  }
+  const dispatchPromise = dispatcher.dispatchStreaming(
+    request,
+    (msg) => {
+      messages.push(JSON.parse(msg))
+    },
+    {
+      connectionId,
+      sendBinary: (bytes: Uint8Array<ArrayBufferLike>) => {
+        binaryFrames.push(bytes)
+        return true
+      },
+      registerBinaryStreamHandler: (
+        streamId: number,
+        handler: (frame: NonNullable<ReturnType<typeof decodeTerminalStreamFrame>>) => void
+      ) => {
+        handlers.set(streamId, handler)
+        return () => {
+          if (handlers.get(streamId) === handler) {
+            handlers.delete(streamId)
+          }
+        }
+      }
+    }
+  )
+  return { messages, binaryFrames, handlers, dispatchPromise }
+}
+
+type Harness = ReturnType<typeof startMultiplex>
+
+function sendSubscribe(harness: Harness, streamId: number, terminal: string, clientId: string) {
+  harness.handlers.get(0)?.(
+    decodeTerminalStreamFrame(
+      encodeTerminalStreamFrame({
+        opcode: TerminalStreamOpcode.Subscribe,
+        streamId,
+        seq: 1,
+        payload: encodeTerminalStreamJson({
+          streamId,
+          terminal,
+          client: { id: clientId, type: 'desktop' }
+        })
+      })
+    )!
+  )
+}
+
+function sendInput(harness: Harness, streamId: number, text: string) {
+  harness.handlers.get(streamId)?.(
+    decodeTerminalStreamFrame(
+      encodeTerminalStreamFrame({
+        opcode: TerminalStreamOpcode.Input,
+        streamId,
+        seq: 2,
+        payload: encodeTerminalStreamText(text)
+      })
+    )!
+  )
+}
+
+async function waitForSubscribed(harness: Harness, streamId: number): Promise<void> {
+  await vi.waitFor(() =>
+    expect(
+      harness.messages.some(
+        (m) => m.result?.type === 'subscribed' && m.result?.streamId === streamId
+      )
+    ).toBe(true)
+  )
+}
+
+function outputText(harness: Harness): string {
+  return harness.binaryFrames
+    .map(decodeTerminalStreamFrame)
+    .filter((frame) => frame?.opcode === TerminalStreamOpcode.Output)
+    .map((frame) => decodeTerminalStreamText(frame!.payload))
+    .join('')
+}
+
+function errorFrames(harness: Harness): number {
+  return harness.binaryFrames
+    .map(decodeTerminalStreamFrame)
+    .filter((frame) => frame?.opcode === TerminalStreamOpcode.Error).length
+}
+
+describe('STA-2854 B: remote subscriber survives a fully unmounted host renderer', () => {
+  it('streams, accepts input, and re-subscribes with no host renderer pane at all', async () => {
+    const runtime = new OrcaRuntimeService()
+    const provider = createHostProvider()
+    provider.bind(runtime)
+    runtime.setPtyController(provider.controller as never)
+    const record = internals(runtime).recordPtyWorktree(provider.ptyId, WORKTREE_ID, {
+      connected: true
+    })
+    const handle = internals(runtime).issuePtyHandle(record)
+    // The park, at its strictest: no authoritative window exists, so a renderer
+    // mount request is impossible — more unmounted than a cold-parked pane.
+    const mountSpy = vi.spyOn(runtime, 'requestRendererTerminalTabMount').mockReturnValue(false)
+    // The pane produced bytes while it was mounted, so main already owns model
+    // state for it — no subscriber-driven (re)attach is in play.
+    expect(provider.emitData('host pane was live\r\n')).toBe(true)
+
+    const harness = startMultiplex(runtime, 'conn-client-b')
+    await vi.waitFor(() => expect(harness.handlers.has(0)).toBe(true))
+
+    sendSubscribe(harness, 1, handle, 'client-b')
+    await waitForSubscribed(harness, 1)
+
+    // Two independent signals: authoritative subscriber presence AND bytes.
+    expect(runtime.hasRemoteTerminalViewSubscriber(provider.ptyId)).toBe(true)
+    // This is the exact input `syncPtyBackgroundedDelivery` reads to veto
+    // daemon keep-tail thinning for a host-locally-hidden PTY.
+    expect(runtime.hasRawTerminalViewSubscriber(provider.ptyId)).toBe(true)
+
+    expect(provider.emitData(`${MARKER_BEFORE_PARK}\r\n`)).toBe(true)
+    await vi.waitFor(() => expect(outputText(harness)).toContain(MARKER_BEFORE_PARK))
+
+    // --- host cold-park episode: nothing about the pane exists on the host ---
+    expect(provider.emitData(`${MARKER_AFTER_PARK}\r\n`)).toBe(true)
+    await vi.waitFor(() => expect(outputText(harness)).toContain(MARKER_AFTER_PARK))
+
+    // Input still reaches the authoritative PTY while fully unmounted.
+    sendInput(harness, 1, CLIENT_INPUT)
+    await vi.waitFor(() => expect(provider.writes).toContainEqual([provider.ptyId, CLIENT_INPUT]))
+
+    // PTY identity never changed and the stream never errored.
+    expect(provider.attachCalls).toEqual([])
+    expect(errorFrames(harness)).toBe(0)
+    expect(harness.messages.some((m) => m.result?.type === 'error')).toBe(false)
+
+    // --- reconnect: a fresh connection re-subscribes with no mount available ---
+    const reconnected = startMultiplex(runtime, 'conn-client-b-2')
+    await vi.waitFor(() => expect(reconnected.handlers.has(0)).toBe(true))
+    sendSubscribe(reconnected, 1, handle, 'client-b')
+    await waitForSubscribed(reconnected, 1)
+    expect(provider.emitData(`${MARKER_AFTER_RECONNECT}\r\n`)).toBe(true)
+    await vi.waitFor(() => expect(outputText(reconnected)).toContain(MARKER_AFTER_RECONNECT))
+
+    // Stronger than expected: subscribe and reconnect never even ASK for a
+    // renderer mount once the leaf owns a PTY, so a re-park cannot cycle them.
+    expect(mountSpy).not.toHaveBeenCalled()
+    expect(provider.attachCalls).toEqual([])
+    expect(errorFrames(reconnected)).toBe(0)
+  })
+
+  it('counterfactual: losing every subscriber is what clears the thinning veto', async () => {
+    const runtime = new OrcaRuntimeService()
+    const provider = createHostProvider()
+    provider.bind(runtime)
+    runtime.setPtyController(provider.controller as never)
+    const record = internals(runtime).recordPtyWorktree(provider.ptyId, WORKTREE_ID, {
+      connected: true
+    })
+    const handle = internals(runtime).issuePtyHandle(record)
+    vi.spyOn(runtime, 'requestRendererTerminalTabMount').mockReturnValue(false)
+
+    const harness = startMultiplex(runtime, 'conn-counterfactual')
+    await vi.waitFor(() => expect(harness.handlers.has(0)).toBe(true))
+    sendSubscribe(harness, 1, handle, 'client-b')
+    await waitForSubscribed(harness, 1)
+    expect(runtime.hasRawTerminalViewSubscriber(provider.ptyId)).toBe(true)
+
+    harness.handlers.get(1)?.(
+      decodeTerminalStreamFrame(
+        encodeTerminalStreamFrame({
+          opcode: TerminalStreamOpcode.Unsubscribe,
+          streamId: 1,
+          seq: 3,
+          payload: encodeTerminalStreamJson({})
+        })
+      )!
+    )
+    await vi.waitFor(() => expect(runtime.hasRawTerminalViewSubscriber(provider.ptyId)).toBe(false))
+    // The PTY itself is untouched: parking/unsubscribing never kills it.
+    expect(provider.session.attached).toBe(true)
+    expect(provider.emitData('post-unsubscribe\r\n')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// C. The path host parking really can starve: a host PTY main never attached
+//    (never-activated or parked-from-birth tab) while no renderer can mount it.
+// ---------------------------------------------------------------------------
+
+describe('STA-2854 C: an unattached host PTY with no mountable renderer pane', () => {
+  it('still streams to the remote subscriber without any renderer mount', async () => {
+    const runtime = new OrcaRuntimeService()
+    const provider = createHostProvider()
+    // Parked/never-activated: no pane ever attached this daemon session, so the
+    // provider is not emitting and only main can start it.
+    provider.session.attached = false
+    provider.bind(runtime)
+    runtime.setPtyController(provider.controller as never)
+    const record = internals(runtime).recordPtyWorktree(provider.ptyId, WORKTREE_ID, {
+      connected: true
+    })
+    const handle = internals(runtime).issuePtyHandle(record)
+    const mountSpy = vi.spyOn(runtime, 'requestRendererTerminalTabMount').mockReturnValue(false)
+
+    const harness = startMultiplex(runtime, 'conn-client-c')
+    await vi.waitFor(() => expect(harness.handlers.has(0)).toBe(true))
+    // Baseline: the daemon refuses to emit for an unattached session.
+    expect(provider.emitData('pre-subscribe\r\n')).toBe(false)
+
+    sendSubscribe(harness, 1, handle, 'client-c')
+    await waitForSubscribed(harness, 1)
+
+    // Main itself must attach: the renderer cannot help while parked.
+    await vi.waitFor(() => expect(provider.attachCalls).toEqual([provider.ptyId]))
+    expect(provider.emitData(`${MARKER_AFTER_PARK}\r\n`)).toBe(true)
+    await vi.waitFor(() => expect(outputText(harness)).toContain(MARKER_AFTER_PARK))
+    expect(mountSpy).not.toHaveBeenCalled()
+    expect(errorFrames(harness)).toBe(0)
+  })
+})

--- a/tests/e2e/host-parked-pane-remote-viewer.spec.ts
+++ b/tests/e2e/host-parked-pane-remote-viewer.spec.ts
@@ -23,7 +23,8 @@
  * override was not the cause.
  *
  * After the fix (parked panes keep publishing their runtime-graph leaf):
- *   H-/connected x45,  input-reached=true within one 2s sample.
+ *   H-/connected x45,  the typed line reaches the host PTY AND its echo paints
+ *   back in the client's own xterm within one 2s sample.
  *
  * Run:
  *   pnpm exec playwright test tests/e2e/host-parked-pane-remote-viewer.spec.ts \
@@ -328,6 +329,7 @@ test('a cold-parked host pane keeps serving its paired remote viewer', async ({
     const timeline: string[] = []
     const timelineDeadline = Date.now() + 90_000
     let inputReached = false
+    let clientEchoed = false
     while (Date.now() < timelineDeadline) {
       const hostMounted = await orcaPage.evaluate(
         (id) => window.__paneManagers?.has(id) ?? false,
@@ -339,12 +341,17 @@ test('a cold-parked host pane keeps serving its paired remote viewer', async ({
         return pane?.container?.dataset?.ptyRecoveryState ?? 'unmounted'
       }, webTabId)
       inputReached ||= readSink(sinkPath).includes(`LINE:${token}`)
-      timeline.push(`${hostMounted ? 'H+' : 'H-'}/${clientPhase}${inputReached ? '/in' : ''}`)
+      // Signal 2, and the reason this is not merely a host-side test: the echo
+      // has to come back out to the client's own xterm.
+      clientEchoed ||= (await readPaneContent(client.page, webTabId)).includes(`LINE:${token}`)
+      timeline.push(
+        `${hostMounted ? 'H+' : 'H-'}/${clientPhase}${inputReached ? '/in' : ''}${clientEchoed ? '/echo' : ''}`
+      )
       await new Promise((resolve) => setTimeout(resolve, 2_000))
     }
     console.log(`[sta2854] timeline=${JSON.stringify(timeline)}`)
     console.log(
-      `[sta2854] input-reached=${inputReached} sink=${JSON.stringify(readSink(sinkPath))}`
+      `[sta2854] input-reached=${inputReached} client-echoed=${clientEchoed} sink=${JSON.stringify(readSink(sinkPath))}`
     )
 
     const disruptedSamples = timeline.filter((entry) => !entry.includes('/connected'))
@@ -353,9 +360,9 @@ test('a cold-parked host pane keeps serving its paired remote viewer', async ({
       'host-local cold parking disrupted the paired client transport'
     ).toEqual({ disrupted: 0, timeline })
     expect(
-      inputReached,
-      'input typed at the moment of the host park never reached the host PTY'
-    ).toBe(true)
+      { inputReached, clientEchoed },
+      'the parked host pane did not carry a full round trip for its remote viewer'
+    ).toEqual({ inputReached: true, clientEchoed: true })
 
     // 5. PTY identity: one process, never respawned across the park.
     const readyLines = readSink(sinkPath)

--- a/tests/e2e/host-parked-pane-remote-viewer.spec.ts
+++ b/tests/e2e/host-parked-pane-remote-viewer.spec.ts
@@ -1,0 +1,381 @@
+/**
+ * STA-2854 live validation: a HOST pane that cold-parks while a paired client
+ * is actively viewing it must keep serving that client.
+ *
+ * Topology: headed Orca desktop host (remote server) + a separate paired Orca
+ * desktop client. The reported shape is the inverse of every existing paired
+ * parking spec: those park on the CLIENT, this parks on the HOST while the
+ * client watches. The host user never touches the tab again after parking it.
+ *
+ * Two independent signals, as required for an end-to-end claim:
+ *   1. host-side: the fixture process's own sink file records the typed line —
+ *      the bytes reached the authoritative host PTY;
+ *   2. client-side: the client's xterm paints the echo — output crossed back.
+ * Plus PTY identity: the sink must still hold exactly one READY line, so the
+ * park never respawned or replaced the process.
+ *
+ * Before the fix, `H±` = host pane mounted, phase = client transport, 2s samples:
+ *   H-/recovering x8  ->  H-/connected x37,  input-reached=false
+ * The host park dropped the paired client into the "Reconnecting to remote
+ * runtime" state for ~16s; it reconnected on its own, but the line typed at
+ * park time was silently discarded forever by recoveryBlocksIo(). Reproduced
+ * identically at the production 30s cold-park hysteresis, so the shortened test
+ * override was not the cause.
+ *
+ * After the fix (parked panes keep publishing their runtime-graph leaf):
+ *   H-/connected x45,  input-reached=true within one 2s sample.
+ *
+ * Run:
+ *   pnpm exec playwright test tests/e2e/host-parked-pane-remote-viewer.spec.ts \
+ *     --config tests/playwright.config.ts --project electron-headless --workers=1
+ */
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { randomUUID } from 'node:crypto'
+import os from 'node:os'
+import path from 'node:path'
+import type { Page } from '@stablyai/playwright-test'
+import {
+  HOST_TERMINAL_SURFACE_SEPARATOR,
+  toWebTerminalSurfaceTabId
+} from '../../src/shared/terminal-surface-id'
+import { expect, test } from './helpers/orca-app'
+import {
+  createRuntimeDesktopPairingOffer,
+  launchPairedElectronClient
+} from './helpers/paired-electron-client'
+import { focusActiveTerminalInput } from './helpers/terminal'
+import { waitForTabParked } from './helpers/terminal-hidden-parking'
+
+const PARK_DELAY_MS = 30_000
+const PAINT_BUDGET_MS = 20_000
+const scratch = mkdtempSync(path.join(os.tmpdir(), 'orca-host-park-viewer-'))
+const fixturePath = path.join(scratch, 'host-park-viewer-terminal.mjs')
+writeFileSync(
+  fixturePath,
+  [
+    "import { appendFileSync } from 'node:fs'",
+    'const sink = process.argv[2]',
+    'const record = (line) => appendFileSync(sink, `${line}\\n`)',
+    'record(`READY:${process.pid}`)',
+    'process.stdout.write(`READY:${process.pid}\\r\\n`)',
+    "process.stdin.setEncoding('utf8')",
+    "let pending = ''",
+    "process.stdin.on('data', (data) => {",
+    '  pending += data',
+    '  const lines = pending.split(/\\r\\n|\\r|\\n/)',
+    "  pending = lines.pop() ?? ''",
+    '  for (const line of lines) {',
+    '    record(`LINE:${line}`)',
+    '    process.stdout.write(`LINE:${line}\\r\\n`)',
+    '  }',
+    '})',
+    'process.stdin.resume()'
+  ].join('\n')
+)
+
+test.afterAll(() => {
+  rmSync(scratch, { recursive: true, force: true })
+})
+
+// Why: the HOST must park quickly too, so its launch env carries the override.
+test.use({ orcaAppExtraEnv: { ORCA_E2E_TERMINAL_PARKING_DELAY_MS: String(PARK_DELAY_MS) } })
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`
+}
+
+function fixtureCommand(sinkPath: string): string {
+  const command = [process.execPath, fixturePath, sinkPath]
+  return process.platform === 'win32'
+    ? command.map((value) => `"${value.replaceAll('"', '""')}"`).join(' ')
+    : command.map(shellQuote).join(' ')
+}
+
+function readSink(sinkPath: string): string {
+  try {
+    return readFileSync(sinkPath, 'utf8')
+  } catch {
+    return ''
+  }
+}
+
+async function callEnvironment<TResult>(
+  page: Page,
+  environmentId: string,
+  method: string,
+  params: unknown
+): Promise<TResult> {
+  return page.evaluate(
+    async ({ environmentId, method, params }) => {
+      const response = await window.api.runtimeEnvironments.call({
+        selector: environmentId,
+        method,
+        params
+      })
+      if (!response.ok) {
+        throw new Error(`${response.error.code}: ${response.error.message}`)
+      }
+      return response.result
+    },
+    { environmentId, method, params }
+  ) as Promise<TResult>
+}
+
+async function readPaneContent(page: Page, tabId: string): Promise<string> {
+  return page.evaluate((id) => {
+    const manager = window.__paneManagers?.get(id)
+    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+    return pane?.serializeAddon?.serialize?.() ?? ''
+  }, tabId)
+}
+
+async function waitForPaneMarker(
+  page: Page,
+  tabId: string,
+  marker: string,
+  budgetMs: number
+): Promise<boolean> {
+  const deadline = Date.now() + budgetMs
+  while (Date.now() < deadline) {
+    if ((await readPaneContent(page, tabId)).includes(marker)) {
+      return true
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250))
+  }
+  return false
+}
+
+// Why fixme: this is a KNOWN-RED reproduction for STA-2854, kept as the
+// deterministic live harness for whoever owns the fix. Delete this line to run
+// it. Observed on 1.4.178-rc.2 (5/5 runs): ~16s of `recovering` after the host
+// park, and the line typed at park time is silently lost forever.
+test('a cold-parked host pane keeps serving its paired remote viewer', async ({
+  orcaPage
+}, testInfo) => {
+  test.setTimeout(600_000)
+  const offer = await createRuntimeDesktopPairingOffer(orcaPage)
+  const previousParkDelay = process.env.ORCA_E2E_TERMINAL_PARKING_DELAY_MS
+  process.env.ORCA_E2E_TERMINAL_PARKING_DELAY_MS = String(PARK_DELAY_MS)
+  const client = await launchPairedElectronClient(offer, testInfo, 'host-park-viewer')
+  const createdTerminals: string[] = []
+  const sinkPath = path.join(scratch, `sink-${randomUUID()}.log`)
+  try {
+    const worktreeId = await orcaPage.evaluate(() => {
+      const id = window.__store?.getState().activeWorktreeId
+      if (!id) {
+        throw new Error('headed host has no active worktree')
+      }
+      return id
+    })
+    await expect
+      .poll(
+        () =>
+          client.page.evaluate(
+            (id) =>
+              window.__store
+                ?.getState()
+                .allWorktrees()
+                .some((worktree) => worktree.id === id) ?? false,
+            worktreeId
+          ),
+        { timeout: 60_000, message: 'paired client never saw the host worktree' }
+      )
+      .toBe(true)
+
+    // Host-owned terminal, created through the host runtime.
+    const created = await callEnvironment<{ tab: { id: string; terminal: string | null } }>(
+      client.page,
+      client.environmentId,
+      'session.tabs.createTerminal',
+      {
+        worktree: `id:${worktreeId}`,
+        command: fixtureCommand(sinkPath),
+        activate: false,
+        select: false,
+        navigation: 'caller'
+      }
+    )
+    if (!created.tab.terminal) {
+      throw new Error('host session terminal was not created')
+    }
+    createdTerminals.push(created.tab.terminal)
+    const hostTabId = created.tab.id.split(HOST_TERMINAL_SURFACE_SEPARATOR)[0]
+    const webTabId = toWebTerminalSurfaceTabId(hostTabId)
+
+    // 1. Host mounts the pane (the ordinary "someone looked at it" state).
+    await orcaPage.evaluate(
+      ({ worktreeId, tabId }) => {
+        const state = window.__store?.getState()
+        state?.setActiveView('terminal')
+        state?.setActiveWorktree(worktreeId)
+        state?.setActiveTab(tabId)
+        state?.setActiveTabType('terminal')
+      },
+      { worktreeId, tabId: hostTabId }
+    )
+    await expect
+      .poll(() => orcaPage.evaluate((id) => window.__paneManagers?.has(id) ?? false, hostTabId), {
+        timeout: 60_000,
+        message: 'host never mounted its own terminal pane'
+      })
+      .toBe(true)
+
+    // 2. Client subscribes and is actively viewing it.
+    await expect
+      .poll(
+        () =>
+          client.page.evaluate(
+            (id) => (window.__store?.getState().tabsByWorktree[id] ?? []).map((tab) => tab.id),
+            worktreeId
+          ),
+        { timeout: 60_000, message: 'client never mirrored the host tab' }
+      )
+      .toContain(webTabId)
+    await client.page.evaluate(
+      ({ webTabId, worktreeId }) => {
+        const state = window.__store?.getState()
+        state?.setActiveView('terminal')
+        state?.setActiveWorktree(worktreeId)
+        state?.setActiveTab(webTabId)
+        state?.setActiveTabType('terminal')
+      },
+      { webTabId, worktreeId }
+    )
+    expect(
+      await waitForPaneMarker(client.page, webTabId, 'READY:', PAINT_BUDGET_MS),
+      'client never painted the host terminal before the host parked it'
+    ).toBe(true)
+
+    // 2b. CONTROL: the same typed path must work BEFORE the host parks. Without
+    //     this, a focus/keyboard artifact would masquerade as the park bug.
+    const controlToken = `sta2854-control-${randomUUID().slice(0, 8)}`
+    await focusActiveTerminalInput(client.page)
+    await client.page.keyboard.type(controlToken)
+    await client.page.keyboard.press('Enter')
+    const controlReached = await (async () => {
+      const deadline = Date.now() + PAINT_BUDGET_MS
+      while (Date.now() < deadline) {
+        if (readSink(sinkPath).includes(`LINE:${controlToken}`)) {
+          return true
+        }
+        await new Promise((resolve) => setTimeout(resolve, 250))
+      }
+      return false
+    })()
+    console.log(
+      `[sta2854] control-reached=${controlReached} sink=${JSON.stringify(readSink(sinkPath))}`
+    )
+    expect(
+      controlReached,
+      'control: client input did not reach the host PTY even before any park'
+    ).toBe(true)
+
+    // 3. The host cold-parks the pane the client is watching. Nobody touches
+    //    it on the host again.
+    // Two decoy tabs on the host: one to age the target, one to take the
+    // most-recently-hidden exemption. Sampled before and after the park lands
+    // so decoy churn cannot be mistaken for the park itself.
+    for (let i = 0; i < 2; i += 1) {
+      await orcaPage.evaluate((id) => {
+        const state = window.__store?.getState()
+        const tab = state?.createTab(id, undefined, undefined, { activate: true })
+        if (tab) {
+          state?.setActiveTab(tab.id)
+          state?.setActiveTabType('terminal')
+        }
+      }, worktreeId)
+    }
+    const readClientState = async (): Promise<unknown> =>
+      client.page.evaluate((id) => {
+        const manager = window.__paneManagers?.get(id)
+        const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+        return {
+          mounted: Boolean(manager),
+          ptyId: pane?.container?.dataset?.ptyId ?? null,
+          recoveryState: pane?.container?.dataset?.ptyRecoveryState ?? null
+        }
+      }, webTabId)
+    console.log(`[sta2854] decoys-created client=${JSON.stringify(await readClientState())}`)
+    await waitForTabParked(orcaPage, hostTabId, { parkDelayMs: PARK_DELAY_MS })
+    console.log(`[sta2854] post-park client=${JSON.stringify(await readClientState())}`)
+
+    // Direct probe: is the host-minted terminal handle still resolvable once
+    // its pane is parked? (It is — so the boundary is not handle liveness.)
+    const handleProbe = await client.page.evaluate(
+      async ({ environmentId, terminal }) => {
+        const response = await window.api.runtimeEnvironments.call({
+          selector: environmentId,
+          method: 'terminal.read',
+          params: { terminal }
+        })
+        return response.ok
+          ? { ok: true as const }
+          : { ok: false as const, code: response.error.code, message: response.error.message }
+      },
+      { environmentId: client.environmentId, terminal: created.tab.terminal }
+    )
+    console.log(`[sta2854] handle-probe=${JSON.stringify(handleProbe)}`)
+
+    // Type the moment the host parks — a user driving the pane does not wait
+    // for a banner. Input accepted here must reach the host PTY.
+    const token = `sta2854-${randomUUID().slice(0, 8)}`
+    await focusActiveTerminalInput(client.page)
+    await client.page.keyboard.type(token)
+    await client.page.keyboard.press('Enter')
+
+    // Timeline: host pane mount state vs client transport phase. Long enough to
+    // catch a second park cycle if the recovery remounts the host pane.
+    const timeline: string[] = []
+    const timelineDeadline = Date.now() + 90_000
+    let inputReached = false
+    while (Date.now() < timelineDeadline) {
+      const hostMounted = await orcaPage.evaluate(
+        (id) => window.__paneManagers?.has(id) ?? false,
+        hostTabId
+      )
+      const clientPhase = await client.page.evaluate((id) => {
+        const manager = window.__paneManagers?.get(id)
+        const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+        return pane?.container?.dataset?.ptyRecoveryState ?? 'unmounted'
+      }, webTabId)
+      inputReached ||= readSink(sinkPath).includes(`LINE:${token}`)
+      timeline.push(`${hostMounted ? 'H+' : 'H-'}/${clientPhase}${inputReached ? '/in' : ''}`)
+      await new Promise((resolve) => setTimeout(resolve, 2_000))
+    }
+    console.log(`[sta2854] timeline=${JSON.stringify(timeline)}`)
+    console.log(
+      `[sta2854] input-reached=${inputReached} sink=${JSON.stringify(readSink(sinkPath))}`
+    )
+
+    const disruptedSamples = timeline.filter((entry) => !entry.includes('/connected'))
+    expect(
+      { disrupted: disruptedSamples.length, timeline },
+      'host-local cold parking disrupted the paired client transport'
+    ).toEqual({ disrupted: 0, timeline })
+    expect(
+      inputReached,
+      'input typed at the moment of the host park never reached the host PTY'
+    ).toBe(true)
+
+    // 5. PTY identity: one process, never respawned across the park.
+    const readyLines = readSink(sinkPath)
+      .split('\n')
+      .filter((line) => line.startsWith('READY:'))
+    expect(readyLines, 'host PTY was replaced across the park').toHaveLength(1)
+    // Intentionally not asserted: whether the host pane stays parked is part of
+    // what the timeline above reports (a recovery-driven remount would show as
+    // H+ samples), not a precondition of the invariant.
+  } finally {
+    if (previousParkDelay === undefined) {
+      delete process.env.ORCA_E2E_TERMINAL_PARKING_DELAY_MS
+    } else {
+      process.env.ORCA_E2E_TERMINAL_PARKING_DELAY_MS = previousParkDelay
+    }
+    for (const terminal of createdTerminals) {
+      await callEnvironment(client.page, client.environmentId, 'terminal.closeTab', {
+        terminal
+      }).catch(() => undefined)
+    }
+    await client.dispose()
+  }
+})

--- a/tests/e2e/host-parked-pane-remote-viewer.spec.ts
+++ b/tests/e2e/host-parked-pane-remote-viewer.spec.ts
@@ -146,10 +146,6 @@ async function waitForPaneMarker(
   return false
 }
 
-// Why fixme: this is a KNOWN-RED reproduction for STA-2854, kept as the
-// deterministic live harness for whoever owns the fix. Delete this line to run
-// it. Observed on 1.4.178-rc.2 (5/5 runs): ~16s of `recovering` after the host
-// park, and the line typed at park time is silently lost forever.
 test('a cold-parked host pane keeps serving its paired remote viewer', async ({
   orcaPage
 }, testInfo) => {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1165 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1164 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​100 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​94 |

<!-- /orca-pr-loc -->

## ELI5

Orca saves memory by switching off terminal panes you can't see ("parking"). The shell keeps running — only the on-screen widget is thrown away.

The problem: when the host threw away the widget, it also stopped telling the system that terminal exists. Locally nobody notices. But if a **second machine is paired to that host and actively using that terminal**, its connection is bound to that entry. The entry vanished, so the remote viewer got knocked into "Reconnecting to remote runtime" for ~16 seconds — and **everything typed during those 16 seconds was silently thrown away.** You'd type a command, watch it echo nowhere, and it would simply never run. The terminal then reconnects and looks perfectly normal, with no sign anything was lost.

The fix: while a parked terminal is still alive, keep saying it exists.

## What Changed

Four production files (one of them a single re-export line):

- `sync-runtime-graph.ts` — the loop that publishes leaves for unmounted tabs already existed for never-mounted background automation tabs, gated on "does this PTY still have a live eager buffer". Cold-parked tabs are the same shape with a different liveness proof, so the gate now also accepts "a parked watcher still owns this PTY".
- `terminal-parked-watcher-registry.ts` — two new readers. `collectParkedTerminalWatcherPtyIds()` is the liveness proof: it reads `disposersByPtyId`, never `paneIdByPtyId` (per-PTY disposal deliberately keeps the pane-id slot so the dead leaf's runtime title can still be cleared), and excludes remote-runtime PTYs and PTYs holding an unowned buffered exit. `getParkedTerminalWatcherPaneIdsByPtyId()` is the identity source: the pane ids the watchers actually own, read from the watcher entry rather than the unmount capture. No new state: parked watchers start on unmount and are disposed on reveal, tab close, PTY exit, and worktree teardown, so a dead terminal still drops out of the graph.
- `terminal-parked-pty-watcher.ts` — refuses to register a watcher for a PTY whose exit landed in the park handoff gap, and clears its stranded title slot (details in the commit bullets below).
- Fourth commit, from review: parked leaves publish the **pane's runtime title** instead of `null` (the parked watcher keeps writing it, and main prefers it over its own older OSC title); pane ids come from the **watcher entry** rather than the unmount capture, so a leaf the layout gained while parked is also named correctly; and refusing a PTY that died in the handoff gap now **clears its title slot**, which no live pane would ever overwrite.
- Third commit, from review: liveness is collected **once per publication** instead of scanned per leaf; **remote-runtime PTYs are excluded** (they get no parked exit subscription, so their disposer outlives the terminal); parked leaves publish the **captured pane id** instead of a positional ordinal; and `activeLeafId` is validated against the leaves actually being sent. The last two are pre-existing defects in this fallback block that the PR made commonly reachable, since parked splits are ordinary where multi-leaf automation tabs were not.
- Second commit, from review: the predicate also rejects a PTY with an **unowned buffered exit**. The pane's primary exit handler is gone once it unmounts and the watcher's sidecar is installed a passive effect later; an exit landing in that gap is buffered with no owner and `subscribeToPtyExit` never replays it, so the entry stayed populated for a dead PTY. That race pre-dates this PR, but publishing on watcher presence alone would have turned a leaked watcher into a dead terminal advertised as live.

Parking behavior itself is unchanged — panes still park on exactly the same schedule.

## Why

`OrcaRuntimeService.syncWindowGraph` replaces its leaf map per publication and calls `invalidateLeafHandle` for anything missing (the existing preservation grace only covers renderer *reload*). `sync-runtime-graph.ts` published a terminal leaf only for a **mounted** pane. So cold-parking deleted the authoritative terminal identity a live paired subscriber was bound to, even though the PTY, its output stream, and the whole multiplex path were untouched. The client's transport then hit `recoveryBlocksIo()` and dropped input until it re-resolved a replacement handle.

**Rejected alternative — a subscriber-aware park exemption** (don't park while someone remote is watching, as the issue suggests). It pins host memory to whatever a remote client happens to be looking at, which is the exact pressure parking exists to relieve, and it leaves the same hole open for cold-activation deferral and floating panes. The bug is that parking *lies about the terminal being gone*, not that it parks.

Scope note: ordinary paired-**client** mirrors are **not** affected. `isWebOnlyMirroredTerminalTab` (`sync-runtime-graph.ts`) excludes web-surface tabs whose PTYs are all `remote:` before the fallback loop runs, so a client parked on a host-mirrored terminal does not publish that remote PTY into its own local graph. Only legacy local-PTY/mixed tabs stay eligible, exactly as they were when mounted. (An earlier revision of this description claimed the opposite; that was wrong.)

## Boundary decision: renderer publishes vs main preserves

Three review rounds converged their substantive findings on one category — the renderer rebuilding, from persisted layout and watcher bookkeeping, a projection main already had. That raised a fair design question, evaluated deliberately before finishing this PR: should the renderer instead send a small "these leaves are parked, not gone" signal and have main **preserve its own existing records** (the way `unchangedMobileSessionWorktrees` works, and the way `syncWindowGraph`'s reload branch preserves a dropped leaf)?

Decision: **keep the renderer-side publication.** Reasons, in order of weight:

1. **The renderer is the sole authority for every published field, and that data keeps changing while parked.** The parked byte watcher writes the pane's runtime title live (`parked-terminal-byte-watcher.ts`); liveness changes (exits, handoff-gap exits); layout can gain leaves. A main-preserved record is a snapshot frozen at park time — strictly staler. Main resolves titles from `leaf.paneTitle` via nullish-coalescing fast paths and classifies **agent presence** from it, so a frozen "working" title would pin stale agent status — the exact bug class the fourth commit fixed.
2. **"Zero fields reconstructed" does not survive parked-tab mutation.** One sibling leaf can die while others stay parked, and a parked tab's layout can gain a leaf. Main's preserved tab record (layout tree, `activeLeafId`) would have to be *edited* to stay consistent with the surviving leaf set — the same consistency logic the findings were about, relocated into main and operating on staler inputs. `this.tabs` is replaced wholesale with no preservation branch today; that branch would be new, steady-state machinery.
3. **A signal design needs a bootstrap/repair protocol; replace-everything does not.** Main can lack a record to preserve (first publication of a renderer generation; app restart with daemon-surviving PTYs). The one existing signal-and-preserve precedent needed exactly that: the `mobileSessionResyncWorktrees` backchannel plus an acknowledge-before-commit memo on the renderer. Its motivation there was snapshot size; parked leaf records are tiny, so the protocol cost buys nothing. The renderer keeps the full-publication path for bootstrap either way — the alternative adds a mode, it does not delete one.
4. **Stateless replace-everything is the load-bearing invariant of graph sync.** Main's tab/leaf snapshot is a pure function of the latest publication. The only preservation branch is deliberately scoped to the transient `reloading` window and even there needs a duplicate-handle guard (two leaves on one PTY crash paired clients). A renderer-signaled preservation mode extends that subtlety from a bounded window to indefinite duration.
5. **The liveness decision — the genuinely hard part — does not move.** Under the signal design the renderer still derives *which keys to name* from the same watcher registry, with the same remote-PTY exclusion and buffered-exit races. Only the field copying would move, and per (1) it would move to a staler source. The round-3 reviewer's "the watcher is the narrower lease" argument stands: renderer-side, retention ends exactly when the watcher does.

The findings trajectory supports this: the fixes converged by moving each field to the **same authoritative renderer sources the mounted path publishes from** (`runtimePaneTitlesByTabId`, persisted layout, PaneManager pane ids held by the watcher) — not by patching fabrications with more fabrications. The remaining ordinal fallback (`index + 1`) applies only to the pre-existing never-mounted automation-tab case, unchanged from before this PR.

## Linked Issue

Fixes #11189

## Visual Proof

`N/A` — the user-visible difference is the **absence** of a transient "Reconnecting to remote runtime" banner, so a recording shows nothing happening. The observable state is captured deterministically instead, from `tests/e2e/host-parked-pane-remote-viewer.spec.ts` (`H±` = host pane mounted, phase = paired client transport, sampled every 2s):

**Before**
```
H-/recovering ×8  →  H-/connected ×37
input typed at park time: never reached the host PTY (lost permanently)
```

**After**
```
H-/connected ×45  (every sample /in/echo)
input typed at park time: reaches the host PTY, and its echo paints back in the
client's own xterm, within one 2s sample
```

Reproduced identically at the production 30s cold-park hysteresis, not just the shortened test override, so the compressed timer is not what made it fragile.

## Testing

Tested on **macOS**. Real two-app topology: a headed Orca desktop host with an isolated profile, plus a separate paired Orca desktop client, host-owned PTY running a fixture that writes to its own sink file. Two independent signals per the remote-repro guidance — the host process's sink proves input arrived, the client's xterm buffer proves output crossed back — plus PTY identity (exactly one `READY:` line, so the park never respawned the process).

New tests:
- `src/renderer/src/runtime/sync-runtime-graph-parked-leaf.test.ts` (9) — publishes while watched; drops once the watcher is disposed; refuses a stale saved PTY no watcher owns (`ptyIdsByLeafId` is merged and never pruned); drops when per-PTY disposal leaves only the pane-id slot; drops when the PTY exited into the park handoff gap; excludes a remote-runtime PTY; publishes the captured pane id rather than an ordinal; never names an active leaf it is not sending; publishes the parked pane's runtime title rather than discarding it. **Verified red with the fix reverted**, and the last two cases kill three mutants that the first revision let through: a `paneIdByPtyId` reader, a `tabPtyId` reader, and dropping the unowned-exit guard.
- `tests/e2e/host-parked-pane-remote-viewer.spec.ts` — the live host-parks-while-client-watches journey, with a pre-park control keystroke so a focus artifact cannot masquerade as the bug. Both signals are asserted: the host fixture's sink proves input landed, and the client's own xterm buffer proves the echo came back.
- `tests/e2e/host-cold-park-remote-subscriber.unit.test.ts` — the deterministic cross-boundary oracle used to scope this: separates the park *policy* from the *stream*, and runs byte-identically against v1.4.159 to separate this from the never-attached-daemon-session bug already fixed by #12589.

Results:
- Full unit suite: **56,330 passed**, 4 failed — all pre-existing, verified by re-running them with the fix stashed. 3 fail identically on clean main (zsh ZDOTDIR, two WSL exec-separator cases); the 4th is a macOS helper benchmark that passes in isolation and flaked under full-suite parallel load.
- Parking E2E, **7/7 pass**: client-side parked-reveal interactivity (incl. across a disconnect/reconnect), hidden-view parking, bell/title side effects while parked, excluded tabs, the 25-cycle byte-for-byte park/reveal reproduction, and parked-tab close retirement (proves closing a parked tab still retires its exact PTY — nothing dead is resurrected).
- `typecheck:node`, `typecheck:web`, full `oxlint`, changed-code quality + type-aware quality, React Doctor, max-lines ratchet, reliability-gate manifest: all clean.
- Electron app built as part of every E2E run.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

Reviewed over three rounds by three independent `gpt-5.6-luna` Codex agents each, in this worktree (correctness/lifecycle, remote-wire blast radius, adversarial test quality). Model identity was verified against a bogus-model control rather than self-reported. Three findings survived my own validation against the source and are fixed in the second commit: the park-handoff exit gap, a unit test that three wrong implementations could pass, and an E2E that had stopped asserting the client-side echo it claimed as evidence. The wire review found nothing actionable and corrected the client-side scope note above.

Round two, against the fixed branch, found four more that also survived validation: the quadratic liveness scan, the remote-runtime watcher that never retires, the fabricated `paneRuntimeId`, and the unvalidated `activeLeafId`. All are fixed in the third commit. It also caught the false performance claim corrected in Notes. A round-two reviewer additionally noted the buffered exit could be evicted by its 64-entry FIFO cap before publication; rather than rely on that evidence surviving, `startParkedPtyWatcher` now refuses the registration outright.

Round three came back materially quieter: one reviewer independently re-derived the original invariant against `syncWindowGraph` and returned a clean functional verdict, also judging the renderer-side formulation preferable to a main-side leaf exemption. The three remaining findings were the discarded pane title, a pane id the unmount capture could not know about, and a title slot stranded by the round-two guard — all fixed in the fourth commit, plus a stale comment removed.

Every fix is pinned by a test that fails without it — **twelve mutants killed** across the three rounds, including one in `terminal-parked-tab-watchers.test.ts` that exercises the real park wiring rather than the helper.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Remote wire compatibility**: no RPC, stream frame, or published payload shape changed. A leaf that already had a defined publication shape is published for longer. A new client against an old host sees today's behavior; an old client against a new host stops losing its handle — no negotiation needed.
- **Cross-platform**: renderer-only policy, no path, shell, shortcut, or platform branch. Validated on macOS; Windows and Linux paired hosts are untested here.
- **SSH**: untouched. SSH panes have their own park-restore policy and no paired subscriber unless a client is also paired to that host, in which case they take the same corrected path.
- **Headless `orca serve`**: unaffected by construction — a headless host has no renderer and never parks. The deterministic oracle covers the stream layer with no window attached; a live `orca serve` paired run was not executed.
- **Performance**: no new polling, listeners, or IPC. Liveness is one set built per publication, so the added cost is O(parked PTYs) once rather than per leaf. Parked tabs are **not** bounded by the hot-retain limits — those bound what stays warm — so the per-leaf scan the first revision used was genuinely quadratic on a large workspace; an earlier version of this note wrongly claimed otherwise.
- **Known remaining gap, not addressed here**: input typed during a transport recovery is silently discarded rather than buffered or surfaced (`recoveryBlocksIo()`). This PR removes the trigger I found, not the hole. Worth its own issue.
- The original report's `terminal_safe_fit_retry_exhausted` evidence is the documented benign signature of hidden panes mounting at 0×0, not a park/remount wave; and the "reconnect re-parks forever" mechanism no longer exists on main. The surviving defect is the one fixed here.
- **For whoever merges**: merging auto-closes Linear STA-2854, whose description still describes a mechanism that no longer exists (30s unmount, permanent reconnect loop, a `hasRemoteSubscriber` park exemption — the last was evaluated and rejected, see the rejected alternative above). The ticket description needs rewriting before merge so the closed record matches what actually shipped.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

