### PR TITLE
fix(settings): offer Remove on path-bound host setups, behind a confirm

### DIFF
--- a/src/renderer/src/components/settings/RepositoryHostSetupsSection.test.tsx
+++ b/src/renderer/src/components/settings/RepositoryHostSetupsSection.test.tsx
@@ -14,6 +14,16 @@ import type { Repo } from '../../../../shared/repo-types'
 import { useAppStore } from '../../store'
 import { RepositoryHostSetupsSection } from './RepositoryHostSetupsSection'
 
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? <div>{children}</div> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>
+}))
+
 let container: HTMLDivElement
 let root: Root
 
@@ -395,9 +405,11 @@ describe('RepositoryHostSetupsSection', () => {
     renderSection(localRepo)
 
     expect(container.textContent).toContain('Path pending')
-    const removeButton = Array.from(container.querySelectorAll('button')).find(
-      (button) => button.textContent === 'Remove'
-    )
+    // The bound local row also carries a Remove now (it opens the confirm
+    // dialog), so target the pending row's button by skipping the current row.
+    const removeButton = Array.from(container.querySelectorAll('button'))
+      .filter((button) => button.textContent === 'Remove')
+      .find((button) => !button.closest('[data-current]'))
     expect(removeButton).toBeTruthy()
 
     await act(async () => {
@@ -407,6 +419,111 @@ describe('RepositoryHostSetupsSection', () => {
     expect(deleteProjectHostSetup).toHaveBeenCalledWith({ setupId: 'gpu-setup' })
     expect(openSettingsPage).not.toHaveBeenCalled()
     expect(openSettingsTarget).not.toHaveBeenCalled()
+  })
+
+  it('confirms before removing a host setup that is bound to a path', async () => {
+    const deleteProjectHostSetup = vi.fn().mockResolvedValue({
+      project: makeProject({ id: 'github:stablyai/orca' }),
+      setup: makeSetup({
+        id: 'local-repo',
+        projectId: 'github:stablyai/orca',
+        repoId: 'local-repo',
+        hostId: 'local',
+        path: '/Users/alice/orca'
+      })
+    })
+    const localRepo = makeRepo({
+      id: 'local-repo',
+      displayName: 'Orca',
+      path: '/Users/alice/orca'
+    })
+    useAppStore.setState({
+      repos: [localRepo],
+      projects: [makeProject({ id: 'github:stablyai/orca' })],
+      projectHostSetups: [
+        makeSetup({
+          id: 'local-repo',
+          projectId: 'github:stablyai/orca',
+          repoId: 'local-repo',
+          hostId: 'local',
+          path: '/Users/alice/orca'
+        }),
+        makeSetup({
+          id: 'gpu-setup',
+          projectId: 'github:stablyai/orca',
+          repoId: 'gpu-repo',
+          hostId: 'runtime:gpu',
+          path: '/home/alice/orca'
+        })
+      ],
+      deleteProjectHostSetup
+    })
+
+    renderSection(localRepo)
+
+    const removeButtons = Array.from(container.querySelectorAll('button')).filter(
+      (button) => button.textContent === 'Remove'
+    )
+    expect(removeButtons.length).toBe(2)
+
+    await act(async () => {
+      removeButtons[0]?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(deleteProjectHostSetup).not.toHaveBeenCalled()
+    expect(container.textContent).toContain('Remove this host setup?')
+    expect(container.textContent).toContain('/Users/alice/orca')
+
+    clickButton('Remove setup')
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(deleteProjectHostSetup).toHaveBeenCalledWith({ setupId: 'local-repo' })
+  })
+
+  it('keeps a bound host setup when the removal confirmation is cancelled', async () => {
+    const deleteProjectHostSetup = vi.fn().mockResolvedValue(null)
+    const localRepo = makeRepo({
+      id: 'local-repo',
+      displayName: 'Orca',
+      path: '/Users/alice/orca'
+    })
+    useAppStore.setState({
+      repos: [localRepo],
+      projects: [makeProject({ id: 'github:stablyai/orca' })],
+      projectHostSetups: [
+        makeSetup({
+          id: 'local-repo',
+          projectId: 'github:stablyai/orca',
+          repoId: 'local-repo',
+          hostId: 'local',
+          path: '/Users/alice/orca'
+        }),
+        makeSetup({
+          id: 'gpu-setup',
+          projectId: 'github:stablyai/orca',
+          repoId: 'gpu-repo',
+          hostId: 'runtime:gpu',
+          path: '/home/alice/orca'
+        })
+      ],
+      deleteProjectHostSetup
+    })
+
+    renderSection(localRepo)
+
+    const removeButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Remove'
+    )
+    await act(async () => {
+      removeButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(container.textContent).toContain('Remove this host setup?')
+    clickButton('Cancel')
+    expect(deleteProjectHostSetup).not.toHaveBeenCalled()
+    expect(container.textContent).not.toContain('Remove this host setup?')
   })
 
   it('sets up the project on another known host from an existing folder path', async () => {

--- a/src/renderer/src/components/settings/RepositoryHostSetupsSection.tsx
+++ b/src/renderer/src/components/settings/RepositoryHostSetupsSection.tsx
@@ -22,6 +22,7 @@ import type { SettingsSearchEntry } from './settings-search'
 import { translate } from '@/i18n/i18n'
 import { buildSetupHostOptions, getSetupStateLabel } from './repository-host-setup-options'
 import { RepositoryHostSetupActions } from './RepositoryHostSetupActions'
+import { SshDestructiveActionDialog } from './SshDestructiveActionDialog'
 import {
   selectRuntimeAwareSshStatus,
   selectRuntimeAwareSshTargetLabel
@@ -135,6 +136,7 @@ export function RepositoryHostSetupsSection({
   })
   const hostOptionById = new Map(hostOptions.map((option) => [option.id, option]))
   const [deletingSetupId, setDeletingSetupId] = useState<string | null>(null)
+  const [confirmRemoveSetup, setConfirmRemoveSetup] = useState<ProjectHostSetup | null>(null)
   const projectId = selectedProjectHostSetup?.projectId
   // Why: the single project pane switches host in place — set the ephemeral
   // per-project selection instead of navigating to a separate repo section.
@@ -305,7 +307,20 @@ export function RepositoryHostSetupsSection({
               : (hostOptionById.get(setup.hostId)?.label ?? getExecutionHostLabel(setup.hostId))
           const isCurrentSetup = setup.id === selectedProjectHostSetup?.id
           const canOpenSetup = setup.repoId.trim().length > 0
-          const canRemoveSetup = !canOpenSetup && deletingSetupId !== setup.id
+          const canRemoveSetup = deletingSetupId !== setup.id
+          // Why (#15281): a repo-backed path cannot be edited in place (the store
+          // rejects path updates on bound setups and expects re-import), so Remove
+          // is the only recovery for a setup pointed at the wrong folder — and it
+          // must be reachable on the bound row, not just the path-pending one.
+          const removeSetup = async (): Promise<void> => {
+            if (!canOpenSetup) {
+              setDeletingSetupId(setup.id)
+              await deleteProjectHostSetup({ setupId: setup.id })
+              setDeletingSetupId(null)
+              return
+            }
+            setConfirmRemoveSetup(setup)
+          }
           return (
             <div
               key={setup.id}
@@ -363,10 +378,8 @@ export function RepositoryHostSetupsSection({
                   type="button"
                   variant="outline"
                   size="sm"
-                  onClick={async () => {
-                    setDeletingSetupId(setup.id)
-                    await deleteProjectHostSetup({ setupId: setup.id })
-                    setDeletingSetupId(null)
+                  onClick={() => {
+                    void removeSetup()
                   }}
                 >
                   {translate('auto.components.settings.RepositoryPane.removeSetup', 'Remove')}
@@ -387,6 +400,48 @@ export function RepositoryHostSetupsSection({
           onSetupReady={selectHost}
         />
       ) : null}
+      <SshDestructiveActionDialog
+        open={confirmRemoveSetup !== null}
+        title={translate(
+          'auto.components.settings.RepositoryPane.removeHostSetupTitle',
+          'Remove this host setup?'
+        )}
+        description={translate(
+          'auto.components.settings.RepositoryPane.removeHostSetupDescription',
+          'Orca forgets this project on that host, including its workspace registrations. Nothing is deleted from the host itself. You can add the project back with "Add to another host".'
+        )}
+        targetLabel={
+          confirmRemoveSetup
+            ? `${
+                hostOptionById.get(confirmRemoveSetup.hostId)?.label ??
+                getExecutionHostLabel(confirmRemoveSetup.hostId)
+              }${confirmRemoveSetup.path ? ` — ${confirmRemoveSetup.path}` : ''}`
+            : undefined
+        }
+        actionLabel={translate(
+          'auto.components.settings.RepositoryPane.removeHostSetupConfirm',
+          'Remove setup'
+        )}
+        isBusy={confirmRemoveSetup !== null && deletingSetupId === confirmRemoveSetup.id}
+        onOpenChange={(nextOpen) => {
+          if (!nextOpen) {
+            setConfirmRemoveSetup(null)
+          }
+        }}
+        onConfirm={async () => {
+          if (!confirmRemoveSetup) {
+            return
+          }
+          const setup = confirmRemoveSetup
+          setDeletingSetupId(setup.id)
+          try {
+            await deleteProjectHostSetup({ setupId: setup.id })
+          } finally {
+            setDeletingSetupId(null)
+            setConfirmRemoveSetup(null)
+          }
+        }}
+      />
     </SearchableSetting>
   )
 }

--- a/src/renderer/src/components/settings/RepositoryHostSetupsSection.tsx
+++ b/src/renderer/src/components/settings/RepositoryHostSetupsSection.tsx
@@ -315,8 +315,11 @@ export function RepositoryHostSetupsSection({
           const removeSetup = async (): Promise<void> => {
             if (!canOpenSetup) {
               setDeletingSetupId(setup.id)
-              await deleteProjectHostSetup({ setupId: setup.id })
-              setDeletingSetupId(null)
+              try {
+                await deleteProjectHostSetup({ setupId: setup.id })
+              } finally {
+                setDeletingSetupId(null)
+              }
               return
             }
             setConfirmRemoveSetup(setup)


### PR DESCRIPTION
## Summary

**What**

The "Available Hosts" section in Settings → Repository now offers **Remove** on host setups that are bound to a folder path, not only on "Path pending" rows. Deleting a bound setup goes through a confirmation dialog (the shared `SshDestructiveActionDialog`) that names the host and the path; path-pending setups keep the existing immediate removal.

**Why**

#15281 — a user who points a host setup at the wrong folder cannot fix it. `RepositoryHostSetupsSection` gated the Remove button on `!canOpenSetup`, i.e. only setups *without* a path could be removed. A bound setup got only "Open", and editing the path in place is not an option by design — `updateRepoBackedProjectHostSetup` explicitly rejects path changes on repo-backed setups ("must be changed by re-importing the project"). So Remove-and-readd is the only recovery path, and the UI made it unreachable: a dead end with no escape.

The backend (`deleteProjectHostSetup`) and the renderer store action both fully support bound-setup deletion — they unregister that host's repo row and clean up dependent projects/presets — so this is purely a missing affordance.

**How**

- `canRemoveSetup` now depends only on the in-flight delete state, so bound rows render Remove.
- Clicking Remove on a bound row opens `SshDestructiveActionDialog` instead of deleting immediately, because deletion unregisters that host's repo (workspace registrations included; nothing on the host's filesystem is touched). The dialog shows the host label and setup path, and stays honest about what happens: "Orca forgets this project on that host… You can add the project back with 'Add to another host'."
- Path-pending setups keep the immediate removal — that path drops metadata only and was already unconfirmed.

**Testing**

- New: `confirms before removing a host setup that is bound to a path` — two bound rows each render Remove; clicking the current row's Remove opens the confirm dialog instead of deleting; confirming calls `deleteProjectHostSetup({ setupId })`.
- New: `keeps a bound host setup when the removal confirmation is cancelled` — Cancel closes the dialog, no deletion, row intact.
- Updated: `removes independent setup metadata instead of opening an empty repo target` — the button finder now targets the pending row's Remove (the bound current row also carries one now); the immediate-removal behavior it asserts is unchanged.
- `RepositoryHostSetupsSection.test.tsx` 13/13, `RepositoryHostSetupsSection.workspace-window.test.tsx` 4/4, `pnpm run typecheck` clean.

Fixes #15281