### PR TITLE
fix(workspaces): settle an orca.yaml trust prompt when the modal slot is taken

### DIFF
--- a/src/renderer/src/lib/ensure-hooks-confirmed.ts
+++ b/src/renderer/src/lib/ensure-hooks-confirmed.ts
@@ -129,6 +129,14 @@ async function confirmScriptContent(
   const previouslyApproved = Boolean(existingHash)
 
   return new Promise<'run' | 'skip'>((resolve) => {
+    let settled = false
+    const settle = (decision: 'run' | 'skip'): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      resolve(decision)
+    }
     state.openModal('confirm-orca-yaml-hooks', {
       repoId,
       repoName,
@@ -136,10 +144,9 @@ async function confirmScriptContent(
       scriptContent,
       contentHash,
       previouslyApproved,
-      onResolve: (decision: 'run' | 'skip') => resolve(decision),
-      // Why: the modal slot holds one entry; losing it must not strand the
-      // caller awaiting this decision. Dismissal is the same as declining.
-      [MODAL_DISMISSED_KEY]: () => resolve('skip')
+      onResolve: settle,
+      // Why: eviction must fail closed without stranding the singleton trust queue.
+      [MODAL_DISMISSED_KEY]: () => settle('skip')
     })
   })
 }

--- a/src/renderer/src/lib/ensure-hooks-confirmed.ts
+++ b/src/renderer/src/lib/ensure-hooks-confirmed.ts
@@ -8,6 +8,7 @@ import {
   type IssueCommandReadResult
 } from '@/runtime/runtime-hooks-client'
 import { getRuntimeEnvironmentIdForRepo } from './repo-runtime-owner'
+import { MODAL_DISMISSED_KEY } from '@/store/slices/modal-slot-dismissal'
 import {
   getRepoExecutionHostId,
   parseExecutionHostId,
@@ -135,7 +136,10 @@ async function confirmScriptContent(
       scriptContent,
       contentHash,
       previouslyApproved,
-      onResolve: (decision: 'run' | 'skip') => resolve(decision)
+      onResolve: (decision: 'run' | 'skip') => resolve(decision),
+      // Why: the modal slot holds one entry; losing it must not strand the
+      // caller awaiting this decision. Dismissal is the same as declining.
+      [MODAL_DISMISSED_KEY]: () => resolve('skip')
     })
   })
 }

