### PR TITLE
fix(agent-status): reconcile completed Claude background tasks

### DIFF
--- a/src/main/agent-hooks/server-hook-http-ingest.test.ts
+++ b/src/main/agent-hooks/server-hook-http-ingest.test.ts
@@ -165,6 +165,8 @@ describe('AgentHookServer listener replay', () => {
       })
       const parent = server.getStatusSnapshot()[0]
       const state = server._getStateForTests()
+      const parentPrompt = state.lastPromptByPaneKey.get(PANE)
+      const parentTool = state.lastToolByPaneKey.get(PANE)
       state.claudeSubagentRosterByPaneKey.set(
         PANE,
         new Map([['agent-1', { state: 'working', startedAt: 1 }]])
@@ -197,6 +199,8 @@ describe('AgentHookServer listener replay', () => {
         server._getStateForTests().claudeSubagentRosterByPaneKey.get(PANE)?.has('agent-1')
       ).toBe(true)
       expect(server._getStateForTests().claudeLeadStateByPaneKey.has(PANE)).toBe(false)
+      expect(server._getStateForTests().lastPromptByPaneKey.get(PANE)).toBe(parentPrompt)
+      expect(server._getStateForTests().lastToolByPaneKey.get(PANE)).toEqual(parentTool)
     } finally {
       server.stop()
       rmSync(dir, { recursive: true, force: true })

--- a/src/main/agent-hooks/server-hook-http-ingest.test.ts
+++ b/src/main/agent-hooks/server-hook-http-ingest.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { appendFileSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { AgentHookServer, _internals } from './server'
 import { AGENT_STATUS_MAX_FIELD_LENGTH } from '../../shared/agent-status-types'
 import { makePaneKey } from '../../shared/stable-pane-id'
@@ -127,6 +130,76 @@ describe('AgentHookServer listener replay', () => {
       expect(server._getStateForTests().claudeActiveSessionCronPaneKeys.has(PANE)).toBe(true)
     } finally {
       server.stop()
+    }
+  })
+
+  it('does not retire Claude subagents from a rejected idle status', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'claude-rejected-idle-'))
+    const transcriptPath = join(dir, 'session.jsonl')
+    writeFileSync(transcriptPath, '')
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      const env = server.buildPtyEnv()
+      const postHook = async (
+        source: 'codex' | 'claude',
+        payload: Record<string, unknown>
+      ): Promise<void> => {
+        const response = await fetch(
+          `http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/${source}`,
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+            },
+            body: JSON.stringify(buildBody(payload))
+          }
+        )
+        expect(response.status).toBe(204)
+      }
+
+      await postHook('codex', {
+        hook_event_name: 'UserPromptSubmit',
+        prompt: 'parent codex'
+      })
+      const parent = server.getStatusSnapshot()[0]
+      const state = server._getStateForTests()
+      state.claudeSubagentRosterByPaneKey.set(
+        PANE,
+        new Map([['agent-1', { state: 'working', startedAt: 1 }]])
+      )
+      state.claudeBackgroundTaskObservationsByPaneKey.set(
+        PANE,
+        new Map([['agent-1', { transcriptPath, transcriptByteOffset: 0, nonAgent: false }]])
+      )
+      appendFileSync(
+        transcriptPath,
+        `${JSON.stringify({
+          type: 'user',
+          promptSource: 'system',
+          origin: { kind: 'task-notification' },
+          message: {
+            content:
+              '<task-notification>\n<task-id>agent-1</task-id>\n<status>completed</status>\n</task-notification>'
+          }
+        })}\n`
+      )
+
+      await postHook('claude', {
+        hook_event_name: 'Notification',
+        notification_type: 'idle_prompt',
+        transcript_path: transcriptPath
+      })
+
+      expect(server.getStatusSnapshot()[0]).toEqual(parent)
+      expect(
+        server._getStateForTests().claudeSubagentRosterByPaneKey.get(PANE)?.has('agent-1')
+      ).toBe(true)
+      expect(server._getStateForTests().claudeLeadStateByPaneKey.has(PANE)).toBe(false)
+    } finally {
+      server.stop()
+      rmSync(dir, { recursive: true, force: true })
     }
   })
 

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -2037,30 +2037,66 @@ export class AgentHookServer {
       return { event: normalizeHookPayload(this.state, source, body, this.env) }
     }
     const previousRunningTask = this.state.claudeRunningNonAgentTaskPaneKeys.has(paneKey)
+    const previousTaskObservations = new Map(
+      this.state.claudeBackgroundTaskObservationsByPaneKey.get(paneKey) ?? []
+    )
+    const previousUnidentifiedTask =
+      this.state.claudeUnidentifiedRunningNonAgentTaskPaneKeys.has(paneKey)
     const previousActiveCron = this.state.claudeActiveSessionCronPaneKeys.has(paneKey)
     const event = normalizeHookPayload(this.state, source, body, this.env)
     const nextRunningTask = this.state.claudeRunningNonAgentTaskPaneKeys.has(paneKey)
+    const nextTaskObservations = new Map(
+      this.state.claudeBackgroundTaskObservationsByPaneKey.get(paneKey) ?? []
+    )
+    const nextUnidentifiedTask =
+      this.state.claudeUnidentifiedRunningNonAgentTaskPaneKeys.has(paneKey)
     const nextActiveCron = this.state.claudeActiveSessionCronPaneKeys.has(paneKey)
