### PR TITLE
fix(runtime): forward the client's resolved agent args to paired hosts

### DIFF
--- a/src/renderer/src/lib/launch-agent-in-new-tab-web-runtime.test.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab-web-runtime.test.ts
@@ -93,6 +93,9 @@ describe('launchAgentInNewTab paired web runtime', () => {
       activate: true,
       agentSessionKind: 'fresh',
       agent: 'claude',
+      // Why: an unconfigured client still resolves the default explicitly, so
+      // the host applies this client's launch defaults rather than its own.
+      agentArgs: '--dangerously-skip-permissions',
       viewMode: 'terminal'
     })
     expect(mocks.createTab).not.toHaveBeenCalled()
@@ -131,8 +134,30 @@ describe('launchAgentInNewTab paired web runtime', () => {
       startupCommandDelivery: 'shell-ready',
       prompt: 'fix the spinner',
       promptDelivery: 'auto-submit',
+      agentArgs: '--model gpt-5 --reasoning-effort high',
       viewMode: 'terminal'
     })
     expect(mocks.createTab).not.toHaveBeenCalled()
+  })
+
+  it('sends an explicit empty agentArgs override when the client is configured for Manual', async () => {
+    // Why (#15373): Manual is stored as an empty-string entry; without it riding
+    // along, a headless host re-resolved its own defaults and relaunched YOLO.
+    store.settings.agentDefaultArgs = { claude: '' }
+    const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
+
+    const result = launchAgentInNewTab({
+      agent: 'claude',
+      worktreeId: 'wt-1',
+      groupId: 'group-1'
+    })
+
+    expect(result).toEqual(expect.objectContaining({ tabId: null }))
+    expect(mocks.createWebRuntimeSessionTerminal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent: 'claude',
+        agentArgs: ''
+      })
+    )
   })
 })

--- a/src/renderer/src/lib/launch-agent-in-new-tab.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.ts
@@ -157,7 +157,12 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
       promptDelivery,
       pastePromptAfterReady: pasteDraftAfterLaunch,
       submitPastedPrompt,
-      agentArgs,
+      // Why: the raw param is undefined on ordinary UI launches, and omitting it
+      // lets a headless host apply its own defaults — so a client configured for
+      // Manual gets the host's YOLO default (#15373). Send the client-resolved
+      // value, empty string included: the host treats present-but-empty as an
+      // explicit no-args override.
+      agentArgs: effectiveAgentArgs,
       // Why: omission means terminal locally, but would let a paired host apply
       // its own default; send the client's resolved terminal choice explicitly.
       viewMode: initialViewModeProps.viewMode ?? 'terminal',


### PR DESCRIPTION
## Summary

**What**

`launchAgentInWebHostTab` now receives the client-resolved `effectiveAgentArgs` (empty string included) instead of the raw `agentArgs` launch parameter, so an agent quick-launch against a paired headless host always carries this client's permission args.

**Why**

#15373 — agent tabs opened on a Remote Orca Server always come up in YOLO, ignoring the client's Settings → AI Capabilities → Agents → Agent Permissions.

The chain:

- Manual is stored client-side as an explicit empty-string entry in `agentDefaultArgs` (`applyAgentPermissionMode` writes `''`), and `resolveTuiAgentLaunchArgs` only falls back to the YOLO default when the key is absent.
- For local tabs the resolved args are baked into the startup command, so local launches honor the setting.
- For a paired host the client delegates: `launch-agent-in-new-tab.ts` passed the **raw** `agentArgs` parameter to `launchAgentInWebHostTab` — `undefined` on ordinary UI launches — so the field was omitted from the host RPC. A prompt-less launch sends no `command` either, just `{ agent }`.
- The host's create path (`terminal.createAgentSession`) treats absent `agentArgs` as "use host settings": `resolveTuiAgentLaunchArgs(agent, settings.agentDefaultArgs)` against the **server's** settings, which are unset on a fresh server — and unset resolves to `DEFAULT_TUI_AGENT_ARGS`, which is the YOLO flag table. Hence always-YOLO on remote hosts, from both Desktop and Web clients (`isWebRuntimeSessionActive` covers both: headless serve sessions are host-owned whether the client is web or Electron).

The host contract was already right — `request.agentArgs !== undefined ? request.agentArgs : host-default` honors present-but-empty as an explicit no-args override — the client just never sent its resolved value.

**How**

One-line change at the `launchAgentInWebHostTab` call site plus the comment documenting why omission is load-bearing. No server changes.

**Testing**

- New: `sends an explicit empty agentArgs override when the client is configured for Manual` — `agentDefaultArgs = { claude: '' }` → host RPC payload contains `agentArgs: ''`.
- Updated: `delegates agent quick launch to the host runtime` — an unconfigured client now sends its resolved default explicitly (`'--dangerously-skip-permissions'`), documenting that the host applies the client's launch defaults rather than its own; `forwards prompt launch env and captured config…` — the configured args also ride as a top-level `agentArgs`.
- `launch-agent-in-new-tab-web-runtime.test.ts` 3/3; sibling suites (`launch-agent-in-new-tab.test.ts` 27, `-cwd`, `-windows-quoting`, `launch-agent-session-continuation`) 43/43; `pnpm run typecheck` clean.

Fixes #15373