### PR TITLE
fix(tabs): follow live Claude session names instead of the first prompt (STA-4865)

### DIFF
--- a/src/renderer/src/components/tab-group/useTabGroupItemProjections.test.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupItemProjections.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest'
+import type * as ReactActual from 'react'
+import { resolveTerminalTabTitle } from '../../../../shared/tab-title-resolution'
+import type { Tab, TabGroup } from '../../../../shared/tab-types'
+import type { TerminalTab } from '../../../../shared/terminal-tab-types'
+import {
+  useTabGroupItemProjections,
+  type TabGroupWorktreeSnapshot
+} from './useTabGroupItemProjections'
+
+vi.mock('react', async () => {
+  const actual = await vi.importActual<typeof ReactActual>('react')
+  return {
+    ...actual,
+    useMemo: <T>(factory: () => T) => factory()
+  }
+})
+
+const WORKTREE_ID = 'wt-1'
+const GROUP_ID = 'group-1'
+const TAB_ID = 'term-1'
+const NOW = 1_700_000_000_000
+
+const aiVaultTitle = {
+  agent: 'claude' as const,
+  sessionId: 'claude-session-1',
+  title: 'Housekeeping'
+}
+
+function makeTerminalTab(overrides: Partial<TerminalTab> = {}): TerminalTab {
+  return {
+    id: TAB_ID,
+    ptyId: 'pty-1',
+    worktreeId: WORKTREE_ID,
+    title: '✳ pull again',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: NOW,
+    generatedTitle: 'Pull again',
+    aiVaultTitle,
+    ...overrides
+  }
+}
+
+function makeUnifiedTab(overrides: Partial<Tab> = {}): Tab {
+  return {
+    id: 'unified-term-1',
+    entityId: TAB_ID,
+    groupId: GROUP_ID,
+    worktreeId: WORKTREE_ID,
+    contentType: 'terminal',
+    label: '✳ pull again',
+    customLabel: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: NOW,
+    generatedLabel: 'Pull again',
+    aiVaultTitle,
+    ...overrides
+  }
+}
+
+function makeState(args: {
+  terminalTab?: TerminalTab
+  unifiedTab?: Tab
+}): TabGroupWorktreeSnapshot {
+  const terminalTab = args.terminalTab ?? makeTerminalTab()
+  const unifiedTab = args.unifiedTab ?? makeUnifiedTab()
+  const group: TabGroup = {
+    id: GROUP_ID,
+    worktreeId: WORKTREE_ID,
+    activeTabId: unifiedTab.id,
+    tabOrder: [unifiedTab.id]
+  }
+  return {
+    groups: [group],
+    unifiedTabs: [unifiedTab],
+    terminalTabs: [terminalTab],
+    openFiles: [],
+    browserTabs: [],
+    expandedPaneByTabId: {},
+    terminalLayoutsByTabId: {},
+    generatedTabTitlesEnabled: true,
+    mobileEmulatorEnabled: true
+  }
+}
+
+describe('useTabGroupItemProjections', () => {
+  it('keeps the live AI Vault title on the tab-bar projection so generated cannot re-win', () => {
+    const { terminalTabs } = useTabGroupItemProjections({
+      groupId: GROUP_ID,
+      worktreeId: WORKTREE_ID,
+      worktreeState: makeState({})
+    })
+
+    const projected = terminalTabs[0]
+    expect(projected?.aiVaultTitle).toEqual(aiVaultTitle)
+    expect(projected ? resolveTerminalTabTitle(projected, true) : undefined).toBe('Housekeeping')
+  })
+
+  it('keeps an explicit-null AI Vault title on the tab-bar projection', () => {
+    const { terminalTabs } = useTabGroupItemProjections({
+      groupId: GROUP_ID,
+      worktreeId: WORKTREE_ID,
+      worktreeState: makeState({
+        terminalTab: makeTerminalTab({ aiVaultTitle: null, generatedTitle: undefined }),
+        unifiedTab: makeUnifiedTab({ aiVaultTitle: null, generatedLabel: undefined })
+      })
+    })
+
+    expect(terminalTabs[0]?.aiVaultTitle).toBeNull()
+  })
+})

--- a/src/renderer/src/components/tab-group/useTabGroupItemProjections.test.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupItemProjections.test.ts
@@ -111,4 +111,19 @@ describe('useTabGroupItemProjections', () => {
 
     expect(terminalTabs[0]?.aiVaultTitle).toBeNull()
   })
+
+  it('uses a terminal clear when the unified tab still has stale title metadata', () => {
+    const { terminalTabs } = useTabGroupItemProjections({
+      groupId: GROUP_ID,
+      worktreeId: WORKTREE_ID,
+      worktreeState: makeState({
+        terminalTab: makeTerminalTab({ aiVaultTitle: null }),
+        unifiedTab: makeUnifiedTab()
+      })
+    })
+
+    expect(terminalTabs[0]?.aiVaultTitle).toBeNull()
+    expect(terminalTabs[0]?.title).toBe('✳ pull again')
+    expect(resolveTerminalTabTitle(terminalTabs[0]!, true)).toBe('✳ pull again')
+  })
 })

