### PR TITLE
feat(workspace): start an agent with a prompt at workspace creation

### DIFF
--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -127,6 +127,13 @@ type NewWorkspaceComposerCardProps = {
   showCreateMultiple?: boolean
   createMultiple?: boolean
   onCreateMultipleChange?: (next: boolean) => void
+  /** When on, the startup prompt is auto-submitted to the agent once the
+   *  workspace's first terminal is ready, instead of only prefilled as a draft. */
+  createAndRun?: boolean
+  onCreateAndRunChange?: (next: boolean) => void
+  /** Hides the "Start with a prompt" field and "Create & run" toggle. Off for
+   *  folder-workspace targets, which don't support prompt auto-submit. */
+  showAgentStartPrompt?: boolean
   smartNameGitHubSourceContext?: TaskSourceContext | null
   smartNameJiraSourceContext?: TaskSourceContext | null
   /** Advisory shown under the name field when a fork PR can't accept maintainer pushes. */
@@ -139,6 +146,10 @@ type NewWorkspaceComposerCardProps = {
   projectError: string | null
   creating: boolean
   onCreate: () => void
+  /** Startup prompt for the created workspace's agent. Empty keeps the
+   *  note/linked-item-derived prompt. */
+  agentPrompt?: string
+  onAgentPromptChange?: (value: string) => void
   note: string
   onNoteChange: (value: string) => void
   setupConfig: SetupConfig | null
@@ -341,6 +352,9 @@ export default function NewWorkspaceComposerCard({
   showCreateMultiple = false,
   createMultiple = false,
   onCreateMultipleChange,
+  createAndRun = false,
+  onCreateAndRunChange,
+  showAgentStartPrompt = true,
   smartNameGitHubSourceContext,
   smartNameJiraSourceContext,
   forkPushWarning,
@@ -352,6 +366,8 @@ export default function NewWorkspaceComposerCard({
   projectError,
   creating,
   onCreate,
+  agentPrompt = '',
+  onAgentPromptChange,
   note,
   onNoteChange,
   setupConfig,
@@ -938,6 +954,27 @@ export default function NewWorkspaceComposerCard({
           />
         </div>
 
+        {showAgentStartPrompt ? (
+          <div className="min-w-0 space-y-1">
+            <label className="text-xs font-medium text-muted-foreground">
+              {translate(
+                'auto.components.NewWorkspaceComposerCard.agentPromptLabel',
+                'Start with a prompt'
+              )}
+            </label>
+            <textarea
+              value={agentPrompt}
+              onChange={(event) => onAgentPromptChange?.(event.target.value)}
+              placeholder={translate(
+                'auto.components.NewWorkspaceComposerCard.agentPromptPlaceholder',
+                'What should the agent do?'
+              )}
+              rows={1}
+              className="w-full min-w-0 resize-none overflow-y-auto scrollbar-sleek rounded-md border border-input bg-transparent px-3 py-1.5 text-sm shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 [field-sizing:content] max-h-40"
+            />
+          </div>
+        ) : null}
+
         {/* Why: keep the Advanced disclosure header grouped with the content below while preserving spacing from the Agent field above. */}
         <div className="!mb-2">
           {/* Why: -ml-2 pulls the button so its label aligns flush-left with the field labels above
@@ -1225,26 +1262,40 @@ export default function NewWorkspaceComposerCard({
         </div>
       ) : null}
 
-      <div
-        className={cn(
-          'flex items-center gap-3',
-          showCreateMultiple ? 'justify-between' : 'justify-end'
-        )}
-      >
-        {showCreateMultiple ? (
-          <button
-            type="button"
-            role="switch"
-            aria-checked={createMultiple}
-            onClick={() => onCreateMultipleChange?.(!createMultiple)}
-            className="group flex w-fit cursor-pointer items-center gap-2 rounded-md text-xs outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
-          >
-            <SwitchIndicator checked={createMultiple} />
-            <span className="text-muted-foreground transition-colors group-hover:text-foreground">
-              {translate('auto.components.NewWorkspaceComposerCard.createMultiple', 'Create more')}
-            </span>
-          </button>
-        ) : null}
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          {showAgentStartPrompt ? (
+            <button
+              type="button"
+              role="switch"
+              aria-checked={createAndRun}
+              onClick={() => onCreateAndRunChange?.(!createAndRun)}
+              className="group flex w-fit cursor-pointer items-center gap-2 rounded-md text-xs outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+            >
+              <SwitchIndicator checked={createAndRun} />
+              <span className="text-muted-foreground transition-colors group-hover:text-foreground">
+                {translate('auto.components.NewWorkspaceComposerCard.createAndRun', 'Create & run')}
+              </span>
+            </button>
+          ) : null}
+          {showCreateMultiple ? (
+            <button
+              type="button"
+              role="switch"
+              aria-checked={createMultiple}
+              onClick={() => onCreateMultipleChange?.(!createMultiple)}
+              className="group flex w-fit cursor-pointer items-center gap-2 rounded-md text-xs outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+            >
+              <SwitchIndicator checked={createMultiple} />
+              <span className="text-muted-foreground transition-colors group-hover:text-foreground">
+                {translate(
+                  'auto.components.NewWorkspaceComposerCard.createMultiple',
+                  'Create more'
+                )}
+              </span>
+            </button>
+          ) : null}
+        </div>
         <Button
           onClick={() => void onCreate()}
           disabled={createDisabled}

--- a/src/renderer/src/components/NewWorkspaceComposerModal.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerModal.tsx
@@ -322,6 +322,7 @@ function QuickTabBody({
         onQuickAgentChange={handleQuickAgentChange}
         {...cardProps}
         primaryActionLabel={primaryActionLabel}
+        showAgentStartPrompt={!isFolderWorkspaceTarget}
         onOpenAgentSettings={() => setAgentSettingsOpen(true)}
         onCreate={() => void handleCreate()}
         onAddProjectOverride={handleOpenAddProject}

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -322,6 +322,9 @@ export type ComposerCardProps = {
   /** When on, the modal stays open after each create and resets identity fields to allow creating several in a row. */
   createMultiple: boolean
   onCreateMultipleChange: (next: boolean) => void
+  /** When on, the startup prompt is auto-submitted to the agent once the workspace's first terminal is ready. */
+  createAndRun: boolean
+  onCreateAndRunChange: (next: boolean) => void
   agentPrompt: string
   onAgentPromptChange: (value: string) => void
   /** Rendered issueCommand template previewed in the empty prompt when a work item is linked but nothing typed. */
@@ -979,6 +982,9 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   const [agentPrompt, setAgentPrompt] = useState<string>(
     persistDraft ? (newWorkspaceDraft?.prompt ?? initialPrompt) : initialPrompt
   )
+  // Why: "Create & run" auto-submits the startup prompt to the agent once the
+  // workspace's first terminal is ready, instead of only prefilling it as a draft.
+  const [createAndRun, setCreateAndRun] = useState<boolean>(false)
   const [note, setNote] = useState<string>(persistDraft ? (newWorkspaceDraft?.note ?? '') : '')
   const [attachmentPaths, setAttachmentPaths] = useState<string[]>(
     persistDraft ? (newWorkspaceDraft?.attachments ?? []) : []
@@ -4390,8 +4396,19 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         const trimmedNote = note.trim()
         // Why: agents needing post-ready paste/follow-up stay on the renderer path so prompt delivery isn't skipped.
         const promptLinkedWorkItem = agent === null ? null : submitLinkedWorkItem
-        const { prompt: quickPrompt, draftPrompt: quickDraftPrompt } =
+        // Why: an explicit "Start with a prompt" wins over the note/linked-item-derived
+        // draft so "Create & run" can auto-submit exactly what the user typed.
+        const trimmedAgentPrompt = agentPrompt.trim()
+        const { prompt: linkedQuickPrompt, draftPrompt: linkedQuickDraftPrompt } =
           resolveQuickCreateLinkedWorkItemPrompt(promptLinkedWorkItem, trimmedNote)
+        // Why: keep the linked item's context (e.g. a referenced GitHub issue URL)
+        // alongside an explicit "Start with a prompt" instead of discarding it.
+        const linkedContextUrl = promptLinkedWorkItem?.url?.trim() || null
+        const mergedPrompt = trimmedAgentPrompt
+          ? [trimmedAgentPrompt, linkedContextUrl].filter(Boolean).join('\n\n')
+          : trimmedAgentPrompt
+        const quickPrompt = mergedPrompt || linkedQuickPrompt
+        const quickDraftPrompt = mergedPrompt || linkedQuickDraftPrompt
         const quickSessionOptions =
           agent === null
             ? undefined
@@ -4586,6 +4603,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
           startupPlan,
           quickPrompt,
           ...(quickDraftPrompt ? { launchDraftPrompt: quickDraftPrompt } : {}),
+          ...(createAndRun ? { createAndRun: true } : {}),
           quickTelemetry,
           ...(createMultiple ? { suppressTerminalFocusOnCompletion: true } : {})
         }
@@ -4617,6 +4635,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     },
     [
       baseBranch,
+      agentPrompt,
       compareBaseRef,
       branchNameOverride,
       branchNameOverridePreservesNameEdits,
@@ -4679,6 +4698,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       ephemeralVmRecipes,
       isProjectGroupTarget,
       submitFolderTarget,
+      createAndRun,
       createMultiple,
       resetForNextCreate
     ]
@@ -4747,6 +4767,8 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     showCreateMultiple: !isProjectGroupTarget,
     createMultiple,
     onCreateMultipleChange: setCreateMultiple,
+    createAndRun,
+    onCreateAndRunChange: setCreateAndRun,
     agentPrompt,
     onAgentPromptChange: setAgentPrompt,
     linkedOnlyTemplatePreview: shouldApplyLinkedOnlyTemplate ? linkedOnlyTemplatePrompt : null,

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -1523,7 +1523,10 @@
         "addSshHostHint": "Use an existing machine over SSH",
         "addRemoteOrcaServer": "Add Remote Orca Server",
         "addRemoteOrcaServerHint": "Pair another Orca runtime",
-        "hostConnectionFailed": "Connection failed"
+        "hostConnectionFailed": "Connection failed",
+        "agentPromptLabel": "Start with a prompt",
+        "agentPromptPlaceholder": "What should the agent do?",
+        "createAndRun": "Create & run"
       },
       "NewWorkspaceComposerModal": {
         "createWorktree": "Create worktree",

--- a/src/renderer/src/lib/pending-worktree-creation.ts
+++ b/src/renderer/src/lib/pending-worktree-creation.ts
@@ -102,6 +102,9 @@ export type WorktreeCreationRequest = {
   /** Launch context delivered only as an unsent TUI-input draft (argv prefill or
    *  startup paste); completion seeds the chat-composer copy from it. */
   launchDraftPrompt?: string
+  /** When true, the startup prompt is auto-submitted to the agent as soon as the
+   *  workspace's first terminal is ready instead of only prefilled as a draft. */
+  createAndRun?: boolean
   quickTelemetry: AgentStartedTelemetry | null
   /** When the composer stays open for sequential creates, completion must not
    *  steal focus from the next workspace name field. */

--- a/src/renderer/src/lib/worktree-creation-flow-startup.test.ts
+++ b/src/renderer/src/lib/worktree-creation-flow-startup.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { WorktreeCreationRequest } from '@/lib/pending-worktree-creation'
+import { buildWorktreeCreationStartupOpt } from './worktree-creation-flow-startup'
+
+vi.mock('@/runtime/runtime-rpc-client', () => ({
+  getActiveRuntimeTarget: () => ({ kind: 'local' })
+}))
+
+const PROMPT = 'do the thing'
+
+function buildRequest(overrides: Partial<WorktreeCreationRequest>): WorktreeCreationRequest {
+  return {
+    agent: 'claude',
+    startupPlan: { agent: 'claude', launchCommand: 'claude' } as never,
+    quickPrompt: PROMPT,
+    quickTelemetry: null,
+    name: 'wt',
+    setupDecision: 'skip',
+    pendingFirstAgentMessageRename: false,
+    note: '',
+    ...overrides
+  } as WorktreeCreationRequest
+}
+
+describe('buildWorktreeCreationStartupOpt', () => {
+  it('auto-submits the startup prompt for any agent when createAndRun is set', () => {
+    const opt = buildWorktreeCreationStartupOpt(buildRequest({ createAndRun: true }), false)
+    expect(opt?.initialAgentStatus).toEqual({ agent: 'claude', prompt: PROMPT })
+  })
+
+  it('does not auto-submit for a non-command-code agent when createAndRun is off', () => {
+    const opt = buildWorktreeCreationStartupOpt(buildRequest({ createAndRun: false }), false)
+    expect(opt?.initialAgentStatus).toBeUndefined()
+  })
+
+  it('keeps auto-submitting for command-code even without the toggle', () => {
+    const opt = buildWorktreeCreationStartupOpt(
+      buildRequest({ agent: 'command-code', createAndRun: false }),
+      false
+    )
+    expect(opt?.initialAgentStatus).toEqual({ agent: 'command-code', prompt: PROMPT })
+  })
+
+  it('never auto-submits when there is no startup prompt', () => {
+    const opt = buildWorktreeCreationStartupOpt(
+      buildRequest({ createAndRun: true, quickPrompt: '   ' }),
+      false
+    )
+    expect(opt?.initialAgentStatus).toBeUndefined()
+  })
+})

--- a/src/renderer/src/lib/worktree-creation-flow-startup.ts
+++ b/src/renderer/src/lib/worktree-creation-flow-startup.ts
@@ -28,8 +28,12 @@ export function buildWorktreeCreationStartupOpt(
     ...(request.launchDraftPrompt ? { launchDraftText: request.launchDraftPrompt } : {}),
     ...(plan.startupCommandDelivery ? { startupCommandDelivery: plan.startupCommandDelivery } : {}),
     // Why: command-code shows its prompt in the tab status before the first
-    // hook fires, so the prompt is threaded through here.
-    ...(request.agent === 'command-code' && request.quickPrompt.trim().length > 0
+    // hook fires, so the prompt is threaded through here. "Create & run" opts in
+    // to the same auto-submit for any agent: the prompt is delivered once the
+    // first terminal is ready instead of only prefilled as a draft.
+    ...(request.agent &&
+    request.quickPrompt.trim().length > 0 &&
+    (request.createAndRun === true || request.agent === 'command-code')
       ? { initialAgentStatus: { agent: request.agent, prompt: request.quickPrompt.trim() } }
       : {}),
     ...(request.quickTelemetry ? { telemetry: request.quickTelemetry } : {})


### PR DESCRIPTION
## ELI5

Right now you can't tell Orca what to work on when you first create a workspace — you have to create it and then type your prompt. This lets you type the prompt (and optionally tick "Create & run") right in the New Workspace dialog, so the agent starts working on it immediately once the workspace is ready.

## What Changed

- Adds a **"Start with a prompt"** textarea to the quick-create workspace composer.
- Adds a **"Create & run"** toggle next to it. When ON, the typed prompt (plus any referenced linked item URL) is auto-submitted to the agent once the workspace's first terminal is ready; when OFF it prefills as a draft (existing behavior).
- The prompt field and toggle are hidden for folder-workspace targets, which use a separate creation path that doesn't support prompt auto-submit.
- When the user types a prompt, any referenced linked item (e.g. a GitHub issue URL) is kept alongside it instead of being discarded.

## Why

The referenced issue asks to "start the agent immediately with a prompt entered at workspace creation". The toggle matches the issue's suggested "Create & run" action and keeps the default behavior unchanged.

## Linked Issue

Fixes #7995

## Visual Proof

Before/after screenshots are attached via drag-drop per the template (not committed to the PR). Local captures:

- **Before (English UI)**: 
<img width="512" height="522" alt="orca-before-en" src="https://github.com/user-attachments/assets/43740b30-8fee-4200-907d-ee4e0730b40f" />

- **After (English UI)**: 
<img width="512" height="602" alt="orca-after-en" src="https://github.com/user-attachments/assets/a9a8670b-9774-4973-b0f2-d9ccc0caeca5" />

- **Agent first screen (launched via Create & run)**: 
<img width="1280" height="900" alt="orca-agent-first-screen" src="https://github.com/user-attachments/assets/cfe3f7bd-1ee4-4139-a64d-591742a5c2ac" />


## Testing

- `pnpm typecheck:web` ✅
- `pnpm lint` (all gates incl. localization) ✅
- New unit test `worktree-creation-flow-startup.test.ts` (4 tests) ✅
- `pnpm test`: 5991 files / 56316 tests pass; 3 pre-existing failures in unrelated WSL/git files
- Captured English-UI modal + agent first screen via Playwright e2e showing the new field, toggle, and auto-launched agent

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

## AI Disclosure

## Review

## Agent skill upstream boundary

- [x] Not applicable — this change follows no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- Cross-platform: no platform-specific behavior introduced.
- SSH/remote: prompt delivery reuses the existing agent startup path.
- Folder workspaces: feature gated off (separate creation path).

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots attached for UI changes
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass

## Author

- X / Twitter: @hanqyu
