### PR TITLE
fix(terminal): keep xterm's render pause latched for a pane with no layout box

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-webgl-renderer.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-renderer.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
 import { WebglAddon } from '@xterm/addon-webgl'
 import type { ManagedPaneInternal } from './pane-manager-types'
 import {
@@ -66,7 +66,7 @@ function createFittablePane(): ManagedPaneInternal {
 type FakeRenderService = {
   _isPaused: boolean
   _needsFullRefresh: boolean
-  refreshRows: ReturnType<typeof vi.fn>
+  refreshRows: Mock<(start: number, end: number, sync?: boolean) => void>
 }
 
 /** A pane whose xterm render service is paused, as it is whenever the pane has
@@ -81,7 +81,7 @@ function createPausedPane(display: 'block' | 'none'): {
     _isPaused: true,
     _needsFullRefresh: false,
     // Mirrors xterm: a refresh while paused only latches the pending full repaint.
-    refreshRows: vi.fn(() => {
+    refreshRows: vi.fn<(start: number, end: number, sync?: boolean) => void>(() => {
       if (renderService._isPaused) {
         renderService._needsFullRefresh = true
       }

--- a/src/renderer/src/lib/pane-manager/pane-webgl-renderer.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-renderer.test.ts
@@ -63,6 +63,42 @@ function createFittablePane(): ManagedPaneInternal {
   return pane
 }
 
+type FakeRenderService = {
+  _isPaused: boolean
+  _needsFullRefresh: boolean
+  refreshRows: ReturnType<typeof vi.fn>
+}
+
+/** A pane whose xterm render service is paused, as it is whenever the pane has
+ *  no layout box: `display` decides whether the element is one xterm's
+ *  IntersectionObserver would report as intersecting. */
+function createPausedPane(display: 'block' | 'none'): {
+  pane: ManagedPaneInternal
+  renderService: FakeRenderService
+} {
+  const pane = createPane()
+  const renderService: FakeRenderService = {
+    _isPaused: true,
+    _needsFullRefresh: false,
+    // Mirrors xterm: a refresh while paused only latches the pending full repaint.
+    refreshRows: vi.fn(() => {
+      if (renderService._isPaused) {
+        renderService._needsFullRefresh = true
+      }
+    })
+  }
+  const view = { getComputedStyle: () => ({ display }) }
+  const element = { ownerDocument: { defaultView: view }, parentElement: null }
+  pane.container = element as never
+  pane.xtermContainer = element as never
+  pane.terminal = {
+    ...pane.terminal,
+    refresh: vi.fn(() => renderService.refreshRows(0, pane.terminal.rows - 1)),
+    _core: { _renderService: renderService }
+  } as never
+  return { pane, renderService }
+}
+
 describe('terminal WebGL addon lifecycle', () => {
   beforeEach(() => {
     resetTerminalWebglSuggestion()
@@ -130,6 +166,36 @@ describe('terminal WebGL addon lifecycle', () => {
     resetWebglTextureAtlas(pane)
 
     expect(pane.terminal.refresh).toHaveBeenCalledWith(0, 23)
+  })
+
+  it('keeps the render pause latched when resetting a pane that has no layout box', () => {
+    // Regression: the atlas reset released xterm's pause for every pane of a
+    // visible manager, including a collapsed sibling of an expanded pane. That
+    // painted the freshly cleared model into an element with no box, and left
+    // the service unpaused for good — the IntersectionObserver only fires on a
+    // change, so it never re-pauses. Clearing _needsFullRefresh with it drops
+    // the repaint the observer owes the pane on reveal, and the deferred
+    // _pausedResizeTask that rides along with it.
+    const { pane, renderService } = createPausedPane('none')
+
+    resetWebglTextureAtlas(pane)
+
+    expect(renderService._isPaused).toBe(true)
+    expect(renderService._needsFullRefresh).toBe(true)
+    expect(pane.terminal.refresh).toHaveBeenCalledWith(0, 23)
+  })
+
+  it('still forces the paused render through for a pane that has a layout box', () => {
+    // The reveal case the release exists for: DOM-visible, but xterm's observer
+    // has not caught up, so a plain refresh() would be swallowed.
+    const { pane, renderService } = createPausedPane('block')
+
+    resetWebglTextureAtlas(pane)
+
+    expect(renderService._isPaused).toBe(false)
+    expect(renderService._needsFullRefresh).toBe(false)
+    expect(renderService.refreshRows).toHaveBeenCalledWith(0, 23, true)
+    expect(pane.terminal.refresh).not.toHaveBeenCalled()
   })
 
   it('skips the reset while WebGL is latched off after a context loss', () => {

--- a/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
@@ -2,6 +2,7 @@ import { WebglAddon } from '@xterm/addon-webgl'
 import type { ManagedPaneInternal } from './pane-manager-types'
 import { recordTerminalWebglDiagnostic } from '../../../../shared/terminal-webgl-diagnostics'
 import { getLivePaneCensus } from './pane-manager-registry'
+import { isManagedPaneDisplayNone } from './pane-display-visibility'
 import { forceRepaintThroughRenderPause } from './terminal-render-pause-release'
 import {
   getTerminalWebglAutoDecision,
@@ -151,7 +152,17 @@ export function resetWebglTextureAtlas(pane: ManagedPaneInternal): void {
     // paused-render gate and the cleared model never repaints (stale bottom rows
     // until a drag-select forces a redraw). Force the paused render through
     // first; only fall back to refresh() when the terminal was not gated.
-    if (!forceRepaintThroughRenderPause(pane.terminal)) {
+    //
+    // Why the display check: that release is only right for a pane that is
+    // DOM-visible. A pane with no box at all (collapsed sibling of an expanded
+    // pane, a restore that stays display:none for its whole reattach) is
+    // legitimately paused, and releasing it paints the just-cleared model into
+    // nothing and then leaves the service unpaused for good — the observer only
+    // fires on a change, so it never re-pauses. Clearing _needsFullRefresh with
+    // it also drops the full repaint the observer owes the pane on reveal, and
+    // the deferred _pausedResizeTask that flushes alongside it. Latching is what
+    // xterm's own gate does, and the reveal repaints from the latch.
+    if (isManagedPaneDisplayNone(pane) || !forceRepaintThroughRenderPause(pane.terminal)) {
       // Why: refresh even without a WebGL addon so recovery never silently
       // no-ops — a DOM-rendered pane can hold stale pixels after reveal too.
       pane.terminal.refresh(0, pane.terminal.rows - 1)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​67 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​66 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​11 |

<!-- /orca-pr-loc -->

## ELI5

When a terminal pane is genuinely hidden with `display: none`, xterm pauses its renderer. Orca's atlas recovery also has a special un-pause step for a different case: a pane that is already visible while xterm's visibility observer is still one frame behind.

A visible pane manager can contain a hidden sibling, such as the sibling of an expanded pane. Atlas recovery was applying the visible-pane un-pause to that hidden sibling too. The sibling's canvas backing store kept its last valid size, so rendering still produced correct pixels, but xterm was left unpaused and performed every later full render while the pane remained invisible.

Now a genuinely hidden pane stays paused and records one full-refresh debt, which xterm pays on reveal. Visible output is unchanged; the fix restores xterm's pause/latch semantics and removes wasted invisible rendering.

## What Changed

`resetWebglTextureAtlas()` (`src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts`) now checks `isManagedPaneDisplayNone(pane)` before calling `forceRepaintThroughRenderPause()`. A pane with no layout box falls to the existing `pane.terminal.refresh(0, rows - 1)` branch: xterm's paused `refreshRows` early-returns and latches `_needsFullRefresh`.

A pane that has a box keeps the existing forced-release behavior for observer-lagged reveal.

## Why

`forceRepaintThroughRenderPause` is for a pane that is DOM-visible while xterm's observer callback lags. It was also reached for a `display: none` pane inside a manager that was visible for atlas recovery.

The production reachability is narrower than “any hidden terminal”:

- `resetAndRefreshAllTerminalWebglAtlases()` filters managers through `isVisibleForAtlasRecovery()`.
- `use-terminal-pane-global-effects.ts:145` drives that state with `setAtlasRecoveryVisible(rendererVisible)`.
- A hidden tab therefore cannot reach this path; live measurement kept it `paused:true / atlasVis:false` across four real tab-reveal bursts.
- The unfiltered `resetAllTerminalWebglAtlases()` has no production callers.
- The other unfiltered iterator belongs to the render-desync sentinel, which is off by default behind localStorage `orca:render-desync-sentinel`.

The normal production shape is therefore a `display: none` pane inside a **visible** manager:

- `applyExpandedLayoutTo()` (`src/renderer/src/components/terminal-pane/expand-collapse.ts:78`) hides the siblings of an expanded pane;
- a layout restore can remain `display: none` for its reattach.

From xterm 6.1.0-beta.287:

```js
_handleIntersectionChange(e) {
  this._isPaused = ... !e.isIntersecting;
  ...
  if (!this._isPaused && this._needsFullRefresh) {
    this._pausedResizeTask.flush();
    this.refreshRows(0, this._rowCount - 1);
    this._needsFullRefresh = false;
  }
}
refreshRows(e, t, i = false, s = false) {
  if (this._isPaused) { this._needsFullRefresh = true; return; }
  ...
}
```

What happened on the reachable hidden-sibling path:

1. `clearTextureAtlas()` clears the glyph atlas and render model, while the hidden element retains its canvas backing store at the last valid size.
2. `forceRepaintThroughRenderPause()` set `_isPaused = false`, cleared `_needsFullRefresh`, and synchronously rendered into that retained backing store.
3. The intersection state did not change while the sibling remained hidden, so it stayed unpaused. A real reveal burst produced about 19 full `refreshRows` calls while the pane was invisible, and all executed.
4. On an unchanged-size reveal, main made zero reveal-time `refreshRows` calls because the latch had been cleared. Pixels were still correct: the retained backing store had tracked output while hidden.
5. With this change, those roughly 19 hidden calls are swallowed by xterm's pause gate, `_needsFullRefresh` stays latched, and exactly one full refresh pays the debt on reveal.

### Unchanged-dimensions live comparison

Two panes were held at the same grid and restored to the exact prior box (`66x58`, `528x928`), so `performSafeFit` early-returned without resize or refresh.

| observation | main `d541982b` | PR `81875fa0` |
|---|---:|---:|
| hidden after real reveal burst | `paused:false nfr:false` | `paused:true nfr:true` |
| hidden-burst `refreshRows` | ~19, all executed | ~19, all swallowed |
| same-size reveal `refreshRows` | 0 | 1 |
| ink after same-size reveal | 13.373% | 13.373% |

Static content stayed at 34.999% ink with a byte-identical buffer hash. Content replaced while hidden also revealed the new content on both refs (31.258% → 13.373%). The observable improvement is avoided invisible work and restored latch semantics, not a visual-output change.

**Scope:** this is a standalone performance and renderer-invariant fix for the measured hidden-sibling path.

## Linked Issue

N/A — this is a standalone renderer performance/invariant defect found during investigation.

## Visual Proof

No visual delta is expected. Same-size live comparison produced identical ink, static-content pixels, and buffer content before and after the fix; the state and call-count measurements above are the behavioral proof.

## Testing

**Automated** — `src/renderer/src/lib/pane-manager/pane-webgl-renderer.test.ts`, two new cases.

RED (before the fix):

```
 ❯ src/renderer/src/lib/pane-manager/pane-webgl-renderer.test.ts (18 tests | 1 failed | 16 skipped)
     × keeps the render pause latched when resetting a pane that has no layout box

AssertionError: expected false to be true // Object.is equality
- Expected  + Received
- true
+ false

 ❯ src/renderer/src/lib/pane-manager/pane-webgl-renderer.test.ts:183:37
    183|     expect(renderService._isPaused).toBe(true)

 Test Files  1 failed (1)
      Tests  1 failed | 1 passed | 16 skipped (18)
```

(The companion case, `still forces the paused render through for a pane that has a layout box`, passes before *and* after — it pins the behaviour the release exists for.)

GREEN (after the fix):

```
npx vitest run --config config/vitest.config.ts \
  src/renderer/src/lib/pane-manager/pane-webgl-renderer.test.ts \
  src/renderer/src/lib/pane-manager/terminal-render-pause-release.test.ts

 Test Files  2 passed (2)
      Tests  23 passed (23)
```

Suites around the change:

```
npx vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/
 Test Files  67 passed (67)
      Tests  733 passed | 1 skipped (734)

npx vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/
 Test Files  1 failed | 377 passed (378)
      Tests  1 failed | 3677 passed (3678)
```

That single failure is `fish-color-scheme-child-stdin.node-pty.test.ts` — `node-pty: posix_openpt failed: errno (errno 6, Device not configured)`, PTY exhaustion under parallel load on this machine. Re-run alone: `Test Files 1 passed (1) / Tests 18 passed (18)`. Unrelated to this change, which touches no PTY code.

Gates: `oxfmt --write`, `oxlint`, `oxlint --config config/oxlint-code-quality-native-plugins.json`, `oxlint --config config/oxlint-react-doctor.json`, `check:max-lines-ratchet` — all clean.

**Manual (macOS, `pnpm dev`, Playwright over CDP against an isolated dev instance — no computer-use)**

Steps a reviewer can follow:
1. New terminal tab, fill the pane with output, `Cmd+D` to split, fill the second pane.
2. `Cmd+Shift+Enter` to expand the active pane — the sibling goes `display: none`.
3. Run `manager.resetWebglTextureAtlases()` (or switch tabs away and back, which schedules the same burst).
4. Read `terminal._core._renderService._isPaused` / `._needsFullRefresh` on the hidden pane.
5. `Cmd+Shift+Enter` to collapse; screenshot each pane's `.xterm-screen` and measure ink.

Latch results are the two tables above. No rendering regression on reveal — pixel ink measured from element screenshots, identical to the pre-fix run:

```
baseline            pane1 ink=15.741%  pane2 ink=9.255%
after reveal        pane1 ink=15.741%  pane2 ink=9.255%
after Cmd+L         pane1 ink=15.713%  pane2 ink=14.350%
after Cmd+L back    pane1 ink=15.741%  pane2 ink=9.255%
```

And the reveal path the release exists for is unchanged — alt-screen TUI (repaints on `SIGWINCH` only) held across hide/reveal with a sidebar width change while hidden, same numbers as before the fix:

```
tui-running          ink=12.247  179x58
away + back          ink=12.237  179x58
sidebar while away   ink=10.236  214x58
sidebar back         ink=12.247  179x58
Cmd+L                ink=15.236  135x58
```


Additional same-dimensions production-burst evidence:

```
                                  main                    #15555
hidden, after real burst          paused=false nfr=false  paused=true nfr=true
refreshRows while hidden          ~19, all executed       ~19, all swallowed
refreshRows on same-size reveal   0                       1
ink after same-size reveal        13.373%                 13.373%
```

The restored box and grid were unchanged (`528x928`, `66x58`), so `performSafeFit` returned without resize or refresh. Static content stayed at 34.999% ink with a byte-identical buffer hash; replacing the buffer while hidden revealed the new content on both refs.

Platforms actually tested: **macOS** only. Linux/Windows/SSH not exercised — see Notes.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

## AI Disclosure

Claude Opus 5 via Claude Code.

## Review

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

- **Security** — no new inputs, IPC, or persistence. Reads one computed style off a pane element already owned by the renderer.
- **Cross-platform (Linux, Windows, macOS)** — pure renderer/DOM logic, no platform branches, no paths, no shortcuts. Verified on macOS; the code path is identical everywhere because it is driven by CSS `display` and xterm internals, not by OS behaviour.
- **Remote SSH** — none. The atlas reset is renderer-local; nothing crosses the RPC or stream wire, and no host-published content changes. Safe for mixed client/host versions.
- **Mobile** — none. `resetWebglTextureAtlas` is desktop-renderer-only; the phone renders through its own client. No shared code touched.
- **Backwards compatibility** — internal renderer function, not exported past `pane-rendering-control` / `PaneManager`. No persisted state, no settings, no wire format.
- **Performance** — strictly a reduction. A hidden pane no longer runs a full render per PTY frame indefinitely. The added cost is one `isManagedPaneDisplayNone()` ancestor walk per pane per atlas-recovery burst; those bursts already force style and layout via `clearTextureAtlas()` and `refresh()` on the same panes.
- **xterm coupling** — the change removes a reach into xterm internals for hidden panes rather than adding one. `forceRepaintThroughRenderPause` keeps its existing `typeof` guards, so an xterm upgrade that renames `_isPaused`/`_needsFullRefresh` still degrades to a no-op.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] `N/A` with reason for visual proof
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] Targeted tests + surrounding suites pass locally; full `lint`/`typecheck`/`build` left to CI


## Terminal reliability contract

- **Invariant — `xterm-addon.boundary-containment`:** a genuinely hidden `display:none` pane remains render-paused during atlas recovery and carries a full-refresh debt until reveal; a DOM-visible pane whose observer lags still receives the existing forced synchronous repaint.
- **Failure source:** a hidden split sibling could be force-unpaused during atlas recovery, clearing its repaint latch and causing later full renders to execute while the pane remained invisible.
- **Oracle:** renderer tests require `paused:true / needsFullRefresh:true` for a hidden pane and the existing forced repaint for a visible paused pane. Electron evidence exercises two real WebGL panes, the production registry atlas reset while one sibling is hidden, collapse/reveal, and post-reveal input/output.
- **Gate:** existing experimental `xterm-addon.boundary-containment` gate plus the focused render-pause and pane-manager suites.
- **Provider/platform coverage:** local macOS Electron is covered. The renderer-only DOM decision is shared by local, daemon, SSH, remote-runtime, folder-workspace, Linux, and Windows surfaces; no provider, PTY, wire, path, shell, or platform-specific code changed. Live Linux/Windows/SSH/WSL runs remain uncollected.
- **Performance budget:** one bounded ancestor computed-style check per pane during explicit atlas-recovery bursts; no polling, timers, listeners, subprocesses, broad session scans, output parsing, or hidden-pane renderer wakeups were added. The fix removes the proven indefinite invisible render work.
- **Diagnostics:** Electron evidence records pane display/box dimensions, `_isPaused`, `_needsFullRefresh`, WebGL state, visible output, and console inspection before reset, after reset, after 1.2 seconds, and after reveal.
- **Residual gap:** same-size live measurement found identical visible output and buffer content on main and this PR. This change makes no visual-output claim. Live coverage remains macOS-only.
