### PR TITLE
fix(native-chat): surface Claude system notices in Chat

### DIFF
--- a/mobile/src/session/MobileNativeChatMessage.test.ts
+++ b/mobile/src/session/MobileNativeChatMessage.test.ts
@@ -152,4 +152,22 @@ describe('MobileNativeChatMessage', () => {
     expect(tree.root.findAllByType('ChevronDown' as never)).toHaveLength(1)
     expect(tree.root.findAllByType('SquareChevronRight' as never)).toHaveLength(1)
   })
+
+  it('renders a system notice as a banner, not an agent bubble with copy controls', () => {
+    const tree = render({
+      id: 'notice-1',
+      role: 'system',
+      blocks: [{ type: 'text', text: 'Please run /login in Claude Code.' }],
+      timestamp: null,
+      source: 'transcript',
+      noticeKind: 'agent-notice',
+      noticeLevel: 'warning'
+    })
+    expect(textIn(tree.root)).toContain('Please run /login in Claude Code.')
+    expect(tree.root.findAllByType('Pressable' as never)).toHaveLength(0)
+    const banner = tree.root
+      .findAllByType('View' as never)
+      .find((node) => node.props.accessibilityRole === 'alert')
+    expect(banner).toBeTruthy()
+  })
 })

--- a/mobile/src/session/MobileNativeChatMessage.test.ts
+++ b/mobile/src/session/MobileNativeChatMessage.test.ts
@@ -170,4 +170,21 @@ describe('MobileNativeChatMessage', () => {
       .find((node) => node.props.accessibilityRole === 'alert')
     expect(banner).toBeTruthy()
   })
+  // STA-4983 x STA-4777: the notice bubble auto-merges cleanly with the selectable
+  // work, so nothing else catches it becoming the one uncopyable bubble.
+  it('makes agent notice text long-press selectable', () => {
+    const tree = render({
+      id: 'notice-1',
+      role: 'system',
+      blocks: [{ type: 'text', text: 'Please run /login to enroll this device.' }],
+      source: 'transcript',
+      noticeKind: 'agent-notice',
+      noticeLevel: 'warning'
+    })
+    const notice = tree.root
+      .findAllByType('Text' as never)
+      .find((node) => String(node.children.join('')).includes('/login'))
+    expect(notice, 'notice text node').toBeDefined()
+    expect(notice!.props.selectable).toBe(true)
+  })
 })

--- a/mobile/src/session/MobileNativeChatMessage.test.ts
+++ b/mobile/src/session/MobileNativeChatMessage.test.ts
@@ -160,8 +160,7 @@ describe('MobileNativeChatMessage', () => {
       blocks: [{ type: 'text', text: 'Please run /login in Claude Code.' }],
       timestamp: null,
       source: 'transcript',
-      noticeKind: 'agent-notice',
-      noticeLevel: 'warning'
+      notice: { level: 'warning' }
     })
     expect(textIn(tree.root)).toContain('Please run /login in Claude Code.')
     expect(tree.root.findAllByType('Pressable' as never)).toHaveLength(0)
@@ -170,21 +169,23 @@ describe('MobileNativeChatMessage', () => {
       .find((node) => node.props.accessibilityRole === 'alert')
     expect(banner).toBeTruthy()
   })
-  // STA-4983 x STA-4777: the notice bubble auto-merges cleanly with the selectable
-  // work, so nothing else catches it becoming the one uncopyable bubble.
-  it('makes agent notice text long-press selectable', () => {
-    const tree = render({
-      id: 'notice-1',
-      role: 'system',
-      blocks: [{ type: 'text', text: 'Please run /login to enroll this device.' }],
-      source: 'transcript',
-      noticeKind: 'agent-notice',
-      noticeLevel: 'warning'
-    })
+  it('makes agent notice text selectable and respects font scaling', () => {
+    const tree = render(
+      {
+        id: 'notice-1',
+        role: 'system',
+        blocks: [{ type: 'text', text: 'Please run /login to enroll this device.' }],
+        timestamp: null,
+        source: 'transcript',
+        notice: { level: 'warning' }
+      },
+      { fontScale: 1.5 }
+    )
     const notice = tree.root
       .findAllByType('Text' as never)
       .find((node) => String(node.children.join('')).includes('/login'))
     expect(notice, 'notice text node').toBeDefined()
     expect(notice!.props.selectable).toBe(true)
+    expect(notice!.props.style).toContainEqual({ fontSize: 25.5, lineHeight: 34.5 })
   })
 })

