### PR TITLE
fix(filesystem-auth): discard a stale authorized-roots rebuild instead of marking the cache clean

### DIFF
--- a/src/main/ipc/registered-worktree-roots-cache.test.ts
+++ b/src/main/ipc/registered-worktree-roots-cache.test.ts
@@ -1,0 +1,91 @@
+import { resolve } from 'node:path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Store } from '../persistence'
+import type * as RepoWorktrees from '../repo-worktrees'
+import { listRepoWorktrees } from '../repo-worktrees'
+import type { Repo } from '../../shared/repo-types'
+import type { GitWorktreeInfo } from '../../shared/worktree/types'
+import {
+  ensureAuthorizedRootsCache,
+  invalidateAuthorizedRootsCache,
+  isRegisteredWorktreePath,
+  resolveRegisteredWorktreePath
+} from './registered-worktree-roots-cache'
+
+vi.mock('../repo-worktrees', async () => {
+  const actual = await vi.importActual<typeof RepoWorktrees>('../repo-worktrees')
+  return {
+    ...actual,
+    listRepoWorktrees: vi.fn()
+  }
+})
+
+const repo: Repo = {
+  id: 'repo-1',
+  path: '/repos/app',
+  displayName: 'app',
+  badgeColor: '#000000',
+  addedAt: 1,
+  kind: 'git'
+}
+
+function makeStore(repos: Repo[]): Store {
+  return { getRepos: () => repos } as unknown as Store
+}
+
+function linkedWorktree(path: string): GitWorktreeInfo {
+  return { path, head: '', branch: 'refs/heads/feature', isBare: false, isMainWorktree: false }
+}
+
+// Parks the first `git worktree list` so a mutation can land mid-rebuild.
+function parkFirstWorktreeListing(): (worktrees: GitWorktreeInfo[]) => void {
+  let release!: (worktrees: GitWorktreeInfo[]) => void
+  vi.mocked(listRepoWorktrees).mockReturnValueOnce(
+    new Promise((resolvePromise) => {
+      release = resolvePromise
+    })
+  )
+  return release
+}
+
+describe('authorized roots cache invalidation during a rebuild', () => {
+  beforeEach(() => {
+    invalidateAuthorizedRootsCache()
+    vi.mocked(listRepoWorktrees).mockReset()
+  })
+
+  it('still authorizes a worktree created while a rebuild was awaiting git', async () => {
+    const release = parkFirstWorktreeListing()
+    // What git reports once the new worktree exists.
+    vi.mocked(listRepoWorktrees).mockResolvedValue([linkedWorktree('/linked/new')])
+    const store = makeStore([repo])
+
+    const pending = ensureAuthorizedRootsCache(store)
+    // The worktree is created while the first listing is still in flight.
+    invalidateAuthorizedRootsCache()
+    release([])
+    await pending
+
+    await expect(resolveRegisteredWorktreePath('/linked/new', store)).resolves.toBe(
+      resolve('/linked/new')
+    )
+  })
+
+  it('does not resurrect roots of a repo forgotten while a rebuild was awaiting git', async () => {
+    const release = parkFirstWorktreeListing()
+    vi.mocked(listRepoWorktrees).mockResolvedValue([])
+    const repos = [repo]
+    const store = makeStore(repos)
+
+    const pending = ensureAuthorizedRootsCache(store)
+    // The repo is forgotten while the first listing is still in flight.
+    repos.length = 0
+    invalidateAuthorizedRootsCache()
+    release([linkedWorktree('/linked/old')])
+    await pending
+    await ensureAuthorizedRootsCache(store)
+
+    expect(isRegisteredWorktreePath('/repos/app')).toBe(false)
+    expect(isRegisteredWorktreePath('/linked/old')).toBe(false)
+  })
+})

--- a/src/main/ipc/registered-worktree-roots-cache.ts
+++ b/src/main/ipc/registered-worktree-roots-cache.ts
@@ -9,9 +9,14 @@ const registeredWorktreeRootsByRepo = new Map<string, Set<string>>()
 const registeredWorktreeRootRepoIds = new Set<string>()
 let registeredWorktreeRootsDirty = true
 let registeredWorktreeRootsRefresh: Promise<void> | null = null
