### PR TITLE
fix(browser): fail closed on wedged cookie CDP mutations

### DIFF
--- a/src/main/browser/browser-cookie-clear-store-lifecycle.test.ts
+++ b/src/main/browser/browser-cookie-clear-store-lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Session } from 'electron'
 
 const electron = vi.hoisted(() => {
@@ -56,6 +56,10 @@ describe('cookie clear debugger lifecycle', () => {
     lease.release.mockClear()
   })
 
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('memoizes a pending hidden-window attachment across concurrent callers', async () => {
     const store = openCookieClearStore(targetSession())
     const snapshot = store.snapshotClearIdentities([])
@@ -97,5 +101,38 @@ describe('cookie clear debugger lifecycle', () => {
 
     await expect(restore).rejects.toThrow(/restore/i)
     expect(sendCommand.mock.calls.map(([, params]) => params?.name)).toEqual(['first', 'second'])
+  })
+
+  it('classifies a retired command as timed out only after its late result settles', async () => {
+    vi.useFakeTimers()
+    let resolveCommand!: (value: unknown) => void
+    const pendingCommand = new Promise<unknown>((resolve) => {
+      resolveCommand = resolve
+    })
+    const store = openCookieClearStore(targetSession())
+    const write = store.writeCookieIdentity({
+      url: 'https://late.example/',
+      name: 'late',
+      value: 'value',
+      sameSite: 'unspecified'
+    })
+    const window = electron.windows[0]
+    window.webContents.debugger.sendCommand.mockReturnValueOnce(pendingCommand)
+    window.resolveLoad()
+    await vi.advanceTimersByTimeAsync(10_000)
+
+    expect(lease.release).toHaveBeenCalledOnce()
+    expect(window.destroy).toHaveBeenCalledOnce()
+    await expect(
+      Promise.race([write.then(() => 'settled'), Promise.resolve('pending')])
+    ).resolves.toBe('pending')
+
+    resolveCommand({ success: true })
+    await expect(write).rejects.toMatchObject({
+      name: 'CookieDebuggerCommandTimeoutError',
+      message: 'Cookie debugger command Network.setCookie timed out after 10000ms'
+    })
+    store.dispose()
+    expect(lease.release).toHaveBeenCalledOnce()
   })
 })

--- a/src/main/browser/browser-cookie-clear-store-lifecycle.test.ts
+++ b/src/main/browser/browser-cookie-clear-store-lifecycle.test.ts
@@ -3,7 +3,6 @@ import type { Session } from 'electron'
 
 const electron = vi.hoisted(() => {
   const windows: BrowserWindow[] = []
-  const getAllWebContents = vi.fn(() => [])
 
   class BrowserWindow {
     destroy = vi.fn()
@@ -30,14 +29,13 @@ const electron = vi.hoisted(() => {
     }
   }
 
-  return { BrowserWindow, getAllWebContents, windows }
+  return { BrowserWindow, windows }
 })
 
 const lease = vi.hoisted(() => ({ release: vi.fn() }))
 
 vi.mock('electron', () => ({
-  BrowserWindow: electron.BrowserWindow,
-  webContents: { getAllWebContents: electron.getAllWebContents }
+  BrowserWindow: electron.BrowserWindow
 }))
 vi.mock('./electron-debugger-lease', () => ({
   acquireElectronDebugger: vi.fn(() => lease)
@@ -52,7 +50,6 @@ function targetSession(): Session {
 describe('cookie clear debugger lifecycle', () => {
   beforeEach(() => {
     electron.windows.length = 0
-    electron.getAllWebContents.mockReturnValue([])
     lease.release.mockClear()
   })
 
@@ -103,7 +100,7 @@ describe('cookie clear debugger lifecycle', () => {
     expect(sendCommand.mock.calls.map(([, params]) => params?.name)).toEqual(['first', 'second'])
   })
 
-  it('classifies a retired command as timed out only after its late result settles', async () => {
+  it('classifies a retired command after a bounded settlement grace', async () => {
     vi.useFakeTimers()
     let resolveCommand!: (value: unknown) => void
     const pendingCommand = new Promise<unknown>((resolve) => {
@@ -119,19 +116,18 @@ describe('cookie clear debugger lifecycle', () => {
     const window = electron.windows[0]
     window.webContents.debugger.sendCommand.mockReturnValueOnce(pendingCommand)
     window.resolveLoad()
-    await vi.advanceTimersByTimeAsync(10_000)
-
-    expect(lease.release).toHaveBeenCalledOnce()
-    expect(window.destroy).toHaveBeenCalledOnce()
-    await expect(
-      Promise.race([write.then(() => 'settled'), Promise.resolve('pending')])
-    ).resolves.toBe('pending')
-
-    resolveCommand({ success: true })
-    await expect(write).rejects.toMatchObject({
+    const timeoutExpectation = expect(write).rejects.toMatchObject({
       name: 'CookieDebuggerCommandTimeoutError',
       message: 'Cookie debugger command Network.setCookie timed out after 10000ms'
     })
+    await vi.advanceTimersByTimeAsync(11_000)
+
+    expect(lease.release).toHaveBeenCalledOnce()
+    expect(window.destroy).toHaveBeenCalledOnce()
+    await timeoutExpectation
+
+    resolveCommand({ success: true })
+    await Promise.resolve()
     store.dispose()
     expect(lease.release).toHaveBeenCalledOnce()
   })

--- a/src/main/browser/browser-cookie-clear-store.ts
+++ b/src/main/browser/browser-cookie-clear-store.ts
@@ -1,4 +1,5 @@
-import { BrowserWindow, webContents, type Cookie, type Session } from 'electron'
+import { BrowserWindow, type Cookie, type Session } from 'electron'
+import { sendCookieDebuggerCommand } from './browser-cookie-debugger-command'
 import { acquireElectronDebugger } from './electron-debugger-lease'
 import { normalizeCookieDomain } from './browser-cookie-import-policy'
 import type {
@@ -36,12 +37,6 @@ type CookieClearDebugger = {
 type CookieClearSession = {
   debugger: CookieClearDebugger
   dispose: () => void
-}
-
-function findPartitionWebContents(targetSession: Session) {
-  return webContents
-    .getAllWebContents()
-    .find((contents) => !contents.isDestroyed() && contents.session === targetSession)
 }
 
 function cdpSameSite(sameSite: Cookie['sameSite']): 'Strict' | 'Lax' | 'None' | undefined {
@@ -148,31 +143,26 @@ async function leaseHiddenCookieDebugger(targetSession: Session): Promise<Cookie
       throw new Error('Could not attach to the cookie session for an atomic clear')
     }
     const lease = acquireElectronDebugger(contents)
+    let disposed = false
     return {
       debugger: contents.debugger,
       dispose: () => {
-        lease.release()
-        window.destroy()
+        if (disposed) {
+          return
+        }
+        disposed = true
+        try {
+          lease.release()
+        } finally {
+          if (!contents.isDestroyed()) {
+            window.destroy()
+          }
+        }
       }
     }
   } catch (error) {
     window.destroy()
     throw error
-  }
-}
-
-async function attachCookieClearSession(targetSession: Session): Promise<CookieClearSession> {
-  const existing = findPartitionWebContents(targetSession)
-  if (!existing) {
-    return leaseHiddenCookieDebugger(targetSession)
-  }
-  try {
-    const lease = acquireElectronDebugger(existing)
-    return { debugger: existing.debugger, dispose: () => lease.release() }
-  } catch {
-    // Why (STA-4300): every cookie write now needs this channel, and attaching to a live tab fails
-    // outright when DevTools already owns its debugger. A hidden window of our own always can.
-    return leaseHiddenCookieDebugger(targetSession)
   }
 }
 
@@ -246,22 +236,19 @@ function cdpSetCookieSucceeded(value: unknown): boolean {
 }
 
 async function snapshotClearIdentitiesFromCdp(
-  cookieDebugger: CookieClearDebugger,
+  sendCommand: (method: string, params?: Record<string, unknown>) => Promise<unknown>,
   cookies: readonly { cookie: Cookie; url: string }[]
 ): Promise<CookieClearIdentity[]> {
-  const result = await cookieDebugger.sendCommand('Network.getAllCookies')
+  const result = await sendCommand('Network.getAllCookies')
   return cookieClearIdentitiesFromCdp(cookies, cdpCookiesFromCommand(result))
 }
 
 async function writeIdentityWithCdp(
-  cookieDebugger: CookieClearDebugger,
+  sendCommand: (method: string, params?: Record<string, unknown>) => Promise<unknown>,
   identity: CookieClearIdentity,
   failureLabel: string
 ): Promise<void> {
-  const result = await cookieDebugger.sendCommand(
-    'Network.setCookie',
-    cdpSetCookieParamsFromIdentity(identity)
-  )
+  const result = await sendCommand('Network.setCookie', cdpSetCookieParamsFromIdentity(identity))
   // Why: Network.setCookie reports rejection in the reply rather than throwing, so an unchecked
   // call reads as a successful write of a cookie that was never stored.
   if (!cdpSetCookieSucceeded(result)) {
@@ -275,6 +262,12 @@ export function openCookieClearStore(
   let attached: CookieClearSession | null = null
   let pendingAttach: Promise<CookieClearSession> | null = null
   let disposed = false
+  const retire = (session: CookieClearSession) => {
+    if (attached === session) {
+      attached = null
+    }
+    session.dispose()
+  }
   const attach = async () => {
     if (disposed) {
       throw new Error('Cookie clear store was disposed')
@@ -285,7 +278,7 @@ export function openCookieClearStore(
     if (pendingAttach) {
       return pendingAttach
     }
-    const pending = attachCookieClearSession(targetSession).then((session) => {
+    const pending = leaseHiddenCookieDebugger(targetSession).then((session) => {
       if (disposed) {
         session.dispose()
         throw new Error('Cookie clear store was disposed during debugger attachment')
@@ -302,19 +295,22 @@ export function openCookieClearStore(
       }
     }
   }
+  const sendCommand = async (method: string, params?: Record<string, unknown>) => {
+    const session = await attach()
+    return sendCookieDebuggerCommand(session, method, params, () => retire(session))
+  }
   return {
     get: (filter) => targetSession.cookies.get(filter),
     remove: (url, name) => targetSession.cookies.remove(url, name),
     snapshotClearIdentities: async (cookies) =>
-      snapshotClearIdentitiesFromCdp((await attach()).debugger, cookies),
+      snapshotClearIdentitiesFromCdp(sendCommand, cookies),
     restoreClearIdentities: async (identities) => {
-      const cookieDebugger = (await attach()).debugger
+      await attach()
       await restoreEveryCookieIdentity(identities, (identity) =>
-        writeIdentityWithCdp(cookieDebugger, identity, 'restore')
+        writeIdentityWithCdp(sendCommand, identity, 'restore')
       )
     },
-    writeCookieIdentity: async (identity) =>
-      writeIdentityWithCdp((await attach()).debugger, identity, 'import'),
+    writeCookieIdentity: async (identity) => writeIdentityWithCdp(sendCommand, identity, 'import'),
     dispose: () => {
       disposed = true
       pendingAttach = null

--- a/src/main/browser/browser-cookie-clear-store.ts
+++ b/src/main/browser/browser-cookie-clear-store.ts
@@ -1,6 +1,13 @@
-import { BrowserWindow, type Cookie, type Session } from 'electron'
+import type { Cookie, Session } from 'electron'
 import { sendCookieDebuggerCommand } from './browser-cookie-debugger-command'
-import { acquireElectronDebugger } from './electron-debugger-lease'
+import {
+  leaseCookieDebuggerSession,
+  type CookieDebuggerSession
+} from './browser-cookie-debugger-session'
+import {
+  assertCookieMutationsAvailable,
+  quarantineCookieMutations
+} from './browser-cookie-mutation-quarantine'
 import { normalizeCookieDomain } from './browser-cookie-import-policy'
 import type {
   CookieClearIdentity,
@@ -28,15 +35,6 @@ type CdpCookie = {
   sameSite?: string
   partitionKey?: CdpCookiePartitionKey | null
   partitionKeyOpaque?: boolean
-}
-
-type CookieClearDebugger = {
-  sendCommand: (method: string, params?: Record<string, unknown>) => Promise<unknown>
-}
-
-type CookieClearSession = {
-  debugger: CookieClearDebugger
-  dispose: () => void
 }
 
 function cdpSameSite(sameSite: Cookie['sameSite']): 'Strict' | 'Lax' | 'None' | undefined {
@@ -119,50 +117,6 @@ function identityFromCdpCookie(url: string, cdpCookie: CdpCookie): CookieClearId
       ? {}
       : { expirationDate: cdpCookie.expires }),
     ...(partitionKey ? { partitionKey } : {})
-  }
-}
-
-function openHiddenCookieWindow(targetSession: Session): BrowserWindow {
-  return new BrowserWindow({
-    show: false,
-    webPreferences: {
-      session: targetSession,
-      sandbox: true,
-      contextIsolation: true,
-      nodeIntegration: false
-    }
-  })
-}
-
-async function leaseHiddenCookieDebugger(targetSession: Session): Promise<CookieClearSession> {
-  const window = openHiddenCookieWindow(targetSession)
-  try {
-    await window.loadURL('data:text/html,<!doctype html><title>cookie-clear</title>')
-    const contents = window.webContents
-    if (contents.isDestroyed()) {
-      throw new Error('Could not attach to the cookie session for an atomic clear')
-    }
-    const lease = acquireElectronDebugger(contents)
-    let disposed = false
-    return {
-      debugger: contents.debugger,
-      dispose: () => {
-        if (disposed) {
-          return
-        }
-        disposed = true
-        try {
-          lease.release()
-        } finally {
-          if (!contents.isDestroyed()) {
-            window.destroy()
-          }
-        }
-      }
-    }
-  } catch (error) {
-    window.destroy()
-    throw error
   }
 }
 
@@ -259,10 +213,11 @@ async function writeIdentityWithCdp(
 export function openCookieClearStore(
   targetSession: Session
 ): CookieClearStore & CookieImportWriteStore & { dispose: () => void } {
-  let attached: CookieClearSession | null = null
-  let pendingAttach: Promise<CookieClearSession> | null = null
+  let attached: CookieDebuggerSession | null = null
+  let pendingAttach: Promise<CookieDebuggerSession> | null = null
   let disposed = false
-  const retire = (session: CookieClearSession) => {
+  const retire = (session: CookieDebuggerSession, settled: Promise<void>) => {
+    quarantineCookieMutations(targetSession, settled)
     if (attached === session) {
       attached = null
     }
@@ -278,7 +233,7 @@ export function openCookieClearStore(
     if (pendingAttach) {
       return pendingAttach
     }
-    const pending = leaseHiddenCookieDebugger(targetSession).then((session) => {
+    const pending = leaseCookieDebuggerSession(targetSession).then((session) => {
       if (disposed) {
         session.dispose()
         throw new Error('Cookie clear store was disposed during debugger attachment')
@@ -296,15 +251,20 @@ export function openCookieClearStore(
     }
   }
   const sendCommand = async (method: string, params?: Record<string, unknown>) => {
+    assertCookieMutationsAvailable(targetSession)
     const session = await attach()
-    return sendCookieDebuggerCommand(session, method, params, () => retire(session))
+    return sendCookieDebuggerCommand(session, method, params, (settled) => retire(session, settled))
   }
   return {
     get: (filter) => targetSession.cookies.get(filter),
-    remove: (url, name) => targetSession.cookies.remove(url, name),
+    remove: (url, name) => {
+      assertCookieMutationsAvailable(targetSession)
+      return targetSession.cookies.remove(url, name)
+    },
     snapshotClearIdentities: async (cookies) =>
       snapshotClearIdentitiesFromCdp(sendCommand, cookies),
     restoreClearIdentities: async (identities) => {
+      assertCookieMutationsAvailable(targetSession)
       await attach()
       await restoreEveryCookieIdentity(identities, (identity) =>
         writeIdentityWithCdp(sendCommand, identity, 'restore')

--- a/src/main/browser/browser-cookie-clear-store.ts
+++ b/src/main/browser/browser-cookie-clear-store.ts
@@ -216,8 +216,8 @@ export function openCookieClearStore(
   let attached: CookieDebuggerSession | null = null
   let pendingAttach: Promise<CookieDebuggerSession> | null = null
   let disposed = false
-  const retire = (session: CookieDebuggerSession, settled: Promise<void>) => {
-    quarantineCookieMutations(targetSession, settled)
+  const retire = (session: CookieDebuggerSession) => {
+    quarantineCookieMutations(targetSession)
     if (attached === session) {
       attached = null
     }
@@ -253,7 +253,7 @@ export function openCookieClearStore(
   const sendCommand = async (method: string, params?: Record<string, unknown>) => {
     assertCookieMutationsAvailable(targetSession)
     const session = await attach()
-    return sendCookieDebuggerCommand(session, method, params, (settled) => retire(session, settled))
+    return sendCookieDebuggerCommand(session, method, params, () => retire(session))
   }
   return {
     get: (filter) => targetSession.cookies.get(filter),

--- a/src/main/browser/browser-cookie-debugger-command.ts
+++ b/src/main/browser/browser-cookie-debugger-command.ts
@@ -5,6 +5,7 @@ type CookieDebuggerCommandSession = {
 }
 
 const COOKIE_DEBUGGER_COMMAND_TIMEOUT_MS = 10_000
+const COOKIE_DEBUGGER_RETIREMENT_TIMEOUT_MS = 1_000
 
 export class CookieDebuggerCommandTimeoutError extends Error {
   constructor(method: string, options?: ErrorOptions) {
@@ -20,11 +21,12 @@ export async function sendCookieDebuggerCommand(
   session: CookieDebuggerCommandSession,
   method: string,
   params: Record<string, unknown> | undefined,
-  retire: () => void
+  retire: (settled: Promise<void>) => void
 ): Promise<unknown> {
   let timedOut = false
   let retirementError: unknown = null
   let timer: ReturnType<typeof setTimeout> | null = null
+  let retirementTimer: ReturnType<typeof setTimeout> | null = null
   const command = Promise.resolve().then(() => session.debugger.sendCommand(method, params))
   const settled = command.then(
     () => undefined,
@@ -34,7 +36,7 @@ export async function sendCookieDebuggerCommand(
     timer = setTimeout(() => {
       timedOut = true
       try {
-        retire()
+        retire(settled)
       } catch (error) {
         retirementError = error
       }
@@ -47,11 +49,19 @@ export async function sendCookieDebuggerCommand(
     if (!timedOut) {
       return await command
     }
-    await settled
+    await Promise.race([
+      settled,
+      new Promise<void>((resolve) => {
+        retirementTimer = setTimeout(resolve, COOKIE_DEBUGGER_RETIREMENT_TIMEOUT_MS)
+      })
+    ])
     throw new CookieDebuggerCommandTimeoutError(method, { cause: retirementError })
   } finally {
     if (timer) {
       clearTimeout(timer)
+    }
+    if (retirementTimer) {
+      clearTimeout(retirementTimer)
     }
   }
 }

--- a/src/main/browser/browser-cookie-debugger-command.ts
+++ b/src/main/browser/browser-cookie-debugger-command.ts
@@ -1,0 +1,57 @@
+type CookieDebuggerCommandSession = {
+  debugger: {
+    sendCommand: (method: string, params?: Record<string, unknown>) => Promise<unknown>
+  }
+}
+
+const COOKIE_DEBUGGER_COMMAND_TIMEOUT_MS = 10_000
+
+export class CookieDebuggerCommandTimeoutError extends Error {
+  constructor(method: string, options?: ErrorOptions) {
+    super(
+      `Cookie debugger command ${method} timed out after ${COOKIE_DEBUGGER_COMMAND_TIMEOUT_MS}ms`,
+      options
+    )
+    this.name = 'CookieDebuggerCommandTimeoutError'
+  }
+}
+
+export async function sendCookieDebuggerCommand(
+  session: CookieDebuggerCommandSession,
+  method: string,
+  params: Record<string, unknown> | undefined,
+  retire: () => void
+): Promise<unknown> {
+  let timedOut = false
+  let retirementError: unknown = null
+  let timer: ReturnType<typeof setTimeout> | null = null
+  const command = Promise.resolve().then(() => session.debugger.sendCommand(method, params))
+  const settled = command.then(
+    () => undefined,
+    () => undefined
+  )
+  const deadline = new Promise<void>((resolve) => {
+    timer = setTimeout(() => {
+      timedOut = true
+      try {
+        retire()
+      } catch (error) {
+        retirementError = error
+      }
+      resolve()
+    }, COOKIE_DEBUGGER_COMMAND_TIMEOUT_MS)
+  })
+
+  try {
+    await Promise.race([settled, deadline])
+    if (!timedOut) {
+      return await command
+    }
+    await settled
+    throw new CookieDebuggerCommandTimeoutError(method, { cause: retirementError })
+  } finally {
+    if (timer) {
+      clearTimeout(timer)
+    }
+  }
+}

--- a/src/main/browser/browser-cookie-debugger-command.ts
+++ b/src/main/browser/browser-cookie-debugger-command.ts
@@ -28,9 +28,9 @@ export async function sendCookieDebuggerCommand(
   let timer: ReturnType<typeof setTimeout> | null = null
   let retirementTimer: ReturnType<typeof setTimeout> | null = null
   const command = Promise.resolve().then(() => session.debugger.sendCommand(method, params))
-  const settled = command.then(
-    () => undefined,
-    () => undefined
+  const outcome = command.then(
+    () => 'fulfilled' as const,
+    () => 'rejected' as const
   )
   const deadline = new Promise<void>((resolve) => {
     timer = setTimeout(() => {
@@ -40,20 +40,20 @@ export async function sendCookieDebuggerCommand(
   })
 
   try {
-    await Promise.race([settled, deadline])
+    await Promise.race([outcome, deadline])
     if (!timedOut) {
       return await command
     }
-    let settledDuringGrace = false
-    await Promise.race([
-      settled.then(() => {
-        settledDuringGrace = true
-      }),
-      new Promise<void>((resolve) => {
-        retirementTimer = setTimeout(resolve, COOKIE_DEBUGGER_RETIREMENT_TIMEOUT_MS)
+    const graceOutcome = await Promise.race([
+      outcome,
+      new Promise<'pending'>((resolve) => {
+        retirementTimer = setTimeout(
+          () => resolve('pending'),
+          COOKIE_DEBUGGER_RETIREMENT_TIMEOUT_MS
+        )
       })
     ])
-    if (!settledDuringGrace) {
+    if (graceOutcome !== 'fulfilled') {
       try {
         retire()
       } catch (error) {

--- a/src/main/browser/browser-cookie-debugger-command.ts
+++ b/src/main/browser/browser-cookie-debugger-command.ts
@@ -21,7 +21,7 @@ export async function sendCookieDebuggerCommand(
   session: CookieDebuggerCommandSession,
   method: string,
   params: Record<string, unknown> | undefined,
-  retire: (settled: Promise<void>) => void
+  retire: () => void
 ): Promise<unknown> {
   let timedOut = false
   let retirementError: unknown = null
@@ -35,11 +35,6 @@ export async function sendCookieDebuggerCommand(
   const deadline = new Promise<void>((resolve) => {
     timer = setTimeout(() => {
       timedOut = true
-      try {
-        retire(settled)
-      } catch (error) {
-        retirementError = error
-      }
       resolve()
     }, COOKIE_DEBUGGER_COMMAND_TIMEOUT_MS)
   })
@@ -49,12 +44,22 @@ export async function sendCookieDebuggerCommand(
     if (!timedOut) {
       return await command
     }
+    let settledDuringGrace = false
     await Promise.race([
-      settled,
+      settled.then(() => {
+        settledDuringGrace = true
+      }),
       new Promise<void>((resolve) => {
         retirementTimer = setTimeout(resolve, COOKIE_DEBUGGER_RETIREMENT_TIMEOUT_MS)
       })
     ])
+    if (!settledDuringGrace) {
+      try {
+        retire()
+      } catch (error) {
+        retirementError = error
+      }
+    }
     throw new CookieDebuggerCommandTimeoutError(method, { cause: retirementError })
   } finally {
     if (timer) {

--- a/src/main/browser/browser-cookie-debugger-retirement.electron.test.ts
+++ b/src/main/browser/browser-cookie-debugger-retirement.electron.test.ts
@@ -1,0 +1,191 @@
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, describe, expect, it } from 'vitest'
+import { build as buildVite } from 'vite'
+
+const electronBinary = createRequire(import.meta.url)('electron') as string
+const fixtureRoots: string[] = []
+
+afterAll(() => {
+  for (const root of fixtureRoots) {
+    rmSync(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+  }
+})
+
+type FixtureResult = {
+  step: string
+  firstError: { name: string; message: string } | null
+  events: string[]
+  recoveredCookieValues: string[]
+}
+
+function fixtureMain(bundlePath: string, resultPath: string): string {
+  return `
+const { app, BrowserWindow, session } = require('electron')
+const { writeFileSync } = require('node:fs')
+const {
+  openCookieClearStore,
+  sendCookieDebuggerCommand,
+  withCookieMutationLock
+} = require(${JSON.stringify(bundlePath)})
+const resultPath = ${JSON.stringify(resultPath)}
+let step = 'starting'
+const events = []
+const mark = (value) => {
+  step = value
+  writeFileSync(resultPath, JSON.stringify({ step, events }))
+}
+
+async function run() {
+  const fixtureTimeout = setTimeout(() => {
+    writeFileSync(resultPath, JSON.stringify({ step: 'timed out after ' + step, events }))
+    app.exit(1)
+  }, 40000)
+  await app.whenReady()
+  const partition = 'persist:cookie-debugger-retirement-test'
+  const targetSession = session.fromPartition(partition)
+  const keeper = new BrowserWindow({ show: false })
+  await keeper.loadURL('data:text/html,<title>fixture keeper</title>')
+  const firstWindow = new BrowserWindow({
+    show: false,
+    webPreferences: { session: targetSession, sandbox: true, contextIsolation: true }
+  })
+  await firstWindow.loadURL('data:text/html,<title>wedged cookie debugger</title>')
+  const firstDebugger = firstWindow.webContents.debugger
+  firstDebugger.attach('1.3')
+
+  let firstError = null
+  const first = withCookieMutationLock(targetSession, async () => {
+    events.push('first:start')
+    try {
+      await sendCookieDebuggerCommand(
+        { debugger: firstDebugger },
+        'Runtime.evaluate',
+        { expression: 'new Promise(() => {})', awaitPromise: true },
+        () => {
+          events.push('first:retire')
+          if (firstDebugger.isAttached()) firstDebugger.detach()
+          firstWindow.destroy()
+        }
+      )
+    } catch (error) {
+      firstError = { name: error?.name || '', message: String(error?.message || error) }
+      events.push('first:error')
+    }
+  })
+
+  const second = withCookieMutationLock(targetSession, async () => {
+    events.push('second:start')
+    const store = openCookieClearStore(targetSession)
+    try {
+      await store.writeCookieIdentity({
+        url: 'https://recovered.example/',
+        name: 'recovered',
+        value: 'written-after-retirement',
+        sameSite: 'unspecified',
+        secure: true
+      })
+      events.push('second:done')
+    } finally {
+      store.dispose()
+    }
+  })
+
+  mark('commands started')
+  await Promise.all([first, second])
+  mark('imports settled')
+
+  const viewer = new BrowserWindow({
+    show: false,
+    webPreferences: { session: targetSession, sandbox: true, contextIsolation: true }
+  })
+  await viewer.loadURL('data:text/html,<title>cookie debugger verifier</title>')
+  const viewerDebugger = viewer.webContents.debugger
+  viewerDebugger.attach('1.3')
+  const cookies = (await viewerDebugger.sendCommand('Network.getAllCookies')).cookies
+  const recoveredCookieValues = cookies
+    .filter((cookie) => cookie.name === 'recovered')
+    .map((cookie) => cookie.value)
+  viewerDebugger.detach()
+  viewer.destroy()
+  keeper.destroy()
+
+  clearTimeout(fixtureTimeout)
+  writeFileSync(resultPath, JSON.stringify({ step, firstError, events, recoveredCookieValues }))
+  app.exit(0)
+}
+
+run().catch((error) => {
+  writeFileSync(resultPath, JSON.stringify({ step, events, error: String(error?.stack || error) }))
+  app.exit(1)
+})
+`
+}
+
+async function runFixture(): Promise<FixtureResult> {
+  const root = mkdtempSync(join(tmpdir(), 'orca-cookie-debugger-retirement-'))
+  fixtureRoots.push(root)
+  const bundleEntryPath = join(root, 'cookie-debugger-retirement.ts')
+  const bundlePath = join(root, 'cookie-debugger-retirement.cjs')
+  const fixturePath = join(root, 'main.cjs')
+  const resultPath = join(root, 'result.json')
+  writeFileSync(
+    bundleEntryPath,
+    [
+      `export { openCookieClearStore } from ${JSON.stringify(join(process.cwd(), 'src/main/browser/browser-cookie-clear-store.ts'))}`,
+      `export { sendCookieDebuggerCommand } from ${JSON.stringify(join(process.cwd(), 'src/main/browser/browser-cookie-debugger-command.ts'))}`,
+      `export { withCookieMutationLock } from ${JSON.stringify(join(process.cwd(), 'src/main/browser/browser-cookie-import-clear.ts'))}`
+    ].join('\n')
+  )
+  await buildVite({
+    configFile: false,
+    logLevel: 'silent',
+    build: {
+      emptyOutDir: false,
+      lib: {
+        entry: bundleEntryPath,
+        formats: ['cjs'],
+        fileName: () => 'cookie-debugger-retirement.cjs'
+      },
+      outDir: root,
+      target: 'node20',
+      rollupOptions: { external: ['electron', /^node:/] }
+    }
+  })
+  writeFileSync(fixturePath, fixtureMain(bundlePath, resultPath))
+  const { ELECTRON_RUN_AS_NODE: _electronRunAsNode, ...env } = process.env
+  const electronArgs = [fixturePath, `--user-data-dir=${join(root, 'profile')}`]
+  const executable = process.platform === 'linux' ? 'xvfb-run' : electronBinary
+  const args =
+    process.platform === 'linux'
+      ? ['--auto-servernum', electronBinary, ...electronArgs, '--no-sandbox']
+      : electronArgs
+  const run = spawnSync(executable, args, { encoding: 'utf8', env, timeout: 60_000 })
+  const fixtureResult = existsSync(resultPath) ? readFileSync(resultPath, 'utf8') : 'no result'
+  expect(run.error).toBeUndefined()
+  expect(run.status, `${fixtureResult}\n${run.stdout}\n${run.stderr}`).toBe(0)
+  return JSON.parse(fixtureResult) as FixtureResult
+}
+
+describe('cookie debugger retirement in Electron', () => {
+  it('settles the wedged command before a queued cookie mutation starts', async () => {
+    const result = await runFixture()
+
+    expect(result.step).toBe('imports settled')
+    expect(result.firstError).toEqual({
+      name: 'CookieDebuggerCommandTimeoutError',
+      message: 'Cookie debugger command Runtime.evaluate timed out after 10000ms'
+    })
+    expect(result.events).toEqual([
+      'first:start',
+      'first:retire',
+      'first:error',
+      'second:start',
+      'second:done'
+    ])
+    expect(result.recoveredCookieValues).toEqual(['written-after-retirement'])
+  }, 60_000)
+})

--- a/src/main/browser/browser-cookie-debugger-retirement.electron.test.ts
+++ b/src/main/browser/browser-cookie-debugger-retirement.electron.test.ts
@@ -19,6 +19,7 @@ type FixtureResult = {
   step: string
   firstError: { name: string; message: string } | null
   secondError: { name: string; message: string } | null
+  thirdError: { name: string; message: string } | null
   events: string[]
   recoveredCookieValues: string[]
 }
@@ -101,24 +102,16 @@ async function run() {
   mark('quarantine proven')
 
   if (!resolveOrphan) throw new Error('the injected cookie command never started')
+  await new Promise((resolve) => setImmediate(resolve))
   resolveOrphan()
   await new Promise((resolve) => setImmediate(resolve))
 
+  let thirdError = null
   await withCookieMutationLock(targetSession, async () => {
     events.push('third:start')
-    const store = openCookieClearStore(targetSession)
-    try {
-      await store.writeCookieIdentity({
-        url: 'https://recovered.example/',
-        name: 'recovered',
-        value: 'written-after-quarantine',
-        sameSite: 'unspecified',
-        secure: true
-      })
-      events.push('third:done')
-    } finally {
-      store.dispose()
-    }
+  }).catch((error) => {
+    thirdError = { name: error?.name || '', message: String(error?.message || error) }
+    events.push('third:error')
   })
 
   const cookies = await targetSession.cookies.get({ name: 'recovered' })
@@ -130,7 +123,7 @@ async function run() {
   clearTimeout(fixtureTimeout)
   writeFileSync(
     resultPath,
-    JSON.stringify({ step, firstError, secondError, events, recoveredCookieValues })
+    JSON.stringify({ step, firstError, secondError, thirdError, events, recoveredCookieValues })
   )
   app.exit(0)
 }
@@ -187,7 +180,7 @@ async function runFixture(): Promise<FixtureResult> {
 }
 
 describe('cookie debugger retirement in Electron', () => {
-  it('quarantines an unsettled cookie command and recovers after its late completion', async () => {
+  it('keeps an ambiguously retired cookie command quarantined after late completion', async () => {
     const result = await runFixture()
 
     expect(result.step).toBe('quarantine proven')
@@ -198,19 +191,19 @@ describe('cookie debugger retirement in Electron', () => {
     expect(result.secondError).toEqual({
       name: 'CookieMutationQuarantinedError',
       message:
-        'A previous cookie import is still finishing in Chromium. Wait a moment and try again; if it continues, restart Orca.'
+        'A cookie import timed out in Chromium, so this browser session is locked for safety. Restart Orca before importing cookies again.'
     })
-    expect(result.events).not.toContain('second:start')
-    expect(result.events.indexOf('first:error')).toBeLessThan(
-      result.events.indexOf('first:late-completion')
-    )
-    expect(result.events.indexOf('first:late-completion')).toBeLessThan(
-      result.events.indexOf('third:start')
-    )
-    expect(result.events).toContain('target:1:Network.setCookie')
-    expect(result.events).toContain('target:1:destroyed')
-    expect(result.events).toContain('target:2:Network.setCookie')
-    expect(result.events).toContain('third:done')
-    expect(result.recoveredCookieValues).toEqual(['written-after-quarantine'])
+    expect(result.thirdError).toEqual(result.secondError)
+    expect(result.events).toEqual([
+      'first:start',
+      'target:1:created',
+      'target:1:Network.setCookie',
+      'first:error',
+      'second:error',
+      'target:1:destroyed',
+      'first:late-completion',
+      'third:error'
+    ])
+    expect(result.recoveredCookieValues).toEqual([])
   }, 60_000)
 })

--- a/src/main/browser/browser-cookie-debugger-retirement.electron.test.ts
+++ b/src/main/browser/browser-cookie-debugger-retirement.electron.test.ts
@@ -18,6 +18,7 @@ afterAll(() => {
 type FixtureResult = {
   step: string
   firstError: { name: string; message: string } | null
+  secondError: { name: string; message: string } | null
   events: string[]
   recoveredCookieValues: string[]
 }
@@ -26,11 +27,7 @@ function fixtureMain(bundlePath: string, resultPath: string): string {
   return `
 const { app, BrowserWindow, session } = require('electron')
 const { writeFileSync } = require('node:fs')
-const {
-  openCookieClearStore,
-  sendCookieDebuggerCommand,
-  withCookieMutationLock
-} = require(${JSON.stringify(bundlePath)})
+const { openCookieClearStore, withCookieMutationLock } = require(${JSON.stringify(bundlePath)})
 const resultPath = ${JSON.stringify(resultPath)}
 let step = 'starting'
 const events = []
@@ -49,72 +46,92 @@ async function run() {
   const targetSession = session.fromPartition(partition)
   const keeper = new BrowserWindow({ show: false })
   await keeper.loadURL('data:text/html,<title>fixture keeper</title>')
-  const firstWindow = new BrowserWindow({
-    show: false,
-    webPreferences: { session: targetSession, sandbox: true, contextIsolation: true }
+  let targetCount = 0
+  let resolveOrphan = null
+  app.on('web-contents-created', (_event, contents) => {
+    targetCount += 1
+    const label = String(targetCount)
+    events.push('target:' + label + ':created')
+    contents.once('destroyed', () => events.push('target:' + label + ':destroyed'))
+    const sendCommand = contents.debugger.sendCommand.bind(contents.debugger)
+    contents.debugger.sendCommand = (method, params) => {
+      events.push('target:' + label + ':' + method)
+      if (label === '1' && method === 'Network.setCookie') {
+        return new Promise((resolve) => {
+          resolveOrphan = () => {
+            events.push('first:late-completion')
+            resolve({ success: true })
+          }
+        })
+      }
+      return sendCommand(method, params)
+    }
   })
-  await firstWindow.loadURL('data:text/html,<title>wedged cookie debugger</title>')
-  const firstDebugger = firstWindow.webContents.debugger
-  firstDebugger.attach('1.3')
 
   let firstError = null
   const first = withCookieMutationLock(targetSession, async () => {
     events.push('first:start')
-    try {
-      await sendCookieDebuggerCommand(
-        { debugger: firstDebugger },
-        'Runtime.evaluate',
-        { expression: 'new Promise(() => {})', awaitPromise: true },
-        () => {
-          events.push('first:retire')
-          if (firstDebugger.isAttached()) firstDebugger.detach()
-          firstWindow.destroy()
-        }
-      )
-    } catch (error) {
-      firstError = { name: error?.name || '', message: String(error?.message || error) }
-      events.push('first:error')
-    }
-  })
-
-  const second = withCookieMutationLock(targetSession, async () => {
-    events.push('second:start')
     const store = openCookieClearStore(targetSession)
     try {
       await store.writeCookieIdentity({
-        url: 'https://recovered.example/',
-        name: 'recovered',
-        value: 'written-after-retirement',
+        url: 'https://wedged.example/',
+        name: 'wedged',
+        value: 'never-committed',
         sameSite: 'unspecified',
         secure: true
       })
-      events.push('second:done')
+    } catch (error) {
+      firstError = { name: error?.name || '', message: String(error?.message || error) }
+      events.push('first:error')
     } finally {
       store.dispose()
     }
   })
 
+  let secondError = null
+  const second = withCookieMutationLock(targetSession, async () => {
+    events.push('second:start')
+  }).catch((error) => {
+    secondError = { name: error?.name || '', message: String(error?.message || error) }
+    events.push('second:error')
+  })
+
   mark('commands started')
   await Promise.all([first, second])
-  mark('imports settled')
+  mark('quarantine proven')
 
-  const viewer = new BrowserWindow({
-    show: false,
-    webPreferences: { session: targetSession, sandbox: true, contextIsolation: true }
+  if (!resolveOrphan) throw new Error('the injected cookie command never started')
+  resolveOrphan()
+  await new Promise((resolve) => setImmediate(resolve))
+
+  await withCookieMutationLock(targetSession, async () => {
+    events.push('third:start')
+    const store = openCookieClearStore(targetSession)
+    try {
+      await store.writeCookieIdentity({
+        url: 'https://recovered.example/',
+        name: 'recovered',
+        value: 'written-after-quarantine',
+        sameSite: 'unspecified',
+        secure: true
+      })
+      events.push('third:done')
+    } finally {
+      store.dispose()
+    }
   })
-  await viewer.loadURL('data:text/html,<title>cookie debugger verifier</title>')
-  const viewerDebugger = viewer.webContents.debugger
-  viewerDebugger.attach('1.3')
-  const cookies = (await viewerDebugger.sendCommand('Network.getAllCookies')).cookies
+
+  const cookies = await targetSession.cookies.get({ name: 'recovered' })
   const recoveredCookieValues = cookies
     .filter((cookie) => cookie.name === 'recovered')
     .map((cookie) => cookie.value)
-  viewerDebugger.detach()
-  viewer.destroy()
   keeper.destroy()
 
   clearTimeout(fixtureTimeout)
-  writeFileSync(resultPath, JSON.stringify({ step, firstError, events, recoveredCookieValues }))
+  writeFileSync(
+    resultPath,
+    JSON.stringify({ step, firstError, secondError, events, recoveredCookieValues })
+  )
   app.exit(0)
 }
 
@@ -136,7 +153,6 @@ async function runFixture(): Promise<FixtureResult> {
     bundleEntryPath,
     [
       `export { openCookieClearStore } from ${JSON.stringify(join(process.cwd(), 'src/main/browser/browser-cookie-clear-store.ts'))}`,
-      `export { sendCookieDebuggerCommand } from ${JSON.stringify(join(process.cwd(), 'src/main/browser/browser-cookie-debugger-command.ts'))}`,
       `export { withCookieMutationLock } from ${JSON.stringify(join(process.cwd(), 'src/main/browser/browser-cookie-import-clear.ts'))}`
     ].join('\n')
   )
@@ -171,21 +187,30 @@ async function runFixture(): Promise<FixtureResult> {
 }
 
 describe('cookie debugger retirement in Electron', () => {
-  it('settles the wedged command before a queued cookie mutation starts', async () => {
+  it('quarantines an unsettled cookie command and recovers after its late completion', async () => {
     const result = await runFixture()
 
-    expect(result.step).toBe('imports settled')
+    expect(result.step).toBe('quarantine proven')
     expect(result.firstError).toEqual({
       name: 'CookieDebuggerCommandTimeoutError',
-      message: 'Cookie debugger command Runtime.evaluate timed out after 10000ms'
+      message: 'Cookie debugger command Network.setCookie timed out after 10000ms'
     })
-    expect(result.events).toEqual([
-      'first:start',
-      'first:retire',
-      'first:error',
-      'second:start',
-      'second:done'
-    ])
-    expect(result.recoveredCookieValues).toEqual(['written-after-retirement'])
+    expect(result.secondError).toEqual({
+      name: 'CookieMutationQuarantinedError',
+      message:
+        'A previous cookie import is still finishing in Chromium. Wait a moment and try again; if it continues, restart Orca.'
+    })
+    expect(result.events).not.toContain('second:start')
+    expect(result.events.indexOf('first:error')).toBeLessThan(
+      result.events.indexOf('first:late-completion')
+    )
+    expect(result.events.indexOf('first:late-completion')).toBeLessThan(
+      result.events.indexOf('third:start')
+    )
+    expect(result.events).toContain('target:1:Network.setCookie')
+    expect(result.events).toContain('target:1:destroyed')
+    expect(result.events).toContain('target:2:Network.setCookie')
+    expect(result.events).toContain('third:done')
+    expect(result.recoveredCookieValues).toEqual(['written-after-quarantine'])
   }, 60_000)
 })

--- a/src/main/browser/browser-cookie-debugger-session.ts
+++ b/src/main/browser/browser-cookie-debugger-session.ts
@@ -1,0 +1,51 @@
+import { BrowserWindow, type Session } from 'electron'
+import { acquireElectronDebugger } from './electron-debugger-lease'
+
+export type CookieDebuggerSession = {
+  debugger: {
+    sendCommand: (method: string, params?: Record<string, unknown>) => Promise<unknown>
+  }
+  dispose: () => void
+}
+
+export async function leaseCookieDebuggerSession(
+  targetSession: Session
+): Promise<CookieDebuggerSession> {
+  const window = new BrowserWindow({
+    show: false,
+    webPreferences: {
+      session: targetSession,
+      sandbox: true,
+      contextIsolation: true,
+      nodeIntegration: false
+    }
+  })
+  try {
+    await window.loadURL('data:text/html,<!doctype html><title>cookie-clear</title>')
+    const contents = window.webContents
+    if (contents.isDestroyed()) {
+      throw new Error('Could not attach to the cookie session for an atomic clear')
+    }
+    const lease = acquireElectronDebugger(contents)
+    let disposed = false
+    return {
+      debugger: contents.debugger,
+      dispose: () => {
+        if (disposed) {
+          return
+        }
+        disposed = true
+        try {
+          lease.release()
+        } finally {
+          if (!contents.isDestroyed()) {
+            window.destroy()
+          }
+        }
+      }
+    }
+  } catch (error) {
+    window.destroy()
+    throw error
+  }
+}

--- a/src/main/browser/browser-cookie-import-cdp-timeout.test.ts
+++ b/src/main/browser/browser-cookie-import-cdp-timeout.test.ts
@@ -1,0 +1,175 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const electron = vi.hoisted(() => {
+  type PendingCommand = {
+    promise: Promise<unknown>
+    resolve: (value: unknown) => void
+  }
+
+  const events: string[] = []
+  const windows: BrowserWindow[] = []
+  let firstCommandStarted: () => void = () => undefined
+  let firstCommand: PendingCommand
+  let userDataPath = ''
+
+  function reset(): void {
+    events.length = 0
+    windows.length = 0
+    let resolveCommand!: (value: unknown) => void
+    firstCommand = {
+      promise: new Promise((resolve) => {
+        resolveCommand = resolve
+      }),
+      resolve: resolveCommand
+    }
+  }
+
+  class BrowserWindow {
+    readonly label = windows.length === 0 ? 'A' : 'B'
+    readonly webContents = {
+      label: this.label,
+      debugger: {
+        sendCommand: vi.fn((method: string): Promise<unknown> => {
+          events.push(`${this.label}:${method}`)
+          if (this.label === 'A') {
+            firstCommandStarted()
+            return firstCommand.promise
+          }
+          return Promise.resolve({ success: true })
+        })
+      },
+      isDestroyed: vi.fn(() => false)
+    }
+
+    constructor() {
+      windows.push(this)
+    }
+
+    async loadURL(): Promise<void> {}
+
+    destroy(): void {
+      events.push(`${this.label}:destroy`)
+    }
+  }
+
+  const cookies = {
+    get: vi.fn(async () => []),
+    remove: vi.fn(async (_url: string, name: string) => {
+      events.push(`rollback:${name}`)
+    })
+  }
+  const stableSession = { cookies }
+
+  reset()
+  return {
+    BrowserWindow,
+    cookies,
+    events,
+    firstCommand: () => firstCommand,
+    onFirstCommand: () =>
+      new Promise<void>((resolve) => {
+        firstCommandStarted = resolve
+      }),
+    reset,
+    stableSession,
+    windows,
+    getUserDataPath: () => userDataPath,
+    setUserDataPath: (value: string) => {
+      userDataPath = value
+    }
+  }
+})
+
+vi.mock('electron', () => ({
+  app: { getPath: electron.getUserDataPath },
+  BrowserWindow: electron.BrowserWindow,
+  dialog: { showOpenDialog: vi.fn() },
+  session: { fromPartition: vi.fn(() => electron.stableSession) },
+  webContents: { getAllWebContents: vi.fn(() => []) }
+}))
+
+vi.mock('./electron-debugger-lease', () => ({
+  acquireElectronDebugger: (contents: { label: string }) => ({
+    release: () => {
+      electron.events.push(`${contents.label}:detach`)
+    }
+  })
+}))
+
+vi.mock('./browser-session-registry', () => ({
+  browserSessionRegistry: {
+    setPendingCookieImport: vi.fn(),
+    clearPendingCookieImport: vi.fn()
+  }
+}))
+
+import { importCookiesFromFile } from './browser-cookie-import'
+
+describe('cookie import debugger timeout', () => {
+  let fixtureDir: string
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    electron.reset()
+    electron.cookies.get.mockClear()
+    electron.cookies.remove.mockClear()
+    fixtureDir = mkdtempSync(join(tmpdir(), 'orca-cookie-cdp-timeout-'))
+    electron.setUserDataPath(fixtureDir)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    rmSync(fixtureDir, { recursive: true, force: true })
+  })
+
+  function writeCookieSource(name: string): string {
+    const filePath = join(fixtureDir, `${name}.json`)
+    writeFileSync(
+      filePath,
+      JSON.stringify([
+        { domain: `.${name}.example`, name, value: 'value', path: '/', secure: true }
+      ])
+    )
+    return filePath
+  }
+
+  it('retires a timed-out debugger without releasing serialization before its late write settles', async () => {
+    const firstStarted = electron.onFirstCommand()
+    const first = importCookiesFromFile(writeCookieSource('first'), 'persist:timeout-oracle')
+    await firstStarted
+
+    const second = importCookiesFromFile(writeCookieSource('second'), 'persist:timeout-oracle')
+    await vi.advanceTimersByTimeAsync(60_000)
+
+    const whileFirstCanCompleteLate = [...electron.events]
+    electron.events.push('A:late-completion')
+    electron.firstCommand().resolve({ success: true })
+    const [firstResult, secondResult] = await Promise.all([first, second])
+
+    expect(whileFirstCanCompleteLate).toEqual(['A:Network.setCookie', 'A:detach', 'A:destroy'])
+    expect(firstResult).toEqual({
+      ok: false,
+      reason: expect.stringContaining('Could not safely replace cookies for the imported sites.')
+    })
+    expect(secondResult.ok).toBe(true)
+    expect(electron.events).toEqual([
+      'A:Network.setCookie',
+      'A:detach',
+      'A:destroy',
+      'A:late-completion',
+      'rollback:first',
+      'B:Network.setCookie',
+      'B:detach',
+      'B:destroy'
+    ])
+    expect(electron.windows).toHaveLength(2)
+    expect(
+      electron.windows.every(
+        (window) => window.webContents.debugger.sendCommand.mock.calls.length === 1
+      )
+    ).toBe(true)
+  })
+})

--- a/src/main/browser/browser-cookie-import-cdp-timeout.test.ts
+++ b/src/main/browser/browser-cookie-import-cdp-timeout.test.ts
@@ -2,6 +2,11 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { sendCookieDebuggerCommand } from './browser-cookie-debugger-command'
+
+type CookieDebuggerCommandModule = {
+  sendCookieDebuggerCommand: typeof sendCookieDebuggerCommand
+}
 
 const electron = vi.hoisted(() => {
   type PendingCommand = {
@@ -11,24 +16,54 @@ const electron = vi.hoisted(() => {
 
   const events: string[] = []
   const windows: BrowserWindow[] = []
+  const sessions = new Map<string, ReturnType<typeof createSession>>()
   let firstCommandStarted: () => void = () => undefined
   let firstCommand: PendingCommand
   let userDataPath = ''
+  let commandTimeoutEnabled = true
+
+  function createSession(partition: string) {
+    return {
+      partition,
+      cookies: {
+        get: vi.fn(async () => []),
+        remove: vi.fn(async (_url: string, name: string) => {
+          events.push(`remove:${partition}:${name}`)
+        })
+      }
+    }
+  }
+
+  function fromPartition(partition: string) {
+    let target = sessions.get(partition)
+    if (!target) {
+      target = createSession(partition)
+      sessions.set(partition, target)
+    }
+    return target
+  }
 
   function reset(): void {
     events.length = 0
     windows.length = 0
+    sessions.clear()
+    firstCommandStarted = () => undefined
+    commandTimeoutEnabled = true
     let resolveCommand!: (value: unknown) => void
     firstCommand = {
       promise: new Promise((resolve) => {
         resolveCommand = resolve
       }),
-      resolve: resolveCommand
+      resolve: (value) => {
+        events.push('A:late-completion')
+        resolveCommand(value)
+      }
     }
   }
 
   class BrowserWindow {
-    readonly label = windows.length === 0 ? 'A' : 'B'
+    readonly label = String.fromCharCode(65 + windows.length)
+    private closed = false
     readonly webContents = {
       label: this.label,
       debugger: {
@@ -41,7 +76,7 @@ const electron = vi.hoisted(() => {
           return Promise.resolve({ success: true })
         })
       },
-      isDestroyed: vi.fn(() => false)
+      isDestroyed: vi.fn(() => this.closed)
     }
 
     constructor() {
@@ -51,44 +86,40 @@ const electron = vi.hoisted(() => {
     async loadURL(): Promise<void> {}
 
     destroy(): void {
+      this.closed = true
       events.push(`${this.label}:destroy`)
     }
   }
 
-  const cookies = {
-    get: vi.fn(async () => []),
-    remove: vi.fn(async (_url: string, name: string) => {
-      events.push(`rollback:${name}`)
-    })
-  }
-  const stableSession = { cookies }
-
   reset()
   return {
     BrowserWindow,
-    cookies,
     events,
     firstCommand: () => firstCommand,
+    fromPartition,
+    isCommandTimeoutEnabled: () => commandTimeoutEnabled,
     onFirstCommand: () =>
       new Promise<void>((resolve) => {
         firstCommandStarted = resolve
       }),
     reset,
-    stableSession,
+    sessions,
     windows,
     getUserDataPath: () => userDataPath,
     setUserDataPath: (value: string) => {
       userDataPath = value
+    },
+    setCommandTimeoutEnabled: (value: boolean) => {
+      commandTimeoutEnabled = value
     }
   }
 })
 
 vi.mock('electron', () => ({
   app: { getPath: electron.getUserDataPath },
-  BrowserWindow: electron.BrowserWindow,
   dialog: { showOpenDialog: vi.fn() },
-  session: { fromPartition: vi.fn(() => electron.stableSession) },
-  webContents: { getAllWebContents: vi.fn(() => []) }
+  session: { fromPartition: vi.fn(electron.fromPartition) },
+  BrowserWindow: electron.BrowserWindow
 }))
 
 vi.mock('./electron-debugger-lease', () => ({
@@ -98,6 +129,19 @@ vi.mock('./electron-debugger-lease', () => ({
     }
   })
 }))
+
+vi.mock('./browser-cookie-debugger-command', async (importOriginal) => {
+  const actual = await importOriginal<CookieDebuggerCommandModule>()
+  return {
+    ...actual,
+    sendCookieDebuggerCommand: (
+      ...args: Parameters<typeof actual.sendCookieDebuggerCommand>
+    ): ReturnType<typeof actual.sendCookieDebuggerCommand> =>
+      electron.isCommandTimeoutEnabled()
+        ? actual.sendCookieDebuggerCommand(...args)
+        : args[0].debugger.sendCommand(args[1], args[2])
+  }
+})
 
 vi.mock('./browser-session-registry', () => ({
   browserSessionRegistry: {
@@ -114,8 +158,6 @@ describe('cookie import debugger timeout', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     electron.reset()
-    electron.cookies.get.mockClear()
-    electron.cookies.remove.mockClear()
     fixtureDir = mkdtempSync(join(tmpdir(), 'orca-cookie-cdp-timeout-'))
     electron.setUserDataPath(fixtureDir)
   })
@@ -136,20 +178,21 @@ describe('cookie import debugger timeout', () => {
     return filePath
   }
 
-  it('retires a timed-out debugger without releasing serialization before its late write settles', async () => {
+  it('recovers after retirement proves the late command settled during its grace period', async () => {
     const firstStarted = electron.onFirstCommand()
     const first = importCookiesFromFile(writeCookieSource('first'), 'persist:timeout-oracle')
     await firstStarted
 
     const second = importCookiesFromFile(writeCookieSource('second'), 'persist:timeout-oracle')
-    await vi.advanceTimersByTimeAsync(60_000)
+    await vi.advanceTimersByTimeAsync(10_000)
 
     const whileFirstCanCompleteLate = [...electron.events]
-    electron.events.push('A:late-completion')
+    const firstState = await Promise.race([first.then(() => 'settled'), Promise.resolve('pending')])
     electron.firstCommand().resolve({ success: true })
     const [firstResult, secondResult] = await Promise.all([first, second])
 
     expect(whileFirstCanCompleteLate).toEqual(['A:Network.setCookie', 'A:detach', 'A:destroy'])
+    expect(firstState).toBe('pending')
     expect(firstResult).toEqual({
       ok: false,
       reason: expect.stringContaining('Could not safely replace cookies for the imported sites.')
@@ -160,7 +203,7 @@ describe('cookie import debugger timeout', () => {
       'A:detach',
       'A:destroy',
       'A:late-completion',
-      'rollback:first',
+      'remove:persist:timeout-oracle:first',
       'B:Network.setCookie',
       'B:detach',
       'B:destroy'
@@ -171,5 +214,89 @@ describe('cookie import debugger timeout', () => {
         (window) => window.webContents.debugger.sendCommand.mock.calls.length === 1
       )
     ).toBe(true)
+  })
+
+  it('fails fast while an orphan is unsettled and reopens only after its late completion', async () => {
+    const firstStarted = electron.onFirstCommand()
+    const first = importCookiesFromFile(writeCookieSource('first'), 'persist:timeout-oracle')
+    await firstStarted
+    const second = importCookiesFromFile(writeCookieSource('second'), 'persist:timeout-oracle')
+
+    await vi.advanceTimersByTimeAsync(11_000)
+    const [firstResult, secondResult] = await Promise.all([first, second])
+
+    expect(firstResult).toEqual({
+      ok: false,
+      reason: expect.stringContaining('Could not safely replace cookies for the imported sites.')
+    })
+    expect(secondResult).toEqual({
+      ok: false,
+      reason:
+        'A previous cookie import is still finishing in Chromium. Wait a moment and try again; if it continues, restart Orca.'
+    })
+    expect(electron.events).toEqual(['A:Network.setCookie', 'A:detach', 'A:destroy'])
+    expect(electron.windows).toHaveLength(1)
+
+    const otherResult = await importCookiesFromFile(
+      writeCookieSource('other'),
+      'persist:other-partition'
+    )
+    expect(otherResult.ok).toBe(true)
+
+    electron.firstCommand().resolve({ success: true })
+    await electron.firstCommand().promise
+    await Promise.resolve()
+    const recoveredResult = await importCookiesFromFile(
+      writeCookieSource('recovered'),
+      'persist:timeout-oracle'
+    )
+
+    expect(recoveredResult.ok).toBe(true)
+    expect(electron.events).toEqual([
+      'A:Network.setCookie',
+      'A:detach',
+      'A:destroy',
+      'B:Network.setCookie',
+      'B:detach',
+      'B:destroy',
+      'A:late-completion',
+      'C:Network.setCookie',
+      'C:detach',
+      'C:destroy'
+    ])
+    expect(electron.windows).toHaveLength(3)
+  })
+
+  it('exposes the permanent-blockage signal when retirement is disabled', async () => {
+    electron.setCommandTimeoutEnabled(false)
+    const firstStarted = electron.onFirstCommand()
+    const first = importCookiesFromFile(writeCookieSource('first'), 'persist:timeout-oracle')
+    await firstStarted
+    const second = importCookiesFromFile(writeCookieSource('second'), 'persist:timeout-oracle')
+
+    await vi.advanceTimersByTimeAsync(60_000)
+    const firstState = await Promise.race([first.then(() => 'settled'), Promise.resolve('pending')])
+    const secondState = await Promise.race([
+      second.then(() => 'settled'),
+      Promise.resolve('pending')
+    ])
+
+    expect(firstState).toBe('pending')
+    expect(secondState).toBe('pending')
+    expect(electron.events).toEqual(['A:Network.setCookie'])
+
+    electron.firstCommand().resolve({ success: true })
+    const [firstResult, secondResult] = await Promise.all([first, second])
+    expect(firstResult.ok).toBe(true)
+    expect(secondResult.ok).toBe(true)
+    expect(electron.events).toEqual([
+      'A:Network.setCookie',
+      'A:late-completion',
+      'A:detach',
+      'A:destroy',
+      'B:Network.setCookie',
+      'B:detach',
+      'B:destroy'
+    ])
   })
 })

--- a/src/main/browser/browser-cookie-import-cdp-timeout.test.ts
+++ b/src/main/browser/browser-cookie-import-cdp-timeout.test.ts
@@ -3,6 +3,8 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { sendCookieDebuggerCommand } from './browser-cookie-debugger-command'
+import { createChromiumCookieTestDatabase } from './browser-cookie-import-test-database'
+import type { DetectedBrowser } from './browser-cookie-import'
 
 type CookieDebuggerCommandModule = {
   sendCookieDebuggerCommand: typeof sendCookieDebuggerCommand
@@ -27,10 +29,13 @@ const electron = vi.hoisted(() => {
       partition,
       cookies: {
         get: vi.fn(async () => []),
+        set: vi.fn(async () => undefined),
         remove: vi.fn(async (_url: string, name: string) => {
           events.push(`remove:${partition}:${name}`)
-        })
-      }
+        }),
+        flushStore: vi.fn(async () => undefined)
+      },
+      getStoragePath: () => join(userDataPath, 'Partitions', partition.replace('persist:', ''))
     }
   }
 
@@ -150,7 +155,7 @@ vi.mock('./browser-session-registry', () => ({
   }
 }))
 
-import { importCookiesFromFile } from './browser-cookie-import'
+import { importCookiesFromBrowser, importCookiesFromFile } from './browser-cookie-import'
 
 describe('cookie import debugger timeout', () => {
   let fixtureDir: string
@@ -178,6 +183,20 @@ describe('cookie import debugger timeout', () => {
     return filePath
   }
 
+  async function settlementState(promise: Promise<unknown>): Promise<'pending' | 'settled'> {
+    let state: 'pending' | 'settled' = 'pending'
+    void promise.then(
+      () => {
+        state = 'settled'
+      },
+      () => {
+        state = 'settled'
+      }
+    )
+    await Promise.resolve()
+    return state
+  }
+
   it('recovers after retirement proves the late command settled during its grace period', async () => {
     const firstStarted = electron.onFirstCommand()
     const first = importCookiesFromFile(writeCookieSource('first'), 'persist:timeout-oracle')
@@ -187,11 +206,11 @@ describe('cookie import debugger timeout', () => {
     await vi.advanceTimersByTimeAsync(10_000)
 
     const whileFirstCanCompleteLate = [...electron.events]
-    const firstState = await Promise.race([first.then(() => 'settled'), Promise.resolve('pending')])
+    const firstState = await settlementState(first)
     electron.firstCommand().resolve({ success: true })
     const [firstResult, secondResult] = await Promise.all([first, second])
 
-    expect(whileFirstCanCompleteLate).toEqual(['A:Network.setCookie', 'A:detach', 'A:destroy'])
+    expect(whileFirstCanCompleteLate).toEqual(['A:Network.setCookie'])
     expect(firstState).toBe('pending')
     expect(firstResult).toEqual({
       ok: false,
@@ -200,10 +219,10 @@ describe('cookie import debugger timeout', () => {
     expect(secondResult.ok).toBe(true)
     expect(electron.events).toEqual([
       'A:Network.setCookie',
-      'A:detach',
-      'A:destroy',
       'A:late-completion',
       'remove:persist:timeout-oracle:first',
+      'A:detach',
+      'A:destroy',
       'B:Network.setCookie',
       'B:detach',
       'B:destroy'
@@ -216,7 +235,7 @@ describe('cookie import debugger timeout', () => {
     ).toBe(true)
   })
 
-  it('fails fast while an orphan is unsettled and reopens only after its late completion', async () => {
+  it('fails fast after retirement and stays poisoned after an ambiguous late completion', async () => {
     const firstStarted = electron.onFirstCommand()
     const first = importCookiesFromFile(writeCookieSource('first'), 'persist:timeout-oracle')
     await firstStarted
@@ -232,7 +251,7 @@ describe('cookie import debugger timeout', () => {
     expect(secondResult).toEqual({
       ok: false,
       reason:
-        'A previous cookie import is still finishing in Chromium. Wait a moment and try again; if it continues, restart Orca.'
+        'A cookie import timed out in Chromium, so this browser session is locked for safety. Restart Orca before importing cookies again.'
     })
     expect(electron.events).toEqual(['A:Network.setCookie', 'A:detach', 'A:destroy'])
     expect(electron.windows).toHaveLength(1)
@@ -246,12 +265,16 @@ describe('cookie import debugger timeout', () => {
     electron.firstCommand().resolve({ success: true })
     await electron.firstCommand().promise
     await Promise.resolve()
-    const recoveredResult = await importCookiesFromFile(
+    const poisonedResult = await importCookiesFromFile(
       writeCookieSource('recovered'),
       'persist:timeout-oracle'
     )
 
-    expect(recoveredResult.ok).toBe(true)
+    expect(poisonedResult).toEqual({
+      ok: false,
+      reason:
+        'A cookie import timed out in Chromium, so this browser session is locked for safety. Restart Orca before importing cookies again.'
+    })
     expect(electron.events).toEqual([
       'A:Network.setCookie',
       'A:detach',
@@ -259,12 +282,9 @@ describe('cookie import debugger timeout', () => {
       'B:Network.setCookie',
       'B:detach',
       'B:destroy',
-      'A:late-completion',
-      'C:Network.setCookie',
-      'C:detach',
-      'C:destroy'
+      'A:late-completion'
     ])
-    expect(electron.windows).toHaveLength(3)
+    expect(electron.windows).toHaveLength(2)
   })
 
   it('exposes the permanent-blockage signal when retirement is disabled', async () => {
@@ -275,11 +295,8 @@ describe('cookie import debugger timeout', () => {
     const second = importCookiesFromFile(writeCookieSource('second'), 'persist:timeout-oracle')
 
     await vi.advanceTimersByTimeAsync(60_000)
-    const firstState = await Promise.race([first.then(() => 'settled'), Promise.resolve('pending')])
-    const secondState = await Promise.race([
-      second.then(() => 'settled'),
-      Promise.resolve('pending')
-    ])
+    const firstState = await settlementState(first)
+    const secondState = await settlementState(second)
 
     expect(firstState).toBe('pending')
     expect(secondState).toBe('pending')
@@ -298,5 +315,35 @@ describe('cookie import debugger timeout', () => {
       'B:detach',
       'B:destroy'
     ])
+  })
+
+  it('reports an ambiguously retired native Chromium write as a failure', async () => {
+    const sourceCookiesPath = join(fixtureDir, 'Chrome', 'Default', 'Network', 'Cookies')
+    const targetCookiesPath = join(fixtureDir, 'Partitions', 'native-timeout', 'Network', 'Cookies')
+    createChromiumCookieTestDatabase(sourceCookiesPath, [
+      { name: 'native', value: 'source-value' }
+    ]).close()
+    createChromiumCookieTestDatabase(targetCookiesPath, []).close()
+    const browser: DetectedBrowser = {
+      family: 'chrome',
+      label: 'Google Chrome',
+      cookiesPath: sourceCookiesPath,
+      keychainService: 'Chrome Safe Storage',
+      keychainAccount: 'Chrome',
+      profiles: [{ name: 'Default', directory: 'Default' }],
+      selectedProfile: 'Default'
+    }
+    const firstStarted = electron.onFirstCommand()
+    const resultPromise = importCookiesFromBrowser(browser, 'persist:native-timeout')
+    await firstStarted
+
+    await vi.advanceTimersByTimeAsync(11_000)
+
+    await expect(resultPromise).resolves.toEqual({
+      ok: false,
+      reason:
+        'A cookie import timed out in Chromium, so this browser session is locked for safety. Restart Orca before importing cookies again.'
+    })
+    expect(electron.events).toEqual(['A:Network.setCookie', 'A:detach', 'A:destroy'])
   })
 })

--- a/src/main/browser/browser-cookie-import-cdp-timeout.test.ts
+++ b/src/main/browser/browser-cookie-import-cdp-timeout.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Cookie } from 'electron'
 import type { sendCookieDebuggerCommand } from './browser-cookie-debugger-command'
 import { createChromiumCookieTestDatabase } from './browser-cookie-import-test-database'
 import type { DetectedBrowser } from './browser-cookie-import'
@@ -14,6 +15,7 @@ const electron = vi.hoisted(() => {
   type PendingCommand = {
     promise: Promise<unknown>
     resolve: (value: unknown) => void
+    reject: (reason: unknown) => void
   }
 
   const events: string[] = []
@@ -28,7 +30,7 @@ const electron = vi.hoisted(() => {
     return {
       partition,
       cookies: {
-        get: vi.fn(async () => []),
+        get: vi.fn(async (): Promise<Cookie[]> => []),
         set: vi.fn(async () => undefined),
         remove: vi.fn(async (_url: string, name: string) => {
           events.push(`remove:${partition}:${name}`)
@@ -55,13 +57,19 @@ const electron = vi.hoisted(() => {
     firstCommandStarted = () => undefined
     commandTimeoutEnabled = true
     let resolveCommand!: (value: unknown) => void
+    let rejectCommand!: (reason: unknown) => void
     firstCommand = {
-      promise: new Promise((resolve) => {
+      promise: new Promise((resolve, reject) => {
         resolveCommand = resolve
+        rejectCommand = reject
       }),
       resolve: (value) => {
         events.push('A:late-completion')
         resolveCommand(value)
+      },
+      reject: (reason) => {
+        events.push('A:late-rejection')
+        rejectCommand(reason)
       }
     }
   }
@@ -197,6 +205,30 @@ describe('cookie import debugger timeout', () => {
     return state
   }
 
+  function createNativeBrowser(partition: string): DetectedBrowser {
+    const sourceCookiesPath = join(fixtureDir, 'Chrome', 'Default', 'Network', 'Cookies')
+    const targetCookiesPath = join(
+      fixtureDir,
+      'Partitions',
+      partition.replace('persist:', ''),
+      'Network',
+      'Cookies'
+    )
+    createChromiumCookieTestDatabase(sourceCookiesPath, [
+      { name: 'native', value: 'source-value' }
+    ]).close()
+    createChromiumCookieTestDatabase(targetCookiesPath, []).close()
+    return {
+      family: 'chrome',
+      label: 'Google Chrome',
+      cookiesPath: sourceCookiesPath,
+      keychainService: 'Chrome Safe Storage',
+      keychainAccount: 'Chrome',
+      profiles: [{ name: 'Default', directory: 'Default' }],
+      selectedProfile: 'Default'
+    }
+  }
+
   it('recovers after retirement proves the late command settled during its grace period', async () => {
     const firstStarted = electron.onFirstCommand()
     const first = importCookiesFromFile(writeCookieSource('first'), 'persist:timeout-oracle')
@@ -287,6 +319,34 @@ describe('cookie import debugger timeout', () => {
     expect(electron.windows).toHaveLength(2)
   })
 
+  it('stays poisoned when the timed-out command rejects during the retirement grace', async () => {
+    const firstStarted = electron.onFirstCommand()
+    const first = importCookiesFromFile(writeCookieSource('first'), 'persist:timeout-rejection')
+    await firstStarted
+    const second = importCookiesFromFile(writeCookieSource('second'), 'persist:timeout-rejection')
+
+    await vi.advanceTimersByTimeAsync(10_000)
+    electron.firstCommand().reject(new Error('debugger transport detached'))
+    const [firstResult, secondResult] = await Promise.all([first, second])
+
+    expect(firstResult).toEqual({
+      ok: false,
+      reason: expect.stringContaining('Could not safely replace cookies for the imported sites.')
+    })
+    expect(secondResult).toEqual({
+      ok: false,
+      reason:
+        'A cookie import timed out in Chromium, so this browser session is locked for safety. Restart Orca before importing cookies again.'
+    })
+    expect(electron.events).toEqual([
+      'A:Network.setCookie',
+      'A:late-rejection',
+      'A:detach',
+      'A:destroy'
+    ])
+    expect(electron.windows).toHaveLength(1)
+  })
+
   it('exposes the permanent-blockage signal when retirement is disabled', async () => {
     electron.setCommandTimeoutEnabled(false)
     const firstStarted = electron.onFirstCommand()
@@ -318,21 +378,7 @@ describe('cookie import debugger timeout', () => {
   })
 
   it('reports an ambiguously retired native Chromium write as a failure', async () => {
-    const sourceCookiesPath = join(fixtureDir, 'Chrome', 'Default', 'Network', 'Cookies')
-    const targetCookiesPath = join(fixtureDir, 'Partitions', 'native-timeout', 'Network', 'Cookies')
-    createChromiumCookieTestDatabase(sourceCookiesPath, [
-      { name: 'native', value: 'source-value' }
-    ]).close()
-    createChromiumCookieTestDatabase(targetCookiesPath, []).close()
-    const browser: DetectedBrowser = {
-      family: 'chrome',
-      label: 'Google Chrome',
-      cookiesPath: sourceCookiesPath,
-      keychainService: 'Chrome Safe Storage',
-      keychainAccount: 'Chrome',
-      profiles: [{ name: 'Default', directory: 'Default' }],
-      selectedProfile: 'Default'
-    }
+    const browser = createNativeBrowser('persist:native-timeout')
     const firstStarted = electron.onFirstCommand()
     const resultPromise = importCookiesFromBrowser(browser, 'persist:native-timeout')
     await firstStarted
@@ -345,5 +391,35 @@ describe('cookie import debugger timeout', () => {
         'A cookie import timed out in Chromium, so this browser session is locked for safety. Restart Orca before importing cookies again.'
     })
     expect(electron.events).toEqual(['A:Network.setCookie', 'A:detach', 'A:destroy'])
+  })
+
+  it('reports an ambiguously retired native Chromium snapshot as quarantined', async () => {
+    const partition = 'persist:native-snapshot-timeout'
+    const browser = createNativeBrowser(partition)
+    electron.fromPartition(partition).cookies.get.mockResolvedValue([
+      {
+        domain: '.example.com',
+        hostOnly: false,
+        path: '/',
+        name: 'existing',
+        value: 'old-value',
+        secure: false,
+        httpOnly: false,
+        session: true,
+        sameSite: 'unspecified'
+      }
+    ])
+    const firstStarted = electron.onFirstCommand()
+    const resultPromise = importCookiesFromBrowser(browser, partition)
+    await firstStarted
+
+    await vi.advanceTimersByTimeAsync(11_000)
+
+    await expect(resultPromise).resolves.toEqual({
+      ok: false,
+      reason:
+        'A cookie import timed out in Chromium, so this browser session is locked for safety. Restart Orca before importing cookies again.'
+    })
+    expect(electron.events).toEqual(['A:Network.getAllCookies', 'A:detach', 'A:destroy'])
   })
 })

--- a/src/main/browser/browser-cookie-import-clear.ts
+++ b/src/main/browser/browser-cookie-import-clear.ts
@@ -1,5 +1,6 @@
 import type { Cookie, Cookies } from 'electron'
 import { mapSettledWithConcurrency } from '../../shared/map-with-concurrency'
+import { assertCookieMutationsAvailable } from './browser-cookie-mutation-quarantine'
 import type { ImportedDomainScope } from './browser-cookie-import-policy'
 import {
   cookieRemovalUrl,
@@ -86,6 +87,7 @@ export function identitiesFromClearCookies(
  * try/finally take it directly; callers with a single callback use the wrapper below.
  */
 export async function acquireCookieMutationLock(owner: object): Promise<() => void> {
+  assertCookieMutationsAvailable(owner)
   const previous = mutationLocks.get(owner) ?? Promise.resolve()
   let release!: () => void
   const current = new Promise<void>((resolve) => {
@@ -96,6 +98,12 @@ export async function acquireCookieMutationLock(owner: object): Promise<() => vo
     previous.then(() => current)
   )
   await previous
+  try {
+    assertCookieMutationsAvailable(owner)
+  } catch (error) {
+    release()
+    throw error
+  }
   return release
 }
 

--- a/src/main/browser/browser-cookie-import.ts
+++ b/src/main/browser/browser-cookie-import.ts
@@ -2181,18 +2181,14 @@ export async function importCookiesFromBrowser(
       } catch {
         /* may already be closed */
       }
-      try {
-        stagingDb?.close()
-      } catch {
-        /* may already be closed */
-      }
+      closeStagingDb()
       // Why: drop the staging DB so a stale staged import isn't applied on the next cold start.
-      try {
-        unlinkSync(stagingCookiesPath)
-      } catch {
-        /* may not exist yet */
-      }
+      discardStagingFile()
       diag(`  SQLite import failed: ${String(err)}`)
+      if (areCookieMutationsQuarantined(targetSession)) {
+        browserSessionRegistry.clearPendingCookieImport(targetPartition)
+        return { ok: false, reason: COOKIE_MUTATION_QUARANTINED_REASON }
+      }
       return {
         ok: false,
         reason: reasonWithDiagLog(

--- a/src/main/browser/browser-cookie-import.ts
+++ b/src/main/browser/browser-cookie-import.ts
@@ -93,6 +93,7 @@ import {
 } from './browser-cookie-import-clear'
 import { openCookieClearStore } from './browser-cookie-clear-store'
 import {
+  areCookieMutationsQuarantined,
   COOKIE_MUTATION_QUARANTINED_REASON,
   isCookieMutationQuarantinedError
 } from './browser-cookie-mutation-quarantine'
@@ -2113,6 +2114,12 @@ export async function importCookiesFromBrowser(
         memoryFailed += phase.writeRejected
       } finally {
         cookieClearStore.dispose()
+      }
+
+      if (areCookieMutationsQuarantined(targetSession)) {
+        browserSessionRegistry.clearPendingCookieImport(targetPartition)
+        discardStagingFile()
+        return { ok: false, reason: COOKIE_MUTATION_QUARANTINED_REASON }
       }
 
       diag(

--- a/src/main/browser/browser-cookie-import.ts
+++ b/src/main/browser/browser-cookie-import.ts
@@ -93,6 +93,10 @@ import {
 } from './browser-cookie-import-clear'
 import { openCookieClearStore } from './browser-cookie-clear-store'
 import {
+  COOKIE_MUTATION_QUARANTINED_REASON,
+  isCookieMutationQuarantinedError
+} from './browser-cookie-mutation-quarantine'
+import {
   readChromiumRowPartition,
   readFirefoxRowPartition,
   readJsonCookiePartition,
@@ -677,9 +681,10 @@ async function importValidatedCookies(
     // remove cookies the newer import already wrote and reported as imported. Taken AFTER the
     // store is opened on purpose — openWriteStore only builds the adapter, it attaches no
     // debugger, so holding it while queued cannot deadlock against the holder.
-    const releaseMutationLock = await acquireCookieMutationLock(target.mutationLockOwner)
+    let releaseMutationLock: (() => void) | null = null
     let replaced: ReplacedImportedDomainCookies | null = null
     try {
+      releaseMutationLock = await acquireCookieMutationLock(target.mutationLockOwner)
       if (mode === 'replace-imported-domains') {
         try {
           // Why (STA-4300 I2 / §2b): the removal scope is the write set. Filtering per exact
@@ -737,11 +742,16 @@ async function importValidatedCookies(
           reason: reasonWithDiagLog('Could not safely replace cookies for the imported sites.')
         }
       }
+    } catch (error) {
+      if (isCookieMutationQuarantinedError(error)) {
+        return { ok: false, reason: COOKIE_MUTATION_QUARANTINED_REASON }
+      }
+      throw error
     } finally {
       try {
         cookieClearStore.dispose()
       } finally {
-        releaseMutationLock()
+        releaseMutationLock?.()
       }
     }
   }
@@ -1595,7 +1605,7 @@ export async function importCookiesFromBrowser(
   // clear/write lock was reached. Hold the per-partition lock from the first flush through staging,
   // live replacement, pending-image bookkeeping, and cleanup so an older image cannot race a newer
   // import on the same partition.
-  return withCookieMutationLock(targetSession, async () => {
+  return withCookieMutationLock<BrowserCookieImportResult>(targetSession, async () => {
     await targetSession.cookies.flushStore()
 
     // Why (STA-4300): ask the Session where its own storage lives instead of rebuilding the path from
@@ -2189,5 +2199,10 @@ export async function importCookiesFromBrowser(
         diag(`  Chromium snapshot cleanup failed: ${String(err)}`)
       }
     }
+  }).catch((error: unknown) => {
+    if (isCookieMutationQuarantinedError(error)) {
+      return { ok: false as const, reason: COOKIE_MUTATION_QUARANTINED_REASON }
+    }
+    throw error
   })
 }

--- a/src/main/browser/browser-cookie-mutation-quarantine.ts
+++ b/src/main/browser/browser-cookie-mutation-quarantine.ts
@@ -1,7 +1,7 @@
-const mutationQuarantines = new WeakMap<object, Promise<void>>()
+const mutationQuarantines = new WeakSet<object>()
 
 export const COOKIE_MUTATION_QUARANTINED_REASON =
-  'A previous cookie import is still finishing in Chromium. Wait a moment and try again; if it continues, restart Orca.'
+  'A cookie import timed out in Chromium, so this browser session is locked for safety. Restart Orca before importing cookies again.'
 
 export class CookieMutationQuarantinedError extends Error {
   constructor() {
@@ -10,23 +10,18 @@ export class CookieMutationQuarantinedError extends Error {
   }
 }
 
-export function quarantineCookieMutations(owner: object, until: Promise<void>): void {
-  const quarantine = until.then(
-    () => undefined,
-    () => undefined
-  )
-  mutationQuarantines.set(owner, quarantine)
-  void quarantine.then(() => {
-    if (mutationQuarantines.get(owner) === quarantine) {
-      mutationQuarantines.delete(owner)
-    }
-  })
+export function quarantineCookieMutations(owner: object): void {
+  mutationQuarantines.add(owner)
 }
 
 export function assertCookieMutationsAvailable(owner: object): void {
   if (mutationQuarantines.has(owner)) {
     throw new CookieMutationQuarantinedError()
   }
+}
+
+export function areCookieMutationsQuarantined(owner: object): boolean {
+  return mutationQuarantines.has(owner)
 }
 
 export function isCookieMutationQuarantinedError(

--- a/src/main/browser/browser-cookie-mutation-quarantine.ts
+++ b/src/main/browser/browser-cookie-mutation-quarantine.ts
@@ -1,0 +1,36 @@
+const mutationQuarantines = new WeakMap<object, Promise<void>>()
+
+export const COOKIE_MUTATION_QUARANTINED_REASON =
+  'A previous cookie import is still finishing in Chromium. Wait a moment and try again; if it continues, restart Orca.'
+
+export class CookieMutationQuarantinedError extends Error {
+  constructor() {
+    super(COOKIE_MUTATION_QUARANTINED_REASON)
+    this.name = 'CookieMutationQuarantinedError'
+  }
+}
+
+export function quarantineCookieMutations(owner: object, until: Promise<void>): void {
+  const quarantine = until.then(
+    () => undefined,
+    () => undefined
+  )
+  mutationQuarantines.set(owner, quarantine)
+  void quarantine.then(() => {
+    if (mutationQuarantines.get(owner) === quarantine) {
+      mutationQuarantines.delete(owner)
+    }
+  })
+}
+
+export function assertCookieMutationsAvailable(owner: object): void {
+  if (mutationQuarantines.has(owner)) {
+    throw new CookieMutationQuarantinedError()
+  }
+}
+
+export function isCookieMutationQuarantinedError(
+  error: unknown
+): error is CookieMutationQuarantinedError {
+  return error instanceof CookieMutationQuarantinedError
+}


### PR DESCRIPTION
## Summary

- give a CDP command a 10-second deadline and a bounded 1-second settlement grace
- treat only a fulfilled reply during that grace as proven completion; rejection or silence retires the exclusively owned debugger target
- permanently quarantine the stable Electron Session after ambiguous retirement, so later same-partition imports fail fast without mutating the jar
- require an Orca restart to recover an ambiguously retired partition; other partitions remain independent

## Why

The per-partition lock correctly serialized imports, but a `debugger.sendCommand` promise that never settled held it forever. A plain `Promise.race` would restore liveness by releasing the lock while the original CDP mutation could still finish late and overlap a newer import. This change keeps the stable Electron Session as the authoritative partition identity and fails closed whenever retirement cannot prove completion.

## Evidence

- Baseline `012e9f410c`: deterministic oracle red. After 60 seconds, both same-partition imports remained pending and the only command was the first wedged `Network.setCookie`.
- Candidate: first call returns after target retirement and bounded grace; queued same-partition imports fail fast; no second target or mutation starts even if the injected promise later settles ambiguously.
- Fix disabled: the same oracle returns to the baseline red signal.
- Late completion: quarantine remains fail-closed because target destruction or debugger-promise rejection is not proof that Chromium cannot still mutate the Session.
- Grace rejection: a command that rejects after its deadline still retires and poisons the Session; the queued import never starts.
- Native clear/snapshot: an ambiguously retired `Network.getAllCookies` returns the same restart-required classification and discards pending staging state.
- Partition isolation: another Electron Session continues importing while the first is quarantined.
- Real Electron: the production `openCookieClearStore` path executes an injected wedged `Network.setCookie`, destroys its hidden target, rejects both queued and post-completion mutations, and verifies no recovery cookie entered the real jar.

## Validation

- `pnpm exec vitest run src/main/browser` — 76 files, 803 tests passed
- `pnpm run typecheck`
- `pnpm run lint`
- rendered Orca dev smoke through Playwright CDP: intended worktree identity, normal visible welcome surface, zero renderer console errors

## Remaining gap

Chromium does not expose a safe way to force a real internal `Network.setCookie` implementation to hang. The Electron fixture injects the fault at the production debugger method boundary while retaining the real Session, target lifecycle, CDP command name, recovery write, and cookie jar.
