### PR TITLE
fix(agent-hooks): stop Antigravity's Windows hook from spawning PowerShell on every event

### DIFF
--- a/src/main/agent-hooks/windows-hook-post-interpreter.test.ts
+++ b/src/main/agent-hooks/windows-hook-post-interpreter.test.ts
@@ -1,14 +1,7 @@
-// Why (#15117): Antigravity spent three months posting hook status through Windows
-// PowerShell 5.1 after every other agent had moved to curl.exe. Nothing caught it, because
-// the drift was invisible to per-agent tests: the shared builder took only `(source)` and had
-// no way to add the extra form field Antigravity needs, so it forked a private copy of the
-// then-correct PowerShell command (#2100). When the shared builder switched to curl (#6402),
-// every agent that *called* it was fixed for free and the private copy silently was not.
-//
-// This suite asserts the invariant that drift violated, across every agent at once: a managed
-// Windows .cmd hook posts through curl.exe and spawns no interpreter. It generates the scripts
-// under a mocked win32 platform rather than executing them, so it guards the POSIX CI legs too
-// — the drift would otherwise only be visible on a Windows runner.
+// Why (#15117): an agent holding a private copy of the shared post command missed the move to
+// curl for three months, invisible to per-agent tests. Assert the invariant across every agent
+// at once: a managed Windows .cmd hook posts through curl.exe and spawns no interpreter.
+// Generated under a mocked win32 platform, not executed, so the POSIX CI legs guard it too.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'

--- a/src/main/agent-hooks/windows-hook-post-interpreter.test.ts
+++ b/src/main/agent-hooks/windows-hook-post-interpreter.test.ts
@@ -1,0 +1,138 @@
+// Why (#15117): Antigravity spent three months posting hook status through Windows
+// PowerShell 5.1 after every other agent had moved to curl.exe. Nothing caught it, because
+// the drift was invisible to per-agent tests: the shared builder took only `(source)` and had
+// no way to add the extra form field Antigravity needs, so it forked a private copy of the
+// then-correct PowerShell command (#2100). When the shared builder switched to curl (#6402),
+// every agent that *called* it was fixed for free and the private copy silently was not.
+//
+// This suite asserts the invariant that drift violated, across every agent at once: a managed
+// Windows .cmd hook posts through curl.exe and spawns no interpreter. It generates the scripts
+// under a mocked win32 platform rather than executing them, so it guards the POSIX CI legs too
+// — the drift would otherwise only be visible on a Windows runner.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type * as osModule from 'node:os'
+
+let isolatedUserDataDir = ''
+let previousUserDataPath: string | undefined
+
+const { homedirMock } = vi.hoisted(() => ({
+  homedirMock: vi.fn<() => string>()
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => '/tmp/orca-user-data'
+  }
+}))
+
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof osModule>()
+  return {
+    ...actual,
+    homedir: homedirMock.mockImplementation(actual.homedir)
+  }
+})
+
+import { AntigravityHookService } from '../antigravity/hook-service'
+import { ClaudeHookService } from '../claude/hook-service'
+import { CodexHookService } from '../codex/hook-service'
+import { CommandCodeHookService } from '../command-code/hook-service'
+import { CursorHookService } from '../cursor/hook-service'
+import { DevinHookService } from '../devin/hook-service'
+import { DroidHookService } from '../droid/hook-service'
+import { GeminiHookService } from '../gemini/hook-service'
+import { GrokHookService } from '../grok/hook-service'
+import { openClaudeHookService } from '../openclaude/hook-service'
+
+// Why: only agents whose managed Windows script is a .cmd batch file. Copilot's hook is a
+// `.ps1` — PowerShell is its interpreter, not a child process it spawns per event — and Kimi's
+// is a Git Bash `.sh`, so neither is subject to this invariant.
+const BATCH_SCRIPT_INSTALLERS = [
+  { agent: 'antigravity', install: () => new AntigravityHookService().install() },
+  { agent: 'claude', install: () => new ClaudeHookService().install() },
+  { agent: 'openclaude', install: () => openClaudeHookService.install() },
+  { agent: 'codex', install: () => new CodexHookService().install() },
+  { agent: 'command-code', install: () => new CommandCodeHookService().install() },
+  { agent: 'cursor', install: () => new CursorHookService().install() },
+  { agent: 'devin', install: () => new DevinHookService().install() },
+  { agent: 'droid', install: () => new DroidHookService().install() },
+  { agent: 'gemini', install: () => new GeminiHookService().install() },
+  { agent: 'grok', install: () => new GrokHookService().install() }
+] as const
+
+function withPlatform<T>(platform: NodeJS.Platform, run: () => T): T {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+  Object.defineProperty(process, 'platform', { configurable: true, value: platform })
+  try {
+    return run()
+  } finally {
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform)
+    }
+  }
+}
+
+describe('Windows managed hook post interpreter', () => {
+  let home = ''
+
+  beforeEach(() => {
+    previousUserDataPath = process.env.ORCA_USER_DATA_PATH
+    isolatedUserDataDir = mkdtempSync(join(tmpdir(), 'orca-hook-interpreter-user-data-'))
+    // Why: Orca-managed Codex hooks resolve through ORCA_USER_DATA_PATH before the mocked
+    // home; an inherited live path would let this test rewrite the developer's own hooks.
+    process.env.ORCA_USER_DATA_PATH = isolatedUserDataDir
+    home = mkdtempSync(join(tmpdir(), 'orca-hook-interpreter-'))
+    homedirMock.mockReturnValue(home)
+  })
+
+  afterEach(() => {
+    if (previousUserDataPath === undefined) {
+      delete process.env.ORCA_USER_DATA_PATH
+    } else {
+      process.env.ORCA_USER_DATA_PATH = previousUserDataPath
+    }
+    rmSync(isolatedUserDataDir, { recursive: true, force: true })
+    homedirMock.mockImplementation(() => process.env.HOME ?? tmpdir())
+    rmSync(home, { recursive: true, force: true })
+    home = ''
+  })
+
+  it('posts through curl.exe from every managed batch script, spawning no interpreter', () => {
+    const scripts = withPlatform('win32', () => {
+      for (const entry of BATCH_SCRIPT_INSTALLERS) {
+        expect(entry.install().state, `${entry.agent} install status`).toBe('installed')
+      }
+      const hooksDir = join(home, '.orca', 'agent-hooks')
+      return readdirSync(hooksDir)
+        .filter((name) => name.endsWith('.cmd'))
+        .map((name) => ({ name, body: readFileSync(join(hooksDir, name), 'utf8') }))
+    })
+
+    // Why: a silent zero would make this suite pass while asserting nothing.
+    expect(scripts.length).toBeGreaterThanOrEqual(BATCH_SCRIPT_INSTALLERS.length)
+
+    const posting = scripts.filter((script) => script.body.includes('/hook/'))
+    // Why: every agent in the matrix owns exactly one posting script; event wrappers that only
+    // set an env var and delegate are not expected to post themselves.
+    expect(posting.length).toBeGreaterThanOrEqual(BATCH_SCRIPT_INSTALLERS.length)
+
+    for (const script of posting) {
+      // Why: PowerShell costs ~300ms of interpreter startup per event and recodes the UTF-8
+      // payload through the console code page. curl.exe (Win10 1803+) does neither.
+      expect(script.body, `${script.name} must not spawn an interpreter`).not.toMatch(
+        /powershell(\.exe)?/i
+      )
+      // Why: fully qualified so a repo-local curl.exe cannot intercept hook payloads.
+      expect(script.body, `${script.name} must post through curl.exe`).toContain(
+        '"%SystemRoot%\\System32\\curl.exe"'
+      )
+      // Why: keeps multi-KB tool output off the command line (EDR oversized-command-line rules).
+      expect(script.body, `${script.name} must pipe the payload via stdin`).toContain(
+        '--data-urlencode "payload@-"'
+      )
+    }
+  })
+})

