### PR TITLE
fix(mobile): keep a desktop take-back from being undone by a passive viewport report

### DIFF
--- a/src/main/runtime/mobile-presence-lock.test.ts
+++ b/src/main/runtime/mobile-presence-lock.test.ts
@@ -817,3 +817,42 @@ describe('mobile presence lock — issue #7588 held-modal restore convergence', 
     })
   })
 })
+
+// Why: reported against local Mac terminals — "Take back all terminals" looked like
+// a no-op. The phone stays subscribed, and its passive viewport report (forced on
+// iOS app resume and on every reconnect) silently re-took the floor.
+describe('mobile presence lock — desktop take-back survives passive viewport reports', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('a still-subscribed phone reporting its viewport does not undo a desktop take-back', async () => {
+    const { runtime, ptySizes, driverEvents } = createRuntime(null)
+    await runtime.handleMobileSubscribe('pty-1', 'phone-A', { cols: 40, rows: 20 })
+    expect(await runtime.reclaimTerminalForDesktop('pty-1')).toBe(true)
+    expect(runtime.getDriver('pty-1')).toEqual({ kind: 'desktop' })
+    expect(ptySizes.get('pty-1')).toEqual({ cols: 150, rows: 40 })
+    const driverEventsBefore = driverEvents.length
+
+    await vi.advanceTimersByTimeAsync(10)
+    await expect(
+      runtime.updateMobileViewport('pty-1', 'phone-A', { cols: 40, rows: 20 })
+    ).resolves.toEqual({ updated: true, applied: false })
+
+    expect(runtime.getDriver('pty-1')).toEqual({ kind: 'desktop' })
+    expect(ptySizes.get('pty-1')).toEqual({ cols: 150, rows: 40 })
+    expect(runtime.getTerminalFitOverride('pty-1')).toBeNull()
+    expect(driverEvents.slice(driverEventsBefore)).toEqual([])
+  })
+
+  it('a deliberate mobile gesture still re-takes the floor after a desktop take-back', async () => {
+    const { runtime, ptySizes } = createRuntime(null)
+    await runtime.handleMobileSubscribe('pty-1', 'phone-A', { cols: 40, rows: 20 })
+    expect(await runtime.reclaimTerminalForDesktop('pty-1')).toBe(true)
+
+    await vi.advanceTimersByTimeAsync(10)
+    await runtime.mobileTookFloor('pty-1', 'phone-A')
+
+    expect(runtime.getDriver('pty-1')).toEqual({ kind: 'mobile', clientId: 'phone-A' })
+    expect(ptySizes.get('pty-1')).toEqual({ cols: 40, rows: 20 })
+  })
+})

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -15865,6 +15865,13 @@ export class OrcaRuntimeService {
       // Watching at desktop dims — viewport is informational only.
       return { updated: true, applied: false }
     }
+    // Why: a desktop take-back is released only by a deliberate mobile gesture
+    // (mobileTookFloor / setDisplayMode / fresh subscribe). A passive viewport report
+    // — iOS resume and every reconnect force one — must not re-phone-fit and re-take
+    // the floor, or the take-back looks like a no-op to the desktop user.
+    if (this.getDriver(ptyId).kind === 'desktop') {
+      return { updated: true, applied: false }
+    }
     // Drive PTY dims by the most-recent-actor (just updated to this client).
     const winner = this.pickMostRecentActor(inner!)
     if (!winner) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​39 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​39 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 |

<!-- /orca-pr-loc -->

## ELI5

You're driving a terminal from your phone. On the Mac you click **"Take back this terminal"** — the terminal snaps back to desktop size and the banner disappears. Then your phone wakes up in your pocket, or its connection blips, and it quietly tells the Mac "here's how big my screen is." The Mac took that as "the phone wants control again," shrank the terminal back to phone size, and put the banner back. To you it looked like the take-back button did nothing.

Now a *passive* size report from a phone can't steal control back. Only something you actually do on the phone — typing, switching display mode, opening the session — takes the floor again.

## What Changed

One guard in `OrcaRuntimeService.updateMobileViewport` (`src/main/runtime/orca-runtime.ts`): when the PTY's driver is already `desktop`, record the subscriber's viewport and return `{ updated: true, applied: false }` — no `wasResizedToPhone`, no `setDriver`, no `enqueueLayout`. This is the same passive-watch treatment the method already gives `mobileDisplayModes[ptyId] === 'desktop'`, three lines above.

Plus two tests in `src/main/runtime/mobile-presence-lock.test.ts`: the defect, and a regression guard that a deliberate mobile gesture still re-takes.

No behavior change on any other path. No wire, schema, or IPC change.

## Why

