### PR TITLE
fix(skills): surface stdin stall on inline skill install

### DIFF
--- a/src/renderer/src/components/feature-tips/CliSkillSetupTerminal.tsx
+++ b/src/renderer/src/components/feature-tips/CliSkillSetupTerminal.tsx
@@ -3,6 +3,8 @@ import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { OnboardingInlineCommandTerminal } from '@/components/onboarding/OnboardingInlineCommandTerminal'
+import { InlineSetupTerminalStallNotice } from '@/components/onboarding/InlineSetupTerminalStallNotice'
+import { useInlineSetupTerminalStall } from '@/components/onboarding/use-inline-setup-terminal-stall'
 import {
   buildSkillCommandForRuntime,
   buildSkillSetupTerminalCommand
@@ -13,6 +15,7 @@ import { translate } from '@/i18n/i18n'
 
 export function CliSkillSetupTerminal(): React.JSX.Element {
   const activeSkillRuntime = useActiveProjectSkillRuntime()
+  const setupStalled = useInlineSetupTerminalStall(true)
   // Why: a repair-required runtime resolves to a WSL distro that is missing, so
   // drop back to the host runtime. This terminal auto-pastes with no install
   // gate, and repair-required only happens on Windows, so it still needs the
@@ -76,6 +79,7 @@ export function CliSkillSetupTerminal(): React.JSX.Element {
           </TooltipContent>
         </Tooltip>
       </div>
+      <InlineSetupTerminalStallNotice stalled={setupStalled} />
       <OnboardingInlineCommandTerminal
         command={skillCommand}
         prepareCommandForShell={prepareCommandForShell}
@@ -89,7 +93,7 @@ export function CliSkillSetupTerminal(): React.JSX.Element {
         )}
         description={translate(
           'auto.components.feature.tips.CliSkillSetupTerminal.1953e90447',
-          'Press Enter to install the Orca CLI orchestration skill for your agents.'
+          'Press Enter to install, then answer the prompts for which agents to install into and whether to symlink or copy.'
         )}
         terminalHeightPx={280}
         terminalTopMarginPx={8}

--- a/src/renderer/src/components/onboarding/FeatureSetupInlineTerminal.test.tsx
+++ b/src/renderer/src/components/onboarding/FeatureSetupInlineTerminal.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
 import { FeatureSetupInlineTerminal } from './FeatureSetupInlineTerminal'
 
 const mocks = vi.hoisted(() => ({
@@ -59,6 +59,10 @@ describe('FeatureSetupInlineTerminal', () => {
     mocks.terminalProps = null
     mocks.buildCommand.mockClear()
     mocks.buildSetupCommand.mockClear()
+  })
+
+  afterEach(() => {
+    cleanup()
   })
 
   it('runs the command through the resolved WSL runtime', () => {

--- a/src/renderer/src/components/onboarding/FeatureSetupInlineTerminal.tsx
+++ b/src/renderer/src/components/onboarding/FeatureSetupInlineTerminal.tsx
@@ -7,6 +7,8 @@ import {
   buildSkillSetupTerminalCommand
 } from '../settings/CliSkillRuntimeSetup'
 import { OnboardingInlineCommandTerminal } from './OnboardingInlineCommandTerminal'
+import { InlineSetupTerminalStallNotice } from './InlineSetupTerminalStallNotice'
+import { useInlineSetupTerminalStall } from './use-inline-setup-terminal-stall'
 import {
   getOnboardingFeatureSetupAgentRuntime,
   type OnboardingFeatureSetupRuntimeContext
@@ -30,6 +32,7 @@ export function FeatureSetupInlineTerminal({
 }: FeatureSetupInlineTerminalProps): React.JSX.Element {
   const terminalOpenedTrackedRef = useRef(false)
   const terminalInteractedTrackedRef = useRef(false)
+  const setupStalled = useInlineSetupTerminalStall(true)
   const activeSkillRuntime = useActiveProjectSkillRuntime()
   const setupRuntime = runtimeContext ?? activeSkillRuntime
   const agentRuntime = getOnboardingFeatureSetupAgentRuntime(setupRuntime)
@@ -75,29 +78,32 @@ export function FeatureSetupInlineTerminal({
   )
 
   return (
-    <OnboardingInlineCommandTerminal
-      command={copiedCommand}
-      prepareCommandForShell={prepareCommandForShell}
-      shellOverride={setupRuntime.terminalShellOverride}
-      forceHostRuntime={Boolean(setupRuntime.installDisabledReason)}
-      title={translate(
-        'auto.components.onboarding.FeatureSetupInlineTerminal.c767ab7061',
-        'Skill setup'
-      )}
-      ariaLabel={translate(
-        'auto.components.onboarding.FeatureSetupInlineTerminal.47fc6cc6dc',
-        'Skill setup command'
-      )}
-      description={translate(
-        'auto.components.onboarding.FeatureSetupInlineTerminal.789b59936e',
-        'Press Enter to run the command and confirm npx if asked. You can also set this up later in Settings.'
-      )}
-      terminalHeightPx={180}
-      terminalTopMarginPx={16}
-      autoScrollIntoView={false}
-      onOpened={trackTerminalOpened}
-      onInteracted={trackTerminalInteraction}
-      onTerminalExit={notifyInstalledAgentSkillsChanged}
-    />
+    <>
+      <InlineSetupTerminalStallNotice stalled={setupStalled} />
+      <OnboardingInlineCommandTerminal
+        command={copiedCommand}
+        prepareCommandForShell={prepareCommandForShell}
+        shellOverride={setupRuntime.terminalShellOverride}
+        forceHostRuntime={Boolean(setupRuntime.installDisabledReason)}
+        title={translate(
+          'auto.components.onboarding.FeatureSetupInlineTerminal.c767ab7061',
+          'Skill setup'
+        )}
+        ariaLabel={translate(
+          'auto.components.onboarding.FeatureSetupInlineTerminal.47fc6cc6dc',
+          'Skill setup command'
+        )}
+        description={translate(
+          'auto.components.onboarding.FeatureSetupInlineTerminal.789b59936e',
+          'Press Enter to run the command, then answer the install prompts. You can also set this up later in Settings.'
+        )}
+        terminalHeightPx={180}
+        terminalTopMarginPx={16}
+        autoScrollIntoView={false}
+        onOpened={trackTerminalOpened}
+        onInteracted={trackTerminalInteraction}
+        onTerminalExit={notifyInstalledAgentSkillsChanged}
+      />
+    </>
   )
 }

--- a/src/renderer/src/components/onboarding/InlineSetupTerminalStallNotice.tsx
+++ b/src/renderer/src/components/onboarding/InlineSetupTerminalStallNotice.tsx
@@ -1,0 +1,17 @@
+import { translate } from '@/i18n/i18n'
+
+export function InlineSetupTerminalStallNotice(props: {
+  stalled: boolean
+}): React.JSX.Element | null {
+  if (!props.stalled) {
+    return null
+  }
+  return (
+    <p className="mt-2 text-[12px] leading-snug text-amber-600 dark:text-amber-400">
+      {translate(
+        'auto.components.onboarding.InlineSetupTerminalStallNotice.body',
+        'The install is still running and may be waiting for input. Answer the prompts in the terminal — they choose which agents to install into and whether to symlink or copy. You can also copy the command and run it in your own terminal.'
+      )}
+    </p>
+  )
+}

--- a/src/renderer/src/components/onboarding/inline-setup-terminal-stall.ts
+++ b/src/renderer/src/components/onboarding/inline-setup-terminal-stall.ts
@@ -1,0 +1,3 @@
+// Why: skills add blocks on stdin without -y; bound the wait so Settings cannot
+// look identical to "Not installed" while the PTY sleeps forever.
+export const INLINE_SETUP_TERMINAL_STALL_TIMEOUT_MS = 45_000

--- a/src/renderer/src/components/onboarding/use-inline-setup-terminal-stall.ts
+++ b/src/renderer/src/components/onboarding/use-inline-setup-terminal-stall.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react'
+import { INLINE_SETUP_TERMINAL_STALL_TIMEOUT_MS } from './inline-setup-terminal-stall'
+
+export function useInlineSetupTerminalStall(active: boolean): boolean {
+  const [stalled, setStalled] = useState(false)
+
+  useEffect(() => {
+    if (!active) {
+      setStalled(false)
+      return
+    }
+    const timer = window.setTimeout(() => setStalled(true), INLINE_SETUP_TERMINAL_STALL_TIMEOUT_MS)
+    return () => window.clearTimeout(timer)
+  }, [active])
+
+  return stalled
+}

--- a/src/renderer/src/components/settings/AgentSkillSetupPanel.stall.test.tsx
+++ b/src/renderer/src/components/settings/AgentSkillSetupPanel.stall.test.tsx
@@ -1,0 +1,203 @@
+// @vitest-environment happy-dom
+
+import { act, useState, type ComponentProps } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AgentSkillSetupPanel } from './AgentSkillSetupPanel'
+import { INLINE_SETUP_TERMINAL_STALL_TIMEOUT_MS } from '../onboarding/inline-setup-terminal-stall'
+import { TooltipProvider } from '../ui/tooltip'
+
+const INSTALL_COMMAND = 'npx skills add https://github.com/stablyai/orca --skill orca-cli --global'
+
+const mocks = vi.hoisted(() => ({
+  terminalProps: [] as {
+    command: string
+    onTerminalExit?: () => void
+    onCommandFinished?: (bestEffortExitCode: number | null) => void
+  }[]
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() }
+}))
+
+vi.mock('@/hooks/useInstalledAgentSkills', () => ({
+  notifyInstalledAgentSkillsChanged: vi.fn(),
+  notifyInstalledAgentSkillsRefreshed: vi.fn()
+}))
+
+vi.mock('@/hooks/useSkillFreshness', () => ({
+  refreshSkillFreshness: vi.fn()
+}))
+
+vi.mock('../onboarding/OnboardingInlineCommandTerminal', () => ({
+  OnboardingInlineCommandTerminal: (props: {
+    command: string
+    onTerminalExit?: () => void
+    onCommandFinished?: (bestEffortExitCode: number | null) => void
+  }) => {
+    const [instance] = useState(() => mocks.terminalProps.push(props))
+    return (
+      <div data-testid="inline-command-terminal" data-instance={instance}>
+        {props.command}
+      </div>
+    )
+  }
+}))
+
+function panelProps(
+  overrides: Partial<ComponentProps<typeof AgentSkillSetupPanel>> = {}
+): ComponentProps<typeof AgentSkillSetupPanel> {
+  return {
+    title: 'CLI skill',
+    description: 'Enables agents to use Orca workflows.',
+    command: INSTALL_COMMAND,
+    terminalTitle: 'CLI skill setup',
+    terminalAriaLabel: 'CLI skill install terminal',
+    terminalWorktreeId: 'settings-cli-skill-terminal',
+    installed: false,
+    loading: false,
+    error: null,
+    onRecheck: vi.fn(),
+    ...overrides
+  }
+}
+
+let root: Root | null = null
+let container: HTMLDivElement | null = null
+
+async function renderInteractivePanel(
+  overrides: Partial<ComponentProps<typeof AgentSkillSetupPanel>> = {}
+): Promise<HTMLDivElement> {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  await act(async () => {
+    root?.render(
+      <TooltipProvider>
+        <AgentSkillSetupPanel {...panelProps(overrides)} />
+      </TooltipProvider>
+    )
+  })
+  await act(async () => {})
+  return container
+}
+
+function findButton(label: string): HTMLButtonElement {
+  const button = Array.from((container ?? document.body).querySelectorAll('button')).find(
+    (candidate) => candidate.textContent?.trim() === label
+  )
+  expect(button).toBeDefined()
+  return button as HTMLButtonElement
+}
+
+async function clickButton(label: string): Promise<void> {
+  await act(async () => {
+    findButton(label).dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+  await act(async () => {})
+}
+
+describe('AgentSkillSetupPanel stdin stall', () => {
+  beforeEach(() => {
+    mocks.terminalProps.length = 0
+    vi.useFakeTimers()
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: {
+        cli: { getInstallStatus: vi.fn() },
+        ui: { writeClipboardText: vi.fn() },
+        platform: { get: () => ({ platform: 'linux' }) }
+      }
+    })
+  })
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root?.unmount()
+      })
+    }
+    root = null
+    container?.remove()
+    container = null
+    Reflect.deleteProperty(window, 'api')
+    vi.useRealTimers()
+  })
+
+  it('does not launch the install command with -y', async () => {
+    await renderInteractivePanel()
+    await clickButton('Install')
+
+    expect(mocks.terminalProps.at(-1)?.command).toBe(INSTALL_COMMAND)
+    expect(mocks.terminalProps.at(-1)?.command).not.toContain('-y')
+    expect(container?.textContent).toContain(INSTALL_COMMAND)
+  })
+
+  it('marks the row as in progress instead of silent Not installed', async () => {
+    await renderInteractivePanel()
+    await clickButton('Install')
+
+    expect(container?.textContent).toContain('Installing...')
+    expect(container?.textContent).not.toContain('Not installed')
+    expect(container?.textContent).not.toMatch(/Waiting for input/)
+  })
+
+  it('surfaces a stdin stall instead of hanging on Not installed', async () => {
+    await renderInteractivePanel()
+    await clickButton('Install')
+
+    await act(async () => {
+      vi.advanceTimersByTime(INLINE_SETUP_TERMINAL_STALL_TIMEOUT_MS)
+    })
+
+    expect(container?.textContent).toContain('Waiting for input')
+    expect(container?.textContent).not.toContain('Not installed')
+    expect(container?.textContent).toContain(
+      'The install is still running and may be waiting for input.'
+    )
+    expect(container?.textContent).toContain(
+      'Answer the prompts in the terminal — they choose which agents to install into and whether to symlink or copy.'
+    )
+    expect(container?.textContent).toContain(
+      'You can also copy the command and run it in your own terminal.'
+    )
+    expect(container?.querySelector('[data-testid="inline-command-terminal"]')).not.toBeNull()
+    expect(findButton('Cancel').disabled).toBe(false)
+  })
+
+  it('flips the row to installed after a successful command', async () => {
+    const onRecheck = vi.fn()
+    await renderInteractivePanel({ onRecheck })
+    await clickButton('Install')
+
+    await act(async () => {
+      mocks.terminalProps.at(-1)?.onCommandFinished?.(0)
+    })
+    await act(async () => {
+      root?.render(
+        <TooltipProvider>
+          <AgentSkillSetupPanel {...panelProps({ installed: true, onRecheck })} />
+        </TooltipProvider>
+      )
+    })
+
+    expect(container?.textContent).toContain('Installed')
+    expect(container?.textContent).not.toContain('Waiting for input')
+    expect(onRecheck).toHaveBeenCalledOnce()
+  })
+
+  it('clears the stall when the user cancels the hung terminal', async () => {
+    await renderInteractivePanel()
+    await clickButton('Install')
+    await act(async () => {
+      vi.advanceTimersByTime(INLINE_SETUP_TERMINAL_STALL_TIMEOUT_MS)
+    })
+
+    await clickButton('Cancel')
+
+    expect(container?.querySelector('[data-testid="inline-command-terminal"]')).toBeNull()
+    expect(container?.textContent).not.toContain('Waiting for input')
+    expect(container?.textContent).toContain('Not installed')
+  })
+})

--- a/src/renderer/src/components/settings/AgentSkillSetupPanel.test.tsx
+++ b/src/renderer/src/components/settings/AgentSkillSetupPanel.test.tsx
@@ -354,7 +354,8 @@ describe('AgentSkillSetupPanel', () => {
     expect(container?.textContent).toContain(INSTALL_COMMAND)
     expect(mocks.terminalProps.at(-1)).toMatchObject({
       command: INSTALL_COMMAND,
-      description: 'Press Enter to run the command.'
+      description:
+        'Press Enter to run the command, then answer the install prompts in this terminal.'
     })
 
     await act(async () => {

--- a/src/renderer/src/components/settings/AgentSkillSetupPanel.tsx
+++ b/src/renderer/src/components/settings/AgentSkillSetupPanel.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Copy, Loader2, RefreshCw, Terminal } from 'lucide-react'
 import { toast } from 'sonner'
-import { IntegrationStatusPill } from '../integration-status-pill'
-import { SkillFreshnessStatusPill } from '../skills/SkillFreshnessStatusPill'
 import { OnboardingInlineCommandTerminal } from '../onboarding/OnboardingInlineCommandTerminal'
+import { InlineSetupTerminalStallNotice } from '../onboarding/InlineSetupTerminalStallNotice'
+import { useInlineSetupTerminalStall } from '../onboarding/use-inline-setup-terminal-stall'
 import { AgentSkillSetupFailureNotice } from './AgentSkillSetupFailureNotice'
+import { AgentSkillSetupPresenceStatus } from './AgentSkillSetupPresenceStatus'
 import { createTerminalSnapshot, type SkillTerminalSnapshot } from './agent-skill-terminal-snapshot'
 import type { AgentSkillSetupPanelProps } from './agent-skill-setup-panel-props'
 import { Button } from '../ui/button'
@@ -66,6 +67,7 @@ export function AgentSkillSetupPanel({
   const [setupAttemptRunning, setSetupAttemptRunning] = useState(false)
   const [setupCommandFailedCode, setSetupCommandFailedCode] = useState<number | null>(null)
   const setupAttemptRunningRef = useRef(false)
+  const setupStalled = useInlineSetupTerminalStall(setupAttemptRunning)
   const [preInstallNoticeVisible, setPreInstallNoticeVisible] = useState(
     Boolean(preInstallNotice && !installed)
   )
@@ -249,6 +251,17 @@ export function AgentSkillSetupPanel({
             : translate('auto.components.settings.AgentSkillSetupPanel.c689392435', 'Re-check')}
         </Button>
       ) : null}
+      {terminalOpen ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={handleTerminalExit}
+          disabled={terminalOpening}
+        >
+          {translate('auto.components.settings.AgentSkillSetupPanel.cancelSetup', 'Cancel')}
+        </Button>
+      ) : null}
       {terminalOpening ? (
         <p className="basis-full text-[12px] leading-snug text-muted-foreground">
           {openingHint ??
@@ -275,10 +288,20 @@ export function AgentSkillSetupPanel({
         {hideHeader ? (
           <>
             {error ? <p className="text-[12px] text-destructive">{error}</p> : null}
-            {/* hideHeader drops the title row; keep freshness so guided hubs still surface updates. */}
-            {installed && freshnessSkillName && setupCommandFailedCode === null ? (
+            {/* hideHeader drops the title row; keep presence/freshness so guided hubs still surface updates. */}
+            {setupCommandFailedCode !== null ||
+            setupStalled ||
+            setupAttemptRunning ||
+            (installed && freshnessSkillName) ? (
               <div className="mb-2">
-                <SkillFreshnessStatusPill skillName={freshnessSkillName} />
+                <AgentSkillSetupPresenceStatus
+                  setupFailed={setupCommandFailedCode !== null}
+                  stalled={setupStalled}
+                  installing={setupAttemptRunning}
+                  loading={loading}
+                  installed={installed}
+                  freshnessSkillName={freshnessSkillName}
+                />
               </div>
             ) : null}
           </>
@@ -293,39 +316,14 @@ export function AgentSkillSetupPanel({
             <div className="min-w-0 flex-1 self-center">
               <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
                 <h3 className="text-[15px] font-semibold leading-tight text-foreground">{title}</h3>
-                {setupCommandFailedCode !== null ? (
-                  <IntegrationStatusPill tone="attention">
-                    {translate(
-                      'auto.components.settings.AgentSkillSetupPanel.setupFailed',
-                      'Setup failed'
-                    )}
-                  </IntegrationStatusPill>
-                ) : loading && !installed ? (
-                  <IntegrationStatusPill tone="neutral">
-                    {translate(
-                      'auto.components.settings.AgentSkillSetupPanel.68a468752e',
-                      'Checking...'
-                    )}
-                  </IntegrationStatusPill>
-                ) : installed ? (
-                  freshnessSkillName ? (
-                    <SkillFreshnessStatusPill skillName={freshnessSkillName} />
-                  ) : (
-                    <IntegrationStatusPill tone="connected">
-                      {translate(
-                        'auto.components.settings.AgentSkillSetupPanel.9fcebceb2a',
-                        'Installed'
-                      )}
-                    </IntegrationStatusPill>
-                  )
-                ) : (
-                  <IntegrationStatusPill tone="attention">
-                    {translate(
-                      'auto.components.settings.AgentSkillSetupPanel.5289300939',
-                      'Not installed'
-                    )}
-                  </IntegrationStatusPill>
-                )}
+                <AgentSkillSetupPresenceStatus
+                  setupFailed={setupCommandFailedCode !== null}
+                  stalled={setupStalled}
+                  installing={setupAttemptRunning}
+                  loading={loading}
+                  installed={installed}
+                  freshnessSkillName={freshnessSkillName}
+                />
               </div>
               {error ? <p className="mt-1 text-[12px] text-destructive">{error}</p> : null}
             </div>
@@ -337,6 +335,7 @@ export function AgentSkillSetupPanel({
           ) : null}
           {actionRow}
           <AgentSkillSetupFailureNotice exitCode={setupCommandFailedCode} />
+          <InlineSetupTerminalStallNotice stalled={setupStalled} />
           {actionHint ? <div className="mt-2">{actionHint}</div> : null}
           {!installed && preInstallNotice && preInstallNoticeVisible ? (
             <p className="mt-3 text-[12px] leading-snug text-muted-foreground">
@@ -395,14 +394,14 @@ export function AgentSkillSetupPanel({
             title={terminalTitle}
             description={translate(
               'auto.components.settings.AgentSkillSetupPanel.runCommandDescription',
-              'Press Enter to run the command.'
+              'Press Enter to run the command, then answer the install prompts in this terminal.'
             )}
             ariaLabel={terminalAriaLabel}
             terminalHeightPx={terminalHeightPx}
             shellOverride={terminalSnapshot.shellOverride}
             terminalTopMarginPx={8}
             descriptionPaddingClassName="px-4 py-2"
-            autoScrollIntoView={false}
+            autoScrollIntoView
             onTerminalExit={handleTerminalExit}
             onCommandFinished={handleSetupCommandFinished}
           />

--- a/src/renderer/src/components/settings/AgentSkillSetupPresenceStatus.tsx
+++ b/src/renderer/src/components/settings/AgentSkillSetupPresenceStatus.tsx
@@ -1,0 +1,58 @@
+import { IntegrationStatusPill } from '../integration-status-pill'
+import { SkillFreshnessStatusPill } from '../skills/SkillFreshnessStatusPill'
+import { translate } from '@/i18n/i18n'
+
+export function AgentSkillSetupPresenceStatus(props: {
+  setupFailed: boolean
+  stalled: boolean
+  installing: boolean
+  loading: boolean
+  installed: boolean
+  freshnessSkillName?: string
+}): React.JSX.Element {
+  if (props.setupFailed) {
+    return (
+      <IntegrationStatusPill tone="attention">
+        {translate('auto.components.settings.AgentSkillSetupPanel.setupFailed', 'Setup failed')}
+      </IntegrationStatusPill>
+    )
+  }
+  if (props.stalled) {
+    return (
+      <IntegrationStatusPill tone="attention">
+        {translate(
+          'auto.components.settings.AgentSkillSetupPanel.waitingForInput',
+          'Waiting for input'
+        )}
+      </IntegrationStatusPill>
+    )
+  }
+  if (props.installing) {
+    return (
+      <IntegrationStatusPill tone="neutral">
+        {translate('auto.components.settings.AgentSkillSetupPanel.installing', 'Installing...')}
+      </IntegrationStatusPill>
+    )
+  }
+  if (props.loading && !props.installed) {
+    return (
+      <IntegrationStatusPill tone="neutral">
+        {translate('auto.components.settings.AgentSkillSetupPanel.68a468752e', 'Checking...')}
+      </IntegrationStatusPill>
+    )
+  }
+  if (props.installed) {
+    return props.freshnessSkillName ? (
+      <SkillFreshnessStatusPill skillName={props.freshnessSkillName} />
+    ) : (
+      <IntegrationStatusPill tone="connected">
+        {translate('auto.components.settings.AgentSkillSetupPanel.9fcebceb2a', 'Installed')}
+      </IntegrationStatusPill>
+    )
+  }
+  return (
+    <IntegrationStatusPill tone="attention">
+      {translate('auto.components.settings.AgentSkillSetupPanel.5289300939', 'Not installed')}
+    </IntegrationStatusPill>
+  )
+}

--- a/src/renderer/src/components/settings/CliSection.test.tsx
+++ b/src/renderer/src/components/settings/CliSection.test.tsx
@@ -141,7 +141,9 @@ describe('CliSection project runtime defaults', () => {
       })
     )
     expect(capturedPanel.props?.command).toBe(ORCA_CLI_SKILL_INSTALL_COMMAND)
+    expect(capturedPanel.props?.command).not.toContain('-y')
     expect(capturedPanel.props?.installedCommand).toBe(ORCA_CLI_SKILL_UPDATE_COMMAND)
+    expect(capturedPanel.props?.installedCommand).not.toContain('-y')
     expect(capturedPanel.props?.terminalRuntime).toEqual({
       runtime: 'wsl',
       wslDistro: 'Ubuntu',

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6170,7 +6170,7 @@
           "f97b986b7f": "wsl"
         },
         "AgentSkillSetupPanel": {
-          "0b810ec59f": "Press Enter to run the command.",
+          "0b810ec59f": "Press Enter to run the command, then answer the install prompts in this terminal.",
           "ed197f59a2": "Copy command",
           "817d3f9f18": "Copy command",
           "5289300939": "Not installed",
@@ -6182,14 +6182,17 @@
           "copiedCommand": "Copied command.",
           "failedToCopyCommand": "Failed to copy command.",
           "copyCommandAria": "Copy command",
-          "runCommandDescription": "Press Enter to run the command.",
+          "runCommandDescription": "Press Enter to run the command, then answer the install prompts in this terminal.",
           "5f818f12ab": "Preparing...",
           "4c05b9d7cb": "Preparing setup terminal.",
           "installLabel": "Install",
           "updateLabel": "Update",
           "setupCommandFailed": "The setup command exited with code {{value0}}. This error will clear after a successful retry.",
           "setupFailed": "Setup failed",
-          "retrySetup": "Retry"
+          "retrySetup": "Retry",
+          "cancelSetup": "Cancel",
+          "waitingForInput": "Waiting for input",
+          "installing": "Installing..."
         },
         "AgentsPane": {
           "d83834f5e6": "Detecting installed agents…",
@@ -12840,7 +12843,7 @@
           "yoloPermissionsTooltip": "Skip permission checks for agents for less interruptions"
         },
         "FeatureSetupInlineTerminal": {
-          "789b59936e": "Press Enter to run the command and confirm npx if asked. You can also set this up later in Settings.",
+          "789b59936e": "Press Enter to run the command, then answer the install prompts. You can also set this up later in Settings.",
           "47fc6cc6dc": "Skill setup command",
           "c767ab7061": "Skill setup"
         },
@@ -12991,6 +12994,9 @@
               }
             }
           }
+        },
+        "InlineSetupTerminalStallNotice": {
+          "body": "The install is still running and may be waiting for input. Answer the prompts in the terminal — they choose which agents to install into and whether to symlink or copy. You can also copy the command and run it in your own terminal."
         }
       },
       "new": {
@@ -13769,7 +13775,7 @@
             "22e62f3bab": "Claude Code session started"
           },
           "CliSkillSetupTerminal": {
-            "1953e90447": "Press Enter to install the Orca CLI orchestration skill for your agents.",
+            "1953e90447": "Press Enter to install, then answer the prompts for which agents to install into and whether to symlink or copy.",
             "43b60ec5c3": "Orca CLI and orchestration skill install terminal",
             "84e9576dac": "Skill setup",
             "5c3aee22c0": "Copy command",


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​213 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​210 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​180 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​70 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​110 |

<!-- /orca-pr-loc -->

## ELI5

Clicking Install for a CLI skill opens a small terminal that runs an interactive command. That command asks real questions (which agents, symlink vs copy). If nobody answers, it used to sit there forever while the row still said Not installed. Now the row shows that install is running, and if it is still waiting after 45 seconds it tells you to answer the prompts or copy the command into your own terminal. We did not add `-y`.

## What Changed

- Keep the Settings / onboarding skill install command interactive. It still has **no** `-y`.
- While the inline setup terminal is open, the row shows **Installing...** instead of silent **Not installed**.
- If the command has not finished after 45 seconds, the row becomes **Waiting for input** and an amber notice tells the user to answer the prompts (agents and symlink/copy) or copy the command and run it themselves.
- **Cancel** closes the hung setup terminal so the PTY does not leak.
- The terminal copy now says to answer the install prompts, and Settings scrolls the terminal into view.
- The same stall notice is shown on onboarding and feature-tip skill terminals (same hang class).

## Why

The hang is not "the CLI prompted." The hang is that Orca ran an interactive command in a surface that looked idle, then never timed out. Adding `-y` is the wrong fix: with zero detected agents it installs into every known agent home, and it silently picks symlink. Those prompts are genuine choices.

This is option 1 from the issue (make the inline terminal a real prompt surface) plus a bounded stall so a stdin block can never look identical to Not installed. It supersedes the approach in #13948, which routed Settings installs through unattended `-y` + `--agent`. Differences:

1. This PR does not add `-y` to any Settings/onboarding/feature-tip command.
2. This PR detects a blocked stdin install and surfaces it on the row.
3. This PR keeps the user in control of agent targets and install method.
4. Successful installs still flip the row to Installed via the existing re-check path.

## Linked Issue

Fixes #13542
STA-3815

## Visual Proof

N/A — no layout restyle. The change is status-pill and notice copy on an existing inline terminal. Those states are covered by `AgentSkillSetupPanel.stall.test.tsx` (Installing..., Waiting for input, Installed, Cancel). A live `npx skills add` click-through was not run here because it would mutate the host skill install and wait on real prompts.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

HOUSE-RULES §4:

- Pre-fix: stall tests failed — row stayed **Not installed** after Install and after 45s; no Cancel.
- Post-fix: `AgentSkillSetupPanel.stall.test.tsx` 5/5 passed. Related panel/CliSection/command tests 54/54 passed.
- Neutered (`setupStalled = false`, tests kept): **surfaces a stdin stall** failed again — pill stayed Installing... with no Waiting for input. Hook restored.

Also: `pnpm typecheck` passed. oxlint + oxfmt on changed files only.

- [x] Command string has no `-y` (builder constant, CliSection caller, and the command the panel actually opens).

## AI Disclosure

<!-- internal -->

## Review

- Cross-platform: stall detection is renderer-side and applies to macOS, Linux, and Windows setup terminals. Windows/WSL command wrapping is unchanged.
- Remote/SSH: no RPC or stream opcode changes. Ephemeral setup terminals remain local/floating-scoped.
- Compatibility: shared install command stays interactive; no new wire fields.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @BrennanKB5