### PR TITLE
fix(browser): add a repeatable Google cookie clear (STA-4398)

### DIFF
--- a/src/main/browser/browser-cookie-import-clear.ts
+++ b/src/main/browser/browser-cookie-import-clear.ts
@@ -169,6 +169,33 @@ function groupRemovableCookies(
   return groups
 }
 
+export async function removePlannedCookieEntries(
+  targetSession: CookieClearSession,
+  removable: readonly { cookie: Cookie; url: string }[]
+): Promise<void> {
+  if (removable.length === 0) {
+    return
+  }
+  const identities = await targetSession.snapshotClearIdentities(removable)
+  assertClearIdentitiesCoverRemovable(removable, identities)
+  const removalGroups = [...groupRemovableCookies(removable).values()]
+  const results = await mapSettledWithConcurrency(
+    removalGroups,
+    COOKIE_CLEAR_CONCURRENCY,
+    async (group) => {
+      for (const { cookie, url } of group) {
+        await targetSession.cookies.remove(url, cookie.name)
+      }
+    }
+  )
+  const failures = results.flatMap((result) =>
+    result.status === 'rejected' ? [result.reason] : []
+  )
+  if (failures.length > 0) {
+    await restoreClearedCookies(targetSession, identities, failures)
+  }
+}
+
 async function restoreClearedCookies(
   targetSession: CookieClearSession,
   identities: readonly CookieClearIdentity[],
@@ -219,40 +246,10 @@ export async function removeTransplantableCookies(
     }
 
     const initialRemovable = removableCookieEntries(initialCookies, preserveFamilies, importScope)
-    if (initialRemovable.length === 0) {
-      return
-    }
-    const identities = await targetSession.snapshotClearIdentities(initialRemovable)
-    assertClearIdentitiesCoverRemovable(initialRemovable, identities)
-    // Why (STA-4170): fixing the removal plan here, beside the identities that can undo it, is what
-    // keeps the two sets equal. Re-reading the jar in the fallback widened the removal set past the
-    // restore set, so a cookie that arrived mid-clear — a login the user had just completed — was
-    // deleted with nothing able to put it back. Removing an already-deleted cookie is a harmless
-    // no-op, so the stale plan costs nothing; only its narrowness matters.
-    const removalGroups = [...groupRemovableCookies(initialRemovable).values()]
-
-    // Why (STA-4797): the bulk clearData shortcut is gone. It clears by exclusion, so the only
-    // scope it could express was "everything except google.com" — the defect itself. Narrowing it
-    // to an include list would not help either: clearData matches at the registrable-domain
-    // boundary, so it would still take host-only siblings this import does not replace, and a
-    // partial delete followed by a rejection would destroy them with no identity to restore from.
-    // The frozen per-coordinate plan is now the only path, and it is a small one — it covers the
-    // imported domains rather than the jar.
-    const results = await mapSettledWithConcurrency(
-      removalGroups,
-      COOKIE_CLEAR_CONCURRENCY,
-      async (group) => {
-        // Why: identical removal coordinates must stay ordered instead of racing.
-        for (const { cookie, url } of group) {
-          await store.remove(url, cookie.name)
-        }
-      }
-    )
-    const failures = results.flatMap((result) =>
-      result.status === 'rejected' ? [result.reason] : []
-    )
-    if (failures.length > 0) {
-      await restoreClearedCookies(targetSession, identities, failures)
-    }
+    // Why (STA-4170): the plan is frozen here, beside the identities that can undo it.
+    // Why (STA-4797): clearData is gone — it can only exclude, so the only scope it could
+    // express was "everything except google.com". The frozen per-coordinate plan is the
+    // only path, and it covers the imported domains rather than the jar.
+    await removePlannedCookieEntries(targetSession, initialRemovable)
   })
 }

