### PR TITLE
test(agent-session): cover paired Windows ownership races

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -4331,9 +4331,9 @@
       ],
       "platforms": ["macos", "linux", "windows"],
       "providers": ["local", "daemon", "ssh", "wsl", "remote-runtime"],
-      "coveredPlatforms": ["macos"],
+      "coveredPlatforms": ["macos", "windows"],
       "coveredProviders": ["local", "daemon", "remote-runtime"],
-      "coverageNotes": "Renderer ownership/dedupe contracts cover provider-session claims. Local and daemon attach-only contracts prove an existing stable-pane owner is adopted without provider creation, while remote-runtime transport contracts preserve adopted ownership through cancellation. The Electron oracle covers a local macOS runtime and daemon with real agent, Setup, and unrelated-canary processes; SSH, WSL, paired-server, Linux, and Windows remain contract-only or unrun.",
+      "coverageNotes": "Renderer ownership/dedupe contracts cover provider-session claims. Local and daemon attach-only contracts prove an existing stable-pane owner is adopted without provider creation, while remote-runtime transport contracts preserve adopted ownership through cancellation. Electron oracles cover a local macOS runtime and a physical Windows paired host with two persistent viewers racing one provider-session identity; SSH, WSL, and Linux remain contract-only or unrun.",
       "motivatingLinks": [
         "https://github.com/stablyai/orca/pull/6800",
         "https://github.com/stablyai/orca/pull/5240",
@@ -4348,7 +4348,8 @@
         "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/resume-sleeping-agent-session.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts tests/e2e/completed-worker-retirement-resume.unit.test.ts --reporter=verbose",
         "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/resume-sleeping-agent-session.test.ts src/main/providers/local-pty-provider-spawn-session.test.ts src/main/daemon/terminal-host.test.ts src/main/daemon/daemon-pty-adapter.test.ts src/main/ipc/pty-pane-materialization-race.test.ts src/main/ipc/pty-persisted-incarnation-repair.test.ts src/main/ipc/pty-pane-reservation-settlement.test.ts src/main/runtime/orca-runtime.test.ts src/renderer/src/lib/pane-manager/pane-fit.test.ts src/renderer/src/components/terminal-pane/pty-connection-deferred-reattach-live-output.test.ts src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-host-session-launch.test.ts",
-        "pnpm exec electron-vite build --mode e2e && SKIP_BUILD=1 pnpm exec playwright test tests/e2e/live-background-terminal-mount-authority.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1"
+        "pnpm exec electron-vite build --mode e2e && SKIP_BUILD=1 pnpm exec playwright test tests/e2e/live-background-terminal-mount-authority.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
+        "SKIP_BUILD=1 pnpm exec playwright test tests/e2e/paired-agent-session-ownership.spec.ts --config tests/playwright.config.ts --project electron-headful --workers=1"
       ],
       "testFiles": [
         "src/renderer/src/lib/resume-sleeping-agent-session.test.ts",
@@ -4363,7 +4364,8 @@
         "src/renderer/src/lib/pane-manager/pane-fit.test.ts",
         "src/renderer/src/components/terminal-pane/pty-connection-deferred-reattach-live-output.test.ts",
         "src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-host-session-launch.test.ts",
-        "tests/e2e/live-background-terminal-mount-authority.spec.ts"
+        "tests/e2e/live-background-terminal-mount-authority.spec.ts",
+        "tests/e2e/paired-agent-session-ownership.spec.ts"
       ],
       "assertionRefs": [
         {
@@ -4427,9 +4429,25 @@
             "runtime inventory, renderer graph, persisted session, runtime epoch, and daemon PID converge without replacement or resume",
             "the unrelated canary remains writable and receives no signal across target projection repair"
           ]
+        },
+        {
+          "file": "tests/e2e/paired-agent-session-ownership.spec.ts",
+          "assertions": [
+            "two persistent paired viewers racing one exact resume identity receive created plus adopted dispositions and share one live writable Windows process",
+            "retries preserve the canonical terminal handle, tab, and PTY without another process spawn"
+          ]
         }
       ],
       "evidenceRuns": [
+        {
+          "date": "2026-08-20",
+          "runner": "local",
+          "platform": "windows",
+          "command": "SKIP_BUILD=1 pnpm exec playwright test tests/e2e/paired-agent-session-ownership.spec.ts --config tests/playwright.config.ts --project electron-headful --workers=1",
+          "result": "passed",
+          "durationSeconds": 72,
+          "summary": "A physical Windows host and two persistent paired web viewers shared one live writable resumed provider session. Reverting only canonical claim-key sharing re-failed with two live fixture PIDs, 129856 and 73496, running identical resume argv 292 ms apart; restoring it returned to one process."
+        },
         {
           "date": "2026-07-03",
           "runner": "local",
@@ -4463,9 +4481,9 @@
         "Record byte-identical latest-main, candidate, and candidate-revert Electron results."
       ],
       "knownGaps": [
-        "Providers listed on this gate are affected identity surfaces; live integration is limited to local macOS while daemon and remote-runtime adoption also have focused contracts.",
+        "Providers listed on this gate are affected identity surfaces; live integration covers local macOS and a paired Windows host while SSH, WSL, Linux, and installed-app update paths remain gaps.",
         "The Electron oracle seeds the production hook-store contract instead of running an authenticated Codex hook end to end.",
-        "The live Electron topology is local macOS only; folder workspaces, SSH, WSL, paired headed/headless servers, Linux, and Windows are not exercised by that journey.",
+        "Folder workspaces, SSH, WSL, Linux, and installed-app update paths are not exercised by the live ownership journeys.",
         "The oracle covers first activation and one renderer reload, not repeated soak activation or an installed-app update."
       ],
       "demotionRule": "Demote or quarantine if failures are non-actionable or if a duplicate resume escape occurs outside the modeled matrix."
@@ -4490,9 +4508,9 @@
       ],
       "platforms": ["macos", "linux", "windows"],
       "providers": ["local", "daemon", "ssh", "wsl", "remote-runtime"],
-      "coveredPlatforms": ["macos"],
+      "coveredPlatforms": ["macos", "windows"],
       "coveredProviders": ["local", "daemon", "ssh", "wsl", "remote-runtime"],
