### PR TITLE
fix(ports): stop duplicating rows in the status-bar popover after Stop Process

### DIFF
--- a/src/renderer/src/components/right-sidebar/PortsPanel.test.tsx
+++ b/src/renderer/src/components/right-sidebar/PortsPanel.test.tsx
@@ -573,7 +573,13 @@ describe('PortsPanel runtime routing', () => {
         runtimeTarget: { kind: 'environment', environmentId: 'env-1' },
         setWorkspacePortScan: setWorkspacePortScan as never,
         setWorkspacePortScanForKey: setWorkspacePortScanForKey as never,
-        getWorkspacePortScansByKey: () => ({ 'local:all': localHostScan }),
+        // Why: the real store already reflects setWorkspacePortScanForKey's
+        // write for the target host by the time this is read — a mock that
+        // omits it understates how many hosts are actually tracked.
+        getWorkspacePortScansByKey: () => ({
+          'local:all': localHostScan,
+          'environment:env-1:all': remoteHostScan
+        }),
         setWorkspacePortScanRefreshing: setWorkspacePortScanRefreshing as never
       })
     ).resolves.toEqual({ ok: true })

--- a/src/renderer/src/lib/workspace-port-actions.test.ts
+++ b/src/renderer/src/lib/workspace-port-actions.test.ts
@@ -96,11 +96,7 @@ describe('refreshWorkspacePortScanAfterStop', () => {
   })
 
   it('publishes the settled scan under the plain host key, not a synthetic aggregate, for a single tracked host', async () => {
-    // Regression for a bug where currentScans always contained the entry this
-    // same publish had just written, so ">0 keys" was true even with one
-    // host. That routed every Stop click through 'all-hosts:all' and merged
-    // the settled (process gone) scan back with the first (process present)
-    // scan, resurrecting the just-killed port as a ghost row.
+    // Regression for the ghost-duplicate-row bug: a single host was wrongly treated as multi-host.
     runWorkspacePortScanForTargetMock
       .mockResolvedValueOnce(scanWithPort(port('tcp:5199'), 1))
       .mockResolvedValueOnce(scanWithPort(null, 2))

--- a/src/renderer/src/lib/workspace-port-actions.test.ts
+++ b/src/renderer/src/lib/workspace-port-actions.test.ts
@@ -1,0 +1,146 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { WorkspacePort, WorkspacePortScanResult } from '../../../shared/workspace-ports'
+
+const { runWorkspacePortScanForTargetMock } = vi.hoisted(() => ({
+  runWorkspacePortScanForTargetMock: vi.fn()
+}))
+
+vi.mock('./workspace-port-scan-client', () => ({
+  runWorkspacePortScanForTarget: runWorkspacePortScanForTargetMock
+}))
+
+const {
+  mergeWorkspacePortScans,
+  refreshWorkspacePortScanAfterStop,
+  workspacePortScanKeyForTarget
+} = await import('./workspace-port-actions')
+
+function scanWithPort(port: WorkspacePort | null, scannedAt = 1): WorkspacePortScanResult {
+  return { platform: 'darwin', scannedAt, ports: port ? [port] : [] }
+}
+
+function port(id: string): WorkspacePort {
+  return {
+    id,
+    bindHost: '127.0.0.1',
+    connectHost: '127.0.0.1',
+    port: 5199,
+    processName: 'node',
+    protocol: 'http',
+    kind: 'external'
+  }
+}
+
+/** Mirrors the Zustand store's read-after-write semantics the bug depended on. */
+function makeScanStoreHarness(): {
+  scansByKey: Record<string, WorkspacePortScanResult>
+  projections: { key: string; result: WorkspacePortScanResult }[]
+  setWorkspacePortScanForKey: (key: string, scan: WorkspacePortScanResult | null) => void
+  setWorkspacePortScan: (next: { key: string; result: WorkspacePortScanResult } | null) => void
+  getWorkspacePortScansByKey: () => Record<string, WorkspacePortScanResult>
+  setWorkspacePortScanRefreshing: (value: boolean) => void
+} {
+  const scansByKey: Record<string, WorkspacePortScanResult> = {}
+  const projections: { key: string; result: WorkspacePortScanResult }[] = []
+  return {
+    scansByKey,
+    projections,
+    setWorkspacePortScanForKey: (key, scan) => {
+      if (scan) {
+        scansByKey[key] = scan
+      } else {
+        delete scansByKey[key]
+      }
+    },
+    setWorkspacePortScan: (next) => {
+      if (next) {
+        projections.push(next)
+      }
+    },
+    getWorkspacePortScansByKey: () => scansByKey,
+    setWorkspacePortScanRefreshing: () => {}
+  }
+}
+
+describe('mergeWorkspacePortScans', () => {
+  it('returns a single entry verbatim, without prefixing ids', () => {
+    const scan = scanWithPort(port('tcp:5199'))
+    expect(mergeWorkspacePortScans({ 'local:all': scan })).toBe(scan)
+  })
+
+  it('concatenates ports across multiple entries with key-prefixed ids', () => {
+    const merged = mergeWorkspacePortScans({
+      'local:all': scanWithPort(port('tcp:5199')),
+      'environment:x:all': scanWithPort(port('tcp:6000'))
+    })
+    expect(merged?.ports.map((p) => p.id)).toEqual([
+      'environment:x:all:tcp:6000',
+      'local:all:tcp:5199'
+    ])
+  })
+})
+
+describe('refreshWorkspacePortScanAfterStop', () => {
+  const target = { kind: 'local' as const }
+  const scanKey = workspacePortScanKeyForTarget(target)
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    runWorkspacePortScanForTargetMock.mockReset()
+  })
+
+  it('publishes the settled scan under the plain host key, not a synthetic aggregate, for a single tracked host', async () => {
+    // Regression for a bug where currentScans always contained the entry this
+    // same publish had just written, so ">0 keys" was true even with one
+    // host. That routed every Stop click through 'all-hosts:all' and merged
+    // the settled (process gone) scan back with the first (process present)
+    // scan, resurrecting the just-killed port as a ghost row.
+    runWorkspacePortScanForTargetMock
+      .mockResolvedValueOnce(scanWithPort(port('tcp:5199'), 1))
+      .mockResolvedValueOnce(scanWithPort(null, 2))
+    const harness = makeScanStoreHarness()
+
+    const resultPromise = refreshWorkspacePortScanAfterStop({
+      runtimeTarget: target,
+      setWorkspacePortScan: harness.setWorkspacePortScan,
+      setWorkspacePortScanForKey: harness.setWorkspacePortScanForKey,
+      setWorkspacePortScanRefreshing: harness.setWorkspacePortScanRefreshing,
+      getWorkspacePortScansByKey: harness.getWorkspacePortScansByKey
+    })
+    await vi.advanceTimersByTimeAsync(500)
+    await resultPromise
+
+    expect(harness.projections).toHaveLength(2)
+    const settled = harness.projections[1]
+    expect(settled.key).toBe(scanKey)
+    expect(settled.result.ports).toHaveLength(0)
+  })
+
+  it('aggregates under the synthetic key only when a second host is genuinely tracked', async () => {
+    runWorkspacePortScanForTargetMock
+      .mockResolvedValueOnce(scanWithPort(port('tcp:5199'), 1))
+      .mockResolvedValueOnce(scanWithPort(null, 2))
+    const harness = makeScanStoreHarness()
+    harness.scansByKey['environment:other:all'] = scanWithPort(port('tcp:6000'))
+
+    const resultPromise = refreshWorkspacePortScanAfterStop({
+      runtimeTarget: target,
+      setWorkspacePortScan: harness.setWorkspacePortScan,
+      setWorkspacePortScanForKey: harness.setWorkspacePortScanForKey,
+      setWorkspacePortScanRefreshing: harness.setWorkspacePortScanRefreshing,
+      getWorkspacePortScansByKey: harness.getWorkspacePortScansByKey
+    })
+    await vi.advanceTimersByTimeAsync(500)
+    await resultPromise
+
+    const settled = harness.projections[1]
+    expect(settled.key).toBe('all-hosts:all')
+    expect(settled.result.ports.map((p) => p.id)).toEqual(['environment:other:all:tcp:6000'])
+  })
+})

