### PR TITLE
fix(agent-status): stop an Antigravity pane reading as Gemini CLI

### DIFF
--- a/src/shared/agent-title-agy-gemini-collision.test.ts
+++ b/src/shared/agent-title-agy-gemini-collision.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { getAgentLabel } from './agent-title-identity'
+import { resolveExplicitTerminalTitleAgentType } from './terminal-title-agent-type'
+import { GEMINI_IDLE, GEMINI_WORKING } from './agent-title-core'
+
+// Why: Antigravity's models are named "Gemini <n.n> <Name>" (see the real `agy models`
+// output parsed in commit-message-agent-spec.test.ts), so an agy pane's own title carries a
+// whole `gemini` token. Gemini CLI is checked before Antigravity in getAgentLabel, so the
+// model name used to win and an agy pane read as Gemini CLI.
+describe('agy titles carrying a Gemini model name', () => {
+  const AGY_TITLES = [
+    '⠋ agy · Gemini 3.7 Flash · high',
+    'Antigravity · Gemini 3.7 Flash',
+    'agy · Gemini 3.5 Flash (High)'
+  ]
+
+  it.each(AGY_TITLES)('labels %s as Antigravity', (title) => {
+    expect(getAgentLabel(title)).toBe('Antigravity')
+  })
+
+  // Why: the two chain copies are reached by different surfaces — the sidebar goes through
+  // getAgentLabel, the tab through resolveExplicitTerminalTitleAgentType. A fix in one only
+  // moves the disagreement rather than removing it.
+  it.each(AGY_TITLES)('resolves %s as antigravity on the tab path too', (title) => {
+    expect(resolveExplicitTerminalTitleAgentType(title)).toBe('antigravity')
+  })
+})
+
+describe('titles that must keep their existing label', () => {
+  // Why: a real recorded pane title from terminal history. A Grok pane whose TASK TEXT
+  // contains the token "Antigravity" — it resolves correctly only because grok is checked
+  // before antigravity, which is why this fix narrows a token instead of reordering.
+  it('keeps a grok pane whose task text names Antigravity', () => {
+    expect(getAgentLabel('STA-4011 Linux Antigravity Commit Messages - grok')).toBe('Grok')
+  })
+
+  // Why: the four Gemini OSC glyphs are decisive and stay so; agy emits none of them.
+  it('still labels a glyph-bearing Gemini CLI title', () => {
+    expect(getAgentLabel(`${GEMINI_WORKING} Gemini CLI`)).toBe('Gemini CLI')
+    expect(getAgentLabel(`${GEMINI_IDLE} Gemini CLI`)).toBe('Gemini CLI')
+  })
+
+  // Why: a Gemini CLI title with no agy token must be unaffected by the narrowing.
+  it('still labels a bare gemini token title', () => {
+    expect(getAgentLabel('gemini ready')).toBe('Gemini CLI')
+  })
+})

--- a/src/shared/agent-title-core.ts
+++ b/src/shared/agent-title-core.ts
@@ -67,6 +67,14 @@ export function isGeminiTerminalTitle(title: string): boolean {
   if (isPiAgentTitle(title)) {
     return false
   }
+  // Why: Antigravity's models are named "Gemini <n.n> <Name>", so an agy pane's own
+  // title carries a whole `gemini` token. Gemini CLI is checked before Antigravity in
+  // getAgentLabel, so without this the model name wins and an agy pane reads as Gemini
+  // CLI. Only the token path defers — the four Gemini OSC glyphs stay decisive, and agy
+  // emits none of them.
+  if (titleHasAgentName(title, 'antigravity') || AGY_AGENT_NAME_RE.test(title)) {
+    return false
+  }
   return titleHasAgentName(title, 'gemini')
 }
 

--- a/src/shared/terminal-title-agent-type.ts
+++ b/src/shared/terminal-title-agent-type.ts
@@ -48,6 +48,14 @@ export function isGeminiTerminalTitle(title: string): boolean {
   if (isPiAgentTitle(title)) {
     return false
   }
+  // Why: Antigravity's models are named "Gemini <n.n> <Name>", so an agy pane's own
+  // title carries a whole `gemini` token. Gemini CLI is checked before Antigravity in
+  // getAgentLabel, so without this the model name wins and an agy pane reads as Gemini
+  // CLI. Only the token path defers — the four Gemini OSC glyphs stay decisive, and agy
+  // emits none of them.
+  if (titleHasAgentName(title, 'antigravity') || AGY_AGENT_NAME_RE.test(title)) {
+    return false
+  }
   return titleHasAgentName(title, 'gemini')
 }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​47 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​47 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 |

<!-- /orca-pr-loc -->

## ELI5

Antigravity's models are called things like "Gemini 3.7 Flash". Orca guesses which agent is in a pane partly from the terminal title, and it checks for the word "gemini" before it checks for "agy" — so an Antigravity pane advertising its own model got labelled Gemini CLI. That's why the tab and the sidebar disagreed about the same pane.

## What Changed

`isGeminiTerminalTitle` now declines its **bare-token** branch when the title also carries an agy/antigravity token. The four Gemini OSC glyphs (`✦ ⏲ ◇ ✋`) remain decisive — Antigravity emits none of them.