--- a/src/main/agent-hooks/windows-hook-post-interpreter.test.ts
+++ b/src/main/agent-hooks/windows-hook-post-interpreter.test.ts
@@ -107,22 +107,40 @@ describe('Windows managed hook post interpreter', () => {
     // Why: a silent zero would make this suite pass while asserting nothing.
     expect(scripts.length).toBeGreaterThanOrEqual(BATCH_SCRIPT_INSTALLERS.length)
 
-    const posting = scripts.filter((script) => script.body.includes('/hook/'))
-    // Why: every agent in the matrix owns exactly one posting script; event wrappers that only
-    // set an env var and delegate are not expected to post themselves.
-    expect(posting.length).toBeGreaterThanOrEqual(BATCH_SCRIPT_INSTALLERS.length)
-
-    for (const script of posting) {
+    // Why: assert this across every .cmd before narrowing. Filtering to posting scripts first
+    // hides the failure that matters — a script that swapped its curl POST for an interpreter
+    // no longer matches the filter, so the suite fails on an opaque count instead.
+    for (const script of scripts) {
       // Why: PowerShell costs ~300ms of interpreter startup per event and recodes the UTF-8
       // payload through the console code page. curl.exe (Win10 1803+) does neither.
       expect(script.body, `${script.name} must not spawn an interpreter`).not.toMatch(
         /powershell(\.exe)?/i
       )
+    }
+
+    // Why: `%~dp0` marks an event wrapper that only sets env and delegates to the core script.
+    const isWrapper = (body: string): boolean => body.includes('%~dp0')
+    const posts = (body: string): boolean => body.includes('127.0.0.1:%ORCA_AGENT_HOOK_PORT%')
+
+    // Why: name the script that stopped posting rather than failing on a bare count.
+    expect(
+      scripts.filter((s) => !isWrapper(s.body) && !posts(s.body)).map((s) => s.name),
+      'every non-wrapper script must post to the hook port'
+    ).toEqual([])
+
+    const posting = scripts.filter((script) => posts(script.body))
+    expect(posting.length).toBeGreaterThanOrEqual(BATCH_SCRIPT_INSTALLERS.length)
+
+    for (const script of posting) {
       // Why: fully qualified so a repo-local curl.exe cannot intercept hook payloads.
       expect(script.body, `${script.name} must post through curl.exe`).toContain(
         '"%SystemRoot%\\System32\\curl.exe"'
       )
-      // Why: keeps multi-KB tool output off the command line (EDR oversized-command-line rules).
+    }
+
+    // Why: hook events pipe via stdin to keep multi-KB tool output off the command line (EDR
+    // oversized-command-line rules). The statusline script stages a temp file instead.
+    for (const script of posting.filter((s) => s.body.includes('/hook/'))) {
       expect(script.body, `${script.name} must pipe the payload via stdin`).toContain(
         '--data-urlencode "payload@-"'
       )

--- a/src/main/antigravity/hook-script.ts
+++ b/src/main/antigravity/hook-script.ts
@@ -4,13 +4,27 @@ import {
   buildWindowsHookStdinDrainEpilogue,
   WINDOWS_HOOK_STDIN_DRAIN_COMMAND
 } from '../agent-hooks/hook-stdin-contract'
+import { buildWindowsAgentHookPostCommand } from '../agent-hooks/installer-utils'
 import { ANTIGRAVITY_PRE_TOOL_USE_DECISION } from './hook-events'
+
+// Why (#15117): Antigravity was the last agent posting hook status through Windows
+// PowerShell 5.1. Its ~300ms cold start per event is what made the console the agent
+// allocates for each hook visible; curl.exe (Win10 1803+) finishes in ~10ms and, unlike
+// PowerShell, does not recode the UTF-8 payload through the console code page.
+const WINDOWS_ANTIGRAVITY_HOOK_POST_COMMAND = buildWindowsAgentHookPostCommand('antigravity', [
+  // Why: the event name lives in the wrapper's env, not the payload, and the listener
+  // reads it as a top-level form field — same position as the POSIX branch below.
+  '  --data-urlencode "hook_event_name=%ORCA_ANTIGRAVITY_EVENT%" ^'
+])
 
 export function getManagedScript(target: 'local' | 'posix' = 'local'): string {
   if (target === 'local' && process.platform === 'win32') {
     return [
       '@echo off',
-      'setlocal',
+      // Why (#9358/#9941): a bare `setlocal` inherits delayed expansion from the caller, and
+      // every `!` in a percent-expanded value on the curl line is then eaten as a delayed
+      // reference — silently mangling paneKey and dropping worktreeId. `!` is legal in a path.
+      'setlocal DisableDelayedExpansion',
       'if /I "%ORCA_ANTIGRAVITY_EVENT%"=="Stop" (',
       '  echo {"decision":""}',
       ') else if /I "%ORCA_ANTIGRAVITY_EVENT%"=="PreToolUse" (',
@@ -20,7 +34,7 @@ export function getManagedScript(target: 'local' | 'posix' = 'local'): string {
       ')',
       'if defined ORCA_AGENT_HOOK_ENDPOINT if exist "%ORCA_AGENT_HOOK_ENDPOINT%" call "%ORCA_AGENT_HOOK_ENDPOINT%" 2>nul',
       ...buildWindowsHookEnvironmentGuardLines(),
-      buildWindowsAntigravityHookPostCommand(),
+      WINDOWS_ANTIGRAVITY_HOOK_POST_COMMAND,
       'exit /b 0',
       ...buildWindowsHookStdinDrainEpilogue(),
       ''
@@ -95,11 +109,4 @@ export function getWindowsWrapperScript(eventName: string): string {
     'exit /b 0',
     ''
   ].join('\r\n')
-}
-
-function buildWindowsAntigravityHookPostCommand(): string {
-  // Why: Antigravity hooks are best-effort status updates; do not let a stalled
-  // local listener hold the agent process open. Qualify PowerShell so a
-  // worktree-local powershell.exe cannot hijack hook payloads.
-  return `"%SystemRoot%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -NoProfile -ExecutionPolicy Bypass -Command "$utf8=[System.Text.UTF8Encoding]::new($false); [Console]::InputEncoding=$utf8; [Console]::OutputEncoding=$utf8; $inputData=[Console]::In.ReadToEnd(); try { $payload=if ([string]::IsNullOrWhiteSpace($inputData)) { @{} } else { $inputData | ConvertFrom-Json }; $body=@{ paneKey=$env:ORCA_PANE_KEY; launchToken=$env:ORCA_AGENT_LAUNCH_TOKEN; tabId=$env:ORCA_TAB_ID; worktreeId=$env:ORCA_WORKTREE_ID; env=$env:ORCA_AGENT_HOOK_ENV; version=$env:ORCA_AGENT_HOOK_VERSION; hook_event_name=$env:ORCA_ANTIGRAVITY_EVENT; payload=$payload } | ConvertTo-Json -Depth 100 -Compress; $bodyBytes=$utf8.GetBytes($body); Invoke-WebRequest -UseBasicParsing -Method Post -Uri ('http://127.0.0.1:' + $env:ORCA_AGENT_HOOK_PORT + '/hook/antigravity') -ContentType 'application/json; charset=utf-8' -Headers @{ 'X-Orca-Agent-Hook-Token'=$env:ORCA_AGENT_HOOK_TOKEN } -Body $bodyBytes -TimeoutSec 2 | Out-Null } catch {}"`
 }

--- a/src/main/antigravity/hook-script.ts
+++ b/src/main/antigravity/hook-script.ts
@@ -7,14 +7,10 @@ import {
 import { buildWindowsAgentHookPostCommand } from '../agent-hooks/installer-utils'
 import { ANTIGRAVITY_PRE_TOOL_USE_DECISION } from './hook-events'
 
-// Why (#15117): Antigravity was the last agent posting hook status through Windows
-// PowerShell 5.1. Its ~300ms cold start per event is what made the console the agent
-// allocates for each hook visible; curl.exe (Win10 1803+) finishes in ~10ms and, unlike
-// PowerShell, does not recode the UTF-8 payload through the console code page.
+// Why (#15117): PowerShell cost ~300ms of startup per event, which is what made the console
+// the agent allocates for each hook last long enough to see.
 const WINDOWS_ANTIGRAVITY_HOOK_POST_COMMAND = buildWindowsAgentHookPostCommand('antigravity', [
-  // Why: Antigravity alone takes its event name from the wrapper's env rather than the piped
-  // payload. Before `extraFormLines` existed this forced a private copy of the shared command,
-  // which is how this script missed the fleet-wide move to curl for three months (#15117).
+  // Why: Antigravity alone takes its event name from the wrapper's env, not the piped payload.
   '  --data-urlencode "hook_event_name=%ORCA_ANTIGRAVITY_EVENT%" ^'
 ])
 
@@ -22,9 +18,8 @@ export function getManagedScript(target: 'local' | 'posix' = 'local'): string {
   if (target === 'local' && process.platform === 'win32') {
     return [
       '@echo off',
-      // Why (#9358/#9941): a bare `setlocal` inherits delayed expansion from the caller, and
-      // every `!` in a percent-expanded value on the curl line is then eaten as a delayed
-      // reference — silently mangling paneKey and dropping worktreeId. `!` is legal in a path.
+      // Why (#9358/#9941): inherited delayed expansion eats `!` out of the percent-expanded
+      // curl args, mangling paneKey and dropping worktreeId. `!` is legal in a Windows path.
       'setlocal DisableDelayedExpansion',
       'if /I "%ORCA_ANTIGRAVITY_EVENT%"=="Stop" (',
       '  echo {"decision":""}',

--- a/src/main/antigravity/hook-script.ts
+++ b/src/main/antigravity/hook-script.ts
@@ -12,8 +12,9 @@ import { ANTIGRAVITY_PRE_TOOL_USE_DECISION } from './hook-events'
 // allocates for each hook visible; curl.exe (Win10 1803+) finishes in ~10ms and, unlike
 // PowerShell, does not recode the UTF-8 payload through the console code page.
 const WINDOWS_ANTIGRAVITY_HOOK_POST_COMMAND = buildWindowsAgentHookPostCommand('antigravity', [
-  // Why: the event name lives in the wrapper's env, not the payload, and the listener
-  // reads it as a top-level form field — same position as the POSIX branch below.
+  // Why: Antigravity alone takes its event name from the wrapper's env rather than the piped
+  // payload. Before `extraFormLines` existed this forced a private copy of the shared command,
+  // which is how this script missed the fleet-wide move to curl for three months (#15117).
   '  --data-urlencode "hook_event_name=%ORCA_ANTIGRAVITY_EVENT%" ^'
 ])
 

--- a/src/main/antigravity/hook-service.test.ts
+++ b/src/main/antigravity/hook-service.test.ts
@@ -98,10 +98,14 @@ describe('AntigravityHookService', () => {
     )
     expect(script).toContain('/hook/antigravity')
     if (process.platform === 'win32') {
-      expect(script).toContain('%SystemRoot%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe')
-      expect(script).toContain('hook_event_name=$env:ORCA_ANTIGRAVITY_EVENT')
-      expect(script).toContain('[string]::IsNullOrWhiteSpace($inputData)) { @{} }')
-      expect(script).not.toContain('[string]::IsNullOrWhiteSpace($inputData)) { exit 0 }')
+      // Why (#15117): PowerShell's ~300ms cold start per hook event is what made the
+      // per-event console visible; curl.exe keeps the flash imperceptible.
+      expect(script).not.toContain('powershell.exe')
+      expect(script).toContain('%SystemRoot%\\System32\\curl.exe')
+      expect(script).toContain('hook_event_name=%ORCA_ANTIGRAVITY_EVENT%')
+      expect(script).toContain('--data-urlencode "payload@-"')
+      // Why (#9358/#9941): delayed expansion eats `!` out of percent-expanded curl args.
+      expect(script).toContain('setlocal DisableDelayedExpansion')
     } else {
       expect(script).toContain('hook_event_name=${ORCA_ANTIGRAVITY_EVENT}')
       expect(script).toContain(`payload=$(${POSIX_HOOK_STDIN_READER})`)
@@ -275,10 +279,10 @@ describe('AntigravityHookService', () => {
         'utf8'
       )
       expect(script).toContain('/hook/antigravity')
-      expect(script).toContain('%SystemRoot%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe')
-      expect(script).toContain('hook_event_name=$env:ORCA_ANTIGRAVITY_EVENT')
-      expect(script).toContain('[string]::IsNullOrWhiteSpace($inputData)) { @{} }')
-      expect(script).not.toContain('[string]::IsNullOrWhiteSpace($inputData)) { exit 0 }')
+      expect(script).not.toContain('powershell.exe')
+      expect(script).toContain('%SystemRoot%\\System32\\curl.exe')
+      expect(script).toContain('hook_event_name=%ORCA_ANTIGRAVITY_EVENT%')
+      expect(script).toContain('setlocal DisableDelayedExpansion')
     })
   })
 

--- a/src/main/antigravity/hook-service.test.ts
+++ b/src/main/antigravity/hook-service.test.ts
@@ -98,8 +98,6 @@ describe('AntigravityHookService', () => {
     )
     expect(script).toContain('/hook/antigravity')
     if (process.platform === 'win32') {
-      // Why (#15117): PowerShell's ~300ms cold start per hook event is what made the
-      // per-event console visible; curl.exe keeps the flash imperceptible.
       expect(script).not.toContain('powershell.exe')
       expect(script).toContain('%SystemRoot%\\System32\\curl.exe')
       expect(script).toContain('hook_event_name=%ORCA_ANTIGRAVITY_EVENT%')

--- a/src/main/antigravity/windows-hook-payload-delivery.test.ts
+++ b/src/main/antigravity/windows-hook-payload-delivery.test.ts
@@ -96,7 +96,11 @@ async function startHookListener(): Promise<{
 
 type HookRun = { exitCode: number | null; stdout: string; stderr: string; timedOut: boolean }
 
-function runWrapper(wrapperPath: string, env: NodeJS.ProcessEnv): Promise<HookRun> {
+function runWrapper(
+  wrapperPath: string,
+  env: NodeJS.ProcessEnv,
+  stdinPayload: string = PAYLOAD
+): Promise<HookRun> {
   return new Promise((resolve, reject) => {
     // Why: mirror how Antigravity spawns the hook — `cmd /c <bare .cmd path>`, the exact
     // chain in the bug report's process trace.
@@ -127,7 +131,7 @@ function runWrapper(wrapperPath: string, env: NodeJS.ProcessEnv): Promise<HookRu
       // Why: curl exits once the POST is written; give the listener a beat to finish reading it.
       setTimeout(() => resolve({ exitCode, stdout, stderr, timedOut }), 250)
     })
-    child.stdin.end(Buffer.from(PAYLOAD, 'utf8'))
+    child.stdin.end(Buffer.from(stdinPayload, 'utf8'))
   })
 }
 
@@ -226,6 +230,35 @@ describe.skipIf(process.platform !== 'win32')('Antigravity Windows hook payload 
     }
     // Why: five wrapper launches plus a real install can overrun the default under load.
   }, 60_000)
+
+  // Why (#15117): Antigravity fires some events with no stdin at all. PowerShell substituted
+  // `{}` before posting; curl forwards the empty body, so prove the post still happens — the
+  // listener's matching allowance is covered in agent-hook-listener-antigravity.test.ts.
+  it('still posts a status event when the agent supplies no payload', async () => {
+    home = mkdtempSync(join(tmpdir(), 'orca-antigravity-hook-'))
+    homedirMock.mockReturnValue(home)
+    expect(new AntigravityHookService().install().state).toBe('installed')
+
+    const listener = await startHookListener()
+    server = listener.server
+    const result = await runWrapper(
+      join(home, '.orca', 'agent-hooks', 'antigravity-pre-invocation.cmd'),
+      hookEnvironment({
+        USERPROFILE: home,
+        HOME: home,
+        ORCA_AGENT_HOOK_PORT: String(listener.port),
+        ORCA_AGENT_HOOK_TOKEN: HOOK_TOKEN,
+        ORCA_PANE_KEY: PANE_KEY
+      }),
+      ''
+    )
+
+    expect(result.timedOut).toBe(false)
+    expect(result.exitCode).toBe(0)
+    expect(listener.posts).toHaveLength(1)
+    expect(listener.posts[0].payload).toBe('')
+    expect(listener.posts[0].hookEventName).toBe('PreInvocation')
+  }, 30_000)
 
   it('exits without reading stdin when the pane env is missing', async () => {
     home = mkdtempSync(join(tmpdir(), 'orca-antigravity-hook-'))

--- a/src/main/antigravity/windows-hook-payload-delivery.test.ts
+++ b/src/main/antigravity/windows-hook-payload-delivery.test.ts
@@ -1,0 +1,249 @@
+// Why (#15117): Antigravity was the last agent whose Windows hook posted status through
+// Windows PowerShell 5.1. The agent spawns each hook itself, so Orca cannot suppress the
+// console it allocates — but PowerShell's ~300ms cold start is what made that console
+// linger long enough to be seen, roughly every 2-6s for a whole session. Moving to
+// curl.exe removes the interpreter from the hot path. Shape assertions alone would not
+// catch a curl line that posts nothing, so this suite pipes a real payload through the
+// installed wrappers and follows it to a listener.
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { spawn } from 'node:child_process'
+import { createServer, type Server } from 'node:http'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type * as osModule from 'node:os'
+
+const { homedirMock } = vi.hoisted(() => ({
+  homedirMock: vi.fn<() => string>()
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => '/tmp/orca-user-data'
+  }
+}))
+
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof osModule>()
+  return {
+    ...actual,
+    homedir: homedirMock.mockImplementation(actual.homedir)
+  }
+})
+
+import { AntigravityHookService } from './hook-service'
+import { ANTIGRAVITY_EVENTS, ANTIGRAVITY_PRE_TOOL_USE_DECISION } from './hook-events'
+import { getManagedScript } from './hook-script'
+
+// Why (#9358/#9941): `!` is legal in a Windows path and in a pane key. Under inherited
+// delayed expansion cmd eats it out of a percent-expanded curl argument, so bake one into
+// every value the script forwards rather than asserting the `setlocal` line alone.
+const PANE_KEY = 'tab-1:leaf-1!bang'
+const WORKTREE_ID = 'repo-1::C:\\Users\\alice\\orca\\feature!branch'
+const HOOK_TOKEN = 'antigravity-payload-delivery-token'
+// Why: exercise the sizes and bytes a real hook carries — a multi-KB body crosses the pipe
+// in several chunks, and non-ASCII catches a launcher that recodes stdin through a code page.
+const PAYLOAD = JSON.stringify({
+  session_id: 'a3f9c1e0-antigravity-delivery',
+  tool_name: 'Bash',
+  tool_input: { command: 'echo "café 日本語 😀" & echo %PATH% | more' },
+  transcript: 'y'.repeat(4096)
+})
+
+type HookPost = {
+  payload: string | null
+  paneKey: string | null
+  worktreeId: string | null
+  hookEventName: string | null
+  token: string | null
+  contentType: string | null
+}
+
+async function startHookListener(): Promise<{
+  server: Server
+  port: number
+  posts: HookPost[]
+}> {
+  const posts: HookPost[] = []
+  const server = createServer((req, res) => {
+    let body = ''
+    req.setEncoding('utf8')
+    req.on('data', (chunk) => {
+      body += chunk
+    })
+    req.on('end', () => {
+      const form = new URLSearchParams(body)
+      posts.push({
+        payload: form.get('payload'),
+        paneKey: form.get('paneKey'),
+        worktreeId: form.get('worktreeId'),
+        hookEventName: form.get('hook_event_name'),
+        token: (req.headers['x-orca-agent-hook-token'] as string | undefined) ?? null,
+        contentType: (req.headers['content-type'] as string | undefined) ?? null
+      })
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end('{}')
+    })
+  })
+  const port = await new Promise<number>((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      resolve(typeof address === 'object' && address ? address.port : 0)
+    })
+  })
+  return { server, port, posts }
+}
+
+type HookRun = { exitCode: number | null; stdout: string; stderr: string; timedOut: boolean }
+
+function runWrapper(wrapperPath: string, env: NodeJS.ProcessEnv): Promise<HookRun> {
+  return new Promise((resolve, reject) => {
+    // Why: mirror how Antigravity spawns the hook — `cmd /c <bare .cmd path>`, the exact
+    // chain in the bug report's process trace.
+    const child = spawn('cmd.exe', ['/d', '/c', wrapperPath], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
+      env
+    })
+    let stdout = ''
+    let stderr = ''
+    let timedOut = false
+    const timer = setTimeout(() => {
+      timedOut = true
+      child.kill('SIGKILL')
+    }, 15_000)
+    child.on('error', (error) => {
+      clearTimeout(timer)
+      reject(error)
+    })
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString()
+    })
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString()
+    })
+    child.on('close', (exitCode) => {
+      clearTimeout(timer)
+      // Why: curl exits once the POST is written; give the listener a beat to finish reading it.
+      setTimeout(() => resolve({ exitCode, stdout, stderr, timedOut }), 250)
+    })
+    child.stdin.end(Buffer.from(PAYLOAD, 'utf8'))
+  })
+}
+
+function hookEnvironment(extra: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const base = Object.fromEntries(
+    Object.entries(process.env).filter(([key]) => !key.startsWith('ORCA_'))
+  )
+  return { ...base, ...extra }
+}
+
+function expectedStdout(eventName: string): string {
+  if (eventName === 'PreToolUse') {
+    return ANTIGRAVITY_PRE_TOOL_USE_DECISION
+  }
+  return eventName === 'Stop' ? '{"decision":""}' : '{}'
+}
+
+// Why: runs on every platform — the live delivery suite below is Windows-only, so this
+// keeps a POSIX-only CI leg from letting the interpreter back into the hot path.
+describe('Antigravity Windows hook post command', () => {
+  it('posts through curl.exe rather than a PowerShell interpreter', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    const script = getManagedScript('local')
+
+    expect(script).not.toMatch(/powershell/i)
+    expect(script).toContain('"%SystemRoot%\\System32\\curl.exe" -sS -X POST')
+    expect(script).toContain('http://127.0.0.1:%ORCA_AGENT_HOOK_PORT%/hook/antigravity')
+    expect(script).toContain('--data-urlencode "hook_event_name=%ORCA_ANTIGRAVITY_EVENT%"')
+    // Why: keep the payload off the command line so multi-KB tool output cannot trip an
+    // EDR oversized-command-line rule.
+    expect(script).toContain('--data-urlencode "payload@-"')
+    expect(script).toContain('setlocal DisableDelayedExpansion')
+    vi.restoreAllMocks()
+  })
+})
+
+describe.skipIf(process.platform !== 'win32')('Antigravity Windows hook payload delivery', () => {
+  let home = ''
+  let server: Server | null = null
+
+  afterEach(() => {
+    server?.close()
+    server = null
+    homedirMock.mockImplementation(() => process.env.HOME ?? tmpdir())
+    if (home) {
+      rmSync(home, { recursive: true, force: true })
+      home = ''
+    }
+  })
+
+  it('delivers every event wrapper payload to the listener without spawning PowerShell', async () => {
+    home = mkdtempSync(join(tmpdir(), 'orca-antigravity-hook-'))
+    homedirMock.mockReturnValue(home)
+    expect(new AntigravityHookService().install().state).toBe('installed')
+
+    const hooksDir = join(home, '.orca', 'agent-hooks')
+    const coreScript = readFileSync(join(hooksDir, 'antigravity-hook.cmd'), 'utf8')
+    expect(coreScript).not.toMatch(/powershell/i)
+
+    const listener = await startHookListener()
+    server = listener.server
+    const env = hookEnvironment({
+      USERPROFILE: home,
+      HOME: home,
+      ORCA_AGENT_HOOK_PORT: String(listener.port),
+      ORCA_AGENT_HOOK_TOKEN: HOOK_TOKEN,
+      ORCA_PANE_KEY: PANE_KEY,
+      ORCA_WORKTREE_ID: WORKTREE_ID
+    })
+
+    for (const event of ANTIGRAVITY_EVENTS) {
+      const label = event.eventName
+      const before = listener.posts.length
+      const result = await runWrapper(join(hooksDir, event.windowsWrapperFileName), env)
+
+      expect(result.timedOut, `${label} timed out`).toBe(false)
+      expect(result.exitCode, `${label} exit code`).toBe(0)
+      expect(result.stderr, `${label} stderr`).toBe('')
+      // Why: Antigravity reads silence on PreToolUse as deny (#2426), so the gate answer
+      // must survive the transport change.
+      expect(result.stdout.trim(), `${label} stdout`).toBe(expectedStdout(label))
+
+      const posts = listener.posts.slice(before)
+      expect(posts, `${label} posted exactly one hook`).toHaveLength(1)
+      // Why: byte-exact, not "non-empty" — PowerShell recoded this body through the console
+      // code page, and a silently corrupted payload still looks posted.
+      expect(posts[0].payload, `${label} payload`).toBe(PAYLOAD)
+      expect(posts[0].hookEventName, `${label} hook_event_name`).toBe(label)
+      // Why: the `!` in both values is the delayed-expansion regression guard.
+      expect(posts[0].paneKey, `${label} paneKey`).toBe(PANE_KEY)
+      expect(posts[0].worktreeId, `${label} worktreeId`).toBe(WORKTREE_ID)
+      expect(posts[0].token, `${label} token`).toBe(HOOK_TOKEN)
+      expect(posts[0].contentType, `${label} content-type`).toContain(
+        'application/x-www-form-urlencoded'
+      )
+    }
+    // Why: five wrapper launches plus a real install can overrun the default under load.
+  }, 60_000)
+
+  it('exits without reading stdin when the pane env is missing', async () => {
+    home = mkdtempSync(join(tmpdir(), 'orca-antigravity-hook-'))
+    homedirMock.mockReturnValue(home)
+    expect(new AntigravityHookService().install().state).toBe('installed')
+
+    const listener = await startHookListener()
+    server = listener.server
+    // Why (#11549): outside an Orca pane the caller may abandon stdin rather than close it,
+    // so the guard must exit before the read — otherwise the console lingers indefinitely.
+    const result = await runWrapper(
+      join(home, '.orca', 'agent-hooks', 'antigravity-pre-tool-use.cmd'),
+      hookEnvironment({ USERPROFILE: home, HOME: home })
+    )
+
+    expect(result.timedOut).toBe(false)
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout.trim()).toBe(ANTIGRAVITY_PRE_TOOL_USE_DECISION)
+    expect(listener.posts).toHaveLength(0)
+  }, 30_000)
+})

