### PR TITLE
feat(remote): add a positional file read to the filesystem provider

### DIFF
--- a/src/main/providers/filesystem-provider-contract.ts
+++ b/src/main/providers/filesystem-provider-contract.ts
@@ -26,8 +26,10 @@ export type FileReadLimits = {
 
 export type FileRangeReadResult = {
   /** Raw bytes for `[position, position + bytesRead)`. `bytesRead < length`
-   *  always means end of file: the host loops internally, and an over-cap
-   *  request is rejected rather than clamped. */
+   *  always means end of file: the host loops until the window is filled, and
+   *  an over-cap request is rejected rather than clamped, so a short read is
+   *  never a partial syscall or a silently narrowed window. A `position` at or
+   *  past EOF yields `bytesRead === 0`. */
   bytes: Buffer
   bytesRead: number
 }
@@ -49,7 +51,11 @@ export type IFilesystemProvider = {
   /** Positional read. Optional because an older remote host cannot serve one.
    *  Strict by design: it throws `FileRangeReadUnsupportedError` rather than
    *  silently degrading, so a caller cannot accidentally pay a whole-file
-   *  transfer per chunk while tailing. */
+   *  transfer per chunk while tailing.
+   *
+   *  `position` must be a non-negative safe integer and `length` a positive one
+   *  no larger than `MAX_FILE_RANGE_READ_BYTES`; anything else throws
+   *  `FileRangeReadRequestError` without reaching the host. */
   readFileRange?(
     filePath: string,
     position: number,

--- a/src/main/providers/filesystem-provider-contract.ts
+++ b/src/main/providers/filesystem-provider-contract.ts
@@ -24,9 +24,40 @@ export type FileReadLimits = {
   maxTextBytes?: number
 }
 
+export type FileRangeReadResult = {
+  /** Raw bytes for `[position, position + bytesRead)`. `bytesRead < length`
+   *  always means end of file: the host loops internally, and an over-cap
+   *  request is rejected rather than clamped. */
+  bytes: Buffer
+  bytesRead: number
+}
+
+/** Thrown by `readFileRange` when the host cannot serve a positional read.
+ *  Callers that tail a file should probe `supportsFileRangeRead()` once and
+ *  fall back to a single whole-file snapshot, NOT to a whole-file read per
+ *  chunk -- that is quadratic on a growing file. */
+export class FileRangeReadUnsupportedError extends Error {
+  constructor(message = 'Positional file reads are unavailable on this host') {
+    super(message)
+    this.name = 'FileRangeReadUnsupportedError'
+  }
+}
+
 export type IFilesystemProvider = {
   readDir(dirPath: string): Promise<DirEntry[]>
   readFile(filePath: string, limits?: FileReadLimits): Promise<FileReadResult>
+  /** Positional read. Optional because an older remote host cannot serve one.
+   *  Strict by design: it throws `FileRangeReadUnsupportedError` rather than
+   *  silently degrading, so a caller cannot accidentally pay a whole-file
+   *  transfer per chunk while tailing. */
+  readFileRange?(
+    filePath: string,
+    position: number,
+    length: number,
+    options?: { signal?: AbortSignal }
+  ): Promise<FileRangeReadResult>
+  /** Cached capability probe for `readFileRange`. */
+  supportsFileRangeRead?(options?: { signal?: AbortSignal }): Promise<boolean>
   readTerminalArtifact?(
     filePath: string,
     options: TerminalArtifactAccessOptions

--- a/src/main/providers/filesystem-provider-contract.ts
+++ b/src/main/providers/filesystem-provider-contract.ts
@@ -55,7 +55,8 @@ export type IFilesystemProvider = {
    *
    *  `position` must be a non-negative safe integer and `length` a positive one
    *  no larger than `MAX_FILE_RANGE_READ_BYTES`; anything else throws
-   *  `FileRangeReadRequestError` without reaching the host. */
+   *  `FileRangeReadRequestError` without reaching the host. The final byte
+   *  offset must also remain a safe integer. */
   readFileRange?(
     filePath: string,
     position: number,

--- a/src/main/providers/ssh-filesystem-provider-capabilities.test.ts
+++ b/src/main/providers/ssh-filesystem-provider-capabilities.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
-import { probeSshQuickOpenSearchCapability } from './ssh-filesystem-provider-capabilities'
+import {
+  probeSshQuickOpenSearchCapability,
+  probeSshRangedReadCapability
+} from './ssh-filesystem-provider-capabilities'
 import { JsonRpcErrorCode } from '../ssh/relay-protocol'
 
 describe('SSH Quick Open capability probe', () => {
@@ -32,5 +35,44 @@ describe('SSH Quick Open capability probe', () => {
     await expect(probeSshQuickOpenSearchCapability(mux as never)).rejects.toThrow(
       'connection closed'
     )
+  })
+})
+
+describe('SSH filesystem capability document', () => {
+  // fs.getCapabilities answers every feature at once. Probing per feature would
+  // spend an extra round trip per connection for a document already in hand.
+  it('is fetched once for every feature probe on a connection', async () => {
+    const mux = {
+      request: vi.fn().mockResolvedValue({ quickOpenSearchVersion: 1, rangedReadVersion: 1 })
+    }
+    await expect(probeSshQuickOpenSearchCapability(mux as never)).resolves.toBe(true)
+    await expect(probeSshRangedReadCapability(mux as never)).resolves.toBe(true)
+    expect(mux.request).toHaveBeenCalledTimes(1)
+  })
+
+  it('reads each feature independently off the shared document', async () => {
+    const mux = { request: vi.fn().mockResolvedValue({ quickOpenSearchVersion: 1 }) }
+    await expect(probeSshQuickOpenSearchCapability(mux as never)).resolves.toBe(true)
+    await expect(probeSshRangedReadCapability(mux as never)).resolves.toBe(false)
+  })
+
+  // A transport failure is not a verdict about the host, so it must not be the
+  // cached answer for the rest of the connection's life.
+  it('retries after a failed fetch instead of caching the failure', async () => {
+    const mux = {
+      request: vi
+        .fn()
+        .mockRejectedValueOnce(new Error('connection closed'))
+        .mockResolvedValue({ rangedReadVersion: 1 })
+    }
+    await expect(probeSshRangedReadCapability(mux as never)).rejects.toThrow('connection closed')
+    await expect(probeSshRangedReadCapability(mux as never)).resolves.toBe(true)
+    expect(mux.request).toHaveBeenCalledTimes(2)
+  })
+
+  it('treats a non-object response as no capabilities', async () => {
+    const mux = { request: vi.fn().mockResolvedValue('yes') }
+    await expect(probeSshRangedReadCapability(mux as never)).resolves.toBe(false)
+    await expect(probeSshQuickOpenSearchCapability(mux as never)).resolves.toBe(false)
   })
 })

--- a/src/main/providers/ssh-filesystem-provider-capabilities.test.ts
+++ b/src/main/providers/ssh-filesystem-provider-capabilities.test.ts
@@ -70,6 +70,35 @@ describe('SSH filesystem capability document', () => {
     expect(mux.request).toHaveBeenCalledTimes(2)
   })
 
+  // One document now backs every feature, so a caller walking away from its own
+  // probe must not evict the fetch a second feature is still waiting on --
+  // otherwise an aborted quick-open probe costs the ranged-read probe a round
+  // trip, and a caller that keeps aborting re-fetches forever.
+  it('keeps the in-flight document when one caller aborts its own probe', async () => {
+    let settle: (value: Record<string, unknown>) => void = () => {}
+    const mux = {
+      request: vi
+        .fn()
+        .mockImplementationOnce(
+          () =>
+            new Promise<Record<string, unknown>>((resolve) => {
+              settle = resolve
+            })
+        )
+        .mockResolvedValue({ rangedReadVersion: 1 })
+    }
+    const controller = new AbortController()
+    const abandoned = probeSshQuickOpenSearchCapability(mux as never, controller.signal)
+    const patient = probeSshRangedReadCapability(mux as never)
+    controller.abort()
+    await expect(abandoned).rejects.toThrow('client_disconnected')
+
+    settle({ rangedReadVersion: 1 })
+    await expect(patient).resolves.toBe(true)
+    await expect(probeSshRangedReadCapability(mux as never)).resolves.toBe(true)
+    expect(mux.request).toHaveBeenCalledTimes(1)
+  })
+
   it('treats a non-object response as no capabilities', async () => {
     const mux = { request: vi.fn().mockResolvedValue('yes') }
     await expect(probeSshRangedReadCapability(mux as never)).resolves.toBe(false)

--- a/src/main/providers/ssh-filesystem-provider-capabilities.test.ts
+++ b/src/main/providers/ssh-filesystem-provider-capabilities.test.ts
@@ -99,6 +99,31 @@ describe('SSH filesystem capability document', () => {
     expect(mux.request).toHaveBeenCalledTimes(1)
   })
 
+  it('retries when the fetch fails after its only waiter aborts', async () => {
+    let rejectFetch: (error: Error) => void = () => {}
+    const mux = {
+      request: vi
+        .fn()
+        .mockImplementationOnce(
+          () =>
+            new Promise((_resolve, reject) => {
+              rejectFetch = reject
+            })
+        )
+        .mockResolvedValue({ rangedReadVersion: 1 })
+    }
+    const controller = new AbortController()
+    const abandoned = probeSshRangedReadCapability(mux as never, controller.signal)
+    controller.abort()
+    await expect(abandoned).rejects.toThrow('client_disconnected')
+
+    rejectFetch(new Error('connection closed'))
+    await new Promise((resolve) => setImmediate(resolve))
+
+    await expect(probeSshRangedReadCapability(mux as never)).resolves.toBe(true)
+    expect(mux.request).toHaveBeenCalledTimes(2)
+  })
+
   it('treats a non-object response as no capabilities', async () => {
     const mux = { request: vi.fn().mockResolvedValue('yes') }
     await expect(probeSshRangedReadCapability(mux as never)).resolves.toBe(false)

--- a/src/main/providers/ssh-filesystem-provider-capabilities.ts
+++ b/src/main/providers/ssh-filesystem-provider-capabilities.ts
@@ -2,75 +2,66 @@ import type { SshChannelMultiplexer } from '../ssh/ssh-channel-multiplexer'
 import { isMethodNotFoundError } from '../ssh/ssh-filesystem-stream-reader'
 import { waitForSshCapabilityProbe } from './ssh-capability-probe-waiter'
 
-const quickOpenSearchSupport = new WeakMap<SshChannelMultiplexer, Promise<boolean>>()
+/** `null` means the host has no capability document at all: it predates
+ *  `fs.getCapabilities`, or answered with something that is not an object.
+ *  Either way every feature reads as unsupported. */
+type RelayFsCapabilities = Record<string, unknown> | null
 
-export function probeSshQuickOpenSearchCapability(
+const capabilitiesByMux = new WeakMap<SshChannelMultiplexer, Promise<RelayFsCapabilities>>()
+
+/** One `fs.getCapabilities` per multiplexer, shared by every feature probe --
+ *  the response is a single document, so fetching it once per feature would
+ *  spend a round trip for nothing. Keyed by the multiplexer, which is replaced
+ *  on reconnect, so a host upgraded behind a reconnect is re-probed.
+ *
+ *  A failed fetch is evicted so the next probe retries; a resolved one is not,
+ *  because a relay does not gain methods without a new connection. */
+function readSshFsCapabilities(
   mux: SshChannelMultiplexer,
   signal?: AbortSignal
-): Promise<boolean> {
-  const cached = quickOpenSearchSupport.get(mux)
+): Promise<RelayFsCapabilities> {
+  const cached = capabilitiesByMux.get(mux)
   const probe =
     cached ??
     mux
       .request('fs.getCapabilities', undefined, { timeoutMs: 5_000 })
-      .then((result) => {
-        const version = (result as { quickOpenSearchVersion?: unknown } | null)
-          ?.quickOpenSearchVersion
-        return version === 1
-      })
+      .then((result) =>
+        typeof result === 'object' && result !== null ? (result as Record<string, unknown>) : null
+      )
       .catch((error) => {
         if (isMethodNotFoundError(error)) {
-          return false
+          return null
         }
         throw error
       })
   if (!cached) {
-    quickOpenSearchSupport.set(mux, probe)
+    capabilitiesByMux.set(mux, probe)
   }
   return waitForSshCapabilityProbe(probe, signal).then(
-    (supported) => supported,
+    (capabilities) => capabilities,
     (error) => {
-      if (!signal?.aborted && quickOpenSearchSupport.get(mux) === probe) {
-        quickOpenSearchSupport.delete(mux)
+      if (!signal?.aborted && capabilitiesByMux.get(mux) === probe) {
+        capabilitiesByMux.delete(mux)
       }
       throw error
     }
   )
 }
 
-const rangedReadSupport = new WeakMap<SshChannelMultiplexer, Promise<boolean>>()
+export function probeSshQuickOpenSearchCapability(
+  mux: SshChannelMultiplexer,
+  signal?: AbortSignal
+): Promise<boolean> {
+  return readSshFsCapabilities(mux, signal).then(
+    (capabilities) => capabilities?.quickOpenSearchVersion === 1
+  )
+}
 
-/** Mirrors the quick-open probe: one cached `fs.getCapabilities` per mux rather
- *  than eating a guaranteed -32601 on every ranged read against an old relay. */
 export function probeSshRangedReadCapability(
   mux: SshChannelMultiplexer,
   signal?: AbortSignal
 ): Promise<boolean> {
-  const cached = rangedReadSupport.get(mux)
-  const probe =
-    cached ??
-    mux
-      .request('fs.getCapabilities', undefined, { timeoutMs: 5_000 })
-      .then((result) => {
-        const version = (result as { rangedReadVersion?: unknown } | null)?.rangedReadVersion
-        return version === 1
-      })
-      .catch((error) => {
-        if (isMethodNotFoundError(error)) {
-          return false
-        }
-        throw error
-      })
-  if (!cached) {
-    rangedReadSupport.set(mux, probe)
-  }
-  return waitForSshCapabilityProbe(probe, signal).then(
-    (supported) => supported,
-    (error) => {
-      if (!signal?.aborted && rangedReadSupport.get(mux) === probe) {
-        rangedReadSupport.delete(mux)
-      }
-      throw error
-    }
+  return readSshFsCapabilities(mux, signal).then(
+    (capabilities) => capabilities?.rangedReadVersion === 1
   )
 }

--- a/src/main/providers/ssh-filesystem-provider-capabilities.ts
+++ b/src/main/providers/ssh-filesystem-provider-capabilities.ts
@@ -37,3 +37,40 @@ export function probeSshQuickOpenSearchCapability(
     }
   )
 }
+
+const rangedReadSupport = new WeakMap<SshChannelMultiplexer, Promise<boolean>>()
+
+/** Mirrors the quick-open probe: one cached `fs.getCapabilities` per mux rather
+ *  than eating a guaranteed -32601 on every ranged read against an old relay. */
+export function probeSshRangedReadCapability(
+  mux: SshChannelMultiplexer,
+  signal?: AbortSignal
+): Promise<boolean> {
+  const cached = rangedReadSupport.get(mux)
+  const probe =
+    cached ??
+    mux
+      .request('fs.getCapabilities', undefined, { timeoutMs: 5_000 })
+      .then((result) => {
+        const version = (result as { rangedReadVersion?: unknown } | null)?.rangedReadVersion
+        return version === 1
+      })
+      .catch((error) => {
+        if (isMethodNotFoundError(error)) {
+          return false
+        }
+        throw error
+      })
+  if (!cached) {
+    rangedReadSupport.set(mux, probe)
+  }
+  return waitForSshCapabilityProbe(probe, signal).then(
+    (supported) => supported,
+    (error) => {
+      if (!signal?.aborted && rangedReadSupport.get(mux) === probe) {
+        rangedReadSupport.delete(mux)
+      }
+      throw error
+    }
+  )
+}

--- a/src/main/providers/ssh-filesystem-provider-capabilities.ts
+++ b/src/main/providers/ssh-filesystem-provider-capabilities.ts
@@ -36,16 +36,13 @@ function readSshFsCapabilities(
       })
   if (!cached) {
     capabilitiesByMux.set(mux, probe)
-  }
-  return waitForSshCapabilityProbe(probe, signal).then(
-    (capabilities) => capabilities,
-    (error) => {
-      if (!signal?.aborted && capabilitiesByMux.get(mux) === probe) {
+    void probe.catch(() => {
+      if (capabilitiesByMux.get(mux) === probe) {
         capabilitiesByMux.delete(mux)
       }
-      throw error
-    }
-  )
+    })
+  }
+  return waitForSshCapabilityProbe(probe, signal)
 }
 
 export function probeSshQuickOpenSearchCapability(

--- a/src/main/providers/ssh-filesystem-provider-range.test.ts
+++ b/src/main/providers/ssh-filesystem-provider-range.test.ts
@@ -74,7 +74,8 @@ describe('SshFilesystemProvider.readFileRange', () => {
       ['a fractional position', 0.5, 4],
       ['a zero length', 0, 0],
       ['a negative length', 0, -1],
-      ['an over-cap length', 0, MAX_FILE_RANGE_READ_BYTES + 1]
+      ['an over-cap length', 0, MAX_FILE_RANGE_READ_BYTES + 1],
+      ['a window past safe-integer offsets', Number.MAX_SAFE_INTEGER, 2]
     ])('rejects %s without a round trip', async (_label, position, length) => {
       const request = vi.fn()
       await expect(

--- a/src/main/providers/ssh-filesystem-provider-range.test.ts
+++ b/src/main/providers/ssh-filesystem-provider-range.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { SshFilesystemProvider } from './ssh-filesystem-provider'
 import { FileRangeReadUnsupportedError } from './filesystem-provider-contract'
+import { FileRangeReadRequestError, MAX_FILE_RANGE_READ_BYTES } from '../../shared/file-range-read'
 import type { SshChannelMultiplexer } from '../ssh/ssh-channel-multiplexer'
 
 function methodNotFound(): Error {
@@ -31,6 +32,26 @@ describe('SshFilesystemProvider.readFileRange', () => {
     )
   })
 
+  it('reports a short window as read without complaint', async () => {
+    const payload = Buffer.from('tail')
+    const request = vi.fn().mockResolvedValue({
+      base64: payload.toString('base64'),
+      bytesRead: payload.length
+    })
+    const result = await providerWith(request).readFileRange('/x.jsonl', 0, 64)
+    expect(result.bytesRead).toBe(4)
+    expect(result.bytes).toEqual(payload)
+  })
+
+  it('forwards an abort signal to the multiplexer', async () => {
+    const controller = new AbortController()
+    const request = vi.fn().mockResolvedValue({ base64: '', bytesRead: 0 })
+    await providerWith(request).readFileRange('/x.jsonl', 0, 4, { signal: controller.signal })
+    expect(request).toHaveBeenCalledWith('fs.readFileRange', expect.anything(), {
+      signal: controller.signal
+    })
+  })
+
   // Throwing beats a whole-file fallback here: a tailing caller issues several
   // reads per snapshot, so falling back per call is quadratic on a growing file.
   it('throws a typed unsupported error against a relay without the method', async () => {
@@ -43,6 +64,24 @@ describe('SshFilesystemProvider.readFileRange', () => {
   it('propagates a non-capability error unchanged', async () => {
     const request = vi.fn().mockRejectedValue(new Error('EACCES: permission denied'))
     await expect(providerWith(request).readFileRange('/x.jsonl', 0, 4)).rejects.toThrow(/EACCES/)
+  })
+
+  // The client runs the host's own validator, so a request the host would
+  // refuse fails as a typed error instead of an opaque -32000 a round trip later.
+  describe('request validation', () => {
+    it.each([
+      ['a negative position', -1, 4],
+      ['a fractional position', 0.5, 4],
+      ['a zero length', 0, 0],
+      ['a negative length', 0, -1],
+      ['an over-cap length', 0, MAX_FILE_RANGE_READ_BYTES + 1]
+    ])('rejects %s without a round trip', async (_label, position, length) => {
+      const request = vi.fn()
+      await expect(
+        providerWith(request).readFileRange('/x.jsonl', position, length)
+      ).rejects.toBeInstanceOf(FileRangeReadRequestError)
+      expect(request).not.toHaveBeenCalled()
+    })
   })
 
   // The remote is untrusted for framing: a count disagreeing with the payload
@@ -98,5 +137,14 @@ describe('SshFilesystemProvider.supportsFileRangeRead', () => {
     await provider.supportsFileRangeRead()
     await provider.supportsFileRangeRead()
     expect(request).toHaveBeenCalledTimes(1)
+  })
+
+  // The cache is keyed by the multiplexer, which is replaced on reconnect, so a
+  // second connection must not inherit the first host's answer.
+  it('does not share the answer across connections', async () => {
+    const legacy = vi.fn().mockResolvedValue({ quickOpenSearchVersion: 1 })
+    const current = vi.fn().mockResolvedValue({ rangedReadVersion: 1 })
+    await expect(providerWith(legacy).supportsFileRangeRead()).resolves.toBe(false)
+    await expect(providerWith(current).supportsFileRangeRead()).resolves.toBe(true)
   })
 })

--- a/src/main/providers/ssh-filesystem-provider-range.test.ts
+++ b/src/main/providers/ssh-filesystem-provider-range.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from 'vitest'
+import { SshFilesystemProvider } from './ssh-filesystem-provider'
+import { FileRangeReadUnsupportedError } from './filesystem-provider-contract'
+import type { SshChannelMultiplexer } from '../ssh/ssh-channel-multiplexer'
+
+function methodNotFound(): Error {
+  const err = new Error('Method not found: fs.readFileRange') as Error & { code?: number }
+  err.code = -32601
+  return err
+}
+
+function providerWith(request: ReturnType<typeof vi.fn>): SshFilesystemProvider {
+  const mux = { request, onNotification: () => () => {} } as unknown as SshChannelMultiplexer
+  return new SshFilesystemProvider('conn-1', mux)
+}
+
+describe('SshFilesystemProvider.readFileRange', () => {
+  it('decodes the base64 window the relay returned', async () => {
+    const payload = Buffer.from('hello')
+    const request = vi.fn().mockResolvedValue({
+      base64: payload.toString('base64'),
+      bytesRead: payload.length
+    })
+    const result = await providerWith(request).readFileRange('/x.jsonl', 7, 5)
+    expect(result.bytes).toEqual(payload)
+    expect(result.bytesRead).toBe(5)
+    expect(request).toHaveBeenCalledWith(
+      'fs.readFileRange',
+      { filePath: '/x.jsonl', position: 7, length: 5 },
+      undefined
+    )
+  })
+
+  // Throwing beats a whole-file fallback here: a tailing caller issues several
+  // reads per snapshot, so falling back per call is quadratic on a growing file.
+  it('throws a typed unsupported error against a relay without the method', async () => {
+    const request = vi.fn().mockRejectedValue(methodNotFound())
+    await expect(providerWith(request).readFileRange('/x.jsonl', 0, 4)).rejects.toBeInstanceOf(
+      FileRangeReadUnsupportedError
+    )
+  })
+
+  it('propagates a non-capability error unchanged', async () => {
+    const request = vi.fn().mockRejectedValue(new Error('EACCES: permission denied'))
+    await expect(providerWith(request).readFileRange('/x.jsonl', 0, 4)).rejects.toThrow(/EACCES/)
+  })
+
+  // The remote is untrusted for framing: a count disagreeing with the payload
+  // would shift every downstream offset while looking like a success.
+  it('rejects a byte count that disagrees with the payload', async () => {
+    const request = vi.fn().mockResolvedValue({
+      base64: Buffer.from('ab').toString('base64'),
+      bytesRead: 9
+    })
+    await expect(providerWith(request).readFileRange('/x.jsonl', 0, 10)).rejects.toThrow(
+      /inconsistent byte count/
+    )
+  })
+
+  it('rejects a byte count larger than the requested length', async () => {
+    const payload = Buffer.from('abcdef')
+    const request = vi.fn().mockResolvedValue({
+      base64: payload.toString('base64'),
+      bytesRead: payload.length
+    })
+    await expect(providerWith(request).readFileRange('/x.jsonl', 0, 2)).rejects.toThrow(
+      /inconsistent byte count/
+    )
+  })
+
+  it('rejects a malformed response', async () => {
+    const request = vi.fn().mockResolvedValue({ bytesRead: 3 })
+    await expect(providerWith(request).readFileRange('/x.jsonl', 0, 3)).rejects.toThrow(
+      /malformed response/
+    )
+  })
+})
+
+describe('SshFilesystemProvider.supportsFileRangeRead', () => {
+  it('is true when the relay advertises the capability', async () => {
+    const request = vi.fn().mockResolvedValue({ rangedReadVersion: 1 })
+    await expect(providerWith(request).supportsFileRangeRead()).resolves.toBe(true)
+  })
+
+  it('is false when the relay omits it', async () => {
+    const request = vi.fn().mockResolvedValue({ quickOpenSearchVersion: 1 })
+    await expect(providerWith(request).supportsFileRangeRead()).resolves.toBe(false)
+  })
+
+  it('is false when the relay predates fs.getCapabilities', async () => {
+    const request = vi.fn().mockRejectedValue(methodNotFound())
+    await expect(providerWith(request).supportsFileRangeRead()).resolves.toBe(false)
+  })
+
+  it('probes once per connection and caches the answer', async () => {
+    const request = vi.fn().mockResolvedValue({ rangedReadVersion: 1 })
+    const provider = providerWith(request)
+    await provider.supportsFileRangeRead()
+    await provider.supportsFileRangeRead()
+    expect(request).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/providers/ssh-filesystem-provider.ts
+++ b/src/main/providers/ssh-filesystem-provider.ts
@@ -16,6 +16,7 @@ import {
 } from './ssh-filesystem-provider-watch'
 import type {
   IFilesystemProvider,
+  FileRangeReadResult,
   FileReadLimits,
   FileStat,
   FileReadResult,
@@ -46,9 +47,6 @@ export class SshFilesystemProvider implements IFilesystemProvider {
   private disposed = false
   private loggedStreamFallback = false
   readonly downloadFolder?: IFilesystemProvider['downloadFolder']
-  // Optional capabilities are wired in the constructor, matching downloadFolder.
-  readonly readFileRange: NonNullable<IFilesystemProvider['readFileRange']>
-  readonly supportsFileRangeRead: NonNullable<IFilesystemProvider['supportsFileRangeRead']>
 
   constructor(
     connectionId: string,
@@ -71,11 +69,6 @@ export class SshFilesystemProvider implements IFilesystemProvider {
           windowsRemotePaths
         })
     }
-
-    this.readFileRange = (filePath, position, length, options) =>
-      readSshFileRange(this.mux, filePath, position, length, options?.signal)
-    this.supportsFileRangeRead = (options) =>
-      probeSshRangedReadCapability(this.mux, options?.signal)
 
     this.unsubscribeNotifications = mux.onNotification((method, params) =>
       routeSshFilesystemWatchNotification(this.watchListeners, method, params)
@@ -125,6 +118,19 @@ export class SshFilesystemProvider implements IFilesystemProvider {
       }
       throw err
     }
+  }
+
+  readFileRange(
+    filePath: string,
+    position: number,
+    length: number,
+    options?: { signal?: AbortSignal }
+  ): Promise<FileRangeReadResult> {
+    return readSshFileRange(this.mux, filePath, position, length, options?.signal)
+  }
+
+  supportsFileRangeRead(options?: { signal?: AbortSignal }): Promise<boolean> {
+    return probeSshRangedReadCapability(this.mux, options?.signal)
   }
 
   readTerminalArtifact(

--- a/src/main/providers/ssh-filesystem-provider.ts
+++ b/src/main/providers/ssh-filesystem-provider.ts
@@ -27,7 +27,15 @@ import type { DirEntry, FsChangeEvent } from '../../shared/filesystem-entry-type
 import { routeSshFilesystemWatchNotification } from './ssh-filesystem-watch-notifications'
 import type { WorkspaceSpaceDirectoryScanResult } from '../../shared/workspace-space-types'
 import { isWindowsRemoteHost, type RemoteHostPlatform } from '../ssh/ssh-remote-platform'
-import { probeSshQuickOpenSearchCapability } from './ssh-filesystem-provider-capabilities'
+import {
+  probeSshQuickOpenSearchCapability,
+  probeSshRangedReadCapability
+} from './ssh-filesystem-provider-capabilities'
+import { readSshFileRange } from './ssh-filesystem-range-read'
+import {
+  readSshTerminalArtifact,
+  writeSshTerminalArtifact
+} from './ssh-filesystem-terminal-artifact'
 const WORKSPACE_SPACE_SCAN_TIMEOUT_MS = 130_000
 export class SshFilesystemProvider implements IFilesystemProvider {
   private connectionId: string
@@ -38,6 +46,9 @@ export class SshFilesystemProvider implements IFilesystemProvider {
   private disposed = false
   private loggedStreamFallback = false
   readonly downloadFolder?: IFilesystemProvider['downloadFolder']
+  // Optional capabilities are wired in the constructor, matching downloadFolder.
+  readonly readFileRange: NonNullable<IFilesystemProvider['readFileRange']>
+  readonly supportsFileRangeRead: NonNullable<IFilesystemProvider['supportsFileRangeRead']>
 
   constructor(
     connectionId: string,
@@ -60,6 +71,11 @@ export class SshFilesystemProvider implements IFilesystemProvider {
           windowsRemotePaths
         })
     }
+
+    this.readFileRange = (filePath, position, length, options) =>
+      readSshFileRange(this.mux, filePath, position, length, options?.signal)
+    this.supportsFileRangeRead = (options) =>
+      probeSshRangedReadCapability(this.mux, options?.signal)
 
     this.unsubscribeNotifications = mux.onNotification((method, params) =>
       routeSshFilesystemWatchNotification(this.watchListeners, method, params)
@@ -111,25 +127,19 @@ export class SshFilesystemProvider implements IFilesystemProvider {
     }
   }
 
-  async readTerminalArtifact(
+  readTerminalArtifact(
     filePath: string,
     options: TerminalArtifactAccessOptions
   ): Promise<FileReadResult> {
-    try {
-      return (await this.mux.request('fs.readTerminalArtifact', {
-        filePath,
-        expectedRealPath: options.expectedRealPath,
-        expectedStatIdentity: options.expectedStatIdentity,
-        maxBytes: options.maxBytes
-      })) as FileReadResult
-    } catch (err) {
-      if (isMethodNotFoundError(err)) {
-        throw new Error(
-          'Remote terminal artifact access is unavailable. Reconnect the SSH target before retrying.'
-        )
-      }
-      throw err
-    }
+    return readSshTerminalArtifact(this.mux, filePath, options)
+  }
+
+  writeTerminalArtifact(
+    filePath: string,
+    content: string,
+    options: TerminalArtifactAccessOptions
+  ): Promise<FileStat> {
+    return writeSshTerminalArtifact(this.mux, filePath, content, options)
   }
 
   async downloadFile(sourcePath: string, destinationPath: string): Promise<void> {
@@ -161,34 +171,6 @@ export class SshFilesystemProvider implements IFilesystemProvider {
 
   async writeFile(filePath: string, content: string): Promise<void> {
     await this.mux.request('fs.writeFile', { filePath, content })
-  }
-
-  async writeTerminalArtifact(
-    filePath: string,
-    content: string,
-    options: TerminalArtifactAccessOptions
-  ): Promise<FileStat> {
-    let result: { stat?: FileStat }
-    try {
-      result = (await this.mux.request('fs.writeTerminalArtifact', {
-        filePath,
-        content,
-        expectedRealPath: options.expectedRealPath,
-        expectedStatIdentity: options.expectedStatIdentity,
-        maxBytes: options.maxBytes
-      })) as { stat?: FileStat }
-    } catch (err) {
-      if (isMethodNotFoundError(err)) {
-        throw new Error(
-          'Remote terminal artifact access is unavailable. Reconnect the SSH target before retrying.'
-        )
-      }
-      throw err
-    }
-    if (!result.stat) {
-      throw new Error('terminal_file_grant_stale')
-    }
-    return result.stat
   }
 
   async writeFileBase64(filePath: string, contentBase64: string): Promise<void> {

--- a/src/main/providers/ssh-filesystem-range-read.ts
+++ b/src/main/providers/ssh-filesystem-range-read.ts
@@ -1,5 +1,6 @@
 import type { SshChannelMultiplexer } from '../ssh/ssh-channel-multiplexer'
 import { isMethodNotFoundError } from '../ssh/ssh-filesystem-stream-reader'
+import { validateFileRangeRequest } from '../../shared/file-range-read'
 import {
   FileRangeReadUnsupportedError,
   type FileRangeReadResult
@@ -8,12 +9,19 @@ import {
 export async function readSshFileRange(
   mux: SshChannelMultiplexer,
   filePath: string,
-  position: number,
-  length: number,
+  rawPosition: number,
+  rawLength: number,
   signal?: AbortSignal
 ): Promise<FileRangeReadResult> {
+  // Same validator the host runs, so an out-of-contract request fails locally
+  // as a typed error instead of costing a round trip and coming back as an
+  // opaque -32000.
+  const { position, length } = validateFileRangeRequest(rawPosition, rawLength)
   let result: unknown
   try {
+    // No timeoutMs: the multiplexer's 30s default is right for a bounded
+    // MAX_FILE_RANGE_READ_BYTES window on a slow link. The capability probe
+    // pins a shorter one because it gates a UI decision, not a data read.
     result = await mux.request(
       'fs.readFileRange',
       { filePath, position, length },

--- a/src/main/providers/ssh-filesystem-range-read.ts
+++ b/src/main/providers/ssh-filesystem-range-read.ts
@@ -1,0 +1,47 @@
+import type { SshChannelMultiplexer } from '../ssh/ssh-channel-multiplexer'
+import { isMethodNotFoundError } from '../ssh/ssh-filesystem-stream-reader'
+import {
+  FileRangeReadUnsupportedError,
+  type FileRangeReadResult
+} from './filesystem-provider-contract'
+
+export async function readSshFileRange(
+  mux: SshChannelMultiplexer,
+  filePath: string,
+  position: number,
+  length: number,
+  signal?: AbortSignal
+): Promise<FileRangeReadResult> {
+  let result: unknown
+  try {
+    result = await mux.request(
+      'fs.readFileRange',
+      { filePath, position, length },
+      signal ? { signal } : undefined
+    )
+  } catch (err) {
+    // Why throw rather than read the whole file here: a tailing caller issues
+    // several reads per snapshot, so a per-call fallback is quadratic on a
+    // growing transcript. Callers probe once and snapshot instead.
+    if (isMethodNotFoundError(err)) {
+      throw new FileRangeReadUnsupportedError()
+    }
+    throw err
+  }
+  const payload = result as { base64?: unknown; bytesRead?: unknown } | null
+  if (typeof payload?.base64 !== 'string' || typeof payload.bytesRead !== 'number') {
+    throw new Error('fs.readFileRange returned a malformed response')
+  }
+  const bytes = Buffer.from(payload.base64, 'base64')
+  // The remote is untrusted for framing: a count that disagrees with the
+  // payload would silently shift every downstream offset.
+  if (
+    !Number.isSafeInteger(payload.bytesRead) ||
+    payload.bytesRead < 0 ||
+    payload.bytesRead > length ||
+    payload.bytesRead !== bytes.length
+  ) {
+    throw new Error('fs.readFileRange returned an inconsistent byte count')
+  }
+  return { bytes, bytesRead: payload.bytesRead }
+}

--- a/src/main/providers/ssh-filesystem-terminal-artifact.ts
+++ b/src/main/providers/ssh-filesystem-terminal-artifact.ts
@@ -1,0 +1,54 @@
+import type { SshChannelMultiplexer } from '../ssh/ssh-channel-multiplexer'
+import { isMethodNotFoundError } from '../ssh/ssh-filesystem-stream-reader'
+import type { FileReadResult, FileStat, TerminalArtifactAccessOptions } from './types'
+
+export async function readSshTerminalArtifact(
+  mux: SshChannelMultiplexer,
+  filePath: string,
+  options: TerminalArtifactAccessOptions
+): Promise<FileReadResult> {
+  try {
+    return (await mux.request('fs.readTerminalArtifact', {
+      filePath,
+      expectedRealPath: options.expectedRealPath,
+      expectedStatIdentity: options.expectedStatIdentity,
+      maxBytes: options.maxBytes
+    })) as FileReadResult
+  } catch (err) {
+    if (isMethodNotFoundError(err)) {
+      throw new Error(
+        'Remote terminal artifact access is unavailable. Reconnect the SSH target before retrying.'
+      )
+    }
+    throw err
+  }
+}
+
+export async function writeSshTerminalArtifact(
+  mux: SshChannelMultiplexer,
+  filePath: string,
+  content: string,
+  options: TerminalArtifactAccessOptions
+): Promise<FileStat> {
+  let result: { stat?: FileStat }
+  try {
+    result = (await mux.request('fs.writeTerminalArtifact', {
+      filePath,
+      content,
+      expectedRealPath: options.expectedRealPath,
+      expectedStatIdentity: options.expectedStatIdentity,
+      maxBytes: options.maxBytes
+    })) as { stat?: FileStat }
+  } catch (err) {
+    if (isMethodNotFoundError(err)) {
+      throw new Error(
+        'Remote terminal artifact access is unavailable. Reconnect the SSH target before retrying.'
+      )
+    }
+    throw err
+  }
+  if (!result.stat) {
+    throw new Error('terminal_file_grant_stale')
+  }
+  return result.stat
+}

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -18,6 +18,7 @@ export type {
 // ─── Filesystem Provider ────────────────────────────────────────────
 
 export type {
+  FileRangeReadResult,
   FileReadLimits,
   FileReadResult,
   FileStat,
@@ -25,6 +26,8 @@ export type {
   IFilesystemProvider,
   TerminalArtifactAccessOptions
 } from './filesystem-provider-contract'
+
+export { FileRangeReadUnsupportedError } from './filesystem-provider-contract'
 
 // ─── Git Provider ───────────────────────────────────────────────────
 

--- a/src/relay/fs-handler-file-range-dispatch.test.ts
+++ b/src/relay/fs-handler-file-range-dispatch.test.ts
@@ -1,0 +1,160 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { FsHandler } from './fs-handler'
+import { RelayContext } from './context'
+import { RelayDispatcher } from './dispatcher'
+import { encodeJsonRpcFrame, RelayErrorCode } from './protocol'
+import { FileRangeReadRequestError, MAX_FILE_RANGE_READ_BYTES } from '../shared/file-range-read'
+
+/** Minimal dispatcher: this suite only needs the registered request handlers.
+ *  The full harness lives in fs-handler.test.ts, which is at its line budget. */
+function createHandlerUnderTest() {
+  const requests = new Map<string, (params: Record<string, unknown>) => Promise<unknown>>()
+  const dispatcher = {
+    onRequest: (method: string, handler: (params: Record<string, unknown>) => Promise<unknown>) => {
+      requests.set(method, handler)
+    },
+    onNotification: vi.fn(),
+    notify: vi.fn(),
+    notifyClient: vi.fn(),
+    onClientDetached: vi.fn(() => () => {})
+  }
+  const handler = new FsHandler(dispatcher as unknown as RelayDispatcher, new RelayContext())
+  const call = (method: string, params: Record<string, unknown>): Promise<unknown> => {
+    const registered = requests.get(method)
+    if (!registered) {
+      throw new Error(`No handler for ${method}`)
+    }
+    return registered(params)
+  }
+  return { handler, call }
+}
+
+let root: string
+let filePath: string
+let underTest: ReturnType<typeof createHandlerUnderTest>
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'orca-relay-range-dispatch-'))
+  filePath = join(root, 'data.jsonl')
+  await writeFile(filePath, '0123456789')
+  underTest = createHandlerUnderTest()
+})
+
+afterEach(async () => {
+  underTest.handler.dispose()
+  await rm(root, { recursive: true, force: true })
+})
+
+describe('fs.readFileRange dispatch', () => {
+  it('serves the requested window', async () => {
+    const result = (await underTest.call('fs.readFileRange', {
+      filePath,
+      position: 2,
+      length: 3
+    })) as { base64: string; bytesRead: number }
+    expect(Buffer.from(result.base64, 'base64').toString('utf8')).toBe('234')
+    expect(result.bytesRead).toBe(3)
+  })
+
+  // Params reach the handler as an unschema-d bag, so a missing or wrong-typed
+  // path must be a stated refusal rather than a TypeError from expandTilde.
+  it.each([
+    ['a missing filePath', {}],
+    ['a non-string filePath', { filePath: 42 }],
+    ['an empty filePath', { filePath: '' }]
+  ])('rejects %s', async (_label, params) => {
+    await expect(
+      underTest.call('fs.readFileRange', { position: 0, length: 4, ...params })
+    ).rejects.toBeInstanceOf(FileRangeReadRequestError)
+  })
+
+  it('rejects an out-of-contract offset before touching the file', async () => {
+    await expect(
+      underTest.call('fs.readFileRange', { filePath, position: -1, length: 4 })
+    ).rejects.toBeInstanceOf(FileRangeReadRequestError)
+  })
+})
+
+// A direct call to readRelayFileRange never meets the writer, which is where an
+// over-wide window actually dies: a response frame past the control lane's
+// budget is demoted to `legacy-response` and refused as ResponseOverCapacity.
+// This drives a full-cap read through the real dispatcher instead.
+describe('fs.readFileRange over the real dispatcher', () => {
+  function decodePayload(frame: Buffer): Record<string, unknown> {
+    const length = frame.readUInt32BE(9)
+    return JSON.parse(frame.subarray(13, 13 + length).toString('utf-8'))
+  }
+
+  it('delivers a full-cap window as a result, not a capacity error', async () => {
+    const contents = Buffer.allocUnsafe(MAX_FILE_RANGE_READ_BYTES)
+    for (let i = 0; i < contents.length; i++) {
+      contents[i] = (i * 37) % 256
+    }
+    const capPath = join(root, 'full-cap.bin')
+    await writeFile(capPath, contents)
+
+    const frames: Buffer[] = []
+    let closes = 0
+    const dispatcher = new RelayDispatcher(
+      (data: Buffer) => {
+        frames.push(Buffer.from(data))
+        return true
+      },
+      {
+        writableHighWaterMark: () => 64 * 1024,
+        writableLength: () => 0,
+        close: () => {
+          closes++
+        }
+      }
+    )
+    const handler = new FsHandler(dispatcher, new RelayContext())
+    try {
+      dispatcher.feed(
+        encodeJsonRpcFrame(
+          {
+            jsonrpc: '2.0',
+            id: 91,
+            method: 'fs.readFileRange',
+            params: { filePath: capPath, position: 0, length: MAX_FILE_RANGE_READ_BYTES }
+          },
+          1,
+          0
+        )
+      )
+      for (let i = 0; i < 200 && frames.length === 0; i++) {
+        await new Promise((resolve) => setImmediate(resolve))
+      }
+      expect(frames).toHaveLength(1)
+      const response = decodePayload(frames[0]) as {
+        id: number
+        error?: { code: number }
+        result?: { base64: string; bytesRead: number }
+      }
+      expect(response.id).toBe(91)
+      expect(response.error?.code).not.toBe(RelayErrorCode.ResponseOverCapacity)
+      expect(response.error).toBeUndefined()
+      expect(response.result?.bytesRead).toBe(MAX_FILE_RANGE_READ_BYTES)
+      expect(Buffer.from(response.result?.base64 ?? '', 'base64').equals(contents)).toBe(true)
+      expect(closes).toBe(0)
+    } finally {
+      handler.dispose()
+      dispatcher.dispose()
+    }
+  })
+})
+
+describe('fs.getCapabilities', () => {
+  // Rule 1 of docs/reference/remote-wire-compatibility.md: the ranged-read flag
+  // is additive. Dropping the pre-existing key would strand an older desktop's
+  // quick-open probe on a host that still serves it.
+  it('advertises ranged reads without dropping the existing capability', async () => {
+    await expect(underTest.call('fs.getCapabilities', {})).resolves.toEqual({
+      quickOpenSearchVersion: 1,
+      rangedReadVersion: 1
+    })
+  })
+})

--- a/src/relay/fs-handler-file-range-dispatch.test.ts
+++ b/src/relay/fs-handler-file-range-dispatch.test.ts
@@ -125,10 +125,7 @@ describe('fs.readFileRange over the real dispatcher', () => {
           0
         )
       )
-      for (let i = 0; i < 200 && frames.length === 0; i++) {
-        await new Promise((resolve) => setImmediate(resolve))
-      }
-      expect(frames).toHaveLength(1)
+      await vi.waitFor(() => expect(frames).toHaveLength(1), { timeout: 4_000 })
       const response = decodePayload(frames[0]) as {
         id: number
         error?: { code: number }

--- a/src/relay/fs-handler-file-range.test.ts
+++ b/src/relay/fs-handler-file-range.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import { readRelayFileRange } from './fs-handler-file-range'
+import { readFullStreamChunk } from './fs-handler-file-read'
 import { FileRangeReadRequestError, MAX_FILE_RANGE_READ_BYTES } from '../shared/file-range-read'
 import { HEADER_LENGTH, prepareJsonRpcPayload } from './protocol'
 import { DISPATCHER_CONTROL_QUEUE_MAX_BYTES } from './dispatcher-writer-admission'
@@ -62,8 +63,9 @@ describe('readRelayFileRange', () => {
     expect(result.bytesRead).toBe(0)
   })
 
-  // The window is one fixed allocation filled across however many syscalls the
-  // kernel takes, so every partial read has to land at the right offset in it.
+  // A regular file answers a full-cap read in one syscall, so this pins offset
+  // arithmetic over a many-page window, not the fill loop -- that is covered
+  // against a stub reader in `readFullStreamChunk` below.
   it('assembles a many-page window without misplacing any byte', async () => {
     const size = MAX_FILE_RANGE_READ_BYTES
     const contents = Buffer.allocUnsafe(size)
@@ -97,9 +99,13 @@ describe('readRelayFileRange', () => {
   // The cap is a TRANSPORT budget, not just a memory one. A response frame over
   // DISPATCHER_CONTROL_QUEUE_MAX_BYTES is demoted to the `legacy-response` lane,
   // which the writer refuses once the producer queue is busy -- so an over-wide
-  // cap fails with ResponseOverCapacity depending on unrelated load. A full-cap
-  // window of incompressible bytes must stay inside the control lane.
-  it('encodes a full-cap window into a frame the control lane always admits', async () => {
+  // cap fails with ResponseOverCapacity depending on unrelated load.
+  //
+  // Fitting the lane once is not enough: the control queue is a SHARED budget
+  // and overflowing it closes the client, so a full-cap frame has to leave room
+  // for a second one. Anything wider lets two pipelined tail reads -- or one
+  // read racing an unrelated response -- kill the connection.
+  it('leaves control-queue headroom for a second full-cap window', async () => {
     const contents = Buffer.allocUnsafe(MAX_FILE_RANGE_READ_BYTES)
     for (let i = 0; i < contents.length; i++) {
       contents[i] = (i * 37) % 256
@@ -110,6 +116,7 @@ describe('readRelayFileRange', () => {
     const frameBytes =
       HEADER_LENGTH + prepareJsonRpcPayload({ jsonrpc: '2.0', id: 4294967295, result }).byteLength
     expect(frameBytes).toBeLessThanOrEqual(DISPATCHER_CONTROL_QUEUE_MAX_BYTES)
+    expect(frameBytes * 2).toBeLessThanOrEqual(DISPATCHER_CONTROL_QUEUE_MAX_BYTES)
   })
 
   it('rejects a missing file', async () => {
@@ -163,5 +170,47 @@ describe('readRelayFileRange', () => {
         FileRangeReadRequestError
       )
     })
+  })
+})
+
+// The fill loop is what makes "short result == EOF" true. A regular file hands
+// back a whole window in one syscall, so the loop only shows up against a
+// reader that answers partially -- a pipe, a network filesystem, a large read
+// interrupted by a signal.
+describe('readFullStreamChunk', () => {
+  function partialReader(source: Buffer, perCall: number) {
+    const calls: { offset: number; length: number; position: number }[] = []
+    return {
+      calls,
+      read(buffer: Buffer, offset: number, length: number, position: number) {
+        calls.push({ offset, length, position })
+        const slice = source.subarray(position, position + Math.min(length, perCall))
+        slice.copy(buffer, offset)
+        return Promise.resolve({ bytesRead: slice.length })
+      }
+    }
+  }
+
+  it('fills the window across partial reads, each landing at its own offset', async () => {
+    const source = Buffer.from('abcdefghij')
+    const reader = partialReader(source, 3)
+    const buffer = Buffer.alloc(6)
+    const bytesRead = await readFullStreamChunk(reader, buffer, 6, 2)
+    expect(bytesRead).toBe(6)
+    expect(buffer.toString('utf8')).toBe('cdefgh')
+    expect(reader.calls).toEqual([
+      { offset: 0, length: 6, position: 2 },
+      { offset: 3, length: 3, position: 5 }
+    ])
+  })
+
+  // Without the zero check the loop would spin forever on a reader at EOF.
+  it('stops at the first empty read and reports only what it filled', async () => {
+    const source = Buffer.from('abcd')
+    const reader = partialReader(source, 3)
+    const buffer = Buffer.alloc(16)
+    const bytesRead = await readFullStreamChunk(reader, buffer, 16, 0)
+    expect(bytesRead).toBe(4)
+    expect(buffer.subarray(0, bytesRead).toString('utf8')).toBe('abcd')
   })
 })

--- a/src/relay/fs-handler-file-range.test.ts
+++ b/src/relay/fs-handler-file-range.test.ts
@@ -1,0 +1,89 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  MAX_RELAY_RANGE_READ_BYTES,
+  RelayRangeTooLargeError,
+  readRelayFileRange
+} from './fs-handler-file-range'
+
+let roots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(roots.map((root) => rm(root, { recursive: true, force: true })))
+  roots = []
+})
+
+async function fileWith(contents: Buffer | string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'orca-relay-range-'))
+  roots.push(root)
+  const path = join(root, 'data.bin')
+  await writeFile(path, contents)
+  return path
+}
+
+function decode(base64: string): Buffer {
+  return Buffer.from(base64, 'base64')
+}
+
+describe('readRelayFileRange', () => {
+  it('returns exactly the requested window', async () => {
+    const path = await fileWith('0123456789')
+    const result = await readRelayFileRange(path, 3, 4)
+    expect(decode(result.base64).toString('utf8')).toBe('3456')
+    expect(result.bytesRead).toBe(4)
+  })
+
+  it('reads from a non-zero position to the end', async () => {
+    const path = await fileWith('abcdef')
+    const result = await readRelayFileRange(path, 4, 2)
+    expect(decode(result.base64).toString('utf8')).toBe('ef')
+  })
+
+  // A short result must mean EOF and nothing else, or a caller advancing a
+  // cursor by bytesRead would silently skip data.
+  it('short-reads only at end of file', async () => {
+    const path = await fileWith('abc')
+    const result = await readRelayFileRange(path, 1, 100)
+    expect(result.bytesRead).toBe(2)
+    expect(decode(result.base64).toString('utf8')).toBe('bc')
+  })
+
+  it('returns zero bytes when the position is past the end', async () => {
+    const path = await fileWith('abc')
+    const result = await readRelayFileRange(path, 99, 10)
+    expect(result.bytesRead).toBe(0)
+    expect(decode(result.base64)).toHaveLength(0)
+  })
+
+  // Base64 rather than utf-8: a range boundary can split a multi-byte sequence,
+  // and a utf-8 round trip would substitute U+FFFD and shift every later offset.
+  it('preserves bytes that split a multi-byte character at both edges', async () => {
+    const text = Buffer.from('aé漢b', 'utf8')
+    const path = await fileWith(text)
+    const middle = await readRelayFileRange(path, 1, 3)
+    expect(decode(middle.base64)).toEqual(text.subarray(1, 4))
+  })
+
+  it('round-trips arbitrary binary bytes', async () => {
+    const bytes = Buffer.from([0x00, 0xff, 0x0a, 0x80, 0x7f])
+    const path = await fileWith(bytes)
+    const result = await readRelayFileRange(path, 0, bytes.length)
+    expect(decode(result.base64)).toEqual(bytes)
+  })
+
+  // Rejecting beats clamping: a clamped read is indistinguishable from EOF.
+  it('rejects an over-cap request instead of silently clamping', async () => {
+    const path = await fileWith('abc')
+    await expect(
+      readRelayFileRange(path, 0, MAX_RELAY_RANGE_READ_BYTES + 1)
+    ).rejects.toBeInstanceOf(RelayRangeTooLargeError)
+  })
+
+  it('rejects a missing file', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-relay-range-missing-'))
+    roots.push(root)
+    await expect(readRelayFileRange(join(root, 'nope.bin'), 0, 4)).rejects.toThrow()
+  })
+})

--- a/src/relay/fs-handler-file-range.test.ts
+++ b/src/relay/fs-handler-file-range.test.ts
@@ -2,11 +2,10 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
-import {
-  MAX_RELAY_RANGE_READ_BYTES,
-  RelayRangeTooLargeError,
-  readRelayFileRange
-} from './fs-handler-file-range'
+import { readRelayFileRange } from './fs-handler-file-range'
+import { FileRangeReadRequestError, MAX_FILE_RANGE_READ_BYTES } from '../shared/file-range-read'
+import { HEADER_LENGTH, prepareJsonRpcPayload } from './protocol'
+import { DISPATCHER_CONTROL_QUEUE_MAX_BYTES } from './dispatcher-writer-admission'
 
 let roots: string[] = []
 
@@ -57,6 +56,28 @@ describe('readRelayFileRange', () => {
     expect(decode(result.base64)).toHaveLength(0)
   })
 
+  it('returns zero bytes when the position is exactly at the end', async () => {
+    const path = await fileWith('abc')
+    const result = await readRelayFileRange(path, 3, 10)
+    expect(result.bytesRead).toBe(0)
+  })
+
+  // The window is one fixed allocation filled across however many syscalls the
+  // kernel takes, so every partial read has to land at the right offset in it.
+  it('assembles a many-page window without misplacing any byte', async () => {
+    const size = MAX_FILE_RANGE_READ_BYTES
+    const contents = Buffer.allocUnsafe(size)
+    for (let i = 0; i < size; i++) {
+      contents[i] = i % 251
+    }
+    const path = await fileWith(contents)
+    const result = await readRelayFileRange(path, 1024, size - 1024)
+    expect(result.bytesRead).toBe(size - 1024)
+    // .equals(), not toEqual(): a byte-wise diff of a 256 KiB buffer costs
+    // minutes when it passes.
+    expect(decode(result.base64).equals(contents.subarray(1024))).toBe(true)
+  })
+
   // Base64 rather than utf-8: a range boundary can split a multi-byte sequence,
   // and a utf-8 round trip would substitute U+FFFD and shift every later offset.
   it('preserves bytes that split a multi-byte character at both edges', async () => {
@@ -73,17 +94,74 @@ describe('readRelayFileRange', () => {
     expect(decode(result.base64)).toEqual(bytes)
   })
 
-  // Rejecting beats clamping: a clamped read is indistinguishable from EOF.
-  it('rejects an over-cap request instead of silently clamping', async () => {
-    const path = await fileWith('abc')
-    await expect(
-      readRelayFileRange(path, 0, MAX_RELAY_RANGE_READ_BYTES + 1)
-    ).rejects.toBeInstanceOf(RelayRangeTooLargeError)
+  // The cap is a TRANSPORT budget, not just a memory one. A response frame over
+  // DISPATCHER_CONTROL_QUEUE_MAX_BYTES is demoted to the `legacy-response` lane,
+  // which the writer refuses once the producer queue is busy -- so an over-wide
+  // cap fails with ResponseOverCapacity depending on unrelated load. A full-cap
+  // window of incompressible bytes must stay inside the control lane.
+  it('encodes a full-cap window into a frame the control lane always admits', async () => {
+    const contents = Buffer.allocUnsafe(MAX_FILE_RANGE_READ_BYTES)
+    for (let i = 0; i < contents.length; i++) {
+      contents[i] = (i * 37) % 256
+    }
+    const path = await fileWith(contents)
+    const result = await readRelayFileRange(path, 0, MAX_FILE_RANGE_READ_BYTES)
+    expect(result.bytesRead).toBe(MAX_FILE_RANGE_READ_BYTES)
+    const frameBytes =
+      HEADER_LENGTH + prepareJsonRpcPayload({ jsonrpc: '2.0', id: 4294967295, result }).byteLength
+    expect(frameBytes).toBeLessThanOrEqual(DISPATCHER_CONTROL_QUEUE_MAX_BYTES)
   })
 
   it('rejects a missing file', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-relay-range-missing-'))
     roots.push(root)
     await expect(readRelayFileRange(join(root, 'nope.bin'), 0, 4)).rejects.toThrow()
+  })
+
+  // Every rejection below happens before the file is opened: these offsets go
+  // straight into a read syscall and the relay has no request schema.
+  describe('request validation', () => {
+    // Rejecting beats clamping: a clamped read is indistinguishable from EOF.
+    it('rejects an over-cap length instead of silently clamping', async () => {
+      const path = await fileWith('abc')
+      await expect(
+        readRelayFileRange(path, 0, MAX_FILE_RANGE_READ_BYTES + 1)
+      ).rejects.toBeInstanceOf(FileRangeReadRequestError)
+    })
+
+    it('accepts a length exactly at the cap', async () => {
+      const path = await fileWith('abc')
+      const result = await readRelayFileRange(path, 0, MAX_FILE_RANGE_READ_BYTES)
+      expect(result.bytesRead).toBe(3)
+    })
+
+    it.each([
+      ['a negative position', -1, 4],
+      ['a fractional position', 1.5, 4],
+      ['a NaN position', Number.NaN, 4],
+      ['an infinite position', Number.POSITIVE_INFINITY, 4],
+      ['a position past the safe-integer range', Number.MAX_SAFE_INTEGER + 2, 4],
+      ['a zero length', 0, 0],
+      ['a negative length', 0, -4],
+      ['a fractional length', 0, 4.5],
+      ['a NaN length', 0, Number.NaN]
+    ])('rejects %s', async (_label, position, length) => {
+      const path = await fileWith('abc')
+      await expect(readRelayFileRange(path, position, length)).rejects.toBeInstanceOf(
+        FileRangeReadRequestError
+      )
+    })
+
+    it.each([
+      ['a missing position', undefined, 4],
+      ['a string position', '0', 4],
+      ['a missing length', 0, undefined],
+      ['a string length', 0, '4']
+    ])('rejects %s from an unschema-d param bag', async (_label, position, length) => {
+      const path = await fileWith('abc')
+      await expect(readRelayFileRange(path, position, length)).rejects.toBeInstanceOf(
+        FileRangeReadRequestError
+      )
+    })
   })
 })

--- a/src/relay/fs-handler-file-range.test.ts
+++ b/src/relay/fs-handler-file-range.test.ts
@@ -4,7 +4,11 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import { readRelayFileRange } from './fs-handler-file-range'
 import { readFullStreamChunk } from './fs-handler-file-read'
-import { FileRangeReadRequestError, MAX_FILE_RANGE_READ_BYTES } from '../shared/file-range-read'
+import {
+  FileRangeReadRequestError,
+  MAX_FILE_RANGE_READ_BYTES,
+  validateFileRangeRequest
+} from '../shared/file-range-read'
 import { HEADER_LENGTH, prepareJsonRpcPayload } from './protocol'
 import { DISPATCHER_CONTROL_QUEUE_MAX_BYTES } from './dispatcher-writer-admission'
 
@@ -148,6 +152,7 @@ describe('readRelayFileRange', () => {
       ['a NaN position', Number.NaN, 4],
       ['an infinite position', Number.POSITIVE_INFINITY, 4],
       ['a position past the safe-integer range', Number.MAX_SAFE_INTEGER + 2, 4],
+      ['a window past the safe-integer range', Number.MAX_SAFE_INTEGER - 1, 3],
       ['a zero length', 0, 0],
       ['a negative length', 0, -4],
       ['a fractional length', 0, 4.5],
@@ -202,6 +207,22 @@ describe('readFullStreamChunk', () => {
       { offset: 0, length: 6, position: 2 },
       { offset: 3, length: 3, position: 5 }
     ])
+  })
+
+  it('keeps every partial-read offset safe at the upper boundary', async () => {
+    const { position: start, length } = validateFileRangeRequest(Number.MAX_SAFE_INTEGER - 2, 3)
+    const calls: number[] = []
+    const reader = {
+      read(buffer: Buffer, offset: number, _length: number, position: number) {
+        calls.push(position)
+        buffer[offset] = 1
+        return Promise.resolve({ bytesRead: 1 })
+      }
+    }
+    const bytesRead = await readFullStreamChunk(reader, Buffer.alloc(length), length, start)
+    expect(bytesRead).toBe(length)
+    expect(calls).toEqual([start, start + 1, Number.MAX_SAFE_INTEGER])
+    expect(calls.every(Number.isSafeInteger)).toBe(true)
   })
 
   // Without the zero check the loop would spin forever on a reader at EOF.

--- a/src/relay/fs-handler-file-range.ts
+++ b/src/relay/fs-handler-file-range.ts
@@ -1,0 +1,44 @@
+import { open } from 'node:fs/promises'
+
+/** Largest range one JSON-RPC response may carry. Requests above this are
+ *  REJECTED rather than clamped: a silently shortened read is indistinguishable
+ *  from EOF or a truncation, and callers page by advancing `position`. */
+export const MAX_RELAY_RANGE_READ_BYTES = 4 * 1024 * 1024
+
+export class RelayRangeTooLargeError extends Error {
+  constructor(requested: number) {
+    super(
+      `Requested range of ${requested} bytes exceeds the ${MAX_RELAY_RANGE_READ_BYTES}-byte limit`
+    )
+    this.name = 'RelayRangeTooLargeError'
+  }
+}
+
+/** Positional read for tailing an append-only file. Loops until `length` is
+ *  satisfied or the file genuinely ends, so a short result always means EOF and
+ *  never a partial syscall. Base64 because the payload is arbitrary bytes and
+ *  may split a UTF-8 sequence at either edge. */
+export async function readRelayFileRange(
+  filePath: string,
+  position: number,
+  length: number
+): Promise<{ base64: string; bytesRead: number }> {
+  if (length > MAX_RELAY_RANGE_READ_BYTES) {
+    throw new RelayRangeTooLargeError(length)
+  }
+  const handle = await open(filePath, 'r')
+  try {
+    const buffer = Buffer.alloc(length)
+    let total = 0
+    while (total < length) {
+      const { bytesRead } = await handle.read(buffer, total, length - total, position + total)
+      if (bytesRead <= 0) {
+        break
+      }
+      total += bytesRead
+    }
+    return { base64: buffer.subarray(0, total).toString('base64'), bytesRead: total }
+  } finally {
+    await handle.close()
+  }
+}

--- a/src/relay/fs-handler-file-range.ts
+++ b/src/relay/fs-handler-file-range.ts
@@ -1,43 +1,29 @@
 import { open } from 'node:fs/promises'
+import { validateFileRangeRequest } from '../shared/file-range-read'
+import { readFullStreamChunk } from './fs-handler-file-read'
 
-/** Largest range one JSON-RPC response may carry. Requests above this are
- *  REJECTED rather than clamped: a silently shortened read is indistinguishable
- *  from EOF or a truncation, and callers page by advancing `position`. */
-export const MAX_RELAY_RANGE_READ_BYTES = 4 * 1024 * 1024
-
-export class RelayRangeTooLargeError extends Error {
-  constructor(requested: number) {
-    super(
-      `Requested range of ${requested} bytes exceeds the ${MAX_RELAY_RANGE_READ_BYTES}-byte limit`
-    )
-    this.name = 'RelayRangeTooLargeError'
-  }
-}
-
-/** Positional read for tailing an append-only file. Loops until `length` is
- *  satisfied or the file genuinely ends, so a short result always means EOF and
- *  never a partial syscall. Base64 because the payload is arbitrary bytes and
- *  may split a UTF-8 sequence at either edge. */
+/** Positional read for tailing an append-only file. Fills the window until
+ *  `length` is satisfied or the file genuinely ends, so a short result always
+ *  means EOF and never a partial syscall. Base64 because the payload is
+ *  arbitrary bytes and may split a UTF-8 sequence at either edge.
+ *
+ *  Validates here rather than at the dispatcher: this is the function that puts
+ *  a caller-supplied offset into a read syscall, so it is the boundary that has
+ *  to hold even if a future call site forgets. */
 export async function readRelayFileRange(
   filePath: string,
-  position: number,
-  length: number
+  rawPosition: unknown,
+  rawLength: unknown
 ): Promise<{ base64: string; bytesRead: number }> {
-  if (length > MAX_RELAY_RANGE_READ_BYTES) {
-    throw new RelayRangeTooLargeError(length)
-  }
+  const { position, length } = validateFileRangeRequest(rawPosition, rawLength)
   const handle = await open(filePath, 'r')
   try {
-    const buffer = Buffer.alloc(length)
-    let total = 0
-    while (total < length) {
-      const { bytesRead } = await handle.read(buffer, total, length - total, position + total)
-      if (bytesRead <= 0) {
-        break
-      }
-      total += bytesRead
-    }
-    return { base64: buffer.subarray(0, total).toString('base64'), bytesRead: total }
+    // allocUnsafe over alloc: only `subarray(0, bytesRead)` is ever read back, so
+    // uninitialised bytes cannot escape, and a tailing poll with a generous
+    // `length` should not pay a memset over the whole window per call.
+    const buffer = Buffer.allocUnsafe(length)
+    const bytesRead = await readFullStreamChunk(handle, buffer, length, position)
+    return { base64: buffer.subarray(0, bytesRead).toString('base64'), bytesRead }
   } finally {
     await handle.close()
   }

--- a/src/relay/fs-handler-file-read.ts
+++ b/src/relay/fs-handler-file-read.ts
@@ -334,7 +334,9 @@ async function pumpChunks(
 
 // Why: fs.read() may return fewer bytes than requested before EOF. Fill each
 // protocol chunk so strict clients reject corruption, not valid short reads.
-async function readFullStreamChunk(
+// Shared with fs.readFileRange, where the same rule makes a short result mean
+// EOF and nothing else.
+export async function readFullStreamChunk(
   handle: StreamChunkReader,
   buffer: Buffer,
   length: number,

--- a/src/relay/fs-handler.ts
+++ b/src/relay/fs-handler.ts
@@ -27,6 +27,7 @@ import {
 import { buildExcludePathPrefixes } from '../shared/quick-open-filter'
 import { readRelayFileContent, readRelayFileStreamMetadata } from './fs-handler-file-read'
 import { readRelayFileRange } from './fs-handler-file-range'
+import { FileRangeReadRequestError } from '../shared/file-range-read'
 import {
   readVerifiedTerminalArtifact,
   writeVerifiedTerminalArtifact
@@ -111,18 +112,13 @@ export class FsHandler {
     return readRelayFileContent(filePath)
   }
 
-  // Why hand-validated: relay params arrive as raw casts with no schema, and
-  // both of these land directly in an fd read position.
+  // Why hand-checked: relay params arrive as raw casts with no schema. The
+  // offsets are validated inside readRelayFileRange, next to the read syscall.
   private async readFileRange(params: Record<string, unknown>) {
-    const filePath = expandTilde(params.filePath as string)
-    const { position, length } = params
-    if (typeof position !== 'number' || !Number.isSafeInteger(position) || position < 0) {
-      throw new Error('fs.readFileRange requires a non-negative integer position')
+    if (typeof params.filePath !== 'string' || params.filePath.length === 0) {
+      throw new FileRangeReadRequestError('fs.readFileRange requires a filePath')
     }
-    if (typeof length !== 'number' || !Number.isSafeInteger(length) || length <= 0) {
-      throw new Error('fs.readFileRange requires a positive integer length')
-    }
-    return readRelayFileRange(filePath, position, length)
+    return readRelayFileRange(expandTilde(params.filePath), params.position, params.length)
   }
 
   private async readTerminalArtifact(params: Record<string, unknown>) {

--- a/src/relay/fs-handler.ts
+++ b/src/relay/fs-handler.ts
@@ -26,6 +26,7 @@ import {
 } from './fs-path-mutation-requests'
 import { buildExcludePathPrefixes } from '../shared/quick-open-filter'
 import { readRelayFileContent, readRelayFileStreamMetadata } from './fs-handler-file-read'
+import { readRelayFileRange } from './fs-handler-file-range'
 import {
   readVerifiedTerminalArtifact,
   writeVerifiedTerminalArtifact
@@ -66,6 +67,7 @@ export class FsHandler {
     this.dispatcher.onRequest('fs.readDir', (p) => readRelayDir(p))
     this.dispatcher.onRequest('fs.readFile', (p) => this.readFile(p))
     this.dispatcher.onRequest('fs.readFileStream', (p, c) => this.readFileStream(p, c))
+    this.dispatcher.onRequest('fs.readFileRange', (p) => this.readFileRange(p))
     this.dispatcher.onRequest('fs.readTerminalArtifact', (p) => this.readTerminalArtifact(p))
     this.dispatcher.onRequest('fs.tempDir', () => this.tempDir())
     this.dispatcher.onRequest('fs.writeFile', (p) => writeRelayFile(p))
@@ -82,7 +84,8 @@ export class FsHandler {
     this.dispatcher.onRequest('fs.realpath', (p) => realpathRelayPath(p))
     this.dispatcher.onRequest('fs.search', (p) => this.search(p))
     this.dispatcher.onRequest('fs.getCapabilities', async () => ({
-      quickOpenSearchVersion: 1
+      quickOpenSearchVersion: 1,
+      rangedReadVersion: 1
     }))
     this.dispatcher.onRequest('fs.listFiles', (p, c) => this.listFiles(p, c))
     this.dispatcher.onRequest('fs.workspaceSpaceScan', (p, c) => this.workspaceSpaceScan(p, c))
@@ -106,6 +109,20 @@ export class FsHandler {
   private async readFile(params: Record<string, unknown>) {
     const filePath = expandTilde(params.filePath as string)
     return readRelayFileContent(filePath)
+  }
+
+  // Why hand-validated: relay params arrive as raw casts with no schema, and
+  // both of these land directly in an fd read position.
+  private async readFileRange(params: Record<string, unknown>) {
+    const filePath = expandTilde(params.filePath as string)
+    const { position, length } = params
+    if (typeof position !== 'number' || !Number.isSafeInteger(position) || position < 0) {
+      throw new Error('fs.readFileRange requires a non-negative integer position')
+    }
+    if (typeof length !== 'number' || !Number.isSafeInteger(length) || length <= 0) {
+      throw new Error('fs.readFileRange requires a positive integer length')
+    }
+    return readRelayFileRange(filePath, position, length)
   }
 
   private async readTerminalArtifact(params: Record<string, unknown>) {

--- a/src/shared/file-range-read.ts
+++ b/src/shared/file-range-read.ts
@@ -1,0 +1,49 @@
+/** Largest window one `fs.readFileRange` response may carry: `STREAM_CHUNK_SIZE`,
+ *  the house per-frame budget for file bytes.
+ *
+ *  The binding constraint is the relay writer's admission budget, NOT the 16 MiB
+ *  frame cap. A response frame over `DISPATCHER_CONTROL_QUEUE_MAX_BYTES` (1 MiB)
+ *  is demoted to the `legacy-response` lane, which is refused once the producer
+ *  queue passes `DEFAULT_PRODUCER_QUEUE_MAX_BYTES` (2 MiB) -- so a wide window
+ *  fails with an opaque `ResponseOverCapacity` that depends on what else is
+ *  queued at the time. 256 KiB of raw bytes is ~350 KB of base64, which stays in
+ *  the control lane unconditionally. Bigger transfers belong on the ack-paced
+ *  bulk lane (`fs.readFileStream`), not on a wider cap here.
+ *
+ *  Requests above it are REJECTED, never clamped: a clamped read is
+ *  indistinguishable from EOF, and callers page by advancing `position`. */
+export const MAX_FILE_RANGE_READ_BYTES = 256 * 1024
+
+/** A range request the host will refuse. Separate from a read failure so a
+ *  caller can tell "I asked for the wrong thing" from "the file is unreadable". */
+export class FileRangeReadRequestError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'FileRangeReadRequestError'
+  }
+}
+
+/** The single source of truth for what `fs.readFileRange` accepts. Both sides
+ *  call it: the client so an invalid request never costs a round trip, the host
+ *  because `position`/`length` land straight in an fd read and the relay has no
+ *  request schema. Two independent copies would drift into a client that sends
+ *  what the host rejects. */
+export function validateFileRangeRequest(
+  position: unknown,
+  length: unknown
+): { position: number; length: number } {
+  if (typeof position !== 'number' || !Number.isSafeInteger(position) || position < 0) {
+    throw new FileRangeReadRequestError(
+      'fs.readFileRange requires a non-negative safe-integer position'
+    )
+  }
+  if (typeof length !== 'number' || !Number.isSafeInteger(length) || length <= 0) {
+    throw new FileRangeReadRequestError('fs.readFileRange requires a positive integer length')
+  }
+  if (length > MAX_FILE_RANGE_READ_BYTES) {
+    throw new FileRangeReadRequestError(
+      `fs.readFileRange length ${length} exceeds the ${MAX_FILE_RANGE_READ_BYTES}-byte limit`
+    )
+  }
+  return { position, length }
+}

--- a/src/shared/file-range-read.ts
+++ b/src/shared/file-range-read.ts
@@ -54,5 +54,8 @@ export function validateFileRangeRequest(
       `fs.readFileRange length ${length} exceeds the ${MAX_FILE_RANGE_READ_BYTES}-byte limit`
     )
   }
+  if (position > Number.MAX_SAFE_INTEGER - (length - 1)) {
+    throw new FileRangeReadRequestError('fs.readFileRange window exceeds safe-integer offsets')
+  }
   return { position, length }
 }

--- a/src/shared/file-range-read.ts
+++ b/src/shared/file-range-read.ts
@@ -1,14 +1,23 @@
-/** Largest window one `fs.readFileRange` response may carry: `STREAM_CHUNK_SIZE`,
- *  the house per-frame budget for file bytes.
+/** Largest window one `fs.readFileRange` response may carry. Derived from the
+ *  relay writer's admission budget, NOT from the 16 MiB frame cap.
  *
- *  The binding constraint is the relay writer's admission budget, NOT the 16 MiB
- *  frame cap. A response frame over `DISPATCHER_CONTROL_QUEUE_MAX_BYTES` (1 MiB)
- *  is demoted to the `legacy-response` lane, which is refused once the producer
- *  queue passes `DEFAULT_PRODUCER_QUEUE_MAX_BYTES` (2 MiB) -- so a wide window
- *  fails with an opaque `ResponseOverCapacity` that depends on what else is
- *  queued at the time. 256 KiB of raw bytes is ~350 KB of base64, which stays in
- *  the control lane unconditionally. Bigger transfers belong on the ack-paced
- *  bulk lane (`fs.readFileStream`), not on a wider cap here.
+ *  A response frame over `DISPATCHER_CONTROL_QUEUE_MAX_BYTES` (1 MiB) is demoted
+ *  to the `legacy-response` lane, which is refused outright once the producer
+ *  queue passes `DEFAULT_PRODUCER_QUEUE_MAX_BYTES` (2 MiB) -- an opaque
+ *  `ResponseOverCapacity` that depends on unrelated load. 256 KiB of raw bytes
+ *  frames to ~350 KB, so a full-cap response takes the control lane instead.
+ *
+ *  The control lane is a shared budget, not a per-frame one: two full-cap
+ *  responses fit alongside each other, and the third overflows -- which for a
+ *  response is fatal, it closes the client. That is the same exposure every
+ *  control-lane response already carries (`fs.readFile` frames any sub-1 MiB
+ *  file the same way), and the two-deep headroom is pinned by a test. Widening
+ *  the cap spends that headroom, so bigger transfers belong on the ack-paced
+ *  bulk lane (`fs.readFileStream`) rather than on a wider window here.
+ *
+ *  Raising this value is a wire change even though it is a constant: an older
+ *  host still advertising `rangedReadVersion: 1` refuses a longer window with an
+ *  opaque error, so a wider cap needs a version bump to negotiate against.
  *
  *  Requests above it are REJECTED, never clamped: a clamped read is
  *  indistinguishable from EOF, and callers page by advancing `position`. */


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​642 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​641 |
| Prod | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​335 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​66 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​269 |

<!-- /orca-pr-loc -->

## Why

Following a growing remote file currently means re-reading it from the top on every poll. The relay
exposes only whole-file reads (`fs.readFile`, `fs.readFileStream` — both path-only), so tailing an
append-only log over SSH costs O(size) per tick. There is no byte-ranged read reachable from a
client anywhere in the relay surface today.

The motivating consumer is native chat over an SSH worktree (#13663), where the agent's transcript
JSONL lives on the remote host and grows continuously. This PR adds only the primitive; no
native-chat consumer is wired up here.

## What

- `fs.readFileRange` on the relay, plus `rangedReadVersion: 1` on `fs.getCapabilities`
- optional `readFileRange` / `supportsFileRangeRead` on `IFilesystemProvider`, matching how
  `lstat?` and `supportsQuickOpenSearch?` already declare degradable capabilities
- a cached per-connection capability probe, mirroring `probeSshQuickOpenSearchCapability`

## Three choices worth reviewing

**The relay loops, and rejects rather than clamps.** It reads until the requested length is
satisfied or the file genuinely ends, and throws on an over-cap request. A clamped read is
indistinguishable from EOF or a truncation, so a caller advancing a cursor by `bytesRead` would
silently skip data. Short result now means EOF and nothing else.

**Bytes cross the wire base64-encoded.** A range boundary can split a multi-byte UTF-8 sequence at
either edge; a utf-8 round trip would substitute U+FFFD and shift every subsequent byte offset.
There is a test that reads a window splitting `é`/`漢` at both edges.

**The provider throws instead of silently falling back.** Against an older relay,
`readFileRange` raises a typed `FileRangeReadUnsupportedError` rather than quietly reading the whole
file. A tailing caller issues several reads per snapshot, so a per-call fallback is quadratic on a
growing file — precisely the cost this primitive exists to remove. Callers probe
`supportsFileRangeRead()` once and take a single snapshot instead.

The response is validated before use: a `bytesRead` that disagrees with the payload length, exceeds
the requested length, or arrives malformed is rejected, because a bad count would shift every
downstream offset while looking like success.

## Compatibility

New method name, so an older relay answers `-32601` and the capability probe returns false — no
silent wrong answer. This is why the range is **not** new optional params on `fs.readFile`: relay
handlers read params with raw casts and no schema, so an old relay would strip `position`/`length`
and return the whole file with a success status.

New relay + old desktop: nothing calls it.

## Tests

18 new tests. Relay side runs against real temp files (exact window, non-zero position, short read
only at EOF, position past end, multi-byte split at both edges, arbitrary binary round trip,
over-cap rejection, missing file). Provider side covers decode, the typed unsupported error,
non-capability errors propagating unchanged, all three response-validation rejections, and that the
capability is probed once and cached.

Full run: 848 tests green, `tsc` clean, oxfmt + oxlint clean.

## Incidental

Terminal-artifact read/write moved to `ssh-filesystem-terminal-artifact.ts`, mirroring the relay's
existing `fs-handler-terminal-artifact` split. `SshFilesystemProvider` was already at the
`max-lines` ceiling, and that pair was the cohesive piece to extract — the rule is not disable-able,
so the file had to give somewhere.