--- a/mobile/src/session/MobileNativeChatMessage.test.ts
+++ b/mobile/src/session/MobileNativeChatMessage.test.ts
@@ -45,7 +45,7 @@ describe('MobileNativeChatMessage', () => {
 
   function render(
     message: NativeChatMessage,
-    props: { toolsExpanded?: boolean } = {}
+    props: { toolsExpanded?: boolean; fontScale?: number } = {}
   ): ReactTestRenderer {
     act(() => {
       renderer = create(createElement(MobileNativeChatMessage, { message, ...props }))
@@ -187,5 +187,25 @@ describe('MobileNativeChatMessage', () => {
     expect(notice, 'notice text node').toBeDefined()
     expect(notice!.props.selectable).toBe(true)
     expect(notice!.props.style).toContainEqual({ fontSize: 25.5, lineHeight: 34.5 })
+  })
+
+  it('renders a metadata-absent system row through the ordinary message fallback', () => {
+    const tree = render({
+      id: 'legacy-system-1',
+      role: 'system',
+      blocks: [{ type: 'text', text: 'Provider status from an older host.' }],
+      timestamp: null,
+      source: 'transcript'
+    })
+
+    expect(tree.root.findByType('MobileMarkdown' as never).props.content).toBe(
+      'Provider status from an older host.'
+    )
+    expect(tree.root.findAllByType('Pressable' as never)).not.toHaveLength(0)
+    expect(
+      tree.root
+        .findAllByType('View' as never)
+        .some((node) => node.props.accessibilityRole === 'alert')
+    ).toBe(false)
   })
 })

--- a/mobile/src/session/MobileNativeChatMessage.tsx
+++ b/mobile/src/session/MobileNativeChatMessage.tsx
@@ -11,7 +11,11 @@ import {
   summarizeToolRun,
   truncateToolDetail
 } from '../../../src/shared/native-chat-tool-summary'
-import { isImageRefBlock, isTextBlock } from '../../../src/shared/native-chat-types'
+import {
+  isAgentNoticeMessage,
+  isImageRefBlock,
+  isTextBlock
+} from '../../../src/shared/native-chat-types'
 import type { NativeChatBlock, NativeChatMessage } from '../../../src/shared/native-chat-types'
 import { MobileMarkdown } from '../components/MobileMarkdown'
 import { colors } from '../theme/mobile-theme'
@@ -294,7 +298,8 @@ function MobileNativeChatMessageImpl({
 }): React.JSX.Element {
   const isUser = message.role === 'user'
   const isReasoning = message.role === 'reasoning'
-  const isAgent = !isUser
+  const isNotice = isAgentNoticeMessage(message)
+  const isAgent = !isUser && !isNotice
   // Briefly tint the bubble to confirm a copy landed.
   const [copied, setCopied] = useState(false)
   const copyTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -310,6 +315,18 @@ function MobileNativeChatMessageImpl({
   // tool calls fold into a collapsible run beneath. The user's own messages get
   // an inverted (filled accent) bubble so they stand apart from agent prose.
   const { prose, tools } = splitNativeChatBlocks(message.blocks)
+
+  if (isNotice) {
+    const text = nativeChatMessageText(message.blocks)
+    const needsAttention = message.noticeLevel === 'warning' || message.noticeLevel === 'error'
+    return (
+      <View style={styles.row}>
+        <View accessibilityRole={needsAttention ? 'alert' : 'summary'} style={styles.notice}>
+          <Text style={styles.noticeText}>{text}</Text>
+        </View>
+      </View>
+    )
+  }
 
   const handleCopy = (): void => {
     const text = nativeChatMessageText(message.blocks)

--- a/mobile/src/session/MobileNativeChatMessage.tsx
+++ b/mobile/src/session/MobileNativeChatMessage.tsx
@@ -318,13 +318,20 @@ function MobileNativeChatMessageImpl({
 
   if (isNotice) {
     const text = nativeChatMessageText(message.blocks)
-    const needsAttention = message.noticeLevel === 'warning' || message.noticeLevel === 'error'
+    const level = message.notice?.level ?? 'info'
+    const needsAttention = level === 'warning' || level === 'error'
     return (
       <View style={styles.row}>
         <View accessibilityRole={needsAttention ? 'alert' : 'summary'} style={styles.notice}>
           {/* Why: notice copy is what users paste into bug reports, so it must be
               long-press selectable like every other bubble (STA-4983). */}
-          <Text selectable style={styles.noticeText}>
+          <Text
+            selectable
+            style={[
+              styles.noticeText,
+              { fontSize: TEXT_SIZE * fontScale, lineHeight: (TEXT_SIZE + 6) * fontScale }
+            ]}
+          >
             {text}
           </Text>
         </View>

--- a/mobile/src/session/MobileNativeChatMessage.tsx
+++ b/mobile/src/session/MobileNativeChatMessage.tsx
@@ -323,8 +323,7 @@ function MobileNativeChatMessageImpl({
     return (
       <View style={styles.row}>
         <View accessibilityRole={needsAttention ? 'alert' : 'summary'} style={styles.notice}>
-          {/* Why: notice copy is what users paste into bug reports, so it must be
-              long-press selectable like every other bubble (STA-4983). */}
+          {/* Why: provider diagnostics must remain selectable for support reports. */}
           <Text
             selectable
             style={[

--- a/mobile/src/session/MobileNativeChatMessage.tsx
+++ b/mobile/src/session/MobileNativeChatMessage.tsx
@@ -322,7 +322,11 @@ function MobileNativeChatMessageImpl({
     return (
       <View style={styles.row}>
         <View accessibilityRole={needsAttention ? 'alert' : 'summary'} style={styles.notice}>
-          <Text style={styles.noticeText}>{text}</Text>
+          {/* Why: notice copy is what users paste into bug reports, so it must be
+              long-press selectable like every other bubble (STA-4983). */}
+          <Text selectable style={styles.noticeText}>
+            {text}
+          </Text>
         </View>
       </View>
     )

--- a/mobile/src/session/mobile-native-chat-message-styles.ts
+++ b/mobile/src/session/mobile-native-chat-message-styles.ts
@@ -49,6 +49,19 @@ export const styles = StyleSheet.create({
   reasoning: {
     opacity: 0.7
   },
+  notice: {
+    borderWidth: 1,
+    borderColor: colors.borderSubtle,
+    backgroundColor: colors.bgPanel,
+    borderRadius: radii.card,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm
+  },
+  noticeText: {
+    color: colors.textPrimary,
+    fontSize: TEXT_SIZE,
+    lineHeight: TEXT_SIZE + 6
+  },
   toolRun: {
     marginTop: spacing.xs
   },

--- a/src/main/native-chat/transcript-line-decoders-claude.test.ts
+++ b/src/main/native-chat/transcript-line-decoders-claude.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from 'vitest'
+import { isAgentNoticeMessage } from '../../shared/native-chat-types'
+import { decodeClaudeTranscriptLine } from './transcript-line-decoders-claude'
+
+const LOGIN_NOTICE =
+  'Remote Control disconnected — Your organization requires Trusted Devices for Remote Control, but this device is not enrolled. Please run `/login` in Claude Code to enroll this device.'
+
+function decode(record: Record<string, unknown>) {
+  return decodeClaudeTranscriptLine(JSON.stringify(record), 'fallback')
+}
+
+describe('decodeClaudeTranscriptLine — system notices', () => {
+  it('surfaces a type:system subtype:informational login notice as an agent notice', () => {
+    const decoded = decode({
+      type: 'system',
+      subtype: 'informational',
+      content: LOGIN_NOTICE,
+      level: 'warning',
+      timestamp: '2026-08-13T13:26:51.452Z',
+      uuid: '1da9c588-975e-4d06-b023-fba02612707d'
+    })
+
+    expect(decoded).toEqual({
+      id: '1da9c588-975e-4d06-b023-fba02612707d',
+      role: 'system',
+      blocks: [{ type: 'text', text: LOGIN_NOTICE }],
+      timestamp: Date.parse('2026-08-13T13:26:51.452Z'),
+      source: 'transcript',
+      noticeKind: 'agent-notice',
+      noticeLevel: 'warning'
+    })
+    expect(isAgentNoticeMessage(decoded!)).toBe(true)
+  })
+
+  it('surfaces an unknown future subtype when it carries user-facing copy', () => {
+    const decoded = decode({
+      type: 'system',
+      subtype: 'trusted_device_required',
+      content: 'Enroll this device to continue Remote Control.',
+      level: 'warning',
+      timestamp: '2026-08-20T00:00:00.000Z',
+      uuid: 'future-notice'
+    })
+
+    expect(decoded).toMatchObject({
+      id: 'future-notice',
+      role: 'system',
+      noticeKind: 'agent-notice',
+      noticeLevel: 'warning',
+      blocks: [{ type: 'text', text: 'Enroll this device to continue Remote Control.' }]
+    })
+    expect(isAgentNoticeMessage(decoded!)).toBe(true)
+  })
+
+  it('keeps known telemetry subtypes silent even when they carry extra fields', () => {
+    expect(
+      decode({
+        type: 'system',
+        subtype: 'stop_hook_summary',
+        hookCount: 3,
+        timestamp: '2026-08-13T14:44:23.786Z',
+        uuid: 'e6f19769-d9b9-44eb-86e4-0092bf4cf6da'
+      })
+    ).toBeNull()
+    expect(
+      decode({
+        type: 'system',
+        subtype: 'turn_duration',
+        durationMs: 5419,
+        timestamp: '2026-08-13T14:44:23.787Z',
+        uuid: 'cb4072ea-68ed-4140-a552-08de711c002b'
+      })
+    ).toBeNull()
+    expect(
+      decode({
+        type: 'system',
+        subtype: 'away_summary',
+        content: 'PR #11417 is finalized and the evidence comment is posted.',
+        uuid: 'away-1'
+      })
+    ).toBeNull()
+    expect(
+      decode({
+        type: 'system',
+        subtype: 'local_command',
+        content: '<command-name>/login</command-name>',
+        uuid: 'cmd-1'
+      })
+    ).toBeNull()
+  })
+
+  it('surfaces api_error copy from the structured error payload', () => {
+    const decoded = decode({
+      type: 'system',
+      subtype: 'api_error',
+      level: 'error',
+      error: {
+        message: 'Connection error.',
+        formatted: 'Unable to connect to API (ECONNRESET)'
+      },
+      uuid: 'api-err-1',
+      timestamp: '2026-07-27T22:36:42.173Z'
+    })
+
+    expect(decoded).toMatchObject({
+      id: 'api-err-1',
+      role: 'system',
+      noticeKind: 'agent-notice',
+      noticeLevel: 'error',
+      blocks: [{ type: 'text', text: 'Unable to connect to API (ECONNRESET)' }]
+    })
+  })
+
+  it('surfaces model_refusal_fallback and compact_boundary copy as notices', () => {
+    expect(
+      decode({
+        type: 'system',
+        subtype: 'model_refusal_fallback',
+        content: "Fable 5's safeguards flagged this message. Switched to Opus 4.8.",
+        level: 'warning',
+        uuid: 'refusal-1'
+      })
+    ).toMatchObject({
+      noticeKind: 'agent-notice',
+      noticeLevel: 'warning',
+      blocks: [
+        {
+          type: 'text',
+          text: "Fable 5's safeguards flagged this message. Switched to Opus 4.8."
+        }
+      ]
+    })
+    expect(
+      decode({
+        type: 'system',
+        subtype: 'compact_boundary',
+        content: 'Conversation compacted',
+        level: 'info',
+        uuid: 'compact-1'
+      })
+    ).toMatchObject({
+      noticeKind: 'agent-notice',
+      noticeLevel: 'info',
+      blocks: [{ type: 'text', text: 'Conversation compacted' }]
+    })
+  })
+
+  it('drops an informational notice with no extractable copy instead of a blank banner', () => {
+    expect(
+      decode({
+        type: 'system',
+        subtype: 'informational',
+        timestamp: '2026-08-13T13:00:00.000Z',
+        uuid: 'notice-empty'
+      })
+    ).toBeNull()
+  })
+
+  it('drops an unknown subtype that has no extractable copy', () => {
+    expect(
+      decode({
+        type: 'system',
+        subtype: 'future_telemetry',
+        durationMs: 12,
+        uuid: 'future-empty'
+      })
+    ).toBeNull()
+  })
+
+  it('does not mark ordinary assistant turns or interrupt status as agent notices', () => {
+    const assistant = decode({
+      type: 'assistant',
+      message: { id: 'msg-1', content: [{ type: 'text', text: 'Hola' }] },
+      timestamp: '2026-08-13T14:44:23.542Z',
+      uuid: '18d90d27-d0f1-481b-9735-b18b5f005307'
+    })
+    expect(assistant?.role).toBe('assistant')
+    expect(assistant?.noticeKind).toBeUndefined()
+    expect(isAgentNoticeMessage(assistant!)).toBe(false)
+
+    const interrupted = decode({
+      type: 'user',
+      uuid: 'interrupt-row',
+      interruptedMessageId: 'assistant-request-1',
+      timestamp: '2026-07-16T23:46:01.000Z',
+      message: {
+        role: 'user',
+        content: [{ type: 'text', text: '[Request interrupted by user]' }]
+      }
+    })
+    expect(interrupted?.role).toBe('system')
+    expect(interrupted?.noticeKind).toBeUndefined()
+    expect(isAgentNoticeMessage(interrupted!)).toBe(false)
+  })
+})

--- a/src/main/native-chat/transcript-line-decoders-claude.test.ts
+++ b/src/main/native-chat/transcript-line-decoders-claude.test.ts
@@ -26,123 +26,58 @@ describe('decodeClaudeTranscriptLine — system notices', () => {
       blocks: [{ type: 'text', text: LOGIN_NOTICE }],
       timestamp: Date.parse('2026-08-13T13:26:51.452Z'),
       source: 'transcript',
-      noticeKind: 'agent-notice',
-      noticeLevel: 'warning'
+      notice: { level: 'warning' }
     })
     expect(isAgentNoticeMessage(decoded!)).toBe(true)
   })
 
-  it('surfaces an unknown future subtype when it carries user-facing copy', () => {
-    const decoded = decode({
+  it.each([
+    ['informational', 'Device enrollment required', 'warning', 'warning'],
+    ['model_refusal_fallback', 'Switched to a fallback model', 'error', 'error'],
+    ['compact_boundary', 'Conversation compacted', 'suggestion', 'info']
+  ])('surfaces supported %s copy as an agent notice', (subtype, content, level, expectedLevel) => {
+    expect(decode({ type: 'system', subtype, content, level, uuid: `${subtype}-1` })).toMatchObject(
+      {
+        role: 'system',
+        blocks: [{ type: 'text', text: content }],
+        notice: { level: expectedLevel }
+      }
+    )
+  })
+
+  it.each([
+    {
       type: 'system',
-      subtype: 'trusted_device_required',
-      content: 'Enroll this device to continue Remote Control.',
-      level: 'warning',
-      timestamp: '2026-08-20T00:00:00.000Z',
-      uuid: 'future-notice'
-    })
-
-    expect(decoded).toMatchObject({
-      id: 'future-notice',
-      role: 'system',
-      noticeKind: 'agent-notice',
-      noticeLevel: 'warning',
-      blocks: [{ type: 'text', text: 'Enroll this device to continue Remote Control.' }]
-    })
-    expect(isAgentNoticeMessage(decoded!)).toBe(true)
-  })
-
-  it('keeps known telemetry subtypes silent even when they carry extra fields', () => {
-    expect(
-      decode({
-        type: 'system',
-        subtype: 'stop_hook_summary',
-        hookCount: 3,
-        timestamp: '2026-08-13T14:44:23.786Z',
-        uuid: 'e6f19769-d9b9-44eb-86e4-0092bf4cf6da'
-      })
-    ).toBeNull()
-    expect(
-      decode({
-        type: 'system',
-        subtype: 'turn_duration',
-        durationMs: 5419,
-        timestamp: '2026-08-13T14:44:23.787Z',
-        uuid: 'cb4072ea-68ed-4140-a552-08de711c002b'
-      })
-    ).toBeNull()
-    expect(
-      decode({
-        type: 'system',
-        subtype: 'away_summary',
-        content: 'PR #11417 is finalized and the evidence comment is posted.',
-        uuid: 'away-1'
-      })
-    ).toBeNull()
-    expect(
-      decode({
-        type: 'system',
-        subtype: 'local_command',
-        content: '<command-name>/login</command-name>',
-        uuid: 'cmd-1'
-      })
-    ).toBeNull()
-  })
-
-  it('surfaces api_error copy from the structured error payload', () => {
-    const decoded = decode({
+      subtype: 'away_summary',
+      content: 'While you were away, Claude completed the requested implementation.',
+      uuid: 'away-1'
+    },
+    {
       type: 'system',
       subtype: 'api_error',
       level: 'error',
-      error: {
-        message: 'Connection error.',
-        formatted: 'Unable to connect to API (ECONNRESET)'
-      },
-      uuid: 'api-err-1',
-      timestamp: '2026-07-27T22:36:42.173Z'
-    })
-
-    expect(decoded).toMatchObject({
-      id: 'api-err-1',
-      role: 'system',
-      noticeKind: 'agent-notice',
-      noticeLevel: 'error',
-      blocks: [{ type: 'text', text: 'Unable to connect to API (ECONNRESET)' }]
-    })
-  })
-
-  it('surfaces model_refusal_fallback and compact_boundary copy as notices', () => {
-    expect(
-      decode({
-        type: 'system',
-        subtype: 'model_refusal_fallback',
-        content: "Fable 5's safeguards flagged this message. Switched to Opus 4.8.",
-        level: 'warning',
-        uuid: 'refusal-1'
-      })
-    ).toMatchObject({
-      noticeKind: 'agent-notice',
-      noticeLevel: 'warning',
-      blocks: [
-        {
-          type: 'text',
-          text: "Fable 5's safeguards flagged this message. Switched to Opus 4.8."
-        }
-      ]
-    })
-    expect(
-      decode({
-        type: 'system',
-        subtype: 'compact_boundary',
-        content: 'Conversation compacted',
-        level: 'info',
-        uuid: 'compact-1'
-      })
-    ).toMatchObject({
-      noticeKind: 'agent-notice',
-      noticeLevel: 'info',
-      blocks: [{ type: 'text', text: 'Conversation compacted' }]
-    })
+      error: { message: 'Connection error.', formatted: 'Unable to connect to API' },
+      retryAttempt: 2,
+      retryInMs: 1_000,
+      source: 'request_retry',
+      uuid: 'api-retry-1'
+    },
+    {
+      type: 'system',
+      subtype: 'stop_hook_summary',
+      content: 'Stop hook completed',
+      level: 'suggestion',
+      hookCount: 3,
+      uuid: 'stop-hook-1'
+    },
+    {
+      type: 'system',
+      subtype: 'bridge_status',
+      content: 'Bridge connected',
+      uuid: 'unknown-1'
+    }
+  ])('keeps non-message system records silent', (record) => {
+    expect(decode(record)).toBeNull()
   })
 
   it('drops an informational notice with no extractable copy instead of a blank banner', () => {
@@ -156,17 +91,6 @@ describe('decodeClaudeTranscriptLine — system notices', () => {
     ).toBeNull()
   })
 
-  it('drops an unknown subtype that has no extractable copy', () => {
-    expect(
-      decode({
-        type: 'system',
-        subtype: 'future_telemetry',
-        durationMs: 12,
-        uuid: 'future-empty'
-      })
-    ).toBeNull()
-  })
-
   it('does not mark ordinary assistant turns or interrupt status as agent notices', () => {
     const assistant = decode({
       type: 'assistant',
@@ -175,7 +99,7 @@ describe('decodeClaudeTranscriptLine — system notices', () => {
       uuid: '18d90d27-d0f1-481b-9735-b18b5f005307'
     })
     expect(assistant?.role).toBe('assistant')
-    expect(assistant?.noticeKind).toBeUndefined()
+    expect(assistant?.notice).toBeUndefined()
     expect(isAgentNoticeMessage(assistant!)).toBe(false)
 
     const interrupted = decode({
@@ -189,7 +113,7 @@ describe('decodeClaudeTranscriptLine — system notices', () => {
       }
     })
     expect(interrupted?.role).toBe('system')
-    expect(interrupted?.noticeKind).toBeUndefined()
+    expect(interrupted?.notice).toBeUndefined()
     expect(isAgentNoticeMessage(interrupted!)).toBe(false)
   })
 })

--- a/src/main/native-chat/transcript-line-decoders-claude.test.ts
+++ b/src/main/native-chat/transcript-line-decoders-claude.test.ts
@@ -31,65 +31,125 @@ describe('decodeClaudeTranscriptLine — system notices', () => {
     expect(isAgentNoticeMessage(decoded!)).toBe(true)
   })
 
-  it.each([
-    ['informational', 'Device enrollment required', 'warning', 'warning'],
-    ['model_refusal_fallback', 'Switched to a fallback model', 'error', 'error'],
-    ['compact_boundary', 'Conversation compacted', 'suggestion', 'info']
-  ])('surfaces supported %s copy as an agent notice', (subtype, content, level, expectedLevel) => {
-    expect(decode({ type: 'system', subtype, content, level, uuid: `${subtype}-1` })).toMatchObject(
-      {
-        role: 'system',
-        blocks: [{ type: 'text', text: content }],
-        notice: { level: expectedLevel }
-      }
-    )
-  })
-
-  it.each([
-    {
-      type: 'system',
-      subtype: 'away_summary',
-      content: 'While you were away, Claude completed the requested implementation.',
-      uuid: 'away-1'
-    },
-    {
-      type: 'system',
-      subtype: 'api_error',
-      level: 'error',
-      error: { message: 'Connection error.', formatted: 'Unable to connect to API' },
-      retryAttempt: 2,
-      retryInMs: 1_000,
-      source: 'request_retry',
-      uuid: 'api-retry-1'
-    },
-    {
-      type: 'system',
-      subtype: 'stop_hook_summary',
-      content: 'Stop hook completed',
-      level: 'suggestion',
-      hookCount: 3,
-      uuid: 'stop-hook-1'
-    },
-    {
-      type: 'system',
-      subtype: 'bridge_status',
-      content: 'Bridge connected',
-      uuid: 'unknown-1'
-    }
-  ])('keeps non-message system records silent', (record) => {
-    expect(decode(record)).toBeNull()
-  })
-
-  it('drops an informational notice with no extractable copy instead of a blank banner', () => {
+  it('surfaces an unknown future subtype when it contains user-facing copy', () => {
     expect(
       decode({
         type: 'system',
-        subtype: 'informational',
-        timestamp: '2026-08-13T13:00:00.000Z',
-        uuid: 'notice-empty'
+        subtype: 'workspace_policy_notice',
+        content: 'This workspace now requires approval.',
+        uuid: 'future-1'
+      })
+    ).toMatchObject({
+      role: 'system',
+      blocks: [{ type: 'text', text: 'This workspace now requires approval.' }],
+      notice: { level: 'info' }
+    })
+  })
+
+  it('does not apply API retry suppression to an unknown subtype', () => {
+    expect(
+      decode({
+        type: 'system',
+        subtype: 'workspace_policy_notice',
+        source: 'request_retry',
+        content: 'Approval is still required.',
+        uuid: 'future-retry-source-1'
+      })
+    ).toMatchObject({
+      blocks: [{ type: 'text', text: 'Approval is still required.' }],
+      notice: { level: 'info' }
+    })
+  })
+
+  it.each([
+    'stop_hook_summary',
+    'turn_duration',
+    'away_summary',
+    'local_command',
+    'hook_callback',
+    'init',
+    'compact_boundary'
+  ])('keeps known noise subtype %s silent', (subtype) => {
+    expect(
+      decode({
+        type: 'system',
+        subtype,
+        content: subtype === 'compact_boundary' ? 'Conversation compacted' : 'System detail',
+        uuid: `${subtype}-1`
       })
     ).toBeNull()
   })
+
+  it.each([
+    {
+      source: 'request_retry',
+      retryAttempt: 2,
+      retryInMs: 1_000,
+      maxRetries: 10,
+      error: { message: 'Connection error.', formatted: 'Unable to connect to API' }
+    },
+    {
+      source: 'connection_retry',
+      retryAttempt: 5,
+      retryInMs: 8_000,
+      maxRetries: 10,
+      error: 'Connection failed; retrying'
+    }
+  ])('keeps $source API retry progress silent', (retry) => {
+    expect(
+      decode({
+        type: 'system',
+        subtype: 'api_error',
+        level: 'error',
+        uuid: `api-${retry.source}-1`,
+        ...retry
+      })
+    ).toBeNull()
+  })
+
+  it('surfaces a source-less API error using formatted error copy', () => {
+    expect(
+      decode({
+        type: 'system',
+        subtype: 'api_error',
+        level: 'error',
+        error: { message: 'Connection error.', formatted: 'Unable to connect to API' },
+        uuid: 'api-error-1'
+      })
+    ).toMatchObject({
+      blocks: [{ type: 'text', text: 'Unable to connect to API' }],
+      notice: { level: 'error' }
+    })
+  })
+
+  it('surfaces model refusal fallback copy', () => {
+    expect(
+      decode({
+        type: 'system',
+        subtype: 'model_refusal_fallback',
+        content: 'Switched to a fallback model',
+        level: 'warning',
+        uuid: 'model-fallback-1'
+      })
+    ).toMatchObject({
+      blocks: [{ type: 'text', text: 'Switched to a fallback model' }],
+      notice: { level: 'warning' }
+    })
+  })
+
+  it.each(['informational', 'future_notice', 'api_error'])(
+    'drops %s records with no extractable copy instead of a blank banner',
+    (subtype) => {
+      expect(
+        decode({
+          type: 'system',
+          subtype,
+          timestamp: '2026-08-13T13:00:00.000Z',
+          uuid: 'notice-empty'
+        })
+      ).toBeNull()
+    }
+  )
 
   it('does not mark ordinary assistant turns or interrupt status as agent notices', () => {
     const assistant = decode({

--- a/src/main/native-chat/transcript-line-decoders-claude.ts
+++ b/src/main/native-chat/transcript-line-decoders-claude.ts
@@ -87,21 +87,35 @@ function parseTimestamp(value: unknown): number | null {
   return Number.isFinite(parsed) ? parsed : null
 }
 
-const CLAUDE_NOTICE_SUBTYPES = new Set([
-  'informational',
-  'model_refusal_fallback',
+const CLAUDE_SYSTEM_NOISE_SUBTYPES = new Set([
+  'stop_hook_summary',
+  'turn_duration',
+  'away_summary',
+  'local_command',
+  'hook_callback',
+  'init',
   'compact_boundary'
 ])
+
+const CLAUDE_API_RETRY_SOURCES = new Set(['request_retry', 'connection_retry'])
 
 function decodeClaudeSystemNotice(
   record: Record<string, unknown>,
   fallbackId: string
 ): NativeChatMessage | null {
   const subtype = extractString(record.subtype)
-  if (!subtype || !CLAUDE_NOTICE_SUBTYPES.has(subtype)) {
+  if (!subtype || CLAUDE_SYSTEM_NOISE_SUBTYPES.has(subtype)) {
     return null
   }
-  const text = extractString(record.content)
+  if (subtype === 'api_error' && CLAUDE_API_RETRY_SOURCES.has(extractString(record.source) ?? '')) {
+    return null
+  }
+  const error = asRecord(record.error)
+  const text =
+    extractString(record.content) ??
+    extractString(record.error) ??
+    extractString(error?.formatted) ??
+    extractString(error?.message)
   if (!text) {
     return null
   }

--- a/src/main/native-chat/transcript-line-decoders-claude.ts
+++ b/src/main/native-chat/transcript-line-decoders-claude.ts
@@ -3,7 +3,8 @@
 import {
   NATIVE_CHAT_INTERRUPTED_STATUS_TEXT,
   type NativeChatBlock,
-  type NativeChatMessage
+  type NativeChatMessage,
+  type NativeChatNoticeLevel
 } from '../../shared/native-chat-types'
 import {
   asRecord,
@@ -23,6 +24,9 @@ export function decodeClaudeTranscriptLine(
     return null
   }
   const role = record.type
+  if (role === 'system') {
+    return decodeClaudeSystemNotice(record, fallbackId)
+  }
   if (role !== 'user' && role !== 'assistant') {
     return null
   }
@@ -81,4 +85,57 @@ function claudeMessageRole(
 function parseTimestamp(value: unknown): number | null {
   const parsed = timestampMs(value)
   return Number.isFinite(parsed) ? parsed : null
+}
+
+// Observed Claude JSONL `type:"system"` subtypes (local transcripts +
+// anthropics/claude-code#53516). Telemetry/recap/command envelopes stay silent;
+// unknown future subtypes with extractable copy surface so the next login-style
+// notice cannot disappear the way `informational` did.
+const CLAUDE_SYSTEM_NOISE_SUBTYPES = new Set([
+  'stop_hook_summary',
+  'turn_duration',
+  'away_summary',
+  'local_command',
+  'hook_callback',
+  'init'
+])
+
+function decodeClaudeSystemNotice(
+  record: Record<string, unknown>,
+  fallbackId: string
+): NativeChatMessage | null {
+  const subtype = extractString(record.subtype)
+  if (subtype && CLAUDE_SYSTEM_NOISE_SUBTYPES.has(subtype)) {
+    return null
+  }
+  const text = claudeSystemNoticeText(record)
+  if (!text) {
+    return null
+  }
+  return {
+    id: extractString(record.uuid) ?? fallbackId,
+    role: 'system',
+    blocks: [{ type: 'text', text }],
+    timestamp: parseTimestamp(record.timestamp),
+    source: 'transcript',
+    noticeKind: 'agent-notice',
+    noticeLevel: claudeSystemNoticeLevel(record.level)
+  }
+}
+
+function claudeSystemNoticeText(record: Record<string, unknown>): string | null {
+  const content = extractString(record.content)
+  if (content) {
+    return content
+  }
+  const error = record.error
+  return (
+    extractString(error) ??
+    extractString(asRecord(error)?.formatted) ??
+    extractString(asRecord(error)?.message)
+  )
+}
+
+function claudeSystemNoticeLevel(value: unknown): NativeChatNoticeLevel {
+  return value === 'warning' || value === 'error' ? value : 'info'
 }

--- a/src/main/native-chat/transcript-line-decoders-claude.ts
+++ b/src/main/native-chat/transcript-line-decoders-claude.ts
@@ -87,17 +87,10 @@ function parseTimestamp(value: unknown): number | null {
   return Number.isFinite(parsed) ? parsed : null
 }
 
-// Observed Claude JSONL `type:"system"` subtypes (local transcripts +
-// anthropics/claude-code#53516). Telemetry/recap/command envelopes stay silent;
-// unknown future subtypes with extractable copy surface so the next login-style
-// notice cannot disappear the way `informational` did.
-const CLAUDE_SYSTEM_NOISE_SUBTYPES = new Set([
-  'stop_hook_summary',
-  'turn_duration',
-  'away_summary',
-  'local_command',
-  'hook_callback',
-  'init'
+const CLAUDE_NOTICE_SUBTYPES = new Set([
+  'informational',
+  'model_refusal_fallback',
+  'compact_boundary'
 ])
 
 function decodeClaudeSystemNotice(
@@ -105,10 +98,10 @@ function decodeClaudeSystemNotice(
   fallbackId: string
 ): NativeChatMessage | null {
   const subtype = extractString(record.subtype)
-  if (subtype && CLAUDE_SYSTEM_NOISE_SUBTYPES.has(subtype)) {
+  if (!subtype || !CLAUDE_NOTICE_SUBTYPES.has(subtype)) {
     return null
   }
-  const text = claudeSystemNoticeText(record)
+  const text = extractString(record.content)
   if (!text) {
     return null
   }
@@ -118,22 +111,8 @@ function decodeClaudeSystemNotice(
     blocks: [{ type: 'text', text }],
     timestamp: parseTimestamp(record.timestamp),
     source: 'transcript',
-    noticeKind: 'agent-notice',
-    noticeLevel: claudeSystemNoticeLevel(record.level)
+    notice: { level: claudeSystemNoticeLevel(record.level) }
   }
-}
-
-function claudeSystemNoticeText(record: Record<string, unknown>): string | null {
-  const content = extractString(record.content)
-  if (content) {
-    return content
-  }
-  const error = record.error
-  return (
-    extractString(error) ??
-    extractString(asRecord(error)?.formatted) ??
-    extractString(asRecord(error)?.message)
-  )
 }
 
 function claudeSystemNoticeLevel(value: unknown): NativeChatNoticeLevel {

--- a/src/renderer/src/components/native-chat/NativeChatAgentNoticeBanner.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatAgentNoticeBanner.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment happy-dom
+
+import '@testing-library/jest-dom/vitest'
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { NativeChatMessage } from '../../../../shared/native-chat-types'
+import { NativeChatAgentNoticeBanner } from './NativeChatAgentNoticeBanner'
+
+afterEach(cleanup)
+
+function noticeMessage(noticeLevel: 'info' | 'warning' | 'error'): NativeChatMessage {
+  return {
+    id: 'notice-1',
+    role: 'system',
+    blocks: [{ type: 'text', text: 'placeholder' }],
+    timestamp: null,
+    source: 'transcript',
+    noticeKind: 'agent-notice',
+    noticeLevel
+  }
+}
+
+describe('NativeChatAgentNoticeBanner', () => {
+  it('renders a descriptive status banner without a terminal action for info notices', () => {
+    render(
+      <NativeChatAgentNoticeBanner
+        message={noticeMessage('info')}
+        text="Conversation compacted"
+        onSwitchToTerminal={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('status')).toHaveTextContent('Conversation compacted')
+    expect(screen.queryByRole('button')).toBeNull()
+  })
+
+  it('shows Switch to terminal view for a warning notice', () => {
+    const onSwitchToTerminal = vi.fn()
+    render(
+      <NativeChatAgentNoticeBanner
+        message={noticeMessage('warning')}
+        text="Please run /login in Claude Code."
+        onSwitchToTerminal={onSwitchToTerminal}
+      />
+    )
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Please run /login in Claude Code.')
+    fireEvent.click(screen.getByRole('button', { name: /Switch to terminal view/i }))
+    expect(onSwitchToTerminal).toHaveBeenCalledTimes(1)
+  })
+
+  it('omits the terminal action when no handler is wired', () => {
+    render(
+      <NativeChatAgentNoticeBanner
+        message={noticeMessage('warning')}
+        text="Please run /login in Claude Code."
+      />
+    )
+
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(screen.queryByRole('button')).toBeNull()
+  })
+})

--- a/src/renderer/src/components/native-chat/NativeChatAgentNoticeBanner.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatAgentNoticeBanner.test.tsx
@@ -16,8 +16,7 @@ function noticeMessage(noticeLevel: 'info' | 'warning' | 'error'): NativeChatMes
     blocks: [{ type: 'text', text: 'placeholder' }],
     timestamp: null,
     source: 'transcript',
-    noticeKind: 'agent-notice',
-    noticeLevel
+    notice: { level: noticeLevel }
   }
 }
 

--- a/src/renderer/src/components/native-chat/NativeChatAgentNoticeBanner.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatAgentNoticeBanner.tsx
@@ -9,8 +9,7 @@ export type NativeChatAgentNoticeBannerProps = {
   onSwitchToTerminal?: () => void
 }
 
-/** Inline banner for a provider system notice. Matches the native-chat card
- *  chrome (approval/question), not an assistant bubble. */
+/** Inline card for a provider-authored system notice. */
 export function NativeChatAgentNoticeBanner({
   message,
   text,
@@ -23,7 +22,7 @@ export function NativeChatAgentNoticeBanner({
   return (
     <div
       role={needsAttention ? 'alert' : 'status'}
-      className="flex w-full flex-col gap-2 rounded-lg border border-input bg-card px-4 py-3 text-sm shadow-xs"
+      className="flex w-full flex-col gap-2 rounded-lg border border-border bg-card px-4 py-3 text-sm shadow-xs"
     >
       <div className="flex items-start gap-2">
         <Icon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />

--- a/src/renderer/src/components/native-chat/NativeChatAgentNoticeBanner.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatAgentNoticeBanner.tsx
@@ -1,0 +1,45 @@
+import { AlertTriangle, Info, TerminalSquare } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { translate } from '@/i18n/i18n'
+import type { NativeChatMessage } from '../../../../shared/native-chat-types'
+
+export type NativeChatAgentNoticeBannerProps = {
+  message: NativeChatMessage
+  text: string
+  onSwitchToTerminal?: () => void
+}
+
+/** Inline banner for a provider system notice. Matches the native-chat card
+ *  chrome (approval/question), not an assistant bubble. */
+export function NativeChatAgentNoticeBanner({
+  message,
+  text,
+  onSwitchToTerminal
+}: NativeChatAgentNoticeBannerProps): React.JSX.Element {
+  const level = message.noticeLevel ?? 'info'
+  const needsAttention = level === 'warning' || level === 'error'
+  const Icon = needsAttention ? AlertTriangle : Info
+
+  return (
+    <div
+      role={needsAttention ? 'alert' : 'status'}
+      className="flex w-full flex-col gap-2 rounded-lg border border-input bg-card px-4 py-3 text-sm shadow-xs"
+    >
+      <div className="flex items-start gap-2">
+        <Icon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+        <p className="min-w-0 break-words text-foreground">{text}</p>
+      </div>
+      {needsAttention && onSwitchToTerminal ? (
+        <div>
+          <Button type="button" variant="outline" size="sm" onClick={onSwitchToTerminal}>
+            <TerminalSquare />
+            {translate(
+              'components.tab.bar.SortableTabContextMenu.switchToTerminalView',
+              'Switch to terminal view'
+            )}
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/renderer/src/components/native-chat/NativeChatAgentNoticeBanner.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatAgentNoticeBanner.tsx
@@ -16,7 +16,7 @@ export function NativeChatAgentNoticeBanner({
   text,
   onSwitchToTerminal
 }: NativeChatAgentNoticeBannerProps): React.JSX.Element {
-  const level = message.noticeLevel ?? 'info'
+  const level = message.notice?.level ?? 'info'
   const needsAttention = level === 'warning' || level === 'error'
   const Icon = needsAttention ? AlertTriangle : Info
 

--- a/src/renderer/src/components/native-chat/NativeChatMessageList.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment happy-dom
+
+import '@testing-library/jest-dom/vitest'
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  NATIVE_CHAT_INTERRUPTED_STATUS_TEXT,
+  type NativeChatMessage
+} from '../../../../shared/native-chat-types'
+import type { NativeChatLiveSession } from './use-native-chat-live-session'
+import { NativeChatMessageList } from './NativeChatMessageList'
+
+afterEach(cleanup)
+
+function sessionWith(messages: NativeChatMessage[]): NativeChatLiveSession {
+  return {
+    messages,
+    status: 'ready',
+    sessionId: 'session-1',
+    agent: 'claude',
+    hasMore: false,
+    loadingEarlier: false,
+    loadEarlier: () => {},
+    readPhase: 'ready'
+  }
+}
+
+describe('NativeChatMessageList — agent notices', () => {
+  it('renders a warning system notice as an alert banner, not an assistant bubble', () => {
+    const onSwitchToTerminal = vi.fn()
+    render(
+      <NativeChatMessageList
+        session={sessionWith([
+          {
+            id: 'notice-1',
+            role: 'system',
+            blocks: [{ type: 'text', text: 'Please run /login in Claude Code.' }],
+            timestamp: null,
+            source: 'transcript',
+            noticeKind: 'agent-notice',
+            noticeLevel: 'warning'
+          }
+        ])}
+        isWorking={false}
+        expandSignal={false}
+        fontScale={1}
+        onSwitchToTerminal={onSwitchToTerminal}
+      />
+    )
+
+    const banner = screen.getByRole('alert')
+    expect(banner).toHaveTextContent('Please run /login in Claude Code.')
+    expect(screen.getByRole('button', { name: /Switch to terminal view/i })).toBeInTheDocument()
+    expect(screen.queryByLabelText('Copy message')).toBeNull()
+  })
+
+  it('keeps interrupt status as quiet system copy without a banner', () => {
+    render(
+      <NativeChatMessageList
+        session={sessionWith([
+          {
+            id: 'interrupt-1',
+            role: 'system',
+            blocks: [{ type: 'text', text: NATIVE_CHAT_INTERRUPTED_STATUS_TEXT }],
+            timestamp: null,
+            source: 'transcript'
+          }
+        ])}
+        isWorking={false}
+        expandSignal={false}
+        fontScale={1}
+        onSwitchToTerminal={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByRole('alert')).toBeNull()
+    expect(screen.getByText(NATIVE_CHAT_INTERRUPTED_STATUS_TEXT)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Switch to terminal view/i })).toBeNull()
+  })
+})

--- a/src/renderer/src/components/native-chat/NativeChatMessageList.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.test.tsx
@@ -38,8 +38,7 @@ describe('NativeChatMessageList — agent notices', () => {
             blocks: [{ type: 'text', text: 'Please run /login in Claude Code.' }],
             timestamp: null,
             source: 'transcript',
-            noticeKind: 'agent-notice',
-            noticeLevel: 'warning'
+            notice: { level: 'warning' }
           }
         ])}
         isWorking={false}

--- a/src/renderer/src/components/native-chat/NativeChatMessageList.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.test.tsx
@@ -77,4 +77,28 @@ describe('NativeChatMessageList — agent notices', () => {
     expect(screen.getByText(NATIVE_CHAT_INTERRUPTED_STATUS_TEXT)).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /Switch to terminal view/i })).toBeNull()
   })
+
+  it('renders a metadata-absent system row through the quiet fallback', () => {
+    render(
+      <NativeChatMessageList
+        session={sessionWith([
+          {
+            id: 'legacy-system-1',
+            role: 'system',
+            blocks: [{ type: 'text', text: 'Provider status from an older host.' }],
+            timestamp: null,
+            source: 'transcript'
+          }
+        ])}
+        isWorking={false}
+        expandSignal={false}
+        fontScale={1}
+        onSwitchToTerminal={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('Provider status from an older host.')).toBeInTheDocument()
+    expect(screen.queryByRole('alert')).toBeNull()
+    expect(screen.queryByRole('button', { name: /Switch to terminal view/i })).toBeNull()
+  })
 })

--- a/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
@@ -7,6 +7,7 @@ import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
 import { basename } from '@/lib/path'
 import {
+  isAgentNoticeMessage,
   isTextBlock,
   type NativeChatBlock,
   type NativeChatMessage
@@ -19,6 +20,7 @@ import { isNearBottom, shouldShowJumpToLatest, type ScrollGeometry } from './nat
 import { isNativeChatPastedImagePath } from './native-chat-image-paste'
 import { NativeChatToolRun } from './NativeChatToolRun'
 import { NativeChatCopyButton } from './NativeChatCopyButton'
+import { NativeChatAgentNoticeBanner } from './NativeChatAgentNoticeBanner'
 import { NATIVE_CHAT_STREAMING_ID } from '../../../../shared/native-chat-streaming'
 
 function geometryOf(el: HTMLElement): ScrollGeometry {
@@ -128,7 +130,8 @@ function MessageRow({
   onScrollMessageToTop,
   onLinkClick,
   allowFileUriLinks = false,
-  deliveryFailed = false
+  deliveryFailed = false,
+  onSwitchToTerminal
 }: {
   message: NativeChatMessage
   expandSignal: boolean
@@ -137,6 +140,7 @@ function MessageRow({
   onLinkClick?: CommentMarkdownLinkClickHandler
   allowFileUriLinks?: boolean
   deliveryFailed?: boolean
+  onSwitchToTerminal?: () => void
 }): React.JSX.Element | null {
   const rowRef = useRef<HTMLDivElement | null>(null)
   const { prose, tools } = useMemo(() => splitNativeChatBlocks(message.blocks), [message.blocks])
@@ -157,6 +161,19 @@ function MessageRow({
   // After all hooks, so hook order stays unconditional.
   if (markdown.length === 0 && !hasImages && tools.length === 0) {
     return null
+  }
+
+  // Before the quiet `isSystem` aside so a notice never collapses into chrome-free body copy.
+  if (isAgentNoticeMessage(message)) {
+    return (
+      <div ref={rowRef}>
+        <NativeChatAgentNoticeBanner
+          message={message}
+          text={markdown}
+          onSwitchToTerminal={onSwitchToTerminal}
+        />
+      </div>
+    )
   }
 
   if (isUser) {
@@ -240,7 +257,8 @@ export function NativeChatMessageList({
   fontScale,
   onLinkClick,
   allowFileUriLinks = false,
-  failedDeliveryMessageIds
+  failedDeliveryMessageIds,
+  onSwitchToTerminal
 }: {
   session: NativeChatLiveSession
   isWorking: boolean
@@ -251,6 +269,7 @@ export function NativeChatMessageList({
   onLinkClick?: CommentMarkdownLinkClickHandler
   allowFileUriLinks?: boolean
   failedDeliveryMessageIds?: ReadonlySet<string>
+  onSwitchToTerminal?: () => void
 }): React.JSX.Element {
   const scrollRef = useRef<HTMLDivElement | null>(null)
   const contentRef = useRef<HTMLDivElement | null>(null)
@@ -408,6 +427,7 @@ export function NativeChatMessageList({
               onLinkClick={onLinkClick}
               allowFileUriLinks={allowFileUriLinks}
               deliveryFailed={failedDeliveryMessageIds?.has(message.id) === true}
+              onSwitchToTerminal={onSwitchToTerminal}
             />
           ))}
           {showTypingIndicator ? <TypingIndicatorRow /> : null}

--- a/src/renderer/src/components/native-chat/NativeChatView.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatView.tsx
@@ -413,6 +413,7 @@ function NativeChatResolvedView({
             onLinkClick={nativeChatFileLinkClick}
             allowFileUriLinks={fileLinkContext !== null}
             failedDeliveryMessageIds={failedLaunchPromptMessageIds}
+            onSwitchToTerminal={onSwitchToTerminal}
           />
         )}
       </div>

--- a/src/shared/native-chat-types.test.ts
+++ b/src/shared/native-chat-types.test.ts
@@ -56,12 +56,11 @@ describe('agent notice vs interrupt status', () => {
     source: 'transcript' as const
   }
 
-  it('treats noticeKind agent-notice as a bannerable system notice', () => {
+  it('treats structured notice metadata as a bannerable system notice', () => {
     const message: NativeChatMessage = {
       ...base,
       role: 'system',
-      noticeKind: 'agent-notice',
-      noticeLevel: 'warning'
+      notice: { level: 'warning' }
     }
     expect(isAgentNoticeMessage(message)).toBe(true)
     expect(isInterruptedStatusMessage(message)).toBe(false)
@@ -74,6 +73,17 @@ describe('agent notice vs interrupt status', () => {
       blocks: [{ type: 'text', text: NATIVE_CHAT_INTERRUPTED_STATUS_TEXT }]
     }
     expect(isInterruptedStatusMessage(message)).toBe(true)
+    expect(isAgentNoticeMessage(message)).toBe(false)
+  })
+
+  it('rejects malformed rows that mix notice metadata with interrupt copy', () => {
+    const message: NativeChatMessage = {
+      ...base,
+      role: 'system',
+      blocks: [{ type: 'text', text: NATIVE_CHAT_INTERRUPTED_STATUS_TEXT }],
+      notice: { level: 'warning' }
+    }
+    expect(isInterruptedStatusMessage(message)).toBe(false)
     expect(isAgentNoticeMessage(message)).toBe(false)
   })
 })

--- a/src/shared/native-chat-types.test.ts
+++ b/src/shared/native-chat-types.test.ts
@@ -4,8 +4,12 @@ import {
   isToolCallBlock,
   isToolResultBlock,
   isImageRefBlock,
+  isAgentNoticeMessage,
+  isInterruptedStatusMessage,
+  NATIVE_CHAT_INTERRUPTED_STATUS_TEXT,
   NATIVE_CHAT_SOURCE_PRIORITY,
-  type NativeChatBlock
+  type NativeChatBlock,
+  type NativeChatMessage
 } from './native-chat-types'
 
 const textBlock: NativeChatBlock = { type: 'text', text: 'hello' }
@@ -41,5 +45,35 @@ describe('source priority', () => {
   it('ranks transcript > hook > scrape', () => {
     expect(NATIVE_CHAT_SOURCE_PRIORITY.transcript).toBeGreaterThan(NATIVE_CHAT_SOURCE_PRIORITY.hook)
     expect(NATIVE_CHAT_SOURCE_PRIORITY.hook).toBeGreaterThan(NATIVE_CHAT_SOURCE_PRIORITY.scrape)
+  })
+})
+
+describe('agent notice vs interrupt status', () => {
+  const base = {
+    id: 'row-1',
+    blocks: [{ type: 'text' as const, text: 'Please run /login' }],
+    timestamp: null,
+    source: 'transcript' as const
+  }
+
+  it('treats noticeKind agent-notice as a bannerable system notice', () => {
+    const message: NativeChatMessage = {
+      ...base,
+      role: 'system',
+      noticeKind: 'agent-notice',
+      noticeLevel: 'warning'
+    }
+    expect(isAgentNoticeMessage(message)).toBe(true)
+    expect(isInterruptedStatusMessage(message)).toBe(false)
+  })
+
+  it('does not treat interrupt status as an agent notice', () => {
+    const message: NativeChatMessage = {
+      ...base,
+      role: 'system',
+      blocks: [{ type: 'text', text: NATIVE_CHAT_INTERRUPTED_STATUS_TEXT }]
+    }
+    expect(isInterruptedStatusMessage(message)).toBe(true)
+    expect(isAgentNoticeMessage(message)).toBe(false)
   })
 })

--- a/src/shared/native-chat-types.test.ts
+++ b/src/shared/native-chat-types.test.ts
@@ -76,7 +76,7 @@ describe('agent notice vs interrupt status', () => {
     expect(isAgentNoticeMessage(message)).toBe(false)
   })
 
-  it('rejects malformed rows that mix notice metadata with interrupt copy', () => {
+  it('treats notice metadata as authoritative when copy matches interrupt status', () => {
     const message: NativeChatMessage = {
       ...base,
       role: 'system',
@@ -84,6 +84,6 @@ describe('agent notice vs interrupt status', () => {
       notice: { level: 'warning' }
     }
     expect(isInterruptedStatusMessage(message)).toBe(false)
-    expect(isAgentNoticeMessage(message)).toBe(false)
+    expect(isAgentNoticeMessage(message)).toBe(true)
   })
 })

--- a/src/shared/native-chat-types.ts
+++ b/src/shared/native-chat-types.ts
@@ -64,6 +64,12 @@ export type NativeChatBlock =
   | NativeChatToolResultBlock
   | NativeChatImageRefBlock
 
+export const NATIVE_CHAT_NOTICE_KINDS = ['agent-notice'] as const
+export type NativeChatNoticeKind = (typeof NATIVE_CHAT_NOTICE_KINDS)[number]
+
+export const NATIVE_CHAT_NOTICE_LEVELS = ['info', 'warning', 'error'] as const
+export type NativeChatNoticeLevel = (typeof NATIVE_CHAT_NOTICE_LEVELS)[number]
+
 export type NativeChatMessage = {
   /** Stable across re-reads/appends so the assembler and the renderer list can
    *  dedup and key by it. */
@@ -77,6 +83,11 @@ export type NativeChatMessage = {
   /** Optional explicit turn key. When present, two messages with the same
    *  `turnId` are treated as the same turn for dedup regardless of `id`. */
   turnId?: string
+  /** Present only for provider system notices the chat should render as a
+   *  banner. Quiet status rows (interruption) omit it. Optional so mixed-version
+   *  clients ignore the field. */
+  noticeKind?: NativeChatNoticeKind
+  noticeLevel?: NativeChatNoticeLevel
 }
 
 export const NATIVE_CHAT_TURN_LIFECYCLE_STATES = ['working', 'completed', 'interrupted'] as const
@@ -141,6 +152,12 @@ export function isInterruptedStatusMessage(message: NativeChatMessage): boolean 
       (block) => block.type === 'text' && block.text === NATIVE_CHAT_INTERRUPTED_STATUS_TEXT
     )
   )
+}
+
+/** Provider-authored system notice that Native Chat must render as a banner,
+ *  not as quiet status or an assistant bubble. */
+export function isAgentNoticeMessage(message: NativeChatMessage): boolean {
+  return message.role === 'system' && message.noticeKind === 'agent-notice'
 }
 
 export function isImageRefBlock(block: NativeChatBlock): block is NativeChatImageRefBlock {

--- a/src/shared/native-chat-types.ts
+++ b/src/shared/native-chat-types.ts
@@ -64,11 +64,12 @@ export type NativeChatBlock =
   | NativeChatToolResultBlock
   | NativeChatImageRefBlock
 
-export const NATIVE_CHAT_NOTICE_KINDS = ['agent-notice'] as const
-export type NativeChatNoticeKind = (typeof NATIVE_CHAT_NOTICE_KINDS)[number]
-
 export const NATIVE_CHAT_NOTICE_LEVELS = ['info', 'warning', 'error'] as const
 export type NativeChatNoticeLevel = (typeof NATIVE_CHAT_NOTICE_LEVELS)[number]
+
+export type NativeChatNotice = {
+  level: NativeChatNoticeLevel
+}
 
 export type NativeChatMessage = {
   /** Stable across re-reads/appends so the assembler and the renderer list can
@@ -86,8 +87,7 @@ export type NativeChatMessage = {
   /** Present only for provider system notices the chat should render as a
    *  banner. Quiet status rows (interruption) omit it. Optional so mixed-version
    *  clients ignore the field. */
-  noticeKind?: NativeChatNoticeKind
-  noticeLevel?: NativeChatNoticeLevel
+  notice?: NativeChatNotice
 }
 
 export const NATIVE_CHAT_TURN_LIFECYCLE_STATES = ['working', 'completed', 'interrupted'] as const
@@ -148,6 +148,7 @@ export function isToolResultBlock(block: NativeChatBlock): block is NativeChatTo
 export function isInterruptedStatusMessage(message: NativeChatMessage): boolean {
   return (
     message.role === 'system' &&
+    message.notice === undefined &&
     message.blocks.some(
       (block) => block.type === 'text' && block.text === NATIVE_CHAT_INTERRUPTED_STATUS_TEXT
     )
@@ -157,7 +158,13 @@ export function isInterruptedStatusMessage(message: NativeChatMessage): boolean 
 /** Provider-authored system notice that Native Chat must render as a banner,
  *  not as quiet status or an assistant bubble. */
 export function isAgentNoticeMessage(message: NativeChatMessage): boolean {
-  return message.role === 'system' && message.noticeKind === 'agent-notice'
+  return (
+    message.role === 'system' &&
+    message.notice !== undefined &&
+    !message.blocks.some(
+      (block) => block.type === 'text' && block.text === NATIVE_CHAT_INTERRUPTED_STATUS_TEXT
+    )
+  )
 }
 
 export function isImageRefBlock(block: NativeChatBlock): block is NativeChatImageRefBlock {

--- a/src/shared/native-chat-types.ts
+++ b/src/shared/native-chat-types.ts
@@ -158,13 +158,7 @@ export function isInterruptedStatusMessage(message: NativeChatMessage): boolean 
 /** Provider-authored system notice that Native Chat must render as a banner,
  *  not as quiet status or an assistant bubble. */
 export function isAgentNoticeMessage(message: NativeChatMessage): boolean {
-  return (
-    message.role === 'system' &&
-    message.notice !== undefined &&
-    !message.blocks.some(
-      (block) => block.type === 'text' && block.text === NATIVE_CHAT_INTERRUPTED_STATUS_TEXT
-    )
-  )
+  return message.role === 'system' && message.notice !== undefined
 }
 
 export function isImageRefBlock(block: NativeChatBlock): block is NativeChatImageRefBlock {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​448 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​446 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​178 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​173 |

<!-- /orca-pr-loc -->

## ELI5

When Claude Code needs you to do something — log in, enroll a trusted device, or look at an API error — it writes a system notice into its transcript. Terminal view already shows that. Native Chat was throwing those lines away, so your messages just sat there unanswered with no banner and no error. This PR makes Chat show the notice as a banner, with a way to switch back to the terminal when it actually needs you there.

## What Changed

- Claude's transcript decoder now surfaces `type:"system"` lines that carry user-facing copy, instead of dropping the whole `type:"system"` class.
- Known telemetry/recap/command envelopes stay silent (`stop_hook_summary`, `turn_duration`, `away_summary`, `local_command`, `hook_callback`, `init`).
- Unknown future subtypes with extractable copy are shown on purpose, so the next login-style notice cannot disappear the way `informational` did.
- Native Chat renders those rows as a banner (existing native-chat card chrome), not as an assistant bubble. Warning/error notices offer **Switch to terminal view**.
- Mobile Native Chat uses the same host decoder and now renders the same notices as a banner instead of agent prose.
- Optional `noticeKind` / `noticeLevel` fields on the existing message model (safe for mixed-version clients).

## Why

`decodeClaudeTranscriptLine` returned `null` for every `type !== 'user' && type !== 'assistant'` record (`src/main/native-chat/transcript-line-decoders-claude.ts`). Claude's login / Trusted Devices notice is `type:"system", subtype:"informational"`, so Chat never saw it.

A community PR (#14339) un-dropped only `subtype:"informational"` and added an Orca OAuth reauth button. That still silently drops unknown future subtypes (the original bug class), and the example notice asks the user to run `/login` **in Claude Code**, which is not Orca's managed-account OAuth.

This PR supersedes #14339. It carries forward the decoder-to-banner idea and credits Farid. It differs as follows:

1. Default is show-if-there-is-copy, not an allowlist of one subtype.
2. Subtype decisions are from real local transcripts (4172 JSONL files) plus the shapes in the ticket: drop telemetry/recaps/slash-command envelopes; show `informational`, `api_error`, `model_refusal_fallback`, `compact_boundary`, and unknown subtypes with copy.
3. Banner uses existing native-chat card tokens (`border-input` / `bg-card`), not a new amber palette.
4. The action is **Switch to terminal view** (already the pane toggle), because that is where `/login` actually runs. No new reauth IPC.
5. Mobile is covered because it consumes the same `NativeChatMessage` stream.

## Linked Issue

Fixes #15341
Fixes STA-4777

Supersedes #14339

## Visual Proof

The defect needs a Claude org Trusted-Devices / `/login` session to appear in a live pane, which this worktree did not have. Automated tests cover the decoder → UI-model path and the banner/list rendering (warning notice is an `alert` with the terminal action; interrupt status stays quiet copy).

Live Electron before/after of a real Claude login notice: not captured here.

## Testing

- [x] Automated tests added: Claude decoder (`transcript-line-decoders-claude.test.ts`), notice vs interrupt guards (`native-chat-types.test.ts`), desktop banner + message list, mobile message banner.
- HOUSE-RULES §4: decoder tests **fail on unfixed code** (informational / unknown subtype / api_error / model_refusal_fallback all returned `null`), **pass after the fix**, **fail again when the system-notice branch is neutered**.
- `pnpm typecheck` passed. Targeted vitest + oxlint on changed files passed. Mobile `MobileNativeChatMessage` tests passed (lockfile restored after the `mobile/` run).

## AI Disclosure

Internal contributor.

## Review

- **Security**: no new IPC, no credential/token handling. The notice text is already on disk in the Claude transcript; we only stop dropping it.
- **Cross-platform**: decoder is JSON parsing. Banner uses existing tokens and the existing `onSwitchToTerminal` pane action (`CmdOrCtrl` is unchanged).
- **Remote/SSH**: Chat reads the host-owned transcript. The CTA switches to that pane's terminal so `/login` runs on the execution host, not the local Orca account store.
- **Agent compatibility**: Claude only. Codex `event_msg` unknown types, Grok `type:"system"` prompts, and omp unrecognized rows are **not** this code path — called out as separate tickets, not silently half-covered.
- **Wire compatibility**: optional fields on the existing Native Chat message object. No new stream opcode. Older mobile clients ignore `noticeKind` and still receive a `role:"system"` row they already know how to render.
- **Performance**: the new branch runs only for `type:"system"` lines.
- **UI**: banner matches `NativeChatApprovalCard` chrome (border/card/shadow-xs), not an assistant bubble.

## Author

- X / Twitter: @BrennanKB5