### PR TITLE
fix(ssh): retire orphaned relays during version GC instead of skipping them

### DIFF
--- a/src/main/ssh/ssh-relay-cross-version-isolation.test.ts
+++ b/src/main/ssh/ssh-relay-cross-version-isolation.test.ts
@@ -196,6 +196,8 @@ describe('cross-version isolation', () => {
     // — never a write, mkdir, chmod, touch, rm, node launch, or socket poll.
     // This prevents a future refactor that accidentally writes to the v1 dir
     // (e.g. shared install-complete, upload over symlink) from passing.
+    // The one non-probe exception is the orphan-retire signal (#13614): a
+    // SIGTERM addressed to the daemon process, which never writes the v1 dir.
     const v1Refs = allCmds.filter((c) => c.includes('relay-0.1.0+111111111111'))
     for (const cmd of v1Refs) {
       const isReadOnlyProbe =
@@ -205,7 +207,8 @@ describe('cross-version isolation', () => {
         /\btest -f\b/.test(cmd) ||
         /\btest -S\b/.test(cmd) ||
         /\bfor f in .*\.sock\b/.test(cmd)
-      expect(isReadOnlyProbe, `unexpected v1 reference: ${cmd}`).toBe(true)
+      const isOrphanRetireSignal = cmd.includes('kill -TERM') && cmd.includes('command -v lsof')
+      expect(isReadOnlyProbe || isOrphanRetireSignal, `unexpected v1 reference: ${cmd}`).toBe(true)
     }
   })
 })

