### PR TITLE
fix(repos): keep the desktop-owned manual project order authoritative across paired clients and SSH catalog publishes (STA-4850)

### DIFF
--- a/src/main/persistence-ui-state.test.ts
+++ b/src/main/persistence-ui-state.test.ts
@@ -95,6 +95,27 @@ describe('Store', () => {
     ])
   })
 
+  // The RPC now strips manualRepoOrder, so every paired-client ui.set reaches the store without
+  // the key. Absent has to mean preserve: if it read as clear, the strip would erase the desktop's
+  // order on the first unrelated setting a phone or web client changes.
+  it('updateUI preserves the manual repo order when an update omits it', async () => {
+    const store = await createStore()
+    store.updateUI({
+      manualRepoOrder: [
+        { hostId: 'local', repoId: 'alpha' },
+        { hostId: 'ssh:box', repoId: 'bravo' }
+      ] as never
+    })
+
+    store.updateUI({ sidebarWidth: 400 })
+
+    expect(store.getUI().manualRepoOrder).toEqual([
+      { hostId: 'local', repoId: 'alpha' },
+      { hostId: 'ssh:box', repoId: 'bravo' }
+    ])
+    expect(store.getUI().sidebarWidth).toBe(400)
+  })
+
   it('updateUI persists sanitized per-worktree dotfile visibility', async () => {
     const store = await createStore()
     store.updateUI({

--- a/src/main/persistence-ui-state.test.ts
+++ b/src/main/persistence-ui-state.test.ts
@@ -98,13 +98,16 @@ describe('Store', () => {
   // The RPC now strips manualRepoOrder, so every paired-client ui.set reaches the store without
   // the key. Absent has to mean preserve: if it read as clear, the strip would erase the desktop's
   // order on the first unrelated setting a phone or web client changes.
-  it('updateUI preserves the manual repo order when an update omits it', async () => {
+  // Absent-means-preserve is what makes the pairing-local strip safe: a client's ui.set arrives
+  // without these fields, so the desktop's own values must survive the update.
+  it('updateUI preserves the manual repo and host-section order when an update omits them', async () => {
     const store = await createStore()
     store.updateUI({
       manualRepoOrder: [
         { hostId: 'local', repoId: 'alpha' },
         { hostId: 'ssh:box', repoId: 'bravo' }
-      ] as never
+      ] as never,
+      workspaceHostOrder: ['ssh:box', 'local'] as never
     })
 
     store.updateUI({ sidebarWidth: 400 })
@@ -113,6 +116,7 @@ describe('Store', () => {
       { hostId: 'local', repoId: 'alpha' },
       { hostId: 'ssh:box', repoId: 'bravo' }
     ])
+    expect(store.getUI().workspaceHostOrder).toEqual(['ssh:box', 'local'])
     expect(store.getUI().sidebarWidth).toBe(400)
   })
 

--- a/src/main/runtime/rpc/methods/client-ui-pairing-local-fields.test.ts
+++ b/src/main/runtime/rpc/methods/client-ui-pairing-local-fields.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from 'vitest'
+import { getDefaultUIState } from '../../../../shared/constants'
+import { PAIRING_LOCAL_UI_FIELDS } from '../../../../shared/pairing-local-ui-fields'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import type { RpcRequest } from '../core'
+import { RpcDispatcher } from '../dispatcher'
+import { CLIENT_UI_METHODS } from './client-ui'
+
+function makeRequest(method: string, params?: unknown): RpcRequest {
+  return { id: 'req-1', authToken: 'tok', method, params }
+}
+
+// Both directions of the pairing boundary for the fields in PAIRING_LOCAL_UI_FIELDS: a client's
+// value must never be persisted by the host, and the host's must never be returned to a client.
+describe('client UI RPC pairing-local field seams', () => {
+  it('drops a paired client manualRepoOrder while forwarding the rest of the payload', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      updateUIState: vi.fn(() => getDefaultUIState())
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: CLIENT_UI_METHODS })
+
+    // A paired web client restamps every repo onto its own runtime:web-* pseudo-host, so its
+    // overlay names hosts this profile will never own; persisting it erases the desktop order.
+    const response = await dispatcher.dispatch(
+      makeRequest('ui.set', {
+        sidebarWidth: 280,
+        manualRepoOrder: [
+          { hostId: 'runtime:web-11111111-2222-3333-4444-555555555555', repoId: 'repo-a' },
+          { hostId: 'runtime:web-11111111-2222-3333-4444-555555555555', repoId: 'repo-b' }
+        ]
+      })
+    )
+
+    expect(response).toMatchObject({ ok: true })
+    expect(runtime.updateUIState).toHaveBeenCalledWith({ sidebarWidth: 280 })
+  })
+
+  // Driven off the census so a field added to PAIRING_LOCAL_UI_FIELDS without wiring a seam
+  // fails here rather than shipping. Sample values are what a paired web client actually sends.
+  const pairingLocalSamples: Record<(typeof PAIRING_LOCAL_UI_FIELDS)[number], unknown> = {
+    hideWorkspacesFromOtherDevices: true,
+    manualRepoOrder: [
+      { hostId: 'runtime:web-11111111-2222-3333-4444-555555555555', repoId: 'repo-a' }
+    ]
+  }
+
+  it.each(PAIRING_LOCAL_UI_FIELDS.map((field) => [field] as const))(
+    'ui.set never persists the pairing-local field %s',
+    async (field) => {
+      const runtime = {
+        getRuntimeId: () => 'test-runtime',
+        updateUIState: vi.fn(() => getDefaultUIState())
+      } as unknown as OrcaRuntimeService
+      const dispatcher = new RpcDispatcher({ runtime, methods: CLIENT_UI_METHODS })
+
+      const response = await dispatcher.dispatch(
+        makeRequest('ui.set', { sidebarWidth: 280, [field]: pairingLocalSamples[field] })
+      )
+
+      expect(response).toMatchObject({ ok: true })
+      const forwarded = vi.mocked(runtime.updateUIState).mock.calls[0]?.[0] ?? {}
+      expect(Object.keys(forwarded)).not.toContain(field)
+      expect(forwarded).toMatchObject({ sidebarWidth: 280 })
+    }
+  )
+
+  // The read path matters as much as the write path: a host that echoes these back overwrites the
+  // client's own value, and on a profile poisoned before the write strip the echoed
+  // runtime:web-* keys match the very client that minted them.
+  it.each(PAIRING_LOCAL_UI_FIELDS.map((field) => [field] as const))(
+    'ui.get never returns the pairing-local field %s',
+    async (field) => {
+      const runtime = {
+        getRuntimeId: () => 'test-runtime',
+        getUIState: vi.fn(() => ({ ...getDefaultUIState(), [field]: pairingLocalSamples[field] }))
+      } as unknown as OrcaRuntimeService
+      const dispatcher = new RpcDispatcher({ runtime, methods: CLIENT_UI_METHODS })
+
+      const response = await dispatcher.dispatch(makeRequest('ui.get'))
+
+      const ui = (response as { result: { ui: Record<string, unknown> } }).result.ui
+      expect(Object.keys(ui)).not.toContain(field)
+      expect(ui).toMatchObject({ sidebarWidth: getDefaultUIState().sidebarWidth })
+    }
+  )
+
+  it.each(PAIRING_LOCAL_UI_FIELDS.map((field) => [field] as const))(
+    'the ui.set and ui.recordFeatureInteraction responses omit the pairing-local field %s',
+    async (field) => {
+      const stored = { ...getDefaultUIState(), [field]: pairingLocalSamples[field] }
+      const runtime = {
+        getRuntimeId: () => 'test-runtime',
+        updateUIState: vi.fn(() => stored),
+        recordFeatureInteraction: vi.fn(() => stored)
+      } as unknown as OrcaRuntimeService
+      const dispatcher = new RpcDispatcher({ runtime, methods: CLIENT_UI_METHODS })
+
+      const setResponse = await dispatcher.dispatch(makeRequest('ui.set', { sidebarWidth: 280 }))
+      const interactionResponse = await dispatcher.dispatch(
+        makeRequest('ui.recordFeatureInteraction', 'tasks')
+      )
+
+      for (const response of [setResponse, interactionResponse]) {
+        const ui = (response as { result: { ui: Record<string, unknown> } }).result.ui
+        expect(Object.keys(ui)).not.toContain(field)
+      }
+    }
+  )
+})

--- a/src/main/runtime/rpc/methods/client-ui-pairing-local-fields.test.ts
+++ b/src/main/runtime/rpc/methods/client-ui-pairing-local-fields.test.ts
@@ -42,7 +42,8 @@ describe('client UI RPC pairing-local field seams', () => {
     hideWorkspacesFromOtherDevices: true,
     manualRepoOrder: [
       { hostId: 'runtime:web-11111111-2222-3333-4444-555555555555', repoId: 'repo-a' }
-    ]
+    ],
+    workspaceHostOrder: ['runtime:web-11111111-2222-3333-4444-555555555555', 'local']
   }
 
   it.each(PAIRING_LOCAL_UI_FIELDS.map((field) => [field] as const))(

--- a/src/main/runtime/rpc/methods/client-ui.test.ts
+++ b/src/main/runtime/rpc/methods/client-ui.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { getDefaultUIState } from '../../../../shared/constants'
+import { omitPairingLocalUiFields } from '../../../../shared/pairing-local-ui-fields'
 import {
   MAX_QUICK_COMMAND_AGENT_PROMPT_LENGTH,
   MAX_QUICK_COMMAND_ID_LENGTH,
@@ -375,7 +376,7 @@ describe('client UI RPC methods', () => {
     const response = await dispatcher.dispatch(makeRequest('ui.get'))
 
     expect(runtime.getUIState).toHaveBeenCalledTimes(1)
-    expect(response).toMatchObject({ ok: true, result: { ui } })
+    expect(response).toMatchObject({ ok: true, result: { ui: omitPairingLocalUiFields(ui) } })
   })
 
   it('persists UI updates on the runtime host and returns the updated state', async () => {
@@ -415,7 +416,7 @@ describe('client UI RPC methods', () => {
       hideAutomationGeneratedWorkspaces: true,
       filterRepoIds: ['repo-1']
     })
-    expect(response).toMatchObject({ ok: true, result: { ui: updated } })
+    expect(response).toMatchObject({ ok: true, result: { ui: omitPairingLocalUiFields(updated) } })
   })
 
   it('lets a paired client clear the OSC 52 default-on notice', async () => {
@@ -565,30 +566,7 @@ describe('client UI RPC methods', () => {
       ...forwarded,
       worktreeCardProperties: ['status', 'unread', 'branch', 'automation', 'inline-agents']
     })
-    expect(response).toMatchObject({ ok: true, result: { ui: updated } })
-  })
-
-  it('drops a paired client manualRepoOrder while forwarding the rest of the payload', async () => {
-    const runtime = {
-      getRuntimeId: () => 'test-runtime',
-      updateUIState: vi.fn(() => getDefaultUIState())
-    } as unknown as OrcaRuntimeService
-    const dispatcher = new RpcDispatcher({ runtime, methods: CLIENT_UI_METHODS })
-
-    // A paired web client restamps every repo onto its own runtime:web-* pseudo-host, so its
-    // overlay names hosts this profile will never own; persisting it erases the desktop order.
-    const response = await dispatcher.dispatch(
-      makeRequest('ui.set', {
-        sidebarWidth: 280,
-        manualRepoOrder: [
-          { hostId: 'runtime:web-11111111-2222-3333-4444-555555555555', repoId: 'repo-a' },
-          { hostId: 'runtime:web-11111111-2222-3333-4444-555555555555', repoId: 'repo-b' }
-        ]
-      })
-    )
-
-    expect(response).toMatchObject({ ok: true })
-    expect(runtime.updateUIState).toHaveBeenCalledWith({ sidebarWidth: 280 })
+    expect(response).toMatchObject({ ok: true, result: { ui: omitPairingLocalUiFields(updated) } })
   })
 
   // Why one case per field: the schema is strict, so a single unlisted key makes
@@ -683,7 +661,7 @@ describe('client UI RPC methods', () => {
     const response = await dispatcher.dispatch(makeRequest('ui.recordFeatureInteraction', 'tasks'))
 
     expect(runtime.recordFeatureInteraction).toHaveBeenCalledWith('tasks')
-    expect(response).toMatchObject({ ok: true, result: { ui: updated } })
+    expect(response).toMatchObject({ ok: true, result: { ui: omitPairingLocalUiFields(updated) } })
   })
 
   it('rejects unknown and malformed UI update fields', async () => {
@@ -745,7 +723,7 @@ describe('client UI RPC methods', () => {
     expect(runtime.updateUIState).toHaveBeenCalledWith({
       worktreeCardProperties: ['status', 'unread', 'jira-issue']
     })
-    expect(response).toMatchObject({ ok: true, result: { ui: updated } })
+    expect(response).toMatchObject({ ok: true, result: { ui: omitPairingLocalUiFields(updated) } })
   })
 
   it('accepts every worktree card property the shared union defines', async () => {
@@ -825,7 +803,7 @@ describe('client UI RPC methods', () => {
     expect(runtime.updateUIState).toHaveBeenCalledWith({
       worktreeCardProperties: ['status', 'unread', 'ci', 'issue', 'pr']
     })
-    expect(response).toMatchObject({ ok: true, result: { ui: updated } })
+    expect(response).toMatchObject({ ok: true, result: { ui: omitPairingLocalUiFields(updated) } })
   })
 
   it('rejects each star-nag persisted state mutation field from remote clients', async () => {

--- a/src/main/runtime/rpc/methods/client-ui.test.ts
+++ b/src/main/runtime/rpc/methods/client-ui.test.ts
@@ -560,11 +560,35 @@ describe('client UI RPC methods', () => {
     }
     const response = await dispatcher.dispatch(makeRequest('ui.set', payload))
 
+    const { manualRepoOrder: _desktopOwnedOrder, ...forwarded } = payload
     expect(runtime.updateUIState).toHaveBeenCalledWith({
-      ...payload,
+      ...forwarded,
       worktreeCardProperties: ['status', 'unread', 'branch', 'automation', 'inline-agents']
     })
     expect(response).toMatchObject({ ok: true, result: { ui: updated } })
+  })
+
+  it('drops a paired client manualRepoOrder while forwarding the rest of the payload', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      updateUIState: vi.fn(() => getDefaultUIState())
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: CLIENT_UI_METHODS })
+
+    // A paired web client restamps every repo onto its own runtime:web-* pseudo-host, so its
+    // overlay names hosts this profile will never own; persisting it erases the desktop order.
+    const response = await dispatcher.dispatch(
+      makeRequest('ui.set', {
+        sidebarWidth: 280,
+        manualRepoOrder: [
+          { hostId: 'runtime:web-11111111-2222-3333-4444-555555555555', repoId: 'repo-a' },
+          { hostId: 'runtime:web-11111111-2222-3333-4444-555555555555', repoId: 'repo-b' }
+        ]
+      })
+    )
+
+    expect(response).toMatchObject({ ok: true })
+    expect(runtime.updateUIState).toHaveBeenCalledWith({ sidebarWidth: 280 })
   })
 
   // Why one case per field: the schema is strict, so a single unlisted key makes

--- a/src/main/runtime/rpc/methods/client-ui.ts
+++ b/src/main/runtime/rpc/methods/client-ui.ts
@@ -1,3 +1,4 @@
+import { omitPairingLocalUiFields } from '../../../../shared/pairing-local-ui-fields'
 import type { PersistedUIState } from '../../../../shared/persisted-ui-state-types'
 import { defineMethod, type RpcMethod } from '../core'
 import {
@@ -50,30 +51,24 @@ export const CLIENT_UI_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'ui.get',
     params: null,
-    handler: (_params, { runtime }) => ({ ui: runtime.getUIState() })
+    handler: (_params, { runtime }) => ({ ui: omitPairingLocalUiFields(runtime.getUIState()) })
   }),
   defineMethod({
     name: 'ui.set',
     params: UiUpdate,
-    // Why manualRepoOrder is dropped rather than removed from the schema: a paired client keys
-    // its overlay to its own execution hosts, so forwarding it blind-replaces the desktop's
-    // order. The strict schema still has to accept the field or old clients' whole payload fails.
-    handler: (params, { runtime }) => {
-      const {
-        hideWorkspacesFromOtherDevices: _clientLocalFilter,
-        manualRepoOrder: _desktopOwnedOrder,
-        ...hostUpdates
-      } = params
-      void _clientLocalFilter
-      void _desktopOwnedOrder
-      return { ui: runtime.updateUIState(hostUpdates as Partial<PersistedUIState>) }
-    }
+    // Why the fields are dropped here rather than removed from the schema: UiUpdate is strict, so
+    // an unlisted key would make the dispatcher reject an old client's ENTIRE payload.
+    handler: (params, { runtime }) => ({
+      ui: omitPairingLocalUiFields(
+        runtime.updateUIState(omitPairingLocalUiFields(params) as Partial<PersistedUIState>)
+      )
+    })
   }),
   defineMethod({
     name: 'ui.recordFeatureInteraction',
     params: FeatureInteractionIdParam,
     handler: (params, { runtime }) => ({
-      ui: runtime.recordFeatureInteraction(params)
+      ui: omitPairingLocalUiFields(runtime.recordFeatureInteraction(params))
     })
   })
 ]

--- a/src/main/runtime/rpc/methods/client-ui.ts
+++ b/src/main/runtime/rpc/methods/client-ui.ts
@@ -55,9 +55,17 @@ export const CLIENT_UI_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'ui.set',
     params: UiUpdate,
+    // Why manualRepoOrder is dropped rather than removed from the schema: a paired client keys
+    // its overlay to its own execution hosts, so forwarding it blind-replaces the desktop's
+    // order. The strict schema still has to accept the field or old clients' whole payload fails.
     handler: (params, { runtime }) => {
-      const { hideWorkspacesFromOtherDevices: _clientLocalFilter, ...hostUpdates } = params
+      const {
+        hideWorkspacesFromOtherDevices: _clientLocalFilter,
+        manualRepoOrder: _desktopOwnedOrder,
+        ...hostUpdates
+      } = params
       void _clientLocalFilter
+      void _desktopOwnedOrder
       return { ui: runtime.updateUIState(hostUpdates as Partial<PersistedUIState>) }
     }
   }),

--- a/src/renderer/src/hooks/direct-ssh-host-hydration.test.ts
+++ b/src/renderer/src/hooks/direct-ssh-host-hydration.test.ts
@@ -139,6 +139,33 @@ describe('createDirectSshHostHydration', () => {
     expect(store.getState().repos.map((entry) => entry.id)).toEqual(['bravo', 'alpha', 'delta'])
   })
 
+  // A repo added after the last drag has no overlay entry. Ranked rows must keep their order and
+  // the newcomer sinks to the tail, rather than the overlay being discarded for being incomplete.
+  it('keeps ranked rows in order and appends unranked ones when the overlay is partial', async () => {
+    const owner = authority('box')
+    const store = createStore<AppState>(() =>
+      state({
+        repos: [repo('bravo', 'box'), repo('alpha', null), repo('delta', 'box')],
+        manualRepoOrder: [
+          { hostId: 'ssh:box', repoId: 'delta' },
+          { hostId: 'local', repoId: 'alpha' }
+        ]
+      })
+    )
+    const hydration = createDirectSshHostHydration({
+      store,
+      listRepos: vi.fn(async () =>
+        hostSnapshot(owner, [repo('bravo', 'box'), repo('delta', 'box')])
+      ),
+      listLineage: vi.fn(),
+      isCurrentAuthority: () => true
+    })
+
+    await hydration.capturePreparationInput(owner, 'reconnect')
+
+    expect(store.getState().repos.map((entry) => entry.id)).toEqual(['delta', 'alpha', 'bravo'])
+  })
+
   it('rejects a mismatched host response without publishing', async () => {
     const owner = authority()
     const store = createStore<AppState>(() => state({ repos: [repo('cached', 'target-a')] }))

--- a/src/renderer/src/hooks/direct-ssh-host-hydration.test.ts
+++ b/src/renderer/src/hooks/direct-ssh-host-hydration.test.ts
@@ -113,6 +113,32 @@ describe('createDirectSshHostHydration', () => {
     ])
   })
 
+  it('keeps the manual cross-host order when the host catalog is republished', async () => {
+    const owner = authority('box')
+    const store = createStore<AppState>(() =>
+      state({
+        repos: [repo('bravo', 'box'), repo('alpha', null), repo('delta', 'box')],
+        manualRepoOrder: [
+          { hostId: 'ssh:box', repoId: 'bravo' },
+          { hostId: 'local', repoId: 'alpha' },
+          { hostId: 'ssh:box', repoId: 'delta' }
+        ]
+      })
+    )
+    const hydration = createDirectSshHostHydration({
+      store,
+      listRepos: vi.fn(async () =>
+        hostSnapshot(owner, [repo('bravo', 'box'), repo('delta', 'box')])
+      ),
+      listLineage: vi.fn(),
+      isCurrentAuthority: () => true
+    })
+
+    await hydration.capturePreparationInput(owner, 'reconnect')
+
+    expect(store.getState().repos.map((entry) => entry.id)).toEqual(['bravo', 'alpha', 'delta'])
+  })
+
   it('rejects a mismatched host response without publishing', async () => {
     const owner = authority()
     const store = createStore<AppState>(() => state({ repos: [repo('cached', 'target-a')] }))

--- a/src/renderer/src/hooks/direct-ssh-host-hydration.ts
+++ b/src/renderer/src/hooks/direct-ssh-host-hydration.ts
@@ -2,6 +2,7 @@ import type { StoreApi } from 'zustand'
 import { getRepoExecutionHostId, toSshExecutionHostId } from '../../../shared/execution-host'
 import type { HostLineageSnapshot } from '../../../shared/host-lineage-contract'
 import type { HostRepoCatalogSnapshot } from '../../../shared/host-repo-catalog-contract'
+import { applyManualRepoOrder } from '../../../shared/manual-repo-order'
 import type { DirectSshAuthority } from '../../../shared/ssh-types'
 import { isWorkspaceKey } from '../../../shared/workspace-scope'
 import type { AppState } from '../store/types'
@@ -63,12 +64,14 @@ function mergeExactHostCatalog(state: AppState, snapshot: HostRepoCatalogSnapsho
     return state
   }
   const hostId = snapshot.authority.executionHostId
+  // Why re-apply the overlay: re-appending the host's rows puts them at the tail, which would
+  // undo the user's manual cross-host order on every connect.
   return {
     ...state,
-    repos: [
-      ...state.repos.filter((repo) => getRepoExecutionHostId(repo) !== hostId),
-      ...snapshot.repos
-    ]
+    repos: applyManualRepoOrder(
+      [...state.repos.filter((repo) => getRepoExecutionHostId(repo) !== hostId), ...snapshot.repos],
+      state.manualRepoOrder
+    )
   }
 }
 

--- a/src/renderer/src/web/web-preload-api-ui.test.ts
+++ b/src/renderer/src/web/web-preload-api-ui.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { FeatureInteractionState } from '../../../shared/feature-interactions'
 import type { RuntimeRpcResponse } from '../../../shared/runtime-rpc-envelope'
+import type { ManualRepoOrderEntry } from '../../../shared/ui-chrome-types'
 import {
   installApi,
   installBrowserGlobals,
@@ -324,6 +325,44 @@ describe('web UI preload API', () => {
     })
     expect(JSON.parse(globals.storage.getItem('orca.web.ui.v1') ?? '{}')).toMatchObject({
       hideWorkspacesFromOtherDevices: true
+    })
+  })
+
+  it('keeps the manual repo order browser-local instead of overwriting the host order', async () => {
+    const runtimeCalls: { method: string; params: unknown }[] = []
+    vi.doMock('./web-runtime-client', () => ({
+      WebRuntimeClient: class {
+        call(method: string, params?: unknown): Promise<RuntimeRpcResponse<unknown>> {
+          runtimeCalls.push({ method, params })
+          return Promise.resolve({
+            id: method,
+            ok: true,
+            result: { ui: {} },
+            _meta: { runtimeId: 'runtime-1' }
+          })
+        }
+
+        close(): void {}
+      }
+    }))
+
+    const globals = installBrowserGlobals('Linux')
+    writeStoredRuntimeEnvironment(globals.storage)
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+
+    // The web client keys its order to its own runtime:web-* host, so a host that predates the
+    // RPC-side strip would persist it over the desktop's local/ssh-keyed order.
+    const manualRepoOrder: ManualRepoOrderEntry[] = [
+      { hostId: 'runtime:web-11111111-2222-3333-4444-555555555555', repoId: 'repo-b' },
+      { hostId: 'runtime:web-11111111-2222-3333-4444-555555555555', repoId: 'repo-a' }
+    ]
+    await globals.window.api.ui.set({ manualRepoOrder, sidebarWidth: 280 })
+
+    expect(runtimeCalls[0]).toEqual({ method: 'ui.set', params: { sidebarWidth: 280 } })
+    expect(JSON.parse(globals.storage.getItem('orca.web.ui.v1') ?? '{}')).toMatchObject({
+      manualRepoOrder,
+      sidebarWidth: 280
     })
   })
 

--- a/src/renderer/src/web/web-preload-api-ui.test.ts
+++ b/src/renderer/src/web/web-preload-api-ui.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { FeatureInteractionState } from '../../../shared/feature-interactions'
+import {
+  PAIRING_LOCAL_UI_FIELDS,
+  type PairingLocalUiField
+} from '../../../shared/pairing-local-ui-fields'
+import type { PersistedUIState } from '../../../shared/persisted-ui-state-types'
 import type { RuntimeRpcResponse } from '../../../shared/runtime-rpc-envelope'
 import type { ManualRepoOrderEntry } from '../../../shared/ui-chrome-types'
 import {
@@ -451,6 +456,57 @@ describe('web UI preload API', () => {
       sidebarWidth: 320
     })
   })
+
+  // Census-driven, matching the host-side seam tests: a field added to PAIRING_LOCAL_UI_FIELDS
+  // without wiring the web read seam fails here rather than shipping. The host sample differs from
+  // the browser's for every field, so only the pin makes this pass.
+  const browserLocalUiSamples: Record<PairingLocalUiField, unknown> = {
+    hideWorkspacesFromOtherDevices: true,
+    manualRepoOrder: [{ hostId: 'runtime:web-env-1', repoId: 'repo-b' }],
+    workspaceHostOrder: ['runtime:web-env-1', 'local']
+  }
+  const hostUiSamples: Record<PairingLocalUiField, unknown> = {
+    hideWorkspacesFromOtherDevices: false,
+    manualRepoOrder: [{ hostId: 'local', repoId: 'repo-a' }],
+    workspaceHostOrder: ['local', 'ssh:box']
+  }
+
+  it.each(PAIRING_LOCAL_UI_FIELDS.map((field) => [field] as const))(
+    'keeps the browser-local %s and never sends it to the host',
+    async (field) => {
+      const runtimeCalls: { method: string; params: unknown }[] = []
+      vi.doMock('./web-runtime-client', () => ({
+        WebRuntimeClient: class {
+          call(method: string, params?: unknown): Promise<RuntimeRpcResponse<unknown>> {
+            runtimeCalls.push({ method, params })
+            return Promise.resolve({
+              id: method,
+              ok: true,
+              result: { ui: { [field]: hostUiSamples[field] } },
+              _meta: { runtimeId: 'runtime-1' }
+            })
+          }
+
+          close(): void {}
+        }
+      }))
+
+      const browserLocal = { [field]: browserLocalUiSamples[field] } as Partial<PersistedUIState>
+      const globals = installBrowserGlobals('Linux')
+      writeStoredRuntimeEnvironment(globals.storage)
+      globals.storage.setItem('orca.web.ui.v1', JSON.stringify(browserLocal))
+      const { installWebPreloadApi } = await import('./web-preload-api')
+      installWebPreloadApi()
+
+      await globals.window.api.ui.set({ ...browserLocal, sidebarWidth: 280 })
+
+      expect(runtimeCalls[0]).toEqual({ method: 'ui.set', params: { sidebarWidth: 280 } })
+      await expect(globals.window.api.ui.get()).resolves.toMatchObject(browserLocal)
+      expect(JSON.parse(globals.storage.getItem('orca.web.ui.v1') ?? '{}')).toMatchObject(
+        browserLocal
+      )
+    }
+  )
 
   it('union-merges local contextual tour seen ids when ui.get returns stale host state', async () => {
     vi.doMock('./web-runtime-client', () => ({

--- a/src/renderer/src/web/web-preload-api-ui.test.ts
+++ b/src/renderer/src/web/web-preload-api-ui.test.ts
@@ -366,6 +366,92 @@ describe('web UI preload API', () => {
     })
   })
 
+  // Why cover a host that still sends the field: clients and hosts update independently, so a new
+  // web client meets hosts predating the response omission. On a profile an old web client
+  // poisoned, those echoed runtime:web-* entries match this browser's own repos and would beat
+  // every drag it has made since.
+  it.each([
+    [
+      'this browser own stale runtime:web-* entries',
+      [
+        { hostId: 'runtime:web-env-1', repoId: 'repo-c' },
+        { hostId: 'runtime:web-env-1', repoId: 'repo-a' }
+      ]
+    ],
+    [
+      'the desktop local/ssh-keyed order',
+      [
+        { hostId: 'local', repoId: 'repo-a' },
+        { hostId: 'ssh:box', repoId: 'repo-b' }
+      ]
+    ],
+    ['an empty overlay from a desktop that never dragged', []]
+  ])('keeps the browser-local manual repo order when ui.get returns %s', async (_label, hosted) => {
+    vi.doMock('./web-runtime-client', () => ({
+      WebRuntimeClient: class {
+        call(method: string): Promise<RuntimeRpcResponse<unknown>> {
+          return Promise.resolve({
+            id: method,
+            ok: true,
+            result: { ui: { manualRepoOrder: hosted } },
+            _meta: { runtimeId: 'runtime-1' }
+          })
+        }
+
+        close(): void {}
+      }
+    }))
+
+    const webOwnOrder: ManualRepoOrderEntry[] = [
+      { hostId: 'runtime:web-env-1', repoId: 'repo-b' },
+      { hostId: 'runtime:web-env-1', repoId: 'repo-a' }
+    ]
+    const globals = installBrowserGlobals('Linux')
+    writeStoredRuntimeEnvironment(globals.storage)
+    globals.storage.setItem('orca.web.ui.v1', JSON.stringify({ manualRepoOrder: webOwnOrder }))
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+
+    await expect(globals.window.api.ui.get()).resolves.toMatchObject({
+      manualRepoOrder: webOwnOrder
+    })
+    expect(JSON.parse(globals.storage.getItem('orca.web.ui.v1') ?? '{}')).toMatchObject({
+      manualRepoOrder: webOwnOrder
+    })
+  })
+
+  it('keeps the browser-local manual repo order when a new host omits it entirely', async () => {
+    vi.doMock('./web-runtime-client', () => ({
+      WebRuntimeClient: class {
+        call(method: string): Promise<RuntimeRpcResponse<unknown>> {
+          return Promise.resolve({
+            id: method,
+            ok: true,
+            result: { ui: { sidebarWidth: 320 } },
+            _meta: { runtimeId: 'runtime-1' }
+          })
+        }
+
+        close(): void {}
+      }
+    }))
+
+    const webOwnOrder: ManualRepoOrderEntry[] = [
+      { hostId: 'runtime:web-env-1', repoId: 'repo-b' },
+      { hostId: 'runtime:web-env-1', repoId: 'repo-a' }
+    ]
+    const globals = installBrowserGlobals('Linux')
+    writeStoredRuntimeEnvironment(globals.storage)
+    globals.storage.setItem('orca.web.ui.v1', JSON.stringify({ manualRepoOrder: webOwnOrder }))
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+
+    await expect(globals.window.api.ui.get()).resolves.toMatchObject({
+      manualRepoOrder: webOwnOrder,
+      sidebarWidth: 320
+    })
+  })
+
   it('union-merges local contextual tour seen ids when ui.get returns stale host state', async () => {
     vi.doMock('./web-runtime-client', () => ({
       WebRuntimeClient: class {

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -34,6 +34,7 @@ import type { OnboardingState } from '../../../shared/onboarding-state-types'
 import type { PersistedUIState } from '../../../shared/persisted-ui-state-types'
 import {
   omitPairingLocalUiFields,
+  type PairedUiState,
   type PairingLocalUiField
 } from '../../../shared/pairing-local-ui-fields'
 import type { MemorySnapshot, StatsSummary } from '../../../shared/process-stats-types'
@@ -2706,11 +2707,7 @@ function createWebUiApi(): NonNullable<Partial<PreloadApi>['ui']> {
   return {
     get: async () => {
       try {
-        const result = await callRuntimeResult<{ ui: PersistedUIState }>(
-          'ui.get',
-          undefined,
-          15_000
-        )
+        const result = await callRuntimeResult<{ ui: PairedUiState }>('ui.get', undefined, 15_000)
         const local = readLocalWebUIState()
         const next = {
           ...mergeHostWebUIState(local, result.ui),
@@ -2759,7 +2756,7 @@ function createWebUiApi(): NonNullable<Partial<PreloadApi>['ui']> {
       })
       writeJson(UI_STORAGE_KEY, optimistic)
       try {
-        const result = await callRuntimeResult<{ ui: PersistedUIState }>(
+        const result = await callRuntimeResult<{ ui: PairedUiState }>(
           'ui.recordFeatureInteraction',
           id,
           15_000
@@ -4173,14 +4170,14 @@ function mergeWebUIState(
 // Why pin instead of trusting the host's strip: an old host still returns these fields, and for a
 // profile a pre-fix drag poisoned they echo back the same runtime:web-* keys this browser minted,
 // which then match its own repos and beat every newer drag.
-function mergeHostWebUIState(
-  local: PersistedUIState,
-  incoming: PersistedUIState
-): PersistedUIState {
-  const pinned: Pick<PersistedUIState, PairingLocalUiField> = {
+function mergeHostWebUIState(local: PersistedUIState, incoming: PairedUiState): PersistedUIState {
+  // Why `satisfies Record<...>` rather than a `Pick<...>` annotation: every member is optional in
+  // PersistedUIState, so Pick would accept a literal that silently skipped a newly added member.
+  const pinned = {
     hideWorkspacesFromOtherDevices: local.hideWorkspacesFromOtherDevices === true,
-    manualRepoOrder: local.manualRepoOrder
-  }
+    manualRepoOrder: local.manualRepoOrder,
+    workspaceHostOrder: local.workspaceHostOrder
+  } satisfies Record<PairingLocalUiField, unknown> & Partial<PersistedUIState>
   return { ...mergeWebUIState(local, incoming), ...pinned }
 }
 

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2731,9 +2731,15 @@ function createWebUiApi(): NonNullable<Partial<PreloadApi>['ui']> {
       const next = mergeWebUIState(readLocalWebUIState(), updates)
       writeJson(UI_STORAGE_KEY, next)
       zoomLevel = next.uiZoomLevel
-      const { hideWorkspacesFromOtherDevices: _clientLocalWorkspaceFilter, ...hostUpdates } =
-        updates
+      // Why manualRepoOrder stays local: it is keyed to this client's runtime:web-* hosts, so
+      // sending it would overwrite the desktop profile's order on hosts that predate the strip.
+      const {
+        hideWorkspacesFromOtherDevices: _clientLocalWorkspaceFilter,
+        manualRepoOrder: _desktopOwnedOrder,
+        ...hostUpdates
+      } = updates
       void _clientLocalWorkspaceFilter
+      void _desktopOwnedOrder
       try {
         await callRuntimeResult('ui.set', hostUpdates, 15_000)
       } catch {

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -32,6 +32,10 @@ import type {
 } from '../../../shared/global-settings-types'
 import type { OnboardingState } from '../../../shared/onboarding-state-types'
 import type { PersistedUIState } from '../../../shared/persisted-ui-state-types'
+import {
+  omitPairingLocalUiFields,
+  type PairingLocalUiField
+} from '../../../shared/pairing-local-ui-fields'
 import type { MemorySnapshot, StatsSummary } from '../../../shared/process-stats-types'
 import type { Repo } from '../../../shared/repo-types'
 import type {
@@ -2731,15 +2735,9 @@ function createWebUiApi(): NonNullable<Partial<PreloadApi>['ui']> {
       const next = mergeWebUIState(readLocalWebUIState(), updates)
       writeJson(UI_STORAGE_KEY, next)
       zoomLevel = next.uiZoomLevel
-      // Why manualRepoOrder stays local: it is keyed to this client's runtime:web-* hosts, so
-      // sending it would overwrite the desktop profile's order on hosts that predate the strip.
-      const {
-        hideWorkspacesFromOtherDevices: _clientLocalWorkspaceFilter,
-        manualRepoOrder: _desktopOwnedOrder,
-        ...hostUpdates
-      } = updates
-      void _clientLocalWorkspaceFilter
-      void _desktopOwnedOrder
+      // Why strip here too when the host also strips: an old host predating that strip would
+      // otherwise persist this browser's runtime:web-* keys over the desktop profile's order.
+      const hostUpdates = omitPairingLocalUiFields(updates)
       try {
         await callRuntimeResult('ui.set', hostUpdates, 15_000)
       } catch {
@@ -4172,14 +4170,18 @@ function mergeWebUIState(
   }
 }
 
+// Why pin instead of trusting the host's strip: an old host still returns these fields, and for a
+// profile a pre-fix drag poisoned they echo back the same runtime:web-* keys this browser minted,
+// which then match its own repos and beat every newer drag.
 function mergeHostWebUIState(
   local: PersistedUIState,
   incoming: PersistedUIState
 ): PersistedUIState {
-  return {
-    ...mergeWebUIState(local, incoming),
-    hideWorkspacesFromOtherDevices: local.hideWorkspacesFromOtherDevices === true
+  const pinned: Pick<PersistedUIState, PairingLocalUiField> = {
+    hideWorkspacesFromOtherDevices: local.hideWorkspacesFromOtherDevices === true,
+    manualRepoOrder: local.manualRepoOrder
   }
+  return { ...mergeWebUIState(local, incoming), ...pinned }
 }
 
 function mergeFeatureInteractionState(

--- a/src/shared/pairing-local-ui-fields.test.ts
+++ b/src/shared/pairing-local-ui-fields.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { omitPairingLocalUiFields, PAIRING_LOCAL_UI_FIELDS } from './pairing-local-ui-fields'
+
+describe('pairing-local UI fields', () => {
+  // Why a census: the seams that honor this set are spread across the host RPC and the web
+  // preload, so a field added here without wiring every seam would otherwise ship silently.
+  it('census: the set is exactly the fields no pairing may exchange', () => {
+    expect([...PAIRING_LOCAL_UI_FIELDS]).toEqual([
+      'hideWorkspacesFromOtherDevices',
+      'manualRepoOrder'
+    ])
+  })
+
+  it('omits every member and keeps everything else', () => {
+    const state = {
+      hideWorkspacesFromOtherDevices: true,
+      manualRepoOrder: [{ hostId: 'local' as const, repoId: 'repo-a' }],
+      sidebarWidth: 280,
+      activeView: 'tasks' as const
+    }
+
+    expect(omitPairingLocalUiFields(state)).toEqual({ sidebarWidth: 280, activeView: 'tasks' })
+  })
+
+  it('leaves a payload that carries no member untouched', () => {
+    const state = { sidebarWidth: 280 }
+
+    expect(omitPairingLocalUiFields(state)).toEqual(state)
+  })
+
+  // A member explicitly set to undefined must still be removed, not forwarded as a present key
+  // that a receiver would read as "cleared".
+  it('drops a member present with an undefined value', () => {
+    expect(
+      Object.keys(omitPairingLocalUiFields({ manualRepoOrder: undefined, sidebarWidth: 280 }))
+    ).toEqual(['sidebarWidth'])
+  })
+})

--- a/src/shared/pairing-local-ui-fields.test.ts
+++ b/src/shared/pairing-local-ui-fields.test.ts
@@ -7,7 +7,8 @@ describe('pairing-local UI fields', () => {
   it('census: the set is exactly the fields no pairing may exchange', () => {
     expect([...PAIRING_LOCAL_UI_FIELDS]).toEqual([
       'hideWorkspacesFromOtherDevices',
-      'manualRepoOrder'
+      'manualRepoOrder',
+      'workspaceHostOrder'
     ])
   })
 
@@ -15,6 +16,7 @@ describe('pairing-local UI fields', () => {
     const state = {
       hideWorkspacesFromOtherDevices: true,
       manualRepoOrder: [{ hostId: 'local' as const, repoId: 'repo-a' }],
+      workspaceHostOrder: ['local' as const],
       sidebarWidth: 280,
       activeView: 'tasks' as const
     }

--- a/src/shared/pairing-local-ui-fields.ts
+++ b/src/shared/pairing-local-ui-fields.ts
@@ -1,16 +1,21 @@
 import type { PersistedUIState } from './persisted-ui-state-types'
 
 // UI state each side of a pairing owns for itself. These fields describe a client's own view —
-// which workspaces it hides, what order it puts repos in — and are keyed to hosts only that side
-// knows about, so a value copied across the boundary in either direction overwrites the receiver's
-// answer with one computed for somebody else. They must be stripped on the way to a host (ui.set)
-// and pinned to the local value on the way back (ui.get).
+// which workspaces it hides, what order it puts repos and host sections in — and are keyed to hosts
+// only that side knows about, so a value copied across the boundary in either direction overwrites
+// the receiver's answer with one computed for somebody else. They must be stripped on the way to a
+// host (ui.set) and pinned to the local value on the way back (ui.get).
 export const PAIRING_LOCAL_UI_FIELDS = [
   'hideWorkspacesFromOtherDevices',
-  'manualRepoOrder'
+  'manualRepoOrder',
+  'workspaceHostOrder'
 ] as const satisfies readonly (keyof PersistedUIState)[]
 
 export type PairingLocalUiField = (typeof PAIRING_LOCAL_UI_FIELDS)[number]
+
+// What a paired client actually receives over the UI RPCs, so reading a pairing-local field off a
+// host response is a compile error rather than a silent undefined.
+export type PairedUiState = Omit<PersistedUIState, PairingLocalUiField>
 
 const PAIRING_LOCAL_UI_FIELD_SET: ReadonlySet<string> = new Set(PAIRING_LOCAL_UI_FIELDS)
 

--- a/src/shared/pairing-local-ui-fields.ts
+++ b/src/shared/pairing-local-ui-fields.ts
@@ -1,0 +1,23 @@
+import type { PersistedUIState } from './persisted-ui-state-types'
+
+// UI state each side of a pairing owns for itself. These fields describe a client's own view —
+// which workspaces it hides, what order it puts repos in — and are keyed to hosts only that side
+// knows about, so a value copied across the boundary in either direction overwrites the receiver's
+// answer with one computed for somebody else. They must be stripped on the way to a host (ui.set)
+// and pinned to the local value on the way back (ui.get).
+export const PAIRING_LOCAL_UI_FIELDS = [
+  'hideWorkspacesFromOtherDevices',
+  'manualRepoOrder'
+] as const satisfies readonly (keyof PersistedUIState)[]
+
+export type PairingLocalUiField = (typeof PAIRING_LOCAL_UI_FIELDS)[number]
+
+const PAIRING_LOCAL_UI_FIELD_SET: ReadonlySet<string> = new Set(PAIRING_LOCAL_UI_FIELDS)
+
+// Accepts any object, not just Partial<PersistedUIState>: the ui.set seam passes the zod-inferred
+// update type, whose optionality differs from the persisted shape.
+export function omitPairingLocalUiFields<T extends object>(state: T): Omit<T, PairingLocalUiField> {
+  return Object.fromEntries(
+    Object.entries(state).filter(([key]) => !PAIRING_LOCAL_UI_FIELD_SET.has(key))
+  ) as Omit<T, PairingLocalUiField>
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​419 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​412 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​67 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​28 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​39 |

<!-- /orca-pr-loc -->

Fixes #15468

The reporter's manual project order was being lost two independent ways. Both are fixed here. Cross-host project *grouping* (#13986) is deliberately **not** addressed — see the last section.

## Root cause 1 — a paired client's overlay overwrites the desktop's

`ui.manualRepoOrder` is a list of `{ hostId, repoId }` entries, host-qualified since #7237 so the same repo id on two hosts stays two distinct rows. A paired client computes that list against *its own* execution hosts and then sends it to the desktop profile, which stores it verbatim:

- `src/renderer/src/web/web-runtime-environment.ts` mints a per-pairing pseudo-host `web-${createBrowserUuid()}`, and `withRuntimeRepoOwner` in `src/renderer/src/web/web-preload-api.ts:3567` restamps every repo with `executionHostId: runtime:web-<uuid>`.
- `reorderRepos` (`src/renderer/src/store/slices/repos.ts:3989-4020`) derives the overlay via `getRepoExecutionHostId` and unconditionally calls `window.api.ui.set({ manualRepoOrder })`. On web every entry is therefore keyed `runtime:web-<uuid>`.
- The web `ui.set` (`src/renderer/src/web/web-preload-api.ts:2734-2742`) stripped only `hideWorkspacesFromOtherDevices` and forwarded the rest.
- The host `ui.set` (`src/main/runtime/rpc/methods/client-ui.ts:56-62`) stripped only `hideWorkspacesFromOtherDevices` and forwarded the rest.
- `updatePersistedUI` (`src/main/persistence/applying-settings/ui-state-update.ts:160-163`) does a blind whole-array replace. Its neighbours `contextualToursSeenIds` and `featureInteractions` each grew a stale-client merge helper; `manualRepoOrder` never did.

The write is **subtractive**, not merely re-keyed: the web client only sees the desktop's local repos, so the desktop's runtime-host entries are erased outright. `applyManualRepoOrder` then matches nothing, no-ops silently, and the scramble appears at the next cold start — matching the report's "each time the site is closed and reopened" and "the update disrupted my order".

## Root cause 2 — a direct-SSH catalog publish sinks SSH repos to the tail

`mergeExactHostCatalog` (`src/renderer/src/hooks/direct-ssh-host-hydration.ts:61-73`) filtered out the host's rows and re-appended the snapshot at the end of the array without re-applying the overlay. This runs on every connect, including the first after launch, so SSH repos fell to the bottom even when the persisted overlay was perfectly intact. Regression introduced after #8894 (#11003, 2026-07-28).

## The fix — one authority model

> The desktop profile owns `ui.manualRepoOrder`. Paired clients own only their host-local permutation, via `repo.reorder`. Every writer of the repos array applies the overlay.

Write path — a client's value never reaches host storage:

1. `src/main/runtime/rpc/methods/client-ui.ts` — the `ui.set` handler strips the pairing-local fields before persisting.
2. `src/renderer/src/web/web-preload-api.ts` — the web `ui.set` drops them from `hostUpdates` before `callRuntimeResult`, so an old host has nothing to persist either. The local write is unchanged.

Read path — the host's value never reaches a client (added in round 2, see below):

3. `client-ui.ts` — `ui.get`, and the `ui.set` / `ui.recordFeatureInteraction` responses, omit the pairing-local fields.
4. `web-preload-api.ts` — `mergeHostWebUIState` pins `manualRepoOrder` to the browser's own value, the pattern `hideWorkspacesFromOtherDevices` already used.

Hydration — every writer of the repos array re-applies the overlay:

5. `src/renderer/src/hooks/direct-ssh-host-hydration.ts` — `mergeExactHostCatalog` applies `applyManualRepoOrder(merged, state.manualRepoOrder)` before returning.

All six boundary seams — the host `ui.set` strip, the host `ui.get` / `ui.set` / `ui.recordFeatureInteraction` response omissions, the web `ui.set` strip, and the web `mergeHostWebUIState` pin — consume one exported set, `PAIRING_LOCAL_UI_FIELDS` in `src/shared/pairing-local-ui-fields.ts`, rather than six hand-maintained field lists that drift apart. Its members:

| field | why it cannot cross the boundary | what that prevents |
|---|---|---|
| `manualRepoOrder` | keyed to hosts only the sending side owns; a web client keys every entry to its own `runtime:web-<uuid>` | the scramble in root cause 1 |
| `workspaceHostOrder` | same shape, same poisoning: `ui.ts:2107-2111` sends it on every host-section drag with the same `runtime:web-<uuid>` ids, and `ui-state-update.ts:156-159` blind-replaces it | the desktop's host-section order silently resetting on the next cold start — `orderHostSectionOptions` (`host-section-order.ts:14-20`) skips ids matching no host, so a poisoned array leaves plain discovery order. Sibling defect of the same class, found in review. |
| `hideWorkspacesFromOtherDevices` | a per-device view filter by definition | nothing new — it was already stripped and pinned; joining the set is a no-op for behavior |

Enforcement is both compile-time and test-time. The host seams iterate the set directly, so a new member is covered automatically and the census `it.each` names it. The web pin is a literal (one member needs its own `=== true` normalization), so it is constrained by `satisfies Record<PairingLocalUiField, unknown>`: dropping a member from it fails `tsc` *and* fails the named web-seam test for that field. Both signals were confirmed by mutation.

Adding `workspaceHostOrder` is inert in the directions that are not the bug: the web client's own host order is localStorage-backed, mobile references none of the three fields (`ui.get`'s only mobile consumer, `NewWorktreeModal.tsx:395`, reads `trustedOrcaHooks` and nothing else), and an old client against a new host lands on the absent-key-preserves branch of the same spread merge.

A paired client's drag still reorders that client's own view; it just no longer rewrites the desktop's saved order.

## Wire compatibility

`manualRepoOrder` is **kept in the zod schema** (`client-ui-schemas.ts`). `UiUpdate` is strict, so deleting the field would make the dispatcher reject an old client's *entire* `ui.set` payload with `invalid_argument`, taking every unrelated setting in that payload down with it. Stripping it inside the handler is the compatible shape, and it is the same pattern already used for `hideWorkspacesFromOtherDevices`.

Under `docs/reference/remote-wire-compatibility.md` this is a Rule 3 change — the host stops consuming a field it used to consume — so all four pairings are enumerated:

| client | host | behaviour |
|---|---|---|
| old | old | unchanged (the bug) |
| **old** | **new** | client still sends the field; host accepts the payload and ignores that one key. This is the fix's main path — an un-updated web client can no longer corrupt an updated desktop. |
| **new** | **old** | client no longer sends the field; old host has nothing to overwrite with. This is why the strip is done at both ends rather than only on the host. |
| new | new | field never crosses the wire. |

And the same four pairings on the read path (`ui.get` and the `ui.set` / `recordFeatureInteraction` responses):

| client | host | behaviour |
|---|---|---|
| old | old | unchanged (the bug) |
| old | **new** | host omits the field; the old web client's merge is a plain spread, so an ABSENT key leaves its local value intact. This repairs old web clients with no client update. |
| **new** | old | host still sends it; the new client pins its local value in `mergeHostWebUIState` and ignores the response's. |
| new | new | field never crosses the wire. |

Rule 3 applies to the read path since the host stops populating a field. It is safe for every reader: mobile reads only `trustedOrcaHooks` off `ui.get`, and the web client pins both members locally.

No opcode, no schema change, no protocol version bump. `PersistedUIState` still carries the field; only the client-to-host direction stops.

## Evidence

Every assertion below was verified red→green→red: it fails with the production change reverted and passes with it applied (`test-results/sta-4850/impl-logs/12-revert-check.log`).

New/updated committed regression tests:

- `client-ui.test.ts` — a `ui.set` carrying a `runtime:web-<uuid>`-keyed `manualRepoOrder` reaches `runtime.updateUIState` without the field while `sidebarWidth` still passes through. The existing full-payload pass-through case was updated to assert the same exclusion.
- `web-preload-api-ui.test.ts` — the web `ui.set` forwards `{ sidebarWidth: 280 }` only, while `manualRepoOrder` still lands in `orca.web.ui.v1`.
- `direct-ssh-host-hydration.test.ts` — a snapshot publish over `[bravo(ssh), alpha(local), delta(ssh)]` preserves that order instead of yielding `[alpha, bravo, delta]`. The existing first test, which pins tail-append when no overlay is set, stays green: `applyManualRepoOrder` returns its input unchanged for an empty overlay.

Four throwaway diagnostic probes were written against `main` before the fix to pin the failure modes; they are not committed. Two are green on this branch and two stay red **by design**:

| probe | after fix | why |
|---|---|---|
| `ui.set` forwards a paired client's `manualRepoOrder` | **green** | the durable protection: the host no longer accepts the field |
| direct-SSH publish sinks SSH repos to the tail | **green** | the overlay is re-applied on every catalog merge |
| an *already-poisoned* overlay still restores the saved order | **red, by design** | a pure-function demo of the consequence of root cause 1, not a target. It calls `applyManualRepoOrder` directly with hardcoded `runtime:web-*` entries; the only way to satisfy it is to fall back to matching on bare `repoId`, which deliberately breaks the #7237/#8894 host-qualification and would reorder the wrong host's row whenever a repo id exists on two hosts. Prevention at the `ui.set` boundary is the fix; tolerance of foreign keys is not. |
| the same canonical repo on two hosts renders two project headers | **red, by design** | invariant A, #13986 — see below |

Round 2 added: a census test on `PAIRING_LOCAL_UI_FIELDS`; seam tests iterating that set for the `ui.set` strip, the `ui.get` omission and the response omissions; web `ui.get` round-trip tests covering a host that returns this browser's own stale `runtime:web-*` entries, a desktop-keyed array, an empty array, and a new host that omits the field; a store test pinning that an update omitting `manualRepoOrder` preserves it rather than clearing it (after the strip, that is every paired `ui.set`); and a partial-overlay case at the SSH site where ranked rows hold their order and an unranked newcomer sinks to the tail.

Round 3 added `workspaceHostOrder` to the set (picking up the host-side seam `it.each` automatically), converted the web-side merge coverage to an `it.each` over `PAIRING_LOCAL_UI_FIELDS` with a host sample that differs from the browser's for every field, made the web pin fail compile when a member is dropped, and extended the persistence preserve-branch test to cover both order fields.

Validation, all green: 11 related unit files (209 tests), `pnpm run typecheck`, `pnpm run lint`, `check:code-quality:changed`, and `check:react-doctor:changed`.

The E2E oracles were rerun byte-identically against the round-2 tree and both stay green: the B1 journey (web drag, cold relaunch, host restart, late/offline host, update-equivalent relaunch onto the same profile) keeps all six host-qualified entries in `orca-data.json` and the rendered header order stable at every checkpoint, and the B2 direct-SSH journey holds `[ssh-one, alpha, ssh-two, bravo]` across reconnect, cold start before connect, and cold start after connect.

Pre-merge E2E oracles (harness under `test-results/sta-4850/harness/`, gitignored) read two independent signals — the desktop profile's `orca-data.json` `ui.manualRepoOrder`, and the rendered sidebar header order over CDP — across a web-client drag, desktop cold relaunch, host restart, an update-equivalent relaunch onto the same profile, a late/offline host, and varied catalog arrival order. Checkpoint 05 is the sharpest: after a web drag legitimately changes the client's local permutation, the desktop overlay must still win at hydration.

## Already-poisoned profiles are not migrated

A profile whose overlay was overwritten by a pre-fix web drag keeps that stale array on disk; it is not rewritten. What that costs depends on who is reading it, and an earlier revision of this description got the client half wrong:

- **On the desktop it is inert.** Every entry names a `runtime:web-<uuid>` host the profile does not own, so `applyManualRepoOrder` matches nothing, every row sorts as unranked, and the identity check at `manual-repo-order.ts:73` returns the input array untouched. The user sees arrival order.
- **On the web client that minted it, it was live, not inert.** The environment id is persisted per pairing in `orca.web.runtimeEnvironment.v1`, so the same browser restamps its repos onto the same `runtime:web-<uuid>` host. Those entries came back over `ui.get` and matched, which meant the stale array beat every drag the user made after it — the reported symptom reappearing on each reload. The read-path seams above neutralize this: the host stops returning the field, and the client pins its own value even against a host that still sends it.

Recovery of the stored array is by user action. A desktop drag goes through the local `ui:set` IPC (`src/main/ipc/ui.ts:66`), not the runtime RPC, so `getManualRepoOrder` re-derives a clean host-qualified overlay from the profile's real repos and replaces the stale one wholesale.

No read-time cleanup pass is included on purpose. The overlay legitimately outlives the repos it names: #8894 retains entries for hosts that are offline or arrive late, precisely so a disconnected SSH host does not lose its position while away. A cleaner cannot distinguish a poisoned entry from a valid dormant one by looking at the data — it would have to guess from key *shape* (`runtime:web-*` looks client-minted) and prune on that heuristic, which would be a second, weaker authority rule on top of the one this PR establishes and would silently drop legitimate `runtime:*` entries for real remote runtimes.

## Known limitations and follow-ups

- `repo.reorder` still rejects a reorder on a catalog where two hosts' repos collapse onto one identity. This PR removes the user-visible consequence (the client's own order is now authoritative for the client), but the underlying rejection is unchanged and is tracked separately.
- `mergeExactHostCatalog` rebuilds the repos array without reusing equal row identities, so a no-op republish still produces new object identities downstream. Pre-existing and orthogonal to ordering; not addressed here.
- Every web drag still sends an `ui.set` whose payload is now empty after the strip. Harmless, and removing the round trip would be a contract change.

## Not addressed here: cross-host grouping (#13986)

The same report also asks that one repo present on two hosts render as two project headers instead of one. That is **not** in this PR, and #13986 is deliberately left open.

Merging the same canonical repo across hosts is a deliberate, three-point contract: the `project:<id>` grouping key (`project-grouping.ts:122`), the store's project merge (`repos.ts:605`, `repos.ts:1074`), and the selector normalizer (`project-host-setup-selector-normalization.ts:12`). It is pinned by `worktree-list-groups-project-host-setups.test.ts` and was explicitly preserved by #8894. Splitting it is a product decision that reverses a shipped contract, not a bug fix, and it is a strictly separate change from ordering. A follow-up ticket carries the recommended design: host-qualify at the grouping layer only, emitting a host-qualified header key when a project spans more than one host, with reveal keys moving in lockstep — and specifically *not* host-qualifying `getProjectIdentityKey`, which would reach project groups, succession, cmd-J, and colors.