+// Why: a rebuild snapshots repos, then awaits `git worktree list`. A mutation landing during that
+// await outdates the snapshot; the generation lets the rebuild detect it and discard its result
+// instead of overwriting the fresher state and clearing the dirty flag it did not earn.
+let registeredWorktreeRootsGeneration = 0
 const AUTHORIZED_ROOTS_REBUILD_CONCURRENCY = 8
 
 export function invalidateAuthorizedRootsCache(): void {
+  registeredWorktreeRootsGeneration += 1
   registeredWorktreeRootsDirty = true
   // Why: dirty roots can't be trusted for auth short-circuits; fresh worktrees:list seeds safe per-repo roots before a full rebuild.
   registeredWorktreeRoots.clear()
@@ -22,6 +27,7 @@ export function invalidateAuthorizedRootsCache(): void {
 export async function rebuildAuthorizedRootsCache(store: Store): Promise<void> {
   // Why: bounded parallelism keeps the Windows speedup without one git process per repo.
   // Why no realpath here: canonicalizing every root on invalidation would trigger macOS TCC prompts; handlers still canonicalize the target before any operation.
+  const generation = registeredWorktreeRootsGeneration
   const repos = getLocalRepos(store)
   const perProjectResults = await mapWithConcurrency(
     repos,
@@ -41,6 +47,13 @@ export async function rebuildAuthorizedRootsCache(store: Store): Promise<void> {
       return { repoId: repo.id, roots }
     }
   )
+
+  // Why: an invalidation or per-repo seed landed while git was listing, so this snapshot predates
+  // the current state. Writing it would resurrect removed roots (or drop a just-created worktree)
+  // and mark the cache clean; leave the fresher state and dirty flag alone instead.
+  if (generation !== registeredWorktreeRootsGeneration) {
+    return
+  }
 
   registeredWorktreeRoots.clear()
   registeredWorktreeRootsByRepo.clear()
@@ -82,6 +95,9 @@ export function registerWorktreeRootsForRepo(
   repoId: string,
   worktreeRoots: string[]
 ): void {
+  // Why: this seed rewrites per-repo roots from a fresh worktrees:list; an in-flight rebuild's
+  // older git listing must not clobber it.
+  registeredWorktreeRootsGeneration += 1
   const localRepoIds = new Set(getLocalRepos(store).map((repo) => repo.id))
   for (const registeredRepoId of registeredWorktreeRootsByRepo.keys()) {
     if (!localRepoIds.has(registeredRepoId)) {
@@ -103,15 +119,16 @@ export function registerWorktreeRootsForRepo(
 }
 
 export async function ensureAuthorizedRootsCache(store: Store): Promise<void> {
-  if (!registeredWorktreeRootsDirty) {
-    return
+  // Why a loop: the joined refresh may have started before this caller's invalidation, in which
+  // case it discards its stale result and leaves the cache dirty — rebuild again until clean.
+  while (registeredWorktreeRootsDirty) {
+    if (!registeredWorktreeRootsRefresh) {
+      registeredWorktreeRootsRefresh = rebuildAuthorizedRootsCache(store).finally(() => {
+        registeredWorktreeRootsRefresh = null
+      })
+    }
+    await registeredWorktreeRootsRefresh
   }
-  if (!registeredWorktreeRootsRefresh) {
-    registeredWorktreeRootsRefresh = rebuildAuthorizedRootsCache(store).finally(() => {
-      registeredWorktreeRootsRefresh = null
-    })
-  }
-  await registeredWorktreeRootsRefresh
 }
 
 /**


### PR DESCRIPTION
## ELI5

Orca keeps a little allow-list of folders that File Explorer and Quick Open may touch. When that list is being recomputed (it asks git, which takes a moment) and you create or remove a workspace in that moment, the recompute finishes with an outdated answer, stamps it "fresh", and Orca either refuses to open your brand-new workspace ("Access denied") or keeps trusting folders you just removed.

## What Changed

- `registered-worktree-roots-cache.ts`: added a module-level generation counter. `invalidateAuthorizedRootsCache()` and the per-repo seed `registerWorktreeRootsForRepo()` bump it; `rebuildAuthorizedRootsCache()` captures it before awaiting `git worktree list` and discards its result if it changed — leaving the fresher state and the dirty flag alone. `ensureAuthorizedRootsCache()` now loops while dirty, so a caller that joined a rebuild older than its own invalidation gets a fresh rebuild instead of a stale "clean".
- New `registered-worktree-roots-cache.test.ts`: two deterministic interleaving tests (parked `listRepoWorktrees`, mutation mid-flight). Both fail on main — `Access denied: unknown repository or worktree path` for the created worktree; resurrected roots for the forgotten repo — and pass with the fix.

## Why

The dirty flag was cleared by whichever rebuild finished last, not by the rebuild that observed the latest state. Every worktree create/remove and repo add/forget invalidates this cache while `filesystem-auth` rebuilds it on any denied read, so the window is hit in normal use; the removal direction re-authorizes forgotten paths, which `worktrees-forget-local.test.ts` exists to prevent.

## Linked Issue

Fixes #15667

## Visual Proof

N/A — main-process auth-cache timing fix; no UI or interaction change.

## Testing

- [x] Automated tests added: `npx vitest run --config config/vitest.config.ts src/main/ipc/registered-worktree-roots-cache.test.ts` (2 pass with fix; both fail on main with the exact symptoms above)
- [x] `npx vitest run --config config/vitest.config.ts src/main/ipc` — 3084 passed / 11 skipped, incl. `filesystem-auth.test.ts` and `worktrees-forget-local.test.ts`; also green: `src/main/persistence`, `src/relay`, `src/shared`, `src/main/runtime/orchestration`, `src/main/git`
- [x] `oxlint` (exit 0), `oxfmt --check` clean, `typecheck:tsc:node`/`cli`/`web` all pass
- [ ] `pnpm build` — not run locally (Electron packaging); pure-TS main-process change, no native or build config touched — flagging for CI
- [ ] Manually tested locally: the window is a race; the deterministic vitest interleavings stand in for manual timing

## AI Disclosure

Found and fixed with Claude Code (model: Fable 5). Root-caused by hand from the module source; regression tests written against the existing `filesystem-auth.test.ts` mock harness. AI code-review summary: the generation is captured before the only `await`; both map writers bump it; the discarded path leaves dirty exactly as the invalidator set it; the `ensure` loop terminates because each iteration either observes `dirty === false` or runs a rebuild whose write is only skipped when a newer mutation occurred. Cross-platform: pure TS state logic, no paths/shells/platform APIs; widest race window is Windows (slowest `git worktree list`), which benefits most. SSH/remote: cache only holds local roots (`getLocalRepos` filters `connectionId`); remote flows unaffected. Security: fail-closed direction improved — removed roots can no longer be resurrected into the auth allow-list.

## Agent skill upstream boundary

- [x] Not applicable

## Checklist

- [x] Small and focused / ELI5 included / self-reviewed / cross-platform+SSH considered / lint+typecheck+tests pass locally (build via CI)