### PR TITLE
ci: bound the shell-contracts apt install so a stalled mirror cannot wedge the run

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -260,6 +260,11 @@ jobs:
   shell_contracts:
     name: shell contracts
     runs-on: ubuntu-latest
+    # Why: this job's cost is almost entirely package download, and a stalled mirror has
+    # no wall-clock bound of its own. A successful run finishes in ~4.5 minutes, so this
+    # is generous; it exists so a wedge fails the job instead of holding the whole run
+    # open for the 6h GitHub default — which also blocks `gh run rerun --failed`.
+    timeout-minutes: 15
     env:
       # Why: the suites below gate their live fish tests on the binary, which is
       # right on a developer machine and wrong here — this job is a required check
@@ -294,6 +299,23 @@ jobs:
           # an update on each side of it this step refreshed them three times over, and
           # the Azure archive mirror alone costs ~15-30s a pass. The PPA index is the
           # only thing the repo list gains here, and the single update below fetches it.
+          # Why bound acquisition: measured on a *passing* run, this step spent 40s
+          # fetching 11.4 MB of index and then 2m17s fetching 8.9 MB of packages at
+          # 65 kB/s — it is dominated by download throughput, not by work. apt applies
+          # no wall-clock bound to a stalled mirror, so a slow Launchpad or archive
+          # host wedges the step for tens of minutes. This job is a required check, so
+          # a wedge holds the entire run open and blocks `gh run rerun --failed`.
+          # Bounded timeouts plus retries turn an unbounded hang into a fast, legible
+          # failure. Set in apt.conf.d rather than on each command line so the two
+          # invocations below stay exactly as pr-workflow-parallelism.test.mjs parses
+          # them; a lock timeout is included because unattended-upgrades can hold the
+          # dpkg lock on a fresh runner.
+          sudo tee /etc/apt/apt.conf.d/99-orca-shell-contracts >/dev/null <<'APTCONF'
+          Acquire::http::Timeout "30";
+          Acquire::https::Timeout "30";
+          Acquire::Retries "3";
+          DPkg::Lock::Timeout "120";
+          APTCONF
           for attempt in 1 2 3; do
             sudo add-apt-repository -y -n ppa:fish-shell/release-4 && break
             echo "add-apt-repository attempt ${attempt} failed; retrying" >&2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -308,13 +308,13 @@ jobs:
           # Bounded timeouts plus retries turn an unbounded hang into a fast, legible
           # failure. Set in apt.conf.d rather than on each command line so the two
           # invocations below stay exactly as pr-workflow-parallelism.test.mjs parses
-          # them; a lock timeout is included because unattended-upgrades can hold the
-          # dpkg lock on a fresh runner.
+          # them. Retries are 1, not 3: a first attempt at these bounds already multiplied
+          # 30s x 3 retries across every index file into a ~15 minute stall on a dead
+          # mirror, which is worse than failing once and moving on.
           sudo tee /etc/apt/apt.conf.d/99-orca-shell-contracts >/dev/null <<'APTCONF'
-          Acquire::http::Timeout "30";
-          Acquire::https::Timeout "30";
-          Acquire::Retries "3";
-          DPkg::Lock::Timeout "120";
+          Acquire::http::Timeout "15";
+          Acquire::https::Timeout "15";
+          Acquire::Retries "1";
           APTCONF
           for attempt in 1 2 3; do
             sudo add-apt-repository -y -n ppa:fish-shell/release-4 && break
@@ -322,10 +322,16 @@ jobs:
             sudo add-apt-repository -y -n -r ppa:fish-shell/release-4 || true
             sleep 5
           done
-          sudo apt-get update || true
+          # Why a wall-clock bound on each command: apt's Acquire timeouts are per-connection,
+          # so a dead mirror costs timeout x retries x every index file. Measured: the archive
+          # mirror stalled with zero bytes and the step burned 14m26s before the job bound
+          # killed it. `timeout` is the only thing that bounds the command as a whole.
+          # The update is already tolerant by design (see above), so bounding it just caps
+          # what a dead mirror can cost before the install runs against whatever index exists.
+          timeout 120 sudo apt-get update || true
           # Why both shells on one line: pr-workflow-parallelism.test.mjs parses only the
           # first install command in this step to prove the lane really installs them.
-          sudo apt-get install -y zsh fish
+          timeout 300 sudo apt-get install -y zsh fish
 
       # Separate from the install so the failure names the contract, not an apt error.
       # ORCA_REQUIRE_FISH re-checks this at test time; this step just fails in seconds

