### PR TITLE
docs(readme): add Android install guide link to README.ko.md (STA-4817)

### DIFF
--- a/docs/readme/README.ko.md
+++ b/docs/readme/README.ko.md
@@ -230,7 +230,7 @@ yay -S stably-orca-bin
 데스크톱 앱과 페어링해 휴대폰에서 에이전트를 모니터링하고 조종하세요.
 
 - **iOS:** [App Store에서 다운로드](https://apps.apple.com/us/app/orca-ide/id6766130217) 또는 [TestFlight 참여](https://testflight.apple.com/join/YjeGMQBA)
-- **Android:** [APK 0.0.43 다운로드](https://github.com/stablyai/orca/releases/download/mobile-android-v0.0.43/app-release.apk)
+- **Android:** [APK 0.0.43 다운로드](https://github.com/stablyai/orca/releases/download/mobile-android-v0.0.43/app-release.apk) · [설치 가이드](https://www.onorca.dev/docs/android-apk)
 
 ---
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | 0 |

<!-- /orca-pr-loc -->

## ELI5

The English README links an Android install guide next to the APK download. The Korean README was missing that same link.

## What Changed

Added `· [설치 가이드](https://www.onorca.dev/docs/android-apk)` after the Android APK download link in `docs/readme/README.ko.md`, matching the English README and the "가이드" terminology already used in the Korean file.

## Why

`#14978` added the install guide link to English `README.md`. The Korean README was last fully synced in `#14124`, before that change, so this one line drifted.

This takes the same one-line fix from community PR `#15396` (which also has a duplicate in `#15426`; `#15394` was closed as a duplicate of `#15396`).

## Linked Issue

Fixes #15395
STA-4817

## Visual Proof

N/A — Markdown-only text addition. No UI or rendering behavior change.

## Testing

- [x] I manually tested these changes locally
- [ ] Automated tests added/updated, or explained why not below

Doc-only single-line Markdown change. Diffed against the English `README.md` install-guide link and confirmed the URL is the same.

## AI Disclosure

Change taken from `#15396` by @erishforG.

## Review

- Security: no code paths touched.
- Cross-platform: Markdown text only.
- SSH/remote: not applicable.
- Backwards compatibility: additive text only.
- Performance: no runtime impact.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Doc-only change.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)