--- a/src/main/ssh/ssh-relay-retire.test.ts
+++ b/src/main/ssh/ssh-relay-retire.test.ts
@@ -1,0 +1,175 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { createConnection, createServer, type Server } from 'node:net'
+import { tmpdir } from 'node:os'
+import { delimiter, join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./ssh-relay-deploy-helpers', () => ({
+  execCommand: vi.fn()
+}))
+
+import { execCommand } from './ssh-relay-deploy-helpers'
+import { retireOrphanedRelayCommand, tryRetireOrphanedRelay } from './ssh-relay-retire'
+import type { SshConnection } from './ssh-connection'
+import type { RemoteHostPlatform } from './ssh-remote-platform'
+
+const asHost = (os: string): RemoteHostPlatform =>
+  ({
+    path: os === 'win32' ? 'windows' : 'posix',
+    command: os === 'win32' ? 'powershell' : 'posix',
+    os,
+    arch: 'x64',
+    home: '/home/u'
+  }) as unknown as RemoteHostPlatform
+
+const POSIX_HOST = asHost('linux')
+const WINDOWS_HOST = asHost('win32')
+
+function writeExecutable(filePath: string, body: string): void {
+  writeFileSync(filePath, `#!/bin/sh\n${body}\n`, { mode: 0o755 })
+}
+
+async function listenOnSocket(server: Server, socketPath: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: Error): void => reject(error)
+    server.once('error', onError)
+    server.listen(socketPath, () => {
+      server.off('error', onError)
+      resolve()
+    })
+  })
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()))
+}
+
+describe('tryRetireOrphanedRelay', () => {
+  let envBin: string
+  let remoteDir: string
+  let server: Server
+
+  beforeEach(() => {
+    envBin = mkdtempSync(join(tmpdir(), 'orca-retire-bin-'))
+    remoteDir = mkdtempSync(join(tmpdir(), 'orca-retire-dir-'))
+    server = createServer(() => {})
+  })
+
+  afterEach(async () => {
+    await closeServer(server).catch(() => {})
+    rmSync(envBin, { recursive: true, force: true })
+    rmSync(remoteDir, { recursive: true, force: true })
+    vi.resetAllMocks()
+  })
+
+  // Runs the generated POSIX script under /bin/sh locally with a fake lsof on
+  // PATH and the temp dir substituted for the remote relay dir.
+  function mockExecRunsScriptLocally(): void {
+    vi.mocked(execCommand).mockImplementation(async (_conn, command) => {
+      const script = command.replace(
+        /dir=[^\n]+/,
+        `dir=${JSON.stringify(remoteDir).replaceAll('~', '\\~')}`
+      )
+      return execFileSync('/bin/sh', ['-c', script], {
+        encoding: 'utf8',
+        env: { ...process.env, PATH: `${envBin}${delimiter}${process.env.PATH}` },
+        timeout: 15_000
+      }).trim()
+    })
+  }
+
+  it('returns false without touching the host for Windows remotes', async () => {
+    mockExecRunsScriptLocally()
+    await expect(
+      tryRetireOrphanedRelay(
+        {} as SshConnection,
+        '/remote/orca-remote/relay-0.1.0+abc',
+        WINDOWS_HOST
+      )
+    ).resolves.toBe(false)
+    expect(vi.mocked(execCommand)).not.toHaveBeenCalled()
+  })
+
+  it('retires an orphaned listening daemon and reports RETIRED once its socket is gone', async () => {
+    mockExecRunsScriptLocally()
+    const sockPath = join(remoteDir, 'relay-0123456789abcdef.sock')
+    await listenOnSocket(server, sockPath)
+    // Fake lsof: one holder (the daemon), then unlink the socket like SIGTERM cleanup would.
+    writeExecutable(
+      join(envBin, 'lsof'),
+      ['for last; do :; done', '(sleep 0.2; rm -f "$last") &', 'echo $!'].join('\n')
+    )
+
+    const result = await tryRetireOrphanedRelay(
+      {} as SshConnection,
+      '/remote/orca-remote/relay-0.1.0+abc',
+      POSIX_HOST
+    )
+
+    expect(result).toBe(true)
+  })
+
+  it('keeps the directory when a client is still connected to the socket', async () => {
+    mockExecRunsScriptLocally()
+    const sockPath = join(remoteDir, 'relay-0123456789abcdef.sock')
+    await listenOnSocket(server, sockPath)
+    const client = createConnection(sockPath)
+    await new Promise<void>((resolve, reject) => {
+      client.once('connect', resolve)
+      client.once('error', reject)
+    })
+    writeExecutable(
+      join(envBin, 'lsof'),
+      ['for last; do :; done', 'echo $$ $PARENT_FAKE # two holders: listener plus client'].join(
+        '\n'
+      )
+    )
+
+    const result = await tryRetireOrphanedRelay(
+      {} as SshConnection,
+      '/remote/orca-remote/relay-0.1.0+abc',
+      POSIX_HOST
+    )
+
+    expect(result).toBe(false)
+    expect(existsSync(sockPath)).toBe(true)
+    client.destroy()
+  })
+
+  it('keeps the directory when lsof is unavailable on the remote host', async () => {
+    mockExecRunsScriptLocally()
+    writeExecutable(join(envBin, 'lsof'), `exit 127 # not installed`)
+    await listenOnSocket(server, join(remoteDir, 'relay-0123456789abcdef.sock'))
+    await expect(
+      tryRetireOrphanedRelay({} as SshConnection, '/remote/orca-remote/relay-0.1.0+abc', POSIX_HOST)
+    ).resolves.toBe(false)
+  })
+
+  it('reports RETIRED for a directory with no sockets at all', async () => {
+    mockExecRunsScriptLocally()
+    await expect(
+      tryRetireOrphanedRelay({} as SshConnection, '/remote/orca-remote/relay-0.1.0+abc', POSIX_HOST)
+    ).resolves.toBe(true)
+  })
+
+  it('returns false when the exec fails', async () => {
+    vi.mocked(execCommand).mockRejectedValue(new Error('ssh channel died'))
+    await expect(
+      tryRetireOrphanedRelay({} as SshConnection, '/remote/orca-remote/relay-0.1.0+abc', POSIX_HOST)
+    ).resolves.toBe(false)
+  })
+})
+
+describe('retireOrphanedRelayCommand', () => {
+  it('escapes the directory path', () => {
+    const command = retireOrphanedRelayCommand('/remote/dir with space')
+    expect(command).toContain("dir='/remote/dir with space'")
+  })
+
+  it('never emits SIGKILL — retirement stays graceful', () => {
+    const command = retireOrphanedRelayCommand('/remote/dir')
+    expect(command).toContain('kill -TERM')
+    expect(command).not.toContain('kill -KILL')
+  })
+})

