### PR TITLE
fix(native-chat): stream an idle-agent reply below the prompt that caused it

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatView.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatView.tsx
@@ -21,6 +21,7 @@ import {
   appendPendingSendCache,
   launchPromptAsMessage,
   pendingSendsAsMessages,
+  splitPendingMessagesAroundStreaming,
   nextNativeChatPendingSendId,
   prunePendingSends,
   readPendingSendCache,
@@ -238,12 +239,16 @@ function NativeChatResolvedView({
         sentAt,
         afterMessageId: boundary?.id ?? null,
         afterMessageTimestamp: boundary?.timestamp ?? null,
+        // Why (#15608): a send into an idle agent is the newest turn — its reply
+        // must stream BELOW the echo. Only sends queued behind live work sort
+        // below the streaming bubble.
+        ...(liveWorking ? { queuedWhileWorking: true } : {}),
         ...(imagePaths ? { imagePaths } : {})
       }
       setPending(appendPendingSendCache(pendingScope, entry))
       return entry.id
     },
-    [pendingScope, session.messages]
+    [pendingScope, session.messages, liveWorking]
   )
   const onOptimisticSendCanceled = useCallback(
     (pendingId: string) => {
@@ -286,11 +291,17 @@ function NativeChatResolvedView({
     return new Set([id])
   }, [paneLaunchPrompt?.failed, launchPromptMessage?.id, sessionAfterCommandBoundaries.messages])
 
-  // The streaming preview bubble (if any) sits after the transcript but before
-  // the optimistic user echoes — same order mobile uses.
+  // The streaming preview bubble (if any) sits after the transcript. Where it
+  // sits relative to the optimistic echoes depends on WHY an echo is pending
+  // (#15608): a send into an idle agent is the newest turn, so its reply
+  // streams BELOW it; a send queued behind live work stays below the bubble.
   const pendingMessages = useMemo(
     () => pendingSendsAsMessages(pending, sessionAfterCommandBoundaries.messages),
     [pending, sessionAfterCommandBoundaries.messages]
+  )
+  const pendingAroundStreaming = useMemo(
+    () => splitPendingMessagesAroundStreaming(pendingMessages, pending),
+    [pendingMessages, pending]
   )
   const streamingText = useMemo(() => {
     return deriveNativeChatStreamingText({
@@ -311,11 +322,12 @@ function NativeChatResolvedView({
       messages: [
         ...sessionAfterCommandBoundaries.messages,
         ...commandMarkersAsMessages(commandMarkers),
+        ...pendingAroundStreaming.beforeStreaming,
         ...(streamingText ? [nativeChatStreamingMessage(streamingText)] : []),
-        ...pendingMessages
+        ...pendingAroundStreaming.afterStreaming
       ]
     }
-  }, [sessionAfterCommandBoundaries, pending, pendingMessages, commandMarkers, streamingText])
+  }, [sessionAfterCommandBoundaries, pendingAroundStreaming, commandMarkers, streamingText])
   // Derive the view state from the pending-augmented session so a send into an
   // otherwise-empty conversation flips to the list (showing the queued bubble)
   // instead of staying on the empty state.

--- a/src/renderer/src/components/native-chat/native-chat-pending.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.test.ts
@@ -12,6 +12,7 @@ import {
   readPendingSendCache,
   shouldPruneLaunchPrompt,
   writePendingSendCache,
+  splitPendingMessagesAroundStreaming,
   type NativeChatPendingSend
 } from './native-chat-pending'
 import {
@@ -806,5 +807,45 @@ describe('scope-cache key counts stay bounded (memory-leak regression)', () => {
     expect(readPendingSendCache({ paneKey: `tab-${CAP + 4}:leaf`, agent: 'claude' })).toHaveLength(
       1
     )
+  })
+})
+
+describe('splitPendingMessagesAroundStreaming', () => {
+  const entry = (id: string, queuedWhileWorking?: boolean): NativeChatPendingSend => ({
+    id,
+    text: id,
+    sentAt: 1,
+    ...(queuedWhileWorking ? { queuedWhileWorking: true } : {})
+  })
+  const message = (id: string): NativeChatMessage => ({
+    id: `pending:${id}`,
+    role: 'user',
+    blocks: [{ type: 'text', text: id }],
+    timestamp: 1,
+    source: 'scrape'
+  })
+
+  it('places an idle-time echo BEFORE the streaming bubble — the reply answers it (#15608)', () => {
+    const pending = [entry('idle-send')]
+    const messages = [message('idle-send')]
+    const split = splitPendingMessagesAroundStreaming(messages, pending)
+    expect(split.beforeStreaming.map((m) => m.id)).toEqual(['pending:idle-send'])
+    expect(split.afterStreaming).toEqual([])
+  })
+
+  it('keeps a send queued behind live work AFTER the streaming bubble', () => {
+    const pending = [entry('queued-send', true)]
+    const messages = [message('queued-send')]
+    const split = splitPendingMessagesAroundStreaming(messages, pending)
+    expect(split.beforeStreaming).toEqual([])
+    expect(split.afterStreaming.map((m) => m.id)).toEqual(['pending:queued-send'])
+  })
+
+  it('splits a mixed pending list while preserving relative order on both sides', () => {
+    const pending = [entry('idle-a'), entry('queued-b', true), entry('idle-c'), entry('queued-d', true)]
+    const messages = pending.map((e) => message(e.id))
+    const split = splitPendingMessagesAroundStreaming(messages, pending)
+    expect(split.beforeStreaming.map((m) => m.id)).toEqual(['pending:idle-a', 'pending:idle-c'])
+    expect(split.afterStreaming.map((m) => m.id)).toEqual(['pending:queued-b', 'pending:queued-d'])
   })
 })

--- a/src/renderer/src/components/native-chat/native-chat-pending.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.ts
@@ -40,6 +40,12 @@ export type NativeChatPendingSend = {
   matchingOccurrence?: number
   /** Shared time boundary when that message boundary is unavailable. */
   matchingAfterTimestamp?: number
+  /**
+   * True when the agent was already working when this send was issued. Such an
+   * echo is queued BEHIND the in-flight turn; an idle-time echo is the newest
+   * turn, and whatever streams after it is its reply (#15608).
+   */
+  queuedWhileWorking?: boolean
 }
 
 export type NativeChatPendingSendScope = {
@@ -265,6 +271,34 @@ export function pendingSendsAsMessages(
 /** True when a message id was minted for an optimistic pending send. */
 export function isPendingMessageId(id: string): boolean {
   return id.startsWith('pending:')
+}
+
+/**
+ * Split rendered optimistic echoes around the streaming reply bubble (#15608).
+ *
+ * An echo sent while the agent was idle is the newest turn of the conversation
+ * — the reply that streams next is its ANSWER, so the bubble belongs below it.
+ * An echo queued while the agent was already working waits behind that
+ * in-flight turn, so it stays below the bubble. The pending list order itself
+ * is preserved on both sides.
+ */
+export function splitPendingMessagesAroundStreaming(
+  pendingMessages: readonly NativeChatMessage[],
+  pending: readonly NativeChatPendingSend[]
+): { beforeStreaming: NativeChatMessage[]; afterStreaming: NativeChatMessage[] } {
+  const queuedWhileWorkingIds = new Set(
+    pending.filter((entry) => entry.queuedWhileWorking).map((entry) => `pending:${entry.id}`)
+  )
+  const beforeStreaming: NativeChatMessage[] = []
+  const afterStreaming: NativeChatMessage[] = []
+  for (const message of pendingMessages) {
+    if (queuedWhileWorkingIds.has(message.id)) {
+      afterStreaming.push(message)
+    } else {
+      beforeStreaming.push(message)
+    }
+  }
+  return { beforeStreaming, afterStreaming }
 }
 
 // Why: the seeded prompt has a synthetic id that never matches the real turn's,


### PR DESCRIPTION
## Summary

**What**

The desktop native-chat view now renders the streaming reply bubble **below** an optimistic user echo that was sent while the agent was idle, and keeps it **above** echoes that were queued while the agent was already working.

A pending send records `queuedWhileWorking` at issue time (`session.status === 'working'`), and the transcript merge splits the rendered echoes around the streaming bubble via a new pure helper, `splitPendingMessagesAroundStreaming` (`native-chat-pending.ts`).

**Why**

#15608 — sending a prompt to an idle agent rendered the streaming reply *above* the optimistic echo of that prompt, so the sent message sat stranded at the bottom of the transcript while its answer built above it. The old merge unconditionally placed the bubble before all echoes (the code comment even documented that order), which is correct only for sends queued behind an in-flight turn — for an idle-time send, the echo is the newest turn and the bubble is its *answer*.

**Scope**

Desktop chat view only, as called out in the issue: the mobile view reaches the same wrong order through its own mechanism and needs a separate change. This PR does not touch mobile.

**Testing**

- New unit cases in `native-chat-pending.test.ts` (pure module, no React): idle-time echo sorts before the bubble; queued-behind-work echo stays after; a mixed pending list splits while preserving relative order on both sides. 73/73 in the two pending suites.
- `NativeChatView.test.tsx` 5/5 unchanged; `pnpm run typecheck` clean.

Fixes the desktop half of #15608.