### PR TITLE
fix(grok): stop the Windows status hook from spawning two interpreters per event

### DIFF
--- a/src/main/grok/hook-service.test.ts
+++ b/src/main/grok/hook-service.test.ts
@@ -25,6 +25,13 @@ const GROK_SCRIPT_FILE_NAME = process.platform === 'win32' ? 'grok-hook.cmd' : '
 const WINDOWS_POWERSHELL_LAUNCHER =
   /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -EncodedCommand \S+$/
 
+// Why (#14828): Windows registers the bare script path when it is cmd-safe and only falls back
+// to the encoded launcher for a profile path that is not (#6078). windows-hook-launcher-chain
+// .test.ts pins which branch applies; these cases only care that Orca's hook is present.
+function registersManagedGrokScript(command: string): boolean {
+  return command.includes(GROK_SCRIPT_FILE_NAME) || WINDOWS_POWERSHELL_LAUNCHER.test(command)
+}
+
 type WindowsGrokHookRun = {
   status: number | null
   stderr: string
@@ -253,9 +260,7 @@ describe('GrokHookService', () => {
     // Why: build the invalid pattern at runtime so static lint does not flag it.
     const bareStar = ['*', ''].join('')
     expect(() => new RegExp(bareStar)).toThrow()
-    expect(config.hooks.PreToolUse[0].hooks[0].command).toMatch(
-      process.platform === 'win32' ? WINDOWS_POWERSHELL_LAUNCHER : /grok-hook/
-    )
+    expect(registersManagedGrokScript(config.hooks.PreToolUse[0].hooks[0].command)).toBe(true)
     if (process.platform !== 'win32') {
       expect(config.hooks.PreToolUse[0].hooks[0].command).toContain(join(homeDir, '.orca'))
     }
@@ -364,12 +369,6 @@ describe('GrokHookService', () => {
       definition.hooks.map((hook) => hook.command)
     )
     expect(commands).toContain('/usr/local/bin/user-hook')
-    expect(
-      commands.some((command) =>
-        process.platform === 'win32'
-          ? WINDOWS_POWERSHELL_LAUNCHER.test(command)
-          : command.includes(GROK_SCRIPT_FILE_NAME)
-      )
-    ).toBe(true)
+    expect(commands.some(registersManagedGrokScript)).toBe(true)
   })
 })

