### PR TITLE
feat(git): add OMP commit-message agent spec for Source Control AI

### DIFF
--- a/src/shared/commit-message-agent-spec.test.ts
+++ b/src/shared/commit-message-agent-spec.test.ts
@@ -510,6 +510,29 @@ describe('model discovery parsers', () => {
     ])
   })
 
+  it('drops non-string and whitespace-only OMP model fields instead of exposing them', () => {
+    const stdout = JSON.stringify({
+      models: [
+        { selector: 42, name: 'Numeric selector' },
+        { selector: 'openrouter/ok', name: true },
+        { selector: '   ', name: 'Blank selector' },
+        { selector: 'openrouter/blank-name', name: '\t\n' },
+        { selector: ' openrouter/trimmed ', name: ' Trimmed Name ' },
+        { selector: 'openrouter/think', name: 'Thinky', thinking: [1, '  ', 'low'] }
+      ]
+    })
+
+    expect(parseOmpModels(stdout)).toEqual([
+      { id: 'openrouter/trimmed', label: 'Trimmed Name' },
+      {
+        id: 'openrouter/think',
+        label: 'Thinky',
+        thinkingLevels: [{ id: 'low', label: 'Low' }],
+        defaultThinkingLevel: 'low'
+      }
+    ])
+  })
+
   it('returns no OMP models on malformed JSON so the seed stays', () => {
     expect(parseOmpModels('not json')).toEqual([])
     expect(parseOmpModels('{"models":[{"id":"no-selector"}]}')).toEqual([])
@@ -642,6 +665,7 @@ describe('buildArgs (OMP)', () => {
       '--no-tools',
       '--no-extensions',
       '--no-skills',
+      '--no-rules',
       '--mode',
       'text'
     ])

--- a/src/shared/commit-message-agent-spec.test.ts
+++ b/src/shared/commit-message-agent-spec.test.ts
@@ -16,6 +16,7 @@ import {
   parseCodexModels,
   parseCursorModels,
   parseLineModels,
+  parseOmpModels,
   parsePiModels,
   resolveCommitMessageAgentChoice
 } from './commit-message-agent-spec'
@@ -35,6 +36,7 @@ describe('COMMIT_MESSAGE_AGENT_SPECS', () => {
       'copilot',
       'cursor',
       'kimi',
+      'omp',
       'opencode',
       'pi'
     ])
@@ -473,6 +475,45 @@ describe('model discovery parsers', () => {
     expect(usedFullLineSplit).toBe(false)
     expect(usedWhitespaceFieldSplit).toBe(false)
   })
+  it('parses OMP models JSON into provider-qualified selector ids', () => {
+    const stdout = `${JSON.stringify({
+      models: [
+        {
+          provider: 'openrouter',
+          id: '~anthropic/claude-haiku-latest',
+          selector: 'openrouter/~anthropic/claude-haiku-latest',
+          name: 'Anthropic Claude Haiku Latest',
+          thinking: ['minimal', 'low', 'medium', 'high']
+        },
+        {
+          provider: 'openrouter',
+          id: '~deepseek/deepseek-v4-flash-latest',
+          selector: 'openrouter/~deepseek/deepseek-v4-flash-latest',
+          name: 'DeepSeek V4 Flash Latest'
+        }
+      ]
+    })}\n`
+
+    expect(parseOmpModels(stdout)).toEqual([
+      {
+        id: 'openrouter/~anthropic/claude-haiku-latest',
+        label: 'Anthropic Claude Haiku Latest',
+        thinkingLevels: [
+          { id: 'minimal', label: 'Minimal' },
+          { id: 'low', label: 'Low' },
+          { id: 'medium', label: 'Medium' },
+          { id: 'high', label: 'High' }
+        ],
+        defaultThinkingLevel: 'low'
+      },
+      { id: 'openrouter/~deepseek/deepseek-v4-flash-latest', label: 'DeepSeek V4 Flash Latest' }
+    ])
+  })
+
+  it('returns no OMP models on malformed JSON so the seed stays', () => {
+    expect(parseOmpModels('not json')).toEqual([])
+    expect(parseOmpModels('{"models":[{"id":"no-selector"}]}')).toEqual([])
+  })
 })
 
 describe('buildArgs (Codex)', () => {
@@ -585,5 +626,52 @@ describe('buildArgs (Antigravity)', () => {
 
   it('uses Gemini 3.5 Flash (Medium) as default model', () => {
     expect(COMMIT_MESSAGE_AGENT_SPECS.antigravity?.defaultModelId).toBe('Gemini 3.5 Flash (Medium)')
+  })
+})
+
+describe('buildArgs (OMP)', () => {
+  const spec = getCommitMessageAgentSpec('omp')!
+
+  it('runs `omp -p` in isolated text mode without passing the prompt via argv', () => {
+    const prompt = `PROMPT ${'x'.repeat(1024)}`
+    const args = spec.buildArgs({ prompt, model: 'default' })
+
+    expect(args).toEqual([
+      '-p',
+      '--no-session',
+      '--no-tools',
+      '--no-extensions',
+      '--no-skills',
+      '--mode',
+      'text'
+    ])
+    expect(args).not.toContain(prompt)
+    expect(spec.promptDelivery).toBe('stdin')
+  })
+
+  it('passes the provider-qualified selector to --model and thinking to --thinking', () => {
+    const args = spec.buildArgs({
+      prompt: 'PROMPT',
+      model: 'openrouter/~anthropic/claude-haiku-latest',
+      thinkingLevel: 'low'
+    })
+
+    expect(args).toContain('--model')
+    expect(args).toEqual(
+      expect.arrayContaining(['--model', 'openrouter/~anthropic/claude-haiku-latest', '--thinking', 'low'])
+    )
+  })
+
+  it('omits --model and --thinking when unset', () => {
+    const args = spec.buildArgs({ prompt: 'PROMPT', model: 'default' })
+
+    expect(args).not.toContain('--model')
+    expect(args).not.toContain('--thinking')
+  })
+
+  it('uses dynamic model discovery via `omp models --json`', () => {
+    expect(spec.modelSource).toBe('dynamic')
+    expect(spec.modelDiscovery?.binary).toBe('omp')
+    expect(spec.modelDiscovery?.args).toEqual(['models', '--json'])
   })
 })

--- a/src/shared/commit-message-agent-spec.ts
+++ b/src/shared/commit-message-agent-spec.ts
@@ -207,6 +207,53 @@ export function parseCodexModels(stdout: string): CommitMessageModel[] {
   }
 }
 
+export function parseOmpModels(stdout: string): CommitMessageModel[] {
+  try {
+    assertJsonTextStructureWithinLimits(stdout, COMMIT_MESSAGE_MODEL_JSON_STRUCTURE_LIMITS)
+    const parsed = JSON.parse(stdout) as {
+      models?: {
+        selector?: string
+        name?: string
+        thinking?: unknown
+      }[]
+    }
+    return uniqueModels(
+      (parsed.models ?? [])
+        .filter((model) => model.selector && model.name)
+        .map((model) => ({
+          id: model.selector!,
+          label: model.name!,
+          ...withOmpThinkingLevels(model.thinking)
+        }))
+    )
+  } catch {
+    return []
+  }
+}
+
+function withOmpThinkingLevels(
+  thinking: unknown
+): Pick<CommitMessageModel, 'thinkingLevels' | 'defaultThinkingLevel'> {
+  if (!Array.isArray(thinking)) {
+    return {}
+  }
+  const thinkingLevels = thinking
+    .filter((level): level is string => typeof level === 'string' && level.trim().length > 0)
+    .map((level) => ({
+      id: level,
+      label: level === 'xhigh' ? 'Extra High' : labelFromModelId(level)
+    }))
+  if (thinkingLevels.length === 0) {
+    return {}
+  }
+  return {
+    thinkingLevels,
+    defaultThinkingLevel: thinkingLevels.some((level) => level.id === 'low')
+      ? 'low'
+      : thinkingLevels[0].id
+  }
+}
+
 export function parseLineModels(stdout: string): CommitMessageModel[] {
   const models: CommitMessageModel[] = []
   for (const rawLine of iterateModelOutputLines(stdout)) {
@@ -516,6 +563,33 @@ export const COMMIT_MESSAGE_AGENT_SPECS: Partial<Record<TuiAgent, CommitMessageA
       }
     ],
     defaultModelId: 'github-copilot/gpt-5.4-mini'
+  },
+  omp: {
+    id: 'omp',
+    label: 'OMP',
+    binary: 'omp',
+    // Why: OMP is a Pi-family CLI; `omp -p` with no positional prompt reads
+    // stdin, so large diffs stay off argv.
+    promptDelivery: 'stdin',
+    buildArgs: ({ model, thinkingLevel }) => [
+      '-p',
+      '--no-session',
+      '--no-tools',
+      '--no-extensions',
+      '--no-skills',
+      '--mode',
+      'text',
+      // Why: omitting --model lets OMP run with its own configured default,
+      // so a fresh install works before any model is picked (Kimi precedent).
+      ...(model && model !== 'default' ? ['--model', model] : []),
+      ...(thinkingLevel ? ['--thinking', thinkingLevel] : [])
+    ],
+    modelSource: 'dynamic',
+    // Why: `omp models --json` emits provider-qualified selectors that OMP's
+    // fuzzy `--model` matcher accepts directly (`omp` has no --list-models).
+    modelDiscovery: { binary: 'omp', args: ['models', '--json'], parse: parseOmpModels },
+    models: [{ id: 'default', label: 'Config default' }],
+    defaultModelId: 'default'
   },
   amp: {
     id: 'amp',

--- a/src/shared/commit-message-agent-spec.ts
+++ b/src/shared/commit-message-agent-spec.ts
@@ -212,19 +212,21 @@ export function parseOmpModels(stdout: string): CommitMessageModel[] {
     assertJsonTextStructureWithinLimits(stdout, COMMIT_MESSAGE_MODEL_JSON_STRUCTURE_LIMITS)
     const parsed = JSON.parse(stdout) as {
       models?: {
-        selector?: string
-        name?: string
+        selector?: unknown
+        name?: unknown
         thinking?: unknown
       }[]
     }
     return uniqueModels(
       (parsed.models ?? [])
-        .filter((model) => model.selector && model.name)
         .map((model) => ({
-          id: model.selector!,
-          label: model.name!,
+          // Why: validate and trim before use — a truthy non-string or
+          // whitespace-only field must not become a selectable model id.
+          id: typeof model.selector === 'string' ? model.selector.trim() : '',
+          label: typeof model.name === 'string' ? model.name.trim() : '',
           ...withOmpThinkingLevels(model.thinking)
         }))
+        .filter((model) => model.id.length > 0 && model.label.length > 0)
     )
   } catch {
     return []
@@ -238,7 +240,8 @@ function withOmpThinkingLevels(
     return {}
   }
   const thinkingLevels = thinking
-    .filter((level): level is string => typeof level === 'string' && level.trim().length > 0)
+    .map((level) => (typeof level === 'string' ? level.trim() : ''))
+    .filter((level) => level.length > 0)
     .map((level) => ({
       id: level,
       label: level === 'xhigh' ? 'Extra High' : labelFromModelId(level)
@@ -577,6 +580,9 @@ export const COMMIT_MESSAGE_AGENT_SPECS: Partial<Record<TuiAgent, CommitMessageA
       '--no-tools',
       '--no-extensions',
       '--no-skills',
+      // Why: rules are workspace files the model would otherwise read and
+      // follow; keep the headless generation spawn free of workspace rules.
+      '--no-rules',
       '--mode',
       'text',
       // Why: omitting --model lets OMP run with its own configured default,

--- a/src/shared/source-control-ai-action-recipes.test.ts
+++ b/src/shared/source-control-ai-action-recipes.test.ts
@@ -82,6 +82,30 @@ describe('source-control AI action recipes', () => {
     expect(result.ok && result.value.params.model).toBe('gpt-5.5')
   })
 
+  it('resolves an omp default TUI agent now that OMP has a commit-message spec', () => {
+    // Why: before the omp spec existed, a null action recipe plus defaultTuiAgent
+    // 'omp' failed with "Choose a supported Source Control AI agent" (#14319).
+    const base = settings()
+    base.defaultTuiAgent = 'omp'
+    base.sourceControlAi = {
+      ...base.sourceControlAi!,
+      agentId: null,
+      actions: {
+        ...base.sourceControlAi!.actions,
+        branchName: { agentId: null, commandInputTemplate: '{basePrompt}' }
+      }
+    }
+
+    const result = resolveSourceControlAiForOperation({
+      settings: base,
+      repo: null,
+      operation: 'branchName',
+      discoveryHostKey: 'local'
+    })
+    expect(result.ok && result.value.params.agentId).toBe('omp')
+    expect(result.ok && result.value.params.model).toBe('default')
+  })
+
   it('treats a repo action null agent as the default agent, not the global action agent', () => {
     const base = settings()
     base.defaultTuiAgent = 'codex'
@@ -427,7 +451,7 @@ describe('source-control AI action recipes', () => {
     ).toEqual({
       ok: false,
       error:
-        'Agent "aider" does not support Source Control AI commit messages. Supported agents: Claude, Codex, OpenCode, Pi, Amp, Cursor, Kimi, GitHub Copilot, Antigravity, or Custom command.'
+        'Agent "aider" does not support Source Control AI commit messages. Supported agents: Claude, Codex, OpenCode, Pi, OMP, Amp, Cursor, Kimi, GitHub Copilot, Antigravity, or Custom command.'
     })
   })
 })


### PR DESCRIPTION
## ELI5

Orca can ask your AI coding agent to write commit messages and name branches, but only for agents it has a "recipe" for. OMP was already on Orca's agent list without a recipe, so OMP users got an error instead of AI-generated text. This adds the OMP recipe, plus the ability to list OMP's available models in the settings dropdown.

## What Changed

One new entry in `COMMIT_MESSAGE_AGENT_SPECS` (`src/shared/commit-message-agent-spec.ts`) and a new `parseOmpModels` discovery parser:

- **Invocation** (verified against omp v17.3.7): `omp -p --no-session --no-tools --no-extensions --no-skills --mode text`, prompt delivered on stdin — `omp -p` reads stdin when no positional prompt is given, keeping large diffs off argv (same contract as the existing `pi` spec; OMP is a Pi-family CLI).
- **Model selection**: `--model <selector>` omitted for the `default` seed model so a fresh install works before any model is picked (Kimi precedent, #11674). OMP's fuzzy `--model` matcher accepts the provider-qualified selectors (e.g. `openrouter/~anthropic/claude-haiku-latest`) emitted by discovery — verified end-to-end.
- **Model discovery**: `omp models --json` → `{models: [{selector, name, thinking[], …}]}`; `parseOmpModels` maps it to `CommitMessageModel[]` (thinking array → thinkingLevels). `--list-models` does not exist in omp; `models --json` is the real listing command. Output is ~150KB/466 models on the dev host — within `COMMIT_MESSAGE_MODEL_JSON_STRUCTURE_LIMITS` (structural tokens only, ~12k).
- `--thinking <level>` passed through when a thinking level is selected.
- The error string in `supportedSourceControlAiAgentSummary()` now includes OMP automatically; no hardcoded UI lists needed changes.

Tests: agent-ids list, `buildArgs (OMP)` block (argv isolation, selector+thinking, omission cases, discovery wiring), parser tests (happy path + malformed JSON → seed stays), and a resolution regression test (`defaultTuiAgent: 'omp'` + null action recipe now resolves to agent `omp` instead of the "Choose a supported…" error).

## Why

`omp` is a first-class `TuiAgent` (PTY launch, hooks, AI Vault session scanning) but had no `COMMIT_MESSAGE_AGENT_SPECS` entry. `resolveCommitMessageAgentChoice` returns `null` for a spec-less default TUI agent, so every user with `defaultTuiAgent: 'omp'` hits "Choose a supported Source Control AI agent…" on all Source Control AI operations, most visibly the first-work auto branch rename. A real spec makes omp runnable end-to-end; #5878 (fall back to claude when the default TUI agent has no spec) is an orthogonal mitigation that reroutes rather than runs omp.

## Linked Issue

Fixes stablyai/orca#15646

## Visual Proof

N/A — no new UI surface and no change to existing surfaces' layout. The only visual delta is one more entry ("OMP") in the Settings → Git → Source Control AI agent dropdown and the action-row agent Select, both populated dynamically from `listCommitMessageAgentCapabilities()`; there is no hardcoded list to screenshot.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Manual (macOS arm64, omp v17.3.7):
- `printf 'Reply with exactly: ok' | omp -p --no-session --no-tools --no-extensions --no-skills --mode text` → `ok` on stdout, exit 0, ~4s; same with `--model openrouter/~anthropic/claude-haiku-latest`.
- Earlier, the full real pipeline (resolve → `buildBranchNamePrompt` → `planCommitMessageGeneration` → spawn → `sanitizeBranchSlug`) was verified against the released app using a custom-command omp invocation: valid branch name in ~5-8s, well inside `GENERATION_TIMEOUT_MS`.

Automated:
- `pnpm test` — 56,752 passed / 4 failed (5 files). The 4 failures are pre-existing and unrelated: `pty-subprocess-env-inheritance` (3) and `shell-startup-feature-channel` (1) fail identically with this PR's changes reverted (verified by checking out `main`'s versions of the three touched files and re-running) — they test ORCA_HISTFILE/ZDOTDIR env handling and break when the suite itself runs inside an Orca terminal; `cross-version-terminal-wire.unit.test.ts` fails at collection level regardless. The new omp spec, buildArgs, parser, and resolution regression tests all pass. X-only-warning: repo pins node 24, host ran node 25.
- `pnpm typecheck` — clean.
- `pnpm lint` — clean (oxlint, code-quality audits, max-lines ratchet, localization gates).
- `pnpm build` — clean.

## AI Disclosure

Developed with an AI coding agent (oh-my-pi harness, GLM model via OpenRouter) under human direction; all CLI behaviors and flags cited above were verified against the real binaries on this machine.

## Review

- **Cross-platform**: spec spawns `omp` via argv with stdin pipe — no shell interpolation, no POSIX-only paths; flags are cross-platform CLI flags of the omp binary itself. Discovery uses `models --json`, identical on all platforms.
- **SSH/remote**: discovery and generation both spawn through the existing source-control-ai planning path, which already routes through `planAgentBinary`/host overrides; no new local-only assumptions.
- **Agent/integration compatibility**: change is additive — a new registry key; existing agents' specs untouched. Consumers of `listCommitMessageAgentCapabilities()` get OMP automatically.
- **Performance**: one extra entry in an in-memory registry; discovery only runs when the user opens OMP's model picker. `parseOmpModels` is O(n) over the JSON and structure-limit-checked before `JSON.parse`.
- **Security**: model discovery output is `assertJsonTextStructureWithinLimits`-checked before parsing (matches `parseCodexModels` posture); malformed JSON returns `[]` and the seed list stays. Generation and discovery both run with `--no-tools --no-extensions --no-skills`, so the headless invocation cannot execute project code.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Author

No X (Twitter) handle — please skip the merge shout-out.

## Notes

- `omp models --json` may include models from providers the user has no key for; that matches the Copilot spec's posture (pick what your account can use).
- Existing users who worked around this via a Custom command (`omp -p --no-session --no-tools --mode text`) can switch the action rows to "Use default agent" and delete the custom command.
- No platform-specific, remote/SSH-specific, or git-provider-specific behavior introduced.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
