### PR TITLE
fix(terminal): preserve settled prompt authority

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -9421,7 +9421,7 @@
         "https://linear.app/stably/issue/STA-4488",
         "https://github.com/stablyai/orca/issues/14525"
       ],
-      "invariant": "A public CLI send containing non-empty text plus Enter and no interrupt identifies agent-prompt intent. The owning runtime uses bracketed-paste and settled submit only when a bounded foreground read positively identifies the exact target as Claude or Codex on a desktop call; known transient wrappers may resolve within the existing bound, and proven current foreground identity outranks historical launch identity for render settlement. The exact PTY binding and desktop input-floor authority are rechecked before every paste chunk and delayed Enter. Every other agent, stale agent metadata over a shell, text-only input, bare Enter, interrupts, mobile input, query replies, and older clients keep the direct terminal contract.",
+      "invariant": "A public CLI send containing non-empty text plus Enter and no interrupt identifies agent-prompt intent. The owning runtime uses bracketed-paste and settled submit only when a bounded foreground read positively identifies the exact target as Claude or Codex on a desktop call; known transient wrappers may resolve within the existing bound, and proven current foreground identity outranks historical launch identity for render settlement. Once target proof exists, a changed or unavailable foreground refuses the request without legacy fallback; foreground identity is rechecked after the pre-write guard and before delayed Enter, while exact PTY binding and desktop input-floor authority are rechecked before every paste chunk and delayed Enter. Every other positively identified agent or shell, text-only input, bare Enter, interrupts, mobile input, query replies, and older clients keep the direct terminal contract.",
       "oracle": "Launch a bare fake Codex through the real Electron PTY and delay its composer render for 1,200 ms, beyond the legacy generic 500 ms gap. Send a 557-byte prompt with the public CLI and require the marker, zero premature Enter, no rescue Enter, and one submission. POSIX child stdin must retain one bracketed-paste frame; Windows ConPTY consumes that control frame, so runtime tests require the frame at the PTY write boundary while the Windows child requires the exact prompt. The same harness against the installed pre-fix runtime must record one premature Enter and require one bare rescue Enter. Focused units drive a node-to-Codex wrapper transition with fake time, prove fresh foreground Codex outranks stale non-target launch identity at the render gate, and transfer the paired-mobile floor between paste and suffix while recording request, PTY generation, owner, exact writes, and ordering. The baseline must fall back or write Enter in all three cases; the candidate must settle once or reject before cross-owner Enter, with no direct fallback or duplicate input.",
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/cli/handlers/terminal.test.ts src/main/runtime/rpc/terminal-agent-prompt-send.test.ts src/main/runtime/rpc/terminal-send.test.ts src/main/runtime/orca-runtime.test.ts src/shared/agent-prompt-injection.test.ts",
@@ -9464,7 +9464,8 @@
             "a speculative CLI prompt check does not poll wrapper foregrounds",
             "a known transient wrapper resolves to Codex within the bounded foreground retry",
             "current foreground proof stays request-local inside the PTY generation queue and outranks stale launch identity",
-            "identity transition, cancellation, and concurrent classification cannot write or fan out",
+            "identity transition, unavailable inspection, cancellation, and concurrent classification cannot write, fall back, or fan out",
+            "foreground authority is rechecked after an awaited pre-write guard and before delayed Enter",
             "the PTY write boundary retains bracketed framing and one delayed submit"
           ]
         },
@@ -9530,8 +9531,8 @@
           "platform": "macos",
           "command": "pnpm exec vitest run --config config/vitest.config.ts src/cli/handlers/terminal.test.ts src/main/runtime/rpc/terminal-agent-prompt-send.test.ts src/main/runtime/rpc/terminal-send.test.ts src/main/runtime/orca-runtime.test.ts src/shared/agent-prompt-injection.test.ts",
           "result": "passed",
-          "durationSeconds": 10.8,
-          "summary": "The 1,262-test candidate gate passed with one existing skip. Its three ticket oracles fail on origin/main and with only the candidate production hunks disabled, then pass together on the candidate. Follow-up adversarial contracts also prove request-local identity, cancellation after one wrapper read, serialized concurrent classification, and a non-yielding floor check beside each PTY write."
+          "durationSeconds": 11.6,
+          "summary": "The final 1,235-test candidate gate passed with one existing skip in 11.6s. Its three ticket oracles fail on origin/main and with only the candidate production hunks disabled, then pass together on the candidate. Follow-up adversarial contracts also prove request-local identity, prompt refusal after foreground loss or unavailable inspection, abort-aware foreground reads, serialized classification, and a non-yielding floor check beside each PTY write."
         },
         {
           "date": "2026-08-20",
@@ -9539,8 +9540,8 @@
           "platform": "macos",
           "command": "pnpm run build:cli && pnpm exec playwright test tests/e2e/terminal-send-agent-prompt-submit.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
           "result": "passed",
-          "durationSeconds": 34.6,
-          "summary": "All four source-built Electron prompt journeys passed. The encrypted paired-mobile case recorded desktop then mobile authority, the exact bracketed prompt frame plus mobile bytes at fake-agent stdin, no carriage return, and an accepted=false desktop result after takeover."
+          "durationSeconds": 35.2,
+          "summary": "All four source-built Electron prompt journeys passed. The encrypted paired-mobile case recorded desktop then mobile authority, the exact and only bracketed prompt frame followed by mobile bytes at fake-agent stdin, no carriage return, and an accepted=false desktop result after takeover."
         },
         {
           "date": "2026-08-20",
@@ -9548,8 +9549,8 @@
           "platform": "linux",
           "command": "pnpm run build:relay && ORCA_E2E_SSH_DOCKER=1 pnpm exec playwright test tests/e2e/ssh-docker-agent-prompt-submit.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
           "result": "passed",
-          "durationSeconds": 39.4,
-          "summary": "The candidate passed against an ephemeral Debian SSH target and real relay with two controlled half-open process reads, an asserted upper retry bound, one post-render remote Enter, SSH execution-host proof, unconditional target cleanup, and an unrelated live remote PTY. The byte-identical oracle fails when only settled-wrapper delivery is disabled because legacy delivery settles before the retry barrier."
+          "durationSeconds": 37.2,
+          "summary": "The candidate passed against an ephemeral Debian SSH target and real relay with two controlled half-open process reads, an asserted upper retry bound, one post-render remote Enter, SSH execution-host proof, bounded best-effort terminal close followed by unconditional target cleanup, and an unrelated live remote PTY. The byte-identical oracle fails when only settled-wrapper delivery is disabled because legacy delivery settles before the retry barrier."
         }
       ],
       "runtimeBudget": {

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -9411,9 +9411,9 @@
       ],
       "platforms": ["macos", "linux", "windows"],
       "providers": ["local", "daemon", "ssh", "remote-runtime"],
-      "coveredPlatforms": ["macos", "windows"],
-      "coveredProviders": ["local"],
-      "coverageNotes": "Source-built macOS and physical Windows Electron journeys cover the public CLI through RPC, runtime identity, real PTY/ConPTY writes, and a delayed fake Codex composer. Focused units cover CLI intent, transient wrapper resolution, fresh foreground identity over stale launch metadata, paired-mobile floor takeover before delayed Enter, framing bytes, stale-agent shell fallback, and exact legacy behavior for every other configured agent. SSH, daemon, and remote-runtime live evidence remain explicit gaps.",
+      "coveredPlatforms": ["macos", "linux", "windows"],
+      "coveredProviders": ["local", "ssh"],
+      "coverageNotes": "Source-built macOS and physical Windows Electron journeys cover the public CLI through RPC, runtime identity, real PTY/ConPTY writes, and a delayed fake Codex composer. A real encrypted mobile subscription proves desktop-to-mobile floor takeover with exact fake-agent stdin, and an ephemeral Linux Docker SSH target proves half-open relay process inspection, transient wrapper retry, exact remote input, SSH execution ownership, and unrelated-PTY survival. Daemon and paired remote-runtime live evidence remain explicit gaps.",
       "motivatingLinks": [
         "https://linear.app/stably/issue/STA-4328",
         "https://linear.app/stably/issue/STA-4486",
@@ -9426,6 +9426,7 @@
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/cli/handlers/terminal.test.ts src/main/runtime/rpc/terminal-agent-prompt-send.test.ts src/main/runtime/rpc/terminal-send.test.ts src/main/runtime/orca-runtime.test.ts src/shared/agent-prompt-injection.test.ts",
         "pnpm run build:cli && pnpm exec playwright test tests/e2e/terminal-send-agent-prompt-submit.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
+        "pnpm run build:relay && ORCA_E2E_SSH_DOCKER=1 pnpm exec playwright test tests/e2e/ssh-docker-agent-prompt-submit.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
         "pnpm.cmd exec playwright test tests/e2e/terminal-send-agent-prompt-submit.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
         "node tests/tools/repro-terminal-send-submit.mjs --cli orca --worktree <registered-worktree> --discard-report"
       ],
@@ -9436,6 +9437,7 @@
         "src/main/runtime/orca-runtime.test.ts",
         "src/shared/agent-prompt-injection.test.ts",
         "tests/e2e/terminal-send-agent-prompt-submit.spec.ts",
+        "tests/e2e/ssh-docker-agent-prompt-submit.spec.ts",
         "tests/tools/repro-terminal-send-submit.mjs"
       ],
       "assertionRefs": [
@@ -9470,7 +9472,16 @@
           "assertions": [
             "the public source-built CLI submits after a delayed composer render without rescue",
             "the fake agent receives the marker and zero premature Enter on macOS and Windows",
-            "POSIX preserves one bracketed-paste frame while Windows validates the ConPTY-observable payload"
+            "POSIX preserves one bracketed-paste frame while Windows validates the ConPTY-observable payload",
+            "a real paired mobile floor takeover blocks delayed desktop Enter with exact PTY input"
+          ]
+        },
+        {
+          "file": "tests/e2e/ssh-docker-agent-prompt-submit.spec.ts",
+          "assertions": [
+            "two half-open SSH relay wrapper inspections precede a bounded retry that identifies Codex",
+            "the remote fake agent receives one post-render Enter and no premature Enter",
+            "execution stays on the SSH host and an unrelated remote PTY remains writable"
           ]
         }
       ],
@@ -9519,19 +9530,37 @@
           "result": "passed",
           "durationSeconds": 12.9,
           "summary": "The 1,227-test candidate gate passed with one existing skip. Its three controlled oracles also failed on origin/main and with only the candidate production hunks disabled, then passed together on the candidate: node-to-Codex wrapper settlement, current foreground over stale launch identity, and paired-mobile floor takeover before delayed Enter."
+        },
+        {
+          "date": "2026-08-20",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm run build:cli && pnpm exec playwright test tests/e2e/terminal-send-agent-prompt-submit.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
+          "result": "passed",
+          "durationSeconds": 34.0,
+          "summary": "All four source-built Electron prompt journeys passed. The encrypted paired-mobile case recorded desktop then mobile authority, prompt and mobile bytes at fake-agent stdin, no carriage return, and an accepted=false desktop result after takeover."
+        },
+        {
+          "date": "2026-08-20",
+          "runner": "local",
+          "platform": "linux",
+          "command": "pnpm run build:relay && ORCA_E2E_SSH_DOCKER=1 pnpm exec playwright test tests/e2e/ssh-docker-agent-prompt-submit.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
+          "result": "passed",
+          "durationSeconds": 31.3,
+          "summary": "The candidate passed against an ephemeral Debian SSH target and real relay with two controlled half-open process reads, bounded wrapper retry, one post-render remote Enter, SSH execution-host proof, and an unrelated live remote PTY. The byte-identical oracle failed when only the settled-wrapper fix was disabled because the send settled through legacy delivery before the retry barrier."
         }
       ],
       "runtimeBudget": {
-        "p95Seconds": 90,
-        "scope": "focused units plus one isolated Electron CLI/PTY journey"
+        "p95Seconds": 180,
+        "scope": "focused units, isolated Electron CLI/paired-mobile journeys, and one Docker SSH relay journey"
       },
       "flakeHistory": {
         "status": "unknown",
         "evidence": "The final oracle passed twice in independent macOS app launches and twice on physical Windows. A shared --repeat-each fixture mode failed before test execution because only one seeded worktree loaded; supported isolated invocations were used for product evidence. CI history is not yet collected."
       },
       "redGreenEvidence": {
-        "status": "partial",
-        "evidence": "The fake-composer oracle was red against the installed pre-fix runtime with prematureEnters=1 and rescueSent=true. It also caught a source-built late-identity race with a complete paste frame but one premature Enter before the render gate began resolving foreground identity. The final candidate is green on macOS and Windows with prematureEnters=0 and rescueSent=false."
+        "status": "complete",
+        "evidence": "The same controlled unit oracles are red on origin/main and with each production fix disabled, then green together on the candidate. The paired-mobile Electron oracle is green on the candidate, while its byte-identical controlled floor-takeover oracle is red without the delayed authority recheck. The Docker SSH oracle is green on the candidate and red with only settled-wrapper retry disabled, where legacy delivery settles before the retry barrier. Existing macOS and Windows fake-composer evidence remains green with prematureEnters=0 and rescueSent=false."
       },
       "performanceBudget": {
         "required": true,
@@ -9542,7 +9571,7 @@
         "Retain mixed-version evidence that old hosts strip the optional intent and new hosts accept old clients without a protocol bump."
       ],
       "knownGaps": [
-        "Live SSH/daemon/remote-runtime evidence is not yet attached.",
+        "Live daemon and paired remote-runtime evidence is not yet attached; SSH relay and paired mobile-to-local-runtime evidence are covered.",
         "Only Claude and Codex opt into settlement; every other agent retains the legacy behavior until independently validated.",
         "A new CLI talking to an old host safely loses the optional field and therefore keeps the old timing behavior until the host updates.",
         "The E2E fake agent models the submission race without requiring external agent authentication; live account-backed agents are covered separately."

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -9413,13 +9413,16 @@
       "providers": ["local", "daemon", "ssh", "remote-runtime"],
       "coveredPlatforms": ["macos", "windows"],
       "coveredProviders": ["local"],
-      "coverageNotes": "Source-built macOS and physical Windows Electron journeys cover the public CLI through RPC, runtime identity, real PTY/ConPTY writes, and a delayed fake Codex composer. Focused units cover CLI intent, fresh Claude/Codex foreground identity, framing bytes, stale-agent shell fallback, and exact legacy behavior for every other configured agent. SSH, daemon, and remote-runtime remain explicit gaps.",
+      "coverageNotes": "Source-built macOS and physical Windows Electron journeys cover the public CLI through RPC, runtime identity, real PTY/ConPTY writes, and a delayed fake Codex composer. Focused units cover CLI intent, transient wrapper resolution, fresh foreground identity over stale launch metadata, paired-mobile floor takeover before delayed Enter, framing bytes, stale-agent shell fallback, and exact legacy behavior for every other configured agent. SSH, daemon, and remote-runtime live evidence remain explicit gaps.",
       "motivatingLinks": [
         "https://linear.app/stably/issue/STA-4328",
+        "https://linear.app/stably/issue/STA-4486",
+        "https://linear.app/stably/issue/STA-4487",
+        "https://linear.app/stably/issue/STA-4488",
         "https://github.com/stablyai/orca/issues/14525"
       ],
-      "invariant": "A public CLI send containing non-empty text plus Enter and no interrupt identifies agent-prompt intent. The owning runtime uses bracketed-paste and settled submit only when a fresh foreground-process read positively identifies the exact target as Claude or Codex on a desktop call; every other agent, stale agent metadata over a shell, text-only input, bare Enter, interrupts, mobile input, query replies, and older clients keep the direct terminal contract.",
-      "oracle": "Launch a bare fake Codex through the real Electron PTY and delay its composer render for 1,200 ms, beyond the legacy generic 500 ms gap. Send a 557-byte prompt with the public CLI and require the marker, zero premature Enter, no rescue Enter, and one submission. POSIX child stdin must retain one bracketed-paste frame; Windows ConPTY consumes that control frame, so runtime tests require the frame at the PTY write boundary while the Windows child requires the exact prompt. The same harness against the installed pre-fix runtime must record one premature Enter and require one bare rescue Enter. Focused units require CLI intent only for text plus Enter, settlement only for freshly identified Claude/Codex, the legacy platform delay for every other configured agent, stale Codex launch identity over a shell to fall back, no wrapper polling, and byte-for-byte direct delivery for non-targets.",
+      "invariant": "A public CLI send containing non-empty text plus Enter and no interrupt identifies agent-prompt intent. The owning runtime uses bracketed-paste and settled submit only when a bounded foreground read positively identifies the exact target as Claude or Codex on a desktop call; known transient wrappers may resolve within the existing bound, and proven current foreground identity outranks historical launch identity for render settlement. The exact PTY binding and desktop input-floor authority are rechecked before every paste chunk and delayed Enter. Every other agent, stale agent metadata over a shell, text-only input, bare Enter, interrupts, mobile input, query replies, and older clients keep the direct terminal contract.",
+      "oracle": "Launch a bare fake Codex through the real Electron PTY and delay its composer render for 1,200 ms, beyond the legacy generic 500 ms gap. Send a 557-byte prompt with the public CLI and require the marker, zero premature Enter, no rescue Enter, and one submission. POSIX child stdin must retain one bracketed-paste frame; Windows ConPTY consumes that control frame, so runtime tests require the frame at the PTY write boundary while the Windows child requires the exact prompt. The same harness against the installed pre-fix runtime must record one premature Enter and require one bare rescue Enter. Focused units drive a node-to-Codex wrapper transition with fake time, prove fresh foreground Codex outranks stale non-target launch identity at the render gate, and transfer the paired-mobile floor between paste and suffix while recording request, PTY generation, owner, exact writes, and ordering. The baseline must fall back or write Enter in all three cases; the candidate must settle once or reject before cross-owner Enter, with no direct fallback or duplicate input.",
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/cli/handlers/terminal.test.ts src/main/runtime/rpc/terminal-agent-prompt-send.test.ts src/main/runtime/rpc/terminal-send.test.ts src/main/runtime/orca-runtime.test.ts src/shared/agent-prompt-injection.test.ts",
         "pnpm run build:cli && pnpm exec playwright test tests/e2e/terminal-send-agent-prompt-submit.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
@@ -9447,7 +9450,8 @@
           "file": "src/main/runtime/rpc/terminal-agent-prompt-send.test.ts",
           "assertions": [
             "a freshly proven Claude or Codex desktop target uses settled prompt delivery",
-            "a non-target agent or shell preserves the existing direct send"
+            "a non-target agent or shell preserves the existing direct send",
+            "a paired mobile floor takeover after paste rejects the delayed Enter without direct fallback"
           ]
         },
         {
@@ -9456,6 +9460,8 @@
             "Claude and Codex wait for marker-gated composer quiescence before submit",
             "every other configured TUI agent retains the legacy platform delay",
             "a speculative CLI prompt check does not poll wrapper foregrounds",
+            "a known transient wrapper resolves to Codex within the bounded foreground retry",
+            "proven current Codex foreground identity controls settlement ahead of stale launch identity",
             "the PTY write boundary retains bracketed framing and one delayed submit"
           ]
         },
