### PR TITLE
feat(cmd-j): rank palette results by direct matches and recency

### DIFF
--- a/src/renderer/src/components/WorktreeJumpPalette.test.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.test.tsx
@@ -435,4 +435,29 @@ describe('WorktreeJumpPalette', () => {
 
     expect(input?.value).toBe('😉')
   })
+
+  it('renders last active timestamp when worktree has lastActivityAt', async () => {
+    const twentyThreeDaysAgo = Date.now() - 23 * 24 * 60 * 60 * 1000
+    const activeWorktree = makeWorktree('active-wt', 'Active workspace', {
+      lastActivityAt: twentyThreeDaysAgo
+    })
+    const noActivityWorktree = makeWorktree('no-activity-wt', 'No activity workspace', {
+      lastActivityAt: 0
+    })
+
+    await renderPalette({
+      worktreesByRepo: { 'repo-1': [activeWorktree, noActivityWorktree] },
+      showSleepingWorkspaces: true
+    })
+
+    const activeRow = testContainer.querySelector('[data-command-item="worktree:active-wt"]')
+    expect(activeRow?.textContent).toContain('23d')
+    const activeSpan = activeRow?.querySelector('span[aria-label="Last active 23d ago"]')
+    expect(activeSpan).not.toBeNull()
+    expect(activeSpan?.textContent).toBe('23d')
+
+    const noActivityRow = testContainer.querySelector('[data-command-item="worktree:no-activity-wt"]')
+    expect(noActivityRow?.querySelector('span[aria-label*="Last active"]')).toBeNull()
+  })
 })