--- a/src/renderer/src/lib/workspace-port-actions.ts
+++ b/src/renderer/src/lib/workspace-port-actions.ts
@@ -178,11 +178,7 @@ export async function refreshWorkspacePortScanAfterStop(args: {
     args.setWorkspacePortScanForKey?.(scanKey, scan)
     const currentScans = args.getWorkspacePortScansByKey?.() ?? {}
     const merged = mergeWorkspacePortScans({ ...currentScans, [scanKey]: scan })
-    // Why: currentScans already contains the entry just written above for
-    // scanKey, so ">0" was true for a single tracked host too — every Stop
-    // click routed the projection through the synthetic 'all-hosts:all' key,
-    // which then concatenated with the next publish's scan instead of being
-    // replaced, producing ghost duplicate rows. Multiple real hosts means >1.
+    // Why: currentScans already contains the entry just written above, so ">1" (not ">0") is the real multi-host check.
     args.setWorkspacePortScan({
       key: merged && Object.keys(currentScans).length > 1 ? 'all-hosts:all' : scanKey,
       result: merged ?? scan

--- a/src/renderer/src/lib/workspace-port-actions.ts
+++ b/src/renderer/src/lib/workspace-port-actions.ts
@@ -178,8 +178,13 @@ export async function refreshWorkspacePortScanAfterStop(args: {
     args.setWorkspacePortScanForKey?.(scanKey, scan)
     const currentScans = args.getWorkspacePortScansByKey?.() ?? {}
     const merged = mergeWorkspacePortScans({ ...currentScans, [scanKey]: scan })
+    // Why: currentScans already contains the entry just written above for
+    // scanKey, so ">0" was true for a single tracked host too — every Stop
+    // click routed the projection through the synthetic 'all-hosts:all' key,
+    // which then concatenated with the next publish's scan instead of being
+    // replaced, producing ghost duplicate rows. Multiple real hosts means >1.
     args.setWorkspacePortScan({
-      key: merged && Object.keys(currentScans).length > 0 ? 'all-hosts:all' : scanKey,
+      key: merged && Object.keys(currentScans).length > 1 ? 'all-hosts:all' : scanKey,
       result: merged ?? scan
     })
   }


### PR DESCRIPTION
## Summary

Reported: after killing a process holding a port from the Ports status-bar popover, the killed port's row keeps showing (duplicated many times over) for a few seconds before self-clearing.

Root cause is a one-character bug in `refreshWorkspacePortScanAfterStop`'s `publishScan` (`src/renderer/src/lib/workspace-port-actions.ts`):

```ts
key: merged && Object.keys(currentScans).length > 0 ? 'all-hosts:all' : scanKey,
```

`currentScans` is read via `getWorkspacePortScansByKey()` *after* `setWorkspacePortScanForKey(scanKey, scan)` already wrote this same publish's entry into the store, so `currentScans` always has at least one key — the check is true even with exactly one host tracked, not only when there genuinely are multiple hosts. `WorkspacePortScanner`'s own equivalent projection-key logic elsewhere in the same file already uses the correct `> 1` threshold; this call site had drifted from it.

Effect: every Stop click on a single-host setup routed the projection through the synthetic `'all-hosts:all'` key instead of the plain per-host key. `mergeWorkspacePortScans` then concatenates whatever is under that key with the next publish 500ms later (the "settled" re-scan) instead of replacing it, so the fresh (process now gone) scan gets merged with the previous (process still present) scan, resurrecting the just-killed port as a ghost row. This self-heals once the 30s background `WorkspacePortScanner` tick prunes the stray non-target key — matching the reported "for a few seconds" symptom.

The right-sidebar `PortsPanel` reads `workspacePortScansByKey[key]` directly rather than the aggregate projection, so it's unaffected — consistent with the report being specific to the status-bar popover.

## Fix

One-line: require *more than one* tracked host before aggregating (`> 1`), matching the threshold already used elsewhere in this file.

Also fixed an existing `PortsPanel.test.tsx` test whose `getWorkspacePortScansByKey` mock didn't reflect the store's real read-after-write ordering (it omitted the entry the store already has by the time `publishScan` reads it back) — that gap in the mock is exactly what let the original bug go unnoticed.

## Test plan

- [x] Added `workspace-port-actions.test.ts`: single-host Stop no longer aggregates (regression test for the exact bug), two-host Stop still aggregates correctly under the synthetic key
- [x] Fixed `PortsPanel.test.tsx`'s mock and reran — 22/22 passing
- [x] `pnpm run typecheck`, `pnpm oxlint` on touched files
- [x] Broader `vitest` pass across `src/renderer/src/lib`, `src/renderer/src/components/status-bar`, `PortsPanel.test.tsx`, `src/renderer/src/i18n`, `src/main/i18n` — all green (two unrelated failures elsewhere in the repo, both confirmed flaky/environment-load-sensitive on rerun in isolation, not touched by this change)