### PR TITLE
fix(terminal): seed list preview from daemon snapshots after restart (STA-4326)

### DIFF
--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1522,6 +1522,8 @@ type RuntimePtyWorktreeRecord = {
   // provider snapshot must not be re-asked on every list (200-row hot path).
   providerActivitySeedAttempted?: boolean
   providerActivityObservation?: 'unverifiable'
+  // Listing-only screen; must not write the restore tail (read/reveal owns that budget).
+  providerActivityPreview?: string
 }
 
 type TerminalAgentStatusSnapshot = {
@@ -11069,6 +11071,7 @@ export class OrcaRuntimeService {
       pty.disconnectedAt = null
       pty.lastOutputAt = at
       pty.providerActivityObservation = undefined
+      pty.providerActivityPreview = undefined
       const normalized = normalizeTerminalChunk(data, pty.tailPendingAnsi)
       pty.tailPendingAnsi = normalized.pendingAnsi
       const nextTail = appendNormalizedToTailBuffer(
@@ -17185,6 +17188,9 @@ export class OrcaRuntimeService {
       resolvedWorktrees,
       targetWorktreeId
     )
+    if (controllerInventory) {
+      await this.seedUnattachedLocalDaemonPtyActivityFromProvider(controllerInventory.livePtyIds)
+    }
     const refreshedPtyLiveness = controllerInventory
       ? new Set(controllerInventory.livePtyIds)
       : null
@@ -32742,22 +32748,18 @@ export class OrcaRuntimeService {
       }
     }
     this.pruneDisconnectedPtyRecords()
-    const livePtyIdsForActivitySeed = targetWorktreeId ? selectedLivePtyIds : allLivePtyIds
-    if (deadline === undefined || Date.now() < deadline) {
-      await this.seedUnattachedLocalDaemonPtyActivityFromProvider(livePtyIdsForActivitySeed)
-    }
     return {
-      livePtyIds: livePtyIdsForActivitySeed,
+      livePtyIds: targetWorktreeId ? selectedLivePtyIds : allLivePtyIds,
       allLivePtyIds,
       terminalIdentityByPtyId: controllerIdentityByPtyId,
       queriedHostIds
     }
   }
 
-  // Why: inventory records a never-attached local daemon PTY at construction
-  // defaults; list would otherwise report lastOutputAt:null / preview:"" as if
-  // that were an observation. Seed once from the same provider snapshot `read`
-  // already consults. Recency stays unset — snapshot bytes are historical.
+  // Why: list would otherwise report lastOutputAt:null / preview:"" for a
+  // never-attached local daemon PTY as if that were an observation. Seed a
+  // listing-only preview from a shallow provider snapshot. Recency stays unset
+  // — snapshot bytes are historical — and the restore tail is left for read.
   private async seedUnattachedLocalDaemonPtyActivityFromProvider(
     livePtyIds: ReadonlySet<string>
   ): Promise<void> {
@@ -32767,6 +32769,10 @@ export class OrcaRuntimeService {
         break
       }
       if (!this.isKnownUnattachedLocalDaemonPty(ptyId)) {
+        continue
+      }
+      // Recovered legacy workers own a 120-row provider read; listing must not serialize them.
+      if (this.legacyWorkerRecoveredPtys.has(ptyId)) {
         continue
       }
       const pty = this.ptysById.get(ptyId)
@@ -32804,7 +32810,11 @@ export class OrcaRuntimeService {
       VISIBLE_TERMINAL_SNAPSHOT_TIMEOUT_MS,
       null
     )
-    if (!this.ptysById.has(pty.ptyId) || !restoredTerminalTailSeedAllowed(pty)) {
+    if (
+      !this.ptysById.has(pty.ptyId) ||
+      this.legacyWorkerRecoveredPtys.has(pty.ptyId) ||
+      !restoredTerminalTailSeedAllowed(pty)
+    ) {
       return
     }
     if (!snapshot) {
@@ -32812,10 +32822,12 @@ export class OrcaRuntimeService {
       return
     }
     const text = `${snapshot.scrollbackAnsi ?? ''}${snapshot.data}`
-    this.seedTerminalRestoreTail(pty.ptyId, {
-      ...(text.length > 0 ? { text } : {}),
-      ...(snapshot.lastTitle ? { lastTitle: snapshot.lastTitle } : {})
-    })
+    // Listing preview only — applying this 24-row snapshot to the restore tail
+    // spends the one-shot seed and blocks the 120-row read/reveal fetch.
+    const seed = text.length > 0 ? buildRestoredTerminalTailSeed(text) : null
+    if (seed) {
+      pty.providerActivityPreview = seed.preview
+    }
   }
 
   private refreshFloatingWorkspacePtyLiveness(): Set<string> | null {
@@ -33050,10 +33062,11 @@ export class OrcaRuntimeService {
       !leaf.ptyId.startsWith('remote:') &&
       parseAppSshPtyId(leaf.ptyId) === null &&
       this.ptyController?.hasPty?.(leaf.ptyId) !== true
+    const preview = leaf.preview || pty?.providerActivityPreview || ''
     const activityUnverifiable =
       !provenAbsent &&
       leaf.lastOutputAt === null &&
-      leaf.preview.length === 0 &&
+      preview.length === 0 &&
       pty?.providerActivityObservation === 'unverifiable'
     return {
       handle: this.issueHandle(leaf),
@@ -33069,7 +33082,7 @@ export class OrcaRuntimeService {
       connected: provenAbsent ? false : leaf.connected,
       writable: provenAbsent ? false : leaf.writable,
       lastOutputAt: leaf.lastOutputAt,
-      preview: leaf.preview,
+      preview,
       ...(activityUnverifiable ? { activityObservation: 'unverifiable' } : {}),
       ...(leaf.lastExitCause ? { exitCause: leaf.lastExitCause } : {}),
       ...this.terminalExecutionHostField(leaf.ptyId, leaf.worktreeId)
@@ -35035,9 +35048,10 @@ export class OrcaRuntimeService {
 
     const pane = parsePaneKey(pty.paneKey ?? '')
     const orphaned = !pty.tabId || !pane || pane.tabId !== pty.tabId
+    const preview = pty.preview || pty.providerActivityPreview || ''
     const activityUnverifiable =
       pty.lastOutputAt === null &&
-      pty.preview.length === 0 &&
+      preview.length === 0 &&
       pty.providerActivityObservation === 'unverifiable'
     return {
       handle: this.issuePtyHandle(pty),
@@ -35053,7 +35067,7 @@ export class OrcaRuntimeService {
       connected: pty.connected,
       writable: pty.connected,
       lastOutputAt: pty.lastOutputAt,
-      preview: pty.preview,
+      preview,
       ...(activityUnverifiable ? { activityObservation: 'unverifiable' } : {}),
       ...(pty.lastExitCause ? { exitCause: pty.lastExitCause } : {}),
       ...this.terminalExecutionHostField(pty.ptyId, pty.worktreeId)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1518,6 +1518,10 @@ type RuntimePtyWorktreeRecord = {
   waitBlockedAt: number | null
   // Why: memoized wait scan of the current retained tail (see RuntimeLeafRecord).
   tailWaitState?: TerminalTailWaitState
+  // Why: inventory rediscovers daemon PTYs this main never attached to; a failed
+  // provider snapshot must not be re-asked on every list (200-row hot path).
+  providerActivitySeedAttempted?: boolean
+  providerActivityObservation?: 'unverifiable'
 }
 
 type TerminalAgentStatusSnapshot = {
@@ -11064,6 +11068,7 @@ export class OrcaRuntimeService {
       pty.connected = true
       pty.disconnectedAt = null
       pty.lastOutputAt = at
+      pty.providerActivityObservation = undefined
       const normalized = normalizeTerminalChunk(data, pty.tailPendingAnsi)
       pty.tailPendingAnsi = normalized.pendingAnsi
       const nextTail = appendNormalizedToTailBuffer(
@@ -32737,12 +32742,80 @@ export class OrcaRuntimeService {
       }
     }
     this.pruneDisconnectedPtyRecords()
+    const livePtyIdsForActivitySeed = targetWorktreeId ? selectedLivePtyIds : allLivePtyIds
+    if (deadline === undefined || Date.now() < deadline) {
+      await this.seedUnattachedLocalDaemonPtyActivityFromProvider(livePtyIdsForActivitySeed)
+    }
     return {
-      livePtyIds: targetWorktreeId ? selectedLivePtyIds : allLivePtyIds,
+      livePtyIds: livePtyIdsForActivitySeed,
       allLivePtyIds,
       terminalIdentityByPtyId: controllerIdentityByPtyId,
       queriedHostIds
     }
+  }
+
+  // Why: inventory records a never-attached local daemon PTY at construction
+  // defaults; list would otherwise report lastOutputAt:null / preview:"" as if
+  // that were an observation. Seed once from the same provider snapshot `read`
+  // already consults. Recency stays unset — snapshot bytes are historical.
+  private async seedUnattachedLocalDaemonPtyActivityFromProvider(
+    livePtyIds: ReadonlySet<string>
+  ): Promise<void> {
+    const candidates: RuntimePtyWorktreeRecord[] = []
+    for (const ptyId of livePtyIds) {
+      if (candidates.length >= DEFAULT_TERMINAL_LIST_LIMIT) {
+        break
+      }
+      if (!this.isKnownUnattachedLocalDaemonPty(ptyId)) {
+        continue
+      }
+      const pty = this.ptysById.get(ptyId)
+      if (!pty || pty.providerActivitySeedAttempted || !restoredTerminalTailSeedAllowed(pty)) {
+        continue
+      }
+      pty.providerActivitySeedAttempted = true
+      candidates.push(pty)
+    }
+    if (candidates.length === 0) {
+      return
+    }
+    const serialize = this.ptyController?.serializeProviderBuffer
+    if (!serialize) {
+      for (const pty of candidates) {
+        pty.providerActivityObservation = 'unverifiable'
+      }
+      return
+    }
+    await Promise.all(
+      candidates.map((pty) => this.seedOneUnattachedLocalDaemonPtyActivity(pty, serialize))
+    )
+  }
+
+  private async seedOneUnattachedLocalDaemonPtyActivity(
+    pty: RuntimePtyWorktreeRecord,
+    serialize: NonNullable<RuntimePtyController['serializeProviderBuffer']>
+  ): Promise<void> {
+    // Why Promise.resolve().then: a synchronous serialize throw must become a
+    // rejection so withTimeout can map it to null instead of aborting the sweep.
+    const snapshot = await withTimeout(
+      Promise.resolve().then(() =>
+        serialize(pty.ptyId, { scrollbackRows: LIST_PROVIDER_ACTIVITY_SEED_ROWS })
+      ),
+      VISIBLE_TERMINAL_SNAPSHOT_TIMEOUT_MS,
+      null
+    )
+    if (!this.ptysById.has(pty.ptyId) || !restoredTerminalTailSeedAllowed(pty)) {
+      return
+    }
+    if (!snapshot) {
+      pty.providerActivityObservation = 'unverifiable'
+      return
+    }
+    const text = `${snapshot.scrollbackAnsi ?? ''}${snapshot.data}`
+    this.seedTerminalRestoreTail(pty.ptyId, {
+      ...(text.length > 0 ? { text } : {}),
+      ...(snapshot.lastTitle ? { lastTitle: snapshot.lastTitle } : {})
+    })
   }
 
   private refreshFloatingWorkspacePtyLiveness(): Set<string> | null {
@@ -32977,6 +33050,11 @@ export class OrcaRuntimeService {
       !leaf.ptyId.startsWith('remote:') &&
       parseAppSshPtyId(leaf.ptyId) === null &&
       this.ptyController?.hasPty?.(leaf.ptyId) !== true
+    const activityUnverifiable =
+      !provenAbsent &&
+      leaf.lastOutputAt === null &&
+      leaf.preview.length === 0 &&
+      pty?.providerActivityObservation === 'unverifiable'
     return {
       handle: this.issueHandle(leaf),
       ptyId: leaf.ptyId,
@@ -32992,6 +33070,7 @@ export class OrcaRuntimeService {
       writable: provenAbsent ? false : leaf.writable,
       lastOutputAt: leaf.lastOutputAt,
       preview: leaf.preview,
+      ...(activityUnverifiable ? { activityObservation: 'unverifiable' } : {}),
       ...(leaf.lastExitCause ? { exitCause: leaf.lastExitCause } : {}),
       ...this.terminalExecutionHostField(leaf.ptyId, leaf.worktreeId)
     }
@@ -34956,6 +35035,10 @@ export class OrcaRuntimeService {
 
     const pane = parsePaneKey(pty.paneKey ?? '')
     const orphaned = !pty.tabId || !pane || pane.tabId !== pty.tabId
+    const activityUnverifiable =
+      pty.lastOutputAt === null &&
+      pty.preview.length === 0 &&
+      pty.providerActivityObservation === 'unverifiable'
     return {
       handle: this.issuePtyHandle(pty),
       ptyId: pty.ptyId,
@@ -34971,6 +35054,7 @@ export class OrcaRuntimeService {
       writable: pty.connected,
       lastOutputAt: pty.lastOutputAt,
       preview: pty.preview,
+      ...(activityUnverifiable ? { activityObservation: 'unverifiable' } : {}),
       ...(pty.lastExitCause ? { exitCause: pty.lastExitCause } : {}),
       ...this.terminalExecutionHostField(pty.ptyId, pty.worktreeId)
     }
@@ -38588,6 +38672,9 @@ const VISIBLE_TERMINAL_SNAPSHOT_TIMEOUT_MS = 750
 const VISIBLE_TERMINAL_SNAPSHOT_RETRY_MS = 1_000
 const MAX_PREVIEW_LINES = 6
 const MAX_PREVIEW_CHARS = 300
+// Why: list preview is 6 lines; extra rows cover CR redraws without a full
+// terminal-read snapshot (DEFAULT_TERMINAL_READ_LIMIT is 120).
+const LIST_PROVIDER_ACTIVITY_SEED_ROWS = 24
 const WORKTREE_STATUS_PRIORITY: Record<RuntimeWorktreeStatus, number> = {
   inactive: 0,
   active: 1,

--- a/src/main/runtime/terminal-list-inventory-activity-seed.test.ts
+++ b/src/main/runtime/terminal-list-inventory-activity-seed.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it, vi } from 'vitest'
+import { OrcaRuntimeService } from './orca-runtime'
+import { getDefaultWorkspaceSession } from '../../shared/constants'
+import type { WorkspaceSessionState } from '../../shared/workspace-session-state-types'
+import type { PtyProviderBufferSnapshot } from '../providers/pty-provider-contract'
+
+// STA-4326: after an Orca restart, local daemon PTYs are rediscovered only
+// through controller inventory. This main never attached, so onPtyData never
+// writes lastOutputAt/preview and `terminal list` reported construction
+// defaults (null / "") while `terminal read` already fell back to the
+// provider snapshot. List must seed from that same authority once, without
+// fabricating recency or doing a daemon round trip per row on every list.
+
+const WORKTREE_ID = 'repo-1::/tmp/inventory-activity'
+const UUID = (n: number): string => {
+  const hex = n.toString(16).padStart(12, '0')
+  return `11111111-1111-4111-8111-${hex}`
+}
+
+function makeStore() {
+  const session: WorkspaceSessionState = getDefaultWorkspaceSession()
+  return {
+    getWorkspaceSession: vi.fn(() => session),
+    setWorkspaceSession: vi.fn(),
+    getRepos: vi.fn(() => [
+      {
+        id: 'repo-1',
+        path: '/tmp/inventory-activity',
+        displayName: 'inventory-activity',
+        badgeColor: '#000000',
+        addedAt: 0
+      }
+    ]),
+    getAllWorktreeMeta: vi.fn(() => ({})),
+    getWorktreeMeta: vi.fn(() => undefined),
+    setWorktreeMeta: vi.fn(),
+    removeWorktreeMeta: vi.fn(),
+    getSettings: vi.fn(() => ({ workspaceDir: '/tmp/workspaces' })),
+    getProjects: vi.fn(() => [])
+  }
+}
+
+type SnapshotFn = (ptyId: string) => Promise<PtyProviderBufferSnapshot | null>
+
+function providerSnapshot(data: string): PtyProviderBufferSnapshot {
+  return {
+    data,
+    cols: 80,
+    rows: 24,
+    seq: 42,
+    source: 'headless'
+  }
+}
+
+function makeRuntime(options: {
+  panes: { ptyId: string; leafId: string }[]
+  serializeProviderBuffer?: SnapshotFn
+}): { runtime: OrcaRuntimeService; serializeProviderBuffer: ReturnType<typeof vi.fn> } {
+  const serializeProviderBuffer = vi.fn(
+    options.serializeProviderBuffer ??
+      (async (ptyId: string) => providerSnapshot(`daemon screen for ${ptyId}\r\n`))
+  )
+  const runtime = new OrcaRuntimeService(makeStore() as never)
+  runtime.setPtyController({
+    spawn: vi.fn(async () => ({ id: 'never' })),
+    write: () => true,
+    kill: () => true,
+    listProcesses: vi.fn(async () =>
+      options.panes.map((pane) => ({
+        id: pane.ptyId,
+        cwd: '/tmp/inventory-activity',
+        worktreeId: WORKTREE_ID,
+        title: 'shell'
+      }))
+    ),
+    serializeProviderBuffer
+  } as never)
+  runtime.attachWindow(1)
+  runtime.syncWindowGraph(1, {
+    tabs: options.panes.map((pane, index) => ({
+      tabId: `tab-${index + 1}`,
+      worktreeId: WORKTREE_ID,
+      title: '',
+      activeLeafId: pane.leafId,
+      layout: null
+    })),
+    leaves: options.panes.map((pane, index) => ({
+      tabId: `tab-${index + 1}`,
+      worktreeId: WORKTREE_ID,
+      leafId: pane.leafId,
+      paneRuntimeId: 1,
+      ptyId: pane.ptyId,
+      paneTitle: null,
+      title: ''
+    }))
+  })
+  return { runtime, serializeProviderBuffer }
+}
+
+describe('listTerminals provider activity seed for never-attached daemon PTYs', () => {
+  it('reports the provider screen for a PTY this main never attached to', async () => {
+    const ptyId = 'pty-never-attached'
+    const { runtime, serializeProviderBuffer } = makeRuntime({
+      panes: [{ ptyId, leafId: UUID(1) }],
+      serializeProviderBuffer: async () =>
+        providerSnapshot('Thinking… 12.4k tokens\r\nEditing src/foo.ts\r\n')
+    })
+
+    const { terminals } = await runtime.listTerminals(`id:${WORKTREE_ID}`)
+
+    expect(terminals).toHaveLength(1)
+    expect(terminals[0]).toMatchObject({
+      ptyId,
+      connected: true,
+      preview: expect.stringContaining('Thinking… 12.4k tokens')
+    })
+    expect(terminals[0]!.preview).toContain('Editing src/foo.ts')
+    // Snapshot bytes are historical — recency is only live onPtyData.
+    expect(terminals[0]!.lastOutputAt).toBeNull()
+    expect(terminals[0]!.activityObservation).toBeUndefined()
+    expect(serializeProviderBuffer).toHaveBeenCalledOnce()
+    expect(serializeProviderBuffer).toHaveBeenCalledWith(
+      ptyId,
+      expect.objectContaining({ scrollbackRows: expect.any(Number) })
+    )
+    expect(serializeProviderBuffer.mock.calls[0]![1]!.scrollbackRows).toBeLessThan(120)
+  })
+
+  it('leaves an attached PTY that already ingested live bytes unchanged', async () => {
+    const livePtyId = 'pty-already-attached'
+    const { runtime, serializeProviderBuffer } = makeRuntime({
+      panes: [{ ptyId: livePtyId, leafId: UUID(2) }]
+    })
+    runtime.onPtyData(livePtyId, 'live prompt $\r\n', 1_700_000_000_000)
+
+    const { terminals } = await runtime.listTerminals(`id:${WORKTREE_ID}`)
+
+    expect(terminals).toHaveLength(1)
+    expect(terminals[0]).toMatchObject({
+      ptyId: livePtyId,
+      connected: true,
+      lastOutputAt: 1_700_000_000_000,
+      preview: 'live prompt $'
+    })
+    expect(terminals[0]!.activityObservation).toBeUndefined()
+    expect(serializeProviderBuffer).not.toHaveBeenCalled()
+  })
+
+  it('marks activity unverifiable when the provider snapshot cannot be consulted', async () => {
+    const ptyId = 'pty-snapshot-unavailable'
+    const { runtime, serializeProviderBuffer } = makeRuntime({
+      panes: [{ ptyId, leafId: UUID(3) }],
+      serializeProviderBuffer: async () => null
+    })
+
+    const { terminals } = await runtime.listTerminals(`id:${WORKTREE_ID}`)
+
+    expect(terminals).toHaveLength(1)
+    expect(terminals[0]).toMatchObject({
+      ptyId,
+      connected: true,
+      lastOutputAt: null,
+      preview: '',
+      activityObservation: 'unverifiable'
+    })
+    // A missing snapshot is not an exit and must not invent recency.
+    expect(terminals[0]!.lastOutputAt).toBeNull()
+    expect(serializeProviderBuffer).toHaveBeenCalledOnce()
+  })
+
+  it('seeds each never-attached PTY once and never round-trips an attached row', async () => {
+    const attachedPtyId = 'pty-live'
+    const unattached = ['pty-a', 'pty-b', 'pty-c', 'pty-d'].map((ptyId, index) => ({
+      ptyId,
+      leafId: UUID(10 + index)
+    }))
+    const { runtime, serializeProviderBuffer } = makeRuntime({
+      panes: [{ ptyId: attachedPtyId, leafId: UUID(20) }, ...unattached]
+    })
+    runtime.onPtyData(attachedPtyId, 'already live\r\n', 42)
+
+    const first = await runtime.listTerminals(`id:${WORKTREE_ID}`)
+    const second = await runtime.listTerminals(`id:${WORKTREE_ID}`)
+
+    expect(first.terminals).toHaveLength(5)
+    expect(second.terminals).toHaveLength(5)
+    const unattachedFirst = first.terminals.filter((terminal) => terminal.ptyId !== attachedPtyId)
+    expect(unattachedFirst.map((terminal) => terminal.preview)).toEqual([
+      'daemon screen for pty-a',
+      'daemon screen for pty-b',
+      'daemon screen for pty-c',
+      'daemon screen for pty-d'
+    ])
+    expect(unattachedFirst.every((terminal) => terminal.lastOutputAt === null)).toBe(true)
+    expect(first.terminals.find((terminal) => terminal.ptyId === attachedPtyId)).toMatchObject({
+      lastOutputAt: 42,
+      preview: 'already live'
+    })
+    expect(serializeProviderBuffer).toHaveBeenCalledTimes(unattached.length)
+    expect(serializeProviderBuffer.mock.calls.map((call) => call[0])).toEqual(
+      unattached.map((pane) => pane.ptyId)
+    )
+  })
+})

--- a/src/main/runtime/terminal-list-inventory-activity-seed.test.ts
+++ b/src/main/runtime/terminal-list-inventory-activity-seed.test.ts
@@ -201,4 +201,25 @@ describe('listTerminals provider activity seed for never-attached daemon PTYs', 
       unattached.map((pane) => pane.ptyId)
     )
   })
+
+  it('does not spend the restore-tail budget a later read still fetches at 120 rows', async () => {
+    const ptyId = 'pty-list-must-not-consume-restore-tail'
+    const { runtime, serializeProviderBuffer } = makeRuntime({
+      panes: [{ ptyId, leafId: UUID(4) }],
+      serializeProviderBuffer: async () =>
+        providerSnapshot('Thinking… 12.4k tokens\r\nEditing src/foo.ts\r\n')
+    })
+
+    const { terminals } = await runtime.listTerminals(`id:${WORKTREE_ID}`)
+    expect(terminals[0]).toMatchObject({
+      ptyId,
+      preview: expect.stringContaining('Thinking… 12.4k tokens')
+    })
+    expect(serializeProviderBuffer).toHaveBeenCalledOnce()
+    expect(serializeProviderBuffer.mock.calls[0]![1]!.scrollbackRows).toBeLessThan(120)
+
+    serializeProviderBuffer.mockClear()
+    await runtime.readTerminal(terminals[0]!.handle)
+    expect(serializeProviderBuffer).toHaveBeenCalledWith(ptyId, { scrollbackRows: 120 })
+  })
 })

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -470,8 +470,17 @@ export type RuntimeTerminalSummary = {
   title: string | null
   connected: boolean
   writable: boolean
+  /** Epoch ms of the last byte this main ingested via live PTY data. Null means
+   *  this main has not ingested live output — never a synthesized snapshot time,
+   *  and never idle/exited by itself. A seeded `preview` is retained screen;
+   *  `activityObservation: 'unverifiable'` means the provider could not be asked. */
   lastOutputAt: number | null
   preview: string
+  /** Present only when this main has no live output, the listing preview is
+   *  empty, and the provider snapshot could not be consulted. The PTY is still
+   *  live in inventory — never read this as idle or exited. Absent on older
+   *  hosts. */
+  activityObservation?: 'unverifiable'
   /** Why this terminal's process is gone. Absent while it is still running, and
    *  absent from a host predating the field — never read an absent value as a
    *  clean finish (STA-4536). */


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​225 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​225 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​114 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​19 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​95 |

<!-- /orca-pr-loc -->

## ELI5

After Orca restarts, `orca terminal list` said a still-running agent pane had never produced output, while `orca terminal read` of the same pane showed the live TUI. List was looking at a blank in-memory notepad this process never wrote to. It now copies a small screen snapshot from the daemon that kept the pane alive, once, when listing rediscovers that pane. That listing snapshot is a short preview only — it does not steal the deeper scrollback `terminal read` and legacy worker reveal still fetch.

## What Changed

- `listTerminals` seeds a **listing-only** preview from a 24-row provider snapshot for never-attached local daemon PTYs. It does **not** write the shared restore tail.
- `lastOutputAt` is not invented from that snapshot. Snapshot bytes are historical screen state, not a recency event.
- If the daemon snapshot cannot be consulted, list adds optional `activityObservation: "unverifiable"` and leaves `lastOutputAt` null. That is not idle and not exited.
- Seed is once per PTY, capped at the 200-row listing limit, 24 rows, 750ms timeout. Attached PTYs that already ingested live bytes are not round-tripped.
- Recovered legacy workers skip the listing seed so their own 120-row provider read still runs.

## Why

`onPtyData` was the only writer of `lastOutputAt` / `preview`. A pane whose PTY survived restart is discovered only through controller inventory, so this main never attached and never ingested a byte. `terminal read` already fell back to the provider snapshot; `terminal list` did not. Callers treat a null `lastOutputAt` as idle/dead and conclude a live worker is finished.

A first version of this seed wrote the shared restore tail. That spent the one-shot restore budget at 24 rows, so the legacy provider-reveal never issued its own 120-row fetch and the revealed worker showed a truncated scrollback. Listing preview and restore tail are different products with different depths; they stay separate.

## Linked Issue

Fixes #14523
Linear: [STA-4326](https://linear.app/stably/issue/STA-4326)

## Visual Proof

N/A — CLI listing contract in the main process. No layout, chrome, or renderer styling change.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated

Commands:

```
pnpm vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts -t "fences provider resume and reveals one exact live legacy worker without stealing focus"
pnpm vitest run --config config/vitest.config.ts src/main/runtime/terminal-list-inventory-activity-seed.test.ts
pnpm typecheck
node config/scripts/check-changed-code-quality.mjs -- 4e058d4a52ea4653a5cf86fac271c8010334361e
```

Legacy-worker reveal (`serializeProviderBuffer` at 120 rows), unmodified expectation:

- **Pre-fix:** FAIL. `toHaveBeenCalledWith('pty-legacy', { scrollbackRows: 120 })` received `{ scrollbackRows: 24 }`, number of calls: 1.
- **Post-fix:** PASS.
- **Neutered** (listing seed wrote the restore tail again from shared inventory): FAIL, same 24-vs-120 assertion.

Listing seed suite (5 tests):

- **Pre-fix (STA-4326):** 3 failed / 1 passed. Inventory-discovered PTY listed `preview: ""`; `activityObservation` absent.
- **Post-fix:** 5 passed, including a new assertion that a later `read` still fetches at 120 rows.
- **Neutered** (list seed call removed, tests kept): 4 failed / 1 passed (attached live-bytes row still passes).

Covered: (a) never-attached PTY reports the provider screen through `list`; (b) attached PTY with live bytes is unchanged and does not call `serializeProviderBuffer`; (c) missing snapshot is `activityObservation: unverifiable` with `lastOutputAt` still null; (d) four unattached rows seed once, the attached row is skipped, and a second `list` does not round-trip again; (e) listing seed does not consume the restore-tail budget.

`pnpm typecheck` passed. Changed-code quality gate passed since `4e058d4a52ea`.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

**`lastOutputAt` after this change:** epoch ms of the last byte this main ingested via `onPtyData`. Null means this main has not ingested live output — not idle, not exited, and never a synthesized snapshot timestamp. A seeded listing `preview` is retained screen. `activityObservation: "unverifiable"` means the provider snapshot could not be asked; inventory still proved the PTY live.

SSH-scoped PTYs are not seeded here (they have their own lease/reattach path). Folder workspaces use the same inventory record. New optional JSON field only; old clients ignore it. No new stream opcode.

Author: @BrennanKB5

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)