### PR TITLE
fix(runtime): use visible snapshot for tui-idle on adopted PTYs

### DIFF
--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -19619,6 +19619,20 @@ export class OrcaRuntimeService {
       ) {
         return buildPtyTerminalWaitResult(handle, condition, pty.pty)
       }
+      if (condition === 'tui-idle' && !ptyWaitText && pty.pty.lastAgentStatus == null) {
+        const snapshotVerdict = await this.resolveTuiIdleFromVisibleSnapshot(pty.pty.ptyId)
+        if (snapshotVerdict?.kind === 'blocked') {
+          return buildPtyTerminalWaitBlockedResult(
+            handle,
+            condition,
+            pty.pty,
+            snapshotVerdict.reason
+          )
+        }
+        if (snapshotVerdict?.kind === 'idle') {
+          return buildPtyTerminalWaitResult(handle, condition, pty.pty)
+        }
+      }
       return await new Promise<RuntimeTerminalWait>((resolve, reject) => {
         const effectiveTimeoutMs =
           typeof options?.timeoutMs === 'number' && options.timeoutMs > 0
@@ -19709,6 +19723,15 @@ export class OrcaRuntimeService {
         isKnownReadyPromptPreview(leafWaitText)
       ) {
         return buildTerminalWaitResult(handle, condition, leaf)
+      }
+      if (!leafWaitText && leaf.lastAgentStatus == null && leaf.ptyId) {
+        const snapshotVerdict = await this.resolveTuiIdleFromVisibleSnapshot(leaf.ptyId)
+        if (snapshotVerdict?.kind === 'blocked') {
+          return buildTerminalWaitBlockedResult(handle, condition, leaf, snapshotVerdict.reason)
+        }
+        if (snapshotVerdict?.kind === 'idle') {
+          return buildTerminalWaitResult(handle, condition, leaf)
+        }
       }
     }
 
@@ -35454,6 +35477,33 @@ export class OrcaRuntimeService {
     }, TUI_IDLE_POLL_INTERVAL_MS)
   }
 
+  private async resolveTuiIdleFromVisibleSnapshot(
+    ptyId: string
+  ): Promise<
+    { kind: 'blocked'; reason: RuntimeTerminalWaitBlockedReason } | { kind: 'idle' } | null
+  > {
+    const visibleState = await this.readVisibleTerminalState(ptyId)
+    let lines = visibleState?.lines ?? []
+    if (lines.length === 0) {
+      lines = await this.readRendererVisibleSnapshotLines(ptyId)
+    }
+    if (lines.length === 0) {
+      lines = await this.readProviderTerminalTailLines(ptyId, undefined)
+    }
+    if (lines.length === 0) {
+      return null
+    }
+    const snapshotText = lines.join('\n')
+    const blockedReason = detectTerminalWaitBlockedReason(snapshotText)
+    if (blockedReason) {
+      return { kind: 'blocked', reason: blockedReason }
+    }
+    if (isKnownReadyPromptPreview(snapshotText)) {
+      return { kind: 'idle' }
+    }
+    return null
+  }
+
   private startPtyTuiIdleFallbackPoll(waiter: TerminalWaiter, pty: RuntimePtyWorktreeRecord): void {
     let foregroundPollInFlight = false
     waiter.pollInterval = setInterval(async () => {
@@ -35482,6 +35532,33 @@ export class OrcaRuntimeService {
             buildPtyTerminalWaitBlockedResult(waiter.handle, 'tui-idle', pty, blockedReason)
           )
           return
+        }
+        if (!ptyWaitText && pty.lastAgentStatus == null) {
+          const snapshotVerdict = await this.resolveTuiIdleFromVisibleSnapshot(pty.ptyId)
+          if (snapshotVerdict?.kind === 'blocked') {
+            if (waiter.pollInterval) {
+              clearInterval(waiter.pollInterval)
+              waiter.pollInterval = null
+            }
+            this.resolveWaiter(
+              waiter,
+              buildPtyTerminalWaitBlockedResult(
+                waiter.handle,
+                'tui-idle',
+                pty,
+                snapshotVerdict.reason
+              )
+            )
+            return
+          }
+          if (snapshotVerdict?.kind === 'idle') {
+            if (waiter.pollInterval) {
+              clearInterval(waiter.pollInterval)
+              waiter.pollInterval = null
+            }
+            this.resolveWaiter(waiter, buildPtyTerminalWaitResult(waiter.handle, 'tui-idle', pty))
+            return
+          }
         }
         // Why: adopted background PTY handles use their live xterm title as the same readiness signal as leaf handles.
         if (

--- a/src/main/runtime/terminal-interactive-wait-visibility.test.ts
+++ b/src/main/runtime/terminal-interactive-wait-visibility.test.ts
@@ -187,6 +187,49 @@ describe('terminal interactive-wait visibility (STA-4513, STA-3714)', () => {
       await expect(runtime.showTerminal(handle)).resolves.toMatchObject({ agentWait: null })
     })
 
+    it('resolves tui-idle from a visible snapshot when an adopted PTY retained no tail', async () => {
+      const { runtime, handle } = await createPane({
+        paneTitle: 'bash',
+        foregroundProcess: 'zsh',
+        data: ''
+      })
+      vi.spyOn(
+        runtime as unknown as {
+          readVisibleTerminalState: (ptyId: string) => Promise<{ lines: string[] } | null>
+        },
+        'readVisibleTerminalState'
+      ).mockResolvedValue({
+        lines: ['OpenAI Codex', 'model: gpt-5', 'directory: /repo']
+      })
+
+      await expect(
+        runtime.waitForTerminal(handle, { condition: 'tui-idle', timeoutMs: 1_000 })
+      ).resolves.toMatchObject({ satisfied: true })
+    })
+
+    it('keeps a blocked visible snapshot blocked for an adopted PTY', async () => {
+      const { runtime, handle } = await createPane({
+        paneTitle: 'bash',
+        foregroundProcess: 'zsh',
+        data: ''
+      })
+      vi.spyOn(
+        runtime as unknown as {
+          readVisibleTerminalState: (ptyId: string) => Promise<{ lines: string[] } | null>
+        },
+        'readVisibleTerminalState'
+      ).mockResolvedValue({
+        lines: CLAUDE_TRUST.split('\n')
+      })
+
+      await expect(
+        runtime.waitForTerminal(handle, { condition: 'tui-idle', timeoutMs: 1_000 })
+      ).resolves.toMatchObject({
+        satisfied: false,
+        blockedReason: 'codex-trust-workspace'
+      })
+    })
+
     it('reports no wait once the agent is idle again', async () => {
       const { runtime, handle } = await createPane({
         paneTitle: CURSOR_TITLE,


### PR DESCRIPTION
## Description
`terminal wait --for tui-idle` now consults the same provider-visible snapshot `terminal read` uses, so an adopted/recovered PTY at a ready prompt no longer times out with empty retained tail.

## Focused fix
- In scope: tui-idle on adopted PTYs with no retained tail/status
- Out of scope: changing tui-idle false-positives (#9929 / #10020), OSC-title idle, or foreground-quiescence policy

## Preserves
- Blocked prompts (trust / approval) still fail closed
- Process sleep or output quiescence alone still does not imply idle

## Evidence
- Test: `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/terminal-interactive-wait-visibility.test.ts` → **29 passed**
- Quality: 0 findings on 2 files

## User-regression-tradeoffs
- One extra snapshot read on empty-tail tui-idle waits. Ready/blocked verdicts use the existing detectors.

Fixes #15523