**Reported:** *"Take back all terminals from mobile doesn't work on the orca mac app either."* The reporter later confirmed **all his terminals are local on the Mac** — no SSH, no remote hosts. iOS TestFlight 0.0.44 (2) `64de8dd637`.

This is **not** the bug #15473 fixes. That PR fixes the two *remote-desktop* branches of `reclaimTerminalForDesktop`; the local branches already release unconditionally, and I measured them doing exactly that (see Testing). The take-back itself works. It just doesn't *stay*.

**Root cause.** `reclaimTerminalForDesktop` releases the lock and then deliberately resets the display mode:

```ts
this.setMobileDisplayMode(ptyId, 'desktop')
await this.applyMobileDisplayMode(ptyId)
this.releaseDesktopTakeBack(ptyId)
// Why: a desktop-initiated reclaim is "I'm taking over right now", not a
// sticky preference. The next mobile subscribe ... must default to phone-fit again
this.setMobileDisplayMode(ptyId, 'auto')
```

That reset is correct — a take-back shouldn't permanently pin the terminal to desktop dims. But `mobileDisplayModes[ptyId] === 'desktop'` was `updateMobileViewport`'s *only* suppression mechanism, and it's gone the instant reclaim returns. The method never consulted the driver, so the very next viewport frame from the still-subscribed phone re-phone-fit the PTY and called `setDriver(ptyId, { kind: 'mobile', clientId })`.

The method's own doc comment already promised the behavior this restores: *"Forces the PTY back to desktop dims and flips the driver to `desktop`, suppressing further mobile-driven dim changes **until a mobile actor takes the floor again**."* A passive viewport measurement is not a mobile actor taking the floor.

**Why the reporter hits it with no phone interaction at all.** `mobile/src/terminal/terminal-viewport-refit.ts` exposes `scheduleForcedViewportRefit()`, which bypasses the "dims unchanged" early-out that the normal refit path has, and it is wired to two triggers that need no user action:

- iOS `AppState` resume (`shouldRecoverTerminalOnAppStateChange`) — phone wakes, sends viewport.
- every `connState` transition to `'connected'` — reconnect, sends viewport.

Both call `terminal.updateViewport`, which routes to `runtime.updateMobileViewport` for mobile clients (`src/main/runtime/rpc/methods/terminal.ts:844`). A phone sitting idle on a desk re-steals the terminal.

**Why the driver check is the right predicate.** `setDriver(ptyId, { kind: 'desktop' })` has exactly two call sites in the runtime, both inside the reclaim path (`releaseDesktopTakeBack` and the remote-reclaim branch). So `getDriver(ptyId).kind === 'desktop'` means precisely "an explicit desktop take-back is in force" — never anything incidental.

**Why the host and not the mobile client.** A mobile-side fix could not help the reporter, who is on already-shipped 0.0.44. The host is the only side that knows a take-back is in force.

**Why not `reclaimTerminalForDesktop`.** Keeping the display mode at `'desktop'` would fix this symptom but break the deliberate design decision quoted above — the next mobile subscribe would come up at desktop dims instead of phone-fit. The defect is that the *viewport* path lacks a guard, so that's where the guard goes.

## Linked Issue

No filed issue — reported directly in Discord (verbatim quote under **Why**).

Fixes #

## Visual Proof

`N/A` — no UI code changed. The visible effect is the existing take-back banner staying dismissed instead of reappearing; the banner component, its labels, and its render conditions are untouched. The state change is host-side and covered by the tests below.

## Testing

Automated, main-process suite. Both tests are new in this PR.

**RED** — before the fix, on the commit's parent:

```
$ npx vitest run --config config/vitest.config.ts src/main/runtime/mobile-presence-lock.test.ts -t 'passive viewport reports'

 ❯ src/main/runtime/mobile-presence-lock.test.ts (42 tests | 1 failed | 40 skipped) 26ms
     × a still-subscribed phone reporting its viewport does not undo a desktop take-back 14ms

 FAIL  ... > a still-subscribed phone reporting its viewport does not undo a desktop take-back
AssertionError: expected { updated: true, applied: true } to deeply equal { updated: true, applied: false }

- Expected
+ Received

  {
-   "applied": false,
+   "applied": true,
    "updated": true,
  }

 Test Files  1 failed (1)
      Tests  1 failed | 1 passed | 40 skipped (42)
```

The first assertion is the one that trips, so the failure output stops there. The measured post-state before the fix, from the scratch probe that found this:

```
afterReclaim: { driver: {kind:'desktop'}, size: {cols:150, rows:40} }
upd:          { applied: true, updated: true }
driver:       { clientId: 'phone-A', kind: 'mobile' }     <- lock re-taken
size:         { cols: 40, rows: 20 }                      <- re-phone-fit
driverEvents: [ mobile(phone-A), desktop, mobile(phone-A) ]
```