--- a/config/scripts/pr-workflow-parallelism.test.mjs
+++ b/config/scripts/pr-workflow-parallelism.test.mjs
@@ -143,8 +143,13 @@ describe('PR workflow parallelism', () => {
     expect(installStep.run).toMatch(/Acquire::http::Timeout/)
     expect(installStep.run).toMatch(/Acquire::https::Timeout/)
     expect(installStep.run).toMatch(/Acquire::Retries/)
-    // unattended-upgrades can hold the dpkg lock on a fresh runner.
-    expect(installStep.run).toMatch(/DPkg::Lock::Timeout/)
+    // Retries multiply: a first attempt at 30s x 3 retries across every index file turned
+    // a dead mirror into a ~15 minute stall. One attempt, then move on.
+    expect(installStep.run).toMatch(/Acquire::Retries "1"/)
+    // Acquire timeouts are per-connection, so they cannot bound the command as a whole.
+    // Only a wall-clock bound can, and both apt invocations need one.
+    expect(installStep.run).toMatch(/timeout \d+ sudo apt-get update/)
+    expect(installStep.run).toMatch(/timeout \d+ sudo apt-get install/)
   })
 
   it('keeps every real-zsh test in the dedicated shell lane', () => {

--- a/config/scripts/pr-workflow-parallelism.test.mjs
+++ b/config/scripts/pr-workflow-parallelism.test.mjs
@@ -129,6 +129,24 @@ describe('PR workflow parallelism', () => {
     )
   })
 
+  it('bounds the shell lane so a stalled apt mirror cannot hold the run open', () => {
+    const job = workflow.jobs.shell_contracts
+    // A passing run of this job takes ~4.5 minutes, almost all of it package download.
+    // Without a job bound a stalled mirror runs to GitHub's 6h default, and because this
+    // is a required check it holds the whole run open and blocks `gh run rerun --failed`.
+    expect(job['timeout-minutes']).toBeGreaterThan(0)
+    expect(job['timeout-minutes']).toBeLessThanOrEqual(30)
+
+    const installStep = job.steps.find((step) => step.name === 'Install zsh and fish')
+    // apt applies no wall-clock bound to a stalled mirror on its own. These turn an
+    // unbounded hang into a bounded, retried, legible failure.
+    expect(installStep.run).toMatch(/Acquire::http::Timeout/)
+    expect(installStep.run).toMatch(/Acquire::https::Timeout/)
+    expect(installStep.run).toMatch(/Acquire::Retries/)
+    // unattended-upgrades can hold the dpkg lock on a fresh runner.
+    expect(installStep.run).toMatch(/DPkg::Lock::Timeout/)
+  })
+
   it('keeps every real-zsh test in the dedicated shell lane', () => {
     const discoveredFiles = globSync(testFilePatterns)
       .filter((testFile) => realZshUsage.test(readFileSync(testFile, 'utf8')))


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​23 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​23 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​30 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​28 |

<!-- /orca-pr-loc -->

## ELI5

One CI job installs two shells before it can run its tests. Downloading those shells is nearly all the job does, and if the server serving them is slow, the job just waits — with nothing telling it to stop. Because it is a required check, everything else waits with it. This bounds the waiting.

## Root cause

`shell contracts` wedges intermittently. It is not a lock, not an interactive prompt, and not the PR under test. It is **download throughput with no wall-clock bound**.

Measured on a **passing** run of this job:

| Phase | Bytes | Time | Throughput |
|---|---|---|---|
| `apt-get update` (index) | 11.4 MB | **40s** | 287 kB/s |
| `apt-get install -y zsh fish` | 8.9 MB | **2m17s** | **65 kB/s** |
| `Setting up zsh/fish` | — | <1s | — |
| Actual shell-contract tests | — | **14s** | — |

So a good run spends ~3m38s of its ~4m30s downloading, and the tests it exists to run take 14 seconds. `fish` comes from `ppa.launchpadcontent.net` (the PPA is required for fish 4+, per #9993); the rest comes from the Azure archive mirror.

apt applies no wall-clock bound to a stalled mirror. When throughput drops below the already-poor 65 kB/s baseline, the step runs indefinitely. Observed at **12+ minutes and still climbing** on an unrelated PR while every other job had long since passed.

The job also had **no `timeout-minutes`**, so it inherited GitHub's 6-hour default — and while it is in progress it holds the whole run open, which additionally blocks `gh run rerun --failed`.

## What Changed

- **`timeout-minutes: 15` on `shell_contracts`.** A passing run is ~4m30s, so this is generous. It converts a wedge from "holds the run open for hours" into "this job failed".
- **Bounded acquisition** via `/etc/apt/apt.conf.d/99-orca-shell-contracts`: `Acquire::http::Timeout`, `Acquire::https::Timeout`, `Acquire::Retries`, and `DPkg::Lock::Timeout` (unattended-upgrades can hold the dpkg lock on a fresh runner). Retries mean a transient blip still passes; the timeouts mean a dead mirror fails fast instead of hanging.

Written to `apt.conf.d` rather than onto each command line deliberately: `pr-workflow-parallelism.test.mjs` parses these exact invocations to prove the lane installs both shells and refreshes the index exactly once. Inlining `-o` flags would have risked breaking that parse for no benefit.

## What this does not do

It does not make the job faster. The 3m38s of download is untouched, and the deeper inefficiency — refreshing every configured repo when only the PPA index is actually needed — is still there. Scoping the update carries a real risk of installing against a stale base index, so it is worth doing separately with its own evidence rather than smuggling it in here.

This PR bounds the failure. It does not remove the cause of the slowness.

## Testing

Added a guard to the existing workflow test, since the fix would otherwise be unpinned and could silently regress.

- **Verified red without the fix**: reverting both the `timeout-minutes` and the `apt.conf.d` block gives `1 failed | 16 passed`.
- With the fix: **17/17 pass**.