+

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -1196,6 +1196,7 @@ function WorktreeJumpPaletteContent({
       worktreeOrder,
       browserTabsByWorktree,
       browserPagesByWorkspace,
+      unifiedTabsByWorktree,
       activeBrowserTabId,
       activeWorktreeId,
       activeWorkspaceExecutionHostId,
@@ -1212,6 +1213,7 @@ function WorktreeJumpPaletteContent({
     browserSortedWorktrees,
     repoByHostIdentity,
     repoMap,
+    unifiedTabsByWorktree,
     worktreeOrder
   ])
 
@@ -3234,10 +3236,7 @@ function WorktreeJumpPaletteContent({
                   ? (sshConnectionStates.get(sshConnectionId)?.status ?? 'disconnected')
                   : null
                 const isSshDisconnected = sshStatus != null && sshStatus !== 'connected'
-                const sessionAge = formatPaletteSessionAge(
-                  worktree.lastActivityAt,
-                  paletteNowMs
-                )
+                const sessionAge = formatPaletteSessionAge(worktree.lastActivityAt, paletteNowMs)
                 return (
                   <CommandItem
                     key={renderKey}
@@ -3546,7 +3545,10 @@ function WorktreeJumpPaletteContent({
                   ? resolveRepoForWorktree(simulatorWorktree)
                   : undefined
                 const simulatorRepoName = simulatorRepo?.displayName ?? result.repoName
-                const sessionAge = formatPaletteSessionAge(result.lastActiveAt ?? null, paletteNowMs)
+                const sessionAge = formatPaletteSessionAge(
+                  result.lastActiveAt ?? null,
+                  paletteNowMs
+                )
 
                 return (
                   <CommandItem

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -138,7 +138,7 @@ import {
 } from '@/components/browser-pane/host-guest/browser-focus'
 import { RepoBadgeMark } from '@/components/repo/RepoBadgeLabel'
 import { buildSidebarHostOptions } from '@/components/sidebar/sidebar-host-options'
-import { getPaletteHostBadge, type PaletteHostBadge } from '@/components/cmd-j/palette-host-badge'
+import { getPaletteHostBadge } from '@/components/cmd-j/palette-host-badge'
 import {
   composeWorktreeHostIdentity,
   getWorktreeHostIdentity
@@ -1385,8 +1385,18 @@ function WorktreeJumpPaletteContent({
     // An empty query leaves every rank null, so ordering falls through to those scores.
     return items.sort((a, b) =>
       comparePaletteRankedItems(
-        { rank: a.result.rank, order: a.result.score, id: a.id },
-        { rank: b.result.rank, order: b.result.score, id: b.id }
+        {
+          rank: a.result.rank,
+          order: a.result.score,
+          id: a.id,
+          lastActiveAt: a.result.lastActiveAt ?? undefined
+        },
+        {
+          rank: b.result.rank,
+          order: b.result.score,
+          id: b.id,
+          lastActiveAt: b.result.lastActiveAt ?? undefined
+        }
       )
     )
   }, [browserItems, simulatorItems, workspaceTabItems])

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -527,7 +527,7 @@ function PaletteOpenTabPrimaryLine({
             'Last active {{value0}} ago',
             { value0: sessionAge }
           )}
-          className="inline-flex h-5 shrink-0 items-center self-center text-[11px] font-medium leading-none tabular-nums text-muted-foreground/70"
+          className="shrink-0 text-[11px] font-medium tabular-nums text-muted-foreground/70"
         >
           {sessionAge}
         </span>
@@ -3234,6 +3234,10 @@ function WorktreeJumpPaletteContent({
                   ? (sshConnectionStates.get(sshConnectionId)?.status ?? 'disconnected')
                   : null
                 const isSshDisconnected = sshStatus != null && sshStatus !== 'connected'
+                const sessionAge = formatPaletteSessionAge(
+                  worktree.lastActivityAt,
+                  paletteNowMs
+                )
                 return (
                   <CommandItem
                     key={renderKey}
@@ -3281,6 +3285,18 @@ function WorktreeJumpPaletteContent({
                               slot="palette-worktree-name"
                               className="truncate text-[14px] font-semibold text-foreground"
                             />
+                            {sessionAge ? (
+                              <span
+                                aria-label={translate(
+                                  'auto.components.WorktreeJumpPalette.lastActiveTime',
+                                  'Last active {{value0}} ago',
+                                  { value0: sessionAge }
+                                )}
+                                className="shrink-0 text-[11px] font-medium tabular-nums text-muted-foreground/70"
+                              >
+                                {sessionAge}
+                              </span>
+                            ) : null}
                             {isCurrentWorktree && (
                               <span className="shrink-0 self-center rounded-[6px] border border-border/60 bg-background/45 px-1.5 py-px text-[9px] font-medium leading-normal text-muted-foreground/88">
                                 {translate(
@@ -3530,6 +3546,7 @@ function WorktreeJumpPaletteContent({
                   ? resolveRepoForWorktree(simulatorWorktree)
                   : undefined
                 const simulatorRepoName = simulatorRepo?.displayName ?? result.repoName
+                const sessionAge = formatPaletteSessionAge(result.lastActiveAt ?? null, paletteNowMs)
 
                 return (
                   <CommandItem
@@ -3549,6 +3566,7 @@ function WorktreeJumpPaletteContent({
                             titleRanges={result.titleRanges}
                             secondaryText={result.secondaryText}
                             secondaryRanges={result.secondaryRanges}
+                            sessionAge={sessionAge}
                             leadingBadges={
                               <>
                                 {result.isCurrentTab && (
@@ -3606,6 +3624,7 @@ function WorktreeJumpPaletteContent({
                 ? resolveRepoForWorktree(browserWorktree)
                 : undefined
               const browserRepoName = browserRepo?.displayName ?? result.repoName
+              const sessionAge = formatPaletteSessionAge(result.lastActiveAt ?? null, paletteNowMs)
 
               return (
                 <CommandItem
@@ -3625,6 +3644,7 @@ function WorktreeJumpPaletteContent({
                           titleRanges={result.titleRanges}
                           secondaryText={result.secondaryText}
                           secondaryRanges={result.secondaryRanges}
+                          sessionAge={sessionAge}
                           leadingBadges={
                             <>
                               {result.isCurrentPage && (

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -151,6 +151,7 @@ import {
   type ExecutionHostId
 } from '../../../shared/execution-host'
 import { buildPaletteListEntryRenderKeys } from '@/components/cmd-j/palette-list-entry-render-keys'
+import { formatPaletteSessionAge } from '@/components/cmd-j/palette-session-age'
 import PaletteFilterMenu from '@/components/cmd-j/PaletteFilterMenu'
 import PaletteFilterChips from '@/components/cmd-j/PaletteFilterChips'
 import { buildPaletteFilterModel } from '@/components/cmd-j/palette-filter-options'
@@ -497,12 +498,14 @@ function PaletteOpenTabPrimaryLine({
   titleRanges,
   secondaryText,
   secondaryRanges,
+  sessionAge,
   leadingBadges
 }: {
   title: string
   titleRanges: readonly MatchRange[]
   secondaryText: string
   secondaryRanges: readonly MatchRange[]
+  sessionAge?: string
   leadingBadges?: React.ReactNode
 }): React.JSX.Element {
   // Why gate on non-empty: empty secondaries (terminals/simulators) used to still
@@ -517,6 +520,18 @@ function PaletteOpenTabPrimaryLine({
       >
         <HighlightedText text={title} matchRanges={titleRanges} />
       </span>
+      {sessionAge ? (
+        <span
+          aria-label={translate(
+            'auto.components.WorktreeJumpPalette.lastActiveTime',
+            'Last active {{value0}} ago',
+            { value0: sessionAge }
+          )}
+          className="inline-flex h-5 shrink-0 items-center self-center text-[11px] font-medium leading-none tabular-nums text-muted-foreground/70"
+        >
+          {sessionAge}
+        </span>
+      ) : null}
       {leadingBadges}
       {showSecondary ? (
         <>
@@ -621,31 +636,6 @@ function FooterKey({ children }: { children: React.ReactNode }): React.JSX.Eleme
   )
 }
 
-function PaletteHostBadgeChip({
-  badge
-}: {
-  badge: PaletteHostBadge | null
-}): React.JSX.Element | null {
-  if (!badge) {
-    return null
-  }
-  // Host labels come from the registry and are intentionally not translated.
-  return (
-    <span
-      aria-label={translate(
-        'auto.components.WorktreeJumpPalette.paletteHostBadge',
-        'Host: {{value0}}',
-        { value0: badge.label }
-      )}
-      // Why solid background: left-column text used to paint through translucent
-      // host chips when a long worktree name overflowed under the badge column.
-      className="max-w-[140px] truncate rounded-[6px] border border-border/60 bg-background px-1.5 py-px text-[9px] font-medium leading-normal text-muted-foreground/88"
-    >
-      {badge.label}
-    </span>
-  )
-}
-
 function getSettingsTargetFromSectionId(sectionId: string): {
   pane: SettingsNavTarget
   repoId: string | null
@@ -694,6 +684,9 @@ function WorktreeJumpPaletteContent({
 }): React.JSX.Element | null {
   // Why: subscribe to language changes so translated memos recompute without a fake i18n.language dependency.
   useTranslation()
+  // Why frozen on open: recomputing every keystroke would tick the session-age badges mid-session.
+  // oxlint-disable-next-line react-hooks/exhaustive-deps -- visible is the freeze trigger, not a read value.
+  const paletteNowMs = useMemo(() => Date.now(), [visible])
   const closeModal = useAppStore((s) => s.closeModal)
   const openModal = useAppStore((s) => s.openModal)
   const openSettingsPage = useAppStore((s) => s.openSettingsPage)
@@ -3231,8 +3224,6 @@ function WorktreeJumpPaletteContent({
                   ? (sshConnectionStates.get(sshConnectionId)?.status ?? 'disconnected')
                   : null
                 const isSshDisconnected = sshStatus != null && sshStatus !== 'connected'
-                const hostBadge = getPaletteHostBadge(repo, hostOptions, hostFilterActive)
-
                 return (
                   <CommandItem
                     key={renderKey}
@@ -3329,7 +3320,6 @@ function WorktreeJumpPaletteContent({
                           )}
                         </div>
                         <div className="flex shrink-0 items-center gap-1.5">
-                          <PaletteHostBadgeChip badge={hostBadge} />
                           {repoName && (
                             <span className="inline-flex max-w-[180px] items-center gap-1.5 rounded-md border border-border bg-muted px-2 py-1 text-[11px] font-semibold leading-none text-foreground">
                               <RepoBadgeMark color={repo?.badgeColor} />
@@ -3351,9 +3341,6 @@ function WorktreeJumpPaletteContent({
               if (entry.type === 'project-target') {
                 const result = entry.result
                 const isProject = result.kind === 'project'
-                const hostBadge = isProject
-                  ? getPaletteHostBadge(result.repo, hostOptions, hostFilterActive)
-                  : null
                 const badgeLabel = isProject
                   ? translate('auto.components.WorktreeJumpPalette.projectBadge', 'Project')
                   : translate('auto.components.WorktreeJumpPalette.repoGroupBadge', 'Repo group')
@@ -3381,7 +3368,6 @@ function WorktreeJumpPaletteContent({
                         </div>
                         {isProject ? (
                           <div className="flex shrink-0 items-center gap-1.5">
-                            <PaletteHostBadgeChip badge={hostBadge} />
                             <span className="inline-flex max-w-[180px] items-center gap-1.5 rounded-md border border-border bg-muted px-2 py-1 text-[11px] font-semibold leading-none text-foreground">
                               <RepoBadgeMark color={result.repo.badgeColor} />
                               <span className="truncate">{result.repo.displayName}</span>
@@ -3430,6 +3416,7 @@ function WorktreeJumpPaletteContent({
 
               if (entry.type === 'workspace-tab') {
                 const result = entry.result
+                const sessionAge = formatPaletteSessionAge(result.lastActiveAt, paletteNowMs)
                 const workspaceTabWorktree = resolveWorktree(
                   result.worktreeId,
                   result.executionHostId
@@ -3438,11 +3425,6 @@ function WorktreeJumpPaletteContent({
                   ? resolveRepoForWorktree(workspaceTabWorktree)
                   : undefined
                 const workspaceTabRepoName = workspaceTabRepo?.displayName ?? result.repoName
-                const workspaceTabHostBadge = getPaletteHostBadge(
-                  workspaceTabRepo,
-                  hostOptions,
-                  hostFilterActive
-                )
                 const workspaceTabFallback =
                   result.contentType === 'terminal' && result.occupantAgent ? (
                     <span
@@ -3479,6 +3461,7 @@ function WorktreeJumpPaletteContent({
                             titleRanges={result.titleRanges}
                             secondaryText={result.secondaryText}
                             secondaryRanges={result.secondaryRanges}
+                            sessionAge={sessionAge}
                             leadingBadges={
                               <>
                                 {result.isCurrentTab && (
@@ -3508,7 +3491,6 @@ function WorktreeJumpPaletteContent({
                             worktree={workspaceTabWorktree}
                             className="max-w-[280px] truncate text-[12px] font-medium text-muted-foreground"
                           />
-                          <PaletteHostBadgeChip badge={workspaceTabHostBadge} />
                           {workspaceTabRepoName && (
                             <span className="inline-flex max-w-[180px] items-center gap-1.5 rounded-md border border-border bg-muted px-2 py-1 text-[11px] font-semibold leading-none text-foreground">
                               <RepoBadgeMark color={workspaceTabRepo?.badgeColor} />
@@ -3538,11 +3520,6 @@ function WorktreeJumpPaletteContent({
                   ? resolveRepoForWorktree(simulatorWorktree)
                   : undefined
                 const simulatorRepoName = simulatorRepo?.displayName ?? result.repoName
-                const simulatorHostBadge = getPaletteHostBadge(
-                  simulatorRepo,
-                  hostOptions,
-                  hostFilterActive
-                )
 
                 return (
                   <CommandItem
@@ -3591,7 +3568,6 @@ function WorktreeJumpPaletteContent({
                             worktree={simulatorWorktree}
                             className="max-w-[280px] truncate text-[12px] font-medium text-muted-foreground"
                           />
-                          <PaletteHostBadgeChip badge={simulatorHostBadge} />
                           {simulatorRepoName && (
                             <span className="inline-flex max-w-[180px] items-center gap-1.5 rounded-md border border-border bg-muted px-2 py-1 text-[11px] font-semibold leading-none text-foreground">
                               <RepoBadgeMark color={simulatorRepo?.badgeColor} />
@@ -3620,11 +3596,6 @@ function WorktreeJumpPaletteContent({
                 ? resolveRepoForWorktree(browserWorktree)
                 : undefined
               const browserRepoName = browserRepo?.displayName ?? result.repoName
-              const browserHostBadge = getPaletteHostBadge(
-                browserRepo,
-                hostOptions,
-                hostFilterActive
-              )
 
               return (
                 <CommandItem
@@ -3673,7 +3644,6 @@ function WorktreeJumpPaletteContent({
                           worktree={browserWorktree}
                           className="max-w-[280px] truncate text-[12px] font-medium text-muted-foreground"
                         />
-                        <PaletteHostBadgeChip badge={browserHostBadge} />
                         {browserRepoName && (
                           <span className="inline-flex max-w-[180px] items-center gap-1.5 rounded-md border border-border bg-muted px-2 py-1 text-[11px] font-semibold leading-none text-foreground">
                             <RepoBadgeMark color={browserRepo?.badgeColor} />

--- a/src/renderer/src/components/cmd-j/palette-session-age.test.ts
+++ b/src/renderer/src/components/cmd-j/palette-session-age.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { formatPaletteSessionAge } from './palette-session-age'
+
+const NOW = 1_000_000_000
+
+describe('formatPaletteSessionAge', () => {
+  it('returns undefined when there is no known activity', () => {
+    expect(formatPaletteSessionAge(null, NOW)).toBeUndefined()
+  })
+
+  it('buckets clock skew (negative delta) as "<1m"', () => {
+    expect(formatPaletteSessionAge(NOW + 5_000, NOW)).toBe('<1m')
+  })
+
+  it('stays "<1m" just under the one-minute boundary', () => {
+    expect(formatPaletteSessionAge(NOW - 59_000, NOW)).toBe('<1m')
+  })
+
+  it('switches to minutes at the one-minute boundary', () => {
+    expect(formatPaletteSessionAge(NOW - 60_000, NOW)).toBe('1m')
+    expect(formatPaletteSessionAge(NOW - 90_000, NOW)).toBe('1m')
+  })
+
+  it('stays in minutes just under the one-hour boundary', () => {
+    expect(formatPaletteSessionAge(NOW - 59 * 60_000, NOW)).toBe('59m')
+  })
+
+  it('switches to hours at the one-hour boundary', () => {
+    expect(formatPaletteSessionAge(NOW - 60 * 60_000, NOW)).toBe('1h')
+  })
+
+  it('stays in hours just under the two-day boundary', () => {
+    expect(formatPaletteSessionAge(NOW - 47 * 60 * 60_000, NOW)).toBe('47h')
+  })
+
+  it('switches to days at the two-day boundary', () => {
+    expect(formatPaletteSessionAge(NOW - 48 * 60 * 60_000, NOW)).toBe('2d')
+    expect(formatPaletteSessionAge(NOW - 72 * 60 * 60_000, NOW)).toBe('3d')
+  })
+})

--- a/src/renderer/src/components/cmd-j/palette-session-age.ts
+++ b/src/renderer/src/components/cmd-j/palette-session-age.ts
@@ -1,0 +1,30 @@
+import { translate } from '@/i18n/i18n'
+
+/** Bare compact "how long ago" token for the Cmd+J session-age badge, e.g. "3h"/"2d". */
+export function formatPaletteSessionAge(
+  lastActiveAt: number | null,
+  now: number
+): string | undefined {
+  if (!lastActiveAt) {
+    return undefined
+  }
+  const deltaMs = now - lastActiveAt
+  // Why not "now": the badge feeds `aria-label="Last active {{value}} ago"`, and
+  // "Last active now ago" reads wrong — keep the token numeric like the other buckets.
+  if (deltaMs < 60_000) {
+    return translate('components.cmd-j.paletteSessionAge.underOneMinute', '<1m')
+  }
+  const minutes = Math.floor(deltaMs / 60_000)
+  if (minutes < 60) {
+    return translate('components.cmd-j.paletteSessionAge.minutes', '{{value0}}m', {
+      value0: minutes
+    })
+  }
+  const hours = Math.floor(minutes / 60)
+  if (hours < 48) {
+    return translate('components.cmd-j.paletteSessionAge.hours', '{{value0}}h', { value0: hours })
+  }
+  return translate('components.cmd-j.paletteSessionAge.days', '{{value0}}d', {
+    value0: Math.floor(hours / 24)
+  })
+}

--- a/src/renderer/src/components/tab-bar/open-tab-search-entries.ts
+++ b/src/renderer/src/components/tab-bar/open-tab-search-entries.ts
@@ -160,6 +160,7 @@ export function buildOpenTabSearchEntries(
       ...scope,
       browserTabsByWorktree: state.browserTabsByWorktree,
       browserPagesByWorkspace: state.browserPagesByWorkspace,
+      unifiedTabsByWorktree: state.unifiedTabsByWorktree,
       activeBrowserTabId: state.activeBrowserTabId,
       activeWorktreeId: state.activeWorktreeId,
       activeTabType: state.activeTabType

--- a/src/renderer/src/components/tab-bar/open-tab-search-retention.test.ts
+++ b/src/renderer/src/components/tab-bar/open-tab-search-retention.test.ts
@@ -87,7 +87,14 @@ function makeWorkspaceTab({
       typeAliases: aliases
     }),
     agentMetadata: agentSnippets.length
-      ? [{ paneKey: `${id}-pane`, textParts: [], snippetCandidates: agentSnippets }]
+      ? [
+          {
+            paneKey: `${id}-pane`,
+            textParts: [],
+            snippetCandidates: agentSnippets,
+            lastActivityAt: 0
+          }
+        ]
       : [],
     occupantAgent: null,
     isCurrentTab: false,

--- a/src/renderer/src/components/tab-bar/open-tab-search.test.ts
+++ b/src/renderer/src/components/tab-bar/open-tab-search.test.ts
@@ -105,7 +105,14 @@ function makeWorkspaceTab({
       repoName: REPO_NAME
     }),
     agentMetadata: agentSnippets.length
-      ? [{ paneKey: `${id}-pane`, textParts: [], snippetCandidates: agentSnippets }]
+      ? [
+          {
+            paneKey: `${id}-pane`,
+            textParts: [],
+            snippetCandidates: agentSnippets,
+            lastActivityAt: 0
+          }
+        ]
       : [],
     occupantAgent,
     isCurrentTab,

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2198,7 +2198,8 @@
         "27f10cca63": "Search chats, terminals, worktrees, settings, and actions...",
         "2770f02910": "Search chats, terminals, worktrees, settings, and actions",
         "paletteOpenTabBranch": "Branch name",
-        "paletteOpenTabWorkspace": "Workspace name"
+        "paletteOpenTabWorkspace": "Workspace name",
+        "lastActiveTime": "Last active {{value0}} ago"
       },
       "github": {
         "pr": {
@@ -16245,6 +16246,14 @@
         "workspaceSpace": {
           "otherTopLevelItems": "Other top-level items ({{value0}})"
         }
+      }
+    },
+    "cmd-j": {
+      "paletteSessionAge": {
+        "minutes": "{{value0}}m",
+        "hours": "{{value0}}h",
+        "days": "{{value0}}d",
+        "underOneMinute": "<1m"
       }
     }
   },

--- a/src/renderer/src/lib/browser-palette-page-entries.test.ts
+++ b/src/renderer/src/lib/browser-palette-page-entries.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { BrowserPage, BrowserWorkspace } from '../../../shared/browser-workspace-types'
+import type { Tab } from '../../../shared/tab-types'
 import type { Worktree } from '../../../shared/worktree/types'
 import { buildSearchableBrowserPages } from './browser-palette-page-entries'
 import { searchBrowserPages } from './browser-palette-search'
@@ -189,6 +190,53 @@ describe('buildSearchableBrowserPages', () => {
     })
 
     expect(entries[0].worktreeSortIndex).toBe(Number.MAX_SAFE_INTEGER)
+  })
+
+  it('reads page recency from the owning workspace unified tab, clamped to page age', () => {
+    function browserTab(overrides: Partial<Tab>): Tab {
+      return {
+        id: 'tab-ws-1',
+        entityId: 'ws-1',
+        groupId: 'group-1',
+        worktreeId: 'wt-1',
+        contentType: 'browser',
+        label: 'Example',
+        customLabel: null,
+        color: null,
+        sortOrder: 0,
+        createdAt: 0,
+        ...overrides
+      }
+    }
+
+    const [unfocused] = buildSearchableBrowserPages({
+      worktrees: [worktreeA],
+      repoMap,
+      worktreeOrder,
+      browserTabsByWorktree: { 'wt-1': [makeWorkspace()] },
+      browserPagesByWorkspace: { 'ws-1': [makePage()] },
+      unifiedTabsByWorktree: { 'wt-1': [browserTab({})] },
+      activeBrowserTabId: null,
+      activeWorktreeId: null,
+      activeTabType: 'browser'
+    })
+    expect(unfocused.lastActiveAt).toBeNull()
+
+    const entries = buildSearchableBrowserPages({
+      worktrees: [worktreeA],
+      repoMap,
+      worktreeOrder,
+      browserTabsByWorktree: { 'wt-1': [makeWorkspace({ pageIds: ['page-1', 'page-2'] })] },
+      browserPagesByWorkspace: {
+        'ws-1': [makePage(), makePage({ id: 'page-2', createdAt: 9000 })]
+      },
+      unifiedTabsByWorktree: { 'wt-1': [browserTab({ lastFocusedAt: 4000 })] },
+      activeBrowserTabId: null,
+      activeWorktreeId: null,
+      activeTabType: 'browser'
+    })
+
+    expect(entries.map((entry) => entry.lastActiveAt)).toEqual([4000, 9000])
   })
 
   it('feeds Cmd+J browser search the same ranking as the inline builder did', () => {

--- a/src/renderer/src/lib/browser-palette-page-entries.ts
+++ b/src/renderer/src/lib/browser-palette-page-entries.ts
@@ -1,5 +1,6 @@
 import { getWorktreeHostIdentity } from '../../../shared/worktree/host-qualified-identity'
 import type { BrowserPage, BrowserWorkspace } from '../../../shared/browser-workspace-types'
+import type { Tab } from '../../../shared/tab-types'
 import type { Worktree } from '../../../shared/worktree/types'
 import type { ExecutionHostId } from '../../../shared/execution-host'
 import { isPaletteCurrentWorktree, resolvePaletteRepoForWorktree } from './palette-repo-resolution'
@@ -17,6 +18,8 @@ export type BuildSearchableBrowserPagesOptions = {
   worktreeOrder: ReadonlyMap<string, number>
   browserTabsByWorktree: Record<string, readonly BrowserWorkspace[] | undefined>
   browserPagesByWorkspace: Record<string, readonly BrowserPage[] | undefined>
+  /** Source of browser recency: focus lives on the workspace's unified tab, not the page. */
+  unifiedTabsByWorktree?: Record<string, readonly Tab[] | undefined>
   activeBrowserTabId: string | null
   activeWorktreeId: string | null
   activeWorkspaceExecutionHostId?: ExecutionHostId | null
@@ -30,6 +33,7 @@ export function buildSearchableBrowserPages({
   worktreeOrder,
   browserTabsByWorktree,
   browserPagesByWorkspace,
+  unifiedTabsByWorktree,
   activeBrowserTabId,
   activeWorktreeId,
   activeWorkspaceExecutionHostId,
@@ -43,7 +47,14 @@ export function buildSearchableBrowserPages({
       worktreeOrder.get(getWorktreeHostIdentity(worktree)) ??
       worktreeOrder.get(worktree.id) ??
       Number.MAX_SAFE_INTEGER
+    const focusedAtByWorkspaceId = new Map<string, number>()
+    for (const tab of unifiedTabsByWorktree?.[worktree.id] ?? []) {
+      if (tab.contentType === 'browser' && tab.lastFocusedAt) {
+        focusedAtByWorkspaceId.set(tab.entityId, tab.lastFocusedAt)
+      }
+    }
     for (const workspace of browserTabsByWorktree[worktree.id] ?? []) {
+      const workspaceFocusedAt = focusedAtByWorkspaceId.get(workspace.id)
       for (const page of browserPagesByWorkspace[workspace.id] ?? []) {
         entries.push({
           page,
@@ -61,6 +72,8 @@ export function buildSearchableBrowserPages({
             activeWorktreeId,
             activeWorkspaceExecutionHostId
           ),
+          // Never older than the page itself: it was opened while the workspace was focused.
+          lastActiveAt: workspaceFocusedAt ? Math.max(workspaceFocusedAt, page.createdAt) : null,
           document: buildSearchableBrowserPageDocument({ page, workspace, worktree, repoName })
         })
       }

--- a/src/renderer/src/lib/browser-palette-search.test.ts
+++ b/src/renderer/src/lib/browser-palette-search.test.ts
@@ -363,6 +363,37 @@ describe('browser-palette-search', () => {
     expect(results[1].pageId).toBe('page-other')
   })
 
+  it('breaks a rank tie between equally-matching pages by recency', () => {
+    // Ids are ordered so an id-only tiebreak would flip this expectation.
+    const entries = [
+      makeEntry({
+        page: makePage({ id: 'page-a-older', title: 'React Docs' }),
+        workspace: makeWorkspace({ id: 'ws-1' }),
+        worktree: makeWorktree(),
+        repoName: 'repo',
+        worktreeSortIndex: 0,
+        isCurrentPage: false,
+        isCurrentWorktree: false,
+        lastActiveAt: 1000
+      }),
+      makeEntry({
+        page: makePage({ id: 'page-z-newer', title: 'React Docs' }),
+        workspace: makeWorkspace({ id: 'ws-2' }),
+        worktree: makeWorktree(),
+        repoName: 'repo',
+        worktreeSortIndex: 0,
+        isCurrentPage: false,
+        isCurrentWorktree: false,
+        lastActiveAt: 5000
+      })
+    ]
+
+    const results = searchBrowserPages(entries, 'react')
+
+    expect(results.map((result) => result.pageId)).toEqual(['page-z-newer', 'page-a-older'])
+    expect(results[0].lastActiveAt).toBe(5000)
+  })
+
   it('matches the visible workspace label in browser search', () => {
     const results = searchBrowserPages(
       [

--- a/src/renderer/src/lib/browser-palette-search.ts
+++ b/src/renderer/src/lib/browser-palette-search.ts
@@ -28,6 +28,8 @@ export type SearchableBrowserPage = {
   worktreeSortIndex: number
   isCurrentPage: boolean
   isCurrentWorktree: boolean
+  /** Last time the owning browser workspace was focused; null when never focused. */
+  lastActiveAt?: number | null
   /** Normalized field index, built once per entry rather than per keystroke. */
   document: PaletteDocument
 }
@@ -130,8 +132,8 @@ function compareEmptyQueryResults(
   return compareText(a.title, b.title)
 }
 
-// Why: empty-query browser ordering is intentionally deterministic and context-first.
-// The palette should not invent hidden browser recency semantics.
+// Why: empty-query browser ordering is intentionally deterministic and context-first;
+// lastActiveAt only breaks ties between equally-ranked query matches.
 function positionScore(entry: SearchableBrowserPage): number {
   if (entry.isCurrentPage) {
     return entry.worktreeSortIndex * 100 - 4000
@@ -163,7 +165,8 @@ function baseResult(entry: SearchableBrowserPage): BrowserPaletteSearchResult {
     isCurrentWorktree: entry.isCurrentWorktree,
     score: positionScore(entry),
     qualityClass: null,
-    rank: null
+    rank: null,
+    lastActiveAt: entry.lastActiveAt ?? null
   }
 }
 

--- a/src/renderer/src/lib/browser-palette-search.ts
+++ b/src/renderer/src/lib/browser-palette-search.ts
@@ -55,6 +55,7 @@ export type BrowserPaletteSearchResult = {
   score: number
   qualityClass: PaletteResultQualityClass | null
   rank: PaletteDocumentRank | null
+  lastActiveAt?: number | null
 }
 
 export const BROWSER_PALETTE_QUERY_MAX_BYTES = 2 * 1024
@@ -208,8 +209,18 @@ export function searchBrowserPages(
   return results.sort((a, b) =>
     a.rank && b.rank
       ? comparePaletteTabResults(
-          { rank: a.rank, positionScore: a.score, id: a.pageId },
-          { rank: b.rank, positionScore: b.score, id: b.pageId }
+          {
+            rank: a.rank,
+            positionScore: a.score,
+            id: a.pageId,
+            lastActiveAt: a.lastActiveAt ?? undefined
+          },
+          {
+            rank: b.rank,
+            positionScore: b.score,
+            id: b.pageId,
+            lastActiveAt: b.lastActiveAt ?? undefined
+          }
         )
       : compareEmptyQueryResults(a, b)
   )

--- a/src/renderer/src/lib/cmd-j-section-leadership.test.ts
+++ b/src/renderer/src/lib/cmd-j-section-leadership.test.ts
@@ -12,6 +12,7 @@ import type { PaletteDocumentRank } from './palette-match/palette-document'
 function rank(overrides: Partial<PaletteDocumentRank> = {}): PaletteDocumentRank {
   return {
     exactIntent: 1,
+    matchedDirectField: 0,
     wholeQuery: 3,
     worstQuality: 5,
     usesSupportingEvidence: 0,
@@ -114,9 +115,15 @@ describe('ranked item comparison', () => {
     expect(comparePaletteRankedItems(strong, weak)).toBeLessThan(0)
   })
 
-  it('falls back to the section order when match rank ties', () => {
-    const first = { rank: rank(), order: 1, id: 'z' }
-    const second = { rank: rank(), order: 2, id: 'a' }
+  it('prefers recently active item when match rank ties', () => {
+    const recent = { rank: rank(), order: 10, id: 'z', lastActiveAt: 2000 }
+    const older = { rank: rank(), order: 0, id: 'a', lastActiveAt: 1000 }
+    expect(comparePaletteRankedItems(recent, older)).toBeLessThan(0)
+  })
+
+  it('falls back to the section order when match rank and recency tie', () => {
+    const first = { rank: rank(), order: 1, id: 'z', lastActiveAt: 1000 }
+    const second = { rank: rank(), order: 2, id: 'a', lastActiveAt: 1000 }
     expect(comparePaletteRankedItems(first, second)).toBeLessThan(0)
   })
 

--- a/src/renderer/src/lib/cmd-j-section-leadership.ts
+++ b/src/renderer/src/lib/cmd-j-section-leadership.ts
@@ -31,9 +31,11 @@ export type PaletteRankedItem = {
   /** Existing smart-recency / list position, used only after match rank ties. */
   order: number
   id: string
+  /** Timestamp of most recent activity (focus or agent interaction). */
+  lastActiveAt?: number
 }
 
-/** Match rank first, then the section's own recency order, then a stable id. */
+/** Match rank first, then recent activity, then positional order, then stable id. */
 export function comparePaletteRankedItems(a: PaletteRankedItem, b: PaletteRankedItem): number {
   if (a.rank && b.rank) {
     const byRank = comparePaletteDocumentRank(a.rank, b.rank)
@@ -42,6 +44,13 @@ export function comparePaletteRankedItems(a: PaletteRankedItem, b: PaletteRanked
     }
   } else if (a.rank !== b.rank) {
     return a.rank ? -1 : 1
+  }
+  if (a.lastActiveAt !== b.lastActiveAt) {
+    const aTime = a.lastActiveAt ?? 0
+    const bTime = b.lastActiveAt ?? 0
+    if (aTime !== bTime) {
+      return bTime - aTime
+    }
   }
   if (a.order !== b.order) {
     return a.order - b.order

--- a/src/renderer/src/lib/palette-match/indexed-field.ts
+++ b/src/renderer/src/lib/palette-match/indexed-field.ts
@@ -30,6 +30,8 @@ export type PaletteFieldSource = {
   /** null marks a visible identity field; identity fields combine freely. */
   evidenceId?: string | null
   identifier?: PaletteIdentifierOptions
+  /** Container-level fields (e.g. worktree/branch for tabs) demote when matched alone. */
+  isContainer?: boolean
 }
 
 export type PaletteIndexedField = {
@@ -40,6 +42,7 @@ export type PaletteIndexedField = {
   words: readonly PaletteWord[]
   evidenceId: string | null
   identifier: PaletteIdentifierOptions | null
+  isContainer: boolean
 }
 
 const IDENTIFIER_PREFIX_KINDS: ReadonlySet<PaletteIdentifierKind> = new Set<PaletteIdentifierKind>([
@@ -125,7 +128,8 @@ export function indexPaletteField(source: PaletteFieldSource): PaletteIndexedFie
     atoms: segments.atoms,
     words: segments.words,
     evidenceId: source.evidenceId ?? null,
-    identifier: source.identifier ?? null
+    identifier: source.identifier ?? null,
+    isContainer: Boolean(source.isContainer)
   }
 }
 

--- a/src/renderer/src/lib/palette-match/match-document.ts
+++ b/src/renderer/src/lib/palette-match/match-document.ts
@@ -163,7 +163,8 @@ function rankAssignments(args: {
   let worstQuality: PaletteMatchQuality = 'field-exact'
   let fuzzyTokenCount = 0
   const fields = new Set<string>()
-  let hasDirectHit = args.usesEvidence
+  // Derive from field metadata only: an evidence field can itself be a container.
+  let hasDirectHit = false
 
   for (const assignment of args.assignments) {
     if (paletteMatchQualityRank(assignment.quality) > paletteMatchQualityRank(worstQuality)) {

--- a/src/renderer/src/lib/palette-match/match-document.ts
+++ b/src/renderer/src/lib/palette-match/match-document.ts
@@ -154,14 +154,16 @@ function buildAssignments(
 }
 
 function rankAssignments(args: {
+  document: PaletteDocument
   assignments: readonly PaletteTokenAssignment[]
   usesEvidence: boolean
   wholeQuery: number
   exactIntent: boolean
-}): { rank: PaletteDocumentRank; worstQuality: PaletteMatchQuality } {
+}): { rank: PaletteDocumentRank; worstQuality: PaletteMatchQuality; isContainerOnly: boolean } {
   let worstQuality: PaletteMatchQuality = 'field-exact'
   let fuzzyTokenCount = 0
   const fields = new Set<string>()
+  let hasDirectHit = args.usesEvidence
 
   for (const assignment of args.assignments) {
     if (paletteMatchQualityRank(assignment.quality) > paletteMatchQualityRank(worstQuality)) {
@@ -171,12 +173,20 @@ function rankAssignments(args: {
       fuzzyTokenCount += 1
     }
     fields.add(assignment.fieldId)
+    const field = args.document.fieldById.get(assignment.fieldId)
+    if (field && !field.isContainer) {
+      hasDirectHit = true
+    }
   }
+
+  const isContainerOnly = !hasDirectHit
 
   return {
     worstQuality,
+    isContainerOnly,
     rank: {
       exactIntent: args.exactIntent ? 0 : 1,
+      matchedDirectField: isContainerOnly ? 1 : 0,
       wholeQuery: args.wholeQuery,
       worstQuality: paletteMatchQualityRank(worstQuality),
       usesSupportingEvidence: args.usesEvidence ? 1 : 0,
@@ -274,7 +284,8 @@ export function matchPaletteDocument(args: {
       continue
     }
     const usedEvidenceId = built.usesEvidence ? evidenceId : null
-    const { rank, worstQuality } = rankAssignments({
+    const { rank, worstQuality, isContainerOnly } = rankAssignments({
+      document,
       assignments: built.assignments,
       usesEvidence: built.usesEvidence,
       wholeQuery,
@@ -288,7 +299,8 @@ export function matchPaletteDocument(args: {
         ? 'exact-intent'
         : resolvePaletteResultQualityClass({
             worstQuality,
-            usesSupportingEvidence: built.usesEvidence
+            usesSupportingEvidence: built.usesEvidence,
+            isContainerOnly
           }),
       rank,
       assignments: built.assignments,

--- a/src/renderer/src/lib/palette-match/match-quality.ts
+++ b/src/renderer/src/lib/palette-match/match-quality.ts
@@ -59,10 +59,14 @@ export function paletteResultQualityClassRank(value: PaletteResultQualityClass):
 export function resolvePaletteResultQualityClass(args: {
   worstQuality: PaletteMatchQuality
   usesSupportingEvidence: boolean
+  isContainerOnly?: boolean
 }): PaletteResultQualityClass {
-  const { worstQuality, usesSupportingEvidence } = args
+  const { worstQuality, usesSupportingEvidence, isContainerOnly } = args
   if (isFuzzyPaletteMatchQuality(worstQuality)) {
     return 'fuzzy-evidence'
+  }
+  if (isContainerOnly) {
+    return isExactPaletteMatchQuality(worstQuality) ? 'exact-evidence' : 'partial-evidence'
   }
   if (usesSupportingEvidence) {
     return isExactPaletteMatchQuality(worstQuality) ? 'exact-evidence' : 'partial-evidence'

--- a/src/renderer/src/lib/palette-match/palette-document.ts
+++ b/src/renderer/src/lib/palette-match/palette-document.ts
@@ -40,6 +40,7 @@ export type PaletteDocument = {
   /** Visible identity fields, cached because they carry the whole-query check. */
   visibleFields: readonly PaletteIndexedField[]
   fieldsByEvidenceId: ReadonlyMap<string, readonly PaletteIndexedField[]>
+  fieldById: ReadonlyMap<string, PaletteIndexedField>
 }
 
 export type PaletteDocumentInput = {
@@ -80,7 +81,9 @@ export function buildPaletteDocument(input: PaletteDocumentInput): PaletteDocume
   const fields = indexPaletteFields([...input.visibleFields, ...evidenceSources])
   const fieldsByEvidenceId = new Map<string, PaletteIndexedField[]>()
   const visibleFields: PaletteIndexedField[] = []
+  const fieldById = new Map<string, PaletteIndexedField>()
   for (const field of fields) {
+    fieldById.set(field.id, field)
     if (!field.evidenceId) {
       visibleFields.push(field)
       continue
@@ -103,7 +106,8 @@ export function buildPaletteDocument(input: PaletteDocumentInput): PaletteDocume
     evidenceUnits,
     renderOffsetByFieldId,
     visibleFields,
-    fieldsByEvidenceId
+    fieldsByEvidenceId,
+    fieldById
   }
 }
 
@@ -125,6 +129,8 @@ export type PaletteSupportingEvidence = {
 export type PaletteDocumentRank = {
   /** 0 when a recognized exact intent (such as a task URL) produced this row. */
   exactIntent: number
+  /** 0 when query matched at least one direct field; 1 when all matched tokens are container-only. */
+  matchedDirectField: number
   /** 0 equality, 1 prefix, 2 word boundary, 3 none — whole query in visible text. */
   wholeQuery: number
   worstQuality: number
@@ -144,6 +150,7 @@ export type PaletteDocumentMatch = {
 
 const RANK_KEYS: readonly (keyof PaletteDocumentRank)[] = [
   'exactIntent',
+  'matchedDirectField',
   'wholeQuery',
   'worstQuality',
   'usesSupportingEvidence',

--- a/src/renderer/src/lib/palette-match/palette-match-core.test.ts
+++ b/src/renderer/src/lib/palette-match/palette-match-core.test.ts
@@ -381,3 +381,35 @@ describe('typo distance', () => {
     expect(isWithinOnePaletteEdit(a, b)).toBe(expected)
   })
 })
+
+describe('container field matching', () => {
+  it('marks matchedDirectField as 1 and demotes quality class when all tokens land on container fields', () => {
+    const tabDoc: PaletteDocumentInput = {
+      id: 'tab-1',
+      visibleFields: [
+        { id: 'title', profile: 'structured-label', text: 'README.md' },
+        { id: 'worktree', profile: 'structured-label', text: 'STA-4360-feature', isContainer: true }
+      ],
+      evidence: []
+    }
+    const match = run(tabDoc, '4360')
+    expect(match).not.toBeNull()
+    expect(match?.rank.matchedDirectField).toBe(1)
+    expect(match?.qualityClass).toBe('exact-evidence')
+  })
+
+  it('marks matchedDirectField as 0 when at least one token lands on a direct field', () => {
+    const tabDoc: PaletteDocumentInput = {
+      id: 'tab-1',
+      visibleFields: [
+        { id: 'title', profile: 'structured-label', text: 'wsl-transcript-4360.ts' },
+        { id: 'worktree', profile: 'structured-label', text: 'STA-4360-feature', isContainer: true }
+      ],
+      evidence: []
+    }
+    const match = run(tabDoc, '4360')
+    expect(match).not.toBeNull()
+    expect(match?.rank.matchedDirectField).toBe(0)
+    expect(match?.qualityClass).toBe('exact-visible')
+  })
+})

--- a/src/renderer/src/lib/palette-match/tab-document.ts
+++ b/src/renderer/src/lib/palette-match/tab-document.ts
@@ -72,13 +72,29 @@ function dedupeSecondaryTexts(
 export function buildPaletteTabDocument(input: PaletteTabDocumentInput): PaletteDocument {
   const fields: PaletteFieldSource[] = [
     { id: PALETTE_TAB_TITLE_FIELD_ID, profile: 'structured-label', text: input.title },
-    { id: PALETTE_TAB_WORKTREE_FIELD_ID, profile: 'structured-label', text: input.worktreeName },
-    { id: PALETTE_TAB_BRANCH_FIELD_ID, profile: 'structured-label', text: input.branch },
-    { id: PALETTE_TAB_REPO_FIELD_ID, profile: 'structured-label', text: input.repoName },
+    {
+      id: PALETTE_TAB_WORKTREE_FIELD_ID,
+      profile: 'structured-label',
+      text: input.worktreeName,
+      isContainer: true
+    },
+    {
+      id: PALETTE_TAB_BRANCH_FIELD_ID,
+      profile: 'structured-label',
+      text: input.branch,
+      isContainer: true
+    },
+    {
+      id: PALETTE_TAB_REPO_FIELD_ID,
+      profile: 'structured-label',
+      text: input.repoName,
+      isContainer: true
+    },
     {
       id: PALETTE_TAB_WORKSPACE_FIELD_ID,
       profile: 'structured-label',
-      text: input.workspaceLabel ?? ''
+      text: input.workspaceLabel ?? '',
+      isContainer: true
     }
   ]
 

--- a/src/renderer/src/lib/palette-match/tab-match.ts
+++ b/src/renderer/src/lib/palette-match/tab-match.ts
@@ -12,7 +12,11 @@ import {
 } from './tab-document'
 import type { MatchRange } from './normalized-text'
 import type { PaletteResultQualityClass } from './match-quality'
-import type { PaletteDocument, PaletteDocumentRank } from './palette-document'
+import {
+  comparePaletteDocumentRank,
+  type PaletteDocument,
+  type PaletteDocumentRank
+} from './palette-document'
 
 const NO_RANGES: readonly MatchRange[] = []
 
@@ -93,22 +97,21 @@ export type PaletteTabRankInputs = {
   /** Existing positional score: current tab, current worktree, then list order. */
   positionScore: number
   id: string
+  /** Timestamp of most recent activity (focus or agent interaction). */
+  lastActiveAt?: number
 }
 
-const RANK_KEYS: readonly (keyof PaletteDocumentRank)[] = [
-  'exactIntent',
-  'wholeQuery',
-  'worstQuality',
-  'usesSupportingEvidence',
-  'fuzzyTokenCount',
-  'fieldHopCount'
-]
-
-/** Lexicographic match rank first, then the section's existing recency order. */
+/** Lexicographic match rank first, then recent activity, then positional order. */
 export function comparePaletteTabResults(a: PaletteTabRankInputs, b: PaletteTabRankInputs): number {
-  for (const key of RANK_KEYS) {
-    if (a.rank[key] !== b.rank[key]) {
-      return a.rank[key] - b.rank[key]
+  const byRank = comparePaletteDocumentRank(a.rank, b.rank)
+  if (byRank !== 0) {
+    return byRank
+  }
+  if (a.lastActiveAt !== b.lastActiveAt) {
+    const aTime = a.lastActiveAt ?? 0
+    const bTime = b.lastActiveAt ?? 0
+    if (aTime !== bTime) {
+      return bTime - aTime
     }
   }
   if (a.positionScore !== b.positionScore) {

--- a/src/renderer/src/lib/simulator-palette-search.test.ts
+++ b/src/renderer/src/lib/simulator-palette-search.test.ts
@@ -82,6 +82,42 @@ function makeEntry(entry: Omit<SearchableSimulatorTab, 'document'>): SearchableS
   }
 }
 
+describe('simulator-palette-search lastActiveAt', () => {
+  function entryFor(overrides: Partial<Tab>): SearchableSimulatorTab {
+    return makeEntry({
+      tab: makeTab(overrides),
+      worktree: makeWorktree(),
+      repoName: 'repo/mobile',
+      worktreeSortIndex: 0,
+      isCurrentTab: false,
+      isCurrentWorktree: true
+    })
+  }
+
+  it('is null when the tab was never focused', () => {
+    expect(searchSimulatorTabs([entryFor({})], '')[0].lastActiveAt).toBeNull()
+  })
+
+  it('carries the tab focus timestamp, never older than the tab itself', () => {
+    expect(
+      searchSimulatorTabs([entryFor({ createdAt: 5000, lastFocusedAt: 9000 })], '')[0].lastActiveAt
+    ).toBe(9000)
+    expect(
+      searchSimulatorTabs([entryFor({ createdAt: 5000, lastFocusedAt: 1000 })], '')[0].lastActiveAt
+    ).toBe(5000)
+  })
+
+  it('breaks a rank tie between equally-matching tabs by recency', () => {
+    // Ids are ordered so an id-only tiebreak would flip this expectation.
+    const older = entryFor({ id: 'sim-a-older', lastFocusedAt: 1000 })
+    const newer = entryFor({ id: 'sim-z-newer', lastFocusedAt: 5000 })
+
+    const results = searchSimulatorTabs([older, newer], 'emulator')
+
+    expect(results.map((result) => result.tabId)).toEqual(['sim-z-newer', 'sim-a-older'])
+  })
+})
+
 describe('simulator-palette-search', () => {
   it('keeps empty-query ordering deterministic and context-first', () => {
     const results = searchSimulatorTabs(

--- a/src/renderer/src/lib/simulator-palette-search.ts
+++ b/src/renderer/src/lib/simulator-palette-search.ts
@@ -54,6 +54,7 @@ export type SimulatorPaletteSearchResult = {
   score: number
   qualityClass: PaletteResultQualityClass | null
   rank: PaletteDocumentRank | null
+  lastActiveAt?: number | null
 }
 
 type SimulatorPaletteActiveTabType = 'browser' | 'editor' | 'terminal' | 'simulator'
@@ -290,8 +291,18 @@ export function searchSimulatorTabs(
   return results.sort((a, b) =>
     a.rank && b.rank
       ? comparePaletteTabResults(
-          { rank: a.rank, positionScore: a.score, id: a.tabId },
-          { rank: b.rank, positionScore: b.score, id: b.tabId }
+          {
+            rank: a.rank,
+            positionScore: a.score,
+            id: a.tabId,
+            lastActiveAt: a.lastActiveAt ?? undefined
+          },
+          {
+            rank: b.rank,
+            positionScore: b.score,
+            id: b.tabId,
+            lastActiveAt: b.lastActiveAt ?? undefined
+          }
         )
       : compareEmptyQueryResults(a, b)
   )

--- a/src/renderer/src/lib/simulator-palette-search.ts
+++ b/src/renderer/src/lib/simulator-palette-search.ts
@@ -115,8 +115,8 @@ function compareEmptyQueryResults(
   return compareText(a.title, b.title)
 }
 
-// Why: simulator tabs follow browser-tab Cmd+J ordering — deterministic and
-// context-first until Orca tracks per-tab recency for this surface.
+// Why: empty-query simulator ordering stays deterministic and context-first;
+// lastActiveAt only breaks ties between equally-ranked query matches.
 function positionScore(entry: SearchableSimulatorTab): number {
   if (entry.isCurrentTab) {
     return entry.worktreeSortIndex * 100 - 4000
@@ -150,7 +150,11 @@ function baseResult(entry: SearchableSimulatorTab): SimulatorPaletteSearchResult
     isCurrentWorktree: entry.isCurrentWorktree,
     score: positionScore(entry),
     qualityClass: null,
-    rank: null
+    rank: null,
+    // Never older than the tab itself: creation is a focus event too.
+    lastActiveAt: entry.tab.lastFocusedAt
+      ? Math.max(entry.tab.lastFocusedAt, entry.tab.createdAt)
+      : null
   }
 }
 

--- a/src/renderer/src/lib/workspace-tab-agent-metadata.test.ts
+++ b/src/renderer/src/lib/workspace-tab-agent-metadata.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import type { AgentStatusEntry } from '../../../shared/agent-status-types'
-import { collectAgentMetadataForTerminal } from './workspace-tab-agent-metadata'
+import {
+  collectAgentMetadataForTerminal,
+  maxAgentActivityAt,
+  type AgentMetadata
+} from './workspace-tab-agent-metadata'
 
 function makeEntry(overrides: Partial<AgentStatusEntry> = {}): AgentStatusEntry {
   return {
@@ -38,5 +42,47 @@ describe('collectAgentMetadataForTerminal', () => {
     expect(metadata?.textParts).toContain('Checkout race')
     expect(metadata?.snippetCandidates).toContain('Fix checkout race')
     expect(metadata?.snippetCandidates).toContain('Checkout race')
+  })
+
+  it('carries the live entry updatedAt through as lastActivityAt', () => {
+    const [metadata] = collectAgentMetadataForTerminal({
+      terminalTabId: 'tab-1',
+      worktreeId: 'wt-1',
+      agentStatusByPaneKey: { 'tab-1:leaf-1': makeEntry({ updatedAt: 5000 }) },
+      retainedAgentsByPaneKey: {},
+      sleepingAgentSessionsByPaneKey: {}
+    })
+
+    expect(metadata?.lastActivityAt).toBe(5000)
+  })
+})
+
+function makeMetadata(overrides: Partial<AgentMetadata> = {}): AgentMetadata {
+  return {
+    paneKey: 'pane-1',
+    textParts: [],
+    snippetCandidates: [],
+    lastActivityAt: 0,
+    ...overrides
+  }
+}
+
+describe('maxAgentActivityAt', () => {
+  it('returns null when there is no metadata', () => {
+    expect(maxAgentActivityAt([])).toBeNull()
+  })
+
+  it('returns the highest lastActivityAt across panes', () => {
+    const metadata = [
+      makeMetadata({ paneKey: 'pane-1', lastActivityAt: 1000 }),
+      makeMetadata({ paneKey: 'pane-2', lastActivityAt: 3000 }),
+      makeMetadata({ paneKey: 'pane-3', lastActivityAt: 2000 })
+    ]
+
+    expect(maxAgentActivityAt(metadata)).toBe(3000)
+  })
+
+  it('ignores non-positive lastActivityAt values', () => {
+    expect(maxAgentActivityAt([makeMetadata({ lastActivityAt: 0 })])).toBeNull()
   })
 })

--- a/src/renderer/src/lib/workspace-tab-agent-metadata.ts
+++ b/src/renderer/src/lib/workspace-tab-agent-metadata.ts
@@ -6,6 +6,18 @@ export type AgentMetadata = {
   paneKey: string
   textParts: string[]
   snippetCandidates: string[]
+  lastActivityAt: number
+}
+
+/** Latest agent activity across a tab's panes, or null if it has none. */
+export function maxAgentActivityAt(metadata: readonly AgentMetadata[]): number | null {
+  let max: number | null = null
+  for (const entry of metadata) {
+    if (entry.lastActivityAt > 0 && (max === null || entry.lastActivityAt > max)) {
+      max = entry.lastActivityAt
+    }
+  }
+  return max
 }
 
 export type WorkspaceTabAgentMetadataState = {
@@ -68,7 +80,7 @@ function agentRecordMatchesTab({
 
 function collectLiveMetadata(
   entry: AgentStatusEntry
-): Pick<AgentMetadata, 'snippetCandidates' | 'textParts'> {
+): Pick<AgentMetadata, 'snippetCandidates' | 'textParts' | 'lastActivityAt'> {
   const textParts: string[] = []
   const snippetCandidates: string[] = []
   addText(textParts, entry.orchestration?.displayName)
@@ -86,12 +98,12 @@ function collectLiveMetadata(
     addText(textParts, historyEntry.prompt)
     addText(snippetCandidates, historyEntry.prompt)
   }
-  return { textParts, snippetCandidates }
+  return { textParts, snippetCandidates, lastActivityAt: entry.updatedAt }
 }
 
 function collectSleepingMetadata(
   record: SleepingAgentSessionRecord
-): Pick<AgentMetadata, 'snippetCandidates' | 'textParts'> {
+): Pick<AgentMetadata, 'snippetCandidates' | 'textParts' | 'lastActivityAt'> {
   const textParts: string[] = []
   const snippetCandidates: string[] = []
   addText(textParts, record.prompt)
@@ -101,7 +113,7 @@ function collectSleepingMetadata(
   addText(textParts, record.terminalTitle)
   addText(snippetCandidates, record.terminalTitle)
   addProviderSession(textParts, record.providerSession)
-  return { textParts, snippetCandidates }
+  return { textParts, snippetCandidates, lastActivityAt: record.updatedAt }
 }
 
 export function collectAgentMetadataForTerminal({

--- a/src/renderer/src/lib/workspace-tab-agent-snippet-match.ts
+++ b/src/renderer/src/lib/workspace-tab-agent-snippet-match.ts
@@ -21,6 +21,7 @@ import type { AgentMetadata } from './workspace-tab-agent-metadata'
  */
 const AGENT_SNIPPET_RANK: PaletteDocumentRank = {
   exactIntent: 1,
+  matchedDirectField: 0,
   wholeQuery: 3,
   worstQuality: paletteMatchQualityRank(PALETTE_MATCH_QUALITIES.at(-1) as PaletteMatchQuality) + 1,
   usesSupportingEvidence: 1,

--- a/src/renderer/src/lib/workspace-tab-palette-activation.test.ts
+++ b/src/renderer/src/lib/workspace-tab-palette-activation.test.ts
@@ -118,6 +118,7 @@ function makeResult(
     score: 0,
     qualityClass: null,
     rank: null,
+    lastActiveAt: null,
     ...overrides
   }
 }

--- a/src/renderer/src/lib/workspace-tab-palette-entry-builder.ts
+++ b/src/renderer/src/lib/workspace-tab-palette-entry-builder.ts
@@ -92,9 +92,12 @@ function isCurrentWorkspaceTab({
   ) {
     return false
   }
+  if (activeUnifiedTabId) {
+    return activeUnifiedTabId === tab.id
+  }
   const visibleType = tab.contentType === 'terminal' ? 'terminal' : 'editor'
   const storedType = activeTabTypeByWorktree[tab.worktreeId] ?? activeTabType
-  if (storedType !== visibleType || activeUnifiedTabId !== tab.id) {
+  if (storedType !== visibleType) {
     return false
   }
   return visibleType === 'terminal'

--- a/src/renderer/src/lib/workspace-tab-palette-results.test.ts
+++ b/src/renderer/src/lib/workspace-tab-palette-results.test.ts
@@ -68,6 +68,7 @@ function makeEntry({
     worktreeSortIndex: 0,
     groupSortIndex: 0,
     tabSortIndex: 0,
+    occupantAgent: null,
     title,
     secondaryText: '',
     titleSearchText: title,
@@ -136,5 +137,74 @@ describe('searchWorkspaceTabs lastActiveAt', () => {
     })
     const [result] = searchWorkspaceTabs([entry], '')
     expect(result.lastActiveAt).toBe(4000)
+  })
+
+  it('uses tab lastFocusedAt when no agent metadata is present', () => {
+    const entry = makeEntry({
+      id: 'tab-focused',
+      createdAt: 1000
+    })
+    entry.tab.lastFocusedAt = 6000
+    const [result] = searchWorkspaceTabs([entry], '')
+    expect(result.lastActiveAt).toBe(6000)
+  })
+})
+
+describe('searchWorkspaceTabs ranking', () => {
+  it('ranks direct tab title matches ahead of container-only worktree matches', () => {
+    const directEntry = makeEntry({ id: 'README-4360' })
+    const containerEntry = makeEntry({ id: 'unrelated-file' })
+    // Both are in WORKTREE_NAME 'Aurora Workspace', but suppose worktree has 4360
+    directEntry.document = buildPaletteTabDocument({
+      id: 'tab-direct',
+      title: 'STA-4360-fix.ts',
+      secondaryTexts: [],
+      worktreeName: 'STA-4360',
+      branch: 'main',
+      repoName: 'repo'
+    })
+    containerEntry.document = buildPaletteTabDocument({
+      id: 'tab-container',
+      title: 'other-file.ts',
+      secondaryTexts: [],
+      worktreeName: 'STA-4360',
+      branch: 'main',
+      repoName: 'repo'
+    })
+
+    const results = searchWorkspaceTabs([containerEntry, directEntry], '4360')
+    expect(results).toHaveLength(2)
+    expect(results[0].tabId).toBe('README-4360')
+    expect(results[0].rank?.matchedDirectField).toBe(0)
+    expect(results[1].tabId).toBe('unrelated-file')
+    expect(results[1].rank?.matchedDirectField).toBe(1)
+  })
+
+  it('breaks tie between two container-matching tabs using lastActiveAt recency', () => {
+    const olderTab = makeEntry({ id: 'older-tab' })
+    const newerTab = makeEntry({ id: 'newer-tab' })
+    olderTab.document = buildPaletteTabDocument({
+      id: 'older',
+      title: 'file-a.ts',
+      secondaryTexts: [],
+      worktreeName: 'STA-4360',
+      branch: 'main',
+      repoName: 'repo'
+    })
+    newerTab.document = buildPaletteTabDocument({
+      id: 'newer',
+      title: 'file-b.ts',
+      secondaryTexts: [],
+      worktreeName: 'STA-4360',
+      branch: 'main',
+      repoName: 'repo'
+    })
+    olderTab.tab.lastFocusedAt = 1000
+    newerTab.tab.lastFocusedAt = 5000
+
+    const results = searchWorkspaceTabs([olderTab, newerTab], '4360')
+    expect(results).toHaveLength(2)
+    expect(results[0].tabId).toBe('newer-tab')
+    expect(results[1].tabId).toBe('older-tab')
   })
 })

--- a/src/renderer/src/lib/workspace-tab-palette-results.test.ts
+++ b/src/renderer/src/lib/workspace-tab-palette-results.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest'
+import type { Tab, TabContentType } from '../../../shared/tab-types'
+import type { Worktree } from '../../../shared/worktree/types'
+import { buildPaletteTabDocument } from './palette-match/tab-document'
+import { searchWorkspaceTabs } from './workspace-tab-palette-results'
+import type { SearchableWorkspaceTab } from './workspace-tab-palette-search'
+
+const REPO_NAME = 'octo/rocket'
+const WORKTREE_NAME = 'Aurora Workspace'
+const BRANCH_NAME = 'main'
+
+function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: 'wt-1',
+    repoId: 'repo-1',
+    path: '/tmp/wt-1',
+    head: 'abc123',
+    branch: 'refs/heads/main',
+    isBare: false,
+    isMainWorktree: false,
+    displayName: WORKTREE_NAME,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    ...overrides
+  }
+}
+
+function makeTab(id: string, contentType: TabContentType, createdAt: number): Tab {
+  return {
+    id,
+    entityId: `${id}-entity`,
+    groupId: 'group-1',
+    worktreeId: 'wt-1',
+    contentType,
+    label: id,
+    customLabel: null,
+    color: null,
+    sortOrder: 0,
+    createdAt
+  }
+}
+
+function makeEntry({
+  id = 'tab-1',
+  contentType = 'terminal',
+  createdAt = 0,
+  worktree = makeWorktree(),
+  agentLastActivityAt
+}: {
+  id?: string
+  contentType?: 'terminal' | 'editor'
+  createdAt?: number
+  worktree?: Worktree
+  agentLastActivityAt?: number
+} = {}): SearchableWorkspaceTab {
+  const title = id
+  return {
+    tab: makeTab(id, contentType, createdAt) as SearchableWorkspaceTab['tab'],
+    worktree,
+    repoName: REPO_NAME,
+    worktreeSortIndex: 0,
+    groupSortIndex: 0,
+    tabSortIndex: 0,
+    title,
+    secondaryText: '',
+    titleSearchText: title,
+    secondarySearchTexts: [],
+    document: buildPaletteTabDocument({
+      id,
+      title,
+      secondaryTexts: [],
+      worktreeName: WORKTREE_NAME,
+      branch: BRANCH_NAME,
+      repoName: REPO_NAME
+    }),
+    agentMetadata:
+      agentLastActivityAt === undefined
+        ? []
+        : [
+            {
+              paneKey: `${id}-pane`,
+              textParts: [],
+              snippetCandidates: [],
+              lastActivityAt: agentLastActivityAt
+            }
+          ],
+    isCurrentTab: false,
+    isCurrentWorktree: true
+  }
+}
+
+describe('searchWorkspaceTabs lastActiveAt', () => {
+  it('is null when neither agent activity nor worktree activity is known', () => {
+    const [result] = searchWorkspaceTabs([makeEntry()], '')
+    expect(result.lastActiveAt).toBeNull()
+  })
+
+  it('falls back to worktree PTY activity for editor tabs with no agent metadata', () => {
+    const entry = makeEntry({
+      contentType: 'editor',
+      worktree: makeWorktree({ lastActivityAt: 5000 })
+    })
+    const [result] = searchWorkspaceTabs([entry], '')
+    expect(result.lastActiveAt).toBe(5000)
+  })
+
+  it('prefers agent activity over worktree activity when agent activity is newer', () => {
+    const entry = makeEntry({
+      worktree: makeWorktree({ lastActivityAt: 1000 }),
+      agentLastActivityAt: 9000
+    })
+    const [result] = searchWorkspaceTabs([entry], '')
+    expect(result.lastActiveAt).toBe(9000)
+  })
+
+  it('prefers agent activity even when it is older than worktree activity', () => {
+    const entry = makeEntry({
+      worktree: makeWorktree({ lastActivityAt: 9000 }),
+      agentLastActivityAt: 1000
+    })
+    const [result] = searchWorkspaceTabs([entry], '')
+    expect(result.lastActiveAt).toBe(1000)
+  })
+
+  it('clamps to the tab creation time when the activity signal predates it', () => {
+    const entry = makeEntry({
+      createdAt: 4000,
+      worktree: makeWorktree({ lastActivityAt: 1000 })
+    })
+    const [result] = searchWorkspaceTabs([entry], '')
+    expect(result.lastActiveAt).toBe(4000)
+  })
+})

--- a/src/renderer/src/lib/workspace-tab-palette-results.ts
+++ b/src/renderer/src/lib/workspace-tab-palette-results.ts
@@ -10,6 +10,7 @@ import {
   resolveWorktreeDisplayName
 } from './worktree-default-display-name'
 import { matchWorkspaceTabAgentSnippet } from './workspace-tab-agent-snippet-match'
+import { maxAgentActivityAt } from './workspace-tab-agent-metadata'
 import type { ExecutionHostId } from '../../../shared/execution-host'
 import type { MatchRange } from './palette-match/normalized-text'
 import type { PaletteDocumentRank } from './palette-match/palette-document'
@@ -47,6 +48,8 @@ export type WorkspaceTabPaletteSearchResult = {
   score: number
   qualityClass: PaletteResultQualityClass | null
   rank: PaletteDocumentRank | null
+  /** Most recent activity for this tab, or null when nothing is known. */
+  lastActiveAt: number | null
 }
 
 function compareText(a: string, b: string): number {
@@ -82,6 +85,18 @@ function positionScore(entry: SearchableWorkspaceTab): number {
   return entry.isCurrentWorktree ? base - 1000 : base
 }
 
+function resolveWorkspaceTabLastActiveAt(entry: SearchableWorkspaceTab): number | null {
+  // Agent activity wins when present; otherwise fall back to the worktree's PTY
+  // activity, which covers idle terminals and editor tabs alike.
+  const candidate =
+    maxAgentActivityAt(entry.agentMetadata) ?? (entry.worktree.lastActivityAt || null)
+  if (candidate == null) {
+    return null
+  }
+  // Never report activity older than the tab itself (e.g. a stale worktree signal).
+  return Math.max(candidate, entry.tab.createdAt)
+}
+
 function baseResult(entry: SearchableWorkspaceTab): WorkspaceTabPaletteSearchResult {
   return {
     ...(entry.worktree.hostId ? { executionHostId: entry.worktree.hostId } : {}),
@@ -106,7 +121,8 @@ function baseResult(entry: SearchableWorkspaceTab): WorkspaceTabPaletteSearchRes
     isCurrentWorktree: entry.isCurrentWorktree,
     score: positionScore(entry),
     qualityClass: null,
-    rank: null
+    rank: null,
+    lastActiveAt: resolveWorkspaceTabLastActiveAt(entry)
   }
 }
 

--- a/src/renderer/src/lib/workspace-tab-palette-results.ts
+++ b/src/renderer/src/lib/workspace-tab-palette-results.ts
@@ -86,10 +86,11 @@ function positionScore(entry: SearchableWorkspaceTab): number {
 }
 
 function resolveWorkspaceTabLastActiveAt(entry: SearchableWorkspaceTab): number | null {
-  // Agent activity wins when present; otherwise fall back to the worktree's PTY
-  // activity, which covers idle terminals and editor tabs alike.
+  // Agent activity wins when present; then explicit tab focus; otherwise fall back to worktree.
   const candidate =
-    maxAgentActivityAt(entry.agentMetadata) ?? (entry.worktree.lastActivityAt || null)
+    maxAgentActivityAt(entry.agentMetadata) ??
+    entry.tab.lastFocusedAt ??
+    (entry.worktree.lastActivityAt || null)
   if (candidate == null) {
     return null
   }
@@ -193,8 +194,18 @@ export function searchWorkspaceTabs(
   return results.sort((a, b) =>
     a.rank && b.rank
       ? comparePaletteTabResults(
-          { rank: a.rank, positionScore: a.score, id: a.tabId },
-          { rank: b.rank, positionScore: b.score, id: b.tabId }
+          {
+            rank: a.rank,
+            positionScore: a.score,
+            id: a.tabId,
+            lastActiveAt: a.lastActiveAt ?? undefined
+          },
+          {
+            rank: b.rank,
+            positionScore: b.score,
+            id: b.tabId,
+            lastActiveAt: b.lastActiveAt ?? undefined
+          }
         )
       : compareEmptyQueryResults(a, b)
   )

--- a/src/renderer/src/lib/worktree-palette-task-url-result.ts
+++ b/src/renderer/src/lib/worktree-palette-task-url-result.ts
@@ -38,6 +38,7 @@ export function buildWorktreePaletteTaskUrlResult(args: {
     qualityClass: 'exact-intent',
     rank: {
       exactIntent: 0,
+      matchedDirectField: 0,
       wholeQuery: 0,
       worstQuality: 0,
       usesSupportingEvidence: 1,

--- a/src/renderer/src/store/slices/tabs-unread-and-focus.test.ts
+++ b/src/renderer/src/store/slices/tabs-unread-and-focus.test.ts
@@ -79,6 +79,35 @@ describe('TabsSlice', () => {
   })
 
   // Ghostty "show until interact": BEL always marks unread (even focused/visible tabs); only user interaction via clearTerminalTabUnread dismisses it.
+  describe('lastFocusedAt', () => {
+    it('stamps a newly created tab that activates', () => {
+      const before = Date.now()
+      const tab = store.getState().createUnifiedTab(WT, 'terminal')
+
+      const stored = store.getState().unifiedTabsByWorktree[WT].find((t) => t.id === tab.id)
+      expect(stored?.lastFocusedAt).toBeGreaterThanOrEqual(before)
+    })
+
+    it('leaves a background-created tab unstamped', () => {
+      const tab = store.getState().createUnifiedTab(WT, 'terminal', { activate: false })
+
+      const stored = store.getState().unifiedTabsByWorktree[WT].find((t) => t.id === tab.id)
+      expect(stored?.lastFocusedAt).toBeUndefined()
+    })
+
+    it('stamps a tab created into a new split group', () => {
+      const source = store.getState().createUnifiedTab(WT, 'terminal')
+      const before = Date.now()
+      const split = store.getState().createUnifiedTabInSplit(WT, 'terminal', {
+        sourceGroupId: source.groupId,
+        splitDirection: 'right'
+      })
+
+      const stored = store.getState().unifiedTabsByWorktree[WT].find((t) => t.id === split?.id)
+      expect(stored?.lastFocusedAt).toBeGreaterThanOrEqual(before)
+    })
+  })
+
   describe('markTerminalTabUnread', () => {
     it('marks the tab even when it is active in a visible split group of the active worktree', () => {
       // Group A: the worktree's root group (implicit from createUnifiedTab), populated with tabA.

--- a/src/renderer/src/store/slices/tabs.ts
+++ b/src/renderer/src/store/slices/tabs.ts
@@ -1059,14 +1059,18 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
             })()
           : state.unreadTerminalTabs
       return {
-        unifiedTabsByWorktree: opts?.preservePreview
-          ? state.unifiedTabsByWorktree
-          : {
-              ...state.unifiedTabsByWorktree,
-              [worktreeId]: (state.unifiedTabsByWorktree[worktreeId] ?? []).map((item) =>
-                item.id === tabId ? { ...item, isPreview: false } : item
-              )
-            },
+        unifiedTabsByWorktree: {
+          ...state.unifiedTabsByWorktree,
+          [worktreeId]: (state.unifiedTabsByWorktree[worktreeId] ?? []).map((item) =>
+            item.id === tabId
+              ? {
+                  ...item,
+                  isPreview: opts?.preservePreview ? item.isPreview : false,
+                  lastFocusedAt: Date.now()
+                }
+              : item
+          )
+        },
         groupsByWorktree: {
           ...state.groupsByWorktree,
           [worktreeId]: (state.groupsByWorktree[worktreeId] ?? []).map((group) =>

--- a/src/renderer/src/store/slices/tabs.ts
+++ b/src/renderer/src/store/slices/tabs.ts
@@ -854,6 +854,8 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
         }
       }
 
+      const shouldActivate = init?.activate ?? true
+      const createdAt = Date.now()
       created = {
         id,
         entityId: init?.entityId ?? id,
@@ -869,13 +871,14 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
         customLabel: init?.customLabel ?? null,
         color: init?.color ?? null,
         sortOrder: nextOrder.length,
-        createdAt: Date.now(),
+        createdAt,
+        // Why: creating an active tab is a focus event; Cmd+J recency reads lastFocusedAt.
+        ...(shouldActivate ? { lastFocusedAt: createdAt } : {}),
         isPreview: init?.isPreview,
         isPinned: init?.isPinned
       }
 
       nextOrder = dedupeTabOrder([...nextOrder, created.id])
-      const shouldActivate = init?.activate ?? true
       const nextActiveTabId = shouldActivate ? created.id : (group.activeTabId ?? created.id)
       const sanitizedRecent = sanitizeRecentTabIds(group.recentTabIds, nextOrder)
       // Why: automation-created browser tabs must paint without stealing the visible group selection from the user's current tab.
@@ -925,6 +928,7 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
       const currentLayout =
         state.layoutByWorktree[worktreeId] ??
         ({ type: 'leaf', groupId: target.sourceGroupId } as const)
+      const createdAt = Date.now()
       const createdTab: Tab = {
         id,
         entityId: init?.entityId ?? id,
@@ -940,7 +944,9 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
         customLabel: init?.customLabel ?? null,
         color: init?.color ?? null,
         sortOrder: 0,
-        createdAt: Date.now(),
+        createdAt,
+        // Why: creating an active tab is a focus event; Cmd+J recency reads lastFocusedAt.
+        ...(shouldActivate ? { lastFocusedAt: createdAt } : {}),
         isPreview: init?.isPreview,
         isPinned: init?.isPinned
       }

--- a/src/shared/tab-types.ts
+++ b/src/shared/tab-types.ts
@@ -58,6 +58,8 @@ export type Tab = {
    *  underneath; `'terminal'` (the default for legacy/missing) shows the raw
    *  xterm. Optional so sessions persisted before this field hydrate cleanly. */
   viewMode?: 'terminal' | 'chat'
+  /** Timestamp when the tab was last focused / activated by the user. */
+  lastFocusedAt?: number
 }
 
 export type TabGroup = {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​525 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​519 |
| Prod | 21 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​303 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​107 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​196 |

<!-- /orca-pr-loc -->

## ELI5

Cmd+J now puts the row you actually meant at the top. Matching a real name — a tab title, a file path, agent output — beats matching only the *container* a row lives in (worktree, branch, repo, workspace label), so typing a worktree name no longer buries the one tab you wanted under every other tab in that worktree. When two rows are equally good, the one you touched most recently wins. Every row also carries a small "how long ago" badge, so a live session is distinguishable from one you abandoned five days ago.

## What Changed

**Ranking: direct fields beat container fields**

- `PaletteDocumentRank` gains `matchedDirectField`, ordered right after `exactIntent`. A row whose matched tokens all landed on container fields sorts below any row with a direct hit.
- Container-ness is declared at the source (`PaletteFieldSource.isContainer`, set by `buildPaletteTabDocument` for worktree / branch / repo / workspace-label) and read back through the new `PaletteDocument.fieldById` index, so `rankAssignments` classifies from field metadata rather than inferring it at compare time.
- Container-only matches also drop to the `*-evidence` quality class, landing in the same visual tier as supporting-evidence hits.

**Ranking: recency as a tiebreak**

- `comparePaletteTabResults` and `comparePaletteRankedItems` compare newest `lastActiveAt` first, between match rank and positional score. It only ever breaks ties — an exact title match never loses to a merely-recent row, and empty-query ordering stays deterministic.
- `comparePaletteTabResults` now delegates to the shared `comparePaletteDocumentRank` instead of maintaining a second rank-key list that could drift from `PaletteDocumentRank`.

**Where the recency signal comes from**

- New optional `Tab.lastFocusedAt`, stamped by `activateTab` and by `createUnifiedTab` / `createUnifiedTabInSplit` when the created tab activates. Background-created tabs stay unstamped, so tabs opened by automation don't claim recency they never had.
- Workspace tabs resolve activity as newest agent activity → tab focus → worktree activity, clamped so a stale worktree signal can never predate `tab.createdAt`.
- Agent metadata now carries `lastActivityAt` (live `entry.updatedAt`, sleeping `record.updatedAt`), aggregated by `maxAgentActivityAt`.
- Simulator tabs read their own `lastFocusedAt`. Browser pages read the owning workspace's unified-tab focus — the finest granularity Orca tracks for browsers — clamped to `page.createdAt`.

**UI**

- New `formatPaletteSessionAge` renders `<1m` / `12m` / `3h` / `5d` as a muted `tabular-nums` badge on worktree, workspace-tab, simulator, and browser rows, with an `aria-label` of "Last active {age} ago". It never prints "now", since that label would read "Last active now ago".
- The clock is frozen when the palette opens (`paletteNowMs`), so badges don't tick while you type.
- The per-row host badge chip is dropped from worktree and project rows to make room; host context still comes from the host filter and the worktree rail.
- `isCurrentWorkspaceTab` fix: when an active unified tab id is known, trust it directly instead of additionally requiring the stored visible-tab-type to agree — the two disagree after some split/activation paths, and the current tab lost its badge.

## Why

Ranking was match quality plus list position, with no notion of *where* a match landed or *when* the row was last used. Two things fell out of that: typing a worktree name (`4360`) filled the top of the palette with every tab in that worktree, and rows tied on quality fell back to list order rather than to what you had actually been working in.

Both fixes sit where the information already lives. "Container vs. direct" is a property of the field, so it is declared when the document is built rather than guessed during comparison. Recency is a tiebreak rather than a score component, which keeps the ordering rules independent and prevents a recently-touched-but-poor match from outranking a good one.

## Linked Issue

<!-- TODO(author): link the issue this PR addresses -->

Fixes #

## Visual Proof

<!-- TODO(author): attach BEFORE / AFTER of the Cmd+J palette — (1) the session-age badge on rows, (2) a worktree-name query showing direct matches ranked above container-only matches. -->

## Testing

Automated, all green on this branch:

- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib` — 444 files, 4226 tests passed
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/store/slices` — 267 files, 2680 tests passed
- Palette component suites (`WorktreeJumpPalette`, `components/cmd-j`, `components/tab-bar`) passed
- `tsc --noEmit -p config/tsconfig.tc.web.json` clean; `oxlint` and `oxfmt --check` clean

New coverage: session-age bucket formatting, direct-vs-container ranking, recency tiebreaks for workspace / simulator / browser rows (ids are deliberately ordered so an id-only tiebreak would fail the assertion), `lastFocusedAt` stamping on create / split / activate, and agent `lastActivityAt` aggregation.

Reviewer steps: open Cmd+J, type a worktree or branch name, and confirm tabs whose own title matches sort above tabs that merely belong to that worktree; confirm each row shows a session-age badge and that the badge does not tick while you keep typing.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

<!-- DO NOT FILL IN IF YOU ARE STABLYAI TEAM MEMBER (INTERNAL CONTRIBUTOR), IGNORE SECTION: -->
<!-- Which AI model if anyone was used, please state the details -->

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

- **Backwards compatibility**: `Tab.lastFocusedAt` and the agent `lastActivityAt` field are optional, so sessions persisted before this change hydrate cleanly — those tabs fall back to worktree activity, or show no badge until first focus.
- **Remote / SSH**: renderer-only. No main-process, IPC, RPC, or stream-frame surface is touched, so this is a pure client-side ranking and presentation change and needs no capability negotiation against older hosts.
- **Cross-platform**: no new shortcuts, accelerators, or path handling; nothing platform-conditional was added.
- **Folder workspaces**: recency falls back through agent activity and worktree activity, so folder workspaces and non-git worktrees behave the same as git worktrees.
- **Performance**: ranking stays O(matches) — the container flag is precomputed at index time into `fieldById`, and `paletteNowMs` is computed once per palette open rather than per keystroke or per row.

## Checklist

- [ ] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [ ] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @your_handle
  <!-- Optional but appreciated -->
