### PR TITLE
Fix flaky CI tests by adding retry logic and increasing timeouts

### DIFF
--- a/src/main/browser/browser-cookie-import-partition.electron.test.ts
+++ b/src/main/browser/browser-cookie-import-partition.electron.test.ts
@@ -16,12 +16,7 @@ afterAll(() => {
   }
 })
 
-// Why: on CI runners this Electron launch intermittently never reaches `ready` — the fixture's
-// watchdog fires with its step still 'starting', and the same signature hits sibling cookie
-// fixtures on unrelated PRs, including one whose watchdog allows 20s. Measured off-runner, `ready`
-// costs ~0.1-0.4s even at a quarter CPU, so the launch is wedged rather than slow and no watchdog
-// value fixes it. Relaunch once, and only for that signature: every assertion, import failure, and
-// crash after `ready` still fails on the first attempt.
+// Retry once when Electron startup times out before `ready`; keep later failures fatal.
 const FIXTURE_LAUNCH_ATTEMPTS = 2
 
 function neverReachedElectronReady(fixtureResult: string): boolean {

--- a/src/main/browser/browser-cookie-import-partition.electron.test.ts
+++ b/src/main/browser/browser-cookie-import-partition.electron.test.ts
@@ -16,6 +16,22 @@ afterAll(() => {
   }
 })
 
+// Why: on CI runners this Electron launch intermittently never reaches `ready` — the fixture's
+// watchdog fires with its step still 'starting', and the same signature hits sibling cookie
+// fixtures on unrelated PRs, including one whose watchdog allows 20s. Measured off-runner, `ready`
+// costs ~0.1-0.4s even at a quarter CPU, so the launch is wedged rather than slow and no watchdog
+// value fixes it. Relaunch once, and only for that signature: every assertion, import failure, and
+// crash after `ready` still fails on the first attempt.
+const FIXTURE_LAUNCH_ATTEMPTS = 2
+
+function neverReachedElectronReady(fixtureResult: string): boolean {
+  try {
+    return (JSON.parse(fixtureResult) as { step?: string }).step === 'timed out after starting'
+  } catch {
+    return false
+  }
+}
+
 type FixtureResult = {
   before: Record<string, unknown>
   after: Record<string, unknown>
@@ -182,21 +198,27 @@ async function runFixture(): Promise<FixtureResult> {
   })
   writeFileSync(fixturePath, buildFixtureMain(importPath, resultPath, sourceCookiesPath))
   const { ELECTRON_RUN_AS_NODE: _electronRunAsNode, ...env } = process.env
-  const electronArgs = [fixturePath, `--user-data-dir=${join(root, 'profile')}`]
   const executable = process.platform === 'linux' ? 'xvfb-run' : electronBinary
-  const args =
-    process.platform === 'linux'
-      ? ['--auto-servernum', electronBinary, ...electronArgs, '--no-sandbox']
-      : electronArgs
-  const run = spawnSync(executable, args, {
-    encoding: 'utf8',
-    env,
-    timeout: 60_000
-  })
-  const fixtureResult = existsSync(resultPath) ? readFileSync(resultPath, 'utf8') : 'no result'
-  expect(run.error).toBeUndefined()
-  expect(run.status, `${fixtureResult}\n${run.stdout}\n${run.stderr}`).toBe(0)
-  return JSON.parse(fixtureResult) as FixtureResult
+  for (let attempt = 1; ; attempt += 1) {
+    rmSync(resultPath, { force: true })
+    // Why a fresh profile per attempt: a launch that never reached `ready` may have left the
+    // Chromium profile mid-initialization, and reusing it would bias the retry.
+    const electronArgs = [fixturePath, `--user-data-dir=${join(root, `profile-${attempt}`)}`]
+    const run = spawnSync(
+      executable,
+      process.platform === 'linux'
+        ? ['--auto-servernum', electronBinary, ...electronArgs, '--no-sandbox']
+        : electronArgs,
+      { encoding: 'utf8', env, timeout: 60_000 }
+    )
+    const fixtureResult = existsSync(resultPath) ? readFileSync(resultPath, 'utf8') : 'no result'
+    if (attempt < FIXTURE_LAUNCH_ATTEMPTS && neverReachedElectronReady(fixtureResult)) {
+      continue
+    }
+    expect(run.error).toBeUndefined()
+    expect(run.status, `${fixtureResult}\n${run.stdout}\n${run.stderr}`).toBe(0)
+    return JSON.parse(fixtureResult) as FixtureResult
+  }
 }
 
 describe('native Chromium excluded partition cookie under Electron', () => {
@@ -220,5 +242,5 @@ describe('native Chromium excluded partition cookie under Electron', () => {
       'partitioned-google',
       'stale'
     ])
-  }, 90_000)
+  }, 150_000)
 })

--- a/src/main/skills/skill-install-lock.test.ts
+++ b/src/main/skills/skill-install-lock.test.ts
@@ -43,7 +43,9 @@ describe('skill install lock', () => {
       JSON.stringify({ token: 'dead-owner', pid: 2_147_483_647, createdAt: Date.now() })
     )
 
-    const release = await acquireSkillInstallLock({ path: lockPath, timeoutMs: 100 })
+    // Why: reclaiming costs a fsync plus one 50ms retry, so a 100ms budget expires on a
+    // loaded CI runner and surfaces the legacy file's rename ENOTDIR instead of reclaiming.
+    const release = await acquireSkillInstallLock({ path: lockPath, timeoutMs: 5_000 })
     expect((await readPublishedOwner(lockPath)).token).not.toBe('dead-owner')
     await release()
     await expect(readdir(lockPath)).rejects.toMatchObject({ code: 'ENOENT' })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​35 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​16 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​19 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## Problem

Two tests fail intermittently on CI runners due to timing and system load:
1. `browser-cookie-import-partition.electron.test.ts`: Electron launch never reaches 'ready' state before watchdog timeout, especially on busy runners
2. `skill-install-lock.test.ts`: Lock acquisition timeout (100ms) expires before fsync + retry cycle completes under load

## Solution

**browser-cookie-import-partition.electron.test.ts**:
- Retry Electron fixture up to 2 attempts if launch gets stuck in 'starting' state (detected via watchdog message)
- Use fresh profile directory per attempt to avoid bias from incomplete initialization
- Increase test timeout from 90s to 150s

**skill-install-lock.test.ts**:
- Increase lock acquisition timeout from 100ms to 5s to allow fsync + retry cycle to complete

## ELI5

Some tests fail randomly on busy CI runners. We added retry logic to restart Electron when it hangs, and we gave lock acquisition more time to complete its work.

## What Changed

- `browser-cookie-import-partition.electron.test.ts`: Added retry mechanism for flaky Electron launches with fresh profiles per attempt, increased timeout
- `skill-install-lock.test.ts`: Increased lock acquisition timeout from 100ms to 5s

## Why

CI runners are sometimes busy or slow, causing tests to fail due to timing issues rather than actual bugs. Retrying transient Electron launch failures and allowing sufficient time for system operations reduces flakiness without masking real issues.

## Linked Issue

Fixes #

## Visual Proof

N/A — test-only changes with no UI or behavior modifications

## Testing

- [ ] I manually tested these changes locally
- [ ] Automated tests added/updated, or explained why not below

## AI Disclosure

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [ ] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)