### PR TITLE
fix(agent-resume): drop a recorded permission escalation the settings no longer grant

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection-cold-restore-agent-resume.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-cold-restore-agent-resume.test.ts
@@ -402,6 +402,67 @@ describe('connectPanePty', () => {
     expect(mockStoreState.clearSleepingAgentSession).toHaveBeenCalledWith(paneKey)
   })
 
+  it('drops a recorded escalation the agent permission setting no longer grants', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('fresh-pty')
+    transport.connect.mockImplementation(async ({ sessionId }: { sessionId?: string }) => {
+      if (sessionId) {
+        return { id: 'fresh-pty', coldRestore: { scrollback: 'cold-payload', cwd: '/tmp/wt-1' } }
+      }
+      return 'fresh-pty'
+    })
+    transportFactoryQueue.push(transport)
+    const paneKey = makePaneKey('tab-1', LEAF_1)
+    // Why: the record was captured while the setting was still yolo, so only the
+    // current setting can tell the resume that the escalation is stale (#10886).
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: 'lost-pty' }] },
+      settings: {
+        ...mockStoreState.settings,
+        agentCmdOverrides: {},
+        agentDefaultArgs: { codex: '' }
+      },
+      agentStatusByPaneKey: {},
+      sleepingAgentSessionsByPaneKey: {
+        [paneKey]: {
+          paneKey,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          agent: 'codex',
+          providerSession: { key: 'session_id', id: 'codex-session-1' },
+          prompt: 'finish the task',
+          state: 'working',
+          capturedAt: 1,
+          updatedAt: 1,
+          launchConfig: {
+            agentCommand: "codex '--dangerously-bypass-approvals-and-sandbox'",
+            agentArgs: '--dangerously-bypass-approvals-and-sandbox',
+            agentEnv: {}
+          }
+        }
+      }
+    } as StoreState
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps({
+      restoredLeafId: LEAF_1,
+      restoredPtyIdByLeafId: { [LEAF_1]: 'lost-pty' }
+    })
+
+    connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks(20)
+    await new Promise((resolve) => setTimeout(resolve, 70))
+
+    expect(transport.connect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'lost-pty',
+        command: "codex 'resume' 'codex-session-1'"
+      })
+    )
+  })
+
   it('marks the pane as freshly started when main declined an unverifiable resume', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('fresh-pty')

--- a/src/renderer/src/components/terminal-pane/pty-connection/cold-restore-resume-startup.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/cold-restore-resume-startup.ts
@@ -2,10 +2,7 @@ import { useAppStore } from '@/store'
 import { createBrowserUuid } from '@/lib/browser-uuid'
 import { buildAgentResumeStartupPlan } from '@/lib/tui-agent-startup'
 import { resolveAgentResumeLaunchTarget } from '@/lib/agent-resume-launch-target'
-import {
-  resolveTuiAgentLaunchArgs,
-  resolveTuiAgentLaunchEnv
-} from '../../../../../shared/tui-agent-launch-defaults'
+import { resolveResumeLaunchInputs } from '../../../../../shared/agent-resume-permission-drop'
 import {
   agentProviderSessionsEqual,
   isResumableTuiAgent,
@@ -46,7 +43,7 @@ export function bindBuildColdRestoreAgentResumeStartup(session: ConnectPanePtySe
           agentProviderSessionsEqual(agent, sleepingRecord.providerSession, providerSession)))
         ? sleepingRecord.launchConfig
         : undefined
-    const launchConfig =
+    const recordedLaunchConfig =
       (useLiveEntry && entry ? state.getAgentLaunchConfigForStatusEntry(entry) : undefined) ??
       matchingSleepingLaunchConfig
     // Why: the resume line is typed into this pane's live shell, so its quoting must
@@ -59,18 +56,22 @@ export function bindBuildColdRestoreAgentResumeStartup(session: ConnectPanePtySe
       terminalWindowsShell: state.settings?.terminalWindowsShell,
       tabShellOverride: session.shellOverride
     })