--- a/src/renderer/src/components/tab-group/useTabGroupItemProjections.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupItemProjections.ts
@@ -73,6 +73,12 @@ export function useTabGroupItemProjections({
             defaultTitle: terminalTab?.defaultTitle,
             quickCommandLabel: terminalTab?.quickCommandLabel ?? item.quickCommandLabel ?? null,
             generatedTitle: terminalTab?.generatedTitle ?? item.generatedLabel ?? null,
+            // Why: TabBar re-resolves this projection; dropping vault lets first-bind generated win.
+            ...(terminalTab?.aiVaultTitle !== undefined
+              ? { aiVaultTitle: terminalTab.aiVaultTitle }
+              : item.aiVaultTitle !== undefined
+                ? { aiVaultTitle: item.aiVaultTitle }
+                : {}),
             customTitle: item.customLabel ?? terminalTab?.customTitle ?? null,
             color: item.color ?? terminalTab?.color ?? null,
             sortOrder: item.sortOrder,

--- a/src/renderer/src/components/tab-group/useTabGroupItemProjections.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupItemProjections.ts
@@ -56,6 +56,8 @@ export function useTabGroupItemProjections({
         .filter((item) => item.contentType === 'terminal')
         .map((item) => {
           const terminalTab = terminalTabById.get(item.entityId)
+          const aiVaultTitle =
+            terminalTab?.aiVaultTitle !== undefined ? terminalTab.aiVaultTitle : item.aiVaultTitle
           return {
             id: item.entityId,
             unifiedTabId: item.id,
@@ -65,7 +67,8 @@ export function useTabGroupItemProjections({
               {
                 ...item,
                 quickCommandLabel: item.quickCommandLabel ?? terminalTab?.quickCommandLabel,
-                generatedLabel: item.generatedLabel ?? terminalTab?.generatedTitle
+                generatedLabel: item.generatedLabel ?? terminalTab?.generatedTitle,
+                aiVaultTitle
               },
               worktreeState.generatedTabTitlesEnabled,
               item.label
@@ -74,11 +77,7 @@ export function useTabGroupItemProjections({
             quickCommandLabel: terminalTab?.quickCommandLabel ?? item.quickCommandLabel ?? null,
             generatedTitle: terminalTab?.generatedTitle ?? item.generatedLabel ?? null,
             // Why: TabBar re-resolves this projection; dropping vault lets first-bind generated win.
-            ...(terminalTab?.aiVaultTitle !== undefined
-              ? { aiVaultTitle: terminalTab.aiVaultTitle }
-              : item.aiVaultTitle !== undefined
-                ? { aiVaultTitle: item.aiVaultTitle }
-                : {}),
+            ...(aiVaultTitle !== undefined ? { aiVaultTitle } : {}),
             customTitle: item.customLabel ?? terminalTab?.customTitle ?? null,
             color: item.color ?? terminalTab?.color ?? null,
             sortOrder: item.sortOrder,

--- a/src/renderer/src/lib/ai-vault-tab-title-sync-inputs.test.ts
+++ b/src/renderer/src/lib/ai-vault-tab-title-sync-inputs.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { createTestStore, makeTab } from '@/store/slices/store-test-helpers'
+import { aiVaultTitleSyncInputsChanged } from './ai-vault-tab-title-sync-inputs'
+
+describe('aiVaultTitleSyncInputsChanged', () => {
+  it('distinguishes an absent Vault title from an explicit clear', () => {
+    const previous = createTestStore().getState()
+    const tab = makeTab({ id: 'terminal-1', worktreeId: 'wt-1' })
+    const withAbsent = {
+      ...previous,
+      tabsByWorktree: { 'wt-1': [tab] }
+    }
+    const withClear = {
+      ...withAbsent,
+      tabsByWorktree: { 'wt-1': [{ ...tab, aiVaultTitle: null }] }
+    }
+
+    expect(aiVaultTitleSyncInputsChanged(withClear, withAbsent)).toBe(true)
+    expect(aiVaultTitleSyncInputsChanged(withClear, withClear)).toBe(false)
+  })
+})

--- a/src/renderer/src/lib/ai-vault-tab-title-sync-inputs.ts
+++ b/src/renderer/src/lib/ai-vault-tab-title-sync-inputs.ts
@@ -1,6 +1,8 @@
 import type { AgentProviderSessionMetadata } from '../../../shared/agent-session-resume'
-import { isAiVaultTitleAgent } from '../../../shared/ai-vault-session-title'
-import type { TerminalTab } from '../../../shared/terminal-tab-types'
+import {
+  aiVaultSessionTitlesEqual,
+  isAiVaultTitleAgent
+} from '../../../shared/ai-vault-session-title'
 import { getExecutionHostIdForWorktree } from '@/lib/worktree-runtime-owner'
 import type { AppState } from '@/store/types'
 import { collectAiVaultTitleRequests } from './ai-vault-tab-title-requests'
@@ -92,17 +94,6 @@ function agentRecordsEqual(current: AppState, previous: AppState): boolean {
   )
 }
 
-function titleEqual(
-  left: TerminalTab['aiVaultTitle'],
-  right: TerminalTab['aiVaultTitle']
-): boolean {
-  return (
-    left?.agent === right?.agent &&
-    left?.sessionId === right?.sessionId &&
-    left?.title === right?.title
-  )
-}
-
 function terminalTabsEqual(current: AppState, previous: AppState): boolean {
   const currentKeys = Object.keys(current.tabsByWorktree)
   const previousKeys = Object.keys(previous.tabsByWorktree)
@@ -121,7 +112,7 @@ function terminalTabsEqual(current: AppState, previous: AppState): boolean {
       if (
         left.id !== right.id ||
         left.worktreeId !== right.worktreeId ||
-        !titleEqual(left.aiVaultTitle, right.aiVaultTitle)
+        !aiVaultSessionTitlesEqual(left.aiVaultTitle, right.aiVaultTitle)
       ) {
         return false
       }

--- a/src/renderer/src/lib/ai-vault-tab-title-sync.test.ts
+++ b/src/renderer/src/lib/ai-vault-tab-title-sync.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
-import type { AiVaultSessionTitlesResult } from '../../../shared/ai-vault-session-title'
+import type {
+  AiVaultSessionTitlesArgs,
+  AiVaultSessionTitlesResult
+} from '../../../shared/ai-vault-session-title'
 import { resolveTerminalTabTitle } from '../../../shared/tab-title-resolution'
 import type { TerminalTab } from '../../../shared/terminal-tab-types'
 import {
@@ -363,6 +366,38 @@ describe('AI Vault tab title sync', () => {
 
     await vi.waitFor(() => expect(resolveSessionTitles).toHaveBeenCalledTimes(2))
     expect(store.getState().tabsByWorktree['worktree-1'][0].aiVaultTitle).toBeNull()
+    stop()
+  })
+
+  it('binds the live hook session after /clear instead of keeping the previous title', async () => {
+    const store = makeState({
+      aiVaultTitle: { agent: 'codex', sessionId: 'codex-session', title: 'pull again' },
+      executionHostId: 'ssh:dev-box',
+      worktreeId: 'worktree-1',
+      path: '/workspace/albacore'
+    })
+    const resolveSessionTitles = vi.fn(async (args: AiVaultSessionTitlesArgs) => ({
+      titles: args.requests.map((request) => ({
+        agent: request.agent,
+        sessionId: request.sessionId,
+        title: request.sessionId === 'codex-session-2' ? 'Housekeeping' : 'pull again'
+      }))
+    }))
+    const stop = startAiVaultTabTitleSync({ ...store, resolveSessionTitles })
+
+    await vi.waitFor(() =>
+      expect(store.getState().tabsByWorktree['worktree-1'][0].aiVaultTitle?.title).toBe(
+        'pull again'
+      )
+    )
+    store.setProviderSessionId('codex-session-2')
+    await vi.waitFor(() =>
+      expect(store.getState().tabsByWorktree['worktree-1'][0].aiVaultTitle).toEqual({
+        agent: 'codex',
+        sessionId: 'codex-session-2',
+        title: 'Housekeeping'
+      })
+    )
     stop()
   })
 

--- a/src/renderer/src/lib/ai-vault-tab-title-sync.test.ts
+++ b/src/renderer/src/lib/ai-vault-tab-title-sync.test.ts
@@ -292,6 +292,20 @@ describe('AI Vault tab title sync', () => {
     stop()
   })
 
+  it('leaves a fresh unnamed session absent when the Vault has no title', async () => {
+    const store = makeState({
+      executionHostId: 'ssh:dev-box',
+      worktreeId: 'worktree-1',
+      path: '/workspace/albacore'
+    })
+    const resolveSessionTitles = vi.fn(async () => ({ titles: [] }))
+    const stop = startAiVaultTabTitleSync({ ...store, resolveSessionTitles })
+
+    await vi.waitFor(() => expect(resolveSessionTitles).toHaveBeenCalledTimes(1))
+    expect(store.getState().tabsByWorktree['worktree-1'][0].aiVaultTitle).toBeUndefined()
+    stop()
+  })
+
   it('defers title reads through the configured background scheduler', async () => {
     const store = makeState({
       executionHostId: 'ssh:dev-box',

--- a/src/renderer/src/runtime/sync-runtime-graph-terminal-surface-projection.test.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph-terminal-surface-projection.test.ts
@@ -494,6 +494,49 @@ describe('buildMobileSessionTabSnapshots', () => {
     })
   })
 
+  it('publishes the tri-state Vault title precedence to paired clients', () => {
+    const leafId = '11111111-1111-4111-8111-111111111111'
+    const tab = {
+      id: 'term-1',
+      worktreeId: 'wt-1',
+      title: 'Claude working',
+      generatedTitle: 'Pull again',
+      customTitle: null,
+      ptyId: 'pty-1',
+      color: null,
+      sortOrder: 0,
+      createdAt: 1
+    }
+    const base = makeState({
+      settings: { ...getDefaultSettings('/tmp'), tabAutoGenerateTitle: true },
+      tabBarOrderByWorktree: { 'wt-1': ['term-1'] },
+      tabsByWorktree: { 'wt-1': [tab] } as unknown as AppState['tabsByWorktree'],
+      terminalLayoutsByTabId: {
+        'term-1': {
+          root: { type: 'leaf', leafId },
+          activeLeafId: leafId,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [leafId]: 'pty-1' }
+        }
+      } as AppState['terminalLayoutsByTabId']
+    })
+    const publishedTitle = (
+      aiVaultTitle?: AppState['tabsByWorktree'][string][number]['aiVaultTitle']
+    ) =>
+      buildMobileSessionTabSnapshots({
+        ...base,
+        tabsByWorktree: {
+          'wt-1': [{ ...tab, ...(aiVaultTitle !== undefined ? { aiVaultTitle } : {}) }]
+        } as AppState['tabsByWorktree']
+      })[0]?.tabs[0]?.title
+
+    expect(publishedTitle()).toBe('Pull again')
+    expect(publishedTitle(null)).toBe('Claude working')
+    expect(publishedTitle({ agent: 'claude', sessionId: 'session-1', title: 'Housekeeping' })).toBe(
+      'Housekeeping'
+    )
+  })
+
   it('publishes quick command labels to mobile snapshots before generated titles', () => {
     const leafId = '11111111-1111-4111-8111-111111111111'
     const state = makeState({

--- a/src/renderer/src/runtime/web-session-tabs-sync-terminal-mirroring.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync-terminal-mirroring.test.ts
@@ -118,6 +118,45 @@ describe('applyWebSessionTabsSnapshot', () => {
     expect(patch.tabsByWorktree?.[WT]?.[0]?.launchAgent).toBeUndefined()
   })
 
+  it('keeps an explicit-null AI Vault title across a live-title snapshot rebuild', () => {
+    const existingTab: TerminalTab = {
+      id: toWebTerminalSurfaceTabId('host-tab-1'),
+      ptyId: 'remote:web-env-1@@terminal-1',
+      worktreeId: WT,
+      title: 'Claude working',
+      defaultTitle: 'Terminal',
+      customTitle: null,
+      color: null,
+      sortOrder: 0,
+      createdAt: NOW,
+      aiVaultTitle: null
+    }
+
+    const patch = applyWebSessionTabsSnapshot(
+      makeState({
+        tabsByWorktree: { [WT]: [existingTab] },
+        ptyIdsByTabId: { [existingTab.id]: ['remote:web-env-1@@terminal-1'] }
+      }),
+      makeSnapshot([
+        {
+          type: 'terminal',
+          id: HOST_SURFACE_ID,
+          title: 'Claude',
+          parentTabId: 'host-tab-1',
+          leafId: LEAF_ID,
+          isActive: true,
+          status: 'ready',
+          terminal: 'terminal-1'
+        }
+      ]),
+      ENV,
+      NOW + 1
+    ) as Partial<WebSessionTabsSyncState>
+
+    expect(patch.tabsByWorktree?.[WT]?.[0]?.aiVaultTitle).toBeNull()
+    expect(patch.unifiedTabsByWorktree?.[WT]?.[0]?.aiVaultTitle).toBeNull()
+  })
+
   it('drops mirrored startup cwd when a later host snapshot omits it', () => {
     const existingTab: TerminalTab = {
       id: toWebTerminalSurfaceTabId('host-tab-1'),

--- a/src/renderer/src/runtime/web-session-tabs-sync-terminal-mirroring.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync-terminal-mirroring.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { makePaneKey } from '../../../shared/stable-pane-id'
 import { toWebTerminalSurfaceTabId } from '../../../shared/terminal-surface-id'
+import type { Tab } from '../../../shared/tab-types'
 import type { TerminalTab } from '../../../shared/terminal-tab-types'
 import { applyWebSessionTabsSnapshot, type WebSessionTabsSyncState } from './web-session-tabs-sync'
 import {
@@ -123,18 +124,34 @@ describe('applyWebSessionTabsSnapshot', () => {
       id: toWebTerminalSurfaceTabId('host-tab-1'),
       ptyId: 'remote:web-env-1@@terminal-1',
       worktreeId: WT,
-      title: 'Claude working',
-      defaultTitle: 'Terminal',
+      title: 'Claude',
+      defaultTitle: 'Claude',
       customTitle: null,
       color: null,
       sortOrder: 0,
       createdAt: NOW,
       aiVaultTitle: null
     }
+    const existingUnifiedTab: Tab = {
+      id: existingTab.id,
+      entityId: existingTab.id,
+      groupId: 'host-group-1',
+      worktreeId: WT,
+      executionHostId: 'runtime:web-env-1',
+      contentType: 'terminal',
+      label: 'Claude',
+      customLabel: null,
+      color: null,
+      sortOrder: 0,
+      createdAt: NOW,
+      isPreview: false,
+      isPinned: false
+    }
 
     const patch = applyWebSessionTabsSnapshot(
       makeState({
         tabsByWorktree: { [WT]: [existingTab] },
+        unifiedTabsByWorktree: { [WT]: [existingUnifiedTab] },
         ptyIdsByTabId: { [existingTab.id]: ['remote:web-env-1@@terminal-1'] }
       }),
       makeSnapshot([
@@ -153,7 +170,6 @@ describe('applyWebSessionTabsSnapshot', () => {
       NOW + 1
     ) as Partial<WebSessionTabsSyncState>
 
-    expect(patch.tabsByWorktree?.[WT]?.[0]?.aiVaultTitle).toBeNull()
     expect(patch.unifiedTabsByWorktree?.[WT]?.[0]?.aiVaultTitle).toBeNull()
   })
 

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -1136,7 +1136,9 @@ function buildMirroredTerminalTabs(
         // Why: the host transport carries no generated title, so rebuilding the tab
         // without this dropped the client's agent-prompt label on every snapshot.
         ...(existing?.generatedTitle ? { generatedTitle: existing.generatedTitle } : {}),
-        ...(existing?.aiVaultTitle ? { aiVaultTitle: existing.aiVaultTitle } : {}),
+        // Why: /clear stores explicit null to pause first-prompt regen; a truthy copy
+        // would drop that sentinel on the next live-title snapshot and restore it.
+        ...(existing?.aiVaultTitle !== undefined ? { aiVaultTitle: existing.aiVaultTitle } : {}),
         ...(quickCommandLabel ? { quickCommandLabel } : {}),
         ...(startupCwd ? { startupCwd } : {}),
         customTitle: existing?.customTitle ?? null,
@@ -1512,7 +1514,7 @@ function buildTerminalUnifiedTab(
     label: tab.title,
     ...(tab.quickCommandLabel?.trim() ? { quickCommandLabel: tab.quickCommandLabel.trim() } : {}),
     ...(tab.generatedTitle?.trim() ? { generatedLabel: tab.generatedTitle.trim() } : {}),
-    ...(tab.aiVaultTitle ? { aiVaultTitle: tab.aiVaultTitle } : {}),
+    ...(tab.aiVaultTitle !== undefined ? { aiVaultTitle: tab.aiVaultTitle } : {}),
     customLabel: tab.customTitle,
     color: tab.color,
     sortOrder: tab.sortOrder,

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -29,6 +29,7 @@ import type {
 } from '../../../shared/browser-workspace-types'
 import type { Tab, TabGroup, TabGroupLayoutNode } from '../../../shared/tab-types'
 import type { TerminalLayoutSnapshot, TerminalTab } from '../../../shared/terminal-tab-types'
+import { aiVaultSessionTitlesEqual } from '../../../shared/ai-vault-session-title'
 import type { OpenFile } from '../store/slices/editor'
 import { isTerminalLeafId, makePaneKey, parsePaneKey } from '../../../shared/stable-pane-id'
 import {
@@ -2255,9 +2256,7 @@ function terminalTabEqual(a: TerminalTab, b: TerminalTab): boolean {
     a.quickCommandLabel === b.quickCommandLabel &&
     a.startupCwd === b.startupCwd &&
     a.generatedTitle === b.generatedTitle &&
-    a.aiVaultTitle?.agent === b.aiVaultTitle?.agent &&
-    a.aiVaultTitle?.sessionId === b.aiVaultTitle?.sessionId &&
-    a.aiVaultTitle?.title === b.aiVaultTitle?.title &&
+    aiVaultSessionTitlesEqual(a.aiVaultTitle, b.aiVaultTitle) &&
     a.customTitle === b.customTitle &&
     a.color === b.color &&
     a.sortOrder === b.sortOrder &&
@@ -2465,9 +2464,7 @@ function tabEqual(a: Tab, b: Tab): boolean {
     // Why: the generated label is the visible tab title; ignoring it let the
     // equality bail keep a unified tab that disagreed with its terminal tab.
     a.generatedLabel === b.generatedLabel &&
-    a.aiVaultTitle?.agent === b.aiVaultTitle?.agent &&
-    a.aiVaultTitle?.sessionId === b.aiVaultTitle?.sessionId &&
-    a.aiVaultTitle?.title === b.aiVaultTitle?.title &&
+    aiVaultSessionTitlesEqual(a.aiVaultTitle, b.aiVaultTitle) &&
     a.customLabel === b.customLabel &&
     a.color === b.color &&
     a.sortOrder === b.sortOrder &&

--- a/src/renderer/src/store/slices/agent-generated-tab-title.test.ts
+++ b/src/renderer/src/store/slices/agent-generated-tab-title.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { getAgentRowConversationName } from '../../../../shared/agent-row-conversation-name'
-import { GENERATED_TAB_TITLE_SOURCE_SCAN_LIMIT } from '../../../../shared/agent-tab-title'
+import {
+  deriveGeneratedTabTitle,
+  GENERATED_TAB_TITLE_SOURCE_SCAN_LIMIT
+} from '../../../../shared/agent-tab-title'
 import { getDefaultSettings } from '../../../../shared/constants'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 import { resolveTerminalTabTitle } from '../../../../shared/tab-title-resolution'
@@ -442,7 +445,82 @@ Implement task B worker instructions for the next dispatch`,
     })
 
     const tab = store.getState().tabsByWorktree[WORKTREE_ID][0]
+    const unified = store.getState().unifiedTabsByWorktree[WORKTREE_ID][0]
+    expect(tab.generatedTitle).toBe('Pull again')
+    expect(unified.generatedLabel).toBe('Pull again')
     expect(resolveTerminalTabTitle(tab, true)).toBe('Housekeeping')
     expect(getAgentRowConversationName(tab, 'claude', true)).toBe('Housekeeping')
+  })
+
+  it('keeps the first-prompt generated title when the vault title first binds', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    const tabId = seedWorktree(store, true)
+    store.setState({
+      tabsByWorktree: {
+        ...store.getState().tabsByWorktree,
+        [WORKTREE_ID]: store
+          .getState()
+          .tabsByWorktree[WORKTREE_ID].map((tab) =>
+            tab.id === tabId ? { ...tab, generatedTitle: 'Pull again' } : tab
+          )
+      },
+      unifiedTabsByWorktree: {
+        ...store.getState().unifiedTabsByWorktree,
+        [WORKTREE_ID]: (store.getState().unifiedTabsByWorktree[WORKTREE_ID] ?? []).map((tab) =>
+          tab.entityId === tabId ? { ...tab, generatedLabel: 'Pull again' } : tab
+        )
+      }
+    })
+
+    store.getState().setAiVaultTabTitle(tabId, {
+      agent: 'claude',
+      sessionId: 'claude-session-1',
+      title: 'Housekeeping'
+    })
+
+    store.getState().setAgentStatus(makePaneKey(tabId, LEAF_ID), {
+      state: 'working',
+      prompt: 'A later mid-conversation prompt about billing',
+      agentType: 'claude'
+    })
+
+    const tab = store.getState().tabsByWorktree[WORKTREE_ID][0]
+    const unified = store.getState().unifiedTabsByWorktree[WORKTREE_ID][0]
+    expect(tab.generatedTitle).toBe('Pull again')
+    expect(unified.generatedLabel).toBe('Pull again')
+    expect(resolveTerminalTabTitle(tab, true)).toBe('Housekeeping')
+    expect(getAgentRowConversationName(tab, 'claude', true)).toBe('Housekeeping')
+  })
+
+  it('does not restore the previous first-prompt title from a later status ping after /clear', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    const tabId = seedWorktree(store, true)
+    persistStaleSessionName(store, tabId, {
+      sessionId: 'claude-session-1',
+      title: 'pull again',
+      generatedTitle: 'Pull again'
+    })
+
+    const replayedPrompt = 'pull again please'
+    const replayedTitle = deriveGeneratedTabTitle(replayedPrompt)
+    expect(replayedTitle).toBeTruthy()
+
+    store.getState().setAiVaultTabTitle(tabId, null)
+    store.getState().setAgentStatus(makePaneKey(tabId, LEAF_ID), {
+      state: 'working',
+      prompt: replayedPrompt,
+      agentType: 'claude'
+    })
+
+    const tab = store.getState().tabsByWorktree[WORKTREE_ID][0]
+    const unified = store.getState().unifiedTabsByWorktree[WORKTREE_ID][0]
+    expect(tab.aiVaultTitle).toBeNull()
+    expect(tab.generatedTitle).toBeUndefined()
+    expect(unified.generatedLabel).toBeUndefined()
+    expect(tab.generatedTitle).not.toBe(replayedTitle)
+    expect(resolveTerminalTabTitle(tab, true)).not.toBe('Pull again')
+    expect(getAgentRowConversationName(tab, 'claude', true)).not.toBe('Pull again')
   })
 })

--- a/src/renderer/src/store/slices/agent-generated-tab-title.test.ts
+++ b/src/renderer/src/store/slices/agent-generated-tab-title.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getAgentRowConversationName } from '../../../../shared/agent-row-conversation-name'
 import { GENERATED_TAB_TITLE_SOURCE_SCAN_LIMIT } from '../../../../shared/agent-tab-title'
 import { getDefaultSettings } from '../../../../shared/constants'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
@@ -19,6 +20,34 @@ function seedWorktree(store: ReturnType<typeof createTestStore>, enabled: boolea
     }
   })
   return store.getState().createTab(WORKTREE_ID).id
+}
+
+function persistStaleSessionName(
+  store: ReturnType<typeof createTestStore>,
+  tabId: string,
+  args: { sessionId: string; title: string; generatedTitle: string }
+): void {
+  const aiVaultTitle = {
+    agent: 'claude' as const,
+    sessionId: args.sessionId,
+    title: args.title
+  }
+  store.setState({
+    tabsByWorktree: {
+      ...store.getState().tabsByWorktree,
+      [WORKTREE_ID]: store
+        .getState()
+        .tabsByWorktree[WORKTREE_ID].map((tab) =>
+          tab.id === tabId ? { ...tab, generatedTitle: args.generatedTitle, aiVaultTitle } : tab
+        )
+    },
+    unifiedTabsByWorktree: {
+      ...store.getState().unifiedTabsByWorktree,
+      [WORKTREE_ID]: (store.getState().unifiedTabsByWorktree[WORKTREE_ID] ?? []).map((tab) =>
+        tab.entityId === tabId ? { ...tab, generatedLabel: args.generatedTitle, aiVaultTitle } : tab
+      )
+    }
+  })
 }
 
 describe('generated agent tab titles', () => {
@@ -339,5 +368,81 @@ Implement task B worker instructions for the next dispatch`,
     const tab = store.getState().tabsByWorktree[WORKTREE_ID][0]
     expect(tab.generatedTitle).toBeUndefined()
     expect(resolveTerminalTabTitle(tab, true)).toBe('Run tests')
+  })
+
+  it('drops the first-prompt generated title when the pane rebinds to a new session', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    const tabId = seedWorktree(store, true)
+    persistStaleSessionName(store, tabId, {
+      sessionId: 'claude-session-1',
+      title: 'pull again',
+      generatedTitle: 'Pull again'
+    })
+
+    store.getState().setAiVaultTabTitle(tabId, {
+      agent: 'claude',
+      sessionId: 'claude-session-2',
+      title: 'Housekeeping'
+    })
+
+    const tab = store.getState().tabsByWorktree[WORKTREE_ID][0]
+    const unified = store.getState().unifiedTabsByWorktree[WORKTREE_ID][0]
+    expect(tab.generatedTitle).toBeUndefined()
+    expect(unified.generatedLabel).toBeUndefined()
+    expect(tab.aiVaultTitle).toEqual({
+      agent: 'claude',
+      sessionId: 'claude-session-2',
+      title: 'Housekeeping'
+    })
+    expect(resolveTerminalTabTitle(tab, true)).toBe('Housekeeping')
+    expect(getAgentRowConversationName(tab, 'claude', true)).toBe('Housekeeping')
+  })
+
+  it('heals a persisted first-prompt name when a later live session title arrives', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    const tabId = seedWorktree(store, true)
+    persistStaleSessionName(store, tabId, {
+      sessionId: 'stale-session',
+      title: 'pull again',
+      generatedTitle: 'Pull again'
+    })
+
+    const stale = store.getState().tabsByWorktree[WORKTREE_ID][0]
+    expect(stale.generatedTitle).toBe('Pull again')
+    expect(getAgentRowConversationName(stale, 'claude', true)).toBe('pull again')
+
+    store.getState().setAiVaultTabTitle(tabId, {
+      agent: 'claude',
+      sessionId: 'live-session',
+      title: 'Housekeeping'
+    })
+
+    const healed = store.getState().tabsByWorktree[WORKTREE_ID][0]
+    expect(healed.generatedTitle).toBeUndefined()
+    expect(resolveTerminalTabTitle(healed, true)).toBe('Housekeeping')
+    expect(getAgentRowConversationName(healed, 'claude', true)).toBe('Housekeeping')
+  })
+
+  it('keeps a same-session AI Vault rename on the pane label', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    const tabId = seedWorktree(store, true)
+    persistStaleSessionName(store, tabId, {
+      sessionId: 'claude-session-1',
+      title: 'pull again',
+      generatedTitle: 'Pull again'
+    })
+
+    store.getState().setAiVaultTabTitle(tabId, {
+      agent: 'claude',
+      sessionId: 'claude-session-1',
+      title: 'Housekeeping'
+    })
+
+    const tab = store.getState().tabsByWorktree[WORKTREE_ID][0]
+    expect(resolveTerminalTabTitle(tab, true)).toBe('Housekeeping')
+    expect(getAgentRowConversationName(tab, 'claude', true)).toBe('Housekeeping')
   })
 })

--- a/src/renderer/src/store/slices/agent-generated-tab-title.test.ts
+++ b/src/renderer/src/store/slices/agent-generated-tab-title.test.ts
@@ -523,4 +523,53 @@ Implement task B worker instructions for the next dispatch`,
     expect(resolveTerminalTabTitle(tab, true)).not.toBe('Pull again')
     expect(getAgentRowConversationName(tab, 'claude', true)).not.toBe('Pull again')
   })
+
+  it('persists an explicit clear from an absent Vault title and blocks later generation', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    const tabId = seedWorktree(store, true)
+
+    store.setState({
+      tabsByWorktree: {
+        ...store.getState().tabsByWorktree,
+        [WORKTREE_ID]: store
+          .getState()
+          .tabsByWorktree[WORKTREE_ID].map((tab) =>
+            tab.id === tabId ? { ...tab, generatedTitle: 'Pull again' } : tab
+          )
+      }
+    })
+    store.getState().setAiVaultTabTitle(tabId, null)
+    store.getState().setAgentStatus(makePaneKey(tabId, LEAF_ID), {
+      state: 'working',
+      prompt: 'Restore the stale title',
+      agentType: 'claude'
+    })
+
+    const tab = store.getState().tabsByWorktree[WORKTREE_ID][0]
+    expect(tab.aiVaultTitle).toBeNull()
+    expect(tab.generatedTitle).toBe('Pull again')
+    expect(resolveTerminalTabTitle(tab, true)).not.toBe('Pull again')
+  })
+
+  it('treats repeated clears as equal and accepts the next resolved title', () => {
+    const store = createTestStore()
+    const tabId = seedWorktree(store, true)
+    store.getState().setAiVaultTabTitle(tabId, null)
+    const clearedTabs = store.getState().tabsByWorktree
+
+    store.getState().setAiVaultTabTitle(tabId, null)
+    expect(store.getState().tabsByWorktree).toBe(clearedTabs)
+
+    store.getState().setAiVaultTabTitle(tabId, {
+      agent: 'claude',
+      sessionId: 'claude-session-2',
+      title: 'Housekeeping'
+    })
+    expect(store.getState().tabsByWorktree[WORKTREE_ID][0].aiVaultTitle).toEqual({
+      agent: 'claude',
+      sessionId: 'claude-session-2',
+      title: 'Housekeeping'
+    })
+  })
 })

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -435,7 +435,7 @@ function getTabIdFromPaneKey(paneKey: string): string | null {
   return paneKey.slice(0, separator)
 }
 
-/** True when auto-title generation would no-op without replace (custom/quick/generated). */
+/** True when auto-title generation would no-op without replace (custom/quick/generated, or a /clear vault gap). */
 function agentStatusTabAlreadyHasProtectedOrGeneratedTitle(
   state: AppState,
   tabId: string | null,
@@ -448,7 +448,10 @@ function agentStatusTabAlreadyHasProtectedOrGeneratedTitle(
   if (ownerTabs) {
     const tab = ownerTabs.find((candidate) => candidate.id === tabId)
     return Boolean(
-      tab?.customTitle?.trim() || tab?.quickCommandLabel?.trim() || tab?.generatedTitle?.trim()
+      tab?.customTitle?.trim() ||
+      tab?.quickCommandLabel?.trim() ||
+      tab?.generatedTitle?.trim() ||
+      tab?.aiVaultTitle === null
     )
   }
   for (const tabs of Object.values(state.tabsByWorktree)) {
@@ -457,7 +460,10 @@ function agentStatusTabAlreadyHasProtectedOrGeneratedTitle(
       continue
     }
     return Boolean(
-      tab.customTitle?.trim() || tab.quickCommandLabel?.trim() || tab.generatedTitle?.trim()
+      tab.customTitle?.trim() ||
+      tab.quickCommandLabel?.trim() ||
+      tab.generatedTitle?.trim() ||
+      tab.aiVaultTitle === null
     )
   }
   return false

--- a/src/renderer/src/store/slices/tabs-hydration-generated-title.test.ts
+++ b/src/renderer/src/store/slices/tabs-hydration-generated-title.test.ts
@@ -82,6 +82,81 @@ describe('buildHydratedTabState generated terminal titles', () => {
     expect(result.unifiedTabsByWorktree.w1[0].generatedLabel).toBe('Persisted agent title')
   })
 
+  it('preserves an explicit Vault clear across unified hydration conflicts', () => {
+    const title = { agent: 'claude' as const, sessionId: 'session-1', title: 'Stale name' }
+    const baseTerminal = {
+      id: 't1',
+      ptyId: null,
+      worktreeId: 'w1',
+      title: 'Claude working',
+      customTitle: null,
+      color: null,
+      sortOrder: 0,
+      createdAt: 1
+    }
+    const baseUnified = {
+      id: 't1',
+      entityId: 't1',
+      groupId: 'g1',
+      worktreeId: 'w1',
+      contentType: 'terminal' as const,
+      label: 'Claude working',
+      customLabel: null,
+      color: null,
+      sortOrder: 0,
+      createdAt: 1
+    }
+    const hydrate = (terminalTitle: typeof title | null, unifiedTitle: typeof title | null) =>
+      buildHydratedTabState(
+        {
+          ...makeBaseSession(),
+          tabsByWorktree: { w1: [{ ...baseTerminal, aiVaultTitle: terminalTitle }] },
+          unifiedTabs: { w1: [{ ...baseUnified, aiVaultTitle: unifiedTitle }] },
+          tabGroups: {
+            w1: [{ id: 'g1', worktreeId: 'w1', activeTabId: 't1', tabOrder: ['t1'] }]
+          }
+        },
+        new Set(['w1'])
+      ).unifiedTabsByWorktree.w1[0].aiVaultTitle
+
+    expect(hydrate(title, null)).toBeNull()
+    expect(hydrate(null, title)).toBeNull()
+  })
+
+  it('converts legacy Vault title objects and clears without inventing absence', () => {
+    const makeSession = (
+      aiVaultTitle: { agent: 'claude'; sessionId: string; title: string } | null
+    ) =>
+      ({
+        ...makeBaseSession(),
+        tabsByWorktree: {
+          w1: [
+            {
+              id: 'tt1',
+              ptyId: null,
+              worktreeId: 'w1',
+              title: 'bash',
+              aiVaultTitle,
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 100
+            }
+          ]
+        }
+      }) satisfies WorkspaceSessionState
+    const title = { agent: 'claude' as const, sessionId: 'session-1', title: 'Housekeeping' }
+
+    expect(
+      buildHydratedTabState(makeSession(title), new Set(['w1'])).unifiedTabsByWorktree.w1[0]
+        .aiVaultTitle
+    ).toEqual(title)
+    expect(
+      buildHydratedTabState(makeSession(null), new Set(['w1'])).unifiedTabsByWorktree.w1[0]
+        .aiVaultTitle
+    ).toBeNull()
+  })
+
   it('hydrates quick command labels from persisted terminal metadata', () => {
     const session: WorkspaceSessionState = {
       ...makeBaseSession(),

--- a/src/renderer/src/store/slices/tabs-hydration.ts
+++ b/src/renderer/src/store/slices/tabs-hydration.ts
@@ -87,9 +87,9 @@ function hydrateUnifiedFormat(
         .map((tab) => [tab.id, tab.quickCommandLabel!.trim()])
     )
     const aiVaultTitleByTerminalId = new Map(
-      (session.tabsByWorktree[worktreeId] ?? [])
-        .filter((tab) => tab.aiVaultTitle)
-        .map((tab) => [tab.id, tab.aiVaultTitle!])
+      (session.tabsByWorktree[worktreeId] ?? []).flatMap((tab) =>
+        tab.aiVaultTitle !== undefined ? [[tab.id, tab.aiVaultTitle] as const] : []
+      )
     )
     const hydratedTabs = [...tabs]
       .map((tab) => ({
@@ -104,11 +104,15 @@ function hydrateUnifiedFormat(
           ? tab.quickCommandLabel.trim()
           : quickCommandLabelByTerminalId.get(tab.entityId)
         const generatedLabel = generatedTitleByTerminalId.get(tab.entityId)
-        const aiVaultTitle = tab.aiVaultTitle ?? aiVaultTitleByTerminalId.get(tab.entityId)
+        const terminalAiVaultTitle = aiVaultTitleByTerminalId.get(tab.entityId)
+        const aiVaultTitle =
+          tab.aiVaultTitle === null || terminalAiVaultTitle === null
+            ? null
+            : (tab.aiVaultTitle ?? terminalAiVaultTitle)
         return {
           ...tab,
           ...(quickCommandLabel ? { quickCommandLabel } : {}),
-          ...(aiVaultTitle ? { aiVaultTitle } : {}),
+          ...(aiVaultTitle !== undefined ? { aiVaultTitle } : {}),
           ...(!tab.generatedLabel?.trim() && generatedLabel ? { generatedLabel } : {})
         }
       })
@@ -238,6 +242,7 @@ function hydrateLegacyFormat(
         label: tt.title,
         ...(tt.quickCommandLabel?.trim() ? { quickCommandLabel: tt.quickCommandLabel.trim() } : {}),
         ...(tt.generatedTitle?.trim() ? { generatedLabel: tt.generatedTitle.trim() } : {}),
+        ...(tt.aiVaultTitle !== undefined ? { aiVaultTitle: tt.aiVaultTitle } : {}),
         customLabel: tt.customTitle,
         color: tt.color,
         sortOrder: tt.sortOrder,

--- a/src/renderer/src/store/slices/tabs-model-reconciliation.test.ts
+++ b/src/renderer/src/store/slices/tabs-model-reconciliation.test.ts
@@ -108,6 +108,35 @@ describe('TabsSlice', () => {
       expect(result.renderableTabCount).toBe(1)
     })
 
+    it('keeps an explicit Vault clear while promoting a reconnecting legacy terminal', () => {
+      store.setState({
+        tabsByWorktree: {
+          [WT]: [
+            {
+              id: 'reconnecting-terminal',
+              ptyId: null,
+              worktreeId: WT,
+              title: 'claude',
+              aiVaultTitle: null,
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1
+            }
+          ]
+        },
+        ptyIdsByTabId: { 'reconnecting-terminal': [] },
+        pendingReconnectPtyIdByTabId: { 'reconnecting-terminal': 'session-live' },
+        unifiedTabsByWorktree: { [WT]: [] },
+        groupsByWorktree: {},
+        activeGroupIdByWorktree: {}
+      })
+
+      store.getState().reconcileWorktreeTabModel(WT)
+
+      expect(store.getState().unifiedTabsByWorktree[WT][0]?.aiVaultTitle).toBeNull()
+    })
+
     // A session mirrored from a runtime host used to append a fresh leaf for a
     // group the layout already held, so returning to a split workspace showed the
     // same tab strip in several columns. Reconciliation collapses the repeats.

--- a/src/renderer/src/store/slices/tabs.ts
+++ b/src/renderer/src/store/slices/tabs.ts
@@ -664,7 +664,7 @@ export function projectWorktreeTabModelReconciliation(
               ? { quickCommandLabel: tab.quickCommandLabel.trim() }
               : {}),
             ...(tab.generatedTitle?.trim() ? { generatedLabel: tab.generatedTitle.trim() } : {}),
-            ...(tab.aiVaultTitle ? { aiVaultTitle: tab.aiVaultTitle } : {}),
+            ...(tab.aiVaultTitle !== undefined ? { aiVaultTitle: tab.aiVaultTitle } : {}),
             customLabel: tab.customTitle,
             color: tab.color,
             sortOrder: tab.sortOrder,

--- a/src/renderer/src/store/slices/terminal-session-row-hydration.ts
+++ b/src/renderer/src/store/slices/terminal-session-row-hydration.ts
@@ -18,7 +18,7 @@ type CanonicalTerminals = {
   /** PTYs already claimed by canonical rows that survive hydration, keyed to their claimant. */
   tabIdByPtyId: Map<string, string>
   quickCommandLabelByTabId: Map<string, string>
-  aiVaultTitleByTabId: Map<string, AiVaultSessionTitle>
+  aiVaultTitleByTabId: Map<string, AiVaultSessionTitle | null>
 }
 
 export type HydrateWorkspaceTerminalRowsOptions = {
@@ -146,7 +146,9 @@ function readCanonicalTerminals(
       )
     ),
     aiVaultTitleByTabId: new Map(
-      canonicalTabs.flatMap((tab) => (tab.aiVaultTitle ? [[tab.entityId, tab.aiVaultTitle]] : []))
+      canonicalTabs.flatMap((tab) =>
+        tab.aiVaultTitle !== undefined ? [[tab.entityId, tab.aiVaultTitle] as const] : []
+      )
     )
   }
 }
@@ -202,11 +204,15 @@ function restoreCanonicalMetadata(
 ): TerminalTab {
   const quickCommandLabel =
     row.quickCommandLabel?.trim() || canonical.quickCommandLabelByTabId.get(row.id)
-  const aiVaultTitle = row.aiVaultTitle ?? canonical.aiVaultTitleByTabId.get(row.id)
+  const canonicalAiVaultTitle = canonical.aiVaultTitleByTabId.get(row.id)
+  const aiVaultTitle =
+    row.aiVaultTitle === null || canonicalAiVaultTitle === null
+      ? null
+      : (row.aiVaultTitle ?? canonicalAiVaultTitle)
   return {
     ...clearTransientTerminalState(row, index),
     ...(quickCommandLabel ? { quickCommandLabel } : {}),
-    ...(aiVaultTitle ? { aiVaultTitle } : {}),
+    ...(aiVaultTitle !== undefined ? { aiVaultTitle } : {}),
     sortOrder: index,
     // Why: suppress restored mounts so only real activity updates Recent.
     pendingActivationSpawn: true

--- a/src/renderer/src/store/slices/terminal-tab-title-batch.ts
+++ b/src/renderer/src/store/slices/terminal-tab-title-batch.ts
@@ -228,6 +228,10 @@ export function applyGeneratedTabTitleUpdates(
     ) {
       continue
     }
+    // Why: /clear writes aiVaultTitle null and drops generatedTitle; a later ping still carries the previous prompt.
+    if (currentTab.aiVaultTitle === null && options?.replaceExistingGeneratedTitle !== true) {
+      continue
+    }
     const existingGeneratedTitle = currentTab.generatedTitle?.trim()
     if (existingGeneratedTitle && options?.replaceExistingGeneratedTitle !== true) {
       continue

--- a/src/renderer/src/store/slices/terminals-hydration-canonical-rows.test.ts
+++ b/src/renderer/src/store/slices/terminals-hydration-canonical-rows.test.ts
@@ -5,8 +5,54 @@ import type { WorkspaceSessionState } from '../../../../shared/workspace-session
 import { getDefaultWorkspaceSession } from '../../../../shared/constants'
 import { buildWorkspaceSessionPayload } from '@/lib/workspace-session'
 import { createTestStore, makeLayout, makeTab, makeWorktree, seedStore } from './store-test-helpers'
+import { hydrateWorkspaceTerminalRows } from './terminal-session-row-hydration'
 
 describe('hydrateWorkspaceSession canonical terminal rows', () => {
+  it('keeps an explicit clear when canonical and legacy Vault metadata disagree', () => {
+    const worktreeId = 'repo1::/wt-1'
+    const staleTitle = {
+      agent: 'claude' as const,
+      sessionId: 'claude-session-1',
+      title: 'Stale name'
+    }
+    const row = makeTab({ id: 'terminal-1', worktreeId, aiVaultTitle: null })
+    const session = {
+      ...getDefaultWorkspaceSession(),
+      tabsByWorktree: { [worktreeId]: [row] },
+      unifiedTabs: {
+        [worktreeId]: [
+          {
+            id: 'unified-1',
+            entityId: row.id,
+            groupId: 'group-1',
+            worktreeId,
+            contentType: 'terminal' as const,
+            label: row.title,
+            aiVaultTitle: staleTitle,
+            customLabel: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1
+          }
+        ]
+      }
+    }
+
+    expect(hydrateWorkspaceTerminalRows(session, worktreeId, [row]).rows[0].aiVaultTitle).toBeNull()
+    expect(
+      hydrateWorkspaceTerminalRows(
+        {
+          ...session,
+          unifiedTabs: {
+            [worktreeId]: [{ ...session.unifiedTabs[worktreeId][0], aiVaultTitle: null }]
+          }
+        },
+        worktreeId,
+        [{ ...row, aiVaultTitle: staleTitle }]
+      ).rows[0].aiVaultTitle
+    ).toBeNull()
+  })
+
   it('drops only legacy rows that duplicate canonical PTY ownership', () => {
     const store = createTestStore()
     const worktreeId = 'repo1::/wt-1'

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -1994,10 +1994,13 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       if (!current || sameTitle) {
         return s
       }
-      // Why: first-prompt generated titles belong to the previous provider session.
+      // Why: wipe only when a previously bound vault session unbinds or changes.
+      // First bind (undefined → session) is the same conversation; ranking already
+      // prefers vault, and clearing would re-open write-once first-prompt generation.
+      const previous = current.aiVaultTitle
       const sessionChanged =
-        current.aiVaultTitle?.agent !== aiVaultTitle?.agent ||
-        current.aiVaultTitle?.sessionId !== aiVaultTitle?.sessionId
+        previous != null &&
+        (previous.agent !== aiVaultTitle?.agent || previous.sessionId !== aiVaultTitle?.sessionId)
       const ownerTabs = tabs.map((tab) =>
         tab.id === tabId
           ? {
@@ -2042,6 +2045,10 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
     const tabs = state.tabsByWorktree[ownerWorktreeId] ?? []
     const currentTab = tabs.find((tab) => tab.id === tabId)
     if (!currentTab || currentTab.customTitle?.trim() || currentTab.quickCommandLabel?.trim()) {
+      return
+    }
+    // Why: /clear writes aiVaultTitle null and drops generatedTitle; a later ping still carries the previous prompt.
+    if (currentTab.aiVaultTitle === null && options?.replaceExistingGeneratedTitle !== true) {
       return
     }
     const existingGeneratedTitle = currentTab.generatedTitle?.trim()

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -1994,10 +1994,28 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       if (!current || sameTitle) {
         return s
       }
-      const ownerTabs = tabs.map((tab) => (tab.id === tabId ? { ...tab, aiVaultTitle } : tab))
+      // Why: first-prompt generated titles belong to the previous provider session.
+      const sessionChanged =
+        current.aiVaultTitle?.agent !== aiVaultTitle?.agent ||
+        current.aiVaultTitle?.sessionId !== aiVaultTitle?.sessionId
+      const ownerTabs = tabs.map((tab) =>
+        tab.id === tabId
+          ? {
+              ...tab,
+              aiVaultTitle,
+              ...(sessionChanged ? { generatedTitle: undefined } : {})
+            }
+          : tab
+      )
       const unifiedTabs = s.unifiedTabsByWorktree[ownerWorktreeId] ?? []
       const nextUnifiedTabs = unifiedTabs.map((tab) =>
-        tab.contentType === 'terminal' && tab.entityId === tabId ? { ...tab, aiVaultTitle } : tab
+        tab.contentType === 'terminal' && tab.entityId === tabId
+          ? {
+              ...tab,
+              aiVaultTitle,
+              ...(sessionChanged ? { generatedLabel: undefined } : {})
+            }
+          : tab
       )
       scheduleRuntimeGraphSync()
       return {

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -47,7 +47,10 @@ import type { SessionOptionValue } from '../../../../shared/native-chat-session-
 import { resolveLocalWindowsTerminalShellOverrideForTab } from '../../../../shared/local-windows-terminal-runtime'
 import { WINDOWS_GIT_BASH_SHELL } from '../../../../shared/windows-terminal-shell'
 import type { AgentStartedTelemetry } from '../../lib/worktree-startup-payload'
-import type { AiVaultSessionTitle } from '../../../../shared/ai-vault-session-title'
+import {
+  aiVaultSessionTitlesEqual,
+  type AiVaultSessionTitle
+} from '../../../../shared/ai-vault-session-title'
 import { scheduleRuntimeGraphSync } from '@/runtime/sync-runtime-graph'
 import { terminalLayoutEqual } from '@/lib/terminal-layout-equality'
 import { sweepRetiredTerminalTabState } from './retired-terminal-tab-state-sweep'
@@ -1987,10 +1990,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       }
       const tabs = s.tabsByWorktree[ownerWorktreeId] ?? []
       const current = tabs.find((tab) => tab.id === tabId)
-      const sameTitle =
-        current?.aiVaultTitle?.agent === aiVaultTitle?.agent &&
-        current?.aiVaultTitle?.sessionId === aiVaultTitle?.sessionId &&
-        current?.aiVaultTitle?.title === aiVaultTitle?.title
+      const sameTitle = aiVaultSessionTitlesEqual(current?.aiVaultTitle, aiVaultTitle)
       if (!current || sameTitle) {
         return s
       }

--- a/src/shared/agent-row-conversation-name.test.ts
+++ b/src/shared/agent-row-conversation-name.test.ts
@@ -37,6 +37,35 @@ describe('getAgentRowConversationName', () => {
     expect(getAgentRowConversationName(tab, 'claude', false)).toBe('Investigate replay bug')
   })
 
+  it('uses the live AI Vault session name ahead of a first-prompt generated title', () => {
+    const tab = makeTab({
+      aiVaultTitle: {
+        agent: 'claude',
+        sessionId: 'claude-session-2',
+        title: 'Housekeeping'
+      },
+      generatedTitle: 'pull again',
+      title: '✳ pull again'
+    })
+    expect(getAgentRowConversationName(tab, 'claude', true)).toBe('Housekeeping')
+    expect(getAgentRowConversationName(tab, 'claude', true, null)).toBe('Housekeeping')
+  })
+
+  it('follows a later AI Vault rename instead of keeping the first prompt', () => {
+    const tab = makeTab({
+      aiVaultTitle: {
+        agent: 'claude',
+        sessionId: 'claude-session-1',
+        title: 'Orca stats and usage with WSL environments'
+      },
+      generatedTitle: 'pull again',
+      title: '◑ Housekeeping'
+    })
+    expect(getAgentRowConversationName(tab, 'claude', true)).toBe(
+      'Orca stats and usage with WSL environments'
+    )
+  })
+
   it('names a split pane from its own live title, not the tab title', () => {
     // Why: the tab title is the FOCUSED pane's, so the sibling must not read it.
     const tab = makeTab({ title: '\u2733 Linear work log' })

--- a/src/shared/agent-row-conversation-name.test.ts
+++ b/src/shared/agent-row-conversation-name.test.ts
@@ -66,6 +66,16 @@ describe('getAgentRowConversationName', () => {
     )
   })
 
+  it('does not restore a generated name while the AI Vault title is explicitly cleared', () => {
+    const tab = makeTab({
+      aiVaultTitle: null,
+      generatedTitle: 'Pull again',
+      title: '✳ Housekeeping'
+    })
+    expect(getAgentRowConversationName(tab, 'claude', true)).toBe('Housekeeping')
+    expect(getAgentRowConversationName(tab, 'claude', true, null)).toBeNull()
+  })
+
   it('names a split pane from its own live title, not the tab title', () => {
     // Why: the tab title is the FOCUSED pane's, so the sibling must not read it.
     const tab = makeTab({ title: '\u2733 Linear work log' })

--- a/src/shared/agent-row-conversation-name.ts
+++ b/src/shared/agent-row-conversation-name.ts
@@ -1,10 +1,10 @@
 // Resolves the stable "conversation name" an agent row can show instead of the
 // live last-message preview. Sources, in the same precedence the tab bar uses
 // (tab-title-resolution.ts): manual rename → quick-command label → OpenCode's
-// semantic session title → Orca's generated title → the agent-set live title.
-// Live titles are accepted only when they carry a real name — pure status,
-// identity-echo, and spinner/cwd titles yield null so callers keep the
-// last-message label.
+// semantic session title → AI Vault session name → Orca's generated title →
+// the agent-set live title. Live titles are accepted only when they carry a
+// real name — pure status, identity-echo, and spinner/cwd titles yield null so
+// callers keep the last-message label.
 import type { AgentType } from './agent-status-types'
 import { isClaudeManagementTitle } from './agent-title-core'
 import { stripLeadingAgentTitleDecorationOrEmpty } from './agent-title-decoration'
@@ -15,7 +15,7 @@ import type { TerminalTab } from './terminal-tab-types'
 
 export type ConversationNameTab = Pick<
   TerminalTab,
-  'customTitle' | 'quickCommandLabel' | 'generatedTitle' | 'title' | 'defaultTitle'
+  'customTitle' | 'quickCommandLabel' | 'aiVaultTitle' | 'generatedTitle' | 'title' | 'defaultTitle'
 >
 
 // Why: synthetic status titles ("Codex ready", "Cursor - action required") are
@@ -133,6 +133,10 @@ export function getAgentRowConversationName(
     paneLiveTitle === undefined ? (tab.title?.trim() ?? '') : (paneLiveTitle?.trim() ?? '')
   if (isMeaningfulOpenCodeTerminalTitle(liveTitle)) {
     return liveTitle
+  }
+  const aiVaultTitle = tab.aiVaultTitle?.title.trim()
+  if (aiVaultTitle) {
+    return aiVaultTitle
   }
   const generatedTitle = generatedTitlesEnabled ? tab.generatedTitle?.trim() : ''
   if (generatedTitle) {

--- a/src/shared/agent-row-conversation-name.ts
+++ b/src/shared/agent-row-conversation-name.ts
@@ -138,7 +138,8 @@ export function getAgentRowConversationName(
   if (aiVaultTitle) {
     return aiVaultTitle
   }
-  const generatedTitle = generatedTitlesEnabled ? tab.generatedTitle?.trim() : ''
+  const generatedTitle =
+    generatedTitlesEnabled && tab.aiVaultTitle !== null ? tab.generatedTitle?.trim() : ''
   if (generatedTitle) {
     return generatedTitle
   }

--- a/src/shared/ai-vault-session-title.ts
+++ b/src/shared/ai-vault-session-title.ts
@@ -24,6 +24,22 @@ export type AiVaultSessionTitlesResult = {
   titles: AiVaultSessionTitle[]
 }
 
+export function aiVaultSessionTitlesEqual(
+  left: AiVaultSessionTitle | null | undefined,
+  right: AiVaultSessionTitle | null | undefined
+): boolean {
+  if (left === right) {
+    return true
+  }
+  return (
+    left != null &&
+    right != null &&
+    left.agent === right.agent &&
+    left.sessionId === right.sessionId &&
+    left.title === right.title
+  )
+}
+
 export function isAiVaultTitleAgent(
   agent: string | null | undefined
 ): agent is AiVaultSessionTitle['agent'] {

--- a/src/shared/tab-title-resolution.test.ts
+++ b/src/shared/tab-title-resolution.test.ts
@@ -90,6 +90,24 @@ describe('tab title resolution', () => {
     ).toBe('Repair provider-native tab titles')
   })
 
+  it('keeps a Claude session name ahead of the first-prompt generated title', () => {
+    expect(
+      resolveTerminalTabTitle(
+        {
+          customTitle: null,
+          aiVaultTitle: {
+            agent: 'claude',
+            sessionId: 'claude-session-2',
+            title: 'Housekeeping'
+          },
+          generatedTitle: 'pull again',
+          title: '✳ pull again'
+        },
+        true
+      )
+    ).toBe('Housekeeping')
+  })
+
   it('keeps manual and quick-command labels ahead of AI Vault titles', () => {
     const aiVaultTitle = {
       agent: 'claude' as const,

--- a/src/shared/tab-title-resolution.test.ts
+++ b/src/shared/tab-title-resolution.test.ts
@@ -108,6 +108,31 @@ describe('tab title resolution', () => {
     ).toBe('Housekeeping')
   })
 
+  it('treats an explicit Vault clear as suppressing only the generated fallback', () => {
+    expect(
+      resolveTerminalTabTitle(
+        {
+          customTitle: null,
+          aiVaultTitle: null,
+          generatedTitle: 'Pull again',
+          title: 'Claude working'
+        },
+        true
+      )
+    ).toBe('Claude working')
+    expect(
+      resolveUnifiedTabLabel(
+        {
+          customLabel: null,
+          aiVaultTitle: null,
+          generatedLabel: 'Pull again',
+          label: 'Claude working'
+        },
+        true
+      )
+    ).toBe('Claude working')
+  })
+
   it('keeps manual and quick-command labels ahead of AI Vault titles', () => {
     const aiVaultTitle = {
       agent: 'claude' as const,

--- a/src/shared/tab-title-resolution.ts
+++ b/src/shared/tab-title-resolution.ts
@@ -16,7 +16,7 @@ export function resolveTerminalTabTitle(
     tab.quickCommandLabel?.trim() ||
     (isMeaningfulOpenCodeTerminalTitle(liveTitle) ? liveTitle : '') ||
     tab.aiVaultTitle?.title.trim() ||
-    (generatedTitlesEnabled ? tab.generatedTitle?.trim() : '') ||
+    (generatedTitlesEnabled && tab.aiVaultTitle !== null ? tab.generatedTitle?.trim() : '') ||
     liveTitle ||
     fallback
   )
@@ -35,7 +35,7 @@ export function resolveUnifiedTabLabel(
     tab?.quickCommandLabel?.trim() ||
     (isMeaningfulOpenCodeTerminalTitle(liveLabel) ? liveLabel : '') ||
     tab?.aiVaultTitle?.title.trim() ||
-    (generatedTitlesEnabled ? tab?.generatedLabel?.trim() : '') ||
+    (generatedTitlesEnabled && tab?.aiVaultTitle !== null ? tab?.generatedLabel?.trim() : '') ||
     liveLabel ||
     fallback
   )

--- a/src/shared/workspace-session-schema.test.ts
+++ b/src/shared/workspace-session-schema.test.ts
@@ -14,6 +14,64 @@ describe('parseWorkspaceSession', () => {
     expect(result.ok).toBe(true)
   })
 
+  it('preserves absent, cleared, and resolved Vault titles on both tab representations', () => {
+    const title = { agent: 'claude' as const, sessionId: 'session-1', title: 'Housekeeping' }
+    for (const aiVaultTitle of [undefined, null, title]) {
+      const optionalTitle = aiVaultTitle === undefined ? {} : { aiVaultTitle }
+      const result = parseWorkspaceSession({
+        activeRepoId: null,
+        activeWorktreeId: 'wt',
+        activeTabId: 'terminal-1',
+        tabsByWorktree: {
+          wt: [
+            {
+              id: 'terminal-1',
+              ptyId: null,
+              worktreeId: 'wt',
+              title: 'Claude working',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1,
+              ...optionalTitle
+            }
+          ]
+        },
+        terminalLayoutsByTabId: {},
+        unifiedTabs: {
+          wt: [
+            {
+              id: 'unified-1',
+              entityId: 'terminal-1',
+              groupId: 'group-1',
+              worktreeId: 'wt',
+              contentType: 'terminal',
+              label: 'Claude working',
+              customLabel: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1,
+              ...optionalTitle
+            }
+          ]
+        }
+      })
+
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        const terminal = result.value.tabsByWorktree.wt[0]
+        const unified = result.value.unifiedTabs?.wt[0]
+        if (aiVaultTitle === undefined) {
+          expect(terminal).not.toHaveProperty('aiVaultTitle')
+          expect(unified).not.toHaveProperty('aiVaultTitle')
+        } else {
+          expect(terminal.aiVaultTitle).toEqual(aiVaultTitle)
+          expect(unified?.aiVaultTitle).toEqual(aiVaultTitle)
+        }
+      }
+    }
+  })
+
   it('preserves external SSH file ownership across session parsing', () => {
     const result = parseWorkspaceSession({
       activeRepoId: null,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​821 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​819 |
| Prod | 12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​113 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​51 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​62 |

<!-- /orca-pr-loc -->

## ELI5

A Claude pane was keeping the name of its first prompt forever. After this change, the tab and the session list show the current Claude session name, including after a rename, after `/clear`, and for panes that already had a stale name saved.

## What Changed

- Session-list conversation names now use the same title order as the tab bar: manual rename → quick command → native OpenCode title → **AI Vault session name** → generated first-prompt title → live terminal title.
- When a pane rebinds to a new provider session (`/clear`, new session id from the live hook), the first-prompt generated title is dropped so it cannot keep describing the previous session.
- Same-session Claude `/rename` still updates through the existing live AI Vault title sync; the session list now actually displays that updated name.

## Why

Orca already stored the live Claude session name on the tab (`aiVaultTitle`) and already re-resolved it when the hook reported a new `providerSession.id`. Two display bugs made that live data unused:

1. The session list (`getAgentRowConversationName`) never read `aiVaultTitle`, so the write-once first-prompt generated title won.
2. That generated title is persisted, so a restart could not heal already-stale panes.

The reporter's "new or split terminal shows the right name" workaround matches this: a new pane latches a *new* first prompt, while the old pane keeps its original one. The live hook status (`agent-hooks/last-status.json`) was current the whole time.

This is not WSL-specific. WSL UNC workspaces made it easier to see because vault parse-cache misses leave the first-prompt name as the only label, but the same latch happens on any host.

## Linked Issue

Fixes https://github.com/stablyai/orca/issues/15497
Linear: https://linear.app/stably/issue/STA-4865

## Visual Proof

N/A — no layout, styling, or interaction-path change. The only user-visible difference is which string the existing tab label and session-list row already render, and that derivation is covered by unit tests (rename, `/clear` rebind, persisted-stale heal). Reproducing in a running app requires a live Claude session.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Pre-fix (tests against unfixed code): 5 failed. Session list returned `"pull again"` / `"Pull again"` instead of `"Housekeeping"`, and `/clear` left `generatedTitle` set.

Post-fix: `pnpm vitest run --config config/vitest.config.ts src/shared/agent-row-conversation-name.test.ts src/shared/tab-title-resolution.test.ts src/renderer/src/store/slices/agent-generated-tab-title.test.ts src/renderer/src/lib/ai-vault-tab-title-sync.test.ts` — 53 passed.

Neutered (reverted the two production hunks, kept tests): same 5 failed again.

Platform: logic is host-agnostic (macOS / Linux / Windows / WSL / SSH). Title reads still go through the existing execution-host AI Vault path.

## AI Disclosure

Internal contributor — ignore.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Sibling tickets, not in this PR:

- **STA-2848** — generated tab titles pinning to the first prompt. Same latch, but this PR only ranks Claude/Codex AI Vault names above that generated title and drops it on session rebind. Agents without an AI Vault title still first-write-wins.
- **STA-2467** — session list names vs user-set custom names. Claude `/rename` lands in `aiVaultTitle` (transcript `custom-title`). The session list now reads that field, so this likely covers the Claude/Codex case. Orca-side tab renames (`customTitle`) already outranked everything.

`session-parse-cache.json` stopping after 1.4.185 and empty `claudeLivePtySessionIds` were noted by the reporter and are not treated as causal here.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)