--- a/src/main/antigravity/windows-hook-payload-delivery.test.ts
+++ b/src/main/antigravity/windows-hook-payload-delivery.test.ts
@@ -256,7 +256,9 @@ describe.skipIf(process.platform !== 'win32')('Antigravity Windows hook payload 
     expect(result.timedOut).toBe(false)
     expect(result.exitCode).toBe(0)
     expect(listener.posts).toHaveLength(1)
-    expect(listener.posts[0].payload).toBe('')
+    // Why: curl drops a `--data-urlencode name@-` field entirely when stdin is empty, so the
+    // event reaches the listener with no `payload` key — not an empty one.
+    expect(listener.posts[0].payload).toBeNull()
     expect(listener.posts[0].hookEventName).toBe('PreInvocation')
   }, 30_000)
 

--- a/src/main/antigravity/windows-hook-payload-delivery.test.ts
+++ b/src/main/antigravity/windows-hook-payload-delivery.test.ts
@@ -1,10 +1,5 @@
-// Why (#15117): Antigravity was the last agent whose Windows hook posted status through
-// Windows PowerShell 5.1. The agent spawns each hook itself, so Orca cannot suppress the
-// console it allocates — but PowerShell's ~300ms cold start is what made that console
-// linger long enough to be seen, roughly every 2-6s for a whole session. Moving to
-// curl.exe removes the interpreter from the hot path. Shape assertions alone would not
-// catch a curl line that posts nothing, so this suite pipes a real payload through the
-// installed wrappers and follows it to a listener.
+// Why (#15117): shape assertions cannot catch a curl line that posts nothing, so this suite
+// pipes a real payload through the installed wrappers and follows it to a live listener.
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { spawn } from 'node:child_process'
 import { createServer, type Server } from 'node:http'
