### PR TITLE
Change 'SEÑOR' to 'MR' in Spanish locale

### DIFF
--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -14301,7 +14301,7 @@
           "e9f3a7b1c0": "pull request",
           "d8e2f6a0b9": "Solicitud de extracción",
           "c7d1e5f9a8": "GitHub",
-          "c4e8f1a2b9": "SEÑOR",
+          "c4e8f1a2b9": "MR",
           "b3d7e0f1a8": "solicitud de fusión",
           "a2c6d9e0f7": "Solicitud de fusión",
           "91b5c8d7e6": "GitLab"


### PR DESCRIPTION
## ELI5

Keep `SEÑOR` in English because the Spanish translation does not make sense in this context, while the English term is clear to users.

## What Changed

Updated the relevant text to keep `SEÑOR` in English instead of translating it into Spanish.

## Why

The Spanish translation is confusing and does not fit the context. Keeping the English term preserves the intended meaning and is understandable to users.

## Linked Issue

Fixes #

## Visual Proof

Attach before/after screenshots showing the text change.

## Testing

- [x] I manually tested these changes locally
- [ ] Automated tests added/updated, or explained why not below

Verified that the updated text appears correctly and that no unrelated text or behavior changed.

## AI Disclosure

Codex (GPT-5) was used to help prepare this pull request description.

## Review

Please verify that keeping `SEÑOR` in English is the intended wording for this context.

## Agent skill upstream boundary

- [x] Not applicable

## Notes

No security, cross-platform, Remote SSH, mobile, backwards-compatibility, or performance impact expected.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
