### PR TITLE
fix(native-chat): retire chat echoes whose transcript row carries the TUI clear byte

### DIFF
--- a/mobile/src/session/mobile-native-chat-pending-echo.test.ts
+++ b/mobile/src/session/mobile-native-chat-pending-echo.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest'
+import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
+import {
+  countUserTextOccurrences,
+  normalizeReconcileText
+} from './mobile-native-chat-draft-reconcile'
+import {
+  appendMobileNativeChatPending,
+  type MobileNativeChatSendOrigin
+} from './mobile-native-chat-pending-echo'
+import { retireLandedMobileNativeChatPending } from './mobile-native-chat-pending-retirement'
+
+const NO_IMAGE_ECHOES: ReadonlySet<string> = new Set()
+
+/** A send captured against `messages`, exactly as `captureSendOrigin` builds it. */
+function sendOrigin(
+  text: string,
+  messages: readonly NativeChatMessage[]
+): MobileNativeChatSendOrigin {
+  const normalizedText = normalizeReconcileText(text)
+  return {
+    draftKey: 'host\0worktree\0tab',
+    pendingKey: 'host\0worktree\0tab\0session',
+    normalizedText,
+    // Use production's counter so the test cannot mirror its normalization drift.
+    baselineOccurrences: countUserTextOccurrences(messages, normalizedText),
+    baselineTailMessageId: messages.at(-1)?.id ?? null,
+    baselineResolved: true
+  }
+}
+
+function userTurn(id: string, text: string): NativeChatMessage {
+  return {
+    id,
+    role: 'user',
+    blocks: [{ type: 'text', text }],
+    timestamp: 1000,
+    source: 'transcript'
+  }
+}
+
+describe('appendMobileNativeChatPending ordinals for repeated sends', () => {
+  const KEY = 'host\0worktree\0tab\0session'
+  // Multi-line text distinguishes raw trim from reconciliation normalization.
+  const MULTILINE = 'first line of the prompt\nsecond line of the prompt'
+
+  it('gives a repeated multi-line send the next ordinal', () => {
+    const baseline = [userTurn('m1', 'unrelated')]
+    const first = appendMobileNativeChatPending(
+      {},
+      KEY,
+      'p1',
+      sendOrigin(MULTILINE, baseline),
+      MULTILINE
+    )
+    const both = appendMobileNativeChatPending(
+      first,
+      KEY,
+      'p2',
+      sendOrigin(MULTILINE, baseline),
+      MULTILINE
+    )
+
+    expect(both[KEY]?.map((item) => item.expectedOccurrence)).toEqual([1, 2])
+  })
+
+  it('retires only the first echo when the first of two identical rows lands', () => {
+    const baseline = [userTurn('m1', 'unrelated')]
+    const pending = appendMobileNativeChatPending(
+      appendMobileNativeChatPending({}, KEY, 'p1', sendOrigin(MULTILINE, baseline), MULTILINE),
+      KEY,
+      'p2',
+      sendOrigin(MULTILINE, baseline),
+      MULTILINE
+    )[KEY]!
+    const landedOnce = [...baseline, userTurn('m2', MULTILINE)]
+
+    expect(
+      retireLandedMobileNativeChatPending(landedOnce, pending, NO_IMAGE_ECHOES).map(
+        (item) => item.id
+      )
+    ).toEqual(['p2'])
+  })
+
+  it('still counts a single-line repeat, which never regressed', () => {
+    const baseline = [userTurn('m1', 'unrelated')]
+    const both = appendMobileNativeChatPending(
+      appendMobileNativeChatPending({}, KEY, 'p1', sendOrigin('ping', baseline), 'ping'),
+      KEY,
+      'p2',
+      sendOrigin('ping', baseline),
+      'ping'
+    )
+
+    expect(both[KEY]?.map((item) => item.expectedOccurrence)).toEqual([1, 2])
+  })
+})
+
+describe('mobile pending echoes whose text normalizes to nothing', () => {
+  const KEY = 'host\0worktree\0tab\0session'
+
+  // KNOWN GAP: marker-only rows render empty; suppressing their echo would hide the send.
+  it('cannot retire an echo whose row normalizes away', () => {
+    const stranded = [
+      {
+        id: 'p1',
+        text: '[Image #1]',
+        expectedOccurrence: 1,
+        baselineTailMessageId: 'm1',
+        baselineResolved: true
+      }
+    ]
+    const landed = [userTurn('m1', 'hi'), userTurn('m2', '[Image #1]')]
+
+    expect(retireLandedMobileNativeChatPending(landed, stranded, NO_IMAGE_ECHOES)).toEqual(stranded)
+  })
+
+  it('gives a caption-less photo its own ordinal after a marker-only caption', () => {
+    const first = appendMobileNativeChatPending(
+      {},
+      KEY,
+      'p1',
+      sendOrigin('[Image #1]', []),
+      '[Image #1]',
+      ['file:///a.jpg']
+    )
+    const both = appendMobileNativeChatPending(first, KEY, 'p2', sendOrigin('', []), '', [
+      'file:///b.jpg'
+    ])
+
+    expect(both[KEY]?.map((item) => item.expectedOccurrence)).toEqual([1, 2])
+  })
+
+  it('records an image echo, whose text is empty by design', () => {
+    const pending = appendMobileNativeChatPending({}, KEY, 'p1', sendOrigin('', []), '', [
+      'file:///photo.jpg'
+    ])
+
+    expect(pending[KEY]).toHaveLength(1)
+    expect(pending[KEY]?.[0]?.expectedOccurrence).toBe(1)
+  })
+})

