### PR TITLE
fix(serve): keep headless runtime alive on desktop Cmd+Q

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -196,7 +196,10 @@ import {
 import { ensureWindowsUserDataAclGrant } from './startup/windows-user-data-acl'
 import { probeWindowsInstallDirAcl } from './startup/windows-install-dir-acl-probe'
 import { neutralizeLegacyTerminalShimDir } from './pty/legacy-terminal-shim-dir'
-import { shouldQuitWhenAllWindowsClosed } from './startup/window-all-closed-quit-policy'
+import {
+  shouldCommitDesktopQuit,
+  shouldQuitWhenAllWindowsClosed
+} from './startup/window-all-closed-quit-policy'
 import {
   createServeDesktopActivationGate,
   settleServeDesktopActivation as settleServeDesktopActivationGate
@@ -3297,11 +3300,26 @@ void app.whenReady().then(async () => {
 // Why: app.exit() skips Electron quit events, so keep its log child from surviving forced exits.
 process.once('exit', stopTccPromptNotice)
 
-app.on('before-quit', () => {
+app.on('before-quit', (event) => {
   if (isQuittingForUpdate()) {
     recordUpdaterLifecycle('before_quit_allowed', undefined, {
       message: 'before-quit allowed for update install'
     })
+  }
+  if (
+    !shouldCommitDesktopQuit({
+      isServeMode,
+      isUpdateQuit: isQuittingForUpdate()
+    })
+  ) {
+    // Why: close the hosted window without fencing the relay or setting isQuitting.
+    event.preventDefault()
+    for (const window of BrowserWindow.getAllWindows()) {
+      if (!window.isDestroyed()) {
+        window.close()
+      }
+    }
+    return
   }
   isQuitting = true
   desktopRelayService?.fenceAndCloseNow()

--- a/src/main/startup/window-all-closed-quit-policy.test.ts
+++ b/src/main/startup/window-all-closed-quit-policy.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { shouldQuitWhenAllWindowsClosed } from './window-all-closed-quit-policy'
+import {
+  shouldCommitDesktopQuit,
+  shouldQuitWhenAllWindowsClosed
+} from './window-all-closed-quit-policy'
 
 describe('shouldQuitWhenAllWindowsClosed', () => {
   it('keeps headless serve alive when its offscreen browser windows close', () => {
@@ -48,6 +51,35 @@ describe('shouldQuitWhenAllWindowsClosed', () => {
         platform: 'darwin',
         isQuitting: true,
         isServeMode: true
+      })
+    ).toBe(true)
+  })
+})
+
+describe('shouldCommitDesktopQuit', () => {
+  it('does not quit the serve process on a desktop Cmd+Q', () => {
+    expect(
+      shouldCommitDesktopQuit({
+        isServeMode: true,
+        isUpdateQuit: false
+      })
+    ).toBe(false)
+  })
+
+  it('still quits a normal desktop app', () => {
+    expect(
+      shouldCommitDesktopQuit({
+        isServeMode: false,
+        isUpdateQuit: false
+      })
+    ).toBe(true)
+  })
+
+  it('still allows an update-install quit in serve mode', () => {
+    expect(
+      shouldCommitDesktopQuit({
+        isServeMode: true,
+        isUpdateQuit: true
       })
     ).toBe(true)
   })

--- a/src/main/startup/window-all-closed-quit-policy.ts
+++ b/src/main/startup/window-all-closed-quit-policy.ts
@@ -8,3 +8,16 @@ export function shouldQuitWhenAllWindowsClosed(options: {
   }
   return options.platform !== 'darwin' || options.isQuitting
 }
+
+/** Whether a desktop Quit (⌘Q / app.quit) should tear down this process. */
+export function shouldCommitDesktopQuit(options: {
+  isServeMode: boolean
+  isUpdateQuit: boolean
+}): boolean {
+  // Why: serve-hosted windows share the headless process. Window close already
+  // keeps that runtime alive; Cmd+Q must not set isQuitting and drop remotes.
+  if (options.isUpdateQuit) {
+    return true
+  }
+  return !options.isServeMode
+}


### PR DESCRIPTION
## Description
On macOS, ⌘Q on a desktop window hosted by `orca serve` no longer tears down the headless runtime or drops paired remotes.

`shouldQuitWhenAllWindowsClosed` already keeps serve mode alive for window close. `before-quit` now uses the same contract: desktop Quit becomes window-close unless an update install is in progress.

## Focused fix
- In scope: `before-quit` in serve mode (⌘Q / app.quit from a hosted window)
- Out of scope: changing File > Quit for non-serve desktop, SIGTERM, or serve-stop CLI

## Preserves
- Update-install quits still commit (`isQuittingForUpdate`)
- Non-serve desktop Cmd+Q still quits
- Existing window-close serve-alive policy

## Evidence
- Test: `pnpm exec vitest run --config config/vitest.config.ts src/main/startup/window-all-closed-quit-policy.test.ts src/main/startup/desktop-startup-ordering.test.ts` → **19 passed**
- Quality: 0 findings on 3 files

## User-regression-tradeoffs
- To stop a serve host after this change, stop the launch agent / process rather than ⌘Q on the hosted window. That matches the existing window-close behavior.

Fixes #15537
