### PR TITLE
fix(mobile): converge the persisted WS fallback port after the default port recovers (STA-4859)

### DIFF
--- a/src/main/runtime/rpc/ws-fallback-port-store.test.ts
+++ b/src/main/runtime/rpc/ws-fallback-port-store.test.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
   clearWsFallbackPort,
   readWsFallbackPort,
@@ -47,9 +47,14 @@ describe('ws-fallback-port-store', () => {
 
   it('clearing is a no-op when nothing is persisted and survives an unremovable path', () => {
     const userDataPath = makeUserDataPath()
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     expect(() => clearWsFallbackPort(userDataPath)).not.toThrow()
-    // Why: a directory at the file's path makes rmSync throw — clearing is best-effort like the write.
+    expect(warnSpy).not.toHaveBeenCalled()
+    // Why: a directory at the file's path makes rmSync throw — clearing is best-effort like the write, but
+    // must leave a trace, since a silently kept file re-arms the flip-flop it was meant to end.
     mkdirSync(join(userDataPath, 'mobile-ws-fallback-port.json'))
     expect(() => clearWsFallbackPort(userDataPath)).not.toThrow()
+    expect(warnSpy).toHaveBeenCalled()
+    warnSpy.mockRestore()
   })
 })

--- a/src/main/runtime/rpc/ws-fallback-port-store.test.ts
+++ b/src/main/runtime/rpc/ws-fallback-port-store.test.ts
@@ -1,8 +1,12 @@
-import { mkdtempSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { readWsFallbackPort, writeWsFallbackPort } from './ws-fallback-port-store'
+import {
+  clearWsFallbackPort,
+  readWsFallbackPort,
+  writeWsFallbackPort
+} from './ws-fallback-port-store'
 
 function makeUserDataPath(): string {
   return mkdtempSync(join(tmpdir(), 'ws-fallback-port-test-'))
@@ -31,5 +35,21 @@ describe('ws-fallback-port-store', () => {
     writeWsFallbackPort(userDataPath, 0)
     writeWsFallbackPort(userDataPath, 70000)
     expect(readWsFallbackPort(userDataPath)).toBeUndefined()
+  })
+
+  it('clears a persisted fallback port', () => {
+    const userDataPath = makeUserDataPath()
+    writeWsFallbackPort(userDataPath, 54321)
+    clearWsFallbackPort(userDataPath)
+    expect(existsSync(join(userDataPath, 'mobile-ws-fallback-port.json'))).toBe(false)
+    expect(readWsFallbackPort(userDataPath)).toBeUndefined()
+  })
+
+  it('clearing is a no-op when nothing is persisted and survives an unremovable path', () => {
+    const userDataPath = makeUserDataPath()
+    expect(() => clearWsFallbackPort(userDataPath)).not.toThrow()
+    // Why: a directory at the file's path makes rmSync throw — clearing is best-effort like the write.
+    mkdirSync(join(userDataPath, 'mobile-ws-fallback-port.json'))
+    expect(() => clearWsFallbackPort(userDataPath)).not.toThrow()
   })
 })

--- a/src/main/runtime/rpc/ws-fallback-port-store.ts
+++ b/src/main/runtime/rpc/ws-fallback-port-store.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync } from 'node:fs'
+import { readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 // Why: when the preferred WS port is taken (second Orca instance), the OS
@@ -41,5 +41,16 @@ export function writeWsFallbackPort(userDataPath: string, port: number): void {
   } catch {
     // Why: persistence is best-effort — failing to record the port must not
     // break transport startup; the cost is a re-pair after the next restart.
+  }
+}
+
+// Why: a fallback that failed to bind while the configured port recovered is obsolete — leaving it
+// re-arms a dead endpoint next launch, so the advertised port flip-flops (STA-4859, seen with
+// Windows Hyper-V reserved ranges that move across reboots).
+export function clearWsFallbackPort(userDataPath: string): void {
+  try {
+    rmSync(join(userDataPath, FALLBACK_PORT_FILE), { force: true })
+  } catch {
+    // Why: best-effort like the write — a stale file costs one more convergence pass, not a startup failure.
   }
 }

--- a/src/main/runtime/rpc/ws-fallback-port-store.ts
+++ b/src/main/runtime/rpc/ws-fallback-port-store.ts
@@ -44,13 +44,14 @@ export function writeWsFallbackPort(userDataPath: string, port: number): void {
   }
 }
 
-// Why: a fallback that failed to bind while the configured port recovered is obsolete — leaving it
-// re-arms a dead endpoint next launch, so the advertised port flip-flops (STA-4859, seen with
-// Windows Hyper-V reserved ranges that move across reboots).
+// Why: a fallback the OS refused to listen on is obsolete — leaving it re-arms a dead endpoint next
+// launch and flip-flops the advertised port (STA-4859, Windows reserved ranges that move across reboots).
 export function clearWsFallbackPort(userDataPath: string): void {
+  const target = join(userDataPath, FALLBACK_PORT_FILE)
   try {
-    rmSync(join(userDataPath, FALLBACK_PORT_FILE), { force: true })
-  } catch {
-    // Why: best-effort like the write — a stale file costs one more convergence pass, not a startup failure.
+    rmSync(target, { force: true })
+  } catch (error) {
+    // Why: best-effort like the write, but a silent failure re-arms the flip-flop — say so.
+    console.warn(`[ws-fallback-port-store] Failed to clear ${target}:`, error)
   }
 }

