### PR TITLE
fix(native-chat): surface Codex startup dialogs and update flow in chat view

### DIFF
--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -488,6 +488,14 @@ import {
   type BrowserScreencastResult
 } from '../../shared/runtime-types'
 import {
+  WAIT_BLOCKED_KEYWORD_PATTERN,
+  WAIT_BLOCKED_KEYWORD_CARRY_CHARS,
+  TERMINAL_WAIT_BLOCKED_SENTINEL_RE,
+  isKnownReadyPromptPreview,
+  detectTerminalWaitBlockedReason,
+  findActionableTerminalWaitBlockedSignal
+} from '../../shared/agent-startup-prompt-detection'
+import {
   RUNTIME_GRAPH_RELOAD_TIMEOUT_MS,
   RuntimeGraphReloadLifecycle
 } from './runtime-graph-reload-lifecycle'
@@ -38281,10 +38289,6 @@ export class OrcaRuntimeService {
 }
 
 const WAIT_BLOCKED_CHECK_MIN_INTERVAL_MS = 50
-// Why: chunks that could complete an actionable prompt bypass the throttle so blocked stamps stay immediate; scanned over the new chunk + short carry, never the whole window.
-const WAIT_BLOCKED_KEYWORD_PATTERN =
-  /press enter|press t to trust|do you trust|trust this|trusted workspace|permission required|requires permission|allow once|allow always|update available|choose working directory|codex just got an upgrade|hooks need review/
-const WAIT_BLOCKED_KEYWORD_CARRY_CHARS = 31
 const MAX_TAIL_LINES = 2000
 const MAX_TAIL_CHARS = 256 * 1024
 const MAX_TAIL_PARTIAL_CHARS = 4000
@@ -39634,208 +39638,6 @@ function detectExplicitIdleStatusFromTitle(title: string): AgentStatus | null {
   return null
 }
 
