### PR TITLE
feat(settings): add live appearance previews and backgrounds

### DIFF
--- a/src/main/ipc/orca-background-library.test.ts
+++ b/src/main/ipc/orca-background-library.test.ts
@@ -1,0 +1,227 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtemp, mkdir, readFile, rm, symlink, truncate, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+const { fromWebContentsMock, getPathMock, handleMock, openPathMock, showOpenDialogMock } =
+  vi.hoisted(() => ({
+    fromWebContentsMock: vi.fn(),
+    getPathMock: vi.fn(),
+    handleMock: vi.fn(),
+    openPathMock: vi.fn(),
+    showOpenDialogMock: vi.fn()
+  }))
+
+vi.mock('electron', () => ({
+  BrowserWindow: { fromWebContents: fromWebContentsMock },
+  app: { getPath: getPathMock },
+  dialog: { showOpenDialog: showOpenDialogMock },
+  ipcMain: { handle: handleMock },
+  shell: { openPath: openPathMock }
+}))
+
+import {
+  importOrcaBackgroundImages,
+  listOrcaBackgroundLibrary,
+  loadOrcaBackgroundImage,
+  openOrcaBackgroundLibrary,
+  registerOrcaBackgroundLibraryHandlers
+} from './orca-background-library'
+
+const VALID_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=',
+  'base64'
+)
+const ALTERNATE_VALID_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+  'base64'
+)
+const CORRUPT_PNG = Buffer.from([0x89, 0x50, 0x4e])
+
+function oversizedPng(): Buffer {
+  const bytes = Buffer.from(VALID_PNG)
+  bytes.writeUInt32BE(32_769, 16)
+  return bytes
+}
+
+const tempRoots: string[] = []
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'orca-backgrounds-'))
+  tempRoots.push(root)
+  return root
+}
+
+describe('Orca background library', () => {
+  beforeEach(() => {
+    fromWebContentsMock.mockReset().mockReturnValue(null)
+    handleMock.mockReset()
+    openPathMock.mockReset().mockResolvedValue('')
+    showOpenDialogMock.mockReset().mockResolvedValue({ canceled: true, filePaths: [] })
+    getPathMock.mockReset()
+  })
+
+  afterEach(async () => {
+    await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+  })
+
+  it('lists supported regular images in filename order', async () => {
+    const root = await makeTempRoot()
+    const library = join(root, 'backgrounds')
+    await mkdir(library)
+    await writeFile(join(library, 'zeta.png'), ALTERNATE_VALID_PNG)
+    await writeFile(join(library, 'alpha.PNG'), VALID_PNG)
+    await writeFile(join(library, 'corrupt.png'), CORRUPT_PNG)
+    await writeFile(join(library, 'oversized.png'), oversizedPng())
+    await writeFile(join(library, 'unsupported.avif'), VALID_PNG)
+    await writeFile(join(library, 'notes.txt'), 'not an image')
+    await writeFile(join(library, 'empty.jpg'), '')
+    await writeFile(join(library, 'large.png'), '')
+    await truncate(join(library, 'large.png'), 12 * 1024 * 1024 + 1)
+
+    await expect(listOrcaBackgroundLibrary(library)).resolves.toEqual({
+      dir: library,
+      images: [
+        { fileName: 'alpha.PNG', path: join(library, 'alpha.PNG'), size: VALID_PNG.byteLength },
+        {
+          fileName: 'zeta.png',
+          path: join(library, 'zeta.png'),
+          size: ALTERNATE_VALID_PNG.byteLength
+        }
+      ]
+    })
+  })
+
+  it('loads image bytes without allowing path traversal', async () => {
+    const root = await makeTempRoot()
+    const library = join(root, 'backgrounds')
+    await mkdir(library)
+    await writeFile(join(library, 'scene.png'), VALID_PNG)
+    await writeFile(join(root, 'secret.png'), ALTERNATE_VALID_PNG)
+
+    await expect(loadOrcaBackgroundImage('scene.png', library)).resolves.toEqual({
+      ok: true,
+      data: Uint8Array.from(VALID_PNG),
+      mimeType: 'image/png'
+    })
+    await expect(loadOrcaBackgroundImage('../secret.png', library)).resolves.toEqual({
+      ok: false,
+      reason: 'invalid-name'
+    })
+    await expect(loadOrcaBackgroundImage('..\\secret.png', library)).resolves.toEqual({
+      ok: false,
+      reason: 'invalid-name'
+    })
+  })
+
+  it('rejects corrupt and unsafe-dimension image bytes', async () => {
+    const root = await makeTempRoot()
+    const library = join(root, 'backgrounds')
+    await mkdir(library)
+    await writeFile(join(library, 'corrupt.png'), CORRUPT_PNG)
+    await writeFile(join(library, 'oversized.png'), oversizedPng())
+
+    await expect(loadOrcaBackgroundImage('corrupt.png', library)).resolves.toEqual({
+      ok: false,
+      reason: 'read-failed'
+    })
+    await expect(loadOrcaBackgroundImage('oversized.png', library)).resolves.toEqual({
+      ok: false,
+      reason: 'too-large'
+    })
+  })
+
+  it('imports collision-safe copies without overwriting existing images', async () => {
+    const root = await makeTempRoot()
+    const library = join(root, 'backgrounds')
+    const sourceDir = join(root, 'source')
+    await mkdir(library)
+    await mkdir(sourceDir)
+    await writeFile(join(library, 'scene.png'), VALID_PNG)
+    await writeFile(join(sourceDir, 'scene.png'), ALTERNATE_VALID_PNG)
+
+    const result = await importOrcaBackgroundImages([join(sourceDir, 'scene.png')], library)
+
+    expect(result.added).toEqual(['scene-2.png'])
+    await expect(readFile(join(library, 'scene.png'))).resolves.toEqual(VALID_PNG)
+    await expect(readFile(join(library, 'scene-2.png'))).resolves.toEqual(ALTERNATE_VALID_PNG)
+  })
+
+  it('skips corrupt and unsafe-dimension imports', async () => {
+    const root = await makeTempRoot()
+    const library = join(root, 'backgrounds')
+    const sourceDir = join(root, 'source')
+    await mkdir(sourceDir)
+    await writeFile(join(sourceDir, 'valid.png'), VALID_PNG)
+    await writeFile(join(sourceDir, 'corrupt.png'), CORRUPT_PNG)
+    await writeFile(join(sourceDir, 'oversized.png'), oversizedPng())
+
+    const result = await importOrcaBackgroundImages(
+      [
+        join(sourceDir, 'valid.png'),
+        join(sourceDir, 'corrupt.png'),
+        join(sourceDir, 'oversized.png')
+      ],
+      library
+    )
+
+    expect(result.added).toEqual(['valid.png'])
+    expect(result.skipped).toEqual(['corrupt.png', 'oversized.png'])
+    expect(result.images.map((image) => image.fileName)).toEqual(['valid.png'])
+  })
+
+  it.runIf(process.platform !== 'win32')('rejects symbolic links', async () => {
+    const root = await makeTempRoot()
+    const library = join(root, 'backgrounds')
+    await mkdir(library)
+    await writeFile(join(root, 'outside.png'), VALID_PNG)
+    await symlink(join(root, 'outside.png'), join(library, 'linked.png'))
+
+    await expect(loadOrcaBackgroundImage('linked.png', library)).resolves.toEqual({
+      ok: false,
+      reason: 'invalid-name'
+    })
+    await expect(listOrcaBackgroundLibrary(library)).resolves.toEqual({ dir: library, images: [] })
+  })
+
+  it('opens the app-owned folder and exposes only native-picker imports', async () => {
+    const root = await makeTempRoot()
+    const parentWindow = { id: 1 }
+    const sender = { id: 2 }
+    getPathMock.mockReturnValue(root)
+    fromWebContentsMock.mockReturnValue(parentWindow)
+    registerOrcaBackgroundLibraryHandlers()
+
+    const channels = handleMock.mock.calls.map(([channel]) => channel)
+    expect(channels).toEqual([
+      'backgrounds:listLibrary',
+      'backgrounds:addImages',
+      'backgrounds:openLibrary',
+      'backgrounds:loadImage'
+    ])
+
+    const addImages = handleMock.mock.calls.find(
+      ([channel]) => channel === 'backgrounds:addImages'
+    )?.[1] as (...args: unknown[]) => Promise<unknown>
+    await expect(addImages({ sender }, ['C:\\untrusted\\secret.png'])).resolves.toMatchObject({
+      added: [],
+      skipped: []
+    })
+    expect(fromWebContentsMock).toHaveBeenCalledWith(sender)
+    expect(showOpenDialogMock).toHaveBeenCalledOnce()
+    expect(showOpenDialogMock).toHaveBeenCalledWith(parentWindow, {
+      properties: ['openFile', 'multiSelections'],
+      filters: [
+        {
+          name: 'Images',
+          extensions: ['png', 'jpg', 'jpeg', 'webp', 'gif', 'bmp']
+        }
+      ]
+    })
+
+    await expect(openOrcaBackgroundLibrary(join(root, 'backgrounds'))).resolves.toEqual({
+      ok: true
+    })
+    expect(openPathMock).toHaveBeenCalledWith(join(root, 'backgrounds'))
+  })
+})

--- a/src/main/ipc/orca-background-library.test.ts
+++ b/src/main/ipc/orca-background-library.test.ts
@@ -1,5 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { mkdtemp, mkdir, readFile, rm, symlink, truncate, writeFile } from 'node:fs/promises'
+import {
+  link,
+  mkdtemp,
+  mkdir,
+  readFile,
+  rename,
+  rm,
+  symlink,
+  truncate,
+  writeFile
+} from 'node:fs/promises'
+import type * as FsPromises from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 
@@ -11,6 +22,21 @@ const { fromWebContentsMock, getPathMock, handleMock, openPathMock, showOpenDial
     openPathMock: vi.fn(),
     showOpenDialogMock: vi.fn()
   }))
+
+const fileOpenRace = vi.hoisted(() => ({
+  beforeOpen: null as ((path: string) => Promise<void>) | null
+}))
+
+vi.mock('node:fs/promises', async () => {
+  const actual = await vi.importActual<typeof FsPromises>('node:fs/promises')
+  const open = (async (...args: Parameters<typeof actual.open>) => {
+    const beforeOpen = fileOpenRace.beforeOpen
+    fileOpenRace.beforeOpen = null
+    await beforeOpen?.(String(args[0]))
+    return actual.open(...args)
+  }) as typeof actual.open
+  return { ...actual, open }
+})
 
 vi.mock('electron', () => ({
   BrowserWindow: { fromWebContents: fromWebContentsMock },
@@ -59,6 +85,7 @@ describe('Orca background library', () => {
     openPathMock.mockReset().mockResolvedValue('')
     showOpenDialogMock.mockReset().mockResolvedValue({ canceled: true, filePaths: [] })
     getPathMock.mockReset()
+    fileOpenRace.beforeOpen = null
   })
 
   afterEach(async () => {
@@ -112,6 +139,43 @@ describe('Orca background library', () => {
       ok: false,
       reason: 'invalid-name'
     })
+  })
+
+  it('rejects a file swapped between lstat and open', async () => {
+    const root = await makeTempRoot()
+    const library = join(root, 'backgrounds')
+    const imagePath = join(library, 'scene.png')
+    const originalPath = join(library, 'original.png')
+    const outsidePath = join(root, 'outside.png')
+    await mkdir(library)
+    await writeFile(imagePath, VALID_PNG)
+    await writeFile(outsidePath, ALTERNATE_VALID_PNG)
+    fileOpenRace.beforeOpen = async (openedPath) => {
+      expect(openedPath).toBe(imagePath)
+      await rename(imagePath, originalPath)
+      await rename(outsidePath, imagePath)
+    }
+
+    const result = await loadOrcaBackgroundImage('scene.png', library)
+    expect(result).toEqual({
+      ok: false,
+      reason: 'read-failed'
+    })
+    expect(result).not.toHaveProperty('data')
+  })
+
+  it('rejects hard links already present in the library', async () => {
+    const root = await makeTempRoot()
+    const library = join(root, 'backgrounds')
+    await mkdir(library)
+    await writeFile(join(root, 'outside.png'), VALID_PNG)
+    await link(join(root, 'outside.png'), join(library, 'linked.png'))
+
+    await expect(loadOrcaBackgroundImage('linked.png', library)).resolves.toEqual({
+      ok: false,
+      reason: 'read-failed'
+    })
+    await expect(listOrcaBackgroundLibrary(library)).resolves.toEqual({ dir: library, images: [] })
   })
 
   it('rejects corrupt and unsafe-dimension image bytes', async () => {

--- a/src/main/ipc/orca-background-library.ts
+++ b/src/main/ipc/orca-background-library.ts
@@ -1,0 +1,249 @@
+import { BrowserWindow, app, dialog, ipcMain, shell } from 'electron'
+import { constants, lstat, mkdir, open, readdir, writeFile } from 'node:fs/promises'
+import { basename, extname, join, parse, resolve } from 'node:path'
+import {
+  RASTER_IMAGE_PREVIEW_TOO_LARGE_ERROR,
+  assertRasterImagePreviewWithinLimits
+} from '../../shared/raster-image-preview-limits'
+import type {
+  OrcaBackgroundImageLoadResult,
+  OrcaBackgroundImportResult,
+  OrcaBackgroundLibrary,
+  OrcaBackgroundLibraryImage,
+  OrcaBackgroundOpenLibraryResult
+} from '../../shared/orca-background-library-types'
+
+const ORCA_BACKGROUND_LIBRARY_DIR_NAME = 'backgrounds'
+const ORCA_BACKGROUND_MAX_BYTES = 12 * 1024 * 1024
+const ORCA_BACKGROUND_MIME_BY_EXTENSION: Readonly<Record<string, string>> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.webp': 'image/webp',
+  '.gif': 'image/gif',
+  '.bmp': 'image/bmp'
+}
+const ORCA_BACKGROUND_DIALOG_EXTENSIONS = Object.keys(ORCA_BACKGROUND_MIME_BY_EXTENSION).map(
+  (extension) => extension.slice(1)
+)
+
+function backgroundLibraryDir(): string {
+  return join(app.getPath('userData'), ORCA_BACKGROUND_LIBRARY_DIR_NAME)
+}
+
+function mimeTypeForFileName(fileName: string): string | null {
+  return ORCA_BACKGROUND_MIME_BY_EXTENSION[extname(fileName).toLowerCase()] ?? null
+}
+
+function isSafeFileName(fileName: unknown): fileName is string {
+  return (
+    typeof fileName === 'string' &&
+    fileName.length > 0 &&
+    fileName.length <= 255 &&
+    basename(fileName) === fileName &&
+    !fileName.includes('/') &&
+    !fileName.includes('\\') &&
+    !fileName.includes('\0') &&
+    fileName !== '.' &&
+    fileName !== '..'
+  )
+}
+
+type ValidatedImageReadResult =
+  | { ok: true; data: Uint8Array; mimeType: string; size: number }
+  | { ok: false; reason: 'too-large' | 'read-failed' }
+
+async function readValidatedImage(pathValue: string): Promise<ValidatedImageReadResult> {
+  const mimeType = mimeTypeForFileName(pathValue)
+  if (!mimeType) {
+    return { ok: false, reason: 'read-failed' }
+  }
+  let handle
+  try {
+    const initialStats = await lstat(pathValue)
+    if (!initialStats.isFile() || initialStats.isSymbolicLink() || initialStats.size === 0) {
+      return { ok: false, reason: 'read-failed' }
+    }
+    if (initialStats.size > ORCA_BACKGROUND_MAX_BYTES) {
+      return { ok: false, reason: 'too-large' }
+    }
+    // O_NOFOLLOW closes the lstat/open race on Unix; the lstat check rejects links on Windows.
+    handle = await open(pathValue, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0))
+    const stats = await handle.stat()
+    if (!stats.isFile() || stats.size === 0) {
+      return { ok: false, reason: 'read-failed' }
+    }
+    if (stats.size > ORCA_BACKGROUND_MAX_BYTES) {
+      return { ok: false, reason: 'too-large' }
+    }
+    const data = await handle.readFile()
+    if (data.byteLength === 0) {
+      return { ok: false, reason: 'read-failed' }
+    }
+    if (data.byteLength > ORCA_BACKGROUND_MAX_BYTES) {
+      return { ok: false, reason: 'too-large' }
+    }
+    const bytes = Uint8Array.from(data)
+    assertRasterImagePreviewWithinLimits(bytes, mimeType)
+    return { ok: true, data: bytes, mimeType, size: data.byteLength }
+  } catch (error) {
+    return {
+      ok: false,
+      reason:
+        error instanceof Error && error.message === RASTER_IMAGE_PREVIEW_TOO_LARGE_ERROR
+          ? 'too-large'
+          : 'read-failed'
+    }
+  } finally {
+    await handle?.close()
+  }
+}
+
+export async function listOrcaBackgroundLibrary(
+  dir = backgroundLibraryDir()
+): Promise<OrcaBackgroundLibrary> {
+  let entries
+  try {
+    entries = await readdir(dir, { withFileTypes: true })
+  } catch {
+    return { dir, images: [] }
+  }
+
+  const images: OrcaBackgroundLibraryImage[] = []
+  for (const entry of entries) {
+    if (!entry.isFile() || !isSafeFileName(entry.name)) {
+      continue
+    }
+    const path = join(dir, entry.name)
+    const inspected = await readValidatedImage(path)
+    if (inspected.ok) {
+      images.push({ fileName: entry.name, path, size: inspected.size })
+    }
+  }
+  return {
+    dir,
+    images: images.sort((left, right) => left.fileName.localeCompare(right.fileName))
+  }
+}
+
+function isAlreadyExistsError(error: unknown): boolean {
+  return (
+    error !== null &&
+    typeof error === 'object' &&
+    'code' in error &&
+    (error as { code?: unknown }).code === 'EEXIST'
+  )
+}
+
+async function writeImportedImage(
+  dir: string,
+  requestedFileName: string,
+  data: Uint8Array
+): Promise<string> {
+  const parsed = parse(requestedFileName)
+  for (let index = 1; index < 10_000; index += 1) {
+    const fileName = index === 1 ? requestedFileName : `${parsed.name}-${index}${parsed.ext}`
+    try {
+      await writeFile(join(dir, fileName), data, { flag: 'wx' })
+      return fileName
+    } catch (error) {
+      if (!isAlreadyExistsError(error)) {
+        throw error
+      }
+    }
+  }
+  throw new Error('Background library contains too many files with the same name')
+}
+
+export async function importOrcaBackgroundImages(
+  sourcePaths: readonly string[],
+  dir = backgroundLibraryDir()
+): Promise<OrcaBackgroundImportResult> {
+  await mkdir(dir, { recursive: true })
+  const added: string[] = []
+  const skipped: string[] = []
+
+  for (const sourcePath of sourcePaths) {
+    const sourceFileName = basename(sourcePath)
+    const image = isSafeFileName(sourceFileName)
+      ? await readValidatedImage(sourcePath)
+      : ({ ok: false, reason: 'read-failed' } as const)
+    if (!image.ok) {
+      skipped.push(sourceFileName || 'unknown')
+      continue
+    }
+    if (resolve(sourcePath) === resolve(join(dir, sourceFileName))) {
+      added.push(sourceFileName)
+      continue
+    }
+    try {
+      added.push(await writeImportedImage(dir, sourceFileName, image.data))
+    } catch {
+      skipped.push(sourceFileName)
+    }
+  }
+
+  return { ...(await listOrcaBackgroundLibrary(dir)), added, skipped }
+}
+
+export async function loadOrcaBackgroundImage(
+  fileName: unknown,
+  dir = backgroundLibraryDir()
+): Promise<OrcaBackgroundImageLoadResult> {
+  if (!isSafeFileName(fileName)) {
+    return { ok: false, reason: 'invalid-name' }
+  }
+  const mimeType = mimeTypeForFileName(fileName)
+  if (!mimeType) {
+    return { ok: false, reason: 'unsupported-type' }
+  }
+  const path = join(dir, fileName)
+  let stats
+  try {
+    stats = await lstat(path)
+  } catch {
+    return { ok: false, reason: 'not-found' }
+  }
+  if (!stats.isFile() || stats.isSymbolicLink()) {
+    return { ok: false, reason: 'invalid-name' }
+  }
+  if (stats.size > ORCA_BACKGROUND_MAX_BYTES) {
+    return { ok: false, reason: 'too-large' }
+  }
+  const image = await readValidatedImage(path)
+  if (!image.ok) {
+    return image
+  }
+  return { ok: true, data: image.data, mimeType }
+}
+
+export async function openOrcaBackgroundLibrary(
+  dir = backgroundLibraryDir()
+): Promise<OrcaBackgroundOpenLibraryResult> {
+  try {
+    await mkdir(dir, { recursive: true })
+    const error = await shell.openPath(dir)
+    return error ? { ok: false, reason: 'open-failed' } : { ok: true }
+  } catch {
+    return { ok: false, reason: 'open-failed' }
+  }
+}
+
+export function registerOrcaBackgroundLibraryHandlers(): void {
+  ipcMain.handle('backgrounds:listLibrary', () => listOrcaBackgroundLibrary())
+  ipcMain.handle('backgrounds:addImages', async (event) => {
+    const parent = BrowserWindow.fromWebContents(event.sender)
+    const options: Electron.OpenDialogOptions = {
+      properties: ['openFile', 'multiSelections'],
+      filters: [{ name: 'Images', extensions: ORCA_BACKGROUND_DIALOG_EXTENSIONS }]
+    }
+    const picked = parent
+      ? await dialog.showOpenDialog(parent, options)
+      : await dialog.showOpenDialog(options)
+    return importOrcaBackgroundImages(picked.canceled ? [] : picked.filePaths)
+  })
+  ipcMain.handle('backgrounds:openLibrary', () => openOrcaBackgroundLibrary())
+  ipcMain.handle('backgrounds:loadImage', (_event, fileName: unknown) =>
+    loadOrcaBackgroundImage(fileName)
+  )
+}

--- a/src/main/ipc/orca-background-library.ts
+++ b/src/main/ipc/orca-background-library.ts
@@ -15,6 +15,7 @@ import type {
 
 const ORCA_BACKGROUND_LIBRARY_DIR_NAME = 'backgrounds'
 const ORCA_BACKGROUND_MAX_BYTES = 12 * 1024 * 1024
+const ORCA_BACKGROUND_MAX_BYTES_BIGINT = BigInt(ORCA_BACKGROUND_MAX_BYTES)
 const ORCA_BACKGROUND_MIME_BY_EXTENSION: Readonly<Record<string, string>> = {
   '.png': 'image/png',
   '.jpg': 'image/jpeg',
@@ -53,27 +54,42 @@ type ValidatedImageReadResult =
   | { ok: true; data: Uint8Array; mimeType: string; size: number }
   | { ok: false; reason: 'too-large' | 'read-failed' }
 
-async function readValidatedImage(pathValue: string): Promise<ValidatedImageReadResult> {
+async function readValidatedImage(
+  pathValue: string,
+  rejectHardLinks = false
+): Promise<ValidatedImageReadResult> {
   const mimeType = mimeTypeForFileName(pathValue)
   if (!mimeType) {
     return { ok: false, reason: 'read-failed' }
   }
   let handle
   try {
-    const initialStats = await lstat(pathValue)
-    if (!initialStats.isFile() || initialStats.isSymbolicLink() || initialStats.size === 0) {
+    const initialStats = await lstat(pathValue, { bigint: true })
+    if (
+      !initialStats.isFile() ||
+      initialStats.isSymbolicLink() ||
+      initialStats.size === 0n ||
+      (rejectHardLinks && initialStats.nlink !== 1n)
+    ) {
       return { ok: false, reason: 'read-failed' }
     }
-    if (initialStats.size > ORCA_BACKGROUND_MAX_BYTES) {
+    if (initialStats.size > ORCA_BACKGROUND_MAX_BYTES_BIGINT) {
       return { ok: false, reason: 'too-large' }
     }
-    // O_NOFOLLOW closes the lstat/open race on Unix; the lstat check rejects links on Windows.
+    // O_NOFOLLOW rejects Unix links; handle identity closes the Windows lstat/open race.
     handle = await open(pathValue, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0))
-    const stats = await handle.stat()
-    if (!stats.isFile() || stats.size === 0) {
+    const stats = await handle.stat({ bigint: true })
+    if (
+      stats.dev !== initialStats.dev ||
+      stats.ino !== initialStats.ino ||
+      (process.platform === 'win32' && stats.ino === 0n)
+    ) {
       return { ok: false, reason: 'read-failed' }
     }
-    if (stats.size > ORCA_BACKGROUND_MAX_BYTES) {
+    if (!stats.isFile() || stats.size === 0n || (rejectHardLinks && stats.nlink !== 1n)) {
+      return { ok: false, reason: 'read-failed' }
+    }
+    if (stats.size > ORCA_BACKGROUND_MAX_BYTES_BIGINT) {
       return { ok: false, reason: 'too-large' }
     }
     const data = await handle.readFile()
@@ -115,7 +131,7 @@ export async function listOrcaBackgroundLibrary(
       continue
     }
     const path = join(dir, entry.name)
-    const inspected = await readValidatedImage(path)
+    const inspected = await readValidatedImage(path, true)
     if (inspected.ok) {
       images.push({ fileName: entry.name, path, size: inspected.size })
     }
@@ -210,7 +226,7 @@ export async function loadOrcaBackgroundImage(
   if (stats.size > ORCA_BACKGROUND_MAX_BYTES) {
     return { ok: false, reason: 'too-large' }
   }
-  const image = await readValidatedImage(path)
+  const image = await readValidatedImage(path, true)
   if (!image.ok) {
     return image
   }

--- a/src/main/ipc/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers.test.ts
@@ -15,6 +15,7 @@ const {
   registerNotificationHandlersMock,
   registerDeveloperPermissionHandlersMock,
   registerComputerUsePermissionHandlersMock,
+  registerOrcaBackgroundLibraryHandlersMock,
   registerSettingsHandlersMock,
   registerKeybindingHandlersMock,
   registerTelemetryHandlersMock,
@@ -80,6 +81,7 @@ const {
   registerNotificationHandlersMock: vi.fn(),
   registerDeveloperPermissionHandlersMock: vi.fn(),
   registerComputerUsePermissionHandlersMock: vi.fn(),
+  registerOrcaBackgroundLibraryHandlersMock: vi.fn(),
   registerSettingsHandlersMock: vi.fn(),
   registerKeybindingHandlersMock: vi.fn(),
   registerTelemetryHandlersMock: vi.fn(),
@@ -216,6 +218,10 @@ vi.mock('./developer-permissions', () => ({
 
 vi.mock('./computer-use-permissions', () => ({
   registerComputerUsePermissionHandlers: registerComputerUsePermissionHandlersMock
+}))
+
+vi.mock('./orca-background-library', () => ({
+  registerOrcaBackgroundLibraryHandlers: registerOrcaBackgroundLibraryHandlersMock
 }))
 
 vi.mock('./settings', () => ({
@@ -401,6 +407,7 @@ describe('registerCoreHandlers', () => {
     registerNotificationHandlersMock.mockReset()
     registerDeveloperPermissionHandlersMock.mockReset()
     registerComputerUsePermissionHandlersMock.mockReset()
+    registerOrcaBackgroundLibraryHandlersMock.mockReset()
     registerSettingsHandlersMock.mockReset()
     registerKeybindingHandlersMock.mockReset()
     registerTelemetryHandlersMock.mockReset()
@@ -524,6 +531,7 @@ describe('registerCoreHandlers', () => {
     expect(registerNotificationHandlersMock).toHaveBeenCalledWith(store, runtime)
     expect(registerDeveloperPermissionHandlersMock).toHaveBeenCalled()
     expect(registerComputerUsePermissionHandlersMock).toHaveBeenCalled()
+    expect(registerOrcaBackgroundLibraryHandlersMock).toHaveBeenCalled()
     expect(registerDashboardPopoutHandlersMock).toHaveBeenCalledWith(store, undefined)
     expect(registerTerminalPreviewHandlersMock).toHaveBeenCalledWith(runtime)
     expect(registerSettingsHandlersMock).toHaveBeenCalledWith(store, agentAwakeService)

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -52,6 +52,7 @@ import { registerUIHandlers, setTrustedUIRendererWebContentsId } from './ui'
 import { registerEmulatorFrameStreamHandlers } from './emulator-frame-stream'
 import { registerEmulatorVideoStreamHandlers } from './emulator-video-stream'
 import { registerSpeechHandlers } from './speech'
+import { registerOrcaBackgroundLibraryHandlers } from './orca-background-library'
 import { registerTerminalRenderDesyncEvidenceHandler } from './terminal-render-desync-evidence'
 import { registerOrcaProfileHandlers } from './orca-profiles'
 import { registerCodexAccountHandlers } from './codex-accounts'
@@ -174,6 +175,7 @@ export function registerCoreHandlers(
   registerDiagnosticsHandlers()
   registerTerminalRenderDesyncEvidenceHandler()
   registerComputerUsePermissionHandlers()
+  registerOrcaBackgroundLibraryHandlers()
   registerSettingsHandlers(store, agentAwakeService)
   registerSkillsHandlers(store, runtime)
   if (automations) {

--- a/src/main/persistence-settings-update.test.ts
+++ b/src/main/persistence-settings-update.test.ts
@@ -93,6 +93,45 @@ describe('Store', () => {
     expect(updated.branchPrefix).toBe('git-username')
   })
 
+  it('normalizes custom background settings on load and update', async () => {
+    writeDataFile({
+      settings: {
+        orcaBackgroundByArea: {
+          terminal: 'terminal.png',
+          leftSidebar: '../outside.png'
+        },
+        orcaBackgroundOpacity: 2,
+        orcaBackgroundBlurByArea: { terminal: 60 },
+        orcaBackgroundFit: 'invalid',
+        orcaBackgroundAreas: { terminal: false, leftSidebar: true }
+      } as never
+    })
+    const store = await createStore()
+
+    expect(store.getSettings()).toMatchObject({
+      orcaBackgroundByArea: { terminal: 'terminal.png', leftSidebar: null },
+      orcaBackgroundOpacity: 1,
+      orcaBackgroundBlurByArea: { terminal: 40 },
+      orcaBackgroundFit: 'cover',
+      orcaBackgroundAreas: {
+        terminal: false,
+        leftSidebar: true,
+        rightSidebar: false
+      }
+    })
+
+    const updated = store.updateSettings({
+      orcaBackgroundOpacityByArea: { terminal: -1, rightSidebar: 0.75 },
+      orcaBackgroundBlur: -4
+    })
+    expect(updated.orcaBackgroundOpacityByArea).toEqual({ terminal: 0, rightSidebar: 0.75 })
+    expect(updated.orcaBackgroundBlur).toBe(0)
+    expect(updated.orcaBackgroundByArea).toEqual({
+      terminal: 'terminal.png',
+      leftSidebar: null
+    })
+  })
+
   it('persists the agent skill sharing capability as an exact boolean', async () => {
     const store = await createStore()
 

--- a/src/main/persistence/applying-settings/settings-update.ts
+++ b/src/main/persistence/applying-settings/settings-update.ts
@@ -37,6 +37,10 @@ import {
   buildWorkspaceDirHistoryForUpdate,
   stripRetiredGlobalSettings
 } from './terminal-settings-migrations'
+import {
+  normalizeOrcaBackgroundSettingsUpdate,
+  ORCA_BACKGROUND_SETTING_KEYS
+} from '../../../shared/orca-background-settings'
 
 export type SettingsMutationOperations = {
   state: StoreOwnedPersistedState
@@ -160,6 +164,12 @@ export function updateSettings(
   }
   if ('uiLanguage' in updates) {
     sanitizedUpdates.uiLanguage = normalizeUiLanguage(updates.uiLanguage)
+  }
+  if (ORCA_BACKGROUND_SETTING_KEYS.some((key) => Object.hasOwn(updates, key))) {
+    Object.assign(
+      sanitizedUpdates,
+      normalizeOrcaBackgroundSettingsUpdate(updates, operations.state.settings)
+    )
   }
   if ('prBotAuthorOverrides' in updates) {
     // Why: every writer (desktop IPC, web RPC, migrations) hits this boundary, so the persisted list stays bounded and well-formed.

--- a/src/main/persistence/loading-store/store.ts
+++ b/src/main/persistence/loading-store/store.ts
@@ -122,6 +122,7 @@ import { hasWorktreeRemovalRepoOwnerOnOtherHost } from '../../worktree-removal-r
 import { isPathInsideOrEqual } from '../../../shared/cross-platform-path'
 import { normalizeTerminalQuickCommands } from '../../../shared/terminal-quick-commands'
 import { normalizeTaskProviderSettings } from '../../../shared/task-providers'
+import { normalizeOrcaBackgroundSettings } from '../../../shared/orca-background-settings'
 import { normalizeAutoRenameBranchFromWorkDefaultOn } from '../../../shared/auto-rename-branch-from-work-settings'
 import {
   addMobilePairingCustomAddress,
@@ -1202,6 +1203,7 @@ export class Store {
             ...defaults.settings,
             // Why (#7977): keep persisted experimentalNewWorktreeCardStyle:true — v1.4.130's onboarding auto-wrote it as a plain boolean, so it's indistinguishable from a real opt-in; only the default changed.
             ...stripRetiredGlobalSettings(parsed.settings),
+            ...normalizeOrcaBackgroundSettings(parsed.settings),
             worktreeVisibilityDefaults: migratedExternalVisibility.defaults,
             prBotAuthorOverrides: normalizePRBotAuthorOverrides(
               parsed.settings?.prBotAuthorOverrides

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -35,6 +35,7 @@ import type { JiraApi } from './api/jira-api'
 import type { LinearApi } from './api/linear-api'
 import type { MobileApi } from './api/mobile-api'
 import type { NativeChatApi } from './api/native-chat-api'
+import type { OrcaBackgroundApi } from './api/orca-background-api'
 import type { OnboardingApi, StarNagApi } from './api/onboarding-api'
 import type { OrcaProfileApi } from './api/orca-profile-api'
 import type {
@@ -93,6 +94,7 @@ export type PreloadApi = {
   telemetryTrack: TelemetryApi['telemetryTrack']
   telemetrySetOptIn: TelemetryApi['telemetrySetOptIn']
   diagnostics: DiagnosticsApi
+  backgrounds: OrcaBackgroundApi
   telemetryGetConsentState: TelemetryApi['telemetryGetConsentState']
   telemetryAcknowledgeBanner: TelemetryApi['telemetryAcknowledgeBanner']
   settings: SettingsApi

--- a/src/preload/api/orca-background-api.ts
+++ b/src/preload/api/orca-background-api.ts
@@ -1,0 +1,21 @@
+import type {
+  OrcaBackgroundImageLoadResult,
+  OrcaBackgroundImportResult,
+  OrcaBackgroundLibrary,
+  OrcaBackgroundOpenLibraryResult
+} from '../../shared/orca-background-library-types'
+
+export type OrcaBackgroundApi = {
+  listLibrary: () => Promise<OrcaBackgroundLibrary>
+  addImages: () => Promise<OrcaBackgroundImportResult>
+  openLibrary: () => Promise<OrcaBackgroundOpenLibraryResult>
+  loadImage: (fileName: string) => Promise<OrcaBackgroundImageLoadResult>
+}
+
+export type {
+  OrcaBackgroundImageLoadResult,
+  OrcaBackgroundImportResult,
+  OrcaBackgroundLibrary,
+  OrcaBackgroundLibraryImage,
+  OrcaBackgroundOpenLibraryResult
+} from '../../shared/orca-background-library-types'

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2,6 +2,7 @@
 import { contextBridge, ipcRenderer, webFrame, webUtils } from 'electron'
 import { electronAPI } from '@electron-toolkit/preload'
 import { preloadE2EConfig } from './e2e-config'
+import { createOrcaBackgroundApi } from './orca-background-api'
 import { glApi } from './gitlab'
 import type { AppIdentity } from '../shared/app-identity'
 import type { MacCapturedDigitRowChord } from '../shared/macos-symbolic-hotkeys'
@@ -2109,6 +2110,8 @@ const api = {
     deleteBundle: (ticketId: string): Promise<void> =>
       ipcRenderer.invoke('diagnostics:deleteBundle', ticketId)
   },
+
+  backgrounds: createOrcaBackgroundApi(ipcRenderer),
 
   settings: {
     get: (): Promise<unknown> => ipcRenderer.invoke('settings:get'),

--- a/src/preload/orca-background-api.test.ts
+++ b/src/preload/orca-background-api.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createOrcaBackgroundApi } from './orca-background-api'
+
+describe('Orca background preload API', () => {
+  it('keeps filesystem operations on dedicated IPC channels', async () => {
+    const invoke = vi.fn().mockResolvedValue(undefined)
+    const api = createOrcaBackgroundApi({ invoke } as never)
+
+    await api.listLibrary()
+    await api.addImages()
+    await api.openLibrary()
+    await api.loadImage('scene.png')
+
+    expect(invoke.mock.calls).toEqual([
+      ['backgrounds:listLibrary'],
+      ['backgrounds:addImages'],
+      ['backgrounds:openLibrary'],
+      ['backgrounds:loadImage', 'scene.png']
+    ])
+  })
+})

--- a/src/preload/orca-background-api.ts
+++ b/src/preload/orca-background-api.ts
@@ -1,0 +1,13 @@
+import type { IpcRenderer } from 'electron'
+import type { OrcaBackgroundApi } from './api/orca-background-api'
+
+type OrcaBackgroundIpc = Pick<IpcRenderer, 'invoke'>
+
+export function createOrcaBackgroundApi(ipcRenderer: OrcaBackgroundIpc): OrcaBackgroundApi {
+  return {
+    listLibrary: () => ipcRenderer.invoke('backgrounds:listLibrary'),
+    addImages: () => ipcRenderer.invoke('backgrounds:addImages'),
+    openLibrary: () => ipcRenderer.invoke('backgrounds:openLibrary'),
+    loadImage: (fileName) => ipcRenderer.invoke('backgrounds:loadImage', fileName)
+  }
+}

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -20,6 +20,7 @@ import {
   hasCustomTitleBar
 } from './app-shell/app-window-chrome'
 import { useAppChromeLayout } from './app-shell/use-app-chrome-layout'
+import { useAppearanceBackgroundRuntime } from './app-shell/use-appearance-background-runtime'
 import { useAppSessionPersistence } from './app-shell/use-app-session-persistence'
 import { useAppShellServices } from './app-shell/use-app-shell-services'
 import { useAppStartupHydration } from './app-shell/use-app-startup-hydration'
@@ -47,6 +48,7 @@ function App(): React.JSX.Element {
   useRuntimeGraphSync()
   usePersistedUIWriter()
   useDocumentAppearance()
+  useAppearanceBackgroundRuntime()
   useWindowVisibilityEffects()
   useGlobalKeybindings({ layout, floatingWorkspace })
 

--- a/src/renderer/src/app-shell/use-appearance-background-runtime.ts
+++ b/src/renderer/src/app-shell/use-appearance-background-runtime.ts
@@ -1,0 +1,24 @@
+import { useEffect, useRef } from 'react'
+
+import { AppearanceBackgroundRuntime } from '@/lib/appearance-background-runtime'
+import { useAppStore } from '@/store'
+
+export function useAppearanceBackgroundRuntime(): void {
+  const settings = useAppStore((state) => state.settings)
+  const runtimeRef = useRef<AppearanceBackgroundRuntime | null>(null)
+
+  useEffect(() => {
+    const runtime = new AppearanceBackgroundRuntime(document.documentElement)
+    runtimeRef.current = runtime
+    return () => {
+      if (runtimeRef.current === runtime) {
+        runtimeRef.current = null
+      }
+      runtime.dispose()
+    }
+  }, [])
+
+  useEffect(() => {
+    runtimeRef.current?.apply(settings)
+  }, [settings])
+}

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -129,7 +129,8 @@
 
 /* ── Light Mode ──────────────────────────────────────── */
 
-:root {
+:root,
+.theme-light {
   --app-font-family: 'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   --font-sans: var(--app-font-family);
   --font-mono:
@@ -710,6 +711,54 @@
   height: 100dvh;
   width: 100vw;
   overflow: hidden;
+}
+
+[data-orca-background-relative] {
+  position: relative;
+}
+
+[data-orca-background-area] {
+  isolation: isolate;
+}
+
+[data-orca-background-area='terminal'] {
+  --orca-background-area-image: var(--orca-background-terminal-image);
+  --orca-background-area-opacity: var(--orca-background-terminal-opacity, 0.35);
+  --orca-background-area-blur: var(--orca-background-terminal-blur, 0px);
+  --orca-background-area-scale: var(--orca-background-terminal-scale, 1);
+}
+
+[data-orca-background-area='left-sidebar'] {
+  --orca-background-area-image: var(--orca-background-left-sidebar-image);
+  --orca-background-area-opacity: var(--orca-background-left-sidebar-opacity, 0.35);
+  --orca-background-area-blur: var(--orca-background-left-sidebar-blur, 0px);
+  --orca-background-area-scale: var(--orca-background-left-sidebar-scale, 1);
+}
+
+[data-orca-background-area='right-sidebar'] {
+  --orca-background-area-image: var(--orca-background-right-sidebar-image);
+  --orca-background-area-opacity: var(--orca-background-right-sidebar-opacity, 0.35);
+  --orca-background-area-blur: var(--orca-background-right-sidebar-blur, 0px);
+  --orca-background-area-scale: var(--orca-background-right-sidebar-scale, 1);
+}
+
+html[data-orca-background-areas~='terminal'] [data-orca-background-area='terminal']::before,
+html[data-orca-background-areas~='left-sidebar'] [data-orca-background-area='left-sidebar']::before,
+html[data-orca-background-areas~='right-sidebar']
+  [data-orca-background-area='right-sidebar']::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background-image: var(--orca-background-area-image);
+  background-position: center;
+  background-repeat: var(--orca-background-repeat, no-repeat);
+  background-size: var(--orca-background-size, cover);
+  opacity: var(--orca-background-area-opacity);
+  filter: blur(var(--orca-background-area-blur));
+  transform: scale(var(--orca-background-area-scale));
+  transform-origin: center;
 }
 
 /* Why: native windows have a stable content box and need no wake-time viewport reflow. */

--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -151,7 +151,8 @@ function RightSidebarInner(): React.JSX.Element {
     >
       {/* Panel content area */}
       <div
-        className="flex flex-col flex-1 min-w-0 bg-sidebar overflow-hidden"
+        data-orca-background-area="right-sidebar"
+        className="relative flex flex-col flex-1 min-w-0 bg-sidebar overflow-hidden"
         style={{
           borderLeft: rightSidebarOpen ? '1px solid var(--sidebar-border)' : 'none'
         }}

--- a/src/renderer/src/components/settings/AppearanceBackgroundImageSelector.tsx
+++ b/src/renderer/src/components/settings/AppearanceBackgroundImageSelector.tsx
@@ -1,0 +1,121 @@
+import type React from 'react'
+import { useEffect, useState } from 'react'
+import { ChevronLeft, ChevronRight, ImageIcon } from 'lucide-react'
+
+import type { OrcaBackgroundLibraryImage } from '../../../../shared/orca-background-library-types'
+import { browserBackgroundImageObjectUrls } from '../../lib/background-image-object-url'
+import { Button } from '../ui/button'
+import { createAppearancePreviewBackgroundObjectUrl } from './appearance-preview-background'
+import { translate } from '@/i18n/i18n'
+
+type AppearanceBackgroundImageSelectorProps = {
+  images: readonly OrcaBackgroundLibraryImage[]
+  selectedImage: string | null
+  onSelect: (fileName: string) => void
+}
+
+function useSelectedBackgroundThumbnail(fileName: string | null): string | null {
+  const [objectUrl, setObjectUrl] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    let ownedUrl: string | null = null
+    setObjectUrl(null)
+    if (!fileName) {
+      return
+    }
+
+    void createAppearancePreviewBackgroundObjectUrl(fileName).then((nextUrl) => {
+      if (!nextUrl) {
+        return
+      }
+      ownedUrl = nextUrl
+      if (cancelled) {
+        browserBackgroundImageObjectUrls.revoke(nextUrl)
+      } else {
+        setObjectUrl(nextUrl)
+      }
+    })
+
+    return () => {
+      cancelled = true
+      if (ownedUrl) {
+        browserBackgroundImageObjectUrls.revoke(ownedUrl)
+      }
+    }
+  }, [fileName])
+
+  return objectUrl
+}
+
+export function AppearanceBackgroundImageSelector({
+  images,
+  selectedImage,
+  onSelect
+}: AppearanceBackgroundImageSelectorProps): React.JSX.Element | null {
+  const selectedIndex = images.findIndex((image) => image.fileName === selectedImage)
+  const thumbnailUrl = useSelectedBackgroundThumbnail(selectedImage)
+  if (!selectedImage) {
+    return null
+  }
+
+  const canNavigate = images.length > 1 && selectedIndex !== -1
+  const selectOffset = (offset: number): void => {
+    const nextIndex = (selectedIndex + offset + images.length) % images.length
+    const nextImage = images[nextIndex]
+    if (nextImage) {
+      onSelect(nextImage.fileName)
+    }
+  }
+
+  return (
+    <div className="flex items-center justify-center gap-2" aria-live="polite">
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        disabled={!canNavigate}
+        aria-label={translate(
+          'auto.components.settings.AppearanceBackgroundSection.previousImage',
+          'Previous background image'
+        )}
+        onClick={() => selectOffset(-1)}
+      >
+        <ChevronLeft className="size-4" aria-hidden="true" />
+      </Button>
+      <div className="flex w-24 flex-col items-center gap-1.5">
+        <div className="flex size-20 items-center justify-center overflow-hidden rounded-lg border border-border bg-muted">
+          {thumbnailUrl ? (
+            <img
+              src={thumbnailUrl}
+              alt={translate(
+                'auto.components.settings.AppearanceBackgroundSection.imagePreview',
+                'Preview of {{value0}}',
+                { value0: selectedImage }
+              )}
+              className="size-full object-cover"
+            />
+          ) : (
+            <ImageIcon className="size-5 text-muted-foreground" aria-hidden="true" />
+          )}
+        </div>
+        <span className="w-full truncate text-center font-mono text-[11px] text-muted-foreground">
+          {selectedImage}
+        </span>
+      </div>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        disabled={!canNavigate}
+        aria-label={translate(
+          'auto.components.settings.AppearanceBackgroundSection.nextImage',
+          'Next background image'
+        )}
+        onClick={() => selectOffset(1)}
+      >
+        <ChevronRight className="size-4" aria-hidden="true" />
+      </Button>
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/AppearanceBackgroundSection.test.tsx
+++ b/src/renderer/src/components/settings/AppearanceBackgroundSection.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment happy-dom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { I18nextProvider } from 'react-i18next'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getDefaultSettings } from '../../../../shared/constants'
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import { i18n } from '@/i18n/i18n'
+import { TooltipProvider } from '../ui/tooltip'
+import { AppearanceBackgroundSection } from './AppearanceBackgroundSection'
+
+const listLibrary = vi.fn()
+const addImages = vi.fn()
+const openLibrary = vi.fn()
+
+function settingsWith(background: Record<string, unknown> = {}): GlobalSettings {
+  return { ...getDefaultSettings('/tmp'), ...background } as GlobalSettings
+}
+
+function renderSection(
+  settings: GlobalSettings = settingsWith(),
+  updateSettings = vi.fn()
+): ReturnType<typeof render> & { updateSettings: typeof updateSettings } {
+  const result = render(
+    <I18nextProvider i18n={i18n}>
+      <TooltipProvider>
+        <AppearanceBackgroundSection settings={settings} updateSettings={updateSettings} />
+      </TooltipProvider>
+    </I18nextProvider>
+  )
+  return { ...result, updateSettings }
+}
+
+describe('AppearanceBackgroundSection', () => {
+  beforeEach(() => {
+    listLibrary.mockResolvedValue({
+      dir: '/backgrounds',
+      images: [
+        { fileName: 'left.png', path: '/backgrounds/left.png', size: 10 },
+        { fileName: 'terminal.png', path: '/backgrounds/terminal.png', size: 20 }
+      ]
+    })
+    addImages.mockResolvedValue({
+      dir: '/backgrounds',
+      images: [{ fileName: 'new.png', path: '/backgrounds/new.png', size: 30 }],
+      added: ['new.png'],
+      skipped: []
+    })
+    openLibrary.mockResolvedValue({ ok: true })
+    ;(window as unknown as { api: unknown }).api = {
+      backgrounds: { listLibrary, addImages, openLibrary }
+    }
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+    delete (window as unknown as { api?: unknown }).api
+  })
+
+  it('selects a distinct image for each background area', async () => {
+    const { updateSettings } = renderSection()
+    await screen.findByRole('button', { name: 'left.png' })
+
+    const target = screen.getByRole('radiogroup', { name: 'Background target' })
+    fireEvent.click(target.querySelectorAll<HTMLButtonElement>('[role="radio"]')[1])
+    fireEvent.click(screen.getByRole('button', { name: 'left.png' }))
+
+    expect(updateSettings).toHaveBeenCalledWith({
+      orcaBackgroundByArea: { leftSidebar: 'left.png' },
+      orcaBackgroundAreas: { terminal: true, leftSidebar: true, rightSidebar: false }
+    })
+  })
+
+  it('resets opacity and blur only for the selected area', async () => {
+    const { updateSettings } = renderSection(
+      settingsWith({
+        orcaBackgroundOpacityByArea: { terminal: 0.4, rightSidebar: 0.7 },
+        orcaBackgroundBlurByArea: { terminal: 5, rightSidebar: 12 }
+      })
+    )
+    await screen.findByRole('button', { name: 'left.png' })
+
+    const target = screen.getByRole('radiogroup', { name: 'Background effects target' })
+    fireEvent.click(target.querySelectorAll<HTMLButtonElement>('[role="radio"]')[2])
+    fireEvent.click(screen.getByRole('button', { name: 'Reset background effects' }))
+
+    expect(updateSettings).toHaveBeenCalledWith({
+      orcaBackgroundOpacityByArea: { terminal: 0.4, rightSidebar: 1 },
+      orcaBackgroundBlurByArea: { terminal: 5, rightSidebar: 0 }
+    })
+  })
+
+  it('shows the selected thumbnail and cycles through the managed library', async () => {
+    const { updateSettings } = renderSection(
+      settingsWith({
+        orcaBackgroundByArea: { terminal: 'left.png' },
+        orcaBackgroundAreas: { terminal: true, leftSidebar: false, rightSidebar: false }
+      })
+    )
+    await screen.findByText('left.png', { selector: 'span' })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next background image' }))
+
+    expect(updateSettings).toHaveBeenCalledWith({
+      orcaBackgroundByArea: { terminal: 'terminal.png' },
+      orcaBackgroundAreas: { terminal: true, leftSidebar: false, rightSidebar: false }
+    })
+  })
+
+  it('adds an image to the active area and opens the managed folder', async () => {
+    const { updateSettings } = renderSection()
+    await screen.findByRole('button', { name: 'left.png' })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Image' }))
+    await waitFor(() => expect(addImages).toHaveBeenCalledOnce())
+    await waitFor(() =>
+      expect(updateSettings).toHaveBeenCalledWith({
+        orcaBackgroundByArea: { terminal: 'new.png' },
+        orcaBackgroundAreas: { terminal: true, leftSidebar: false, rightSidebar: false }
+      })
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open Backgrounds Folder' }))
+    expect(openLibrary).toHaveBeenCalledOnce()
+  })
+})

--- a/src/renderer/src/components/settings/AppearanceBackgroundSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceBackgroundSection.tsx
@@ -1,0 +1,286 @@
+import type React from 'react'
+import { useState } from 'react'
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import { Button } from '../ui/button'
+import { SettingsRow, SettingsSegmentedControl, SettingsSwitchRow } from './SettingsFormControls'
+import { AppearanceBackgroundSlider } from './AppearanceBackgroundSlider'
+import { AppearanceBackgroundImageSelector } from './AppearanceBackgroundImageSelector'
+import {
+  asBackgroundSettingsUpdate,
+  getAppearanceBackgroundAreaOptions,
+  getAppearanceBackgroundFitOptions,
+  getAppearanceBackgroundSearchEntry,
+  resolveAppearanceBackgroundAreas,
+  resolveAppearanceBackgroundImage,
+  resolveAppearanceBackgroundNumber
+} from './appearance-background-section-model'
+import type { AppearanceBackgroundArea } from './appearance-background-section-model'
+import { useAppearanceBackgroundLibrary } from './use-appearance-background-library'
+import { translate } from '@/i18n/i18n'
+import { cn } from '@/lib/utils'
+export function AppearanceBackgroundSection({
+  settings,
+  updateSettings
+}: {
+  settings: GlobalSettings
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+}): React.JSX.Element {
+  const [imageArea, setImageArea] = useState<AppearanceBackgroundArea>('terminal')
+  const [effectsArea, setEffectsArea] = useState<AppearanceBackgroundArea>('terminal')
+  const areaOptions = getAppearanceBackgroundAreaOptions()
+  const areas = resolveAppearanceBackgroundAreas(settings)
+  const byArea = settings.orcaBackgroundByArea ?? {}
+  const opacityByArea = settings.orcaBackgroundOpacityByArea ?? {}
+  const blurByArea = settings.orcaBackgroundBlurByArea ?? {}
+  const selectedImage = resolveAppearanceBackgroundImage(settings, imageArea)
+  const opacity = resolveAppearanceBackgroundNumber(
+    opacityByArea,
+    settings.orcaBackgroundOpacity,
+    effectsArea,
+    0.35,
+    1
+  )
+  const blur = resolveAppearanceBackgroundNumber(
+    blurByArea,
+    settings.orcaBackgroundBlur,
+    effectsArea,
+    0,
+    40
+  )
+  const fit = settings.orcaBackgroundFit ?? 'cover'
+  const updateAreaImage = (fileName: string | null): void => {
+    updateSettings(
+      asBackgroundSettingsUpdate({
+        orcaBackgroundByArea: { ...byArea, [imageArea]: fileName },
+        orcaBackgroundAreas: { ...areas, [imageArea]: fileName !== null }
+      })
+    )
+  }
+  const { library, busy, addImages, openLibrary } = useAppearanceBackgroundLibrary(updateAreaImage)
+  return (
+    <div className="space-y-3">
+      <SettingsRow
+        alignTop
+        label={getAppearanceBackgroundSearchEntry().title}
+        description={getAppearanceBackgroundSearchEntry().description}
+        control={
+          <div className="flex flex-wrap justify-end gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={busy}
+              onClick={() => void addImages()}
+            >
+              {translate(
+                'auto.components.settings.AppearanceBackgroundSection.addImage',
+                'Add Image'
+              )}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={!library.dir}
+              onClick={() => void openLibrary()}
+            >
+              {translate(
+                'auto.components.settings.AppearanceBackgroundSection.openFolder',
+                'Open Backgrounds Folder'
+              )}
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={!selectedImage}
+              onClick={() => updateAreaImage(null)}
+            >
+              {translate(
+                'auto.components.settings.AppearanceBackgroundSection.clearArea',
+                'Clear Area'
+              )}
+            </Button>
+          </div>
+        }
+      />
+
+      <SettingsRow
+        label={translate(
+          'auto.components.settings.AppearanceBackgroundSection.backgroundFor',
+          'Background for'
+        )}
+        description={translate(
+          'auto.components.settings.AppearanceBackgroundSection.backgroundForDescription',
+          'Choose an area, then select its image. Each area can use a different image.'
+        )}
+        control={
+          <SettingsSegmentedControl
+            size="sm"
+            ariaLabel={translate(
+              'auto.components.settings.AppearanceBackgroundSection.backgroundTarget',
+              'Background target'
+            )}
+            value={imageArea}
+            onChange={setImageArea}
+            options={areaOptions}
+          />
+        }
+      />
+
+      <div className="flex max-w-full gap-2 overflow-x-auto pb-1" aria-live="polite">
+        {library.images.map((image) => (
+          <Button
+            key={image.fileName}
+            type="button"
+            variant={selectedImage === image.fileName ? 'secondary' : 'outline'}
+            size="sm"
+            aria-pressed={selectedImage === image.fileName}
+            className={cn(
+              'max-w-48 shrink-0 truncate font-mono text-[11px]',
+              selectedImage === image.fileName
+                ? 'ring-1 ring-ring'
+                : 'text-muted-foreground hover:text-foreground'
+            )}
+            onClick={() => updateAreaImage(image.fileName)}
+          >
+            {image.fileName}
+          </Button>
+        ))}
+      </div>
+      {library.images.length === 0 ? (
+        <p className="font-mono text-[11px] text-muted-foreground">
+          {translate(
+            'auto.components.settings.AppearanceBackgroundSection.empty',
+            'No images yet. Add an image from your computer.'
+          )}
+        </p>
+      ) : null}
+      <AppearanceBackgroundImageSelector
+        images={library.images}
+        selectedImage={selectedImage}
+        onSelect={updateAreaImage}
+      />
+
+      <div className="divide-y divide-border/40">
+        {areaOptions.map((area) => (
+          <SettingsSwitchRow
+            key={area.value}
+            label={area.label}
+            description={area.description}
+            checked={areas[area.value]}
+            onChange={() =>
+              updateSettings(
+                asBackgroundSettingsUpdate({
+                  orcaBackgroundAreas: { ...areas, [area.value]: !areas[area.value] }
+                })
+              )
+            }
+          />
+        ))}
+      </div>
+
+      <SettingsRow
+        label={translate(
+          'auto.components.settings.AppearanceBackgroundSection.effectsFor',
+          'Effects for'
+        )}
+        description={translate(
+          'auto.components.settings.AppearanceBackgroundSection.effectsDescription',
+          'Adjust opacity and blur for the selected area.'
+        )}
+        control={
+          <div className="flex items-center gap-2">
+            <SettingsSegmentedControl
+              size="sm"
+              ariaLabel={translate(
+                'auto.components.settings.AppearanceBackgroundSection.effectsTarget',
+                'Background effects target'
+              )}
+              value={effectsArea}
+              onChange={setEffectsArea}
+              options={areaOptions}
+            />
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={opacity === 1 && blur === 0}
+              aria-label={translate(
+                'auto.components.settings.AppearanceBackgroundSection.resetEffects',
+                'Reset background effects'
+              )}
+              onClick={() =>
+                updateSettings(
+                  asBackgroundSettingsUpdate({
+                    orcaBackgroundOpacityByArea: { ...opacityByArea, [effectsArea]: 1 },
+                    orcaBackgroundBlurByArea: { ...blurByArea, [effectsArea]: 0 }
+                  })
+                )
+              }
+            >
+              {translate('auto.components.settings.AppearanceBackgroundSection.reset', 'Reset')}
+            </Button>
+          </div>
+        }
+      />
+
+      <AppearanceBackgroundSlider
+        label={translate('auto.components.settings.AppearanceBackgroundSection.opacity', 'Opacity')}
+        description={translate(
+          'auto.components.settings.AppearanceBackgroundSection.opacityDescription',
+          'How strongly the image shows through. Lower keeps text readable.'
+        )}
+        value={opacity}
+        min={0}
+        max={1}
+        step={0.01}
+        onChange={(next) =>
+          updateSettings(
+            asBackgroundSettingsUpdate({
+              orcaBackgroundOpacityByArea: { ...opacityByArea, [effectsArea]: next }
+            })
+          )
+        }
+      />
+      <AppearanceBackgroundSlider
+        label={translate('auto.components.settings.AppearanceBackgroundSection.blur', 'Blur')}
+        description={translate(
+          'auto.components.settings.AppearanceBackgroundSection.blurDescription',
+          'Softens the image so it does not compete with text.'
+        )}
+        value={blur}
+        min={0}
+        max={40}
+        step={1}
+        suffix="px"
+        onChange={(next) =>
+          updateSettings(
+            asBackgroundSettingsUpdate({
+              orcaBackgroundBlurByArea: { ...blurByArea, [effectsArea]: next }
+            })
+          )
+        }
+      />
+
+      <SettingsRow
+        label={translate('auto.components.settings.AppearanceBackgroundSection.fit', 'Fit')}
+        description={translate(
+          'auto.components.settings.AppearanceBackgroundSection.fitDescription',
+          'How the image is scaled. Applied to every background area.'
+        )}
+        control={
+          <SettingsSegmentedControl
+            size="sm"
+            ariaLabel={translate('auto.components.settings.AppearanceBackgroundSection.fit', 'Fit')}
+            value={fit}
+            onChange={(orcaBackgroundFit) =>
+              updateSettings(asBackgroundSettingsUpdate({ orcaBackgroundFit }))
+            }
+            options={getAppearanceBackgroundFitOptions()}
+          />
+        }
+      />
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/AppearanceBackgroundSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceBackgroundSection.tsx
@@ -17,6 +17,10 @@ import {
 import type { AppearanceBackgroundArea } from './appearance-background-section-model'
 import { useAppearanceBackgroundLibrary } from './use-appearance-background-library'
 import { translate } from '@/i18n/i18n'
+import {
+  APPEARANCE_BACKGROUND_BLUR_PX_RANGE,
+  APPEARANCE_BACKGROUND_OPACITY_RANGE
+} from '@/lib/appearance-background-settings'
 import { cn } from '@/lib/utils'
 export function AppearanceBackgroundSection({
   settings,
@@ -38,14 +42,14 @@ export function AppearanceBackgroundSection({
     settings.orcaBackgroundOpacity,
     effectsArea,
     0.35,
-    1
+    APPEARANCE_BACKGROUND_OPACITY_RANGE.max
   )
   const blur = resolveAppearanceBackgroundNumber(
     blurByArea,
     settings.orcaBackgroundBlur,
     effectsArea,
-    0,
-    40
+    APPEARANCE_BACKGROUND_BLUR_PX_RANGE.min,
+    APPEARANCE_BACKGROUND_BLUR_PX_RANGE.max
   )
   const fit = settings.orcaBackgroundFit ?? 'cover'
   const updateAreaImage = (fileName: string | null): void => {
@@ -205,7 +209,10 @@ export function AppearanceBackgroundSection({
               type="button"
               variant="outline"
               size="sm"
-              disabled={opacity === 1 && blur === 0}
+              disabled={
+                opacity === APPEARANCE_BACKGROUND_OPACITY_RANGE.max &&
+                blur === APPEARANCE_BACKGROUND_BLUR_PX_RANGE.min
+              }
               aria-label={translate(
                 'auto.components.settings.AppearanceBackgroundSection.resetEffects',
                 'Reset background effects'
@@ -213,8 +220,14 @@ export function AppearanceBackgroundSection({
               onClick={() =>
                 updateSettings(
                   asBackgroundSettingsUpdate({
-                    orcaBackgroundOpacityByArea: { ...opacityByArea, [effectsArea]: 1 },
-                    orcaBackgroundBlurByArea: { ...blurByArea, [effectsArea]: 0 }
+                    orcaBackgroundOpacityByArea: {
+                      ...opacityByArea,
+                      [effectsArea]: APPEARANCE_BACKGROUND_OPACITY_RANGE.max
+                    },
+                    orcaBackgroundBlurByArea: {
+                      ...blurByArea,
+                      [effectsArea]: APPEARANCE_BACKGROUND_BLUR_PX_RANGE.min
+                    }
                   })
                 )
               }
@@ -232,8 +245,8 @@ export function AppearanceBackgroundSection({
           'How strongly the image shows through. Lower keeps text readable.'
         )}
         value={opacity}
-        min={0}
-        max={1}
+        min={APPEARANCE_BACKGROUND_OPACITY_RANGE.min}
+        max={APPEARANCE_BACKGROUND_OPACITY_RANGE.max}
         step={0.01}
         onChange={(next) =>
           updateSettings(
@@ -250,8 +263,8 @@ export function AppearanceBackgroundSection({
           'Softens the image so it does not compete with text.'
         )}
         value={blur}
-        min={0}
-        max={40}
+        min={APPEARANCE_BACKGROUND_BLUR_PX_RANGE.min}
+        max={APPEARANCE_BACKGROUND_BLUR_PX_RANGE.max}
         step={1}
         suffix="px"
         onChange={(next) =>

--- a/src/renderer/src/components/settings/AppearanceBackgroundSlider.tsx
+++ b/src/renderer/src/components/settings/AppearanceBackgroundSlider.tsx
@@ -1,0 +1,65 @@
+import type React from 'react'
+
+import { Label } from '../ui/label'
+import { Slider } from '../ui/slider'
+
+type AppearanceBackgroundSliderProps = {
+  label: string
+  description: string
+  value: number
+  min: number
+  max: number
+  step: number
+  suffix?: string
+  onChange: (value: number) => void
+}
+
+function formatValue(value: number): string {
+  return Number.isInteger(value)
+    ? String(value)
+    : value.toFixed(2).replace(/0+$/, '').replace(/\.$/, '')
+}
+
+export function AppearanceBackgroundSlider({
+  label,
+  description,
+  value,
+  min,
+  max,
+  step,
+  suffix = '',
+  onChange
+}: AppearanceBackgroundSliderProps): React.JSX.Element {
+  return (
+    <div className="rounded-md border border-border/60 bg-background/50 p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 space-y-0.5">
+          <Label className="text-xs font-medium">{label}</Label>
+          <p className="text-[11px] leading-4 text-muted-foreground">{description}</p>
+        </div>
+        <span className="shrink-0 rounded-md border border-border/50 bg-muted/40 px-1.5 py-0.5 font-mono text-[11px] tabular-nums text-foreground">
+          {formatValue(value)}
+          {suffix}
+        </span>
+      </div>
+      <Slider
+        className="mt-3"
+        min={min}
+        max={max}
+        step={step}
+        value={[value]}
+        thumbLabels={[label]}
+        thumbValueLabels={[`${formatValue(value)}${suffix}`]}
+        onValueChange={([next]) => {
+          if (next !== undefined) {
+            onChange(next)
+          }
+        }}
+      />
+      <div className="mt-1 flex justify-between font-mono text-[10px] text-muted-foreground">
+        <span>{formatValue(min)}</span>
+        <span>{formatValue(max)}</span>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/AppearanceInterfaceSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceInterfaceSection.tsx
@@ -37,7 +37,6 @@ import { usePluginLanguagePacks } from '@/store/plugin-language-packs'
 type AppearanceInterfaceSectionProps = {
   settings: GlobalSettings
   updateSettings: (updates: Partial<GlobalSettings>) => void
-  applyTheme: (theme: 'system' | 'dark' | 'light') => void
   fontSuggestions: string[]
   isDesktopMac: boolean
   isDesktopWindows: boolean
@@ -48,7 +47,6 @@ type AppearanceInterfaceSectionProps = {
 export function AppearanceInterfaceSection({
   settings,
   updateSettings,
-  applyTheme,
   fontSuggestions,
   isDesktopMac,
   isDesktopWindows,
@@ -90,10 +88,7 @@ export function AppearanceInterfaceSection({
             <SettingsSegmentedControl
               ariaLabel={themeLabel}
               value={settings.theme}
-              onChange={(option) => {
-                updateSettings({ theme: option })
-                applyTheme(option)
-              }}
+              onChange={(option) => updateSettings({ theme: option })}
               options={[
                 {
                   value: 'system',
@@ -166,6 +161,10 @@ export function AppearanceInterfaceSection({
               {translate(
                 'auto.components.settings.AppearancePane.ef89200c1f',
                 'when not in a terminal pane.'
+              )}{' '}
+              {translate(
+                'auto.components.settings.AppearanceInterfaceSection.zoomAppliesImmediately',
+                'Applies immediately.'
               )}
             </>
           }

--- a/src/renderer/src/components/settings/AppearancePane.test.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.test.tsx
@@ -47,6 +47,10 @@ vi.mock('./TerminalAppearanceSection', () => ({
   TerminalAppearanceSection: () => null
 }))
 
+vi.mock('./AppearancePreviewColumn', () => ({
+  AppearancePreviewColumn: () => <div data-testid="appearance-preview" />
+}))
+
 vi.mock('../ui/select', async () => {
   const React = await import('react')
 
@@ -103,41 +107,16 @@ import { TooltipProvider } from '../ui/tooltip'
 
 const mountedRoots: Root[] = []
 
-function createGhosttyStub() {
-  return {
-    loading: false,
-    preview: null,
-    error: null,
-    open: vi.fn(),
-    close: vi.fn(),
-    refresh: vi.fn(),
-    apply: vi.fn()
-  }
-}
-
-function createWarpThemesStub() {
-  return {
-    open: false,
-    preview: null,
-    loading: false,
-    desktopOnly: false,
-    applyError: null,
-    importSignal: 0,
-    selectedThemeIds: new Set<string>(),
-    handleClick: vi.fn(),
-    handlePreviewSource: vi.fn(),
-    handleToggleTheme: vi.fn(),
-    handleToggleAll: vi.fn(),
-    handleApply: vi.fn(),
-    handleOpenChange: vi.fn()
-  }
-}
-
 async function renderAppearancePane(
   settings: GlobalSettings,
   updateSettings: (updates: Partial<GlobalSettings>) => void = vi.fn(),
   options: {
+    changeCount?: number
+    discardChanges?: () => void
     onRequestFontSuggestions?: () => void
+    saveChanges?: () => Promise<boolean>
+    saveFailed?: boolean
+    saving?: boolean
   } = {}
 ): Promise<HTMLDivElement> {
   const container = document.createElement('div')
@@ -152,13 +131,15 @@ async function renderAppearancePane(
           <AppearancePane
             settings={settings}
             updateSettings={updateSettings}
-            applyTheme={vi.fn()}
+            changeCount={options.changeCount ?? 0}
+            saving={options.saving ?? false}
+            saveFailed={options.saveFailed ?? false}
+            saveChanges={options.saveChanges ?? vi.fn().mockResolvedValue(true)}
+            discardChanges={options.discardChanges ?? vi.fn()}
             fontSuggestions={[]}
             terminalFontSuggestions={[]}
             onRequestFontSuggestions={options.onRequestFontSuggestions}
             systemPrefersDark={false}
-            ghostty={createGhosttyStub() as never}
-            warpThemes={createWarpThemesStub() as never}
           />
         </TooltipProvider>
       </I18nextProvider>
@@ -182,12 +163,14 @@ async function rerenderAppearancePane(
           <AppearancePane
             settings={settings}
             updateSettings={vi.fn()}
-            applyTheme={vi.fn()}
+            changeCount={0}
+            saving={false}
+            saveFailed={false}
+            saveChanges={vi.fn().mockResolvedValue(undefined)}
+            discardChanges={vi.fn()}
             fontSuggestions={[]}
             terminalFontSuggestions={[]}
             systemPrefersDark={false}
-            ghostty={createGhosttyStub() as never}
-            warpThemes={createWarpThemesStub() as never}
           />
         </TooltipProvider>
       </I18nextProvider>
@@ -197,7 +180,7 @@ async function rerenderAppearancePane(
 
 function appearanceSectionToggle(
   container: HTMLElement,
-  sectionId: 'interface' | 'terminal' | 'window'
+  sectionId: 'interface' | 'terminal' | 'window' | 'background'
 ): HTMLButtonElement | undefined {
   return Array.from(container.querySelectorAll<HTMLButtonElement>('button[aria-expanded]')).find(
     (button) => button.getAttribute('aria-controls') === `appearance-section-${sectionId}`
@@ -256,6 +239,34 @@ describe('AppearancePane', () => {
     expect(
       container.querySelector('button[role="switch"][aria-label="Titlebar App Name"]')
     ).toBeNull()
+  })
+
+  it('renders the fixed preview and applies or discards the visible draft', async () => {
+    mocks.state.settingsSearchQuery = ''
+    const saveChanges = vi.fn().mockResolvedValue(undefined)
+    const discardChanges = vi.fn()
+    const container = await renderAppearancePane(getDefaultSettings('/tmp'), vi.fn(), {
+      changeCount: 2,
+      discardChanges,
+      saveChanges
+    })
+    const buttons = Array.from(container.querySelectorAll<HTMLButtonElement>('button'))
+    const saveButton = buttons.find((button) => button.textContent === 'Save')
+    const discardButton = buttons.find((button) => button.textContent === 'Discard')
+
+    expect(container.querySelector('[data-testid="appearance-preview"]')).not.toBeNull()
+    expect(
+      container.querySelector('[data-testid="appearance-preview"]')?.parentElement?.className
+    ).toContain('lg:grid-cols-[minmax(0,1fr)_18rem]')
+    expect(container.textContent).toContain('2 unsaved changes')
+
+    await act(async () => {
+      saveButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      discardButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(saveChanges).toHaveBeenCalledOnce()
+    expect(discardChanges).toHaveBeenCalledOnce()
   })
 
   it('keeps Advanced closed when searching for language', async () => {
@@ -393,13 +404,14 @@ describe('AppearancePane', () => {
     expect(mocks.state.setWorktreeCardMode).toHaveBeenCalledWith('Compact')
   })
 
-  it('renders the three top-level section rows and no Code & Markdown row when not searching', async () => {
+  it('renders the four top-level section rows and no Code & Markdown row when not searching', async () => {
     mocks.state.settingsSearchQuery = ''
     const container = await renderAppearancePane(getDefaultSettings('/tmp'))
 
     expect(container.textContent).toContain('Interface')
     expect(container.textContent).toContain('Terminal')
     expect(container.textContent).toContain('Window & Sidebar')
+    expect(container.textContent).toContain('Background Image')
     // Code & Markdown is intentionally omitted — Orca has no Appearance-level
     // code/markdown settings, so the row would be empty.
     expect(container.textContent).not.toContain('Code & Markdown')
@@ -576,7 +588,7 @@ describe('AppearancePane', () => {
     expect(mocks.state.toggleStatusBarItem).toHaveBeenCalledWith('antigravity')
   })
 
-  it('expands Interface, Terminal, and Window & Sidebar by default', async () => {
+  it('expands all appearance sections by default', async () => {
     mocks.state.settingsSearchQuery = ''
     const container = await renderAppearancePane(getDefaultSettings('/tmp'))
 
@@ -584,10 +596,11 @@ describe('AppearancePane', () => {
       container.querySelectorAll<HTMLButtonElement>('button[aria-expanded="true"]')
     ).filter((button) => button.getAttribute('aria-controls')?.startsWith('appearance-section-'))
 
-    expect(expanded).toHaveLength(3)
+    expect(expanded).toHaveLength(4)
     expect(expanded.map((button) => button.textContent).join(' ')).toContain('Interface')
     expect(expanded.map((button) => button.textContent).join(' ')).toContain('Terminal')
     expect(expanded.map((button) => button.textContent).join(' ')).toContain('Window & Sidebar')
+    expect(expanded.map((button) => button.textContent).join(' ')).toContain('Background Image')
   })
 
   it('lets each appearance section collapse independently', async () => {
@@ -608,10 +621,13 @@ describe('AppearancePane', () => {
       container.querySelectorAll<HTMLButtonElement>('button[aria-expanded="true"]')
     ).filter((button) => button.getAttribute('aria-controls')?.startsWith('appearance-section-'))
 
-    expect(stillExpanded).toHaveLength(2)
+    expect(stillExpanded).toHaveLength(3)
     expect(stillExpanded.map((button) => button.textContent).join(' ')).toContain('Interface')
     expect(stillExpanded.map((button) => button.textContent).join(' ')).toContain(
       'Window & Sidebar'
+    )
+    expect(stillExpanded.map((button) => button.textContent).join(' ')).toContain(
+      'Background Image'
     )
   })
 

--- a/src/renderer/src/components/settings/AppearancePane.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.tsx
@@ -1,6 +1,6 @@
 import type React from 'react'
 import { useLayoutEffect, useState } from 'react'
-import { AppWindow, PanelLeft, TerminalSquare } from 'lucide-react'
+import { AppWindow, ImageIcon, PanelLeft, TerminalSquare } from 'lucide-react'
 
 import type { GlobalSettings } from '../../../../shared/global-settings-types'
 
@@ -27,9 +27,14 @@ import {
 } from './appearance-search'
 import { getTerminalAppearanceSearchEntries } from './terminal-search'
 import { TerminalAppearanceSection } from './TerminalAppearanceSection'
-import type { UseGhosttyImportReturn } from './useGhosttyImport'
-import type { UseWarpThemeImportReturn } from './useWarpThemeImport'
+import { getInitialTerminalThemeTarget, type TerminalThemeTarget } from './TerminalThemeSections'
+import { useGhosttyImport } from './useGhosttyImport'
+import { useWarpThemeImport } from './useWarpThemeImport'
 import { AppIconSelector } from './AppIconSelector'
+import { AppearancePreviewColumn } from './AppearancePreviewColumn'
+import { AppearanceSaveBar } from './AppearanceSaveBar'
+import { AppearanceBackgroundSection } from './AppearanceBackgroundSection'
+import { getAppearanceBackgroundSearchEntry } from './appearance-background-section-model'
 import { normalizeAppIconId } from '../../../../shared/app-icon'
 import { getRendererAppPlatform } from '@/lib/renderer-app-platform'
 import { isWebClientLocation } from '@/lib/web-client-location'
@@ -45,33 +50,38 @@ export { getAppearancePaneSearchEntries }
 type AppearancePaneProps = {
   settings: GlobalSettings
   updateSettings: (updates: Partial<GlobalSettings>) => void
-  applyTheme: (theme: 'system' | 'dark' | 'light') => void
+  changeCount: number
+  saving: boolean
+  saveFailed: boolean
+  saveChanges: () => Promise<boolean>
+  discardChanges: () => void
   fontSuggestions: string[]
   terminalFontSuggestions: string[]
   onRequestFontSuggestions?: () => void
   systemPrefersDark: boolean
-  ghostty: UseGhosttyImportReturn
-  warpThemes: UseWarpThemeImportReturn
 }
 
-type AppearanceSectionKey = 'interface' | 'terminal' | 'window'
+type AppearanceSectionKey = 'interface' | 'terminal' | 'window' | 'background'
 
 const ALL_APPEARANCE_SECTIONS = [
   'interface',
   'terminal',
-  'window'
+  'window',
+  'background'
 ] as const satisfies readonly AppearanceSectionKey[]
 
 export function AppearancePane({
   settings,
   updateSettings,
-  applyTheme,
+  changeCount,
+  saving,
+  saveFailed,
+  saveChanges,
+  discardChanges,
   fontSuggestions,
   terminalFontSuggestions,
   onRequestFontSuggestions,
-  systemPrefersDark,
-  ghostty,
-  warpThemes
+  systemPrefersDark
 }: AppearancePaneProps): React.JSX.Element {
   const searchQuery = useAppStore((state) => state.settingsSearchQuery)
   const appearanceAccordionDeepLink = useAppStore((state) => state.appearanceAccordionDeepLink)
@@ -84,6 +94,12 @@ export function AppearancePane({
   // browser web client has no local tray to control.
   const isDesktopWindows = getRendererAppPlatform() === 'win32' && !isWebClient
   const isDesktopMac = getRendererAppPlatform() === 'darwin' && !isWebClient
+  const ghostty = useGhosttyImport(updateSettings, settings)
+  const warpThemes = useWarpThemeImport(updateSettings, settings)
+  const [terminalPreviewMode, setTerminalPreviewMode] = useState<TerminalThemeTarget>(() =>
+    getInitialTerminalThemeTarget(settings, systemPrefersDark)
+  )
+  const [previewFontFamily, setPreviewFontFamily] = useState<string | null>(null)
 
   // Why: Terminal / Window settings were too easy to miss when only Interface
   // started open; keep sections independently collapsible but expanded by default.
@@ -133,6 +149,11 @@ export function AppearancePane({
     'auto.components.settings.AppearancePane.windowSidebarSummary',
     'Sidebar, status bar, and file explorer'
   )
+  const backgroundEntry = getAppearanceBackgroundSearchEntry()
+  const backgroundSummary = translate(
+    'auto.components.settings.AppearancePane.backgroundSummary',
+    'Images, opacity, blur, and fit'
+  )
 
   // Search-entry buckets per section so a query can force-open the matching one.
   const interfaceSearchEntries = [
@@ -164,6 +185,7 @@ export function AppearancePane({
   const interfaceMatches = matchesSettingsSearch(searchQuery, interfaceSearchEntries)
   const terminalMatches = matchesSettingsSearch(searchQuery, terminalSearchEntries)
   const windowMatches = matchesSettingsSearch(searchQuery, windowSearchEntries)
+  const backgroundMatches = !isWebClient && matchesSettingsSearch(searchQuery, backgroundEntry)
   const interfaceLabelMatches = matchesSettingsSearch(searchQuery, { title: interfaceTitle })
   const terminalLabelMatches = matchesSettingsSearch(searchQuery, { title: terminalTitle })
   const windowLabelMatches = matchesSettingsSearch(searchQuery, {
@@ -177,11 +199,16 @@ export function AppearancePane({
   // independent open/closed state (all expanded by default).
   function isSectionOpen(key: AppearanceSectionKey): boolean {
     if (isSearching) {
-      return key === 'interface'
-        ? interfaceMatches
-        : key === 'terminal'
-          ? terminalMatches
-          : windowMatches
+      if (key === 'interface') {
+        return interfaceMatches
+      }
+      if (key === 'terminal') {
+        return terminalMatches
+      }
+      if (key === 'window') {
+        return windowMatches
+      }
+      return backgroundMatches
     }
     return openSections.has(key)
   }
@@ -205,99 +232,131 @@ export function AppearancePane({
   } · ${settings.terminalFontSize}px`
 
   return (
-    <div className="space-y-2.5">
-      {interfaceMatches ? (
-        <AppearanceSection
-          id="interface"
-          icon={<AppWindow aria-hidden="true" />}
-          title={interfaceTitle}
-          summary={interfaceSummary}
-          open={isSectionOpen('interface')}
-          onToggle={() => toggleSection('interface')}
-          toggleDisabled={isSearching}
-        >
-          <AppearanceInterfaceSection
-            settings={settings}
-            updateSettings={updateSettings}
-            applyTheme={applyTheme}
-            fontSuggestions={fontSuggestions}
-            onRequestFontSuggestions={onRequestFontSuggestions}
-            isDesktopMac={isDesktopMac}
-            isDesktopWindows={isDesktopWindows}
-            forceVisiblePrimary={interfaceLabelMatches}
-          />
-        </AppearanceSection>
-      ) : null}
+    <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_18rem] lg:items-start xl:grid-cols-[minmax(0,1fr)_20rem]">
+      <div className="min-w-0">
+        <AppearanceSaveBar
+          changeCount={changeCount}
+          saving={saving}
+          saveFailed={saveFailed}
+          onSave={saveChanges}
+          onDiscard={discardChanges}
+        />
+        <div className="space-y-2.5">
+          {interfaceMatches ? (
+            <AppearanceSection
+              id="interface"
+              icon={<AppWindow aria-hidden="true" />}
+              title={interfaceTitle}
+              summary={interfaceSummary}
+              open={isSectionOpen('interface')}
+              onToggle={() => toggleSection('interface')}
+              toggleDisabled={isSearching}
+            >
+              <AppearanceInterfaceSection
+                settings={settings}
+                updateSettings={updateSettings}
+                fontSuggestions={fontSuggestions}
+                onRequestFontSuggestions={onRequestFontSuggestions}
+                isDesktopMac={isDesktopMac}
+                isDesktopWindows={isDesktopWindows}
+                forceVisiblePrimary={interfaceLabelMatches}
+              />
+            </AppearanceSection>
+          ) : null}
 
-      {/* Why: Code & Markdown is intentionally omitted. Orca has no Appearance-level
-          code/markdown settings — the Monaco editor reuses the terminal font and
-          there is no markdown-style or line-number setting — so a fourth row would
-          be empty. We surface only the three sections that hold real controls
-          rather than fabricate settings. */}
+          {/* Code & Markdown is omitted because it has no Appearance-level settings. */}
 
-      {terminalMatches ? (
-        <AppearanceSection
-          id="terminal"
-          icon={<TerminalSquare aria-hidden="true" />}
-          title={terminalTitle}
-          summary={terminalSummary}
-          open={isSectionOpen('terminal')}
-          onToggle={() => toggleSection('terminal')}
-          toggleDisabled={isSearching}
-        >
-          <TerminalAppearanceSection
-            settings={settings}
-            updateSettings={updateSettings}
-            systemPrefersDark={systemPrefersDark}
-            terminalFontSuggestions={terminalFontSuggestions}
-            onRequestFontSuggestions={onRequestFontSuggestions}
-            ghostty={ghostty}
-            warpThemes={warpThemes}
-            forceVisiblePrimary={terminalLabelMatches}
-          />
-        </AppearanceSection>
-      ) : null}
+          {terminalMatches ? (
+            <AppearanceSection
+              id="terminal"
+              icon={<TerminalSquare aria-hidden="true" />}
+              title={terminalTitle}
+              summary={terminalSummary}
+              open={isSectionOpen('terminal')}
+              onToggle={() => toggleSection('terminal')}
+              toggleDisabled={isSearching}
+            >
+              <TerminalAppearanceSection
+                settings={settings}
+                updateSettings={updateSettings}
+                systemPrefersDark={systemPrefersDark}
+                terminalFontSuggestions={terminalFontSuggestions}
+                onRequestFontSuggestions={onRequestFontSuggestions}
+                ghostty={ghostty}
+                warpThemes={warpThemes}
+                showPreview={false}
+                previewThemeTarget={terminalPreviewMode}
+                onPreviewThemeTargetChange={setTerminalPreviewMode}
+                onPreviewFontFamilyChange={setPreviewFontFamily}
+                hasUnsavedChanges={changeCount > 0}
+                forceVisiblePrimary={terminalLabelMatches}
+              />
+            </AppearanceSection>
+          ) : null}
 
-      {windowMatches ? (
-        <AppearanceSection
-          id="window"
-          icon={<PanelLeft aria-hidden="true" />}
-          title={windowSidebarTitle}
-          summary={windowSidebarSummary}
-          open={isSectionOpen('window')}
-          onToggle={() => toggleSection('window')}
-          toggleDisabled={isSearching}
-        >
-          <AppearanceWindowSidebarSection
-            settings={settings}
-            updateSettings={updateSettings}
-            forceVisiblePrimary={windowLabelMatches}
-          />
-        </AppearanceSection>
-      ) : null}
+          {windowMatches ? (
+            <AppearanceSection
+              id="window"
+              icon={<PanelLeft aria-hidden="true" />}
+              title={windowSidebarTitle}
+              summary={windowSidebarSummary}
+              open={isSectionOpen('window')}
+              onToggle={() => toggleSection('window')}
+              toggleDisabled={isSearching}
+            >
+              <AppearanceWindowSidebarSection
+                settings={settings}
+                updateSettings={updateSettings}
+                forceVisiblePrimary={windowLabelMatches}
+              />
+            </AppearanceSection>
+          ) : null}
 
-      {/* App icon stays at the bottom of Appearance as a small easter egg,
+          {backgroundMatches ? (
+            <AppearanceSection
+              id="background"
+              icon={<ImageIcon aria-hidden="true" />}
+              title={backgroundEntry.title}
+              summary={backgroundSummary}
+              open={isSectionOpen('background')}
+              onToggle={() => toggleSection('background')}
+              toggleDisabled={isSearching}
+            >
+              <AppearanceBackgroundSection settings={settings} updateSettings={updateSettings} />
+            </AppearanceSection>
+          ) : null}
+
+          {/* App icon stays at the bottom of Appearance as a small easter egg,
           matching production — not buried inside Interface advanced. */}
-      {appIconMatches ? (
-        <SearchableSetting
-          title={translate('auto.components.settings.AppearancePane.ca1590d42f', 'App Icon')}
-          description={translate(
-            'auto.components.settings.AppearancePane.0cd9b8228f',
-            'Choose the app icon shown in the Dock and window switcher.'
-          )}
-          keywords={getAppIconEntries().flatMap((entry) => [
-            entry.title,
-            entry.description ?? '',
-            ...(entry.keywords ?? [])
-          ])}
-          className="max-w-none px-1 pt-2"
-        >
-          <AppIconSelector
-            value={normalizeAppIconId(settings.appIcon)}
-            onChange={(appIcon) => updateSettings({ appIcon })}
-          />
-        </SearchableSetting>
-      ) : null}
+          {appIconMatches ? (
+            <SearchableSetting
+              title={translate('auto.components.settings.AppearancePane.ca1590d42f', 'App Icon')}
+              description={translate(
+                'auto.components.settings.AppearancePane.0cd9b8228f',
+                'Choose the app icon shown in the Dock and window switcher.'
+              )}
+              keywords={getAppIconEntries().flatMap((entry) => [
+                entry.title,
+                entry.description ?? '',
+                ...(entry.keywords ?? [])
+              ])}
+              className="max-w-none px-1 pt-2"
+            >
+              <AppIconSelector
+                value={normalizeAppIconId(settings.appIcon)}
+                onChange={(appIcon) => updateSettings({ appIcon })}
+              />
+            </SearchableSetting>
+          ) : null}
+        </div>
+      </div>
+      <AppearancePreviewColumn
+        settings={settings}
+        systemPrefersDark={systemPrefersDark}
+        previewFontFamily={previewFontFamily}
+        terminalPreviewMode={terminalPreviewMode}
+        onTerminalPreviewModeChange={setTerminalPreviewMode}
+      />
     </div>
   )
 }

--- a/src/renderer/src/components/settings/AppearancePreviewColumn.test.tsx
+++ b/src/renderer/src/components/settings/AppearancePreviewColumn.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment happy-dom
+
+import '@testing-library/jest-dom/vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import type { StatusBarItem } from '../../../../shared/ui-chrome-types'
+
+const mocks = vi.hoisted(() => ({
+  state: {
+    statusBarItems: [] as StatusBarItem[]
+  },
+  terminalRender: vi.fn()
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: typeof mocks.state) => unknown) => selector(mocks.state)
+}))
+
+vi.mock('./TerminalSettingsPreview', () => ({
+  TerminalSettingsPreview: (props: {
+    description: string
+    modeOverride?: 'dark' | 'light'
+    onModeOverrideChange?: (mode: 'dark' | 'light') => void
+    previewFontFamily?: string | null
+    settings: GlobalSettings
+    showThemeToggle?: boolean
+    systemPrefersDark: boolean
+    title: string
+  }) => {
+    mocks.terminalRender(props)
+    return <div data-testid="terminal-preview" data-settings-theme={props.settings.theme} />
+  }
+}))
+
+import { getDefaultSettings } from '../../../../shared/constants'
+import { AppearancePreviewColumn } from './AppearancePreviewColumn'
+
+const onTerminalPreviewModeChange = vi.fn()
+
+function renderPreviewColumn(
+  settings: GlobalSettings,
+  systemPrefersDark: boolean
+): ReturnType<typeof render> {
+  return render(
+    <AppearancePreviewColumn
+      settings={settings}
+      systemPrefersDark={systemPrefersDark}
+      previewFontFamily="JetBrains Mono"
+      terminalPreviewMode="dark"
+      onTerminalPreviewModeChange={onTerminalPreviewModeChange}
+    />
+  )
+}
+
+describe('AppearancePreviewColumn', () => {
+  beforeEach(() => {
+    mocks.state.statusBarItems = []
+    mocks.terminalRender.mockClear()
+    onTerminalPreviewModeChange.mockClear()
+    document.documentElement.className = ''
+  })
+
+  afterEach(() => {
+    cleanup()
+    document.documentElement.className = ''
+  })
+
+  it('scopes the drafted theme without changing the active document theme', () => {
+    document.documentElement.className = 'theme-light'
+    const settings = { ...getDefaultSettings('/tmp'), theme: 'dark' as const }
+
+    renderPreviewColumn(settings, false)
+
+    const previewColumn = screen.getByRole('complementary', { name: 'Appearance preview' })
+    expect(previewColumn).toHaveClass('order-first', 'lg:order-none', 'lg:sticky')
+    expect(screen.getByText('Live preview')).toBeInTheDocument()
+    expect(screen.getByText('Updates as you edit.')).toBeInTheDocument()
+    const themeBoundary = previewColumn.querySelector<HTMLElement>('[data-preview-theme="dark"]')
+    expect(themeBoundary).toHaveClass('dark')
+    expect(themeBoundary).not.toHaveClass('theme-light')
+    expect(document.documentElement).toHaveClass('theme-light')
+    expect(document.documentElement).not.toHaveClass('dark')
+    expect(screen.getByTestId('terminal-preview')).toHaveAttribute('data-settings-theme', 'dark')
+    expect(mocks.terminalRender).toHaveBeenCalledWith(
+      expect.objectContaining({
+        settings,
+        modeOverride: 'dark',
+        onModeOverrideChange: onTerminalPreviewModeChange,
+        previewFontFamily: 'JetBrains Mono',
+        showThemeToggle: true,
+        systemPrefersDark: false
+      })
+    )
+  })
+
+  it('resolves a drafted system theme from the current system preference', () => {
+    const settings = { ...getDefaultSettings('/tmp'), theme: 'system' as const }
+    const { rerender } = renderPreviewColumn(settings, false)
+
+    expect(document.querySelector('[data-preview-theme="light"]')).toHaveClass('theme-light')
+
+    rerender(
+      <AppearancePreviewColumn
+        settings={settings}
+        systemPrefersDark
+        terminalPreviewMode="dark"
+        onTerminalPreviewModeChange={onTerminalPreviewModeChange}
+      />
+    )
+
+    expect(document.querySelector('[data-preview-theme="dark"]')).toHaveClass('dark')
+  })
+
+  it('labels the preview column and reflects status items from the app store', () => {
+    mocks.state.statusBarItems = ['codex', 'resource-usage']
+
+    renderPreviewColumn(getDefaultSettings('/tmp'), false)
+
+    expect(screen.getByRole('complementary', { name: 'Appearance preview' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('img', {
+        name: 'Orca interface preview. Status bar: Codex, Resource usage'
+      })
+    ).toBeInTheDocument()
+    expect(document.querySelector('[data-status-bar-item="codex"]')).not.toBeNull()
+    expect(document.querySelector('[data-status-bar-item="resource-usage"]')).not.toBeNull()
+  })
+})

--- a/src/renderer/src/components/settings/AppearancePreviewColumn.tsx
+++ b/src/renderer/src/components/settings/AppearancePreviewColumn.tsx
@@ -1,0 +1,85 @@
+import type React from 'react'
+
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import { translate } from '@/i18n/i18n'
+import { useAppStore } from '@/store'
+import { AppearanceChromeMock } from './appearance-chrome-mock'
+import { TerminalSettingsPreview } from './TerminalSettingsPreview'
+import type { TerminalThemeTarget } from './TerminalThemeSections'
+
+type AppearancePreviewColumnProps = {
+  settings: GlobalSettings
+  systemPrefersDark: boolean
+  previewFontFamily?: string | null
+  terminalPreviewMode: TerminalThemeTarget
+  onTerminalPreviewModeChange: (mode: TerminalThemeTarget) => void
+}
+
+function resolvePreviewTheme(
+  settings: Pick<GlobalSettings, 'theme'>,
+  systemPrefersDark: boolean
+): 'dark' | 'light' {
+  return settings.theme === 'system' ? (systemPrefersDark ? 'dark' : 'light') : settings.theme
+}
+
+export function AppearancePreviewColumn({
+  settings,
+  systemPrefersDark,
+  previewFontFamily,
+  terminalPreviewMode,
+  onTerminalPreviewModeChange
+}: AppearancePreviewColumnProps): React.JSX.Element {
+  const statusBarItems = useAppStore((state) => state.statusBarItems)
+  const previewTheme = resolvePreviewTheme(settings, systemPrefersDark)
+
+  return (
+    <aside
+      className="order-first w-full shrink-0 scrollbar-sleek lg:order-none lg:sticky lg:top-4 lg:max-h-[calc(100vh-2rem)] lg:self-start lg:overflow-y-auto lg:pr-1"
+      aria-label={translate(
+        'auto.components.settings.AppearancePreviewColumn.label',
+        'Appearance preview'
+      )}
+    >
+      <div className="mb-3 space-y-1">
+        <h3 className="text-sm font-medium">
+          {translate(
+            'auto.components.settings.AppearancePreviewColumn.visibleTitle',
+            'Live preview'
+          )}
+        </h3>
+        <p className="text-xs text-muted-foreground">
+          {translate(
+            'auto.components.settings.AppearancePreviewColumn.visibleDescription',
+            'Updates as you edit.'
+          )}
+        </p>
+      </div>
+      <div
+        className={`${previewTheme === 'dark' ? 'dark' : 'theme-light'} space-y-4 rounded-xl bg-background text-foreground`}
+        data-preview-theme={previewTheme}
+      >
+        <AppearanceChromeMock
+          settings={settings}
+          systemPrefersDark={systemPrefersDark}
+          statusBarItems={statusBarItems}
+        />
+        <TerminalSettingsPreview
+          title={translate(
+            'auto.components.settings.AppearancePreviewColumn.terminalTitle',
+            'Terminal preview'
+          )}
+          description={translate(
+            'auto.components.settings.AppearancePreviewColumn.terminalDraftDescription',
+            'Drafted terminal appearance. Compare dark and light themes.'
+          )}
+          settings={settings}
+          systemPrefersDark={systemPrefersDark}
+          previewFontFamily={previewFontFamily}
+          modeOverride={terminalPreviewMode}
+          onModeOverrideChange={onTerminalPreviewModeChange}
+          showThemeToggle
+        />
+      </div>
+    </aside>
+  )
+}

--- a/src/renderer/src/components/settings/AppearanceSaveBar.test.tsx
+++ b/src/renderer/src/components/settings/AppearanceSaveBar.test.tsx
@@ -55,12 +55,19 @@ describe('AppearanceSaveBar', () => {
     expect(container.textContent).toBe('')
   })
 
-  it('shows the change count and invokes Save and Discard', async () => {
+  it.each([
+    [1, '1 unsaved change'],
+    [2, '2 unsaved changes']
+  ])('pluralizes a count of %i', async (changeCount, label) => {
+    const container = await renderSaveBar({ changeCount })
+
+    expect(container.textContent).toContain(label)
+  })
+
+  it('invokes Save and Discard', async () => {
     const onSave = vi.fn().mockResolvedValue(undefined)
     const onDiscard = vi.fn()
     const container = await renderSaveBar({ changeCount: 2, onSave, onDiscard })
-
-    expect(container.textContent).toContain('2 unsaved changes')
 
     await act(async () => {
       findButton(container, 'Save')?.click()

--- a/src/renderer/src/components/settings/AppearanceSaveBar.test.tsx
+++ b/src/renderer/src/components/settings/AppearanceSaveBar.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { AppearanceSaveBar } from './AppearanceSaveBar'
+
+const mountedRoots: Root[] = []
+
+async function renderSaveBar(
+  props: Partial<React.ComponentProps<typeof AppearanceSaveBar>> = {}
+): Promise<HTMLDivElement> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  mountedRoots.push(root)
+
+  await act(async () => {
+    root.render(
+      <AppearanceSaveBar
+        changeCount={1}
+        saving={false}
+        saveFailed={false}
+        onSave={vi.fn().mockResolvedValue(undefined)}
+        onDiscard={vi.fn()}
+        {...props}
+      />
+    )
+  })
+
+  return container
+}
+
+function findButton(container: ParentNode, label: string): HTMLButtonElement | undefined {
+  return Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(
+    (button) => button.textContent?.trim() === label
+  )
+}
+
+afterEach(async () => {
+  vi.useRealTimers()
+  await act(async () => {
+    for (const root of mountedRoots.splice(0)) {
+      root.unmount()
+    }
+  })
+  document.body.innerHTML = ''
+})
+
+describe('AppearanceSaveBar', () => {
+  it('stays hidden without changes or a save failure', async () => {
+    const container = await renderSaveBar({ changeCount: 0 })
+
+    expect(container.textContent).toBe('')
+  })
+
+  it('shows the change count and invokes Save and Discard', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined)
+    const onDiscard = vi.fn()
+    const container = await renderSaveBar({ changeCount: 2, onSave, onDiscard })
+
+    expect(container.textContent).toContain('2 unsaved changes')
+
+    await act(async () => {
+      findButton(container, 'Save')?.click()
+      findButton(container, 'Discard')?.click()
+    })
+
+    expect(onSave).toHaveBeenCalledOnce()
+    expect(onDiscard).toHaveBeenCalledOnce()
+  })
+
+  it('disables actions immediately and delays the saving indicator', async () => {
+    vi.useFakeTimers()
+    const container = await renderSaveBar({ saving: true })
+
+    expect(findButton(container, 'Save')?.disabled).toBe(true)
+    expect(findButton(container, 'Discard')?.disabled).toBe(true)
+
+    act(() => vi.advanceTimersByTime(749))
+    expect(findButton(container, 'Save')).toBeDefined()
+    expect(container.textContent).not.toContain('Saving…')
+
+    act(() => vi.advanceTimersByTime(1))
+    expect(findButton(container, 'Saving…')?.disabled).toBe(true)
+  })
+
+  it('remains visible with failure guidance when no changes are left', async () => {
+    const container = await renderSaveBar({ changeCount: 0, saveFailed: true })
+
+    expect(container.textContent).toContain('0 unsaved changes')
+    expect(container.textContent).toContain('Appearance settings could not be saved. Try again.')
+    expect(findButton(container, 'Save')?.disabled).toBe(true)
+    expect(findButton(container, 'Discard')?.disabled).toBe(false)
+  })
+})

--- a/src/renderer/src/components/settings/AppearanceSaveBar.tsx
+++ b/src/renderer/src/components/settings/AppearanceSaveBar.tsx
@@ -34,14 +34,11 @@ export function AppearanceSaveBar({
     return null
   }
 
-  const changeLabel =
-    changeCount === 1
-      ? translate('auto.components.settings.AppearanceSaveBar.singleChange', '1 unsaved change')
-      : translate(
-          'auto.components.settings.AppearanceSaveBar.multipleChanges',
-          '{{value0}} unsaved changes',
-          { value0: changeCount }
-        )
+  const changeLabel = translate(
+    'auto.components.settings.AppearanceSaveBar.unsavedChanges',
+    '{{count}} unsaved changes',
+    { count: changeCount }
+  )
 
   return (
     <div className="sticky top-4 z-10 mb-4 flex flex-wrap items-center justify-between gap-3 rounded-xl border border-border bg-card px-4 py-3 shadow-xs">

--- a/src/renderer/src/components/settings/AppearanceSaveBar.tsx
+++ b/src/renderer/src/components/settings/AppearanceSaveBar.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from 'react'
+import { Loader2 } from 'lucide-react'
+
+import { Button } from '../ui/button'
+import { translate } from '@/i18n/i18n'
+
+type AppearanceSaveBarProps = {
+  changeCount: number
+  saving: boolean
+  saveFailed: boolean
+  onSave: () => Promise<unknown>
+  onDiscard: () => void
+}
+
+export function AppearanceSaveBar({
+  changeCount,
+  saving,
+  saveFailed,
+  onSave,
+  onDiscard
+}: AppearanceSaveBarProps): React.JSX.Element | null {
+  const [showSaving, setShowSaving] = useState(false)
+
+  useEffect(() => {
+    if (!saving) {
+      setShowSaving(false)
+      return
+    }
+    const timer = window.setTimeout(() => setShowSaving(true), 750)
+    return () => window.clearTimeout(timer)
+  }, [saving])
+
+  if (changeCount === 0 && !saveFailed) {
+    return null
+  }
+
+  const changeLabel =
+    changeCount === 1
+      ? translate('auto.components.settings.AppearanceSaveBar.singleChange', '1 unsaved change')
+      : translate(
+          'auto.components.settings.AppearanceSaveBar.multipleChanges',
+          '{{value0}} unsaved changes',
+          { value0: changeCount }
+        )
+
+  return (
+    <div className="sticky top-4 z-10 mb-4 flex flex-wrap items-center justify-between gap-3 rounded-xl border border-border bg-card px-4 py-3 shadow-xs">
+      <div className="min-w-0" aria-live="polite">
+        <p className="text-sm font-medium text-card-foreground">{changeLabel}</p>
+        {saveFailed ? (
+          <p className="text-xs text-destructive">
+            {translate(
+              'auto.components.settings.AppearanceSaveBar.saveFailed',
+              'Appearance settings could not be saved. Try again.'
+            )}
+          </p>
+        ) : null}
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        <Button type="button" variant="ghost" size="sm" disabled={saving} onClick={onDiscard}>
+          {translate('auto.components.settings.AppearanceSaveBar.discard', 'Discard')}
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          className="w-24"
+          disabled={saving || changeCount === 0}
+          onClick={() => void onSave().catch(() => undefined)}
+        >
+          {showSaving ? <Loader2 className="size-4 animate-spin" /> : null}
+          {showSaving
+            ? translate('auto.components.settings.AppearanceSaveBar.saving', 'Saving…')
+            : translate('auto.components.settings.AppearanceSaveBar.save', 'Save')}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/AppearanceSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceSection.tsx
@@ -31,6 +31,7 @@ export function AppearanceSection({
   children
 }: AppearanceSectionProps): React.JSX.Element {
   const contentId = `appearance-section-${id}`
+  const toggleId = `${contentId}-toggle`
   return (
     <div
       className={cn(
@@ -39,6 +40,7 @@ export function AppearanceSection({
       )}
     >
       <button
+        id={toggleId}
         type="button"
         aria-expanded={open}
         aria-controls={contentId}
@@ -73,7 +75,7 @@ export function AppearanceSection({
         inert={!open}
       >
         <div className="min-h-0 overflow-hidden">
-          <div id={contentId} role="region" className="px-4 pt-1 pb-4">
+          <div id={contentId} role="region" aria-labelledby={toggleId} className="px-4 pt-1 pb-4">
             {children}
           </div>
         </div>

--- a/src/renderer/src/components/settings/AppearanceUnsavedChangesDialog.test.tsx
+++ b/src/renderer/src/components/settings/AppearanceUnsavedChangesDialog.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { AppearanceUnsavedChangesDialog } from './AppearanceUnsavedChangesDialog'
+
+const mountedRoots: Root[] = []
+
+async function renderDialog(
+  props: Partial<React.ComponentProps<typeof AppearanceUnsavedChangesDialog>> = {}
+): Promise<void> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  mountedRoots.push(root)
+
+  await act(async () => {
+    root.render(
+      <AppearanceUnsavedChangesDialog
+        open
+        saving={false}
+        saveFailed={false}
+        onSave={vi.fn()}
+        onDiscard={vi.fn()}
+        onCancel={vi.fn()}
+        {...props}
+      />
+    )
+  })
+  await act(() => Promise.resolve())
+}
+
+function findButton(label: string): HTMLButtonElement | undefined {
+  return Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
+    (button) => button.textContent?.trim() === label
+  )
+}
+
+afterEach(async () => {
+  vi.useRealTimers()
+  await act(async () => {
+    for (const root of mountedRoots.splice(0)) {
+      root.unmount()
+    }
+  })
+  document.body.innerHTML = ''
+})
+
+describe('AppearanceUnsavedChangesDialog', () => {
+  it('only renders its content while open and focuses Save by default', async () => {
+    await renderDialog({ open: false })
+    expect(document.querySelector('[role="dialog"]')).toBeNull()
+
+    await renderDialog()
+
+    expect(document.querySelector('[role="dialog"]')).not.toBeNull()
+    expect(document.body.textContent).toContain('Unsaved appearance changes')
+    expect(document.body.textContent).toContain('Save the appearance draft before leaving?')
+    expect(document.activeElement).toBe(findButton('Save'))
+  })
+
+  it('invokes Save, Discard, and Cancel from their actions', async () => {
+    const onSave = vi.fn()
+    const onDiscard = vi.fn()
+    const onCancel = vi.fn()
+    await renderDialog({ onSave, onDiscard, onCancel })
+
+    await act(async () => {
+      findButton('Save')?.click()
+      findButton('Discard')?.click()
+      findButton('Cancel')?.click()
+    })
+
+    expect(onSave).toHaveBeenCalledOnce()
+    expect(onDiscard).toHaveBeenCalledOnce()
+    expect(onCancel).toHaveBeenCalledOnce()
+  })
+
+  it('disables every action immediately and delays the saving indicator', async () => {
+    vi.useFakeTimers()
+    await renderDialog({ saving: true })
+
+    expect(findButton('Save')?.disabled).toBe(true)
+    expect(findButton('Discard')?.disabled).toBe(true)
+    expect(findButton('Cancel')?.disabled).toBe(true)
+
+    act(() => vi.advanceTimersByTime(749))
+    expect(findButton('Save')).toBeDefined()
+    expect(document.body.textContent).not.toContain('Saving…')
+
+    act(() => vi.advanceTimersByTime(1))
+    expect(findButton('Saving…')?.disabled).toBe(true)
+  })
+
+  it('keeps the draft recovery message visible after a save failure', async () => {
+    await renderDialog({ saveFailed: true })
+
+    const alert = document.querySelector('[role="alert"]')
+    expect(alert?.textContent).toContain(
+      'Appearance settings could not be saved. The draft is still available.'
+    )
+  })
+})

--- a/src/renderer/src/components/settings/AppearanceUnsavedChangesDialog.tsx
+++ b/src/renderer/src/components/settings/AppearanceUnsavedChangesDialog.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useRef, useState } from 'react'
+import { Loader2 } from 'lucide-react'
+
+import { Button } from '../ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '../ui/dialog'
+import { translate } from '@/i18n/i18n'
+
+type AppearanceUnsavedChangesDialogProps = {
+  open: boolean
+  saving: boolean
+  saveFailed: boolean
+  onSave: () => void
+  onDiscard: () => void
+  onCancel: () => void
+}
+
+export function AppearanceUnsavedChangesDialog({
+  open,
+  saving,
+  saveFailed,
+  onSave,
+  onDiscard,
+  onCancel
+}: AppearanceUnsavedChangesDialogProps): React.JSX.Element {
+  const [showSaving, setShowSaving] = useState(false)
+  const saveButtonRef = useRef<HTMLButtonElement | null>(null)
+
+  useEffect(() => {
+    if (!saving) {
+      setShowSaving(false)
+      return
+    }
+    const timer = window.setTimeout(() => setShowSaving(true), 750)
+    return () => window.clearTimeout(timer)
+  }, [saving])
+
+  return (
+    <Dialog open={open} onOpenChange={(nextOpen) => !nextOpen && !saving && onCancel()}>
+      <DialogContent
+        showCloseButton={false}
+        className="max-w-sm"
+        onOpenAutoFocus={(event) => {
+          event.preventDefault()
+          saveButtonRef.current?.focus()
+        }}
+      >
+        <DialogHeader>
+          <DialogTitle>
+            {translate(
+              'auto.components.settings.AppearanceUnsavedChangesDialog.title',
+              'Unsaved appearance changes'
+            )}
+          </DialogTitle>
+          <DialogDescription>
+            {translate(
+              'auto.components.settings.AppearanceUnsavedChangesDialog.description',
+              'Save the appearance draft before leaving?'
+            )}
+          </DialogDescription>
+        </DialogHeader>
+        {saveFailed ? (
+          <p className="text-sm text-destructive" role="alert">
+            {translate(
+              'auto.components.settings.AppearanceUnsavedChangesDialog.saveFailed',
+              'Appearance settings could not be saved. The draft is still available.'
+            )}
+          </p>
+        ) : null}
+        <DialogFooter className="gap-2">
+          <Button type="button" variant="ghost" size="sm" disabled={saving} onClick={onCancel}>
+            {translate('auto.components.settings.AppearanceUnsavedChangesDialog.cancel', 'Cancel')}
+          </Button>
+          <Button type="button" variant="ghost" size="sm" disabled={saving} onClick={onDiscard}>
+            {translate(
+              'auto.components.settings.AppearanceUnsavedChangesDialog.discard',
+              'Discard'
+            )}
+          </Button>
+          <Button
+            ref={saveButtonRef}
+            type="button"
+            size="sm"
+            className="w-24"
+            disabled={saving}
+            onClick={onSave}
+          >
+            {showSaving ? <Loader2 className="size-4 animate-spin" /> : null}
+            {showSaving
+              ? translate(
+                  'auto.components.settings.AppearanceUnsavedChangesDialog.saving',
+                  'Saving…'
+                )
+              : translate('auto.components.settings.AppearanceUnsavedChangesDialog.save', 'Save')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/src/components/settings/AppearanceWindowSidebarSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceWindowSidebarSection.tsx
@@ -86,6 +86,10 @@ export function AppearanceWindowSidebarSection({
     'auto.components.settings.AppearancePane.statusBarDescription',
     'Choose which indicators appear in the status bar.'
   )
+  const appliesImmediately = translate(
+    'auto.components.settings.AppearanceWindowSidebarSection.appliesImmediately',
+    'Applies immediately.'
+  )
   const statusBarKeywords = ['status bar', 'indicators']
   const statusBarSectionMatches = matchesSettingsSearch(searchQuery, {
     title: statusBarTitle,
@@ -129,7 +133,15 @@ export function AppearanceWindowSidebarSection({
           keywords={statusBarKeywords}
           forceVisible={forceVisiblePrimary || statusBarSectionMatches || statusBarControlMatches}
         >
-          <SettingsRow label={statusBarTitle} description={statusBarDescription} control={null} />
+          <SettingsRow
+            label={statusBarTitle}
+            description={
+              <>
+                {statusBarDescription} {appliesImmediately}
+              </>
+            }
+            control={null}
+          />
           {showStatusBarControls ? (
             <div className="ml-4 divide-y divide-border/40 border-t border-border/40">
               <SearchableSetting
@@ -212,7 +224,11 @@ export function AppearanceWindowSidebarSection({
                   >
                     <SettingsRow
                       label={workspaceCardLayoutEntry.title}
-                      description={workspaceCardLayoutEntry.description}
+                      description={
+                        <>
+                          {workspaceCardLayoutEntry.description} {appliesImmediately}
+                        </>
+                      }
                       control={
                         <SettingsSegmentedControl
                           value={settings.compactWorktreeCards ? 'compact' : 'detailed'}

--- a/src/renderer/src/components/settings/GhosttyImportModal.test.ts
+++ b/src/renderer/src/components/settings/GhosttyImportModal.test.ts
@@ -87,10 +87,10 @@ describe('GhosttyImportModal', () => {
 
     const buttons = findButtons(element)
     expect(buttons.some((b) => b.text === 'Cancel')).toBe(true)
-    expect(buttons.some((b) => b.text === 'Apply Changes')).toBe(true)
+    expect(buttons.some((b) => b.text === 'Add to Draft')).toBe(true)
     expect(buttons.some((b) => b.text === 'Done')).toBe(false)
 
-    const applyButton = buttons.find((b) => b.text === 'Apply Changes')
+    const applyButton = buttons.find((b) => b.text === 'Add to Draft')
     applyButton?.onClick()
     expect(onApply).toHaveBeenCalledTimes(1)
 
@@ -131,13 +131,13 @@ describe('GhosttyImportModal', () => {
       applied: true
     })
 
-    expect(containsText(element, 'Import complete')).toBe(true)
+    expect(containsText(element, 'Added to appearance draft')).toBe(true)
     expect(containsText(element, 'Font Size')).toBe(true)
     expect(containsText(element, 'JetBrains Mono')).toBe(true)
 
     const buttons = findButtons(element)
     expect(buttons.some((b) => b.text === 'Done')).toBe(true)
-    expect(buttons.some((b) => b.text === 'Apply Changes')).toBe(false)
+    expect(buttons.some((b) => b.text === 'Add to Draft')).toBe(false)
     expect(buttons.some((b) => b.text === 'Cancel')).toBe(false)
 
     const doneButton = buttons.find((b) => b.text === 'Done')
@@ -156,7 +156,7 @@ describe('GhosttyImportModal', () => {
     })
 
     expect(containsText(element, 'Loading preview')).toBe(true)
-    expect(findButtons(element).some((b) => b.text === 'Apply Changes')).toBe(false)
+    expect(findButtons(element).some((b) => b.text === 'Add to Draft')).toBe(false)
   })
 
   it('shows no-config message when preview is not found', () => {
@@ -170,7 +170,7 @@ describe('GhosttyImportModal', () => {
     })
 
     expect(containsText(element, 'No Ghostty config found')).toBe(true)
-    expect(findButtons(element).some((b) => b.text === 'Apply Changes')).toBe(false)
+    expect(findButtons(element).some((b) => b.text === 'Add to Draft')).toBe(false)
   })
 
   it('shows already-matched message when diff is empty', () => {
@@ -184,6 +184,6 @@ describe('GhosttyImportModal', () => {
     })
 
     expect(containsText(element, 'No new settings to import')).toBe(true)
-    expect(findButtons(element).some((b) => b.text === 'Apply Changes')).toBe(false)
+    expect(findButtons(element).some((b) => b.text === 'Add to Draft')).toBe(false)
   })
 })

--- a/src/renderer/src/components/settings/GhosttyImportModal.tsx
+++ b/src/renderer/src/components/settings/GhosttyImportModal.tsx
@@ -55,8 +55,8 @@ export function GhosttyImportModal({
           </DialogTitle>
           <DialogDescription className="text-xs">
             {translate(
-              'auto.components.settings.GhosttyImportModal.2763b0c045',
-              'Review the settings that will be imported from your Ghostty config.'
+              'auto.components.settings.GhosttyImportModal.draftDescription',
+              'Review the Ghostty settings to add to your appearance draft.'
             )}
           </DialogDescription>
         </DialogHeader>
@@ -80,10 +80,10 @@ export function GhosttyImportModal({
             )}
             {applied ? (
               <div>
-                <p className="text-xs font-medium text-green-600 mb-1">
+                <p className="mb-1 text-xs font-medium text-status-success">
                   {translate(
-                    'auto.components.settings.GhosttyImportModal.4466f4cdaa',
-                    'Import complete'
+                    'auto.components.settings.GhosttyImportModal.staged',
+                    'Added to appearance draft'
                   )}
                 </p>
                 <ul className="text-xs space-y-1">
@@ -121,7 +121,11 @@ export function GhosttyImportModal({
               </p>
             )}
 
-            {!applied && applyError && <p className="text-xs text-red-500">{applyError}</p>}
+            {!applied && applyError && (
+              <p className="text-xs text-destructive" role="alert">
+                {applyError}
+              </p>
+            )}
 
             {!applied && preview.unsupportedKeys.length > 0 && (
               <div>
@@ -142,7 +146,9 @@ export function GhosttyImportModal({
             )}
           </div>
         ) : preview.error ? (
-          <p className="text-xs text-red-500">{preview.error}</p>
+          <p className="text-xs text-destructive" role="alert">
+            {preview.error}
+          </p>
         ) : (
           <p className="text-xs text-muted-foreground">
             {translate(
@@ -159,14 +165,14 @@ export function GhosttyImportModal({
             </Button>
           ) : (
             <>
-              <Button variant="outline" onClick={() => onOpenChange(false)}>
+              <Button variant="ghost" onClick={() => onOpenChange(false)}>
                 {translate('auto.components.settings.GhosttyImportModal.f96688b6bc', 'Cancel')}
               </Button>
               {hasChanges && (
                 <Button onClick={() => void onApply()}>
                   {translate(
-                    'auto.components.settings.GhosttyImportModal.9d3e56ca36',
-                    'Apply Changes'
+                    'auto.components.settings.GhosttyImportModal.addToDraft',
+                    'Add to Draft'
                   )}
                 </Button>
               )}

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -49,6 +49,12 @@ import {
   runSettingsPageLeaveTransaction,
   runSettingsWindowCloseGuard
 } from './settings-page-leave-transaction'
+import {
+  pinDirtySettingsNavSections,
+  releaseSettledSettingsNavGuard,
+  runSettingsSectionLeaveConfirmation,
+  settleAppearanceSettingsSectionBeforeLeave
+} from './settings-section-navigation'
 import { useAppearanceLeaveDialog } from './use-appearance-leave-dialog'
 import { useAppearanceSettingsDraft } from './use-appearance-settings-draft'
 import { RepositoryPane } from './RepositoryPane'
@@ -578,12 +584,23 @@ function Settings(): React.JSX.Element {
     promptDiscardSourceControlAiPromptChanges
   ])
 
+  const confirmAppearanceSectionLeave = useCallback(
+    (): Promise<boolean> =>
+      settleAppearanceSettingsSectionBeforeLeave({
+        dirty: appearanceHasDraftChanges,
+        confirmLeave: confirmAppearanceLeave,
+        discardDraft: discardAppearanceDraft
+      }),
+    [appearanceHasDraftChanges, confirmAppearanceLeave, discardAppearanceDraft]
+  )
+
   const confirmSectionLeave = useCallback(
     (sectionId: string): Promise<boolean> =>
-      sectionId === 'appearance'
-        ? confirmSettingsPageLeave()
-        : confirmDiscardSourceControlAiPromptChanges(),
-    [confirmDiscardSourceControlAiPromptChanges, confirmSettingsPageLeave]
+      runSettingsSectionLeaveConfirmation(sectionId, {
+        appearance: confirmAppearanceSectionLeave,
+        sourceControl: confirmDiscardSourceControlAiPromptChanges
+      }),
+    [confirmAppearanceSectionLeave, confirmDiscardSourceControlAiPromptChanges]
   )
 
   const closeSettingsPageWithPromptGuard = useCallback(async (): Promise<void> => {
@@ -893,15 +910,17 @@ function Settings(): React.JSX.Element {
       navSections,
       getSettingsSectionSearchEntries
     ).map(({ item }) => item)
-    if (
-      !hasUnsavedSourceControlAiPromptChanges ||
-      rankedSections.some((section) => section.id === 'git')
-    ) {
-      return rankedSections
-    }
-    const gitSection = navSectionById.get('git')
-    return gitSection ? [...rankedSections, gitSection] : rankedSections
-  }, [hasUnsavedSourceControlAiPromptChanges, navSectionById, navSections, settingsSearchQuery])
+    return pinDirtySettingsNavSections(rankedSections, navSectionById, {
+      appearance: appearanceHasDraftChanges,
+      sourceControl: hasUnsavedSourceControlAiPromptChanges
+    })
+  }, [
+    appearanceHasDraftChanges,
+    hasUnsavedSourceControlAiPromptChanges,
+    navSectionById,
+    navSections,
+    settingsSearchQuery
+  ])
   const visibleSectionIds = useMemo(
     () => new Set(visibleNavSections.map((section) => section.id)),
     [visibleNavSections]
@@ -1122,10 +1141,13 @@ function Settings(): React.JSX.Element {
         }
         guardedNavSectionRef.current = pendingNavSectionId
         void confirmSectionLeave(activeSectionId).then((canLeave) => {
+          guardedNavSectionRef.current = releaseSettledSettingsNavGuard(
+            guardedNavSectionRef.current,
+            pendingNavSectionId
+          )
           if (!settingsMountedRef.current || pendingNavSectionRef.current !== pendingNavSectionId) {
             return
           }
-          guardedNavSectionRef.current = null
           if (!canLeave) {
             pendingNavSectionRef.current = null
             pendingScrollTargetRef.current = null
@@ -1170,14 +1192,10 @@ function Settings(): React.JSX.Element {
     }
 
     if (!visibleSectionIds.has(activeSectionId) && visibleNavSections.length > 0) {
-      if (activeSectionId === 'appearance' && appearanceHasDraftChanges) {
-        return
-      }
       setActiveSectionId(getFallbackVisibleSection(visibleNavSections)?.id ?? activeSectionId)
     }
   }, [
     activeSectionId,
-    appearanceHasDraftChanges,
     confirmSectionLeave,
     pendingNavRequestTick,
     setSettingsSearchQuery,
@@ -1719,6 +1737,7 @@ function Settings(): React.JSX.Element {
                     'Theme, zoom, app and terminal appearance, sidebars, and status bar.'
                   )}
                   searchEntries={getSectionSearchEntries('appearance')}
+                  forceVisible={appearanceHasDraftChanges}
                   bodyClassName="border-0 bg-transparent p-0 shadow-none"
                 >
                   {isSectionMounted('appearance') ? (

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -44,8 +44,13 @@ import { InputPane } from './InputPane'
 import { ShortcutsPane } from './ShortcutsPane'
 import { TerminalPane } from './TerminalPane'
 import { FloatingWorkspacePane } from './FloatingWorkspacePane'
-import { useGhosttyImport } from './useGhosttyImport'
-import { useWarpThemeImport } from './useWarpThemeImport'
+import { AppearanceUnsavedChangesDialog } from './AppearanceUnsavedChangesDialog'
+import {
+  runSettingsPageLeaveTransaction,
+  runSettingsWindowCloseGuard
+} from './settings-page-leave-transaction'
+import { useAppearanceLeaveDialog } from './use-appearance-leave-dialog'
+import { useAppearanceSettingsDraft } from './use-appearance-settings-draft'
 import { RepositoryPane } from './RepositoryPane'
 import { GitPane } from './GitPane'
 import { CommitMessageAiPane } from './CommitMessageAiPane'
@@ -365,9 +370,6 @@ function Settings(): React.JSX.Element {
   // Why: trim platform-only Terminal entries from the shared search index so search never reveals hidden controls.
   const [scrollbackMode, setScrollbackMode] = useState<'preset' | 'custom'>('preset')
   const [prevScrollbackRows, setPrevScrollbackRows] = useState(settings?.terminalScrollbackRows)
-  // Why: keep Ghostty import state at Settings level so the modal survives section remounts.
-  const ghostty = useGhosttyImport(updateSettings, settings)
-  const warpThemes = useWarpThemeImport(updateSettings, settings)
   const [fontSuggestions, setFontSuggestions] = useState<string[]>(
     mergeFontSuggestions([], getFallbackTerminalFonts())
   )
@@ -375,6 +377,32 @@ function Settings(): React.JSX.Element {
     () => fontSuggestions.filter((font) => font !== DEFAULT_APP_FONT_FAMILY),
     [fontSuggestions]
   )
+  const applyTheme = useCallback((theme: GlobalSettings['theme']) => {
+    applyDocumentTheme(theme)
+  }, [])
+  const appearanceDraft = useAppearanceSettingsDraft({
+    settings,
+    persistSettings: updateSettingsOrThrow,
+    applyTheme
+  })
+  const appearanceHasDraftChanges = appearanceDraft.hasChanges
+  const discardAppearanceDraft = appearanceDraft.discard
+  const appearanceLeaveDialog = useAppearanceLeaveDialog({
+    hasChanges: appearanceHasDraftChanges,
+    draftSaving: appearanceDraft.saving,
+    draftSaveFailed: appearanceDraft.saveFailed,
+    saveDraft: appearanceDraft.save,
+    discardDraft: appearanceDraft.discard
+  })
+  const {
+    open: appearanceLeaveDialogOpen,
+    saving: appearanceLeaveDialogSaving,
+    saveFailed: appearanceLeaveDialogSaveFailed,
+    confirmLeave: confirmAppearanceLeave,
+    save: saveAppearanceBeforeLeave,
+    discard: discardAppearanceBeforeLeave,
+    cancel: cancelAppearanceLeave
+  } = appearanceLeaveDialog
   const [activeSectionId, setActiveSectionId] = useState('general')
   const [mountedSectionIds, setMountedSectionIds] = useState<Set<string>>(
     getInitialMountedSectionIds
@@ -399,6 +427,7 @@ function Settings(): React.JSX.Element {
   const settingsMountedRef = useRef(true)
   const pendingNavSectionRef = useRef<string | null>(null)
   const pendingScrollTargetRef = useRef<string | null>(null)
+  const guardedNavSectionRef = useRef<string | null>(null)
   const pendingSubsectionScrollFrameRef = useRef<number | null>(null)
   const repoHooksRequestSeqRef = useRef(0)
   const shortcutsEscapeConfirmUntilRef = useRef(0)
@@ -510,25 +539,59 @@ function Settings(): React.JSX.Element {
     })
   }, [confirm])
 
+  const discardSourceControlAiPromptChanges = useCallback((): void => {
+    setSourceControlAiPromptDiscardSignal((signal) => signal + 1)
+    setHasUnsavedCommitPromptChanges(false)
+    setHasUnsavedBranchPromptChanges(false)
+  }, [])
+
   const confirmDiscardSourceControlAiPromptChanges = useCallback(async (): Promise<boolean> => {
     if (!hasUnsavedSourceControlAiPromptChanges) {
       return true
     }
     const shouldDiscard = await promptDiscardSourceControlAiPromptChanges()
     if (shouldDiscard) {
-      setSourceControlAiPromptDiscardSignal((signal) => signal + 1)
-      setHasUnsavedCommitPromptChanges(false)
-      setHasUnsavedBranchPromptChanges(false)
+      discardSourceControlAiPromptChanges()
     }
     return shouldDiscard
-  }, [promptDiscardSourceControlAiPromptChanges, hasUnsavedSourceControlAiPromptChanges])
+  }, [
+    discardSourceControlAiPromptChanges,
+    promptDiscardSourceControlAiPromptChanges,
+    hasUnsavedSourceControlAiPromptChanges
+  ])
+
+  const confirmSettingsPageLeave = useCallback(async (): Promise<boolean> => {
+    return runSettingsPageLeaveTransaction({
+      appearanceDirty: appearanceHasDraftChanges,
+      sourceControlDirty: hasUnsavedSourceControlAiPromptChanges,
+      confirmAppearanceLeave,
+      confirmSourceControlDiscard: promptDiscardSourceControlAiPromptChanges,
+      discardAppearanceDraft,
+      discardSourceControlDrafts: discardSourceControlAiPromptChanges
+    })
+  }, [
+    appearanceHasDraftChanges,
+    confirmAppearanceLeave,
+    discardAppearanceDraft,
+    discardSourceControlAiPromptChanges,
+    hasUnsavedSourceControlAiPromptChanges,
+    promptDiscardSourceControlAiPromptChanges
+  ])
+
+  const confirmSectionLeave = useCallback(
+    (sectionId: string): Promise<boolean> =>
+      sectionId === 'appearance'
+        ? confirmSettingsPageLeave()
+        : confirmDiscardSourceControlAiPromptChanges(),
+    [confirmDiscardSourceControlAiPromptChanges, confirmSettingsPageLeave]
+  )
 
   const closeSettingsPageWithPromptGuard = useCallback(async (): Promise<void> => {
-    if (!(await confirmDiscardSourceControlAiPromptChanges())) {
+    if (!(await confirmSettingsPageLeave())) {
       return
     }
     closeSettingsPage()
-  }, [closeSettingsPage, confirmDiscardSourceControlAiPromptChanges])
+  }, [closeSettingsPage, confirmSettingsPageLeave])
 
   useEffect(() => {
     fetchSettings()
@@ -616,16 +679,15 @@ function Settings(): React.JSX.Element {
 
   // Why: route window close/quit through the discard dialog; a bare beforeunload veto shows no UI and reads as an unquittable window.
   useEffect(() => {
-    return registerWindowCloseGuard(() => {
-      if (isIntentionalAppRestartInProgress()) {
-        return true
-      }
-      if (!hasUnsavedSourceControlAiPromptChangesRef.current) {
-        return true
-      }
-      return promptDiscardSourceControlAiPromptChanges()
-    })
-  }, [promptDiscardSourceControlAiPromptChanges])
+    return registerWindowCloseGuard(() =>
+      runSettingsWindowCloseGuard({
+        intentionalRestart: isIntentionalAppRestartInProgress(),
+        sourceControlDirty: hasUnsavedSourceControlAiPromptChangesRef.current,
+        confirmAppearanceLeave,
+        confirmSourceControlDiscard: promptDiscardSourceControlAiPromptChanges
+      })
+    )
+  }, [confirmAppearanceLeave, promptDiscardSourceControlAiPromptChanges])
 
   useEffect(() => {
     const handleFindShortcut = (event: KeyboardEvent): void => {
@@ -734,10 +796,6 @@ function Settings(): React.JSX.Element {
       )
     }
   }
-
-  const applyTheme = useCallback((theme: 'system' | 'dark' | 'light') => {
-    applyDocumentTheme(theme)
-  }, [])
 
   const displayedGitUsername = repos[0]?.gitUsername ?? ''
   const baseNavSections = useSettingsNavigationMetadata()
@@ -1059,7 +1117,22 @@ function Settings(): React.JSX.Element {
     if (scrollTargetId && pendingNavSectionId && visibleSectionIds.has(pendingNavSectionId)) {
       // Why: inactive panes don't render; activate the pane first, then find the subsection next render.
       if (activeSectionId !== pendingNavSectionId) {
-        setActiveSectionId(pendingNavSectionId)
+        if (guardedNavSectionRef.current === pendingNavSectionId) {
+          return
+        }
+        guardedNavSectionRef.current = pendingNavSectionId
+        void confirmSectionLeave(activeSectionId).then((canLeave) => {
+          if (!settingsMountedRef.current || pendingNavSectionRef.current !== pendingNavSectionId) {
+            return
+          }
+          guardedNavSectionRef.current = null
+          if (!canLeave) {
+            pendingNavSectionRef.current = null
+            pendingScrollTargetRef.current = null
+            return
+          }
+          setActiveSectionId(pendingNavSectionId)
+        })
         return
       }
       const container = contentScrollRef.current
@@ -1097,10 +1170,15 @@ function Settings(): React.JSX.Element {
     }
 
     if (!visibleSectionIds.has(activeSectionId) && visibleNavSections.length > 0) {
+      if (activeSectionId === 'appearance' && appearanceHasDraftChanges) {
+        return
+      }
       setActiveSectionId(getFallbackVisibleSection(visibleNavSections)?.id ?? activeSectionId)
     }
   }, [
     activeSectionId,
+    appearanceHasDraftChanges,
+    confirmSectionLeave,
     pendingNavRequestTick,
     setSettingsSearchQuery,
     settingsSearchQuery,
@@ -1113,9 +1191,15 @@ function Settings(): React.JSX.Element {
       sectionId: string,
       modifiers?: { metaKey: boolean; ctrlKey: boolean; shiftKey: boolean; altKey: boolean }
     ): Promise<void> => {
-      if (sectionId !== activeSectionId && !(await confirmDiscardSourceControlAiPromptChanges())) {
-        return
+      if (sectionId !== activeSectionId) {
+        const canLeave = await confirmSectionLeave(activeSectionId)
+        if (!canLeave) {
+          return
+        }
       }
+      guardedNavSectionRef.current = null
+      pendingNavSectionRef.current = null
+      pendingScrollTargetRef.current = null
       // Why: Shift-click the Experimental row unlocks the hidden power-user group (session-only).
       if (sectionId === 'experimental' && modifiers?.shiftKey) {
         setHiddenExperimentalUnlocked((previous) => !previous)
@@ -1130,12 +1214,7 @@ function Settings(): React.JSX.Element {
       }
       setActiveSectionId(sectionId)
     },
-    [
-      activeSectionId,
-      confirmDiscardSourceControlAiPromptChanges,
-      setSettingsSearchQuery,
-      settingsSearchQuery
-    ]
+    [activeSectionId, confirmSectionLeave, setSettingsSearchQuery, settingsSearchQuery]
   )
 
   const openComputerUseFromBrowser = useCallback(async () => {
@@ -1227,7 +1306,9 @@ function Settings(): React.JSX.Element {
             className={cn(
               'mx-auto flex w-full flex-col gap-10 px-8 pt-10',
               isFocusedShortcutsPane ? 'h-full pb-6' : 'pb-24',
-              isFocusedSetupGuidePane ? 'max-w-6xl' : 'max-w-4xl'
+              isFocusedSetupGuidePane || activeSectionId === 'appearance'
+                ? 'max-w-6xl'
+                : 'max-w-4xl'
             )}
           >
             {visibleNavSections.length === 0 ? (
@@ -1638,18 +1719,21 @@ function Settings(): React.JSX.Element {
                     'Theme, zoom, app and terminal appearance, sidebars, and status bar.'
                   )}
                   searchEntries={getSectionSearchEntries('appearance')}
+                  bodyClassName="border-0 bg-transparent p-0 shadow-none"
                 >
                   {isSectionMounted('appearance') ? (
                     <AppearancePane
-                      settings={settings}
-                      updateSettings={updateSettings}
-                      applyTheme={applyTheme}
+                      settings={appearanceDraft.settings ?? settings}
+                      updateSettings={appearanceDraft.stage}
+                      changeCount={appearanceDraft.changedKeys.length}
+                      saving={appearanceDraft.saving}
+                      saveFailed={appearanceDraft.saveFailed}
+                      saveChanges={appearanceDraft.save}
+                      discardChanges={appearanceDraft.discard}
                       fontSuggestions={fontSuggestions}
                       terminalFontSuggestions={terminalFontSuggestions}
                       onRequestFontSuggestions={requestFontSuggestions}
                       systemPrefersDark={systemPrefersDark}
-                      ghostty={ghostty}
-                      warpThemes={warpThemes}
                     />
                   ) : null}
                 </SettingsSection>
@@ -1924,6 +2008,14 @@ function Settings(): React.JSX.Element {
           </div>
         </div>
       </div>
+      <AppearanceUnsavedChangesDialog
+        open={appearanceLeaveDialogOpen}
+        saving={appearanceLeaveDialogSaving}
+        saveFailed={appearanceLeaveDialogSaveFailed}
+        onSave={saveAppearanceBeforeLeave}
+        onDiscard={discardAppearanceBeforeLeave}
+        onCancel={cancelAppearanceLeave}
+      />
     </div>
   )
 }

--- a/src/renderer/src/components/settings/TerminalAppearanceSection.ghostty.test.ts
+++ b/src/renderer/src/components/settings/TerminalAppearanceSection.ghostty.test.ts
@@ -23,6 +23,7 @@ vi.mock('react', async () => {
       return [mockStateValues[i], setter]
     },
     useCallback: (fn: () => void) => fn,
+    useEffect: (effect: () => void) => effect(),
     useMemo: (fn: () => unknown) => fn(),
     useSyncExternalStore: (_subscribe: () => () => void, getSnapshot: () => unknown) =>
       getSnapshot()
@@ -392,18 +393,47 @@ describe('TerminalAppearanceSection ghostty import wiring', () => {
     expect(catalog?.props.showThemeImport).toBe(true)
   })
 
+  it('shares font hover and theme target state with the central preview', () => {
+    const onPreviewFontFamilyChange = vi.fn()
+    const onPreviewThemeTargetChange = vi.fn()
+    const element = TerminalAppearanceSection({
+      settings: {} as never,
+      updateSettings: () => {},
+      systemPrefersDark: true,
+      terminalFontSuggestions: [],
+      ghostty: ghosttyMock,
+      warpThemes: warpThemesMock,
+      previewThemeTarget: 'light',
+      onPreviewFontFamilyChange,
+      onPreviewThemeTargetChange
+    })
+    const fontRow = findComponentByTypeName(element, 'SettingsRow')
+    const fontAutocomplete = fontRow?.props.control as ReactElementLike
+    const catalog = findTerminalThemeCatalogSection(element)
+
+    ;(fontAutocomplete.props.onPreviewFontFamily as (font: string | null) => void)('JetBrains Mono')
+
+    expect(onPreviewFontFamilyChange).toHaveBeenCalledWith('JetBrains Mono')
+    expect(catalog?.props.selectedTarget).toBe('light')
+    expect(catalog?.props.onTargetChange).toBe(onPreviewThemeTargetChange)
+  })
+
   it('routes dark and light theme searches to the matching catalog target', () => {
     mockSettingsSearchQuery = 'Light Divider Color'
+    const onPreviewThemeTargetChange = vi.fn()
     const lightElement = TerminalAppearanceSection({
       settings: {} as never,
       updateSettings: () => {},
       systemPrefersDark: true,
       terminalFontSuggestions: [],
       ghostty: ghosttyMock,
-      warpThemes: warpThemesMock
+      warpThemes: warpThemesMock,
+      previewThemeTarget: 'dark',
+      onPreviewThemeTargetChange
     })
 
     expect(findTerminalThemeCatalogSection(lightElement)?.props.preferredTarget).toBe('light')
+    expect(onPreviewThemeTargetChange).toHaveBeenCalledWith('light')
 
     mockSettingsSearchQuery = 'Dark Theme'
     resetMockState()

--- a/src/renderer/src/components/settings/TerminalAppearanceSection.tsx
+++ b/src/renderer/src/components/settings/TerminalAppearanceSection.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import type { GlobalSettings } from '../../../../shared/global-settings-types'
 import {
   matchesSettingsSearch,
@@ -25,7 +25,7 @@ import { SettingsRow, SettingsSubsectionHeader, FontAutocomplete } from './Setti
 import { SearchableSetting } from './SearchableSetting'
 import { TerminalFontSizeSetting } from './TerminalFontSizeSetting'
 import { TerminalAdvancedTypographyControls } from './TerminalAdvancedTypographyControls'
-import { TerminalThemeCatalogSection } from './TerminalThemeSections'
+import { TerminalThemeCatalogSection, type TerminalThemeTarget } from './TerminalThemeSections'
 import { TerminalWindowSection } from './TerminalWindowSection'
 import { TerminalCursorAppearanceSection } from './TerminalCursorAppearanceSection'
 import { TerminalPaneAppearanceSection } from './TerminalPaneAppearanceSection'
@@ -46,10 +46,13 @@ type TerminalAppearanceSectionProps = {
   onRequestFontSuggestions?: () => void
   ghostty: UseGhosttyImportReturn
   warpThemes: UseWarpThemeImportReturn
+  showPreview?: boolean
+  hasUnsavedChanges?: boolean
   forceVisiblePrimary?: boolean
+  previewThemeTarget?: TerminalThemeTarget
+  onPreviewThemeTargetChange?: (target: TerminalThemeTarget) => void
+  onPreviewFontFamilyChange?: (fontFamily: string | null) => void
 }
-
-type TerminalThemeTarget = 'dark' | 'light'
 
 function scoreThemeTargetIntent(searchQuery: string, entries: SettingsSearchEntry[]): number {
   // Why: descriptions mention dark/light incidentally; target intent should come from labels and aliases.
@@ -77,12 +80,21 @@ export function TerminalAppearanceSection({
   onRequestFontSuggestions,
   ghostty,
   warpThemes,
-  forceVisiblePrimary = false
+  showPreview = true,
+  hasUnsavedChanges = false,
+  forceVisiblePrimary = false,
+  previewThemeTarget,
+  onPreviewThemeTargetChange,
+  onPreviewFontFamilyChange
 }: TerminalAppearanceSectionProps): React.JSX.Element {
   const searchQuery = useAppStore((state) => state.settingsSearchQuery)
   const isSearching = normalizeSettingsSearchQuery(searchQuery).length > 0
   const [themeSearch, setThemeSearch] = useState('')
   const [previewFontFamily, setPreviewFontFamily] = useState<string | null>(null)
+  const handlePreviewFontFamily = (fontFamily: string | null): void => {
+    setPreviewFontFamily(fontFamily)
+    onPreviewFontFamilyChange?.(fontFamily)
+  }
   const showWarpThemeImport = !isWebClientLocation()
   const darkThemeSearchEntries = getTerminalDarkThemeSearchEntries()
   const lightThemeSearchEntries = getTerminalLightThemeSearchEntries()
@@ -99,6 +111,12 @@ export function TerminalAppearanceSection({
   const darkThemeTargetScore = scoreThemeTargetIntent(searchQuery, darkThemeSearchEntries)
   const lightThemeTargetScore = scoreThemeTargetIntent(searchQuery, lightThemeSearchEntries)
   const preferredThemeTarget = getPreferredThemeTarget(darkThemeTargetScore, lightThemeTargetScore)
+
+  useEffect(() => {
+    if (preferredThemeTarget) {
+      onPreviewThemeTargetChange?.(preferredThemeTarget)
+    }
+  }, [onPreviewThemeTargetChange, preferredThemeTarget])
 
   // Why: low-frequency knobs are force-opened during search; render each group
   // only when its own search matches so an active query never leaves a dangling header.
@@ -146,7 +164,13 @@ export function TerminalAppearanceSection({
     windowMatches
       ? {
           key: 'window',
-          node: <TerminalWindowSection settings={settings} updateSettings={updateSettings} />
+          node: (
+            <TerminalWindowSection
+              settings={settings}
+              updateSettings={updateSettings}
+              relaunchDisabled={hasUnsavedChanges}
+            />
+          )
         }
       : null
   ].filter((group): group is { key: string; node: React.JSX.Element } => group !== null)
@@ -228,7 +252,7 @@ export function TerminalAppearanceSection({
                     suggestions={terminalFontSuggestions}
                     onRequestSuggestions={onRequestFontSuggestions}
                     onChange={(value) => updateSettings({ terminalFontFamily: value })}
-                    onPreviewFontFamily={setPreviewFontFamily}
+                    onPreviewFontFamily={handlePreviewFontFamily}
                   />
                 }
               />
@@ -260,7 +284,10 @@ export function TerminalAppearanceSection({
           importedHighlightSignal={warpThemes.importSignal}
           warpThemes={warpThemes}
           showThemeImport={showWarpThemeImport}
+          showPreview={showPreview}
           preferredTarget={preferredThemeTarget}
+          selectedTarget={previewThemeTarget}
+          onTargetChange={onPreviewThemeTargetChange}
           advancedContent={previewAdvancedContent}
         />
       ) : null}

--- a/src/renderer/src/components/settings/TerminalSettingsPreview.lifecycle.test.tsx
+++ b/src/renderer/src/components/settings/TerminalSettingsPreview.lifecycle.test.tsx
@@ -36,6 +36,16 @@ const mockLigaturesAddon = vi.hoisted(() => ({
   instances: [] as MockLigaturesAddonInstance[]
 }))
 
+const mockPreviewBackground = vi.hoisted(() => ({
+  current: null as null | {
+    fileName: string
+    objectUrl: string
+    opacity: number
+    blurPx: number
+    fit: 'cover'
+  }
+}))
+
 vi.mock('react', async () => {
   const actual = await vi.importActual<typeof import('react')>('react') // eslint-disable-line @typescript-eslint/consistent-type-imports -- vi.importActual requires inline import()
   return {
@@ -123,7 +133,22 @@ vi.mock('@/components/terminal-pane/layout-serialization', () => ({
 }))
 
 vi.mock('@/components/terminal-pane/terminal-appearance', () => ({
-  composeActiveTerminalTheme: () => ({ background: '#111111', foreground: '#eeeeee' })
+  composeActiveTerminalTheme: (
+    _theme: unknown,
+    settings: { terminalBackgroundOpacity?: number },
+    terminalBackgroundImageActive = false
+  ) => ({
+    background:
+      terminalBackgroundImageActive || settings.terminalBackgroundOpacity === 0
+        ? 'rgba(17, 17, 17, 0)'
+        : '#111111',
+    foreground: '#eeeeee'
+  })
+}))
+
+vi.mock('./appearance-preview-background', () => ({
+  getAppearancePreviewBackgroundStyle: () => ({}),
+  useAppearancePreviewBackground: () => mockPreviewBackground.current
 }))
 
 vi.mock('@/lib/terminal-theme', () => ({
@@ -168,13 +193,57 @@ function makeSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings {
   } as GlobalSettings
 }
 
-function renderPreview(settings = makeSettings()): void {
-  TerminalSettingsPreview({
+function renderPreview(settings = makeSettings()): React.JSX.Element {
+  return TerminalSettingsPreview({
     title: 'Preview',
     description: 'Preview description',
     settings,
     systemPrefersDark: true
   })
+}
+
+type ReactElementLike = {
+  props?: Record<string, unknown>
+}
+
+function findByClassName(node: unknown, className: string): ReactElementLike | null {
+  if (node == null || typeof node === 'string' || typeof node === 'number') {
+    return null
+  }
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const found = findByClassName(child, className)
+      if (found) {
+        return found
+      }
+    }
+    return null
+  }
+  const element = node as ReactElementLike
+  if (String(element.props?.className ?? '').includes(className)) {
+    return element
+  }
+  return findByClassName(element.props?.children, className)
+}
+
+function findByDataAttribute(node: unknown, attribute: string): ReactElementLike | null {
+  if (node == null || typeof node === 'string' || typeof node === 'number') {
+    return null
+  }
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const found = findByDataAttribute(child, attribute)
+      if (found) {
+        return found
+      }
+    }
+    return null
+  }
+  const element = node as ReactElementLike
+  if (element.props?.[attribute]) {
+    return element
+  }
+  return findByDataAttribute(element.props?.children, attribute)
 }
 
 function runCleanups(): void {
@@ -193,6 +262,7 @@ describe('TerminalSettingsPreview terminal lifecycle', () => {
     mockXterm.nextOpenError = null
     mockLigaturesAddon.enabled = false
     mockLigaturesAddon.instances.length = 0
+    mockPreviewBackground.current = null
   })
 
   it('initializes once, writes once on mount, and disposes on unmount', () => {
@@ -229,6 +299,42 @@ describe('TerminalSettingsPreview terminal lifecycle', () => {
     renderPreview(makeSettings({ terminalLineHeight: 0.85 }))
 
     expect(mockXterm.instances[0]?.options.lineHeight).toBe(1)
+  })
+
+  it('makes xterm transparent only after the preview background is ready', () => {
+    mockPreviewBackground.current = {
+      fileName: 'ocean.png',
+      objectUrl: 'blob:ocean',
+      opacity: 0.4,
+      blurPx: 8,
+      fit: 'cover'
+    }
+
+    renderPreview()
+
+    expect(mockXterm.instances[0]?.options).toMatchObject({
+      allowTransparency: true,
+      theme: { background: 'rgba(17, 17, 17, 0)' }
+    })
+  })
+
+  it('keeps the surface below the image instead of covering it with the active pane', () => {
+    mockPreviewBackground.current = {
+      fileName: 'ocean.png',
+      objectUrl: 'blob:ocean',
+      opacity: 0.4,
+      blurPx: 8,
+      fit: 'cover'
+    }
+
+    const preview = renderPreview()
+    const frame = findByClassName(preview, 'h-[300px]')
+    const activePane = findByClassName(preview, 'min-w-0 flex-1')
+    const stubPane = findByDataAttribute(preview, 'data-terminal-preview-stub')
+
+    expect(frame?.props?.style).toEqual({ backgroundColor: '#111111' })
+    expect(activePane?.props?.style).toBeUndefined()
+    expect(stubPane?.props?.style).toMatchObject({ backgroundColor: 'transparent' })
   })
 
   it('disposes the ligatures addon before disposing the terminal', () => {

--- a/src/renderer/src/components/settings/TerminalSettingsPreview.tsx
+++ b/src/renderer/src/components/settings/TerminalSettingsPreview.tsx
@@ -3,7 +3,9 @@ import { Terminal } from '@xterm/xterm'
 import { LigaturesAddon } from '@xterm/addon-ligatures'
 import { Moon, Sun } from 'lucide-react'
 import '@xterm/xterm/css/xterm.css'
+import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { buildDefaultTerminalOptions } from '@/lib/pane-manager/pane-terminal-options'
 import { buildFontFamily } from '@/components/terminal-pane/layout-serialization'
 import { composeActiveTerminalTheme } from '@/components/terminal-pane/terminal-appearance'
@@ -14,6 +16,10 @@ import { resolveTerminalLigaturesEnabled } from '../../../../shared/terminal-lig
 import { normalizeTerminalLineHeight } from '../../../../shared/terminal-line-height-settings'
 import { PREVIEW_BUFFER } from './terminal-preview-content'
 import { SettingsSwitch } from './SettingsFormControls'
+import {
+  getAppearancePreviewBackgroundStyle,
+  useAppearancePreviewBackground
+} from './appearance-preview-background'
 import type { GlobalSettings } from '../../../../shared/global-settings-types'
 import { translate } from '@/i18n/i18n'
 
@@ -33,9 +39,10 @@ type TerminalSettingsPreviewProps = {
   systemPrefersDark: boolean
   /** Override for `settings.terminalFontFamily`; set by the font picker on hover to preview a font before committing. */
   previewFontFamily?: string | null
-  /** Force the preview into this mode regardless of app settings; hides the in-header theme toggle when set. */
+  /** Force the preview into this mode regardless of app settings. */
   modeOverride?: PreviewMode
-  /** Render a Moon/Sun header toggle to flip the preview theme without changing the app theme. Ignored when `modeOverride` is set. */
+  onModeOverrideChange?: (mode: PreviewMode) => void
+  /** Render a Moon/Sun toggle; controlled overrides require `onModeOverrideChange`. */
   showThemeToggle?: boolean
 }
 
@@ -56,6 +63,7 @@ export function TerminalSettingsPreview({
   systemPrefersDark,
   previewFontFamily,
   modeOverride,
+  onModeOverrideChange,
   showThemeToggle
 }: TerminalSettingsPreviewProps): React.JSX.Element {
   const containerRef = useRef<HTMLDivElement | null>(null)
@@ -67,16 +75,15 @@ export function TerminalSettingsPreview({
   const effectiveFontFamily = previewFontFamily || settings.terminalFontFamily
   const terminalLineHeight = normalizeTerminalLineHeight(settings.terminalLineHeight)
 
-  // Why: lazy-init from the active app theme; after mount the toggle is independent of later app-theme changes.
-  const [togglePreviewMode, setTogglePreviewMode] = useState<PreviewMode>(() =>
-    resolveAppMode(settings, systemPrefersDark)
-  )
+  const [togglePreviewMode, setTogglePreviewMode] = useState<PreviewMode | null>(null)
   const [previewPaneDividerVisible, setPreviewPaneDividerVisible] = useState(false)
 
-  // Why: recomputed each render so plain previews (no override/toggle) track live app-theme changes.
+  const selectedPreviewMode = togglePreviewMode ?? resolveAppMode(settings, systemPrefersDark)
   const effectiveMode: PreviewMode =
     modeOverride ??
-    (showThemeToggle ? togglePreviewMode : resolveAppMode(settings, systemPrefersDark))
+    (showThemeToggle ? selectedPreviewMode : resolveAppMode(settings, systemPrefersDark))
+  const previewBackground = useAppearancePreviewBackground(settings, 'terminal')
+  const hasPreviewBackground = previewBackground !== null
 
   // Why: reuse the live-pane resolver so divider color, theme palette, and dark/light variant rules stay in lockstep.
   // Why: list resolveEffectiveTerminalAppearance's inputs explicitly so unrelated changes (font, cursor) don't re-derive.
@@ -97,20 +104,25 @@ export function TerminalSettingsPreview({
   )
 
   // Why: list composeActiveTerminalTheme inputs explicitly so font/cursor changes don't trigger a buffer rewrite.
-  const composedTheme = useMemo(
-    () => composeActiveTerminalTheme(appearance.theme, settings),
+  const previewThemes = useMemo(
+    () => ({
+      surface: composeActiveTerminalTheme(appearance.theme, settings),
+      xterm: composeActiveTerminalTheme(appearance.theme, settings, hasPreviewBackground)
+    }),
     // oxlint-disable-next-line react-hooks/exhaustive-deps
     [
       appearance,
+      hasPreviewBackground,
       settings.terminalColorOverrides,
       settings.terminalBackgroundOpacity,
       settings.terminalCursorOpacity
     ]
   )
+  const composedTheme = previewThemes.xterm
 
   const dividerThicknessPx = clampNumber(settings.terminalDividerThicknessPx, 1, 32)
   const inactivePaneOpacity = clampNumber(settings.terminalInactivePaneOpacity, 0, 1)
-  const paneBackground = composedTheme?.background ?? '#000'
+  const paneBackground = previewThemes.surface?.background ?? '#000'
 
   useEffect(() => {
     const container = containerRef.current
@@ -139,7 +151,9 @@ export function TerminalSettingsPreview({
       lineHeight: terminalLineHeight,
       theme: composedTheme ?? undefined,
       allowTransparency:
-        settings.terminalBackgroundOpacity !== undefined && settings.terminalBackgroundOpacity < 1,
+        hasPreviewBackground ||
+        (settings.terminalBackgroundOpacity !== undefined &&
+          settings.terminalBackgroundOpacity < 1),
       cols: PREVIEW_COLS,
       rows: PREVIEW_ROWS
     })
@@ -205,12 +219,13 @@ export function TerminalSettingsPreview({
     terminal.options.theme = composedTheme
     // Why: share applyTerminalAppearance's gating helper (#7934) so the preview can't drift from live panes.
     terminal.options.minimumContrastRatio = resolveTerminalMinimumContrastRatio(
-      composedTheme.background,
+      previewThemes.surface?.background,
       effectiveMode
     )
     // Why: xterm renders an alpha-channel background opaque unless allowTransparency is set (matches applyTerminalAppearance).
     terminal.options.allowTransparency =
-      settings.terminalBackgroundOpacity !== undefined && settings.terminalBackgroundOpacity < 1
+      hasPreviewBackground ||
+      (settings.terminalBackgroundOpacity !== undefined && settings.terminalBackgroundOpacity < 1)
     if (skipInitialThemeRewriteRef.current) {
       skipInitialThemeRewriteRef.current = false
       return
@@ -218,7 +233,13 @@ export function TerminalSettingsPreview({
     // Why reset() not clear(): buffer ends mid-line on the prompt, so clear()+write would duplicate the trailing fragment.
     terminal.reset()
     terminal.write(PREVIEW_BUFFER)
-  }, [composedTheme, effectiveMode, settings.terminalBackgroundOpacity])
+  }, [
+    composedTheme,
+    effectiveMode,
+    hasPreviewBackground,
+    previewThemes.surface?.background,
+    settings.terminalBackgroundOpacity
+  ])
 
   useEffect(() => {
     const terminal = terminalRef.current
@@ -245,17 +266,24 @@ export function TerminalSettingsPreview({
     }
   }, [settings.terminalLigatures, effectiveFontFamily])
 
-  const showToggle = showThemeToggle && modeOverride === undefined
+  const showToggle = showThemeToggle && (modeOverride === undefined || onModeOverrideChange)
+  const selectPreviewMode = (mode: PreviewMode): void => {
+    if (modeOverride === undefined) {
+      setTogglePreviewMode(mode)
+    } else {
+      onModeOverrideChange?.(mode)
+    }
+  }
 
   return (
     <Card className="gap-4 overflow-hidden py-0">
       <CardHeader className="gap-0 border-b border-border/50 px-4 py-3 !pb-3">
-        <div className="flex min-h-7 items-center justify-between gap-3">
-          <div className="min-w-0 space-y-1">
+        <div className="flex min-h-7 flex-wrap items-center justify-between gap-3">
+          <div className="min-w-0 flex-1 basis-48 space-y-1">
             <CardTitle className="text-sm">{title}</CardTitle>
             {description ? <CardDescription>{description}</CardDescription> : null}
           </div>
-          <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
+          <div className="ml-auto flex shrink-0 flex-wrap items-center justify-end gap-2">
             <div className="flex items-center gap-2 rounded-md border border-border/50 bg-background/40 px-2 py-1">
               <span className="text-xs font-medium text-muted-foreground">
                 {translate(
@@ -281,31 +309,41 @@ export function TerminalSettingsPreview({
                   'Preview theme'
                 )}
               >
-                {(['dark', 'light'] as const).map((mode) => (
-                  <button
-                    key={mode}
-                    type="button"
-                    onClick={() => setTogglePreviewMode(mode)}
-                    aria-pressed={togglePreviewMode === mode}
-                    aria-label={translate(
-                      'auto.components.settings.TerminalSettingsPreview.a63953a48a',
-                      'Preview {{value0}} theme',
-                      { value0: mode }
-                    )}
-                    title={translate(
-                      'auto.components.settings.TerminalSettingsPreview.a63953a48a',
-                      'Preview {{value0}} theme',
-                      { value0: mode }
-                    )}
-                    className={`rounded-sm p-1 transition-colors ${
-                      togglePreviewMode === mode
-                        ? 'bg-accent text-accent-foreground'
-                        : 'text-muted-foreground hover:text-foreground'
-                    }`}
-                  >
-                    {mode === 'dark' ? <Moon className="size-3.5" /> : <Sun className="size-3.5" />}
-                  </button>
-                ))}
+                {(['dark', 'light'] as const).map((mode) => {
+                  const label = translate(
+                    'auto.components.settings.TerminalSettingsPreview.a63953a48a',
+                    'Preview {{value0}} theme',
+                    { value0: mode }
+                  )
+                  return (
+                    <Tooltip key={mode}>
+                      <TooltipTrigger asChild>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon-sm"
+                          onClick={() => selectPreviewMode(mode)}
+                          aria-pressed={effectiveMode === mode}
+                          aria-label={label}
+                          className={
+                            effectiveMode === mode
+                              ? 'bg-accent text-accent-foreground'
+                              : 'text-muted-foreground hover:text-foreground'
+                          }
+                        >
+                          {mode === 'dark' ? (
+                            <Moon className="size-3.5" aria-hidden="true" />
+                          ) : (
+                            <Sun className="size-3.5" aria-hidden="true" />
+                          )}
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent side="top" sideOffset={4}>
+                        {label}
+                      </TooltipContent>
+                    </Tooltip>
+                  )
+                })}
               </div>
             ) : null}
           </div>
@@ -313,14 +351,20 @@ export function TerminalSettingsPreview({
       </CardHeader>
       <CardContent className="px-4 pb-4">
         {/* Why: stub pane on the right keeps inactive-pane opacity visible; divider is opt-in to keep the default preview clean. */}
-        <div className="flex h-[300px] flex-col overflow-hidden rounded-md border border-border/50">
-          <div className="flex min-h-0 flex-1 overflow-hidden" aria-hidden="true">
+        <div
+          className="relative flex h-[300px] flex-col overflow-hidden rounded-md border border-border/50"
+          style={{ backgroundColor: paneBackground }}
+        >
+          {previewBackground ? (
             <div
-              ref={containerRef}
-              className="min-w-0 flex-1 overflow-hidden p-2"
-              style={{ backgroundColor: paneBackground }}
-              tabIndex={-1}
+              className="pointer-events-none absolute inset-0"
+              data-terminal-preview-background={previewBackground.fileName}
+              style={getAppearancePreviewBackgroundStyle(previewBackground)}
+              aria-hidden="true"
             />
+          ) : null}
+          <div className="relative z-10 flex min-h-0 flex-1 overflow-hidden" aria-hidden="true">
+            <div ref={containerRef} className="min-w-0 flex-1 overflow-hidden p-2" tabIndex={-1} />
             {previewPaneDividerVisible ? (
               <div
                 className="shrink-0"
@@ -332,9 +376,10 @@ export function TerminalSettingsPreview({
             ) : null}
             <div
               className="shrink-0"
+              data-terminal-preview-stub="true"
               style={{
                 width: `${STUB_PANE_PX}px`,
-                backgroundColor: paneBackground,
+                backgroundColor: hasPreviewBackground ? 'transparent' : paneBackground,
                 opacity: inactivePaneOpacity
               }}
             />

--- a/src/renderer/src/components/settings/TerminalThemeSections.lifecycle.test.ts
+++ b/src/renderer/src/components/settings/TerminalThemeSections.lifecycle.test.ts
@@ -280,6 +280,36 @@ describe('TerminalThemeCatalogSection', () => {
     expect(preview?.props?.modeOverride).toBe('light')
   })
 
+  it('uses and reports a shared preview target', () => {
+    const onTargetChange = vi.fn()
+    const element = TerminalThemeCatalogSection({
+      settings: makeSettings({ terminalUseSeparateLightTheme: true }),
+      systemPrefersDark: true,
+      themeSearch: '',
+      setThemeSearch: () => {},
+      updateSettings: vi.fn(),
+      previewFontFamily: null,
+      importedHighlightSignal: 0,
+      warpThemes: warpThemesMock,
+      showThemeImport: true,
+      selectedTarget: 'light',
+      onTargetChange
+    })
+    const targetControl = findElementByTypeName(element, 'SettingsSegmentedControl')
+
+    expect(findElementByTypeName(element, 'ThemePicker')?.props?.selectedTheme).toBe(
+      'Builtin Tango Light'
+    )
+
+    const onChange = targetControl?.props?.onChange
+    expect(onChange).toBeTypeOf('function')
+    if (typeof onChange === 'function') {
+      onChange('dark')
+    }
+
+    expect(onTargetChange).toHaveBeenCalledWith('dark')
+  })
+
   it('updates the dark theme from the catalog when the dark target is active', () => {
     const updateSettings = vi.fn()
     const element = renderCatalog(makeSettings(), updateSettings, 'dark')

--- a/src/renderer/src/components/settings/TerminalThemeSections.tsx
+++ b/src/renderer/src/components/settings/TerminalThemeSections.tsx
@@ -21,7 +21,7 @@ import {
 import { translate } from '@/i18n/i18n'
 import { cn } from '@/lib/utils'
 
-type TerminalThemeTarget = 'dark' | 'light'
+export type TerminalThemeTarget = 'dark' | 'light'
 
 let lastEditedTerminalThemeTarget: TerminalThemeTarget | null = null
 
@@ -38,7 +38,7 @@ function isCustomizedTheme(themeName: string, defaultThemeName: string): boolean
   return trimmed.length > 0 && trimmed !== defaultThemeName
 }
 
-function getInitialTerminalThemeTarget(
+export function getInitialTerminalThemeTarget(
   settings: GlobalSettings,
   systemPrefersDark: boolean,
   preferredTarget?: TerminalThemeTarget
@@ -72,7 +72,10 @@ type TerminalThemeCatalogSectionProps = {
   importedHighlightSignal: number
   warpThemes: UseWarpThemeImportReturn
   showThemeImport: boolean
+  showPreview?: boolean
   preferredTarget?: TerminalThemeTarget
+  selectedTarget?: TerminalThemeTarget
+  onTargetChange?: (target: TerminalThemeTarget) => void
   advancedContent?: ReactNode
 }
 
@@ -86,15 +89,20 @@ export function TerminalThemeCatalogSection({
   importedHighlightSignal,
   warpThemes,
   showThemeImport,
+  showPreview = true,
   preferredTarget,
+  selectedTarget,
+  onTargetChange,
   advancedContent
 }: TerminalThemeCatalogSectionProps): React.JSX.Element {
-  const [target, setTargetState] = useState<TerminalThemeTarget>(() =>
+  const [localTarget, setTargetState] = useState<TerminalThemeTarget>(() =>
     getInitialTerminalThemeTarget(settings, systemPrefersDark, preferredTarget)
   )
+  const target = selectedTarget ?? preferredTarget ?? localTarget
   const setTarget = (nextTarget: TerminalThemeTarget): void => {
     rememberTerminalThemeTarget(nextTarget)
     setTargetState(nextTarget)
+    onTargetChange?.(nextTarget)
   }
   const themeOptions = getAvailableTerminalThemeOptions(settings)
   const isLightTarget = target === 'light'
@@ -290,34 +298,36 @@ export function TerminalThemeCatalogSection({
 
         {advancedContent ? <div className="-mt-4">{advancedContent}</div> : null}
 
-        <TerminalSettingsPreview
-          title={
-            isLightTarget
-              ? translate(
-                  'auto.components.settings.TerminalThemeSections.db210115c5',
-                  'Light Mode Preview'
-                )
-              : translate(
-                  'auto.components.settings.TerminalThemeSections.bc8e8a251a',
-                  'Dark Mode Preview'
-                )
-          }
-          description={
-            isLightTarget
-              ? translate(
-                  'auto.components.settings.TerminalThemeSections.light_preview_description',
-                  'Shows the effective light terminal appearance.'
-                )
-              : translate(
-                  'auto.components.settings.TerminalThemeSections.dark_preview_description',
-                  'Shows the effective dark terminal appearance.'
-                )
-          }
-          settings={settings}
-          systemPrefersDark={systemPrefersDark}
-          previewFontFamily={previewFontFamily}
-          modeOverride={target}
-        />
+        {showPreview ? (
+          <TerminalSettingsPreview
+            title={
+              isLightTarget
+                ? translate(
+                    'auto.components.settings.TerminalThemeSections.db210115c5',
+                    'Light Mode Preview'
+                  )
+                : translate(
+                    'auto.components.settings.TerminalThemeSections.bc8e8a251a',
+                    'Dark Mode Preview'
+                  )
+            }
+            description={
+              isLightTarget
+                ? translate(
+                    'auto.components.settings.TerminalThemeSections.light_preview_description',
+                    'Shows the effective light terminal appearance.'
+                  )
+                : translate(
+                    'auto.components.settings.TerminalThemeSections.dark_preview_description',
+                    'Shows the effective dark terminal appearance.'
+                  )
+            }
+            settings={settings}
+            systemPrefersDark={systemPrefersDark}
+            previewFontFamily={previewFontFamily}
+            modeOverride={target}
+          />
+        ) : null}
       </div>
     </section>
   )

--- a/src/renderer/src/components/settings/TerminalWindowSection.tsx
+++ b/src/renderer/src/components/settings/TerminalWindowSection.tsx
@@ -13,13 +13,15 @@ import { translate } from '@/i18n/i18n'
 type TerminalWindowSectionProps = {
   settings: GlobalSettings
   updateSettings: (updates: Partial<GlobalSettings>) => void
+  relaunchDisabled?: boolean
 }
 
 import { COLOR_OVERRIDE_GROUPS } from './terminal-window-color-groups'
 
 export function TerminalWindowSection({
   settings,
-  updateSettings
+  updateSettings,
+  relaunchDisabled = false
 }: TerminalWindowSectionProps): React.JSX.Element {
   const [colorOverridesExpanded, setColorOverridesExpanded] = useState(false)
   // Why: windowBackgroundBlur is only read by createMainWindow() at startup
@@ -33,7 +35,7 @@ export function TerminalWindowSection({
   const mountedRef = useMountedRef()
 
   const handleRelaunch = async (): Promise<void> => {
-    if (relaunchingBlur) {
+    if (relaunchingBlur || relaunchDisabled) {
       return
     }
     setRelaunchingBlur(true)
@@ -140,17 +142,22 @@ export function TerminalWindowSection({
                   )}
                 </p>
                 <p className="text-xs text-muted-foreground">
-                  {translate(
-                    'auto.components.settings.TerminalWindowSection.53ce336e15',
-                    'Restart Orca to apply the window blur change.'
-                  )}
+                  {relaunchDisabled
+                    ? translate(
+                        'auto.components.settings.TerminalWindowSection.saveBeforeRestart',
+                        'Save the appearance draft before restarting Orca.'
+                      )
+                    : translate(
+                        'auto.components.settings.TerminalWindowSection.53ce336e15',
+                        'Restart Orca to apply the window blur change.'
+                      )}
                 </p>
               </div>
               <Button
                 size="sm"
                 variant="default"
                 className="shrink-0 gap-1.5"
-                disabled={relaunchingBlur}
+                disabled={relaunchingBlur || relaunchDisabled}
                 onClick={() => void handleRelaunch()}
               >
                 <RotateCw className={`size-3 ${relaunchingBlur ? 'animate-spin' : ''}`} />

--- a/src/renderer/src/components/settings/TerminalWindowSection.tsx
+++ b/src/renderer/src/components/settings/TerminalWindowSection.tsx
@@ -144,7 +144,7 @@ export function TerminalWindowSection({
                 <p className="text-xs text-muted-foreground">
                   {relaunchDisabled
                     ? translate(
-                        'auto.components.settings.TerminalWindowSection.saveBeforeRestart',
+                        'auto.components.settings.TerminalWindowSection.a62a827eda',
                         'Save the appearance draft before restarting Orca.'
                       )
                     : translate(

--- a/src/renderer/src/components/settings/WarpThemeImportModal.tsx
+++ b/src/renderer/src/components/settings/WarpThemeImportModal.tsx
@@ -92,12 +92,12 @@ export function WarpThemeImportModal({
           <DialogDescription className="text-xs">
             {mode === 'yaml'
               ? translate(
-                  'auto.components.settings.WarpThemeImportModal.yaml_description',
-                  'Import theme YAML files (Warp format) as Orca terminal themes.'
+                  'auto.components.settings.WarpThemeImportModal.yaml_draft_description',
+                  'Add theme YAML files (Warp format) to your appearance draft.'
                 )
               : translate(
-                  'auto.components.settings.WarpThemeImportModal.description',
-                  'Import Warp themes as Orca terminal themes.'
+                  'auto.components.settings.WarpThemeImportModal.draft_description',
+                  'Add Warp themes to your appearance draft.'
                 )}
           </DialogDescription>
         </DialogHeader>
@@ -238,7 +238,7 @@ export function WarpThemeImportModal({
             </div>
           ) : (
             <div className="space-y-2 text-xs text-muted-foreground">
-              <p>
+              <p role={preview.error ? 'alert' : undefined}>
                 {preview.error ??
                   (mode === 'yaml'
                     ? translate(
@@ -305,11 +305,15 @@ export function WarpThemeImportModal({
             </div>
           ) : null}
 
-          {applyError ? <p className="text-xs text-destructive">{applyError}</p> : null}
+          {applyError ? (
+            <p className="text-xs text-destructive" role="alert">
+              {applyError}
+            </p>
+          ) : null}
         </div>
 
         <DialogFooter>
-          <Button variant="outline" onClick={() => handleOpenChange(false)}>
+          <Button variant="ghost" onClick={() => handleOpenChange(false)}>
             {translate('auto.components.settings.WarpThemeImportModal.cancel', 'Cancel')}
           </Button>
           <Button
@@ -318,18 +322,18 @@ export function WarpThemeImportModal({
           >
             {selectedCount === 1
               ? translate(
-                  'auto.components.settings.WarpThemeImportModal.import_theme_one',
-                  'Import 1 Theme'
+                  'auto.components.settings.WarpThemeImportModal.add_theme_one',
+                  'Add 1 Theme to Draft'
                 )
               : selectedCount > 0
                 ? translate(
-                    'auto.components.settings.WarpThemeImportModal.import_theme_other',
-                    'Import {{value0}} Themes',
+                    'auto.components.settings.WarpThemeImportModal.add_theme_other',
+                    'Add {{value0}} Themes to Draft',
                     { value0: selectedCount }
                   )
                 : translate(
-                    'auto.components.settings.WarpThemeImportModal.import_themes',
-                    'Import Themes'
+                    'auto.components.settings.WarpThemeImportModal.add_themes',
+                    'Add Themes to Draft'
                   )}
           </Button>
         </DialogFooter>

--- a/src/renderer/src/components/settings/appearance-background-section-model.ts
+++ b/src/renderer/src/components/settings/appearance-background-section-model.ts
@@ -1,0 +1,164 @@
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import {
+  DEFAULT_ORCA_BACKGROUND_SETTINGS,
+  type OrcaBackgroundArea,
+  type OrcaBackgroundFit,
+  type OrcaBackgroundSettings
+} from '../../../../shared/orca-background-settings'
+import { translate } from '@/i18n/i18n'
+import { translateSearchKeyword } from './settings-search-keywords'
+
+export type AppearanceBackgroundArea = OrcaBackgroundArea
+
+export function getAppearanceBackgroundAreaOptions(): readonly {
+  value: AppearanceBackgroundArea
+  label: string
+  description: string
+}[] {
+  return [
+    {
+      value: 'terminal',
+      label: translate('auto.components.settings.AppearanceBackgroundSection.terminal', 'Terminal'),
+      description: translate(
+        'auto.components.settings.AppearanceBackgroundSection.terminalDescription',
+        'Show the background behind terminal panes.'
+      )
+    },
+    {
+      value: 'leftSidebar',
+      label: translate(
+        'auto.components.settings.AppearanceBackgroundSection.leftSidebar',
+        'Left Sidebar'
+      ),
+      description: translate(
+        'auto.components.settings.AppearanceBackgroundSection.leftSidebarDescription',
+        'Show the background behind the workspace sidebar.'
+      )
+    },
+    {
+      value: 'rightSidebar',
+      label: translate(
+        'auto.components.settings.AppearanceBackgroundSection.rightSidebar',
+        'Right Sidebar'
+      ),
+      description: translate(
+        'auto.components.settings.AppearanceBackgroundSection.rightSidebarDescription',
+        'Show the background behind explorer and source control panels.'
+      )
+    }
+  ]
+}
+
+export function getAppearanceBackgroundFitOptions(): readonly {
+  value: OrcaBackgroundFit
+  label: string
+}[] {
+  return [
+    {
+      value: 'cover',
+      label: translate('auto.components.settings.AppearanceBackgroundSection.cover', 'Cover')
+    },
+    {
+      value: 'contain',
+      label: translate('auto.components.settings.AppearanceBackgroundSection.contain', 'Contain')
+    },
+    {
+      value: 'stretch',
+      label: translate('auto.components.settings.AppearanceBackgroundSection.stretch', 'Stretch')
+    },
+    {
+      value: 'tile',
+      label: translate('auto.components.settings.AppearanceBackgroundSection.tile', 'Tile')
+    }
+  ]
+}
+
+export function resolveAppearanceBackgroundAreas(
+  settings: Partial<OrcaBackgroundSettings>
+): Record<AppearanceBackgroundArea, boolean> {
+  const areas = settings.orcaBackgroundAreas
+  return {
+    terminal: areas?.terminal ?? DEFAULT_ORCA_BACKGROUND_SETTINGS.orcaBackgroundAreas.terminal,
+    leftSidebar:
+      areas?.leftSidebar ?? DEFAULT_ORCA_BACKGROUND_SETTINGS.orcaBackgroundAreas.leftSidebar,
+    rightSidebar:
+      areas?.rightSidebar ?? DEFAULT_ORCA_BACKGROUND_SETTINGS.orcaBackgroundAreas.rightSidebar
+  }
+}
+
+export function resolveAppearanceBackgroundImage(
+  settings: Partial<OrcaBackgroundSettings>,
+  area: AppearanceBackgroundArea
+): string | null {
+  if (settings.orcaBackgroundByArea && Object.hasOwn(settings.orcaBackgroundByArea, area)) {
+    return settings.orcaBackgroundByArea[area] || null
+  }
+  return settings.orcaBackgroundImage || null
+}
+
+export function resolveAppearanceBackgroundNumber(
+  areaValues: Partial<Record<AppearanceBackgroundArea, number>> | undefined,
+  shared: number | undefined,
+  area: AppearanceBackgroundArea,
+  fallback: number,
+  max: number
+): number {
+  const value = areaValues?.[area]
+  const resolved = typeof value === 'number' && Number.isFinite(value) ? value : shared
+  return typeof resolved === 'number' && Number.isFinite(resolved)
+    ? Math.min(max, Math.max(0, resolved))
+    : fallback
+}
+
+export function asBackgroundSettingsUpdate(
+  updates: Partial<OrcaBackgroundSettings>
+): Partial<GlobalSettings> {
+  return updates
+}
+
+export function getAppearanceBackgroundSearchEntry(): {
+  title: string
+  description: string
+  keywords: string[]
+} {
+  return {
+    title: translate(
+      'auto.components.settings.AppearanceBackgroundSection.title',
+      'Background Image'
+    ),
+    description: translate(
+      'auto.components.settings.AppearanceBackgroundSection.description',
+      'Use your own images behind the terminal and sidebars.'
+    ),
+    keywords: [
+      ...translateSearchKeyword(
+        'auto.components.settings.AppearanceBackgroundSection.keywordBackground',
+        'background'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.AppearanceBackgroundSection.keywordImage',
+        'image'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.AppearanceBackgroundSection.keywordWallpaper',
+        'wallpaper'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.AppearanceBackgroundSection.keywordTerminal',
+        'terminal'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.AppearanceBackgroundSection.keywordSidebar',
+        'sidebar'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.AppearanceBackgroundSection.keywordOpacity',
+        'opacity'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.AppearanceBackgroundSection.keywordBlur',
+        'blur'
+      )
+    ]
+  }
+}

--- a/src/renderer/src/components/settings/appearance-chrome-mock.test.tsx
+++ b/src/renderer/src/components/settings/appearance-chrome-mock.test.tsx
@@ -1,0 +1,191 @@
+// @vitest-environment happy-dom
+
+import '@testing-library/jest-dom/vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getDefaultSettings } from '../../../../shared/constants'
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import { AppearanceChromeMock } from './appearance-chrome-mock'
+
+describe('AppearanceChromeMock', () => {
+  const createObjectURL = vi.fn()
+  const revokeObjectURL = vi.fn()
+  const loadImage = vi.fn()
+
+  beforeEach(() => {
+    createObjectURL.mockReset()
+    revokeObjectURL.mockReset()
+    loadImage.mockReset()
+    Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: createObjectURL })
+    Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: revokeObjectURL })
+    ;(window as unknown as { api: unknown }).api = { backgrounds: { loadImage } }
+  })
+
+  afterEach(() => {
+    cleanup()
+    delete (window as unknown as { api?: unknown }).api
+  })
+
+  it('reflects drafted font, sidebar, card, navigation, and status settings', () => {
+    const settings: GlobalSettings = {
+      ...getDefaultSettings('/tmp'),
+      appFontFamily: 'IBM Plex Sans',
+      compactWorktreeCards: true,
+      leftSidebarAppearanceMode: 'tinted' as const,
+      leftSidebarTintColor: '#123456',
+      leftSidebarTintOpacity: 0.25,
+      showAutomationsButton: false,
+      showMobileButton: true,
+      showTasksButton: true,
+      showTitlebarAppName: false
+    }
+
+    render(
+      <AppearanceChromeMock
+        settings={settings}
+        systemPrefersDark={false}
+        statusBarItems={['codex', 'ssh', 'ports']}
+      />
+    )
+
+    const preview = screen.getByRole('img', {
+      name: 'Orca interface preview. Status bar: Codex, SSH, Ports'
+    })
+    expect(preview.style.getPropertyValue('--app-font-family')).toContain('"IBM Plex Sans"')
+    expect(preview.getAttribute('style')).toContain('font-family: var(--app-font-family)')
+
+    const sidebar = preview.querySelector<HTMLElement>('[data-left-sidebar-appearance="tinted"]')
+    expect(sidebar?.style.getPropertyValue('--worktree-sidebar')).toBe(
+      'color-mix(in srgb, #123456 25%, var(--background))'
+    )
+    expect(preview.querySelector('[data-workspace-card-layout="compact"]')).not.toBeNull()
+    expect(screen.getByText('Tasks')).toBeInTheDocument()
+    expect(screen.getByText('Mobile')).toBeInTheDocument()
+    expect(screen.queryByText('Automations')).not.toBeInTheDocument()
+    expect(screen.queryByText('feature/preview')).not.toBeInTheDocument()
+    expect(preview.querySelector('[data-titlebar-app-name-visible="false"]')).not.toBeNull()
+
+    for (const item of ['codex', 'ssh', 'ports']) {
+      expect(preview.querySelector(`[data-status-bar-item="${item}"]`)).not.toBeNull()
+    }
+  })
+
+  it('labels an empty-status detailed preview and exposes its visible chrome', () => {
+    const settings = {
+      ...getDefaultSettings('/tmp'),
+      compactWorktreeCards: false,
+      showAutomationsButton: false,
+      showMobileButton: false,
+      showTasksButton: false,
+      showTitlebarAppName: true
+    }
+
+    render(
+      <AppearanceChromeMock settings={settings} systemPrefersDark={false} statusBarItems={[]} />
+    )
+
+    const preview = screen.getByRole('img', { name: 'Orca interface preview' })
+    expect(preview.querySelector('[data-workspace-card-layout="detailed"]')).not.toBeNull()
+    expect(preview.querySelector('[data-titlebar-app-name-visible="true"]')).not.toBeNull()
+    expect(screen.getByText('Orca')).toBeInTheDocument()
+    expect(screen.getByText('feature/preview')).toBeInTheDocument()
+    expect(screen.getByText('1 terminal')).toBeInTheDocument()
+    expect(preview.querySelector('[data-status-bar-item]')).toBeNull()
+  })
+
+  it('renders independent draft images inside the left and right sidebar previews', async () => {
+    loadImage.mockResolvedValue({
+      ok: true,
+      data: new Uint8Array([1]),
+      mimeType: 'image/png'
+    })
+    createObjectURL.mockReturnValueOnce('blob:left').mockReturnValueOnce('blob:right')
+    const settings: GlobalSettings = {
+      ...getDefaultSettings('/tmp'),
+      orcaBackgroundByArea: {
+        terminal: 'terminal.png',
+        leftSidebar: 'left.png',
+        rightSidebar: 'right.png'
+      },
+      orcaBackgroundAreas: { terminal: true, leftSidebar: true, rightSidebar: true },
+      orcaBackgroundOpacity: 0.4,
+      orcaBackgroundOpacityByArea: { leftSidebar: 0.2, rightSidebar: 0.8 },
+      orcaBackgroundBlur: 6,
+      orcaBackgroundBlurByArea: { leftSidebar: 4, rightSidebar: 20 },
+      orcaBackgroundFit: 'contain'
+    }
+    const { rerender } = render(
+      <AppearanceChromeMock settings={settings} systemPrefersDark={false} statusBarItems={[]} />
+    )
+
+    await waitFor(() =>
+      expect(document.querySelectorAll('[data-appearance-preview-background]')).toHaveLength(2)
+    )
+
+    const leftArea = document.querySelector<HTMLElement>('[data-preview-area="left-sidebar"]')
+    const rightArea = document.querySelector<HTMLElement>('[data-preview-area="right-sidebar"]')
+    const leftLayer = leftArea?.querySelector<HTMLElement>(
+      '[data-appearance-preview-background="left-sidebar"]'
+    )
+    const rightLayer = rightArea?.querySelector<HTMLElement>(
+      '[data-appearance-preview-background="right-sidebar"]'
+    )
+    expect(leftLayer).toHaveAttribute('data-background-file-name', 'left.png')
+    expect(rightLayer).toHaveAttribute('data-background-file-name', 'right.png')
+    expect(leftLayer).toHaveStyle({
+      backgroundImage: 'url("blob:left")',
+      backgroundSize: 'contain',
+      filter: 'blur(4px)',
+      opacity: '0.2'
+    })
+    expect(rightLayer).toHaveStyle({
+      backgroundImage: 'url("blob:right")',
+      filter: 'blur(20px)',
+      opacity: '0.8'
+    })
+    expect(screen.getByText('Explorer')).toBeInTheDocument()
+    expect(loadImage).toHaveBeenCalledWith('left.png')
+    expect(loadImage).toHaveBeenCalledWith('right.png')
+
+    rerender(
+      <AppearanceChromeMock
+        settings={
+          {
+            ...settings,
+            orcaBackgroundOpacityByArea: { leftSidebar: 0.5, rightSidebar: 0.8 },
+            orcaBackgroundBlurByArea: { leftSidebar: 10, rightSidebar: 20 }
+          } as typeof settings
+        }
+        systemPrefersDark={false}
+        statusBarItems={[]}
+      />
+    )
+
+    expect(leftLayer).toHaveStyle({ filter: 'blur(10px)', opacity: '0.5' })
+    expect(rightLayer).toHaveStyle({ filter: 'blur(20px)', opacity: '0.8' })
+    expect(loadImage).toHaveBeenCalledTimes(2)
+
+    rerender(
+      <AppearanceChromeMock
+        settings={
+          {
+            ...settings,
+            orcaBackgroundAreas: { terminal: true, leftSidebar: false, rightSidebar: true }
+          } as typeof settings
+        }
+        systemPrefersDark={false}
+        statusBarItems={[]}
+      />
+    )
+
+    await waitFor(() =>
+      expect(
+        document.querySelector('[data-appearance-preview-background="left-sidebar"]')
+      ).toBeNull()
+    )
+    expect(
+      document.querySelector('[data-appearance-preview-background="right-sidebar"]')
+    ).not.toBeNull()
+  })
+})

--- a/src/renderer/src/components/settings/appearance-chrome-mock.tsx
+++ b/src/renderer/src/components/settings/appearance-chrome-mock.tsx
@@ -1,0 +1,294 @@
+import type React from 'react'
+import type { CSSProperties } from 'react'
+import { CalendarClock, GitBranch, List, PanelLeft, Smartphone, TerminalSquare } from 'lucide-react'
+
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import type { StatusBarItem } from '../../../../shared/ui-chrome-types'
+import { translate } from '@/i18n/i18n'
+import { buildAppFontFamily } from '@/lib/app-font-family'
+import { resolveLeftSidebarStyleVariables } from '@/lib/left-sidebar-appearance'
+import { Card } from '@/components/ui/card'
+import {
+  getAppearancePreviewBackgroundStyle,
+  useAppearancePreviewBackground
+} from './appearance-preview-background'
+import type { LoadedAppearancePreviewBackground } from './appearance-preview-background'
+
+type AppearanceChromeMockProps = {
+  settings: GlobalSettings
+  systemPrefersDark: boolean
+  statusBarItems: readonly StatusBarItem[]
+}
+
+type PreviewNavItem = {
+  id: string
+  label: string
+  icon: typeof List
+}
+
+const SYSTEM_STATUS_ITEMS = new Set<StatusBarItem>(['ssh', 'resource-usage', 'ports'])
+
+function isPreviewNavItemVisible(value: boolean | undefined): boolean {
+  return value !== false
+}
+
+function AppearancePreviewBackgroundLayer({
+  area,
+  background
+}: {
+  area: 'left-sidebar' | 'right-sidebar'
+  background: LoadedAppearancePreviewBackground | null
+}): React.JSX.Element | null {
+  if (!background) {
+    return null
+  }
+  return (
+    <div
+      className="pointer-events-none absolute inset-0"
+      data-appearance-preview-background={area}
+      data-background-file-name={background.fileName}
+      style={getAppearancePreviewBackgroundStyle(background)}
+      aria-hidden="true"
+    />
+  )
+}
+
+function statusBarItemLabel(item: StatusBarItem): string {
+  switch (item) {
+    case 'claude':
+      return 'Claude'
+    case 'codex':
+      return 'Codex'
+    case 'gemini':
+      return 'Gemini'
+    case 'antigravity':
+      return 'Antigravity'
+    case 'opencode-go':
+      return 'OpenCode Go'
+    case 'kimi':
+      return 'Kimi'
+    case 'minimax':
+      return 'MiniMax'
+    case 'grok':
+      return 'Grok'
+    case 'ssh':
+      return translate('auto.components.settings.AppearanceChromeMock.ssh', 'SSH')
+    case 'resource-usage':
+      return translate(
+        'auto.components.settings.AppearanceChromeMock.resourceUsage',
+        'Resource usage'
+      )
+    case 'ports':
+      return translate('auto.components.settings.AppearanceChromeMock.ports', 'Ports')
+  }
+}
+
+export function AppearanceChromeMock({
+  settings,
+  systemPrefersDark,
+  statusBarItems
+}: AppearanceChromeMockProps): React.JSX.Element {
+  const leftSidebarStyle = resolveLeftSidebarStyleVariables(settings, systemPrefersDark) as
+    | CSSProperties
+    | undefined
+  const leftSidebarBackground = useAppearancePreviewBackground(settings, 'leftSidebar')
+  const rightSidebarBackground = useAppearancePreviewBackground(settings, 'rightSidebar')
+  const appFontStyle = {
+    '--app-font-family': buildAppFontFamily(settings.appFontFamily),
+    fontFamily: 'var(--app-font-family)'
+  } as CSSProperties
+  const cardLayout = settings.compactWorktreeCards ? 'compact' : 'detailed'
+  const navItems: PreviewNavItem[] = [
+    ...(isPreviewNavItemVisible(settings.showTasksButton)
+      ? [
+          {
+            id: 'tasks',
+            label: translate('auto.components.settings.AppearanceChromeMock.tasks', 'Tasks'),
+            icon: List
+          }
+        ]
+      : []),
+    ...(isPreviewNavItemVisible(settings.showAutomationsButton)
+      ? [
+          {
+            id: 'automations',
+            label: translate(
+              'auto.components.settings.AppearanceChromeMock.automations',
+              'Automations'
+            ),
+            icon: CalendarClock
+          }
+        ]
+      : []),
+    ...(isPreviewNavItemVisible(settings.showMobileButton)
+      ? [
+          {
+            id: 'mobile',
+            label: translate('auto.components.settings.AppearanceChromeMock.mobile', 'Mobile'),
+            icon: Smartphone
+          }
+        ]
+      : [])
+  ]
+  const statusSummary = statusBarItems.map(statusBarItemLabel).join(', ')
+  const previewLabel = statusSummary
+    ? translate(
+        'auto.components.settings.AppearanceChromeMock.previewLabelWithStatus',
+        'Orca interface preview. Status bar: {{value0}}',
+        { value0: statusSummary }
+      )
+    : translate(
+        'auto.components.settings.AppearanceChromeMock.previewLabel',
+        'Orca interface preview'
+      )
+
+  return (
+    <Card
+      className="gap-0 overflow-hidden py-0"
+      style={appFontStyle}
+      role="img"
+      aria-label={previewLabel}
+    >
+      <div
+        className="flex h-8 items-center gap-2 border-b border-border/50 bg-[var(--bg-titlebar,var(--card))] px-3"
+        data-titlebar-app-name-visible={settings.showTitlebarAppName}
+      >
+        <PanelLeft className="size-3.5 text-muted-foreground" aria-hidden="true" />
+        {settings.showTitlebarAppName ? (
+          <span className="text-xs font-medium">{translate('auto.App.5096cbbc86', 'Orca')}</span>
+        ) : null}
+        <div className="ml-auto flex items-center gap-1" aria-hidden="true">
+          <span className="size-1.5 rounded-full bg-muted-foreground/30" />
+          <span className="size-1.5 rounded-full bg-muted-foreground/30" />
+          <span className="size-1.5 rounded-full bg-muted-foreground/30" />
+        </div>
+      </div>
+
+      <div className="flex h-60 min-h-0">
+        <div
+          className="relative isolate flex w-32 shrink-0 flex-col overflow-hidden border-r border-worktree-sidebar-border bg-worktree-sidebar text-worktree-sidebar-foreground"
+          style={leftSidebarStyle}
+          data-preview-area="left-sidebar"
+          data-left-sidebar-appearance={settings.leftSidebarAppearanceMode}
+        >
+          <AppearancePreviewBackgroundLayer
+            area="left-sidebar"
+            background={leftSidebarBackground}
+          />
+          {navItems.length > 0 ? (
+            <div className="relative z-10 space-y-0.5 border-b border-worktree-sidebar-border p-2">
+              {navItems.map((item) => {
+                const Icon = item.icon
+                return (
+                  <div
+                    key={item.id}
+                    className="flex items-center gap-2 rounded-md px-2 py-1 text-[11px] text-worktree-sidebar-foreground/60"
+                  >
+                    <Icon className="size-3.5 shrink-0" aria-hidden="true" />
+                    <span className="truncate">{item.label}</span>
+                  </div>
+                )
+              })}
+            </div>
+          ) : null}
+
+          <div className="relative z-10 min-h-0 flex-1 p-2">
+            <p className="px-2 pb-1 text-[11px] font-semibold uppercase tracking-[0.05em] text-worktree-sidebar-foreground/60">
+              {translate('auto.components.settings.AppearanceChromeMock.projects', 'Projects')}
+            </p>
+            <div
+              className="rounded-lg border border-worktree-sidebar-border bg-worktree-sidebar-accent px-2.5 py-2 text-worktree-sidebar-accent-foreground"
+              data-workspace-card-layout={cardLayout}
+            >
+              <div className="flex min-w-0 items-center gap-1.5">
+                <span className="size-1.5 shrink-0 rounded-full bg-worktree-sidebar-foreground/50" />
+                <span className="truncate text-xs font-medium">
+                  {translate(
+                    'auto.components.settings.AppearanceChromeMock.workspace',
+                    'appearance-preview'
+                  )}
+                </span>
+              </div>
+              {cardLayout === 'detailed' ? (
+                <div className="mt-2 space-y-1 text-[11px] text-worktree-sidebar-foreground/60">
+                  <div className="flex items-center gap-1.5">
+                    <GitBranch className="size-3 shrink-0" aria-hidden="true" />
+                    <span className="truncate">
+                      {translate(
+                        'auto.components.settings.AppearanceChromeMock.branchName',
+                        'feature/preview'
+                      )}
+                    </span>
+                  </div>
+                  <p className="truncate pl-4.5">
+                    {translate(
+                      'auto.components.settings.AppearanceChromeMock.terminalCount',
+                      '1 terminal'
+                    )}
+                  </p>
+                </div>
+              ) : null}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex min-w-0 flex-1 flex-col bg-background text-foreground">
+          <div className="flex h-8 items-center gap-2 border-b border-border/50 px-3 text-xs text-muted-foreground">
+            <TerminalSquare className="size-3.5" aria-hidden="true" />
+            <span className="truncate">
+              {translate('auto.components.settings.AppearanceChromeMock.editorPath', 'src/App.tsx')}
+            </span>
+          </div>
+          <div className="min-h-0 flex-1 bg-[var(--editor-surface)] p-3" aria-hidden="true">
+            <div className="space-y-2 font-mono">
+              <div className="h-1.5 w-3/4 rounded-full bg-muted-foreground/30" />
+              <div className="ml-3 h-1.5 w-1/2 rounded-full bg-muted-foreground/20" />
+              <div className="ml-3 h-1.5 w-2/3 rounded-full bg-muted-foreground/20" />
+              <div className="h-1.5 w-1/3 rounded-full bg-muted-foreground/30" />
+              <div className="mt-4 h-1.5 w-4/5 rounded-full bg-muted-foreground/20" />
+              <div className="ml-3 h-1.5 w-3/5 rounded-full bg-muted-foreground/20" />
+            </div>
+          </div>
+        </div>
+
+        <div
+          className="relative isolate flex w-20 shrink-0 flex-col overflow-hidden border-l border-border/50 bg-background text-foreground"
+          data-preview-area="right-sidebar"
+        >
+          <AppearancePreviewBackgroundLayer
+            area="right-sidebar"
+            background={rightSidebarBackground}
+          />
+          <div className="relative z-10 flex h-8 items-center gap-1.5 border-b border-border/50 px-2 text-[11px] text-muted-foreground">
+            <List className="size-3 shrink-0" aria-hidden="true" />
+            <span className="truncate">
+              {translate('auto.components.settings.AppearanceChromeMock.explorer', 'Explorer')}
+            </span>
+          </div>
+          <div className="relative z-10 min-h-0 flex-1 space-y-2 p-2" aria-hidden="true">
+            <div className="h-1.5 w-4/5 rounded-full bg-muted-foreground/30" />
+            <div className="ml-2 h-1.5 w-3/5 rounded-full bg-muted-foreground/20" />
+            <div className="ml-2 h-1.5 w-3/4 rounded-full bg-muted-foreground/20" />
+            <div className="h-1.5 w-2/3 rounded-full bg-muted-foreground/30" />
+          </div>
+        </div>
+      </div>
+
+      <div className="flex h-6 items-center gap-2 border-t border-border bg-[var(--bg-titlebar,var(--card))] px-3 text-[11px] text-muted-foreground">
+        <GitBranch className="size-3" aria-hidden="true" />
+        <span>{translate('auto.components.settings.AppearanceChromeMock.baseBranch', 'main')}</span>
+        <div className="ml-auto flex min-w-0 items-center gap-1" aria-hidden="true">
+          {statusBarItems.map((item) => (
+            <span
+              key={item}
+              data-status-bar-item={item}
+              className={`h-1.5 rounded-full bg-muted-foreground/50 ${
+                SYSTEM_STATUS_ITEMS.has(item) ? 'w-3' : 'w-1'
+              }`}
+            />
+          ))}
+        </div>
+      </div>
+    </Card>
+  )
+}

--- a/src/renderer/src/components/settings/appearance-draft-diff.test.ts
+++ b/src/renderer/src/components/settings/appearance-draft-diff.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import {
+  areAppearanceSettingValuesEqual,
+  getAppearanceDraftChangedKeys,
+  getAppearanceDraftChanges
+} from './appearance-draft-diff'
+
+function asSettings(values: Partial<GlobalSettings>): GlobalSettings {
+  return values as GlobalSettings
+}
+
+describe('appearance draft diff', () => {
+  it('compares primitive, null, and undefined values', () => {
+    expect(areAppearanceSettingValuesEqual('dark', 'dark')).toBe(true)
+    expect(areAppearanceSettingValuesEqual(true, false)).toBe(false)
+    expect(areAppearanceSettingValuesEqual(14, 15)).toBe(false)
+    expect(areAppearanceSettingValuesEqual(null, null)).toBe(true)
+    expect(areAppearanceSettingValuesEqual(null, undefined)).toBe(false)
+    expect(areAppearanceSettingValuesEqual(undefined, undefined)).toBe(true)
+  })
+
+  it('compares nested records independent of key order and arrays by value', () => {
+    const current = {
+      palette: { foreground: '#fff', background: '#000' },
+      variants: [{ name: 'dim', colors: ['gray', 'black'] }]
+    }
+    const reordered = {
+      variants: [{ colors: ['gray', 'black'], name: 'dim' }],
+      palette: { background: '#000', foreground: '#fff' }
+    }
+
+    expect(areAppearanceSettingValuesEqual(current, reordered)).toBe(true)
+    expect(
+      areAppearanceSettingValuesEqual(current, {
+        ...reordered,
+        variants: [{ colors: ['black', 'gray'], name: 'dim' }]
+      })
+    ).toBe(false)
+  })
+
+  it('keeps an explicit undefined reset in the changes', () => {
+    const settings = asSettings({ leftSidebarTintColor: '#336699' })
+    const changes = getAppearanceDraftChanges(settings, { leftSidebarTintColor: undefined })
+
+    expect(changes).toEqual({ leftSidebarTintColor: undefined })
+    expect(Object.hasOwn(changes, 'leftSidebarTintColor')).toBe(true)
+  })
+
+  it('returns only changed draft values and typed changed keys', () => {
+    const settings = asSettings({
+      theme: 'dark',
+      terminalFontSize: 14,
+      terminalColorOverrides: { foreground: '#fff' }
+    })
+    const draft: Partial<GlobalSettings> = {
+      theme: 'dark',
+      terminalFontSize: 16,
+      terminalColorOverrides: { foreground: '#fff' }
+    }
+    const changedKeys: (keyof GlobalSettings)[] = getAppearanceDraftChangedKeys(settings, draft)
+
+    expect(changedKeys).toEqual(['terminalFontSize'])
+    expect(getAppearanceDraftChanges(settings, draft)).toEqual({ terminalFontSize: 16 })
+  })
+})

--- a/src/renderer/src/components/settings/appearance-draft-diff.ts
+++ b/src/renderer/src/components/settings/appearance-draft-diff.ts
@@ -1,0 +1,34 @@
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import { structuralValuesEqual } from '../../../../shared/structural-value-equality'
+
+export function areAppearanceSettingValuesEqual(a: unknown, b: unknown): boolean {
+  return structuralValuesEqual(a, b)
+}
+
+export function getAppearanceDraftChangedKeys(
+  settings: GlobalSettings,
+  draft: Partial<GlobalSettings>
+): (keyof GlobalSettings)[] {
+  return (Object.keys(draft) as (keyof GlobalSettings)[]).filter(
+    (key) => !areAppearanceSettingValuesEqual(settings[key], draft[key])
+  )
+}
+
+export function getAppearanceDraftChanges(
+  settings: GlobalSettings,
+  draft: Partial<GlobalSettings>
+): Partial<GlobalSettings> {
+  const changes: Partial<GlobalSettings> = {}
+  for (const key of getAppearanceDraftChangedKeys(settings, draft)) {
+    copyAppearanceDraftValue(changes, draft, key)
+  }
+  return changes
+}
+
+function copyAppearanceDraftValue<Key extends keyof GlobalSettings>(
+  changes: Partial<GlobalSettings>,
+  draft: Partial<GlobalSettings>,
+  key: Key
+): void {
+  changes[key] = draft[key]
+}

--- a/src/renderer/src/components/settings/appearance-preview-background.test.tsx
+++ b/src/renderer/src/components/settings/appearance-preview-background.test.tsx
@@ -1,0 +1,313 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import { getDefaultSettings } from '../../../../shared/constants'
+import { createBackgroundImageObjectUrlApi } from '../../lib/background-image-object-url'
+import {
+  createAppearancePreviewBackgroundObjectUrl,
+  getAppearancePreviewBackgroundStyle,
+  resolveAppearancePreviewBackground,
+  useAppearancePreviewBackground
+} from './appearance-preview-background'
+
+type BackgroundOverrides = {
+  orcaBackgroundImage?: string | null
+  orcaBackgroundByArea?: Partial<Record<'terminal' | 'leftSidebar' | 'rightSidebar', string | null>>
+  orcaBackgroundOpacity?: number
+  orcaBackgroundOpacityByArea?: Partial<
+    Record<'terminal' | 'leftSidebar' | 'rightSidebar', unknown>
+  >
+  orcaBackgroundBlur?: number
+  orcaBackgroundBlurByArea?: Partial<Record<'terminal' | 'leftSidebar' | 'rightSidebar', unknown>>
+  orcaBackgroundFit?: string
+  orcaBackgroundAreas?: { terminal?: boolean; leftSidebar?: boolean; rightSidebar?: boolean }
+}
+
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+} {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((next) => {
+    resolve = next
+  })
+  return { promise, resolve }
+}
+
+function makeSettings(overrides: BackgroundOverrides = {}): GlobalSettings {
+  return { ...getDefaultSettings('/tmp'), ...overrides } as GlobalSettings
+}
+
+describe('appearance preview background', () => {
+  const createObjectURL = vi.fn(() => 'blob:preview-background')
+  const revokeObjectURL = vi.fn()
+  const decodeImage = vi.fn<(_: string) => Promise<void>>()
+  const loadImage = vi.fn()
+  const imageApi = { loadImage }
+  const backgroundObjectUrls = createBackgroundImageObjectUrlApi({
+    objectUrls: { createObjectURL, revokeObjectURL },
+    decodeImage
+  })
+  const dependencies = { imageApi, backgroundObjectUrls }
+
+  beforeEach(() => {
+    createObjectURL.mockReset().mockReturnValue('blob:preview-background')
+    revokeObjectURL.mockReset()
+    decodeImage.mockReset().mockResolvedValue()
+    loadImage.mockReset()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('preserves legacy defaults, clamps appearance, and gates each area independently', () => {
+    expect(resolveAppearancePreviewBackground(makeSettings(), 'terminal')).toBeNull()
+    const settings = makeSettings({
+      orcaBackgroundImage: 'ocean.png',
+      orcaBackgroundOpacity: 3,
+      orcaBackgroundBlur: -2,
+      orcaBackgroundFit: 'tile',
+      orcaBackgroundAreas: { terminal: true, leftSidebar: true, rightSidebar: false }
+    })
+
+    expect(resolveAppearancePreviewBackground(settings, 'terminal')).toEqual({
+      area: 'terminal',
+      fileName: 'ocean.png',
+      opacity: 1,
+      blurPx: 0,
+      fit: 'tile'
+    })
+    expect(resolveAppearancePreviewBackground(settings, 'leftSidebar')).toMatchObject({
+      area: 'leftSidebar',
+      fileName: 'ocean.png'
+    })
+    expect(resolveAppearancePreviewBackground(settings, 'rightSidebar')).toBeNull()
+    expect(
+      resolveAppearancePreviewBackground(
+        makeSettings({ orcaBackgroundImage: 'ocean.png', orcaBackgroundFit: 'toString' }),
+        'terminal'
+      )
+    ).toMatchObject({ fit: 'cover' })
+  })
+
+  it('resolves distinct images, partial legacy fallback, and explicit per-area clearing', () => {
+    const distinct = makeSettings({
+      orcaBackgroundImage: 'legacy.png',
+      orcaBackgroundByArea: {
+        terminal: 'terminal.png',
+        leftSidebar: 'left.png',
+        rightSidebar: 'right.png'
+      },
+      orcaBackgroundAreas: { terminal: true, leftSidebar: true, rightSidebar: true }
+    })
+
+    expect(resolveAppearancePreviewBackground(distinct, 'terminal')?.fileName).toBe('terminal.png')
+    expect(resolveAppearancePreviewBackground(distinct, 'leftSidebar')?.fileName).toBe('left.png')
+    expect(resolveAppearancePreviewBackground(distinct, 'rightSidebar')?.fileName).toBe('right.png')
+
+    const partial = makeSettings({
+      orcaBackgroundImage: 'legacy.png',
+      orcaBackgroundByArea: { terminal: 'terminal.png', leftSidebar: null },
+      orcaBackgroundAreas: { terminal: true, leftSidebar: true, rightSidebar: true }
+    })
+    expect(resolveAppearancePreviewBackground(partial, 'terminal')?.fileName).toBe('terminal.png')
+    expect(resolveAppearancePreviewBackground(partial, 'leftSidebar')).toBeNull()
+    expect(resolveAppearancePreviewBackground(partial, 'rightSidebar')?.fileName).toBe('legacy.png')
+  })
+
+  it('maps blur, opacity, and fit to the live background treatment', () => {
+    expect(
+      getAppearancePreviewBackgroundStyle({
+        area: 'rightSidebar',
+        fileName: 'ocean.png',
+        objectUrl: 'blob:ocean',
+        opacity: 0.42,
+        blurPx: 10,
+        fit: 'stretch'
+      })
+    ).toEqual({
+      backgroundImage: 'url("blob:ocean")',
+      backgroundPosition: 'center center',
+      backgroundSize: '100% 100%',
+      backgroundRepeat: 'no-repeat',
+      opacity: 0.42,
+      filter: 'blur(10px)',
+      transform: 'scale(1.4)',
+      transformOrigin: 'center center'
+    })
+  })
+
+  it('resolves opacity and blur independently with shared fallback', () => {
+    const settings = makeSettings({
+      orcaBackgroundImage: 'ocean.png',
+      orcaBackgroundAreas: { terminal: true, leftSidebar: true, rightSidebar: true },
+      orcaBackgroundOpacity: 0.49,
+      orcaBackgroundOpacityByArea: { terminal: 0, leftSidebar: 2, rightSidebar: null },
+      orcaBackgroundBlur: 4,
+      orcaBackgroundBlurByArea: { terminal: 8, leftSidebar: -2, rightSidebar: Infinity }
+    })
+
+    expect(resolveAppearancePreviewBackground(settings, 'terminal')).toMatchObject({
+      opacity: 0,
+      blurPx: 8
+    })
+    expect(resolveAppearancePreviewBackground(settings, 'leftSidebar')).toMatchObject({
+      opacity: 1,
+      blurPx: 0
+    })
+    expect(resolveAppearancePreviewBackground(settings, 'rightSidebar')).toMatchObject({
+      opacity: 0.49,
+      blurPx: 4
+    })
+  })
+
+  it('returns an object URL only after the background bytes decode', async () => {
+    const decode = deferred<void>()
+    decodeImage.mockReturnValue(decode.promise)
+    loadImage.mockResolvedValue({
+      ok: true,
+      data: new Uint8Array([1, 2, 3]),
+      mimeType: 'image/png'
+    })
+
+    const pending = createAppearancePreviewBackgroundObjectUrl(
+      'ocean.png',
+      imageApi,
+      backgroundObjectUrls
+    )
+
+    await waitFor(() => expect(decodeImage).toHaveBeenCalledWith('blob:preview-background'))
+    decode.resolve(undefined)
+    await expect(pending).resolves.toBe('blob:preview-background')
+
+    expect(loadImage).toHaveBeenCalledWith('ocean.png')
+    expect(createObjectURL).toHaveBeenCalledWith(expect.any(Blob))
+  })
+
+  it('updates appearance without reloading bytes and revokes the URL when disabled', async () => {
+    loadImage.mockResolvedValue({
+      ok: true,
+      data: new Uint8Array([1]),
+      mimeType: 'image/png'
+    })
+    const initial = makeSettings({
+      orcaBackgroundByArea: { terminal: 'ocean.png' },
+      orcaBackgroundOpacity: 0.2,
+      orcaBackgroundBlur: 4,
+      orcaBackgroundFit: 'cover'
+    })
+    const { result, rerender } = renderHook(
+      ({ settings }: { settings: GlobalSettings }) =>
+        useAppearancePreviewBackground(settings, 'terminal', dependencies),
+      { initialProps: { settings: initial } }
+    )
+
+    await waitFor(() => expect(result.current?.objectUrl).toBe('blob:preview-background'))
+
+    rerender({
+      settings: makeSettings({
+        orcaBackgroundByArea: { terminal: 'ocean.png' },
+        orcaBackgroundOpacity: 0.2,
+        orcaBackgroundOpacityByArea: { terminal: 0.65 },
+        orcaBackgroundBlur: 4,
+        orcaBackgroundBlurByArea: { terminal: 18 },
+        orcaBackgroundFit: 'contain'
+      })
+    })
+
+    expect(result.current).toMatchObject({ opacity: 0.65, blurPx: 18, fit: 'contain' })
+    expect(loadImage).toHaveBeenCalledOnce()
+
+    rerender({
+      settings: makeSettings({
+        orcaBackgroundByArea: { terminal: 'ocean.png' },
+        orcaBackgroundAreas: { terminal: false }
+      })
+    })
+
+    await waitFor(() => expect(result.current).toBeNull())
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:preview-background')
+  })
+
+  it('keeps one failed area empty without throwing', async () => {
+    loadImage.mockResolvedValue({ ok: false, reason: 'read-failed' })
+    const { result } = renderHook(() =>
+      useAppearancePreviewBackground(
+        makeSettings({
+          orcaBackgroundByArea: { leftSidebar: 'missing.png' },
+          orcaBackgroundAreas: { leftSidebar: true }
+        }),
+        'leftSidebar',
+        dependencies
+      )
+    )
+
+    await waitFor(() => expect(loadImage).toHaveBeenCalledOnce())
+
+    expect(result.current).toBeNull()
+    expect(createObjectURL).not.toHaveBeenCalled()
+  })
+
+  it('never combines the next file settings with the previous image URL', async () => {
+    const firstLoad = deferred<{
+      ok: true
+      data: Uint8Array
+      mimeType: string
+    }>()
+    const secondLoad = deferred<{
+      ok: true
+      data: Uint8Array
+      mimeType: string
+    }>()
+    loadImage.mockImplementation((fileName: string) =>
+      fileName === 'first.png' ? firstLoad.promise : secondLoad.promise
+    )
+    createObjectURL.mockReturnValueOnce('blob:second').mockReturnValueOnce('blob:first')
+
+    const { result, rerender } = renderHook(
+      ({ settings }: { settings: GlobalSettings }) =>
+        useAppearancePreviewBackground(settings, 'leftSidebar', dependencies),
+      {
+        initialProps: {
+          settings: makeSettings({
+            orcaBackgroundByArea: { leftSidebar: 'first.png' },
+            orcaBackgroundAreas: { leftSidebar: true },
+            orcaBackgroundOpacity: 0.2
+          })
+        }
+      }
+    )
+
+    rerender({
+      settings: makeSettings({
+        orcaBackgroundByArea: { leftSidebar: 'second.png' },
+        orcaBackgroundAreas: { leftSidebar: true },
+        orcaBackgroundOpacity: 0.8
+      })
+    })
+    expect(result.current).toBeNull()
+
+    await act(async () => {
+      secondLoad.resolve({ ok: true, data: new Uint8Array([2]), mimeType: 'image/png' })
+      await secondLoad.promise
+    })
+    await waitFor(() =>
+      expect(result.current).toMatchObject({
+        fileName: 'second.png',
+        objectUrl: 'blob:second',
+        opacity: 0.8
+      })
+    )
+
+    await act(async () => {
+      firstLoad.resolve({ ok: true, data: new Uint8Array([1]), mimeType: 'image/png' })
+      await firstLoad.promise
+    })
+    expect(result.current).toMatchObject({ fileName: 'second.png', objectUrl: 'blob:second' })
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:first')
+  })
+})

--- a/src/renderer/src/components/settings/appearance-preview-background.ts
+++ b/src/renderer/src/components/settings/appearance-preview-background.ts
@@ -1,0 +1,178 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import type { CSSProperties } from 'react'
+
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import type { OrcaBackgroundFit } from '../../../../shared/orca-background-settings'
+import {
+  browserBackgroundImageObjectUrls,
+  type BackgroundImageObjectUrlApi
+} from '../../lib/background-image-object-url'
+import {
+  resolveAppearanceBackground,
+  type AppearanceBackgroundArea
+} from '../../lib/appearance-background-settings'
+
+export type { AppearanceBackgroundArea } from '../../lib/appearance-background-settings'
+
+type BackgroundImageLoadResult =
+  | { ok: true; data: Uint8Array; mimeType: string }
+  | { ok: false; reason: string }
+
+type BackgroundImageApi = {
+  loadImage: (fileName: string) => Promise<BackgroundImageLoadResult>
+}
+
+export type AppearancePreviewBackground = {
+  area: AppearanceBackgroundArea
+  fileName: string
+  opacity: number
+  blurPx: number
+  fit: OrcaBackgroundFit
+}
+
+export type LoadedAppearancePreviewBackground = AppearancePreviewBackground & {
+  objectUrl: string
+}
+
+const BACKGROUND_FITS: Record<
+  OrcaBackgroundFit,
+  Pick<CSSProperties, 'backgroundRepeat' | 'backgroundSize'>
+> = {
+  cover: { backgroundSize: 'cover', backgroundRepeat: 'no-repeat' },
+  contain: { backgroundSize: 'contain', backgroundRepeat: 'no-repeat' },
+  stretch: { backgroundSize: '100% 100%', backgroundRepeat: 'no-repeat' },
+  tile: { backgroundSize: 'auto', backgroundRepeat: 'repeat' }
+}
+
+function getBackgroundImageApi(): BackgroundImageApi | null {
+  if (typeof window === 'undefined') {
+    return null
+  }
+  const backgrounds = (
+    window as Window & {
+      api?: { backgrounds?: BackgroundImageApi }
+    }
+  ).api?.backgrounds
+  return backgrounds && typeof backgrounds.loadImage === 'function' ? backgrounds : null
+}
+
+export function resolveAppearancePreviewBackground(
+  settings: GlobalSettings,
+  area: AppearanceBackgroundArea
+): AppearancePreviewBackground | null {
+  const background = resolveAppearanceBackground(settings, area)
+  if (!background.active || !background.imageName) {
+    return null
+  }
+
+  return {
+    area,
+    fileName: background.imageName,
+    opacity: background.opacity,
+    blurPx: background.blurPx,
+    fit: background.fit
+  }
+}
+
+export async function createAppearancePreviewBackgroundObjectUrl(
+  fileName: string,
+  api: BackgroundImageApi | null = getBackgroundImageApi(),
+  backgroundObjectUrls: BackgroundImageObjectUrlApi = browserBackgroundImageObjectUrls
+): Promise<string | null> {
+  if (!api) {
+    return null
+  }
+  try {
+    const result = await api.loadImage(fileName)
+    if (!result.ok) {
+      return null
+    }
+    return backgroundObjectUrls.create(result.data, result.mimeType)
+  } catch {
+    return null
+  }
+}
+
+export function getAppearancePreviewBackgroundStyle(
+  background: LoadedAppearancePreviewBackground
+): CSSProperties {
+  return {
+    backgroundImage: `url("${background.objectUrl}")`,
+    backgroundPosition: 'center center',
+    ...BACKGROUND_FITS[background.fit],
+    opacity: background.opacity,
+    filter: `blur(${background.blurPx}px)`,
+    transform: `scale(${Math.min(2, 1 + background.blurPx / 25)})`,
+    transformOrigin: 'center center'
+  }
+}
+
+export function useAppearancePreviewBackground(
+  settings: GlobalSettings,
+  area: AppearanceBackgroundArea,
+  dependencies: {
+    imageApi?: BackgroundImageApi | null
+    backgroundObjectUrls?: BackgroundImageObjectUrlApi
+  } = {}
+): LoadedAppearancePreviewBackground | null {
+  const background = useMemo(
+    () => resolveAppearancePreviewBackground(settings, area),
+    [area, settings]
+  )
+  const fileName = background?.fileName ?? null
+  const [loadedImage, setLoadedImage] = useState<{
+    fileName: string
+    objectUrl: string
+  } | null>(null)
+  const objectUrlRef = useRef<{
+    objectUrl: string
+    owner: BackgroundImageObjectUrlApi
+  } | null>(null)
+  const imageApi =
+    dependencies.imageApi === undefined ? getBackgroundImageApi() : dependencies.imageApi
+  const backgroundObjectUrls = dependencies.backgroundObjectUrls ?? browserBackgroundImageObjectUrls
+
+  useEffect(() => {
+    let cancelled = false
+    if (objectUrlRef.current) {
+      objectUrlRef.current.owner.revoke(objectUrlRef.current.objectUrl)
+      objectUrlRef.current = null
+    }
+    setLoadedImage(null)
+
+    if (!fileName) {
+      return
+    }
+
+    void createAppearancePreviewBackgroundObjectUrl(fileName, imageApi, backgroundObjectUrls).then(
+      (nextUrl) => {
+        if (cancelled) {
+          if (nextUrl) {
+            backgroundObjectUrls.revoke(nextUrl)
+          }
+          return
+        }
+        objectUrlRef.current = nextUrl ? { objectUrl: nextUrl, owner: backgroundObjectUrls } : null
+        setLoadedImage(nextUrl ? { fileName, objectUrl: nextUrl } : null)
+      }
+    )
+
+    return () => {
+      cancelled = true
+    }
+  }, [backgroundObjectUrls, fileName, imageApi])
+
+  useEffect(
+    () => () => {
+      if (objectUrlRef.current) {
+        objectUrlRef.current.owner.revoke(objectUrlRef.current.objectUrl)
+        objectUrlRef.current = null
+      }
+    },
+    []
+  )
+
+  return background && loadedImage?.fileName === background.fileName
+    ? { ...background, objectUrl: loadedImage.objectUrl }
+    : null
+}

--- a/src/renderer/src/components/settings/appearance-search.ts
+++ b/src/renderer/src/components/settings/appearance-search.ts
@@ -8,6 +8,7 @@ import { SHOW_UI_LANGUAGE_SETTING } from '@/i18n/supported-languages'
 import { getStatusBarToggles } from './appearance-status-bar-search'
 import { getUsagePercentageDisplayEntry } from './appearance-usage-percentage-search'
 import { getMenuBarIconEntries, getSystemTrayEntries } from './appearance-system-presence-search'
+import { getAppearanceBackgroundSearchEntry } from './appearance-background-section-model'
 
 export {
   getMenuBarIconEntries,
@@ -224,6 +225,7 @@ type AppearancePaneSearchOptions = {
   showWarpImport?: boolean
   showSystemTray?: boolean
   showMenuBarIcon?: boolean
+  showBackgroundImages?: boolean
 }
 
 function buildAppearancePaneSearchEntries(
@@ -240,6 +242,7 @@ function buildAppearancePaneSearchEntries(
     ...getTitlebarEntries(),
     ...getStatusBarEntries(),
     ...getSidebarEntries(),
+    ...(options.showBackgroundImages ? [getAppearanceBackgroundSearchEntry()] : []),
     ...getAppIconEntries(),
     ...getSystemTrayEntries(options),
     ...getMenuBarIconEntries(options)
@@ -252,6 +255,7 @@ export function getAppearancePaneSearchEntries(
   return buildAppearancePaneSearchEntries({
     showWarpImport: options.showWarpImport ?? true,
     showSystemTray: options.showSystemTray,
-    showMenuBarIcon: options.showMenuBarIcon
+    showMenuBarIcon: options.showMenuBarIcon,
+    showBackgroundImages: options.showBackgroundImages ?? true
   })
 }

--- a/src/renderer/src/components/settings/settings-page-leave-transaction.test.ts
+++ b/src/renderer/src/components/settings/settings-page-leave-transaction.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  runSettingsPageLeaveTransaction,
+  runSettingsWindowCloseGuard
+} from './settings-page-leave-transaction'
+
+type TransactionOverrides = Partial<Parameters<typeof runSettingsPageLeaveTransaction>[0]>
+
+function createTransaction(overrides: TransactionOverrides = {}) {
+  return {
+    appearanceDirty: true,
+    sourceControlDirty: true,
+    confirmAppearanceLeave: vi.fn(async () => true),
+    confirmSourceControlDiscard: vi.fn(async () => true),
+    discardAppearanceDraft: vi.fn(),
+    discardSourceControlDrafts: vi.fn(),
+    ...overrides
+  }
+}
+
+describe('settings page leave transaction', () => {
+  it('leaves immediately when both drafts are clean', async () => {
+    const transaction = createTransaction({ appearanceDirty: false, sourceControlDirty: false })
+
+    await expect(runSettingsPageLeaveTransaction(transaction)).resolves.toBe(true)
+
+    expect(transaction.confirmAppearanceLeave).not.toHaveBeenCalled()
+    expect(transaction.confirmSourceControlDiscard).not.toHaveBeenCalled()
+    expect(transaction.discardAppearanceDraft).not.toHaveBeenCalled()
+    expect(transaction.discardSourceControlDrafts).not.toHaveBeenCalled()
+  })
+
+  it('confirms in order and commits both discards after approval', async () => {
+    const events: string[] = []
+    const transaction = createTransaction({
+      confirmAppearanceLeave: vi.fn(async ({ discardDraftOnLeave }) => {
+        events.push(`appearance:${discardDraftOnLeave}`)
+        return true
+      }),
+      confirmSourceControlDiscard: vi.fn(async () => {
+        events.push('source-control')
+        return true
+      }),
+      discardAppearanceDraft: vi.fn(() => events.push('discard-appearance')),
+      discardSourceControlDrafts: vi.fn(() => events.push('discard-source-control'))
+    })
+
+    await expect(runSettingsPageLeaveTransaction(transaction)).resolves.toBe(true)
+
+    expect(events).toEqual([
+      'appearance:false',
+      'source-control',
+      'discard-appearance',
+      'discard-source-control'
+    ])
+  })
+
+  it('preserves both drafts when Appearance cancels', async () => {
+    const transaction = createTransaction({
+      confirmAppearanceLeave: vi.fn(async () => false)
+    })
+
+    await expect(runSettingsPageLeaveTransaction(transaction)).resolves.toBe(false)
+
+    expect(transaction.confirmSourceControlDiscard).not.toHaveBeenCalled()
+    expect(transaction.discardAppearanceDraft).not.toHaveBeenCalled()
+    expect(transaction.discardSourceControlDrafts).not.toHaveBeenCalled()
+  })
+
+  it('preserves both drafts when Source Control cancels', async () => {
+    const transaction = createTransaction({
+      confirmSourceControlDiscard: vi.fn(async () => false)
+    })
+
+    await expect(runSettingsPageLeaveTransaction(transaction)).resolves.toBe(false)
+
+    expect(transaction.confirmAppearanceLeave).toHaveBeenCalledWith({ discardDraftOnLeave: false })
+    expect(transaction.discardAppearanceDraft).not.toHaveBeenCalled()
+    expect(transaction.discardSourceControlDrafts).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['Appearance', true, false, 'discardAppearanceDraft'],
+    ['Source Control', false, true, 'discardSourceControlDrafts']
+  ] as const)(
+    'prompts and discards only the dirty %s draft',
+    async (_, appearanceDirty, sourceControlDirty, discardKey) => {
+      const transaction = createTransaction({ appearanceDirty, sourceControlDirty })
+
+      await expect(runSettingsPageLeaveTransaction(transaction)).resolves.toBe(true)
+
+      expect(transaction.confirmAppearanceLeave).toHaveBeenCalledTimes(appearanceDirty ? 1 : 0)
+      expect(transaction.confirmSourceControlDiscard).toHaveBeenCalledTimes(
+        sourceControlDirty ? 1 : 0
+      )
+      expect(transaction.discardAppearanceDraft).toHaveBeenCalledTimes(
+        discardKey === 'discardAppearanceDraft' ? 1 : 0
+      )
+      expect(transaction.discardSourceControlDrafts).toHaveBeenCalledTimes(
+        discardKey === 'discardSourceControlDrafts' ? 1 : 0
+      )
+    }
+  )
+})
+
+describe('settings window close guard', () => {
+  it('keeps a discarded appearance draft until every downstream close prompt approves', async () => {
+    const confirmAppearanceLeave = vi.fn(async () => true)
+
+    await expect(
+      runSettingsWindowCloseGuard({
+        intentionalRestart: false,
+        sourceControlDirty: false,
+        confirmAppearanceLeave,
+        confirmSourceControlDiscard: vi.fn(async () => true)
+      })
+    ).resolves.toBe(true)
+
+    expect(confirmAppearanceLeave).toHaveBeenCalledWith({ discardDraftOnLeave: false })
+  })
+
+  it('stops before Appearance when Source Control vetoes the close', async () => {
+    const confirmAppearanceLeave = vi.fn(async () => true)
+
+    await expect(
+      runSettingsWindowCloseGuard({
+        intentionalRestart: false,
+        sourceControlDirty: true,
+        confirmAppearanceLeave,
+        confirmSourceControlDiscard: vi.fn(async () => false)
+      })
+    ).resolves.toBe(false)
+
+    expect(confirmAppearanceLeave).not.toHaveBeenCalled()
+  })
+
+  it('bypasses draft prompts during an intentional restart', async () => {
+    const confirmAppearanceLeave = vi.fn(async () => false)
+    const confirmSourceControlDiscard = vi.fn(async () => false)
+
+    await expect(
+      runSettingsWindowCloseGuard({
+        intentionalRestart: true,
+        sourceControlDirty: true,
+        confirmAppearanceLeave,
+        confirmSourceControlDiscard
+      })
+    ).resolves.toBe(true)
+
+    expect(confirmAppearanceLeave).not.toHaveBeenCalled()
+    expect(confirmSourceControlDiscard).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/settings/settings-page-leave-transaction.test.ts
+++ b/src/renderer/src/components/settings/settings-page-leave-transaction.test.ts
@@ -134,6 +134,21 @@ describe('settings window close guard', () => {
     expect(confirmAppearanceLeave).not.toHaveBeenCalled()
   })
 
+  it('keeps the window open when Appearance vetoes the close', async () => {
+    const confirmAppearanceLeave = vi.fn(async () => false)
+
+    await expect(
+      runSettingsWindowCloseGuard({
+        intentionalRestart: false,
+        sourceControlDirty: false,
+        confirmAppearanceLeave,
+        confirmSourceControlDiscard: vi.fn(async () => true)
+      })
+    ).resolves.toBe(false)
+
+    expect(confirmAppearanceLeave).toHaveBeenCalledWith({ discardDraftOnLeave: false })
+  })
+
   it('bypasses draft prompts during an intentional restart', async () => {
     const confirmAppearanceLeave = vi.fn(async () => false)
     const confirmSourceControlDiscard = vi.fn(async () => false)

--- a/src/renderer/src/components/settings/settings-page-leave-transaction.ts
+++ b/src/renderer/src/components/settings/settings-page-leave-transaction.ts
@@ -1,0 +1,53 @@
+export type SettingsPageLeaveTransaction = {
+  appearanceDirty: boolean
+  sourceControlDirty: boolean
+  confirmAppearanceLeave: (options: { discardDraftOnLeave: false }) => Promise<boolean>
+  confirmSourceControlDiscard: () => Promise<boolean>
+  discardAppearanceDraft: () => void
+  discardSourceControlDrafts: () => void
+}
+
+export type SettingsWindowCloseGuard = {
+  intentionalRestart: boolean
+  sourceControlDirty: boolean
+  confirmAppearanceLeave: (options: { discardDraftOnLeave: false }) => Promise<boolean>
+  confirmSourceControlDiscard: () => Promise<boolean>
+}
+
+export async function runSettingsWindowCloseGuard({
+  intentionalRestart,
+  sourceControlDirty,
+  confirmAppearanceLeave,
+  confirmSourceControlDiscard
+}: SettingsWindowCloseGuard): Promise<boolean> {
+  if (intentionalRestart) {
+    return true
+  }
+  if (sourceControlDirty && !(await confirmSourceControlDiscard())) {
+    return false
+  }
+  return confirmAppearanceLeave({ discardDraftOnLeave: false })
+}
+
+export async function runSettingsPageLeaveTransaction({
+  appearanceDirty,
+  sourceControlDirty,
+  confirmAppearanceLeave,
+  confirmSourceControlDiscard,
+  discardAppearanceDraft,
+  discardSourceControlDrafts
+}: SettingsPageLeaveTransaction): Promise<boolean> {
+  if (appearanceDirty && !(await confirmAppearanceLeave({ discardDraftOnLeave: false }))) {
+    return false
+  }
+  if (sourceControlDirty && !(await confirmSourceControlDiscard())) {
+    return false
+  }
+  if (appearanceDirty) {
+    discardAppearanceDraft()
+  }
+  if (sourceControlDirty) {
+    discardSourceControlDrafts()
+  }
+  return true
+}

--- a/src/renderer/src/components/settings/settings-section-navigation.test.ts
+++ b/src/renderer/src/components/settings/settings-section-navigation.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  pinDirtySettingsNavSections,
+  releaseSettledSettingsNavGuard,
+  runSettingsSectionLeaveConfirmation,
+  settleAppearanceSettingsSectionBeforeLeave
+} from './settings-section-navigation'
+
+describe('settings section navigation', () => {
+  it('settles only Appearance when navigating away from a dirty Appearance section', async () => {
+    const confirmAppearance = vi.fn().mockResolvedValue(true)
+    const confirmSourceControl = vi.fn().mockResolvedValue(true)
+    const discardAppearance = vi.fn()
+
+    await expect(
+      runSettingsSectionLeaveConfirmation('appearance', {
+        appearance: () =>
+          settleAppearanceSettingsSectionBeforeLeave({
+            dirty: true,
+            confirmLeave: confirmAppearance,
+            discardDraft: discardAppearance
+          }),
+        sourceControl: confirmSourceControl
+      })
+    ).resolves.toBe(true)
+
+    expect(confirmAppearance).toHaveBeenCalledWith({ discardDraftOnLeave: false })
+    expect(discardAppearance).toHaveBeenCalledOnce()
+    expect(confirmSourceControl).not.toHaveBeenCalled()
+  })
+
+  it('preserves the Appearance draft when leaving is canceled', async () => {
+    const discardAppearance = vi.fn()
+
+    await expect(
+      settleAppearanceSettingsSectionBeforeLeave({
+        dirty: true,
+        confirmLeave: vi.fn().mockResolvedValue(false),
+        discardDraft: discardAppearance
+      })
+    ).resolves.toBe(false)
+
+    expect(discardAppearance).not.toHaveBeenCalled()
+  })
+
+  it('pins dirty Appearance and Git sections when search has no matches', () => {
+    const git = { id: 'git' }
+    const appearance = { id: 'appearance' }
+    const sectionById = new Map([
+      [git.id, git],
+      [appearance.id, appearance]
+    ])
+
+    expect(
+      pinDirtySettingsNavSections([], sectionById, {
+        appearance: true,
+        sourceControl: true
+      })
+    ).toEqual([git, appearance])
+  })
+
+  it('does not duplicate dirty sections already matched by search', () => {
+    const appearance = { id: 'appearance' }
+
+    expect(
+      pinDirtySettingsNavSections([appearance], new Map([[appearance.id, appearance]]), {
+        appearance: true,
+        sourceControl: false
+      })
+    ).toEqual([appearance])
+  })
+
+  it('releases a settled stale guard without clearing a newer navigation guard', () => {
+    expect(releaseSettledSettingsNavGuard('appearance', 'appearance')).toBeNull()
+    expect(releaseSettledSettingsNavGuard('git', 'appearance')).toBe('git')
+  })
+})

--- a/src/renderer/src/components/settings/settings-section-navigation.test.ts
+++ b/src/renderer/src/components/settings/settings-section-navigation.test.ts
@@ -43,6 +43,36 @@ describe('settings section navigation', () => {
     expect(discardAppearance).not.toHaveBeenCalled()
   })
 
+  it('settles only Source Control when navigating away from Git', async () => {
+    const confirmAppearance = vi.fn().mockResolvedValue(true)
+    const confirmSourceControl = vi.fn().mockResolvedValue(false)
+
+    await expect(
+      runSettingsSectionLeaveConfirmation('git', {
+        appearance: confirmAppearance,
+        sourceControl: confirmSourceControl
+      })
+    ).resolves.toBe(false)
+
+    expect(confirmAppearance).not.toHaveBeenCalled()
+    expect(confirmSourceControl).toHaveBeenCalledOnce()
+  })
+
+  it('does not settle unrelated sections', async () => {
+    const confirmAppearance = vi.fn().mockResolvedValue(false)
+    const confirmSourceControl = vi.fn().mockResolvedValue(false)
+
+    await expect(
+      runSettingsSectionLeaveConfirmation('general', {
+        appearance: confirmAppearance,
+        sourceControl: confirmSourceControl
+      })
+    ).resolves.toBe(true)
+
+    expect(confirmAppearance).not.toHaveBeenCalled()
+    expect(confirmSourceControl).not.toHaveBeenCalled()
+  })
+
   it('pins dirty Appearance and Git sections when search has no matches', () => {
     const git = { id: 'git' }
     const appearance = { id: 'appearance' }

--- a/src/renderer/src/components/settings/settings-section-navigation.ts
+++ b/src/renderer/src/components/settings/settings-section-navigation.ts
@@ -54,7 +54,13 @@ export function runSettingsSectionLeaveConfirmation(
   sectionId: string,
   confirmations: SettingsSectionLeaveConfirmations
 ): Promise<boolean> {
-  return sectionId === 'appearance' ? confirmations.appearance() : confirmations.sourceControl()
+  if (sectionId === 'appearance') {
+    return confirmations.appearance()
+  }
+  if (sectionId === 'git') {
+    return confirmations.sourceControl()
+  }
+  return Promise.resolve(true)
 }
 
 export function releaseSettledSettingsNavGuard(

--- a/src/renderer/src/components/settings/settings-section-navigation.ts
+++ b/src/renderer/src/components/settings/settings-section-navigation.ts
@@ -1,0 +1,65 @@
+type SettingsNavEntry = {
+  id: string
+}
+
+type DirtySettingsSections = {
+  appearance: boolean
+  sourceControl: boolean
+}
+
+type SettingsSectionLeaveConfirmations = {
+  appearance: () => Promise<boolean>
+  sourceControl: () => Promise<boolean>
+}
+
+type AppearanceSectionLeave = {
+  dirty: boolean
+  confirmLeave: (options: { discardDraftOnLeave: false }) => Promise<boolean>
+  discardDraft: () => void
+}
+
+export function pinDirtySettingsNavSections<T extends SettingsNavEntry>(
+  rankedSections: readonly T[],
+  sectionById: ReadonlyMap<string, T>,
+  dirtySections: DirtySettingsSections
+): T[] {
+  const pinnedIds = [
+    dirtySections.sourceControl ? 'git' : null,
+    dirtySections.appearance ? 'appearance' : null
+  ].filter((id): id is string => id !== null)
+  const visibleIds = new Set(rankedSections.map((section) => section.id))
+  const pinnedSections = pinnedIds.flatMap((id) => {
+    const section = sectionById.get(id)
+    return section && !visibleIds.has(id) ? [section] : []
+  })
+  return pinnedSections.length > 0 ? [...rankedSections, ...pinnedSections] : [...rankedSections]
+}
+
+export async function settleAppearanceSettingsSectionBeforeLeave({
+  dirty,
+  confirmLeave,
+  discardDraft
+}: AppearanceSectionLeave): Promise<boolean> {
+  if (!dirty) {
+    return true
+  }
+  if (!(await confirmLeave({ discardDraftOnLeave: false }))) {
+    return false
+  }
+  discardDraft()
+  return true
+}
+
+export function runSettingsSectionLeaveConfirmation(
+  sectionId: string,
+  confirmations: SettingsSectionLeaveConfirmations
+): Promise<boolean> {
+  return sectionId === 'appearance' ? confirmations.appearance() : confirmations.sourceControl()
+}
+
+export function releaseSettledSettingsNavGuard(
+  guardedSectionId: string | null,
+  settledSectionId: string
+): string | null {
+  return guardedSectionId === settledSectionId ? null : guardedSectionId
+}

--- a/src/renderer/src/components/settings/use-appearance-background-library.ts
+++ b/src/renderer/src/components/settings/use-appearance-background-library.ts
@@ -1,0 +1,105 @@
+import { useEffect, useState } from 'react'
+import { toast } from 'sonner'
+
+import type { OrcaBackgroundApi } from '../../../../preload/api/orca-background-api'
+import type { OrcaBackgroundLibrary } from '../../../../shared/orca-background-library-types'
+import { translate } from '@/i18n/i18n'
+
+function getBackgroundsApi(): OrcaBackgroundApi | null {
+  return (
+    (
+      window as Window & {
+        api?: { backgrounds?: OrcaBackgroundApi }
+      }
+    ).api?.backgrounds ?? null
+  )
+}
+
+export function useAppearanceBackgroundLibrary(onFirstAdded: (fileName: string) => void): {
+  library: OrcaBackgroundLibrary
+  busy: boolean
+  addImages: () => Promise<void>
+  openLibrary: () => Promise<void>
+} {
+  const [library, setLibrary] = useState<OrcaBackgroundLibrary>({ dir: '', images: [] })
+  const [busy, setBusy] = useState(false)
+
+  useEffect(() => {
+    const api = getBackgroundsApi()
+    if (!api) {
+      return
+    }
+    let alive = true
+    void api
+      .listLibrary()
+      .then((next) => alive && setLibrary(next))
+      .catch(() => {
+        if (alive) {
+          toast.error(
+            translate(
+              'auto.components.settings.AppearanceBackgroundSection.loadFailed',
+              'Could not load the backgrounds library.'
+            )
+          )
+        }
+      })
+    return () => {
+      alive = false
+    }
+  }, [])
+
+  const addImages = async (): Promise<void> => {
+    const api = getBackgroundsApi()
+    if (busy || !api) {
+      return
+    }
+    setBusy(true)
+    try {
+      const next = await api.addImages()
+      setLibrary(next)
+      if (next.skipped.length > 0) {
+        toast.error(
+          translate(
+            'auto.components.settings.AppearanceBackgroundSection.skipped',
+            'Some images could not be added: {{value0}}',
+            { value0: next.skipped.join(', ') }
+          )
+        )
+      }
+      if (next.added[0]) {
+        onFirstAdded(next.added[0])
+      }
+    } catch {
+      toast.error(
+        translate(
+          'auto.components.settings.AppearanceBackgroundSection.addFailed',
+          'Could not add the selected images.'
+        )
+      )
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const openLibrary = async (): Promise<void> => {
+    const api = getBackgroundsApi()
+    let opened = false
+    try {
+      const result = await api?.openLibrary()
+      opened = result?.ok === true
+    } catch {
+      opened = false
+    }
+    if (opened) {
+      return
+    }
+    toast.error(
+      translate(
+        'auto.components.settings.AppearanceBackgroundSection.openFailed',
+        'Could not open the backgrounds folder.'
+      )
+    )
+  }
+
+  return { library, busy, addImages, openLibrary }
+}

--- a/src/renderer/src/components/settings/use-appearance-leave-dialog.test.tsx
+++ b/src/renderer/src/components/settings/use-appearance-leave-dialog.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 
+import { useLayoutEffect } from 'react'
 import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { useAppearanceLeaveDialog } from './use-appearance-leave-dialog'
@@ -153,6 +154,36 @@ describe('useAppearanceLeaveDialog', () => {
     expect(duplicate).toBe(first)
     act(() => hook.result.current.cancel())
     await expect(Promise.all([first, duplicate])).resolves.toEqual([false, false])
+  })
+
+  it('syncs fresh edits before caller layout effects can request leave', async () => {
+    const onDecision = vi.fn<(decision: Promise<boolean>) => void>()
+    const saveDraft = vi.fn(async () => true)
+    const discardDraft = vi.fn()
+    const hook = renderHook(
+      ({ hasChanges }) => {
+        const dialog = useAppearanceLeaveDialog({ hasChanges, saveDraft, discardDraft })
+        const { confirmLeave } = dialog
+        useLayoutEffect(() => {
+          if (hasChanges) {
+            onDecision(confirmLeave({ discardDraftOnLeave: true }))
+          }
+        }, [confirmLeave, hasChanges])
+        return dialog
+      },
+      { initialProps: { hasChanges: false } }
+    )
+
+    hook.rerender({ hasChanges: true })
+
+    expect(onDecision).toHaveBeenCalledOnce()
+    expect(hook.result.current.open).toBe(true)
+    const decision = onDecision.mock.calls[0]?.[0]
+    if (!decision) {
+      throw new Error('Expected a pending leave decision')
+    }
+    act(() => hook.result.current.cancel())
+    await expect(decision).resolves.toBe(false)
   })
 
   it('cancels a pending leave decision when the dialog owner unmounts', async () => {

--- a/src/renderer/src/components/settings/use-appearance-leave-dialog.test.tsx
+++ b/src/renderer/src/components/settings/use-appearance-leave-dialog.test.tsx
@@ -1,0 +1,247 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useAppearanceLeaveDialog } from './use-appearance-leave-dialog'
+
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+} {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((next) => {
+    resolve = next
+  })
+  return { promise, resolve }
+}
+
+afterEach(cleanup)
+
+describe('useAppearanceLeaveDialog', () => {
+  it('allows leaving immediately when there are no changes', async () => {
+    const saveDraft = vi.fn(async () => true)
+    const discardDraft = vi.fn()
+    const hook = renderHook(() =>
+      useAppearanceLeaveDialog({ hasChanges: false, saveDraft, discardDraft })
+    )
+
+    await expect(hook.result.current.confirmLeave({ discardDraftOnLeave: true })).resolves.toBe(
+      true
+    )
+
+    expect(hook.result.current.open).toBe(false)
+    expect(saveDraft).not.toHaveBeenCalled()
+    expect(discardDraft).not.toHaveBeenCalled()
+  })
+
+  it('resolves the pending decision as false when cancelled', async () => {
+    const hook = renderHook(() =>
+      useAppearanceLeaveDialog({
+        hasChanges: true,
+        saveDraft: vi.fn(async () => true),
+        discardDraft: vi.fn()
+      })
+    )
+    let decision!: Promise<boolean>
+
+    act(() => {
+      decision = hook.result.current.confirmLeave({ discardDraftOnLeave: true })
+    })
+    expect(hook.result.current.open).toBe(true)
+
+    act(() => hook.result.current.cancel())
+
+    await expect(decision).resolves.toBe(false)
+    expect(hook.result.current.open).toBe(false)
+  })
+
+  it.each([true, false])(
+    'allows discard with discardDraftOnLeave=%s',
+    async (discardDraftOnLeave) => {
+      const discardDraft = vi.fn()
+      const hook = renderHook(() =>
+        useAppearanceLeaveDialog({
+          hasChanges: true,
+          saveDraft: vi.fn(async () => true),
+          discardDraft
+        })
+      )
+      let decision!: Promise<boolean>
+
+      act(() => {
+        decision = hook.result.current.confirmLeave({ discardDraftOnLeave })
+      })
+      act(() => hook.result.current.discard())
+
+      await expect(decision).resolves.toBe(true)
+      expect(discardDraft).toHaveBeenCalledTimes(discardDraftOnLeave ? 1 : 0)
+      expect(hook.result.current.open).toBe(false)
+    }
+  )
+
+  it('waits for a successful save before allowing leave', async () => {
+    const pendingSave = deferred<boolean>()
+    const saveDraft = vi.fn(() => pendingSave.promise)
+    const hook = renderHook(() =>
+      useAppearanceLeaveDialog({ hasChanges: true, saveDraft, discardDraft: vi.fn() })
+    )
+    let decision!: Promise<boolean>
+
+    act(() => {
+      decision = hook.result.current.confirmLeave({ discardDraftOnLeave: true })
+    })
+    act(() => hook.result.current.save())
+
+    expect(saveDraft).toHaveBeenCalledOnce()
+    expect(hook.result.current.open).toBe(true)
+    expect(hook.result.current.saving).toBe(true)
+
+    await act(async () => {
+      pendingSave.resolve(true)
+      expect(await decision).toBe(true)
+    })
+
+    expect(hook.result.current.open).toBe(false)
+    expect(hook.result.current.saving).toBe(false)
+  })
+
+  it('keeps a failed save open and allows retrying', async () => {
+    const saveDraft = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('save failed'))
+      .mockResolvedValueOnce(true)
+    const hook = renderHook(() =>
+      useAppearanceLeaveDialog({ hasChanges: true, saveDraft, discardDraft: vi.fn() })
+    )
+    let decision!: Promise<boolean>
+
+    act(() => {
+      decision = hook.result.current.confirmLeave({ discardDraftOnLeave: true })
+    })
+    act(() => hook.result.current.save())
+
+    await waitFor(() => expect(hook.result.current.saveFailed).toBe(true))
+    expect(hook.result.current.open).toBe(true)
+    expect(hook.result.current.saving).toBe(false)
+
+    await act(async () => {
+      hook.result.current.save()
+      expect(await decision).toBe(true)
+    })
+
+    expect(saveDraft).toHaveBeenCalledTimes(2)
+    expect(hook.result.current.open).toBe(false)
+    expect(hook.result.current.saveFailed).toBe(false)
+  })
+
+  it('shares one pending decision across duplicate leave requests', async () => {
+    const hook = renderHook(() =>
+      useAppearanceLeaveDialog({
+        hasChanges: true,
+        saveDraft: vi.fn(async () => true),
+        discardDraft: vi.fn()
+      })
+    )
+    let first!: Promise<boolean>
+    let duplicate!: Promise<boolean>
+
+    act(() => {
+      first = hook.result.current.confirmLeave({ discardDraftOnLeave: true })
+      duplicate = hook.result.current.confirmLeave({ discardDraftOnLeave: false })
+    })
+
+    expect(duplicate).toBe(first)
+    act(() => hook.result.current.cancel())
+    await expect(Promise.all([first, duplicate])).resolves.toEqual([false, false])
+  })
+
+  it('cancels a pending leave decision when the dialog owner unmounts', async () => {
+    const hook = renderHook(() =>
+      useAppearanceLeaveDialog({
+        hasChanges: true,
+        saveDraft: vi.fn(async () => true),
+        discardDraft: vi.fn()
+      })
+    )
+    let decision!: Promise<boolean>
+
+    act(() => {
+      decision = hook.result.current.confirmLeave({ discardDraftOnLeave: true })
+    })
+    hook.unmount()
+
+    await expect(decision).resolves.toBe(false)
+  })
+
+  it('blocks actions during an external save and leaves when that save finishes', async () => {
+    const pendingSave = deferred<boolean>()
+    const saveDraft = vi.fn(() => pendingSave.promise)
+    const discardDraft = vi.fn()
+    const hook = renderHook(
+      ({ hasChanges, draftSaving }) =>
+        useAppearanceLeaveDialog({
+          hasChanges,
+          draftSaving,
+          saveDraft,
+          discardDraft
+        }),
+      { initialProps: { hasChanges: true, draftSaving: true } }
+    )
+    let decision!: Promise<boolean>
+
+    act(() => {
+      decision = hook.result.current.confirmLeave({ discardDraftOnLeave: true })
+    })
+    expect(saveDraft).toHaveBeenCalledOnce()
+    expect(hook.result.current.open).toBe(true)
+    expect(hook.result.current.saving).toBe(true)
+
+    act(() => {
+      hook.result.current.save()
+      hook.result.current.discard()
+      hook.result.current.cancel()
+    })
+
+    expect(discardDraft).not.toHaveBeenCalled()
+    expect(hook.result.current.open).toBe(true)
+
+    await act(async () => {
+      pendingSave.resolve(true)
+      hook.rerender({ hasChanges: false, draftSaving: false })
+    })
+
+    await expect(decision).resolves.toBe(true)
+    expect(hook.result.current.open).toBe(false)
+  })
+
+  it('keeps the leave decision open when edits remain after an in-flight save', async () => {
+    const pendingSave = deferred<boolean>()
+    const saveDraft = vi.fn(() => pendingSave.promise)
+    const hook = renderHook(
+      ({ hasChanges, draftSaving }) =>
+        useAppearanceLeaveDialog({
+          hasChanges,
+          draftSaving,
+          saveDraft,
+          discardDraft: vi.fn()
+        }),
+      { initialProps: { hasChanges: true, draftSaving: true } }
+    )
+    let decision!: Promise<boolean>
+
+    act(() => {
+      decision = hook.result.current.confirmLeave({ discardDraftOnLeave: true })
+    })
+
+    await act(async () => {
+      pendingSave.resolve(false)
+      await pendingSave.promise
+      hook.rerender({ hasChanges: true, draftSaving: false })
+    })
+
+    expect(hook.result.current.open).toBe(true)
+    expect(hook.result.current.saving).toBe(false)
+    act(() => hook.result.current.cancel())
+    await expect(decision).resolves.toBe(false)
+  })
+})

--- a/src/renderer/src/components/settings/use-appearance-leave-dialog.ts
+++ b/src/renderer/src/components/settings/use-appearance-leave-dialog.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 
 type AppearanceLeaveRequest = {
   discardDraftOnLeave: boolean
@@ -41,7 +41,7 @@ export function useAppearanceLeaveDialog({
   const pendingPromiseRef = useRef<Promise<boolean> | null>(null)
   const busy = saving || draftSaving
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     hasChangesRef.current = hasChanges
     draftSavingRef.current = draftSaving
     saveDraftRef.current = saveDraft
@@ -75,6 +75,7 @@ export function useAppearanceLeaveDialog({
         setOpen(true)
       })
       pendingPromiseRef.current = pending
+      // Avoid a duplicate save; saveDraft returns the active promise.
       if (draftSavingRef.current) {
         void saveDraftRef
           .current()

--- a/src/renderer/src/components/settings/use-appearance-leave-dialog.ts
+++ b/src/renderer/src/components/settings/use-appearance-leave-dialog.ts
@@ -1,0 +1,151 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+type AppearanceLeaveRequest = {
+  discardDraftOnLeave: boolean
+  resolve: (allowed: boolean) => void
+}
+
+type UseAppearanceLeaveDialogOptions = {
+  hasChanges: boolean
+  draftSaving?: boolean
+  draftSaveFailed?: boolean
+  saveDraft: () => Promise<boolean>
+  discardDraft: () => void
+}
+
+export type AppearanceLeaveDialog = {
+  open: boolean
+  saving: boolean
+  saveFailed: boolean
+  confirmLeave: (options: { discardDraftOnLeave: boolean }) => Promise<boolean>
+  save: () => void
+  discard: () => void
+  cancel: () => void
+}
+
+export function useAppearanceLeaveDialog({
+  hasChanges,
+  draftSaving = false,
+  draftSaveFailed = false,
+  saveDraft,
+  discardDraft
+}: UseAppearanceLeaveDialogOptions): AppearanceLeaveDialog {
+  const [open, setOpen] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [saveFailed, setSaveFailed] = useState(false)
+  const hasChangesRef = useRef(hasChanges)
+  const draftSavingRef = useRef(draftSaving)
+  const saveDraftRef = useRef(saveDraft)
+  const discardDraftRef = useRef(discardDraft)
+  const requestRef = useRef<AppearanceLeaveRequest | null>(null)
+  const pendingPromiseRef = useRef<Promise<boolean> | null>(null)
+  const busy = saving || draftSaving
+
+  useEffect(() => {
+    hasChangesRef.current = hasChanges
+    draftSavingRef.current = draftSaving
+    saveDraftRef.current = saveDraft
+    discardDraftRef.current = discardDraft
+  }, [discardDraft, draftSaving, hasChanges, saveDraft])
+
+  const settle = useCallback((allowed: boolean): void => {
+    const request = requestRef.current
+    if (!request) {
+      return
+    }
+    requestRef.current = null
+    pendingPromiseRef.current = null
+    setOpen(false)
+    setSaving(false)
+    setSaveFailed(false)
+    request.resolve(allowed)
+  }, [])
+
+  const confirmLeave = useCallback(
+    ({ discardDraftOnLeave }: { discardDraftOnLeave: boolean }): Promise<boolean> => {
+      if (!hasChangesRef.current) {
+        return Promise.resolve(true)
+      }
+      if (pendingPromiseRef.current) {
+        return pendingPromiseRef.current
+      }
+      const pending = new Promise<boolean>((resolve) => {
+        requestRef.current = { discardDraftOnLeave, resolve }
+        setSaveFailed(false)
+        setOpen(true)
+      })
+      pendingPromiseRef.current = pending
+      if (draftSavingRef.current) {
+        void saveDraftRef
+          .current()
+          .then((clean) => {
+            if (clean) {
+              settle(true)
+            }
+          })
+          .catch(() => {
+            setSaving(false)
+            setSaveFailed(true)
+          })
+      }
+      return pending
+    },
+    [settle]
+  )
+
+  const save = useCallback((): void => {
+    if (!requestRef.current || busy) {
+      return
+    }
+    setSaving(true)
+    setSaveFailed(false)
+    void saveDraftRef
+      .current()
+      .then((clean) => {
+        if (clean) {
+          settle(true)
+          return
+        }
+        setSaving(false)
+      })
+      .catch(() => {
+        setSaving(false)
+        setSaveFailed(true)
+      })
+  }, [busy, settle])
+
+  const discard = useCallback((): void => {
+    const request = requestRef.current
+    if (!request || busy) {
+      return
+    }
+    if (request.discardDraftOnLeave) {
+      discardDraftRef.current()
+    }
+    settle(true)
+  }, [busy, settle])
+
+  const cancel = useCallback((): void => {
+    if (!busy) {
+      settle(false)
+    }
+  }, [busy, settle])
+
+  useEffect(() => {
+    return () => {
+      requestRef.current?.resolve(false)
+      requestRef.current = null
+      pendingPromiseRef.current = null
+    }
+  }, [])
+
+  return {
+    open,
+    saving: busy,
+    saveFailed: saveFailed || draftSaveFailed,
+    confirmLeave,
+    save,
+    discard,
+    cancel
+  }
+}

--- a/src/renderer/src/components/settings/use-appearance-settings-draft.test.tsx
+++ b/src/renderer/src/components/settings/use-appearance-settings-draft.test.tsx
@@ -1,0 +1,202 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getDefaultSettings } from '../../../../shared/constants'
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import { useAppearanceSettingsDraft } from './use-appearance-settings-draft'
+
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+} {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((next) => {
+    resolve = next
+  })
+  return { promise, resolve }
+}
+
+afterEach(cleanup)
+
+describe('useAppearanceSettingsDraft', () => {
+  it('stages effective settings without persisting them', () => {
+    const settings = getDefaultSettings('/tmp')
+    const persistSettings = vi.fn(async (): Promise<void> => {})
+    const applyTheme = vi.fn()
+    const hook = renderHook(() =>
+      useAppearanceSettingsDraft({ settings, persistSettings, applyTheme })
+    )
+
+    act(() => hook.result.current.stage({ terminalFontSize: 18 }))
+
+    expect(hook.result.current.settings?.terminalFontSize).toBe(18)
+    expect(hook.result.current.changedKeys).toEqual(['terminalFontSize'])
+    expect(hook.result.current.hasChanges).toBe(true)
+    expect(persistSettings).not.toHaveBeenCalled()
+    expect(applyTheme).not.toHaveBeenCalled()
+  })
+
+  it('saves multiple staged fields as one patch before applying the theme', async () => {
+    const settings = getDefaultSettings('/tmp')
+    const persistence = deferred<void>()
+    const persistSettings = vi.fn(() => persistence.promise)
+    const applyTheme = vi.fn()
+    const hook = renderHook(() =>
+      useAppearanceSettingsDraft({ settings, persistSettings, applyTheme })
+    )
+
+    act(() => {
+      hook.result.current.stage({ theme: 'dark' })
+      hook.result.current.stage({ terminalFontSize: 16 })
+    })
+
+    let savePromise!: Promise<boolean>
+    act(() => {
+      savePromise = hook.result.current.save()
+    })
+
+    expect(persistSettings).toHaveBeenCalledOnce()
+    expect(persistSettings).toHaveBeenCalledWith({ theme: 'dark', terminalFontSize: 16 })
+    expect(applyTheme).not.toHaveBeenCalled()
+    expect(hook.result.current.saving).toBe(true)
+
+    await act(async () => {
+      persistence.resolve(undefined)
+      await savePromise
+    })
+
+    expect(applyTheme).toHaveBeenCalledOnce()
+    expect(applyTheme).toHaveBeenCalledWith('dark')
+    expect(hook.result.current.hasChanges).toBe(false)
+    expect(hook.result.current.saving).toBe(false)
+  })
+
+  it('discards all staged fields', () => {
+    const settings = getDefaultSettings('/tmp')
+    const hook = renderHook(() =>
+      useAppearanceSettingsDraft({
+        settings,
+        persistSettings: vi.fn(async (): Promise<void> => {}),
+        applyTheme: vi.fn()
+      })
+    )
+
+    act(() => hook.result.current.stage({ theme: 'dark', terminalFontSize: 20 }))
+    act(() => hook.result.current.discard())
+
+    expect(hook.result.current.settings).toEqual(settings)
+    expect(hook.result.current.changedKeys).toEqual([])
+    expect(hook.result.current.hasChanges).toBe(false)
+  })
+
+  it('preserves the draft and reports a failed save', async () => {
+    const settings = getDefaultSettings('/tmp')
+    const error = new Error('write failed')
+    const persistSettings = vi.fn(async (): Promise<void> => {
+      throw error
+    })
+    const applyTheme = vi.fn()
+    const hook = renderHook(() =>
+      useAppearanceSettingsDraft({ settings, persistSettings, applyTheme })
+    )
+
+    act(() => hook.result.current.stage({ theme: 'dark' }))
+    await act(async () => {
+      await expect(hook.result.current.save()).rejects.toBe(error)
+    })
+
+    expect(hook.result.current.settings?.theme).toBe('dark')
+    expect(hook.result.current.changedKeys).toEqual(['theme'])
+    expect(hook.result.current.hasChanges).toBe(true)
+    expect(hook.result.current.saveFailed).toBe(true)
+    expect(hook.result.current.saving).toBe(false)
+    expect(applyTheme).not.toHaveBeenCalled()
+  })
+
+  it('merges external base updates without overwriting dirty fields', () => {
+    const initialSettings = getDefaultSettings('/tmp')
+    const persistSettings = vi.fn(async (): Promise<void> => {})
+    const applyTheme = vi.fn()
+    const hook = renderHook(
+      ({ settings }: { settings: GlobalSettings }) =>
+        useAppearanceSettingsDraft({ settings, persistSettings, applyTheme }),
+      { initialProps: { settings: initialSettings } }
+    )
+
+    act(() => hook.result.current.stage({ theme: 'dark' }))
+    hook.rerender({
+      settings: { ...initialSettings, theme: 'light', terminalFontSize: 19 }
+    })
+
+    expect(hook.result.current.settings?.theme).toBe('dark')
+    expect(hook.result.current.settings?.terminalFontSize).toBe(19)
+    expect(hook.result.current.changedKeys).toEqual(['theme'])
+  })
+
+  it('shares one persistence operation between concurrent saves', async () => {
+    const settings = getDefaultSettings('/tmp')
+    const persistence = deferred<void>()
+    const persistSettings = vi.fn(() => persistence.promise)
+    const hook = renderHook(() =>
+      useAppearanceSettingsDraft({ settings, persistSettings, applyTheme: vi.fn() })
+    )
+
+    act(() => hook.result.current.stage({ terminalFontSize: 17 }))
+
+    let firstSave!: Promise<boolean>
+    let secondSave!: Promise<boolean>
+    act(() => {
+      firstSave = hook.result.current.save()
+      secondSave = hook.result.current.save()
+    })
+
+    expect(secondSave).toBe(firstSave)
+    expect(persistSettings).toHaveBeenCalledOnce()
+
+    await act(async () => {
+      persistence.resolve(undefined)
+      await firstSave
+    })
+
+    expect(hook.result.current.hasChanges).toBe(false)
+    expect(hook.result.current.saving).toBe(false)
+  })
+
+  it('rebases a same-field edit made while saving onto the persisted value', async () => {
+    const settings = getDefaultSettings('/tmp')
+    const originalFontSize = settings.terminalFontSize
+    const persistence = deferred<void>()
+    const persistSettings = vi.fn(() => persistence.promise)
+    const applyTheme = vi.fn()
+    const hook = renderHook(
+      ({ currentSettings }: { currentSettings: GlobalSettings }) =>
+        useAppearanceSettingsDraft({
+          settings: currentSettings,
+          persistSettings,
+          applyTheme
+        }),
+      { initialProps: { currentSettings: settings } }
+    )
+
+    act(() => hook.result.current.stage({ terminalFontSize: originalFontSize + 2 }))
+    let savePromise!: Promise<boolean>
+    act(() => {
+      savePromise = hook.result.current.save()
+    })
+    act(() => hook.result.current.stage({ terminalFontSize: originalFontSize }))
+    hook.rerender({
+      currentSettings: { ...settings, terminalFontSize: originalFontSize + 2 }
+    })
+
+    let cleanAfterSave = true
+    await act(async () => {
+      persistence.resolve(undefined)
+      cleanAfterSave = await savePromise
+    })
+
+    expect(cleanAfterSave).toBe(false)
+    expect(hook.result.current.settings?.terminalFontSize).toBe(originalFontSize)
+    expect(hook.result.current.changedKeys).toEqual(['terminalFontSize'])
+  })
+})

--- a/src/renderer/src/components/settings/use-appearance-settings-draft.ts
+++ b/src/renderer/src/components/settings/use-appearance-settings-draft.ts
@@ -1,0 +1,139 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import {
+  areAppearanceSettingValuesEqual,
+  getAppearanceDraftChangedKeys,
+  getAppearanceDraftChanges
+} from './appearance-draft-diff'
+
+type UseAppearanceSettingsDraftOptions = {
+  settings: GlobalSettings | null
+  persistSettings: (updates: Partial<GlobalSettings>) => Promise<void>
+  applyTheme: (theme: GlobalSettings['theme']) => void
+}
+
+export type AppearanceSettingsDraft = {
+  settings: GlobalSettings | null
+  changedKeys: (keyof GlobalSettings)[]
+  hasChanges: boolean
+  saving: boolean
+  saveFailed: boolean
+  stage: (updates: Partial<GlobalSettings>) => void
+  save: () => Promise<boolean>
+  discard: () => void
+}
+
+export function useAppearanceSettingsDraft({
+  settings,
+  persistSettings,
+  applyTheme
+}: UseAppearanceSettingsDraftOptions): AppearanceSettingsDraft {
+  const [draft, setDraft] = useState<Partial<GlobalSettings>>({})
+  const [saving, setSaving] = useState(false)
+  const [saveFailed, setSaveFailed] = useState(false)
+  const settingsRef = useRef(settings)
+  const draftRef = useRef(draft)
+  const savePromiseRef = useRef<Promise<boolean> | null>(null)
+
+  useEffect(() => {
+    settingsRef.current = settings
+    draftRef.current = draft
+  }, [draft, settings])
+
+  const changes = useMemo(
+    () => (settings ? getAppearanceDraftChanges(settings, draft) : {}),
+    [draft, settings]
+  )
+  const changedKeys = useMemo(
+    () => (settings ? getAppearanceDraftChangedKeys(settings, draft) : []),
+    [draft, settings]
+  )
+  const effectiveSettings = useMemo(
+    () => (settings ? { ...settings, ...changes } : null),
+    [changes, settings]
+  )
+
+  const stage = useCallback((updates: Partial<GlobalSettings>): void => {
+    const base = settingsRef.current
+    if (!base) {
+      return
+    }
+    setSaveFailed(false)
+    const next = { ...draftRef.current, ...updates }
+    const rebased = savePromiseRef.current ? next : getAppearanceDraftChanges(base, next)
+    draftRef.current = rebased
+    setDraft(rebased)
+  }, [])
+
+  const discard = useCallback((): void => {
+    if (savePromiseRef.current) {
+      return
+    }
+    draftRef.current = {}
+    setDraft(draftRef.current)
+    setSaveFailed(false)
+  }, [])
+
+  const save = useCallback((): Promise<boolean> => {
+    if (savePromiseRef.current) {
+      return savePromiseRef.current
+    }
+    const base = settingsRef.current
+    if (!base) {
+      return Promise.resolve(true)
+    }
+    const patch = getAppearanceDraftChanges(base, draftRef.current)
+    const keys = Object.keys(patch) as (keyof GlobalSettings)[]
+    if (keys.length === 0) {
+      return Promise.resolve(true)
+    }
+
+    setSaving(true)
+    setSaveFailed(false)
+    let persistence: Promise<void>
+    try {
+      persistence = persistSettings(patch)
+    } catch (error) {
+      persistence = Promise.reject(error)
+    }
+    const pending = persistence
+      .then(() => {
+        if (patch.theme) {
+          applyTheme(patch.theme)
+        }
+        const next = { ...draftRef.current }
+        for (const key of keys) {
+          if (areAppearanceSettingValuesEqual(next[key], patch[key])) {
+            delete next[key]
+          }
+        }
+        const savedBase = { ...(settingsRef.current ?? base), ...patch }
+        const remaining = getAppearanceDraftChanges(savedBase, next)
+        draftRef.current = remaining
+        setDraft(remaining)
+        return Object.keys(remaining).length === 0
+      })
+      .catch((error: unknown) => {
+        setSaveFailed(true)
+        throw error
+      })
+      .finally(() => {
+        savePromiseRef.current = null
+        setSaving(false)
+      })
+    savePromiseRef.current = pending
+    return pending
+  }, [applyTheme, persistSettings])
+
+  return {
+    settings: effectiveSettings,
+    changedKeys,
+    hasChanges: changedKeys.length > 0,
+    saving,
+    saveFailed,
+    stage,
+    save,
+    discard
+  }
+}

--- a/src/renderer/src/components/settings/useGhosttyImport.test.ts
+++ b/src/renderer/src/components/settings/useGhosttyImport.test.ts
@@ -3,6 +3,8 @@ import type { GhosttyImportPreview, GlobalSettings } from '../../../../shared/gl
 
 const mockStateValues: unknown[] = []
 let mockStateIndex = 0
+const mockRefValues: { current: unknown }[] = []
+let mockRefIndex = 0
 
 const baseSettings: GlobalSettings = {
   theme: 'system',
@@ -25,6 +27,15 @@ const baseSettings: GlobalSettings = {
 
 function resetMockState() {
   mockStateIndex = 0
+  mockRefIndex = 0
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((settle) => {
+    resolve = settle
+  })
+  return { promise, resolve }
 }
 
 vi.mock('react', async () => {
@@ -34,7 +45,11 @@ vi.mock('react', async () => {
     useEffect: (effect: () => void | (() => void)) => {
       void effect()
     },
-    useRef: (initial: unknown) => ({ current: initial }),
+    useRef: (initial: unknown) => {
+      const i = mockRefIndex++
+      mockRefValues[i] ??= { current: initial }
+      return mockRefValues[i]
+    },
     useState: (initial: unknown) => {
       const i = mockStateIndex++
       if (mockStateValues[i] === undefined) {
@@ -53,6 +68,7 @@ import { useGhosttyImport } from './useGhosttyImport'
 describe('useGhosttyImport', () => {
   beforeEach(() => {
     mockStateValues.length = 0
+    mockRefValues.length = 0
     resetMockState()
     vi.unstubAllGlobals()
     vi.clearAllMocks()
@@ -234,5 +250,80 @@ describe('useGhosttyImport', () => {
         background: '#1a1a1a'
       }
     })
+  })
+
+  it('keeps the newest preview when responses resolve out of order', async () => {
+    const first = createDeferred<GhosttyImportPreview>()
+    const second = createDeferred<GhosttyImportPreview>()
+    const firstResponse = {
+      found: true,
+      diff: { terminalFontSize: 13 },
+      unsupportedKeys: []
+    } satisfies GhosttyImportPreview
+    const secondResponse = {
+      found: true,
+      diff: { terminalFontSize: 15 },
+      unsupportedKeys: []
+    } satisfies GhosttyImportPreview
+    const previewMock = vi
+      .fn()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise)
+    vi.stubGlobal('window', {
+      api: { settings: { previewGhosttyImport: previewMock } }
+    })
+
+    let ghostty = useGhosttyImport(vi.fn(), baseSettings)
+    const firstRequest = ghostty.handleClick()
+    const secondRequest = ghostty.handleClick()
+
+    second.resolve(secondResponse)
+    await secondRequest
+    first.resolve(firstResponse)
+    await firstRequest
+
+    resetMockState()
+    ghostty = useGhosttyImport(vi.fn(), baseSettings)
+    expect(ghostty.preview).toEqual(secondResponse)
+    expect(ghostty.loading).toBe(false)
+  })
+
+  it('ignores a closed preview after reopening with a new request', async () => {
+    const first = createDeferred<GhosttyImportPreview>()
+    const second = createDeferred<GhosttyImportPreview>()
+    const previewMock = vi
+      .fn()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise)
+    vi.stubGlobal('window', {
+      api: { settings: { previewGhosttyImport: previewMock } }
+    })
+
+    let ghostty = useGhosttyImport(vi.fn(), baseSettings)
+    const firstRequest = ghostty.handleClick()
+    ghostty.handleOpenChange(false)
+    resetMockState()
+    ghostty = useGhosttyImport(vi.fn(), baseSettings)
+    const secondRequest = ghostty.handleClick()
+
+    first.resolve({ found: false, diff: {}, unsupportedKeys: [], error: 'stale' })
+    await firstRequest
+    resetMockState()
+    ghostty = useGhosttyImport(vi.fn(), baseSettings)
+    expect(ghostty.open).toBe(true)
+    expect(ghostty.preview).toBeNull()
+    expect(ghostty.loading).toBe(true)
+
+    const currentResponse = {
+      found: true,
+      diff: { terminalFontSize: 16 },
+      unsupportedKeys: []
+    } satisfies GhosttyImportPreview
+    second.resolve(currentResponse)
+    await secondRequest
+    resetMockState()
+    ghostty = useGhosttyImport(vi.fn(), baseSettings)
+    expect(ghostty.preview).toEqual(currentResponse)
+    expect(ghostty.loading).toBe(false)
   })
 })

--- a/src/renderer/src/components/settings/useGhosttyImport.ts
+++ b/src/renderer/src/components/settings/useGhosttyImport.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import type { GhosttyImportPreview, GlobalSettings } from '../../../../shared/global-settings-types'
 import { useMountedRef } from '../../hooks/useMountedRef'
 
@@ -27,22 +27,24 @@ export function useGhosttyImport(
   const [applied, setApplied] = useState(false)
   const [applyError, setApplyError] = useState<string | null>(null)
   const mountedRef = useMountedRef()
+  const operationSequenceRef = useRef(0)
 
   async function handleClick(): Promise<void> {
+    const operationId = ++operationSequenceRef.current
     setOpen(true)
     setLoading(true)
     try {
       const result = await window.api.settings.previewGhosttyImport()
-      if (mountedRef.current) {
+      if (mountedRef.current && operationId === operationSequenceRef.current) {
         setPreview(result)
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Unknown error'
-      if (mountedRef.current) {
+      if (mountedRef.current && operationId === operationSequenceRef.current) {
         setPreview({ found: false, diff: {}, unsupportedKeys: [], error: message })
       }
     } finally {
-      if (mountedRef.current) {
+      if (mountedRef.current && operationId === operationSequenceRef.current) {
         setLoading(false)
       }
     }
@@ -52,6 +54,7 @@ export function useGhosttyImport(
     if (applied || !preview?.found || Object.keys(preview.diff).length === 0 || !settings) {
       return
     }
+    const operationId = operationSequenceRef.current
     const merged = {
       ...preview.diff,
       ...(preview.diff.terminalColorOverrides
@@ -69,12 +72,12 @@ export function useGhosttyImport(
       // must keep the modal in its "unapplied" state and surface the error so
       // the user doesn't see a false success.
       await updateSettings(merged)
-      if (mountedRef.current) {
+      if (mountedRef.current && operationId === operationSequenceRef.current) {
         setApplied(true)
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to apply settings'
-      if (mountedRef.current) {
+      if (mountedRef.current && operationId === operationSequenceRef.current) {
         setApplyError(message)
       }
     }
@@ -83,6 +86,7 @@ export function useGhosttyImport(
   function handleOpenChange(newOpen: boolean): void {
     setOpen(newOpen)
     if (!newOpen) {
+      operationSequenceRef.current += 1
       setPreview(null)
       setLoading(false)
       setApplied(false)

--- a/src/renderer/src/components/settings/useWarpThemeImport.sequencing.test.ts
+++ b/src/renderer/src/components/settings/useWarpThemeImport.sequencing.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import type { WarpThemeImportPreview } from '../../../../shared/terminal-custom-themes'
+
+const mockStateValues: unknown[] = []
+let mockStateIndex = 0
+const mockRefValues: { current: unknown }[] = []
+let mockRefIndex = 0
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn() } }))
+
+function resetMockHooks() {
+  mockStateIndex = 0
+  mockRefIndex = 0
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((settle) => {
+    resolve = settle
+  })
+  return { promise, resolve }
+}
+
+function createPreview(sourceLabel: string): WarpThemeImportPreview {
+  return { found: false, sourceLabel, themes: [], skippedFiles: [] }
+}
+
+vi.mock('react', async () => {
+  const actual = await vi.importActual<typeof import('react')>('react') // eslint-disable-line @typescript-eslint/consistent-type-imports -- vi.importActual requires inline import()
+  return {
+    ...actual,
+    useEffect: (effect: () => void | (() => void)) => {
+      void effect()
+    },
+    useRef: (initial: unknown) => {
+      const i = mockRefIndex++
+      mockRefValues[i] ??= { current: initial }
+      return mockRefValues[i]
+    },
+    useState: (initial: unknown) => {
+      const i = mockStateIndex++
+      if (mockStateValues[i] === undefined) {
+        mockStateValues[i] = typeof initial === 'function' ? initial() : initial
+      }
+      const setter = (value: unknown) => {
+        mockStateValues[i] = typeof value === 'function' ? value(mockStateValues[i]) : value
+      }
+      return [mockStateValues[i], setter]
+    }
+  }
+})
+
+import { useWarpThemeImport } from './useWarpThemeImport'
+
+const baseSettings = { terminalCustomThemes: [] } as unknown as GlobalSettings
+
+describe('useWarpThemeImport request sequencing', () => {
+  beforeEach(() => {
+    mockStateValues.length = 0
+    mockRefValues.length = 0
+    resetMockHooks()
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('keeps the newest preview when responses resolve out of order', async () => {
+    const first = createDeferred<WarpThemeImportPreview>()
+    const second = createDeferred<WarpThemeImportPreview>()
+    const previewMock = vi
+      .fn()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise)
+    vi.stubGlobal('window', {
+      api: { settings: { previewWarpThemeImport: previewMock } }
+    })
+
+    let warp = useWarpThemeImport(vi.fn(), baseSettings)
+    const firstRequest = warp.handlePreviewSource({ kind: 'auto' })
+    const secondRequest = warp.handlePreviewSource({ kind: 'chooseFile' })
+
+    second.resolve(createPreview('current'))
+    await secondRequest
+    first.resolve(createPreview('stale'))
+    await firstRequest
+
+    resetMockHooks()
+    warp = useWarpThemeImport(vi.fn(), baseSettings)
+    expect(warp.preview?.sourceLabel).toBe('current')
+    expect(warp.loading).toBe(false)
+  })
+
+  it('ignores a closed preview while a reopened import is pending', async () => {
+    const first = createDeferred<WarpThemeImportPreview>()
+    const second = createDeferred<WarpThemeImportPreview>()
+    const previewMock = vi
+      .fn()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise)
+    vi.stubGlobal('window', {
+      api: { settings: { previewWarpThemeImport: previewMock } }
+    })
+
+    let warp = useWarpThemeImport(vi.fn(), baseSettings)
+    const firstRequest = warp.handleClick()
+    warp.handleOpenChange(false)
+    resetMockHooks()
+    warp = useWarpThemeImport(vi.fn(), baseSettings)
+    const secondRequest = warp.handleImportYamlClick()
+
+    first.resolve(createPreview('stale'))
+    await firstRequest
+    resetMockHooks()
+    warp = useWarpThemeImport(vi.fn(), baseSettings)
+    expect(warp.open).toBe(false)
+    expect(warp.preview).toBeNull()
+    expect(warp.loading).toBe(true)
+
+    second.resolve(createPreview('current'))
+    await secondRequest
+    resetMockHooks()
+    warp = useWarpThemeImport(vi.fn(), baseSettings)
+    expect(warp.open).toBe(true)
+    expect(warp.preview?.sourceLabel).toBe('current')
+    expect(warp.loading).toBe(false)
+  })
+})

--- a/src/renderer/src/components/settings/useWarpThemeImport.test.ts
+++ b/src/renderer/src/components/settings/useWarpThemeImport.test.ts
@@ -111,8 +111,7 @@ describe('useWarpThemeImport', () => {
         expect.objectContaining({ id: 'warp:tokyo-night', name: 'Tokyo Night' })
       ]
     })
-    // Success is reported via a toast, and the modal closes itself.
-    expect(toastSuccess).toHaveBeenCalledWith('Imported 1 theme')
+    expect(toastSuccess).toHaveBeenCalledWith('Added 1 theme to appearance draft')
 
     resetMockState()
     warp = useWarpThemeImport(updateSettings, baseSettings)

--- a/src/renderer/src/components/settings/useWarpThemeImport.ts
+++ b/src/renderer/src/components/settings/useWarpThemeImport.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { toast } from 'sonner'
 import type { GlobalSettings } from '../../../../shared/global-settings-types'
 import {
@@ -34,6 +34,11 @@ export type UseWarpThemeImportReturn = {
   handleOpenChange: (open: boolean) => void
 }
 
+type PreviewOperation = {
+  result: WarpThemeImportPreview
+  operationId: number
+}
+
 export function useWarpThemeImport(
   updateSettings: (updates: Partial<GlobalSettings>) => void | Promise<void>,
   settings: GlobalSettings | null
@@ -46,19 +51,21 @@ export function useWarpThemeImport(
   const [importSignal, setImportSignal] = useState(0)
   const [selectedThemeIds, setSelectedThemeIds] = useState<Set<string>>(() => new Set())
   const mountedRef = useMountedRef()
+  const operationSequenceRef = useRef(0)
 
-  async function previewSource(source: WarpThemeImportSource): Promise<WarpThemeImportPreview> {
+  async function previewSource(source: WarpThemeImportSource): Promise<PreviewOperation> {
+    const operationId = ++operationSequenceRef.current
     setLoading(true)
     setApplyError(null)
     try {
       const result = await window.api.settings.previewWarpThemeImport(source)
       // Why: a dismissed native picker keeps whatever preview was already
       // showing instead of wiping it with an empty result.
-      if (mountedRef.current && !result.canceled) {
+      if (mountedRef.current && operationId === operationSequenceRef.current && !result.canceled) {
         setPreview(result)
         setSelectedThemeIds(new Set(result.themes.map((theme) => theme.id)))
       }
-      return result
+      return { result, operationId }
     } catch (err) {
       const message =
         err instanceof Error
@@ -70,13 +77,13 @@ export function useWarpThemeImport(
         skippedFiles: [],
         error: message
       }
-      if (mountedRef.current) {
+      if (mountedRef.current && operationId === operationSequenceRef.current) {
         setPreview(failure)
         setSelectedThemeIds(new Set())
       }
-      return failure
+      return { result: failure, operationId }
     } finally {
-      if (mountedRef.current) {
+      if (mountedRef.current && operationId === operationSequenceRef.current) {
         setLoading(false)
       }
     }
@@ -96,8 +103,8 @@ export function useWarpThemeImport(
     setMode('yaml')
     // Why: go straight to the native picker and only surface the modal once
     // there is a selection to preview — canceling leaves settings untouched.
-    const result = await previewSource({ kind: 'chooseFile' })
-    if (mountedRef.current && !result.canceled) {
+    const { result, operationId } = await previewSource({ kind: 'chooseFile' })
+    if (mountedRef.current && operationId === operationSequenceRef.current && !result.canceled) {
       setOpen(true)
     }
   }
@@ -123,6 +130,7 @@ export function useWarpThemeImport(
     if (!preview?.found || !settings || selectedThemeIds.size === 0) {
       return
     }
+    const operationId = operationSequenceRef.current
     const selectedThemes = preview.themes.filter((theme) => selectedThemeIds.has(theme.id))
     const byId = new Map<string, TerminalCustomTheme>()
     for (const theme of normalizeTerminalCustomThemes(settings.terminalCustomThemes)) {
@@ -156,18 +164,20 @@ export function useWarpThemeImport(
       await updateSettings({
         terminalCustomThemes: normalizeTerminalCustomThemes([...byId.values()])
       })
+      if (!mountedRef.current || operationId !== operationSequenceRef.current) {
+        return
+      }
       const count = selectedThemes.length
-      // Why: report success via a toast and dismiss the modal rather than
-      // leaving an "imported" state inside the dialog.
+      // Why: the Appearance pane owns persistence, so this success only confirms staging.
       toast.success(
         count === 1
           ? translate(
-              'auto.components.settings.useWarpThemeImport.imported_one',
-              'Imported 1 theme'
+              'auto.components.settings.useWarpThemeImport.staged_one',
+              'Added 1 theme to appearance draft'
             )
           : translate(
-              'auto.components.settings.useWarpThemeImport.imported_other',
-              'Imported {{value0}} themes',
+              'auto.components.settings.useWarpThemeImport.staged_other',
+              'Added {{value0}} themes to appearance draft',
               { value0: count }
             )
       )
@@ -184,7 +194,7 @@ export function useWarpThemeImport(
               'auto.components.settings.useWarpThemeImport.import_failed',
               'Failed to import themes'
             )
-      if (mountedRef.current) {
+      if (mountedRef.current && operationId === operationSequenceRef.current) {
         setApplyError(message)
       }
     }
@@ -193,6 +203,7 @@ export function useWarpThemeImport(
   function handleOpenChange(newOpen: boolean): void {
     setOpen(newOpen)
     if (!newOpen) {
+      operationSequenceRef.current += 1
       setPreview(null)
       setLoading(false)
       setApplyError(null)

--- a/src/renderer/src/components/sidebar/index.tsx
+++ b/src/renderer/src/components/sidebar/index.tsx
@@ -106,6 +106,7 @@ function Sidebar({
     <TooltipProvider delayDuration={400}>
       <div
         ref={containerRef}
+        data-orca-background-area="left-sidebar"
         data-native-file-drop-target={sidebarOpen ? nativeDropTarget : undefined}
         className="relative min-h-0 flex-shrink-0 bg-worktree-sidebar flex flex-col overflow-hidden scrollbar-sleek-parent"
         style={leftSidebarStyle}

--- a/src/renderer/src/components/terminal-pane/compose-active-terminal-theme.test.ts
+++ b/src/renderer/src/components/terminal-pane/compose-active-terminal-theme.test.ts
@@ -74,6 +74,30 @@ describe('composeActiveTerminalTheme', () => {
     expect(composeActiveTerminalTheme(base, settings, true)?.background).toBe('rgba(17, 34, 51, 0)')
   })
 
+  it('preserves background RGB when making an rgba override transparent', () => {
+    const base = { background: 'rgba(17, 34, 51, 0.5)' }
+
+    expect(composeActiveTerminalTheme(base, settingsWith({}), true)?.background).toBe(
+      'rgba(17, 34, 51, 0)'
+    )
+  })
+
+  it('makes a loaded image transparent with a non-hex background override', () => {
+    const base = { background: 'red' }
+
+    expect(composeActiveTerminalTheme(base, settingsWith({}), true)?.background).toBe('transparent')
+  })
+
+  it('leaves non-hex backgrounds intact when applying configured opacity', () => {
+    const base = { background: 'red' }
+    const result = composeActiveTerminalTheme(
+      base,
+      settingsWith({ terminalBackgroundOpacity: 0.5 })
+    )
+
+    expect(result!.background).toBe('red')
+  })
+
   it('applies cursor opacity only when the cursor is a hex color', () => {
     const base = { cursor: '#ffffff' }
     const result = composeActiveTerminalTheme(base, settingsWith({ terminalCursorOpacity: 0.3 }))

--- a/src/renderer/src/components/terminal-pane/compose-active-terminal-theme.test.ts
+++ b/src/renderer/src/components/terminal-pane/compose-active-terminal-theme.test.ts
@@ -66,6 +66,14 @@ describe('composeActiveTerminalTheme', () => {
     expect(result!.background).toBe('rgba(17, 34, 51, 0)')
   })
 
+  it('only makes the terminal transparent for an explicitly loaded background image', () => {
+    const base = { background: '#112233' }
+    const settings = settingsWith({ terminalBackgroundOpacity: undefined })
+
+    expect(composeActiveTerminalTheme(base, settings)?.background).toBe('#112233')
+    expect(composeActiveTerminalTheme(base, settings, true)?.background).toBe('rgba(17, 34, 51, 0)')
+  })
+
   it('applies cursor opacity only when the cursor is a hex color', () => {
     const base = { cursor: '#ffffff' }
     const result = composeActiveTerminalTheme(base, settingsWith({ terminalCursorOpacity: 0.3 }))

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ManagedPane, PaneManager } from '@/lib/pane-manager/pane-manager'
 import { getDefaultSettings } from '../../../../shared/constants'
 import {
@@ -11,6 +11,18 @@ import { safeFit } from '@/lib/pane-manager/pane-fit'
 import { mode2031SequenceFor } from '../../../../shared/terminal-color-scheme-protocol'
 import { _resetTerminalViewAttributesPublisherForTest } from './terminal-view-attributes-publisher'
 import type { TerminalViewAttributes } from '../../../../shared/terminal-view-attributes'
+
+const { terminalBackgroundActiveMock } = vi.hoisted(() => ({
+  terminalBackgroundActiveMock: vi.fn(() => false)
+}))
+
+vi.mock('@/lib/appearance-background-runtime', () => ({
+  isTerminalAppearanceBackgroundActive: terminalBackgroundActiveMock
+}))
+
+beforeEach(() => {
+  terminalBackgroundActiveMock.mockReset().mockReturnValue(false)
+})
 
 function fakeTransport(overrides?: { connected?: boolean; sendOk?: boolean }): {
   isConnected: () => boolean
@@ -216,6 +228,33 @@ describe('applyTerminalAppearance theme assignment', () => {
     expect(pane.terminal.options.theme?.background).toBe('#102030')
   })
 
+  it('keeps the pane surface opaque behind a loaded terminal background image', () => {
+    terminalBackgroundActiveMock.mockReturnValue(true)
+    const pane = makePane(1)
+    const manager = makeManager([pane])
+    const settings = getDefaultSettings('/tmp')
+
+    applyTerminalAppearance(
+      manager,
+      {
+        ...settings,
+        terminalBackgroundOpacity: undefined,
+        terminalColorOverrides: { background: '#102030' }
+      },
+      true,
+      new Map(),
+      new Map(),
+      'false',
+      new Map(),
+      new Map()
+    )
+
+    expect(pane.terminal.options.theme?.background).toBe('rgba(16, 32, 48, 0)')
+    expect(pane.terminal.options.allowTransparency).toBe(true)
+    expect(manager.setPaneStyleOptions).toHaveBeenCalledWith(
+      expect.objectContaining({ paneBackground: '#102030' })
+    )
+  })
   // #7934: contrast correction rescues invisible white text on light backgrounds but over-corrects on dark;
   // gate by the composed theme's background luminance (either theme slot can hold either kind of theme).
   it('keeps xterm contrast correction on light themes', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.ts
@@ -29,6 +29,7 @@ import { publishTerminalViewAttributes } from './terminal-view-attributes-publis
 import { normalizeTerminalLineHeight } from '../../../../shared/terminal-line-height-settings'
 import { maybePushMode2031Flip } from './terminal-mode-2031-replies'
 import { resolveTerminalMinimumContrastRatio } from '@/lib/terminal-contrast-correction'
+import { isTerminalAppearanceBackgroundActive } from '@/lib/appearance-background-runtime'
 
 export function hexToRgba(hex: string, alpha: number): string {
   let clean = hex.replace('#', '')
@@ -48,13 +49,23 @@ export function isHexColor(value: string): boolean {
   return HEX_COLOR_RE.test(value)
 }
 
+type ComposableTerminalAppearanceSettings = Pick<
+  GlobalSettings,
+  'terminalColorOverrides' | 'terminalBackgroundOpacity' | 'terminalCursorOpacity'
+>
+
+function resolveTerminalBackgroundOpacity(
+  settings: ComposableTerminalAppearanceSettings,
+  terminalBackgroundImageActive: boolean
+): number | undefined {
+  return terminalBackgroundImageActive ? 0 : settings.terminalBackgroundOpacity
+}
+
 // Why extracted: lets the settings preview compose the same theme without depending on PaneManager. Keep pure.
 export function composeActiveTerminalTheme(
   baseTheme: ITheme | null,
-  settings: Pick<
-    GlobalSettings,
-    'terminalColorOverrides' | 'terminalBackgroundOpacity' | 'terminalCursorOpacity'
-  >
+  settings: ComposableTerminalAppearanceSettings,
+  terminalBackgroundImageActive = false
 ): ITheme | null {
   if (!baseTheme) {
     return null
@@ -73,10 +84,14 @@ export function composeActiveTerminalTheme(
     theme = { ...theme, ...settings.terminalColorOverrides }
   }
   // Why: convert the hex background to rgba so xterm honors the opacity when allowTransparency is set.
-  if (settings.terminalBackgroundOpacity !== undefined && theme.background) {
+  const backgroundOpacity = resolveTerminalBackgroundOpacity(
+    settings,
+    terminalBackgroundImageActive
+  )
+  if (backgroundOpacity !== undefined && theme.background) {
     theme = {
       ...theme,
-      background: hexToRgba(theme.background, settings.terminalBackgroundOpacity)
+      background: hexToRgba(theme.background, backgroundOpacity)
     }
   }
   // Why hex-only: hexToRgba expects a hex input, so named CSS cursor colors are left untouched.
@@ -145,10 +160,16 @@ export function applyTerminalAppearance(
   const appearance = resolveEffectiveTerminalAppearance(settings, systemPrefersDark)
   const paneStyles = resolvePaneStyleOptions(settings)
   const baseTheme: ITheme | null = appearance.theme ?? getBuiltinTheme(appearance.themeName)
-  const theme = composeActiveTerminalTheme(baseTheme, settings)
+  const terminalBackgroundImageActive = isTerminalAppearanceBackgroundActive(settings)
+  const surfaceTheme = composeActiveTerminalTheme(baseTheme, settings)
+  const theme = composeActiveTerminalTheme(baseTheme, settings, terminalBackgroundImageActive)
+  const backgroundOpacity = resolveTerminalBackgroundOpacity(
+    settings,
+    terminalBackgroundImageActive
+  )
   // Publish composed appearance to main's hidden-PTY query responder — the only point it exists; deduped in the publisher.
-  publishTerminalViewAttributes(theme, appearance.mode, settings)
-  const paneBackground = theme?.background ?? '#000000'
+  publishTerminalViewAttributes(surfaceTheme, appearance.mode, settings)
+  const paneBackground = surfaceTheme?.background ?? '#000000'
 
   const terminalFontWeights = resolveTerminalFontWeights(
     settings.terminalFontWeight,
@@ -168,7 +189,7 @@ export function applyTerminalAppearance(
     // theme write above, so a TUI that repaints its background at runtime won't re-gate (known limitation).
     // Why value-gated: writing minimumContrastRatio clears xterm's contrast cache, so skip on no-op re-applies.
     const minimumContrastRatio = resolveTerminalMinimumContrastRatio(
-      theme?.background,
+      surfaceTheme?.background,
       appearance.mode
     )
     if (pane.terminal.options.minimumContrastRatio !== minimumContrastRatio) {
@@ -176,7 +197,7 @@ export function applyTerminalAppearance(
     }
     // Why clear explicitly: allowTransparency has rendering cost and a stale `true` could bleed in from a prior opacity.
     pane.terminal.options.allowTransparency =
-      settings.terminalBackgroundOpacity !== undefined && settings.terminalBackgroundOpacity < 1
+      backgroundOpacity !== undefined && backgroundOpacity < 1
     const cursorStyle = settings.terminalCursorStyle ?? 'block'
     pane.terminal.options.cursorStyle = cursorStyle
     pane.terminal.options.cursorInactiveStyle = resolveTerminalCursorInactiveStyle(cursorStyle)

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.ts
@@ -25,7 +25,7 @@ import type { PtyTransport } from './pty-transport'
 import type { EffectiveMacOptionAsAlt } from '@/lib/keyboard-layout/detect-option-as-alt'
 import { HEX_COLOR_RE } from '../../../../shared/color-validation'
 import type { TerminalViewAttributes } from '../../../../shared/terminal-view-attributes'
-import { publishTerminalViewAttributes } from './terminal-view-attributes-publisher'
+import { parseCssColor, publishTerminalViewAttributes } from './terminal-view-attributes-publisher'
 import { normalizeTerminalLineHeight } from '../../../../shared/terminal-line-height-settings'
 import { maybePushMode2031Flip } from './terminal-mode-2031-replies'
 import { resolveTerminalMinimumContrastRatio } from '@/lib/terminal-contrast-correction'
@@ -61,6 +61,15 @@ function resolveTerminalBackgroundOpacity(
   return terminalBackgroundImageActive ? 0 : settings.terminalBackgroundOpacity
 }
 
+function makeTerminalBackgroundTransparent(background: string): string {
+  const parsed = parseCssColor(background)
+  if (!parsed) {
+    return 'transparent'
+  }
+  // Why preserve RGB: xterm still uses it for cursor and selection blending at zero alpha.
+  return `rgba(${parsed.rgb[0]}, ${parsed.rgb[1]}, ${parsed.rgb[2]}, 0)`
+}
+
 // Why extracted: lets the settings preview compose the same theme without depending on PaneManager. Keep pure.
 export function composeActiveTerminalTheme(
   baseTheme: ITheme | null,
@@ -83,15 +92,20 @@ export function composeActiveTerminalTheme(
   if (settings.terminalColorOverrides) {
     theme = { ...theme, ...settings.terminalColorOverrides }
   }
-  // Why: convert the hex background to rgba so xterm honors the opacity when allowTransparency is set.
-  const backgroundOpacity = resolveTerminalBackgroundOpacity(
-    settings,
-    terminalBackgroundImageActive
-  )
-  if (backgroundOpacity !== undefined && theme.background) {
+  // Why explicit transparent: manual overrides may be valid CSS colors that hexToRgba cannot parse.
+  if (terminalBackgroundImageActive && theme.background) {
     theme = {
       ...theme,
-      background: hexToRgba(theme.background, backgroundOpacity)
+      background: makeTerminalBackgroundTransparent(theme.background)
+    }
+  } else if (
+    settings.terminalBackgroundOpacity !== undefined &&
+    theme.background &&
+    isHexColor(theme.background)
+  ) {
+    theme = {
+      ...theme,
+      background: hexToRgba(theme.background, settings.terminalBackgroundOpacity)
     }
   }
   // Why hex-only: hexToRgba expects a hex input, so named CSS cursor colors are left untouched.

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.ts
@@ -199,9 +199,8 @@ export function applyTerminalAppearance(
     if (theme && !composedTerminalThemesEqual(pane.terminal.options.theme, theme)) {
       pane.terminal.options.theme = theme
     }
-    // Gate off the configured theme background; the live OSC-11 background is deliberately preserved by the
-    // theme write above, so a TUI that repaints its background at runtime won't re-gate (known limitation).
-    // Why value-gated: writing minimumContrastRatio clears xterm's contrast cache, so skip on no-op re-applies.
+    // Runtime OSC-11 background changes do not re-gate contrast.
+    // Why value-gated: no-op writes clear xterm's contrast cache.
     const minimumContrastRatio = resolveTerminalMinimumContrastRatio(
       surfaceTheme?.background,
       appearance.mode

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines -- Why: terminal pane lifecycle wiring is intentionally co-located so PTY attach, theme sync, and runtime graph publication remain consistent for live terminals. */
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useSyncExternalStore } from 'react'
 import type { IDisposable, Terminal } from '@xterm/xterm'
 import type { ParsedAgentStatusPayload } from '../../../../shared/agent-status-types'
 import type { TerminalKittyKeyboardModeTracker } from '../../../../shared/terminal-kitty-keyboard-mode-tracker'
@@ -81,6 +81,10 @@ import { resolveTerminalLayoutActiveLeafId } from './terminal-layout-leaf-ids'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 import { applyExpandedLayoutTo, restoreExpandedLayoutFrom } from './expand-collapse'
 import { applyTerminalAppearance } from './terminal-appearance'
+import {
+  getTerminalAppearanceBackgroundRevision,
+  subscribeToTerminalAppearanceBackground
+} from '@/lib/appearance-background-runtime'
 import { createOsc52OscHandler } from './osc52-clipboard'
 import {
   showOsc52ClipboardBlockedToast,
@@ -740,6 +744,11 @@ export function useTerminalPaneLifecycle({
   configureTerminalOutputBacklogCap(settings?.terminalScrollbackRows)
   const systemPrefersDarkRef = useRef(systemPrefersDark)
   systemPrefersDarkRef.current = systemPrefersDark
+  const appearanceBackgroundRevision = useSyncExternalStore(
+    subscribeToTerminalAppearanceBackground,
+    getTerminalAppearanceBackgroundRevision,
+    getTerminalAppearanceBackgroundRevision
+  )
   const previousVisibleForReconcileRef = useRef<TerminalPaneVisibilitySnapshot | null>(null)
   const mountFollowsTerminalPark = useTerminalParkMountIntent(tabId)
   const linkProviderDisposablesRef = useRef(new Map<number, IDisposable>())
@@ -2078,7 +2087,7 @@ export function useTerminalPaneLifecycle({
     applyAppearance(manager)
     // Why: effectiveMacOptionAsAlt can change mid-session (layout switch or override flip); re-apply macOptionIsMeta live on every pane.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [settings, systemPrefersDark, effectiveMacOptionAsAlt])
+  }, [settings, systemPrefersDark, effectiveMacOptionAsAlt, appearanceBackgroundRevision])
 
   useEffect(() => {
     managerRef.current?.setTerminalGpuAcceleration(settings?.terminalGpuAcceleration ?? 'auto')

--- a/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
+++ b/src/renderer/src/hooks/useSettingsNavigationMetadata.ts
@@ -485,7 +485,8 @@ export function buildSettingsNavigationMetadata({
       searchEntries: getAppearancePaneSearchEntries({
         showWarpImport: showDesktopOnlySettings,
         showSystemTray: showDesktopOnlySettings && isWindows,
-        showMenuBarIcon: showDesktopOnlySettings && isMac
+        showMenuBarIcon: showDesktopOnlySettings && isMac,
+        showBackgroundImages: showDesktopOnlySettings
       }),
       group: 'interface'
     },

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11384,8 +11384,9 @@
           "visibleDescription": "Updates as you edit."
         },
         "AppearanceSaveBar": {
-          "singleChange": "1 unsaved change",
-          "multipleChanges": "{{value0}} unsaved changes",
+          "unsavedChanges": "{{count}} unsaved changes",
+          "unsavedChanges_one": "{{count}} unsaved change",
+          "unsavedChanges_other": "{{count}} unsaved changes",
           "saveFailed": "Appearance settings could not be saved. Try again.",
           "discard": "Discard",
           "saving": "Saving…",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -8390,7 +8390,7 @@
           "8abdab9f7c": "Restart now",
           "907131d741": "Restarting…",
           "605a35d600": "Not applied by the terminal renderer yet — xterm.js has no bold color slot. A saved value is preserved.",
-          "saveBeforeRestart": "Save the appearance draft before restarting Orca."
+          "a62a827eda": "Save the appearance draft before restarting Orca."
         },
         "UIZoomControl": {
           "c2c64b24d0": "Reset"

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6311,6 +6311,7 @@
           "terminalTitle": "Terminal",
           "windowSidebarTitle": "Window & Sidebar",
           "windowSidebarSummary": "Sidebar, status bar, and file explorer",
+          "backgroundSummary": "Images, opacity, blur, and fit",
           "statusBarCount": "{{value0}} indicators visible.",
           "gitIgnoredGlossary": "Files matched by .gitignore.",
           "statusBarDescription": "Choose which indicators appear in the status bar.",
@@ -6863,7 +6864,10 @@
           "2763b0c045": "Review the settings that will be imported from your Ghostty config.",
           "d2f33670a9": "Import from Ghostty",
           "273e7e81fe": "Configs",
-          "1f744a72f4": "Config"
+          "1f744a72f4": "Config",
+          "draftDescription": "Review the Ghostty settings to add to your appearance draft.",
+          "staged": "Added to appearance draft",
+          "addToDraft": "Add to Draft"
         },
         "WarpThemeImportModal": {
           "title": "Import from Warp",
@@ -6889,7 +6893,12 @@
           "cancel": "Cancel",
           "import_theme_one": "Import 1 Theme",
           "import_theme_other": "Import {{value0}} Themes",
-          "import_themes": "Import Themes"
+          "import_themes": "Import Themes",
+          "yaml_draft_description": "Add theme YAML files (Warp format) to your appearance draft.",
+          "draft_description": "Add Warp themes to your appearance draft.",
+          "add_theme_one": "Add 1 Theme to Draft",
+          "add_theme_other": "Add {{value0}} Themes to Draft",
+          "add_themes": "Add Themes to Draft"
         },
         "useWarpThemeImport": {
           "unknown_error": "Unknown error",
@@ -6897,7 +6906,9 @@
           "imported_other": "Imported {{value0}} themes",
           "import_failed": "Failed to import themes",
           "over_limit_one": "Importing these themes would exceed the {{value0}} custom terminal theme limit. Deselect 1 new theme and try again.",
-          "over_limit_other": "Importing these themes would exceed the {{value0}} custom terminal theme limit. Deselect {{value1}} new themes and try again."
+          "over_limit_other": "Importing these themes would exceed the {{value0}} custom terminal theme limit. Deselect {{value1}} new themes and try again.",
+          "staged_one": "Added 1 theme to appearance draft",
+          "staged_other": "Added {{value0}} themes to appearance draft"
         },
         "YamlThemeImportButton": {
           "label": "Import from YAML"
@@ -8378,7 +8389,8 @@
           "cf37ff69f6": "Base",
           "8abdab9f7c": "Restart now",
           "907131d741": "Restarting…",
-          "605a35d600": "Not applied by the terminal renderer yet — xterm.js has no bold color slot. A saved value is preserved."
+          "605a35d600": "Not applied by the terminal renderer yet — xterm.js has no bold color slot. A saved value is preserved.",
+          "saveBeforeRestart": "Save the appearance draft before restarting Orca."
         },
         "UIZoomControl": {
           "c2c64b24d0": "Reset"
@@ -10573,7 +10585,8 @@
         },
         "AppearanceWindowSidebarSection": {
           "usagePercentageDisplayUsed": "Used",
-          "usagePercentageDisplayRemaining": "Remaining"
+          "usagePercentageDisplayRemaining": "Remaining",
+          "appliesImmediately": "Applies immediately."
         },
         "TerminalInteractionSection": {
           "567633ff50": "Right-click pastes the clipboard into the terminal. Control-click to open the context menu.",
@@ -11293,6 +11306,99 @@
         },
         "shortcutDefinitionCatalog": {
           "missionControlConflict": "Blocked by Mission Control. Remap here or change it in System Settings."
+        },
+        "AppearanceChromeMock": {
+          "ssh": "SSH",
+          "resourceUsage": "Resource usage",
+          "ports": "Ports",
+          "tasks": "Tasks",
+          "automations": "Automations",
+          "mobile": "Mobile",
+          "previewLabel": "Orca interface preview",
+          "projects": "Projects",
+          "workspace": "appearance-preview",
+          "terminalCount": "1 terminal",
+          "statusSummary": "Status bar: {{value0}}",
+          "emptyStatus": "Status bar without optional items",
+          "previewLabelWithStatus": "Orca interface preview. Status bar: {{value0}}",
+          "branchName": "feature/preview",
+          "editorPath": "src/App.tsx",
+          "baseBranch": "main",
+          "explorer": "Explorer"
+        },
+        "AppearanceInterfaceSection": {
+          "zoomAppliesImmediately": "Applies immediately."
+        },
+        "AppearanceBackgroundSection": {
+          "title": "Background Image",
+          "description": "Use your own images behind the terminal and sidebars.",
+          "loadFailed": "Could not load the backgrounds library.",
+          "skipped": "Some images could not be added: {{value0}}",
+          "addFailed": "Could not add the selected images.",
+          "openFailed": "Could not open the backgrounds folder.",
+          "terminal": "Terminal",
+          "leftSidebar": "Left Sidebar",
+          "rightSidebar": "Right Sidebar",
+          "terminalDescription": "Show the background behind terminal panes.",
+          "leftSidebarDescription": "Show the background behind the workspace sidebar.",
+          "rightSidebarDescription": "Show the background behind explorer and source control panels.",
+          "cover": "Cover",
+          "contain": "Contain",
+          "stretch": "Stretch",
+          "tile": "Tile",
+          "addImage": "Add Image",
+          "openFolder": "Open Backgrounds Folder",
+          "clearArea": "Clear Area",
+          "backgroundFor": "Background for",
+          "backgroundForDescription": "Choose an area, then select its image. Each area can use a different image.",
+          "backgroundTarget": "Background target",
+          "empty": "No images yet. Add an image from your computer.",
+          "previousImage": "Previous background image",
+          "nextImage": "Next background image",
+          "imagePreview": "Preview of {{value0}}",
+          "keywordBackground": "background",
+          "keywordImage": "image",
+          "keywordWallpaper": "wallpaper",
+          "keywordTerminal": "terminal",
+          "keywordSidebar": "sidebar",
+          "keywordOpacity": "opacity",
+          "keywordBlur": "blur",
+          "effectsFor": "Effects for",
+          "effectsDescription": "Adjust opacity and blur for the selected area.",
+          "effectsTarget": "Background effects target",
+          "resetEffects": "Reset background effects",
+          "reset": "Reset",
+          "opacity": "Opacity",
+          "opacityDescription": "How strongly the image shows through. Lower keeps text readable.",
+          "blur": "Blur",
+          "blurDescription": "Softens the image so it does not compete with text.",
+          "fit": "Fit",
+          "fitDescription": "How the image is scaled. Applied to every background area."
+        },
+        "AppearancePreviewColumn": {
+          "label": "Appearance preview",
+          "terminalTitle": "Terminal preview",
+          "terminalDescription": "Effective terminal appearance.",
+          "terminalDraftDescription": "Drafted terminal appearance. Compare dark and light themes.",
+          "visibleTitle": "Live preview",
+          "visibleDescription": "Updates as you edit."
+        },
+        "AppearanceSaveBar": {
+          "singleChange": "1 unsaved change",
+          "multipleChanges": "{{value0}} unsaved changes",
+          "saveFailed": "Appearance settings could not be saved. Try again.",
+          "discard": "Discard",
+          "saving": "Saving…",
+          "save": "Save"
+        },
+        "AppearanceUnsavedChangesDialog": {
+          "title": "Unsaved appearance changes",
+          "description": "Save the appearance draft before leaving?",
+          "saveFailed": "Appearance settings could not be saved. The draft is still available.",
+          "cancel": "Cancel",
+          "discard": "Discard",
+          "saving": "Saving…",
+          "save": "Save"
         }
       },
       "right": {

--- a/src/renderer/src/lib/appearance-background-runtime.test.ts
+++ b/src/renderer/src/lib/appearance-background-runtime.test.ts
@@ -1,0 +1,305 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { GlobalSettings } from '../../../shared/global-settings-types'
+import type { OrcaBackgroundSettings } from '../../../shared/orca-background-settings'
+import { composeActiveTerminalTheme } from '../components/terminal-pane/terminal-appearance'
+import {
+  AppearanceBackgroundRuntime,
+  getTerminalAppearanceBackgroundRevision,
+  isTerminalAppearanceBackgroundActive,
+  markAppearanceBackgroundArea
+} from './appearance-background-runtime'
+import { createBackgroundImageObjectUrlApi } from './background-image-object-url'
+
+type ImageResult = { ok: true; data: Uint8Array; mimeType: string }
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((next) => {
+    resolve = next
+  })
+  return { promise, resolve }
+}
+
+function settingsWith(
+  overrides: Partial<OrcaBackgroundSettings> = {}
+): Partial<OrcaBackgroundSettings> {
+  return overrides
+}
+
+describe('AppearanceBackgroundRuntime', () => {
+  const runtimes: AppearanceBackgroundRuntime[] = []
+  const createObjectURL = vi.fn(() => 'blob:background')
+  const revokeObjectURL = vi.fn()
+  const decodeImage = vi.fn<(_: string) => Promise<void>>()
+  const loadImage = vi.fn()
+
+  function createRuntime(
+    imageApi: { loadImage: typeof loadImage } | null = { loadImage }
+  ): AppearanceBackgroundRuntime {
+    const runtime = new AppearanceBackgroundRuntime(document.documentElement, {
+      imageApi,
+      backgroundObjectUrls: createBackgroundImageObjectUrlApi({
+        objectUrls: { createObjectURL, revokeObjectURL },
+        decodeImage
+      })
+    })
+    runtimes.push(runtime)
+    return runtime
+  }
+
+  beforeEach(() => {
+    loadImage.mockReset()
+    createObjectURL.mockReset().mockReturnValue('blob:background')
+    revokeObjectURL.mockReset()
+    decodeImage.mockReset().mockResolvedValue()
+  })
+
+  afterEach(() => {
+    for (const runtime of runtimes.splice(0)) {
+      runtime.dispose()
+    }
+  })
+
+  it('loads independent areas and publishes their image and effect variables', async () => {
+    loadImage.mockImplementation((name: string) =>
+      Promise.resolve({ ok: true, data: new Uint8Array([name.length]), mimeType: 'image/png' })
+    )
+    createObjectURL
+      .mockReturnValueOnce('blob:terminal')
+      .mockReturnValueOnce('blob:left')
+      .mockReturnValueOnce('blob:right')
+    const runtime = createRuntime()
+
+    runtime.apply(
+      settingsWith({
+        orcaBackgroundByArea: {
+          terminal: 'terminal.png',
+          leftSidebar: 'left.png',
+          rightSidebar: 'right.png'
+        },
+        orcaBackgroundAreas: { terminal: true, leftSidebar: true, rightSidebar: true },
+        orcaBackgroundOpacityByArea: { leftSidebar: 0.2, rightSidebar: 0.8 },
+        orcaBackgroundBlurByArea: { terminal: 5, rightSidebar: 20 },
+        orcaBackgroundFit: 'contain'
+      })
+    )
+
+    await vi.waitFor(() =>
+      expect(document.documentElement.getAttribute('data-orca-background-areas')).toBe(
+        'terminal left-sidebar right-sidebar'
+      )
+    )
+    const style = document.documentElement.style
+    expect(style.getPropertyValue('--orca-background-terminal-image')).toContain('blob:terminal')
+    expect(style.getPropertyValue('--orca-background-left-sidebar-image')).toContain('blob:left')
+    expect(style.getPropertyValue('--orca-background-right-sidebar-image')).toContain('blob:right')
+    expect(style.getPropertyValue('--orca-background-left-sidebar-opacity')).toBe('0.2')
+    expect(style.getPropertyValue('--orca-background-right-sidebar-blur')).toBe('20px')
+    expect(style.getPropertyValue('--orca-background-size')).toBe('contain')
+    expect(loadImage).toHaveBeenCalledTimes(3)
+  })
+
+  it('shares one object URL between areas and keeps it for effect-only updates', async () => {
+    loadImage.mockResolvedValue({
+      ok: true,
+      data: new Uint8Array([1]),
+      mimeType: 'image/png'
+    })
+    const runtime = createRuntime()
+    const images = { terminal: 'same.png', leftSidebar: 'same.png' }
+
+    runtime.apply(
+      settingsWith({
+        orcaBackgroundByArea: images,
+        orcaBackgroundAreas: { terminal: true, leftSidebar: true, rightSidebar: false }
+      })
+    )
+    await vi.waitFor(() =>
+      expect(document.documentElement.getAttribute('data-orca-background-areas')).toContain(
+        'left-sidebar'
+      )
+    )
+
+    runtime.apply(
+      settingsWith({
+        orcaBackgroundByArea: images,
+        orcaBackgroundAreas: { terminal: true, leftSidebar: true, rightSidebar: false },
+        orcaBackgroundOpacityByArea: { terminal: 0.7 }
+      })
+    )
+
+    expect(loadImage).toHaveBeenCalledOnce()
+    expect(createObjectURL).toHaveBeenCalledOnce()
+    expect(
+      document.documentElement.style.getPropertyValue('--orca-background-terminal-opacity')
+    ).toBe('0.7')
+  })
+
+  it('discards and revokes a stale load after the selected image changes', async () => {
+    const first = deferred<ImageResult>()
+    const second = deferred<ImageResult>()
+    loadImage.mockImplementation((name: string) =>
+      name === 'first.png' ? first.promise : second.promise
+    )
+    createObjectURL.mockReturnValueOnce('blob:second').mockReturnValueOnce('blob:first')
+    const runtime = createRuntime()
+
+    runtime.apply(
+      settingsWith({
+        orcaBackgroundByArea: { leftSidebar: 'first.png' },
+        orcaBackgroundAreas: { terminal: false, leftSidebar: true, rightSidebar: false }
+      })
+    )
+    runtime.apply(
+      settingsWith({
+        orcaBackgroundByArea: { leftSidebar: 'second.png' },
+        orcaBackgroundAreas: { terminal: false, leftSidebar: true, rightSidebar: false }
+      })
+    )
+
+    second.resolve({ ok: true, data: new Uint8Array([2]), mimeType: 'image/png' })
+    await vi.waitFor(() =>
+      expect(
+        document.documentElement.style.getPropertyValue('--orca-background-left-sidebar-image')
+      ).toContain('blob:second')
+    )
+    first.resolve({ ok: true, data: new Uint8Array([1]), mimeType: 'image/png' })
+    await vi.waitFor(() => expect(revokeObjectURL).toHaveBeenCalledWith('blob:first'))
+
+    expect(
+      document.documentElement.style.getPropertyValue('--orca-background-left-sidebar-image')
+    ).toContain('blob:second')
+  })
+
+  it('keeps xterm opaque until the terminal image loads successfully', async () => {
+    const image = deferred<ImageResult>()
+    const replacement = deferred<ImageResult>()
+    const decode = deferred<void>()
+    loadImage.mockImplementation((name: string) =>
+      name === 'terminal.png' ? image.promise : replacement.promise
+    )
+    decodeImage.mockReturnValueOnce(decode.promise)
+    const runtime = createRuntime()
+    const settings = settingsWith({
+      orcaBackgroundByArea: { terminal: 'terminal.png' },
+      orcaBackgroundAreas: { terminal: true, leftSidebar: false, rightSidebar: false }
+    })
+
+    runtime.apply(settings)
+    const pendingRevision = getTerminalAppearanceBackgroundRevision()
+    expect(isTerminalAppearanceBackgroundActive(settings)).toBe(false)
+    expect(
+      composeActiveTerminalTheme(
+        { background: '#112233' },
+        settings as GlobalSettings,
+        isTerminalAppearanceBackgroundActive(settings)
+      )?.background
+    ).toBe('#112233')
+
+    image.resolve({ ok: true, data: new Uint8Array([1]), mimeType: 'image/png' })
+    await vi.waitFor(() => expect(decodeImage).toHaveBeenCalledWith('blob:background'))
+    expect(isTerminalAppearanceBackgroundActive(settings)).toBe(false)
+    decode.resolve(undefined)
+    await vi.waitFor(() => expect(isTerminalAppearanceBackgroundActive(settings)).toBe(true))
+    expect(getTerminalAppearanceBackgroundRevision()).toBeGreaterThan(pendingRevision)
+    expect(
+      composeActiveTerminalTheme(
+        { background: '#112233' },
+        settings as GlobalSettings,
+        isTerminalAppearanceBackgroundActive(settings)
+      )?.background
+    ).toBe('rgba(17, 34, 51, 0)')
+
+    const replacementSettings = settingsWith({
+      orcaBackgroundByArea: { terminal: 'replacement.png' },
+      orcaBackgroundAreas: { terminal: true, leftSidebar: false, rightSidebar: false }
+    })
+    runtime.apply(replacementSettings)
+    expect(isTerminalAppearanceBackgroundActive(replacementSettings)).toBe(false)
+    replacement.resolve({ ok: true, data: new Uint8Array([2]), mimeType: 'image/png' })
+    await vi.waitFor(() =>
+      expect(isTerminalAppearanceBackgroundActive(replacementSettings)).toBe(true)
+    )
+  })
+
+  it('keeps the area and xterm inactive when image loading fails', async () => {
+    loadImage.mockResolvedValue({ ok: false, reason: 'not-found' })
+    const runtime = createRuntime()
+    const settings = settingsWith({
+      orcaBackgroundImage: 'missing.png',
+      orcaBackgroundAreas: { terminal: true, leftSidebar: false, rightSidebar: false }
+    })
+
+    runtime.apply(settings)
+    await vi.waitFor(() => expect(loadImage).toHaveBeenCalledOnce())
+
+    expect(document.documentElement.hasAttribute('data-orca-background-areas')).toBe(false)
+    expect(isTerminalAppearanceBackgroundActive(settings)).toBe(false)
+    expect(createObjectURL).not.toHaveBeenCalled()
+  })
+
+  it('revokes a decoded URL candidate and keeps the area inactive when decode fails', async () => {
+    loadImage.mockResolvedValue({
+      ok: true,
+      data: new Uint8Array([1]),
+      mimeType: 'image/png'
+    })
+    decodeImage.mockRejectedValue(new Error('decode failed'))
+    const runtime = createRuntime()
+    const settings = settingsWith({
+      orcaBackgroundImage: 'corrupt.png',
+      orcaBackgroundAreas: { terminal: true, leftSidebar: false, rightSidebar: false }
+    })
+
+    runtime.apply(settings)
+    await vi.waitFor(() => expect(revokeObjectURL).toHaveBeenCalledWith('blob:background'))
+
+    expect(document.documentElement.hasAttribute('data-orca-background-areas')).toBe(false)
+    expect(isTerminalAppearanceBackgroundActive(settings)).toBe(false)
+  })
+
+  it('degrades without an image API and clears styles and URLs on disposal', async () => {
+    const unavailable = createRuntime(null)
+    const settings = settingsWith({
+      orcaBackgroundImage: 'terminal.png',
+      orcaBackgroundAreas: { terminal: true, leftSidebar: false, rightSidebar: false }
+    })
+    unavailable.apply(settings)
+    expect(document.documentElement.hasAttribute('data-orca-background-areas')).toBe(false)
+    expect(isTerminalAppearanceBackgroundActive(settings)).toBe(false)
+
+    loadImage.mockResolvedValue({
+      ok: true,
+      data: new Uint8Array([1]),
+      mimeType: 'image/png'
+    })
+    const available = createRuntime()
+    available.apply(settings)
+    await vi.waitFor(() => expect(isTerminalAppearanceBackgroundActive(settings)).toBe(true))
+    available.dispose()
+
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:background')
+    expect(document.documentElement.hasAttribute('data-orca-background-areas')).toBe(false)
+    expect(document.documentElement.style.getPropertyValue('--orca-background-size')).toBe('')
+    expect(isTerminalAppearanceBackgroundActive(settings)).toBe(false)
+  })
+
+  it('marks static area roots without overriding positioned roots', () => {
+    const staticRoot = document.createElement('div')
+    const positionedRoot = document.createElement('div')
+    positionedRoot.style.position = 'absolute'
+    document.body.append(staticRoot, positionedRoot)
+
+    markAppearanceBackgroundArea(staticRoot, 'terminal')
+    markAppearanceBackgroundArea(positionedRoot, 'terminal')
+
+    expect(staticRoot.getAttribute('data-orca-background-area')).toBe('terminal')
+    expect(staticRoot.hasAttribute('data-orca-background-relative')).toBe(true)
+    expect(positionedRoot.hasAttribute('data-orca-background-relative')).toBe(false)
+    staticRoot.remove()
+    positionedRoot.remove()
+  })
+})

--- a/src/renderer/src/lib/appearance-background-runtime.ts
+++ b/src/renderer/src/lib/appearance-background-runtime.ts
@@ -1,0 +1,299 @@
+import {
+  ORCA_BACKGROUND_AREAS,
+  type AppearanceBackgroundArea,
+  type ResolvedAppearanceBackground,
+  getAppearanceBackgroundDomArea,
+  resolveAppearanceBackground
+} from './appearance-background-settings'
+import type { OrcaBackgroundSettings } from '../../../shared/orca-background-settings'
+import type { OrcaBackgroundImageLoadResult } from '../../../shared/orca-background-library-types'
+import {
+  browserBackgroundImageObjectUrls,
+  type BackgroundImageObjectUrlApi
+} from './background-image-object-url'
+
+export type AppearanceBackgroundImageApi = {
+  loadImage: (fileName: string) => Promise<OrcaBackgroundImageLoadResult>
+}
+
+type CachedObjectUrl = {
+  url: string | null
+  promise: Promise<string | null> | null
+}
+
+type AppearanceBackgroundRuntimeOptions = {
+  imageApi?: AppearanceBackgroundImageApi | null
+  backgroundObjectUrls?: BackgroundImageObjectUrlApi
+}
+
+const ACTIVE_AREAS_ATTRIBUTE = 'data-orca-background-areas'
+const AREA_ATTRIBUTE = 'data-orca-background-area'
+const RELATIVE_ATTRIBUTE = 'data-orca-background-relative'
+const terminalBackgroundListeners = new Set<() => void>()
+let loadedTerminalBackgroundImage: string | null = null
+let terminalBackgroundRevision = 0
+
+function setLoadedTerminalBackgroundImage(imageName: string | null): void {
+  if (imageName === loadedTerminalBackgroundImage) {
+    return
+  }
+  loadedTerminalBackgroundImage = imageName
+  terminalBackgroundRevision += 1
+  for (const listener of terminalBackgroundListeners) {
+    listener()
+  }
+}
+
+export function getTerminalAppearanceBackgroundRevision(): number {
+  return terminalBackgroundRevision
+}
+
+export function subscribeToTerminalAppearanceBackground(listener: () => void): () => void {
+  terminalBackgroundListeners.add(listener)
+  return () => terminalBackgroundListeners.delete(listener)
+}
+
+function getRendererWindow():
+  | (Window & { api?: { backgrounds?: AppearanceBackgroundImageApi } })
+  | undefined {
+  return typeof window === 'undefined'
+    ? undefined
+    : (window as Window & { api?: { backgrounds?: AppearanceBackgroundImageApi } })
+}
+
+export function getAppearanceBackgroundImageApi(): AppearanceBackgroundImageApi | null {
+  const backgrounds = getRendererWindow()?.api?.backgrounds
+  return backgrounds && typeof backgrounds.loadImage === 'function' ? backgrounds : null
+}
+
+export function isTerminalAppearanceBackgroundActive(
+  settings: Partial<OrcaBackgroundSettings> | null | undefined
+): boolean {
+  const background = resolveAppearanceBackground(settings, 'terminal')
+  return background.active && background.imageName === loadedTerminalBackgroundImage
+}
+
+export function markAppearanceBackgroundArea(
+  element: HTMLElement,
+  area: AppearanceBackgroundArea
+): void {
+  element.setAttribute(AREA_ATTRIBUTE, getAppearanceBackgroundDomArea(area))
+  try {
+    const position = getComputedStyle(element).position
+    if (!position || position === 'static') {
+      element.setAttribute(RELATIVE_ATTRIBUTE, '')
+    } else {
+      element.removeAttribute(RELATIVE_ATTRIBUTE)
+    }
+  } catch {
+    element.setAttribute(RELATIVE_ATTRIBUTE, '')
+  }
+}
+
+function areaVariable(area: AppearanceBackgroundArea, suffix: string): string {
+  return `--orca-background-${getAppearanceBackgroundDomArea(area)}-${suffix}`
+}
+
+export class AppearanceBackgroundRuntime {
+  private readonly imageApi: AppearanceBackgroundImageApi | null
+  private readonly backgroundObjectUrls: BackgroundImageObjectUrlApi
+  private readonly objectUrlCache = new Map<string, CachedObjectUrl>()
+  private applyVersion = 0
+  private disposed = false
+
+  constructor(
+    private readonly root: HTMLElement,
+    options: AppearanceBackgroundRuntimeOptions = {}
+  ) {
+    this.imageApi =
+      options.imageApi === undefined ? getAppearanceBackgroundImageApi() : options.imageApi
+    this.backgroundObjectUrls = options.backgroundObjectUrls ?? browserBackgroundImageObjectUrls
+  }
+
+  apply(settings: Partial<OrcaBackgroundSettings> | null | undefined): void {
+    if (this.disposed) {
+      return
+    }
+    const version = ++this.applyVersion
+    const resolved = ORCA_BACKGROUND_AREAS.map((area) =>
+      resolveAppearanceBackground(settings, area)
+    )
+    const active = resolved.filter(
+      (background): background is ResolvedAppearanceBackground & { imageName: string } =>
+        background.active && background.imageName !== null
+    )
+
+    this.retainOnly(new Set(active.map((background) => background.imageName)))
+    this.applyAppearanceVariables(resolved)
+    this.clearAreaImages()
+
+    const readyAreas: AppearanceBackgroundArea[] = []
+    let readyTerminalImage: string | null = null
+    const pending: Promise<{
+      area: AppearanceBackgroundArea
+      imageName: string
+      url: string | null
+    }>[] = []
+    for (const background of active) {
+      const cached = this.objectUrlCache.get(background.imageName)
+      if (cached?.url) {
+        this.setAreaImage(background.area, cached.url)
+        readyAreas.push(background.area)
+        if (background.area === 'terminal') {
+          readyTerminalImage = background.imageName
+        }
+        continue
+      }
+      pending.push(
+        this.ensureObjectUrl(background.imageName).then((url) => ({
+          area: background.area,
+          imageName: background.imageName,
+          url
+        }))
+      )
+    }
+    this.setReadyAreas(readyAreas, readyTerminalImage)
+
+    if (pending.length > 0) {
+      void Promise.all(pending).then((loaded) => {
+        if (this.disposed || version !== this.applyVersion) {
+          return
+        }
+        for (const { area, imageName, url } of loaded) {
+          if (url) {
+            this.setAreaImage(area, url)
+            readyAreas.push(area)
+            if (area === 'terminal') {
+              readyTerminalImage = imageName
+            }
+          }
+        }
+        this.setReadyAreas(readyAreas, readyTerminalImage)
+      })
+    }
+  }
+
+  dispose(): void {
+    if (this.disposed) {
+      return
+    }
+    this.disposed = true
+    this.applyVersion += 1
+    this.retainOnly(new Set())
+    this.clearAreaImages()
+    this.clearAppearanceVariables()
+    setLoadedTerminalBackgroundImage(null)
+  }
+
+  private applyAppearanceVariables(backgrounds: readonly ResolvedAppearanceBackground[]): void {
+    const fit = backgrounds[0]?.fit ?? 'cover'
+    this.root.style.setProperty(
+      '--orca-background-size',
+      fit === 'stretch' ? '100% 100%' : fit === 'tile' ? 'auto' : fit
+    )
+    this.root.style.setProperty('--orca-background-repeat', fit === 'tile' ? 'repeat' : 'no-repeat')
+    for (const background of backgrounds) {
+      this.root.style.setProperty(
+        areaVariable(background.area, 'opacity'),
+        String(background.opacity)
+      )
+      this.root.style.setProperty(areaVariable(background.area, 'blur'), `${background.blurPx}px`)
+      this.root.style.setProperty(
+        areaVariable(background.area, 'scale'),
+        String(Math.min(2, 1 + background.blurPx / 25))
+      )
+    }
+  }
+
+  private clearAppearanceVariables(): void {
+    this.root.style.removeProperty('--orca-background-size')
+    this.root.style.removeProperty('--orca-background-repeat')
+    for (const area of ORCA_BACKGROUND_AREAS) {
+      this.root.style.removeProperty(areaVariable(area, 'opacity'))
+      this.root.style.removeProperty(areaVariable(area, 'blur'))
+      this.root.style.removeProperty(areaVariable(area, 'scale'))
+    }
+  }
+
+  private clearAreaImages(): void {
+    this.root.removeAttribute(ACTIVE_AREAS_ATTRIBUTE)
+    for (const area of ORCA_BACKGROUND_AREAS) {
+      this.root.style.removeProperty(areaVariable(area, 'image'))
+    }
+  }
+
+  private setAreaImage(area: AppearanceBackgroundArea, url: string): void {
+    this.root.style.setProperty(areaVariable(area, 'image'), `url("${url}")`)
+  }
+
+  private setReadyAreas(
+    areas: readonly AppearanceBackgroundArea[],
+    terminalImageName: string | null
+  ): void {
+    setLoadedTerminalBackgroundImage(areas.includes('terminal') ? terminalImageName : null)
+    if (areas.length === 0) {
+      this.root.removeAttribute(ACTIVE_AREAS_ATTRIBUTE)
+      return
+    }
+    this.root.setAttribute(
+      ACTIVE_AREAS_ATTRIBUTE,
+      [...new Set(areas.map(getAppearanceBackgroundDomArea))].join(' ')
+    )
+  }
+
+  private ensureObjectUrl(fileName: string): Promise<string | null> {
+    const cached = this.objectUrlCache.get(fileName)
+    if (cached?.url) {
+      return Promise.resolve(cached.url)
+    }
+    if (cached?.promise) {
+      return cached.promise
+    }
+    if (!this.imageApi) {
+      return Promise.resolve(null)
+    }
+
+    const entry: CachedObjectUrl = { url: null, promise: null }
+    entry.promise = this.loadObjectUrl(fileName).then((url) => {
+      if (this.objectUrlCache.get(fileName) !== entry) {
+        if (url) {
+          this.backgroundObjectUrls.revoke(url)
+        }
+        return null
+      }
+      entry.promise = null
+      if (!url) {
+        this.objectUrlCache.delete(fileName)
+        return null
+      }
+      entry.url = url
+      return url
+    })
+    this.objectUrlCache.set(fileName, entry)
+    return entry.promise
+  }
+
+  private async loadObjectUrl(fileName: string): Promise<string | null> {
+    try {
+      const result = await this.imageApi!.loadImage(fileName)
+      if (!result.ok) {
+        return null
+      }
+      return this.backgroundObjectUrls.create(result.data, result.mimeType)
+    } catch {
+      return null
+    }
+  }
+
+  private retainOnly(fileNames: ReadonlySet<string>): void {
+    for (const [fileName, entry] of this.objectUrlCache) {
+      if (fileNames.has(fileName)) {
+        continue
+      }
+      this.objectUrlCache.delete(fileName)
+      if (entry.url) {
+        this.backgroundObjectUrls.revoke(entry.url)
+      }
+    }
+  }
+}

--- a/src/renderer/src/lib/appearance-background-settings.test.ts
+++ b/src/renderer/src/lib/appearance-background-settings.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest'
 
 import type { OrcaBackgroundSettings } from '../../../shared/orca-background-settings'
 import {
+  APPEARANCE_BACKGROUND_BLUR_PX_RANGE,
+  APPEARANCE_BACKGROUND_OPACITY_RANGE,
   getAppearanceBackgroundDomArea,
   resolveAppearanceBackground
 } from './appearance-background-settings'
@@ -13,6 +15,11 @@ function settingsWith(
 }
 
 describe('appearance background settings', () => {
+  it('publishes the effect bounds used by resolution and controls', () => {
+    expect(APPEARANCE_BACKGROUND_OPACITY_RANGE).toEqual({ min: 0, max: 1 })
+    expect(APPEARANCE_BACKGROUND_BLUR_PX_RANGE).toEqual({ min: 0, max: 40 })
+  })
+
   it('resolves independent images and preserves the legacy shared fallback', () => {
     const settings = settingsWith({
       orcaBackgroundImage: 'legacy.png',

--- a/src/renderer/src/lib/appearance-background-settings.test.ts
+++ b/src/renderer/src/lib/appearance-background-settings.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+
+import type { OrcaBackgroundSettings } from '../../../shared/orca-background-settings'
+import {
+  getAppearanceBackgroundDomArea,
+  resolveAppearanceBackground
+} from './appearance-background-settings'
+
+function settingsWith(
+  overrides: Partial<OrcaBackgroundSettings> = {}
+): Partial<OrcaBackgroundSettings> {
+  return overrides
+}
+
+describe('appearance background settings', () => {
+  it('resolves independent images and preserves the legacy shared fallback', () => {
+    const settings = settingsWith({
+      orcaBackgroundImage: 'legacy.png',
+      orcaBackgroundByArea: {
+        terminal: 'terminal.png',
+        leftSidebar: null,
+        rightSidebar: 'right.png'
+      },
+      orcaBackgroundAreas: { terminal: true, leftSidebar: true, rightSidebar: true }
+    })
+
+    expect(resolveAppearanceBackground(settings, 'terminal').imageName).toBe('terminal.png')
+    expect(resolveAppearanceBackground(settings, 'leftSidebar').imageName).toBeNull()
+    expect(resolveAppearanceBackground(settings, 'rightSidebar').imageName).toBe('right.png')
+    expect(
+      resolveAppearanceBackground(
+        settingsWith({ orcaBackgroundImage: 'legacy.png' }),
+        'rightSidebar'
+      ).imageName
+    ).toBe('legacy.png')
+  })
+
+  it('uses safe area defaults when older settings omit the new maps', () => {
+    const settings = settingsWith({ orcaBackgroundImage: 'legacy.png' })
+
+    expect(resolveAppearanceBackground(settings, 'terminal').active).toBe(true)
+    expect(resolveAppearanceBackground(settings, 'leftSidebar').active).toBe(false)
+    expect(resolveAppearanceBackground(settings, 'rightSidebar').active).toBe(false)
+  })
+
+  it('clamps independent effects and rejects inherited fit names', () => {
+    const settings = settingsWith({
+      orcaBackgroundImage: 'image.png',
+      orcaBackgroundOpacity: 0.4,
+      orcaBackgroundOpacityByArea: { terminal: 2, leftSidebar: 0 },
+      orcaBackgroundBlur: 5,
+      orcaBackgroundBlurByArea: { terminal: -2, rightSidebar: 50 },
+      orcaBackgroundFit: 'toString' as never
+    })
+
+    expect(resolveAppearanceBackground(settings, 'terminal')).toMatchObject({
+      opacity: 1,
+      blurPx: 0,
+      fit: 'cover'
+    })
+    expect(resolveAppearanceBackground(settings, 'leftSidebar')).toMatchObject({
+      opacity: 0,
+      blurPx: 5
+    })
+    expect(resolveAppearanceBackground(settings, 'rightSidebar')).toMatchObject({
+      opacity: 0.4,
+      blurPx: 40
+    })
+  })
+
+  it('maps setting area names to stable DOM tokens', () => {
+    expect(getAppearanceBackgroundDomArea('terminal')).toBe('terminal')
+    expect(getAppearanceBackgroundDomArea('leftSidebar')).toBe('left-sidebar')
+    expect(getAppearanceBackgroundDomArea('rightSidebar')).toBe('right-sidebar')
+  })
+})

--- a/src/renderer/src/lib/appearance-background-settings.ts
+++ b/src/renderer/src/lib/appearance-background-settings.ts
@@ -1,0 +1,116 @@
+import {
+  DEFAULT_ORCA_BACKGROUND_SETTINGS,
+  ORCA_BACKGROUND_AREAS,
+  type OrcaBackgroundArea,
+  type OrcaBackgroundFit,
+  type OrcaBackgroundSettings
+} from '../../../shared/orca-background-settings'
+
+export type AppearanceBackgroundArea = OrcaBackgroundArea
+
+export type ResolvedAppearanceBackground = {
+  area: AppearanceBackgroundArea
+  imageName: string | null
+  active: boolean
+  opacity: number
+  blurPx: number
+  fit: OrcaBackgroundFit
+}
+
+const DOM_AREA_NAMES = {
+  terminal: 'terminal',
+  leftSidebar: 'left-sidebar',
+  rightSidebar: 'right-sidebar'
+} as const satisfies Record<AppearanceBackgroundArea, string>
+
+const BACKGROUND_FITS = new Set<OrcaBackgroundFit>(['cover', 'contain', 'stretch', 'tile'])
+
+function clampNumber(value: unknown, fallback: number, min: number, max: number): number {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? Math.min(max, Math.max(min, value))
+    : fallback
+}
+
+function resolveAreaNumber(
+  byArea: unknown,
+  area: AppearanceBackgroundArea,
+  shared: unknown,
+  fallback: number,
+  min: number,
+  max: number
+): number {
+  if (byArea && typeof byArea === 'object' && Object.hasOwn(byArea, area)) {
+    const areaValue = (byArea as Record<AppearanceBackgroundArea, unknown>)[area]
+    if (typeof areaValue === 'number' && Number.isFinite(areaValue)) {
+      return clampNumber(areaValue, fallback, min, max)
+    }
+  }
+  return clampNumber(shared, fallback, min, max)
+}
+
+function resolveImageName(
+  settings: Partial<OrcaBackgroundSettings>,
+  area: AppearanceBackgroundArea
+): string | null {
+  const byArea = settings.orcaBackgroundByArea
+  if (byArea && Object.hasOwn(byArea, area)) {
+    const areaImage = byArea[area]
+    return typeof areaImage === 'string' && areaImage.length > 0 ? areaImage : null
+  }
+  return typeof settings.orcaBackgroundImage === 'string' && settings.orcaBackgroundImage.length > 0
+    ? settings.orcaBackgroundImage
+    : null
+}
+
+function resolveAreaEnabled(
+  settings: Partial<OrcaBackgroundSettings>,
+  area: AppearanceBackgroundArea
+): boolean {
+  const configured = settings.orcaBackgroundAreas?.[area]
+  return typeof configured === 'boolean'
+    ? configured
+    : DEFAULT_ORCA_BACKGROUND_SETTINGS.orcaBackgroundAreas[area]
+}
+
+function resolveFit(value: unknown): OrcaBackgroundFit {
+  return typeof value === 'string' && BACKGROUND_FITS.has(value as OrcaBackgroundFit)
+    ? (value as OrcaBackgroundFit)
+    : DEFAULT_ORCA_BACKGROUND_SETTINGS.orcaBackgroundFit
+}
+
+export function getAppearanceBackgroundDomArea(area: AppearanceBackgroundArea): string {
+  return DOM_AREA_NAMES[area]
+}
+
+export function resolveAppearanceBackground(
+  settings: Partial<OrcaBackgroundSettings> | null | undefined,
+  area: AppearanceBackgroundArea
+): ResolvedAppearanceBackground {
+  const background = settings ?? {}
+  const imageName = resolveImageName(background, area)
+
+  return {
+    area,
+    imageName,
+    active: imageName !== null && resolveAreaEnabled(background, area),
+    opacity: resolveAreaNumber(
+      background.orcaBackgroundOpacityByArea,
+      area,
+      background.orcaBackgroundOpacity,
+      DEFAULT_ORCA_BACKGROUND_SETTINGS.orcaBackgroundOpacity,
+      0,
+      1
+    ),
+    blurPx: resolveAreaNumber(
+      background.orcaBackgroundBlurByArea,
+      area,
+      background.orcaBackgroundBlur,
+      DEFAULT_ORCA_BACKGROUND_SETTINGS.orcaBackgroundBlur,
+      0,
+      40
+    ),
+    fit: resolveFit(background.orcaBackgroundFit)
+  }
+}
+
+export { ORCA_BACKGROUND_AREAS }

--- a/src/renderer/src/lib/appearance-background-settings.ts
+++ b/src/renderer/src/lib/appearance-background-settings.ts
@@ -25,6 +25,9 @@ const DOM_AREA_NAMES = {
 
 const BACKGROUND_FITS = new Set<OrcaBackgroundFit>(['cover', 'contain', 'stretch', 'tile'])
 
+export const APPEARANCE_BACKGROUND_OPACITY_RANGE = { min: 0, max: 1 } as const
+export const APPEARANCE_BACKGROUND_BLUR_PX_RANGE = { min: 0, max: 40 } as const
+
 function clampNumber(value: unknown, fallback: number, min: number, max: number): number {
   return typeof value === 'number' && Number.isFinite(value)
     ? Math.min(max, Math.max(min, value))
@@ -98,16 +101,16 @@ export function resolveAppearanceBackground(
       area,
       background.orcaBackgroundOpacity,
       DEFAULT_ORCA_BACKGROUND_SETTINGS.orcaBackgroundOpacity,
-      0,
-      1
+      APPEARANCE_BACKGROUND_OPACITY_RANGE.min,
+      APPEARANCE_BACKGROUND_OPACITY_RANGE.max
     ),
     blurPx: resolveAreaNumber(
       background.orcaBackgroundBlurByArea,
       area,
       background.orcaBackgroundBlur,
       DEFAULT_ORCA_BACKGROUND_SETTINGS.orcaBackgroundBlur,
-      0,
-      40
+      APPEARANCE_BACKGROUND_BLUR_PX_RANGE.min,
+      APPEARANCE_BACKGROUND_BLUR_PX_RANGE.max
     ),
     fit: resolveFit(background.orcaBackgroundFit)
   }

--- a/src/renderer/src/lib/background-image-object-url.test.ts
+++ b/src/renderer/src/lib/background-image-object-url.test.ts
@@ -1,0 +1,63 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createBackgroundImageObjectUrlApi } from './background-image-object-url'
+
+const VALID_PNG = Uint8Array.from(
+  Buffer.from(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=',
+    'base64'
+  )
+)
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void
+  const promise = new Promise<void>((next) => {
+    resolve = next
+  })
+  return { promise, resolve }
+}
+
+describe('background image object URL', () => {
+  const createObjectURL = vi.fn(() => 'blob:background')
+  const revokeObjectURL = vi.fn()
+  const decodeImage = vi.fn<(_: string) => Promise<void>>()
+
+  beforeEach(() => {
+    createObjectURL.mockReset().mockReturnValue('blob:background')
+    revokeObjectURL.mockReset()
+    decodeImage.mockReset().mockResolvedValue()
+  })
+
+  it('publishes a valid PNG URL only after image decode succeeds', async () => {
+    const decode = deferred()
+    decodeImage.mockReturnValue(decode.promise)
+    const objectUrls = createBackgroundImageObjectUrlApi({
+      objectUrls: { createObjectURL, revokeObjectURL },
+      decodeImage
+    })
+
+    const pending = objectUrls.create(VALID_PNG, 'image/png')
+    await vi.waitFor(() => expect(decodeImage).toHaveBeenCalledWith('blob:background'))
+    await expect(Promise.race([pending, Promise.resolve('decode-pending')])).resolves.toBe(
+      'decode-pending'
+    )
+
+    decode.resolve()
+    await expect(pending).resolves.toBe('blob:background')
+    expect(revokeObjectURL).not.toHaveBeenCalled()
+  })
+
+  it('revokes the object URL when browser decode rejects it', async () => {
+    decodeImage.mockRejectedValue(new Error('corrupt image'))
+    const objectUrls = createBackgroundImageObjectUrlApi({
+      objectUrls: { createObjectURL, revokeObjectURL },
+      decodeImage
+    })
+
+    await expect(objectUrls.create(VALID_PNG, 'image/png')).resolves.toBeNull()
+    expect(revokeObjectURL).toHaveBeenCalledOnce()
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:background')
+  })
+})

--- a/src/renderer/src/lib/background-image-object-url.ts
+++ b/src/renderer/src/lib/background-image-object-url.ts
@@ -1,0 +1,51 @@
+type NativeObjectUrlApi = Pick<typeof URL, 'createObjectURL' | 'revokeObjectURL'>
+
+export type BackgroundImageObjectUrlApi = {
+  create: (data: Uint8Array, mimeType: string) => Promise<string | null>
+  revoke: (objectUrl: string) => void
+}
+
+type BackgroundImageObjectUrlOptions = {
+  objectUrls?: NativeObjectUrlApi
+  decodeImage?: (objectUrl: string) => Promise<void>
+}
+
+function copyImageBytes(data: Uint8Array): ArrayBuffer {
+  const bytes = new Uint8Array(data.byteLength)
+  bytes.set(data)
+  return bytes.buffer
+}
+
+export async function decodeBrowserBackgroundImage(objectUrl: string): Promise<void> {
+  const image = new Image()
+  image.src = objectUrl
+  await image.decode()
+}
+
+export function createBackgroundImageObjectUrlApi(
+  options: BackgroundImageObjectUrlOptions = {}
+): BackgroundImageObjectUrlApi {
+  const objectUrls = options.objectUrls ?? URL
+  const decodeImage = options.decodeImage ?? decodeBrowserBackgroundImage
+
+  return {
+    async create(data, mimeType) {
+      let objectUrl: string | null = null
+      try {
+        objectUrl = objectUrls.createObjectURL(new Blob([copyImageBytes(data)], { type: mimeType }))
+        await decodeImage(objectUrl)
+        return objectUrl
+      } catch {
+        if (objectUrl !== null) {
+          objectUrls.revokeObjectURL(objectUrl)
+        }
+        return null
+      }
+    },
+    revoke(objectUrl) {
+      objectUrls.revokeObjectURL(objectUrl)
+    }
+  }
+}
+
+export const browserBackgroundImageObjectUrls = createBackgroundImageObjectUrlApi()

--- a/src/renderer/src/lib/pane-manager/pane-divider.ts
+++ b/src/renderer/src/lib/pane-manager/pane-divider.ts
@@ -1,5 +1,6 @@
 import type { PaneStyleOptions, ManagedPaneInternal } from './pane-manager-types'
 import { attachDividerDrag, disposeDividerDrag, type DividerCallbacks } from './pane-divider-drag'
+import { markAppearanceBackgroundArea } from '@/lib/appearance-background-runtime'
 export { createDividerFlexFrameScheduler } from './pane-divider-drag'
 
 // ---------------------------------------------------------------------------
@@ -88,6 +89,7 @@ export function applyPaneOpacity(
 }
 
 export function applyRootBackground(root: HTMLElement, styleOptions: PaneStyleOptions): void {
+  markAppearanceBackgroundArea(root, 'terminal')
   if (styleOptions.splitBackground) {
     root.style.background = styleOptions.splitBackground
   }

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -165,6 +165,7 @@ import {
 } from '@/components/native-chat/native-chat-runtime-contract'
 import { createWebFileMutationMethods } from './web-file-mutation-methods'
 import { mergeWorkspaceCleanupUIState } from '../../../shared/workspace-cleanup-ui-state'
+import { normalizeOrcaBackgroundSettings } from '../../../shared/orca-background-settings'
 
 const SETTINGS_STORAGE_KEY = 'orca.web.settings.v1'
 const UI_STORAGE_KEY = 'orca.web.ui.v1'
@@ -823,6 +824,13 @@ function createWebPreloadApi(): Partial<PreloadApi> {
       uploadBundle: () => Promise.reject(new Error('Sending diagnostics is unavailable on web.')),
       deleteBundle: () => Promise.reject(new Error('Sent diagnostics are unavailable on web.'))
     },
+    // Background files belong to the desktop client's userData directory and never cross RPC.
+    backgrounds: {
+      listLibrary: () => Promise.resolve({ dir: '', images: [] }),
+      addImages: () => Promise.resolve({ dir: '', images: [], added: [], skipped: [] }),
+      openLibrary: () => Promise.resolve({ ok: false, reason: 'open-failed' }),
+      loadImage: () => Promise.resolve({ ok: false, reason: 'not-found' })
+    } satisfies PreloadApi['backgrounds'],
     session: {
       // Mirrors desktop bridge: non-local hosts persist under a host-suffixed key so their sessions stay isolated from local.
       get: (hostId) => Promise.resolve(getStoredWorkspaceSession(hostId)),
@@ -4270,6 +4278,7 @@ function mergeSettings(
   }
   return {
     ...merged,
+    ...normalizeOrcaBackgroundSettings(merged),
     ...normalizeAutoRenameBranchFromWorkDefaultOn(merged, {
       preserveExplicitValue: options.preserveAutoRenameBranchFromWorkUpdate
     })

--- a/src/shared/constants.test.ts
+++ b/src/shared/constants.test.ts
@@ -107,6 +107,23 @@ describe('getDefaultSettings', () => {
     expect(getDefaultSettings('/tmp').compactWorktreeCards).toBe(false)
   })
 
+  it('defaults custom backgrounds to the terminal with safe effects', () => {
+    expect(getDefaultSettings('/tmp')).toMatchObject({
+      orcaBackgroundImage: null,
+      orcaBackgroundByArea: {},
+      orcaBackgroundOpacity: 0.35,
+      orcaBackgroundOpacityByArea: {},
+      orcaBackgroundBlur: 0,
+      orcaBackgroundBlurByArea: {},
+      orcaBackgroundFit: 'cover',
+      orcaBackgroundAreas: {
+        terminal: true,
+        leftSidebar: false,
+        rightSidebar: false
+      }
+    })
+  })
+
   it('keeps per-workspace environments disabled by default', () => {
     expect(getDefaultSettings('/tmp').experimentalEphemeralVms).toBe(false)
   })

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -31,6 +31,7 @@ import { DEFAULT_SETUP_AGENT_STARTUP_POLICY } from './setup-agent-startup-policy
 import { DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT } from './terminal-scrollback-policy'
 import { DEFAULT_USAGE_PERCENTAGE_DISPLAY } from './usage-percentage-display'
 import { DEFAULT_STATUS_BAR_USAGE_MODE } from './status-bar-usage-mode'
+import { getDefaultOrcaBackgroundSettings } from './orca-background-settings'
 
 export { DEFAULT_STATUS_BAR_ITEMS } from './status-bar-defaults'
 export {
@@ -184,6 +185,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     leftSidebarAppearanceMode: 'default',
     leftSidebarTintColor: DEFAULT_LEFT_SIDEBAR_TINT_COLOR,
     leftSidebarTintOpacity: DEFAULT_LEFT_SIDEBAR_TINT_OPACITY,
+    ...getDefaultOrcaBackgroundSettings(),
     uiLanguage: UI_LANGUAGE_SYSTEM,
     appIcon: DEFAULT_APP_ICON_ID,
     appFontFamily: DEFAULT_APP_FONT_FAMILY,

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -26,6 +26,11 @@ import type { TerminalColorOverrides } from './terminal-color-overrides'
 import type { TerminalQuickCommand } from './terminal-quick-command-types'
 import type { TuiAgent } from './tui-agent'
 import type {
+  OrcaBackgroundArea,
+  OrcaBackgroundAreaMap,
+  OrcaBackgroundFit
+} from './orca-background-settings'
+import type {
   AgentDashboardMode,
   BranchPrefixStrategy,
   FloatingTerminalTriggerLocation,
@@ -78,6 +83,17 @@ export type GlobalSettings = {
   leftSidebarAppearanceMode: LeftSidebarAppearanceMode
   leftSidebarTintColor?: string
   leftSidebarTintOpacity?: number
+  /** Legacy shared image retained as the fallback for early background-enabled profiles. */
+  orcaBackgroundImage?: string | null
+  orcaBackgroundByArea?: OrcaBackgroundAreaMap<string | null>
+  /** Legacy shared opacity retained as the fallback for areas without an override. */
+  orcaBackgroundOpacity?: number
+  orcaBackgroundOpacityByArea?: OrcaBackgroundAreaMap<number>
+  /** Legacy shared blur retained as the fallback for areas without an override. */
+  orcaBackgroundBlur?: number
+  orcaBackgroundBlurByArea?: OrcaBackgroundAreaMap<number>
+  orcaBackgroundFit?: OrcaBackgroundFit
+  orcaBackgroundAreas?: Record<OrcaBackgroundArea, boolean>
   uiLanguage: UiLanguage
   appIcon: AppIconId
   appFontFamily: string

--- a/src/shared/orca-background-library-types.ts
+++ b/src/shared/orca-background-library-types.ts
@@ -1,0 +1,24 @@
+export type OrcaBackgroundLibraryImage = {
+  fileName: string
+  path: string
+  size: number
+}
+
+export type OrcaBackgroundLibrary = {
+  dir: string
+  images: OrcaBackgroundLibraryImage[]
+}
+
+export type OrcaBackgroundImportResult = OrcaBackgroundLibrary & {
+  added: string[]
+  skipped: string[]
+}
+
+export type OrcaBackgroundImageLoadResult =
+  | { ok: true; data: Uint8Array; mimeType: string }
+  | {
+      ok: false
+      reason: 'invalid-name' | 'unsupported-type' | 'not-found' | 'too-large' | 'read-failed'
+    }
+
+export type OrcaBackgroundOpenLibraryResult = { ok: true } | { ok: false; reason: 'open-failed' }

--- a/src/shared/orca-background-settings.test.ts
+++ b/src/shared/orca-background-settings.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getDefaultOrcaBackgroundSettings,
+  normalizeOrcaBackgroundSettings,
+  normalizeOrcaBackgroundSettingsUpdate
+} from './orca-background-settings'
+
+describe('Orca background settings', () => {
+  it('creates independent nested defaults', () => {
+    const first = getDefaultOrcaBackgroundSettings()
+    const second = getDefaultOrcaBackgroundSettings()
+
+    first.orcaBackgroundAreas.terminal = false
+    first.orcaBackgroundByArea.terminal = 'first.png'
+
+    expect(second).toEqual({
+      orcaBackgroundImage: null,
+      orcaBackgroundByArea: {},
+      orcaBackgroundOpacity: 0.35,
+      orcaBackgroundOpacityByArea: {},
+      orcaBackgroundBlur: 0,
+      orcaBackgroundBlurByArea: {},
+      orcaBackgroundFit: 'cover',
+      orcaBackgroundAreas: {
+        terminal: true,
+        leftSidebar: false,
+        rightSidebar: false
+      }
+    })
+  })
+
+  it('normalizes known areas, filenames, effects, and fit', () => {
+    expect(
+      normalizeOrcaBackgroundSettings({
+        orcaBackgroundImage: '../legacy.png',
+        orcaBackgroundByArea: {
+          terminal: 'terminal.png',
+          leftSidebar: null,
+          rightSidebar: 'nested\\right.png',
+          unknown: 'ignored.png'
+        },
+        orcaBackgroundOpacity: 2,
+        orcaBackgroundOpacityByArea: {
+          terminal: -1,
+          leftSidebar: 0.6,
+          rightSidebar: Number.NaN
+        },
+        orcaBackgroundBlur: -4,
+        orcaBackgroundBlurByArea: {
+          terminal: 60,
+          leftSidebar: 8,
+          rightSidebar: Number.POSITIVE_INFINITY
+        },
+        orcaBackgroundFit: 'unknown',
+        orcaBackgroundAreas: {
+          terminal: false,
+          leftSidebar: true,
+          rightSidebar: 'yes'
+        }
+      })
+    ).toEqual({
+      orcaBackgroundImage: null,
+      orcaBackgroundByArea: {
+        terminal: 'terminal.png',
+        leftSidebar: null,
+        rightSidebar: null
+      },
+      orcaBackgroundOpacity: 1,
+      orcaBackgroundOpacityByArea: { terminal: 0, leftSidebar: 0.6 },
+      orcaBackgroundBlur: 0,
+      orcaBackgroundBlurByArea: { terminal: 40, leftSidebar: 8 },
+      orcaBackgroundFit: 'cover',
+      orcaBackgroundAreas: {
+        terminal: false,
+        leftSidebar: true,
+        rightSidebar: false
+      }
+    })
+  })
+
+  it('normalizes only the keys present in an update', () => {
+    const current = {
+      ...getDefaultOrcaBackgroundSettings(),
+      orcaBackgroundByArea: { terminal: 'terminal.png', leftSidebar: 'left.png' }
+    }
+
+    expect(
+      normalizeOrcaBackgroundSettingsUpdate(
+        {
+          orcaBackgroundOpacityByArea: { terminal: 2, rightSidebar: 0.25 }
+        },
+        current
+      )
+    ).toEqual({
+      orcaBackgroundOpacityByArea: { terminal: 1, rightSidebar: 0.25 }
+    })
+  })
+})

--- a/src/shared/orca-background-settings.test.ts
+++ b/src/shared/orca-background-settings.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  ORCA_BACKGROUND_AREAS,
   getDefaultOrcaBackgroundSettings,
   normalizeOrcaBackgroundSettings,
   normalizeOrcaBackgroundSettingsUpdate
@@ -75,6 +76,19 @@ describe('Orca background settings', () => {
         leftSidebar: true,
         rightSidebar: false
       }
+    })
+  })
+
+  it('normalizes every canonical enabled area', () => {
+    const settings = normalizeOrcaBackgroundSettings({
+      orcaBackgroundAreas: { terminal: false }
+    })
+
+    expect(Object.keys(settings.orcaBackgroundAreas)).toEqual([...ORCA_BACKGROUND_AREAS])
+    expect(settings.orcaBackgroundAreas).toEqual({
+      terminal: false,
+      leftSidebar: false,
+      rightSidebar: false
     })
   })
 

--- a/src/shared/orca-background-settings.ts
+++ b/src/shared/orca-background-settings.ts
@@ -116,20 +116,15 @@ function normalizeNumberMap(
 
 function normalizeEnabledAreas(value: unknown): Record<OrcaBackgroundArea, boolean> {
   const source = isRecord(value) ? value : {}
-  return {
-    terminal:
-      typeof source.terminal === 'boolean'
-        ? source.terminal
-        : DEFAULT_ORCA_BACKGROUND_SETTINGS.orcaBackgroundAreas.terminal,
-    leftSidebar:
-      typeof source.leftSidebar === 'boolean'
-        ? source.leftSidebar
-        : DEFAULT_ORCA_BACKGROUND_SETTINGS.orcaBackgroundAreas.leftSidebar,
-    rightSidebar:
-      typeof source.rightSidebar === 'boolean'
-        ? source.rightSidebar
-        : DEFAULT_ORCA_BACKGROUND_SETTINGS.orcaBackgroundAreas.rightSidebar
+  const result = {} as Record<OrcaBackgroundArea, boolean>
+  for (const area of ORCA_BACKGROUND_AREAS) {
+    const enabled = source[area]
+    result[area] =
+      typeof enabled === 'boolean'
+        ? enabled
+        : DEFAULT_ORCA_BACKGROUND_SETTINGS.orcaBackgroundAreas[area]
   }
+  return result
 }
 
 export function normalizeOrcaBackgroundSettings(value: unknown): OrcaBackgroundSettings {

--- a/src/shared/orca-background-settings.ts
+++ b/src/shared/orca-background-settings.ts
@@ -1,0 +1,175 @@
+export const ORCA_BACKGROUND_AREAS = ['terminal', 'leftSidebar', 'rightSidebar'] as const
+
+export type OrcaBackgroundArea = (typeof ORCA_BACKGROUND_AREAS)[number]
+export type OrcaBackgroundFit = 'cover' | 'contain' | 'stretch' | 'tile'
+export type OrcaBackgroundAreaMap<T> = Partial<Record<OrcaBackgroundArea, T>>
+
+export type OrcaBackgroundSettings = {
+  /** Legacy shared image retained so profiles from the first background build still migrate. */
+  orcaBackgroundImage?: string | null
+  orcaBackgroundByArea: OrcaBackgroundAreaMap<string | null>
+  /** Legacy shared opacity retained as the fallback for areas without an override. */
+  orcaBackgroundOpacity: number
+  orcaBackgroundOpacityByArea: OrcaBackgroundAreaMap<number>
+  /** Legacy shared blur retained as the fallback for areas without an override. */
+  orcaBackgroundBlur: number
+  orcaBackgroundBlurByArea: OrcaBackgroundAreaMap<number>
+  orcaBackgroundFit: OrcaBackgroundFit
+  orcaBackgroundAreas: Record<OrcaBackgroundArea, boolean>
+}
+
+export const DEFAULT_ORCA_BACKGROUND_SETTINGS: Readonly<OrcaBackgroundSettings> = {
+  orcaBackgroundImage: null,
+  orcaBackgroundByArea: {},
+  orcaBackgroundOpacity: 0.35,
+  orcaBackgroundOpacityByArea: {},
+  orcaBackgroundBlur: 0,
+  orcaBackgroundBlurByArea: {},
+  orcaBackgroundFit: 'cover',
+  orcaBackgroundAreas: {
+    terminal: true,
+    leftSidebar: false,
+    rightSidebar: false
+  }
+}
+
+export function getDefaultOrcaBackgroundSettings(): OrcaBackgroundSettings {
+  return {
+    ...DEFAULT_ORCA_BACKGROUND_SETTINGS,
+    orcaBackgroundByArea: {},
+    orcaBackgroundOpacityByArea: {},
+    orcaBackgroundBlurByArea: {},
+    orcaBackgroundAreas: { ...DEFAULT_ORCA_BACKGROUND_SETTINGS.orcaBackgroundAreas }
+  }
+}
+
+export const ORCA_BACKGROUND_SETTING_KEYS = [
+  'orcaBackgroundImage',
+  'orcaBackgroundByArea',
+  'orcaBackgroundOpacity',
+  'orcaBackgroundOpacityByArea',
+  'orcaBackgroundBlur',
+  'orcaBackgroundBlurByArea',
+  'orcaBackgroundFit',
+  'orcaBackgroundAreas'
+] as const satisfies readonly (keyof OrcaBackgroundSettings)[]
+
+const ORCA_BACKGROUND_FITS: readonly OrcaBackgroundFit[] = ['cover', 'contain', 'stretch', 'tile']
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function normalizeFileName(value: unknown): string | null {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    value.length > 255 ||
+    value.includes('/') ||
+    value.includes('\\') ||
+    value.includes('\0') ||
+    value === '.' ||
+    value === '..'
+  ) {
+    return null
+  }
+  return value
+}
+
+function normalizeNumber(value: unknown, fallback: number, min: number, max: number): number {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? Math.min(max, Math.max(min, value))
+    : fallback
+}
+
+function normalizeImageMap(value: unknown): OrcaBackgroundAreaMap<string | null> {
+  if (!isRecord(value)) {
+    return {}
+  }
+  const result: OrcaBackgroundAreaMap<string | null> = {}
+  for (const area of ORCA_BACKGROUND_AREAS) {
+    if (!Object.hasOwn(value, area)) {
+      continue
+    }
+    result[area] = value[area] === null ? null : normalizeFileName(value[area])
+  }
+  return result
+}
+
+function normalizeNumberMap(
+  value: unknown,
+  min: number,
+  max: number
+): OrcaBackgroundAreaMap<number> {
+  if (!isRecord(value)) {
+    return {}
+  }
+  const result: OrcaBackgroundAreaMap<number> = {}
+  for (const area of ORCA_BACKGROUND_AREAS) {
+    const candidate = value[area]
+    if (typeof candidate === 'number' && Number.isFinite(candidate)) {
+      result[area] = Math.min(max, Math.max(min, candidate))
+    }
+  }
+  return result
+}
+
+function normalizeEnabledAreas(value: unknown): Record<OrcaBackgroundArea, boolean> {
+  const source = isRecord(value) ? value : {}
+  return {
+    terminal:
+      typeof source.terminal === 'boolean'
+        ? source.terminal
+        : DEFAULT_ORCA_BACKGROUND_SETTINGS.orcaBackgroundAreas.terminal,
+    leftSidebar:
+      typeof source.leftSidebar === 'boolean'
+        ? source.leftSidebar
+        : DEFAULT_ORCA_BACKGROUND_SETTINGS.orcaBackgroundAreas.leftSidebar,
+    rightSidebar:
+      typeof source.rightSidebar === 'boolean'
+        ? source.rightSidebar
+        : DEFAULT_ORCA_BACKGROUND_SETTINGS.orcaBackgroundAreas.rightSidebar
+  }
+}
+
+export function normalizeOrcaBackgroundSettings(value: unknown): OrcaBackgroundSettings {
+  const source = isRecord(value) ? value : {}
+  const fit = source.orcaBackgroundFit
+  return {
+    orcaBackgroundImage: normalizeFileName(source.orcaBackgroundImage),
+    orcaBackgroundByArea: normalizeImageMap(source.orcaBackgroundByArea),
+    orcaBackgroundOpacity: normalizeNumber(
+      source.orcaBackgroundOpacity,
+      DEFAULT_ORCA_BACKGROUND_SETTINGS.orcaBackgroundOpacity,
+      0,
+      1
+    ),
+    orcaBackgroundOpacityByArea: normalizeNumberMap(source.orcaBackgroundOpacityByArea, 0, 1),
+    orcaBackgroundBlur: normalizeNumber(
+      source.orcaBackgroundBlur,
+      DEFAULT_ORCA_BACKGROUND_SETTINGS.orcaBackgroundBlur,
+      0,
+      40
+    ),
+    orcaBackgroundBlurByArea: normalizeNumberMap(source.orcaBackgroundBlurByArea, 0, 40),
+    orcaBackgroundFit:
+      typeof fit === 'string' && ORCA_BACKGROUND_FITS.includes(fit as OrcaBackgroundFit)
+        ? (fit as OrcaBackgroundFit)
+        : DEFAULT_ORCA_BACKGROUND_SETTINGS.orcaBackgroundFit,
+    orcaBackgroundAreas: normalizeEnabledAreas(source.orcaBackgroundAreas)
+  }
+}
+
+export function normalizeOrcaBackgroundSettingsUpdate(
+  updates: object,
+  current: Partial<OrcaBackgroundSettings>
+): Partial<OrcaBackgroundSettings> {
+  const normalized = normalizeOrcaBackgroundSettings({ ...current, ...updates })
+  const result: Partial<OrcaBackgroundSettings> = {}
+  for (const key of ORCA_BACKGROUND_SETTING_KEYS) {
+    if (Object.hasOwn(updates, key)) {
+      Object.assign(result, { [key]: normalized[key] })
+    }
+  }
+  return result
+}


### PR DESCRIPTION
## ELI5

Appearance settings now work like a safe draft: changes appear immediately in a fixed preview, can be saved or discarded, and the terminal plus both sidebars can each use their own background image and effects.

## What Changed

- Added a live draft/save/discard lifecycle with navigation and close guards.
- Added one fixed preview for Orca chrome and the terminal, synchronized with theme mode, font, colors, and background settings.
- Added independent image selection, enablement, opacity, blur, and reset controls for the terminal, left sidebar, and right sidebar; fit remains shared.
- Rendered the saved background layers in the real workspace.
- Added a local Electron image library with a parented picker, validated/copy-on-import files, preload APIs, and a safe web fallback.
- Guarded Ghostty/Warp imports and image decoding against stale asynchronous results.
- Added coverage for draft behavior, previews, runtime rendering, IPC, image validation, and decode failures.

## Why

The previous preview did not represent terminal background changes, sidebar images were not previewed, and all areas were tied to one image. Reusing the same background resolver in the editor preview and runtime keeps both views consistent. The settings remain optional and client-local, so this adds no remote wire dependency and preserves existing configurations.

## Linked Issue

Fixes #15524

## Visual Proof

| Before: static terminal preview | After: live per-area previews |
| --- | --- |
| ![Appearance settings before](https://raw.githubusercontent.com/Sylen00/orca/pr-assets-appearance-live-preview/.github/pr-assets/appearance-live-preview/before.png) | ![Appearance settings after](https://raw.githubusercontent.com/Sylen00/orca/pr-assets-appearance-live-preview/.github/pr-assets/appearance-live-preview/after.png) |

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Manual validation used Electron on Windows 11 with an isolated profile:

- Selected different images for all three areas and changed opacity/blur.
- Confirmed Reset restores opacity `1` and blur `0`.
- Confirmed light/dark mode and editor/central preview synchronization.
- Saved and confirmed terminal, left-sidebar, and right-sidebar layers render in the workspace.
- Confirmed there were no renderer page errors.

Local automated checks:

- `corepack pnpm typecheck`
- 28 related Vitest files: 237 passed, 1 platform skip
- `corepack pnpm exec oxlint src`
- `corepack pnpm check:max-lines-ratchet`
- `corepack pnpm run build:electron-vite`
- Localization catalog, extraction, and coverage checks
- Type-aware code-quality audit and reliability gates
- React Doctor changed-lines blocking check: 0 errors

macOS, Linux, and SSH were not manually exercised; full root lint/test/build wrappers are left to CI. No remote protocol, shortcut, or Git command changed.

## AI Disclosure

Claude (exact model/version unavailable from the continued session) and OpenAI Codex (GPT-5) were used for implementation, review, and testing.

## Review

- **Security:** imported images are copied into Orca-owned storage and checked for supported content, bounded file size/dimensions, symlinks, and decode failures; failed/stale object URLs are revoked.
- **Cross-platform:** uses Electron/Node path and dialog APIs without hard-coded separators. Windows was manually tested; macOS/Linux remain covered by CI.
- **Remote SSH/folder workspaces:** settings and image storage are client-local and do not assume a Git worktree or alter the remote wire contract.
- **Mobile/web:** no mobile behavior changed; the web preload fallback safely reports the image library as unavailable.
- **Backward compatibility:** optional fields are normalized to existing defaults; old settings keep their prior appearance.
- **Performance:** images load only for enabled areas, decode before activation, and reuse/revoke object URLs deterministically.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

The scope is cohesive but not small in line count because it spans settings state, Electron IPC, the runtime layers, and their tests. The PR branch itself contains no screenshots; visual proof is hosted on a separate fork branch after the `gh image` browser-session fallback was unavailable.

## Checklist

- [ ] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: Not provided (GitHub: @Sylen00)
