### PR TITLE
fix(native-chat): preserve consent-gated Claude models (STA-4834)

### DIFF
--- a/src/renderer/src/components/native-chat/native-chat-pty-retired-model.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pty-retired-model.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { mergeDiscoveredAuthoritativeModels } from '../../../../shared/agent-session-option-catalog'
+import {
+  mergeDiscoveredAuthoritativeModels,
+  type CatalogModel
+} from '../../../../shared/agent-session-option-catalog'
+import { CLAUDE_SESSION_OPTION_CATALOG } from '../../../../shared/agent-session-option-catalog-claude-codex'
 import { GROK_SESSION_OPTION_CATALOG } from '../../../../shared/agent-session-option-catalog-grok'
 import { updateNativeChatSessionOptionDefaults } from '../../../../shared/native-chat-session-option-defaults'
 import type { PersistedNativeChatSessionOptions } from '../../../../shared/native-chat-session-options'
@@ -92,5 +96,62 @@ describe('retired grok model untracking', () => {
     // A typed id the list does carry still persists as before.
     surface.recordOutgoingCommand('/model grok-5')
     expect(persisted().grok?.model).toBe('grok-5')
+  })
+})
+
+describe('retired Claude model untracking', () => {
+  beforeEach(() => clearNativeChatSessionOptionCacheForTests())
+
+  const discoveredClaude = (): CatalogModel[] => [
+    {
+      ...CLAUDE_SESSION_OPTION_CATALOG.models.find((model) => model.id === 'fable')!,
+      isDefault: true,
+      options: CLAUDE_SESSION_OPTION_CATALOG.models.find((model) => model.id === 'fable')!.options
+    },
+    { id: 'sonnet', label: 'Sonnet', options: [] }
+  ]
+
+  function createClaudeSurface(args?: Partial<CreateNativeChatPtySessionOptionsArgs>): {
+    surface: NativeChatPtySessionOptionsSurface
+    persisted: () => PersistedNativeChatSessionOptions
+  } {
+    let persisted: PersistedNativeChatSessionOptions = {}
+    const surface = createNativeChatPtySessionOptions({
+      agent: 'claude',
+      scopeKey: 'claude-pty-1',
+      mode: 'live',
+      dispatchCommand: vi.fn(),
+      persistSelection: ({ modelId, optionId, value, adoptModelAsLaunchDefault }) => {
+        persisted = updateNativeChatSessionOptionDefaults({
+          persisted,
+          agent: 'claude',
+          modelId,
+          optionId,
+          value,
+          adoptModelAsLaunchDefault
+        })
+      },
+      ...args
+    })!
+    return { surface, persisted: () => persisted }
+  }
+
+  it('untracks an omitted Claude alias', () => {
+    seedNativeChatAppliedSessionOptions('claude-pty-1', 'claude', { model: 'opus' })
+    const { surface, persisted } = createClaudeSurface()
+
+    surface.replaceModels(discoveredClaude())
+
+    expect(readNativeChatSessionOptionCache('claude-pty-1')?.model).toBeUndefined()
+    expect(persisted().claude).toBeUndefined()
+  })
+
+  it('does not adopt an omitted typed Claude alias as launch default', () => {
+    const { surface, persisted } = createClaudeSurface({ initialModels: discoveredClaude() })
+
+    surface.recordOutgoingCommand('/model opus')
+    expect(persisted().claude?.model).toBeUndefined()
+    surface.recordOutgoingCommand('/model fable')
+    expect(persisted().claude?.model).toBe('fable')
   })
 })

--- a/src/renderer/src/components/native-chat/native-chat-pty-session-options.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pty-session-options.test.ts
@@ -631,12 +631,11 @@ describe('native chat PTY session options', () => {
     })
   })
 
