### PR TITLE
fix(editor): keep currency dollars out of rich-editor math spans

### DIFF
--- a/src/renderer/src/components/editor/rich-markdown-extensions.ts
+++ b/src/renderer/src/components/editor/rich-markdown-extensions.ts
@@ -10,7 +10,8 @@ import { Table } from '@tiptap/extension-table'
 import { TableCell } from '@tiptap/extension-table-cell'
 import { TableHeader } from '@tiptap/extension-table-header'
 import { TableRow } from '@tiptap/extension-table-row'
-import { BlockMath, InlineMath } from '@tiptap/extension-mathematics'
+import { BlockMath } from '@tiptap/extension-mathematics'
+import { RichMarkdownInlineMath } from './rich-markdown-inline-math'
 import { Markdown } from '@tiptap/markdown'
 import { createLowlight, common } from 'lowlight'
 import { loadLocalImageSrc, onImageCacheInvalidated } from './useLocalImageSrc'
@@ -201,7 +202,7 @@ export function createRichMarkdownExtensions({
     TableRow,
     TableHeader,
     TableCell,
-    InlineMath.configure({
+    RichMarkdownInlineMath.configure({
       katexOptions: {
         throwOnError: false
       }

--- a/src/renderer/src/components/editor/rich-markdown-inline-math.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-inline-math.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import { Editor } from '@tiptap/core'
+import { encodeRawMarkdownHtmlForRichEditor } from './raw-markdown-html'
+import { createRichMarkdownExtensions } from './rich-markdown-extensions'
+import { createRichMarkdownEditorCodec } from './rich-markdown-source-transport'
+
+// STA-4635 / #15100 reporter string — two unguarded `$…$` spans swallow currency and CJK prose.
+const ISSUE_CURRENCY_PROSE =
+  '月成本 **$148+ → $19**（省 **87%**，年省 ~$1,550）；后续释放老 EIP 可再降到 $15.4/月'
+
+function createEditor(content: string): Editor {
+  const codec = createRichMarkdownEditorCodec()
+  return new Editor({
+    element: null,
+    extensions: createRichMarkdownExtensions({ codec }),
+    content: encodeRawMarkdownHtmlForRichEditor(content, codec),
+    contentType: 'markdown'
+  })
+}
+
+function parseMarkdown(content: string): {
+  markdown: string
+  text: string
+  inlineMath: string[]
+  blockMath: string[]
+} {
+  const editor = createEditor(content)
+  try {
+    const inlineMath: string[] = []
+    const blockMath: string[] = []
+    editor.state.doc.descendants((node) => {
+      if (node.type.name === 'inlineMath') {
+        inlineMath.push(String(node.attrs.latex ?? ''))
+      }
+      if (node.type.name === 'blockMath') {
+        blockMath.push(String(node.attrs.latex ?? ''))
+      }
+    })
+    return {
+      markdown: editor.getMarkdown().trimEnd(),
+      text: editor.state.doc.textContent,
+      inlineMath,
+      blockMath
+    }
+  } finally {
+    editor.destroy()
+  }
+}
+
+describe('rich markdown inline math currency guard', () => {
+  it('round-trips the reporter currency string with prose and every amount intact', () => {
+    const { markdown, inlineMath } = parseMarkdown(ISSUE_CURRENCY_PROSE)
+
+    expect(inlineMath).toEqual([])
+    expect(markdown).toContain('$148')
+    expect(markdown).toContain('$19')
+    expect(markdown).toContain('$1,550')
+    expect(markdown).toContain('$15.4')
+    expect(markdown).toContain('月成本')
+    expect(markdown).toContain('后续释放老 EIP')
+    expect((markdown.match(/\$/g) ?? []).length).toBe(4)
+  })
+
+  it('still parses $$…$$ as display math', () => {
+    const { inlineMath, blockMath, markdown } = parseMarkdown('Before\n\n$$\nx + y\n$$\n\nAfter')
+
+    expect(inlineMath).toEqual([])
+    expect(blockMath).toEqual(['x + y'])
+    expect(markdown).toBe('Before\n\n$$\nx + y\n$$\n\nAfter')
+  })
+
+  it('never treats a single $ adjacent to digits as math', () => {
+    expect(parseMarkdown('The price is $19.').inlineMath).toEqual([])
+    expect(parseMarkdown('$148 is the monthly cost').inlineMath).toEqual([])
+    expect(parseMarkdown('$148+ → $19').inlineMath).toEqual([])
+    expect(parseMarkdown('costs $100$ exactly').inlineMath).toEqual([])
+  })
+
+  it('does not consume CJK prose between two currency $ signs', () => {
+    const source = '~$1,550）；后续释放老 EIP 可再降到 $15.4/月'
+    const { markdown, inlineMath, text } = parseMarkdown(source)
+
+    expect(inlineMath).toEqual([])
+    expect(markdown).toContain('$1,550')
+    expect(markdown).toContain('$15.4')
+    expect(text).toContain('后续释放老 EIP')
+  })
+
+  it('still parses genuine Pandoc inline math', () => {
+    expect(parseMarkdown('Einstein wrote $E=mc^2$ in 1905.').inlineMath).toEqual(['E=mc^2'])
+    expect(parseMarkdown('The variable is $x$.').inlineMath).toEqual(['x'])
+    expect(parseMarkdown('Arithmetic $2+2$ is math.').inlineMath).toEqual(['2+2'])
+  })
+})

--- a/src/renderer/src/components/editor/rich-markdown-inline-math.ts
+++ b/src/renderer/src/components/editor/rich-markdown-inline-math.ts
@@ -1,0 +1,22 @@
+import type { MarkdownTokenizer } from '@tiptap/core'
+import { InlineMath } from '@tiptap/extension-mathematics'
+
+const baseTokenizer = InlineMath.config.markdownTokenizer as MarkdownTokenizer
+
+// Pandoc: no space after the opening `$`, none before the closer, no digit after it.
+const PANDOC_INLINE_MATH = /^\$(?!\s)([^$]*[^\s$])\$(?!\$)(?!\d)/
+// Why: `$100$` satisfies Pandoc delimiters but is still a USD amount, not a formula.
+const PURE_CURRENCY_AMOUNT = /^(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?$/
+
+export const RichMarkdownInlineMath = InlineMath.extend({
+  markdownTokenizer: {
+    ...baseTokenizer,
+    tokenize(src, tokens, lexer) {
+      const match = PANDOC_INLINE_MATH.exec(src)
+      if (!match || PURE_CURRENCY_AMOUNT.test(match[1].trim())) {
+        return undefined
+      }
+      return baseTokenizer.tokenize(src, tokens, lexer)
+    }
+  }
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​94 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​94 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​25 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​23 |

<!-- /orca-pr-loc -->

## ELI5

The default rich editor was treating ordinary dollar amounts like `$19` as LaTeX math, which ate the `$` and sometimes swallowed the sentence between two prices. It now treats those as money, and only real math like `$x$` or `$$…$$` still renders as math.

## What Changed

- `@tiptap/extension-mathematics` 3.22.5 has no option to disable unguarded `$…$` parsing (`InlineMathOptions` is only `katexOptions` / `onClick`).
- Extend `InlineMath` the same way the task-list tokenizer is wrapped, and register that at the rich-editor extension set.
- Tokenize inline math only when it matches Pandoc delimiters (no space after the opening `$`, none before the closer, no digit after it) and is not a pure currency amount such as `$100$`.
- `$$…$$` display math, the `/inline math` slash command, and genuine `$x$` / `$E=mc^2$` / `$2+2$` are unchanged.

## Why

The markdown tokenizer in `@tiptap/extension-mathematics` is `^\$([^$]+)\$(?!\$)` — a single `$` with no digit or whitespace guard. That is live because `MarkdownManager.registerExtension` calls `registerTokenizer`, and `createTiptapMarkedFacade()` keeps the extension registry. Rich mode is the default markdown surface, so a cost-table document is parsed this way.

Measured on the reporter string, `$148+ → $19` became latex `148+ →` and `$1,550）；后续释放老 EIP 可再降到 $15.4/月` swallowed the entire CJK clause as math.

This matches the preview-surface intent (currency stays literal, `$$…$$` stays math) without disabling math or forcing source mode.

## Linked Issue

Fixes #15100
STA-4635

## Visual Proof

N/A — no layout, chrome, or styling change. The defect is markdown tokenization in the rich editor; coverage is the live TipTap `Editor` document model (inlineMath nodes vs preserved `$` amounts) using the same extension set as the app.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Pre-fix (stock `InlineMath` tokenizer): 3 failed / 2 passed. Failed cases reproduced latex `148+ →` and `1,550）；后续释放老 EIP 可再降到`.

Post-fix: 5 passed, plus existing slash-command and round-trip suites (53 tests across 3 files). `pnpm typecheck:web` clean.

Neutered (guard removed, tests kept): the same 3 tests went red again with the same swallowed latex.

Command: `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/editor/rich-markdown-inline-math.test.ts`

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Parse-only change in the renderer markdown tokenizer. No path, shortcut, SSH, or mobile impact. BlockMath (`$$…$$`) is unchanged. CommentMarkdown and mobile do not register this math plugin.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)