### PR TITLE
fix(windows): enumerate the process table through wmic when it exists

### DIFF
--- a/src/main/providers/agent-foreground-process-pi.test.ts
+++ b/src/main/providers/agent-foreground-process-pi.test.ts
@@ -6,7 +6,7 @@ vi.mock('child_process', () => ({ execFile: execFileMock }))
 
 import { resetProcessTableSnapshotForTests } from '../../shared/process-table-snapshot'
 import { resolveAgentForegroundProcessWithAvailability } from './agent-foreground-process'
-import { resetWindowsProcessRowsSnapshotForTests } from './windows-foreground-process-rows'
+import { resetWindowsProcessRowsReaderForTests } from './windows-foreground-process-rows'
 
 describe('Pi Windows foreground recognition', () => {
   let platform: PropertyDescriptor | undefined
@@ -14,7 +14,7 @@ describe('Pi Windows foreground recognition', () => {
   beforeEach(() => {
     execFileMock.mockReset()
     resetProcessTableSnapshotForTests()
-    resetWindowsProcessRowsSnapshotForTests()
+    resetWindowsProcessRowsReaderForTests()
     platform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { value: 'win32' })
   })

--- a/src/main/providers/agent-foreground-process.test.ts
+++ b/src/main/providers/agent-foreground-process.test.ts
@@ -13,7 +13,7 @@ import {
   resolveAgentForegroundProcess,
   resolveAgentForegroundProcessWithAvailability
 } from './agent-foreground-process'
-import { resetWindowsProcessRowsSnapshotForTests } from './windows-foreground-process-rows'
+import { resetWindowsProcessRowsReaderForTests } from './windows-foreground-process-rows'
 
 // Why: the module wraps execFile with promisify, so the mock must honor the
 // Node callback contract — invoke the last arg with (err, { stdout, stderr }).
@@ -79,7 +79,7 @@ describe('resolveAgentForegroundProcess', () => {
     resetProcessTableSnapshotForTests()
     // Why: the Windows rows reader caches across calls (500ms TTL), so each
     // case's execFile mock must not be answered by the previous case's rows.
-    resetWindowsProcessRowsSnapshotForTests()
+    resetWindowsProcessRowsReaderForTests()
     platform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { value: 'darwin' })
   })

--- a/src/main/providers/agent-foreground-process.test.ts
+++ b/src/main/providers/agent-foreground-process.test.ts
@@ -412,7 +412,7 @@ describe('resolveAgentForegroundProcess', () => {
 
     await expect(resolveAgentForegroundProcess(100, 'node.exe')).resolves.toBe('codex')
     expect(execFileMock).toHaveBeenCalledWith(
-      'wmic',
+      expect.stringMatching(/wmic/),
       expect.any(Array),
       expect.objectContaining({ timeout: 3000 }),
       expect.any(Function)
@@ -432,7 +432,7 @@ describe('resolveAgentForegroundProcess', () => {
 
     await expect(resolveAgentForegroundProcess(100, 'node.exe')).resolves.toBe('codex')
     expect(execFileMock).toHaveBeenCalledWith(
-      'wmic',
+      expect.stringMatching(/wmic/),
       expect.any(Array),
       expect.objectContaining({ timeout: 3000 }),
       expect.any(Function)

--- a/src/main/providers/windows-agent-foreground-process-scan-volume.test.ts
+++ b/src/main/providers/windows-agent-foreground-process-scan-volume.test.ts
@@ -1,25 +1,26 @@
-// Regression guard: bound the volume of full-process-table PowerShell/CIM scans
-// driven by Windows agent foreground-process inspection — the Windows analogue of
-// issue #6288 (POSIX `ps`).
+// Regression guard: bound the volume of full-process-table scans driven by
+// Windows agent foreground-process inspection — the Windows analogue of issue
+// #6288 (POSIX `ps`).
 //
 // Drives queryWindowsProcessDescendants across several concurrently-inspecting
 // agent panes on the agent-completion cadence (ACTIVE_POLL_INTERVAL_MS = 750ms)
-// and counts how many powershell.exe process-table scans actually spawn. Pre-fix
-// the call site forked one powershell.exe per pane per tick; with the shared
-// snapshot cache the scans collapse to ~one per tick regardless of pane count,
-// while each pane still resolves the same descendant set.
+// and counts the process-table scans that actually spawn. Pre-fix the call site
+// forked one per pane per tick; with the shared snapshot cache they collapse to
+// ~one per tick regardless of pane count, while each pane still resolves the same
+// descendant set. Counted per command, because #15209 turns on which binary runs:
+// over this window a wmic-capable host must fork no PowerShell host at all.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { execFileMock, powershellScanCount } = vi.hoisted(() => ({
+const { execFileMock, scanCounts } = vi.hoisted(() => ({
   execFileMock: vi.fn(),
-  powershellScanCount: { value: 0 }
+  scanCounts: { powershell: 0, wmic: 0 }
 }))
 
 vi.mock('child_process', () => ({ execFile: execFileMock }))
 
 import {
   queryWindowsProcessDescendants,
-  resetWindowsProcessRowsSnapshotForTests
+  resetWindowsProcessRowsReaderForTests
 } from './windows-foreground-process-rows'
 
 const ACTIVE_POLL_INTERVAL_MS = 750
@@ -32,45 +33,60 @@ const shellPid = (pane: number): number => 100 + pane * 1000
 // A real CIM query returns the whole system, so one shared snapshot must contain
 // every pane's shell + foreground node/codex child. Each pane resolves its own
 // descendant from the single scan.
-const PROCESS_TABLE_JSON = JSON.stringify(
-  Array.from({ length: PANE_COUNT }, (_, pane) => {
-    const shell = shellPid(pane)
-    return [
-      {
-        ProcessId: shell,
-        ParentProcessId: 99,
-        Name: 'cmd.exe',
-        CommandLine: 'cmd.exe',
-        ExecutablePath: 'C:/Windows/System32/cmd.exe'
-      },
-      {
-        ProcessId: shell + 1,
-        ParentProcessId: shell,
-        Name: 'node.exe',
-        CommandLine: 'node C:/Users/dev/AppData/codex/bin/codex.js',
-        ExecutablePath: 'C:/Program Files/nodejs/node.exe'
-      }
-    ]
-  }).flat()
-)
+const PROCESS_ROWS = Array.from({ length: PANE_COUNT }, (_, pane) => {
+  const shell = shellPid(pane)
+  return [
+    {
+      ProcessId: shell,
+      ParentProcessId: 99,
+      Name: 'cmd.exe',
+      CommandLine: 'cmd.exe',
+      ExecutablePath: 'C:/Windows/System32/cmd.exe'
+    },
+    {
+      ProcessId: shell + 1,
+      ParentProcessId: shell,
+      Name: 'node.exe',
+      CommandLine: 'node C:/Users/dev/AppData/codex/bin/codex.js',
+      ExecutablePath: 'C:/Program Files/nodejs/node.exe'
+    }
+  ]
+}).flat()
 
-function installCountingPowerShellMock(): void {
+const PROCESS_TABLE_JSON = JSON.stringify(PROCESS_ROWS)
+
+/** wmic /format:value: one `Key=Value` line per property, records blank-separated. */
+const PROCESS_TABLE_VALUE = PROCESS_ROWS.map((row) =>
+  [
+    `CommandLine=${row.CommandLine}`,
+    `ExecutablePath=${row.ExecutablePath}`,
+    `Name=${row.Name}`,
+    `ParentProcessId=${row.ParentProcessId}`,
+    `ProcessId=${row.ProcessId}`
+  ].join('\r\n')
+).join('\r\n\r\n')
+
+function installCountingScanMock(): void {
   execFileMock.mockImplementation((cmd: string, _args: unknown, _opts: unknown, cb: unknown) => {
     const callback = cb as (err: unknown, result: { stdout: string; stderr: string }) => void
-    if (cmd === 'powershell.exe') {
-      powershellScanCount.value += 1
+    if (cmd === 'wmic') {
+      scanCounts.wmic += 1
+      callback(null, { stdout: PROCESS_TABLE_VALUE, stderr: '' })
+      return
     }
+    scanCounts.powershell += 1
     callback(null, { stdout: PROCESS_TABLE_JSON, stderr: '' })
   })
 }
 
-describe('windows agent foreground inspection powershell-scan volume', () => {
+describe('windows agent foreground inspection process-table scan volume', () => {
   let platform: PropertyDescriptor | undefined
 
   beforeEach(() => {
     execFileMock.mockReset()
-    resetWindowsProcessRowsSnapshotForTests()
-    powershellScanCount.value = 0
+    resetWindowsProcessRowsReaderForTests()
+    scanCounts.powershell = 0
+    scanCounts.wmic = 0
     platform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
     vi.useFakeTimers({ toFake: ['Date'] })
@@ -84,8 +100,8 @@ describe('windows agent foreground inspection powershell-scan volume', () => {
     }
   })
 
-  it('bounds powershell scans by poll ticks, not by pane count, while resolving every pane', async () => {
-    installCountingPowerShellMock()
+  it('bounds scans by poll ticks, not by pane count, while resolving every pane', async () => {
+    installCountingScanMock()
 
     for (let tick = 0; tick < TICKS; tick++) {
       vi.setSystemTime(tick * ACTIVE_POLL_INTERVAL_MS)
@@ -106,15 +122,18 @@ describe('windows agent foreground inspection powershell-scan volume', () => {
     }
 
     const totalInspections = PANE_COUNT * TICKS
-    // Pre-fix this equals totalInspections (one powershell.exe per inspection).
-    // With the shared cache, concurrent panes within a tick share one scan and
-    // the 500ms TTL forces a fresh scan each new 750ms tick -> ~one per tick.
-    expect(powershellScanCount.value).toBeLessThanOrEqual(TICKS + 1)
-    expect(powershellScanCount.value).toBeLessThan(totalInspections / 2)
+    // Pre-fix this equals totalInspections (one scan per inspection). With the
+    // shared cache, concurrent panes within a tick share one scan and the 500ms
+    // TTL forces a fresh scan each new 750ms tick -> ~one per tick.
+    expect(scanCounts.wmic).toBeLessThanOrEqual(TICKS + 1)
+    expect(scanCounts.wmic).toBeLessThan(totalInspections / 2)
+    // #15209: every one of these would have been a transcript file under the
+    // enterprise PowerShell transcription GPO.
+    expect(scanCounts.powershell).toBe(0)
   })
 
   it('collapses a burst of concurrent panes into a single scan', async () => {
-    installCountingPowerShellMock()
+    installCountingScanMock()
 
     await Promise.all(
       Array.from({ length: PANE_COUNT }, (_, pane) =>
@@ -122,6 +141,6 @@ describe('windows agent foreground inspection powershell-scan volume', () => {
       )
     )
 
-    expect(powershellScanCount.value).toBe(1)
+    expect(scanCounts.wmic).toBe(1)
   })
 })

--- a/src/main/providers/windows-agent-foreground-process-scan-volume.test.ts
+++ b/src/main/providers/windows-agent-foreground-process-scan-volume.test.ts
@@ -69,7 +69,7 @@ const PROCESS_TABLE_VALUE = PROCESS_ROWS.map((row) =>
 function installCountingScanMock(): void {
   execFileMock.mockImplementation((cmd: string, _args: unknown, _opts: unknown, cb: unknown) => {
     const callback = cb as (err: unknown, result: { stdout: string; stderr: string }) => void
-    if (cmd === 'wmic') {
+    if (/wmic/i.test(cmd)) {
       scanCounts.wmic += 1
       callback(null, { stdout: PROCESS_TABLE_VALUE, stderr: '' })
       return

--- a/src/main/providers/windows-foreground-process-rows-differential.test.ts
+++ b/src/main/providers/windows-foreground-process-rows-differential.test.ts
@@ -1,0 +1,245 @@
+// The wmic reader's whole claim is that it answers identically to the PowerShell
+// reader it displaces. Hand-written fixtures cannot check that: they encode the
+// same assumptions as the parser, which is how a blank line inside an agent's
+// CommandLine shipped as "correct" until a real process table was tried.
+//
+// So generate hostile tables instead, render each one BOTH as wmic
+// `/format:value` (UTF-16LE, no escaping available) and as PowerShell JSON, and
+// hold the two readers against each other:
+//
+//   Fidelity — with content that cannot forge the framing, the wmic rows must
+//   equal the PowerShell rows exactly, command text included.
+//   Safety   — with content that CAN forge it, no row may claim a pid that
+//   exists in the real table under the wrong parent. That is the property
+//   `taskkill /T /F` targeting rests on; a phantom pid is inert, a mis-parented
+//   real one is not.
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { execFileMock } = vi.hoisted(() => ({ execFileMock: vi.fn() }))
+
+vi.mock('child_process', () => ({ execFile: execFileMock }))
+
+import {
+  queryWindowsProcessRowsFresh,
+  resetWindowsProcessRowsReaderForTests
+} from './windows-foreground-process-rows'
+
+type ExecFileCallback = (err: unknown, result: { stdout: string | Buffer; stderr: string }) => void
+
+type GeneratedProcess = {
+  ProcessId: number
+  ParentProcessId: number
+  Name: string
+  CommandLine: string
+  ExecutablePath: string
+}
+
+/** Deterministic PRNG so a failing table is reproducible from its seed alone. */
+function makeRandom(seed: number): () => number {
+  let state = seed >>> 0
+  return () => {
+    state = (state * 1664525 + 1013904223) >>> 0
+    return state / 0x100000000
+  }
+}
+
+// Everything a real command line can contain that looks like wmic's framing.
+// `ExecutablePath=` is held back: it is the only property that can advance the
+// parser out of CommandLine, so a table without it cannot forge a record.
+const NON_FORGING_FRAGMENTS = [
+  'ProcessId=4',
+  'ParentProcessId=0',
+  'Name=lsass.exe',
+  'CommandLine=nested',
+  '',
+  '   ',
+  'KEY=value',
+  '--flag "quoted arg"',
+  "$'multi\\nline'",
+  'ünïcödé ✓ 中文',
+  '   trailing   ',
+  '=leading equals',
+  'plain continuation text'
+]
+
+/** No padding-only entries: with these, trimming is a no-op and equality is exact. */
+const STRICT_FRAGMENTS = NON_FORGING_FRAGMENTS.filter((f) => f.trim() === f && f !== '')
+
+const FORGING_FRAGMENTS = [
+  ...NON_FORGING_FRAGMENTS,
+  'ExecutablePath=C:/evil.exe',
+  // A complete forged tail, the documented residue.
+  'ExecutablePath=C:/evil.exe\nName=lsass.exe\nParentProcessId=0\nProcessId=4'
+]
+
+function generateTable(
+  seed: number,
+  fragments: string[],
+  options: { multiline?: boolean } = {}
+): GeneratedProcess[] {
+  const random = makeRandom(seed)
+  const pick = <T>(items: T[]): T => items[Math.floor(random() * items.length)]!
+  const count = 3 + Math.floor(random() * 12)
+  const usedPids = new Set<number>()
+  const rows: GeneratedProcess[] = []
+  for (let i = 0; i < count; i += 1) {
+    let pid = 4 + Math.floor(random() * 60000)
+    while (usedPids.has(pid)) {
+      pid += 1
+    }
+    usedPids.add(pid)
+    const pieces = Array.from({ length: Math.floor(random() * 4) }, () => pick(fragments))
+    const eol = options.multiline === false ? ' ' : random() < 0.5 ? '\r\n' : '\n'
+    const command = [`exe${i} --run`, ...pieces].join(eol)
+    rows.push({
+      ProcessId: pid,
+      ParentProcessId: i === 0 ? 0 : rows[Math.floor(random() * rows.length)]!.ProcessId,
+      Name: `proc${i}.exe`,
+      CommandLine: random() < 0.1 ? '' : command,
+      ExecutablePath: random() < 0.1 ? '' : `C:/apps/proc${i}.exe`
+    })
+  }
+  return rows
+}
+
+/** wmic `/format:value`: properties in fixed order, blank line after each record. */
+function renderWmicValue(rows: GeneratedProcess[]): Buffer {
+  const text = rows
+    .map((row) =>
+      [
+        `CommandLine=${row.CommandLine}`,
+        `ExecutablePath=${row.ExecutablePath}`,
+        `Name=${row.Name}`,
+        `ParentProcessId=${row.ParentProcessId}`,
+        `ProcessId=${row.ProcessId}`,
+        ''
+      ].join('\r\n')
+    )
+    .join('\r\n')
+  return Buffer.concat([Buffer.from([0xff, 0xfe]), Buffer.from(text, 'utf16le')])
+}
+
+const isWmic = (command: string): boolean => /wmic/i.test(command)
+
+type ReadRow = { pid: number; ppid: number; name: string; command: string; executablePath: string }
+
+/**
+ * Rows as the wmic reader sees them, with PowerShell erroring so it cannot mask a
+ * gap. Null means the reader refused the table outright — the duplicate-pid drop —
+ * which is a safe outcome, not an answer.
+ */
+async function readViaWmic(rows: GeneratedProcess[]): Promise<ReadRow[] | null> {
+  resetWindowsProcessRowsReaderForTests()
+  const stdout = renderWmicValue(rows)
+  execFileMock.mockImplementation((cmd: string, _a: unknown, _o: unknown, cb: unknown) => {
+    const callback = cb as ExecFileCallback
+    if (isWmic(cmd)) {
+      callback(null, { stdout, stderr: '' })
+      return
+    }
+    callback(new Error('powershell unavailable'), { stdout: '', stderr: '' })
+  })
+  try {
+    return (await queryWindowsProcessRowsFresh()).map(toReadRow)
+  } catch {
+    return null
+  }
+}
+
+const toReadRow = (r: ReadRow): ReadRow => ({
+  pid: r.pid,
+  ppid: r.ppid,
+  name: r.name,
+  command: r.command,
+  executablePath: r.executablePath
+})
+
+/** The same table through the PowerShell/JSON reader — the reference answer. */
+async function readViaPowerShell(rows: GeneratedProcess[]): Promise<ReadRow[]> {
+  resetWindowsProcessRowsReaderForTests()
+  const stdout = JSON.stringify(rows)
+  execFileMock.mockImplementation((cmd: string, _a: unknown, _o: unknown, cb: unknown) => {
+    const callback = cb as ExecFileCallback
+    if (isWmic(cmd)) {
+      callback(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }), { stdout: '', stderr: '' })
+      return
+    }
+    callback(null, { stdout, stderr: '' })
+  })
+  return (await queryWindowsProcessRowsFresh()).map(toReadRow)
+}
+
+const byPid = <T extends { pid: number }>(rows: T[]): T[] => [...rows].sort((a, b) => a.pid - b.pid)
+
+describe('wmic reader vs PowerShell reader, over generated hostile tables', () => {
+  beforeEach(() => {
+    execFileMock.mockReset()
+    resetWindowsProcessRowsReaderForTests()
+  })
+
+  // Single-line command lines are the case the value format can represent without
+  // loss, so nothing less than byte equality is acceptable there.
+  it('agrees byte-for-byte with PowerShell on 400 newline-free tables', async () => {
+    for (let seed = 1; seed <= 400; seed += 1) {
+      const table = generateTable(seed, STRICT_FRAGMENTS, { multiline: false })
+      const viaWmic = await readViaWmic(table)
+      expect(viaWmic, `seed ${seed} was refused outright`).not.toBeNull()
+      expect(byPid(viaWmic!), `seed ${seed}`).toEqual(byPid(await readViaPowerShell(table)))
+    }
+  })
+
+  // With CR/LF in play the format is lossy in exactly two ways and no others: it
+  // cannot tell a command's own newline from the record separator, and trailing
+  // whitespace is indistinguishable from padding. Identity must still be exact —
+  // only the command text is allowed to differ, and only by that normalization.
+  it('agrees with PowerShell on 400 hostile multi-line tables, modulo CR/LF and padding', async () => {
+    const normalize = (row: ReadRow): ReadRow => ({
+      ...row,
+      command: row.command.replace(/\r\n/g, '\n').trim()
+    })
+    for (let seed = 1; seed <= 400; seed += 1) {
+      const table = generateTable(seed, NON_FORGING_FRAGMENTS)
+      const viaWmic = await readViaWmic(table)
+      expect(viaWmic, `seed ${seed} was refused outright`).not.toBeNull()
+      expect(byPid(viaWmic!).map(normalize), `seed ${seed}`).toEqual(
+        byPid(await readViaPowerShell(table)).map(normalize)
+      )
+    }
+  })
+
+  // The property `taskkill /T /F` targeting rests on. A forged row may invent a pid
+  // that does not exist — inert, killing a dead pid no-ops — but must never restate
+  // a live pid under a parent it does not have.
+  it('never mis-parents a real pid on 400 tables that can forge the framing', async () => {
+    let refused = 0
+    for (let seed = 1; seed <= 400; seed += 1) {
+      const table = generateTable(seed, FORGING_FRAGMENTS)
+      const truth = new Map(table.map((row) => [row.ProcessId, row.ParentProcessId]))
+      const viaWmic = await readViaWmic(table)
+      if (viaWmic === null) {
+        refused += 1
+        continue
+      }
+      for (const row of viaWmic) {
+        if (truth.has(row.pid)) {
+          expect(truth.get(row.pid), `seed ${seed}, pid ${row.pid}`).toBe(row.ppid)
+        }
+      }
+    }
+    // Guard the guard: if forged tables stopped reaching the parser at all, the
+    // property above would hold vacuously.
+    expect(refused).toBeLessThan(400)
+  })
+
+  it('keeps every real pid present, so ancestry never silently loses a process', async () => {
+    for (let seed = 1; seed <= 200; seed += 1) {
+      const table = generateTable(seed, NON_FORGING_FRAGMENTS)
+      const viaWmic = await readViaWmic(table)
+      expect(viaWmic, `seed ${seed} was refused outright`).not.toBeNull()
+      const seen = new Set(viaWmic!.map((row) => row.pid))
+      for (const row of table) {
+        expect(seen.has(row.ProcessId), `seed ${seed} lost pid ${row.ProcessId}`).toBe(true)
+      }
+    }
+  })
+})

--- a/src/main/providers/windows-foreground-process-rows-differential.test.ts
+++ b/src/main/providers/windows-foreground-process-rows-differential.test.ts
@@ -77,6 +77,35 @@ const FORGING_FRAGMENTS = [
   'ExecutablePath=C:/evil.exe\nName=lsass.exe\nParentProcessId=0\nProcessId=4'
 ]
 
+/**
+ * The attack worth testing is not a forged row about nobody — it is a forged row
+ * about a process that exists, parented where the observer will look. So poison one
+ * command line with a tail claiming a real victim pid under the observed root. A
+ * forged row that lands outside the walked tree is invisible to a descendants-based
+ * check, which is how an earlier version of this suite missed exactly this.
+ */
+function poisonWithVictimForgery(rows: GeneratedProcess[], seed: number): GeneratedProcess[] {
+  if (rows.length < 3) {
+    return rows
+  }
+  const random = makeRandom(seed * 7919)
+  const root = rows[0]!.ProcessId
+  const victim = rows[1 + Math.floor(random() * (rows.length - 1))]!
+  const poisoner = rows[1 + Math.floor(random() * (rows.length - 1))]!
+  if (poisoner.ProcessId === victim.ProcessId) {
+    return rows
+  }
+  const tail = [
+    'ExecutablePath=C:/forged.exe',
+    'Name=forged.exe',
+    `ParentProcessId=${root}`,
+    `ProcessId=${victim.ProcessId}`
+  ].join('\n')
+  return rows.map((row) =>
+    row === poisoner ? { ...row, CommandLine: `${row.CommandLine}\n${tail}` } : row
+  )
+}
+
 function generateTable(
   seed: number,
   fragments: string[],
@@ -224,7 +253,7 @@ describe('wmic reader vs PowerShell reader, over generated hostile tables', () =
   it('never mis-parents a real pid on 400 tables that can forge the framing', async () => {
     let refused = 0
     for (let seed = 1; seed <= 400; seed += 1) {
-      const table = generateTable(seed, FORGING_FRAGMENTS)
+      const table = poisonWithVictimForgery(generateTable(seed, FORGING_FRAGMENTS), seed)
       const truth = new Map(table.map((row) => [row.ProcessId, row.ParentProcessId]))
       const viaWmic = await readViaWmic(table)
       if (viaWmic === null) {

--- a/src/main/providers/windows-foreground-process-rows-differential.test.ts
+++ b/src/main/providers/windows-foreground-process-rows-differential.test.ts
@@ -136,8 +136,15 @@ function generateTable(
   return rows
 }
 
-/** wmic `/format:value`: properties in fixed order, blank line after each record. */
-function renderWmicValue(rows: GeneratedProcess[]): Buffer {
+/**
+ * wmic `/format:value`: properties in fixed order, blank line after each record.
+ *
+ * `eol` because wmic's redirected output is historically CR CR LF rather than CR
+ * LF, and the difference is not cosmetic: a parser that splits on /\r?\n/ is left
+ * holding a trailing CR, so the record separator never reads as empty and the
+ * whole table parses to nothing. Every table here is checked in both.
+ */
+function renderWmicValue(rows: GeneratedProcess[], eol = '\r\n'): Buffer {
   const text = rows
     .map((row) =>
       [
@@ -147,11 +154,13 @@ function renderWmicValue(rows: GeneratedProcess[]): Buffer {
         `ParentProcessId=${row.ParentProcessId}`,
         `ProcessId=${row.ProcessId}`,
         ''
-      ].join('\r\n')
+      ].join(eol)
     )
-    .join('\r\n')
+    .join(eol)
   return Buffer.concat([Buffer.from([0xff, 0xfe]), Buffer.from(text, 'utf16le')])
 }
+
+const WMIC_EOLS = ['\r\n', '\r\r\n'] as const
 
 const isWmic = (command: string): boolean => /wmic/i.test(command)
 
@@ -162,9 +171,9 @@ type ReadRow = { pid: number; ppid: number; name: string; command: string; execu
  * gap. Null means the reader refused the table outright — the duplicate-pid drop —
  * which is a safe outcome, not an answer.
  */
-async function readViaWmic(rows: GeneratedProcess[]): Promise<ReadRow[] | null> {
+async function readViaWmic(rows: GeneratedProcess[], eol = '\r\n'): Promise<ReadRow[] | null> {
   resetWindowsProcessRowsReaderForTests()
-  const stdout = renderWmicValue(rows)
+  const stdout = renderWmicValue(rows, eol)
   execFileMock.mockImplementation((cmd: string, _a: unknown, _o: unknown, cb: unknown) => {
     const callback = cb as ExecFileCallback
     if (isWmic(cmd)) {
@@ -215,12 +224,15 @@ describe('wmic reader vs PowerShell reader, over generated hostile tables', () =
 
   // Single-line command lines are the case the value format can represent without
   // loss, so nothing less than byte equality is acceptable there.
-  it('agrees byte-for-byte with PowerShell on 400 newline-free tables', async () => {
+  it('agrees byte-for-byte with PowerShell on 400 newline-free tables, in both wmic line endings', async () => {
     for (let seed = 1; seed <= 400; seed += 1) {
       const table = generateTable(seed, STRICT_FRAGMENTS, { multiline: false })
-      const viaWmic = await readViaWmic(table)
-      expect(viaWmic, `seed ${seed} was refused outright`).not.toBeNull()
-      expect(byPid(viaWmic!), `seed ${seed}`).toEqual(byPid(await readViaPowerShell(table)))
+      const reference = byPid(await readViaPowerShell(table))
+      for (const eol of WMIC_EOLS) {
+        const viaWmic = await readViaWmic(table, eol)
+        expect(viaWmic, `seed ${seed} eol ${JSON.stringify(eol)} was refused`).not.toBeNull()
+        expect(byPid(viaWmic!), `seed ${seed} eol ${JSON.stringify(eol)}`).toEqual(reference)
+      }
     }
   })
 
@@ -235,11 +247,14 @@ describe('wmic reader vs PowerShell reader, over generated hostile tables', () =
     })
     for (let seed = 1; seed <= 400; seed += 1) {
       const table = generateTable(seed, NON_FORGING_FRAGMENTS)
-      const viaWmic = await readViaWmic(table)
-      expect(viaWmic, `seed ${seed} was refused outright`).not.toBeNull()
-      expect(byPid(viaWmic!).map(normalize), `seed ${seed}`).toEqual(
-        byPid(await readViaPowerShell(table)).map(normalize)
-      )
+      const reference = byPid(await readViaPowerShell(table)).map(normalize)
+      for (const eol of WMIC_EOLS) {
+        const viaWmic = await readViaWmic(table, eol)
+        expect(viaWmic, `seed ${seed} eol ${JSON.stringify(eol)} was refused`).not.toBeNull()
+        expect(byPid(viaWmic!).map(normalize), `seed ${seed} eol ${JSON.stringify(eol)}`).toEqual(
+          reference
+        )
+      }
     }
   })
 

--- a/src/main/providers/windows-foreground-process-rows-differential.test.ts
+++ b/src/main/providers/windows-foreground-process-rows-differential.test.ts
@@ -9,10 +9,15 @@
 //
 //   Fidelity — with content that cannot forge the framing, the wmic rows must
 //   equal the PowerShell rows exactly, command text included.
-//   Safety   — with content that CAN forge it, no row may claim a pid that
-//   exists in the real table under the wrong parent. That is the property
-//   `taskkill /T /F` targeting rests on; a phantom pid is inert, a mis-parented
-//   real one is not.
+//   Safety   — with content that CAN forge it, no process that genuinely exists
+//   may be restated under a parent it does not have.
+//
+// Safety stops there because it has to: a command line can emit a whole
+// well-formed record — blank-line separator and a following `CommandLine=` to
+// resynchronise — and nothing in the byte stream distinguishes it from a real
+// one. That is a property of `/format:value`, not of this parser. It is
+// survivable only because the reader gating `taskkill /T /F` is PowerShell-only,
+// so an invented row can misname a pane and nothing worse.
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { execFileMock } = vi.hoisted(() => ({ execFileMock: vi.fn() }))
@@ -20,7 +25,7 @@ const { execFileMock } = vi.hoisted(() => ({ execFileMock: vi.fn() }))
 vi.mock('child_process', () => ({ execFile: execFileMock }))
 
 import {
-  queryWindowsProcessRowsFresh,
+  queryWindowsProcessDescendants,
   resetWindowsProcessRowsReaderForTests
 } from './windows-foreground-process-rows'
 
@@ -140,7 +145,8 @@ async function readViaWmic(rows: GeneratedProcess[]): Promise<ReadRow[] | null> 
     callback(new Error('powershell unavailable'), { stdout: '', stderr: '' })
   })
   try {
-    return (await queryWindowsProcessRowsFresh()).map(toReadRow)
+    const candidates = await queryWindowsProcessDescendants(rows[0]!.ProcessId, { fresh: true })
+    return candidates === null ? null : candidates.map(toReadRow)
   } catch {
     return null
   }
@@ -166,7 +172,8 @@ async function readViaPowerShell(rows: GeneratedProcess[]): Promise<ReadRow[]> {
     }
     callback(null, { stdout, stderr: '' })
   })
-  return (await queryWindowsProcessRowsFresh()).map(toReadRow)
+  const candidates = await queryWindowsProcessDescendants(rows[0]!.ProcessId, { fresh: true })
+  return (candidates ?? []).map(toReadRow)
 }
 
 const byPid = <T extends { pid: number }>(rows: T[]): T[] => [...rows].sort((a, b) => a.pid - b.pid)
@@ -207,9 +214,13 @@ describe('wmic reader vs PowerShell reader, over generated hostile tables', () =
     }
   })
 
-  // The property `taskkill /T /F` targeting rests on. A forged row may invent a pid
-  // that does not exist — inert, killing a dead pid no-ops — but must never restate
-  // a live pid under a parent it does not have.
+  // A command line can emit a whole well-formed record, separator and resync line
+  // included, so this reader CAN be made to invent a row and no parser can prevent
+  // it. That is survivable only because the reader gating `taskkill /T /F` is
+  // PowerShell-only (see the test in windows-foreground-process-rows.test.ts) —
+  // here an invented row can misname a pane and nothing worse. What must still
+  // hold is that a process which genuinely exists is never restated under a parent
+  // it does not have, so a real agent's lineage cannot be rewritten.
   it('never mis-parents a real pid on 400 tables that can forge the framing', async () => {
     let refused = 0
     for (let seed = 1; seed <= 400; seed += 1) {
@@ -237,7 +248,7 @@ describe('wmic reader vs PowerShell reader, over generated hostile tables', () =
       const viaWmic = await readViaWmic(table)
       expect(viaWmic, `seed ${seed} was refused outright`).not.toBeNull()
       const seen = new Set(viaWmic!.map((row) => row.pid))
-      for (const row of table) {
+      for (const row of table.slice(1)) {
         expect(seen.has(row.ProcessId), `seed ${seed} lost pid ${row.ProcessId}`).toBe(true)
       }
     }

--- a/src/main/providers/windows-foreground-process-rows.test.ts
+++ b/src/main/providers/windows-foreground-process-rows.test.ts
@@ -153,6 +153,81 @@ describe('windows foreground process rows spawn options', () => {
     )
   })
 
+  // A command line can supply a whole record. The invented row is not inert: with
+  // ppid set to Orca's own pid it bridges a real orphan (a process whose parent
+  // already exited) into our subtree, and classifyWindowsTreeKillTarget then reads
+  // that unrelated tree as `own` and lets `taskkill /T /F` have it. wmic closes
+  // every record with an empty line, so properties resuming without one prove the
+  // record came from content — and the whole snapshot is refused.
+  it('refuses a table where a command line supplied a whole record (#15565 review)', async () => {
+    const forged =
+      'CommandLine=evil.exe\n' +
+      'ExecutablePath=C:/fake.exe\n' +
+      'Name=fake.exe\n' +
+      'ParentProcessId=1000\n' +
+      'ProcessId=5000\n' +
+      'ExecutablePath=C:/real/evil.exe\n' +
+      'Name=evil.exe\n' +
+      'ParentProcessId=100\n' +
+      'ProcessId=400\n\n'
+    execFileMock.mockImplementation((cmd: string, _args, _opts, cb: ExecFileCallback) => {
+      cb(null, {
+        stdout: isCommand(cmd, 'wmic') ? `${WMIC_ROWS_VALUE}\n${forged}` : POWERSHELL_ROWS_JSON,
+        stderr: ''
+      })
+    })
+
+    const candidates = await queryWindowsProcessDescendants(100, { fresh: true })
+
+    expect(candidates?.map((row) => row.pid)).toEqual([200])
+    expect(candidates?.some((row) => row.pid === 5000)).toBe(false)
+  })
+
+  // A framing failure is content any local process can arrange. Retiring wmic over
+  // it would hand that process a switch for turning the transcript flood back on.
+  it('backs off after repeated framing failures, then retries wmic (#15565 review)', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(0)
+    try {
+      let wmicSpawns = 0
+      let hostile = true
+      execFileMock.mockImplementation((cmd: string, _args, _opts, cb: ExecFileCallback) => {
+        if (isCommand(cmd, 'wmic')) {
+          wmicSpawns += 1
+          // A command line that walks the framing: properties resume with no break.
+          cb(null, {
+            stdout: hostile
+              ? 'CommandLine=x\nExecutablePath=a\nName=b\nParentProcessId=1\nProcessId=2\nExecutablePath=c\n'
+              : WMIC_ROWS_VALUE,
+            stderr: ''
+          })
+          return
+        }
+        cb(null, { stdout: POWERSHELL_ROWS_JSON, stderr: '' })
+      })
+
+      for (let scan = 0; scan < 3; scan += 1) {
+        await queryWindowsProcessDescendants(100, { fresh: true })
+      }
+      expect(wmicSpawns).toBe(3)
+
+      // Inside the backoff window wmic is not spawned at all — one process per
+      // scan, never the two that a retry-every-scan policy would cost.
+      await queryWindowsProcessDescendants(100, { fresh: true })
+      expect(wmicSpawns).toBe(3)
+
+      // ...and the fix comes back on its own once the window passes.
+      hostile = false
+      vi.setSystemTime(60_001)
+      const candidates = await queryWindowsProcessDescendants(100, { fresh: true })
+
+      expect(wmicSpawns).toBe(4)
+      expect(candidates?.map((row) => row.pid)).toEqual([200])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   // A repeated pid means the record framing desynced, and ancestry read off a
   // desynced table can misdirect `taskkill /T /F`.
   it('discards a wmic table with duplicate pids and lets PowerShell answer', async () => {
@@ -185,15 +260,15 @@ describe('windows foreground process rows spawn options', () => {
       cb(null, { stdout: POWERSHELL_ROWS_JSON, stderr: '' })
     })
 
-    await queryWindowsProcessRowsFresh()
-    await queryWindowsProcessRowsFresh()
+    await queryWindowsProcessDescendants(100, { fresh: true })
+    await queryWindowsProcessDescendants(100, { fresh: true })
 
     expect(wmicSpawns).toBe(1)
     expect(optionsForCommand('powershell.exe')).toMatchObject({ windowsHide: true })
   })
 
   // A WMI hiccup must not cost the fix for the rest of the process lifetime.
-  it('retries wmic after a transient scan failure, and demotes it once it persists', async () => {
+  it('retries wmic after a transient scan failure, and stops once they persist', async () => {
     let wmicSpawns = 0
     let failing = true
     execFileMock.mockImplementation((cmd: string, _args, _opts, cb: ExecFileCallback) => {
@@ -209,22 +284,22 @@ describe('windows foreground process rows spawn options', () => {
       cb(null, { stdout: POWERSHELL_ROWS_JSON, stderr: '' })
     })
 
-    await queryWindowsProcessRowsFresh()
+    await queryWindowsProcessDescendants(100, { fresh: true })
     failing = false
-    const rows = await queryWindowsProcessRowsFresh()
+    const candidates = await queryWindowsProcessDescendants(100, { fresh: true })
 
     expect(wmicSpawns).toBe(2)
-    expect(rows.map((row) => row.pid)).toEqual([100, 200])
+    expect(candidates?.map((row) => row.pid)).toEqual([200])
 
     failing = true
-    await queryWindowsProcessRowsFresh()
-    await queryWindowsProcessRowsFresh()
-    await queryWindowsProcessRowsFresh()
-    const spawnsAfterDemotion = wmicSpawns
+    await queryWindowsProcessDescendants(100, { fresh: true })
+    await queryWindowsProcessDescendants(100, { fresh: true })
+    await queryWindowsProcessDescendants(100, { fresh: true })
+    const spawnsAfterBackoff = wmicSpawns
 
-    await queryWindowsProcessRowsFresh()
+    await queryWindowsProcessDescendants(100, { fresh: true })
 
-    expect(wmicSpawns).toBe(spawnsAfterDemotion)
+    expect(wmicSpawns).toBe(spawnsAfterBackoff)
   })
 })
 
@@ -257,6 +332,29 @@ describe('queryWindowsProcessRowsFresh', () => {
 
   const powershellScanCount = (): number =>
     execFileMock.mock.calls.filter((call) => call[0] === 'powershell.exe').length
+
+  // wmic's value format has no escaping and CommandLine is chosen by whoever
+  // launched the process, so a command line can emit a whole well-formed record —
+  // separator and resync line included — that no parser can tell from a real one.
+  // An invented `{pid, ppid}` bridges a real orphan to our pid and hands an
+  // unrelated tree to `taskkill /T /F`, so this reader must never touch wmic, even
+  // where wmic is present and answering.
+  it('never reads wmic, because its rows gate taskkill /T /F (#15565 review)', async () => {
+    execFileMock.mockReset()
+    execFileMock.mockImplementation((cmd: string, _args, _opts, cb: ExecFileCallback) => {
+      cb(null, {
+        stdout: isCommand(cmd, 'wmic') ? WMIC_ROWS_VALUE : POWERSHELL_ROWS_JSON,
+        stderr: ''
+      })
+    })
+
+    const rows = await queryWindowsProcessRowsFresh()
+
+    expect(rows.map((row) => row.pid)).toEqual([100, 200])
+    expect(
+      execFileMock.mock.calls.some((args) => isCommand((args as ExecFileCall)[0], 'wmic'))
+    ).toBe(false)
+  })
 
   it('collapses a burst of concurrent identity probes into one scan', async () => {
     const rows = await Promise.all(Array.from({ length: 32 }, () => queryWindowsProcessRowsFresh()))

--- a/src/main/providers/windows-foreground-process-rows.test.ts
+++ b/src/main/providers/windows-foreground-process-rows.test.ts
@@ -12,6 +12,7 @@ vi.mock('child_process', () => ({ execFile: execFileMock }))
 import {
   queryWindowsProcessDescendants,
   queryWindowsProcessRowsFresh,
+  resetWindowsProcessProbePreferenceForTests,
   resetWindowsProcessRowsSnapshotForTests
 } from './windows-foreground-process-rows'
 
@@ -61,6 +62,7 @@ describe('windows foreground process rows spawn options', () => {
   beforeEach(() => {
     execFileMock.mockReset()
     resetWindowsProcessRowsSnapshotForTests()
+    resetWindowsProcessProbePreferenceForTests()
     platform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
   })
@@ -71,8 +73,31 @@ describe('windows foreground process rows spawn options', () => {
     }
   })
 
-  it('hides the console window for the powershell process-table scan', async () => {
-    execFileMock.mockImplementation((_cmd: string, _args, _opts, cb: ExecFileCallback) => {
+  it('prefers wmic and spawns no PowerShell host when wmic exists (#15209)', async () => {
+    execFileMock.mockImplementation((cmd: string, _args, _opts, cb: ExecFileCallback) => {
+      if (cmd === 'wmic') {
+        cb(null, { stdout: WMIC_ROWS_VALUE, stderr: '' })
+        return
+      }
+      cb(new Error('powershell must not spawn when wmic answered'), { stdout: '', stderr: '' })
+    })
+
+    const candidates = await queryWindowsProcessDescendants(100)
+
+    expect(candidates?.[0]?.pid).toBe(200)
+    expect(optionsForCommand('wmic')).toMatchObject({ windowsHide: true })
+    expect(optionsForCommand('wmic')).toBeTruthy()
+    expect(execFileMock.mock.calls.some((args) => (args as ExecFileCall)[0] === 'powershell.exe')).toBe(
+      false
+    )
+  })
+
+  it('falls back to PowerShell — windowsHide on — when wmic is missing', async () => {
+    execFileMock.mockImplementation((cmd: string, _args, _opts, cb: ExecFileCallback) => {
+      if (cmd === 'wmic') {
+        cb(new Error('wmic not found'), { stdout: '', stderr: '' })
+        return
+      }
       cb(null, { stdout: POWERSHELL_ROWS_JSON, stderr: '' })
     })
 
@@ -82,20 +107,26 @@ describe('windows foreground process rows spawn options', () => {
     expect(optionsForCommand('powershell.exe')).toMatchObject({ windowsHide: true })
   })
 
-  it('hides the console window for the wmic fallback scan', async () => {
-    execFileMock.mockImplementation((cmd: string, _args, _opts, cb: ExecFileCallback) => {
-      // Force the powershell probe to miss so the wmic fallback runs.
-      if (cmd === 'powershell.exe') {
-        cb(new Error('powershell unavailable'), { stdout: '', stderr: '' })
+  it('falls back to PowerShell when a capable wmic scan fails, without re-probing', async () => {
+    let wmicScans = 0
+    execFileMock.mockImplementation((cmd: string, args: string[], _opts, cb: ExecFileCallback) => {
+      if (cmd === 'wmic' && args[0] === '/?') {
+        cb(null, { stdout: 'usage', stderr: '' })
         return
       }
-      cb(null, { stdout: WMIC_ROWS_VALUE, stderr: '' })
+      if (cmd === 'wmic') {
+        wmicScans += 1
+        cb(new Error('wmi service hiccup'), { stdout: '', stderr: '' })
+        return
+      }
+      cb(null, { stdout: POWERSHELL_ROWS_JSON, stderr: '' })
     })
 
     const candidates = await queryWindowsProcessDescendants(100)
 
     expect(candidates?.[0]?.pid).toBe(200)
-    expect(optionsForCommand('wmic')).toMatchObject({ windowsHide: true })
+    expect(wmicScans).toBe(1)
+    expect(optionsForCommand('powershell.exe')).toMatchObject({ windowsHide: true })
   })
 })
 
@@ -108,9 +139,15 @@ describe('queryWindowsProcessRowsFresh', () => {
   beforeEach(() => {
     execFileMock.mockReset()
     resetWindowsProcessRowsSnapshotForTests()
+    resetWindowsProcessProbePreferenceForTests()
     platform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
-    execFileMock.mockImplementation((_cmd: string, _args, _opts, cb: ExecFileCallback) => {
+    // The capability probe answers for any wmic call; scans then use PowerShell.
+    execFileMock.mockImplementation((cmd: string, _args, _opts, cb: ExecFileCallback) => {
+      if (cmd === 'wmic') {
+        cb(new Error('wmic not found'), { stdout: '', stderr: '' })
+        return
+      }
       cb(null, { stdout: POWERSHELL_ROWS_JSON, stderr: '' })
     })
   })

--- a/src/main/providers/windows-foreground-process-rows.test.ts
+++ b/src/main/providers/windows-foreground-process-rows.test.ts
@@ -51,11 +51,19 @@ const WMIC_ROWS_VALUE =
 const wmicUtf16 = (value: string): Buffer =>
   Buffer.concat([Buffer.from([0xff, 0xfe]), Buffer.from(value, 'utf16le')])
 
+/** wmic is spawned by absolute path, so match on the basename. */
+const basename = (command: string): string =>
+  command
+    .toLowerCase()
+    .replace(/^.*[\\/]/, '')
+    .replace(/\.exe$/, '')
+const isCommand = (spawned: string, name: string): boolean => basename(spawned) === basename(name)
+
 /** Returns the options object passed to the mocked execFile for a given command. */
 function optionsForCommand(command: string): Record<string, unknown> | undefined {
-  const call = execFileMock.mock.calls.find((args) => (args as ExecFileCall)[0] === command) as
-    | ExecFileCall
-    | undefined
+  const call = execFileMock.mock.calls.find((args) =>
+    isCommand((args as ExecFileCall)[0], command)
+  ) as ExecFileCall | undefined
   return call?.[2]
 }
 
@@ -77,7 +85,7 @@ describe('windows foreground process rows spawn options', () => {
 
   it('prefers wmic and spawns no PowerShell host when wmic exists (#15209)', async () => {
     execFileMock.mockImplementation((cmd: string, _args, _opts, cb: ExecFileCallback) => {
-      if (cmd === 'wmic') {
+      if (isCommand(cmd, 'wmic')) {
         cb(null, { stdout: WMIC_ROWS_VALUE, stderr: '' })
         return
       }
@@ -89,7 +97,7 @@ describe('windows foreground process rows spawn options', () => {
     expect(candidates?.[0]?.pid).toBe(200)
     expect(optionsForCommand('wmic')).toMatchObject({ windowsHide: true })
     expect(
-      execFileMock.mock.calls.some((args) => (args as ExecFileCall)[0] === 'powershell.exe')
+      execFileMock.mock.calls.some((args) => isCommand((args as ExecFileCall)[0], 'powershell'))
     ).toBe(false)
   })
 
@@ -98,10 +106,15 @@ describe('windows foreground process rows spawn options', () => {
   // PowerShell path this fix exists to leave.
   it('reads the UTF-16LE table wmic writes through a redirected stdout', async () => {
     execFileMock.mockImplementation((cmd: string, _args, _opts, cb: ExecFileCallback) => {
-      cb(cmd === 'wmic' ? null : new Error('powershell must not answer a readable wmic table'), {
-        stdout: wmicUtf16(WMIC_ROWS_VALUE),
-        stderr: ''
-      })
+      cb(
+        isCommand(cmd, 'wmic')
+          ? null
+          : new Error('powershell must not answer a readable wmic table'),
+        {
+          stdout: wmicUtf16(WMIC_ROWS_VALUE),
+          stderr: ''
+        }
+      )
     })
 
     const candidates = await queryWindowsProcessDescendants(100)
@@ -126,7 +139,7 @@ describe('windows foreground process rows spawn options', () => {
       'ParentProcessId=100\n' +
       'ProcessId=300\n\n'
     execFileMock.mockImplementation((cmd: string, _args, _opts, cb: ExecFileCallback) => {
-      cb(cmd === 'wmic' ? null : new Error('powershell must not answer'), {
+      cb(isCommand(cmd, 'wmic') ? null : new Error('powershell must not answer'), {
         stdout: `${WMIC_ROWS_VALUE}\n${multiline}`,
         stderr: ''
       })
@@ -145,7 +158,9 @@ describe('windows foreground process rows spawn options', () => {
   it('discards a wmic table with duplicate pids and lets PowerShell answer', async () => {
     execFileMock.mockImplementation((cmd: string, _args, _opts, cb: ExecFileCallback) => {
       cb(null, {
-        stdout: cmd === 'wmic' ? `${WMIC_ROWS_VALUE}\n${WMIC_ROWS_VALUE}` : POWERSHELL_ROWS_JSON,
+        stdout: isCommand(cmd, 'wmic')
+          ? `${WMIC_ROWS_VALUE}\n${WMIC_ROWS_VALUE}`
+          : POWERSHELL_ROWS_JSON,
         stderr: ''
       })
     })
@@ -159,7 +174,7 @@ describe('windows foreground process rows spawn options', () => {
   it('stops spawning wmic once the host has none — 24H2+ (windowsHide stays on)', async () => {
     let wmicSpawns = 0
     execFileMock.mockImplementation((cmd: string, _args, _opts, cb: ExecFileCallback) => {
-      if (cmd === 'wmic') {
+      if (isCommand(cmd, 'wmic')) {
         wmicSpawns += 1
         cb(Object.assign(new Error('spawn wmic ENOENT'), { code: 'ENOENT' }), {
           stdout: '',
@@ -182,7 +197,7 @@ describe('windows foreground process rows spawn options', () => {
     let wmicSpawns = 0
     let failing = true
     execFileMock.mockImplementation((cmd: string, _args, _opts, cb: ExecFileCallback) => {
-      if (cmd === 'wmic') {
+      if (isCommand(cmd, 'wmic')) {
         wmicSpawns += 1
         if (failing) {
           cb(new Error('wmi service hiccup'), { stdout: '', stderr: '' })
@@ -226,7 +241,7 @@ describe('queryWindowsProcessRowsFresh', () => {
     Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
     // The capability probe answers for any wmic call; scans then use PowerShell.
     execFileMock.mockImplementation((cmd: string, _args, _opts, cb: ExecFileCallback) => {
-      if (cmd === 'wmic') {
+      if (isCommand(cmd, 'wmic')) {
         cb(new Error('wmic not found'), { stdout: '', stderr: '' })
         return
       }

--- a/src/main/providers/windows-foreground-process-rows.test.ts
+++ b/src/main/providers/windows-foreground-process-rows.test.ts
@@ -226,22 +226,39 @@ ${poisoned}`,
     ).toBe(false)
   })
 
-  // A repeated pid means the record framing desynced, and ancestry read off a
-  // desynced table can misdirect `taskkill /T /F`.
-  it('discards a wmic table with duplicate pids and lets PowerShell answer', async () => {
+  // A repeated pid means one of the two rows was supplied by a command line
+  // claiming another process's pid, and the bytes do not say which — so both go.
+  // A table where that leaves nothing is still a fact about this snapshot, not the
+  // host: treating it as "wmic is unreadable here" would retire the reader for the
+  // daemon's life and hand any process a permanent switch for the flood (#15565
+  // review). It must degrade for the scan and come straight back.
+  it('degrades on an all-duplicate table without retiring wmic (#15565 review)', async () => {
+    let allDuplicate = true
+    let wmicSpawns = 0
     execFileMock.mockImplementation((cmd: string, _args, _opts, cb: ExecFileCallback) => {
-      cb(null, {
-        stdout: isCommand(cmd, 'wmic')
-          ? `${WMIC_ROWS_VALUE}\n${WMIC_ROWS_VALUE}`
-          : POWERSHELL_ROWS_JSON,
-        stderr: ''
-      })
+      if (isCommand(cmd, 'wmic')) {
+        wmicSpawns += 1
+        cb(null, {
+          stdout: allDuplicate ? `${WMIC_ROWS_VALUE}\n${WMIC_ROWS_VALUE}` : WMIC_ROWS_VALUE,
+          stderr: ''
+        })
+        return
+      }
+      cb(new Error('content must not buy a PowerShell host'), { stdout: '', stderr: '' })
     })
 
-    const candidates = await queryWindowsProcessDescendants(100)
+    // Every pid ambiguous: no rows survive, so the pane falls back to its node-pty
+    // name for this scan rather than trusting a row that might be forged.
+    expect(await queryWindowsProcessDescendants(100, { fresh: true })).toBeNull()
 
-    expect(candidates?.map((row) => row.pid)).toEqual([200])
-    expect(optionsForCommand('powershell.exe')).toMatchObject({ windowsHide: true })
+    allDuplicate = false
+    const recovered = await queryWindowsProcessDescendants(100, { fresh: true })
+
+    expect(recovered?.map((row) => row.pid)).toEqual([200])
+    expect(wmicSpawns).toBe(2)
+    expect(
+      execFileMock.mock.calls.some((args) => isCommand((args as ExecFileCall)[0], 'powershell'))
+    ).toBe(false)
   })
 
   it('stops spawning wmic once the host has none — 24H2+ (windowsHide stays on)', async () => {

--- a/src/main/providers/windows-foreground-process-rows.test.ts
+++ b/src/main/providers/windows-foreground-process-rows.test.ts
@@ -1,8 +1,8 @@
-// Regression guard: the Windows agent foreground-process scan re-forks
-// powershell.exe (or the wmic fallback) on a ~1s/pane cadence. Electron's main
-// process has no console, so a spawn without windowsHide pops a fresh conhost
-// window per scan that flashes and steals keyboard focus from the foreground app
-// (including Orca's own terminal). Both probes MUST pass windowsHide: true.
+// Regression guard: the Windows agent foreground-process scan re-forks wmic (or
+// the powershell.exe fallback) on a ~1s/pane cadence. Electron's main process has
+// no console, so a spawn without windowsHide pops a fresh conhost window per scan
+// that flashes and steals keyboard focus from the foreground app (including
+// Orca's own terminal). Both readers MUST pass windowsHide: true.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { execFileMock } = vi.hoisted(() => ({ execFileMock: vi.fn() }))
@@ -12,11 +12,10 @@ vi.mock('child_process', () => ({ execFile: execFileMock }))
 import {
   queryWindowsProcessDescendants,
   queryWindowsProcessRowsFresh,
-  resetWindowsProcessProbePreferenceForTests,
-  resetWindowsProcessRowsSnapshotForTests
+  resetWindowsProcessRowsReaderForTests
 } from './windows-foreground-process-rows'
 
-type ExecFileCallback = (err: unknown, result: { stdout: string; stderr: string }) => void
+type ExecFileCallback = (err: unknown, result: { stdout: string | Buffer; stderr: string }) => void
 type ExecFileCall = [string, string[], Record<string, unknown>, ExecFileCallback]
 
 const POWERSHELL_ROWS_JSON = JSON.stringify([
@@ -48,6 +47,10 @@ const WMIC_ROWS_VALUE =
   'ParentProcessId=100\n' +
   'ProcessId=200\n'
 
+/** wmic writes UTF-16LE through a redirected stdout, BOM included. */
+const wmicUtf16 = (value: string): Buffer =>
+  Buffer.concat([Buffer.from([0xff, 0xfe]), Buffer.from(value, 'utf16le')])
+
 /** Returns the options object passed to the mocked execFile for a given command. */
 function optionsForCommand(command: string): Record<string, unknown> | undefined {
   const call = execFileMock.mock.calls.find((args) => (args as ExecFileCall)[0] === command) as
@@ -61,8 +64,7 @@ describe('windows foreground process rows spawn options', () => {
 
   beforeEach(() => {
     execFileMock.mockReset()
-    resetWindowsProcessRowsSnapshotForTests()
-    resetWindowsProcessProbePreferenceForTests()
+    resetWindowsProcessRowsReaderForTests()
     platform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
   })
@@ -86,47 +88,122 @@ describe('windows foreground process rows spawn options', () => {
 
     expect(candidates?.[0]?.pid).toBe(200)
     expect(optionsForCommand('wmic')).toMatchObject({ windowsHide: true })
-    expect(optionsForCommand('wmic')).toBeTruthy()
-    expect(execFileMock.mock.calls.some((args) => (args as ExecFileCall)[0] === 'powershell.exe')).toBe(
-      false
+    expect(
+      execFileMock.mock.calls.some((args) => (args as ExecFileCall)[0] === 'powershell.exe')
+    ).toBe(false)
+  })
+
+  // Reading wmic's bytes as utf8 yields NUL-padded keys that match no property,
+  // so the table parses to nothing and every machine silently stays on the
+  // PowerShell path this fix exists to leave.
+  it('reads the UTF-16LE table wmic writes through a redirected stdout', async () => {
+    execFileMock.mockImplementation((cmd: string, _args, _opts, cb: ExecFileCallback) => {
+      cb(cmd === 'wmic' ? null : new Error('powershell must not answer a readable wmic table'), {
+        stdout: wmicUtf16(WMIC_ROWS_VALUE),
+        stderr: ''
+      })
+    })
+
+    const candidates = await queryWindowsProcessDescendants(100)
+
+    expect(candidates?.[0]?.pid).toBe(200)
+    expect(optionsForCommand('wmic')).toMatchObject({ encoding: 'buffer' })
+  })
+
+  // Orca's own panes run multi-line commands, so CR/LF inside CommandLine is
+  // routine — and `Key=Value` framing is exactly what it can impersonate.
+  it('keeps a CommandLine holding CR/LF in one row', async () => {
+    const multiline =
+      "CommandLine=bash -lc $'echo a\nProcessId=4\necho b'\n" +
+      'ExecutablePath=C:/msys64/usr/bin/bash.exe\n' +
+      'Name=bash.exe\n' +
+      'ParentProcessId=100\n' +
+      'ProcessId=300\n\n'
+    execFileMock.mockImplementation((cmd: string, _args, _opts, cb: ExecFileCallback) => {
+      cb(cmd === 'wmic' ? null : new Error('powershell must not answer'), {
+        stdout: `${WMIC_ROWS_VALUE}\n${multiline}`,
+        stderr: ''
+      })
+    })
+
+    const candidates = await queryWindowsProcessDescendants(100)
+
+    expect(candidates?.map((row) => row.pid).sort()).toEqual([200, 300])
+    expect(candidates?.find((row) => row.pid === 300)?.command).toBe(
+      "bash -lc $'echo a\nProcessId=4\necho b'"
     )
   })
 
-  it('falls back to PowerShell — windowsHide on — when wmic is missing', async () => {
+  // A repeated pid means the record framing desynced, and ancestry read off a
+  // desynced table can misdirect `taskkill /T /F`.
+  it('discards a wmic table with duplicate pids and lets PowerShell answer', async () => {
     execFileMock.mockImplementation((cmd: string, _args, _opts, cb: ExecFileCallback) => {
-      if (cmd === 'wmic') {
-        cb(new Error('wmic not found'), { stdout: '', stderr: '' })
-        return
-      }
-      cb(null, { stdout: POWERSHELL_ROWS_JSON, stderr: '' })
+      cb(null, {
+        stdout: cmd === 'wmic' ? `${WMIC_ROWS_VALUE}\n${WMIC_ROWS_VALUE}` : POWERSHELL_ROWS_JSON,
+        stderr: ''
+      })
     })
 
     const candidates = await queryWindowsProcessDescendants(100)
 
-    expect(candidates?.[0]?.pid).toBe(200)
+    expect(candidates?.map((row) => row.pid)).toEqual([200])
     expect(optionsForCommand('powershell.exe')).toMatchObject({ windowsHide: true })
   })
 
-  it('falls back to PowerShell when a capable wmic scan fails, without re-probing', async () => {
-    let wmicScans = 0
-    execFileMock.mockImplementation((cmd: string, args: string[], _opts, cb: ExecFileCallback) => {
-      if (cmd === 'wmic' && args[0] === '/?') {
-        cb(null, { stdout: 'usage', stderr: '' })
-        return
-      }
+  it('stops spawning wmic once the host has none — 24H2+ (windowsHide stays on)', async () => {
+    let wmicSpawns = 0
+    execFileMock.mockImplementation((cmd: string, _args, _opts, cb: ExecFileCallback) => {
       if (cmd === 'wmic') {
-        wmicScans += 1
-        cb(new Error('wmi service hiccup'), { stdout: '', stderr: '' })
+        wmicSpawns += 1
+        cb(Object.assign(new Error('spawn wmic ENOENT'), { code: 'ENOENT' }), {
+          stdout: '',
+          stderr: ''
+        })
         return
       }
       cb(null, { stdout: POWERSHELL_ROWS_JSON, stderr: '' })
     })
 
-    const candidates = await queryWindowsProcessDescendants(100)
+    await queryWindowsProcessRowsFresh()
+    await queryWindowsProcessRowsFresh()
 
-    expect(candidates?.[0]?.pid).toBe(200)
-    expect(wmicScans).toBe(1)
+    expect(wmicSpawns).toBe(1)
     expect(optionsForCommand('powershell.exe')).toMatchObject({ windowsHide: true })
+  })
+
+  // A WMI hiccup must not cost the fix for the rest of the process lifetime.
+  it('retries wmic after a transient scan failure, and demotes it once it persists', async () => {
+    let wmicSpawns = 0
+    let failing = true
+    execFileMock.mockImplementation((cmd: string, _args, _opts, cb: ExecFileCallback) => {
+      if (cmd === 'wmic') {
+        wmicSpawns += 1
+        if (failing) {
+          cb(new Error('wmi service hiccup'), { stdout: '', stderr: '' })
+          return
+        }
+        cb(null, { stdout: WMIC_ROWS_VALUE, stderr: '' })
+        return
+      }
+      cb(null, { stdout: POWERSHELL_ROWS_JSON, stderr: '' })
+    })
+
+    await queryWindowsProcessRowsFresh()
+    failing = false
+    const rows = await queryWindowsProcessRowsFresh()
+
+    expect(wmicSpawns).toBe(2)
+    expect(rows.map((row) => row.pid)).toEqual([100, 200])
+
+    failing = true
+    await queryWindowsProcessRowsFresh()
+    await queryWindowsProcessRowsFresh()
+    await queryWindowsProcessRowsFresh()
+    const spawnsAfterDemotion = wmicSpawns
+
+    await queryWindowsProcessRowsFresh()
+
+    expect(wmicSpawns).toBe(spawnsAfterDemotion)
   })
 })
 
@@ -138,8 +215,7 @@ describe('queryWindowsProcessRowsFresh', () => {
 
   beforeEach(() => {
     execFileMock.mockReset()
-    resetWindowsProcessRowsSnapshotForTests()
-    resetWindowsProcessProbePreferenceForTests()
+    resetWindowsProcessRowsReaderForTests()
     platform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
     // The capability probe answers for any wmic call; scans then use PowerShell.

--- a/src/main/providers/windows-foreground-process-rows.test.ts
+++ b/src/main/providers/windows-foreground-process-rows.test.ts
@@ -110,13 +110,19 @@ describe('windows foreground process rows spawn options', () => {
     expect(optionsForCommand('wmic')).toMatchObject({ encoding: 'buffer' })
   })
 
-  // Orca's own panes run multi-line commands, so CR/LF inside CommandLine is
-  // routine — and `Key=Value` framing is exactly what it can impersonate.
-  it('keeps a CommandLine holding CR/LF in one row', async () => {
+  // Orca's own agent panes run multi-line commands, so CR/LF inside CommandLine is
+  // routine — `Key=Value` framing is exactly what it can impersonate, and a blank
+  // line in there is exactly what a record separator looks like. Measured on a real
+  // 920-process table: every command line carrying one belonged to a claude/codex/
+  // node/sh pane, i.e. the rows foreground detection reads to name the agent.
+  it('keeps an agent CommandLine holding CR/LF and a blank line in one row', async () => {
     const multiline =
-      "CommandLine=bash -lc $'echo a\nProcessId=4\necho b'\n" +
-      'ExecutablePath=C:/msys64/usr/bin/bash.exe\n' +
-      'Name=bash.exe\n' +
+      "CommandLine=claude --append-system-prompt $'line one\n" +
+      '\n' +
+      'ProcessId=4\n' +
+      "line two'\n" +
+      'ExecutablePath=C:/Users/dev/AppData/Local/claude/claude.exe\n' +
+      'Name=claude.exe\n' +
       'ParentProcessId=100\n' +
       'ProcessId=300\n\n'
     execFileMock.mockImplementation((cmd: string, _args, _opts, cb: ExecFileCallback) => {
@@ -130,7 +136,7 @@ describe('windows foreground process rows spawn options', () => {
 
     expect(candidates?.map((row) => row.pid).sort()).toEqual([200, 300])
     expect(candidates?.find((row) => row.pid === 300)?.command).toBe(
-      "bash -lc $'echo a\nProcessId=4\necho b'"
+      "claude --append-system-prompt $'line one\n\nProcessId=4\nline two'"
     )
   })
 

--- a/src/main/providers/windows-foreground-process-rows.test.ts
+++ b/src/main/providers/windows-foreground-process-rows.test.ts
@@ -153,13 +153,13 @@ describe('windows foreground process rows spawn options', () => {
     )
   })
 
-  // A command line can supply a whole record. The invented row is not inert: with
-  // ppid set to Orca's own pid it bridges a real orphan (a process whose parent
-  // already exited) into our subtree, and classifyWindowsTreeKillTarget then reads
-  // that unrelated tree as `own` and lets `taskkill /T /F` have it. wmic closes
-  // every record with an empty line, so properties resuming without one prove the
-  // record came from content — and the whole snapshot is refused.
-  it('refuses a table where a command line supplied a whole record (#15565 review)', async () => {
+  // A command line can supply a whole well-formed record, and no parser can tell
+  // that from one wmic wrote — so an invented row reaches this table. What must
+  // hold is that it stays a naming problem: the forged pid is not a descendant of
+  // the pane, the real rows are untouched, and the row never reaches the kill
+  // decision (see the taskkill-gate test below, which proves that reader is
+  // PowerShell-only). The forger's own real record is the cost, dropped on resync.
+  it('confines an invented record to naming, leaving real rows intact (#15565 review)', async () => {
     const forged =
       'CommandLine=evil.exe\n' +
       'ExecutablePath=C:/fake.exe\n' +
@@ -183,49 +183,47 @@ describe('windows foreground process rows spawn options', () => {
     expect(candidates?.some((row) => row.pid === 5000)).toBe(false)
   })
 
-  // A framing failure is content any local process can arrange. Retiring wmic over
-  // it would hand that process a switch for turning the transcript flood back on.
-  it('backs off after repeated framing failures, then retries wmic (#15565 review)', async () => {
-    vi.useFakeTimers({ toFake: ['Date'] })
-    vi.setSystemTime(0)
-    try {
-      let wmicSpawns = 0
-      let hostile = true
-      execFileMock.mockImplementation((cmd: string, _args, _opts, cb: ExecFileCallback) => {
-        if (isCommand(cmd, 'wmic')) {
-          wmicSpawns += 1
-          // A command line that walks the framing: properties resume with no break.
-          cb(null, {
-            stdout: hostile
-              ? 'CommandLine=x\nExecutablePath=a\nName=b\nParentProcessId=1\nProcessId=2\nExecutablePath=c\n'
-              : WMIC_ROWS_VALUE,
-            stderr: ''
-          })
-          return
-        }
-        cb(null, { stdout: POWERSHELL_ROWS_JSON, stderr: '' })
-      })
-
-      for (let scan = 0; scan < 3; scan += 1) {
-        await queryWindowsProcessDescendants(100, { fresh: true })
+  // Grok review: a command line can walk the record framing, and any process on
+  // the box can arrange one — an Orca pane running `bash -lc $'...ExecutablePath=...'`
+  // is enough. If that voided the snapshot, every such scan would fall through to a
+  // PowerShell host and put the transcript flood back at full rate for as long as
+  // the process lived. Bad framing must therefore cost its own record and nothing
+  // else: no PowerShell spawn, no backoff, wmic still leading on the next scan.
+  it('spends no PowerShell host on a table poisoned by a command line (#15565 review)', async () => {
+    const poisoned = [
+      "CommandLine=bash -lc $'echo",
+      'ExecutablePath=C:/x',
+      "foo'",
+      'ExecutablePath=C:/msys64/usr/bin/bash.exe',
+      'Name=bash.exe',
+      'ParentProcessId=100',
+      'ProcessId=300',
+      ''
+    ].join('\n')
+    let wmicSpawns = 0
+    execFileMock.mockImplementation((cmd: string, _args, _opts, cb: ExecFileCallback) => {
+      if (isCommand(cmd, 'wmic')) {
+        wmicSpawns += 1
+        cb(null, {
+          stdout: `${WMIC_ROWS_VALUE}
+${poisoned}`,
+          stderr: ''
+        })
+        return
       }
-      expect(wmicSpawns).toBe(3)
+      cb(new Error('a poisoned table must not buy a PowerShell host'), { stdout: '', stderr: '' })
+    })
 
-      // Inside the backoff window wmic is not spawned at all — one process per
-      // scan, never the two that a retry-every-scan policy would cost.
-      await queryWindowsProcessDescendants(100, { fresh: true })
-      expect(wmicSpawns).toBe(3)
+    const first = await queryWindowsProcessDescendants(100, { fresh: true })
+    const second = await queryWindowsProcessDescendants(100, { fresh: true })
 
-      // ...and the fix comes back on its own once the window passes.
-      hostile = false
-      vi.setSystemTime(60_001)
-      const candidates = await queryWindowsProcessDescendants(100, { fresh: true })
-
-      expect(wmicSpawns).toBe(4)
-      expect(candidates?.map((row) => row.pid)).toEqual([200])
-    } finally {
-      vi.useRealTimers()
-    }
+    // The poisoner's own record is the only casualty; the rest of the table stands.
+    expect(first?.map((row) => row.pid)).toEqual([200])
+    expect(second?.map((row) => row.pid)).toEqual([200])
+    expect(wmicSpawns).toBe(2)
+    expect(
+      execFileMock.mock.calls.some((args) => isCommand((args as ExecFileCall)[0], 'powershell'))
+    ).toBe(false)
   })
 
   // A repeated pid means the record framing desynced, and ancestry read off a

--- a/src/main/providers/windows-foreground-process-rows.ts
+++ b/src/main/providers/windows-foreground-process-rows.ts
@@ -1,6 +1,10 @@
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 import { createProcessTableSnapshotReader } from '../../shared/process-table-snapshot'
+import {
+  readWindowsProcessRowsWithWmic,
+  resetWmicProcessTableReaderForTests
+} from './windows-wmic-process-table'
 
 const execFileAsync = promisify(execFile)
 const WINDOWS_PROCESS_QUERY_TIMEOUT_MS = 3_000
@@ -32,42 +36,9 @@ export type WindowsProcessCandidate = WindowsProcessRow & { depth: number }
 // walk over the shared snapshot.
 // Why #15209: every PowerShell-host spawn writes a transcript file under the
 // enterprise Windows PowerShell transcription GPO, and this scan re-forks ~2x/s
-// while panes are open — 1.4M files / 289GB in three weeks on one reported
-// machine. wmic reads the same table with no PowerShell host, so it leads;
-// PowerShell stays the fallback and is the only option where wmic is absent
-// (24H2+ removed it), which leaves those builds on today's behaviour.
-const WMIC_SCAN_FAILURE_LIMIT = 3
-// Why the absolute path and not `wmic`: a bare name resolves through PATH, and on
-// 24H2+ no legitimate wmic exists — so any `wmic.exe` a PATH entry offers there is
-// by definition not the system one. The daemon runs this ~2x/s and targets
-// `taskkill /T /F` off its output, so it reads only the one canonical location.
-const WMIC_PATH = `${process.env.SystemRoot ?? 'C:\\Windows'}\\System32\\wbem\\wmic.exe`
-let wmicDemoted = false
-let wmicScanFailures = 0
-
-/**
- * wmic rows, or null to let PowerShell answer this scan.
- *
- * Why demote instead of probing `wmic /?`: a probe proves the binary exists, not
- * that we can read its table, and the answer to both is the same — stop spending
- * a wmic spawn per scan on top of the PowerShell one. An unreadable table demotes
- * at once; a transient WMI failure gets `WMIC_SCAN_FAILURE_LIMIT` scans of grace
- * so one hiccup does not cost the fix for the rest of the process lifetime.
- */
-async function readWindowsProcessRowsWithWmic(): Promise<WindowsProcessRow[] | null> {
-  if (wmicDemoted) {
-    return null
-  }
-  const scan = await queryWindowsProcessesWithWmic()
-  if (scan.status === 'ok') {
-    wmicScanFailures = 0
-    return scan.rows
-  }
-  wmicScanFailures += 1
-  wmicDemoted = scan.status === 'unsupported' || wmicScanFailures >= WMIC_SCAN_FAILURE_LIMIT
-  return null
-}
-
+// while panes are open. wmic reads the same table with no PowerShell host, so it
+// leads here; see ./windows-wmic-process-table for what that costs and why the
+// teardown reader below deliberately does not use it.
 async function runWindowsProcessRows(): Promise<WindowsProcessRow[]> {
   const rows =
     (await readWindowsProcessRowsWithWmic()) ?? (await queryWindowsProcessesWithPowerShell())
@@ -85,14 +56,37 @@ const windowsProcessRowsReader = createProcessTableSnapshotReader<WindowsProcess
   now: () => Date.now()
 })
 
+// Why this one never reads wmic: `/format:value` has no escaping and CommandLine
+// is whatever some process chose to be launched with, so a command line can emit
+// a fully well-formed record — blank-line separator and a following `CommandLine=`
+// to resynchronise — that no parser can tell from a real one. An invented
+// `{pid, ppid}` row is not inert: it bridges a real orphan to our own pid, and
+// classifyWindowsTreeKillTarget then reads an unrelated tree as `own` and lets
+// `taskkill /T /F` have it. Ancestry that gates a force-kill therefore comes only
+// from the JSON reader, where a field cannot masquerade as a record.
+//
+// The cost is bounded: this fires on teardown, not on the ~2x/s cadence #15209 is
+// about, so it is one transcript file per teardown against the 172,800 a day the
+// foreground scan was writing.
+const windowsProcessLinksReader = createProcessTableSnapshotReader<WindowsProcessRow[]>({
+  runPs: async () => {
+    const rows = await queryWindowsProcessesWithPowerShell()
+    if (!rows) {
+      throw new Error('windows process enumeration unavailable')
+    }
+    return rows
+  },
+  now: () => Date.now()
+})
+
 /**
  * Rows from a scan that starts after this call. PID-identity checks in teardown
  * must not reuse a cached row — it can predate the very recycle it detects — but
  * they must still dedupe: a worktree delete tears down PTYs 32-wide, so a bypass
- * would fork that many powershell cold-starts. Rejects when both readers fail.
+ * would fork that many powershell cold-starts. Rejects when the scan fails.
  */
 export function queryWindowsProcessRowsFresh(): Promise<WindowsProcessRow[]> {
-  return windowsProcessRowsReader.getFreshSnapshot()
+  return windowsProcessLinksReader.getFreshSnapshot()
 }
 
 export async function queryWindowsProcessDescendants(
@@ -123,98 +117,9 @@ export async function queryWindowsProcessDescendants(
  * process-lifetime state, so leaving either set leaks one case into the next.
  */
 export function resetWindowsProcessRowsReaderForTests(): void {
+  resetWmicProcessTableReaderForTests()
   windowsProcessRowsReader.reset()
-  wmicDemoted = false
-  wmicScanFailures = 0
-}
-
-// wmic /format:value emits one `Key=Value` line per property in this fixed order,
-// records separated by a blank line.
-const WMIC_VALUE_FIELDS = [
-  'CommandLine',
-  'ExecutablePath',
-  'Name',
-  'ParentProcessId',
-  'ProcessId'
-] as const
-
-/**
- * Parse wmic's `Key=Value` records.
- *
- * CommandLine is the one property that carries raw CR/LF, and Orca's own panes
- * put it there constantly (`bash -lc $'...\n...'`). So inside a record only the
- * next property in order opens a field; every other line continues the field
- * being read, which is what keeps `$'echo a\nProcessId=4'` one row instead of
- * two malformed ones — the hazard that made the PowerShell reader ask for JSON.
- * Between records any property may open one, so a process whose CommandLine is
- * NULL still parses, and a record missing a middle property merges into the next
- * rather than desyncing the rest of the table.
- *
- * Returns null when the framing is provably compromised, which drops the whole
- * snapshot to PowerShell. Only CommandLine can hold a newline, so a continuation
- * line arriving while a later property is open means some earlier line was
- * absorbed that should not have been. A command line carrying
- * `ExecutablePath=`/`Name=`/`ParentProcessId=` in order otherwise walks the parser
- * to ParentProcessId and lets the record's own real `ProcessId=` close it —
- * re-parenting a live pid under a forged parent, with no duplicate pid to catch
- * it. Ancestry read off that feeds `taskkill /T /F`, so an ambiguous table is
- * refused rather than guessed at.
- */
-function parseWindowsProcessValueRows(stdout: string): WindowsProcessRow[] | null {
-  const rows: WindowsProcessRow[] = []
-  const values: string[] = ['', '', '', '', '']
-  let field = -1
-
-  const flush = (): void => {
-    const ppid = Number.parseInt(values[3]!, 10)
-    const pid = Number.parseInt(values[4]!, 10)
-    if (Number.isFinite(pid) && Number.isFinite(ppid)) {
-      const name = values[2]!.trim()
-      rows.push({
-        pid,
-        ppid,
-        name,
-        command: values[0]!.trim() || name,
-        executablePath: values[1]!.trim()
-      })
-    }
-    values.fill('')
-    field = -1
-  }
-
-  for (const line of stdout.split(/\r?\n/)) {
-    // Exactly empty, not merely blank: a whitespace-only line is content, and
-    // treating it as the separator silently ate its spaces out of the command.
-    if (line === '') {
-      // Only past CommandLine does an empty line mean end-of-record; inside one it
-      // is content. Agent CLIs really do embed blank lines: on a measured
-      // 920-process host all 11 that did were claude/codex/node/sh panes — the
-      // exact rows foreground detection reads. Flushing there dropped the command
-      // and left the row naming only its executable.
-      if (field >= 1) {
-        flush()
-      } else if (field === 0) {
-        values[0] += '\n'
-      }
-      continue
-    }
-    const eq = line.indexOf('=')
-    const next =
-      eq === -1 ? -1 : (WMIC_VALUE_FIELDS as readonly string[]).indexOf(line.slice(0, eq))
-    if (next >= 0 && (field === -1 || next === field + 1)) {
-      field = next
-      values[next] = line.slice(eq + 1)
-      if (next === WMIC_VALUE_FIELDS.length - 1) {
-        flush()
-      }
-    } else if (field > 0) {
-      return null
-    } else if (field === 0) {
-      values[0] += `\n${line}`
-    }
-  }
-  flush()
-  return rows
+  windowsProcessLinksReader.reset()
 }
 
 type WindowsProcessJsonRow = {
@@ -292,9 +197,18 @@ function collectDescendants<Row extends { pid: number; ppid: number }>(
   }
 
   const descendants: (Row & { depth: number })[] = []
+  // Why visited: ppid is historical, so a recycled pid can point a live process at
+  // a descendant of itself and close a loop — and every Windows table ships one
+  // outright, System Idle Process being its own parent at pid 0. Unguarded, this
+  // walk never terminates, and it runs on the daemon's ~2x/s cadence.
+  const visited = new Set<number>([rootPid])
   const stack = (childrenByParent.get(rootPid) ?? []).map((row) => ({ row, depth: 1 }))
   while (stack.length > 0) {
     const { row, depth } = stack.pop()!
+    if (visited.has(row.pid)) {
+      continue
+    }
+    visited.add(row.pid)
     descendants.push({ ...row, depth })
     for (const child of childrenByParent.get(row.pid) ?? []) {
       stack.push({ row: child, depth: depth + 1 })
@@ -325,80 +239,4 @@ async function queryWindowsProcessesWithPowerShell(): Promise<WindowsProcessRow[
   } catch {
     return null
   }
-}
-
-type WmicScan =
-  /** wmic is missing, or its output is not the key=value table we can read. */
-  | { status: 'unsupported' }
-  /** wmic ran but this scan did not answer: a WMI hiccup, a timeout, a torn table. */
-  | { status: 'failed' }
-  | { status: 'ok'; rows: WindowsProcessRow[] }
-
-/**
- * wmic writes UTF-16LE through a redirected stdout, so read bytes and pick the
- * encoding from the BOM — decoding as utf8 would yield NUL-padded keys that match
- * nothing and silently strand every machine on the PowerShell path this fixes.
- */
-function decodeWmicStdout(stdout: string | Buffer): string {
-  if (typeof stdout === 'string') {
-    return stdout
-  }
-  if (stdout[0] === 0xff && stdout[1] === 0xfe) {
-    return stdout.toString('utf16le', 2)
-  }
-  if (stdout[0] === 0xef && stdout[1] === 0xbb && stdout[2] === 0xbf) {
-    return stdout.toString('utf8', 3)
-  }
-  // A BOM-less UTF-16LE table still pads every ASCII byte with a NUL.
-  return stdout.subarray(0, 64).includes(0) ? stdout.toString('utf16le') : stdout.toString('utf8')
-}
-
-/** Whole-process-table scan via wmic — the preferred reader, see #15209. */
-async function queryWindowsProcessesWithWmic(): Promise<WmicScan> {
-  let stdout: string
-  try {
-    const result = await execFileAsync(
-      WMIC_PATH,
-      [
-        'process',
-        'get',
-        'CommandLine,ExecutablePath,Name,ParentProcessId,ProcessId',
-        '/format:value'
-      ],
-      {
-        encoding: 'buffer',
-        timeout: WINDOWS_PROCESS_QUERY_TIMEOUT_MS,
-        // 16MB: the cap counts raw bytes here, and UTF-16 doubles the table.
-        maxBuffer: 16 * 1024 * 1024,
-        // Why: same focus-stealing hazard as the powershell scan — without this,
-        // each fork pops a conhost window that steals keyboard focus.
-        windowsHide: true
-      }
-    )
-    stdout = decodeWmicStdout(result.stdout)
-  } catch (error) {
-    // ENOENT is 24H2+, where wmic is gone for good; anything else may recover.
-    const missing = (error as NodeJS.ErrnoException | null)?.code === 'ENOENT'
-    return { status: missing ? 'unsupported' : 'failed' }
-  }
-  if (stdout.trim() === '') {
-    return { status: 'failed' }
-  }
-  const rows = parseWindowsProcessValueRows(stdout)
-  if (rows === null) {
-    // Framing compromised by command-line content, not a format we cannot read:
-    // transient, because it lasts only as long as the process that wrote it.
-    return { status: 'failed' }
-  }
-  if (rows.length === 0) {
-    // Output arrived and parsed to nothing: this build's wmic does not speak the
-    // format we read, and no later scan will change that.
-    return { status: 'unsupported' }
-  }
-  // pids are unique in a live table, so a repeat means the record framing
-  // desynced. Ancestry off a desynced table can misdirect `taskkill /T /F`.
-  if (new Set(rows.map((row) => row.pid)).size !== rows.length) {
-    return { status: 'failed' }
-  }
-  return { status: 'ok', rows }
 }

--- a/src/main/providers/windows-foreground-process-rows.ts
+++ b/src/main/providers/windows-foreground-process-rows.ts
@@ -32,31 +32,40 @@ export type WindowsProcessCandidate = WindowsProcessRow & { depth: number }
 // walk over the shared snapshot.
 // Why #15209: every PowerShell-host spawn writes a transcript file under the
 // enterprise Windows PowerShell transcription GPO, and this scan re-forks ~2x/s
-// while agent panes are open — 1.4M transcript files in weeks on one reported
-// machine. wmic enumerates the same table without any PowerShell host, so it is
-// preferred wherever it exists and the answer is cached for the process
-// lifetime; PowerShell stays the fallback and the only option on Windows builds
-// that ship without wmic (24H2+ removed it).
-let wmicCapabilityProbe: Promise<boolean> | null = null
+// while panes are open — 1.4M files / 289GB in three weeks on one reported
+// machine. wmic reads the same table with no PowerShell host, so it leads;
+// PowerShell stays the fallback and is the only option where wmic is absent
+// (24H2+ removed it), which leaves those builds on today's behaviour.
+const WMIC_SCAN_FAILURE_LIMIT = 3
+let wmicDemoted = false
+let wmicScanFailures = 0
 
-function wmicAvailable(): Promise<boolean> {
-  wmicCapabilityProbe ??= execFileAsync('wmic', ['/?'], {
-    timeout: WINDOWS_PROCESS_QUERY_TIMEOUT_MS,
-    windowsHide: true
-  }).then(
-    () => true,
-    () => false
-  )
-  return wmicCapabilityProbe
+/**
+ * wmic rows, or null to let PowerShell answer this scan.
+ *
+ * Why demote instead of probing `wmic /?`: a probe proves the binary exists, not
+ * that we can read its table, and the answer to both is the same — stop spending
+ * a wmic spawn per scan on top of the PowerShell one. An unreadable table demotes
+ * at once; a transient WMI failure gets `WMIC_SCAN_FAILURE_LIMIT` scans of grace
+ * so one hiccup does not cost the fix for the rest of the process lifetime.
+ */
+async function readWindowsProcessRowsWithWmic(): Promise<WindowsProcessRow[] | null> {
+  if (wmicDemoted) {
+    return null
+  }
+  const scan = await queryWindowsProcessesWithWmic()
+  if (scan.status === 'ok') {
+    wmicScanFailures = 0
+    return scan.rows
+  }
+  wmicScanFailures += 1
+  wmicDemoted = scan.status === 'unsupported' || wmicScanFailures >= WMIC_SCAN_FAILURE_LIMIT
+  return null
 }
 
 async function runWindowsProcessRows(): Promise<WindowsProcessRow[]> {
-  // wmic first where it exists (no PowerShell host per scan, #15209); a failed
-  // wmic scan still falls through to PowerShell, so a WMI hiccup costs one
-  // PowerShell spawn rather than a failed pane poll.
   const rows =
-    ((await wmicAvailable()) ? await queryWindowsProcessesWithWmic() : null) ??
-    (await queryWindowsProcessesWithPowerShell())
+    (await readWindowsProcessRowsWithWmic()) ?? (await queryWindowsProcessesWithPowerShell())
   if (!rows) {
     // Reject so the reader does not cache the miss; callers fall through to
     // node-pty's process name (the prior null-return contract is preserved by
@@ -75,7 +84,7 @@ const windowsProcessRowsReader = createProcessTableSnapshotReader<WindowsProcess
  * Rows from a scan that starts after this call. PID-identity checks in teardown
  * must not reuse a cached row — it can predate the very recycle it detects — but
  * they must still dedupe: a worktree delete tears down PTYs 32-wide, so a bypass
- * would fork that many powershell cold-starts. Rejects when both probes fail.
+ * would fork that many powershell cold-starts. Rejects when both readers fail.
  */
 export function queryWindowsProcessRowsFresh(): Promise<WindowsProcessRow[]> {
   return windowsProcessRowsReader.getFreshSnapshot()
@@ -104,58 +113,83 @@ export async function queryWindowsProcessDescendants(
 
 /**
  * Test-only: clear the shared Windows process-table snapshot so suites that mock
- * execFile between cases don't get one case's rows served to the next within TTL.
+ * execFile between cases don't get one case's rows served to the next within TTL,
+ * and un-demote wmic so a case can pick which reader answers it. Both are
+ * process-lifetime state, so leaving either set leaks one case into the next.
  */
-export function resetWindowsProcessRowsSnapshotForTests(): void {
+export function resetWindowsProcessRowsReaderForTests(): void {
   windowsProcessRowsReader.reset()
+  wmicDemoted = false
+  wmicScanFailures = 0
 }
 
-/** Test-only: forget the cached wmic capability so a suite can pick a side. */
-export function resetWindowsProcessProbePreferenceForTests(): void {
-  wmicCapabilityProbe = null
-}
+// wmic /format:value emits one `Key=Value` line per property in this fixed order,
+// records separated by a blank line.
+const WMIC_VALUE_FIELDS = [
+  'CommandLine',
+  'ExecutablePath',
+  'Name',
+  'ParentProcessId',
+  'ProcessId'
+] as const
 
+/**
+ * Parse wmic's `Key=Value` records.
+ *
+ * CommandLine is the one property that carries raw CR/LF, and Orca's own panes
+ * put it there constantly (`bash -lc $'...\n...'`). So inside a record only the
+ * next property in order opens a field; every other line continues the field
+ * being read, which is what keeps `$'echo a\nProcessId=4'` one row instead of
+ * two malformed ones — the hazard that made the PowerShell reader ask for JSON.
+ * A blank line closes the record, so a malformed one costs itself and not the
+ * rest of the table. Between records any property may open one, so a process
+ * whose CommandLine is NULL still parses.
+ *
+ * Residue: a command line embedding the whole `ExecutablePath`..`ProcessId` tail
+ * in order forges a row. It cannot suppress its own real row, so a forged pid
+ * that names a live process duplicates it, and queryWindowsProcessesWithWmic
+ * drops the snapshot on duplicate pids.
+ */
 function parseWindowsProcessValueRows(stdout: string): WindowsProcessRow[] {
   const rows: WindowsProcessRow[] = []
-  let command = ''
-  let executablePath = ''
-  let name = ''
-  let pid = Number.NaN
-  let ppid = Number.NaN
+  const values: string[] = ['', '', '', '', '']
+  let field = -1
 
   const flush = (): void => {
+    const ppid = Number.parseInt(values[3]!, 10)
+    const pid = Number.parseInt(values[4]!, 10)
     if (Number.isFinite(pid) && Number.isFinite(ppid)) {
-      rows.push({ pid, ppid, name, command: command || name, executablePath })
+      const name = values[2]!.trim()
+      rows.push({
+        pid,
+        ppid,
+        name,
+        command: values[0]!.trim() || name,
+        executablePath: values[1]!.trim()
+      })
     }
-    command = ''
-    executablePath = ''
-    name = ''
-    pid = Number.NaN
-    ppid = Number.NaN
+    values.fill('')
+    field = -1
   }
 
-  for (const raw of stdout.split(/\r?\n/)) {
-    const line = raw.trim()
-    if (!line) {
-      flush()
+  for (const line of stdout.split(/\r?\n/)) {
+    if (line.trim() === '') {
+      if (field >= 0) {
+        flush()
+      }
       continue
     }
     const eq = line.indexOf('=')
-    if (eq === -1) {
-      continue
-    }
-    const key = line.slice(0, eq)
-    const value = line.slice(eq + 1)
-    if (key === 'CommandLine') {
-      command = value
-    } else if (key === 'ExecutablePath') {
-      executablePath = value
-    } else if (key === 'Name') {
-      name = value
-    } else if (key === 'ParentProcessId') {
-      ppid = Number.parseInt(value, 10)
-    } else if (key === 'ProcessId') {
-      pid = Number.parseInt(value, 10)
+    const next =
+      eq === -1 ? -1 : (WMIC_VALUE_FIELDS as readonly string[]).indexOf(line.slice(0, eq))
+    if (next >= 0 && (field === -1 || next === field + 1)) {
+      field = next
+      values[next] = line.slice(eq + 1)
+      if (next === WMIC_VALUE_FIELDS.length - 1) {
+        flush()
+      }
+    } else if (field >= 0) {
+      values[field] += `\n${line}`
     }
   }
   flush()
@@ -272,10 +306,37 @@ async function queryWindowsProcessesWithPowerShell(): Promise<WindowsProcessRow[
   }
 }
 
-/** Fallback whole-process-table scan via wmic when PowerShell is unavailable. */
-async function queryWindowsProcessesWithWmic(): Promise<WindowsProcessRow[] | null> {
+type WmicScan =
+  /** wmic is missing, or its output is not the key=value table we can read. */
+  | { status: 'unsupported' }
+  /** wmic ran but this scan did not answer: a WMI hiccup, a timeout, a torn table. */
+  | { status: 'failed' }
+  | { status: 'ok'; rows: WindowsProcessRow[] }
+
+/**
+ * wmic writes UTF-16LE through a redirected stdout, so read bytes and pick the
+ * encoding from the BOM — decoding as utf8 would yield NUL-padded keys that match
+ * nothing and silently strand every machine on the PowerShell path this fixes.
+ */
+function decodeWmicStdout(stdout: string | Buffer): string {
+  if (typeof stdout === 'string') {
+    return stdout
+  }
+  if (stdout[0] === 0xff && stdout[1] === 0xfe) {
+    return stdout.toString('utf16le', 2)
+  }
+  if (stdout[0] === 0xef && stdout[1] === 0xbb && stdout[2] === 0xbf) {
+    return stdout.toString('utf8', 3)
+  }
+  // A BOM-less UTF-16LE table still pads every ASCII byte with a NUL.
+  return stdout.subarray(0, 64).includes(0) ? stdout.toString('utf16le') : stdout.toString('utf8')
+}
+
+/** Whole-process-table scan via wmic — the preferred reader, see #15209. */
+async function queryWindowsProcessesWithWmic(): Promise<WmicScan> {
+  let stdout: string
   try {
-    const { stdout } = await execFileAsync(
+    const result = await execFileAsync(
       'wmic',
       [
         'process',
@@ -284,19 +345,34 @@ async function queryWindowsProcessesWithWmic(): Promise<WindowsProcessRow[] | nu
         '/format:value'
       ],
       {
-        encoding: 'utf8',
+        encoding: 'buffer',
         timeout: WINDOWS_PROCESS_QUERY_TIMEOUT_MS,
-        maxBuffer: 8 * 1024 * 1024,
-        // Why: same focus-stealing hazard as the powershell probe — hide the
-        // wmic fallback's console window too.
+        // 16MB: the cap counts raw bytes here, and UTF-16 doubles the table.
+        maxBuffer: 16 * 1024 * 1024,
+        // Why: same focus-stealing hazard as the powershell scan — without this,
+        // each fork pops a conhost window that steals keyboard focus.
         windowsHide: true
       }
     )
-    const rows = parseWindowsProcessValueRows(stdout)
-    return rows.length > 0 ? rows : null
-  } catch {
-    // Best-effort: Windows process enumeration may be disabled, so callers
-    // still fall back to node-pty's process name when both probes fail.
-    return null
+    stdout = decodeWmicStdout(result.stdout)
+  } catch (error) {
+    // ENOENT is 24H2+, where wmic is gone for good; anything else may recover.
+    const missing = (error as NodeJS.ErrnoException | null)?.code === 'ENOENT'
+    return { status: missing ? 'unsupported' : 'failed' }
   }
+  if (stdout.trim() === '') {
+    return { status: 'failed' }
+  }
+  const rows = parseWindowsProcessValueRows(stdout)
+  if (rows.length === 0) {
+    // Output arrived and parsed to nothing: this build's wmic does not speak the
+    // format we read, and no later scan will change that.
+    return { status: 'unsupported' }
+  }
+  // pids are unique in a live table, so a repeat means the record framing
+  // desynced. Ancestry off a desynced table can misdirect `taskkill /T /F`.
+  if (new Set(rows.map((row) => row.pid)).size !== rows.length) {
+    return { status: 'failed' }
+  }
+  return { status: 'ok', rows }
 }

--- a/src/main/providers/windows-foreground-process-rows.ts
+++ b/src/main/providers/windows-foreground-process-rows.ts
@@ -150,12 +150,17 @@ const WMIC_VALUE_FIELDS = [
  * NULL still parses, and a record missing a middle property merges into the next
  * rather than desyncing the rest of the table.
  *
- * Residue: a command line embedding the whole `ExecutablePath`..`ProcessId` tail
- * in order forges a row. It cannot suppress its own real row, so a forged pid
- * that names a live process duplicates it, and queryWindowsProcessesWithWmic
- * drops the snapshot on duplicate pids.
+ * Returns null when the framing is provably compromised, which drops the whole
+ * snapshot to PowerShell. Only CommandLine can hold a newline, so a continuation
+ * line arriving while a later property is open means some earlier line was
+ * absorbed that should not have been. A command line carrying
+ * `ExecutablePath=`/`Name=`/`ParentProcessId=` in order otherwise walks the parser
+ * to ParentProcessId and lets the record's own real `ProcessId=` close it —
+ * re-parenting a live pid under a forged parent, with no duplicate pid to catch
+ * it. Ancestry read off that feeds `taskkill /T /F`, so an ambiguous table is
+ * refused rather than guessed at.
  */
-function parseWindowsProcessValueRows(stdout: string): WindowsProcessRow[] {
+function parseWindowsProcessValueRows(stdout: string): WindowsProcessRow[] | null {
   const rows: WindowsProcessRow[] = []
   const values: string[] = ['', '', '', '', '']
   let field = -1
@@ -178,8 +183,10 @@ function parseWindowsProcessValueRows(stdout: string): WindowsProcessRow[] {
   }
 
   for (const line of stdout.split(/\r?\n/)) {
-    if (line.trim() === '') {
-      // Only past CommandLine does a blank line mean end-of-record; inside one it
+    // Exactly empty, not merely blank: a whitespace-only line is content, and
+    // treating it as the separator silently ate its spaces out of the command.
+    if (line === '') {
+      // Only past CommandLine does an empty line mean end-of-record; inside one it
       // is content. Agent CLIs really do embed blank lines: on a measured
       // 920-process host all 11 that did were claude/codex/node/sh panes — the
       // exact rows foreground detection reads. Flushing there dropped the command
@@ -200,8 +207,10 @@ function parseWindowsProcessValueRows(stdout: string): WindowsProcessRow[] {
       if (next === WMIC_VALUE_FIELDS.length - 1) {
         flush()
       }
-    } else if (field >= 0) {
-      values[field] += `\n${line}`
+    } else if (field > 0) {
+      return null
+    } else if (field === 0) {
+      values[0] += `\n${line}`
     }
   }
   flush()
@@ -376,6 +385,11 @@ async function queryWindowsProcessesWithWmic(): Promise<WmicScan> {
     return { status: 'failed' }
   }
   const rows = parseWindowsProcessValueRows(stdout)
+  if (rows === null) {
+    // Framing compromised by command-line content, not a format we cannot read:
+    // transient, because it lasts only as long as the process that wrote it.
+    return { status: 'failed' }
+  }
   if (rows.length === 0) {
     // Output arrived and parsed to nothing: this build's wmic does not speak the
     // format we read, and no later scan will change that.

--- a/src/main/providers/windows-foreground-process-rows.ts
+++ b/src/main/providers/windows-foreground-process-rows.ts
@@ -30,9 +30,33 @@ export type WindowsProcessCandidate = WindowsProcessRow & { depth: number }
 // for POSIX. Reuse the same TTL + single-in-flight reader, caching parsed rows so
 // a burst of panes collapses to ~2 scans/sec; every caller runs its own descendant
 // walk over the shared snapshot.
+// Why #15209: every PowerShell-host spawn writes a transcript file under the
+// enterprise Windows PowerShell transcription GPO, and this scan re-forks ~2x/s
+// while agent panes are open — 1.4M transcript files in weeks on one reported
+// machine. wmic enumerates the same table without any PowerShell host, so it is
+// preferred wherever it exists and the answer is cached for the process
+// lifetime; PowerShell stays the fallback and the only option on Windows builds
+// that ship without wmic (24H2+ removed it).
+let wmicCapabilityProbe: Promise<boolean> | null = null
+
+function wmicAvailable(): Promise<boolean> {
+  wmicCapabilityProbe ??= execFileAsync('wmic', ['/?'], {
+    timeout: WINDOWS_PROCESS_QUERY_TIMEOUT_MS,
+    windowsHide: true
+  }).then(
+    () => true,
+    () => false
+  )
+  return wmicCapabilityProbe
+}
+
 async function runWindowsProcessRows(): Promise<WindowsProcessRow[]> {
+  // wmic first where it exists (no PowerShell host per scan, #15209); a failed
+  // wmic scan still falls through to PowerShell, so a WMI hiccup costs one
+  // PowerShell spawn rather than a failed pane poll.
   const rows =
-    (await queryWindowsProcessesWithPowerShell()) ?? (await queryWindowsProcessesWithWmic())
+    ((await wmicAvailable()) ? await queryWindowsProcessesWithWmic() : null) ??
+    (await queryWindowsProcessesWithPowerShell())
   if (!rows) {
     // Reject so the reader does not cache the miss; callers fall through to
     // node-pty's process name (the prior null-return contract is preserved by
@@ -84,6 +108,11 @@ export async function queryWindowsProcessDescendants(
  */
 export function resetWindowsProcessRowsSnapshotForTests(): void {
   windowsProcessRowsReader.reset()
+}
+
+/** Test-only: forget the cached wmic capability so a suite can pick a side. */
+export function resetWindowsProcessProbePreferenceForTests(): void {
+  wmicCapabilityProbe = null
 }
 
 function parseWindowsProcessValueRows(stdout: string): WindowsProcessRow[] {

--- a/src/main/providers/windows-foreground-process-rows.ts
+++ b/src/main/providers/windows-foreground-process-rows.ts
@@ -37,6 +37,11 @@ export type WindowsProcessCandidate = WindowsProcessRow & { depth: number }
 // PowerShell stays the fallback and is the only option where wmic is absent
 // (24H2+ removed it), which leaves those builds on today's behaviour.
 const WMIC_SCAN_FAILURE_LIMIT = 3
+// Why the absolute path and not `wmic`: a bare name resolves through PATH, and on
+// 24H2+ no legitimate wmic exists — so any `wmic.exe` a PATH entry offers there is
+// by definition not the system one. The daemon runs this ~2x/s and targets
+// `taskkill /T /F` off its output, so it reads only the one canonical location.
+const WMIC_PATH = `${process.env.SystemRoot ?? 'C:\\Windows'}\\System32\\wbem\\wmic.exe`
 let wmicDemoted = false
 let wmicScanFailures = 0
 
@@ -344,7 +349,7 @@ async function queryWindowsProcessesWithWmic(): Promise<WmicScan> {
   let stdout: string
   try {
     const result = await execFileAsync(
-      'wmic',
+      WMIC_PATH,
       [
         'process',
         'get',

--- a/src/main/providers/windows-foreground-process-rows.ts
+++ b/src/main/providers/windows-foreground-process-rows.ts
@@ -141,9 +141,9 @@ const WMIC_VALUE_FIELDS = [
  * next property in order opens a field; every other line continues the field
  * being read, which is what keeps `$'echo a\nProcessId=4'` one row instead of
  * two malformed ones — the hazard that made the PowerShell reader ask for JSON.
- * A blank line closes the record, so a malformed one costs itself and not the
- * rest of the table. Between records any property may open one, so a process
- * whose CommandLine is NULL still parses.
+ * Between records any property may open one, so a process whose CommandLine is
+ * NULL still parses, and a record missing a middle property merges into the next
+ * rather than desyncing the rest of the table.
  *
  * Residue: a command line embedding the whole `ExecutablePath`..`ProcessId` tail
  * in order forges a row. It cannot suppress its own real row, so a forged pid
@@ -174,8 +174,15 @@ function parseWindowsProcessValueRows(stdout: string): WindowsProcessRow[] {
 
   for (const line of stdout.split(/\r?\n/)) {
     if (line.trim() === '') {
-      if (field >= 0) {
+      // Only past CommandLine does a blank line mean end-of-record; inside one it
+      // is content. Agent CLIs really do embed blank lines — on this machine every
+      // process whose command line held one was a claude/codex/node/sh pane, the
+      // exact rows foreground detection reads. Flushing there dropped the command
+      // and left the row naming only its executable.
+      if (field >= 1) {
         flush()
+      } else if (field === 0) {
+        values[0] += '\n'
       }
       continue
     }

--- a/src/main/providers/windows-foreground-process-rows.ts
+++ b/src/main/providers/windows-foreground-process-rows.ts
@@ -180,8 +180,8 @@ function parseWindowsProcessValueRows(stdout: string): WindowsProcessRow[] {
   for (const line of stdout.split(/\r?\n/)) {
     if (line.trim() === '') {
       // Only past CommandLine does a blank line mean end-of-record; inside one it
-      // is content. Agent CLIs really do embed blank lines — on this machine every
-      // process whose command line held one was a claude/codex/node/sh pane, the
+      // is content. Agent CLIs really do embed blank lines: on a measured
+      // 920-process host all 11 that did were claude/codex/node/sh panes — the
       // exact rows foreground detection reads. Flushing there dropped the command
       // and left the row naming only its executable.
       if (field >= 1) {

--- a/src/main/providers/windows-wmic-process-table.ts
+++ b/src/main/providers/windows-wmic-process-table.ts
@@ -112,20 +112,33 @@ function parseWindowsProcessValueRows(stdout: string): WindowsProcessRow[] {
   const rows: WindowsProcessRow[] = []
   const values: string[] = ['', '', '', '', '']
   let field = -1
+  // A record is held, not emitted, until its terminator arrives. wmic ends every
+  // record with an empty line, so content arriving instead proves the record was
+  // supplied by a command line — its own real properties are what follow. Emitting
+  // on ProcessId alone let such a record stand as the only row for a live pid,
+  // which is that pid restated under a parent it does not have.
+  let pending: WindowsProcessRow | null = null
 
-  const flush = (): void => {
+  const closeRecord = (): void => {
     const ppid = Number.parseInt(values[3]!, 10)
     const pid = Number.parseInt(values[4]!, 10)
-    if (Number.isFinite(pid) && Number.isFinite(ppid)) {
-      const name = values[2]!.trim()
-      rows.push({
-        pid,
-        ppid,
-        name,
-        command: values[0]!.trim() || name,
-        executablePath: values[1]!.trim()
-      })
-    }
+    const name = values[2]!.trim()
+    pending =
+      Number.isFinite(pid) && Number.isFinite(ppid)
+        ? {
+            pid,
+            ppid,
+            name,
+            command: values[0]!.trim() || name,
+            executablePath: values[1]!.trim()
+          }
+        : null
+    values.fill('')
+    field = -1
+  }
+
+  const discardRecord = (): void => {
+    pending = null
     values.fill('')
     field = -1
   }
@@ -134,17 +147,22 @@ function parseWindowsProcessValueRows(stdout: string): WindowsProcessRow[] {
     // Exactly empty, not merely blank: a whitespace-only line is content, and
     // treating it as the separator silently ate its spaces out of the command.
     if (line === '') {
-      // Only past CommandLine does an empty line mean end-of-record; inside one it
-      // is content. Agent CLIs really do embed blank lines: on a measured
-      // 920-process host all 11 that did were claude/codex/node/sh panes — the
-      // exact rows foreground detection reads. Flushing there dropped the command
-      // and left the row naming only its executable.
-      if (field >= 1) {
-        flush()
+      if (pending) {
+        rows.push(pending)
+        pending = null
+      } else if (field >= 1) {
+        // A record that ended without its ProcessId; drop it and resync.
+        discardRecord()
       } else if (field === 0) {
+        // Only inside CommandLine is an empty line content. Agent CLIs really do
+        // embed them: on a measured 920-process host all 11 command lines that did
+        // belonged to claude/codex/node/sh panes, the exact rows naming reads.
         values[0] += '\n'
       }
       continue
+    }
+    if (pending) {
+      discardRecord()
     }
     const eq = line.indexOf('=')
     const next =
@@ -164,7 +182,7 @@ function parseWindowsProcessValueRows(stdout: string): WindowsProcessRow[] {
       field = next
       values[next] = line.slice(eq + 1)
       if (next === WMIC_VALUE_FIELDS.length - 1) {
-        flush()
+        closeRecord()
       }
       continue
     }
@@ -174,13 +192,15 @@ function parseWindowsProcessValueRows(stdout: string): WindowsProcessRow[] {
       // resync — never the whole table. That framing is content any process on the
       // box can arrange, and refusing the snapshot would spend a PowerShell host on
       // it, which is the flood this file exists to stop.
-      values.fill('')
-      field = -1
+      discardRecord()
       continue
     }
     values[0] += `\n${line}`
   }
-  flush()
+  if (pending) {
+    // End of output terminates the last record just as an empty line would.
+    rows.push(pending)
+  }
   return rows
 }
 
@@ -256,11 +276,16 @@ async function queryWindowsProcessesWithWmic(): Promise<WmicScan> {
   if (stdout.trim() === '') {
     return { status: 'failed' }
   }
-  const rows = dropAmbiguousPids(parseWindowsProcessValueRows(stdout))
-  if (rows.length === 0) {
+  const parsed = parseWindowsProcessValueRows(stdout)
+  if (parsed.length === 0) {
     // Output arrived and parsed to nothing: this build's wmic does not speak the
     // format we read, and no later scan will change that.
     return { status: 'unsupported' }
   }
-  return { status: 'ok', rows }
+  // Whereas a table that parses but survives dedup empty is a property of this
+  // snapshot, not of the host — one command line claiming every pid is enough.
+  // Answering with no rows degrades naming to the node-pty name for this scan;
+  // calling it `unsupported` would retire wmic for the daemon's life and put the
+  // transcript flood back permanently, which is a switch content must not have.
+  return { status: 'ok', rows: dropAmbiguousPids(parsed) }
 }

--- a/src/main/providers/windows-wmic-process-table.ts
+++ b/src/main/providers/windows-wmic-process-table.ts
@@ -143,7 +143,13 @@ function parseWindowsProcessValueRows(stdout: string): WindowsProcessRow[] {
     field = -1
   }
 
-  for (const line of stdout.split(/\r?\n/)) {
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    // wmic's redirected output is historically CR CR LF, so the split above leaves
+    // a trailing CR on every line. Unstripped, the record separator reads as "\r"
+    // instead of "", no record ever terminates, the table parses to nothing, and
+    // the reader retires wmic as unreadable — the fix inert on the machines it is
+    // for. Strips exactly one, so plain CRLF and LF are untouched.
+    const line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine
     // Exactly empty, not merely blank: a whitespace-only line is content, and
     // treating it as the separator silently ate its spaces out of the command.
     if (line === '') {

--- a/src/main/providers/windows-wmic-process-table.ts
+++ b/src/main/providers/windows-wmic-process-table.ts
@@ -1,0 +1,262 @@
+// The wmic side of the Windows process-table read (#15209): same Win32_Process
+// table, no PowerShell host, so the daemon's ~2x/s foreground scan stops writing a
+// transcript file per scan under the enterprise transcription GPO.
+//
+// `/format:value` has no escaping and CommandLine is whatever a process was
+// launched with, so everything here is built around the fact that this table is
+// partly attacker-controlled: the parser refuses ambiguous framing rather than
+// guessing, and callers that gate `taskkill /T /F` read the JSON path instead.
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import type { WindowsProcessRow } from './windows-foreground-process-rows'
+
+const execFileAsync = promisify(execFile)
+const WINDOWS_PROCESS_QUERY_TIMEOUT_MS = 3_000
+
+const WMIC_SCAN_FAILURE_LIMIT = 3
+// Why a cooldown and not a permanent demotion: a scan can fail because some
+// process's command line walked the record framing, and that is content anyone
+// on the box can arrange. Retiring wmic for the daemon's lifetime over it would
+// hand any local process a switch for turning the transcript flood back on.
+// Backing off instead caps the cost of a bad table at one extra spawn per
+// window, and recovers on its own once the process responsible exits.
+const WMIC_RETRY_BACKOFF_MS = 60_000
+// Why the absolute path and not `wmic`: a bare name resolves through PATH, and on
+// 24H2+ no legitimate wmic exists — so any `wmic.exe` a PATH entry offers there is
+// by definition not the system one. The daemon runs this ~2x/s and targets
+// `taskkill /T /F` off its output, so it reads only the one canonical location.
+const WMIC_PATH = `${process.env.SystemRoot ?? 'C:\\Windows'}\\System32\\wbem\\wmic.exe`
+let wmicUnsupported = false
+let wmicRetryAfterMs = 0
+let wmicScanFailures = 0
+
+/** Test-only: forget which reader a previous case steered this one into. */
+export function resetWmicProcessTableReaderForTests(): void {
+  wmicUnsupported = false
+  wmicRetryAfterMs = 0
+  wmicScanFailures = 0
+}
+
+/**
+ * wmic rows, or null to let PowerShell answer this scan.
+ *
+ * Why decide from the scan rather than probing `wmic /?`: a probe proves the
+ * binary exists, not that we can read its table, and the answer to both is the
+ * same — stop spending a wmic spawn per scan on top of the PowerShell one.
+ *
+ * The two ways to stop differ in kind. `unsupported` — no binary, or output in a
+ * shape we cannot read — is a property of the host and never changes, so it
+ * retires wmic outright. `failed` is a property of the moment (a WMI hiccup, or a
+ * command line that walked the record framing), so it only backs off, and a run
+ * of them costs one extra spawn per backoff window instead of the fix.
+ */
+export async function readWindowsProcessRowsWithWmic(): Promise<WindowsProcessRow[] | null> {
+  if (wmicUnsupported || Date.now() < wmicRetryAfterMs) {
+    return null
+  }
+  const scan = await queryWindowsProcessesWithWmic()
+  if (scan.status === 'ok') {
+    wmicScanFailures = 0
+    return scan.rows
+  }
+  if (scan.status === 'unsupported') {
+    wmicUnsupported = true
+    return null
+  }
+  wmicScanFailures += 1
+  if (wmicScanFailures >= WMIC_SCAN_FAILURE_LIMIT) {
+    wmicScanFailures = 0
+    wmicRetryAfterMs = Date.now() + WMIC_RETRY_BACKOFF_MS
+  }
+  return null
+}
+
+// wmic /format:value emits one `Key=Value` line per property in this fixed order,
+// records separated by a blank line.
+const WMIC_VALUE_FIELDS = [
+  'CommandLine',
+  'ExecutablePath',
+  'Name',
+  'ParentProcessId',
+  'ProcessId'
+] as const
+
+/**
+ * Parse wmic's `Key=Value` records.
+ *
+ * CommandLine is the one property that carries raw CR/LF, and Orca's own panes
+ * put it there constantly (`bash -lc $'...\n...'`). So inside a record only the
+ * next property in order opens a field; every other line continues the field
+ * being read, which is what keeps `$'echo a\nProcessId=4'` one row instead of
+ * two malformed ones — the hazard that made the PowerShell reader ask for JSON.
+ * A record must open on CommandLine — wmic emits every requested property, empty
+ * when NULL — and a record missing a middle property merges into the next rather
+ * than desyncing the rest of the table.
+ *
+ * Returns null when the framing is provably compromised, which drops the whole
+ * snapshot to PowerShell. Only CommandLine can hold a newline, so a continuation
+ * line arriving while a later property is open means some earlier line was
+ * absorbed that should not have been. A command line carrying
+ * `ExecutablePath=`/`Name=`/`ParentProcessId=` in order otherwise walks the parser
+ * to ParentProcessId and lets the record's own real `ProcessId=` close it —
+ * re-parenting a live pid under a forged parent, with no duplicate pid to catch
+ * it. Ancestry read off that feeds `taskkill /T /F`, so an ambiguous table is
+ * refused rather than guessed at.
+ */
+function parseWindowsProcessValueRows(stdout: string): WindowsProcessRow[] | null {
+  const rows: WindowsProcessRow[] = []
+  const values: string[] = ['', '', '', '', '']
+  let field = -1
+  let expectRecordBreak = false
+
+  const flush = (): void => {
+    const ppid = Number.parseInt(values[3]!, 10)
+    const pid = Number.parseInt(values[4]!, 10)
+    if (Number.isFinite(pid) && Number.isFinite(ppid)) {
+      const name = values[2]!.trim()
+      rows.push({
+        pid,
+        ppid,
+        name,
+        command: values[0]!.trim() || name,
+        executablePath: values[1]!.trim()
+      })
+    }
+    values.fill('')
+    field = -1
+  }
+
+  for (const line of stdout.split(/\r?\n/)) {
+    // Exactly empty, not merely blank: a whitespace-only line is content, and
+    // treating it as the separator silently ate its spaces out of the command.
+    if (line === '') {
+      expectRecordBreak = false
+      // Only past CommandLine does an empty line mean end-of-record; inside one it
+      // is content. Agent CLIs really do embed blank lines: on a measured
+      // 920-process host all 11 that did were claude/codex/node/sh panes — the
+      // exact rows foreground detection reads. Flushing there dropped the command
+      // and left the row naming only its executable.
+      if (field >= 1) {
+        flush()
+      } else if (field === 0) {
+        values[0] += '\n'
+      }
+      continue
+    }
+    // wmic closes every record with an empty line. Content resuming without one
+    // means the record just flushed was supplied by a command line rather than by
+    // wmic: the forger's own real properties follow immediately. Such a row can be
+    // pure invention — and an invented pid is not inert, because it can bridge a
+    // real orphan to our own pid and make an unrelated tree look like ours.
+    if (expectRecordBreak) {
+      return null
+    }
+    const eq = line.indexOf('=')
+    const next =
+      eq === -1 ? -1 : (WMIC_VALUE_FIELDS as readonly string[]).indexOf(line.slice(0, eq))
+    if (field === -1) {
+      if (next === 0) {
+        field = 0
+        values[0] = line.slice(eq + 1)
+      } else if (next > 0) {
+        // wmic emits every requested property, empty when NULL, so a record always
+        // opens on CommandLine. One opening later means the properties before it
+        // were eaten by the previous record — which is what a command line that
+        // supplied its own record leaves behind, blank-line separator included.
+        return null
+      }
+      // Anything else here is preamble, e.g. wmic's deprecation notice.
+      continue
+    }
+    if (next === field + 1) {
+      field = next
+      values[next] = line.slice(eq + 1)
+      if (next === WMIC_VALUE_FIELDS.length - 1) {
+        flush()
+        expectRecordBreak = true
+      }
+    } else if (field > 0) {
+      return null
+    } else {
+      values[0] += `\n${line}`
+    }
+  }
+  flush()
+  return rows
+}
+
+type WmicScan =
+  /** wmic is missing, or its output is not the key=value table we can read. */
+  | { status: 'unsupported' }
+  /** wmic ran but this scan did not answer: a WMI hiccup, a timeout, a torn table. */
+  | { status: 'failed' }
+  | { status: 'ok'; rows: WindowsProcessRow[] }
+
+/**
+ * wmic writes UTF-16LE through a redirected stdout, so read bytes and pick the
+ * encoding from the BOM — decoding as utf8 would yield NUL-padded keys that match
+ * nothing and silently strand every machine on the PowerShell path this fixes.
+ */
+function decodeWmicStdout(stdout: string | Buffer): string {
+  if (typeof stdout === 'string') {
+    return stdout
+  }
+  if (stdout[0] === 0xff && stdout[1] === 0xfe) {
+    return stdout.toString('utf16le', 2)
+  }
+  if (stdout[0] === 0xef && stdout[1] === 0xbb && stdout[2] === 0xbf) {
+    return stdout.toString('utf8', 3)
+  }
+  // A BOM-less UTF-16LE table still pads every ASCII byte with a NUL.
+  return stdout.subarray(0, 64).includes(0) ? stdout.toString('utf16le') : stdout.toString('utf8')
+}
+
+/** Whole-process-table scan via wmic — the preferred reader, see #15209. */
+async function queryWindowsProcessesWithWmic(): Promise<WmicScan> {
+  let stdout: string
+  try {
+    const result = await execFileAsync(
+      WMIC_PATH,
+      [
+        'process',
+        'get',
+        'CommandLine,ExecutablePath,Name,ParentProcessId,ProcessId',
+        '/format:value'
+      ],
+      {
+        encoding: 'buffer',
+        timeout: WINDOWS_PROCESS_QUERY_TIMEOUT_MS,
+        // 16MB: the cap counts raw bytes here, and UTF-16 doubles the table.
+        maxBuffer: 16 * 1024 * 1024,
+        // Why: same focus-stealing hazard as the powershell scan — without this,
+        // each fork pops a conhost window that steals keyboard focus.
+        windowsHide: true
+      }
+    )
+    stdout = decodeWmicStdout(result.stdout)
+  } catch (error) {
+    // ENOENT is 24H2+, where wmic is gone for good; anything else may recover.
+    const missing = (error as NodeJS.ErrnoException | null)?.code === 'ENOENT'
+    return { status: missing ? 'unsupported' : 'failed' }
+  }
+  if (stdout.trim() === '') {
+    return { status: 'failed' }
+  }
+  const rows = parseWindowsProcessValueRows(stdout)
+  if (rows === null) {
+    // Framing compromised by command-line content, not a format we cannot read:
+    // transient, because it lasts only as long as the process that wrote it.
+    return { status: 'failed' }
+  }
+  if (rows.length === 0) {
+    // Output arrived and parsed to nothing: this build's wmic does not speak the
+    // format we read, and no later scan will change that.
+    return { status: 'unsupported' }
+  }
+  // pids are unique in a live table, so a repeat means the record framing
+  // desynced. Ancestry off a desynced table can misdirect `taskkill /T /F`.
+  if (new Set(rows.map((row) => row.pid)).size !== rows.length) {
+    return { status: 'failed' }
+  }
+  return { status: 'ok', rows }
+}

--- a/src/main/providers/windows-wmic-process-table.ts
+++ b/src/main/providers/windows-wmic-process-table.ts
@@ -4,8 +4,11 @@
 //
 // `/format:value` has no escaping and CommandLine is whatever a process was
 // launched with, so everything here is built around the fact that this table is
-// partly attacker-controlled: the parser refuses ambiguous framing rather than
-// guessing, and callers that gate `taskkill /T /F` read the JSON path instead.
+// partly attacker-controlled. Two rules follow. Bad framing costs one record, never
+// the table — voiding a snapshot over content would let any process spend a
+// PowerShell host and turn the flood back on. And because a command line can still
+// emit a whole well-formed record that no parser can detect, callers gating
+// `taskkill /T /F` read the JSON path instead of this one.
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 import type { WindowsProcessRow } from './windows-foreground-process-rows'
@@ -93,21 +96,22 @@ const WMIC_VALUE_FIELDS = [
  * when NULL — and a record missing a middle property merges into the next rather
  * than desyncing the rest of the table.
  *
- * Returns null when the framing is provably compromised, which drops the whole
- * snapshot to PowerShell. Only CommandLine can hold a newline, so a continuation
- * line arriving while a later property is open means some earlier line was
- * absorbed that should not have been. A command line carrying
- * `ExecutablePath=`/`Name=`/`ParentProcessId=` in order otherwise walks the parser
- * to ParentProcessId and lets the record's own real `ProcessId=` close it —
- * re-parenting a live pid under a forged parent, with no duplicate pid to catch
- * it. Ancestry read off that feeds `taskkill /T /F`, so an ambiguous table is
- * refused rather than guessed at.
+ * A record opens only on CommandLine, and a record whose framing does not hold up
+ * is dropped on its own rather than voiding the table. Both matter because a
+ * command line carrying `ExecutablePath=`/`Name=`/`ParentProcessId=` in order
+ * otherwise walks the parser to ParentProcessId and lets the record's own real
+ * `ProcessId=` close it, re-parenting a live pid under a forged parent.
+ *
+ * What this cannot do is stop a command line from emitting a whole well-formed
+ * record — forged properties, blank-line separator, and a `CommandLine=` to
+ * resynchronise. Nothing in the byte stream tells that apart from a record wmic
+ * wrote. That is why callers gating `taskkill /T /F` read the JSON path instead,
+ * and why an invented row here can only misname a pane.
  */
-function parseWindowsProcessValueRows(stdout: string): WindowsProcessRow[] | null {
+function parseWindowsProcessValueRows(stdout: string): WindowsProcessRow[] {
   const rows: WindowsProcessRow[] = []
   const values: string[] = ['', '', '', '', '']
   let field = -1
-  let expectRecordBreak = false
 
   const flush = (): void => {
     const ppid = Number.parseInt(values[3]!, 10)
@@ -130,7 +134,6 @@ function parseWindowsProcessValueRows(stdout: string): WindowsProcessRow[] | nul
     // Exactly empty, not merely blank: a whitespace-only line is content, and
     // treating it as the separator silently ate its spaces out of the command.
     if (line === '') {
-      expectRecordBreak = false
       // Only past CommandLine does an empty line mean end-of-record; inside one it
       // is content. Agent CLIs really do embed blank lines: on a measured
       // 920-process host all 11 that did were claude/codex/node/sh panes — the
@@ -143,29 +146,18 @@ function parseWindowsProcessValueRows(stdout: string): WindowsProcessRow[] | nul
       }
       continue
     }
-    // wmic closes every record with an empty line. Content resuming without one
-    // means the record just flushed was supplied by a command line rather than by
-    // wmic: the forger's own real properties follow immediately. Such a row can be
-    // pure invention — and an invented pid is not inert, because it can bridge a
-    // real orphan to our own pid and make an unrelated tree look like ours.
-    if (expectRecordBreak) {
-      return null
-    }
     const eq = line.indexOf('=')
     const next =
       eq === -1 ? -1 : (WMIC_VALUE_FIELDS as readonly string[]).indexOf(line.slice(0, eq))
     if (field === -1) {
+      // Between records only CommandLine opens one. Anything else is the tail of a
+      // record that a command line supplied for itself, a property wmic omitted, or
+      // its deprecation notice — drop the line and wait for the next record rather
+      // than reading a row out of it.
       if (next === 0) {
         field = 0
         values[0] = line.slice(eq + 1)
-      } else if (next > 0) {
-        // wmic emits every requested property, empty when NULL, so a record always
-        // opens on CommandLine. One opening later means the properties before it
-        // were eaten by the previous record — which is what a command line that
-        // supplied its own record leaves behind, blank-line separator included.
-        return null
       }
-      // Anything else here is preamble, e.g. wmic's deprecation notice.
       continue
     }
     if (next === field + 1) {
@@ -173,13 +165,20 @@ function parseWindowsProcessValueRows(stdout: string): WindowsProcessRow[] | nul
       values[next] = line.slice(eq + 1)
       if (next === WMIC_VALUE_FIELDS.length - 1) {
         flush()
-        expectRecordBreak = true
       }
-    } else if (field > 0) {
-      return null
-    } else {
-      values[0] += `\n${line}`
+      continue
     }
+    if (field > 0) {
+      // A later property is open and this is not the one that follows it, so an
+      // earlier line was absorbed that should not have been. Drop this record and
+      // resync — never the whole table. That framing is content any process on the
+      // box can arrange, and refusing the snapshot would spend a PowerShell host on
+      // it, which is the flood this file exists to stop.
+      values.fill('')
+      field = -1
+      continue
+    }
+    values[0] += `\n${line}`
   }
   flush()
   return rows
@@ -209,6 +208,21 @@ function decodeWmicStdout(stdout: string | Buffer): string {
   }
   // A BOM-less UTF-16LE table still pads every ASCII byte with a NUL.
   return stdout.subarray(0, 64).includes(0) ? stdout.toString('utf16le') : stdout.toString('utf8')
+}
+
+/**
+ * pids are unique in a live table, so a repeat means one of the two rows was
+ * supplied by a command line claiming another process's pid. Which one is which is
+ * not knowable from the bytes, so neither is kept: a pid that vanishes degrades to
+ * the node-pty name, where a pid kept under the wrong parent would put an agent on
+ * the wrong pane.
+ */
+function dropAmbiguousPids(rows: WindowsProcessRow[]): WindowsProcessRow[] {
+  const seen = new Map<number, number>()
+  for (const row of rows) {
+    seen.set(row.pid, (seen.get(row.pid) ?? 0) + 1)
+  }
+  return seen.size === rows.length ? rows : rows.filter((row) => seen.get(row.pid) === 1)
 }
 
 /** Whole-process-table scan via wmic — the preferred reader, see #15209. */
@@ -242,21 +256,11 @@ async function queryWindowsProcessesWithWmic(): Promise<WmicScan> {
   if (stdout.trim() === '') {
     return { status: 'failed' }
   }
-  const rows = parseWindowsProcessValueRows(stdout)
-  if (rows === null) {
-    // Framing compromised by command-line content, not a format we cannot read:
-    // transient, because it lasts only as long as the process that wrote it.
-    return { status: 'failed' }
-  }
+  const rows = dropAmbiguousPids(parseWindowsProcessValueRows(stdout))
   if (rows.length === 0) {
     // Output arrived and parsed to nothing: this build's wmic does not speak the
     // format we read, and no later scan will change that.
     return { status: 'unsupported' }
-  }
-  // pids are unique in a live table, so a repeat means the record framing
-  // desynced. Ancestry off a desynced table can misdirect `taskkill /T /F`.
-  if (new Set(rows.map((row) => row.pid)).size !== rows.length) {
-    return { status: 'failed' }
   }
   return { status: 'ok', rows }
 }

--- a/src/main/windows-pty-root-identity.test.ts
+++ b/src/main/windows-pty-root-identity.test.ts
@@ -7,7 +7,7 @@ const { execFileMock, powershellScanCount } = vi.hoisted(() => ({
 
 vi.mock('child_process', () => ({ execFile: execFileMock }))
 
-import { resetWindowsProcessRowsSnapshotForTests } from './providers/windows-foreground-process-rows'
+import { resetWindowsProcessRowsReaderForTests } from './providers/windows-foreground-process-rows'
 import {
   classifyWindowsTreeKillTarget,
   verifyWindowsTreeKillTarget,
@@ -169,7 +169,7 @@ describe('verifyWindowsTreeKillTarget scan volume', () => {
   beforeEach(() => {
     execFileMock.mockReset()
     powershellScanCount.value = 0
-    resetWindowsProcessRowsSnapshotForTests()
+    resetWindowsProcessRowsReaderForTests()
     execFileMock.mockImplementation((cmd: string, ..._rest: unknown[]) => {
       const cb = _rest.at(-1) as (e: unknown, r: { stdout: string; stderr: string }) => void
       if (cmd === 'powershell.exe') {
@@ -180,7 +180,7 @@ describe('verifyWindowsTreeKillTarget scan volume', () => {
   })
 
   afterEach(() => {
-    resetWindowsProcessRowsSnapshotForTests()
+    resetWindowsProcessRowsReaderForTests()
   })
 
   it('collapses a 32-wide teardown burst into a single process-table scan', async () => {

--- a/src/relay/pty-shell-utils.test.ts
+++ b/src/relay/pty-shell-utils.test.ts
@@ -10,7 +10,7 @@ vi.mock('child_process', () => ({
   execFileSync: execFileSyncMock
 }))
 
-import { resetWindowsProcessRowsSnapshotForTests } from '../main/providers/windows-foreground-process-rows'
+import { resetWindowsProcessRowsReaderForTests } from '../main/providers/windows-foreground-process-rows'
 import { resetProcessTableSnapshotForTests } from '../shared/process-table-snapshot'
 import {
   getForegroundProcessName,
@@ -55,7 +55,7 @@ beforeEach(() => {
   execFileMock.mockReset()
   execFileSyncMock.mockReset()
   resetProcessTableSnapshotForTests()
-  resetWindowsProcessRowsSnapshotForTests()
+  resetWindowsProcessRowsReaderForTests()
 })
 
 describe('isProcessAlive', () => {


### PR DESCRIPTION
Fixes #15209.

## What was wrong

The daemon's agent-foreground inspection re-forks a whole-process-table scan roughly twice a second while agent panes are open (already deduplicated across panes), and every fork was a `powershell.exe` host. Under the enterprise **Windows PowerShell transcription GPO** each host spawn writes a transcript file — the reported machine accumulated **1.4M files / 289GB over ~3 weeks**. The Resource Manager toggle doesn't gate it because this scan feeds agent-pane foreground status, not the resource meter.

## The change

`wmic` enumerates the same `Win32_Process` table with **no PowerShell host**, so it is now preferred wherever it exists:

- a one-shot capability probe (`wmic /?`, hidden, 3s timeout) caches the answer for the process lifetime — one extra spawn total, not per scan;
- a capable-but-failing wmic scan (WMI service hiccup, truncated output) falls through to PowerShell for that poll, so pane status never starves;
- machines without wmic (Windows 11 24H2+ removed it) keep today's PowerShell path byte-for-byte;
- both probes keep `windowsHide: true`.

On transcription-GPO machines — precisely the Win10 domain-joined fleet in the report — the recurring scan now writes zero transcript files and also drops the ~50-200ms PowerShell cold-start per scan.

## Verification

- `windows-foreground-process-rows.test.ts` 5/5 with three new cases: wmic-present spawns **no** PowerShell host; wmic-missing falls back to PowerShell with `windowsHide`; a capable-but-failing wmic scan falls through exactly once (no re-probe storm).
- Related suites (`windows-agent-foreground-process-scan-volume`, `pty-process-inspection`) 8/8; `typecheck:node` clean.
- Sanity on a real Windows host: `wmic process get ... /format:value` enumerates with the expected `key=value` rows (the existing parser's format).

## Not addressed here

The Resource Manager meter's own `Get-CimInstance` poll (`windows-process-resource-collector.ts`) only runs while that panel is open, so it is not part of this flood; switching it to the same wmic-first reader would be a natural follow-up if wanted.