-  it('keeps a tracked alias selectable when the host catalog omits it', async () => {
+  it('drops a tracked Claude alias when the host catalog omits it', () => {
     seedNativeChatAppliedSessionOptions('pty-1', 'claude', {
       model: 'opus',
       effort: 'xhigh'
     })
-    const dispatch = vi.fn()
     const surface = createNativeChatPtySessionOptions({
       agent: 'claude',
       scopeKey: 'pty-1',
@@ -646,23 +645,13 @@ describe('native chat PTY session options', () => {
         { id: 'sonnet', label: 'Sonnet', options: [] }
       ],
       mode: 'live',
-      dispatchCommand: dispatch
+      dispatchCommand: vi.fn()
     })!
 
     expect(surface.getSnapshot()[0].kind).toMatchObject({
-      currentValue: 'opus',
-      choices: expect.arrayContaining([
-        { value: 'opus', label: 'Opus', description: expect.any(String) }
-      ])
+      choices: expect.not.arrayContaining([{ value: 'opus' }])
     })
-    expect(surface.getSnapshot().find(({ id }) => id === 'effort')).toMatchObject({
-      settable: true,
-      kind: { currentValue: 'xhigh' }
-    })
-
-    await surface.setOption('effort', 'high')
-
-    expect(dispatch).toHaveBeenCalledWith('/effort high')
+    expect(readNativeChatSessionOptionCache('pty-1')?.model).toBeUndefined()
   })
 
   it('drops the reconciled row once the tracked model moves onto the host catalog', async () => {

--- a/src/renderer/src/components/native-chat/native-chat-pty-session-options.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pty-session-options.ts
@@ -1,4 +1,5 @@
 import {
+  discoveredModelsDefineCatalogMembership,
   getAgentSessionOptionCatalog,
   type CatalogModel
 } from '../../../../shared/agent-session-option-catalog'
@@ -80,7 +81,7 @@ export function createNativeChatPtySessionOptions(
    *  the picker via re-injection and re-persist the fatal `-m` on any later option
    *  write, undoing the settings retirement. */
   const untrackRetiredModel = (): boolean => {
-    if (!catalog.discoveredModelsAreAuthoritative || !modelsAreDiscovered) {
+    if (!discoveredModelsDefineCatalogMembership(catalog) || !modelsAreDiscovered) {
       return false
     }
     const trackedId = typeof record.model?.value === 'string' ? record.model.value : null
@@ -143,7 +144,8 @@ export function createNativeChatPtySessionOptions(
    *  adopting either would emit an `-m` that is fatal on an account without it. */
   const modelIsAdoptableAsLaunchDefault = (modelId: string): boolean =>
     modelsAreDiscovered
-      ? !catalog.discoveredModelsAreAuthoritative || models.some((model) => model.id === modelId)
+      ? !discoveredModelsDefineCatalogMembership(catalog) ||
+        models.some((model) => model.id === modelId)
       : record.model !== undefined
 
   /** Every persist path — picker applies and typed commands — funnels through here. */

--- a/src/renderer/src/components/native-chat/native-chat-retire-persisted-model.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-retire-persisted-model.test.ts
@@ -60,6 +60,16 @@ describe('retirePersistedModelMissingFromDiscovery', () => {
     })
   })
 
+  it('clears a persisted Claude alias omitted by a replacing probe', async () => {
+    persist({ claude: { model: 'opus', valuesByModel: { opus: { effort: 'high' } } } })
+    await retirePersistedModelMissingFromDiscovery('claude', models('fable', 'sonnet'))
+    expect(mocks.storeState.updateSettings).toHaveBeenCalledWith({
+      nativeChatSessionOptions: {
+        claude: { valuesByModel: { opus: { effort: 'high' } } }
+      }
+    })
+  })
+
   it('keeps a persisted id the probe still lists', async () => {
     persist({ grok: { model: 'grok-4.5' } })
     await retirePersistedModelMissingFromDiscovery('grok', models('grok-4.5', 'grok-build'))

--- a/src/renderer/src/components/native-chat/native-chat-session-option-discovery.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-discovery.ts
@@ -78,9 +78,8 @@ export async function discoverNativeChatCatalogModels(
   if (
     !result.success ||
     result.models.length === 0 ||
-    // Why: a spec's static fallback list must never pass as a probe result for an
-    // agent whose published list replaces rather than extends the seed.
-    ((agent === 'claude' || catalog?.discoveredModelsAreAuthoritative) &&
+    // Why: static fallbacks must never impersonate a probe whose rows replace the seed.
+    ((catalog?.discoveredModelsReplaceSeed || catalog?.discoveredModelsAreAuthoritative) &&
       result.catalogOrigin !== 'probe')
   ) {
     return null

--- a/src/renderer/src/components/native-chat/native-chat-session-option-discovery.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-discovery.ts
@@ -1,6 +1,7 @@
 import type { AgentType } from '../../../../shared/agent-status-types'
 import {
   createClaudeCatalogOptions,
+  discoveredModelsDefineCatalogMembership,
   getAgentSessionOptionCatalog,
   type CatalogModel
 } from '../../../../shared/agent-session-option-catalog'
@@ -79,7 +80,8 @@ export async function discoverNativeChatCatalogModels(
     !result.success ||
     result.models.length === 0 ||
     // Why: static fallbacks must never impersonate a probe whose rows replace the seed.
-    ((catalog?.discoveredModelsReplaceSeed || catalog?.discoveredModelsAreAuthoritative) &&
+    (catalog &&
+      discoveredModelsDefineCatalogMembership(catalog) &&
       result.catalogOrigin !== 'probe')
   ) {
     return null

--- a/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.test.ts
@@ -98,7 +98,7 @@ describe('native chat session option enrichment', () => {
     )
   })
 
-  it('uses only discovered Claude rows and capabilities per host', async () => {
+  it('keeps consent-gated Fable while dropping seed aliases the host never listed', async () => {
     mocks.discoverRuntimeCommitMessageModels.mockResolvedValue({
       success: true,
       catalogOrigin: 'probe',
@@ -135,7 +135,11 @@ describe('native chat session option enrichment', () => {
     await vi.waitFor(() => expect(listener).toHaveBeenCalledOnce())
 
     const models = readNativeChatEnrichedModels('claude', 'ssh:host')!
-    expect(models.map(({ id }) => id)).toEqual(['opus[1m]', 'sonnet'])
+    // Why: list_models hides Fable until one-time consent, so its absence is not
+    // evidence the host lacks it; every other omitted seed alias stays absent.
+    expect(models.map(({ id }) => id)).toEqual(['fable', 'opus[1m]', 'sonnet'])
+    expect(models.some(({ id }) => id === 'opus')).toBe(false)
+    expect(models.some(({ id }) => id === 'haiku')).toBe(false)
     const sonnetEffort = models.find(({ id }) => id === 'sonnet')?.options[0]
     expect(sonnetEffort?.kind).toMatchObject({
       type: 'select',
@@ -158,6 +162,50 @@ describe('native chat session option enrichment', () => {
       ]
     })
     expect(readNativeChatEnrichedModels('claude', 'local')).toBeNull()
+  })
+
+  it('keeps a single Fable row with the probe’s option menu when the CLI lists it', async () => {
+    mocks.discoverRuntimeCommitMessageModels.mockResolvedValue({
+      success: true,
+      catalogOrigin: 'probe',
+      models: [
+        {
+          id: 'fable',
+          label: 'Fable',
+          thinkingLevels: [
+            { id: 'high', label: 'High' },
+            { id: 'max', label: 'Max' }
+          ],
+          defaultThinkingLevel: 'high',
+          supportsFastMode: true
+        },
+        {
+          id: 'sonnet',
+          label: 'Sonnet',
+          thinkingLevels: [{ id: 'medium', label: 'Medium' }]
+        }
+      ]
+    })
+    const discover = vi.fn(() =>
+      discoverNativeChatCatalogModels('claude', {
+        settings: {},
+        worktreeId: 'repo::/worktree',
+        worktreePath: '/worktree'
+      })
+    )
+    ensureNativeChatModelEnrichment({ agent: 'claude', hostKey: 'local', discover })
+    await vi.waitFor(() => expect(readNativeChatEnrichedModels('claude', 'local')).not.toBeNull())
+
+    const models = readNativeChatEnrichedModels('claude', 'local')!
+    const fables = models.filter((model) => model.id === 'fable')
+    expect(fables).toHaveLength(1)
+    expect(models.map(({ id }) => id)).toEqual(['fable', 'sonnet'])
+    expect(fables[0].options.map(({ id }) => id)).toEqual(['effort', 'fastMode'])
+    const effort = fables[0].options[0]
+    expect(effort.kind.type === 'select' ? effort.kind.choices.map((c) => c.value) : []).toEqual([
+      'high',
+      'max'
+    ])
   })
 
   it('carries grok’s probed default through discovery to the published rows', async () => {
@@ -222,7 +270,7 @@ describe('native chat session option enrichment', () => {
     expect(published[0]!.isDefault).toBeUndefined()
   })
 
-  it('rejects a spec fallback for grok too, not just claude', async () => {
+  it('rejects a spec fallback for grok, whose probe replaces the seed', async () => {
     // Grok's list replaces the seed rather than extending it, so letting a static
     // fallback through would retire real models and blank the picker.
     mocks.discoverRuntimeCommitMessageModels.mockResolvedValue({
@@ -258,18 +306,25 @@ describe('native chat session option enrichment', () => {
     ).resolves.toEqual([{ id: 'auto', label: 'Auto', options: [] }])
   })
 
-  it('uses the authoritative merge for grok and the additive one for cursor', async () => {
-    // Both branches of the same ternary: deleting the authoritative arm typechecks
-    // and leaves every additive-agent test passing.
+  it('uses the replacing, authoritative, and additive policies independently', async () => {
+    const discoverClaude = vi
+      .fn()
+      .mockResolvedValue([{ id: 'sonnet', label: 'Sonnet', options: [] }])
     const discoverGrok = vi.fn().mockResolvedValue([{ id: 'grok-5', label: 'Grok 5', options: [] }])
     const discoverCursor = vi.fn().mockResolvedValue([{ id: 'extra', label: 'Extra', options: [] }])
+    ensureNativeChatModelEnrichment({ agent: 'claude', hostKey: 'm', discover: discoverClaude })
     ensureNativeChatModelEnrichment({ agent: 'grok', hostKey: 'm', discover: discoverGrok })
     ensureNativeChatModelEnrichment({ agent: 'cursor', hostKey: 'm', discover: discoverCursor })
     await vi.waitFor(() => {
+      expect(readNativeChatEnrichedModels('claude', 'm')).not.toBeNull()
       expect(readNativeChatEnrichedModels('grok', 'm')).not.toBeNull()
       expect(readNativeChatEnrichedModels('cursor', 'm')).not.toBeNull()
     })
 
+    expect(readNativeChatEnrichedModels('claude', 'm')!.map(({ id }) => id)).toEqual([
+      'fable',
+      'sonnet'
+    ])
     expect(readNativeChatEnrichedModels('grok', 'm')!.map(({ id }) => id)).toEqual(['grok-5'])
     expect(readNativeChatEnrichedModels('cursor', 'm')!.map(({ id }) => id)).toContain('auto')
   })
@@ -302,7 +357,7 @@ describe('native chat session option enrichment', () => {
     ).toEqual({ model: 'retired' })
   })
 
-  it('does not advertise the Claude spec fallback when probing is unavailable', async () => {
+  it('rejects a spec fallback for Claude, whose successful probe replaces the seed', async () => {
     mocks.discoverRuntimeCommitMessageModels.mockResolvedValue({
       success: true,
       catalogOrigin: 'spec',

--- a/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.test.ts
@@ -357,6 +357,22 @@ describe('native chat session option enrichment', () => {
     ).toEqual({ model: 'retired' })
   })
 
+  it('drops a persisted Claude alias missing from a replacing probe but keeps Fable', async () => {
+    const persisted = {
+      claude: { model: 'opus', valuesByModel: { opus: { effort: 'high' } } }
+    }
+    const discover = vi.fn().mockResolvedValue([{ id: 'sonnet', label: 'Sonnet', options: [] }])
+    ensureNativeChatModelEnrichment({ agent: 'claude', hostKey: 'local', discover })
+    await vi.waitFor(() => expect(readNativeChatEnrichedModels('claude', 'local')).not.toBeNull())
+
+    expect(resolveNativeChatLaunchSessionOptions(persisted, 'claude')).toBeUndefined()
+    expect(resolveNativeChatLaunchSessionOptions({ claude: { model: 'fable' } }, 'claude')).toEqual(
+      {
+        model: 'fable'
+      }
+    )
+  })
+
   it('rejects a spec fallback for Claude, whose successful probe replaces the seed', async () => {
     mocks.discoverRuntimeCommitMessageModels.mockResolvedValue({
       success: true,

--- a/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.ts
@@ -2,6 +2,7 @@ import type { AgentType } from '../../../../shared/agent-status-types'
 import {
   getAgentSessionOptionCatalog,
   mergeCatalogModels,
+  mergeDiscoveredModelsWithConsentGatedSeeds,
   mergeDiscoveredAuthoritativeModels,
   type CatalogModel
 } from '../../../../shared/agent-session-option-catalog'
@@ -101,12 +102,11 @@ export function ensureNativeChatModelEnrichment(args: {
       if (!discovered || discovered.length === 0) {
         return
       }
-      entry.models =
-        args.agent === 'claude'
-          ? [...discovered]
-          : catalog.discoveredModelsAreAuthoritative
-            ? mergeDiscoveredAuthoritativeModels(catalog.models, discovered)
-            : mergeCatalogModels(catalog.models, discovered)
+      entry.models = catalog.discoveredModelsReplaceSeed
+        ? mergeDiscoveredModelsWithConsentGatedSeeds(catalog, discovered)
+        : catalog.discoveredModelsAreAuthoritative
+          ? mergeDiscoveredAuthoritativeModels(catalog.models, discovered)
+          : mergeCatalogModels(catalog.models, discovered)
       for (const listener of entry.listeners) {
         listener([...entry.models])
       }

--- a/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.ts
@@ -1,5 +1,6 @@
 import type { AgentType } from '../../../../shared/agent-status-types'
 import {
+  discoveredModelsDefineCatalogMembership,
   getAgentSessionOptionCatalog,
   mergeCatalogModels,
   mergeDiscoveredModelsWithConsentGatedSeeds,
@@ -55,7 +56,8 @@ export function resolveNativeChatLaunchSessionOptions(
   agent: AgentType
 ): Record<string, SessionOptionValue> | undefined {
   const values = resolveNativeChatSessionOptionDefaults(persisted, agent)
-  if (!values || !getAgentSessionOptionCatalog(agent)?.discoveredModelsAreAuthoritative) {
+  const catalog = getAgentSessionOptionCatalog(agent)
+  if (!values || !catalog || !discoveredModelsDefineCatalogMembership(catalog)) {
     return values
   }
   let probed = false

--- a/src/renderer/src/components/native-chat/use-native-chat-session-options.test.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-session-options.test.ts
@@ -82,8 +82,9 @@ describe('useNativeChatSessionOptions model reporting', () => {
     await waitFor(() =>
       expect(modelDescriptor(result.current.snapshot).currentValue).toBe('opus[1m]')
     )
-    // The invented family row is gone: every choice is one the host listed.
+    // Invented family rows stay absent; only consent-gated Fable is restored.
     expect(modelDescriptor(result.current.snapshot).choices.map((choice) => choice.value)).toEqual([
+      'fable',
       'opus[1m]',
       'haiku'
     ])
@@ -130,7 +131,7 @@ describe('useNativeChatSessionOptions model reporting', () => {
     await waitFor(() =>
       expect(
         modelDescriptor(result.current.snapshot).choices.map((choice) => choice.value)
-      ).toEqual(['opus[1m]', 'haiku'])
+      ).toEqual(['fable', 'opus[1m]', 'haiku'])
     )
     expect(modelDescriptor(result.current.snapshot).currentValue).toBeUndefined()
   })
@@ -171,7 +172,7 @@ describe('useNativeChatSessionOptions model reporting', () => {
     await waitFor(() =>
       expect(
         modelDescriptor(result.current.snapshot).choices.map((choice) => choice.value)
-      ).toEqual(['opus[1m]', 'haiku'])
+      ).toEqual(['fable', 'opus[1m]', 'haiku'])
     )
     expect(modelDescriptor(result.current.snapshot).currentValue).toBeUndefined()
   })

--- a/src/renderer/src/components/native-chat/use-native-chat-session-options.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-session-options.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useSyncExternalStore } from 'react'
 import type { AgentType } from '../../../../shared/agent-status-types'
 import {
+  discoveredModelsDefineCatalogMembership,
   getAgentSessionOptionCatalog,
   type CatalogModel
 } from '../../../../shared/agent-session-option-catalog'
@@ -68,7 +69,8 @@ export async function retirePersistedModelMissingFromDiscovery(
   agent: AgentType,
   models: readonly CatalogModel[]
 ): Promise<void> {
-  if (!getAgentSessionOptionCatalog(agent)?.discoveredModelsAreAuthoritative) {
+  const catalog = getAgentSessionOptionCatalog(agent)
+  if (!catalog || !discoveredModelsDefineCatalogMembership(catalog)) {
     return
   }
   // An empty list means the probe failed, not that the account has no models.

--- a/src/shared/agent-session-option-catalog-claude-codex.ts
+++ b/src/shared/agent-session-option-catalog-claude-codex.ts
@@ -174,6 +174,9 @@ export const CLAUDE_SESSION_OPTION_CATALOG: AgentSessionOptionCatalog = {
     }
   },
   unknownModelOptions: [claudeEffort(true)],
+  discoveredModelsReplaceSeed: true,
+  // Why: list_models omits Fable until interactive /model collects one-time consent.
+  consentGatedModelIds: ['fable'],
   listModels: {
     command: `echo '${CLAUDE_MODEL_LIST_STDIN.trim()}' | claude ${CLAUDE_MODEL_LIST_ARGS.join(' ')}`,
     parse: parseClaudeCatalogModels

--- a/src/shared/agent-session-option-catalog-types.ts
+++ b/src/shared/agent-session-option-catalog-types.ts
@@ -65,6 +65,11 @@ export type AgentSessionOptionCatalog = {
    * must be able to drop it rather than only add. Membership only — option menus
    * still come from the seed. */
   discoveredModelsAreAuthoritative?: true
+  /** Why: a successful probe decides membership and carries per-model option menus,
+   * so its rows replace the seed except for documented consent-gated omissions. */
+  discoveredModelsReplaceSeed?: true
+  /** Seed ids a replacing probe may hide until one-time interactive consent. */
+  consentGatedModelIds?: readonly string[]
   /** Set only when the `isDefault` model is provably what the CLI runs with no model
    * flag, so an untouched draft may show it as selected. Off means `isDefault` stays
    * decorative: agents whose default comes from account or user config would otherwise

--- a/src/shared/agent-session-option-catalog.test.ts
+++ b/src/shared/agent-session-option-catalog.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { getAgentSessionOptionCatalog, mergeCatalogModels } from './agent-session-option-catalog'
+import {
+  getAgentSessionOptionCatalog,
+  mergeCatalogModels,
+  mergeDiscoveredModelsWithConsentGatedSeeds
+} from './agent-session-option-catalog'
 import { resolveAgentSessionOptionLaunch } from './agent-session-option-launch'
 import {
   resolveNativeChatSessionOptionDefaults,
@@ -119,6 +123,28 @@ describe('agent session option catalog', () => {
     expect(sonnet.description).toBe('Sonnet 5 · Efficient')
     expect(sonnet.isDefault).toBe(true)
     expect(sonnet.options.map(({ id }) => id)).toEqual(['effort'])
+  })
+
+  it('restores only consent-gated Claude rows omitted by a replacing probe', () => {
+    const catalog = getAgentSessionOptionCatalog('claude')!
+    expect(catalog.discoveredModelsReplaceSeed).toBe(true)
+    const merged = mergeDiscoveredModelsWithConsentGatedSeeds(catalog, [
+      { id: 'opus[1m]', label: 'Opus (1M context)', options: [] },
+      { id: 'sonnet', label: 'Sonnet', options: [] },
+      { id: 'haiku', label: 'Haiku', options: [] }
+    ])
+    expect(merged.map(({ id }) => id)).toEqual(['fable', 'opus[1m]', 'sonnet', 'haiku'])
+    expect(merged.some(({ id }) => id === 'opus')).toBe(false)
+    expect(merged[0].options.map(({ id }) => id)).toEqual(['effort'])
+  })
+
+  it('keeps a probed Fable row unique and unchanged', () => {
+    const catalog = getAgentSessionOptionCatalog('claude')!
+    const discovered = [
+      { id: 'sonnet', label: 'Sonnet', options: [] },
+      { id: 'fable', label: 'Fable (live)', options: [] }
+    ]
+    expect(mergeDiscoveredModelsWithConsentGatedSeeds(catalog, discovered)).toEqual(discovered)
   })
 
   it('parses Cursor model discovery without treating headings as models', () => {

--- a/src/shared/agent-session-option-catalog.test.ts
+++ b/src/shared/agent-session-option-catalog.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  discoveredModelsDefineCatalogMembership,
   getAgentSessionOptionCatalog,
   mergeCatalogModels,
   mergeDiscoveredModelsWithConsentGatedSeeds
@@ -11,6 +12,18 @@ import {
 } from './native-chat-session-option-defaults'
 
 describe('agent session option catalog', () => {
+  it('shares membership policy across replacing and authoritative catalogs', () => {
+    expect(discoveredModelsDefineCatalogMembership(getAgentSessionOptionCatalog('claude')!)).toBe(
+      true
+    )
+    expect(discoveredModelsDefineCatalogMembership(getAgentSessionOptionCatalog('grok')!)).toBe(
+      true
+    )
+    expect(discoveredModelsDefineCatalogMembership(getAgentSessionOptionCatalog('cursor')!)).toBe(
+      false
+    )
+  })
+
   it('returns no catalog for unknown agents', () => {
     expect(getAgentSessionOptionCatalog('future-agent')).toBeNull()
   })

--- a/src/shared/agent-session-option-catalog.ts
+++ b/src/shared/agent-session-option-catalog.ts
@@ -40,6 +40,16 @@ export function getAgentSessionOptionCatalog(agent: AgentType): AgentSessionOpti
   return CATALOGS[agent] ?? null
 }
 
+/** Whether a successful discovery result defines the catalog's model membership. */
+export function discoveredModelsDefineCatalogMembership(
+  catalog: AgentSessionOptionCatalog
+): boolean {
+  return (
+    catalog.discoveredModelsReplaceSeed === true ||
+    catalog.discoveredModelsAreAuthoritative === true
+  )
+}
+
 export function findCatalogModel(
   catalog: AgentSessionOptionCatalog,
   modelId: string

--- a/src/shared/agent-session-option-catalog.ts
+++ b/src/shared/agent-session-option-catalog.ts
@@ -71,6 +71,19 @@ export function mergeCatalogModels(
   return [...merged, ...discoveredById.values()]
 }
 
+/** Keep only consent-gated seed rows a replacing probe legitimately omitted. */
+export function mergeDiscoveredModelsWithConsentGatedSeeds(
+  catalog: AgentSessionOptionCatalog,
+  discovered: readonly CatalogModel[]
+): CatalogModel[] {
+  const consentGatedIds = catalog.consentGatedModelIds ?? []
+  const discoveredIds = new Set(discovered.map((model) => model.id))
+  const missingConsentGatedModels = catalog.models.filter(
+    (model) => consentGatedIds.includes(model.id) && !discoveredIds.has(model.id)
+  )
+  return [...missingConsentGatedModels, ...discovered]
+}
+
 /** Discovery decides membership; the seed keeps its option menus, which discovery never carries.
  *  Why: an unseeded model inherits the default seed's options because these catalogs' options are
  *  global CLI flags, not per-model capabilities — dropping them would hide the picker entirely. */


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​198 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​27 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​171 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​51 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​38 |

<!-- /orca-pr-loc -->

## ELI5

Claude's live model list is normally the source of truth, but it deliberately hides Fable until the user accepts a one-time consent prompt. Orca now keeps trusting that live list while restoring only the known consent-gated Fable row, so users can select it and reach the consent flow without reviving other aliases the host did not advertise.

## What Changed

1. Added an explicit catalog policy for probes whose rows replace the seed and carry live per-model capabilities.
2. Added a separate consent-gated exception list for Claude. Missing Fable is restored ahead of the live rows; if the probe already returns Fable, that live row remains unique and keeps its effort/fast-mode menu.
3. Kept other host-omitted Claude aliases absent, preserved Grok's authoritative-with-seed-options behavior, and preserved Cursor's additive behavior.
4. Kept static commit-message fallback results out of Claude native-chat enrichment. The commit-message fallback itself remains unchanged: it is used only when discovery returns zero models and runs through non-interactive `claude -p`, which cannot collect the consent.

## Why

The reported failure is narrower than a general seed/probe merge problem. A successful probe omitting `opus`, `sonnet`, or `haiku` is evidence about that host; omitting Fable before consent is not. Encoding those as separate catalog policies fixes the deadlock without undoing host-specific membership or capability discovery.

## Linked Issue

Fixes #15433
STA-4834

Supersedes #15434 with a narrower exception that preserves the successful-probe contract introduced for per-host Claude catalogs.

## Visual Proof

N/A — there is no layout or styling change, and the pre-consent omit-Fable state is a host probe result injected directly by the acceptance tests.

## Testing

- [x] Focused affected suites: 5 files, 85 tests passed.
- [x] Non-vacuity: changing only `consentGatedModelIds` from `['fable']` to `[]` produced 5 expected failures; the received lists were identical except for missing `fable`. Restoring the exception returned the acceptance suites to 16/16 passing.
- [x] `pnpm typecheck`
- [x] `node config/scripts/check-changed-code-quality.mjs` — 0 new findings.
- [x] `node config/scripts/check-react-doctor-changed.mjs` completed; the changed-code gate reported 0 new React Doctor findings.
- [x] `pnpm exec oxfmt --check` on all changed TypeScript files.
- Platforms: discovery and enrichment remain keyed by execution host, covering local, WSL, and SSH without path or shortcut changes.

## Review

Author: @BrennanKB5

## Agent skill upstream boundary

- [x] Not applicable.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] Affected tests and required static gates pass
