### PR TITLE
fix(runtime): settle exited headless terminal closes

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -571,6 +571,15 @@ jobs:
           src/main/runtime/worktree-scan-admin-fingerprint-gate.test.ts
           src/shared/secure-file-fsync-flags.test.ts
 
+      - name: Build Electron app for Windows terminal lifecycle E2E
+        run: pnpm exec electron-vite build --mode e2e
+
+      - name: Run Windows terminal close lifecycle regression
+        env:
+          SKIP_BUILD: '1'
+          ORCA_E2E_FORWARD_APP_LOGS: '1'
+        run: pnpm run test:e2e tests/e2e/windows-headless-terminal-close-lifecycle.spec.ts --workers=1
+
       # Why the :parallel variant: identical to build:release except the three
       # electron-vite targets overlap instead of running back to back. The Linux package
       # job already packages and smoke-tests an AppImage built that way.

--- a/.github/workflows/windows-terminal-restart-e2e.yml
+++ b/.github/workflows/windows-terminal-restart-e2e.yml
@@ -59,7 +59,8 @@ jobs:
           pnpm run test:e2e
           tests/e2e/restart-restore-terminal-input.spec.ts
           tests/e2e/terminal-restart-persistence.spec.ts
-          --grep "clean restart with a live daemon session|cold-restored pane accepts typing|daemon snapshot relaunch preserves"
+          tests/e2e/windows-headless-terminal-close-lifecycle.spec.ts
+          --grep "clean restart with a live daemon session|cold-restored pane accepts typing|daemon snapshot relaunch preserves|physical Windows exit wins the headless-tab close race"
           --workers=1
 
       - name: Upload Playwright traces

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -31441,7 +31441,6 @@ describe('OrcaRuntimeService', () => {
     runtime.syncWindowGraph(0, { tabs: [], leaves: [] })
     await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
     const handle = runtime.preAllocateHandleForPty(ptyId)
-    vi.spyOn(runtime, 'closeMobileSessionTab').mockRejectedValue(new Error('tab_not_found'))
 
     await expect(runtime.closeTerminal(handle)).resolves.toEqual({
       handle,
@@ -31449,6 +31448,52 @@ describe('OrcaRuntimeService', () => {
       ptyKilled: true
     })
     expect(kill).toHaveBeenCalledWith(ptyId)
+    expect((await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)).tabs).toEqual([])
+  })
+
+  it('does not mask a missing durable tab while its headless surface remains live', async () => {
+    const ptyId = 'headless-worker-live-tab'
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession(
+      makeWorkspaceSessionWithHeadlessTerminal({
+        tabsByWorktree: {
+          [TEST_WORKTREE_ID]: [
+            {
+              id: 'host-tab',
+              ptyId,
+              worktreeId: TEST_WORKTREE_ID,
+              title: 'Headless worker',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1
+            }
+          ]
+        },
+        terminalLayoutsByTabId: {
+          'host-tab': makeHeadlessTerminalLayout({ [HEADLESS_LEAF_ID]: ptyId })
+        }
+      })
+    )
+    const kill = vi.fn(() => false)
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    runtime.setPtyController({
+      write: () => true,
+      kill,
+      getForegroundProcess: async () => null,
+      listProcesses: async () => []
+    })
+    runtime.registerPty(ptyId, TEST_WORKTREE_ID, null, {
+      tabId: 'host-tab',
+      leafId: HEADLESS_LEAF_ID
+    })
+    runtime.syncWindowGraph(0, { tabs: [], leaves: [] })
+    await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+    const handle = runtime.preAllocateHandleForPty(ptyId)
+    vi.spyOn(runtime, 'closeMobileSessionTab').mockRejectedValue(new Error('tab_not_found'))
+
+    await expect(runtime.closeTerminal(handle)).rejects.toThrow('tab_not_found')
+    expect(kill).toHaveBeenCalledWith(ptyId)
+    expect((await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)).tabs).not.toEqual([])
   })
 
   it('keeps the renderer close transaction for an adopted runtime-owned tab', async () => {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -31399,6 +31399,58 @@ describe('OrcaRuntimeService', () => {
     expect((await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)).tabs).toEqual([])
   })
 
+  it('keeps a confirmed PTY stop successful when its exited headless tab is already absent', async () => {
+    const ptyId = 'headless-worker-exited-tab'
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession(
+      makeWorkspaceSessionWithHeadlessTerminal({
+        tabsByWorktree: {
+          [TEST_WORKTREE_ID]: [
+            {
+              id: 'host-tab',
+              ptyId,
+              worktreeId: TEST_WORKTREE_ID,
+              title: 'Headless worker',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1
+            }
+          ]
+        },
+        terminalLayoutsByTabId: {
+          'host-tab': makeHeadlessTerminalLayout({ [HEADLESS_LEAF_ID]: ptyId })
+        }
+      })
+    )
+    let runtime!: OrcaRuntimeService
+    const kill = vi.fn((closedPtyId: string) => {
+      runtime.onPtyExit(closedPtyId, 143)
+      return true
+    })
+    runtime = new OrcaRuntimeService(runtimeStore as never)
+    runtime.setPtyController({
+      write: () => true,
+      kill,
+      getForegroundProcess: async () => null,
+      listProcesses: async () => []
+    })
+    runtime.registerPty(ptyId, TEST_WORKTREE_ID, null, {
+      tabId: 'host-tab',
+      leafId: HEADLESS_LEAF_ID
+    })
+    runtime.syncWindowGraph(0, { tabs: [], leaves: [] })
+    await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+    const handle = runtime.preAllocateHandleForPty(ptyId)
+    vi.spyOn(runtime, 'closeMobileSessionTab').mockRejectedValue(new Error('tab_not_found'))
+
+    await expect(runtime.closeTerminal(handle)).resolves.toEqual({
+      handle,
+      tabId: 'host-tab',
+      ptyKilled: true
+    })
+    expect(kill).toHaveBeenCalledWith(ptyId)
+  })
+
   it('keeps the renderer close transaction for an adopted runtime-owned tab', async () => {
     // The renderer pin state can be newer than the debounced session, so once adopted its live close guard must win over stale persisted metadata.
     const servePtyId = 'serve-adopted-1'

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -31451,6 +31451,86 @@ describe('OrcaRuntimeService', () => {
     expect((await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)).tabs).toEqual([])
   })
 
+  it('settles a renderer-owned close when another transaction retires its surface first', async () => {
+    const ptyId = 'renderer-worker-retired-tab'
+    const { runtimeStore, getSession } = makeRuntimeStoreWithWorkspaceSession(
+      makeWorkspaceSessionWithHeadlessTerminal({
+        tabsByWorktree: {
+          [TEST_WORKTREE_ID]: [
+            {
+              id: 'host-tab',
+              ptyId,
+              worktreeId: TEST_WORKTREE_ID,
+              title: 'Renderer worker',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1
+            }
+          ]
+        },
+        terminalLayoutsByTabId: {
+          'host-tab': makeHeadlessTerminalLayout({ [HEADLESS_LEAF_ID]: ptyId })
+        }
+      })
+    )
+    const kill = vi.fn(() => true)
+    const closeTerminalTab = vi.fn(async () => {})
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    runtime.setNotifier({ closeTerminalTab } as never)
+    runtime.setPtyController({
+      write: () => true,
+      kill,
+      getForegroundProcess: async () => null,
+      listProcesses: async () => []
+    })
+    runtime.registerPty(ptyId, TEST_WORKTREE_ID, null, {
+      tabId: 'host-tab',
+      leafId: HEADLESS_LEAF_ID
+    })
+    runtime.syncWindowGraph(1, {
+      tabs: [
+        {
+          tabId: 'host-tab',
+          worktreeId: TEST_WORKTREE_ID,
+          title: 'Renderer worker',
+          activeLeafId: HEADLESS_LEAF_ID,
+          layout: null
+        }
+      ],
+      leaves: [
+        {
+          tabId: 'host-tab',
+          worktreeId: TEST_WORKTREE_ID,
+          leafId: HEADLESS_LEAF_ID,
+          paneRuntimeId: 1,
+          ptyId
+        }
+      ]
+    })
+    const listed = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+    const terminal = listed.tabs.find((tab) => tab.type === 'terminal')
+    if (!terminal || terminal.type !== 'terminal' || !terminal.terminal) {
+      throw new Error('Expected a ready terminal')
+    }
+    const closeMobileSessionTab = runtime.closeMobileSessionTab.bind(runtime)
+    vi.spyOn(runtime, 'closeMobileSessionTab').mockImplementation(async (...args) => {
+      runtime.syncWindowGraph(1, { tabs: [], leaves: [] })
+      await closeMobileSessionTab(...args)
+      throw new Error('tab_not_found')
+    })
+
+    await expect(runtime.closeTerminal(terminal.terminal)).resolves.toEqual({
+      handle: terminal.terminal,
+      tabId: 'host-tab',
+      ptyKilled: true
+    })
+    expect(kill).toHaveBeenCalledWith(ptyId)
+    expect(closeTerminalTab).not.toHaveBeenCalled()
+    expect(getSession().tabsByWorktree[TEST_WORKTREE_ID]).toEqual([])
+    expect((await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)).tabs).toEqual([])
+  })
+
   it('does not mask a missing durable tab while its headless surface remains live', async () => {
     const ptyId = 'headless-worker-live-tab'
     const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession(

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -31475,9 +31475,10 @@ describe('OrcaRuntimeService', () => {
       })
     )
     const kill = vi.fn(() => true)
+    const closeTerminal = vi.fn()
     const closeTerminalTab = vi.fn(async () => {})
     const runtime = new OrcaRuntimeService(runtimeStore as never)
-    runtime.setNotifier({ closeTerminalTab } as never)
+    runtime.setNotifier({ closeTerminal, closeTerminalTab } as never)
     runtime.setPtyController({
       write: () => true,
       kill,
@@ -31526,6 +31527,7 @@ describe('OrcaRuntimeService', () => {
       ptyKilled: true
     })
     expect(kill).toHaveBeenCalledWith(ptyId)
+    expect(closeTerminal).toHaveBeenCalledWith('host-tab')
     expect(closeTerminalTab).not.toHaveBeenCalled()
     expect(getSession().tabsByWorktree[TEST_WORKTREE_ID]).toEqual([])
     expect((await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)).tabs).toEqual([])
@@ -31574,6 +31576,113 @@ describe('OrcaRuntimeService', () => {
     await expect(runtime.closeTerminal(handle)).rejects.toThrow('tab_not_found')
     expect(kill).toHaveBeenCalledWith(ptyId)
     expect((await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)).tabs).not.toEqual([])
+  })
+
+  it('does not settle a missing mobile projection while the renderer still owns the parent', () => {
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession(getDefaultWorkspaceSession())
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    runtime.syncWindowGraph(1, {
+      tabs: [
+        {
+          tabId: 'host-tab',
+          worktreeId: TEST_WORKTREE_ID,
+          title: 'Headless worker',
+          activeLeafId: HEADLESS_LEAF_ID,
+          layout: null
+        }
+      ],
+      leaves: []
+    })
+    const isAlreadyRetired = (
+      runtime as unknown as {
+        isAlreadyRetiredMobileTerminalSurfaceError: (
+          error: Error,
+          worktreeId: string,
+          parentTabId: string
+        ) => boolean
+      }
+    ).isAlreadyRetiredMobileTerminalSurfaceError.bind(runtime)
+
+    expect(isAlreadyRetired(new Error('tab_not_found'), TEST_WORKTREE_ID, 'host-tab')).toBe(false)
+  })
+
+  it('keeps a split sibling when exit retires the addressed leaf before an unconfirmed stop returns', async () => {
+    const tabId = '33333333-3333-4333-8333-333333333333'
+    const leftPtyId = 'headless-split-left'
+    const rightPtyId = 'headless-split-right'
+    const layout = makeHeadlessTerminalLayout({
+      [HEADLESS_LEAF_ID]: leftPtyId,
+      [HEADLESS_SECOND_LEAF_ID]: rightPtyId
+    })
+    const { runtimeStore, getSession } = makeRuntimeStoreWithWorkspaceSession(
+      makeWorkspaceSessionWithHeadlessTerminal({
+        activeTabId: tabId,
+        activeTabIdByWorktree: { [TEST_WORKTREE_ID]: tabId },
+        tabsByWorktree: {
+          [TEST_WORKTREE_ID]: [
+            {
+              id: tabId,
+              ptyId: leftPtyId,
+              worktreeId: TEST_WORKTREE_ID,
+              title: 'Split workers',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1
+            }
+          ]
+        },
+        terminalLayoutsByTabId: { [tabId]: layout }
+      })
+    )
+    let runtime!: OrcaRuntimeService
+    let tabIdsAfterExit: string[] = []
+    const kill = vi.fn(() => false)
+    const stopAndWait = vi.fn(async (ptyId: string) => {
+      runtime.onPtyExit(ptyId, 0)
+      tabIdsAfterExit = (await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)).tabs.map(
+        (tab) => tab.id
+      )
+      return false
+    })
+    runtime = new OrcaRuntimeService({ ...runtimeStore, flushOrThrow: vi.fn() } as never)
+    runtime.setPtyController({
+      write: () => true,
+      kill,
+      stopAndWait,
+      getForegroundProcess: async () => null,
+      listProcesses: async () => []
+    })
+    runtime.registerPty(leftPtyId, TEST_WORKTREE_ID, null, {
+      tabId,
+      leafId: HEADLESS_LEAF_ID
+    })
+    runtime.registerPty(rightPtyId, TEST_WORKTREE_ID, null, {
+      tabId,
+      leafId: HEADLESS_SECOND_LEAF_ID
+    })
+    runtime.syncWindowGraph(0, { tabs: [], leaves: [] })
+    await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+    const rightHandle = runtime.preAllocateHandleForPty(rightPtyId)
+
+    await expect(runtime.closeTerminal(rightHandle)).resolves.toMatchObject({
+      handle: rightHandle,
+      tabId,
+      ptyKilled: false,
+      ptyStopVerdict: 'unverifiable'
+    })
+
+    expect(stopAndWait).toHaveBeenCalledWith(rightPtyId, expect.anything())
+    expect(tabIdsAfterExit).toEqual([`${tabId}::${HEADLESS_LEAF_ID}`])
+    expect(kill).toHaveBeenCalledWith(rightPtyId)
+    expect(kill).not.toHaveBeenCalledWith(leftPtyId)
+    expect(getSession().tabsByWorktree[TEST_WORKTREE_ID]).toHaveLength(1)
+    expect(getSession().terminalLayoutsByTabId[tabId]?.ptyIdsByLeafId).toMatchObject({
+      [HEADLESS_LEAF_ID]: leftPtyId
+    })
+    expect(
+      (await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)).tabs.map((tab) => tab.id)
+    ).toEqual([`${tabId}::${HEADLESS_LEAF_ID}`])
   })
 
   it('keeps the renderer close transaction for an adopted runtime-owned tab', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -29161,7 +29161,7 @@ export class OrcaRuntimeService {
   private findMobileTerminalSurface(
     worktreeId: string,
     parentTabId: string,
-    options: { requireReady?: boolean } = {}
+    options: { leafId?: string; requireReady?: boolean } = {}
   ): RuntimeMobileSessionCreateTerminalResult | null {
     const snapshot = this.mobileSessionTabsByWorktree.get(worktreeId)
     if (!snapshot) {
@@ -29169,7 +29169,10 @@ export class OrcaRuntimeService {
     }
     const result = this.toMobileSessionTabsResult(snapshot)
     const tab = result.tabs.find(
-      (candidate) => candidate.type === 'terminal' && candidate.parentTabId === parentTabId
+      (candidate) =>
+        candidate.type === 'terminal' &&
+        candidate.parentTabId === parentTabId &&
+        (options.leafId === undefined || candidate.leafId === options.leafId)
     )
     if (!tab || tab.type !== 'terminal') {
       return null
@@ -29192,7 +29195,9 @@ export class OrcaRuntimeService {
   ): boolean {
     // Why: missing persistence is ambiguous while a sibling or stale live publication still owns the surface.
     return (
-      error.message === 'tab_not_found' && !this.findMobileTerminalSurface(worktreeId, parentTabId)
+      error.message === 'tab_not_found' &&
+      !this.tabs.has(parentTabId) &&
+      !this.findMobileTerminalSurface(worktreeId, parentTabId)
     )
   }
 
@@ -29208,7 +29213,7 @@ export class OrcaRuntimeService {
           candidate.parentLayout?.ptyIdsByLeafId?.[candidate.leafId] === ptyId)
     )
     return tab?.type === 'terminal'
-      ? this.findMobileTerminalSurface(worktreeId, tab.parentTabId)
+      ? this.findMobileTerminalSurface(worktreeId, tab.parentTabId, { leafId: tab.leafId })
       : null
   }
 
@@ -29795,9 +29800,8 @@ export class OrcaRuntimeService {
     if (pty) {
       // Why: PTY exit can immediately replace a ready SSH publication with a pending one, so capture its durable HUB surface before killing it.
       const surface =
-        (pty.pty.tabId
-          ? this.findMobileTerminalSurface(pty.pty.worktreeId, pty.pty.tabId)
-          : null) ?? this.findMobileTerminalSurfaceForPty(pty.pty.worktreeId, pty.pty.ptyId)
+        this.findMobileTerminalSurfaceForPty(pty.pty.worktreeId, pty.pty.ptyId) ??
+        (pty.pty.tabId ? this.findMobileTerminalSurface(pty.pty.worktreeId, pty.pty.tabId) : null)
       const tabId = surface?.tab.parentTabId ?? pty.pty.tabId ?? pty.record.tabId
       // Why: relay recovery can leave stale renderer leaves; the persisted HUB layout defines whether closing this PTY closes the whole surface.
       const siblingCount = surface?.tab.parentLayout
@@ -29831,7 +29835,16 @@ export class OrcaRuntimeService {
         return this.describeTerminalClose(handle, tabId, pty.pty.ptyId, ptyKilled)
       }
       const ptyKilled = await this.stopExplicitlyClosedTabPtys([pty.pty.ptyId], pty.pty.ptyId)
-      if (!ptyKilled || siblingCount <= 1) {
+      // Why: an exit callback can retire the addressed split leaf before an unconfirmed stop returns; parent fallback would destroy its surviving siblings.
+      const addressedSplitSurfaceRetired =
+        siblingCount > 1 &&
+        surface !== null &&
+        !this.mobileSessionSnapshotHasSurface(
+          pty.pty.worktreeId,
+          surface.tab.parentTabId,
+          surface.tab.leafId
+        )
+      if ((!ptyKilled || siblingCount <= 1) && !addressedSplitSurfaceRetired) {
         if (surface) {
           // Why: paired viewers keep ended streams mounted until the HUB publishes removal, so explicit close uses the durable host-tab transaction instead of viewer-local exit handling.
           try {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -29185,6 +29185,17 @@ export class OrcaRuntimeService {
     return surface
   }
 
+  private isAlreadyRetiredMobileTerminalSurfaceError(
+    error: Error,
+    worktreeId: string,
+    parentTabId: string
+  ): boolean {
+    // Why: missing persistence is ambiguous while a sibling or stale live publication still owns the surface.
+    return (
+      error.message === 'tab_not_found' && !this.findMobileTerminalSurface(worktreeId, parentTabId)
+    )
+  }
+
   private findMobileTerminalSurfaceForPty(
     worktreeId: string,
     ptyId: string
@@ -29799,10 +29810,16 @@ export class OrcaRuntimeService {
             localPtyTeardownOwnedExternally: true
           })
         } catch (error) {
-          if (!(error instanceof Error) || error.message !== 'workspace_session_unavailable') {
+          if (!(error instanceof Error)) {
             throw error
           }
-          this.notifier.closeTerminal?.(tabId)
+          if (error.message === 'workspace_session_unavailable') {
+            this.notifier.closeTerminal?.(tabId)
+          } else if (
+            !this.isAlreadyRetiredMobileTerminalSurfaceError(error, pty.pty.worktreeId, tabId)
+          ) {
+            throw error
+          }
         }
         const ptyKilled = await this.stopExplicitlyClosedTabPtys(ptyIdsToKill, pty.pty.ptyId)
         return this.describeTerminalClose(handle, tabId, pty.pty.ptyId, ptyKilled)
@@ -29826,10 +29843,8 @@ export class OrcaRuntimeService {
             if (error.message === 'workspace_session_unavailable') {
               this.notifier?.closeTerminal(tabId)
             } else if (
-              error.message !== 'tab_not_found' ||
-              this.findMobileTerminalSurface(pty.pty.worktreeId, tabId)
+              !this.isAlreadyRetiredMobileTerminalSurfaceError(error, pty.pty.worktreeId, tabId)
             ) {
-              // Only absence in both persistence and the live publication proves another owner finished teardown.
               throw error
             }
           }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -29820,16 +29820,17 @@ export class OrcaRuntimeService {
           try {
             await this.closeMobileSessionTab(`id:${pty.pty.worktreeId}`, tabId)
           } catch (error) {
-            // Exit handling or another host-tab transaction may retire this surface first.
-            if (
-              !(error instanceof Error) ||
-              (error.message !== 'workspace_session_unavailable' &&
-                error.message !== 'tab_not_found')
-            ) {
+            if (!(error instanceof Error)) {
               throw error
             }
             if (error.message === 'workspace_session_unavailable') {
               this.notifier?.closeTerminal(tabId)
+            } else if (
+              error.message !== 'tab_not_found' ||
+              this.findMobileTerminalSurface(pty.pty.worktreeId, tabId)
+            ) {
+              // Only absence in both persistence and the live publication proves another owner finished teardown.
+              throw error
             }
           }
         } else {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -29820,7 +29820,7 @@ export class OrcaRuntimeService {
           try {
             await this.closeMobileSessionTab(`id:${pty.pty.worktreeId}`, tabId)
           } catch (error) {
-            // The PTY exit may retire its headless tab before this late surface cleanup.
+            // Exit handling or another host-tab transaction may retire this surface first.
             if (
               !(error instanceof Error) ||
               (error.message !== 'workspace_session_unavailable' &&

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -29820,10 +29820,17 @@ export class OrcaRuntimeService {
           try {
             await this.closeMobileSessionTab(`id:${pty.pty.worktreeId}`, tabId)
           } catch (error) {
-            if (!(error instanceof Error) || error.message !== 'workspace_session_unavailable') {
+            // The PTY exit may retire its headless tab before this late surface cleanup.
+            if (
+              !(error instanceof Error) ||
+              (error.message !== 'workspace_session_unavailable' &&
+                error.message !== 'tab_not_found')
+            ) {
               throw error
             }
-            this.notifier?.closeTerminal(tabId)
+            if (error.message === 'workspace_session_unavailable') {
+              this.notifier?.closeTerminal(tabId)
+            }
           }
         } else {
           this.notifier?.closeTerminal(tabId)

--- a/tests/e2e/windows-headless-terminal-close-lifecycle.spec.ts
+++ b/tests/e2e/windows-headless-terminal-close-lifecycle.spec.ts
@@ -118,7 +118,7 @@ test('physical Windows exit wins the headless-tab close race', async ({ testRepo
     const processBefore = await queryWindowsAncestry(childPid!)
     expect(processBefore).toMatchObject([
       { pid: childPid, name: 'node.exe' },
-      { name: 'pwsh.exe' },
+      { name: expect.stringMatching(/^(?:pwsh|powershell)\.exe$/i) },
       { name: 'electron.exe' }
     ])
     const ptyShellPid = processBefore[1]!.pid

--- a/tests/e2e/windows-headless-terminal-close-lifecycle.spec.ts
+++ b/tests/e2e/windows-headless-terminal-close-lifecycle.spec.ts
@@ -1,0 +1,175 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { test, expect } from './helpers/orca-app'
+import { launchHeadlessPairedRuntimeHost } from './helpers/headless-paired-runtime-host'
+import type { RuntimeClient } from '../../src/cli/runtime/client'
+import type {
+  RuntimeMobileSessionTabsResult,
+  RuntimeTerminalClose,
+  RuntimeTerminalCreate,
+  RuntimeTerminalListResult,
+  RuntimeTerminalRead
+} from '../../src/shared/runtime-types'
+
+const execFileAsync = promisify(execFile)
+const CHILD_PID_PREFIX = 'STA4903_CHILD_PID='
+
+type WindowsProcessEvidence = {
+  pid: number
+  parentPid: number
+  name: string
+  handleCount: number | null
+}
+
+async function queryWindowsAncestry(pid: number): Promise<WindowsProcessEvidence[]> {
+  const script = [
+    `$targetPid = ${pid}`,
+    '$rows = Get-CimInstance Win32_Process',
+    '$byPid = @{}',
+    'foreach ($row in $rows) { $byPid[[int]$row.ProcessId] = $row }',
+    '$result = @()',
+    'while ($byPid.ContainsKey($targetPid) -and $result.Count -lt 3) {',
+    '  $row = $byPid[$targetPid]',
+    '  $process = Get-Process -Id $targetPid -ErrorAction SilentlyContinue',
+    '  $result += [pscustomobject]@{ pid = [int]$row.ProcessId; parentPid = [int]$row.ParentProcessId; name = [string]$row.Name; handleCount = if ($process) { [int]$process.HandleCount } else { $null } }',
+    '  if ([int]$row.ParentProcessId -eq 0) { break }',
+    '  $targetPid = [int]$row.ParentProcessId',
+    '}',
+    '$result | ConvertTo-Json -Compress'
+  ].join('; ')
+  const { stdout } = await execFileAsync(
+    'powershell.exe',
+    ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', script],
+    { encoding: 'utf8', windowsHide: true, timeout: 10_000 }
+  )
+  const parsed = JSON.parse(stdout.trim() || '[]') as
+    | WindowsProcessEvidence
+    | WindowsProcessEvidence[]
+  return Array.isArray(parsed) ? parsed : [parsed]
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function readChildPid(client: RuntimeClient, handle: string): Promise<number | null> {
+  const read = await client.call<{ terminal: RuntimeTerminalRead }>('terminal.read', {
+    terminal: handle
+  })
+  const marker = read.result.terminal.tail.find((line) => line.includes(CHILD_PID_PREFIX))
+  const value = marker?.slice(marker.indexOf(CHILD_PID_PREFIX) + CHILD_PID_PREFIX.length).trim()
+  const pid = Number.parseInt(value ?? '', 10)
+  return Number.isSafeInteger(pid) && pid > 0 ? pid : null
+}
+
+test.describe.configure({ mode: 'serial' })
+
+test('physical Windows exit wins the headless-tab close race', async ({ testRepoPath }) => {
+  test.skip(process.platform !== 'win32', 'Physical Windows PTY lifecycle coverage')
+  test.setTimeout(120_000)
+  const host = await launchHeadlessPairedRuntimeHost()
+
+  try {
+    const client = host.client
+    const added = await client.call<{ repo: { id: string } }>('repo.add', {
+      path: testRepoPath,
+      kind: 'git'
+    })
+    let worktreeId = ''
+    await expect
+      .poll(
+        async () => {
+          const listed = await client.call<{ worktrees: { id: string }[] }>('worktree.list', {
+            repo: `id:${added.result.repo.id}`
+          })
+          worktreeId = listed.result.worktrees[0]?.id ?? ''
+          return worktreeId
+        },
+        { message: 'Headless host did not publish the physical test worktree' }
+      )
+      .not.toBe('')
+    const created = await client.call<{ terminal: RuntimeTerminalCreate }>('terminal.create', {
+      worktree: `id:${worktreeId}`,
+      title: 'STA-4903 physical close race',
+      command: `node -e "console.log('${CHILD_PID_PREFIX}' + process.pid); setInterval(() => {}, 1000)"`,
+      presentation: 'background'
+    })
+    const terminal = created.result.terminal
+
+    let childPid: number | null = null
+    await expect
+      .poll(
+        async () => {
+          childPid = await readChildPid(client, terminal.handle)
+          return childPid
+        },
+        { message: 'Background PTY did not publish its physical Windows child PID' }
+      )
+      .not.toBeNull()
+    const processBefore = await queryWindowsAncestry(childPid!)
+    const windowCountBefore = await host.app.evaluate(
+      ({ BrowserWindow }) => BrowserWindow.getAllWindows().length
+    )
+    const hostTabsBefore = await client.call<RuntimeMobileSessionTabsResult>('session.tabs.list', {
+      worktree: `id:${worktreeId}`
+    })
+    const inventoryBefore = await client.call<RuntimeTerminalListResult>('terminal.list', {
+      worktree: `id:${worktreeId}`
+    })
+    expect(windowCountBefore).toBe(0)
+    expect(hostTabsBefore.result.tabs.some((tab) => tab.parentTabId === terminal.tabId)).toBe(true)
+    expect(inventoryBefore.result.terminals).toContainEqual(
+      expect.objectContaining({ handle: terminal.handle, connected: true, writable: true })
+    )
+
+    const closeStartedAt = performance.now()
+    let close: RuntimeTerminalClose | null = null
+    let closeError: string | null = null
+    try {
+      close = (
+        await client.call<{ close: RuntimeTerminalClose }>('terminal.close', {
+          terminal: terminal.handle
+        })
+      ).result.close
+    } catch (error) {
+      closeError = error instanceof Error ? error.message : String(error)
+    }
+    const closeElapsedMs = performance.now() - closeStartedAt
+
+    await expect
+      .poll(() => isProcessAlive(childPid!), { message: 'Windows child survived close' })
+      .toBe(false)
+    let inventoryAfter: RuntimeTerminalListResult | null = null
+    await expect
+      .poll(
+        async () => {
+          inventoryAfter = (
+            await client.call<RuntimeTerminalListResult>('terminal.list', {
+              worktree: `id:${worktreeId}`
+            })
+          ).result
+          return inventoryAfter.terminals.some((entry) => entry.handle === terminal.handle)
+        },
+        { message: 'Closed terminal remained in the authoritative runtime inventory' }
+      )
+      .toBe(false)
+    const hostTabsAfter = await client.call<RuntimeMobileSessionTabsResult>('session.tabs.list', {
+      worktree: `id:${worktreeId}`
+    })
+
+    console.log(
+      `[sta4903] ${JSON.stringify({ terminal, processBefore, windowCountBefore, hostTabIdsBefore: hostTabsBefore.result.tabs.map((tab) => tab.parentTabId), close, closeError, closeElapsedMs, processAliveAfter: isProcessAlive(childPid!), hostTabIdsAfter: hostTabsAfter.result.tabs.map((tab) => tab.parentTabId), inventoryHandlesAfter: inventoryAfter?.terminals.map((entry) => entry.handle) })}`
+    )
+
+    expect(closeError).toBeNull()
+    expect(close).toMatchObject({ handle: terminal.handle, ptyKilled: expect.any(Boolean) })
+    expect(hostTabsAfter.result.tabs.some((tab) => tab.parentTabId === terminal.tabId)).toBe(false)
+  } finally {
+    await host.dispose()
+  }
+})

--- a/tests/e2e/windows-headless-terminal-close-lifecycle.spec.ts
+++ b/tests/e2e/windows-headless-terminal-close-lifecycle.spec.ts
@@ -57,6 +57,10 @@ function isProcessAlive(pid: number): boolean {
   }
 }
 
+function terminalParentTabIds(result: RuntimeMobileSessionTabsResult): string[] {
+  return result.tabs.flatMap((tab) => (tab.type === 'terminal' ? [tab.parentTabId] : []))
+}
+
 async function readChildPid(client: RuntimeClient, handle: string): Promise<number | null> {
   const read = await client.call<{ terminal: RuntimeTerminalRead }>('terminal.read', {
     terminal: handle
@@ -112,6 +116,12 @@ test('physical Windows exit wins the headless-tab close race', async ({ testRepo
       )
       .not.toBeNull()
     const processBefore = await queryWindowsAncestry(childPid!)
+    expect(processBefore).toMatchObject([
+      { pid: childPid, name: 'node.exe' },
+      { name: 'pwsh.exe' },
+      { name: 'electron.exe' }
+    ])
+    const ptyShellPid = processBefore[1]!.pid
     const windowCountBefore = await host.app.evaluate(
       ({ BrowserWindow }) => BrowserWindow.getAllWindows().length
     )
@@ -122,7 +132,7 @@ test('physical Windows exit wins the headless-tab close race', async ({ testRepo
       worktree: `id:${worktreeId}`
     })
     expect(windowCountBefore).toBe(0)
-    expect(hostTabsBefore.result.tabs.some((tab) => tab.parentTabId === terminal.tabId)).toBe(true)
+    expect(terminalParentTabIds(hostTabsBefore.result)).toEqual([terminal.tabId])
     expect(inventoryBefore.result.terminals).toContainEqual(
       expect.objectContaining({ handle: terminal.handle, connected: true, writable: true })
     )
@@ -140,35 +150,42 @@ test('physical Windows exit wins the headless-tab close race', async ({ testRepo
       closeError = error instanceof Error ? error.message : String(error)
     }
     const closeElapsedMs = performance.now() - closeStartedAt
+    expect(closeError).toBeNull()
 
     await expect
       .poll(() => isProcessAlive(childPid!), { message: 'Windows child survived close' })
       .toBe(false)
-    let inventoryAfter: RuntimeTerminalListResult | null = null
+    await expect
+      .poll(() => isProcessAlive(ptyShellPid), { message: 'Windows PTY shell survived close' })
+      .toBe(false)
     await expect
       .poll(
         async () => {
-          inventoryAfter = (
+          const inventory = (
             await client.call<RuntimeTerminalListResult>('terminal.list', {
               worktree: `id:${worktreeId}`
             })
           ).result
-          return inventoryAfter.terminals.some((entry) => entry.handle === terminal.handle)
+          return inventory.terminals.length
         },
         { message: 'Closed terminal remained in the authoritative runtime inventory' }
       )
-      .toBe(false)
+      .toBe(0)
+    const inventoryAfter = (
+      await client.call<RuntimeTerminalListResult>('terminal.list', {
+        worktree: `id:${worktreeId}`
+      })
+    ).result
     const hostTabsAfter = await client.call<RuntimeMobileSessionTabsResult>('session.tabs.list', {
       worktree: `id:${worktreeId}`
     })
 
     console.log(
-      `[sta4903] ${JSON.stringify({ terminal, processBefore, windowCountBefore, hostTabIdsBefore: hostTabsBefore.result.tabs.map((tab) => tab.parentTabId), close, closeError, closeElapsedMs, processAliveAfter: isProcessAlive(childPid!), hostTabIdsAfter: hostTabsAfter.result.tabs.map((tab) => tab.parentTabId), inventoryHandlesAfter: inventoryAfter?.terminals.map((entry) => entry.handle) })}`
+      `[sta4903] ${JSON.stringify({ terminal, processBefore, windowCountBefore, hostTabIdsBefore: terminalParentTabIds(hostTabsBefore.result), close, closeError, closeElapsedMs, processAliveAfter: { child: isProcessAlive(childPid!), ptyShell: isProcessAlive(ptyShellPid) }, hostTabIdsAfter: terminalParentTabIds(hostTabsAfter.result), inventoryHandlesAfter: inventoryAfter.terminals.map((entry) => entry.handle) })}`
     )
 
-    expect(closeError).toBeNull()
-    expect(close).toMatchObject({ handle: terminal.handle, ptyKilled: expect.any(Boolean) })
-    expect(hostTabsAfter.result.tabs.some((tab) => tab.parentTabId === terminal.tabId)).toBe(false)
+    expect(close).toMatchObject({ handle: terminal.handle, tabId: terminal.tabId })
+    expect(terminalParentTabIds(hostTabsAfter.result)).toEqual([])
   } finally {
     await host.dispose()
   }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​478 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​478 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​58 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​46 |

<!-- /orca-pr-loc -->

## Summary

- settle terminal.close when a physical PTY exit has already retired the same headless host tab
- preserve workspace_session_unavailable fallback and propagate every other close error
- add a physical Windows headless-host regression that captures tab state, runtime inventory, PID ancestry/handles, process death, close receipt, and timing

## Root cause

The explicit background-terminal close stops the PTY first. On Windows, the daemon exit event can retire the host-owned tab before closeTerminal reaches its late surface transaction. closeMobileSessionTab then reports tab_not_found even though the OS process, host tab, and authoritative inventory record are already gone.

The PTY/exit owner remains responsible for physical retirement. This change only treats tab_not_found from that late, post-stop surface cleanup as an already-completed transaction. It adds no sweeper, cleanup owner, RPC field, or wire change.

## Physical Windows evidence

Current main, before the fix:

- zero BrowserWindows
- inventory connected=true and writable=true before close
- child node.exe -> pwsh.exe -> daemon electron.exe ancestry captured with PIDs and handle counts
- child process gone, host tab gone, inventory record gone after about 2.0 seconds
- terminal.close failed with tab_not_found

Candidate:

- identical physical cleanup
- terminal.close settled successfully

Fix-only revert:

- identical physical cleanup
- terminal.close failed again with tab_not_found

Restored candidate passed again.

## Testing

- 1,185 OrcaRuntimeService tests
- physical Windows lifecycle E2E candidate green
- physical Windows fix-only revert red, restored candidate green
- max-lines ratchet and touched-file Oxlint
- current-main daemon dead-session reaping regressions: 35 tests across reaping and Windows resource collection
- real Windows CIM sample attributed a busy child at 107.4% CPU and 57,049,088 bytes
- three physical Windows create/output/exit cycles left no live daemon sessions or child processes

## Compatibility and risk

No UI, schema, opcode, RPC parameter, or publication change. The exception is limited to tab_not_found in the existing late headless surface cleanup. Renderer-owned/adopted tab transactions, background survival rules, folder workspaces, SSH provider stop verdicts, paired clients, and mixed-version behavior are unchanged.

## Ticket assessment

STA-4903 is valid as a close-acknowledgement race; current main did not reproduce a surviving OS process or ghost authoritative inventory row.

STA-2729 appears already fixed by PR #5788 (dead daemon session/emulator reaping) and PR #8845 (Windows memory/CPU attribution), with current physical and regression evidence passing. Linear is disconnected in the running Orca profile, so the exact ticket bodies could not be read or updated; do not close or consolidate until that text is compared with this evidence.

No visual change.