@@ -99,7 +94,9 @@ type HookRun = { exitCode: number | null; stdout: string; stderr: string; timedO
 function runWrapper(
   wrapperPath: string,
   env: NodeJS.ProcessEnv,
-  stdinPayload: string = PAYLOAD
+  // Why: `null` abandons stdin instead of closing it — the shape a caller outside an Orca
+  // pane produces, and the only way to prove the env guard exits before reading (#11549).
+  stdinPayload: string | null = PAYLOAD
 ): Promise<HookRun> {
   return new Promise((resolve, reject) => {
     // Why: mirror how Antigravity spawns the hook — `cmd /c <bare .cmd path>`, the exact
@@ -131,7 +128,12 @@ function runWrapper(
       // Why: curl exits once the POST is written; give the listener a beat to finish reading it.
       setTimeout(() => resolve({ exitCode, stdout, stderr, timedOut }), 250)
     })
-    child.stdin.end(Buffer.from(stdinPayload, 'utf8'))
+    // Why: an abandoned pipe raises EPIPE once the child exits; swallow it so the run still
+    // resolves on the child's own terms.
+    child.stdin.on('error', () => {})
+    if (stdinPayload !== null) {
+      child.stdin.end(Buffer.from(stdinPayload, 'utf8'))
+    }
   })
 }
 