--- a/src/main/runtime/rpc/ws-transport.ts
+++ b/src/main/runtime/rpc/ws-transport.ts
@@ -63,6 +63,7 @@ export class WebSocketTransport implements RpcTransport {
   private wsClientIds = new Map<WebSocket, string>()
   private heartbeatConnections = new Set<WebSocket>()
   private preAuthTimers = new WeakMap<WebSocket, ReturnType<typeof setTimeout>>()
+  private fallbackListenDenied = false
 
   constructor({
     host,
@@ -127,6 +128,12 @@ export class WebSocketTransport implements RpcTransport {
     return this.port
   }
 
+  // Why: reports that the OS refused a listen on the persisted fallback (reserved range), not merely that
+  // the bind failed — callers need the distinction to tell a dead port from a momentarily busy one.
+  get persistedFallbackListenDenied(): boolean {
+    return this.fallbackListenDenied
+  }
+
   // Why: the actual OS-reported bind interface, so callers can verify loopback vs all-interfaces (STA-2370).
   get resolvedHost(): string | null {
     const addr = this.httpServer?.address()
@@ -137,6 +144,7 @@ export class WebSocketTransport implements RpcTransport {
     if (this.wss) {
       return
     }
+    this.fallbackListenDenied = false
 
     // Why: bind a persisted fallback first so devices paired to it aren't stranded (STA-1511); serve --port flips to pinned-first (issue #8535); on failure each candidate falls through to OS-assigned port 0.
     const persistedFallbackPort =
@@ -155,10 +163,9 @@ export class WebSocketTransport implements RpcTransport {
         return
       } catch (error: unknown) {
         // Why: a persisted fallback may fail for any reason, while configured ports fall through only when their listen is occupied or denied.
-        if (
-          port !== persistedFallbackPort &&
-          (!isPortListenFallbackError(error, port) || port === 0)
-        ) {
+        if (port === persistedFallbackPort) {
+          this.fallbackListenDenied = isListenPermissionDenied(error, port)
+        } else if (!isPortListenFallbackError(error, port) || port === 0) {
           throw error
         }
         console.warn(
@@ -340,10 +347,15 @@ function isPortListenFallbackError(error: unknown, port: number): boolean {
   if (!(error instanceof Error) || !('code' in error)) {
     return false
   }
-  if (error.code === 'EADDRINUSE') {
-    return true
-  }
+  return error.code === 'EADDRINUSE' || isListenPermissionDenied(error, port)
+}
+
+// Why: the OS reserving the port itself (Windows Hyper-V excluded ranges) rather than another process
+// holding it — the former stays refused for this boot, the latter frees up on its own.
+function isListenPermissionDenied(error: unknown, port: number): boolean {
   return (
+    error instanceof Error &&
+    'code' in error &&
     error.code === 'EACCES' &&
     'syscall' in error &&
     error.syscall === 'listen' &&

--- a/src/main/runtime/runtime-rpc-ws-fallback-convergence.test.ts
+++ b/src/main/runtime/runtime-rpc-ws-fallback-convergence.test.ts
@@ -1,0 +1,303 @@
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { createServer, type AddressInfo, type Server } from 'node:net'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { OrcaRuntimeService } from './orca-runtime'
+import { OrcaRuntimeRpcServer } from './runtime-rpc'
+import { WebSocketTransport } from './rpc/ws-transport'
+import { readWsFallbackPort } from './rpc/ws-fallback-port-store'
+
+vi.mock('../git/worktree', () => {
+  const worktrees = [
+    {
+      path: '/tmp/worktree-a',
+      head: 'abc',
+      branch: 'feature/foo',
+      isBare: false,
+      isMainWorktree: false
+    }
+  ]
+  return {
+    listWorktrees: vi.fn().mockResolvedValue(worktrees),
+    listWorktreesStrict: vi.fn().mockResolvedValue(worktrees)
+  }
+})
+
+const FALLBACK_PORT_FILE = 'mobile-ws-fallback-port.json'
+
+const heldSockets: Server[] = []
+let restoreListen: (() => void) | null = null
+
+afterEach(async () => {
+  restoreListen?.()
+  restoreListen = null
+  await Promise.all(
+    heldSockets
+      .splice(0)
+      .map((socket) => new Promise<void>((resolve) => socket.close(() => resolve())))
+  )
+  vi.restoreAllMocks()
+})
+
+function makeUserDataPath(): string {
+  return mkdtempSync(join(tmpdir(), 'orca-ws-fallback-'))
+}
+
+function fallbackFile(userDataPath: string): string {
+  return join(userDataPath, FALLBACK_PORT_FILE)
+}
+
+function seedFallback(userDataPath: string, port: number): void {
+  writeFileSync(fallbackFile(userDataPath), JSON.stringify({ port }), 'utf8')
+}
+
+async function reserveFreePort(): Promise<number> {
+  const socket = createServer()
+  await new Promise<void>((resolve) => socket.listen(0, '127.0.0.1', () => resolve()))
+  const { port } = socket.address() as AddressInfo
+  await new Promise<void>((resolve) => socket.close(() => resolve()))
+  return port
+}
+
+async function holdPort(port: number): Promise<Server> {
+  const socket = createServer()
+  heldSockets.push(socket)
+  await new Promise<void>((resolve, reject) => {
+    socket.once('error', reject)
+    socket.listen(port, '127.0.0.1', () => resolve())
+  })
+  return socket
+}
+
+async function releasePort(socket: Server): Promise<void> {
+  heldSockets.splice(heldSockets.indexOf(socket), 1)
+  await new Promise<void>((resolve) => socket.close(() => resolve()))
+}
+
+// Why: reproduce a host that refuses one specific port (Windows Hyper-V excluded range) without needing one.
+function blockListen(
+  isBlocked: (port: number) => boolean,
+  makeError: (port: number) => Error
+): () => void {
+  const prototype = WebSocketTransport.prototype as unknown as {
+    tryListen: (port: number) => Promise<void>
+  }
+  const original = prototype.tryListen
+  prototype.tryListen = function (port: number): Promise<void> {
+    return isBlocked(port) ? Promise.reject(makeError(port)) : original.call(this, port)
+  }
+  return () => {
+    prototype.tryListen = original
+  }
+}
+
+function listenDenied(port: number): Error {
+  return Object.assign(new Error(`listen EACCES: permission denied 127.0.0.1:${port}`), {
+    code: 'EACCES',
+    syscall: 'listen',
+    port
+  })
+}
+
+async function startRuntime(options: {
+  userDataPath: string
+  wsPort: number
+  preferPinnedWsPort?: boolean
+}): Promise<OrcaRuntimeRpcServer> {
+  const server = new OrcaRuntimeRpcServer({
+    runtime: new OrcaRuntimeService(),
+    userDataPath: options.userDataPath,
+    enableWebSocket: true,
+    wsPort: options.wsPort,
+    preferPinnedWsPort: options.preferPinnedWsPort
+  })
+  await server.start()
+  return server
+}
+
+function servedPort(server: OrcaRuntimeRpcServer): number | null {
+  const endpoint = server.getWebSocketEndpoint()
+  return endpoint === null ? null : Number(new URL(endpoint).port)
+}
+
+describe('OrcaRuntimeRpcServer persisted WS fallback convergence (STA-4859)', () => {
+  it('drops a fallback that failed to bind while the configured port served', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const userDataPath = makeUserDataPath()
+    const configuredPort = await reserveFreePort()
+    const deadFallbackPort = await reserveFreePort()
+    seedFallback(userDataPath, deadFallbackPort)
+    restoreListen = blockListen((port) => port === deadFallbackPort, listenDenied)
+
+    const server = await startRuntime({ userDataPath, wsPort: configuredPort })
+    try {
+      expect(servedPort(server)).toBe(configuredPort)
+      // Why: the persisted state must converge on what is actually served — keeping the dead fallback is
+      // what re-armed it on the next launch and made the advertised endpoint flip-flop.
+      expect(existsSync(fallbackFile(userDataPath))).toBe(false)
+    } finally {
+      await server.stop()
+    }
+
+    // Why: the excluded range moved after a reboot, so the old fallback is bindable again. Fallback-first
+    // order (STA-1511) would re-take it and strand every device paired to the configured port.
+    restoreListen()
+    restoreListen = null
+    const relaunched = await startRuntime({ userDataPath, wsPort: configuredPort })
+    try {
+      expect(servedPort(relaunched)).toBe(configuredPort)
+      expect(existsSync(fallbackFile(userDataPath))).toBe(false)
+    } finally {
+      await relaunched.stop()
+    }
+  })
+
+  it('drops a fallback occupied by another process once the configured port serves', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const userDataPath = makeUserDataPath()
+    const configuredPort = await reserveFreePort()
+    const busyFallbackPort = await reserveFreePort()
+    const squatter = await holdPort(busyFallbackPort)
+    seedFallback(userDataPath, busyFallbackPort)
+
+    const server = await startRuntime({ userDataPath, wsPort: configuredPort })
+    try {
+      expect(servedPort(server)).toBe(configuredPort)
+      expect(existsSync(fallbackFile(userDataPath))).toBe(false)
+    } finally {
+      await server.stop()
+    }
+
+    await releasePort(squatter)
+    const relaunched = await startRuntime({ userDataPath, wsPort: configuredPort })
+    try {
+      expect(servedPort(relaunched)).toBe(configuredPort)
+    } finally {
+      await relaunched.stop()
+    }
+  })
+
+  it('keeps a bindable fallback winning over the configured port (STA-1511)', async () => {
+    const userDataPath = makeUserDataPath()
+    const configuredPort = await reserveFreePort()
+    const fallbackPort = await reserveFreePort()
+    seedFallback(userDataPath, fallbackPort)
+
+    const server = await startRuntime({ userDataPath, wsPort: configuredPort })
+    try {
+      // Why: devices paired to the fallback keep reconnecting only while it stays served and persisted.
+      expect(servedPort(server)).toBe(fallbackPort)
+      expect(readWsFallbackPort(userDataPath)).toBe(fallbackPort)
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('leaves an untried fallback in place when a pinned port wins (#9005)', async () => {
+    const userDataPath = makeUserDataPath()
+    const pinnedPort = await reserveFreePort()
+    const fallbackPort = await reserveFreePort()
+    seedFallback(userDataPath, fallbackPort)
+
+    const server = await startRuntime({
+      userDataPath,
+      wsPort: pinnedPort,
+      preferPinnedWsPort: true
+    })
+    try {
+      expect(servedPort(server)).toBe(pinnedPort)
+      // Why: pinned-first means the fallback was never attempted, so nothing proves it dead — clearing it
+      // here would discard a working endpoint that `orca serve` without --port still hands back to devices.
+      expect(readWsFallbackPort(userDataPath)).toBe(fallbackPort)
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('keeps the fallback when a pinned port is busy and the fallback serves (#9005)', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const userDataPath = makeUserDataPath()
+    const pinnedPort = await reserveFreePort()
+    const fallbackPort = await reserveFreePort()
+    await holdPort(pinnedPort)
+    seedFallback(userDataPath, fallbackPort)
+
+    const server = await startRuntime({
+      userDataPath,
+      wsPort: pinnedPort,
+      preferPinnedWsPort: true
+    })
+    try {
+      expect(servedPort(server)).toBe(fallbackPort)
+      expect(readWsFallbackPort(userDataPath)).toBe(fallbackPort)
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('never touches the store when the port is OS-assigned (wsPort 0, E2E)', async () => {
+    const userDataPath = makeUserDataPath()
+    const seeded = '{"port":54321}'
+    writeFileSync(fallbackFile(userDataPath), seeded, 'utf8')
+
+    const server = await startRuntime({ userDataPath, wsPort: 0 })
+    try {
+      expect(servedPort(server)).not.toBe(0)
+      expect(readFileSync(fallbackFile(userDataPath), 'utf8')).toBe(seeded)
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('leaves the store untouched when the WebSocket transport fails to start', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const userDataPath = makeUserDataPath()
+    const configuredPort = await reserveFreePort()
+    const fallbackPort = await reserveFreePort()
+    const seeded = JSON.stringify({ port: fallbackPort })
+    writeFileSync(fallbackFile(userDataPath), seeded, 'utf8')
+    // Why: a non-listen EACCES is not a fall-through candidate error, so the configured port rethrows and
+    // the whole WS start fails — a failed bind must never mutate what the next launch will trust.
+    restoreListen = blockListen(
+      () => true,
+      () => Object.assign(new Error('open EACCES'), { code: 'EACCES', syscall: 'open' })
+    )
+
+    const server = await startRuntime({ userDataPath, wsPort: configuredPort })
+    try {
+      expect(server.getWebSocketEndpoint()).toBeNull()
+      expect(readFileSync(fallbackFile(userDataPath), 'utf8')).toBe(seeded)
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('persists an OS-assigned port when the configured port is taken and re-binds it next launch', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const userDataPath = makeUserDataPath()
+    const configuredPort = await reserveFreePort()
+    const firstInstance = await holdPort(configuredPort)
+
+    const server = await startRuntime({ userDataPath, wsPort: configuredPort })
+    let assignedPort: number | null = null
+    try {
+      assignedPort = servedPort(server)
+      expect(assignedPort).not.toBe(configuredPort)
+      expect(readWsFallbackPort(userDataPath)).toBe(assignedPort)
+    } finally {
+      await server.stop()
+    }
+
+    await releasePort(firstInstance)
+    const relaunched = await startRuntime({ userDataPath, wsPort: configuredPort })
+    try {
+      // Why: STA-1511 stability — the freed configured port must not steal the endpoint devices paired to.
+      expect(servedPort(relaunched)).toBe(assignedPort)
+      expect(readWsFallbackPort(userDataPath)).toBe(assignedPort)
+    } finally {
+      await relaunched.stop()
+    }
+  })
+})

--- a/src/main/runtime/runtime-rpc-ws-fallback-convergence.test.ts
+++ b/src/main/runtime/runtime-rpc-ws-fallback-convergence.test.ts
@@ -25,6 +25,7 @@ vi.mock('../git/worktree', () => {
 })
 
 const FALLBACK_PORT_FILE = 'mobile-ws-fallback-port.json'
+const ALL_INTERFACES = '0.0.0.0'
 
 const heldSockets: Server[] = []
 let restoreListen: (() => void) | null = null
@@ -52,40 +53,39 @@ function seedFallback(userDataPath: string, port: number): void {
   writeFileSync(fallbackFile(userDataPath), JSON.stringify({ port }), 'utf8')
 }
 
-async function reserveFreePort(): Promise<number> {
-  const socket = createServer()
-  await new Promise<void>((resolve) => socket.listen(0, '127.0.0.1', () => resolve()))
-  const { port } = socket.address() as AddressInfo
-  await new Promise<void>((resolve) => socket.close(() => resolve()))
-  return port
-}
+type ReservedPort = { port: number; release: () => Promise<void> }
 
-async function holdPort(port: number): Promise<Server> {
+// Why: the reserving socket keeps listening until the caller is ready, so nothing else on the machine can
+// take the port in between — picking a port and closing immediately is a TOCTOU flake under load.
+async function reservePort(): Promise<ReservedPort> {
   const socket = createServer()
   heldSockets.push(socket)
-  await new Promise<void>((resolve, reject) => {
-    socket.once('error', reject)
-    socket.listen(port, '127.0.0.1', () => resolve())
-  })
-  return socket
+  await new Promise<void>((resolve) => socket.listen(0, '127.0.0.1', () => resolve()))
+  const { port } = socket.address() as AddressInfo
+  return {
+    port,
+    release: async () => {
+      heldSockets.splice(heldSockets.indexOf(socket), 1)
+      await new Promise<void>((resolve) => socket.close(() => resolve()))
+    }
+  }
 }
 
-async function releasePort(socket: Server): Promise<void> {
-  heldSockets.splice(heldSockets.indexOf(socket), 1)
-  await new Promise<void>((resolve) => socket.close(() => resolve()))
-}
-
-// Why: reproduce a host that refuses one specific port (Windows Hyper-V excluded range) without needing one.
+// Why: reproduce host-level bind refusals (reserved ranges, descriptor exhaustion) that cannot be staged
+// with a real socket.
 function blockListen(
-  isBlocked: (port: number) => boolean,
-  makeError: (port: number) => Error
+  isBlocked: (port: number, host: string) => boolean,
+  makeError: (port: number, host: string) => Error
 ): () => void {
   const prototype = WebSocketTransport.prototype as unknown as {
     tryListen: (port: number) => Promise<void>
+    host: string
   }
   const original = prototype.tryListen
   prototype.tryListen = function (port: number): Promise<void> {
-    return isBlocked(port) ? Promise.reject(makeError(port)) : original.call(this, port)
+    return isBlocked(port, this.host)
+      ? Promise.reject(makeError(port, this.host))
+      : original.call(this, port)
   }
   return () => {
     prototype.tryListen = original
@@ -95,6 +95,14 @@ function blockListen(
 function listenDenied(port: number): Error {
   return Object.assign(new Error(`listen EACCES: permission denied 127.0.0.1:${port}`), {
     code: 'EACCES',
+    syscall: 'listen',
+    port
+  })
+}
+
+function portInUse(port: number): Error {
+  return Object.assign(new Error(`listen EADDRINUSE: address already in use ${port}`), {
+    code: 'EADDRINUSE',
     syscall: 'listen',
     port
   })
@@ -122,73 +130,109 @@ function servedPort(server: OrcaRuntimeRpcServer): number | null {
 }
 
 describe('OrcaRuntimeRpcServer persisted WS fallback convergence (STA-4859)', () => {
-  it('drops a fallback that failed to bind while the configured port served', async () => {
+  it('drops a fallback the OS refused to listen on once the configured port served', async () => {
     vi.spyOn(console, 'warn').mockImplementation(() => {})
     const userDataPath = makeUserDataPath()
-    const configuredPort = await reserveFreePort()
-    const deadFallbackPort = await reserveFreePort()
-    seedFallback(userDataPath, deadFallbackPort)
-    restoreListen = blockListen((port) => port === deadFallbackPort, listenDenied)
+    const configured = await reservePort()
+    const reserved = await reservePort()
+    seedFallback(userDataPath, reserved.port)
+    restoreListen = blockListen((port) => port === reserved.port, listenDenied)
+    await configured.release()
 
-    const server = await startRuntime({ userDataPath, wsPort: configuredPort })
+    const server = await startRuntime({ userDataPath, wsPort: configured.port })
     try {
-      expect(servedPort(server)).toBe(configuredPort)
-      // Why: the persisted state must converge on what is actually served — keeping the dead fallback is
-      // what re-armed it on the next launch and made the advertised endpoint flip-flop.
+      expect(servedPort(server)).toBe(configured.port)
+      // Why: an EACCES listen means the OS itself holds the port for this boot, so the pairing behind it is
+      // already dead — keeping the file is what re-armed it and flip-flopped the advertised endpoint.
       expect(existsSync(fallbackFile(userDataPath))).toBe(false)
     } finally {
       await server.stop()
     }
 
-    // Why: the excluded range moved after a reboot, so the old fallback is bindable again. Fallback-first
-    // order (STA-1511) would re-take it and strand every device paired to the configured port.
+    // Why: the reserved range moved after a reboot, so the old port is bindable again. Fallback-first order
+    // (STA-1511) would re-take it and strand every device paired to the configured port.
     restoreListen()
     restoreListen = null
-    const relaunched = await startRuntime({ userDataPath, wsPort: configuredPort })
+    await reserved.release()
+    const relaunched = await startRuntime({ userDataPath, wsPort: configured.port })
     try {
-      expect(servedPort(relaunched)).toBe(configuredPort)
+      expect(servedPort(relaunched)).toBe(configured.port)
       expect(existsSync(fallbackFile(userDataPath))).toBe(false)
     } finally {
       await relaunched.stop()
     }
   })
 
-  it('drops a fallback occupied by another process once the configured port serves', async () => {
+  it('keeps a fallback that was merely occupied and re-binds it once free', async () => {
     vi.spyOn(console, 'warn').mockImplementation(() => {})
     const userDataPath = makeUserDataPath()
-    const configuredPort = await reserveFreePort()
-    const busyFallbackPort = await reserveFreePort()
-    const squatter = await holdPort(busyFallbackPort)
-    seedFallback(userDataPath, busyFallbackPort)
+    const configured = await reservePort()
+    const squatted = await reservePort()
+    seedFallback(userDataPath, squatted.port)
+    await configured.release()
 
-    const server = await startRuntime({ userDataPath, wsPort: configuredPort })
+    const server = await startRuntime({ userDataPath, wsPort: configured.port })
     try {
-      expect(servedPort(server)).toBe(configuredPort)
-      expect(existsSync(fallbackFile(userDataPath))).toBe(false)
+      expect(servedPort(server)).toBe(configured.port)
+      // Why: occupation is transient (an outbound ephemeral socket is enough) and a phone has no recovery
+      // for a dropped endpoint but re-pairing, so one bad launch must not discard a live pairing.
+      expect(readWsFallbackPort(userDataPath)).toBe(squatted.port)
     } finally {
       await server.stop()
     }
 
-    await releasePort(squatter)
-    const relaunched = await startRuntime({ userDataPath, wsPort: configuredPort })
+    await squatted.release()
+    const relaunched = await startRuntime({ userDataPath, wsPort: configured.port })
     try {
-      expect(servedPort(relaunched)).toBe(configuredPort)
+      // Why: STA-1511's self-heal — the pairing comes back on its own once the squatter leaves.
+      expect(servedPort(relaunched)).toBe(squatted.port)
+      expect(readWsFallbackPort(userDataPath)).toBe(squatted.port)
     } finally {
       await relaunched.stop()
+    }
+  })
+
+  it('keeps a fallback whose bind failed for an unclassified reason', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const userDataPath = makeUserDataPath()
+    const configured = await reservePort()
+    const fallback = await reservePort()
+    seedFallback(userDataPath, fallback.port)
+    // Why: the transport falls through the fallback candidate on ANY error, so process-wide failures like
+    // descriptor exhaustion reach the same branch — they say nothing about the port and must not clear it.
+    restoreListen = blockListen(
+      (port) => port === fallback.port,
+      () =>
+        Object.assign(new Error('listen EMFILE: too many open files'), {
+          code: 'EMFILE',
+          syscall: 'listen'
+        })
+    )
+    await configured.release()
+    await fallback.release()
+
+    const server = await startRuntime({ userDataPath, wsPort: configured.port })
+    try {
+      expect(servedPort(server)).toBe(configured.port)
+      expect(readWsFallbackPort(userDataPath)).toBe(fallback.port)
+    } finally {
+      await server.stop()
     }
   })
 
   it('keeps a bindable fallback winning over the configured port (STA-1511)', async () => {
     const userDataPath = makeUserDataPath()
-    const configuredPort = await reserveFreePort()
-    const fallbackPort = await reserveFreePort()
-    seedFallback(userDataPath, fallbackPort)
+    const configured = await reservePort()
+    const fallback = await reservePort()
+    seedFallback(userDataPath, fallback.port)
+    await configured.release()
+    await fallback.release()
 
-    const server = await startRuntime({ userDataPath, wsPort: configuredPort })
+    const server = await startRuntime({ userDataPath, wsPort: configured.port })
     try {
       // Why: devices paired to the fallback keep reconnecting only while it stays served and persisted.
-      expect(servedPort(server)).toBe(fallbackPort)
-      expect(readWsFallbackPort(userDataPath)).toBe(fallbackPort)
+      expect(servedPort(server)).toBe(fallback.port)
+      expect(readWsFallbackPort(userDataPath)).toBe(fallback.port)
     } finally {
       await server.stop()
     }
@@ -196,20 +240,22 @@ describe('OrcaRuntimeRpcServer persisted WS fallback convergence (STA-4859)', ()
 
   it('leaves an untried fallback in place when a pinned port wins (#9005)', async () => {
     const userDataPath = makeUserDataPath()
-    const pinnedPort = await reserveFreePort()
-    const fallbackPort = await reserveFreePort()
-    seedFallback(userDataPath, fallbackPort)
+    const pinned = await reservePort()
+    const fallback = await reservePort()
+    seedFallback(userDataPath, fallback.port)
+    await pinned.release()
+    await fallback.release()
 
     const server = await startRuntime({
       userDataPath,
-      wsPort: pinnedPort,
+      wsPort: pinned.port,
       preferPinnedWsPort: true
     })
     try {
-      expect(servedPort(server)).toBe(pinnedPort)
+      expect(servedPort(server)).toBe(pinned.port)
       // Why: pinned-first means the fallback was never attempted, so nothing proves it dead — clearing it
-      // here would discard a working endpoint that `orca serve` without --port still hands back to devices.
-      expect(readWsFallbackPort(userDataPath)).toBe(fallbackPort)
+      // here would discard a working endpoint that a later default launch still hands back to devices.
+      expect(readWsFallbackPort(userDataPath)).toBe(fallback.port)
     } finally {
       await server.stop()
     }
@@ -218,19 +264,19 @@ describe('OrcaRuntimeRpcServer persisted WS fallback convergence (STA-4859)', ()
   it('keeps the fallback when a pinned port is busy and the fallback serves (#9005)', async () => {
     vi.spyOn(console, 'warn').mockImplementation(() => {})
     const userDataPath = makeUserDataPath()
-    const pinnedPort = await reserveFreePort()
-    const fallbackPort = await reserveFreePort()
-    await holdPort(pinnedPort)
-    seedFallback(userDataPath, fallbackPort)
+    const pinned = await reservePort()
+    const fallback = await reservePort()
+    seedFallback(userDataPath, fallback.port)
+    await fallback.release()
 
     const server = await startRuntime({
       userDataPath,
-      wsPort: pinnedPort,
+      wsPort: pinned.port,
       preferPinnedWsPort: true
     })
     try {
-      expect(servedPort(server)).toBe(fallbackPort)
-      expect(readWsFallbackPort(userDataPath)).toBe(fallbackPort)
+      expect(servedPort(server)).toBe(fallback.port)
+      expect(readWsFallbackPort(userDataPath)).toBe(fallback.port)
     } finally {
       await server.stop()
     }
@@ -254,9 +300,9 @@ describe('OrcaRuntimeRpcServer persisted WS fallback convergence (STA-4859)', ()
     vi.spyOn(console, 'warn').mockImplementation(() => {})
     vi.spyOn(console, 'error').mockImplementation(() => {})
     const userDataPath = makeUserDataPath()
-    const configuredPort = await reserveFreePort()
-    const fallbackPort = await reserveFreePort()
-    const seeded = JSON.stringify({ port: fallbackPort })
+    const configured = await reservePort()
+    const fallback = await reservePort()
+    const seeded = JSON.stringify({ port: fallback.port })
     writeFileSync(fallbackFile(userDataPath), seeded, 'utf8')
     // Why: a non-listen EACCES is not a fall-through candidate error, so the configured port rethrows and
     // the whole WS start fails — a failed bind must never mutate what the next launch will trust.
@@ -264,8 +310,10 @@ describe('OrcaRuntimeRpcServer persisted WS fallback convergence (STA-4859)', ()
       () => true,
       () => Object.assign(new Error('open EACCES'), { code: 'EACCES', syscall: 'open' })
     )
+    await configured.release()
+    await fallback.release()
 
-    const server = await startRuntime({ userDataPath, wsPort: configuredPort })
+    const server = await startRuntime({ userDataPath, wsPort: configured.port })
     try {
       expect(server.getWebSocketEndpoint()).toBeNull()
       expect(readFileSync(fallbackFile(userDataPath), 'utf8')).toBe(seeded)
@@ -277,27 +325,93 @@ describe('OrcaRuntimeRpcServer persisted WS fallback convergence (STA-4859)', ()
   it('persists an OS-assigned port when the configured port is taken and re-binds it next launch', async () => {
     vi.spyOn(console, 'warn').mockImplementation(() => {})
     const userDataPath = makeUserDataPath()
-    const configuredPort = await reserveFreePort()
-    const firstInstance = await holdPort(configuredPort)
+    const configured = await reservePort()
 
-    const server = await startRuntime({ userDataPath, wsPort: configuredPort })
+    const server = await startRuntime({ userDataPath, wsPort: configured.port })
     let assignedPort: number | null = null
     try {
       assignedPort = servedPort(server)
-      expect(assignedPort).not.toBe(configuredPort)
+      expect(assignedPort).not.toBe(configured.port)
       expect(readWsFallbackPort(userDataPath)).toBe(assignedPort)
     } finally {
       await server.stop()
     }
 
-    await releasePort(firstInstance)
-    const relaunched = await startRuntime({ userDataPath, wsPort: configuredPort })
+    await configured.release()
+    const relaunched = await startRuntime({ userDataPath, wsPort: configured.port })
     try {
       // Why: STA-1511 stability — the freed configured port must not steal the endpoint devices paired to.
       expect(servedPort(relaunched)).toBe(assignedPort)
       expect(readWsFallbackPort(userDataPath)).toBe(assignedPort)
     } finally {
       await relaunched.stop()
+    }
+  })
+
+  it('persists the widen port when the pairing rebind cannot retake the configured port', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const userDataPath = makeUserDataPath()
+    const configured = await reservePort()
+    await configured.release()
+
+    const server = await startRuntime({ userDataPath, wsPort: configured.port })
+    try {
+      expect(servedPort(server)).toBe(configured.port)
+      expect(existsSync(fallbackFile(userDataPath))).toBe(false)
+
+      // Why: the widen stops the loopback listener before re-binding, so a port lost in that gap lands the
+      // LAN listener on an OS-assigned one — which the QR already advertises and devices must find again.
+      restoreListen = blockListen((port) => port === configured.port, portInUse)
+      const offer = await server.createMobilePairingOffer({
+        address: '100.64.1.20',
+        connectionMode: 'local-only'
+      })
+      expect(offer.available).toBe(true)
+
+      const widenedPort = servedPort(server)
+      expect(widenedPort).not.toBe(configured.port)
+      expect(readWsFallbackPort(userDataPath)).toBe(widenedPort)
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('leaves the store alone when a failed widen recovers on a different loopback port', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const userDataPath = makeUserDataPath()
+    const configured = await reservePort()
+    const fallback = await reservePort()
+    seedFallback(userDataPath, fallback.port)
+    await configured.release()
+    await fallback.release()
+
+    const server = await startRuntime({ userDataPath, wsPort: configured.port })
+    try {
+      expect(servedPort(server)).toBe(fallback.port)
+      const seeded = readFileSync(fallbackFile(userDataPath), 'utf8')
+
+      // Why: fail the wide bind outright and make the loopback restore miss its old port, so recovery lands
+      // on an OS-assigned one — a degraded listener that serves no pairing.
+      restoreListen = blockListen(
+        (port, host) => host === ALL_INTERFACES || port === fallback.port,
+        (port, host) =>
+          host === ALL_INTERFACES
+            ? Object.assign(new Error('open EACCES'), { code: 'EACCES', syscall: 'open' })
+            : portInUse(port)
+      )
+      const offer = await server.createMobilePairingOffer({
+        address: '100.64.1.20',
+        connectionMode: 'local-only'
+      })
+      expect(offer.available).toBe(false)
+
+      // Why: persisting the recovery port would overwrite the fallback that paired devices still dial, for
+      // a listener that cannot serve them anyway.
+      expect(servedPort(server)).not.toBe(fallback.port)
+      expect(readFileSync(fallbackFile(userDataPath), 'utf8')).toBe(seeded)
+    } finally {
+      await server.stop()
     }
   })
 })

--- a/src/main/runtime/runtime-rpc-ws-fallback-convergence.test.ts
+++ b/src/main/runtime/runtime-rpc-ws-fallback-convergence.test.ts
@@ -65,7 +65,11 @@ async function reservePort(): Promise<ReservedPort> {
   return {
     port,
     release: async () => {
-      heldSockets.splice(heldSockets.indexOf(socket), 1)
+      // Why: a second release would splice(-1) and untrack someone else's socket.
+      const index = heldSockets.indexOf(socket)
+      if (index !== -1) {
+        heldSockets.splice(index, 1)
+      }
       await new Promise<void>((resolve) => socket.close(() => resolve()))
     }
   }
@@ -175,7 +179,9 @@ describe('OrcaRuntimeRpcServer persisted WS fallback convergence (STA-4859)', ()
     try {
       expect(servedPort(server)).toBe(configured.port)
       // Why: occupation is transient (an outbound ephemeral socket is enough) and a phone has no recovery
-      // for a dropped endpoint but re-pairing, so one bad launch must not discard a live pairing.
+      // for a dropped endpoint but re-pairing, so one bad launch must not discard a live pairing. The keep
+      // holds while the configured port serves; if it were taken too, the OS-assigned fall-through still
+      // overwrites the fallback, as it does on main.
       expect(readWsFallbackPort(userDataPath)).toBe(squatted.port)
     } finally {
       await server.stop()

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -19,7 +19,11 @@ import { fingerprintAuthenticatedPairingCredential } from './rpc/orchestration-m
 import type { RpcMessageContext, RpcTransport } from './rpc/transport'
 import { UnixSocketTransport } from './rpc/unix-socket-transport'
 import { WebSocketTransport } from './rpc/ws-transport'
-import { readWsFallbackPort, writeWsFallbackPort } from './rpc/ws-fallback-port-store'
+import {
+  clearWsFallbackPort,
+  readWsFallbackPort,
+  writeWsFallbackPort
+} from './rpc/ws-fallback-port-store'
 import type { WebSocket } from 'ws'
 import { DeviceRegistry, type DeviceEntry, type DeviceScope } from './device-registry'
 import { loadOrCreateE2EEKeypair, type E2EEKeypair } from './e2ee-keypair'
@@ -1192,9 +1196,7 @@ export class OrcaRuntimeRpcServer {
             // Why: stable fallback port across restarts keeps paired devices' endpoints valid (STA-1511); wsPort 0 = random (E2E).
             ...(this.wsPort !== 0 ? { fallbackPort: readWsFallbackPort(this.userDataPath) } : {})
           })
-          if (this.wsPort !== 0 && transport.resolvedPort !== this.wsPort) {
-            writeWsFallbackPort(this.userDataPath, transport.resolvedPort)
-          }
+          this.syncPersistedWsFallback(transport.resolvedPort)
           activeTransports.push(transport)
           transportsMeta.push({ kind: 'websocket', endpoint })
         } catch (error) {
@@ -1237,6 +1239,23 @@ export class OrcaRuntimeRpcServer {
         )
       }
     })
+  }
+
+  // Why: after a successful bind the persisted fallback must describe what is actually served, or the
+  // advertised endpoint oscillates between the two across launches (STA-4859). A resolved port that
+  // differs from the configured one is the STA-1511 fallback to keep. Landing ON the configured port in
+  // default (fallback-first) mode means any persisted fallback was tried and failed, so it is obsolete;
+  // in pinned mode (`serve --port`, #9005) the pin binds first and the fallback was never tried — leave it.
+  // wsPort 0 (E2E) stays fully exempt.
+  private syncPersistedWsFallback(resolvedPort: number): void {
+    if (this.wsPort === 0) {
+      return
+    }
+    if (resolvedPort !== this.wsPort) {
+      writeWsFallbackPort(this.userDataPath, resolvedPort)
+    } else if (!this.preferPinnedWsPort) {
+      clearWsFallbackPort(this.userDataPath)
+    }
   }
 
   // Why: STA-2370 — a desktop with no previously-connected device stays on loopback until the user
@@ -1415,11 +1434,7 @@ export class OrcaRuntimeRpcServer {
       this.transports[metaIndex] = { kind: 'websocket', endpoint: widened.endpoint }
     }
     try {
-      // Why: a rebind that lands on a different port (same-port bind refused) must be persisted so a
-      // later reconnect from a device paired to this port matches on the next launch (STA-1511).
-      if (this.wsPort !== 0 && widened.transport.resolvedPort !== this.wsPort) {
-        writeWsFallbackPort(this.userDataPath, widened.transport.resolvedPort)
-      }
+      this.syncPersistedWsFallback(widened.transport.resolvedPort)
       this.writeMetadata()
     } catch (persistError) {
       // Why: the wide listener is live and tracked; a persistence failure must not tear it down. Keep

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -1196,7 +1196,7 @@ export class OrcaRuntimeRpcServer {
             // Why: stable fallback port across restarts keeps paired devices' endpoints valid (STA-1511); wsPort 0 = random (E2E).
             ...(this.wsPort !== 0 ? { fallbackPort: readWsFallbackPort(this.userDataPath) } : {})
           })
-          this.syncPersistedWsFallback(transport.resolvedPort)
+          this.syncPersistedWsFallback(transport)
           activeTransports.push(transport)
           transportsMeta.push({ kind: 'websocket', endpoint })
         } catch (error) {
@@ -1241,19 +1241,17 @@ export class OrcaRuntimeRpcServer {
     })
   }
 
-  // Why: after a successful bind the persisted fallback must describe what is actually served, or the
-  // advertised endpoint oscillates between the two across launches (STA-4859). A resolved port that
-  // differs from the configured one is the STA-1511 fallback to keep. Landing ON the configured port in
-  // default (fallback-first) mode means any persisted fallback was tried and failed, so it is obsolete;
-  // in pinned mode (`serve --port`, #9005) the pin binds first and the fallback was never tried — leave it.
-  // wsPort 0 (E2E) stays fully exempt.
-  private syncPersistedWsFallback(resolvedPort: number): void {
+  // Why: a fallback the OS refused to listen on is dead, and keeping it re-arms the STA-4859 endpoint
+  // flip-flop; dropping it costs devices paired to it one re-pair. Merely-occupied or unclassified
+  // failures keep the file so a still-valid pairing self-heals next launch (STA-1511), and a pinned port
+  // (#9005) never attempts the fallback, so its success proves nothing. wsPort 0 (E2E) stays exempt.
+  private syncPersistedWsFallback(transport: WebSocketTransport): void {
     if (this.wsPort === 0) {
       return
     }
-    if (resolvedPort !== this.wsPort) {
-      writeWsFallbackPort(this.userDataPath, resolvedPort)
-    } else if (!this.preferPinnedWsPort) {
+    if (transport.resolvedPort !== this.wsPort) {
+      writeWsFallbackPort(this.userDataPath, transport.resolvedPort)
+    } else if (!this.preferPinnedWsPort && transport.persistedFallbackListenDenied) {
       clearWsFallbackPort(this.userDataPath)
     }
   }
@@ -1434,7 +1432,7 @@ export class OrcaRuntimeRpcServer {
       this.transports[metaIndex] = { kind: 'websocket', endpoint: widened.endpoint }
     }
     try {
-      this.syncPersistedWsFallback(widened.transport.resolvedPort)
+      this.syncPersistedWsFallback(widened.transport)
       this.writeMetadata()
     } catch (persistError) {
       // Why: the wide listener is live and tracked; a persistence failure must not tear it down. Keep
@@ -1448,6 +1446,8 @@ export class OrcaRuntimeRpcServer {
 
   // Why: a failed widen already tore down the loopback listener; bring one back on the same host/port so the
   // runtime keeps serving locally (wsBoundHost stays loopback, so the next pairing offer retries the widen).
+  // Deliberately does NOT sync the fallback store: this is a degraded loopback-only listener that serves no
+  // pairing, so persisting its port would overwrite the fallback that paired devices still dial.
   private async recoverWebSocketBindAfterFailedWiden(
     index: number,
     previousPort: number


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​451 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​448 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​56 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​39 |

<!-- /orca-pr-loc -->

## Symptom

A desktop's advertised mobile WebSocket endpoint oscillates between two ports across launches, stranding paired devices. Reported on Windows, where Hyper-V / WinNAT reserve dynamic port ranges that move across reboots: a port that refuses `listen` with `EACCES` one boot binds fine the next.

## Root cause

`mobile-ws-fallback-port.json` (`src/main/runtime/rpc/ws-fallback-port-store.ts`) was only ever **written** — when `transport.resolvedPort !== this.wsPort` — and never cleared.

1. Launch 1: no fallback file, default port `D` (6768) is busy, OS assigns `N`. File records `N`. Devices pair to `N`.
2. Launch 2: `N` now lands inside a Hyper-V reserved range → `EACCES/listen`. The transport falls through to `D`, which binds. **The file still says `N`.**
3. Launch 3: the reserved range has moved, `N` is bindable again. Fallback-first bind order (STA-1511, #7855) tries `N` first and takes it — the endpoint flips back.

Steps 2 and 3 then alternate indefinitely, and every device is paired to whichever port it last saw. Deterministically reproduced on `main`.

## The fix: clear only on observed evidence that the port is dead

The clear is gated on what the OS actually said, not on what the resolved port implies. `WebSocketTransport` records, for the persisted-fallback candidate only, whether its bind was refused with `EACCES` + `syscall === 'listen'` + matching port — the reserved-range signature, which stays refused for the whole boot — and exposes it as `persistedFallbackListenDenied`. The existing `EACCES` branch of `isPortListenFallbackError` is extracted into `isListenPermissionDenied` so that predicate has exactly one definition.

`src/main/runtime/runtime-rpc.ts` gains one private `syncPersistedWsFallback(transport)` replacing both former write sites (initial start and the pairing-time `widenWebSocketBind`):

- `wsPort === 0` → return (E2E stays fully exempt: no read, no write, no delete).
- `resolvedPort !== wsPort` → `writeWsFallbackPort(...)` — unchanged, this is the STA-1511 fallback worth keeping.
- else if `!preferPinnedWsPort` **and** `persistedFallbackListenDenied` → `clearWsFallbackPort(...)` (new).

An earlier revision of this PR inferred "the fallback is dead" from `resolvedPort === wsPort` alone. Review showed that inference is wrong twice over, and it was narrowed:

- The transport falls through the fallback candidate on **any** error, so `EMFILE` or an unclassified failure would have cleared a perfectly good pairing on no evidence at all.
- A transient `EADDRINUSE` — an outbound ephemeral socket is enough on a `0.0.0.0` bind — is a realistic one-launch event that STA-1511 already self-heals on the next launch. Mobile has no recovery for a dropped endpoint other than re-pairing, so keeping a possibly-stale file is far cheaper than a wrong clear.

Called only after a **successful** bind, so a failed WS start never mutates the store. `recoverWebSocketBindAfterFailedWiden` deliberately does not sync either, and now says why: it restores a degraded loopback-only listener that serves no pairing, so persisting its port would overwrite the fallback paired devices still dial. `clearWsFallbackPort` also warns on failure — a silently failed clear re-arms the flip-flop with no diagnostics.

## Behavior by path

| Path | Bind order | Resolved | Store after |
| --- | --- | --- | --- |
| Default desktop (`wsPort` 6768), no fallback file | `[6768]` | 6768 | absent (no-op) |
| Default, fallback `N` bindable | `[N, 6768]` | `N` | `N` kept — **STA-1511 preserved** |
| Default, fallback `N` refused `EACCES`/`listen` | `[N, 6768]` | 6768 | **cleared** — the fix |
| Default, fallback `N` busy (`EADDRINUSE`) | `[N, 6768]` | 6768 | `N` **kept** — self-heals next launch |
| Default, fallback `N` fails otherwise (`EMFILE`, …) | `[N, 6768]` | 6768 | `N` **kept** — no evidence |
| Default, 6768 held by another instance | `[6768]` → OS | `N` | `N` written (endpoint stability preserved) |
| Non-`listen` `EACCES` on the configured port | — | none | still fatal to the WS transport; store untouched |
| `orca serve --port P` (`preferPinnedWsPort`), pin free | `[P, N]` | `P` | `N` **left untouched** — **#9005 preserved** |
| `orca serve --port P`, pin busy | `[P, N]` | `N` | `N` kept |
| Dev/alternate configured port (e.g. 6769) | same rules vs. its own `wsPort` | — | same rules |
| Pairing widen that cannot retake its port | `[prev]` → OS | `M` | `M` written |
| Failed widen, loopback recovery | `[prev]` → OS | `M` | untouched |
| `wsPort: 0` (E2E) | OS-assigned | random | untouched (read/write/delete all skipped) |

Purely local persistence — no RPC params, stream frames, or published content change, so remote wire compatibility is unaffected. No platform branches: the fix is platform-neutral; Windows is only where the trigger is common.

## Intentional tradeoff

A reserved-range refusal drops the fallback, so devices paired to that port re-pair once. That is the deliberate cost, and it is bounded: those devices were already unreachable for the entire session in which the port was refused, and the alternative is an endpoint that oscillates between two ports indefinitely, stranding devices on **both** sides of the flip.

Everything short of that evidence keeps the file. A busy or unclassifiable port is assumed recoverable, so the pairing survives and STA-1511's fallback-first order re-binds it on the next launch with no user action. The residual risk is the inverse case — a port that is genuinely dead but fails with something other than `EACCES/listen` — which leaves the old flip-flop in place for that signature. That is the intended bias: a wrong keep costs a launch, a wrong clear costs a re-pair.

## Test evidence

`src/main/runtime/runtime-rpc-ws-fallback-convergence.test.ts` (11 tests) drives the real `OrcaRuntimeRpcServer` against real OS ports, staging refusals by wrapping `WebSocketTransport.prototype.tryListen` and holding ports with real `net` sockets. Reservations keep their socket listening until the moment the port is needed, so no test races another process for a port it picked earlier.

**STA-4859 regression coverage** is the `EACCES/listen` pair: the fallback is refused, the configured port serves, the file is removed — **and** a relaunch with the port bindable again still serves the configured port. The flip-back is what fails on revert.

The rest are behavior guards, not regression tests for this bug:

- `EADDRINUSE` on the fallback keeps the file, and a relaunch after the squatter leaves re-binds it (self-heal)
- an unclassified `EMFILE` on the fallback keeps the file
- a bindable fallback still wins and stays persisted (STA-1511)
- `preferPinnedWsPort` with pin free → pin binds, untried fallback left intact (#9005); pin busy → fallback binds and is kept
- `wsPort: 0` → seeded file bytes byte-for-byte unchanged
- WS start failure (non-fall-through `EACCES/open` on every candidate) → endpoint `null`, store bytes unchanged
- configured port held → OS-assigned `N` persisted and re-bound on relaunch after it frees
- a pairing widen that cannot retake its port persists the OS-assigned port it lands on
- a failed widen whose loopback recovery lands elsewhere leaves the store untouched

The last two are behavior pins on the widen paths, which this PR does not change: both pass on `main` as well, and exist to keep the store's one write site and one deliberate non-write site from drifting later.

`src/main/runtime/rpc/ws-fallback-port-store.test.ts` covers `clearWsFallbackPort`: removes an existing file, no-ops silently when absent, and warns without throwing when the path is unremovable.

**Fail-on-revert verified** with three independent mutations, each caught by a different test and by nothing else:

| Mutation | Result |
| --- | --- |
| Drop the `persistedFallbackListenDenied` gate | the two "keep" tests fail (2 failed, 9 passed) |
| Neutralize the clear entirely | the `EACCES` regression test fails (1 failed, 10 passed) |
| Add a store sync to the failed-widen recovery path | the recovery guard fails (1 failed, 10 passed) |

```
$ pnpm exec vitest run --config config/vitest.config.ts \
    src/main/runtime/runtime-rpc-ws-fallback-convergence.test.ts \
    src/main/runtime/rpc/ws-fallback-port-store.test.ts \
    src/main/runtime/rpc/ws-transport.test.ts \
    src/main/runtime/runtime-rpc-websocket-bind-host.test.ts \
    src/main/runtime/runtime-rpc-metadata-lifecycle.test.ts

 Test Files  5 passed (5)
      Tests  67 passed (67)
```

`pnpm typecheck:node`, `oxlint` (base + code-quality native plugins) on the touched files, `oxfmt --check`, and `check:max-lines-ratchet` all pass. No `max-lines` disable added.