--- a/src/main/grok/hook-service.ts
+++ b/src/main/grok/hook-service.ts
@@ -9,7 +9,7 @@ import {
   readHooksJson,
   removeManagedCommands,
   wrapPosixHookCommand,
-  wrapWindowsHookCommand,
+  wrapWindowsCmdHookCommand,
   writeHooksJson,
   writeManagedScript,
   type HookDefinition
@@ -102,9 +102,23 @@ function getManagedScriptPath(): string {
 }
 
 function getManagedCommand(scriptPath: string): string {
+  // Why (#14828): Grok runs a hook command containing a space as `pwsh -Command <cmd>`, so the
+  // encoded PowerShell launcher cost two interpreters before reaching the script —
+  // `grok.exe -> pwsh.exe -> powershell.exe -> cmd.exe`, ~610ms per event, and the agent's hook
+  // console stays up for all of it. A cmd-safe bare path is spawned directly
+  // (`grok.exe -> cmd.exe`, ~110ms), the same shape Codex/Devin/Antigravity already register
+  // (#8430). Paths that are not cmd-safe still fall back to the encoded launcher (#6078).
+  // Tradeoff, as for those agents: a bare path cannot carry the launcher's missing-script
+  // guard, so a deleted script surfaces as a per-event `command not found` in the agent's log
+  // instead of a silent drain. Grok fails open — the tool still runs, including on PreToolUse.
   return process.platform === 'win32'
-    ? wrapWindowsHookCommand(scriptPath)
+    ? wrapWindowsCmdHookCommand(scriptPath)
     : wrapPosixHookCommand(scriptPath)
+}
+
+/** Test seam: the command registered for `scriptPath` on the current platform. */
+export function getManagedCommandForTests(scriptPath: string): string {
+  return getManagedCommand(scriptPath)
 }
 
 function getManagedScript(target: 'local' | 'posix' = 'local'): string {

--- a/src/main/grok/windows-hook-launcher-chain.test.ts
+++ b/src/main/grok/windows-hook-launcher-chain.test.ts
@@ -1,0 +1,190 @@
+// Why (#14828): Grok runs a hook `command` containing a space as `pwsh -Command <cmd>`, so the
+// encoded PowerShell launcher put two interpreters between the agent and the script —
+// `grok.exe -> pwsh.exe -> powershell.exe -> cmd.exe` — and the console Grok allocates for a
+// hook stays up for the whole chain. Measured against Grok 1.0.5's own dispatcher timing, the
+// same script costs ~610ms behind the launcher and ~110ms as a bare path. These assertions pin
+// the launch shape; the payload/exit-code contract stays covered by hook-service.test.ts.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+const { homedirMock } = vi.hoisted(() => ({
+  homedirMock: vi.fn<() => string>()
+}))
+
+vi.mock('os', async () => {
+  const actual = (await vi.importActual('os')) as Record<string, unknown>
+  return {
+    ...actual,
+    homedir: homedirMock
+  }
+})
+
+import { getManagedCommandForTests, GrokHookService } from './hook-service'
+import { wrapWindowsHookCommand } from '../agent-hooks/installer-utils'
+
+const GROK_EVENT_NAMES = [
+  'SessionStart',
+  'UserPromptSubmit',
+  'Stop',
+  'StopFailure',
+  'SessionEnd',
+  'PreToolUse',
+  'PostToolUse',
+  'PostToolUseFailure',
+  'Notification'
+] as const
+
+type InstalledConfig = {
+  hooks: Record<string, { matcher?: string; hooks: { command: string }[] }[]>
+}
+
+// Why: generate under a mocked win32 so the POSIX CI legs guard this too (#15117).
+function withWin32<T>(run: () => T): T {
+  const original = Object.getOwnPropertyDescriptor(process, 'platform')
+  Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+  try {
+    return run()
+  } finally {
+    if (original) {
+      Object.defineProperty(process, 'platform', original)
+    }
+  }
+}
+
+function readInstalledConfig(home: string): InstalledConfig {
+  return JSON.parse(
+    readFileSync(join(home, '.grok', 'hooks', 'orca-status.json'), 'utf8')
+  ) as InstalledConfig
+}
+
+function registeredCommands(config: InstalledConfig): string[] {
+  return GROK_EVENT_NAMES.flatMap((eventName) =>
+    (config.hooks[eventName] ?? []).flatMap((definition) =>
+      definition.hooks.map((hook) => hook.command)
+    )
+  )
+}
+
+describe('Windows Grok managed hook launch shape', () => {
+  // Why: only `process.platform` can be mocked, not `path.join`, so an install on a POSIX
+  // runner produces a `/`-separated path that is cmd-safe by no definition and routes to the
+  // #6078 fallback by design. These synthetic-path cases carry the invariant on every CI leg;
+  // the install-based ones below re-check it against a real generated path on Windows.
+  describe('registered command, from a synthetic Windows path', () => {
+    const scriptPath = 'C:\\Users\\dev\\.orca\\agent-hooks\\grok-hook.cmd'
+
+    it('registers a cmd-safe script path as the command itself (#14828)', () => {
+      const command = withWin32(() => getManagedCommandForTests(scriptPath))
+
+      // Why (#8430): Grok spawns this as argv[0], so it must be exactly one spawnable token.
+      expect(command).toBe(scriptPath)
+      // Why: whitespace is the sole trigger for Grok's `pwsh -Command` wrapper, which is the
+      // interpreter this fix removes. Assert the trigger, not just the absence of the name.
+      expect(command, 'a space would reintroduce the pwsh wrapper').not.toMatch(/\s/)
+      expect(command).not.toMatch(/powershell|pwsh/i)
+      expect(command).not.toMatch(/-EncodedCommand/i)
+    })
+
+    it('still wraps a path cmd.exe would split or expand (#6078)', () => {
+      const spaced = 'C:\\Users\\Jane Doe\\.orca\\agent-hooks\\grok-hook.cmd'
+      const command = withWin32(() => getManagedCommandForTests(spaced))
+
+      expect(command).toMatch(/-EncodedCommand \S+$/)
+      // Why: the raw path must never reach a cmd.exe command line unquoted.
+      expect(command).not.toContain(spaced)
+    })
+  })
+
+  describe('installed config', () => {
+    let home = ''
+
+    beforeEach(() => {
+      home = mkdtempSync(join(tmpdir(), 'orca-grok-launcher-'))
+      homedirMock.mockReturnValue(home)
+    })
+
+    afterEach(() => {
+      vi.clearAllMocks()
+      rmSync(home, { recursive: true, force: true })
+      home = ''
+    })
+
+    // win32-only: a real cmd-safe managed path needs backslashes; see the note above.
+    it.skipIf(process.platform !== 'win32')(
+      'writes the generated script path itself to every managed event',
+      () => {
+        const scriptPath = join(home, '.orca', 'agent-hooks', 'grok-hook.cmd')
+        const commands = withWin32(() => {
+          expect(new GrokHookService().install().state).toBe('installed')
+          return registeredCommands(readInstalledConfig(home))
+        })
+
+        expect(commands).toHaveLength(GROK_EVENT_NAMES.length)
+        for (const command of commands) {
+          expect(command).toBe(scriptPath)
+          expect(existsSync(command), 'registered command must name a real file').toBe(true)
+        }
+      }
+    )
+
+    it.skipIf(process.platform !== 'win32')(
+      'replaces a previously installed encoded-PowerShell entry on reinstall',
+      () => {
+        const scriptPath = join(home, '.orca', 'agent-hooks', 'grok-hook.cmd')
+        const staleCommand = wrapWindowsHookCommand(scriptPath)
+        const configPath = join(home, '.grok', 'hooks', 'orca-status.json')
+        mkdirSync(dirname(configPath), { recursive: true })
+        writeFileSync(
+          configPath,
+          `${JSON.stringify({
+            hooks: {
+              Stop: [{ hooks: [{ type: 'command', command: staleCommand, timeout: 10 }] }],
+              // Why: a retired event must be swept too, or the old launcher keeps firing there.
+              SubagentStop: [{ hooks: [{ type: 'command', command: staleCommand, timeout: 10 }] }],
+              Notification: [{ hooks: [{ type: 'command', command: '/usr/local/bin/user-hook' }] }]
+            }
+          })}\n`,
+          'utf8'
+        )
+
+        const config = withWin32(() => {
+          expect(new GrokHookService().install().state).toBe('installed')
+          return readInstalledConfig(home)
+        })
+
+        const all = Object.values(config.hooks).flatMap((definitions) =>
+          definitions.flatMap((definition) => definition.hooks.map((hook) => hook.command))
+        )
+        expect(all).not.toContain(staleCommand)
+        expect(all.filter((command) => /-EncodedCommand/i.test(command))).toEqual([])
+        expect(config.hooks.SubagentStop).toBeUndefined()
+        // Why: sweeping stale Orca entries must not touch hooks the user wrote.
+        expect(all).toContain('/usr/local/bin/user-hook')
+        expect(all.filter((command) => command === scriptPath)).toHaveLength(
+          GROK_EVENT_NAMES.length
+        )
+      }
+    )
+
+    it('falls back to the encoded launcher when the profile path is not cmd-safe (#6078)', () => {
+      const spaceHome = mkdtempSync(join(tmpdir(), 'orca grok spaced '))
+      homedirMock.mockReturnValue(spaceHome)
+      try {
+        const commands = withWin32(() => {
+          expect(new GrokHookService().install().state).toBe('installed')
+          return registeredCommands(readInstalledConfig(spaceHome))
+        })
+
+        expect(commands.length).toBeGreaterThan(0)
+        for (const command of commands) {
+          expect(command).toMatch(/-EncodedCommand \S+$/)
+          expect(command).not.toContain(spaceHome)
+        }
+      } finally {
+        rmSync(spaceHome, { recursive: true, force: true })
+      }
+    })
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​199 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​189 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​14 |

<!-- /orca-pr-loc -->

## ELI5

On Windows, Grok runs any hook command that contains a space by handing it to PowerShell 7
(`pwsh -Command …`). Orca registered its Grok status hook as an encoded `powershell.exe …`
command line, which is full of spaces — so every status event started **two** interpreters
before it reached a script whose whole job is one loopback POST:

```
before   grok.exe -> pwsh.exe -> powershell.exe -> cmd.exe -> curl.exe     518-719 ms
after    grok.exe -> cmd.exe -> curl.exe                                    43-213 ms
```

Orca now registers the script's own path, the same way Codex, Devin and Antigravity hooks are
already registered. Grok spawns it directly, the two interpreters disappear, and the status
posts are byte-for-byte the same.

## What Changed

- `src/main/grok/hook-service.ts` — the Windows managed command comes from the shared
  `wrapWindowsCmdHookCommand(scriptPath)` instead of `wrapWindowsHookCommand(scriptPath)`. That
  helper returns the bare path when it is cmd-safe and otherwise falls back to the same encoded
  PowerShell launcher as before, so #6078 (space in the profile path) stays covered.
- `src/main/grok/windows-hook-launcher-chain.test.ts` — new. Pins the launch shape: the
  registered command is the script path itself, names a real file, contains no whitespace (the
  sole trigger for Grok's `pwsh` wrapper), and carries no interpreter. Also covers the upgrade
  sweep and the non-cmd-safe fallback. Split into synthetic-path cases that run on **every** CI
  leg and install-based cases gated to win32 — only `process.platform` can be mocked, not
  `path.join`, so a real install on a POSIX runner yields a `/`-separated path that routes to
  the #6078 fallback by design (same gating and reason as `installer-utils.test.ts:692`).
- `src/main/grok/hook-service.ts` — small `getManagedCommandForTests` seam, so the
  platform-independent cases assert the decision this PR makes rather than the shared helper.
- `src/main/grok/hook-service.test.ts` — the two assertions that hard-coded the PowerShell
  launcher now accept either registration; which branch applies is pinned by the new file.

No change to the script body, the POSIX script, the remote/SSH installer, the WSL relay path,
or any other agent.

## Why

`#14828` reports a console flash and focus steal on every Grok tool call. Three reporters
posted the same process tree — `grok.exe -> pwsh.exe/powershell.exe -> cmd.exe`. I reproduced
that tree exactly by instrumenting a managed hook to log its own ancestor chain while the real
Grok CLI ran in a real ConPTY:

```
current shape   cmd.exe(28880)  <- powershell.exe(114684) <- pwsh.exe(100120) <- grok.exe
bare .cmd       cmd.exe(123544) <- grok.exe
```

Grok's own debug log names the mechanism: `xai_grok_config::shell: Windows shell: pwsh`.

Measured with Grok 1.0.5's own dispatcher timing, both variants registered in the same session,
running a **byte-identical copy** of the real `grok-hook.cmd` against a live listener:

| | per hook event |
|---|---|
| current (encoded PowerShell launcher) | 518, 565, 625, 719 ms — mean **607 ms** |
| bare `.cmd` path | 43, 53, 55, 133, 213 ms — mean **114 ms** |

A controlled A/B outside Grok (12 spawns each, both delivering 12/12 posts) reproduces the
ratio: 215 ms vs 49 ms.

Orca installs nine Grok events, and one single-tool-call prompt dispatched ten of them. This is
the mechanism the merged Antigravity fix (#15520) already established for this class of bug —
Orca cannot suppress the console the agent allocates for a hook, but it controls how long that
console lives. Grok was the worse case, paying two interpreters rather than one.

### What I could not reproduce

I could not make a visible console window appear from the Grok hook path on this hardware
(Windows 11 26200, Orca `main`, Grok 1.0.5), in either shape, across ~30 real hook events with a
5 ms window sampler running. The reason is measurable: Grok creates hook processes with
`CREATE_NO_WINDOW`. Verified by discriminating the flags from inside a hook —

| creation flag | what the hook process sees |
|---|---|
| `CREATE_NO_WINDOW` | `console=NONE` |
| `DETACHED_PROCESS` | `console=2361644 visible=True class=PseudoConsoleWindow` |

Grok's hooks report `console=NONE` at every level of the chain, so they have a console with no
window and every child inherits it. **This is also the check that says the change is safe**:
`DETACHED_PROCESS` is the one mode where a bare `.cmd` would be worse than the PowerShell
launcher (cmd.exe must allocate a console; PowerShell does not), and Grok demonstrably does not
use it.

So I am not claiming this makes a window I observed go away. I am claiming it removes the
interpreter chain that determines how long such a window can exist, on the same reasoning and
in the same shape as the fix already merged for Antigravity.

### Community PRs

Two open PRs target this issue. I took neither, but both contributed to the diagnosis:

- **#15530 (@sanshengai)** — correctly identified that *"Grok treats any hook `command` that
  contains a space as `pwsh -Command …`"*. That is the load-bearing insight here and my
  instrumentation confirms it. Their fix ships a new GUI-subsystem `orca-grok-hook.exe` plus a
  native build step and packaging changes; registering the existing `.cmd` removes the same
  `pwsh` wrapper with no new binary in the shipped build.
- **#15506 (@ynjmxn)** — supplied the accurate process tree that this PR reproduces. Their fix
  keeps the encoded PowerShell wrapper and replaces `& $scriptPath` with `ProcessStartInfo` +
  `CreateNoWindow`, which leaves both interpreters and the ~607 ms in place. Their stated
  premise — that the `.cmd` has no console to inherit so Windows creates one — is the
  `DETACHED_PROCESS` case above, which I could not reproduce under Grok's actual flags.

### Not this issue, but found while looking

node-pty's ConPTY teardown forks `conpty_console_list_agent` with no `windowsHide`
(`windowsPtyAgent.js:184`). From a host with no console that pops a **focus-stealing** Windows
Terminal window on every `kill()` — reproduced 3/3, with 0/2 on natural exit. Orca is not
affected because it pins `useConptyDll: true`, which skips that branch entirely (verified 0/3).
Recording it on the issue rather than changing anything here.

## Linked Issue

Fixes #14828

## Visual Proof

`N/A` for rendered Orca UI — no Orca view, layout, or in-app control changes. The subject is an
OS console belonging to the agent's own process tree, so the evidence is process-level and
lives in **Why**: measured ancestor chains, Grok's own dispatcher timings, and the creation-flag
discriminator.

## Testing

- `src/main/grok/` — **29 passed**. Verified as a real guard, not a tautology: against the
  pre-fix code the new suite fails and names the defect (`expected
  'C:/WINDOWS/…powershell.exe -NoProfile…' to be 'C:\…\grok-hook.cmd'`), including the
  synthetic-path case that runs on the POSIX legs.
- `src/main/agent-hooks/` + `src/main/grok/` — 649 passed, **6 failures that are pre-existing on
  this box**: 3 × `installer-utils` symlink, 2 × Claude `managed-hook-stdin-lifecycle`, 1 ×
  Claude `windows-hook-payload-delivery`. Confirmed identical on a clean `HEAD` worktree — same
  6, none in `src/main/grok/`, none touching this change. (Same set #15520 recorded.)
- `pnpm typecheck` clean. `oxlint --deny-warnings` clean. `oxfmt --check` clean on the content
  Git stores (the local checkout is CRLF, which flags files this PR does not touch).
- **Live Windows, real Grok CLI**: installed the fixed shape and ran a two-tool-call prompt —
  **9/9 status posts delivered** with full payloads (607–1538 bytes), hook events completing in
  43–121 ms.
- **Missing-script behaviour** (the one contract the encoded launcher provided and a bare path
  cannot): registered a nonexistent script and ran a tool call. Grok fails open — logs
  `hook failed … hook_failure=command not found: …` at `elapsed_ms=0` and **the tool still
  runs**, including for `pre_tool_use`, which Grok declares a blocking event. Same posture
  Codex/Devin/Antigravity already have, and `install()` writes the script and the config
  together.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

## Review

Ran `/code-review high` over the branch. It raised three findings; all are addressed:

- **HIGH — the cmd-safe cases would fail on the Linux CI shard.** Correct, and I had reached
  the same conclusion independently: only `process.platform` is mockable, so `path.join` still
  produces `/tmp/…`, which is not cmd-safe and takes the fallback. Restructured as described in
  **What Changed**.
- **MEDIUM — no cross-platform pin on the launch shape.** Fixed by the `getManagedCommandForTests`
  seam; the pin now runs on every leg and is verified to fail against the pre-fix code.
- **LOW — the bare path drops the launcher's missing-script guard.** Real, and now stated in the
  code comment, the commit message, and **Testing** above, with the fail-open behaviour measured
  rather than assumed.

- **Upgrade path:** `installManagedAgentHooks` calls `install()` unconditionally behind the CLI
  presence gate, and `createManagedCommandMatcher` decodes encoded commands before matching, so
  an existing `-EncodedCommand` entry is swept and replaced — including in retired events.
  Covered by a test.
- **Security:** the registered value is an absolute path under the user's own profile,
  constrained by `WINDOWS_CMD_SAFE_PATH` and spawned as argv[0], not through a shell, so there is
  no command line to quote or inject into. No secret moves onto a command line. No new binary,
  dependency, install hook, or network sink.
- **Cross-platform:** POSIX branch untouched. `installRemote` still writes the POSIX `.sh` over
  SFTP; WSL uses the POSIX script via the relay. Windows validated on hardware.
- **Known gap (unchanged by this PR, worth stating):** a profile path that is not cmd-safe —
  spaces, or non-ASCII characters — still takes the encoded-launcher fallback and keeps the old
  cost. That is the shared helper's existing behaviour for Codex/Devin/Antigravity too;
  widening the character class would change those three agents and is deliberately out of scope.
- **Performance:** strictly better — two fewer processes and ~490 ms less per hook event, ~10
  events per tool-calling turn.
- **Provider neutrality / UI / mobile / persisted state / wire format:** untouched.

## Agent skill upstream boundary

- [x] Not applicable.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