--- a/src/main/browser/browser-google-cookie-clear.test.ts
+++ b/src/main/browser/browser-google-cookie-clear.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest'
+import type { Cookie } from 'electron'
+import {
+  identitiesFromClearCookies,
+  type CookieClearIdentity,
+  type CookieClearSession
+} from './browser-cookie-import-clear'
+import { cookieRemovalUrl, normalizeCookieDomain } from './browser-cookie-import-policy'
+import { removeNonTransplantableCookies } from './browser-google-cookie-clear'
+
+function cookie(domain: string, name: string, path = '/', secure = true): Cookie {
+  return {
+    domain,
+    name,
+    path,
+    secure,
+    sameSite: 'unspecified',
+    value: `${name}-value`
+  }
+}
+
+function createJarSession(initial: Cookie[]) {
+  let jar = [...initial]
+  const removed: { url: string; name: string }[] = []
+  const session: CookieClearSession & {
+    namesByDomain: () => string[]
+    removed: () => { url: string; name: string }[]
+    add: (entry: Cookie) => void
+  } = {
+    cookies: {
+      get: async () => [...jar],
+      remove: async (url, name) => {
+        removed.push({ url, name })
+        jar = jar.filter((entry) => {
+          const domain = entry.domain ? normalizeCookieDomain(entry.domain) : null
+          if (!domain) {
+            return true
+          }
+          return cookieRemovalUrl(entry, domain) !== url || entry.name !== name
+        })
+      }
+    },
+    snapshotClearIdentities: async (items) => identitiesFromClearCookies(items),
+    restoreClearIdentities: async (identities: readonly CookieClearIdentity[]) => {
+      for (const identity of identities) {
+        if (jar.some((entry) => entry.name === identity.name && entry.domain === identity.domain)) {
+          continue
+        }
+        jar.push(
+          cookie(identity.domain ?? '', identity.name, identity.path, identity.secure === true)
+        )
+      }
+    },
+    namesByDomain: () => jar.map((entry) => `${entry.domain}:${entry.name}`).sort(),
+    removed: () => [...removed],
+    add: (entry) => {
+      jar.push(entry)
+    }
+  }
+  return session
+}
+
+function seedMixedJar(): Cookie[] {
+  return [
+    cookie('.google.com', 'SID'),
+    cookie('accounts.google.com', '__Secure-1PSID'),
+    cookie('.mail.google.com', 'OSID'),
+    cookie('.example.com', 'session'),
+    cookie('.youtube.com', 'SID'),
+    cookie('github.com', 'user', '/', false),
+    cookie('google.com.evil.example', 'SID')
+  ]
+}
+
+describe('STA-4398 Google-family cookie clear', () => {
+  it('removes google.com-family cookies and leaves every other family intact', async () => {
+    const jar = createJarSession(seedMixedJar())
+
+    await removeNonTransplantableCookies(jar)
+
+    expect(jar.namesByDomain()).toEqual([
+      '.example.com:session',
+      '.youtube.com:SID',
+      'github.com:user',
+      'google.com.evil.example:SID'
+    ])
+  })
+
+  it('can clear Google cookies more than once after they return', async () => {
+    const jar = createJarSession(seedMixedJar())
+
+    await removeNonTransplantableCookies(jar)
+    expect(jar.namesByDomain()).not.toContain('.google.com:SID')
+
+    jar.add(cookie('.google.com', 'SID'))
+    jar.add(cookie('accounts.google.com', 'SAPISID'))
+    await removeNonTransplantableCookies(jar)
+
+    expect(jar.namesByDomain()).toEqual([
+      '.example.com:session',
+      '.youtube.com:SID',
+      'github.com:user',
+      'google.com.evil.example:SID'
+    ])
+  })
+
+  it('is a no-op success when the jar has no Google cookies', async () => {
+    const jar = createJarSession([cookie('.example.com', 'session'), cookie('.youtube.com', 'SID')])
+
+    await expect(removeNonTransplantableCookies(jar)).resolves.toBeUndefined()
+    expect(jar.namesByDomain()).toEqual(['.example.com:session', '.youtube.com:SID'])
+    expect(jar.removed()).toEqual([])
+  })
+})

--- a/src/main/browser/browser-google-cookie-clear.ts
+++ b/src/main/browser/browser-google-cookie-clear.ts
@@ -1,0 +1,67 @@
+import { session, type Cookie } from 'electron'
+import { openCookieClearStore } from './browser-cookie-clear-store'
+import {
+  removePlannedCookieEntries,
+  withCookieMutationLock,
+  type CookieClearSession
+} from './browser-cookie-import-clear'
+import {
+  cookieRemovalUrl,
+  isNonTransplantableCookieDomain,
+  normalizeCookieDomain
+} from './browser-cookie-import-policy'
+
+function nonTransplantableCookieEntries(
+  cookies: readonly Cookie[]
+): { cookie: Cookie; url: string }[] {
+  const removable: { cookie: Cookie; url: string }[] = []
+  for (const cookie of cookies) {
+    if (!isNonTransplantableCookieDomain(cookie.domain ?? '')) {
+      continue
+    }
+    const scopedDomain = cookie.domain ? normalizeCookieDomain(cookie.domain) : null
+    if (scopedDomain === null) {
+      continue
+    }
+    removable.push({ cookie, url: cookieRemovalUrl(cookie, scopedDomain) })
+  }
+  return removable
+}
+
+/**
+ * Removes only non-transplantable (currently Google-family) cookies.
+ *
+ * Why (STA-4398): imports neither write nor clear this family, so stale Google
+ * cookies have no other exit. The plan is an include-list of that family — never
+ * clearStorageData / a whole-jar wipe, which would sign the user out of every
+ * other site in the partition (STA-4797).
+ */
+export async function removeNonTransplantableCookies(
+  targetSession: CookieClearSession
+): Promise<void> {
+  return withCookieMutationLock(targetSession, async () => {
+    const cookies = await targetSession.cookies.get({})
+    await removePlannedCookieEntries(targetSession, nonTransplantableCookieEntries(cookies))
+  })
+}
+
+export async function clearGoogleCookiesForPartition(partition: string): Promise<boolean> {
+  try {
+    const targetSession = session.fromPartition(partition)
+    return await withCookieMutationLock(targetSession, async () => {
+      const store = openCookieClearStore(targetSession)
+      try {
+        await removeNonTransplantableCookies({
+          cookies: store,
+          snapshotClearIdentities: (cookies) => store.snapshotClearIdentities(cookies),
+          restoreClearIdentities: (identities) => store.restoreClearIdentities(identities)
+        })
+        return true
+      } finally {
+        store.dispose()
+      }
+    })
+  } catch {
+    return false
+  }
+}

