### PR TITLE
fix(worktrees): stop separator-variant worktree ids purging live checkouts

### DIFF
--- a/src/main/worktree-lineage-pruning.test.ts
+++ b/src/main/worktree-lineage-pruning.test.ts
@@ -78,6 +78,44 @@ describe('pruneLineageForMissingRepoWorktrees', () => {
     expect(workspaceLineageByChildKey[worktreeWorkspaceKey(childId)]).toBe(workspaceEdge)
   })
 
+  it('keeps lineage whose worktree id only differs by path separator spelling (#15598)', () => {
+    const repoOnWindows: Repo = { ...repo, path: 'D:/Agentic/game2' }
+    const parentId = 'repo-1::D:' + String.fromCharCode(92) + 'Agentic' + String.fromCharCode(92) + 'game2'
+    const childId = 'repo-1::D:/Agentic/game2/battle-core'
+    const edge = lineage(childId, parentId)
+    const worktreeLineageById = { [childId]: edge }
+    const workspaceLineageByChildKey = {
+      [worktreeWorkspaceKey(childId)]: workspaceLineage(childId, parentId)
+    }
+    const metaById = {
+      [parentId]: { instanceId: edge.parentWorktreeInstanceId } as WorktreeMeta
+    }
+    const store = createStore(worktreeLineageById, workspaceLineageByChildKey, metaById)
+
+    // Git reports Windows paths with forward slashes; the stored parent id
+    // carries backslashes from a pre-restart registration.
+    pruneLineageForMissingRepoWorktrees(store as never, repoOnWindows, [
+      {
+        path: 'D:/Agentic/game2',
+        head: 'a',
+        branch: 'main',
+        isBare: false,
+        isMainWorktree: true
+      },
+      {
+        path: 'D:/Agentic/game2/battle-core',
+        head: 'b',
+        branch: 'battle-core',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    expect(store.removeWorktreeLineage).not.toHaveBeenCalled()
+    expect(store.removeWorkspaceLineage).not.toHaveBeenCalled()
+    expect(store.setWorktreeMeta).not.toHaveBeenCalled()
+  })
+
   it('prunes missing children and rotates missing parents after a trusted non-empty scan', () => {
     const liveParentId = 'repo-1::/repo/live-parent'
     const missingChildId = 'repo-1::/repo/missing-child'

--- a/src/main/worktree-lineage-pruning.ts
+++ b/src/main/worktree-lineage-pruning.ts
@@ -3,6 +3,7 @@ import type { Repo } from '../shared/repo-types'
 import type { WorkspaceLineage, WorktreeLineage } from '../shared/worktree/lineage-types'
 import type { GitWorktreeInfo } from '../shared/worktree/types'
 import { getRepoExecutionHostId } from '../shared/execution-host'
+import { worktreeIdComparisonKey } from '../shared/worktree/id'
 import { isWorkspaceKey, parseWorkspaceKey, worktreeWorkspaceKey } from '../shared/workspace-scope'
 import type { Store } from './persistence'
 
@@ -56,6 +57,18 @@ export function pruneLineageForMissingRepoWorktrees(
     return
   }
   const liveIds = new Set(gitWorktrees.map((worktree) => `${repo.id}::${worktree.path}`))
+  // Why (#15598): git reports Windows paths with forward slashes while stored
+  // lineage keys can carry backslashes; exact-only membership would prune the
+  // lineage (and rotate the parent's instance) of a checkout that never went
+  // anywhere. An id is live when either spelling matches.
+  const liveComparisonKeys = new Set(
+    [...liveIds]
+      .map((id) => worktreeIdComparisonKey(id))
+      .filter((key): key is string => key !== null)
+  )
+  const isLiveWorktreeId = (worktreeId: string): boolean =>
+    liveIds.has(worktreeId) ||
+    liveComparisonKeys.has(worktreeIdComparisonKey(worktreeId) ?? worktreeId)
   const expectedHostId = getRepoExecutionHostId(repo)
   const repoOwners = store.getRepos().filter((candidate) => candidate.id === repo.id)
   const canMutateWorktree = (worktreeId: string): boolean => {
@@ -68,7 +81,7 @@ export function pruneLineageForMissingRepoWorktrees(
       childScope?.type === 'worktree' &&
       worktreeIdBelongsToRepo(childScope.worktreeId, repoPrefix) &&
       canMutateWorktree(childScope.worktreeId) &&
-      !liveIds.has(childScope.worktreeId) &&
+      !isLiveWorktreeId(childScope.worktreeId) &&
       isWorkspaceKey(childWorkspaceKey)
     ) {
       store.removeWorkspaceLineage?.(childWorkspaceKey)
@@ -78,7 +91,7 @@ export function pruneLineageForMissingRepoWorktrees(
     if (
       worktreeIdBelongsToRepo(childId, repoPrefix) &&
       canMutateWorktree(childId) &&
-      !liveIds.has(childId)
+      !isLiveWorktreeId(childId)
     ) {
       // Why: a proven-missing path must not transfer its lineage to a future checkout at that path.
       store.removeWorktreeLineage(childId)
@@ -87,7 +100,7 @@ export function pruneLineageForMissingRepoWorktrees(
     if (
       worktreeIdBelongsToRepo(lineage.parentWorktreeId, repoPrefix) &&
       canMutateWorktree(lineage.parentWorktreeId) &&
-      !liveIds.has(lineage.parentWorktreeId)
+      !isLiveWorktreeId(lineage.parentWorktreeId)
     ) {
       const parentMeta = store.getWorktreeMeta(lineage.parentWorktreeId)
       if (!parentMeta || parentMeta.instanceId === lineage.parentWorktreeInstanceId) {

--- a/src/renderer/src/store/slices/worktrees/listing/worktree-host-ownership-purge.test.ts
+++ b/src/renderer/src/store/slices/worktrees/listing/worktree-host-ownership-purge.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import type { DetectedWorktreeListResult } from '../../../../../../shared/worktree/types'
+import { getRemovedWorktreeIdsAfterAuthoritativeScan } from './worktree-host-ownership'
+
+const repo = {
+  id: 'repo-1',
+  path: 'D:/Agentic/game2',
+  displayName: 'game2',
+  badgeColor: 'blue',
+  addedAt: 1
+}
+
+const WINDOWS_BACKSLASH_ID =
+  'repo-1::D:' + String.fromCharCode(92) + 'Agentic' + String.fromCharCode(92) + 'game2'
+const WINDOWS_FORWARD_SLASH_ID = 'repo-1::D:/Agentic/game2'
+
+function stateWithKnownDetected(worktreeIds: string[]) {
+  return {
+    repos: [repo],
+    detectedWorktreesByRepo: {
+      'repo-1': {
+        repoId: 'repo-1',
+        authoritative: true,
+        worktrees: worktreeIds.map((id) => ({ id }))
+      }
+    },
+    worktreesByRepo: {},
+    hasHydratedWorktreePurge: true
+  }
+}
+
+function authoritativeScan(worktreeIds: string[]): DetectedWorktreeListResult {
+  return {
+    repoId: 'repo-1',
+    authoritative: true,
+    source: 'git',
+    worktrees: worktreeIds.map((id) => ({ id, ownership: 'orca-managed', selectedCheckout: false, visible: true }))
+  } as unknown as DetectedWorktreeListResult
+}
+
+describe('getRemovedWorktreeIdsAfterAuthoritativeScan', () => {
+  it('does not purge a known worktree whose id differs only by path separator spelling (#15598)', () => {
+    const state = stateWithKnownDetected([WINDOWS_BACKSLASH_ID])
+
+    const removed = getRemovedWorktreeIdsAfterAuthoritativeScan(
+      state as never,
+      'repo-1',
+      authoritativeScan([WINDOWS_FORWARD_SLASH_ID]),
+      'local'
+    )
+
+    // The backslash spelling was written by an earlier registration of the same
+    // checkout; purging it force-kills the terminals still bound to it.
+    expect(removed).toEqual([])
+  })
+
+  it('still purges a worktree that is genuinely gone from the scan', () => {
+    const state = stateWithKnownDetected([WINDOWS_FORWARD_SLASH_ID, 'repo-1::D:/Agentic/gone'])
+
+    const removed = getRemovedWorktreeIdsAfterAuthoritativeScan(
+      state as never,
+      'repo-1',
+      authoritativeScan([WINDOWS_FORWARD_SLASH_ID]),
+      'local'
+    )
+
+    expect(removed).toEqual(['repo-1::D:/Agentic/gone'])
+  })
+
+  it('still purges separator variants when the checkout is no longer scanned at all', () => {
+    const state = stateWithKnownDetected([WINDOWS_BACKSLASH_ID])
+
+    const removed = getRemovedWorktreeIdsAfterAuthoritativeScan(
+      state as never,
+      'repo-1',
+      authoritativeScan(['repo-1::D:/Agentic/other-checkout']),
+      'local'
+    )
+
+    expect(removed).toEqual([WINDOWS_BACKSLASH_ID])
+  })
+})

--- a/src/renderer/src/store/slices/worktrees/listing/worktree-host-ownership.ts
+++ b/src/renderer/src/store/slices/worktrees/listing/worktree-host-ownership.ts
@@ -4,6 +4,7 @@ import type { DetectedWorktreeListResult, Worktree } from '../../../../../../sha
 import { findRepoForHost } from '../../repo-host-identity'
 import { reuseEqualCatalogRows } from '../../worktree-catalog-reconciliation'
 import { getRepoIdFromWorktreeId } from '../../worktree-helpers'
+import { worktreeIdComparisonKey } from '../../../../../../shared/worktree/id'
 import {
   getRepoExecutionHostId,
   LOCAL_EXECUTION_HOST_ID,
@@ -272,7 +273,22 @@ export function getRemovedWorktreeIdsAfterAuthoritativeScan(
     return []
   }
   const detectedIds = new Set(detected.worktrees.map((worktree) => worktree.id))
-  return getKnownWorktreeIdsForPurge(state, repoId, hostId).filter((id) => !detectedIds.has(id))
+  // Why (#15598): the same Windows checkout can be keyed with backslashes by
+  // the app and forward slashes by git; a purge decided by exact id alone
+  // force-kills live terminals of the other spelling. A known id survives
+  // when either its exact id or its path-normalized key is still detected.
+  const detectedComparisonKeys = new Set(
+    detected.worktrees
+      .map((worktree) => worktreeIdComparisonKey(worktree.id))
+      .filter((key): key is string => key !== null)
+  )
+  return getKnownWorktreeIdsForPurge(state, repoId, hostId).filter((id) => {
+    if (detectedIds.has(id)) {
+      return false
+    }
+    const comparisonKey = worktreeIdComparisonKey(id)
+    return comparisonKey === null || !detectedComparisonKeys.has(comparisonKey)
+  })
 }
 
 export function toLegacyDetectedWorktreeResult(

--- a/src/shared/worktree/id.test.ts
+++ b/src/shared/worktree/id.test.ts
@@ -4,7 +4,8 @@ import {
   getRepoIdFromWorktreeId,
   getWorktreePathBasenameFromId,
   splitWorktreeId,
-  splitWorktreeIdForFilesystem
+  splitWorktreeIdForFilesystem,
+  worktreeIdComparisonKey
 } from './id'
 
 describe('WORKTREE_ID_SEPARATOR', () => {
@@ -117,5 +118,28 @@ describe('getWorktreePathBasenameFromId', () => {
   it('returns null when no worktree path is available', () => {
     expect(getWorktreePathBasenameFromId('repo-123')).toBeNull()
     expect(getWorktreePathBasenameFromId('repo-123::')).toBeNull()
+  })
+})
+
+describe('worktreeIdComparisonKey', () => {
+  const BACKSLASH = 'repo-1::D:' + String.fromCharCode(92) + 'Agentic' + String.fromCharCode(92) + 'game2'
+  const FORWARD = 'repo-1::D:/Agentic/game2'
+
+  it('folds Windows separator and drive-letter spelling of one checkout (#15598)', () => {
+    expect(worktreeIdComparisonKey(BACKSLASH)).toBe(worktreeIdComparisonKey(FORWARD))
+  })
+
+  it('keeps distinct repos, paths, and folder-workspace instances distinct', () => {
+    const key = worktreeIdComparisonKey(FORWARD)
+    expect(worktreeIdComparisonKey('repo-2::D:/Agentic/game2')).not.toBe(key)
+    expect(worktreeIdComparisonKey('repo-1::D:/Agentic/game2/battle-core')).not.toBe(key)
+    expect(
+      worktreeIdComparisonKey('repo-1::D:/Agentic/game2::workspace:123e4567-e89b-12d3-a456-426614174000')
+    ).not.toBe(key)
+  })
+
+  it('returns null for malformed ids', () => {
+    expect(worktreeIdComparisonKey('repo-1')).toBeNull()
+    expect(worktreeIdComparisonKey('repo-1::')).toBeNull()
   })
 })

--- a/src/shared/worktree/id.ts
+++ b/src/shared/worktree/id.ts
@@ -1,4 +1,5 @@
 import { WORKTREE_ID_SEPARATOR } from '../pty-session-id-format'
+import { normalizeRuntimePathForComparison } from '../cross-platform-path'
 
 export { WORKTREE_ID_SEPARATOR } from '../pty-session-id-format'
 
@@ -15,6 +16,31 @@ const FOLDER_WORKSPACE_INSTANCE_SUFFIX = new RegExp(
 export function getRepoIdFromWorktreeId(worktreeId: string): string {
   const separatorIdx = worktreeId.indexOf(WORKTREE_ID_SEPARATOR)
   return separatorIdx === -1 ? worktreeId : worktreeId.slice(0, separatorIdx)
+}
+
+/**
+ * Canonical comparison form of a worktree id: one repo, one filesystem
+ * location, one folder-workspace instance — regardless of separator or
+ * drive-letter spelling.
+ *
+ * Why (#15598): git reports Windows paths with forward slashes while
+ * app-written ids can carry backslashes, so the same checkout can sit in
+ * `worktreeMeta` under two spellings. Exact-string set membership then
+ * declares the other spelling "removed" on an authoritative scan, which purges
+ * its terminals (force-kill) and lineage for a checkout that never went
+ * anywhere. Comparison only — never persist or return this key.
+ *
+ * Returns null for malformed ids so callers can keep their exact-match
+ * behavior for them.
+ */
+export function worktreeIdComparisonKey(worktreeId: string): string | null {
+  const parsed = splitWorktreeId(worktreeId)
+  if (!parsed || !parsed.repoId || !parsed.worktreePath) {
+    return null
+  }
+  return `${parsed.repoId}${WORKTREE_ID_SEPARATOR}${normalizeRuntimePathForComparison(
+    parsed.worktreePath
+  )}`
 }
 
 export function splitWorktreeId(worktreeId: string): ParsedWorktreeId | null {


### PR DESCRIPTION
## Summary

**What**

Two exact-string worktree-id membership checks now compare through a new shared `worktreeIdComparisonKey` (`src/shared/worktree/id.ts`), which folds separator and drive-letter spelling via the existing `normalizeRuntimePathForComparison`:

- `getRemovedWorktreeIdsAfterAuthoritativeScan` (renderer) — a known id survives an authoritative scan when either its exact id or its normalized key is still detected.
- `pruneLineageForMissingRepoWorktrees` (main) — a lineage child/parent is "live" when either spelling appears in the git worktree list.

**Why**

#15598 — on Windows the same checkout ends up in `worktreeMeta` under two spellings (`repo::D:\Agentic\game2` from an app-written registration, `repo::D:/Agentic/game2` from git). The reporter's forensics show the exact failure: a Claude Code coordinator survived a restart attached to the backslash entry; when its fleet created a child worktree, the fresh authoritative scan listed only the forward-slash id, `getRemovedWorktreeIdsAfterAuthoritativeScan` declared the backslash id removed, and the renderer purge force-killed the live pane (`session-killed ... immediate:true`) 543 ms later. The same exact-match shape in the lineage pruner would delete the lineage and rotate the parent's instanceId for a checkout that never went anywhere.

`normalizeRuntimePathForComparison` already exists for exactly this class of mismatch (added for session attribution in #10832: separator folding, Windows case folding, NFC); this PR points the two worktree-id set-membership sites at the same contract through one shared key. Distinct repos, distinct paths, and distinct folder-workspace instances remain distinct; malformed ids keep the exact-match behavior; genuinely-missing checkouts purge exactly as before.

**Not in scope** (per the issue's expectations, worth their own follow-ups): merging/canonicalizing the duplicate `worktreeMeta` entries themselves at load, and the broader "reconciliation should never force-kill" question — this PR removes the wrongful purge trigger, not the force-kill mechanism.

**Testing**

- `src/shared/worktree/id.test.ts` — new `worktreeIdComparisonKey` unit cases: backslash/forward-slash fold, repo/path/instance distinctness, malformed-id nulls. 24/24.
- `src/main/worktree-lineage-pruning.test.ts` — new case: git listing with forward-slash paths vs a backslash-keyed lineage keeps the lineage and does not rotate the parent instanceId (verified to fail on the pre-fix code). 3/3.
- New `worktree-host-ownership-purge.test.ts` — a backslash-spelled known id is not purged when the scan reports the forward-slash spelling; a genuinely-gone checkout still purges; a separator variant with no surviving scan row still purges (also verified to fail pre-fix). 3/3.
- Adjacent suites (`worktree-removal-maps-leak`, `bulk-worktree-purge-terminal-maps-leak`) 11/11; `pnpm run typecheck` clean.

Fixes #15598