### PR TITLE
fix(terminal): fence I/O by process incarnation

### DIFF
--- a/src/cli/handlers/terminal.ts
+++ b/src/cli/handlers/terminal.ts
@@ -8,8 +8,10 @@ import type {
   RuntimeTerminalSend,
   RuntimeTerminalShow,
   RuntimeTerminalSplit,
-  RuntimeTerminalWait
+  RuntimeTerminalWait,
+  RuntimeStatus
 } from '../../shared/runtime-types'
+import { TERMINAL_READ_INCARNATION_FENCE_RUNTIME_CAPABILITY } from '../../shared/protocol-version'
 import type { CommandHandler } from '../dispatch'
 import { shouldUseRendererBackedInteractiveTerminal } from '../codex-command-classification'
 import {
@@ -68,6 +70,14 @@ export const TERMINAL_HANDLERS: Record<string, CommandHandler> = {
     printResult(result, json, formatTerminalShow)
   },
   'terminal read': async ({ flags, client, cwd, json }) => {
+    const expectedIncarnationId = getOptionalStringFlag(flags, 'expected-incarnation-id')
+    let capabilityRuntimeId: string | undefined
+    if (flags.has('expected-incarnation-id') && expectedIncarnationId === undefined) {
+      throw new RuntimeClientError(
+        'invalid_argument',
+        '--expected-incarnation-id must not be empty'
+      )
+    }
     const cursorFlag = getOptionalStringFlag(flags, 'cursor')
     const cursor =
       cursorFlag !== undefined && /^\d+$/.test(cursorFlag)
@@ -85,8 +95,26 @@ export const TERMINAL_HANDLERS: Record<string, CommandHandler> = {
         '--screen reads the current rendered screen, which has no cursor to page from. Use --cursor without --screen to page through accumulated output.'
       )
     }
+    if (expectedIncarnationId !== undefined) {
+      const status = await client.call<RuntimeStatus>('status.get')
+      if (
+        !status.result.capabilities?.includes(TERMINAL_READ_INCARNATION_FENCE_RUNTIME_CAPABILITY)
+      ) {
+        throw new RuntimeClientError(
+          'incompatible_runtime',
+          'The connected Orca runtime cannot safely fence terminal reads by process incarnation.'
+        )
+      }
+      const statusRuntimeId = status._meta?.runtimeId
+      if (typeof statusRuntimeId !== 'string' || statusRuntimeId.length === 0) {
+        throw new RuntimeClientError('terminal_handle_stale', 'terminal_handle_stale')
+      }
+      capabilityRuntimeId = statusRuntimeId
+    }
+    const terminalHandle = await getTerminalHandle(flags, cwd, client)
     const result = await client.call<{ terminal: RuntimeTerminalRead }>('terminal.read', {
-      terminal: await getTerminalHandle(flags, cwd, client),
+      terminal: terminalHandle,
+      ...(expectedIncarnationId !== undefined ? { expectedIncarnationId } : {}),
       ...(cursor !== undefined ? { cursor } : {}),
       ...(screen ? { screen: true } : {}),
       limit: getOptionalPositiveIntegerFlag(flags, 'limit')
@@ -99,6 +127,16 @@ export const TERMINAL_HANDLERS: Record<string, CommandHandler> = {
         'incompatible_runtime',
         'This Orca host does not support --screen reads, so it answered with accumulated output instead of the rendered screen. Update Orca on the host, or drop --screen to read accumulated output deliberately.'
       )
+    }
+    if (
+      expectedIncarnationId !== undefined &&
+      (result._meta?.runtimeId !== capabilityRuntimeId ||
+        result.result.terminal.handle !== terminalHandle ||
+        result.result.terminal.incarnationId !== expectedIncarnationId ||
+        typeof result.result.terminal.worktreeId !== 'string' ||
+        result.result.terminal.worktreeId.length === 0)
+    ) {
+      throw new RuntimeClientError('terminal_handle_stale', 'terminal_handle_stale')
     }
     printResult(result, json, formatTerminalRead)
   },

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -245,7 +245,7 @@ Common Commands:
   orca file open-changed [--mode edit|diff|both] [--worktree <selector>] [--json]
   orca terminal list [--worktree <selector>] [--limit <n>] [--include-visual-layouts] [--json]
   orca terminal show [--terminal <handle>] [--json]
-  orca terminal read [--terminal <handle>] [--cursor <n>] [--limit <n>] [--json]
+  orca terminal read [--terminal <handle>] [--expected-incarnation-id <id>] [--cursor <n>] [--limit <n>] [--screen] [--json]
   orca terminal send [--terminal <handle>] [--text <text>] [--enter] [--interrupt] [--json]
   orca terminal wait [--terminal <handle>] --for exit|tui-idle [--timeout-ms <ms>] [--json]
   orca terminal stop --worktree <selector> [--json]

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -1,6 +1,7 @@
 import type { CommandSpec } from '../args'
 import { GLOBAL_FLAGS } from '../args'
 import { SERVE_COMMAND_SPECS } from './serve'
+import { TERMINAL_READ_COMMAND_SPEC } from './terminal-read'
 
 export const CORE_COMMAND_SPECS: CommandSpec[] = [
   {
@@ -194,28 +195,7 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
     usage: 'orca terminal show [--terminal <handle>] [--json]',
     allowedFlags: [...GLOBAL_FLAGS, 'terminal']
   },
-  {
-    path: ['terminal', 'read'],
-    summary: 'Read bounded terminal output',
-    usage:
-      'orca terminal read [--terminal <handle>] [--cursor <n>] [--limit <n>] [--screen] [--json]',
-    allowedFlags: [...GLOBAL_FLAGS, 'terminal', 'cursor', 'limit', 'screen'],
-    notes: [
-      'Omit --terminal to target the active terminal in the current worktree.',
-      'By default this returns accumulated terminal output with escape sequences stripped, not the rendered screen. Any program that repaints a line — shells, progress bars, TUIs — comes back as stacked fragments, so one `clear` keystroke by keystroke reads as `cclclecleaclear`, and spaces a prompt draws by moving the cursor are absent.',
-      'Use --screen to read what the terminal actually renders. Prefer it whenever the answer depends on how output looks rather than what was emitted over time; the default is unsuitable for verifying rendered output.',
-      'The result reports source: stream when it is accumulated output, screen when it is the rendered screen, and screen-unavailable when a screen was asked for but none could be rendered and the accumulated output is being returned instead. An absent source means the host predates the field.',
-      '--screen and --cursor are mutually exclusive: a screen read is the current frame and has no history to page.',
-      'Use --cursor with the nextCursor value from a previous read to get only new output since that read.',
-      'Use --limit to request more retained lines for long agent responses; output reports oldestCursor when older lines were dropped.',
-      'Useful for capturing the response to a command: read before sending, then read --cursor <prev> after waiting.'
-    ],
-    examples: [
-      'orca terminal read --json',
-      'orca terminal read --terminal term_abc123 --cursor 42 --limit 1000 --json',
-      'orca terminal read --terminal term_abc123 --screen --json'
-    ]
-  },
+  TERMINAL_READ_COMMAND_SPEC,
   {
     path: ['terminal', 'send'],
     summary: 'Send input to a live terminal',

--- a/src/cli/specs/terminal-read.ts
+++ b/src/cli/specs/terminal-read.ts
@@ -1,0 +1,33 @@
+import type { CommandSpec } from '../args'
+import { GLOBAL_FLAGS } from '../args'
+
+export const TERMINAL_READ_COMMAND_SPEC: CommandSpec = {
+  path: ['terminal', 'read'],
+  summary: 'Read bounded terminal output',
+  usage:
+    'orca terminal read [--terminal <handle>] [--expected-incarnation-id <id>] [--cursor <n>] [--limit <n>] [--screen] [--json]',
+  allowedFlags: [
+    ...GLOBAL_FLAGS,
+    'terminal',
+    'expected-incarnation-id',
+    'cursor',
+    'limit',
+    'screen'
+  ],
+  notes: [
+    'Omit --terminal to target the active terminal in the current worktree.',
+    'By default this returns accumulated terminal output with escape sequences stripped, not the rendered screen. Any program that repaints a line — shells, progress bars, TUIs — comes back as stacked fragments, so one `clear` keystroke by keystroke reads as `cclclecleaclear`, and spaces a prompt draws by moving the cursor are absent.',
+    'Use --screen to read what the terminal actually renders. Prefer it whenever the answer depends on how output looks rather than what was emitted over time; the default is unsuitable for verifying rendered output.',
+    'The result reports source: stream when it is accumulated output, screen when it is the rendered screen, and screen-unavailable when a screen was asked for but none could be rendered and the accumulated output is being returned instead. An absent source means the host predates the field.',
+    '--screen and --cursor are mutually exclusive: a screen read is the current frame and has no history to page.',
+    'Use --cursor with the nextCursor value from a previous read to get only new output since that read.',
+    'Use --expected-incarnation-id with terminal list/show identity when output must belong to that exact process.',
+    'Use --limit to request more retained lines for long agent responses; output reports oldestCursor when older lines were dropped.',
+    'Useful for capturing the response to a command: read before sending, then read --cursor <prev> after waiting.'
+  ],
+  examples: [
+    'orca terminal read --json',
+    'orca terminal read --terminal term_abc123 --cursor 42 --limit 1000 --json',
+    'orca terminal read --terminal term_abc123 --screen --json'
+  ]
+}

--- a/src/cli/terminal-read-incarnation-fence.test.ts
+++ b/src/cli/terminal-read-incarnation-fence.test.ts
@@ -1,0 +1,283 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  callMock,
+  runtimeClientConstructorMock,
+  serveOrcaAppMock,
+  getDefaultUserDataPathMock,
+  addEnvironmentFromPairingCodeMock,
+  listEnvironmentsMock,
+  spawnMock
+} = vi.hoisted(() => ({
+  callMock: vi.fn(),
+  runtimeClientConstructorMock: vi.fn(),
+  serveOrcaAppMock: vi.fn(),
+  getDefaultUserDataPathMock: vi.fn(() => '/tmp/orca-user-data'),
+  addEnvironmentFromPairingCodeMock: vi.fn(),
+  listEnvironmentsMock: vi.fn(),
+  spawnMock: vi.fn()
+}))
+
+vi.mock('./runtime-client', async () => {
+  const { createRuntimeClientModuleMock } = await import('./index-test-harness.js')
+  return createRuntimeClientModuleMock({
+    callMock,
+    runtimeClientConstructorMock,
+    serveOrcaAppMock,
+    getDefaultUserDataPathMock
+  })
+})
+
+vi.mock('./runtime/environments', () => ({
+  addEnvironmentFromPairingCode: addEnvironmentFromPairingCodeMock,
+  listEnvironments: listEnvironmentsMock,
+  removeEnvironment: vi.fn(),
+  resolveEnvironment: vi.fn()
+}))
+
+vi.mock('child_process', async () => {
+  const { createChildProcessModuleMock } = await import('./index-test-harness.js')
+  return createChildProcessModuleMock(spawnMock)
+})
+
+import { main } from './index'
+import { useWorktreeAwarenessEnvironment } from './index-test-harness'
+import { okFixture, queueFixtures } from './test-fixtures'
+import { TERMINAL_READ_INCARNATION_FENCE_RUNTIME_CAPABILITY } from '../shared/protocol-version'
+
+function guardedStatusFixture() {
+  return okFixture('status', {
+    capabilities: [TERMINAL_READ_INCARNATION_FENCE_RUNTIME_CAPABILITY]
+  })
+}
+
+describe('orca terminal read incarnation fence', () => {
+  let priorExitCode: typeof process.exitCode
+
+  useWorktreeAwarenessEnvironment({
+    callMock,
+    serveOrcaAppMock,
+    getDefaultUserDataPathMock,
+    addEnvironmentFromPairingCodeMock,
+    listEnvironmentsMock,
+    spawnMock
+  })
+
+  beforeEach(() => {
+    priorExitCode = process.exitCode
+    process.exitCode = 0
+  })
+
+  afterEach(() => {
+    process.exitCode = priorExitCode
+  })
+
+  it('negotiates the capability and sends the exact guarded read identity', async () => {
+    queueFixtures(
+      callMock,
+      guardedStatusFixture(),
+      okFixture('read', {
+        terminal: {
+          handle: 'term_worker',
+          incarnationId: 'inc-worker',
+          worktreeId: 'repo::/tmp/worktree',
+          status: 'running',
+          tail: [],
+          truncated: false,
+          nextCursor: '42'
+        }
+      })
+    )
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(
+      [
+        'terminal',
+        'read',
+        '--terminal',
+        'term_worker',
+        '--expected-incarnation-id',
+        'inc-worker',
+        '--cursor',
+        '42',
+        '--limit',
+        '100',
+        '--json'
+      ],
+      '/tmp/repo'
+    )
+
+    expect(callMock).toHaveBeenNthCalledWith(1, 'status.get')
+    expect(callMock).toHaveBeenNthCalledWith(2, 'terminal.read', {
+      terminal: 'term_worker',
+      expectedIncarnationId: 'inc-worker',
+      cursor: 42,
+      limit: 100
+    })
+    expect(process.exitCode).toBe(0)
+  })
+
+  it('does not read from a runtime without the fence capability', async () => {
+    queueFixtures(callMock, okFixture('status', { capabilities: [] }))
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await main(
+      [
+        'terminal',
+        'read',
+        '--terminal',
+        'term_worker',
+        '--expected-incarnation-id',
+        'inc-worker',
+        '--json'
+      ],
+      '/tmp/repo'
+    )
+
+    expect(callMock).toHaveBeenCalledTimes(1)
+    expect(callMock).toHaveBeenCalledWith('status.get')
+    expect([...logSpy.mock.calls, ...errorSpy.mock.calls].flat().join('\n')).toContain(
+      'incompatible_runtime'
+    )
+    expect(process.exitCode).toBe(1)
+  })
+
+  it('does not read when capability status lacks a runtime identity', async () => {
+    const malformedStatus = guardedStatusFixture()
+    Reflect.deleteProperty(malformedStatus, '_meta')
+    callMock.mockResolvedValueOnce(malformedStatus)
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await main(
+      [
+        'terminal',
+        'read',
+        '--terminal',
+        'term_worker',
+        '--expected-incarnation-id',
+        'inc-worker',
+        '--json'
+      ],
+      '/tmp/repo'
+    )
+
+    expect(callMock).toHaveBeenCalledTimes(1)
+    expect(callMock).toHaveBeenCalledWith('status.get')
+    expect([...logSpy.mock.calls, ...errorSpy.mock.calls].flat().join('\n')).toContain(
+      'terminal_handle_stale'
+    )
+    expect(process.exitCode).toBe(1)
+  })
+
+  it('rejects an explicitly empty incarnation fence before RPC', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await main(
+      ['terminal', 'read', '--terminal', 'term_worker', '--expected-incarnation-id', '', '--json'],
+      '/tmp/repo'
+    )
+
+    expect(callMock).not.toHaveBeenCalled()
+    expect([...logSpy.mock.calls, ...errorSpy.mock.calls].flat().join('\n')).toContain(
+      '--expected-incarnation-id must not be empty'
+    )
+    expect(process.exitCode).toBe(1)
+  })
+
+  it('rejects a guarded response without runtime metadata before printing output', async () => {
+    const responseFixture = okFixture('read', {
+      terminal: {
+        handle: 'term_worker',
+        incarnationId: 'inc-worker',
+        worktreeId: 'repo::/wt',
+        status: 'running',
+        tail: ['must-not-print'],
+        truncated: false,
+        nextCursor: null
+      }
+    })
+    Reflect.deleteProperty(responseFixture, '_meta')
+    queueFixtures(callMock, guardedStatusFixture(), responseFixture)
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await main(
+      [
+        'terminal',
+        'read',
+        '--terminal',
+        'term_worker',
+        '--expected-incarnation-id',
+        'inc-worker',
+        '--json'
+      ],
+      '/tmp/repo'
+    )
+
+    const output = [...logSpy.mock.calls, ...errorSpy.mock.calls].flat().join('\n')
+    expect(callMock).toHaveBeenCalledTimes(2)
+    expect(output).toContain('terminal_handle_stale')
+    expect(output).not.toContain('must-not-print')
+    expect(process.exitCode).toBe(1)
+  })
+
+  it.each([
+    ['runtime mismatch', true, { incarnationId: 'inc-worker', worktreeId: 'repo::/wt' }],
+    ['missing incarnation', false, { worktreeId: 'repo::/wt' }],
+    ['missing worktree', false, { incarnationId: 'inc-worker' }],
+    [
+      'handle mismatch',
+      false,
+      {
+        handle: 'term_replacement',
+        incarnationId: 'inc-worker',
+        worktreeId: 'repo::/wt'
+      }
+    ],
+    ['identity mismatch', false, { incarnationId: 'inc-replacement', worktreeId: 'repo::/wt' }]
+  ])('rejects a guarded response with %s', async (_name, runtimeMismatch, responseIdentity) => {
+    const statusFixture = guardedStatusFixture()
+    const responseFixture = okFixture('read', {
+      terminal: {
+        handle: 'term_worker',
+        ...responseIdentity,
+        status: 'running',
+        tail: ['must-not-print'],
+        truncated: false,
+        nextCursor: null
+      }
+    })
+    responseFixture._meta.runtimeId = runtimeMismatch
+      ? `${statusFixture._meta.runtimeId}-replacement`
+      : statusFixture._meta.runtimeId
+    queueFixtures(callMock, statusFixture, responseFixture)
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await main(
+      [
+        'terminal',
+        'read',
+        '--terminal',
+        'term_worker',
+        '--expected-incarnation-id',
+        'inc-worker',
+        '--json'
+      ],
+      '/tmp/repo'
+    )
+
+    const output = [...logSpy.mock.calls, ...errorSpy.mock.calls].flat().join('\n')
+    expect(callMock).toHaveBeenNthCalledWith(1, 'status.get')
+    expect(callMock).toHaveBeenNthCalledWith(2, 'terminal.read', {
+      terminal: 'term_worker',
+      expectedIncarnationId: 'inc-worker'
+    })
+    expect(output).toContain('terminal_handle_stale')
+    expect(output).not.toContain('must-not-print')
+    expect(process.exitCode).toBe(1)
+  })
+})

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -11494,6 +11494,202 @@ describe('OrcaRuntimeService', () => {
     expect(cwds.get('pty-debian')).toBe('\\\\wsl.localhost\\Debian\\home\\me\\repo')
   })
 
+  it('keeps an initial preallocated handle when execution context precedes the first PTY record', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    const ptyId = `${TEST_WORKTREE_ID}@@prepared-first-spawn`
+    const handle = runtime.preAllocateHandleForPty(ptyId)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+
+    // A preview installs an async fence generation, but does not prove that a
+    // process lifecycle already existed.
+    await expect(runtime.writeTerminalPreviewInput(ptyId, 'probe')).resolves.toBe(true)
+
+    runtime.preparePtyExecutionContext(ptyId, null, { resetIncarnation: true })
+    runtime.onPtyData(ptyId, 'first prepared process output\n', 100)
+    runtime.onPtySpawned(ptyId)
+    syncSinglePty(runtime, ptyId)
+    runtime.registerPty(ptyId, TEST_WORKTREE_ID, null, {
+      tabId: 'tab-1',
+      leafId: 'pane:1',
+      incarnationId: 'inc-first'
+    })
+
+    expect((await runtime.listTerminals()).terminals[0]?.handle).toBe(handle)
+    await expect(
+      runtime.readTerminal(handle, { expectedIncarnationId: 'inc-first' })
+    ).resolves.toMatchObject({
+      incarnationId: 'inc-first',
+      tail: ['first prepared process output']
+    })
+  })
+
+  it.each([
+    { label: 'known', nextIncarnation: 'inc-next' },
+    { label: 'unknown', nextIncarnation: undefined }
+  ])(
+    'clears late prior-process bytes at a prepared $label replacement spawn',
+    async ({ nextIncarnation }) => {
+      const runtime = new OrcaRuntimeService(store)
+      syncSinglePty(runtime)
+      runtime.registerPty('pty-1', TEST_WORKTREE_ID, null, {
+        tabId: 'tab-1',
+        leafId: 'pane:1',
+        incarnationId: 'inc-old'
+      })
+      const [oldTerminal] = (await runtime.listTerminals()).terminals
+
+      runtime.preparePtyExecutionContext('pty-1', null, { resetIncarnation: true })
+      const [preparedTerminal] = (await runtime.listTerminals()).terminals
+      runtime.onPtyData('pty-1', 'late prior-process output\n', 100)
+      runtime.onPtySpawned('pty-1', nextIncarnation)
+      runtime.registerPty(
+        'pty-1',
+        TEST_WORKTREE_ID,
+        null,
+        nextIncarnation
+          ? { tabId: 'tab-1', leafId: 'pane:1', incarnationId: nextIncarnation }
+          : undefined
+      )
+
+      const [replacement] = (await runtime.listTerminals()).terminals
+      expect(replacement.handle).not.toBe(oldTerminal.handle)
+      expect(replacement.handle).not.toBe(preparedTerminal.handle)
+      await expect(runtime.readTerminal(oldTerminal.handle)).rejects.toThrow(
+        'terminal_handle_stale'
+      )
+      await expect(runtime.readTerminal(preparedTerminal.handle)).rejects.toThrow(
+        'terminal_handle_stale'
+      )
+      const read = await runtime.readTerminal(
+        replacement.handle,
+        nextIncarnation ? { expectedIncarnationId: nextIncarnation } : undefined
+      )
+      expect(read.tail).toEqual([])
+      expect(read.tail.join('\n')).not.toContain('late prior-process output')
+    }
+  )
+
+  it.each([
+    { label: 'known', nextIncarnation: 'inc-next' },
+    { label: 'unknown', nextIncarnation: undefined }
+  ])(
+    'clears late graph-observed bytes at a prepared $label replacement spawn',
+    async ({ nextIncarnation }) => {
+      const runtime = new OrcaRuntimeService(store)
+      syncSinglePty(runtime)
+      const [observedTerminal] = (await runtime.listTerminals()).terminals
+      runtime.onPtyData('pty-1', 'observed prior-process output\n', 99)
+
+      runtime.preparePtyExecutionContext('pty-1', null, { resetIncarnation: true })
+      const [preparedTerminal] = (await runtime.listTerminals()).terminals
+      runtime.onPtyData('pty-1', 'late prior-process output\n', 100)
+      runtime.onPtySpawned('pty-1', nextIncarnation)
+      runtime.registerPty(
+        'pty-1',
+        TEST_WORKTREE_ID,
+        null,
+        nextIncarnation
+          ? { tabId: 'tab-1', leafId: 'pane:1', incarnationId: nextIncarnation }
+          : undefined
+      )
+
+      const [replacement] = (await runtime.listTerminals()).terminals
+      expect(replacement.handle).not.toBe(observedTerminal.handle)
+      expect(replacement.handle).not.toBe(preparedTerminal.handle)
+      await expect(runtime.readTerminal(observedTerminal.handle)).rejects.toThrow(
+        'terminal_handle_stale'
+      )
+      await expect(runtime.readTerminal(preparedTerminal.handle)).rejects.toThrow(
+        'terminal_handle_stale'
+      )
+      const read = await runtime.readTerminal(
+        replacement.handle,
+        nextIncarnation ? { expectedIncarnationId: nextIncarnation } : undefined
+      )
+      expect(read.tail).toEqual([])
+      expect(read.tail.join('\n')).not.toContain('prior-process output')
+    }
+  )
+
+  it.each([
+    { label: 'known', nextIncarnation: 'inc-next' },
+    { label: 'unknown', nextIncarnation: undefined }
+  ])(
+    'clears late recordless screen bytes at a prepared $label replacement spawn',
+    async ({ nextIncarnation }) => {
+      const runtime = new OrcaRuntimeService(store)
+      const ptyId = 'controller-only'
+      runtime.preparePtyExecutionContext(ptyId, null, { resetIncarnation: true })
+      runtime.onPtySpawned(ptyId, undefined, { awaitsRegistration: false })
+
+      runtime.preparePtyExecutionContext(ptyId, null, { resetIncarnation: true })
+      const preparedHandle = runtime.preAllocateHandleForPty(ptyId)
+      runtime.onPtyData(ptyId, '\x1b[?1049hLate prior-process screen\r\n', 100)
+      runtime.onPtySpawned(ptyId, nextIncarnation)
+      runtime.registerPty(
+        ptyId,
+        TEST_WORKTREE_ID,
+        null,
+        nextIncarnation
+          ? { tabId: 'tab-1', leafId: 'pane:1', incarnationId: nextIncarnation }
+          : undefined
+      )
+
+      const [replacement] = (await runtime.listTerminals()).terminals
+      expect(replacement.handle).not.toBe(preparedHandle)
+      await expect(runtime.readTerminal(preparedHandle)).rejects.toThrow()
+      const read = await runtime.readTerminal(replacement.handle, {
+        screen: true,
+        ...(nextIncarnation ? { expectedIncarnationId: nextIncarnation } : {})
+      })
+      expect(read.tail).toEqual([])
+      expect(read.tail.join('\n')).not.toContain('Late prior-process screen')
+    }
+  )
+
+  it('retires pristine null-incarnation handles at an explicit execution lifecycle reset', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    const handle = runtime.preAllocateHandleForPty('pty-1')
+    syncSinglePty(runtime)
+    expect((await runtime.listTerminals()).terminals[0]?.handle).toBe(handle)
+
+    runtime.preparePtyExecutionContext('pty-1', null, { resetIncarnation: true })
+
+    const [replacement] = (await runtime.listTerminals()).terminals
+    expect(replacement.handle).not.toBe(handle)
+    await expect(runtime.readTerminal(handle)).rejects.toThrow('terminal_handle_stale')
+  })
+
+  it('clears known incarnation authority and output at an explicit execution lifecycle reset', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    syncSinglePty(runtime)
+    runtime.registerPty('pty-1', TEST_WORKTREE_ID, null, {
+      tabId: 'tab-1',
+      leafId: 'pane:1',
+      incarnationId: 'inc-old'
+    })
+    const [original] = (await runtime.listTerminals()).terminals
+    runtime.onPtyData('pty-1', 'old-lifecycle-line\n', 100)
+
+    runtime.preparePtyExecutionContext('pty-1', null, { resetIncarnation: true })
+
+    const [replacement] = (await runtime.listTerminals()).terminals
+    expect(replacement.handle).not.toBe(original.handle)
+    await expect(
+      runtime.readTerminal(original.handle, { expectedIncarnationId: 'inc-old' })
+    ).rejects.toThrow('terminal_handle_stale')
+    await expect(
+      runtime.readTerminal(replacement.handle, { expectedIncarnationId: 'inc-old' })
+    ).rejects.toThrow('terminal_handle_stale')
+    const read = await runtime.readTerminal(replacement.handle)
+    expect(read.tail).toEqual([])
+    expect(read).not.toHaveProperty('incarnationId')
+  })
+
   it('does not retain WSL context when a PTY id is reused', () => {
     setPlatform('win32')
     const runtime = new OrcaRuntimeService(store)
@@ -17266,6 +17462,234 @@ describe('OrcaRuntimeService', () => {
     expect(writes).toEqual(['x'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES), 'tail'])
   })
 
+  it('stops a multi-chunk terminal.send when the admitted incarnation is replaced', async () => {
+    const writes: string[] = []
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      write: (_ptyId, data) => {
+        writes.push(data)
+        return true
+      },
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, { tabs: [], leaves: [] })
+    runtime.registerPty('pty-owned', TEST_WORKTREE_ID, null, {
+      tabId: 'tab-1',
+      leafId: 'pane:1',
+      incarnationId: 'inc-a'
+    })
+    const [terminal] = (await runtime.listTerminals()).terminals
+    const text = `${'x'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES)}tail`
+
+    await expect(
+      runtime.sendTerminal(
+        terminal.handle,
+        { text },
+        {
+          afterWrite: () => {
+            runtime.registerPty('pty-owned', TEST_WORKTREE_ID, null, {
+              tabId: 'tab-1',
+              leafId: 'pane:1',
+              incarnationId: 'inc-b'
+            })
+          }
+        }
+      )
+    ).rejects.toThrow('terminal_handle_stale')
+    expect(writes).toEqual(['x'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES)])
+  })
+
+  it('stops an in-flight send at a pristine null-to-null spawn boundary', async () => {
+    const writes: string[] = []
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      write: (_ptyId, data) => {
+        writes.push(data)
+        return true
+      },
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    syncSinglePty(runtime)
+    const [terminal] = (await runtime.listTerminals()).terminals
+    const text = `${'x'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES)}tail`
+
+    await expect(
+      runtime.sendTerminal(
+        terminal.handle,
+        { text },
+        {
+          afterWrite: () => {
+            runtime.onPtySpawned('pty-1', undefined, { awaitsRegistration: false })
+          }
+        }
+      )
+    ).rejects.toThrow('terminal_handle_stale')
+    expect(writes).toEqual(['x'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES)])
+  })
+
+  it('does not write a terminal.send suffix after the admitted incarnation is replaced', async () => {
+    vi.useFakeTimers()
+    try {
+      const writes: string[] = []
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        write: (_ptyId, data) => {
+          writes.push(data)
+          if (data === 'notes') {
+            setTimeout(() => {
+              runtime.registerPty('pty-owned', TEST_WORKTREE_ID, null, {
+                tabId: 'tab-1',
+                leafId: 'pane:1',
+                incarnationId: 'inc-b'
+              })
+            }, 250)
+          }
+          return true
+        },
+        kill: () => true,
+        getForegroundProcess: async () => null
+      })
+      runtime.attachWindow(1)
+      runtime.syncWindowGraph(1, { tabs: [], leaves: [] })
+      runtime.registerPty('pty-owned', TEST_WORKTREE_ID, null, {
+        tabId: 'tab-1',
+        leafId: 'pane:1',
+        incarnationId: 'inc-a'
+      })
+      const [terminal] = (await runtime.listTerminals()).terminals
+
+      const sendPromise = runtime.sendTerminal(terminal.handle, { text: 'notes', enter: true })
+      const rejection = expect(sendPromise).rejects.toThrow('terminal_handle_stale')
+      await vi.runAllTimersAsync()
+
+      await rejection
+      expect(writes).toEqual(['notes'])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('stops preview input when the PTY lifecycle changes between chunks', async () => {
+    vi.useFakeTimers()
+    try {
+      const writes: string[] = []
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        write: (_ptyId, data) => {
+          writes.push(data)
+          if (writes.length === 1) {
+            setTimeout(() => {
+              runtime.preparePtyExecutionContext('pty-1', null, {
+                resetIncarnation: true
+              })
+            }, 0)
+          }
+          return true
+        },
+        kill: () => true,
+        getForegroundProcess: async () => null
+      })
+      syncSinglePty(runtime)
+      runtime.registerPty('pty-1', TEST_WORKTREE_ID, null, {
+        tabId: 'tab-1',
+        leafId: 'pane:1',
+        incarnationId: 'inc-a'
+      })
+      const text = `${'x'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES)}tail`
+
+      const writePromise = runtime.writeTerminalPreviewInput('pty-1', text)
+      await vi.runAllTimersAsync()
+
+      await expect(writePromise).resolves.toBe(false)
+      expect(writes).toEqual(['x'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES)])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('writes fenced preview input for a controller-only PTY without a runtime record', async () => {
+    const writes: string[] = []
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      write: (ptyId, data) => {
+        writes.push(`${ptyId}:${data}`)
+        return true
+      },
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+
+    await expect(runtime.writeTerminalPreviewInput('controller-only', 'input')).resolves.toBe(true)
+    expect(writes).toEqual(['controller-only:input'])
+  })
+
+  it('stops controller-only preview input at a recordless spawn boundary', async () => {
+    vi.useFakeTimers()
+    try {
+      const writes: string[] = []
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        write: (_ptyId, data) => {
+          writes.push(data)
+          if (writes.length === 1) {
+            setTimeout(() => {
+              runtime.onPtySpawned('controller-only', undefined, {
+                awaitsRegistration: false
+              })
+            }, 0)
+          }
+          return true
+        },
+        kill: () => true,
+        getForegroundProcess: async () => null
+      })
+      const text = `${'x'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES)}tail`
+
+      const writePromise = runtime.writeTerminalPreviewInput('controller-only', text)
+      await vi.runAllTimersAsync()
+
+      await expect(writePromise).resolves.toBe(false)
+      expect(writes).toEqual(['x'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES)])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('stops controller-only preview input at a recordless execution reset boundary', async () => {
+    vi.useFakeTimers()
+    try {
+      const writes: string[] = []
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        write: (_ptyId, data) => {
+          writes.push(data)
+          if (writes.length === 1) {
+            setTimeout(() => {
+              runtime.preparePtyExecutionContext('controller-only', null, {
+                resetIncarnation: true
+              })
+            }, 0)
+          }
+          return true
+        },
+        kill: () => true,
+        getForegroundProcess: async () => null
+      })
+      const text = `${'x'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES)}tail`
+
+      const writePromise = runtime.writeTerminalPreviewInput('controller-only', text)
+      await vi.runAllTimersAsync()
+
+      await expect(writePromise).resolves.toBe(false)
+      expect(writes).toEqual(['x'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES)])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('yields while validating accepted large terminal.send text before provider writes', async () => {
     const writes: string[] = []
     const runtime = new OrcaRuntimeService(store)
@@ -17925,6 +18349,547 @@ describe('OrcaRuntimeService', () => {
     expect(thirdRead.nextCursor).toBe('2')
   })
 
+  it('attests guarded reads for runtime-owned terminals', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, { tabs: [], leaves: [] })
+    runtime.registerPty('pty-owned', TEST_WORKTREE_ID, null, {
+      tabId: 'tab-1',
+      leafId: 'pane:1',
+      incarnationId: 'inc-owned'
+    })
+    const [terminal] = (await runtime.listTerminals()).terminals
+
+    await expect(
+      runtime.readTerminal(terminal.handle, { expectedIncarnationId: 'inc-owned' })
+    ).resolves.toMatchObject({
+      handle: terminal.handle,
+      incarnationId: 'inc-owned',
+      worktreeId: TEST_WORKTREE_ID
+    })
+    await expect(
+      runtime.readTerminal(terminal.handle, { expectedIncarnationId: 'inc-replacement' })
+    ).rejects.toThrow('terminal_handle_stale')
+  })
+
+  it('retires runtime-owned handles when the PTY incarnation changes', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, { tabs: [], leaves: [] })
+    runtime.registerPty('pty-owned', TEST_WORKTREE_ID, null, {
+      tabId: 'tab-1',
+      leafId: 'pane:1',
+      incarnationId: 'inc-a'
+    })
+    const [original] = (await runtime.listTerminals()).terminals
+
+    runtime.registerPty('pty-owned', TEST_WORKTREE_ID, null, {
+      tabId: 'tab-1',
+      leafId: 'pane:1',
+      incarnationId: 'inc-b'
+    })
+
+    const [replacement] = (await runtime.listTerminals()).terminals
+    expect(replacement.handle).not.toBe(original.handle)
+    await expect(
+      runtime.readTerminal(original.handle, { expectedIncarnationId: 'inc-b' })
+    ).rejects.toThrow('terminal_handle_stale')
+  })
+
+  it('preserves a pristine preallocated handle for first attestation but retires it on replacement', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    const preAllocatedHandle = runtime.preAllocateHandleForPty('pty-1')
+    syncSinglePty(runtime)
+
+    runtime.registerPty('pty-1', TEST_WORKTREE_ID, null, {
+      tabId: 'tab-1',
+      leafId: 'pane:1',
+      incarnationId: 'inc-a'
+    })
+    expect((await runtime.listTerminals()).terminals[0]?.handle).toBe(preAllocatedHandle)
+
+    runtime.registerPty('pty-1', TEST_WORKTREE_ID, null, {
+      tabId: 'tab-1',
+      leafId: 'pane:1',
+      incarnationId: 'inc-b'
+    })
+
+    const [replacement] = (await runtime.listTerminals()).terminals
+    expect(replacement.handle).not.toBe(preAllocatedHandle)
+    await expect(
+      runtime.readTerminal(preAllocatedHandle, { expectedIncarnationId: 'inc-b' })
+    ).rejects.toThrow('terminal_handle_stale')
+  })
+
+  it('preserves first legacy pre-spawn output and handle but retires them on respawn', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    const ptyId = `${TEST_WORKTREE_ID}@@daemon-first-spawn`
+    const preAllocatedHandle = runtime.preAllocateHandleForPty(ptyId)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, { tabs: [], leaves: [] })
+
+    // Lazy controller-only observation must fence at spawn without being
+    // mistaken for a previous process lifecycle.
+    await expect(runtime.writeTerminalPreviewInput(ptyId, 'probe')).resolves.toBe(true)
+    runtime.onPtyData(ptyId, 'first-process pre-spawn output\r\n', 100)
+    runtime.onPtySpawned(ptyId)
+    runtime.synchronizePtyOutputSequenceFromProvider(ptyId, { value: 0, generation: 'reset' }, 0)
+    runtime.registerPty(ptyId, TEST_WORKTREE_ID)
+
+    const [firstSpawn] = (await runtime.listTerminals()).terminals
+    expect(firstSpawn.handle).toBe(preAllocatedHandle)
+    await expect(runtime.readTerminal(preAllocatedHandle)).resolves.toMatchObject({
+      handle: preAllocatedHandle,
+      worktreeId: TEST_WORKTREE_ID,
+      tail: ['first-process pre-spawn output']
+    })
+
+    runtime.onPtyData(ptyId, 'ambiguous replacement pre-spawn output\r\n', 101)
+    runtime.onPtySpawned(ptyId)
+    runtime.registerPty(ptyId, TEST_WORKTREE_ID)
+
+    const [secondSpawn] = (await runtime.listTerminals()).terminals
+    expect(secondSpawn.handle).not.toBe(preAllocatedHandle)
+    await expect(runtime.readTerminal(preAllocatedHandle)).rejects.toThrow('terminal_handle_stale')
+    await expect(runtime.readTerminal(secondSpawn.handle)).resolves.toMatchObject({ tail: [] })
+  })
+
+  it('clears a published lifecycle admission when the PTY generation ends', () => {
+    const runtime = new OrcaRuntimeService(store)
+    const ptyId = `${TEST_WORKTREE_ID}@@admission-exit`
+    const admissions = (
+      runtime as unknown as {
+        ptyLifecycleAdmissions: Map<string, 'prepared' | 'prepared-replacement' | 'spawned'>
+      }
+    ).ptyLifecycleAdmissions
+
+    runtime.onPtySpawned(ptyId)
+    expect(admissions.get(ptyId)).toBe('spawned')
+
+    runtime.onPtyExit(ptyId, 0)
+    expect(admissions.has(ptyId)).toBe(false)
+  })
+
+  it('attests guarded reads for renderer leaf terminals', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    syncSinglePty(runtime)
+    const [terminal] = (await runtime.listTerminals()).terminals
+
+    await expect(
+      runtime.readTerminal(terminal.handle, { expectedIncarnationId: 'inc-renderer' })
+    ).rejects.toThrow('terminal_handle_stale')
+
+    runtime.registerPty('pty-1', TEST_WORKTREE_ID, null, {
+      tabId: 'tab-1',
+      leafId: 'pane:1',
+      incarnationId: 'inc-renderer'
+    })
+
+    await expect(
+      runtime.readTerminal(terminal.handle, { expectedIncarnationId: 'inc-renderer' })
+    ).resolves.toMatchObject({
+      handle: terminal.handle,
+      incarnationId: 'inc-renderer',
+      worktreeId: TEST_WORKTREE_ID
+    })
+  })
+
+  it('does not expose retained leaf output after a same-pty incarnation replacement', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    syncSinglePty(runtime)
+    runtime.registerPty('pty-1', TEST_WORKTREE_ID, null, {
+      tabId: 'tab-1',
+      leafId: 'pane:1',
+      incarnationId: 'inc-a'
+    })
+    const [terminal] = (await runtime.listTerminals()).terminals
+
+    runtime.onPtyData('pty-1', 'incarnation-a-line-1\nincarnation-a-line-2\n', 100)
+    await expect(
+      runtime.readTerminal(terminal.handle, { expectedIncarnationId: 'inc-a', cursor: 0 })
+    ).resolves.toMatchObject({
+      tail: ['incarnation-a-line-1', 'incarnation-a-line-2'],
+      nextCursor: '2'
+    })
+
+    runtime.registerPty('pty-1', TEST_WORKTREE_ID, null, {
+      tabId: 'tab-1',
+      leafId: 'pane:1',
+      incarnationId: 'inc-b'
+    })
+    const [replacementTerminal] = (await runtime.listTerminals()).terminals
+    expect(replacementTerminal.handle).not.toBe(terminal.handle)
+    await expect(
+      runtime.readTerminal(terminal.handle, { expectedIncarnationId: 'inc-b' })
+    ).rejects.toThrow('terminal_handle_stale')
+
+    const replacementPreview = await runtime.readTerminal(replacementTerminal.handle, {
+      expectedIncarnationId: 'inc-b'
+    })
+    expect(replacementPreview.tail).toEqual([])
+    expect(replacementPreview.latestCursor).toBe('0')
+    expect(replacementPreview.incarnationId).toBe('inc-b')
+
+    const replacementCursorRead = await runtime.readTerminal(replacementTerminal.handle, {
+      expectedIncarnationId: 'inc-b',
+      cursor: 0
+    })
+    expect(replacementCursorRead.tail).toEqual([])
+    expect(replacementCursorRead.nextCursor).toBe('0')
+    expect(replacementCursorRead.latestCursor).toBe('0')
+    expect(replacementCursorRead.incarnationId).toBe('inc-b')
+
+    runtime.onPtyData('pty-1', 'incarnation-b-line\n', 101)
+    const replacementOutput = await runtime.readTerminal(replacementTerminal.handle, {
+      expectedIncarnationId: 'inc-b',
+      cursor: 0
+    })
+    expect(replacementOutput.tail).toEqual(['incarnation-b-line'])
+    expect(replacementOutput.tail.join('\n')).not.toContain('incarnation-a')
+  })
+
+  it('does not attest retained output captured before the first known incarnation', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    syncSinglePty(runtime)
+    const [terminal] = (await runtime.listTerminals()).terminals
+
+    runtime.onPtyData('pty-1', 'unattested-line\n', 100)
+    runtime.registerPty('pty-1', TEST_WORKTREE_ID, null, {
+      tabId: 'tab-1',
+      leafId: 'pane:1',
+      incarnationId: 'inc-b'
+    })
+
+    await expect(
+      runtime.readTerminal(terminal.handle, { expectedIncarnationId: 'inc-b' })
+    ).rejects.toThrow('terminal_handle_stale')
+    const [attestedTerminal] = (await runtime.listTerminals()).terminals
+
+    const firstAttestedPreview = await runtime.readTerminal(attestedTerminal.handle, {
+      expectedIncarnationId: 'inc-b'
+    })
+    expect(firstAttestedPreview.tail).toEqual([])
+    expect(firstAttestedPreview.latestCursor).toBe('0')
+
+    const firstAttestedCursorRead = await runtime.readTerminal(attestedTerminal.handle, {
+      expectedIncarnationId: 'inc-b',
+      cursor: 0
+    })
+    expect(firstAttestedCursorRead.tail).toEqual([])
+    expect(firstAttestedCursorRead.nextCursor).toBe('0')
+    expect(firstAttestedCursorRead.latestCursor).toBe('0')
+
+    runtime.onPtyData('pty-1', 'incarnation-b-line\n', 101)
+    const replacementOutput = await runtime.readTerminal(attestedTerminal.handle, {
+      expectedIncarnationId: 'inc-b',
+      cursor: 0
+    })
+    expect(replacementOutput.tail).toEqual(['incarnation-b-line'])
+    expect(replacementOutput.tail.join('\n')).not.toContain('unattested-line')
+  })
+
+  it('revokes exited incarnation authority before an unattested same-id replacement', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    syncSinglePty(runtime)
+    runtime.registerPty('pty-1', TEST_WORKTREE_ID, null, {
+      tabId: 'tab-1',
+      leafId: 'pane:1',
+      incarnationId: 'inc-old'
+    })
+    const [oldTerminal] = (await runtime.listTerminals()).terminals
+    runtime.onPtyData('pty-1', 'old-process-line\n', 100)
+
+    runtime.onPtyExit('pty-1', 0, 'inc-old')
+    runtime.onPtyData('pty-1', 'ambiguous-replacement-line\n', 101)
+    runtime.onPtySpawned('pty-1', undefined, { awaitsRegistration: false })
+    runtime.registerPty('pty-1', TEST_WORKTREE_ID)
+    runtime.onPtyData('pty-1', 'unattested-replacement-line\n', 102)
+
+    await expect(
+      runtime.readTerminal(oldTerminal.handle, { expectedIncarnationId: 'inc-old' })
+    ).rejects.toThrow('terminal_handle_stale')
+    const [unattestedTerminal] = (await runtime.listTerminals()).terminals
+    await expect(
+      runtime.readTerminal(unattestedTerminal.handle, { expectedIncarnationId: 'inc-old' })
+    ).rejects.toThrow('terminal_handle_stale')
+    await expect(runtime.readTerminal(unattestedTerminal.handle)).resolves.toMatchObject({
+      tail: ['unattested-replacement-line']
+    })
+    expect(await runtime.readTerminal(unattestedTerminal.handle)).not.toHaveProperty(
+      'incarnationId'
+    )
+
+    runtime.registerPty('pty-1', TEST_WORKTREE_ID, null, {
+      tabId: 'tab-1',
+      leafId: 'pane:1',
+      incarnationId: 'inc-new'
+    })
+    const [attestedTerminal] = (await runtime.listTerminals()).terminals
+    expect(attestedTerminal.handle).not.toBe(unattestedTerminal.handle)
+    await expect(
+      runtime.readTerminal(attestedTerminal.handle, { expectedIncarnationId: 'inc-new' })
+    ).resolves.toMatchObject({ tail: [], incarnationId: 'inc-new' })
+
+    runtime.onPtyData('pty-1', 'new-process-line\n', 103)
+    await expect(
+      runtime.readTerminal(attestedTerminal.handle, { expectedIncarnationId: 'inc-new' })
+    ).resolves.toMatchObject({ tail: ['new-process-line'], incarnationId: 'inc-new' })
+  })
+
+  it('preserves a known SSH incarnation across an unconfirmed no-lease reattach', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    const ptyId = 'ssh:target-1@@relay-pty-1'
+    syncSinglePty(runtime, ptyId)
+    runtime.registerPty(ptyId, TEST_WORKTREE_ID, 'target-1', {
+      tabId: 'tab-1',
+      leafId: 'pane:1',
+      incarnationId: 'inc-ssh'
+    })
+    runtime.onPtyData(ptyId, 'preserved ssh output\n', 100)
+    const [beforeDisconnect] = (await runtime.listTerminals()).terminals
+
+    runtime.onPtyExit(ptyId, -1, 'inc-ssh', { hostExitConfirmed: false })
+    runtime.onPtySpawned(ptyId, 'inc-ssh', { awaitsRegistration: false })
+
+    const [reattached] = (await runtime.listTerminals()).terminals
+    expect(reattached.handle).toBe(beforeDisconnect.handle)
+    await expect(
+      runtime.readTerminal(reattached.handle, { expectedIncarnationId: 'inc-ssh' })
+    ).resolves.toMatchObject({
+      incarnationId: 'inc-ssh',
+      tail: ['preserved ssh output']
+    })
+  })
+
+  it('retires a graph-discovered null lifecycle after exit before its null replacement spawn', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    syncSinglePty(runtime)
+    const [oldTerminal] = (await runtime.listTerminals()).terminals
+    runtime.onPtyData('pty-1', 'old graph-only output\n', 100)
+
+    runtime.onPtyExit('pty-1', 0)
+    runtime.onPtyData('pty-1', 'ambiguous replacement output\n', 101)
+    runtime.onPtySpawned('pty-1', undefined, { awaitsRegistration: false })
+
+    const [replacement] = (await runtime.listTerminals()).terminals
+    expect(replacement.handle).not.toBe(oldTerminal.handle)
+    await expect(runtime.readTerminal(oldTerminal.handle)).rejects.toThrow('terminal_handle_stale')
+    await expect(runtime.readTerminal(replacement.handle)).resolves.toMatchObject({ tail: [] })
+  })
+
+  it('applies a pending incarnation when registration omits its binding', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    syncSinglePty(runtime)
+    runtime.registerPty('pty-1', TEST_WORKTREE_ID, null, {
+      tabId: 'tab-1',
+      leafId: 'pane:1',
+      incarnationId: 'inc-a'
+    })
+    const [original] = (await runtime.listTerminals()).terminals
+
+    runtime.onPtyExit('pty-1', 0, 'inc-a')
+    runtime.beginPtyRegistration('pty-1', 'inc-b')
+    runtime.registerPty('pty-1', TEST_WORKTREE_ID)
+    runtime.onPtyData('pty-1', 'incarnation-b-line\n', 101)
+
+    const [replacement] = (await runtime.listTerminals()).terminals
+    expect(replacement.handle).not.toBe(original.handle)
+    await expect(
+      runtime.readTerminal(original.handle, { expectedIncarnationId: 'inc-a' })
+    ).rejects.toThrow('terminal_handle_stale')
+    await expect(
+      runtime.readTerminal(replacement.handle, { expectedIncarnationId: 'inc-a' })
+    ).rejects.toThrow('terminal_handle_stale')
+    await expect(
+      runtime.readTerminal(replacement.handle, { expectedIncarnationId: 'inc-b' })
+    ).resolves.toMatchObject({
+      incarnationId: 'inc-b',
+      tail: ['incarnation-b-line']
+    })
+  })
+
+  it('does not carry retained output across a same-pty worktree reassignment', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    const preAllocatedHandle = runtime.preAllocateHandleForPty('pty-1')
+    syncSinglePty(runtime)
+    runtime.registerPty('pty-1', TEST_WORKTREE_ID, null, {
+      tabId: 'tab-1',
+      leafId: 'pane:1',
+      incarnationId: 'inc-shared'
+    })
+    const [oldTerminal] = (await runtime.listTerminals()).terminals
+    expect(oldTerminal.handle).toBe(preAllocatedHandle)
+    runtime.onPtyData('pty-1', 'old-worktree-line\n', 100)
+
+    runtime.markRendererReloading(1)
+    const nextWorktreeId = `${TEST_REPO_ID}::/tmp/worktree-b`
+    runtime.registerPty('pty-1', nextWorktreeId, null, {
+      tabId: 'tab-1',
+      leafId: 'pane:1',
+      incarnationId: 'inc-shared'
+    })
+    runtime.syncWindowGraph(1, {
+      tabs: [
+        {
+          tabId: 'tab-1',
+          worktreeId: nextWorktreeId,
+          title: 'Codex',
+          activeLeafId: 'pane:1',
+          layout: null
+        }
+      ],
+      leaves: [
+        {
+          tabId: 'tab-1',
+          worktreeId: nextWorktreeId,
+          leafId: 'pane:1',
+          paneRuntimeId: 1,
+          ptyId: 'pty-1',
+          paneTitle: null
+        }
+      ]
+    })
+
+    const [replacementTerminal] = (await runtime.listTerminals()).terminals
+    expect(replacementTerminal.handle).not.toBe(oldTerminal.handle)
+    expect(replacementTerminal.worktreeId).toBe(nextWorktreeId)
+    await expect(
+      runtime.readTerminal(oldTerminal.handle, { expectedIncarnationId: 'inc-shared' })
+    ).rejects.toThrow('terminal_handle_stale')
+    const firstReplacementRead = await runtime.readTerminal(replacementTerminal.handle, {
+      expectedIncarnationId: 'inc-shared',
+      cursor: 0
+    })
+    expect(firstReplacementRead.worktreeId).toBe(nextWorktreeId)
+    expect(firstReplacementRead.tail).toEqual([])
+    expect(firstReplacementRead.nextCursor).toBe('0')
+
+    runtime.onPtyData('pty-1', 'new-worktree-line\n', 101)
+    const replacementOutput = await runtime.readTerminal(replacementTerminal.handle, {
+      expectedIncarnationId: 'inc-shared',
+      cursor: 0
+    })
+    expect(replacementOutput.tail).toEqual(['new-worktree-line'])
+    expect(replacementOutput.tail.join('\n')).not.toContain('old-worktree-line')
+  })
+
+  it('preserves terminal provenance across equivalent Windows worktree spellings', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    const windowsWorktree = `${TEST_REPO_ID}::C:\\Repo\\Feature`
+    const equivalentWorktree = `${TEST_REPO_ID}::c:/repo/feature`
+    const syncWindowsPty = (worktreeId: string): void => {
+      runtime.syncWindowGraph(1, {
+        tabs: [
+          {
+            tabId: 'tab-1',
+            worktreeId,
+            title: 'Codex',
+            activeLeafId: 'pane:1',
+            layout: null
+          }
+        ],
+        leaves: [
+          {
+            tabId: 'tab-1',
+            worktreeId,
+            leafId: 'pane:1',
+            paneRuntimeId: 1,
+            ptyId: 'pty-windows',
+            paneTitle: null
+          }
+        ]
+      })
+    }
+
+    runtime.attachWindow(1)
+    syncWindowsPty(windowsWorktree)
+    runtime.registerPty('pty-windows', equivalentWorktree, null, {
+      tabId: 'tab-1',
+      leafId: 'pane:1',
+      incarnationId: 'inc-windows'
+    })
+    runtime.onPtyData('pty-windows', 'retained-line\n', 100)
+    const [terminal] = (await runtime.listTerminals()).terminals
+
+    syncWindowsPty(equivalentWorktree)
+
+    const [afterEquivalentSync] = (await runtime.listTerminals()).terminals
+    expect(afterEquivalentSync.handle).toBe(terminal.handle)
+    await expect(
+      runtime.readTerminal(terminal.handle, { expectedIncarnationId: 'inc-windows' })
+    ).resolves.toMatchObject({
+      handle: terminal.handle,
+      incarnationId: 'inc-windows',
+      tail: ['retained-line']
+    })
+  })
+
+  it('drops incarnation authority on a graph-only worktree reassignment', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    syncSinglePty(runtime)
+    runtime.registerPty('pty-1', TEST_WORKTREE_ID, null, {
+      tabId: 'tab-1',
+      leafId: 'pane:1',
+      incarnationId: 'inc-old'
+    })
+    const [oldTerminal] = (await runtime.listTerminals()).terminals
+    runtime.onPtyData('pty-1', 'old-worktree-line\n', 100)
+
+    const nextWorktreeId = `${TEST_REPO_ID}::/tmp/worktree-b`
+    runtime.syncWindowGraph(1, {
+      tabs: [
+        {
+          tabId: 'tab-1',
+          worktreeId: nextWorktreeId,
+          title: 'Codex',
+          activeLeafId: 'pane:1',
+          layout: null
+        }
+      ],
+      leaves: [
+        {
+          tabId: 'tab-1',
+          worktreeId: nextWorktreeId,
+          leafId: 'pane:1',
+          paneRuntimeId: 1,
+          ptyId: 'pty-1',
+          paneTitle: null
+        }
+      ]
+    })
+
+    const [unattestedTerminal] = (await runtime.listTerminals()).terminals
+    expect(unattestedTerminal.handle).not.toBe(oldTerminal.handle)
+    await expect(
+      runtime.readTerminal(unattestedTerminal.handle, { expectedIncarnationId: 'inc-old' })
+    ).rejects.toThrow('terminal_handle_stale')
+
+    runtime.registerPty('pty-1', nextWorktreeId, null, {
+      tabId: 'tab-1',
+      leafId: 'pane:1',
+      incarnationId: 'inc-new'
+    })
+    await expect(
+      runtime.readTerminal(unattestedTerminal.handle, {
+        expectedIncarnationId: 'inc-new',
+        cursor: 0
+      })
+    ).resolves.toMatchObject({ tail: [], worktreeId: nextWorktreeId })
+
+    runtime.onPtyData('pty-1', 'new-worktree-line\n', 101)
+    await expect(
+      runtime.readTerminal(unattestedTerminal.handle, {
+        expectedIncarnationId: 'inc-new',
+        cursor: 0
+      })
+    ).resolves.toMatchObject({ tail: ['new-worktree-line'], worktreeId: nextWorktreeId })
+  })
+
   it('paginates retained terminal output with explicit limits and truncation metadata', async () => {
     const runtime = new OrcaRuntimeService(store)
 
@@ -18512,6 +19477,114 @@ describe('OrcaRuntimeService', () => {
     expect(runtime.isTerminalAlternateScreen('pty-1')).toBe(false)
   })
 
+  it('rejects a guarded read when the provider generation resets during capture', async () => {
+    type Snapshot = {
+      data: string
+      cols: number
+      rows: number
+      seq: number
+      source: 'headless'
+      alternateScreen: boolean
+    }
+    let resolveSnapshot!: (snapshot: Snapshot) => void
+    const serializeProviderBuffer = vi.fn(
+      () =>
+        new Promise<Snapshot>((resolve) => {
+          resolveSnapshot = resolve
+        })
+    )
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      serializeProviderBuffer,
+      hasRendererSerializer: () => false
+    })
+    syncSinglePty(runtime)
+    runtime.registerPty('pty-1', TEST_WORKTREE_ID, null, {
+      tabId: 'tab-1',
+      leafId: 'pane:1',
+      incarnationId: 'inc-stable'
+    })
+    runtime.synchronizePtyOutputSequenceFromProvider(
+      'pty-1',
+      { value: 900, generation: 'continued' },
+      0
+    )
+    const [terminal] = (await runtime.listTerminals()).terminals
+
+    const readPromise = runtime.readTerminal(terminal.handle, {
+      expectedIncarnationId: 'inc-stable'
+    })
+    const rejection = expect(readPromise).rejects.toThrow('terminal_handle_stale')
+    await vi.waitFor(() => expect(serializeProviderBuffer).toHaveBeenCalledOnce())
+    runtime.synchronizePtyOutputSequenceFromProvider(
+      'pty-1',
+      { value: 0, generation: 'reset' },
+      runtime.getPtyOutputSequence('pty-1')
+    )
+    resolveSnapshot({
+      data: '\x1b[?1049hReset provider frame\r\n',
+      cols: 80,
+      rows: 24,
+      seq: 900,
+      source: 'headless',
+      alternateScreen: true
+    })
+
+    await rejection
+  })
+
+  it('rejects an unguarded read when a null-incarnation handle is re-adopted', async () => {
+    type Snapshot = {
+      data: string
+      cols: number
+      rows: number
+      seq: number
+      source: 'headless'
+      alternateScreen: boolean
+    }
+    let resolveSnapshot!: (snapshot: Snapshot) => void
+    const serializeProviderBuffer = vi.fn(
+      () =>
+        new Promise<Snapshot>((resolve) => {
+          resolveSnapshot = resolve
+        })
+    )
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      serializeProviderBuffer,
+      hasRendererSerializer: () => false
+    })
+    syncSinglePty(runtime)
+    runtime.synchronizePtyOutputSequenceFromProvider(
+      'pty-1',
+      { value: 900, generation: 'continued' },
+      0
+    )
+    const [terminal] = (await runtime.listTerminals()).terminals
+
+    const readPromise = runtime.readTerminal(terminal.handle)
+    const rejection = expect(readPromise).rejects.toThrow('terminal_handle_stale')
+    await vi.waitFor(() => expect(serializeProviderBuffer).toHaveBeenCalledOnce())
+    runtime.onPtySpawned('pty-1', undefined, { awaitsRegistration: false })
+    runtime.registerPreAllocatedHandleForPty('pty-1', terminal.handle)
+    resolveSnapshot({
+      data: '\x1b[?1049hReplacement process frame\r\n',
+      cols: 80,
+      rows: 24,
+      seq: 900,
+      source: 'headless',
+      alternateScreen: true
+    })
+
+    await rejection
+  })
+
   it('rejects a visible frame when its terminal handle changes during capture', async () => {
     type Snapshot = {
       data: string
@@ -18545,6 +19618,7 @@ describe('OrcaRuntimeService', () => {
     const [terminal] = (await runtime.listTerminals()).terminals
 
     const readPromise = runtime.readTerminal(terminal.handle)
+    const rejection = expect(readPromise).rejects.toThrow('terminal_handle_stale')
     await vi.waitFor(() => expect(serializeProviderBuffer).toHaveBeenCalledOnce())
     syncSinglePty(runtime, 'pty-2')
     resolveSnapshot({
@@ -18556,7 +19630,170 @@ describe('OrcaRuntimeService', () => {
       alternateScreen: true
     })
 
-    await expect(readPromise).rejects.toThrow('terminal_handle_stale')
+    await rejection
+  })
+
+  it('rejects a guarded read when the same PTY id changes incarnation during capture', async () => {
+    type Snapshot = {
+      data: string
+      cols: number
+      rows: number
+      seq: number
+      source: 'headless'
+      alternateScreen: boolean
+    }
+    let resolveSnapshot!: (snapshot: Snapshot) => void
+    const serializeProviderBuffer = vi.fn(
+      () =>
+        new Promise<Snapshot>((resolve) => {
+          resolveSnapshot = resolve
+        })
+    )
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      serializeProviderBuffer,
+      hasRendererSerializer: () => false
+    })
+    syncSinglePty(runtime)
+    runtime.registerPty('pty-1', TEST_WORKTREE_ID, null, {
+      tabId: 'tab-1',
+      leafId: 'pane:1',
+      incarnationId: 'inc-old'
+    })
+    runtime.synchronizePtyOutputSequenceFromProvider(
+      'pty-1',
+      { value: 900, generation: 'continued' },
+      0
+    )
+    const [terminal] = (await runtime.listTerminals()).terminals
+
+    const readPromise = runtime.readTerminal(terminal.handle, {
+      expectedIncarnationId: 'inc-old'
+    })
+    const rejection = expect(readPromise).rejects.toThrow('terminal_handle_stale')
+    await vi.waitFor(() => expect(serializeProviderBuffer).toHaveBeenCalledOnce())
+    runtime.registerPty('pty-1', TEST_WORKTREE_ID, null, {
+      tabId: 'tab-1',
+      leafId: 'pane:1',
+      incarnationId: 'inc-new'
+    })
+    resolveSnapshot({
+      data: '\x1b[?1049hReplacement process frame\r\n',
+      cols: 80,
+      rows: 24,
+      seq: 900,
+      source: 'headless',
+      alternateScreen: true
+    })
+
+    await rejection
+  })
+
+  it('rejects a guarded read when the PTY worktree changes during capture', async () => {
+    type Snapshot = {
+      data: string
+      cols: number
+      rows: number
+      seq: number
+      source: 'headless'
+      alternateScreen: boolean
+    }
+    let resolveSnapshot!: (snapshot: Snapshot) => void
+    const serializeProviderBuffer = vi.fn(
+      () =>
+        new Promise<Snapshot>((resolve) => {
+          resolveSnapshot = resolve
+        })
+    )
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      serializeProviderBuffer,
+      hasRendererSerializer: () => false
+    })
+    syncSinglePty(runtime)
+    runtime.registerPty('pty-1', TEST_WORKTREE_ID, null, {
+      tabId: 'tab-1',
+      leafId: 'pane:1',
+      incarnationId: 'inc-old'
+    })
+    runtime.synchronizePtyOutputSequenceFromProvider(
+      'pty-1',
+      { value: 900, generation: 'continued' },
+      0
+    )
+    const [terminal] = (await runtime.listTerminals()).terminals
+
+    const readPromise = runtime.readTerminal(terminal.handle, {
+      expectedIncarnationId: 'inc-old'
+    })
+    const rejection = expect(readPromise).rejects.toThrow('terminal_handle_stale')
+    await vi.waitFor(() => expect(serializeProviderBuffer).toHaveBeenCalledOnce())
+    runtime.registerPty('pty-1', `${TEST_REPO_ID}::/tmp/worktree-b`, null, {
+      tabId: 'tab-1',
+      leafId: 'pane:1',
+      incarnationId: 'inc-old'
+    })
+    resolveSnapshot({
+      data: '\x1b[?1049hMoved process frame\r\n',
+      cols: 80,
+      rows: 24,
+      seq: 900,
+      source: 'headless',
+      alternateScreen: true
+    })
+
+    await rejection
+  })
+
+  it('rejects a renderer snapshot when the same PTY id changes incarnation', async () => {
+    type Snapshot = { data: string; cols: number; rows: number }
+    let resolveSnapshot!: (snapshot: Snapshot) => void
+    const serializeBuffer = vi.fn(
+      () =>
+        new Promise<Snapshot>((resolve) => {
+          resolveSnapshot = resolve
+        })
+    )
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      serializeBuffer,
+      hasRendererSerializer: () => true
+    })
+    syncSinglePty(runtime)
+    runtime.registerPty('pty-1', TEST_WORKTREE_ID, null, {
+      tabId: 'tab-1',
+      leafId: 'pane:1',
+      incarnationId: 'inc-old'
+    })
+    const [terminal] = (await runtime.listTerminals()).terminals
+    runtime.onPtyData('pty-1', `${Array.from({ length: 3000 }, () => '').join('\n')}\n`, 100)
+
+    const readPromise = runtime.readTerminal(terminal.handle, {
+      expectedIncarnationId: 'inc-old'
+    })
+    const rejection = expect(readPromise).rejects.toThrow('terminal_handle_stale')
+    await vi.waitFor(() => expect(serializeBuffer).toHaveBeenCalledOnce())
+    runtime.registerPty('pty-1', TEST_WORKTREE_ID, null, {
+      tabId: 'tab-1',
+      leafId: 'pane:1',
+      incarnationId: 'inc-new'
+    })
+    resolveSnapshot({
+      data: '\x1b[?1049hReplacement renderer frame\r\n',
+      cols: 80,
+      rows: 24
+    })
+
+    await rejection
   })
 
   it('bounds provider visible frames for read and show responses', async () => {
@@ -36064,7 +37301,7 @@ describe('OrcaRuntimeService', () => {
       ).leaves
       expect(leaves.size).toBeGreaterThan(0)
       const rebuilt = [...leaves.values()][0]
-      expect(rebuilt.lastAgentStatus).toBe('idle')
+      expect(rebuilt.lastAgentStatus).toBeNull()
       expect(rebuilt.lastAgentStatusObservedLive).toBe(false)
 
       setInMemoryOrchestrationMessages(runtime, db)
@@ -36160,14 +37397,16 @@ describe('OrcaRuntimeService', () => {
       runtime.onPtyExit('pty-1', 0)
       runtime.onPtySpawned('pty-1', undefined, { awaitsRegistration: false })
       setInMemoryOrchestrationMessages(runtime, db)
-      bindSinglePtyRun(db, terminal.handle)
+      const [replacement] = (await runtime.listTerminals()).terminals
+      expect(replacement.handle).not.toBe(terminal.handle)
+      bindSinglePtyRun(db, replacement.handle)
       const message = db.insertMessage({
         from: 'sender',
-        to: terminal.handle,
+        to: replacement.handle,
         subject: 'after same id respawn'
       })
 
-      runtime.notifyMessageArrived(terminal.handle, 'status')
+      runtime.notifyMessageArrived(replacement.handle, 'status')
       await Promise.resolve()
 
       expect(write).not.toHaveBeenCalled()

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -2273,6 +2273,15 @@ type PtyIncarnationHandleRecord = {
   leafKey: string
 }
 
+type TerminalProvenanceIdentity = {
+  handle: string | null
+  ptyId: string | null
+  incarnationId: PtyIncarnationId | null
+  worktreeId: string | null
+  lifecycleGeneration: number | null
+  provenanceGeneration: number | null
+}
+
 export type OrchestrationCompatibilityTerminalAuthority = {
   runtimeId: string
   terminalHandle: string
@@ -3302,7 +3311,16 @@ export class OrcaRuntimeService {
   private providerVisibleRetryAtByPtyId = new Map<string, number>()
   private providerSnapshotsWithLiveModeTransition = new WeakSet<PtyProviderBufferSnapshot>()
   private ptyLifecycleGenerationById = new Map<string, number>()
+  private ptyProvenanceGenerationById = new Map<string, number>()
+  // Unlike spawnPublishedPtys, this evidence survives exit/generation cleanup
+  // so a later same-id legacy spawn cannot masquerade as the first lifecycle.
+  private ptyIdsWithPublishedLifecycle = new Set<string>()
+  private ptyLifecycleAdmissions = new Map<
+    string,
+    'prepared' | 'prepared-replacement' | 'spawned'
+  >()
   private nextPtyLifecycleGeneration = 1
+  private nextPtyProvenanceGeneration = 1
   private recentPtyPathCandidatesById = new Map<string, string[]>()
   // Why: candidates only feed mobile file-tap provenance; desktop-only
   // sessions skip the 3-regex extraction on every PTY chunk until a
@@ -6771,12 +6789,21 @@ export class OrcaRuntimeService {
         preserveLivePtysDuringReload && leaf.ptyId === null && existing?.ptyId
           ? existing.ptyId
           : leaf.ptyId
+      const existingPty = ptyId ? this.ptysById.get(ptyId) : undefined
+      const worktreeProvenanceChanged =
+        (existing?.ptyId === ptyId &&
+          !runtimeWorktreeIdsEqual(existing.worktreeId, leaf.worktreeId)) ||
+        (existingPty !== undefined &&
+          !runtimeWorktreeIdsEqual(existingPty.worktreeId, leaf.worktreeId))
       const ptyGeneration =
-        existing && existing.ptyId !== ptyId
+        existing && (existing.ptyId !== ptyId || worktreeProvenanceChanged)
           ? existing.ptyGeneration + 1
           : (existing?.ptyGeneration ?? 0)
-      const existingPty = ptyId ? this.ptysById.get(ptyId) : undefined
-      const tailSource = existing?.ptyId === ptyId ? existing : existingPty
+      const tailSource = worktreeProvenanceChanged
+        ? undefined
+        : existing?.ptyId === ptyId
+          ? existing
+          : existingPty
 
       nextLeaves.set(leafKey, {
         ...leaf,
@@ -6810,8 +6837,12 @@ export class OrcaRuntimeService {
       if (leaf.ptyId) {
         this.recordPtyWorktree(leaf.ptyId, leaf.worktreeId, {
           connected: true,
-          lastOutputAt: existing?.ptyId === leaf.ptyId ? existing.lastOutputAt : null,
-          preview: existing?.ptyId === leaf.ptyId ? existing.preview : '',
+          lastOutputAt:
+            !worktreeProvenanceChanged && existing?.ptyId === leaf.ptyId
+              ? existing.lastOutputAt
+              : null,
+          preview:
+            !worktreeProvenanceChanged && existing?.ptyId === leaf.ptyId ? existing.preview : '',
           tabId: leaf.tabId,
           paneKey: this.makeRuntimePaneKey(leaf)
         })
@@ -10753,19 +10784,74 @@ export class OrcaRuntimeService {
     options: { awaitsRegistration?: boolean } = {}
   ): void {
     this.forgetPtyLivenessVerdict(ptyId)
+    const admission = this.ptyLifecycleAdmissions.get(ptyId)
+    const preparedAdmission = admission === 'prepared' || admission === 'prepared-replacement'
+    const preparedReplacement = admission === 'prepared-replacement'
+    const hadPublishedLifecycle = this.ptyIdsWithPublishedLifecycle.has(ptyId)
+    const observedGeneration = this.ptyLifecycleGenerationById.get(ptyId)
     if (options.awaitsRegistration !== false) {
       // Why: surface absence cannot distinguish an in-flight admission from a completed headless lifecycle.
       this.pendingPtyRegistrationIncarnations.set(ptyId, incarnationId ?? null)
     }
-    this.spawnPublishedPtys.add(ptyId)
     const pty = this.getOrCreatePtyWorktreeRecord(ptyId)
     if (pty) {
-      if (incarnationId) {
+      // A recoverable SSH relay reconnect may republish the same known process
+      // without a complete lease. Its incarnation is the process identity, so
+      // keep the surface while still advancing the async lifecycle fence below.
+      const exactKnownRepublish =
+        !preparedAdmission &&
+        incarnationId !== undefined &&
+        pty.incarnationId !== null &&
+        pty.incarnationId === incarnationId
+      const replacementBoundary =
+        (hadPublishedLifecycle || preparedReplacement) && !exactKnownRepublish
+      // Why: an already-published spawn is an actual process boundary. A lazy
+      // generation read is only an async fence and must not retire the handle
+      // preallocated for the first process.
+      //
+      // A prepared replacement resets again here: the prior process can emit
+      // a late queued frame after preparation but before this spawn callback.
+      if (replacementBoundary) {
+        this.resetPtyReadStateForProvenanceChange(ptyId, pty)
+        this.invalidatePtyHandlesForProvenanceChange(ptyId)
+      }
+      // Provider data may arrive before this callback. Once any prior
+      // lifecycle has been reset above, the retained bytes belong to this
+      // admitted spawn and must not revoke its preallocated handle.
+      if (incarnationId === undefined) {
+        if (!replacementBoundary && !preparedAdmission && pty.incarnationId !== null) {
+          this.setPtyIncarnation(ptyId, pty, null)
+        } else {
+          pty.incarnationId = null
+        }
+      } else if (replacementBoundary || preparedAdmission) {
         pty.incarnationId = incarnationId
+      } else {
+        // Without spawn-history or a fresh preparation, retained unattested
+        // bytes cannot be promoted to a newly known process identity.
+        this.setPtyIncarnation(ptyId, pty, incarnationId)
       }
       pty.connected = true
       pty.disconnectedAt = null
+    } else if (hadPublishedLifecycle || preparedReplacement) {
+      this.resetRecordlessPtyLifecycle(ptyId)
     }
+    // A controller-only operation may have captured a generation before the
+    // first real spawn. Fence that operation without revoking this process's
+    // preallocated handle.
+    if (
+      observedGeneration !== undefined &&
+      this.ptyLifecycleGenerationById.get(ptyId) === observedGeneration
+    ) {
+      this.advancePtyLifecycleGeneration(ptyId)
+    }
+    if (options.awaitsRegistration === false) {
+      this.ptyLifecycleAdmissions.delete(ptyId)
+    } else {
+      this.ptyLifecycleAdmissions.set(ptyId, 'spawned')
+    }
+    this.spawnPublishedPtys.add(ptyId)
+    this.ptyIdsWithPublishedLifecycle.add(ptyId)
     for (const leaf of this.getLeavesForPty(ptyId)) {
       leaf.connected = true
       leaf.writable = this.graphStatus === 'ready'
@@ -10785,9 +10871,36 @@ export class OrcaRuntimeService {
     },
     isWsl?: boolean
   ): void {
-    this.assertPtyDidNotExitBeforeRegistration(ptyId, binding?.incarnationId)
+    const lifecycleAdmission = this.ptyLifecycleAdmissions.get(ptyId)
+    const lifecycleAlreadyFenced = lifecycleAdmission !== undefined
+    const hasPendingIncarnation = this.pendingPtyRegistrationIncarnations.has(ptyId)
+    const pendingIncarnation = this.pendingPtyRegistrationIncarnations.get(ptyId)
+    const admissionIncarnationId = binding?.incarnationId ?? pendingIncarnation ?? undefined
+    this.assertPtyDidNotExitBeforeRegistration(ptyId, admissionIncarnationId)
     this.forgetPtyLivenessVerdict(ptyId)
-    this.spawnPublishedPtys.add(ptyId)
+    const existingPty = this.ptysById.get(ptyId)
+    if (
+      existingPty &&
+      admissionIncarnationId === undefined &&
+      !lifecycleAlreadyFenced &&
+      (!existingPty.connected || hasPendingIncarnation)
+    ) {
+      // Why: a registration after exit, or an explicit pending unknown
+      // admission, can be the first observable boundary for legacy providers.
+      // Unknown proof must revoke prior authority before connected=true.
+      this.revokePtyIncarnationForUnattestedLifecycle(ptyId, existingPty, hasPendingIncarnation)
+    }
+    if (
+      existingPty &&
+      lifecycleAdmission === 'spawned' &&
+      existingPty.incarnationId === null &&
+      admissionIncarnationId !== undefined
+    ) {
+      // onPtySpawned is the provider's process boundary. It already cleared a
+      // replacement's pre-callback bytes, so a later registration may attest
+      // the admitted null identity without discarding this process's output.
+      existingPty.incarnationId = admissionIncarnationId
+    }
     // Why: record the renderer pane identity at spawn time so a stalled graph
     // sync can't hide that a live PTY already backs a pending mobile create.
     const paneKey =
@@ -10802,8 +10915,10 @@ export class OrcaRuntimeService {
         : {}),
       ...(isWsl !== undefined ? { isWsl } : {}),
       ...(binding && paneKey ? { tabId: binding.tabId, paneKey } : {}),
-      ...(binding?.incarnationId ? { incarnationId: binding.incarnationId } : {})
+      ...(admissionIncarnationId ? { incarnationId: admissionIncarnationId } : {})
     })
+    this.spawnPublishedPtys.add(ptyId)
+    this.ptyIdsWithPublishedLifecycle.add(ptyId)
     const agentLaunchAuthority = binding?.agentLaunchAuthority
     if (
       agentLaunchAuthority &&
@@ -10820,15 +10935,14 @@ export class OrcaRuntimeService {
       pty.launchIncarnationId = binding.incarnationId
       pty.launchAgent = agentLaunchAuthority.launchAgent
     }
-    const pendingIncarnation = this.pendingPtyRegistrationIncarnations.get(ptyId)
     if (
       pendingIncarnation === null ||
       pendingIncarnation === undefined ||
-      binding?.incarnationId === undefined ||
-      pendingIncarnation === binding.incarnationId
+      pendingIncarnation === admissionIncarnationId
     ) {
       this.pendingPtyRegistrationIncarnations.delete(ptyId)
     }
+    this.ptyLifecycleAdmissions.delete(ptyId)
     // Why: the renderer's own PTY spawn is the reliable signal that the pending
     // mobile create's tab is live; publish its surface main-side (#7587).
     if (binding && paneKey) {
@@ -10857,6 +10971,7 @@ export class OrcaRuntimeService {
       // Why: the rejected spawn call was the fence's sole late publisher; retaining it leaks fresh PTY ids.
       this.earlyExitedPtyIncarnations.delete(ptyId)
       this.pendingPtyRegistrationIncarnations.delete(ptyId)
+      this.ptyLifecycleAdmissions.delete(ptyId)
     }
   }
 
@@ -10868,7 +10983,7 @@ export class OrcaRuntimeService {
     const pty = this.ptysById.get(ptyId)
     if (pty) {
       // Why: a reconnect attach reply can prove the exit generation after stale local proof was cleared.
-      pty.incarnationId = incarnationId
+      this.setPtyIncarnation(ptyId, pty, incarnationId)
     }
   }
 
@@ -10881,6 +10996,7 @@ export class OrcaRuntimeService {
       return
     }
     this.pendingPtyRegistrationIncarnations.delete(ptyId)
+    this.ptyLifecycleAdmissions.delete(ptyId)
     const exited = this.earlyExitedPtyIncarnations.get(ptyId)
     if (
       exited === null ||
@@ -10916,7 +11032,13 @@ export class OrcaRuntimeService {
     options: { resetIncarnation?: boolean; preserveExisting?: boolean } = {}
   ): boolean {
     const pty = this.ptysById.get(ptyId)
-    const hadExistingContext = this.wslDistroByPtyId.has(ptyId) || pty !== undefined
+    const hadPublishedLifecycle = this.ptyIdsWithPublishedLifecycle.has(ptyId)
+    const observedGeneration = this.ptyLifecycleGenerationById.get(ptyId)
+    const hadExistingContext =
+      this.wslDistroByPtyId.has(ptyId) ||
+      pty !== undefined ||
+      this.ptyLifecycleAdmissions.has(ptyId)
+    const preparesReplacement = hadExistingContext || hadPublishedLifecycle
     if (options.preserveExisting && hadExistingContext) {
       // Why: attach-time settings are only a fallback; a live PTY's recorded
       // execution namespace remains authoritative until its provider replies.
@@ -10926,6 +11048,24 @@ export class OrcaRuntimeService {
     if (options.resetIncarnation) {
       // Why: an explicit new lifecycle supersedes an unidentifiable exit from the reused PTY id.
       this.earlyExitedPtyIncarnations.delete(ptyId)
+      if (pty) {
+        this.resetPtyReadStateForProvenanceChange(ptyId, pty)
+        this.invalidatePtyHandlesForProvenanceChange(ptyId)
+        pty.incarnationId = null
+      } else if (hadExistingContext || hadPublishedLifecycle) {
+        // Why: execution context can precede the PTY record. A repeated reset
+        // still retires any handle preallocation from the previous lifecycle.
+        this.resetRecordlessPtyLifecycle(ptyId)
+      } else if (observedGeneration !== undefined) {
+        // A preview/read may have installed a generation before the first
+        // process. Fence that async operation but preserve the first process's
+        // preallocated handle.
+        this.advancePtyLifecycleGeneration(ptyId)
+      }
+      this.ptyLifecycleAdmissions.set(
+        ptyId,
+        preparesReplacement ? 'prepared-replacement' : 'prepared'
+      )
       this.disposeHeadlessTerminal(ptyId)
       this.osc7ScanTailByPtyId.delete(ptyId)
       this.terminalCwdByPtyId.delete(ptyId)
@@ -12217,25 +12357,176 @@ export class OrcaRuntimeService {
     return generation
   }
 
-  private advancePtyLifecycleGeneration(ptyId: string): void {
+  private getPtyProvenanceGeneration(ptyId: string): number {
+    const existing = this.ptyProvenanceGenerationById.get(ptyId)
+    if (existing !== undefined) {
+      return existing
+    }
+    const generation = this.nextPtyProvenanceGeneration++
+    this.ptyProvenanceGenerationById.set(ptyId, generation)
+    return generation
+  }
+
+  private advancePtyLifecycleGeneration(ptyId: string, provenanceChanged = true): void {
     this.ptyLifecycleGenerationById.set(ptyId, this.nextPtyLifecycleGeneration++)
-    // Why: a stop whose exit never arrived would otherwise stay armed across a
-    // same-id respawn and label the NEXT process's crash an operator close —
-    // the exact lie this cause model exists to remove.
-    this.stopRequestedPtyIds.delete(ptyId)
-    this.agentPromptLifecycleByPtyId.delete(ptyId)
-    this.agentPromptPermissionSequenceByPtyId.delete(ptyId)
-    this.agentPromptExplicitStatusFloorByPtyId.set(ptyId, Date.now())
-    this.legacyWorkerRecoveredPtys.delete(ptyId)
-    // Why: a respawn under the same session id needs its own subscriber-driven attach.
-    this.subscriberDrivenProviderAttachesByPtyId.delete(ptyId)
-    this.subscriberDrivenProviderAttachInventoryWaiters.delete(ptyId)
-    this.spawnPublishedPtys.delete(ptyId)
+    if (provenanceChanged) {
+      this.ptyProvenanceGenerationById.set(ptyId, this.nextPtyProvenanceGeneration++)
+      // Admission belongs to exactly one process lifecycle. Retaining it after
+      // exit would let a legacy same-id registration skip unknown-provenance
+      // revocation in the replacement lifecycle.
+      this.ptyLifecycleAdmissions.delete(ptyId)
+      // Why: a stop whose exit never arrived would otherwise stay armed across
+      // a same-id respawn and label the next process's crash an operator close.
+      this.stopRequestedPtyIds.delete(ptyId)
+      this.agentPromptLifecycleByPtyId.delete(ptyId)
+      this.agentPromptPermissionSequenceByPtyId.delete(ptyId)
+      this.agentPromptExplicitStatusFloorByPtyId.set(ptyId, Date.now())
+      this.legacyWorkerRecoveredPtys.delete(ptyId)
+      // Why: a respawn under the same session id needs its own subscriber-driven attach.
+      this.subscriberDrivenProviderAttachesByPtyId.delete(ptyId)
+      this.subscriberDrivenProviderAttachInventoryWaiters.delete(ptyId)
+      this.spawnPublishedPtys.delete(ptyId)
+    }
     // Why: a provider response belongs to the process generation that issued
-    // it; a respawn must neither reuse its frame nor join its in-flight call.
+    // it; both a frame-domain reset and a respawn must retire in-flight calls.
     this.providerBufferAcquisitionsByPtyId.delete(ptyId)
     this.providerVisibleStateByPtyId.delete(ptyId)
     this.providerVisibleRetryAtByPtyId.delete(ptyId)
+  }
+
+  private resetRecordlessPtyLifecycle(ptyId: string): void {
+    // Why: a published or repeatedly prepared recordless PTY is an actual
+    // prior lifecycle. Lazy generation observation alone is handled by the
+    // caller and never revokes a first-process preallocation.
+    this.resetPtyReadStateForProvenanceChange(ptyId)
+    this.invalidatePtyHandlesForProvenanceChange(ptyId)
+  }
+
+  private clearRetainedTerminalReadState(
+    record: RuntimePtyWorktreeRecord | RuntimeLeafRecord
+  ): void {
+    record.lastOutputAt = null
+    record.lastExitCode = null
+    record.lastExitCause = null
+    record.tailBuffer = []
+    record.tailTranscriptBuffer = []
+    record.tailTranscriptChars = 0
+    record.tailPartialLine = ''
+    record.tailPendingAnsi = ''
+    record.tailRedrawCursor = null
+    record.tailTruncated = false
+    record.tailLinesTotal = 0
+    record.preview = ''
+    record.waitBlockedAt = null
+    record.tailWaitState = undefined
+  }
+
+  private hasRetainedTerminalReadState(
+    record: RuntimePtyWorktreeRecord | RuntimeLeafRecord
+  ): boolean {
+    return (
+      record.lastOutputAt !== null ||
+      record.lastExitCode !== null ||
+      record.lastExitCause !== null ||
+      record.tailBuffer.length > 0 ||
+      record.tailTranscriptBuffer.length > 0 ||
+      record.tailTranscriptChars > 0 ||
+      record.tailPartialLine.length > 0 ||
+      record.tailPendingAnsi.length > 0 ||
+      record.tailRedrawCursor !== null ||
+      record.tailTruncated ||
+      record.tailLinesTotal > 0 ||
+      record.preview.length > 0 ||
+      record.waitBlockedAt !== null ||
+      record.tailWaitState !== undefined
+    )
+  }
+
+  private hasUnattestedPtyReadState(ptyId: string, pty: RuntimePtyWorktreeRecord): boolean {
+    return (
+      this.hasRetainedTerminalReadState(pty) ||
+      this.getLeavesForPty(ptyId).some((leaf) => this.hasRetainedTerminalReadState(leaf)) ||
+      this.headlessTerminals.has(ptyId) ||
+      this.headlessHydrationState.has(ptyId) ||
+      this.legacyWorkerRecoveredPtys.has(ptyId) ||
+      this.recentPtyOutputById.has(ptyId) ||
+      this.recentPtyPathCandidatesById.has(ptyId) ||
+      this.ptyOutputSequenceById.has(ptyId) ||
+      this.providerSequenceInitializedPtys.has(ptyId) ||
+      this.providerSequenceOffsetByPtyId.has(ptyId) ||
+      this.providerSnapshotPreferredPtys.has(ptyId) ||
+      this.providerModeTrackersByPtyId.has(ptyId) ||
+      this.providerModeSnapshotScansByPtyId.has(ptyId) ||
+      this.providerBufferAcquisitionsByPtyId.has(ptyId) ||
+      this.providerVisibleStateByPtyId.has(ptyId) ||
+      this.providerVisibleRetryAtByPtyId.has(ptyId)
+    )
+  }
+
+  private resetPtyReadStateForProvenanceChange(
+    ptyId: string,
+    pty?: RuntimePtyWorktreeRecord
+  ): void {
+    // Why: a provider may reuse a PTY id for a different process or execution
+    // owner. Every byte, cursor, emulator, and in-flight snapshot retained
+    // under that id belongs to the prior or still-unattested provenance and
+    // must become unreachable before publishing its replacement identity.
+    this.advancePtyLifecycleGeneration(ptyId)
+    this.disposeHeadlessTerminal(ptyId)
+    this.recentPtyOutputById.delete(ptyId)
+    this.recentPtyPathCandidatesById.delete(ptyId)
+    this.clearWaitBlockedCheckState(ptyId)
+    this.ptyOutputSequenceById.delete(ptyId)
+    this.providerSequenceInitializedPtys.delete(ptyId)
+    this.providerSequenceOffsetByPtyId.delete(ptyId)
+    this.providerSnapshotPreferredPtys.delete(ptyId)
+    this.providerModeTrackersByPtyId.delete(ptyId)
+    this.providerModeSnapshotScansByPtyId.delete(ptyId)
+    this.terminalCwdByPtyId.delete(ptyId)
+    this.terminalFileUriHostnameByPtyId.delete(ptyId)
+    if (pty) {
+      this.clearRetainedTerminalReadState(pty)
+    }
+    for (const leaf of this.getLeavesForPty(ptyId)) {
+      this.clearRetainedTerminalReadState(leaf)
+    }
+    this.resetTrackedTerminalStateForProviderGeneration(ptyId)
+  }
+
+  private invalidatePtyHandlesForProvenanceChange(ptyId: string): void {
+    this.invalidateAllHandlesForPty(ptyId)
+    this.detachedPreAllocatedLeaves.delete(ptyId)
+  }
+
+  private setPtyIncarnation(
+    ptyId: string,
+    pty: RuntimePtyWorktreeRecord,
+    incarnationId: PtyIncarnationId | null
+  ): void {
+    const incarnationChanged = pty.incarnationId !== incarnationId
+    const requiresProvenanceReset =
+      incarnationChanged &&
+      (pty.incarnationId !== null || this.hasUnattestedPtyReadState(ptyId, pty))
+    if (requiresProvenanceReset) {
+      this.resetPtyReadStateForProvenanceChange(ptyId, pty)
+      this.invalidatePtyHandlesForProvenanceChange(ptyId)
+    }
+    pty.incarnationId = incarnationId
+  }
+
+  private revokePtyIncarnationForUnattestedLifecycle(
+    ptyId: string,
+    pty: RuntimePtyWorktreeRecord,
+    forceReset = false
+  ): void {
+    if (pty.incarnationId !== null) {
+      this.setPtyIncarnation(ptyId, pty, null)
+      return
+    }
+    if (forceReset || this.hasUnattestedPtyReadState(ptyId, pty)) {
+      this.resetPtyReadStateForProvenanceChange(ptyId, pty)
+      this.invalidatePtyHandlesForProvenanceChange(ptyId)
+    }
   }
 
   synchronizePtyOutputSequenceFromProvider(
@@ -12264,7 +12555,9 @@ export class OrcaRuntimeService {
     const providerBaseline = providerOffset + baseline
 
     if (providerSequence.generation === 'reset') {
-      this.advancePtyLifecycleGeneration(ptyId)
+      // A provider frame reset invalidates guarded async snapshots, but it is
+      // not by itself proof that the terminal process or owner changed.
+      this.advancePtyLifecycleGeneration(ptyId, false)
       // Why: daemon respawn/cold restore starts a new absolute domain. Old
       // emulator state cannot remain authoritative over the replacement.
       if (replacesExistingRuntimeGeneration) {
@@ -12621,8 +12914,10 @@ export class OrcaRuntimeService {
       return false
     }
     try {
+      const identity = this.capturePtyProvenanceIdentity(ptyId)
       await assertTerminalInputWithinLimitWithYield(data)
-      await this.writeTerminalInputChunks(ptyId, data, {
+      this.assertTerminalProvenanceIdentity(identity)
+      await this.writeTerminalInputChunks(ptyId, data, identity, {
         // Why: a phone can claim the floor while a paste yields between chunks.
         beforeWrite: () => {
           if (this.getDriver(ptyId).kind === 'mobile') {
@@ -15189,6 +15484,9 @@ export class OrcaRuntimeService {
       exitIncarnationId ??
       pty?.incarnationId ??
       `runtime:${this.runtimeId}:${this.getPtyLifecycleGeneration(ptyId)}`
+    // Exit is authoritative evidence that this id already named a process,
+    // even when its spawn/register publication predates this runtime instance.
+    this.ptyIdsWithPublishedLifecycle.add(ptyId)
     this.advancePtyLifecycleGeneration(ptyId)
     this.notifyPtyExitListeners(ptyId)
     const exactSurfaceByKey = new Map<
@@ -18450,20 +18748,53 @@ export class OrcaRuntimeService {
 
   async readTerminal(
     handle: string,
-    opts: { cursor?: number; limit?: number; screen?: boolean } = {},
+    opts: {
+      expectedIncarnationId?: PtyIncarnationId
+      cursor?: number
+      limit?: number
+      screen?: boolean
+    } = {},
     providerWait: { timeoutMs?: number; retireOnTimeout?: boolean } = {}
   ): Promise<RuntimeTerminalRead> {
     const pty = this.getLivePtyForHandle(handle)
     if (pty) {
+      if (!runtimeWorktreeIdsEqual(pty.record.worktreeId, pty.pty.worktreeId)) {
+        throw new Error('terminal_handle_stale')
+      }
+      const identity: TerminalProvenanceIdentity = {
+        handle,
+        ptyId: pty.pty.ptyId,
+        incarnationId: pty.pty.incarnationId,
+        worktreeId: pty.pty.worktreeId,
+        lifecycleGeneration: this.getPtyLifecycleGeneration(pty.pty.ptyId),
+        provenanceGeneration: this.getPtyProvenanceGeneration(pty.pty.ptyId)
+      }
+      this.assertExpectedTerminalReadIncarnation(identity, opts.expectedIncarnationId)
       const read = this.readPtyTerminal(handle, pty.pty, opts)
       const visibleRead = opts.screen
         ? await this.readRenderedScreen(pty.pty.ptyId, read, opts)
         : await this.withVisibleSnapshotFallback(pty.pty.ptyId, read, opts, providerWait)
-      this.assertLiveTerminalHandleTargetsPty(handle, pty.pty.ptyId)
-      return labelTerminalReadSource(visibleRead)
+      this.assertTerminalProvenanceIdentity(identity, opts.expectedIncarnationId !== undefined)
+      return attestTerminalRead(labelTerminalReadSource(visibleRead), identity)
     }
 
-    const { leaf } = this.getLiveLeafForHandle(handle)
+    const { record, leaf } = this.getLiveLeafForHandle(handle)
+    if (!runtimeWorktreeIdsEqual(record.worktreeId, leaf.worktreeId)) {
+      throw new Error('terminal_handle_stale')
+    }
+    const leafPty = leaf.ptyId ? this.ptysById.get(leaf.ptyId) : undefined
+    if (leafPty && !runtimeWorktreeIdsEqual(leafPty.worktreeId, leaf.worktreeId)) {
+      throw new Error('terminal_handle_stale')
+    }
+    const identity: TerminalProvenanceIdentity = {
+      handle,
+      ptyId: leaf.ptyId,
+      incarnationId: leafPty?.incarnationId ?? null,
+      worktreeId: leaf.worktreeId,
+      lifecycleGeneration: leaf.ptyId ? this.getPtyLifecycleGeneration(leaf.ptyId) : null,
+      provenanceGeneration: leaf.ptyId ? this.getPtyProvenanceGeneration(leaf.ptyId) : null
+    }
+    this.assertExpectedTerminalReadIncarnation(identity, opts.expectedIncarnationId)
     const read = readTerminalTail({
       handle,
       status: getTerminalState(leaf),
@@ -18476,13 +18807,16 @@ export class OrcaRuntimeService {
       limit: opts.limit
     })
     if (!leaf.ptyId) {
-      return { ...read, source: opts.screen ? 'screen-unavailable' : 'stream' }
+      return attestTerminalRead(
+        { ...read, source: opts.screen ? 'screen-unavailable' : 'stream' },
+        identity
+      )
     }
     const visibleRead = opts.screen
       ? await this.readRenderedScreen(leaf.ptyId, read, opts)
       : await this.withVisibleSnapshotFallback(leaf.ptyId, read, opts, providerWait)
-    this.assertLiveTerminalHandleTargetsPty(handle, leaf.ptyId)
-    return labelTerminalReadSource(visibleRead)
+    this.assertTerminalProvenanceIdentity(identity, opts.expectedIncarnationId !== undefined)
+    return attestTerminalRead(labelTerminalReadSource(visibleRead), identity)
   }
 
   // Why: the default read is the accumulated pty stream, which stacks every repaint of a line
@@ -18588,8 +18922,11 @@ export class OrcaRuntimeService {
       if (payload === null) {
         throw new Error('invalid_terminal_send')
       }
+      const identity = this.captureTerminalProvenanceIdentity(handle)
       await assertTerminalInputWithinLimitWithYield(action.text)
-      await this.writeTerminalAction(pty.pty.ptyId, action, payload, options)
+      this.assertTerminalProvenanceIdentity(identity)
+      await this.writeTerminalAction(pty.pty.ptyId, action, payload, identity, options)
+      this.assertTerminalProvenanceIdentity(identity)
       return {
         handle,
         accepted: true,
@@ -18605,16 +18942,21 @@ export class OrcaRuntimeService {
     if (payload === null) {
       throw new Error('invalid_terminal_send')
     }
+    const identity = this.captureTerminalProvenanceIdentity(handle)
     await assertTerminalInputWithinLimitWithYield(action.text)
+    this.assertTerminalProvenanceIdentity(identity)
     // Why: leaf.writable mirrors the renderer graph, which can still answer for
     // a prior process's ptyId — and provider writes to unknown ids are accepted
     // no-ops. Only controller-proven absence rejects; unknown proceeds (a
     // restored daemon session takes writes before its pane remounts).
-    if (await this.isLeafPtyProvenAbsent(leaf.ptyId)) {
+    const ptyProvenAbsent = await this.isLeafPtyProvenAbsent(leaf.ptyId)
+    this.assertTerminalProvenanceIdentity(identity)
+    if (ptyProvenAbsent) {
       throw new Error('terminal_not_writable')
     }
 
-    await this.writeTerminalAction(leaf.ptyId, action, payload, options)
+    await this.writeTerminalAction(leaf.ptyId, action, payload, identity, options)
+    this.assertTerminalProvenanceIdentity(identity)
 
     return {
       handle,
@@ -19268,6 +19610,7 @@ export class OrcaRuntimeService {
     ptyId: string,
     action: { text?: string; enter?: boolean; interrupt?: boolean },
     payload: string,
+    identity: TerminalProvenanceIdentity,
     options: {
       beforeWrite?: (ptyId: string) => void | Promise<void>
       reserveWrite?: (ptyId: string) => void
@@ -19280,17 +19623,27 @@ export class OrcaRuntimeService {
     const hasText = typeof action.text === 'string' && action.text.length > 0
     const hasSuffix = action.enter || action.interrupt
     if (hasText) {
-      await this.writeTerminalInputChunks(ptyId, action.text!, options)
+      await this.writeTerminalInputChunks(ptyId, action.text!, identity, options)
     }
     if (hasSuffix) {
       const suffix = (action.enter ? '\r' : '') + (action.interrupt ? '\x03' : '')
       if (hasText) {
         await new Promise((resolve) => setTimeout(resolve, 500))
+        this.assertTerminalProvenanceIdentity(identity)
       }
       try {
-        await options.beforeWrite?.(ptyId)
-        options.reserveWrite?.(ptyId)
+        await this.runTerminalWriteHookWithProvenance(options.beforeWrite, ptyId, identity)
       } catch (error) {
+        this.assertTerminalProvenanceIdentity(identity)
+        if (options.suffixFailureError) {
+          throw new Error(options.suffixFailureError)
+        }
+        throw error
+      }
+      try {
+        this.runTerminalWriteReservationWithProvenance(options.reserveWrite, ptyId, identity)
+      } catch (error) {
+        this.assertTerminalProvenanceIdentity(identity)
         if (options.suffixFailureError) {
           throw new Error(options.suffixFailureError)
         }
@@ -19300,25 +19653,26 @@ export class OrcaRuntimeService {
       if (!suffixWrote) {
         throw new Error(options.suffixFailureError ?? 'terminal_not_writable')
       }
-      await options.afterWrite?.(ptyId)
+      await this.runTerminalWriteHookWithProvenance(options.afterWrite, ptyId, identity)
       return
     }
     if (hasText) {
       return
     }
 
-    await options.beforeWrite?.(ptyId)
-    options.reserveWrite?.(ptyId)
+    await this.runTerminalWriteHookWithProvenance(options.beforeWrite, ptyId, identity)
+    this.runTerminalWriteReservationWithProvenance(options.reserveWrite, ptyId, identity)
     const wrote = this.ptyController?.write(ptyId, payload) ?? false
     if (!wrote) {
       throw new Error('terminal_not_writable')
     }
-    await options.afterWrite?.(ptyId)
+    await this.runTerminalWriteHookWithProvenance(options.afterWrite, ptyId, identity)
   }
 
   private async writeTerminalInputChunks(
     ptyId: string,
     text: string,
+    identity: TerminalProvenanceIdentity,
     options: {
       beforeWrite?: (ptyId: string) => void | Promise<void>
       reserveWrite?: (ptyId: string) => void
@@ -19328,18 +19682,48 @@ export class OrcaRuntimeService {
     const chunks = iterateTerminalInputChunks(text)
     let chunk = chunks.next()
     while (!chunk.done) {
-      await options.beforeWrite?.(ptyId)
-      options.reserveWrite?.(ptyId)
+      await this.runTerminalWriteHookWithProvenance(options.beforeWrite, ptyId, identity)
+      this.runTerminalWriteReservationWithProvenance(options.reserveWrite, ptyId, identity)
       const wrote = this.ptyController?.write(ptyId, chunk.value) ?? false
       if (!wrote) {
         throw new Error('terminal_not_writable')
       }
-      await options.afterWrite?.(ptyId)
+      await this.runTerminalWriteHookWithProvenance(options.afterWrite, ptyId, identity)
       chunk = chunks.next()
       if (!chunk.done) {
         await new Promise((resolve) => setTimeout(resolve, 0))
+        this.assertTerminalProvenanceIdentity(identity)
       }
     }
+  }
+
+  private runTerminalWriteReservationWithProvenance(
+    reserveWrite: ((ptyId: string) => void) | undefined,
+    ptyId: string,
+    identity: TerminalProvenanceIdentity
+  ): void {
+    this.assertTerminalProvenanceIdentity(identity)
+    try {
+      reserveWrite?.(ptyId)
+    } catch (error) {
+      this.assertTerminalProvenanceIdentity(identity)
+      throw error
+    }
+    this.assertTerminalProvenanceIdentity(identity)
+  }
+
+  private async runTerminalWriteHookWithProvenance(
+    hook: ((ptyId: string) => void | Promise<void>) | undefined,
+    ptyId: string,
+    identity: TerminalProvenanceIdentity
+  ): Promise<void> {
+    try {
+      await hook?.(ptyId)
+    } catch (error) {
+      this.assertTerminalProvenanceIdentity(identity)
+      throw error
+    }
+    this.assertTerminalProvenanceIdentity(identity)
   }
 
   private async writeTerminalAgentPrompt(
@@ -32365,12 +32749,16 @@ export class OrcaRuntimeService {
       return pty
     }
 
+    const worktreeChanged = !runtimeWorktreeIdsEqual(pty.worktreeId, worktreeId)
+    if (worktreeChanged) {
+      this.resetPtyReadStateForProvenanceChange(ptyId, pty)
+      this.invalidatePtyHandlesForProvenanceChange(ptyId)
+    }
     pty.worktreeId = worktreeId
-    if (state.incarnationId !== undefined) {
-      if (pty.incarnationId && state.incarnationId && pty.incarnationId !== state.incarnationId) {
-        this.invalidatePtyIncarnationHandle(ptyId)
-      }
-      pty.incarnationId = state.incarnationId
+    if (worktreeChanged) {
+      pty.incarnationId = state.incarnationId ?? null
+    } else if (state.incarnationId !== undefined) {
+      this.setPtyIncarnation(ptyId, pty, state.incarnationId)
     }
     if (state.connectionId !== undefined) {
       pty.connectionId = state.connectionId
@@ -35037,6 +35425,139 @@ export class OrcaRuntimeService {
     }
     const { leaf } = this.getLiveLeafForHandle(handle)
     if (leaf.ptyId !== expectedPtyId) {
+      throw new Error('terminal_handle_stale')
+    }
+  }
+
+  private assertExpectedTerminalReadIncarnation(
+    identity: TerminalProvenanceIdentity,
+    expectedIncarnationId: PtyIncarnationId | undefined
+  ): void {
+    if (expectedIncarnationId !== undefined && identity.incarnationId !== expectedIncarnationId) {
+      throw new Error('terminal_handle_stale')
+    }
+  }
+
+  private captureTerminalProvenanceIdentity(handle: string): TerminalProvenanceIdentity {
+    const currentPty = this.getLivePtyForHandle(handle)
+    if (currentPty) {
+      if (!runtimeWorktreeIdsEqual(currentPty.record.worktreeId, currentPty.pty.worktreeId)) {
+        throw new Error('terminal_handle_stale')
+      }
+      return {
+        handle,
+        ptyId: currentPty.pty.ptyId,
+        incarnationId: currentPty.pty.incarnationId,
+        worktreeId: currentPty.pty.worktreeId,
+        lifecycleGeneration: this.getPtyLifecycleGeneration(currentPty.pty.ptyId),
+        provenanceGeneration: this.getPtyProvenanceGeneration(currentPty.pty.ptyId)
+      }
+    }
+
+    const current = this.getLiveLeafForHandle(handle)
+    if (!runtimeWorktreeIdsEqual(current.record.worktreeId, current.leaf.worktreeId)) {
+      throw new Error('terminal_handle_stale')
+    }
+    const currentLeafPty = current.leaf.ptyId ? this.ptysById.get(current.leaf.ptyId) : undefined
+    if (
+      currentLeafPty &&
+      !runtimeWorktreeIdsEqual(currentLeafPty.worktreeId, current.leaf.worktreeId)
+    ) {
+      throw new Error('terminal_handle_stale')
+    }
+    return {
+      handle,
+      ptyId: current.leaf.ptyId,
+      incarnationId: currentLeafPty?.incarnationId ?? null,
+      worktreeId: current.leaf.worktreeId,
+      lifecycleGeneration: current.leaf.ptyId
+        ? this.getPtyLifecycleGeneration(current.leaf.ptyId)
+        : null,
+      provenanceGeneration: current.leaf.ptyId
+        ? this.getPtyProvenanceGeneration(current.leaf.ptyId)
+        : null
+    }
+  }
+
+  private capturePtyProvenanceIdentity(ptyId: string): TerminalProvenanceIdentity {
+    const pty = this.ptysById.get(ptyId)
+    return {
+      handle: null,
+      ptyId,
+      incarnationId: pty?.incarnationId ?? null,
+      worktreeId: pty?.worktreeId ?? null,
+      lifecycleGeneration: this.getPtyLifecycleGeneration(ptyId),
+      provenanceGeneration: this.getPtyProvenanceGeneration(ptyId)
+    }
+  }
+
+  private assertTerminalProvenanceIdentity(
+    expected: TerminalProvenanceIdentity,
+    requireLifecycleGeneration = true
+  ): void {
+    if (expected.ptyId && expected.provenanceGeneration !== null) {
+      if (this.getPtyProvenanceGeneration(expected.ptyId) !== expected.provenanceGeneration) {
+        throw new Error('terminal_handle_stale')
+      }
+    }
+    if (requireLifecycleGeneration && expected.ptyId && expected.lifecycleGeneration !== null) {
+      if (this.getPtyLifecycleGeneration(expected.ptyId) !== expected.lifecycleGeneration) {
+        throw new Error('terminal_handle_stale')
+      }
+    }
+    if (expected.handle === null) {
+      const currentPty = expected.ptyId ? this.ptysById.get(expected.ptyId) : undefined
+      if (expected.worktreeId === null) {
+        if (currentPty) {
+          throw new Error('terminal_handle_stale')
+        }
+        return
+      }
+      if (
+        !currentPty ||
+        currentPty.incarnationId !== expected.incarnationId ||
+        !runtimeWorktreeIdsEqual(currentPty.worktreeId, expected.worktreeId)
+      ) {
+        throw new Error('terminal_handle_stale')
+      }
+      return
+    }
+    if (expected.worktreeId === null) {
+      throw new Error('terminal_handle_stale')
+    }
+    if (
+      !this.handles.has(expected.handle) &&
+      (expected.ptyId === null || this.handleByPtyId.get(expected.ptyId) !== expected.handle)
+    ) {
+      throw new Error('terminal_handle_stale')
+    }
+    const currentPty = this.getLivePtyForHandle(expected.handle)
+    if (currentPty) {
+      if (
+        currentPty.record.handle !== expected.handle ||
+        currentPty.record.ptyId !== expected.ptyId ||
+        !runtimeWorktreeIdsEqual(currentPty.record.worktreeId, expected.worktreeId) ||
+        currentPty.pty.ptyId !== expected.ptyId ||
+        currentPty.pty.incarnationId !== expected.incarnationId ||
+        !runtimeWorktreeIdsEqual(currentPty.pty.worktreeId, expected.worktreeId)
+      ) {
+        throw new Error('terminal_handle_stale')
+      }
+      return
+    }
+
+    const current = this.getLiveLeafForHandle(expected.handle)
+    const currentLeafPty = current.leaf.ptyId ? this.ptysById.get(current.leaf.ptyId) : undefined
+    if (
+      current.record.handle !== expected.handle ||
+      current.record.ptyId !== expected.ptyId ||
+      !runtimeWorktreeIdsEqual(current.record.worktreeId, expected.worktreeId) ||
+      current.leaf.ptyId !== expected.ptyId ||
+      !runtimeWorktreeIdsEqual(current.leaf.worktreeId, expected.worktreeId) ||
+      (currentLeafPty?.incarnationId ?? null) !== expected.incarnationId ||
+      (currentLeafPty !== undefined &&
+        !runtimeWorktreeIdsEqual(currentLeafPty.worktreeId, expected.worktreeId))
+    ) {
       throw new Error('terminal_handle_stale')
     }
   }
@@ -39862,6 +40383,17 @@ function buildVisibleSnapshotReadFallback(
       read.limited || lineBoundedTail.length < visibleLines.length || charBoundedTail.limited,
     returnedLineCount: charBoundedTail.tail.length,
     source: 'screen'
+  }
+}
+
+function attestTerminalRead(
+  read: RuntimeTerminalRead,
+  identity: TerminalProvenanceIdentity
+): RuntimeTerminalRead {
+  return {
+    ...read,
+    ...(identity.incarnationId ? { incarnationId: identity.incarnationId } : {}),
+    ...(identity.worktreeId ? { worktreeId: identity.worktreeId } : {})
   }
 }
 

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -74,6 +74,7 @@ import {
 import type { TerminalSnapshotUnavailableReason } from '../../../../shared/terminal-snapshot-unavailability'
 import type { RemoteTerminalSourceRangeReplacementReservation } from '../../remote-terminal-source-range-consumer'
 import { withTerminalCloseAttribution } from '../terminal-close-attribution'
+import { isPtyIncarnationId, type PtyIncarnationId } from '../../../../shared/pty-incarnation'
 
 const REQUESTED_SNAPSHOT_BYTE_BUDGET = 2 * 1024 * 1024
 const TERMINAL_OUTPUT_FLUSH_MS = 5
@@ -868,6 +869,11 @@ const TerminalHandle = z.object({
   terminal: requiredString('Missing terminal handle')
 })
 
+const TerminalIncarnationId = z.custom<PtyIncarnationId>(
+  isPtyIncarnationId,
+  'Invalid PTY incarnation'
+)
+
 const TerminalFocus = TerminalHandle.extend({
   navigation: z.enum(['caller', 'host']).optional()
 })
@@ -901,6 +907,7 @@ const TerminalRecoverPane = z.object({
 })
 
 const TerminalRead = TerminalHandle.extend({
+  expectedIncarnationId: TerminalIncarnationId.optional(),
   cursor: z
     .unknown()
     .transform((value) => {
@@ -1231,6 +1238,7 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
     params: TerminalRead,
     handler: async (params, { runtime }) => ({
       terminal: await runtime.readTerminal(params.terminal, {
+        expectedIncarnationId: params.expectedIncarnationId,
         cursor: params.cursor,
         limit: params.limit,
         screen: params.screen

--- a/src/main/runtime/rpc/terminal-read-incarnation-fence.test.ts
+++ b/src/main/runtime/rpc/terminal-read-incarnation-fence.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  RUNTIME_CAPABILITIES,
+  TERMINAL_READ_INCARNATION_FENCE_RUNTIME_CAPABILITY
+} from '../../../shared/protocol-version'
+import type { OrcaRuntimeService } from '../orca-runtime'
+import type { RpcRequest } from './core'
+import { RpcDispatcher } from './dispatcher'
+import { TERMINAL_METHODS } from './methods/terminal'
+
+function makeRequest(params: unknown): RpcRequest {
+  return { id: 'req-1', authToken: 'tok', method: 'terminal.read', params }
+}
+
+describe('terminal read incarnation fence RPC', () => {
+  it('passes the optional expected incarnation to the runtime', async () => {
+    const readTerminal = vi.fn().mockResolvedValue({
+      handle: 'term-1',
+      incarnationId: 'inc-1',
+      worktreeId: 'repo-1::/tmp/worktree',
+      status: 'running',
+      tail: [],
+      truncated: false,
+      nextCursor: null
+    })
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      readTerminal
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest({
+        terminal: 'term-1',
+        expectedIncarnationId: 'inc-1',
+        cursor: 12,
+        limit: 50
+      })
+    )
+
+    expect(response.ok).toBe(true)
+    expect(readTerminal).toHaveBeenCalledWith('term-1', {
+      expectedIncarnationId: 'inc-1',
+      cursor: 12,
+      limit: 50,
+      screen: undefined
+    })
+  })
+
+  it('keeps legacy requests valid when the optional fence is absent', async () => {
+    const readTerminal = vi.fn().mockResolvedValue({
+      handle: 'term-1',
+      status: 'running',
+      tail: [],
+      truncated: false,
+      nextCursor: null
+    })
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      readTerminal
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+
+    const response = await dispatcher.dispatch(makeRequest({ terminal: 'term-1' }))
+
+    expect(response.ok).toBe(true)
+    expect(readTerminal).toHaveBeenCalledWith('term-1', {
+      expectedIncarnationId: undefined,
+      cursor: undefined,
+      limit: undefined,
+      screen: undefined
+    })
+  })
+
+  it('preserves terminal_handle_stale as the guarded-read failure code', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      readTerminal: vi.fn().mockRejectedValue(new Error('terminal_handle_stale'))
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest({ terminal: 'term-1', expectedIncarnationId: 'inc-old' })
+    )
+
+    expect(response.ok).toBe(false)
+    if (response.ok) {
+      throw new Error('expected guarded read rejection')
+    }
+    expect(response.error.code).toBe('terminal_handle_stale')
+  })
+
+  it('rejects an oversized expected incarnation before calling the runtime', async () => {
+    const readTerminal = vi.fn()
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      readTerminal
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest({ terminal: 'term-1', expectedIncarnationId: 'x'.repeat(129) })
+    )
+
+    expect(response.ok).toBe(false)
+    expect(readTerminal).not.toHaveBeenCalled()
+  })
+
+  it('publishes the guarded-read capability', () => {
+    expect(RUNTIME_CAPABILITIES).toContain(TERMINAL_READ_INCARNATION_FENCE_RUNTIME_CAPABILITY)
+  })
+})

--- a/src/shared/protocol-version.ts
+++ b/src/shared/protocol-version.ts
@@ -81,6 +81,9 @@ export const TERMINAL_QUERY_REPLY_INPUT_RUNTIME_CAPABILITY =
 // Why: paired clients may unmount xterm only when the host can return a
 // bounded, sequenced scrollback snapshot for lossless reveal.
 export const TERMINAL_PAIRED_PARKING_RUNTIME_CAPABILITY = 'terminal.paired-parking.v1' as const
+// Why: guarded terminal reads require the host to atomically attest the PTY process incarnation.
+export const TERMINAL_READ_INCARNATION_FENCE_RUNTIME_CAPABILITY =
+  'terminal.read-incarnation-fence.v1' as const
 // Why: older hosts lack the targeted settings RPCs and strip agentPrompt from
 // terminal creation, so mobile must hide Quick Commands unless both are present.
 export const TERMINAL_QUICK_COMMANDS_RUNTIME_CAPABILITY = 'terminal.quick-commands.v1' as const
@@ -136,6 +139,7 @@ export const RUNTIME_CAPABILITIES = [
   AI_VAULT_SESSION_TITLES_RUNTIME_CAPABILITY,
   TERMINAL_QUERY_REPLY_INPUT_RUNTIME_CAPABILITY,
   TERMINAL_PAIRED_PARKING_RUNTIME_CAPABILITY,
+  TERMINAL_READ_INCARNATION_FENCE_RUNTIME_CAPABILITY,
   TERMINAL_QUICK_COMMANDS_RUNTIME_CAPABILITY,
   WORKTREE_CREATE_IDEMPOTENCY_RUNTIME_CAPABILITY,
   TERMINAL_CREATE_IDEMPOTENCY_RUNTIME_CAPABILITY,

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -643,6 +643,8 @@ export type RuntimeTerminalState = 'running' | 'exited' | 'unknown'
 
 export type RuntimeTerminalRead = {
   handle: string
+  incarnationId?: string
+  worktreeId?: string
   status: RuntimeTerminalState
   tail: string[]
   truncated: boolean


### PR DESCRIPTION
## ELI5

A terminal slot can be reused by a different process. This change lets automation prove that terminal output still belongs to the exact process it selected and stops an in-progress write if that process changes.

## What Changed

- Added the opt-in `terminal.read-incarnation-fence.v1` runtime capability.
- Added `expectedIncarnationId` to guarded terminal reads and identity fields to successful responses.
- Bound CLI capability negotiation and the read response to the same runtime ID.
- Added pre/post attestation of handle, PTY, process incarnation, worktree, lifecycle generation, and process provenance across asynchronous read and screen-snapshot paths.
- Reset retained terminal output and retire handles when process or worktree provenance changes.
- Fenced multi-chunk sends, delayed Enter/interrupt suffixes, and preview writes at every asynchronous/write boundary.
- Preserved first-lifecycle preallocated handles while revoking them on actual same-PTY replacement.
- Added focused CLI, RPC, runtime, renderer, provider, headless, and controller-only regression tests.

## Why

Handle-to-PTY validation alone cannot distinguish a replacement process that reused the same PTY ID. A list-before/read-after strategy also leaves a time-of-check/time-of-use window. The runtime must enforce the expected incarnation atomically around the operation.

## Linked Issue

Fixes #15584

## Visual Proof

N/A — CLI/RPC and runtime safety change with no UI changes.

## Testing

- `git diff --check origin/main...HEAD` passes.
- `pnpm install --frozen-lockfile` completed with Node 24.18.0 and pnpm 10.24.0.
- `pnpm run lint` passes.
- `pnpm run typecheck` passes.
- Focused Vitest coverage passes: 7 files, 1,306 tests passed, 1 skipped. This includes CLI capability negotiation, RPC forwarding, runtime provenance races, mobile preview writes, and CLI registry parity.
- `pnpm run build:desktop` passes, including relay, CLI, Electron/Vite, bundled-skill verification, and web projection.
- `pnpm run test` was executed. The repository-wide suite is not green in this local environment because unrelated baseline/environment tests fail in newline-path temporary Git fixtures and an `ssh2` mock that lacks the `utils` export; the focused feature suite above is green.
- `pnpm run build` was executed. The desktop build passes, then the native macOS step stops because the installed Swift is 5.5.2 while `native/computer-use-macos` requires Swift tools 6.0.

## AI Disclosure

OpenAI Codex was used for implementation, adversarial review, and test-case design. The final diff received independent architecture and security passes with no remaining blocker, high, or medium findings.

## Review

The change was reviewed for mixed-version fail-closed behavior, runtime restart races, renderer/provider snapshot races, headless/controller-only terminals, worktree reassignment, preallocated handles, same-handle null-incarnation reuse, and cross-platform/SSH runtime paths.

## Checklist

- [x] The change is scoped to terminal I/O provenance.
- [x] Backward compatibility is preserved through optional fields and explicit capability negotiation.
- [x] Security-relevant lifecycle and failure paths have regression tests.
- [x] No UI change requires visual proof.
- [x] Self-review and independent static reviews completed.
- [x] Local lint, typecheck, tests, and build run.