--- a/src/renderer/src/lib/orca-yaml-trust-prompt-slot-eviction.test.ts
+++ b/src/renderer/src/lib/orca-yaml-trust-prompt-slot-eviction.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { StoreApi } from 'zustand/vanilla'
+import type { AppState } from '@/store/types'
+import { createUIStore } from '@/store/slices/ui-slice-test-harness'
+import { __resetTrustPromptChainForTests, ensureHooksConfirmed } from './ensure-hooks-confirmed'
+import {
+  createCompatibleRuntimeStatusResponseIfNeeded,
+  type RuntimeEnvironmentCallRequest
+} from '@/runtime/runtime-compatibility-test-fixture'
+import { clearRuntimeCompatibilityCacheForTests } from '@/runtime/runtime-rpc-client'
+
+const hooksCheckMock = vi.fn()
+const readIssueCommandMock = vi.fn()
+const runtimeEnvironmentTransportCallMock = vi.fn()
+
+// Why: the real UI slice owns the single modal slot, so the eviction under test
+// has to come from it — a hand-rolled openModal double would decide the outcome.
+function createStateBackedByRealModalSlot(): {
+  store: StoreApi<AppState>
+  state: AppState
+} {
+  const store = createUIStore()
+  store.setState({
+    repos: [{ id: 'repo-1', displayName: 'Repo One' }],
+    trustedOrcaHooks: {}
+  } as unknown as Partial<AppState>)
+  return { store, state: store.getState() }
+}
+
+async function settleOrReport<T>(promise: Promise<T>): Promise<T | 'never-settled'> {
+  return Promise.race([
+    promise,
+    new Promise<'never-settled'>((resolve) => setTimeout(() => resolve('never-settled'), 100))
+  ])
+}
+
+describe('orca.yaml trust prompt evicted from the modal slot', () => {
+  beforeEach(() => {
+    hooksCheckMock.mockReset()
+    readIssueCommandMock.mockReset()
+    runtimeEnvironmentTransportCallMock.mockReset()
+    runtimeEnvironmentTransportCallMock.mockImplementation((args: RuntimeEnvironmentCallRequest) =>
+      createCompatibleRuntimeStatusResponseIfNeeded(args)
+    )
+    clearRuntimeCompatibilityCacheForTests()
+    vi.stubGlobal('window', {
+      api: {
+        hooks: { check: hooksCheckMock, readIssueCommand: readIssueCommandMock },
+        runtimeEnvironments: { call: runtimeEnvironmentTransportCallMock }
+      }
+    })
+    __resetTrustPromptChainForTests()
+    hooksCheckMock.mockResolvedValue({
+      hasHooks: true,
+      hooks: { scripts: { setup: 'pnpm install' } },
+      mayNeedUpdate: false
+    })
+  })
+
+  it('resolves the pending decision as skip when another modal takes the slot', async () => {
+    const { store, state } = createStateBackedByRealModalSlot()
+
+    const decision = ensureHooksConfirmed(state, 'repo-1', 'setup')
+    await vi.waitFor(() => expect(store.getState().activeModal).toBe('confirm-orca-yaml-hooks'))
+
+    store.getState().openModal('worktree-palette')
+
+    await expect(settleOrReport(decision)).resolves.toBe('skip')
+  })
+
+  it('resolves the pending decision as skip when the slot is closed outright', async () => {
+    const { store, state } = createStateBackedByRealModalSlot()
+
+    const decision = ensureHooksConfirmed(state, 'repo-1', 'setup')
+    await vi.waitFor(() => expect(store.getState().activeModal).toBe('confirm-orca-yaml-hooks'))
+
+    store.getState().closeModal()
+
+    await expect(settleOrReport(decision)).resolves.toBe('skip')
+  })
+
+  it('keeps later trust prompts working after one is evicted', async () => {
+    const { store, state } = createStateBackedByRealModalSlot()
+
+    const evicted = ensureHooksConfirmed(state, 'repo-1', 'setup')
+    await vi.waitFor(() => expect(store.getState().activeModal).toBe('confirm-orca-yaml-hooks'))
+    store.getState().openModal('worktree-palette')
+    await settleOrReport(evicted)
+
+    const next = ensureHooksConfirmed(state, 'repo-1', 'setup')
+    await vi.waitFor(() => expect(store.getState().activeModal).toBe('confirm-orca-yaml-hooks'))
+    const onResolve = store.getState().modalData.onResolve as (d: 'run' | 'skip') => void
+    onResolve('run')
+
+    await expect(settleOrReport(next)).resolves.toBe('run')
+  })
+
+  it('leaves the answered decision alone when the dialog closes the slot itself', async () => {
+    const { store, state } = createStateBackedByRealModalSlot()
+
+    const decision = ensureHooksConfirmed(state, 'repo-1', 'setup')
+    await vi.waitFor(() => expect(store.getState().activeModal).toBe('confirm-orca-yaml-hooks'))
+
+    // Mirrors OrcaYamlTrustDialog: resolve first, then vacate the slot.
+    ;(store.getState().modalData.onResolve as (d: 'run' | 'skip') => void)('run')
+    store.getState().closeModal()
+
+    await expect(settleOrReport(decision)).resolves.toBe('run')
+  })
+})

--- a/src/renderer/src/lib/orca-yaml-trust-prompt-slot-eviction.test.ts
+++ b/src/renderer/src/lib/orca-yaml-trust-prompt-slot-eviction.test.ts
@@ -13,8 +13,7 @@ const hooksCheckMock = vi.fn()
 const readIssueCommandMock = vi.fn()
 const runtimeEnvironmentTransportCallMock = vi.fn()
 