-      "coverageNotes": "Deterministic macOS tests cover controller claims, daemon and SSH/relay operation replay, mixed-version selection, runtime ownership, exact provisional handoff, durable terminal retirement, two independent viewer mirrors, guarded adoption of legacy live PTYs, and completion classification when either the outer remote transport or authoritative host/provider process inspection becomes unreachable. The adoption harness models v1.4.150 agent/setup/shell tabs, current-generation restart and reconnect, exact handle/incarnation/worktree/host checks, topology CAS, competing clients, split-pane/group restoration, WSL ownership, and SSH owner rejection. The secondary parity repro runs independent clients against one headless remote Orca runtime over encrypted pairing and a real daemon-backed PTY, with tokened fixture-process identity separated from unrelated Codex app-server startup probes. The automated primary topology runs an isolated headed macOS Orca desktop server plus a separate paired web client and proves viewer-local fresh/resume focus, exact legacy placement, writable PTYs, unrelated-terminal survival, and host/client cleanup. SSH coverage is provider/relay contract and fault-injection coverage only; it does not substitute for paired-server coverage. Live Windows, Linux, WSL, SSH, and physical paired-Linux hosts remain gaps.",
+      "coverageNotes": "Deterministic macOS tests cover controller claims, daemon and SSH/relay operation replay, mixed-version selection, runtime ownership, exact provisional handoff, durable terminal retirement, two independent viewer mirrors, guarded adoption of legacy live PTYs, and completion classification when either the outer remote transport or authoritative host/provider process inspection becomes unreachable. The adoption harness models v1.4.150 agent/setup/shell tabs, current-generation restart and reconnect, exact handle/incarnation/worktree/host checks, topology CAS, competing clients, split-pane/group restoration, WSL ownership, and SSH owner rejection. The secondary parity repro runs independent clients against one headless remote Orca runtime over encrypted pairing and a real daemon-backed PTY. Headed physical-host coverage includes macOS focus/placement and one local Windows create-with-agent plus synchronized two-viewer resume journey, with exact fixture PIDs and writable ConPTY input. SSH coverage is provider/relay contract and fault-injection coverage only; Linux, WSL, SSH, Windows CI, and physical paired-Linux hosts remain gaps.",
       "motivatingLinks": [
         "https://github.com/stablyai/orca/issues/8878",
         "https://github.com/stablyai/orca/issues/9151",
@@ -4513,6 +4531,7 @@
         "pnpm exec electron-vite build --mode e2e",
         "VITE_EXPOSE_STORE=true pnpm run build:web",
         "ORCA_E2E_WEB_CLIENT=1 SKIP_BUILD=1 pnpm exec playwright test tests/e2e/remote-agent-session-focus-authority.spec.ts --config tests/playwright.config.ts --project electron-headful --workers=1",
+        "SKIP_BUILD=1 pnpm exec playwright test tests/e2e/paired-agent-session-ownership.spec.ts --config tests/playwright.config.ts --project electron-headful --workers=1",
         "Manual headed paired-server journey: isolated Orca desktop host + separate paired web client + real Codex process + 20-second WebSocket fault + reconnect + explicit stop",
         "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts src/main/runtime/terminal-orphan-owner.test.ts src/main/runtime/terminal-orphan-topology.test.ts src/renderer/src/runtime/web-session-terminal-orphan-recovery.test.ts src/renderer/src/runtime/web-session-terminal-orphan-mixed-version.test.ts src/renderer/src/runtime/web-session-tabs-sync.test.ts --maxWorkers=1",
         "pnpm exec vitest run --config config/vitest.config.ts src/main/providers/pty-process-inspection.test.ts src/main/daemon/terminal-host.test.ts src/main/daemon/daemon-pty-router.test.ts src/main/daemon/degraded-daemon-pty-provider.test.ts src/relay/pty-handler-spawn-admission.test.ts src/main/daemon/daemon-pty-adapter.test.ts src/main/runtime/orca-runtime.test.ts tests/e2e/remote-agent-completion-authority.unit.test.ts src/renderer/src/runtime/runtime-terminal-inspection.test.ts src/renderer/src/components/terminal-pane/agent-completion-coordinator-process-cadence.test.ts src/renderer/src/components/terminal-pane/agent-completion-coordinator-pending-title-inspection.test.ts",
@@ -4546,6 +4565,7 @@
         "src/renderer/src/runtime/web-session-intent-owner.test.ts",
         "src/renderer/src/runtime/remote-server-parity.test.ts",
         "tests/e2e/remote-agent-session-focus-authority.spec.ts",
+        "tests/e2e/paired-agent-session-ownership.spec.ts",
         "config/scripts/remote-agent-session-authority-repro.mjs",
         "config/scripts/remote-agent-session-process-cleanup.mjs",
         "tests/e2e/remote-terminal-tab-retirement.unit.test.ts",
@@ -4677,6 +4697,13 @@
           ]
         },
         {
+          "file": "tests/e2e/paired-agent-session-ownership.spec.ts",
+          "assertions": [
+            "a paired viewer's real create-with-agent response identifies the backend-spawned terminal, PTY, and live fixture PID retained in both renderer mirrors",
+            "two persistent paired viewers synchronously dispatch and retry one provider-session identity, preserve independent focus, mirror the same tab, and both write to one canonical ConPTY process"
+          ]
+        },
+        {
           "file": "config/scripts/remote-agent-session-authority-repro.mjs",
           "assertions": [
             "headless focused fresh/resume requests create background host surfaces without a renderer window",
@@ -4725,6 +4752,15 @@
         }
       ],
       "evidenceRuns": [
+        {
+          "date": "2026-08-20",
+          "runner": "local",
+          "platform": "windows",
+          "command": "SKIP_BUILD=1 pnpm exec playwright test tests/e2e/paired-agent-session-ownership.spec.ts --config tests/playwright.config.ts --project electron-headful --workers=1",
+          "result": "passed",
+          "durationSeconds": 60,
+          "summary": "One source-built local physical Windows run passed a paired-viewer worktree.create-with-Codex RPC and explicit mirror activation with one backend startup PID/PTY in both renderers, then passed a synchronized two-persistent-viewer resume request and retry with one canonical writable ConPTY PID."
+        },
         {
           "date": "2026-07-23",
           "runner": "local",
@@ -4822,11 +4858,11 @@
       },
       "flakeHistory": {
         "status": "unknown",
-        "evidence": "New experimental gate with deterministic local coverage and no soak history yet."
+        "evidence": "New experimental gate with deterministic contract coverage plus one local physical-Windows paired journey; it has no Windows CI or soak history yet."
       },
       "redGreenEvidence": {
         "status": "partial",
-        "evidence": "Issue #10192 has byte-identical renderer-oracle evidence: origin/main@ee87bb38d (and earlier ef985ed80 and 94d3db4a2) fails activated fresh and resume rows by requesting focused host presentation, the PR client change passes all four rows, and disabling it turns the activated rows red again. The original PR still fails an old-client focused request against a new headless host; host-boundary normalization turns that mixed-version control green while trusted local callers remain focused. Issue #9151 has local red/green evidence for completion authority. The exact retirement oracle is red on pre-#9687 commit 2a32c5c9a and PR #9053 head d3a1d3047, and green on main@4fce2de49. Saved CI artifacts are still needed."
+        "evidence": "Issue #10192 has byte-identical renderer-oracle evidence: origin/main@ee87bb38d (and earlier ef985ed80 and 94d3db4a2) fails activated fresh and resume rows by requesting focused host presentation, the PR client change passes all four rows, and disabling it turns the activated rows red again. The original PR still fails an old-client focused request against a new headless host; host-boundary normalization turns that mixed-version control green while trusted local callers remain focused. Issue #9151 has local red/green evidence for completion authority. The exact retirement oracle is red on pre-#9687 commit 2a32c5c9a and PR #9053 head d3a1d3047, and green on main@4fce2de49. For STA-3859, replacing only the canonical claim key with a per-call key spawned two live Windows fixture PIDs 292 ms apart; restoring the canonical key returned the suite to one process. STA-4908 is green on current main, and reverting only startup-terminal propagation did not turn it red because later paired-runtime ownership protections overlap. Saved CI artifacts and Windows soak remain needed."
       },
       "performanceBudget": {
         "required": true,

--- a/config/scripts/remote-agent-session-authority-repro.mjs
+++ b/config/scripts/remote-agent-session-authority-repro.mjs
@@ -176,7 +176,13 @@ try {
   const closed = await callClient(pairingCode, 'terminal.close', {
     terminal: first.result.terminal.handle
   })
-  assertOk(closed, 'fixture terminal close')
+  await assertClosedOrRetired(
+    pairingCode,
+    worktree,
+    first.result.terminal.handle,
+    closed,
+    'fixture terminal close'
+  )
   await waitFor(async () => {
     const [terminals, tabs] = await Promise.all([
       callClient(pairingCode, 'terminal.list', { worktree }),
@@ -252,7 +258,13 @@ try {
   const freshClosed = await callClient(pairingCode, 'terminal.close', {
     terminal: fresh.result.terminal.handle
   })
-  assertOk(freshClosed, 'unrelated fresh terminal close')
+  await assertClosedOrRetired(
+    pairingCode,
+    worktree,
+    fresh.result.terminal.handle,
+    freshClosed,
+    'unrelated fresh terminal close'
+  )
   const remainingClosed = await callClient(pairingCode, 'terminal.stop', { worktree })
   assertOk(remainingClosed, 'isolated fixture terminal cleanup')
   await waitFor(async () => {
@@ -306,7 +318,29 @@ try {
     child.kill()
   }
   await cleanupIsolatedDaemons(profilePath)
-  rmSync(scratch, { recursive: true, force: true })
+  await removeScratchDirectory()
+}
+
+async function removeScratchDirectory() {
+  if (process.platform === 'win32') {
+    execFileSync('attrib.exe', ['-R', '-H', '-S', path.join(scratch, '*'), '/S', '/D'], {
+      stdio: 'ignore'
+    })
+  }
+  let lastError
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    try {
+      rmSync(scratch, { recursive: true, force: true })
+      return
+    } catch (error) {
+      if (!['EBUSY', 'ENOTEMPTY', 'EPERM'].includes(error?.code)) {
+        throw error
+      }
+      lastError = error
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    }
+  }
+  throw lastError
 }
 
 function installFixtureAgent(targetDir) {
@@ -327,7 +361,7 @@ function installFixtureAgent(targetDir) {
 
 function quoteFixtureAgentCommand(commandPath) {
   return process.platform === 'win32'
-    ? `"${commandPath.replaceAll('"', '""')}" ${agentSessionToken}`
+    ? `& '${process.execPath.replaceAll("'", "''")}' '${fixtureScript.replaceAll("'", "''")}' ${agentSessionToken}`
     : `${shellQuote(commandPath)} ${agentSessionToken}`
 }
 
@@ -337,9 +371,9 @@ function shellQuote(value) {
 
 function fixtureCommand(scriptPath, markerPath) {
   if (process.platform === 'win32') {
-    return [process.execPath, scriptPath, markerPath]
-      .map((value) => `"${value.replaceAll('"', '""')}"`)
-      .join(' ')
+    return `& ${[process.execPath, scriptPath, markerPath]
+      .map((value) => `'${value.replaceAll("'", "''")}'`)
+      .join(' ')}`
   }
   return [process.execPath, scriptPath, markerPath].map(shellQuote).join(' ')
 }
@@ -536,6 +570,19 @@ function assertOk(response, description) {
   if (!response?.ok) {
     throw new Error(`${description} failed: ${JSON.stringify(response)}`)
   }
+}
+
+async function assertClosedOrRetired(pairingCode, worktree, terminal, response, description) {
+  if (response?.ok) {
+    return
+  }
+  if (response?.error?.message !== 'tab_not_found') {
+    assertOk(response, description)
+  }
+  await waitFor(async () => {
+    const inventory = await callClient(pairingCode, 'terminal.list', { worktree })
+    return inventory.ok && !inventory.result.terminals.some((entry) => entry.handle === terminal)
+  }, `${description} retirement`)
 }
 
 function assertSameTerminal(left, right) {

--- a/config/scripts/remote-agent-session-repro-fixture.mjs
+++ b/config/scripts/remote-agent-session-repro-fixture.mjs
@@ -5,6 +5,7 @@ import { appendFileSync, existsSync } from 'node:fs'
 const markerPath = process.env.ORCA_REPRO_SPAWN_MARKER
 const exitTriggerPath = process.env.ORCA_REPRO_EXIT_TRIGGER
 const inputMarkerPath = process.env.ORCA_REPRO_INPUT_MARKER
+const lifecycleMarkerPath = process.env.ORCA_REPRO_LIFECYCLE_MARKER
 const agentSessionToken = process.env.ORCA_REPRO_AGENT_SESSION_TOKEN
 if (!markerPath || !exitTriggerPath) {
   process.exit(2)
@@ -19,15 +20,32 @@ appendFileSync(
   markerPath,
   `${process.pid}:${process.ppid}:${Date.now()}:${JSON.stringify(process.argv.slice(2))}\n`
 )
+const recordLifecycle = (event) => {
+  if (lifecycleMarkerPath) {
+    appendFileSync(lifecycleMarkerPath, `${process.pid}:${process.ppid}:${Date.now()}:${event}\n`)
+  }
+}
+recordLifecycle(
+  `started:stdin-tty=${String(process.stdin.isTTY)}:stdout-tty=${String(process.stdout.isTTY)}`
+)
+process.stdout.write(`ORCA_REPRO_AGENT_READY:${process.pid}\r\n`)
 if (inputMarkerPath) {
   process.stdin.setEncoding('utf8')
-  process.stdin.on('data', (chunk) => appendFileSync(inputMarkerPath, chunk))
+  if (process.stdin.isTTY) {
+    process.stdin.setRawMode(true)
+  }
+  process.stdin.on('data', (chunk) => {
+    recordLifecycle('input')
+    appendFileSync(inputMarkerPath, chunk)
+  })
+  process.stdin.resume()
 }
 
 const interval = setInterval(() => {
   if (!existsSync(exitTriggerPath)) {
     return
   }
+  recordLifecycle('exit-trigger')
   clearInterval(interval)
   try {
     // Why: the agent is a child of the startup shell; terminating that shell
@@ -39,5 +57,12 @@ const interval = setInterval(() => {
   process.exit(0)
 }, 25)
 
-process.on('SIGTERM', () => process.exit(0))
-process.on('SIGINT', () => process.exit(0))
+process.on('SIGTERM', () => {
+  recordLifecycle('sigterm')
+  process.exit(0)
+})
+process.on('SIGINT', () => {
+  recordLifecycle('sigint')
+  process.exit(0)
+})
+process.on('exit', (code) => recordLifecycle(`exit:${code}`))

--- a/config/scripts/remote-agent-session-repro-writable-shell.mjs
+++ b/config/scripts/remote-agent-session-repro-writable-shell.mjs
@@ -8,7 +8,11 @@ if (!markerPath) {
 }
 
 process.stdin.setEncoding('utf8')
+if (process.stdin.isTTY) {
+  process.stdin.setRawMode(true)
+}
 process.stdin.on('data', (data) => appendFileSync(markerPath, data))
+process.stdin.resume()
 setInterval(() => {}, 1_000)
 process.on('SIGTERM', () => process.exit(0))
 process.on('SIGINT', () => process.exit(0))

--- a/tests/e2e/helpers/agent-session-process-fixture.ts
+++ b/tests/e2e/helpers/agent-session-process-fixture.ts
@@ -1,0 +1,141 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+export type AgentSessionSpawnRecord = {
+  pid: number
+  ppid: number
+  spawnedAt: number
+  argv: string[]
+}
+
+export type AgentSessionLifecycleRecord = {
+  pid: number
+  ppid: number
+  recordedAt: number
+  event: string
+}
+
+const scratch = mkdtempSync(path.join(os.tmpdir(), 'orca-paired-agent-ownership-'))
+const spawnMarkerPath = path.join(scratch, 'agent-spawns.txt')
+const inputMarkerPath = path.join(scratch, 'agent-input.txt')
+const lifecycleMarkerPath = path.join(scratch, 'agent-lifecycle.txt')
+const exitTriggerPath = path.join(scratch, 'exit-agent')
+const fixtureScript = path.join(
+  process.cwd(),
+  'config',
+  'scripts',
+  'remote-agent-session-repro-fixture.mjs'
+)
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`
+}
+
+function fixtureCommand(): string {
+  const command = [process.execPath, fixtureScript]
+  return process.platform === 'win32'
+    ? `& ${command.map((value) => `'${value.replaceAll("'", "''")}'`).join(' ')}`
+    : command.map(shellQuote).join(' ')
+}
+
+function readMarkerLines(markerPath: string): string[] {
+  return existsSync(markerPath)
+    ? readFileSync(markerPath, 'utf8').split(/\r?\n/).filter(Boolean)
+    : []
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== 'ESRCH'
+  }
+}
+
+async function removeScratchDirectory(): Promise<void> {
+  if (process.platform === 'win32') {
+    try {
+      execFileSync('attrib.exe', ['-R', '-H', '-S', path.join(scratch, '*'), '/S', '/D'], {
+        stdio: 'ignore'
+      })
+    } catch {
+      // The directory may already be empty.
+    }
+  }
+  rmSync(scratch, {
+    recursive: true,
+    force: true,
+    maxRetries: 100,
+    retryDelay: 100
+  })
+}
+
+export const agentSessionProcessFixture = {
+  launchEnv: {
+    ORCA_REPRO_EXIT_TRIGGER: exitTriggerPath,
+    ORCA_REPRO_INPUT_MARKER: inputMarkerPath,
+    ORCA_REPRO_LIFECYCLE_MARKER: lifecycleMarkerPath,
+    ORCA_REPRO_SPAWN_MARKER: spawnMarkerPath
+  },
+  command: fixtureCommand(),
+  reset(): void {
+    for (const markerPath of [
+      spawnMarkerPath,
+      inputMarkerPath,
+      lifecycleMarkerPath,
+      exitTriggerPath
+    ]) {
+      rmSync(markerPath, { force: true })
+    }
+  },
+  readSpawns(): AgentSessionSpawnRecord[] {
+    return readMarkerLines(spawnMarkerPath).map((line) => {
+      const [pid, ppid, spawnedAt, ...argvParts] = line.split(':')
+      return {
+        pid: Number(pid),
+        ppid: Number(ppid),
+        spawnedAt: Number(spawnedAt),
+        argv: JSON.parse(argvParts.join(':')) as string[]
+      }
+    })
+  },
+  readLifecycle(): AgentSessionLifecycleRecord[] {
+    return readMarkerLines(lifecycleMarkerPath).map((line) => {
+      const [pid, ppid, recordedAt, ...eventParts] = line.split(':')
+      return {
+        pid: Number(pid),
+        ppid: Number(ppid),
+        recordedAt: Number(recordedAt),
+        event: eventParts.join(':')
+      }
+    })
+  },
+  readInput(): string {
+    return existsSync(inputMarkerPath) ? readFileSync(inputMarkerPath, 'utf8') : ''
+  },
+  livePids(): number[] {
+    return this.readSpawns()
+      .map((spawn) => spawn.pid)
+      .filter(isProcessAlive)
+  },
+  requestExit(): void {
+    writeFileSync(exitTriggerPath, '')
+  },
+  async dispose(): Promise<void> {
+    this.requestExit()
+    for (let attempt = 0; attempt < 50 && this.livePids().length > 0; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    }
+    for (const pid of this.livePids()) {
+      try {
+        process.kill(pid, 'SIGTERM')
+      } catch {
+        // The fixture may exit between liveness inspection and signaling.
+      }
+    }
+    await removeScratchDirectory()
+  }
+}

--- a/tests/e2e/helpers/paired-agent-session-evidence.ts
+++ b/tests/e2e/helpers/paired-agent-session-evidence.ts
@@ -1,0 +1,110 @@
+import type { Page } from '@stablyai/playwright-test'
+import { expect } from '@stablyai/playwright-test'
+import type { RuntimeTerminalSummary } from '../../../src/shared/runtime-types'
+
+export type TimedClientResult<TResult> = {
+  startedAt: number
+  completedAt: number
+  result: TResult
+}
+
+export async function callAgentSessionClient<TResult>(
+  page: Page,
+  method: string,
+  params: unknown
+): Promise<TResult> {
+  return page.evaluate(
+    async ({ method, params }) => {
+      const response = await window.api.runtime.call({ method, params })
+      if (!response.ok) {
+        throw new Error(`${response.error.code}: ${response.error.message}`)
+      }
+      return response.result
+    },
+    { method, params }
+  ) as Promise<TResult>
+}
+
+export async function callAgentSessionClientAt<TResult>(
+  page: Page,
+  startAt: number,
+  method: string,
+  params: unknown
+): Promise<TimedClientResult<TResult>> {
+  return page.evaluate(
+    async ({ startAt, method, params }) => {
+      await new Promise((resolve) => setTimeout(resolve, Math.max(0, startAt - Date.now())))
+      const startedAt = Date.now()
+      const response = await window.api.runtime.call({ method, params })
+      if (!response.ok) {
+        throw new Error(`${response.error.code}: ${response.error.message}`)
+      }
+      return { startedAt, completedAt: Date.now(), result: response.result }
+    },
+    { startAt, method, params }
+  ) as Promise<TimedClientResult<TResult>>
+}
+
+export async function activePairedWorktreeId(page: Page): Promise<string> {
+  const worktreeId = await page.evaluate(() => window.__store?.getState().activeWorktreeId)
+  if (!worktreeId) {
+    throw new Error('Renderer has no active worktree')
+  }
+  return worktreeId
+}
+
+export async function waitForPairedWorktree(page: Page, worktreeId: string): Promise<void> {
+  await expect
+    .poll(
+      () =>
+        page.evaluate(
+          (id) =>
+            window.__store
+              ?.getState()
+              .allWorktrees()
+              .some((worktree) => worktree.id === id),
+          worktreeId
+        ),
+      { timeout: 30_000 }
+    )
+    .toBe(true)
+}
+
+export async function listPairedTerminals(
+  page: Page,
+  worktreeId: string
+): Promise<RuntimeTerminalSummary[]> {
+  return (
+    await callAgentSessionClient<{ terminals: RuntimeTerminalSummary[] }>(page, 'terminal.list', {
+      worktree: `id:${worktreeId}`
+    })
+  ).terminals
+}
+
+export async function mirroredPairedTabIds(page: Page, worktreeId: string): Promise<string[]> {
+  return page.evaluate(
+    (id) => (window.__store?.getState().tabsByWorktree[id] ?? []).map((tab) => tab.id),
+    worktreeId
+  )
+}
+
+export async function activePairedTabId(page: Page, worktreeId: string): Promise<string | null> {
+  return page.evaluate(
+    (id) => window.__store?.getState().activeTabIdByWorktree[id] ?? null,
+    worktreeId
+  )
+}
+
+export async function pairedTerminalViewportText(page: Page, tabId: string): Promise<string> {
+  return page.evaluate((id) => {
+    const pane = window.__paneManagers?.get(id)?.getActivePane?.()
+    if (!pane) {
+      return ''
+    }
+    const buffer = pane.terminal.buffer.active
+    return Array.from(
+      { length: pane.terminal.rows },
+      (_, row) => buffer.getLine(buffer.viewportY + row)?.translateToString(true) ?? ''
+    ).join('\n')
+  }, tabId)
+}

--- a/tests/e2e/paired-agent-session-ownership.spec.ts
+++ b/tests/e2e/paired-agent-session-ownership.spec.ts
@@ -1,0 +1,399 @@
+import type { Page, TestInfo } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import { agentSessionProcessFixture } from './helpers/agent-session-process-fixture'
+import {
+  activePairedTabId,
+  activePairedWorktreeId,
+  callAgentSessionClient,
+  callAgentSessionClientAt,
+  listPairedTerminals,
+  mirroredPairedTabIds,
+  pairedTerminalViewportText,
+  waitForPairedWorktree
+} from './helpers/paired-agent-session-evidence'
+import {
+  createRuntimeDesktopPairingOffer,
+  launchPairedWebClient,
+  type PairedWebClient
+} from './helpers/paired-electron-client'
+import { toWebTerminalSurfaceTabId } from '../../src/shared/terminal-surface-id'
+import type { RuntimeTerminalSummary } from '../../src/shared/runtime-types'
+import type { CreateWorktreeResult } from '../../src/shared/worktree/create-types'
+import type { WorktreeRemovalTarget } from '../../src/shared/worktree/removal'
+
+type AgentSessionResult = {
+  disposition: 'created' | 'adopted' | 'replayed'
+  terminal: RuntimeTerminalSummary
+}
+
+test.use({
+  launchEnv: agentSessionProcessFixture.launchEnv
+})
+
+test.beforeEach(() => {
+  agentSessionProcessFixture.reset()
+})
+
+test.afterAll(async () => {
+  await agentSessionProcessFixture.dispose()
+})
+
+async function configureFixtureAgent(page: Page): Promise<void> {
+  await page.evaluate(async (command) => {
+    const settings = await window.api.settings.set({
+      agentCmdOverrides: { codex: command },
+      defaultTuiAgent: 'codex'
+    })
+    window.__store?.setState({ settings })
+  }, agentSessionProcessFixture.command)
+}
+
+async function repoIdForWorktree(page: Page, worktreeId: string): Promise<string> {
+  const repoId = await page.evaluate(
+    (id) =>
+      window.__store
+        ?.getState()
+        .allWorktrees()
+        .find((worktree) => worktree.id === id)?.repoId,
+    worktreeId
+  )
+  if (!repoId) {
+    throw new Error(`Renderer has no repository for ${worktreeId}`)
+  }
+  return repoId
+}
+
+async function worktreeTargetByName(
+  page: Page,
+  name: string
+): Promise<WorktreeRemovalTarget | null> {
+  return page.evaluate((displayName) => {
+    const worktree = window.__store
+      ?.getState()
+      .allWorktrees()
+      .find((candidate) => candidate.displayName === displayName)
+    return worktree ? { id: worktree.id, executionHostId: worktree.hostId ?? null } : null
+  }, name)
+}
+
+async function attachEvidence(testInfo: TestInfo, name: string, value: unknown): Promise<void> {
+  await testInfo.attach(name, {
+    body: Buffer.from(`${JSON.stringify(value, null, 2)}\n`),
+    contentType: 'application/json'
+  })
+}
+
+async function removeCreatedWorktree(page: Page, target: WorktreeRemovalTarget): Promise<void> {
+  await page.evaluate(async (removalTarget) => {
+    const state = window.__store?.getState()
+    if (!state) {
+      throw new Error('Renderer store is unavailable during worktree cleanup')
+    }
+    await state.removeWorktree(removalTarget, true)
+  }, target)
+  await expect
+    .poll(() =>
+      page.evaluate(
+        ({ id, executionHostId }) =>
+          window.__store
+            ?.getState()
+            .allWorktrees()
+            .some(
+              (worktree) => worktree.id === id && (worktree.hostId ?? null) === executionHostId
+            ) ?? false,
+        target
+      )
+    )
+    .toBe(false)
+}
+
+async function stopTerminal(client: PairedWebClient, worktreeId: string): Promise<void> {
+  await callAgentSessionClient(client.page, 'terminal.stop', {
+    worktree: `id:${worktreeId}`
+  }).catch(() => undefined)
+}
+
+async function assertFixtureRetired(expectedSpawnCount: number | null): Promise<void> {
+  agentSessionProcessFixture.requestExit()
+  await expect.poll(() => agentSessionProcessFixture.livePids(), { timeout: 30_000 }).toEqual([])
+  await new Promise((resolve) => setTimeout(resolve, 1_000))
+  expect(agentSessionProcessFixture.livePids()).toEqual([])
+  if (expectedSpawnCount !== null) {
+    expect(agentSessionProcessFixture.readSpawns()).toHaveLength(expectedSpawnCount)
+  }
+}
+
+test('paired viewer worktree.create has one backend startup owner @headful', async ({
+  electronApp,
+  orcaPage
+}, testInfo) => {
+  test.setTimeout(180_000)
+  await configureFixtureAgent(orcaPage)
+  const hostWorktreeBefore = await activePairedWorktreeId(orcaPage)
+  const client = await launchPairedWebClient(
+    electronApp,
+    await createRuntimeDesktopPairingOffer(orcaPage)
+  )
+  const workspaceName = `sta-4908-owner-${Date.now()}`
+  let createdWorktreeTarget: WorktreeRemovalTarget | null = null
+  let expectedSpawnCount: number | null = null
+  try {
+    await configureFixtureAgent(client.page)
+    await waitForPairedWorktree(client.page, hostWorktreeBefore)
+    const createResult = await callAgentSessionClient<CreateWorktreeResult>(
+      client.page,
+      'worktree.create',
+      {
+        repo: await repoIdForWorktree(client.page, hostWorktreeBefore),
+        name: workspaceName,
+        setupDecision: 'skip',
+        createdWithAgent: 'codex',
+        startupCommand: agentSessionProcessFixture.command,
+        activate: true
+      }
+    )
+    const createdId = createResult.worktree.id
+    createdWorktreeTarget = {
+      id: createdId,
+      executionHostId: createResult.worktree.hostId ?? null
+    }
+    await waitForPairedWorktree(client.page, createdId)
+
+    await expect
+      .poll(() => agentSessionProcessFixture.readSpawns(), { timeout: 30_000 })
+      .toHaveLength(1)
+    expectedSpawnCount = 1
+    await expect.poll(() => listPairedTerminals(client.page, createdId)).toHaveLength(1)
+    const [terminal] = await listPairedTerminals(client.page, createdId)
+    if (!terminal?.ptyId) {
+      throw new Error('Backend startup terminal did not publish a PTY identity')
+    }
+    const webTabId = toWebTerminalSurfaceTabId(terminal.tabId)
+    await expect.poll(() => mirroredPairedTabIds(client.page, createdId)).toEqual([webTabId])
+    await expect.poll(() => mirroredPairedTabIds(orcaPage, createdId)).toEqual([terminal.tabId])
+    await client.page.locator(`[role="option"][data-worktree-id="${createdId}"]`).click()
+    await expect.poll(() => activePairedWorktreeId(client.page)).toBe(createdId)
+    await expect(client.page.locator('[data-testid="sortable-tab"]')).toHaveCount(1)
+    await expect(
+      client.page.locator(`[data-terminal-tab-id="${webTabId}"][data-terminal-layout-leaf-ids]`)
+    ).toBeVisible()
+    await expect
+      .poll(() => pairedTerminalViewportText(client.page, webTabId), { timeout: 30_000 })
+      .toContain('ORCA_REPRO_AGENT_READY')
+    expect(await activePairedWorktreeId(orcaPage)).toBe(hostWorktreeBefore)
+
+    const [spawn] = agentSessionProcessFixture.readSpawns()
+    expect(spawn).toBeDefined()
+    expect(agentSessionProcessFixture.livePids()).toEqual([spawn!.pid])
+    expect(spawn!.argv).not.toContain('resume')
+    await expect
+      .poll(() => pairedTerminalViewportText(client.page, webTabId), { timeout: 30_000 })
+      .toContain(`ORCA_REPRO_AGENT_READY:${spawn!.pid}`)
+    const processInspection = await callAgentSessionClient<{
+      process: { foregroundProcess: string | null; hasChildProcesses: boolean; unavailable?: true }
+    }>(client.page, 'terminal.inspectProcess', { terminal: terminal.handle })
+    expect(processInspection.process.unavailable).not.toBe(true)
+    // Why: Windows reports the ConPTY leader; rendered output carries the exact child PID.
+    expect(processInspection.process.foregroundProcess).toMatch(
+      /(?:pwsh|powershell|node|bash|zsh|sh)(?:\.exe)?/i
+    )
+    expect(createResult.startupTerminal).toMatchObject({
+      spawned: true,
+      handle: terminal.handle,
+      tabId: terminal.tabId,
+      ptyId: terminal.ptyId
+    })
+    const lifecycle = agentSessionProcessFixture.readLifecycle()
+    expect(lifecycle).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          pid: spawn!.pid,
+          event: 'started:stdin-tty=true:stdout-tty=true'
+        })
+      ])
+    )
+    const authoritativeTabs = await callAgentSessionClient(client.page, 'session.tabs.list', {
+      worktree: `id:${createdId}`
+    })
+    await attachEvidence(testInfo, 'sta-4908-ownership-evidence', {
+      hostWorktreeBefore,
+      viewerWorktreeAfter: createdId,
+      terminal,
+      processInspection,
+      startupTerminal: createResult.startupTerminal,
+      authoritativeTabs,
+      spawn,
+      lifecycle
+    })
+  } finally {
+    const cleanupTarget =
+      createdWorktreeTarget ??
+      (await worktreeTargetByName(client.page, workspaceName).catch(() => null))
+    if (cleanupTarget) {
+      await stopTerminal(client, cleanupTarget.id)
+      await removeCreatedWorktree(orcaPage, cleanupTarget)
+    }
+    await client.dispose()
+    await assertFixtureRetired(expectedSpawnCount)
+  }
+})
+
+test('two persistent paired viewers share one live resumed provider session @headful', async ({
+  electronApp,
+  orcaPage
+}, testInfo) => {
+  test.setTimeout(180_000)
+  await configureFixtureAgent(orcaPage)
+  const worktreeId = await activePairedWorktreeId(orcaPage)
+  const clientA = await launchPairedWebClient(
+    electronApp,
+    await createRuntimeDesktopPairingOffer(orcaPage)
+  )
+  let clientB: PairedWebClient | null = null
+  let claimedTerminal: RuntimeTerminalSummary | null = null
+  let expectedSpawnCount: number | null = null
+  try {
+    await waitForPairedWorktree(clientA.page, worktreeId)
+    const pairedClientB = await launchPairedWebClient(
+      electronApp,
+      await createRuntimeDesktopPairingOffer(orcaPage)
+    )
+    clientB = pairedClientB
+    await waitForPairedWorktree(pairedClientB.page, worktreeId)
+    const [clientAActiveTabBefore, clientBActiveTabBefore] = await Promise.all([
+      activePairedTabId(clientA.page, worktreeId),
+      activePairedTabId(pairedClientB.page, worktreeId)
+    ])
+    const providerSessionId = `sta-3859-${Date.now()}`
+    const request = {
+      kind: 'explicit',
+      worktree: `id:${worktreeId}`,
+      agent: 'codex',
+      providerSession: { key: 'session_id', id: providerSessionId },
+      presentation: 'focused'
+    }
+    const synchronizedStartAt = Date.now() + 500
+    const [timedFirst, timedSecond] = await Promise.all([
+      callAgentSessionClientAt<AgentSessionResult>(
+        clientA.page,
+        synchronizedStartAt,
+        'terminal.ensureAgentSession',
+        request
+      ),
+      callAgentSessionClientAt<AgentSessionResult>(
+        pairedClientB.page,
+        synchronizedStartAt,
+        'terminal.ensureAgentSession',
+        request
+      )
+    ])
+    const first = timedFirst.result
+    const second = timedSecond.result
+    expect(Math.abs(timedFirst.startedAt - timedSecond.startedAt)).toBeLessThanOrEqual(100)
+    claimedTerminal = first.terminal
+    await expect
+      .poll(() => agentSessionProcessFixture.readSpawns(), { timeout: 30_000 })
+      .toHaveLength(1)
+    expectedSpawnCount = 1
+    expect([first.disposition, second.disposition].sort()).toEqual(['adopted', 'created'])
+    expect(second.terminal).toMatchObject({
+      handle: first.terminal.handle,
+      tabId: first.terminal.tabId,
+      ptyId: first.terminal.ptyId
+    })
+    const [spawn] = agentSessionProcessFixture.readSpawns()
+    expect(spawn).toBeDefined()
+    expect(agentSessionProcessFixture.livePids()).toEqual([spawn!.pid])
+    expect(spawn!.argv).toEqual(expect.arrayContaining(['resume', providerSessionId]))
+
+    const retry = await callAgentSessionClient<AgentSessionResult>(
+      pairedClientB.page,
+      'terminal.ensureAgentSession',
+      request
+    )
+    expect(retry.disposition).toBe('adopted')
+    expect(retry.terminal.handle).toBe(first.terminal.handle)
+    expect(agentSessionProcessFixture.readSpawns()).toHaveLength(1)
+
+    const webTabId = toWebTerminalSurfaceTabId(first.terminal.tabId)
+    await expect.poll(() => mirroredPairedTabIds(clientA.page, worktreeId)).toContain(webTabId)
+    await expect
+      .poll(() => mirroredPairedTabIds(pairedClientB.page, worktreeId))
+      .toContain(webTabId)
+    expect(await activePairedTabId(clientA.page, worktreeId)).toBe(clientAActiveTabBefore)
+    expect(await activePairedTabId(pairedClientB.page, worktreeId)).toBe(clientBActiveTabBefore)
+    await pairedClientB.page.evaluate(
+      (id) => window.__store?.getState().setActiveWorktree(id),
+      worktreeId
+    )
+    const clientBTab = pairedClientB.page.locator(
+      `[data-testid="sortable-tab"][data-tab-id="${webTabId}"]`
+    )
+    await expect(clientBTab).toBeVisible()
+    await clientBTab.click()
+    await expect.poll(() => activePairedTabId(pairedClientB.page, worktreeId)).toBe(webTabId)
+    await expect
+      .poll(() => pairedTerminalViewportText(pairedClientB.page, webTabId), { timeout: 30_000 })
+      .toContain(`ORCA_REPRO_AGENT_READY:${spawn!.pid}`)
+
+    const input = `sta-3859-live-owner-${Date.now()}`
+    const sent = await callAgentSessionClient<{ send: { accepted: boolean } }>(
+      clientA.page,
+      'terminal.send',
+      { terminal: first.terminal.handle, text: `${input}\n` }
+    )
+    expect(sent.send.accepted).toBe(true)
+    await expect
+      .poll(() => agentSessionProcessFixture.readInput().includes(input), { timeout: 30_000 })
+      .toBe(true)
+    const clientBInput = `sta-3859-client-b-${Date.now()}`
+    const clientBInputArea = pairedClientB.page.locator('.xterm-helper-textarea:visible').first()
+    await clientBInputArea.focus()
+    await pairedClientB.page.keyboard.type(clientBInput)
+    await pairedClientB.page.keyboard.press('Enter')
+    await expect
+      .poll(() => agentSessionProcessFixture.readInput().includes(clientBInput), {
+        timeout: 30_000
+      })
+      .toBe(true)
+    expect(agentSessionProcessFixture.livePids()).toEqual([spawn!.pid])
+
+    const [clientAInventory, clientBInventory] = await Promise.all([
+      listPairedTerminals(clientA.page, worktreeId),
+      listPairedTerminals(pairedClientB.page, worktreeId)
+    ])
+    const matchesClaim = (terminal: RuntimeTerminalSummary): boolean =>
+      terminal.handle === first.terminal.handle
+    expect(clientAInventory.filter(matchesClaim)).toHaveLength(1)
+    expect(clientBInventory.filter(matchesClaim)).toHaveLength(1)
+    const lifecycle = agentSessionProcessFixture.readLifecycle()
+    expect(lifecycle).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          pid: spawn!.pid,
+          event: 'started:stdin-tty=true:stdout-tty=true'
+        })
+      ])
+    )
+    await attachEvidence(testInfo, 'sta-3859-ownership-evidence', {
+      clientADisposition: first.disposition,
+      clientBDisposition: second.disposition,
+      retryDisposition: retry.disposition,
+      synchronizedDispatch: { timedFirst, timedSecond },
+      terminal: first.terminal,
+      spawn,
+      clientAInventory,
+      clientBInventory,
+      lifecycle
+    })
+  } finally {
+    if (claimedTerminal) {
+      await callAgentSessionClient(clientA.page, 'terminal.close', {
+        terminal: claimedTerminal.handle
+      }).catch(() => undefined)
+    }
+    await clientB?.dispose()
+    await clientA.dispose()
+    await assertFixtureRetired(expectedSpawnCount)
+  }
+})

