### PR TITLE
fix(native-chat): adopt only the real user replay as a Claude send's identity

### DIFF
--- a/src/main/claude/claude-owned-turn-lifecycle.ts
+++ b/src/main/claude/claude-owned-turn-lifecycle.ts
@@ -1,0 +1,82 @@
+export type ClaudeOwnedTurnLifecycle = {
+  register: (sessionId: string, turnId: string, sequence: number) => void
+  confirm: (turnId: string) => void
+  settle: (turnId: string) => void
+  end: () => void
+  dispose: () => void
+}
+
+type OwnedTurn = {
+  sessionId: string
+  turnId: string
+  sequence: number
+  state: 'provisional' | 'confirmed' | 'abandoned' | 'settled'
+}
+
+export function createClaudeOwnedTurnLifecycle(
+  publish: (sessionId: string, turnId: string, running: boolean) => void
+): ClaudeOwnedTurnLifecycle & { abandon: (turnId: string) => void } {
+  const turns = new Map<string, OwnedTurn>()
+  let terminal = false
+
+  const settle = (turnId: string): void => {
+    const turn = turns.get(turnId)
+    if (!turn || turn.state === 'settled') {
+      return
+    }
+    const published = turn.state === 'confirmed'
+    turn.state = 'settled'
+    if (published) {
+      publish(turn.sessionId, turn.turnId, false)
+    }
+  }
+
+  return {
+    register: (sessionId, turnId, sequence) => {
+      if (!terminal && !turns.has(turnId)) {
+        turns.set(turnId, { sessionId, turnId, sequence, state: 'provisional' })
+      }
+    },
+    confirm: (turnId) => {
+      if (terminal) {
+        return
+      }
+      const turn = turns.get(turnId)
+      if (!turn || turn.state === 'confirmed' || turn.state === 'settled') {
+        return
+      }
+      turn.state = 'confirmed'
+      publish(turn.sessionId, turn.turnId, true)
+    },
+    settle: (turnId) => {
+      if (!terminal) {
+        settle(turnId)
+      }
+    },
+    abandon: (turnId) => {
+      if (terminal) {
+        return
+      }
+      const turn = turns.get(turnId)
+      if (turn?.state === 'provisional') {
+        turn.state = 'abandoned'
+      }
+    },
+    end: () => {
+      if (terminal) {
+        return
+      }
+      for (const turn of turns.values()) {
+        if (turn.state === 'confirmed') {
+          publish(turn.sessionId, turn.turnId, false)
+        }
+        turn.state = 'settled'
+      }
+      terminal = true
+    },
+    dispose: () => {
+      terminal = true
+      turns.clear()
+    }
+  }
+}

--- a/src/main/claude/claude-owned-turn-receipts.ts
+++ b/src/main/claude/claude-owned-turn-receipts.ts
@@ -1,0 +1,97 @@
+import { readClaudeFrameString } from './claude-structured-init-proof'
+import type { ClaudeSession } from './claude-structured-session-state'
+
+const NONTERMINAL_COMMAND_STATES = new Set(['queued', 'started'])
+const TERMINAL_COMMAND_STATES = new Set(['completed', 'cancelled', 'discarded'])
+
+export class ClaudeRetiredSentUserUuids {
+  private readonly bySession = new Map<string, Set<string>>()
+
+  has(sessionId: string, uuid: string): boolean {
+    return this.bySession.get(sessionId)?.has(uuid) === true
+  }
+
+  retire(sessionId: string, session: ClaudeSession): void {
+    if (session.sentUserUuidSequence.size === 0) {
+      return
+    }
+    const retired = this.bySession.get(sessionId) ?? new Set<string>()
+    for (const uuid of session.sentUserUuidSequence.keys()) {
+      retired.add(uuid)
+    }
+    this.bySession.set(sessionId, retired)
+  }
+}
+
+function ownedClaudeUserTurnSequence(
+  session: ClaudeSession,
+  message: Record<string, unknown>,
+  uuid: string | null
+): number | undefined {
+  if (
+    !uuid ||
+    message.type !== 'user' ||
+    message.parent_tool_use_id !== null ||
+    readClaudeFrameString(message, 'session_id') !== session.providerSessionId
+  ) {
+    return undefined
+  }
+  return session.sentUserUuidSequence.get(uuid)
+}
+
+function handleClaudeOwnedReceipt(session: ClaudeSession, message: Record<string, unknown>): void {
+  if (readClaudeFrameString(message, 'session_id') !== session.providerSessionId) {
+    return
+  }
+  if (message.type === 'command_lifecycle') {
+    const turnId = readClaudeFrameString(message, 'command_uuid')
+    const state = readClaudeFrameString(message, 'state')
+    if (!turnId || !state || !session.sentUserUuidSequence.has(turnId)) {
+      return
+    }
+    if (NONTERMINAL_COMMAND_STATES.has(state)) {
+      session.deliveryEvidenceUuids.add(turnId)
+      session.translator?.confirmOwnedTurn(turnId)
+    } else if (TERMINAL_COMMAND_STATES.has(state)) {
+      session.deliveryEvidenceUuids.add(turnId)
+      session.translator?.settleOwnedTurn(turnId)
+    }
+    return
+  }
+  if (message.type !== 'result') {
+    return
+  }
+  const turnId = readClaudeFrameString(message, 'user_message_uuid')
+  if (!turnId || !session.sentUserUuidSequence.has(turnId)) {
+    return
+  }
+  session.deliveryEvidenceUuids.add(turnId)
+  session.translator?.settleOwnedTurn(turnId)
+}
+
+export function applyClaudeSessionMessageIdentity(input: {
+  session: ClaudeSession
+  message: Record<string, unknown>
+  uuid: string | null
+  retiredOwnedUuid: boolean
+}): boolean {
+  const { session, message, uuid, retiredOwnedUuid } = input
+  if (
+    !retiredOwnedUuid &&
+    readClaudeFrameString(message, 'session_id') === session.providerSessionId
+  ) {
+    session.leafUuid = uuid ?? session.leafUuid
+  }
+  const sequence = retiredOwnedUuid
+    ? undefined
+    : ownedClaudeUserTurnSequence(session, message, uuid)
+  if (uuid && sequence !== undefined) {
+    session.deliveryEvidenceUuids.add(uuid)
+    session.translator?.confirmOwnedTurn(uuid)
+    return false
+  }
+  if (!retiredOwnedUuid) {
+    handleClaudeOwnedReceipt(session, message)
+  }
+  return true
+}

--- a/src/main/claude/claude-structured-acquisition-events.ts
+++ b/src/main/claude/claude-structured-acquisition-events.ts
@@ -1,0 +1,105 @@
+import type { ClaudeStreamJsonConnectionHandlers } from './claude-stream-json-connection'
+import {
+  handleClaudeInboundControl,
+  handleClaudeInboundControlCancel
+} from './claude-structured-inbound-control'
+import type { ClaudeInitDeadline } from './claude-structured-init-deadline'
+import { readClaudeFrameString, readClaudeInit } from './claude-structured-init-proof'
+import {
+  applyClaudeSessionMessageIdentity,
+  type ClaudeRetiredSentUserUuids
+} from './claude-owned-turn-receipts'
+import type {
+  ClaudeAcquisitionAttempt,
+  ClaudeSession,
+  ClaudeStructuredSessionEvent
+} from './claude-structured-session-state'
+
+export function createClaudeAcquisitionConnectionHandlers(input: {
+  sessionId: string
+  attempt: ClaudeAcquisitionAttempt
+  generation: object
+  initDeadline: ClaudeInitDeadline
+  retiredSentUserUuids: ClaudeRetiredSentUserUuids
+  isCurrentAttempt: () => boolean
+  getLiveSession: () => ClaudeSession | null
+  isCurrentSession: (session: ClaudeSession) => boolean
+  observeLeafUuid: (uuid: string | null) => void
+  deliver: (event: () => void) => void
+  emit: (event: ClaudeStructuredSessionEvent, translate?: boolean) => void
+  onExit: (error: Error) => void
+}): ClaudeStreamJsonConnectionHandlers {
+  const { sessionId, attempt } = input
+  return {
+    onMessage: (message) => {
+      const init = readClaudeInit(message)
+      if (init) {
+        input.initDeadline.resolve(init)
+      }
+      const uuid = readClaudeFrameString(message, 'uuid')
+      const retiredOwnedUuid =
+        !init && uuid ? input.retiredSentUserUuids.has(sessionId, uuid) : false
+      if (
+        !retiredOwnedUuid &&
+        !attempt.published &&
+        !attempt.cancelled &&
+        input.isCurrentAttempt()
+      ) {
+        input.observeLeafUuid(uuid)
+      }
+      input.deliver(() => {
+        const session = input.getLiveSession()
+        if (
+          !session ||
+          !input.isCurrentSession(session) ||
+          session.generation !== input.generation
+        ) {
+          return
+        }
+        const translate = applyClaudeSessionMessageIdentity({
+          session,
+          message,
+          uuid,
+          retiredOwnedUuid
+        })
+        input.observeLeafUuid(session.leafUuid)
+        input.emit({ type: 'message', sessionId, message }, translate)
+      })
+    },
+    onControlRequest: (request, responder) => {
+      handleClaudeInboundControl({
+        sessionId,
+        attempt,
+        request,
+        responder,
+        emit: (event) => input.deliver(() => input.emit(event))
+      })
+    },
+    onControlCancelRequest: ({ request_id: requestId }) => {
+      handleClaudeInboundControlCancel({
+        sessionId,
+        attempt,
+        requestId,
+        emit: (event) => input.deliver(() => input.emit(event))
+      })
+    },
+    onExit: (error) => {
+      if (!attempt.published) {
+        input.initDeadline.reject(error)
+      }
+      input.onExit(error)
+    }
+  }
+}
+
+export function emitClaudeSessionEvent(
+  session: ClaudeSession | null,
+  onEvent: ((event: ClaudeStructuredSessionEvent) => void) | undefined,
+  event: ClaudeStructuredSessionEvent,
+  translate = true
+): void {
+  if (translate) {
+    session?.translator?.handle(event)
+  }
+  onEvent?.(event)
+}

--- a/src/main/claude/claude-structured-adapter-fake-connection.ts
+++ b/src/main/claude/claude-structured-adapter-fake-connection.ts
@@ -1,0 +1,201 @@
+import type {
+  AgentJournalMessageItem,
+  AgentSessionJournalIdentity
+} from '../../shared/agent-session-journal-types'
+import type {
+  ClaudeStreamJsonConnection,
+  ClaudeStreamJsonConnectionHandlers,
+  ClaudeStreamJsonLaunch,
+  openClaudeStreamJsonConnection
+} from './claude-stream-json-connection'
+import { ClaudeStructuredSessionAdapter } from './claude-structured-session-adapter'
+import type {
+  ClaudeStructuredLaunch,
+  ClaudeStructuredSessionEvent
+} from './claude-structured-session-adapter'
+
+export const PROVIDER_SESSION_ID = '819cf9f8-e43c-4ad7-b50f-54aa158a726a'
+
+export const USER_MESSAGE: AgentJournalMessageItem = {
+  kind: 'message',
+  role: 'user',
+  blocks: [{ type: 'text', text: 'ship it' }]
+}
+
+export function deferred() {
+  let resolve = (): void => {}
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+export function identityFor(sessionId = 'session-1'): AgentSessionJournalIdentity {
+  return {
+    sessionId,
+    workspaceId: 'workspace-1',
+    hostId: 'host-1',
+    agent: 'claude',
+    providerHandle: { kind: 'claude', sessionId: PROVIDER_SESSION_ID, leafUuid: null }
+  }
+}
+
+type Route = (params: Record<string, unknown> | undefined) => unknown
+
+export type FakeClaudeConnection = Omit<ClaudeStreamJsonConnection, 'closed'> & {
+  closed: boolean
+  launch: ClaudeStreamJsonLaunch
+  handlers: ClaudeStreamJsonConnectionHandlers
+  calls: { subtype: string; params?: Record<string, unknown> }[]
+  sent: Record<string, unknown>[]
+  replies: { requestId: string; response?: unknown; error?: string }[]
+  closeCount: number
+}
+
+export function fakeClaude(
+  options: {
+    initSessionId?: string
+    initUuid?: string
+    initModel?: string
+    initEffort?: string
+    initProof?: 'init' | 'session-start' | 'none'
+    initAccount?: unknown
+    exitBeforeInit?: string
+    settings?: unknown
+    replayUuid?: string | null
+    sendError?: Error
+    sendErrorAfterReplay?: Error
+    onSend?: (
+      message: Record<string, unknown>,
+      handlers: ClaudeStreamJsonConnectionHandlers
+    ) => void | Promise<void>
+    routes?: Record<string, Route>
+  } = {}
+): {
+  connections: FakeClaudeConnection[]
+  openConnection: typeof openClaudeStreamJsonConnection
+  routes: Record<string, Route>
+} {
+  const connections: FakeClaudeConnection[] = []
+  const routes = options.routes ?? {}
+  const openConnection = (async (launch, handlers = {}) => {
+    const connection: FakeClaudeConnection = {
+      launch,
+      handlers,
+      calls: [],
+      sent: [],
+      replies: [],
+      closeCount: 0,
+      pid: 4321,
+      closed: false,
+      request: async (subtype, params) => {
+        connection.calls.push({ subtype, params })
+        if (subtype === 'initialize') {
+          if (options.exitBeforeInit) {
+            handlers.onExit?.(new Error(options.exitBeforeInit))
+            return { models: [] }
+          }
+          if (options.initProof === 'session-start') {
+            handlers.onMessage?.({
+              type: 'system',
+              subtype: 'hook_started',
+              hook_name: 'SessionStart:startup',
+              session_id: options.initSessionId ?? PROVIDER_SESSION_ID,
+              uuid: options.initUuid ?? 'init-uuid'
+            })
+          } else if (options.initProof !== 'none') {
+            handlers.onMessage?.({
+              type: 'system',
+              subtype: 'init',
+              session_id: options.initSessionId ?? PROVIDER_SESSION_ID,
+              uuid: options.initUuid ?? 'init-uuid',
+              model: options.initModel ?? 'claude-sonnet-5',
+              effortLevel: options.initEffort ?? 'high',
+              apiKeySource: 'none'
+            })
+          }
+          return {
+            models: [{ value: 'claude-sonnet', displayName: 'Sonnet' }],
+            ...(options.initAccount === undefined ? {} : { account: options.initAccount })
+          }
+        }
+        if (subtype === 'get_settings') {
+          return options.settings ?? { env: {} }
+        }
+        const route = routes[subtype]
+        return route ? route(params) : {}
+      },
+      send: async (message) => {
+        connection.sent.push(message)
+        await options.onSend?.(message, handlers)
+        if (options.sendError) {
+          throw options.sendError
+        }
+        if (message.type === 'user' && options.replayUuid !== null) {
+          handlers.onMessage?.({
+            ...message,
+            uuid: options.replayUuid ?? message.uuid,
+            isReplay: true
+          })
+        }
+        if (options.sendErrorAfterReplay) {
+          throw options.sendErrorAfterReplay
+        }
+      },
+      respond: async (requestId, response) => {
+        connection.replies.push({ requestId, response })
+      },
+      respondWithError: async (requestId, error) => {
+        connection.replies.push({ requestId, error })
+      },
+      close: async () => {
+        connection.closeCount += 1
+        connection.closed = true
+      }
+    }
+    connections.push(connection)
+    return connection
+  }) as typeof openClaudeStreamJsonConnection
+  return { connections, openConnection, routes }
+}
+
+export function adapterFor(
+  claude: ReturnType<typeof fakeClaude>,
+  launch: Partial<ClaudeStructuredLaunch> = {},
+  events: ClaudeStructuredSessionEvent[] = [],
+  persistedHandles: unknown[] = [],
+  initTimeoutMs?: number,
+  persistHandleOverride?: () => Promise<void>
+): ClaudeStructuredSessionAdapter {
+  return new ClaudeStructuredSessionAdapter({
+    resolveLaunch: async () => ({
+      command: 'claude',
+      args: ['-p'],
+      cwd: '/work/repo',
+      claudeConfigDir: '/accounts/claude',
+      providerSessionId: PROVIDER_SESSION_ID,
+      resumeLeafUuid: null,
+      resumed: false,
+      ...launch
+    }),
+    onEvent: (event) => events.push(event),
+    openConnection: claude.openConnection,
+    readProcessStartTime: async () => 1_700_000_000_000,
+    now: () => 1_700_000_000_500,
+    ...(initTimeoutMs === undefined ? {} : { initTimeoutMs }),
+    persistHandle: async (handle) => {
+      await persistHandleOverride?.()
+      persistedHandles.push(handle)
+    }
+  })
+}
+
+export async function acquired(
+  claude: ReturnType<typeof fakeClaude>,
+  launch: Partial<ClaudeStructuredLaunch> = {},
+  events: ClaudeStructuredSessionEvent[] = []
+): Promise<ClaudeStructuredSessionAdapter> {
+  const adapter = adapterFor(claude, launch, events)
+  await adapter.acquire({ identity: identityFor(), fence: 7, spawnToken: 'spawn-9' })
+  return adapter
+}

--- a/src/main/claude/claude-structured-dispatch.test.ts
+++ b/src/main/claude/claude-structured-dispatch.test.ts
@@ -128,6 +128,46 @@ describe('Claude structured dispatch image limits', () => {
     })
   })
 