--- a/src/main/browser/browser-session-registry.test.ts
+++ b/src/main/browser/browser-session-registry.test.ts
@@ -1,12 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { sessionFromPartitionMock, askForMediaAccessMock, getMediaAccessStatusMock } = vi.hoisted(
-  () => ({
-    sessionFromPartitionMock: vi.fn(),
-    askForMediaAccessMock: vi.fn(),
-    getMediaAccessStatusMock: vi.fn()
-  })
-)
+const {
+  sessionFromPartitionMock,
+  askForMediaAccessMock,
+  getMediaAccessStatusMock,
+  clearGoogleCookiesForPartitionMock
+} = vi.hoisted(() => ({
+  sessionFromPartitionMock: vi.fn(),
+  askForMediaAccessMock: vi.fn(),
+  getMediaAccessStatusMock: vi.fn(),
+  clearGoogleCookiesForPartitionMock: vi.fn()
+}))
 
 vi.mock('electron', () => ({
   session: {
@@ -27,6 +31,11 @@ vi.mock('./browser-manager', () => ({
   }
 }))
 
+vi.mock('./browser-google-cookie-clear', () => ({
+  clearGoogleCookiesForPartition: (...args: unknown[]) =>
+    clearGoogleCookiesForPartitionMock(...args)
+}))
+
 import { browserSessionRegistry } from './browser-session-registry'
 import { googleAuthUserAgent } from './browser-google-auth-ua'
 import { setupClientHintsOverride } from './browser-session-ua'
@@ -42,6 +51,8 @@ describe('BrowserSessionRegistry', () => {
     sessionFromPartitionMock.mockReset()
     askForMediaAccessMock.mockReset()
     getMediaAccessStatusMock.mockReset()
+    clearGoogleCookiesForPartitionMock.mockReset()
+    clearGoogleCookiesForPartitionMock.mockResolvedValue(true)
     askForMediaAccessMock.mockResolvedValue(true)
     getMediaAccessStatusMock.mockReturnValue('granted')
     sessionFromPartitionMock.mockReturnValue({
@@ -192,6 +203,24 @@ describe('BrowserSessionRegistry', () => {
     const deleted = await browserSessionRegistry.deleteProfile('default')
     expect(deleted).toBe(false)
     expect(browserSessionRegistry.getDefaultProfile()).not.toBeNull()
+  })
+
+  it('clears Google cookies on the default partition without wiping import source', async () => {
+    const sourced = browserSessionRegistry.updateProfileSource('default', {
+      browserFamily: 'chrome',
+      importedAt: 1
+    })
+    expect(sourced?.source).not.toBeNull()
+
+    const first = await browserSessionRegistry.clearDefaultGoogleCookies()
+    const second = await browserSessionRegistry.clearDefaultGoogleCookies()
+
+    expect(first).toBe(true)
+    expect(second).toBe(true)
+    expect(clearGoogleCookiesForPartitionMock).toHaveBeenCalledTimes(2)
+    expect(clearGoogleCookiesForPartitionMock).toHaveBeenCalledWith(ORCA_BROWSER_PARTITION)
+    expect(browserSessionRegistry.getDefaultProfile().source).not.toBeNull()
+    expect(sessionFromPartitionMock).not.toHaveBeenCalled()
   })
 
   it('hydrates profiles from persisted data', () => {

--- a/src/main/browser/browser-session-registry.ts
+++ b/src/main/browser/browser-session-registry.ts
@@ -30,6 +30,7 @@ import {
 } from './browser-session-partition-policies'
 import { isValidPersistedBrowserSessionProfile } from './browser-session-persisted-profile-validation'
 import { clearBrowserSessionUserAgentMode } from './browser-session-user-agent-mode'
+import { clearGoogleCookiesForPartition } from './browser-google-cookie-clear'
 
 export type BrowserSessionRegistryProfileOptions = {
   orcaProfileId: string
@@ -278,6 +279,11 @@ class BrowserSessionRegistry {
     } catch {
       return false
     }
+  }
+
+  // Why (STA-4398): import neither writes nor clears this family; source metadata stays.
+  async clearDefaultGoogleCookies(): Promise<boolean> {
+    return clearGoogleCookiesForPartition(this.defaultPartition)
   }
 
   hydrateFromPersisted(profiles: BrowserSessionProfile[]): void {

--- a/src/main/ipc/browser-session-profile-ipc.ts
+++ b/src/main/ipc/browser-session-profile-ipc.ts
@@ -97,12 +97,20 @@ export function registerBrowserSessionProfileHandlers(): void {
   )
 
   ipcMain.removeHandler('browser:session:clearDefaultCookies')
+  ipcMain.removeHandler('browser:session:clearDefaultGoogleCookies')
 
   ipcMain.handle('browser:session:clearDefaultCookies', async (event): Promise<boolean> => {
     if (!isTrustedBrowserRenderer(event.sender)) {
       return false
     }
     return browserSessionRegistry.clearDefaultSessionCookies()
+  })
+
+  ipcMain.handle('browser:session:clearDefaultGoogleCookies', async (event): Promise<boolean> => {
+    if (!isTrustedBrowserRenderer(event.sender)) {
+      return false
+    }
+    return browserSessionRegistry.clearDefaultGoogleCookies()
   })
 
   ipcMain.removeHandler('browser:session:detectBrowsers')

--- a/src/main/runtime/orca-runtime-browser.ts
+++ b/src/main/runtime/orca-runtime-browser.ts
@@ -1602,6 +1602,10 @@ export class RuntimeBrowserCommands {
     return { cleared: await browserSessionRegistry.clearDefaultSessionCookies() }
   }
 
+  async browserProfileClearDefaultGoogleCookies(): Promise<BrowserProfileClearDefaultCookiesResult> {
+    return { cleared: await browserSessionRegistry.clearDefaultGoogleCookies() }
+  }
+
   async browserTabClose(params: {
     index?: number
     page?: string

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -38502,6 +38502,9 @@ export class OrcaRuntimeService {
   browserProfileClearDefaultCookies: RuntimeBrowserCommands['browserProfileClearDefaultCookies'] =
     this.browserCommands.browserProfileClearDefaultCookies.bind(this.browserCommands)
 
+  browserProfileClearDefaultGoogleCookies: RuntimeBrowserCommands['browserProfileClearDefaultGoogleCookies'] =
+    this.browserCommands.browserProfileClearDefaultGoogleCookies.bind(this.browserCommands)
+
   browserTabClose: RuntimeBrowserCommands['browserTabClose'] =
     this.browserCommands.browserTabClose.bind(this.browserCommands)
 

--- a/src/main/runtime/rpc/dispatcher-feature-interactions.test.ts
+++ b/src/main/runtime/rpc/dispatcher-feature-interactions.test.ts
@@ -114,6 +114,11 @@ const METHODS = [
     handler: () => ({ cleared: false })
   }),
   defineMethod({
+    name: 'browser.profileClearDefaultGoogleCookies',
+    params: z.object({}),
+    handler: () => ({ cleared: true })
+  }),
+  defineMethod({
     name: 'computer.permissions',
     params: z.object({}),
     handler: () => ({ opened: true })
@@ -165,6 +170,7 @@ describe('RpcDispatcher feature interactions', () => {
     await dispatcher.dispatch(makeRequest('browser.profileImportFromBrowser'))
     await dispatcher.dispatch(makeRequest('browser.profileList'))
     await dispatcher.dispatch(makeRequest('browser.profileClearDefaultCookies'))
+    await dispatcher.dispatch(makeRequest('browser.profileClearDefaultGoogleCookies'))
 
     expect(runtime.recordFeatureInteraction).toHaveBeenCalledWith('computer-use-setup')
     expect(runtime.recordFeatureInteraction).toHaveBeenCalledWith('cookie-import')

--- a/src/main/runtime/rpc/methods/browser-core.ts
+++ b/src/main/runtime/rpc/methods/browser-core.ts
@@ -166,6 +166,11 @@ export const BROWSER_CORE_METHODS: RpcMethod[] = [
     handler: async (_params, { runtime }) => runtime.browserProfileClearDefaultCookies()
   }),
   defineMethod({
+    name: 'browser.profileClearDefaultGoogleCookies',
+    params: null,
+    handler: async (_params, { runtime }) => runtime.browserProfileClearDefaultGoogleCookies()
+  }),
+  defineMethod({
     name: 'browser.hover',
     params: Element,
     handler: async (params, { runtime }) => runtime.browserHover(params)

--- a/src/preload/api/browser-api.ts
+++ b/src/preload/api/browser-api.ts
@@ -125,6 +125,7 @@ export type BrowserApi = {
     browserProfile?: string
   }) => Promise<BrowserCookieImportResult>
   sessionClearDefaultCookies: () => Promise<boolean>
+  sessionClearDefaultGoogleCookies: () => Promise<boolean>
   notifyActiveTabChanged: (args: { browserPageId: string }) => Promise<boolean>
 }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3028,6 +3028,9 @@ const api = {
     sessionClearDefaultCookies: (): Promise<boolean> =>
       ipcRenderer.invoke('browser:session:clearDefaultCookies'),
 
+    sessionClearDefaultGoogleCookies: (): Promise<boolean> =>
+      ipcRenderer.invoke('browser:session:clearDefaultGoogleCookies'),
+
     notifyActiveTabChanged: (args: { browserPageId: string }): Promise<boolean> =>
       ipcRenderer.invoke('browser:activeTabChanged', args)
   },

--- a/src/renderer/src/components/BrowserCookieImportDisclosure.tsx
+++ b/src/renderer/src/components/BrowserCookieImportDisclosure.tsx
@@ -1,6 +1,11 @@
 import { Info } from 'lucide-react'
 import { translate } from '@/i18n/i18n'
-import { DropdownMenuLabel, DropdownMenuSeparator } from '@/components/ui/dropdown-menu'
+import {
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator
+} from '@/components/ui/dropdown-menu'
+import { openDefaultGoogleCookieClearSettings } from '@/lib/browser-google-cookie-clear-settings'
 
 export function BrowserCookieImportDisclosure(): React.JSX.Element {
   return (
@@ -18,11 +23,21 @@ export function BrowserCookieImportDisclosure(): React.JSX.Element {
           <span className="block leading-4 text-muted-foreground">
             {translate(
               'auto.components.BrowserCookieImportDisclosure.description',
-              'Sign in to Google directly in Orca.'
+              'Sign in to Google directly in Orca. Stale Google cookies can be cleared from Session & Cookies.'
             )}
           </span>
         </span>
       </DropdownMenuLabel>
+      <DropdownMenuItem
+        onSelect={() => {
+          openDefaultGoogleCookieClearSettings()
+        }}
+      >
+        {translate(
+          'auto.components.BrowserCookieImportDisclosure.clearGoogleCookies',
+          'Clear Google cookies…'
+        )}
+      </DropdownMenuItem>
     </>
   )
 }

--- a/src/renderer/src/components/browser-cookie-import-google-disclosure.test.tsx
+++ b/src/renderer/src/components/browser-cookie-import-google-disclosure.test.tsx
@@ -10,7 +10,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import en from '@/i18n/locales/en.json'
 
 const DISCLOSURE_TITLE = "Google logins aren't imported"
-const DISCLOSURE_DESCRIPTION = 'Sign in to Google directly in Orca.'
+const DISCLOSURE_DESCRIPTION =
+  'Sign in to Google directly in Orca. Stale Google cookies can be cleared from Session & Cookies.'
+const DISCLOSURE_ACTION = 'Clear Google cookies…'
 
 vi.mock('@/components/ui/dropdown-menu', () => dropdownMenuStubs())
 vi.mock('../ui/dropdown-menu', () => dropdownMenuStubs())
@@ -18,6 +20,9 @@ vi.mock('@/components/ui/popover', () => popoverStubs())
 vi.mock('@/store', () => ({ useAppStore: appStoreStub() }))
 vi.mock('../../store', () => ({ useAppStore: appStoreStub() }))
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+vi.mock('@/components/confirmation-dialog-context', () => ({
+  useConfirmationDialog: () => vi.fn().mockResolvedValue(true)
+}))
 
 import { BrowserCookieImportDisclosure } from './BrowserCookieImportDisclosure'
 import { BrowserImportHintButton } from './browser-pane/assemble-chrome/BrowserImportHintButton'
@@ -91,6 +96,7 @@ describe('cookie-import Google disclosure footer', () => {
           importState={null}
           isActive
           onSelect={vi.fn()}
+          isDefault
         />
       )
     ]
@@ -99,6 +105,7 @@ describe('cookie-import Google disclosure footer', () => {
 
     expect(container.textContent).toContain(DISCLOSURE_TITLE)
     expect(container.textContent).toContain(DISCLOSURE_DESCRIPTION)
+    expect(container.textContent).toContain(DISCLOSURE_ACTION)
   })
 
   it('renders the icon and separator as non-interactive footer chrome', () => {
@@ -109,12 +116,47 @@ describe('cookie-import Google disclosure footer', () => {
     expect(label?.previousElementSibling?.tagName).toBe('HR')
   })
 
+  it('keeps Clear Google cookies enabled on the default profile with no import source', () => {
+    act(() =>
+      root.render(
+        <BrowserProfileRow
+          profile={
+            {
+              id: 'default',
+              scope: 'default',
+              partition: 'persist:default',
+              label: 'Default',
+              source: null
+            } as never
+          }
+          detectedBrowsers={DETECTED_BROWSERS}
+          importState={null}
+          isActive
+          onSelect={vi.fn()}
+          isDefault
+        />
+      )
+    )
+
+    const googleClear = [...container.querySelectorAll('button')].find(
+      (button) => button.textContent === 'Clear Google cookies'
+    )
+    const importedClear = [...container.querySelectorAll('button')].find(
+      (button) => button.getAttribute('aria-label') === 'Clear imported cookies'
+    )
+    expect(googleClear?.disabled).toBe(false)
+    expect(importedClear?.disabled).toBe(true)
+  })
+
   it('reads the footer copy from the catalog', () => {
     expect(catalogEntry('auto.components.BrowserCookieImportDisclosure.title')).toBe(
       DISCLOSURE_TITLE
     )
     expect(catalogEntry('auto.components.BrowserCookieImportDisclosure.description')).toBe(
       DISCLOSURE_DESCRIPTION
+    )
+    expect(catalogEntry('auto.components.BrowserCookieImportDisclosure.clearGoogleCookies')).toBe(
+      DISCLOSURE_ACTION
     )
   })
 })
@@ -176,6 +218,8 @@ function appStoreStub(): unknown {
     importCookiesToProfile: vi.fn(),
     openSettingsTarget: vi.fn(),
     openSettingsPage: vi.fn(),
+    clearDefaultGoogleCookies: vi.fn(),
+    clearDefaultSessionCookies: vi.fn(),
     persistedUIReady: true,
     setBrowserImportHintHidden: vi.fn(),
     settingsSearchQuery: ''

--- a/src/renderer/src/components/settings/BrowserProfileRow.tsx
+++ b/src/renderer/src/components/settings/BrowserProfileRow.tsx
@@ -18,6 +18,7 @@ import {
   DropdownMenuTrigger
 } from '../ui/dropdown-menu'
 import { BrowserCookieImportDisclosure } from '../BrowserCookieImportDisclosure'
+import { ClearDefaultGoogleCookiesButton } from './ClearDefaultGoogleCookiesButton'
 import { useAppStore } from '../../store'
 import { BROWSER_FAMILY_LABELS } from '../../../../shared/constants'
 import { translate } from '@/i18n/i18n'
@@ -223,25 +224,32 @@ export function BrowserProfileRow({
           </DropdownMenuContent>
         </DropdownMenu>
         {isDefault ? (
-          <Button
-            variant="ghost"
-            size="icon"
-            className="size-7 text-muted-foreground hover:text-destructive"
-            disabled={!profile.source}
-            onClick={async () => {
-              const ok = await useAppStore.getState().clearDefaultSessionCookies()
-              if (ok) {
-                toast.success(
-                  translate(
-                    'auto.components.settings.BrowserProfileRow.2d4bea7f35',
-                    'Default cookies cleared.'
+          <>
+            <ClearDefaultGoogleCookiesButton />
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-7 text-muted-foreground hover:text-destructive"
+              aria-label={translate(
+                'auto.components.settings.BrowserProfileRow.clearImportedCookies',
+                'Clear imported cookies'
+              )}
+              disabled={!profile.source}
+              onClick={async () => {
+                const ok = await useAppStore.getState().clearDefaultSessionCookies()
+                if (ok) {
+                  toast.success(
+                    translate(
+                      'auto.components.settings.BrowserProfileRow.2d4bea7f35',
+                      'Default cookies cleared.'
+                    )
                   )
-                )
-              }
-            }}
-          >
-            <Trash2 className="size-3" />
-          </Button>
+                }
+              }}
+            >
+              <Trash2 className="size-3" />
+            </Button>
+          </>
         ) : (
           <Button
             variant="ghost"

--- a/src/renderer/src/components/settings/BrowserSessionCookiesSection.tsx
+++ b/src/renderer/src/components/settings/BrowserSessionCookiesSection.tsx
@@ -59,7 +59,9 @@ export function BrowserSessionCookiesSection({
         'chrome',
         'edge',
         'arc',
-        'profile'
+        'profile',
+        'google',
+        'clear'
       ]}
       className="space-y-3 py-2"
     >

--- a/src/renderer/src/components/settings/ClearDefaultGoogleCookiesButton.tsx
+++ b/src/renderer/src/components/settings/ClearDefaultGoogleCookiesButton.tsx
@@ -1,0 +1,57 @@
+import { toast } from 'sonner'
+import { Button } from '../ui/button'
+import { useConfirmationDialog } from '@/components/confirmation-dialog-context'
+import { useAppStore } from '@/store'
+import { translate } from '@/i18n/i18n'
+
+export function ClearDefaultGoogleCookiesButton(): React.JSX.Element {
+  const confirm = useConfirmationDialog()
+  const label = translate(
+    'auto.components.settings.ClearDefaultGoogleCookiesButton.label',
+    'Clear Google cookies'
+  )
+
+  return (
+    <Button
+      variant="ghost"
+      size="xs"
+      className="h-6 gap-1 px-1.5 text-[11px] text-muted-foreground hover:text-destructive"
+      aria-label={label}
+      onClick={async () => {
+        const confirmed = await confirm({
+          title: translate(
+            'auto.components.settings.ClearDefaultGoogleCookiesButton.confirmTitle',
+            'Clear Google cookies?'
+          ),
+          description: translate(
+            'auto.components.settings.ClearDefaultGoogleCookiesButton.confirmDescription',
+            'This signs you out of Google in the default browser profile. Cookies for other sites stay. You can sign in to Google again inside Orca.'
+          ),
+          confirmLabel: label,
+          confirmVariant: 'destructive'
+        })
+        if (!confirmed) {
+          return
+        }
+        const ok = await useAppStore.getState().clearDefaultGoogleCookies()
+        if (ok) {
+          toast.success(
+            translate(
+              'auto.components.settings.ClearDefaultGoogleCookiesButton.cleared',
+              'Google cookies cleared.'
+            )
+          )
+          return
+        }
+        toast.error(
+          translate(
+            'auto.components.settings.ClearDefaultGoogleCookiesButton.failed',
+            'Could not clear Google cookies. Try again.'
+          )
+        )
+      }}
+    >
+      {label}
+    </Button>
+  )
+}

--- a/src/renderer/src/components/settings/browser-search.ts
+++ b/src/renderer/src/components/settings/browser-search.ts
@@ -217,7 +217,9 @@ export function getBrowserPaneSearchEntries(
         ...translateSearchKeyword('auto.components.settings.browser.search.75a0d435b7', 'chrome'),
         ...translateSearchKeyword('auto.components.settings.browser.search.533a253deb', 'edge'),
         ...translateSearchKeyword('auto.components.settings.browser.search.1c1e097985', 'arc'),
-        ...translateSearchKeyword('auto.components.settings.browser.search.7539f6336c', 'profile')
+        ...translateSearchKeyword('auto.components.settings.browser.search.7539f6336c', 'profile'),
+        ...translateSearchKeyword('auto.components.settings.browser.search.8a489aab8d', 'google'),
+        ...translateSearchKeyword('auto.components.settings.browser.search.clearCookies', 'clear')
       ]
     }
   ]

--- a/src/renderer/src/components/settings/clear-default-google-cookies-button.test.tsx
+++ b/src/renderer/src/components/settings/clear-default-google-cookies-button.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import '@testing-library/jest-dom/vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { confirm, clearDefaultGoogleCookies, successToast, errorToast } = vi.hoisted(() => ({
+  confirm: vi.fn(),
+  clearDefaultGoogleCookies: vi.fn(),
+  successToast: vi.fn(),
+  errorToast: vi.fn()
+}))
+
+vi.mock('@/components/confirmation-dialog-context', () => ({
+  useConfirmationDialog: () => confirm
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: () => ({ clearDefaultGoogleCookies })
+  }
+}))
+
+vi.mock('sonner', () => ({
+  toast: { success: successToast, error: errorToast }
+}))
+
+import { ClearDefaultGoogleCookiesButton } from './ClearDefaultGoogleCookiesButton'
+
+describe('ClearDefaultGoogleCookiesButton', () => {
+  afterEach(() => {
+    cleanup()
+    confirm.mockReset()
+    clearDefaultGoogleCookies.mockReset()
+    successToast.mockReset()
+    errorToast.mockReset()
+  })
+
+  it('stays enabled after a successful clear and can run again', async () => {
+    confirm.mockResolvedValue(true)
+    clearDefaultGoogleCookies.mockResolvedValue(true)
+    render(<ClearDefaultGoogleCookiesButton />)
+
+    const button = screen.getByRole('button', { name: 'Clear Google cookies' })
+    expect(button).toBeEnabled()
+
+    await userEvent.click(button)
+    await userEvent.click(button)
+
+    expect(clearDefaultGoogleCookies).toHaveBeenCalledTimes(2)
+    expect(screen.getByRole('button', { name: 'Clear Google cookies' })).toBeEnabled()
+  })
+
+  it('does not clear when the confirmation is dismissed', async () => {
+    confirm.mockResolvedValue(false)
+    render(<ClearDefaultGoogleCookiesButton />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Clear Google cookies' }))
+
+    expect(clearDefaultGoogleCookies).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -788,6 +788,7 @@
               "restartFallbackUnavailableNone": "None of the {{value0}} cookies could be loaded, and the restart fallback was unavailable. The previous cookies for this profile were replaced. Try the import again.",
               "restartFallbackUnavailablePartial": "Imported {{value0}} of {{value1}} cookies. The rest could not be loaded, and the restart fallback was unavailable. Try the import again.",
               "googleCookiesSkipped": "Google cookies were not imported. Open a browser in Orca on {{value0}} with this profile, then sign into Google.",
+              "clearGoogleCookies": "Clear Google cookies",
               "undecryptableAppBound": "Orca cannot decrypt {{value0}} of this browser's cookies because they use app-bound encryption. You can import cookies from a file using “From File…”.",
               "undecryptableAppBoundMixed": "Orca cannot decrypt {{value0}} of this browser's cookies because they use app-bound encryption; {{value1}} more could not be decrypted for another reason. You can import cookies from a file using “From File…”.",
               "undecryptableKeyring": "{{value0}} cookies could not be decrypted because the system keyring was unavailable. Unlock your login keyring (or install a Secret Service provider such as gnome-keyring) and import again.",
@@ -981,7 +982,8 @@
     "components": {
       "BrowserCookieImportDisclosure": {
         "title": "Google logins aren't imported",
-        "description": "Sign in to Google directly in Orca."
+        "description": "Sign in to Google directly in Orca. Stale Google cookies can be cleared from Session & Cookies.",
+        "clearGoogleCookies": "Clear Google cookies…"
       },
       "CodexRestartChip": {
         "a4c8e1b2f7": "Codex is still signed in as {{value0}}",
@@ -6399,7 +6401,15 @@
           "4399c77caa": "Default",
           "4af9a17947": "kagi"
         },
+        "ClearDefaultGoogleCookiesButton": {
+          "label": "Clear Google cookies",
+          "confirmTitle": "Clear Google cookies?",
+          "confirmDescription": "This signs you out of Google in the default browser profile. Cookies for other sites stay. You can sign in to Google again inside Orca.",
+          "cleared": "Google cookies cleared.",
+          "failed": "Could not clear Google cookies. Try again."
+        },
         "BrowserProfileRow": {
+          "clearImportedCookies": "Clear imported cookies",
           "8e636cae25": "Profile \"{{value0}}\" removed.",
           "2d4bea7f35": "Default cookies cleared.",
           "ebb78dfd6f": "From File…",

--- a/src/renderer/src/lib/browser-cookie-import-toast.test.ts
+++ b/src/renderer/src/lib/browser-cookie-import-toast.test.ts
@@ -9,6 +9,10 @@ vi.mock('sonner', () => ({
   toast: { success: successToastMock, warning: warningToastMock }
 }))
 
+vi.mock('@/lib/browser-google-cookie-clear-settings', () => ({
+  openDefaultGoogleCookieClearSettings: vi.fn()
+}))
+
 import type { BrowserCookieImportSummary } from '../../../shared/browser-workspace-types'
 import { emitBrowserCookieImportToast } from './browser-cookie-import-toast'
 
@@ -83,7 +87,10 @@ describe('emitBrowserCookieImportToast', () => {
     expect(successToastMock).toHaveBeenCalledWith('Imported 2 cookies.')
     expect(warningToastMock).toHaveBeenCalledWith(
       'Google cookies were not imported. Open a browser in Orca on Remote Mac with this profile, then sign into Google.',
-      { duration: 12000 }
+      expect.objectContaining({
+        duration: 12000,
+        action: expect.objectContaining({ label: 'Clear Google cookies' })
+      })
     )
     expect(successToastMock.mock.invocationCallOrder[0]).toBeLessThan(
       warningToastMock.mock.invocationCallOrder[0]
@@ -231,7 +238,10 @@ describe('emitBrowserCookieImportToast', () => {
       ],
       [
         'Google cookies were not imported. Open a browser in Orca on Remote Mac with this profile, then sign into Google.',
-        { duration: 12000 }
+        expect.objectContaining({
+          duration: 12000,
+          action: expect.objectContaining({ label: 'Clear Google cookies' })
+        })
       ]
     ])
   })

--- a/src/renderer/src/lib/browser-cookie-import-toast.ts
+++ b/src/renderer/src/lib/browser-cookie-import-toast.ts
@@ -2,6 +2,7 @@ import { toast } from 'sonner'
 import type { BrowserCookieImportSummary } from '../../../shared/browser-workspace-types'
 import { isHandledWireDiscriminant } from '../../../shared/handled-wire-discriminant'
 import { translate } from '@/i18n/i18n'
+import { openDefaultGoogleCookieClearSettings } from '@/lib/browser-google-cookie-clear-settings'
 
 type CookieImportWarning = NonNullable<BrowserCookieImportSummary['warning']>
 type CookieImportWarningCode = CookieImportWarning['code']
@@ -103,7 +104,16 @@ function emitGoogleCookieImportWarning(
       'Google cookies were not imported. Open a browser in Orca on {{value0}} with this profile, then sign into Google.',
       { value0: executionHostLabel }
     ),
-    { duration: 12000 }
+    {
+      duration: 12000,
+      action: {
+        label: translate(
+          'auto.lib.browser.cookie.import.toast.clearGoogleCookies',
+          'Clear Google cookies'
+        ),
+        onClick: openDefaultGoogleCookieClearSettings
+      }
+    }
   )
 }
 

--- a/src/renderer/src/lib/browser-google-cookie-clear-settings.test.ts
+++ b/src/renderer/src/lib/browser-google-cookie-clear-settings.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const { openSettingsPage, openSettingsTarget } = vi.hoisted(() => ({
+  openSettingsPage: vi.fn(),
+  openSettingsTarget: vi.fn()
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: () => ({ openSettingsPage, openSettingsTarget })
+  }
+}))
+
+import {
+  BROWSER_GOOGLE_COOKIE_CLEAR_SECTION_ID,
+  openDefaultGoogleCookieClearSettings
+} from './browser-google-cookie-clear-settings'
+
+describe('openDefaultGoogleCookieClearSettings', () => {
+  it('opens Settings to Session & Cookies', () => {
+    openDefaultGoogleCookieClearSettings()
+
+    expect(openSettingsPage).toHaveBeenCalledOnce()
+    expect(openSettingsTarget).toHaveBeenCalledWith({
+      pane: 'browser',
+      repoId: null,
+      sectionId: BROWSER_GOOGLE_COOKIE_CLEAR_SECTION_ID
+    })
+    expect(BROWSER_GOOGLE_COOKIE_CLEAR_SECTION_ID).toBe('browser-session-cookies')
+  })
+})

--- a/src/renderer/src/lib/browser-google-cookie-clear-settings.ts
+++ b/src/renderer/src/lib/browser-google-cookie-clear-settings.ts
@@ -1,0 +1,13 @@
+import { useAppStore } from '@/store'
+
+export const BROWSER_GOOGLE_COOKIE_CLEAR_SECTION_ID = 'browser-session-cookies'
+
+export function openDefaultGoogleCookieClearSettings(): void {
+  const store = useAppStore.getState()
+  store.openSettingsPage()
+  store.openSettingsTarget({
+    pane: 'browser',
+    repoId: null,
+    sectionId: BROWSER_GOOGLE_COOKIE_CLEAR_SECTION_ID
+  })
+}

--- a/src/renderer/src/store/slices/browser-slice-test-harness.ts
+++ b/src/renderer/src/store/slices/browser-slice-test-harness.ts
@@ -17,6 +17,7 @@ export type BrowserMockApi = {
     sessionDetectBrowsers: Mock
     sessionImportFromBrowser: Mock
     sessionClearDefaultCookies: Mock
+    sessionClearDefaultGoogleCookies: Mock
     notifyActiveTabChanged: Mock
   }
   runtimeEnvironments: { call: Mock }
@@ -32,6 +33,7 @@ export function createBrowserMockApi(runtimeEnvironmentTransportCall: Mock): Bro
       sessionDetectBrowsers: vi.fn().mockResolvedValue([]),
       sessionImportFromBrowser: vi.fn().mockResolvedValue({ ok: false, reason: 'canceled' }),
       sessionClearDefaultCookies: vi.fn().mockResolvedValue(false),
+      sessionClearDefaultGoogleCookies: vi.fn().mockResolvedValue(false),
       notifyActiveTabChanged: vi.fn().mockResolvedValue(undefined)
     },
     runtimeEnvironments: {

--- a/src/renderer/src/store/slices/browser.ts
+++ b/src/renderer/src/store/slices/browser.ts
@@ -237,6 +237,7 @@ export type BrowserSlice = {
     browserProfile?: string
   ) => Promise<BrowserCookieImportExecutionResult>
   clearDefaultSessionCookies: () => Promise<boolean>
+  clearDefaultGoogleCookies: () => Promise<boolean>
   browserUrlHistory: BrowserHistoryEntry[]
   addBrowserHistoryEntry: (url: string, title: string) => void
   clearBrowserHistory: () => void
@@ -2330,6 +2331,28 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
         await get().fetchBrowserSessionProfiles()
       }
       return ok
+    } catch {
+      return false
+    }
+  },
+
+  clearDefaultGoogleCookies: async () => {
+    const runtimeEnvironmentId = getBrowserSettingsRuntimeEnvironmentId(get())
+    if (runtimeEnvironmentId) {
+      try {
+        const result = await callRuntimeRpc<BrowserProfileClearDefaultCookiesResult>(
+          { kind: 'environment', environmentId: runtimeEnvironmentId },
+          'browser.profileClearDefaultGoogleCookies',
+          undefined,
+          { timeoutMs: 15_000 }
+        )
+        return result.cleared
+      } catch {
+        return false
+      }
+    }
+    try {
+      return await window.api.browser.sessionClearDefaultGoogleCookies()
     } catch {
       return false
     }

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2422,6 +2422,7 @@ function createBrowserApi(): NonNullable<Partial<PreloadApi>['browser']> {
         )
       }),
     sessionClearDefaultCookies: () => Promise.resolve(false),
+    sessionClearDefaultGoogleCookies: () => Promise.resolve(false),
     notifyActiveTabChanged: () => Promise.resolve(false)
   } as unknown as NonNullable<Partial<PreloadApi>['browser']>
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​308 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​298 |
| Prod | 20 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​296 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​59 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​237 |

<!-- /orca-pr-loc -->

## Summary

Since cookie import started excluding `google.com`, imports neither write nor clear Google cookies. The only default-partition remover was a one-shot trash control that wiped the **whole jar** and then disabled itself (`disabled={!profile.source}`). Stale Google cookies had no way out.

This adds a **Google-family-only** clear for the default partition that stays usable more than once, plus routing from the Google import toast and import-menu disclosure.

Closes #14678
Linear: [STA-4398](https://linear.app/stably/issue/STA-4398)

## What changed

1. **Clear is scoped to the Google family.** `removeNonTransplantableCookies` uses the existing per-coordinate `cookies.remove` plan (same atomic snapshot/restore path as import clears). It never calls `clearStorageData`, never copies over the live cookie DB, and never deletes `-wal`/`-shm`. Tests seed Google *and* non-Google cookies (`example.com`, `youtube.com`, `github.com`, `google.com.evil.example`) and assert the non-Google ones survive.
2. **The control does not disable itself.** Settings → Browser → Session & Cookies now has a labeled **Clear Google cookies** button on the default profile. It is not gated on `profile.source`, asks for confirmation, and stays enabled after a successful clear.
3. **Google-facing surfaces route to it.** The "Google cookies were not imported" toast has a **Clear Google cookies** action, and the import-menu disclosure is a real menu item, both opening Settings at Session & Cookies.
4. **`deleteProfile` still refuses `scope === 'default'`.** Unchanged; covered by the existing registry test.
5. **Import policy is unchanged.** `google.com` stays in `NON_TRANSPLANTABLE_DOMAINS`. Imports still neither write nor clear Google cookies.

Remote hosts get a new RPC (`browser.profileClearDefaultGoogleCookies`). Older hosts that do not implement it fail closed (`cleared: false`) instead of falling back to a whole-jar wipe.

## Test evidence (HOUSE-RULES §4)

- **Pre-fix (no-op stub):** 2 failed / 1 passed. Google cookies remained in a mixed jar.
- **Post-fix:** 3 passed. Google-family cookies removed; `example.com` / `youtube.com` / `github.com` / `google.com.evil.example` survived; a second clear after re-seeding still works.
- **Neutered (clear function emptied again):** 2 failed / 1 passed — same red assertions as pre-fix.
- Import exclusion suite still passes (STA-3811). `deleteProfile('default')` still returns `false`.

## Test plan

- [ ] Settings → Browser → Session & Cookies: **Clear Google cookies** is labeled, enabled with no import source, and stays enabled after use
- [ ] Confirming the dialog signs out of Google in the default profile and leaves other site sessions
- [ ] Cookie import toast "Google cookies were not imported" action opens Session & Cookies
- [ ] Import menu **Clear Google cookies…** opens the same settings section
- [ ] Isolated profile delete still works; default profile still cannot be deleted