-function isKnownReadyPromptPreview(preview: string): boolean {
-  const normalized = preview.toLowerCase()
-  const readyIndex = findKnownReadyPromptIndex(normalized)
-  if (readyIndex === null) {
-    return false
-  }
-  const blockedSignal = findTerminalWaitBlockedSignal(normalized)
-  if (blockedSignal !== null && blockedSignal.index > readyIndex) {
-    return false
-  }
-  return true
-}
-
-function detectTerminalWaitBlockedReason(preview: string): RuntimeTerminalWaitBlockedReason | null {
-  const normalized = preview.toLowerCase()
-  return findActionableTerminalWaitBlockedSignal(normalized)?.reason ?? null
-}
-
-function findActionableTerminalWaitBlockedSignal(
-  normalized: string
-): { reason: RuntimeTerminalWaitBlockedReason; index: number } | null {
-  const blockedSignal = findTerminalWaitBlockedSignal(normalized)
-  if (blockedSignal === null) {
-    return null
-  }
-  const dismissedModalIndex = findDismissedStartupModalIndex(normalized)
-  // Why: a live prompt after the modal means it was dismissed → signal no longer actionable, even mid-run (Cursor never reports idle via OSC title).
-  return dismissedModalIndex !== null && dismissedModalIndex > blockedSignal.index
-    ? null
-    : blockedSignal
-}
-
-// Why: a live prompt (idle OR busy) proves the startup modal was dismissed, so a mid-run Cursor lane stops reporting stale trust hits.
-function findDismissedStartupModalIndex(normalized: string): number | null {
-  const indexes = [
-    findCodexReadyPromptIndex(normalized),
-    findAntigravityReadyPromptIndex(normalized),
-    findCursorActivePromptIndex(normalized)
-  ].filter((index): index is number => index !== null)
-  return indexes.length > 0 ? Math.max(...indexes) : null
-}
-
-function findKnownReadyPromptIndex(normalized: string): number | null {
-  const indexes = [
-    findCodexReadyPromptIndex(normalized),
-    findAntigravityReadyPromptIndex(normalized),
-    findCursorReadyPromptIndex(normalized)
-  ].filter((index): index is number => index !== null)
-  return indexes.length > 0 ? Math.max(...indexes) : null
-}
-
-// Why: match the banner's last occurrence to skip the trust dialog's own "Cursor Agent" text; "→" is cursor-agent's persistent input prompt.
-function findCursorActivePromptIndex(normalized: string): number | null {
-  const headerIndex = normalized.lastIndexOf('cursor agent')
-  if (headerIndex === -1) {
-    return null
-  }
-  return normalized.includes('→', headerIndex) ? headerIndex : null
-}
-
-// Why: cursor-agent emits no idle OSC title; infer idle from the tail (braille spinner = busy, its absence = idle).
-const CURSOR_BUSY_SPINNER_RE = /[⠁-⣿]/
-
-function findCursorReadyPromptIndex(normalized: string): number | null {
-  const activeIndex = findCursorActivePromptIndex(normalized)
-  if (activeIndex === null) {
-    return null
-  }
-  return CURSOR_BUSY_SPINNER_RE.test(normalized.slice(activeIndex)) ? null : activeIndex
-}
-
-function findCodexReadyPromptIndex(normalized: string): number | null {
-  const headerIndex = normalized.lastIndexOf('openai codex')
-  if (headerIndex === -1) {
-    return null
-  }
-  const readySegment = normalized.slice(headerIndex)
-  // Why: Codex prints permissions only in YOLO mode; the stable ready header is OpenAI Codex + model + directory.
-  return readySegment.includes('model:') && readySegment.includes('directory:') ? headerIndex : null
-}
-
-function findAntigravityReadyPromptIndex(normalized: string): number | null {
-  const headerIndex = normalized.lastIndexOf('antigravity cli')
-  if (headerIndex === -1) {
-    return null
-  }
-  let lineStart = headerIndex
-  let modelIndex: number | null = null
-  let promptIndex: number | null = null
-
-  // Why: ready previews can include echoed paste after the header; scan line bounds directly instead of splitting the whole tail.
-  for (let cursor = headerIndex; cursor <= normalized.length; cursor += 1) {
-    if (cursor < normalized.length && normalized.charCodeAt(cursor) !== 10) {
-      continue
-    }
-    let trimmedStart = lineStart
-    let trimmedEnd = cursor
-    while (trimmedStart < trimmedEnd && isTerminalWaitWhitespace(normalized, trimmedStart)) {
-      trimmedStart += 1
-    }
-    while (trimmedEnd > trimmedStart && isTerminalWaitWhitespace(normalized, trimmedEnd - 1)) {
-      trimmedEnd -= 1
-    }
-    if (lineStart > headerIndex && trimmedStart < trimmedEnd) {
-      if (modelIndex === null && normalized.startsWith('gemini', trimmedStart)) {
-        modelIndex = trimmedStart
-      }
-      if (
-        promptIndex === null &&
-        trimmedEnd - trimmedStart === 1 &&
-        normalized.charCodeAt(trimmedStart) === 62
-      ) {
-        promptIndex = trimmedStart
-      }
-    }
-    lineStart = cursor + 1
-  }
-
-  return modelIndex !== null && promptIndex !== null ? Math.max(modelIndex, promptIndex) : null
-}
-
-function isTerminalWaitWhitespace(value: string, index: number): boolean {
-  const code = value.charCodeAt(index)
-  return code === 32 || (code >= 9 && code <= 13)
-}
-
-const TERMINAL_WAIT_BLOCKED_SENTINEL_RE =
-  /update available|choose working directory to|codex just got an upgrade|hooks need review|do you trust|trust this|trusted workspace|press enter to (?:confirm|continue|view|insert)|press t to trust|permission required|requires permission|allow once|allow always|run this command\?/i
-
-// Why text at all: cursor-agent's hook set has no approval event and beforeShellExecution
-// fires for auto-allowed commands too, so the menu is the only authority. Match the key-bound
-// choices rather than the prose above them.
-const CURSOR_APPROVAL_CHOICE_MARKERS = [
-  'run (once)',
-  'to allowlist?',
-  'run everything',
-  'skip & tell the agent'
-]
-// Why bounded to the last lines: an answered menu stays in scrollback, and a stale hit fails
-// tui-idle and refuses prompt injection. Only a dialog that still owns the bottom of the
-// screen is live, and confining the whole match to that window also keeps prose above or
-// below — an agent narrating "I'll pick Run Everything" — from anchoring it.
-const CURSOR_APPROVAL_TAIL_LINES = 8
-
-function findCursorApprovalPromptIndex(normalized: string): number | null {
-  const windowStart = startOfLastLines(normalized, CURSOR_APPROVAL_TAIL_LINES)
-  const tail = normalized.slice(windowStart)
-  if (!tail.includes('run this command?')) {
-    return null
-  }
-  const lines = tail.split('\n')
-  while (lines.length > 0 && lines.at(-1)?.trim() === '') {
-    lines.pop()
-  }
-  let matchedLines = 0
-  let lastChoiceLine = -1
-  for (let index = 0; index < lines.length; index += 1) {
-    if (!isCursorApprovalChoiceLine(lines[index])) {
-      continue
-    }
-    matchedLines += 1
-    lastChoiceLine = index
-  }
-  if (matchedLines < 2) {
-    return null
-  }
-  // Why no slack: every capture of a live dialog ends on its last choice, and one line of
-  // tolerance is enough for the agent's own narration of a choice to revive an answered menu.
-  // A redraw caught mid-flight reads as no wait until the next poll, which is the safe way
-  // to be wrong.
-  return lastChoiceLine === lines.length - 1
-    ? windowStart + tail.lastIndexOf('run this command?')
-    : null
-}
-
-// Why the trailing key and not the wording alone: an agent narrating "next time I'll suggest
-// Run Everything" writes the same words as the menu. A selectable row ends in the key that
-// picks it, and prose does not. Spelled as key names rather than a character class, because
-// any lowercase run would readmit "…suggest Run Everything (as before)".
-const CURSOR_APPROVAL_CHOICE_KEY_RE =
-  /\((?:shift\+tab|ctrl\+[a-z]|esc(?: or [a-z])*|tab|enter|return|space|[a-z]|[\u21b5\u21e7\u21b9\u238b\u23ce]{1,3})\)\s*$/
-
-function isCursorApprovalChoiceLine(line: string): boolean {
-  return (
-    CURSOR_APPROVAL_CHOICE_KEY_RE.test(line) &&
-    CURSOR_APPROVAL_CHOICE_MARKERS.some((marker) => line.includes(marker))
-  )
-}
-
-/** Offset of the first character of the last `count` newline-separated lines. */
-function startOfLastLines(value: string, count: number): number {
-  let cursor = value.length
-  for (let seen = 0; seen < count; seen += 1) {
-    const previous = value.lastIndexOf('\n', cursor - 1)
-    if (previous === -1) {
-      return 0
-    }
-    cursor = previous
-  }
-  return cursor + 1
-}
-
 /** Why a spread and not `agentWait: value`: an absent key is the only way to say the pane was
  *  never evaluated, which a reader must not confuse with an evaluated "no wait". */
 function expandTerminalInteractiveWait(
@@ -39846,99 +39648,6 @@ function expandTerminalInteractiveWait(
 
 /** A wedged PTY controller must not stall every reader of this pane. */
 const TERMINAL_INTERACTIVE_WAIT_PROBE_TIMEOUT_MS = 2_000
-
-function findTerminalWaitBlockedSignal(
-  normalized: string
-): { reason: RuntimeTerminalWaitBlockedReason; index: number } | null {
-  // Why: one combined negative scan over the up-to-256 KiB tail avoids a dozen full-tail searches when no prompt can match.
-  if (!TERMINAL_WAIT_BLOCKED_SENTINEL_RE.test(normalized)) {
-    return null
-  }
-  const candidates: { reason: RuntimeTerminalWaitBlockedReason; index: number }[] = []
-  const updateIndex = normalized.lastIndexOf('update available')
-  if (updateIndex !== -1 && normalized.includes('press enter to continue', updateIndex)) {
-    candidates.push({ reason: 'codex-update-prompt', index: updateIndex })
-  }
-  const cwdIndex = normalized.lastIndexOf('choose working directory to')
-  if (cwdIndex !== -1 && normalized.includes('press enter to continue', cwdIndex)) {
-    candidates.push({ reason: 'codex-cwd-prompt', index: cwdIndex })
-  }
-  const modelMigrationIndex = normalized.lastIndexOf('codex just got an upgrade')
-  if (
-    modelMigrationIndex !== -1 &&
-    normalized.includes('press enter to continue', modelMigrationIndex)
-  ) {
-    candidates.push({ reason: 'codex-model-migration-prompt', index: modelMigrationIndex })
-  }
-  const hooksIndex = normalized.lastIndexOf('hooks need review')
-  if (hooksIndex !== -1 && normalized.includes('press enter to confirm', hooksIndex)) {
-    candidates.push({ reason: 'codex-hooks-review-prompt', index: hooksIndex })
-  }
-  const trustIndex = Math.max(
-    normalized.lastIndexOf('do you trust'),
-    normalized.lastIndexOf('trust this'),
-    normalized.lastIndexOf('trusted workspace')
-  )
-  const trustSegment = trustIndex === -1 ? '' : normalized.slice(trustIndex)
-  if (
-    trustIndex !== -1 &&
-    (trustSegment.includes('workspace') ||
-      trustSegment.includes('folder') ||
-      trustSegment.includes('directory') ||
-      trustSegment.includes('repo'))
-  ) {
-    candidates.push({ reason: 'codex-trust-workspace', index: trustIndex })
-  }
-  const interactivePromptIndex = Math.max(
-    normalized.lastIndexOf('press enter to confirm'),
-    normalized.lastIndexOf('press enter to continue'),
-    normalized.lastIndexOf('press enter to view'),
-    normalized.lastIndexOf('press enter to insert'),
-    normalized.lastIndexOf('press t to trust')
-  )
-  const interactivePromptContext =
-    interactivePromptIndex === -1
-      ? ''
-      : normalized.slice(Math.max(0, interactivePromptIndex - 600), interactivePromptIndex + 200)
-  const hasCodexInteractiveContext =
-    interactivePromptContext.includes('codex') ||
-    interactivePromptContext.includes('permission') ||
-    interactivePromptContext.includes('sandbox') ||
-    interactivePromptContext.includes('trust') ||
-    interactivePromptContext.includes('hook')
-  if (interactivePromptIndex !== -1 && hasCodexInteractiveContext) {
-    const contextStart = Math.max(0, interactivePromptIndex - 600)
-    const hasSpecificPromptInContext = candidates.some(
-      (candidate) => candidate.index >= contextStart && candidate.index <= interactivePromptIndex
-    )
-    if (!hasSpecificPromptInContext) {
-      candidates.push({ reason: 'codex-interactive-prompt', index: interactivePromptIndex })
-    }
-  }
-  const cursorApprovalIndex = findCursorApprovalPromptIndex(normalized)
-  if (cursorApprovalIndex !== null) {
-    candidates.push({ reason: 'agent-approval-prompt', index: cursorApprovalIndex })
-  }
-  const permissionPromptIndex = Math.max(
-    normalized.lastIndexOf('permission required'),
-    normalized.lastIndexOf('requires permission')
-  )
-  if (permissionPromptIndex !== -1) {
-    const permissionSegment = normalized.slice(permissionPromptIndex, permissionPromptIndex + 1_500)
-    const decisionCount = ['allow once', 'allow always', 'reject', 'deny'].filter((choice) =>
-      permissionSegment.includes(choice)
-    ).length
-    if (decisionCount >= 2) {
-      // Why: preserve the existing remote receipt value for mixed-version clients.
-      candidates.push({ reason: 'codex-interactive-prompt', index: permissionPromptIndex })
-    }
-  }
-  return candidates.length > 0
-    ? candidates.reduce((latest, candidate) =>
-        candidate.index > latest.index ? candidate : latest
-      )
-    : null
-}
 
 function buildTerminalWaitResult(
   handle: string,

--- a/src/renderer/src/components/native-chat/NativeChatComposer.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposer.tsx
@@ -35,6 +35,7 @@ import { useNativeChatSendLifecycle } from './use-native-chat-send-lifecycle'
 import { useNativeChatSessionOptions } from './use-native-chat-session-options'
 import { useNativeChatFileAttachmentActions } from './use-native-chat-file-attachment-actions'
 import { useNativeChatDictationActions } from './use-native-chat-dictation-actions'
+import { useNativeChatDictationState } from './use-native-chat-dictation-state'
 import { useNativeChatSessionOptionCommand } from './use-native-chat-session-option-command'
 import { useNativeChatPickerState } from './use-native-chat-picker-state'
 import { useNativeChatPickerCommandDispatch } from './use-native-chat-picker-command-dispatch'
@@ -71,6 +72,7 @@ export const NativeChatComposer = forwardRef<NativeChatComposerHandle, NativeCha
       targetPtyId,
       agent,
       canSend = true,
+      lockedReason = null,
       isWorking = false,
       onStop,
       onOptimisticSend,
@@ -83,10 +85,9 @@ export const NativeChatComposer = forwardRef<NativeChatComposerHandle, NativeCha
     },
     ref
   ): React.JSX.Element {
-    // Scope key shared with image attachments so an unsent draft + its attached
-    // images survive both TUI/GUI toggles and PTY replacement on reconnect.
-    // Why: local, SSH, and runtime reconnects can replace or temporarily clear
-    // the PTY id. Pane identity is the stable ownership key for unsent input.
+    // Scope key shared with image attachments so an unsent draft + its attached images
+    // survive both TUI/GUI toggles and PTY replacement on reconnect — local, SSH, and
+    // runtime reconnects can replace or clear the PTY id, so pane identity is the anchor.
     const draftScopeKey = paneKey
     const { draft, setDraft } = useNativeChatDraft(draftScopeKey)
     const [caret, setCaret] = useState(draft.length)
@@ -110,19 +111,11 @@ export const NativeChatComposer = forwardRef<NativeChatComposerHandle, NativeCha
       targetPtyId,
       onOptimisticSendCanceled
     )
-    const dictationState = useAppStore((store) => store.dictationState)
-    const voiceSettings = useAppStore((store) => store.settings?.voice)
-    const isDictationHoldMode = voiceSettings?.dictationMode === 'hold'
-    const dictationDisabled = voiceSettings?.enabled !== true || !voiceSettings.sttModel
-    const isDictating =
-      dictationPressed ||
-      dictationState === 'starting' ||
-      dictationState === 'listening' ||
-      dictationState === 'stopping'
+    const { isDictating, isDictationHoldMode, dictationDisabled } =
+      useNativeChatDictationState(dictationPressed)
 
-    // Place the caret at the end of the (possibly restored) draft when the
-    // composer is reused for a different pane. Adjusted during render (matching
-    // the draft reload) so caret and text stay consistent on the first paint.
+    // Place the caret at the end of the (possibly restored) draft on pane reuse; adjusted
+    // during render (matching the draft reload) so caret and text stay consistent on paint.
     const lastDraftScopeKey = useRef(draftScopeKey)
     if (lastDraftScopeKey.current !== draftScopeKey) {
       lastDraftScopeKey.current = draftScopeKey
@@ -398,6 +391,7 @@ export const NativeChatComposer = forwardRef<NativeChatComposerHandle, NativeCha
         disabled={disabled}
         hasPty={hasPty}
         canSend={canSend}
+        lockedReason={lockedReason}
         autocomplete={autocomplete}
         activeSuggestion={activeSuggestion}
         notice={notice}

--- a/src/renderer/src/components/native-chat/NativeChatComposerField.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposerField.tsx
@@ -14,6 +14,7 @@ import type { ComposerAutocomplete, NativeChatPickerItem } from './native-chat-c
 import { NativeChatMentionHint, NativeChatPickerMenu } from './NativeChatAutocompleteMenus'
 import { NativeChatComposerActions } from './NativeChatComposerActions'
 import { nativeChatComposerPlaceholder } from './native-chat-composer-target'
+import type { NativeChatSendLock } from './use-native-chat-can-send'
 import type {
   SessionOptionDescriptor,
   SessionOptionsSurface
@@ -25,6 +26,7 @@ export type NativeChatComposerFieldProps = {
   disabled: boolean
   hasPty: boolean
   canSend: boolean
+  lockedReason: NativeChatSendLock
   autocomplete: ComposerAutocomplete
   activeSuggestion: number
   notice: string | null
@@ -67,6 +69,7 @@ export function NativeChatComposerField({
   disabled,
   hasPty,
   canSend,
+  lockedReason,
   autocomplete,
   activeSuggestion,
   notice,
@@ -185,7 +188,7 @@ export function NativeChatComposerField({
                   ? `${pickerListboxId}-option-${Math.min(activeSuggestion, autocomplete.items.length - 1)}`
                   : undefined
               }
-              placeholder={nativeChatComposerPlaceholder(hasPty, canSend)}
+              placeholder={nativeChatComposerPlaceholder(hasPty, canSend, lockedReason)}
               // Why: coarse-pointer min-height follows the app's touch target convention.
               // field-sizing:content grows the field with the draft; the 8lh cap (plus
               // py-1) turns further growth into internal scrolling, and scrollbar-sleek

--- a/src/renderer/src/components/native-chat/NativeChatEmptyState.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatEmptyState.tsx
@@ -9,7 +9,7 @@ export function NativeChatEmptyState({
   message,
   agent
 }: {
-  kind: 'loading' | 'empty' | 'error' | 'not-agent'
+  kind: 'loading' | 'empty' | 'error' | 'not-agent' | 'starting-agent'
   message?: string
   agent?: NativeChatSession['agent']
 }): React.JSX.Element {
@@ -38,7 +38,7 @@ export function NativeChatEmptyState({
 }
 
 function emptyStateCopy(
-  kind: 'loading' | 'empty' | 'error' | 'not-agent',
+  kind: 'loading' | 'empty' | 'error' | 'not-agent' | 'starting-agent',
   message?: string,
   agent?: NativeChatSession['agent']
 ): { title: string; subtitle: string | null } {
@@ -89,6 +89,21 @@ function emptyStateCopy(
         subtitle: translate(
           'components.native-chat.state.empty.subtitle',
           NATIVE_CHAT_EMPTY_STATE_COPY.empty.subtitle,
+          { value0: agentName }
+        )
+      }
+    }
+    case 'starting-agent': {
+      const agentName = agent ? formatAgentTypeLabel(agent) : 'the agent'
+      return {
+        title: translate(
+          'components.native-chat.state.startingAgent.title',
+          NATIVE_CHAT_EMPTY_STATE_COPY.startingAgent.title,
+          { value0: agentName }
+        ),
+        subtitle: translate(
+          'components.native-chat.state.startingAgent.subtitle',
+          NATIVE_CHAT_EMPTY_STATE_COPY.startingAgent.subtitle,
           { value0: agentName }
         )
       }

--- a/src/renderer/src/components/native-chat/NativeChatStartupNoticeCard.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatStartupNoticeCard.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useRef } from 'react'
+import { Download, ShieldQuestion, TriangleAlert } from 'lucide-react'
+import { translate } from '@/i18n/i18n'
+import { cn } from '@/lib/utils'
+import type { NativeChatStartupNotice } from '../../../../shared/native-chat-startup-notice'
+import type { RuntimeTerminalWaitBlockedReason } from '../../../../shared/runtime-types'
+
+// i18n keys under components.native-chat.startupNotice.title.*, camelCased from the reason/
+// phase; `notice.title` (the shared module's canonical English) is the translate() fallback,
+// same dual-use as NATIVE_CHAT_EMPTY_STATE_COPY in native-chat-empty-state.ts.
+const REASON_TITLE_KEYS: Record<RuntimeTerminalWaitBlockedReason, string> = {
+  'codex-update-prompt': 'codexUpdatePrompt',
+  'codex-trust-workspace': 'codexTrustWorkspace',
+  'codex-cwd-prompt': 'codexCwdPrompt',
+  'codex-model-migration-prompt': 'codexModelMigrationPrompt',
+  'codex-hooks-review-prompt': 'codexHooksReviewPrompt',
+  'codex-interactive-prompt': 'codexInteractivePrompt',
+  'agent-approval-prompt': 'agentApprovalPrompt'
+}
+const PHASE_TITLE_KEYS: Record<Exclude<NativeChatStartupNotice['phase'], 'prompt'>, string> = {
+  running: 'running',
+  'restart-required': 'restartRequired',
+  'update-failed': 'updateFailed',
+  restarting: 'restarting'
+}
+
+function titleForNotice(notice: NativeChatStartupNotice): string {
+  const key =
+    notice.phase === 'prompt' && notice.reason
+      ? REASON_TITLE_KEYS[notice.reason]
+      : PHASE_TITLE_KEYS[notice.phase as Exclude<NativeChatStartupNotice['phase'], 'prompt'>]
+  return translate(`components.native-chat.startupNotice.title.${key}`, notice.title)
+}
+
+export type NativeChatStartupNoticeCardProps = {
+  notice: NativeChatStartupNotice
+  /** Send a parsed option's literal string to the agent's PTY (a menu digit, `\r`, `t`). */
+  onChoose: (send: string) => void
+  /** Present only on `restart-required` / `update-failed` — the update finished (or died)
+   *  and Codex needs a manual restart. Omitted while a restart is already underway. */
+  onRestart?: () => void
+  /** Always available: drop back to the raw terminal without leaving the dialog unresolved. */
+  onOpenTerminal?: () => void
+}
+
+function iconForNotice(notice: NativeChatStartupNotice): typeof Download {
+  if (notice.phase === 'update-failed') {
+    return TriangleAlert
+  }
+  if (
+    notice.phase === 'running' ||
+    notice.phase === 'restart-required' ||
+    notice.phase === 'restarting'
+  ) {
+    return Download
+  }
+  if (notice.reason === 'codex-trust-workspace') {
+    return ShieldQuestion
+  }
+  if (notice.reason === 'codex-update-prompt' || notice.reason === 'codex-model-migration-prompt') {
+    return Download
+  }
+  return TriangleAlert
+}
+
+/**
+ * Renders a Codex startup takeover the chat view otherwise has no way to show — a blocking
+ * dialog (update prompt, trust, hooks-review, …) or the self-update's own running/
+ * restart-required/update-failed/restarting phases. Modeled on NativeChatApprovalCard: same
+ * container and "first option is primary" button styling, so the two read as one family.
+ */
+export function NativeChatStartupNoticeCard({
+  notice,
+  onChoose,
+  onRestart,
+  onOpenTerminal
+}: NativeChatStartupNoticeCardProps): React.JSX.Element {
+  const Icon = iconForNotice(notice)
+  const logRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const el = logRef.current
+    if (el) {
+      el.scrollTop = el.scrollHeight
+    }
+  }, [notice.body])
+
+  const primaryActions = [
+    ...notice.options.map((option) => ({
+      label: option.label,
+      onClick: () => onChoose(option.send)
+    })),
+    ...(onRestart
+      ? [
+          {
+            label: translate('components.native-chat.startupNotice.restart', 'Restart Codex'),
+            onClick: onRestart
+          }
+        ]
+      : [])
+  ]
+
+  return (
+    <div className="shrink-0 bg-background">
+      <div className="mx-auto w-full max-w-4xl px-3 pt-2 pb-1 sm:px-4">
+        <div className="flex w-full flex-col gap-2 rounded-lg border border-input bg-card px-4 py-3 shadow-xs">
+          <div className="flex items-start gap-2">
+            <Icon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+            <p className="text-sm font-semibold text-foreground">{titleForNotice(notice)}</p>
+          </div>
+          {notice.body.length > 0 ? (
+            <div
+              ref={logRef}
+              aria-live="polite"
+              className="scrollbar-sleek max-h-64 overflow-y-auto whitespace-pre-wrap break-words rounded-md bg-muted/50 px-2 py-1.5 font-mono text-xs text-muted-foreground"
+            >
+              {notice.body.join('\n')}
+            </div>
+          ) : null}
+          <div className="flex flex-wrap gap-2">
+            {primaryActions.map((action, i) => (
+              <button
+                key={`${action.label}-${i}`}
+                type="button"
+                onClick={action.onClick}
+                className={cn(
+                  'rounded-md px-4 py-1.5 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                  i === 0
+                    ? 'bg-primary text-primary-foreground hover:bg-primary/90'
+                    : 'border border-border bg-background text-foreground hover:bg-accent'
+                )}
+              >
+                {action.label}
+              </button>
+            ))}
+            {onOpenTerminal ? (
+              <button
+                type="button"
+                onClick={onOpenTerminal}
+                className="rounded-md border border-border bg-background px-4 py-1.5 text-sm font-semibold text-foreground transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                {translate('components.native-chat.startupNotice.openTerminal', 'Open terminal')}
+              </button>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/native-chat/NativeChatView.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatView.tsx
@@ -1,14 +1,16 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '../../store'
 import { useNativeChatLaunchDraftSignal } from './use-native-chat-launch-draft-adoption'
 import { useNativeChatRetainedSession } from './use-native-chat-retained-session'
-import { selectNativeChatViewState } from './native-chat-view-state'
+import { useNativeChatSessionAugmentation } from './use-native-chat-session-augmentation'
 import { NativeChatMessageList } from './NativeChatMessageList'
 import { NativeChatComposer, type NativeChatComposerHandle } from './NativeChatComposer'
 import { useNativeChatFontScale } from './use-native-chat-font-scale'
 import { useNativeChatCanSend } from './use-native-chat-can-send'
 import { NativeChatInteractiveCard } from './NativeChatInteractiveCard'
+import { useNativeChatStartupRestart } from './use-native-chat-startup-restart'
+import { NativeChatStartupNoticeCard } from './NativeChatStartupNoticeCard'
 import { NativeChatEmptyState } from './NativeChatEmptyState'
 import { NativeChatSessionGate } from './NativeChatSessionGate'
 import { useNativeChatInteractiveSend } from './use-native-chat-interactive-send'
@@ -17,28 +19,6 @@ import {
   shouldClearNativeChatWorkingSuppression,
   shouldShowNativeChatWorking
 } from './native-chat-working-suppression'
-import {
-  appendPendingSendCache,
-  launchPromptAsMessage,
-  pendingSendsAsMessages,
-  nextNativeChatPendingSendId,
-  prunePendingSends,
-  readPendingSendCache,
-  shouldPruneLaunchPrompt,
-  writePendingSendCache,
-  type NativeChatPendingSend
-} from './native-chat-pending'
-import {
-  appendCommandMarkerCache,
-  applyCommandMarkerBoundaries,
-  commandMarkersAsMessages,
-  readCommandMarkerCache,
-  type NativeChatCommandMarker
-} from './native-chat-command-marker'
-import {
-  deriveNativeChatStreamingText,
-  nativeChatStreamingMessage
-} from '../../../../shared/native-chat-streaming'
 import {
   shouldFocusNativeChatComposerFromEditingKey,
   shouldFocusNativeChatPaneFromPointerTarget,
@@ -66,6 +46,7 @@ export default function NativeChatView({
   resolvedAgent,
   onSwitchToTerminal,
   readTerminalScreen,
+  onHoldChatForAgentRestart,
   contextMenuActions
 }: NativeChatViewProps): React.JSX.Element {
   // Select only this tab's status entry (shallow-compared) so an unrelated
@@ -100,6 +81,7 @@ export default function NativeChatView({
           terminalTabId={terminalTabId}
           onSwitchToTerminal={onSwitchToTerminal}
           readTerminalScreen={readTerminalScreen}
+          onHoldChatForAgentRestart={onHoldChatForAgentRestart}
           contextMenuActions={contextMenuActions}
         />
       )}
@@ -117,6 +99,7 @@ function NativeChatResolvedView({
   terminalTabId,
   onSwitchToTerminal,
   readTerminalScreen,
+  onHoldChatForAgentRestart,
   contextMenuActions
 }: NativeChatResolvedViewProps): React.JSX.Element {
   // Primitive owner selection (no useShallow): routes the pane's read/subscribe to
@@ -155,14 +138,34 @@ function NativeChatResolvedView({
   const hookWorkingEpoch = useAppStore(
     (s) => s.agentStatusByPaneKey[paneKey]?.stateStartedAt ?? null
   )
-  const canSend = useNativeChatCanSend(targetPtyId)
+  const { canSend, lockedReason } = useNativeChatCanSend(targetPtyId, paneKey)
   // Reuse the verified composer send path for interactive cards and composer
   // stop (Stop sends ESC, the agent-TUI interrupt key).
   const interactiveSend = useNativeChatInteractiveSend(terminalTabId, paneKey, targetPtyId, agent)
+  // Startup takeover (Codex update prompt/log, trust/hooks-review dialogs, an
+  // update-in-progress log, restart handling, …) the chat view otherwise has no way to see —
+  // see use-native-chat-startup-restart.ts. `session.messages` (not the pending/
+  // command-marker-augmented list below) so a real transcript arrival stops the watch.
+  const {
+    notice: startupNotice,
+    onChoose: onChooseStartupOption,
+    onRestart: onRestartCodex
+  } = useNativeChatStartupRestart({
+    paneKey,
+    targetPtyId,
+    readTerminalScreen,
+    isVisible,
+    messageCount: session.messages.length,
+    onHoldChatForAgentRestart,
+    sendRaw: interactiveSend.sendRaw
+  })
   const [workingInterrupted, setWorkingInterrupted] = useState(false)
   const previousWorkingEpochRef = useRef<number | null>(null)
   // True while a question card owns the input region, so the composer is hidden.
   const [questionActive, setQuestionActive] = useState(false)
+  // A startup dialog/update-in-progress/dead-agent notice also owns the input region: you
+  // cannot chat with a Codex that is blocked on a dialog, updating, or not running.
+  const inputRegionOwned = questionActive || startupNotice !== null
   const rootRef = useRef<HTMLDivElement>(null)
   const composerRef = useRef<NativeChatComposerHandle>(null)
   // The question card's free-text row; keeps Paste working while the card
@@ -185,141 +188,30 @@ function NativeChatResolvedView({
     }
   })
 
-  // Optimistic "queued" sends (mobile parity): a composer send is echoed
-  // immediately and pruned once its real user turn lands in the transcript, so
-  // the message never vanishes between send and transcript catch-up.
-  const commandMarkerScope = useMemo(
-    () => ({ paneKey, agent, sessionId }),
-    [paneKey, agent, sessionId]
-  )
-  const pendingScope = useMemo(() => ({ paneKey, agent }), [paneKey, agent])
-  const [pending, setPending] = useState<NativeChatPendingSend[]>(() =>
-    readPendingSendCache(pendingScope)
-  )
-  // Slash commands aren't chat turns, so they get a small local "Ran /clear"
-  // system line instead of a user bubble. Capped + cached per conversation.
-  const [commandMarkers, setCommandMarkers] = useState<NativeChatCommandMarker[]>(() =>
-    readCommandMarkerCache(commandMarkerScope)
-  )
-  // Reset the optimistic queue only when the pane/agent changes. A fresh launch
-  // often learns its provider session id after the first send; clearing pending
-  // on that transition briefly flashes the empty state before the transcript
-  // user turn lands.
-  useEffect(() => {
-    setPending(readPendingSendCache(pendingScope))
-    setWorkingInterrupted(false)
-  }, [pendingScope])
-  // Command markers are session-scoped because slash commands like /clear are
-  // local feedback for a specific transcript boundary.
-  useEffect(() => {
-    setCommandMarkers(readCommandMarkerCache(commandMarkerScope))
-    setWorkingInterrupted(false)
-  }, [commandMarkerScope])
-  // Prune echoes whose real user turn is now in the transcript.
-  useEffect(() => {
-    setPending((prev) =>
-      writePendingSendCache(pendingScope, prunePendingSends(prev, session.messages))
-    )
-  }, [session.messages, pendingScope])
-  useEffect(() => {
-    if (!paneLaunchPrompt || !shouldPruneLaunchPrompt(paneLaunchPrompt, session.messages)) {
-      return
-    }
-    clearNativeChatLaunchPrompt(terminalTabId)
-  }, [clearNativeChatLaunchPrompt, paneLaunchPrompt, session.messages, terminalTabId])
-  const onOptimisticSend = useCallback(
-    (text: string, imagePaths?: string[]) => {
-      setWorkingInterrupted(false)
-      const sentAt = Date.now()
-      const boundary = session.messages.at(-1)
-      const entry: NativeChatPendingSend = {
-        id: nextNativeChatPendingSendId(sentAt),
-        text,
-        sentAt,
-        afterMessageId: boundary?.id ?? null,
-        afterMessageTimestamp: boundary?.timestamp ?? null,
-        ...(imagePaths ? { imagePaths } : {})
-      }
-      setPending(appendPendingSendCache(pendingScope, entry))
-      return entry.id
-    },
-    [pendingScope, session.messages]
-  )
-  const onOptimisticSendCanceled = useCallback(
-    (pendingId: string) => {
-      // Why: detach/interrupt cancels the delayed Enter, so its optimistic echo
-      // must not come back from the pane cache as a prompt that was delivered.
-      const next = readPendingSendCache(pendingScope).filter((entry) => entry.id !== pendingId)
-      setPending(writePendingSendCache(pendingScope, next))
-    },
-    [pendingScope]
-  )
-  const onSlashCommand = useCallback(
-    (command: string) => {
-      setCommandMarkers(appendCommandMarkerCache(commandMarkerScope, command))
-    },
-    [commandMarkerScope]
-  )
-
-  const launchPromptMessage = useMemo(
-    () => launchPromptAsMessage(paneLaunchPrompt, session.messages),
-    [paneLaunchPrompt, session.messages]
-  )
-  const sessionWithLaunchPrompt = useMemo<typeof session>(() => {
-    if (!launchPromptMessage) {
-      return session
-    }
-    return { ...session, messages: [...session.messages, launchPromptMessage] }
-  }, [launchPromptMessage, session])
-
-  const sessionAfterCommandBoundaries = useMemo<typeof session>(() => {
-    const messages = applyCommandMarkerBoundaries(sessionWithLaunchPrompt.messages, commandMarkers)
-    return messages === sessionWithLaunchPrompt.messages
-      ? sessionWithLaunchPrompt
-      : { ...sessionWithLaunchPrompt, messages }
-  }, [sessionWithLaunchPrompt, commandMarkers])
-  const failedLaunchPromptMessageIds = useMemo(() => {
-    const id = paneLaunchPrompt?.failed ? launchPromptMessage?.id : null
-    if (!id || !sessionAfterCommandBoundaries.messages.some((message) => message.id === id)) {
-      return undefined
-    }
-    return new Set([id])
-  }, [paneLaunchPrompt?.failed, launchPromptMessage?.id, sessionAfterCommandBoundaries.messages])
-
-  // The streaming preview bubble (if any) sits after the transcript but before
-  // the optimistic user echoes — same order mobile uses.
-  const pendingMessages = useMemo(
-    () => pendingSendsAsMessages(pending, sessionAfterCommandBoundaries.messages),
-    [pending, sessionAfterCommandBoundaries.messages]
-  )
-  const streamingText = useMemo(() => {
-    return deriveNativeChatStreamingText({
-      messages:
-        pendingMessages.length > 0
-          ? [...sessionAfterCommandBoundaries.messages, ...pendingMessages]
-          : sessionAfterCommandBoundaries.messages,
-      previewText: hookPreview,
-      working: liveWorking
-    })
-  }, [sessionAfterCommandBoundaries.messages, pendingMessages, hookPreview, liveWorking])
-  const sessionWithPending = useMemo<typeof session>(() => {
-    if (pending.length === 0 && commandMarkers.length === 0 && !streamingText) {
-      return sessionAfterCommandBoundaries
-    }
-    return {
-      ...sessionAfterCommandBoundaries,
-      messages: [
-        ...sessionAfterCommandBoundaries.messages,
-        ...commandMarkersAsMessages(commandMarkers),
-        ...(streamingText ? [nativeChatStreamingMessage(streamingText)] : []),
-        ...pendingMessages
-      ]
-    }
-  }, [sessionAfterCommandBoundaries, pending, pendingMessages, commandMarkers, streamingText])
-  // Derive the view state from the pending-augmented session so a send into an
-  // otherwise-empty conversation flips to the list (showing the queued bubble)
-  // instead of staying on the empty state.
-  const viewState = selectNativeChatViewState(sessionWithPending)
+  // Local-only content layered on top of the transcript: optimistic "queued" send echoes,
+  // "Ran /clear" markers, the launch-context draft, and the streaming preview bubble — see
+  // use-native-chat-session-augmentation.ts.
+  const {
+    sessionWithPending,
+    sessionAfterCommandBoundariesMessages,
+    viewState,
+    failedLaunchPromptMessageIds,
+    onOptimisticSend,
+    onOptimisticSendCanceled,
+    onSlashCommand,
+    clearPendingSends
+  } = useNativeChatSessionAugmentation({
+    paneKey,
+    agent,
+    sessionId,
+    session,
+    terminalTabId,
+    paneLaunchPrompt,
+    clearNativeChatLaunchPrompt,
+    hookPreview,
+    liveWorking,
+    setWorkingInterrupted
+  })
 
   const isConversation = viewState.kind === 'ready'
   useEffect(() => {
@@ -351,9 +243,9 @@ function NativeChatResolvedView({
     // Why: Stop after a submitted turn drops the delayed-write handle once it
     // settles, so cancelPendingSends no longer sees the optimistic id. Clear
     // the echo cache here so a cancelled prompt cannot stick as a ghost bubble.
-    setPending(writePendingSendCache(pendingScope, []))
+    clearPendingSends()
     interactiveSend.cancel()
-  }, [interactiveSend, pendingScope])
+  }, [interactiveSend, clearPendingSends])
   const nativeChatFileLinkClick = useNativeChatFileLinkClick(fileLinkContext)
 
   // Chat-only font zoom via Cmd/Ctrl +/-/0, gated to the live conversation so
@@ -403,7 +295,7 @@ function NativeChatResolvedView({
         ) : viewState.kind === 'error' ? (
           <NativeChatEmptyState kind="error" message={viewState.message} />
         ) : viewState.kind === 'empty' ? (
-          <NativeChatEmptyState kind="empty" agent={agent} />
+          <NativeChatEmptyState kind={startupNotice ? 'starting-agent' : 'empty'} agent={agent} />
         ) : (
           <NativeChatMessageList
             session={sessionWithPending}
@@ -416,6 +308,19 @@ function NativeChatResolvedView({
           />
         )}
       </div>
+      {/* Startup takeover (Codex update prompt/log, trust/hooks-review dialogs, an
+          update-in-progress log, a required/failed restart, or a dead agent) — see
+          use-native-chat-startup-notice.ts + use-native-chat-startup-restart.ts. Rendered
+          above the interactive card since it reflects an earlier point in the agent's
+          lifecycle (no conversation exists yet). */}
+      {startupNotice ? (
+        <NativeChatStartupNoticeCard
+          notice={startupNotice}
+          onChoose={onChooseStartupOption}
+          onRestart={onRestartCodex}
+          onOpenTerminal={onSwitchToTerminal}
+        />
+      ) : null}
       {/* Live interactive prompt (question / approval) is the bottom input region
           (mobile parity). A question card supplies its own answer input, so it
           fully replaces the composer while active — no stray "Send a message". */}
@@ -423,15 +328,17 @@ function NativeChatResolvedView({
         paneKey={paneKey}
         send={interactiveSend}
         canSend={canSend}
-        messages={sessionAfterCommandBoundaries.messages}
+        messages={sessionAfterCommandBoundariesMessages}
         transcriptSettled={session.readPhase === 'ready'}
         onShowingQuestionChange={setQuestionActive}
         answerInputRef={questionAnswerInputRef}
       />
-      {/* canSend reflects the mobile presence-lock: when a mobile client holds
-          the pty, the composer shows its guarded state instead of racing the
-          mobile driver (R8). */}
-      {questionActive ? null : (
+      {/* canSend reflects the mobile presence-lock or the agent's foreground evidence
+          being gone (see use-native-chat-can-send.ts): either way the composer shows its
+          guarded state instead of racing the mobile driver (R8) or typing into a dead
+          agent's shell. inputRegionOwned additionally hides the composer while a question
+          card OR a startup notice owns the input region. */}
+      {inputRegionOwned ? null : (
         <NativeChatComposer
           ref={composerRef}
           terminalTabId={terminalTabId}
@@ -439,6 +346,7 @@ function NativeChatResolvedView({
           targetPtyId={targetPtyId}
           agent={agent}
           canSend={canSend}
+          lockedReason={lockedReason}
           isWorking={isWorking}
           onStop={stopAgent}
           onOptimisticSend={onOptimisticSend}

--- a/src/renderer/src/components/native-chat/native-chat-composer-autogrow.test.tsx
+++ b/src/renderer/src/components/native-chat/native-chat-composer-autogrow.test.tsx
@@ -34,6 +34,7 @@ function renderField(draft: string): HTMLTextAreaElement {
       disabled={false}
       hasPty
       canSend
+      lockedReason={null}
       autocomplete={{ mode: 'none' }}
       activeSuggestion={0}
       notice={null}

--- a/src/renderer/src/components/native-chat/native-chat-composer-target.ts
+++ b/src/renderer/src/components/native-chat/native-chat-composer-target.ts
@@ -1,6 +1,7 @@
 import { translate } from '@/i18n/i18n'
 import { isRemoteRuntimePtyId } from '@/runtime/runtime-terminal-inspection'
 import type { getSettingsForAgentTabRuntimeOwner } from '@/lib/agent-paste-draft'
+import type { NativeChatSendLock } from './use-native-chat-can-send'
 
 export type NativeChatResolvedTarget = {
   ptyId: string
@@ -11,7 +12,11 @@ export type NativeChatResolvedTarget = {
  *  pathological clipboard can't stall the round-trip. */
 export const NATIVE_CHAT_CONTEXT_PASTE_MAX_BYTES = 16 * 1024 * 1024
 
-export function nativeChatComposerPlaceholder(hasPty: boolean, canSend: boolean): string {
+export function nativeChatComposerPlaceholder(
+  hasPty: boolean,
+  canSend: boolean,
+  lockedReason: NativeChatSendLock = null
+): string {
   if (!hasPty) {
     return translate(
       'components.native-chat.composer.noPty',
@@ -19,6 +24,12 @@ export function nativeChatComposerPlaceholder(hasPty: boolean, canSend: boolean)
     )
   }
   if (!canSend) {
+    if (lockedReason === 'agent-gone') {
+      return translate(
+        'components.native-chat.composer.agentGone',
+        "The agent isn't running — toggle back to the terminal."
+      )
+    }
     return translate('components.native-chat.composer.locked', 'Input is held by another device.')
   }
   return translate('components.native-chat.composer.placeholder', 'Send a message…')

--- a/src/renderer/src/components/native-chat/native-chat-composer-types.ts
+++ b/src/renderer/src/components/native-chat/native-chat-composer-types.ts
@@ -1,5 +1,6 @@
 import type { AgentType } from '../../../../shared/agent-status-types'
 import type { NativeChatLaunchDraft } from '@/lib/native-chat-launch-prompt'
+import type { NativeChatSendLock } from './use-native-chat-can-send'
 
 export type NativeChatComposerProps = {
   /** Tab hosting the agent; used to resolve the live ptyId + runtime settings. */
@@ -9,8 +10,12 @@ export type NativeChatComposerProps = {
   /** Specific split-pane PTY this chat view owns. */
   targetPtyId: string | null
   agent: AgentType
-  /** Guard desktop sends while a mobile client owns the terminal input lease. */
+  /** Guard desktop sends while a mobile client owns the terminal input lease, or while the
+   *  agent's foreground evidence shows it is no longer running. */
   canSend?: boolean
+  /** Why `!canSend`, for the placeholder copy — "another device has it" vs. "nothing is
+   *  running" call for different next actions. Ignored when `canSend` is true. */
+  lockedReason?: NativeChatSendLock
   /** True while the hosted TUI reports an in-flight turn; swaps Send to Stop. */
   isWorking?: boolean
   /** Interrupt the hosted agent, usually by sending ESC into the PTY. */

--- a/src/renderer/src/components/native-chat/native-chat-leaf-routing.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-leaf-routing.test.ts
@@ -197,6 +197,48 @@ describe('resolveNativeChatLeafRoute', () => {
     ).toEqual({ chatLeafId: 'restored-agent', exitChat: false })
   })
 
+  it('holds chat open on a confirmed agent exit while an authorized restart is in flight', () => {
+    expect(
+      resolveNativeChatLeafRoute({
+        isChatViewMode: true,
+        chatLeafId: 'restarting-agent',
+        activeLeafId: 'restarting-agent',
+        chatLeafStillMounted: true,
+        activeLeafIsEligible: true,
+        chatLeafHasConfirmedAgentExit: true,
+        holdChatForAgentRestart: true
+      })
+    ).toEqual({ chatLeafId: 'restarting-agent', exitChat: false })
+  })
+
+  it('still exits chat once the hold expires even if the exit was already confirmed', () => {
+    expect(
+      resolveNativeChatLeafRoute({
+        isChatViewMode: true,
+        chatLeafId: 'restarting-agent',
+        activeLeafId: 'restarting-agent',
+        chatLeafStillMounted: true,
+        activeLeafIsEligible: true,
+        chatLeafHasConfirmedAgentExit: true,
+        holdChatForAgentRestart: false
+      })
+    ).toEqual({ chatLeafId: null, exitChat: true })
+  })
+
+  it('a restart hold does not override the leaf actually closing', () => {
+    expect(
+      resolveNativeChatLeafRoute({
+        isChatViewMode: true,
+        chatLeafId: 'closed-agent',
+        activeLeafId: 'shell-leaf',
+        chatLeafStillMounted: false,
+        activeLeafIsEligible: false,
+        chatLeafHasConfirmedAgentExit: true,
+        holdChatForAgentRestart: true
+      })
+    ).toEqual({ chatLeafId: null, exitChat: true })
+  })
+
   it('clears leaf ownership after returning to terminal view', () => {
     expect(
       resolveNativeChatLeafRoute({

--- a/src/renderer/src/components/native-chat/native-chat-leaf-routing.ts
+++ b/src/renderer/src/components/native-chat/native-chat-leaf-routing.ts
@@ -73,11 +73,19 @@ export function resolveNativeChatLeafRoute(args: {
   chatLeafStillMounted: boolean
   activeLeafIsEligible: boolean
   chatLeafHasConfirmedAgentExit?: boolean
+  /** Suppresses `chatLeafHasConfirmedAgentExit`'s effect while an Orca-authorized Codex
+   *  restart is in flight — that exit is expected and temporary (the update flow itself
+   *  exits Codex to the shell before it can be relaunched), so it must not kick the tab
+   *  back to terminal view mid-restart. Every OTHER reason to exit chat — the leaf closing,
+   *  the active leaf becoming ineligible — is untouched: this only changes what
+   *  `chatLeafHasConfirmedAgentExit: true` means, not any of the other branches below. */
+  holdChatForAgentRestart?: boolean
 }): NativeChatLeafRoute {
   if (!args.isChatViewMode) {
     return { chatLeafId: null, exitChat: false }
   }
-  if (args.chatLeafId && args.chatLeafStillMounted && !args.chatLeafHasConfirmedAgentExit) {
+  const confirmedAgentExit = args.chatLeafHasConfirmedAgentExit && !args.holdChatForAgentRestart
+  if (args.chatLeafId && args.chatLeafStillMounted && !confirmedAgentExit) {
     // Why: agent/title evidence can disappear while local, SSH, or runtime
     // transports reconnect. A mounted owning pane is not a terminal lifecycle
     // event, so keep its chat surface until the pane itself is removed.
@@ -85,13 +93,10 @@ export function resolveNativeChatLeafRoute(args: {
   }
   // Manager hydration can briefly have no active pane; preserve the requested
   // mode until a concrete leaf exists instead of toggling it off during mount.
-  if (!args.activeLeafId && !args.chatLeafHasConfirmedAgentExit) {
+  if (!args.activeLeafId && !confirmedAgentExit) {
     return { chatLeafId: args.chatLeafId, exitChat: false }
   }
-  if (
-    args.activeLeafIsEligible &&
-    (!args.chatLeafHasConfirmedAgentExit || args.activeLeafId !== args.chatLeafId)
-  ) {
+  if (args.activeLeafIsEligible && (!confirmedAgentExit || args.activeLeafId !== args.chatLeafId)) {
     return { chatLeafId: args.activeLeafId, exitChat: false }
   }
   // Why: removing the owning leaf or confirming its agent exited must not leave

--- a/src/renderer/src/components/native-chat/native-chat-scrape-fallback.ts
+++ b/src/renderer/src/components/native-chat/native-chat-scrape-fallback.ts
@@ -12,40 +12,11 @@ import type {
   NativeChatSession
 } from '../../../../shared/native-chat-types'
 import { assembleNativeChatSession } from './native-chat-session-assembler'
+// Moved to src/shared so non-renderer (and shared) consumers — the startup-notice reader —
+// can use it too; re-exported here so this file's existing importers are unaffected.
+import { stripScrollbackAnsi } from '../../../../shared/terminal-ansi-strip'
 
-// Why: replicate (not import) the minimal ANSI/control-sequence strip used by
-// agent-session-fork-context.ts so we don't modify that file. Same three
-// patterns: CSI sequences, OSC sequences, and stray single-char escapes.
-const ESC = String.fromCharCode(27)
-const ANSI_ESCAPE_PATTERN = new RegExp(`${ESC}\\[[0-?]*[ -/]*[@-~]`, 'g')
-const OSC_SEQUENCE_PATTERN = new RegExp(`${ESC}\\][^\\u0007]*(?:\\u0007|${ESC}\\\\)`, 'g')
-const SINGLE_ESCAPE_PATTERN = new RegExp(`${ESC}(?:[@-Z\\\\-_]|[()*+\\-./][0-~]|c)`, 'g')
-
-function stripUnsupportedControlCharacters(value: string): string {
-  let result = ''
-  for (const char of value) {
-    const code = char.charCodeAt(0)
-    // Drop C0 control chars except tab (9) and newline (10); keep DEL (127) out.
-    if (code <= 8 || code === 11 || code === 12 || (code >= 14 && code <= 31) || code === 127) {
-      continue
-    }
-    result += char
-  }
-  return result
-}
-
-/** Strip ANSI/OSC escapes and normalize newlines so the raw scrollback reads as
- *  plain text. Pure; safe to reuse in tests. */
-export function stripScrollbackAnsi(value: string): string {
-  return stripUnsupportedControlCharacters(
-    value
-      .replace(OSC_SEQUENCE_PATTERN, '')
-      .replace(ANSI_ESCAPE_PATTERN, '')
-      .replace(SINGLE_ESCAPE_PATTERN, '')
-  )
-    .replace(/\r\n/g, '\n')
-    .replace(/\r/g, '\n')
-}
+export { stripScrollbackAnsi } from '../../../../shared/terminal-ansi-strip'
 
 // Why: a user prompt in a terminal almost always begins with a recognizable
 // shell/agent prompt marker. We treat a segment whose first line starts with one

--- a/src/renderer/src/components/native-chat/native-chat-send-eligibility.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-send-eligibility.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   deriveNativeChatCanSend,
+  isNativeChatAgentForegroundGone,
   shouldChatTakeOverMobileSurface
 } from './native-chat-send-eligibility'
 
@@ -20,6 +21,20 @@ describe('deriveNativeChatCanSend', () => {
   it('treats an unresolved driver (null/undefined) as unlocked', () => {
     expect(deriveNativeChatCanSend(null)).toBe(true)
     expect(deriveNativeChatCanSend(undefined)).toBe(true)
+  })
+})
+
+describe('isNativeChatAgentForegroundGone', () => {
+  it('blocks a local pane once the foreground is proven back at the shell', () => {
+    expect(isNativeChatAgentForegroundGone({ shellForeground: true, isRemote: false })).toBe(true)
+  })
+
+  it('allows a local pane while the agent still owns the foreground', () => {
+    expect(isNativeChatAgentForegroundGone({ shellForeground: false, isRemote: false })).toBe(false)
+  })
+
+  it('never blocks a remote pane — shellForeground has no producer there (use-tab-agent.ts parity)', () => {
+    expect(isNativeChatAgentForegroundGone({ shellForeground: true, isRemote: true })).toBe(false)
   })
 })
 

--- a/src/renderer/src/components/native-chat/native-chat-send-eligibility.ts
+++ b/src/renderer/src/components/native-chat/native-chat-send-eligibility.ts
@@ -25,3 +25,19 @@ export function deriveNativeChatCanSend(driver: DriverState | null | undefined):
 export function shouldChatTakeOverMobileSurface(viewMode: 'terminal' | 'chat'): boolean {
   return viewMode === 'chat'
 }
+
+/**
+ * True once the pane's foreground process is proven back at a shell — the agent this chat
+ * surface was talking to is no longer running, so a send would type into the shell instead
+ * of the agent (the reported repro: authorizing a Codex update, Codex exits to restart, and
+ * chat sends kept landing in PowerShell). Gated on `!isRemote`: `shellForeground` is a
+ * local-only OSC 133;D signal (see pane-foreground-agent-tracker.ts) — remote panes never
+ * produce it, so treating its absence as "gone" there would lock every remote chat pane
+ * permanently. Same caveat as the identical gate in use-tab-agent.ts.
+ */
+export function isNativeChatAgentForegroundGone(args: {
+  shellForeground: boolean
+  isRemote: boolean
+}): boolean {
+  return !args.isRemote && args.shellForeground
+}

--- a/src/renderer/src/components/native-chat/native-chat-view-types.ts
+++ b/src/renderer/src/components/native-chat/native-chat-view-types.ts
@@ -19,6 +19,11 @@ export type NativeChatViewProps = {
   onSwitchToTerminal?: () => void
   /** Current xterm screen reader used to recover agent-reported session state. */
   readTerminalScreen?: () => string | null
+  /** Arms a short-TTL hold, keyed to `ptyId`, so a subsequent confirmed agent-exit on that
+   *  exact pty does not kick the tab back to terminal view — used when Orca itself
+   *  authorized a Codex update and the agent's coming exit is expected and temporary. See
+   *  native-chat-leaf-routing.ts's `holdChatForAgentRestart`. */
+  onHoldChatForAgentRestart?: (ptyId: string, holdMs: number) => void
   contextMenuActions?: Omit<NativeChatContextMenuActions, 'onPaste'>
 }
 
@@ -32,5 +37,6 @@ export type NativeChatResolvedViewProps = {
   terminalTabId: string
   onSwitchToTerminal?: () => void
   readTerminalScreen?: () => string | null
+  onHoldChatForAgentRestart?: (ptyId: string, holdMs: number) => void
   contextMenuActions?: Omit<NativeChatContextMenuActions, 'onPaste'>
 }

--- a/src/renderer/src/components/native-chat/use-native-chat-can-send.test.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-can-send.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment happy-dom
+
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const storeState = {
+  paneForegroundAgentByPaneKey: {} as Record<string, { shellForeground: boolean }>
+}
+
+vi.mock('../../store', () => ({
+  useAppStore: (selector: (state: typeof storeState) => unknown) => selector(storeState)
+}))
+
+vi.mock('@/lib/pane-manager/mobile-driver-state', () => ({
+  getDriverForPty: vi.fn(() => ({ kind: 'idle' })),
+  onDriverChange: vi.fn(() => () => {})
+}))
+
+vi.mock('@/runtime/runtime-terminal-inspection', () => ({
+  isRemoteRuntimePtyId: (ptyId: string) => ptyId.startsWith('remote:')
+}))
+
+import { getDriverForPty } from '@/lib/pane-manager/mobile-driver-state'
+import { useNativeChatCanSend } from './use-native-chat-can-send'
+
+const PANE_KEY = 'tab-1:leaf-1'
+
+describe('useNativeChatCanSend', () => {
+  beforeEach(() => {
+    storeState.paneForegroundAgentByPaneKey = {}
+    vi.mocked(getDriverForPty).mockReturnValue({ kind: 'idle' })
+  })
+
+  it('allows sends when nothing locks the pane', () => {
+    const { result } = renderHook(() => useNativeChatCanSend('pty-1', PANE_KEY))
+    expect(result.current).toEqual({ canSend: true, lockedReason: null })
+  })
+
+  it('reports mobile lock ahead of foreground evidence', () => {
+    vi.mocked(getDriverForPty).mockReturnValue({ kind: 'mobile', clientId: 'phone-1' })
+    storeState.paneForegroundAgentByPaneKey[PANE_KEY] = { shellForeground: true }
+    const { result } = renderHook(() => useNativeChatCanSend('pty-1', PANE_KEY))
+    expect(result.current).toEqual({ canSend: false, lockedReason: 'mobile' })
+  })
+
+  it("blocks sends once the local pane's foreground is proven back at the shell", () => {
+    storeState.paneForegroundAgentByPaneKey[PANE_KEY] = { shellForeground: true }
+    const { result } = renderHook(() => useNativeChatCanSend('pty-1', PANE_KEY))
+    expect(result.current).toEqual({ canSend: false, lockedReason: 'agent-gone' })
+  })
+
+  it('does not block a remote pane on shellForeground (no producer there)', () => {
+    storeState.paneForegroundAgentByPaneKey[PANE_KEY] = { shellForeground: true }
+    const { result } = renderHook(() => useNativeChatCanSend('remote:pty-1', PANE_KEY))
+    expect(result.current).toEqual({ canSend: true, lockedReason: null })
+  })
+
+  it('treats a null ptyId as unlocked (nothing to guard yet)', () => {
+    const { result } = renderHook(() => useNativeChatCanSend(null, PANE_KEY))
+    expect(result.current).toEqual({ canSend: true, lockedReason: null })
+  })
+})

--- a/src/renderer/src/components/native-chat/use-native-chat-can-send.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-can-send.ts
@@ -1,14 +1,33 @@
 import { useEffect, useMemo, useState } from 'react'
+import { useAppStore } from '../../store'
 import { getDriverForPty, onDriverChange } from '@/lib/pane-manager/mobile-driver-state'
-import { deriveNativeChatCanSend } from './native-chat-send-eligibility'
+import { isRemoteRuntimePtyId } from '@/runtime/runtime-terminal-inspection'
+import {
+  deriveNativeChatCanSend,
+  isNativeChatAgentForegroundGone
+} from './native-chat-send-eligibility'
+
+/** Why a lockedReason and not just the boolean: the composer's placeholder needs to tell
+ *  "another device has it" apart from "the agent isn't running" — very different next
+ *  actions for the user. `null` when unlocked. */
+export type NativeChatSendLock = 'mobile' | 'agent-gone' | null
+
+export type NativeChatSendEligibility = {
+  canSend: boolean
+  lockedReason: NativeChatSendLock
+}
 
 /**
- * Track the mobile presence-lock for this chat pane's live pty and derive the
- * composer's `canSend` (R8). The driver Map lives outside React for perf, so we
- * subscribe to its change events and re-read on each flip. A pty held by a
- * mobile client guards desktop sends exactly as it guards xterm input.
+ * Track the mobile presence-lock and the pane's own foreground-agent evidence for this chat
+ * pane's live pty, and derive the composer's `canSend`. The driver Map lives outside React
+ * for perf, so we subscribe to its change events and re-read on each flip. Mobile lock is
+ * checked first since it is the more specific/user-actionable reason ("another device has
+ * it" vs. "nothing is running").
  */
-export function useNativeChatCanSend(ptyId: string | null): boolean {
+export function useNativeChatCanSend(
+  ptyId: string | null,
+  paneKey: string
+): NativeChatSendEligibility {
   const [driverTick, setDriverTick] = useState(0)
   // Why: the driver event fires for every pty; only re-derive when it targets
   // this pane's pty. ptyId is a dep so the listener re-binds on a pty swap.
@@ -22,8 +41,18 @@ export function useNativeChatCanSend(ptyId: string | null): boolean {
       }),
     [ptyId]
   )
-  return useMemo(() => {
+  const shellForeground = useAppStore(
+    (s) => s.paneForegroundAgentByPaneKey[paneKey]?.shellForeground ?? false
+  )
+  return useMemo<NativeChatSendEligibility>(() => {
     void driverTick
-    return deriveNativeChatCanSend(ptyId ? getDriverForPty(ptyId) : null)
-  }, [ptyId, driverTick])
+    if (!deriveNativeChatCanSend(ptyId ? getDriverForPty(ptyId) : null)) {
+      return { canSend: false, lockedReason: 'mobile' }
+    }
+    const isRemote = ptyId !== null && isRemoteRuntimePtyId(ptyId)
+    if (isNativeChatAgentForegroundGone({ shellForeground, isRemote })) {
+      return { canSend: false, lockedReason: 'agent-gone' }
+    }
+    return { canSend: true, lockedReason: null }
+  }, [ptyId, driverTick, shellForeground])
 }

--- a/src/renderer/src/components/native-chat/use-native-chat-dictation-state.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-dictation-state.ts
@@ -1,0 +1,21 @@
+import { useAppStore } from '../../store'
+
+/** Derives the composer's dictation-related booleans from live voice settings + dictation
+ *  state. Sibling to use-native-chat-dictation-actions.ts (which dispatches the
+ *  toggle/start/stop controls); this one only reads. */
+export function useNativeChatDictationState(dictationPressed: boolean): {
+  isDictating: boolean
+  isDictationHoldMode: boolean
+  dictationDisabled: boolean
+} {
+  const dictationState = useAppStore((store) => store.dictationState)
+  const voiceSettings = useAppStore((store) => store.settings?.voice)
+  const isDictationHoldMode = voiceSettings?.dictationMode === 'hold'
+  const dictationDisabled = voiceSettings?.enabled !== true || !voiceSettings.sttModel
+  const isDictating =
+    dictationPressed ||
+    dictationState === 'starting' ||
+    dictationState === 'listening' ||
+    dictationState === 'stopping'
+  return { isDictating, isDictationHoldMode, dictationDisabled }
+}

--- a/src/renderer/src/components/native-chat/use-native-chat-session-augmentation.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-session-augmentation.ts
@@ -1,0 +1,233 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type Dispatch,
+  type SetStateAction
+} from 'react'
+import type { NativeChatLaunchPrompt } from '@/lib/native-chat-launch-prompt'
+import type { NativeChatSession } from '../../../../shared/native-chat-types'
+import type { NativeChatLiveSession } from './use-native-chat-live-session'
+import { selectNativeChatViewState, type NativeChatViewState } from './native-chat-view-state'
+import {
+  appendPendingSendCache,
+  launchPromptAsMessage,
+  pendingSendsAsMessages,
+  nextNativeChatPendingSendId,
+  prunePendingSends,
+  readPendingSendCache,
+  shouldPruneLaunchPrompt,
+  writePendingSendCache,
+  type NativeChatPendingSend
+} from './native-chat-pending'
+import {
+  appendCommandMarkerCache,
+  applyCommandMarkerBoundaries,
+  commandMarkersAsMessages,
+  readCommandMarkerCache,
+  type NativeChatCommandMarker
+} from './native-chat-command-marker'
+import {
+  deriveNativeChatStreamingText,
+  nativeChatStreamingMessage
+} from '../../../../shared/native-chat-streaming'
+
+/**
+ * Layers the chat view's local-only content on top of the transcript session: the optimistic
+ * "queued" echo of a just-sent message (mobile parity — pruned once the real transcript turn
+ * lands), the "Ran /clear" system line for a dispatched slash command, the launch-context
+ * draft-as-message, and the in-flight streaming preview bubble. None of these are transcript
+ * turns, so they never touch the source session — they're composed fresh on every render into
+ * `sessionWithPending`, the one session NativeChatMessageList actually renders.
+ *
+ * Pulled out of NativeChatResolvedView (native-chat-view.tsx) as its own cohesive unit —
+ * everything here answers "what does the pending-augmented conversation look like," nothing
+ * here decides send eligibility, startup dialogs, or composer focus.
+ */
+export function useNativeChatSessionAugmentation(args: {
+  paneKey: string
+  agent: NativeChatSession['agent']
+  sessionId: string | null
+  session: NativeChatLiveSession
+  terminalTabId: string
+  paneLaunchPrompt: NativeChatLaunchPrompt | null
+  clearNativeChatLaunchPrompt: (terminalTabId: string) => void
+  hookPreview: string | undefined
+  liveWorking: boolean
+  setWorkingInterrupted: Dispatch<SetStateAction<boolean>>
+}): {
+  sessionWithPending: NativeChatLiveSession
+  sessionAfterCommandBoundariesMessages: NativeChatSession['messages']
+  viewState: NativeChatViewState
+  failedLaunchPromptMessageIds: Set<string> | undefined
+  onOptimisticSend: (text: string, imagePaths?: string[]) => string | undefined
+  onOptimisticSendCanceled: (pendingId: string) => void
+  onSlashCommand: (command: string) => void
+  clearPendingSends: () => void
+} {
+  const {
+    paneKey,
+    agent,
+    sessionId,
+    session,
+    terminalTabId,
+    paneLaunchPrompt,
+    clearNativeChatLaunchPrompt,
+    hookPreview,
+    liveWorking,
+    setWorkingInterrupted
+  } = args
+
+  // Optimistic "queued" sends (mobile parity): a composer send is echoed
+  // immediately and pruned once its real user turn lands in the transcript, so
+  // the message never vanishes between send and transcript catch-up.
+  const commandMarkerScope = useMemo(
+    () => ({ paneKey, agent, sessionId }),
+    [paneKey, agent, sessionId]
+  )
+  const pendingScope = useMemo(() => ({ paneKey, agent }), [paneKey, agent])
+  const [pending, setPending] = useState<NativeChatPendingSend[]>(() =>
+    readPendingSendCache(pendingScope)
+  )
+  // Slash commands aren't chat turns, so they get a small local "Ran /clear"
+  // system line instead of a user bubble. Capped + cached per conversation.
+  const [commandMarkers, setCommandMarkers] = useState<NativeChatCommandMarker[]>(() =>
+    readCommandMarkerCache(commandMarkerScope)
+  )
+  // Reset the optimistic queue only when the pane/agent changes. A fresh launch
+  // often learns its provider session id after the first send; clearing pending
+  // on that transition briefly flashes the empty state before the transcript
+  // user turn lands.
+  useEffect(() => {
+    setPending(readPendingSendCache(pendingScope))
+    setWorkingInterrupted(false)
+  }, [pendingScope, setWorkingInterrupted])
+  // Command markers are session-scoped because slash commands like /clear are
+  // local feedback for a specific transcript boundary.
+  useEffect(() => {
+    setCommandMarkers(readCommandMarkerCache(commandMarkerScope))
+    setWorkingInterrupted(false)
+  }, [commandMarkerScope, setWorkingInterrupted])
+  // Prune echoes whose real user turn is now in the transcript.
+  useEffect(() => {
+    setPending((prev) =>
+      writePendingSendCache(pendingScope, prunePendingSends(prev, session.messages))
+    )
+  }, [session.messages, pendingScope])
+  useEffect(() => {
+    if (!paneLaunchPrompt || !shouldPruneLaunchPrompt(paneLaunchPrompt, session.messages)) {
+      return
+    }
+    clearNativeChatLaunchPrompt(terminalTabId)
+  }, [clearNativeChatLaunchPrompt, paneLaunchPrompt, session.messages, terminalTabId])
+  const onOptimisticSend = useCallback(
+    (text: string, imagePaths?: string[]) => {
+      setWorkingInterrupted(false)
+      const sentAt = Date.now()
+      const boundary = session.messages.at(-1)
+      const entry: NativeChatPendingSend = {
+        id: nextNativeChatPendingSendId(sentAt),
+        text,
+        sentAt,
+        afterMessageId: boundary?.id ?? null,
+        afterMessageTimestamp: boundary?.timestamp ?? null,
+        ...(imagePaths ? { imagePaths } : {})
+      }
+      setPending(appendPendingSendCache(pendingScope, entry))
+      return entry.id
+    },
+    [pendingScope, session.messages, setWorkingInterrupted]
+  )
+  const onOptimisticSendCanceled = useCallback(
+    (pendingId: string) => {
+      // Why: detach/interrupt cancels the delayed Enter, so its optimistic echo
+      // must not come back from the pane cache as a prompt that was delivered.
+      const next = readPendingSendCache(pendingScope).filter((entry) => entry.id !== pendingId)
+      setPending(writePendingSendCache(pendingScope, next))
+    },
+    [pendingScope]
+  )
+  const onSlashCommand = useCallback(
+    (command: string) => {
+      setCommandMarkers(appendCommandMarkerCache(commandMarkerScope, command))
+    },
+    [commandMarkerScope]
+  )
+  // Why here and not in stopAgent's own file: clearing pending must go through the same
+  // scoped cache write as every other pending mutation above.
+  const clearPendingSends = useCallback(() => {
+    setPending(writePendingSendCache(pendingScope, []))
+  }, [pendingScope])
+
+  const launchPromptMessage = useMemo(
+    () => launchPromptAsMessage(paneLaunchPrompt, session.messages),
+    [paneLaunchPrompt, session.messages]
+  )
+  const sessionWithLaunchPrompt = useMemo<NativeChatLiveSession>(() => {
+    if (!launchPromptMessage) {
+      return session
+    }
+    return { ...session, messages: [...session.messages, launchPromptMessage] }
+  }, [launchPromptMessage, session])
+
+  const sessionAfterCommandBoundaries = useMemo<NativeChatLiveSession>(() => {
+    const messages = applyCommandMarkerBoundaries(sessionWithLaunchPrompt.messages, commandMarkers)
+    return messages === sessionWithLaunchPrompt.messages
+      ? sessionWithLaunchPrompt
+      : { ...sessionWithLaunchPrompt, messages }
+  }, [sessionWithLaunchPrompt, commandMarkers])
+  const failedLaunchPromptMessageIds = useMemo(() => {
+    const id = paneLaunchPrompt?.failed ? launchPromptMessage?.id : null
+    if (!id || !sessionAfterCommandBoundaries.messages.some((message) => message.id === id)) {
+      return undefined
+    }
+    return new Set([id])
+  }, [paneLaunchPrompt?.failed, launchPromptMessage?.id, sessionAfterCommandBoundaries.messages])
+
+  // The streaming preview bubble (if any) sits after the transcript but before
+  // the optimistic user echoes — same order mobile uses.
+  const pendingMessages = useMemo(
+    () => pendingSendsAsMessages(pending, sessionAfterCommandBoundaries.messages),
+    [pending, sessionAfterCommandBoundaries.messages]
+  )
+  const streamingText = useMemo(() => {
+    return deriveNativeChatStreamingText({
+      messages:
+        pendingMessages.length > 0
+          ? [...sessionAfterCommandBoundaries.messages, ...pendingMessages]
+          : sessionAfterCommandBoundaries.messages,
+      previewText: hookPreview,
+      working: liveWorking
+    })
+  }, [sessionAfterCommandBoundaries.messages, pendingMessages, hookPreview, liveWorking])
+  const sessionWithPending = useMemo<NativeChatLiveSession>(() => {
+    if (pending.length === 0 && commandMarkers.length === 0 && !streamingText) {
+      return sessionAfterCommandBoundaries
+    }
+    return {
+      ...sessionAfterCommandBoundaries,
+      messages: [
+        ...sessionAfterCommandBoundaries.messages,
+        ...commandMarkersAsMessages(commandMarkers),
+        ...(streamingText ? [nativeChatStreamingMessage(streamingText)] : []),
+        ...pendingMessages
+      ]
+    }
+  }, [sessionAfterCommandBoundaries, pending, pendingMessages, commandMarkers, streamingText])
+  // Derive the view state from the pending-augmented session so a send into an
+  // otherwise-empty conversation flips to the list (showing the queued bubble)
+  // instead of staying on the empty state.
+  const viewState = selectNativeChatViewState(sessionWithPending)
+
+  return {
+    sessionWithPending,
+    sessionAfterCommandBoundariesMessages: sessionAfterCommandBoundaries.messages,
+    viewState,
+    failedLaunchPromptMessageIds,
+    onOptimisticSend,
+    onOptimisticSendCanceled,
+    onSlashCommand,
+    clearPendingSends
+  }
+}

--- a/src/renderer/src/components/native-chat/use-native-chat-startup-notice.test.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-startup-notice.test.ts
@@ -1,0 +1,245 @@
+// @vitest-environment happy-dom
+
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const storeState = {
+  agentStatusByPaneKey: {} as Record<string, { interactivePrompt?: string | null }>
+}
+
+vi.mock('../../store', () => ({
+  useAppStore: (selector: (state: typeof storeState) => unknown) => selector(storeState)
+}))
+
+import { useNativeChatStartupNotice } from './use-native-chat-startup-notice'
+
+const PANE_KEY = 'tab-1:leaf-1'
+const PTY_ID = 'pty-1'
+
+const UPDATE_PROMPT_SCREEN = [
+  'Update available! 0.145.0 -> 0.146.0',
+  '1. Update now',
+  '2. Skip',
+  'Press enter to continue'
+].join('\n')
+
+const RUNNING_SCREEN = [
+  'Updating Codex via `npm install -g @openai/codex`...',
+  'added 5 packages, and changed 2 packages in 30s'
+].join('\n')
+
+const RESTART_REQUIRED_SCREEN = [
+  RUNNING_SCREEN,
+  '',
+  '🎉 Update ran successfully! Please restart Codex.',
+  'PS C:\\Users\\visuz\\repo>'
+].join('\n')
+
+const READY_SCREEN = [
+  ' >_ OpenAI Codex (v0.146.0)',
+  ' model:       gpt-5.5 high   /model to change',
+  ' directory:   ~/repo'
+].join('\n')
+
+function makeScreenReader(initial: string | null): {
+  read: () => string | null
+  set: (value: string | null) => void
+} {
+  let current = initial
+  return { read: () => current, set: (value) => (current = value) }
+}
+
+describe('useNativeChatStartupNotice', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    storeState.agentStatusByPaneKey = {}
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('reports null when there is no ptyId or screen reader', () => {
+    const { result } = renderHook(() =>
+      useNativeChatStartupNotice({
+        paneKey: PANE_KEY,
+        targetPtyId: null,
+        readTerminalScreen: () => null,
+        isVisible: true,
+        messageCount: 0
+      })
+    )
+    expect(result.current).toBeNull()
+  })
+
+  it('detects an update prompt on first tick and keeps polling on the active cadence', () => {
+    const screen = makeScreenReader(UPDATE_PROMPT_SCREEN)
+    const { result } = renderHook(() =>
+      useNativeChatStartupNotice({
+        paneKey: PANE_KEY,
+        targetPtyId: PTY_ID,
+        readTerminalScreen: screen.read,
+        isVisible: true,
+        messageCount: 0
+      })
+    )
+    expect(result.current?.phase).toBe('prompt')
+    expect(result.current?.reason).toBe('codex-update-prompt')
+  })
+
+  it('transitions prompt → running → restart-required as the screen changes', () => {
+    const screen = makeScreenReader(UPDATE_PROMPT_SCREEN)
+    const { result } = renderHook(() =>
+      useNativeChatStartupNotice({
+        paneKey: PANE_KEY,
+        targetPtyId: PTY_ID,
+        readTerminalScreen: screen.read,
+        isVisible: true,
+        messageCount: 0
+      })
+    )
+    expect(result.current?.phase).toBe('prompt')
+
+    screen.set(RUNNING_SCREEN)
+    act(() => {
+      vi.advanceTimersByTime(300)
+    })
+    expect(result.current?.phase).toBe('running')
+
+    screen.set(RESTART_REQUIRED_SCREEN)
+    act(() => {
+      vi.advanceTimersByTime(300)
+    })
+    expect(result.current?.phase).toBe('restart-required')
+  })
+
+  it('settles for good once the agent reaches its ready prompt, and stops polling', () => {
+    const screen = makeScreenReader(UPDATE_PROMPT_SCREEN)
+    const { result } = renderHook(() =>
+      useNativeChatStartupNotice({
+        paneKey: PANE_KEY,
+        targetPtyId: PTY_ID,
+        readTerminalScreen: screen.read,
+        isVisible: true,
+        messageCount: 0
+      })
+    )
+    screen.set(READY_SCREEN)
+    act(() => {
+      vi.advanceTimersByTime(300)
+    })
+    expect(result.current).toBeNull()
+
+    // Even if the screen flips back to a dialog, the latch for this ptyId must not reopen.
+    screen.set(UPDATE_PROMPT_SCREEN)
+    act(() => {
+      vi.advanceTimersByTime(10_000)
+    })
+    expect(result.current).toBeNull()
+  })
+
+  it('resets the settled latch when the ptyId changes (relaunch)', () => {
+    const screen = makeScreenReader(READY_SCREEN)
+    const { result, rerender } = renderHook(
+      (props: { ptyId: string }) =>
+        useNativeChatStartupNotice({
+          paneKey: PANE_KEY,
+          targetPtyId: props.ptyId,
+          readTerminalScreen: screen.read,
+          isVisible: true,
+          messageCount: 0
+        }),
+      { initialProps: { ptyId: PTY_ID } }
+    )
+    act(() => {
+      vi.advanceTimersByTime(300)
+    })
+    expect(result.current).toBeNull()
+
+    screen.set(UPDATE_PROMPT_SCREEN)
+    rerender({ ptyId: 'pty-2' })
+    expect(result.current?.phase).toBe('prompt')
+  })
+
+  it('suppresses the notice when a hook-reported interactive prompt is present', () => {
+    storeState.agentStatusByPaneKey[PANE_KEY] = { interactivePrompt: '{"questions":[]}' }
+    const screen = makeScreenReader(UPDATE_PROMPT_SCREEN)
+    const { result } = renderHook(() =>
+      useNativeChatStartupNotice({
+        paneKey: PANE_KEY,
+        targetPtyId: PTY_ID,
+        readTerminalScreen: screen.read,
+        isVisible: true,
+        messageCount: 0
+      })
+    )
+    expect(result.current).toBeNull()
+  })
+
+  it('stops watching once a real transcript message arrives after mount', () => {
+    const screen = makeScreenReader(UPDATE_PROMPT_SCREEN)
+    const { result, rerender } = renderHook(
+      (props: { messageCount: number }) =>
+        useNativeChatStartupNotice({
+          paneKey: PANE_KEY,
+          targetPtyId: PTY_ID,
+          readTerminalScreen: screen.read,
+          isVisible: true,
+          messageCount: props.messageCount
+        }),
+      { initialProps: { messageCount: 3 } } // resumed session, messages already present
+    )
+    expect(result.current?.phase).toBe('prompt')
+
+    rerender({ messageCount: 4 }) // a NEW message arrived — proof of life
+    expect(result.current).toBeNull()
+
+    // Must stay settled even if the screen still looks like a dialog.
+    act(() => {
+      vi.advanceTimersByTime(10_000)
+    })
+    expect(result.current).toBeNull()
+  })
+
+  it('does not poll while the pane is not visible', () => {
+    const screen = makeScreenReader(UPDATE_PROMPT_SCREEN)
+    const { result } = renderHook(() =>
+      useNativeChatStartupNotice({
+        paneKey: PANE_KEY,
+        targetPtyId: PTY_ID,
+        readTerminalScreen: screen.read,
+        isVisible: false,
+        messageCount: 0
+      })
+    )
+    expect(result.current).toBeNull()
+  })
+
+  it('gives up after the watch budget expires without ever reaching a ready prompt', () => {
+    // Simulates a resumed session whose Codex header already scrolled out of the viewport —
+    // the screen never matches a known-ready pattern, so the watch must give up on its own.
+    const screen = makeScreenReader('some unrelated shell output\n')
+    const { result } = renderHook(() =>
+      useNativeChatStartupNotice({
+        paneKey: PANE_KEY,
+        targetPtyId: PTY_ID,
+        readTerminalScreen: screen.read,
+        isVisible: true,
+        messageCount: 0
+      })
+    )
+    expect(result.current).toBeNull()
+    act(() => {
+      vi.advanceTimersByTime(120_001)
+    })
+    expect(result.current).toBeNull()
+
+    // Confirm the watch actually stopped (latched settled) rather than merely reporting null
+    // this tick: a dialog appearing afterward must not reopen it.
+    screen.set(UPDATE_PROMPT_SCREEN)
+    act(() => {
+      vi.advanceTimersByTime(10_000)
+    })
+    expect(result.current).toBeNull()
+  })
+})

--- a/src/renderer/src/components/native-chat/use-native-chat-startup-notice.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-startup-notice.ts
@@ -1,0 +1,130 @@
+import { useEffect, useRef, useState } from 'react'
+import { useAppStore } from '../../store'
+import {
+  isAgentStartupSettled,
+  readNativeChatStartupNotice,
+  type NativeChatStartupNotice
+} from '../../../../shared/native-chat-startup-notice'
+
+// Why these two cadences: 300ms keeps an active dialog's log mirror (npm output, menu
+// changes) feeling live; 700ms is enough to notice a dialog appearing without polling an
+// idle, already-working conversation needlessly.
+const ACTIVE_POLL_INTERVAL_MS = 300
+const IDLE_POLL_INTERVAL_MS = 700
+// Backstop for a resumed session whose Codex header already scrolled out of the live
+// viewport before this hook ever mounted — isAgentStartupSettled would never fire, so the
+// watch must give up on its own rather than poll forever.
+const STARTUP_WATCH_BUDGET_MS = 120_000
+
+/**
+ * Watches the live terminal viewport for a Codex startup dialog (update prompt, trust,
+ * hooks-review, …) or the update flow's own running/restart-required phases, none of which
+ * reach the transcript or agent-hook status — see the header comment in
+ * native-chat-startup-notice.ts for why. Renderer-local and read-only: it never writes to
+ * the PTY (NativeChatView wires the card's chosen option through the existing
+ * useNativeChatInteractiveSend path) and does not participate in the restart flow.
+ *
+ * Stops polling for good once the agent reaches its own ready prompt, keyed per `ptyId` — a
+ * startup dialog cannot recur without a relaunch, which changes the ptyId and resets the
+ * latch. Two more backstops guard against polling forever: the watch budget above, and a
+ * message arriving in the transcript after this hook mounted (proof the conversation is
+ * live, even for a resumed session whose earlier messages were already present at mount —
+ * that pre-existing count must not itself silence the watch, since Codex's own resume flow
+ * can present a startup dialog, e.g. the "Choose working directory to resume this session"
+ * prompt, before any of those messages are known to be current).
+ */
+export function useNativeChatStartupNotice(args: {
+  paneKey: string
+  targetPtyId: string | null
+  readTerminalScreen?: () => string | null
+  isVisible: boolean
+  messageCount: number
+}): NativeChatStartupNotice | null {
+  const { paneKey, targetPtyId, readTerminalScreen, isVisible, messageCount } = args
+  // A hook-reported interactive prompt (question/approval) is more specific and always
+  // wins — NativeChatInteractiveCard already owns rendering it.
+  const interactivePrompt = useAppStore(
+    (s) => s.agentStatusByPaneKey[paneKey]?.interactivePrompt ?? null
+  )
+  const [notice, setNotice] = useState<NativeChatStartupNotice | null>(null)
+  const watchedPtyIdRef = useRef<string | null>(null)
+  const settledPtyIdRef = useRef<string | null>(null)
+  const mountedAtRef = useRef<number | null>(null)
+  const baselineMessageCountRef = useRef(0)
+
+  // Reset per-ptyId watch state on relaunch/restart — a new ptyId means a fresh startup
+  // sequence that may block again even if the previous one settled.
+  if (watchedPtyIdRef.current !== targetPtyId) {
+    watchedPtyIdRef.current = targetPtyId
+    settledPtyIdRef.current = null
+    mountedAtRef.current = null
+    baselineMessageCountRef.current = messageCount
+  }
+
+  useEffect(() => {
+    if (!targetPtyId || !readTerminalScreen || !isVisible) {
+      return
+    }
+    if (settledPtyIdRef.current === targetPtyId) {
+      setNotice(null)
+      return
+    }
+    if (messageCount > baselineMessageCountRef.current) {
+      settledPtyIdRef.current = targetPtyId
+      setNotice(null)
+      return
+    }
+    if (mountedAtRef.current === null) {
+      mountedAtRef.current = Date.now()
+    }
+    let cancelled = false
+    let timer: ReturnType<typeof setTimeout> | null = null
+
+    const settle = (): void => {
+      settledPtyIdRef.current = targetPtyId
+      setNotice(null)
+    }
+
+    const schedule = (delay: number): void => {
+      if (cancelled) {
+        return
+      }
+      timer = setTimeout(tick, delay)
+    }
+
+    function tick(): void {
+      if (cancelled) {
+        return
+      }
+      const screen = readTerminalScreen?.() ?? null
+      if (screen === null) {
+        schedule(IDLE_POLL_INTERVAL_MS)
+        return
+      }
+      if (isAgentStartupSettled(screen)) {
+        settle()
+        return
+      }
+      if (
+        mountedAtRef.current !== null &&
+        Date.now() - mountedAtRef.current > STARTUP_WATCH_BUDGET_MS
+      ) {
+        settle()
+        return
+      }
+      const next = readNativeChatStartupNotice(screen)
+      setNotice(next)
+      schedule(next ? ACTIVE_POLL_INTERVAL_MS : IDLE_POLL_INTERVAL_MS)
+    }
+
+    tick()
+    return () => {
+      cancelled = true
+      if (timer) {
+        clearTimeout(timer)
+      }
+    }
+  }, [targetPtyId, readTerminalScreen, isVisible, messageCount])
+
+  return interactivePrompt ? null : notice
+}

--- a/src/renderer/src/components/native-chat/use-native-chat-startup-restart.test.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-startup-restart.test.ts
@@ -1,0 +1,175 @@
+// @vitest-environment happy-dom
+
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { NativeChatStartupNotice } from '../../../../shared/native-chat-startup-notice'
+
+const mocks = vi.hoisted(() => ({
+  queueCodexPaneRestarts: vi.fn(),
+  useNativeChatStartupNotice: vi.fn<() => NativeChatStartupNotice | null>()
+}))
+
+vi.mock('../../store', () => ({
+  useAppStore: { getState: () => ({ queueCodexPaneRestarts: mocks.queueCodexPaneRestarts }) }
+}))
+
+// The hook under test now composes useNativeChatStartupNotice internally (folded in to keep
+// the call site in NativeChatView.tsx to one hook instead of two — see the file's own
+// header comment). Its own poll/latch/phase-detection behavior is covered by
+// use-native-chat-startup-notice.test.ts; here it's mocked, driven by the `notice` prop
+// each render passes, so these tests stay focused on the restart-authorization decision.
+vi.mock('./use-native-chat-startup-notice', () => ({
+  useNativeChatStartupNotice: () => mocks.useNativeChatStartupNotice()
+}))
+
+import { useNativeChatStartupRestart } from './use-native-chat-startup-restart'
+
+const PTY_ID = 'pty-1'
+
+type Props = { ptyId: string; notice: NativeChatStartupNotice | null }
+
+function updatePromptNotice(options: NativeChatStartupNotice['options']): NativeChatStartupNotice {
+  return {
+    phase: 'prompt',
+    reason: 'codex-update-prompt',
+    title: 'Codex has an update',
+    body: ['Update available! 0.145.0 -> 0.146.0'],
+    options
+  }
+}
+
+const RESTART_REQUIRED: NativeChatStartupNotice = {
+  phase: 'restart-required',
+  reason: null,
+  title: 'Update complete — restart required',
+  body: ['Update ran successfully! Please restart Codex.'],
+  options: []
+}
+
+const UPDATE_FAILED: NativeChatStartupNotice = {
+  phase: 'update-failed',
+  reason: null,
+  title: 'Codex update did not finish',
+  body: ['npm ERR!'],
+  options: []
+}
+
+describe('useNativeChatStartupRestart', () => {
+  let sendRaw: (raw: string) => void
+  let onHold: (ptyId: string, holdMs: number) => void
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    sendRaw = vi.fn<(raw: string) => void>()
+    onHold = vi.fn<(ptyId: string, holdMs: number) => void>()
+  })
+
+  function renderRestart(initialProps: Props) {
+    return renderHook(
+      (props: Props) => {
+        mocks.useNativeChatStartupNotice.mockReturnValue(props.notice)
+        return useNativeChatStartupRestart({
+          paneKey: 'tab-1:leaf-1',
+          targetPtyId: props.ptyId,
+          readTerminalScreen: () => null,
+          isVisible: true,
+          messageCount: 0,
+          onHoldChatForAgentRestart: onHold,
+          sendRaw
+        })
+      },
+      { initialProps }
+    )
+  }
+
+  it('forwards an unrelated choice without authorizing anything', () => {
+    const notice = updatePromptNotice([{ label: 'Trust', send: 't' }])
+    const { result } = renderRestart({ ptyId: PTY_ID, notice })
+    result.current.onChoose('t')
+    expect(sendRaw).toHaveBeenCalledWith('t')
+    expect(onHold).not.toHaveBeenCalled()
+  })
+
+  it('does not authorize on Skip, so a later restart-required stays manual', () => {
+    const notice = updatePromptNotice([
+      { label: 'Update now', send: '1' },
+      { label: 'Skip', send: '2' }
+    ])
+    const { result, rerender } = renderRestart({ ptyId: PTY_ID, notice })
+    result.current.onChoose('2')
+    expect(onHold).not.toHaveBeenCalled()
+
+    rerender({ ptyId: PTY_ID, notice: RESTART_REQUIRED })
+    expect(mocks.queueCodexPaneRestarts).not.toHaveBeenCalled()
+  })
+
+  it('authorizes on "Update now", then auto-restarts and holds chat once restart-required is observed', () => {
+    const notice = updatePromptNotice([
+      { label: 'Update now', send: '1' },
+      { label: 'Skip', send: '2' }
+    ])
+    const { result, rerender } = renderRestart({ ptyId: PTY_ID, notice })
+    result.current.onChoose('1')
+    expect(sendRaw).toHaveBeenCalledWith('1')
+    expect(onHold).toHaveBeenCalledWith(PTY_ID, expect.any(Number))
+
+    rerender({ ptyId: PTY_ID, notice: RESTART_REQUIRED })
+    expect(mocks.queueCodexPaneRestarts).toHaveBeenCalledWith([PTY_ID])
+    expect(result.current.notice).toMatchObject({
+      phase: 'restarting',
+      body: RESTART_REQUIRED.body
+    })
+    expect(result.current.onRestart).toBeUndefined()
+  })
+
+  it('never authorizes on codex-model-migration-prompt even if a label contains "update"', () => {
+    const migrationNotice: NativeChatStartupNotice = {
+      phase: 'prompt',
+      reason: 'codex-model-migration-prompt',
+      title: 'Codex has a new default model',
+      body: ['Codex just got an upgrade.'],
+      options: [{ label: 'Update to gpt-5.1-codex-max', send: '\r' }]
+    }
+    const { result, rerender } = renderRestart({ ptyId: PTY_ID, notice: migrationNotice })
+    result.current.onChoose('\r')
+    expect(onHold).not.toHaveBeenCalled()
+
+    rerender({ ptyId: PTY_ID, notice: RESTART_REQUIRED })
+    expect(mocks.queueCodexPaneRestarts).not.toHaveBeenCalled()
+    expect(result.current.onRestart).toBeInstanceOf(Function)
+  })
+
+  it('offers a manual restart for restart-required with no prior authorization, and queues + holds on click', () => {
+    const { result } = renderRestart({ ptyId: PTY_ID, notice: RESTART_REQUIRED })
+    expect(result.current.notice).toBe(RESTART_REQUIRED)
+    expect(mocks.queueCodexPaneRestarts).not.toHaveBeenCalled()
+    result.current.onRestart?.()
+    expect(mocks.queueCodexPaneRestarts).toHaveBeenCalledWith([PTY_ID])
+    expect(onHold).toHaveBeenCalledWith(PTY_ID, expect.any(Number))
+  })
+
+  it('offers a manual restart for update-failed and never auto-restarts it', () => {
+    const notice = updatePromptNotice([{ label: 'Update now', send: '1' }])
+    const { result, rerender } = renderRestart({ ptyId: PTY_ID, notice })
+    result.current.onChoose('1') // authorize
+    rerender({ ptyId: PTY_ID, notice: UPDATE_FAILED })
+    expect(mocks.queueCodexPaneRestarts).not.toHaveBeenCalled()
+    expect(result.current.onRestart).toBeInstanceOf(Function)
+  })
+
+  it('does not re-queue a restart already queued for the same pty', () => {
+    const { result, rerender } = renderRestart({ ptyId: PTY_ID, notice: RESTART_REQUIRED })
+    result.current.onRestart?.()
+    result.current.onRestart?.()
+    rerender({ ptyId: PTY_ID, notice: RESTART_REQUIRED })
+    expect(mocks.queueCodexPaneRestarts).toHaveBeenCalledTimes(1)
+  })
+
+  it('drops a stale authorization when the ptyId changes (relaunch/rebind)', () => {
+    const notice = updatePromptNotice([{ label: 'Update now', send: '1' }])
+    const { result, rerender } = renderRestart({ ptyId: PTY_ID, notice })
+    result.current.onChoose('1')
+    rerender({ ptyId: 'pty-2', notice: RESTART_REQUIRED })
+    expect(mocks.queueCodexPaneRestarts).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/native-chat/use-native-chat-startup-restart.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-startup-restart.ts
@@ -1,0 +1,141 @@
+import { useCallback, useEffect, useRef } from 'react'
+import { useAppStore } from '../../store'
+import {
+  nativeChatStartupPhaseNoticeWithBody,
+  type NativeChatStartupNotice
+} from '../../../../shared/native-chat-startup-notice'
+import { useNativeChatStartupNotice } from './use-native-chat-startup-notice'
+
+// Why this specific reason only: `codex-update-prompt` is the CLI's own "Update available!"
+// menu, the one dialog that actually runs `npm install -g @openai/codex` and needs a
+// restart. `codex-model-migration-prompt` ("Codex just got an upgrade…") looks similar but
+// is a one-time default-model notice — dismissing it never spawns an update or exits Codex,
+// so it must never arm a restart hold.
+const UPDATE_PROMPT_REASON = 'codex-update-prompt'
+// Case-insensitive substring match against the real "1. Update now" / "2. Skip" menu — the
+// only signal available, since the option's PTY-send digit carries no semantic meaning.
+const UPDATE_ACCEPT_LABEL_RE = /update/i
+
+// Generous on purpose: npm installs can be slow (disk contention, a cold registry cache,
+// the Windows EPERM/unlink-retry path seen in the reported capture), and the hold only
+// needs to outlive the single window between "user clicked Update now" and "the respawned
+// Codex reaches its own ready prompt, resetting the watch." A hold that's too short just
+// reproduces the original bug (kicked out of chat mid-restart); too long costs nothing,
+// since it is scoped to one ptyId and is never consulted again once that pty is gone.
+const RESTART_HOLD_MS = 5 * 60 * 1000
+
+export type NativeChatStartupRestart = {
+  /** The notice to render — same as the input while nothing is auto-restarting, swapped to
+   *  a `restarting` phase (carrying the same log tail) once an authorized restart queues. */
+  notice: NativeChatStartupNotice | null
+  /** Wraps the raw PTY send: recognizes "the update was just authorized" before forwarding. */
+  onChoose: (send: string) => void
+  /** Present only on `restart-required` / `update-failed` when nothing is already queued —
+   *  lets the user restart an update they ran by hand in the raw terminal. */
+  onRestart: (() => void) | undefined
+}
+
+/**
+ * Owns the whole startup-takeover surface for one chat pane: watches the terminal via
+ * `useNativeChatStartupNotice`, then layers the one stateful decision notice-reading alone
+ * cannot make on top — was this specific update authorized by the user through this card?
+ * On `restart-required`, if it was, the restart is queued automatically through the
+ * existing Codex account-switch restart machinery (`queueCodexPaneRestarts` →
+ * `TerminalPane.tsx`'s `handleRestartCodexPane`, unchanged) and the tab's chat mode is held
+ * across the agent's exit. An update run by hand in the raw terminal is left alone — only a
+ * manual "Restart Codex" button is offered. The single hook call keeps the composition
+ * detail out of the view component; see use-native-chat-startup-notice.ts for the reader.
+ */
+export function useNativeChatStartupRestart(args: {
+  paneKey: string
+  targetPtyId: string | null
+  readTerminalScreen?: () => string | null
+  isVisible: boolean
+  messageCount: number
+  onHoldChatForAgentRestart?: (ptyId: string, holdMs: number) => void
+  sendRaw: (raw: string) => void
+}): NativeChatStartupRestart {
+  const { targetPtyId, onHoldChatForAgentRestart, sendRaw } = args
+  const startupNotice = useNativeChatStartupNotice({
+    paneKey: args.paneKey,
+    targetPtyId,
+    readTerminalScreen: args.readTerminalScreen,
+    isVisible: args.isVisible,
+    messageCount: args.messageCount
+  })
+  // The ptyId this hook has seen the user authorize an update for, so a later
+  // restart-required observation on the SAME pty knows to auto-restart. A pty swap
+  // (relaunch, split rebind) invalidates it — never let an old authorization silently
+  // auto-restart an unrelated later session. A ref write during render (not an effect) is
+  // fine here: it is idempotent under StrictMode's double-render and nothing reads it until
+  // after this render commits.
+  const authorizedPtyIdRef = useRef<string | null>(null)
+  if (targetPtyId !== authorizedPtyIdRef.current) {
+    authorizedPtyIdRef.current = null
+  }
+  // Guards the actual restart-queueing side effect against firing twice for the same ptyId
+  // (repeated restart-required polls, or an auto-restart racing a manual click).
+  const queuedPtyIdRef = useRef<string | null>(null)
+
+  const queueRestartWithHold = useCallback(
+    (ptyId: string) => {
+      queuedPtyIdRef.current = ptyId
+      onHoldChatForAgentRestart?.(ptyId, RESTART_HOLD_MS)
+      useAppStore.getState().queueCodexPaneRestarts([ptyId])
+    },
+    [onHoldChatForAgentRestart]
+  )
+
+  const onChoose = useCallback(
+    (send: string) => {
+      if (
+        targetPtyId &&
+        startupNotice?.phase === 'prompt' &&
+        startupNotice.reason === UPDATE_PROMPT_REASON
+      ) {
+        const chosen = startupNotice.options.find((option) => option.send === send)
+        if (chosen && UPDATE_ACCEPT_LABEL_RE.test(chosen.label)) {
+          authorizedPtyIdRef.current = targetPtyId
+          onHoldChatForAgentRestart?.(targetPtyId, RESTART_HOLD_MS)
+        }
+      }
+      sendRaw(send)
+    },
+    [targetPtyId, startupNotice, onHoldChatForAgentRestart, sendRaw]
+  )
+
+  const onManualRestart = useCallback(() => {
+    if (targetPtyId && queuedPtyIdRef.current !== targetPtyId) {
+      queueRestartWithHold(targetPtyId)
+    }
+  }, [targetPtyId, queueRestartWithHold])
+
+  const authorized = targetPtyId !== null && authorizedPtyIdRef.current === targetPtyId
+  const shouldAutoRestart = Boolean(
+    targetPtyId && startupNotice?.phase === 'restart-required' && authorized
+  )
+
+  // The actual store write is a side effect and belongs in an effect, not render — the
+  // `notice` override below still switches to `restarting` in this same render, so the UI
+  // is instant even though queueing itself lands a tick later.
+  useEffect(() => {
+    if (shouldAutoRestart && targetPtyId && queuedPtyIdRef.current !== targetPtyId) {
+      queueRestartWithHold(targetPtyId)
+    }
+  }, [shouldAutoRestart, targetPtyId, queueRestartWithHold])
+
+  if (shouldAutoRestart && startupNotice) {
+    return {
+      notice: nativeChatStartupPhaseNoticeWithBody('restarting', startupNotice.body),
+      onChoose,
+      onRestart: undefined
+    }
+  }
+  const showManualRestart =
+    startupNotice?.phase === 'restart-required' || startupNotice?.phase === 'update-failed'
+  return {
+    notice: startupNotice,
+    onChoose,
+    onRestart: showManualRestart ? onManualRestart : undefined
+  }
+}

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -630,6 +630,15 @@ function TerminalPane(
     },
     [chatLeafId, setTabViewMode, unifiedTabId]
   )
+  // Why a ref and not store state: the hold is scoped to this one pane's lifetime and is
+  // consulted exactly once, synchronously, right when handleConfirmedAgentExit runs — no
+  // other component needs to read or react to it, so it does not belong in shared state.
+  // Keyed by ptyId (not just a boolean) so a hold armed for an earlier pty on this same
+  // leaf can never suppress a later, unrelated exit.
+  const chatRestartHoldRef = useRef<{ ptyId: string; expiresAt: number } | null>(null)
+  const holdChatForAgentRestart = useCallback((ptyId: string, holdMs: number): void => {
+    chatRestartHoldRef.current = { ptyId, expiresAt: Date.now() + holdMs }
+  }, [])
   const handleConfirmedAgentExit = useCallback(
     (leafId: string): void => {
       if (leafId !== chatLeafId) {
@@ -637,6 +646,13 @@ function TerminalPane(
       }
       const panes = managerRef.current?.getPanes() ?? []
       const activeLeafId = managerRef.current?.getActivePane()?.leafId ?? null
+      const exitingPane = panes.find((pane) => pane.leafId === chatLeafId)
+      const exitingPtyId = exitingPane
+        ? (paneTransportsRef.current.get(exitingPane.id)?.getPtyId() ?? null)
+        : null
+      const hold = chatRestartHoldRef.current
+      const holdChatForAgentRestartActive =
+        hold !== null && hold.ptyId === exitingPtyId && hold.expiresAt > Date.now()
       applyNativeChatLeafRoute(
         resolveNativeChatLeafRoute({
           isChatViewMode,
@@ -644,7 +660,8 @@ function TerminalPane(
           activeLeafId,
           chatLeafStillMounted: panes.some((pane) => pane.leafId === chatLeafId),
           activeLeafIsEligible: isChatEligibleForLeaf(activeLeafId),
-          chatLeafHasConfirmedAgentExit: true
+          chatLeafHasConfirmedAgentExit: true,
+          holdChatForAgentRestart: holdChatForAgentRestartActive
         })
       )
     },
@@ -3090,6 +3107,7 @@ function TerminalPane(
                 resolvedAgent={chatPaneResolvedAgent}
                 onSwitchToTerminal={switchNativeChatToTerminal}
                 readTerminalScreen={readNativeChatTerminalScreen}
+                onHoldChatForAgentRestart={holdChatForAgentRestart}
                 contextMenuActions={{
                   onSplitRight: () => contextMenu.runForPane(chatPane.id, contextMenu.onSplitRight),
                   onSplitDown: () => contextMenu.runForPane(chatPane.id, contextMenu.onSplitDown),

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -15903,6 +15903,7 @@
         "send": "Send",
         "noPty": "No live terminal — toggle back to reconnect.",
         "locked": "Input is held by another device.",
+        "agentGone": "The agent isn't running — toggle back to the terminal.",
         "placeholder": "Send a message…",
         "mentionHint": "Referencing file:",
         "attach": "Attach file",
@@ -15988,6 +15989,10 @@
         "empty": {
           "title": "Start a chat with {{value0}}",
           "subtitle": "Ask {{value0}} to inspect code, explain output, or make a change."
+        },
+        "startingAgent": {
+          "title": "Starting {{value0}}…",
+          "subtitle": "{{value0}} needs your attention before the conversation can start."
         }
       },
       "stop": "Stop the agent",
@@ -16012,6 +16017,23 @@
         "title": "Allow {{value0}}?",
         "allow": "Allow",
         "deny": "Deny"
+      },
+      "startupNotice": {
+        "restart": "Restart Codex",
+        "openTerminal": "Open terminal",
+        "title": {
+          "codexUpdatePrompt": "Codex has an update",
+          "codexTrustWorkspace": "Codex wants to trust this workspace",
+          "codexCwdPrompt": "Codex is asking about the working directory",
+          "codexModelMigrationPrompt": "Codex has a new default model",
+          "codexHooksReviewPrompt": "Codex hooks need review",
+          "codexInteractivePrompt": "Codex needs your input",
+          "agentApprovalPrompt": "Codex wants to run a command",
+          "running": "Updating Codex…",
+          "restartRequired": "Update complete — restart required",
+          "updateFailed": "Codex update did not finish",
+          "restarting": "Restarting Codex…"
+        }
       },
       "launchPromptNotDelivered": "Not delivered — check the terminal"
     },

--- a/src/shared/agent-startup-prompt-detection.test.ts
+++ b/src/shared/agent-startup-prompt-detection.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'vitest'
+import {
+  detectTerminalWaitBlockedReason,
+  findActionableTerminalWaitBlockedSignal,
+  isKnownReadyPromptPreview
+} from './agent-startup-prompt-detection'
+
+// Fixtures ported verbatim from src/main/runtime/orca-runtime.test.ts (the detector's
+// original home) so this module and the OrcaRuntimeService integration tests exercise the
+// exact same banner text — see the "Step 1" extraction in
+// docs/plans/... (agent-startup-prompt-detection). Real captures from the Codex update flow
+// (from the user-reported PowerShell/Windows update session) are marked below.
+
+const CODEX_READY_HEADER = [
+  ' >_ OpenAI Codex (v0.132.0)\n',
+  ' model:       gpt-5.5 high   /model to change\n',
+  ' directory:   ~/orca/workspaces/orca/cli-debug\n'
+].join('')
+
+function cursorReadyScreen(): string {
+  return [
+    'Cursor Agent',
+    'v2026.07.09-a3815c0',
+    'Tip: Use /plan to plan execution and reach the right outcome faster.',
+    '→ Plan, search, build anything',
+    'Composer 2.5 Fast                                          Run Everything',
+    '~/Documents/projects/AutoGenie · main'
+  ].join('\n')
+}
+
+function cursorBusyScreen(): string {
+  return [
+    'Cursor Agent',
+    'v2026.07.09-a3815c0',
+    '⠰⠳ Thinking  28.61k tokens',
+    '→ Plan, search, build anything',
+    'Composer 2.5 Fast                                          Run Everything',
+    '~/Documents/projects/AutoGenie · main'
+  ].join('\n')
+}
+
+describe('detectTerminalWaitBlockedReason', () => {
+  it('detects a Codex update prompt', () => {
+    const preview = [
+      'Update available! 0.131.0 -> 0.132.0\n',
+      '1. Update now\n',
+      '2. Skip\n',
+      'Press enter to continue\n'
+    ].join('')
+    expect(detectTerminalWaitBlockedReason(preview)).toBe('codex-update-prompt')
+  })
+
+  it('detects a Codex workspace trust prompt', () => {
+    const preview = 'Do you trust this workspace directory?\n1. Yes\n2. No\n'
+    expect(detectTerminalWaitBlockedReason(preview)).toBe('codex-trust-workspace')
+  })
+
+  it('detects a Codex cwd selection prompt', () => {
+    const preview = [
+      'Choose working directory to resume this session\n',
+      '  Session = latest cwd recorded in the resumed session\n',
+      '  Current = your current working directory\n',
+      '  Press enter to continue\n'
+    ].join('')
+    expect(detectTerminalWaitBlockedReason(preview)).toBe('codex-cwd-prompt')
+  })
+
+  it('detects a Codex model migration prompt', () => {
+    const preview = [
+      'Codex just got an upgrade. Introducing gpt-5.1-codex-max.\n',
+      'We recommend switching from gpt-5-codex to gpt-5.1-codex-max.\n',
+      'Press enter to continue\n'
+    ].join('')
+    expect(detectTerminalWaitBlockedReason(preview)).toBe('codex-model-migration-prompt')
+  })
+
+  it('detects a Codex hooks-review prompt', () => {
+    const preview = [
+      'Hooks need review\n',
+      '2 hooks are new or changed.\n',
+      '1. Review hooks\n',
+      '2. Trust all and continue\n',
+      'Press enter to confirm or esc to go back\n'
+    ].join('')
+    expect(detectTerminalWaitBlockedReason(preview)).toBe('codex-hooks-review-prompt')
+  })
+
+  it('returns null for a ready Codex header with no blocked signal', () => {
+    expect(detectTerminalWaitBlockedReason(CODEX_READY_HEADER)).toBeNull()
+  })
+
+  // Real capture: the update flow reported over screenshot. Codex's update check runs
+  // before it ever draws the "OpenAI Codex / Model: / Directory:" ready header, so the
+  // header never appears in the same viewport as the dialog — findDismissedStartupModalIndex
+  // must not suppress this signal. See the plan's Step 0 analysis.
+  it('detects the real update-prompt banner with no ready header present (#Codex-restart-capture)', () => {
+    const preview = [
+      'Update available! 0.145.0 -> 0.146.0\n',
+      '1. Update now\n',
+      '2. Skip\n',
+      'Press enter to continue\n'
+    ].join('')
+    expect(detectTerminalWaitBlockedReason(preview)).toBe('codex-update-prompt')
+    expect(isKnownReadyPromptPreview(preview)).toBe(false)
+  })
+})
+
+describe('findActionableTerminalWaitBlockedSignal — dismissed-modal downgrade', () => {
+  it('picks the later blocked reason when a ready header sits between two prompts', () => {
+    const preview = [
+      'Update available! 0.131.0 -> 0.132.0\n',
+      'Press enter to continue\n',
+      CODEX_READY_HEADER,
+      'Hooks need review\n',
+      'Press enter to confirm\n'
+    ].join('')
+    expect(findActionableTerminalWaitBlockedSignal(preview.toLowerCase())?.reason).toBe(
+      'codex-hooks-review-prompt'
+    )
+  })
+
+  it('suppresses a stale prompt once a ready header follows it with nothing after', () => {
+    const preview = [
+      'Update available! 0.131.0 -> 0.132.0\n',
+      'Press enter to continue\n',
+      CODEX_READY_HEADER
+    ].join('')
+    expect(findActionableTerminalWaitBlockedSignal(preview.toLowerCase())).toBeNull()
+    expect(isKnownReadyPromptPreview(preview)).toBe(true)
+  })
+})
+
+describe('cursor approval + trust dismissal', () => {
+  it('resolves an idle Cursor lane past its dismissed trust dialog (#8210)', () => {
+    const preview = [
+      'Cursor Agent\n',
+      '⚠ Workspace Trust Required\n',
+      'Do you trust the contents of this directory?\n',
+      '  ▶ [a] Trust this workspace\n',
+      '    [q] Quit\n',
+      cursorReadyScreen()
+    ].join('')
+    expect(findActionableTerminalWaitBlockedSignal(preview.toLowerCase())).toBeNull()
+    expect(isKnownReadyPromptPreview(preview)).toBe(true)
+  })
+
+  it('reports neither blocked nor ready for a busy Cursor lane past its dismissed trust dialog (#8210)', () => {
+    // Why not a specific blockedReason: findCursorActivePromptIndex matches on the `→`
+    // prompt glyph regardless of busy/idle, so the dismissed-modal check suppresses the
+    // stale trust signal even while busy — the lane is honestly neither blocked nor idle,
+    // matching the real runtime test's `.rejects.toThrow('timeout')` expectation.
+    const preview = [
+      'Cursor Agent\n',
+      '⚠ Workspace Trust Required\n',
+      'Do you trust the contents of this directory?\n',
+      '  ▶ [a] Trust this workspace\n',
+      '    [q] Quit\n',
+      cursorBusyScreen()
+    ].join('')
+    expect(findActionableTerminalWaitBlockedSignal(preview.toLowerCase())).toBeNull()
+    expect(isKnownReadyPromptPreview(preview)).toBe(false)
+  })
+
+  it('detects a live cursor-agent shell approval menu', () => {
+    const preview = [
+      'cursor-agent wants to run:',
+      '  rm -rf build/',
+      '',
+      'Run this command?',
+      '  Run (once) (enter)',
+      '  Add to allowlist? (a)',
+      '  Run everything (r)',
+      '  Skip & tell the agent (esc)'
+    ].join('\n')
+    expect(findActionableTerminalWaitBlockedSignal(preview.toLowerCase())?.reason).toBe(
+      'agent-approval-prompt'
+    )
+  })
+
+  it('does not match narration of an approval choice, only the live menu', () => {
+    const preview = [
+      "I'll suggest Run Everything (as before) next time.",
+      'Continuing with the plan.'
+    ].join('\n')
+    expect(findActionableTerminalWaitBlockedSignal(preview.toLowerCase())).toBeNull()
+  })
+})

--- a/src/shared/agent-startup-prompt-detection.ts
+++ b/src/shared/agent-startup-prompt-detection.ts
@@ -1,0 +1,315 @@
+// Detects a TUI agent's blocking startup dialogs (self-update prompt, trust/workspace
+// dialog, hooks-review, cwd picker, permission/approval menus) from a terminal tail
+// preview. Extracted from src/main/runtime/orca-runtime.ts so the renderer (native chat)
+// can reach the same matchers the runtime's `terminal.wait` already uses — previously this
+// lived only in the main process and the chat view had no way to see these dialogs at all.
+//
+// Pure string matching, no side effects, no runtime/PTY dependencies. The `codex-` prefixes
+// on several reason codes are historical: these startup prompts are matched by shape, not by
+// vendor, so they also fire for Claude and Cursor. Renaming them would break paired hosts —
+// see the comment on RuntimeTerminalWaitBlockedReason in ./runtime-types.
+
+import type { RuntimeTerminalWaitBlockedReason } from './runtime-types'
+
+// Why: chunks that could complete an actionable prompt bypass the throttle so blocked stamps
+// stay immediate; scanned over the new chunk + short carry, never the whole window.
+export const WAIT_BLOCKED_KEYWORD_PATTERN =
+  /press enter|press t to trust|do you trust|trust this|trusted workspace|permission required|requires permission|allow once|allow always|update available|choose working directory|codex just got an upgrade|hooks need review/
+export const WAIT_BLOCKED_KEYWORD_CARRY_CHARS = 31
+
+export function isKnownReadyPromptPreview(preview: string): boolean {
+  const normalized = preview.toLowerCase()
+  const readyIndex = findKnownReadyPromptIndex(normalized)
+  if (readyIndex === null) {
+    return false
+  }
+  const blockedSignal = findTerminalWaitBlockedSignal(normalized)
+  if (blockedSignal !== null && blockedSignal.index > readyIndex) {
+    return false
+  }
+  return true
+}
+
+export function detectTerminalWaitBlockedReason(
+  preview: string
+): RuntimeTerminalWaitBlockedReason | null {
+  const normalized = preview.toLowerCase()
+  return findActionableTerminalWaitBlockedSignal(normalized)?.reason ?? null
+}
+
+export function findActionableTerminalWaitBlockedSignal(
+  normalized: string
+): { reason: RuntimeTerminalWaitBlockedReason; index: number } | null {
+  const blockedSignal = findTerminalWaitBlockedSignal(normalized)
+  if (blockedSignal === null) {
+    return null
+  }
+  const dismissedModalIndex = findDismissedStartupModalIndex(normalized)
+  // Why: a live prompt after the modal means it was dismissed → signal no longer actionable, even mid-run (Cursor never reports idle via OSC title).
+  return dismissedModalIndex !== null && dismissedModalIndex > blockedSignal.index
+    ? null
+    : blockedSignal
+}
+
+// Why: a live prompt (idle OR busy) proves the startup modal was dismissed, so a mid-run Cursor lane stops reporting stale trust hits.
+function findDismissedStartupModalIndex(normalized: string): number | null {
+  const indexes = [
+    findCodexReadyPromptIndex(normalized),
+    findAntigravityReadyPromptIndex(normalized),
+    findCursorActivePromptIndex(normalized)
+  ].filter((index): index is number => index !== null)
+  return indexes.length > 0 ? Math.max(...indexes) : null
+}
+
+function findKnownReadyPromptIndex(normalized: string): number | null {
+  const indexes = [
+    findCodexReadyPromptIndex(normalized),
+    findAntigravityReadyPromptIndex(normalized),
+    findCursorReadyPromptIndex(normalized)
+  ].filter((index): index is number => index !== null)
+  return indexes.length > 0 ? Math.max(...indexes) : null
+}
+
+// Why: match the banner's last occurrence to skip the trust dialog's own "Cursor Agent" text; "→" is cursor-agent's persistent input prompt.
+function findCursorActivePromptIndex(normalized: string): number | null {
+  const headerIndex = normalized.lastIndexOf('cursor agent')
+  if (headerIndex === -1) {
+    return null
+  }
+  return normalized.includes('→', headerIndex) ? headerIndex : null
+}
+
+// Why: cursor-agent emits no idle OSC title; infer idle from the tail (braille spinner = busy, its absence = idle).
+const CURSOR_BUSY_SPINNER_RE = /[⠁-⣿]/
+
+function findCursorReadyPromptIndex(normalized: string): number | null {
+  const activeIndex = findCursorActivePromptIndex(normalized)
+  if (activeIndex === null) {
+    return null
+  }
+  return CURSOR_BUSY_SPINNER_RE.test(normalized.slice(activeIndex)) ? null : activeIndex
+}
+
+function findCodexReadyPromptIndex(normalized: string): number | null {
+  const headerIndex = normalized.lastIndexOf('openai codex')
+  if (headerIndex === -1) {
+    return null
+  }
+  const readySegment = normalized.slice(headerIndex)
+  // Why: Codex prints permissions only in YOLO mode; the stable ready header is OpenAI Codex + model + directory.
+  return readySegment.includes('model:') && readySegment.includes('directory:') ? headerIndex : null
+}
+
+function findAntigravityReadyPromptIndex(normalized: string): number | null {
+  const headerIndex = normalized.lastIndexOf('antigravity cli')
+  if (headerIndex === -1) {
+    return null
+  }
+  let lineStart = headerIndex
+  let modelIndex: number | null = null
+  let promptIndex: number | null = null
+
+  // Why: ready previews can include echoed paste after the header; scan line bounds directly instead of splitting the whole tail.
+  for (let cursor = headerIndex; cursor <= normalized.length; cursor += 1) {
+    if (cursor < normalized.length && normalized.charCodeAt(cursor) !== 10) {
+      continue
+    }
+    let trimmedStart = lineStart
+    let trimmedEnd = cursor
+    while (trimmedStart < trimmedEnd && isTerminalWaitWhitespace(normalized, trimmedStart)) {
+      trimmedStart += 1
+    }
+    while (trimmedEnd > trimmedStart && isTerminalWaitWhitespace(normalized, trimmedEnd - 1)) {
+      trimmedEnd -= 1
+    }
+    if (lineStart > headerIndex && trimmedStart < trimmedEnd) {
+      if (modelIndex === null && normalized.startsWith('gemini', trimmedStart)) {
+        modelIndex = trimmedStart
+      }
+      if (
+        promptIndex === null &&
+        trimmedEnd - trimmedStart === 1 &&
+        normalized.charCodeAt(trimmedStart) === 62
+      ) {
+        promptIndex = trimmedStart
+      }
+    }
+    lineStart = cursor + 1
+  }
+
+  return modelIndex !== null && promptIndex !== null ? Math.max(modelIndex, promptIndex) : null
+}
+
+function isTerminalWaitWhitespace(value: string, index: number): boolean {
+  const code = value.charCodeAt(index)
+  return code === 32 || (code >= 9 && code <= 13)
+}
+
+export const TERMINAL_WAIT_BLOCKED_SENTINEL_RE =
+  /update available|choose working directory to|codex just got an upgrade|hooks need review|do you trust|trust this|trusted workspace|press enter to (?:confirm|continue|view|insert)|press t to trust|permission required|requires permission|allow once|allow always|run this command\?/i
+
+// Why text at all: cursor-agent's hook set has no approval event and beforeShellExecution
+// fires for auto-allowed commands too, so the menu is the only authority. Match the key-bound
+// choices rather than the prose above them.
+const CURSOR_APPROVAL_CHOICE_MARKERS = [
+  'run (once)',
+  'to allowlist?',
+  'run everything',
+  'skip & tell the agent'
+]
+// Why bounded to the last lines: an answered menu stays in scrollback, and a stale hit fails
+// tui-idle and refuses prompt injection. Only a dialog that still owns the bottom of the
+// screen is live, and confining the whole match to that window also keeps prose above or
+// below — an agent narrating "I'll pick Run Everything" — from anchoring it.
+const CURSOR_APPROVAL_TAIL_LINES = 8
+
+function findCursorApprovalPromptIndex(normalized: string): number | null {
+  const windowStart = startOfLastLines(normalized, CURSOR_APPROVAL_TAIL_LINES)
+  const tail = normalized.slice(windowStart)
+  if (!tail.includes('run this command?')) {
+    return null
+  }
+  const lines = tail.split('\n')
+  while (lines.length > 0 && lines.at(-1)?.trim() === '') {
+    lines.pop()
+  }
+  let matchedLines = 0
+  let lastChoiceLine = -1
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!isCursorApprovalChoiceLine(lines[index])) {
+      continue
+    }
+    matchedLines += 1
+    lastChoiceLine = index
+  }
+  if (matchedLines < 2) {
+    return null
+  }
+  // Why no slack: every capture of a live dialog ends on its last choice, and one line of
+  // tolerance is enough for the agent's own narration of a choice to revive an answered menu.
+  // A redraw caught mid-flight reads as no wait until the next poll, which is the safe way
+  // to be wrong.
+  return lastChoiceLine === lines.length - 1
+    ? windowStart + tail.lastIndexOf('run this command?')
+    : null
+}
+
+// Why the trailing key and not the wording alone: an agent narrating "next time I'll suggest
+// Run Everything" writes the same words as the menu. A selectable row ends in the key that
+// picks it, and prose does not. Spelled as key names rather than a character class, because
+// any lowercase run would readmit "…suggest Run Everything (as before)".
+const CURSOR_APPROVAL_CHOICE_KEY_RE =
+  /\((?:shift\+tab|ctrl\+[a-z]|esc(?: or [a-z])*|tab|enter|return|space|[a-z]|[↵⇧↹⎋⏎]{1,3})\)\s*$/
+
+function isCursorApprovalChoiceLine(line: string): boolean {
+  return (
+    CURSOR_APPROVAL_CHOICE_KEY_RE.test(line) &&
+    CURSOR_APPROVAL_CHOICE_MARKERS.some((marker) => line.includes(marker))
+  )
+}
+
+/** Offset of the first character of the last `count` newline-separated lines. */
+function startOfLastLines(value: string, count: number): number {
+  let cursor = value.length
+  for (let seen = 0; seen < count; seen += 1) {
+    const previous = value.lastIndexOf('\n', cursor - 1)
+    if (previous === -1) {
+      return 0
+    }
+    cursor = previous
+  }
+  return cursor + 1
+}
+
+function findTerminalWaitBlockedSignal(
+  normalized: string
+): { reason: RuntimeTerminalWaitBlockedReason; index: number } | null {
+  // Why: one combined negative scan over the up-to-256 KiB tail avoids a dozen full-tail searches when no prompt can match.
+  if (!TERMINAL_WAIT_BLOCKED_SENTINEL_RE.test(normalized)) {
+    return null
+  }
+  const candidates: { reason: RuntimeTerminalWaitBlockedReason; index: number }[] = []
+  const updateIndex = normalized.lastIndexOf('update available')
+  if (updateIndex !== -1 && normalized.includes('press enter to continue', updateIndex)) {
+    candidates.push({ reason: 'codex-update-prompt', index: updateIndex })
+  }
+  const cwdIndex = normalized.lastIndexOf('choose working directory to')
+  if (cwdIndex !== -1 && normalized.includes('press enter to continue', cwdIndex)) {
+    candidates.push({ reason: 'codex-cwd-prompt', index: cwdIndex })
+  }
+  const modelMigrationIndex = normalized.lastIndexOf('codex just got an upgrade')
+  if (
+    modelMigrationIndex !== -1 &&
+    normalized.includes('press enter to continue', modelMigrationIndex)
+  ) {
+    candidates.push({ reason: 'codex-model-migration-prompt', index: modelMigrationIndex })
+  }
+  const hooksIndex = normalized.lastIndexOf('hooks need review')
+  if (hooksIndex !== -1 && normalized.includes('press enter to confirm', hooksIndex)) {
+    candidates.push({ reason: 'codex-hooks-review-prompt', index: hooksIndex })
+  }
+  const trustIndex = Math.max(
+    normalized.lastIndexOf('do you trust'),
+    normalized.lastIndexOf('trust this'),
+    normalized.lastIndexOf('trusted workspace')
+  )
+  const trustSegment = trustIndex === -1 ? '' : normalized.slice(trustIndex)
+  if (
+    trustIndex !== -1 &&
+    (trustSegment.includes('workspace') ||
+      trustSegment.includes('folder') ||
+      trustSegment.includes('directory') ||
+      trustSegment.includes('repo'))
+  ) {
+    candidates.push({ reason: 'codex-trust-workspace', index: trustIndex })
+  }
+  const interactivePromptIndex = Math.max(
+    normalized.lastIndexOf('press enter to confirm'),
+    normalized.lastIndexOf('press enter to continue'),
+    normalized.lastIndexOf('press enter to view'),
+    normalized.lastIndexOf('press enter to insert'),
+    normalized.lastIndexOf('press t to trust')
+  )
+  const interactivePromptContext =
+    interactivePromptIndex === -1
+      ? ''
+      : normalized.slice(Math.max(0, interactivePromptIndex - 600), interactivePromptIndex + 200)
+  const hasCodexInteractiveContext =
+    interactivePromptContext.includes('codex') ||
+    interactivePromptContext.includes('permission') ||
+    interactivePromptContext.includes('sandbox') ||
+    interactivePromptContext.includes('trust') ||
+    interactivePromptContext.includes('hook')
+  if (interactivePromptIndex !== -1 && hasCodexInteractiveContext) {
+    const contextStart = Math.max(0, interactivePromptIndex - 600)
+    const hasSpecificPromptInContext = candidates.some(
+      (candidate) => candidate.index >= contextStart && candidate.index <= interactivePromptIndex
+    )
+    if (!hasSpecificPromptInContext) {
+      candidates.push({ reason: 'codex-interactive-prompt', index: interactivePromptIndex })
+    }
+  }
+  const cursorApprovalIndex = findCursorApprovalPromptIndex(normalized)
+  if (cursorApprovalIndex !== null) {
+    candidates.push({ reason: 'agent-approval-prompt', index: cursorApprovalIndex })
+  }
+  const permissionPromptIndex = Math.max(
+    normalized.lastIndexOf('permission required'),
+    normalized.lastIndexOf('requires permission')
+  )
+  if (permissionPromptIndex !== -1) {
+    const permissionSegment = normalized.slice(permissionPromptIndex, permissionPromptIndex + 1_500)
+    const decisionCount = ['allow once', 'allow always', 'reject', 'deny'].filter((choice) =>
+      permissionSegment.includes(choice)
+    ).length
+    if (decisionCount >= 2) {
+      // Why: preserve the existing remote receipt value for mixed-version clients.
+      candidates.push({ reason: 'codex-interactive-prompt', index: permissionPromptIndex })
+    }
+  }
+  return candidates.length > 0
+    ? candidates.reduce((latest, candidate) =>
+        candidate.index > latest.index ? candidate : latest
+      )
+    : null
+}

--- a/src/shared/native-chat-empty-state.ts
+++ b/src/shared/native-chat-empty-state.ts
@@ -22,6 +22,14 @@ export const NATIVE_CHAT_EMPTY_STATE_COPY = {
   notAgent: {
     title: 'No conversation here',
     subtitle: 'This terminal is not running a recognized coding agent.'
+  },
+  // Why a distinct kind from 'empty': a just-launched agent blocked on its own startup
+  // dialog (update prompt, trust dialog, …) has no conversation yet either, but "Start a
+  // chat" reads as an invitation to type — which the startup notice card intercepts, since
+  // the composer is hidden until the dialog clears. See NativeChatStartupNoticeCard.
+  startingAgent: {
+    title: 'Starting {{value0}}…',
+    subtitle: '{{value0}} needs your attention before the conversation can start.'
   }
 } as const satisfies Record<string, NativeChatEmptyStateCopy>
 

--- a/src/shared/native-chat-startup-notice.test.ts
+++ b/src/shared/native-chat-startup-notice.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildNativeChatStartupPhaseNotice,
+  isAgentStartupSettled,
+  readNativeChatStartupNotice,
+  readTerminalActivityTail
+} from './native-chat-startup-notice'
+
+const CODEX_READY_HEADER = [
+  ' >_ OpenAI Codex (v0.132.0)\n',
+  ' model:       gpt-5.5 high   /model to change\n',
+  ' directory:   ~/orca/workspaces/orca/cli-debug\n'
+].join('')
+
+// Real capture, verbatim (line-wrapped only for readability here), from the reported
+// Windows PTY update flow: authorize → npm install runs → restart required → shell prompt.
+const UPDATE_RUNNING_CAPTURE = [
+  'Updating Codex via `npm install -g @openai/codex`...',
+  'npm warn cleanup Failed to remove some directories [',
+  "npm warn cleanup   'C:\\\\Users\\\\visuz\\\\AppData\\\\Local\\\\nvm\\\\v24.8.0\\\\node_modules\\\\@openai\\\\.codex-Lrx46Vb0',",
+  '',
+  'added 5 packages, and changed 2 packages in 30s'
+].join('\n')
+
+const RESTART_REQUIRED_CAPTURE = [
+  UPDATE_RUNNING_CAPTURE,
+  '',
+  '🎉 Update ran successfully! Please restart Codex.',
+  'PS C:\\Users\\visuz\\orca\\workspaces\\productfactory-monorepo\\comber>'
+].join('\n')
+
+describe('readNativeChatStartupNotice', () => {
+  it('returns a prompt notice with parsed numbered options for the update dialog', () => {
+    const screen = [
+      'Update available! 0.145.0 -> 0.146.0',
+      '1. Update now',
+      '2. Skip',
+      'Press enter to continue'
+    ].join('\n')
+    const notice = readNativeChatStartupNotice(screen)
+    expect(notice?.phase).toBe('prompt')
+    expect(notice?.reason).toBe('codex-update-prompt')
+    expect(notice?.title).toBe('Codex has an update')
+    expect(notice?.options).toEqual([
+      { label: 'Update now', send: '1' },
+      { label: 'Skip', send: '2' }
+    ])
+  })
+
+  it('falls back to a single Continue option when the dialog has no numbered menu', () => {
+    const screen = [
+      'Choose working directory to resume this session',
+      '  Session = latest cwd recorded in the resumed session',
+      '  Press enter to continue'
+    ].join('\n')
+    const notice = readNativeChatStartupNotice(screen)
+    expect(notice?.reason).toBe('codex-cwd-prompt')
+    expect(notice?.options).toEqual([{ label: 'Continue', send: '\r' }])
+  })
+
+  it('falls back to a Trust option for a bare press-t-to-trust dialog', () => {
+    const screen = ['Do you trust this workspace directory?', 'Press t to trust'].join('\n')
+    const notice = readNativeChatStartupNotice(screen)
+    expect(notice?.reason).toBe('codex-trust-workspace')
+    expect(notice?.options).toEqual([{ label: 'Trust', send: 't' }])
+  })
+
+  it('detects the running phase from the real update-in-progress capture', () => {
+    const notice = readNativeChatStartupNotice(UPDATE_RUNNING_CAPTURE)
+    expect(notice?.phase).toBe('running')
+    expect(notice?.reason).toBeNull()
+    expect(notice?.options).toEqual([])
+    expect(notice?.body.some((line) => line.includes('added 5 packages'))).toBe(true)
+  })
+
+  it('detects the restart-required phase from the real post-update capture', () => {
+    const notice = readNativeChatStartupNotice(RESTART_REQUIRED_CAPTURE)
+    expect(notice?.phase).toBe('restart-required')
+    expect(notice?.body.some((line) => line.includes('Please restart Codex'))).toBe(true)
+  })
+
+  it('prefers restart-required over a running marker still present in the same viewport', () => {
+    // Why: the running log usually stays in the same viewport once the success banner
+    // prints below it, so the most-advanced phase must win.
+    const notice = readNativeChatStartupNotice(RESTART_REQUIRED_CAPTURE)
+    expect(notice?.phase).toBe('restart-required')
+  })
+
+  it('returns null for a settled, ready Codex screen', () => {
+    expect(readNativeChatStartupNotice(CODEX_READY_HEADER)).toBeNull()
+  })
+
+  it('returns null for plain shell output with no dialog markers', () => {
+    const screen = 'PS C:\\Users\\visuz\\repo> git status\nOn branch main\nnothing to commit\n'
+    expect(readNativeChatStartupNotice(screen)).toBeNull()
+  })
+
+  it('strips ANSI SGR styling before matching markers', () => {
+    const styled =
+      '\x1b[33mUpdate available! 0.145.0 -> 0.146.0\x1b[0m\n\x1b[32mPress enter to continue\x1b[0m\n'
+    expect(readNativeChatStartupNotice(styled)?.reason).toBe('codex-update-prompt')
+  })
+})
+
+describe('isAgentStartupSettled', () => {
+  it('is true for a ready Codex header', () => {
+    expect(isAgentStartupSettled(CODEX_READY_HEADER)).toBe(true)
+  })
+
+  it('is false while the update dialog is showing', () => {
+    expect(
+      isAgentStartupSettled(
+        ['Update available! 0.145.0 -> 0.146.0', 'Press enter to continue'].join('\n')
+      )
+    ).toBe(false)
+  })
+
+  it('is false right after the restart-required banner (no ready header yet)', () => {
+    expect(isAgentStartupSettled(RESTART_REQUIRED_CAPTURE)).toBe(false)
+  })
+})
+
+describe('readTerminalActivityTail', () => {
+  it('caps to the last N non-blank lines', () => {
+    const screen = Array.from({ length: 20 }, (_, i) => `line ${i}`).join('\n')
+    const tail = readTerminalActivityTail(screen, 5)
+    expect(tail).toEqual(['line 15', 'line 16', 'line 17', 'line 18', 'line 19'])
+  })
+
+  it('drops blank lines', () => {
+    expect(readTerminalActivityTail('a\n\n\nb\n', 10)).toEqual(['a', 'b'])
+  })
+})
+
+describe('buildNativeChatStartupPhaseNotice', () => {
+  it('builds an update-failed notice carrying the last observed log tail', () => {
+    const notice = buildNativeChatStartupPhaseNotice('update-failed', UPDATE_RUNNING_CAPTURE)
+    expect(notice.phase).toBe('update-failed')
+    expect(notice.reason).toBeNull()
+    expect(notice.options).toEqual([])
+    expect(notice.title).toBe('Codex update did not finish')
+  })
+
+  it('builds a restarting notice', () => {
+    const notice = buildNativeChatStartupPhaseNotice('restarting', RESTART_REQUIRED_CAPTURE)
+    expect(notice.phase).toBe('restarting')
+    expect(notice.title).toBe('Restarting Codex…')
+  })
+})

--- a/src/shared/native-chat-startup-notice.ts
+++ b/src/shared/native-chat-startup-notice.ts
@@ -1,0 +1,190 @@
+// Presentation model for a TUI agent's blocking startup dialog (self-update prompt,
+// trust/workspace dialog, hooks-review, cwd picker, approval menu) plus the Codex
+// self-update's own two extra phases (running, restart-required) surfaced in the native
+// chat view. The chat view has no other way to see these: they happen before any
+// conversation turn, so neither the transcript nor agent-hook status carries them — see
+// src/main/native-chat/transcript-line-decoders-codex.ts, which silently drops anything
+// that isn't a conversation turn.
+//
+// Pure: reads an already-serialized terminal viewport (ANSI included — xterm's
+// SerializeAddon preserves SGR styling by default) and turns it into structured,
+// presentable content. No React, no PTY access, no polling — that state lives in the
+// renderer hook (use-native-chat-startup-notice.ts) which also owns the two phases that
+// cannot be read from a single snapshot: 'update-failed' (needs "was running, agent is now
+// gone") and 'restarting' (an intent the hook itself set).
+
+import { stripScrollbackAnsi } from './terminal-ansi-strip'
+import {
+  findActionableTerminalWaitBlockedSignal,
+  isKnownReadyPromptPreview
+} from './agent-startup-prompt-detection'
+import type { RuntimeTerminalWaitBlockedReason } from './runtime-types'
+
+export type NativeChatStartupPhase =
+  | 'prompt'
+  | 'running'
+  | 'restart-required'
+  | 'update-failed'
+  | 'restarting'
+
+export type NativeChatStartupNoticeOption = {
+  label: string
+  /** Literal bytes to write to the agent's PTY, e.g. a menu digit or `\r`. */
+  send: string
+}
+
+export type NativeChatStartupNotice = {
+  phase: NativeChatStartupPhase
+  /** Set only for `phase: 'prompt'`; null for every other phase. */
+  reason: RuntimeTerminalWaitBlockedReason | null
+  title: string
+  /** ANSI-stripped tail of the terminal, most-recent line last. */
+  body: string[]
+  /** Empty for every phase but `'prompt'` — the other phases are answered through
+   *  phase-specific UI (restart button, dismiss), not a raw PTY send. */
+  options: NativeChatStartupNoticeOption[]
+}
+
+const REASON_TITLES: Record<RuntimeTerminalWaitBlockedReason, string> = {
+  'codex-update-prompt': 'Codex has an update',
+  'codex-trust-workspace': 'Codex wants to trust this workspace',
+  'codex-cwd-prompt': 'Codex is asking about the working directory',
+  'codex-model-migration-prompt': 'Codex has a new default model',
+  'codex-hooks-review-prompt': 'Codex hooks need review',
+  'codex-interactive-prompt': 'Codex needs your input',
+  'agent-approval-prompt': 'Codex wants to run a command'
+}
+
+const PHASE_TITLES: Record<Exclude<NativeChatStartupPhase, 'prompt'>, string> = {
+  running: 'Updating Codex…',
+  'restart-required': 'Update complete — restart required',
+  'update-failed': 'Codex update did not finish',
+  restarting: 'Restarting Codex…'
+}
+
+// Real capture, verbatim, from the Codex self-update flow reported over a Windows PTY:
+// "Updating Codex via `npm install -g @openai/codex`..." → npm output → "🎉 Update ran
+// successfully! Please restart Codex." Matched case-insensitively; ANSI already stripped.
+const UPDATE_RUNNING_MARKERS = ['updating codex via', 'npm install -g @openai/codex']
+const UPDATE_RESTART_REQUIRED_MARKERS = ['update ran successfully', 'please restart codex']
+
+const MAX_ACTIVITY_TAIL_LINES = 14
+
+/** ANSI-stripped tail of the viewport, most-recent line last, blank lines dropped. */
+export function readTerminalActivityTail(
+  screenText: string,
+  maxLines: number = MAX_ACTIVITY_TAIL_LINES
+): string[] {
+  const lines = stripScrollbackAnsi(screenText)
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+  return lines.slice(-maxLines)
+}
+
+/** Wraps `isKnownReadyPromptPreview`: true once the agent has reached its own ready prompt,
+ *  the signal the polling hook uses to stop watching for good. */
+export function isAgentStartupSettled(screenText: string): boolean {
+  return isKnownReadyPromptPreview(stripScrollbackAnsi(screenText))
+}
+
+function containsAllMarkers(normalized: string, markers: readonly string[]): boolean {
+  return markers.every((marker) => normalized.includes(marker))
+}
+
+const NUMBERED_OPTION_RE = /^[>❯]?\s*(\d)[.)]\s+(.{1,60})$/
+
+/** Parse a numbered menu ("1. Update now") into raw digit sends; falls back to a single
+ *  Continue/Trust option when the dialog is a bare "press enter/t" prompt with no menu. */
+function parseStartupNoticeOptions(body: readonly string[]): NativeChatStartupNoticeOption[] {
+  const numbered: NativeChatStartupNoticeOption[] = []
+  for (const line of body) {
+    const match = NUMBERED_OPTION_RE.exec(line)
+    if (match) {
+      numbered.push({ label: match[2].trim(), send: match[1] })
+    }
+  }
+  if (numbered.length > 0) {
+    return numbered
+  }
+  const normalized = body.join('\n').toLowerCase()
+  if (normalized.includes('press t to trust')) {
+    return [{ label: 'Trust', send: 't' }]
+  }
+  if (
+    normalized.includes('press enter to continue') ||
+    normalized.includes('press enter to confirm') ||
+    normalized.includes('press enter to view') ||
+    normalized.includes('press enter to insert')
+  ) {
+    return [{ label: 'Continue', send: '\r' }]
+  }
+  return []
+}
+
+/**
+ * Read the current startup notice from a live terminal viewport, or null when none of the
+ * three text-detectable phases apply. Priority — restart-required, then running, then a
+ * blocked prompt reason — because a dismissed/scrolled banner from an earlier phase can
+ * still be present in the same viewport as the current one; the most-advanced phase wins.
+ *
+ * Does not detect `'update-failed'` or `'restarting'`: those require state this module does
+ * not have (a prior 'running' observation, an explicit restart intent) and are composed by
+ * the renderer hook on top of this reader.
+ */
+export function readNativeChatStartupNotice(screenText: string): NativeChatStartupNotice | null {
+  const stripped = stripScrollbackAnsi(screenText)
+  const normalized = stripped.toLowerCase()
+  const body = readTerminalActivityTail(screenText)
+
+  if (containsAllMarkers(normalized, UPDATE_RESTART_REQUIRED_MARKERS)) {
+    return {
+      phase: 'restart-required',
+      reason: null,
+      title: PHASE_TITLES['restart-required'],
+      body,
+      options: []
+    }
+  }
+  if (containsAllMarkers(normalized, UPDATE_RUNNING_MARKERS)) {
+    return { phase: 'running', reason: null, title: PHASE_TITLES.running, body, options: [] }
+  }
+  const signal = findActionableTerminalWaitBlockedSignal(normalized)
+  if (signal) {
+    return {
+      phase: 'prompt',
+      reason: signal.reason,
+      title: REASON_TITLES[signal.reason],
+      body,
+      options: parseStartupNoticeOptions(body)
+    }
+  }
+  return null
+}
+
+/** Builds the `'update-failed'` / `'restarting'` notices the hook composes from state this
+ *  module cannot read on its own. Exposed so the hook and its tests share one source of
+ *  title copy instead of inlining `PHASE_TITLES` lookups themselves. */
+export function buildNativeChatStartupPhaseNotice(
+  phase: 'update-failed' | 'restarting',
+  screenText: string
+): NativeChatStartupNotice {
+  return {
+    phase,
+    reason: null,
+    title: PHASE_TITLES[phase],
+    body: readTerminalActivityTail(screenText),
+    options: []
+  }
+}
+
+/** Same as `buildNativeChatStartupPhaseNotice`, but takes an already-computed body instead
+ *  of re-deriving it from a screenshot — for the `restarting` transition, which fires from
+ *  the last observed `restart-required` notice rather than a fresh terminal read (the PTY
+ *  is mid-respawn and has nothing new to show yet). */
+export function nativeChatStartupPhaseNoticeWithBody(
+  phase: Exclude<NativeChatStartupPhase, 'prompt'>,
+  body: readonly string[]
+): NativeChatStartupNotice {
+  return { phase, reason: null, title: PHASE_TITLES[phase], body: [...body], options: [] }
+}

--- a/src/shared/terminal-ansi-strip.ts
+++ b/src/shared/terminal-ansi-strip.ts
@@ -1,0 +1,37 @@
+// Minimal ANSI/OSC/control-sequence strip for turning a raw terminal viewport or
+// scrollback string into plain text. Extracted from
+// src/renderer/src/components/native-chat/native-chat-scrape-fallback.ts (which re-exports
+// it for its existing importers) so src/shared consumers — like the startup-notice reader,
+// which is not renderer-only — can use it too. Same three patterns as
+// agent-session-fork-context.ts's local copy: CSI sequences, OSC sequences, and stray
+// single-char escapes.
+
+const ESC = String.fromCharCode(27)
+const ANSI_ESCAPE_PATTERN = new RegExp(`${ESC}\\[[0-?]*[ -/]*[@-~]`, 'g')
+const OSC_SEQUENCE_PATTERN = new RegExp(`${ESC}\\][^\\u0007]*(?:\\u0007|${ESC}\\\\)`, 'g')
+const SINGLE_ESCAPE_PATTERN = new RegExp(`${ESC}(?:[@-Z\\\\-_]|[()*+\\-./][0-~]|c)`, 'g')
+
+function stripUnsupportedControlCharacters(value: string): string {
+  let result = ''
+  for (const char of value) {
+    const code = char.charCodeAt(0)
+    // Drop C0 control chars except tab (9) and newline (10); keep DEL (127) out.
+    if (code <= 8 || code === 11 || code === 12 || (code >= 14 && code <= 31) || code === 127) {
+      continue
+    }
+    result += char
+  }
+  return result
+}
+
+/** Strip ANSI/OSC escapes and normalize newlines so raw terminal output reads as plain text. */
+export function stripScrollbackAnsi(value: string): string {
+  return stripUnsupportedControlCharacters(
+    value
+      .replace(OSC_SEQUENCE_PATTERN, '')
+      .replace(ANSI_ESCAPE_PATTERN, '')
+      .replace(SINGLE_ESCAPE_PATTERN, '')
+  )
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n')
+}


### PR DESCRIPTION
## ELI5

When Codex is updating itself or asking a startup question (update available, trust this workspace, etc.), the chat view in Orca shows an empty "Start a chat" box instead of the actual dialog — because chat view only reads Codex's own conversation transcript, and none of that startup stuff is part of the conversation. You had to flip to terminal view to see or answer it. On top of that, after you authorized an update, Codex would quit back to a plain shell and ask you to restart it by hand — and nothing stopped you from accidentally typing chat messages into that dead shell.

This PR makes chat view show those startup dialogs and the live update log as an actionable card, and — when the update was authorized from that card — restarts Codex automatically without kicking you out of chat view.

## What Changed

- Extracted Orca's existing startup-dialog detector (`findTerminalWaitBlockedSignal` and friends, previously trapped in a 40k-line main-process-only file) into `src/shared/agent-startup-prompt-detection.ts` so the renderer can use it too. Pure move — no behavior change, proven by the pre-existing `orca-runtime.test.ts` suite passing unedited.
- Added a pure presentation model (`src/shared/native-chat-startup-notice.ts`) that classifies the pane's live terminal screen into `prompt` / `running` / `restart-required` / `update-failed` phases, built from a real capture of the actual Windows update flow (including the EPERM warnings and the `Please restart Codex.` prompt).
- Added a renderer hook (`use-native-chat-startup-notice.ts`) that polls the chat leaf's terminal screen and a card (`NativeChatStartupNoticeCard.tsx`) that renders the current dialog's options and a live log, replacing the composer while a notice is active.
- Added seamless restart (`use-native-chat-startup-restart.ts`): when the user authorizes the update *from the chat card*, Orca holds chat mode across the exit-to-shell/respawn window (new `holdChatForAgentRestart` suppression on the existing "confirmed agent exit → switch to terminal" route) and drives the existing Codex restart machinery automatically. A manual, terminal-side update instead offers a "Restart Codex" button with no auto-restart — Orca never kills a PTY the user didn't ask it to.
- Added a composer liveness guard (`isNativeChatAgentForegroundGone`): once the pane's foreground is proven back at a plain shell, the composer refuses to send, closing the gap where authorized-but-not-yet-restarted (or just stray) input could land in PowerShell instead of Codex.

## Why

Reported by a user: opening Codex in chat view while it's mid-update (or blocked on any startup dialog) shows nothing actionable, and after authorizing an update the chat composer kept accepting input that silently went nowhere useful once Codex exited to the shell.

## Linked Issue

Fixes #15597

## Visual Proof

Opening as **draft** — real screenshots/video of the new card across the prompt / running / restart-required / update-failed phases still need to be captured against a pinned older `@openai/codex` build and attached before this comes out of draft.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated

Automated:
- `src/shared/agent-startup-prompt-detection.test.ts` — matchers ported from the existing `orca-runtime.test.ts` fixtures plus new fixtures built from the real update-flow capture (update prompt, dismissed-modal downgrade, model migration, trust, hooks review, cwd, cursor approval).
- `src/main/runtime/orca-runtime.test.ts` / `orca-runtime-tail-wait-memo.test.ts` — **unedited**, still green after the extraction.
- `src/shared/native-chat-startup-notice.test.ts` — all four phases off the real capture, option parsing, `null` on a ready Codex header.
- `use-native-chat-startup-notice.test.ts` (fake timers) — full phase lifecycle, settled latch, ptyId-reset, `interactivePrompt` suppression, message-count backstop, visibility gating, watch-budget expiry.
- `use-native-chat-startup-restart.test.ts` — authorization tracking, held chat mode, manual-vs-authorized restart branching.
- `native-chat-leaf-routing.test.ts` — `holdChatForAgentRestart` keeps chat on agent exit, still exits for a removed/ineligible leaf.
- `use-native-chat-can-send.test.ts` / `native-chat-send-eligibility.test.ts` — liveness guard, remote-pane exemption.

Local verification run for this PR: `pnpm run typecheck` (clean), `pnpm run` oxlint (native + type-aware, both clean), reliability gates, max-lines ratchet, and `verify:localization-catalog`/`extraction`/`coverage` (all clean — no new `en.json` keys missing extraction or catalog coverage). Full `pnpm run lint` also runs an unrelated `verify:skill-bundle-manifest` staleness check that fails identically on a clean base branch with none of this diff applied (confirmed by stashing and re-running) — pre-existing repo drift, not something this PR touches. Full `pnpm test` was run but produced ~2000 unrelated failed test files in this sandbox from `spawn /bin/sh ENOENT` (no `/bin/sh` in this Windows sandbox's PATH) inside unrelated IPC/ephemeral-VM suites — an environment limitation, not a regression from this diff; every test file that actually exercises this change passed individually as listed above.

Not yet done: full end-to-end run against a pinned older Codex build via the `$electron` skill + Playwright CDP (macOS/Linux/Windows + SSH), per this repo's own `AGENTS.md` UI-validation guidance — tracked as the reason this PR stays in draft.

## AI Disclosure

Implemented with [Claude Code](https://claude.com/claude-code) (Sonnet 5), from an initial bug report through an approved implementation plan (including a self-critique pass that caught two real issues before implementation: a route conflict with existing "exit chat on confirmed agent exit" behavior, and a mis-scoped update-authorization trigger) to the code in this PR.

## Review

- **Cross-platform**: detection is pure text-matching over the renderer's already-serialized terminal screen (`readTerminalScreen()`), identical on macOS/Linux/Windows; no new OS-specific branches. The Windows EPERM `update-failed` fixture is just one more text pattern, not an OS gate.
- **SSH/remote**: sends reuse the existing `sendRaw` path that already branches local `pty:write` vs. remote runtime RPC — no new IPC. The liveness guard explicitly gates on `!isRemote`, since the `shellForeground` OSC 133;D signal has no producer on remote panes; treating its absence as "gone" there would lock every remote chat pane permanently.
- **Agent/integration compatibility**: reuses the existing multi-agent detector (Codex/Cursor/Antigravity matchers) unchanged. Auto-restart is scoped strictly to the `codex-update-prompt` reason and only for the exact ptyId that displayed the card the user clicked — no other agent or dialog type triggers a restart.
- **Performance**: polling is 300ms while a notice might be active, 700ms otherwise, with a permanent settled-latch stop once Codex reaches its ready prompt and a 120s hard budget backstop — no unbounded per-pane timers.
- **UI quality**: card follows `docs/STYLEGUIDE.md` tokens/shadcn primitives and mirrors the existing `NativeChatApprovalCard` pattern; scrollable log region uses the required `scrollbar-sleek` class.
- **Security**: no new IPC/RPC surface or wire opcode (renderer-local detection by design — see the plan's "why renderer-side, not a main-process fact" section for the remote-wire-compatibility reasoning). Auto-restart authorization is tracked per-ptyId from the card click, never inferred from ambient terminal state. Net effect on the composer is strictly more restrictive (adds a send-refusal path), not less.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No new RPC params, stream opcodes, or host-published content — `docs/reference/remote-wire-compatibility.md` is not triggered.

## Checklist

- [x] This PR is small and focused *(single cohesive fix; landed as one PR per maintainer direction rather than the 3-stage split considered during planning — extraction, visible fix, and restart are still separable commits-worth of review if preferred)*
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes *(pending — see Visual Proof)*
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) *(see Testing notes above for the two pre-existing/environmental exceptions)*

## Author

- X / Twitter: _(optional — add if you'd like the shoutout)_
