### PR TITLE
feat(plugins): project providerSession.id as sessionId on agent.status.changed

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2907,7 +2907,8 @@ void app.whenReady().then(async () => {
       worktreeId: enriched.worktreeId ?? null,
       paneKey: enriched.paneKey,
       state: enriched.payload.state,
-      receivedAt: enriched.receivedAt
+      receivedAt: enriched.receivedAt,
+      sessionId: enriched.providerSession?.id ?? null
     })
   })
   runtimeService.onWorktreeLifecycle((event) => {

--- a/src/shared/plugins/plugin-events.test.ts
+++ b/src/shared/plugins/plugin-events.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { agentStatusChangedPayloadSchema } from './plugin-events'
+
+const base = {
+  worktreeId: 'repo::/Users/a/project',
+  paneKey: '8f2a-4b1c:9de1-77af',
+  state: 'done',
+  receivedAt: 1_700_000_000_000
+}
+
+describe('agent.status.changed sessionId projection', () => {
+  it('accepts a provider session id and projects it through', () => {
+    const parsed = agentStatusChangedPayloadSchema.parse({ ...base, sessionId: 'sess-abc-123' })
+    expect(parsed.sessionId).toBe('sess-abc-123')
+  })
+
+  it('accepts null when the pane has no provider session yet', () => {
+    expect(agentStatusChangedPayloadSchema.parse({ ...base, sessionId: null }).sessionId).toBeNull()
+  })
+
+  it('stays backward compatible: existing emitters omit the field entirely', () => {
+    const parsed = agentStatusChangedPayloadSchema.parse(base)
+    expect(parsed.sessionId).toBeUndefined()
+    expect(parsed.paneKey).toBe(base.paneKey)
+  })
+
+  it('still strips anything not in the projection', () => {
+    // The point of the projection is that unknown fields do not reach plugins.
+    const parsed = agentStatusChangedPayloadSchema.parse({
+      ...base,
+      sessionId: 'sess-1',
+      transcriptPath: '/Users/a/.claude/projects/x/y.jsonl',
+      prompt: 'something private'
+    } as never)
+    expect(parsed).not.toHaveProperty('transcriptPath')
+    expect(parsed).not.toHaveProperty('prompt')
+  })
+
+  it('rejects a non-string session id', () => {
+    expect(() =>
+      agentStatusChangedPayloadSchema.parse({ ...base, sessionId: 42 } as never)
+    ).toThrow()
+  })
+
+  it('rejects an empty session id, so "" cannot masquerade as an identity', () => {
+    expect(() => agentStatusChangedPayloadSchema.parse({ ...base, sessionId: '' })).toThrow()
+  })
+})

--- a/src/shared/plugins/plugin-events.ts
+++ b/src/shared/plugins/plugin-events.ts
@@ -29,7 +29,14 @@ export const agentStatusChangedPayloadSchema = z.object({
   worktreeId: z.string().min(1).max(2048).nullable(),
   paneKey: z.string().min(1).max(2048),
   state: z.string().min(1).max(256),
-  receivedAt: z.number().finite().positive()
+  receivedAt: z.number().finite().positive(),
+  /** Provider-owned session id, when the pane has one.
+   *  Why: `paneKey` is `<tabId>:<layoutLeaf>` and carries no session identity, so a plugin seeing
+   *  two panes in one worktree cannot tell which agent transitioned — and several agents per
+   *  worktree is the common case. This is the id only, never `providerSession.transcriptPath`:
+   *  correlation needs a stable distinct token, not a filesystem path, so the payload stays a
+   *  bounded projection. Nullable and optional, so existing subscribers are unaffected. */
+  sessionId: z.string().min(1).max(2048).nullable().optional()
 })
 
 export const PLUGIN_EVENT_PAYLOAD_SCHEMAS: Record<PluginEventName, z.ZodTypeAny> = {


### PR DESCRIPTION
Closes #15639.

## Problem

`agent.status.changed` gives a plugin two identifiers, and neither identifies the agent session:

```
paneKey    = "<tabId UUID>:<layoutLeaf UUID>"    ← no session identity
worktreeId = "<repoId>::<absolute worktree path>"
```

A plugin watching two panes in one worktree cannot tell which agent transitioned. Since running
several agents side by side in one repo is what Orca is *for*, the gap bites in exactly the case the
product is built around.

The information is already at the emit site — `enriched.providerSession` — and is dropped when the
four-field projection is built (`src/main/index.ts:2906-2911`).

## Change

Three lines of behaviour, plus a test file.

- `plugin-events.ts` — add `sessionId: z.string().min(1).max(2048).nullable().optional()` to
  `agentStatusChangedPayloadSchema`.
- `index.ts` — emit `sessionId: enriched.providerSession?.id ?? null`.

**The id only, never `transcriptPath`.** Correlation needs a stable, distinct token — not a
filesystem path — so the payload stays a bounded projection and nothing sensitive is added to the
event stream. That is deliberate, and I'd rather ship the weaker field than widen the surface.

**Optional and nullable**, so every existing subscriber parses unchanged.

## Tests

New `src/shared/plugins/plugin-events.test.ts`, 6 cases:

- a session id is projected through
- `null` is accepted when the pane has no provider session yet
- **backward compatibility**: a payload omitting the field entirely still parses
- **the projection still strips**: `transcriptPath` and `prompt` do not survive
- a non-string id is rejected
- an empty string is rejected, so `""` cannot masquerade as an identity

```
✓ src/shared/plugins/plugin-events.test.ts (6 tests)
```

I also ran your existing plugin suites to be sure nothing regressed:

```
npx vitest run --config config/vitest.config.ts src/shared/plugins src/main/plugins
Test Files  57 passed (57)
     Tests  359 passed (359)
```

## Why other plugin authors want this

Any plugin doing per-session bookkeeping needs it — time trackers, per-agent notifications,
dashboards, cost accounting, session-scoped storage. Today each one either mis-attributes silently
or carries a heuristic.

My case is a text-to-speech plugin ([YoraiLevi/orca-plugin-tts](https://github.com/YoraiLevi/orca-plugin-tts)):
without a session id it picks the most-recently-modified transcript in the worktree, which is a coin
flip when two agents are active. It currently detects the ambiguity and warns the user rather than
confidently speaking the wrong agent's words. This field removes the guess entirely.

## Alternatives I'm happy to take instead

- a different field name
- a per-plugin pseudonymous id rather than the provider's own, if you'd rather not expose it
- gating it behind a capability

Any of those solves the correlation problem. Tell me which you prefer and I'll rework it.