The second new test — the deliberate-gesture regression guard — passes both before and after, by design.

**GREEN** — after the fix:

```
$ npx vitest run --config config/vitest.config.ts src/main/runtime/mobile-presence-lock.test.ts

 Test Files  1 passed (1)
      Tests  42 passed (42)
```

**Adjacent suites** — every other suite that exercises `updateMobileViewport` or `reclaimTerminalForDesktop`:

```
$ npx vitest run --config config/vitest.config.ts \
    src/main/runtime/mobile-subscribe-integration.test.ts \
    src/main/runtime/rpc/terminal-multiplex-output-pause-and-viewport.test.ts \
    src/main/runtime/rpc/terminal-geometry-stale-handle.test.ts \
    src/main/runtime/rpc/terminal-multiplex-input-write-rejection.test.ts \
    src/main/runtime/rpc/terminal-subscribe-buffer.test.ts \
    src/main/runtime/rpc/terminal-output-batching.test.ts \
    src/main/runtime/rpc/terminal-provider-snapshot-sequence.test.ts \
    src/main/runtime/rpc/terminal-send.test.ts

 Test Files  8 passed (8)
      Tests  111 passed | 2 skipped (113)
```

Also verified: `npx oxlint` clean on both changed files, `npx oxfmt` applied.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Not manually tested end-to-end — reproducing the trigger needs a paired iOS device backgrounded and resumed, which I don't have. The reproduction was driven through the runtime's real entry points (`handleMobileSubscribe` → `reclaimTerminalForDesktop` → `updateMobileViewport`), and the production trigger was traced to the two `scheduleForcedViewportRefit()` call sites cited above rather than assumed.

## AI Disclosure

<!-- DO NOT FILL IN IF YOU ARE STABLYAI TEAM MEMBER (INTERNAL CONTRIBUTOR), IGNORE SECTION: -->

## Review

**Security** — no new inputs, no privilege or trust-boundary change. Strictly reduces what a mobile client can do to a PTY it doesn't hold the floor on.

**Cross-platform (Linux / Windows / macOS)** — pure runtime state logic, no paths, shells, or platform APIs. Identical on all three.

**Remote SSH** — the guard sits in the local-runtime method. Remote-desktop viewers go through `updateRemoteDesktopViewer` / `refreshRemoteDesktopViewer`, a different branch of the same RPC dispatcher; untouched. A remote host running this code gets the same fix for phones paired to it.

**Mobile** — the response shape is unchanged: `{ updated: true, applied: false }` is exactly what the existing desktop-display-mode branch already returns, so shipped clients (including the reporter's 0.0.44) already handle it. `isTerminalUpdateViewportUpdated` is true → the client calls `rpc.updateTerminalSubscriptionViewport` and returns; `applied: false` → it skips `ref.reflow` and does not resubscribe. The phone stays connected and keeps rendering at the terminal's desktop dims, same as when a user has explicitly set desktop display mode. Typing on the phone, switching display mode, or re-opening the session all still take the floor back immediately — that path is `mobileTookFloor`, which handles `prev.kind === 'desktop'` explicitly and is pinned by the second new test.

**Backwards compatibility** — no wire change, so no capability negotiation needed. Old client + new host: fixed. New client + old host: unchanged (the bug persists, as before). Mixed versions in either direction are safe.

**Performance** — one `Map.get` on a path that previously did a full `enqueueLayout` round-trip. Strictly cheaper, and only on a path that shouldn't have been doing work at all.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Two adjacent issues found while tracing this, **deliberately not folded in** — each is a separate defect and deserves its own PR:

1. `restoreTerminalFitsToDesktop` (`src/renderer/src/components/terminal-pane/terminal-fit-restore.ts`) computes one `deadlineAt` for the whole batch and runs at concurrency 8. With enough held PTYs, later items hit `timeoutMs === 0` and return `false` **without ever issuing the IPC** — a silent partial "Take back all".
2. `reclaimTerminalForDesktop` branch 3 clears `pendingRestoreTimers` but not `pendingSoftLeavers`, so a soft-leave timer can still fire `setDriver(idle)` 250ms after a take-back. Cosmetically harmless today (both `desktop` and `idle` are non-mobile, so no banner), but it silently drops the take-back marker this PR now depends on.

Does not touch #15473, #15355, or #15519.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Ran targeted `oxlint` + `oxfmt` + the affected vitest suites locally; full typecheck/build left to CI.

## Author

- X / Twitter: @BrennanKB5