+    // Why: the recorded config describes the launch this pane started with, so a
+    // permission escalation the user has since turned off must not ride along
+    // into the restart's resume (#10886).
+    const { launchConfig, agentArgs, agentEnv } = resolveResumeLaunchInputs({
+      agent,
+      launchConfig: recordedLaunchConfig,
+      settings: state.settings,
+      platform: resumeTarget.platform,
+      shell: resumeTarget.shell
+    })
     const startupPlan = buildAgentResumeStartupPlan({
       agent,
       providerSession,
       cmdOverrides: state.settings?.agentCmdOverrides ?? {},
-      agentArgs:
-        launchConfig !== undefined
-          ? launchConfig.agentArgs
-          : resolveTuiAgentLaunchArgs(agent, state.settings?.agentDefaultArgs),
-      agentEnv:
-        launchConfig !== undefined
-          ? launchConfig.agentEnv
-          : resolveTuiAgentLaunchEnv(agent, state.settings?.agentDefaultEnv),
+      agentArgs,
+      agentEnv,
       ...(launchConfig?.agentCommand ? { agentCommand: launchConfig.agentCommand } : {}),
       ...(launchConfig?.ompResumeFilePath
         ? { ompResumeFilePath: launchConfig.ompResumeFilePath }

--- a/src/renderer/src/lib/sleeping-agent-session-launch-permission-drop.test.ts
+++ b/src/renderer/src/lib/sleeping-agent-session-launch-permission-drop.test.ts
@@ -1,0 +1,108 @@
+// Permission coverage for the sleeping-agent resume launch (#10886): the recorded
+// launch config is the pane's original launch, so an escalation the user has since
+// turned off must not ride along into the resume.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-resume'
+
+const mockCreateTab = vi.fn()
+const mockQueueTabStartupCommand = vi.fn()
+
+const store = {
+  settings: {
+    agentCmdOverrides: {} as Record<string, string>,
+    agentDefaultArgs: {} as Record<string, string>,
+    agentDefaultEnv: {} as Record<string, Record<string, string>>,
+    activeRuntimeEnvironmentId: null as string | null
+  },
+  repos: [{ id: 'repo-1', connectionId: null as string | null, path: '/home/dev/repo' }],
+  worktreesByRepo: {
+    'repo-1': [
+      { id: 'wt-1', repoId: 'repo-1', path: '/home/dev/repo/feature', displayName: 'feature' }
+    ]
+  },
+  getKnownWorktreeById: (id: string) =>
+    Object.values(store.worktreesByRepo)
+      .flat()
+      .find((worktree) => worktree.id === id),
+  tabsByWorktree: { 'wt-1': [{ id: 'tab-1' }] },
+  openFiles: [] as { id: string; worktreeId: string }[],
+  browserTabsByWorktree: {} as Record<string, { id: string }[]>,
+  tabBarOrderByWorktree: {} as Record<string, string[]>,
+  createTab: mockCreateTab,
+  queueTabStartupCommand: mockQueueTabStartupCommand,
+  claimAutomaticAgentResume: vi.fn(),
+  clearSleepingAgentSession: vi.fn(),
+  setActiveTabType: vi.fn(),
+  setTabBarOrder: vi.fn()
+}
+
+vi.mock('@/store', () => ({ useAppStore: { getState: () => store } }))
+vi.mock('@/lib/new-workspace', () => ({ CLIENT_PLATFORM: 'darwin' }))
+vi.mock('sonner', () => ({ toast: { message: vi.fn(), error: vi.fn() } }))
+vi.mock('@/lib/telemetry', () => ({
+  track: vi.fn(),
+  tuiAgentToAgentKind: (agent: string) => agent
+}))
+vi.mock('@/components/tab-bar/reconcile-order', () => ({
+  reconcileTabOrder: vi.fn((_stored, termIds: string[]) => [...termIds])
+}))
+
+const SESSION_ID = '0199f7a1-0000-7000-8000-000000000001'
+
+const record: SleepingAgentSessionRecord = {
+  paneKey: 'tab-1::leaf-1',
+  tabId: 'tab-1',
+  worktreeId: 'wt-1',
+  agent: 'claude',
+  providerSession: { key: 'session_id', id: SESSION_ID },
+  prompt: 'finish the task',
+  state: 'done',
+  origin: 'worktree-sleep',
+  capturedAt: 1,
+  updatedAt: 1,
+  launchConfig: {
+    agentCommand: "claude '--dangerously-skip-permissions'",
+    agentArgs: '--dangerously-skip-permissions',
+    agentEnv: {}
+  }
+}
+
+async function launch(): Promise<{ command: string; agentArgsOverride?: string } | undefined> {
+  const { launchSleepingAgentSession } = await import('./sleeping-agent-session-launch')
+  launchSleepingAgentSession(record)
+  return mockQueueTabStartupCommand.mock.calls.at(-1)?.[1] as
+    | { command: string; agentArgsOverride?: string }
+    | undefined
+}
+
+describe('launchSleepingAgentSession permission escalation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    store.settings = {
+      agentCmdOverrides: {},
+      agentDefaultArgs: {},
+      agentDefaultEnv: {},
+      activeRuntimeEnvironmentId: null
+    }
+    mockCreateTab.mockReturnValue({ id: 'tab-1' })
+  })
+
+  it('resumes without the escalation once the setting no longer grants it', async () => {
+    store.settings.agentDefaultArgs = { claude: '' }
+
+    await expect(launch()).resolves.toMatchObject({
+      command: `claude '--resume' '${SESSION_ID}'`,
+      agentArgsOverride: ''
+    })
+  })
+
+  it('keeps the escalation while the setting still grants it', async () => {
+    store.settings.agentDefaultArgs = { claude: '--dangerously-skip-permissions' }
+
+    await expect(launch()).resolves.toMatchObject({
+      command: `claude '--dangerously-skip-permissions' '--resume' '${SESSION_ID}'`,
+      agentArgsOverride: '--dangerously-skip-permissions'
+    })
+  })
+})

--- a/src/renderer/src/lib/sleeping-agent-session-launch-permission-drop.test.ts
+++ b/src/renderer/src/lib/sleeping-agent-session-launch-permission-drop.test.ts
@@ -6,7 +6,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-resume'
 
 const mockCreateTab = vi.fn()
