### PR TITLE
fix(automations): keep completed run sessions visible

### DIFF
--- a/src/main/ipc/pty-runtime-kill-and-exit.test.ts
+++ b/src/main/ipc/pty-runtime-kill-and-exit.test.ts
@@ -163,6 +163,12 @@ describe('registerPtyHandlers', () => {
     deletePtyOwnership('missing-pty')
   })
   it('rethrows non-not-found local provider shutdown failures', async () => {
+    const runtime = {
+      setPtyController: vi.fn(),
+      markPtyStopRequested: vi.fn(),
+      markPtyHistoryPreservingStopRequested: vi.fn(),
+      clearPtyHistoryPreservingStopRequested: vi.fn()
+    }
     setLocalPtyProvider({
       spawn: vi.fn(),
       write: vi.fn(),
@@ -186,11 +192,13 @@ describe('registerPtyHandlers', () => {
       getProfiles: vi.fn()
     } as never)
     handlers.clear()
-    registerPtyHandlers(mainWindow as never)
+    registerPtyHandlers(mainWindow as never, runtime as never)
 
-    await expect(handlers.get('pty:kill')!(null, { id: 'local-pty' })).rejects.toThrow(
-      'daemon unavailable'
-    )
+    await expect(
+      handlers.get('pty:kill')!(null, { id: 'local-pty', keepHistory: true })
+    ).rejects.toThrow('daemon unavailable')
+    expect(runtime.markPtyHistoryPreservingStopRequested).toHaveBeenCalledWith('local-pty')
+    expect(runtime.clearPtyHistoryPreservingStopRequested).toHaveBeenCalledWith('local-pty')
   })
   it('rejects runtime terminal IDs before unowned local provider routing', async () => {
     const shutdown = vi.spyOn(getLocalPtyProvider(), 'shutdown')
@@ -206,7 +214,9 @@ describe('registerPtyHandlers', () => {
     const shutdown = vi.fn(async () => undefined)
     const runtime = {
       setPtyController: vi.fn(),
-      onPtyExit: vi.fn()
+      onPtyExit: vi.fn(),
+      markPtyHistoryPreservingStopRequested: vi.fn(),
+      clearPtyHistoryPreservingStopRequested: vi.fn()
     }
     setLocalPtyProvider({
       spawn: vi.fn(),
@@ -240,6 +250,14 @@ describe('registerPtyHandlers', () => {
       keepHistory: true
     })
     expect(runtime.onPtyExit).toHaveBeenCalledWith('local-pty', -1, undefined)
+    expect(runtime.markPtyHistoryPreservingStopRequested).toHaveBeenCalledWith('local-pty')
+    expect(runtime.clearPtyHistoryPreservingStopRequested).toHaveBeenCalledWith('local-pty')
+    expect(runtime.markPtyHistoryPreservingStopRequested.mock.invocationCallOrder[0]).toBeLessThan(
+      runtime.onPtyExit.mock.invocationCallOrder[0]!
+    )
+    expect(runtime.onPtyExit.mock.invocationCallOrder[0]).toBeLessThan(
+      runtime.clearPtyHistoryPreservingStopRequested.mock.invocationCallOrder[0]!
+    )
     expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:exit', {
       id: 'local-pty',
       code: -1

--- a/src/main/ipc/pty-runtime-kill-and-exit.test.ts
+++ b/src/main/ipc/pty-runtime-kill-and-exit.test.ts
@@ -166,7 +166,8 @@ describe('registerPtyHandlers', () => {
     const runtime = {
       setPtyController: vi.fn(),
       markPtyStopRequested: vi.fn(),
-      markPtyHistoryPreservingStopRequested: vi.fn(),
+      markPtyHistoryPreservingStopRequested: vi.fn(() => 1),
+      preservePtyHistoryThroughLateExit: vi.fn(),
       clearPtyHistoryPreservingStopRequested: vi.fn()
     }
     setLocalPtyProvider({
@@ -198,7 +199,8 @@ describe('registerPtyHandlers', () => {
       handlers.get('pty:kill')!(null, { id: 'local-pty', keepHistory: true })
     ).rejects.toThrow('daemon unavailable')
     expect(runtime.markPtyHistoryPreservingStopRequested).toHaveBeenCalledWith('local-pty')
-    expect(runtime.clearPtyHistoryPreservingStopRequested).toHaveBeenCalledWith('local-pty')
+    expect(runtime.preservePtyHistoryThroughLateExit).toHaveBeenCalledWith('local-pty', 1)
+    expect(runtime.clearPtyHistoryPreservingStopRequested).not.toHaveBeenCalled()
   })
   it('rejects runtime terminal IDs before unowned local provider routing', async () => {
     const shutdown = vi.spyOn(getLocalPtyProvider(), 'shutdown')
@@ -215,7 +217,7 @@ describe('registerPtyHandlers', () => {
     const runtime = {
       setPtyController: vi.fn(),
       onPtyExit: vi.fn(),
-      markPtyHistoryPreservingStopRequested: vi.fn(),
+      markPtyHistoryPreservingStopRequested: vi.fn(() => 1),
       clearPtyHistoryPreservingStopRequested: vi.fn()
     }
     setLocalPtyProvider({
@@ -251,7 +253,7 @@ describe('registerPtyHandlers', () => {
     })
     expect(runtime.onPtyExit).toHaveBeenCalledWith('local-pty', -1, undefined)
     expect(runtime.markPtyHistoryPreservingStopRequested).toHaveBeenCalledWith('local-pty')
-    expect(runtime.clearPtyHistoryPreservingStopRequested).toHaveBeenCalledWith('local-pty')
+    expect(runtime.clearPtyHistoryPreservingStopRequested).toHaveBeenCalledWith('local-pty', 1)
     expect(runtime.markPtyHistoryPreservingStopRequested.mock.invocationCallOrder[0]).toBeLessThan(
       runtime.onPtyExit.mock.invocationCallOrder[0]!
     )

--- a/src/main/ipc/pty-runtime-kill-and-exit.test.ts
+++ b/src/main/ipc/pty-runtime-kill-and-exit.test.ts
@@ -357,6 +357,30 @@ describe('registerPtyHandlers', () => {
       [['pty:exit', { id: 'local-pty', code: -1 }]]
     )
   })
+  it('retains an SSH history lease after a synthetic exit until the host exit arrives', async () => {
+    const runtime = {
+      setPtyController: vi.fn(),
+      markPtyHistoryPreservingStopRequested: vi.fn(() => 1),
+      preservePtyHistoryThroughLateExit: vi.fn(),
+      clearPtyHistoryPreservingStopRequested: vi.fn(),
+      markPtyStopRequested: vi.fn(),
+      onPtyExit: vi.fn()
+    }
+    registerSshPtyProvider('ssh-history', {
+      shutdown: vi.fn(async () => undefined),
+      onExit: vi.fn(() => () => {})
+    } as never)
+    setPtyOwnership('ssh-history-pty', 'ssh-history')
+    handlers.clear()
+    registerPtyHandlers(mainWindow as never, runtime as never)
+
+    await handlers.get('pty:kill')!(null, { id: 'ssh-history-pty', keepHistory: true })
+
+    expect(runtime.onPtyExit).toHaveBeenCalledWith('ssh-history-pty', -1, undefined)
+    expect(runtime.preservePtyHistoryThroughLateExit).toHaveBeenCalledWith('ssh-history-pty', 1)
+    expect(runtime.clearPtyHistoryPreservingStopRequested).not.toHaveBeenCalled()
+    deletePtyOwnership('ssh-history-pty')
+  })
   it('waits for the desktop startup barrier before renderer local spawns resolve the provider', async () => {
     const barrier = makeDeferred()
     registerPtyHandlers(

--- a/src/main/ipc/pty-runtime-kill-and-exit.test.ts
+++ b/src/main/ipc/pty-runtime-kill-and-exit.test.ts
@@ -357,6 +357,71 @@ describe('registerPtyHandlers', () => {
       [['pty:exit', { id: 'local-pty', code: -1 }]]
     )
   })
+  it('does not let a delayed kill clear a same-id legacy replacement', async () => {
+    const shutdown = makeDeferred()
+    const daemon = installObservableDaemonTestProvider()
+    daemon.spawn.mockImplementation(async (options: { sessionId?: string }) => ({
+      id: options.sessionId ?? 'daemon-pty'
+    }))
+    daemon.shutdown.mockImplementation(() => shutdown.promise)
+    const runtime = {
+      setPtyController: vi.fn(),
+      markPtyStopRequested: vi.fn(() => 42),
+      clearPtyStopRequested: vi.fn()
+    }
+    handlers.clear()
+    registerPtyHandlers(mainWindow as never)
+
+    const spawnArgs = { cols: 80, rows: 24, sessionId: 'reused-pty' }
+    await handlers.get('pty:spawn')!(null, spawnArgs)
+    handlers.clear()
+    registerPtyHandlers(mainWindow as never, runtime as never)
+    const pendingKill = handlers.get('pty:kill')!(null, { id: 'reused-pty' }) as Promise<void>
+    await vi.waitFor(() => expect(daemon.shutdown).toHaveBeenCalledOnce())
+    handlers.clear()
+    registerPtyHandlers(mainWindow as never)
+    await handlers.get('pty:spawn')!(null, spawnArgs)
+
+    shutdown.resolve()
+    await pendingKill
+
+    expect(
+      mainWindow.webContents.send.mock.calls.filter(
+        (call) => call[0] === 'pty:exit' && call[1]?.id === 'reused-pty'
+      )
+    ).toEqual([])
+    expect(runtime.clearPtyStopRequested).toHaveBeenCalledWith('reused-pty', 42)
+  })
+  it('fences a delayed kill from a same-id legacy SSH reattachment', async () => {
+    const shutdown = makeDeferred()
+    const runtime = {
+      setPtyController: vi.fn(),
+      markPtyStopRequested: vi.fn(() => 43),
+      clearPtyStopRequested: vi.fn(),
+      onPtyExit: vi.fn()
+    }
+    registerSshPtyProvider('ssh-legacy', {
+      shutdown: vi.fn(() => shutdown.promise),
+      onExit: vi.fn(() => () => {})
+    } as never)
+    setPtyOwnership('legacy-pty', 'ssh-legacy')
+    handlers.clear()
+    registerPtyHandlers(mainWindow as never, runtime as never)
+
+    const pendingKill = handlers.get('pty:kill')!(null, { id: 'legacy-pty' }) as Promise<void>
+    setPtyOwnership('legacy-pty', 'ssh-legacy')
+    shutdown.resolve()
+    await pendingKill
+
+    expect(runtime.onPtyExit).not.toHaveBeenCalled()
+    expect(runtime.clearPtyStopRequested).toHaveBeenCalledWith('legacy-pty', 43)
+    expect(
+      mainWindow.webContents.send.mock.calls.filter(
+        (call) => call[0] === 'pty:exit' && call[1]?.id === 'legacy-pty'
+      )
+    ).toEqual([])
+    deletePtyOwnership('legacy-pty')
+  })
   it('retains an SSH history lease after a synthetic exit until the host exit arrives', async () => {
     const runtime = {
       setPtyController: vi.fn(),

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -253,6 +253,13 @@ import type { PtyListedSession } from '../../shared/pty-listed-session'
 let localProvider: IPtyProvider = new LocalPtyProvider()
 const sshProviders = new Map<string, IPtyProvider>()
 const sshProvidersByGeneration = new Map<number, IPtyProvider>()
+// Why: legacy providers omit incarnation IDs, so delayed teardown needs a local replacement fence.
+const ptyAdmissionGenerationById = new Map<string, number>()
+let nextPtyAdmissionGeneration = 1
+
+function recordPtyAdmission(id: string): void {
+  ptyAdmissionGenerationById.set(id, nextPtyAdmissionGeneration++)
+}
 
 type RegisteredPtyProvider = {
   provider: IPtyProvider
@@ -2117,6 +2124,7 @@ export function clearProviderPtyState(
   id: string,
   opts: { preserveAgentSessionOwners?: boolean } = {}
 ): void {
+  ptyAdmissionGenerationById.delete(id)
   if (!opts.preserveAgentSessionOwners) {
     agentSessionOwners.release(id)
     // Why: the launch-account record outlives the app, so only a real teardown
@@ -2192,9 +2200,11 @@ export function clearProviderPtyState(
 
 export function deletePtyOwnership(id: string): void {
   ptyOwnership.delete(id)
+  ptyAdmissionGenerationById.delete(id)
 }
 
 export function setPtyOwnership(id: string, connectionId: string | null): void {
+  recordPtyAdmission(id)
   ptyOwnership.set(id, connectionId)
 }
 
@@ -5275,6 +5285,7 @@ export function registerPtyHandlers(
         }
         if (result.agentSessionEnsure?.disposition === 'adopted') {
           const owner = result.agentSessionEnsure.owner
+          recordPtyAdmission(result.id)
           ptyOwnership.set(result.id, args.connectionId ?? ptyOwnership.get(result.id) ?? null)
           runtime?.registerPreAllocatedHandleForPty(result.id, owner.surface.terminalHandle)
           if (result.incarnationId) {
@@ -5302,6 +5313,7 @@ export function registerPtyHandlers(
             agentSessionEnsure: result.agentSessionEnsure
           }
         }
+        recordPtyAdmission(result.id)
         ptyOwnership.set(result.id, args.connectionId ?? null)
         if (result.incarnationId) {
           ptyIncarnationById.set(result.id, result.incarnationId)
@@ -6915,6 +6927,7 @@ export function registerPtyHandlers(
           target: codexSelectionTarget,
           settings: getSettings?.()
         })
+        recordPtyAdmission(result.id)
         ptyOwnership.set(result.id, args.connectionId ?? null)
         if (result.incarnationId) {
           ptyIncarnationById.set(result.id, result.incarnationId)
@@ -7723,7 +7736,12 @@ export function registerPtyHandlers(
       // Why: runtime terminal handles belong to terminal.close; unowned PTY routing could target the local provider.
       throw new Error('Invalid PTY provider id')
     }
-    runtime?.markPtyStopRequested?.(args.id)
+    const expectedIncarnationId = ptyIncarnationById.get(args.id)
+    const expectedAdmissionGeneration = ptyAdmissionGenerationById.get(args.id)
+    const stopRequestId = runtime?.markPtyStopRequested?.(args.id)
+    const ptyIdentityChanged = (): boolean =>
+      ptyIncarnationById.get(args.id) !== expectedIncarnationId ||
+      ptyAdmissionGenerationById.get(args.id) !== expectedAdmissionGeneration
     let historyPreservingStopId = args.keepHistory
       ? runtime?.markPtyHistoryPreservingStopRequested(args.id)
       : undefined
@@ -7741,6 +7759,12 @@ export function registerPtyHandlers(
         // Why: detached SSH PTYs intentionally keep ownership after their
         // provider is unregistered; hydrated app-scoped ids can also arrive
         // before ownership is rebuilt. Tombstone instead of falling back local.
+        if (ptyIdentityChanged()) {
+          if (stopRequestId !== undefined) {
+            runtime?.clearPtyStopRequested(args.id, stopRequestId)
+          }
+          return
+        }
         const incarnationId = finishPtyShutdown(args.id, connectionId, store)
         runtime?.markPtyLivenessUnverifiable?.(args.id, SSH_PROVIDER_UNREGISTERED_REASON)
         runtime?.onPtyExit(args.id, -1, incarnationId)
@@ -7779,6 +7803,12 @@ export function registerPtyHandlers(
       }
       // Why: some shutdown paths do not emit onExit through the provider listener.
       // Explicit cleanup is idempotent and covers already-dead PTYs.
+      if (ptyIdentityChanged()) {
+        if (stopRequestId !== undefined) {
+          runtime?.clearPtyStopRequested(args.id, stopRequestId)
+        }
+        return
+      }
       const incarnationId = finishPtyShutdown(args.id, connectionId, store)
       if (!providerExitObserved) {
         runtime?.onPtyExit(args.id, -1, incarnationId)

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -7746,6 +7746,10 @@ export function registerPtyHandlers(
         runtime?.onPtyExit(args.id, -1, incarnationId)
         rememberSyntheticKillExit(args.id)
         sendPtyExitToRenderer({ id: args.id, code: -1 })
+        if (historyPreservingStopId !== undefined) {
+          runtime?.preservePtyHistoryThroughLateExit(args.id, historyPreservingStopId)
+          historyPreservingStopId = undefined
+        }
         return
       }
       const shutdownProvider = provider ?? getProviderForPty(args.id)
@@ -7780,6 +7784,10 @@ export function registerPtyHandlers(
         runtime?.onPtyExit(args.id, -1, incarnationId)
         rememberSyntheticKillExit(args.id)
         sendPtyExitToRenderer({ id: args.id, code: -1 })
+        if (connectionId && historyPreservingStopId !== undefined) {
+          runtime?.preservePtyHistoryThroughLateExit(args.id, historyPreservingStopId)
+          historyPreservingStopId = undefined
+        }
       }
     } finally {
       if (historyPreservingStopId !== undefined) {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -4033,7 +4033,8 @@ export function registerPtyHandlers(
   async function shutdownProviderAndDetectExit(
     provider: IPtyProvider,
     id: string,
-    opts: { immediate?: boolean; keepHistory?: boolean; deadlineMs?: number }
+    opts: { immediate?: boolean; keepHistory?: boolean; deadlineMs?: number },
+    onExitObserved?: () => void
   ): Promise<boolean> {
     let providerExitObserved = false
     const expectedIncarnationId = ptyIncarnationById.get(id)
@@ -4043,6 +4044,7 @@ export function registerPtyHandlers(
         (!expectedIncarnationId || payload.incarnationId === expectedIncarnationId)
       ) {
         providerExitObserved = true
+        onExitObserved?.()
       }
     })
     try {
@@ -7722,9 +7724,9 @@ export function registerPtyHandlers(
       throw new Error('Invalid PTY provider id')
     }
     runtime?.markPtyStopRequested?.(args.id)
-    if (args.keepHistory) {
-      runtime?.markPtyHistoryPreservingStopRequested(args.id)
-    }
+    let historyPreservingStopId = args.keepHistory
+      ? runtime?.markPtyHistoryPreservingStopRequested(args.id)
+      : undefined
     try {
       const ownedConnectionId = ptyOwnership.get(args.id)
       const parsedSshId = ownedConnectionId === undefined ? parseAppSshPtyId(args.id) : null
@@ -7749,13 +7751,24 @@ export function registerPtyHandlers(
       const shutdownProvider = provider ?? getProviderForPty(args.id)
       let providerExitObserved = false
       try {
-        providerExitObserved = await shutdownProviderAndDetectExit(shutdownProvider, args.id, {
-          immediate: true,
-          keepHistory: args.keepHistory ?? false
-        })
+        providerExitObserved = await shutdownProviderAndDetectExit(
+          shutdownProvider,
+          args.id,
+          {
+            immediate: true,
+            keepHistory: args.keepHistory ?? false
+          },
+          () => {
+            providerExitObserved = true
+          }
+        )
       } catch (err) {
         if (!isPtyAlreadyGoneError(err)) {
           // Why: a failed shutdown can leave the process alive (SSH relay grace window / local daemon); keep ownership/lease state so the user can retry.
+          if (historyPreservingStopId !== undefined && !providerExitObserved) {
+            runtime?.preservePtyHistoryThroughLateExit(args.id, historyPreservingStopId)
+            historyPreservingStopId = undefined
+          }
           throw err
         }
         /* session already dead — cleanup below handles the rest */
@@ -7769,8 +7782,8 @@ export function registerPtyHandlers(
         sendPtyExitToRenderer({ id: args.id, code: -1 })
       }
     } finally {
-      if (args.keepHistory) {
-        runtime?.clearPtyHistoryPreservingStopRequested(args.id)
+      if (historyPreservingStopId !== undefined) {
+        runtime?.clearPtyHistoryPreservingStopRequested(args.id, historyPreservingStopId)
       }
     }
   })

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -7722,47 +7722,56 @@ export function registerPtyHandlers(
       throw new Error('Invalid PTY provider id')
     }
     runtime?.markPtyStopRequested?.(args.id)
-    const ownedConnectionId = ptyOwnership.get(args.id)
-    const parsedSshId = ownedConnectionId === undefined ? parseAppSshPtyId(args.id) : null
-    const connectionId = ownedConnectionId ?? parsedSshId?.connectionId
-    // Why: wait for daemon startup before selecting the local provider, else a fallback shutdown falsely succeeds and orphans a restored daemon PTY (#7742).
-    const startupPromise = getLocalPtyProviderStartupPromise(connectionId)
-    if (startupPromise) {
-      await startupPromise
+    if (args.keepHistory) {
+      runtime?.markPtyHistoryPreservingStopRequested(args.id)
     }
-    const provider = connectionId ? sshProviders.get(connectionId) : tryGetProviderForPty(args.id)
-    if (!provider && connectionId) {
-      // Why: detached SSH PTYs intentionally keep ownership after their
-      // provider is unregistered; hydrated app-scoped ids can also arrive
-      // before ownership is rebuilt. Tombstone instead of falling back local.
-      const incarnationId = finishPtyShutdown(args.id, connectionId, store)
-      runtime?.markPtyLivenessUnverifiable?.(args.id, SSH_PROVIDER_UNREGISTERED_REASON)
-      runtime?.onPtyExit(args.id, -1, incarnationId)
-      rememberSyntheticKillExit(args.id)
-      sendPtyExitToRenderer({ id: args.id, code: -1 })
-      return
-    }
-    const shutdownProvider = provider ?? getProviderForPty(args.id)
-    let providerExitObserved = false
     try {
-      providerExitObserved = await shutdownProviderAndDetectExit(shutdownProvider, args.id, {
-        immediate: true,
-        keepHistory: args.keepHistory ?? false
-      })
-    } catch (err) {
-      if (!isPtyAlreadyGoneError(err)) {
-        // Why: a failed shutdown can leave the process alive (SSH relay grace window / local daemon); keep ownership/lease state so the user can retry.
-        throw err
+      const ownedConnectionId = ptyOwnership.get(args.id)
+      const parsedSshId = ownedConnectionId === undefined ? parseAppSshPtyId(args.id) : null
+      const connectionId = ownedConnectionId ?? parsedSshId?.connectionId
+      // Why: wait for daemon startup before selecting the local provider, else a fallback shutdown falsely succeeds and orphans a restored daemon PTY (#7742).
+      const startupPromise = getLocalPtyProviderStartupPromise(connectionId)
+      if (startupPromise) {
+        await startupPromise
       }
-      /* session already dead — cleanup below handles the rest */
-    }
-    // Why: some shutdown paths do not emit onExit through the provider listener.
-    // Explicit cleanup is idempotent and covers already-dead PTYs.
-    const incarnationId = finishPtyShutdown(args.id, connectionId, store)
-    if (!providerExitObserved) {
-      runtime?.onPtyExit(args.id, -1, incarnationId)
-      rememberSyntheticKillExit(args.id)
-      sendPtyExitToRenderer({ id: args.id, code: -1 })
+      const provider = connectionId ? sshProviders.get(connectionId) : tryGetProviderForPty(args.id)
+      if (!provider && connectionId) {
+        // Why: detached SSH PTYs intentionally keep ownership after their
+        // provider is unregistered; hydrated app-scoped ids can also arrive
+        // before ownership is rebuilt. Tombstone instead of falling back local.
+        const incarnationId = finishPtyShutdown(args.id, connectionId, store)
+        runtime?.markPtyLivenessUnverifiable?.(args.id, SSH_PROVIDER_UNREGISTERED_REASON)
+        runtime?.onPtyExit(args.id, -1, incarnationId)
+        rememberSyntheticKillExit(args.id)
+        sendPtyExitToRenderer({ id: args.id, code: -1 })
+        return
+      }
+      const shutdownProvider = provider ?? getProviderForPty(args.id)
+      let providerExitObserved = false
+      try {
+        providerExitObserved = await shutdownProviderAndDetectExit(shutdownProvider, args.id, {
+          immediate: true,
+          keepHistory: args.keepHistory ?? false
+        })
+      } catch (err) {
+        if (!isPtyAlreadyGoneError(err)) {
+          // Why: a failed shutdown can leave the process alive (SSH relay grace window / local daemon); keep ownership/lease state so the user can retry.
+          throw err
+        }
+        /* session already dead — cleanup below handles the rest */
+      }
+      // Why: some shutdown paths do not emit onExit through the provider listener.
+      // Explicit cleanup is idempotent and covers already-dead PTYs.
+      const incarnationId = finishPtyShutdown(args.id, connectionId, store)
+      if (!providerExitObserved) {
+        runtime?.onPtyExit(args.id, -1, incarnationId)
+        rememberSyntheticKillExit(args.id)
+        sendPtyExitToRenderer({ id: args.id, code: -1 })
+      }
+    } finally {
+      if (args.keepHistory) {
+        runtime?.clearPtyHistoryPreservingStopRequested(args.id)
+      }
     }
   })
 

--- a/src/main/runtime/exit-provenance-audit.test.ts
+++ b/src/main/runtime/exit-provenance-audit.test.ts
@@ -204,6 +204,23 @@ describe('STA-4603/STA-4536 exit provenance', () => {
     })
   })
 
+  it('clears only the matching stop request for overlapping stops', () => {
+    const db = createDb()
+    const runtime = createRuntime(db)
+    const firstRequest = runtime.markPtyStopRequested(PTY_ID)
+    const secondRequest = runtime.markPtyStopRequested(PTY_ID)
+
+    runtime.clearPtyStopRequested(PTY_ID, firstRequest)
+    expect(runtime.isPtyStopRequested(PTY_ID)).toBe(true)
+
+    runtime.clearPtyStopRequested(PTY_ID, secondRequest)
+    expect(runtime.isPtyStopRequested(PTY_ID)).toBe(false)
+
+    const ctx = dispatchOnHandle(db, 'replacement crashes naturally')
+    runtime.onPtyExit(PTY_ID, 0, undefined, { cause: { kind: 'signaled', signal: 9 } })
+    expect(observe(db, ctx.id).termination_reason).toBe('signaled')
+  })
+
   it('does not file an unconfirmed stop as a completed operator close', () => {
     const db = createDb()
     const runtime = createRuntime(db)

--- a/src/main/runtime/orca-runtime-terminal-retirement.test.ts
+++ b/src/main/runtime/orca-runtime-terminal-retirement.test.ts
@@ -470,6 +470,35 @@ describe('OrcaRuntimeService terminal surface retirement', () => {
     })
   })
 
+  it('preserves a surface while its history-preserving stop is in flight', async () => {
+    const session = makePersistedSplitSession()
+    const setWorkspaceSession = vi.fn()
+    const runtime = new OrcaRuntimeService(
+      runtimeStore({
+        getWorkspaceSession: () => session,
+        setWorkspaceSession,
+        flushOrThrow: vi.fn()
+      })
+    )
+    runtime.attachWindow(1)
+    syncSplit(runtime)
+    runtime.registerPty('pty-left', WORKTREE_ID, null, {
+      tabId: 'tab',
+      leafId: 'left',
+      incarnationId: 'incarnation-left'
+    })
+
+    runtime.markPtyHistoryPreservingStopRequested('pty-left')
+    runtime.onPtyExit('pty-left', 0, 'incarnation-left')
+    runtime.clearPtyHistoryPreservingStopRequested('pty-left')
+
+    expect((await runtime.listMobileSessionTabs(`id:${WORKTREE_ID}`)).tabs).toEqual([
+      expect.objectContaining({ id: 'tab::left' }),
+      expect.objectContaining({ id: 'tab::right' })
+    ])
+    expect(setWorkspaceSession).not.toHaveBeenCalled()
+  })
+
   it('ignores a delayed exit from an older incarnation of a reused PTY id', async () => {
     const setWorkspaceSession = vi.fn()
     const runtime = new OrcaRuntimeService(

--- a/src/main/runtime/orca-runtime-terminal-retirement.test.ts
+++ b/src/main/runtime/orca-runtime-terminal-retirement.test.ts
@@ -488,15 +488,80 @@ describe('OrcaRuntimeService terminal surface retirement', () => {
       incarnationId: 'incarnation-left'
     })
 
-    runtime.markPtyHistoryPreservingStopRequested('pty-left')
+    const stopRequestId = runtime.markPtyHistoryPreservingStopRequested('pty-left')
     runtime.onPtyExit('pty-left', 0, 'incarnation-left')
-    runtime.clearPtyHistoryPreservingStopRequested('pty-left')
+    runtime.clearPtyHistoryPreservingStopRequested('pty-left', stopRequestId)
 
     expect((await runtime.listMobileSessionTabs(`id:${WORKTREE_ID}`)).tabs).toEqual([
       expect.objectContaining({ id: 'tab::left' }),
       expect.objectContaining({ id: 'tab::right' })
     ])
     expect(setWorkspaceSession).not.toHaveBeenCalled()
+  })
+
+  it('preserves a surface until every overlapping history-preserving stop finishes', async () => {
+    const session = makePersistedSplitSession()
+    const setWorkspaceSession = vi.fn()
+    const runtime = new OrcaRuntimeService(
+      runtimeStore({
+        getWorkspaceSession: () => session,
+        setWorkspaceSession,
+        flushOrThrow: vi.fn()
+      })
+    )
+    runtime.attachWindow(1)
+    syncSplit(runtime)
+    runtime.registerPty('pty-left', WORKTREE_ID, null, {
+      tabId: 'tab',
+      leafId: 'left',
+      incarnationId: 'incarnation-left'
+    })
+
+    const firstStopRequestId = runtime.markPtyHistoryPreservingStopRequested('pty-left')
+    const secondStopRequestId = runtime.markPtyHistoryPreservingStopRequested('pty-left')
+    runtime.clearPtyHistoryPreservingStopRequested('pty-left', firstStopRequestId)
+    runtime.onPtyExit('pty-left', 0, 'incarnation-left')
+    runtime.clearPtyHistoryPreservingStopRequested('pty-left', secondStopRequestId)
+
+    expect((await runtime.listMobileSessionTabs(`id:${WORKTREE_ID}`)).tabs).toEqual([
+      expect.objectContaining({ id: 'tab::left' }),
+      expect.objectContaining({ id: 'tab::right' })
+    ])
+    expect(setWorkspaceSession).not.toHaveBeenCalled()
+  })
+
+  it('consumes a failed stop lease when its late exit arrives', async () => {
+    const session = makePersistedSplitSession()
+    const runtime = new OrcaRuntimeService(
+      runtimeStore({
+        getWorkspaceSession: () => session,
+        setWorkspaceSession: vi.fn(),
+        flushOrThrow: vi.fn()
+      })
+    )
+    runtime.attachWindow(1)
+    syncSplit(runtime)
+    runtime.registerPty('pty-left', WORKTREE_ID, null, {
+      tabId: 'tab',
+      leafId: 'left',
+      incarnationId: 'incarnation-left'
+    })
+
+    const stopRequestId = runtime.markPtyHistoryPreservingStopRequested('pty-left')
+    runtime.preservePtyHistoryThroughLateExit('pty-left', stopRequestId)
+    runtime.onPtyExit('pty-left', 0, 'incarnation-left')
+
+    expect((await runtime.listMobileSessionTabs(`id:${WORKTREE_ID}`)).tabs).toEqual([
+      expect.objectContaining({ id: 'tab::left' }),
+      expect.objectContaining({ id: 'tab::right' })
+    ])
+
+    runtime.onPtyExit('pty-left', 0, 'incarnation-left')
+    expect(
+      (await runtime.listMobileSessionTabs(`id:${WORKTREE_ID}`)).tabs.find(
+        (tab) => tab.id === 'tab::left'
+      )
+    ).toBeUndefined()
   })
 
   it('ignores a delayed exit from an older incarnation of a reused PTY id', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -3091,9 +3091,12 @@ export class OrcaRuntimeService {
   // Why: provider exit can beat surface registration; that exact dead incarnation must never publish.
   private earlyExitedPtyIncarnations = new Map<string, PtyIncarnationId | null>()
   private pendingPtyRegistrationIncarnations = new Map<string, PtyIncarnationId | null>()
-  // Why: exact-stop is the current sleep transaction boundary; its exit must
-  // leave the renderer's intentional sleeping surface available for wake.
-  private intentionalHandlelessPtyStops = new Map<string, string | null>()
+  // Why: every overlapping hibernation owns its lease until its stop settles.
+  private intentionalHandlelessPtyStops = new Map<
+    string,
+    Map<number, { incarnationId: string | null; awaitsLateExit: boolean }>
+  >()
+  private nextIntentionalHandlelessPtyStopId = 1
   // Why: coalesces title/status-driven session.tabs emits so spinner churn
   // doesn't fan out (and per-client JSON.stringify) a snapshot several times a
   // second. Emit reads the latest snapshot, so only the freshest version ships.
@@ -15217,10 +15220,27 @@ export class OrcaRuntimeService {
         exitIncarnationId ?? pendingIncarnation ?? pty?.incarnationId ?? null
       )
     }
-    const intentionalStopIncarnation = this.intentionalHandlelessPtyStops.get(ptyId)
+    const intentionalStops = this.intentionalHandlelessPtyStops.get(ptyId)
     const preservesIntentionalHandlelessSurface =
-      this.intentionalHandlelessPtyStops.has(ptyId) &&
-      (intentionalStopIncarnation === null || intentionalStopIncarnation === incarnationId)
+      intentionalStops !== undefined &&
+      [...intentionalStops.values()].some(
+        (intentionalStop) =>
+          intentionalStop.incarnationId === null || intentionalStop.incarnationId === incarnationId
+      )
+    if (intentionalStops) {
+      for (const [requestId, intentionalStop] of intentionalStops) {
+        if (
+          intentionalStop.awaitsLateExit &&
+          (intentionalStop.incarnationId === null ||
+            intentionalStop.incarnationId === incarnationId)
+        ) {
+          intentionalStops.delete(requestId)
+        }
+      }
+      if (intentionalStops.size === 0) {
+        this.intentionalHandlelessPtyStops.delete(ptyId)
+      }
+    }
     advertisedUrlWatcher.unbindPty(ptyId)
     // Clean up new mobile state for this PTY
     this.mobileSubscribers.delete(ptyId)
@@ -18211,12 +18231,32 @@ export class OrcaRuntimeService {
     this.stopRequestedPtyIds.add(ptyId)
   }
 
-  markPtyHistoryPreservingStopRequested(ptyId: string): void {
-    this.intentionalHandlelessPtyStops.set(ptyId, this.ptysById.get(ptyId)?.incarnationId ?? null)
+  markPtyHistoryPreservingStopRequested(ptyId: string): number {
+    const incarnationId = this.ptysById.get(ptyId)?.incarnationId ?? null
+    const requestId = this.nextIntentionalHandlelessPtyStopId
+    this.nextIntentionalHandlelessPtyStopId += 1
+    const requests = this.intentionalHandlelessPtyStops.get(ptyId) ?? new Map()
+    requests.set(requestId, { incarnationId, awaitsLateExit: false })
+    this.intentionalHandlelessPtyStops.set(ptyId, requests)
+    return requestId
   }
 
-  clearPtyHistoryPreservingStopRequested(ptyId: string): void {
-    this.intentionalHandlelessPtyStops.delete(ptyId)
+  preservePtyHistoryThroughLateExit(ptyId: string, requestId: number): void {
+    const request = this.intentionalHandlelessPtyStops.get(ptyId)?.get(requestId)
+    if (request) {
+      request.awaitsLateExit = true
+    }
+  }
+
+  clearPtyHistoryPreservingStopRequested(ptyId: string, requestId: number): void {
+    const requests = this.intentionalHandlelessPtyStops.get(ptyId)
+    if (!requests) {
+      return
+    }
+    requests.delete(requestId)
+    if (requests.size === 0) {
+      this.intentionalHandlelessPtyStops.delete(ptyId)
+    }
   }
 
   isPtyStopRequested(ptyId: string): boolean {
@@ -30798,15 +30838,17 @@ export class OrcaRuntimeService {
 
     const stoppedPtyIds: string[] = []
     for (const ptyId of [...expected].sort()) {
-      if (opts.keepHistory) {
-        this.markPtyHistoryPreservingStopRequested(ptyId)
-      }
+      const historyPreservingStopId = opts.keepHistory
+        ? this.markPtyHistoryPreservingStopRequested(ptyId)
+        : null
       try {
         if (!(await this.ptyController.stopAndWait(ptyId, { keepHistory: opts.keepHistory }))) {
           throw Object.assign(new Error('terminal_exact_stop_failed'), { ptyId })
         }
       } finally {
-        this.clearPtyHistoryPreservingStopRequested(ptyId)
+        if (historyPreservingStopId !== null) {
+          this.clearPtyHistoryPreservingStopRequested(ptyId, historyPreservingStopId)
+        }
       }
       stoppedPtyIds.push(ptyId)
     }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -3164,10 +3164,11 @@ export class OrcaRuntimeService {
   private ptyForegroundAgentRefreshes = new Map<string, PtyForegroundAgentRefresh>()
   private ptyForegroundProcessReads = new Map<string, PtyForegroundProcessReadEntry>()
   private ptyDelayedForegroundSnapshotTitleObservations = new Map<string, number>()
-  // Why a set and not a timer: the intent is retired by the exit it explains, or
+  // Why request IDs and not a timer: the intent is retired by the exit it explains, or
   // by the next lifecycle generation on that id (advancePtyLifecycleGeneration),
   // so a stop that never produced an exit cannot outlive its process.
-  private readonly stopRequestedPtyIds = new Set<string>()
+  private readonly stopRequestedPtyIds = new Map<string, Set<number>>()
+  private nextPtyStopRequestId = 1
   private _orchestrationDb: OrchestrationDb | null = null
   private messageWaitersByHandle = new Map<string, Set<MessageWaiter>>()
   private readonly orchestrationMailboxOwner = new OrchestrationMailboxOwner({
@@ -18227,8 +18228,23 @@ export class OrcaRuntimeService {
    * separates "the operator closed it" from "the agent died", so it is recorded
    * where it is known rather than reconstructed afterwards (STA-4603).
    */
-  markPtyStopRequested(ptyId: string): void {
-    this.stopRequestedPtyIds.add(ptyId)
+  markPtyStopRequested(ptyId: string): number {
+    const requestId = this.nextPtyStopRequestId++
+    const requests = this.stopRequestedPtyIds.get(ptyId) ?? new Set()
+    requests.add(requestId)
+    this.stopRequestedPtyIds.set(ptyId, requests)
+    return requestId
+  }
+
+  clearPtyStopRequested(ptyId: string, requestId: number): void {
+    const requests = this.stopRequestedPtyIds.get(ptyId)
+    if (!requests) {
+      return
+    }
+    requests.delete(requestId)
+    if (requests.size === 0) {
+      this.stopRequestedPtyIds.delete(ptyId)
+    }
   }
 
   markPtyHistoryPreservingStopRequested(ptyId: string): number {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -18211,6 +18211,14 @@ export class OrcaRuntimeService {
     this.stopRequestedPtyIds.add(ptyId)
   }
 
+  markPtyHistoryPreservingStopRequested(ptyId: string): void {
+    this.intentionalHandlelessPtyStops.set(ptyId, this.ptysById.get(ptyId)?.incarnationId ?? null)
+  }
+
+  clearPtyHistoryPreservingStopRequested(ptyId: string): void {
+    this.intentionalHandlelessPtyStops.delete(ptyId)
+  }
+
   isPtyStopRequested(ptyId: string): boolean {
     return this.stopRequestedPtyIds.has(ptyId)
   }
@@ -30791,17 +30799,14 @@ export class OrcaRuntimeService {
     const stoppedPtyIds: string[] = []
     for (const ptyId of [...expected].sort()) {
       if (opts.keepHistory) {
-        this.intentionalHandlelessPtyStops.set(
-          ptyId,
-          this.ptysById.get(ptyId)?.incarnationId ?? null
-        )
+        this.markPtyHistoryPreservingStopRequested(ptyId)
       }
       try {
         if (!(await this.ptyController.stopAndWait(ptyId, { keepHistory: opts.keepHistory }))) {
           throw Object.assign(new Error('terminal_exact_stop_failed'), { ptyId })
         }
       } finally {
-        this.intentionalHandlelessPtyStops.delete(ptyId)
+        this.clearPtyHistoryPreservingStopRequested(ptyId)
       }
       stoppedPtyIds.push(ptyId)
     }

--- a/src/renderer/src/hooks/useAutomationDispatchEvents.ts
+++ b/src/renderer/src/hooks/useAutomationDispatchEvents.ts
@@ -119,10 +119,10 @@ export function useAutomationDispatchEvents(): void {
           terminalOwnership = null
           ownership?.release()
         }
-        const finalizeTerminalOwnership = (): boolean => {
+        const finalizeTerminalOwnership = async (): Promise<boolean> => {
           const ownership = terminalOwnership
           terminalOwnership = null
-          return ownership?.finalize() ?? false
+          return (await ownership?.finalize()) ?? false
         }
 
         if (!repo) {
@@ -365,7 +365,7 @@ export function useAutomationDispatchEvents(): void {
               releaseTerminalOwnership()
               throw error
             }
-            if (finalizeTerminalOwnership()) {
+            if (await finalizeTerminalOwnership()) {
               await clearRetiredRunTerminalIdentity()
             }
           }
@@ -407,7 +407,7 @@ export function useAutomationDispatchEvents(): void {
               throw error
             }
             if (code === 0) {
-              if (finalizeTerminalOwnership()) {
+              if (await finalizeTerminalOwnership()) {
                 await clearRetiredRunTerminalIdentity()
               }
             } else {

--- a/src/renderer/src/lib/automation-terminal-ownership.test.ts
+++ b/src/renderer/src/lib/automation-terminal-ownership.test.ts
@@ -23,10 +23,12 @@ type OwnershipState = Pick<
   | 'terminalLayoutsByTabId'
   | 'lastTerminalInputAtByPaneKey'
   | 'closeTab'
+  | 'shutdownCompletedAgentPaneForHibernation'
 >
 
 function createStore() {
   const closeTab = vi.fn()
+  const shutdownCompletedAgentPaneForHibernation = vi.fn().mockResolvedValue(undefined)
   let state: OwnershipState = {
     activeWorktreeId: 'other-worktree',
     activeTabId: 'other-tab',
@@ -50,7 +52,8 @@ function createStore() {
       [TAB_ID]: singlePaneLayoutSnapshot(LEAF_ID, PTY_ID)
     },
     lastTerminalInputAtByPaneKey: {},
-    closeTab
+    closeTab,
+    shutdownCompletedAgentPaneForHibernation
   }
   const listeners = new Set<(state: AppState, previousState: AppState) => void>()
   const store: AutomationTerminalOwnershipStore = {
@@ -67,7 +70,13 @@ function createStore() {
       listener(state as unknown as AppState, previousState as unknown as AppState)
     }
   }
-  return { closeTab, getState: () => state, store, update }
+  return {
+    closeTab,
+    getState: () => state,
+    shutdownCompletedAgentPaneForHibernation,
+    store,
+    update
+  }
 }
 
 function own(
@@ -89,23 +98,20 @@ function own(
 describe('automation terminal ownership', () => {
   beforeEach(() => vi.clearAllMocks())
 
-  it('closes the exact fresh desktop tab once after the PTY exit binding is cleared', () => {
-    const { closeTab, store, update } = createStore()
+  it('hibernates the exact fresh desktop session once after automation completion', async () => {
+    const { closeTab, shutdownCompletedAgentPaneForHibernation, store } = createStore()
     const ownership = own(store)
-    update({
-      ptyIdsByTabId: { [TAB_ID]: [] },
-      tabsByWorktree: {
-        [WORKTREE_ID]: [{ ...store.getState().tabsByWorktree[WORKTREE_ID]![0]!, ptyId: null }]
-      }
-    })
 
-    expect(ownership.finalize()).toBe(true)
-    expect(ownership.finalize()).toBe(false)
-    expect(closeTab).toHaveBeenCalledTimes(1)
-    expect(closeTab).toHaveBeenCalledWith(TAB_ID, {
-      recordInteraction: false,
-      reason: 'cleanup'
+    expect(await ownership.finalize()).toBe(true)
+    expect(await ownership.finalize()).toBe(false)
+    expect(shutdownCompletedAgentPaneForHibernation).toHaveBeenCalledOnce()
+    expect(shutdownCompletedAgentPaneForHibernation).toHaveBeenCalledWith(WORKTREE_ID, {
+      paneKey: PANE_KEY,
+      tabId: TAB_ID,
+      leafId: LEAF_ID,
+      ptyId: PTY_ID
     })
+    expect(closeTab).not.toHaveBeenCalled()
   })
 
   it('preserves a tab activated after launch even when focus later moves away', () => {

--- a/src/renderer/src/lib/automation-terminal-ownership.test.ts
+++ b/src/renderer/src/lib/automation-terminal-ownership.test.ts
@@ -114,24 +114,40 @@ describe('automation terminal ownership', () => {
     expect(closeTab).not.toHaveBeenCalled()
   })
 
-  it('preserves a tab activated after launch even when focus later moves away', () => {
+  it('keeps live terminal identity when hibernation fails', async () => {
+    const { closeTab, shutdownCompletedAgentPaneForHibernation, store } = createStore()
+    const error = new Error('capture failed')
+    shutdownCompletedAgentPaneForHibernation.mockRejectedValueOnce(error)
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const ownership = own(store)
+
+    expect(await ownership.finalize()).toBe(false)
+    expect(await ownership.finalize()).toBe(false)
+    expect(consoleError).toHaveBeenCalledWith(
+      '[automations] Failed to hibernate owned automation terminal:',
+      error
+    )
+    expect(closeTab).not.toHaveBeenCalled()
+  })
+
+  it('preserves a tab activated after launch even when focus later moves away', async () => {
     const { closeTab, store, update } = createStore()
     const ownership = own(store)
 
     update({ activeWorktreeId: WORKTREE_ID, activeTabId: TAB_ID })
     update({ activeWorktreeId: 'other-worktree', activeTabId: 'other-tab' })
 
-    expect(ownership.finalize()).toBe(false)
+    expect(await ownership.finalize()).toBe(false)
     expect(closeTab).not.toHaveBeenCalled()
   })
 
-  it('preserves a tab that received user input after launch', () => {
+  it('preserves a tab that received user input after launch', async () => {
     const { closeTab, store, update } = createStore()
     const ownership = own(store)
 
     update({ lastTerminalInputAtByPaneKey: { [PANE_KEY]: 200 } })
 
-    expect(ownership.finalize()).toBe(false)
+    expect(await ownership.finalize()).toBe(false)
     expect(closeTab).not.toHaveBeenCalled()
   })
 
@@ -145,7 +161,7 @@ describe('automation terminal ownership', () => {
       'pane layout',
       { tabsByWorktree: null, ptyIdsByTabId: undefined, layoutPty: 'pty-replacement' }
     ]
-  ])('refuses a replacement identity in the %s binding', (_label, drift) => {
+  ])('refuses a replacement identity in the %s binding', async (_label, drift) => {
     const { closeTab, getState, store, update } = createStore()
     const ownership = own(store)
     const tab = getState().tabsByWorktree[WORKTREE_ID]![0]!
@@ -166,11 +182,11 @@ describe('automation terminal ownership', () => {
         : {})
     })
 
-    expect(ownership.finalize()).toBe(false)
+    expect(await ownership.finalize()).toBe(false)
     expect(closeTab).not.toHaveBeenCalled()
   })
 
-  it('refuses a tab recreated with the same id', () => {
+  it('refuses a tab recreated with the same id', async () => {
     const { closeTab, getState, store, update } = createStore()
     const ownership = own(store)
     update({
@@ -181,28 +197,28 @@ describe('automation terminal ownership', () => {
       }
     })
 
-    expect(ownership.finalize()).toBe(false)
+    expect(await ownership.finalize()).toBe(false)
     expect(closeTab).not.toHaveBeenCalled()
   })
 
   it.each([
     ['remote runtime', { runtimeKind: 'environment' as const }],
     ['remote PTY identity', { ptyId: 'remote:env-1@@terminal-1' }]
-  ])('never owns a %s terminal', (_label, overrides) => {
+  ])('never owns a %s terminal', async (_label, overrides) => {
     const { closeTab, store } = createStore()
     const ownership = own(store, overrides)
 
-    expect(ownership.finalize()).toBe(false)
+    expect(await ownership.finalize()).toBe(false)
     expect(closeTab).not.toHaveBeenCalled()
   })
 
-  it('release consumes ownership without closing the terminal', () => {
+  it('release consumes ownership without closing the terminal', async () => {
     const { closeTab, store } = createStore()
     const ownership = own(store)
 
     ownership.release()
 
-    expect(ownership.finalize()).toBe(false)
+    expect(await ownership.finalize()).toBe(false)
     expect(closeTab).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/lib/automation-terminal-ownership.ts
+++ b/src/renderer/src/lib/automation-terminal-ownership.ts
@@ -11,7 +11,7 @@ export type AutomationTerminalOwnershipStore = {
 }
 
 export type AutomationTerminalOwnership = {
-  finalize: () => boolean
+  finalize: () => Promise<boolean>
   release: () => void
 }
 
@@ -104,7 +104,7 @@ export function createAutomationTerminalOwnership(
 
   return {
     release,
-    finalize: () => {
+    finalize: async () => {
       if (consumed) {
         return false
       }
@@ -121,13 +121,22 @@ export function createAutomationTerminalOwnership(
         return false
       }
       try {
-        // Why: closeTab centrally owns provider shutdown and pane removal; a
-        // direct kill here would create a second teardown authority.
-        state.closeTab(args.tabId, { recordInteraction: false, reason: 'cleanup' })
+        const parsedPane = parsePaneKey(args.paneKey)
+        if (!parsedPane) {
+          return false
+        }
+        // Why: hibernation owns exact PTY shutdown and durable provider-session
+        // capture while preserving the automation tab for later activation.
+        await state.shutdownCompletedAgentPaneForHibernation(args.worktreeId, {
+          paneKey: args.paneKey,
+          tabId: args.tabId,
+          leafId: parsedPane.leafId,
+          ptyId: args.ptyId
+        })
       } catch (error) {
-        // Why: a throwing close leaves the terminal alive; report not-closed so
+        // Why: a failed hibernation leaves the terminal alive; report not-retired so
         // the run keeps its (still-valid) terminal identity and no stale clear runs.
-        console.error('[automations] Failed to close owned automation terminal:', error)
+        console.error('[automations] Failed to hibernate owned automation terminal:', error)
         return false
       }
       return true

--- a/src/renderer/src/store/slices/store-sleep-pane-hibernation-failure-races.test.ts
+++ b/src/renderer/src/store/slices/store-sleep-pane-hibernation-failure-races.test.ts
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as AgentStatusModule from '@/lib/agent-status'
+import { getDefaultSettings } from '../../../../shared/constants'
+import { createCompatibleRuntimeStatusResponseIfNeeded } from '../../runtime/runtime-compatibility-test-fixture'
+import { clearRuntimeCompatibilityCacheForTests } from '../../runtime/runtime-rpc-client'
+import {
+  createTestStore,
+  makeRuntimeOwnedWorktree,
+  makeTab,
+  makeWorktree,
+  seedStore
+} from './store-test-helpers'
+import { shutdownBufferCaptures } from '@/components/terminal-pane/shutdown-buffer-captures'
+import {
+  applySleepRuntimeRpcDefault,
+  createStoreCascadesMockApi
+} from './store-cascades-test-harness'
+
+const mockUnregisterPtyDataHandlers = vi.hoisted(() => vi.fn<() => unknown[]>(() => []))
+
+vi.mock('sonner', () => ({
+  toast: { info: vi.fn(), success: vi.fn(), error: vi.fn(), warning: vi.fn() }
+}))
+
+vi.mock('@/components/terminal-pane/pty-dispatcher', () => ({
+  restorePtyDataHandlersAfterFailedShutdown: vi.fn(),
+  unregisterPtyDataHandlers: mockUnregisterPtyDataHandlers
+}))
+
+vi.mock('@/lib/agent-status', async (importOriginal) => {
+  const actual = await importOriginal<typeof AgentStatusModule>()
+  return {
+    ...actual,
+    detectAgentStatusFromTitle: vi.fn().mockReturnValue(null)
+  }
+})
+
+const mockApi = createStoreCascadesMockApi()
+
+describe('completed pane hibernation failure races', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    clearRuntimeCompatibilityCacheForTests()
+    mockApi.pty.kill.mockResolvedValue(undefined)
+    mockUnregisterPtyDataHandlers.mockReturnValue([])
+    applySleepRuntimeRpcDefault(mockApi)
+    shutdownBufferCaptures.clear()
+  })
+
+  it('does not retain stale completion evidence when pane status changes during hibernation', async () => {
+    const store = createTestStore()
+    const wt = 'repo1::/path/wt1'
+    const targetLeaf = '11111111-1111-4111-8111-111111111111'
+    const targetPaneKey = `tab-1:${targetLeaf}`
+
+    mockApi.pty.kill.mockImplementationOnce(async () => {
+      store
+        .getState()
+        .setAgentStatus(
+          targetPaneKey,
+          { state: 'working', prompt: 'still running', agentType: 'codex' },
+          'Codex',
+          { updatedAt: 3000, stateStartedAt: 3000 },
+          { tabId: 'tab-1', worktreeId: wt },
+          { providerSession: { key: 'session_id', id: 'target-session' } }
+        )
+    })
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: wt, repoId: 'repo1', path: '/path/wt1' })]
+      },
+      tabsByWorktree: {
+        [wt]: [makeTab({ id: 'tab-1', worktreeId: wt, title: 'Codex', ptyId: 'pty-agent' })]
+      },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: targetLeaf },
+          activeLeafId: targetLeaf,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [targetLeaf]: 'pty-agent' }
+        }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-agent'] }
+    })
+    store.getState().setAgentStatus(
+      targetPaneKey,
+      {
+        state: 'done',
+        prompt: 'stale done',
+        agentType: 'codex',
+        lastAssistantMessage: 'old done'
+      },
+      'Codex',
+      { updatedAt: 2000, stateStartedAt: 1000 },
+      { tabId: 'tab-1', worktreeId: wt },
+      { providerSession: { key: 'session_id', id: 'target-session' } }
+    )
+
+    await store.getState().shutdownCompletedAgentPaneForHibernation(wt, {
+      paneKey: targetPaneKey,
+      tabId: 'tab-1',
+      leafId: targetLeaf,
+      ptyId: 'pty-agent'
+    })
+
+    expect(store.getState().agentStatusByPaneKey[targetPaneKey]).toBeUndefined()
+    expect(store.getState().retainedAgentsByPaneKey[targetPaneKey]).toBeUndefined()
+    expect(store.getState().retentionSuppressedPaneKeys[targetPaneKey]).toBe(true)
+  })
+
+  it('rolls back target suppressions when target-only runtime stop fails', async () => {
+    const store = createTestStore()
+    const wt = 'repo1::/path/wt1'
+    const targetLeaf = '11111111-1111-4111-8111-111111111111'
+    const siblingLeaf = '22222222-2222-4222-8222-222222222222'
+    const targetPaneKey = `tab-1:${targetLeaf}`
+
+    mockApi.runtimeEnvironments.call.mockImplementation((args: { method: string }) =>
+      Promise.resolve(
+        createCompatibleRuntimeStatusResponseIfNeeded(args) ?? {
+          id: 'rpc-default',
+          ok: true,
+          result:
+            args.method === 'terminal.stopExact'
+              ? {
+                  stoppedPtyIds: ['terminal-1'],
+                  livePtyIds: ['terminal-1', 'terminal-2'],
+                  postStopVerified: false,
+                  postStopFailure: 'target_still_live'
+                }
+              : {},
+          _meta: { runtimeId: 'remote-runtime' }
+        }
+      )
+    )
+    seedStore(store, {
+      settings: { ...getDefaultSettings('/tmp'), activeRuntimeEnvironmentId: 'runtime-1' },
+      worktreesByRepo: {
+        repo1: [makeRuntimeOwnedWorktree({ id: wt, repoId: 'repo1', path: '/path/wt1' })]
+      },
+      tabsByWorktree: {
+        [wt]: [makeTab({ id: 'tab-1', worktreeId: wt, title: 'Codex' })]
+      },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: {
+            type: 'split',
+            direction: 'horizontal',
+            first: { type: 'leaf', leafId: targetLeaf },
+            second: { type: 'leaf', leafId: siblingLeaf }
+          },
+          activeLeafId: siblingLeaf,
+          expandedLeafId: null,
+          ptyIdsByLeafId: {
+            [targetLeaf]: 'remote:env-1@@terminal-1',
+            [siblingLeaf]: 'remote:env-1@@terminal-2'
+          }
+        }
+      },
+      ptyIdsByTabId: {
+        'tab-1': ['remote:env-1@@terminal-1', 'remote:env-1@@terminal-2']
+      }
+    })
+    store
+      .getState()
+      .setAgentStatus(
+        targetPaneKey,
+        { state: 'done', prompt: 'resume target', agentType: 'codex' },
+        'Codex',
+        { updatedAt: 2000, stateStartedAt: 1000 },
+        { tabId: 'tab-1', worktreeId: wt },
+        { providerSession: { key: 'session_id', id: 'target-session' } }
+      )
+
+    await expect(
+      store.getState().shutdownCompletedAgentPaneForHibernation(wt, {
+        paneKey: targetPaneKey,
+        tabId: 'tab-1',
+        leafId: targetLeaf,
+        ptyId: 'remote:env-1@@terminal-1',
+        expectedRuntimePtyId: 'terminal-1'
+      })
+    ).rejects.toThrow('target_still_live')
+
+    const state = store.getState()
+    expect(state.ptyIdsByTabId['tab-1']).toEqual([
+      'remote:env-1@@terminal-1',
+      'remote:env-1@@terminal-2'
+    ])
+    expect(state.suppressedPtyExitIds['remote:env-1@@terminal-1']).toBeUndefined()
+    expect(state.suppressedPtyExitIds['terminal-1']).toBeUndefined()
+    expect(state.sleepingAgentSessionsByPaneKey[targetPaneKey]).toMatchObject({
+      origin: 'live',
+      agent: 'codex',
+      providerSession: { key: 'session_id', id: 'target-session' }
+    })
+    expect(state.agentStatusByPaneKey[targetPaneKey]).toBeDefined()
+  })
+})

--- a/src/renderer/src/store/slices/store-sleep-pane-hibernation.test.ts
+++ b/src/renderer/src/store/slices/store-sleep-pane-hibernation.test.ts
@@ -332,6 +332,88 @@ describe('shutdownWorktreeTerminals (sleep) — agent status hygiene', () => {
     expect(state.sleepingAgentSessionsByPaneKey[targetPaneKey]).toBeDefined()
   })
 
+  it('does not clear a replacement pane that binds while hibernation is stopping', async () => {
+    const store = createTestStore()
+    const wt = 'repo1::/path/wt1'
+    const targetLeaf = '11111111-1111-4111-8111-111111111111'
+    const targetPaneKey = `tab-1:${targetLeaf}`
+    let finishKill: (() => void) | undefined
+    mockApi.pty.kill.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishKill = resolve
+        })
+    )
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: wt, repoId: 'repo1', path: '/path/wt1' })]
+      },
+      tabsByWorktree: {
+        [wt]: [makeTab({ id: 'tab-1', worktreeId: wt, title: 'Codex', ptyId: 'pty-agent' })]
+      },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: targetLeaf },
+          activeLeafId: targetLeaf,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [targetLeaf]: 'pty-agent' }
+        }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-agent'] }
+    })
+    store
+      .getState()
+      .setAgentStatus(
+        targetPaneKey,
+        { state: 'done', prompt: 'old run', agentType: 'codex' },
+        'Codex',
+        { updatedAt: 2000, stateStartedAt: 1000 },
+        { tabId: 'tab-1', worktreeId: wt },
+        { providerSession: { key: 'session_id', id: 'old-session' } }
+      )
+
+    const shutdown = store.getState().shutdownCompletedAgentPaneForHibernation(wt, {
+      paneKey: targetPaneKey,
+      tabId: 'tab-1',
+      leafId: targetLeaf,
+      ptyId: 'pty-agent'
+    })
+    store.setState((state) => ({
+      tabsByWorktree: {
+        ...state.tabsByWorktree,
+        [wt]: state.tabsByWorktree[wt]!.map((tab) =>
+          tab.id === 'tab-1' ? { ...tab, ptyId: 'pty-replacement' } : tab
+        )
+      },
+      terminalLayoutsByTabId: {
+        ...state.terminalLayoutsByTabId,
+        'tab-1': {
+          ...state.terminalLayoutsByTabId['tab-1']!,
+          ptyIdsByLeafId: { [targetLeaf]: 'pty-replacement' }
+        }
+      },
+      ptyIdsByTabId: { ...state.ptyIdsByTabId, 'tab-1': ['pty-replacement'] }
+    }))
+    store
+      .getState()
+      .setAgentStatus(
+        targetPaneKey,
+        { state: 'working', prompt: 'replacement run', agentType: 'codex' },
+        'Codex',
+        { updatedAt: 3000, stateStartedAt: 3000 },
+        { tabId: 'tab-1', worktreeId: wt },
+        { providerSession: { key: 'session_id', id: 'replacement-session' } }
+      )
+    finishKill?.()
+    await shutdown
+
+    expect(store.getState().ptyIdsByTabId['tab-1']).toEqual(['pty-replacement'])
+    expect(store.getState().agentStatusByPaneKey[targetPaneKey]).toMatchObject({
+      state: 'working',
+      providerSession: { key: 'session_id', id: 'replacement-session' }
+    })
+  })
+
   it('keeps manual sleep worktree-wide', async () => {
     const store = createTestStore()
     const wt = 'repo1::/path/wt1'

--- a/src/renderer/src/store/slices/store-sleep-pane-hibernation.test.ts
+++ b/src/renderer/src/store/slices/store-sleep-pane-hibernation.test.ts
@@ -216,6 +216,54 @@ describe('shutdownWorktreeTerminals (sleep) — agent status hygiene', () => {
     expect(state.agentStatusByPaneKey[targetPaneKey]).toBeDefined()
   })
 
+  it('captures a completed pane after its PTY exit already cleared the live binding', async () => {
+    const store = createTestStore()
+    const wt = 'repo1::/path/wt1'
+    const targetLeaf = '11111111-1111-4111-8111-111111111111'
+    const targetPaneKey = `tab-1:${targetLeaf}`
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: wt, repoId: 'repo1', path: '/path/wt1' })]
+      },
+      tabsByWorktree: {
+        [wt]: [makeTab({ id: 'tab-1', worktreeId: wt, title: 'Codex', ptyId: null })]
+      },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: targetLeaf },
+          activeLeafId: targetLeaf,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [targetLeaf]: 'pty-agent' }
+        }
+      },
+      ptyIdsByTabId: { 'tab-1': [] }
+    })
+    store
+      .getState()
+      .setAgentStatus(
+        targetPaneKey,
+        { state: 'done', prompt: 'finished naturally', agentType: 'codex' },
+        'Codex',
+        { updatedAt: 2000, stateStartedAt: 1000 },
+        { tabId: 'tab-1', worktreeId: wt },
+        { providerSession: { key: 'session_id', id: 'natural-exit-session' } }
+      )
+
+    await store.getState().shutdownCompletedAgentPaneForHibernation(wt, {
+      paneKey: targetPaneKey,
+      tabId: 'tab-1',
+      leafId: targetLeaf,
+      ptyId: 'pty-agent'
+    })
+
+    expect(mockApi.pty.kill).not.toHaveBeenCalled()
+    expect(store.getState().sleepingAgentSessionsByPaneKey[targetPaneKey]).toMatchObject({
+      origin: 'worktree-sleep',
+      providerSession: { key: 'session_id', id: 'natural-exit-session' }
+    })
+    expect(store.getState().suppressedPtyExitIds['pty-agent']).toBeUndefined()
+  })
+
   it('rolls back the sleeping record and suppression when the hibernation kill fails', async () => {
     // Record written before the kill (pty:exit can beat it back); both it and the suppression must roll back if the kill fails.
     const store = createTestStore()
@@ -378,6 +426,12 @@ describe('shutdownWorktreeTerminals (sleep) — agent status hygiene', () => {
       leafId: targetLeaf,
       ptyId: 'pty-agent'
     })
+    const overlappingShutdown = store.getState().shutdownCompletedAgentPaneForHibernation(wt, {
+      paneKey: targetPaneKey,
+      tabId: 'tab-1',
+      leafId: targetLeaf,
+      ptyId: 'pty-agent'
+    })
     store.setState((state) => ({
       tabsByWorktree: {
         ...state.tabsByWorktree,
@@ -405,13 +459,102 @@ describe('shutdownWorktreeTerminals (sleep) — agent status hygiene', () => {
         { providerSession: { key: 'session_id', id: 'replacement-session' } }
       )
     finishKill?.()
-    await shutdown
+    await Promise.all([shutdown, overlappingShutdown])
 
+    expect(mockApi.pty.kill).toHaveBeenCalledOnce()
     expect(store.getState().ptyIdsByTabId['tab-1']).toEqual(['pty-replacement'])
     expect(store.getState().agentStatusByPaneKey[targetPaneKey]).toMatchObject({
       state: 'working',
       providerSession: { key: 'session_id', id: 'replacement-session' }
     })
+    expect(store.getState().sleepingAgentSessionsByPaneKey[targetPaneKey]).toMatchObject({
+      origin: 'live',
+      providerSession: { key: 'session_id', id: 'replacement-session' }
+    })
+    expect(store.getState().suppressedPtyExitIds['pty-agent']).toBeUndefined()
+  })
+
+  it('does not clear a replacement before its layout binding catches up', async () => {
+    const store = createTestStore()
+    const wt = 'repo1::/path/wt1'
+    const targetLeaf = '11111111-1111-4111-8111-111111111111'
+    const targetPaneKey = `tab-1:${targetLeaf}`
+    let finishKill: (() => void) | undefined
+    mockApi.pty.kill.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishKill = resolve
+        })
+    )
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: wt, repoId: 'repo1', path: '/path/wt1' })]
+      },
+      tabsByWorktree: {
+        [wt]: [makeTab({ id: 'tab-1', worktreeId: wt, title: 'Codex', ptyId: 'pty-agent' })]
+      },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: targetLeaf },
+          activeLeafId: targetLeaf,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [targetLeaf]: 'pty-agent' }
+        }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-agent'] }
+    })
+    store
+      .getState()
+      .setAgentStatus(
+        targetPaneKey,
+        { state: 'done', prompt: 'old run', agentType: 'codex' },
+        'Codex',
+        { updatedAt: 2000, stateStartedAt: 1000 },
+        { tabId: 'tab-1', worktreeId: wt },
+        { providerSession: { key: 'session_id', id: 'old-session' } }
+      )
+
+    const shutdown = store.getState().shutdownCompletedAgentPaneForHibernation(wt, {
+      paneKey: targetPaneKey,
+      tabId: 'tab-1',
+      leafId: targetLeaf,
+      ptyId: 'pty-agent'
+    })
+    store.setState((state) => ({
+      tabsByWorktree: {
+        ...state.tabsByWorktree,
+        [wt]: state.tabsByWorktree[wt]!.map((tab) =>
+          tab.id === 'tab-1' ? { ...tab, ptyId: 'pty-replacement' } : tab
+        )
+      },
+      ptyIdsByTabId: { ...state.ptyIdsByTabId, 'tab-1': ['pty-replacement'] }
+    }))
+    store
+      .getState()
+      .setAgentStatus(
+        targetPaneKey,
+        { state: 'working', prompt: 'replacement run', agentType: 'codex' },
+        'Codex',
+        { updatedAt: 3000, stateStartedAt: 3000 },
+        { tabId: 'tab-1', worktreeId: wt },
+        { providerSession: { key: 'session_id', id: 'replacement-session' } }
+      )
+    finishKill?.()
+    await shutdown
+
+    expect(store.getState().ptyIdsByTabId['tab-1']).toEqual(['pty-replacement'])
+    expect(store.getState().terminalLayoutsByTabId['tab-1']?.ptyIdsByLeafId?.[targetLeaf]).toBe(
+      'pty-agent'
+    )
+    expect(store.getState().agentStatusByPaneKey[targetPaneKey]).toMatchObject({
+      state: 'working',
+      providerSession: { key: 'session_id', id: 'replacement-session' }
+    })
+    expect(store.getState().sleepingAgentSessionsByPaneKey[targetPaneKey]).toMatchObject({
+      origin: 'live',
+      providerSession: { key: 'session_id', id: 'replacement-session' }
+    })
+    expect(store.getState().suppressedPtyExitIds['pty-agent']).toBeUndefined()
   })
 
   it('keeps manual sleep worktree-wide', async () => {
@@ -500,7 +643,7 @@ describe('shutdownWorktreeTerminals (sleep) — agent status hygiene', () => {
     expect(mockRestorePtyDataHandlersAfterFailedShutdown).toHaveBeenCalledWith(handlerSnapshots)
   })
 
-  it('uses target-only runtime stop for automatic pane hibernation', async () => {
+  it('uses target-only runtime stop after the renderer binding exits', async () => {
     const store = createTestStore()
     const wt = 'repo1::/path/wt1'
     const targetLeaf = '11111111-1111-4111-8111-111111111111'
@@ -550,7 +693,7 @@ describe('shutdownWorktreeTerminals (sleep) — agent status hygiene', () => {
         }
       },
       ptyIdsByTabId: {
-        'tab-1': ['remote:env-1@@terminal-1', 'remote:env-1@@terminal-2', 'terminal-1']
+        'tab-1': ['remote:env-1@@terminal-2', 'terminal-1']
       }
     })
     store
@@ -595,7 +738,7 @@ describe('shutdownWorktreeTerminals (sleep) — agent status hygiene', () => {
     ])
     expect(mockUnregisterPtyDataHandlers).toHaveBeenCalledWith(['remote:env-1@@terminal-1'])
     expect(mockUnregisterPtyDataHandlers).not.toHaveBeenCalledWith(['terminal-1'])
-    expect(store.getState().suppressedPtyExitIds['remote:env-1@@terminal-1']).toBe(true)
+    expect(store.getState().suppressedPtyExitIds['remote:env-1@@terminal-1']).toBeUndefined()
     expect(store.getState().suppressedPtyExitIds['remote:runtime-1@@terminal-1']).toBeUndefined()
     expect(store.getState().suppressedPtyExitIds['terminal-1']).toBeUndefined()
     expect(mockApi.pty.kill).not.toHaveBeenCalled()
@@ -652,156 +795,5 @@ describe('shutdownWorktreeTerminals (sleep) — agent status hygiene', () => {
 
     expect(store.getState().ptyIdsByTabId['tab-1']).toEqual([])
     expect(store.getState().lastKnownRelayPtyIdByTabId['tab-1']).toBeUndefined()
-  })
-
-  it('does not retain stale completion evidence when pane status changes during hibernation', async () => {
-    const store = createTestStore()
-    const wt = 'repo1::/path/wt1'
-    const targetLeaf = '11111111-1111-4111-8111-111111111111'
-    const targetPaneKey = `tab-1:${targetLeaf}`
-
-    mockApi.pty.kill.mockImplementationOnce(async () => {
-      store
-        .getState()
-        .setAgentStatus(
-          targetPaneKey,
-          { state: 'working', prompt: 'still running', agentType: 'codex' },
-          'Codex',
-          { updatedAt: 3000, stateStartedAt: 3000 },
-          { tabId: 'tab-1', worktreeId: wt },
-          { providerSession: { key: 'session_id', id: 'target-session' } }
-        )
-    })
-    seedStore(store, {
-      worktreesByRepo: {
-        repo1: [makeWorktree({ id: wt, repoId: 'repo1', path: '/path/wt1' })]
-      },
-      tabsByWorktree: {
-        [wt]: [makeTab({ id: 'tab-1', worktreeId: wt, title: 'Codex', ptyId: 'pty-agent' })]
-      },
-      terminalLayoutsByTabId: {
-        'tab-1': {
-          root: { type: 'leaf', leafId: targetLeaf },
-          activeLeafId: targetLeaf,
-          expandedLeafId: null,
-          ptyIdsByLeafId: { [targetLeaf]: 'pty-agent' }
-        }
-      },
-      ptyIdsByTabId: { 'tab-1': ['pty-agent'] }
-    })
-    store.getState().setAgentStatus(
-      targetPaneKey,
-      {
-        state: 'done',
-        prompt: 'stale done',
-        agentType: 'codex',
-        lastAssistantMessage: 'old done'
-      },
-      'Codex',
-      { updatedAt: 2000, stateStartedAt: 1000 },
-      { tabId: 'tab-1', worktreeId: wt },
-      { providerSession: { key: 'session_id', id: 'target-session' } }
-    )
-
-    await store.getState().shutdownCompletedAgentPaneForHibernation(wt, {
-      paneKey: targetPaneKey,
-      tabId: 'tab-1',
-      leafId: targetLeaf,
-      ptyId: 'pty-agent'
-    })
-
-    expect(store.getState().agentStatusByPaneKey[targetPaneKey]).toBeUndefined()
-    expect(store.getState().retainedAgentsByPaneKey[targetPaneKey]).toBeUndefined()
-    expect(store.getState().retentionSuppressedPaneKeys[targetPaneKey]).toBe(true)
-  })
-
-  it('rolls back target suppressions when target-only runtime stop fails', async () => {
-    const store = createTestStore()
-    const wt = 'repo1::/path/wt1'
-    const targetLeaf = '11111111-1111-4111-8111-111111111111'
-    const siblingLeaf = '22222222-2222-4222-8222-222222222222'
-    const targetPaneKey = `tab-1:${targetLeaf}`
-
-    mockApi.runtimeEnvironments.call.mockImplementation((args: { method: string }) =>
-      Promise.resolve(
-        createCompatibleRuntimeStatusResponseIfNeeded(args) ?? {
-          id: 'rpc-default',
-          ok: true,
-          result:
-            args.method === 'terminal.stopExact'
-              ? {
-                  stoppedPtyIds: ['terminal-1'],
-                  livePtyIds: ['terminal-1', 'terminal-2'],
-                  postStopVerified: false,
-                  postStopFailure: 'target_still_live'
-                }
-              : {},
-          _meta: { runtimeId: 'remote-runtime' }
-        }
-      )
-    )
-    seedStore(store, {
-      settings: { ...getDefaultSettings('/tmp'), activeRuntimeEnvironmentId: 'runtime-1' },
-      worktreesByRepo: {
-        repo1: [makeRuntimeOwnedWorktree({ id: wt, repoId: 'repo1', path: '/path/wt1' })]
-      },
-      tabsByWorktree: {
-        [wt]: [makeTab({ id: 'tab-1', worktreeId: wt, title: 'Codex' })]
-      },
-      terminalLayoutsByTabId: {
-        'tab-1': {
-          root: {
-            type: 'split',
-            direction: 'horizontal',
-            first: { type: 'leaf', leafId: targetLeaf },
-            second: { type: 'leaf', leafId: siblingLeaf }
-          },
-          activeLeafId: siblingLeaf,
-          expandedLeafId: null,
-          ptyIdsByLeafId: {
-            [targetLeaf]: 'remote:env-1@@terminal-1',
-            [siblingLeaf]: 'remote:env-1@@terminal-2'
-          }
-        }
-      },
-      ptyIdsByTabId: {
-        'tab-1': ['remote:env-1@@terminal-1', 'remote:env-1@@terminal-2']
-      }
-    })
-    store
-      .getState()
-      .setAgentStatus(
-        targetPaneKey,
-        { state: 'done', prompt: 'resume target', agentType: 'codex' },
-        'Codex',
-        { updatedAt: 2000, stateStartedAt: 1000 },
-        { tabId: 'tab-1', worktreeId: wt },
-        { providerSession: { key: 'session_id', id: 'target-session' } }
-      )
-
-    await expect(
-      store.getState().shutdownCompletedAgentPaneForHibernation(wt, {
-        paneKey: targetPaneKey,
-        tabId: 'tab-1',
-        leafId: targetLeaf,
-        ptyId: 'remote:env-1@@terminal-1',
-        expectedRuntimePtyId: 'terminal-1'
-      })
-    ).rejects.toThrow('target_still_live')
-
-    const state = store.getState()
-    expect(state.ptyIdsByTabId['tab-1']).toEqual([
-      'remote:env-1@@terminal-1',
-      'remote:env-1@@terminal-2'
-    ])
-    expect(state.suppressedPtyExitIds['remote:env-1@@terminal-1']).toBeUndefined()
-    expect(state.suppressedPtyExitIds['terminal-1']).toBeUndefined()
-    // Why: done resumable agent keeps its origin:'live' anchor (#9454); a failed target-only stop rolls back to it, not undefined, and never commits worktree-sleep.
-    expect(state.sleepingAgentSessionsByPaneKey[targetPaneKey]).toMatchObject({
-      origin: 'live',
-      agent: 'codex',
-      providerSession: { key: 'session_id', id: 'target-session' }
-    })
-    expect(state.agentStatusByPaneKey[targetPaneKey]).toBeDefined()
   })
 })

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -2771,6 +2771,21 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       }
     }
 
+    const stateAfterShutdown = get()
+    const tabAfterShutdown = (stateAfterShutdown.tabsByWorktree[worktreeId] ?? []).find(
+      (candidate) => candidate.id === opts.tabId
+    )
+    const panePtyAfterShutdown =
+      stateAfterShutdown.terminalLayoutsByTabId[opts.tabId]?.ptyIdsByLeafId?.[opts.leafId]
+    if (
+      !tabAfterShutdown ||
+      tabAfterShutdown.createdAt !== tab.createdAt ||
+      (panePtyAfterShutdown !== undefined && panePtyAfterShutdown !== opts.ptyId)
+    ) {
+      // Why: the stopped process is gone, but a replacement pane owns all later store cleanup.
+      return
+    }
+
     set((s) => {
       const existingPtyIds = s.ptyIdsByTabId[opts.tabId] ?? []
       const shutdownPtyIdSet = new Set(rendererShutdownPtyIds)

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -163,6 +163,8 @@ import {
   type TerminalTabRetirementPlan
 } from './terminal-tab-retirement'
 
+const completedAgentPaneHibernations = new Map<string, Promise<void>>()
+
 function getNextTerminalOrdinal(tabs: TerminalTab[]): number {
   const usedOrdinals = new Set<number>()
   for (const tab of tabs) {
@@ -2616,250 +2618,293 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
     }
   },
 
-  shutdownCompletedAgentPaneForHibernation: async (worktreeId, opts) => {
-    const paneKeys = [opts.paneKey]
-    const expectedRuntimePtyIds = sortedUniquePtyIds(
-      opts.expectedRuntimePtyId ? [opts.expectedRuntimePtyId] : []
-    )
-    const rendererShutdownPtyIds = [opts.ptyId]
-    const state = get()
-    const runtimeEnvironmentId = resolveTerminalStopRuntimeEnvironmentId(state, worktreeId)
-    // Why: pane transports emit renderer PTY ids, not raw exact-stop handles; guard only the identity that can deliver an exit callback.
-    const exitGuardPtyIds = [opts.ptyId]
-    const tab = (state.tabsByWorktree[worktreeId] ?? []).find(
-      (candidate) => candidate.id === opts.tabId
-    )
-    const parsed = parsePaneKey(opts.paneKey)
-    const layout = state.terminalLayoutsByTabId[opts.tabId]
-    const liveTabPtyIds = state.ptyIdsByTabId[opts.tabId] ?? []
-    if (
-      !tab ||
-      !parsed ||
-      parsed.tabId !== opts.tabId ||
-      parsed.leafId !== opts.leafId ||
-      layout?.ptyIdsByLeafId?.[opts.leafId] !== opts.ptyId ||
-      (expectedRuntimePtyIds.length === 0 && !liveTabPtyIds.includes(opts.ptyId))
-    ) {
-      throw new Error('agent_hibernation_pane_binding_mismatch')
+  shutdownCompletedAgentPaneForHibernation: (worktreeId, opts) => {
+    const hibernationKey = `${worktreeId}\0${opts.paneKey}\0${opts.ptyId}`
+    const existingHibernation = completedAgentPaneHibernations.get(hibernationKey)
+    if (existingHibernation) {
+      return existingHibernation
     }
-
-    const sleepingAgentSessionRecords = collectSleepingAgentSessionRecordsForWorktree(
-      state,
-      worktreeId,
-      {
-        paneKeys,
-        captureMode: 'completed-agent-hibernation'
+    const hibernation = (async (): Promise<void> => {
+      const paneKeys = [opts.paneKey]
+      const expectedRuntimePtyIds = sortedUniquePtyIds(
+        opts.expectedRuntimePtyId ? [opts.expectedRuntimePtyId] : []
+      )
+      const rendererShutdownPtyIds = [opts.ptyId]
+      const state = get()
+      const runtimeEnvironmentId = resolveTerminalStopRuntimeEnvironmentId(state, worktreeId)
+      // Why: pane transports emit renderer PTY ids, not raw exact-stop handles; guard only the identity that can deliver an exit callback.
+      const exitGuardPtyIds = [opts.ptyId]
+      const tab = (state.tabsByWorktree[worktreeId] ?? []).find(
+        (candidate) => candidate.id === opts.tabId
+      )
+      const parsed = parsePaneKey(opts.paneKey)
+      const layout = state.terminalLayoutsByTabId[opts.tabId]
+      const liveTabPtyIds = state.ptyIdsByTabId[opts.tabId] ?? []
+      const targetIsLive = liveTabPtyIds.includes(opts.ptyId)
+      const localTargetAlreadyExited =
+        expectedRuntimePtyIds.length === 0 &&
+        !targetIsLive &&
+        tab?.ptyId === null &&
+        liveTabPtyIds.length === 0
+      if (
+        !tab ||
+        !parsed ||
+        parsed.tabId !== opts.tabId ||
+        parsed.leafId !== opts.leafId ||
+        layout?.ptyIdsByLeafId?.[opts.leafId] !== opts.ptyId ||
+        (!targetIsLive && expectedRuntimePtyIds.length === 0 && !localTargetAlreadyExited)
+      ) {
+        throw new Error('agent_hibernation_pane_binding_mismatch')
       }
-    )
-    const retainedCompletionEvidence = collectHibernatedCompletionEvidenceForWorktree(
-      state,
-      worktreeId,
-      paneKeys
-    )
-    if (!sleepingAgentSessionRecords[opts.paneKey]) {
-      // Why: killing the PTY with no persisted resume record strands the pane unwakeable; abort instead of hibernating unrecoverably.
-      throw new Error('agent_hibernation_capture_missing')
-    }
 
-    const capture = shutdownBufferCaptures.get(opts.tabId)
-    if (capture) {
-      try {
-        capture({ includeLocalBuffers: false })
-      } catch {
-        // Don't let one tab's capture failure block the pane hibernation.
-      }
-    }
-
-    // Why: store sleeping records before kill, since pty:exit can arrive first.
-    const sleepingRecordKeys = Object.keys(sleepingAgentSessionRecords)
-    const replacedSleepingRecords: Record<string, (typeof sleepingAgentSessionRecords)[string]> = {}
-    for (const key of sleepingRecordKeys) {
-      const existing = state.sleepingAgentSessionsByPaneKey[key]
-      if (existing) {
-        replacedSleepingRecords[key] = existing
-      }
-    }
-
-    const rollbackTargetShutdownState = (): void => {
-      set((s) => {
-        const next = { ...s.suppressedPtyExitIds }
-        for (const ptyId of exitGuardPtyIds) {
-          delete next[ptyId]
+      const sleepingAgentSessionRecords = collectSleepingAgentSessionRecordsForWorktree(
+        state,
+        worktreeId,
+        {
+          paneKeys,
+          captureMode: 'completed-agent-hibernation'
         }
-        const nextSleeping = { ...s.sleepingAgentSessionsByPaneKey }
-        for (const key of sleepingRecordKeys) {
-          const replaced = replacedSleepingRecords[key]
-          if (replaced) {
-            nextSleeping[key] = replaced
-          } else {
-            delete nextSleeping[key]
+      )
+      const retainedCompletionEvidence = collectHibernatedCompletionEvidenceForWorktree(
+        state,
+        worktreeId,
+        paneKeys
+      )
+      if (!sleepingAgentSessionRecords[opts.paneKey]) {
+        // Why: killing the PTY with no persisted resume record strands the pane unwakeable; abort instead of hibernating unrecoverably.
+        throw new Error('agent_hibernation_capture_missing')
+      }
+
+      const capture = shutdownBufferCaptures.get(opts.tabId)
+      if (capture) {
+        try {
+          capture({ includeLocalBuffers: false })
+        } catch {
+          // Don't let one tab's capture failure block the pane hibernation.
+        }
+      }
+
+      // Why: store sleeping records before kill, since pty:exit can arrive first.
+      const sleepingRecordKeys = Object.keys(sleepingAgentSessionRecords)
+      const replacedSleepingRecords: Record<string, (typeof sleepingAgentSessionRecords)[string]> =
+        {}
+      for (const key of sleepingRecordKeys) {
+        const existing = state.sleepingAgentSessionsByPaneKey[key]
+        if (existing) {
+          replacedSleepingRecords[key] = existing
+        }
+      }
+
+      const rollbackTargetShutdownState = (): void => {
+        set((s) => {
+          const next = { ...s.suppressedPtyExitIds }
+          for (const ptyId of exitGuardPtyIds) {
+            delete next[ptyId]
           }
+          const nextSleeping = { ...s.sleepingAgentSessionsByPaneKey }
+          for (const key of sleepingRecordKeys) {
+            const replaced = replacedSleepingRecords[key]
+            if (replaced) {
+              nextSleeping[key] = replaced
+            } else {
+              delete nextSleeping[key]
+            }
+          }
+          return { suppressedPtyExitIds: next, sleepingAgentSessionsByPaneKey: nextSleeping }
+        })
+      }
+
+      set((s) => ({
+        ...(targetIsLive
+          ? {
+              suppressedPtyExitIds: {
+                ...s.suppressedPtyExitIds,
+                ...Object.fromEntries(exitGuardPtyIds.map((ptyId) => [ptyId, true] as const))
+              }
+            }
+          : {}),
+        sleepingAgentSessionsByPaneKey: {
+          ...s.sleepingAgentSessionsByPaneKey,
+          ...sleepingAgentSessionRecords
         }
-        return { suppressedPtyExitIds: next, sleepingAgentSessionsByPaneKey: nextSleeping }
-      })
-    }
+      }))
 
-    set((s) => ({
-      suppressedPtyExitIds: {
-        ...s.suppressedPtyExitIds,
-        ...Object.fromEntries(exitGuardPtyIds.map((ptyId) => [ptyId, true] as const))
-      },
-      sleepingAgentSessionsByPaneKey: {
-        ...s.sleepingAgentSessionsByPaneKey,
-        ...sleepingAgentSessionRecords
-      }
-    }))
-
-    if (expectedRuntimePtyIds.length > 0) {
-      if (!runtimeEnvironmentId) {
-        rollbackTargetShutdownState()
-        throw new Error('missing_runtime_for_exact_terminal_stop')
-      }
-      let stopResult: {
-        stoppedPtyIds?: string[]
-        livePtyIds?: string[]
-        postStopVerified?: boolean
-        postStopFailure?: string
-      }
-      try {
-        stopResult = await callRuntimeRpc<{
+      if (expectedRuntimePtyIds.length > 0) {
+        if (!runtimeEnvironmentId) {
+          rollbackTargetShutdownState()
+          throw new Error('missing_runtime_for_exact_terminal_stop')
+        }
+        let stopResult: {
           stoppedPtyIds?: string[]
           livePtyIds?: string[]
           postStopVerified?: boolean
           postStopFailure?: string
-        }>(
-          { kind: 'environment', environmentId: runtimeEnvironmentId },
-          'terminal.stopExact',
-          {
-            worktree: toRuntimeWorktreeSelector(worktreeId),
-            expectedPtyIds: expectedRuntimePtyIds,
-            keepHistory: true,
-            targetOnly: true
-          },
-          { timeoutMs: 15_000 }
-        )
-      } catch (err) {
-        rollbackTargetShutdownState()
-        throw err
-      }
-      const stoppedPtyIds = sortedUniquePtyIds(stopResult.stoppedPtyIds)
-      const livePtyIds = sortedUniquePtyIds(stopResult.livePtyIds)
-      const targetWasLive = expectedRuntimePtyIds.every((ptyId) => livePtyIds.includes(ptyId))
-      if (!equalStringSets(stoppedPtyIds, expectedRuntimePtyIds) || !targetWasLive) {
-        rollbackTargetShutdownState()
-        throw new Error('exact_terminal_stop_mismatch')
-      }
-      if (stopResult.postStopVerified !== true) {
-        rollbackTargetShutdownState()
-        throw new Error(stopResult.postStopFailure ?? 'exact_terminal_stop_unverified')
-      }
-      for (const snapshot of unregisterPtyDataHandlers(rendererShutdownPtyIds) ?? []) {
-        snapshot.commit?.()
-      }
-    } else if (!opts.ptyId.startsWith('remote:')) {
-      // Why: pty.kill can flush final data before exit; unregister first so stale handlers can't fire phantom notifications during hibernation.
-      const handlerSnapshots = unregisterPtyDataHandlers(rendererShutdownPtyIds) ?? []
-      try {
-        await window.api.pty.kill(opts.ptyId, { keepHistory: true })
-      } catch (err) {
-        restorePtyDataHandlersAfterFailedShutdown(handlerSnapshots)
-        rollbackTargetShutdownState()
-        throw err
-      }
-      for (const snapshot of handlerSnapshots) {
-        snapshot.commit?.()
-      }
-    }
-
-    const stateAfterShutdown = get()
-    const tabAfterShutdown = (stateAfterShutdown.tabsByWorktree[worktreeId] ?? []).find(
-      (candidate) => candidate.id === opts.tabId
-    )
-    const panePtyAfterShutdown =
-      stateAfterShutdown.terminalLayoutsByTabId[opts.tabId]?.ptyIdsByLeafId?.[opts.leafId]
-    if (
-      !tabAfterShutdown ||
-      tabAfterShutdown.createdAt !== tab.createdAt ||
-      (panePtyAfterShutdown !== undefined && panePtyAfterShutdown !== opts.ptyId)
-    ) {
-      // Why: the stopped process is gone, but a replacement pane owns all later store cleanup.
-      return
-    }
-
-    set((s) => {
-      const existingPtyIds = s.ptyIdsByTabId[opts.tabId] ?? []
-      const shutdownPtyIdSet = new Set(rendererShutdownPtyIds)
-      const remainingPtyIds = existingPtyIds.filter((ptyId) => !shutdownPtyIdSet.has(ptyId))
-      const nextTabsByWorktree = { ...s.tabsByWorktree }
-      const tabs = nextTabsByWorktree[worktreeId] ?? []
-      const tabIndex = tabs.findIndex((candidate) => candidate.id === opts.tabId)
-      if (tabIndex !== -1) {
-        const nextTabs = [...tabs]
-        nextTabs[tabIndex] = {
-          ...nextTabs[tabIndex],
-          ptyId: remainingPtyIds.at(-1) ?? null
         }
-        nextTabsByWorktree[worktreeId] = nextTabs
+        try {
+          stopResult = await callRuntimeRpc<{
+            stoppedPtyIds?: string[]
+            livePtyIds?: string[]
+            postStopVerified?: boolean
+            postStopFailure?: string
+          }>(
+            { kind: 'environment', environmentId: runtimeEnvironmentId },
+            'terminal.stopExact',
+            {
+              worktree: toRuntimeWorktreeSelector(worktreeId),
+              expectedPtyIds: expectedRuntimePtyIds,
+              keepHistory: true,
+              targetOnly: true
+            },
+            { timeoutMs: 15_000 }
+          )
+        } catch (err) {
+          rollbackTargetShutdownState()
+          throw err
+        }
+        const stoppedPtyIds = sortedUniquePtyIds(stopResult.stoppedPtyIds)
+        const livePtyIds = sortedUniquePtyIds(stopResult.livePtyIds)
+        const targetWasLive = expectedRuntimePtyIds.every((ptyId) => livePtyIds.includes(ptyId))
+        if (!equalStringSets(stoppedPtyIds, expectedRuntimePtyIds) || !targetWasLive) {
+          rollbackTargetShutdownState()
+          throw new Error('exact_terminal_stop_mismatch')
+        }
+        if (stopResult.postStopVerified !== true) {
+          rollbackTargetShutdownState()
+          throw new Error(stopResult.postStopFailure ?? 'exact_terminal_stop_unverified')
+        }
+        for (const snapshot of unregisterPtyDataHandlers(rendererShutdownPtyIds) ?? []) {
+          snapshot.commit?.()
+        }
+      } else if (targetIsLive && !opts.ptyId.startsWith('remote:')) {
+        // Why: pty.kill can flush final data before exit; unregister first so stale handlers can't fire phantom notifications during hibernation.
+        const handlerSnapshots = unregisterPtyDataHandlers(rendererShutdownPtyIds) ?? []
+        try {
+          await window.api.pty.kill(opts.ptyId, { keepHistory: true })
+        } catch (err) {
+          restorePtyDataHandlersAfterFailedShutdown(handlerSnapshots)
+          rollbackTargetShutdownState()
+          throw err
+        }
+        for (const snapshot of handlerSnapshots) {
+          snapshot.commit?.()
+        }
       }
 
-      const nextCodexRestartNoticeByPtyId = { ...s.codexRestartNoticeByPtyId }
-      for (const ptyId of exitGuardPtyIds) {
-        delete nextCodexRestartNoticeByPtyId[ptyId]
-      }
-      const nextLastKnownRelay =
-        remainingPtyIds.length === 0
-          ? { ...s.lastKnownRelayPtyIdByTabId }
-          : s.lastKnownRelayPtyIdByTabId
-      if (remainingPtyIds.length === 0) {
-        delete nextLastKnownRelay[opts.tabId]
-      }
-
-      let nextRuntimePaneTitlesByTabId = s.runtimePaneTitlesByTabId
-      const numericPaneId = Number(opts.leafId)
+      const stateAfterShutdown = get()
+      const tabAfterShutdown = (stateAfterShutdown.tabsByWorktree[worktreeId] ?? []).find(
+        (candidate) => candidate.id === opts.tabId
+      )
+      const panePtyAfterShutdown =
+        stateAfterShutdown.terminalLayoutsByTabId[opts.tabId]?.ptyIdsByLeafId?.[opts.leafId]
+      const livePtyIdsAfterShutdown = stateAfterShutdown.ptyIdsByTabId[opts.tabId] ?? []
       if (
-        Number.isInteger(numericPaneId) &&
-        s.runtimePaneTitlesByTabId[opts.tabId]?.[numericPaneId]
+        !tabAfterShutdown ||
+        tabAfterShutdown.createdAt !== tab.createdAt ||
+        (tabAfterShutdown.ptyId !== null && !liveTabPtyIds.includes(tabAfterShutdown.ptyId)) ||
+        livePtyIdsAfterShutdown.some((ptyId) => !liveTabPtyIds.includes(ptyId)) ||
+        (panePtyAfterShutdown !== undefined && panePtyAfterShutdown !== opts.ptyId)
       ) {
-        const nextByPane = { ...s.runtimePaneTitlesByTabId[opts.tabId] }
-        delete nextByPane[numericPaneId]
-        nextRuntimePaneTitlesByTabId = { ...s.runtimePaneTitlesByTabId }
-        if (Object.keys(nextByPane).length > 0) {
-          nextRuntimePaneTitlesByTabId[opts.tabId] = nextByPane
-        } else {
-          delete nextRuntimePaneTitlesByTabId[opts.tabId]
+        // Why: the stopped process is gone, but a replacement pane owns all live/status cleanup.
+        set((s) => {
+          const nextSuppressed = { ...s.suppressedPtyExitIds }
+          delete nextSuppressed[opts.ptyId]
+          const nextSleeping = { ...s.sleepingAgentSessionsByPaneKey }
+          if (nextSleeping[opts.paneKey] === sleepingAgentSessionRecords[opts.paneKey]) {
+            delete nextSleeping[opts.paneKey]
+          }
+          return {
+            suppressedPtyExitIds: nextSuppressed,
+            sleepingAgentSessionsByPaneKey: nextSleeping
+          }
+        })
+        return
+      }
+
+      set((s) => {
+        const existingPtyIds = s.ptyIdsByTabId[opts.tabId] ?? []
+        const shutdownPtyIdSet = new Set(rendererShutdownPtyIds)
+        const remainingPtyIds = existingPtyIds.filter((ptyId) => !shutdownPtyIdSet.has(ptyId))
+        const nextTabsByWorktree = { ...s.tabsByWorktree }
+        const tabs = nextTabsByWorktree[worktreeId] ?? []
+        const tabIndex = tabs.findIndex((candidate) => candidate.id === opts.tabId)
+        if (tabIndex !== -1) {
+          const nextTabs = [...tabs]
+          nextTabs[tabIndex] = {
+            ...nextTabs[tabIndex],
+            ptyId: remainingPtyIds.at(-1) ?? null
+          }
+          nextTabsByWorktree[worktreeId] = nextTabs
         }
+
+        const nextCodexRestartNoticeByPtyId = { ...s.codexRestartNoticeByPtyId }
+        for (const ptyId of exitGuardPtyIds) {
+          delete nextCodexRestartNoticeByPtyId[ptyId]
+        }
+        const nextLastKnownRelay =
+          remainingPtyIds.length === 0
+            ? { ...s.lastKnownRelayPtyIdByTabId }
+            : s.lastKnownRelayPtyIdByTabId
+        if (remainingPtyIds.length === 0) {
+          delete nextLastKnownRelay[opts.tabId]
+        }
+
+        let nextRuntimePaneTitlesByTabId = s.runtimePaneTitlesByTabId
+        const numericPaneId = Number(opts.leafId)
+        if (
+          Number.isInteger(numericPaneId) &&
+          s.runtimePaneTitlesByTabId[opts.tabId]?.[numericPaneId]
+        ) {
+          const nextByPane = { ...s.runtimePaneTitlesByTabId[opts.tabId] }
+          delete nextByPane[numericPaneId]
+          nextRuntimePaneTitlesByTabId = { ...s.runtimePaneTitlesByTabId }
+          if (Object.keys(nextByPane).length > 0) {
+            nextRuntimePaneTitlesByTabId[opts.tabId] = nextByPane
+          } else {
+            delete nextRuntimePaneTitlesByTabId[opts.tabId]
+          }
+        }
+
+        const nextUnreadTerminalPanes = { ...s.unreadTerminalPanes }
+        const nextUnreadAgentCompletionPanes = { ...s.unreadAgentCompletionPanes }
+        const nextLastTerminalInputAtByPaneKey = { ...s.lastTerminalInputAtByPaneKey }
+        delete nextUnreadTerminalPanes[opts.paneKey]
+        delete nextUnreadAgentCompletionPanes[opts.paneKey]
+        delete nextLastTerminalInputAtByPaneKey[opts.paneKey]
+
+        return {
+          tabsByWorktree: nextTabsByWorktree,
+          ptyIdsByTabId: {
+            ...s.ptyIdsByTabId,
+            [opts.tabId]: remainingPtyIds
+          },
+          lastKnownRelayPtyIdByTabId: nextLastKnownRelay,
+          ...(targetIsLive
+            ? {
+                suppressedPtyExitIds: {
+                  ...s.suppressedPtyExitIds,
+                  ...Object.fromEntries(exitGuardPtyIds.map((ptyId) => [ptyId, true] as const))
+                }
+              }
+            : {}),
+          codexRestartNoticeByPtyId: nextCodexRestartNoticeByPtyId,
+          ...(nextRuntimePaneTitlesByTabId !== s.runtimePaneTitlesByTabId
+            ? { runtimePaneTitlesByTabId: nextRuntimePaneTitlesByTabId }
+            : {}),
+          unreadTerminalPanes: nextUnreadTerminalPanes,
+          unreadAgentCompletionPanes: nextUnreadAgentCompletionPanes,
+          lastTerminalInputAtByPaneKey: nextLastTerminalInputAtByPaneKey
+        }
+      })
+
+      get().dropHibernatedAgentStatusPane(worktreeId, opts.paneKey, {
+        retainedCompletionEvidence
+      })
+    })()
+    completedAgentPaneHibernations.set(hibernationKey, hibernation)
+    return hibernation.finally(() => {
+      if (completedAgentPaneHibernations.get(hibernationKey) === hibernation) {
+        completedAgentPaneHibernations.delete(hibernationKey)
       }
-
-      const nextUnreadTerminalPanes = { ...s.unreadTerminalPanes }
-      const nextUnreadAgentCompletionPanes = { ...s.unreadAgentCompletionPanes }
-      const nextLastTerminalInputAtByPaneKey = { ...s.lastTerminalInputAtByPaneKey }
-      delete nextUnreadTerminalPanes[opts.paneKey]
-      delete nextUnreadAgentCompletionPanes[opts.paneKey]
-      delete nextLastTerminalInputAtByPaneKey[opts.paneKey]
-
-      return {
-        tabsByWorktree: nextTabsByWorktree,
-        ptyIdsByTabId: {
-          ...s.ptyIdsByTabId,
-          [opts.tabId]: remainingPtyIds
-        },
-        lastKnownRelayPtyIdByTabId: nextLastKnownRelay,
-        suppressedPtyExitIds: {
-          ...s.suppressedPtyExitIds,
-          ...Object.fromEntries(exitGuardPtyIds.map((ptyId) => [ptyId, true] as const))
-        },
-        codexRestartNoticeByPtyId: nextCodexRestartNoticeByPtyId,
-        ...(nextRuntimePaneTitlesByTabId !== s.runtimePaneTitlesByTabId
-          ? { runtimePaneTitlesByTabId: nextRuntimePaneTitlesByTabId }
-          : {}),
-        unreadTerminalPanes: nextUnreadTerminalPanes,
-        unreadAgentCompletionPanes: nextUnreadAgentCompletionPanes,
-        lastTerminalInputAtByPaneKey: nextLastTerminalInputAtByPaneKey
-      }
-    })
-
-    get().dropHibernatedAgentStatusPane(worktreeId, opts.paneKey, {
-      retainedCompletionEvidence
     })
   },
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​702 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​187 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​515 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​465 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​273 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​192 |

<!-- /orca-pr-loc -->

## Summary

- hibernate completed automation agent panes instead of deleting their tabs
- preserve the main-process terminal surface through overlapping, failed, and late SSH history-preserving stops
- retain the provider session, layout, sleeping record, and terminal transcript across restart/resume

## Current-main reproduction

Using an isolated Electron profile, I created and ran an automation through the production IPC/session path on `4daace6251`. When Codex completed, the workspace persisted `tabs: []` with no sleeping session; **Resume workspace** opened a blank `Terminal 1` instead of the run.

Expected: the completed run stays visible by default and resumes the exact agent session.

Actual: the completion cleanup deleted the only tab and its resumable identity.

![Current main resumes a blank workspace](https://github.com/user-attachments/assets/fd49b40e-cb33-4bee-a840-359a9b6c7f75)

## Root cause and fix boundary

`AutomationTerminalOwnership.finalize()` used the general tab-close path, so successful automation completion removed the run surface. Switching that ownership boundary to the existing completed-agent hibernation path exposed a second lifecycle bug: the main process retired the durable surface on provider exit because a repeated `connected` publication had erased the prior stop bookkeeping.

The fix reuses the existing renderer hibernation owner and brackets local/SSH `pty:kill(... keepHistory: true)` with request-scoped main-process surface leases. Each overlapping stop owns its lease; failed stops retain it through a late exit, and SSH synthetic exits retain it until the host-confirmed exit. Post-stop renderer cleanup also refuses to mutate a tab generation or pane binding that was replaced while shutdown awaited. There are no new UI defaults, wire fields/opcodes, schemas, provider assumptions, or duplicated recovery fallbacks.

## Baseline / candidate / revert proof

- focused regression failed on current main: completion closed the owned automation tab
- candidate passed and the real run remained visible, persisted, and resumable
- reverting only `6f43c84534` made the focused test fail with the original assertion and a real run again persisted `tabs: []`
- aborting the revert restored the passing candidate

Final candidate run `56e5b793-cee4-4bd1-a33c-52b160d84a38` retained provider session `01a01df7-8af2-7af3-b29a-e4fa827893d6`. The same tab, layout, unified tab/group records, and sleeping session survived a full app restart; cold activation restored the original prompt and `STA4870_DONE` transcript rather than creating a blank terminal.

![Completed run remains visible](https://github.com/user-attachments/assets/2d68ab5c-7a25-432c-97f3-f84b7b33c815)

![Exact session resumes after restart](https://github.com/user-attachments/assets/bcec204b-8aa4-4533-956a-5d2020373f4e)

## Compatibility boundary

- local and SSH desktop PTYs use the same `pty:kill` ownership bracket
- paired/environment terminals continue through the existing capability-compatible `terminal.stopExact` path
- workspace identity is passed through existing selectors, so folder workspaces and git worktrees share the fix
- restart/reconnect durability uses existing persisted tabs/layout/sleeping-session records
- no remote wire or persisted schema change; mixed-version peers retain existing behavior

Immediately after a cold app restart, the durable workspace/tab is present but the inline agent child row is rebuilt only when the workspace is activated. Activation restores the exact session. That pre-activation row hydration is existing behavior and is outside this ticket's completed-run deletion regression.

## Independent review

Three fresh read-only gpt-5.6-luna reviewers audited lifecycle races, end-to-end coverage, and local/remote compatibility in the same worktree. Confirmed findings were fixed and regression-covered: overlapping hibernation calls now coalesce; exit-before-finalization still captures the resumable record; partial tab/index rebinding cannot erase a replacement; delayed teardown is fenced for legacy no-incarnation providers and SSH reattachments; and stale stop intent is request-scoped. CodeRabbit independently flagged the partial-rebinding race, which the same guard/test addresses. An alleged direct-SSH late-exit lease leak was rejected after tracing `SshPtyOutputIntake.finalizeExit`: it calls `runtime.onPtyExit` before relay retirement, while the synthetic duplicate map belongs only to the local-provider path.

## Validation

- `src/main/ipc/pty-runtime-kill-and-exit.test.ts` — passing
- `src/main/runtime/orca-runtime-terminal-retirement.test.ts` — passing
- `src/renderer/src/lib/automation-terminal-ownership.test.ts` — passing
- `src/renderer/src/store/slices/store-sleep-pane-hibernation.test.ts` and failure-race split — passing
- expanded lifecycle/resume suite: 1,341 passed, 1 skipped across 13 files
- `pnpm run typecheck:tsc:node`
- `pnpm run typecheck:tsc:web`
- `pnpm run check:code-quality:changed`
- `git diff --check`

Closes STA-4870 after human verification; this draft does not merge or close the Linear issue.
