### PR TITLE
fix(native-chat): set Claude fast mode with /fast on|off (STA-4428)

### DIFF
--- a/mobile/src/session/MobileNativeChatSessionOptionRows.tsx
+++ b/mobile/src/session/MobileNativeChatSessionOptionRows.tsx
@@ -169,17 +169,6 @@ export function DescriptorRows({
   onInvokeAction: () => void
 }): React.JSX.Element {
   const locked = disabled || !descriptor.settable
-  // Why: flip-only without a baseline is an action — never claim On/Off.
-  if (descriptor.action?.type === 'toggle-command') {
-    return (
-      <ActionRow
-        label={`Toggle ${descriptor.label.toLowerCase()}`}
-        disabled={locked}
-        grouped={grouped}
-        onPress={onInvokeAction}
-      />
-    )
-  }
   // Why: agent-picker opens the TUI; it is not a set of radio choices.
   if (descriptor.action?.type === 'agent-picker') {
     return (

--- a/mobile/src/session/use-mobile-native-chat-session-options.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-session-options.test.ts
@@ -143,6 +143,21 @@ describe('useMobileNativeChatSessionOptions', () => {
     expect(effort!.kind).toMatchObject({ currentValue: 'low' })
   })
 
+  it('sets Claude fast mode with /fast on rather than a bare /fast', async () => {
+    mount({ reportedModel: 'opus' })
+    const fast = api!.snapshot.find((descriptor) => descriptor.id === 'fastMode')
+    expect(fast?.action).toBeUndefined()
+    await act(async () => {
+      await api!.setOption('fastMode', true)
+    })
+    expect(dispatchCommand).toHaveBeenCalledWith('/fast on')
+    expect(dispatchCommand).not.toHaveBeenCalledWith('/fast')
+    expect(api!.snapshot.find((descriptor) => descriptor.id === 'fastMode')).toMatchObject({
+      valueSource: 'dispatched',
+      kind: { currentValue: true }
+    })
+  })
+
   it('does not file an option under a model that changed mid-dispatch', async () => {
     const resolvers: ((outcome: MobileNativeChatSendOutcome) => void)[] = []
     dispatchCommand.mockImplementation(

--- a/mobile/src/session/use-mobile-native-chat-session-options.ts
+++ b/mobile/src/session/use-mobile-native-chat-session-options.ts
@@ -23,7 +23,6 @@ import {
   clearNativeChatSessionModel,
   createNativeChatSessionOptionRecord,
   getTrackedSessionOption,
-  isFlipOnlyMidSession,
   matchNativeChatCatalogModelId,
   setTrackedSessionOption,
   type NativeChatSessionOptionRecord
@@ -224,18 +223,6 @@ export function useMobileNativeChatSessionOptions(args: {
         if (!apply || apply.midSession?.kind === 'agent-picker') {
           return false
         }
-        const flipOnly = isFlipOnlyMidSession(apply.midSession)
-        const trackedToggle = flipOnly
-          ? getTrackedSessionOption(record, previousModelId, id)
-          : undefined
-        if (flipOnly && !trackedToggle) {
-          // Why: a flip from an unknown baseline cannot honor an absolute target.
-          return false
-        }
-        // Why: same absolute target must never re-dispatch a flip (would invert the agent).
-        if (flipOnly && trackedToggle?.value === value) {
-          return true
-        }
         const command = buildNativeChatSessionOptionCommand({
           optionId: id,
           value,
@@ -276,8 +263,7 @@ export function useMobileNativeChatSessionOptions(args: {
             delete record.valuesByModel[value]
           }
         }
-        // Why: flip-only never heals via agent report — track as applied best-known.
-        setTrackedSessionOption(record, id, value, flipOnly ? 'applied' : 'dispatched')
+        setTrackedSessionOption(record, id, value, 'dispatched')
         bump()
         return true
       })
@@ -311,10 +297,6 @@ export function useMobileNativeChatSessionOptions(args: {
           bump()
           onAgentPicker?.()
           return true
-        }
-        if (isFlipOnlyMidSession(midSession) && !getTrackedSessionOption(record, modelId, id)) {
-          // Why: an unknown baseline remains unknown after one inversion.
-          return (await dispatchCommand(midSession.command)) !== 'rejected'
         }
         return false
       })

--- a/src/renderer/src/components/native-chat/NativeChatSessionOptionPickers.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatSessionOptionPickers.test.tsx
@@ -337,7 +337,7 @@ describe('NativeChatSessionOptionPickers', () => {
     await waitFor(() => expect(invokeAction).toHaveBeenCalledWith('model'))
   })
 
-  it('uses a Toggle action for unknown flip-only options via invokeAction', async () => {
+  it('uses On/Off radios for unknown fast mode instead of a Toggle action', async () => {
     const invokeAction = vi.fn().mockResolvedValue({ snapshot: [] })
     const setOption = vi.fn().mockResolvedValue({ snapshot: [] })
     const liveSurface = { ...surface, setOption, invokeAction }
@@ -349,19 +349,17 @@ describe('NativeChatSessionOptionPickers', () => {
           {
             ...fast,
             kind: { type: 'boolean' },
-            valueSource: 'unknown',
-            action: { type: 'toggle-command' }
+            valueSource: 'unknown'
           }
         ]}
         isWorking={false}
       />
     )
-    expect(screen.getByText('Toggle fast mode')).not.toBeNull()
-    expect(screen.queryByText('On')).toBeNull()
-    expect(screen.queryByText('Off')).toBeNull()
-    screen.getByText('Toggle fast mode').click()
-    await waitFor(() => expect(invokeAction).toHaveBeenCalledWith('fastMode'))
-    expect(setOption).not.toHaveBeenCalled()
+    expect(screen.queryByText('Toggle fast mode')).toBeNull()
+    expect(screen.getByText('Current value unknown — pick On or Off')).not.toBeNull()
+    screen.getByRole('radio', { name: 'On' }).click()
+    await waitFor(() => expect(setOption).toHaveBeenCalledWith('fastMode', true))
+    expect(invokeAction).not.toHaveBeenCalled()
   })
 
   it('uses On/Off radios for known boolean options without inventing a selection', async () => {

--- a/src/renderer/src/components/native-chat/NativeChatSessionOptionPickers.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatSessionOptionPickers.tsx
@@ -116,16 +116,6 @@ function DescriptorMenuRows(props: {
   invokeAction: () => void
 }): React.JSX.Element {
   const { descriptor, pending, setValue, invokeAction } = props
-  // Why: flip-only without a baseline is an action — never claim On/Off.
-  if (descriptor.action?.type === 'toggle-command') {
-    return (
-      <DropdownMenuItem disabled={!descriptor.settable || pending} onSelect={() => invokeAction()}>
-        {translate('components.native-chat.composer.toggleOption', 'Toggle {{value0}}', {
-          value0: nativeChatSessionOptionLabel(descriptor).toLowerCase()
-        })}
-      </DropdownMenuItem>
-    )
-  }
   // Why: agent-picker opens the TUI; it is not a set of radio choices.
   if (descriptor.action?.type === 'agent-picker') {
     return (

--- a/src/renderer/src/components/native-chat/claude-terminal-session-options.test.ts
+++ b/src/renderer/src/components/native-chat/claude-terminal-session-options.test.ts
@@ -248,7 +248,7 @@ describe('Claude terminal session option detection', () => {
         frame('Opus 4.8 with high effort · API Usage Billing'),
         DISCOVERED
       )
-    ).toEqual({ model: 'opus', effort: 'high' })
+    ).toEqual({ model: 'opus', effort: 'high', fastMode: false })
   })
 
   it('still reports a custom model when the host list cannot name it', () => {
@@ -268,7 +268,8 @@ describe('Claude terminal session option detection', () => {
 
     expect(readClaudeSessionOptionsFromTerminalScreen(screen)).toEqual({
       model: 'opus',
-      effort: 'high'
+      effort: 'high',
+      fastMode: false
     })
   })
 
@@ -280,7 +281,8 @@ describe('Claude terminal session option detection', () => {
 
     expect(readClaudeSessionOptionsFromTerminalScreen(screen)).toEqual({
       model: 'opus',
-      effort: 'high'
+      effort: 'high',
+      fastMode: false
     })
   })
 
@@ -316,7 +318,8 @@ describe('Claude terminal session option detection', () => {
 
     expect(readClaudeSessionOptionsFromTerminalScreen(screen)).toEqual({
       model: 'opus',
-      effort: 'xhigh'
+      effort: 'xhigh',
+      fastMode: false
     })
   })
 
@@ -332,6 +335,44 @@ describe('Claude terminal session option detection', () => {
     expect(
       readClaudeSessionOptionsFromTerminalScreen('I recommend Opus 4.8 for this task.')
     ).toBeNull()
+  })
+
+  it('reads fast mode from the status-line ↯ glyph once the banner names Opus', () => {
+    const withGlyph =
+      'Claude Code v2.1.237\r\n' +
+      'Opus 5 with high effort · API Usage Billing\r\n' +
+      '~/repo\r\n' +
+      '↯ Fast'
+
+    expect(readClaudeSessionOptionsFromTerminalScreen(withGlyph)).toEqual({
+      model: 'opus',
+      effort: 'high',
+      fastMode: true
+    })
+
+    const withoutGlyph =
+      'Claude Code v2.1.237\r\n' + 'Opus 5 with high effort · API Usage Billing\r\n' + '~/repo'
+
+    expect(readClaudeSessionOptionsFromTerminalScreen(withoutGlyph)).toEqual({
+      model: 'opus',
+      effort: 'high',
+      fastMode: false
+    })
+  })
+
+  it('does not treat the confirmation panel title as live fast mode', () => {
+    const screen =
+      'Claude Code v2.1.237\r\n' +
+      'Opus 5 with high effort · API Usage Billing\r\n' +
+      '~/repo\r\n' +
+      '↯ Fast mode (research preview)\r\n' +
+      'Tab to toggle · Enter to confirm · Esc to cancel'
+
+    expect(readClaudeSessionOptionsFromTerminalScreen(screen)).toEqual({
+      model: 'opus',
+      effort: 'high',
+      fastMode: false
+    })
   })
 
   it('recovers a custom model name that is not in the catalog', () => {

--- a/src/renderer/src/components/native-chat/claude-terminal-session-options.ts
+++ b/src/renderer/src/components/native-chat/claude-terminal-session-options.ts
@@ -231,5 +231,21 @@ export function readClaudeSessionOptionsFromTerminalScreen(
   if (effort && model.options.some((option) => option.id === 'effort')) {
     result.effort = effort
   }
+  // The banner proves this is Claude, so a missing glyph is a truthful `off`.
+  if (model.options.some((option) => option.id === 'fastMode')) {
+    result.fastMode = matchFastModeGlyph(lines)
+  }
   return result
+}
+
+const FAST_MODE_GLYPH = '\u21AF'
+const FAST_MODE_PANEL_TITLE = 'fast mode (research preview)'
+
+/** Whether the live status line carries the fast-mode glyph. Skips the
+ *  confirmation panel's title row, which carries it too — we never open that
+ *  panel ourselves, but a user can. */
+function matchFastModeGlyph(lines: readonly string[]): boolean {
+  return lines.some(
+    (line) => line.includes(FAST_MODE_GLYPH) && !line.toLowerCase().includes(FAST_MODE_PANEL_TITLE)
+  )
 }

--- a/src/renderer/src/components/native-chat/native-chat-pty-session-options.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pty-session-options.test.ts
@@ -54,7 +54,7 @@ describe('native chat PTY session options', () => {
       agent: 'claude',
       scopeKey: 'pty-1',
       mode: 'live',
-      reportedValues: { model: 'opus', effort: 'medium' },
+      reportedValues: { model: 'opus', effort: 'medium', fastMode: true },
       dispatchCommand: vi.fn()
     })!
 
@@ -69,6 +69,11 @@ describe('native chat PTY session options', () => {
           id: 'effort',
           valueSource: 'reported',
           kind: expect.objectContaining({ currentValue: 'medium' })
+        }),
+        expect.objectContaining({
+          id: 'fastMode',
+          valueSource: 'reported',
+          kind: expect.objectContaining({ type: 'boolean', currentValue: true })
         })
       ])
     )
@@ -235,7 +240,7 @@ describe('native chat PTY session options', () => {
     expect(onAgentPicker).not.toHaveBeenCalled()
   })
 
-  it('leaves flip-only unknown after a one-shot so the UI never invents on/off', async () => {
+  it('sets Claude fast mode with /fast on and /fast off rather than a bare /fast', async () => {
     seedNativeChatAppliedSessionOptions('pty-1', 'claude', {
       model: 'opus',
       effort: 'high'
@@ -250,25 +255,34 @@ describe('native chat PTY session options', () => {
       persistSelection: persist
     })!
     const fastBefore = surface.getSnapshot().find(({ id }) => id === 'fastMode')
-    expect(fastBefore?.action?.type).toBe('toggle-command')
+    expect(fastBefore?.action).toBeUndefined()
     expect(fastBefore?.kind).toMatchObject({ type: 'boolean' })
-    expect(fastBefore?.kind).not.toHaveProperty('defaultValue')
+    expect(fastBefore?.kind).not.toHaveProperty('currentValue')
 
-    await expect(surface.setOption('fastMode', true)).rejects.toThrow(
-      'Current value is unknown; use the Toggle action instead.'
-    )
-    expect(dispatch).not.toHaveBeenCalled()
-    const result = await surface.invokeAction('fastMode')
-    expect(dispatch).toHaveBeenCalledWith('/fast')
-    // Why: a flip-only command never reports an absolute value.
-    expect(result.snapshot.find(({ id }) => id === 'fastMode')).toMatchObject({
-      valueSource: 'unknown',
-      action: { type: 'toggle-command' }
+    const onResult = await surface.setOption('fastMode', true)
+    expect(dispatch.mock.calls.map((call) => call[0])).toEqual(['/fast on'])
+    expect(onResult.snapshot.find(({ id }) => id === 'fastMode')).toMatchObject({
+      valueSource: 'dispatched',
+      kind: { type: 'boolean', currentValue: true }
     })
+
+    const offResult = await surface.setOption('fastMode', false)
+    expect(dispatch.mock.calls.map((call) => call[0])).toEqual(['/fast on', '/fast off'])
+    expect(offResult.snapshot.find(({ id }) => id === 'fastMode')).toMatchObject({
+      valueSource: 'dispatched',
+      kind: { type: 'boolean', currentValue: false }
+    })
+    for (const [command, options] of dispatch.mock.calls) {
+      expect(command).not.toBe('/fast')
+      expect(String(command)).not.toMatch(/[\t\r]/)
+      expect(options).toBeUndefined()
+    }
+    // Why: Claude has no launch flag for fast mode, so a picker set is not a
+    // durable default the next session can honor.
     expect(persist).not.toHaveBeenCalled()
   })
 
-  it('no-ops a seeded toggle when already at the requested value', async () => {
+  it('re-sends an absolute fast-mode command at the current value', async () => {
     seedNativeChatAppliedSessionOptions('pty-1', 'claude', {
       model: 'opus',
       effort: 'high',
@@ -283,64 +297,14 @@ describe('native chat PTY session options', () => {
     })!
 
     const result = await surface.setOption('fastMode', true)
-    expect(dispatch).not.toHaveBeenCalled()
+    expect(dispatch).toHaveBeenCalledWith('/fast on')
     expect(result.snapshot.find(({ id }) => id === 'fastMode')).toMatchObject({
-      valueSource: 'applied',
+      valueSource: 'dispatched',
       kind: { type: 'boolean', currentValue: true }
     })
   })
 
-  it('no-ops a known toggle at the same absolute target (flip is not set-to-value)', async () => {
-    seedNativeChatAppliedSessionOptions('pty-1', 'claude', {
-      model: 'opus',
-      effort: 'high',
-      fastMode: true
-    })
-    const dispatch = vi.fn()
-    const surface = createNativeChatPtySessionOptions({
-      agent: 'claude',
-      scopeKey: 'pty-1',
-      mode: 'live',
-      dispatchCommand: dispatch
-    })!
-
-    await surface.setOption('fastMode', false)
-    dispatch.mockClear()
-    // Why: a second same-target set would re-send `/fast` and invert the agent
-    // if the first flip landed — unlike set-to-value commands, flips cannot retry.
-    const result = await surface.setOption('fastMode', false)
-    expect(dispatch).not.toHaveBeenCalled()
-    expect(result.snapshot.find(({ id }) => id === 'fastMode')).toMatchObject({
-      valueSource: 'applied',
-      kind: { type: 'boolean', currentValue: false }
-    })
-  })
-
-  it('dispatches the opposite absolute target for a known toggle', async () => {
-    seedNativeChatAppliedSessionOptions('pty-1', 'claude', {
-      model: 'opus',
-      effort: 'high',
-      fastMode: true
-    })
-    const dispatch = vi.fn()
-    const surface = createNativeChatPtySessionOptions({
-      agent: 'claude',
-      scopeKey: 'pty-1',
-      mode: 'live',
-      dispatchCommand: dispatch
-    })!
-
-    await surface.setOption('fastMode', false)
-    dispatch.mockClear()
-    const result = await surface.setOption('fastMode', true)
-    expect(dispatch).toHaveBeenCalledWith('/fast')
-    expect(result.snapshot.find(({ id }) => id === 'fastMode')).toMatchObject({
-      valueSource: 'applied',
-      kind: { type: 'boolean', currentValue: true }
-    })
-  })
-
-  it('tracks a known toggle flip as applied without persisting', async () => {
+  it('dispatches the opposite absolute fast-mode target', async () => {
     seedNativeChatAppliedSessionOptions('pty-1', 'claude', {
       model: 'opus',
       effort: 'high',
@@ -357,10 +321,9 @@ describe('native chat PTY session options', () => {
     })!
 
     const result = await surface.setOption('fastMode', false)
-    expect(dispatch).toHaveBeenCalledWith('/fast')
-    // Why: flip-only never heals; applied is best-known absolute, not dispatched.
+    expect(dispatch).toHaveBeenCalledWith('/fast off')
     expect(result.snapshot.find(({ id }) => id === 'fastMode')).toMatchObject({
-      valueSource: 'applied',
+      valueSource: 'dispatched',
       kind: { type: 'boolean', currentValue: false }
     })
     expect(result.snapshot.find(({ id }) => id === 'fastMode')?.action).toBeUndefined()
@@ -375,7 +338,7 @@ describe('native chat PTY session options', () => {
     })
     let releaseFirst: (() => void) | undefined
     const dispatch = vi.fn((command: string) => {
-      if (command === '/fast') {
+      if (command === '/fast off') {
         return new Promise<void>((resolve) => {
           releaseFirst = resolve
         })
@@ -407,31 +370,34 @@ describe('native chat PTY session options', () => {
     })
   })
 
-  it('stays unknown after a typed flip then a picker toggle (no invented absolute)', async () => {
+  it('sets fast mode from an unknown baseline after a typed bare /fast', async () => {
     seedNativeChatAppliedSessionOptions('pty-1', 'claude', {
       model: 'opus',
       effort: 'high'
     })
     const dispatch = vi.fn()
+    const onAgentPicker = vi.fn()
     const surface = createNativeChatPtySessionOptions({
       agent: 'claude',
       scopeKey: 'pty-1',
       mode: 'live',
-      dispatchCommand: dispatch
+      dispatchCommand: dispatch,
+      onAgentPicker
     })!
 
-    // Typed `/fast` clears any prior tracking; option stays unknown.
+    // Typed `/fast` opens Claude's panel; tracking is gone until an absolute set.
     surface.recordOutgoingCommand('/fast')
+    expect(onAgentPicker).toHaveBeenCalledOnce()
     expect(surface.getSnapshot().find(({ id }) => id === 'fastMode')).toMatchObject({
-      valueSource: 'unknown',
-      action: { type: 'toggle-command' }
+      valueSource: 'unknown'
     })
+    expect(surface.getSnapshot().find(({ id }) => id === 'fastMode')?.action).toBeUndefined()
 
-    await surface.invokeAction('fastMode')
-    expect(dispatch).toHaveBeenCalledWith('/fast')
-    expect(surface.getSnapshot().find(({ id }) => id === 'fastMode')).toMatchObject({
-      valueSource: 'unknown',
-      action: { type: 'toggle-command' }
+    const result = await surface.setOption('fastMode', true)
+    expect(dispatch).toHaveBeenCalledWith('/fast on')
+    expect(result.snapshot.find(({ id }) => id === 'fastMode')).toMatchObject({
+      valueSource: 'dispatched',
+      kind: { type: 'boolean', currentValue: true }
     })
   })
 
@@ -462,9 +428,9 @@ describe('native chat PTY session options', () => {
     resolveDispatch?.()
     await pending
     expect(surface.getSnapshot().find(({ id }) => id === 'fastMode')).toMatchObject({
-      valueSource: 'unknown',
-      action: { type: 'toggle-command' }
+      valueSource: 'unknown'
     })
+    expect(surface.getSnapshot().find(({ id }) => id === 'fastMode')?.action).toBeUndefined()
   })
 
   it('does not write flip state onto a model that changed mid-dispatch', async () => {

--- a/src/renderer/src/components/native-chat/native-chat-session-option-apply.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-apply.ts
@@ -14,7 +14,6 @@ import type {
 import { buildNativeChatSessionOptionCommand } from '../../../../shared/native-chat-session-option-commands'
 import {
   getTrackedSessionOption as getTrackedOption,
-  isFlipOnlyMidSession,
   type NativeChatSessionOptionRecord
 } from '../../../../shared/native-chat-session-option-state'
 import type {
@@ -194,20 +193,10 @@ async function applySetOption(
     throw new Error('This option must be changed in the agent picker.')
   }
 
-  const liveFlipOnly = ctx.mode === 'live' && isFlipOnlyMidSession(apply.midSession)
-  const trackedToggle = liveFlipOnly
-    ? getTrackedOption(ctx.getRecord(), previousModelId, id)
-    : undefined
-  if (liveFlipOnly && !trackedToggle) {
-    // Why: a flip from an unknown baseline cannot honor an absolute target.
-    throw new Error('Current value is unknown; use the Toggle action instead.')
-  }
-  // Why: same absolute target must never re-dispatch a flip (would invert the agent).
-  if (liveFlipOnly && trackedToggle?.value === value) {
-    return { snapshot: ctx.publish() }
-  }
-  // Why: flip-only never heals via agent report — track as applied best-known.
-  const source = liveFlipOnly || ctx.mode !== 'live' ? 'applied' : 'dispatched'
+  const source = ctx.mode !== 'live' ? 'applied' : 'dispatched'
+  // Why: Claude fast mode has no launch flag, so a picker set is not a durable
+  // default the next session can honor. Effort/model still persist.
+  const skipPersist = id !== 'model' && !apply.launchArgs && !apply.composedIntoModel
 
   // Why: baseline for detecting a model switch, typed command, or agent report
   // that lands mid-dispatch, so the commit below never overwrites newer state.
@@ -243,20 +232,6 @@ async function applySetOption(
     }
   }
 
-  if (liveFlipOnly) {
-    // Why: typed flips, reports, or model changes during dispatch supersede the
-    // baseline this absolute target was computed from.
-    if (trackedModelId(record) !== trackedModelBeforeDispatch) {
-      return finish(ctx, { modelId: previousModelId, optionId: id, value, skipPersist: true })
-    }
-    if (getTrackedOption(record, previousModelId, id) !== trackedToggle) {
-      return finish(ctx, { modelId: previousModelId, optionId: id, value, skipPersist: true })
-    }
-    // Why: never persist unconfirmed flip-only state into durable defaults.
-    ctx.setTrackedValue(id, value, source)
-    return finish(ctx, { modelId: previousModelId, optionId: id, value, skipPersist: true })
-  }
-
   if (ctx.mode === 'live' && id !== 'model') {
     // Why: a model switch, typed command, or agent report during dispatch supersedes
     // the baseline this commit was computed from — committing now would overwrite
@@ -270,7 +245,12 @@ async function applySetOption(
   }
 
   const modelId = ctx.setTrackedValue(id, value, source)
-  return finish(ctx, { modelId: modelId ?? previousModelId, optionId: id, value })
+  return finish(ctx, {
+    modelId: modelId ?? previousModelId,
+    optionId: id,
+    value,
+    skipPersist
+  })
 }
 
 async function applyInvokeAction(
@@ -281,25 +261,14 @@ async function applyInvokeAction(
   if (!resolved) {
     throw new Error(`Unknown session option: ${id}`)
   }
-  const { apply, modelId } = resolved
+  const { apply } = resolved
   if (apply.midSession?.kind === 'agent-picker') {
     if (ctx.mode !== 'live') {
       throw new Error('This option is only available after the session starts.')
     }
     return handleAgentPicker(ctx, apply.midSession)
   }
-  if (!isFlipOnlyMidSession(apply.midSession)) {
-    throw new Error('This option requires a value.')
-  }
-  if (ctx.mode !== 'live') {
-    throw new Error('This option is only available after the session starts.')
-  }
-  if (getTrackedOption(ctx.getRecord(), modelId, id)) {
-    throw new Error('This option has a known value; choose On or Off instead.')
-  }
-  // Why: an unknown baseline remains unknown after one inversion.
-  await ctx.dispatchCommand(apply.midSession.command)
-  return finish(ctx)
+  throw new Error('This option requires a value.')
 }
 
 export function createSessionOptionAppliers(ctx: SessionOptionApplyContext): {

--- a/src/shared/agent-session-option-catalog-claude-codex.ts
+++ b/src/shared/agent-session-option-catalog-claude-codex.ts
@@ -118,12 +118,22 @@ function parseClaudeCatalogModels(stdout: string): CatalogModel[] {
   })
 }
 
+// Why `/fast on|off` rather than a bare `/fast`: the bare form opens a
+// confirmation panel (Tab to toggle · Enter to confirm) that a dispatch leaves
+// hanging and unapplied. The argument form sets the value outright.
 const CLAUDE_FAST_MODE: CatalogOption = {
   id: 'fastMode',
   label: 'Fast mode',
   category: 'mode',
   kind: { type: 'boolean', defaultValue: false },
-  apply: { midSession: { kind: 'toggle-command', command: '/fast' } }
+  apply: {
+    midSession: {
+      kind: 'command',
+      build: (value) => `/fast ${value === true ? 'on' : value === false ? 'off' : String(value)}`,
+      // A typed bare `/fast` opens the panel; the outcome is not observable.
+      pickerCommand: '/fast'
+    }
+  }
 }
 
 export const CLAUDE_SESSION_OPTION_CATALOG: AgentSessionOptionCatalog = {

--- a/src/shared/agent-session-option-catalog-types.ts
+++ b/src/shared/agent-session-option-catalog-types.ts
@@ -15,7 +15,6 @@ export type CatalogMidSessionApply =
       pickerCommand?: string
       detectAgentInteraction?: CatalogAgentInteractionDetection
     }
-  | { kind: 'toggle-command'; command: string }
   | { kind: 'agent-picker'; command: string; delivery?: CatalogCommandDelivery }
   | { kind: 'unsupported' }
 

--- a/src/shared/native-chat-session-option-commands.test.ts
+++ b/src/shared/native-chat-session-option-commands.test.ts
@@ -51,21 +51,22 @@ describe('buildNativeChatSessionOptionCommand', () => {
     ).toBe('/effort high')
   })
 
-  it('returns the bare toggle command for flip-only options', () => {
+  it('sets Claude fast mode with /fast on and /fast off rather than a bare /fast', () => {
     const fastModeApply = CLAUDE_SESSION_OPTION_CATALOG.models
       .find((model) => model.id === 'opus')!
       .options.find((option) => option.id === 'fastMode')!.apply
-    expect(
-      buildNativeChatSessionOptionCommand({
-        optionId: 'fastMode',
-        value: true,
-        apply: fastModeApply,
-        modelId: 'opus',
-        catalog: CLAUDE_SESSION_OPTION_CATALOG,
-        models: CLAUDE_SESSION_OPTION_CATALOG.models,
-        record: claudeRecord('opus')
-      })
-    ).toBe('/fast')
+    const args = {
+      optionId: 'fastMode' as const,
+      apply: fastModeApply,
+      modelId: 'opus',
+      catalog: CLAUDE_SESSION_OPTION_CATALOG,
+      models: CLAUDE_SESSION_OPTION_CATALOG.models,
+      record: claudeRecord('opus')
+    }
+    expect(buildNativeChatSessionOptionCommand({ ...args, value: true })).toBe('/fast on')
+    expect(buildNativeChatSessionOptionCommand({ ...args, value: false })).toBe('/fast off')
+    expect(buildNativeChatSessionOptionCommand({ ...args, value: true })).not.toBe('/fast')
+    expect(buildNativeChatSessionOptionCommand({ ...args, value: false })).not.toBe('/fast')
   })
 
   it('does not turn a Codex model pick into pasted slash-command prose', () => {
@@ -141,17 +142,62 @@ describe('recordNativeChatSessionOptionCommand', () => {
     expect(codexRecord.model).toBeUndefined()
   })
 
-  it('clears a flip-only toggle’s tracked baseline on a typed flip', () => {
+  it('tracks typed /fast on and /fast off as booleans without clearing the model', () => {
     const record = claudeRecord('opus')
-    record.valuesByModel.opus = { fastMode: { value: true, source: 'applied' } }
+    record.valuesByModel.opus = { effort: { value: 'high', source: 'applied' } }
+    expect(
+      recordNativeChatSessionOptionCommand({
+        catalog: CLAUDE_SESSION_OPTION_CATALOG,
+        models: CLAUDE_SESSION_OPTION_CATALOG.models,
+        record,
+        command: '/fast on'
+      })
+    ).toEqual({ changed: true, opensAgentPicker: false })
+    expect(record.model).toEqual({ value: 'opus', source: 'dispatched' })
+    expect(record.valuesByModel.opus?.fastMode).toEqual({ value: true, source: 'dispatched' })
+    expect(record.valuesByModel.opus?.effort).toEqual({ value: 'high', source: 'applied' })
+
     recordNativeChatSessionOptionCommand({
+      catalog: CLAUDE_SESSION_OPTION_CATALOG,
+      models: CLAUDE_SESSION_OPTION_CATALOG.models,
+      record,
+      command: '/fast off'
+    })
+    expect(record.valuesByModel.opus?.fastMode).toEqual({ value: false, source: 'dispatched' })
+  })
+
+  it('clears only fast mode on a typed bare /fast, not the model', () => {
+    const record = claudeRecord('opus')
+    record.valuesByModel.opus = {
+      effort: { value: 'high', source: 'applied' },
+      fastMode: { value: true, source: 'applied' }
+    }
+    const result = recordNativeChatSessionOptionCommand({
       catalog: CLAUDE_SESSION_OPTION_CATALOG,
       models: CLAUDE_SESSION_OPTION_CATALOG.models,
       record,
       command: '/fast'
     })
-    // A typed flip inverts an unknown-to-us direction; the baseline is gone.
+    // Why: a typed bare `/fast` opens Claude's confirmation panel. We cannot
+    // observe the outcome, so fast mode is unknown — but the model did not change.
+    expect(result.opensAgentPicker).toBe(true)
+    expect(record.model).toEqual({ value: 'opus', source: 'dispatched' })
+    expect(record.valuesByModel.opus?.effort).toEqual({ value: 'high', source: 'applied' })
     expect(record.valuesByModel.opus?.fastMode).toBeUndefined()
+  })
+
+  it('rejects a /fast argument the CLI would also reject', () => {
+    const record = claudeRecord('opus')
+    record.valuesByModel.opus = { fastMode: { value: true, source: 'applied' } }
+    expect(
+      recordNativeChatSessionOptionCommand({
+        catalog: CLAUDE_SESSION_OPTION_CATALOG,
+        models: CLAUDE_SESSION_OPTION_CATALOG.models,
+        record,
+        command: '/fast maybe'
+      })
+    ).toEqual({ changed: false, opensAgentPicker: false })
+    expect(record.valuesByModel.opus?.fastMode).toEqual({ value: true, source: 'applied' })
   })
 
   it('rejects prose that merely starts with a command template', () => {

--- a/src/shared/native-chat-session-option-commands.ts
+++ b/src/shared/native-chat-session-option-commands.ts
@@ -2,6 +2,7 @@ import type {
   AgentSessionOptionCatalog,
   CatalogMidSessionApply,
   CatalogModel,
+  CatalogOption,
   CatalogOptionApply
 } from './agent-session-option-catalog'
 import type { SessionOptionValue } from './native-chat-session-options'
@@ -9,7 +10,6 @@ import {
   clearNativeChatSessionModel,
   clearTrackedSessionOption,
   flattenNativeChatSessionOptionRecord,
-  isFlipOnlyMidSession,
   matchNativeChatCatalogModelId,
   type NativeChatSessionOptionRecord
 } from './native-chat-session-option-state'
@@ -57,9 +57,6 @@ export function buildNativeChatSessionOptionCommand(args: {
   if (midSession?.kind === 'command') {
     return midSession.build(args.value)
   }
-  if (midSession?.kind === 'toggle-command') {
-    return midSession.command
-  }
   if (!args.apply.composedIntoModel || !args.modelId || !args.catalog.composeModelValue) {
     return null
   }
@@ -90,7 +87,7 @@ function recordCommandApply(args: {
    *  prose that merely starts with it (`/model` parses `is a weird word` out of
    *  "/model is a weird word"), and tracking that renders raw prose as the
    *  current value — and, for the model, drops every option the model owns. */
-  canonicalize: (value: string) => string | null
+  canonicalize: (value: string) => SessionOptionValue | null
   /** The model the picker draws this option under. Reading the tracked model alone
    *  would drop a typed `/effort low` under a CLI default, and treat a typed
    *  `/model <that default>` as a switch that resets the model's tracked state. */
@@ -101,12 +98,14 @@ function recordCommandApply(args: {
   if (!midSession || midSession.kind === 'unsupported') {
     return false
   }
-  if (isFlipOnlyMidSession(midSession) && command === midSession.command) {
-    clearTrackedSessionOption(record, effectiveModelId, optionId)
-    return true
-  }
   if (isSessionOptionAgentPickerCommand(midSession, command)) {
-    clearNativeChatSessionModel(record)
+    // Why per-option: a picker only invalidates what it edits. Clearing the
+    // model for a typed bare `/fast` would blank every model-scoped row.
+    if (optionId === 'model') {
+      clearNativeChatSessionModel(record)
+    } else {
+      clearTrackedSessionOption(record, effectiveModelId, optionId)
+    }
     return true
   }
   if (midSession.kind !== 'command') {
@@ -117,7 +116,7 @@ function recordCommandApply(args: {
     return false
   }
   const value = canonicalize(parsed)
-  if (!value) {
+  if (value == null) {
     return false
   }
   const previousModelId = effectiveModelId
@@ -179,20 +178,38 @@ export function recordNativeChatSessionOptionCommand(args: {
   for (const option of model?.options ?? []) {
     opensAgentPicker =
       opensAgentPicker || isSessionOptionAgentPickerCommand(option.apply.midSession, command)
+    const persistLaunchValue =
+      option.apply.launchArgs || option.apply.composedIntoModel ? persist : undefined
     changed =
       recordCommandApply({
         record,
         optionId: option.id,
         midSession: option.apply.midSession,
         command,
-        canonicalize: (value) =>
-          option.kind.type === 'select' &&
-          !option.kind.choices.some((choice) => choice.value === value)
-            ? null
-            : value,
+        canonicalize: (value) => canonicalizeCatalogOptionValue(option, value),
         effectiveModelId: modelId,
-        persist
+        persist: persistLaunchValue
       }) || changed
   }
   return { changed, opensAgentPicker }
+}
+
+function canonicalizeCatalogOptionValue(
+  option: CatalogOption,
+  value: string
+): SessionOptionValue | null {
+  if (option.kind.type === 'select') {
+    return option.kind.choices.some((choice) => choice.value === value) ? value : null
+  }
+  if (option.kind.type === 'boolean') {
+    const normalized = value.toLowerCase()
+    if (normalized === 'on') {
+      return true
+    }
+    if (normalized === 'off') {
+      return false
+    }
+    return null
+  }
+  return value
 }

--- a/src/shared/native-chat-session-option-commands.ts
+++ b/src/shared/native-chat-session-option-commands.ts
@@ -121,6 +121,12 @@ function recordCommandApply(args: {
   }
   const previousModelId = effectiveModelId
   if (optionId === 'model') {
+    // Why: SessionOptionValue widened to string | boolean for fast mode, but a
+    // model id is always a string - a boolean here is a malformed command, not a
+    // model, and must not index valuesByModel or reach the persist callback.
+    if (typeof value !== 'string') {
+      return false
+    }
     if (previousModelId !== value) {
       // Why: a model command can reset model-scoped state, so an older value
       // from a prior visit is no longer evidence about this live session.

--- a/src/shared/native-chat-session-option-snapshot.test.ts
+++ b/src/shared/native-chat-session-option-snapshot.test.ts
@@ -225,7 +225,7 @@ describe('buildNativeChatSessionOptionSnapshot', () => {
     })
   })
 
-  it('marks flip-only toggles without a baseline as toggle actions', () => {
+  it('offers On/Off for unknown Claude fast mode instead of a Toggle action', () => {
     const record = claudeRecord()
     record.model = { value: 'opus', source: 'reported' }
     const snapshot = buildNativeChatSessionOptionSnapshot({
@@ -236,7 +236,13 @@ describe('buildNativeChatSessionOptionSnapshot', () => {
       modelLabel: 'Model'
     })
     const fastMode = snapshot.find((descriptor) => descriptor.id === 'fastMode')
-    expect(fastMode).toMatchObject({ action: { type: 'toggle-command' } })
+    expect(fastMode).toMatchObject({
+      kind: { type: 'boolean' },
+      valueSource: 'unknown',
+      settable: true
+    })
+    expect(fastMode?.action).toBeUndefined()
+    expect(fastMode?.kind).not.toHaveProperty('currentValue')
   })
 })
 

--- a/src/shared/native-chat-session-option-snapshot.ts
+++ b/src/shared/native-chat-session-option-snapshot.ts
@@ -8,10 +8,9 @@ import type {
   SessionOptionDescriptor,
   SessionOptionSelectChoice
 } from './native-chat-session-options'
-import {
-  isFlipOnlyMidSession,
-  type NativeChatSessionOptionRecord,
-  type TrackedNativeChatSessionOption
+import type {
+  NativeChatSessionOptionRecord,
+  TrackedNativeChatSessionOption
 } from './native-chat-session-option-state'
 
 export type NativeChatSessionOptionMode = 'draft' | 'live'
@@ -49,7 +48,6 @@ function settableState(args: {
 
 function actionForApply(
   apply: { midSession?: CatalogMidSessionApply },
-  tracked: TrackedNativeChatSessionOption | undefined,
   mode: NativeChatSessionOptionMode
 ): SessionOptionDescriptor['action'] {
   if (mode !== 'live') {
@@ -58,9 +56,7 @@ function actionForApply(
   if (apply.midSession?.kind === 'agent-picker') {
     return { type: 'agent-picker' }
   }
-  // Why: only unknown flip-only options are actions; once we have a tracked
-  // baseline the UI can show absolute On/Off without inventing a start state.
-  return isFlipOnlyMidSession(apply.midSession) && !tracked ? { type: 'toggle-command' } : undefined
+  return undefined
 }
 
 function optionDescriptor(args: {
@@ -71,7 +67,7 @@ function optionDescriptor(args: {
   composedModelApply: AgentSessionOptionCatalog['modelApply']
 }): SessionOptionDescriptor | null {
   const { option, tracked, mode, modelIsCliDefault, composedModelApply } = args
-  const action = actionForApply(option.apply, tracked, mode)
+  const action = actionForApply(option.apply, mode)
   const settable = settableState({ mode, apply: option.apply, composedModelApply })
   // Why: the launch only emits `values[id] ?? defaultValue` alongside a model flag, so
   // a draft names this option's value exactly when a model was picked. Under the CLI's
@@ -212,7 +208,7 @@ export function buildNativeChatSessionOptionSnapshot(args: {
   const trackedModelId = typeof modelTracked?.value === 'string' ? modelTracked.value : null
   const defaultModelId = cliDefaultModelId(catalog, models, trackedModelId)
   const effectiveModelId = trackedModelId ?? defaultModelId
-  const modelAction = actionForApply(catalog.modelApply, modelTracked, mode)
+  const modelAction = actionForApply(catalog.modelApply, mode)
   const snapshot: SessionOptionDescriptor[] = [
     {
       id: 'model',

--- a/src/shared/native-chat-session-option-state.ts
+++ b/src/shared/native-chat-session-option-state.ts
@@ -1,8 +1,5 @@
 import type { AgentType } from './agent-status-types'
-import type {
-  CatalogMidSessionApply,
-  AgentSessionOptionCatalog
-} from './agent-session-option-catalog'
+import type { AgentSessionOptionCatalog } from './agent-session-option-catalog'
 import type { SessionOptionValue, SessionOptionValueSource } from './native-chat-session-options'
 
 export type TrackedNativeChatSessionOption = {
@@ -35,12 +32,6 @@ export function cloneNativeChatSessionOptionRecord(
       ])
     )
   }
-}
-
-export function isFlipOnlyMidSession(
-  midSession: CatalogMidSessionApply | undefined
-): midSession is Extract<CatalogMidSessionApply, { kind: 'toggle-command' }> {
-  return midSession?.kind === 'toggle-command'
 }
 
 export function getTrackedSessionOption(

--- a/src/shared/native-chat-session-options.ts
+++ b/src/shared/native-chat-session-options.ts
@@ -36,9 +36,9 @@ export type SessionOptionDescriptor = {
   valueSource: SessionOptionValueSource
   settable: boolean
   disabledReason?: SessionOptionDisabledReason
-  /** Why: picker-only and toggle-only PTY commands cannot be represented as
-   * a truthful radio/checkbox state, so the producer exposes an action row. */
-  action?: { type: 'agent-picker' | 'toggle-command' }
+  /** Why: picker-only PTY commands cannot be represented as a truthful
+   *  radio/checkbox state, so the producer exposes an action row. */
+  action?: { type: 'agent-picker' }
 }
 
 export type SessionOptionSetResult = {
@@ -57,7 +57,7 @@ export type PersistedNativeChatSessionOptions = Partial<
 
 export type SessionOptionsSurface = {
   getSnapshot(): SessionOptionDescriptor[]
-  /** Apply an absolute target; known flip-only options use their tracked baseline. */
+  /** Apply an absolute target. */
   setOption(id: string, value: SessionOptionValue): Promise<SessionOptionSetResult>
   /** Invoke the value-less action exposed by the current descriptor. */
   invokeAction(id: string): Promise<SessionOptionSetResult>


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​183 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​111 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​72 |
| Prod | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​91 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​126 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​35 |

<!-- /orca-pr-loc -->

## ELI5

Claude's Chat UI Fast mode switch stopped working. Typing `/fast` used to flip the setting; now it opens a confirmation panel about a higher rate (`$10/$50 per Mtok`) and waits for Tab/Enter. Orca was still sending that bare `/fast`, so the panel hung and nothing applied. This PR sets Fast mode with `/fast on` and `/fast off` instead, which the CLI applies immediately, and reads the `↯` glyph so the picker can show On/Off.

## What Changed

- Claude Fast mode is an absolute setter: On → `/fast on`, Off → `/fast off`. Never a bare `/fast`, and never Tab/Enter on the confirmation panel (that would auto-confirm a paid-rate decision the user did not see).
- The picker reads Claude's `↯` status-line glyph when the startup banner is present, so it can show a real On/Off instead of an unknown baseline. A typed bare `/fast` (which still opens the panel) invalidates only fast mode and switches to the terminal so the user can confirm themselves.
- Flip-only machinery is gone (`toggle-command`, Toggle action row) — Fast mode was its last catalog user. Cursor Fast mode is unchanged (it is composed into the model slug).
- Fast mode is not saved as a launch default: Claude has no `--fast` flag.

This supersedes the Fast mode portion of #14745. It is not a replacement for that PR's permission-mode picker. How it differs from that Fast mode work:

1. Focused on STA-4428 / #14752 only — no permission-mode cycle.
2. Boolean `/fast on|off` build interpolates the parse marker, so typed `/fast off` actually parses.
3. Canonicalize treats `false` as a real value (`value == null`), so Off is not dropped as falsy.
4. Does not persist Fast mode into launch defaults.
5. `recordCommandApply` clears only the matching option, so a typed `/fast` cannot blank the model.

## Why

Claude Code 2.1.237's `/fast` dialog short-circuits on an `on`/`off` argument and never renders the confirmation panel. A bare `/fast` is the panel. Older CLIs that do not take the argument print `Unknown argument` as text; we never fall back to bare `/fast`, which is what strands the panel.

## Linked Issue

Fixes #14752
STA-4428

## Visual Proof

N/A — no layout or styling change. The existing On/Off radios replace the Toggle action for this option; dispatch of `/fast on|off` (and never Tab/Enter) is pinned by tests.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Acceptance tests fail on the pre-fix catalog (`expected '/fast' to be '/fast on'`), pass after the fix, and fail again when the catalog is neutered back to a bare `/fast`.

- macOS unit tests (vitest). Linux/Windows/SSH: command dispatch is the existing slash-command path (no new keystrokes, no path separators). Mobile uses the same catalog builder.

## Review

Author: @BrennanKB5

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No new stream opcodes. Folder workspaces and SSH sessions use the same mid-session slash command. GitLab not involved.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)