### PR TITLE
feat(plugins): carry session identifiers on agent.status.changed

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2907,7 +2907,13 @@ void app.whenReady().then(async () => {
       worktreeId: enriched.worktreeId ?? null,
       paneKey: enriched.paneKey,
       state: enriched.payload.state,
-      receivedAt: enriched.receivedAt
+      receivedAt: enriched.receivedAt,
+      ...(enriched.providerSession?.id
+        ? { sessionId: enriched.providerSession.id }
+        : {}),
+      ...(enriched.providerSession?.transcriptPath
+        ? { transcriptPath: enriched.providerSession.transcriptPath }
+        : {})
     })
   })
   runtimeService.onWorktreeLifecycle((event) => {

--- a/src/shared/plugins/plugin-agent-status-payload.test.ts
+++ b/src/shared/plugins/plugin-agent-status-payload.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { agentStatusChangedPayloadSchema } from './plugin-events'
+
+describe('agent.status.changed payload schema', () => {
+  const base = {
+    worktreeId: 'repo-1::/repo',
+    paneKey: 'tab-1:11111111-1111-4111-8111-111111111111',
+    state: 'working',
+    receivedAt: Date.now()
+  }
+
+  it('accepts the historical four-field payload (backwards compatibility)', () => {
+    const parsed = agentStatusChangedPayloadSchema.safeParse(base)
+    expect(parsed.success).toBe(true)
+  })
+
+  it('accepts session identifiers so plugins can tell agents apart (#15639)', () => {
+    const parsed = agentStatusChangedPayloadSchema.safeParse({
+      ...base,
+      sessionId: 'session-A',
+      transcriptPath: '/transcripts/session-A.jsonl'
+    })
+    expect(parsed.success).toBe(true)
+    if (parsed.success) {
+      expect(parsed.data.sessionId).toBe('session-A')
+      expect(parsed.data.transcriptPath).toBe('/transcripts/session-A.jsonl')
+    }
+  })
+
+  it('keeps the fields optional for agents that report no session', () => {
+    const parsed = agentStatusChangedPayloadSchema.safeParse(base)
+    expect(parsed.success).toBe(true)
+    if (parsed.success) {
+      expect(parsed.data.sessionId).toBeUndefined()
+      expect(parsed.data.transcriptPath).toBeUndefined()
+    }
+  })
+
+  it('rejects empty session identifiers rather than emitting ambiguous blanks', () => {
+    const parsed = agentStatusChangedPayloadSchema.safeParse({
+      ...base,
+      sessionId: ''
+    })
+    expect(parsed.success).toBe(false)
+  })
+})

--- a/src/shared/plugins/plugin-events.ts
+++ b/src/shared/plugins/plugin-events.ts
@@ -29,7 +29,14 @@ export const agentStatusChangedPayloadSchema = z.object({
   worktreeId: z.string().min(1).max(2048).nullable(),
   paneKey: z.string().min(1).max(2048),
   state: z.string().min(1).max(256),
-  receivedAt: z.number().finite().positive()
+  receivedAt: z.number().finite().positive(),
+  // Why (#15639): several agents can share one worktree, and paneKey alone
+  // cannot name WHICH session changed. The provider's own session id and
+  // transcript path are already captured on the status entry; surface them so
+  // plugins correlate without guessing by transcript mtime. Optional because
+  // not every agent CLI reports a session on every status event.
+  sessionId: z.string().min(1).max(2048).optional(),
+  transcriptPath: z.string().min(1).max(4096).optional()
 })
 
 export const PLUGIN_EVENT_PAYLOAD_SCHEMAS: Record<PluginEventName, z.ZodTypeAny> = {


### PR DESCRIPTION
## Summary

**What**

`agent.status.changed` plugin events now carry `sessionId` and `transcriptPath` (both optional) when the status entry captured a provider session, alongside the existing `worktreeId` / `paneKey` / `state` / `receivedAt`.

**Why**

#15639 — a plugin that needs to know *which agent session* changed state had to guess, typically by picking the most-recently-modified transcript under the worktree's project slug. With two agents side by side in one worktree — Orca's headline workflow — that's a coin flip. The reporter's TTS plugin detects the ambiguity and warns rather than confidently speaking the wrong agent's words.

The data already existed: `AgentStatusEntry.providerSession` carries the provider's own session id and transcript path, and the hook server already surfaces the same fields in its status-change notification (`AgentHookProviderSessionIdentity`). The plugin emit site simply copied only four fields. This forwards the two correlation handles when present.

Both fields are optional in the payload schema — not every agent CLI reports a session on every status event — so existing emitters and plugins keep working with the historical four-field shape.

**Testing**

New `plugin-agent-status-payload.test.ts` (4 cases): the historical four-field payload still parses (backwards compatibility); session identifiers parse and round-trip; the fields stay optional when absent; empty strings are rejected rather than emitting ambiguous blanks. `plugin-host-process.test.ts` unchanged 6/6 (its event flood uses the historical shape); `pnpm run typecheck` clean.

Fixes #15639