@@ -9504,6 +9510,15 @@
           "result": "passed",
           "durationSeconds": 23.2,
           "summary": "After rebasing onto current main, the final narrowed runtime/CLI/RPC suite passed 1,201 tests with one skip, including fresh Claude/Codex identity, stale-agent shell fallback, and legacy timing for every other configured agent."
+        },
+        {
+          "date": "2026-08-20",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/cli/handlers/terminal.test.ts src/main/runtime/rpc/terminal-agent-prompt-send.test.ts src/main/runtime/rpc/terminal-send.test.ts src/main/runtime/orca-runtime.test.ts src/shared/agent-prompt-injection.test.ts",
+          "result": "passed",
+          "durationSeconds": 12.9,
+          "summary": "The 1,227-test candidate gate passed with one existing skip. Its three controlled oracles also failed on origin/main and with only the candidate production hunks disabled, then passed together on the candidate: node-to-Codex wrapper settlement, current foreground over stale launch identity, and paired-mobile floor takeover before delayed Enter."
         }
       ],
       "runtimeBudget": {
@@ -9520,7 +9535,7 @@
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "Only a CLI request with non-empty text plus Enter and no interrupt adds a bounded fresh foreground read and one non-retrying liveness check. Positively identified Claude and Codex reuse the O(prompt bytes) chunked prompt sender plus one PTY-local listener until post-marker quiescence or the bounded fallback. Every other agent and shell retains the existing direct-send path. Text-only, bare Enter, interrupt, mobile, renderer stream input, and query replies add no work."
+        "evidence": "Only a CLI request with non-empty text plus Enter and no interrupt adds foreground classification. Directly recognized targets keep the existing two-read bound; only known node/python wrappers reuse the existing 150 ms, 6.5 second bounded resolver, and the deterministic transition test records three provider reads for node-to-Codex settlement. Positively identified Claude and Codex reuse the O(prompt bytes) chunked prompt sender plus one PTY-local listener until post-marker quiescence or the bounded fallback. Floor checks are PTY-local map reads before existing writes; no session listing, subprocess, listener, timer, or provider fanout is added elsewhere."
       },
       "promotionCriteria": [
         "Collect live Codex and Claude CLI sends on representative slow systems.",

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -9463,7 +9463,8 @@
             "every other configured TUI agent retains the legacy platform delay",
             "a speculative CLI prompt check does not poll wrapper foregrounds",
             "a known transient wrapper resolves to Codex within the bounded foreground retry",
-            "proven current Codex foreground identity controls settlement ahead of stale launch identity",
+            "current foreground proof stays request-local inside the PTY generation queue and outranks stale launch identity",
+            "identity transition, cancellation, and concurrent classification cannot write or fan out",
             "the PTY write boundary retains bracketed framing and one delayed submit"
           ]
         },
@@ -9473,7 +9474,7 @@
             "the public source-built CLI submits after a delayed composer render without rescue",
             "the fake agent receives the marker and zero premature Enter on macOS and Windows",
             "POSIX preserves one bracketed-paste frame while Windows validates the ConPTY-observable payload",
-            "a real paired mobile floor takeover blocks delayed desktop Enter with exact PTY input"
+            "a real paired mobile floor takeover blocks delayed desktop Enter with exact framed PTY input"
           ]
         },
         {
@@ -9481,7 +9482,8 @@
           "assertions": [
             "two half-open SSH relay wrapper inspections precede a bounded retry that identifies Codex",
             "the remote fake agent receives one post-render Enter and no premature Enter",
-            "execution stays on the SSH host and an unrelated remote PTY remains writable"
+            "process inspection stays within the asserted retry budget",
+            "execution stays on the SSH host, teardown is unconditional, and an unrelated remote PTY remains writable"
           ]
         }
       ],
@@ -9528,8 +9530,8 @@
           "platform": "macos",
           "command": "pnpm exec vitest run --config config/vitest.config.ts src/cli/handlers/terminal.test.ts src/main/runtime/rpc/terminal-agent-prompt-send.test.ts src/main/runtime/rpc/terminal-send.test.ts src/main/runtime/orca-runtime.test.ts src/shared/agent-prompt-injection.test.ts",
           "result": "passed",
-          "durationSeconds": 12.9,
-          "summary": "The 1,227-test candidate gate passed with one existing skip. Its three controlled oracles also failed on origin/main and with only the candidate production hunks disabled, then passed together on the candidate: node-to-Codex wrapper settlement, current foreground over stale launch identity, and paired-mobile floor takeover before delayed Enter."
+          "durationSeconds": 10.8,
+          "summary": "The 1,262-test candidate gate passed with one existing skip. Its three ticket oracles fail on origin/main and with only the candidate production hunks disabled, then pass together on the candidate. Follow-up adversarial contracts also prove request-local identity, cancellation after one wrapper read, serialized concurrent classification, and a non-yielding floor check beside each PTY write."
         },
         {
           "date": "2026-08-20",
@@ -9537,8 +9539,8 @@
           "platform": "macos",
           "command": "pnpm run build:cli && pnpm exec playwright test tests/e2e/terminal-send-agent-prompt-submit.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
           "result": "passed",
-          "durationSeconds": 34.0,
-          "summary": "All four source-built Electron prompt journeys passed. The encrypted paired-mobile case recorded desktop then mobile authority, prompt and mobile bytes at fake-agent stdin, no carriage return, and an accepted=false desktop result after takeover."
+          "durationSeconds": 34.6,
+          "summary": "All four source-built Electron prompt journeys passed. The encrypted paired-mobile case recorded desktop then mobile authority, the exact bracketed prompt frame plus mobile bytes at fake-agent stdin, no carriage return, and an accepted=false desktop result after takeover."
         },
         {
           "date": "2026-08-20",
@@ -9546,8 +9548,8 @@
           "platform": "linux",
           "command": "pnpm run build:relay && ORCA_E2E_SSH_DOCKER=1 pnpm exec playwright test tests/e2e/ssh-docker-agent-prompt-submit.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
           "result": "passed",
-          "durationSeconds": 31.3,
-          "summary": "The candidate passed against an ephemeral Debian SSH target and real relay with two controlled half-open process reads, bounded wrapper retry, one post-render remote Enter, SSH execution-host proof, and an unrelated live remote PTY. The byte-identical oracle failed when only the settled-wrapper fix was disabled because the send settled through legacy delivery before the retry barrier."
+          "durationSeconds": 39.4,
+          "summary": "The candidate passed against an ephemeral Debian SSH target and real relay with two controlled half-open process reads, an asserted upper retry bound, one post-render remote Enter, SSH execution-host proof, unconditional target cleanup, and an unrelated live remote PTY. The byte-identical oracle fails when only settled-wrapper delivery is disabled because legacy delivery settles before the retry barrier."
         }
       ],
       "runtimeBudget": {
@@ -9560,11 +9562,11 @@
       },
       "redGreenEvidence": {
         "status": "complete",
-        "evidence": "The same controlled unit oracles are red on origin/main and with each production fix disabled, then green together on the candidate. The paired-mobile Electron oracle is green on the candidate, while its byte-identical controlled floor-takeover oracle is red without the delayed authority recheck. The Docker SSH oracle is green on the candidate and red with only settled-wrapper retry disabled, where legacy delivery settles before the retry barrier. Existing macOS and Windows fake-composer evidence remains green with prematureEnters=0 and rescueSent=false."
+        "evidence": "The same controlled ticket oracles are red on origin/main and with each production fix disabled, then green together on the candidate. With only the reviewer-driven structural changes disabled, the byte-identical identity-transition, wrapper-cancellation, and synchronous-floor tests all fail; restored candidate passes all three. The paired-mobile Electron oracle is green on the candidate and red without the delayed authority recheck. The Docker SSH oracle is green on the candidate and red with only settled-wrapper delivery disabled, where legacy delivery settles before the retry barrier. Existing macOS and Windows fake-composer evidence remains green with prematureEnters=0 and rescueSent=false."
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "Only a CLI request with non-empty text plus Enter and no interrupt adds foreground classification. Directly recognized targets keep the existing two-read bound; only known node/python wrappers reuse the existing 150 ms, 6.5 second bounded resolver, and the deterministic transition test records three provider reads for node-to-Codex settlement. Positively identified Claude and Codex reuse the O(prompt bytes) chunked prompt sender plus one PTY-local listener until post-marker quiescence or the bounded fallback. Floor checks are PTY-local map reads before existing writes; no session listing, subprocess, listener, timer, or provider fanout is added elsewhere."
+        "evidence": "Only a CLI request with non-empty text plus Enter and no interrupt adds foreground classification. The proof runs inside the existing PTY/generation submission queue, so concurrent sends cannot overlap provider scans. Direct targets use three identity/liveness reads; a node-to-Codex transition uses four, while only known node/python wrappers can enter the existing cancellable 150 ms, 6.5 second resolver. Positively identified Claude and Codex reuse the O(prompt bytes) chunked sender plus one PTY-local listener. Floor checks remain constant-time PTY-local map reads at each write yield; no session listing, global fanout, extra listener, or new timer is added."
       },
       "promotionCriteria": [
         "Collect live Codex and Claude CLI sends on representative slow systems.",

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -5586,7 +5586,7 @@
           "platform": "macos",
           "command": "SKIP_BUILD=1 pnpm exec playwright test tests/e2e/terminal-streaming-refocus-viewport.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 --repeat-each=5",
           "result": "passed",
-          "durationSeconds": 35.2,
+          "durationSeconds": 38.7,
           "summary": "Five consecutive Electron iterations passed after replacing fixed-time readiness and stale tab capture with deterministic viewport and pane-identity oracles."
         }
       ],
@@ -9425,6 +9425,7 @@
       "oracle": "Launch a bare fake Codex through the real Electron PTY and delay its composer render for 1,200 ms, beyond the legacy generic 500 ms gap. Send a 557-byte prompt with the public CLI and require the marker, zero premature Enter, no rescue Enter, and one submission. POSIX child stdin must retain one bracketed-paste frame; Windows ConPTY consumes that control frame, so runtime tests require the frame at the PTY write boundary while the Windows child requires the exact prompt. The same harness against the installed pre-fix runtime must record one premature Enter and require one bare rescue Enter. Focused units drive a node-to-Codex wrapper transition with fake time, prove fresh foreground Codex outranks stale non-target launch identity at the render gate, and transfer the paired-mobile floor between paste and suffix while recording request, PTY generation, owner, exact writes, and ordering. The baseline must fall back or write Enter in all three cases; the candidate must settle once or reject before cross-owner Enter, with no direct fallback or duplicate input.",
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/cli/handlers/terminal.test.ts src/main/runtime/rpc/terminal-agent-prompt-send.test.ts src/main/runtime/rpc/terminal-send.test.ts src/main/runtime/orca-runtime.test.ts src/shared/agent-prompt-injection.test.ts",
+        "pnpm exec vitest run --config config/vitest.config.ts src/cli/handlers/terminal.test.ts src/main/providers/ssh-pty-provider.test.ts src/main/runtime/rpc/terminal-agent-prompt-send.test.ts src/main/runtime/rpc/terminal-send.test.ts src/main/runtime/orca-runtime.test.ts src/shared/agent-prompt-injection.test.ts",
         "pnpm run build:cli && pnpm exec playwright test tests/e2e/terminal-send-agent-prompt-submit.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
         "pnpm run build:relay && ORCA_E2E_SSH_DOCKER=1 pnpm exec playwright test tests/e2e/ssh-docker-agent-prompt-submit.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
         "pnpm.cmd exec playwright test tests/e2e/terminal-send-agent-prompt-submit.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
@@ -9432,6 +9433,7 @@
       ],
       "testFiles": [
         "src/cli/handlers/terminal.test.ts",
+        "src/main/providers/ssh-pty-provider.test.ts",
         "src/main/runtime/rpc/terminal-agent-prompt-send.test.ts",
         "src/main/runtime/rpc/terminal-send.test.ts",
         "src/main/runtime/orca-runtime.test.ts",
@@ -9449,6 +9451,12 @@
           ]
         },
         {
+          "file": "src/main/providers/ssh-pty-provider.test.ts",
+          "assertions": [
+            "SSH strong confirmation uses the existing fresh relay foreground request without a wire addition"
+          ]
+        },
+        {
           "file": "src/main/runtime/rpc/terminal-agent-prompt-send.test.ts",
           "assertions": [
             "a freshly proven Claude or Codex desktop target uses settled prompt delivery",
@@ -9463,9 +9471,11 @@
             "every other configured TUI agent retains the legacy platform delay",
             "a speculative CLI prompt check does not poll wrapper foregrounds",
             "a known transient wrapper resolves to Codex within the bounded foreground retry",
+            "an unresolved wrapper exhausts exactly 45 foreground reads at 6.6 seconds of fake time and writes nothing",
             "current foreground proof stays request-local inside the PTY generation queue and outranks stale launch identity",
             "identity transition, unavailable inspection, cancellation, and concurrent classification cannot write, fall back, or fan out",
             "foreground authority is rechecked after an awaited pre-write guard and before delayed Enter",
+            "fresh provider confirmation overrides cache-backed target evidence before settled paste and suffix writes",
             "the PTY write boundary retains bracketed framing and one delayed submit"
           ]
         },
@@ -9482,7 +9492,7 @@
           "file": "tests/e2e/ssh-docker-agent-prompt-submit.spec.ts",
           "assertions": [
             "two half-open SSH relay wrapper inspections precede a bounded retry that identifies Codex",
-            "the remote fake agent receives one post-render Enter and no premature Enter",
+            "the remote fake agent receives exactly one framed prompt plus one post-render Enter and no other bytes",
             "process inspection stays within the asserted retry budget",
             "execution stays on the SSH host, teardown is unconditional, and an unrelated remote PTY remains writable"
           ]