@@ -273,7 +275,8 @@ describe.skipIf(process.platform !== 'win32')('Antigravity Windows hook payload 
     // so the guard must exit before the read — otherwise the console lingers indefinitely.
     const result = await runWrapper(
       join(home, '.orca', 'agent-hooks', 'antigravity-pre-tool-use.cmd'),
-      hookEnvironment({ USERPROFILE: home, HOME: home })
+      hookEnvironment({ USERPROFILE: home, HOME: home }),
+      null
     )
 
     expect(result.timedOut).toBe(false)

--- a/src/shared/agent-hook-listener-antigravity.test.ts
+++ b/src/shared/agent-hook-listener-antigravity.test.ts
@@ -23,6 +23,57 @@ describe('shared agent-hook-listener', () => {
     vi.unstubAllEnvs()
   })
 
+  // Why (#15117): the Windows script posts stdin verbatim through curl, so an event that
+  // fires without a payload arrives as `payload=""` rather than the `{}` the POSIX script
+  // substitutes. Both transports must still produce the status transition.
+  it('accepts an Antigravity event whose payload arrived empty', () => {
+    const started = normalizeHookPayload(
+      state,
+      'antigravity',
+      {
+        paneKey: PANE_KEY,
+        tabId: 'tab-1',
+        worktreeId: 'wt',
+        hook_event_name: 'PreInvocation',
+        payload: ''
+      },
+      'production'
+    )
+    expect(started?.payload).toMatchObject({ state: 'working', agentType: 'antigravity' })
+  })
+
+  it('still drops an Antigravity event whose payload is malformed rather than empty', () => {
+    expect(
+      normalizeHookPayload(
+        state,
+        'antigravity',
+        {
+          paneKey: PANE_KEY,
+          hook_event_name: 'PreInvocation',
+          payload: '{"prompt":'
+        },
+        'production'
+      )
+    ).toBeNull()
+  })
+
+  // Why: the empty-payload allowance is Antigravity's documented policy, not a global one —
+  // every other source must keep rejecting a body it cannot parse.
+  it('does not extend the empty-payload allowance to other sources', () => {
+    expect(
+      normalizeHookPayload(
+        state,
+        'gemini',
+        {
+          paneKey: PANE_KEY,
+          hook_event_name: 'BeforeAgent',
+          payload: ''
+        },
+        'production'
+      )
+    ).toBeNull()
+  })
+
   it('normalizes Antigravity invocation and tool hooks', () => {
     const started = normalizeHookPayload(
       state,

--- a/src/shared/agent-hook-listener-antigravity.test.ts
+++ b/src/shared/agent-hook-listener-antigravity.test.ts
@@ -26,20 +26,25 @@ describe('shared agent-hook-listener', () => {
   // Why (#15117): the Windows script posts stdin verbatim through curl, so an event that
   // fires without a payload arrives as `payload=""` rather than the `{}` the POSIX script
   // substitutes. Both transports must still produce the status transition.
-  it('accepts an Antigravity event whose payload arrived empty', () => {
-    const started = normalizeHookPayload(
-      state,
-      'antigravity',
-      {
-        paneKey: PANE_KEY,
-        tabId: 'tab-1',
-        worktreeId: 'wt',
-        hook_event_name: 'PreInvocation',
-        payload: ''
-      },
-      'production'
-    )
-    expect(started?.payload).toMatchObject({ state: 'working', agentType: 'antigravity' })
+  it('accepts an Antigravity event whose payload is empty or whitespace-only', () => {
+    for (const payload of ['', '   ', '\r\n']) {
+      const started = normalizeHookPayload(
+        state,
+        'antigravity',
+        {
+          paneKey: PANE_KEY,
+          tabId: 'tab-1',
+          worktreeId: 'wt',
+          hook_event_name: 'PreInvocation',
+          payload
+        },
+        'production'
+      )
+      expect(started?.payload, `payload ${JSON.stringify(payload)}`).toMatchObject({
+        state: 'working',
+        agentType: 'antigravity'
+      })
+    }
   })
 
   // Why (#15117): this is the shape Windows actually produces — curl omits the form field

--- a/src/shared/agent-hook-listener-antigravity.test.ts
+++ b/src/shared/agent-hook-listener-antigravity.test.ts
@@ -42,6 +42,23 @@ describe('shared agent-hook-listener', () => {
     expect(started?.payload).toMatchObject({ state: 'working', agentType: 'antigravity' })
   })
 
+  // Why (#15117): this is the shape Windows actually produces — curl omits the form field
+  // entirely when the agent supplies no stdin, so the key is absent rather than empty.
+  it('accepts an Antigravity event that carries no payload key at all', () => {
+    const started = normalizeHookPayload(
+      state,
+      'antigravity',
+      {
+        paneKey: PANE_KEY,
+        tabId: 'tab-1',
+        worktreeId: 'wt',
+        hook_event_name: 'PreInvocation'
+      },
+      'production'
+    )
+    expect(started?.payload).toMatchObject({ state: 'working', agentType: 'antigravity' })
+  })
+
   it('still drops an Antigravity event whose payload is malformed rather than empty', () => {
     expect(
       normalizeHookPayload(
@@ -60,18 +77,20 @@ describe('shared agent-hook-listener', () => {
   // Why: the empty-payload allowance is Antigravity's documented policy, not a global one —
   // every other source must keep rejecting a body it cannot parse.
   it('does not extend the empty-payload allowance to other sources', () => {
-    expect(
-      normalizeHookPayload(
-        state,
-        'gemini',
-        {
-          paneKey: PANE_KEY,
-          hook_event_name: 'BeforeAgent',
-          payload: ''
-        },
-        'production'
-      )
-    ).toBeNull()
+    for (const payload of ['', undefined]) {
+      expect(
+        normalizeHookPayload(
+          state,
+          'gemini',
+          {
+            paneKey: PANE_KEY,
+            hook_event_name: 'BeforeAgent',
+            ...(payload === undefined ? {} : { payload })
+          },
+          'production'
+        )
+      ).toBeNull()
+    }
   })
 
   it('normalizes Antigravity invocation and tool hooks', () => {

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -4369,6 +4369,13 @@ export function normalizeHookPayload(
   const hookPayload =
     typeof rawPayload === 'string'
       ? (() => {
+          // Why (#15117): some Antigravity events fire with no stdin at all, yet still carry a
+          // status transition in `hook_event_name`. The POSIX script maps empty input to `{}`
+          // before posting; the Windows script pipes stdin straight into curl and cannot, so
+          // accept the empty body here instead of dropping the event.
+          if (source === 'antigravity' && rawPayload.trim() === '') {
+            return {}
+          }
           try {
             return parseAgentHookJson(rawPayload)
           } catch {

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -4366,16 +4366,17 @@ export function normalizeHookPayload(
   const paneKey = typeof record.paneKey === 'string' ? record.paneKey.trim() : ''
   const parsedPaneKey = parsePaneKey(paneKey)
   const rawPayload = record.payload
-  const hookPayload =
-    typeof rawPayload === 'string'
+  // Why (#15117): some Antigravity events fire with no stdin at all, yet still carry a status
+  // transition in `hook_event_name`. The POSIX script substitutes `{}` before posting; on
+  // Windows curl omits the form field entirely when stdin is empty, so the event arrives with
+  // no `payload` key at all. Accept both shapes rather than dropping the transition.
+  const antigravityPayloadAbsent =
+    source === 'antigravity' &&
+    (rawPayload === undefined || (typeof rawPayload === 'string' && rawPayload.trim() === ''))
+  const hookPayload = antigravityPayloadAbsent
+    ? {}
+    : typeof rawPayload === 'string'
       ? (() => {
-          // Why (#15117): some Antigravity events fire with no stdin at all, yet still carry a
-          // status transition in `hook_event_name`. The POSIX script maps empty input to `{}`
-          // before posting; the Windows script pipes stdin straight into curl and cannot, so
-          // accept the empty body here instead of dropping the event.
-          if (source === 'antigravity' && rawPayload.trim() === '') {
-            return {}
-          }
           try {
             return parseAgentHookJson(rawPayload)
           } catch {

--- a/src/shared/wsl-exec-mode-separator.test.ts
+++ b/src/shared/wsl-exec-mode-separator.test.ts
@@ -85,7 +85,7 @@ describe('wsl.exe mode separator', () => {
   it('sees a `--` separator split across lines by the formatter', () => {
     // Why: the guard once matched line-by-line and was blind to this exact shape,
     // which is how every multi-element argv array in this repo is formatted.
-    const formatted = ["args: [", "  '-d',", "  distro,", "  '--',", "  'bash'", "]"].join('\n')
+    const formatted = ['args: [', "  '-d',", '  distro,', "  '--',", "  'bash'", ']'].join('\n')
 
     expect(ARGV_FORM.test(codeText(formatted))).toBe(true)
   })

--- a/src/shared/wsl-exec-mode-separator.test.ts
+++ b/src/shared/wsl-exec-mode-separator.test.ts
@@ -85,7 +85,7 @@ describe('wsl.exe mode separator', () => {
   it('sees a `--` separator split across lines by the formatter', () => {
     // Why: the guard once matched line-by-line and was blind to this exact shape,
     // which is how every multi-element argv array in this repo is formatted.
-    const formatted = ['args: [', "  '-d',", '  distro,', "  '--',", "  'bash'", ']'].join('\n')
+    const formatted = ["args: [", "  '-d',", "  distro,", "  '--',", "  'bash'", "]"].join('\n')
 
     expect(ARGV_FORM.test(codeText(formatted))).toBe(true)
   })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​521 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​513 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​22 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​11 |

<!-- /orca-pr-loc -->

## ELI5

On Windows, the Antigravity agent fired a hook every few seconds, and each one started a
whole Windows PowerShell just to send one small status message to Orca. PowerShell takes
about a third of a second to boot, and the black console window the agent opens for the
hook stays on screen that entire time — so users saw it flashing all session long. Orca
now sends that message with `curl.exe` instead, which every other agent already uses. The
work still happens, it just finishes fast enough that there is nothing to see.

## What Changed

- `src/main/antigravity/hook-script.ts` — the Windows managed hook posts through the shared
  `buildWindowsAgentHookPostCommand('antigravity', …)` curl builder instead of a bespoke
  `powershell.exe -Command "… Invoke-WebRequest …"`. The event name rides along as the same
  top-level `hook_event_name` form field the POSIX branch already sends.
- Same file — `setlocal` becomes `setlocal DisableDelayedExpansion`. The curl line
  percent-expands `paneKey` / `worktreeId`, and inherited delayed expansion eats a `!` out of
  those values (#9358 / #9941). The old PowerShell line read `$env:` at runtime and was
  immune; the curl line is not.
- `src/shared/agent-hook-listener.ts` — accept an absent or empty Antigravity `payload` as
  `{}`. The POSIX script substitutes `{}` before posting and PowerShell did the same for
  empty stdin, but curl omits a `--data-urlencode name@-` field entirely when stdin is
  empty. Without this, payload-less events were dropped and lost the status transition their
  `hook_event_name` still carried. Scoped to `antigravity`; every other source keeps
  rejecting a body it cannot parse.
- Tests — new `src/main/antigravity/windows-hook-payload-delivery.test.ts` (live, Windows)
  plus listener and shape coverage.

No change to the POSIX script, the remote/SSH installer, the WSL relay path, the registered
hook command, or the wrapper `.cmd` files.

## Why

Antigravity was the **last** agent still posting hook status through Windows PowerShell 5.1
(`git grep` on `main` finds the interpreter in `src/main/antigravity/hook-script.ts` and
nowhere else). Claude, Codex, Cursor, Devin, Droid, Gemini, Grok, and Command Code all moved
to `curl.exe` behind the shared builders in `installer-utils.ts`, whose own comment records
the reason: *"PowerShell per-post costs ~300ms startup and mangles UTF-8 via code-page
translation."*

Antigravity spawns its hooks itself, so Orca cannot suppress the console Windows allocates
for them — but it fully controls how long that console lives. Removing the interpreter takes
the visible window from a third of a second to a flicker, which is the same state the other
bare-`.cmd` agents (Codex, Devin) are already in and which nobody reports.

Measured on Windows 11, 20 runs per variant against a local listener, identical harness:

| | per hook event |
|---|---|
| before (PowerShell 5.1) | **326 ms** |
| after (curl.exe) | **134 ms** |

Both figures include Git Bash harness overhead, so the ~192 ms delta is the honest number.
At one event every 2–6 s that is the difference between continuous flashing and nothing.

Secondary wins that fall out of the same change: UTF-8 no longer round-trips through the
console code page, the timeout tightens from `-TimeoutSec 2` to
`--connect-timeout 0.5 --max-time 1.5`, and each event drops a ~50 MB .NET process for a
~4 MB one.

### How it drifted

Worth recording, because it explains why no test caught it and what stops the next one.

| | |
|---|---|
| **May 16** (#2100) | The *shared* Windows hook POST was PowerShell **by design** — its comment: *"Windows PowerShell 5.1 defaults redirected stdin/request bodies to the active code page. Hook payloads are UTF-8 JSON, so force UTF-8 on both read and POST or CJK prompts arrive in Orca as literal question marks."* PowerShell was the Unicode *fix*. |
| **May 19** (#2389) | Antigravity added, three days later, copying that then-correct command verbatim plus one field. The shared builder's signature was `buildWindowsAgentHookPostCommand(source)` — no extension point — and Antigravity is the one agent whose event name comes from the wrapper's env rather than the piped payload. It *could not* call the shared builder, so it forked a private copy. **That fork is the root cause.** |
| **Jun 25** (#6402) | Shared builder switched to `curl.exe`, motivated by latency (two PowerShell processes ≈ 650 ms/hook). Every agent that *called* it was fixed for free; the private copy silently was not. |
| **~Sep** (#11782) | `extraFormLines` added so Grok could attach `grokHome` — precisely the extension point Antigravity needed in May, arriving after the fork had set. This PR uses it. |

So the original code was not wrong when written; a missing extension point forced a copy, and copies do not receive fixes.

**Note for the reporter:** the issue infers a regression on 2026-08-14 from file mtimes. That is a rewrite, not an introduction — the PowerShell POST has been in the core script since May 19 and executing since the wrapper/core split on May 22 (#2645). The "did not used to happen" is most likely #13378 (Aug 10, *"refresh existing Orca launchers when agent CLIs are unavailable"*): before it, a host where the Antigravity CLI was not detected never got its core script refreshed, so the wrappers' `if exist "%ORCA_ANTIGRAVITY_CORE%"` check failed and they fell through to the harmless `echo {}` path — exactly as described. That switched on a dormant code path. Inferred from the commit's stated purpose, not reproduced.

### Stopping the next one

New `src/main/agent-hooks/windows-hook-post-interpreter.test.ts` asserts the invariant the drift violated, across all ten batch-script agents at once: a managed Windows `.cmd` hook posts through fully-qualified `curl.exe`, pipes its payload via `payload@-`, and spawns no interpreter. It generates the scripts under a mocked `win32` platform instead of executing them, so the POSIX CI legs guard it too — otherwise this class is only visible on a Windows runner.

Confirmed to be a real guard rather than a tautology: reverting `hook-script.ts` to `main` makes it fail with `antigravity-hook.cmd must not spawn an interpreter`, and restoring the fix makes it pass. Copilot (`.ps1`) and Kimi (`.sh`) are excluded with a stated reason — their interpreter is the host, not a per-event child.

## Linked Issue

Fixes #15117

## Visual Proof

`N/A` for rendered Orca UI — no Orca view, layout, or in-app control changes. The symptom is
an OS console window belonging to the agent's own process tree, not an Orca surface, so
there is no tab-switchable Orca screenshot pair to attach. The measurable before/after is the
process-level evidence in **Why** and **Testing**; the interpreter's removal is asserted
directly by `expect(script).not.toMatch(/powershell/i)`.

## Testing

Validated on a real Windows 11 host, not an emulated platform check.

**Windows (live)** — `src/main/antigravity/`, `src/shared/agent-hook-listener-antigravity.test.ts`:
`25 passed | 3 skipped`. Includes a suite that installs the hooks for real, spawns each of
the five event wrappers the way Antigravity does (`cmd /c <bare .cmd path>`, matching the
issue's process trace), pipes a 4 KB payload containing `café 日本語 😀`, and follows it to a
live listener:

- payload arrives **byte-exact** (catches a code-page-translating transport)
- `hook_event_name` correct for all five events
- `paneKey` and `worktreeId` containing `!` survive intact (delayed-expansion guard)
- `PreToolUse` still answers `{"decision":"ask"}` — Antigravity reads silence as deny (#2426)
- exit 0, empty stderr, `application/x-www-form-urlencoded`
- payload-less event still posts; missing-Orca-env event exits without reading stdin (#11549)

**Windows baseline comparison** — ran `src/main/agent-hooks/` on `origin/main` on the same
host first: **6 pre-existing failures** (3 × `installer-utils` symlink tests, 2 × Claude
`managed-hook-stdin-lifecycle`, 1 × Claude `windows-hook-payload-delivery`) — all
environment-specific to that box and all in Claude's PowerShell path, none touched here. My
branch reproduces exactly those 6 and adds none.

That comparison also caught a real defect mid-review: the first cut of the listener fix only
handled `payload=""`, but curl actually omits the field entirely, so the event still dropped.
Fixed and re-validated on hardware.

**macOS** — `src/shared/ src/main/agent-hooks/ src/main/antigravity/`: **5853 passed**, 0
failures (includes the new cross-agent interpreter guard, which runs on every platform). `pnpm typecheck`, `pnpm build`, `oxlint --deny-warnings`, `oxfmt --check` all clean.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

## Review

- **Security:** `curl.exe` is fully qualified as `%SystemRoot%\System32\curl.exe`, preserving
  the same repo-local-binary-hijack protection the qualified `powershell.exe` path had. The
  payload stays off the command line via `payload@-`. One honest note: the hook token moves
  from a runtime `$env:` read into a percent-expanded `-H` argument, so it is briefly visible
  in the curl process command line. That is the existing posture for all eight other agents
  using these shared builders (`installer-utils.ts:153`, `:172`) — Antigravity was the
  outlier — and the token is loopback-only and per-session. Called out rather than buried.
- **Cross-platform:** POSIX branch byte-identical. Windows validated on hardware. `curl.exe`
  is Win10 1803+, already a hard dependency of every other agent hook, so no new floor.
- **SSH / remote / folder workspaces:** remote installs write `getManagedScript('posix')`
  (`hook-service.ts:193`) — untouched. WSL uses the POSIX script via the relay. The hook post
  is loopback within the host that runs the agent, so there is no client/host version skew.
- **Backwards compatibility:** no persisted state, schema, migration, setting, or wire
  contract. `refreshManagedScriptIfPresent` rewrites the script in place on upgrade; the
  registered command and wrapper `.cmd` files are unchanged, so no stale-registration path.
  Downgrade restores the old script cleanly.
- **Performance:** strictly better — one fewer interpreter, ~192 ms and ~46 MB less per
  event, tighter timeouts.
- **Provider neutrality / UI / mobile:** no surface touched.

## Agent skill upstream boundary

- [x] Not applicable.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