--- a/mobile/src/session/mobile-native-chat-pending-echo.ts
+++ b/mobile/src/session/mobile-native-chat-pending-echo.ts
@@ -1,3 +1,5 @@
+import { normalizeReconcileText } from './mobile-native-chat-draft-reconcile'
+
 export type MobileNativeChatPendingMessage = {
   id: string
   text: string
@@ -43,13 +45,17 @@ export function appendMobileNativeChatPending(
   images?: string[]
 ): PendingByKey {
   const current = previous[key] ?? []
+  // Count outstanding repeats with the same normalized key.
   const earlierOutstanding = current.filter(
     (pending) =>
-      pending.text.trim() === origin.normalizedText &&
+      normalizeReconcileText(pending.text) === origin.normalizedText &&
       pending.expectedOccurrence > origin.baselineOccurrences
   ).length
+  // Image ordinal selection and counting must share the empty-text discriminator.
   const expectedImageEchoOrdinal =
-    current.filter((pending) => pending.text.trim() === '' && pending.images?.length).length + 1
+    current.filter(
+      (pending) => normalizeReconcileText(pending.text) === '' && pending.images?.length
+    ).length + 1
   return {
     ...previous,
     [key]: [

--- a/mobile/src/session/mobile-native-chat-pending-retirement.test.ts
+++ b/mobile/src/session/mobile-native-chat-pending-retirement.test.ts
@@ -321,3 +321,27 @@ describe('retireLandedMobileNativeChatPending', () => {
     expect(retireLandedMobileNativeChatPending(messages, pending, new Set(['p1']))).toEqual([])
   })
 })
+
+describe('retireLandedMobileNativeChatPending on a PTY-typed send', () => {
+  // A TUI may record the leading Ctrl+U transport byte as prompt content.
+  const COMPOSER_TEXT = 'run the focused tests\nand summarize failures'
+  const TRANSCRIPT_ROW = `\u0015${COMPOSER_TEXT}`
+
+  it('retires the echo of a row the TUI pasted the Ctrl+U byte into', () => {
+    const messages = [
+      assistantTurn('m1', 'ready', 1000),
+      userTurn('m2', TRANSCRIPT_ROW, 5000),
+      assistantTurn('m3', 'on it', 6000)
+    ]
+    const pending = [pendingSend('p1', COMPOSER_TEXT, 'm1')]
+
+    expect(retireLandedMobileNativeChatPending(messages, pending, NO_IMAGE_ECHOES)).toEqual([])
+  })
+
+  it('still holds the echo when no row carries the text at all', () => {
+    const messages = [assistantTurn('m1', 'ready', 1000)]
+    const pending = [pendingSend('p1', COMPOSER_TEXT, 'm1')]
+
+    expect(retireLandedMobileNativeChatPending(messages, pending, NO_IMAGE_ECHOES)).toEqual(pending)
+  })
+})

--- a/mobile/src/session/mobile-native-chat-send.test.ts
+++ b/mobile/src/session/mobile-native-chat-send.test.ts
@@ -176,7 +176,7 @@ describe('sendMobileNativeChatMessage', () => {
     ).resolves.toBe('rejected')
   })
 
-  it('prepends the input-line clear byte when clearInputFirst is set', async () => {
+  it('never bundles terminal controls into the submitted body', async () => {
     const client = clientWithResponse({
       id: 'request',
       ok: true,
@@ -187,14 +187,13 @@ describe('sendMobileNativeChatMessage', () => {
     await sendMobileNativeChatMessage({
       client,
       terminal: 'term',
-      text: 'hello',
-      clearInputFirst: true
+      text: 'hello'
     })
     expect(client.sendRequest).toHaveBeenCalledWith(
       'terminal.send',
       {
         terminal: 'term',
-        text: '\x15hello',
+        text: 'hello',
         enter: true
       },
       { timeoutMs: MOBILE_NATIVE_CHAT_SEND_TIMEOUT_MS, budgetSpansConnect: true }
@@ -214,8 +213,7 @@ describe('sendMobileNativeChatMessage', () => {
     await sendMobileNativeChatMessage({
       client,
       terminal: 'term',
-      text: 'what is this',
-      clearInputFirst: false
+      text: 'what is this'
     })
     const sent = vi.mocked(client.sendRequest).mock.calls[0]?.[1] as { text: string }
     expect(sent.text).toBe('what is this')
@@ -396,38 +394,5 @@ describe('clearMobileNativeChatInput', () => {
       })
     ).resolves.toBe(false)
     expect(client.sendRequest).not.toHaveBeenCalled()
-  })
-})
-
-describe('the body write never carries a multi-line burst', () => {
-  const accepted = {
-    id: 'request',
-    ok: true,
-    result: { send: { accepted: true } },
-    _meta: { runtimeId: 'runtime' }
-  }
-  const sentText = (client: RpcClient): string =>
-    (vi.mocked(client.sendRequest).mock.calls[0]![1] as { text: string }).text
-
-  it('still prefixes only a single Ctrl+U when asked to clear first', async () => {
-    const client = clientWithResponse(accepted)
-    await sendMobileNativeChatMessage({
-      client,
-      terminal: 'term',
-      text: 'hello',
-      clearInputFirst: true
-    })
-    expect(sentText(client)).toBe('\x15hello')
-  })
-
-  it('never prefixes a clear when the caller already pasted (image sends)', async () => {
-    const client = clientWithResponse(accepted)
-    await sendMobileNativeChatMessage({
-      client,
-      terminal: 'term',
-      text: 'caption',
-      clearInputFirst: false
-    })
-    expect(sentText(client)).toBe('caption')
   })
 })

--- a/mobile/src/session/mobile-native-chat-send.ts
+++ b/mobile/src/session/mobile-native-chat-send.ts
@@ -9,22 +9,11 @@ type MobileTerminalClient = {
   type: 'mobile'
 }
 
-// Why: Ctrl+U kills the TUI's current input line (desktop native chat sends the
-// same byte before its body), so a launch-context prefill parked there cannot
-// concatenate with a mobile chat message. The host writes text bytes verbatim.
-//
-// One Ctrl+U clears ONE logical line, which is all this prefix can do. A parked
-// launch draft is routinely multi-line (every Linear block is); callers that know
-// one is parked must call clearMobileNativeChatInput FIRST — see
-// src/shared/agent-tui-input-clear.ts for the measured 2N-1 law.
-const CLEAR_UNSUBMITTED_INPUT = '\x15'
-
 type MobileNativeChatSendArgs = {
   client: RpcClient
   terminal: string
   text: string
   enter?: boolean
-  clearInputFirst?: boolean
   /** Exact host launch draft this submitting write resolves when accepted. */
   resolvedLaunchDraft?: { text: string; createdAt: number }
   mobileClient?: MobileTerminalClient
@@ -65,7 +54,7 @@ export async function sendMobileNativeChatMessageWithOutcome(
       'terminal.send',
       {
         terminal: args.terminal,
-        text: args.clearInputFirst ? `${CLEAR_UNSUBMITTED_INPUT}${args.text}` : args.text,
+        text: args.text,
         enter: args.enter ?? true,
         ...(args.resolvedLaunchDraft ? { resolvedLaunchDraft: args.resolvedLaunchDraft } : {}),
         ...(args.mobileClient ? { client: args.mobileClient } : {})

--- a/mobile/src/session/use-mobile-native-chat-controller.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-controller.test.ts
@@ -129,6 +129,12 @@ describe('useMobileNativeChatController handleNativeChatSend', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    clientStub.sendRequest.mockResolvedValue({
+      id: 'send',
+      ok: true,
+      result: { send: { accepted: true } },
+      _meta: { runtimeId: 'r' }
+    })
     resetMobileNativeChatStaleInputForTests()
     captureSendOrigin.mockReturnValue(ORIGIN)
     act(() => {
@@ -157,12 +163,10 @@ describe('useMobileNativeChatController handleNativeChatSend', () => {
       accepted = await controller!.handleNativeChatSend('answer')
     })
     expect(accepted).toBe(true)
-    expect(clientStub.sendRequest).toHaveBeenCalledTimes(1)
-    expect(clientStub.sendRequest.mock.calls[0]?.[1]).toMatchObject({
-      terminal: 'term-1',
-      text: '\x15',
-      enter: false
-    })
+    expect(clientStub.sendRequest).toHaveBeenCalledTimes(2)
+    for (const call of clientStub.sendRequest.mock.calls) {
+      expect(call[1]).toMatchObject({ terminal: 'term-1', text: '\x15', enter: false })
+    }
     expect(isMobileNativeChatInputStale('term-1')).toBe(false)
   })
 
@@ -228,7 +232,7 @@ describe('useMobileNativeChatController handleNativeChatSend', () => {
     expect(restoreRejectedDraft).not.toHaveBeenCalled()
   })
 
-  it('pre-clears the input line for a text-only send but never for an image send', async () => {
+  it('pre-clears separately for a text-only send but never for an image send', async () => {
     // The image path pastes the image behind its OWN leading Ctrl+U and then calls
     // this send; a second clear here wipes the image off the input line and the
     // agent receives text alone while the echo bubble still shows the thumbnail.
@@ -237,16 +241,23 @@ describe('useMobileNativeChatController handleNativeChatSend', () => {
     await act(async () => {
       await controller!.handleNativeChatSend('answer')
     })
-    expect(sendWithOutcome).toHaveBeenLastCalledWith(
-      expect.objectContaining({ text: 'answer', clearInputFirst: true })
+    expect(clientStub.sendRequest).toHaveBeenCalledWith(
+      'terminal.send',
+      expect.objectContaining({ text: '\x15', enter: false }),
+      expect.any(Object)
     )
+    expect(sendWithOutcome).toHaveBeenLastCalledWith(
+      expect.not.objectContaining({ clearInputFirst: expect.anything() })
+    )
+
+    clientStub.sendRequest.mockClear()
 
     await act(async () => {
       await controller!.handleNativeChatSend('look', ['file:///a.jpg'])
     })
-    expect(sendWithOutcome).toHaveBeenLastCalledWith(
-      expect.objectContaining({ text: 'look', clearInputFirst: false })
-    )
+    expect(clientStub.sendRequest).not.toHaveBeenCalled()
+    expect(sendWithOutcome).toHaveBeenLastCalledWith(expect.objectContaining({ text: 'look' }))
+    expect(sendWithOutcome.mock.calls.at(-1)?.[0]).not.toHaveProperty('clearInputFirst')
   })
 
   it('holds an unknown-outcome send without posting the optimistic echo', async () => {

--- a/mobile/src/session/use-mobile-native-chat-message-send.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-message-send.test.ts
@@ -77,12 +77,10 @@ describe('useMobileNativeChatMessageSend', () => {
 
   const sentArgs = (): {
     text?: string
-    clearInputFirst?: boolean
     resolvedLaunchDraft?: { text: string; createdAt: number }
   } =>
     sendWithOutcome.mock.calls[0]![0] as {
       text?: string
-      clearInputFirst?: boolean
       resolvedLaunchDraft?: { text: string; createdAt: number }
     }
   const clearArgs = (): { clearInput?: string } =>
@@ -146,32 +144,36 @@ describe('useMobileNativeChatMessageSend', () => {
     expect(sendWithOutcome).not.toHaveBeenCalled()
   })
 
-  it('drops the body write\u2019s own Ctrl+U prefix once the dedicated clear ran', async () => {
+  it('keeps the body write free of the dedicated terminal control', async () => {
     // A Ctrl+U written immediately before body text in the SAME write arrives as
     // a literal control character, so it would head the received message.
     mount(() => ({ text: DRAFT, createdAt: 1 }))
     await act(async () => {
       await api!.send('hello')
     })
-    expect(sentArgs().clearInputFirst).toBe(false)
+    expect(sentArgs()).not.toHaveProperty('clearInputFirst')
     expect(sentArgs().resolvedLaunchDraft).toEqual({ text: DRAFT, createdAt: 1 })
   })
 
-  it('keeps the single-Ctrl+U prefix when no dedicated clear ran', async () => {
+  it('writes a single Ctrl+U separately when no launch draft is parked', async () => {
     mount(() => null)
     await act(async () => {
       await api!.send('hello')
     })
-    expect(sentArgs().clearInputFirst).toBe(true)
+    expect(clearArgs().clearInput).toBe('\x15')
+    expect(sentArgs()).not.toHaveProperty('clearInputFirst')
     expect(sentArgs().resolvedLaunchDraft).toBeUndefined()
   })
 
-  it('writes no clear at all when nothing is parked on the line', async () => {
+  it('writes the ordinary clear before the body', async () => {
     mount(() => null)
     await act(async () => {
       await api!.send('hello')
     })
-    expect(clearInputWrite).not.toHaveBeenCalled()
+    expect(clearInputWrite).toHaveBeenCalledTimes(1)
+    expect(clearInputWrite.mock.invocationCallOrder[0]).toBeLessThan(
+      sendWithOutcome.mock.invocationCallOrder[0]!
+    )
   })
 
   it('reads the draft at send time, so a retired seed stops widening the clear', async () => {
@@ -184,9 +186,11 @@ describe('useMobileNativeChatMessageSend', () => {
     await act(async () => {
       await api!.send('second')
     })
-    expect(sendWithOutcome.mock.calls[1]![0]).toMatchObject({ clearInputFirst: true })
-    expect(clearInputWrite).toHaveBeenCalledTimes(1)
-    expect(sendWithOutcome.mock.calls[0]![0]).toMatchObject({ clearInputFirst: false })
+    expect(clearInputWrite).toHaveBeenCalledTimes(2)
+    expect(clearInputWrite.mock.calls[0]![0]).toMatchObject({
+      clearInput: buildAgentTuiClearInputForText(DRAFT)
+    })
+    expect(clearInputWrite.mock.calls[1]![0]).toMatchObject({ clearInput: '\x15' })
   })
 
   it('does not clear an image send after the image was pasted', async () => {
@@ -196,7 +200,7 @@ describe('useMobileNativeChatMessageSend', () => {
       await api!.send('caption', ['file:///a.png'])
     })
     expect(clearInputWrite).not.toHaveBeenCalled()
-    expect(sentArgs().clearInputFirst).toBe(false)
+    expect(sentArgs()).not.toHaveProperty('clearInputFirst')
     expect(sentArgs().resolvedLaunchDraft).toEqual({ text: DRAFT, createdAt: 1 })
   })
 

--- a/mobile/src/session/use-mobile-native-chat-message-send.ts
+++ b/mobile/src/session/use-mobile-native-chat-message-send.ts
@@ -17,7 +17,10 @@ import {
 } from './mobile-native-chat-terminal-write-lock'
 import type { MobileNativeChatSendOrigin } from './use-mobile-native-chat-drafts'
 import type { MobileNativeChatLaunchDraftSeed } from './use-mobile-native-chat-launch-draft-seed'
-import { buildAgentTuiClearInputForText } from '../../../src/shared/agent-tui-input-clear'
+import {
+  AGENT_TUI_CLEAR_INPUT_LINE,
+  buildAgentTuiClearInputForText
+} from '../../../src/shared/agent-tui-input-clear'
 
 export type MobileNativeChatMessageSend = {
   /** Composer send that syncs the draft (clear on send, restore on rejection). */
@@ -131,23 +134,22 @@ export function useMobileNativeChatMessageSend(args: {
       if (syncComposer) {
         clearDraftForSend(origin, draftText)
       }
-      // Why: a parked launch draft is routinely multi-line, and one Ctrl+U clears
-      // only one logical line. Size the clear to the text Orca injected, with
-      // slack — the user can also have typed into the TUI line directly, so that
-      // line count is a lower bound. Mobile cannot read the agent's screen, so
-      // there is no empty-line observable to confirm against here; the upper
-      // bound plus the host's write acceptance is what makes it safe.
-      //
-      // The burst goes out as its OWN write: bundled into the body write it
-      // arrived as literal Ctrl+U text and the draft concatenated (see
-      // clearMobileNativeChatInput). A rejected clear aborts the send rather
-      // than pasting on top of an uncleared line.
       const seededLaunchDraft = readSeededLaunchDraftSeed()
-      if (seededLaunchDraft && !images?.length) {
+      const classification = classifyMobileNativeChatSend(agent, text)
+      const typesCodexCommand =
+        agent === 'codex' &&
+        classification !== 'chat' &&
+        isSlashCommandDraft(text) &&
+        !images?.length
+      // Keep terminal controls in their own write. When bundled with the body,
+      // a pasted burst can become literal prompt text instead of editing input.
+      if (!images?.length && (seededLaunchDraft || !typesCodexCommand)) {
         const cleared = await clearMobileNativeChatInput({
           client,
           terminal: handle,
-          clearInput: buildAgentTuiClearInputForText(seededLaunchDraft.text),
+          clearInput: seededLaunchDraft
+            ? buildAgentTuiClearInputForText(seededLaunchDraft.text)
+            : AGENT_TUI_CLEAR_INPUT_LINE,
           deadline,
           ...(deviceTokenRef.current
             ? { mobileClient: { id: deviceTokenRef.current, type: 'mobile' } }
@@ -161,7 +163,6 @@ export function useMobileNativeChatMessageSend(args: {
           return 'rejected'
         }
       }
-      const classification = classifyMobileNativeChatSend(agent, text)
       const mobileClient = deviceTokenRef.current
         ? { id: deviceTokenRef.current, type: 'mobile' as const }
         : undefined
@@ -169,30 +170,23 @@ export function useMobileNativeChatMessageSend(args: {
         syncComposer && typeof seededLaunchDraft?.createdAt === 'number'
           ? { text: seededLaunchDraft.text, createdAt: seededLaunchDraft.createdAt }
           : undefined
-      const outcome =
-        agent === 'codex' &&
-        classification !== 'chat' &&
-        isSlashCommandDraft(text) &&
-        !images?.length
-          ? await typeMobileNativeChatCommandWithOutcome({
-              client,
-              terminal: handle,
-              command: text,
-              ...(resolvedLaunchDraft ? { resolvedLaunchDraft } : {}),
-              ...(mobileClient ? { mobileClient } : {}),
-              deadline
-            })
-          : await sendMobileNativeChatMessageWithOutcome({
-              client,
-              terminal: handle,
-              text,
-              // Why: an image send already cleared before its paste; a second
-              // clear here would wipe the image before submission.
-              clearInputFirst: !images?.length && !seededLaunchDraft,
-              ...(resolvedLaunchDraft ? { resolvedLaunchDraft } : {}),
-              deadline,
-              ...(mobileClient ? { mobileClient } : {})
-            })
+      const outcome = typesCodexCommand
+        ? await typeMobileNativeChatCommandWithOutcome({
+            client,
+            terminal: handle,
+            command: text,
+            ...(resolvedLaunchDraft ? { resolvedLaunchDraft } : {}),
+            ...(mobileClient ? { mobileClient } : {}),
+            deadline
+          })
+        : await sendMobileNativeChatMessageWithOutcome({
+            client,
+            terminal: handle,
+            text,
+            ...(resolvedLaunchDraft ? { resolvedLaunchDraft } : {}),
+            deadline,
+            ...(mobileClient ? { mobileClient } : {})
+          })
       // Why (desktop parity): a slash/skill send dispatches into the agent's own
       // TUI, not the conversation — the transcript never echoes it as a user
       // turn, so an optimistic bubble would never reconcile and the

--- a/src/main/native-chat/transcript-line-decoders-claude-control-bytes.test.ts
+++ b/src/main/native-chat/transcript-line-decoders-claude-control-bytes.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import {
+  normalizeNativeChatUserText,
+  normalizedNativeChatUserMessageText
+} from '../../shared/native-chat-image-transcript-markers'
+import { decodeClaudeTranscriptLine } from './transcript-line-decoders-claude'
+
+const COMPOSER_TEXT = 'line 000 xxxxxxxxxx\nline 001 xxxxxxxxxx\nline 002 xxxxxxxxxx'
+
+// Matches the string-content shape observed when a TUI records Ctrl+U with the prompt.
+const MOBILE_SEND_LINE = JSON.stringify({
+  type: 'user',
+  uuid: 'synthetic-user-turn',
+  message: { role: 'user', content: `\u0015${COMPOSER_TEXT}` }
+})
+
+describe('decodeClaudeTranscriptLine on a mobile-sent prompt', () => {
+  it('keeps the Ctrl+U byte the TUI pasted into the prompt', () => {
+    const message = decodeClaudeTranscriptLine(MOBILE_SEND_LINE, 'fallback')
+    expect(message?.role).toBe('user')
+    expect(message?.blocks[0]).toEqual({
+      type: 'text',
+      text: `\u0015${COMPOSER_TEXT}`
+    })
+  })
+
+  it('normalizes to the composer text so the optimistic echo can retire', () => {
+    const message = decodeClaudeTranscriptLine(MOBILE_SEND_LINE, 'fallback')!
+    expect(normalizedNativeChatUserMessageText(message)).toBe(
+      normalizeNativeChatUserText(COMPOSER_TEXT)
+    )
+  })
+})

--- a/src/renderer/src/components/native-chat/native-chat-pending-occurrence.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending-occurrence.test.ts
@@ -94,3 +94,26 @@ describe('countLeadingPendingTextsGluedToUserText', () => {
     expect(countLeadingPendingTextsGluedToUserText(['a', '', 'b'], 'ab')).toBe(0)
   })
 })
+
+describe('pending sends typed through an agent TUI', () => {
+  beforeEach(() => clearPendingSendCacheForTests())
+
+  // A transcript row carrying the clear byte must match the body-only echo.
+  const COMPOSER_TEXT = 'summarize the failing test and propose a fix'
+
+  it('prunes the echo of a row carrying the clear byte', () => {
+    const pending = appendPendingSendCache(scope, {
+      id: 'p1',
+      text: COMPOSER_TEXT,
+      sentAt: 100,
+      afterMessageId: 'boundary'
+    })
+    const transcript = [
+      message('u1', 'user', `\u0015${COMPOSER_TEXT}`, 150),
+      message('a1', 'assistant', 'done', 160)
+    ]
+
+    expect(prunePendingSends(pending, transcript)).toEqual([])
+    expect(pendingSendsAsMessages(pending, transcript)).toEqual([])
+  })
+})

--- a/src/shared/native-chat-image-transcript-markers.test.ts
+++ b/src/shared/native-chat-image-transcript-markers.test.ts
@@ -211,3 +211,32 @@ describe('normalizeImageTranscriptMessages', () => {
     expect(normalizeImageTranscriptMessages([assistant])).toEqual([assistant])
   })
 })
+
+describe('normalizeNativeChatUserText control bytes', () => {
+  it('drops the Ctrl+U a TUI pasted in front of the prompt', () => {
+    expect(normalizeNativeChatUserText('\u0015run the tests')).toBe('run the tests')
+  })
+
+  it('drops control bytes that landed inside the prompt', () => {
+    expect(normalizeNativeChatUserText('run\u0015 the\u0000 tests')).toBe('run the tests')
+  })
+
+  it('still finds the image marker behind a leading control byte', () => {
+    expect(normalizeNativeChatUserText('\u0015[Image #1] describe this')).toBe('describe this')
+  })
+
+  // Remove a bracketed-paste wrapper as one sequence so its printable tail cannot survive.
+  it('drops a bracketed-paste wrapper, not just its ESC introducer', () => {
+    expect(normalizeNativeChatUserText('\u001b[200~/tmp/orca-paste-1.png\u001b[201~')).toBe(
+      '/tmp/orca-paste-1.png'
+    )
+  })
+
+  it('preserves bracketed-paste-looking text without an ESC introducer', () => {
+    expect(normalizeNativeChatUserText('[200~literal[201~')).toBe('[200~literal[201~')
+  })
+
+  it('leaves tabs, newlines and carriage returns to the whitespace collapse', () => {
+    expect(normalizeNativeChatUserText('run\tthe\r\ntests')).toBe('run the tests')
+  })
+})

--- a/src/shared/native-chat-image-transcript-markers.ts
+++ b/src/shared/native-chat-image-transcript-markers.ts
@@ -1,3 +1,7 @@
+import {
+  stripAnsiEscapeSequences,
+  TERMINAL_CONTROL_CHARACTER_PATTERN
+} from './ansi-escape-sequences'
 import { isTextBlock, type NativeChatBlock, type NativeChatMessage } from './native-chat-types'
 
 const IMAGE_SOURCE_MARKER = /^\[Image:\s*source:\s*(.+?)\]\s*$/
@@ -36,8 +40,14 @@ export function stripImagePromptMarker(text: string): string {
   return result
 }
 
+/** Normalizes PTY-backed user text into the pending-echo comparison key. */
 export function normalizeNativeChatUserText(text: string): string {
-  return stripImagePromptMarker(text).trim().replace(/\s+/g, ' ')
+  // Strip sequences first so their printable tails cannot survive a lone-control pass.
+  return stripImagePromptMarker(
+    stripAnsiEscapeSequences(text).replace(TERMINAL_CONTROL_CHARACTER_PATTERN, '')
+  )
+    .trim()
+    .replace(/\s+/g, ' ')
 }
 
 export function normalizedNativeChatUserMessageText(message: NativeChatMessage): string | null {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​293 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​62 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​231 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​53 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​54 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 |

<!-- /orca-pr-loc -->

## ELI5

Mobile chat showed a message immediately, then failed to retire that temporary bubble when the real transcript row arrived. The terminal clear command could be recorded as part of the prompt, so the two copies no longer compared equal.

## What changed

- Send the terminal input clear as its own acknowledged, non-submitting write before the prompt body. Terminal editing controls never become submitted prompt content.
- Keep the clear and body ordered under the existing terminal write lock and one shared 15-second action budget. A definite clear rejection aborts the body; an ambiguous body outcome keeps the existing transcript-confirmation behavior.
- Normalize ANSI/control transport bytes while reconciling legacy transcript rows already written in the malformed shape.
- Use the same normalized text on both sides of repeated text and image echo occurrence counting.
- Cover the observed decoder shape with a fully synthetic fixture.

Image sends keep their existing paste flow, which already clears separately. Codex command typing keeps its per-key terminal-control path.

## Reliability contract

- **Invariant:** terminal editing controls never become submitted prompt content, and every optimistic echo retires exactly once when its corresponding transcript occurrence lands.
- **Failure source:** bundling Ctrl+U with the body allowed the TUI to treat the clear byte as literal prompt content, so transcript reconciliation could not match it.
- **Oracle:** tests prove clear/body writes are separate and ordered, a rejected clear prevents the body write, legacy malformed rows still reconcile, and repeated normalized messages receive distinct occurrence ordinals.
- **Gate:** there is no exact existing reliability-matrix gate for this mobile multi-write path; that coverage gap is accepted and recorded here.
- **Budget:** text sends add one bounded sequential RPC inside the existing shared 15-second deadline. No polling, retries, listeners, timers, subprocesses, or unbounded state were added.

## Compatibility

The change reuses the existing optional `terminal.send` request shape; it adds no RPC field, stream opcode, persisted value, route, or protocol-version requirement. Local, daemon, SSH, WSL, and relay execution keep the same host routing, and the behavior is provider-neutral across supported agents. Older hosts already accept the standalone non-submitting terminal write.

## Privacy

The test fixture contains synthetic identifiers and prompt text only. The PR branch was rewritten to a single commit so an earlier captured fixture is no longer retained in branch history.

## Known remaining gap

A literal prompt consisting only of image-marker text still has a pre-existing reconciliation hole because normalization intentionally removes the entire value. The regression test documents it; changing that render/retirement contract is outside this focused fix.

## Testing

- Mobile focused suites: 5 files, 109 tests passed
- Root focused suites: 3 files, 42 tests passed
- Mobile `tsc --noEmit`
- Focused `oxlint` and `oxfmt --check`
- `git diff --check`

## Visual proof

[Native iOS QA passed](https://github.com/stablyai/orca/pull/15656#issuecomment-5388411511) on an iPhone 17 Pro Max simulator: the text-only prompt reconciled to exactly one bubble with no visible control byte.

## Linked issue

Reported by @BrennanKB5 on 2026-08-20.