### PR TITLE
fix(dev): give each worktree its own dev userData profile

### DIFF
--- a/config/scripts/dev-user-data-profile.mjs
+++ b/config/scripts/dev-user-data-profile.mjs
@@ -1,0 +1,169 @@
+// Why this module exists: every dev checkout resolved userData to the same `<appData>/orca-dev`
+// directory, so two `pnpm dev` instances from different worktrees shared one profile. The
+// single-instance lock is skipped in dev on purpose (#1419), so the second instance boots fully and
+// overwrites the first's `orca-runtime.json`, terminal daemon, and generated CLI shim. Nothing
+// errors -- both windows work -- but `orca <cmd>` silently retargets the last instance to start, and
+// the runtime record only self-heals once a pid is dead (#10840, which documents that two live
+// runtimes on one profile fight over the file).
+//
+// The profile directory is the one identity axis that is free to vary: it is set through
+// `app.setPath('userData')`, not `app.setName()`, so the dev bundle's cdhash and the shared
+// "Orca Dev Safe Storage" Keychain item both stay put (#15183).
+
+import { createHash } from 'node:crypto'
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+
+export const SHARED_DEV_PROFILE_DIR_NAME = 'orca-dev'
+export const DEV_PROFILE_OWNER_FILE = 'dev-profile-owner.json'
+
+export function getDevProfileBaseDir(platform = process.platform, env = process.env) {
+  if (platform === 'darwin') {
+    return path.join(env.HOME ?? '', 'Library', 'Application Support')
+  }
+  if (platform === 'win32') {
+    return env.APPDATA ?? path.join(env.USERPROFILE ?? '', 'AppData', 'Roaming')
+  }
+  return env.XDG_CONFIG_HOME ?? path.join(env.HOME ?? '', '.config')
+}
+
+// Why: the directory name is addressed by hand (`"<profile>/cli/bin/orca" status`), so keep it
+// legible rather than hashing every checkout into an opaque path.
+export function sanitizeProfileSegment(value) {
+  const cleaned = (value ?? '')
+    .replace(/[^A-Za-z0-9._-]+/g, '-')
+    .replace(/^[-.]+|[-.]+$/g, '')
+    .slice(0, 60)
+  return cleaned || 'worktree'
+}
+
+function shortRepoRootHash(repoRoot) {
+  return createHash('sha1').update(repoRoot).digest('hex').slice(0, 6)
+}
+
+/**
+ * Which userData directory this checkout owns.
+ *
+ * `readOwnerRepoRoot(dir)` returns the repoRoot recorded in that directory's owner marker, or null
+ * when the directory is unclaimed (never used, or predates this marker). It is injected so the
+ * decision stays testable without a filesystem.
+ *
+ * The legacy shared directory is adopted rather than abandoned: an existing developer's main
+ * checkout keeps the profile it has always used, and only the checkouts that would have collided
+ * with it get a new one. Adoption is restricted to a primary worktree so a linked worktree cannot
+ * claim the profile its own main checkout is about to want.
+ */
+export function resolveDevUserDataProfile({
+  repoRoot,
+  baseDir,
+  isPrimaryWorktree,
+  worktreeName,
+  readOwnerRepoRoot,
+  env = process.env
+}) {
+  const override = env.ORCA_DEV_USER_DATA_PATH?.trim()
+  if (override) {
+    return { path: override, kind: 'override', shouldClaim: false }
+  }
+
+  const sharedPath = path.join(baseDir, SHARED_DEV_PROFILE_DIR_NAME)
+  if (env.ORCA_DEV_SHARED_PROFILE === '1') {
+    return { path: sharedPath, kind: 'shared-forced', shouldClaim: false }
+  }
+
+  const sharedOwner = readOwnerRepoRoot(sharedPath)
+  if (isPrimaryWorktree && (sharedOwner === null || sharedOwner === repoRoot)) {
+    return { path: sharedPath, kind: 'shared', shouldClaim: true }
+  }
+
+  const named = path.join(
+    baseDir,
+    `${SHARED_DEV_PROFILE_DIR_NAME}-${sanitizeProfileSegment(worktreeName)}`
+  )
+  const namedOwner = readOwnerRepoRoot(named)
+  if (namedOwner === null || namedOwner === repoRoot) {
+    return { path: named, kind: 'worktree', shouldClaim: true }
+  }
+
+  // Why: two checkouts can share a directory name (`~/a/sandbox` and `~/b/sandbox`), and handing
+  // both the same profile would reintroduce exactly the collision this module exists to prevent.
+  return {
+    path: `${named}-${shortRepoRootHash(repoRoot)}`,
+    kind: 'worktree-disambiguated',
+    shouldClaim: true
+  }
+}
+
+export function readDevProfileOwner(profileDir) {
+  try {
+    const parsed = JSON.parse(readFileSync(path.join(profileDir, DEV_PROFILE_OWNER_FILE), 'utf8'))
+    return typeof parsed?.repoRoot === 'string' && parsed.repoRoot ? parsed.repoRoot : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Record which checkout owns this profile.
+ *
+ * `wx` makes the first writer win: two runners starting together would otherwise both read an
+ * unclaimed directory and both believe they own it. The loser re-reads and re-resolves.
+ */
+export function claimDevProfile(profileDir, repoRoot, nowMs) {
+  mkdirSync(profileDir, { recursive: true })
+  try {
+    writeFileSync(
+      path.join(profileDir, DEV_PROFILE_OWNER_FILE),
+      `${JSON.stringify({ repoRoot, claimedAt: nowMs }, null, 2)}\n`,
+      { encoding: 'utf8', flag: 'wx' }
+    )
+    return repoRoot
+  } catch {
+    return readDevProfileOwner(profileDir) ?? repoRoot
+  }
+}
+
+/** Resolve the profile and record ownership, re-resolving once if another checkout claimed it first. */
+export function resolveAndClaimDevUserDataProfile({
+  repoRoot,
+  baseDir,
+  isPrimaryWorktree,
+  worktreeName,
+  env = process.env,
+  nowMs = Date.now()
+}) {
+  const inputs = {
+    repoRoot,
+    baseDir,
+    isPrimaryWorktree,
+    worktreeName,
+    env,
+    readOwnerRepoRoot: readDevProfileOwner
+  }
+  const resolved = resolveDevUserDataProfile(inputs)
+  if (!resolved.shouldClaim || claimDevProfile(resolved.path, repoRoot, nowMs) === repoRoot) {
+    return resolved
+  }
+  const reResolved = resolveDevUserDataProfile(inputs)
+  if (reResolved.shouldClaim) {
+    claimDevProfile(reResolved.path, repoRoot, nowMs)
+  }
+  return reResolved
+}
+
+/**
+ * Whether `repoRoot` is the repository's primary worktree.
+ *
+ * `git rev-parse` reports the same path for both in a primary worktree; a linked worktree's gitdir
+ * is `<primary>/.git/worktrees/<name>` while its common dir stays `<primary>/.git`. A checkout with
+ * no usable git (tarball, git missing) is treated as primary so it keeps the legacy behaviour.
+ *
+ * Both values are resolved against `repoRoot`: `--git-dir` and `--git-common-dir` answer relative to
+ * the working directory, and `--path-format=absolute` is Git 2.31+, above the 2.25 baseline.
+ */
+export function isPrimaryWorktreePath(gitDir, gitCommonDir, repoRoot) {
+  if (!gitDir || !gitCommonDir) {
+    return true
+  }
+  return path.resolve(repoRoot, gitDir) === path.resolve(repoRoot, gitCommonDir)
+}

--- a/config/scripts/dev-user-data-profile.test.ts
+++ b/config/scripts/dev-user-data-profile.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+// @ts-expect-error -- plain .mjs build script without type declarations
+import {
+  isPrimaryWorktreePath,
+  resolveDevUserDataProfile,
+  sanitizeProfileSegment
+} from './dev-user-data-profile.mjs'
+
+const BASE = '/home/dev/.config'
+const MAIN = '/src/orca'
+const WORKTREE = '/src/orca-worktrees/sandbox-a'
+
+function resolve(overrides: Partial<Parameters<typeof resolveDevUserDataProfile>[0]> = {}): {
+  path: string
+  kind: string
+  shouldClaim: boolean
+} {
+  return resolveDevUserDataProfile({
+    repoRoot: MAIN,
+    baseDir: BASE,
+    isPrimaryWorktree: true,
+    worktreeName: 'orca',
+    readOwnerRepoRoot: () => null,
+    env: {},
+    ...overrides
+  })
+}
+
+describe('resolveDevUserDataProfile', () => {
+  it('keeps the legacy shared profile for an unclaimed primary worktree', () => {
+    expect(resolve()).toMatchObject({ path: `${BASE}/orca-dev`, kind: 'shared' })
+  })
+
+  it('keeps the shared profile across restarts of the checkout that claimed it', () => {
+    expect(resolve({ readOwnerRepoRoot: () => MAIN })).toMatchObject({ path: `${BASE}/orca-dev` })
+  })
+
+  it('gives a linked worktree its own profile even when the shared one is unclaimed', () => {
+    expect(
+      resolve({ repoRoot: WORKTREE, isPrimaryWorktree: false, worktreeName: 'sandbox-a' })
+    ).toMatchObject({ path: `${BASE}/orca-dev-sandbox-a`, kind: 'worktree', shouldClaim: true })
+  })
+
+  it('gives a second clone its own profile once another checkout owns the shared one', () => {
+    expect(
+      resolve({
+        repoRoot: '/src/orca-two',
+        worktreeName: 'orca-two',
+        readOwnerRepoRoot: (dir: string) => (dir === `${BASE}/orca-dev` ? MAIN : null)
+      })
+    ).toMatchObject({ path: `${BASE}/orca-dev-orca-two`, kind: 'worktree' })
+  })
+
+  it('disambiguates same-named worktrees from different repositories', () => {
+    const first = resolve({
+      repoRoot: '/a/sandbox',
+      isPrimaryWorktree: false,
+      worktreeName: 'sandbox',
+      readOwnerRepoRoot: (dir: string) => (dir === `${BASE}/orca-dev-sandbox` ? '/b/sandbox' : null)
+    })
+    expect(first.kind).toBe('worktree-disambiguated')
+    expect(first.path).toMatch(new RegExp(`^${BASE}/orca-dev-sandbox-[0-9a-f]{6}$`))
+    // Why: a stable path per checkout — a rotating suffix would strand the previous run's state.
+    expect(
+      resolve({
+        repoRoot: '/a/sandbox',
+        isPrimaryWorktree: false,
+        worktreeName: 'sandbox',
+        readOwnerRepoRoot: (dir: string) =>
+          dir === `${BASE}/orca-dev-sandbox` ? '/b/sandbox' : null
+      }).path
+    ).toBe(first.path)
+  })
+
+  it('honours an explicit override without claiming it', () => {
+    expect(
+      resolve({ env: { ORCA_DEV_USER_DATA_PATH: '/tmp/probe' }, isPrimaryWorktree: false })
+    ).toMatchObject({ path: '/tmp/probe', kind: 'override', shouldClaim: false })
+  })
+
+  it('lets ORCA_DEV_SHARED_PROFILE opt a worktree back into the shared profile', () => {
+    expect(
+      resolve({
+        env: { ORCA_DEV_SHARED_PROFILE: '1' },
+        isPrimaryWorktree: false,
+        repoRoot: WORKTREE,
+        worktreeName: 'sandbox-a'
+      })
+    ).toMatchObject({ path: `${BASE}/orca-dev`, kind: 'shared-forced', shouldClaim: false })
+  })
+})
+
+describe('sanitizeProfileSegment', () => {
+  it('keeps a readable directory name and strips path-significant characters', () => {
+    expect(sanitizeProfileSegment('feat/new thing')).toBe('feat-new-thing')
+    expect(sanitizeProfileSegment('../escape')).toBe('escape')
+    expect(sanitizeProfileSegment('')).toBe('worktree')
+  })
+})
+
+describe('isPrimaryWorktreePath', () => {
+  it('treats matching git dirs as primary, resolving git rev-parse output against the repo root', () => {
+    expect(isPrimaryWorktreePath('.git', '.git', MAIN)).toBe(true)
+    expect(isPrimaryWorktreePath(`${MAIN}/.git`, '.git', MAIN)).toBe(true)
+  })
+
+  it('treats a linked worktree gitdir as non-primary', () => {
+    expect(
+      isPrimaryWorktreePath(`${MAIN}/.git/worktrees/sandbox-a`, `${MAIN}/.git`, WORKTREE)
+    ).toBe(false)
+  })
+
+  it('falls back to primary when git is unavailable', () => {
+    expect(isPrimaryWorktreePath(null, null, MAIN)).toBe(true)
+  })
+})

--- a/config/scripts/orca-dev.mjs
+++ b/config/scripts/orca-dev.mjs
@@ -4,6 +4,11 @@ import { spawnSync } from 'node:child_process'
 import { accessSync, constants, existsSync, realpathSync, statSync } from 'node:fs'
 import path from 'node:path'
 import { prepareDevCliTerminalWrappers } from './dev-cli-terminal-wrapper.mjs'
+import {
+  getDevProfileBaseDir,
+  isPrimaryWorktreePath,
+  resolveAndClaimDevUserDataProfile
+} from './dev-user-data-profile.mjs'
 
 const scriptPath = realpathSync(import.meta.filename)
 const scriptDir = path.dirname(scriptPath)
@@ -43,20 +48,27 @@ if (result.signal) {
 }
 process.exit(result.status ?? (result.error ? 1 : 0))
 
+// Why the same resolution as the dev runner: `orca-dev status` run from a worktree must address that
+// worktree's instance, not whichever instance last claimed the shared profile.
 function getDefaultDevUserDataPath() {
-  if (process.platform === 'darwin') {
-    return path.join(process.env.HOME ?? '', 'Library', 'Application Support', 'orca-dev')
-  }
-  if (process.platform === 'win32') {
-    return path.join(
-      process.env.APPDATA ?? path.join(process.env.USERPROFILE ?? '', 'AppData', 'Roaming'),
-      'orca-dev'
-    )
-  }
-  return path.join(
-    process.env.XDG_CONFIG_HOME ?? path.join(process.env.HOME ?? '', '.config'),
-    'orca-dev'
-  )
+  return resolveAndClaimDevUserDataProfile({
+    repoRoot,
+    baseDir: getDevProfileBaseDir(),
+    isPrimaryWorktree: isPrimaryWorktreePath(
+      readGitValue(['rev-parse', '--git-dir']),
+      readGitValue(['rev-parse', '--git-common-dir']),
+      repoRoot
+    ),
+    worktreeName: path.basename(repoRoot)
+  }).path
+}
+
+function readGitValue(args) {
+  const result = spawnSync('git', ['-C', repoRoot, ...args], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore']
+  })
+  return result.status === 0 ? result.stdout.trim() || null : null
 }
 
 function getElectronExecutable() {

--- a/config/scripts/run-electron-vite-dev.mjs
+++ b/config/scripts/run-electron-vite-dev.mjs
@@ -23,6 +23,11 @@ import {
   getDevBundlePlistPatches,
   getDevHelperPlistPatches
 } from './dev-electron-bundle-identity.mjs'
+import {
+  getDevProfileBaseDir,
+  isPrimaryWorktreePath,
+  resolveAndClaimDevUserDataProfile
+} from './dev-user-data-profile.mjs'
 
 // Why: Electron-based hosts (e.g. Claude Code, VS Code) set
 // ELECTRON_RUN_AS_NODE=1 in their terminal environment. If this leaks into
@@ -436,23 +441,25 @@ function restoreElectronFrameworkSymlinks(appPath) {
   }
 }
 
+// Why every instance exports the resolved path: the Electron main, the generated CLI shim, and any
+// terminal the app spawns must agree on one profile. Leaving it implicit is what let a second
+// worktree's instance take over the first's runtime record.
 function getDevUserDataPath() {
   if (process.env.ORCA_DEV_USER_DATA_PATH) {
     return process.env.ORCA_DEV_USER_DATA_PATH
   }
-  if (process.platform === 'darwin') {
-    return path.join(process.env.HOME ?? '', 'Library', 'Application Support', 'orca-dev')
-  }
-  if (process.platform === 'win32') {
-    return path.join(
-      process.env.APPDATA ?? path.join(process.env.USERPROFILE ?? '', 'AppData', 'Roaming'),
-      'orca-dev'
-    )
-  }
-  return path.join(
-    process.env.XDG_CONFIG_HOME ?? path.join(process.env.HOME ?? '', '.config'),
-    'orca-dev'
-  )
+  const resolved = resolveAndClaimDevUserDataProfile({
+    repoRoot,
+    baseDir: getDevProfileBaseDir(),
+    isPrimaryWorktree: isPrimaryWorktreePath(
+      readGitValue(['rev-parse', '--git-dir']),
+      readGitValue(['rev-parse', '--git-common-dir']),
+      repoRoot
+    ),
+    worktreeName: path.basename(repoRoot)
+  })
+  process.env.ORCA_DEV_USER_DATA_PATH = resolved.path
+  return resolved.path
 }
 
 function prepareDevCliWrapper() {
@@ -465,6 +472,8 @@ function prepareDevCliWrapper() {
 
   process.env.PATH = `${binDir}${path.delimiter}${process.env.PATH ?? ''}`
   console.log(`[orca-dev] Prepared wrapper in ${binDir}`)
+  // Why: the profile is how every CLI command addresses this instance, so print the one it got.
+  console.log(`[orca-dev] Profile: ${userDataPath}`)
 }
 
 function getElectronExecutable() {


### PR DESCRIPTION
## ELI5

If you run `pnpm dev` from two different worktrees, both dev builds write their state into the same folder. They both run fine, but only one of them can be "the" Orca that `orca <cmd>` talks to — and it's whichever started last. So you can run a command intending your feature branch's build and silently hit the other one. This makes each checkout use its own folder, while the checkout you already use keeps the folder it has today.

## What Changed

`pnpm dev` (and `orca-dev`) now resolve `userData` per checkout instead of always `<appData>/orca-dev`:

- A checkout claims its profile directory with an owner marker (`dev-profile-owner.json`) recording its repo root. The marker is written with `wx`, so if two runners start together the first writer wins and the loser re-resolves.
- A **primary worktree** adopts the legacy `orca-dev` directory when it is unclaimed — existing profiles are untouched and nothing migrates.
- A linked worktree, or a second clone once another checkout owns the shared directory, resolves to `orca-dev-<worktree>`; if two checkouts share a directory name (`~/a/sandbox`, `~/b/sandbox`) the loser gets a stable `-<repoRootHash>` suffix.
- `ORCA_DEV_USER_DATA_PATH` still overrides everything (`config/scripts/dev-fresh-profile.sh` depends on this), and `ORCA_DEV_SHARED_PROFILE=1` opts back into the old shared behaviour.
- The runner prints `[orca-dev] Profile: <path>` at startup, because that path is how any CLI command addresses the instance.
- `config/scripts/orca-dev.mjs` uses the same resolution, so `orca-dev status` run inside a worktree addresses *that* worktree's instance.

New module `config/scripts/dev-user-data-profile.mjs` holds the decision as a pure function with the filesystem injected; the runner and the CLI entry both call it.

## Why

The dev single-instance lock is skipped on purpose so parallel worktree dev builds are possible (#1419), and per-branch Dock names (#2068, #2111), per-worktree CDP ports (#1511) and the content-addressed bundle cache (#15247) all exist to make several instances usable at once. The profile directory was the one identity axis left shared — and it is the one that decides *which instance a CLI command reaches*, because the address is the profile path (`orca-runtime.json` inside it), not a flag.

The result was silent misrouting: the second instance boots fully, takes over `orca-runtime.json`, replaces the terminal daemon, and rewrites `<profile>/cli/bin/orca` to point at its own Electron/CLI while still exporting the other profile. #10840 already documents the boundary this change removes — "two live runtimes sharing a profile would otherwise fight over the file" — and only repairs the record once a pid is *dead*.

**Why this axis is safe to vary.** `userData` moves through `app.setPath('userData')`, which runs before `app.setName()`. It does not touch the dev bundle's Info.plist (so the ad-hoc cdhash is unchanged) and does not touch `appName` (so the shared `Orca Dev Safe Storage` Keychain item is unchanged) — the two invariants `dev-electron-bundle-identity.mjs` and #15183 exist to protect. Confirmed in practice: no Keychain prompt on any run below.

Adopting the legacy directory rather than renaming it is deliberate: an existing developer's main checkout keeps its projects, settings and sessions, and only the checkouts that would have collided get something new. Adoption is restricted to a primary worktree so a linked worktree cannot claim the profile its own main checkout is about to want.

Seeding a new worktree profile from an existing one is intentionally out of scope; `config/scripts/dev-fresh-profile.sh` remains the way to ask for a deliberately empty profile.

## Linked Issue

Fixes #15647

## Visual Proof

N/A — no UI or interaction change. The only user-visible surface is one added stdout line from the dev runner (`[orca-dev] Profile: <path>`).

## Testing

Manually verified on macOS 15 (Darwin 25.5.0) with three Orca processes running at once: packaged `/Applications/Orca.app`, a dev build from the main checkout, and a dev build from a linked worktree.

The probe is the same before and after — the pid recorded in the *shared* profile's `orca-runtime.json` while the main checkout's instance is running, then `pnpm dev` in a linked worktree with no env overrides:

| | before this change | after this change |
|---|---|---|
| `orca-dev/orca-runtime.json` pid | 55813 → **62233** (taken over) | 55813 → **55813** (untouched) |
| worktree instance's profile | — (shared) | `orca-dev-sandbox-a`, pid 5965 |
| `[daemon] Replacing daemon…` lines | 1 | 0 |
| `<profile>/cli/bin/orca` target | rewritten to the worktree's build | unchanged |

Before the change, `orca status` on the shared profile answered for the worktree instance while the main checkout's instance was still running and windowed. After the change, each profile's CLI shim answers for its own instance, and both CDP endpoints stay independently reachable.

Also checked live in the main checkout: with `orca-dev` unclaimed, a primary worktree still resolves to it (`kind: shared`), so an existing developer's profile is adopted rather than replaced.

Automated: `config/scripts/dev-user-data-profile.test.ts` covers legacy adoption, re-adoption by the same checkout, linked-worktree isolation, second-clone isolation, same-name disambiguation being stable across runs, the env override, and the shared-profile opt-out.

```
pnpm vitest run --config config/vitest.config.ts config/scripts/dev-user-data-profile.test.ts   # 11 passed
pnpm vitest run --config config/vitest.config.ts \
  src/main/startup/run-electron-vite-dev.test.ts \
  src/main/startup/run-electron-vite-dev-web.test.ts \
  config/scripts/orca-dev-bin.test.mjs \
  config/scripts/dev-cli-terminal-wrapper.test.mjs \
  config/scripts/dev-electron-bundle-identity.test.ts                                            # 30 passed
pnpm typecheck                                                                                   # clean
oxlint / oxfmt on the changed files                                                              # clean
```

Platforms: exercised on macOS. Linux and Windows are covered by construction rather than by a run — the base directory keeps the existing per-platform branches (`XDG_CONFIG_HOME`/`APPDATA`), all paths go through `path.join`, and the git probe uses `--git-dir`/`--git-common-dir` resolved against the repo root rather than `--path-format=absolute`, which is Git 2.31+ and above the 2.25 baseline in `docs/reference/git-compatibility.md`. A checkout with no usable git falls back to primary, i.e. today's behaviour.

No remote/SSH surface: this is a local dev-launcher path only. Packaged builds are untouched — `configureDevUserDataPath` returns early when not `is.dev`.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Investigated, implemented and tested with Claude Opus 5 in Claude Code. The failure mode was reproduced and measured before the fix was written, and the same probe was re-run afterwards.

## Review

Cross-platform: base directory retains the existing darwin/win32/other branches; every path is composed with `path.join`; no shell invocation. The directory name is sanitized to `[A-Za-z0-9._-]`, so a branch-derived worktree name cannot introduce a path separator or a leading dot segment.

Git compatibility: only `git rev-parse --git-dir` and `--git-common-dir` (Git 2.5+, below the 2.25 baseline). Failure of either probe degrades to "primary", which is the pre-change behaviour, not an error.

SSH/remote: none — dev-launcher only, and the packaged path returns before any of this.

Performance: two `git rev-parse` calls and at most two small file reads at launch.

Security: the marker holds a repo path and a timestamp; it is written inside the profile directory that the same process already owns. No credential or token surface. Adoption cannot be hijacked to point a checkout at an unrelated directory, because a mismatched owner sends the caller to a name derived from its own repo root.

Risk: a developer who *wants* several worktrees on one profile now needs `ORCA_DEV_SHARED_PROFILE=1`. That is the intended trade — the previous default was the dangerous one and it was silent.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Security, cross-platform, remote/SSH, mobile, backwards compatibility and performance are covered in the Review section above. Backwards compatibility is the main one worth a second look: the legacy `orca-dev` directory is adopted, not migrated or renamed, so a developer with one checkout sees no change at all.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — ran locally: `pnpm typecheck` (clean), `oxlint`/`oxfmt` on the changed files via the pre-commit hook, and the dev-script and dev-runner test files listed above. The full `pnpm test` and `pnpm build` were not run locally; leaving this to CI.

## Author

[@YoraiLevi](https://x.com/YoraiLevi)

Write-up of the workflow this unblocks, with the reproduction and the pitfalls found along the way: https://gist.github.com/YoraiLevi/e171337e96dedd678769cdc0ba074bbd
