### PR TITLE
feat(browser): add a real profile-reset operation, wired to nothing

### DIFF
--- a/src/main/browser/browser-profile-reset.test.ts
+++ b/src/main/browser/browser-profile-reset.test.ts
@@ -10,11 +10,12 @@ vi.mock('electron', () => ({
 import { findPartitionWebContents, resetBrowserProfilePartition } from './browser-profile-reset'
 import { acquireCookieMutationLock, withCookieMutationLock } from './browser-cookie-import-clear'
 
-type SessionMock = Session & Mocked<Pick<Session, 'clearData'>>
+type SessionMock = Session & Mocked<Pick<Session, 'clearData' | 'clearStorageData'>>
 
 function makeSession(overrides: Partial<SessionMock> = {}): SessionMock {
   return {
     clearData: vi.fn<Session['clearData']>(async () => undefined),
+    clearStorageData: vi.fn<Session['clearStorageData']>(async () => undefined),
     ...overrides
   } as SessionMock
 }
@@ -33,7 +34,7 @@ describe('resetBrowserProfilePartition', () => {
     getAllWebContentsMock.mockReturnValue([])
   })
 
-  it('clears the whole partition, not a filtered subset', async () => {
+  it('rotates media-device IDs and clears the whole partition', async () => {
     const targetSession = makeSession()
     await resetBrowserProfilePartition({
       targetSession,
@@ -41,6 +42,8 @@ describe('resetBrowserProfilePartition', () => {
       clearPendingCookieImport: vi.fn(),
       clearImportedSource: vi.fn()
     })
+    expect(targetSession.clearStorageData).toHaveBeenCalledTimes(1)
+    expect(targetSession.clearStorageData).toHaveBeenCalledWith({ storages: ['cookies'] })
     expect(targetSession.clearData).toHaveBeenCalledTimes(1)
     expect(targetSession.clearData).toHaveBeenCalledWith()
   })
@@ -61,6 +64,7 @@ describe('resetBrowserProfilePartition', () => {
     const order: string[] = []
     const clearImportedSource = vi.fn(() => void order.push('source'))
     const targetSession = makeSession({
+      clearStorageData: vi.fn(async () => void order.push('clearStorageData')),
       clearData: vi.fn(async () => void order.push('clearData'))
     })
     await resetBrowserProfilePartition({
@@ -70,7 +74,7 @@ describe('resetBrowserProfilePartition', () => {
       clearImportedSource
     })
     expect(clearImportedSource).toHaveBeenCalledTimes(1)
-    expect(order).toEqual(['source', 'staged', 'clearData'])
+    expect(order).toEqual(['source', 'staged', 'clearStorageData', 'clearData'])
   })
 
   it('reloads every live context in the partition after clearing', async () => {
@@ -130,6 +134,26 @@ describe('resetBrowserProfilePartition', () => {
       })
     ).resolves.toBeUndefined()
     expect(healthy.reload).toHaveBeenCalledTimes(1)
+  })
+
+  it('reloads live contexts after a partially failed clear', async () => {
+    const targetSession = makeSession({
+      clearData: vi.fn(async () => {
+        throw new Error('clear failed')
+      })
+    })
+    const live = makeContents(targetSession)
+    getAllWebContentsMock.mockReturnValue([live])
+
+    await expect(
+      resetBrowserProfilePartition({
+        targetSession,
+        partition: 'persist:orca-browser',
+        clearPendingCookieImport: vi.fn(),
+        clearImportedSource: vi.fn()
+      })
+    ).rejects.toThrow('clear failed')
+    expect(live.reload).toHaveBeenCalledTimes(1)
   })
 
   it('waits for the session mutation lock and releases it after failure', async () => {

--- a/src/main/browser/browser-profile-reset.test.ts
+++ b/src/main/browser/browser-profile-reset.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Mocked } from 'vitest'
+import type { Session } from 'electron'
+
+const getAllWebContentsMock = vi.fn()
+vi.mock('electron', () => ({
+  webContents: { getAllWebContents: () => getAllWebContentsMock() }
+}))
+
+import { findPartitionWebContents, resetBrowserProfilePartition } from './browser-profile-reset'
+import { acquireCookieMutationLock, withCookieMutationLock } from './browser-cookie-import-clear'
+
+type SessionMock = Session & Mocked<Pick<Session, 'clearData'>>
+
+function makeSession(overrides: Partial<SessionMock> = {}): SessionMock {
+  return {
+    clearData: vi.fn<Session['clearData']>(async () => undefined),
+    ...overrides
+  } as SessionMock
+}
+
+function makeContents(session: unknown, opts: { destroyed?: boolean; onReload?: () => void } = {}) {
+  return {
+    session,
+    isDestroyed: () => opts.destroyed === true,
+    reload: vi.fn(() => opts.onReload?.())
+  }
+}
+
+describe('resetBrowserProfilePartition', () => {
+  beforeEach(() => {
+    getAllWebContentsMock.mockReset()
+    getAllWebContentsMock.mockReturnValue([])
+  })
+
+  it('clears the whole partition, not a filtered subset', async () => {
+    const targetSession = makeSession()
+    await resetBrowserProfilePartition({
+      targetSession,
+      partition: 'persist:orca-browser',
+      clearPendingCookieImport: vi.fn(),
+      clearImportedSource: vi.fn()
+    })
+    expect(targetSession.clearData).toHaveBeenCalledTimes(1)
+    expect(targetSession.clearData).toHaveBeenCalledWith()
+  })
+
+  it('forwards non-default partitions to staged-import deletion', async () => {
+    const partition = 'persist:orca-browser-session-imported'
+    const clearPendingCookieImport = vi.fn()
+    await resetBrowserProfilePartition({
+      targetSession: makeSession(),
+      partition,
+      clearPendingCookieImport,
+      clearImportedSource: vi.fn()
+    })
+    expect(clearPendingCookieImport).toHaveBeenCalledWith(partition)
+  })
+
+  it('clears the imported-source badge before the data is gone', async () => {
+    const order: string[] = []
+    const clearImportedSource = vi.fn(() => void order.push('source'))
+    const targetSession = makeSession({
+      clearData: vi.fn(async () => void order.push('clearData'))
+    })
+    await resetBrowserProfilePartition({
+      targetSession,
+      partition: 'persist:orca-browser',
+      clearPendingCookieImport: vi.fn(() => void order.push('staged')),
+      clearImportedSource
+    })
+    expect(clearImportedSource).toHaveBeenCalledTimes(1)
+    expect(order).toEqual(['source', 'staged', 'clearData'])
+  })
+
+  it('reloads every live context in the partition after clearing', async () => {
+    const order: string[] = []
+    const targetSession = makeSession({
+      clearData: vi.fn(async () => void order.push('clearData'))
+    })
+    const other = makeSession()
+    const mine = makeContents(targetSession, { onReload: () => void order.push('mine') })
+    const popup = makeContents(targetSession, { onReload: () => void order.push('popup') })
+    const offscreen = makeContents(targetSession, { onReload: () => void order.push('offscreen') })
+    const foreign = makeContents(other)
+    const dead = makeContents(targetSession, { destroyed: true })
+    getAllWebContentsMock.mockReturnValue([mine, popup, offscreen, foreign, dead])
+
+    await resetBrowserProfilePartition({
+      targetSession,
+      partition: 'persist:orca-browser',
+      clearPendingCookieImport: vi.fn(),
+      clearImportedSource: vi.fn()
+    })
+
+    expect(mine.reload).toHaveBeenCalledTimes(1)
+    expect(popup.reload).toHaveBeenCalledTimes(1)
+    expect(offscreen.reload).toHaveBeenCalledTimes(1)
+    expect(foreign.reload).not.toHaveBeenCalled()
+    expect(dead.reload).not.toHaveBeenCalled()
+    expect(order).toEqual(['clearData', 'mine', 'popup', 'offscreen'])
+  })
+
+  it('selects contexts by session identity so popups and offscreen guests are included', () => {
+    const targetSession = makeSession()
+    const other = makeSession()
+    const a = makeContents(targetSession)
+    const b = makeContents(other)
+    getAllWebContentsMock.mockReturnValue([a, b])
+    expect(findPartitionWebContents(targetSession)).toEqual([a])
+  })
+
+  it('survives a context that dies mid-reset', async () => {
+    const targetSession = makeSession()
+    const exploding = {
+      session: targetSession,
+      isDestroyed: () => false,
+      reload: vi.fn(() => {
+        throw new Error('destroyed')
+      })
+    }
+    const healthy = makeContents(targetSession)
+    getAllWebContentsMock.mockReturnValue([exploding, healthy])
+    await expect(
+      resetBrowserProfilePartition({
+        targetSession,
+        partition: 'persist:orca-browser',
+        clearPendingCookieImport: vi.fn(),
+        clearImportedSource: vi.fn()
+      })
+    ).resolves.toBeUndefined()
+    expect(healthy.reload).toHaveBeenCalledTimes(1)
+  })
+
+  it('waits for the session mutation lock and releases it after failure', async () => {
+    const targetSession = makeSession({
+      clearData: vi.fn(async () => {
+        throw new Error('clear failed')
+      })
+    })
+    const clearImportedSource = vi.fn()
+    const releaseImport = await acquireCookieMutationLock(targetSession)
+    const reset = resetBrowserProfilePartition({
+      targetSession,
+      partition: 'persist:orca-browser',
+      clearPendingCookieImport: vi.fn(),
+      clearImportedSource
+    })
+
+    await Promise.resolve()
+    expect(clearImportedSource).not.toHaveBeenCalled()
+    releaseImport()
+    await expect(reset).rejects.toThrow('clear failed')
+    await expect(withCookieMutationLock(targetSession, async () => 'released')).resolves.toBe(
+      'released'
+    )
+  })
+})

--- a/src/main/browser/browser-profile-reset.ts
+++ b/src/main/browser/browser-profile-reset.ts
@@ -1,0 +1,43 @@
+import { webContents } from 'electron'
+import type { Session, WebContents } from 'electron'
+
+import { withCookieMutationLock } from './browser-cookie-import-clear'
+
+export type BrowserProfileResetDependencies = {
+  targetSession: Session
+  partition: string
+  clearPendingCookieImport: (partition: string) => void
+  clearImportedSource: () => void
+}
+
+// Electron's global list includes popups and offscreen guests omitted by Orca's tab registry.
+export function findPartitionWebContents(targetSession: Session): WebContents[] {
+  return webContents
+    .getAllWebContents()
+    .filter((contents) => !contents.isDestroyed() && contents.session === targetSession)
+}
+
+function reloadPartitionContexts(targetSession: Session): void {
+  for (const contents of findPartitionWebContents(targetSession)) {
+    try {
+      contents.reload()
+    } catch {
+      // A context that dies between enumeration and reload needs no reload.
+    }
+  }
+}
+
+/** Resets one session partition while serializing against cookie import mutations. */
+export async function resetBrowserProfilePartition(
+  deps: BrowserProfileResetDependencies
+): Promise<void> {
+  const { targetSession, partition, clearPendingCookieImport, clearImportedSource } = deps
+  await withCookieMutationLock(targetSession, async () => {
+    // Clear metadata first so a partial reset never advertises an import whose data may be gone.
+    clearImportedSource()
+    clearPendingCookieImport(partition)
+    // clearStorageData bypasses trust-token, bounce-tracking, and network-history removal.
+    await targetSession.clearData()
+    reloadPartitionContexts(targetSession)
+  })
+}

--- a/src/main/browser/browser-profile-reset.ts
+++ b/src/main/browser/browser-profile-reset.ts
@@ -36,8 +36,14 @@ export async function resetBrowserProfilePartition(
     // Clear metadata first so a partial reset never advertises an import whose data may be gone.
     clearImportedSource()
     clearPendingCookieImport(partition)
-    // clearStorageData bypasses trust-token, bounce-tracking, and network-history removal.
-    await targetSession.clearData()
-    reloadPartitionContexts(targetSession)
+    try {
+      // Electron only rotates its persisted media-device ID salt on a cookie storage clear.
+      await targetSession.clearStorageData({ storages: ['cookies'] })
+      // BrowsingDataRemover additionally reaches trust tokens, bounce tracking, and network history.
+      await targetSession.clearData()
+    } finally {
+      // A rejected removal can still leave the partition partially cleared.
+      reloadPartitionContexts(targetSession)
+    }
   })
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​182 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​182 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​49 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​49 |

<!-- /orca-pr-loc -->

## ELI5

"Clear browser profile" only deleted cookies. Everything else a site can store stayed behind, so the documented clear-and-retry workaround could not reset the affected profile. This PR adds the complete internal reset operation; **nothing calls it yet**, on purpose.

## The defect

`clearDefaultSessionCookies` calls `clearStorageData({ storages: ['cookies'] })`. A measured profile retained 445MB after that cookie-only clear, including Local Storage, IndexedDB, Service Workers, Session Storage, Trust Tokens, DIPS, Shared Storage, and Network Persistent State.

This is separate from Google sign-in. That redirect defect was fixed by #15221.

## Why this is wired to nothing

A reset is destructive and irreversible. This PR adds no UI, IPC verb, RPC method, preload surface, or existing-call-site change. `resetBrowserProfilePartition` appears only in its module and tests, so this branch is a user-visible no-op. Exposure and confirmation belong in the follow-up PR.

## What the operation does

**Rotates Electron's media-device identity before the full clear.** Electron only rotates its persisted media-device ID salt when `clearStorageData()` includes cookies, so the reset first calls `clearStorageData({ storages: ['cookies'] })`.

**Uses `clearData()` without a filter for the full reset.** Electron 43's unfiltered `clearStorageData()` clears Chromium's full StoragePartition mask, including Session Storage and Shared Storage. It still bypasses Chromium's BrowsingDataRemover, so it does not reach Trust Tokens, DIPS/BTM records, or persisted network history. `clearData()` enters BrowsingDataRemover with every real data type enabled, which covers those surfaces and delegates the ordinary partition storage clear too.

**Deletes staged import files.** `clearPendingCookieImport` removes both metadata and the staged SQLite database plus its sidecars, so startup cannot replay an old import over the reset partition.

**Clears imported-source metadata before storage.** A partial reset must not advertise an import whose data may already be gone.

**Reloads every live context in the partition after deletion or a partial-clear failure.** Contexts are enumerated from Electron's global WebContents list and filtered by Session identity. This includes popups and offscreen guests that Orca's tab registry omits, while leaving other partitions untouched. Reload runs in `finally` because a rejected browsing-data clear may already have removed some state.

**Serializes with cookie imports.** The body uses the existing per-Session mutation lock. Electron returns one Session wrapper per partition, so native imports, file imports, and resets share the same owner. The lock releases through `finally`, including when deletion rejects.

## Known gap before exposure

The import source-badge write still occurs outside the import mutation lock at three call sites, after the import function returns. A reset could land in that narrow window and then have the badge rewritten. Because this operation is unreachable here, closing that call-site transaction boundary remains a prerequisite of the exposure PR rather than a behavior regression in this one.

## Compatibility and scope

The operation is partition-generic, so default, isolated, and imported profiles take the same path. It contains no path, shell, platform, workspace, provider, IPC, RPC, or persisted-schema behavior; Windows, Linux, folder workspaces, git worktrees, SSH/offscreen guests, and mixed client/host versions therefore gain no new reachable behavior. The browser permission and auth-host changes in #15221, #15481, and #15542 are kept in memory and do not overlap this storage reset module.

## Testing

- 8 focused reset tests pass, covering media-device salt rotation, optionless full-data clearing, metadata/staged-file ordering, non-default partition forwarding, post-delete reload ordering, session-identity filtering, destroyed-context tolerance, partial-clear failure reload, lock serialization, and lock release after failure.
- The adjacent 8 cookie-import concurrency tests and 17 session-registry persistence tests pass: 33 focused tests total.
- Typecheck, focused formatting and lint, max-lines ratchet, and `git diff --check` pass. All 45 current CI checks pass; E2E is skipped because no E2E surface changed.
- Three deliberate mutations were caught: removing reload fails 2 tests; filtering `clearData` to cookies fails 1; moving the source clear after deletion fails 1.

Electron QA was run on `e2d70a23ef` and confirmed the intended result: browsing unchanged, the existing Session & Cookies control untouched, and no new reachable surface anywhere. Screenshots are in the QA comment below.



---

## Next steps — what follows this PR

This lands the engine. Nothing is plugged into it yet, and **the follow-up must ship all of the
below together**, because several items are preconditions for the others rather than a menu.

### 1. Close the transaction gap first — this is the blocker

The import writes its source badge **outside** the cookie mutation lock, at three call sites
(`browser-session-profile-ipc.ts` ×2, `orca-runtime-browser.ts` ×1), after `importCookiesFromFile`
has already released it. So a reset can complete, report success, and then have the imported badge
reappear when the in-flight import finishes.

The fix is to move that write inside the import's locked region so cookie work and source update are
one transaction. Until this lands, the reset is not race-safe — which is exactly why this PR is
wired to nothing rather than shipped with a button.

### 2. New IPC and RPC verbs, not a redefinition of the existing ones

The full reset must **not** ride `browser.profileClearDefaultCookies` or
`browser:session:clearDefaultCookies`. Mixed client/host versions are the normal state, and an older
client's trash control is gated on `profile.source`, labelled "Default cookies cleared.", and shows
**no confirmation dialog**. Redefining the existing verb would hand that client a full profile wipe
it cannot warn about.

Both boundaries need the new verb, or the local and remote paths disagree about what one name means.

### 3. Handle new client against old host explicitly

The new verb is simply absent on an older host. That must surface as "this host is too old to reset
the profile", **not** a silent fallback to cookie-only — telling a user the profile was reset when it
was not is worse than failing.

### 4. Then the user-facing surface

- **Enable the control unconditionally** — drop `disabled={!profile.source}`, which hides it from
  anyone who never imported.
- **Confirmation before the destructive call**, naming what is lost: signed-in sessions across every
  site in the profile, not just Google.
- **Surface failures** — the handler currently swallows them in a `catch` returning `false` and shows
  a success toast either way.
- **Fix the copy** — "Default cookies cleared." stops being true once it clears everything.

### 5. Fix the web client stub

`sessionClearDefaultCookies: () => Promise.resolve(false)` in `web-preload-api.ts` silently reports
failure on the web client. Whatever the new verb is, the web path needs a real implementation or an
honest unsupported state.

### Why this ordering

Shipping the button before items 1–3 would expose a destructive action that can be silently undone
by a concurrent import and that misbehaves against older hosts. A reset that reports success without
having reset is worse than no reset control at all — the current cookies-only clear already taught us
that, when "clear your profile and retry" was given as a workaround and did nothing.
