### PR TITLE
feat(plugins): let sandboxed panels call storage.get, so a panel can render live state

### DIFF
--- a/src/main/plugins/plugin-host-conformance.test.ts
+++ b/src/main/plugins/plugin-host-conformance.test.ts
@@ -199,8 +199,11 @@ describe('plugin host main/relay conformance', () => {
       code: 'invalid_params'
     },
     {
+      // storage.get is panel-callable so a panel can render live state; storage WRITES stay
+      // worker-only, so this exercises the same panel_forbidden path with a method that is
+      // still forbidden by design.
       name: 'panel-forbidden method',
-      request: { method: 'storage.get', params: { key: 'alpha' } },
+      request: { method: 'storage.set', params: { key: 'alpha', value: 1 } },
       viaPanel: true,
       policy: () => createPolicy(['storage']),
       code: 'panel_forbidden'

--- a/src/shared/plugins/plugin-host-api.ts
+++ b/src/shared/plugins/plugin-host-api.ts
@@ -156,7 +156,13 @@ export const PLUGIN_HOST_API_V0: readonly PluginHostMethodSpec[] = [
     scope: 'plugin-private',
     capability: 'storage',
     mutation: false,
-    panel: false,
+    // Why panel-callable: a panel currently has no way to read ANY state its own worker computed,
+    // so a plugin panel can only ever render static markup. This is the narrowest possible fix —
+    // read-only, plugin-private scope, already gated on the `storage` capability, and strictly
+    // less powerful than `terminal.sendText`, which panels may already call and which mutates a
+    // terminal. Writes (`storage.set`/`delete`) deliberately stay worker-only, so a panel can
+    // observe state but never author it.
+    panel: true,
     params: storageGetParams,
     result: storageGetResult
   }),

--- a/src/shared/plugins/plugin-panel-storage-read.test.ts
+++ b/src/shared/plugins/plugin-panel-storage-read.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { PLUGIN_HOST_API_V0, isPluginPanelAction } from './plugin-host-api'
+
+const byName = (name: string) => PLUGIN_HOST_API_V0.find((s) => s.name === name)
+
+describe('panel-callable surface', () => {
+  it('storage.get is callable from a panel, so a panel can render live state', () => {
+    expect(isPluginPanelAction('storage.get')).toBe(true)
+    expect(byName('storage.get')?.panel).toBe(true)
+  })
+
+  it('storage.get stays read-only and plugin-private', () => {
+    const spec = byName('storage.get')
+    expect(spec?.mutation).toBe(false)
+    expect(spec?.scope).toBe('plugin-private')
+    expect(spec?.capability).toBe('storage')
+  })
+
+  it('writes stay worker-only: a panel may observe state but never author it', () => {
+    for (const name of ['storage.set', 'storage.delete']) {
+      expect(isPluginPanelAction(name), `${name} must not be panel-callable`).toBe(false)
+      expect(byName(name)?.panel).toBe(false)
+    }
+  })
+
+  it('secrets remain entirely worker-only', () => {
+    for (const name of ['secrets.get', 'secrets.set', 'secrets.delete']) {
+      expect(isPluginPanelAction(name), `${name} must not be panel-callable`).toBe(false)
+    }
+  })
+
+  it('every panel-callable method is still capability-gated', () => {
+    for (const spec of PLUGIN_HOST_API_V0.filter((s) => s.panel)) {
+      expect(spec.capability, `${spec.name} is panel-callable without a capability`).toBeTruthy()
+    }
+  })
+
+  it('no panel-callable method mutates anything outside an explicit scope', () => {
+    for (const spec of PLUGIN_HOST_API_V0.filter((s) => s.panel && s.mutation)) {
+      expect(['explicit-terminal', 'desktop']).toContain(spec.scope)
+    }
+  })
+})


### PR DESCRIPTION
Follows #15638. That issue asked for a host→panel message channel; this is a much smaller change
that solves most of the same problem, so I built it instead.

## Problem

A plugin panel cannot read **any** state its own worker computed.

| Method | `panel:` |
|---|---|
| `workspace.readContext` | true |
| `terminal.sendText` | true |
| `notifications.show` | true |
| `storage.get`, `storage.set`, `settings.get`, `settings.set`, `secrets.*`, `events.subscribe` | **false** |

There is also no host→panel push. So a panel can only render static markup — whatever the plugin
author hard-coded at build time.

My plugin reads agent replies aloud. Users cannot see what is currently being read, which session
it came from, or what is queued behind it, because the panel has no way to learn any of it. The
real report that prompted this: *"this is really confusing what it is even reading right now… a way
to control something and not feel helpless."* For an accessibility plugin that is not a cosmetic
gap.

## Change

One line: `storage.get` becomes `panel: true`.

The worker writes its status to plugin-private storage; the panel polls and renders it. No new API,
no new capability, no new transport.

**Why this is the narrowest possible fix**

- **Read-only.** `storage.set` and `storage.delete` stay worker-only, so a panel can observe state
  but never author it.
- **Plugin-private scope.** A plugin can only read what it wrote itself.
- **Already capability-gated** on `storage`, which the user consents to at install.
- **Strictly less powerful than what panels can already do.** `terminal.sendText` is panel-callable
  and *types into the user's terminal*. Reading a plugin's own private key/value store is a smaller
  privilege than that, and today the weaker one is the forbidden one.
- **Secrets untouched.** `secrets.*` remain entirely worker-only.

## Tests

New `src/shared/plugins/plugin-panel-storage-read.test.ts` — 6 cases. Beyond the new surface it
pins invariants that should hold regardless of this PR:

- writes and `secrets.*` are **not** panel-callable
- every panel-callable method is capability-gated
- no panel-callable mutation escapes an explicit scope

**One existing fixture changed, and I want to flag it explicitly.**
`plugin-host-conformance.test.ts` used `storage.get` as its exemplar of a panel-forbidden method.
That case exists to prove main and relay return identical `panel_forbidden` codes, not to pin that
particular method, so it now uses `storage.set` — a write, still forbidden by design. The case still
exercises the same path. If you would rather it used `settings.get`, say so and I will switch it.

```
npx vitest run --config config/vitest.config.ts src/main/plugins src/shared/plugins
Test Files  57 passed (57)
     Tests  359 passed (359)
```

## Why other plugin authors want this

Every panel today is a static page. With this, a panel can show progress, a queue, a log tail, a
last-run result, a live status — anything the worker knows. That is the difference between panels
being decorative and being useful.

If you would rather solve it with the push channel from #15638, I am happy to build that instead —
this seemed like the version most likely to be safely mergeable today.