### PR TITLE
Fix native chat IME composition lag

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatComposerField.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposerField.tsx
@@ -4,6 +4,7 @@ import type {
   KeyboardEventHandler,
   RefObject
 } from 'react'
+import { useRef } from 'react'
 import { Image as ImageIcon, ImageOff, X } from 'lucide-react'
 import { translate } from '@/i18n/i18n'
 import { cn } from '@/lib/utils'
@@ -97,6 +98,8 @@ export function NativeChatComposerField({
   sessionOptionsSurface,
   sessionOptionsSnapshot
 }: NativeChatComposerFieldProps): React.JSX.Element {
+  const isComposingRef = useRef(false)
+
   return (
     <div className="shrink-0 bg-background">
       {/* Extra bottom padding keeps the input box off the window rim. */}
@@ -167,12 +170,26 @@ export function NativeChatComposerField({
               value={draft}
               disabled={disabled}
               rows={2}
-              onChange={(e) => onDraftChange(e.target.value, e.currentTarget)}
+              onChange={(e) => {
+                if (!isComposingRef.current) {
+                  onDraftChange(e.target.value, e.currentTarget)
+                }
+              }}
               onKeyDown={onKeyDown}
-              onCompositionStart={onCompositionStart}
-              onCompositionEnd={onCompositionEnd}
+              onCompositionStart={(e) => {
+                isComposingRef.current = true
+                onCompositionStart(e)
+              }}
+              onCompositionEnd={(e) => {
+                isComposingRef.current = false
+                onCompositionEnd(e)
+              }}
               onPaste={onPaste}
-              onSelect={(e) => onTextareaSelect(e.currentTarget)}
+              onSelect={(e) => {
+                if (!isComposingRef.current) {
+                  onTextareaSelect(e.currentTarget)
+                }
+              }}
               aria-expanded={autocomplete.mode === 'slash' || autocomplete.mode === 'skill'}
               aria-controls={
                 autocomplete.mode === 'slash' || autocomplete.mode === 'skill'

--- a/src/renderer/src/components/native-chat/native-chat-composer-autogrow.test.tsx
+++ b/src/renderer/src/components/native-chat/native-chat-composer-autogrow.test.tsx
@@ -6,7 +6,7 @@
  *  has no layout engine, so real pixel growth is covered by app validation. */
 
 import { createRef } from 'react'
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/i18n/i18n', () => ({
@@ -23,10 +23,19 @@ vi.mock('./NativeChatAutocompleteMenus', () => ({
 }))
 
 import { NativeChatComposerField } from './NativeChatComposerField'
+import type { NativeChatComposerFieldProps } from './NativeChatComposerField'
 
 afterEach(() => cleanup())
 
-function renderField(draft: string): HTMLTextAreaElement {
+function renderField(
+  draft: string,
+  overrides: Partial<
+    Pick<
+      NativeChatComposerFieldProps,
+      'onDraftChange' | 'onTextareaSelect' | 'onCompositionStart' | 'onCompositionEnd'
+    >
+  > = {}
+): HTMLTextAreaElement {
   render(
     <NativeChatComposerField
       textareaRef={createRef<HTMLTextAreaElement>()}
@@ -44,11 +53,11 @@ function renderField(draft: string): HTMLTextAreaElement {
       dictationDisabled={false}
       isDictating={false}
       isDictationHoldMode={false}
-      onDraftChange={vi.fn()}
-      onTextareaSelect={vi.fn()}
+      onDraftChange={overrides.onDraftChange ?? vi.fn()}
+      onTextareaSelect={overrides.onTextareaSelect ?? vi.fn()}
       onKeyDown={vi.fn()}
-      onCompositionStart={vi.fn()}
-      onCompositionEnd={vi.fn()}
+      onCompositionStart={overrides.onCompositionStart ?? vi.fn()}
+      onCompositionEnd={overrides.onCompositionEnd ?? vi.fn()}
       onPaste={vi.fn()}
       pickerListboxId="picker"
       onChoosePickerItem={vi.fn()}
@@ -94,5 +103,23 @@ describe('native chat composer autogrow', () => {
     // A JS measure pass writes style.height and only re-measures on the next
     // value change, so a re-wrap from a window/pane resize would strand it.
     expect(renderField('a\n'.repeat(6)).style.height).toBe('')
+  })
+
+  it('keeps IME preedit text out of draft callbacks until compositionend', () => {
+    const onDraftChange = vi.fn()
+    const onTextareaSelect = vi.fn()
+    const onCompositionEnd = vi.fn()
+    const textarea = renderField('', { onDraftChange, onTextareaSelect, onCompositionEnd })
+
+    fireEvent.compositionStart(textarea)
+    fireEvent.change(textarea, { target: { value: 'ni' } })
+    fireEvent.select(textarea)
+
+    expect(onDraftChange).not.toHaveBeenCalled()
+    expect(onTextareaSelect).not.toHaveBeenCalled()
+
+    fireEvent.compositionEnd(textarea, { data: '你好' })
+
+    expect(onCompositionEnd).toHaveBeenCalledOnce()
   })
 })

--- a/tests/e2e/native-chat-chinese-ime-composition.spec.ts
+++ b/tests/e2e/native-chat-chinese-ime-composition.spec.ts
@@ -1,0 +1,197 @@
+import { randomUUID } from 'node:crypto'
+import { rmSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import type { Page } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import {
+  waitForActivePaneHookDescriptor,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager
+} from './helpers/terminal'
+import type { GlobalSettings } from '../../src/shared/global-settings-types'
+
+async function enableNativeChatSetting(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    const nextSettings = await window.api.settings.set({ experimentalNativeChat: true })
+    window.__store?.setState({ settings: nextSettings as GlobalSettings })
+  })
+}
+
+async function seedClaudeProviderSession(
+  page: Page,
+  args: { paneKey: string; worktreeId: string; sessionId: string; transcriptPath: string }
+): Promise<void> {
+  await page.evaluate(({ paneKey, worktreeId, sessionId, transcriptPath }) => {
+    window.__store
+      ?.getState()
+      .setAgentStatus(
+        paneKey,
+        { state: 'done', prompt: 'native chat IME probe', agentType: 'claude' },
+        'Claude',
+        undefined,
+        { worktreeId },
+        { providerSession: { key: 'session_id', id: sessionId, transcriptPath } }
+      )
+  }, args)
+}
+
+async function toggleTerminalTabToChatView(
+  page: Page,
+  args: { tabId: string; worktreeId: string }
+): Promise<void> {
+  await page.evaluate(({ tabId, worktreeId }) => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('Store unavailable')
+    }
+    const state = store.getState()
+    const unifiedTab = (state.unifiedTabsByWorktree[worktreeId] ?? []).find(
+      (tab) => tab.contentType === 'terminal' && tab.entityId === tabId
+    )
+    if (!unifiedTab) {
+      throw new Error('Unified terminal tab not found for chat toggle')
+    }
+    state.toggleTabViewMode(unifiedTab.id)
+  }, args)
+}
+
+function claudeTranscriptLines(args: {
+  sessionId: string
+  userText: string
+  assistantText: string
+}): string {
+  const userTime = new Date()
+  const assistantTime = new Date(userTime.getTime() + 2_000)
+  return `${[
+    {
+      sessionId: args.sessionId,
+      uuid: `${args.sessionId}-user`,
+      timestamp: userTime.toISOString(),
+      type: 'user',
+      message: { role: 'user', content: [{ type: 'text', text: args.userText }] }
+    },
+    {
+      sessionId: args.sessionId,
+      uuid: `${args.sessionId}-assistant`,
+      timestamp: assistantTime.toISOString(),
+      type: 'assistant',
+      message: { model: 'claude-opus-4', content: [{ type: 'text', text: args.assistantText }] }
+    }
+  ]
+    .map((line) => JSON.stringify(line))
+    .join('\n')}\n`
+}
+
+async function dispatchComposerCompositionStart(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const composer = document.querySelector<HTMLTextAreaElement>(
+      '[data-native-chat-root="true"] textarea'
+    )
+    if (!composer) {
+      throw new Error('Native chat composer textarea not found')
+    }
+    composer.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }))
+  })
+}
+
+async function dispatchComposerCompositionFrame(page: Page, text: string): Promise<void> {
+  await page.evaluate((nextText) => {
+    const composer = document.querySelector<HTMLTextAreaElement>(
+      '[data-native-chat-root="true"] textarea'
+    )
+    if (!composer) {
+      throw new Error('Native chat composer textarea not found')
+    }
+    composer.value = nextText
+    composer.setSelectionRange(nextText.length, nextText.length)
+    composer.dispatchEvent(
+      new InputEvent('input', {
+        bubbles: true,
+        data: nextText,
+        inputType: 'insertCompositionText'
+      })
+    )
+  }, text)
+}
+
+async function dispatchComposerCompositionCommit(page: Page, text: string): Promise<void> {
+  await page.evaluate((committedText) => {
+    const composer = document.querySelector<HTMLTextAreaElement>(
+      '[data-native-chat-root="true"] textarea'
+    )
+    if (!composer) {
+      throw new Error('Native chat composer textarea not found')
+    }
+    composer.value = committedText
+    composer.setSelectionRange(committedText.length, committedText.length)
+    composer.dispatchEvent(
+      new CompositionEvent('compositionend', { bubbles: true, data: committedText })
+    )
+  }, text)
+}
+
+test.describe('Native chat Chinese IME composition', () => {
+  test('keeps Pinyin preedit text out of the composer draft until commit', async ({
+    orcaPage,
+    testRepoPath
+  }) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+
+    const descriptor = await waitForActivePaneHookDescriptor(orcaPage)
+    const [tabId] = descriptor.paneKey.split(':')
+    const ptyId = await waitForActivePanePtyId(orcaPage)
+    expect(ptyId).toBeTruthy()
+
+    const sessionId = `e2e-native-chat-ime-${randomUUID()}`
+    const transcriptPath = path.join(testRepoPath, `.orca-native-chat-ime-${sessionId}.jsonl`)
+    writeFileSync(
+      transcriptPath,
+      claudeTranscriptLines({
+        sessionId,
+        userText: 'Open native chat for an IME composition probe',
+        assistantText: 'Ready for Pinyin composition.'
+      })
+    )
+
+    try {
+      await enableNativeChatSetting(orcaPage)
+      await seedClaudeProviderSession(orcaPage, {
+        paneKey: descriptor.paneKey,
+        worktreeId: descriptor.worktreeId,
+        sessionId,
+        transcriptPath
+      })
+      await toggleTerminalTabToChatView(orcaPage, { tabId, worktreeId: descriptor.worktreeId })
+
+      const root = orcaPage.locator('[data-native-chat-root="true"]')
+      await expect(root).toBeVisible({ timeout: 15_000 })
+      await expect(orcaPage.getByText('Ready for Pinyin composition.')).toBeVisible({
+        timeout: 15_000
+      })
+
+      const composer = root.locator('textarea').last()
+      const sendButton = root.getByRole('button', { name: /^(Send|发送)$/ })
+      await composer.focus()
+      await expect(sendButton).toBeDisabled()
+
+      await dispatchComposerCompositionStart(orcaPage)
+      await dispatchComposerCompositionFrame(orcaPage, 'n')
+      await expect(composer).toHaveValue('n')
+      await expect(sendButton).toBeDisabled()
+
+      await dispatchComposerCompositionFrame(orcaPage, 'ni')
+      await expect(composer).toHaveValue('ni')
+      await expect(sendButton).toBeDisabled()
+
+      await dispatchComposerCompositionCommit(orcaPage, '你好')
+      await expect(composer).toHaveValue('你好')
+      await expect(sendButton).toBeEnabled()
+    } finally {
+      rmSync(transcriptPath, { force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Prevent native chat preedit text from flowing into draft state during IME composition.
- Keep composition start/end propagation intact so the parent composer still guards key handling and adopts the committed text.
- Add unit and Electron e2e coverage for Chinese Pinyin composition (`n` -> `ni` -> `你好`).

## Audit
- Scoped to native chat textarea composition handling and regression tests.
- No remote wire, Git command, SSH, filesystem provider, or platform-specific behavior changes.
- E2E fixture writes only a temporary transcript under the test repo and removes it in `finally`.
- No secrets, credentials, external network calls, or private data added.

## Validation
- `pnpm exec oxfmt --check src/renderer/src/components/native-chat/NativeChatComposerField.tsx src/renderer/src/components/native-chat/native-chat-composer-autogrow.test.tsx tests/e2e/native-chat-chinese-ime-composition.spec.ts`
- `pnpm exec oxlint src/renderer/src/components/native-chat/NativeChatComposerField.tsx src/renderer/src/components/native-chat/native-chat-composer-autogrow.test.tsx tests/e2e/native-chat-chinese-ime-composition.spec.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/native-chat/NativeChatComposer.test.tsx src/renderer/src/components/native-chat/native-chat-composer-autogrow.test.tsx`
- `npx playwright test tests/e2e/native-chat-chinese-ime-composition.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1`

Note: local validation emitted the existing Node engine warning (`wanted: node 24`, current `v22.18.0`) and the existing `/usr/local/bin/orca-dev` symlink permission warning during CLI build; neither blocked the passing Electron e2e run.