-const mockQueueTabStartupCommand = vi.fn()
 
 const store = {
   settings: {
@@ -30,7 +29,6 @@ const store = {
   browserTabsByWorktree: {} as Record<string, { id: string }[]>,
   tabBarOrderByWorktree: {} as Record<string, string[]>,
   createTab: mockCreateTab,
-  queueTabStartupCommand: mockQueueTabStartupCommand,
   claimAutomaticAgentResume: vi.fn(),
   clearSleepingAgentSession: vi.fn(),
   setActiveTabType: vi.fn(),
@@ -71,9 +69,10 @@ const record: SleepingAgentSessionRecord = {
 async function launch(): Promise<{ command: string; agentArgsOverride?: string } | undefined> {
   const { launchSleepingAgentSession } = await import('./sleeping-agent-session-launch')
   launchSleepingAgentSession(record)
-  return mockQueueTabStartupCommand.mock.calls.at(-1)?.[1] as
-    | { command: string; agentArgsOverride?: string }
+  const options = mockCreateTab.mock.calls.at(-1)?.[3] as
+    | { pendingStartup?: { command: string; agentArgsOverride?: string } }
     | undefined
+  return options?.pendingStartup
 }
 
 describe('launchSleepingAgentSession permission escalation', () => {

--- a/src/renderer/src/lib/sleeping-agent-session-launch.ts
+++ b/src/renderer/src/lib/sleeping-agent-session-launch.ts
@@ -9,10 +9,7 @@ import {
 } from '@/lib/agent-resume-launch-target'
 import { getExecutionHostIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { getLocalProjectExecutionRuntimeContext } from '@/lib/local-preflight-context'
-import {
-  resolveTuiAgentLaunchArgs,
-  resolveTuiAgentLaunchEnv
-} from '../../../shared/tui-agent-launch-defaults'
+import { resolveResumeLaunchInputs } from '../../../shared/agent-resume-permission-drop'
 import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-resume'
 import { translate } from '@/i18n/i18n'
 
@@ -67,20 +64,22 @@ export function launchSleepingAgentSession(
   options?: ResumeSleepingAgentSessionsOptions
 ): boolean {
   const state = useAppStore.getState()
-  const launchConfig = record.launchConfig
   const resumeTarget = getResumeLaunchTarget(record.worktreeId)
+  // Why: see agent-resume-permission-drop — a resume replays the pane's original
+  // launch, which must not re-grant an escalation the user has turned off.
+  const { launchConfig, agentArgs, agentEnv } = resolveResumeLaunchInputs({
+    agent: record.agent,
+    launchConfig: record.launchConfig,
+    settings: state.settings,
+    platform: resumeTarget.platform,
+    shell: resumeTarget.shell
+  })
   const startupPlan = buildAgentResumeStartupPlan({
     agent: record.agent,
     providerSession: record.providerSession,
     cmdOverrides: state.settings?.agentCmdOverrides ?? {},
-    agentArgs:
-      launchConfig !== undefined
-        ? launchConfig.agentArgs
-        : resolveTuiAgentLaunchArgs(record.agent, state.settings?.agentDefaultArgs),
-    agentEnv:
-      launchConfig !== undefined
-        ? launchConfig.agentEnv
-        : resolveTuiAgentLaunchEnv(record.agent, state.settings?.agentDefaultEnv),
+    agentArgs,
+    agentEnv,
     ...(launchConfig?.agentCommand ? { agentCommand: launchConfig.agentCommand } : {}),
     ...(launchConfig?.ompResumeFilePath
       ? { ompResumeFilePath: launchConfig.ompResumeFilePath }

--- a/src/shared/agent-resume-permission-drop.test.ts
+++ b/src/shared/agent-resume-permission-drop.test.ts
@@ -177,6 +177,26 @@ describe('dropStaleResumePermissionEscalation', () => {
     ).toEqual({ agentCommand: 'qwen', agentArgs: '', agentEnv: {} })
   })
 
+  it('keeps an escalation split across the command override and the args', () => {
+    const launchConfig = {
+      agentCommand: "qwen '--approval-mode' 'yolo'",
+      agentArgs: '--approval-mode yolo',
+      agentEnv: {}
+    }
+    // Why: the launch is `<override> <args>`, so these two settings still put
+    // `--approval-mode yolo` on the command line.
+    expect(
+      dropStaleResumePermissionEscalation({
+        agent: 'qwen-code',
+        launchConfig,
+        cmdOverride: 'qwen --approval-mode',
+        currentAgentArgs: 'yolo',
+        currentAgentEnv: {},
+        platform: 'darwin'
+      })
+    ).toEqual(launchConfig)
+  })
+
   it('drops a stale escalation env var', () => {
     expect(
       dropStaleResumePermissionEscalation({

--- a/src/shared/agent-resume-permission-drop.test.ts
+++ b/src/shared/agent-resume-permission-drop.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it } from 'vitest'
+import {
+  dropStaleResumePermissionEscalation,
+  resolveResumeLaunchInputs
+} from './agent-resume-permission-drop'
+
+const CLAUDE_YOLO_COMMAND = "claude '--dangerously-skip-permissions'"
+
+function dropForClaude(args: {
+  agentCommand?: string
+  agentArgs: string
+  currentAgentArgs: string
+  cmdOverride?: string
+  platform?: NodeJS.Platform
+}) {
+  return dropStaleResumePermissionEscalation({
+    agent: 'claude',
+    launchConfig: {
+      ...(args.agentCommand !== undefined ? { agentCommand: args.agentCommand } : {}),
+      agentArgs: args.agentArgs,
+      agentEnv: {}
+    },
+    ...(args.cmdOverride !== undefined ? { cmdOverride: args.cmdOverride } : {}),
+    currentAgentArgs: args.currentAgentArgs,
+    currentAgentEnv: {},
+    platform: args.platform ?? 'darwin'
+  })
+}
+
+describe('dropStaleResumePermissionEscalation', () => {
+  it('drops an escalation the current settings no longer grant', () => {
+    expect(
+      dropForClaude({
+        agentCommand: CLAUDE_YOLO_COMMAND,
+        agentArgs: '--dangerously-skip-permissions',
+        currentAgentArgs: ''
+      })
+    ).toEqual({ agentCommand: 'claude', agentArgs: '', agentEnv: {} })
+  })
+
+  it('keeps the escalation while the current settings still grant it', () => {
+    expect(
+      dropForClaude({
+        agentCommand: CLAUDE_YOLO_COMMAND,
+        agentArgs: '--dangerously-skip-permissions',
+        currentAgentArgs: '--dangerously-skip-permissions'
+      })
+    ).toEqual({
+      agentCommand: CLAUDE_YOLO_COMMAND,
+      agentArgs: '--dangerously-skip-permissions',
+      agentEnv: {}
+    })
+  })
+
+  it('keeps the escalation carried by the agent command override', () => {
+    expect(
+      dropForClaude({
+        agentCommand: "my-claude '--dangerously-skip-permissions'",
+        agentArgs: '--dangerously-skip-permissions',
+        currentAgentArgs: '',
+        cmdOverride: 'my-claude --dangerously-skip-permissions'
+      })
+    ).toEqual({
+      agentCommand: "my-claude '--dangerously-skip-permissions'",
+      agentArgs: '--dangerously-skip-permissions',
+      agentEnv: {}
+    })
+  })
+
+  it('preserves the launch flags that are not permission escalations', () => {
+    expect(
+      dropForClaude({
+        agentCommand: "claude '--dangerously-skip-permissions' '--model' 'opus'",
+        agentArgs: '--dangerously-skip-permissions --model opus',
+        currentAgentArgs: '--model opus'
+      })
+    ).toEqual({
+      agentCommand: "claude '--model' 'opus'",
+      agentArgs: '--model opus',
+      agentEnv: {}
+    })
+  })
+
+  it('drops every occurrence a recorded launch accumulated', () => {
+    expect(
+      dropForClaude({
+        agentCommand:
+          "claude '--dangerously-skip-permissions' '--dangerously-skip-permissions' '--model' 'opus'",
+        agentArgs: '--dangerously-skip-permissions --dangerously-skip-permissions --model opus',
+        currentAgentArgs: '--model opus'
+      })
+    ).toEqual({
+      agentCommand: "claude '--model' 'opus'",
+      agentArgs: '--model opus',
+      agentEnv: {}
+    })
+  })
+
+  it('never adds an escalation the recorded launch did not have', () => {
+    expect(
+      dropForClaude({
+        agentCommand: 'claude',
+        agentArgs: '',
+        currentAgentArgs: '--dangerously-skip-permissions'
+      })
+    ).toEqual({ agentCommand: 'claude', agentArgs: '', agentEnv: {} })
+  })
+
+  it('leaves a sequence behind the agent terminator alone', () => {
+    const agentCommand = "claude '--' '--dangerously-skip-permissions'"
+    expect(
+      dropForClaude({
+        agentCommand,
+        agentArgs: '-- --dangerously-skip-permissions',
+        currentAgentArgs: ''
+      })
+    ).toEqual({ agentCommand, agentArgs: '-- --dangerously-skip-permissions', agentEnv: {} })
+  })
+
+  it('fails open on a recorded command it cannot tokenize', () => {
+    const agentCommand = "claude '--dangerously-skip-permissions"
+    expect(dropForClaude({ agentCommand, agentArgs: '', currentAgentArgs: '' })).toEqual({
+      agentCommand,
+      agentArgs: '',
+      agentEnv: {}
+    })
+  })
+
+  it('drops the escalation from an args-only launch config', () => {
+    expect(
+      dropForClaude({ agentArgs: '--dangerously-skip-permissions', currentAgentArgs: '' })
+    ).toEqual({ agentArgs: '', agentEnv: {} })
+  })
+
+  it('fails open on a recorded command carrying shell syntax between tokens', () => {
+    const agentCommand = "claude '--dangerously-skip-permissions' && echo done"
+    expect(dropForClaude({ agentCommand, agentArgs: '', currentAgentArgs: '' })).toEqual({
+      agentCommand,
+      agentArgs: '',
+      agentEnv: {}
+    })
+  })
+
+  it('fails open when a newline separates the recorded tokens', () => {
+    const agentCommand = "claude\n'--dangerously-skip-permissions'"
+    expect(dropForClaude({ agentCommand, agentArgs: '', currentAgentArgs: '' })).toEqual({
+      agentCommand,
+      agentArgs: '',
+      agentEnv: {}
+    })
+  })
+
+  it('quotes-aware drops the escalation from a PowerShell recorded command', () => {
+    expect(
+      dropForClaude({
+        agentCommand: "claude '--dangerously-skip-permissions'",
+        agentArgs: '--dangerously-skip-permissions',
+        currentAgentArgs: '',
+        platform: 'win32'
+      })
+    ).toEqual({ agentCommand: 'claude', agentArgs: '', agentEnv: {} })
+  })
+
+  it('drops a multi-token escalation', () => {
+    expect(
+      dropStaleResumePermissionEscalation({
+        agent: 'qwen-code',
+        launchConfig: {
+          agentCommand: "qwen '--approval-mode' 'yolo'",
+          agentArgs: '--approval-mode yolo',
+          agentEnv: {}
+        },
+        currentAgentArgs: '',
+        currentAgentEnv: {},
+        platform: 'darwin'
+      })
+    ).toEqual({ agentCommand: 'qwen', agentArgs: '', agentEnv: {} })
+  })
+
+  it('drops a stale escalation env var', () => {
+    expect(
+      dropStaleResumePermissionEscalation({
+        agent: 'goose',
+        launchConfig: { agentCommand: 'goose', agentArgs: '', agentEnv: { GOOSE_MODE: 'auto' } },
+        currentAgentArgs: '',
+        currentAgentEnv: {},
+        platform: 'darwin'
+      })
+    ).toEqual({ agentCommand: 'goose', agentArgs: '', agentEnv: {} })
+  })
+
+  it('keeps an escalation env var the current settings still grant', () => {
+    expect(
+      dropStaleResumePermissionEscalation({
+        agent: 'goose',
+        launchConfig: { agentCommand: 'goose', agentArgs: '', agentEnv: { GOOSE_MODE: 'auto' } },
+        currentAgentArgs: '',
+        currentAgentEnv: { GOOSE_MODE: 'auto' },
+        platform: 'darwin'
+      })
+    ).toEqual({ agentCommand: 'goose', agentArgs: '', agentEnv: { GOOSE_MODE: 'auto' } })
+  })
+
+  it('keeps a non-escalation env var the pane recorded', () => {
+    expect(
+      dropStaleResumePermissionEscalation({
+        agent: 'goose',
+        launchConfig: {
+          agentCommand: 'goose',
+          agentArgs: '',
+          agentEnv: { GOOSE_MODE: 'auto', GOOSE_MODEL: 'gpt-5' }
+        },
+        currentAgentArgs: '',
+        currentAgentEnv: {},
+        platform: 'darwin'
+      })
+    ).toEqual({ agentCommand: 'goose', agentArgs: '', agentEnv: { GOOSE_MODEL: 'gpt-5' } })
+  })
+})
+
+describe('resolveResumeLaunchInputs', () => {
+  it('falls back to the current settings when the pane recorded no launch config', () => {
+    expect(
+      resolveResumeLaunchInputs({
+        agent: 'claude',
+        launchConfig: undefined,
+        settings: { agentDefaultArgs: { claude: '--model opus' } },
+        platform: 'darwin'
+      })
+    ).toEqual({ launchConfig: undefined, agentArgs: '--model opus', agentEnv: {} })
+  })
+
+  it('reports the de-escalated recorded config as the resume inputs', () => {
+    expect(
+      resolveResumeLaunchInputs({
+        agent: 'claude',
+        launchConfig: {
+          agentCommand: "claude '--dangerously-skip-permissions'",
+          agentArgs: '--dangerously-skip-permissions',
+          agentEnv: {}
+        },
+        settings: { agentDefaultArgs: { claude: '' } },
+        platform: 'darwin'
+      })
+    ).toEqual({
+      launchConfig: { agentCommand: 'claude', agentArgs: '', agentEnv: {} },
+      agentArgs: '',
+      agentEnv: {}
+    })
+  })
+
+  it('keeps the recorded escalation when the command override still carries it', () => {
+    const launchConfig = {
+      agentCommand: "my-claude '--dangerously-skip-permissions'",
+      agentArgs: '--dangerously-skip-permissions',
+      agentEnv: {}
+    }
+    expect(
+      resolveResumeLaunchInputs({
+        agent: 'claude',
+        launchConfig,
+        settings: {
+          agentDefaultArgs: { claude: '' },
+          agentCmdOverrides: { claude: 'my-claude --dangerously-skip-permissions' }
+        },
+        platform: 'darwin'
+      })
+    ).toEqual({
+      launchConfig,
+      agentArgs: '--dangerously-skip-permissions',
+      agentEnv: {}
+    })
+  })
+})

--- a/src/shared/agent-resume-permission-drop.ts
+++ b/src/shared/agent-resume-permission-drop.ts
@@ -150,22 +150,29 @@ export function dropStaleResumePermissionEscalation(args: {
 }
 
 /** Fails open (reports granted) for any string it cannot tokenize, so an
- * unreadable setting never silently narrows a resumed pane. */
+ * unreadable setting never silently narrows a resumed pane.
+ *
+ * Why one token list rather than a scan per source: `resolveAgentLaunchCommand`
+ * emits the override ahead of the args, so a multi-token escalation can be
+ * split across the two — `qwen --approval-mode` plus `yolo` still launches with
+ * the flag, and scanning each source alone would call it stale. */
 function currentLaunchGrantsEscalation(
   args: { cmdOverride?: string | null; currentAgentArgs: string },
   sequence: readonly string[],
   shell: AgentStartupShell
 ): boolean {
-  for (const source of [args.currentAgentArgs, args.cmdOverride ?? '']) {
+  const tokens: string[] = []
+  for (const source of [args.cmdOverride ?? '', args.currentAgentArgs]) {
     if (!source.trim()) {
       continue
     }
     const tokenized = tokenizeStartupCommand(source, shell)
-    if (!tokenized.ok || containsTokenSequence(tokenized.tokens, sequence)) {
+    if (!tokenized.ok) {
       return true
     }
+    tokens.push(...tokenized.tokens)
   }
-  return false
+  return containsTokenSequence(tokens, sequence)
 }
 
 export type ResumeLaunchInputs = {

--- a/src/shared/agent-resume-permission-drop.ts
+++ b/src/shared/agent-resume-permission-drop.ts
@@ -1,0 +1,208 @@
+import { resolveTuiAgentLaunchArgs, resolveTuiAgentLaunchEnv } from './tui-agent-launch-defaults'
+import { YOLO_TUI_AGENT_ARGS, YOLO_TUI_AGENT_ENV } from './tui-agent-permissions'
+import {
+  resolveStartupShell,
+  tokenizeStartupCommand,
+  type AgentStartupShell
+} from './tui-agent-startup-shell'
+import type { SleepingAgentLaunchConfig } from './agent-session-resume'
+import type { GlobalSettings } from './global-settings-types'
+import type { TuiAgent } from './tui-agent'
+
+/** Scans option position only: a sequence behind the agent's own `--` is data
+ * for the child, not a permission flag. */
+function containsTokenSequence(tokens: readonly string[], sequence: readonly string[]): boolean {
+  for (let index = 0; index + sequence.length <= tokens.length; index += 1) {
+    if (tokens[index] === '--') {
+      return false
+    }
+    if (sequence.every((token, offset) => tokens[index + offset] === token)) {
+      return true
+    }
+  }
+  return false
+}
+
+/** Splices every occurrence of `sequence` out of `value` by source span, so
+ * bytes outside the removed tokens survive verbatim instead of being requoted.
+ *
+ * Fails open — returns `value` untouched — whenever the string cannot be
+ * modeled for `shell`: an unparseable command, a token this tokenizer reads
+ * differently than the shell will, or live syntax between tokens. */
+function dropTokenSequence(
+  value: string,
+  sequence: readonly string[],
+  shell: AgentStartupShell,
+  from: number
+): string {
+  const tokenized = tokenizeStartupCommand(value, shell)
+  if (!tokenized.ok) {
+    return value
+  }
+  const { tokens, spans } = tokenized
+  for (let index = 0; index <= tokens.length; index += 1) {
+    const gapStart = index === 0 ? 0 : spans[index - 1].end
+    const gapEnd = index === tokens.length ? value.length : spans[index].start
+    if (!/^[ \t]*$/.test(value.slice(gapStart, gapEnd))) {
+      return value
+    }
+    if (index < tokens.length && spans[index].divergesFromShell) {
+      return value
+    }
+  }
+  const cuts: { start: number; end: number }[] = []
+  for (let index = from; index + sequence.length <= tokens.length; index += 1) {
+    if (tokens[index] === '--') {
+      break
+    }
+    if (!sequence.every((token, offset) => tokens[index + offset] === token)) {
+      continue
+    }
+    // Why: absorb the separator ahead of the flag so removing it cannot leave a
+    // double space, but never cross into the previous token or an earlier cut.
+    let start = spans[index].start
+    let end = spans[index + sequence.length - 1].end
+    const floor = Math.max(index === 0 ? 0 : spans[index - 1].end, cuts.at(-1)?.end ?? 0)
+    while (start > floor && ' \t'.includes(value[start - 1])) {
+      start -= 1
+    }
+    // A leading flag has no separator ahead of it, so it takes the one behind.
+    if (start === 0) {
+      while (end < value.length && ' \t'.includes(value[end])) {
+        end += 1
+      }
+    }
+    cuts.push({ start, end })
+    index += sequence.length - 1
+  }
+  let result = value
+  for (let index = cuts.length - 1; index >= 0; index -= 1) {
+    result = `${result.slice(0, cuts[index].start)}${result.slice(cuts[index].end)}`
+  }
+  // Why: consecutive leading flags each hand their separator to the next cut,
+  // which leaves one behind. Nothing the caller wrote survives ahead of a cut
+  // that started at 0, so trimming there cannot lose a byte.
+  return result.trim() === '' ? '' : cuts[0]?.start === 0 ? result.trimStart() : result
+}
+
+/**
+ * Drops the agent's permission-escalation flag from a recorded resume launch
+ * when the launch the same agent would get today no longer carries it.
+ *
+ * Resume prefers the launch config captured when the pane first started, so a
+ * user who turns Yolo off keeps getting the old escalation replayed on every
+ * app restart (#10886). This only ever removes an escalation, never adds one:
+ * a resume must not re-grant permissions the user has since withdrawn, and it
+ * must not widen a pane the recorded config launched without them.
+ */
+export function dropStaleResumePermissionEscalation(args: {
+  agent: TuiAgent
+  launchConfig: SleepingAgentLaunchConfig
+  /** The agent's command override, which may carry the escalation itself. */
+  cmdOverride?: string | null
+  currentAgentArgs: string
+  currentAgentEnv: Record<string, string>
+  platform: NodeJS.Platform
+  shell?: AgentStartupShell
+}): SleepingAgentLaunchConfig {
+  const shell = resolveStartupShell(args.platform, args.shell)
+  let next = args.launchConfig
+  const escalationEnv = YOLO_TUI_AGENT_ENV[args.agent]
+  if (escalationEnv) {
+    const staleNames = Object.entries(escalationEnv)
+      .filter(
+        ([name, value]) => next.agentEnv[name] === value && args.currentAgentEnv[name] !== value
+      )
+      .map(([name]) => name)
+    if (staleNames.length > 0) {
+      const agentEnv = { ...next.agentEnv }
+      for (const name of staleNames) {
+        delete agentEnv[name]
+      }
+      next = { ...next, agentEnv }
+    }
+  }
+  const escalation = YOLO_TUI_AGENT_ARGS[args.agent]?.trim()
+  if (!escalation) {
+    return next
+  }
+  const sequence = tokenizeStartupCommand(escalation, shell)
+  if (!sequence.ok || sequence.tokens.length === 0) {
+    return next
+  }
+  if (currentLaunchGrantsEscalation(args, sequence.tokens, shell)) {
+    return next
+  }
+  const agentArgs = dropTokenSequence(next.agentArgs, sequence.tokens, shell, 0)
+  // Why: the recorded command already embeds the args as quoted tokens, and
+  // resume prefers it over agentArgs, so both have to lose the escalation.
+  const agentCommand = next.agentCommand
+    ? dropTokenSequence(next.agentCommand, sequence.tokens, shell, 1)
+    : next.agentCommand
+  if (agentArgs === next.agentArgs && agentCommand === next.agentCommand) {
+    return next
+  }
+  return {
+    ...next,
+    agentArgs,
+    ...(agentCommand ? { agentCommand } : {})
+  }
+}
+
+/** Fails open (reports granted) for any string it cannot tokenize, so an
+ * unreadable setting never silently narrows a resumed pane. */
+function currentLaunchGrantsEscalation(
+  args: { cmdOverride?: string | null; currentAgentArgs: string },
+  sequence: readonly string[],
+  shell: AgentStartupShell
+): boolean {
+  for (const source of [args.currentAgentArgs, args.cmdOverride ?? '']) {
+    if (!source.trim()) {
+      continue
+    }
+    const tokenized = tokenizeStartupCommand(source, shell)
+    if (!tokenized.ok || containsTokenSequence(tokenized.tokens, sequence)) {
+      return true
+    }
+  }
+  return false
+}
+
+export type ResumeLaunchInputs = {
+  /** The recorded config with any stale escalation removed, or undefined when
+   *  the pane has none and the resume falls back to current settings. */
+  launchConfig: SleepingAgentLaunchConfig | undefined
+  agentArgs: string
+  agentEnv: Record<string, string>
+}
+
+/** Resolves what a resume should launch with: the recorded config once its stale
+ * escalation is dropped, or the agent's current settings when nothing was
+ * recorded. Both resume paths go through here so a change to what "the launch
+ * this agent would get today" means cannot be applied to only one of them. */
+export function resolveResumeLaunchInputs(args: {
+  agent: TuiAgent
+  launchConfig: SleepingAgentLaunchConfig | undefined
+  settings:
+    | Partial<Pick<GlobalSettings, 'agentCmdOverrides' | 'agentDefaultArgs' | 'agentDefaultEnv'>>
+    | null
+    | undefined
+  platform: NodeJS.Platform
+  shell?: AgentStartupShell
+}): ResumeLaunchInputs {
+  const currentAgentArgs = resolveTuiAgentLaunchArgs(args.agent, args.settings?.agentDefaultArgs)
+  const currentAgentEnv = resolveTuiAgentLaunchEnv(args.agent, args.settings?.agentDefaultEnv)
+  if (!args.launchConfig) {
+    return { launchConfig: undefined, agentArgs: currentAgentArgs, agentEnv: currentAgentEnv }
+  }
+  const launchConfig = dropStaleResumePermissionEscalation({
+    agent: args.agent,
+    launchConfig: args.launchConfig,
+    cmdOverride: args.settings?.agentCmdOverrides?.[args.agent],
+    currentAgentArgs,
+    currentAgentEnv,
+    platform: args.platform,
+    ...(args.shell ? { shell: args.shell } : {})
+  })
+  return { launchConfig, agentArgs: launchConfig.agentArgs, agentEnv: launchConfig.agentEnv }
+}


### PR DESCRIPTION
## ELI5

When Orca starts an agent, it remembers the exact command it used so it can bring that session back later. If that command contained a "skip all permission prompts" flag, the flag is remembered too — so turning the setting off changes nothing for panes that already exist. Every app restart brings the old, more permissive flag back. This PR makes a resume drop that flag when the setting no longer grants it. It only ever takes permissions away, never adds them.

## What Changed

- New `src/shared/agent-resume-permission-drop.ts`. `dropStaleResumePermissionEscalation` removes the agent's escalation from a recorded `launchConfig` — `agentCommand`, `agentArgs` and `agentEnv` — when the launch that agent would get today no longer carries it. The escalation is whatever `YOLO_TUI_AGENT_ARGS` / `YOLO_TUI_AGENT_ENV` define for that agent, so every supported harness is covered without a per-agent branch. Removal is span-spliced out of the recorded command string, so every byte outside the removed tokens survives verbatim instead of being requoted.
- Wired into the two resume paths that prefer the recorded config over current settings: cold restore in `pty-connection.ts` and sleeping-record resume in `sleeping-agent-session-launch.ts`. `orca-runtime`'s `agentSessionResume` and the AI Vault resume already resolve args from current settings and needed no change.

It never widens a pane: an escalation absent from the recorded config is never added, whatever the current setting says. It fails open — recorded config used byte-for-byte — when the recorded command cannot be modelled for the target shell (unparseable, or a token this tokenizer reads differently than cmd/PowerShell will), when the sequence sits behind the agent's own `--`, or when the escalation comes from the agent's command **override** rather than from the permission setting.

## Why

Resume prefers the launch config captured when the pane first started (#6281 made that deliberate, so per-pane launch flags survive). Permission flags ride along with it, which makes a permission *reduction* unenforceable for any session that already exists: the user turns Yolo off, and the next app restart silently relaunches the pane with `--dangerously-bypass-approvals-and-sandbox` / `--dangerously-skip-permissions` anyway. Escalating a pane the user has since restricted should not be something a restart can do on its own.

This is remedy 3 from #10886 ("resolve permission mode from the current settings when restoring"). Doing it as a removal-only pass keeps the recorded config authoritative for everything that is not a permission flag, and keeps the change out of the persisted record shape, so no migration and no behavior change for anyone still on Yolo.

## Linked Issue

Related to #10886.

Not marked as `Fixes`: that report's repro has Orca's own setting still on Yolo, with only the running Codex thread moved to "Approve for me". A settings-level comparison has nothing to compare against there, so the recorded flag still wins. Covering that needs per-thread provider state (Codex's rollout does record `approval_policy` / `sandbox_policy` in its `turn_context`), which is provider-specific and deliberately out of scope here — see my comment on the issue.

## Visual Proof

`N/A` — no UI surface changes. The only user-visible difference is the command a resumed pane launches with.

## Testing

`pnpm typecheck`, `pnpm lint` and `pnpm build` pass locally on macOS. `pnpm test` reports 8 failures across 5 files (`wsl-exec-mode-separator`, `shell-startup-feature-channel`, `pty-subprocess-env-inheritance`, an `ssh-remote-commands` 30s timeout, and one order-dependent `feature-interactions` case) — all of them fail identically on unmodified `main` on this machine, which I verified by re-running the same files from a clean checkout. The suites this change touches — `src/shared`, `src/renderer/src/lib`, `src/renderer/src/components/terminal-pane`, 1326 files — pass in full.

New tests:

- `src/shared/agent-resume-permission-drop.test.ts` — 13 cases: drop, keep-while-granted, keep-when-the-command-override-carries-it, non-permission flags preserved, never-add, repeated occurrences, behind `--`, unparseable command fails open, PowerShell-quoted recorded command, multi-token escalation (`--approval-mode yolo`), and the `GOOSE_MODE` env variant (dropped, kept, and a non-escalation var left alone).
- `src/renderer/src/lib/sleeping-agent-session-launch-permission-drop.test.ts` — the sidebar resume launches `claude '--resume' '<id>'` once the setting is cleared, and keeps the flag while it is not. Also pins the `agentArgsOverride` that gets forwarded to a remote host.
- `pty-connection-cold-restore-agent-resume.test.ts` — the app-restart path cold-restores a recorded Codex pane as `codex 'resume' '<id>'`.

Reviewer steps: launch an agent pane with Agent Permissions on Yolo, quit Orca, switch Agent Permissions to Manual (or clear that agent's args), reopen Orca, and check the resumed pane's command — before this change it still carries the escalation flag.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Not yet exercised by hand in a packaged build; the three automated tests cover both resume paths end to end from the store state a restart actually produces.

## AI Disclosure

Written with Claude Code (Claude Opus 5). Investigation, implementation and tests were reviewed by me.

## Review

- **Security**: strictly permission-reducing. The only new code path removes an escalation; there is no branch that can add one, and every ambiguous case falls back to the recorded config.
- **Cross-platform**: the splice runs through `tokenizeStartupCommand` with the resume target's shell, so cmd.exe, PowerShell and posix recorded commands are each parsed by their own tokenizer, and any token flagged `divergesFromShell` aborts the splice for that string. Covered by a PowerShell case in the unit tests; the existing Windows-quoting resume suites still pass.
- **Remote / SSH**: no filesystem or host access added. Both call sites already resolve the resume target's platform and shell (`resolveAgentResumeLaunchTarget`), and the de-escalated `agentArgs` is what the remote path forwards as `agentArgsOverride`, so a remote host receives the same reduction. No wire shape changed.
- **Mobile**: mobile wake resumes through `launchSleepingAgentSession`, so it inherits the same behavior; no mobile-specific code touched.
- **Backwards compatibility**: persisted `SleepingAgentLaunchConfig` shape is unchanged, and a record with no `launchConfig` keeps taking the current-settings path exactly as before.
- **Performance**: one tokenizer pass over two short strings, only on a resume that has a recorded launch config.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance — covered in Review above.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck` and `pnpm build` pass; `pnpm test` passes apart from the 8 pre-existing failures noted under Testing (identical on unmodified `main` here)
