### PR TITLE
fix(pty): parse a user alias named codex in shell-ready wrappers

### DIFF
--- a/src/main/pty/codex-shell-launch-preflight.test.ts
+++ b/src/main/pty/codex-shell-launch-preflight.test.ts
@@ -92,6 +92,59 @@ describe.skipIf(process.platform === 'win32')('Codex shell launch preflight', ()
     expect(runAliasLaunch(root, getPosixCodexShellLaunchPreflight(), '/bin/zsh')).toBe('normal')
   })
 
+  it.each([
+    ['/bin/zsh', 'setopt aliases ALIAS_FUNC_DEF'],
+    ['/bin/bash', 'shopt -s expand_aliases']
+  ])(
+    'parses in %s when the user already aliased the name codex',
+    (shell, enableAliases) => {
+      if (!existsSync(shell)) {
+        return
+      }
+      const root = mkdtempSync(join(tmpdir(), 'orca-codex-named-alias-'))
+      roots.push(root)
+      const bin = join(root, 'bin')
+      mkdirSync(bin)
+      writeExecutable(join(bin, 'codex'), '#!/bin/sh\nprintf launched\\n')
+      writeExecutable(
+        join(bin, 'orca-test'),
+        '#!/bin/sh\n[ "$1 $2 $3" = "agent hooks prepare-codex" ] || exit 2\n'
+      )
+      // Why a sourced file nested in `if true`: zsh parses a compound command
+      // before running it, so `codex()` inside Orca's non-login zshrc gate
+      // expands a user alias even if `unalias` appears earlier in that `if`.
+      const startup = join(root, 'startup.sh')
+      writeFileSync(
+        startup,
+        [
+          enableAliases,
+          "alias codex='GIT_AUTHOR_NAME=Codex GIT_AUTHOR_EMAIL=codex@openai.com GIT_COMMITTER_NAME=Codex GIT_COMMITTER_EMAIL=codex@openai.com codex --dangerously-bypass-approvals-and-sandbox'",
+          'if true; then',
+          getPosixCodexShellLaunchPreflight(),
+          'fi',
+          'printf parsed\\n',
+          'codex'
+        ].join('\n')
+      )
+
+      const result = spawnSync(
+        shell,
+        shell.endsWith('/zsh') ? ['-f', startup] : ['--noprofile', '--norc', startup],
+        {
+          encoding: 'utf-8',
+          env: {
+            ...process.env,
+            PATH: `${bin}${delimiter}${process.env.PATH ?? ''}`,
+            ORCA_CODEX_LAUNCH_PREFLIGHT: join(bin, 'orca-test')
+          }
+        }
+      )
+
+      expect(result.status, result.stderr).toBe(0)
+      expect(result.stdout).toBe('parsed\nlaunched\n')
+    }
+  )
+
   it('still launches Codex when the best-effort preflight fails', () => {
     const root = mkdtempSync(join(tmpdir(), 'orca-codex-preflight-failure-'))
     roots.push(root)

--- a/src/main/pty/codex-shell-launch-preflight.ts
+++ b/src/main/pty/codex-shell-launch-preflight.ts
@@ -60,12 +60,17 @@ function isExecutableFileOnDisk(path: string, platform: NodeJS.Platform): boolea
 
 export function getPosixCodexShellLaunchPreflight(): string {
   return `# Why: a typed alias expands inside the shell, after pane launch prep.
+# Why: unalias, then eval the function definition, so a user alias named
+# codex cannot expand into the function header at parse time (interactive
+# zsh ALIAS_FUNC_DEF, bash expand_aliases), even when this block sits
+# inside another compound command such as zshrc's non-login gate.
+unalias codex 2>/dev/null || true
 __orca_codex_binary="$(command -v codex 2>/dev/null || :)"
 if [[ -n "\${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" && -n "\${__orca_codex_binary:-}" && -x "\${__orca_codex_binary}" ]]; then
-  codex() {
+  eval 'codex() {
     "\${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex >/dev/null 2>&1 || :
     command codex "$@"
-  }
+  }'
 fi
 unset __orca_codex_binary
 `


### PR DESCRIPTION
## ELI5

If someone has `alias codex='… codex --flags'`, Orca's zsh wrapper dies at startup with `parse error near '()'`. Interactive zsh expands that alias into the `codex()` header, and the wrapper sits inside `.zshrc`'s non-login `if`, so `unalias` in the same block is too late. The wrapper now unaliases, then `eval`s the function body, so parse never sees the name.

## What Changed

- `src/main/pty/codex-shell-launch-preflight.ts` — `unalias codex` first, then define the wrapper with `eval 'codex() { … }'` so a same-name alias cannot expand into the function header at parse time, even when the snippet is nested in another compound command.
- `src/main/pty/codex-shell-launch-preflight.test.ts` — sourced nested-`if` regression for zsh `ALIAS_FUNC_DEF` and bash `expand_aliases` using a user alias named `codex`.

Existing `alias cx=codex` coverage is unchanged.

## Why

The current tests alias `cx` to `codex`. They do not alias the name `codex` itself, and they run the snippet in a `zsh -c` string that is parsed before any alias exists. A real startup file sources the user's `.zshrc` first, then parses the wrapper. That is the failure.

Repro:

```zsh
# user .zshrc
alias codex="GIT_AUTHOR_NAME='Codex' GIT_AUTHOR_EMAIL='codex@openai.com' GIT_COMMITTER_NAME='Codex' GIT_COMMITTER_EMAIL='codex@openai.com' codex --dangerously-bypass-approvals-and-sandbox"
```

Then an Orca-managed zsh reports:

```text
…/shell-ready/zsh/.zshrc:60: parse error near `()'
…/shell-ready/zsh/.zlogin:59: parse error near `()'
```

`zsh -n` on the wrapper files is clean. The error is expansion-time.