-    this.setClaudeBackgroundEvidence(paneKey, previousRunningTask, previousActiveCron)
+    this.setClaudeBackgroundEvidence(
+      paneKey,
+      previousRunningTask,
+      previousTaskObservations,
+      previousUnidentifiedTask,
+      previousActiveCron
+    )
     if (!event || event.paneKey !== paneKey) {
       return { event }
     }
     // Why: nested CLIs may inherit the pane key; only accepted statuses may mutate its background-work gate.
     return {
       event,
-      onAccepted: () => this.setClaudeBackgroundEvidence(paneKey, nextRunningTask, nextActiveCron)
+      onAccepted: () =>
+        this.setClaudeBackgroundEvidence(
+          paneKey,
+          nextRunningTask,
+          nextTaskObservations,
+          nextUnidentifiedTask,
+          nextActiveCron
+        )
     }
   }
 
   private setClaudeBackgroundEvidence(
     paneKey: string,
     hasRunningTask: boolean,
+    taskObservations: ReadonlyMap<
+      string,
+      { transcriptPath: string; transcriptByteOffset: number; nonAgent: boolean }
+    >,
+    hasUnidentifiedTask: boolean,
     hasActiveCron: boolean
   ): void {
     if (hasRunningTask) {
       this.state.claudeRunningNonAgentTaskPaneKeys.add(paneKey)
+      this.state.claudeBackgroundTaskObservationsByPaneKey.set(paneKey, new Map(taskObservations))
+      if (hasUnidentifiedTask) {
+        this.state.claudeUnidentifiedRunningNonAgentTaskPaneKeys.add(paneKey)
+      } else {
+        this.state.claudeUnidentifiedRunningNonAgentTaskPaneKeys.delete(paneKey)
+      }
     } else {
       this.state.claudeRunningNonAgentTaskPaneKeys.delete(paneKey)
+      this.state.claudeBackgroundTaskObservationsByPaneKey.delete(paneKey)
+      this.state.claudeUnidentifiedRunningNonAgentTaskPaneKeys.delete(paneKey)
     }
     if (hasActiveCron) {
       this.state.claudeActiveSessionCronPaneKeys.add(paneKey)
@@ -2386,8 +2422,12 @@ export class AgentHookServer {
         ? () => {
             if (envelope.claudeRunningNonAgentTask) {
               this.state.claudeRunningNonAgentTaskPaneKeys.add(paneKey)
+              this.state.claudeBackgroundTaskObservationsByPaneKey.delete(paneKey)
+              this.state.claudeUnidentifiedRunningNonAgentTaskPaneKeys.add(paneKey)
             } else {
               this.state.claudeRunningNonAgentTaskPaneKeys.delete(paneKey)
+              this.state.claudeBackgroundTaskObservationsByPaneKey.delete(paneKey)
+              this.state.claudeUnidentifiedRunningNonAgentTaskPaneKeys.delete(paneKey)
             }
           }
         : undefined
@@ -2620,6 +2660,8 @@ export class AgentHookServer {
           this.state.claudeSubagentRosterByPaneKey.delete(paneKey)
           this.state.claudeLeadStateByPaneKey.delete(paneKey)
           this.state.claudeRunningNonAgentTaskPaneKeys.delete(paneKey)
+          this.state.claudeBackgroundTaskObservationsByPaneKey.delete(paneKey)
+          this.state.claudeUnidentifiedRunningNonAgentTaskPaneKeys.delete(paneKey)
           this.state.claudeActiveSessionCronPaneKeys.delete(paneKey)
         }
       }

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -39,6 +39,7 @@ import {
   warnOnHookEnvOrVersionMismatch,
   writeEndpointFile,
   type AgentHookEventPayload,
+  type ClaudeLeadTurnState,
   type HookListenerState
 } from '../../shared/agent-hook-listener'
 import {
@@ -51,7 +52,8 @@ import {
   claudeTeammateIdMatchesName,
   claudeRosterHasRestoredSnapshotSubagent,
   claudeRosterHasWorkingSubagent,
-  claudeRosterToSnapshots
+  claudeRosterToSnapshots,
+  type ClaudeSubagentRoster
 } from '../../shared/claude-subagent-roster'
 import {
   isAgentHookSource,
@@ -118,6 +120,12 @@ type EnrichedAgentHookEventPayload = AgentHookEventPayload & {
 type NormalizedLocalHook = {
   event: AgentHookEventPayload | null
   onAccepted?: () => void
+}
+
+function cloneClaudeSubagentRoster(
+  roster: ClaudeSubagentRoster | undefined
+): ClaudeSubagentRoster | undefined {
+  return roster ? new Map(Array.from(roster, ([id, tracked]) => [id, { ...tracked }])) : undefined
 }
 
 type PersistedAgentHookEventPayload = Omit<
@@ -2043,6 +2051,10 @@ export class AgentHookServer {
     const previousUnidentifiedTask =
       this.state.claudeUnidentifiedRunningNonAgentTaskPaneKeys.has(paneKey)
     const previousActiveCron = this.state.claudeActiveSessionCronPaneKeys.has(paneKey)
+    const previousSubagentRoster = cloneClaudeSubagentRoster(
+      this.state.claudeSubagentRosterByPaneKey.get(paneKey)
+    )
+    const previousLeadState = this.cloneClaudeLeadState(paneKey)
     const event = normalizeHookPayload(this.state, source, body, this.env)
     const nextRunningTask = this.state.claudeRunningNonAgentTaskPaneKeys.has(paneKey)
     const nextTaskObservations = new Map(
@@ -2051,6 +2063,10 @@ export class AgentHookServer {
     const nextUnidentifiedTask =
       this.state.claudeUnidentifiedRunningNonAgentTaskPaneKeys.has(paneKey)
     const nextActiveCron = this.state.claudeActiveSessionCronPaneKeys.has(paneKey)
+    const nextSubagentRoster = cloneClaudeSubagentRoster(
+      this.state.claudeSubagentRosterByPaneKey.get(paneKey)
+    )
+    const nextLeadState = this.cloneClaudeLeadState(paneKey)
     this.setClaudeBackgroundEvidence(
       paneKey,
       previousRunningTask,
@@ -2058,13 +2074,15 @@ export class AgentHookServer {
       previousUnidentifiedTask,
       previousActiveCron
     )
+    this.setClaudeSubagentRoster(paneKey, previousSubagentRoster)
+    this.setClaudeLeadState(paneKey, previousLeadState)
     if (!event || event.paneKey !== paneKey) {
       return { event }
     }
-    // Why: nested CLIs may inherit the pane key; only accepted statuses may mutate its background-work gate.
+    // Why: nested CLIs may inherit the pane key; only accepted statuses may mutate Claude lifecycle evidence.
     return {
       event,
-      onAccepted: () =>
+      onAccepted: () => {
         this.setClaudeBackgroundEvidence(
           paneKey,
           nextRunningTask,
@@ -2072,6 +2090,35 @@ export class AgentHookServer {
           nextUnidentifiedTask,
           nextActiveCron
         )
+        this.setClaudeSubagentRoster(paneKey, nextSubagentRoster)
+        this.setClaudeLeadState(paneKey, nextLeadState)
+      }
+    }
+  }
+
+  private setClaudeSubagentRoster(paneKey: string, roster: ClaudeSubagentRoster | undefined): void {
+    if (roster) {
+      this.state.claudeSubagentRosterByPaneKey.set(paneKey, roster)
+    } else {
+      this.state.claudeSubagentRosterByPaneKey.delete(paneKey)
+    }
+  }
+
+  private cloneClaudeLeadState(paneKey: string): ClaudeLeadTurnState | undefined {
+    const lead = this.state.claudeLeadStateByPaneKey.get(paneKey)
+    return lead
+      ? {
+          ...lead,
+          ...(lead.stateBeforeWait ? { stateBeforeWait: { ...lead.stateBeforeWait } } : {})
+        }
+      : undefined
+  }
+
+  private setClaudeLeadState(paneKey: string, lead: ClaudeLeadTurnState | undefined): void {
+    if (lead) {
+      this.state.claudeLeadStateByPaneKey.set(paneKey, lead)
+    } else {
+      this.state.claudeLeadStateByPaneKey.delete(paneKey)
     }
   }
 

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -40,7 +40,8 @@ import {
   writeEndpointFile,
   type AgentHookEventPayload,
   type ClaudeLeadTurnState,
-  type HookListenerState
+  type HookListenerState,
+  type ToolSnapshot
 } from '../../shared/agent-hook-listener'
 import {
   createHookTransportInterferenceTracker,
@@ -2055,6 +2056,9 @@ export class AgentHookServer {
       this.state.claudeSubagentRosterByPaneKey.get(paneKey)
     )
     const previousLeadState = this.cloneClaudeLeadState(paneKey)
+    const previousPrompt = this.state.lastPromptByPaneKey.get(paneKey)
+    const previousTool = this.cloneClaudeToolState(paneKey)
+    const previousUnconfirmed = this.state.claudeUnconfirmedRestoredStatusPaneKeys.has(paneKey)
     const event = normalizeHookPayload(this.state, source, body, this.env)
     const nextRunningTask = this.state.claudeRunningNonAgentTaskPaneKeys.has(paneKey)
     const nextTaskObservations = new Map(
@@ -2067,6 +2071,9 @@ export class AgentHookServer {
       this.state.claudeSubagentRosterByPaneKey.get(paneKey)
     )
     const nextLeadState = this.cloneClaudeLeadState(paneKey)
+    const nextPrompt = this.state.lastPromptByPaneKey.get(paneKey)
+    const nextTool = this.cloneClaudeToolState(paneKey)
+    const nextUnconfirmed = this.state.claudeUnconfirmedRestoredStatusPaneKeys.has(paneKey)
     this.setClaudeBackgroundEvidence(
       paneKey,
       previousRunningTask,
@@ -2076,6 +2083,7 @@ export class AgentHookServer {
     )
     this.setClaudeSubagentRoster(paneKey, previousSubagentRoster)
     this.setClaudeLeadState(paneKey, previousLeadState)
+    this.setClaudeNormalizationCache(paneKey, previousPrompt, previousTool, previousUnconfirmed)
     if (!event || event.paneKey !== paneKey) {
       return { event }
     }
@@ -2092,6 +2100,7 @@ export class AgentHookServer {
         )
         this.setClaudeSubagentRoster(paneKey, nextSubagentRoster)
         this.setClaudeLeadState(paneKey, nextLeadState)
+        this.setClaudeNormalizationCache(paneKey, nextPrompt, nextTool, nextUnconfirmed)
       }
     }
   }
@@ -2119,6 +2128,34 @@ export class AgentHookServer {
       this.state.claudeLeadStateByPaneKey.set(paneKey, lead)
     } else {
       this.state.claudeLeadStateByPaneKey.delete(paneKey)
+    }
+  }
+
+  private cloneClaudeToolState(paneKey: string): ToolSnapshot | undefined {
+    const tool = this.state.lastToolByPaneKey.get(paneKey)
+    return tool ? { ...tool } : undefined
+  }
+
+  private setClaudeNormalizationCache(
+    paneKey: string,
+    prompt: string | undefined,
+    tool: ToolSnapshot | undefined,
+    restoredUnconfirmed: boolean
+  ): void {
+    if (prompt === undefined) {
+      this.state.lastPromptByPaneKey.delete(paneKey)
+    } else {
+      this.state.lastPromptByPaneKey.set(paneKey, prompt)
+    }
+    if (tool === undefined) {
+      this.state.lastToolByPaneKey.delete(paneKey)
+    } else {
+      this.state.lastToolByPaneKey.set(paneKey, tool)
+    }
+    if (restoredUnconfirmed) {
+      this.state.claudeUnconfirmedRestoredStatusPaneKeys.add(paneKey)
+    } else {
+      this.state.claudeUnconfirmedRestoredStatusPaneKeys.delete(paneKey)
     }
   }
 

--- a/src/main/ai-vault/session-scanner-claude-subagents.test.ts
+++ b/src/main/ai-vault/session-scanner-claude-subagents.test.ts
@@ -144,6 +144,8 @@ describe('listClaudeSubagentSessions', () => {
       {
         // Interim notification: superseded by the terminal one below.
         type: 'user',
+        promptSource: 'system',
+        origin: { kind: 'task-notification' },
         sessionId: 'parent-session',
         timestamp: '2026-07-05T10:00:30.000Z',
         message: {
@@ -154,6 +156,8 @@ describe('listClaudeSubagentSessions', () => {
       },
       {
         type: 'user',
+        promptSource: 'system',
+        origin: { kind: 'task-notification' },
         sessionId: 'parent-session',
         timestamp: '2026-07-05T10:01:00.000Z',
         message: {
@@ -163,13 +167,16 @@ describe('listClaudeSubagentSessions', () => {
         }
       },
       {
-        // queue-operation records carry the notification as a plain string.
-        type: 'queue-operation',
-        operation: 'enqueue',
+        type: 'user',
+        promptSource: 'system',
+        origin: { kind: 'task-notification' },
         sessionId: 'parent-session',
         timestamp: '2026-07-05T10:02:00.000Z',
-        content:
-          '<task-notification>\n<task-id>crashed</task-id>\n<status>failed</status>\n</task-notification>'
+        message: {
+          role: 'user',
+          content:
+            '<task-notification>\n<task-id>crashed</task-id>\n<status>failed</status>\n</task-notification>'
+        }
       },
       {
         // Synchronous Tasks finish with a toolUseResult record, no notification.
@@ -240,6 +247,8 @@ describe('listClaudeSubagentSessions', () => {
       },
       {
         type: 'user',
+        promptSource: 'system',
+        origin: { kind: 'task-notification' },
         sessionId: 'parent-session',
         timestamp: '2026-07-05T10:01:00.000Z',
         message: { role: 'user', content: notification }
@@ -269,6 +278,8 @@ describe('listClaudeSubagentSessions', () => {
     await writeJsonlFile(parentFilePath, [
       {
         type: 'user',
+        promptSource: 'system',
+        origin: { kind: 'task-notification' },
         sessionId: 'parent-session',
         timestamp: '2026-07-05T10:00:00.000Z',
         message: {

--- a/src/main/ai-vault/session-scanner-claude-subagents.test.ts
+++ b/src/main/ai-vault/session-scanner-claude-subagents.test.ts
@@ -167,16 +167,13 @@ describe('listClaudeSubagentSessions', () => {
         }
       },
       {
-        type: 'user',
-        promptSource: 'system',
-        origin: { kind: 'task-notification' },
+        // The view-only scanner preserves historical queue-record support.
+        type: 'queue-operation',
+        operation: 'enqueue',
         sessionId: 'parent-session',
         timestamp: '2026-07-05T10:02:00.000Z',
-        message: {
-          role: 'user',
-          content:
-            '<task-notification>\n<task-id>crashed</task-id>\n<status>failed</status>\n</task-notification>'
-        }
+        content:
+          '<task-notification>\n<task-id>crashed</task-id>\n<status>failed</status>\n</task-notification>'
       },
       {
         // Synchronous Tasks finish with a toolUseResult record, no notification.

--- a/src/main/ai-vault/session-scanner-claude-subagents.ts
+++ b/src/main/ai-vault/session-scanner-claude-subagents.ts
@@ -7,6 +7,10 @@ import type {
   AiVaultSubagentRunStatus
 } from '../../shared/ai-vault-types'
 import {
+  CLAUDE_TASK_NOTIFICATION_MARKER,
+  parseClaudeTaskNotificationLine
+} from '../../shared/claude-task-notification'
+import {
   openTranscriptReadStream,
   wslGatedReaddir,
   wslGatedReadFile,
@@ -40,15 +44,12 @@ const SUBAGENT_PARSE_CONCURRENCY = 8
 // stays reserved for live transcript probes.
 const SUBAGENT_FS_PRIORITY = 'scan'
 
-const TASK_NOTIFICATION_MARKER = '<task-notification>'
 const TOOL_USE_RESULT_MARKER = '"toolUseResult"'
 // A sync-Task toolUseResult sets a status only when it carries an agentId. Tool
 // output records (Read/Bash) also carry "toolUseResult" and are the largest lines
 // in a transcript, so gating on this second marker keeps the status pass from
 // JSON-parsing ~all of the file's bytes on every on-demand fetch.
 const TOOL_USE_RESULT_AGENT_ID_MARKER = '"agentId"'
-const TASK_ID_PATTERN = /<task-id>([^<]+)<\/task-id>/
-const TASK_STATUS_PATTERN = /<status>([a-z_]+)<\/status>/
 
 // Statuses reported by parent-transcript <task-notification> records
 // (background Tasks) and toolUseResult records (synchronous Tasks).
@@ -214,7 +215,7 @@ async function collectSubagentTaskStatuses(parentFilePath: string): Promise<Map<
   const lines = createInterface({ input, crlfDelay: Infinity })
   try {
     for await (const line of lines) {
-      const hasNotification = line.includes(TASK_NOTIFICATION_MARKER)
+      const hasNotification = line.includes(CLAUDE_TASK_NOTIFICATION_MARKER)
       const hasTaskResult =
         line.includes(TOOL_USE_RESULT_MARKER) && line.includes(TOOL_USE_RESULT_AGENT_ID_MARKER)
       if (!hasNotification && !hasTaskResult) {
@@ -234,13 +235,9 @@ async function collectSubagentTaskStatuses(parentFilePath: string): Promise<Map<
       // dot on a view-only row, so we don't gate on user-type markers here (that
       // would risk dropping genuine harness-delivered statuses).
       if (hasNotification) {
-        const text = taskNotificationText(record)
-        if (text.startsWith(TASK_NOTIFICATION_MARKER)) {
-          const taskId = TASK_ID_PATTERN.exec(text)?.[1]?.trim()
-          const status = TASK_STATUS_PATTERN.exec(text)?.[1]
-          if (taskId && status) {
-            statuses.set(taskId, status)
-          }
+        const notification = parseClaudeTaskNotificationLine(line)
+        if (notification) {
+          statuses.set(notification.taskId, notification.status)
           continue
         }
       }
@@ -260,34 +257,6 @@ async function collectSubagentTaskStatuses(parentFilePath: string): Promise<Map<
     input.destroy()
   }
   return statuses
-}
-
-// The <status> marker follows <tool-use-id>/<output-file> lines in real
-// notifications, so it sits well past the 96-char title cap — the notification
-// text must be read untruncated (unlike titles/previews). Both delivery shapes
-// appear: queue-operation records carry it as top-level `content`; user-message
-// records under `message.content` (a string, or text content blocks).
-function taskNotificationText(record: Record<string, unknown>): string {
-  const direct = extractString(record.content)
-  if (direct) {
-    return direct
-  }
-  const content = asRecord(record.message)?.content
-  if (typeof content === 'string') {
-    return content.trim()
-  }
-  if (Array.isArray(content)) {
-    return content.map(taskNotificationBlockText).filter(Boolean).join(' ').trim()
-  }
-  return ''
-}
-
-function taskNotificationBlockText(block: unknown): string {
-  if (typeof block === 'string') {
-    return block
-  }
-  const record = asRecord(block)
-  return extractString(record?.text) ?? extractString(record?.content) ?? ''
 }
 
 // Claude writes an `agent-<id>.meta.json` sidecar for every subagent transcript,

--- a/src/main/ai-vault/session-scanner-claude-subagents.ts
+++ b/src/main/ai-vault/session-scanner-claude-subagents.ts
@@ -8,7 +8,7 @@ import type {
 } from '../../shared/ai-vault-types'
 import {
   CLAUDE_TASK_NOTIFICATION_MARKER,
-  parseClaudeTaskNotificationLine
+  parseClaudeTaskNotificationLineForDisplay
 } from '../../shared/claude-task-notification'
 import {
   openTranscriptReadStream,
@@ -235,7 +235,7 @@ async function collectSubagentTaskStatuses(parentFilePath: string): Promise<Map<
       // dot on a view-only row, so we don't gate on user-type markers here (that
       // would risk dropping genuine harness-delivered statuses).
       if (hasNotification) {
-        const notification = parseClaudeTaskNotificationLine(line)
+        const notification = parseClaudeTaskNotificationLineForDisplay(line)
         if (notification) {
           statuses.set(notification.taskId, notification.status)
           continue

--- a/src/main/claude/hook-settings-notification.test.ts
+++ b/src/main/claude/hook-settings-notification.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { applyManagedHooks } from './hook-settings'
+
+describe('Claude managed idle notification hook', () => {
+  it('installs only the provider idle_prompt notification matcher', () => {
+    const config = applyManagedHooks(
+      { hooks: {} },
+      { type: 'command', command: '/home/ada/.orca/agent-hooks/claude-hook.sh' }
+    )
+
+    expect(config.hooks?.Notification).toEqual([
+      {
+        matcher: 'idle_prompt',
+        hooks: [{ type: 'command', command: '/home/ada/.orca/agent-hooks/claude-hook.sh' }]
+      }
+    ])
+  })
+
+  it('preserves user-owned notification hooks', () => {
+    const userHook = {
+      matcher: 'permission_prompt',
+      hooks: [{ type: 'command' as const, command: 'notify-user' }]
+    }
+    const config = applyManagedHooks(
+      { hooks: { Notification: [userHook] } },
+      { type: 'command', command: '/home/ada/.orca/agent-hooks/claude-hook.sh' }
+    )
+
+    expect(config.hooks?.Notification?.[0]).toEqual(userHook)
+    expect(config.hooks?.Notification?.[1]?.matcher).toBe('idle_prompt')
+  })
+})

--- a/src/main/claude/hook-settings.ts
+++ b/src/main/claude/hook-settings.ts
@@ -48,6 +48,10 @@ export const CLAUDE_EVENTS = [
     eventName: 'Stop',
     definition: { hooks: [{ type: 'command', command: '' }] }
   },
+  {
+    eventName: 'Notification',
+    definition: { matcher: 'idle_prompt', hooks: [{ type: 'command', command: '' }] }
+  },
   // Why: OpenClaude skips normal Stop hooks after API/model errors and emits
   // StopFailure instead; without this hook Orca leaves the turn spinning.
   {

--- a/src/relay/agent-hook-server.test.ts
+++ b/src/relay/agent-hook-server.test.ts
@@ -133,9 +133,13 @@ describe('RelayAgentHookServer', () => {
       appendFileSync(
         transcriptPath,
         `${JSON.stringify({
-          type: 'queue-operation',
-          content:
-            '<task-notification>\n<task-id>shell-1</task-id>\n<status>completed</status>\n</task-notification>'
+          type: 'user',
+          promptSource: 'system',
+          origin: { kind: 'task-notification' },
+          message: {
+            content:
+              '<task-notification>\n<task-id>shell-1</task-id>\n<status>completed</status>\n</task-notification>'
+          }
         })}\n`
       )
       await post({ hook_event_name: 'PreToolUse', tool_name: 'Bash' })

--- a/src/relay/agent-hook-server.test.ts
+++ b/src/relay/agent-hook-server.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { appendFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { RelayAgentHookServer } from './agent-hook-server'
@@ -100,6 +100,66 @@ describe('RelayAgentHookServer', () => {
       expect(forward.mock.calls[0][0]).toMatchObject({
         claudeRunningNonAgentTask: true,
         payload: { state: 'working', agentType: 'claude' }
+      })
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('settles completed Claude background work before reconnect replay', async () => {
+    const forward = vi.fn<(envelope: AgentHookRelayEnvelope) => void>()
+    const server = new RelayAgentHookServer({ endpointDir: dir, forward })
+    const transcriptPath = join(dir, 'claude-session.jsonl')
+    writeFileSync(transcriptPath, `${JSON.stringify({ type: 'assistant', message: {} })}\n`)
+    await server.start()
+    try {
+      const { port, token } = server.getCoordinates()
+      const post = (payload: Record<string, unknown>): Promise<Response> =>
+        fetch(`http://127.0.0.1:${port}/hook/claude`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Orca-Agent-Hook-Token': token
+          },
+          body: JSON.stringify({ paneKey: PANE_KEY, payload })
+        })
+
+      await post({ hook_event_name: 'UserPromptSubmit', prompt: 'run it' })
+      await post({
+        hook_event_name: 'Stop',
+        transcript_path: transcriptPath,
+        background_tasks: [{ id: 'shell-1', type: 'shell', status: 'running' }]
+      })
+      appendFileSync(
+        transcriptPath,
+        `${JSON.stringify({
+          type: 'queue-operation',
+          content:
+            '<task-notification>\n<task-id>shell-1</task-id>\n<status>completed</status>\n</task-notification>'
+        })}\n`
+      )
+      await post({ hook_event_name: 'PreToolUse', tool_name: 'Bash' })
+      await post({ hook_event_name: 'PostToolUse', tool_name: 'Bash' })
+      appendFileSync(
+        transcriptPath,
+        `${JSON.stringify({
+          type: 'assistant',
+          uuid: 'final-message',
+          message: { stop_reason: 'end_turn', content: [{ type: 'text', text: 'Finished.' }] }
+        })}\n`
+      )
+      await post({
+        hook_event_name: 'Notification',
+        notification_type: 'idle_prompt',
+        transcript_path: transcriptPath
+      })
+
+      expect(forward.mock.calls.at(-1)?.[0].payload.state).toBe('done')
+      forward.mockClear()
+      expect(server.replayCachedPayloadsForPanes()).toBe(1)
+      expect(forward.mock.calls[0][0]).toMatchObject({
+        isReplay: true,
+        payload: { state: 'done' }
       })
     } finally {
       server.stop()

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2670,6 +2670,7 @@ function updateClaudeBackgroundTaskEvidence(
       transcriptByteOffset = null
     }
   }
+  const previous = state.claudeBackgroundTaskObservationsByPaneKey.get(paneKey)
   const observations = new Map<
     string,
     { transcriptPath: string; transcriptByteOffset: number; nonAgent: boolean }
@@ -2683,7 +2684,14 @@ function updateClaudeBackgroundTaskEvidence(
         .map((task) => ({ id: task.id, nonAgent: false }))
     ]
     for (const task of runningTasks) {
-      if (transcriptPath && transcriptByteOffset !== null) {
+      const existing = previous?.get(task.id)
+      if (
+        existing &&
+        existing.transcriptPath === transcriptPath &&
+        existing.nonAgent === task.nonAgent
+      ) {
+        observations.set(task.id, existing)
+      } else if (transcriptPath && transcriptByteOffset !== null) {
         observations.set(task.id, { transcriptPath, transcriptByteOffset, nonAgent: task.nonAgent })
       } else if (task.nonAgent) {
         hasUnidentified = true

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -39,7 +39,11 @@ import {
   upsertWorkingClaudeSubagent,
   type ClaudeSubagentRoster
 } from './claude-subagent-roster'
-import { readClaudeBackgroundAgentTasks } from './claude-background-task-inventory'
+import {
+  readClaudeBackgroundAgentTasks,
+  type ClaudeBackgroundAgentTask
+} from './claude-background-task-inventory'
+import { readClaudeTerminalTaskNotifications } from './claude-task-notification'
 import {
   codexRosterEffectiveState,
   codexRosterToSnapshots,
@@ -140,6 +144,13 @@ export type HookListenerState = {
   claudeUnconfirmedRestoredStatusPaneKeys: Set<string>
   /** Panes whose latest authoritative Claude task inventory still has running non-agent work. */
   claudeRunningNonAgentTaskPaneKeys: Set<string>
+  /** Provider task ids backing the non-agent working gate. */
+  claudeBackgroundTaskObservationsByPaneKey: Map<
+    string,
+    Map<string, { transcriptPath: string; transcriptByteOffset: number; nonAgent: boolean }>
+  >
+  /** Panes whose working inventory contained a task Orca cannot match by id. */
+  claudeUnidentifiedRunningNonAgentTaskPaneKeys: Set<string>
   /** Panes whose latest authoritative Claude cron inventory still has a scheduled job. */
   claudeActiveSessionCronPaneKeys: Set<string>
   /** Live thread-spawn children per Codex pane. */
@@ -181,6 +192,8 @@ export function createHookListenerState(): HookListenerState {
     claudeLeadStateByPaneKey: new Map(),
     claudeUnconfirmedRestoredStatusPaneKeys: new Set(),
     claudeRunningNonAgentTaskPaneKeys: new Set(),
+    claudeBackgroundTaskObservationsByPaneKey: new Map(),
+    claudeUnidentifiedRunningNonAgentTaskPaneKeys: new Set(),
     claudeActiveSessionCronPaneKeys: new Set(),
     codexSubagentRosterByPaneKey: new Map(),
     codexSubagentTranscriptByPaneKey: new Map(),
@@ -198,6 +211,8 @@ export function clearPaneCacheState(state: HookListenerState, paneKey: string): 
   state.claudeLeadStateByPaneKey.delete(paneKey)
   state.claudeUnconfirmedRestoredStatusPaneKeys.delete(paneKey)
   state.claudeRunningNonAgentTaskPaneKeys.delete(paneKey)
+  state.claudeBackgroundTaskObservationsByPaneKey.delete(paneKey)
+  state.claudeUnidentifiedRunningNonAgentTaskPaneKeys.delete(paneKey)
   state.claudeActiveSessionCronPaneKeys.delete(paneKey)
   state.codexSubagentRosterByPaneKey.delete(paneKey)
   state.codexSubagentTranscriptByPaneKey.delete(paneKey)
@@ -245,6 +260,12 @@ export function movePaneCacheState(
   movePaneScopedMapEntries(state.claudeLeadStateByPaneKey, fromPaneKey, toPaneKey)
   movePaneScopedSetEntries(state.claudeUnconfirmedRestoredStatusPaneKeys, fromPaneKey, toPaneKey)
   movePaneScopedSetEntries(state.claudeRunningNonAgentTaskPaneKeys, fromPaneKey, toPaneKey)
+  movePaneScopedMapEntries(state.claudeBackgroundTaskObservationsByPaneKey, fromPaneKey, toPaneKey)
+  movePaneScopedSetEntries(
+    state.claudeUnidentifiedRunningNonAgentTaskPaneKeys,
+    fromPaneKey,
+    toPaneKey
+  )
   movePaneScopedSetEntries(state.claudeActiveSessionCronPaneKeys, fromPaneKey, toPaneKey)
   movePaneScopedMapEntries(state.codexSubagentRosterByPaneKey, fromPaneKey, toPaneKey)
   movePaneScopedMapEntries(state.codexSubagentTranscriptByPaneKey, fromPaneKey, toPaneKey)
@@ -290,6 +311,8 @@ export function clearAllListenerCaches(state: HookListenerState): void {
   state.claudeLeadStateByPaneKey.clear()
   state.claudeUnconfirmedRestoredStatusPaneKeys.clear()
   state.claudeRunningNonAgentTaskPaneKeys.clear()
+  state.claudeBackgroundTaskObservationsByPaneKey.clear()
+  state.claudeUnidentifiedRunningNonAgentTaskPaneKeys.clear()
   state.claudeActiveSessionCronPaneKeys.clear()
   state.codexSubagentRosterByPaneKey.clear()
   state.codexSubagentTranscriptByPaneKey.clear()
@@ -1632,7 +1655,10 @@ function extractClaudeToolFields(
       update.lastAssistantMessage = errorText
     }
   }
-  if (eventName === 'Stop') {
+  if (
+    eventName === 'Stop' ||
+    (eventName === 'Notification' && hookPayload.notification_type === 'idle_prompt')
+  ) {
     const direct = readString(hookPayload, 'last_assistant_message')
     if (direct) {
       update.lastAssistantMessage = direct
@@ -2625,16 +2651,128 @@ function getOrCreateClaudeSubagentRoster(
   return roster
 }
 
-function updateClaudeRunningNonAgentTask(
+function updateClaudeBackgroundTaskEvidence(
   state: HookListenerState,
   paneKey: string,
   hasRunningNonAgentTask: boolean,
-  interrupted: boolean
+  runningNonAgentTaskIds: readonly string[],
+  agentTasks: readonly ClaudeBackgroundAgentTask[],
+  hasUnidentifiedRunningTask: boolean,
+  interrupted: boolean,
+  hookPayload: Record<string, unknown>
 ): void {
+  const transcriptPath = readString(hookPayload, 'transcript_path')
+  let transcriptByteOffset: number | null = null
+  if (transcriptPath) {
+    try {
+      transcriptByteOffset = statSync(transcriptPath).size
+    } catch {
+      transcriptByteOffset = null
+    }
+  }
+  const previous = state.claudeBackgroundTaskObservationsByPaneKey.get(paneKey)
+  const observations = new Map<
+    string,
+    { transcriptPath: string; transcriptByteOffset: number; nonAgent: boolean }
+  >()
+  let hasUnidentified = hasUnidentifiedRunningTask
+  if (!interrupted) {
+    const runningTasks = [
+      ...runningNonAgentTaskIds.map((id) => ({ id, nonAgent: true })),
+      ...agentTasks
+        .filter((task) => task.running && !task.teammate)
+        .map((task) => ({ id: task.id, nonAgent: false }))
+    ]
+    for (const task of runningTasks) {
+      const existing = previous?.get(task.id)
+      if (
+        existing &&
+        existing.transcriptPath === transcriptPath &&
+        existing.nonAgent === task.nonAgent
+      ) {
+        observations.set(task.id, existing)
+      } else if (transcriptPath && transcriptByteOffset !== null) {
+        observations.set(task.id, { transcriptPath, transcriptByteOffset, nonAgent: task.nonAgent })
+      } else if (task.nonAgent) {
+        hasUnidentified = true
+      }
+    }
+  }
+  if (observations.size > 0) {
+    state.claudeBackgroundTaskObservationsByPaneKey.set(paneKey, observations)
+  } else {
+    state.claudeBackgroundTaskObservationsByPaneKey.delete(paneKey)
+  }
   if (hasRunningNonAgentTask && !interrupted) {
     state.claudeRunningNonAgentTaskPaneKeys.add(paneKey)
+    if (hasUnidentified) {
+      state.claudeUnidentifiedRunningNonAgentTaskPaneKeys.add(paneKey)
+    } else {
+      state.claudeUnidentifiedRunningNonAgentTaskPaneKeys.delete(paneKey)
+    }
   } else {
     state.claudeRunningNonAgentTaskPaneKeys.delete(paneKey)
+    state.claudeUnidentifiedRunningNonAgentTaskPaneKeys.delete(paneKey)
+  }
+}
+
+function reconcileClaudeIdlePromptTasks(
+  state: HookListenerState,
+  paneKey: string,
+  hookPayload: Record<string, unknown>
+): void {
+  const transcriptPath = readString(hookPayload, 'transcript_path')
+  const observations = state.claudeBackgroundTaskObservationsByPaneKey.get(paneKey)
+  if (!transcriptPath || !observations) {
+    return
+  }
+  const matchingObservations = Array.from(observations.entries()).filter(
+    ([, observation]) => observation.transcriptPath === transcriptPath
+  )
+  const minimumByteOffset = Math.min(
+    ...matchingObservations.map(([, observation]) => observation.transcriptByteOffset)
+  )
+  if (!Number.isFinite(minimumByteOffset)) {
+    return
+  }
+  const notifications = readClaudeTerminalTaskNotifications(transcriptPath, minimumByteOffset)
+  const terminalTaskIds = new Set<string>()
+  for (const [taskId, observation] of matchingObservations) {
+    if (
+      notifications.some(
+        (notification) =>
+          notification.taskId === taskId &&
+          notification.byteOffset >= observation.transcriptByteOffset
+      )
+    ) {
+      observations.delete(taskId)
+      terminalTaskIds.add(taskId)
+    }
+  }
+  if (terminalTaskIds.size === 0) {
+    return
+  }
+  if (observations.size === 0) {
+    state.claudeBackgroundTaskObservationsByPaneKey.delete(paneKey)
+  }
+  const hasTrackedNonAgentTask = Array.from(observations.values()).some(
+    (observation) => observation.nonAgent
+  )
+  if (
+    !hasTrackedNonAgentTask &&
+    !state.claudeUnidentifiedRunningNonAgentTaskPaneKeys.has(paneKey)
+  ) {
+    state.claudeRunningNonAgentTaskPaneKeys.delete(paneKey)
+  }
+  const roster = state.claudeSubagentRosterByPaneKey.get(paneKey)
+  if (!roster) {
+    return
+  }
+  for (const taskId of terminalTaskIds) {
+    stopClaudeSubagent(roster, taskId)
+  }
+  if (roster.size === 0) {
+    state.claudeSubagentRosterByPaneKey.delete(paneKey)
   }
 }
 
@@ -2749,7 +2887,7 @@ function normalizeClaudeSubagentLifecycleEvent(
 /** Sync the Claude lead-turn record when the SERVER infers an interrupt outside the hook stream (Ctrl+C with a missed Stop); else a later child lifecycle event resurrects the cancelled pane. */
 export function markClaudeLeadTurnInterrupted(state: HookListenerState, paneKey: string): void {
   state.claudeLeadStateByPaneKey.set(paneKey, { state: 'done', interrupted: true })
-  state.claudeRunningNonAgentTaskPaneKeys.delete(paneKey)
+  updateClaudeBackgroundTaskEvidence(state, paneKey, false, [], [], false, true, {})
   state.claudeActiveSessionCronPaneKeys.delete(paneKey)
 }
 
@@ -2947,7 +3085,7 @@ function normalizeClaudeEvent(
     // Why: a new process owns the pane; stale children/tasks/crons must not gate the
     // fresh session's idle row back up to 'working' (same reset Codex does on SessionStart).
     state.claudeSubagentRosterByPaneKey.delete(paneKey)
-    state.claudeRunningNonAgentTaskPaneKeys.delete(paneKey)
+    updateClaudeBackgroundTaskEvidence(state, paneKey, false, [], [], false, false, {})
     state.claudeActiveSessionCronPaneKeys.delete(paneKey)
     state.claudeLeadStateByPaneKey.set(paneKey, { state: 'done' })
     return buildClaudeStatusPayload(state, eventName, promptText, paneKey, hookPayload, {
@@ -2957,6 +3095,8 @@ function normalizeClaudeEvent(
     })
   }
   const previousLead = state.claudeLeadStateByPaneKey.get(paneKey)
+  const isIdlePromptNotification =
+    eventName === 'Notification' && hookPayload['notification_type'] === 'idle_prompt'
   // Why: only a turn boundary may declare an interrupt or carry a prior one forward; any other event starts a fresh turn and drops it.
   const isTurnBoundary = eventName === 'Stop' || eventName === 'StopFailure'
   const interrupted =
@@ -2993,19 +3133,28 @@ function normalizeClaudeEvent(
       ? 'working'
       : eventName === 'PermissionRequest' || isAskUserQuestion
         ? 'waiting'
-        : isTurnBoundary || (eventName === 'PostCompact' && hookPayload.trigger === 'manual')
+        : isTurnBoundary ||
+            isIdlePromptNotification ||
+            (eventName === 'PostCompact' && hookPayload.trigger === 'manual')
           ? 'done'
           : null
 
   if (!reportedStateName) {
     return null
   }
+  if (isIdlePromptNotification && eventAgentId === undefined) {
+    reconcileClaudeIdlePromptTasks(state, paneKey, hookPayload)
+  }
   if (backgroundTasks.present && eventAgentId === undefined) {
-    updateClaudeRunningNonAgentTask(
+    updateClaudeBackgroundTaskEvidence(
       state,
       paneKey,
       backgroundTasks.hasRunningNonAgentTask,
-      interrupted === true
+      backgroundTasks.runningNonAgentTaskIds,
+      backgroundTasks.tasks,
+      backgroundTasks.hasUnidentifiedRunningNonAgentTask,
+      interrupted === true,
+      hookPayload
     )
   }
   if (sessionCronInventoryPresent && eventAgentId === undefined) {
@@ -3118,7 +3267,7 @@ function normalizeClaudeEvent(
   const waitingToolUseId = eventToolUseId ?? previousLead?.waitingToolUseId
 
   if (interrupted && eventAgentId === undefined) {
-    state.claudeRunningNonAgentTaskPaneKeys.delete(paneKey)
+    updateClaudeBackgroundTaskEvidence(state, paneKey, false, [], [], false, true, {})
     state.claudeActiveSessionCronPaneKeys.delete(paneKey)
   }
 
@@ -3129,11 +3278,14 @@ function normalizeClaudeEvent(
   // Why: the lead already ended — the pane stays `working` only because background inventory is still registered. `stateStartedAt` is pinned for that whole run, so this end time is the per-turn identity and the later all-clear's pair key.
   const turnCompletedAt =
     eventAgentId === undefined &&
-    isTurnBoundary &&
+    (isTurnBoundary || isIdlePromptNotification) &&
     reportedStateName === 'done' &&
-    effectiveState === 'working' &&
     interrupted !== true
-      ? Date.now()
+      ? effectiveState === 'working'
+        ? (previousLead?.turnCompletedAt ?? Date.now())
+        : isIdlePromptNotification
+          ? previousLead?.turnCompletedAt
+          : undefined
       : undefined
 
   state.claudeLeadStateByPaneKey.set(paneKey, {

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2670,7 +2670,6 @@ function updateClaudeBackgroundTaskEvidence(
       transcriptByteOffset = null
     }
   }
-  const previous = state.claudeBackgroundTaskObservationsByPaneKey.get(paneKey)
   const observations = new Map<
     string,
     { transcriptPath: string; transcriptByteOffset: number; nonAgent: boolean }
@@ -2684,14 +2683,7 @@ function updateClaudeBackgroundTaskEvidence(
         .map((task) => ({ id: task.id, nonAgent: false }))
     ]
     for (const task of runningTasks) {
-      const existing = previous?.get(task.id)
-      if (
-        existing &&
-        existing.transcriptPath === transcriptPath &&
-        existing.nonAgent === task.nonAgent
-      ) {
-        observations.set(task.id, existing)
-      } else if (transcriptPath && transcriptByteOffset !== null) {
+      if (transcriptPath && transcriptByteOffset !== null) {
         observations.set(task.id, { transcriptPath, transcriptByteOffset, nonAgent: task.nonAgent })
       } else if (task.nonAgent) {
         hasUnidentified = true
@@ -2720,11 +2712,11 @@ function reconcileClaudeIdlePromptTasks(
   state: HookListenerState,
   paneKey: string,
   hookPayload: Record<string, unknown>
-): void {
+): boolean {
   const transcriptPath = readString(hookPayload, 'transcript_path')
   const observations = state.claudeBackgroundTaskObservationsByPaneKey.get(paneKey)
   if (!transcriptPath || !observations) {
-    return
+    return false
   }
   const matchingObservations = Array.from(observations.entries()).filter(
     ([, observation]) => observation.transcriptPath === transcriptPath
@@ -2733,7 +2725,7 @@ function reconcileClaudeIdlePromptTasks(
     ...matchingObservations.map(([, observation]) => observation.transcriptByteOffset)
   )
   if (!Number.isFinite(minimumByteOffset)) {
-    return
+    return false
   }
   const notifications = readClaudeTerminalTaskNotifications(transcriptPath, minimumByteOffset)
   const terminalTaskIds = new Set<string>()
@@ -2750,7 +2742,7 @@ function reconcileClaudeIdlePromptTasks(
     }
   }
   if (terminalTaskIds.size === 0) {
-    return
+    return false
   }
   if (observations.size === 0) {
     state.claudeBackgroundTaskObservationsByPaneKey.delete(paneKey)
@@ -2766,7 +2758,7 @@ function reconcileClaudeIdlePromptTasks(
   }
   const roster = state.claudeSubagentRosterByPaneKey.get(paneKey)
   if (!roster) {
-    return
+    return true
   }
   for (const taskId of terminalTaskIds) {
     stopClaudeSubagent(roster, taskId)
@@ -2774,6 +2766,7 @@ function reconcileClaudeIdlePromptTasks(
   if (roster.size === 0) {
     state.claudeSubagentRosterByPaneKey.delete(paneKey)
   }
+  return true
 }
 
 function resolveClaudePaneState(
@@ -3097,6 +3090,10 @@ function normalizeClaudeEvent(
   const previousLead = state.claudeLeadStateByPaneKey.get(paneKey)
   const isIdlePromptNotification =
     eventName === 'Notification' && hookPayload['notification_type'] === 'idle_prompt'
+  const reconciledIdlePrompt =
+    isIdlePromptNotification && eventAgentId === undefined
+      ? reconcileClaudeIdlePromptTasks(state, paneKey, hookPayload)
+      : false
   // Why: only a turn boundary may declare an interrupt or carry a prior one forward; any other event starts a fresh turn and drops it.
   const isTurnBoundary = eventName === 'Stop' || eventName === 'StopFailure'
   const interrupted =
@@ -3134,16 +3131,13 @@ function normalizeClaudeEvent(
       : eventName === 'PermissionRequest' || isAskUserQuestion
         ? 'waiting'
         : isTurnBoundary ||
-            isIdlePromptNotification ||
+            reconciledIdlePrompt ||
             (eventName === 'PostCompact' && hookPayload.trigger === 'manual')
           ? 'done'
           : null
 
   if (!reportedStateName) {
     return null
-  }
-  if (isIdlePromptNotification && eventAgentId === undefined) {
-    reconcileClaudeIdlePromptTasks(state, paneKey, hookPayload)
   }
   if (backgroundTasks.present && eventAgentId === undefined) {
     updateClaudeBackgroundTaskEvidence(
@@ -3278,12 +3272,12 @@ function normalizeClaudeEvent(
   // Why: the lead already ended — the pane stays `working` only because background inventory is still registered. `stateStartedAt` is pinned for that whole run, so this end time is the per-turn identity and the later all-clear's pair key.
   const turnCompletedAt =
     eventAgentId === undefined &&
-    (isTurnBoundary || isIdlePromptNotification) &&
+    (isTurnBoundary || reconciledIdlePrompt) &&
     reportedStateName === 'done' &&
     interrupted !== true
       ? effectiveState === 'working'
         ? (previousLead?.turnCompletedAt ?? Date.now())
-        : isIdlePromptNotification
+        : reconciledIdlePrompt
           ? previousLead?.turnCompletedAt
           : undefined
       : undefined

--- a/src/shared/claude-background-task-inventory.ts
+++ b/src/shared/claude-background-task-inventory.ts
@@ -21,6 +21,8 @@ const CLAUDE_TERMINAL_BACKGROUND_TASK_STATUSES = new Set([
   'canceled',
   'timed_out'
 ])
+const CLAUDE_NON_AGENT_TASK_ID_MAX_LENGTH = 128
+const CLAUDE_NON_AGENT_TASK_ID_MAX_COUNT = 256
 
 /** One agent entry from the `background_tasks` array Claude attaches to Stop
  *  (and SubagentStop) hook payloads. Non-agent tasks do not become rows. */
@@ -43,18 +45,30 @@ export function readClaudeBackgroundAgentTasks(hookPayload: Record<string, unkno
   tasks: ClaudeBackgroundAgentTask[]
   truncated: boolean
   hasRunningNonAgentTask: boolean
+  runningNonAgentTaskIds: string[]
+  hasUnidentifiedRunningNonAgentTask: boolean
 } {
   const raw = hookPayload['background_tasks']
   if (!Array.isArray(raw)) {
-    return { present: false, tasks: [], truncated: false, hasRunningNonAgentTask: false }
+    return {
+      present: false,
+      tasks: [],
+      truncated: false,
+      hasRunningNonAgentTask: false,
+      runningNonAgentTaskIds: [],
+      hasUnidentifiedRunningNonAgentTask: false
+    }
   }
   const tasks: ClaudeBackgroundAgentTask[] = []
+  const runningNonAgentTaskIds: string[] = []
   let truncated = false
   let hasRunningNonAgentTask = false
+  let hasUnidentifiedRunningNonAgentTask = false
   for (const item of raw) {
     if (typeof item !== 'object' || item === null) {
       truncated = true
       hasRunningNonAgentTask = true
+      hasUnidentifiedRunningNonAgentTask = true
       continue
     }
     const obj = item as Record<string, unknown>
@@ -65,12 +79,23 @@ export function readClaudeBackgroundAgentTasks(hookPayload: Record<string, unkno
     if (taskType.length === 0) {
       truncated = true
       hasRunningNonAgentTask ||= !isTerminal
+      hasUnidentifiedRunningNonAgentTask ||= !isTerminal
       continue
     }
     const isAgentTask = taskType === 'subagent' || taskType === 'teammate'
     // Why: future non-agent types and nonterminal labels must fail active; only typed agent rows or explicit terminal states can safely retire work.
     if (!isAgentTask && !isTerminal) {
       hasRunningNonAgentTask = true
+      const taskId = typeof obj.id === 'string' ? obj.id.trim() : ''
+      if (
+        taskId.length > 0 &&
+        taskId.length <= CLAUDE_NON_AGENT_TASK_ID_MAX_LENGTH &&
+        runningNonAgentTaskIds.length < CLAUDE_NON_AGENT_TASK_ID_MAX_COUNT
+      ) {
+        runningNonAgentTaskIds.push(taskId)
+      } else {
+        hasUnidentifiedRunningNonAgentTask = true
+      }
     }
     if (!isAgentTask) {
       continue
@@ -93,5 +118,12 @@ export function readClaudeBackgroundAgentTasks(hookPayload: Record<string, unkno
       teammate: taskType === 'teammate'
     })
   }
-  return { present: true, tasks, truncated, hasRunningNonAgentTask }
+  return {
+    present: true,
+    tasks,
+    truncated,
+    hasRunningNonAgentTask,
+    runningNonAgentTaskIds,
+    hasUnidentifiedRunningNonAgentTask
+  }
 }

--- a/src/shared/claude-background-task-status.test.ts
+++ b/src/shared/claude-background-task-status.test.ts
@@ -32,10 +32,14 @@ function claudeEvent(state: HookListenerState, paneKey: string, payload: Record<
 
 function taskNotificationLine(taskId: string, status = 'completed'): string {
   return `${JSON.stringify({
-    type: 'queue-operation',
-    content:
-      `<task-notification>\n<task-id>${taskId}</task-id>\n` +
-      `<status>${status}</status>\n</task-notification>`
+    type: 'user',
+    promptSource: 'system',
+    origin: { kind: 'task-notification' },
+    message: {
+      content:
+        `<task-notification>\n<task-id>${taskId}</task-id>\n` +
+        `<status>${status}</status>\n</task-notification>`
+    }
   })}\n`
 }
 
@@ -186,8 +190,9 @@ describe('Claude background task status', () => {
           hook_event_name: 'Notification',
           notification_type: 'idle_prompt',
           transcript_path: transcriptPath
-        })?.state
-      ).toBe('working')
+        })
+      ).toBeUndefined()
+      expect(state.claudeLeadStateByPaneKey.get(SOURCE_PANE)?.state).toBe('done')
 
       appendFileSync(transcriptPath, taskNotificationLine(RUNNING_SHELL.id))
       expect(
@@ -195,8 +200,9 @@ describe('Claude background task status', () => {
           hook_event_name: 'Notification',
           notification_type: 'idle_prompt',
           transcript_path: transcriptPath
-        })?.state
-      ).toBe('working')
+        })
+      ).toMatchObject({ state: 'working' })
+      expect(state.claudeRunningNonAgentTaskPaneKeys.has(SOURCE_PANE)).toBe(true)
 
       appendFileSync(transcriptPath, taskNotificationLine('shell-2', 'failed'))
       expect(
@@ -228,8 +234,9 @@ describe('Claude background task status', () => {
           hook_event_name: 'Notification',
           notification_type: 'idle_prompt',
           transcript_path: transcriptPath
-        })?.state
-      ).toBe('working')
+        })
+      ).toBeUndefined()
+      expect(state.claudeRunningNonAgentTaskPaneKeys.has(SOURCE_PANE)).toBe(true)
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }
@@ -251,8 +258,9 @@ describe('Claude background task status', () => {
           hook_event_name: 'Notification',
           notification_type: 'idle_prompt',
           transcript_path: transcriptPath
-        })?.state
-      ).toBe('working')
+        })
+      ).toBeUndefined()
+      expect(state.claudeRunningNonAgentTaskPaneKeys.has(SOURCE_PANE)).toBe(true)
 
       appendFileSync(transcriptPath, taskNotificationLine(RUNNING_SHELL.id))
       expect(
@@ -262,6 +270,46 @@ describe('Claude background task status', () => {
           transcript_path: transcriptPath
         })?.state
       ).toBe('done')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('refreshes ownership when Claude reports a reused task id as running', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'claude-idle-reused-task-'))
+    const transcriptPath = join(dir, 'session.jsonl')
+    writeFileSync(transcriptPath, '')
+    try {
+      const state = createHookListenerState()
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'Stop',
+        transcript_path: transcriptPath,
+        background_tasks: [RUNNING_SHELL]
+      })
+      appendFileSync(transcriptPath, taskNotificationLine(RUNNING_SHELL.id))
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'Stop',
+        transcript_path: transcriptPath,
+        background_tasks: [RUNNING_SHELL]
+      })
+
+      expect(
+        claudeEvent(state, SOURCE_PANE, {
+          hook_event_name: 'Notification',
+          notification_type: 'idle_prompt',
+          transcript_path: transcriptPath
+        })
+      ).toBeUndefined()
+      expect(state.claudeRunningNonAgentTaskPaneKeys.has(SOURCE_PANE)).toBe(true)
+
+      appendFileSync(transcriptPath, taskNotificationLine(RUNNING_SHELL.id))
+      expect(
+        claudeEvent(state, SOURCE_PANE, {
+          hook_event_name: 'Notification',
+          notification_type: 'idle_prompt',
+          transcript_path: transcriptPath
+        })
+      ).toMatchObject({ state: 'done' })
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }
@@ -306,6 +354,7 @@ describe('Claude background task status', () => {
         background_tasks: [RUNNING_SHELL],
         session_crons: [{ id: 'cron-1' }]
       })
+      appendFileSync(transcriptPath, taskNotificationLine(RUNNING_SHELL.id))
 
       expect(
         claudeEvent(state, SOURCE_PANE, {
@@ -328,6 +377,21 @@ describe('Claude background task status', () => {
       claudeEvent(state, SOURCE_PANE, {
         hook_event_name: 'Notification',
         notification_type: 'permission_prompt'
+      })
+    ).toBeUndefined()
+    expect(state.claudeLeadStateByPaneKey.get(SOURCE_PANE)?.state).toBe('working')
+  })
+
+  it('does not treat idle_prompt alone as task completion evidence', () => {
+    const state = createHookListenerState()
+    claudeEvent(state, SOURCE_PANE, { hook_event_name: 'UserPromptSubmit', prompt: 'run it' })
+    claudeEvent(state, SOURCE_PANE, { hook_event_name: 'PreToolUse', tool_name: 'Bash' })
+
+    expect(
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'Notification',
+        notification_type: 'idle_prompt',
+        transcript_path: 'unowned-session.jsonl'
       })
     ).toBeUndefined()
     expect(state.claudeLeadStateByPaneKey.get(SOURCE_PANE)?.state).toBe('working')

--- a/src/shared/claude-background-task-status.test.ts
+++ b/src/shared/claude-background-task-status.test.ts
@@ -275,8 +275,8 @@ describe('Claude background task status', () => {
     }
   })
 
-  it('refreshes ownership when Claude reports a reused task id as running', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'claude-idle-reused-task-'))
+  it('preserves completion evidence across repeated running inventories', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'claude-idle-repeated-task-'))
     const transcriptPath = join(dir, 'session.jsonl')
     writeFileSync(transcriptPath, '')
     try {
@@ -293,16 +293,6 @@ describe('Claude background task status', () => {
         background_tasks: [RUNNING_SHELL]
       })
 
-      expect(
-        claudeEvent(state, SOURCE_PANE, {
-          hook_event_name: 'Notification',
-          notification_type: 'idle_prompt',
-          transcript_path: transcriptPath
-        })
-      ).toBeUndefined()
-      expect(state.claudeRunningNonAgentTaskPaneKeys.has(SOURCE_PANE)).toBe(true)
-
-      appendFileSync(transcriptPath, taskNotificationLine(RUNNING_SHELL.id))
       expect(
         claudeEvent(state, SOURCE_PANE, {
           hook_event_name: 'Notification',

--- a/src/shared/claude-background-task-status.test.ts
+++ b/src/shared/claude-background-task-status.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from 'vitest'
+import { appendFileSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import {
   clearAllListenerCaches,
   clearPaneCacheState,
@@ -27,6 +30,15 @@ function claudeEvent(state: HookListenerState, paneKey: string, payload: Record<
   return normalizeHookPayload(state, 'claude', { paneKey, payload }, 'production')?.payload
 }
 
+function taskNotificationLine(taskId: string, status = 'completed'): string {
+  return `${JSON.stringify({
+    type: 'queue-operation',
+    content:
+      `<task-notification>\n<task-id>${taskId}</task-id>\n` +
+      `<status>${status}</status>\n</task-notification>`
+  })}\n`
+}
+
 describe('Claude background task status', () => {
   it('finds pending monitor work after the visible child-row cap', () => {
     const agentTasks = Array.from({ length: AGENT_STATUS_MAX_SUBAGENTS + 1 }, (_, index) => ({
@@ -51,6 +63,10 @@ describe('Claude background task status', () => {
   })
 
   it('fails unknown, partial, or malformed task entries active but ignores terminal entries', () => {
+    expect(readClaudeBackgroundAgentTasks({ background_tasks: [RUNNING_SHELL] })).toMatchObject({
+      runningNonAgentTaskIds: [RUNNING_SHELL.id],
+      hasUnidentifiedRunningNonAgentTask: false
+    })
     for (const status of ['queued', undefined]) {
       expect(
         readClaudeBackgroundAgentTasks({
@@ -76,6 +92,14 @@ describe('Claude background task status', () => {
     expect(
       readClaudeBackgroundAgentTasks({ background_tasks: [null, 'shell'] }).hasRunningNonAgentTask
     ).toBe(true)
+    expect(
+      readClaudeBackgroundAgentTasks({
+        background_tasks: [{ id: 'x'.repeat(129), type: 'shell', status: 'running' }]
+      })
+    ).toMatchObject({
+      runningNonAgentTaskIds: [],
+      hasUnidentifiedRunningNonAgentTask: true
+    })
 
     for (const backgroundTasks of [
       [{ id: 'shell-1', type: 'shell', status: 'completed' }],
@@ -140,6 +164,173 @@ describe('Claude background task status', () => {
         background_tasks: []
       })?.state
     ).toBe('done')
+  })
+
+  it('reconciles only matching completed tasks at Claude idle ownership boundaries', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'claude-idle-task-'))
+    const transcriptPath = join(dir, 'session.jsonl')
+    writeFileSync(transcriptPath, '')
+    try {
+      const state = createHookListenerState()
+      expect(
+        claudeEvent(state, SOURCE_PANE, {
+          hook_event_name: 'Stop',
+          transcript_path: transcriptPath,
+          background_tasks: [RUNNING_SHELL, { id: 'shell-2', type: 'shell', status: 'running' }]
+        })?.state
+      ).toBe('working')
+
+      appendFileSync(transcriptPath, taskNotificationLine('different-task'))
+      expect(
+        claudeEvent(state, SOURCE_PANE, {
+          hook_event_name: 'Notification',
+          notification_type: 'idle_prompt',
+          transcript_path: transcriptPath
+        })?.state
+      ).toBe('working')
+
+      appendFileSync(transcriptPath, taskNotificationLine(RUNNING_SHELL.id))
+      expect(
+        claudeEvent(state, SOURCE_PANE, {
+          hook_event_name: 'Notification',
+          notification_type: 'idle_prompt',
+          transcript_path: transcriptPath
+        })?.state
+      ).toBe('working')
+
+      appendFileSync(transcriptPath, taskNotificationLine('shell-2', 'failed'))
+      expect(
+        claudeEvent(state, SOURCE_PANE, {
+          hook_event_name: 'Notification',
+          notification_type: 'idle_prompt',
+          transcript_path: transcriptPath
+        })
+      ).toMatchObject({ state: 'done' })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('fails unidentified background work active at an idle notification', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'claude-idle-unknown-task-'))
+    const transcriptPath = join(dir, 'session.jsonl')
+    writeFileSync(transcriptPath, taskNotificationLine('shell-1'))
+    try {
+      const state = createHookListenerState()
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'Stop',
+        transcript_path: transcriptPath,
+        background_tasks: [{ type: 'shell', status: 'running' }]
+      })
+
+      expect(
+        claudeEvent(state, SOURCE_PANE, {
+          hook_event_name: 'Notification',
+          notification_type: 'idle_prompt',
+          transcript_path: transcriptPath
+        })?.state
+      ).toBe('working')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('does not reuse a matching completion that predates task ownership', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'claude-idle-old-task-'))
+    const transcriptPath = join(dir, 'session.jsonl')
+    writeFileSync(transcriptPath, taskNotificationLine(RUNNING_SHELL.id))
+    try {
+      const state = createHookListenerState()
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'Stop',
+        transcript_path: transcriptPath,
+        background_tasks: [RUNNING_SHELL]
+      })
+      expect(
+        claudeEvent(state, SOURCE_PANE, {
+          hook_event_name: 'Notification',
+          notification_type: 'idle_prompt',
+          transcript_path: transcriptPath
+        })?.state
+      ).toBe('working')
+
+      appendFileSync(transcriptPath, taskNotificationLine(RUNNING_SHELL.id))
+      expect(
+        claudeEvent(state, SOURCE_PANE, {
+          hook_event_name: 'Notification',
+          notification_type: 'idle_prompt',
+          transcript_path: transcriptPath
+        })?.state
+      ).toBe('done')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('retires a background subagent whose SubagentStop was missed', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'claude-idle-subagent-'))
+    const transcriptPath = join(dir, 'session.jsonl')
+    writeFileSync(transcriptPath, '')
+    try {
+      const state = createHookListenerState()
+      expect(
+        claudeEvent(state, SOURCE_PANE, {
+          hook_event_name: 'Stop',
+          transcript_path: transcriptPath,
+          background_tasks: [{ id: 'agent-1', type: 'subagent', status: 'running' }]
+        })
+      ).toMatchObject({ state: 'working', subagents: [{ id: 'agent-1', state: 'working' }] })
+
+      appendFileSync(transcriptPath, taskNotificationLine('agent-1'))
+      expect(
+        claudeEvent(state, SOURCE_PANE, {
+          hook_event_name: 'Notification',
+          notification_type: 'idle_prompt',
+          transcript_path: transcriptPath
+        })
+      ).toMatchObject({ state: 'done', subagents: undefined })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps session cron work separate from matching task completion', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'claude-idle-cron-'))
+    const transcriptPath = join(dir, 'session.jsonl')
+    writeFileSync(transcriptPath, taskNotificationLine(RUNNING_SHELL.id))
+    try {
+      const state = createHookListenerState()
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'Stop',
+        transcript_path: transcriptPath,
+        background_tasks: [RUNNING_SHELL],
+        session_crons: [{ id: 'cron-1' }]
+      })
+
+      expect(
+        claudeEvent(state, SOURCE_PANE, {
+          hook_event_name: 'Notification',
+          notification_type: 'idle_prompt',
+          transcript_path: transcriptPath
+        })?.state
+      ).toBe('working')
+      expect(state.claudeActiveSessionCronPaneKeys.has(SOURCE_PANE)).toBe(true)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('ignores Claude notifications that are not idle_prompt', () => {
+    const state = createHookListenerState()
+    claudeEvent(state, SOURCE_PANE, { hook_event_name: 'UserPromptSubmit', prompt: 'run it' })
+
+    expect(
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'Notification',
+        notification_type: 'permission_prompt'
+      })
+    ).toBeUndefined()
+    expect(state.claudeLeadStateByPaneKey.get(SOURCE_PANE)?.state).toBe('working')
   })
 
   it('keeps pending task state when pane authority moves', () => {

--- a/src/shared/claude-task-notification.test.ts
+++ b/src/shared/claude-task-notification.test.ts
@@ -82,12 +82,18 @@ describe('Claude task notifications', () => {
       [
         notificationRecord('running-task', 'running'),
         notificationRecord('completed-task', 'completed'),
-        notificationRecord('killed-task', 'killed')
+        notificationRecord('killed-task', 'killed'),
+        JSON.stringify({
+          type: 'queue-operation',
+          operation: 'enqueue',
+          content:
+            '<task-notification><task-id>queued-task</task-id><status>completed</status></task-notification>'
+        })
       ].join('\n')
     )
     try {
       expect(readClaudeTerminalTaskNotificationIds(transcriptPath)).toEqual(
-        new Set(['completed-task', 'killed-task'])
+        new Set(['completed-task', 'killed-task', 'queued-task'])
       )
     } finally {
       rmSync(dir, { recursive: true, force: true })

--- a/src/shared/claude-task-notification.test.ts
+++ b/src/shared/claude-task-notification.test.ts
@@ -10,15 +10,20 @@ import {
 
 function notificationRecord(taskId: string, status: string): string {
   return JSON.stringify({
-    type: 'queue-operation',
-    content:
-      `<task-notification>\n<task-id>${taskId}</task-id>\n` +
-      `<status>${status}</status>\n</task-notification>`
+    type: 'user',
+    promptSource: 'system',
+    origin: { kind: 'task-notification' },
+    message: {
+      role: 'user',
+      content:
+        `<task-notification>\n<task-id>${taskId}</task-id>\n` +
+        `<status>${status}</status>\n</task-notification>`
+    }
   })
 }
 
 describe('Claude task notifications', () => {
-  it('parses queue and user delivery shapes but not quoted prose', () => {
+  it('parses provider task delivery but not queue or user-authored shapes', () => {
     expect(parseClaudeTaskNotificationLine(notificationRecord('task-1', 'completed'))).toEqual({
       taskId: 'task-1',
       status: 'completed'
@@ -27,6 +32,8 @@ describe('Claude task notifications', () => {
       parseClaudeTaskNotificationLine(
         JSON.stringify({
           type: 'user',
+          promptSource: 'system',
+          origin: { kind: 'task-notification' },
           message: {
             content: [
               {
@@ -41,10 +48,26 @@ describe('Claude task notifications', () => {
     expect(
       parseClaudeTaskNotificationLine(
         JSON.stringify({
+          type: 'queue-operation',
+          operation: 'enqueue',
+          content:
+            '<task-notification><task-id>task-2</task-id><status>failed</status></task-notification>'
+        })
+      )
+    ).toBeNull()
+    expect(
+      parseClaudeTaskNotificationLine(
+        notificationRecord('task-4', 'completed').replace('</task-notification>', '')
+      )
+    ).toBeNull()
+    expect(
+      parseClaudeTaskNotificationLine(
+        JSON.stringify({
           type: 'user',
+          promptSource: 'user',
           message: {
             content:
-              'Explain <task-notification><task-id>task-3</task-id><status>completed</status></task-notification>'
+              '<task-notification><task-id>task-3</task-id><status>completed</status></task-notification>'
           }
         })
       )
@@ -74,7 +97,8 @@ describe('Claude task notifications', () => {
   it('skips a partial JSONL record at the ownership offset', () => {
     const dir = mkdtempSync(join(tmpdir(), 'claude-task-offset-'))
     const transcriptPath = join(dir, 'session.jsonl')
-    const partialRecord = '{"type":"user","message":{"content":"'
+    const partialRecord =
+      '{"type":"user","promptSource":"system","origin":{"kind":"task-notification"},"message":{"content":"'
     writeFileSync(transcriptPath, partialRecord)
     try {
       appendFileSync(

--- a/src/shared/claude-task-notification.test.ts
+++ b/src/shared/claude-task-notification.test.ts
@@ -1,0 +1,106 @@
+import { appendFileSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  parseClaudeTaskNotificationLine,
+  readClaudeTerminalTaskNotificationIds,
+  readClaudeTerminalTaskNotifications
+} from './claude-task-notification'
+
+function notificationRecord(taskId: string, status: string): string {
+  return JSON.stringify({
+    type: 'queue-operation',
+    content:
+      `<task-notification>\n<task-id>${taskId}</task-id>\n` +
+      `<status>${status}</status>\n</task-notification>`
+  })
+}
+
+describe('Claude task notifications', () => {
+  it('parses queue and user delivery shapes but not quoted prose', () => {
+    expect(parseClaudeTaskNotificationLine(notificationRecord('task-1', 'completed'))).toEqual({
+      taskId: 'task-1',
+      status: 'completed'
+    })
+    expect(
+      parseClaudeTaskNotificationLine(
+        JSON.stringify({
+          type: 'user',
+          message: {
+            content: [
+              {
+                type: 'text',
+                text: '<task-notification><task-id>task-2</task-id><status>failed</status></task-notification>'
+              }
+            ]
+          }
+        })
+      )
+    ).toEqual({ taskId: 'task-2', status: 'failed' })
+    expect(
+      parseClaudeTaskNotificationLine(
+        JSON.stringify({
+          type: 'user',
+          message: {
+            content:
+              'Explain <task-notification><task-id>task-3</task-id><status>completed</status></task-notification>'
+          }
+        })
+      )
+    ).toBeNull()
+  })
+
+  it('returns only terminal task ids from the bounded transcript reader', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'claude-task-notification-'))
+    const transcriptPath = join(dir, 'session.jsonl')
+    writeFileSync(
+      transcriptPath,
+      [
+        notificationRecord('running-task', 'running'),
+        notificationRecord('completed-task', 'completed'),
+        notificationRecord('killed-task', 'killed')
+      ].join('\n')
+    )
+    try {
+      expect(readClaudeTerminalTaskNotificationIds(transcriptPath)).toEqual(
+        new Set(['completed-task', 'killed-task'])
+      )
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('skips a partial JSONL record at the ownership offset', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'claude-task-offset-'))
+    const transcriptPath = join(dir, 'session.jsonl')
+    const partialRecord = '{"type":"user","message":{"content":"'
+    writeFileSync(transcriptPath, partialRecord)
+    try {
+      appendFileSync(
+        transcriptPath,
+        `continued"}}\n${notificationRecord('later-task', 'completed')}\n`
+      )
+
+      expect(readClaudeTerminalTaskNotifications(transcriptPath, partialRecord.length)).toEqual([
+        expect.objectContaining({ taskId: 'later-task', status: 'completed' })
+      ])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('skips a partial first record at the bounded scan boundary', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'claude-task-boundary-'))
+    const transcriptPath = join(dir, 'session.jsonl')
+    writeFileSync(
+      transcriptPath,
+      `${'x'.repeat(4 * 1024 * 1024 + 256)}\n${notificationRecord('tail-task', 'failed')}\n`
+    )
+    try {
+      expect(readClaudeTerminalTaskNotificationIds(transcriptPath)).toEqual(new Set(['tail-task']))
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/shared/claude-task-notification.ts
+++ b/src/shared/claude-task-notification.ts
@@ -16,7 +16,11 @@ const TERMINAL_TASK_STATUSES = new Set([
 
 /** Read terminal Claude task notifications from the bounded transcript tail. */
 export function readClaudeTerminalTaskNotificationIds(transcriptPath: unknown): Set<string> {
-  return new Set(readClaudeTerminalTaskNotifications(transcriptPath).map(({ taskId }) => taskId))
+  return new Set(
+    readClaudeTerminalTaskNotificationsInternal(transcriptPath, 0, false).map(
+      ({ taskId }) => taskId
+    )
+  )
 }
 
 export type ClaudeTerminalTaskNotification = {
@@ -28,6 +32,14 @@ export type ClaudeTerminalTaskNotification = {
 export function readClaudeTerminalTaskNotifications(
   transcriptPath: unknown,
   minimumByteOffset = 0
+): ClaudeTerminalTaskNotification[] {
+  return readClaudeTerminalTaskNotificationsInternal(transcriptPath, minimumByteOffset, true)
+}
+
+function readClaudeTerminalTaskNotificationsInternal(
+  transcriptPath: unknown,
+  minimumByteOffset: number,
+  requireProviderDelivery: boolean
 ): ClaudeTerminalTaskNotification[] {
   if (typeof transcriptPath !== 'string' || transcriptPath.length === 0) {
     return []
@@ -70,7 +82,7 @@ export function readClaudeTerminalTaskNotifications(
         lineStart = newline === -1 ? buffer.length : newline + 1
         continue
       }
-      const notification = parseClaudeTaskNotificationLine(line)
+      const notification = parseClaudeTaskNotificationLineInternal(line, requireProviderDelivery)
       if (notification && TERMINAL_TASK_STATUSES.has(notification.status)) {
         notifications.push({ ...notification, byteOffset: start + lineStart })
       }
@@ -85,7 +97,21 @@ export function readClaudeTerminalTaskNotifications(
 export function parseClaudeTaskNotificationLine(
   line: string
 ): { taskId: string; status: string } | null {
-  const notification = taskNotificationText(line)
+  return parseClaudeTaskNotificationLineInternal(line, true)
+}
+
+/** Preserve historical queue-record support for view-only transcript status. */
+export function parseClaudeTaskNotificationLineForDisplay(
+  line: string
+): { taskId: string; status: string } | null {
+  return parseClaudeTaskNotificationLineInternal(line, false)
+}
+
+function parseClaudeTaskNotificationLineInternal(
+  line: string,
+  requireProviderDelivery: boolean
+): { taskId: string; status: string } | null {
+  const notification = taskNotificationText(line, requireProviderDelivery)
   if (
     !notification.startsWith(CLAUDE_TASK_NOTIFICATION_MARKER) ||
     !notification.endsWith('</task-notification>')
@@ -97,23 +123,27 @@ export function parseClaudeTaskNotificationLine(
   return taskId && status ? { taskId, status } : null
 }
 
-function taskNotificationText(line: string): string {
+function taskNotificationText(line: string, requireProviderDelivery: boolean): string {
   try {
     const parsed = JSON.parse(line) as unknown
     if (!parsed || typeof parsed !== 'object') {
       return ''
     }
     const record = parsed as Record<string, unknown>
-    const origin =
-      record.origin && typeof record.origin === 'object'
-        ? (record.origin as Record<string, unknown>)
-        : undefined
-    if (
-      record.type !== 'user' ||
-      record.promptSource !== 'system' ||
-      origin?.kind !== 'task-notification'
-    ) {
-      return ''
+    if (requireProviderDelivery) {
+      const origin =
+        record.origin && typeof record.origin === 'object'
+          ? (record.origin as Record<string, unknown>)
+          : undefined
+      if (
+        record.type !== 'user' ||
+        record.promptSource !== 'system' ||
+        origin?.kind !== 'task-notification'
+      ) {
+        return ''
+      }
+    } else if (typeof record.content === 'string') {
+      return record.content.trim()
     }
     if (!record.message || typeof record.message !== 'object') {
       return ''

--- a/src/shared/claude-task-notification.ts
+++ b/src/shared/claude-task-notification.ts
@@ -86,7 +86,10 @@ export function parseClaudeTaskNotificationLine(
   line: string
 ): { taskId: string; status: string } | null {
   const notification = taskNotificationText(line)
-  if (!notification.startsWith(CLAUDE_TASK_NOTIFICATION_MARKER)) {
+  if (
+    !notification.startsWith(CLAUDE_TASK_NOTIFICATION_MARKER) ||
+    !notification.endsWith('</task-notification>')
+  ) {
     return null
   }
   const taskId = TASK_ID_PATTERN.exec(notification)?.[1]?.trim()
@@ -101,8 +104,16 @@ function taskNotificationText(line: string): string {
       return ''
     }
     const record = parsed as Record<string, unknown>
-    if (typeof record.content === 'string') {
-      return record.content.trim()
+    const origin =
+      record.origin && typeof record.origin === 'object'
+        ? (record.origin as Record<string, unknown>)
+        : undefined
+    if (
+      record.type !== 'user' ||
+      record.promptSource !== 'system' ||
+      origin?.kind !== 'task-notification'
+    ) {
+      return ''
     }
     if (!record.message || typeof record.message !== 'object') {
       return ''

--- a/src/shared/claude-task-notification.ts
+++ b/src/shared/claude-task-notification.ts
@@ -1,0 +1,135 @@
+import { closeSync, openSync, readSync, statSync } from 'node:fs'
+
+export const CLAUDE_TASK_NOTIFICATION_MARKER = '<task-notification>'
+const TASK_ID_PATTERN = /<task-id>([^<]+)<\/task-id>/
+const TASK_STATUS_PATTERN = /<status>([a-z_]+)<\/status>/
+const TRANSCRIPT_SCAN_BYTES = 4 * 1024 * 1024
+const TERMINAL_TASK_STATUSES = new Set([
+  'completed',
+  'failed',
+  'killed',
+  'stopped',
+  'cancelled',
+  'canceled',
+  'timed_out'
+])
+
+/** Read terminal Claude task notifications from the bounded transcript tail. */
+export function readClaudeTerminalTaskNotificationIds(transcriptPath: unknown): Set<string> {
+  return new Set(readClaudeTerminalTaskNotifications(transcriptPath).map(({ taskId }) => taskId))
+}
+
+export type ClaudeTerminalTaskNotification = {
+  taskId: string
+  status: string
+  byteOffset: number
+}
+
+export function readClaudeTerminalTaskNotifications(
+  transcriptPath: unknown,
+  minimumByteOffset = 0
+): ClaudeTerminalTaskNotification[] {
+  if (typeof transcriptPath !== 'string' || transcriptPath.length === 0) {
+    return []
+  }
+  try {
+    const size = statSync(transcriptPath).size
+    if (size <= 0 || minimumByteOffset >= size) {
+      return []
+    }
+    const requestedStart = Math.max(0, minimumByteOffset)
+    const length = Math.min(size - requestedStart, TRANSCRIPT_SCAN_BYTES)
+    const start = size - length
+    const buffer = Buffer.alloc(length)
+    const fd = openSync(transcriptPath, 'r')
+    try {
+      let filled = 0
+      while (filled < length) {
+        const count = readSync(fd, buffer, filled, length - filled, start + filled)
+        if (count === 0) {
+          break
+        }
+        filled += count
+      }
+      if (filled !== length) {
+        return []
+      }
+    } finally {
+      closeSync(fd)
+    }
+    let lineStart = start === 0 || start === requestedStart ? 0 : buffer.indexOf(0x0a) + 1
+    if (lineStart === 0 && start > 0 && start !== requestedStart) {
+      return []
+    }
+    const notifications: ClaudeTerminalTaskNotification[] = []
+    while (lineStart < buffer.length) {
+      const newline = buffer.indexOf(0x0a, lineStart)
+      const lineEnd = newline === -1 ? buffer.length : newline
+      const line = buffer.subarray(lineStart, lineEnd).toString('utf8')
+      if (!line.includes(CLAUDE_TASK_NOTIFICATION_MARKER)) {
+        lineStart = newline === -1 ? buffer.length : newline + 1
+        continue
+      }
+      const notification = parseClaudeTaskNotificationLine(line)
+      if (notification && TERMINAL_TASK_STATUSES.has(notification.status)) {
+        notifications.push({ ...notification, byteOffset: start + lineStart })
+      }
+      lineStart = newline === -1 ? buffer.length : newline + 1
+    }
+    return notifications
+  } catch {
+    return []
+  }
+}
+
+export function parseClaudeTaskNotificationLine(
+  line: string
+): { taskId: string; status: string } | null {
+  const notification = taskNotificationText(line)
+  if (!notification.startsWith(CLAUDE_TASK_NOTIFICATION_MARKER)) {
+    return null
+  }
+  const taskId = TASK_ID_PATTERN.exec(notification)?.[1]?.trim()
+  const status = TASK_STATUS_PATTERN.exec(notification)?.[1]
+  return taskId && status ? { taskId, status } : null
+}
+
+function taskNotificationText(line: string): string {
+  try {
+    const parsed = JSON.parse(line) as unknown
+    if (!parsed || typeof parsed !== 'object') {
+      return ''
+    }
+    const record = parsed as Record<string, unknown>
+    if (typeof record.content === 'string') {
+      return record.content.trim()
+    }
+    if (!record.message || typeof record.message !== 'object') {
+      return ''
+    }
+    const content = (record.message as Record<string, unknown>).content
+    if (typeof content === 'string') {
+      return content.trim()
+    }
+    return Array.isArray(content)
+      ? content.map(taskNotificationBlockText).filter(Boolean).join(' ').trim()
+      : ''
+  } catch {
+    return ''
+  }
+}
+
+function taskNotificationBlockText(block: unknown): string {
+  if (typeof block === 'string') {
+    return block
+  }
+  if (!block || typeof block !== 'object') {
+    return ''
+  }
+  const record = block as Record<string, unknown>
+  return typeof record.text === 'string'
+    ? record.text
+    : typeof record.content === 'string'
+      ? record.content
+      : ''
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​564 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​562 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​520 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​59 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​461 |

<!-- /orca-pr-loc -->

## Summary

Addresses #15317 / STA-4756.

- reconcile Claude background task ownership from exact terminal task notifications at a provider-owned `idle_prompt` boundary
- keep unknown, unbounded, mismatched, and transcript-less work fail-active
- retire a missed `SubagentStop` through the same exact task-id evidence
- replay the reconciled ordinary `done` payload without adding a wire field or opcode

## Root cause

Claude can emit `Stop` while `background_tasks` still contains running work, append a structured `<task-notification>` when that work terminates, resume internally without `UserPromptSubmit`, and then miss the final `Stop`/`SubagentStop` hook. Orca consequently retains the last working tool event in authoritative relay state. Reconnect and client restart faithfully replay that stale host state; replay is propagation, not the source.

An `idle_prompt` notification alone is not a completion signal: Claude 2.1.237 also emits it while a background shell is still running. This change only clears task IDs that Orca previously observed as running in the same transcript and whose terminal notification was appended at or after Orca observed that ownership. The transcript scan is bounded to 4 MiB and fails active if evidence is unavailable.

## Real paired candidate validation

Fresh candidate server on Windows 2 (`6aae67d0-9e72-4bb7-b1ac-f5b21f09cb43`):

- Claude 2.1.237 ran a real background `sleep 12`; provider output reached `FINISHED` and the TUI was idle
- authoritative remote `worktree ps` transitioned from agent `working` while the shell ran to `done` after the provider-authored task delivery
- the installed client was fully restarted while the candidate server and Claude process survived; Electron CDP rendered the remote workspace and agent as `Done`
- switching to a local workspace and back preserved rendered `Done`
- a separate Codex control could not start because the isolated candidate profile lacked `CODEX_LB_API_KEY`; no Codex product conclusion is drawn from that environment failure

This covers provider/session state, execution-host authority, client mirror/rendering, reconnect/client restart, and hidden workspace switching. Parking was not involved in the reproduced failure or the authoritative fix.

## Reviewer hardening

Three independent `gpt-5.6-luna` reviewers challenged the lifecycle and compatibility boundary. Valid findings were fixed before this update:

- `idle_prompt` without an exact owned terminal task record emits no completion
- rejected nested/stale hooks roll back both subagent roster and lead lifecycle state
- repeated running inventories retain the original ownership boundary so a delayed idle hook can still consume an already-written completion
- authoritative reconciliation accepts only Claude's `promptSource: system` / `origin.kind: task-notification` delivery record and rejects queue, user-authored, and malformed shapes; the view-only AI Vault scanner retains historical queue-record support

The 4 MiB transcript scan and in-memory ownership are deliberately fail-active: missing evidence preserves `working` rather than fabricating `done`.
## Windows 2 evidence

Installed Orca 1.4.185, paired remote workspace:

- workspace: `C:/Users/neil/orca/workspaces/orca/fix-windows-enumerate-the-process-table-through`
- pane: `f02245b1-f3fb-46e9-8b51-5f2fa1dfdd76:204ffd75-ce36-4a11-9c2b-c9a74695d68f`
- terminal: `term_e89c6c93-24c5-4b1a-a379-bfd6f0fcda73`
- Claude session: `e6a90aa2-d59a-4ce3-b084-76f19153b7b7`

Independent signals at failure:

- provider session file reported idle; provider PID remained live
- `orca terminal wait --for tui-idle` succeeded and the prompt/title was idle
- authoritative `orca worktree ps --json` and persisted Orca state remained `working`, with last hook `PostToolUse:Bash`
- disconnect/reconnect and full client restart replayed `working` while the remote server survived

This excludes process death, terminal parking, and renderer-only projection staleness for the reproduced failure.

## Deterministic proof

`src/relay/agent-hook-server.test.ts` reproduces the exact host transition and reconnect replay. Mutation proof:

- reconciliation disabled: `expected done`, received `working`
- reconciliation restored: same test passes and replay returns `done`

Additional coverage pins exact-id matching, multiple tasks, repeated-inventory ownership retention, provider-authored notification provenance, malformed/unidentified tasks, missed `SubagentStop`, cron isolation, hook preservation, partial JSONL records, and the bounded scan boundary.

## Validation

- 213 relevant Claude/relay/parser/installer tests pass (10 skipped by existing platform guards)
- mutation proof: disabling reconciliation reproduces `expected done, received working`; restoring it passes and reconnect replay returns `done`
- full `pnpm run typecheck`
- focused `oxlint --deny-warnings`
- `pnpm run check:max-lines-ratchet`
- `git diff --check`
- prior pushed head passed all PR CI, including Windows packaging, managed hooks on Node 18, Git compatibility, and cross-version wire compatibility; the hardened head is running the same checks
- local cross-version harness remains blocked before execution by its Windows `sh`/`tar -C` native-path handling; CI's cross-version job passed
## Residual risks

- ownership is in-memory and transcript scanning is bounded to 4 MiB; missing evidence fails active and preserves `working`
- transcript file identity is path-based; replacement by another local process is outside the proven provider lifecycle boundary
- Claude task IDs are treated as session-unique provider identities; preserving the original offset across repeated stale inventories is required for the demonstrated final-Stop sequence
- nested cross-provider working-hook cache ownership predates this change; the new idle/done reconciliation path is covered by admission rollback
## Compatibility

The execution host/relay owns reconciliation. There is no RPC, stream-frame, or status-payload schema change; mixed-version clients receive the existing `done` payload. Native, WSL, SSH, and folder-workspace authority remains at the execution host. Parked/hidden renderer paths are not modified.

Open PR #15558 independently filters Claude settings to schema-supported hook events. `Notification` is a Claude-supported event, but that PR's allowlist must retain it if both changes land.
