### PR TITLE
fix(terminal): copy relay terminal IDs from the remote PTY handle

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-handle-copy.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-handle-copy.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
+import { toRemoteRuntimePtyId } from '../../../../shared/remote-runtime-pty-id'
 import { copyTerminalHandleForPane } from './terminal-handle-copy'
 
 const LEAF_ID = '11111111-1111-4111-8111-111111111111'
@@ -57,5 +58,23 @@ describe('copyTerminalHandleForPane', () => {
     ).rejects.toThrow('terminal not found')
 
     expect(writeClipboardText).not.toHaveBeenCalled()
+  })
+
+  it('copies a relay terminal handle without asking the local runtime', async () => {
+    const callRuntime = vi.fn()
+    const writeClipboardText = vi.fn().mockResolvedValue(undefined)
+
+    await expect(
+      copyTerminalHandleForPane({
+        tabId: 'tab-1',
+        leafId: LEAF_ID,
+        ptyId: toRemoteRuntimePtyId('term_remote', 'env-relay'),
+        callRuntime,
+        writeClipboardText
+      })
+    ).resolves.toBe('term_remote')
+
+    expect(callRuntime).not.toHaveBeenCalled()
+    expect(writeClipboardText).toHaveBeenCalledWith('term_remote')
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-handle-copy.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-handle-copy.ts
@@ -1,9 +1,11 @@
 import type { RuntimeRpcResponse } from '../../../../shared/runtime-rpc-envelope'
+import { parseRemoteRuntimePtyId } from '../../../../shared/remote-runtime-pty-id'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 
 type CopyTerminalHandleDeps = {
   tabId: string
   leafId: string
+  ptyId?: string | null
   callRuntime: (request: {
     method: 'terminal.resolvePane'
     params: { paneKey: string }
@@ -14,9 +16,16 @@ type CopyTerminalHandleDeps = {
 export async function copyTerminalHandleForPane({
   tabId,
   leafId,
+  ptyId,
   callRuntime,
   writeClipboardText
 }: CopyTerminalHandleDeps): Promise<string> {
+  // Why: relay panes live on the remote runtime. Local resolvePane cannot see them.
+  const remoteHandle = ptyId ? parseRemoteRuntimePtyId(ptyId)?.handle.trim() : ''
+  if (remoteHandle) {
+    await writeClipboardText(remoteHandle)
+    return remoteHandle
+  }
   const paneKey = makePaneKey(tabId, leafId)
   const response = await callRuntime({
     method: 'terminal.resolvePane',

--- a/src/renderer/src/components/terminal-pane/terminal-handle-copy.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-handle-copy.ts
@@ -13,6 +13,7 @@ type CopyTerminalHandleDeps = {
   writeClipboardText: (text: string) => Promise<void>
 }
 
+/** Copy the CLI terminal handle for a pane. Relay panes are not in the local runtime, so use the encoded remote handle when present. */
 export async function copyTerminalHandleForPane({
   tabId,
   leafId,
@@ -42,6 +43,7 @@ export async function copyTerminalHandleForPane({
   return handle
 }
 
+/** Read `terminal.handle` from a `terminal.resolvePane` result. */
 function readResolvedTerminalHandle(result: unknown): string | null {
   if (!isRecord(result) || !isRecord(result.terminal)) {
     return null
@@ -49,6 +51,7 @@ function readResolvedTerminalHandle(result: unknown): string | null {
   return typeof result.terminal.handle === 'string' ? result.terminal.handle : null
 }
 
+/** Narrow unknown RPC payloads to a plain object. */
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null
 }

--- a/src/renderer/src/components/terminal-pane/terminal-pane-menu-copy-actions.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-menu-copy-actions.ts
@@ -5,6 +5,7 @@ import { translate } from '@/i18n/i18n'
 import { copyTerminalHandleForPane } from './terminal-handle-copy'
 import { runCopyPaneId, runTerminalCopy } from './terminal-copy-rejection-guards'
 
+/** Copy the current terminal selection from a context-menu pane. */
 export const copyTerminalPaneMenuSelection = async (pane: ManagedPane | null): Promise<void> => {
   if (!pane) {
     return
@@ -20,6 +21,7 @@ export const copyTerminalPaneMenuSelection = async (pane: ManagedPane | null): P
   })
 }
 
+/** Copy the stable pane key from a context-menu pane. */
 export const copyTerminalPaneMenuPaneId = async (
   pane: ManagedPane | null,
   tabId: string
@@ -52,6 +54,7 @@ export const copyTerminalPaneMenuPaneId = async (
   })
 }
 
+/** Copy Terminal ID from a context-menu pane. Relay panes use the encoded remote handle. */
 export const copyTerminalPaneMenuTerminalId = async (
   pane: ManagedPane | null,
   tabId: string,

--- a/src/renderer/src/components/terminal-pane/terminal-pane-menu-copy-actions.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-menu-copy-actions.ts
@@ -54,7 +54,8 @@ export const copyTerminalPaneMenuPaneId = async (
 
 export const copyTerminalPaneMenuTerminalId = async (
   pane: ManagedPane | null,
-  tabId: string
+  tabId: string,
+  ptyId?: string | null
 ): Promise<void> => {
   if (!pane) {
     return
@@ -63,6 +64,7 @@ export const copyTerminalPaneMenuTerminalId = async (
     await copyTerminalHandleForPane({
       tabId,
       leafId: pane.leafId,
+      ptyId,
       callRuntime: window.api.runtime.call,
       writeClipboardText: window.api.ui.writeTerminalClipboardText
     })

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
@@ -166,8 +166,11 @@ export function useTerminalPaneContextMenu({
   const onCopyPaneId = async (): Promise<void> =>
     copyTerminalPaneMenuPaneId(resolveMenuPane(), tabId)
 
-  const onCopyTerminalId = async (): Promise<void> =>
-    copyTerminalPaneMenuTerminalId(resolveMenuPane(), tabId)
+  const onCopyTerminalId = async (): Promise<void> => {
+    const pane = resolveMenuPane()
+    const ptyId = pane ? (paneTransportsRef.current.get(pane.id)?.getPtyId() ?? null) : null
+    return copyTerminalPaneMenuTerminalId(pane, tabId, ptyId)
+  }
 
   const onPaste = async (): Promise<void> => pasteResolvedPane('context-menu')
 

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
@@ -73,6 +73,7 @@ type TerminalMenuState = {
   runForPane: <Result>(paneId: number, action: () => Result) => Result
 }
 
+/** Context-menu actions for a terminal tab, including Copy Terminal ID. */
 export function useTerminalPaneContextMenu({
   managerRef,
   paneTransportsRef,


### PR DESCRIPTION
## ELI5

Copy Terminal ID looked up the handle on this machine. Relay terminals live on the remote, so the lookup failed. The menu now copies the remote handle that the pane already has.

## What Changed

Copy Terminal ID reads the encoded remote PTY handle when the pane is a relay terminal. Local panes still use `terminal.resolvePane`.

## Why

Relay panes are not registered in the local runtime, so `terminal.resolvePane` returns not found and the menu shows Unable to copy terminal ID.

## Linked Issue

Fixes #15553

## Visual Proof

N/A. The toast text is unchanged. Only the lookup path for relay panes changed.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

`pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-handle-copy.test.ts` (3 passed). The new case copies a relay handle without calling the local runtime.

## AI Disclosure

Grok 4.6

## Review

- Cross-platform: clipboard write is unchanged.
- SSH/remote: this is the relay path. Local resolve is unchanged.
- Performance: one string parse, no extra RPC on relay panes.
- Security: still copies only the existing terminal handle.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No visual change.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
