### PR TITLE
fix(terminal): refuse a cursor on a screen read, and correct the source docs

### DIFF
--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -204,7 +204,7 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
       'Omit --terminal to target the active terminal in the current worktree.',
       'By default this returns accumulated terminal output with escape sequences stripped, not the rendered screen. Any program that repaints a line — shells, progress bars, TUIs — comes back as stacked fragments, so one `clear` keystroke by keystroke reads as `cclclecleaclear`, and spaces a prompt draws by moving the cursor are absent.',
       'Use --screen to read what the terminal actually renders. Prefer it whenever the answer depends on how output looks rather than what was emitted over time; the default is unsuitable for verifying rendered output.',
-      'The result reports source: stream or screen, so a caller can tell which question was answered. A --screen read falls back to source: stream when no rendered state exists rather than passing the stream off as a screen.',
+      'The result reports source: stream when it is accumulated output, screen when it is the rendered screen, and screen-unavailable when a screen was asked for but none could be rendered and the accumulated output is being returned instead. An absent source means the host predates the field.',
       '--screen and --cursor are mutually exclusive: a screen read is the current frame and has no history to page.',
       'Use --cursor with the nextCursor value from a previous read to get only new output since that read.',
       'Use --limit to request more retained lines for long agent responses; output reports oldestCursor when older lines were dropped.',

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -18480,8 +18480,11 @@ export class OrcaRuntimeService {
   // ("cclclecleaclear" for one `clear`) and drops spaces a prompt draws with cursor-forward.
   // That is the right answer for "what happened over time" and the wrong one for "what is on
   // screen", so an explicit screen read goes to the emulator state instead. When no rendered
-  // state exists the stream is still returned, but labelled `stream` rather than passed off as
-  // a screen — silently answering the other question is the defect this exists to stop.
+  // state exists the stream is still returned, but labelled `screen-unavailable` rather than
+  // passed off as a screen — silently answering the other question is the defect this exists to
+  // stop, and that label is what separates it from a stream the caller actually asked for.
+  // A cursor cannot reach here: pairing one with a screen read is refused at the RPC boundary,
+  // because rendered lines carrying the stream's pagination metadata would mix both frames.
   private async readRenderedScreen(
     ptyId: string,
     read: RuntimeTerminalRead,

--- a/src/main/runtime/rpc/methods/terminal-read-screen-cursor.test.ts
+++ b/src/main/runtime/rpc/methods/terminal-read-screen-cursor.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { TERMINAL_METHODS } from './terminal'
+
+function readParams() {
+  const method = TERMINAL_METHODS.find((candidate) => candidate.name === 'terminal.read')
+  if (!method?.params) {
+    throw new Error('Missing params schema for terminal.read')
+  }
+  return method.params
+}
+
+describe('terminal.read screen and cursor', () => {
+  // Why: the CLI refuses this pair, but terminal.read is an RPC and any other caller can send
+  // both. Honoring them would answer with rendered lines carrying the stream's pagination
+  // metadata — two frames of reference in one payload.
+  it('rejects a cursor combined with a screen read', () => {
+    expect(() => readParams().parse({ terminal: 'term_abc', screen: true, cursor: 42 })).toThrow(
+      /Cursor cannot be combined with a screen read/
+    )
+  })
+
+  it('still accepts each on its own', () => {
+    expect(readParams().parse({ terminal: 'term_abc', screen: true })).toMatchObject({
+      screen: true
+    })
+    expect(readParams().parse({ terminal: 'term_abc', cursor: 42 })).toMatchObject({ cursor: 42 })
+  })
+
+  // Why: cursor 0 is a real cursor, not an absent one — an off-by-one here would let the
+  // combination through on the first page.
+  it('rejects cursor zero with a screen read', () => {
+    expect(() => readParams().parse({ terminal: 'term_abc', screen: true, cursor: 0 })).toThrow(
+      /Cursor cannot be combined with a screen read/
+    )
+  })
+
+  it('leaves an ordinary paginated read untouched', () => {
+    expect(readParams().parse({ terminal: 'term_abc', cursor: 0, limit: 100 })).toMatchObject({
+      cursor: 0,
+      limit: 100
+    })
+  })
+})

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -925,6 +925,12 @@ const TerminalRead = TerminalHandle.extend({
   // Why: optional so an older host that does not understand it simply drops the key and answers
   // with its usual stream read; the response's `source` is what tells the caller which it got.
   screen: z.literal(true).optional()
+}).refine((params) => !(params.screen === true && params.cursor !== undefined), {
+  // Why: a cursor pages through accumulated output; a screen is the current frame with nothing
+  // behind it. Honoring both would answer with rendered lines carrying the stream's pagination
+  // metadata — two frames of reference in one payload, which is the confusion `source` exists to
+  // remove. The CLI already refuses the pair, but the RPC is reachable without it.
+  message: 'Cursor cannot be combined with a screen read'
 })
 
 // Why: preserve the legacy contract — `title: string | null` only, `undefined` rejected, so the CLI's "reset" signal stays distinct.


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​43 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​43 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 |

<!-- /orca-pr-loc -->

## ELI5

Two follow-ups from review of #15380, both valid.

1. Asking for the **rendered screen** *and* a **scroll position** at once was accepted, and answered with the screen's text carrying the stream's page markers — two different things stitched into one reply.
2. The docs described a state the code never actually produces.

## What Changed

### 1. `cursor` + `screen` is refused at the RPC boundary

A cursor pages through accumulated output. A screen is the current frame, with nothing behind it to page. Honoring both returned rendered lines alongside `nextCursor` / `oldestCursor` computed from the stream read — pagination metadata describing one thing and a tail describing another, which is exactly the two-frames confusion `source` was introduced to remove.

The CLI already refused the pair, but `terminal.read` is an RPC and any other caller could send both. Notably the guard sitting immediately beside this one already got it right:

```ts
// withVisibleSnapshotFallback
if (typeof opts.cursor === 'number') {
  return read     // declines to substitute rendered lines while paging
}
```

The screen path now agrees, enforced where every remote caller passes rather than only in the CLI.

### 2. The `source` documentation named a value that is never emitted

Both the command notes (`src/cli/specs/core.ts`) and the runtime comment still said the fallback is `source: stream`. That was left over from renaming the value to `screen-unavailable` during implementation.

This is worse than a stale comment: the spec text is surfaced through `orca help` and the agent-context schema, so an agent following the documented contract would test for `source === 'stream'` on a fallback and never match. Both sites now describe all four states, including that an **absent** source means the host predates the field.

## Why

Rejecting the combination breaks no existing caller: `screen` did not exist before #15380, so nothing could previously send both. It is a new invalid combination, not a newly-invalid old one.

Rejecting rather than silently ignoring one of the two options is deliberate — quietly dropping `cursor` would answer a question the caller did not ask, which is the defect #15380 exists to fix.

## Linked Issue

Review follow-up to #15380 (STA-4792 defect 3). No new issue filed.

## Visual Proof

N/A — CLI/RPC behavior, no UI surface.

```
# before: accepted, and answered incoherently
terminal.read { terminal, screen: true, cursor: 42 }
  -> rendered screen lines + nextCursor/oldestCursor from the stream read

# after
  -> invalid_argument: Cursor cannot be combined with a screen read
```

## Testing

- `pnpm exec vitest run src/cli src/main/runtime tests/e2e/cross-version-wire` — 464 files / 5599 tests pass.
- `pnpm run typecheck` (node + cli + web) and `oxlint` base + type-aware — clean.
- New `terminal-read-screen-cursor.test.ts`: the pair is rejected; each option still works alone; **cursor `0` is rejected too** (a real cursor, not an absent one — an off-by-one here would let the combination through on the first page); an ordinary paginated read is untouched.
- Cross-version wire harness green — this narrows accepted input on a field that shipped in the same release, so no peer can be relying on it.
- Platform: macOS. No platform-specific paths.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

<!-- DO NOT FILL IN IF YOU ARE STABLYAI TEAM MEMBER (INTERNAL CONTRIBUTOR), IGNORE SECTION: -->

## Review

One judgment call: this rejects at the RPC schema rather than adding a second guard inside `readRenderedScreen`. The RPC boundary is where every remote caller passes and where the rest of this method's validation already lives; an in-process caller could still pass both to `runtime.readTerminal` directly, but none do, and duplicating the check would be unreachable code. The runtime comment now records that the invariant is enforced upstream so the absence of a local guard is not read as an oversight.

## Agent skill upstream boundary

N/A — no skill content changed.
