### PR TITLE
fix(editor): watch the directory of open files outside every worktree root

### DIFF
--- a/src/renderer/src/hooks/useEditorExternalWatch-targets.test.ts
+++ b/src/renderer/src/hooks/useEditorExternalWatch-targets.test.ts
@@ -40,12 +40,13 @@ describe('getEditorExternalWatchTargets', () => {
 
   const makeOpenFile = (
     worktreeId: string,
-    isDirty = false
+    isDirty = false,
+    filePath = `${worktreeId}/notes.md`
   ): EditorExternalWatchTargetState['openFiles'][number] =>
     ({
       id: `${worktreeId}-file`,
       worktreeId,
-      filePath: `/repo/${worktreeId}/notes.md`,
+      filePath,
       relativePath: 'notes.md',
       language: 'markdown',
       mode: 'edit',
@@ -83,14 +84,105 @@ describe('getEditorExternalWatchTargets', () => {
           } as EditorExternalWatchTargetState['settings'])
   })
 
+
+  it('watches the containing directory of an open file outside the worktree root (#15612)', () => {
+    const repo = makeRepo('repo-scratch')
+    const worktree = makeWorktree(repo.id, 'wt-scratch')
+    const scratchFile = {
+      ...makeOpenFile(worktree.id, false, '/tmp/claude-scratch/plan.md')
+    }
+
+    const { targets } = getEditorExternalWatchTargets(
+      makeState({ repo, worktree, openFiles: [scratchFile] })
+    )
+
+    expect(targets).toEqual([
+      {
+        worktreeId: 'wt-scratch',
+        worktreePath: '/repo-scratch/worktree',
+        connectionId: undefined,
+        runtimeEnvironmentId: null
+      },
+      {
+        worktreeId: 'wt-scratch',
+        worktreePath: '/tmp/claude-scratch',
+        connectionId: undefined,
+        runtimeEnvironmentId: null
+      }
+    ])
+  })
+
+  it('deduplicates out-of-root directory watches for files sharing a directory', () => {
+    const repo = makeRepo('repo-dedupe')
+    const worktree = makeWorktree(repo.id, 'wt-dedupe')
+    const openFiles = [
+      makeOpenFile(worktree.id, false, '/tmp/agent-docs/plan.md'),
+      { ...makeOpenFile(worktree.id, false, '/tmp/agent-docs/report.md'), id: 'report-file' }
+    ]
+
+    const { targets } = getEditorExternalWatchTargets(makeState({ repo, worktree, openFiles }))
+
+    expect(targets.filter((target) => target.worktreePath === '/tmp/agent-docs')).toHaveLength(1)
+  })
+
+  it('does not watch a directory that contains the worktree root', () => {
+    const repo = makeRepo('repo-parent')
+    const worktree = makeWorktree(repo.id, 'wt-parent')
+    // A sibling of the worktree root: its containing directory ALSO contains the root.
+    const siblingFile = makeOpenFile(worktree.id, false, '/repo-parent/notes.md')
+
+    const { targets } = getEditorExternalWatchTargets(
+      makeState({ repo, worktree, openFiles: [siblingFile] })
+    )
+
+    expect(targets).toEqual([
+      {
+        worktreeId: 'wt-parent',
+        worktreePath: '/repo-parent/worktree',
+        connectionId: undefined,
+        runtimeEnvironmentId: null
+      }
+    ])
+  })
+
+  it('skips files owned by a different SSH target', () => {
+    const repo = makeRepo('repo-ssh-external')
+    const worktree = makeWorktree(repo.id, 'wt-ssh-external')
+    const externalFile = {
+      ...makeOpenFile(worktree.id, false, '/remote-scratch/plan.md'),
+      externalSshTargetId: 'ssh-other'
+    }
+
+    const { targets } = getEditorExternalWatchTargets(
+      makeState({ repo, worktree, openFiles: [externalFile] })
+    )
+
+    expect(targets).toHaveLength(1)
+    expect(targets[0].worktreePath).toBe('/repo-ssh-external/worktree')
+  })
+
+  it('bounds the number of out-of-root directory watches', () => {
+    const repo = makeRepo('repo-many')
+    const worktree = makeWorktree(repo.id, 'wt-many')
+    const openFiles = Array.from({ length: 12 }, (_, i) => ({
+      ...makeOpenFile(worktree.id, false, `/tmp/dir-${i}/file-${i}.md`),
+      id: `file-${i}`
+    }))
+
+    const { targets } = getEditorExternalWatchTargets(makeState({ repo, worktree, openFiles }))
+
+    const dirTargets = targets.filter((target) => target.worktreePath.startsWith('/tmp/dir-'))
+    expect(dirTargets).toHaveLength(8)
+  })
+
   it('preserves the snapshot when open-file metadata changes without changing watched roots', () => {
     const repo = makeRepo('repo-1')
     const worktree = makeWorktree(repo.id, 'wt-1')
     const first = getEditorExternalWatchTargets(
-      makeState({ repo, worktree, openFiles: [makeOpenFile(worktree.id, false)] })
+      makeState({ repo, worktree, openFiles: [makeOpenFile(worktree.id, false, '/repo-1/worktree/notes.md')] })
     )
     const second = getEditorExternalWatchTargets(
-      makeState({ repo, worktree, openFiles: [makeOpenFile(worktree.id, true)] })
+      makeState({ repo, worktree, openFiles: [makeOpenFile(worktree.id, true, '/repo-1/worktree/notes.md')] })
     )
 
     expect(second).toBe(first)
@@ -109,7 +201,7 @@ describe('getEditorExternalWatchTargets', () => {
     const worktree = makeWorktree(repo.id, 'wt-local-drive')
     worktree.path = 'C:\\repo'
     worktree.hostId = 'local'
-    const state = makeState({ repo, worktree, openFiles: [makeOpenFile(worktree.id)] })
+    const state = makeState({ repo, worktree, openFiles: [makeOpenFile(worktree.id, false, 'C:' + String.fromCharCode(92) + 'repo' + String.fromCharCode(92) + 'notes.md')] })
     state.repos = [makeRepo(repo.id, 'ssh-1', 'ssh:ssh-1'), repo]
 
     expect(getEditorExternalWatchTargets(state).targets).toEqual([
@@ -128,7 +220,7 @@ describe('getEditorExternalWatchTargets', () => {
     const worktree = makeWorktree(repo.id, 'wt-unresolved')
     worktree.path = 'C:\\repo'
     worktree.hostId = 'local'
-    const state = makeState({ repo, worktree, openFiles: [makeOpenFile(worktree.id)] })
+    const state = makeState({ repo, worktree, openFiles: [makeOpenFile(worktree.id, false, 'C:' + String.fromCharCode(92) + 'repo' + String.fromCharCode(92) + 'notes.md')] })
     state.repos = []
 
     expect(getEditorExternalWatchTargets(state).targets).toEqual([
@@ -155,7 +247,7 @@ describe('getEditorExternalWatchTargets', () => {
       }
 
       const target = getEditorExternalWatchTargets(
-        makeState({ repo, worktree, openFiles: [makeOpenFile(worktree.id)] })
+        makeState({ repo, worktree, openFiles: [makeOpenFile(worktree.id, false, 'C:' + String.fromCharCode(92) + 'repo' + String.fromCharCode(92) + 'notes.md')] })
       ).targets[0]
 
       expect(target).not.toHaveProperty('allowLocalWindowsWslAliases')
@@ -177,7 +269,7 @@ describe('getEditorExternalWatchTargets', () => {
       }
 
       const target = getEditorExternalWatchTargets(
-        makeState({ repo, worktree, openFiles: [makeOpenFile(worktree.id)] })
+        makeState({ repo, worktree, openFiles: [makeOpenFile(worktree.id, false, 'C:' + String.fromCharCode(92) + 'repo' + String.fromCharCode(92) + 'notes.md')] })
       ).targets[0]
 
       expect(target).not.toHaveProperty('allowLocalWindowsWslAliases')
@@ -192,7 +284,7 @@ describe('getEditorExternalWatchTargets', () => {
     const state = makeState({
       repo,
       worktree,
-      openFiles: [makeOpenFile(workspaceKey)]
+      openFiles: [makeOpenFile(workspaceKey, false, 'C:' + String.fromCharCode(92) + 'folder' + String.fromCharCode(92) + 'notes.md')]
     })
     state.folderWorkspaces = [
       {
@@ -234,7 +326,7 @@ describe('getEditorExternalWatchTargets', () => {
       const state = makeState({
         repo,
         worktree,
-        openFiles: [makeOpenFile(workspaceKey)]
+        openFiles: [makeOpenFile(workspaceKey, false, 'C:' + String.fromCharCode(92) + 'folder' + String.fromCharCode(92) + 'notes.md')]
       })
       state.folderWorkspaces = [
         {
@@ -428,13 +520,13 @@ describe('getEditorExternalWatchTargets', () => {
     const remoteRepo = makeRepo('repo-remote', 'ssh-1')
     const worktree = makeWorktree(localRepo.id, 'wt-remote')
     const local = getEditorExternalWatchTargets(
-      makeState({ repo: localRepo, worktree, openFiles: [makeOpenFile(worktree.id)] })
+      makeState({ repo: localRepo, worktree, openFiles: [makeOpenFile(worktree.id, false, '/repo-remote/worktree/notes.md')] })
     )
     const remote = getEditorExternalWatchTargets(
       makeState({
         repo: remoteRepo,
         worktree,
-        openFiles: [makeOpenFile(worktree.id)],
+        openFiles: [makeOpenFile(worktree.id, false, '/repo-remote/worktree/notes.md')],
         runtimeEnvironmentId: ' runtime-1 '
       })
     )
@@ -453,9 +545,9 @@ describe('getEditorExternalWatchTargets', () => {
   it('creates separate watch targets for local and runtime-owned tabs in the same worktree', () => {
     const repo = makeRepo('repo-mixed')
     const worktree = makeWorktree(repo.id, 'wt-mixed')
-    const localFile = makeOpenFile(worktree.id)
+    const localFile = makeOpenFile(worktree.id, false, '/repo-mixed/worktree/notes.md')
     const runtimeFile = {
-      ...makeOpenFile(worktree.id),
+      ...makeOpenFile(worktree.id, false, '/repo-mixed/worktree/notes.md'),
       id: 'runtime-file',
       runtimeEnvironmentId: 'env-1'
     }
@@ -489,12 +581,12 @@ describe('getEditorExternalWatchTargets', () => {
     const repo = makeRepo('repo-restored')
     const worktree = makeWorktree(repo.id, 'wt-restored')
     const restoredLocalFile = {
-      ...makeOpenFile(worktree.id),
+      ...makeOpenFile(worktree.id, false, '/repo-restored/worktree/notes.md'),
       id: 'restored-local-file',
       runtimeEnvironmentId: undefined
     }
     const runtimeFile = {
-      ...makeOpenFile(worktree.id),
+      ...makeOpenFile(worktree.id, false, '/repo-restored/worktree/notes.md'),
       id: 'runtime-file',
       runtimeEnvironmentId: 'env-1'
     }

--- a/src/renderer/src/hooks/useEditorExternalWatch.ts
+++ b/src/renderer/src/hooks/useEditorExternalWatch.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines -- co-locates target diffing, fs:changed dispatch, tombstone coalescing, and rename correlation so the event-to-store contract stays in one file. */
 import { useEffect, useRef } from 'react'
 import { useAppStore, type AppState } from '@/store'
-import { basename, joinPath } from '@/lib/path'
+import { basename, dirname, joinPath } from '@/lib/path'
 import {
   isWindowsAbsolutePathLike,
   normalizeRuntimePathForComparison
@@ -173,6 +173,95 @@ export function getWatchedTargetKey(target: WatchedTarget): string {
   return `${target.worktreeId}::${target.worktreePath}::${target.connectionId ?? 'local'}::${target.runtimeEnvironmentId ?? 'client'}::${target.allowLocalWindowsWslAliases === true ? 'wsl-aliases' : 'literal'}`
 }
 
+/** Bound on out-of-root directory watches so a pathological tab set cannot fan out watchers (#15612). */
+const MAX_OUT_OF_ROOT_DIR_TARGETS = 8
+
+function normalizedPathIsInsideOrEqual(root: string, value: string): boolean {
+  const normalizedRoot = normalizeRuntimePathForComparison(root)
+  const normalizedValue = normalizeRuntimePathForComparison(value)
+  const boundedRoot = normalizedRoot.endsWith('/') ? normalizedRoot : `${normalizedRoot}/`
+  return normalizedValue === normalizedRoot || normalizedValue.startsWith(boundedRoot)
+}
+
+function isWatchableOpenFilePath(filePath: string): boolean {
+  return filePath.includes('/') || filePath.includes('\\')
+}
+
+/**
+ * Directory-scoped watch targets for open files that live OUTSIDE every watched
+ * root (#15612) — agent scratchpads by design sit outside the worktree, and
+ * without a watch they never reload and never show the changed-on-disk banner.
+ *
+ * One target per distinct containing directory, per owner. Directories that
+ * CONTAIN the watched root are skipped: the watch is recursive, so a parent
+ * directory would re-watch the whole root's tree plus every sibling — a file
+ * next to the repo would otherwise fan out a drive-wide watcher. Files owned
+ * by a different SSH target (`externalSshTargetId`) are skipped too: their
+ * path lives on a host this worktree's connection cannot watch.
+ */
+function collectOutOfRootWatchTargets(
+  state: Pick<EditorExternalWatchTargetState, 'openFiles'>,
+  scope: {
+    worktreeId: string
+    rootPath: string
+    runtimeEnvironmentId: string | null
+    connectionId: string | null | undefined
+    worktree: AppState['worktreesByRepo'][string][number] | undefined
+    repo: AppState['repos'][number] | undefined
+    folderWorkspace: AppState['folderWorkspaces'][number] | undefined
+    projectGroup: AppState['projectGroups'][number] | undefined
+  }
+): WatchedTarget[] {
+  const seenDirectories = new Set<string>()
+  const targets: WatchedTarget[] = []
+  for (const file of state.openFiles) {
+    if (
+      file.worktreeId !== scope.worktreeId ||
+      openFileRuntimeOwner(file) !== scope.runtimeEnvironmentId ||
+      (file.mode !== 'edit' && file.mode !== 'markdown-preview') ||
+      file.isUntitled ||
+      file.externalSshTargetId ||
+      !isWatchableOpenFilePath(file.filePath)
+    ) {
+      continue
+    }
+    if (normalizedPathIsInsideOrEqual(scope.rootPath, file.filePath)) {
+      continue
+    }
+    const directory = dirname(file.filePath)
+    const directoryKey = normalizeRuntimePathForComparison(directory)
+    if (
+      seenDirectories.has(directoryKey) ||
+      // Why: a containing directory is a superset of the root watch — recursive and potentially drive-wide.
+      normalizedPathIsInsideOrEqual(directory, scope.rootPath)
+    ) {
+      continue
+    }
+    seenDirectories.add(directoryKey)
+    if (seenDirectories.size > MAX_OUT_OF_ROOT_DIR_TARGETS) {
+      break
+    }
+    targets.push({
+      worktreeId: scope.worktreeId,
+      worktreePath: directory,
+      connectionId: scope.connectionId ?? undefined,
+      runtimeEnvironmentId: scope.runtimeEnvironmentId,
+      ...(canWatchLocalWindowsWslAliases({
+        worktreePath: directory,
+        runtimeEnvironmentId: scope.runtimeEnvironmentId,
+        connectionId: scope.connectionId,
+        worktree: scope.worktree,
+        repo: scope.repo,
+        folderWorkspace: scope.folderWorkspace,
+        projectGroup: scope.projectGroup
+      })
+        ? { allowLocalWindowsWslAliases: true as const }
+        : {})
+    })
+  }
+  return targets
+}
+
 function openFileRuntimeOwner(file: Pick<OpenFile, 'runtimeEnvironmentId'>): string | null {
   return file.runtimeEnvironmentId?.trim() || null
 }
@@ -304,6 +393,19 @@ export function getEditorExternalWatchTargets(
       }
       nextTargets.push(target)
       parts.push(getWatchedTargetKey(target))
+      for (const dirTarget of collectOutOfRootWatchTargets(state, {
+        worktreeId: id,
+        rootPath: wt?.path ?? folderWorkspace!.folderPath,
+        runtimeEnvironmentId: owner,
+        connectionId: connectionId ?? undefined,
+        worktree: wt,
+        repo,
+        folderWorkspace,
+        projectGroup
+      })) {
+        nextTargets.push(dirTarget)
+        parts.push(getWatchedTargetKey(dirTarget))
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

**What**

`getEditorExternalWatchTargets` now emits one additional watch target per distinct containing directory (per owner) for open files that resolve outside their worktree/folder-workspace root.

**Why**

#15612 — agent scratchpads (e.g. Claude Code's `/private/tmp/claude-501/<workspace>/<session>/scratchpad/`) sit outside the worktree **by design**, and every watch target was built as `wt?.path ?? folderWorkspace!.folderPath`, so a scratchpad document open in a tab was structurally unreachable by the watcher: no auto-reload, no changed-on-disk banner, no reaction to ⌘R — a stale document that looks current. As the reporter put it, this silently covers most of what a coding agent writes for a human to read.

The event→tab matching downstream is already absolute-path based (`directEditors` keyed by `file.filePath`), so events from a directory-scoped watch match out-of-root tabs with no changes to the correlation, tombstone, or self-write machinery.

**Guards**

- Directories that **contain** the watched root are skipped — the watch is recursive, so a sibling of the repo would otherwise fan out a parent-wide (potentially drive-wide) watcher.
- Files owned by a different SSH target (`externalSshTargetId`) are skipped: their path lives on a host this worktree's connection cannot watch.
- Untitled/diff-mode tabs excluded; one target per distinct directory; capped at 8 out-of-root directories so a pathological tab set cannot fan out watchers.
- Local Windows WSL-alias eligibility is re-evaluated for the directory path itself.

**Testing**

`useEditorExternalWatch-targets.test.ts` 26/26:

- New: out-of-root file adds a directory-scoped target (`worktreePath` = the containing dir); two files sharing a directory produce one target; a file whose directory contains the root adds nothing; `externalSshTargetId` files add nothing; 12 distinct directories are capped at 8 targets.
- Existing 21 tests updated to build in-root file paths explicitly — their assertions always implied in-root tabs but the fixture paths were accidentally outside the fixture roots, which the new logic would (correctly) have started watching.
- Verified pre-fix: the three positive new tests fail on the old builder.
- Adjacent suites (`useEditorExternalWatch-self-move`, `-complexity`, `editor-external-watch-path-index`) 16/16; `pnpm run typecheck` clean.

Fixes #15612