### PR TITLE
fix(terminal): retire agent resume records when a shell exit closes its tab

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -1808,7 +1808,7 @@ function Terminal(): React.JSX.Element | null {
   )
 
   const handlePtyExit = useCallback(
-    (tabId: string, ptyId: string) => {
+    (tabId: string, ptyId: string, opts?: { sessionLost?: boolean }) => {
       if (consumeSuppressedPtyExit(ptyId)) {
         return
       }
@@ -1816,7 +1816,13 @@ function Terminal(): React.JSX.Element | null {
       if (shouldDeferParkedPtyExitTabClose(tabId, ptyId)) {
         return
       }
-      closeTerminalTab(tabId, { reason: 'pty-exit', lifecyclePtyId: ptyId })
+      closeTerminalTab(tabId, {
+        reason: 'pty-exit',
+        lifecyclePtyId: ptyId,
+        // Why: a reconciled session loss stays resumable, but a process that exited on its own took
+        // its session with it — keep its resume record and activation respawns the closed tab.
+        retireSleepingAgentSessions: opts?.sessionLost !== true
+      })
     },
     [consumeSuppressedPtyExit]
   )
@@ -2644,7 +2650,7 @@ function Terminal(): React.JSX.Element | null {
                             isWorktreeActive={isVisible || isActivityPortalTab}
                             // Why: isolate the portaled Activity leaf so split siblings stay hidden; workspace renders pass null.
                             isolatedPaneKey={activityTerminalPortal?.paneKey ?? null}
-                            onPtyExit={(ptyId) => handlePtyExit(tab.id, ptyId)}
+                            onPtyExit={(ptyId, opts) => handlePtyExit(tab.id, ptyId, opts)}
                             onCloseTab={() => handleCloseTab(tab.id)}
                           />
                         )

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tab-lifecycle.test.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tab-lifecycle.test.tsx
@@ -319,7 +319,8 @@ describe('FloatingTerminalPanel close behavior', () => {
     expect(mocks.shouldDeferParkedPtyExitTabClose).toHaveBeenCalledWith('tab-1', 'pty-1')
     expect(mocks.closeTerminalTab).toHaveBeenCalledWith('tab-1', {
       lifecyclePtyId: 'pty-1',
-      reason: 'pty-exit'
+      reason: 'pty-exit',
+      retireSleepingAgentSessions: true
     })
     expect(mocks.closeTab).not.toHaveBeenCalled()
     expect(onOpenChange).not.toHaveBeenCalled()

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -1916,13 +1916,15 @@ export function FloatingTerminalPanel({
                         // atlas to corrupt) while hidden, and the resume on
                         // reopen rebuilds the renderer from scratch.
                         isVisible={isActive && open}
-                        onPtyExit={(ptyId) => {
+                        onPtyExit={(ptyId, ptyExitOptions) => {
                           if (shouldDeferParkedPtyExitTabClose(tab.id, ptyId)) {
                             return
                           }
                           closeTerminalTab(tab.id, {
                             reason: 'pty-exit',
-                            lifecyclePtyId: ptyId
+                            lifecyclePtyId: ptyId,
+                            // Why: a reconciled session loss stays resumable; a process that exited on its own took its session with it.
+                            retireSleepingAgentSessions: ptyExitOptions?.sessionLost !== true
                           })
                         }}
                         onCloseTab={() => closeFloatingItemConfirmed(tab.id)}

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -248,6 +248,7 @@ import {
 } from './regular-terminal-focus-ownership'
 import { useTerminalQuickCommandHosts } from '@/hooks/use-terminal-quick-command-hosts'
 import { refreshTerminalImeInputContext } from './terminal-ime-input-context-refresh'
+import type { PtyExitOptions } from './pty-connection-types'
 
 type TerminalPaneProps = {
   tabId: string
@@ -260,7 +261,7 @@ type TerminalPaneProps = {
   isolatedPaneKey?: string | null
   // Why: ephemeral one-off command terminals don't need the header's prominent split affordance (split shortcuts still work).
   showSplitButton?: boolean
-  onPtyExit: (ptyId: string) => void
+  onPtyExit: (ptyId: string, opts?: PtyExitOptions) => void
   onCloseTab: () => void
 }
 

--- a/src/renderer/src/components/terminal-pane/pty-connection-pty-exit-teardown.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-pty-exit-teardown.test.ts
@@ -356,7 +356,7 @@ describe('connectPanePty', () => {
     sendTerminalInputThroughPane(pane, 'exit\r')
     onPtyExit?.('tab-pty')
 
-    expect(deps.onPtyExitRef.current).toHaveBeenCalledWith('tab-pty')
+    expect(deps.onPtyExitRef.current).toHaveBeenCalledWith('tab-pty', { sessionLost: false })
     expect(manager.closePane).not.toHaveBeenCalled()
   })
 
@@ -375,7 +375,7 @@ describe('connectPanePty', () => {
     // No onPtySpawn call: simulates a reattach to a persisted session.
     onPtyExit?.('tab-pty')
 
-    expect(deps.onPtyExitRef.current).toHaveBeenCalledWith('tab-pty')
+    expect(deps.onPtyExitRef.current).toHaveBeenCalledWith('tab-pty', { sessionLost: false })
     expect(manager.closePane).not.toHaveBeenCalled()
   })
 
@@ -410,7 +410,7 @@ describe('connectPanePty', () => {
       'terminal-reconnected',
       'terminal-old'
     )
-    expect(deps.onPtyExitRef.current).toHaveBeenCalledWith('terminal-reconnected')
+    expect(deps.onPtyExitRef.current).toHaveBeenCalledWith('terminal-reconnected', { sessionLost: false })
     expect(manager.closePane).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/src/components/terminal-pane/pty-connection-session-liveness.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-session-liveness.test.ts
@@ -339,7 +339,7 @@ describe('connectPanePty', () => {
       // The last pane reattaches to the tab's persisted ptyId ('tab-pty').
       binding.reconcileIfSessionDead(new Set(['some-other-live']))
 
-      expect(deps.onPtyExitRef.current).toHaveBeenCalledWith('tab-pty')
+      expect(deps.onPtyExitRef.current).toHaveBeenCalledWith('tab-pty', { sessionLost: true })
       expect(manager.closePane).not.toHaveBeenCalled()
     })
 

--- a/src/renderer/src/components/terminal-pane/pty-connection-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-types.ts
@@ -13,9 +13,11 @@ import type {
   SleepingAgentLaunchConfig
 } from '../../../../shared/agent-session-resume'
 import type { TerminalKittyKeyboardModeTracker } from '../../../../shared/terminal-kitty-keyboard-mode-tracker'
-import type { PtyTransportRecoveryState } from './pty-transport-types'
+import type { PtyExitOptions, PtyTransportRecoveryState } from './pty-transport-types'
 import type { SessionOptionValue } from '../../../../shared/native-chat-session-options'
 import type { DirectSshPaneRetryAttemptId } from '@/store/slices/direct-ssh-terminal-recovery'
+
+export type { PtyExitOptions }
 
 export type PtyConnectionDeps = {
   tabId: string
@@ -63,7 +65,7 @@ export type PtyConnectionDeps = {
   restoredViewportBlankingPanesRef?: RestoredViewportBlankingPanesRef
   isActiveRef: React.RefObject<boolean>
   isVisibleRef: React.RefObject<boolean>
-  onPtyExitRef: React.RefObject<(ptyId: string) => void>
+  onPtyExitRef: React.RefObject<(ptyId: string, opts?: PtyExitOptions) => void>
   onAgentExitedRef: React.RefObject<(leafId: string) => void>
   onPtyErrorRef?: React.RefObject<(paneId: number, message: string) => void>
   onPtyRecoveryStateRef?: React.RefObject<

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -2632,7 +2632,10 @@ export function connectPanePty(
       })
     return claimKey
   }
-  const onExit = (ptyId: string, opts: { preserveRendererBinding?: boolean } = {}): void => {
+  const onExit = (
+    ptyId: string,
+    opts: { preserveRendererBinding?: boolean; sessionLost?: boolean } = {}
+  ): void => {
     if (handledExitPtyId === ptyId) {
       return
     }
@@ -2640,7 +2643,7 @@ export function connectPanePty(
       // Why: the transport emits exit once; replay it only after a verified commit so rollback keeps renderer state retryable.
       deferPtyShutdownExit(ptyId, (settlement) => {
         if (settlement === 'committed') {
-          onExit(ptyId, { preserveRendererBinding: true })
+          onExit(ptyId, { preserveRendererBinding: true, sessionLost: opts.sessionLost })
         }
       })
       return
@@ -2754,7 +2757,7 @@ export function connectPanePty(
       if (spawnedFreshPtyId === ptyId && !Number.isFinite(lastTerminalInputAt)) {
         return
       }
-      deps.onPtyExitRef.current(ptyId)
+      deps.onPtyExitRef.current(ptyId, { sessionLost: opts.sessionLost === true })
       return
     }
     if (
@@ -9349,7 +9352,7 @@ export function connectPanePty(
     ) {
       return
     }
-    onExit(currentPtyId)
+    onExit(currentPtyId, { sessionLost: true })
   }
 
   const reconcileIfSessionMissing = (
@@ -9393,7 +9396,7 @@ export function connectPanePty(
         ) {
           return
         }
-        onExit(currentPtyId)
+        onExit(currentPtyId, { sessionLost: true })
       })
       .catch(() => {})
   }

--- a/src/renderer/src/components/terminal-pane/pty-transport-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-types.ts
@@ -16,6 +16,9 @@ import type { ExecutionHostId } from '../../../../shared/execution-host'
 import type { PtyDataMeta } from './pty-dispatcher'
 import type { RemoteRuntimeSnapshotOutcome } from '../../runtime/remote-runtime-terminal-multiplexer'
 
+/** Why: a reconciled session loss may still be recoverable; a real process exit ends the session. */
+export type PtyExitOptions = { sessionLost?: boolean }
+
 export type PtyBufferSnapshot = {
   data: string
   /** Live state that can be restored without an alternate-screen frame. */
@@ -245,7 +248,7 @@ export type IpcPtyTransportOptions = {
   projectRuntime?: ProjectExecutionRuntimeResolution
   terminalColorQueryReplies?: TerminalOscColorQueryReplyColors
   telemetry?: EventProps<'agent_started'>
-  onPtyExit?: (ptyId: string) => void
+  onPtyExit?: (ptyId: string, opts?: PtyExitOptions) => void
   onTitleChange?: (title: string, rawTitle: string) => void
   onPtySpawn?: (ptyId: string) => void
   /** Rebind an existing pane after its provider replaces the PTY identity. */

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-expired-pane-recovery.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-expired-pane-recovery.test.ts
@@ -57,7 +57,7 @@ describe('createRemoteRuntimePtyTransport', () => {
       }
     })
 
-    expect(onPtyExit).toHaveBeenCalledWith('remote:env-1@@terminal-exited')
+    expect(onPtyExit).toHaveBeenCalledWith('remote:env-1@@terminal-exited', { sessionLost: true })
     expect(transport.getPtyId()).toBeNull()
     expect(transport.isConnected()).toBe(false)
     expect(transport.getRecoveryState?.().phase).toBe('ended')

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-pane-handle-resolution.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-pane-handle-resolution.test.ts
@@ -498,7 +498,7 @@ describe('createRemoteRuntimePtyTransport', () => {
 
     // Why: no red xterm error — retire quietly and let the next session-tabs
     // snapshot drive respawn/removal.
-    await vi.waitFor(() => expect(onPtyExit).toHaveBeenCalledWith('remote:env-1@@terminal-1'))
+    await vi.waitFor(() => expect(onPtyExit).toHaveBeenCalledWith('remote:env-1@@terminal-1', { sessionLost: true }))
     expect(transport.getPtyId()).toBeNull()
     expect(onError).not.toHaveBeenCalled()
   })

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-stale-handle-recovery.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-stale-handle-recovery.test.ts
@@ -322,7 +322,7 @@ describe('createRemoteRuntimePtyTransport', () => {
 
     await vi.waitFor(() => expect(onPtyExit).toHaveBeenCalledOnce())
     expect(subscribedTerminalHandles()).toEqual(['terminal-old'])
-    expect(onPtyExit).toHaveBeenCalledWith('remote:env-1@@terminal-old')
+    expect(onPtyExit).toHaveBeenCalledWith('remote:env-1@@terminal-old', { sessionLost: true })
     expect(transport.getPtyId()).toBeNull()
     expect(transport.isConnected()).toBe(false)
   })

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -1378,7 +1378,8 @@ export function createRemoteRuntimePtyTransport(
     setAttachmentUnavailable()
     emitRecoveryState()
     if (stalePtyId) {
-      onPtyExit?.(stalePtyId)
+      // Why: the host dropped this surface; the session may still be resumable, unlike a process that exited.
+      onPtyExit?.(stalePtyId, { sessionLost: true })
     }
   }
 
@@ -2302,7 +2303,7 @@ export function createRemoteRuntimePtyTransport(
       emitRecoveryState()
       storedCallbacks.onDisconnect?.()
       if (id) {
-        onPtyExit?.(id)
+        onPtyExit?.(id, { sessionLost: true })
       }
     },
 

--- a/src/renderer/src/components/terminal-pane/remote-runtime-resubscribe-failure-recovery-routing.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-resubscribe-failure-recovery-routing.test.ts
@@ -257,7 +257,7 @@ describe('remote runtime resubscribe failure: recovery routing', () => {
     failNextResubscribeWith(new Error('terminal_handle_stale'), FIRST_HANDLE)
     dropMultiplexedStream()
 
-    await vi.waitFor(() => expect(onPtyExit).toHaveBeenCalledWith(FIRST_PTY_ID))
+    await vi.waitFor(() => expect(onPtyExit).toHaveBeenCalledWith(FIRST_PTY_ID, { sessionLost: true }))
     expect(methodLog.filter((method) => method === 'terminal.resolvePane')).toHaveLength(2)
     expect(subscribedTerminalHandles().filter((handle) => handle === FIRST_HANDLE)).toHaveLength(1)
     expect(transport.getRecoveryState?.().phase).toBe('ended')
@@ -281,7 +281,7 @@ describe('remote runtime resubscribe failure: recovery routing', () => {
     subscribeOutcomes = [new Error('terminal_handle_stale')]
     dropMultiplexedStream()
 
-    await vi.waitFor(() => expect(onPtyExit).toHaveBeenCalledWith(FIRST_PTY_ID))
+    await vi.waitFor(() => expect(onPtyExit).toHaveBeenCalledWith(FIRST_PTY_ID, { sessionLost: true }))
     expect(transport.getRecoveryState?.().phase).toBe('ended')
     expect(transport.getPtyId()).toBeNull()
     expect(onError).not.toHaveBeenCalled()
@@ -296,7 +296,7 @@ describe('remote runtime resubscribe failure: recovery routing', () => {
     failNextResubscribeWith(new Error('terminal_gone'))
     dropMultiplexedStream()
 
-    await vi.waitFor(() => expect(onPtyExit).toHaveBeenCalledWith(FIRST_PTY_ID))
+    await vi.waitFor(() => expect(onPtyExit).toHaveBeenCalledWith(FIRST_PTY_ID, { sessionLost: true }))
     // Lifecycle evidence, not a replaceable handle: no second re-resolve.
     expect(methodLog.filter((method) => method === 'terminal.resolvePane')).toHaveLength(1)
     expect(transport.getRecoveryState?.().phase).toBe('ended')

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -157,6 +157,7 @@ import {
   resolveTabTitleAfterPaneClose,
   shouldClearLaunchAgentForClosedPane
 } from './terminal-pane-close-identity'
+import type { PtyExitOptions } from './pty-connection-types'
 
 export function resetTerminalKeyboardProtocolAfterInterrupt(terminal: Terminal): void {
   // Guarded output path so a throwing xterm can't escape the key handler.
@@ -289,7 +290,7 @@ type UseTerminalPaneLifecycleDeps = {
   replayingPanesRef: ReplayingPanesRef
   isActiveRef: React.RefObject<boolean>
   isVisibleRef: React.RefObject<boolean>
-  onPtyExitRef: React.RefObject<(ptyId: string) => void>
+  onPtyExitRef: React.RefObject<(ptyId: string, opts?: PtyExitOptions) => void>
   onAgentExitedRef: React.RefObject<(leafId: string) => void>
   onPtyErrorRef?: React.RefObject<(paneId: number, message: string) => void>
   onPtyRecoveryStateRef?: React.RefObject<

--- a/src/renderer/src/components/terminal/close-local-terminal-tab-state.ts
+++ b/src/renderer/src/components/terminal/close-local-terminal-tab-state.ts
@@ -11,6 +11,7 @@ export function closeLocalTerminalTabState(
     captureRecentlyClosed?: boolean
     remoteCloseOwnedByHost?: boolean
     localPtyTeardownOwnedExternally?: boolean
+    retireSleepingAgentSessions?: boolean
     precomputedRetirementPlan?: TerminalTabRetirementPlan
   }
 ): void {
@@ -24,6 +25,7 @@ export function closeLocalTerminalTabState(
       options?.captureRecentlyClosed !== undefined ||
       options?.remoteCloseOwnedByHost ||
       options?.localPtyTeardownOwnedExternally ||
+      options?.retireSleepingAgentSessions ||
       options?.precomputedRetirementPlan
     ) {
       state.closeTab(terminalTabId, options)

--- a/src/renderer/src/components/terminal/terminal-tab-actions.test.ts
+++ b/src/renderer/src/components/terminal/terminal-tab-actions.test.ts
@@ -731,6 +731,31 @@ describe('closeTerminalTab', () => {
     expect(closeTab).toHaveBeenCalledWith('tab-1', { reason: 'pty-exit' })
   })
 
+  it('threads resume-record retirement through to closeTab', () => {
+    const closeTab = vi.fn()
+    getStateMock.mockReturnValue({
+      settings: { activeRuntimeEnvironmentId: null },
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-1' }, { id: 'tab-2' }]
+      },
+      unifiedTabsByWorktree: {},
+      activeWorktreeId: 'wt-1',
+      activeTabId: 'tab-2',
+      openFiles: [],
+      browserTabsByWorktree: {},
+      closeTab,
+      setActiveTab: vi.fn()
+    })
+
+    // Why: a shell that exited on its own ends the session, so its resume record must go with the tab.
+    closeTerminalTab('tab-1', { reason: 'pty-exit', retireSleepingAgentSessions: true })
+
+    expect(closeTab).toHaveBeenCalledWith('tab-1', {
+      reason: 'pty-exit',
+      retireSleepingAgentSessions: true
+    })
+  })
+
   it('threads parked-exit history suppression through to closeTab', () => {
     const closeTab = vi.fn()
     getStateMock.mockReturnValue({

--- a/src/renderer/src/components/terminal/terminal-tab-actions.ts
+++ b/src/renderer/src/components/terminal/terminal-tab-actions.ts
@@ -51,6 +51,8 @@ export function closeTerminalTab(
     skipRunningProcessConfirm?: boolean
     captureRecentlyClosed?: boolean
     localPtyTeardownOwnedExternally?: boolean
+    /** Retire the tab's agent resume records; set when the exit ended the session for good. */
+    retireSleepingAgentSessions?: boolean
     precomputedRetirementPlan?: TerminalTabRetirementPlan
     precomputedCloseState?: PrecomputedTerminalCloseState
     onClosed?: () => void
@@ -171,6 +173,7 @@ export function closeTerminalTab(
       ...(options?.localPtyTeardownOwnedExternally
         ? { localPtyTeardownOwnedExternally: true }
         : {}),
+      ...(options?.retireSleepingAgentSessions ? { retireSleepingAgentSessions: true } : {}),
       ...(options?.precomputedRetirementPlan
         ? { precomputedRetirementPlan: options.precomputedRetirementPlan }
         : {})
@@ -207,6 +210,7 @@ export function closeTerminalTab(
       ...(options?.localPtyTeardownOwnedExternally
         ? { localPtyTeardownOwnedExternally: true }
         : {}),
+      ...(options?.retireSleepingAgentSessions ? { retireSleepingAgentSessions: true } : {}),
       ...(options?.precomputedRetirementPlan
         ? { precomputedRetirementPlan: options.precomputedRetirementPlan }
         : {})
@@ -249,6 +253,7 @@ export function closeTerminalTab(
       ? { captureRecentlyClosed: options.captureRecentlyClosed }
       : {}),
     ...(options?.localPtyTeardownOwnedExternally ? { localPtyTeardownOwnedExternally: true } : {}),
+    ...(options?.retireSleepingAgentSessions ? { retireSleepingAgentSessions: true } : {}),
     ...(options?.precomputedRetirementPlan
       ? { precomputedRetirementPlan: options.precomputedRetirementPlan }
       : {})

--- a/src/renderer/src/store/slices/terminal-tab-close-sleeping-session.test.ts
+++ b/src/renderer/src/store/slices/terminal-tab-close-sleeping-session.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { useAppStore } from '@/store'
+import { resumeSleepingAgentSessionsForWorktree } from '@/lib/resume-sleeping-agent-session'
+
+const initialAppStoreState = useAppStore.getState()
+
+afterEach(() => {
+  useAppStore.setState(initialAppStoreState, true)
+})
+
+const WT = 'wt-1'
+const TAB = 'tab-1'
+const PANE = `${TAB}:leaf-1`
+
+function seedRunningAgentTab(): void {
+  const now = Date.now()
+  useAppStore.setState({
+    workspaceSessionReady: true,
+    hydrationSucceeded: true,
+    tabsByWorktree: {
+      [WT]: [{ id: TAB, ptyId: 'pty-1', worktreeId: WT, title: 'claude', sortOrder: 0, createdAt: 1 }]
+    },
+    ptyIdsByTabId: { [TAB]: ['pty-1'] },
+    agentStatusByPaneKey: {
+      [PANE]: {
+        state: 'working',
+        prompt: 'do a thing',
+        updatedAt: now,
+        stateStartedAt: now,
+        agentType: 'claude',
+        paneKey: PANE,
+        worktreeId: WT,
+        tabId: TAB,
+        providerSession: { key: 'session_id', id: 'sess-1' }
+      }
+    }
+  } as never)
+  // The periodic checkpoint in App.tsx records every live agent so a hard kill can still resume it.
+  useAppStore.getState().captureAllSleepingAgentSessions('periodic')
+  expect(Object.keys(useAppStore.getState().sleepingAgentSessionsByPaneKey)).toEqual([PANE])
+}
+
+describe('closing a terminal tab retires its sleeping agent sessions', () => {
+  it('drops the resume record when the shell exits (Ctrl+D), so activation cannot respawn the tab', () => {
+    seedRunningAgentTab()
+
+    useAppStore.getState().closeTab(TAB, { reason: 'pty-exit', retireSleepingAgentSessions: true })
+
+    expect(useAppStore.getState().sleepingAgentSessionsByPaneKey).toEqual({})
+    expect(resumeSleepingAgentSessionsForWorktree(WT)).toBe(0)
+    expect(useAppStore.getState().tabsByWorktree[WT] ?? []).toHaveLength(0)
+  })
+
+  it('drops the resume record on a user close', () => {
+    seedRunningAgentTab()
+
+    useAppStore.getState().closeTab(TAB)
+
+    expect(useAppStore.getState().sleepingAgentSessionsByPaneKey).toEqual({})
+    expect(resumeSleepingAgentSessionsForWorktree(WT)).toBe(0)
+    expect(useAppStore.getState().tabsByWorktree[WT] ?? []).toHaveLength(0)
+  })
+
+  it('keeps the record when an unexpected PTY loss closed the tab', () => {
+    seedRunningAgentTab()
+
+    useAppStore.getState().closeTab(TAB, { reason: 'pty-exit' })
+
+    expect(Object.keys(useAppStore.getState().sleepingAgentSessionsByPaneKey)).toEqual([PANE])
+  })
+})

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -642,6 +642,8 @@ export type TerminalSlice = {
       captureRecentlyClosed?: boolean
       remoteCloseOwnedByHost?: boolean
       localPtyTeardownOwnedExternally?: boolean
+      /** Retire the tab's agent resume records on a 'pty-exit' close, for exits that ended the session for good. */
+      retireSleepingAgentSessions?: boolean
       precomputedRetirementPlan?: TerminalTabRetirementPlan
     }
   ) => void
@@ -1709,9 +1711,13 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
           delete nextLastTerminalInputAtByPaneKey[paneKey]
         }
       }
-      const nextSleepingAgentSessionsByPaneKey = retiresSession
-        ? removeSleepingAgentSessionsForTab(s.sleepingAgentSessionsByPaneKey, tabId)
-        : s.sleepingAgentSessionsByPaneKey
+      // Why: an unexpected PTY loss keeps its resume authority, but a process that exited on its own
+      // (Ctrl+D, `exit`) ends the session — keeping the record respawns the closed tab on the next
+      // workspace activation, and again on every restart, since the record outlives the tab (#14228).
+      const nextSleepingAgentSessionsByPaneKey =
+        retiresSession || opts?.retireSleepingAgentSessions
+          ? removeSleepingAgentSessionsForTab(s.sleepingAgentSessionsByPaneKey, tabId)
+          : s.sleepingAgentSessionsByPaneKey
       const nextPendingStartupByTabId = { ...s.pendingStartupByTabId }
       delete nextPendingStartupByTabId[tabId]
       const nextAutomaticAgentResumeClaimsByTabId = { ...s.automaticAgentResumeClaimsByTabId }


### PR DESCRIPTION
## Problem

A tab closed by its own shell exit (Ctrl+D, `exit`) comes back. Returning to the workspace, or restarting the app, reopens it running `claude --resume <old session>`.

The chain:

1. `App.tsx` runs `captureAllSleepingAgentSessions('periodic')` on a timer, so every agent pane that stays open past one checkpoint has a `sleepingAgentSessionsByPaneKey` record.
2. `closeTab` retired those records only when `retiresSession` (`reason` `'user'` or `'cleanup'`). A `'pty-exit'` close removed the tab and left the record behind.
3. `resumeSleepingAgentSessionsForWorktree` runs on every workspace activation, and `launchSleepingAgentSession` creates a **new** tab per record — it never checks that the record's tab still exists.

The record is persisted, so the same orphan resurrects on every relaunch too. On my own profile 5 of 20 records had a `tabId` that is no longer in `tabsByWorktree`, all `state: working`, `origin: live` — five queued resurrections. Same footprint reported in #14228 (8 records → 8 replacement tabs after an update).

## Fix

Keep the record when the PTY was lost, drop it when the process exited.

`onExit` in `pty-connection.ts` now carries `sessionLost`: `reconcileIfSessionDead` / `reconcileIfSessionMissing` set it, and the remote transport sets it for host-side surface retirement and non-recoverable transport closes. A real `pty:exit` does not. `handlePtyExit` passes `retireSleepingAgentSessions: opts?.sessionLost !== true` to `closeTerminalTab`, and `closeTab` retires the tab's records on that flag.

So an unexpected PTY loss keeps its resume authority (existing behavior, covered by the retirement-store test), while a shell that ended on its own takes its resume record with it.

## Reproduction

`src/renderer/src/store/slices/terminal-tab-close-sleeping-session.test.ts` seeds a working agent tab, runs the periodic capture, closes the tab, and calls `resumeSleepingAgentSessionsForWorktree`. Before this change the Ctrl+D case returned a fresh tab; now it returns 0 launched and 0 tabs. The unexpected-loss case still keeps the record.

## Notes

- Complements #14534, which clears the record at the process-confirmed agent-exit fact while the tab stays open. This one covers the other half: the tab itself going away because its shell exited, including when the agent was still running inside it.
- Remote runtime keeps today's behavior for a host-reported terminal-gone message (treated as a possible session loss); only the clean stream end retires.

## Testing

- `pnpm lint`, `pnpm typecheck`, `pnpm build`
- `pnpm test` (full suite). The remaining failures are in `src/main/daemon/pty-subprocess-env-inheritance`, `src/main/rate-limits/kimi-*`, `src/main/runtime/repo-worktree-admin-fingerprint`, `src/main/shell-startup-feature-channel` and `src/shared/wsl-exec-mode-separator` — files this diff does not touch. I re-ran them on a clean `main` checkout and they fail there too, so they are environment dependent on my machine, not caused by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