--- a/src/main/ssh/ssh-relay-retire.ts
+++ b/src/main/ssh/ssh-relay-retire.ts
@@ -1,0 +1,69 @@
+import type { SshConnection } from './ssh-connection'
+import { shellEscape } from './ssh-connection-utils'
+import { execCommand } from './ssh-relay-deploy-helpers'
+import { isWindowsRemoteHost, type RemoteHostPlatform } from './ssh-remote-platform'
+
+/**
+ * Retire a relay daemon left behind in a superseded version directory (#13614).
+ *
+ * The GC in ssh-relay-versioned-install.ts keeps any directory whose socket is
+ * still alive, so an orphaned daemon blocks its own reclamation forever. This
+ * helper distinguishes a true orphan (a listening daemon with zero connected
+ * clients) from one still serving a client of an older app build, sends the
+ * orphan a graceful SIGTERM, and waits for it to unlink its socket.
+ *
+ * Best-effort by design: any inconclusive answer returns false so the caller
+ * keeps the directory and the next GC pass can try again.
+ */
+export async function tryRetireOrphanedRelay(
+  conn: SshConnection,
+  dir: string,
+  host: RemoteHostPlatform
+): Promise<boolean> {
+  if (isWindowsRemoteHost(host)) {
+    return false
+  }
+  try {
+    const out = await execCommand(conn, retireOrphanedRelayCommand(dir))
+    return out.trim() === 'RETIRED'
+  } catch {
+    return false
+  }
+}
+
+export function retireOrphanedRelayCommand(dir: string): string {
+  const escapedDir = shellEscape(dir)
+  return [
+    `dir=${escapedDir}`,
+    '[ -d "$dir" ] || { echo RETIRED; exit 0; }',
+    'found=0',
+    `for sock in "$dir"/relay-*.sock "$dir"/relay.sock; do`,
+    '  [ -S "$sock" ] || continue',
+    '  found=1',
+    '  command -v lsof >/dev/null 2>&1 || { echo KEEP; exit 0; }',
+    // Why -a: lsof ORs selectors by default and would list every Unix-socket
+    // holder on the host instead of only this socket's users (#8762).
+    '  pids=$(lsof -t -a -U "$sock" 2>/dev/null | sort -u)',
+    '  count=0',
+    '  for p in $pids; do count=$((count+1)); done',
+    '  if [ "$count" -gt 1 ]; then echo KEEP; exit 0; fi',
+    // Why SIGTERM only: the daemon\'s shutdown handler disposes PTYs gracefully
+    // and unlinks its own socket; a KILL here would strand remote shells.
+    '  if [ "$count" -eq 1 ]; then kill -TERM $pids 2>/dev/null || true; fi',
+    // count=0: stale socket with no holder; leave it for the existing stale
+    // socket unlink path so ownership rules stay in one place.
+    'done',
+    '[ "$found" -eq 0 ] && { echo RETIRED; exit 0; }',
+    'i=0',
+    'while [ $i -lt 10 ]; do',
+    '  alive=0',
+    '  for sock in "$dir"/relay-*.sock "$dir"/relay.sock; do',
+    '    [ -S "$sock" ] && alive=1 && break',
+    '  done',
+    '  [ "$alive" -eq 0 ] && { echo RETIRED; exit 0; }',
+    '  sleep 0.3',
+    '  i=$((i+1))',
+    'done',
+    'echo KEEP'
+  ].join('\n')
+}

--- a/src/main/ssh/ssh-relay-versioned-install-gc.test.ts
+++ b/src/main/ssh/ssh-relay-versioned-install-gc.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('fs', () => ({ existsSync: vi.fn(), readFileSync: vi.fn() }))
+vi.mock('./ssh-relay-deploy-helpers', () => ({ execCommand: vi.fn() }))
+vi.mock('./ssh-connection-utils', () => ({ shellEscape: (s: string) => `'${s}'` }))
+
+import { execCommand } from './ssh-relay-deploy-helpers'
+import { gcOldRelayVersions } from './ssh-relay-versioned-install'
+import type { SshConnection } from './ssh-connection'
+
+const mockExec = vi.mocked(execCommand)
+const conn = {} as SshConnection
+
+describe('gcOldRelayVersions orphan reclamation (#13614)', () => {
+  it('reclaims a sibling after retiring its orphaned live relay', async () => {
+    mockExec
+      .mockResolvedValueOnce('relay-0.1.0+aaa\nrelay-0.1.0+bbb\n')
+      .mockResolvedValueOnce('OPEN')
+      .mockResolvedValueOnce('COMPLETE')
+      .mockResolvedValueOnce('ALIVE')
+      .mockResolvedValueOnce('RETIRED')
+      .mockResolvedValueOnce('DEAD')
+      .mockResolvedValueOnce('OK')
+      .mockResolvedValueOnce('')
+      .mockResolvedValueOnce('OPEN')
+      .mockResolvedValueOnce('COMPLETE')
+      .mockResolvedValueOnce('DEAD')
+      .mockResolvedValueOnce('OWNED')
+      .mockResolvedValueOnce('MOVED')
+      .mockResolvedValueOnce('RELEASED')
+      .mockResolvedValueOnce('')
+
+    await gcOldRelayVersions(conn, '/home/u', '/home/u/.orca-remote/relay-0.1.0+bbb')
+
+    const commands = mockExec.mock.calls.map(([, command]) => command)
+    const retireCommand = commands.find((command) => command.includes('kill -TERM'))
+    expect(retireCommand).toContain("dir='/home/u/.orca-remote/relay-0.1.0+aaa'")
+    expect(retireCommand).not.toContain('kill -KILL')
+    expect(commands.at(-1)).toContain('relay-0.1.0+aaa.gc-tombstone')
+  })
+})