Applied to **both** copies of the classifier: `src/shared/agent-title-core.ts` and `src/shared/terminal-title-agent-type.ts`.

## Why

`getAgentLabel` is a hand-ordered if-chain, first match wins. Gemini CLI is checked at `agent-title-identity.ts:65`, Antigravity/agy at `:93`. The Gemini branch matches on **either** its four glyphs **or** a bare `gemini` token — and Antigravity's models are literally named `Gemini <n.n> <Name>`. The real `agy models` output is already parsed in-tree at `commit-message-agent-spec.test.ts:415-419`, listing `Gemini 3.5 Flash (High)` and friends.

Measured on `'⠋ agy · Gemini 3.7 Flash · high'`:

```
geminiGlyphs: false      (agy emits none of ✦ ⏲ ◇ ✋)
geminiToken:  true       (the model name)
agyToken:     true       (matches, but the branch is never reached)
label:        "Gemini CLI"
```

Even `'Antigravity · Gemini 3.7 Flash'` resolved to `Gemini CLI`.

**Why this reached the UI for agy specifically:** `antigravity` has no entry in `SYNTHETIC_AGENT_TITLE_PROFILES` (`synthetic-agent-title.ts:12-60`), unlike codex, cursor, opencode, droid, hermes and devin. Orca never overwrites an agy pane's title from hook state, so there is no corrective path — the title reaches the classifier exactly as the agent wrote it.

**Why both copies:** the chain is duplicated verbatim. The sidebar reaches `agent-title-core.ts` (via `agent-detection`), the tab reaches `terminal-title-agent-type.ts` (via `resolveExplicitTerminalTitleAgentType`). Fixing one alone would move the disagreement rather than remove it.

### Why narrow the token instead of reordering the chain

Reordering looks simpler and is wrong. A real recorded pane title from local terminal history:

```
"STA-4011 Linux Antigravity Commit Messages - grok"
```

That is a **Grok** pane whose *task text* contains the whole token `Antigravity`. It resolves correctly today **only** because grok is checked at `:87` and antigravity at `:93`. Hoisting the Antigravity branch above Gemini (`:65`) necessarily moves it above grok too and would flip that title.

People name agents in prompts, branches and task titles. The chain's order is load-bearing against text we do not control, so this change touches **only** titles that carry both tokens. The Grok title ships as a regression case.

This also mirrors the veto immediately above it in the same function — `isPiAgentTitle`, added because *"substring matching made paths like `gemini-project` masquerade as Gemini CLI."* Same class of defect, same remedy.

## Linked Issue

No issue filed — reported internally against `1.4.185-adhoc.20260818220732`: the tab bar and sidebar showing different agents for one pane, both of which should read agy.

## Visual Proof

`N/A` — the visible effect is a tab and a sidebar row agreeing. A before/after screenshot of two small agent icons carries less information than the label assertions below, which pin the exact strings.

## Testing

New `src/shared/agent-title-agy-gemini-collision.test.ts`, 9 cases.

**Proven red.** Reverting both classifier copies to `origin/main`: **6 failed / 3 passed**. The 6 are the agy titles, across **both** chain copies. The 3 that stay green are the guards — which is the point: they show the suite is not passing simply because everything passes.

| case | assertion |
|---|---|
| `⠋ agy · Gemini 3.7 Flash · high` | `Antigravity` (both copies) |
| `Antigravity · Gemini 3.7 Flash` | `Antigravity` (both copies) |
| `agy · Gemini 3.5 Flash (High)` | `Antigravity` (both copies) |
| `STA-4011 Linux Antigravity Commit Messages - grok` | still `Grok` |
| `✦ Gemini CLI` / `◇ Gemini CLI` | still `Gemini CLI` |
| `gemini ready` | still `Gemini CLI` |

Gates: `pnpm typecheck` exit 0, zero `error TS`. `vitest src/shared` — **499 files, 5183 passed**, 39 skipped, run twice for determinism. `oxfmt --check` and `oxlint` clean on all three files.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

- **Scope**: this fixes the classifier. The two surfaces still derive identity through separate precedence chains, so a future vocabulary collision could surface the same way. That is a larger change and is deliberately not attempted here — a review established that no single precedence rule can distinguish the reported bug from the legitimate "reused pane reclaims its tab" behaviour, because both present identical signals with opposite correct answers. It needs a discriminator, not a reordering.
- **Not verified**: nobody has captured agy's real OSC title. No agy-authored title exists in 2,473 recorded local checkpoints, and agy's banner strings have zero occurrences across 527 MB of terminal history. The screenshot shows exactly the matching form, and this change is correct hardening regardless — but the trigger for that specific report is inferred, not measured.
- **Known-adjacent, not fixed here**: `getAgentLabel('✳ agy')` returns `'Claude Code'`, because Claude's `✳` prefix check sits earlier in the chain. Same family, its own change.
- **Cross-platform / SSH / performance**: pure string classification, no platform-conditional code, no wire or persisted-state change; one extra token test only on titles that already matched `gemini`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @BrennanKB5
