### PR TITLE
fix(source-control-ai): give OMP a commit-message spec

### DIFF
--- a/src/shared/commit-message-agent-spec.test.ts
+++ b/src/shared/commit-message-agent-spec.test.ts
@@ -35,9 +35,26 @@ describe('COMMIT_MESSAGE_AGENT_SPECS', () => {
       'copilot',
       'cursor',
       'kimi',
+      'omp',
       'opencode',
       'pi'
     ])
+  })
+
+
+  it('gives OMP a spec so a spec-less default agent cannot fail Source Control AI (#15646)', () => {
+    const spec = COMMIT_MESSAGE_AGENT_SPECS.omp
+    expect(spec).toBeDefined()
+    expect(spec?.promptDelivery).toBe('stdin')
+    expect(spec?.buildArgs({ prompt: 'p', model: 'default' })).toEqual([
+      '-p',
+      '--no-session',
+      '--no-tools',
+      '--mode',
+      'text'
+    ])
+    expect(spec?.defaultModelId).toBe('default')
+    expect(resolveCommitMessageAgentChoice(null, 'omp')).toBe('omp')
   })
 
   it('uses the strongest available defaults for core agents', () => {

--- a/src/shared/commit-message-agent-spec.ts
+++ b/src/shared/commit-message-agent-spec.ts
@@ -706,6 +706,23 @@ export const COMMIT_MESSAGE_AGENT_SPECS: Partial<Record<TuiAgent, CommitMessageA
     ],
     defaultModelId: 'gpt-5.4'
   },
+  omp: {
+    id: 'omp',
+    label: 'OMP',
+    binary: 'omp',
+    // Why: Source Control AI prompts can include large staged diffs; OMP reads
+    // the prompt on stdin, avoiding cross-platform argv limits (#15646).
+    promptDelivery: 'stdin',
+    // Why: verified against omp v17 — `-p --no-session --no-tools --mode text`
+    // answers on stdout with no persisted session and no workspace writes.
+    buildArgs: () => ['-p', '--no-session', '--no-tools', '--mode', 'text'],
+    // Why: OMP resolves its model from its own config; there is no CLI model
+    // flag on this invocation, so a single config-default entry keeps the
+    // picker honest (the Kimi 'default' pattern).
+    modelSource: 'static',
+    models: [{ id: 'default', label: 'Config default' }],
+    defaultModelId: 'default'
+  },
   antigravity: {
     id: 'antigravity',
     label: 'Antigravity',


### PR DESCRIPTION
## Summary

**What**

Adds an `omp` entry to `COMMIT_MESSAGE_AGENT_SPECS`, so a default TUI agent of OMP resolves to a working Source Control AI agent instead of failing.

**Why**

#15646 — `omp` is a first-class `TuiAgent` (PTY launch, hooks, AI Vault session scanning) but had no commit-message spec, so `resolveCommitMessageAgentChoice(null, 'omp')` hit the `getCommitMessageAgentSpec(defaultTuiAgent) ? defaultTuiAgent : null` branch and returned `null` — turning every Source Control AI operation into "Choose a supported Source Control AI agent…". Most visible: the first-work auto branch rename silently failed, leaving Orca-created creature branches (`<user>/Nautilus-8`) with their generated names.

**Spec details** — from the invocation the reporter verified against omp v17.3.7:

- prompt on **stdin** (large staged diffs stay off argv), `-p --no-session --no-tools --mode text`
- **static** model source with a single config-default entry — this invocation carries no model flag, so OMP's own config decides (the existing Kimi `default` pattern for CLIs without a per-call model flag)

The "Supported agents: …" error list derives from `listCommitMessageAgentCapabilities()`, so it picks OMP up with no further changes.

**Testing**

- New case in `commit-message-agent-spec.test.ts`: the spec exists, delivers via stdin, builds exactly the verified argv, defaults to config-default, and — the regression that matters — `resolveCommitMessageAgentChoice(null, 'omp')` now returns `'omp'`. Verified to fail on the pre-change registry.
- Updated agent-id list test; suites `commit-message-agent-spec` / `-generation` / `-plan` 75/75, `source-control-ai` 25/25, `pnpm run typecheck` clean.

Fixes #15646