### PR TITLE
fix(terminal): keep a quick command queued until its own spawn takes it (STA-4876)

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -731,19 +731,12 @@ function TerminalPane(
   const [sessionRestoredBannerPaneIds, setSessionRestoredBannerPaneIds] = useState<
     Map<number, SessionRestoredBannerReason>
   >(() => new Map())
-  const consumeTabStartupCommand = useAppStore((store) => store.consumeTabStartupCommand)
   const [setupSplit] = useState(() => useAppStore.getState().pendingSetupSplitByTabId[tabId])
   const consumeTabSetupSplit = useAppStore((store) => store.consumeTabSetupSplit)
   const [issueCommandSplit] = useState(
     () => useAppStore.getState().pendingIssueCommandSplitByTabId[tabId]
   )
   const consumeTabIssueCommandSplit = useAppStore((store) => store.consumeTabIssueCommandSplit)
-  useEffect(() => {
-    if (startup) {
-      consumeTabStartupCommand(tabId)
-    }
-  }, [startup, tabId, consumeTabStartupCommand])
-
   useLayoutEffect(() => {
     if (isVisible && shouldMeasureHiddenStartup) {
       // Why: hidden startup measurement is first-launch only; keeping it past first visibility would let inactive tabs refit and SIGWINCH.

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -14,6 +14,7 @@ import { createPortal } from 'react-dom'
 import type { CSSProperties } from 'react'
 import type { IDisposable } from '@xterm/xterm'
 import { useAppStore } from '../../store'
+import { logQuickCommandStartupDiagnostic } from '@/lib/quick-command-startup-diagnostics'
 import { useLinkRoutingPreferenceDialog } from '@/components/link-routing-preference-dialog'
 import { DaemonActionDialog, useDaemonActions } from '@/components/shared/useDaemonActions'
 import {
@@ -724,7 +725,14 @@ function TerminalPane(
   const rightClickToPaste = settings?.terminalRightClickToPaste ?? isWindowsUserAgent()
   // Why: Windows ConPTY doesn't forward DECSET 2004 from TUIs, so xterm may not know multi-line paste needs bracketed protection.
   const forceBracketedMultilineTextPaste = isWindowsUserAgent()
-  const [startup] = useState(() => useAppStore.getState().pendingStartupByTabId[tabId])
+  const [startup] = useState(() => {
+    const queued = useAppStore.getState().pendingStartupByTabId[tabId]
+    logQuickCommandStartupDiagnostic('paneMount', {
+      tabId,
+      queuedStartup: queued ? 'found' : 'MISSING'
+    })
+    return queued
+  })
   const [shouldMeasureHiddenStartup, setShouldMeasureHiddenStartup] = useState(
     () => startup !== undefined && !isVisible
   )

--- a/src/renderer/src/components/terminal-pane/pty-connection-queued-startup-consume.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-queued-startup-consume.test.ts
@@ -1,0 +1,192 @@
+import type * as React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushAsyncTicks } from './pty-connection-test-async'
+import {
+  createMockTransport,
+  createPane,
+  createManager,
+  type MockTransport
+} from './pty-connection-test-pane-fixtures'
+import { buildPaneConnectionDeps } from './pty-connection-test-deps'
+import { createInitialStoreState } from './pty-connection-test-store-fixtures'
+import type { StoreState } from './pty-connection-test-store-state'
+import {
+  installTerminalTestGlobals,
+  restoreTerminalTestGlobals
+} from './pty-connection-test-environment'
+
+const {
+  resetAndRefreshAllTerminalWebglAtlases,
+  scheduleTerminalWebglAtlasRecovery,
+  scheduleRuntimeGraphSync,
+  shouldSeedCacheTimerOnInitialTitle,
+  toastInfo,
+  notifyCodexPaneBoundForStaleSweep
+} = vi.hoisted(() => ({
+  resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
+  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleRuntimeGraphSync: vi.fn(),
+  shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
+  toastInfo: vi.fn(),
+  notifyCodexPaneBoundForStaleSweep: vi.fn()
+}))
+
+let mockStoreState: StoreState
+let transportFactoryQueue: MockTransport[] = []
+let createdTransportOptions: Record<string, unknown>[] = []
+let storeSubscribers: ((state: StoreState) => void)[] = []
+
+vi.mock('@/runtime/sync-runtime-graph', () => ({ scheduleRuntimeGraphSync }))
+
+vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  resetAndRefreshAllTerminalWebglAtlases
+}))
+
+vi.mock('./terminal-webgl-atlas-recovery', () => ({ scheduleTerminalWebglAtlasRecovery }))
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: () => mockStoreState,
+    subscribe: (listener: (state: StoreState) => void) => {
+      storeSubscribers.push(listener)
+      return () => {
+        storeSubscribers = storeSubscribers.filter((candidate) => candidate !== listener)
+      }
+    }
+  }
+}))
+
+vi.mock('@/lib/agent-status', async (importOriginal) => {
+  const { buildAgentStatusModuleMock } = await import('./pty-connection-test-environment')
+  return buildAgentStatusModuleMock(await importOriginal<Record<string, unknown>>())
+})
+
+vi.mock('./cache-timer-seeding', () => ({ shouldSeedCacheTimerOnInitialTitle }))
+
+vi.mock('sonner', () => ({ toast: { info: toastInfo } }))
+
+vi.mock('@/lib/codex-stale-pane-sweep', () => ({ notifyCodexPaneBoundForStaleSweep }))
+
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal<typeof React>()
+  return {
+    ...actual,
+    useCallback: <T extends (...args: unknown[]) => unknown>(fn: T): T => fn
+  }
+})
+
+vi.mock('./pty-transport', () => ({
+  createIpcPtyTransport: vi.fn((options: Record<string, unknown>) => {
+    createdTransportOptions.push(options)
+    const nextTransport = transportFactoryQueue.shift()
+    if (!nextTransport) {
+      throw new Error('No mock transport queued')
+    }
+    return nextTransport
+  })
+}))
+
+vi.mock('./pty-dispatcher', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return { ...actual, getEagerPtyBufferHandle: vi.fn(() => undefined) }
+})
+
+function spawnOnConnect(transport: MockTransport, ptyId: string): void {
+  transport.connect.mockImplementation(async () => {
+    const onPtySpawn = createdTransportOptions[0]?.onPtySpawn as ((id: string) => void) | undefined
+    onPtySpawn?.(ptyId)
+    return ptyId
+  })
+}
+
+// Why this suite exists: the queued startup command is spent through onQueuedStartupSpawned, and
+// both *when* it fires and *how often* are load-bearing. Spending it before the pty is bound
+// unmounts the pane mid-spawn (the entry is what holds its worktree out of the retention-budget
+// force-park); spending it on a later respawn drops a command queued after the first launch
+// (STA-4876).
+describe('connectPanePty queued startup consume', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    transportFactoryQueue = []
+    createdTransportOptions = []
+    storeSubscribers = []
+    mockStoreState = createInitialStoreState(() => mockStoreState)
+    installTerminalTestGlobals()
+  })
+
+  afterEach(async () => {
+    await restoreTerminalTestGlobals()
+  })
+
+  it('spends the queued startup only after the pty is bound to the tab', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    spawnOnConnect(transport, 'fresh-pty')
+    transportFactoryQueue.push(transport)
+
+    const callOrder: string[] = []
+    const deps = buildPaneConnectionDeps(() => mockStoreState, {
+      startup: { command: 'echo queued' },
+      updateTabPtyId: vi.fn(() => {
+        callOrder.push('updateTabPtyId')
+      }),
+      onQueuedStartupSpawned: vi.fn(() => {
+        callOrder.push('onQueuedStartupSpawned')
+      })
+    })
+
+    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks(20)
+
+    expect(callOrder).toContain('onQueuedStartupSpawned')
+    expect(callOrder.indexOf('updateTabPtyId')).toBeGreaterThanOrEqual(0)
+    expect(callOrder.indexOf('updateTabPtyId')).toBeLessThan(
+      callOrder.indexOf('onQueuedStartupSpawned')
+    )
+  })
+
+  it('leaves the queued startup unspent when the spawn never reaches onPtySpawn', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    // A retired/reattached spawn resolves without ever announcing a fresh pty.
+    transport.connect.mockImplementation(async () => undefined)
+    transportFactoryQueue.push(transport)
+
+    const onQueuedStartupSpawned = vi.fn()
+    const deps = buildPaneConnectionDeps(() => mockStoreState, {
+      startup: { command: 'echo queued' },
+      onQueuedStartupSpawned
+    })
+
+    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks(20)
+
+    // The next mount must still find the command queued, or it is lost for good.
+    expect(onQueuedStartupSpawned).not.toHaveBeenCalled()
+  })
+
+  it('does not strand the pane without a pty when the consume throws', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    spawnOnConnect(transport, 'fresh-pty')
+    transportFactoryQueue.push(transport)
+
+    const updateTabPtyId = vi.fn()
+    const deps = buildPaneConnectionDeps(() => mockStoreState, {
+      startup: { command: 'echo queued' },
+      updateTabPtyId,
+      onQueuedStartupSpawned: vi.fn(() => {
+        throw new Error('store blew up')
+      })
+    })
+
+    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks(20)
+
+    // onPtySpawn runs inside the connect promise: an unguarded throw would reject it and leave the
+    // pane with no pty at all, which is strictly worse than a stale queued entry.
+    expect(updateTabPtyId).toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/pty-connection-queued-startup-consume.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-queued-startup-consume.test.ts
@@ -167,10 +167,25 @@ describe('connectPanePty queued startup consume', () => {
     expect(onQueuedStartupSpawned).not.toHaveBeenCalled()
   })
 
-  it('does not strand the pane without a pty when the consume throws', async () => {
+  it('keeps a throwing consume from escaping into the spawn', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport()
-    spawnOnConnect(transport, 'fresh-pty')
+    // Mirror the transport contract: onPtySpawn is invoked from inside the connect promise, so
+    // anything it throws rejects that promise, strands the pane with no pty, and is far worse
+    // than the stale queued entry the callback exists to clear.
+    let escapedIntoSpawn = false
+    transport.connect.mockImplementation(async () => {
+      const onPtySpawn = createdTransportOptions[0]?.onPtySpawn as
+        | ((id: string) => void)
+        | undefined
+      try {
+        onPtySpawn?.('fresh-pty')
+      } catch {
+        escapedIntoSpawn = true
+        return undefined
+      }
+      return 'fresh-pty'
+    })
     transportFactoryQueue.push(transport)
 
     const updateTabPtyId = vi.fn()
@@ -185,8 +200,7 @@ describe('connectPanePty queued startup consume', () => {
     connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
     await flushAsyncTicks(20)
 
-    // onPtySpawn runs inside the connect promise: an unguarded throw would reject it and leave the
-    // pane with no pty at all, which is strictly worse than a stale queued entry.
+    expect(escapedIntoSpawn).toBe(false)
     expect(updateTabPtyId).toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/terminal-pane/pty-connection-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-types.ts
@@ -70,6 +70,9 @@ export type PtyConnectionDeps = {
     (paneId: number, state: PtyTransportRecoveryState | null) => void
   >
   clearTabPtyId: (tabId: string, ptyId: string) => void
+  /** Set only on the pane carrying the tab's queued startup command; called once its own fresh
+   *  spawn exists, which is the first moment the command is guaranteed to reach a shell. */
+  onQueuedStartupSpawned?: () => void
   consumeSuppressedPtyExit: (ptyId: string) => boolean
   isPtyShutdownPending: (ptyId: string) => boolean
   updateTabTitle: (tabId: string, title: string) => void

--- a/src/renderer/src/components/terminal-pane/pty-connection-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-types.ts
@@ -71,7 +71,9 @@ export type PtyConnectionDeps = {
   >
   clearTabPtyId: (tabId: string, ptyId: string) => void
   /** Set only on the pane carrying the tab's queued startup command; called once its own fresh
-   *  spawn exists, which is the first moment the command is guaranteed to reach a shell. */
+   *  spawn exists, which is the first moment a live shell exists to receive it. Not proof of
+   *  delivery: Windows runs an argv-embedded command before this, and a POSIX shell can die
+   *  before the shell-ready write. */
   onQueuedStartupSpawned?: () => void
   consumeSuppressedPtyExit: (ptyId: string) => boolean
   isPtyShutdownPending: (ptyId: string) => boolean

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -3102,6 +3102,23 @@ export function connectPanePty(
     // Why: Command Code has no prompt-start hook. Seed the visible working row
     // once the PTY exists, then let real hook events refine or complete it.
     bindActivePanePty(ptyId, { seedInitialAgentStatus: true })
+    // Why here and nowhere earlier: this is the only point that proves *this* pane's fresh spawn
+    // carried the queued command and survived. A pane retired mid-connect never reaches it, so the
+    // command stays queued for the next mount instead of vanishing (STA-4876).
+    // Why after the bind, and not before: while the tab still has no ptyId, the queued entry is the
+    // only thing keeping its worktree out of the retention-budget force-park
+    // (hasPendingRetentionSpawnWork) — dropping it first unmounts this pane mid-spawn.
+    // Caveat this does NOT cover: the consume tracks "a pty exists", not "the command ran". Windows
+    // embeds short commands in the shell argv, so they execute before the spawn resolves — a pane
+    // retired in that window re-delivers on remount. On POSIX the write waits for shell-ready, so a
+    // pty that dies before then loses a command this already spent. Closing either needs a
+    // delivery signal from main, not this callback.
+    try {
+      deps.onQueuedStartupSpawned?.()
+    } catch {
+      // Why swallowed: this callback runs inside the connect promise, so a throw would reject the
+      // spawn and strand the pane with no pty at all — a far worse failure than a stale entry.
+    }
   }
   const onPtyRebind = (ptyId: string, replacedPtyId: string): void => {
     if (!canAdoptCapturedDirectSshRetryPty(ptyId)) {

--- a/src/renderer/src/components/terminal-pane/terminal-pane-recovery.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-recovery.ts
@@ -4,6 +4,7 @@ import {
   _resetTerminalInputQuarantineForTests,
   armTerminalInputQuarantine
 } from './terminal-input-quarantine'
+import { logQuickCommandStartupDiagnostic } from '@/lib/quick-command-startup-diagnostics'
 
 // Why this module exists: a terminal pane can die renderer-side while its PTY
 // stays alive — a wedged xterm WriteBuffer (issue #2836), a disposed xterm
@@ -197,6 +198,10 @@ function cancelPendingRecoveryRetry(tabId: string): void {
  * either way: a remount rebuilds the renderer over the PTY it already had.
  */
 export async function requestTerminalPaneRecovery(request: RecoveryRequest): Promise<boolean> {
+  logQuickCommandStartupDiagnostic('recoveryRequested', {
+    tabId: request.tabId,
+    reason: request.reason
+  })
   if (!isCurrentTerminalRecoveryRequest(request)) {
     return false
   }

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts
@@ -3,6 +3,7 @@ import {
   applyTerminalPaneCloseRequest,
   applyTerminalScrollbackRowsToMountedPanes,
   clearQueuedInitialCwdAfterFirstPane,
+  createQueuedStartupConsumer,
   getPreviousVisibleForTerminalPane,
   isTerminalPaneVisibilityResume,
   isTouchIOSUserAgent,
@@ -222,6 +223,36 @@ describe('paneOwnsQueuedStartup', () => {
     expect(paneOwnsQueuedStartup(null, null)).toBe(false)
     expect(paneOwnsQueuedStartup(undefined, undefined)).toBe(false)
     expect(paneOwnsQueuedStartup({ command: 'orca setup' }, null)).toBe(false)
+  })
+})
+
+describe('createQueuedStartupConsumer', () => {
+  it('withholds the consumer from a pane that does not own the queued command', () => {
+    const queuedStartup = { command: 'echo queued' }
+    const consume = vi.fn()
+
+    // A setup split's borrowed payload, structurally identical to the queued command.
+    expect(
+      createQueuedStartupConsumer({ command: 'echo queued' }, queuedStartup, consume)
+    ).toBeUndefined()
+    expect(createQueuedStartupConsumer(null, queuedStartup, consume)).toBeUndefined()
+    expect(consume).not.toHaveBeenCalled()
+  })
+
+  // Why: onPtySpawn fires again on hibernation wake and the respawn ladder. Spending the slot on a
+  // later spawn would drop a command queued after the first launch, without ever delivering it.
+  it('spends the queued command at most once across repeated spawns', () => {
+    const queuedStartup = { command: 'echo queued' }
+    const consume = vi.fn()
+
+    const consumer = createQueuedStartupConsumer(queuedStartup, queuedStartup, consume)
+    expect(consumer).toBeTypeOf('function')
+
+    consumer?.()
+    consumer?.()
+    consumer?.()
+
+    expect(consume).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts
@@ -7,6 +7,7 @@ import {
   isTerminalPaneVisibilityResume,
   isTouchIOSUserAgent,
   mapRestoredPaneTitlesByPaneId,
+  paneOwnsQueuedStartup,
   resolvePaneLinkCwd,
   resolvePaneSeedCwd,
   resolveQueuedInitialCwd,
@@ -174,6 +175,53 @@ describe('resetTerminalKeyboardProtocolAfterInterrupt', () => {
     } finally {
       _resetWritePipelineHealthForTests(terminal)
     }
+  })
+})
+
+// Why: onPaneCreated uses paneOwnsQueuedStartup to decide whether a pane may spend the tab's queued
+// startup command. Setup/issue splits borrow the same deps.startup field for their own one-shot
+// payload, so a looser test would let a split pane spend a command it never runs — re-breaking
+// STA-4876 for split-setup worktrees.
+describe('paneOwnsQueuedStartup', () => {
+  it('grants ownership only to the pane still holding the queued object', () => {
+    const queuedStartup = { command: 'echo queued' }
+    const deps: { startup?: { command: string; env?: Record<string, string> } | null } = {
+      startup: queuedStartup
+    }
+    const ownershipAtConnect: boolean[] = []
+    const observeConnect = (): void => {
+      ownershipAtConnect.push(paneOwnsQueuedStartup(deps.startup, queuedStartup))
+    }
+
+    // Primary pane connects first and owns the queued command.
+    observeConnect()
+    // connectPanePty took it; the lifecycle nulls the outer slot so splits cannot replay it.
+    deps.startup = null
+    splitPaneWithOneShotStartup(deps, { command: 'orca setup' }, () => {
+      observeConnect()
+      return { id: 2 }
+    })
+    splitPaneWithOneShotStartup(deps, { command: 'orca issue' }, () => {
+      observeConnect()
+      return { id: 3 }
+    })
+
+    expect(ownershipAtConnect).toEqual([true, false, false])
+  })
+
+  // Why this case matters: a truthiness regression ("has a startup") passes the test above, because
+  // the split payload is non-null there too. Only a structurally-identical payload separates them.
+  it('denies ownership to a split payload structurally identical to the queued command', () => {
+    const queuedStartup = { command: 'orca setup' }
+
+    expect(paneOwnsQueuedStartup({ command: 'orca setup' }, queuedStartup)).toBe(false)
+    expect(paneOwnsQueuedStartup(queuedStartup, queuedStartup)).toBe(true)
+  })
+
+  it('denies ownership when the tab queued nothing, so an unrelated pane cannot spend a slot', () => {
+    expect(paneOwnsQueuedStartup(null, null)).toBe(false)
+    expect(paneOwnsQueuedStartup(undefined, undefined)).toBe(false)
+    expect(paneOwnsQueuedStartup({ command: 'orca setup' }, null)).toBe(false)
   })
 })
 

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -492,6 +492,32 @@ export function paneOwnsQueuedStartup(
   return queuedStartup != null && paneStartup === queuedStartup
 }
 
+/**
+ * The callback that spends the tab's queued startup command, or `undefined` when this pane does
+ * not own it.
+ *
+ * Why one-shot: `onPtySpawn` fires on every fresh spawn a pane makes — hibernation wake, the
+ * respawn ladder — but only the first carried the queued command. A command queued onto the tab
+ * afterwards belongs to that later launch, and spending it here would drop it undelivered.
+ */
+export function createQueuedStartupConsumer(
+  paneStartup: object | null | undefined,
+  queuedStartup: object | null | undefined,
+  consume: () => void
+): (() => void) | undefined {
+  if (!paneOwnsQueuedStartup(paneStartup, queuedStartup)) {
+    return undefined
+  }
+  let spent = false
+  return () => {
+    if (spent) {
+      return
+    }
+    spent = true
+    consume()
+  }
+}
+
 /** Scopes `deps.startup` to a single call of `splitPane()`, clearing it in `finally` so later splits do not replay the payload. */
 export function splitPaneWithOneShotStartup<TPane>(
   deps: SplitWithStartupDeps,
@@ -1309,22 +1335,14 @@ export function useTerminalPaneLifecycle({
           }
         }
         applyAppearance(manager)
-        // Why one-shot: onPtySpawn fires on every fresh spawn this pane makes (hibernation wake,
-        // the respawn ladder), but only the first carried the queued command. A command queued onto
-        // the tab afterwards belongs to that later launch, and spending it here would drop it
-        // without ever delivering it.
-        let queuedStartupSpent = false
-        const consumeQueuedStartupOnce = (): void => {
-          if (queuedStartupSpent) {
-            return
-          }
-          queuedStartupSpent = true
-          useAppStore.getState().consumeTabStartupCommand(tabId)
-        }
-        const ownsQueuedStartup = paneOwnsQueuedStartup(ptyDeps.startup, startupWithSetupSplitWait)
+        const onQueuedStartupSpawned = createQueuedStartupConsumer(
+          ptyDeps.startup,
+          startupWithSetupSplitWait,
+          () => useAppStore.getState().consumeTabStartupCommand(tabId)
+        )
         const panePtyBinding = connectPanePty(pane, manager, {
           ...ptyDeps,
-          ...(ownsQueuedStartup ? { onQueuedStartupSpawned: consumeQueuedStartupOnce } : {}),
+          ...(onQueuedStartupSpawned ? { onQueuedStartupSpawned } : {}),
           // Why: spread order matters — spawnHints.cwd (source pane) must override ptyDeps.cwd (worktree root) so splits boot in the live cwd.
           ...(spawnHints?.cwd ? { cwd: spawnHints.cwd } : {}),
           restoredPtyIdByLeafId: spawnHints?.ptyId

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -25,6 +25,7 @@ import { buildWindowsPtyCompatibilityOptions } from '@/lib/pane-manager/windows-
 import { buildTerminalKeyboardProtocolOptions } from '@/lib/pane-manager/terminal-keyboard-protocol'
 import { resolvePaneKeyboardProtocolAgent } from './terminal-keyboard-protocol-pane-agent'
 import { useAppStore } from '@/store'
+import { logQuickCommandStartupDiagnostic } from '@/lib/quick-command-startup-diagnostics'
 import type { DirectSshPaneRetryAttemptId } from '@/store/slices/direct-ssh-terminal-recovery'
 import {
   createFilePathLinkProvider,
@@ -515,6 +516,7 @@ export function createQueuedStartupConsumer(
     }
     spent = true
     consume()
+    logQuickCommandStartupDiagnostic('consumed', {})
   }
 }
 

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -478,6 +478,20 @@ function resolveTerminalHomePathFromEnv(env: Record<string, string> | undefined)
   return homeDrive && homePath ? `${homeDrive}${homePath}` : null
 }
 
+/**
+ * Whether this pane's startup is the tab's queued command rather than a payload a split borrowed.
+ *
+ * Why reference identity and not truthiness: setup/issue splits assign their own one-shot object to
+ * the same `deps.startup` field, so "has a startup" would let a split pane spend a command it never
+ * runs — and a split's payload can be structurally identical to the queued one (STA-4876).
+ */
+export function paneOwnsQueuedStartup(
+  paneStartup: object | null | undefined,
+  queuedStartup: object | null | undefined
+): boolean {
+  return queuedStartup != null && paneStartup === queuedStartup
+}
+
 /** Scopes `deps.startup` to a single call of `splitPane()`, clearing it in `finally` so later splits do not replay the payload. */
 export function splitPaneWithOneShotStartup<TPane>(
   deps: SplitWithStartupDeps,
@@ -1295,8 +1309,22 @@ export function useTerminalPaneLifecycle({
           }
         }
         applyAppearance(manager)
+        // Why one-shot: onPtySpawn fires on every fresh spawn this pane makes (hibernation wake,
+        // the respawn ladder), but only the first carried the queued command. A command queued onto
+        // the tab afterwards belongs to that later launch, and spending it here would drop it
+        // without ever delivering it.
+        let queuedStartupSpent = false
+        const consumeQueuedStartupOnce = (): void => {
+          if (queuedStartupSpent) {
+            return
+          }
+          queuedStartupSpent = true
+          useAppStore.getState().consumeTabStartupCommand(tabId)
+        }
+        const ownsQueuedStartup = paneOwnsQueuedStartup(ptyDeps.startup, startupWithSetupSplitWait)
         const panePtyBinding = connectPanePty(pane, manager, {
           ...ptyDeps,
+          ...(ownsQueuedStartup ? { onQueuedStartupSpawned: consumeQueuedStartupOnce } : {}),
           // Why: spread order matters — spawnHints.cwd (source pane) must override ptyDeps.cwd (worktree root) so splits boot in the live cwd.
           ...(spawnHints?.cwd ? { cwd: spawnHints.cwd } : {}),
           restoredPtyIdByLeafId: spawnHints?.ptyId

--- a/src/renderer/src/lib/quick-command-startup-diagnostics.ts
+++ b/src/renderer/src/lib/quick-command-startup-diagnostics.ts
@@ -1,0 +1,25 @@
+/**
+ * TEMPORARY diagnostics for STA-4876. Remove before merge.
+ *
+ * Prints the full life of a queued startup command for one quick-command click, so we can see on
+ * a real loaded machine whether a pane remount lands between the pane taking the command and its
+ * shell existing — the window in which the command used to be lost for good.
+ *
+ * Read it in DevTools (Cmd+Opt+I) filtered on `STA-4876`.
+ */
+export function logQuickCommandStartupDiagnostic(
+  event: string,
+  fields: Record<string, string | number | boolean | null | undefined> = {}
+): void {
+  try {
+    const detail = Object.entries(fields)
+      .map(([key, value]) => `${key}=${value ?? 'none'}`)
+      .join(' ')
+    // eslint-disable-next-line no-console
+    console.log(
+      `[STA-4876] ${event}${detail ? ` ${detail}` : ''} t=${Math.round(performance.now())}`
+    )
+  } catch {
+    // Diagnostics must never break a launch.
+  }
+}

--- a/src/renderer/src/lib/run-quick-command-in-new-tab.ts
+++ b/src/renderer/src/lib/run-quick-command-in-new-tab.ts
@@ -1,4 +1,5 @@
 import { useAppStore } from '@/store'
+import { logQuickCommandStartupDiagnostic } from '@/lib/quick-command-startup-diagnostics'
 import { reconcileTabOrder } from '@/components/tab-bar/reconcile-order'
 import { launchAgentInNewTab } from '@/lib/launch-agent-in-new-tab'
 import {
@@ -90,6 +91,7 @@ export function runQuickCommandInNewTab({
   store.queueTabStartupCommand(tab.id, {
     command: flattenTerminalQuickCommand(command).command
   })
+  logQuickCommandStartupDiagnostic('queued', { tabId: tab.id, label: command.label })
 
   // Why: match `+` button's createNewTerminalTab — without this, a worktree
   // currently showing an editor file keeps rendering the editor and the new

--- a/src/renderer/src/store/slices/terminal-startup-command-retention.test.ts
+++ b/src/renderer/src/store/slices/terminal-startup-command-retention.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import { createTestStore, makeWorktree, seedStore } from './store-test-helpers'
+
+const WORKTREE_ID = 'repo1::/path/wt1'
+
+function seedWorktreeWithTab(store: ReturnType<typeof createTestStore>): string {
+  seedStore(store, {
+    worktreesByRepo: {
+      repo1: [makeWorktree({ id: WORKTREE_ID, repoId: 'repo1', path: '/path/wt1' })]
+    }
+  })
+  return store.getState().createTab(WORKTREE_ID).id
+}
+
+// Why this suite exists: TerminalPane snapshots pendingStartupByTabId in a useState initializer,
+// so whatever is missing there at mount is missing for good. The command must therefore survive
+// every store event that can precede its owning pane's fresh spawn, or a quick command leaves the
+// user a titled tab sitting at a bare prompt (STA-4876).
+describe('queued startup command retention', () => {
+  it('survives a recovery remount so the next mount can still deliver it', () => {
+    const store = createTestStore()
+    const tabId = seedWorktreeWithTab(store)
+    store.getState().queueTabStartupCommand(tabId, { command: 'echo hi' })
+
+    store.getState().remountTerminalTabForRecovery(tabId)
+
+    expect(store.getState().pendingStartupByTabId[tabId]).toEqual({ command: 'echo hi' })
+  })
+
+  // Why: binding is pane-scoped but this map is tab-scoped. A tab routinely runs several panes
+  // (setup/issue splits land on the same tabId), and the sibling often binds first — if a bind
+  // spent the command, the pane that actually owns it would find an empty slot on remount.
+  it('is not spent by a sibling pane binding a pty to the same tab', () => {
+    const store = createTestStore()
+    const tabId = seedWorktreeWithTab(store)
+    store.getState().queueTabStartupCommand(tabId, { command: 'echo hi' })
+
+    store.getState().updateTabPtyId(tabId, 'pty-sibling')
+
+    expect(store.getState().pendingStartupByTabId[tabId]).toEqual({ command: 'echo hi' })
+  })
+
+  // Only the owning pane spends it, via this action, once its own fresh spawn exists.
+  it('is spent through consumeTabStartupCommand and does not replay afterwards', () => {
+    const store = createTestStore()
+    const tabId = seedWorktreeWithTab(store)
+    store.getState().queueTabStartupCommand(tabId, { command: 'echo hi' })
+
+    expect(store.getState().consumeTabStartupCommand(tabId)).toEqual({ command: 'echo hi' })
+
+    store.getState().remountTerminalTabForRecovery(tabId)
+    expect(store.getState().pendingStartupByTabId[tabId]).toBeUndefined()
+    expect(store.getState().consumeTabStartupCommand(tabId)).toBeNull()
+  })
+
+  // Why: retention is bounded by tab lifetime, so a spawn that never binds cannot leak forever.
+  it('is dropped when the tab closes without ever spawning', () => {
+    const store = createTestStore()
+    const tabId = seedWorktreeWithTab(store)
+    store.getState().queueTabStartupCommand(tabId, { command: 'echo hi' })
+
+    store.getState().closeTab(tabId)
+
+    expect(store.getState().pendingStartupByTabId[tabId]).toBeUndefined()
+  })
+
+  it('leaves a sibling tab’s queued command alone', () => {
+    const store = createTestStore()
+    const tabId = seedWorktreeWithTab(store)
+    const siblingId = store.getState().createTab(WORKTREE_ID).id
+    store.getState().queueTabStartupCommand(tabId, { command: 'echo mine' })
+    store.getState().queueTabStartupCommand(siblingId, { command: 'echo theirs' })
+
+    store.getState().consumeTabStartupCommand(tabId)
+
+    expect(store.getState().pendingStartupByTabId[siblingId]).toEqual({ command: 'echo theirs' })
+  })
+})

--- a/src/renderer/src/store/slices/worktrees/session/worktree-slice-lookups.ts
+++ b/src/renderer/src/store/slices/worktrees/session/worktree-slice-lookups.ts
@@ -1,3 +1,4 @@
+import { logQuickCommandStartupDiagnostic } from '@/lib/quick-command-startup-diagnostics'
 import type { WorktreeSlice } from '../../worktree-helpers'
 import type { WorktreeSliceGet, WorktreeSliceSet } from '../listing/worktree-slice-types'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../../../shared/constants'
@@ -40,6 +41,11 @@ export function createRemountTerminalTabForRecovery(
           )
         }
         remounted = true
+        logQuickCommandStartupDiagnostic('generationBump', {
+          tabId,
+          source: 'recovery',
+          gen: (tab.generation ?? 0) + 1
+        })
         return {
           tabsByWorktree: {
             ...s.tabsByWorktree,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​363 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​363 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​117 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​109 |

<!-- /orca-pr-loc -->

Fixes STA-4876.

## Symptom

Triggering a quick command opened a terminal tab titled with the command's label, the shell started and drew its prompt, and the command never ran. Repeatable for the reporter, and every scope failed alike — repo, global and agent-prompt.

The reporter's screenshot is the whole bug in one frame: the quick-commands menu is fine (the split button reads "▶ Ad Hoc Build"), a tab carries the command's label, and the pane below it is a bare prompt. Nothing was "empty" except the terminal.

## Cause

`TerminalPane` snapshots `pendingStartupByTabId[tabId]` in a `useState` lazy initializer, and a mount effect deleted the entry immediately. The pane's key is `` `${tab.id}-${tab.generation ?? 0}` ``, so anything that bumps generation before the command reaches a shell mounts a second pane that re-reads an emptied slot and spawns with no command:

- the stall-recovery remount fired from `requestTerminalPaneRecovery` (`input-undeliverable`, or a wedged write pipeline)
- the `allDead` activation regeneration in `set-active-worktree`

Both are load-dependent, which is why this reproduced constantly on a busy machine and not at all on an idle one. All three quick-command scopes funnel through the same queue-then-snapshot sequence, so all three failed together.

**This is not a regression.** It reproduces on `main` and on builds predating the reporter's.

## Fix

Spend the entry at `onPtySpawn` — the one point that proves *this* pane's own fresh spawn exists. A pane retired mid-connect never reaches it, so the command stays queued for the next mount; reattach skips `onPtySpawn`, so it cannot spend a command it never delivers.

Three details are load-bearing, each learned by breaking it:

- **Ownership is reference identity** (`paneOwnsQueuedStartup`). Setup and issue splits borrow the same `deps.startup` field for their own one-shot payload, and that payload can be structurally identical to the queued command — a truthiness test lets a split pane spend a command it never runs.
- **The consume runs after `bindActivePanePty`.** While the tab has no ptyId, the queued entry is the only thing holding its worktree out of the retention-budget force-park; dropping it first unmounts the pane mid-spawn. An earlier cut of this patch did exactly that and left terminals blank.
- **The callback is one-shot.** `onPtySpawn` fires on every fresh spawn a pane makes, including hibernation wake and the respawn ladder, and a command queued after the first launch belongs to that later launch.

Two earlier designs were tried and rejected: consuming in the store's `updateTabPtyId` (binding is pane-scoped but that map is tab-scoped, so a sibling split's bind ate the primary's command), and consuming at the `connectPanePty` call site (the connection took the command, then a remount respawned before the pty registered and it died with the orphaned spawn).

## Verification

e2e through the real split button in a dev build over CDP, measured by appending to a file rather than reading screenshots:

| scenario | before | after |
|---|---|---|
| plain trigger | 1 | 1 |
| **recovery remount** | **0** | **1** |
| all-dead activation bump | 0 | 1 |
| two triggers | — | 2 |

11,302 unit tests, both changed-code gates (0 new findings), full typecheck.

The new tests are mutation-verified, not self-graded — each of these fails the suite: moving the consume before `bindActivePanePty`, deleting the consume call, and relaxing the ownership predicate to truthiness.

## Known residual

The consume tracks "a pty exists", not "the command ran":

- **Windows** embeds short commands in the shell argv, so they execute before the spawn resolves; a pane retired in that window re-delivers on remount (double-run).
- **POSIX** waits for shell-ready, so a pty that dies in that window loses a command already spent.

Closing either needs a real delivery signal from main. There is no existing ack to reuse: `startupCommandDeliveredInShellArgs` lives entirely in `src/main` and crosses only main↔daemon, and `PtyConnectResult` carries no delivery field. A proper fix needs an optional spawn-result field for argv-embedded delivery plus a new post-connect "startup written at shell-ready" event for the provider path — and since old hosts will never emit that event across version skew, the renderer needs this `onPtySpawn` consume as its fallback regardless. This diff is the base layer either way, not work an ack would replace.

Both windows are narrow and both are strictly better than losing the command unconditionally. Documented at the call site.

Separately, a pane that takes a non-fresh-spawn branch and never remounts keeps its entry until `closeTab`, pinning that worktree outside the retention memory bound.