+  // Dispatch base64-encodes a local image path, and `claudeMessageBody` models
+  // only text and URL images - so gating the waiter on "the translator would
+  // build a body" refuses an image-only send its own replay, times out, and
+  // reports a delivered message as unconfirmed (retry then sends it twice).
+  it('accepts the replay of a send that carries only a local image', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'orca-claude-replay-'))
+    try {
+      const path = join(directory, 'shot.png')
+      await writeFile(path, Buffer.alloc(64))
+      const session = sessionFor()
+      const dispatched = dispatchClaudeTurn(
+        session,
+        { clientMessageId: 'client-1', body: userMessage([{ type: 'image-ref', path }]) },
+        100
+      )
+      await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
+
+      resolveClaudeReplayWaiter(session, {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [
+            { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'AAAA' } }
+          ]
+        },
+        parent_tool_use_id: null,
+        session_id: 'provider-session',
+        uuid: 'image-replay-uuid',
+        isReplay: true
+      })
+
+      await expect(dispatched).resolves.toMatchObject({
+        state: 'accepted',
+        providerIdentity: { uuid: 'image-replay-uuid' }
+      })
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
   it('rejects more than twenty URL images before sending', async () => {
     const session = sessionFor()
     const body = userMessage(

--- a/src/main/claude/claude-structured-dispatch.test.ts
+++ b/src/main/claude/claude-structured-dispatch.test.ts
@@ -25,6 +25,18 @@ function userMessage(blocks: AgentJournalMessageItem['blocks']): AgentJournalMes
   return { kind: 'message', role: 'user', blocks }
 }
 
+/** Claude's `--replay-user-messages` echo of a prompt Orca dispatched. */
+function userReplayFrame(uuid: string, text: string): Record<string, unknown> {
+  return {
+    type: 'user',
+    message: { role: 'user', content: [{ type: 'text', text }] },
+    session_id: 'provider-session',
+    parent_tool_use_id: null,
+    uuid,
+    isReplay: true
+  }
+}
+
 describe('Claude structured dispatch image limits', () => {
   it('accepts a slash command from its result receipt when Claude omits the user replay', async () => {
     const session = sessionFor()
@@ -67,12 +79,48 @@ describe('Claude structured dispatch image limits', () => {
       uuid: 'unrelated-result-uuid'
     })
     expect(session.dispatchWaiters).toHaveLength(1)
+    resolveClaudeReplayWaiter(session, userReplayFrame('user-replay-uuid', 'hello'))
+
+    await expect(dispatched).resolves.toMatchObject({
+      state: 'accepted',
+      providerIdentity: { uuid: 'user-replay-uuid' }
+    })
+  })
+
+  // Both frames captured verbatim from `claude -p --input-format stream-json
+  // --output-format stream-json --replay-user-messages`: the replay of the sent
+  // prompt and the tool-result turn that follows it share `type: 'user'` and a
+  // null `parent_tool_use_id`.
+  it('does not adopt a tool-result turn as the user replay', async () => {
+    const session = sessionFor()
+    const dispatched = dispatchClaudeTurn(
+      session,
+      { clientMessageId: 'client-1', body: userMessage([{ type: 'text', text: 'queued' }]) },
+      100
+    )
+    await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
+
     resolveClaudeReplayWaiter(session, {
       type: 'user',
+      message: {
+        role: 'user',
+        content: [
+          {
+            tool_use_id: 'toolu_01TY2ETgHfpYVuq3ETuGYfDV',
+            type: 'tool_result',
+            content: 'probe-two',
+            is_error: false
+          }
+        ]
+      },
       parent_tool_use_id: null,
       session_id: 'provider-session',
-      uuid: 'user-replay-uuid'
+      uuid: 'tool-result-uuid',
+      tool_use_result: { stdout: 'probe-two', stderr: '', interrupted: false }
     })
+    expect(session.dispatchWaiters).toHaveLength(1)
+
+    resolveClaudeReplayWaiter(session, userReplayFrame('user-replay-uuid', 'queued'))
 
     await expect(dispatched).resolves.toMatchObject({
       state: 'accepted',

--- a/src/main/claude/claude-structured-dispatch.test.ts
+++ b/src/main/claude/claude-structured-dispatch.test.ts
@@ -6,6 +6,10 @@ import type { AgentJournalMessageItem } from '../../shared/agent-session-journal
 import { dispatchClaudeTurn, resolveClaudeReplayWaiter } from './claude-structured-dispatch'
 import type { ClaudeSession } from './claude-structured-session-state'
 
+// vi.waitFor's first successful poll lands ~50ms after the waiter is armed, so a
+// 100ms ack budget leaves almost none for the frame under parallel load.
+const ACK_BUDGET_MS = 5_000
+
 function sessionFor(send = vi.fn().mockResolvedValue(undefined)): ClaudeSession {
   return {
     connection: { send } as unknown as ClaudeSession['connection'],
@@ -43,7 +47,7 @@ describe('Claude structured dispatch image limits', () => {
     const dispatched = dispatchClaudeTurn(
       session,
       { clientMessageId: 'client-1', body: userMessage([{ type: 'text', text: '/permissions' }]) },
-      100
+      ACK_BUDGET_MS
     )
     await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
 
@@ -69,7 +73,7 @@ describe('Claude structured dispatch image limits', () => {
     const dispatched = dispatchClaudeTurn(
       session,
       { clientMessageId: 'client-1', body: userMessage([{ type: 'text', text: 'hello' }]) },
-      100
+      ACK_BUDGET_MS
     )
     await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
 
@@ -96,7 +100,7 @@ describe('Claude structured dispatch image limits', () => {
     const dispatched = dispatchClaudeTurn(
       session,
       { clientMessageId: 'client-1', body: userMessage([{ type: 'text', text: 'queued' }]) },
-      100
+      ACK_BUDGET_MS
     )
     await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
 
@@ -136,7 +140,7 @@ describe('Claude structured dispatch image limits', () => {
     const dispatched = dispatchClaudeTurn(
       session,
       { clientMessageId: 'client-1', body: userMessage([{ type: 'text', text: 'queued' }]) },
-      100
+      ACK_BUDGET_MS
     )
     await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
 
@@ -165,7 +169,7 @@ describe('Claude structured dispatch image limits', () => {
     const first = dispatchClaudeTurn(
       session,
       { clientMessageId: 'client-1', body: userMessage([{ type: 'text', text: 'one' }]) },
-      100
+      ACK_BUDGET_MS
     )
     await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
     resolveClaudeReplayWaiter(session, userReplayFrame('replay-one', 'one'))
@@ -174,7 +178,7 @@ describe('Claude structured dispatch image limits', () => {
     const second = dispatchClaudeTurn(
       session,
       { clientMessageId: 'client-2', body: userMessage([{ type: 'text', text: 'two' }]) },
-      100
+      ACK_BUDGET_MS
     )
     await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
 
@@ -202,7 +206,7 @@ describe('Claude structured dispatch image limits', () => {
     const dispatched = dispatchClaudeTurn(
       session,
       { clientMessageId: 'client-1', body: userMessage([{ type: 'text', text: 'hello' }]) },
-      100
+      ACK_BUDGET_MS
     )
     await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
 
@@ -230,12 +234,10 @@ describe('Claude structured dispatch image limits', () => {
       const path = join(directory, 'shot.png')
       await writeFile(path, Buffer.alloc(64))
       const session = sessionFor()
-      // Real file I/O runs before the ack timer starts, so give this one room:
-      // a 100ms budget can expire under parallel load before the frame arrives.
       const dispatched = dispatchClaudeTurn(
         session,
         { clientMessageId: 'client-1', body: userMessage([{ type: 'image-ref', path }]) },
-        5_000
+        ACK_BUDGET_MS
       )
       await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
 
@@ -261,6 +263,36 @@ describe('Claude structured dispatch image limits', () => {
     } finally {
       await rm(directory, { recursive: true, force: true })
     }
+  })
+
+  // The waiter queue is positional, so shifting the head on a send failure
+  // resolves whichever dispatch happens to be first - reporting a delivered
+  // message as unconfirmed while the send that actually failed keeps waiting.
+  it('retires its own waiter when the send fails, not the one at the head', async () => {
+    const session = sessionFor()
+    const first = dispatchClaudeTurn(
+      session,
+      { clientMessageId: 'client-1', body: userMessage([{ type: 'text', text: 'one' }]) },
+      ACK_BUDGET_MS
+    )
+    await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
+    const firstWaiter = session.dispatchWaiters[0]
+
+    session.connection.send = vi.fn().mockRejectedValue(new Error('broken pipe'))
+    await expect(
+      dispatchClaudeTurn(
+        session,
+        { clientMessageId: 'client-2', body: userMessage([{ type: 'text', text: 'two' }]) },
+        ACK_BUDGET_MS
+      )
+    ).resolves.toEqual({ state: 'unknown', reason: 'broken pipe' })
+
+    expect(session.dispatchWaiters).toEqual([firstWaiter])
+    resolveClaudeReplayWaiter(session, userReplayFrame('replay-one', 'one'))
+    await expect(first).resolves.toMatchObject({
+      state: 'accepted',
+      providerIdentity: { uuid: 'replay-one' }
+    })
   })
 
   it('rejects more than twenty URL images before sending', async () => {

--- a/src/main/claude/claude-structured-dispatch.test.ts
+++ b/src/main/claude/claude-structured-dispatch.test.ts
@@ -342,6 +342,40 @@ describe('Claude structured dispatch image limits', () => {
     })
   })
 
+  // A dispatch that gave up still has a replay in flight. Once its waiter is
+  // gone, that frame matches no owner and would otherwise fall to the compat
+  // path and settle whoever is now at the head.
+  it('drops the replay of a dispatch that already timed out', async () => {
+    const session = sessionFor()
+    const first = dispatchClaudeTurn(
+      session,
+      { clientMessageId: 'client-1', body: userMessage([{ type: 'text', text: 'one' }]) },
+      60
+    )
+    await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
+    const firstUuid = session.dispatchWaiters[0]!.sentUuid
+    await expect(first).resolves.toMatchObject({ state: 'unknown' })
+    expect(session.dispatchWaiters).toHaveLength(0)
+
+    const second = dispatchClaudeTurn(
+      session,
+      { clientMessageId: 'client-2', body: userMessage([{ type: 'text', text: 'two' }]) },
+      ACK_BUDGET_MS
+    )
+    await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
+    const secondUuid = session.dispatchWaiters[0]!.sentUuid
+
+    // The dead send's echo lands while the second is waiting.
+    resolveClaudeReplayWaiter(session, userReplayFrame(firstUuid, 'one'))
+    expect(session.dispatchWaiters).toHaveLength(1)
+
+    resolveClaudeReplayWaiter(session, userReplayFrame(secondUuid, 'two'))
+    await expect(second).resolves.toMatchObject({
+      state: 'accepted',
+      providerIdentity: { uuid: secondUuid }
+    })
+  })
+
   // The waiter queue is positional, so shifting the head on a send failure
   // resolves whichever dispatch happens to be first - reporting a delivered
   // message as unconfirmed while the send that actually failed keeps waiting.

--- a/src/main/claude/claude-structured-dispatch.test.ts
+++ b/src/main/claude/claude-structured-dispatch.test.ts
@@ -3,25 +3,39 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import type { AgentJournalMessageItem } from '../../shared/agent-session-journal-types'
-import { dispatchClaudeTurn, resolveClaudeReplayWaiter } from './claude-structured-dispatch'
-import type { ClaudeSession } from './claude-structured-session-state'
+import { dispatchClaudeTurn } from './claude-structured-dispatch'
+import type { ClaudeJournalTranslator } from './claude-structured-journal-translation'
+import { createClaudeSessionTerminal, type ClaudeSession } from './claude-structured-session-state'
 
-// vi.waitFor's first successful poll lands ~50ms after the waiter is armed, so a
-// 100ms ack budget leaves almost none for the frame under parallel load.
-const ACK_BUDGET_MS = 5_000
+function translatorSpies() {
+  return {
+    registerOwnedTurn: vi.fn(),
+    confirmOwnedTurn: vi.fn(),
+    settleOwnedTurn: vi.fn(),
+    abandonOwnedTurn: vi.fn()
+  }
+}
 
-function sessionFor(send = vi.fn().mockResolvedValue(undefined)): ClaudeSession {
+function sessionFor(
+  send = vi.fn().mockResolvedValue(undefined),
+  translator = translatorSpies()
+): ClaudeSession {
   return {
     connection: { send } as unknown as ClaudeSession['connection'],
     providerSessionId: 'provider-session',
     leafUuid: null,
     fence: 1,
     prompts: {} as ClaudeSession['prompts'],
-    dispatchWaiters: [],
+    generation: {},
+    sentUserUuidSequence: new Map(),
+    deliveryEvidenceUuids: new Set(),
+    dispatchLane: Promise.resolve(),
+    dispatchFenced: false,
+    terminal: createClaudeSessionTerminal(),
     options: new Map(),
     reportedOptions: {},
     events: undefined,
-    translator: null
+    translator: translator as unknown as ClaudeJournalTranslator
   }
 }
 
@@ -29,401 +43,207 @@ function userMessage(blocks: AgentJournalMessageItem['blocks']): AgentJournalMes
   return { kind: 'message', role: 'user', blocks }
 }
 
-/** Claude's `--replay-user-messages` echo of a prompt Orca dispatched. */
-function userReplayFrame(uuid: string, text: string): Record<string, unknown> {
-  return {
-    type: 'user',
-    message: { role: 'user', content: [{ type: 'text', text }] },
-    session_id: 'provider-session',
-    parent_tool_use_id: null,
-    uuid,
-    isReplay: true
-  }
+function deferred() {
+  let resolve = (): void => {}
+  let reject = (_error: Error): void => {}
+  const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
 }
 
-describe('Claude structured dispatch image limits', () => {
-  it('accepts a slash command from its result receipt when Claude omits the user replay', async () => {
-    const session = sessionFor()
-    const dispatched = dispatchClaudeTurn(
-      session,
-      { clientMessageId: 'client-1', body: userMessage([{ type: 'text', text: '/permissions' }]) },
-      ACK_BUDGET_MS
-    )
-    await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
-
-    resolveClaudeReplayWaiter(session, {
-      type: 'result',
-      subtype: 'success',
-      session_id: 'provider-session',
-      uuid: 'command-result-uuid'
+describe('Claude structured dispatch', () => {
+  it('registers a caller UUID before writing and accepts that identity after the write', async () => {
+    const translator = translatorSpies()
+    let session!: ClaudeSession
+    const send = vi.fn(async (message: Record<string, unknown>) => {
+      const uuid = message.uuid as string
+      expect(session.sentUserUuidSequence.get(uuid)).toBe(0)
+      expect(translator.registerOwnedTurn).toHaveBeenCalledWith('provider-session', uuid, 0)
     })
+    session = sessionFor(send, translator)
 
-    await expect(dispatched).resolves.toEqual({
+    const result = await dispatchClaudeTurn(session, {
+      clientMessageId: 'client-1',
+      body: userMessage([{ type: 'text', text: 'hello' }])
+    })
+    const sentUuid = send.mock.calls[0]![0].uuid as string
+
+    expect(result).toEqual({
       state: 'accepted',
-      providerIdentity: {
-        provider: 'claude',
-        sessionId: 'provider-session',
-        uuid: 'command-result-uuid'
-      }
+      providerIdentity: { provider: 'claude', sessionId: 'provider-session', uuid: sentUuid }
     })
+    expect(translator.confirmOwnedTurn).toHaveBeenCalledWith(sentUuid)
   })
 
-  it('does not mistake a normal turn result for its missing user replay', async () => {
+  it('keeps concurrent dispatch identities in registration order', async () => {
     const session = sessionFor()
-    const dispatched = dispatchClaudeTurn(
-      session,
-      { clientMessageId: 'client-1', body: userMessage([{ type: 'text', text: 'hello' }]) },
-      ACK_BUDGET_MS
-    )
-    await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
 
-    resolveClaudeReplayWaiter(session, {
-      type: 'result',
-      session_id: 'provider-session',
-      uuid: 'unrelated-result-uuid'
-    })
-    expect(session.dispatchWaiters).toHaveLength(1)
-    resolveClaudeReplayWaiter(session, userReplayFrame('user-replay-uuid', 'hello'))
-
-    await expect(dispatched).resolves.toMatchObject({
-      state: 'accepted',
-      providerIdentity: { uuid: 'user-replay-uuid' }
-    })
-  })
-
-  // Both frames captured verbatim from `claude -p --input-format stream-json
-  // --output-format stream-json --replay-user-messages`: the replay of the sent
-  // prompt and the tool-result turn that follows it share `type: 'user'` and a
-  // null `parent_tool_use_id`.
-  it('does not adopt a tool-result turn as the user replay', async () => {
-    const session = sessionFor()
-    const dispatched = dispatchClaudeTurn(
-      session,
-      { clientMessageId: 'client-1', body: userMessage([{ type: 'text', text: 'queued' }]) },
-      ACK_BUDGET_MS
-    )
-    await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
-
-    resolveClaudeReplayWaiter(session, {
-      type: 'user',
-      message: {
-        role: 'user',
-        content: [
-          {
-            tool_use_id: 'toolu_01TY2ETgHfpYVuq3ETuGYfDV',
-            type: 'tool_result',
-            content: 'probe-two',
-            is_error: false
-          }
-        ]
-      },
-      parent_tool_use_id: null,
-      session_id: 'provider-session',
-      uuid: 'tool-result-uuid',
-      tool_use_result: { stdout: 'probe-two', stderr: '', interrupted: false }
-    })
-    expect(session.dispatchWaiters).toHaveLength(1)
-
-    resolveClaudeReplayWaiter(session, userReplayFrame('user-replay-uuid', 'queued'))
-
-    await expect(dispatched).resolves.toMatchObject({
-      state: 'accepted',
-      providerIdentity: { uuid: 'user-replay-uuid' }
-    })
-  })
-
-  // An injected turn is the worse half of this class: unlike a tool result it
-  // DOES build a journal body, so adopting its uuid upserts harness text over the
-  // user's own bubble AND leaves the real replay to append as a second row.
-  it('does not adopt a harness-injected user turn as the user replay', async () => {
-    const session = sessionFor()
-    const dispatched = dispatchClaudeTurn(
-      session,
-      { clientMessageId: 'client-1', body: userMessage([{ type: 'text', text: 'queued' }]) },
-      ACK_BUDGET_MS
-    )
-    await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
-
-    resolveClaudeReplayWaiter(session, {
-      type: 'user',
-      message: { role: 'user', content: [{ type: 'text', text: '[Request interrupted by user]' }] },
-      parent_tool_use_id: null,
-      session_id: 'provider-session',
-      uuid: 'injected-uuid'
-    })
-    expect(session.dispatchWaiters).toHaveLength(1)
-
-    resolveClaudeReplayWaiter(session, userReplayFrame('user-replay-uuid', 'queued'))
-
-    await expect(dispatched).resolves.toMatchObject({
-      state: 'accepted',
-      providerIdentity: { uuid: 'user-replay-uuid' }
-    })
-  })
-
-  // NOT red against the merge base - the old predicate accepts this frame too.
-  // It pins that the gate never sniffs content: an image-only echo carries no
-  // text and builds no journal body, so any body-model gate would refuse this
-  // send its own replay and report a delivered message as unconfirmed.
-  it('accepts the replay of a send that carries only a local image', async () => {
-    const directory = await mkdtemp(join(tmpdir(), 'orca-claude-replay-'))
-    try {
-      const path = join(directory, 'shot.png')
-      await writeFile(path, Buffer.alloc(64))
-      const session = sessionFor()
-      const dispatched = dispatchClaudeTurn(
-        session,
-        { clientMessageId: 'client-1', body: userMessage([{ type: 'image-ref', path }]) },
-        ACK_BUDGET_MS
-      )
-      await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
-
-      resolveClaudeReplayWaiter(session, {
-        type: 'user',
-        message: {
-          role: 'user',
-          content: [
-            { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'AAAA' } }
-          ]
-        },
-        parent_tool_use_id: null,
-        session_id: 'provider-session',
-        uuid: 'image-replay-uuid',
-        isReplay: true
+    const [first, second] = await Promise.all([
+      dispatchClaudeTurn(session, {
+        clientMessageId: 'client-1',
+        body: userMessage([{ type: 'text', text: 'one' }])
+      }),
+      dispatchClaudeTurn(session, {
+        clientMessageId: 'client-2',
+        body: userMessage([{ type: 'text', text: 'two' }])
       })
+    ])
+    const entries = [...session.sentUserUuidSequence]
 
-      await expect(dispatched).resolves.toMatchObject({
-        state: 'accepted',
-        providerIdentity: { uuid: 'image-replay-uuid' }
+    expect(entries.map((entry) => entry[1])).toEqual([0, 1])
+    expect(first).toMatchObject({ providerIdentity: { uuid: entries[0]![0] } })
+    expect(second).toMatchObject({ providerIdentity: { uuid: entries[1]![0] } })
+  })
+
+  it('keeps acceptance when the exact echo arrives before the write rejects', async () => {
+    const translator = translatorSpies()
+    let session!: ClaudeSession
+    const send = vi.fn(async (message: Record<string, unknown>) => {
+      const uuid = message.uuid as string
+      session.deliveryEvidenceUuids.add(uuid)
+      translator.confirmOwnedTurn(uuid)
+      throw new Error('flush failed')
+    })
+    session = sessionFor(send, translator)
+
+    const result = await dispatchClaudeTurn(session, {
+      clientMessageId: 'client-1',
+      body: userMessage([{ type: 'text', text: 'hello' }])
+    })
+    const sentUuid = send.mock.calls[0]![0].uuid as string
+
+    expect(result).toMatchObject({ state: 'accepted', providerIdentity: { uuid: sentUuid } })
+    expect(session.dispatchFenced).toBe(false)
+    expect(translator.abandonOwnedTurn).not.toHaveBeenCalled()
+  })
+
+  it('fences later dispatches after an unobserved write failure', async () => {
+    const translator = translatorSpies()
+    const send = vi.fn().mockRejectedValueOnce(new Error('broken pipe'))
+    const session = sessionFor(send, translator)
+
+    await expect(
+      dispatchClaudeTurn(session, {
+        clientMessageId: 'client-1',
+        body: userMessage([{ type: 'text', text: 'one' }])
+      })
+    ).resolves.toEqual({ state: 'unknown', reason: 'broken pipe' })
+    const sentUuid = send.mock.calls[0]![0].uuid as string
+    expect(translator.abandonOwnedTurn).toHaveBeenCalledWith(sentUuid)
+
+    await expect(
+      dispatchClaudeTurn(session, {
+        clientMessageId: 'client-2',
+        body: userMessage([{ type: 'text', text: 'two' }])
+      })
+    ).resolves.toMatchObject({ state: 'unknown' })
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not materialize a queued dispatch after the active write becomes uncertain', async () => {
+    const pendingWrite = deferred()
+    const send = vi.fn().mockImplementationOnce(() => pendingWrite.promise)
+    const session = sessionFor(send)
+    const first = dispatchClaudeTurn(session, {
+      clientMessageId: 'client-1',
+      body: userMessage([{ type: 'text', text: 'one' }])
+    })
+    await vi.waitFor(() => expect(send).toHaveBeenCalledTimes(1))
+    const second = dispatchClaudeTurn(session, {
+      clientMessageId: 'client-2',
+      body: userMessage([])
+    })
+
+    pendingWrite.reject(new Error('broken pipe'))
+
+    await expect(first).resolves.toEqual({ state: 'unknown', reason: 'broken pipe' })
+    await expect(second).resolves.toMatchObject({
+      state: 'unknown',
+      reason: 'claude delivery is uncertain until the session reconnects'
+    })
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+
+  it('releases the dispatch lane after local validation fails', async () => {
+    const send = vi.fn().mockResolvedValue(undefined)
+    const session = sessionFor(send)
+
+    const [first, second] = await Promise.all([
+      dispatchClaudeTurn(session, {
+        clientMessageId: 'client-1',
+        body: userMessage([])
+      }),
+      dispatchClaudeTurn(session, {
+        clientMessageId: 'client-2',
+        body: userMessage([{ type: 'text', text: 'two' }])
+      })
+    ])
+
+    expect(first).toEqual({
+      state: 'rejected',
+      reason: 'Claude dispatch requires text or an image'
+    })
+    expect(second).toMatchObject({ state: 'accepted' })
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+
+  it('wakes active and queued dispatches when the session becomes terminal', async () => {
+    const pendingWrite = deferred()
+    const send = vi.fn().mockImplementationOnce(() => pendingWrite.promise)
+    const session = sessionFor(send)
+    const first = dispatchClaudeTurn(session, {
+      clientMessageId: 'client-1',
+      body: userMessage([{ type: 'text', text: 'one' }])
+    })
+    await vi.waitFor(() => expect(send).toHaveBeenCalledTimes(1))
+    const second = dispatchClaudeTurn(session, {
+      clientMessageId: 'client-2',
+      body: userMessage([{ type: 'text', text: 'two' }])
+    })
+
+    session.terminal.close()
+
+    await expect(first).resolves.toEqual({
+      state: 'unknown',
+      reason: 'claude session closed while delivery was pending'
+    })
+    await expect(second).resolves.toEqual({
+      state: 'rejected',
+      reason: 'claude structured session closed before dispatch'
+    })
+    expect(send).toHaveBeenCalledTimes(1)
+    pendingWrite.resolve()
+  })
+
+  it('accepts image-only content under the UUID written to stdin', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'orca-claude-dispatch-'))
+    try {
+      const path = join(directory, 'pixel.png')
+      await writeFile(path, Buffer.from([0, 1, 2]))
+      const session = sessionFor()
+
+      const result = await dispatchClaudeTurn(session, {
+        clientMessageId: 'client-image',
+        body: userMessage([{ type: 'image-ref', path }])
+      })
+      const sent = vi.mocked(session.connection.send).mock.calls[0]![0]
+
+      expect(result).toMatchObject({ state: 'accepted', providerIdentity: { uuid: sent.uuid } })
+      expect(sent).toMatchObject({
+        message: {
+          content: [
+            {
+              type: 'image',
+              source: { type: 'base64', media_type: 'image/png', data: 'AAEC' }
+            }
+          ]
+        }
       })
     } finally {
       await rm(directory, { recursive: true, force: true })
     }
-  })
-
-  // `acceptsResult` settles a send on a bare `result` frame, which carries no
-  // correlation to the waiting dispatch - so a message that merely opens with a
-  // path must not opt into it, or an unrelated turn's result claims its identity.
-  it('does not let a path-leading message settle on an unrelated result frame', async () => {
-    const session = sessionFor()
-    const dispatched = dispatchClaudeTurn(
-      session,
-      {
-        clientMessageId: 'client-1',
-        body: userMessage([{ type: 'text', text: '/Users/me/repo/src/foo.ts - explain this' }])
-      },
-      ACK_BUDGET_MS
-    )
-    await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
-
-    resolveClaudeReplayWaiter(session, {
-      type: 'result',
-      subtype: 'success',
-      session_id: 'provider-session',
-      uuid: 'unrelated-turn-result'
-    })
-    expect(session.dispatchWaiters).toHaveLength(1)
-
-    resolveClaudeReplayWaiter(
-      session,
-      userReplayFrame('real-replay', '/Users/me/repo/src/foo.ts - explain this')
-    )
-    await expect(dispatched).resolves.toMatchObject({
-      state: 'accepted',
-      providerIdentity: { uuid: 'real-replay' }
-    })
-  })
-
-  it.each([
-    ['/README.md - what does this do?', 'a bare filename'],
-    ['  /clear', 'an indented command, which the TUI reads as prose']
-  ])('keeps %s off the result path (%s)', async (text) => {
-    const session = sessionFor()
-    const dispatched = dispatchClaudeTurn(
-      session,
-      { clientMessageId: 'client-1', body: userMessage([{ type: 'text', text }]) },
-      ACK_BUDGET_MS
-    )
-    await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
-
-    resolveClaudeReplayWaiter(session, {
-      type: 'result',
-      subtype: 'success',
-      session_id: 'provider-session',
-      uuid: 'unrelated-turn-result'
-    })
-    expect(session.dispatchWaiters).toHaveLength(1)
-
-    resolveClaudeReplayWaiter(session, userReplayFrame('real-replay', text))
-    await expect(dispatched).resolves.toMatchObject({
-      providerIdentity: { uuid: 'real-replay' }
-    })
-  })
-
-  // Captured from claude 2.1.237: the model-switch breadcrumb is enqueued as
-  // `{type:'user', parent_tool_use_id:null, isReplay:true}` with STRING content.
-  // Orca triggers it itself from the model picker, and the CLI's own
-  // RemoteSessionManager filters the same frames by content prefix.
-  it('does not adopt a model-switch breadcrumb even though it is stamped', async () => {
-    const session = sessionFor()
-    const dispatched = dispatchClaudeTurn(
-      session,
-      { clientMessageId: 'client-1', body: userMessage([{ type: 'text', text: 'queued' }]) },
-      ACK_BUDGET_MS
-    )
-    await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
-
-    resolveClaudeReplayWaiter(session, {
-      type: 'user',
-      message: {
-        role: 'user',
-        content: '<local-command-stdout>Set model to Sonnet</local-command-stdout>'
-      },
-      parent_tool_use_id: null,
-      session_id: 'provider-session',
-      uuid: 'breadcrumb-uuid',
-      isReplay: true
-    })
-    expect(session.dispatchWaiters).toHaveLength(1)
-
-    resolveClaudeReplayWaiter(session, userReplayFrame('user-replay-uuid', 'queued'))
-    await expect(dispatched).resolves.toMatchObject({
-      state: 'accepted',
-      providerIdentity: { uuid: 'user-replay-uuid' }
-    })
-  })
-
-  // The CLI round-trips a client-supplied uuid on the replay (measured), so a
-  // dispatch can be matched to its OWN echo instead of to whatever is at the
-  // head of the queue.
-  it('stamps a uuid on the outgoing frame', async () => {
-    const session = sessionFor()
-    void dispatchClaudeTurn(
-      session,
-      { clientMessageId: 'client-1', body: userMessage([{ type: 'text', text: 'hello' }]) },
-      ACK_BUDGET_MS
-    )
-    await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
-
-    expect(session.connection.send).toHaveBeenCalledWith(
-      expect.objectContaining({ uuid: session.dispatchWaiters[0]!.sentUuid })
-    )
-  })
-
-  it('settles the dispatch whose uuid was echoed, not the queue head', async () => {
-    const session = sessionFor()
-    const first = dispatchClaudeTurn(
-      session,
-      { clientMessageId: 'client-1', body: userMessage([{ type: 'text', text: 'one' }]) },
-      ACK_BUDGET_MS
-    )
-    await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
-    const second = dispatchClaudeTurn(
-      session,
-      { clientMessageId: 'client-2', body: userMessage([{ type: 'text', text: 'two' }]) },
-      ACK_BUDGET_MS
-    )
-    await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(2))
-    const firstUuid = session.dispatchWaiters[0]!.sentUuid
-    const secondUuid = session.dispatchWaiters[1]!.sentUuid
-
-    // Out of order: the second send's echo arrives while the first is still head.
-    resolveClaudeReplayWaiter(session, userReplayFrame(secondUuid, 'two'))
-    await expect(second).resolves.toMatchObject({
-      state: 'accepted',
-      providerIdentity: { uuid: secondUuid }
-    })
-    expect(session.dispatchWaiters.map((waiter) => waiter.sentUuid)).toEqual([firstUuid])
-
-    resolveClaudeReplayWaiter(session, userReplayFrame(firstUuid, 'one'))
-    await expect(first).resolves.toMatchObject({
-      state: 'accepted',
-      providerIdentity: { uuid: firstUuid }
-    })
-  })
-
-  // A dispatch that gave up still has a replay in flight. Once its waiter is
-  // gone, that frame matches no owner and would otherwise fall to the compat
-  // path and settle whoever is now at the head.
-  it('drops the replay of a dispatch that already timed out', async () => {
-    const session = sessionFor()
-    const first = dispatchClaudeTurn(
-      session,
-      { clientMessageId: 'client-1', body: userMessage([{ type: 'text', text: 'one' }]) },
-      60
-    )
-    await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
-    const firstUuid = session.dispatchWaiters[0]!.sentUuid
-    await expect(first).resolves.toMatchObject({ state: 'unknown' })
-    expect(session.dispatchWaiters).toHaveLength(0)
-
-    const second = dispatchClaudeTurn(
-      session,
-      { clientMessageId: 'client-2', body: userMessage([{ type: 'text', text: 'two' }]) },
-      ACK_BUDGET_MS
-    )
-    await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
-    const secondUuid = session.dispatchWaiters[0]!.sentUuid
-
-    // The dead send's echo lands while the second is waiting.
-    resolveClaudeReplayWaiter(session, userReplayFrame(firstUuid, 'one'))
-    expect(session.dispatchWaiters).toHaveLength(1)
-
-    resolveClaudeReplayWaiter(session, userReplayFrame(secondUuid, 'two'))
-    await expect(second).resolves.toMatchObject({
-      state: 'accepted',
-      providerIdentity: { uuid: secondUuid }
-    })
-  })
-
-  // The waiter queue is positional, so shifting the head on a send failure
-  // resolves whichever dispatch happens to be first - reporting a delivered
-  // message as unconfirmed while the send that actually failed keeps waiting.
-  it('retires its own waiter when the send fails, not the one at the head', async () => {
-    const session = sessionFor()
-    const first = dispatchClaudeTurn(
-      session,
-      { clientMessageId: 'client-1', body: userMessage([{ type: 'text', text: 'one' }]) },
-      ACK_BUDGET_MS
-    )
-    await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
-    const firstWaiter = session.dispatchWaiters[0]
-
-    session.connection.send = vi.fn().mockRejectedValue(new Error('broken pipe'))
-    await expect(
-      dispatchClaudeTurn(
-        session,
-        { clientMessageId: 'client-2', body: userMessage([{ type: 'text', text: 'two' }]) },
-        ACK_BUDGET_MS
-      )
-    ).resolves.toEqual({ state: 'unknown', reason: 'broken pipe' })
-
-    expect(session.dispatchWaiters).toEqual([firstWaiter])
-    resolveClaudeReplayWaiter(session, userReplayFrame('replay-one', 'one'))
-    await expect(first).resolves.toMatchObject({
-      state: 'accepted',
-      providerIdentity: { uuid: 'replay-one' }
-    })
-  })
-
-  // A write can reach Claude and still reject on the following flush.
-  it('keeps an identity the replay already claimed when the send then rejects', async () => {
-    const session = sessionFor()
-    session.connection.send = vi.fn().mockImplementation(async () => {
-      resolveClaudeReplayWaiter(session, userReplayFrame('landed-anyway', 'hello'))
-      throw new Error('flush failed')
-    })
-
-    await expect(
-      dispatchClaudeTurn(
-        session,
-        { clientMessageId: 'client-1', body: userMessage([{ type: 'text', text: 'hello' }]) },
-        ACK_BUDGET_MS
-      )
-    ).resolves.toMatchObject({
-      state: 'accepted',
-      providerIdentity: { uuid: 'landed-anyway' }
-    })
   })
 
   it('rejects more than twenty URL images before sending', async () => {
@@ -436,7 +256,7 @@ describe('Claude structured dispatch image limits', () => {
     )
 
     await expect(
-      dispatchClaudeTurn(session, { clientMessageId: 'client-1', body }, 1)
+      dispatchClaudeTurn(session, { clientMessageId: 'client-1', body })
     ).resolves.toEqual({ state: 'rejected', reason: 'Claude messages support at most 20 images' })
     expect(session.connection.send).not.toHaveBeenCalled()
   })
@@ -455,7 +275,7 @@ describe('Claude structured dispatch image limits', () => {
       const body = userMessage(paths.map((path) => ({ type: 'image-ref' as const, path })))
 
       await expect(
-        dispatchClaudeTurn(session, { clientMessageId: 'client-1', body }, 1)
+        dispatchClaudeTurn(session, { clientMessageId: 'client-1', body })
       ).resolves.toEqual({
         state: 'rejected',
         reason: `Claude images must total no more than ${20 * 1024 * 1024} bytes`
@@ -475,7 +295,7 @@ describe('Claude structured dispatch image limits', () => {
       const body = userMessage([{ type: 'image-ref', path }])
 
       await expect(
-        dispatchClaudeTurn(session, { clientMessageId: 'client-1', body }, 1)
+        dispatchClaudeTurn(session, { clientMessageId: 'client-1', body })
       ).resolves.toEqual({
         state: 'rejected',
         reason: `Claude image must be a non-empty file no larger than ${5 * 1024 * 1024} bytes`

--- a/src/main/claude/claude-structured-dispatch.test.ts
+++ b/src/main/claude/claude-structured-dispatch.test.ts
@@ -234,6 +234,32 @@ describe('Claude structured dispatch image limits', () => {
     })
   })
 
+  it.each([
+    ['/README.md - what does this do?', 'a bare filename'],
+    ['  /clear', 'an indented command, which the TUI reads as prose']
+  ])('keeps %s off the result path (%s)', async (text) => {
+    const session = sessionFor()
+    const dispatched = dispatchClaudeTurn(
+      session,
+      { clientMessageId: 'client-1', body: userMessage([{ type: 'text', text }]) },
+      ACK_BUDGET_MS
+    )
+    await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
+
+    resolveClaudeReplayWaiter(session, {
+      type: 'result',
+      subtype: 'success',
+      session_id: 'provider-session',
+      uuid: 'unrelated-turn-result'
+    })
+    expect(session.dispatchWaiters).toHaveLength(1)
+
+    resolveClaudeReplayWaiter(session, userReplayFrame('real-replay', text))
+    await expect(dispatched).resolves.toMatchObject({
+      providerIdentity: { uuid: 'real-replay' }
+    })
+  })
+
   // The waiter queue is positional, so shifting the head on a send failure
   // resolves whichever dispatch happens to be first - reporting a delivered
   // message as unconfirmed while the send that actually failed keeps waiting.

--- a/src/main/claude/claude-structured-dispatch.test.ts
+++ b/src/main/claude/claude-structured-dispatch.test.ts
@@ -230,13 +230,17 @@ describe('Claude structured dispatch image limits', () => {
       const path = join(directory, 'shot.png')
       await writeFile(path, Buffer.alloc(64))
       const session = sessionFor()
+      // Real file I/O runs before the ack timer starts, so give this one room:
+      // a 100ms budget can expire under parallel load before the frame arrives.
       const dispatched = dispatchClaudeTurn(
         session,
         { clientMessageId: 'client-1', body: userMessage([{ type: 'image-ref', path }]) },
-        100
+        5_000
       )
       await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
 
+      // Deliberately UNSTAMPED: `isReplay` would short-circuit the gate and leave
+      // the content branch this test exists for untested.
       resolveClaudeReplayWaiter(session, {
         type: 'user',
         message: {
@@ -247,8 +251,7 @@ describe('Claude structured dispatch image limits', () => {
         },
         parent_tool_use_id: null,
         session_id: 'provider-session',
-        uuid: 'image-replay-uuid',
-        isReplay: true
+        uuid: 'image-replay-uuid'
       })
 
       await expect(dispatched).resolves.toMatchObject({

--- a/src/main/claude/claude-structured-dispatch.test.ts
+++ b/src/main/claude/claude-structured-dispatch.test.ts
@@ -260,6 +260,39 @@ describe('Claude structured dispatch image limits', () => {
     })
   })
 
+  // Captured from claude 2.1.237: the model-switch breadcrumb is enqueued as
+  // `{type:'user', parent_tool_use_id:null, isReplay:true}` with STRING content.
+  // Orca triggers it itself from the model picker, and the CLI's own
+  // RemoteSessionManager filters the same frames by content prefix.
+  it('does not adopt a model-switch breadcrumb even though it is stamped', async () => {
+    const session = sessionFor()
+    const dispatched = dispatchClaudeTurn(
+      session,
+      { clientMessageId: 'client-1', body: userMessage([{ type: 'text', text: 'queued' }]) },
+      ACK_BUDGET_MS
+    )
+    await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
+
+    resolveClaudeReplayWaiter(session, {
+      type: 'user',
+      message: {
+        role: 'user',
+        content: '<local-command-stdout>Set model to Sonnet</local-command-stdout>'
+      },
+      parent_tool_use_id: null,
+      session_id: 'provider-session',
+      uuid: 'breadcrumb-uuid',
+      isReplay: true
+    })
+    expect(session.dispatchWaiters).toHaveLength(1)
+
+    resolveClaudeReplayWaiter(session, userReplayFrame('user-replay-uuid', 'queued'))
+    await expect(dispatched).resolves.toMatchObject({
+      state: 'accepted',
+      providerIdentity: { uuid: 'user-replay-uuid' }
+    })
+  })
+
   // The waiter queue is positional, so shifting the head on a send failure
   // resolves whichever dispatch happens to be first - reporting a delivered
   // message as unconfirmed while the send that actually failed keeps waiting.
@@ -287,6 +320,26 @@ describe('Claude structured dispatch image limits', () => {
     await expect(first).resolves.toMatchObject({
       state: 'accepted',
       providerIdentity: { uuid: 'replay-one' }
+    })
+  })
+
+  // A write can reach Claude and still reject on the following flush.
+  it('keeps an identity the replay already claimed when the send then rejects', async () => {
+    const session = sessionFor()
+    session.connection.send = vi.fn().mockImplementation(async () => {
+      resolveClaudeReplayWaiter(session, userReplayFrame('landed-anyway', 'hello'))
+      throw new Error('flush failed')
+    })
+
+    await expect(
+      dispatchClaudeTurn(
+        session,
+        { clientMessageId: 'client-1', body: userMessage([{ type: 'text', text: 'hello' }]) },
+        ACK_BUDGET_MS
+      )
+    ).resolves.toMatchObject({
+      state: 'accepted',
+      providerIdentity: { uuid: 'landed-anyway' }
     })
   })
 

--- a/src/main/claude/claude-structured-dispatch.test.ts
+++ b/src/main/claude/claude-structured-dispatch.test.ts
@@ -161,73 +161,10 @@ describe('Claude structured dispatch image limits', () => {
     })
   })
 
-  // Once this CLI is seen stamping the marker, the injected-turn allowlist must
-  // stop being load-bearing: an unrecognized injected shape would otherwise still
-  // steal the identity.
-  it('stops trusting frame shape once the CLI is seen stamping isReplay', async () => {
-    const session = sessionFor()
-    const first = dispatchClaudeTurn(
-      session,
-      { clientMessageId: 'client-1', body: userMessage([{ type: 'text', text: 'one' }]) },
-      ACK_BUDGET_MS
-    )
-    await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
-    resolveClaudeReplayWaiter(session, userReplayFrame('replay-one', 'one'))
-    await expect(first).resolves.toMatchObject({ state: 'accepted' })
-
-    const second = dispatchClaudeTurn(
-      session,
-      { clientMessageId: 'client-2', body: userMessage([{ type: 'text', text: 'two' }]) },
-      ACK_BUDGET_MS
-    )
-    await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
-
-    // An injected shape nobody has enumerated yet, so the allowlist would pass it.
-    resolveClaudeReplayWaiter(session, {
-      type: 'user',
-      message: { role: 'user', content: [{ type: 'text', text: '<some-new-notice>hi' }] },
-      parent_tool_use_id: null,
-      session_id: 'provider-session',
-      uuid: 'unknown-injected-uuid'
-    })
-    expect(session.dispatchWaiters).toHaveLength(1)
-
-    resolveClaudeReplayWaiter(session, userReplayFrame('replay-two', 'two'))
-    await expect(second).resolves.toMatchObject({
-      state: 'accepted',
-      providerIdentity: { uuid: 'replay-two' }
-    })
-  })
-
-  // `readClaudeMessageEnvelope` already tolerates string content, so refusing it
-  // here would be a new way for a send to never be acknowledged.
-  it('accepts a replay whose content is a plain string', async () => {
-    const session = sessionFor()
-    const dispatched = dispatchClaudeTurn(
-      session,
-      { clientMessageId: 'client-1', body: userMessage([{ type: 'text', text: 'hello' }]) },
-      ACK_BUDGET_MS
-    )
-    await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
-
-    resolveClaudeReplayWaiter(session, {
-      type: 'user',
-      message: { role: 'user', content: 'hello' },
-      parent_tool_use_id: null,
-      session_id: 'provider-session',
-      uuid: 'string-replay-uuid'
-    })
-
-    await expect(dispatched).resolves.toMatchObject({
-      state: 'accepted',
-      providerIdentity: { uuid: 'string-replay-uuid' }
-    })
-  })
-
-  // Dispatch base64-encodes a local image path, and `claudeMessageBody` models
-  // only text and URL images - so gating the waiter on "the translator would
-  // build a body" refuses an image-only send its own replay, times out, and
-  // reports a delivered message as unconfirmed (retry then sends it twice).
+  // Measured: the CLI stamps an image-only echo like any other, and its content
+  // carries no text. A gate that sniffed content for a modeled body would refuse
+  // this send its own replay, time out, and report a delivered message as
+  // unconfirmed - which sends it twice on retry.
   it('accepts the replay of a send that carries only a local image', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'orca-claude-replay-'))
     try {
@@ -241,8 +178,6 @@ describe('Claude structured dispatch image limits', () => {
       )
       await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
 
-      // Deliberately UNSTAMPED: `isReplay` would short-circuit the gate and leave
-      // the content branch this test exists for untested.
       resolveClaudeReplayWaiter(session, {
         type: 'user',
         message: {
@@ -253,7 +188,8 @@ describe('Claude structured dispatch image limits', () => {
         },
         parent_tool_use_id: null,
         session_id: 'provider-session',
-        uuid: 'image-replay-uuid'
+        uuid: 'image-replay-uuid',
+        isReplay: true
       })
 
       await expect(dispatched).resolves.toMatchObject({

--- a/src/main/claude/claude-structured-dispatch.test.ts
+++ b/src/main/claude/claude-structured-dispatch.test.ts
@@ -128,6 +128,60 @@ describe('Claude structured dispatch image limits', () => {
     })
   })
 
+  // An injected turn is the worse half of this class: unlike a tool result it
+  // DOES build a journal body, so adopting its uuid upserts harness text over the
+  // user's own bubble AND leaves the real replay to append as a second row.
+  it('does not adopt a harness-injected user turn as the user replay', async () => {
+    const session = sessionFor()
+    const dispatched = dispatchClaudeTurn(
+      session,
+      { clientMessageId: 'client-1', body: userMessage([{ type: 'text', text: 'queued' }]) },
+      100
+    )
+    await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
+
+    resolveClaudeReplayWaiter(session, {
+      type: 'user',
+      message: { role: 'user', content: [{ type: 'text', text: '[Request interrupted by user]' }] },
+      parent_tool_use_id: null,
+      session_id: 'provider-session',
+      uuid: 'injected-uuid'
+    })
+    expect(session.dispatchWaiters).toHaveLength(1)
+
+    resolveClaudeReplayWaiter(session, userReplayFrame('user-replay-uuid', 'queued'))
+
+    await expect(dispatched).resolves.toMatchObject({
+      state: 'accepted',
+      providerIdentity: { uuid: 'user-replay-uuid' }
+    })
+  })
+
+  // `readClaudeMessageEnvelope` already tolerates string content, so refusing it
+  // here would be a new way for a send to never be acknowledged.
+  it('accepts a replay whose content is a plain string', async () => {
+    const session = sessionFor()
+    const dispatched = dispatchClaudeTurn(
+      session,
+      { clientMessageId: 'client-1', body: userMessage([{ type: 'text', text: 'hello' }]) },
+      100
+    )
+    await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
+
+    resolveClaudeReplayWaiter(session, {
+      type: 'user',
+      message: { role: 'user', content: 'hello' },
+      parent_tool_use_id: null,
+      session_id: 'provider-session',
+      uuid: 'string-replay-uuid'
+    })
+
+    await expect(dispatched).resolves.toMatchObject({
+      state: 'accepted',
+      providerIdentity: { uuid: 'string-replay-uuid' }
+    })
+  })
+
   // Dispatch base64-encodes a local image path, and `claudeMessageBody` models
   // only text and URL images - so gating the waiter on "the translator would
   // build a body" refuses an image-only send its own replay, times out, and

--- a/src/main/claude/claude-structured-dispatch.test.ts
+++ b/src/main/claude/claude-structured-dispatch.test.ts
@@ -293,6 +293,55 @@ describe('Claude structured dispatch image limits', () => {
     })
   })
 
+  // The CLI round-trips a client-supplied uuid on the replay (measured), so a
+  // dispatch can be matched to its OWN echo instead of to whatever is at the
+  // head of the queue.
+  it('stamps a uuid on the outgoing frame', async () => {
+    const session = sessionFor()
+    void dispatchClaudeTurn(
+      session,
+      { clientMessageId: 'client-1', body: userMessage([{ type: 'text', text: 'hello' }]) },
+      ACK_BUDGET_MS
+    )
+    await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
+
+    expect(session.connection.send).toHaveBeenCalledWith(
+      expect.objectContaining({ uuid: session.dispatchWaiters[0]!.sentUuid })
+    )
+  })
+
+  it('settles the dispatch whose uuid was echoed, not the queue head', async () => {
+    const session = sessionFor()
+    const first = dispatchClaudeTurn(
+      session,
+      { clientMessageId: 'client-1', body: userMessage([{ type: 'text', text: 'one' }]) },
+      ACK_BUDGET_MS
+    )
+    await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
+    const second = dispatchClaudeTurn(
+      session,
+      { clientMessageId: 'client-2', body: userMessage([{ type: 'text', text: 'two' }]) },
+      ACK_BUDGET_MS
+    )
+    await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(2))
+    const firstUuid = session.dispatchWaiters[0]!.sentUuid
+    const secondUuid = session.dispatchWaiters[1]!.sentUuid
+
+    // Out of order: the second send's echo arrives while the first is still head.
+    resolveClaudeReplayWaiter(session, userReplayFrame(secondUuid, 'two'))
+    await expect(second).resolves.toMatchObject({
+      state: 'accepted',
+      providerIdentity: { uuid: secondUuid }
+    })
+    expect(session.dispatchWaiters.map((waiter) => waiter.sentUuid)).toEqual([firstUuid])
+
+    resolveClaudeReplayWaiter(session, userReplayFrame(firstUuid, 'one'))
+    await expect(first).resolves.toMatchObject({
+      state: 'accepted',
+      providerIdentity: { uuid: firstUuid }
+    })
+  })
+
   // The waiter queue is positional, so shifting the head on a send failure
   // resolves whichever dispatch happens to be first - reporting a delivered
   // message as unconfirmed while the send that actually failed keeps waiting.

--- a/src/main/claude/claude-structured-dispatch.test.ts
+++ b/src/main/claude/claude-structured-dispatch.test.ts
@@ -157,6 +157,44 @@ describe('Claude structured dispatch image limits', () => {
     })
   })
 
+  // Once this CLI is seen stamping the marker, the injected-turn allowlist must
+  // stop being load-bearing: an unrecognized injected shape would otherwise still
+  // steal the identity.
+  it('stops trusting frame shape once the CLI is seen stamping isReplay', async () => {
+    const session = sessionFor()
+    const first = dispatchClaudeTurn(
+      session,
+      { clientMessageId: 'client-1', body: userMessage([{ type: 'text', text: 'one' }]) },
+      100
+    )
+    await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
+    resolveClaudeReplayWaiter(session, userReplayFrame('replay-one', 'one'))
+    await expect(first).resolves.toMatchObject({ state: 'accepted' })
+
+    const second = dispatchClaudeTurn(
+      session,
+      { clientMessageId: 'client-2', body: userMessage([{ type: 'text', text: 'two' }]) },
+      100
+    )
+    await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
+
+    // An injected shape nobody has enumerated yet, so the allowlist would pass it.
+    resolveClaudeReplayWaiter(session, {
+      type: 'user',
+      message: { role: 'user', content: [{ type: 'text', text: '<some-new-notice>hi' }] },
+      parent_tool_use_id: null,
+      session_id: 'provider-session',
+      uuid: 'unknown-injected-uuid'
+    })
+    expect(session.dispatchWaiters).toHaveLength(1)
+
+    resolveClaudeReplayWaiter(session, userReplayFrame('replay-two', 'two'))
+    await expect(second).resolves.toMatchObject({
+      state: 'accepted',
+      providerIdentity: { uuid: 'replay-two' }
+    })
+  })
+
   // `readClaudeMessageEnvelope` already tolerates string content, so refusing it
   // here would be a new way for a send to never be acknowledged.
   it('accepts a replay whose content is a plain string', async () => {

--- a/src/main/claude/claude-structured-dispatch.test.ts
+++ b/src/main/claude/claude-structured-dispatch.test.ts
@@ -161,10 +161,10 @@ describe('Claude structured dispatch image limits', () => {
     })
   })
 
-  // Measured: the CLI stamps an image-only echo like any other, and its content
-  // carries no text. A gate that sniffed content for a modeled body would refuse
-  // this send its own replay, time out, and report a delivered message as
-  // unconfirmed - which sends it twice on retry.
+  // NOT red against the merge base - the old predicate accepts this frame too.
+  // It pins that the gate never sniffs content: an image-only echo carries no
+  // text and builds no journal body, so any body-model gate would refuse this
+  // send its own replay and report a delivered message as unconfirmed.
   it('accepts the replay of a send that carries only a local image', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'orca-claude-replay-'))
     try {
@@ -199,6 +199,39 @@ describe('Claude structured dispatch image limits', () => {
     } finally {
       await rm(directory, { recursive: true, force: true })
     }
+  })
+
+  // `acceptsResult` settles a send on a bare `result` frame, which carries no
+  // correlation to the waiting dispatch - so a message that merely opens with a
+  // path must not opt into it, or an unrelated turn's result claims its identity.
+  it('does not let a path-leading message settle on an unrelated result frame', async () => {
+    const session = sessionFor()
+    const dispatched = dispatchClaudeTurn(
+      session,
+      {
+        clientMessageId: 'client-1',
+        body: userMessage([{ type: 'text', text: '/Users/me/repo/src/foo.ts - explain this' }])
+      },
+      ACK_BUDGET_MS
+    )
+    await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
+
+    resolveClaudeReplayWaiter(session, {
+      type: 'result',
+      subtype: 'success',
+      session_id: 'provider-session',
+      uuid: 'unrelated-turn-result'
+    })
+    expect(session.dispatchWaiters).toHaveLength(1)
+
+    resolveClaudeReplayWaiter(
+      session,
+      userReplayFrame('real-replay', '/Users/me/repo/src/foo.ts - explain this')
+    )
+    await expect(dispatched).resolves.toMatchObject({
+      state: 'accepted',
+      providerIdentity: { uuid: 'real-replay' }
+    })
   })
 
   // The waiter queue is positional, so shifting the head on a send failure

--- a/src/main/claude/claude-structured-dispatch.ts
+++ b/src/main/claude/claude-structured-dispatch.ts
@@ -5,7 +5,7 @@ import type { NativeChatBlock } from '../../shared/native-chat-types'
 import type { AgentSessionDispatchOutcome } from '../native-chat/agent-session-wire/structured-agent-session-adapter'
 import type { ClaudeSession } from './claude-structured-session-state'
 import { readClaudeFrameString } from './claude-structured-init-proof'
-import { claudeMessageBody, readClaudeMessageEnvelope } from './claude-structured-item-translation'
+import { claudeRecord } from './claude-structured-item-translation'
 
 const MAX_IMAGE_BYTES = 5 * 1024 * 1024
 const MAX_IMAGE_COUNT = 20
@@ -61,16 +61,27 @@ const IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
  * claims — the user's message then renders twice, once from the submission row
  * and once from the replay.
  *
- * Gate on the same body the journal translator builds, so the identity dispatch
- * adopts is always the one the echo upserts into. A frame we cannot recognize
- * leaves the send `unknown` ("delivery unconfirmed"), never duplicated.
+ * Measured against the real CLI: a queued send's replay is published at the first
+ * tool boundary after it is queued, 2-3 ms AFTER that boundary's tool result. So
+ * rejecting tool results costs no time — whenever there was a frame to adopt, the
+ * right one follows immediately.
+ *
+ * Reject on the tool-result shape rather than on "the journal translator would
+ * build a body from this": `claudeMessageBody` models only text and URL images,
+ * so an image-only send (dispatch base64-encodes local paths) has no modeled
+ * block and would be refused its own replay, timing out into a false
+ * "delivery unconfirmed" that invites a genuine duplicate send on retry.
  */
 function isClaudeUserMessageReplay(message: Record<string, unknown>): boolean {
   if (message.type !== 'user' || message.parent_tool_use_id !== null) {
     return false
   }
-  const envelope = readClaudeMessageEnvelope(message)
-  return envelope?.role === 'user' && claudeMessageBody(envelope) !== null
+  const content = claudeRecord(message.message)?.content
+  return (
+    Array.isArray(content) &&
+    content.length > 0 &&
+    !content.some((part) => claudeRecord(part)?.type === 'tool_result')
+  )
 }
 
 export function resolveClaudeReplayWaiter(

--- a/src/main/claude/claude-structured-dispatch.ts
+++ b/src/main/claude/claude-structured-dispatch.ts
@@ -128,6 +128,12 @@ export function resolveClaudeReplayWaiter(
     settleWaiter(session, owner, uuid)
     return
   }
+  // A replay for a dispatch that already gave up belongs to nobody. Dropping it
+  // here is what keeps the compat path below from handing it to the head, which
+  // would upsert the dead send's text over a live one's bubble.
+  if (session.retiredSentUuids?.includes(uuid)) {
+    return
+  }
   // Compat path for a CLI that mints its own uuid instead of echoing ours. The
   // frame then carries no correlation at all, so the head is the only candidate
   // and the shape gates have to carry the weight.
@@ -194,11 +200,24 @@ async function messageContent(body: AgentJournalMessageItem): Promise<unknown[]>
   return content
 }
 
+/** Enough to cover the replays still in flight for sends that gave up; the list
+ *  only grows when a dispatch leaves without its echo. */
+const RETIRED_UUID_MEMORY = 64
+
 function dropWaiter(session: ClaudeSession, waiter: ClaudeDispatchWaiter): void {
   const index = session.dispatchWaiters.indexOf(waiter)
   if (index !== -1) {
     session.dispatchWaiters.splice(index, 1)
   }
+}
+
+/** Remember a dispatch that left without its echo, so the echo cannot later be
+ *  mistaken for somebody else's on the compat path. */
+function retireWaiter(session: ClaudeSession, waiter: ClaudeDispatchWaiter): void {
+  dropWaiter(session, waiter)
+  const retired = session.retiredSentUuids ?? []
+  retired.push(waiter.sentUuid)
+  session.retiredSentUuids = retired.slice(-RETIRED_UUID_MEMORY)
 }
 
 /** Arms a waiter and hands it back, so a failure can retire ITS OWN waiter — the
@@ -217,7 +236,7 @@ function waitForReplay(
       sentUuid,
       resolve,
       timer: setTimeout(() => {
-        dropWaiter(session, waiter)
+        retireWaiter(session, waiter)
         resolve(null)
       }, timeoutMs)
     }
@@ -302,7 +321,7 @@ export async function dispatchClaudeTurn(
         }
       }
     }
-    dropWaiter(session, waiter)
+    retireWaiter(session, waiter)
     clearTimeout(waiter.timer)
     waiter.resolve(null)
     return { state: 'unknown', reason: (error as Error).message }

--- a/src/main/claude/claude-structured-dispatch.ts
+++ b/src/main/claude/claude-structured-dispatch.ts
@@ -185,6 +185,24 @@ function waitForReplay(
   return { waiter, replayed }
 }
 
+/**
+ * A slash command, not a message that merely opens with a path.
+ *
+ * `acceptsResult` lets a send settle on a bare `result` frame, which carries no
+ * correlation to the dispatch that is waiting - so a false positive lets an
+ * unrelated turn's result claim the send's identity, and the real echo then
+ * appends a second row. `/Users/me/repo/foo.ts - explain this` is an ordinary
+ * message; the second slash is what gives it away.
+ */
+function isSlashCommandText(text: string): boolean {
+  const trimmed = text.trimStart()
+  if (!trimmed.startsWith('/')) {
+    return false
+  }
+  const token = trimmed.slice(1).split(/\s/, 1)[0] ?? ''
+  return token.length > 0 && !token.includes('/')
+}
+
 export async function dispatchClaudeTurn(
   session: ClaudeSession,
   input: { clientMessageId: string; body: AgentJournalMessageItem },
@@ -197,7 +215,7 @@ export async function dispatchClaudeTurn(
     return { state: 'rejected', reason: (error as Error).message }
   }
   const acceptsResult = input.body.blocks.some(
-    (block) => block.type === 'text' && block.text.trimStart().startsWith('/')
+    (block) => block.type === 'text' && isSlashCommandText(block.text)
   )
   const { waiter, replayed } = waitForReplay(session, timeoutMs, acceptsResult)
   try {

--- a/src/main/claude/claude-structured-dispatch.ts
+++ b/src/main/claude/claude-structured-dispatch.ts
@@ -78,36 +78,11 @@ function isClaudeUserMessageReplay(message: Record<string, unknown>): boolean {
   return message.type === 'user' && message.parent_tool_use_id === null && message.isReplay === true
 }
 
-let warnedAboutMissingReplayMarker = false
-
-/** A CLI that echoes without the marker cannot be told apart at runtime from a
- *  turn that simply had no boundary inside the ack budget: both just report
- *  "delivery unconfirmed". Say it once so the cause is diagnosable. */
-function warnIfEchoLacksReplayMarker(message: Record<string, unknown>): void {
-  if (
-    warnedAboutMissingReplayMarker ||
-    message.type !== 'user' ||
-    message.parent_tool_use_id !== null ||
-    message.isReplay !== undefined ||
-    message.tool_use_result !== undefined
-  ) {
-    return
-  }
-  warnedAboutMissingReplayMarker = true
-  console.warn(
-    '[claude-structured] user frame arrived without isReplay while a send was waiting; ' +
-      'sends will report delivery unconfirmed until the CLI stamps the marker'
-  )
-}
-
 export function resolveClaudeReplayWaiter(
   session: ClaudeSession,
   message: Record<string, unknown>
 ): void {
   const isUserReplay = isClaudeUserMessageReplay(message)
-  if (!isUserReplay && session.dispatchWaiters.length > 0) {
-    warnIfEchoLacksReplayMarker(message)
-  }
   const isCompletedCommand = message.type === 'result'
   if (
     (!isUserReplay && !isCompletedCommand) ||

--- a/src/main/claude/claude-structured-dispatch.ts
+++ b/src/main/claude/claude-structured-dispatch.ts
@@ -4,7 +4,9 @@ import type { AgentJournalMessageItem } from '../../shared/agent-session-journal
 import type { NativeChatBlock } from '../../shared/native-chat-types'
 import type { AgentSessionDispatchOutcome } from '../native-chat/agent-session-wire/structured-agent-session-adapter'
 import type { ClaudeDispatchWaiter, ClaudeSession } from './claude-structured-session-state'
+import { isKnownHarnessInjectedUserTurnText } from '../../shared/harness-injected-user-turns'
 import { readClaudeFrameString } from './claude-structured-init-proof'
+import { claudeRecord } from './claude-structured-item-translation'
 
 const MAX_IMAGE_BYTES = 5 * 1024 * 1024
 const MAX_IMAGE_COUNT = 20
@@ -50,32 +52,53 @@ const IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
   '.webp': 'image/webp'
 }
 
+/** Leading text of a top-level user frame, for harness classification. The CLI
+ *  serializes an injected breadcrumb's content as a plain string and a typed
+ *  echo's as a block array, so both shapes have to be read. */
+function claudeUserFrameText(message: Record<string, unknown>): string {
+  const content = claudeRecord(message.message)?.content
+  if (typeof content === 'string') {
+    return content
+  }
+  if (!Array.isArray(content)) {
+    return ''
+  }
+  return content
+    .map((part) => {
+      const text = claudeRecord(part)?.text
+      return typeof text === 'string' ? text : ''
+    })
+    .join('\n')
+}
+
 /**
  * The frame that carries the user's own message back.
  *
- * `type: 'user'` with a null `parent_tool_use_id` is not enough on its own:
- * Claude publishes tool results and harness-injected turns (interruption
- * notices, system reminders, local-command output) in the same shape. Adopting
- * one leaves the real replay to land under an identity nothing claims, so the
- * user's message renders twice - and an injected turn is worse than a tool
- * result, because it DOES build a body and upserts over the user's own bubble.
+ * `type: 'user'` with a null `parent_tool_use_id` is not enough: Claude
+ * publishes tool results and harness-injected turns in the same shape. Adopting
+ * one leaves the real replay under an identity nothing claims, so the user's
+ * message renders twice - and an injected turn is worse than a tool result,
+ * because it can build a body and upsert over the user's own bubble.
  *
- * `CLAUDE_STRUCTURED_BASE_ARGS` always passes `--replay-user-messages`, and the
- * CLI stamps `isReplay` on every echo it publishes in reply - measured for text,
- * image-only and text+image sends. So the marker is the whole test: no content
- * sniffing, and nothing here depends on the injected-turn list that
- * prompt-derived UI maintains for its own reasons.
+ * `isReplay` is necessary but NOT sufficient. Claude stamps it on its own
+ * injected breadcrumbs too: 2.1.237 enqueues the model-switch notice as
+ * `{type:'user', parent_tool_use_id:null, isReplay:true}` whose content is the
+ * string `<local-command-stdout>Set model to ...`. Orca triggers that path
+ * itself from the model picker (`setClaudeStructuredOption` sends `set_model`,
+ * and reconnect replays it). The CLI's own RemoteSessionManager cannot use the
+ * marker alone either - it filters the same frames by content prefix, logging
+ * "Dropped own set_model breadcrumb echo".
  *
- * A slash command may get no user echo at all; `acceptsResult` settles those on
- * the command's result receipt instead.
- *
- * Measured against the real CLI: a queued send's replay is published at the
- * first tool boundary after it is queued, 2-3 ms AFTER that boundary's tool
- * result. So rejecting tool results costs no time - whenever there was a frame
- * to adopt, the right one follows immediately.
+ * So: require the marker, then reject the harness shapes. The residual is a
+ * genuine echo whose own text opens with a harness tag (a user pasting a
+ * transcript excerpt), which is rarer than a model switch and fails the safe
+ * way - `unknown`, not a corrupted bubble.
  */
 function isClaudeUserMessageReplay(message: Record<string, unknown>): boolean {
-  return message.type === 'user' && message.parent_tool_use_id === null && message.isReplay === true
+  if (message.type !== 'user' || message.parent_tool_use_id !== null || message.isReplay !== true) {
+    return false
+  }
+  return !isKnownHarnessInjectedUserTurnText(claudeUserFrameText(message))
 }
 
 export function resolveClaudeReplayWaiter(
@@ -239,6 +262,22 @@ export async function dispatchClaudeTurn(
       session_id: session.providerSessionId
     })
   } catch (error) {
+    // A write can reach Claude and still reject on the flush that follows, so the
+    // replay may already have claimed this waiter. Reporting `unknown` then
+    // strands an identity nothing else can adopt, and the echo duplicates.
+    if (!session.dispatchWaiters.includes(waiter)) {
+      const settled = await replayed
+      if (settled) {
+        return {
+          state: 'accepted',
+          providerIdentity: {
+            provider: 'claude',
+            sessionId: session.providerSessionId,
+            uuid: settled
+          }
+        }
+      }
+    }
     dropWaiter(session, waiter)
     clearTimeout(waiter.timer)
     waiter.resolve(null)

--- a/src/main/claude/claude-structured-dispatch.ts
+++ b/src/main/claude/claude-structured-dispatch.ts
@@ -53,9 +53,10 @@ const IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
 }
 
 /** Text of a top-level user frame, or null when it is a tool-result turn (or
- *  carries nothing). `content` may be a plain string - a shape
- *  `readClaudeMessageEnvelope` already tolerates. An image-only echo has no text
- *  and correctly yields ''. */
+ *  carries nothing). A plain-string `content` is accepted so a CLI that sends the
+ *  simpler shape can still settle its send - note the translator models only the
+ *  array form, so such an echo settles the dispatch without upserting a body, the
+ *  same way an image-only echo does. An image-only echo has no text, yielding ''. */
 function claudeUserFrameText(content: unknown): string | null {
   if (typeof content === 'string') {
     return content
@@ -82,21 +83,31 @@ function claudeUserFrameText(content: unknown): string | null {
  * bubble.
  *
  * `--replay-user-messages` stamps `isReplay` on the genuine echo, so trust that
- * when it is there. The shape test is the fallback for a CLI that omits it:
- * without one, a send that is never acknowledged times out into a false
- * "delivery unconfirmed", and retrying it sends the message to Claude twice.
+ * when it is there. The shape test is only a fallback for a CLI that omits the
+ * marker, and it stays off once this session has seen one: the launch args always
+ * request replays, so after that a frame without the marker is by construction not
+ * the echo, and the hand-maintained injected-turn list must not be load-bearing.
+ * Without any fallback, a CLI that never stamps it would leave every send timing
+ * out into a false "delivery unconfirmed", and retrying sends the message twice.
  *
  * Measured against the real CLI: a queued send's replay is published at the
  * first tool boundary after it is queued, 2-3 ms AFTER that boundary's tool
  * result. So rejecting tool results costs no time - whenever there was a frame
  * to adopt, the right one follows immediately.
  */
-function isClaudeUserMessageReplay(message: Record<string, unknown>): boolean {
+function isClaudeUserMessageReplay(
+  session: ClaudeSession,
+  message: Record<string, unknown>
+): boolean {
   if (message.type !== 'user' || message.parent_tool_use_id !== null) {
     return false
   }
   if (message.isReplay === true) {
+    session.sawUserReplayMarker = true
     return true
+  }
+  if (session.sawUserReplayMarker) {
+    return false
   }
   const text = claudeUserFrameText(claudeRecord(message.message)?.content)
   return text !== null && !isKnownHarnessInjectedUserTurnText(text)
@@ -106,7 +117,7 @@ export function resolveClaudeReplayWaiter(
   session: ClaudeSession,
   message: Record<string, unknown>
 ): void {
-  const isUserReplay = isClaudeUserMessageReplay(message)
+  const isUserReplay = isClaudeUserMessageReplay(session, message)
   const isCompletedCommand = message.type === 'result'
   if (
     (!isUserReplay && !isCompletedCommand) ||

--- a/src/main/claude/claude-structured-dispatch.ts
+++ b/src/main/claude/claude-structured-dispatch.ts
@@ -5,6 +5,7 @@ import type { NativeChatBlock } from '../../shared/native-chat-types'
 import type { AgentSessionDispatchOutcome } from '../native-chat/agent-session-wire/structured-agent-session-adapter'
 import type { ClaudeSession } from './claude-structured-session-state'
 import { readClaudeFrameString } from './claude-structured-init-proof'
+import { claudeMessageBody, readClaudeMessageEnvelope } from './claude-structured-item-translation'
 
 const MAX_IMAGE_BYTES = 5 * 1024 * 1024
 const MAX_IMAGE_COUNT = 20
@@ -50,11 +51,33 @@ const IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
   '.webp': 'image/webp'
 }
 
+/**
+ * The frame that carries the user's own message back.
+ *
+ * Claude publishes a top-level `user` turn for tool results too, with the same
+ * null `parent_tool_use_id`, so "any user turn" adopts whichever arrives first.
+ * A send issued mid-turn is dispatched while tools are running, and adopting a
+ * tool-result uuid leaves the real replay to land under an identity nothing
+ * claims — the user's message then renders twice, once from the submission row
+ * and once from the replay.
+ *
+ * Gate on the same body the journal translator builds, so the identity dispatch
+ * adopts is always the one the echo upserts into. A frame we cannot recognize
+ * leaves the send `unknown` ("delivery unconfirmed"), never duplicated.
+ */
+function isClaudeUserMessageReplay(message: Record<string, unknown>): boolean {
+  if (message.type !== 'user' || message.parent_tool_use_id !== null) {
+    return false
+  }
+  const envelope = readClaudeMessageEnvelope(message)
+  return envelope?.role === 'user' && claudeMessageBody(envelope) !== null
+}
+
 export function resolveClaudeReplayWaiter(
   session: ClaudeSession,
   message: Record<string, unknown>
 ): void {
-  const isUserReplay = message.type === 'user' && message.parent_tool_use_id === null
+  const isUserReplay = isClaudeUserMessageReplay(message)
   const isCompletedCommand = message.type === 'result'
   if (
     (!isUserReplay && !isCompletedCommand) ||

--- a/src/main/claude/claude-structured-dispatch.ts
+++ b/src/main/claude/claude-structured-dispatch.ts
@@ -5,6 +5,7 @@ import type { NativeChatBlock } from '../../shared/native-chat-types'
 import type { AgentSessionDispatchOutcome } from '../native-chat/agent-session-wire/structured-agent-session-adapter'
 import type { ClaudeSession } from './claude-structured-session-state'
 import { readClaudeFrameString } from './claude-structured-init-proof'
+import { isKnownHarnessInjectedUserTurnText } from '../../shared/harness-injected-user-turns'
 import { claudeRecord } from './claude-structured-item-translation'
 
 const MAX_IMAGE_BYTES = 5 * 1024 * 1024
@@ -51,37 +52,54 @@ const IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
   '.webp': 'image/webp'
 }
 
+/** Text of a top-level user frame, or null when it is a tool-result turn (or
+ *  carries nothing). `content` may be a plain string - a shape
+ *  `readClaudeMessageEnvelope` already tolerates. An image-only echo has no text
+ *  and correctly yields ''. */
+function claudeUserFrameText(content: unknown): string | null {
+  if (typeof content === 'string') {
+    return content
+  }
+  if (!Array.isArray(content) || content.length === 0) {
+    return null
+  }
+  const parts = content.map((part) => claudeRecord(part))
+  if (parts.some((part) => part?.type === 'tool_result')) {
+    return null
+  }
+  return parts.map((part) => (typeof part?.text === 'string' ? part.text : '')).join('\n')
+}
+
 /**
  * The frame that carries the user's own message back.
  *
- * Claude publishes a top-level `user` turn for tool results too, with the same
- * null `parent_tool_use_id`, so "any user turn" adopts whichever arrives first.
- * A send issued mid-turn is dispatched while tools are running, and adopting a
- * tool-result uuid leaves the real replay to land under an identity nothing
- * claims — the user's message then renders twice, once from the submission row
- * and once from the replay.
+ * `type: 'user'` with a null `parent_tool_use_id` is not enough on its own:
+ * Claude publishes tool results and harness-injected turns (interruption
+ * notices, system reminders, local-command output) in the same shape. Adopting
+ * one of those leaves the real replay to land under an identity nothing claims,
+ * so the user's message renders twice - and an injected turn is worse than a
+ * tool result, because it DOES build a body and upserts over the user's own
+ * bubble.
  *
- * Measured against the real CLI: a queued send's replay is published at the first
- * tool boundary after it is queued, 2-3 ms AFTER that boundary's tool result. So
- * rejecting tool results costs no time — whenever there was a frame to adopt, the
- * right one follows immediately.
+ * `--replay-user-messages` stamps `isReplay` on the genuine echo, so trust that
+ * when it is there. The shape test is the fallback for a CLI that omits it:
+ * without one, a send that is never acknowledged times out into a false
+ * "delivery unconfirmed", and retrying it sends the message to Claude twice.
  *
- * Reject on the tool-result shape rather than on "the journal translator would
- * build a body from this": `claudeMessageBody` models only text and URL images,
- * so an image-only send (dispatch base64-encodes local paths) has no modeled
- * block and would be refused its own replay, timing out into a false
- * "delivery unconfirmed" that invites a genuine duplicate send on retry.
+ * Measured against the real CLI: a queued send's replay is published at the
+ * first tool boundary after it is queued, 2-3 ms AFTER that boundary's tool
+ * result. So rejecting tool results costs no time - whenever there was a frame
+ * to adopt, the right one follows immediately.
  */
 function isClaudeUserMessageReplay(message: Record<string, unknown>): boolean {
   if (message.type !== 'user' || message.parent_tool_use_id !== null) {
     return false
   }
-  const content = claudeRecord(message.message)?.content
-  return (
-    Array.isArray(content) &&
-    content.length > 0 &&
-    !content.some((part) => claudeRecord(part)?.type === 'tool_result')
-  )
+  if (message.isReplay === true) {
+    return true
+  }
+  const text = claudeUserFrameText(claudeRecord(message.message)?.content)
+  return text !== null && !isKnownHarnessInjectedUserTurnText(text)
 }
 
 export function resolveClaudeReplayWaiter(

--- a/src/main/claude/claude-structured-dispatch.ts
+++ b/src/main/claude/claude-structured-dispatch.ts
@@ -199,8 +199,18 @@ const SLASH_COMMAND_TOKEN = /^\/[a-z0-9][\w:-]*$/i
  * treats any `/`-leading token as command-ish: over-classifying is safe there
  * (it only suppresses an echo) and unsafe here.
  *
- * No trimming, matching that classifier's documented rule: the supported TUIs
- * only treat a LINE-LEADING token as a command, so `  /clear` is prose.
+ * No trimming, and MEASURED rather than inherited from the TUI rule: `  /clear`
+ * came back from `claude -p --input-format stream-json` as a stamped replay, so
+ * this lane also reads an indented token as prose.
+ *
+ * Residual, unfixable by shape: `/tmp what is in here?` matches, because `/tmp`
+ * is indistinguishable from `/clear`. The agent's command catalog cannot close
+ * it either - `getVerifiedNativeChatCommands('claude')` is a curated `/` menu
+ * (clear, compact, init, review, help) and omits real built-ins like `/model`
+ * and `/permissions`, both measured as answering with a bare `result` and no
+ * echo; gating on it would strand those sends instead. Measured mitigation: a
+ * path-leading message DOES get a stamped replay, so it only mis-settles if an
+ * unrelated `result` beats that replay.
  */
 function isSlashCommandText(text: string): boolean {
   return SLASH_COMMAND_TOKEN.test(text.split(/\s/, 1)[0] ?? '')

--- a/src/main/claude/claude-structured-dispatch.ts
+++ b/src/main/claude/claude-structured-dispatch.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import { extname } from 'node:path'
 import { open } from 'node:fs/promises'
 import type { AgentJournalMessageItem } from '../../shared/agent-session-journal-types'
@@ -101,28 +102,44 @@ function isClaudeUserMessageReplay(message: Record<string, unknown>): boolean {
   return !isKnownHarnessInjectedUserTurnText(claudeUserFrameText(message))
 }
 
+function settleWaiter(session: ClaudeSession, waiter: ClaudeDispatchWaiter, uuid: string): void {
+  dropWaiter(session, waiter)
+  clearTimeout(waiter.timer)
+  waiter.settledUuid = uuid
+  waiter.resolve(uuid)
+}
+
 export function resolveClaudeReplayWaiter(
   session: ClaudeSession,
   message: Record<string, unknown>
 ): void {
-  const isUserReplay = isClaudeUserMessageReplay(message)
-  const isCompletedCommand = message.type === 'result'
-  if (
-    (!isUserReplay && !isCompletedCommand) ||
-    readClaudeFrameString(message, 'session_id') !== session.providerSessionId
-  ) {
+  if (readClaudeFrameString(message, 'session_id') !== session.providerSessionId) {
     return
   }
   const uuid = readClaudeFrameString(message, 'uuid')
-  const current = session.dispatchWaiters[0]
-  if (isCompletedCommand && !current?.acceptsResult) {
+  if (!uuid) {
     return
   }
-  const waiter = uuid ? session.dispatchWaiters.shift() : undefined
-  if (waiter && uuid) {
-    clearTimeout(waiter.timer)
-    waiter.resolve(uuid)
+  // Exact correlation: the CLI echoes the uuid we stamped on the outgoing frame,
+  // so this replay belongs to that dispatch whatever its queue position - which
+  // is what keeps a late replay from settling somebody else's send.
+  const owner = session.dispatchWaiters.find((candidate) => candidate.sentUuid === uuid)
+  if (owner) {
+    settleWaiter(session, owner, uuid)
+    return
   }
+  // Compat path for a CLI that mints its own uuid instead of echoing ours. The
+  // frame then carries no correlation at all, so the head is the only candidate
+  // and the shape gates have to carry the weight.
+  const isCompletedCommand = message.type === 'result'
+  if (!isClaudeUserMessageReplay(message) && !isCompletedCommand) {
+    return
+  }
+  const head = session.dispatchWaiters[0]
+  if (!head || (isCompletedCommand && !head.acceptsResult)) {
+    return
+  }
+  settleWaiter(session, head, uuid)
 }
 
 async function imageContent(
@@ -190,12 +207,14 @@ function dropWaiter(session: ClaudeSession, waiter: ClaudeDispatchWaiter): void 
 function waitForReplay(
   session: ClaudeSession,
   timeoutMs: number,
-  acceptsResult: boolean
+  acceptsResult: boolean,
+  sentUuid: string
 ): { waiter: ClaudeDispatchWaiter; replayed: Promise<string | null> } {
   let waiter!: ClaudeDispatchWaiter
   const replayed = new Promise<string | null>((resolve) => {
     waiter = {
       acceptsResult,
+      sentUuid,
       resolve,
       timer: setTimeout(() => {
         dropWaiter(session, waiter)
@@ -253,10 +272,15 @@ export async function dispatchClaudeTurn(
   const acceptsResult = input.body.blocks.some(
     (block) => block.type === 'text' && isSlashCommandText(block.text)
   )
-  const { waiter, replayed } = waitForReplay(session, timeoutMs, acceptsResult)
+  // Stamped so the echo can be matched to THIS dispatch: the CLI round-trips a
+  // client-supplied uuid verbatim (measured), and it also dedupes on it, so a
+  // resend of the same frame cannot land twice.
+  const sentUuid = randomUUID()
+  const { waiter, replayed } = waitForReplay(session, timeoutMs, acceptsResult, sentUuid)
   try {
     await session.connection.send({
       type: 'user',
+      uuid: sentUuid,
       message: { role: 'user', content },
       parent_tool_use_id: null,
       session_id: session.providerSessionId
@@ -265,7 +289,7 @@ export async function dispatchClaudeTurn(
     // A write can reach Claude and still reject on the flush that follows, so the
     // replay may already have claimed this waiter. Reporting `unknown` then
     // strands an identity nothing else can adopt, and the echo duplicates.
-    if (!session.dispatchWaiters.includes(waiter)) {
+    if (waiter.settledUuid) {
       const settled = await replayed
       if (settled) {
         return {

--- a/src/main/claude/claude-structured-dispatch.ts
+++ b/src/main/claude/claude-structured-dispatch.ts
@@ -185,22 +185,25 @@ function waitForReplay(
   return { waiter, replayed }
 }
 
+// A command token: `/model`, `/clear`, `/project:foo`. Not `/Users/me/foo.ts`
+// (slash) and not `/README.md` (dot).
+const SLASH_COMMAND_TOKEN = /^\/[a-z0-9][\w:-]*$/i
+
 /**
  * A slash command, not a message that merely opens with a path.
  *
  * `acceptsResult` lets a send settle on a bare `result` frame, which carries no
  * correlation to the dispatch that is waiting - so a false positive lets an
  * unrelated turn's result claim the send's identity, and the real echo then
- * appends a second row. `/Users/me/repo/foo.ts - explain this` is an ordinary
- * message; the second slash is what gives it away.
+ * appends a second row. This is stricter than `classifyNativeChatSend`, which
+ * treats any `/`-leading token as command-ish: over-classifying is safe there
+ * (it only suppresses an echo) and unsafe here.
+ *
+ * No trimming, matching that classifier's documented rule: the supported TUIs
+ * only treat a LINE-LEADING token as a command, so `  /clear` is prose.
  */
 function isSlashCommandText(text: string): boolean {
-  const trimmed = text.trimStart()
-  if (!trimmed.startsWith('/')) {
-    return false
-  }
-  const token = trimmed.slice(1).split(/\s/, 1)[0] ?? ''
-  return token.length > 0 && !token.includes('/')
+  return SLASH_COMMAND_TOKEN.test(text.split(/\s/, 1)[0] ?? '')
 }
 
 export async function dispatchClaudeTurn(

--- a/src/main/claude/claude-structured-dispatch.ts
+++ b/src/main/claude/claude-structured-dispatch.ts
@@ -78,11 +78,36 @@ function isClaudeUserMessageReplay(message: Record<string, unknown>): boolean {
   return message.type === 'user' && message.parent_tool_use_id === null && message.isReplay === true
 }
 
+let warnedAboutMissingReplayMarker = false
+
+/** A CLI that echoes without the marker cannot be told apart at runtime from a
+ *  turn that simply had no boundary inside the ack budget: both just report
+ *  "delivery unconfirmed". Say it once so the cause is diagnosable. */
+function warnIfEchoLacksReplayMarker(message: Record<string, unknown>): void {
+  if (
+    warnedAboutMissingReplayMarker ||
+    message.type !== 'user' ||
+    message.parent_tool_use_id !== null ||
+    message.isReplay !== undefined ||
+    message.tool_use_result !== undefined
+  ) {
+    return
+  }
+  warnedAboutMissingReplayMarker = true
+  console.warn(
+    '[claude-structured] user frame arrived without isReplay while a send was waiting; ' +
+      'sends will report delivery unconfirmed until the CLI stamps the marker'
+  )
+}
+
 export function resolveClaudeReplayWaiter(
   session: ClaudeSession,
   message: Record<string, unknown>
 ): void {
   const isUserReplay = isClaudeUserMessageReplay(message)
+  if (!isUserReplay && session.dispatchWaiters.length > 0) {
+    warnIfEchoLacksReplayMarker(message)
+  }
   const isCompletedCommand = message.type === 'result'
   if (
     (!isUserReplay && !isCompletedCommand) ||

--- a/src/main/claude/claude-structured-dispatch.ts
+++ b/src/main/claude/claude-structured-dispatch.ts
@@ -5,8 +5,6 @@ import type { NativeChatBlock } from '../../shared/native-chat-types'
 import type { AgentSessionDispatchOutcome } from '../native-chat/agent-session-wire/structured-agent-session-adapter'
 import type { ClaudeDispatchWaiter, ClaudeSession } from './claude-structured-session-state'
 import { readClaudeFrameString } from './claude-structured-init-proof'
-import { isKnownHarnessInjectedUserTurnText } from '../../shared/harness-injected-user-turns'
-import { claudeRecord } from './claude-structured-item-translation'
 
 const MAX_IMAGE_BYTES = 5 * 1024 * 1024
 const MAX_IMAGE_COUNT = 20
@@ -52,72 +50,39 @@ const IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
   '.webp': 'image/webp'
 }
 
-/** Text of a top-level user frame, or null when it is a tool-result turn (or
- *  carries nothing). A plain-string `content` is accepted so a CLI that sends the
- *  simpler shape can still settle its send - note the translator models only the
- *  array form, so such an echo settles the dispatch without upserting a body, the
- *  same way an image-only echo does. An image-only echo has no text, yielding ''. */
-function claudeUserFrameText(content: unknown): string | null {
-  if (typeof content === 'string') {
-    return content
-  }
-  if (!Array.isArray(content) || content.length === 0) {
-    return null
-  }
-  const parts = content.map((part) => claudeRecord(part))
-  if (parts.some((part) => part?.type === 'tool_result')) {
-    return null
-  }
-  return parts.map((part) => (typeof part?.text === 'string' ? part.text : '')).join('\n')
-}
-
 /**
  * The frame that carries the user's own message back.
  *
  * `type: 'user'` with a null `parent_tool_use_id` is not enough on its own:
  * Claude publishes tool results and harness-injected turns (interruption
  * notices, system reminders, local-command output) in the same shape. Adopting
- * one of those leaves the real replay to land under an identity nothing claims,
- * so the user's message renders twice - and an injected turn is worse than a
- * tool result, because it DOES build a body and upserts over the user's own
- * bubble.
+ * one leaves the real replay to land under an identity nothing claims, so the
+ * user's message renders twice - and an injected turn is worse than a tool
+ * result, because it DOES build a body and upserts over the user's own bubble.
  *
- * `--replay-user-messages` stamps `isReplay` on the genuine echo, so trust that
- * when it is there. The shape test is only a fallback for a CLI that omits the
- * marker, and it stays off once this session has seen one: the launch args always
- * request replays, so after that a frame without the marker is by construction not
- * the echo, and the hand-maintained injected-turn list must not be load-bearing.
- * Without any fallback, a CLI that never stamps it would leave every send timing
- * out into a false "delivery unconfirmed", and retrying sends the message twice.
+ * `CLAUDE_STRUCTURED_BASE_ARGS` always passes `--replay-user-messages`, and the
+ * CLI stamps `isReplay` on every echo it publishes in reply - measured for text,
+ * image-only and text+image sends. So the marker is the whole test: no content
+ * sniffing, and nothing here depends on the injected-turn list that
+ * prompt-derived UI maintains for its own reasons.
+ *
+ * A slash command may get no user echo at all; `acceptsResult` settles those on
+ * the command's result receipt instead.
  *
  * Measured against the real CLI: a queued send's replay is published at the
  * first tool boundary after it is queued, 2-3 ms AFTER that boundary's tool
  * result. So rejecting tool results costs no time - whenever there was a frame
  * to adopt, the right one follows immediately.
  */
-function isClaudeUserMessageReplay(
-  session: ClaudeSession,
-  message: Record<string, unknown>
-): boolean {
-  if (message.type !== 'user' || message.parent_tool_use_id !== null) {
-    return false
-  }
-  if (message.isReplay === true) {
-    session.sawUserReplayMarker = true
-    return true
-  }
-  if (session.sawUserReplayMarker) {
-    return false
-  }
-  const text = claudeUserFrameText(claudeRecord(message.message)?.content)
-  return text !== null && !isKnownHarnessInjectedUserTurnText(text)
+function isClaudeUserMessageReplay(message: Record<string, unknown>): boolean {
+  return message.type === 'user' && message.parent_tool_use_id === null && message.isReplay === true
 }
 
 export function resolveClaudeReplayWaiter(
   session: ClaudeSession,
   message: Record<string, unknown>
 ): void {
-  const isUserReplay = isClaudeUserMessageReplay(session, message)
+  const isUserReplay = isClaudeUserMessageReplay(message)
   const isCompletedCommand = message.type === 'result'
   if (
     (!isUserReplay && !isCompletedCommand) ||

--- a/src/main/claude/claude-structured-dispatch.ts
+++ b/src/main/claude/claude-structured-dispatch.ts
@@ -3,7 +3,7 @@ import { open } from 'node:fs/promises'
 import type { AgentJournalMessageItem } from '../../shared/agent-session-journal-types'
 import type { NativeChatBlock } from '../../shared/native-chat-types'
 import type { AgentSessionDispatchOutcome } from '../native-chat/agent-session-wire/structured-agent-session-adapter'
-import type { ClaudeSession } from './claude-structured-session-state'
+import type { ClaudeDispatchWaiter, ClaudeSession } from './claude-structured-session-state'
 import { readClaudeFrameString } from './claude-structured-init-proof'
 import { isKnownHarnessInjectedUserTurnText } from '../../shared/harness-injected-user-turns'
 import { claudeRecord } from './claude-structured-item-translation'
@@ -189,26 +189,35 @@ async function messageContent(body: AgentJournalMessageItem): Promise<unknown[]>
   return content
 }
 
+function dropWaiter(session: ClaudeSession, waiter: ClaudeDispatchWaiter): void {
+  const index = session.dispatchWaiters.indexOf(waiter)
+  if (index !== -1) {
+    session.dispatchWaiters.splice(index, 1)
+  }
+}
+
+/** Arms a waiter and hands it back, so a failure can retire ITS OWN waiter — the
+ *  queue is positional, and shifting the head resolves whichever send happens to
+ *  be first instead. */
 function waitForReplay(
   session: ClaudeSession,
   timeoutMs: number,
   acceptsResult: boolean
-): Promise<string | null> {
-  return new Promise((resolve) => {
-    const waiter = {
+): { waiter: ClaudeDispatchWaiter; replayed: Promise<string | null> } {
+  let waiter!: ClaudeDispatchWaiter
+  const replayed = new Promise<string | null>((resolve) => {
+    waiter = {
       acceptsResult,
       resolve,
       timer: setTimeout(() => {
-        const index = session.dispatchWaiters.indexOf(waiter)
-        if (index !== -1) {
-          session.dispatchWaiters.splice(index, 1)
-        }
+        dropWaiter(session, waiter)
         resolve(null)
       }, timeoutMs)
     }
     waiter.timer.unref?.()
     session.dispatchWaiters.push(waiter)
   })
+  return { waiter, replayed }
 }
 
 export async function dispatchClaudeTurn(
@@ -225,7 +234,7 @@ export async function dispatchClaudeTurn(
   const acceptsResult = input.body.blocks.some(
     (block) => block.type === 'text' && block.text.trimStart().startsWith('/')
   )
-  const replayed = waitForReplay(session, timeoutMs, acceptsResult)
+  const { waiter, replayed } = waitForReplay(session, timeoutMs, acceptsResult)
   try {
     await session.connection.send({
       type: 'user',
@@ -234,11 +243,9 @@ export async function dispatchClaudeTurn(
       session_id: session.providerSessionId
     })
   } catch (error) {
-    const waiter = session.dispatchWaiters.shift()
-    if (waiter) {
-      clearTimeout(waiter.timer)
-      waiter.resolve(null)
-    }
+    dropWaiter(session, waiter)
+    clearTimeout(waiter.timer)
+    waiter.resolve(null)
     return { state: 'unknown', reason: (error as Error).message }
   }
   const uuid = await replayed

--- a/src/main/claude/claude-structured-dispatch.ts
+++ b/src/main/claude/claude-structured-dispatch.ts
@@ -4,10 +4,7 @@ import { open } from 'node:fs/promises'
 import type { AgentJournalMessageItem } from '../../shared/agent-session-journal-types'
 import type { NativeChatBlock } from '../../shared/native-chat-types'
 import type { AgentSessionDispatchOutcome } from '../native-chat/agent-session-wire/structured-agent-session-adapter'
-import type { ClaudeDispatchWaiter, ClaudeSession } from './claude-structured-session-state'
-import { isKnownHarnessInjectedUserTurnText } from '../../shared/harness-injected-user-turns'
-import { readClaudeFrameString } from './claude-structured-init-proof'
-import { claudeRecord } from './claude-structured-item-translation'
+import type { ClaudeSession } from './claude-structured-session-state'
 
 const MAX_IMAGE_BYTES = 5 * 1024 * 1024
 const MAX_IMAGE_COUNT = 20
@@ -51,101 +48,6 @@ const IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
   '.jpg': 'image/jpeg',
   '.png': 'image/png',
   '.webp': 'image/webp'
-}
-
-/** Leading text of a top-level user frame, for harness classification. The CLI
- *  serializes an injected breadcrumb's content as a plain string and a typed
- *  echo's as a block array, so both shapes have to be read. */
-function claudeUserFrameText(message: Record<string, unknown>): string {
-  const content = claudeRecord(message.message)?.content
-  if (typeof content === 'string') {
-    return content
-  }
-  if (!Array.isArray(content)) {
-    return ''
-  }
-  return content
-    .map((part) => {
-      const text = claudeRecord(part)?.text
-      return typeof text === 'string' ? text : ''
-    })
-    .join('\n')
-}
-
-/**
- * The frame that carries the user's own message back.
- *
- * `type: 'user'` with a null `parent_tool_use_id` is not enough: Claude
- * publishes tool results and harness-injected turns in the same shape. Adopting
- * one leaves the real replay under an identity nothing claims, so the user's
- * message renders twice - and an injected turn is worse than a tool result,
- * because it can build a body and upsert over the user's own bubble.
- *
- * `isReplay` is necessary but NOT sufficient. Claude stamps it on its own
- * injected breadcrumbs too: 2.1.237 enqueues the model-switch notice as
- * `{type:'user', parent_tool_use_id:null, isReplay:true}` whose content is the
- * string `<local-command-stdout>Set model to ...`. Orca triggers that path
- * itself from the model picker (`setClaudeStructuredOption` sends `set_model`,
- * and reconnect replays it). The CLI's own RemoteSessionManager cannot use the
- * marker alone either - it filters the same frames by content prefix, logging
- * "Dropped own set_model breadcrumb echo".
- *
- * So: require the marker, then reject the harness shapes. The residual is a
- * genuine echo whose own text opens with a harness tag (a user pasting a
- * transcript excerpt), which is rarer than a model switch and fails the safe
- * way - `unknown`, not a corrupted bubble.
- */
-function isClaudeUserMessageReplay(message: Record<string, unknown>): boolean {
-  if (message.type !== 'user' || message.parent_tool_use_id !== null || message.isReplay !== true) {
-    return false
-  }
-  return !isKnownHarnessInjectedUserTurnText(claudeUserFrameText(message))
-}
-
-function settleWaiter(session: ClaudeSession, waiter: ClaudeDispatchWaiter, uuid: string): void {
-  dropWaiter(session, waiter)
-  clearTimeout(waiter.timer)
-  waiter.settledUuid = uuid
-  waiter.resolve(uuid)
-}
-
-export function resolveClaudeReplayWaiter(
-  session: ClaudeSession,
-  message: Record<string, unknown>
-): void {
-  if (readClaudeFrameString(message, 'session_id') !== session.providerSessionId) {
-    return
-  }
-  const uuid = readClaudeFrameString(message, 'uuid')
-  if (!uuid) {
-    return
-  }
-  // Exact correlation: the CLI echoes the uuid we stamped on the outgoing frame,
-  // so this replay belongs to that dispatch whatever its queue position - which
-  // is what keeps a late replay from settling somebody else's send.
-  const owner = session.dispatchWaiters.find((candidate) => candidate.sentUuid === uuid)
-  if (owner) {
-    settleWaiter(session, owner, uuid)
-    return
-  }
-  // A replay for a dispatch that already gave up belongs to nobody. Dropping it
-  // here is what keeps the compat path below from handing it to the head, which
-  // would upsert the dead send's text over a live one's bubble.
-  if (session.retiredSentUuids?.includes(uuid)) {
-    return
-  }
-  // Compat path for a CLI that mints its own uuid instead of echoing ours. The
-  // frame then carries no correlation at all, so the head is the only candidate
-  // and the shape gates have to carry the weight.
-  const isCompletedCommand = message.type === 'result'
-  if (!isClaudeUserMessageReplay(message) && !isCompletedCommand) {
-    return
-  }
-  const head = session.dispatchWaiters[0]
-  if (!head || (isCompletedCommand && !head.acceptsResult)) {
-    return
-  }
-  settleWaiter(session, head, uuid)
 }
 
 async function imageContent(
@@ -200,137 +102,115 @@ async function messageContent(body: AgentJournalMessageItem): Promise<unknown[]>
   return content
 }
 
-/** Enough to cover the replays still in flight for sends that gave up; the list
- *  only grows when a dispatch leaves without its echo. */
-const RETIRED_UUID_MEMORY = 64
+type DispatchRace<T> =
+  | { kind: 'completed'; value: T }
+  | { kind: 'failed'; error: Error }
+  | { kind: 'terminal' }
 
-function dropWaiter(session: ClaudeSession, waiter: ClaudeDispatchWaiter): void {
-  const index = session.dispatchWaiters.indexOf(waiter)
-  if (index !== -1) {
-    session.dispatchWaiters.splice(index, 1)
+function raceWithSessionTerminal<T>(
+  session: ClaudeSession,
+  work: Promise<T>
+): Promise<DispatchRace<T>> {
+  return Promise.race([
+    work.then(
+      (value): DispatchRace<T> => ({ kind: 'completed', value }),
+      (error: unknown): DispatchRace<T> => ({ kind: 'failed', error: error as Error })
+    ),
+    session.terminal.signal.then<DispatchRace<T>>(() => ({ kind: 'terminal' }))
+  ])
+}
+
+function acceptedDispatch(session: ClaudeSession, sentUuid: string): AgentSessionDispatchOutcome {
+  return {
+    state: 'accepted',
+    providerIdentity: {
+      provider: 'claude',
+      sessionId: session.providerSessionId,
+      uuid: sentUuid
+    }
   }
 }
 
-/** Remember a dispatch that left without its echo, so the echo cannot later be
- *  mistaken for somebody else's on the compat path. */
-function retireWaiter(session: ClaudeSession, waiter: ClaudeDispatchWaiter): void {
-  dropWaiter(session, waiter)
-  const retired = session.retiredSentUuids ?? []
-  retired.push(waiter.sentUuid)
-  session.retiredSentUuids = retired.slice(-RETIRED_UUID_MEMORY)
-}
-
-/** Arms a waiter and hands it back, so a failure can retire ITS OWN waiter — the
- *  queue is positional, and shifting the head resolves whichever send happens to
- *  be first instead. */
-function waitForReplay(
-  session: ClaudeSession,
-  timeoutMs: number,
-  acceptsResult: boolean,
-  sentUuid: string
-): { waiter: ClaudeDispatchWaiter; replayed: Promise<string | null> } {
-  let waiter!: ClaudeDispatchWaiter
-  const replayed = new Promise<string | null>((resolve) => {
-    waiter = {
-      acceptsResult,
-      sentUuid,
-      resolve,
-      timer: setTimeout(() => {
-        retireWaiter(session, waiter)
-        resolve(null)
-      }, timeoutMs)
-    }
-    waiter.timer.unref?.()
-    session.dispatchWaiters.push(waiter)
+async function acquireDispatchLane(session: ClaudeSession): Promise<() => void> {
+  const predecessor = session.dispatchLane
+  let release = (): void => {}
+  const turn = new Promise<void>((resolve) => {
+    release = resolve
   })
-  return { waiter, replayed }
-}
-
-// A command token: `/model`, `/clear`, `/project:foo`. Not `/Users/me/foo.ts`
-// (slash) and not `/README.md` (dot).
-const SLASH_COMMAND_TOKEN = /^\/[a-z0-9][\w:-]*$/i
-
-/**
- * A slash command, not a message that merely opens with a path.
- *
- * `acceptsResult` lets a send settle on a bare `result` frame, which carries no
- * correlation to the dispatch that is waiting - so a false positive lets an
- * unrelated turn's result claim the send's identity, and the real echo then
- * appends a second row. This is stricter than `classifyNativeChatSend`, which
- * treats any `/`-leading token as command-ish: over-classifying is safe there
- * (it only suppresses an echo) and unsafe here.
- *
- * No trimming, and MEASURED rather than inherited from the TUI rule: `  /clear`
- * came back from `claude -p --input-format stream-json` as a stamped replay, so
- * this lane also reads an indented token as prose.
- *
- * Residual, unfixable by shape: `/tmp what is in here?` matches, because `/tmp`
- * is indistinguishable from `/clear`. The agent's command catalog cannot close
- * it either - `getVerifiedNativeChatCommands('claude')` is a curated `/` menu
- * (clear, compact, init, review, help) and omits real built-ins like `/model`
- * and `/permissions`, both measured as answering with a bare `result` and no
- * echo; gating on it would strand those sends instead. Measured mitigation: a
- * path-leading message DOES get a stamped replay, so it only mis-settles if an
- * unrelated `result` beats that replay.
- */
-function isSlashCommandText(text: string): boolean {
-  return SLASH_COMMAND_TOKEN.test(text.split(/\s/, 1)[0] ?? '')
+  session.dispatchLane = predecessor.then(() => turn)
+  const admission = await Promise.race([
+    predecessor.then(() => true),
+    session.terminal.signal.then(() => false)
+  ])
+  if (!admission) {
+    release()
+    throw new Error('claude structured session closed before dispatch')
+  }
+  return release
 }
 
 export async function dispatchClaudeTurn(
   session: ClaudeSession,
-  input: { clientMessageId: string; body: AgentJournalMessageItem },
-  timeoutMs: number
+  input: { clientMessageId: string; body: AgentJournalMessageItem }
 ): Promise<AgentSessionDispatchOutcome> {
-  let content: unknown[]
+  let releaseLane: () => void
   try {
-    content = await messageContent(input.body)
+    releaseLane = await acquireDispatchLane(session)
   } catch (error) {
     return { state: 'rejected', reason: (error as Error).message }
   }
-  const acceptsResult = input.body.blocks.some(
-    (block) => block.type === 'text' && isSlashCommandText(block.text)
-  )
-  // Stamped so the echo can be matched to THIS dispatch: the CLI round-trips a
-  // client-supplied uuid verbatim (measured), and it also dedupes on it, so a
-  // resend of the same frame cannot land twice.
-  const sentUuid = randomUUID()
-  const { waiter, replayed } = waitForReplay(session, timeoutMs, acceptsResult, sentUuid)
   try {
-    await session.connection.send({
-      type: 'user',
-      uuid: sentUuid,
-      message: { role: 'user', content },
-      parent_tool_use_id: null,
-      session_id: session.providerSessionId
-    })
-  } catch (error) {
-    // A write can reach Claude and still reject on the flush that follows, so the
-    // replay may already have claimed this waiter. Reporting `unknown` then
-    // strands an identity nothing else can adopt, and the echo duplicates.
-    if (waiter.settledUuid) {
-      const settled = await replayed
-      if (settled) {
-        return {
-          state: 'accepted',
-          providerIdentity: {
-            provider: 'claude',
-            sessionId: session.providerSessionId,
-            uuid: settled
-          }
-        }
+    if (session.terminal.closed) {
+      return { state: 'rejected', reason: 'claude structured session closed before dispatch' }
+    }
+    if (session.dispatchFenced) {
+      return {
+        state: 'unknown',
+        reason: 'claude delivery is uncertain until the session reconnects'
       }
     }
-    retireWaiter(session, waiter)
-    clearTimeout(waiter.timer)
-    waiter.resolve(null)
-    return { state: 'unknown', reason: (error as Error).message }
-  }
-  const uuid = await replayed
-  return uuid
-    ? {
-        state: 'accepted',
-        providerIdentity: { provider: 'claude', sessionId: session.providerSessionId, uuid }
+    const materialized = await raceWithSessionTerminal(session, messageContent(input.body))
+    if (materialized.kind === 'terminal') {
+      return { state: 'rejected', reason: 'claude structured session closed before dispatch' }
+    }
+    if (materialized.kind === 'failed') {
+      return { state: 'rejected', reason: materialized.error.message }
+    }
+    if (session.terminal.closed) {
+      return { state: 'rejected', reason: 'claude structured session closed before dispatch' }
+    }
+    const sentUuid = randomUUID()
+    const sequence = session.sentUserUuidSequence.size
+    session.sentUserUuidSequence.set(sentUuid, sequence)
+    session.translator?.registerOwnedTurn(session.providerSessionId, sentUuid, sequence)
+    const write = await raceWithSessionTerminal(
+      session,
+      session.connection.send({
+        type: 'user',
+        uuid: sentUuid,
+        message: { role: 'user', content: materialized.value },
+        parent_tool_use_id: null,
+        session_id: session.providerSessionId
+      })
+    )
+    if (write.kind === 'completed') {
+      if (!session.terminal.closed) {
+        session.translator?.confirmOwnedTurn(sentUuid)
       }
-    : { state: 'unknown', reason: 'claude accepted a message but did not replay its uuid in time' }
+      return acceptedDispatch(session, sentUuid)
+    }
+    if (session.deliveryEvidenceUuids.has(sentUuid)) {
+      return acceptedDispatch(session, sentUuid)
+    }
+    if (write.kind === 'terminal') {
+      return { state: 'unknown', reason: 'claude session closed while delivery was pending' }
+    }
+    if (!session.terminal.closed) {
+      session.dispatchFenced = true
+      session.translator?.abandonOwnedTurn(sentUuid)
+    }
+    return { state: 'unknown', reason: write.error.message }
+  } finally {
+    releaseLane()
+  }
 }

--- a/src/main/claude/claude-structured-journal-translation.test.ts
+++ b/src/main/claude/claude-structured-journal-translation.test.ts
@@ -97,6 +97,8 @@ describe('Claude structured journal translation', () => {
     const state = sinkState()
     const translator = createClaudeJournalTranslator({ sink: state.sink })
 
+    translator.registerOwnedTurn('claude-session', 'user-1', 0)
+    translator.confirmOwnedTurn('user-1')
     translator.handle(message('user', 'user-1', [{ type: 'text', text: 'List files' }]))
     translator.handle(
       message('assistant', 'assistant-tool', [
@@ -134,8 +136,14 @@ describe('Claude structured journal translation', () => {
     translator.handle({
       type: 'message',
       sessionId: 'orca-session',
-      message: { type: 'result', session_id: 'claude-session', uuid: 'result-1' }
+      message: {
+        type: 'result',
+        session_id: 'claude-session',
+        uuid: 'result-1',
+        user_message_uuid: 'user-1'
+      }
     })
+    translator.settleOwnedTurn('user-1')
     expect(state.tombstones.at(-1)).toMatchObject({
       provider: 'legacy',
       agent: 'claude',
@@ -156,21 +164,103 @@ describe('Claude structured journal translation', () => {
     })
   })
 
-  it('starts a cancellable lifecycle for image-only root user replays', () => {
+  it('starts a cancellable lifecycle for an owned image-only send', () => {
     const state = sinkState()
     const translator = createClaudeJournalTranslator({ sink: state.sink })
 
-    translator.handle(
-      message('user', 'user-image', [
-        { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'AA==' } }
-      ])
-    )
+    translator.registerOwnedTurn('claude-session', 'user-image', 0)
+    translator.confirmOwnedTurn('user-image')
 
     expect(state.items.at(-1)?.body).toEqual({
       kind: 'status',
       text: 'Claude is working…',
       turnLifecycle: { turnId: 'user-image', state: 'running' }
     })
+  })
+
+  it('settles only the named owned turn and ignores repeated settled echoes', () => {
+    const state = sinkState()
+    const translator = createClaudeJournalTranslator({ sink: state.sink })
+
+    translator.registerOwnedTurn('claude-session', 'turn-a', 0)
+    translator.confirmOwnedTurn('turn-a')
+    translator.registerOwnedTurn('claude-session', 'turn-b', 1)
+    translator.confirmOwnedTurn('turn-b')
+    translator.handle(
+      message(
+        'user',
+        'tool-result',
+        [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'done' }],
+        null
+      )
+    )
+    translator.handle(message('user', 'injected', [{ type: 'text', text: '<local-command>' }]))
+    translator.confirmOwnedTurn('turn-b')
+
+    translator.settleOwnedTurn('turn-b')
+    expect(
+      state.tombstones.map((identity) =>
+        identity.provider === 'legacy' ? identity.recordId : undefined
+      )
+    ).toEqual(['turn-lifecycle:turn-b'])
+    expect(
+      state.items.filter(
+        (item) => item.body.kind === 'status' && item.body.turnLifecycle?.turnId === 'turn-a'
+      )
+    ).toHaveLength(1)
+    translator.confirmOwnedTurn('turn-b')
+    expect(
+      state.items.filter(
+        (item) => item.body.kind === 'status' && item.body.turnLifecycle?.turnId === 'turn-b'
+      )
+    ).toHaveLength(1)
+
+    translator.settleOwnedTurn('turn-a')
+    expect(state.tombstones.at(-1)).toMatchObject({ recordId: 'turn-lifecycle:turn-a' })
+    translator.confirmOwnedTurn('turn-a')
+    expect(
+      state.items.filter(
+        (item) => item.body.kind === 'status' && item.body.turnLifecycle?.turnId === 'turn-a'
+      )
+    ).toHaveLength(1)
+
+    translator.registerOwnedTurn('claude-session', 'turn-c', 2)
+    translator.confirmOwnedTurn('turn-c')
+    translator.handle({ type: 'ended', sessionId: 'orca-session', reason: 'closed' })
+    translator.registerOwnedTurn('claude-session', 'turn-after-exit', 3)
+    translator.confirmOwnedTurn('turn-after-exit')
+    translator.settleOwnedTurn('turn-after-exit')
+    expect(
+      state.tombstones.map((identity) =>
+        identity.provider === 'legacy' ? identity.recordId : undefined
+      )
+    ).toEqual(['turn-lifecycle:turn-b', 'turn-lifecycle:turn-a', 'turn-lifecycle:turn-c'])
+    expect(
+      state.items.some(
+        (item) =>
+          item.body.kind === 'status' && item.body.turnLifecycle?.turnId === 'turn-after-exit'
+      )
+    ).toBe(false)
+  })
+
+  it('does not let results beat provisional or abandoned turn slots', () => {
+    const state = sinkState()
+    const translator = createClaudeJournalTranslator({ sink: state.sink })
+
+    translator.registerOwnedTurn('claude-session', 'before-write-resolves', 0)
+    translator.settleOwnedTurn('before-write-resolves')
+    translator.confirmOwnedTurn('before-write-resolves')
+
+    translator.registerOwnedTurn('claude-session', 'failed-write', 1)
+    translator.abandonOwnedTurn('failed-write')
+    translator.settleOwnedTurn('failed-write')
+    translator.confirmOwnedTurn('failed-write')
+
+    expect(
+      state.items.filter(
+        (item) => item.body.kind === 'status' && item.body.turnLifecycle !== undefined
+      )
+    ).toEqual([])
   })
 
   it('renders empty user frames through the provider fallback', () => {

--- a/src/main/claude/claude-structured-journal-translation.ts
+++ b/src/main/claude/claude-structured-journal-translation.ts
@@ -36,6 +36,7 @@ import {
   createClaudeProviderFrameFallback,
   isModeledClaudeContent
 } from './claude-structured-provider-fallback'
+import { createClaudeOwnedTurnLifecycle } from './claude-owned-turn-lifecycle'
 
 export type ClaudeJournalTranslatorDeps = {
   sink: StructuredAgentSessionEventSink
@@ -46,6 +47,10 @@ export type ClaudeJournalTranslatorDeps = {
 
 export type ClaudeJournalTranslator = {
   handle: (event: ClaudeStructuredSessionEvent) => void
+  registerOwnedTurn: (sessionId: string, turnId: string, sequence: number) => void
+  confirmOwnedTurn: (turnId: string) => void
+  settleOwnedTurn: (turnId: string) => void
+  abandonOwnedTurn: (turnId: string) => void
   flush: () => void
   dispose: () => void
 }
@@ -95,8 +100,8 @@ export function createClaudeJournalTranslator(
   const streamIdentities = new Map<string, AgentJournalItemIdentity>()
   const latestStreamText = new Map<string, string>()
   const checkpointLengths = new Map<string, number>()
-  let currentTurn: { sessionId: string; turnId: string } | null = null
   const providerFallback = createClaudeProviderFrameFallback(deps.sink)
+  let terminal = false
 
   const publishLifecycle = (sessionId: string, turnId: string, running: boolean): void => {
     const identity = lifecycleIdentity(sessionId, turnId)
@@ -111,6 +116,8 @@ export function createClaudeJournalTranslator(
     }
     deps.sink.publish()
   }
+
+  const ownedTurns = createClaudeOwnedTurnLifecycle(publishLifecycle)
 
   const persistStream = (key: string, text: string, force: boolean): void => {
     latestStreamText.set(key, text)
@@ -211,17 +218,6 @@ export function createClaudeJournalTranslator(
       providerFallback.append(`message:${envelope.role}:empty`, message)
       changed = true
     }
-    if (
-      envelope.role === 'user' &&
-      envelope.content.length > 0 &&
-      message.parent_tool_use_id === null
-    ) {
-      if (currentTurn) {
-        publishLifecycle(currentTurn.sessionId, currentTurn.turnId, false)
-      }
-      currentTurn = { sessionId: envelope.sessionId, turnId: envelope.uuid }
-      publishLifecycle(envelope.sessionId, envelope.uuid, true)
-    }
     if (changed) {
       deps.sink.publish()
     }
@@ -253,13 +249,20 @@ export function createClaudeJournalTranslator(
   }
 
   return {
+    registerOwnedTurn: (sessionId, turnId, sequence) => {
+      ownedTurns.register(sessionId, turnId, sequence)
+    },
+    confirmOwnedTurn: ownedTurns.confirm,
+    settleOwnedTurn: ownedTurns.settle,
+    abandonOwnedTurn: ownedTurns.abandon,
     handle: (event) => {
+      if (terminal) {
+        return
+      }
       if (event.type === 'ended') {
         flushStreams()
-        if (currentTurn) {
-          publishLifecycle(currentTurn.sessionId, currentTurn.turnId, false)
-          currentTurn = null
-        }
+        ownedTurns.end()
+        terminal = true
         return
       }
       if (event.type === 'message' && handleStream(event.message)) {
@@ -275,10 +278,6 @@ export function createClaudeJournalTranslator(
         promptItems.delete(event.promptKey)
         deps.sink.publish()
       } else if (event.type === 'message' && event.message.type === 'result') {
-        if (currentTurn) {
-          publishLifecycle(currentTurn.sessionId, currentTurn.turnId, false)
-          currentTurn = null
-        }
         providerFallback.append(claudeProviderFrameKind(event.message), event.message)
       } else if (event.type === 'message') {
         if (!handleMessage(event.message)) {
@@ -290,12 +289,14 @@ export function createClaudeJournalTranslator(
     },
     flush: flushStreams,
     dispose: () => {
+      terminal = true
       coalescer.dispose()
       tools.clear()
       promptItems.clear()
       streamIdentities.clear()
       latestStreamText.clear()
       checkpointLengths.clear()
+      ownedTurns.dispose()
     }
   }
 }

--- a/src/main/claude/claude-structured-launch-resolution.test.ts
+++ b/src/main/claude/claude-structured-launch-resolution.test.ts
@@ -60,9 +60,7 @@ describe('claude structured launch resolution', () => {
     expect(first.args).toContain('--setting-sources')
     expect(first.args).toContain(CLAUDE_DEFAULT_SETTING_SOURCES.join(','))
     expect(CLAUDE_STRUCTURED_BASE_ARGS).toContain('--verbose')
-    // Load-bearing: `resolveClaudeReplayWaiter` settles a send only on the
-    // `isReplay` marker this flag asks for. Drop it and every send blocks its
-    // whole ack budget and lands "delivery unconfirmed".
+    // Exact echoes advance the durable leaf used by the next resume.
     expect(CLAUDE_STRUCTURED_BASE_ARGS).toContain('--replay-user-messages')
   })
 

--- a/src/main/claude/claude-structured-launch-resolution.test.ts
+++ b/src/main/claude/claude-structured-launch-resolution.test.ts
@@ -60,6 +60,10 @@ describe('claude structured launch resolution', () => {
     expect(first.args).toContain('--setting-sources')
     expect(first.args).toContain(CLAUDE_DEFAULT_SETTING_SOURCES.join(','))
     expect(CLAUDE_STRUCTURED_BASE_ARGS).toContain('--verbose')
+    // Load-bearing: `resolveClaudeReplayWaiter` settles a send only on the
+    // `isReplay` marker this flag asks for. Drop it and every send blocks its
+    // whole ack budget and lands "delivery unconfirmed".
+    expect(CLAUDE_STRUCTURED_BASE_ARGS).toContain('--replay-user-messages')
   })
 
   it('resumes the session and leaf at the durable chain head', async () => {

--- a/src/main/claude/claude-structured-session-adapter.test.ts
+++ b/src/main/claude/claude-structured-session-adapter.test.ts
@@ -1,191 +1,23 @@
-import { describe, expect, it } from 'vitest'
-import type {
-  AgentJournalMessageItem,
-  AgentSessionJournalIdentity
-} from '../../shared/agent-session-journal-types'
+import { describe, expect, it, vi } from 'vitest'
+import type { AgentJournalItemBody } from '../../shared/agent-session-journal-types'
 import { AgentSessionAcquisitionRefusal } from '../native-chat/agent-session-wire/structured-agent-session-adapter'
-import type {
-  ClaudeStreamJsonConnection,
-  ClaudeStreamJsonConnectionHandlers,
-  ClaudeStreamJsonLaunch,
-  openClaudeStreamJsonConnection
-} from './claude-stream-json-connection'
+import type { StructuredAgentSessionEventSink } from '../native-chat/agent-session-wire/structured-agent-session-event-sink'
 import { ClaudeControlRequestError } from './claude-stream-json-connection'
+import {
+  acquired,
+  adapterFor,
+  deferred,
+  fakeClaude,
+  identityFor,
+  PROVIDER_SESSION_ID,
+  USER_MESSAGE
+} from './claude-structured-adapter-fake-connection'
 import { CLAUDE_SPAWN_TOKEN_ENV } from './claude-structured-owner-identity'
 import { encodeClaudeQuestionOptionId } from './claude-structured-prompt-replies'
 import {
   CLAUDE_STRUCTURED_INIT_TIMEOUT_MS,
-  ClaudeStructuredSessionAdapter,
-  type ClaudeStructuredLaunch,
   type ClaudeStructuredSessionEvent
 } from './claude-structured-session-adapter'
-
-const PROVIDER_SESSION_ID = '819cf9f8-e43c-4ad7-b50f-54aa158a726a'
-
-const USER_MESSAGE: AgentJournalMessageItem = {
-  kind: 'message',
-  role: 'user',
-  blocks: [{ type: 'text', text: 'ship it' }]
-}
-
-function identityFor(sessionId = 'session-1'): AgentSessionJournalIdentity {
-  return {
-    sessionId,
-    workspaceId: 'workspace-1',
-    hostId: 'host-1',
-    agent: 'claude',
-    providerHandle: { kind: 'claude', sessionId: PROVIDER_SESSION_ID, leafUuid: null }
-  }
-}
-
-type Route = (params: Record<string, unknown> | undefined) => unknown
-
-type FakeConnection = Omit<ClaudeStreamJsonConnection, 'closed'> & {
-  closed: boolean
-  launch: ClaudeStreamJsonLaunch
-  handlers: ClaudeStreamJsonConnectionHandlers
-  calls: { subtype: string; params?: Record<string, unknown> }[]
-  sent: Record<string, unknown>[]
-  replies: { requestId: string; response?: unknown; error?: string }[]
-  closeCount: number
-}
-
-function fakeClaude(
-  options: {
-    initSessionId?: string
-    initUuid?: string
-    initModel?: string
-    initEffort?: string
-    initProof?: 'init' | 'session-start' | 'none'
-    initAccount?: unknown
-    exitBeforeInit?: string
-    settings?: unknown
-    replayUuid?: string | null
-    routes?: Record<string, Route>
-  } = {}
-): {
-  connections: FakeConnection[]
-  openConnection: typeof openClaudeStreamJsonConnection
-  routes: Record<string, Route>
-} {
-  const connections: FakeConnection[] = []
-  const routes = options.routes ?? {}
-  const openConnection = (async (launch, handlers = {}) => {
-    const connection: FakeConnection = {
-      launch,
-      handlers,
-      calls: [],
-      sent: [],
-      replies: [],
-      closeCount: 0,
-      pid: 4321,
-      closed: false,
-      request: async (subtype, params) => {
-        connection.calls.push({ subtype, params })
-        if (subtype === 'initialize') {
-          if (options.exitBeforeInit) {
-            handlers.onExit?.(new Error(options.exitBeforeInit))
-            return { models: [] }
-          }
-          if (options.initProof === 'session-start') {
-            handlers.onMessage?.({
-              type: 'system',
-              subtype: 'hook_started',
-              hook_name: 'SessionStart:startup',
-              session_id: options.initSessionId ?? PROVIDER_SESSION_ID,
-              uuid: options.initUuid ?? 'init-uuid'
-            })
-          } else if (options.initProof !== 'none') {
-            handlers.onMessage?.({
-              type: 'system',
-              subtype: 'init',
-              session_id: options.initSessionId ?? PROVIDER_SESSION_ID,
-              uuid: options.initUuid ?? 'init-uuid',
-              model: options.initModel ?? 'claude-sonnet-5',
-              effortLevel: options.initEffort ?? 'high',
-              apiKeySource: 'none'
-            })
-          }
-          return {
-            models: [{ value: 'claude-sonnet', displayName: 'Sonnet' }],
-            ...(options.initAccount === undefined ? {} : { account: options.initAccount })
-          }
-        }
-        if (subtype === 'get_settings') {
-          return options.settings ?? { env: {} }
-        }
-        const route = routes[subtype]
-        return route ? route(params) : {}
-      },
-      send: async (message) => {
-        connection.sent.push(message)
-        if (message.type === 'user' && options.replayUuid !== null) {
-          // The real CLI stamps `isReplay` on every echo `--replay-user-messages`
-          // produces; a double that omits it invites a gate that cannot tell an
-          // echo from an injected turn.
-          handlers.onMessage?.({
-            ...message,
-            uuid: options.replayUuid ?? 'user-uuid',
-            isReplay: true
-          })
-        }
-      },
-      respond: async (requestId, response) => {
-        connection.replies.push({ requestId, response })
-      },
-      respondWithError: async (requestId, error) => {
-        connection.replies.push({ requestId, error })
-      },
-      close: async () => {
-        connection.closeCount += 1
-        connection.closed = true
-      }
-    }
-    connections.push(connection)
-    return connection
-  }) as typeof openClaudeStreamJsonConnection
-  return { connections, openConnection, routes }
-}
-
-function adapterFor(
-  claude: ReturnType<typeof fakeClaude>,
-  launch: Partial<ClaudeStructuredLaunch> = {},
-  events: ClaudeStructuredSessionEvent[] = [],
-  persistedHandles: unknown[] = [],
-  initTimeoutMs?: number
-): ClaudeStructuredSessionAdapter {
-  return new ClaudeStructuredSessionAdapter({
-    resolveLaunch: async () => ({
-      command: 'claude',
-      args: ['-p'],
-      cwd: '/work/repo',
-      claudeConfigDir: '/accounts/claude',
-      providerSessionId: PROVIDER_SESSION_ID,
-      resumeLeafUuid: null,
-      resumed: false,
-      ...launch
-    }),
-    onEvent: (event) => events.push(event),
-    openConnection: claude.openConnection,
-    readProcessStartTime: async () => 1_700_000_000_000,
-    now: () => 1_700_000_000_500,
-    ...(initTimeoutMs === undefined ? {} : { initTimeoutMs }),
-    dispatchAckTimeoutMs: 10,
-    persistHandle: async (handle) => {
-      persistedHandles.push(handle)
-    }
-  })
-}
-
-async function acquired(
-  claude: ReturnType<typeof fakeClaude>,
-  launch: Partial<ClaudeStructuredLaunch> = {},
-  events: ClaudeStructuredSessionEvent[] = []
-): Promise<ClaudeStructuredSessionAdapter> {
-  const adapter = adapterFor(claude, launch, events)
-  await adapter.acquire({ identity: identityFor(), fence: 7, spawnToken: 'spawn-9' })
-  return adapter
-}
 
 describe('ClaudeStructuredSessionAdapter.acquire', () => {
   it('finishes its startup deadline before the paired mobile request deadline', () => {
@@ -391,8 +223,8 @@ describe('ClaudeStructuredSessionAdapter.acquire', () => {
 })
 
 describe('ClaudeStructuredSessionAdapter turns and controls', () => {
-  it('accepts a dispatch only after Claude replays its provider uuid', async () => {
-    const claude = fakeClaude({ replayUuid: 'user-provider-uuid' })
+  it('accepts a dispatch under the caller UUID written to Claude', async () => {
+    const claude = fakeClaude()
     const adapter = await acquired(claude)
 
     const result = await adapter.dispatch({
@@ -402,12 +234,13 @@ describe('ClaudeStructuredSessionAdapter turns and controls', () => {
       fence: 7
     })
 
+    const sentUuid = claude.connections[0].sent[0]!.uuid
     expect(result).toEqual({
       state: 'accepted',
       providerIdentity: {
         provider: 'claude',
         sessionId: PROVIDER_SESSION_ID,
-        uuid: 'user-provider-uuid'
+        uuid: sentUuid
       }
     })
     expect(claude.connections[0].sent[0]).toMatchObject({
@@ -417,7 +250,7 @@ describe('ClaudeStructuredSessionAdapter turns and controls', () => {
     })
   })
 
-  it('leaves delivery unconfirmed when no replay uuid arrives', async () => {
+  it('accepts a successful write when no replay arrives', async () => {
     const adapter = await acquired(fakeClaude({ replayUuid: null }))
     await expect(
       adapter.dispatch({
@@ -426,7 +259,263 @@ describe('ClaudeStructuredSessionAdapter turns and controls', () => {
         body: USER_MESSAGE,
         fence: 7
       })
-    ).resolves.toMatchObject({ state: 'unknown' })
+    ).resolves.toMatchObject({ state: 'accepted' })
+  })
+
+  it('accepts when the exact echo arrives before the write rejects', async () => {
+    const claude = fakeClaude({ sendErrorAfterReplay: new Error('flush failed') })
+    const adapter = await acquired(claude)
+
+    const result = await adapter.dispatch({
+      sessionId: 'session-1',
+      clientMessageId: 'client-1',
+      body: USER_MESSAGE,
+      fence: 7
+    })
+
+    expect(result).toMatchObject({
+      state: 'accepted',
+      providerIdentity: { uuid: claude.connections[0].sent[0]!.uuid }
+    })
+  })
+
+  it('suppresses a late exact echo after an unobserved write failure', async () => {
+    const claude = fakeClaude({ replayUuid: null, sendError: new Error('broken pipe') })
+    const bodies: AgentJournalItemBody[] = []
+    const events: ClaudeStructuredSessionEvent[] = []
+    const sink: StructuredAgentSessionEventSink = {
+      appendItem: (_identity, body) => bodies.push(body),
+      appendTombstone: () => undefined,
+      publish: () => undefined
+    }
+    const adapter = adapterFor(claude, {}, events)
+    await adapter.acquire({
+      identity: identityFor(),
+      fence: 7,
+      spawnToken: 'spawn-9',
+      events: sink
+    })
+
+    await expect(
+      adapter.dispatch({
+        sessionId: 'session-1',
+        clientMessageId: 'client-1',
+        body: USER_MESSAGE,
+        fence: 7
+      })
+    ).resolves.toEqual({ state: 'unknown', reason: 'broken pipe' })
+    const sent = claude.connections[0].sent[0]!
+    claude.connections[0].handlers.onMessage?.({ ...sent, isReplay: true })
+
+    expect(bodies.filter((body) => body.kind === 'message' && body.role === 'user')).toEqual([])
+    expect(events.at(-1)).toMatchObject({ type: 'message', message: { uuid: sent.uuid } })
+  })
+
+  it('settles only exact owned lifecycle and result identities', async () => {
+    const claude = fakeClaude({ replayUuid: null })
+    const tombstones: string[] = []
+    const sink: StructuredAgentSessionEventSink = {
+      appendItem: () => undefined,
+      appendTombstone: (identity) => {
+        if (identity.provider === 'legacy') {
+          tombstones.push(identity.recordId)
+        }
+      },
+      publish: () => undefined
+    }
+    const adapter = adapterFor(claude)
+    await adapter.acquire({
+      identity: identityFor(),
+      fence: 7,
+      spawnToken: 'spawn-9',
+      events: sink
+    })
+    for (const clientMessageId of ['a', 'b', 'c', 'd']) {
+      await adapter.dispatch({
+        sessionId: 'session-1',
+        clientMessageId,
+        body: USER_MESSAGE,
+        fence: 7
+      })
+    }
+    const [turnA, turnB, turnC, turnD] = claude.connections[0].sent.map(
+      (frame) => frame.uuid as string
+    )
+    const emit = (message: Record<string, unknown>): void =>
+      claude.connections[0].handlers.onMessage?.(message)
+
+    emit({
+      type: 'command_lifecycle',
+      command_uuid: turnA,
+      state: 'future-state',
+      session_id: PROVIDER_SESSION_ID
+    })
+    emit({
+      type: 'command_lifecycle',
+      command_uuid: turnB,
+      state: 'completed',
+      session_id: 'another-session'
+    })
+    emit({ type: 'result', user_message_uuid: 'unknown', session_id: PROVIDER_SESSION_ID })
+    expect(tombstones).toEqual([])
+
+    emit({
+      type: 'command_lifecycle',
+      command_uuid: turnB,
+      state: 'completed',
+      session_id: PROVIDER_SESSION_ID
+    })
+    emit({
+      type: 'command_lifecycle',
+      command_uuid: turnC,
+      state: 'cancelled',
+      session_id: PROVIDER_SESSION_ID
+    })
+    emit({
+      type: 'command_lifecycle',
+      command_uuid: turnD,
+      state: 'discarded',
+      session_id: PROVIDER_SESSION_ID
+    })
+    emit({
+      type: 'result',
+      user_message_uuid: turnA,
+      session_id: PROVIDER_SESSION_ID
+    })
+
+    expect(tombstones).toEqual([
+      `turn-lifecycle:${turnB}`,
+      `turn-lifecycle:${turnC}`,
+      `turn-lifecycle:${turnD}`,
+      `turn-lifecycle:${turnA}`
+    ])
+  })
+
+  it.each(['queued', 'started'])('%s proves delivery without a journal sink', async (state) => {
+    const claude = fakeClaude({
+      replayUuid: null,
+      onSend: (message, handlers) => {
+        handlers.onMessage?.({
+          type: 'command_lifecycle',
+          command_uuid: message.uuid,
+          state,
+          session_id: PROVIDER_SESSION_ID
+        })
+        throw new Error('flush failed')
+      }
+    })
+    const adapter = await acquired(claude)
+
+    const result = await adapter.dispatch({
+      sessionId: 'session-1',
+      clientMessageId: 'client-1',
+      body: USER_MESSAGE,
+      fence: 7
+    })
+    expect(result).toMatchObject({
+      state: 'accepted',
+      providerIdentity: { uuid: claude.connections[0].sent[0]?.uuid }
+    })
+  })
+
+  it('isolates callbacks and owned UUIDs across same-provider-session reacquisition', async () => {
+    const claude = fakeClaude({ replayUuid: null })
+    const events: ClaudeStructuredSessionEvent[] = []
+    const persistedHandles: unknown[] = []
+    const bodies: AgentJournalItemBody[] = []
+    const sink: StructuredAgentSessionEventSink = {
+      appendItem: (_identity, body) => bodies.push(body),
+      appendTombstone: () => undefined,
+      publish: () => undefined
+    }
+    const adapter = adapterFor(claude, {}, events, persistedHandles)
+    await adapter.acquire({
+      identity: identityFor(),
+      fence: 7,
+      spawnToken: 'spawn-9',
+      events: sink
+    })
+    await adapter.dispatch({
+      sessionId: 'session-1',
+      clientMessageId: 'old-client',
+      body: USER_MESSAGE,
+      fence: 7
+    })
+    const oldConnection = claude.connections[0]
+    const oldFrame = oldConnection.sent[0]!
+
+    await adapter.acquire({
+      identity: identityFor(),
+      fence: 8,
+      spawnToken: 'spawn-10',
+      events: sink
+    })
+    const eventCount = events.length
+    oldConnection.handlers.onMessage?.({ ...oldFrame, isReplay: true })
+    expect(events).toHaveLength(eventCount)
+
+    claude.connections[1].handlers.onMessage?.({ ...oldFrame, isReplay: true })
+    expect(bodies.filter((body) => body.kind === 'message' && body.role === 'user')).toHaveLength(1)
+    await adapter.closeSession('session-1')
+    expect(persistedHandles.at(-1)).toMatchObject({ leafUuid: 'init-uuid', fence: 8 })
+  })
+
+  it.each(['close', 'exit'] as const)(
+    'wakes active and queued dispatches on session %s',
+    async (termination) => {
+      const pendingWrite = deferred()
+      const claude = fakeClaude({ replayUuid: null, onSend: () => pendingWrite.promise })
+      const adapter = await acquired(claude)
+      const first = adapter.dispatch({
+        sessionId: 'session-1',
+        clientMessageId: 'client-1',
+        body: USER_MESSAGE,
+        fence: 7
+      })
+      await vi.waitFor(() => expect(claude.connections[0].sent).toHaveLength(1))
+      const second = adapter.dispatch({
+        sessionId: 'session-1',
+        clientMessageId: 'client-2',
+        body: USER_MESSAGE,
+        fence: 7
+      })
+
+      if (termination === 'close') {
+        await adapter.closeSession('session-1')
+      } else {
+        claude.connections[0].handlers.onExit?.(new Error('provider exited'))
+      }
+
+      await expect(first).resolves.toMatchObject({ state: 'unknown' })
+      await expect(second).resolves.toMatchObject({ state: 'rejected' })
+      expect(claude.connections[0].sent).toHaveLength(1)
+      pendingWrite.resolve()
+    }
+  )
+
+  it('marks the session terminal before graceful-close persistence finishes', async () => {
+    const pendingWrite = deferred()
+    const pendingPersistence = deferred()
+    const claude = fakeClaude({ replayUuid: null, onSend: () => pendingWrite.promise })
+    const adapter = adapterFor(claude, {}, [], [], undefined, () => pendingPersistence.promise)
+    await adapter.acquire({ identity: identityFor(), fence: 7, spawnToken: 'spawn-9' })
+    const dispatch = adapter.dispatch({
+      sessionId: 'session-1',
+      clientMessageId: 'client-1',
+      body: USER_MESSAGE,
+      fence: 7
+    })
+    await vi.waitFor(() => expect(claude.connections[0].sent).toHaveLength(1))
+    let closeFinished = false
+    const close = adapter.closeSession('session-1').then(() => {
+      closeFinished = true
+    })
+
+    await expect(dispatch).resolves.toMatchObject({ state: 'unknown' })
+    expect(closeFinished).toBe(false)
+    pendingPersistence.resolve()
+    await close
+    pendingWrite.resolve()
   })
 
   it('requires an acknowledged interrupt and supports controlled options', async () => {

--- a/src/main/claude/claude-structured-session-adapter.test.ts
+++ b/src/main/claude/claude-structured-session-adapter.test.ts
@@ -120,9 +120,13 @@ function fakeClaude(
       send: async (message) => {
         connection.sent.push(message)
         if (message.type === 'user' && options.replayUuid !== null) {
+          // The real CLI stamps `isReplay` on every echo `--replay-user-messages`
+          // produces; a double that omits it invites a gate that cannot tell an
+          // echo from an injected turn.
           handlers.onMessage?.({
             ...message,
-            uuid: options.replayUuid ?? 'user-uuid'
+            uuid: options.replayUuid ?? 'user-uuid',
+            isReplay: true
           })
         }
       },

--- a/src/main/claude/claude-structured-session-adapter.ts
+++ b/src/main/claude/claude-structured-session-adapter.ts
@@ -3,30 +3,21 @@ import type {
   StructuredAgentSessionAcquireInput,
   StructuredAgentSessionAdapter
 } from '../native-chat/agent-session-wire/structured-agent-session-adapter'
-import type { StructuredAgentSessionEventSink } from '../native-chat/agent-session-wire/structured-agent-session-event-sink'
-import {
-  openClaudeStreamJsonConnection,
-  type ClaudeControlRequest,
-  type ClaudeControlResponder
-} from './claude-stream-json-connection'
+import { openClaudeStreamJsonConnection } from './claude-stream-json-connection'
 import { answerClaudePrompt, cancelClaudeTurn } from './claude-structured-control-actions'
-import { dispatchClaudeTurn, resolveClaudeReplayWaiter } from './claude-structured-dispatch'
+import { dispatchClaudeTurn } from './claude-structured-dispatch'
 import {
-  handleClaudeInboundControl,
-  handleClaudeInboundControlCancel
-} from './claude-structured-inbound-control'
-import {
-  claudeAuthDiagnostic,
-  readClaudeFrameString,
-  readClaudeInit,
-  readClaudeModels
-} from './claude-structured-init-proof'
+  createClaudeAcquisitionConnectionHandlers,
+  emitClaudeSessionEvent
+} from './claude-structured-acquisition-events'
+import { claudeAuthDiagnostic, readClaudeModels } from './claude-structured-init-proof'
 import {
   createClaudeInitDeadline,
   requestClaudeInitialization
 } from './claude-structured-init-deadline'
 import { supportsClaudeStructuredLocation } from './claude-structured-location-support'
 import { CLAUDE_SPAWN_TOKEN_ENV, claudeProcessIdentity } from './claude-structured-owner-identity'
+import { ClaudeRetiredSentUserUuids } from './claude-owned-turn-receipts'
 import {
   restoreClaudeStructuredSessionOptions,
   restoredClaudeStructuredSessionOptions,
@@ -46,6 +37,7 @@ import {
 } from './claude-structured-session-state'
 import {
   closeClaudePublishedSession,
+  markClaudeSessionTerminal,
   settleClaudeExitedSession
 } from './claude-structured-session-close'
 
@@ -57,11 +49,11 @@ export type {
 } from './claude-structured-session-state'
 
 export const CLAUDE_STRUCTURED_INIT_TIMEOUT_MS = 10_000
-const DISPATCH_ACK_TIMEOUT_MS = 10_000
 
 export class ClaudeStructuredSessionAdapter implements StructuredAgentSessionAdapter {
   private readonly sessions = new Map<string, ClaudeSession>()
   private readonly acquisitions = new ClaudeAcquisitionRegistry()
+  private readonly retiredSentUserUuids = new ClaudeRetiredSentUserUuids()
 
   constructor(private readonly deps: ClaudeStructuredSessionAdapterDeps) {}
 
@@ -72,38 +64,30 @@ export class ClaudeStructuredSessionAdapter implements StructuredAgentSessionAda
     const prompts = new ClaudePromptRegistry()
     const translator = createClaudeSessionJournalTranslator(input.events, prompts)
     const { previous, attempt } = this.acquisitions.start(sessionId, prompts)
+    const generation = {}
     let liveSession: ClaudeSession | null = null
     let observedLeafUuid: string | null = null
     const initTimeoutMs = this.deps.initTimeoutMs ?? CLAUDE_STRUCTURED_INIT_TIMEOUT_MS
     const initDeadline = createClaudeInitDeadline(sessionId, initTimeoutMs)
 
-    const onMessage = (message: Record<string, unknown>): void => {
-      const init = readClaudeInit(message)
-      if (init) {
-        initDeadline.resolve(init)
-      }
-      observedLeafUuid = readClaudeFrameString(message, 'uuid') ?? observedLeafUuid
-      if (liveSession) {
-        liveSession.leafUuid = observedLeafUuid
-        resolveClaudeReplayWaiter(liveSession, message)
-      }
-      this.deliver(attempt, sessionId, () =>
-        this.emit(liveSession, input.events, { type: 'message', sessionId, message })
-      )
-    }
-    const onControlRequest = (
-      request: ClaudeControlRequest,
-      responder?: ClaudeControlResponder
-    ): void => {
-      handleClaudeInboundControl({
-        sessionId,
-        attempt,
-        request,
-        responder,
-        emit: (event) =>
-          this.deliver(attempt, sessionId, () => this.emit(liveSession, input.events, event))
-      })
-    }
+    const emit = (event: ClaudeStructuredSessionEvent, translate?: boolean): void =>
+      emitClaudeSessionEvent(liveSession, this.deps.onEvent, event, translate)
+    const handlers = createClaudeAcquisitionConnectionHandlers({
+      sessionId,
+      attempt,
+      generation,
+      initDeadline,
+      retiredSentUserUuids: this.retiredSentUserUuids,
+      isCurrentAttempt: () => this.acquisitions.get(sessionId) === attempt,
+      getLiveSession: () => liveSession,
+      isCurrentSession: (session) => this.sessions.get(sessionId) === session,
+      observeLeafUuid: (uuid) => {
+        observedLeafUuid = uuid ?? observedLeafUuid
+      },
+      deliver: (event) => this.deliver(attempt, sessionId, event),
+      emit,
+      onExit: (error) => this.handleExit(sessionId, attempt, error)
+    })
 
     try {
       await cancelClaudeAcquisitionAttempt(previous)
@@ -125,25 +109,7 @@ export class ClaudeStructuredSessionAdapter implements StructuredAgentSessionAda
             CLAUDE_CONFIG_DIR: launch.claudeConfigDir
           }
         },
-        {
-          onMessage,
-          onControlRequest,
-          onControlCancelRequest: ({ request_id: requestId }) => {
-            handleClaudeInboundControlCancel({
-              sessionId,
-              attempt,
-              requestId,
-              emit: (event) =>
-                this.deliver(attempt, sessionId, () => this.emit(liveSession, input.events, event))
-            })
-          },
-          onExit: (error) => {
-            if (!attempt.published) {
-              initDeadline.reject(error)
-            }
-            this.handleExit(sessionId, attempt, error)
-          }
-        }
+        handlers
       )
       attempt.connection = connection
       this.acquisitions.assertCurrent(sessionId, attempt)
@@ -153,9 +119,7 @@ export class ClaudeStructuredSessionAdapter implements StructuredAgentSessionAda
         initDeadline.promise
       ])
       const models = readClaudeModels(initialization)
-      this.deliver(attempt, sessionId, () =>
-        this.emit(liveSession, input.events, { type: 'options', sessionId, models })
-      )
+      this.deliver(attempt, sessionId, () => emit({ type: 'options', sessionId, models }))
       initDeadline.clear()
       this.acquisitions.assertCurrent(sessionId, attempt)
       if (init.providerSessionId !== launch.providerSessionId) {
@@ -167,7 +131,7 @@ export class ClaudeStructuredSessionAdapter implements StructuredAgentSessionAda
         .request('get_settings', {}, { timeoutMs: this.deps.requestTimeoutMs })
         .catch(() => null)
       this.deliver(attempt, sessionId, () =>
-        this.emit(liveSession, input.events, {
+        emit({
           type: 'auth-diagnostic',
           sessionId,
           diagnostic: claudeAuthDiagnostic(init, settings)
@@ -189,6 +153,7 @@ export class ClaudeStructuredSessionAdapter implements StructuredAgentSessionAda
         fence: input.fence,
         resumed: launch.resumed,
         prompts,
+        generation,
         translator,
         events: input.events,
         process,
@@ -236,18 +201,15 @@ export class ClaudeStructuredSessionAdapter implements StructuredAgentSessionAda
     if (!session || session.connection !== attempt.connection) {
       return
     }
+    this.retiredSentUserUuids.retire(sessionId, session)
+    markClaudeSessionTerminal(session)
     this.sessions.delete(sessionId)
-    this.emit(session, session.events, { type: 'ended', sessionId, reason: error.message })
+    emitClaudeSessionEvent(session, this.deps.onEvent, {
+      type: 'ended',
+      sessionId,
+      reason: error.message
+    })
     settleClaudeExitedSession(session)
-  }
-
-  private emit(
-    _session: ClaudeSession | null,
-    _events: StructuredAgentSessionEventSink | undefined,
-    event: ClaudeStructuredSessionEvent
-  ): void {
-    _session?.translator?.handle(event)
-    this.deps.onEvent?.(event)
   }
 
   bindPromptItemId(
@@ -260,11 +222,7 @@ export class ClaudeStructuredSessionAdapter implements StructuredAgentSessionAda
   }
 
   dispatch: StructuredAgentSessionAdapter['dispatch'] = (input) =>
-    dispatchClaudeTurn(
-      this.session(input.sessionId),
-      input,
-      this.deps.dispatchAckTimeoutMs ?? DISPATCH_ACK_TIMEOUT_MS
-    )
+    dispatchClaudeTurn(this.session(input.sessionId), input)
 
   cancelTurn: StructuredAgentSessionAdapter['cancelTurn'] = (input) =>
     cancelClaudeTurn(this.session(input.sessionId), this.deps.requestTimeoutMs)
@@ -293,6 +251,10 @@ export class ClaudeStructuredSessionAdapter implements StructuredAgentSessionAda
   }
 
   private async closePublishedSession(sessionId: string): Promise<void> {
+    const session = this.sessions.get(sessionId)
+    if (session) {
+      this.retiredSentUserUuids.retire(sessionId, session)
+    }
     await closeClaudePublishedSession({
       sessions: this.sessions,
       sessionId,

--- a/src/main/claude/claude-structured-session-close.ts
+++ b/src/main/claude/claude-structured-session-close.ts
@@ -1,16 +1,13 @@
 import type { ClaudeSession, ClaudeStructuredSessionEvent } from './claude-structured-session-state'
 
-export function settleClaudeDispatchWaiters(session: ClaudeSession): void {
-  for (const waiter of session.dispatchWaiters.splice(0)) {
-    clearTimeout(waiter.timer)
-    waiter.resolve(null)
-  }
-}
-
 export function settleClaudeExitedSession(session: ClaudeSession): void {
-  settleClaudeDispatchWaiters(session)
   session.prompts.clear()
   session.translator?.dispose()
+}
+
+export function markClaudeSessionTerminal(session: ClaudeSession): void {
+  session.dispatchFenced = true
+  session.terminal.close()
 }
 
 export async function closeClaudePublishedSession(input: {
@@ -28,8 +25,13 @@ export async function closeClaudePublishedSession(input: {
   if (!session) {
     return
   }
+  markClaudeSessionTerminal(session)
   input.sessions.delete(input.sessionId)
-  settleClaudeDispatchWaiters(session)
+  session.translator?.handle({
+    type: 'ended',
+    sessionId: input.sessionId,
+    reason: 'claude session closed'
+  })
   const pending = session.prompts.clear()
   await Promise.allSettled(
     pending.map((prompt) =>
@@ -64,7 +66,6 @@ export async function closeClaudePublishedSession(input: {
       sessionId: input.sessionId,
       reason: 'claude session closed'
     } as const
-    session.translator?.handle(ended)
     input.onEvent?.(ended)
     session.translator?.dispose()
     await session.connection.close()

--- a/src/main/claude/claude-structured-session-publication.ts
+++ b/src/main/claude/claude-structured-session-publication.ts
@@ -3,7 +3,7 @@ import { readClaudeFrameString, type ClaudeInitObservation } from './claude-stru
 import { claudeProviderHandleLink } from './claude-structured-owner-identity'
 import type { ClaudePromptRegistry } from './claude-structured-prompt-replies'
 import type { ClaudeJournalTranslator } from './claude-structured-journal-translation'
-import type { ClaudeSession } from './claude-structured-session-state'
+import { createClaudeSessionTerminal, type ClaudeSession } from './claude-structured-session-state'
 
 export function createClaudeSessionPublication(input: {
   connection: ClaudeSession['connection']
@@ -12,6 +12,7 @@ export function createClaudeSessionPublication(input: {
   fence: number
   resumed: boolean
   prompts: ClaudePromptRegistry
+  generation: object
   translator: ClaudeJournalTranslator | null
   events: ClaudeSession['events']
   process: AgentSessionAcquisition['process']
@@ -39,7 +40,12 @@ export function createClaudeSessionPublication(input: {
       leafUuid: input.leafUuid,
       fence: input.fence,
       prompts: input.prompts,
-      dispatchWaiters: [],
+      generation: input.generation,
+      sentUserUuidSequence: new Map(),
+      deliveryEvidenceUuids: new Set(),
+      dispatchLane: Promise.resolve(),
+      dispatchFenced: false,
+      terminal: createClaudeSessionTerminal(),
       options: new Map(input.options),
       reportedOptions: {
         ...(model ? { model } : {}),

--- a/src/main/claude/claude-structured-session-state.ts
+++ b/src/main/claude/claude-structured-session-state.ts
@@ -65,6 +65,9 @@ export type ClaudeSession = {
   fence: number
   prompts: ClaudePromptRegistry
   dispatchWaiters: ClaudeDispatchWaiter[]
+  /** Set once this CLI is seen stamping `isReplay` on its user echo. From then on
+   *  a frame without it cannot be an echo, so the shape fallback is switched off. */
+  sawUserReplayMarker?: boolean
   options: Map<string, string>
   reportedOptions: { model?: string; effort?: string }
   translator: ClaudeJournalTranslator | null

--- a/src/main/claude/claude-structured-session-state.ts
+++ b/src/main/claude/claude-structured-session-state.ts
@@ -72,6 +72,10 @@ export type ClaudeSession = {
   fence: number
   prompts: ClaudePromptRegistry
   dispatchWaiters: ClaudeDispatchWaiter[]
+  /** Uuids of dispatches that left the queue without their echo (timed out, or
+   *  the send failed). Their replay can still arrive, and it must be dropped
+   *  rather than fall through to the head - it belongs to nobody now. */
+  retiredSentUuids?: string[]
   options: Map<string, string>
   reportedOptions: { model?: string; effort?: string }
   translator: ClaudeJournalTranslator | null

--- a/src/main/claude/claude-structured-session-state.ts
+++ b/src/main/claude/claude-structured-session-state.ts
@@ -56,6 +56,13 @@ export type ClaudeDispatchWaiter = {
   resolve: (uuid: string | null) => void
   timer: ReturnType<typeof setTimeout>
   acceptsResult: boolean
+  /** The uuid stamped on this dispatch's outgoing frame. The CLI echoes a
+   *  client-supplied uuid verbatim, so a replay carrying it belongs to THIS
+   *  send - no queue-position guessing. */
+  sentUuid: string
+  /** Set when this waiter was actually settled, so a caller can tell "my replay
+   *  arrived" from "something removed me from the queue". */
+  settledUuid?: string
 }
 
 export type ClaudeSession = {

--- a/src/main/claude/claude-structured-session-state.ts
+++ b/src/main/claude/claude-structured-session-state.ts
@@ -65,9 +65,6 @@ export type ClaudeSession = {
   fence: number
   prompts: ClaudePromptRegistry
   dispatchWaiters: ClaudeDispatchWaiter[]
-  /** Set once this CLI is seen stamping `isReplay` on its user echo. From then on
-   *  a frame without it cannot be an echo, so the shape fallback is switched off. */
-  sawUserReplayMarker?: boolean
   options: Map<string, string>
   reportedOptions: { model?: string; effort?: string }
   translator: ClaudeJournalTranslator | null

--- a/src/main/claude/claude-structured-session-state.ts
+++ b/src/main/claude/claude-structured-session-state.ts
@@ -43,7 +43,6 @@ export type ClaudeStructuredSessionAdapterDeps = {
   now?: () => number
   requestTimeoutMs?: number
   initTimeoutMs?: number
-  dispatchAckTimeoutMs?: number
   persistHandle?: (input: {
     sessionId: string
     providerSessionId: string
@@ -52,34 +51,46 @@ export type ClaudeStructuredSessionAdapterDeps = {
   }) => Promise<void>
 }
 
-export type ClaudeDispatchWaiter = {
-  resolve: (uuid: string | null) => void
-  timer: ReturnType<typeof setTimeout>
-  acceptsResult: boolean
-  /** The uuid stamped on this dispatch's outgoing frame. The CLI echoes a
-   *  client-supplied uuid verbatim, so a replay carrying it belongs to THIS
-   *  send - no queue-position guessing. */
-  sentUuid: string
-  /** Set when this waiter was actually settled, so a caller can tell "my replay
-   *  arrived" from "something removed me from the queue". */
-  settledUuid?: string
-}
-
 export type ClaudeSession = {
   connection: ClaudeStreamJsonConnection
   providerSessionId: string
   leafUuid: string | null
   fence: number
   prompts: ClaudePromptRegistry
-  dispatchWaiters: ClaudeDispatchWaiter[]
-  /** Uuids of dispatches that left the queue without their echo (timed out, or
-   *  the send failed). Their replay can still arrive, and it must be dropped
-   *  rather than fall through to the head - it belongs to nobody now. */
-  retiredSentUuids?: string[]
+  generation: object
+  sentUserUuidSequence: Map<string, number>
+  deliveryEvidenceUuids: Set<string>
+  dispatchLane: Promise<void>
+  dispatchFenced: boolean
+  terminal: ClaudeSessionTerminal
   options: Map<string, string>
   reportedOptions: { model?: string; effort?: string }
   translator: ClaudeJournalTranslator | null
   events: StructuredAgentSessionEventSink | undefined
+}
+
+export type ClaudeSessionTerminal = {
+  closed: boolean
+  signal: Promise<void>
+  close: () => void
+}
+
+export function createClaudeSessionTerminal(): ClaudeSessionTerminal {
+  let close = (): void => {}
+  const terminal: ClaudeSessionTerminal = {
+    closed: false,
+    signal: new Promise<void>((resolve) => {
+      close = resolve
+    }),
+    close: () => {
+      if (terminal.closed) {
+        return
+      }
+      terminal.closed = true
+      close()
+    }
+  }
+  return terminal
 }
 
 export type ClaudeAcquisitionAttempt = {

--- a/src/main/runtime/claude-structured-session-integration.test.ts
+++ b/src/main/runtime/claude-structured-session-integration.test.ts
@@ -52,6 +52,7 @@ type FakeClaudeConnection = Omit<ClaudeStreamJsonConnection, 'closed'> & {
 function fakeClaude() {
   const connections: FakeClaudeConnection[] = []
   let initializeAccount: unknown
+  let nextSendError: Error | null = null
   const openConnection = (async (launch, handlers = {}) => {
     const connection: FakeClaudeConnection = {
       launch,
@@ -81,10 +82,13 @@ function fakeClaude() {
       },
       send: async (message) => {
         connection.sent.push(message)
+        if (nextSendError) {
+          const error = nextSendError
+          nextSendError = null
+          throw error
+        }
         if (message.type === 'user') {
-          // The real CLI stamps `isReplay` on the echo `--replay-user-messages`
-          // produces; a double that omits it does not exercise the send path.
-          handlers.onMessage?.({ ...message, uuid: 'user-1', isReplay: true })
+          handlers.onMessage?.({ ...message, isReplay: true })
         }
       },
       respond: async (requestId, response) => {
@@ -111,6 +115,9 @@ function fakeClaude() {
     live,
     setInitializeAccount: (account: unknown) => {
       initializeAccount = account
+    },
+    failNextSend: (error: Error) => {
+      nextSendError = error
     }
   }
 }
@@ -402,10 +409,13 @@ describe('a structured Claude session over agentSession.*', () => {
       envelope: envelope('agentSession.send', { body }, created.fence),
       body
     })
+    const sentUuid = claude.live().sent[0]!.uuid as string
     expect(sent.submission).toMatchObject({
       dispatchState: 'accepted',
-      providerItemId: `claude:${PROVIDER_SESSION}:user-1`
+      providerItemId: `claude:${PROVIDER_SESSION}:${sentUuid}`
     })
+    await getStructuredAgentSessionHost()?.flushStreamedEvents(SESSION)
+    expect(itemsOf(stream).filter((item) => textOf(item) === 'List files')).toHaveLength(1)
 
     claude.live().handlers.onMessage?.({
       type: 'stream_event',
@@ -481,6 +491,72 @@ describe('a structured Claude session over agentSession.*', () => {
       },
       origin: 'resumed'
     })
+  })
+
+  it('does not duplicate a late exact echo after an unknown write', async () => {
+    const created = await ok<{ fence: number }>('agentSession.create', createIntentParams())
+    const stream = await subscribe()
+    const body = { kind: 'message', role: 'user', blocks: [{ type: 'text', text: 'Queued' }] }
+    claude.failNextSend(new Error('broken pipe'))
+
+    const sent = await ok<{ submission: { dispatchState: string } }>('agentSession.send', {
+      envelope: envelope('agentSession.send', { body }, created.fence),
+      body
+    })
+    expect(sent.submission.dispatchState).toBe('unknown')
+    const frame = claude.live().sent[0]!
+    claude.live().handlers.onMessage?.({ ...frame, isReplay: true })
+    await getStructuredAgentSessionHost()?.flushStreamedEvents(SESSION)
+
+    expect(itemsOf(stream).filter((item) => textOf(item) === 'Queued')).toHaveLength(1)
+  })
+
+  it('settles a queued command and root result by their exact owned identities', async () => {
+    const created = await ok<{ fence: number }>('agentSession.create', createIntentParams())
+    const stream = await subscribe()
+    const send = async (text: string): Promise<void> => {
+      const body = { kind: 'message', role: 'user', blocks: [{ type: 'text', text }] }
+      await ok('agentSession.send', {
+        envelope: envelope('agentSession.send', { body }, created.fence),
+        body
+      })
+    }
+    await send('Root command')
+    await send('Queued command')
+    const [turnA, turnB] = claude.live().sent.map((frame) => frame.uuid as string)
+    await getStructuredAgentSessionHost()?.flushStreamedEvents(SESSION)
+    const removedIds = (): string[] =>
+      stream.flatMap((frame) => (frame.type === 'batch' ? frame.batch.removedItemIds : []))
+
+    for (const state of ['queued', 'started']) {
+      claude.live().handlers.onMessage?.({
+        type: 'command_lifecycle',
+        command_uuid: turnB,
+        state,
+        session_id: PROVIDER_SESSION
+      })
+    }
+    await getStructuredAgentSessionHost()?.flushStreamedEvents(SESSION)
+    expect(removedIds()).toEqual([])
+
+    claude.live().handlers.onMessage?.({
+      type: 'command_lifecycle',
+      command_uuid: turnB,
+      state: 'completed',
+      session_id: PROVIDER_SESSION
+    })
+    await getStructuredAgentSessionHost()?.flushStreamedEvents(SESSION)
+    expect(removedIds()).toHaveLength(1)
+    expect(removedIds()[0]).toContain(encodeURIComponent(turnB))
+
+    claude.live().handlers.onMessage?.({
+      type: 'result',
+      user_message_uuid: turnA,
+      session_id: PROVIDER_SESSION
+    })
+    await getStructuredAgentSessionHost()?.flushStreamedEvents(SESSION)
+    expect(removedIds()).toHaveLength(2)
+    expect(removedIds()[1]).toContain(encodeURIComponent(turnA))
   })
 
   it('completes a scripted native to TUI to native cycle with provider-history rehydration', async () => {

--- a/src/main/runtime/claude-structured-session-integration.test.ts
+++ b/src/main/runtime/claude-structured-session-integration.test.ts
@@ -82,7 +82,9 @@ function fakeClaude() {
       send: async (message) => {
         connection.sent.push(message)
         if (message.type === 'user') {
-          handlers.onMessage?.({ ...message, uuid: 'user-1' })
+          // The real CLI stamps `isReplay` on the echo `--replay-user-messages`
+          // produces; a double that omits it does not exercise the send path.
+          handlers.onMessage?.({ ...message, uuid: 'user-1', isReplay: true })
         }
       },
       respond: async (requestId, response) => {


### PR DESCRIPTION
## ELI5

On the structured (Claude SDK) lane, Orca shows your message immediately and then waits for Claude to echo it back so it can tie the two together by id. Claude uses the same frame shape (`type: "user"`) for several different things: the echo of what you typed, results coming back from tools, and its own injected notices. Orca grabbed whichever arrived first — so if you sent a message while the agent was mid-turn running tools, Orca latched onto the wrong one, and your real message then arrived with nowhere to attach and rendered a second time.

## What Changed

Two behaviour changes in `claude-structured-dispatch.ts`, plus two test doubles corrected.

**1. The waiter settles only on the real echo.**

```ts
message.type === 'user' && message.parent_tool_use_id === null && message.isReplay === true
  && !isKnownHarnessInjectedUserTurnText(frameText)
```

`CLAUDE_STRUCTURED_BASE_ARGS` passes `--replay-user-messages` unconditionally, and the CLI stamps `isReplay` on every echo it produces in reply — measured on 2.1.237 for text, image-only and text+image sends.

**But the marker alone is not sufficient**, and the binary is the evidence. 2.1.237 enqueues the model-switch breadcrumb as `{type:'user', parent_tool_use_id:null, isReplay:true}` with the string content `<local-command-stdout>Set model to …`. Orca triggers that path itself — the model picker's `setClaudeStructuredOption` sends `set_model`, and reconnect replays it — so a send in flight during a model switch adopted the breadcrumb's uuid and the real echo appended a second row. The CLI cannot use the marker alone either; its own RemoteSessionManager filters the same frames by content prefix and logs `Dropped own set_model breadcrumb echo`. Hence the harness-shape rejection on top, using the existing `isKnownHarnessInjectedUserTurnText`.

**2. A dispatch settles only on evidence that belongs to it.**

- The send-failure path shifted `dispatchWaiters[0]` instead of its own waiter, so with two sends in flight a broken pipe on the second resolved the **first** as "delivery unconfirmed" despite it being delivered. It now splices its own, mirroring the timeout path. It also no longer discards an identity the replay already claimed: a write can reach Claude and still reject on the following flush, and reporting `unknown` there stranded a uuid nothing else could adopt.
- `acceptsResult` — which lets a send settle on a bare `result` frame carrying no correlation to the waiting dispatch — was set for any text starting with `/`, so `/Users/me/repo/src/foo.ts — explain this` and `/README.md — what does this do?` opted in and an unrelated turn's result could claim their identity. It now matches a command token (`/model`, `/clear`, `/project:foo`), and does not trim leading whitespace — following `classifyNativeChatSend`'s documented rule that only a line-leading token is a command. Deliberately stricter than that shared classifier: over-classifying there only suppresses an echo, but here it claims a wrong identity.

**3. Both fake Claude connections now stamp `isReplay`,** like the real binary. They did not, which is what made a content-sniffing gate look necessary in the first place — three review rounds were spent designing against a frame shape that does not exist. `--replay-user-messages` is now pinned by a test, because with the doubles stamping the marker themselves nothing else asserted the flag that makes the real CLI emit it.

## Why

Reproduced against the real binary. One turn emits **two** top-level `user` frames, both with a null `parent_tool_use_id`:

```
USER FRAME isReplay=True  ptui=None contentTypes=['text']         uuid=ccff3dc8-...   <- the real replay
USER FRAME isReplay=None  ptui=None contentTypes=['tool_result']  uuid=7bbb4161-...   <- a tool result
```

The old predicate was `message.type === 'user' && message.parent_tool_use_id === null`, which accepts both — and also accepts Claude's injected user turns (interruption notices, system reminders, local-command output). Those are the worse half of the class: unlike a tool result they **do** build a journal body, so adopting one upserts harness text over the user's own bubble *and* leaves the real replay to append a second row.

`journal-store.ts` already names the hazard verbatim:

> Accepting REQUIRES the provider identity rather than a free-form id: the adopted key is what the provider's echo will upsert into, so a mismatched string here would silently give the user a second copy of their own message.

### Timing, measured

A queued send's replay is published at the **first tool boundary after it is queued**, 2–3 ms after that boundary's tool result — not at turn end. Three-tool turn, second message written to stdin at 1004 ms:

```
  1004ms >>> queueing SECOND message
  4772ms USER isReplay=undefined content=["tool_result"]
  4774ms USER isReplay=true  content=["text"] "SECOND: reply TWO."
 22194ms result
```

**Scope of that measurement, precisely:** it covers the *tool-result* case, where the correct frame follows the wrongly-adopted one almost immediately, so any window that caught one caught both. It does **not** cover an *injected* turn — nothing follows that one, so where the old predicate settled the waiter promptly with a wrong identity, the waiter now times out. The send is then honestly `unknown` rather than silently corrupted, but the timeout path is more reachable than before.

### Why this branch and not `main`

`src/main/claude/claude-structured-dispatch.ts` exists only on the Claude structured lane. `main` has no structured Claude transport, and `brennanb2025/codex-structured-core` has no `src/main/claude/claude-structured-*` files at all.

### Context

This came out of investigating a duplicate user bubble on the **bridge** lane (PR #15656). That bug's root cause — a Ctrl+U byte in the transcript row defeating normalized text equality — **cannot** occur here: there is no PTY, and `journal-submission-reconciler.ts` states the rule outright ("Matching is by identity only … Never by text equality"). The same user-visible symptom was reachable through this identity seam instead.

## Correlation is now exact, not positional

The last review round pointed out that the CLI round-trips a client-supplied `uuid`. Measured, and it does:

```
stdin : {"type":"user","uuid":"11111111-2222-4333-8444-555555555555", ...}
stdout: replay uuid = 11111111-2222-4333-8444-555555555555   (echoes client uuid? YES)
```

So `dispatchClaudeTurn` stamps one and `resolveClaudeReplayWaiter` matches the echo on it. That closes what earlier revisions of this description called a structural limit "wanting its own change" — it turned out to be a field on the outgoing frame:

- a late replay no longer settles the **next** dispatch after its own waiter timed out, handing it the previous send's identity;
- the send-failure path checks `waiter.settledUuid` — positive evidence that *this* waiter was settled — instead of inferring adoption from queue membership, which could return `accepted` carrying another dispatch's uuid.

The CLI also dedupes on the input uuid, so a resent frame cannot land twice.

The `isReplay` + harness-shape gates remain as the **compat path** for a CLI that mints its own uuid instead of echoing ours; there the frame carries no correlation at all and the head is the only candidate. Every test written before this change exercises that path, because their frames carry uuids matching no waiter.

## Known-remaining, not fixed here

- **The outgoing frame now carries a `uuid` field.** A CLI with a strict input schema would reject the whole message rather than merely fail to echo it. Accepted by 2.1.237 (measured), untested elsewhere — the same version-floor gap as below, but with a harder failure mode.
- **The `isReplay` dependency is verified only behind an availability gate.** `claude-tui-resume-real-binary.integration.test.ts` *does* dispatch against the real binary and assert `state: 'accepted'`, which can only pass if the replay was adopted - so the marker is covered end-to-end, and it passes locally against 2.1.237. But it is `describe.skipIf(!claudeAvailable)`, so on a runner without the binary nothing exercises the un-stamped path and CI is green either way. `resolveClaudeCommand` lets a user point Orca at an arbitrary `claude`, so a fork or older build that honours the flag without stamping would make every send block its 10 s budget and report "delivery unconfirmed". A claude-CLI version floor is the missing piece.
- **A text+image replay drops the image from the user's bubble.** `messageBlocks` keeps only URL images while dispatch base64-encodes local paths, so the echo upserts a text-only body over the submission item. Pre-existing; the new test covers only the image-only case, where nothing upserts at all.
- **Large image sends may exceed the stdout line cap.** `MAX_TOTAL_IMAGE_BYTES` is 20 MiB raw (~27 MiB base64) while `STDOUT_LINE_MAX_BYTES` is 8 MiB, and `--replay-user-messages` echoes the message back as one line. Two 5 MiB PNGs already exceed it. Pre-existing and unrelated to this gate, surfaced while reviewing it.
- **`cancelTurn` does not retire a waiter.** Not the hang it looks like — measured, a queued send's replay lands ~1 s after an interrupt, so the waiter settles normally.

## Linked Issue

Follow-on hardening from the duplicate-echo report by @BrennanKB5 on 2026-08-20. Same symptom class, different lane and different mechanism.

Fixes #

## Visual Proof

N/A — no UI code changed. The user-visible effect is the absence of a duplicated bubble, covered by the regression tests.

## Testing

Red against the merge base (`brennanb2025/claude-structured-mobile`):

```
x does not adopt a tool-result turn as the user replay
    AssertionError: expected [] to have a length of 1 but got +0
x does not adopt a harness-injected user turn as the user replay
    AssertionError: expected [] to have a length of 1 but got +0
x retires its own waiter when the send fails, not the one at the head
    AssertionError: expected [ { acceptsResult: false, ... } ] to deeply equal [ ... ]
x does not let a path-leading message settle on an unrelated result frame
    AssertionError: expected [] to have a length of 1 but got +0
x pre-mints a stable provider id and pins interactive setting sources
    AssertionError: expected [ '-p', '--input-format', ...(9) ] to include '--replay-user-messages'
```

**Not** red against the merge base, and its comment now says so: `accepts the replay of a send that carries only a local image`. The old predicate accepts that frame too. It pins that the gate never sniffs content — an image-only echo carries no text and builds no journal body, so any body-model gate would refuse the send its own replay. That guarantee was worth keeping after an intermediate round shipped exactly such a gate and had to be undone.

- `npx tsc --noEmit -p config/tsconfig.node.json` — clean
- `npx vitest run --no-file-parallelism src/main/claude src/main/runtime/claude-structured-session-integration.test.ts` — 28 of 29 files, 315 tests pass. The one failure, `claude-structured-real-cli.test.ts > proves a pre-minted session before the first user message`, is pre-existing on this branch (verified by reverting all changed files).
- `npx oxlint src/main/claude` and `npx oxfmt --check` — clean

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

Ten `/code-review` rounds at high effort. The ones that changed the code:

- **R1** — gating on `claudeMessageBody(...) !== null` inherits that function's content model, so an image-only send was refused its own replay. Two HIGH timeout concerns from the same round were **refuted by measurement**.
- **R2** — "not a tool result" still admits harness-injected turns, which are worse because they upsert a body.
- **R3** — the shape fallback was still load-bearing for any injected shape not on the allowlist.
- **R4** — the image test did not guard the branch its comment named (the frame was stamped, so the gate short-circuited); reproduced with the reviewer's own mutation.
- **R5** — the send-failure path shifted the queue head.
- **R6** — the latch reset per reconnect. Rather than patch a fourth defect into the fallback, I measured whether it was needed at all and **deleted it** (-98 lines).
- **R7** — a second fake, under `src/main/runtime`, also echoed unstamped; it turned CI red and I had missed it with a path-filtered local run.
- **R8** — the replay flag was unpinned; because the doubles synthesize the marker, dropping it left the suite fully green.
- **R9** — the diagnostic added in R8 false-positived on healthy interrupt frames and its process-wide latch consumed the signal; reverted.
- **R10** — `acceptsResult` matched any `/`-leading text, and the image test's red-then-green claim was wrong.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

- **Backwards compatibility:** narrows which provider frames can settle a dispatch, in the strictly safer direction — an unclassifiable frame leaves the send `unknown` rather than adopting a wrong identity.
- **Performance:** one field read per inbound top-level `user` frame.
- **Cross-platform / SSH:** none — the gate reads the provider's stdout frames, identical on every host.
- **Mobile:** the mobile structured timeline adopts outbox entries by `agentJournalSubmissionKey(clientMessageId)`, so it inherits the fix through the journal alias with no mobile-side change.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] Lint / typecheck / relevant tests pass locally (see Testing)