-// Why: the real UI slice owns the single modal slot, so the eviction under test
-// has to come from it — a hand-rolled openModal double would decide the outcome.
+// Why: a hand-rolled openModal double would decide the eviction outcome under test.
 function createStateBackedByRealModalSlot(): {
   store: StoreApi<AppState>
   state: AppState
@@ -59,13 +58,21 @@ describe('orca.yaml trust prompt evicted from the modal slot', () => {
 
   it('resolves the pending decision as skip when another modal takes the slot', async () => {
     const { store, state } = createStateBackedByRealModalSlot()
+    const runSetup = vi.fn()
 
     const decision = ensureHooksConfirmed(state, 'repo-1', 'setup')
     await vi.waitFor(() => expect(store.getState().activeModal).toBe('confirm-orca-yaml-hooks'))
 
     store.getState().openModal('worktree-palette')
 
-    await expect(settleOrReport(decision)).resolves.toBe('skip')
+    const result = await settleOrReport(decision)
+    if (result === 'run') {
+      runSetup()
+    }
+
+    expect(result).toBe('skip')
+    expect(runSetup).not.toHaveBeenCalled()
+    expect(store.getState().trustedOrcaHooks).toEqual({})
   })
 
   it('resolves the pending decision as skip when the slot is closed outright', async () => {
@@ -101,7 +108,7 @@ describe('orca.yaml trust prompt evicted from the modal slot', () => {
     const decision = ensureHooksConfirmed(state, 'repo-1', 'setup')
     await vi.waitFor(() => expect(store.getState().activeModal).toBe('confirm-orca-yaml-hooks'))
 
-    // Mirrors OrcaYamlTrustDialog: resolve first, then vacate the slot.
+    // Mirrors the trust dialog: resolve first, then vacate the slot.
     ;(store.getState().modalData.onResolve as (d: 'run' | 'skip') => void)('run')
     store.getState().closeModal()
 

--- a/src/renderer/src/store/slices/modal-slot-dismissal.ts
+++ b/src/renderer/src/store/slices/modal-slot-dismissal.ts
@@ -1,8 +1,4 @@
-/**
- * The app has one modal slot, so opening a modal evicts whatever held it. A modal
- * that owns an unsettled promise (a trust prompt awaiting a decision) hands over
- * this callback so eviction settles it instead of stranding the awaiting caller.
- */
+// Modal owners with pending work use this hook to settle when the singleton slot evicts them.
 export const MODAL_DISMISSED_KEY = 'onModalDismissed'
 
 export function settleEvictedModalData(evicted: Record<string, unknown>): void {

--- a/src/renderer/src/store/slices/modal-slot-dismissal.ts
+++ b/src/renderer/src/store/slices/modal-slot-dismissal.ts
@@ -1,0 +1,13 @@
+/**
+ * The app has one modal slot, so opening a modal evicts whatever held it. A modal
+ * that owns an unsettled promise (a trust prompt awaiting a decision) hands over
+ * this callback so eviction settles it instead of stranding the awaiting caller.
+ */
+export const MODAL_DISMISSED_KEY = 'onModalDismissed'
+
+export function settleEvictedModalData(evicted: Record<string, unknown>): void {
+  const onDismissed = evicted[MODAL_DISMISSED_KEY]
+  if (typeof onDismissed === 'function') {
+    ;(onDismissed as () => void)()
+  }
+}

--- a/src/renderer/src/store/slices/ui-modal-slot-dismissal.test.ts
+++ b/src/renderer/src/store/slices/ui-modal-slot-dismissal.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createUIStore } from './ui-slice-test-harness'
+import { MODAL_DISMISSED_KEY } from './modal-slot-dismissal'
+
+function dismissalData(onDismissed: () => void): Record<string, unknown> {
+  return { [MODAL_DISMISSED_KEY]: onDismissed }
+}
+
+describe('UI modal slot dismissal', () => {
+  it('dismisses replaced and closed entries once', () => {
+    const store = createUIStore()
+    const firstDismissed = vi.fn()
+    const secondDismissed = vi.fn()
+
+    store.getState().openModal('worktree-palette', dismissalData(firstDismissed))
+    store.getState().openModal('quick-open', dismissalData(secondDismissed))
+    store.getState().closeModal()
+    store.getState().closeModal()
+
+    expect(firstDismissed).toHaveBeenCalledOnce()
+    expect(secondDismissed).toHaveBeenCalledOnce()
+  })
+
+  it('dismisses each entry across consecutive replacements', () => {
+    const store = createUIStore()
+    const firstDismissed = vi.fn()
+    const secondDismissed = vi.fn()
+    const thirdDismissed = vi.fn()
+
+    store.getState().openModal('worktree-palette', dismissalData(firstDismissed))
+    store.getState().openModal('quick-open', dismissalData(secondDismissed))
+    store.getState().openModal('add-repo', dismissalData(thirdDismissed))
+    store.getState().closeModal()
+
+    expect(firstDismissed).toHaveBeenCalledOnce()
+    expect(secondDismissed).toHaveBeenCalledOnce()
+    expect(thirdDismissed).toHaveBeenCalledOnce()
+  })
+
+  it('updates the slot before notifying the evicted entry', () => {
+    const store = createUIStore()
+    const observedModal = vi.fn(() => store.getState().activeModal)
+
+    store.getState().openModal('worktree-palette', dismissalData(observedModal))
+    store.getState().openModal('quick-open')
+
+    expect(observedModal).toHaveReturnedWith('quick-open')
+  })
+
+  it('ignores modal data without a callable dismissal hook', () => {
+    const store = createUIStore()
+
+    store.getState().openModal('worktree-palette', { [MODAL_DISMISSED_KEY]: 'invalid' })
+
+    expect(() => store.getState().openModal('quick-open')).not.toThrow()
+    expect(store.getState().activeModal).toBe('quick-open')
+  })
+
+  it('settles reentrant replacement and close paths once', () => {
+    const store = createUIStore()
+    const replacementDismissed = vi.fn()
+    const reentrantDismissed = vi.fn()
+    const firstDismissed = vi.fn(() => {
+      store.getState().openModal('quick-open', dismissalData(reentrantDismissed))
+    })
+
+    store.getState().openModal('worktree-palette', dismissalData(firstDismissed))
+    store.getState().openModal('add-repo', dismissalData(replacementDismissed))
+    store.getState().closeModal()
+
+    expect(firstDismissed).toHaveBeenCalledOnce()
+    expect(replacementDismissed).toHaveBeenCalledOnce()
+    expect(reentrantDismissed).toHaveBeenCalledOnce()
+    expect(store.getState().activeModal).toBe('none')
+  })
+
+  it('performs one bounded notification per transition under repeated replacement', () => {
+    const store = createUIStore()
+    const dismissed = new Set<number>()
+    const transitionCount = 1_000
+
+    for (let id = 0; id < transitionCount; id += 1) {
+      store.getState().openModal(
+        'worktree-palette',
+        dismissalData(() => {
+          expect(dismissed.has(id)).toBe(false)
+          dismissed.add(id)
+        })
+      )
+    }
+    store.getState().closeModal()
+
+    expect(dismissed.size).toBe(transitionCount)
+    expect(store.getState().modalData).toEqual({})
+  })
+})

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -2,6 +2,7 @@
 import type { StateCreator } from 'zustand'
 import type { AppState } from '../types'
 import { normalizeRightSidebarRoute } from '../right-sidebar-route'
+import { settleEvictedModalData } from './modal-slot-dismissal'
 import {
   findPrevLiveNonTaskStackHistoryIndex,
   findPrevLiveWorktreeHistoryIndex
@@ -1621,12 +1622,18 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
     if (modal === 'add-repo' || modal === 'create-worktree') {
       get().recordFeatureInteraction?.('workspace-creation')
     }
+    const evicted = get().modalData
     set({
       activeModal: modal,
       modalData: data
     })
+    settleEvictedModalData(evicted)
   },
-  closeModal: () => set({ activeModal: 'none', modalData: {} }),
+  closeModal: () => {
+    const evicted = get().modalData
+    set({ activeModal: 'none', modalData: {} })
+    settleEvictedModalData(evicted)
+  },
   featureTipsSeenIds: [],
   markFeatureTipsSeen: (ids) =>
     set((s) => {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​213 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​213 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​29 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​27 |

<!-- /orca-pr-loc -->

## ELI5

Orca can only show one dialog at a time. When you create a workspace in a repo whose `orca.yaml` has a setup script, Orca pauses mid-create to ask "run setup script from repo?" — and the code that started the create is sitting there waiting for your answer.

If anything else opens a dialog at that moment (a menu accelerator, the worktree palette, a new-workspace shortcut), that question is thrown away without ever being answered. Nobody tells the waiting code, so it waits forever. Worse, trust prompts are queued one-at-a-time behind a shared lock, so the discarded question also blocks *every* future one: for the rest of that app session, clicking Create workspace does nothing at all — no dialog, no error, no toast, no timeout. Force-quitting is the only way out.

This PR makes the modal slot tell an evicted dialog it was dismissed, so the waiting code gets an answer ("skip") instead of waiting forever.

## What Changed

- `src/renderer/src/store/slices/modal-slot-dismissal.ts` (new): `MODAL_DISMISSED_KEY` + `settleEvictedModalData()`. Modal data can carry an `onModalDismissed` callback for the case where the entry owns an unsettled promise.
- `src/renderer/src/store/slices/ui.ts`: `openModal` and `closeModal` now call `settleEvictedModalData()` on the outgoing `modalData` after the slot is updated.
- `src/renderer/src/lib/ensure-hooks-confirmed.ts`: `confirmScriptContent` supplies `onModalDismissed: () => resolve('skip')` alongside the existing `onResolve`. `'skip'` is exactly what dismissing the dialog (Escape / overlay click / "Don't run") already resolves to, so nothing new is granted or denied.
- `src/renderer/src/lib/orca-yaml-trust-prompt-slot-eviction.test.ts` (new): four tests driven through the **real** UI slice, not a hand-rolled `openModal` double.

No behavior change when the user actually answers the prompt.

## Why

`useComposerState.submitQuick` awaits `ensureHooksConfirmed(...)`, and every awaited step goes through `settleComposerSubmit`, which **awaits** rather than races cancellation — so a step that never settles hangs the whole submit and its `finally { setCreating(false) }` never runs.

Exactly one awaited step is a user-decision promise:

```ts
// ensure-hooks-confirmed.ts
return new Promise<'run' | 'skip'>((resolve) => {
  state.openModal('confirm-orca-yaml-hooks', { ..., onResolve: (d) => resolve(d) })
})
```

`OrcaYamlTrustDialog` renders only while `activeModal === 'confirm-orca-yaml-hooks'`. A controlled `open` change does not fire Radix's `onOpenChange`, so when another `openModal` takes the slot the dialog unmounts silently and `onResolve` is dropped.

That would be bad on its own, but trust prompts are serialized on a module-global chain:

```ts
let trustPromptChain: Promise<unknown> = Promise.resolve()
function enqueueTrustPrompt<T>(task: () => Promise<T>): Promise<T> {
  const next = trustPromptChain.then(task, task)
  trustPromptChain = next.catch(() => undefined)
  return next
}
```

One dropped resolver wedges that chain permanently, so every later `ensureHooksConfirmed` / `confirmRuntimeIssueCommandRead` never runs — that is `useComposerState` (create), `remove-worktree.ts` (workspace removal), `AutomationsPage.tsx`, and `launch-work-item-direct.ts`. App-wide, until restart.

Eviction is reachable from ordinary UI: native menu accelerators fire while a renderer modal is up, and none of the IPC handlers that open modals guard against replacing a pending prompt — `onToggleWorktreePalette` (`useIpcEvents.ts:1348`) is unconditional, and `openNewWorkspaceFromShortcut` (`:509`) guards only against the composer.

Fixing this in the modal slot rather than in the trust dialog is deliberate: the slot is what does the evicting, and it covers `closeModal()` too.

## Linked Issue

No GitHub issue — reported on Discord: *"The Tasks -> Create workspace crashes the app."*, clarified by the reporter as *"The button just doesn't work then the ui locks up and the only way to get out is to force close the app."*

Fixes #

## Visual Proof

Both captured on one isolated dev instance (`ORCA_DEV_USER_DATA_PATH` + `ORCA_DEV_INSTANCE_KEY`, own CDP port, fixture repo with an `orca.yaml` setup script), driven over Playwright/CDP. Same sequence in both: open composer → Create → trust prompt appears → another modal takes the slot → open composer → Create again.

**BEFORE** — second Create: spinner on a permanently disabled button, no prompt, no error, no timeout. This is the reported "button does nothing".

![before](https://github.com/user-attachments/assets/12213288-9984-45b7-bb85-179389712779)

**AFTER** — second Create: the trust prompt comes back and creation proceeds. (Sidebar shows the workspaces the earlier attempts now successfully created.)

![after](https://github.com/user-attachments/assets/0d201a2b-767e-4f6c-903a-02d29970a550)

## Testing

**Automated — RED before the fix** (`npx vitest run --config config/vitest.config.ts src/renderer/src/lib/orca-yaml-trust-prompt-slot-eviction.test.ts`, source changes reverted, new test kept):

```
 ❯ src/renderer/src/lib/orca-yaml-trust-prompt-slot-eviction.test.ts (4 tests | 3 failed)
   × resolves the pending decision as skip when another modal takes the slot
   × resolves the pending decision as skip when the slot is closed outright
   × keeps later trust prompts working after one is evicted

 FAIL > resolves the pending decision as skip when another modal takes the slot
 AssertionError: expected 'never-settled' to be 'skip'
   Expected: "skip"
   Received: "never-settled"

 FAIL > resolves the pending decision as skip when the slot is closed outright
 AssertionError: expected 'never-settled' to be 'skip'
   Expected: "skip"
   Received: "never-settled"

 FAIL > keeps later trust prompts working after one is evicted
 AssertionError: expected 'worktree-palette' to be 'confirm-orca-yaml-hooks'
   Expected: "confirm-orca-yaml-hooks"
   Received: "worktree-palette"

 Test Files  1 failed (1)
      Tests  3 failed | 1 passed (4)
```

The one passing test is the guard that the normal answer path is untouched.

**GREEN after the fix:**

```
 ✓ resolves the pending decision as skip when another modal takes the slot 55ms
 ✓ resolves the pending decision as skip when the slot is closed outright 51ms
 ✓ keeps later trust prompts working after one is evicted 102ms
 ✓ leaves the answered decision alone when the dialog closes the slot itself 50ms

 Test Files  1 passed (1)
      Tests  4 passed (4)
```

**Regression sweep** — every store slice suite, since the change is in `openModal`/`closeModal`:

```
npx vitest run --config config/vitest.config.ts --no-file-parallelism src/renderer/src/store/slices
 Test Files  266 passed (266)
      Tests  2671 passed (2671)
```

Plus everything that consumes the modal slot or the trust prompt:

```
npx vitest run --config config/vitest.config.ts --no-file-parallelism \
  src/renderer/src/lib src/renderer/src/components/sidebar src/renderer/src/hooks
 Test Files  815 passed (815)
      Tests  7252 passed | 1 skipped (7253)
```

**Manual** — macOS, local (non-SSH) workspace, dev build, before/after on the same instance via HMR. See Visual Proof.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Claude Opus 5 via Claude Code.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

**Security** — the resolved-on-eviction value is `'skip'`, i.e. do **not** run the repo's `orca.yaml` script. Fail-closed, and identical to what Escape / overlay-click / "Don't run" already produce. Nothing new is trusted, and no trust is persisted on this path. `confirmIssueCommandReadResult` is unchanged.

**Cross-platform (macOS / Linux / Windows)** — renderer-only store logic; no paths, shells, or accelerators. The bug is easiest to hit on macOS because native menu accelerators fire while a renderer modal is up, but the code path is identical everywhere.

**Remote SSH** — unchanged. `ensureHooksConfirmed` still reads hooks through `checkRuntimeHooks` / `readRuntimeIssueCommand` with the same host routing; only the *unanswered* case changes, and previously it could not complete at all on any host.

**Mobile** — not affected. `mobile/` has no `ensureHooksConfirmed` and no `new Promise` prompt in its create path; `mobile/app/h/[hostId]/tasks.tsx` awaits `worktree.create` under `WORKTREE_CREATE_TIMEOUT_MS` with its own `finally { setCreatingKey(null) }`.

**Backwards compatibility** — `onModalDismissed` is optional additive modal data; modals that do not set it see no change. No wire, IPC, or persisted-state change, so no client/host version coupling.

**Performance** — one property read plus an optional call per modal transition.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @BrennanKB5
