### PR TITLE
fix(terminal): repaint the TUI when a mobile-fit hold is released

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection-mobile-fit-release-repaint.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-mobile-fit-release-repaint.test.ts
@@ -149,6 +149,34 @@ async function connectPaneHoldingMobileFit(ptyId: string = PTY_ID): Promise<{
   return { pane, signalPty, setFitOverride, dispose: () => disposable.dispose() }
 }
 
+/** The phone already holds the grid before this pane mounts — an app reload
+ *  hydrating overrides, or a tab reopened mid-hold. No mobile-fit event ever
+ *  reaches this pane's listener, only the later desktop-fit release. */
+async function connectPaneIntoExistingMobileFitHold(): Promise<{
+  signalPty: ReturnType<typeof vi.fn>
+  setFitOverride: typeof SetFitOverride
+  dispose: () => void
+}> {
+  const { connectPanePty } = await import('./pty-connection')
+  const { setFitOverride } = await import('@/lib/pane-manager/mobile-fit-overrides')
+  setFitOverride(PTY_ID, 'mobile-fit', PHONE.cols, PHONE.rows)
+
+  const transport = createMockTransport(PTY_ID)
+  transport.getPtyId.mockReturnValue(PTY_ID)
+  transportFactoryQueue.push(transport)
+  const pane = makeDesktopFittingPane(1)
+  pane.terminal.cols = PHONE.cols
+  pane.terminal.rows = PHONE.rows
+  const manager = createManager(1)
+  const deps = buildPaneConnectionDeps(() => mockStoreState, { isVisibleRef: { current: true } })
+  const disposable = connectPanePty(pane as never, manager as never, deps as never)
+  await flushAsyncTicks(6)
+
+  const signalPty = window.api.pty.signal as unknown as ReturnType<typeof vi.fn>
+  signalPty.mockClear()
+  return { signalPty, setFitOverride, dispose: () => disposable.dispose() }
+}
+
 describe('mobile-fit release repaint', () => {
   beforeEach(() => {
     vi.resetModules()
@@ -212,6 +240,16 @@ describe('mobile-fit release repaint', () => {
     await flushAsyncTicks(6)
 
     expect(signalPty.mock.calls).toEqual([])
+    dispose()
+  })
+
+  it('repaints a pane that connected while the phone already held the grid', async () => {
+    const { signalPty, setFitOverride, dispose } = await connectPaneIntoExistingMobileFitHold()
+
+    setFitOverride(PTY_ID, 'desktop-fit', DESKTOP.cols, DESKTOP.rows)
+    await flushAsyncTicks(6)
+
+    expect(signalPty.mock.calls).toEqual([[PTY_ID, 'SIGWINCH']])
     dispose()
   })
 })

--- a/src/renderer/src/components/terminal-pane/pty-connection-mobile-fit-release-repaint.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-mobile-fit-release-repaint.test.ts
@@ -1,0 +1,217 @@
+import type * as React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushAsyncTicks } from './pty-connection-test-async'
+import {
+  createMockTransport,
+  createPane,
+  createManager,
+  type MockPane,
+  type MockTransport
+} from './pty-connection-test-pane-fixtures'
+import { buildPaneConnectionDeps } from './pty-connection-test-deps'
+import { createInitialStoreState } from './pty-connection-test-store-fixtures'
+import type { StoreState } from './pty-connection-test-store-state'
+import {
+  installTerminalTestGlobals,
+  restoreTerminalTestGlobals
+} from './pty-connection-test-environment'
+import type { setFitOverride as SetFitOverride } from '@/lib/pane-manager/mobile-fit-overrides'
+
+const {
+  resetAndRefreshAllTerminalWebglAtlases,
+  scheduleTerminalWebglAtlasRecovery,
+  scheduleRuntimeGraphSync,
+  shouldSeedCacheTimerOnInitialTitle,
+  toastInfo,
+  notifyCodexPaneBoundForStaleSweep
+} = vi.hoisted(() => ({
+  resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
+  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleRuntimeGraphSync: vi.fn(),
+  shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
+  toastInfo: vi.fn(),
+  notifyCodexPaneBoundForStaleSweep: vi.fn()
+}))
+
+let mockStoreState: StoreState
+let transportFactoryQueue: MockTransport[] = []
+let storeSubscribers: ((state: StoreState) => void)[] = []
+
+vi.mock('@/runtime/sync-runtime-graph', () => ({ scheduleRuntimeGraphSync }))
+
+vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  resetAndRefreshAllTerminalWebglAtlases
+}))
+
+vi.mock('./terminal-webgl-atlas-recovery', () => ({ scheduleTerminalWebglAtlasRecovery }))
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: () => mockStoreState,
+    subscribe: (listener: (state: StoreState) => void) => {
+      storeSubscribers.push(listener)
+      return () => {
+        storeSubscribers = storeSubscribers.filter((candidate) => candidate !== listener)
+      }
+    }
+  }
+}))
+
+vi.mock('@/lib/agent-status', async (importOriginal) => {
+  const { buildAgentStatusModuleMock } = await import('./pty-connection-test-environment')
+  return buildAgentStatusModuleMock(await importOriginal<Record<string, unknown>>())
+})
+
+vi.mock('./cache-timer-seeding', () => ({ shouldSeedCacheTimerOnInitialTitle }))
+
+vi.mock('sonner', () => ({ toast: { info: toastInfo } }))
+
+vi.mock('@/lib/codex-stale-pane-sweep', () => ({ notifyCodexPaneBoundForStaleSweep }))
+
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal<typeof React>()
+  return {
+    ...actual,
+    useCallback: <T extends (...args: unknown[]) => unknown>(fn: T): T => fn
+  }
+})
+
+vi.mock('./pty-transport', () => ({
+  createIpcPtyTransport: vi.fn(() => {
+    const nextTransport = transportFactoryQueue.shift()
+    if (!nextTransport) {
+      throw new Error('No mock transport queued')
+    }
+    return nextTransport
+  })
+}))
+
+vi.mock('./remote-runtime-pty-transport', () => ({
+  createRemoteRuntimePtyTransport: vi.fn(() => {
+    const nextTransport = transportFactoryQueue.shift()
+    if (!nextTransport) {
+      throw new Error('No mock transport queued')
+    }
+    return nextTransport
+  })
+}))
+
+vi.mock('./pty-dispatcher', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return { ...actual, getEagerPtyBufferHandle: vi.fn(() => undefined) }
+})
+
+const PHONE = { cols: 45, rows: 20 }
+const DESKTOP = { cols: 120, rows: 40 }
+// The pty id the store fixture binds to this tab's pane.
+const PTY_ID = 'tab-pty'
+
+/** Mirrors the real fit: proposeDimensions reports the desktop box, and a fit
+ *  moves xterm's grid onto it. The mobile-fit hold parks it at phone dims. */
+function makeDesktopFittingPane(paneId: number): MockPane {
+  const pane = createPane(paneId)
+  pane.fitAddon.proposeDimensions.mockImplementation(() => DESKTOP)
+  pane.fitAddon.fit.mockImplementation(() => {
+    pane.terminal.cols = DESKTOP.cols
+    pane.terminal.rows = DESKTOP.rows
+  })
+  return pane
+}
+
+async function connectPaneHoldingMobileFit(ptyId: string = PTY_ID): Promise<{
+  pane: MockPane
+  signalPty: ReturnType<typeof vi.fn>
+  setFitOverride: typeof SetFitOverride
+  dispose: () => void
+}> {
+  const { connectPanePty } = await import('./pty-connection')
+  // Why: vi.resetModules() gives every test a fresh module graph, so the override
+  // emitter must be resolved from the same one connectPanePty subscribes to.
+  const { setFitOverride } = await import('@/lib/pane-manager/mobile-fit-overrides')
+  const transport = createMockTransport(ptyId)
+  transport.getPtyId.mockReturnValue(ptyId)
+  transportFactoryQueue.push(transport)
+  const pane = makeDesktopFittingPane(1)
+  const manager = createManager(1)
+  const deps = buildPaneConnectionDeps(() => mockStoreState, { isVisibleRef: { current: true } })
+  const disposable = connectPanePty(pane as never, manager as never, deps as never)
+  await flushAsyncTicks(6)
+
+  // The phone takes the floor: the host parks the PTY and xterm at phone dims.
+  setFitOverride(ptyId, 'mobile-fit', PHONE.cols, PHONE.rows)
+  pane.terminal.cols = PHONE.cols
+  pane.terminal.rows = PHONE.rows
+  await flushAsyncTicks(2)
+
+  const signalPty = window.api.pty.signal as unknown as ReturnType<typeof vi.fn>
+  signalPty.mockClear()
+  return { pane, signalPty, setFitOverride, dispose: () => disposable.dispose() }
+}
+
+describe('mobile-fit release repaint', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    transportFactoryQueue = []
+    storeSubscribers = []
+    mockStoreState = createInitialStoreState(() => mockStoreState)
+    installTerminalTestGlobals()
+  })
+
+  afterEach(async () => {
+    await restoreTerminalTestGlobals()
+  })
+
+  it('signals SIGWINCH once the restored desktop grid lands so the TUI repaints', async () => {
+    const { pane, signalPty, setFitOverride, dispose } = await connectPaneHoldingMobileFit()
+
+    setFitOverride(PTY_ID, 'desktop-fit', DESKTOP.cols, DESKTOP.rows)
+    await flushAsyncTicks(6)
+
+    expect({
+      cols: pane.terminal.cols,
+      rows: pane.terminal.rows,
+      signals: signalPty.mock.calls
+    }).toEqual({
+      cols: DESKTOP.cols,
+      rows: DESKTOP.rows,
+      signals: [[PTY_ID, 'SIGWINCH']]
+    })
+    dispose()
+  })
+
+  it('does not repaint-signal when another desktop takes the grid instead', async () => {
+    const { signalPty, setFitOverride, dispose } = await connectPaneHoldingMobileFit()
+
+    setFitOverride(PTY_ID, 'remote-desktop-fit', 100, 30)
+    await flushAsyncTicks(6)
+
+    expect(signalPty.mock.calls).toEqual([])
+    setFitOverride(PTY_ID, 'desktop-fit', DESKTOP.cols, DESKTOP.rows)
+    dispose()
+  })
+
+  it('repaint-signals only the hold it released, not every desktop-fit', async () => {
+    const { signalPty, setFitOverride, dispose } = await connectPaneHoldingMobileFit()
+
+    setFitOverride(PTY_ID, 'desktop-fit', DESKTOP.cols, DESKTOP.rows)
+    // A pty exit re-emits desktop-fit for an id that holds nothing (0x0).
+    setFitOverride(PTY_ID, 'desktop-fit', 0, 0)
+    await flushAsyncTicks(6)
+
+    expect(signalPty.mock.calls).toEqual([[PTY_ID, 'SIGWINCH']])
+    dispose()
+  })
+
+  it('does not repaint-signal a remote runtime pty, which has no signal channel', async () => {
+    const remotePtyId = 'remote:env-1@@terminal-1'
+    const { signalPty, setFitOverride, dispose } = await connectPaneHoldingMobileFit(remotePtyId)
+
+    setFitOverride(remotePtyId, 'desktop-fit', DESKTOP.cols, DESKTOP.rows)
+    await flushAsyncTicks(6)
+
+    expect(signalPty.mock.calls).toEqual([])
+    dispose()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/pty-connection-mobile-fit-release-repaint.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-mobile-fit-release-repaint.test.ts
@@ -16,6 +16,7 @@ import {
   restoreTerminalTestGlobals
 } from './pty-connection-test-environment'
 import type { setFitOverride as SetFitOverride } from '@/lib/pane-manager/mobile-fit-overrides'
+import type { setDriverForPty as SetDriverForPty } from '@/lib/pane-manager/mobile-driver-state'
 
 const {
   resetAndRefreshAllTerminalWebglAtlases,
@@ -123,6 +124,7 @@ async function connectPaneHoldingMobileFit(ptyId: string = PTY_ID): Promise<{
   pane: MockPane
   signalPty: ReturnType<typeof vi.fn>
   setFitOverride: typeof SetFitOverride
+  setDriverForPty: typeof SetDriverForPty
   dispose: () => void
 }> {
   const { connectPanePty } = await import('./pty-connection')
@@ -138,7 +140,10 @@ async function connectPaneHoldingMobileFit(ptyId: string = PTY_ID): Promise<{
   const disposable = connectPanePty(pane as never, manager as never, deps as never)
   await flushAsyncTicks(6)
 
-  // The phone takes the floor: the host parks the PTY and xterm at phone dims.
+  // The phone takes the floor. Production order (handleMobileSubscribe): the
+  // driver flips to mobile first, then the phone layout writes the hold.
+  const { setDriverForPty } = await import('@/lib/pane-manager/mobile-driver-state')
+  setDriverForPty(ptyId, { kind: 'mobile', clientId: 'phone-1' })
   setFitOverride(ptyId, 'mobile-fit', PHONE.cols, PHONE.rows)
   pane.terminal.cols = PHONE.cols
   pane.terminal.rows = PHONE.rows
@@ -146,7 +151,7 @@ async function connectPaneHoldingMobileFit(ptyId: string = PTY_ID): Promise<{
 
   const signalPty = window.api.pty.signal as unknown as ReturnType<typeof vi.fn>
   signalPty.mockClear()
-  return { pane, signalPty, setFitOverride, dispose: () => disposable.dispose() }
+  return { pane, signalPty, setFitOverride, setDriverForPty, dispose: () => disposable.dispose() }
 }
 
 /** The phone already holds the grid before this pane mounts — an app reload
@@ -155,10 +160,13 @@ async function connectPaneHoldingMobileFit(ptyId: string = PTY_ID): Promise<{
 async function connectPaneIntoExistingMobileFitHold(): Promise<{
   signalPty: ReturnType<typeof vi.fn>
   setFitOverride: typeof SetFitOverride
+  setDriverForPty: typeof SetDriverForPty
   dispose: () => void
 }> {
   const { connectPanePty } = await import('./pty-connection')
   const { setFitOverride } = await import('@/lib/pane-manager/mobile-fit-overrides')
+  const { setDriverForPty } = await import('@/lib/pane-manager/mobile-driver-state')
+  setDriverForPty(PTY_ID, { kind: 'mobile', clientId: 'phone-1' })
   setFitOverride(PTY_ID, 'mobile-fit', PHONE.cols, PHONE.rows)
 
   const transport = createMockTransport(PTY_ID)
@@ -174,7 +182,22 @@ async function connectPaneIntoExistingMobileFitHold(): Promise<{
 
   const signalPty = window.api.pty.signal as unknown as ReturnType<typeof vi.fn>
   signalPty.mockClear()
-  return { signalPty, setFitOverride, dispose: () => disposable.dispose() }
+  return { signalPty, setFitOverride, setDriverForPty, dispose: () => disposable.dispose() }
+}
+
+/** The desktop "Take back" gesture exactly as reclaimTerminalForDesktop's
+ *  active-subscriber branch emits it: applyMobileDisplayMode publishes the
+ *  desktop-fit release *while currentDriver is still mobile*, and only the
+ *  following releaseDesktopTakeBack flips the driver. The order is awaited,
+ *  not raced, and webContents.send preserves it across the two channels. */
+async function takeBackFromPhone(
+  setFitOverride: typeof SetFitOverride,
+  setDriverForPty: typeof SetDriverForPty,
+  ptyId: string = PTY_ID
+): Promise<void> {
+  setFitOverride(ptyId, 'desktop-fit', DESKTOP.cols, DESKTOP.rows)
+  setDriverForPty(ptyId, { kind: 'desktop' })
+  await flushAsyncTicks(6)
 }
 
 describe('mobile-fit release repaint', () => {
@@ -192,7 +215,8 @@ describe('mobile-fit release repaint', () => {
   })
 
   it('signals SIGWINCH once the restored desktop grid lands so the TUI repaints', async () => {
-    const { pane, signalPty, setFitOverride, dispose } = await connectPaneHoldingMobileFit()
+    const { pane, signalPty, setFitOverride, setDriverForPty, dispose } =
+      await connectPaneHoldingMobileFit()
     // Why record inside the mock: asserting the final grid plus the call count
     // passes just as well when the signal fires *before* the refit, which is
     // the bug. Only the grid at signal time distinguishes the two.
@@ -201,12 +225,32 @@ describe('mobile-fit release repaint', () => {
       gridAtSignal.push({ cols: pane.terminal.cols, rows: pane.terminal.rows })
     })
 
-    setFitOverride(PTY_ID, 'desktop-fit', DESKTOP.cols, DESKTOP.rows)
-    await flushAsyncTicks(6)
+    await takeBackFromPhone(setFitOverride, setDriverForPty)
 
     expect({ signals: signalPty.mock.calls, gridAtSignal }).toEqual({
       signals: [[PTY_ID, 'SIGWINCH']],
       gridAtSignal: [DESKTOP]
+    })
+    dispose()
+  })
+
+  it('repaints a take-back whose release lands before the driver flips to desktop', async () => {
+    const { signalPty, setFitOverride, setDriverForPty, dispose } =
+      await connectPaneHoldingMobileFit()
+    // Pin the emission order the gesture actually produces: the release is
+    // observed while the presence lock still reads mobile. Gating the repaint
+    // on the lock (rather than on the hold it released) silently drops every
+    // desktop "Take back" — the exact gesture #14321 is about.
+    const signalsBeforeDriverFlip: unknown[][] = []
+    setFitOverride(PTY_ID, 'desktop-fit', DESKTOP.cols, DESKTOP.rows)
+    await flushAsyncTicks(6)
+    signalsBeforeDriverFlip.push(...signalPty.mock.calls)
+    setDriverForPty(PTY_ID, { kind: 'desktop' })
+    await flushAsyncTicks(6)
+
+    expect({ signalsBeforeDriverFlip, allSignals: signalPty.mock.calls }).toEqual({
+      signalsBeforeDriverFlip: [[PTY_ID, 'SIGWINCH']],
+      allSignals: [[PTY_ID, 'SIGWINCH']]
     })
     dispose()
   })
@@ -223,9 +267,10 @@ describe('mobile-fit release repaint', () => {
   })
 
   it('repaint-signals only the hold it released, not every desktop-fit', async () => {
-    const { signalPty, setFitOverride, dispose } = await connectPaneHoldingMobileFit()
+    const { signalPty, setFitOverride, setDriverForPty, dispose } =
+      await connectPaneHoldingMobileFit()
 
-    setFitOverride(PTY_ID, 'desktop-fit', DESKTOP.cols, DESKTOP.rows)
+    await takeBackFromPhone(setFitOverride, setDriverForPty)
     // A pty exit re-emits desktop-fit for an id that holds nothing (0x0).
     setFitOverride(PTY_ID, 'desktop-fit', 0, 0)
     await flushAsyncTicks(6)
@@ -246,10 +291,10 @@ describe('mobile-fit release repaint', () => {
   })
 
   it('repaints a pane that connected while the phone already held the grid', async () => {
-    const { signalPty, setFitOverride, dispose } = await connectPaneIntoExistingMobileFitHold()
+    const { signalPty, setFitOverride, setDriverForPty, dispose } =
+      await connectPaneIntoExistingMobileFitHold()
 
-    setFitOverride(PTY_ID, 'desktop-fit', DESKTOP.cols, DESKTOP.rows)
-    await flushAsyncTicks(6)
+    await takeBackFromPhone(setFitOverride, setDriverForPty)
 
     expect(signalPty.mock.calls).toEqual([[PTY_ID, 'SIGWINCH']])
     dispose()
@@ -267,17 +312,51 @@ describe('mobile-fit release repaint', () => {
     dispose()
   })
 
-  it('does not repaint while the phone still drives the pty without a fit hold', async () => {
-    const { signalPty, setFitOverride, dispose } = await connectPaneHoldingMobileFit()
-    const { setDriverForPty } = await import('@/lib/pane-manager/mobile-driver-state')
-    // A lock-only takeover keeps the phone authoritative with no fit override.
-    setDriverForPty(PTY_ID, { kind: 'mobile', clientId: 'phone-1' })
+  // Why not "the driver still reads mobile": that is true of every take-back at
+  // release time, so it cannot be the discriminator. The hold itself is — the
+  // phone owns the grid only while an override is held.
+  it('drops a parked repaint once the phone has retaken the grid', async () => {
+    const { pane, signalPty, setFitOverride, setDriverForPty, dispose } =
+      await connectPaneHoldingMobileFit()
+    // The pane cannot measure yet (tab mid-layout), so the release parks the
+    // refit for retry instead of running it.
+    pane.fitAddon.proposeDimensions.mockReturnValue(undefined as never)
+    vi.useFakeTimers()
+    await takeBackFromPhone(setFitOverride, setDriverForPty)
+    const signalsWhileParked = [...signalPty.mock.calls]
 
-    setFitOverride(PTY_ID, 'desktop-fit', DESKTOP.cols, DESKTOP.rows)
-    await flushAsyncTicks(6)
+    // The phone takes the floor again before the pane measures, so the PTY is
+    // back at phone dims. Replaying the parked repaint would redraw there.
+    setDriverForPty(PTY_ID, { kind: 'mobile', clientId: 'phone-2' })
+    setFitOverride(PTY_ID, 'mobile-fit', PHONE.cols, PHONE.rows)
+    pane.fitAddon.proposeDimensions.mockReturnValue(DESKTOP)
+    await vi.advanceTimersByTimeAsync(200)
+    vi.useRealTimers()
 
-    expect(signalPty.mock.calls).toEqual([])
+    expect({ signalsWhileParked, allSignals: signalPty.mock.calls }).toEqual({
+      signalsWhileParked: [],
+      allSignals: []
+    })
     setDriverForPty(PTY_ID, { kind: 'desktop' })
+    dispose()
+  })
+
+  it('replays a parked repaint when the phone did not retake the grid', async () => {
+    const { pane, signalPty, setFitOverride, setDriverForPty, dispose } =
+      await connectPaneHoldingMobileFit()
+    pane.fitAddon.proposeDimensions.mockReturnValue(undefined as never)
+    vi.useFakeTimers()
+    await takeBackFromPhone(setFitOverride, setDriverForPty)
+    const signalsWhileParked = [...signalPty.mock.calls]
+
+    pane.fitAddon.proposeDimensions.mockReturnValue(DESKTOP)
+    await vi.advanceTimersByTimeAsync(200)
+    vi.useRealTimers()
+
+    expect({ signalsWhileParked, allSignals: signalPty.mock.calls }).toEqual({
+      signalsWhileParked: [],
+      allSignals: [[PTY_ID, 'SIGWINCH']]
+    })
     dispose()
   })
 })

--- a/src/renderer/src/components/terminal-pane/pty-connection-mobile-fit-release-repaint.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-mobile-fit-release-repaint.test.ts
@@ -193,18 +193,20 @@ describe('mobile-fit release repaint', () => {
 
   it('signals SIGWINCH once the restored desktop grid lands so the TUI repaints', async () => {
     const { pane, signalPty, setFitOverride, dispose } = await connectPaneHoldingMobileFit()
+    // Why record inside the mock: asserting the final grid plus the call count
+    // passes just as well when the signal fires *before* the refit, which is
+    // the bug. Only the grid at signal time distinguishes the two.
+    const gridAtSignal: { cols: number; rows: number }[] = []
+    signalPty.mockImplementation(() => {
+      gridAtSignal.push({ cols: pane.terminal.cols, rows: pane.terminal.rows })
+    })
 
     setFitOverride(PTY_ID, 'desktop-fit', DESKTOP.cols, DESKTOP.rows)
     await flushAsyncTicks(6)
 
-    expect({
-      cols: pane.terminal.cols,
-      rows: pane.terminal.rows,
-      signals: signalPty.mock.calls
-    }).toEqual({
-      cols: DESKTOP.cols,
-      rows: DESKTOP.rows,
-      signals: [[PTY_ID, 'SIGWINCH']]
+    expect({ signals: signalPty.mock.calls, gridAtSignal }).toEqual({
+      signals: [[PTY_ID, 'SIGWINCH']],
+      gridAtSignal: [DESKTOP]
     })
     dispose()
   })
@@ -250,6 +252,32 @@ describe('mobile-fit release repaint', () => {
     await flushAsyncTicks(6)
 
     expect(signalPty.mock.calls).toEqual([[PTY_ID, 'SIGWINCH']])
+    dispose()
+  })
+
+  it('does not repaint when the hold is cleared without a paired resize', async () => {
+    const { signalPty, setFitOverride, dispose } = await connectPaneHoldingMobileFit()
+
+    // A pty exit, or a take-back whose best-effort resize never converged,
+    // clears the hold with a 0x0 marker. The PTY may still be at phone dims.
+    setFitOverride(PTY_ID, 'desktop-fit', 0, 0)
+    await flushAsyncTicks(6)
+
+    expect(signalPty.mock.calls).toEqual([])
+    dispose()
+  })
+
+  it('does not repaint while the phone still drives the pty without a fit hold', async () => {
+    const { signalPty, setFitOverride, dispose } = await connectPaneHoldingMobileFit()
+    const { setDriverForPty } = await import('@/lib/pane-manager/mobile-driver-state')
+    // A lock-only takeover keeps the phone authoritative with no fit override.
+    setDriverForPty(PTY_ID, { kind: 'mobile', clientId: 'phone-1' })
+
+    setFitOverride(PTY_ID, 'desktop-fit', DESKTOP.cols, DESKTOP.rows)
+    await flushAsyncTicks(6)
+
+    expect(signalPty.mock.calls).toEqual([])
+    setDriverForPty(PTY_ID, { kind: 'desktop' })
     dispose()
   })
 })

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -4343,6 +4343,59 @@ export function connectPanePty(
     forwardPtyResize(cols, rows)
   })
 
+  // Why (#14321): the host resizes the PTY back to desktop dims and only then
+  // tells the renderer the hold is released, so an alt-screen TUI's SIGWINCH
+  // redraw (measured 0.4-8ms) is parsed while xterm is still parked at phone
+  // dims — a frame before the release refit lands. Alt screens never reflow, so
+  // that frame is stale until something makes the TUI redraw; the renderer's own
+  // corrective pty:resize cannot, because the phone->desktop layout arms a 500ms
+  // suppress window over it. Re-signal once the restored grid is in place.
+  let heldMobileFitPtyId: string | null = null
+  let mobileFitReleaseRepaintFit: SafeFitContinuationHandle | null = null
+  const unsubscribeMobileFitReleaseRepaint = onOverrideChange((event) => {
+    if (event.ptyId !== transport.getPtyId()) {
+      return
+    }
+    if (event.mode === 'mobile-fit') {
+      heldMobileFitPtyId = event.ptyId
+      return
+    }
+    // Why only mobile-fit: a remote-desktop-fit hand-off keeps another desktop
+    // authoritative for the grid, and its own viewport claim owns the repaint.
+    if (event.mode !== 'desktop-fit' || heldMobileFitPtyId !== event.ptyId) {
+      return
+    }
+    const releasedPtyId = event.ptyId
+    heldMobileFitPtyId = null
+    const isCurrentRelease = (): boolean =>
+      !disposed && transport.getPtyId() === releasedPtyId && !getFitOverrideForPty(releasedPtyId)
+    mobileFitReleaseRepaintFit?.cancel()
+    mobileFitReleaseRepaintFit = safeFitAndThen(
+      pane,
+      'mobile-fit-release-repaint',
+      () => {
+        mobileFitReleaseRepaintFit = null
+        // Why not a resize: the PTY is already at desktop dims, so POSIX sends
+        // no SIGWINCH of its own; signalling explicitly also skips the host's
+        // resize-suppress window instead of being dropped by it.
+        if (
+          isCurrentRelease() &&
+          deps.isVisibleRef.current &&
+          !isRemoteRuntimePtyId(releasedPtyId)
+        ) {
+          window.api.pty.signal(releasedPtyId, 'SIGWINCH')
+        }
+      },
+      {
+        shouldContinue: isCurrentRelease,
+        retryIfUnmeasurable: true,
+        // Why: a hidden pane repaints on reveal, where its grid is measurable
+        // and the redraw is not filed as stale background output.
+        deferIfHidden: true
+      }
+    )
+  })
+
   // Why: renderer resize forwarding is fire-and-forget. A visible pane can
   // finish with xterm at the right grid while the PTY silently kept an older
   // grid, so Codex keeps composing against stale columns. Fit first so xterm's
@@ -9499,6 +9552,9 @@ export function connectPanePty(
       terminalRecoveryInstance.unregister()
       unregisterUndeliverableWriteHandler()
       unsubscribeRemoteDesktopActivationClaim()
+      unsubscribeMobileFitReleaseRepaint()
+      mobileFitReleaseRepaintFit?.cancel()
+      mobileFitReleaseRepaintFit = null
       cancelHiddenOutputSnapshotScrollRestore()
       liveScrollbackRestore?.dispose()
       liveScrollbackRestore = null

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -4350,23 +4350,21 @@ export function connectPanePty(
   // that frame is stale until something makes the TUI redraw; the renderer's own
   // corrective pty:resize cannot, because the phone->desktop layout arms a 500ms
   // suppress window over it. Re-signal once the restored grid is in place.
-  let heldMobileFitPtyId: string | null = null
   let mobileFitReleaseRepaintFit: SafeFitContinuationHandle | null = null
   const unsubscribeMobileFitReleaseRepaint = onOverrideChange((event) => {
-    if (event.ptyId !== transport.getPtyId()) {
-      return
-    }
-    if (event.mode === 'mobile-fit') {
-      heldMobileFitPtyId = event.ptyId
-      return
-    }
-    // Why only mobile-fit: a remote-desktop-fit hand-off keeps another desktop
+    // Why event.priorMode and not a remembered hold: this pane may have
+    // connected while the phone already held the grid (reload hydration, tab
+    // reopened mid-hold), so the opening mobile-fit event never reached it.
+    // Why only mobile-fit: a remote-desktop-fit hand-back keeps another desktop
     // authoritative for the grid, and its own viewport claim owns the repaint.
-    if (event.mode !== 'desktop-fit' || heldMobileFitPtyId !== event.ptyId) {
+    if (
+      event.ptyId !== transport.getPtyId() ||
+      event.mode !== 'desktop-fit' ||
+      event.priorMode !== 'mobile-fit'
+    ) {
       return
     }
     const releasedPtyId = event.ptyId
-    heldMobileFitPtyId = null
     const isCurrentRelease = (): boolean =>
       !disposed && transport.getPtyId() === releasedPtyId && !getFitOverrideForPty(releasedPtyId)
     mobileFitReleaseRepaintFit?.cancel()

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -4372,11 +4372,16 @@ export function connectPanePty(
       return
     }
     const releasedPtyId = event.ptyId
-    // Why the shared guard: a lock-only takeover holds the grid with no
-    // override, so testing the override alone would repaint a PTY the phone
-    // still drives.
+    // Why the hold and not shouldSuppressDesktopPtyResize: the presence lock is
+    // still mobile when this event arrives. reclaimTerminalForDesktop awaits
+    // applyMobileDisplayMode (which publishes this release) before
+    // releaseDesktopTakeBack flips the driver, so gating on the lock cancels
+    // every desktop "Take back" — the gesture this repaint exists for. The hold
+    // is the real question: once it is gone the PTY is at desktop dims, and if
+    // the phone retakes the grid before a parked refit lands, a fresh
+    // mobile-fit reinstates it and this goes false again.
     const isCurrentRelease = (): boolean =>
-      !disposed && transport.getPtyId() === releasedPtyId && !shouldSuppressDesktopPtyResize()
+      !disposed && transport.getPtyId() === releasedPtyId && !getFitOverrideForPty(releasedPtyId)
     mobileFitReleaseRepaintFit?.cancel()
     mobileFitReleaseRepaintFit = safeFitAndThen(
       pane,

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -4357,16 +4357,26 @@ export function connectPanePty(
     // reopened mid-hold), so the opening mobile-fit event never reached it.
     // Why only mobile-fit: a remote-desktop-fit hand-back keeps another desktop
     // authoritative for the grid, and its own viewport claim owns the repaint.
+    // Why 0x0: the runtime publishes real dims only when the release was paired
+    // with a PTY resize. onPtyExit and releaseDesktopTakeBack clear the hold
+    // with a 0x0 marker and no resize — after a take-back whose best-effort
+    // resize did not converge, the PTY is still at phone dims, so repainting
+    // there would redraw the TUI at the wrong width instead of fixing it.
     if (
       event.ptyId !== transport.getPtyId() ||
       event.mode !== 'desktop-fit' ||
-      event.priorMode !== 'mobile-fit'
+      event.priorMode !== 'mobile-fit' ||
+      event.cols === 0 ||
+      event.rows === 0
     ) {
       return
     }
     const releasedPtyId = event.ptyId
+    // Why the shared guard: a lock-only takeover holds the grid with no
+    // override, so testing the override alone would repaint a PTY the phone
+    // still drives.
     const isCurrentRelease = (): boolean =>
-      !disposed && transport.getPtyId() === releasedPtyId && !getFitOverrideForPty(releasedPtyId)
+      !disposed && transport.getPtyId() === releasedPtyId && !shouldSuppressDesktopPtyResize()
     mobileFitReleaseRepaintFit?.cancel()
     mobileFitReleaseRepaintFit = safeFitAndThen(
       pane,

--- a/src/renderer/src/lib/pane-manager/mobile-fit-overrides.test.ts
+++ b/src/renderer/src/lib/pane-manager/mobile-fit-overrides.test.ts
@@ -228,7 +228,8 @@ describe('onOverrideChange', () => {
       cols: 49,
       rows: 20,
       priorCols: null,
-      priorRows: null
+      priorRows: null,
+      priorMode: null
     })
 
     unsub()
@@ -246,7 +247,8 @@ describe('onOverrideChange', () => {
       cols: 120,
       rows: 40,
       priorCols: null,
-      priorRows: null
+      priorRows: null,
+      priorMode: null
     })
 
     unsub()
@@ -265,7 +267,8 @@ describe('onOverrideChange', () => {
       cols: 120,
       rows: 40,
       priorCols: 49,
-      priorRows: 20
+      priorRows: 20,
+      priorMode: 'mobile-fit'
     })
 
     unsub()

--- a/src/renderer/src/lib/pane-manager/mobile-fit-overrides.ts
+++ b/src/renderer/src/lib/pane-manager/mobile-fit-overrides.ts
@@ -34,6 +34,11 @@ type OverrideChangeEvent = {
   // the desktop pane while mobile was active).
   priorCols: number | null
   priorRows: number | null
+  // Why: the hold this event replaced. A listener that only cares about a
+  // phone hand-back cannot track that itself — it may have subscribed after
+  // the hold was already established (reload hydration, tab reopened mid-hold)
+  // and would then never see the opening mobile-fit event.
+  priorMode: 'mobile-fit' | 'remote-desktop-fit' | null
 }
 type OverrideChangeListener = (event: OverrideChangeEvent) => void
 const changeListeners = new Set<OverrideChangeListener>()
@@ -62,7 +67,8 @@ export function setFitOverride(ptyId: string, mode: FitHoldMode, cols: number, r
     cols,
     rows,
     priorCols: prior?.cols ?? null,
-    priorRows: prior?.rows ?? null
+    priorRows: prior?.rows ?? null,
+    priorMode: prior?.mode ?? null
   })
 }
 
@@ -149,7 +155,8 @@ export function hydrateOverrides(
       cols: override.cols,
       rows: override.rows,
       priorCols: prior?.cols ?? null,
-      priorRows: prior?.rows ?? null
+      priorRows: prior?.rows ?? null,
+      priorMode: prior?.mode ?? null
     })
     previous.delete(ptyId)
   }
@@ -161,7 +168,8 @@ export function hydrateOverrides(
       cols: 0,
       rows: 0,
       priorCols: prior.cols,
-      priorRows: prior.rows
+      priorRows: prior.rows,
+      priorMode: prior.mode
     })
   }
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​368 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​365 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​80 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​77 |

<!-- /orca-pr-loc -->

## ELI5

You open a terminal on your phone, so your Mac shrinks that terminal to phone size. You put the phone
down, the Mac takes the terminal back at full size — but the picture is wrong: the top is blank or
garbled, and it stays that way until you toggle a sidebar (`Cmd+L`) or resize the window.

The reason is a one-frame ordering problem. The Mac tells the *shell program* "you're wide again" a
frame before it tells the *terminal widget*. The program immediately repaints itself at the wide size,
and that wide repaint gets read by a widget that is still narrow. Nothing ever asks the program to
repaint again, so the mess sticks. This PR asks it to repaint once the widget is wide again.

## What Changed

`connectPanePty` now watches for a **mobile-fit hold being released to desktop-fit** on its own PTY.
When that happens it fits the pane and, once the restored grid has landed, sends one `SIGWINCH` so the
program redraws against the grid the user is actually looking at.

- One `onOverrideChange` subscription per pane connection, unsubscribed on dispose.
- Only fires for a `mobile-fit` → `desktop-fit` transition it actually observed. A `remote-desktop-fit`
  hand-off, a `desktop-fit` for a hold this pane never had, or a `0×0` release marker do not fire it.
- The `0×0` gate is load-bearing, not defensive. `onPtyExit` (`orca-runtime.ts:15189`) and
  `releaseDesktopTakeBack` (`:15909`) clear the hold with a `0×0` marker and *no* paired resize, so
  after a take-back whose best-effort resize never converged the PTY is still at phone dims —
  repainting there would redraw the TUI at the wrong width instead of fixing it.
- The repaint is gated on **the hold**, not on the presence lock. Those are not the same question:
  `reclaimTerminalForDesktop`'s active-subscriber branch (`orca-runtime.ts:15830-15845`) awaits
  `applyMobileDisplayMode` — which publishes this very release — and only *then* calls
  `releaseDesktopTakeBack`, which flips the driver. So the renderer deterministically observes the
  release while its driver mirror still reads `mobile`. Gating on the lock would cancel the fit for
  every desktop **"Take back"**, i.e. the exact gesture #14321 is about. The hold is also the live
  staleness check: a phone that retakes the grid before a parked refit lands reinstates the override
  and the parked repaint is dropped.
- Local **and SSH** PTYs — SSH pane ids carry the `ssh:` prefix, not `remote:`, so they are not skipped, and the relay's signal handler allows `SIGWINCH`. Only remote-runtime (`remote:`) PTYs are excluded — remote runtime PTYs have no signal channel (same guard as every other SIGWINCH site
  in this file: `:4399`, `:7443`, `:8628`).
- **Windows/ConPTY is a silent no-op — #14321 is NOT fixed on Windows by this PR.** See
  Cross-platform under Review for the mechanism.
- Routed through `safeFitAndThen(..., { retryIfUnmeasurable: true, deferIfHidden: true })`, so a hidden
  pane signals at reveal (where its grid is measurable) instead of filing a repaint as stale
  background output.

New test: `pty-connection-mobile-fit-release-repaint.test.ts`.

## Why

Traced end to end, then measured.

1. On release, `applyLayout` resizes the PTY back to desktop dims first
   (`orca-runtime.ts:16202`), and *then* notifies the renderer
   (`orca-runtime.ts:16245`).
2. The child's post-SIGWINCH full-screen redraw comes back in **0.4–8.3 ms**
   (measured over 8 cycles against a real `node-pty` + a real SIGWINCH-redrawing TUI).
3. The renderer restores xterm's grid on the **next animation frame**
   (`use-mobile-overlay-ticks.ts:46-52`, `:103-107`), with a 100 ms timer as the fallback. That is
   always later than step 2 — and much later when the desktop window is backgrounded, which is exactly
   when the user is on their phone.
4. So the wide redraw is parsed at phone dims. The alternate screen never reflows, so that frame is
   permanent.
5. The renderer's own corrective `pty:resize` — which *would* produce a healing SIGWINCH — is dropped:
   the phone→desktop transition arms `suppressResizesForMs(500)` (`orca-runtime.ts:16242`) and the
   `pty:resize` IPC handler early-returns on it (`src/main/ipc/pty.ts:7442`).

Nothing else asks the TUI to redraw, so the pane stays stale until the *next* real layout change
produces a genuine resize. That is precisely the reported workaround: `Cmd+L` is
`sidebar.right.toggle`, which changes the pane width and therefore does produce one.

**Why a signal and not a resize or a `refresh()`:** the PTY is already at desktop dims, so POSIX emits
no SIGWINCH of its own, and a renderer resize would be eaten by the 500 ms suppress window.
`pty:signal` is not gated by it. A `terminal.refresh()` is useless here — the cells themselves are
wrong, not merely unpainted, which is why the reporter finds that only a resize heals it.

## Linked Issue

Fixes #14321 **on macOS, Linux and SSH remotes.** Windows/ConPTY is untouched — see Cross-platform
under Review.

## Visual Proof

Measured with a real `node-pty`, a real SIGWINCH-driven alt-screen TUI, and a real
`@xterm/headless` buffer replaying the production order (host resizes PTY → renderer refits one frame
later). Left is today. Right is the same sequence with this PR's signal.

![proof.png](https://github.com/user-attachments/assets/9d453d4c-87fe-4e1d-ad72-65c9b9b26bdf)

| | blank rows | rows not drawn at the restored dims |
|---|---|---|
| today | **30 / 50** | **16** |
| `Cmd+L`'s resize pulse (the user's workaround) | 0 / 50 | 0 |
| this PR's SIGWINCH after the refit | **0 / 50** | **0** |

Note the top of the "before" pane: `WINCH-ROW046` is the first legible row, rows 0–45 are wrapped
remnants. That matches the issue's "sometimes the stuff at the top is not visible" exactly.

## Testing

`npx vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection-mobile-fit-release-repaint.test.ts`

The harness now models production faithfully in one respect the earlier revisions of this PR did not:
`handleMobileSubscribe` sets the driver to `mobile` **before** it writes the phone layout
(`orca-runtime.ts:16487`), so the driver mirror reads `mobile` for the whole duration of a hold — and
still reads `mobile` at the instant the release arrives. Releases are driven in the order the gesture
actually produces them: `desktop-fit` first, driver flip second.

**RED (these tests against the branch before this commit):**

```
 × signals SIGWINCH once the restored desktop grid lands so the TUI repaints 917ms
 × repaints a take-back whose release lands before the driver flips to desktop 19ms
 × repaint-signals only the hold it released, not every desktop-fit 17ms
 × repaints a pane that connected while the phone already held the grid 13ms
 × replays a parked repaint when the phone did not retake the grid 12ms

AssertionError: expected { signals: [], gridAtSignal: [] } to deeply equal
  { signals: [ [ 'tab-pty', 'SIGWINCH' ] ], gridAtSignal: [ { cols: 120, rows: 40 } ] }

 Test Files  1 failed (1)
      Tests  5 failed | 4 passed (9)
```

**GREEN (with the fix):**

```
 ✓ signals SIGWINCH once the restored desktop grid lands so the TUI repaints
 ✓ repaints a take-back whose release lands before the driver flips to desktop
 ✓ does not repaint-signal when another desktop takes the grid instead
 ✓ repaint-signals only the hold it released, not every desktop-fit
 ✓ does not repaint-signal a remote runtime pty, which has no signal channel
 ✓ repaints a pane that connected while the phone already held the grid
 ✓ does not repaint when the hold is cleared without a paired resize
 ✓ drops a parked repaint once the phone has retaken the grid
 ✓ replays a parked repaint when the phone did not retake the grid

 Test Files  1 passed (1)
      Tests  9 passed (9)
```

**Both surviving gates are mutation-validated** (each mutant run, then reverted):

| mutant | result |
|---|---|
| drop `!getFitOverrideForPty(releasedPtyId)` from the release gate | `× drops a parked repaint once the phone has retaken the grid` — 1 failed \| 8 passed |
| drop the `cols === 0 \|\| rows === 0` gate | `× does not repaint when the hold is cleared without a paired resize` — 1 failed \| 8 passed |

Neighbours, serial (`--no-file-parallelism`): `pty-connection-mobile-fit-release-repaint`,
`mobile-fit-overrides`, `mobile-fit-overrides-hydration`, `pty-connection-visibility-resume-size`,
`pane-fit` — `Test Files  5 passed (5)` / `Tests  91 passed (91)`.

`npx oxlint` on both changed files: clean. `npx tsc --noEmit -p config/tsconfig.web.json
--composite false`: clean, and **proven to actually cover the changed test file** by injecting
`const __probe: number = "not a number"` into it and observing
`pty-connection-mobile-fit-release-repaint.test.ts(364,7): error TS2322`; then reverted and the tree
verified clean.

- [x] I manually tested these changes locally — *at the runtime/PTY boundary, not in the packaged app.*
- [x] Automated tests added/updated

**What I could not validate:** a paired phone + desktop run in the real app. No paired
phone+desktop rig was available for this revision, so **all evidence for the take-back ordering is
unit-level**, driven against the main-process emission order transcribed from
`reclaimTerminalForDesktop` — not observed on a device. Dev-mode CDP would not have covered it either.
The earlier measurement in Visual Proof does drive the production ordering against a real PTY and a
real xterm buffer, but it is not a rendered-UI check. The fix's mechanism (`SIGWINCH` after a settled
fit) is the one already used at three other sites in this same file, so the risk of the mechanism
itself not working is low; the risk that remains is whether the field report has a second,
independent cause.

## AI Disclosure

<!-- internal contributor -->

## Review

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

- **Security** — no new IPC surface, no new data crosses a trust boundary. `pty:signal` is an existing
  renderer→main channel and the signal sent is a fixed `'SIGWINCH'` literal, not caller-supplied.
- **Cross-platform** — SIGWINCH is POSIX.
  - macOS/Linux: `local-pty-provider.sendSignal` (`:1349`) routes SIGWINCH through
    `signalPosixPtyForegroundGroup`, which targets the tty's foreground process group rather than
    `login(1)`/the shell root pid — required for the redraw to reach the TUI at all.
  - **Windows/ConPTY: this PR does nothing.** `signalPosixPtyForegroundGroup` short-circuits to its
    `fallback()` on `win32` (`posix-pty-foreground-group.ts:110`), and that fallback is
    `process.kill(proc.pid, 'SIGWINCH')` wrapped in a bare `try {} catch {}`
    (`local-pty-provider.ts:1339-1345`). ConPTY has no SIGWINCH, so nothing is delivered and nothing
    is reported — a **silent no-op**. **#14321 therefore stays broken on Windows.** It is not
    *regressed* — the pane behaves exactly as it does today — but the fix does not reach it, and
    Windows needs a ConPTY-appropriate repaint primitive in its own PR. Called out, not folded in.
- **Remote runtime / SSH** — explicitly skipped for `remote:` PTY ids only. Every existing SIGWINCH
  call site in `pty-connection.ts` carries the same `!isRemoteRuntimePtyId` guard, so remote-runtime
  panes keep their current behavior; that gap is real and worth its own PR, and it is not silently
  widened here. SSH panes are a different namespace (`ssh:`) and *are* covered: the relay's signal
  handler lists `SIGWINCH` in its allow-list and routes it through the same POSIX foreground-group
  helper. An older relay that rejects the signal is swallowed by the `.catch(() => {})` in the
  `pty:signal` main handler, so there is no wire change and no error surface either way.
- **Mobile** — nothing on the mobile client changes. No wire format, no RPC, no stream opcode. Mixed
  client/host versions are unaffected: this is entirely desktop-renderer-local.
- **Backwards compatibility** — no persisted state, no settings, no schema. A host that never emits a
  `mobile-fit` override simply never arms the listener.
- **Correctness of the guard choice** — a "lock-only takeover" (driver `mobile`, no fit override)
  cannot reach this listener at all: it runs only on `priorMode === 'mobile-fit'`, and `priorMode` is
  derived from the override that was just replaced, so a hold must have existed. That premise was the
  justification for pulling the presence lock into the gate; it does not exist, while the take-back it
  broke does. The reachable "phone owns the grid" case is a *fresh* `mobile-fit` landing before a
  parked refit runs, which the override check still covers — and which now has a test and its positive
  control.
- **Performance** — one listener per pane connection (joining the one already registered a few lines
  above), and at most one `safeFit` + one signal per mobile-fit release. The `safeFit` early-returns
  when the grid already matches, so the existing rAF refit becomes a no-op rather than duplicated work.
  Nothing runs on the output or keystroke path.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after attached
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] Lint (`oxlint`, code-quality native plugins, react-doctor) and the affected test suites pass locally.
      Full typecheck left to CI per task constraints.

## Author

- X / Twitter: @BrennanKB5