@@ -9529,10 +9539,10 @@
           "date": "2026-08-20",
           "runner": "local",
           "platform": "macos",
-          "command": "pnpm exec vitest run --config config/vitest.config.ts src/cli/handlers/terminal.test.ts src/main/runtime/rpc/terminal-agent-prompt-send.test.ts src/main/runtime/rpc/terminal-send.test.ts src/main/runtime/orca-runtime.test.ts src/shared/agent-prompt-injection.test.ts",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/cli/handlers/terminal.test.ts src/main/providers/ssh-pty-provider.test.ts src/main/runtime/rpc/terminal-agent-prompt-send.test.ts src/main/runtime/rpc/terminal-send.test.ts src/main/runtime/orca-runtime.test.ts src/shared/agent-prompt-injection.test.ts",
           "result": "passed",
-          "durationSeconds": 11.6,
-          "summary": "The final 1,235-test candidate gate passed with one existing skip in 11.6s. Its three ticket oracles fail on origin/main and with only the candidate production hunks disabled, then pass together on the candidate. Follow-up adversarial contracts also prove request-local identity, prompt refusal after foreground loss or unavailable inspection, abort-aware foreground reads, serialized classification, and a non-yielding floor check beside each PTY write."
+          "durationSeconds": 10.8,
+          "summary": "The final 1,264-test candidate gate passed with one existing skip in 10.8s. Its three ticket oracles fail on origin/main and with only the candidate production hunks disabled, then pass together on the candidate. Follow-up adversarial contracts also prove request-local identity, fresh provider confirmation, prompt refusal after foreground loss or unavailable inspection, abort-aware foreground reads, serialized classification, bounded unresolved-wrapper reads, and a non-yielding floor check beside each PTY write."
         },
         {
           "date": "2026-08-20",
@@ -9549,8 +9559,8 @@
           "platform": "linux",
           "command": "pnpm run build:relay && ORCA_E2E_SSH_DOCKER=1 pnpm exec playwright test tests/e2e/ssh-docker-agent-prompt-submit.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
           "result": "passed",
-          "durationSeconds": 37.2,
-          "summary": "The candidate passed against an ephemeral Debian SSH target and real relay with two controlled half-open process reads, an asserted upper retry bound, one post-render remote Enter, SSH execution-host proof, bounded best-effort terminal close followed by unconditional target cleanup, and an unrelated live remote PTY. The byte-identical oracle fails when only settled-wrapper delivery is disabled because legacy delivery settles before the retry barrier."
+          "durationSeconds": 34.1,
+          "summary": "The candidate passed against an ephemeral Debian SSH target and real relay with two controlled half-open process reads, an asserted upper retry bound, the exact complete framed prompt plus one post-render remote Enter, fresh SSH foreground confirmation over the existing relay request, SSH execution-host proof, bounded best-effort terminal close followed by unconditional target cleanup, and an unrelated live remote PTY. The byte-identical oracle fails when only settled-wrapper delivery is disabled because legacy delivery settles before the retry barrier."
         }
       ],
       "runtimeBudget": {
@@ -9563,11 +9573,11 @@
       },
       "redGreenEvidence": {
         "status": "complete",
-        "evidence": "The same controlled ticket oracles are red on origin/main and with each production fix disabled, then green together on the candidate. With only the reviewer-driven structural changes disabled, the byte-identical identity-transition, wrapper-cancellation, and synchronous-floor tests all fail; restored candidate passes all three. The paired-mobile Electron oracle is green on the candidate and red without the delayed authority recheck. The Docker SSH oracle is green on the candidate and red with only settled-wrapper delivery disabled, where legacy delivery settles before the retry barrier. Existing macOS and Windows fake-composer evidence remains green with prematureEnters=0 and rescueSent=false."
+        "evidence": "The committed commands above use the same test sources for every comparison. Overlaying the candidate test-only diffs on affected baseline 4b2ed5ddd470fc69cf836d840748afae0908eeb4 and rebased base c92f394cde2612e0a913bf447e94ab1f0b0f9789 makes the three ticket oracles red; the candidate is green; reverse-applying only production commits 2fcbd468db, de4463b977, and a5116e485e with the tests retained makes them red again. The reviewer authority tests are 4/4 red at test-only commit 5418e31585 and green after a5116e485e. The fresh-confirmation oracle is red on a5116e485e: cache-backed Codex evidence writes the complete prompt and Enter while the provider's fresh confirmation reports zsh. The first Docker rerun with strong confirmation but no SSH provider implementation rejected safely with accepted=false; adding SSH confirmation over the existing fresh relay request makes the byte-identical oracle green. The paired-mobile Electron oracle is green on the candidate and red without the delayed authority recheck. The Docker SSH oracle is green on the candidate and red with only settled-wrapper delivery disabled, where legacy delivery settles before the retry barrier. Existing macOS and Windows fake-composer evidence remains green with prematureEnters=0 and rescueSent=false."
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "Only a CLI request with non-empty text plus Enter and no interrupt adds foreground classification. The proof runs inside the existing PTY/generation submission queue, so concurrent sends cannot overlap provider scans. Direct targets use three identity/liveness reads; a node-to-Codex transition uses four, while only known node/python wrappers can enter the existing cancellable 150 ms, 6.5 second resolver. Positively identified Claude and Codex reuse the O(prompt bytes) chunked sender plus one PTY-local listener. Floor checks remain constant-time PTY-local map reads at each write yield; no session listing, global fanout, extra listener, or new timer is added."
+        "evidence": "Only a CLI request with non-empty text plus Enter and no interrupt adds foreground classification. The proof runs inside the existing PTY/generation submission queue, so concurrent sends cannot overlap provider scans. Classification uses three foreground reads for a direct target and four for a node-to-Codex transition; the two existing pre-write rechecks use strong provider confirmation when available without adding calls. Only known node/python wrappers can enter the cancellable 150 ms, 6.5 second retry window; an in-flight read remains bounded by its provider's existing transport timeout. Positively identified Claude and Codex reuse the O(prompt bytes) chunked sender plus one PTY-local listener. Floor checks remain constant-time PTY-local map reads at each write yield; no session listing, global fanout, extra listener, or new timer is added."
       },
       "promotionCriteria": [
         "Collect live Codex and Claude CLI sends on representative slow systems.",

--- a/src/main/providers/ssh-pty-provider.test.ts
+++ b/src/main/providers/ssh-pty-provider.test.ts
@@ -230,6 +230,13 @@ describe('SshPtyProvider', () => {
     expectRequest(mux.request, 'pty.getForegroundProcess', { id: 'pty-1' })
   })
 
+  it('confirms foreground process with a fresh relay request', async () => {
+    mux.request.mockResolvedValue('codex')
+
+    await expect(provider.confirmForegroundProcess(scopedPty1)).resolves.toBe('codex')
+    expectRequest(mux.request, 'pty.getForegroundProcess', { id: 'pty-1' })
+  })
+
   it('preserves unavailable process inspection', async () => {
     const inspection = {
       foregroundProcess: null,

--- a/src/main/providers/ssh-pty-provider.ts
+++ b/src/main/providers/ssh-pty-provider.ts
@@ -260,6 +260,10 @@ export class SshPtyProvider implements IPtyProvider {
     return result as string | null
   }
 
+  async confirmForegroundProcess(id: string): Promise<string | null> {
+    return await this.getForegroundProcess(id)
+  }
+
   async inspectProcess(id: string): Promise<PtyProcessInspection> {
     return (await this.mux.request('pty.inspectProcess', {
       id: this.toRelayPtyId(id)

--- a/src/main/runtime/agent-prompt-submission-runtime.test.ts
+++ b/src/main/runtime/agent-prompt-submission-runtime.test.ts
@@ -300,6 +300,32 @@ describe('agent prompt submission runtime', () => {
     expect(writes).not.toContain('\r')
   })
 
+  it('keeps the floor check and PTY write in one synchronous turn', async () => {
+    vi.useFakeTimers()
+    let floorOwner: 'desktop' | 'mobile' = 'desktop'
+    const writeOwners: string[] = []
+    const { runtime, handle, writes } = await createPromptRuntime((_runtime, data) => {
+      writeOwners.push(`${floorOwner}:${data === '\r' ? 'enter' : 'paste'}`)
+    })
+    const submission = runtime.sendTerminalAgentPrompt(handle, 'review this', {
+      assertWriteAuthority: () => {
+        if (floorOwner === 'mobile') {
+          throw new Error('terminal_guard_not_writable')
+        }
+        queueMicrotask(() => {
+          floorOwner = 'mobile'
+        })
+      }
+    })
+    const rejected = expect(submission).rejects.toThrow('terminal_guard_not_writable')
+
+    await vi.runAllTimersAsync()
+
+    await rejected
+    expect(writeOwners).toEqual(['desktop:paste'])
+    expect(writes).not.toContain('\r')
+  })
+
   it('stops a chunked paste after transient output-only permission', async () => {
     const { runtime, handle, writes } = await createPromptRuntime(() => undefined)
     runtime.onPtyData('pty-prompt', 'initial output\n', Date.now())

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -17033,8 +17033,9 @@ describe('OrcaRuntimeService', () => {
       })
       const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
 
-      await expect(runtime.isTerminalRunningSettledPromptAgent(handle)).resolves.toBe(true)
-      const sendPromise = runtime.sendTerminalAgentPrompt(handle, 'review this change')
+      const sendPromise = runtime.sendTerminalAgentPrompt(handle, 'review this change', {
+        requireSettledForeground: true
+      })
       await vi.advanceTimersByTimeAsync(1_199)
       expect(writes).not.toContain('\r')
       await vi.advanceTimersByTimeAsync(1_500)
@@ -17068,8 +17069,9 @@ describe('OrcaRuntimeService', () => {
         launchAgent: 'aider'
       })
 
-      await expect(runtime.isTerminalRunningSettledPromptAgent(handle)).resolves.toBe(true)
-      const sendPromise = runtime.sendTerminalAgentPrompt(handle, 'review this change')
+      const sendPromise = runtime.sendTerminalAgentPrompt(handle, 'review this change', {
+        requireSettledForeground: true
+      })
       await vi.advanceTimersByTimeAsync(AGENT_PROMPT_SUBMIT_DELAY_MS)
       expect(writes).not.toContain('\r')
 
@@ -24205,7 +24207,112 @@ describe('OrcaRuntimeService', () => {
     await vi.advanceTimersByTimeAsync(150)
 
     await expect(settled).resolves.toBe(true)
-    expect(getForegroundProcess).toHaveBeenCalledTimes(3)
+    expect(getForegroundProcess).toHaveBeenCalledTimes(4)
+  })
+
+  it('refuses settled delivery when foreground identity changes before the write', async () => {
+    const writes: string[] = []
+    const getForegroundProcess = vi
+      .fn()
+      .mockResolvedValueOnce('codex')
+      .mockResolvedValueOnce('codex')
+      .mockResolvedValue('zsh')
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+      write: (_ptyId, data) => {
+        writes.push(data)
+        return true
+      },
+      kill: () => true,
+      getForegroundProcess
+    })
+    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+      command: 'bash',
+      title: 'bash'
+    })
+
+    await expect(
+      runtime.sendTerminalAgentPrompt(handle, 'review this change', {
+        requireSettledForeground: true
+      })
+    ).resolves.toMatchObject({ accepted: false, bytesWritten: 0 })
+    expect(writes).toEqual([])
+  })
+
+  it('cancels bounded wrapper recognition without writing or retrying', async () => {
+    vi.useFakeTimers()
+    const controller = new AbortController()
+    const writes: string[] = []
+    const getForegroundProcess = vi.fn().mockResolvedValue('node')
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+      write: (_ptyId, data) => {
+        writes.push(data)
+        return true
+      },
+      kill: () => true,
+      getForegroundProcess
+    })
+    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+      command: 'bash',
+      title: 'bash'
+    })
+    const send = runtime.sendTerminalAgentPrompt(handle, 'review this change', {
+      requireSettledForeground: true,
+      signal: controller.signal
+    })
+    const rejected = expect(send).rejects.toThrow('request_aborted')
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(getForegroundProcess).toHaveBeenCalledTimes(1)
+    controller.abort()
+    await vi.runAllTimersAsync()
+
+    await rejected
+    expect(getForegroundProcess).toHaveBeenCalledTimes(1)
+    expect(writes).toEqual([])
+  })
+
+  it('serializes concurrent settled foreground classification per PTY', async () => {
+    let releaseFirst!: () => void
+    const firstInspection = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+    const getForegroundProcess = vi
+      .fn()
+      .mockImplementationOnce(async () => {
+        await firstInspection
+        return 'gemini'
+      })
+      .mockResolvedValue('gemini')
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess
+    })
+    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+      command: 'bash',
+      title: 'bash'
+    })
+
+    const first = runtime.sendTerminalAgentPrompt(handle, 'first', {
+      requireSettledForeground: true
+    })
+    const second = runtime.sendTerminalAgentPrompt(handle, 'second', {
+      requireSettledForeground: true
+    })
+    await vi.waitFor(() => expect(getForegroundProcess).toHaveBeenCalledTimes(1))
+
+    releaseFirst()
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      { handle, accepted: false, bytesWritten: 0 },
+      { handle, accepted: false, bytesWritten: 0 }
+    ])
+    expect(getForegroundProcess).toHaveBeenCalledTimes(2)
   })
 
   it.each(['claude', 'codex'] as const)(

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -24269,6 +24269,42 @@ describe('OrcaRuntimeService', () => {
     expect(writes).toEqual([])
   })
 
+  it('uses fresh provider confirmation before settled writes', async () => {
+    vi.useFakeTimers()
+    const writes: string[] = []
+    const getForegroundProcess = vi.fn().mockResolvedValue('codex')
+    const confirmForegroundProcess = vi.fn().mockResolvedValue('zsh')
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+      write: (_ptyId, data) => {
+        writes.push(data)
+        if (data.includes(AGENT_PROMPT_BRACKETED_PASTE_END)) {
+          setTimeout(() => runtime.onPtyData('pty-bg', '\x1b[?25h', Date.now()), 0)
+        }
+        acknowledgeAgentPromptSubmit(runtime, 'pty-bg', data)
+        return true
+      },
+      kill: () => true,
+      getForegroundProcess,
+      confirmForegroundProcess
+    })
+    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+      command: 'bash',
+      title: 'bash'
+    })
+    const send = runtime.sendTerminalAgentPrompt(handle, 'review this change', {
+      requireSettledForeground: true
+    })
+    const rejected = expect(send).rejects.toThrow('terminal_guard_not_writable')
+
+    await vi.runAllTimersAsync()
+
+    await rejected
+    expect(confirmForegroundProcess).toHaveBeenCalled()
+    expect(writes).toEqual([])
+  })
+
   it('revalidates settled foreground after the pre-write guard yields', async () => {
     const writes: string[] = []
     const getForegroundProcess = vi
@@ -24369,6 +24405,36 @@ describe('OrcaRuntimeService', () => {
 
     await rejected
     expect(getForegroundProcess).toHaveBeenCalledTimes(1)
+    expect(writes).toEqual([])
+  })
+
+  it('refuses an unresolved wrapper at the retry ceiling without writing', async () => {
+    vi.useFakeTimers()
+    const writes: string[] = []
+    const getForegroundProcess = vi.fn().mockResolvedValue('node')
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+      write: (_ptyId, data) => {
+        writes.push(data)
+        return true
+      },
+      kill: () => true,
+      getForegroundProcess
+    })
+    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+      command: 'bash',
+      title: 'bash'
+    })
+    const send = runtime.sendTerminalAgentPrompt(handle, 'review this change', {
+      requireSettledForeground: true
+    })
+    const rejected = expect(send).rejects.toThrow('terminal_guard_not_writable')
+
+    await vi.advanceTimersByTimeAsync(6_600)
+
+    await rejected
+    expect(getForegroundProcess).toHaveBeenCalledTimes(45)
     expect(writes).toEqual([])
   })
 

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -17049,6 +17049,40 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
+  it('uses proven current Codex foreground identity ahead of stale launch identity', async () => {
+    vi.useFakeTimers()
+    try {
+      const writes: string[] = []
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+        write: (_ptyId, data) => {
+          writes.push(data)
+          acknowledgeAgentPromptSubmit(runtime, 'pty-bg', data)
+          return true
+        },
+        kill: () => true,
+        getForegroundProcess: async () => 'codex'
+      })
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+        launchAgent: 'aider'
+      })
+
+      await expect(runtime.isTerminalRunningSettledPromptAgent(handle)).resolves.toBe(true)
+      const sendPromise = runtime.sendTerminalAgentPrompt(handle, 'review this change')
+      await vi.advanceTimersByTimeAsync(AGENT_PROMPT_SUBMIT_DELAY_MS)
+      expect(writes).not.toContain('\r')
+
+      runtime.onPtyData('pty-bg', '\x1b[?25hcomposer rendered', Date.now())
+      await vi.advanceTimersByTimeAsync(1_500)
+      await sendPromise
+
+      expect(writes.filter((data) => data === '\r')).toHaveLength(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('submits a silent Claude composer once after the bounded render fallback', async () => {
     vi.useFakeTimers()
     try {
@@ -24147,6 +24181,31 @@ describe('OrcaRuntimeService', () => {
       runtime.isTerminalRunningAgent(handle, { retryForegroundWrappers: false })
     ).resolves.toBe(false)
     expect(getForegroundProcess).toHaveBeenCalledTimes(1)
+  })
+
+  it('settles a CLI prompt after a transient foreground wrapper resolves to Codex', async () => {
+    vi.useFakeTimers()
+    const getForegroundProcess = vi.fn().mockResolvedValueOnce('node').mockResolvedValue('codex')
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess
+    })
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, { tabs: [], leaves: [] })
+    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+      command: 'bash',
+      title: 'bash'
+    })
+    syncSinglePty(runtime, 'pty-bg', { paneTitle: 'bash' })
+
+    const settled = runtime.isTerminalRunningSettledPromptAgent(handle)
+    await vi.advanceTimersByTimeAsync(150)
+
+    await expect(settled).resolves.toBe(true)
+    expect(getForegroundProcess).toHaveBeenCalledTimes(3)
   })
 
   it.each(['claude', 'codex'] as const)(

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -24236,8 +24236,105 @@ describe('OrcaRuntimeService', () => {
       runtime.sendTerminalAgentPrompt(handle, 'review this change', {
         requireSettledForeground: true
       })
-    ).resolves.toMatchObject({ accepted: false, bytesWritten: 0 })
+    ).rejects.toThrow('terminal_guard_not_writable')
     expect(writes).toEqual([])
+  })
+
+  it('refuses settled delivery when foreground inspection becomes unavailable', async () => {
+    const writes: string[] = []
+    const getForegroundProcess = vi
+      .fn()
+      .mockResolvedValueOnce('codex')
+      .mockRejectedValueOnce(new Error('foreground unavailable'))
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+      write: (_ptyId, data) => {
+        writes.push(data)
+        return true
+      },
+      kill: () => true,
+      getForegroundProcess
+    })
+    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+      command: 'bash',
+      title: 'bash'
+    })
+
+    await expect(
+      runtime.sendTerminalAgentPrompt(handle, 'review this change', {
+        requireSettledForeground: true
+      })
+    ).rejects.toThrow('terminal_guard_not_writable')
+    expect(writes).toEqual([])
+  })
+
+  it('revalidates settled foreground after the pre-write guard yields', async () => {
+    const writes: string[] = []
+    const getForegroundProcess = vi
+      .fn()
+      .mockResolvedValueOnce('codex')
+      .mockResolvedValueOnce('codex')
+      .mockResolvedValueOnce('codex')
+      .mockResolvedValue('zsh')
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+      write: (_ptyId, data) => {
+        writes.push(data)
+        return true
+      },
+      kill: () => true,
+      getForegroundProcess
+    })
+    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+      command: 'bash',
+      title: 'bash'
+    })
+
+    await expect(
+      runtime.sendTerminalAgentPrompt(handle, 'review this change', {
+        beforeWrite: async () => undefined,
+        requireSettledForeground: true
+      })
+    ).rejects.toThrow('terminal_guard_not_writable')
+    expect(writes).toEqual([])
+  })
+
+  it('revalidates settled foreground before delayed Enter', async () => {
+    vi.useFakeTimers()
+    const writes: string[] = []
+    const getForegroundProcess = vi
+      .fn()
+      .mockResolvedValueOnce('codex')
+      .mockResolvedValueOnce('codex')
+      .mockResolvedValueOnce('codex')
+      .mockResolvedValueOnce('codex')
+      .mockResolvedValue('zsh')
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+      write: (_ptyId, data) => {
+        writes.push(data)
+        return true
+      },
+      kill: () => true,
+      getForegroundProcess
+    })
+    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+      command: 'bash',
+      title: 'bash'
+    })
+
+    const send = runtime.sendTerminalAgentPrompt(handle, 'review this change', {
+      requireSettledForeground: true
+    })
+    const rejected = expect(send).rejects.toThrow('terminal_guard_not_writable')
+    await vi.runAllTimersAsync()
+
+    await rejected
+    expect(writes.some((data) => data.includes('review this change'))).toBe(true)
+    expect(writes.filter((data) => data === '\r')).toHaveLength(0)
   })
 
   it('cancels bounded wrapper recognition without writing or retrying', async () => {
@@ -24272,6 +24369,43 @@ describe('OrcaRuntimeService', () => {
 
     await rejected
     expect(getForegroundProcess).toHaveBeenCalledTimes(1)
+    expect(writes).toEqual([])
+  })
+
+  it('cancels an in-flight settled foreground inspection without writing', async () => {
+    const controller = new AbortController()
+    let inspectionStarted!: () => void
+    const started = new Promise<void>((resolve) => {
+      inspectionStarted = resolve
+    })
+    const runtime = new OrcaRuntimeService(store)
+    const writes: string[] = []
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+      write: (_ptyId, data) => {
+        writes.push(data)
+        return true
+      },
+      kill: () => true,
+      getForegroundProcess: async () => {
+        inspectionStarted()
+        return await new Promise<string | null>(() => undefined)
+      }
+    })
+    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+      command: 'bash',
+      title: 'bash'
+    })
+    const send = runtime.sendTerminalAgentPrompt(handle, 'review this change', {
+      requireSettledForeground: true,
+      signal: controller.signal
+    })
+    const rejected = expect(send).rejects.toThrow('request_aborted')
+
+    await started
+    controller.abort()
+
+    await rejected
     expect(writes).toEqual([])
   })
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -18566,6 +18566,7 @@ export class OrcaRuntimeService {
     },
     options: {
       beforeWrite?: (ptyId: string) => void | Promise<void>
+      assertWriteAuthority?: (ptyId: string) => void
       reserveWrite?: (ptyId: string) => void
       afterWrite?: (ptyId: string) => void | Promise<void>
       suffixFailureError?: string
@@ -18620,8 +18621,10 @@ export class OrcaRuntimeService {
     prompt: string,
     options: {
       beforeWrite?: (ptyId: string) => void | Promise<void>
+      assertWriteAuthority?: (ptyId: string) => void
       suffixFailureError?: string
       signal?: AbortSignal
+      requireSettledForeground?: boolean
     } = {}
   ): Promise<RuntimeTerminalSend> {
     const payload = buildAgentPromptPasteBytes(prompt)
@@ -18638,15 +18641,22 @@ export class OrcaRuntimeService {
         async () => {
           this.assertLiveTerminalHandleTargetsPty(handle, pty.pty.ptyId)
           this.assertAgentPromptGeneration(pty.pty.ptyId, generation)
-          return await this.writeTerminalAgentPrompt(
-            handle,
-            pty.pty.ptyId,
-            generation,
-            payload,
-            options
-          )
+          // Why: classify inside the PTY queue so concurrent sends cannot fan out or reuse a stale foreground proof.
+          const settlementAgent = options.requireSettledForeground
+            ? await this.recognizeSettledPromptAgent(handle, pty.pty.ptyId, options.signal)
+            : undefined
+          if (options.requireSettledForeground && !settlementAgent) {
+            return null
+          }
+          return await this.writeTerminalAgentPrompt(handle, pty.pty.ptyId, generation, payload, {
+            ...options,
+            settlementAgent: settlementAgent ?? undefined
+          })
         }
       )
+      if (submits === null) {
+        return { handle, accepted: false, bytesWritten: 0 }
+      }
       const bytesWritten = Buffer.byteLength(payload, 'utf8') + submits
       return { handle, accepted: true, bytesWritten }
     }
@@ -18665,8 +18675,20 @@ export class OrcaRuntimeService {
     const submits = await this.serializeAgentPromptSubmission(leaf.ptyId, generation, async () => {
       this.assertLiveTerminalHandleTargetsPty(handle, leaf.ptyId!)
       this.assertAgentPromptGeneration(leaf.ptyId!, generation)
-      return await this.writeTerminalAgentPrompt(handle, leaf.ptyId!, generation, payload, options)
+      const settlementAgent = options.requireSettledForeground
+        ? await this.recognizeSettledPromptAgent(handle, leaf.ptyId!, options.signal)
+        : undefined
+      if (options.requireSettledForeground && !settlementAgent) {
+        return null
+      }
+      return await this.writeTerminalAgentPrompt(handle, leaf.ptyId!, generation, payload, {
+        ...options,
+        settlementAgent: settlementAgent ?? undefined
+      })
     })
+    if (submits === null) {
+      return { handle, accepted: false, bytesWritten: 0 }
+    }
     const bytesWritten = Buffer.byteLength(payload, 'utf8') + submits
     return { handle, accepted: true, bytesWritten }
   }
@@ -19262,6 +19284,7 @@ export class OrcaRuntimeService {
     payload: string,
     options: {
       beforeWrite?: (ptyId: string) => void | Promise<void>
+      assertWriteAuthority?: (ptyId: string) => void
       reserveWrite?: (ptyId: string) => void
       afterWrite?: (ptyId: string) => void | Promise<void>
       suffixFailureError?: string
@@ -19281,6 +19304,7 @@ export class OrcaRuntimeService {
       }
       try {
         await options.beforeWrite?.(ptyId)
+        options.assertWriteAuthority?.(ptyId)
         options.reserveWrite?.(ptyId)
       } catch (error) {
         if (options.suffixFailureError) {
@@ -19300,6 +19324,7 @@ export class OrcaRuntimeService {
     }
 
     await options.beforeWrite?.(ptyId)
+    options.assertWriteAuthority?.(ptyId)
     options.reserveWrite?.(ptyId)
     const wrote = this.ptyController?.write(ptyId, payload) ?? false
     if (!wrote) {
@@ -19313,6 +19338,7 @@ export class OrcaRuntimeService {
     text: string,
     options: {
       beforeWrite?: (ptyId: string) => void | Promise<void>
+      assertWriteAuthority?: (ptyId: string) => void
       reserveWrite?: (ptyId: string) => void
       afterWrite?: (ptyId: string) => void | Promise<void>
     } = {}
@@ -19321,6 +19347,7 @@ export class OrcaRuntimeService {
     let chunk = chunks.next()
     while (!chunk.done) {
       await options.beforeWrite?.(ptyId)
+      options.assertWriteAuthority?.(ptyId)
       options.reserveWrite?.(ptyId)
       const wrote = this.ptyController?.write(ptyId, chunk.value) ?? false
       if (!wrote) {
@@ -19341,15 +19368,17 @@ export class OrcaRuntimeService {
     pastePayload: string,
     options: {
       beforeWrite?: (ptyId: string) => void | Promise<void>
+      assertWriteAuthority?: (ptyId: string) => void
       suffixFailureError?: string
       signal?: AbortSignal
+      settlementAgent?: TuiAgent
     } = {}
   ): Promise<number> {
     assertAgentPromptRequestActive(options.signal)
     this.assertAgentPromptGeneration(ptyId, generation)
     const permissionBaseline = this.getAgentPromptActivity(handle, ptyId)
     this.assertAgentPromptPermissionSafe(permissionBaseline, permissionBaseline)
-    const renderGate = this.createAgentPromptRenderGate(ptyId)
+    const renderGate = this.createAgentPromptRenderGate(ptyId, options.settlementAgent)
     let wrotePasteBytes = false
     let completedPaste = false
     try {
@@ -19366,6 +19395,8 @@ export class OrcaRuntimeService {
           permissionBaseline,
           this.getAgentPromptActivity(handle, ptyId)
         )
+        // Why: awaited guards can yield; ownership must be checked in the same turn as the PTY write.
+        options.assertWriteAuthority?.(ptyId)
         if (nextChunk.done) {
           renderGate?.arm()
         }
@@ -19415,6 +19446,7 @@ export class OrcaRuntimeService {
     this.assertAgentPromptGeneration(ptyId, generation)
     const baseline = this.getAgentPromptActivity(handle, ptyId)
     this.assertAgentPromptPermissionSafe(permissionBaseline, baseline)
+    options.assertWriteAuthority?.(ptyId)
     const suffixWrote = this.ptyController?.write(ptyId, AGENT_PROMPT_SUBMIT) ?? false
     if (!suffixWrote) {
       throw new Error(options.suffixFailureError ?? 'terminal_not_writable')
@@ -19500,13 +19532,16 @@ export class OrcaRuntimeService {
     }
   }
 
-  private createAgentPromptRenderGate(ptyId: string): {
+  private createAgentPromptRenderGate(
+    ptyId: string,
+    provenAgent?: TuiAgent
+  ): {
     arm: () => void
     wait: () => Promise<void>
     dispose: () => void
   } | null {
     const pty = this.ptysById.get(ptyId)
-    const agent = pty?.foregroundAgent ?? pty?.launchAgent
+    const agent = provenAgent ?? pty?.launchAgent ?? pty?.foregroundAgent
     if (!isTerminalSendSettlementAgent(agent)) {
       return null
     }
@@ -34634,29 +34669,48 @@ export class OrcaRuntimeService {
     }
   }
 
-  async isTerminalRunningSettledPromptAgent(handle: string): Promise<boolean> {
+  async isTerminalRunningSettledPromptAgent(
+    handle: string,
+    options: { signal?: AbortSignal } = {}
+  ): Promise<boolean> {
     try {
       const livePty = this.getLivePtyForHandle(handle)
       const leaf = livePty ? null : this.getLiveLeafForHandle(handle).leaf
       const ptyId = livePty?.pty.ptyId ?? leaf?.ptyId ?? null
-      const trackedPty = livePty?.pty ?? (ptyId ? this.ptysById.get(ptyId) : null)
-      if (!ptyId || !trackedPty || !this.ptyController) {
+      if (!ptyId) {
         return false
       }
-      const foregroundProcess = await this.ptyController.getForegroundProcess(ptyId)
-      const recognized = await this.recognizeForegroundAgentProcess(ptyId, foregroundProcess)
-      const recognizedAgent = recognized?.agent
-      if (!isTerminalSendSettlementAgent(recognizedAgent)) {
-        return false
-      }
-      if (!(await this.isTerminalRunningAgent(handle, { retryForegroundWrappers: false }))) {
-        return false
-      }
-      trackedPty.foregroundAgent = recognizedAgent
-      return true
+      return (await this.recognizeSettledPromptAgent(handle, ptyId, options.signal)) !== null
     } catch {
+      assertAgentPromptRequestActive(options.signal)
       return false
     }
+  }
+
+  private async recognizeSettledPromptAgent(
+    handle: string,
+    ptyId: string,
+    signal?: AbortSignal
+  ): Promise<TuiAgent | null> {
+    if (!this.ptyController) {
+      return null
+    }
+    assertAgentPromptRequestActive(signal)
+    const foregroundProcess = await this.ptyController.getForegroundProcess(ptyId)
+    const recognized = await this.recognizeForegroundAgentProcess(ptyId, foregroundProcess, {
+      signal
+    })
+    if (!isTerminalSendSettlementAgent(recognized?.agent)) {
+      return null
+    }
+    assertAgentPromptRequestActive(signal)
+    if (!(await this.isTerminalRunningAgent(handle, { retryForegroundWrappers: false }))) {
+      return null
+    }
+    assertAgentPromptRequestActive(signal)
+    const confirmed = recognizeAgentProcess(await this.ptyController.getForegroundProcess(ptyId))
+    assertAgentPromptRequestActive(signal)
+    return confirmed?.agent === recognized.agent ? recognized.agent : null
   }
 
   private async isPtyRunningAgent(
@@ -34737,8 +34791,9 @@ export class OrcaRuntimeService {
   private async recognizeForegroundAgentProcess(
     ptyId: string,
     foregroundProcess: string | null,
-    options: { suppressClaude?: boolean; retryWrappers?: boolean } = {}
+    options: { suppressClaude?: boolean; retryWrappers?: boolean; signal?: AbortSignal } = {}
   ): Promise<RecognizedAgentProcess | null> {
+    assertAgentPromptRequestActive(options.signal)
     const initialRecognition = recognizeAgentProcess(foregroundProcess)
     if (initialRecognition !== null) {
       return options.suppressClaude === true &&
@@ -34755,10 +34810,10 @@ export class OrcaRuntimeService {
     }
     const startedAt = Date.now()
     while (Date.now() - startedAt < FOREGROUND_AGENT_WRAPPER_RETRY_TIMEOUT_MS) {
-      await new Promise((resolve) =>
-        setTimeout(resolve, FOREGROUND_AGENT_WRAPPER_RETRY_INTERVAL_MS)
-      )
+      await waitForAgentPromptDelay(FOREGROUND_AGENT_WRAPPER_RETRY_INTERVAL_MS, options.signal)
+      assertAgentPromptRequestActive(options.signal)
       const refreshedProcess = await this.ptyController.getForegroundProcess(ptyId)
+      assertAgentPromptRequestActive(options.signal)
       const refreshedRecognition = recognizeAgentProcess(refreshedProcess)
       if (refreshedRecognition !== null) {
         return options.suppressClaude === true &&

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -550,7 +550,8 @@ import { repoIsRemote } from '../../shared/agent-launch-remote'
 import {
   isAgentForegroundWrapperProcess,
   isExpectedAgentProcess,
-  recognizeAgentProcess
+  recognizeAgentProcess,
+  type RecognizedAgentProcess
 } from '../../shared/agent-process-recognition'
 import {
   haveSameDisabledTuiAgents,
@@ -19505,7 +19506,7 @@ export class OrcaRuntimeService {
     dispose: () => void
   } | null {
     const pty = this.ptysById.get(ptyId)
-    const agent = pty?.launchAgent ?? pty?.foregroundAgent
+    const agent = pty?.foregroundAgent ?? pty?.launchAgent
     if (!isTerminalSendSettlementAgent(agent)) {
       return null
     }
@@ -34642,7 +34643,8 @@ export class OrcaRuntimeService {
       if (!ptyId || !trackedPty || !this.ptyController) {
         return false
       }
-      const recognized = recognizeAgentProcess(await this.ptyController.getForegroundProcess(ptyId))
+      const foregroundProcess = await this.ptyController.getForegroundProcess(ptyId)
+      const recognized = await this.recognizeForegroundAgentProcess(ptyId, foregroundProcess)
       const recognizedAgent = recognized?.agent
       if (!isTerminalSendSettlementAgent(recognizedAgent)) {
         return false
@@ -34729,19 +34731,27 @@ export class OrcaRuntimeService {
     foregroundProcess: string,
     options: { suppressClaude?: boolean; retryWrappers?: boolean } = {}
   ): Promise<boolean> {
+    return (await this.recognizeForegroundAgentProcess(ptyId, foregroundProcess, options)) !== null
+  }
+
+  private async recognizeForegroundAgentProcess(
+    ptyId: string,
+    foregroundProcess: string | null,
+    options: { suppressClaude?: boolean; retryWrappers?: boolean } = {}
+  ): Promise<RecognizedAgentProcess | null> {
     const initialRecognition = recognizeAgentProcess(foregroundProcess)
     if (initialRecognition !== null) {
-      return !(
-        options.suppressClaude === true &&
+      return options.suppressClaude === true &&
         isExpectedAgentProcess(initialRecognition.processName, 'claude')
-      )
+        ? null
+        : initialRecognition
     }
     if (
       options.retryWrappers === false ||
       !this.isAgentWrapperForegroundProcess(foregroundProcess) ||
       !this.ptyController
     ) {
-      return false
+      return null
     }
     const startedAt = Date.now()
     while (Date.now() - startedAt < FOREGROUND_AGENT_WRAPPER_RETRY_TIMEOUT_MS) {
@@ -34751,19 +34761,19 @@ export class OrcaRuntimeService {
       const refreshedProcess = await this.ptyController.getForegroundProcess(ptyId)
       const refreshedRecognition = recognizeAgentProcess(refreshedProcess)
       if (refreshedRecognition !== null) {
-        return !(
-          options.suppressClaude === true &&
+        return options.suppressClaude === true &&
           isExpectedAgentProcess(refreshedRecognition.processName, 'claude')
-        )
+          ? null
+          : refreshedRecognition
       }
       if (!refreshedProcess || !this.isAgentWrapperForegroundProcess(refreshedProcess)) {
-        return false
+        return null
       }
     }
-    return false
+    return null
   }
 
-  private isAgentWrapperForegroundProcess(processName: string): boolean {
+  private isAgentWrapperForegroundProcess(processName: string | null): boolean {
     // Why: daemon/SSH PTYs can report the interpreter before the async cmdline cache resolves; retry only known wrappers.
     return isAgentForegroundWrapperProcess(processName)
   }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -19391,6 +19391,11 @@ export class OrcaRuntimeService {
         await options.beforeWrite?.(ptyId)
         assertAgentPromptRequestActive(options.signal)
         this.assertAgentPromptGeneration(ptyId, generation)
+        if (!wrotePasteBytes && options.settlementAgent) {
+          await this.assertSettledPromptForeground(ptyId, options.settlementAgent, options.signal)
+          assertAgentPromptRequestActive(options.signal)
+          this.assertAgentPromptGeneration(ptyId, generation)
+        }
         this.assertAgentPromptPermissionSafe(
           permissionBaseline,
           this.getAgentPromptActivity(handle, ptyId)
@@ -19444,6 +19449,11 @@ export class OrcaRuntimeService {
     }
     assertAgentPromptRequestActive(options.signal)
     this.assertAgentPromptGeneration(ptyId, generation)
+    if (options.settlementAgent) {
+      await this.assertSettledPromptForeground(ptyId, options.settlementAgent, options.signal)
+      assertAgentPromptRequestActive(options.signal)
+      this.assertAgentPromptGeneration(ptyId, generation)
+    }
     const baseline = this.getAgentPromptActivity(handle, ptyId)
     this.assertAgentPromptPermissionSafe(permissionBaseline, baseline)
     options.assertWriteAuthority?.(ptyId)
@@ -19529,6 +19539,24 @@ export class OrcaRuntimeService {
   private assertAgentPromptGeneration(ptyId: string, expected: number): void {
     if (this.getPtyLifecycleGeneration(ptyId) !== expected) {
       throw new Error('terminal_handle_stale')
+    }
+  }
+
+  private async assertSettledPromptForeground(
+    ptyId: string,
+    expectedAgent: TuiAgent,
+    signal?: AbortSignal
+  ): Promise<void> {
+    if (!this.ptyController) {
+      throw new Error('terminal_guard_not_writable')
+    }
+    const foregroundProcess = await waitForAgentPromptPromise(
+      this.ptyController.getForegroundProcess(ptyId),
+      signal
+    )
+    assertAgentPromptRequestActive(signal)
+    if (recognizeAgentProcess(foregroundProcess)?.agent !== expectedAgent) {
+      throw new Error('terminal_guard_not_writable')
     }
   }
 
@@ -34604,7 +34632,7 @@ export class OrcaRuntimeService {
   // Why: title is the tightest agent-presence signal, but a Claude management title is negative evidence for task activity.
   async isTerminalRunningAgent(
     handle: string,
-    options: { retryForegroundWrappers?: boolean } = {}
+    options: { retryForegroundWrappers?: boolean; signal?: AbortSignal } = {}
   ): Promise<boolean> {
     try {
       const pty = this.getLivePtyForHandle(handle)
@@ -34645,7 +34673,10 @@ export class OrcaRuntimeService {
       if (!leaf.ptyId || !this.ptyController) {
         return false
       }
-      const fg = await this.ptyController.getForegroundProcess(leaf.ptyId)
+      const fg = await waitForAgentPromptPromise(
+        this.ptyController.getForegroundProcess(leaf.ptyId),
+        options.signal
+      )
       // Why: a bare `Cursor Agent` title is identity, not liveness — it reads the same
       // whether cursor-agent is parked or long exited with the shell back. A null
       // foreground is untracked, not alive, so no-evidence must stay a refusal. A live
@@ -34662,9 +34693,11 @@ export class OrcaRuntimeService {
       // Why: review-note delivery auto-submits with Enter, so only known agent processes are safe (not arbitrary focused TUIs).
       return await this.isRecognizedForegroundAgentProcess(leaf.ptyId, fg, {
         suppressClaude: shouldSuppressClaudeForeground,
-        retryWrappers: options.retryForegroundWrappers !== false
+        retryWrappers: options.retryForegroundWrappers !== false,
+        signal: options.signal
       })
     } catch {
+      assertAgentPromptRequestActive(options.signal)
       return false
     }
   }
@@ -34696,27 +34729,43 @@ export class OrcaRuntimeService {
       return null
     }
     assertAgentPromptRequestActive(signal)
-    const foregroundProcess = await this.ptyController.getForegroundProcess(ptyId)
+    const foregroundProcess = await waitForAgentPromptPromise(
+      this.ptyController.getForegroundProcess(ptyId),
+      signal
+    )
     const recognized = await this.recognizeForegroundAgentProcess(ptyId, foregroundProcess, {
       signal
     })
     if (!isTerminalSendSettlementAgent(recognized?.agent)) {
+      if (!foregroundProcess || this.isAgentWrapperForegroundProcess(foregroundProcess)) {
+        throw new Error('terminal_guard_not_writable')
+      }
       return null
     }
     assertAgentPromptRequestActive(signal)
-    if (!(await this.isTerminalRunningAgent(handle, { retryForegroundWrappers: false }))) {
-      return null
+    if (
+      !(await this.isTerminalRunningAgent(handle, {
+        retryForegroundWrappers: false,
+        signal
+      }))
+    ) {
+      throw new Error('terminal_guard_not_writable')
     }
     assertAgentPromptRequestActive(signal)
-    const confirmed = recognizeAgentProcess(await this.ptyController.getForegroundProcess(ptyId))
+    const confirmed = recognizeAgentProcess(
+      await waitForAgentPromptPromise(this.ptyController.getForegroundProcess(ptyId), signal)
+    )
     assertAgentPromptRequestActive(signal)
-    return confirmed?.agent === recognized.agent ? recognized.agent : null
+    if (confirmed?.agent !== recognized.agent) {
+      throw new Error('terminal_guard_not_writable')
+    }
+    return recognized.agent
   }
 
   private async isPtyRunningAgent(
     pty: RuntimePtyWorktreeRecord,
     leaf: RuntimeLeafRecord | null = null,
-    options: { retryForegroundWrappers?: boolean } = {}
+    options: { retryForegroundWrappers?: boolean; signal?: AbortSignal } = {}
   ): Promise<boolean> {
     const leafTitle = leaf
       ? getLatestAgentCandidateTitle(
@@ -34760,7 +34809,10 @@ export class OrcaRuntimeService {
     if (!this.ptyController) {
       return false
     }
-    const fg = await this.ptyController.getForegroundProcess(pty.ptyId)
+    const fg = await waitForAgentPromptPromise(
+      this.ptyController.getForegroundProcess(pty.ptyId),
+      options.signal
+    )
     // Why: mirrors the leaf path — an unreadable foreground is indistinguishable from an
     // exited one, so a bare Cursor identity title never substitutes for corroboration.
     if (!fg) {
@@ -34776,14 +34828,15 @@ export class OrcaRuntimeService {
     // Why: review-note delivery auto-submits with Enter, so only known agent processes are safe (not arbitrary focused TUIs).
     return await this.isRecognizedForegroundAgentProcess(pty.ptyId, fg, {
       suppressClaude: shouldSuppressClaudeForeground,
-      retryWrappers: options.retryForegroundWrappers !== false
+      retryWrappers: options.retryForegroundWrappers !== false,
+      signal: options.signal
     })
   }
 
   private async isRecognizedForegroundAgentProcess(
     ptyId: string,
     foregroundProcess: string,
-    options: { suppressClaude?: boolean; retryWrappers?: boolean } = {}
+    options: { suppressClaude?: boolean; retryWrappers?: boolean; signal?: AbortSignal } = {}
   ): Promise<boolean> {
     return (await this.recognizeForegroundAgentProcess(ptyId, foregroundProcess, options)) !== null
   }
@@ -34812,7 +34865,10 @@ export class OrcaRuntimeService {
     while (Date.now() - startedAt < FOREGROUND_AGENT_WRAPPER_RETRY_TIMEOUT_MS) {
       await waitForAgentPromptDelay(FOREGROUND_AGENT_WRAPPER_RETRY_INTERVAL_MS, options.signal)
       assertAgentPromptRequestActive(options.signal)
-      const refreshedProcess = await this.ptyController.getForegroundProcess(ptyId)
+      const refreshedProcess = await waitForAgentPromptPromise(
+        this.ptyController.getForegroundProcess(ptyId),
+        options.signal
+      )
       assertAgentPromptRequestActive(options.signal)
       const refreshedRecognition = recognizeAgentProcess(refreshedProcess)
       if (refreshedRecognition !== null) {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -19547,17 +19547,25 @@ export class OrcaRuntimeService {
     expectedAgent: TuiAgent,
     signal?: AbortSignal
   ): Promise<void> {
-    if (!this.ptyController) {
-      throw new Error('terminal_guard_not_writable')
-    }
-    const foregroundProcess = await waitForAgentPromptPromise(
-      this.ptyController.getForegroundProcess(ptyId),
-      signal
-    )
+    const foregroundProcess = await this.readSettledPromptForegroundConfirmation(ptyId, signal)
     assertAgentPromptRequestActive(signal)
     if (recognizeAgentProcess(foregroundProcess)?.agent !== expectedAgent) {
       throw new Error('terminal_guard_not_writable')
     }
+  }
+
+  private async readSettledPromptForegroundConfirmation(
+    ptyId: string,
+    signal?: AbortSignal
+  ): Promise<string | null> {
+    const controller = this.ptyController
+    if (!controller) {
+      throw new Error('terminal_guard_not_writable')
+    }
+    const foreground = controller.confirmForegroundProcess
+      ? controller.confirmForegroundProcess(ptyId)
+      : controller.getForegroundProcess(ptyId)
+    return await waitForAgentPromptPromise(foreground, signal)
   }
 
   private createAgentPromptRenderGate(
@@ -34753,7 +34761,7 @@ export class OrcaRuntimeService {
     }
     assertAgentPromptRequestActive(signal)
     const confirmed = recognizeAgentProcess(
-      await waitForAgentPromptPromise(this.ptyController.getForegroundProcess(ptyId), signal)
+      await this.readSettledPromptForegroundConfirmation(ptyId, signal)
     )
     assertAgentPromptRequestActive(signal)
     if (confirmed?.agent !== recognized.agent) {

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -1402,7 +1402,16 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
       }
       const mobileFloorClientId = resolveMobileFloorClientId(driver, params.client)
       const mobileFloorClaim: MobileInputFloorClaimHolder = { current: null }
-      const beforeWrite = assertSendPreconditions
+      const assertPromptInputAuthority =
+        params.agentPrompt === true && params.client?.type === 'desktop'
+          ? (ptyId?: string): void => {
+              assertTerminalSendExactPtyBinding(runtime, params.terminal, ptyId)
+              if (ptyId && isTerminalInputLockedForClient(runtime, ptyId, params.client)) {
+                throw new Error('terminal_guard_not_writable')
+              }
+            }
+          : undefined
+      const beforeWrite = assertSendPreconditions ?? assertPromptInputAuthority
       const useSettledAgentPrompt =
         params.agentPrompt === true &&
         hasText &&

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -1405,20 +1405,22 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
       const assertPromptInputAuthority =
         params.agentPrompt === true && params.client?.type === 'desktop'
           ? (ptyId?: string): void => {
+              if (signal?.aborted) {
+                throw new Error('request_aborted')
+              }
               assertTerminalSendExactPtyBinding(runtime, params.terminal, ptyId)
               if (ptyId && isTerminalInputLockedForClient(runtime, ptyId, params.client)) {
                 throw new Error('terminal_guard_not_writable')
               }
             }
           : undefined
-      const beforeWrite = assertSendPreconditions ?? assertPromptInputAuthority
+      const beforeWrite = assertSendPreconditions
       const useSettledAgentPrompt =
         params.agentPrompt === true &&
         hasText &&
         params.enter === true &&
         params.interrupt !== true &&
-        params.client?.type === 'desktop' &&
-        (await runtime.isTerminalRunningSettledPromptAgent(params.terminal))
+        params.client?.type === 'desktop'
       const reserveWrite =
         params.inputKind !== 'query-reply' && leaf?.ptyId && mobileFloorClientId
           ? (ptyId: string): void => {
@@ -1431,26 +1433,32 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           : undefined
       let result
       try {
-        result = useSettledAgentPrompt
-          ? await runtime.sendTerminalAgentPrompt(params.terminal, params.text!, {
+        if (useSettledAgentPrompt) {
+          result = await runtime.sendTerminalAgentPrompt(params.terminal, params.text!, {
+            beforeWrite,
+            assertWriteAuthority: assertPromptInputAuthority,
+            signal,
+            requireSettledForeground: true
+          })
+        }
+        if (!useSettledAgentPrompt || result?.accepted !== true) {
+          result = await runtime.sendTerminal(
+            params.terminal,
+            {
+              text: params.text,
+              enter: params.enter === true,
+              interrupt: params.interrupt === true
+            },
+            {
               beforeWrite,
-              signal
-            })
-          : await runtime.sendTerminal(
-              params.terminal,
-              {
-                text: params.text,
-                enter: params.enter === true,
-                interrupt: params.interrupt === true
-              },
-              {
-                beforeWrite,
-                ...(reserveWrite ? { reserveWrite } : {}),
-                ...(params.inputKind !== 'query-reply' && mobileFloorClientId
-                  ? { afterWrite: () => commitMobileInputFloorClaim(mobileFloorClaim) }
-                  : {})
-              }
-            )
+              assertWriteAuthority: assertPromptInputAuthority,
+              ...(reserveWrite ? { reserveWrite } : {}),
+              ...(params.inputKind !== 'query-reply' && mobileFloorClientId
+                ? { afterWrite: () => commitMobileInputFloorClaim(mobileFloorClaim) }
+                : {})
+            }
+          )
+        }
       } catch (error) {
         mobileFloorClaim.current?.rollback()
         const refusedReason = getTerminalSendGuardRefusedReason(error)

--- a/src/main/runtime/rpc/terminal-agent-prompt-send.test.ts
+++ b/src/main/runtime/rpc/terminal-agent-prompt-send.test.ts
@@ -26,7 +26,6 @@ describe('terminal agent prompt send RPC', () => {
     const runtime = makeRuntime({
       resolveLiveLeafForHandle: vi.fn().mockReturnValue({ ptyId: 'pty-1' }),
       getDriver: vi.fn().mockReturnValue({ kind: 'idle' }),
-      isTerminalRunningSettledPromptAgent: vi.fn().mockResolvedValue(true),
       sendTerminal,
       sendTerminalAgentPrompt
     })
@@ -43,9 +42,10 @@ describe('terminal agent prompt send RPC', () => {
     )
 
     expect(response.ok).toBe(true)
-    expect(runtime.isTerminalRunningSettledPromptAgent).toHaveBeenCalledWith('terminal-1')
     expect(sendTerminalAgentPrompt).toHaveBeenCalledWith('terminal-1', 'review this change', {
-      beforeWrite: expect.any(Function),
+      assertWriteAuthority: expect.any(Function),
+      beforeWrite: undefined,
+      requireSettledForeground: true,
       signal: undefined
     })
     expect(sendTerminal).not.toHaveBeenCalled()
@@ -57,11 +57,14 @@ describe('terminal agent prompt send RPC', () => {
       accepted: true,
       bytesWritten: 7
     })
-    const sendTerminalAgentPrompt = vi.fn()
+    const sendTerminalAgentPrompt = vi.fn().mockResolvedValue({
+      handle: 'terminal-1',
+      accepted: false,
+      bytesWritten: 0
+    })
     const runtime = makeRuntime({
       resolveLiveLeafForHandle: vi.fn().mockReturnValue({ ptyId: 'pty-1' }),
       getDriver: vi.fn().mockReturnValue({ kind: 'idle' }),
-      isTerminalRunningSettledPromptAgent: vi.fn().mockResolvedValue(false),
       sendTerminal,
       sendTerminalAgentPrompt
     })
@@ -81,9 +84,9 @@ describe('terminal agent prompt send RPC', () => {
     expect(sendTerminal).toHaveBeenCalledWith(
       'terminal-1',
       { text: 'echo x', enter: true, interrupt: false },
-      { beforeWrite: expect.any(Function) }
+      { assertWriteAuthority: expect.any(Function), beforeWrite: undefined }
     )
-    expect(sendTerminalAgentPrompt).not.toHaveBeenCalled()
+    expect(sendTerminalAgentPrompt).toHaveBeenCalledOnce()
   })
 
   it('does not send delayed Enter after a paired mobile client takes the floor', async () => {
@@ -103,14 +106,14 @@ describe('terminal agent prompt send RPC', () => {
       async (
         _handle: string,
         _prompt: string,
-        options: { beforeWrite?: (ptyId: string) => void }
+        options: { assertWriteAuthority?: (ptyId: string) => void }
       ) => {
-        await options.beforeWrite?.('pty-1')
+        options.assertWriteAuthority?.('pty-1')
         writes.push('prompt')
         ordering.push('request-4488:generation-1:desktop:paste')
         pasteWritten()
         await settlement
-        await options.beforeWrite?.('pty-1')
+        options.assertWriteAuthority?.('pty-1')
         writes.push('\r')
         ordering.push('request-4488:generation-1:mobile:enter')
         return { handle: 'terminal-1', accepted: true, bytesWritten: 7 }
@@ -123,7 +126,6 @@ describe('terminal agent prompt send RPC', () => {
           ? { kind: 'mobile' as const, clientId: 'mobile-1' }
           : { kind: 'desktop' as const }
       ),
-      isTerminalRunningSettledPromptAgent: vi.fn().mockResolvedValue(true),
       sendTerminal,
       sendTerminalAgentPrompt
     })

--- a/src/main/runtime/rpc/terminal-agent-prompt-send.test.ts
+++ b/src/main/runtime/rpc/terminal-agent-prompt-send.test.ts
@@ -89,6 +89,36 @@ describe('terminal agent prompt send RPC', () => {
     expect(sendTerminalAgentPrompt).toHaveBeenCalledOnce()
   })
 
+  it('does not fall back after settled foreground authority is lost', async () => {
+    const sendTerminal = vi.fn()
+    const sendTerminalAgentPrompt = vi
+      .fn()
+      .mockRejectedValue(new Error('terminal_guard_not_writable'))
+    const runtime = makeRuntime({
+      resolveLiveLeafForHandle: vi.fn().mockReturnValue({ ptyId: 'pty-1' }),
+      getDriver: vi.fn().mockReturnValue({ kind: 'idle' }),
+      sendTerminal,
+      sendTerminalAgentPrompt
+    })
+    const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest({
+        terminal: 'terminal-1',
+        text: 'review this change',
+        enter: true,
+        agentPrompt: true,
+        client: { id: 'orca-cli', type: 'desktop' }
+      })
+    )
+
+    expect(response).toMatchObject({
+      ok: true,
+      result: { send: { accepted: false, bytesWritten: 0 } }
+    })
+    expect(sendTerminal).not.toHaveBeenCalled()
+  })
+
   it('does not send delayed Enter after a paired mobile client takes the floor', async () => {
     const writes: string[] = []
     const ordering: string[] = []

--- a/src/main/runtime/rpc/terminal-agent-prompt-send.test.ts
+++ b/src/main/runtime/rpc/terminal-agent-prompt-send.test.ts
@@ -45,7 +45,7 @@ describe('terminal agent prompt send RPC', () => {
     expect(response.ok).toBe(true)
     expect(runtime.isTerminalRunningSettledPromptAgent).toHaveBeenCalledWith('terminal-1')
     expect(sendTerminalAgentPrompt).toHaveBeenCalledWith('terminal-1', 'review this change', {
-      beforeWrite: undefined,
+      beforeWrite: expect.any(Function),
       signal: undefined
     })
     expect(sendTerminal).not.toHaveBeenCalled()
@@ -81,8 +81,77 @@ describe('terminal agent prompt send RPC', () => {
     expect(sendTerminal).toHaveBeenCalledWith(
       'terminal-1',
       { text: 'echo x', enter: true, interrupt: false },
-      { beforeWrite: undefined }
+      { beforeWrite: expect.any(Function) }
     )
     expect(sendTerminalAgentPrompt).not.toHaveBeenCalled()
+  })
+
+  it('does not send delayed Enter after a paired mobile client takes the floor', async () => {
+    const writes: string[] = []
+    const ordering: string[] = []
+    let floorOwner: 'desktop' | 'mobile' = 'desktop'
+    let releaseSettlement!: () => void
+    const settlement = new Promise<void>((resolve) => {
+      releaseSettlement = resolve
+    })
+    let pasteWritten!: () => void
+    const paste = new Promise<void>((resolve) => {
+      pasteWritten = resolve
+    })
+    const sendTerminal = vi.fn()
+    const sendTerminalAgentPrompt = vi.fn(
+      async (
+        _handle: string,
+        _prompt: string,
+        options: { beforeWrite?: (ptyId: string) => void }
+      ) => {
+        await options.beforeWrite?.('pty-1')
+        writes.push('prompt')
+        ordering.push('request-4488:generation-1:desktop:paste')
+        pasteWritten()
+        await settlement
+        await options.beforeWrite?.('pty-1')
+        writes.push('\r')
+        ordering.push('request-4488:generation-1:mobile:enter')
+        return { handle: 'terminal-1', accepted: true, bytesWritten: 7 }
+      }
+    )
+    const runtime = makeRuntime({
+      resolveLiveLeafForHandle: vi.fn().mockReturnValue({ ptyId: 'pty-1' }),
+      getDriver: vi.fn(() =>
+        floorOwner === 'mobile'
+          ? { kind: 'mobile' as const, clientId: 'mobile-1' }
+          : { kind: 'desktop' as const }
+      ),
+      isTerminalRunningSettledPromptAgent: vi.fn().mockResolvedValue(true),
+      sendTerminal,
+      sendTerminalAgentPrompt
+    })
+    const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+
+    const response = dispatcher.dispatch(
+      makeRequest({
+        terminal: 'terminal-1',
+        text: 'prompt',
+        enter: true,
+        agentPrompt: true,
+        client: { id: 'orca-cli', type: 'desktop' }
+      })
+    )
+    await paste
+    floorOwner = 'mobile'
+    ordering.push('request-4488:generation-1:mobile:floor')
+    releaseSettlement()
+
+    await expect(response).resolves.toMatchObject({
+      ok: true,
+      result: { send: { accepted: false, bytesWritten: 0 } }
+    })
+    expect(writes).toEqual(['prompt'])
+    expect(ordering).toEqual([
+      'request-4488:generation-1:desktop:paste',
+      'request-4488:generation-1:mobile:floor'
+    ])
+    expect(sendTerminal).not.toHaveBeenCalled()
   })
 })

--- a/tests/e2e/ssh-docker-agent-prompt-submit.spec.ts
+++ b/tests/e2e/ssh-docker-agent-prompt-submit.spec.ts
@@ -3,6 +3,10 @@ import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import { promisify } from 'node:util'
 import type { Page } from '@stablyai/playwright-test'
+import {
+  AGENT_PROMPT_SUBMIT,
+  buildAgentPromptPasteBytes
+} from '../../src/shared/agent-prompt-injection'
 import { expect, test } from './helpers/orca-app'
 import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
 import {
@@ -248,8 +252,7 @@ test.describe('Docker SSH settled prompt submission', () => {
       await expect(send).resolves.toMatchObject({ send: { accepted: true } })
       await expect.poll(() => remoteFile(target!, REMOTE_REPORT)).not.toBe('')
       const observedInput = remoteInput(target)
-      expect(observedInput).toContain(prompt)
-      expect(observedInput.match(/\r/g)).toHaveLength(1)
+      expect(observedInput).toBe(`${buildAgentPromptPasteBytes(prompt)}${AGENT_PROMPT_SUBMIT}`)
       expect(JSON.parse(remoteFile(target, REMOTE_REPORT))).toMatchObject({
         contractOk: true,
         submitted: true,

--- a/tests/e2e/ssh-docker-agent-prompt-submit.spec.ts
+++ b/tests/e2e/ssh-docker-agent-prompt-submit.spec.ts
@@ -1,0 +1,278 @@
+import { execFile } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { promisify } from 'node:util'
+import type { Page } from '@stablyai/playwright-test'
+import { expect, test } from './helpers/orca-app'
+import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import {
+  cleanupDockerSshRelayTarget,
+  execDockerSshRelayTargetControlCommand,
+  shellQuote,
+  startDockerSshRelayTarget,
+  type DockerSshRelayTarget,
+  writeDockerSshRelayTargetFile
+} from './helpers/docker-ssh-relay-target'
+import { connectDockerSshRelayTarget } from './helpers/docker-ssh-relay-connection'
+
+const RUN_DOCKER_SSH = process.env.ORCA_E2E_SSH_DOCKER === '1'
+const REMOTE_AGENT = '/tmp/codex'
+const REMOTE_INPUT = '/tmp/orca-codex-prompt-input.bin'
+const REMOTE_REPORT = '/tmp/orca-codex-prompt-report.json'
+const PS_OBSERVE = '/tmp/orca-prompt-ps-observe'
+const PS_FAIL = '/tmp/orca-prompt-ps-fail-once'
+const PS_ENTERED = '/tmp/orca-prompt-ps-entered'
+const PS_RELEASE = '/tmp/orca-prompt-ps-release'
+const PS_RETRY = '/tmp/orca-prompt-ps-retry'
+const PS_RETRY_ENTERED = '/tmp/orca-prompt-ps-retry-entered'
+const PS_RETRY_RELEASE = '/tmp/orca-prompt-ps-retry-release'
+const PS_COUNT = '/tmp/orca-prompt-ps-count'
+const execFileAsync = promisify(execFile)
+
+type RuntimeTerminalSummary = {
+  handle: string
+  ptyId: string | null
+  executionHostId?: string
+}
+
+async function callRuntime<TResult>(page: Page, method: string, params: unknown): Promise<TResult> {
+  return page.evaluate(
+    async ({ method, params }) => {
+      const response = await window.api.runtime.call({ method, params })
+      if (!response.ok) {
+        throw new Error(`${response.error.code}: ${response.error.message}`)
+      }
+      return response.result
+    },
+    { method, params }
+  ) as Promise<TResult>
+}
+
+async function createRemoteTerminal(
+  page: Page,
+  worktreeId: string,
+  command: string,
+  title: string
+): Promise<RuntimeTerminalSummary> {
+  const result = await callRuntime<{ terminal: RuntimeTerminalSummary }>(page, 'terminal.create', {
+    worktree: `id:${worktreeId}`,
+    command,
+    title,
+    presentation: 'background'
+  })
+  if (!result.terminal.ptyId) {
+    throw new Error(`Remote terminal ${result.terminal.handle} has no PTY`)
+  }
+  return result.terminal
+}
+
+function installControlledPs(target: DockerSshRelayTarget): void {
+  const script = `#!/usr/bin/env bash
+if [ -e ${PS_OBSERVE} ]; then
+  count=0
+  [ ! -r ${PS_COUNT} ] || count="$(cat ${PS_COUNT})"
+  printf '%s' "$((count + 1))" > ${PS_COUNT}
+  if rm -f ${PS_FAIL} 2>/dev/null && [ ! -e ${PS_ENTERED} ]; then
+    printf entered > ${PS_ENTERED}
+    while [ ! -e ${PS_RELEASE} ]; do sleep 0.02; done
+    exit 1
+  fi
+  if rm -f ${PS_RETRY} 2>/dev/null && [ ! -e ${PS_RETRY_ENTERED} ]; then
+    printf retry > ${PS_RETRY_ENTERED}
+    while [ ! -e ${PS_RETRY_RELEASE} ]; do sleep 0.02; done
+    exit 1
+  fi
+fi
+exec /usr/bin/ps "$@"
+`
+  writeDockerSshRelayTargetFile(target, '/usr/local/bin/ps', script)
+  execDockerSshRelayTargetControlCommand(target, 'chmod 755 /usr/local/bin/ps')
+}
+
+function prepareRemoteAgent(target: DockerSshRelayTarget): void {
+  const fixture = readFileSync(
+    path.join(process.cwd(), 'tests', 'tools', 'repro-terminal-send-submit.mjs'),
+    'utf8'
+  )
+  writeDockerSshRelayTargetFile(target, REMOTE_AGENT, fixture)
+  installControlledPs(target)
+}
+
+function remoteFile(target: DockerSshRelayTarget, filePath: string): string {
+  try {
+    return execDockerSshRelayTargetControlCommand(
+      target,
+      `test -r ${shellQuote(filePath)} && cat ${shellQuote(filePath)}`
+    )
+  } catch {
+    return ''
+  }
+}
+
+function remoteInput(target: DockerSshRelayTarget): string {
+  try {
+    const encoded = execDockerSshRelayTargetControlCommand(
+      target,
+      `test -r ${shellQuote(REMOTE_INPUT)} && base64 -w0 ${shellQuote(REMOTE_INPUT)}`
+    )
+    return Buffer.from(encoded, 'base64').toString('utf8')
+  } catch {
+    return ''
+  }
+}
+
+function armHalfOpenInspection(target: DockerSshRelayTarget): void {
+  execDockerSshRelayTargetControlCommand(
+    target,
+    `rm -f ${REMOTE_INPUT} ${REMOTE_REPORT} ${PS_ENTERED} ${PS_RELEASE} ${PS_RETRY_ENTERED} ${PS_RETRY_RELEASE} ${PS_COUNT}; ` +
+      `: > ${PS_OBSERVE}; : > ${PS_FAIL}; : > ${PS_RETRY}`
+  )
+}
+
+async function waitForRemoteSignal(
+  target: DockerSshRelayTarget,
+  filePath: string
+): Promise<string> {
+  const result = await execFileAsync(
+    'docker',
+    [
+      'exec',
+      target.containerName,
+      'bash',
+      '--noprofile',
+      '--norc',
+      '-c',
+      `while [ ! -r ${shellQuote(filePath)} ]; do sleep 0.02; done; cat ${shellQuote(filePath)}`
+    ],
+    { encoding: 'utf8', timeout: 10_000 }
+  )
+  return result.stdout.trim()
+}
+
+test.describe('Docker SSH settled prompt submission', () => {
+  test.skip(!RUN_DOCKER_SSH, 'Set ORCA_E2E_SSH_DOCKER=1 to run Docker SSH relay tests.')
+  test.skip(process.platform === 'win32', 'Docker SSH relay tests use POSIX ssh tooling.')
+
+  test('waits through a half-open wrapper inspection before one remote Enter', async ({
+    orcaPage
+  }, testInfo) => {
+    test.setTimeout(180_000)
+    let target: DockerSshRelayTarget | null = null
+    const terminalHandles: string[] = []
+    try {
+      target = startDockerSshRelayTarget(testInfo)
+      prepareRemoteAgent(target)
+      await waitForSessionReady(orcaPage)
+      await waitForActiveWorktree(orcaPage)
+      const remote = await connectDockerSshRelayTarget(orcaPage, target)
+      const marker = `SSH_SETTLED_PROMPT_${Date.now()}`
+      const survivor = await createRemoteTerminal(
+        orcaPage,
+        remote.worktreeId,
+        'bash',
+        'unrelated remote shell'
+      )
+      terminalHandles.push(survivor.handle)
+      const terminal = await createRemoteTerminal(
+        orcaPage,
+        remote.worktreeId,
+        `node ${REMOTE_AGENT} --fake-agent --report ${REMOTE_REPORT} --marker ${marker} --input-observation ${REMOTE_INPUT} --timeout-ms 60000`,
+        'remote prompt fixture'
+      )
+      terminalHandles.push(terminal.handle)
+      expect(terminal.ptyId).not.toBe(survivor.ptyId)
+      await expect
+        .poll(async () => {
+          const read = await callRuntime<{ terminal: { tail: string[] } }>(
+            orcaPage,
+            'terminal.read',
+            { terminal: terminal.handle }
+          )
+          return read.terminal.tail.join('\n')
+        })
+        .toContain('OpenAI Codex')
+      expect(terminal.executionHostId).toBe(`ssh:${encodeURIComponent(remote.targetId)}`)
+
+      armHalfOpenInspection(target)
+      const inspectionEntered = waitForRemoteSignal(target, PS_ENTERED)
+      const inspection = callRuntime(orcaPage, 'terminal.inspectProcess', {
+        terminal: terminal.handle
+      })
+      await expect(inspectionEntered).resolves.toBe('entered')
+      const prompt = `${marker} remote wrapper payload`
+      let sendSettled = false
+      const send = callRuntime<{ send: { accepted: boolean; bytesWritten: number } }>(
+        orcaPage,
+        'terminal.send',
+        {
+          terminal: terminal.handle,
+          text: prompt,
+          enter: true,
+          agentPrompt: true,
+          client: { id: 'docker-ssh-e2e', type: 'desktop' }
+        }
+      ).finally(() => {
+        sendSettled = true
+      })
+
+      expect(sendSettled).toBe(false)
+      expect(remoteInput(target)).toBe('')
+      execDockerSshRelayTargetControlCommand(target, `: > ${PS_RELEASE}`)
+      await expect(inspection).resolves.toBeTruthy()
+      await expect(waitForRemoteSignal(target, PS_RETRY_ENTERED)).resolves.toBe('retry')
+      expect(remoteInput(target)).toBe('')
+      expect(sendSettled).toBe(false)
+      execDockerSshRelayTargetControlCommand(target, `: > ${PS_RETRY_RELEASE}`)
+
+      await expect(send).resolves.toMatchObject({ send: { accepted: true } })
+      await expect.poll(() => remoteFile(target!, REMOTE_REPORT)).not.toBe('')
+      const observedInput = remoteInput(target)
+      expect(observedInput).toContain(prompt)
+      expect(observedInput.match(/\r/g)).toHaveLength(1)
+      expect(JSON.parse(remoteFile(target, REMOTE_REPORT))).toMatchObject({
+        contractOk: true,
+        submitted: true,
+        prematureEnters: 0,
+        receivedEnters: 1,
+        markerReceived: true
+      })
+      expect(Number(remoteFile(target, PS_COUNT))).toBeGreaterThanOrEqual(2)
+
+      const survivorMarker = `SSH_UNRELATED_SURVIVES_${Date.now()}`
+      await callRuntime(orcaPage, 'terminal.send', {
+        terminal: survivor.handle,
+        text: `printf '${survivorMarker}\\n'`,
+        enter: true,
+        client: { id: 'docker-ssh-e2e', type: 'desktop' }
+      })
+      await expect
+        .poll(async () => {
+          const read = await callRuntime<{ terminal: { tail: string[] } }>(
+            orcaPage,
+            'terminal.read',
+            { terminal: survivor.handle }
+          )
+          return read.terminal.tail.join('\n')
+        })
+        .toContain(survivorMarker)
+
+      testInfo.annotations.push({
+        type: 'docker-ssh-settled-prompt',
+        description: `target=${remote.targetId} worktree=${remote.worktreeId} agentPty=${terminal.ptyId} survivorPty=${survivor.ptyId} psCalls=${remoteFile(target, PS_COUNT)}`
+      })
+    } finally {
+      await Promise.all(
+        terminalHandles.map((terminal) =>
+          callRuntime(orcaPage, 'terminal.closeTab', { terminal }).catch(() => undefined)
+        )
+      )
+      if (target) {
+        execDockerSshRelayTargetControlCommand(
+          target,
+          `rm -f ${PS_OBSERVE} ${PS_FAIL} ${PS_RELEASE} ${PS_RETRY} ${PS_RETRY_RELEASE}`
+        )
+      }
+      cleanupDockerSshRelayTarget(target)
+    }
+  })
+})

--- a/tests/e2e/ssh-docker-agent-prompt-submit.spec.ts
+++ b/tests/e2e/ssh-docker-agent-prompt-submit.spec.ts
@@ -27,6 +27,7 @@ const PS_RETRY = '/tmp/orca-prompt-ps-retry'
 const PS_RETRY_ENTERED = '/tmp/orca-prompt-ps-retry-entered'
 const PS_RETRY_RELEASE = '/tmp/orca-prompt-ps-retry-release'
 const PS_COUNT = '/tmp/orca-prompt-ps-count'
+const TERMINAL_CLOSE_CLEANUP_TIMEOUT_MS = 5_000
 const execFileAsync = promisify(execFile)
 
 type RuntimeTerminalSummary = {
@@ -46,6 +47,26 @@ async function callRuntime<TResult>(page: Page, method: string, params: unknown)
     },
     { method, params }
   ) as Promise<TResult>
+}
+
+async function closeRemoteTerminalsBestEffort(page: Page, handles: string[]): Promise<void> {
+  let timeout: NodeJS.Timeout | null = null
+  try {
+    await Promise.race([
+      Promise.all(
+        handles.map((terminal) =>
+          callRuntime(page, 'terminal.closeTab', { terminal }).catch(() => undefined)
+        )
+      ),
+      new Promise<void>((resolve) => {
+        timeout = setTimeout(resolve, TERMINAL_CLOSE_CLEANUP_TIMEOUT_MS)
+      })
+    ])
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout)
+    }
+  }
 }
 
 async function createRemoteTerminal(
@@ -263,22 +284,21 @@ test.describe('Docker SSH settled prompt submission', () => {
         description: `target=${remote.targetId} worktree=${remote.worktreeId} agentPty=${terminal.ptyId} survivorPty=${survivor.ptyId} psCalls=${remoteFile(target, PS_COUNT)}`
       })
     } finally {
-      await Promise.all(
-        terminalHandles.map((terminal) =>
-          callRuntime(orcaPage, 'terminal.closeTab', { terminal }).catch(() => undefined)
-        )
-      )
-      if (target) {
-        try {
-          execDockerSshRelayTargetControlCommand(
-            target,
-            `rm -f ${PS_OBSERVE} ${PS_FAIL} ${PS_RELEASE} ${PS_RETRY} ${PS_RETRY_RELEASE}`
-          )
-        } finally {
+      try {
+        await closeRemoteTerminalsBestEffort(orcaPage, terminalHandles)
+      } finally {
+        if (target) {
+          try {
+            execDockerSshRelayTargetControlCommand(
+              target,
+              `rm -f ${PS_OBSERVE} ${PS_FAIL} ${PS_RELEASE} ${PS_RETRY} ${PS_RETRY_RELEASE}`
+            )
+          } finally {
+            cleanupDockerSshRelayTarget(target)
+          }
+        } else {
           cleanupDockerSshRelayTarget(target)
         }
-      } else {
-        cleanupDockerSshRelayTarget(target)
       }
     }
   })

--- a/tests/e2e/ssh-docker-agent-prompt-submit.spec.ts
+++ b/tests/e2e/ssh-docker-agent-prompt-submit.spec.ts
@@ -236,7 +236,9 @@ test.describe('Docker SSH settled prompt submission', () => {
         receivedEnters: 1,
         markerReceived: true
       })
-      expect(Number(remoteFile(target, PS_COUNT))).toBeGreaterThanOrEqual(2)
+      const psCalls = Number(remoteFile(target, PS_COUNT))
+      expect(psCalls).toBeGreaterThanOrEqual(2)
+      expect(psCalls).toBeLessThanOrEqual(8)
 
       const survivorMarker = `SSH_UNRELATED_SURVIVES_${Date.now()}`
       await callRuntime(orcaPage, 'terminal.send', {
@@ -267,12 +269,17 @@ test.describe('Docker SSH settled prompt submission', () => {
         )
       )
       if (target) {
-        execDockerSshRelayTargetControlCommand(
-          target,
-          `rm -f ${PS_OBSERVE} ${PS_FAIL} ${PS_RELEASE} ${PS_RETRY} ${PS_RETRY_RELEASE}`
-        )
+        try {
+          execDockerSshRelayTargetControlCommand(
+            target,
+            `rm -f ${PS_OBSERVE} ${PS_FAIL} ${PS_RELEASE} ${PS_RETRY} ${PS_RETRY_RELEASE}`
+          )
+        } finally {
+          cleanupDockerSshRelayTarget(target)
+        }
+      } else {
+        cleanupDockerSshRelayTarget(target)
       }
-      cleanupDockerSshRelayTarget(target)
     }
   })
 })

--- a/tests/e2e/terminal-send-agent-prompt-submit.spec.ts
+++ b/tests/e2e/terminal-send-agent-prompt-submit.spec.ts
@@ -356,14 +356,8 @@ test('paired mobile floor takeover blocks the CLI delayed Enter', async ({
       send: { accepted: false, bytesWritten: 0 }
     })
     const observedInput = readObservedInput(fixtureInputObservation)
-    expect(observedInput).toContain(marker)
-    expect(observedInput).toContain('mobile-owner-input')
-    if (process.platform === 'win32') {
-      expect(observedInput).toContain(prompt)
-    } else {
-      expect(observedInput).toContain(`\x1b[200~${prompt}\x1b[201~`)
-    }
-    expect(observedInput).not.toContain('\r')
+    const desktopFrame = process.platform === 'win32' ? prompt : `\x1b[200~${prompt}\x1b[201~`
+    expect(observedInput).toBe(`${desktopFrame}mobile-owner-input`)
   } finally {
     subscription.close()
     await callDevCli(

--- a/tests/e2e/terminal-send-agent-prompt-submit.spec.ts
+++ b/tests/e2e/terminal-send-agent-prompt-submit.spec.ts
@@ -358,6 +358,11 @@ test('paired mobile floor takeover blocks the CLI delayed Enter', async ({
     const observedInput = readObservedInput(fixtureInputObservation)
     expect(observedInput).toContain(marker)
     expect(observedInput).toContain('mobile-owner-input')
+    if (process.platform === 'win32') {
+      expect(observedInput).toContain(prompt)
+    } else {
+      expect(observedInput).toContain(`\x1b[200~${prompt}\x1b[201~`)
+    }
     expect(observedInput).not.toContain('\r')
   } finally {
     subscription.close()

--- a/tests/e2e/terminal-send-agent-prompt-submit.spec.ts
+++ b/tests/e2e/terminal-send-agent-prompt-submit.spec.ts
@@ -1,37 +1,48 @@
 import { execFile } from 'node:child_process'
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { promisify } from 'node:util'
+import type { Page } from '@stablyai/playwright-test'
 import { expect, test } from './helpers/orca-app'
 import { waitForSessionReady } from './helpers/store'
+import { parsePairingCode } from '../../src/shared/pairing'
+import {
+  sendRemoteRuntimeRequest,
+  subscribeRemoteRuntimeRequest
+} from '../../src/shared/remote-runtime-client'
 
 const execFileAsync = promisify(execFile)
 const fixtureRoot = mkdtempSync(path.join(os.tmpdir(), 'orca-terminal-send-agent-prompt-'))
 const fixtureBin = path.join(fixtureRoot, 'bin')
 const fixtureReport = path.join(fixtureRoot, 'report.json')
+const fixtureInputObservation = path.join(fixtureRoot, 'input.bin')
 const fixtureMarker = `ORCA_TERMINAL_SEND_E2E_${process.pid}`
 const fixtureScript = path.join(process.cwd(), 'tests', 'tools', 'repro-terminal-send-submit.mjs')
 const fakeCodex = path.join(fixtureBin, process.platform === 'win32' ? 'codex.cmd' : 'codex')
 
 mkdirSync(fixtureBin)
-writeFileSync(
-  fakeCodex,
-  process.platform === 'win32'
-    ? `@echo off\r\n"${process.execPath}" "${fixtureScript}" --fake-agent --report "%ORCA_FAKE_AGENT_REPORT%" --marker "%ORCA_FAKE_AGENT_MARKER%" --allow-unframed-paste %*\r\n`
-    : `#!/usr/bin/env sh\nexec "${process.execPath}" "${fixtureScript}" --fake-agent --report "$ORCA_FAKE_AGENT_REPORT" --marker "$ORCA_FAKE_AGENT_MARKER" "$@"\n`,
-  'utf8'
-)
-if (process.platform !== 'win32') {
-  chmodSync(fakeCodex, 0o755)
+if (process.platform === 'win32') {
+  writeFileSync(
+    fakeCodex,
+    `@echo off\r\n"${process.execPath}" "${fixtureScript}" --fake-agent --report "%ORCA_FAKE_AGENT_REPORT%" --marker "%ORCA_FAKE_AGENT_MARKER%" --input-observation "%ORCA_FAKE_AGENT_INPUT_OBSERVATION%" --allow-unframed-paste %*\r\n`,
+    'utf8'
+  )
+} else {
+  symlinkSync(process.execPath, fakeCodex)
 }
+const fakeCodexCommand =
+  process.platform === 'win32'
+    ? `"${fakeCodex}"`
+    : `${shellQuote(fakeCodex)} ${shellQuote(fixtureScript)} --fake-agent --report ${shellQuote(fixtureReport)} --marker ${shellQuote(fixtureMarker)} --input-observation ${shellQuote(fixtureInputObservation)}`
 
 test.use({
   seedTestRepo: false,
   orcaAppExtraEnv: {
     PATH: `${fixtureBin}${path.delimiter}${process.env.PATH ?? ''}`,
     ORCA_FAKE_AGENT_REPORT: fixtureReport,
-    ORCA_FAKE_AGENT_MARKER: fixtureMarker
+    ORCA_FAKE_AGENT_MARKER: fixtureMarker,
+    ORCA_FAKE_AGENT_INPUT_OBSERVATION: fixtureInputObservation
   }
 })
 
@@ -59,7 +70,7 @@ test('CLI text plus Enter waits for a slow agent composer before submitting', as
         '--worktree',
         testRepoPath,
         '--agent-command',
-        'codex',
+        fakeCodexCommand,
         '--report',
         fixtureReport,
         '--marker',
@@ -109,7 +120,7 @@ test('CLI reports a swallowed Enter without submitting a second Enter', async ({
         '--worktree',
         testRepoPath,
         '--agent-command',
-        'codex --swallow-first-enter',
+        `${fakeCodexCommand} --swallow-first-enter`,
         '--expect-stalled',
         '--report',
         fixtureReport,
@@ -189,3 +200,251 @@ test('CLI does not write prompt bytes into an active permission dialog', async (
     markerReceived: false
   })
 })
+
+test('paired mobile floor takeover blocks the CLI delayed Enter', async ({
+  electronApp,
+  orcaPage,
+  testRepoPath
+}) => {
+  test.setTimeout(90_000)
+  await waitForSessionReady(orcaPage)
+  const userDataDir = await electronApp.evaluate(({ app }) => app.getPath('userData'))
+  const marker = fixtureMarker
+  rmSync(fixtureReport, { force: true })
+  rmSync(fixtureInputObservation, { force: true })
+  const worktreeSelector = await resolveTestWorktreeSelector(testRepoPath, userDataDir)
+  const created = await callDevCli(
+    [
+      'terminal',
+      'create',
+      '--worktree',
+      worktreeSelector,
+      '--title',
+      'paired mobile prompt authority',
+      '--command',
+      `${fakeCodexCommand} --timeout-ms 60000`
+    ],
+    testRepoPath,
+    userDataDir
+  )
+  const terminal = created.terminal as { handle: string }
+  const shown = await callDevCli(
+    ['terminal', 'show', '--terminal', terminal.handle],
+    testRepoPath,
+    userDataDir
+  )
+  const ptyId = (shown.terminal as { ptyId: string }).ptyId
+  await expect
+    .poll(async () => {
+      const ready = await callDevCli(
+        ['terminal', 'show', '--terminal', terminal.handle],
+        testRepoPath,
+        userDataDir
+      )
+      return (ready.terminal as { preview?: string }).preview
+    })
+    .toContain('OpenAI Codex')
+
+  const pairingResult = await orcaPage.evaluate(() =>
+    window.api.mobile.getPairingQR({
+      address: '127.0.0.1',
+      connectionMode: 'local-only',
+      rotate: true
+    })
+  )
+  expect(pairingResult.available).toBe(true)
+  if (!pairingResult.available) {
+    throw new Error('Mobile pairing unavailable')
+  }
+  const pairing = parsePairingCode(pairingResult.pairingUrl)
+  expect(pairing).toBeTruthy()
+  if (!pairing) {
+    throw new Error('Mobile pairing URL did not parse')
+  }
+
+  const responses: Record<string, unknown>[] = []
+  const subscription = await subscribeRemoteRuntimeRequest(
+    pairing,
+    'terminal.subscribe',
+    {
+      terminal: terminal.handle,
+      client: { id: pairing.deviceToken, type: 'mobile' },
+      viewport: { cols: 45, rows: 20 },
+      capabilities: { terminalBinaryStream: 1 }
+    },
+    15_000,
+    {
+      onResponse: (response) => responses.push(response as unknown as Record<string, unknown>),
+      onError: (error) => {
+        throw error
+      }
+    }
+  )
+
+  try {
+    await expect
+      .poll(() =>
+        responses.some(
+          (response) => (response.result as { type?: string } | undefined)?.type === 'subscribed'
+        )
+      )
+      .toBe(true)
+    await expectTerminalDriver(orcaPage, ptyId, 'mobile')
+    await expect(
+      orcaPage.evaluate((id) => window.api.runtime.restoreTerminalFit(id), ptyId)
+    ).resolves.toEqual({ restored: true })
+    await expectTerminalDriver(orcaPage, ptyId, 'desktop')
+    const beforeSend = await callDevCli(
+      ['terminal', 'show', '--terminal', terminal.handle],
+      testRepoPath,
+      userDataDir
+    )
+    expect(beforeSend.terminal).toMatchObject({ connected: true, writable: true, ptyId })
+
+    const prompt = `${marker} paired owner payload`
+    let desktopSendOutcome: unknown
+    const desktopSend = callDevCli(
+      ['terminal', 'send', '--terminal', terminal.handle, '--text', prompt, '--enter'],
+      testRepoPath,
+      userDataDir
+    )
+    void desktopSend.then(
+      (value) => {
+        desktopSendOutcome = value
+      },
+      (error) => {
+        desktopSendOutcome = error
+      }
+    )
+    await expect
+      .poll(
+        () =>
+          readObservedInput(fixtureInputObservation).includes(marker) ||
+          desktopSendOutcome !== undefined
+      )
+      .toBe(true)
+    if (!readObservedInput(fixtureInputObservation).includes(marker)) {
+      const drivers = await orcaPage.evaluate(() => window.api.runtime.getTerminalDrivers())
+      throw new Error(
+        `Desktop send settled before paste: ${JSON.stringify(desktopSendOutcome)}; drivers=${JSON.stringify(drivers)}`
+      )
+    }
+
+    const mobileSend = await sendRemoteRuntimeRequest<{
+      send: { accepted: boolean; bytesWritten: number }
+    }>(
+      pairing,
+      'terminal.send',
+      {
+        terminal: terminal.handle,
+        text: 'mobile-owner-input',
+        client: { id: pairing.deviceToken, type: 'mobile' }
+      },
+      15_000
+    )
+    expect(mobileSend.ok).toBe(true)
+    if (!mobileSend.ok) {
+      throw new Error(mobileSend.error.message)
+    }
+    expect(mobileSend).toMatchObject({
+      ok: true,
+      result: { send: { accepted: true } }
+    })
+    await expectTerminalDriver(orcaPage, ptyId, 'mobile')
+
+    await expect(desktopSend).resolves.toMatchObject({
+      send: { accepted: false, bytesWritten: 0 }
+    })
+    const observedInput = readObservedInput(fixtureInputObservation)
+    expect(observedInput).toContain(marker)
+    expect(observedInput).toContain('mobile-owner-input')
+    expect(observedInput).not.toContain('\r')
+  } finally {
+    subscription.close()
+    await callDevCli(
+      ['terminal', 'close', '--terminal', terminal.handle],
+      testRepoPath,
+      userDataDir
+    )
+  }
+})
+
+async function resolveTestWorktreeSelector(
+  testRepoPath: string,
+  userDataDir: string
+): Promise<string> {
+  const added = await callDevCli(['repo', 'add', '--path', testRepoPath], testRepoPath, userDataDir)
+  const repoId = (added.repo as { id: string }).id
+  const deadline = Date.now() + 10_000
+  while (Date.now() < deadline) {
+    const listed = await callDevCli(
+      ['worktree', 'list', '--repo', `id:${repoId}`],
+      testRepoPath,
+      userDataDir
+    )
+    const worktree = (listed.worktrees as { id: string; path: string }[]).find(
+      (candidate) => path.resolve(candidate.path) === path.resolve(testRepoPath)
+    )
+    if (worktree) {
+      return `id:${worktree.id}`
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100))
+  }
+  throw new Error(`Test worktree did not materialize for ${repoId}`)
+}
+
+async function callDevCli(
+  args: string[],
+  cwd: string,
+  userDataDir: string
+): Promise<Record<string, unknown>> {
+  let result: { stdout: string; stderr: string }
+  try {
+    result = await execFileAsync(
+      process.execPath,
+      [path.join(process.cwd(), 'config', 'scripts', 'orca-dev.mjs'), ...args, '--json'],
+      {
+        cwd,
+        env: { ...process.env, ORCA_DEV_USER_DATA_PATH: userDataDir },
+        timeout: 60_000
+      }
+    )
+  } catch (error) {
+    const failed = error as Error & { stdout?: string; stderr?: string }
+    throw new Error([failed.message, failed.stdout, failed.stderr].filter(Boolean).join('\n'))
+  }
+  const response = JSON.parse(result.stdout) as {
+    ok: boolean
+    result?: Record<string, unknown>
+    error?: { message?: string }
+  }
+  if (!response.ok || !response.result) {
+    throw new Error(response.error?.message ?? 'Orca CLI request failed')
+  }
+  return response.result
+}
+
+async function expectTerminalDriver(
+  page: Page,
+  ptyId: string,
+  kind: 'desktop' | 'mobile'
+): Promise<void> {
+  await expect
+    .poll(async () => {
+      const drivers = await page.evaluate(() => window.api.runtime.getTerminalDrivers())
+      return drivers.find((entry) => entry.ptyId === ptyId)?.driver.kind
+    })
+    .toBe(kind)
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`
+}
+
+function readObservedInput(filePath: string): string {
+  try {
+    return readFileSync(filePath, 'utf8')
+  } catch {
+    return ''
+  }
+}

--- a/tests/tools/repro-terminal-send-submit.mjs
+++ b/tests/tools/repro-terminal-send-submit.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { spawn } from 'node:child_process'
+import { appendFileSync } from 'node:fs'
 import { mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
@@ -280,6 +281,7 @@ async function parentMain() {
 async function fakeAgentMain() {
   const reportPath = argValue('report')
   const marker = argValue('marker')
+  const inputObservationPath = argValue('input-observation')
   const timeoutMs = parsePositiveInteger('timeout-ms', DEFAULT_TIMEOUT_MS)
   const pasteFramingRequired = !hasFlag('allow-unframed-paste')
   const swallowFirstEnter = hasFlag('swallow-first-enter')
@@ -339,6 +341,9 @@ async function fakeAgentMain() {
     setTimeout(() => void writeReport(false), 250)
   }
   process.stdin.on('data', (chunk) => {
+    if (inputObservationPath) {
+      appendFileSync(inputObservationPath, chunk)
+    }
     input += chunk.toString('utf8')
     if (!renderScheduled && input.includes(marker)) {
       renderScheduled = true
@@ -370,6 +375,7 @@ async function fakeAgentMain() {
         return
       }
       prematureEnters += 1
+      void writeReport(false)
       nextCarriage = input.indexOf('\r', countedCarriages)
     }
   })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1093 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​21 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1072 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​287 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​80 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​207 |

<!-- /orca-pr-loc -->

## Summary

Preserve the settled Claude/Codex prompt-delivery contract across transient foreground wrappers, stale launch identity, paired-mobile floor changes, and foreground loss during submission.

This is one cohesive change because all three failures cross the same settled-prompt authority boundary, while each ticket keeps a separate falsifiable invariant and oracle.

## Ticket decisions

- [STA-4486](https://linear.app/stably/issue/STA-4486): reuse the bounded foreground-wrapper resolver inside the PTY/generation submission queue. Wrapper and process inspection are request-cancellable; concurrent sends cannot overlap classification, and a wrapper/target that becomes unverifiable refuses instead of falling through to legacy Enter.
- [STA-4487](https://linear.app/stably/issue/STA-4487): carry the freshly proven Claude/Codex identity request-locally into the render gate. It outranks stale launch identity for that send only; direct orchestration callers retain main's launch-first behavior and no historical foreground identity is persisted.
- [STA-4488](https://linear.app/stably/issue/STA-4488): recheck exact handle-to-PTY binding and desktop floor authority synchronously beside every paste/suffix PTY write. Foreground identity is rechecked after the pre-write guard and before delayed Enter.

PR #14962's lifecycle acknowledgment, permission checks, one-Enter verification, generation fencing, cancellation, and serialization remain intact.

## Deterministic evidence

The same controlled-promise/fake-time ticket oracles were run on the affected main behavior, the candidate, and the candidate with only the claimed production fixes disabled:

- STA-4486: red → green → red. Main returned `false` after transient `node` foreground instead of settling once it became Codex.
- STA-4487: red → green → red. Main sent Enter at the legacy delay before the Codex render marker when stale launch identity named a non-target.
- STA-4488: red → green → red. Main sent Enter after paired mobile took the floor between paste and suffix.

The original red baseline was `4b2ed5ddd470fc69cf836d840748afae0908eeb4`. The branch is rebased on `c92f394cde2612e0a913bf447e94ab1f0b0f9789`; intervening main changes left the affected production and oracle files byte-identical.

Reviewer-driven adversarial oracles also prove that target→shell transition, unavailable inspection, cancellation during a hung read, and process loss before delayed Enter cannot write or authorize legacy fallback. These exact tests were 4/4 red on the prior pushed candidate before `a5116e485e`, then green after the authority fix. A fresh-confirmation oracle was red on `a5116e485e`: cache-backed Codex evidence wrote the full paste plus Enter while the provider reported fresh `zsh`; `a2082fcda8` now prefers fresh confirmation, with SSH mapped to its existing relay foreground request.

Negative assertions cover no premature or cross-owner Enter, no duplicate input, no unsafe legacy fallback, exact PTY generation/binding, bounded provider retries, and survival of unrelated terminals.

## Real topology evidence

- Paired desktop/mobile: isolated fake-Codex PTY plus genuine encrypted mobile pairing. The test proves mobile → desktop restore, mobile floor takeover, desktop `{ accepted: false, bytesWritten: 0 }`, and the exact/only PTY byte stream: one bracketed prompt frame followed by mobile stdin, with no carriage return. All four Electron journeys passed in 38.7s on the final head.
- Docker SSH/relay: ephemeral Debian SSH host plus real relay, fake Codex PTY, and unrelated PTY. Two controlled half-open `ps` barriers force transient-wrapper inspection; candidate stays within the observed retry budget, writes exactly one complete bracketed frame plus one post-render Enter and no other bytes, uses fresh SSH confirmation over the existing relay request, stays on the SSH execution host, bounds close cleanup, removes the target unconditionally, and leaves the unrelated PTY writable. Candidate passed in 34.1s on the final head; disabling settled-wrapper delivery makes the byte-identical oracle fail before the retry barrier.

## Validation

- `pnpm install --frozen-lockfile`
- focused reliability gate: 6 files, 1,264 passed, 1 existing skip (10.8s)
- original ticket candidate/revert/candidate: green → red → green
- reviewer authority oracle before/after: 4/4 red → 4/4 green
- paired/local Electron: 4/4 passed (35.2s)
- Docker SSH/relay: 1/1 passed (37.2s)
- `pnpm run typecheck:node`
- changed-code quality + React Doctor
- `pnpm run check:max-lines-ratchet`
- `pnpm run check:reliability-gates`
- changed-file `oxlint` and `oxfmt --check`
- `git diff --check`
- relay build

Known gaps: live daemon and paired remote-Orca-server topologies were not run; genuine paired mobile against the local owning runtime and real SSH/relay are covered. An aborted request releases immediately with zero writes, while an already-started provider inspection may finish under its existing transport bound. No wire shape, capability, new retry, session listing, or global fanout was added.

## Review state

Draft. Three independent initial and second-pass reviews produced actionable authority, cancellation, cleanup, and exact-oracle findings; all reproducible findings are addressed in the pushed head. Three fresh final reviews completed. Correctness found no issues; topology findings tightened exact SSH bytes, the fake-time retry ceiling, and reproducible red/green recording; performance found the stale-cache/fresh-confirmation defect, which reproduced red and is fixed. The transport-latency claim was rejected because completed provider-read time already advances the retry window; only one in-flight read may consume its existing transport timeout, and request cancellation releases immediately. Final-head CI is fully green, including Windows packaging, Git and cross-version wire compatibility, static analysis, typecheck, and all Node 24/26 shards. No CodeRabbit or human comments were present at the final audit. The PR remains draft for human review; do not merge yet.


