### PR TITLE
fix(ai-vault): match WSL /mnt/c sessions to Windows workspaces (STA-4973)

### DIFF
--- a/mobile/src/agent-history/agent-history-resume-target.test.ts
+++ b/mobile/src/agent-history/agent-history-resume-target.test.ts
@@ -209,6 +209,34 @@ describe('mobile AI Vault resume target guards', () => {
     })
   })
 
+  it('uses repo ownership when legacy worktree rows omit hostId', () => {
+    const target = resolveMobileAiVaultSessionResumeTarget({
+      session: session({ cwd: '/mnt/c/Users/ada/orca/feature/src' }),
+      activeWorktreeId: 'route-wt',
+      worktrees: [
+        worktree({
+          worktreeId: 'ssh-lookalike',
+          repoId: 'ssh-repo',
+          path: '/mnt/c/Users/ada/orca/feature'
+        }),
+        worktree({
+          worktreeId: 'local-wsl',
+          path: String.raw`C:\Users\ada\orca\feature`
+        }),
+        worktree({ worktreeId: 'route-wt', path: String.raw`C:\Users\ada\orca\main` })
+      ],
+      repos
+    })
+
+    expect(target).toEqual({
+      status: 'ready',
+      worktreeId: 'local-wsl',
+      targetStatus: 'local',
+      workspacePath: String.raw`C:\Users\ada\orca\feature`,
+      terminalPlatform: null
+    })
+  })
+
   it('falls back to the active route worktree when the session worktree is archived', () => {
     const target = resolveMobileAiVaultSessionResumeTarget({
       session: session({ cwd: '/Users/ada/repo/archive/src' }),

--- a/mobile/src/agent-history/agent-history-resume-target.test.ts
+++ b/mobile/src/agent-history/agent-history-resume-target.test.ts
@@ -179,6 +179,36 @@ describe('mobile AI Vault resume target guards', () => {
     })
   })
 
+  it('resumes a local WSL session in its drive worktree instead of a same-path SSH worktree', () => {
+    const target = resolveMobileAiVaultSessionResumeTarget({
+      session: session({ cwd: '/mnt/c/Users/neil/orca/feature/src' }),
+      activeWorktreeId: 'route-wt',
+      worktrees: [
+        worktree({
+          worktreeId: 'ssh-lookalike',
+          repoId: 'ssh-repo',
+          path: '/mnt/c/Users/neil/orca/feature',
+          hostId: 'ssh:builder'
+        }),
+        worktree({
+          worktreeId: 'local-wsl',
+          path: String.raw`C:\Users\neil\orca\feature`,
+          hostId: 'local'
+        }),
+        worktree({ worktreeId: 'route-wt', path: String.raw`C:\Users\neil\orca\main` })
+      ],
+      repos
+    })
+
+    expect(target).toEqual({
+      status: 'ready',
+      worktreeId: 'local-wsl',
+      targetStatus: 'local',
+      workspacePath: String.raw`C:\Users\neil\orca\feature`,
+      terminalPlatform: null
+    })
+  })
+
   it('falls back to the active route worktree when the session worktree is archived', () => {
     const target = resolveMobileAiVaultSessionResumeTarget({
       session: session({ cwd: '/Users/ada/repo/archive/src' }),

--- a/mobile/src/agent-history/agent-history-resume-target.ts
+++ b/mobile/src/agent-history/agent-history-resume-target.ts
@@ -125,6 +125,7 @@ export function resolveMobileAiVaultSessionResumeTarget(args: {
   const sessionWorktree = resolveMobileAgentHistorySessionWorktree({
     session: args.session,
     worktrees: args.worktrees,
+    repos: args.repos,
     activeWorktreeId: args.activeWorktreeId
   })
   const sessionWorktreeId = canResumeInMobileSessionWorktree(sessionWorktree)

--- a/mobile/src/agent-history/agent-history-session-worktree.test.ts
+++ b/mobile/src/agent-history/agent-history-session-worktree.test.ts
@@ -70,6 +70,20 @@ describe('resolveMobileAgentHistorySessionWorktree', () => {
     ).toBeNull()
   })
 
+  it('matches a Windows drive worktree against a WSL /mnt/c transcript cwd', () => {
+    const resolved = resolveMobileAgentHistorySessionWorktree({
+      session: session('/mnt/c/Users/neil/orca/orca'),
+      worktrees: [
+        worktree({
+          worktreeId: 'win-wsl',
+          path: String.raw`C:\Users\neil\orca\orca`
+        })
+      ],
+      activeWorktreeId: 'win-wsl'
+    })
+    expect(resolved).toMatchObject({ status: 'current', worktreeId: 'win-wsl' })
+  })
+
   it('matches WSL UNC worktree paths against Linux transcript paths', () => {
     const resolved = resolveMobileAgentHistorySessionWorktree({
       session: session('/home/ada/repo/app'),

--- a/mobile/src/agent-history/agent-history-session-worktree.test.ts
+++ b/mobile/src/agent-history/agent-history-session-worktree.test.ts
@@ -6,8 +6,11 @@ import {
   resolveMobileAgentHistorySessionWorktree
 } from './agent-history-session-worktree'
 
-function session(cwd: string | null): Pick<AiVaultSession, 'cwd'> {
-  return { cwd }
+function session(
+  cwd: string | null,
+  executionHostId: AiVaultSession['executionHostId'] = 'local'
+): Pick<AiVaultSession, 'cwd' | 'executionHostId'> {
+  return { cwd, executionHostId }
 }
 
 function worktree(overrides: Partial<Worktree> & { worktreeId: string; path: string }): Worktree {
@@ -82,6 +85,27 @@ describe('resolveMobileAgentHistorySessionWorktree', () => {
       activeWorktreeId: 'win-wsl'
     })
     expect(resolved).toMatchObject({ status: 'current', worktreeId: 'win-wsl' })
+  })
+
+  it('does not attribute a local WSL session to a same-path SSH worktree', () => {
+    const resolved = resolveMobileAgentHistorySessionWorktree({
+      session: session('/mnt/c/Users/neil/orca/orca/src'),
+      worktrees: [
+        worktree({
+          worktreeId: 'ssh-mount',
+          path: '/mnt/c/Users/neil/orca/orca',
+          hostId: 'ssh:builder'
+        }),
+        worktree({
+          worktreeId: 'local-drive',
+          path: String.raw`C:\Users\neil\orca\orca`,
+          hostId: 'local'
+        })
+      ],
+      activeWorktreeId: 'ssh-mount'
+    })
+
+    expect(resolved).toMatchObject({ status: 'active', worktreeId: 'local-drive' })
   })
 
   it('prefers the deepest worktree independently of its WSL alias spelling', () => {

--- a/mobile/src/agent-history/agent-history-session-worktree.test.ts
+++ b/mobile/src/agent-history/agent-history-session-worktree.test.ts
@@ -84,6 +84,42 @@ describe('resolveMobileAgentHistorySessionWorktree', () => {
     expect(resolved).toMatchObject({ status: 'current', worktreeId: 'win-wsl' })
   })
 
+  it('prefers the deepest worktree independently of its WSL alias spelling', () => {
+    const resolved = resolveMobileAgentHistorySessionWorktree({
+      session: session('/mnt/c/Users/neil/orca/app/src'),
+      worktrees: [
+        worktree({
+          worktreeId: 'parent',
+          path: String.raw`\\wsl.localhost\Ubuntu\mnt\c\Users\neil\orca`
+        }),
+        worktree({
+          worktreeId: 'nested',
+          path: String.raw`C:\Users\neil\orca\app`
+        })
+      ],
+      activeWorktreeId: 'parent'
+    })
+
+    expect(resolved).toMatchObject({ status: 'active', worktreeId: 'nested' })
+  })
+
+  it('prefers a drive-root folder workspace over its POSIX /mnt parent', () => {
+    const resolved = resolveMobileAgentHistorySessionWorktree({
+      session: session('/mnt/c/repo'),
+      worktrees: [
+        worktree({ worktreeId: 'mount-parent', path: '/mnt' }),
+        worktree({
+          worktreeId: 'folder-drive-root',
+          path: 'C:\\',
+          workspaceKind: 'folder-workspace'
+        })
+      ],
+      activeWorktreeId: 'mount-parent'
+    })
+
+    expect(resolved).toMatchObject({ status: 'active', worktreeId: 'folder-drive-root' })
+  })
+
   it('matches WSL UNC worktree paths against Linux transcript paths', () => {
     const resolved = resolveMobileAgentHistorySessionWorktree({
       session: session('/home/ada/repo/app'),

--- a/mobile/src/agent-history/agent-history-session-worktree.ts
+++ b/mobile/src/agent-history/agent-history-session-worktree.ts
@@ -4,7 +4,11 @@ import {
   normalizedWslPathCandidateAliases,
   wslAliasedPathDepth
 } from '../../../src/shared/wsl-path-aliases'
-import { normalizeExecutionHostId } from '../../../src/shared/execution-host'
+import {
+  getWorktreeExecutionHostId,
+  normalizeExecutionHostId,
+  type ExecutionHostId
+} from '../../../src/shared/execution-host'
 import { splitWorktreeIdForFilesystem } from '../../../src/shared/worktree/id'
 import type { AiVaultSession } from '../../../src/shared/ai-vault-types'
 import type { Worktree } from '../worktree/workspace-list-types'
@@ -20,9 +24,16 @@ export type MobileAgentHistorySessionWorktreeInfo = {
 type WorktreeCandidate = {
   worktree: WorktreeWithPriorIds
   path: string
+  hostId: ExecutionHostId
   pathDepth: number
   ownsNormalizedCwd: (normalizedCwd: string) => boolean
   source: 'current-path' | 'prior-path'
+}
+
+type WorktreeRepoHost = {
+  id: string
+  connectionId?: string | null
+  executionHostId?: ExecutionHostId | null
 }
 
 type WorktreeWithPriorIds = Worktree & {
@@ -32,6 +43,7 @@ type WorktreeWithPriorIds = Worktree & {
 export function resolveMobileAgentHistorySessionWorktree(args: {
   session: Pick<AiVaultSession, 'cwd' | 'executionHostId'>
   worktrees: readonly Worktree[]
+  repos?: readonly WorktreeRepoHost[]
   activeWorktreeId: string | null
 }): MobileAgentHistorySessionWorktreeInfo | null {
   if (!args.session.cwd) {
@@ -40,7 +52,7 @@ export function resolveMobileAgentHistorySessionWorktree(args: {
   const sessionHostId = normalizeExecutionHostId(args.session.executionHostId)
   const cwdAliases = normalizedWslPathCandidateAliases(args.session.cwd)
   const best = findBestMobileWorktreeCandidate(
-    buildMobileWorktreeCandidates(args.worktrees),
+    buildMobileWorktreeCandidates(args.worktrees, args.repos ?? []),
     sessionHostId,
     cwdAliases
   )
@@ -67,8 +79,7 @@ function findBestMobileWorktreeCandidate(
 ): WorktreeCandidate | null {
   let best: WorktreeCandidate | null = null
   for (const candidate of candidates) {
-    const worktreeHostId = normalizeExecutionHostId(candidate.worktree.hostId)
-    if (sessionHostId && worktreeHostId && worktreeHostId !== sessionHostId) {
+    if (sessionHostId && candidate.hostId !== sessionHostId) {
       continue
     }
     if (!normalizedCwdAliases.some(candidate.ownsNormalizedCwd)) {
@@ -87,13 +98,28 @@ export function canResumeInMobileSessionWorktree(
   return Boolean(worktreeInfo && worktreeInfo.status !== 'archived')
 }
 
-function buildMobileWorktreeCandidates(worktrees: readonly Worktree[]): WorktreeCandidate[] {
+function buildMobileWorktreeCandidates(
+  worktrees: readonly Worktree[],
+  repos: readonly WorktreeRepoHost[]
+): WorktreeCandidate[] {
   const candidates: WorktreeCandidate[] = []
+  const repoById = new Map(repos.map((repo) => [repo.id, repo]))
   for (const worktree of worktrees as readonly WorktreeWithPriorIds[]) {
+    const repo = repoById.get(worktree.repoId)
+    const hostId = getWorktreeExecutionHostId(
+      worktree,
+      repo
+        ? {
+            connectionId: repo.connectionId ?? null,
+            executionHostId: repo.executionHostId ?? null
+          }
+        : undefined
+    )
     if (hasUsablePath(worktree.path)) {
       candidates.push({
         worktree,
         path: worktree.path,
+        hostId,
         pathDepth: wslAliasedPathDepth(worktree.path),
         ownsNormalizedCwd: createWslAliasedPathInsideOrEqualMatcher(worktree.path),
         source: 'current-path'
@@ -107,6 +133,7 @@ function buildMobileWorktreeCandidates(worktrees: readonly Worktree[]): Worktree
       candidates.push({
         worktree,
         path: parsed.worktreePath,
+        hostId,
         pathDepth: wslAliasedPathDepth(parsed.worktreePath),
         ownsNormalizedCwd: createWslAliasedPathInsideOrEqualMatcher(parsed.worktreePath),
         source: 'prior-path'

--- a/mobile/src/agent-history/agent-history-session-worktree.ts
+++ b/mobile/src/agent-history/agent-history-session-worktree.ts
@@ -1,5 +1,8 @@
 import { isRuntimePathAbsolute } from '../../../src/shared/cross-platform-path'
-import { isWslAliasedPathInsideOrEqual } from '../../../src/shared/wsl-path-aliases'
+import {
+  isWslAliasedPathInsideOrEqual,
+  wslAliasedPathDepth
+} from '../../../src/shared/wsl-path-aliases'
 import { splitWorktreeIdForFilesystem } from '../../../src/shared/worktree/id'
 import type { AiVaultSession } from '../../../src/shared/ai-vault-types'
 import type { Worktree } from '../worktree/workspace-list-types'
@@ -15,6 +18,7 @@ export type MobileAgentHistorySessionWorktreeInfo = {
 type WorktreeCandidate = {
   worktree: WorktreeWithPriorIds
   path: string
+  pathDepth: number
   source: 'current-path' | 'prior-path'
 }
 
@@ -62,14 +66,24 @@ function buildMobileWorktreeCandidates(worktrees: readonly Worktree[]): Worktree
   const candidates: WorktreeCandidate[] = []
   for (const worktree of worktrees as readonly WorktreeWithPriorIds[]) {
     if (hasUsablePath(worktree.path)) {
-      candidates.push({ worktree, path: worktree.path, source: 'current-path' })
+      candidates.push({
+        worktree,
+        path: worktree.path,
+        pathDepth: wslAliasedPathDepth(worktree.path),
+        source: 'current-path'
+      })
     }
     for (const priorWorktreeId of worktree.priorWorktreeIds ?? []) {
       const parsed = splitWorktreeIdForFilesystem(priorWorktreeId)
       if (!parsed || parsed.repoId !== worktree.repoId || !hasUsablePath(parsed.worktreePath)) {
         continue
       }
-      candidates.push({ worktree, path: parsed.worktreePath, source: 'prior-path' })
+      candidates.push({
+        worktree,
+        path: parsed.worktreePath,
+        pathDepth: wslAliasedPathDepth(parsed.worktreePath),
+        source: 'prior-path'
+      })
     }
   }
   return candidates
@@ -80,16 +94,12 @@ function hasUsablePath(pathValue: string): boolean {
 }
 
 function compareWorktreeCandidates(left: WorktreeCandidate, right: WorktreeCandidate): number {
-  const lengthDifference = normalizedPathLength(right.path) - normalizedPathLength(left.path)
-  if (lengthDifference !== 0) {
-    return lengthDifference
+  const depthDifference = right.pathDepth - left.pathDepth
+  if (depthDifference !== 0) {
+    return depthDifference
   }
   if (left.source === right.source) {
     return 0
   }
   return left.source === 'current-path' ? -1 : 1
-}
-
-function normalizedPathLength(pathValue: string): number {
-  return pathValue.replace(/\\/g, '/').replace(/\/+$/g, '').toLowerCase().length
 }

--- a/mobile/src/agent-history/agent-history-session-worktree.ts
+++ b/mobile/src/agent-history/agent-history-session-worktree.ts
@@ -1,8 +1,10 @@
 import { isRuntimePathAbsolute } from '../../../src/shared/cross-platform-path'
 import {
-  isWslAliasedPathInsideOrEqual,
+  createWslAliasedPathInsideOrEqualMatcher,
+  normalizedWslPathCandidateAliases,
   wslAliasedPathDepth
 } from '../../../src/shared/wsl-path-aliases'
+import { normalizeExecutionHostId } from '../../../src/shared/execution-host'
 import { splitWorktreeIdForFilesystem } from '../../../src/shared/worktree/id'
 import type { AiVaultSession } from '../../../src/shared/ai-vault-types'
 import type { Worktree } from '../worktree/workspace-list-types'
@@ -19,6 +21,7 @@ type WorktreeCandidate = {
   worktree: WorktreeWithPriorIds
   path: string
   pathDepth: number
+  ownsNormalizedCwd: (normalizedCwd: string) => boolean
   source: 'current-path' | 'prior-path'
 }
 
@@ -27,19 +30,20 @@ type WorktreeWithPriorIds = Worktree & {
 }
 
 export function resolveMobileAgentHistorySessionWorktree(args: {
-  session: Pick<AiVaultSession, 'cwd'>
+  session: Pick<AiVaultSession, 'cwd' | 'executionHostId'>
   worktrees: readonly Worktree[]
   activeWorktreeId: string | null
 }): MobileAgentHistorySessionWorktreeInfo | null {
   if (!args.session.cwd) {
     return null
   }
-  const sessionCwd = args.session.cwd
-
-  const candidates = buildMobileWorktreeCandidates(args.worktrees)
-    .filter((candidate) => isWslAliasedPathInsideOrEqual(candidate.path, sessionCwd))
-    .sort(compareWorktreeCandidates)
-  const best = candidates[0]
+  const sessionHostId = normalizeExecutionHostId(args.session.executionHostId)
+  const cwdAliases = normalizedWslPathCandidateAliases(args.session.cwd)
+  const best = findBestMobileWorktreeCandidate(
+    buildMobileWorktreeCandidates(args.worktrees),
+    sessionHostId,
+    cwdAliases
+  )
   if (!best) {
     return null
   }
@@ -56,6 +60,27 @@ export function resolveMobileAgentHistorySessionWorktree(args: {
   }
 }
 
+function findBestMobileWorktreeCandidate(
+  candidates: readonly WorktreeCandidate[],
+  sessionHostId: AiVaultSession['executionHostId'] | null,
+  normalizedCwdAliases: readonly string[]
+): WorktreeCandidate | null {
+  let best: WorktreeCandidate | null = null
+  for (const candidate of candidates) {
+    const worktreeHostId = normalizeExecutionHostId(candidate.worktree.hostId)
+    if (sessionHostId && worktreeHostId && worktreeHostId !== sessionHostId) {
+      continue
+    }
+    if (!normalizedCwdAliases.some(candidate.ownsNormalizedCwd)) {
+      continue
+    }
+    if (!best || compareWorktreeCandidates(candidate, best) < 0) {
+      best = candidate
+    }
+  }
+  return best
+}
+
 export function canResumeInMobileSessionWorktree(
   worktreeInfo: MobileAgentHistorySessionWorktreeInfo | null
 ): boolean {
@@ -70,6 +95,7 @@ function buildMobileWorktreeCandidates(worktrees: readonly Worktree[]): Worktree
         worktree,
         path: worktree.path,
         pathDepth: wslAliasedPathDepth(worktree.path),
+        ownsNormalizedCwd: createWslAliasedPathInsideOrEqualMatcher(worktree.path),
         source: 'current-path'
       })
     }
@@ -82,6 +108,7 @@ function buildMobileWorktreeCandidates(worktrees: readonly Worktree[]): Worktree
         worktree,
         path: parsed.worktreePath,
         pathDepth: wslAliasedPathDepth(parsed.worktreePath),
+        ownsNormalizedCwd: createWslAliasedPathInsideOrEqualMatcher(parsed.worktreePath),
         source: 'prior-path'
       })
     }

--- a/mobile/src/agent-history/agent-history-session-worktree.ts
+++ b/mobile/src/agent-history/agent-history-session-worktree.ts
@@ -1,5 +1,5 @@
-import { isPathInsideOrEqual, isRuntimePathAbsolute } from '../../../src/shared/cross-platform-path'
-import { parseWslUncPath } from '../../../src/shared/wsl-paths'
+import { isRuntimePathAbsolute } from '../../../src/shared/cross-platform-path'
+import { isWslAliasedPathInsideOrEqual } from '../../../src/shared/wsl-path-aliases'
 import { splitWorktreeIdForFilesystem } from '../../../src/shared/worktree/id'
 import type { AiVaultSession } from '../../../src/shared/ai-vault-types'
 import type { Worktree } from '../worktree/workspace-list-types'
@@ -33,7 +33,7 @@ export function resolveMobileAgentHistorySessionWorktree(args: {
   const sessionCwd = args.session.cwd
 
   const candidates = buildMobileWorktreeCandidates(args.worktrees)
-    .filter((candidate) => isSessionInWorktreePath(candidate.path, sessionCwd))
+    .filter((candidate) => isWslAliasedPathInsideOrEqual(candidate.path, sessionCwd))
     .sort(compareWorktreeCandidates)
   const best = candidates[0]
   if (!best) {
@@ -77,14 +77,6 @@ function buildMobileWorktreeCandidates(worktrees: readonly Worktree[]): Worktree
 
 function hasUsablePath(pathValue: string): boolean {
   return Boolean(pathValue.trim() && isRuntimePathAbsolute(pathValue))
-}
-
-function isSessionInWorktreePath(worktreePath: string, sessionCwd: string): boolean {
-  if (isPathInsideOrEqual(worktreePath, sessionCwd)) {
-    return true
-  }
-  const wslPath = parseWslUncPath(worktreePath)
-  return wslPath ? isPathInsideOrEqual(wslPath.linuxPath, sessionCwd) : false
 }
 
 function compareWorktreeCandidates(left: WorktreeCandidate, right: WorktreeCandidate): number {

--- a/src/main/ai-vault/claude-project-dir-encoding.test.ts
+++ b/src/main/ai-vault/claude-project-dir-encoding.test.ts
@@ -64,13 +64,18 @@ describe('isClaudeProjectDirInScope', () => {
   // case-folding alias re-check could run (STA-4973 follow-up).
   it('matches a WSL drive-mount prefix whose Windows spelling differs in case', () => {
     const prefix = encodeClaudeProjectPath('/mnt/c/Users/Neil/orca')
-    expect(isClaudeProjectDirInScope('-mnt-c-users-neil-orca', [prefix])).toBe(true)
-    expect(isClaudeProjectDirInScope('-mnt-c-users-neil-orca-sub', [prefix])).toBe(true)
+    const caseInsensitive = new Set([prefix])
+    expect(isClaudeProjectDirInScope('-mnt-c-users-neil-orca', [prefix], caseInsensitive)).toBe(
+      true
+    )
+    expect(isClaudeProjectDirInScope('-mnt-c-users-neil-orca-sub', [prefix], caseInsensitive)).toBe(
+      true
+    )
   })
 
   it('matches a native Windows volume prefix whose spelling differs in case', () => {
     const prefix = encodeClaudeProjectPath('C:\\Users\\Neil\\orca')
-    expect(isClaudeProjectDirInScope('c--users-neil-orca', [prefix])).toBe(true)
+    expect(isClaudeProjectDirInScope('c--users-neil-orca', [prefix], new Set([prefix]))).toBe(true)
   })
 
   it('keeps POSIX paths case-sensitive', () => {
@@ -78,9 +83,19 @@ describe('isClaudeProjectDirInScope', () => {
     expect(isClaudeProjectDirInScope('-home-neil-orca', [prefix])).toBe(false)
   })
 
+  it('keeps a raw POSIX /mnt/c prefix case-sensitive', () => {
+    const prefix = encodeClaudeProjectPath('/mnt/c/Users/Neil/orca')
+    expect(isClaudeProjectDirInScope('-mnt-c-users-neil-orca', [prefix])).toBe(false)
+  })
+
   it('still refuses a sibling prefix under case folding', () => {
     const prefix = encodeClaudeProjectPath('/mnt/c/Users/Neil/orca')
-    expect(isClaudeProjectDirInScope('-mnt-c-users-neil-orcadyne', [prefix])).toBe(false)
-    expect(isClaudeProjectDirInScope('-mnt-c-users-neil-orca-secret', [prefix])).toBe(true)
+    const caseInsensitive = new Set([prefix])
+    expect(isClaudeProjectDirInScope('-mnt-c-users-neil-orcadyne', [prefix], caseInsensitive)).toBe(
+      false
+    )
+    expect(
+      isClaudeProjectDirInScope('-mnt-c-users-neil-orca-secret', [prefix], caseInsensitive)
+    ).toBe(true)
   })
 })

--- a/src/main/ai-vault/claude-project-dir-encoding.test.ts
+++ b/src/main/ai-vault/claude-project-dir-encoding.test.ts
@@ -58,4 +58,29 @@ describe('isClaudeProjectDirInScope', () => {
     // Without the boundary, "orca" would absorb every workspace under "orcadyne".
     expect(isClaudeProjectDirInScope('-w-orcadyne-nautilus', ['-w-orca'])).toBe(false)
   })
+  // Why: Windows volumes are case-insensitive, so a WSL pane whose cwd was typed
+  // `/mnt/c/users/neil/orca` encodes differently from the worktree's
+  // `/mnt/c/Users/Neil/orca` and was dropped at the prefix stage, before the
+  // case-folding alias re-check could run (STA-4973 follow-up).
+  it('matches a WSL drive-mount prefix whose Windows spelling differs in case', () => {
+    const prefix = encodeClaudeProjectPath('/mnt/c/Users/Neil/orca')
+    expect(isClaudeProjectDirInScope('-mnt-c-users-neil-orca', [prefix])).toBe(true)
+    expect(isClaudeProjectDirInScope('-mnt-c-users-neil-orca-sub', [prefix])).toBe(true)
+  })
+
+  it('matches a native Windows volume prefix whose spelling differs in case', () => {
+    const prefix = encodeClaudeProjectPath('C:\\Users\\Neil\\orca')
+    expect(isClaudeProjectDirInScope('c--users-neil-orca', [prefix])).toBe(true)
+  })
+
+  it('keeps POSIX paths case-sensitive', () => {
+    const prefix = encodeClaudeProjectPath('/home/neil/Orca')
+    expect(isClaudeProjectDirInScope('-home-neil-orca', [prefix])).toBe(false)
+  })
+
+  it('still refuses a sibling prefix under case folding', () => {
+    const prefix = encodeClaudeProjectPath('/mnt/c/Users/Neil/orca')
+    expect(isClaudeProjectDirInScope('-mnt-c-users-neil-orcadyne', [prefix])).toBe(false)
+    expect(isClaudeProjectDirInScope('-mnt-c-users-neil-orca-secret', [prefix])).toBe(true)
+  })
 })

--- a/src/main/ai-vault/claude-project-dir-encoding.test.ts
+++ b/src/main/ai-vault/claude-project-dir-encoding.test.ts
@@ -19,6 +19,14 @@ describe('encodeClaudeProjectPath', () => {
     expect(encodeClaudeProjectPath('C:\\')).toBe('C--')
   })
 
+  it('encodes a WSL drvfs mount separately from the Windows drive spelling', () => {
+    // Claude in WSL records cwd as /mnt/c/... even when Orca's worktree is C:\...
+    expect(encodeClaudeProjectPath('/mnt/c/Users/neil/orca/orca')).toBe(
+      '-mnt-c-Users-neil-orca-orca'
+    )
+    expect(encodeClaudeProjectPath('C:\\Users\\neil\\orca\\orca')).toBe('C--Users-neil-orca-orca')
+  })
+
   it('encodes a WSL UNC path', () => {
     expect(encodeClaudeProjectPath('\\\\wsl$\\Ubuntu\\home\\ada\\orca\\workspaces')).toBe(
       '--wsl--Ubuntu-home-ada-orca-workspaces'

--- a/src/main/ai-vault/claude-project-dir-encoding.ts
+++ b/src/main/ai-vault/claude-project-dir-encoding.ts
@@ -1,5 +1,7 @@
 import { normalizeRuntimePathSeparators } from '../../shared/cross-platform-path'
 
+const EMPTY_CASE_INSENSITIVE_PREFIXES: ReadonlySet<string> = new Set()
+
 /**
  * Why: Claude derives the directory name from the raw cwd, so encoding from the
  * comparison key would lowercase Windows paths and never match on disk. Encode
@@ -20,27 +22,21 @@ export function encodeClaudeProjectPath(pathValue: string): string {
   return trimmed.replace(/[^a-zA-Z0-9]/g, '-')
 }
 
-/** Encodings rooted at a Windows volume, either native (`c--Users-…`) or through WSL's
- *  drive automount (`-mnt-c-Users-…`). Those filesystems are case-insensitive, so the same
- *  worktree legitimately reaches us as `/mnt/c/Users/Neil` or `/mnt/c/users/neil`. */
-const CASE_INSENSITIVE_ROOT_RE = /^(?:-mnt-[a-z]-|[a-z]--)/i
-
 /** Why the explicit boundary: a bare `startsWith` lets a sibling prefix match, so the encoding of
  *  `…/orca` would claim `…/orca-secret` and `…/orcadyne` as its own.
  *
- *  Case handling is deliberately narrow: POSIX paths stay case-sensitive, but a prefix rooted at a
- *  Windows volume folds case, because encoding is done from the raw cwd (see above) and Windows
- *  spellings vary freely. Without this a WSL pane whose cwd was typed `/mnt/c/users/neil/orca` is
- *  dropped here, before the case-folding alias re-check ever runs. */
+ *  Case-insensitive prefixes are supplied from the original root syntax. The encoded text cannot
+ *  distinguish a Windows drvfs alias from a case-sensitive Linux `/mnt/c` directory. */
 export function isClaudeProjectDirInScope(
   projectDirName: string,
-  scopePrefixes: ReadonlySet<string> | readonly string[]
+  scopePrefixes: ReadonlySet<string> | readonly string[],
+  caseInsensitivePrefixes: ReadonlySet<string> = EMPTY_CASE_INSENSITIVE_PREFIXES
 ): boolean {
   for (const prefix of scopePrefixes) {
     if (projectDirName === prefix || projectDirName.startsWith(`${prefix}-`)) {
       return true
     }
-    if (!CASE_INSENSITIVE_ROOT_RE.test(prefix)) {
+    if (!caseInsensitivePrefixes.has(prefix)) {
       continue
     }
     const foldedPrefix = prefix.toLowerCase()

--- a/src/main/ai-vault/claude-project-dir-encoding.ts
+++ b/src/main/ai-vault/claude-project-dir-encoding.ts
@@ -20,14 +20,32 @@ export function encodeClaudeProjectPath(pathValue: string): string {
   return trimmed.replace(/[^a-zA-Z0-9]/g, '-')
 }
 
+/** Encodings rooted at a Windows volume, either native (`c--Users-…`) or through WSL's
+ *  drive automount (`-mnt-c-Users-…`). Those filesystems are case-insensitive, so the same
+ *  worktree legitimately reaches us as `/mnt/c/Users/Neil` or `/mnt/c/users/neil`. */
+const CASE_INSENSITIVE_ROOT_RE = /^(?:-mnt-[a-z]-|[a-z]--)/i
+
 /** Why the explicit boundary: a bare `startsWith` lets a sibling prefix match, so the encoding of
- *  `…/orca` would claim `…/orca-secret` and `…/orcadyne` as its own. */
+ *  `…/orca` would claim `…/orca-secret` and `…/orcadyne` as its own.
+ *
+ *  Case handling is deliberately narrow: POSIX paths stay case-sensitive, but a prefix rooted at a
+ *  Windows volume folds case, because encoding is done from the raw cwd (see above) and Windows
+ *  spellings vary freely. Without this a WSL pane whose cwd was typed `/mnt/c/users/neil/orca` is
+ *  dropped here, before the case-folding alias re-check ever runs. */
 export function isClaudeProjectDirInScope(
   projectDirName: string,
   scopePrefixes: ReadonlySet<string> | readonly string[]
 ): boolean {
   for (const prefix of scopePrefixes) {
     if (projectDirName === prefix || projectDirName.startsWith(`${prefix}-`)) {
+      return true
+    }
+    if (!CASE_INSENSITIVE_ROOT_RE.test(prefix)) {
+      continue
+    }
+    const foldedPrefix = prefix.toLowerCase()
+    const foldedDir = projectDirName.toLowerCase()
+    if (foldedDir === foldedPrefix || foldedDir.startsWith(`${foldedPrefix}-`)) {
       return true
     }
   }

--- a/src/main/ai-vault/session-scanner-scope-discovery.ts
+++ b/src/main/ai-vault/session-scanner-scope-discovery.ts
@@ -6,9 +6,13 @@ import {
   wslGatedStat
 } from '../native-chat/wsl-transcript-fs-access'
 import { WslTranscriptFsError } from '../native-chat/wsl-transcript-fs-gate'
+import { isCaseInsensitiveRuntimeRoot } from '../../shared/cross-platform-path'
 import { encodeClaudeProjectPaths, isClaudeProjectDirInScope } from './claude-project-dir-encoding'
 import type { AiVaultScanIssue } from '../../shared/ai-vault-types'
-import { isWslAliasedPathInsideOrEqual, wslRootPathAliases } from '../../shared/wsl-path-aliases'
+import {
+  createWslAliasedPathInsideOrEqualScopeMatcher,
+  wslRootPathAliases
+} from '../../shared/wsl-path-aliases'
 import { recordSessionScanIssue } from './session-scan-issues'
 import type { FileWithMtime } from './session-scanner-types'
 import { errorMessage, extractString, parseJsonObject } from './session-scanner-values'
@@ -81,14 +85,12 @@ export async function discoverInScopeClaudeFiles(args: {
     return []
   }
   const scopeProjectPrefixes = claudeProjectScopePrefixes(args.scopePaths)
+  const ownsScopedCwd = createWslAliasedPathInsideOrEqualScopeMatcher(args.scopePaths)
   const collected = new Map<string, FileWithMtime>()
   for (const rootDir of args.rootDirs) {
     for (const projectDir of await listProjectDirs(rootDir, scopeProjectPrefixes, args.issues)) {
       const cwd = await cachedProjectDirCwd(projectDir, args.issues)
-      if (
-        !cwd ||
-        !args.scopePaths.some((scopePath) => isWslAliasedPathInsideOrEqual(scopePath, cwd))
-      ) {
+      if (!cwd || !ownsScopedCwd(cwd)) {
         continue
       }
       await collectClaudeFiles({
@@ -103,21 +105,32 @@ export async function discoverInScopeClaudeFiles(args: {
   return [...collected.values()].sort((left, right) => right.mtimeMs - left.mtimeMs)
 }
 
-function claudeProjectScopePrefixes(scopePaths: readonly string[]): Set<string> {
+type ClaudeProjectScopePrefixes = {
+  all: Set<string>
+  caseInsensitive: Set<string>
+}
+
+function claudeProjectScopePrefixes(scopePaths: readonly string[]): ClaudeProjectScopePrefixes {
   const prefixes = new Set<string>()
+  const caseInsensitivePrefixes = new Set<string>()
   for (const scopePath of scopePaths) {
-    for (const candidate of wslRootPathAliases(scopePath)) {
+    const rootAliases = wslRootPathAliases(scopePath)
+    const caseInsensitive = rootAliases.some(isCaseInsensitiveRuntimeRoot)
+    for (const candidate of rootAliases) {
       for (const prefix of encodeClaudeProjectPaths(candidate)) {
         prefixes.add(prefix)
+        if (caseInsensitive) {
+          caseInsensitivePrefixes.add(prefix)
+        }
       }
     }
   }
-  return prefixes
+  return { all: prefixes, caseInsensitive: caseInsensitivePrefixes }
 }
 
 async function listProjectDirs(
   rootDir: string,
-  scopeProjectPrefixes: ReadonlySet<string>,
+  scopeProjectPrefixes: ClaudeProjectScopePrefixes,
   issues: AiVaultScanIssue[]
 ): Promise<string[]> {
   let entries
@@ -129,7 +142,13 @@ async function listProjectDirs(
   }
   return entries
     .filter(
-      (entry) => entry.isDirectory() && isClaudeProjectDirInScope(entry.name, scopeProjectPrefixes)
+      (entry) =>
+        entry.isDirectory() &&
+        isClaudeProjectDirInScope(
+          entry.name,
+          scopeProjectPrefixes.all,
+          scopeProjectPrefixes.caseInsensitive
+        )
     )
     .map((entry) => join(rootDir, entry.name))
 }

--- a/src/main/ai-vault/session-scanner-scope-discovery.ts
+++ b/src/main/ai-vault/session-scanner-scope-discovery.ts
@@ -8,7 +8,7 @@ import {
 import { WslTranscriptFsError } from '../native-chat/wsl-transcript-fs-gate'
 import { encodeClaudeProjectPaths, isClaudeProjectDirInScope } from './claude-project-dir-encoding'
 import type { AiVaultScanIssue } from '../../shared/ai-vault-types'
-import { isWslAliasedPathInsideOrEqual, wslPathAliases } from '../../shared/wsl-path-aliases'
+import { isWslAliasedPathInsideOrEqual, wslRootPathAliases } from '../../shared/wsl-path-aliases'
 import { recordSessionScanIssue } from './session-scan-issues'
 import type { FileWithMtime } from './session-scanner-types'
 import { errorMessage, extractString, parseJsonObject } from './session-scanner-values'
@@ -106,7 +106,7 @@ export async function discoverInScopeClaudeFiles(args: {
 function claudeProjectScopePrefixes(scopePaths: readonly string[]): Set<string> {
   const prefixes = new Set<string>()
   for (const scopePath of scopePaths) {
-    for (const candidate of wslPathAliases(scopePath)) {
+    for (const candidate of wslRootPathAliases(scopePath)) {
       for (const prefix of encodeClaudeProjectPaths(candidate)) {
         prefixes.add(prefix)
       }

--- a/src/main/ai-vault/session-scanner-scope-discovery.ts
+++ b/src/main/ai-vault/session-scanner-scope-discovery.ts
@@ -6,10 +6,9 @@ import {
   wslGatedStat
 } from '../native-chat/wsl-transcript-fs-access'
 import { WslTranscriptFsError } from '../native-chat/wsl-transcript-fs-gate'
-import { isPathInsideOrEqual } from '../../shared/cross-platform-path'
 import { encodeClaudeProjectPaths, isClaudeProjectDirInScope } from './claude-project-dir-encoding'
 import type { AiVaultScanIssue } from '../../shared/ai-vault-types'
-import { parseWslUncPath } from '../../shared/wsl-paths'
+import { isWslAliasedPathInsideOrEqual, wslPathAliases } from '../../shared/wsl-path-aliases'
 import { recordSessionScanIssue } from './session-scan-issues'
 import type { FileWithMtime } from './session-scanner-types'
 import { errorMessage, extractString, parseJsonObject } from './session-scanner-values'
@@ -86,7 +85,10 @@ export async function discoverInScopeClaudeFiles(args: {
   for (const rootDir of args.rootDirs) {
     for (const projectDir of await listProjectDirs(rootDir, scopeProjectPrefixes, args.issues)) {
       const cwd = await cachedProjectDirCwd(projectDir, args.issues)
-      if (!cwd || !args.scopePaths.some((scopePath) => isCwdInsideScopePath(scopePath, cwd))) {
+      if (
+        !cwd ||
+        !args.scopePaths.some((scopePath) => isWslAliasedPathInsideOrEqual(scopePath, cwd))
+      ) {
         continue
       }
       await collectClaudeFiles({
@@ -104,33 +106,13 @@ export async function discoverInScopeClaudeFiles(args: {
 function claudeProjectScopePrefixes(scopePaths: readonly string[]): Set<string> {
   const prefixes = new Set<string>()
   for (const scopePath of scopePaths) {
-    for (const candidate of scopePathCandidates(scopePath)) {
+    for (const candidate of wslPathAliases(scopePath)) {
       for (const prefix of encodeClaudeProjectPaths(candidate)) {
         prefixes.add(prefix)
       }
     }
   }
   return prefixes
-}
-
-function scopePathCandidates(scopePath: string): string[] {
-  const wslScopePath = parseWslUncPath(scopePath)
-  return wslScopePath ? [scopePath, wslScopePath.linuxPath] : [scopePath]
-}
-
-function isCwdInsideScopePath(scopePath: string, cwd: string): boolean {
-  if (isPathInsideOrEqual(scopePath, cwd)) {
-    return true
-  }
-
-  const wslScopePath = parseWslUncPath(scopePath)
-  if (!wslScopePath) {
-    return false
-  }
-
-  // WSL transcripts record Linux cwd values even when the renderer sends the
-  // active worktree as a Windows UNC path.
-  return isPathInsideOrEqual(wslScopePath.linuxPath, cwd)
 }
 
 async function listProjectDirs(

--- a/src/main/ai-vault/session-scanner-scope.test.ts
+++ b/src/main/ai-vault/session-scanner-scope.test.ts
@@ -177,9 +177,9 @@ describe('scanAiVaultSessions scope inclusion', () => {
     // Claude in WSL encodes the guest cwd, not the Windows drive spelling.
     await writeClaudeSession({
       claudeRoot,
-      dirName: '-mnt-c-Users-neil-orca-orca',
+      dirName: '-mnt-c-users-neil-orca-orca',
       sessionId: 'old-mnt-c-in-scope',
-      cwd: '/mnt/c/Users/neil/orca/orca',
+      cwd: '/mnt/c/users/neil/orca/orca',
       iso: '2026-01-01T00:00:00.000Z'
     })
     for (let index = 0; index < 4; index++) {
@@ -197,7 +197,7 @@ describe('scanAiVaultSessions scope inclusion', () => {
         wslHomeDirs: [wslHome],
         platform: 'win32',
         limit: 2,
-        scopePaths: [String.raw`C:\Users\neil\orca\orca`]
+        scopePaths: [String.raw`C:\Users\Neil\orca\orca`]
       })
     )
 
@@ -205,7 +205,7 @@ describe('scanAiVaultSessions scope inclusion', () => {
     expect(
       result.sessions.find((session) => session.sessionId === 'old-mnt-c-in-scope')
     ).toMatchObject({
-      cwd: '/mnt/c/Users/neil/orca/orca',
+      cwd: '/mnt/c/users/neil/orca/orca',
       agent: 'claude'
     })
   })

--- a/src/main/ai-vault/session-scanner-scope.test.ts
+++ b/src/main/ai-vault/session-scanner-scope.test.ts
@@ -167,4 +167,46 @@ describe('scanAiVaultSessions scope inclusion', () => {
 
     expect(result.sessions.map((session) => session.sessionId)).toContain('old-wsl-in-scope')
   })
+
+  it('surfaces a WSL /mnt/c session for a Windows-drive workspace past the recency cap', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-ai-vault-scope-mnt-'))
+    tempRoots.push(root)
+    const wslHome = join(root, 'wsl', 'Ubuntu', 'home', 'neil')
+    const claudeRoot = join(wslHome, '.claude', 'projects')
+
+    // Claude in WSL encodes the guest cwd, not the Windows drive spelling.
+    await writeClaudeSession({
+      claudeRoot,
+      dirName: '-mnt-c-Users-neil-orca-orca',
+      sessionId: 'old-mnt-c-in-scope',
+      cwd: '/mnt/c/Users/neil/orca/orca',
+      iso: '2026-01-01T00:00:00.000Z'
+    })
+    for (let index = 0; index < 4; index++) {
+      await writeClaudeSession({
+        claudeRoot,
+        dirName: `-other-mnt-${index}`,
+        sessionId: `recent-mnt-${index}`,
+        cwd: `/other/mnt/${index}`,
+        iso: `2026-06-2${index}T00:00:00.000Z`
+      })
+    }
+
+    const result = await scanAiVaultSessions(
+      scopedScanOptions(join(root, 'host-claude-projects'), {
+        wslHomeDirs: [wslHome],
+        platform: 'win32',
+        limit: 2,
+        scopePaths: [String.raw`C:\Users\neil\orca\orca`]
+      })
+    )
+
+    expect(result.sessions.map((session) => session.sessionId)).toContain('old-mnt-c-in-scope')
+    expect(
+      result.sessions.find((session) => session.sessionId === 'old-mnt-c-in-scope')
+    ).toMatchObject({
+      cwd: '/mnt/c/Users/neil/orca/orca',
+      agent: 'claude'
+    })
+  })
 })

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-filters.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-filters.test.ts
@@ -272,6 +272,27 @@ describe('filterAiVaultSessions', () => {
     ).toHaveLength(1)
   })
 
+  it('matches Windows drive workspace paths against WSL /mnt/c session cwd values', () => {
+    expect(
+      filterAiVaultSessions(
+        [
+          {
+            ...baseSession,
+            cwd: '/mnt/c/Users/neil/orca/orca'
+          }
+        ],
+        {
+          query: '',
+          agents: ['claude'],
+          scope: 'workspace',
+          sort: 'updated',
+          activeWorktreePaths: [String.raw`C:\Users\neil\orca\orca`],
+          hideEmptySessions: true
+        }
+      )
+    ).toHaveLength(1)
+  })
+
   it('matches WSL UNC workspace paths against Linux session cwd values', () => {
     expect(
       filterAiVaultSessions(

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-worktree-map.test.tsx
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-worktree-map.test.tsx
@@ -186,6 +186,31 @@ describe('useAiVaultSessionWorktreeMap', () => {
     })
   })
 
+  it('matches a Windows drive worktree against a WSL /mnt/c session cwd', () => {
+    const windowsWorktree = makeWorktree({
+      id: String.raw`repo-1::C:\Users\neil\orca\orca`,
+      path: String.raw`C:\Users\neil\orca\orca`,
+      displayName: 'orca'
+    })
+    const session = makeSession({
+      id: 'claude:mnt-c',
+      cwd: '/mnt/c/Users/neil/orca/orca'
+    })
+
+    const { result } = renderHook(() =>
+      useAiVaultSessionWorktreeMap({
+        sessions: [session],
+        repos,
+        worktrees: [windowsWorktree]
+      })
+    )
+
+    expect(result.current.get(session.id)).toMatchObject({
+      status: 'active',
+      worktreeId: windowsWorktree.id
+    })
+  })
+
   it('does not attribute a session to a workspace that merely shares a path prefix', () => {
     // Guards the candidate matcher's boundary: hoisting the root normalization
     // out of the loop must not degrade containment into a bare startsWith, or

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-worktree-map.test.tsx
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-worktree-map.test.tsx
@@ -211,6 +211,65 @@ describe('useAiVaultSessionWorktreeMap', () => {
     })
   })
 
+  it('prefers the deepest worktree independently of its WSL alias spelling', () => {
+    const parent = makeWorktree({
+      id: String.raw`repo-1::\\wsl.localhost\Ubuntu\mnt\c\Users\neil\orca`,
+      path: String.raw`\\wsl.localhost\Ubuntu\mnt\c\Users\neil\orca`,
+      displayName: 'parent'
+    })
+    const nested = makeWorktree({
+      id: String.raw`repo-1::C:\Users\neil\orca\app`,
+      path: String.raw`C:\Users\neil\orca\app`,
+      displayName: 'nested'
+    })
+    const session = makeSession({
+      id: 'claude:nested-mnt-c',
+      cwd: '/mnt/c/Users/neil/orca/app/src'
+    })
+
+    const { result } = renderHook(() =>
+      useAiVaultSessionWorktreeMap({ sessions: [session], repos, worktrees: [parent, nested] })
+    )
+
+    expect(result.current.get(session.id)).toMatchObject({ worktreeId: nested.id })
+  })
+
+  it('prefers a drive root over its POSIX /mnt parent', () => {
+    const mountParent = makeWorktree({ id: 'repo-1::/mnt', path: '/mnt' })
+    const driveRoot = makeWorktree({ id: 'repo-1::C:\\', path: 'C:\\' })
+    const session = makeSession({ id: 'claude:drive-root', cwd: '/mnt/c/repo' })
+
+    const { result } = renderHook(() =>
+      useAiVaultSessionWorktreeMap({
+        sessions: [session],
+        repos,
+        worktrees: [mountParent, driveRoot]
+      })
+    )
+
+    expect(result.current.get(session.id)).toMatchObject({ worktreeId: driveRoot.id })
+  })
+
+  it('keeps raw /mnt paths case-sensitive on SSH hosts', () => {
+    const sshWorktree = makeWorktree({
+      id: 'repo-1::/mnt/c/Users/Neil/repo',
+      path: '/mnt/c/Users/Neil/repo',
+      hostId: 'ssh:linux'
+    })
+    const session = makeSession({
+      id: 'claude:ssh-mnt-c',
+      cwd: '/mnt/c/users/neil/repo/src',
+      executionHostId: 'ssh:linux'
+    })
+
+    const { result } = renderHook(() =>
+      useAiVaultSessionWorktreeMap({ sessions: [session], repos, worktrees: [sshWorktree] })
+    )
+
+    expect(result.current.get(session.id)).toMatchObject({ status: 'unavailable' })
+    expect(result.current.get(session.id)?.worktreeId).toBeUndefined()
+  })
+
   it('does not attribute a session to a workspace that merely shares a path prefix', () => {
     // Guards the candidate matcher's boundary: hoisting the root normalization
     // out of the loop must not degrade containment into a bare startsWith, or

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-worktree-map.test.tsx
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-worktree-map.test.tsx
@@ -250,6 +250,26 @@ describe('useAiVaultSessionWorktreeMap', () => {
     expect(result.current.get(session.id)).toMatchObject({ worktreeId: driveRoot.id })
   })
 
+  it('keeps first-wins ordering for equal-depth WSL aliases', () => {
+    const first = makeWorktree({
+      id: String.raw`repo-1::C:\Repo`,
+      path: String.raw`C:\Repo`,
+      displayName: 'first'
+    })
+    const second = makeWorktree({
+      id: 'repo-1::/mnt/c/repo',
+      path: '/mnt/c/repo',
+      displayName: 'second'
+    })
+    const session = makeSession({ id: 'claude:equal-depth', cwd: '/mnt/c/repo/src' })
+
+    const { result } = renderHook(() =>
+      useAiVaultSessionWorktreeMap({ sessions: [session], repos, worktrees: [first, second] })
+    )
+
+    expect(result.current.get(session.id)).toMatchObject({ worktreeId: first.id })
+  })
+
   it('keeps raw /mnt paths case-sensitive on SSH hosts', () => {
     const sshWorktree = makeWorktree({
       id: 'repo-1::/mnt/c/Users/Neil/repo',
@@ -303,6 +323,10 @@ describe('useAiVaultSessionWorktreeMap', () => {
       makeSession({ id: `codex:s${i}`, cwd: `/repo/w${i % manyWorktrees.length}/src` })
     )
 
+    // Isolate the production fanout from garbage retained by earlier renderHook cases.
+    const gc = (globalThis as { gc?: () => void }).gc
+    gc?.()
+    gc?.()
     const startedAt = performance.now()
     const { result } = renderHook(() =>
       useAiVaultSessionWorktreeMap({

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-worktree.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-worktree.ts
@@ -1,5 +1,8 @@
 import { useMemo } from 'react'
-import { parseWslUncPath } from '../../../../shared/wsl-paths'
+import {
+  createWslAliasedPathInsideOrEqualMatcher,
+  normalizedWslPathAliases
+} from '../../../../shared/wsl-path-aliases'
 import { splitWorktreeIdForFilesystem } from '../../../../shared/worktree/id'
 import {
   getRepoExecutionHostId,
@@ -8,7 +11,6 @@ import {
   type ExecutionHostId
 } from '../../../../shared/execution-host'
 import {
-  createNormalizedPathInsideOrEqualMatcher,
   isRuntimePathAbsolute,
   normalizeRuntimePathForComparison
 } from '../../../../shared/cross-platform-path'
@@ -87,9 +89,9 @@ function resolveWorktreeInfoFromCandidates(
   }
 
   const sessionHostId = normalizeExecutionHostId(session.executionHostId)
-  const normalizedCwd = normalizeRuntimePathForComparison(session.cwd)
+  const cwdAliases = normalizedWslPathAliases(session.cwd)
   const matched = candidates
-    .filter((candidate) => candidate.ownsNormalizedCwd(normalizedCwd))
+    .filter((candidate) => cwdAliases.some((alias) => candidate.ownsNormalizedCwd(alias)))
     .filter((candidate) => !sessionHostId || candidate.hostId === sessionHostId)
     .sort(compareWorktreeCandidates)
 
@@ -229,20 +231,13 @@ function makeWorktreeCandidate(
   hostId: ExecutionHostId,
   source: WorktreeCandidate['source']
 ): WorktreeCandidate {
-  const ownsCwd = createNormalizedPathInsideOrEqualMatcher(path)
-  // A WSL UNC root also owns sessions recorded under its Linux-native cwd.
-  const wslPath = parseWslUncPath(path)
-  const ownsCwdViaWslAlias = wslPath
-    ? createNormalizedPathInsideOrEqualMatcher(wslPath.linuxPath)
-    : null
   return {
     worktree,
     path,
     hostId,
     status: worktree.isArchived ? 'archived' : 'active',
     source,
-    ownsNormalizedCwd: (normalizedCwd) =>
-      ownsCwd(normalizedCwd) || (ownsCwdViaWslAlias?.(normalizedCwd) ?? false),
+    ownsNormalizedCwd: createWslAliasedPathInsideOrEqualMatcher(path),
     normalizedPathLength: normalizeRuntimePathForComparison(path).length
   }
 }

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-worktree.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-worktree.ts
@@ -1,8 +1,8 @@
 import { useMemo } from 'react'
 import {
-  createWslAliasedPathInsideOrEqualMatcher,
   normalizedWslPathCandidateAliases,
-  wslAliasedPathDepth
+  wslAliasedPathDepth,
+  wslRootPathAliases
 } from '../../../../shared/wsl-path-aliases'
 import { splitWorktreeIdForFilesystem } from '../../../../shared/worktree/id'
 import {
@@ -11,7 +11,10 @@ import {
   normalizeExecutionHostId,
   type ExecutionHostId
 } from '../../../../shared/execution-host'
-import { isRuntimePathAbsolute } from '../../../../shared/cross-platform-path'
+import {
+  isRuntimePathAbsolute,
+  normalizeRuntimePathForComparison
+} from '../../../../shared/cross-platform-path'
 import type { AiVaultSession } from '../../../../shared/ai-vault-types'
 import type { Repo } from '../../../../shared/repo-types'
 import type { Worktree } from '../../../../shared/worktree/types'
@@ -42,9 +45,12 @@ type WorktreeCandidate = {
   hostId: ExecutionHostId
   status: Exclude<AiVaultSessionWorktreeStatus, 'current'>
   source: 'current-path' | 'prior-path'
-  // Precomputed so a 500-session scan doesn't re-normalize ~500 roots per session.
-  ownsNormalizedCwd: (normalizedCwd: string) => boolean
   pathDepth: number
+  order: number
+}
+
+type WorktreeCandidateLookup = {
+  candidatesByRoot: ReadonlyMap<string, readonly WorktreeCandidate[]>
 }
 
 export function resolveAiVaultSessionWorktreeInfo({
@@ -59,7 +65,7 @@ export function resolveAiVaultSessionWorktreeInfo({
   activeWorktreeId: string | null
 }): AiVaultSessionWorktreeInfo | null {
   return withAiVaultCurrentWorktreeStatus(
-    resolveWorktreeInfoFromCandidates(session, buildWorktreeCandidates(worktrees, repos)),
+    resolveWorktreeInfoFromCandidates(session, buildWorktreeCandidateLookup(worktrees, repos)),
     activeWorktreeId
   )
 }
@@ -80,7 +86,7 @@ export function withAiVaultCurrentWorktreeStatus(
 
 function resolveWorktreeInfoFromCandidates(
   session: AiVaultSession,
-  candidates: readonly WorktreeCandidate[]
+  lookup: WorktreeCandidateLookup
 ): AiVaultSessionWorktreeInfo | null {
   if (!session.cwd) {
     return null
@@ -88,12 +94,7 @@ function resolveWorktreeInfoFromCandidates(
 
   const sessionHostId = normalizeExecutionHostId(session.executionHostId)
   const cwdAliases = normalizedWslPathCandidateAliases(session.cwd)
-  const matched = candidates
-    .filter((candidate) => cwdAliases.some((alias) => candidate.ownsNormalizedCwd(alias)))
-    .filter((candidate) => !sessionHostId || candidate.hostId === sessionHostId)
-    .sort(compareWorktreeCandidates)
-
-  const best = matched[0]
+  const best = findBestWorktreeCandidate(lookup, sessionHostId, cwdAliases)
   if (!best) {
     return {
       status: 'unavailable',
@@ -108,6 +109,45 @@ function resolveWorktreeInfoFromCandidates(
     path: best.path,
     worktreeId: best.worktree.id
   }
+}
+
+function findBestWorktreeCandidate(
+  lookup: WorktreeCandidateLookup,
+  sessionHostId: ExecutionHostId | null,
+  normalizedCwdAliases: readonly string[]
+): WorktreeCandidate | null {
+  let best: WorktreeCandidate | null = null
+  for (const cwdAlias of normalizedCwdAliases) {
+    let ancestorPath = cwdAlias
+    while (ancestorPath) {
+      const matchingCandidates = lookup.candidatesByRoot.get(ancestorPath)
+      if (matchingCandidates) {
+        for (const candidate of matchingCandidates) {
+          if (sessionHostId && candidate.hostId !== sessionHostId) {
+            continue
+          }
+          if (!best || compareWorktreeCandidates(candidate, best) < 0) {
+            best = candidate
+          }
+        }
+      }
+      if (ancestorPath === '/' || /^[a-z]:\/$/i.test(ancestorPath)) {
+        break
+      }
+      const separatorIndex = ancestorPath.lastIndexOf('/')
+      if (separatorIndex === -1) {
+        break
+      }
+      if (separatorIndex === 0) {
+        ancestorPath = '/'
+      } else if (separatorIndex === 2 && /^[a-z]:\//i.test(ancestorPath)) {
+        ancestorPath = ancestorPath.slice(0, 3)
+      } else {
+        ancestorPath = ancestorPath.slice(0, separatorIndex)
+      }
+    }
+  }
+  return best
 }
 
 export function extractWorktreePathFromSessionTitle(title: string): string | null {
@@ -134,7 +174,7 @@ export function resolveAiVaultSessionWorktreeDisplay(args: {
   return withAiVaultCurrentWorktreeStatus(
     resolveWorktreeDisplayFromCandidates(
       args.session,
-      buildWorktreeCandidates(args.worktrees, args.repos ?? [])
+      buildWorktreeCandidateLookup(args.worktrees, args.repos ?? [])
     ),
     args.activeWorktreeId
   )
@@ -142,9 +182,9 @@ export function resolveAiVaultSessionWorktreeDisplay(args: {
 
 function resolveWorktreeDisplayFromCandidates(
   session: AiVaultSession,
-  candidates: readonly WorktreeCandidate[]
+  lookup: WorktreeCandidateLookup
 ): AiVaultSessionWorktreeInfo | null {
-  const resolved = resolveWorktreeInfoFromCandidates(session, candidates)
+  const resolved = resolveWorktreeInfoFromCandidates(session, lookup)
   if (resolved) {
     return resolved
   }
@@ -188,20 +228,22 @@ export function useAiVaultSessionWorktreeMap({
   return useMemo(() => {
     // Hoisted out of the per-session loop: candidates and their normalized
     // roots are session-independent.
-    const candidates = buildWorktreeCandidates(worktrees, repos)
-    return new Map(
-      sessions.flatMap((session) => {
-        const worktreeInfo = resolveWorktreeDisplayFromCandidates(session, candidates)
-        return worktreeInfo ? [[session.id, worktreeInfo] as const] : []
-      })
-    )
+    const lookup = buildWorktreeCandidateLookup(worktrees, repos)
+    const worktreeInfoBySessionId = new Map<string, AiVaultSessionWorktreeInfo>()
+    for (const session of sessions) {
+      const worktreeInfo = resolveWorktreeDisplayFromCandidates(session, lookup)
+      if (worktreeInfo) {
+        worktreeInfoBySessionId.set(session.id, worktreeInfo)
+      }
+    }
+    return worktreeInfoBySessionId
   }, [repos, sessions, worktrees])
 }
 
-function buildWorktreeCandidates(
+function buildWorktreeCandidateLookup(
   worktrees: readonly Worktree[],
   repos: readonly Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>[]
-): WorktreeCandidate[] {
+): WorktreeCandidateLookup {
   const candidates: WorktreeCandidate[] = []
   const repoById = new Map(repos.map((repo) => [repo.id, repo]))
   for (const worktree of worktrees) {
@@ -210,24 +252,47 @@ function buildWorktreeCandidates(
       normalizeExecutionHostId(worktree.hostId) ??
       (repo ? getRepoExecutionHostId(repo) : LOCAL_EXECUTION_HOST_ID)
     if (hasUsablePath(worktree.path)) {
-      candidates.push(makeWorktreeCandidate(worktree, worktree.path, hostId, 'current-path'))
+      candidates.push(
+        makeWorktreeCandidate(worktree, worktree.path, hostId, 'current-path', candidates.length)
+      )
     }
     for (const priorWorktreeId of worktree.priorWorktreeIds ?? []) {
       const parsed = splitWorktreeIdForFilesystem(priorWorktreeId)
       if (!parsed || parsed.repoId !== worktree.repoId || !hasUsablePath(parsed.worktreePath)) {
         continue
       }
-      candidates.push(makeWorktreeCandidate(worktree, parsed.worktreePath, hostId, 'prior-path'))
+      candidates.push(
+        makeWorktreeCandidate(
+          worktree,
+          parsed.worktreePath,
+          hostId,
+          'prior-path',
+          candidates.length
+        )
+      )
     }
   }
-  return candidates
+  const candidatesByRoot = new Map<string, WorktreeCandidate[]>()
+  for (const candidate of candidates) {
+    for (const alias of wslRootPathAliases(candidate.path)) {
+      const normalizedRoot = normalizeRuntimePathForComparison(alias)
+      const matchingCandidates = candidatesByRoot.get(normalizedRoot)
+      if (matchingCandidates) {
+        matchingCandidates.push(candidate)
+      } else {
+        candidatesByRoot.set(normalizedRoot, [candidate])
+      }
+    }
+  }
+  return { candidatesByRoot }
 }
 
 function makeWorktreeCandidate(
   worktree: Worktree,
   path: string,
   hostId: ExecutionHostId,
-  source: WorktreeCandidate['source']
+  source: WorktreeCandidate['source'],
+  order: number
 ): WorktreeCandidate {
   return {
     worktree,
@@ -235,8 +300,8 @@ function makeWorktreeCandidate(
     hostId,
     status: worktree.isArchived ? 'archived' : 'active',
     source,
-    ownsNormalizedCwd: createWslAliasedPathInsideOrEqualMatcher(path),
-    pathDepth: wslAliasedPathDepth(path)
+    pathDepth: wslAliasedPathDepth(path),
+    order
   }
 }
 
@@ -251,7 +316,7 @@ function compareWorktreeCandidates(left: WorktreeCandidate, right: WorktreeCandi
     return depthDifference
   }
   if (left.source === right.source) {
-    return 0
+    return left.order - right.order
   }
   return left.source === 'current-path' ? -1 : 1
 }

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-worktree.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-worktree.ts
@@ -1,7 +1,8 @@
 import { useMemo } from 'react'
 import {
   createWslAliasedPathInsideOrEqualMatcher,
-  normalizedWslPathAliases
+  normalizedWslPathCandidateAliases,
+  wslAliasedPathDepth
 } from '../../../../shared/wsl-path-aliases'
 import { splitWorktreeIdForFilesystem } from '../../../../shared/worktree/id'
 import {
@@ -10,10 +11,7 @@ import {
   normalizeExecutionHostId,
   type ExecutionHostId
 } from '../../../../shared/execution-host'
-import {
-  isRuntimePathAbsolute,
-  normalizeRuntimePathForComparison
-} from '../../../../shared/cross-platform-path'
+import { isRuntimePathAbsolute } from '../../../../shared/cross-platform-path'
 import type { AiVaultSession } from '../../../../shared/ai-vault-types'
 import type { Repo } from '../../../../shared/repo-types'
 import type { Worktree } from '../../../../shared/worktree/types'
@@ -46,7 +44,7 @@ type WorktreeCandidate = {
   source: 'current-path' | 'prior-path'
   // Precomputed so a 500-session scan doesn't re-normalize ~500 roots per session.
   ownsNormalizedCwd: (normalizedCwd: string) => boolean
-  normalizedPathLength: number
+  pathDepth: number
 }
 
 export function resolveAiVaultSessionWorktreeInfo({
@@ -89,7 +87,7 @@ function resolveWorktreeInfoFromCandidates(
   }
 
   const sessionHostId = normalizeExecutionHostId(session.executionHostId)
-  const cwdAliases = normalizedWslPathAliases(session.cwd)
+  const cwdAliases = normalizedWslPathCandidateAliases(session.cwd)
   const matched = candidates
     .filter((candidate) => cwdAliases.some((alias) => candidate.ownsNormalizedCwd(alias)))
     .filter((candidate) => !sessionHostId || candidate.hostId === sessionHostId)
@@ -238,7 +236,7 @@ function makeWorktreeCandidate(
     status: worktree.isArchived ? 'archived' : 'active',
     source,
     ownsNormalizedCwd: createWslAliasedPathInsideOrEqualMatcher(path),
-    normalizedPathLength: normalizeRuntimePathForComparison(path).length
+    pathDepth: wslAliasedPathDepth(path)
   }
 }
 
@@ -248,9 +246,9 @@ function hasUsablePath(pathValue: string): boolean {
 }
 
 function compareWorktreeCandidates(left: WorktreeCandidate, right: WorktreeCandidate): number {
-  const lengthDifference = right.normalizedPathLength - left.normalizedPathLength
-  if (lengthDifference !== 0) {
-    return lengthDifference
+  const depthDifference = right.pathDepth - left.pathDepth
+  if (depthDifference !== 0) {
+    return depthDifference
   }
   if (left.source === right.source) {
     return 0

--- a/src/shared/ai-vault-session-depth.test.ts
+++ b/src/shared/ai-vault-session-depth.test.ts
@@ -82,4 +82,18 @@ describe('Agent Session History depth', () => {
     ])
     expect(truncateAiVaultListResult(loaded, 'unlimited')).toBe(loaded)
   })
+
+  it('keeps a WSL /mnt/c session when the scope path is a Windows drive', () => {
+    const loaded = result([
+      session('global-1', '/other', 6),
+      session('global-2', '/other', 5),
+      session('mnt-c', '/mnt/c/Users/neil/orca/orca', 1)
+    ])
+
+    expect(
+      truncateAiVaultListResult(loaded, 2, [String.raw`C:\Users\neil\orca\orca`]).sessions.map(
+        ({ id }) => id
+      )
+    ).toEqual(['global-1', 'global-2', 'mnt-c'])
+  })
 })

--- a/src/shared/ai-vault-session-depth.ts
+++ b/src/shared/ai-vault-session-depth.ts
@@ -1,4 +1,4 @@
-import { isWslAliasedPathInsideOrEqual } from './wsl-path-aliases'
+import { createWslAliasedPathInsideOrEqualScopeMatcher } from './wsl-path-aliases'
 import type { AiVaultListArgs, AiVaultListResult } from './ai-vault-types'
 
 export const DEFAULT_AI_VAULT_SCAN_LIMIT = 1000
@@ -40,10 +40,11 @@ export function truncateAiVaultListResult(
   }
   const selectedIds = new Set(result.sessions.slice(0, depth).map((session) => session.id))
   if (scopePaths.length > 0) {
+    const ownsScopedCwd = createWslAliasedPathInsideOrEqualScopeMatcher(scopePaths)
     let scopedCount = 0
     for (const session of result.sessions) {
       const cwd = session.cwd
-      if (cwd && scopePaths.some((scopePath) => isWslAliasedPathInsideOrEqual(scopePath, cwd))) {
+      if (cwd && ownsScopedCwd(cwd)) {
         selectedIds.add(session.id)
         if (++scopedCount >= depth) {
           break

--- a/src/shared/ai-vault-session-depth.ts
+++ b/src/shared/ai-vault-session-depth.ts
@@ -1,4 +1,4 @@
-import { isPathInsideOrEqual } from './cross-platform-path'
+import { isWslAliasedPathInsideOrEqual } from './wsl-path-aliases'
 import type { AiVaultListArgs, AiVaultListResult } from './ai-vault-types'
 
 export const DEFAULT_AI_VAULT_SCAN_LIMIT = 1000
@@ -43,7 +43,7 @@ export function truncateAiVaultListResult(
     let scopedCount = 0
     for (const session of result.sessions) {
       const cwd = session.cwd
-      if (cwd && scopePaths.some((scopePath) => isPathInsideOrEqual(scopePath, cwd))) {
+      if (cwd && scopePaths.some((scopePath) => isWslAliasedPathInsideOrEqual(scopePath, cwd))) {
         selectedIds.add(session.id)
         if (++scopedCount >= depth) {
           break

--- a/src/shared/ai-vault-session-filters.test.ts
+++ b/src/shared/ai-vault-session-filters.test.ts
@@ -129,6 +129,45 @@ describe('/shared ai-vault-session-filters (lifted core)', () => {
     expect(groups[0].sessions).toHaveLength(2)
   })
 
+  it('matches a Windows drive workspace against a WSL /mnt/c session cwd', () => {
+    expect(
+      filterAiVaultSessions([{ ...baseSession, cwd: '/mnt/c/Users/neil/orca/orca' }], {
+        query: '',
+        agents: ['claude'],
+        scope: 'workspace',
+        sort: 'updated',
+        activeWorktreePaths: [String.raw`C:\Users\neil\orca\orca`],
+        hideEmptySessions: true
+      }).map((session) => session.id)
+    ).toEqual(['claude:1'])
+  })
+
+  it('matches a Windows drive workspace case-insensitively against a WSL /mnt/c cwd', () => {
+    expect(
+      filterAiVaultSessions([{ ...baseSession, cwd: '/mnt/c/Users/neil/orca/orca' }], {
+        query: '',
+        agents: ['claude'],
+        scope: 'workspace',
+        sort: 'updated',
+        activeWorktreePaths: [String.raw`c:\users\neil\orca\orca`],
+        hideEmptySessions: true
+      })
+    ).toHaveLength(1)
+  })
+
+  it('does not treat a sibling /mnt/c path as the same Windows workspace', () => {
+    expect(
+      filterAiVaultSessions([{ ...baseSession, cwd: '/mnt/c/Users/neil/orca-secret' }], {
+        query: '',
+        agents: ['claude'],
+        scope: 'workspace',
+        sort: 'updated',
+        activeWorktreePaths: [String.raw`C:\Users\neil\orca`],
+        hideEmptySessions: true
+      })
+    ).toEqual([])
+  })
+
   it('folds the two WSL UNC aliases of one folder into a single group', () => {
     const groups = groupAiVaultSessions(
       [

--- a/src/shared/ai-vault-session-filters.ts
+++ b/src/shared/ai-vault-session-filters.ts
@@ -7,7 +7,7 @@ import {
   normalizeRuntimePathSeparators
 } from './cross-platform-path'
 import { isClipboardTextByteLengthOverLimit } from './clipboard-text'
-import { isWslAliasedPathInsideOrEqual } from './wsl-path-aliases'
+import { createWslAliasedPathInsideOrEqualScopeMatcher } from './wsl-path-aliases'
 import type {
   AiVaultAgent,
   AiVaultGroup,
@@ -78,6 +78,10 @@ export function filterAiVaultSessions(
 
   const agentSet = new Set(filters.agents)
   const parsedQuery = parseVaultQuery(filters.query)
+  const ownsWorkspaceCwd =
+    filters.scope === 'workspace'
+      ? createWslAliasedPathInsideOrEqualScopeMatcher(filters.activeWorktreePaths)
+      : null
 
   return sessions
     .filter((session) => {
@@ -98,12 +102,7 @@ export function filterAiVaultSessions(
       if (filters.scope === 'workspace') {
         const cwd = session.cwd
         // WSL transcripts record `/home/...` or `/mnt/c/...` for Windows worktrees.
-        if (
-          !cwd ||
-          !filters.activeWorktreePaths.some((pathValue) =>
-            isWslAliasedPathInsideOrEqual(pathValue, cwd)
-          )
-        ) {
+        if (!cwd || !ownsWorkspaceCwd?.(cwd)) {
           return false
         }
       }

--- a/src/shared/ai-vault-session-filters.ts
+++ b/src/shared/ai-vault-session-filters.ts
@@ -3,12 +3,11 @@
 // Metro only watches mobile/ + repo-root src/shared, never src/renderer.
 // INVARIANT: /shared is a leaf — this module must NOT import from src/renderer.
 import {
-  isPathInsideOrEqual,
   normalizeRuntimePathForComparison,
   normalizeRuntimePathSeparators
 } from './cross-platform-path'
 import { isClipboardTextByteLengthOverLimit } from './clipboard-text'
-import { parseWslUncPath } from './wsl-paths'
+import { isWslAliasedPathInsideOrEqual } from './wsl-path-aliases'
 import type {
   AiVaultAgent,
   AiVaultGroup,
@@ -98,10 +97,11 @@ export function filterAiVaultSessions(
       }
       if (filters.scope === 'workspace') {
         const cwd = session.cwd
+        // WSL transcripts record `/home/...` or `/mnt/c/...` for Windows worktrees.
         if (
           !cwd ||
           !filters.activeWorktreePaths.some((pathValue) =>
-            isAiVaultSessionInWorkspacePath(pathValue, cwd)
+            isWslAliasedPathInsideOrEqual(pathValue, cwd)
           )
         ) {
           return false
@@ -274,21 +274,6 @@ function getGroupIdentity(
     }
   }
   return { key: folderGroupKey(session.cwd), label: folderLabel(session.cwd) }
-}
-
-function isAiVaultSessionInWorkspacePath(workspacePath: string, sessionCwd: string): boolean {
-  if (isPathInsideOrEqual(workspacePath, sessionCwd)) {
-    return true
-  }
-
-  const workspaceWslPath = parseWslUncPath(workspacePath)
-  if (!workspaceWslPath) {
-    return false
-  }
-
-  // WSL agent transcripts record Linux cwd values even when Orca stores the
-  // active worktree as a Windows UNC path.
-  return isPathInsideOrEqual(workspaceWslPath.linuxPath, sessionCwd)
 }
 
 function tokenizeQuery(query: string): string[] {

--- a/src/shared/wsl-path-aliases.test.ts
+++ b/src/shared/wsl-path-aliases.test.ts
@@ -30,6 +30,10 @@ describe('wslRootPathAliases', () => {
       '/mnt/c/Users/neil/orca',
       String.raw`C:\Users\neil\orca`
     ])
+    expect(wslRootPathAliases(String.raw`\\wsl.localhost\Ubuntu\mnt\C\Repo`)).toEqual([
+      String.raw`\\wsl.localhost\Ubuntu\mnt\C\Repo`,
+      '/mnt/C/Repo'
+    ])
   })
 
   it('does not invent aliases for an ordinary POSIX path', () => {
@@ -77,6 +81,10 @@ describe('isWslAliasedPathInsideOrEqual', () => {
     ).toBe(false)
   })
 
+  it('does not reinterpret a case-variant /mnt/C directory as a drive mount', () => {
+    expect(isWslAliasedPathInsideOrEqual(String.raw`C:\Repo`, '/mnt/C/Repo/src')).toBe(false)
+  })
+
   it('preserves the distro identity of UNC candidates', () => {
     const ubuntuRoot = String.raw`\\wsl.localhost\Ubuntu\home\ada\repo`
     expect(isWslAliasedPathInsideOrEqual(ubuntuRoot, '/home/ada/repo/src')).toBe(true)
@@ -95,6 +103,10 @@ describe('normalizedWslPathCandidateAliases', () => {
       '/mnt/c/Users/neil/orca/orca',
       'c:/users/neil/orca/orca'
     ])
+  })
+
+  it('keeps a case-variant /mnt/C candidate as a case-sensitive Linux path', () => {
+    expect(normalizedWslPathCandidateAliases('/mnt/C/Repo')).toEqual(['/mnt/C/Repo'])
   })
 })
 

--- a/src/shared/wsl-path-aliases.test.ts
+++ b/src/shared/wsl-path-aliases.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isWslAliasedPathInsideOrEqual,
+  normalizedWslPathAliases,
+  wslPathAliases
+} from './wsl-path-aliases'
+
+describe('wslPathAliases', () => {
+  it('pairs a Windows drive path with its WSL drvfs mount', () => {
+    expect(wslPathAliases(String.raw`C:\Users\neil\orca\orca`)).toEqual([
+      String.raw`C:\Users\neil\orca\orca`,
+      '/mnt/c/Users/neil/orca/orca'
+    ])
+  })
+
+  it('pairs a WSL drvfs mount with its Windows drive path', () => {
+    expect(wslPathAliases('/mnt/c/Users/neil/orca/orca')).toEqual([
+      '/mnt/c/Users/neil/orca/orca',
+      String.raw`C:\Users\neil\orca\orca`
+    ])
+  })
+
+  it('keeps distro-native UNC aliases and unfolds a UNC-mounted drive', () => {
+    expect(wslPathAliases(String.raw`\\wsl.localhost\Ubuntu\home\ada\repo`)).toEqual([
+      String.raw`\\wsl.localhost\Ubuntu\home\ada\repo`,
+      '/home/ada/repo'
+    ])
+    expect(wslPathAliases(String.raw`\\wsl.localhost\Ubuntu\mnt\c\Users\neil\orca`)).toEqual([
+      String.raw`\\wsl.localhost\Ubuntu\mnt\c\Users\neil\orca`,
+      '/mnt/c/Users/neil/orca',
+      String.raw`C:\Users\neil\orca`
+    ])
+  })
+
+  it('does not invent aliases for an ordinary POSIX path', () => {
+    expect(wslPathAliases('/home/ada/repo')).toEqual(['/home/ada/repo'])
+  })
+})
+
+describe('isWslAliasedPathInsideOrEqual', () => {
+  it('treats C:\\ and /mnt/c as the same workspace, including case-folded drives', () => {
+    expect(
+      isWslAliasedPathInsideOrEqual(
+        String.raw`C:\Users\neil\orca\orca`,
+        '/mnt/c/Users/neil/orca/orca'
+      )
+    ).toBe(true)
+    expect(
+      isWslAliasedPathInsideOrEqual(
+        String.raw`c:\users\neil\orca\orca`,
+        '/mnt/c/Users/neil/orca/orca/src'
+      )
+    ).toBe(true)
+  })
+
+  it('rejects a sibling path that only shares a prefix', () => {
+    expect(
+      isWslAliasedPathInsideOrEqual(String.raw`C:\Users\neil\orca`, '/mnt/c/Users/neil/orca-secret')
+    ).toBe(false)
+  })
+
+  it('still matches a WSL UNC worktree against a Linux cwd', () => {
+    expect(
+      isWslAliasedPathInsideOrEqual(
+        String.raw`\\wsl.localhost\Ubuntu\home\ada\repo`,
+        '/home/ada/repo/app'
+      )
+    ).toBe(true)
+  })
+})
+
+describe('normalizedWslPathAliases', () => {
+  it('folds the Windows drive spelling so /mnt/c can match a case-variant workspace', () => {
+    expect(normalizedWslPathAliases('/mnt/c/Users/neil/orca/orca')).toEqual([
+      '/mnt/c/Users/neil/orca/orca',
+      'c:/users/neil/orca/orca'
+    ])
+  })
+})

--- a/src/shared/wsl-path-aliases.test.ts
+++ b/src/shared/wsl-path-aliases.test.ts
@@ -1,31 +1,31 @@
 import { describe, expect, it } from 'vitest'
 import {
   isWslAliasedPathInsideOrEqual,
-  normalizedWslPathAliases,
-  wslPathAliases
+  normalizedWslPathCandidateAliases,
+  wslAliasedPathDepth,
+  wslRootPathAliases
 } from './wsl-path-aliases'
 
-describe('wslPathAliases', () => {
+describe('wslRootPathAliases', () => {
   it('pairs a Windows drive path with its WSL drvfs mount', () => {
-    expect(wslPathAliases(String.raw`C:\Users\neil\orca\orca`)).toEqual([
+    expect(wslRootPathAliases(String.raw`C:\Users\neil\orca\orca`)).toEqual([
       String.raw`C:\Users\neil\orca\orca`,
       '/mnt/c/Users/neil/orca/orca'
     ])
   })
 
-  it('pairs a WSL drvfs mount with its Windows drive path', () => {
-    expect(wslPathAliases('/mnt/c/Users/neil/orca/orca')).toEqual([
-      '/mnt/c/Users/neil/orca/orca',
-      String.raw`C:\Users\neil\orca\orca`
+  it('does not reinterpret a raw POSIX mount as WSL drvfs', () => {
+    expect(wslRootPathAliases('/mnt/c/Users/neil/orca/orca')).toEqual([
+      '/mnt/c/Users/neil/orca/orca'
     ])
   })
 
   it('keeps distro-native UNC aliases and unfolds a UNC-mounted drive', () => {
-    expect(wslPathAliases(String.raw`\\wsl.localhost\Ubuntu\home\ada\repo`)).toEqual([
+    expect(wslRootPathAliases(String.raw`\\wsl.localhost\Ubuntu\home\ada\repo`)).toEqual([
       String.raw`\\wsl.localhost\Ubuntu\home\ada\repo`,
       '/home/ada/repo'
     ])
-    expect(wslPathAliases(String.raw`\\wsl.localhost\Ubuntu\mnt\c\Users\neil\orca`)).toEqual([
+    expect(wslRootPathAliases(String.raw`\\wsl.localhost\Ubuntu\mnt\c\Users\neil\orca`)).toEqual([
       String.raw`\\wsl.localhost\Ubuntu\mnt\c\Users\neil\orca`,
       '/mnt/c/Users/neil/orca',
       String.raw`C:\Users\neil\orca`
@@ -33,7 +33,7 @@ describe('wslPathAliases', () => {
   })
 
   it('does not invent aliases for an ordinary POSIX path', () => {
-    expect(wslPathAliases('/home/ada/repo')).toEqual(['/home/ada/repo'])
+    expect(wslRootPathAliases('/home/ada/repo')).toEqual(['/home/ada/repo'])
   })
 })
 
@@ -67,13 +67,53 @@ describe('isWslAliasedPathInsideOrEqual', () => {
       )
     ).toBe(true)
   })
+
+  it('preserves case for a raw POSIX /mnt root', () => {
+    expect(
+      isWslAliasedPathInsideOrEqual('/mnt/c/Users/Neil/repo', '/mnt/c/Users/Neil/repo/src')
+    ).toBe(true)
+    expect(
+      isWslAliasedPathInsideOrEqual('/mnt/c/Users/Neil/repo', '/mnt/c/users/neil/repo/src')
+    ).toBe(false)
+  })
+
+  it('preserves the distro identity of UNC candidates', () => {
+    const ubuntuRoot = String.raw`\\wsl.localhost\Ubuntu\home\ada\repo`
+    expect(isWslAliasedPathInsideOrEqual(ubuntuRoot, '/home/ada/repo/src')).toBe(true)
+    expect(
+      isWslAliasedPathInsideOrEqual(
+        ubuntuRoot,
+        String.raw`\\wsl.localhost\Debian\home\ada\repo\src`
+      )
+    ).toBe(false)
+  })
 })
 
-describe('normalizedWslPathAliases', () => {
+describe('normalizedWslPathCandidateAliases', () => {
   it('folds the Windows drive spelling so /mnt/c can match a case-variant workspace', () => {
-    expect(normalizedWslPathAliases('/mnt/c/Users/neil/orca/orca')).toEqual([
+    expect(normalizedWslPathCandidateAliases('/mnt/c/Users/neil/orca/orca')).toEqual([
       '/mnt/c/Users/neil/orca/orca',
       'c:/users/neil/orca/orca'
     ])
+  })
+})
+
+describe('wslAliasedPathDepth', () => {
+  it('assigns one depth to every spelling of a drvfs path', () => {
+    expect([
+      wslAliasedPathDepth(String.raw`C:\Users\neil\orca`),
+      wslAliasedPathDepth('/mnt/c/Users/neil/orca'),
+      wslAliasedPathDepth(String.raw`\\wsl.localhost\Ubuntu\mnt\c\Users\neil\orca`)
+    ]).toEqual([5, 5, 5])
+  })
+
+  it('assigns one depth to distro-native UNC and Linux spellings', () => {
+    expect(wslAliasedPathDepth(String.raw`\\wsl$\Ubuntu\home\ada\repo`)).toBe(3)
+    expect(wslAliasedPathDepth('/home/ada/repo')).toBe(3)
+  })
+
+  it('preserves POSIX and drvfs nesting', () => {
+    expect(wslAliasedPathDepth('/srv/repo/child')).toBeGreaterThan(wslAliasedPathDepth('/srv/repo'))
+    expect(wslAliasedPathDepth('C:\\')).toBeGreaterThan(wslAliasedPathDepth('/mnt'))
   })
 })

--- a/src/shared/wsl-path-aliases.ts
+++ b/src/shared/wsl-path-aliases.ts
@@ -84,7 +84,7 @@ function wslMountPathFromWindowsDrive(pathValue: string): string | null {
 }
 
 function windowsDrivePathFromWslMount(pathValue: string): string | null {
-  const match = pathValue.match(/^\/mnt\/([a-zA-Z])(\/.*)?$/)
+  const match = pathValue.match(/^\/mnt\/([a-z])(\/.*)?$/)
   if (!match) {
     return null
   }

--- a/src/shared/wsl-path-aliases.ts
+++ b/src/shared/wsl-path-aliases.ts
@@ -11,6 +11,14 @@ import { parseWslUncPath } from './wsl-paths'
  * A raw `/mnt/c` root stays POSIX because its syntax alone does not prove WSL.
  */
 export function wslRootPathAliases(pathValue: string): string[] {
+  const unc = mightBeWslUncPath(pathValue) ? parseWslUncPath(pathValue) : null
+  const driveMount = mightBeWindowsDrivePath(pathValue)
+    ? wslMountPathFromWindowsDrive(pathValue)
+    : null
+  if (!unc && !driveMount) {
+    return [pathValue]
+  }
+
   const aliases: string[] = []
   const seen = new Set<string>()
   const add = (value: string | null) => {
@@ -23,55 +31,68 @@ export function wslRootPathAliases(pathValue: string): string[] {
 
   add(pathValue)
 
-  const unc = parseWslUncPath(pathValue)
   if (unc) {
     add(unc.linuxPath)
     add(windowsDrivePathFromWslMount(unc.linuxPath))
   }
 
-  add(wslMountPathFromWindowsDrive(pathValue))
+  add(driveMount)
 
   return aliases
 }
 
 /** Candidate spellings include a potential drive alias that only an explicit root can match. */
 export function normalizedWslPathCandidateAliases(pathValue: string): string[] {
-  const aliases: string[] = []
-  const seen = new Set<string>()
-  for (const alias of candidateWslPathAliases(pathValue)) {
-    const normalized = normalizeRuntimePathForComparison(alias)
-    if (seen.has(normalized)) {
-      continue
-    }
-    seen.add(normalized)
-    aliases.push(normalized)
+  const normalizedPath = normalizeRuntimePathForComparison(pathValue)
+  const linuxPath = mightBeWslUncPath(pathValue)
+    ? (parseWslUncPath(pathValue)?.linuxPath ?? pathValue)
+    : pathValue
+  const windowsPath = windowsDrivePathFromWslMount(linuxPath)
+  if (!windowsPath) {
+    return [normalizedPath]
   }
-  return aliases
+  const normalizedWindowsPath = normalizeRuntimePathForComparison(windowsPath)
+  return normalizedPath === normalizedWindowsPath
+    ? [normalizedPath]
+    : [normalizedPath, normalizedWindowsPath]
 }
 
 export function wslAliasedPathDepth(pathValue: string): number {
   const canonicalPath =
-    parseWslUncPath(pathValue)?.linuxPath ?? wslMountPathFromWindowsDrive(pathValue) ?? pathValue
+    (mightBeWslUncPath(pathValue) ? parseWslUncPath(pathValue)?.linuxPath : null) ??
+    (mightBeWindowsDrivePath(pathValue) ? wslMountPathFromWindowsDrive(pathValue) : null) ??
+    pathValue
   return normalizeRuntimePathForComparison(canonicalPath).split('/').filter(Boolean).length
 }
 
 export function createWslAliasedPathInsideOrEqualMatcher(
   rootPath: string
 ): (normalizedCandidate: string) => boolean {
-  const matchers = wslRootPathAliases(rootPath).map(createNormalizedPathInsideOrEqualMatcher)
+  const aliases = wslRootPathAliases(rootPath)
+  if (aliases.length === 1) {
+    return createNormalizedPathInsideOrEqualMatcher(aliases[0])
+  }
+  const matchers = aliases.map(createNormalizedPathInsideOrEqualMatcher)
   return (normalizedCandidate) => matchers.some((ownsPath) => ownsPath(normalizedCandidate))
+}
+
+/** Precomputes every root spelling before matching a session/path fanout. */
+export function createWslAliasedPathInsideOrEqualScopeMatcher(
+  rootPaths: readonly string[]
+): (candidatePath: string) => boolean {
+  const rootMatchers = rootPaths.map(createWslAliasedPathInsideOrEqualMatcher)
+  return (candidatePath) => {
+    const candidateAliases = normalizedWslPathCandidateAliases(candidatePath)
+    if (candidateAliases.length === 1) {
+      return rootMatchers.some((ownsPath) => ownsPath(candidateAliases[0]))
+    }
+    return rootMatchers.some((ownsPath) => candidateAliases.some(ownsPath))
+  }
 }
 
 export function isWslAliasedPathInsideOrEqual(rootPath: string, candidatePath: string): boolean {
   const ownsPath = createWslAliasedPathInsideOrEqualMatcher(rootPath)
   return normalizedWslPathCandidateAliases(candidatePath).some(ownsPath)
-}
-
-function candidateWslPathAliases(pathValue: string): string[] {
-  const aliases = [pathValue]
-  const linuxPath = parseWslUncPath(pathValue)?.linuxPath ?? pathValue
-  const windowsPath = windowsDrivePathFromWslMount(linuxPath)
-  return windowsPath ? [...aliases, windowsPath] : aliases
 }
 
 function wslMountPathFromWindowsDrive(pathValue: string): string | null {
@@ -90,4 +111,12 @@ function windowsDrivePathFromWslMount(pathValue: string): string | null {
   }
   const rest = (match[2] ?? '').replace(/\//g, '\\')
   return `${match[1].toUpperCase()}:${rest || '\\'}`
+}
+
+function mightBeWindowsDrivePath(pathValue: string): boolean {
+  return pathValue.length >= 3 && pathValue.charCodeAt(1) === 58
+}
+
+function mightBeWslUncPath(pathValue: string): boolean {
+  return pathValue.startsWith('\\\\') || pathValue.startsWith('//')
 }

--- a/src/shared/wsl-path-aliases.ts
+++ b/src/shared/wsl-path-aliases.ts
@@ -1,0 +1,73 @@
+import {
+  createNormalizedPathInsideOrEqualMatcher,
+  normalizeRuntimePathForComparison
+} from './cross-platform-path'
+import { parseWslUncPath } from './wsl-paths'
+
+/**
+ * Spellings of one path that Windows and WSL both use for the same files.
+ *
+ * Claude in a WSL pane records `/mnt/c/...` even when Orca's worktree is `C:\...`.
+ * Distro-native repos already had the UNC → Linux alias; this adds the drvfs pair.
+ */
+export function wslPathAliases(pathValue: string): string[] {
+  const aliases: string[] = []
+  const seen = new Set<string>()
+  const add = (value: string) => {
+    if (!value || seen.has(value)) {
+      return
+    }
+    seen.add(value)
+    aliases.push(value)
+  }
+
+  add(pathValue)
+
+  const unc = parseWslUncPath(pathValue)
+  if (unc) {
+    add(unc.linuxPath)
+  }
+
+  const driveMatch = pathValue.match(/^([A-Za-z]):[/\\](.*)$/)
+  if (driveMatch) {
+    const rest = driveMatch[2].replace(/\\/g, '/')
+    add(`/mnt/${driveMatch[1].toLowerCase()}${rest ? `/${rest}` : ''}`)
+  }
+
+  for (const candidate of aliases) {
+    const mountMatch = candidate.match(/^\/mnt\/([a-zA-Z])(\/.*)?$/)
+    if (!mountMatch) {
+      continue
+    }
+    const rest = (mountMatch[2] || '').replace(/\//g, '\\')
+    add(`${mountMatch[1].toUpperCase()}:${rest || '\\'}`)
+  }
+
+  return aliases
+}
+
+export function normalizedWslPathAliases(pathValue: string): string[] {
+  const aliases: string[] = []
+  const seen = new Set<string>()
+  for (const alias of wslPathAliases(pathValue)) {
+    const normalized = normalizeRuntimePathForComparison(alias)
+    if (seen.has(normalized)) {
+      continue
+    }
+    seen.add(normalized)
+    aliases.push(normalized)
+  }
+  return aliases
+}
+
+export function createWslAliasedPathInsideOrEqualMatcher(
+  rootPath: string
+): (normalizedCandidate: string) => boolean {
+  const matchers = wslPathAliases(rootPath).map(createNormalizedPathInsideOrEqualMatcher)
+  return (normalizedCandidate) => matchers.some((ownsPath) => ownsPath(normalizedCandidate))
+}
+
+export function isWslAliasedPathInsideOrEqual(rootPath: string, candidatePath: string): boolean {
+  const ownsPath = createWslAliasedPathInsideOrEqualMatcher(rootPath)
+  return normalizedWslPathAliases(candidatePath).some(ownsPath)
+}

--- a/src/shared/wsl-path-aliases.ts
+++ b/src/shared/wsl-path-aliases.ts
@@ -5,15 +5,15 @@ import {
 import { parseWslUncPath } from './wsl-paths'
 
 /**
- * Spellings of one path that Windows and WSL both use for the same files.
+ * Root spellings that explicitly identify one Windows/WSL filesystem path.
  *
  * Claude in a WSL pane records `/mnt/c/...` even when Orca's worktree is `C:\...`.
- * Distro-native repos already had the UNC → Linux alias; this adds the drvfs pair.
+ * A raw `/mnt/c` root stays POSIX because its syntax alone does not prove WSL.
  */
-export function wslPathAliases(pathValue: string): string[] {
+export function wslRootPathAliases(pathValue: string): string[] {
   const aliases: string[] = []
   const seen = new Set<string>()
-  const add = (value: string) => {
+  const add = (value: string | null) => {
     if (!value || seen.has(value)) {
       return
     }
@@ -26,30 +26,19 @@ export function wslPathAliases(pathValue: string): string[] {
   const unc = parseWslUncPath(pathValue)
   if (unc) {
     add(unc.linuxPath)
+    add(windowsDrivePathFromWslMount(unc.linuxPath))
   }
 
-  const driveMatch = pathValue.match(/^([A-Za-z]):[/\\](.*)$/)
-  if (driveMatch) {
-    const rest = driveMatch[2].replace(/\\/g, '/')
-    add(`/mnt/${driveMatch[1].toLowerCase()}${rest ? `/${rest}` : ''}`)
-  }
-
-  for (const candidate of aliases) {
-    const mountMatch = candidate.match(/^\/mnt\/([a-zA-Z])(\/.*)?$/)
-    if (!mountMatch) {
-      continue
-    }
-    const rest = (mountMatch[2] || '').replace(/\//g, '\\')
-    add(`${mountMatch[1].toUpperCase()}:${rest || '\\'}`)
-  }
+  add(wslMountPathFromWindowsDrive(pathValue))
 
   return aliases
 }
 
-export function normalizedWslPathAliases(pathValue: string): string[] {
+/** Candidate spellings include a potential drive alias that only an explicit root can match. */
+export function normalizedWslPathCandidateAliases(pathValue: string): string[] {
   const aliases: string[] = []
   const seen = new Set<string>()
-  for (const alias of wslPathAliases(pathValue)) {
+  for (const alias of candidateWslPathAliases(pathValue)) {
     const normalized = normalizeRuntimePathForComparison(alias)
     if (seen.has(normalized)) {
       continue
@@ -60,14 +49,45 @@ export function normalizedWslPathAliases(pathValue: string): string[] {
   return aliases
 }
 
+export function wslAliasedPathDepth(pathValue: string): number {
+  const canonicalPath =
+    parseWslUncPath(pathValue)?.linuxPath ?? wslMountPathFromWindowsDrive(pathValue) ?? pathValue
+  return normalizeRuntimePathForComparison(canonicalPath).split('/').filter(Boolean).length
+}
+
 export function createWslAliasedPathInsideOrEqualMatcher(
   rootPath: string
 ): (normalizedCandidate: string) => boolean {
-  const matchers = wslPathAliases(rootPath).map(createNormalizedPathInsideOrEqualMatcher)
+  const matchers = wslRootPathAliases(rootPath).map(createNormalizedPathInsideOrEqualMatcher)
   return (normalizedCandidate) => matchers.some((ownsPath) => ownsPath(normalizedCandidate))
 }
 
 export function isWslAliasedPathInsideOrEqual(rootPath: string, candidatePath: string): boolean {
   const ownsPath = createWslAliasedPathInsideOrEqualMatcher(rootPath)
-  return normalizedWslPathAliases(candidatePath).some(ownsPath)
+  return normalizedWslPathCandidateAliases(candidatePath).some(ownsPath)
+}
+
+function candidateWslPathAliases(pathValue: string): string[] {
+  const aliases = [pathValue]
+  const linuxPath = parseWslUncPath(pathValue)?.linuxPath ?? pathValue
+  const windowsPath = windowsDrivePathFromWslMount(linuxPath)
+  return windowsPath ? [...aliases, windowsPath] : aliases
+}
+
+function wslMountPathFromWindowsDrive(pathValue: string): string | null {
+  const match = pathValue.match(/^([A-Za-z]):[/\\](.*)$/)
+  if (!match) {
+    return null
+  }
+  const rest = match[2].replace(/\\/g, '/')
+  return `/mnt/${match[1].toLowerCase()}${rest ? `/${rest}` : ''}`
+}
+
+function windowsDrivePathFromWslMount(pathValue: string): string | null {
+  const match = pathValue.match(/^\/mnt\/([a-zA-Z])(\/.*)?$/)
+  if (!match) {
+    return null
+  }
+  const rest = (match[2] ?? '').replace(/\//g, '\\')
+  return `${match[1].toUpperCase()}:${rest || '\\'}`
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​537 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​535 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​362 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​125 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​237 |

<!-- /orca-pr-loc -->

## ELI5

Claude running inside WSL writes its session files against a Linux path like `/mnt/c/Users/you/repo`. Orca on Windows thinks of that same folder as `C:\Users\you\repo`. Agent Session History only knew how to match the *other* WSL spelling (`\\wsl.localhost\...` → `/home/...`), so a live WSL Claude session in a Windows-drive repo never showed up on the Workspace tab.

## What Changed

- Added shared, root-aware path aliases: explicit Windows-drive and WSL UNC roots can match drvfs spellings, while raw POSIX `/mnt/<drive>` roots remain case-sensitive.
- Used it everywhere Agent Session History decides “does this session belong to this worktree”:
  - Workspace-tab filtering
  - Claude project-dir encoding + recency-cap bypass
  - cached-result scoped truncation
  - desktop and mobile session→worktree attribution
- Ranked matching worktrees by canonical path-segment depth so a longer alias spelling cannot make a parent beat a nested worktree.
- Unit tests cover WSL-shaped homes, `/mnt/c/...` cwd matching, nested worktree ranking, raw POSIX/SSH case sensitivity, distro identity, folder workspaces, and the recency-cap case.

## Why

**Root cause is workspace/path matching (`C:\` ↔ `/mnt/c`), not missing WSL home discovery.** `getAiVaultWslHomeDirs()` already feeds distro homes into the scanner; the live session in STA-4973 was invisible because Workspace filtering compared a Windows drive worktree path to a Linux `/mnt/c/...` cwd and they never compared equal.

**Before:** Orca on Windows, focused tab is a live WSL Claude session at `/mnt/c/Users/neil/orca/orca` (user typed `hi`, Claude answered). Agent Session History is on Workspace, “6 shown · 250 recent”, and lists only stale Windows-side rows (`1d ago` / `5d ago`). The live WSL session is absent. Left-sidebar pane status still shows `Claude Code - Idle`.

Claude project-dir encoding is a sibling of the same hole: `C:\Users\neil\orca\orca` encodes as `C--Users-neil-orca-orca`, while WSL Claude writes `-mnt-c-Users-neil-orca-orca`, so scoped discovery also missed those buckets past the recency cap.

## Linked Issue

Fixes https://linear.app/stably/issue/STA-4973/agent-session-discovery-not-working-in-wsl

## Visual Proof

**Before** — live WSL Claude session is missing from Workspace Agent Session History (stale Windows-side rows only):

![STA-4973-wsl-screenshot.png](https://github.com/user-attachments/assets/96d010da-2b03-48a4-81f8-3344fdd8a480)

**After** — validated in Windows+WSL dev mode: the live `/mnt/c` session and a case-folded fixture appeared in Workspace while the `-secret` sibling remained excluded.

![STA-4973 Workspace tab, live /mnt/c session visible, sibling -secret absent](https://github.com/user-attachments/assets/8888566c-6c3c-4c28-9de7-590fbc8171bb)

## Testing

- [x] Windows+WSL dev-mode QA validated the live session, case-folded path, and sibling-path exclusion
- [x] Automated tests added/updated, or explained why not below

Pre-fix FAIL / post-fix PASS / neutered FAIL was proven for the `/mnt/c` ↔ `C:\` matcher, Workspace filter, scoped Claude discovery, session-depth truncation, desktop worktree map, and mobile worktree match.

```
pnpm vitest run --config config/vitest.config.ts \
  src/shared/wsl-path-aliases.test.ts \
  src/shared/ai-vault-session-filters.test.ts \
  src/shared/ai-vault-session-depth.test.ts \
  src/main/ai-vault/session-scanner-scope.test.ts \
  src/renderer/src/components/right-sidebar/ai-vault-session-worktree-map.test.tsx \
  src/renderer/src/components/right-sidebar/ai-vault-session-filters.test.ts \
  src/main/ai-vault/claude-project-dir-encoding.test.ts

(cd mobile && ./node_modules/.bin/vitest run --config vitest.config.ts \
  src/agent-history/agent-history-session-worktree.test.ts)
```

## Review

Root-cause matching remains shared (`wslRootPathAliases` / `isWslAliasedPathInsideOrEqual`) rather than copied at call sites. Aliasing is directional: explicit Windows-drive and WSL UNC roots may claim drvfs candidates, while raw POSIX `/mnt/<drive>` roots stay POSIX and case-sensitive; candidate ranking uses alias-independent segment depth.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Related tickets checked, not expanded into this PR:

- STA-2259 / STA-4730 are pane-level WSL *agent detection* (Default Agent, process probe). The screenshot already shows pane status working (`Claude Code - Idle`). Different code path — this matcher does not explain them.
- STA-4617 (mobile session sync / `/resume`) can *benefit* once the host scan maps WSL `/mnt/c` sessions onto the workspace, but resume-target / mobile wire issues should stay their own tickets unless they reproduce as this same matcher.

SSH hosts keep POSIX path semantics, including case-sensitive raw `/mnt/<drive>` roots. Folder workspaces use the same matcher via worktree/folder paths.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
