### PR TITLE
fix(runtime): recover adopted tui-idle and pin worker fixtures

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -20635,6 +20635,8 @@ describe('OrcaRuntimeService', () => {
       runtime.waitForTerminal(terminal.handle, { condition: 'tui-idle', timeoutMs: 50 })
     ).rejects.toThrow('timeout')
     expect(serializeProviderBuffer).toHaveBeenCalledTimes(4)
+    await expect(runtime.readTerminal(terminal.handle)).resolves.toMatchObject({ tail: [] })
+    expect(serializeProviderBuffer).toHaveBeenCalledTimes(4)
     expect(
       runtime.verifyOrchestrationCompatibilityCaller({
         terminalHandle: 'term_legacy',

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -20516,7 +20516,8 @@ describe('OrcaRuntimeService', () => {
     const kill = vi.fn(() => true)
     const serializeProviderBuffer = vi.fn().mockResolvedValue({
       data: '',
-      scrollbackAnsi: 'OpenAI Codex\r\nACK\r\n',
+      scrollbackAnsi:
+        ' >_ OpenAI Codex (v0.131.0)\r\n model:       gpt-5.5 high\r\n directory:   /repo\r\n',
       cols: 80,
       rows: 24,
       seq: 100,
@@ -20598,11 +20599,14 @@ describe('OrcaRuntimeService', () => {
     expect(kill).not.toHaveBeenCalled()
     const [terminal] = (await runtime.listTerminals()).terminals
     await expect(runtime.readTerminal(terminal.handle)).resolves.toMatchObject({
-      tail: ['OpenAI Codex', 'ACK']
+      tail: [' >_ OpenAI Codex (v0.131.0)', ' model:       gpt-5.5 high', ' directory:   /repo']
     })
     expect(serializeProviderBuffer).toHaveBeenCalledWith('pty-legacy', {
       scrollbackRows: 120
     })
+    await expect(
+      runtime.waitForTerminal(terminal.handle, { condition: 'tui-idle', timeoutMs: 100 })
+    ).resolves.toMatchObject({ satisfied: true })
     expect(
       runtime.verifyOrchestrationCompatibilityCaller({
         terminalHandle: 'term_legacy',

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -22322,6 +22322,12 @@ describe('OrcaRuntimeService', () => {
         wslDistro: null
       }
     ])
+    const serializeProviderBuffer = vi.fn().mockResolvedValue(null)
+    const serializeBuffer = vi.fn().mockResolvedValue({
+      data: ' >_ OpenAI Codex (v0.131.0)\r\n model:       gpt-5.5 high\r\n directory:   /repo\r\n',
+      cols: 80,
+      rows: 24
+    })
     const runtime = new OrcaRuntimeService(
       {
         ...runtimeStore,
@@ -22355,7 +22361,10 @@ describe('OrcaRuntimeService', () => {
       kill: vi.fn(() => true),
       getForegroundProcess: async () => null,
       hasPty: (candidate) => candidate === ptyId,
-      listProcesses
+      listProcesses,
+      serializeBuffer,
+      serializeProviderBuffer,
+      hasRendererSerializer: () => true
     })
     const revealTerminalSession = vi.fn().mockImplementation(() =>
       publishLegacyWorkerReveal(runtime, {
@@ -22427,6 +22436,11 @@ describe('OrcaRuntimeService', () => {
         incarnationId
       }
     })
+    await expect(
+      runtime.waitForTerminal('term_ssh_legacy', { condition: 'tui-idle', timeoutMs: 100 })
+    ).resolves.toMatchObject({ satisfied: true })
+    expect(serializeProviderBuffer).toHaveBeenCalledOnce()
+    expect(serializeBuffer).toHaveBeenCalledOnce()
   })
 
   it('refuses a cross-distro WSL worker and adopts it after exact host ownership matches', async () => {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -16208,11 +16208,18 @@ describe('OrcaRuntimeService', () => {
     vi.useFakeTimers()
     try {
       const runtime = new OrcaRuntimeService(store)
+      const serializeProviderBuffer = vi.fn().mockResolvedValue({
+        data: 'OpenAI Codex\r\nmodel: gpt-5.5\r\ndirectory: /repo\r\n',
+        cols: 80,
+        rows: 24,
+        seq: 1
+      })
       runtime.setPtyController({
         spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
         write: () => true,
         kill: () => true,
-        getForegroundProcess: async () => null
+        getForegroundProcess: async () => null,
+        serializeProviderBuffer
       })
       const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
 
@@ -16248,6 +16255,7 @@ describe('OrcaRuntimeService', () => {
       await vi.advanceTimersByTimeAsync(2_000)
 
       await timeoutAssertion
+      expect(serializeProviderBuffer).not.toHaveBeenCalled()
     } finally {
       vi.useRealTimers()
     }
@@ -20607,6 +20615,26 @@ describe('OrcaRuntimeService', () => {
     await expect(
       runtime.waitForTerminal(terminal.handle, { condition: 'tui-idle', timeoutMs: 100 })
     ).resolves.toMatchObject({ satisfied: true })
+    serializeProviderBuffer.mockResolvedValueOnce({
+      data: '',
+      scrollbackAnsi: 'Do you trust this workspace directory?\r\n1. Yes\r\n2. No\r\n',
+      cols: 80,
+      rows: 24,
+      seq: 101,
+      source: 'headless' as const,
+      alternateScreen: false
+    })
+    await expect(
+      runtime.waitForTerminal(terminal.handle, { condition: 'tui-idle', timeoutMs: 100 })
+    ).resolves.toMatchObject({
+      satisfied: false,
+      blockedReason: 'codex-trust-workspace'
+    })
+    serializeProviderBuffer.mockImplementationOnce(() => new Promise(() => {}))
+    await expect(
+      runtime.waitForTerminal(terminal.handle, { condition: 'tui-idle', timeoutMs: 50 })
+    ).rejects.toThrow('timeout')
+    expect(serializeProviderBuffer).toHaveBeenCalledTimes(4)
     expect(
       runtime.verifyOrchestrationCompatibilityCaller({
         terminalHandle: 'term_legacy',

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -13323,7 +13323,8 @@ export class OrcaRuntimeService {
   private async withVisibleSnapshotFallback(
     ptyId: string,
     read: RuntimeTerminalRead,
-    opts: { cursor?: number; limit?: number } = {}
+    opts: { cursor?: number; limit?: number } = {},
+    providerWait: { timeoutMs?: number; retireOnTimeout?: boolean } = {}
   ): Promise<RuntimeTerminalRead> {
     if (typeof opts.cursor === 'number') {
       return read
@@ -13338,7 +13339,11 @@ export class OrcaRuntimeService {
       !recoveredWorkerFallback &&
       this.isKnownUnattachedLocalDaemonPty(ptyId)
     if (recoveredWorkerFallback || neverAttachedProviderFallback) {
-      const providerLines = await this.readProviderTerminalTailLines(ptyId, opts.limit)
+      const providerLines = await this.readProviderTerminalTailLines(
+        ptyId,
+        opts.limit,
+        providerWait
+      )
       if (providerLines.length > 0) {
         return buildVisibleSnapshotReadFallback(read, providerLines, opts.limit)
       }
@@ -13376,12 +13381,15 @@ export class OrcaRuntimeService {
 
   private async readProviderTerminalTailLines(
     ptyId: string,
-    limit: number | undefined
+    limit: number | undefined,
+    wait: { timeoutMs?: number; retireOnTimeout?: boolean } = {}
   ): Promise<string[]> {
     const lineLimit = terminalReadLimit(limit, DEFAULT_TERMINAL_READ_LIMIT)
-    const snapshot = await this.serializeProviderTerminalBuffer(ptyId, {
-      scrollbackRows: lineLimit
-    })
+    const snapshot = await this.serializeProviderTerminalBuffer(
+      ptyId,
+      { scrollbackRows: lineLimit },
+      wait
+    )
     const data = snapshot ? `${snapshot.scrollbackAnsi ?? ''}${snapshot.data}` : ''
     if (!snapshot || data.length === 0) {
       return []
@@ -18442,14 +18450,15 @@ export class OrcaRuntimeService {
 
   async readTerminal(
     handle: string,
-    opts: { cursor?: number; limit?: number; screen?: boolean } = {}
+    opts: { cursor?: number; limit?: number; screen?: boolean } = {},
+    providerWait: { timeoutMs?: number; retireOnTimeout?: boolean } = {}
   ): Promise<RuntimeTerminalRead> {
     const pty = this.getLivePtyForHandle(handle)
     if (pty) {
       const read = this.readPtyTerminal(handle, pty.pty, opts)
       const visibleRead = opts.screen
         ? await this.readRenderedScreen(pty.pty.ptyId, read, opts)
-        : await this.withVisibleSnapshotFallback(pty.pty.ptyId, read, opts)
+        : await this.withVisibleSnapshotFallback(pty.pty.ptyId, read, opts, providerWait)
       this.assertLiveTerminalHandleTargetsPty(handle, pty.pty.ptyId)
       return labelTerminalReadSource(visibleRead)
     }
@@ -18471,7 +18480,7 @@ export class OrcaRuntimeService {
     }
     const visibleRead = opts.screen
       ? await this.readRenderedScreen(leaf.ptyId, read, opts)
-      : await this.withVisibleSnapshotFallback(leaf.ptyId, read, opts)
+      : await this.withVisibleSnapshotFallback(leaf.ptyId, read, opts, providerWait)
     this.assertLiveTerminalHandleTargetsPty(handle, leaf.ptyId)
     return labelTerminalReadSource(visibleRead)
   }
@@ -19680,7 +19689,7 @@ export class OrcaRuntimeService {
           ) {
             this.resolveWaiter(waiter, buildPtyTerminalWaitResult(handle, condition, live.pty))
           } else {
-            this.startPtyTuiIdleFallbackPoll(waiter, live.pty)
+            this.startPtyTuiIdleFallbackPoll(waiter, live.pty, effectiveTimeoutMs)
           }
         }
       })
@@ -19791,7 +19800,7 @@ export class OrcaRuntimeService {
             ) {
               this.resolveWaiter(waiter, buildTerminalWaitResult(handle, condition, live.leaf))
             } else {
-              this.startTuiIdleFallbackPoll(waiter, live.leaf)
+              this.startTuiIdleFallbackPoll(waiter, live.leaf, effectiveTimeoutMs)
             }
           }
         }
@@ -35372,7 +35381,11 @@ export class OrcaRuntimeService {
   }
 
   // Why: the primary OSC-title signal can't fire for daemon-hosted terminals (no PTY data through the runtime), so this fallback polls the renderer-synced tab title + foreground-process quiescence; self-cancels when the OSC path fires.
-  private startTuiIdleFallbackPoll(waiter: TerminalWaiter, leaf: RuntimeLeafRecord): void {
+  private startTuiIdleFallbackPoll(
+    waiter: TerminalWaiter,
+    leaf: RuntimeLeafRecord,
+    waiterTimeoutMs: number
+  ): void {
     let foregroundPollInFlight = false
     waiter.pollInterval = setInterval(async () => {
       if (!waiter.pollInterval) {
@@ -35461,11 +35474,15 @@ export class OrcaRuntimeService {
       leaf.preview
     )
     if (leaf.lastAgentStatus === null && retainedWaitText.length === 0) {
-      this.startTuiIdleVisibleReadProbe(waiter)
+      this.startTuiIdleVisibleReadProbe(waiter, waiterTimeoutMs)
     }
   }
 
-  private startPtyTuiIdleFallbackPoll(waiter: TerminalWaiter, pty: RuntimePtyWorktreeRecord): void {
+  private startPtyTuiIdleFallbackPoll(
+    waiter: TerminalWaiter,
+    pty: RuntimePtyWorktreeRecord,
+    waiterTimeoutMs: number
+  ): void {
     let foregroundPollInFlight = false
     waiter.pollInterval = setInterval(async () => {
       if (!waiter.pollInterval) {
@@ -35531,12 +35548,27 @@ export class OrcaRuntimeService {
     }, TUI_IDLE_POLL_INTERVAL_MS)
     const retainedWaitText = buildTerminalWaitText(pty.tailBuffer, pty.tailPartialLine, pty.preview)
     if (pty.lastAgentStatus === null && retainedWaitText.length === 0) {
-      this.startTuiIdleVisibleReadProbe(waiter)
+      this.startTuiIdleVisibleReadProbe(waiter, waiterTimeoutMs)
     }
   }
 
-  private startTuiIdleVisibleReadProbe(waiter: TerminalWaiter): void {
-    void withTimeout(this.readTerminal(waiter.handle), VISIBLE_TERMINAL_SNAPSHOT_TIMEOUT_MS, null)
+  private startTuiIdleVisibleReadProbe(waiter: TerminalWaiter, waiterTimeoutMs: number): void {
+    const snapshotTimeoutMs = Math.min(
+      VISIBLE_TERMINAL_SNAPSHOT_TIMEOUT_MS,
+      Math.max(0, waiterTimeoutMs - 1)
+    )
+    void withTimeout(
+      this.readTerminal(
+        waiter.handle,
+        {},
+        {
+          timeoutMs: snapshotTimeoutMs,
+          retireOnTimeout: true
+        }
+      ),
+      snapshotTimeoutMs,
+      null
+    )
       .then((read) => {
         if (
           !read ||

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -35455,6 +35455,14 @@ export class OrcaRuntimeService {
         }
       }
     }, TUI_IDLE_POLL_INTERVAL_MS)
+    const retainedWaitText = buildTerminalWaitText(
+      leaf.tailBuffer,
+      leaf.tailPartialLine,
+      leaf.preview
+    )
+    if (leaf.lastAgentStatus === null && retainedWaitText.length === 0) {
+      this.startTuiIdleVisibleReadProbe(waiter)
+    }
   }
 
   private startPtyTuiIdleFallbackPoll(waiter: TerminalWaiter, pty: RuntimePtyWorktreeRecord): void {
@@ -35521,6 +35529,50 @@ export class OrcaRuntimeService {
         }
       }
     }, TUI_IDLE_POLL_INTERVAL_MS)
+    const retainedWaitText = buildTerminalWaitText(pty.tailBuffer, pty.tailPartialLine, pty.preview)
+    if (pty.lastAgentStatus === null && retainedWaitText.length === 0) {
+      this.startTuiIdleVisibleReadProbe(waiter)
+    }
+  }
+
+  private startTuiIdleVisibleReadProbe(waiter: TerminalWaiter): void {
+    void withTimeout(this.readTerminal(waiter.handle), VISIBLE_TERMINAL_SNAPSHOT_TIMEOUT_MS, null)
+      .then((read) => {
+        if (
+          !read ||
+          read.source !== 'screen' ||
+          !this.waitersByHandle.get(waiter.handle)?.has(waiter)
+        ) {
+          return
+        }
+        const snapshotText = read.tail.join('\n')
+        const blockedReason = detectTerminalWaitBlockedReason(snapshotText)
+        if (!blockedReason && !isKnownReadyPromptPreview(snapshotText)) {
+          return
+        }
+        if (waiter.pollInterval) {
+          clearInterval(waiter.pollInterval)
+          waiter.pollInterval = null
+        }
+        const pty = this.getLivePtyForHandle(waiter.handle)
+        if (pty) {
+          this.resolveWaiter(
+            waiter,
+            blockedReason
+              ? buildPtyTerminalWaitBlockedResult(waiter.handle, 'tui-idle', pty.pty, blockedReason)
+              : buildPtyTerminalWaitResult(waiter.handle, 'tui-idle', pty.pty)
+          )
+          return
+        }
+        const { leaf } = this.getLiveLeafForHandle(waiter.handle)
+        this.resolveWaiter(
+          waiter,
+          blockedReason
+            ? buildTerminalWaitBlockedResult(waiter.handle, 'tui-idle', leaf, blockedReason)
+            : buildTerminalWaitResult(waiter.handle, 'tui-idle', leaf)
+        )
+      })
+      .catch(() => {})
   }
 
   private getAdoptedPtyExplicitIdleStatus(pty: RuntimePtyWorktreeRecord): AgentStatus | null {

--- a/tests/e2e/completed-worker-retirement-resume.spec.ts
+++ b/tests/e2e/completed-worker-retirement-resume.spec.ts
@@ -8,6 +8,7 @@ import {
 import {
   cleanupCompletedWorkerFixture,
   clearCompletedWorkerLedger,
+  completedWorkerFakeCodexCommand,
   completedWorkerLaunchEnv,
   listRuntimeTerminals,
   readCompletedWorkerDispatchCapability,
@@ -45,12 +46,13 @@ for (const closeMode of ['terminal-close-cli', 'worker-release'] as const) {
     await ensureTerminalVisible(orcaPage)
     await waitForActiveTerminalManager(orcaPage)
     await waitForActivePanePtyId(orcaPage)
-    await orcaPage.evaluate(async () => {
+    await orcaPage.evaluate(async (agentCommand) => {
       await window.__store?.getState().updateSettings({
+        agentCmdOverrides: { codex: agentCommand },
         disabledTuiAgents: [],
         terminalHiddenViewParking: false
       })
-    })
+    }, completedWorkerFakeCodexCommand)
 
     const userDataDir = await electronApp.evaluate(({ app }) => app.getPath('userData'))
     const isolatedHome = await electronApp.evaluate(({ app }) => app.getPath('home'))

--- a/tests/e2e/helpers/completed-worker-retirement-fixture.ts
+++ b/tests/e2e/helpers/completed-worker-retirement-fixture.ts
@@ -19,6 +19,10 @@ import type {
 
 const fakeCliDir = mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-retired-worker-'))
 const lifecycleLedgerPath = path.join(fakeCliDir, 'codex-lifecycle.jsonl')
+export const completedWorkerFakeCodexCommand = path.join(
+  fakeCliDir,
+  process.platform === 'win32' ? 'codex.cmd' : 'codex'
+)
 const fakeCodexSource = `
 const { appendFileSync } = require('node:fs')
 const ledger = process.env.ORCA_E2E_CODEX_LIFECYCLE_LEDGER
@@ -30,15 +34,24 @@ if (args.includes('app-server')) {
 }
 append({ event: 'spawn', args })
 process.stdout.write('\\u001b]0;Codex Ready\\u0007OpenAI Codex\\nmodel: e2e\\ndirectory: e2e\\n')
+let pasteEnded = false
 process.stdin.on('data', (chunk) => {
   const input = chunk.toString()
+  if (input.includes('\\x1b[201~')) {
+    pasteEnded = true
+    process.stdout.write('\\x1b[?25h')
+  }
   append({ event: 'input', input })
   if (input.includes('ORCA_E2E_EXIT_AFTER_DONE')) {
     append({ event: 'normal-exit' })
     process.exit(0)
   }
-  if (input.includes('\\r')) process.stdout.write('ACK\\n')
+  if (pasteEnded && input.includes('\\r')) {
+    process.stdout.write('\\u001b]0;Codex Working\\u0007ACK\\n')
+    setTimeout(() => process.stdout.write('\\u001b]0;Codex Ready\\u0007'), 10)
+  }
 })
+process.stdin.setRawMode?.(true)
 process.stdin.resume()
 setInterval(() => {}, 60_000)
 `

--- a/tests/e2e/helpers/completed-worker-retirement-fixture.ts
+++ b/tests/e2e/helpers/completed-worker-retirement-fixture.ts
@@ -16,12 +16,13 @@ import type {
   RuntimeTerminalListResult,
   RuntimeTerminalSummary
 } from '../../../src/shared/runtime-types'
+import { buildFakeAgentCommandOverride } from './fake-agent-command-override'
+import { FAKE_AGENT_PASTE_END_SCANNER_SOURCE } from './fake-agent-paste-end-scanner'
 
 const fakeCliDir = mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-retired-worker-'))
 const lifecycleLedgerPath = path.join(fakeCliDir, 'codex-lifecycle.jsonl')
-export const completedWorkerFakeCodexCommand = path.join(
-  fakeCliDir,
-  process.platform === 'win32' ? 'codex.cmd' : 'codex'
+export const completedWorkerFakeCodexCommand = buildFakeAgentCommandOverride(
+  path.join(fakeCliDir, process.platform === 'win32' ? 'codex.cmd' : 'codex')
 )
 const fakeCodexSource = `
 const { appendFileSync } = require('node:fs')
@@ -34,10 +35,13 @@ if (args.includes('app-server')) {
 }
 append({ event: 'spawn', args })
 process.stdout.write('\\u001b]0;Codex Ready\\u0007OpenAI Codex\\nmodel: e2e\\ndirectory: e2e\\n')
+${FAKE_AGENT_PASTE_END_SCANNER_SOURCE}
 let pasteEnded = false
 process.stdin.on('data', (chunk) => {
   const input = chunk.toString()
-  if (input.includes('\\x1b[201~')) {
+  const pasteEndScan = scanFakeAgentPasteEnd(fakeAgentPasteEndTail, input)
+  fakeAgentPasteEndTail = pasteEndScan.tail
+  if (pasteEndScan.ended) {
     pasteEnded = true
     process.stdout.write('\\x1b[?25h')
   }

--- a/tests/e2e/helpers/fake-agent-command-override.ts
+++ b/tests/e2e/helpers/fake-agent-command-override.ts
@@ -1,0 +1,10 @@
+import { quoteStartupArg } from '../../../src/shared/tui-agent-startup-shell'
+
+export function buildFakeAgentCommandOverride(
+  executablePath: string,
+  platform: NodeJS.Platform = process.platform
+): string {
+  const shell = platform === 'win32' ? 'powershell' : 'posix'
+  const quotedPath = quoteStartupArg(executablePath, shell)
+  return platform === 'win32' ? `& ${quotedPath}` : quotedPath
+}

--- a/tests/e2e/helpers/fake-agent-command-override.unit.test.ts
+++ b/tests/e2e/helpers/fake-agent-command-override.unit.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { buildFakeAgentCommandOverride } from './fake-agent-command-override'
+
+describe('buildFakeAgentCommandOverride', () => {
+  it('invokes a quoted Windows command path through PowerShell', () => {
+    expect(
+      buildFakeAgentCommandOverride("C:\\Users\\Jane Doe\\Temp\\fake agent's\\codex.cmd", 'win32')
+    ).toBe("& 'C:\\Users\\Jane Doe\\Temp\\fake agent''s\\codex.cmd'")
+  })
+
+  it('quotes a POSIX command path', () => {
+    expect(buildFakeAgentCommandOverride("/tmp/fake agent's/codex", 'darwin')).toBe(
+      "'/tmp/fake agent'\"'\"'s/codex'"
+    )
+  })
+})

--- a/tests/e2e/helpers/fake-agent-paste-end-scanner.ts
+++ b/tests/e2e/helpers/fake-agent-paste-end-scanner.ts
@@ -1,0 +1,15 @@
+export type FakeAgentPasteEndScan = { tail: string; ended: boolean }
+
+export function scanFakeAgentPasteEnd(tail: string, input: string): FakeAgentPasteEndScan {
+  const marker = '\x1b[201~'
+  const candidate = tail + input
+  return {
+    tail: candidate.slice(1 - marker.length),
+    ended: candidate.includes(marker)
+  }
+}
+
+export const FAKE_AGENT_PASTE_END_SCANNER_SOURCE = `
+const scanFakeAgentPasteEnd = ${scanFakeAgentPasteEnd.toString()}
+let fakeAgentPasteEndTail = ''
+`

--- a/tests/e2e/helpers/fake-agent-paste-end-scanner.unit.test.ts
+++ b/tests/e2e/helpers/fake-agent-paste-end-scanner.unit.test.ts
@@ -1,0 +1,39 @@
+import vm from 'node:vm'
+import { describe, expect, it } from 'vitest'
+import {
+  FAKE_AGENT_PASTE_END_SCANNER_SOURCE,
+  scanFakeAgentPasteEnd
+} from './fake-agent-paste-end-scanner'
+
+const PASTE_END = '\x1b[201~'
+
+describe('scanFakeAgentPasteEnd', () => {
+  it.each(Array.from({ length: PASTE_END.length - 1 }, (_, index) => index + 1))(
+    'recognizes a paste terminator split after byte %i',
+    (splitAt) => {
+      const first = scanFakeAgentPasteEnd('', PASTE_END.slice(0, splitAt))
+      const second = scanFakeAgentPasteEnd(first.tail, PASTE_END.slice(splitAt))
+
+      expect(first.ended).toBe(false)
+      expect(second.ended).toBe(true)
+    }
+  )
+
+  it('keeps only the possible marker prefix between chunks', () => {
+    const scan = scanFakeAgentPasteEnd('', `worker prompt${PASTE_END.slice(0, -1)}`)
+
+    expect(scan).toEqual({ tail: PASTE_END.slice(0, -1), ended: false })
+  })
+
+  it('emits standalone JavaScript for the fake agent process', () => {
+    const context = vm.createContext({ result: null })
+    vm.runInContext(
+      `${FAKE_AGENT_PASTE_END_SCANNER_SOURCE}
+       const first = scanFakeAgentPasteEnd('', '\\x1b[20')
+       result = scanFakeAgentPasteEnd(first.tail, '1~')`,
+      context
+    )
+
+    expect(context.result).toEqual({ tail: PASTE_END.slice(1), ended: true })
+  })
+})

--- a/tests/e2e/orchestration-legacy-worker-missing-terminal-recovery.spec.ts
+++ b/tests/e2e/orchestration-legacy-worker-missing-terminal-recovery.spec.ts
@@ -19,12 +19,16 @@ import Database from '../../src/main/sqlite/sync-database'
 import { LEGACY_CONTRACT_VERSION } from '../../src/main/runtime/orchestration/db'
 import { DEFAULT_LOCAL_ORCA_PROFILE_ID } from '../../src/shared/orca-profiles'
 import type { RuntimeTerminalListResult, RuntimeTerminalRead } from '../../src/shared/runtime-types'
+import { buildFakeAgentCommandOverride } from './helpers/fake-agent-command-override'
+import { FAKE_AGENT_PASTE_END_SCANNER_SOURCE } from './helpers/fake-agent-paste-end-scanner'
 
 const PROVIDER_SESSION_ID = 'e2e-missing-legacy-worker'
 const fakeCliDir = mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-missing-legacy-worker-'))
 const spawnLedgerPath = path.join(fakeCliDir, 'spawn.jsonl')
 const interruptionLedgerPath = path.join(fakeCliDir, 'interruption.jsonl')
-const fakeCodexCommand = path.join(fakeCliDir, process.platform === 'win32' ? 'codex.cmd' : 'codex')
+const fakeCodexCommand = buildFakeAgentCommandOverride(
+  path.join(fakeCliDir, process.platform === 'win32' ? 'codex.cmd' : 'codex')
+)
 const fakeCodexSource = `
 const { appendFileSync } = require('node:fs')
 function appendLedger(envName, event) {
@@ -41,10 +45,13 @@ if (process.argv.slice(2).includes('app-server')) {
 appendLedger('ORCA_E2E_SPAWN_LEDGER', { event: 'spawn' })
 process.stdout.write('\\u001b]0;Codex Ready\\u0007OpenAI Codex\\nmodel: e2e\\ndirectory: e2e\\n')
 let acknowledged = false
+${FAKE_AGENT_PASTE_END_SCANNER_SOURCE}
 let pasteEnded = false
 process.stdin.on('data', (chunk) => {
   const input = chunk.toString()
-  if (input.includes('\\x1b[201~')) {
+  const pasteEndScan = scanFakeAgentPasteEnd(fakeAgentPasteEndTail, input)
+  fakeAgentPasteEndTail = pasteEndScan.tail
+  if (pasteEndScan.ended) {
     pasteEnded = true
     process.stdout.write('\\x1b[?25h')
   }

--- a/tests/e2e/orchestration-legacy-worker-missing-terminal-recovery.spec.ts
+++ b/tests/e2e/orchestration-legacy-worker-missing-terminal-recovery.spec.ts
@@ -24,6 +24,7 @@ const PROVIDER_SESSION_ID = 'e2e-missing-legacy-worker'
 const fakeCliDir = mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-missing-legacy-worker-'))
 const spawnLedgerPath = path.join(fakeCliDir, 'spawn.jsonl')
 const interruptionLedgerPath = path.join(fakeCliDir, 'interruption.jsonl')
+const fakeCodexCommand = path.join(fakeCliDir, process.platform === 'win32' ? 'codex.cmd' : 'codex')
 const fakeCodexSource = `
 const { appendFileSync } = require('node:fs')
 function appendLedger(envName, event) {
@@ -40,16 +41,23 @@ if (process.argv.slice(2).includes('app-server')) {
 appendLedger('ORCA_E2E_SPAWN_LEDGER', { event: 'spawn' })
 process.stdout.write('\\u001b]0;Codex Ready\\u0007OpenAI Codex\\nmodel: e2e\\ndirectory: e2e\\n')
 let acknowledged = false
+let pasteEnded = false
 process.stdin.on('data', (chunk) => {
   const input = chunk.toString()
+  if (input.includes('\\x1b[201~')) {
+    pasteEnded = true
+    process.stdout.write('\\x1b[?25h')
+  }
   if (input.includes('\\x03')) {
     appendLedger('ORCA_E2E_INTERRUPTION_LEDGER', { event: 'stdin-ctrl-c' })
   }
-  if (!acknowledged && input.includes('\\r')) {
+  if (!acknowledged && pasteEnded && input.includes('\\r')) {
     acknowledged = true
-    process.stdout.write('ACK\\n')
+    process.stdout.write('\\u001b]0;Codex Working\\u0007ACK\\n')
+    setTimeout(() => process.stdout.write('\\u001b]0;Codex Ready\\u0007'), 10)
   }
 })
+process.stdin.setRawMode?.(true)
 for (const signal of ['SIGINT', 'SIGHUP', 'SIGTERM']) {
   process.on(signal, () => {
     appendLedger('ORCA_E2E_INTERRUPTION_LEDGER', { event: 'signal', signal })
@@ -200,6 +208,11 @@ test('a missing legacy worker cannot spawn a replacement during restart recovery
     firstApp = first.app
     const worktreeId = await attachRepoAndOpenTerminal(first.page, repoPath)
     await waitForSessionReady(first.page)
+    await first.page.evaluate(async (agentCommand) => {
+      await window.__store?.getState().updateSettings({
+        agentCmdOverrides: { codex: agentCommand }
+      })
+    }, fakeCodexCommand)
     await ensureTerminalVisible(first.page)
     await getActiveTabId(first.page)
     await waitForActivePanePtyId(first.page)

--- a/tests/e2e/orchestration-legacy-worker-restart-recovery.spec.ts
+++ b/tests/e2e/orchestration-legacy-worker-restart-recovery.spec.ts
@@ -31,6 +31,7 @@ const spawnLedgerPath = path.join(fakeCliDir, 'spawn.jsonl')
 const interruptionLedgerPath = path.join(fakeCliDir, 'interruption.jsonl')
 const authorityLedgerPath = path.join(fakeCliDir, 'authority.jsonl')
 const lifecycleLedgerPath = path.join(fakeCliDir, 'lifecycle.jsonl')
+const fakeCodexCommand = path.join(fakeCliDir, process.platform === 'win32' ? 'codex.cmd' : 'codex')
 const fakeCodexSource = `
 const { appendFileSync } = require('node:fs')
 const { spawnSync } = require('node:child_process')
@@ -83,14 +84,20 @@ process.stdout.write('\\u001b]0;Codex Ready\\u0007OpenAI Codex\\nmodel: e2e\\ndi
 void emitAuthorityHook()
 let acknowledged = false
 let lifecycleSent = false
+let pasteEnded = false
 process.stdin.on('data', (chunk) => {
   const input = chunk.toString()
+  if (input.includes('\\x1b[201~')) {
+    pasteEnded = true
+    process.stdout.write('\\x1b[?25h')
+  }
   if (input.includes('\\x03')) {
     appendLedger('ORCA_E2E_INTERRUPTION_LEDGER', { event: 'stdin-ctrl-c' })
   }
-  if (!acknowledged && input.includes('\\r')) {
+  if (!acknowledged && pasteEnded && input.includes('\\r')) {
     acknowledged = true
-    process.stdout.write('ACK\\n')
+    process.stdout.write('\\u001b]0;Codex Working\\u0007ACK\\n')
+    setTimeout(() => process.stdout.write('\\u001b]0;Codex Ready\\u0007'), 10)
   }
   const legacyCompletion = input.match(/ORCA_E2E_RUN_LEGACY_DONE:([A-Za-z0-9+/=]+)/)
   if (!lifecycleSent && legacyCompletion) {
@@ -132,6 +139,7 @@ process.stdin.on('data', (chunk) => {
     process.stdout.write(String(result.stdout || '') + String(result.stderr || ''))
   }
 })
+process.stdin.setRawMode?.(true)
 for (const signal of ['SIGINT', 'SIGHUP', 'SIGTERM']) {
   process.on(signal, () => {
     appendLedger('ORCA_E2E_INTERRUPTION_LEDGER', { event: 'signal', signal })
@@ -414,6 +422,11 @@ for (const contractVersion of [LEGACY_CONTRACT_VERSION, CURRENT_CONTRACT_VERSION
       firstApp = first.app
       const worktreeId = await attachRepoAndOpenTerminal(first.page, repoPath)
       await waitForSessionReady(first.page)
+      await first.page.evaluate(async (agentCommand) => {
+        await window.__store?.getState().updateSettings({
+          agentCmdOverrides: { codex: agentCommand }
+        })
+      }, fakeCodexCommand)
       await ensureTerminalVisible(first.page)
       const coordinatorTabId = await getActiveTabId(first.page)
       expect(coordinatorTabId).toBeTruthy()

--- a/tests/e2e/orchestration-legacy-worker-restart-recovery.spec.ts
+++ b/tests/e2e/orchestration-legacy-worker-restart-recovery.spec.ts
@@ -24,6 +24,8 @@ import {
 import { DEFAULT_LOCAL_ORCA_PROFILE_ID } from '../../src/shared/orca-profiles'
 import type { RuntimeTerminalListResult, RuntimeTerminalRead } from '../../src/shared/runtime-types'
 import { listAllOrchestrationRuns } from './orchestration-run-pages'
+import { buildFakeAgentCommandOverride } from './helpers/fake-agent-command-override'
+import { FAKE_AGENT_PASTE_END_SCANNER_SOURCE } from './helpers/fake-agent-paste-end-scanner'
 
 const PROVIDER_SESSION_ID = 'e2e-legacy-orchestration-worker'
 const fakeCliDir = mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-legacy-worker-'))
@@ -31,7 +33,9 @@ const spawnLedgerPath = path.join(fakeCliDir, 'spawn.jsonl')
 const interruptionLedgerPath = path.join(fakeCliDir, 'interruption.jsonl')
 const authorityLedgerPath = path.join(fakeCliDir, 'authority.jsonl')
 const lifecycleLedgerPath = path.join(fakeCliDir, 'lifecycle.jsonl')
-const fakeCodexCommand = path.join(fakeCliDir, process.platform === 'win32' ? 'codex.cmd' : 'codex')
+const fakeCodexCommand = buildFakeAgentCommandOverride(
+  path.join(fakeCliDir, process.platform === 'win32' ? 'codex.cmd' : 'codex')
+)
 const fakeCodexSource = `
 const { appendFileSync } = require('node:fs')
 const { spawnSync } = require('node:child_process')
@@ -84,10 +88,13 @@ process.stdout.write('\\u001b]0;Codex Ready\\u0007OpenAI Codex\\nmodel: e2e\\ndi
 void emitAuthorityHook()
 let acknowledged = false
 let lifecycleSent = false
+${FAKE_AGENT_PASTE_END_SCANNER_SOURCE}
 let pasteEnded = false
 process.stdin.on('data', (chunk) => {
   const input = chunk.toString()
-  if (input.includes('\\x1b[201~')) {
+  const pasteEndScan = scanFakeAgentPasteEnd(fakeAgentPasteEndTail, input)
+  fakeAgentPasteEndTail = pasteEndScan.tail
+  if (pasteEndScan.ended) {
     pasteEnded = true
     process.stdout.write('\\x1b[?25h')
   }

--- a/tests/e2e/orchestration-worker-settlement-release-cli.spec.ts
+++ b/tests/e2e/orchestration-worker-settlement-release-cli.spec.ts
@@ -12,18 +12,29 @@ import type { RuntimeTerminalListResult, RuntimeTerminalRead } from '../../src/s
 const fakeCliDir = mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-settlement-release-'))
 const cliLedgerPath = path.join(fakeCliDir, 'cli.jsonl')
 const cliEntry = path.join(process.cwd(), 'out', 'cli', 'index.js')
+const fakeCodexCommand = path.join(fakeCliDir, process.platform === 'win32' ? 'codex.cmd' : 'codex')
 const fakeCodexSource = `
 const { appendFileSync } = require('node:fs')
 const { spawnSync } = require('node:child_process')
+if (process.argv.slice(2).includes('app-server')) {
+  process.stderr.write("error: unrecognized subcommand 'app-server'\\n")
+  process.exit(2)
+}
 let capability = null
 let acknowledged = false
+let pasteEnded = false
 process.stdout.write('\\u001b]0;Codex Ready\\u0007OpenAI Codex\\nmodel: e2e\\ndirectory: e2e\\n')
 process.stdin.on('data', (chunk) => {
   const input = chunk.toString()
+  if (input.includes('\\x1b[201~')) {
+    pasteEnded = true
+    process.stdout.write('\\x1b[?25h')
+  }
   capability ||= input.match(/--dispatch-capability (dcap_[A-Za-z0-9_-]+)/)?.[1] || null
-  if (!acknowledged && input.includes('\\r')) {
+  if (!acknowledged && pasteEnded && input.includes('\\r')) {
     acknowledged = true
-    process.stdout.write('ACK\\n')
+    process.stdout.write('\\u001b]0;Codex Working\\u0007ACK\\n')
+    setTimeout(() => process.stdout.write('\\u001b]0;Codex Ready\\u0007'), 10)
   }
   const encoded = input.match(/ORCA_E2E_WORKER_DONE:([A-Za-z0-9+/=]+)/)?.[1]
   if (!encoded || !capability) return
@@ -50,6 +61,7 @@ process.stdin.on('data', (chunk) => {
     JSON.stringify({ mismatch: request.mismatch, args, status: result.status, stdout: result.stdout, stderr: result.stderr }) + '\\n'
   )
 })
+process.stdin.setRawMode?.(true)
 process.stdin.resume()
 setInterval(() => {}, 60_000)
 `
@@ -121,6 +133,11 @@ test('compiled CLI rejects false completion then reconciles the dead retained wo
   test.setTimeout(180_000)
   rmSync(cliLedgerPath, { force: true })
   await waitForSessionReady(orcaPage)
+  await orcaPage.evaluate(async (agentCommand) => {
+    await window.__store?.getState().updateSettings({
+      agentCmdOverrides: { codex: agentCommand }
+    })
+  }, fakeCodexCommand)
   const worktreeId = await waitForActiveWorktree(orcaPage)
   await ensureTerminalVisible(orcaPage)
   await waitForActivePanePtyId(orcaPage)

--- a/tests/e2e/orchestration-worker-settlement-release-cli.spec.ts
+++ b/tests/e2e/orchestration-worker-settlement-release-cli.spec.ts
@@ -8,11 +8,15 @@ import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } fro
 import { RuntimeClient } from '../../src/cli/runtime-client'
 import Database from '../../src/main/sqlite/sync-database'
 import type { RuntimeTerminalListResult, RuntimeTerminalRead } from '../../src/shared/runtime-types'
+import { buildFakeAgentCommandOverride } from './helpers/fake-agent-command-override'
+import { FAKE_AGENT_PASTE_END_SCANNER_SOURCE } from './helpers/fake-agent-paste-end-scanner'
 
 const fakeCliDir = mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-settlement-release-'))
 const cliLedgerPath = path.join(fakeCliDir, 'cli.jsonl')
 const cliEntry = path.join(process.cwd(), 'out', 'cli', 'index.js')
-const fakeCodexCommand = path.join(fakeCliDir, process.platform === 'win32' ? 'codex.cmd' : 'codex')
+const fakeCodexCommand = buildFakeAgentCommandOverride(
+  path.join(fakeCliDir, process.platform === 'win32' ? 'codex.cmd' : 'codex')
+)
 const fakeCodexSource = `
 const { appendFileSync } = require('node:fs')
 const { spawnSync } = require('node:child_process')
@@ -22,11 +26,14 @@ if (process.argv.slice(2).includes('app-server')) {
 }
 let capability = null
 let acknowledged = false
+${FAKE_AGENT_PASTE_END_SCANNER_SOURCE}
 let pasteEnded = false
 process.stdout.write('\\u001b]0;Codex Ready\\u0007OpenAI Codex\\nmodel: e2e\\ndirectory: e2e\\n')
 process.stdin.on('data', (chunk) => {
   const input = chunk.toString()
-  if (input.includes('\\x1b[201~')) {
+  const pasteEndScan = scanFakeAgentPasteEnd(fakeAgentPasteEndTail, input)
+  fakeAgentPasteEndTail = pasteEndScan.tail
+  if (pasteEndScan.ended) {
     pasteEnded = true
     process.stdout.write('\\x1b[?25h')
   }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​224 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​211 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​97 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​84 |

<!-- /orca-pr-loc -->

## ELI5

Two failures looked alike but had different causes.

After Orca adopts a still-running terminal, it can forget the readiness text it normally tracks even though the visible screen says Codex is ready. The runtime now takes one short, bounded screen snapshot only for that empty-metadata adoption case and classifies it with the existing blocked-first/ready-second rules.

The four STA-4907 E2Es were not exposing that product bug: their initial fresh workers accidentally launched the machine's real Codex instead of the fake fixture. The tests now select the fake executable explicitly and make it behave like a real TUI during paste and prompt submission.

## What Changed

### STA-4885 — product fix

- Added a deterministic legacy-worker reconciliation/adoption reproduction.
- After the normal waiter timeout is armed, an adopted PTY with no retained readiness evidence performs one 750 ms bounded `terminal.read` probe.
- Requires `source: screen`, then reuses the existing blocked-prompt classifier before the ready-prompt classifier.
- Fresh PTYs do not probe the provider snapshot; blocked trust screens remain blocked; hung providers honor the caller timeout and retire the cached acquisition so later reads stay responsive.

### STA-4907 — E2E fixture fix

- Pins each fake Codex executable via `agentCmdOverrides` using cross-platform paths (`codex` / `codex.cmd`).
- Runs the fake in raw TTY mode, acknowledges the bracketed-paste render boundary, and emits Codex working → ready title transitions so current prompt-delivery verification stays exercised.
- Rejects unsupported `app-server` probes in the settlement fixture.

## Root Cause and Boundary

STA-4885 belongs in runtime readiness classification: `terminal.read` already had provider-visible screen authority, while `tui-idle` only consulted empty retained metadata after adoption. One bounded fallback at that boundary fixes local/daemon-style adoption without a wire change, new opcode, new polling cadence, or process heuristic. SSH, folder workspaces, paired/remote runtimes, and mixed-version clients retain their existing contracts.

STA-4907 belongs in the tests. Historical run `32307133651` failed during each initial fresh `workerStart`, before any restart/adoption. Current main reproduced the same assertion failure because the fake was only prepended to `PATH`; shell startup could resolve the installed Codex v0.148 instead, whose sign-in screen produced `state=failed`, `stage=agent_readiness`, `codex-interactive-prompt`. No production classifier should treat an account prompt as ready.

The explicit fixture override overlaps the focused approach in #15432; this PR adds the current raw-TUI and working-lifecycle contract required by hardened prompt submission.

## Evidence

### STA-4885 baseline → candidate → revert

- Baseline: the adopted-worker reproduction proves `terminal.read` sees a Codex-ready provider screen while `tui-idle` times out.
- Candidate: the same lifecycle resolves ready.
- Fix-only revert with all regression tests retained: the same wait times out again.
- Controls: trust screen returns `codex-trust-workspace`; hung provider honors caller timeout and retires its cached acquisition; fresh PTY performs zero provider snapshot calls.

### STA-4907 baseline → candidate → revert

- Baseline on refreshed main: `completed-worker-retirement-resume.spec.ts` fails its initial `workerStart`; captured terminal is the real Codex v0.148 sign-in UI, not the fixture.
- Candidate: all four cited files pass, 6 tests total.
- Reverting only commit `825d9704fa` makes the focused test fail again at the initial `expect(started.result.state).toBe('ready')`.

## Testing

- [x] `pnpm exec vitest run src/main/runtime/orca-runtime.test.ts src/main/runtime/orca-runtime-terminal-close-continuity.test.ts src/main/runtime/terminal-interactive-wait-visibility.test.ts` — 1,228 passed, 1 skipped
- [x] `pnpm typecheck`
- [x] Focused oxlint and oxfmt checks
- [x] `completed-worker-retirement-resume.spec.ts` — 2 passed
- [x] Remaining three cited lifecycle specs — 4 passed
- [x] Candidate/revert evidence for both issues
- [x] Self-reviewed plus two independent gpt-5.6-luna reviews; one validated provider-cache finding fixed in `01bcec3155`

## Linked Issues

Fixes #15523

- https://linear.app/stably/issue/STA-4885
- https://linear.app/stably/issue/STA-4907
- Related fixture draft: #15432
- Related runtime draft: #15562

## Visual Proof

N/A — this changes main-process readiness semantics and headless E2E fixtures, with no UI layout or styling change.

## Agent skill upstream boundary

- [x] Not applicable; this change copies or mechanically translates no upstream skill-installer source.
