### PR TITLE
Gate paired-runtime terminal mounts on host snapshots

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -91,6 +91,7 @@ import {
   applyBackgroundMountTabRestriction,
   canDeferColdActivationTabsForHost,
   canMountTerminalWorkspaceForStartup,
+  deferTerminalTabsUntilHostSnapshot,
   planColdActivationTabDeferral,
   pruneClosedBackgroundMountTabs,
   revealActivationDeferredTabs,
@@ -156,6 +157,7 @@ import {
   createWebRuntimeSessionTerminal,
   isWebRuntimeSessionActive
 } from '@/runtime/web-runtime-session'
+import { hasAcceptedWebSessionTabsSnapshot } from '@/runtime/web-session-tabs-sync'
 import { openMobileEmulatorTab } from '@/lib/open-mobile-emulator-tab'
 import { launchAgentInNewTab } from '@/lib/launch-agent-in-new-tab'
 import { resumeSleepingAgentSessionsForWorktree } from '@/lib/resume-sleeping-agent-session'
@@ -1282,6 +1284,19 @@ function Terminal(): React.JSX.Element | null {
   ) {
     // Why: mounting every saved tab at once (scrollback replay + WebGL + sync-IPC snapshot per pane) freezes the renderer, so hidden tabs defer and mount on first reveal.
     const worktreeTabs = tabsByWorktree[renderedActiveWorktreeId] ?? []
+    const runtimeEnvironmentId = getActiveWorktreeRuntimeEnvironmentId(renderedActiveWorktreeId)
+    const runtimeStatus = runtimeEnvironmentId
+      ? runtimeStatusByEnvironmentId.get(runtimeEnvironmentId)
+      : undefined
+    const awaitingHostSnapshot =
+      runtimeEnvironmentId !== null &&
+      isWebRuntimeSessionActive(runtimeEnvironmentId) &&
+      !hasAcceptedWebSessionTabsSnapshot(
+        runtimeEnvironmentId,
+        renderedActiveWorktreeId,
+        runtimeStatus?.status?.runtimeId ?? null,
+        runtimeStatus?.connectionGeneration ?? 0
+      )
     const coldActivationDeferralEnabled =
       terminalParkingEnabled && terminalTitleSnapshotAuthorityEnabled
     const immediateTabIds = new Set<string>()
@@ -1330,7 +1345,15 @@ function Terminal(): React.JSX.Element | null {
             pairedRuntimeParkingEnvironmentIds
           })
         : terminalProviderHasAuthoritativeSnapshot(ptyId)
-    if (lastActivationWorktreeIdRef.current !== renderedActiveWorktreeId) {
+    if (awaitingHostSnapshot) {
+      lastActivationWorktreeIdRef.current = null
+      deferTerminalTabsUntilHostSnapshot({
+        restrictions: backgroundMountTabIdsByWorktreeRef.current,
+        deferredMountTabIdsByWorktree: activationDeferredMountTabIdsByWorktreeRef.current,
+        worktreeId: renderedActiveWorktreeId,
+        allTabIds: worktreeTabs.map((tab) => tab.id)
+      })
+    } else if (lastActivationWorktreeIdRef.current !== renderedActiveWorktreeId) {
       lastActivationWorktreeIdRef.current = renderedActiveWorktreeId
       const tabById = new Map(worktreeTabs.map((tab) => [tab.id, tab]))
       planColdActivationTabDeferral({

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -91,7 +91,6 @@ import {
   applyBackgroundMountTabRestriction,
   canDeferColdActivationTabsForHost,
   canMountTerminalWorkspaceForStartup,
-  deferTerminalTabsUntilHostSnapshot,
   planColdActivationTabDeferral,
   pruneClosedBackgroundMountTabs,
   revealActivationDeferredTabs,
@@ -99,6 +98,7 @@ import {
   takeAllPendingBackgroundTerminalWorktreeMounts,
   takePendingBackgroundTerminalWorktreeMount
 } from './terminal/background-terminal-worktree-mount'
+import { restrictTerminalTabsToHostSnapshot } from './terminal/paired-runtime-terminal-mount'
 import { hasRegisteredRuntimeTerminalTab } from '../runtime/sync-runtime-graph'
 import {
   getEffectiveLayoutForWorktree as getEffectiveLayout,
@@ -157,7 +157,11 @@ import {
   createWebRuntimeSessionTerminal,
   isWebRuntimeSessionActive
 } from '@/runtime/web-runtime-session'
-import { hasAcceptedWebSessionTabsSnapshot } from '@/runtime/web-session-tabs-sync'
+import {
+  hasAcceptedWebSessionTabsSnapshot,
+  isRuntimeTerminalTabForEnvironment,
+  useAcceptedWebSessionTabsSnapshotRevision
+} from '@/runtime/web-session-tabs-sync'
 import { openMobileEmulatorTab } from '@/lib/open-mobile-emulator-tab'
 import { launchAgentInNewTab } from '@/lib/launch-agent-in-new-tab'
 import { resumeSleepingAgentSessionsForWorktree } from '@/lib/resume-sleeping-agent-session'
@@ -331,6 +335,7 @@ function Terminal(): React.JSX.Element | null {
   const terminalParkingEnabled = useAppStore((s) => s.settings?.terminalHiddenViewParking !== false)
   const terminalSshParkingEnabled = useAppStore((s) => s.settings?.terminalSshViewParking !== false)
   const runtimeStatusByEnvironmentId = useAppStore((s) => s.runtimeStatusByEnvironmentId)
+  useAcceptedWebSessionTabsSnapshotRevision()
   const pairedRuntimeParkingEnvironmentIds = useMemo(
     () => selectPairedRuntimeParkingEnvironmentIds(runtimeStatusByEnvironmentId),
     [runtimeStatusByEnvironmentId]
@@ -1288,15 +1293,23 @@ function Terminal(): React.JSX.Element | null {
     const runtimeStatus = runtimeEnvironmentId
       ? runtimeStatusByEnvironmentId.get(runtimeEnvironmentId)
       : undefined
-    const awaitingHostSnapshot =
+    const pairedRuntimeActive =
+      runtimeEnvironmentId !== null && isWebRuntimeSessionActive(runtimeEnvironmentId)
+    const hostSnapshotAccepted =
       runtimeEnvironmentId !== null &&
       isWebRuntimeSessionActive(runtimeEnvironmentId) &&
-      !hasAcceptedWebSessionTabsSnapshot(
+      hasAcceptedWebSessionTabsSnapshot(
         runtimeEnvironmentId,
         renderedActiveWorktreeId,
         runtimeStatus?.status?.runtimeId ?? null,
         runtimeStatus?.connectionGeneration ?? 0
       )
+    const hostMountableTabIds =
+      hostSnapshotAccepted && runtimeEnvironmentId
+        ? worktreeTabs
+            .filter((tab) => isRuntimeTerminalTabForEnvironment(tab, runtimeEnvironmentId))
+            .map((tab) => tab.id)
+        : []
     const coldActivationDeferralEnabled =
       terminalParkingEnabled && terminalTitleSnapshotAuthorityEnabled
     const immediateTabIds = new Set<string>()
@@ -1345,15 +1358,7 @@ function Terminal(): React.JSX.Element | null {
             pairedRuntimeParkingEnvironmentIds
           })
         : terminalProviderHasAuthoritativeSnapshot(ptyId)
-    if (awaitingHostSnapshot) {
-      lastActivationWorktreeIdRef.current = null
-      deferTerminalTabsUntilHostSnapshot({
-        restrictions: backgroundMountTabIdsByWorktreeRef.current,
-        deferredMountTabIdsByWorktree: activationDeferredMountTabIdsByWorktreeRef.current,
-        worktreeId: renderedActiveWorktreeId,
-        allTabIds: worktreeTabs.map((tab) => tab.id)
-      })
-    } else if (lastActivationWorktreeIdRef.current !== renderedActiveWorktreeId) {
+    if (lastActivationWorktreeIdRef.current !== renderedActiveWorktreeId) {
       lastActivationWorktreeIdRef.current = renderedActiveWorktreeId
       const tabById = new Map(worktreeTabs.map((tab) => [tab.id, tab]))
       planColdActivationTabDeferral({
@@ -1402,6 +1407,18 @@ function Terminal(): React.JSX.Element | null {
         worktreeId: renderedActiveWorktreeId,
         allTabIds: worktreeTabs.map((tab) => tab.id),
         immediateTabIds
+      })
+    }
+    if (pairedRuntimeActive) {
+      if (!hostSnapshotAccepted) {
+        lastActivationWorktreeIdRef.current = null
+      }
+      restrictTerminalTabsToHostSnapshot({
+        restrictions: backgroundMountTabIdsByWorktreeRef.current,
+        deferredMountTabIdsByWorktree: activationDeferredMountTabIdsByWorktreeRef.current,
+        worktreeId: renderedActiveWorktreeId,
+        allTabIds: worktreeTabs.map((tab) => tab.id),
+        hostTabIds: hostMountableTabIds
       })
     }
     mountedWorktreeIdsRef.current.add(renderedActiveWorktreeId)

--- a/src/renderer/src/components/terminal/background-terminal-worktree-mount.test.ts
+++ b/src/renderer/src/components/terminal/background-terminal-worktree-mount.test.ts
@@ -13,6 +13,7 @@ import {
   canDeferColdActivationTabsForHost,
   canMountTerminalWorkspaceForStartup,
   collectDeferredMountTabIds,
+  deferTerminalTabsUntilHostSnapshot,
   hasRequestedBackgroundTerminalWorktreeMount,
   planColdActivationTabDeferral,
   pruneClosedBackgroundMountTabs,
@@ -222,6 +223,22 @@ describe('cold activation tab deferral', () => {
       })
     ).toBe(false)
     expect(canDeferColdActivationTabsForHost({ executionHostId: null })).toBe(false)
+  })
+
+  it('withholds every restored tab until the host snapshot arrives', () => {
+    const restrictions = new Map<string, ReadonlySet<string>>()
+    const deferredMountTabIdsByWorktree = new Map<string, ReadonlySet<string>>()
+    const allTabIds = tabIds(8)
+
+    deferTerminalTabsUntilHostSnapshot({
+      restrictions,
+      deferredMountTabIdsByWorktree,
+      worktreeId: 'wt-1',
+      allTabIds
+    })
+
+    expect(restrictions.get('wt-1')).toEqual(new Set())
+    expect(deferredMountTabIdsByWorktree.get('wt-1')).toEqual(new Set(allTabIds))
   })
 
   it('mounts everything at once when few tabs would defer', () => {

--- a/src/renderer/src/components/terminal/background-terminal-worktree-mount.test.ts
+++ b/src/renderer/src/components/terminal/background-terminal-worktree-mount.test.ts
@@ -13,7 +13,6 @@ import {
   canDeferColdActivationTabsForHost,
   canMountTerminalWorkspaceForStartup,
   collectDeferredMountTabIds,
-  deferTerminalTabsUntilHostSnapshot,
   hasRequestedBackgroundTerminalWorktreeMount,
   planColdActivationTabDeferral,
   pruneClosedBackgroundMountTabs,
@@ -23,6 +22,7 @@ import {
   takeAllPendingBackgroundTerminalWorktreeMounts,
   shouldMountBackgroundWorktreeTab
 } from './background-terminal-worktree-mount'
+import { restrictTerminalTabsToHostSnapshot } from './paired-runtime-terminal-mount'
 
 describe('terminal workspace startup mount gate', () => {
   it('waits for hydration unless startup entered degraded mode', () => {
@@ -225,16 +225,17 @@ describe('cold activation tab deferral', () => {
     expect(canDeferColdActivationTabsForHost({ executionHostId: null })).toBe(false)
   })
 
-  it('withholds every restored tab until the host snapshot arrives', () => {
-    const restrictions = new Map<string, ReadonlySet<string>>()
-    const deferredMountTabIdsByWorktree = new Map<string, ReadonlySet<string>>()
+  it('keeps restored PTY-less tabs withheld after an empty host snapshot', () => {
     const allTabIds = tabIds(8)
+    const restrictions = new Map<string, ReadonlySet<string>>([['wt-1', new Set(allTabIds)]])
+    const deferredMountTabIdsByWorktree = new Map<string, ReadonlySet<string>>()
 
-    deferTerminalTabsUntilHostSnapshot({
+    restrictTerminalTabsToHostSnapshot({
       restrictions,
       deferredMountTabIdsByWorktree,
       worktreeId: 'wt-1',
-      allTabIds
+      allTabIds,
+      hostTabIds: []
     })
 
     expect(restrictions.get('wt-1')).toEqual(new Set())

--- a/src/renderer/src/components/terminal/background-terminal-worktree-mount.ts
+++ b/src/renderer/src/components/terminal/background-terminal-worktree-mount.ts
@@ -186,22 +186,6 @@ function replaceActivationDeferredMountTabs(
   deferredMountTabIdsByWorktree.set(worktreeId, next)
 }
 
-export function deferTerminalTabsUntilHostSnapshot(opts: {
-  restrictions: Map<string, ReadonlySet<string>>
-  deferredMountTabIdsByWorktree: Map<string, ReadonlySet<string>>
-  worktreeId: string
-  allTabIds: readonly string[]
-}): void {
-  const restrictedTabIds = new Set<string>()
-  opts.restrictions.set(opts.worktreeId, restrictedTabIds)
-  replaceActivationDeferredMountTabs(
-    opts.deferredMountTabIdsByWorktree,
-    opts.worktreeId,
-    restrictedTabIds,
-    opts.allTabIds
-  )
-}
-
 /**
  * Decides whether activating `worktreeId` should defer mounting its hidden
  * terminal tabs until each is first revealed. Installs the restriction (tabs

--- a/src/renderer/src/components/terminal/background-terminal-worktree-mount.ts
+++ b/src/renderer/src/components/terminal/background-terminal-worktree-mount.ts
@@ -186,6 +186,22 @@ function replaceActivationDeferredMountTabs(
   deferredMountTabIdsByWorktree.set(worktreeId, next)
 }
 
+export function deferTerminalTabsUntilHostSnapshot(opts: {
+  restrictions: Map<string, ReadonlySet<string>>
+  deferredMountTabIdsByWorktree: Map<string, ReadonlySet<string>>
+  worktreeId: string
+  allTabIds: readonly string[]
+}): void {
+  const restrictedTabIds = new Set<string>()
+  opts.restrictions.set(opts.worktreeId, restrictedTabIds)
+  replaceActivationDeferredMountTabs(
+    opts.deferredMountTabIdsByWorktree,
+    opts.worktreeId,
+    restrictedTabIds,
+    opts.allTabIds
+  )
+}
+
 /**
  * Decides whether activating `worktreeId` should defer mounting its hidden
  * terminal tabs until each is first revealed. Installs the restriction (tabs

--- a/src/renderer/src/components/terminal/paired-runtime-terminal-mount.ts
+++ b/src/renderer/src/components/terminal/paired-runtime-terminal-mount.ts
@@ -1,0 +1,23 @@
+import { collectDeferredMountTabIds } from './background-terminal-worktree-mount'
+
+export function restrictTerminalTabsToHostSnapshot(opts: {
+  restrictions: Map<string, ReadonlySet<string>>
+  deferredMountTabIdsByWorktree: Map<string, ReadonlySet<string>>
+  worktreeId: string
+  allTabIds: readonly string[]
+  hostTabIds: readonly string[]
+}): void {
+  const hostTabIds = new Set(opts.hostTabIds)
+  const current = opts.restrictions.get(opts.worktreeId)
+  const restrictedTabIds = current
+    ? new Set([...current].filter((tabId) => hostTabIds.has(tabId)))
+    : hostTabIds
+  opts.restrictions.set(opts.worktreeId, restrictedTabIds)
+
+  const deferredTabIds = collectDeferredMountTabIds(restrictedTabIds, opts.allTabIds)
+  if (deferredTabIds.size === 0) {
+    opts.deferredMountTabIdsByWorktree.delete(opts.worktreeId)
+  } else {
+    opts.deferredMountTabIdsByWorktree.set(opts.worktreeId, deferredTabIds)
+  }
+}

--- a/src/renderer/src/runtime/web-session-tabs-sync-terminal-bootstrap.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync-terminal-bootstrap.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   shouldSyncAllRuntimeSessionTabs,
   shouldApplyWebSessionTabsSnapshot,
+  hasAcceptedWebSessionTabsSnapshot,
   shouldBootstrapInitialWebRuntimeTerminal,
   shouldRespawnWebRuntimeTerminalAfterWake,
   shouldSyncRuntimeSessionTabs
@@ -24,6 +25,18 @@ vi.mock('../store', () => ({
 describe('applyWebSessionTabsSnapshot', () => {
   beforeEach(resetWebSessionTabsSyncTestState)
 
+  it('binds mount authority to the accepted host connection', () => {
+    const freshEmpty = makeSnapshot([], {
+      activeGroupId: null,
+      activeTabId: null,
+      activeTabType: null
+    })
+    const connection = { runtimeId: 'runtime-1', connectionGeneration: 1 }
+    expect(hasAcceptedWebSessionTabsSnapshot(ENV, WT, 'runtime-1', 1)).toBe(false)
+    expect(shouldApplyWebSessionTabsSnapshot(freshEmpty, ENV, connection)).toBe(true)
+    expect(hasAcceptedWebSessionTabsSnapshot(ENV, WT, 'runtime-1', 1)).toBe(true)
+    expect(hasAcceptedWebSessionTabsSnapshot(ENV, WT, 'runtime-1', 2)).toBe(false)
+  })
   it('does not bootstrap a terminal from a stale empty active-worktree snapshot', () => {
     const ready = makeSnapshot([
       {

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -155,6 +155,10 @@ type VisibilityResumeOmission = {
 const latestSessionTabsSnapshotByWorktree = new Map<string, SnapshotFreshness>()
 const replayableSessionTabsSnapshotByWorktree = new Map<string, SnapshotFreshness>()
 const latestReceivedSessionTabsSnapshotByWorktree = new Map<string, ReceivedSessionTabsSnapshot>()
+const acceptedSessionTabsConnectionByWorktree = new Map<
+  string,
+  { runtimeId: string; connectionGeneration: number }
+>()
 const latestSessionTabsRemovalFenceByWorktree = new Map<string, SessionTabsRemovalFence>()
 const sessionTabsRecoveryStateByWorktree = new Map<string, SessionTabsRecoveryState>()
 const trackedSessionTabsWorktreeIdsByEnvironment = new Map<string, Set<string>>()
@@ -552,6 +556,21 @@ export function getLatestWebSessionTabsPublicationEpoch(
   )
 }
 
+export function hasAcceptedWebSessionTabsSnapshot(
+  environmentId: string,
+  worktreeId: string,
+  runtimeId: string | null,
+  connectionGeneration: number
+): boolean {
+  if (!runtimeId) {
+    return false
+  }
+  const accepted = acceptedSessionTabsConnectionByWorktree.get(
+    sessionTabsFreshnessKey(environmentId, worktreeId)
+  )
+  return accepted?.runtimeId === runtimeId && accepted.connectionGeneration === connectionGeneration
+}
+
 // Why: a replay may repeat the current epoch/version; permit only that exact
 // identity once so an older concurrent frame cannot bypass monotonic ordering.
 export function acceptReplayedWebSessionTabsSnapshot(
@@ -567,7 +586,8 @@ export function acceptReplayedWebSessionTabsSnapshot(
 
 export function shouldApplyWebSessionTabsSnapshot(
   snapshot: RuntimeMobileSessionTabsResult,
-  environmentId: string
+  environmentId: string,
+  connection?: { runtimeId: string; connectionGeneration: number }
 ): boolean {
   const key = sessionTabsFreshnessKey(environmentId, snapshot.worktree)
   if ((snapshot as { removed?: unknown }).removed === true) {
@@ -605,6 +625,9 @@ export function shouldApplyWebSessionTabsSnapshot(
     publicationEpoch: snapshot.publicationEpoch,
     snapshotVersion: snapshot.snapshotVersion
   })
+  if (connection) {
+    acceptedSessionTabsConnectionByWorktree.set(key, connection)
+  }
   trackWebSessionTabsWorktree(environmentId, snapshot.worktree)
   recordAcceptedWebSessionTabsEnvironment(environmentId, snapshot)
   // Why: a mounted mirror that exhausted bounded polling needs fresh host evidence without subscribing to every store write.
@@ -677,6 +700,7 @@ export function shouldSyncAllRuntimeSessionTabs(args: {
 
 export function resetWebSessionTabsSnapshotFreshnessForTests(): void {
   latestSessionTabsSnapshotByWorktree.clear()
+  acceptedSessionTabsConnectionByWorktree.clear()
   replayableSessionTabsSnapshotByWorktree.clear()
   latestReceivedSessionTabsSnapshotByWorktree.clear()
   latestSessionTabsRemovalFenceByWorktree.clear()
@@ -721,6 +745,7 @@ export function _getWebSessionTabsRecoveryTrackingCountsForTest(): {
 function clearWebSessionTabsTrackingForWorktree(environmentId: string, worktreeId: string): void {
   const key = sessionTabsFreshnessKey(environmentId, worktreeId)
   latestSessionTabsSnapshotByWorktree.delete(key)
+  acceptedSessionTabsConnectionByWorktree.delete(key)
   replayableSessionTabsSnapshotByWorktree.delete(key)
   latestReceivedSessionTabsSnapshotByWorktree.delete(key)
   untrackWebSessionTabsWorktree(environmentId, worktreeId)
@@ -743,6 +768,11 @@ export function clearWebSessionTabsTrackingForEnvironment(environmentId: string)
   for (const key of latestSessionTabsSnapshotByWorktree.keys()) {
     if (key.startsWith(keyPrefix)) {
       latestSessionTabsSnapshotByWorktree.delete(key)
+    }
+  }
+  for (const key of acceptedSessionTabsConnectionByWorktree.keys()) {
+    if (key.startsWith(keyPrefix)) {
+      acceptedSessionTabsConnectionByWorktree.delete(key)
     }
   }
   for (const key of replayableSessionTabsSnapshotByWorktree.keys()) {
@@ -4566,7 +4596,16 @@ export function useWebSessionTabsSync(): void {
         acceptReplayedWebSessionTabsSnapshot(environmentId, recovered.worktree)
       }
       const recoveredEvent: SessionTabsStreamEvent = { ...recovered, type: event.type }
-      const fresh = shouldApplyWebSessionTabsSnapshot(recovered, environmentId)
+      const fresh = shouldApplyWebSessionTabsSnapshot(
+        recovered,
+        environmentId,
+        activeWorktreeRuntimeId
+          ? {
+              runtimeId: activeWorktreeRuntimeId,
+              connectionGeneration: activeWorktreeRuntimeConnectionGeneration
+            }
+          : undefined
+      )
       const syncState = useAppStore.getState()
       const localWorktreeTabs = syncState.tabsByWorktree[activeWorktreeId] ?? []
       const localTerminalCount = localWorktreeTabs.length

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines -- web session-tab sync reconciles terminal, unified-tab, group, and PTY maps atomically to avoid split-brain tab state */
-import { useEffect, useLayoutEffect, useRef } from 'react'
+import { useEffect, useLayoutEffect, useRef, useSyncExternalStore } from 'react'
 import type { AppState } from '../store'
 import { useAppStore } from '../store'
 import type { RuntimeRpcResponse } from '../../../shared/runtime-rpc-envelope'
@@ -159,6 +159,8 @@ const acceptedSessionTabsConnectionByWorktree = new Map<
   string,
   { runtimeId: string; connectionGeneration: number }
 >()
+const acceptedSessionTabsSnapshotListeners = new Set<() => void>()
+let acceptedSessionTabsSnapshotRevision = 0
 const latestSessionTabsRemovalFenceByWorktree = new Map<string, SessionTabsRemovalFence>()
 const sessionTabsRecoveryStateByWorktree = new Map<string, SessionTabsRecoveryState>()
 const trackedSessionTabsWorktreeIdsByEnvironment = new Map<string, Set<string>>()
@@ -169,6 +171,22 @@ const hostSessionTabMappingKeysByEnvironmentAndWorktree = new Map<
   string,
   Map<string, Set<string>>
 >()
+
+function publishAcceptedSessionTabsSnapshotChange(): void {
+  acceptedSessionTabsSnapshotRevision += 1
+  for (const listener of acceptedSessionTabsSnapshotListeners) {
+    listener()
+  }
+}
+
+function subscribeAcceptedSessionTabsSnapshot(listener: () => void): () => void {
+  acceptedSessionTabsSnapshotListeners.add(listener)
+  return () => acceptedSessionTabsSnapshotListeners.delete(listener)
+}
+
+function getAcceptedSessionTabsSnapshotRevision(): number {
+  return acceptedSessionTabsSnapshotRevision
+}
 // Why: a delayed host stamp belongs to the client boundary seen with its preceding ordered frame.
 const hostWorkingClientBoundaryByPaneKey = new Map<
   string,
@@ -571,6 +589,14 @@ export function hasAcceptedWebSessionTabsSnapshot(
   return accepted?.runtimeId === runtimeId && accepted.connectionGeneration === connectionGeneration
 }
 
+export function useAcceptedWebSessionTabsSnapshotRevision(): number {
+  return useSyncExternalStore(
+    subscribeAcceptedSessionTabsSnapshot,
+    getAcceptedSessionTabsSnapshotRevision,
+    getAcceptedSessionTabsSnapshotRevision
+  )
+}
+
 // Why: a replay may repeat the current epoch/version; permit only that exact
 // identity once so an older concurrent frame cannot bypass monotonic ordering.
 export function acceptReplayedWebSessionTabsSnapshot(
@@ -626,7 +652,14 @@ export function shouldApplyWebSessionTabsSnapshot(
     snapshotVersion: snapshot.snapshotVersion
   })
   if (connection) {
-    acceptedSessionTabsConnectionByWorktree.set(key, connection)
+    const accepted = acceptedSessionTabsConnectionByWorktree.get(key)
+    if (
+      accepted?.runtimeId !== connection.runtimeId ||
+      accepted.connectionGeneration !== connection.connectionGeneration
+    ) {
+      acceptedSessionTabsConnectionByWorktree.set(key, connection)
+      publishAcceptedSessionTabsSnapshotChange()
+    }
   }
   trackWebSessionTabsWorktree(environmentId, snapshot.worktree)
   recordAcceptedWebSessionTabsEnvironment(environmentId, snapshot)
@@ -701,6 +734,7 @@ export function shouldSyncAllRuntimeSessionTabs(args: {
 export function resetWebSessionTabsSnapshotFreshnessForTests(): void {
   latestSessionTabsSnapshotByWorktree.clear()
   acceptedSessionTabsConnectionByWorktree.clear()
+  acceptedSessionTabsSnapshotRevision = 0
   replayableSessionTabsSnapshotByWorktree.clear()
   latestReceivedSessionTabsSnapshotByWorktree.clear()
   latestSessionTabsRemovalFenceByWorktree.clear()
@@ -745,7 +779,9 @@ export function _getWebSessionTabsRecoveryTrackingCountsForTest(): {
 function clearWebSessionTabsTrackingForWorktree(environmentId: string, worktreeId: string): void {
   const key = sessionTabsFreshnessKey(environmentId, worktreeId)
   latestSessionTabsSnapshotByWorktree.delete(key)
-  acceptedSessionTabsConnectionByWorktree.delete(key)
+  if (acceptedSessionTabsConnectionByWorktree.delete(key)) {
+    publishAcceptedSessionTabsSnapshotChange()
+  }
   replayableSessionTabsSnapshotByWorktree.delete(key)
   latestReceivedSessionTabsSnapshotByWorktree.delete(key)
   untrackWebSessionTabsWorktree(environmentId, worktreeId)
@@ -770,10 +806,15 @@ export function clearWebSessionTabsTrackingForEnvironment(environmentId: string)
       latestSessionTabsSnapshotByWorktree.delete(key)
     }
   }
+  let acceptedConnectionChanged = false
   for (const key of acceptedSessionTabsConnectionByWorktree.keys()) {
     if (key.startsWith(keyPrefix)) {
-      acceptedSessionTabsConnectionByWorktree.delete(key)
+      acceptedConnectionChanged =
+        acceptedSessionTabsConnectionByWorktree.delete(key) || acceptedConnectionChanged
     }
+  }
+  if (acceptedConnectionChanged) {
+    publishAcceptedSessionTabsSnapshotChange()
   }
   for (const key of replayableSessionTabsSnapshotByWorktree.keys()) {
     if (key.startsWith(keyPrefix)) {
@@ -911,7 +952,10 @@ function editorSourceFileId(tab: ReadyEditorSurface): string | undefined {
   return tab.type === 'markdown' && tab.mode === 'markdown-preview' ? tab.sourceFilePath : undefined
 }
 
-function isRuntimeTerminalTabForEnvironment(tab: TerminalTab, environmentId: string): boolean {
+export function isRuntimeTerminalTabForEnvironment(
+  tab: TerminalTab,
+  environmentId: string
+): boolean {
   if (!tab.ptyId) {
     return false
   }


### PR DESCRIPTION
## ELI5

Orca now waits for the current remote host's terminal list before mounting saved tabs, so dead entries cannot open duplicate shells.

## What Changed

- Gate paired-runtime mounts on a connection-matched `session.tabs` snapshot.
- Keep PTY-less rows deferred across later renders.
- Make snapshot acceptance reactive.

## Why

Persisted rows mounted before the host snapshot and each mount created a remote shell.

## Linked Issue

Fixes #15622

## Visual Proof

N/A — this is a terminal lifecycle guard with no static visual output.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Focused Vitest: 2 files, 32 tests. Renderer typecheck and changed-file lint pass.

## AI Disclosure

OpenAI Codex.

## Review

Addressed CodeRabbit's reactivity finding: an empty accepted snapshot keeps stale PTY-less rows deferred on later renders.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No PTY teardown changes. Live host shells remain mountable. Local and SSH terminals are unchanged.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)