### PR TITLE
fix(terminal): paste OS-copied files through target host

### DIFF
--- a/src/main/window/clipboard-dashboard-popout-access.test.ts
+++ b/src/main/window/clipboard-dashboard-popout-access.test.ts
@@ -106,6 +106,9 @@ describe('dashboard popout clipboard access', () => {
     await expect(handlers.get('clipboard:saveImageAsTempFile')?.(popoutEvent)).rejects.toThrow(
       'Unauthorized clipboard IPC sender'
     )
+    expect(() => handlers.get('clipboard:readFilePaths')?.(popoutEvent)).toThrow(
+      'Unauthorized clipboard IPC sender'
+    )
     expect(() =>
       handlers.get('clipboard:writeFile')?.(popoutEvent, {
         filePath: '/tmp/copied-file.txt',

--- a/src/main/window/clipboard-file-read.test.ts
+++ b/src/main/window/clipboard-file-read.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  CLIPBOARD_FILE_LIST_MAX_BYTES,
+  readClipboardFilePaths,
+  runClipboardCommandCapture,
+  type ClipboardFileReadDeps
+} from './clipboard-file-read'
+
+function makeDeps(overrides: Partial<ClipboardFileReadDeps> = {}): ClipboardFileReadDeps {
+  return {
+    platform: 'darwin',
+    desktop: undefined,
+    readFormat: vi.fn(() => ''),
+    readBuffer: vi.fn(() => Buffer.alloc(0)),
+    runCommand: vi.fn(async () => ''),
+    ...overrides
+  }
+}
+
+function filenamesPlist(paths: string[]): string {
+  const entries = paths.map((path) => `<string>${path}</string>`).join('\n')
+  return `<?xml version="1.0"?><plist><array>${entries}</array></plist>`
+}
+
+describe('readClipboardFilePaths', () => {
+  it('reads real POSIX paths from the macOS filenames plist', async () => {
+    const readFormat = vi.fn((format: string) =>
+      format === 'NSFilenamesPboardType'
+        ? filenamesPlist(['/Users/me/a.png', '/Users/me/b.pdf'])
+        : ''
+    )
+
+    expect(await readClipboardFilePaths(makeDeps({ readFormat }))).toEqual([
+      '/Users/me/a.png',
+      '/Users/me/b.pdf'
+    ])
+    expect(readFormat).toHaveBeenCalledWith('NSFilenamesPboardType')
+  })
+
+  it('XML-unescapes and deduplicates macOS filenames', async () => {
+    const readBuffer = vi.fn((format: string) =>
+      format === 'NSFilenamesPboardType'
+        ? Buffer.from(filenamesPlist(['/Users/me/a &amp; b.png', '/Users/me/a &amp; b.png']))
+        : Buffer.alloc(0)
+    )
+
+    expect(await readClipboardFilePaths(makeDeps({ readBuffer }))).toEqual(['/Users/me/a & b.png'])
+  })
+
+  it('falls back to public.file-url when the macOS plist is absent', async () => {
+    const readBuffer = vi.fn((format: string) =>
+      format === 'public.file-url'
+        ? Buffer.from('file:///Users/me/a%20b.png\0', 'utf8')
+        : Buffer.alloc(0)
+    )
+
+    expect(await readClipboardFilePaths(makeDeps({ readBuffer }))).toEqual(['/Users/me/a b.png'])
+  })
+
+  it('rejects opaque macOS file ids and non-file URLs', async () => {
+    const opaque = makeDeps({
+      readBuffer: (format) =>
+        format === 'public.file-url'
+          ? Buffer.from('file:///.file/id=6571367.321897404')
+          : Buffer.alloc(0)
+    })
+    const remote = makeDeps({
+      readBuffer: (format) =>
+        format === 'public.file-url' ? Buffer.from('https://example.com/x') : Buffer.alloc(0)
+    })
+
+    await expect(readClipboardFilePaths(opaque)).resolves.toEqual([])
+    await expect(readClipboardFilePaths(remote)).resolves.toEqual([])
+  })
+
+  it('reads FileNameW paths directly on Windows', async () => {
+    const paths = 'C:\\Users\\me\\a.txt\0C:\\Users\\me\\b.txt\0\0'
+    const readBuffer = vi.fn((format: string) =>
+      format === 'FileNameW' ? Buffer.from(paths, 'utf16le') : Buffer.alloc(0)
+    )
+
+    expect(await readClipboardFilePaths(makeDeps({ platform: 'win32', readBuffer }))).toEqual([
+      'C:\\Users\\me\\a.txt',
+      'C:\\Users\\me\\b.txt'
+    ])
+  })
+
+  it('accepts ordinary and extended Windows UNC paths but rejects device namespaces', async () => {
+    const paths = [
+      '\\\\server\\share\\a.txt',
+      '\\\\?\\UNC\\server\\share\\b.txt',
+      '\\\\.\\pipe\\orca',
+      '\\\\?\\GLOBALROOT\\Device\\HarddiskVolume1\\secret.txt'
+    ].join('\0')
+    const readBuffer = vi.fn((format: string) =>
+      format === 'FileNameW' ? Buffer.from(`${paths}\0\0`, 'utf16le') : Buffer.alloc(0)
+    )
+
+    expect(await readClipboardFilePaths(makeDeps({ platform: 'win32', readBuffer }))).toEqual([
+      '\\\\server\\share\\a.txt',
+      '\\\\?\\UNC\\server\\share\\b.txt'
+    ])
+  })
+
+  it('parses the GNOME copied-files payload and drops the copy verb', async () => {
+    const readBuffer = vi.fn((format: string) =>
+      format === 'x-special/gnome-copied-files'
+        ? Buffer.from('copy\nfile:///repo/a.png\nfile:///repo/b.png')
+        : Buffer.alloc(0)
+    )
+
+    expect(
+      await readClipboardFilePaths(makeDeps({ platform: 'linux', desktop: 'GNOME', readBuffer }))
+    ).toEqual(['/repo/a.png', '/repo/b.png'])
+  })
+
+  it('prefers KDE uri-list data and decodes escaped paths', async () => {
+    const readBuffer = vi.fn((format: string) =>
+      format === 'text/uri-list' ? Buffer.from('file:///repo/a%20b.png\r\n') : Buffer.alloc(0)
+    )
+
+    expect(
+      await readClipboardFilePaths(makeDeps({ platform: 'linux', desktop: 'KDE', readBuffer }))
+    ).toEqual(['/repo/a b.png'])
+    expect(readBuffer).not.toHaveBeenCalledWith('x-special/gnome-copied-files')
+  })
+
+  it('falls back to bounded Linux clipboard commands', async () => {
+    const runCommand = vi.fn(async (command: string, args: string[]) => {
+      if (command === 'wl-paste' && args.includes('text/uri-list')) {
+        return 'file:///repo/from-tool.ts'
+      }
+      throw new Error('format unavailable')
+    })
+
+    expect(
+      await readClipboardFilePaths(makeDeps({ platform: 'linux', desktop: 'KDE', runCommand }))
+    ).toEqual(['/repo/from-tool.ts'])
+  })
+
+  it('returns no files when reads fail or exceed the buffer cap', async () => {
+    const throwing = makeDeps({
+      platform: 'linux',
+      readBuffer: () => {
+        throw new Error('clipboard unavailable')
+      },
+      runCommand: async () => {
+        throw new Error('tool unavailable')
+      }
+    })
+    const oversized = makeDeps({
+      readBuffer: () => Buffer.alloc(CLIPBOARD_FILE_LIST_MAX_BYTES + 1, 'x')
+    })
+
+    await expect(readClipboardFilePaths(throwing)).resolves.toEqual([])
+    await expect(readClipboardFilePaths(oversized)).resolves.toEqual([])
+  })
+})
+
+describe('runClipboardCommandCapture', () => {
+  it('waits for stdout to close before resolving', async () => {
+    await expect(
+      runClipboardCommandCapture(process.execPath, ['-e', "process.stdout.write('file:///a')"])
+    ).resolves.toBe('file:///a')
+  })
+
+  it('rejects output beyond the byte cap', async () => {
+    await expect(
+      runClipboardCommandCapture(process.execPath, [
+        '-e',
+        `process.stdout.write('x'.repeat(${CLIPBOARD_FILE_LIST_MAX_BYTES + 1}))`
+      ])
+    ).rejects.toThrow(/exceeded/u)
+  })
+
+  it('rejects commands that exceed the timeout', async () => {
+    await expect(
+      runClipboardCommandCapture(process.execPath, ['-e', 'setTimeout(() => {}, 10_000)'])
+    ).rejects.toThrow(/timed out/u)
+  }, 8_000)
+})

--- a/src/main/window/clipboard-file-read.test.ts
+++ b/src/main/window/clipboard-file-read.test.ts
@@ -138,6 +138,32 @@ describe('readClipboardFilePaths', () => {
     ).toEqual(['/repo/from-tool.ts'])
   })
 
+  it('shares one timeout budget across sequential Linux clipboard probes', async () => {
+    vi.useFakeTimers()
+    try {
+      const runCommand = vi.fn(
+        (_command: string, _args: string[], timeoutMs = 750) =>
+          new Promise<string>((_resolve, reject) =>
+            setTimeout(
+              () => reject(new Error('clipboard probe timed out')),
+              Math.min(timeoutMs, 750)
+            )
+          )
+      )
+      const readPromise = readClipboardFilePaths(
+        makeDeps({ platform: 'linux', desktop: 'GNOME', runCommand })
+      )
+
+      await vi.advanceTimersByTimeAsync(2_000)
+
+      await expect(readPromise).resolves.toEqual([])
+      expect(runCommand).toHaveBeenCalledTimes(3)
+      expect(runCommand.mock.calls.map((call) => call[2])).toEqual([2_000, 1_250, 500])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('returns no files when reads fail or exceed the buffer cap', async () => {
     const throwing = makeDeps({
       platform: 'linux',

--- a/src/main/window/clipboard-file-read.ts
+++ b/src/main/window/clipboard-file-read.ts
@@ -1,0 +1,254 @@
+import { spawn } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+export type ClipboardFileReadDeps = {
+  platform: NodeJS.Platform
+  desktop?: string
+  readFormat: (format: string) => string
+  readBuffer: (format: string) => Buffer
+  runCommand: (command: string, args: string[]) => Promise<string>
+}
+
+export const CLIPBOARD_FILE_LIST_MAX_BYTES = 64 * 1024
+export const CLIPBOARD_FILE_LIST_MAX_PATHS = 256
+export const CLIPBOARD_FILE_READ_TIMEOUT_MS = 2_000
+
+export function runClipboardCommandCapture(command: string, args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'ignore'] })
+    const chunks: Buffer[] = []
+    let received = 0
+    let settled = false
+
+    const finish = (error?: Error, value?: string): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timer)
+      if (error) {
+        if (!child.killed && child.exitCode === null) {
+          child.kill('SIGKILL')
+        }
+        reject(error)
+        return
+      }
+      resolve(value ?? '')
+    }
+
+    const timer = setTimeout(() => {
+      finish(new Error(`${command} timed out`))
+    }, CLIPBOARD_FILE_READ_TIMEOUT_MS)
+
+    child.stdout?.on('data', (chunk: Buffer) => {
+      received += chunk.length
+      if (received > CLIPBOARD_FILE_LIST_MAX_BYTES) {
+        finish(new Error(`${command} exceeded ${CLIPBOARD_FILE_LIST_MAX_BYTES} bytes`))
+        return
+      }
+      chunks.push(chunk)
+    })
+    child.on('error', (error) => finish(error))
+    // Why: close waits until stdout is drained; exit can race the final data event.
+    child.on('close', (code) =>
+      code === 0
+        ? finish(undefined, Buffer.concat(chunks).toString('utf8'))
+        : finish(new Error(`${command} exited with ${code}`))
+    )
+  })
+}
+
+export async function readClipboardFilePaths(deps: ClipboardFileReadDeps): Promise<string[]> {
+  try {
+    if (deps.platform === 'darwin') {
+      return readMacClipboardFiles(deps)
+    }
+    if (deps.platform === 'win32') {
+      return decodeFileNameWList(safeReadBuffer(deps, 'FileNameW'))
+    }
+    return await readLinuxClipboardFiles(deps)
+  } catch {
+    return []
+  }
+}
+
+function readMacClipboardFiles(deps: ClipboardFileReadDeps): string[] {
+  const legacyPaths = parseFilenamesPlist(readClipboardFormatText(deps, 'NSFilenamesPboardType'))
+  return legacyPaths.length > 0
+    ? legacyPaths
+    : parseFileReferences(readClipboardText(deps, 'public.file-url'))
+}
+
+async function readLinuxClipboardFiles(deps: ClipboardFileReadDeps): Promise<string[]> {
+  const mimeTypes = /kde/i.test(deps.desktop ?? '')
+    ? (['text/uri-list', 'x-special/gnome-copied-files'] as const)
+    : (['x-special/gnome-copied-files', 'text/uri-list'] as const)
+
+  for (const mime of mimeTypes) {
+    const fromElectron = parseLinuxClipboardPayload(readClipboardText(deps, mime), mime)
+    if (fromElectron.length > 0) {
+      return fromElectron
+    }
+    for (const [command, args] of [
+      ['wl-paste', ['--type', mime, '--no-newline']],
+      ['xclip', ['-selection', 'clipboard', '-t', mime, '-o']]
+    ] as const) {
+      try {
+        const paths = parseLinuxClipboardPayload(await deps.runCommand(command, [...args]), mime)
+        if (paths.length > 0) {
+          return paths
+        }
+      } catch {
+        // Try the next clipboard tool or format.
+      }
+    }
+  }
+  return []
+}
+
+function parseLinuxClipboardPayload(payload: string, mime: string): string[] {
+  const text = stripTrailingNulls(payload)
+  if (!text.trim()) {
+    return []
+  }
+  if (mime === 'x-special/gnome-copied-files') {
+    return parseFileReferences(text.split(/\r?\n/u).slice(1).join('\n'))
+  }
+  return parseFileReferences(text)
+}
+
+function parseFilenamesPlist(plist: string): string[] {
+  const paths: string[] = []
+  const stringEntry = /<string>([\s\S]*?)<\/string>/gu
+  let match: RegExpExecArray | null
+  while (paths.length < CLIPBOARD_FILE_LIST_MAX_PATHS && (match = stringEntry.exec(plist))) {
+    const filePath = usableClipboardPath(unescapeXml(match[1]).trim())
+    if (filePath && !paths.includes(filePath)) {
+      paths.push(filePath)
+    }
+  }
+  return paths
+}
+
+function parseFileReferences(payload: string): string[] {
+  const paths: string[] = []
+  for (const rawLine of payload.split(/\r?\n/u)) {
+    if (paths.length >= CLIPBOARD_FILE_LIST_MAX_PATHS) {
+      break
+    }
+    const line = rawLine.trim()
+    if (!line || line.startsWith('#')) {
+      continue
+    }
+    const filePath = decodeClipboardFileReference(line)
+    if (filePath && !paths.includes(filePath)) {
+      paths.push(filePath)
+    }
+  }
+  return paths
+}
+
+function decodeClipboardFileReference(value: string): string | null {
+  if (value.startsWith('file:')) {
+    try {
+      return usableClipboardPath(fileURLToPath(value))
+    } catch {
+      return null
+    }
+  }
+  return usableClipboardPath(value)
+}
+
+function decodeFileNameWList(value: Buffer): string[] {
+  if (value.byteLength < 2 || value.byteLength % 2 !== 0) {
+    return []
+  }
+  const paths: string[] = []
+  let offset = 0
+  while (offset + 2 <= value.byteLength && paths.length < CLIPBOARD_FILE_LIST_MAX_PATHS) {
+    let end = offset
+    while (end + 2 <= value.byteLength && value.readUInt16LE(end) !== 0) {
+      end += 2
+    }
+    if (end === offset) {
+      break
+    }
+    const filePath = usableClipboardPath(value.subarray(offset, end).toString('utf16le'))
+    if (filePath && !paths.includes(filePath)) {
+      paths.push(filePath)
+    }
+    offset = end + 2
+  }
+  return paths
+}
+
+function usableClipboardPath(filePath: string): string | null {
+  if (!filePath || filePath.includes('\0') || filePath.startsWith('/.file/')) {
+    return null
+  }
+  if (filePath.startsWith('/') || isFullyQualifiedWindowsPath(filePath)) {
+    return filePath
+  }
+  return null
+}
+
+function isFullyQualifiedWindowsPath(filePath: string): boolean {
+  if (/^[A-Za-z]:[\\/]/u.test(filePath) || /^\\\\\?\\[A-Za-z]:\\/u.test(filePath)) {
+    return true
+  }
+  const extendedUnc = /^\\\\\?\\UNC\\[^\\/]+\\([^\\/]+)(?:\\|$)/iu.exec(filePath)
+  if (extendedUnc) {
+    return isOrdinaryUncShare(extendedUnc[1])
+  }
+  const unc = /^[/\\]{2}(?![?.][/\\])[^/\\]+[/\\]([^/\\]+)(?:[/\\]|$)/u.exec(filePath)
+  return isOrdinaryUncShare(unc?.[1])
+}
+
+function isOrdinaryUncShare(share: string | undefined): boolean {
+  return typeof share === 'string' && share.toLowerCase() !== 'pipe'
+}
+
+function readClipboardText(deps: ClipboardFileReadDeps, format: string): string {
+  return stripTrailingNulls(safeReadBuffer(deps, format).toString('utf8'))
+}
+
+function readClipboardFormatText(deps: ClipboardFileReadDeps, format: string): string {
+  try {
+    const value = deps.readFormat(format)
+    if (
+      typeof value === 'string' &&
+      value.length > 0 &&
+      Buffer.byteLength(value, 'utf8') <= CLIPBOARD_FILE_LIST_MAX_BYTES
+    ) {
+      return stripTrailingNulls(value)
+    }
+  } catch {
+    // Fall back to the raw buffer form.
+  }
+  return readClipboardText(deps, format)
+}
+
+function safeReadBuffer(deps: ClipboardFileReadDeps, format: string): Buffer {
+  try {
+    const value = deps.readBuffer(format)
+    if (!Buffer.isBuffer(value) || value.byteLength > CLIPBOARD_FILE_LIST_MAX_BYTES) {
+      return Buffer.alloc(0)
+    }
+    return value
+  } catch {
+    return Buffer.alloc(0)
+  }
+}
+
+function stripTrailingNulls(value: string): string {
+  return value.replace(/\0+$/u, '')
+}
+
+function unescapeXml(value: string): string {
+  return value
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&quot;', '"')
+    .replaceAll('&apos;', "'")
+    .replaceAll('&amp;', '&')
+}

--- a/src/main/window/clipboard-file-read.ts
+++ b/src/main/window/clipboard-file-read.ts
@@ -6,14 +6,18 @@ export type ClipboardFileReadDeps = {
   desktop?: string
   readFormat: (format: string) => string
   readBuffer: (format: string) => Buffer
-  runCommand: (command: string, args: string[]) => Promise<string>
+  runCommand: (command: string, args: string[], timeoutMs?: number) => Promise<string>
 }
 
 export const CLIPBOARD_FILE_LIST_MAX_BYTES = 64 * 1024
 export const CLIPBOARD_FILE_LIST_MAX_PATHS = 256
 export const CLIPBOARD_FILE_READ_TIMEOUT_MS = 2_000
 
-export function runClipboardCommandCapture(command: string, args: string[]): Promise<string> {
+export function runClipboardCommandCapture(
+  command: string,
+  args: string[],
+  timeoutMs = CLIPBOARD_FILE_READ_TIMEOUT_MS
+): Promise<string> {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'ignore'] })
     const chunks: Buffer[] = []
@@ -38,7 +42,7 @@ export function runClipboardCommandCapture(command: string, args: string[]): Pro
 
     const timer = setTimeout(() => {
       finish(new Error(`${command} timed out`))
-    }, CLIPBOARD_FILE_READ_TIMEOUT_MS)
+    }, timeoutMs)
 
     child.stdout?.on('data', (chunk: Buffer) => {
       received += chunk.length
@@ -80,6 +84,7 @@ function readMacClipboardFiles(deps: ClipboardFileReadDeps): string[] {
 }
 
 async function readLinuxClipboardFiles(deps: ClipboardFileReadDeps): Promise<string[]> {
+  const deadline = Date.now() + CLIPBOARD_FILE_READ_TIMEOUT_MS
   const mimeTypes = /kde/i.test(deps.desktop ?? '')
     ? (['text/uri-list', 'x-special/gnome-copied-files'] as const)
     : (['x-special/gnome-copied-files', 'text/uri-list'] as const)
@@ -93,8 +98,15 @@ async function readLinuxClipboardFiles(deps: ClipboardFileReadDeps): Promise<str
       ['wl-paste', ['--type', mime, '--no-newline']],
       ['xclip', ['-selection', 'clipboard', '-t', mime, '-o']]
     ] as const) {
+      const remainingMs = deadline - Date.now()
+      if (remainingMs <= 0) {
+        return []
+      }
       try {
-        const paths = parseLinuxClipboardPayload(await deps.runCommand(command, [...args]), mime)
+        const paths = parseLinuxClipboardPayload(
+          await deps.runCommand(command, [...args], remainingMs),
+          mime
+        )
         if (paths.length > 0) {
           return paths
         }

--- a/src/main/window/clipboard-ipc-file-read.test.ts
+++ b/src/main/window/clipboard-ipc-file-read.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { handlers, clipboardReadBuffer } = vi.hoisted(() => ({
+  handlers: new Map<string, (...args: unknown[]) => unknown>(),
+  clipboardReadBuffer: vi.fn((_format: string) => Buffer.alloc(0))
+}))
+
+vi.mock('electron', () => ({
+  app: { getPath: vi.fn(() => '/tmp') },
+  clipboard: {
+    read: vi.fn(() => ''),
+    readText: vi.fn(() => ''),
+    readBuffer: clipboardReadBuffer,
+    writeText: vi.fn(),
+    readImage: vi.fn(),
+    writeImage: vi.fn(),
+    writeBuffer: vi.fn()
+  },
+  ipcMain: {
+    removeHandler: (channel: string) => handlers.delete(channel),
+    handle: (channel: string, handler: (...args: unknown[]) => unknown) =>
+      handlers.set(channel, handler)
+  },
+  nativeImage: { createFromBuffer: vi.fn() }
+}))
+
+vi.mock('./dashboard-popout-window', () => ({ isDashboardPopoutRenderer: () => false }))
+vi.mock('./clipboard-remote-file-copy', () => ({
+  cleanupExpiredRemoteClipboardFiles: vi.fn(async () => undefined),
+  scheduleLegacyRemoteClipboardFileCleanup: vi.fn(),
+  writeRemoteFileToClipboard: vi.fn()
+}))
+
+import {
+  registerClipboardHandlers,
+  setTrustedClipboardRendererWebContentsId
+} from './clipboard-ipc-handlers'
+
+function makeClipboardEvent(senderOverrides: Record<string, unknown> = {}): {
+  sender: Record<string, unknown>
+} {
+  return {
+    sender: {
+      id: 17,
+      getType: () => 'window',
+      getURL: () => 'file:///orca/index.html',
+      isDestroyed: () => false,
+      ...senderOverrides
+    }
+  }
+}
+
+describe('clipboard:readFilePaths IPC', () => {
+  beforeEach(() => {
+    handlers.clear()
+    clipboardReadBuffer.mockReset()
+    clipboardReadBuffer.mockReturnValue(Buffer.alloc(0))
+    setTrustedClipboardRendererWebContentsId(null)
+    registerClipboardHandlers({} as never)
+  })
+
+  it('reads file references from the trusted renderer', async () => {
+    clipboardReadBuffer.mockImplementation((format: string) => {
+      if (format === 'public.file-url') {
+        return Buffer.from('file:///tmp/copied-file.txt', 'utf8')
+      }
+      if (format === 'FileNameW') {
+        return Buffer.from('C:\\tmp\\copied-file.txt\0', 'utf16le')
+      }
+      if (format === 'x-special/gnome-copied-files') {
+        return Buffer.from('copy\nfile:///tmp/copied-file.txt', 'utf8')
+      }
+      return Buffer.alloc(0)
+    })
+
+    await expect(handlers.get('clipboard:readFilePaths')?.(makeClipboardEvent())).resolves.toEqual([
+      process.platform === 'win32' ? 'C:\\tmp\\copied-file.txt' : '/tmp/copied-file.txt'
+    ])
+  })
+
+  it('returns no paths when the OS clipboard has no file flavor', async () => {
+    await expect(handlers.get('clipboard:readFilePaths')?.(makeClipboardEvent())).resolves.toEqual(
+      []
+    )
+  })
+
+  it('rejects file-reference reads from untrusted renderers', () => {
+    setTrustedClipboardRendererWebContentsId(17)
+    registerClipboardHandlers({} as never)
+
+    expect(() => handlers.get('clipboard:readFilePaths')?.(makeClipboardEvent({ id: 42 }))).toThrow(
+      'Unauthorized clipboard IPC sender'
+    )
+    expect(clipboardReadBuffer).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/window/clipboard-ipc-handlers.ts
+++ b/src/main/window/clipboard-ipc-handlers.ts
@@ -31,6 +31,11 @@ import {
   type ClipboardFileResult
 } from './clipboard-file-copy'
 import {
+  readClipboardFilePaths,
+  runClipboardCommandCapture,
+  type ClipboardFileReadDeps
+} from './clipboard-file-read'
+import {
   cleanupExpiredRemoteClipboardFiles,
   scheduleLegacyRemoteClipboardFileCleanup,
   writeRemoteFileToClipboard
@@ -84,6 +89,7 @@ export function registerClipboardHandlers(store: Store): void {
   ipcMain.removeHandler('clipboard:writeSelectionText')
   ipcMain.removeHandler('clipboard:writeImage')
   ipcMain.removeHandler('clipboard:writeFile')
+  ipcMain.removeHandler('clipboard:readFilePaths')
   ipcMain.removeHandler('clipboard:saveImageAsTempFile')
 
   void cleanupExpiredRemoteClipboardFiles()
@@ -160,6 +166,14 @@ export function registerClipboardHandlers(store: Store): void {
       return writeFileToClipboard(request.filePath, deps)
     }
   )
+  // Why: a file OS-copied in Finder/Explorer/a file manager should paste its
+  // full path into a terminal (like a drop), not the display name the OS
+  // synthesizes as clipboard text. Target-host resolution happens in the
+  // renderer's existing file-drop pipeline.
+  ipcMain.handle('clipboard:readFilePaths', (event): Promise<string[]> => {
+    assertTrustedClipboardSender(event)
+    return readClipboardFilePaths(makeClipboardFileReadDeps())
+  })
   ipcMain.handle('clipboard:writeText', async (event, text: string) => {
     assertTrustedClipboardTextSender(event)
     return clipboard.writeText(await assertClipboardTextWriteWithinLimitWithYield(text))
@@ -240,6 +254,16 @@ function makeClipboardFileDeps(
     resolveFilePath,
     writeBuffer: (format, buffer) => clipboard.writeBuffer(format, buffer),
     runCommand
+  }
+}
+
+function makeClipboardFileReadDeps(): ClipboardFileReadDeps {
+  return {
+    platform: process.platform,
+    desktop: process.env.XDG_CURRENT_DESKTOP,
+    readFormat: (format) => clipboard.read(format),
+    readBuffer: (format) => clipboard.readBuffer(format),
+    runCommand: runClipboardCommandCapture
   }
 }
 

--- a/src/preload/api/ui-window-api.ts
+++ b/src/preload/api/ui-window-api.ts
@@ -8,6 +8,7 @@ import type {
 export type UiWindowApi = {
   readClipboardText: (options?: ReadClipboardTextOptions) => Promise<string>
   readSelectionClipboardText: (options?: ReadClipboardTextOptions) => Promise<string>
+  readClipboardFilePaths: () => Promise<string[]>
   saveClipboardImageAsTempFile: (args?: {
     connectionId?: string | null
     runtimeEnvironmentId?: string | null

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4294,6 +4294,7 @@ const api = {
       ipcRenderer.invoke('clipboard:readText', options),
     readSelectionClipboardText: (options?: ReadClipboardTextOptions): Promise<string> =>
       ipcRenderer.invoke('clipboard:readSelectionText', options),
+    readClipboardFilePaths: (): Promise<string[]> => ipcRenderer.invoke('clipboard:readFilePaths'),
     saveClipboardImageAsTempFile: (args?: {
       connectionId?: string | null
       runtimeEnvironmentId?: string | null

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -180,6 +180,7 @@ import {
 } from '@/components/terminal-quick-commands/TerminalQuickCommandDialog'
 import { keybindingMatchesAction } from '../../../../shared/keybindings'
 import { pasteTerminalClipboard } from './terminal-clipboard-paste'
+import { pasteTerminalClipboardFilePaths } from './terminal-clipboard-file-paste'
 import {
   firesNativePasteEvent,
   getClipboardEventText,
@@ -2006,6 +2007,17 @@ function TerminalPane(
       const activeElementAtDispatch = document.activeElement
       void pasteTerminalClipboard({
         readClipboardText,
+        readClipboardFilePaths: window.api.ui.readClipboardFilePaths,
+        pasteFilePaths: (paths) =>
+          pasteTerminalClipboardFilePaths({
+            manager: managerRef.current,
+            pane,
+            paneTransports: paneTransportsRef.current,
+            paths,
+            tabId,
+            worktreeId,
+            cwd: paneCwdRef.current.get(pane.id)?.cwd ?? cwd
+          }),
         saveClipboardImageAsTempFile: window.api.ui.saveClipboardImageAsTempFile,
         connectionId,
         runtimeEnvironmentId,
@@ -2153,6 +2165,17 @@ function TerminalPane(
       )
       void pasteTerminalClipboard({
         readClipboardText: window.api.ui.readClipboardText,
+        readClipboardFilePaths: window.api.ui.readClipboardFilePaths,
+        pasteFilePaths: (paths) =>
+          pasteTerminalClipboardFilePaths({
+            manager: managerRef.current,
+            pane,
+            paneTransports: paneTransportsRef.current,
+            paths,
+            tabId,
+            worktreeId,
+            cwd: paneCwdRef.current.get(pane.id)?.cwd ?? cwd
+          }),
         saveClipboardImageAsTempFile: window.api.ui.saveClipboardImageAsTempFile,
         connectionId,
         runtimeEnvironmentId,
@@ -2214,7 +2237,7 @@ function TerminalPane(
       window.removeEventListener(APP_MENU_PASTE_EVENT, onAppMenuPaste)
       window.removeEventListener(APP_MENU_SELECTION_ACTION_EVENT, onAppMenuSelectionAction)
     }
-  }, [isActive, worktreeId, keybindings, forceBracketedMultilineTextPaste, tabId])
+  }, [cwd, isActive, worktreeId, keybindings, forceBracketedMultilineTextPaste, tabId])
 
   // Dismiss the pane's attention indicator on click (ghostty "show until interact"); pointerdown covers the mouse path onData doesn't.
   // NOT gated on isActive: clicking a visible-but-inactive split pane must clear the worktree dot before focusGroup re-renders it active.

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-file-paste.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-file-paste.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NATIVE_FILE_DROP_TARGET } from '../../../../shared/native-file-drop'
+
+const { handleNativeTerminalFileDropMock } = vi.hoisted(() => ({
+  handleNativeTerminalFileDropMock: vi.fn(async () => undefined)
+}))
+
+vi.mock('./terminal-native-file-drop', () => ({
+  handleNativeTerminalFileDrop: handleNativeTerminalFileDropMock
+}))
+
+import { pasteTerminalClipboardFilePaths } from './terminal-clipboard-file-paste'
+
+describe('pasteTerminalClipboardFilePaths', () => {
+  beforeEach(() => {
+    handleNativeTerminalFileDropMock.mockClear()
+  })
+
+  it('routes clipboard files through the native drop owner pipeline', async () => {
+    const manager = {} as never
+    const pane = { id: 7, leafId: 'leaf-7' } as never
+    const paneTransports = new Map([[7, {} as never]])
+
+    await expect(
+      pasteTerminalClipboardFilePaths({
+        manager,
+        pane,
+        paneTransports,
+        paths: ['/Users/me/a file.txt'],
+        tabId: 'tab-1',
+        worktreeId: 'worktree-1',
+        cwd: '/repo'
+      })
+    ).resolves.toBe(true)
+
+    expect(handleNativeTerminalFileDropMock).toHaveBeenCalledWith({
+      manager,
+      paneTransports,
+      worktreeId: 'worktree-1',
+      tabId: 'tab-1',
+      cwd: '/repo',
+      data: {
+        paths: ['/Users/me/a file.txt'],
+        target: NATIVE_FILE_DROP_TARGET.terminal,
+        tabId: 'tab-1',
+        paneLeafId: 'leaf-7'
+      }
+    })
+  })
+
+  it('rejects stale targets before starting file resolution', async () => {
+    await expect(
+      pasteTerminalClipboardFilePaths({
+        manager: null,
+        pane: { id: 7, leafId: 'leaf-7' } as never,
+        paneTransports: new Map(),
+        paths: ['/tmp/a.txt'],
+        tabId: 'tab-1',
+        worktreeId: 'worktree-1'
+      })
+    ).resolves.toBe(false)
+
+    expect(handleNativeTerminalFileDropMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-file-paste.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-file-paste.test.ts
@@ -1,19 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { NATIVE_FILE_DROP_TARGET } from '../../../../shared/native-file-drop'
 
-const { handleNativeTerminalFileDropMock } = vi.hoisted(() => ({
-  handleNativeTerminalFileDropMock: vi.fn(async () => undefined)
+const { pasteNativeTerminalFileDropMock } = vi.hoisted(() => ({
+  pasteNativeTerminalFileDropMock: vi.fn(async () => true)
 }))
 
 vi.mock('./terminal-native-file-drop', () => ({
-  handleNativeTerminalFileDrop: handleNativeTerminalFileDropMock
+  pasteNativeTerminalFileDrop: pasteNativeTerminalFileDropMock
 }))
 
 import { pasteTerminalClipboardFilePaths } from './terminal-clipboard-file-paste'
 
 describe('pasteTerminalClipboardFilePaths', () => {
   beforeEach(() => {
-    handleNativeTerminalFileDropMock.mockClear()
+    pasteNativeTerminalFileDropMock.mockReset()
+    pasteNativeTerminalFileDropMock.mockResolvedValue(true)
   })
 
   it('routes clipboard files through the native drop owner pipeline', async () => {
@@ -33,7 +34,7 @@ describe('pasteTerminalClipboardFilePaths', () => {
       })
     ).resolves.toBe(true)
 
-    expect(handleNativeTerminalFileDropMock).toHaveBeenCalledWith({
+    expect(pasteNativeTerminalFileDropMock).toHaveBeenCalledWith({
       manager,
       paneTransports,
       worktreeId: 'worktree-1',
@@ -60,6 +61,21 @@ describe('pasteTerminalClipboardFilePaths', () => {
       })
     ).resolves.toBe(false)
 
-    expect(handleNativeTerminalFileDropMock).not.toHaveBeenCalled()
+    expect(pasteNativeTerminalFileDropMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects the clipboard paste when the native drop writes no path', async () => {
+    pasteNativeTerminalFileDropMock.mockResolvedValue(false)
+
+    await expect(
+      pasteTerminalClipboardFilePaths({
+        manager: {} as never,
+        pane: { id: 7, leafId: 'leaf-7' } as never,
+        paneTransports: new Map([[7, {} as never]]),
+        paths: ['/tmp/a.txt'],
+        tabId: 'tab-1',
+        worktreeId: 'worktree-1'
+      })
+    ).resolves.toBe(false)
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-file-paste.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-file-paste.ts
@@ -1,7 +1,7 @@
 import type { ManagedPane, PaneManager } from '@/lib/pane-manager/pane-manager'
 import { NATIVE_FILE_DROP_TARGET } from '../../../../shared/native-file-drop'
 import type { PtyTransport } from './pty-transport'
-import { handleNativeTerminalFileDrop } from './terminal-native-file-drop'
+import { pasteNativeTerminalFileDrop } from './terminal-native-file-drop'
 
 export async function pasteTerminalClipboardFilePaths({
   manager,
@@ -23,7 +23,7 @@ export async function pasteTerminalClipboardFilePaths({
   if (!manager || !paneTransports.has(pane.id)) {
     return false
   }
-  await handleNativeTerminalFileDrop({
+  return pasteNativeTerminalFileDrop({
     manager,
     paneTransports,
     worktreeId,
@@ -36,5 +36,4 @@ export async function pasteTerminalClipboardFilePaths({
       paneLeafId: pane.leafId
     }
   })
-  return true
 }

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-file-paste.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-file-paste.ts
@@ -1,0 +1,40 @@
+import type { ManagedPane, PaneManager } from '@/lib/pane-manager/pane-manager'
+import { NATIVE_FILE_DROP_TARGET } from '../../../../shared/native-file-drop'
+import type { PtyTransport } from './pty-transport'
+import { handleNativeTerminalFileDrop } from './terminal-native-file-drop'
+
+export async function pasteTerminalClipboardFilePaths({
+  manager,
+  pane,
+  paneTransports,
+  paths,
+  tabId,
+  worktreeId,
+  cwd
+}: {
+  manager: PaneManager | null
+  pane: ManagedPane
+  paneTransports: Map<number, PtyTransport>
+  paths: string[]
+  tabId: string
+  worktreeId: string
+  cwd?: string
+}): Promise<boolean> {
+  if (!manager || !paneTransports.has(pane.id)) {
+    return false
+  }
+  await handleNativeTerminalFileDrop({
+    manager,
+    paneTransports,
+    worktreeId,
+    tabId,
+    cwd,
+    data: {
+      paths,
+      target: NATIVE_FILE_DROP_TARGET.terminal,
+      tabId,
+      paneLeafId: pane.leafId
+    }
+  })
+  return true
+}

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.test.ts
@@ -6,18 +6,24 @@ import {
   pasteTerminalText
 } from './terminal-bracketed-paste'
 
+// Defaults so tests only spell out the clipboard branch they exercise.
+const noClipboardFilePaths = (): (() => Promise<string[]>) => vi.fn().mockResolvedValue([])
+const noClipboardFilePaste = (): ((paths: string[]) => void) => vi.fn()
+
 describe('terminal clipboard paste', () => {
   it('forces bracketed paste for generated image-only clipboard paths', async () => {
     const pasteText = vi.fn()
 
     await pasteTerminalClipboard({
       readClipboardText: vi.fn().mockResolvedValue(''),
+      readClipboardFilePaths: noClipboardFilePaths(),
       saveClipboardImageAsTempFile: vi
         .fn()
         .mockResolvedValue(
           '/var/folders/3l/b7w02vh17tg5r5s3nhhdf3kh0000gn/T/orca-paste-1760000000000-id.png'
         ),
-      pasteText
+      pasteText,
+      pasteFilePaths: noClipboardFilePaste()
     })
 
     expect(pasteText).toHaveBeenCalledWith(
@@ -42,10 +48,12 @@ describe('terminal clipboard paste', () => {
 
     await pasteTerminalClipboard({
       readClipboardText: vi.fn().mockResolvedValue(''),
+      readClipboardFilePaths: noClipboardFilePaths(),
       saveClipboardImageAsTempFile: vi
         .fn()
         .mockResolvedValue('/tmp/orca-paste-1760000000000-id.png'),
-      pasteText: (text, options) => pasteTerminalText(terminal, text, options)
+      pasteText: (text, options) => pasteTerminalText(terminal, text, options),
+      pasteFilePaths: noClipboardFilePaste()
     })
 
     expect(terminal.input).toHaveBeenCalledWith(
@@ -71,10 +79,12 @@ describe('terminal clipboard paste', () => {
 
     await pasteTerminalClipboard({
       readClipboardText: vi.fn().mockResolvedValue(''),
+      readClipboardFilePaths: noClipboardFilePaths(),
       saveClipboardImageAsTempFile: vi
         .fn()
         .mockResolvedValue('/tmp/orca-paste-1760000000000-id.png'),
-      pasteText: (text, options) => pasteTerminalText(terminal, text, options)
+      pasteText: (text, options) => pasteTerminalText(terminal, text, options),
+      pasteFilePaths: noClipboardFilePaste()
     })
 
     expect(terminal.input).toHaveBeenCalledWith(
@@ -93,9 +103,11 @@ describe('terminal clipboard paste', () => {
 
     await pasteTerminalClipboard({
       readClipboardText: vi.fn().mockResolvedValue(''),
+      readClipboardFilePaths: noClipboardFilePaths(),
       saveClipboardImageAsTempFile,
       connectionId: 'ssh-1',
-      pasteText
+      pasteText,
+      pasteFilePaths: noClipboardFilePaste()
     })
 
     expect(saveClipboardImageAsTempFile).toHaveBeenCalledWith({
@@ -116,9 +128,11 @@ describe('terminal clipboard paste', () => {
 
     await pasteTerminalClipboard({
       readClipboardText: vi.fn().mockResolvedValue(''),
+      readClipboardFilePaths: noClipboardFilePaths(),
       saveClipboardImageAsTempFile,
       runtimeEnvironmentId: 'remote-host-1',
-      pasteText
+      pasteText,
+      pasteFilePaths: noClipboardFilePaste()
     })
 
     expect(saveClipboardImageAsTempFile).toHaveBeenCalledWith({
@@ -136,10 +150,12 @@ describe('terminal clipboard paste', () => {
 
     await pasteTerminalClipboard({
       readClipboardText: vi.fn().mockResolvedValue(''),
+      readClipboardFilePaths: noClipboardFilePaths(),
       saveClipboardImageAsTempFile: vi
         .fn()
         .mockResolvedValue('/tmp/orca-paste-1760000000000-id.png'),
-      pasteText
+      pasteText,
+      pasteFilePaths: noClipboardFilePaste()
     })
 
     expect(pasteText).toHaveBeenCalledWith('/tmp/orca-paste-1760000000000-id.png', {
@@ -156,8 +172,10 @@ describe('terminal clipboard paste', () => {
 
     await pasteTerminalClipboard({
       readClipboardText: vi.fn().mockRejectedValue(new Error('No text clipboard permission')),
+      readClipboardFilePaths: noClipboardFilePaths(),
       saveClipboardImageAsTempFile,
-      pasteText
+      pasteText,
+      pasteFilePaths: noClipboardFilePaste()
     })
 
     expect(saveClipboardImageAsTempFile).toHaveBeenCalledWith({
@@ -177,8 +195,10 @@ describe('terminal clipboard paste', () => {
 
     await pasteTerminalClipboard({
       readClipboardText,
+      readClipboardFilePaths: noClipboardFilePaths(),
       saveClipboardImageAsTempFile,
-      pasteText
+      pasteText,
+      pasteFilePaths: noClipboardFilePaste()
     })
 
     expect(pasteText).toHaveBeenCalledWith('hello')
@@ -193,11 +213,13 @@ describe('terminal clipboard paste', () => {
 
     const result = await pasteTerminalClipboard({
       readClipboardText: vi.fn().mockResolvedValue('hello'),
+      readClipboardFilePaths: noClipboardFilePaths(),
       saveClipboardImageAsTempFile,
       pasteText: vi.fn(() => {
         throw pasteError
       }),
-      onTextPasteError
+      onTextPasteError,
+      pasteFilePaths: noClipboardFilePaste()
     })
 
     expect(onTextPasteError).toHaveBeenCalledWith(pasteError)
@@ -211,9 +233,11 @@ describe('terminal clipboard paste', () => {
 
     const result = await pasteTerminalClipboard({
       readClipboardText: vi.fn().mockResolvedValue('hello'),
+      readClipboardFilePaths: noClipboardFilePaths(),
       saveClipboardImageAsTempFile,
       pasteText: vi.fn().mockResolvedValue(false),
-      onTextPasteError
+      onTextPasteError,
+      pasteFilePaths: noClipboardFilePaste()
     })
 
     expect(onTextPasteError).not.toHaveBeenCalled()
@@ -230,9 +254,11 @@ describe('terminal clipboard paste', () => {
       readClipboardText: vi
         .fn()
         .mockRejectedValue(new Error('Clipboard text is too large for this paste target.')),
+      readClipboardFilePaths: noClipboardFilePaths(),
       saveClipboardImageAsTempFile,
       pasteText,
-      onTextPasteError
+      onTextPasteError,
+      pasteFilePaths: noClipboardFilePaste()
     })
 
     expect(onTextPasteError).toHaveBeenCalledWith(
@@ -249,11 +275,13 @@ describe('terminal clipboard paste', () => {
     const onImagePasteError = vi.fn()
     const result = await pasteTerminalClipboard({
       readClipboardText: vi.fn().mockResolvedValue(''),
+      readClipboardFilePaths: noClipboardFilePaths(),
       saveClipboardImageAsTempFile: vi
         .fn()
         .mockResolvedValue('/tmp/orca-paste-1760000000000-id.png'),
       pasteText: vi.fn().mockResolvedValue(false),
-      onImagePasteError
+      onImagePasteError,
+      pasteFilePaths: noClipboardFilePaste()
     })
 
     expect(onImagePasteError).not.toHaveBeenCalled()
@@ -266,9 +294,11 @@ describe('terminal clipboard paste', () => {
     const onImagePasteError = vi.fn()
     const result = await pasteTerminalClipboard({
       readClipboardText: vi.fn().mockResolvedValue(''),
+      readClipboardFilePaths: noClipboardFilePaths(),
       saveClipboardImageAsTempFile: vi.fn().mockRejectedValue(imageError),
       pasteText,
-      onImagePasteError
+      onImagePasteError,
+      pasteFilePaths: noClipboardFilePaste()
     })
 
     expect(pasteText).not.toHaveBeenCalled()
@@ -282,9 +312,11 @@ describe('terminal clipboard paste', () => {
 
     await pasteTerminalClipboard({
       readClipboardText: vi.fn().mockResolvedValue('line one\nline two'),
+      readClipboardFilePaths: noClipboardFilePaths(),
       saveClipboardImageAsTempFile,
       pasteText,
-      forceBracketedMultilineTextPaste: true
+      forceBracketedMultilineTextPaste: true,
+      pasteFilePaths: noClipboardFilePaste()
     })
 
     expect(pasteText).toHaveBeenCalledWith('line one\nline two', {
@@ -298,9 +330,11 @@ describe('terminal clipboard paste', () => {
 
     await pasteTerminalClipboard({
       readClipboardText: vi.fn().mockResolvedValue('line one\nline two'),
+      readClipboardFilePaths: noClipboardFilePaths(),
       saveClipboardImageAsTempFile: vi.fn(),
       pasteText,
-      forceBracketedMultilineTextPaste: true
+      forceBracketedMultilineTextPaste: true,
+      pasteFilePaths: noClipboardFilePaste()
     })
 
     expect(pasteText).toHaveBeenCalledWith('line one\nline two', {
@@ -313,6 +347,8 @@ describe('terminal clipboard paste', () => {
 
     await pasteTerminalClipboard({
       readClipboardText: vi.fn().mockResolvedValue('\nline two'),
+      readClipboardFilePaths: noClipboardFilePaths(),
+      pasteFilePaths: noClipboardFilePaste(),
       saveClipboardImageAsTempFile: vi.fn(),
       pasteText,
       protectedMultilineTextPasteOptions: { windowsInputRecordNewline: 'alt-enter' }
@@ -329,9 +365,11 @@ describe('terminal clipboard paste', () => {
 
     await pasteTerminalClipboard({
       readClipboardText: vi.fn().mockResolvedValue('hello'),
+      readClipboardFilePaths: noClipboardFilePaths(),
       saveClipboardImageAsTempFile,
       pasteText,
-      forceBracketedMultilineTextPaste: true
+      forceBracketedMultilineTextPaste: true,
+      pasteFilePaths: noClipboardFilePaste()
     })
 
     expect(pasteText).toHaveBeenCalledWith('hello', {
@@ -348,9 +386,11 @@ describe('terminal clipboard paste', () => {
     try {
       await pasteTerminalClipboard({
         readClipboardText: vi.fn().mockResolvedValue('x'.repeat(64)),
+        readClipboardFilePaths: noClipboardFilePaths(),
         saveClipboardImageAsTempFile,
         pasteText,
-        forceBracketedMultilineTextPaste: true
+        forceBracketedMultilineTextPaste: true,
+        pasteFilePaths: noClipboardFilePaste()
       })
 
       expect(codePointAtSpy).not.toHaveBeenCalled()
@@ -380,12 +420,103 @@ describe('terminal clipboard paste', () => {
 
     await pasteTerminalClipboard({
       readClipboardText: vi.fn().mockResolvedValue('a69ce28e1d092e0c8825cd1a109ac36409962bc1'),
+      readClipboardFilePaths: noClipboardFilePaths(),
       saveClipboardImageAsTempFile,
-      pasteText: (text, options) => pasteTerminalText(terminal, text, options)
+      pasteText: (text, options) => pasteTerminalText(terminal, text, options),
+      pasteFilePaths: noClipboardFilePaste()
     })
 
     expect(terminal.paste).toHaveBeenCalledWith('a69ce28e1d092e0c8825cd1a109ac36409962bc1')
     expect(observedIgnoreBracketedPasteMode).toEqual([true])
     expect(saveClipboardImageAsTempFile).not.toHaveBeenCalled()
+  })
+
+  it('routes OS-copied file paths before synthesized clipboard text', async () => {
+    const pasteText = vi.fn()
+    const pasteFilePaths = vi.fn()
+    const saveClipboardImageAsTempFile = vi.fn()
+    // macOS also puts the file's display name on the clipboard as text; the
+    // file-path branch must win so the full path is pasted, not the bare name.
+    const readClipboardText = vi.fn().mockResolvedValue('a file.txt')
+
+    const result = await pasteTerminalClipboard({
+      readClipboardText,
+      readClipboardFilePaths: vi
+        .fn()
+        .mockResolvedValue(['/Users/me/a file.txt', '/Users/me/second.txt']),
+      saveClipboardImageAsTempFile,
+      pasteText,
+      pasteFilePaths
+    })
+
+    expect(pasteFilePaths).toHaveBeenCalledWith(['/Users/me/a file.txt', '/Users/me/second.txt'])
+    expect(pasteText).not.toHaveBeenCalled()
+    expect(readClipboardText).not.toHaveBeenCalled()
+    expect(saveClipboardImageAsTempFile).not.toHaveBeenCalled()
+    expect(result).toEqual({ status: 'pasted', kind: 'file-path' })
+  })
+
+  it('falls back to text/image paste when no OS file is on the clipboard', async () => {
+    const pasteText = vi.fn()
+    const readClipboardFilePaths = vi.fn().mockResolvedValue([])
+
+    const result = await pasteTerminalClipboard({
+      readClipboardText: vi.fn().mockResolvedValue('hello'),
+      readClipboardFilePaths,
+      pasteFilePaths: noClipboardFilePaste(),
+      saveClipboardImageAsTempFile: vi.fn(),
+      pasteText
+    })
+
+    expect(readClipboardFilePaths).toHaveBeenCalledTimes(1)
+    expect(pasteText).toHaveBeenCalledWith('hello')
+    expect(result).toEqual({ status: 'pasted', kind: 'text' })
+  })
+
+  it('ignores copied-file read failures and keeps normal text paste', async () => {
+    const pasteText = vi.fn()
+
+    const result = await pasteTerminalClipboard({
+      readClipboardText: vi.fn().mockResolvedValue('hello'),
+      readClipboardFilePaths: vi.fn().mockRejectedValue(new Error('clipboard read failed')),
+      pasteFilePaths: noClipboardFilePaste(),
+      saveClipboardImageAsTempFile: vi.fn(),
+      pasteText
+    })
+
+    expect(pasteText).toHaveBeenCalledWith('hello')
+    expect(result).toEqual({ status: 'pasted', kind: 'text' })
+  })
+
+  it('reports rejected copied-file pastes without falling through to text', async () => {
+    const readClipboardText = vi.fn().mockResolvedValue('a file.txt')
+
+    const result = await pasteTerminalClipboard({
+      readClipboardText,
+      readClipboardFilePaths: vi.fn().mockResolvedValue(['/Users/me/a file.txt']),
+      pasteFilePaths: vi.fn().mockResolvedValue(false),
+      saveClipboardImageAsTempFile: vi.fn(),
+      pasteText: vi.fn()
+    })
+
+    expect(readClipboardText).not.toHaveBeenCalled()
+    expect(result).toEqual({ status: 'skipped', reason: 'file-paste-rejected' })
+  })
+
+  it('reports copied-file paste failures separately from text failures', async () => {
+    const pasteError = new Error('upload failed')
+    const onFilePasteError = vi.fn()
+
+    const result = await pasteTerminalClipboard({
+      readClipboardText: vi.fn(),
+      readClipboardFilePaths: vi.fn().mockResolvedValue(['/Users/me/a.txt']),
+      pasteFilePaths: vi.fn().mockRejectedValue(pasteError),
+      saveClipboardImageAsTempFile: vi.fn(),
+      pasteText: vi.fn(),
+      onFilePasteError
+    })
+
+    expect(onFilePasteError).toHaveBeenCalledWith(pasteError)
+    expect(result).toEqual({ status: 'skipped', reason: 'file-paste-failed' })
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.ts
@@ -59,12 +59,7 @@ export async function pasteTerminalClipboard({
   onFilePasteError,
   onImagePasteError
 }: PasteTerminalClipboardDeps): Promise<TerminalClipboardPasteResult> {
-  // Why: an OS-copied file also puts its display name on the clipboard as text,
-  // so the text branch below would paste the bare name. Reading the real file
-  // reference first makes paste behave like drop. The file-path callback owns
-  // WSL conversion and SSH/runtime uploads before writing target-host paths.
-  // Only take this branch when a file is actually present; ordinary text and
-  // image copies fall through unchanged.
+  // Why: OS-copied files expose bare display names as text, so resolve file references first.
   let filePaths: string[] = []
   try {
     filePaths = await readClipboardFilePaths()

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.ts
@@ -14,6 +14,8 @@ type SaveClipboardImageAsTempFile = (args?: {
 
 type PasteTerminalClipboardDeps = {
   readClipboardText: (options?: ReadClipboardTextOptions) => Promise<string>
+  readClipboardFilePaths: () => Promise<string[]>
+  pasteFilePaths: (filePaths: string[]) => boolean | void | Promise<boolean | void>
   saveClipboardImageAsTempFile: SaveClipboardImageAsTempFile
   pasteText: (
     text: string,
@@ -24,15 +26,18 @@ type PasteTerminalClipboardDeps = {
   forceBracketedMultilineTextPaste?: boolean
   protectedMultilineTextPasteOptions?: TerminalPasteTextOptions
   onTextPasteError?: (error: unknown) => void
+  onFilePasteError?: (error: unknown) => void
   onImagePasteError?: (error: unknown) => void
 }
 
 export type TerminalClipboardPasteResult =
-  | { status: 'pasted'; kind: 'image-path' | 'text' }
+  | { status: 'pasted'; kind: 'image-path' | 'text' | 'file-path' }
   | {
       status: 'skipped'
       reason:
         | 'empty'
+        | 'file-paste-failed'
+        | 'file-paste-rejected'
         | 'image-paste-failed'
         | 'image-paste-rejected'
         | 'text-paste-failed'
@@ -42,6 +47,8 @@ export type TerminalClipboardPasteResult =
 
 export async function pasteTerminalClipboard({
   readClipboardText,
+  readClipboardFilePaths,
+  pasteFilePaths,
   saveClipboardImageAsTempFile,
   pasteText,
   connectionId,
@@ -49,8 +56,34 @@ export async function pasteTerminalClipboard({
   forceBracketedMultilineTextPaste = false,
   protectedMultilineTextPasteOptions,
   onTextPasteError,
+  onFilePasteError,
   onImagePasteError
 }: PasteTerminalClipboardDeps): Promise<TerminalClipboardPasteResult> {
+  // Why: an OS-copied file also puts its display name on the clipboard as text,
+  // so the text branch below would paste the bare name. Reading the real file
+  // reference first makes paste behave like drop. The file-path callback owns
+  // WSL conversion and SSH/runtime uploads before writing target-host paths.
+  // Only take this branch when a file is actually present; ordinary text and
+  // image copies fall through unchanged.
+  let filePaths: string[] = []
+  try {
+    filePaths = await readClipboardFilePaths()
+  } catch {
+    // Best-effort: a failed file-reference read must not block text/image paste.
+  }
+  if (filePaths.length > 0) {
+    try {
+      const result = await pasteFilePaths(filePaths)
+      if (result === false) {
+        return { status: 'skipped', reason: 'file-paste-rejected' }
+      }
+      return { status: 'pasted', kind: 'file-path' }
+    } catch (error) {
+      onFilePasteError?.(error)
+      return { status: 'skipped', reason: 'file-paste-failed' }
+    }
+  }
+
   let text = ''
   try {
     text = await readClipboardText({ maxBytes: TERMINAL_PASTE_MAX_BYTES })

--- a/src/renderer/src/components/terminal-pane/terminal-drop-local-wsl-path.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-drop-local-wsl-path.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { toLocalWslDropPath } from './terminal-drop-local-wsl-path'
+
+describe('toLocalWslDropPath', () => {
+  it('maps drive-letter and WSL UNC paths into the local distro', () => {
+    expect(toLocalWslDropPath('C:\\Users\\me\\file.txt')).toBe('/mnt/c/Users/me/file.txt')
+    expect(toLocalWslDropPath('\\\\wsl.localhost\\Ubuntu\\home\\me\\file.txt')).toBe(
+      '/home/me/file.txt'
+    )
+  })
+
+  it.each([
+    ['\\\\server\\share\\file.txt', '//server/share/file.txt'],
+    ['//server/share/file.txt', '//server/share/file.txt']
+  ])('preserves generic UNC paths without drive-letter mapping', (path, expected) => {
+    expect(toLocalWslDropPath(path)).toBe(expected)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-drop-local-wsl-path.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-drop-local-wsl-path.ts
@@ -1,4 +1,3 @@
-import { isWindowsAbsolutePathLike } from '../../../../shared/cross-platform-path'
 import { parseWslUncPath } from '../../../../shared/wsl-paths'
 
 export function toLocalWslDropPath(path: string): string {
@@ -6,7 +5,7 @@ export function toLocalWslDropPath(path: string): string {
   if (wslUnc) {
     return wslUnc.linuxPath
   }
-  if (isWindowsAbsolutePathLike(path)) {
+  if (/^[A-Za-z]:[\\/]/u.test(path)) {
     const drive = path[0].toLowerCase()
     return `/mnt/${drive}/${path.slice(3).replace(/\\/g, '/')}`
   }

--- a/src/renderer/src/components/terminal-pane/terminal-drop-local-wsl-path.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-drop-local-wsl-path.ts
@@ -1,0 +1,14 @@
+import { isWindowsAbsolutePathLike } from '../../../../shared/cross-platform-path'
+import { parseWslUncPath } from '../../../../shared/wsl-paths'
+
+export function toLocalWslDropPath(path: string): string {
+  const wslUnc = parseWslUncPath(path)
+  if (wslUnc) {
+    return wslUnc.linuxPath
+  }
+  if (isWindowsAbsolutePathLike(path)) {
+    const drive = path[0].toLowerCase()
+    return `/mnt/${drive}/${path.slice(3).replace(/\\/g, '/')}`
+  }
+  return path.replace(/\\/g, '/')
+}

--- a/src/renderer/src/components/terminal-pane/terminal-native-file-drop.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-native-file-drop.ts
@@ -7,8 +7,7 @@ import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import { importExternalPathsToRuntime } from '@/runtime/runtime-file-client'
 import { useAppStore } from '@/store'
 import { translate } from '@/i18n/i18n'
-import { isWindowsAbsolutePathLike } from '../../../../shared/cross-platform-path'
-import { isWslUncPath, parseWslUncPath } from '../../../../shared/wsl-paths'
+import { isWslUncPath } from '../../../../shared/wsl-paths'
 import type { PtyTransport } from './pty-transport'
 import { recordTerminalUserInputForLeaf } from './terminal-input-activity'
 import { reportTerminalDropUploadSkipsAndFailures } from './terminal-drop-upload-report'
@@ -28,6 +27,7 @@ import {
   resolveTerminalDropWorktreePath
 } from './terminal-drop-worktree-path'
 import { captureRuntimeTerminalDropOwner } from './terminal-drop-runtime-owner'
+import { toLocalWslDropPath } from './terminal-drop-local-wsl-path'
 
 export type NativeTerminalFileDropArgs = {
   manager: PaneManager
@@ -49,28 +49,35 @@ export type NativeTerminalFileDropArgs = {
 export async function handleNativeTerminalFileDrop(
   args: NativeTerminalFileDropArgs
 ): Promise<void> {
+  await pasteNativeTerminalFileDrop(args)
+}
+
+export async function pasteNativeTerminalFileDrop(
+  args: NativeTerminalFileDropArgs
+): Promise<boolean> {
   try {
-    await handleNativeTerminalFileDropWithCapturedOwner(args)
+    return await handleNativeTerminalFileDropWithCapturedOwner(args)
   } catch (err) {
-    // Why: native drop listeners fire-and-forget, so owner-capture failures must terminate here.
+    // Why: both fire-and-forget drops and awaited clipboard pastes need an error boundary.
     toast.error(extractIpcErrorMessage(err, 'Failed to drop files.'))
+    return false
   }
 }
 
 async function handleNativeTerminalFileDropWithCapturedOwner(
   args: NativeTerminalFileDropArgs
-): Promise<void> {
+): Promise<boolean> {
   const { manager, paneTransports, worktreeId, tabId, cwd, data } = args
   if (data.paths.length === 0) {
-    return
+    return false
   }
   const pane = resolveNativeTerminalDropPane(manager, data.paneLeafId)
   if (!pane) {
-    return
+    return false
   }
   const transport = paneTransports.get(pane.id)
   if (!transport) {
-    return
+    return false
   }
   const dropTarget = captureTerminalDropTarget(pane, transport)
   const state = useAppStore.getState()
@@ -84,11 +91,11 @@ async function handleNativeTerminalFileDropWithCapturedOwner(
         'Worktree path not available.'
       )
     )
-    return
+    return false
   }
 
   if (runtimeOwner) {
-    await uploadRuntimeDropPaths({
+    return uploadRuntimeDropPaths({
       dataPaths: data.paths,
       dropTarget,
       manager,
@@ -100,7 +107,6 @@ async function handleNativeTerminalFileDropWithCapturedOwner(
       worktreePath,
       ...runtimeOwner
     })
-    return
   }
 
   // Why: `getConnectionId` returns `string` (SSH), `null` (local repo found),
@@ -115,7 +121,7 @@ async function handleNativeTerminalFileDropWithCapturedOwner(
         'Worktree not ready — try again in a moment.'
       )
     )
-    return
+    return false
   }
   const targetShell = resolveTerminalDropTargetShell({
     activeRuntimeEnvironmentId: null,
@@ -127,7 +133,7 @@ async function handleNativeTerminalFileDropWithCapturedOwner(
   const localWslDrop = !isRemote && isWorktreeUsingLocalWslRuntime(state, worktreeId)
 
   if (!isRemote) {
-    await pasteLocalDropPaths({
+    return pasteLocalDropPaths({
       dataPaths: data.paths,
       dropTarget,
       localWslDrop,
@@ -138,10 +144,9 @@ async function handleNativeTerminalFileDropWithCapturedOwner(
       targetShell: localWslDrop ? 'posix' : targetShell,
       worktreePath
     })
-    return
   }
 
-  await uploadRemoteDropPaths({
+  return uploadRemoteDropPaths({
     connectionId,
     ...captureDirectSshMutationExpectation(state, connectionId),
     dataPaths: data.paths,
@@ -175,7 +180,7 @@ async function uploadRuntimeDropPaths(
     settings: ReturnType<typeof useAppStore.getState>['settings']
     worktreeId: string
   }
-): Promise<void> {
+): Promise<boolean> {
   const targetShell = getTerminalTargetShellForWorktreePath(args.worktreePath)
   const destinationDir = joinRuntimeTerminalDropDir(args.worktreePath)
   const pending = toast.loading(
@@ -207,13 +212,15 @@ async function uploadRuntimeDropPaths(
         ? result.destPath.replace(/\//g, '\\')
         : result.destPath
     )
-    await pasteResolvedDropPaths({ ...args, paths: importedPaths, targetShell })
+    const pasted = await pasteResolvedDropPaths({ ...args, paths: importedPaths, targetShell })
     reportTerminalDropUploadSkipsAndFailures(
       results.filter((result) => result.status === 'skipped'),
       results.filter((result) => result.status === 'failed')
     )
+    return pasted
   } catch (err) {
     toast.error(extractIpcErrorMessage(err, 'Failed to upload files.'))
+    return false
   } finally {
     toast.dismiss(pending)
   }
@@ -221,7 +228,7 @@ async function uploadRuntimeDropPaths(
 
 async function pasteLocalDropPaths(
   args: NativeDropFlowArgs & { localWslDrop: boolean; targetShell: 'posix' | 'windows' }
-): Promise<void> {
+): Promise<boolean> {
   // Why: local WSL worktrees run POSIX shells despite a Windows host, so
   // dropped paths must use the distro-aware resolver before terminal paste.
   if (isWslUncPath(args.worktreePath)) {
@@ -230,17 +237,22 @@ async function pasteLocalDropPaths(
         paths: args.dataPaths,
         worktreePath: args.worktreePath
       })
-      await pasteResolvedDropPaths({ ...args, paths: resolvedPaths, targetShell: 'posix' })
+      const pasted = await pasteResolvedDropPaths({
+        ...args,
+        paths: resolvedPaths,
+        targetShell: 'posix'
+      })
       reportTerminalDropUploadSkipsAndFailures(skipped, failed)
+      return pasted
     } catch (err) {
       toast.error(extractIpcErrorMessage(err, 'Failed to resolve dropped files.'))
+      return false
     }
-    return
   }
 
   // Why: non-WSL local drops stay reference-in-place. Trailing space
   // separates multiple paths, matching standard drag-and-drop UX.
-  await pasteResolvedDropPaths({
+  return pasteResolvedDropPaths({
     ...args,
     paths: args.localWslDrop ? args.dataPaths.map(toLocalWslDropPath) : args.dataPaths,
     targetShell: args.targetShell
@@ -249,7 +261,7 @@ async function pasteLocalDropPaths(
 
 async function uploadRemoteDropPaths(
   args: NativeDropFlowArgs & { connectionId: string; targetShell: 'posix' | 'windows' }
-): Promise<void> {
+): Promise<boolean> {
   const pending = toast.loading(
     translate(
       'auto.components.terminal.pane.terminal.drop.handler.29c031b49a',
@@ -266,10 +278,16 @@ async function uploadRemoteDropPaths(
       expectedSshTargetId: args.expectedSshTargetId,
       expectedSshConnectionGeneration: args.expectedSshConnectionGeneration
     })
-    await pasteResolvedDropPaths({ ...args, paths: resolvedPaths, targetShell: args.targetShell })
+    const pasted = await pasteResolvedDropPaths({
+      ...args,
+      paths: resolvedPaths,
+      targetShell: args.targetShell
+    })
     reportTerminalDropUploadSkipsAndFailures(skipped, failed)
+    return pasted
   } catch (err) {
     toast.error(extractIpcErrorMessage(err, 'Failed to upload files.'))
+    return false
   } finally {
     toast.dismiss(pending)
   }
@@ -277,7 +295,7 @@ async function uploadRemoteDropPaths(
 
 async function pasteResolvedDropPaths(
   args: NativeDropFlowArgs & { paths: string[]; targetShell: 'posix' | 'windows' }
-): Promise<void> {
+): Promise<boolean> {
   // Why: pane may have unmounted during upload/resolution (tab closed,
   // worktree switched). Re-check before writing so we do not call sendInput
   // on a torn-down PTY.
@@ -287,7 +305,7 @@ async function pasteResolvedDropPaths(
     args.dropTarget
   )
   if (!liveTransport) {
-    return
+    return false
   }
   const writeResult = await writeTerminalDropPathsToCapturedTarget({
     dropTarget: args.dropTarget,
@@ -303,6 +321,7 @@ async function pasteResolvedDropPaths(
   if (writeResult.targetCurrent) {
     args.pane.terminal.focus()
   }
+  return writeResult.sentAnyPath
 }
 
 function isWorktreeUsingLocalWslRuntime(
@@ -314,16 +333,4 @@ function isWorktreeUsingLocalWslRuntime(
     return projectRuntime.repair.preferredRuntime.kind === 'wsl'
   }
   return projectRuntime?.status === 'resolved' && projectRuntime.runtime.kind === 'wsl'
-}
-
-function toLocalWslDropPath(path: string): string {
-  const wslUnc = parseWslUncPath(path)
-  if (wslUnc) {
-    return wslUnc.linuxPath
-  }
-  if (isWindowsAbsolutePathLike(path)) {
-    const drive = path[0].toLowerCase()
-    return `/mnt/${drive}/${path.slice(3).replace(/\\/g, '/')}`
-  }
-  return path.replace(/\\/g, '/')
 }

--- a/src/renderer/src/components/terminal-pane/terminal-pane-menu-paste.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-menu-paste.ts
@@ -1,9 +1,11 @@
 import type { ManagedPane, PaneManager } from '@/lib/pane-manager/pane-manager'
 import type { PtyTransport } from './pty-transport'
+import type { PaneCwdMap } from './resolve-split-cwd'
 import { getConnectionId } from '@/lib/connection-context'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { pasteTerminalText } from './terminal-bracketed-paste'
 import { pasteTerminalClipboard } from './terminal-clipboard-paste'
+import { pasteTerminalClipboardFilePaths } from './terminal-clipboard-file-paste'
 import {
   executeTerminalPastePlan,
   planTerminalPasteWithYield,
@@ -24,8 +26,10 @@ import { recordTerminalUserInputForLeaf } from './terminal-input-activity'
 export type TerminalPaneMenuPasteContext = {
   managerRef: React.RefObject<PaneManager | null>
   paneTransportsRef: React.RefObject<Map<number, PtyTransport>>
+  paneCwdRef: React.RefObject<PaneCwdMap>
   tabId: string
   worktreeId: string
+  fallbackCwd: string
   forceBracketedMultilineTextPaste: boolean
   onPasteError: (message: string) => void
 }
@@ -121,6 +125,17 @@ export const pasteTerminalPaneMenuClipboard = async (
   const transport = context.paneTransportsRef.current.get(pane.id) ?? null
   const result = await pasteTerminalClipboard({
     readClipboardText: window.api.ui.readClipboardText,
+    readClipboardFilePaths: window.api.ui.readClipboardFilePaths,
+    pasteFilePaths: (paths) =>
+      pasteTerminalClipboardFilePaths({
+        manager: context.managerRef.current,
+        pane,
+        paneTransports: context.paneTransportsRef.current,
+        paths,
+        tabId,
+        worktreeId,
+        cwd: context.paneCwdRef.current.get(pane.id)?.cwd ?? context.fallbackCwd
+      }),
     saveClipboardImageAsTempFile: window.api.ui.saveClipboardImageAsTempFile,
     connectionId,
     runtimeEnvironmentId,

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
@@ -115,8 +115,10 @@ export function useTerminalPaneContextMenu({
       {
         managerRef,
         paneTransportsRef,
+        paneCwdRef,
         tabId,
         worktreeId,
+        fallbackCwd,
         forceBracketedMultilineTextPaste,
         onPasteError
       },

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2787,6 +2787,9 @@ function createWebUiApi(): NonNullable<Partial<PreloadApi>['ui']> {
       ),
     readSelectionClipboardText: () =>
       Promise.reject(new Error('Selection clipboard is unavailable in the web client')),
+    // The browser clipboard exposes no OS file references, so a web paste can
+    // never carry copied-file paths.
+    readClipboardFilePaths: () => Promise.resolve([]),
     saveClipboardImageAsTempFile: async (args?: {
       connectionId?: string | null
       runtimeEnvironmentId?: string | null


### PR DESCRIPTION
## ELI5

Copying a file in Finder, Explorer, or a Linux file manager and pasting into an Orca terminal now uses the actual file reference instead of the display-name text that the OS also places on the clipboard. Remote terminals receive an uploaded, usable target-host path.

## What Changed

- Read bounded, proven OS file-list clipboard flavors before ordinary clipboard text.
- Support macOS `NSFilenamesPboardType` / `public.file-url`, Windows `FileNameW`, and Linux GNOME/KDE URI formats.
- Bound Linux clipboard helpers by output size and timeout, and wait for stdout to close before parsing it.
- Route copied files through the existing terminal file-drop pipeline for local, WSL, SSH, and managed-runtime targets.
- Preserve ordinary text paste, screenshot/image paste, web-client fallback, and dashboard-popout clipboard authority.

This refresh supersedes #7786 while preserving the original author's commit attribution.

## Why

OS file copies expose multiple clipboard representations. Orca previously accepted the synthesized basename text first, so Finder copies such as `screenshot.png` never reached file handling. Selecting only a proven file-list flavor avoids basename guessing, while reusing the drop pipeline prevents local paths from leaking into remote shells where they are unusable.

## Linked Issue

Fixes #7777
Fixes #15377

## Visual Proof

N/A — this changes terminal clipboard routing without adding persistent UI.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Validated locally:

- `pnpm exec vitest run --config config/vitest.config.ts` on 8 focused clipboard/drop suites: 94 tests passed.
- `pnpm run typecheck:node`
- `pnpm run typecheck:web`
- Base oxlint and type-aware oxlint on all changed files.
- `pnpm run check:max-lines-ratchet`

Cross-platform clipboard formats are unit-tested. Existing WSL/SSH/runtime drop resolution and target-shell path writing are covered by the focused drop suites. A real OS clipboard smoke test is still recommended on macOS, Windows, and Linux.

## AI Disclosure

OpenAI Codex (GPT-5) refreshed the original patch, resolved the rebase, adapted it to current host-ownership infrastructure, and added tests.

## Review

The refresh addresses the earlier automated review findings: subprocess output is consumed on `close`, helpers have byte/time bounds, KDE fallback is covered, and target-shell/remote handling is delegated to the existing drop pipeline rather than duplicated.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- Security: file-list payloads are byte/path-count bounded and available only to the trusted renderer; dashboard popouts retain their narrower text-only authority.
- Cross-platform: format parsing covers macOS, Windows, GNOME, and KDE.
- SSH/runtime: local clipboard files use the existing upload and ownership checks before terminal paste.
- Backwards compatibility: no remote wire protocol changes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (focused tests/typechecks pass; CI will run the full matrix)

## Author

- Original implementation: @hongdroid94