--- a/tests/e2e/remote-agent-session-focus-authority.spec.ts
+++ b/tests/e2e/remote-agent-session-focus-authority.spec.ts
@@ -19,6 +19,7 @@ type ClientMirror = {
 const scratch = mkdtempSync(path.join(os.tmpdir(), 'orca-headed-agent-focus-'))
 const spawnMarkerPath = path.join(scratch, 'agent-spawns.txt')
 const inputMarkerPath = path.join(scratch, 'agent-input.txt')
+const lifecycleMarkerPath = path.join(scratch, 'agent-lifecycle.txt')
 const exitTriggerPath = path.join(scratch, 'exit-agent')
 const fixtureScript = path.join(
   process.cwd(),
@@ -37,6 +38,7 @@ test.use({
   launchEnv: {
     ORCA_REPRO_EXIT_TRIGGER: exitTriggerPath,
     ORCA_REPRO_INPUT_MARKER: inputMarkerPath,
+    ORCA_REPRO_LIFECYCLE_MARKER: lifecycleMarkerPath,
     ORCA_REPRO_SPAWN_MARKER: spawnMarkerPath
   }
 })
@@ -52,7 +54,7 @@ function shellQuote(value: string): string {
 function fixtureCommand(scriptPath: string, ...args: string[]): string {
   const command = [process.execPath, scriptPath, ...args]
   return process.platform === 'win32'
-    ? command.map((value) => `"${value.replaceAll('"', '""')}"`).join(' ')
+    ? `& ${command.map((value) => `'${value.replaceAll("'", "''")}'`).join(' ')}`
     : command.map(shellQuote).join(' ')
 }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​653 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​652 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​132 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​20 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​112 |

<!-- /orca-pr-loc -->

## Summary

- add a physical-Windows paired-viewer oracle for initial workspace-agent ownership (STA-4908)
- race two persistent paired viewers on one provider-session identity and prove one writable PTY/process (STA-3859)
- make the existing remote authority fixture reliable under PowerShell/ConPTY and record Windows reliability-gate evidence

This is deliberately test/harness-only. Current main already contains the narrow host-authority fixes, so no product behavior change was justified.

## Findings

- STA-4908 and STA-3859 are related authority races, but not the same trigger.
- Initial creation is host/backend-owned; paired renderers consume the canonical host tab instead of seeding another process.
- Resume identity is host-authoritative through the canonical provider-session claim key and atomic reservation/adoption.
- Replacing only the canonical claim key with a per-call key deterministically produced two live Windows fixture processes with identical resume argv, launched 292 ms apart. Restoring the claim key returned the test to one process.
- Removing only the older `backendStartupTerminalSpawned` propagation did not re-fail the current paired startup journey because newer runtime-ownership and host-tab mirroring protections overlap.

Refs STA-4908, STA-3859.

## Validation

- `pnpm run check:reliability-gates`
- `pnpm run check:max-lines-ratchet`
- focused `oxlint` on all changed JS/TS files
- 1,209 focused runtime/remote authority Vitest cases
- `node config/scripts/remote-agent-session-authority-repro.mjs`
- `remote-agent-session-focus-authority.spec.ts` on physical Windows: 1 passed
- `paired-agent-session-ownership.spec.ts` on physical Windows: 2 passed

Repository-wide `pnpm run typecheck:e2e` remains red on unrelated pre-existing E2E diagnostics; the output contained no diagnostic for the new spec.