### PR TITLE
fix(sidebar): keep launched agent rows after conversation titles

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -304,6 +304,117 @@ describe('buildTitleDerivedAgentRows', () => {
     expect(rows.map((row) => [row.agentType, row.state])).toEqual([['cursor', 'working']])
   })
 
+  // STA-4774: cursor-agent replaces the native identity title with an arbitrary
+  // conversation name. Launch provenance, not a title token, has to keep the row.
+  it('keeps a launched Cursor pane visible under an arbitrary session title', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { launchAgent: 'cursor', launchAgentLeafId: LEAF_ID_1 })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: { 'tab-1': { 1: 'Rename the auth helper' } },
+      ptyIdsByTabId: { 'tab-1': ['pty-cursor'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+
+    expect(rows.map((row) => [row.agentType, row.state, row.entry.prompt])).toEqual([
+      ['cursor', 'idle', 'Cursor']
+    ])
+    expect(rows[0]?.entry.terminalTitle).toBe('Rename the auth helper')
+  })
+
+  it('keeps a launched Codex pane visible under an arbitrary session title', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { launchAgent: 'codex', launchAgentLeafId: LEAF_ID_1 })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: { 'tab-1': { 1: 'Rename the auth helper' } },
+      ptyIdsByTabId: { 'tab-1': ['pty-codex'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+
+    expect(rows.map((row) => [row.agentType, row.state, row.entry.prompt])).toEqual([
+      ['codex', 'idle', 'Codex']
+    ])
+  })
+
+  it('does not keep a launched Cursor pane after the title returns to the shell', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { launchAgent: 'cursor', launchAgentLeafId: LEAF_ID_1 })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: { 'tab-1': { 1: 'zsh' } },
+      ptyIdsByTabId: { 'tab-1': ['pty-cursor'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+
+    expect(rows).toHaveLength(0)
+  })
+
+  it('does not keep a launched Cursor pane after the title returns to the default Terminal title', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [
+        makeTab('tab-1', {
+          launchAgent: 'cursor',
+          launchAgentLeafId: LEAF_ID_1,
+          defaultTitle: 'Terminal 1'
+        })
+      ],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: { 'tab-1': { 1: 'Terminal 1' } },
+      ptyIdsByTabId: { 'tab-1': ['pty-cursor'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+
+    expect(rows).toHaveLength(0)
+  })
+
+  it('keeps a launched Cursor pane on a sole leaf even before launchAgentLeafId is stamped', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { launchAgent: 'cursor' })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: { 'tab-1': { 1: 'Rename the auth helper' } },
+      ptyIdsByTabId: { 'tab-1': ['pty-cursor'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+
+    expect(rows.map((row) => [row.agentType, row.state])).toEqual([['cursor', 'idle']])
+  })
+
+  it('does not invent a Cursor row from an arbitrary title without launch identity', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1')],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: { 'tab-1': { 1: 'Rename the auth helper' } },
+      ptyIdsByTabId: { 'tab-1': ['pty-anon'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+
+    expect(rows).toHaveLength(0)
+  })
+
+  it('does not recycle launch identity onto a remaining leaf after the original pane closes', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { launchAgent: 'cursor', launchAgentLeafId: LEAF_ID_1 })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: { 'tab-1': { 1: 'Rename the auth helper' } },
+      ptyIdsByTabId: { 'tab-1': ['pty-remaining'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_2) },
+      now: 2000
+    })
+
+    expect(rows).toHaveLength(0)
+  })
+
   // #8940: an OpenCode pane's own task text must not hand the row to Claude Code.
   it('keeps an OpenCode-launched pane OpenCode across its own status frames', () => {
     const frames: [string, string][] = [

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -323,6 +323,26 @@ describe('buildTitleDerivedAgentRows', () => {
     expect(rows[0]?.entry.terminalTitle).toBe('Rename the auth helper')
   })
 
+  it('keeps a live mirrored Cursor title that was also stamped as the tab default', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [
+        makeTab('tab-1', {
+          launchAgent: 'cursor',
+          launchAgentLeafId: LEAF_ID_1,
+          defaultTitle: 'Cursor Agent'
+        })
+      ],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: { 'tab-1': { 1: 'Cursor Agent' } },
+      ptyIdsByTabId: { 'tab-1': ['pty-cursor'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+
+    expect(rows.map((row) => [row.agentType, row.state])).toEqual([['cursor', 'idle']])
+  })
+
   it('keeps a launched Codex pane visible under an arbitrary session title', () => {
     const rows = buildWorktreeAgentRows({
       tabs: [makeTab('tab-1', { launchAgent: 'codex', launchAgentLeafId: LEAF_ID_1 })],

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -373,6 +373,20 @@ describe('buildTitleDerivedAgentRows', () => {
     expect(rows).toHaveLength(0)
   })
 
+  it('does not treat a bare Terminal title as exit unless it matches the tab defaultTitle', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { launchAgent: 'codex', launchAgentLeafId: LEAF_ID_1 })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: { 'tab-1': { 1: 'Terminal 1' } },
+      ptyIdsByTabId: { 'tab-1': ['pty-codex'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+
+    expect(rows.map((row) => [row.agentType, row.state])).toEqual([['codex', 'idle']])
+  })
+
   it('keeps a launched Cursor pane on a sole leaf even before launchAgentLeafId is stamped', () => {
     const rows = buildWorktreeAgentRows({
       tabs: [makeTab('tab-1', { launchAgent: 'cursor' })],
@@ -413,6 +427,20 @@ describe('buildTitleDerivedAgentRows', () => {
     })
 
     expect(rows).toHaveLength(0)
+  })
+
+  it('keeps launch identity on the original leaf after a sibling closes', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { launchAgent: 'cursor', launchAgentLeafId: LEAF_ID_1 })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: { 'tab-1': { 1: 'Rename the auth helper' } },
+      ptyIdsByTabId: { 'tab-1': ['pty-cursor'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+
+    expect(rows.map((row) => [row.agentType, row.state])).toEqual([['cursor', 'idle']])
   })
 
   // #8940: an OpenCode pane's own task text must not hand the row to Claude Code.

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -1,6 +1,7 @@
 import type { DashboardAgentRow } from '@/components/dashboard/useDashboardData'
 import { formatAgentTypeLabel, isClaudeManagementTitle } from '@/lib/agent-status'
 import { isCursorAgentTitle } from '../../../../shared/agent-title-core'
+import { titleShowsNoAgent } from '../../../../shared/agent-detection'
 import { classifyTitleActivity, resolveTitleActivityLabel } from '@/lib/pane-agent-evidence'
 import { tabHasLivePty } from '@/lib/tab-has-live-pty'
 import type {
@@ -149,11 +150,19 @@ function buildTitleDerivedAgentRow(args: {
   // Why (cursor): the native `cursor agent` literal is deliberately status-less so a
   // redraw cannot stomp hook state — but it still identifies a live pane, so the row
   // reads idle instead of vanishing (#10258).
-  const status = isClaudeAgentsTitle
+  const classifiedStatus = isClaudeAgentsTitle
     ? 'idle'
     : (classifyTitleActivity(title) ?? (isCursorAgentTitle(title) ? 'idle' : null))
-  const label = isClaudeAgentsTitle ? 'Claude Code' : resolveTitleActivityLabel(title)
-  if (!status || !label) {
+  const classifiedLabel = isClaudeAgentsTitle ? 'Claude Code' : resolveTitleActivityLabel(title)
+  // Why: Grok keeps identity because session titles still contain "grok". Cursor
+  // (and any launched agent that overwrites OSC with an arbitrary name) does not,
+  // so the pane's launch owner supplies identity. Shell/default titles still mean
+  // exit — same gate as use-tab-agent — so this cannot mint a row from zsh.
+  const owner =
+    args.ownerAgentType && args.ownerAgentType !== 'unknown' ? args.ownerAgentType : null
+  const ownerClaimsLiveSession = owner !== null && !titleShowsNoAgent(title, args.tab.defaultTitle)
+  const status = classifiedStatus ?? (ownerClaimsLiveSession ? 'idle' : null)
+  if (!status || (!classifiedLabel && !ownerClaimsLiveSession)) {
     return null
   }
   if (!isTerminalLeafId(args.leafId)) {
@@ -161,19 +170,23 @@ function buildTitleDerivedAgentRow(args: {
   }
   const paneKey = makePaneKey(args.tab.id, args.leafId)
   const orchestration = args.runtimeAgentOrchestrationByPaneKey?.[paneKey]
-  const titleAgentType = isClaudeAgentsTitle
-    ? 'claude'
-    : resolveTitleDerivedAgentType(title, label, args.ownerAgentType)
+  let titleAgentType: AgentType | null = null
+  if (classifiedLabel) {
+    titleAgentType = isClaudeAgentsTitle
+      ? 'claude'
+      : resolveTitleDerivedAgentType(title, classifiedLabel, args.ownerAgentType)
+  }
   // Why: a status frame proves activity, not identity, so the resolver drops it.
   // Hook-less agents over SSH (Codex, #8711; OpenCode's '. '/'* ' frames, #8940)
   // surface only decorated task titles; fall back to the pane's known owner instead
-  // of hiding the pane. Safe because the `!status || !label` gate above already
-  // rejects plain shell titles — this path must never manufacture a row from one.
-  const agentType = titleAgentType ?? args.ownerAgentType
+  // of hiding the pane. Safe because the gate above already rejects plain shell
+  // titles — this path must never manufacture a row from one.
+  const agentType = titleAgentType ?? owner
   if (!agentType) {
     return null
   }
-  const rowLabel = titleAgentType ? label : formatAgentTypeLabel(agentType)
+  const rowLabel =
+    titleAgentType && classifiedLabel ? classifiedLabel : formatAgentTypeLabel(agentType)
   const rowState = titleStatusToRowState(status)
   const secondary =
     status === 'permission' ? 'Needs input' : status === 'working' ? 'Running' : 'Idle'
@@ -248,6 +261,11 @@ function resolveTitleDerivedPaneOwner(
   // Why: launchAgent is tab-scoped, so it is pane ownership only while the tab has one
   // leaf; applying it inside a split would let one pane brand its sibling.
   if (layout?.root?.type !== 'leaf' || layout.root.leafId !== leafId) {
+    return null
+  }
+  // Why: after a split-pane close the remaining leaf is also a sole leaf. Pin
+  // provenance to the original launched leaf so a sibling cannot inherit it.
+  if (tab.launchAgentLeafId && tab.launchAgentLeafId !== leafId) {
     return null
   }
   return resolvePaneAgentOwner({ launchAgent: tab.launchAgent })

--- a/src/renderer/src/lib/tui-agent-startup.test.ts
+++ b/src/renderer/src/lib/tui-agent-startup.test.ts
@@ -426,7 +426,10 @@ describe('titleShowsNoAgent', () => {
   it('treats shell names and default Terminal titles as no agent', () => {
     expect(titleShowsNoAgent('zsh')).toBe(true)
     expect(titleShowsNoAgent('cmd.exe')).toBe(true)
-    expect(titleShowsNoAgent('Terminal 1')).toBe(true)
+    // A bare "Terminal N" is NOT evidence of exit on its own: a pane can carry a
+    // retained agent identity under that title (use-tab-agent-retained-identity).
+    // It only means "no agent" when it matches the tab's own default title.
+    expect(titleShowsNoAgent('Terminal 1')).toBe(false)
     expect(titleShowsNoAgent('Terminal 1', 'Terminal 1')).toBe(true)
   })
 

--- a/src/renderer/src/lib/tui-agent-startup.test.ts
+++ b/src/renderer/src/lib/tui-agent-startup.test.ts
@@ -4,6 +4,7 @@ import {
   buildAgentStartupPlan,
   isShellProcess
 } from './tui-agent-startup'
+import { titleShowsNoAgent } from '../../../shared/agent-detection'
 import { resolveTuiAgentLaunchArgs } from '../../../shared/tui-agent-launch-defaults'
 
 const emptyLaunchConfig = (agentCommand: string) => ({
@@ -418,5 +419,20 @@ describe('isShellProcess', () => {
   it('does not confuse agent processes with the host shell', () => {
     expect(isShellProcess('gemini')).toBe(false)
     expect(isShellProcess('cursor-agent')).toBe(false)
+  })
+})
+
+describe('titleShowsNoAgent', () => {
+  it('treats shell names and default Terminal titles as no agent', () => {
+    expect(titleShowsNoAgent('zsh')).toBe(true)
+    expect(titleShowsNoAgent('cmd.exe')).toBe(true)
+    expect(titleShowsNoAgent('Terminal 1')).toBe(true)
+    expect(titleShowsNoAgent('Terminal 1', 'Terminal 1')).toBe(true)
+  })
+
+  it('does not treat blank or conversation titles as exit', () => {
+    expect(titleShowsNoAgent('')).toBe(false)
+    expect(titleShowsNoAgent('Rename the auth helper')).toBe(false)
+    expect(titleShowsNoAgent('Cursor Agent')).toBe(false)
   })
 })

--- a/src/renderer/src/lib/use-tab-agent.ts
+++ b/src/renderer/src/lib/use-tab-agent.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { useAppStore } from '@/store'
-import { isShellProcess } from '../../../shared/agent-detection'
+import { titleShowsNoAgent } from '../../../shared/agent-detection'
 import { worktreeUsesRemoteConnection } from '@/store/slices/terminals'
 import { parseRemoteRuntimePtyId } from '@/runtime/runtime-terminal-stream'
 import { isTerminalLeafId, makePaneKey } from '../../../shared/stable-pane-id'
@@ -21,12 +21,6 @@ import { isOpenCodeNativeTitle } from '../../../shared/opencode-terminal-title'
 import { resolvePaneAgentOwner } from '../../../shared/pane-agent-owner'
 import type { TerminalTab } from '../../../shared/terminal-tab-types'
 import type { TuiAgent } from '../../../shared/tui-agent'
-
-// A shell name or the tab's neutral default title (where inferred-interrupt reset parks it); blank titles are no evidence.
-function titleShowsNoAgent(title: string, defaultTitle?: string): boolean {
-  const trimmed = title.trim()
-  return trimmed.length > 0 && (isShellProcess(trimmed) || trimmed === defaultTitle?.trim())
-}
 
 /**
  * Resolves wrapper-compatible signal identity against the launch owner.

--- a/src/renderer/src/runtime/web-session-tabs-sync-terminal-mirroring.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync-terminal-mirroring.test.ts
@@ -55,6 +55,7 @@ describe('applyWebSessionTabsSnapshot', () => {
         id: mirroredId,
         ptyId: 'remote:web-env-1@@terminal-1',
         launchAgent: 'codex',
+        launchAgentLeafId: LEAF_ID,
         startupCwd: '/worktree/packages/web',
         title: 'host shell',
         worktreeId: WT
@@ -87,13 +88,21 @@ describe('applyWebSessionTabsSnapshot', () => {
       color: null,
       sortOrder: 0,
       createdAt: NOW,
-      launchAgent: 'codex'
+      launchAgent: 'codex',
+      launchAgentLeafId: LEAF_ID
     }
 
     const patch = applyWebSessionTabsSnapshot(
       makeState({
         tabsByWorktree: { [WT]: [existingTab] },
-        ptyIdsByTabId: { [existingTab.id]: ['remote:web-env-1@@terminal-1'] }
+        ptyIdsByTabId: { [existingTab.id]: ['remote:web-env-1@@terminal-1'] },
+        terminalLayoutsByTabId: {
+          [existingTab.id]: {
+            root: { type: 'leaf', leafId: LEAF_ID },
+            activeLeafId: LEAF_ID,
+            expandedLeafId: null
+          }
+        }
       }),
       makeSnapshot([
         {
@@ -116,6 +125,60 @@ describe('applyWebSessionTabsSnapshot', () => {
       title: 'zsh'
     })
     expect(patch.tabsByWorktree?.[WT]?.[0]?.launchAgent).toBeUndefined()
+    expect(patch.tabsByWorktree?.[WT]?.[0]?.launchAgentLeafId).toBeUndefined()
+  })
+
+  it('does not recycle launch provenance onto a remaining mirrored sibling', () => {
+    const existingTab: TerminalTab = {
+      id: toWebTerminalSurfaceTabId('host-tab-1'),
+      ptyId: 'remote:web-env-1@@terminal-1',
+      worktreeId: WT,
+      title: 'Rename the auth helper',
+      defaultTitle: 'Codex',
+      customTitle: null,
+      color: null,
+      sortOrder: 0,
+      createdAt: NOW,
+      launchAgent: 'codex',
+      launchAgentLeafId: LEAF_ID
+    }
+
+    const patch = applyWebSessionTabsSnapshot(
+      makeState({
+        tabsByWorktree: { [WT]: [existingTab] },
+        ptyIdsByTabId: { [existingTab.id]: ['remote:web-env-1@@terminal-2'] },
+        terminalLayoutsByTabId: {
+          [existingTab.id]: {
+            root: {
+              type: 'split',
+              direction: 'horizontal',
+              first: { type: 'leaf', leafId: LEAF_ID },
+              second: { type: 'leaf', leafId: SECOND_LEAF_ID }
+            },
+            activeLeafId: SECOND_LEAF_ID,
+            expandedLeafId: null
+          }
+        }
+      }),
+      makeSnapshot([
+        {
+          type: 'terminal',
+          id: `host-tab-1::${SECOND_LEAF_ID}`,
+          title: 'Rename the auth helper',
+          parentTabId: 'host-tab-1',
+          leafId: SECOND_LEAF_ID,
+          isActive: true,
+          launchAgent: 'codex',
+          status: 'ready',
+          terminal: 'terminal-2'
+        }
+      ]),
+      ENV,
+      NOW + 1
+    ) as Partial<WebSessionTabsSyncState>
+
+    expect(patch.tabsByWorktree?.[WT]?.[0]?.launchAgent).toBe('codex')
+    expect(patch.tabsByWorktree?.[WT]?.[0]?.launchAgentLeafId).toBe(LEAF_ID)
   })
 
   it('drops mirrored startup cwd when a later host snapshot omits it', () => {

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -34,6 +34,7 @@ import {
   buildRetiredTerminalTabStateSweepPatch,
   type RetiredTerminalTabSweepState
 } from '../store/slices/retired-terminal-tab-state-sweep'
+import { resolveLaunchAgentLeafId } from '../store/slices/launch-agent-leaf-stamp'
 import { getRemoteRuntimePtyEnvironmentId, toRemoteRuntimePtyId } from './runtime-terminal-stream'
 import { sanitizeTerminalLayoutPaneTitlesForLabels } from '@/lib/terminal-pane-title-sanitization'
 import { terminalLayoutEqual } from '@/lib/terminal-layout-equality'
@@ -1071,6 +1072,14 @@ function buildMirroredTerminalTabs(
     // Why: viewMode echoes back through host snapshots, so prefer the client's record during the echo window and adopt the host value only without a prior tab.
     const hostViewModeSurface = surfaces.find((surface) => surface.viewMode)
     const viewMode = existing ? existing.viewMode : hostViewModeSurface?.viewMode
+    // Why: host snapshots omit this pin; stamp the first sole leaf and keep it
+    // only while launchAgent remains so a remaining sibling cannot inherit it.
+    const launchAgentLeafId = resolveLaunchAgentLeafId({
+      launchAgent,
+      existingLeafId: existing?.launchAgentLeafId,
+      previousLayout: existingLayout,
+      nextLayout: layout
+    })
     return {
       tab: {
         id: localTabId,
@@ -1092,9 +1101,7 @@ function buildMirroredTerminalTabs(
         createdAt: existing?.createdAt ?? now + index,
         // Why: launchAgent is host-owned lifecycle metadata; once the host omits it, don't resurrect stale startup intent.
         ...(launchAgent ? { launchAgent } : {}),
-        // Why: launchAgentLeafId is client-stamped from the first sole leaf; the
-        // host snapshot does not carry it, so dropping it would recycle identity.
-        ...(existing?.launchAgentLeafId ? { launchAgentLeafId: existing.launchAgentLeafId } : {})
+        ...(launchAgentLeafId ? { launchAgentLeafId } : {})
       },
       hostTabId: parentTabId,
       ptyIds,

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -1091,7 +1091,10 @@ function buildMirroredTerminalTabs(
         sortOrder: sortOffset + index,
         createdAt: existing?.createdAt ?? now + index,
         // Why: launchAgent is host-owned lifecycle metadata; once the host omits it, don't resurrect stale startup intent.
-        ...(launchAgent ? { launchAgent } : {})
+        ...(launchAgent ? { launchAgent } : {}),
+        // Why: launchAgentLeafId is client-stamped from the first sole leaf; the
+        // host snapshot does not carry it, so dropping it would recycle identity.
+        ...(existing?.launchAgentLeafId ? { launchAgentLeafId: existing.launchAgentLeafId } : {})
       },
       hostTabId: parentTabId,
       ptyIds,
@@ -2195,6 +2198,7 @@ function terminalTabEqual(a: TerminalTab, b: TerminalTab): boolean {
     a.generation === b.generation &&
     a.shellOverride === b.shellOverride &&
     a.launchAgent === b.launchAgent &&
+    a.launchAgentLeafId === b.launchAgentLeafId &&
     a.pendingActivationSpawn === b.pendingActivationSpawn
   )
 }

--- a/src/renderer/src/store/slices/launch-agent-leaf-stamp.test.ts
+++ b/src/renderer/src/store/slices/launch-agent-leaf-stamp.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import type { TerminalLayoutSnapshot, TerminalTab } from '../../../../shared/terminal-tab-types'
+import { emptyLayoutSnapshot, singlePaneLayoutSnapshot } from './terminal-helpers'
+import { stampLaunchAgentLeafIdOnFirstLayout } from './launch-agent-leaf-stamp'
+
+const LEAF_A = '11111111-1111-4111-8111-111111111111'
+const LEAF_B = '22222222-2222-4222-8222-222222222222'
+
+function makeTab(overrides: Partial<TerminalTab> = {}): TerminalTab {
+  return {
+    id: 'tab-1',
+    worktreeId: 'wt-1',
+    ptyId: null,
+    title: 'Terminal 1',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0,
+    ...overrides
+  }
+}
+
+function splitLayout(): TerminalLayoutSnapshot {
+  return {
+    root: {
+      type: 'split',
+      direction: 'vertical',
+      first: { type: 'leaf', leafId: LEAF_A },
+      second: { type: 'leaf', leafId: LEAF_B }
+    },
+    activeLeafId: LEAF_A,
+    expandedLeafId: null
+  }
+}
+
+describe('stampLaunchAgentLeafIdOnFirstLayout', () => {
+  it('pins launch provenance to the first sole leaf', () => {
+    const stamped = stampLaunchAgentLeafIdOnFirstLayout({
+      tabs: [makeTab({ launchAgent: 'cursor' })],
+      tabId: 'tab-1',
+      previousLayout: emptyLayoutSnapshot(),
+      nextLayout: singlePaneLayoutSnapshot(LEAF_A)
+    })
+
+    expect(stamped?.[0]?.launchAgentLeafId).toBe(LEAF_A)
+  })
+
+  it('does not overwrite a stamp after the original leaf closes', () => {
+    const stamped = stampLaunchAgentLeafIdOnFirstLayout({
+      tabs: [makeTab({ launchAgent: 'cursor', launchAgentLeafId: LEAF_A })],
+      tabId: 'tab-1',
+      previousLayout: splitLayout(),
+      nextLayout: singlePaneLayoutSnapshot(LEAF_B)
+    })
+
+    expect(stamped).toBeNull()
+  })
+
+  it('does not stamp a split as the original leaf', () => {
+    const stamped = stampLaunchAgentLeafIdOnFirstLayout({
+      tabs: [makeTab({ launchAgent: 'cursor' })],
+      tabId: 'tab-1',
+      previousLayout: emptyLayoutSnapshot(),
+      nextLayout: splitLayout()
+    })
+
+    expect(stamped).toBeNull()
+  })
+
+  it('does not stamp a tab with no launch identity', () => {
+    const stamped = stampLaunchAgentLeafIdOnFirstLayout({
+      tabs: [makeTab()],
+      tabId: 'tab-1',
+      previousLayout: emptyLayoutSnapshot(),
+      nextLayout: singlePaneLayoutSnapshot(LEAF_A)
+    })
+
+    expect(stamped).toBeNull()
+  })
+})

--- a/src/renderer/src/store/slices/launch-agent-leaf-stamp.test.ts
+++ b/src/renderer/src/store/slices/launch-agent-leaf-stamp.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import type { TerminalLayoutSnapshot, TerminalTab } from '../../../../shared/terminal-tab-types'
 import { emptyLayoutSnapshot, singlePaneLayoutSnapshot } from './terminal-helpers'
-import { stampLaunchAgentLeafIdOnFirstLayout } from './launch-agent-leaf-stamp'
+import {
+  resolveLaunchAgentLeafId,
+  stampLaunchAgentLeafIdOnFirstLayout
+} from './launch-agent-leaf-stamp'
 
 const LEAF_A = '11111111-1111-4111-8111-111111111111'
 const LEAF_B = '22222222-2222-4222-8222-222222222222'
@@ -76,5 +79,40 @@ describe('stampLaunchAgentLeafIdOnFirstLayout', () => {
     })
 
     expect(stamped).toBeNull()
+  })
+})
+
+describe('resolveLaunchAgentLeafId', () => {
+  it('stamps the first sole leaf while launch identity is live', () => {
+    expect(
+      resolveLaunchAgentLeafId({
+        launchAgent: 'cursor',
+        existingLeafId: undefined,
+        previousLayout: emptyLayoutSnapshot(),
+        nextLayout: singlePaneLayoutSnapshot(LEAF_A)
+      })
+    ).toBe(LEAF_A)
+  })
+
+  it('keeps the original pin after a remaining sibling becomes the sole leaf', () => {
+    expect(
+      resolveLaunchAgentLeafId({
+        launchAgent: 'cursor',
+        existingLeafId: LEAF_A,
+        previousLayout: splitLayout(),
+        nextLayout: singlePaneLayoutSnapshot(LEAF_B)
+      })
+    ).toBe(LEAF_A)
+  })
+
+  it('drops the pin when launch identity is gone', () => {
+    expect(
+      resolveLaunchAgentLeafId({
+        launchAgent: undefined,
+        existingLeafId: LEAF_A,
+        previousLayout: singlePaneLayoutSnapshot(LEAF_A),
+        nextLayout: singlePaneLayoutSnapshot(LEAF_A)
+      })
+    ).toBeUndefined()
   })
 })

--- a/src/renderer/src/store/slices/launch-agent-leaf-stamp.test.ts
+++ b/src/renderer/src/store/slices/launch-agent-leaf-stamp.test.ts
@@ -3,7 +3,8 @@ import type { TerminalLayoutSnapshot, TerminalTab } from '../../../../shared/ter
 import { emptyLayoutSnapshot, singlePaneLayoutSnapshot } from './terminal-helpers'
 import {
   resolveLaunchAgentLeafId,
-  stampLaunchAgentLeafIdOnFirstLayout
+  stampLaunchAgentLeafIdOnFirstLayout,
+  transferLaunchAgentLeafStampOnDetach
 } from './launch-agent-leaf-stamp'
 
 const LEAF_A = '11111111-1111-4111-8111-111111111111'
@@ -114,5 +115,51 @@ describe('resolveLaunchAgentLeafId', () => {
         nextLayout: singlePaneLayoutSnapshot(LEAF_A)
       })
     ).toBeUndefined()
+  })
+})
+
+describe('transferLaunchAgentLeafStampOnDetach', () => {
+  it('moves launch provenance with the detached leaf', () => {
+    const tabs = transferLaunchAgentLeafStampOnDetach({
+      tabs: [
+        makeTab({ id: 'source', launchAgent: 'cursor', launchAgentLeafId: LEAF_A }),
+        makeTab({ id: 'target' })
+      ],
+      sourceTabId: 'source',
+      targetTabId: 'target',
+      detachedLeafId: LEAF_A
+    })
+
+    expect(tabs?.find((tab) => tab.id === 'source')).not.toHaveProperty('launchAgent')
+    expect(tabs?.find((tab) => tab.id === 'source')).not.toHaveProperty('launchAgentLeafId')
+    expect(tabs?.find((tab) => tab.id === 'target')).toMatchObject({
+      launchAgent: 'cursor',
+      launchAgentLeafId: LEAF_A
+    })
+  })
+
+  it('does not overwrite existing target launch provenance', () => {
+    expect(
+      transferLaunchAgentLeafStampOnDetach({
+        tabs: [
+          makeTab({ id: 'source', launchAgent: 'cursor', launchAgentLeafId: LEAF_A }),
+          makeTab({ id: 'target', launchAgent: 'codex', launchAgentLeafId: LEAF_B })
+        ],
+        sourceTabId: 'source',
+        targetTabId: 'target',
+        detachedLeafId: LEAF_A
+      })
+    ).toBeNull()
+  })
+
+  it('does not guess ownership for an unpinned launch', () => {
+    expect(
+      transferLaunchAgentLeafStampOnDetach({
+        tabs: [makeTab({ id: 'source', launchAgent: 'cursor' }), makeTab({ id: 'target' })],
+        sourceTabId: 'source',
+        targetTabId: 'target',
+        detachedLeafId: LEAF_A
+      })
+    ).toBeNull()
   })
 })

--- a/src/renderer/src/store/slices/launch-agent-leaf-stamp.ts
+++ b/src/renderer/src/store/slices/launch-agent-leaf-stamp.ts
@@ -2,6 +2,26 @@ import { isTerminalLeafId } from '../../../../shared/stable-pane-id'
 import type { TerminalLayoutSnapshot, TerminalTab } from '../../../../shared/terminal-tab-types'
 
 /**
+ * Next persisted launch-leaf pin while rebuilding a tab.
+ * Drops with launchAgent so a later relaunch cannot inherit a stale leaf;
+ * never overwrites an existing pin — a remaining sibling is also a sole leaf.
+ */
+export function resolveLaunchAgentLeafId(args: {
+  launchAgent: TerminalTab['launchAgent']
+  existingLeafId: TerminalTab['launchAgentLeafId']
+  previousLayout: TerminalLayoutSnapshot | undefined
+  nextLayout: TerminalLayoutSnapshot
+}): string | undefined {
+  if (!args.launchAgent) {
+    return undefined
+  }
+  if (args.existingLeafId) {
+    return args.existingLeafId
+  }
+  return soleLeafIdOnFirstLayout(args.previousLayout, args.nextLayout)
+}
+
+/**
  * Bind tab-scoped launchAgent to the first sole leaf the layout describes.
  * Later topologies must not overwrite it — a remaining sibling after a close
  * is also a sole leaf, and inheriting would recycle the launched identity.
@@ -12,19 +32,32 @@ export function stampLaunchAgentLeafIdOnFirstLayout(args: {
   previousLayout: TerminalLayoutSnapshot | undefined
   nextLayout: TerminalLayoutSnapshot
 }): TerminalTab[] | null {
-  if (args.previousLayout?.root) {
-    return null
-  }
-  const nextRoot = args.nextLayout.root
-  if (nextRoot?.type !== 'leaf' || !isTerminalLeafId(nextRoot.leafId)) {
-    return null
-  }
   const tabIndex = args.tabs.findIndex((tab) => tab.id === args.tabId)
   const tab = args.tabs[tabIndex]
-  if (!tab?.launchAgent || tab.launchAgentLeafId) {
+  const launchAgentLeafId = resolveLaunchAgentLeafId({
+    launchAgent: tab?.launchAgent,
+    existingLeafId: tab?.launchAgentLeafId,
+    previousLayout: args.previousLayout,
+    nextLayout: args.nextLayout
+  })
+  if (!tab || !launchAgentLeafId || launchAgentLeafId === tab.launchAgentLeafId) {
     return null
   }
   const nextTabs = [...args.tabs]
-  nextTabs[tabIndex] = { ...tab, launchAgentLeafId: nextRoot.leafId }
+  nextTabs[tabIndex] = { ...tab, launchAgentLeafId }
   return nextTabs
+}
+
+function soleLeafIdOnFirstLayout(
+  previousLayout: TerminalLayoutSnapshot | undefined,
+  nextLayout: TerminalLayoutSnapshot
+): string | undefined {
+  if (previousLayout?.root) {
+    return undefined
+  }
+  const nextRoot = nextLayout.root
+  if (nextRoot?.type !== 'leaf' || !isTerminalLeafId(nextRoot.leafId)) {
+    return undefined
+  }
+  return nextRoot.leafId
 }

--- a/src/renderer/src/store/slices/launch-agent-leaf-stamp.ts
+++ b/src/renderer/src/store/slices/launch-agent-leaf-stamp.ts
@@ -48,6 +48,40 @@ export function stampLaunchAgentLeafIdOnFirstLayout(args: {
   return nextTabs
 }
 
+/** Moves launch provenance with a detached leaf without overwriting existing target ownership. */
+export function transferLaunchAgentLeafStampOnDetach(args: {
+  tabs: readonly TerminalTab[]
+  sourceTabId: string
+  targetTabId: string
+  detachedLeafId: string
+}): TerminalTab[] | null {
+  const sourceIndex = args.tabs.findIndex((tab) => tab.id === args.sourceTabId)
+  const targetIndex = args.tabs.findIndex((tab) => tab.id === args.targetTabId)
+  const source = args.tabs[sourceIndex]
+  const target = args.tabs[targetIndex]
+  if (
+    !source?.launchAgent ||
+    source.launchAgentLeafId !== args.detachedLeafId ||
+    !target ||
+    target.launchAgent ||
+    target.launchAgentLeafId
+  ) {
+    return null
+  }
+
+  const sourceWithoutLaunchProvenance = { ...source }
+  delete sourceWithoutLaunchProvenance.launchAgent
+  delete sourceWithoutLaunchProvenance.launchAgentLeafId
+  const nextTabs = [...args.tabs]
+  nextTabs[sourceIndex] = sourceWithoutLaunchProvenance
+  nextTabs[targetIndex] = {
+    ...target,
+    launchAgent: source.launchAgent,
+    launchAgentLeafId: args.detachedLeafId
+  }
+  return nextTabs
+}
+
 function soleLeafIdOnFirstLayout(
   previousLayout: TerminalLayoutSnapshot | undefined,
   nextLayout: TerminalLayoutSnapshot

--- a/src/renderer/src/store/slices/launch-agent-leaf-stamp.ts
+++ b/src/renderer/src/store/slices/launch-agent-leaf-stamp.ts
@@ -1,0 +1,30 @@
+import { isTerminalLeafId } from '../../../../shared/stable-pane-id'
+import type { TerminalLayoutSnapshot, TerminalTab } from '../../../../shared/terminal-tab-types'
+
+/**
+ * Bind tab-scoped launchAgent to the first sole leaf the layout describes.
+ * Later topologies must not overwrite it — a remaining sibling after a close
+ * is also a sole leaf, and inheriting would recycle the launched identity.
+ */
+export function stampLaunchAgentLeafIdOnFirstLayout(args: {
+  tabs: readonly TerminalTab[]
+  tabId: string
+  previousLayout: TerminalLayoutSnapshot | undefined
+  nextLayout: TerminalLayoutSnapshot
+}): TerminalTab[] | null {
+  if (args.previousLayout?.root) {
+    return null
+  }
+  const nextRoot = args.nextLayout.root
+  if (nextRoot?.type !== 'leaf' || !isTerminalLeafId(nextRoot.leafId)) {
+    return null
+  }
+  const tabIndex = args.tabs.findIndex((tab) => tab.id === args.tabId)
+  const tab = args.tabs[tabIndex]
+  if (!tab?.launchAgent || tab.launchAgentLeafId) {
+    return null
+  }
+  const nextTabs = [...args.tabs]
+  nextTabs[tabIndex] = { ...tab, launchAgentLeafId: nextRoot.leafId }
+  return nextTabs
+}

--- a/src/renderer/src/store/slices/terminal-pane-detach-agent-identity.test.ts
+++ b/src/renderer/src/store/slices/terminal-pane-detach-agent-identity.test.ts
@@ -20,7 +20,13 @@ describe('syncPaneDetachPtyOwnership agent identity', () => {
       },
       tabsByWorktree: {
         [worktreeId]: [
-          makeTab({ id: sourceTabId, worktreeId, ptyId: 'pty-droid' }),
+          makeTab({
+            id: sourceTabId,
+            worktreeId,
+            ptyId: 'pty-droid',
+            launchAgent: 'droid',
+            launchAgentLeafId: detachedLeafId
+          }),
           makeTab({ id: targetTabId, worktreeId, ptyId: null })
         ]
       },
@@ -112,6 +118,13 @@ describe('syncPaneDetachPtyOwnership agent identity', () => {
     expect(state.paneForegroundAgentByPaneKey[siblingPaneKey]).toEqual({
       agent: 'antigravity',
       shellForeground: false
+    })
+    const tabs = state.tabsByWorktree[worktreeId] ?? []
+    expect(tabs.find((tab) => tab.id === sourceTabId)).not.toHaveProperty('launchAgent')
+    expect(tabs.find((tab) => tab.id === sourceTabId)).not.toHaveProperty('launchAgentLeafId')
+    expect(tabs.find((tab) => tab.id === targetTabId)).toMatchObject({
+      launchAgent: 'droid',
+      launchAgentLeafId: detachedLeafId
     })
     expect(resolveWindowsShiftEnterEncodingForPane(state, targetPaneKey)).toBe('csi-u')
     expect(resolveWindowsShiftEnterEncodingForPane(state, siblingPaneKey)).toBe('alt-enter')

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -51,6 +51,7 @@ import type { AiVaultSessionTitle } from '../../../../shared/ai-vault-session-ti
 import { scheduleRuntimeGraphSync } from '@/runtime/sync-runtime-graph'
 import { terminalLayoutEqual } from '@/lib/terminal-layout-equality'
 import { sweepRetiredTerminalTabState } from './retired-terminal-tab-state-sweep'
+import { stampLaunchAgentLeafIdOnFirstLayout } from './launch-agent-leaf-stamp'
 import { clearTransientTerminalState, emptyLayoutSnapshot } from './terminal-helpers'
 import {
   collectReleasedLeafIds,
@@ -2065,11 +2066,16 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       const tabs = s.tabsByWorktree[ownerWorktreeId] ?? []
       const tabIndex = tabs.findIndex((t) => t.id === tabId)
       const currentTab = tabs[tabIndex]
-      if (!currentTab?.launchAgent) {
+      if (!currentTab?.launchAgent && !currentTab?.launchAgentLeafId) {
         return s
       }
-      const { launchAgent: _launchAgent, ...tabWithoutLaunchAgent } = currentTab
+      const {
+        launchAgent: _launchAgent,
+        launchAgentLeafId: _launchAgentLeafId,
+        ...tabWithoutLaunchAgent
+      } = currentTab
       void _launchAgent
+      void _launchAgentLeafId
       const nextTabs = [...tabs]
       nextTabs[tabIndex] = tabWithoutLaunchAgent
       scheduleRuntimeGraphSync()
@@ -3591,8 +3597,21 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       if (existing && terminalLayoutEqual(existing, normalized.snapshot)) {
         return s
       }
+      const ownerWorktreeId = getTerminalTabOwnerWorktreeId(s.tabsByWorktree, tabId)
+      const stampedTabs =
+        ownerWorktreeId === null
+          ? null
+          : stampLaunchAgentLeafIdOnFirstLayout({
+              tabs: s.tabsByWorktree[ownerWorktreeId] ?? [],
+              tabId,
+              previousLayout: existing,
+              nextLayout: normalized.snapshot
+            })
       return {
-        terminalLayoutsByTabId: { ...s.terminalLayoutsByTabId, [tabId]: normalized.snapshot }
+        terminalLayoutsByTabId: { ...s.terminalLayoutsByTabId, [tabId]: normalized.snapshot },
+        ...(stampedTabs && ownerWorktreeId
+          ? { tabsByWorktree: { ...s.tabsByWorktree, [ownerWorktreeId]: stampedTabs } }
+          : {})
       }
     })
     transferNormalizedTerminalLayoutPtyOwnership(get(), tabId, ownershipTransfers)

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -51,7 +51,10 @@ import type { AiVaultSessionTitle } from '../../../../shared/ai-vault-session-ti
 import { scheduleRuntimeGraphSync } from '@/runtime/sync-runtime-graph'
 import { terminalLayoutEqual } from '@/lib/terminal-layout-equality'
 import { sweepRetiredTerminalTabState } from './retired-terminal-tab-state-sweep'
-import { stampLaunchAgentLeafIdOnFirstLayout } from './launch-agent-leaf-stamp'
+import {
+  stampLaunchAgentLeafIdOnFirstLayout,
+  transferLaunchAgentLeafStampOnDetach
+} from './launch-agent-leaf-stamp'
 import { clearTransientTerminalState, emptyLayoutSnapshot } from './terminal-helpers'
 import {
   collectReleasedLeafIds,
@@ -3663,6 +3666,24 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       const nextTabsByWorktree = detachedPtyId
         ? withTerminalTabPtyId(sourceTabsByWorktree, targetTabId, detachedPtyId)
         : sourceTabsByWorktree
+      const sourceWorktreeId = getTerminalTabOwnerWorktreeId(nextTabsByWorktree, sourceTabId)
+      const targetWorktreeId = getTerminalTabOwnerWorktreeId(nextTabsByWorktree, targetTabId)
+      const transferredTabs =
+        sourceWorktreeId !== null && sourceWorktreeId === targetWorktreeId
+          ? transferLaunchAgentLeafStampOnDetach({
+              tabs: nextTabsByWorktree[sourceWorktreeId] ?? [],
+              sourceTabId,
+              targetTabId,
+              detachedLeafId
+            })
+          : null
+      const tabsByWorktree =
+        transferredTabs && sourceWorktreeId !== null
+          ? { ...nextTabsByWorktree, [sourceWorktreeId]: transferredTabs }
+          : nextTabsByWorktree
+      if (transferredTabs) {
+        scheduleRuntimeGraphSync()
+      }
       const directSshLedger = transferDirectSshPaneDetachLedger(s, {
         detachedPtyId,
         sourcePtyId: sourcePrimaryPtyId,
@@ -3675,7 +3696,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         ptyIdsByTabId: nextPtyIdsByTabId,
         lastKnownRelayPtyIdByTabId: nextLastKnownRelayPtyIdByTabId,
         ...directSshLedger,
-        ...(nextTabsByWorktree !== s.tabsByWorktree ? { tabsByWorktree: nextTabsByWorktree } : {})
+        ...(tabsByWorktree !== s.tabsByWorktree ? { tabsByWorktree } : {})
       }
     })
     // Why: detach keeps the process and its pane key alive, so move resume/status authority to the new surface before the source closes.

--- a/src/shared/agent-detection.ts
+++ b/src/shared/agent-detection.ts
@@ -37,4 +37,4 @@ export {
   MAX_OSC_TITLE_CHARS,
   MAX_OSC_TITLES_PER_CHUNK
 } from './osc-title-extraction'
-export { isShellProcess } from './shell-process-detection'
+export { isShellProcess, titleShowsNoAgent } from './shell-process-detection'

--- a/src/shared/shell-process-detection.ts
+++ b/src/shared/shell-process-detection.ts
@@ -22,6 +22,19 @@ export function isShellProcess(processName: string): boolean {
   )
 }
 
+const DEFAULT_TERMINAL_TITLE_RE = /^terminal \d+$/i
+
+/** A shell name or the tab's default Terminal title; blank titles are no evidence. */
+export function titleShowsNoAgent(title: string, defaultTitle?: string): boolean {
+  const trimmed = title.trim()
+  return (
+    trimmed.length > 0 &&
+    (isShellProcess(trimmed) ||
+      trimmed === defaultTitle?.trim() ||
+      DEFAULT_TERMINAL_TITLE_RE.test(trimmed))
+  )
+}
+
 // Why: a ConPTY-side buffer clear cannot reach PSReadLine's cached cursor
 // row, so the first Enter after a terminal clear still repaints the prompt at
 // the stale row. Only the PowerShell family binds Ctrl+L (form feed) to a

--- a/src/shared/shell-process-detection.ts
+++ b/src/shared/shell-process-detection.ts
@@ -22,17 +22,10 @@ export function isShellProcess(processName: string): boolean {
   )
 }
 
-const DEFAULT_TERMINAL_TITLE_RE = /^terminal \d+$/i
-
-/** A shell name or the tab's default Terminal title; blank titles are no evidence. */
+/** A shell name or the tab's own neutral default title; blank titles are no evidence. */
 export function titleShowsNoAgent(title: string, defaultTitle?: string): boolean {
   const trimmed = title.trim()
-  return (
-    trimmed.length > 0 &&
-    (isShellProcess(trimmed) ||
-      trimmed === defaultTitle?.trim() ||
-      DEFAULT_TERMINAL_TITLE_RE.test(trimmed))
-  )
+  return trimmed.length > 0 && (isShellProcess(trimmed) || trimmed === defaultTitle?.trim())
 }
 
 // Why: a ConPTY-side buffer clear cannot reach PSReadLine's cached cursor

--- a/src/shared/terminal-tab-types.ts
+++ b/src/shared/terminal-tab-types.ts
@@ -43,6 +43,10 @@ export type TerminalTab = {
    *  hook status overrides this once the agent does anything. Plain terminals
    *  and manually-started agents omit it. */
   launchAgent?: TuiAgent
+  /** Why: `launchAgent` is tab-scoped. Pinning it to the original leaf stops a
+   *  remaining sibling (or a new pane in the same slot) from inheriting the
+   *  launched identity after the launched pane closes. */
+  launchAgentLeafId?: string
   /** Why: when `setActiveWorktree` bumps generation on all-dead tabs to drive a
    *  TerminalPane remount, the fresh PTY that results is caused by navigation,
    *  not by the user doing work. Without this flag the resulting

--- a/src/shared/workspace-session-schema.test.ts
+++ b/src/shared/workspace-session-schema.test.ts
@@ -200,6 +200,36 @@ describe('parseWorkspaceSession', () => {
     }
   })
 
+  it('drops an invalid launchAgentLeafId without failing the whole session', () => {
+    const result = parseWorkspaceSession({
+      activeRepoId: null,
+      activeWorktreeId: null,
+      activeTabId: null,
+      tabsByWorktree: {
+        wt: [
+          {
+            id: 'tab1',
+            ptyId: null,
+            worktreeId: 'wt',
+            title: 'codex',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            launchAgent: 'cursor',
+            launchAgentLeafId: 'not-a-leaf-id'
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {}
+    })
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value.tabsByWorktree.wt[0].launchAgentLeafId).toBeUndefined()
+      expect(result.value.tabsByWorktree.wt[0].launchAgent).toBe('cursor')
+    }
+  })
+
   it('drops an unknown launchAgent without failing the whole session', () => {
     const result = parseWorkspaceSession({
       activeRepoId: null,

--- a/src/shared/workspace-session-schema.test.ts
+++ b/src/shared/workspace-session-schema.test.ts
@@ -169,6 +169,37 @@ describe('parseWorkspaceSession', () => {
     }
   })
 
+  it('preserves a valid launchAgentLeafId on a terminal tab', () => {
+    const result = parseWorkspaceSession({
+      activeRepoId: null,
+      activeWorktreeId: null,
+      activeTabId: null,
+      tabsByWorktree: {
+        wt: [
+          {
+            id: 'tab1',
+            ptyId: null,
+            worktreeId: 'wt',
+            title: 'codex',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            launchAgent: 'cursor',
+            launchAgentLeafId: '11111111-1111-4111-8111-111111111111'
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {}
+    })
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value.tabsByWorktree.wt[0].launchAgentLeafId).toBe(
+        '11111111-1111-4111-8111-111111111111'
+      )
+    }
+  })
+
   it('drops an unknown launchAgent without failing the whole session', () => {
     const result = parseWorkspaceSession({
       activeRepoId: null,

--- a/src/shared/workspace-session-schema.ts
+++ b/src/shared/workspace-session-schema.ts
@@ -20,6 +20,7 @@ import type { WorkspaceSessionState } from './workspace-session-state-types'
 import { isValidTerminalTabId } from './terminal-tab-id'
 import { parseExecutionHostId, type ExecutionHostId } from './execution-host'
 import { isTuiAgent } from './tui-agent-config'
+import { isTerminalLeafId } from './stable-pane-id'
 import { isWorkspaceKey } from './workspace-scope'
 import {
   browserHistoryEntriesSchema,
@@ -103,7 +104,10 @@ const terminalTabSchema = z.object({
   launchAgent: z
     .custom<TuiAgent>((v) => isTuiAgent(v))
     .optional()
-    .catch(undefined)
+    .catch(undefined),
+  // Why: optional so older sessions restore; unknown/non-UUID values drop rather
+  // than failing the whole-session parse.
+  launchAgentLeafId: z.string().refine(isTerminalLeafId).optional().catch(undefined)
 })
 
 // ─── Unified tab model ──────────────────────────────────────────────


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​483 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​480 |
| Prod | 9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​198 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​24 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​174 |

<!-- /orca-pr-loc -->

## ELI5

If you start Cursor from Orca, the session is running, but it disappears from the left-hand Agents list as soon as Cursor names the chat. Orca now keeps that row for the whole session, and only hides it when the terminal is back at a shell prompt.

## What Changed

- Title-derived sidebar rows bind identity to **launch provenance** (Orca launched this pane as this agent), not to a provider token in the live OSC title.
- Shell names (`zsh`, `bash`, `cmd.exe`, …) and the tab's default Terminal title still mean the agent exited, matching `use-tab-agent`.
- Provenance is pinned to the original leaf UUID so a remaining sibling after a split-pane close cannot inherit the launched identity.
- Tests cover: arbitrary session title + launched Cursor/Codex stays visible; `zsh` / `Terminal 1` hides the row; a closed pane's identity is not inherited by a new pane in the same slot.

## Why

#10258 kept panes whose title was the native `Cursor Agent` literal. cursor-agent then replaces that literal with a generated conversation name that has no provider token. Grok session titles still contain `grok`, so they stay classified; Cursor titles do not. Parsing one Cursor title format is the wrong fix — the conversation name is arbitrary, and any launched agent that overwrites OSC the same way has the same defect.

## Supersedes #15336

This PR supersedes #15336. Carry-forward: keep a launched pane visible under a non-shell conversation title, and retire on `zsh` / default Terminal title.

How it differs:

1. Generic launch provenance for every launched agent, not a Cursor-only owner fallback.
2. Pins provenance to the original leaf (`launchAgentLeafId`) so a remaining sibling after a split-pane close cannot inherit the row (STA-2926 recycle hazard).
3. Tests the recycle case and a Codex conversation-name case, not only Cursor keep/retire.

## Linked Issue

Fixes #15335
STA-4774

## Visual Proof

N/A — no new chrome. A launched Cursor pane whose title is an arbitrary conversation name now gets a Cursor row; previously that title classified as nothing. Shell / default Terminal titles still hide the row.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Focused: `worktree-title-derived-agent-rows.test.ts`, `launch-agent-leaf-stamp.test.ts`, `workspace-session-schema.test.ts`, `tui-agent-startup.test.ts`, `use-tab-agent.test.ts`, `worktree-status-spinner-launch-agent.test.ts`, web-session tab mirroring tests. `pnpm typecheck` passed.

Pre-fix: conversation-name keep tests failed (`expected []` vs Cursor/Codex row). Post-fix: those tests pass. Neutering the keep-row hunk made them fail again. Neutering the leaf pin made the recycle test fail (`expected length 0, received 1`).

Platforms: classification is on the OSC title string plus launch provenance (macOS / Linux / Windows / SSH identical). Folder workspaces use the same tab/leaf model.

## Review

### Agent code-review summary

- Cross-platform: matching is on the title string and tab launch provenance; no path or shortcut changes.
- SSH/remote: title-derived rows already run on the client that owns the pane; client-stamped `launchAgentLeafId` is preserved across host snapshots. `launchAgentLeafId` is an optional persisted field (safe for mixed versions).
- Agent compatibility: generic owner fallback. Explicit title identity still outranks launch identity. A shell / default Terminal title still drops the row.
- Performance: one extra shell/default-title check on an existing title-derived path; first-layout stamp is a single tab write.
- UI: no new controls.
- Security: no new network, credentials, or command execution.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

Out of scope (do not widen): Windows "never detected" reports #8258 / STA-1628 and #14434 / STA-4265 — those panes are never recognised at all. This only keeps a pane Orca launched after its conversation title replaces the identity title.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Focused unit tests and `pnpm typecheck` passed locally.

## Author

- X / Twitter: @BrennanKB5