--- a/src/main/ssh/ssh-relay-versioned-install.test.ts
+++ b/src/main/ssh/ssh-relay-versioned-install.test.ts
@@ -751,13 +751,15 @@ describe('gcOldRelayVersions', () => {
       .mockResolvedValueOnce('OPEN')
       .mockResolvedValueOnce('COMPLETE')
       .mockRejectedValueOnce(new Error('liveness probe failed'))
+      .mockResolvedValueOnce('KEEP')
       .mockResolvedValueOnce('OPEN')
       .mockResolvedValueOnce('COMPLETE')
       .mockResolvedValueOnce('INCONCLUSIVE')
+      .mockResolvedValueOnce('KEEP')
 
     await gcOldRelayVersions(conn, '/home/u', '/home/u/.orca-remote/relay-0.1.0+bbb')
 
-    expect(mockExec).toHaveBeenCalledTimes(7)
+    expect(mockExec).toHaveBeenCalledTimes(9)
   })
 
   it('probes Windows GC liveness by connecting to named pipes, not process command lines', async () => {

--- a/src/main/ssh/ssh-relay-versioned-install.ts
+++ b/src/main/ssh/ssh-relay-versioned-install.ts
@@ -38,6 +38,7 @@ import {
 } from './ssh-remote-platform'
 import { windowsRelayPipePathsForSocketName } from './ssh-relay-endpoints'
 import { isUnconfirmedSshCommandTermination } from './ssh-relay-exec-command'
+import { tryRetireOrphanedRelay } from './ssh-relay-retire'
 import { isSshSessionLimitError } from './ssh-session-limit-error'
 
 // Single source of truth for GC and the version-dir parser; matches both the new and legacy relay-dir layouts.
@@ -323,7 +324,13 @@ async function isCandidateSafeToRemove(
 
   const sockAlive = await hasLiveRelaySocket(conn, dir, host, options)
   if (sockAlive) {
-    return false
+    // Why: a live socket in a superseded version dir is the #13614 upgrade orphan —
+    // the current daemon already owns its own versioned path, so retire the old one
+    // (gracefully, never with a connected client) instead of skipping GC forever.
+    const retired = await tryRetireOrphanedRelay(conn, dir, host)
+    if (!retired || (await hasLiveRelaySocket(conn, dir, host, options))) {
+      return false
+    }
   }
   return true
 }


### PR DESCRIPTION
Fixes #13614 (expected behaviour #2: "Reap the old relay after migration").

## Problem

Each relay build lives in its own content-hashed directory with its own socket path, so when Orca upgrades, the new daemon can never reattach the previous daemon's PTYs — the old one is structurally orphaned. `gcOldRelayVersions` keeps any sibling whose socket is still alive (`hasLiveRelaySocket` → `return false`), so the orphaned daemon survives indefinitely with its PTYs, memory, and CPU.

We hit this in the field: after an upgrade, the superseded relay (`--detached --grace-time 0`, 7 pooled PTYs, `clients=0`) kept one core pegged and accumulated **30+ hours of CPU** before it was killed by hand. The old directory also blocks GC forever, so `.orca-remote` accumulates one version directory per upgrade.

## Change

When the GC liveness probe finds a live socket inside a superseded version dir, ask the holder to leave before giving up:

- **`tryRetireOrphanedRelay`** (`src/main/ssh/ssh-relay-retire.ts`) sends a graceful SIGTERM only when `lsof -t -a -U` reports **exactly one holder** (the listener itself). A daemon that still has a connected client of an older app build is never signalled — e.g. a second machine on an older version stays untouched.
- **SIGTERM only, never SIGKILL**: the daemon's existing shutdown handler disposes PTYs gracefully and unlinks its own socket. If the kill is refused or the socket lingers, the directory is kept and the next GC pass retries — matching the GC's best-effort contract.
- Hosts without `lsof` and Windows remotes keep the previous keep-forever behavior (conservative first cut; happy to follow up on Windows named-pipe retirement if wanted).
- After a successful retirement, the socket is re-probed; once dead, the existing claim/move/tombstone removal path proceeds unchanged. No removal logic was modified.
- The cross-version isolation gate (`ssh-relay-cross-version-isolation.test.ts`) now admits the retire signal as the one non-probe v1 reference, since it addresses the daemon process and never writes the superseded directory.

## Verification

- `vitest run src/main/ssh/` — 1615 passed, 15 skipped (includes new tests below)
- `oxlint src/main/ssh/` — clean (no max-lines regressions)
- `tsc --noEmit -p config/tsconfig.node.json` — clean

New tests:
- `ssh-relay-retire.test.ts` — real Unix sockets + fake `lsof`: retires a single-holder orphan; keeps a daemon with a connected client; keeps when `lsof` is missing; RETIRED for a socket-less dir; false on exec failure; no-op on Windows; script contains SIGTERM and never SIGKILL.
- `ssh-relay-versioned-install-gc.test.ts` — full GC integration: `ALIVE` → retire → `RETIRED` → re-probe `DEAD` → claim/move/tombstone removal completes.