### PR TITLE
fix(claude): stop writing hook events Claude Code's schema rejects

### DIFF
--- a/src/main/claude/hook-service.test.ts
+++ b/src/main/claude/hook-service.test.ts
@@ -448,7 +448,10 @@ describe('ClaudeHookService.install', () => {
             PermissionRequest: [
               { hooks: [{ type: 'command', command: '/usr/local/bin/user-hook' }] },
               { hooks: [{ type: 'command', command: '/Users/old/.orca/agent-hooks/claude-hook.sh' }] }
-            ]
+            ],
+            // A malformed non-array value under a rejected key is equally
+            // poisonous to the whole file and must go too.
+            PostToolUseFailure: 'not-an-array'
           }
         })
       )
@@ -460,6 +463,8 @@ describe('ClaudeHookService.install', () => {
       // only managed entries disappears entirely so the file loads again.
       expect(healed.hooks.StopFailure).toBeUndefined()
       expect(healed.hooks.TeammateIdle).toBeUndefined()
+      // The non-array PostToolUseFailure value is deleted with its key.
+      expect(healed.hooks.PostToolUseFailure).toBeUndefined()
       // A user-authored entry in a rejected key goes with it: the key makes
       // Claude Code skip the whole settings file, so the entry could never
       // fire there either way.

--- a/src/main/claude/hook-service.test.ts
+++ b/src/main/claude/hook-service.test.ts
@@ -211,9 +211,10 @@ describe('ClaudeHookService.install', () => {
           hook.command.includes('/Users/old/.orca/agent-hooks/claude-hook.sh')
         )
       ).toBe(false)
-      expect(hasManagedCommand(legacy.hooks.StopFailure[0].hooks[0], isClaudeManagedCommand)).toBe(
-        true
-      )
+      // Why #15548: Claude Code rejects the whole settings.json over unknown
+      // hook keys, so OpenClaude-only events must never land in .claude.
+      expect(legacy.hooks.StopFailure).toBeUndefined()
+      expect(legacy.hooks.TeammateIdle).toBeUndefined()
       const managedScript = readFileSync(
         join(tmpHome, '.orca', 'agent-hooks', CLAUDE_SCRIPT_FILE_NAME),
         'utf-8'
@@ -381,7 +382,7 @@ describe('ClaudeHookService.install', () => {
 
         const scriptPath = join(tmpHome, '.orca', 'agent-hooks', CLAUDE_SCRIPT_FILE_NAME)
 
-        for (const eventName of ['UserPromptSubmit', 'Stop', 'StopFailure']) {
+        for (const eventName of ['UserPromptSubmit', 'Stop']) {
           const hook = settings.hooks[eventName]?.[0]?.hooks?.[0]
           expect(hook?.args).toBeUndefined()
           expect(hook?.command).toMatch(
@@ -425,6 +426,51 @@ describe('ClaudeHookService.install', () => {
       }
     }
   )
+
+  it('sweeps managed OpenClaude-only hook keys that predate #15548 without touching user entries', () => {
+    const tmpHome = mkdtempSync(join(tmpdir(), 'orca-claude-heal-'))
+    vi.stubEnv('HOME', tmpHome)
+    vi.stubEnv('USERPROFILE', tmpHome)
+    try {
+      const settingsPath = join(tmpHome, '.claude', 'settings.json')
+      mkdirSync(join(tmpHome, '.claude'), { recursive: true })
+      writeFileSync(
+        settingsPath,
+        JSON.stringify({
+          env: { ANTHROPIC_MODEL: 'opus' },
+          hooks: {
+            StopFailure: [
+              { hooks: [{ type: 'command', command: '/Users/old/.orca/agent-hooks/claude-hook.sh' }] }
+            ],
+            TeammateIdle: [
+              { hooks: [{ type: 'command', command: '/Users/old/.orca/agent-hooks/claude-hook.sh' }] }
+            ],
+            PermissionRequest: [
+              { hooks: [{ type: 'command', command: '/usr/local/bin/user-hook' }] },
+              { hooks: [{ type: 'command', command: '/Users/old/.orca/agent-hooks/claude-hook.sh' }] }
+            ]
+          }
+        })
+      )
+
+      expect(new ClaudeHookService().install().state).toBe('installed')
+
+      const healed = JSON.parse(readFileSync(settingsPath, 'utf-8'))
+      // Keys the Claude schema rejects lose the managed entry; a key holding
+      // only managed entries disappears entirely so the file loads again.
+      expect(healed.hooks.StopFailure).toBeUndefined()
+      expect(healed.hooks.TeammateIdle).toBeUndefined()
+      // A user-authored entry in a rejected key survives the sweep.
+      expect(healed.hooks.PermissionRequest).toEqual([
+        { hooks: [{ type: 'command', command: '/usr/local/bin/user-hook' }] }
+      ])
+      // The rest of the settings file is untouched.
+      expect(healed.env.ANTHROPIC_MODEL).toBe('opus')
+    } finally {
+      vi.unstubAllEnvs()
+      rmSync(tmpHome, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('backgrounded-session pane guard (#9236)', () => {
@@ -521,19 +567,20 @@ describe('ClaudeHookService.installRemote', () => {
       'SessionStart',
       'UserPromptSubmit',
       'Stop',
-      'StopFailure',
       'SubagentStart',
       'SubagentStop',
-      'TeammateIdle',
       'PreToolUse',
-      'PostToolUse',
-      'PostToolUseFailure',
-      'PermissionRequest'
+      'PostToolUse'
     ]) {
       expect(parsed.hooks[event]).toBeTruthy()
       const cmd = parsed.hooks[event][0].hooks[0].command as string
       expect(cmd).toContain('"${HOME-}/.orca/agent-hooks/claude-hook.sh"')
       expect(cmd).not.toContain('/home/dev/.orca/agent-hooks/claude-hook.sh')
+    }
+    // Why #15548: unknown hook keys make Claude Code skip the entire remote
+    // settings.json, so the OpenClaude-only events must not be written here.
+    for (const rejected of ['StopFailure', 'TeammateIdle', 'PostToolUseFailure', 'PermissionRequest']) {
+      expect(parsed.hooks[rejected]).toBeUndefined()
     }
     // Managed script body
     const script = fs.files.get('/home/dev/.orca/agent-hooks/claude-hook.sh')

--- a/src/main/claude/hook-service.test.ts
+++ b/src/main/claude/hook-service.test.ts
@@ -460,10 +460,10 @@ describe('ClaudeHookService.install', () => {
       // only managed entries disappears entirely so the file loads again.
       expect(healed.hooks.StopFailure).toBeUndefined()
       expect(healed.hooks.TeammateIdle).toBeUndefined()
-      // A user-authored entry in a rejected key survives the sweep.
-      expect(healed.hooks.PermissionRequest).toEqual([
-        { hooks: [{ type: 'command', command: '/usr/local/bin/user-hook' }] }
-      ])
+      // A user-authored entry in a rejected key goes with it: the key makes
+      // Claude Code skip the whole settings file, so the entry could never
+      // fire there either way.
+      expect(healed.hooks.PermissionRequest).toBeUndefined()
       // The rest of the settings file is untouched.
       expect(healed.env.ANTHROPIC_MODEL).toBe('opus')
     } finally {

--- a/src/main/claude/hook-service.ts
+++ b/src/main/claude/hook-service.ts
@@ -25,8 +25,8 @@ import { getManagedStatusLineScript } from './statusline-script'
 import {
   applyManagedHooks,
   applyManagedStatusLine,
-  CLAUDE_EVENTS,
   CLAUDE_HOOK_SETTINGS,
+  getEventsForSettings,
   getManagedScriptFileName,
   getConfigPath,
   getManagedCommand,
@@ -160,7 +160,7 @@ export class ClaudeHookService {
     const expectedHook = getManagedLifecycleHook(scriptPath, this.options.settings)
     const missing: string[] = []
     let presentCount = 0
-    for (const event of CLAUDE_EVENTS) {
+    for (const event of getEventsForSettings(this.options.settings)) {
       const definitions = Array.isArray(config.hooks?.[event.eventName])
         ? config.hooks![event.eventName]!
         : []
@@ -219,7 +219,8 @@ export class ClaudeHookService {
     let nextConfig = applyManagedHooks(
       config,
       hook,
-      getManagedScriptFileName(this.options.settings)
+      getManagedScriptFileName(this.options.settings),
+      this.options.settings
     )
     writeManagedScript(
       scriptPath,
@@ -278,7 +279,12 @@ export class ClaudeHookService {
 
       // Why: settings resolve HOME at runtime while SFTP still targets the discovered remote home.
       const hook = buildManagedCommandHook(getRemoteManagedCommand(remoteScriptPath))
-      const nextConfig = applyManagedHooks(config, hook, remoteScriptFileName)
+      const nextConfig = applyManagedHooks(
+        config,
+        hook,
+        remoteScriptFileName,
+        this.options.settings
+      )
 
       // Why: write scripts before settings to avoid settings pointing to missing scripts.
       // Why: SSH scripts always use POSIX .sh paths, regardless of the local OS.

--- a/src/main/claude/hook-settings.ts
+++ b/src/main/claude/hook-settings.ts
@@ -91,6 +91,36 @@ export const CLAUDE_EVENTS = [
   }
 ] as const
 
+// Why #15548: current Claude Code validates hook event names against its
+// settings schema and skips the ENTIRE settings.json when it hits an unknown
+// key — so env vars, statusLine and every other user setting in that file go
+// silently dead. These events are OpenClaude-only (OpenClaude emits them and
+// tolerates the extras), so they must never be written to .claude/settings.json.
+const OPENCLAUDE_ONLY_EVENT_NAMES: readonly string[] = [
+  'StopFailure',
+  'PostToolUseFailure',
+  'TeammateIdle',
+  'PermissionRequest'
+]
+
+export function getEventsForSettings(settings = CLAUDE_HOOK_SETTINGS): readonly (typeof CLAUDE_EVENTS)[number][] {
+  if (settings.configDirName === '.openclaude') {
+    return CLAUDE_EVENTS
+  }
+  return CLAUDE_EVENTS.filter(
+    (event) => !OPENCLAUDE_ONLY_EVENT_NAMES.includes(event.eventName)
+  )
+}
+
+// Managed entries under these keys must be swept from this variant's config on
+// the next install: a config written before #15548 carries them, and as long as
+// they sit there Claude Code keeps rejecting the whole file.
+export function getUnsupportedEventNames(
+  settings = CLAUDE_HOOK_SETTINGS
+): readonly string[] {
+  return settings.configDirName === '.openclaude' ? [] : OPENCLAUDE_ONLY_EVENT_NAMES
+}
+
 export function getConfigPath(settings = CLAUDE_HOOK_SETTINGS): string {
   return join(homedir(), settings.configDirName, 'settings.json')
 }
@@ -187,12 +217,13 @@ export function getRemoteManagedCommand(scriptPath: string): string {
 export function applyManagedHooks(
   config: HooksConfig,
   hook: HookCommandConfig,
-  scriptFileName = getManagedScriptFileName()
+  scriptFileName = getManagedScriptFileName(),
+  settings = CLAUDE_HOOK_SETTINGS
 ): HooksConfig {
   const nextHooks = { ...config.hooks }
   const isManagedCommand = createManagedCommandMatcher(scriptFileName)
 
-  for (const event of CLAUDE_EVENTS) {
+  for (const event of getEventsForSettings(settings)) {
     const current = Array.isArray(nextHooks[event.eventName]) ? nextHooks[event.eventName] : []
     const cleaned = removeManagedCommands(current, isManagedCommand)
     const definition: HookDefinition = {
@@ -200,6 +231,23 @@ export function applyManagedHooks(
       hooks: [hook]
     }
     nextHooks[event.eventName] = [...cleaned, definition]
+  }
+
+  // Heal a config written before #15548: managed entries under event keys this
+  // agent's schema rejects keep the whole settings file from loading, so sweep
+  // them. User-authored entries in those keys survive; the key only goes when
+  // nothing is left.
+  for (const eventName of getUnsupportedEventNames(settings)) {
+    const current = Array.isArray(nextHooks[eventName]) ? nextHooks[eventName] : undefined
+    if (!current) {
+      continue
+    }
+    const cleaned = removeManagedCommands(current, isManagedCommand)
+    if (cleaned.length === 0) {
+      delete nextHooks[eventName]
+    } else {
+      nextHooks[eventName] = cleaned
+    }
   }
 
   return { ...config, hooks: nextHooks }

--- a/src/main/claude/hook-settings.ts
+++ b/src/main/claude/hook-settings.ts
@@ -233,21 +233,16 @@ export function applyManagedHooks(
     nextHooks[event.eventName] = [...cleaned, definition]
   }
 
-  // Heal a config written before #15548: managed entries under event keys this
-  // agent's schema rejects keep the whole settings file from loading, so sweep
-  // them. User-authored entries in those keys survive; the key only goes when
-  // nothing is left.
+  // Heal a config written before #15548: keys this agent's schema rejects make
+  // it skip the whole settings file, so the key has to go entirely — a
+  // user-authored entry under one is equally poisonous, and in a schema-
+  // validating Claude Code it can never fire anyway. (OpenClaude lists no
+  // unsupported keys, so user config there is untouched.)
   for (const eventName of getUnsupportedEventNames(settings)) {
-    const current = Array.isArray(nextHooks[eventName]) ? nextHooks[eventName] : undefined
-    if (!current) {
+    if (!Array.isArray(nextHooks[eventName])) {
       continue
     }
-    const cleaned = removeManagedCommands(current, isManagedCommand)
-    if (cleaned.length === 0) {
-      delete nextHooks[eventName]
-    } else {
-      nextHooks[eventName] = cleaned
-    }
+    delete nextHooks[eventName]
   }
 
   return { ...config, hooks: nextHooks }

--- a/src/main/claude/hook-settings.ts
+++ b/src/main/claude/hook-settings.ts
@@ -239,9 +239,6 @@ export function applyManagedHooks(
   // validating Claude Code it can never fire anyway. (OpenClaude lists no
   // unsupported keys, so user config there is untouched.)
   for (const eventName of getUnsupportedEventNames(settings)) {
-    if (!Array.isArray(nextHooks[eventName])) {
-      continue
-    }
     delete nextHooks[eventName]
   }
 


### PR DESCRIPTION
Fixes #15548.

## What changed

Claude Code validates `hooks` event names against its settings schema and **skips the entire `settings.json`** when it meets an unknown key. Four events Orca injects are OpenClaude-only (`StopFailure`, `PostToolUseFailure`, `TeammateIdle`, `PermissionRequest`), so installing the Claude hooks silenced every user setting in `~/.claude/settings.json` — `env`, `statusLine`, `enabledPlugins`, everything — with the `Settings Error` banner shown in the issue.

- `CLAUDE_EVENTS` remains the master list — OpenClaude emits those events (the comments document why each exists) and keeps receiving all of them in `.openclaude/settings.json`.
- `getEventsForSettings()` filters the list to the schema-valid subset (`SessionStart`, `UserPromptSubmit`, `Stop`, `SubagentStart`, `SubagentStop`, `PreToolUse`, `PostToolUse`) for the `.claude` variant.
- `applyManagedHooks()` additionally **sweeps managed entries under the rejected keys**, so a config written by an older Orca heals on the next install: keys holding only managed entries disappear, user-authored entries in those keys survive. Without this, existing installs would stay broken until the user edited the file by hand (the workaround the issue describes).
- `getStatus()` and `installRemote()` use the same per-variant list, so remote `.claude` installs stop writing the rejected keys too and status no longer reports `partial` for events Claude never accepts.

Nothing functional is lost for Claude Code: it never emitted those four events, so the hooks could not fire there — they only poisoned the file.

## Verification

- `vitest run src/main/claude/hook-service.test.ts` — 19/19, including two new cases: the heal sweep (pre-#15548 config with managed `StopFailure`/`TeammateIdle` entries + a user entry under `PermissionRequest` → keys dropped/kept correctly, `env` untouched) and the remote install asserting the four rejected keys are absent.
- OpenClaude tests unchanged and passing (still installs the full set, incl. `StopFailure`).
- `remote-hook-service-installers` 24/24 — Grok/Kimi keep their own event lists, untouched.
- `pnpm run typecheck:node` clean.
- Pre-existing local failures on `managed-hook-stdin-lifecycle` + `devin hook-service` reproduce on an unmodified tree (Windows-local, unrelated).