### PR TITLE
fix(sidebar): keep folder workspaces on execution host

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.test.ts
@@ -295,7 +295,10 @@ describe('planWorkspaceStatusAssignment (context-menu "Move to Status" routing)'
         statuses,
         false
       )
-    ).toEqual({ kind: 'local-only', localWriteIds: ['a'] })
+    ).toEqual({
+      kind: 'local-only',
+      localWrites: [{ worktreeId: 'a', executionHostId: undefined }]
+    })
   })
 
   it('writes nothing on the local-only path when every worktree already has the target status', () => {
@@ -306,6 +309,19 @@ describe('planWorkspaceStatusAssignment (context-menu "Move to Status" routing)'
         statuses,
         false
       )
-    ).toEqual({ kind: 'local-only', localWriteIds: [] })
+    ).toEqual({ kind: 'local-only', localWrites: [] })
+  })
+
+  it('keeps host identity on local-only writes with colliding ids', () => {
+    const local = { ...wt('same', 'todo'), hostId: 'local' as const }
+    const runtime = { ...wt('same', 'todo'), hostId: 'runtime:env-1' as const }
+
+    expect(planWorkspaceStatusAssignment([local, runtime], 'in-review', statuses, false)).toEqual({
+      kind: 'local-only',
+      localWrites: [
+        { worktreeId: 'same', executionHostId: 'local' },
+        { worktreeId: 'same', executionHostId: 'runtime:env-1' }
+      ]
+    })
   })
 })

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -554,12 +554,16 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
   )
 
   const handleCopyPath = useCallback(() => {
-    window.api.ui.writeClipboardText(worktree.path)
+    void window.api.ui.writeClipboardText(worktree.path)
   }, [worktree.path])
 
   const handleToggleRead = useCallback(() => {
-    updateWorktreeMeta(worktree.id, { isUnread: !worktree.isUnread })
-  }, [worktree.id, worktree.isUnread, updateWorktreeMeta])
+    void updateWorktreeMeta(
+      worktree.id,
+      { isUnread: !worktree.isUnread },
+      worktree.hostId ? { executionHostId: worktree.hostId } : undefined
+    )
+  }, [worktree.hostId, worktree.id, worktree.isUnread, updateWorktreeMeta])
 
   const handleTogglePin = useCallback(() => {
     setWorktreesPinnedAndReveal([worktree.id], !worktree.isPinned)
@@ -642,6 +646,7 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
       // Why: the same workspace ID can exist under two hosts. Naming the owner
       // keeps the dialog on this row instead of the ambiguous lookup.
       repoId: worktree.repoId,
+      executionHostId: worktree.hostId,
       currentDisplayName: worktree.displayName,
       currentIssue: worktree.linkedIssue,
       currentPR: worktree.linkedPR,
@@ -650,6 +655,7 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
     })
   }, [
     worktree.id,
+    worktree.hostId,
     worktree.repoId,
     worktree.displayName,
     worktree.linkedIssue,

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -293,7 +293,13 @@ function preserveDeleteSiblingPosition(scope: HTMLElement | null): () => void {
 
 export type WorkspaceStatusAssignmentPlan =
   | { readonly kind: 'board-sync'; readonly worktreeIds: readonly string[] }
-  | { readonly kind: 'local-only'; readonly localWriteIds: readonly string[] }
+  | {
+      readonly kind: 'local-only'
+      readonly localWrites: readonly {
+        worktreeId: string
+        executionHostId: Worktree['hostId']
+      }[]
+    }
 
 // Why: the context-menu "Move to Status" routes to the board's local-first +
 // Linear-sync path when the board wired a callback, else a local-only write of
@@ -308,10 +314,10 @@ export function planWorkspaceStatusAssignment(
   if (boardSyncEnabled) {
     return { kind: 'board-sync', worktreeIds: worktrees.map((item) => item.id) }
   }
-  const localWriteIds = worktrees
+  const localWrites = worktrees
     .filter((item) => getWorkspaceStatus(item, workspaceStatuses) !== status)
-    .map((item) => item.id)
-  return { kind: 'local-only', localWriteIds }
+    .map((item) => ({ worktreeId: item.id, executionHostId: item.hostId }))
+  return { kind: 'local-only', localWrites }
 }
 
 const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
@@ -566,8 +572,8 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
   }, [worktree.hostId, worktree.id, worktree.isUnread, updateWorktreeMeta])
 
   const handleTogglePin = useCallback(() => {
-    setWorktreesPinnedAndReveal([worktree.id], !worktree.isPinned)
-  }, [worktree.id, worktree.isPinned, setWorktreesPinnedAndReveal])
+    setWorktreesPinnedAndReveal([worktree.id], !worktree.isPinned, worktree.hostId)
+  }, [worktree.hostId, worktree.id, worktree.isPinned, setWorktreesPinnedAndReveal])
 
   const handleCreateGroupFromRepo = useCallback(() => {
     if (!repo) {
@@ -628,7 +634,13 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
       // Why: outside the workspace board (e.g. the sidebar list) status changes
       // are local-only; Linear sync is scoped to board moves like drag-and-drop.
       void Promise.all(
-        plan.localWriteIds.map((id) => updateWorktreeMeta(id, { workspaceStatus: status }))
+        plan.localWrites.map(({ worktreeId, executionHostId }) =>
+          updateWorktreeMeta(
+            worktreeId,
+            { workspaceStatus: status },
+            executionHostId ? { executionHostId } : undefined
+          )
+        )
       )
     },
     [

--- a/src/renderer/src/components/sidebar/WorktreeList.folder-workspace-rows.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeList.folder-workspace-rows.test.ts
@@ -165,7 +165,7 @@ describe('WorktreeList lineage child card renderer', () => {
     const markup = await renderWorktreeListMarkup()
 
     expect(markup).toContain(
-      'aria-activedescendant="worktree-list-option-folder%3Afolder-workspace-1"'
+      'aria-activedescendant="worktree-list-option-local%7Cfolder%3Afolder-workspace-1"'
     )
   })
 

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -232,6 +232,8 @@ const WorktreeList = React.memo(function WorktreeList({
     worktreeMap,
     worktrees: allWorktrees,
     folderWorkspaces,
+    projectGroups,
+    defaultHostId,
     hasFilters,
     clearFilters
   })

--- a/src/renderer/src/components/sidebar/WorktreeMetaDialog.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeMetaDialog.tsx
@@ -31,6 +31,7 @@ import {
   type IssueLinkProvider
 } from '../../../../shared/issue-link-input'
 import { WorktreeDisplayNameField } from './WorktreeDisplayNameField'
+import { normalizeExecutionHostId } from '../../../../shared/execution-host'
 
 function resizeCommentTextarea(textarea: HTMLTextAreaElement): void {
   textarea.style.height = 'auto'
@@ -69,6 +70,9 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
   // Why: the opening row names its repo bucket for workspace IDs the owner index
   // reads as ambiguous across hosts.
   const ownerRepoId = typeof modalData.repoId === 'string' ? modalData.repoId : null
+  const executionHostId = normalizeExecutionHostId(
+    typeof modalData.executionHostId === 'string' ? modalData.executionHostId : null
+  )
   const {
     worktree,
     linkedIssue,
@@ -77,7 +81,7 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
     currentProvider,
     isFolderWorkspace,
     liveLinks
-  } = useWorktreeMetaWorkspace({ worktreeId, ownerRepoId })
+  } = useWorktreeMetaWorkspace({ worktreeId, ownerRepoId, executionHostId })
   // Why: ChecksPanel seeds the PR it is looking at, which may not be linked yet.
   const currentPR =
     typeof modalData.currentPR === 'number'
@@ -224,7 +228,11 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
     try {
       const updates = buildWorktreeMetaUpdates(draft, snapshot, liveLinks)
 
-      const result = await updateWorktreeMeta(worktreeId, updates)
+      const result = await updateWorktreeMeta(
+        worktreeId,
+        updates,
+        executionHostId ? { executionHostId } : undefined
+      )
       // Why: a failed save refetches and reverts the optimistic write. Closing
       // here would report success for an edit that silently undid itself, and
       // would discard the name, comment and PR changes in the same payload.
@@ -249,6 +257,7 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
     }
   }, [
     worktreeId,
+    executionHostId,
     canSave,
     draft,
     snapshot,
@@ -265,7 +274,7 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
       if (isPlainEnter || isScreenSubmitShortcut(e)) {
         e.preventDefault()
         e.stopPropagation()
-        handleSave()
+        void handleSave()
       }
     },
     [handleSave]
@@ -275,7 +284,7 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === 'Enter') {
         e.preventDefault()
-        handleSave()
+        void handleSave()
       }
     },
     [handleSave]

--- a/src/renderer/src/components/sidebar/folder-workspace-host-ambiguity.test.ts
+++ b/src/renderer/src/components/sidebar/folder-workspace-host-ambiguity.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import type { FolderWorkspace } from '../../../../shared/folder-workspace-types'
+import type { ProjectGroup } from '../../../../shared/project-group-types'
+import {
+  findFolderWorkspaceProjectGroup,
+  getFolderWorkspaceHostIdFromGroups
+} from './folder-workspace-host-id'
+
+const OWNER_HOST_ID = 'runtime:owner' as const
+const FOCUSED_HOST_ID = 'runtime:focused' as const
+
+function folderWorkspace(overrides: Partial<FolderWorkspace> = {}): FolderWorkspace {
+  return {
+    id: 'folder-same-id',
+    projectGroupId: 'group-same-id',
+    name: 'Folder workspace',
+    folderPath: '/workspace/folder',
+    linkedTask: null,
+    comment: '',
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 1,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides
+  }
+}
+
+function projectGroup(overrides: Partial<ProjectGroup> = {}): ProjectGroup {
+  return {
+    id: 'group-same-id',
+    name: 'Folder group',
+    parentPath: '/workspace',
+    parentGroupId: null,
+    createdFrom: 'manual',
+    tabOrder: 0,
+    isCollapsed: false,
+    color: null,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides
+  }
+}
+
+describe('ambiguous folder workspace host resolution', () => {
+  it('does not invent a group owner when same-id groups disagree across hosts', () => {
+    const workspace = folderWorkspace({ connectionId: 'legacy-target' })
+    const groups = [
+      projectGroup({ executionHostId: 'local' }),
+      projectGroup({ executionHostId: OWNER_HOST_ID })
+    ]
+
+    expect(getFolderWorkspaceHostIdFromGroups(workspace, groups, FOCUSED_HOST_ID)).toBe(
+      'ssh:legacy-target'
+    )
+  })
+
+  it('does not treat one owned and one legacy same-id group as unanimous', () => {
+    const workspace = folderWorkspace()
+    const groups = [
+      projectGroup({ executionHostId: OWNER_HOST_ID }),
+      projectGroup({ executionHostId: undefined })
+    ]
+
+    expect(getFolderWorkspaceHostIdFromGroups(workspace, groups, 'local')).toBe('local')
+    expect(findFolderWorkspaceProjectGroup(workspace, groups, 'local')).toBe(groups[1])
+  })
+})

--- a/src/renderer/src/components/sidebar/folder-workspace-host-id.test.ts
+++ b/src/renderer/src/components/sidebar/folder-workspace-host-id.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
+import type { FolderWorkspace } from '../../../../shared/folder-workspace-types'
+import type { ProjectGroup } from '../../../../shared/project-group-types'
+import { getFolderWorkspaceHostId } from './folder-workspace-host-id'
+import { addHostSectionRows, type HostSectionOption } from './host-section-rows'
+import type { Row } from './worktree-list/grouping/row-types'
+
+const OWNER_HOST_ID: ExecutionHostId = 'runtime:owner'
+const FOCUSED_HOST_ID: ExecutionHostId = 'runtime:focused'
+
+function folderWorkspace(overrides: Partial<FolderWorkspace> = {}): FolderWorkspace {
+  return {
+    id: 'folder-same-id',
+    projectGroupId: 'group-same-id',
+    name: 'Folder workspace',
+    folderPath: '/workspace/folder',
+    linkedTask: null,
+    comment: '',
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 1,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides
+  }
+}
+
+function projectGroup(overrides: Partial<ProjectGroup> = {}): ProjectGroup {
+  return {
+    id: 'group-same-id',
+    name: 'Folder group',
+    parentPath: '/workspace',
+    parentGroupId: null,
+    createdFrom: 'manual',
+    tabOrder: 0,
+    isCollapsed: false,
+    color: null,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides
+  }
+}
+
+function folderRow(
+  workspace: FolderWorkspace,
+  group: ProjectGroup
+): Extract<Row, { type: 'folder-workspace' }> {
+  return {
+    type: 'folder-workspace',
+    key: `folder-workspace:${workspace.id}`,
+    folderWorkspace: workspace,
+    projectGroup: group,
+    depth: 0,
+    groupDepth: 0
+  }
+}
+
+function hostOption(id: ExecutionHostId): HostSectionOption {
+  return {
+    id,
+    kind: id === 'local' ? 'local' : id.startsWith('ssh:') ? 'ssh' : 'runtime',
+    label: id,
+    detail: 'Host',
+    health: id === 'local' ? 'local' : 'available'
+  }
+}
+
+function folderPlacements(rows: ReturnType<typeof addHostSectionRows>): string[] {
+  let hostId: ExecutionHostId | null = null
+  const placements: string[] = []
+  for (const row of rows) {
+    if (row.type === 'host-header') {
+      hostId = row.hostId
+    } else if (row.type === 'folder-workspace') {
+      placements.push(`${row.folderWorkspace.executionHostId ?? 'legacy'}@${hostId ?? 'none'}`)
+    }
+  }
+  return placements
+}
+
+describe('folder workspace host resolution', () => {
+  it.each([
+    {
+      name: 'workspace executionHostId',
+      workspace: { executionHostId: OWNER_HOST_ID },
+      group: {},
+      expected: OWNER_HOST_ID
+    },
+    {
+      name: 'legacy workspace connectionId',
+      workspace: { connectionId: 'legacy-target' },
+      group: {},
+      expected: 'ssh:legacy-target'
+    },
+    {
+      name: 'executionHostId with connectionId',
+      workspace: { executionHostId: OWNER_HOST_ID, connectionId: 'legacy-target' },
+      group: {},
+      expected: OWNER_HOST_ID
+    },
+    {
+      name: 'neither authoritative field',
+      workspace: {},
+      group: {},
+      expected: FOCUSED_HOST_ID
+    },
+    {
+      name: 'project group executionHostId',
+      workspace: {},
+      group: { executionHostId: OWNER_HOST_ID },
+      expected: OWNER_HOST_ID
+    },
+    {
+      name: 'legacy project group connectionId',
+      workspace: {},
+      group: { connectionId: 'legacy-target' },
+      expected: 'ssh:legacy-target'
+    },
+    {
+      name: 'new group owner with legacy workspace connectionId',
+      workspace: { connectionId: 'legacy-target' },
+      group: { executionHostId: OWNER_HOST_ID },
+      expected: OWNER_HOST_ID
+    }
+  ])('resolves $name', ({ workspace, group, expected }) => {
+    expect(
+      getFolderWorkspaceHostId(folderWorkspace(workspace), projectGroup(group), FOCUSED_HOST_ID)
+    ).toBe(expected)
+  })
+
+  it('does not change an authoritative owner when focus changes', () => {
+    const workspace = folderWorkspace({ executionHostId: OWNER_HOST_ID })
+    const group = projectGroup({ executionHostId: OWNER_HOST_ID })
+
+    expect(getFolderWorkspaceHostId(workspace, group, 'local')).toBe(OWNER_HOST_ID)
+    expect(getFolderWorkspaceHostId(workspace, group, FOCUSED_HOST_ID)).toBe(OWNER_HOST_ID)
+  })
+
+  it('keeps colliding workspace IDs partitioned through disconnect and reconnect', () => {
+    const localRow = folderRow(
+      folderWorkspace({ executionHostId: 'local', folderPath: '/local/folder' }),
+      projectGroup({ executionHostId: 'local', parentPath: '/local' })
+    )
+    const ownerRow = folderRow(
+      folderWorkspace({ executionHostId: OWNER_HOST_ID, folderPath: '/owner/folder' }),
+      projectGroup({ executionHostId: OWNER_HOST_ID, parentPath: '/owner' })
+    )
+    const common = {
+      rows: [localRow, ownerRow],
+      workspaceHostScope: 'all' as const,
+      defaultHostId: FOCUSED_HOST_ID
+    }
+
+    const connected = addHostSectionRows({
+      ...common,
+      hostOptions: [hostOption('local'), hostOption(OWNER_HOST_ID), hostOption(FOCUSED_HOST_ID)]
+    })
+    const disconnected = addHostSectionRows({
+      ...common,
+      hostOptions: [hostOption('local'), hostOption(FOCUSED_HOST_ID)]
+    })
+    const reconnected = addHostSectionRows({
+      ...common,
+      hostOptions: [hostOption('local'), hostOption(OWNER_HOST_ID), hostOption(FOCUSED_HOST_ID)]
+    })
+
+    const expected = ['local@local', `${OWNER_HOST_ID}@${OWNER_HOST_ID}`]
+    expect(folderPlacements(connected)).toEqual(expected)
+    expect(folderPlacements(disconnected)).toEqual(expected)
+    expect(folderPlacements(reconnected)).toEqual(expected)
+  })
+})

--- a/src/renderer/src/components/sidebar/folder-workspace-host-id.test.ts
+++ b/src/renderer/src/components/sidebar/folder-workspace-host-id.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest'
 import type { ExecutionHostId } from '../../../../shared/execution-host'
 import type { FolderWorkspace } from '../../../../shared/folder-workspace-types'
 import type { ProjectGroup } from '../../../../shared/project-group-types'
-import { getFolderWorkspaceHostId } from './folder-workspace-host-id'
+import {
+  getFolderWorkspaceHostId,
+  getFolderWorkspaceHostIdFromGroups
+} from './folder-workspace-host-id'
 import { addHostSectionRows, type HostSectionOption } from './host-section-rows'
 import type { Row } from './worktree-list/grouping/row-types'
 
@@ -171,5 +174,17 @@ describe('folder workspace host resolution', () => {
     expect(folderPlacements(connected)).toEqual(expected)
     expect(folderPlacements(disconnected)).toEqual(expected)
     expect(folderPlacements(reconnected)).toEqual(expected)
+  })
+
+  it('does not invent a group owner when same-id groups disagree across hosts', () => {
+    const workspace = folderWorkspace({ connectionId: 'legacy-target' })
+    const groups = [
+      projectGroup({ executionHostId: 'local' }),
+      projectGroup({ executionHostId: OWNER_HOST_ID })
+    ]
+
+    expect(getFolderWorkspaceHostIdFromGroups(workspace, groups, FOCUSED_HOST_ID)).toBe(
+      'ssh:legacy-target'
+    )
   })
 })

--- a/src/renderer/src/components/sidebar/folder-workspace-host-id.test.ts
+++ b/src/renderer/src/components/sidebar/folder-workspace-host-id.test.ts
@@ -102,6 +102,12 @@ describe('folder workspace host resolution', () => {
       expected: OWNER_HOST_ID
     },
     {
+      name: 'workspace executionHostId over conflicting group executionHostId',
+      workspace: { executionHostId: 'local' as const },
+      group: { executionHostId: OWNER_HOST_ID },
+      expected: 'local'
+    },
+    {
       name: 'neither authoritative field',
       workspace: {},
       group: {},

--- a/src/renderer/src/components/sidebar/folder-workspace-host-id.test.ts
+++ b/src/renderer/src/components/sidebar/folder-workspace-host-id.test.ts
@@ -2,10 +2,7 @@ import { describe, expect, it } from 'vitest'
 import type { ExecutionHostId } from '../../../../shared/execution-host'
 import type { FolderWorkspace } from '../../../../shared/folder-workspace-types'
 import type { ProjectGroup } from '../../../../shared/project-group-types'
-import {
-  getFolderWorkspaceHostId,
-  getFolderWorkspaceHostIdFromGroups
-} from './folder-workspace-host-id'
+import { getFolderWorkspaceHostId } from './folder-workspace-host-id'
 import { addHostSectionRows, type HostSectionOption } from './host-section-rows'
 import type { Row } from './worktree-list/grouping/row-types'
 
@@ -174,17 +171,5 @@ describe('folder workspace host resolution', () => {
     expect(folderPlacements(connected)).toEqual(expected)
     expect(folderPlacements(disconnected)).toEqual(expected)
     expect(folderPlacements(reconnected)).toEqual(expected)
-  })
-
-  it('does not invent a group owner when same-id groups disagree across hosts', () => {
-    const workspace = folderWorkspace({ connectionId: 'legacy-target' })
-    const groups = [
-      projectGroup({ executionHostId: 'local' }),
-      projectGroup({ executionHostId: OWNER_HOST_ID })
-    ]
-
-    expect(getFolderWorkspaceHostIdFromGroups(workspace, groups, FOCUSED_HOST_ID)).toBe(
-      'ssh:legacy-target'
-    )
   })
 })

--- a/src/renderer/src/components/sidebar/folder-workspace-host-id.ts
+++ b/src/renderer/src/components/sidebar/folder-workspace-host-id.ts
@@ -1,4 +1,5 @@
 export {
+  findFolderWorkspaceProjectGroup,
   getFolderWorkspaceHostId,
   getFolderWorkspaceHostIdFromGroups
 } from '../../../../shared/folder-workspace-host'

--- a/src/renderer/src/components/sidebar/folder-workspace-host-id.ts
+++ b/src/renderer/src/components/sidebar/folder-workspace-host-id.ts
@@ -1,23 +1,4 @@
-import {
-  normalizeExecutionHostId,
-  toSshExecutionHostId,
-  type ExecutionHostId
-} from '../../../../shared/execution-host'
-import type { FolderWorkspace } from '../../../../shared/folder-workspace-types'
-import type { ProjectGroup } from '../../../../shared/project-group-types'
-
-/** Keeps folder filtering, bucketing, counting, and reveal on one host precedence. */
-export function getFolderWorkspaceHostId(
-  folderWorkspace: Pick<FolderWorkspace, 'connectionId' | 'executionHostId'>,
-  projectGroup: Pick<ProjectGroup, 'connectionId' | 'executionHostId'> | null | undefined,
-  defaultHostId: ExecutionHostId
-): ExecutionHostId {
-  const executionHostId =
-    normalizeExecutionHostId(folderWorkspace.executionHostId) ??
-    normalizeExecutionHostId(projectGroup?.executionHostId)
-  if (executionHostId) {
-    return executionHostId
-  }
-  const connectionId = folderWorkspace.connectionId ?? projectGroup?.connectionId
-  return connectionId ? toSshExecutionHostId(connectionId) : defaultHostId
-}
+export {
+  getFolderWorkspaceHostId,
+  getFolderWorkspaceHostIdFromGroups
+} from '../../../../shared/folder-workspace-host'

--- a/src/renderer/src/components/sidebar/folder-workspace-host-id.ts
+++ b/src/renderer/src/components/sidebar/folder-workspace-host-id.ts
@@ -1,21 +1,23 @@
-import { toSshExecutionHostId, type ExecutionHostId } from '../../../../shared/execution-host'
+import {
+  normalizeExecutionHostId,
+  toSshExecutionHostId,
+  type ExecutionHostId
+} from '../../../../shared/execution-host'
 import type { FolderWorkspace } from '../../../../shared/folder-workspace-types'
 import type { ProjectGroup } from '../../../../shared/project-group-types'
 
-/**
- * Which host section a folder workspace's row belongs to.
- *
- * Single source of truth: header counting, host bucketing and reveal all resolve
- * the host through here. Two resolvers that drift is how folder workspaces went
- * missing from the sidebar in the first place (#15362). Deliberately distinct
- * from the host *filter* resolver, which also consults executionHostId — this
- * one must match where the row actually renders.
- */
+/** Keeps folder filtering, bucketing, counting, and reveal on one host precedence. */
 export function getFolderWorkspaceHostId(
-  folderWorkspace: Pick<FolderWorkspace, 'connectionId'>,
-  projectGroup: Pick<ProjectGroup, 'connectionId'>,
+  folderWorkspace: Pick<FolderWorkspace, 'connectionId' | 'executionHostId'>,
+  projectGroup: Pick<ProjectGroup, 'connectionId' | 'executionHostId'> | null | undefined,
   defaultHostId: ExecutionHostId
 ): ExecutionHostId {
-  const connectionId = folderWorkspace.connectionId ?? projectGroup.connectionId
+  const executionHostId =
+    normalizeExecutionHostId(folderWorkspace.executionHostId) ??
+    normalizeExecutionHostId(projectGroup?.executionHostId)
+  if (executionHostId) {
+    return executionHostId
+  }
+  const connectionId = folderWorkspace.connectionId ?? projectGroup?.connectionId
   return connectionId ? toSshExecutionHostId(connectionId) : defaultHostId
 }

--- a/src/renderer/src/components/sidebar/use-worktree-card-activation-actions.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-card-activation-actions.ts
@@ -107,9 +107,13 @@ export function useWorktreeCardActivationActions({
     // Inline rename has no surface for the failure; the store already logs and
     // refetches, which reverts the optimistic title in place.
     async (displayName: string): Promise<void> => {
-      await updateWorktreeMeta(worktree.id, { displayName })
+      await updateWorktreeMeta(
+        worktree.id,
+        { displayName },
+        worktree.hostId ? { executionHostId: worktree.hostId } : undefined
+      )
     },
-    [updateWorktreeMeta, worktree.id]
+    [updateWorktreeMeta, worktree.hostId, worktree.id]
   )
 
   const handleDoubleClick = useCallback(
@@ -123,6 +127,7 @@ export function useWorktreeCardActivationActions({
       openModal('edit-meta', {
         worktreeId: worktree.id,
         repoId: worktree.repoId,
+        executionHostId: worktree.hostId,
         currentDisplayName: worktree.displayName,
         currentIssue: worktree.linkedIssue,
         currentPR: worktree.linkedPR,
@@ -135,6 +140,7 @@ export function useWorktreeCardActivationActions({
       worktree.comment,
       worktree.displayName,
       worktree.id,
+      worktree.hostId,
       worktree.linkedIssue,
       worktree.linkedPR,
       worktree.repoId
@@ -145,9 +151,13 @@ export function useWorktreeCardActivationActions({
     (event: React.MouseEvent<HTMLButtonElement>) => {
       event.preventDefault()
       event.stopPropagation()
-      updateWorktreeMeta(worktree.id, { isUnread: !worktree.isUnread })
+      void updateWorktreeMeta(
+        worktree.id,
+        { isUnread: !worktree.isUnread },
+        worktree.hostId ? { executionHostId: worktree.hostId } : undefined
+      )
     },
-    [worktree.id, worktree.isUnread, updateWorktreeMeta]
+    [worktree.hostId, worktree.id, worktree.isUnread, updateWorktreeMeta]
   )
 
   return { handleClick, handleRenameTitle, handleDoubleClick, handleToggleUnreadQuick }

--- a/src/renderer/src/components/sidebar/use-worktree-card-foundation.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-card-foundation.ts
@@ -50,6 +50,7 @@ export function useWorktreeCardFoundation({
         // Why: the same workspace ID can exist under two hosts. Naming the owner
         // keeps the dialog on the clicked row instead of the ambiguous lookup.
         repoId: worktree.repoId,
+        executionHostId: worktree.hostId,
         currentDisplayName: worktree.displayName,
         currentIssue: worktree.linkedIssue,
         currentPR: worktree.linkedPR,
@@ -66,6 +67,7 @@ export function useWorktreeCardFoundation({
       openModal('edit-meta', {
         worktreeId: worktree.id,
         repoId: worktree.repoId,
+        executionHostId: worktree.hostId,
         currentDisplayName: worktree.displayName,
         currentIssue: worktree.linkedIssue,
         currentPR: worktree.linkedPR,

--- a/src/renderer/src/components/sidebar/use-worktree-card-workspace-actions.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-card-workspace-actions.ts
@@ -54,7 +54,10 @@ export function useWorktreeCardWorkspaceActions({
       event.stopPropagation()
       if (showDeleteQuickAction) {
         if (folderWorkspaceId) {
-          void deleteFolderWorkspace(folderWorkspaceId).then((deleted) => {
+          void deleteFolderWorkspace(
+            folderWorkspaceId,
+            worktree.hostId ? { executionHostId: worktree.hostId } : undefined
+          ).then((deleted) => {
             if (
               deleted &&
               useAppStore.getState().activeWorktreeId === folderWorkspaceKey(folderWorkspaceId)

--- a/src/renderer/src/components/sidebar/use-worktree-meta-workspace.test.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-meta-workspace.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import type { FolderWorkspace } from '../../../../shared/folder-workspace-types'
+import type { ProjectGroup } from '../../../../shared/project-group-types'
+import { findFolderWorkspaceForMeta } from './use-worktree-meta-workspace'
+
+function folder(
+  executionHostId: FolderWorkspace['executionHostId'],
+  name: string
+): FolderWorkspace {
+  return {
+    id: 'folder-shared',
+    projectGroupId: 'group-shared',
+    name,
+    folderPath: `/${name}`,
+    linkedTask: null,
+    comment: '',
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 1,
+    createdAt: 1,
+    updatedAt: 1,
+    executionHostId
+  }
+}
+
+function group(executionHostId: ProjectGroup['executionHostId']): ProjectGroup {
+  return {
+    id: 'group-shared',
+    name: 'Group',
+    parentPath: '/group',
+    parentGroupId: null,
+    createdFrom: 'manual',
+    tabOrder: 0,
+    isCollapsed: false,
+    color: null,
+    createdAt: 1,
+    updatedAt: 1,
+    executionHostId
+  }
+}
+
+describe('folder workspace metadata identity', () => {
+  it('selects the requested host when folder ids collide', () => {
+    const local = folder('local', 'Local')
+    const runtime = folder('runtime:env-1', 'Runtime')
+
+    expect(
+      findFolderWorkspaceForMeta(
+        [local, runtime],
+        [group('local'), group('runtime:env-1')],
+        runtime.id,
+        'runtime:env-1'
+      )
+    ).toBe(runtime)
+  })
+
+  it('uses group ownership for a legacy folder record', () => {
+    const runtime = { ...folder(undefined, 'Runtime'), connectionId: 'legacy-target' }
+
+    expect(
+      findFolderWorkspaceForMeta([runtime], [group('runtime:env-1')], runtime.id, 'runtime:env-1')
+    ).toBe(runtime)
+  })
+})

--- a/src/renderer/src/components/sidebar/use-worktree-meta-workspace.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-meta-workspace.ts
@@ -2,10 +2,31 @@ import { useMemo } from 'react'
 import { useAppStore } from '@/store'
 import { findIndexedWorktreeOwner } from '@/lib/worktree-runtime-owner-index'
 import type { Worktree } from '../../../../shared/worktree/types'
+import type { FolderWorkspace } from '../../../../shared/folder-workspace-types'
+import type { ProjectGroup } from '../../../../shared/project-group-types'
 import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
-import { folderWorkspaceToWorktree } from '../../../../shared/folder-workspace-worktree'
+import { folderWorkspaceToWorktreeForHost } from '../../../../shared/folder-workspace-worktree'
+import { getFolderWorkspaceHostIdFromGroups } from '../../../../shared/folder-workspace-host'
+import { LOCAL_EXECUTION_HOST_ID, type ExecutionHostId } from '../../../../shared/execution-host'
 import type { IssueLinkProvider } from '../../../../shared/issue-link-input'
 import type { WorktreeMetaLiveLinks } from './worktree-meta-updates'
+
+export function findFolderWorkspaceForMeta(
+  folderWorkspaces: readonly FolderWorkspace[],
+  projectGroups: readonly ProjectGroup[],
+  folderWorkspaceId: string,
+  executionHostId: ExecutionHostId | null
+): FolderWorkspace | null {
+  return (
+    folderWorkspaces.find(
+      (item) =>
+        item.id === folderWorkspaceId &&
+        (!executionHostId ||
+          getFolderWorkspaceHostIdFromGroups(item, projectGroups, executionHostId) ===
+            executionHostId)
+    ) ?? null
+  )
+}
 
 /** Resolves the workspace the meta dialog edits and the issue-link state it
  *  seeds from. Link state is read from the store rather than threaded through
@@ -15,6 +36,7 @@ export function useWorktreeMetaWorkspace(args: {
   worktreeId: string
   /** The repo bucket the opening row belongs to, when it knows. */
   ownerRepoId: string | null
+  executionHostId: ExecutionHostId | null
 }): {
   worktree: Worktree | undefined
   linkedIssue: number | null
@@ -26,7 +48,7 @@ export function useWorktreeMetaWorkspace(args: {
   /** Link state as it stands now, for save-time displacement decisions. */
   liveLinks: WorktreeMetaLiveLinks
 } {
-  const { worktreeId, ownerRepoId } = args
+  const { worktreeId, ownerRepoId, executionHostId } = args
   const workspaceScope = useMemo(() => parseWorkspaceKey(worktreeId), [worktreeId])
   const indexedWorktree = useAppStore((s) => {
     // Why: the same workspace ID can exist under two hosts, which the owner index
@@ -48,14 +70,31 @@ export function useWorktreeMetaWorkspace(args: {
   // the stored record — a stable reference — and the projection happens outside
   // it, because a selector that built the object would return a fresh identity
   // on every store write and re-render the dialog continuously.
+  const projectGroups = useAppStore((s) => s.projectGroups)
   const folderWorkspace = useAppStore((s) =>
     workspaceScope?.type === 'folder'
-      ? (s.folderWorkspaces.find((item) => item.id === workspaceScope.folderWorkspaceId) ?? null)
+      ? findFolderWorkspaceForMeta(
+          s.folderWorkspaces,
+          s.projectGroups,
+          workspaceScope.folderWorkspaceId,
+          executionHostId
+        )
       : null
   )
   const worktree = useMemo(
-    () => (folderWorkspace ? folderWorkspaceToWorktree(folderWorkspace) : indexedWorktree),
-    [folderWorkspace, indexedWorktree]
+    () =>
+      folderWorkspace
+        ? folderWorkspaceToWorktreeForHost(
+            folderWorkspace,
+            executionHostId ??
+              getFolderWorkspaceHostIdFromGroups(
+                folderWorkspace,
+                projectGroups,
+                LOCAL_EXECUTION_HOST_ID
+              )
+          )
+        : indexedWorktree,
+    [executionHostId, folderWorkspace, indexedWorktree, projectGroups]
   )
   const linkedIssue = worktree?.linkedIssue ?? null
   const linkedLinearIssue = worktree?.linkedLinearIssue ?? null

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.folder-workspace-lanes.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.folder-workspace-lanes.test.ts
@@ -96,6 +96,42 @@ describe('folder workspaces render under every Group by mode', () => {
     const rows = buildSidebarRows({ groupBy: 'repo' })
     expect(folderRows(rows).map((row) => row.key)).toEqual(['folder-workspace:fw-1'])
   })
+
+  it('pairs same-id folders and groups by execution host', () => {
+    const runtimeHostId: ExecutionHostId = 'runtime:env-1'
+    const groups = [
+      { ...GROUP, name: 'Local group', executionHostId: 'local' as const },
+      { ...GROUP, name: 'Runtime group', executionHostId: runtimeHostId }
+    ]
+    const workspaces = [
+      makeFolderWorkspace({ name: 'Local folder', executionHostId: 'local' }),
+      makeFolderWorkspace({ name: 'Runtime folder', executionHostId: runtimeHostId })
+    ]
+    const rows = buildSidebarRows({
+      groupBy: 'repo',
+      projectGroups: groups,
+      folderWorkspaces: workspaces,
+      worktrees: []
+    })
+
+    expect(
+      folderRows(rows).map((row) => [
+        row.folderWorkspace.executionHostId,
+        row.projectGroup.executionHostId
+      ])
+    ).toEqual([
+      ['local', 'local'],
+      [runtimeHostId, runtimeHostId]
+    ])
+    const headers = rows.filter(
+      (row): row is Extract<Row, { type: 'header' }> => row.type === 'header'
+    )
+    expect(headers.map((row) => [row.label, row.count])).toEqual([
+      ['Local group', 1],
+      ['Runtime group', 1]
+    ])
+    expect(new Set(headers.map((row) => row.key)).size).toBe(2)
+  })
 })
 
 describe('a folder workspace can be the only member of a lane', () => {

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.ts
@@ -76,7 +76,11 @@ export function buildRows(
   const projectIndex = buildProjectGroupingIndex(projectGrouping)
   // Membership is decided once, above the groupBy switch: every mode renders the
   // same set of folder workspaces and only chooses where they land (#15362).
-  const renderableFolderWorkspaces = getRenderableFolderWorkspaces(folderWorkspaces, projectGroups)
+  const renderableFolderWorkspaces = getRenderableFolderWorkspaces(
+    folderWorkspaces,
+    projectGroups,
+    defaultHostId
+  )
   const cyclicLineageIds = nestLineage
     ? getCyclicProjectedWorktreeLineageIds(lineageById, worktreeMap)
     : new Set<string>()
@@ -241,7 +245,8 @@ export function buildRows(
     projectGroups,
     folderWorkspaces: renderableFolderWorkspaces,
     projectOrderBy,
-    repoOrder
+    repoOrder,
+    defaultHostId
   })
 
   return result

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/folder-workspace-lanes.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/folder-workspace-lanes.ts
@@ -7,6 +7,8 @@ import {
 } from '../../../../../../shared/workspace-statuses'
 import { ALL_GROUP_KEY, getPRLaneKey } from './group-keys'
 import type { WorktreeGroupBy } from './row-types'
+import type { ExecutionHostId } from '../../../../../../shared/execution-host'
+import { findFolderWorkspaceProjectGroup } from '../../../../../../shared/folder-workspace-host'
 
 /** A folder workspace paired with the project group that owns it. The pair is
  *  carried through grouping because FolderWorkspaceRow needs a non-optional
@@ -25,12 +27,16 @@ export type RenderableFolderWorkspace = {
  */
 export function getRenderableFolderWorkspaces(
   folderWorkspaces: readonly FolderWorkspace[],
-  projectGroups: readonly ProjectGroup[]
+  projectGroups: readonly ProjectGroup[],
+  defaultHostId: ExecutionHostId
 ): RenderableFolderWorkspace[] {
-  const projectGroupsById = new Map(projectGroups.map((group) => [group.id, group]))
   const renderable: RenderableFolderWorkspace[] = []
   for (const folderWorkspace of folderWorkspaces) {
-    const projectGroup = projectGroupsById.get(folderWorkspace.projectGroupId)
+    const projectGroup = findFolderWorkspaceProjectGroup(
+      folderWorkspace,
+      projectGroups,
+      defaultHostId
+    )
     // A group filtered out for host visibility legitimately hides its workspaces.
     if (!projectGroup?.parentPath) {
       continue

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/project-group-sections.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/project-group-sections.ts
@@ -15,6 +15,15 @@ import {
   withRepoSectionDisplayLabels
 } from './section-order'
 import { buildFolderWorkspaceRow } from './row-builders'
+import {
+  getRepoExecutionHostId,
+  type ExecutionHostId
+} from '../../../../../../shared/execution-host'
+import { getProjectGroupHostId } from '../../../../../../shared/folder-workspace-host'
+
+function getProjectGroupIdentity(group: ProjectGroup, defaultHostId: ExecutionHostId): string {
+  return JSON.stringify([getProjectGroupHostId(group, defaultHostId), group.id])
+}
 
 export function appendProjectGroupSections(
   ctx: SectionAppendContext,
@@ -24,18 +33,49 @@ export function appendProjectGroupSections(
     folderWorkspaces: readonly RenderableFolderWorkspace[]
     projectOrderBy: ProjectOrderBy
     repoOrder: Map<string, number> | undefined
+    defaultHostId: ExecutionHostId
   }
 ): void {
-  const { orderedGroups, projectGroups, folderWorkspaces, projectOrderBy, repoOrder } = args
+  const {
+    orderedGroups,
+    projectGroups,
+    folderWorkspaces,
+    projectOrderBy,
+    repoOrder,
+    defaultHostId
+  } = args
   const { result, collapsedGroups } = ctx
 
-  const groupByProjectGroupId = new Map<string | null, OrderedGroupEntry[]>()
-  for (const entry of orderedGroups) {
+  const projectGroupsById = new Map<string, ProjectGroup[]>()
+  const projectGroupsByIdentity = new Map<string, ProjectGroup>()
+  for (const group of projectGroups) {
+    const sameIdGroups = projectGroupsById.get(group.id) ?? []
+    sameIdGroups.push(group)
+    projectGroupsById.set(group.id, sameIdGroups)
+    projectGroupsByIdentity.set(getProjectGroupIdentity(group, defaultHostId), group)
+  }
+  const getRepoProjectGroupIdentity = (entry: OrderedGroupEntry): string | null => {
     const repo = entry[1].repo
-    const projectGroupId = repo?.projectGroupId ?? null
-    const list = groupByProjectGroupId.get(projectGroupId) ?? []
+    if (!repo?.projectGroupId) {
+      return null
+    }
+    const matchingGroups = projectGroupsById.get(repo.projectGroupId) ?? []
+    if (matchingGroups.length === 1) {
+      return getProjectGroupIdentity(matchingGroups[0]!, defaultHostId)
+    }
+    const repoHostId =
+      repo.connectionId || repo.executionHostId ? getRepoExecutionHostId(repo) : defaultHostId
+    const hostMatches = matchingGroups.filter(
+      (group) => getProjectGroupHostId(group, defaultHostId) === repoHostId
+    )
+    return hostMatches.length === 1 ? getProjectGroupIdentity(hostMatches[0]!, defaultHostId) : null
+  }
+  const groupByProjectGroupIdentity = new Map<string | null, OrderedGroupEntry[]>()
+  for (const entry of orderedGroups) {
+    const projectGroupIdentity = getRepoProjectGroupIdentity(entry)
+    const list = groupByProjectGroupIdentity.get(projectGroupIdentity) ?? []
     list.push(entry)
-    groupByProjectGroupId.set(projectGroupId, list)
+    groupByProjectGroupIdentity.set(projectGroupIdentity, list)
   }
 
   const sortRepoEntriesWithinGroup = (entries: OrderedGroupEntry[]): OrderedGroupEntry[] => {
@@ -54,61 +94,79 @@ export function appendProjectGroupSections(
     })
   }
 
-  const projectGroupsById = new Map(projectGroups.map((group) => [group.id, group]))
   // Membership already decided by getRenderableFolderWorkspaces in buildRows, so
   // repo grouping no longer owns the filter — it only groups and orders (#15362).
-  const folderWorkspacesByProjectGroupId = new Map<string, RenderableFolderWorkspace[]>()
+  const folderWorkspacesByProjectGroupIdentity = new Map<string, RenderableFolderWorkspace[]>()
   for (const pair of folderWorkspaces) {
-    const groupId = pair.folderWorkspace.projectGroupId
-    const list = folderWorkspacesByProjectGroupId.get(groupId) ?? []
+    const groupIdentity = getProjectGroupIdentity(pair.projectGroup, defaultHostId)
+    const list = folderWorkspacesByProjectGroupIdentity.get(groupIdentity) ?? []
     list.push(pair)
-    folderWorkspacesByProjectGroupId.set(groupId, list)
+    folderWorkspacesByProjectGroupIdentity.set(groupIdentity, list)
   }
-  for (const list of folderWorkspacesByProjectGroupId.values()) {
+  for (const list of folderWorkspacesByProjectGroupIdentity.values()) {
     list.sort((left, right) =>
       compareFolderWorkspacesForDisplay(left.folderWorkspace, right.folderWorkspace)
     )
   }
-  const childGroupsByParentId = new Map<string | null, ProjectGroup[]>()
+  const childGroupsByParentIdentity = new Map<string | null, ProjectGroup[]>()
   for (const group of projectGroups) {
-    const parentId =
-      group.parentGroupId && projectGroupsById.has(group.parentGroupId) ? group.parentGroupId : null
-    const children = childGroupsByParentId.get(parentId) ?? []
+    const parentCandidates = group.parentGroupId
+      ? (projectGroupsById.get(group.parentGroupId) ?? [])
+      : []
+    const groupHostId = getProjectGroupHostId(group, defaultHostId)
+    const hostParents = parentCandidates.filter(
+      (candidate) => getProjectGroupHostId(candidate, defaultHostId) === groupHostId
+    )
+    const parent =
+      hostParents.length === 1
+        ? hostParents[0]
+        : parentCandidates.length === 1
+          ? parentCandidates[0]
+          : undefined
+    const parentIdentity = parent ? getProjectGroupIdentity(parent, defaultHostId) : null
+    const children = childGroupsByParentIdentity.get(parentIdentity) ?? []
     children.push(group)
-    childGroupsByParentId.set(parentId, children)
+    childGroupsByParentIdentity.set(parentIdentity, children)
   }
-  for (const groups of childGroupsByParentId.values()) {
+  for (const groups of childGroupsByParentIdentity.values()) {
     groups.sort(
       (left, right) => left.tabOrder - right.tabOrder || left.name.localeCompare(right.name)
     )
   }
 
-  const getProjectGroupSubtreeCount = (groupId: string): number => {
-    const directCount = groupByProjectGroupId.get(groupId)?.length ?? 0
-    const folderWorkspaceCount = folderWorkspacesByProjectGroupId.get(groupId)?.length ?? 0
-    const children = childGroupsByParentId.get(groupId) ?? []
+  const getProjectGroupSubtreeCount = (groupIdentity: string): number => {
+    const directCount = groupByProjectGroupIdentity.get(groupIdentity)?.length ?? 0
+    const folderWorkspaceCount =
+      folderWorkspacesByProjectGroupIdentity.get(groupIdentity)?.length ?? 0
+    const children = childGroupsByParentIdentity.get(groupIdentity) ?? []
     return children.reduce(
-      (count, child) => count + getProjectGroupSubtreeCount(child.id),
+      (count, child) =>
+        count + getProjectGroupSubtreeCount(getProjectGroupIdentity(child, defaultHostId)),
       directCount + folderWorkspaceCount
     )
   }
 
   const appendProjectGroup = (projectGroup: ProjectGroup, depth: number): void => {
-    const repoEntries = sortRepoEntriesWithinGroup(groupByProjectGroupId.get(projectGroup.id) ?? [])
-    const childGroups = childGroupsByParentId.get(projectGroup.id) ?? []
-    const key = getProjectGroupHeaderKey(projectGroup.id)
+    const groupIdentity = getProjectGroupIdentity(projectGroup, defaultHostId)
+    const repoEntries = sortRepoEntriesWithinGroup(
+      groupByProjectGroupIdentity.get(groupIdentity) ?? []
+    )
+    const childGroups = childGroupsByParentIdentity.get(groupIdentity) ?? []
+    const key = getProjectGroupHeaderKey(
+      (projectGroupsById.get(projectGroup.id)?.length ?? 0) > 1 ? groupIdentity : projectGroup.id
+    )
     result.push({
       type: 'header',
       key,
       label: projectGroup.name,
-      count: getProjectGroupSubtreeCount(projectGroup.id),
+      count: getProjectGroupSubtreeCount(groupIdentity),
       tone: PROJECT_GROUP_META.tone,
       icon: PROJECT_GROUP_META.icon,
       projectGroup,
       projectGroupDepth: depth
     })
     if (!collapsedGroups.has(key)) {
-      for (const pair of folderWorkspacesByProjectGroupId.get(projectGroup.id) ?? []) {
+      for (const pair of folderWorkspacesByProjectGroupIdentity.get(groupIdentity) ?? []) {
         result.push(buildFolderWorkspaceRow(pair, depth + 1))
       }
       appendOrderedGroups(ctx, withRepoSectionDisplayLabels(repoEntries), depth + 1)
@@ -116,16 +174,16 @@ export function appendProjectGroupSections(
         appendProjectGroup(childGroup, depth + 1)
       }
     }
-    groupByProjectGroupId.delete(projectGroup.id)
+    groupByProjectGroupIdentity.delete(groupIdentity)
   }
 
-  for (const projectGroup of childGroupsByParentId.get(null) ?? []) {
+  for (const projectGroup of childGroupsByParentIdentity.get(null) ?? []) {
     appendProjectGroup(projectGroup, 0)
   }
 
-  const remainingRepoEntries = [...(groupByProjectGroupId.get(null) ?? [])]
-  for (const [projectGroupId, entries] of groupByProjectGroupId) {
-    if (projectGroupId === null || projectGroupsById.has(projectGroupId)) {
+  const remainingRepoEntries = [...(groupByProjectGroupIdentity.get(null) ?? [])]
+  for (const [projectGroupIdentity, entries] of groupByProjectGroupIdentity) {
+    if (projectGroupIdentity === null || projectGroupsByIdentity.has(projectGroupIdentity)) {
       continue
     }
     // Why: startup can have repos from hosts whose project-group metadata was

--- a/src/renderer/src/components/sidebar/worktree-list/listing/host-filtering.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/host-filtering.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import type { FolderWorkspace } from '../../../../../../shared/folder-workspace-types'
 import type { ProjectGroup } from '../../../../../../shared/project-group-types'
 import {
+  filterFolderWorkspacesForVisibleHosts,
   getFolderPathStatusRouteOptionsForRows,
   getFolderWorkspaceExecutionHostIdForRows,
   getProjectGroupExecutionHostIdForRows,
@@ -143,5 +144,28 @@ describe('WorktreeList host filtering ownership', () => {
         folderWorkspace: folderWorkspace({ executionHostId: 'runtime:env-1' })
       })
     ).toEqual({ runtimeEnvironmentId: 'env-1' })
+  })
+
+  it('filters mixed same-id groups independently of catalog order', () => {
+    const workspace = folderWorkspace()
+    const legacyGroup = group()
+    const runtimeGroup = group({ executionHostId: 'runtime:env-1' })
+
+    for (const groups of [
+      [legacyGroup, runtimeGroup],
+      [runtimeGroup, legacyGroup]
+    ]) {
+      expect(
+        filterFolderWorkspacesForVisibleHosts([workspace], groups, new Set(['local']), 'local')
+      ).toEqual([workspace])
+      expect(
+        filterFolderWorkspacesForVisibleHosts(
+          [workspace],
+          groups,
+          new Set(['runtime:env-1']),
+          'local'
+        )
+      ).toEqual([])
+    }
   })
 })

--- a/src/renderer/src/components/sidebar/worktree-list/listing/host-filtering.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/host-filtering.test.ts
@@ -87,8 +87,7 @@ describe('WorktreeList host filtering ownership', () => {
     expect(
       getFolderPathStatusRouteOptionsForRows({
         request: { scope: 'project-group', projectGroupId: runtimeGroup.id },
-        projectGroupsById: new Map([[runtimeGroup.id, runtimeGroup]]),
-        folderWorkspacesById: new Map()
+        projectGroup: runtimeGroup
       })
     ).toEqual({ runtimeEnvironmentId: 'env-1' })
   })
@@ -99,8 +98,8 @@ describe('WorktreeList host filtering ownership', () => {
     expect(
       getFolderPathStatusRouteOptionsForRows({
         request: { scope: 'folder-workspace', folderWorkspaceId: workspace.id },
-        projectGroupsById: new Map([[runtimeGroup.id, runtimeGroup]]),
-        folderWorkspacesById: new Map([[workspace.id, workspace]])
+        projectGroup: runtimeGroup,
+        folderWorkspace: workspace
       })
     ).toEqual({ runtimeEnvironmentId: 'env-1' })
   })
@@ -110,8 +109,7 @@ describe('WorktreeList host filtering ownership', () => {
     expect(
       getFolderPathStatusRouteOptionsForRows({
         request: { scope: 'project-group', projectGroupId: localGroup.id },
-        projectGroupsById: new Map([[localGroup.id, localGroup]]),
-        folderWorkspacesById: new Map()
+        projectGroup: localGroup
       })
     ).toEqual({ runtimeEnvironmentId: null })
   })
@@ -121,9 +119,29 @@ describe('WorktreeList host filtering ownership', () => {
     expect(
       getFolderPathStatusRouteOptionsForRows({
         request: { scope: 'project-group', projectGroupId: sshGroup.id },
-        projectGroupsById: new Map([[sshGroup.id, sshGroup]]),
-        folderWorkspacesById: new Map()
+        projectGroup: sshGroup
       })
     ).toEqual({ runtimeEnvironmentId: null })
+  })
+
+  it('routes identical folder ids from each concrete host row', () => {
+    const request = { scope: 'folder-workspace' as const, folderWorkspaceId: 'folder-1' }
+    const localGroup = group({ executionHostId: 'local' })
+    const runtimeGroup = group({ executionHostId: 'runtime:env-1' })
+
+    expect(
+      getFolderPathStatusRouteOptionsForRows({
+        request,
+        projectGroup: localGroup,
+        folderWorkspace: folderWorkspace({ executionHostId: 'local' })
+      })
+    ).toEqual({ runtimeEnvironmentId: null })
+    expect(
+      getFolderPathStatusRouteOptionsForRows({
+        request,
+        projectGroup: runtimeGroup,
+        folderWorkspace: folderWorkspace({ executionHostId: 'runtime:env-1' })
+      })
+    ).toEqual({ runtimeEnvironmentId: 'env-1' })
   })
 })

--- a/src/renderer/src/components/sidebar/worktree-list/listing/host-filtering.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/host-filtering.ts
@@ -10,6 +10,7 @@ import type { FolderWorkspacePathStatusRequest } from '../../../../../../shared/
 import type { FolderWorkspace } from '../../../../../../shared/folder-workspace-types'
 import type { ProjectGroup } from '../../../../../../shared/project-group-types'
 import { getFolderWorkspaceHostId } from '../../folder-workspace-host-id'
+import { getFolderWorkspaceHostIdFromGroups } from '../../../../../../shared/folder-workspace-host'
 
 /** null means "no host filter" — every host is visible. */
 export function getVisibleSidebarHostIdSet(
@@ -46,14 +47,9 @@ export function filterFolderWorkspacesForVisibleHosts(
   if (!visibleHostIdSet) {
     return folderWorkspaces
   }
-  const projectGroupById = new Map(projectGroups.map((group) => [group.id, group]))
   return folderWorkspaces.filter((folderWorkspace) =>
     visibleHostIdSet.has(
-      getFolderWorkspaceExecutionHostIdForRows({
-        folderWorkspace,
-        projectGroup: projectGroupById.get(folderWorkspace.projectGroupId),
-        defaultHostId
-      })
+      getFolderWorkspaceHostIdFromGroups(folderWorkspace, projectGroups, defaultHostId)
     )
   )
 }

--- a/src/renderer/src/components/sidebar/worktree-list/listing/host-filtering.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/host-filtering.ts
@@ -88,6 +88,12 @@ export function getRuntimeEnvironmentIdForFolderPathStatusHost(
   return parsed?.kind === 'runtime' ? parsed.environmentId : null
 }
 
+export function getFolderPathStatusRouteOptionsForHost(hostId: ExecutionHostId): {
+  runtimeEnvironmentId: string | null
+} {
+  return { runtimeEnvironmentId: getRuntimeEnvironmentIdForFolderPathStatusHost(hostId) }
+}
+
 function getProjectGroupExecutionHostIdForFolderPathStatus(
   group: Pick<ProjectGroup, 'connectionId' | 'executionHostId'>
 ): ExecutionHostId {
@@ -100,32 +106,25 @@ function getProjectGroupExecutionHostIdForFolderPathStatus(
 
 export function getFolderPathStatusRouteOptionsForRows({
   request,
-  projectGroupsById,
-  folderWorkspacesById
+  projectGroup,
+  folderWorkspace
 }: {
   request: FolderWorkspacePathStatusRequest
-  projectGroupsById: ReadonlyMap<string, ProjectGroup>
-  folderWorkspacesById: ReadonlyMap<string, FolderWorkspace>
+  projectGroup: ProjectGroup | null | undefined
+  folderWorkspace?: FolderWorkspace
 }): { runtimeEnvironmentId: string | null } | undefined {
-  const folderWorkspace =
-    request.scope === 'folder-workspace'
-      ? folderWorkspacesById.get(request.folderWorkspaceId)
-      : undefined
-  const group =
-    request.scope === 'project-group'
-      ? projectGroupsById.get(request.projectGroupId)
-      : projectGroupsById.get(folderWorkspace?.projectGroupId ?? '')
-  if (!group) {
+  if (request.scope === 'project-group' && !projectGroup) {
     return undefined
   }
   const hostId =
     request.scope === 'project-group'
-      ? getProjectGroupExecutionHostIdForFolderPathStatus(group)
+      ? getProjectGroupExecutionHostIdForFolderPathStatus(projectGroup!)
       : getFolderWorkspaceExecutionHostIdForRows({
           folderWorkspace: folderWorkspace ?? { connectionId: null, executionHostId: null },
-          projectGroup: group,
-          defaultHostId: getProjectGroupExecutionHostIdForFolderPathStatus(group)
+          projectGroup: projectGroup ?? undefined,
+          defaultHostId: projectGroup
+            ? getProjectGroupExecutionHostIdForFolderPathStatus(projectGroup)
+            : 'local'
         })
-  const runtimeEnvironmentId = getRuntimeEnvironmentIdForFolderPathStatusHost(hostId)
-  return { runtimeEnvironmentId }
+  return getFolderPathStatusRouteOptionsForHost(hostId)
 }

--- a/src/renderer/src/components/sidebar/worktree-list/listing/host-filtering.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/host-filtering.ts
@@ -9,6 +9,7 @@ import {
 import type { FolderWorkspacePathStatusRequest } from '../../../../../../shared/folder-workspace-path-status'
 import type { FolderWorkspace } from '../../../../../../shared/folder-workspace-types'
 import type { ProjectGroup } from '../../../../../../shared/project-group-types'
+import { getFolderWorkspaceHostId } from '../../folder-workspace-host-id'
 
 /** null means "no host filter" — every host is visible. */
 export function getVisibleSidebarHostIdSet(
@@ -77,23 +78,7 @@ export function getFolderWorkspaceExecutionHostIdForRows({
   projectGroup: Pick<ProjectGroup, 'connectionId' | 'executionHostId'> | undefined
   defaultHostId: ExecutionHostId
 }): ExecutionHostId {
-  const explicitFolderHostId = normalizeExecutionHostId(folderWorkspace.executionHostId)
-  if (explicitFolderHostId) {
-    return explicitFolderHostId
-  }
-  if (projectGroup) {
-    const explicitProjectGroupHostId = normalizeExecutionHostId(projectGroup.executionHostId)
-    if (explicitProjectGroupHostId) {
-      return explicitProjectGroupHostId
-    }
-    const projectGroupHostId = getProjectGroupExecutionHostIdForRows(projectGroup, defaultHostId)
-    if (projectGroupHostId !== defaultHostId || !folderWorkspace.connectionId) {
-      return projectGroupHostId
-    }
-  }
-  return folderWorkspace.connectionId
-    ? toSshExecutionHostId(folderWorkspace.connectionId)
-    : defaultHostId
+  return getFolderWorkspaceHostId(folderWorkspace, projectGroup, defaultHostId)
 }
 
 export function getRuntimeEnvironmentIdForFolderPathStatusHost(

--- a/src/renderer/src/components/sidebar/worktree-list/listing/render-row.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/render-row.ts
@@ -1,4 +1,7 @@
 import type { HostSectionRow } from '../../host-section-rows'
+import { getFolderWorkspaceHostId } from '../../folder-workspace-host-id'
+import { composeWorktreeHostIdentity } from '../../../../../../shared/worktree/host-qualified-identity'
+import { folderWorkspaceKey } from '../../../../../../shared/workspace-scope'
 
 type WorktreeItemRow = Extract<HostSectionRow, { type: 'item' }>
 export type RenderRow =
@@ -25,7 +28,11 @@ export function getRenderRowKey(row: RenderRow): string {
     return `pending:${row.creationId}`
   }
   if (row.type === 'folder-workspace') {
-    return `folder-workspace:${row.folderWorkspace.id}`
+    const hostId = getFolderWorkspaceHostId(row.folderWorkspace, row.projectGroup, 'local')
+    return `folder-workspace:${composeWorktreeHostIdentity(
+      hostId,
+      folderWorkspaceKey(row.folderWorkspace.id)
+    )}`
   }
   return `wt:${row.rowKey}`
 }

--- a/src/renderer/src/components/sidebar/worktree-list/listing/render-row.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/render-row.ts
@@ -2,13 +2,18 @@ import type { HostSectionRow } from '../../host-section-rows'
 import { getFolderWorkspaceHostId } from '../../folder-workspace-host-id'
 import { composeWorktreeHostIdentity } from '../../../../../../shared/worktree/host-qualified-identity'
 import { folderWorkspaceKey } from '../../../../../../shared/workspace-scope'
+import { LOCAL_EXECUTION_HOST_ID } from '../../../../../../shared/execution-host'
+import type { ExecutionHostId } from '../../../../../../shared/execution-host'
 
 type WorktreeItemRow = Extract<HostSectionRow, { type: 'item' }>
 export type RenderRow =
   | HostSectionRow
   | { type: 'lineage-group'; key: string; rows: WorktreeItemRow[] }
 
-export function getRenderRowKey(row: RenderRow): string {
+export function getRenderRowKey(
+  row: RenderRow,
+  defaultHostId: ExecutionHostId = LOCAL_EXECUTION_HOST_ID
+): string {
   if (row.type === 'host-header') {
     return `host:${row.hostId}`
   }
@@ -28,7 +33,7 @@ export function getRenderRowKey(row: RenderRow): string {
     return `pending:${row.creationId}`
   }
   if (row.type === 'folder-workspace') {
-    const hostId = getFolderWorkspaceHostId(row.folderWorkspace, row.projectGroup, 'local')
+    const hostId = getFolderWorkspaceHostId(row.folderWorkspace, row.projectGroup, defaultHostId)
     return `folder-workspace:${composeWorktreeHostIdentity(
       hostId,
       folderWorkspaceKey(row.folderWorkspace.id)

--- a/src/renderer/src/components/sidebar/worktree-list/listing/render-row.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/render-row.ts
@@ -10,6 +10,16 @@ export type RenderRow =
   | HostSectionRow
   | { type: 'lineage-group'; key: string; rows: WorktreeItemRow[] }
 
+export function getFolderWorkspaceSidebarRowKey(
+  row: Extract<HostSectionRow, { type: 'folder-workspace' }>,
+  defaultHostId: ExecutionHostId
+): string {
+  return composeWorktreeHostIdentity(
+    getFolderWorkspaceHostId(row.folderWorkspace, row.projectGroup, defaultHostId),
+    folderWorkspaceKey(row.folderWorkspace.id)
+  )
+}
+
 export function getRenderRowKey(
   row: RenderRow,
   defaultHostId: ExecutionHostId = LOCAL_EXECUTION_HOST_ID
@@ -33,11 +43,7 @@ export function getRenderRowKey(
     return `pending:${row.creationId}`
   }
   if (row.type === 'folder-workspace') {
-    const hostId = getFolderWorkspaceHostId(row.folderWorkspace, row.projectGroup, defaultHostId)
-    return `folder-workspace:${composeWorktreeHostIdentity(
-      hostId,
-      folderWorkspaceKey(row.folderWorkspace.id)
-    )}`
+    return `folder-workspace:${getFolderWorkspaceSidebarRowKey(row, defaultHostId)}`
   }
   return `wt:${row.rowKey}`
 }

--- a/src/renderer/src/components/sidebar/worktree-list/listing/use-folder-path-statuses.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/use-folder-path-statuses.ts
@@ -6,7 +6,11 @@ import type { FolderWorkspace } from '../../../../../../shared/folder-workspace-
 import type { ProjectGroup } from '../../../../../../shared/project-group-types'
 import type { Repo } from '../../../../../../shared/repo-types'
 import type { AppState } from '@/store/types'
-import { getFolderPathStatusRouteOptionsForRows } from './host-filtering'
+import {
+  getFolderPathStatusRouteOptionsForHost,
+  getFolderPathStatusRouteOptionsForRows
+} from './host-filtering'
+import { getFolderWorkspaceHostIdFromGroups } from '../../../../../../shared/folder-workspace-host'
 
 type FolderPathStatusRequest = Parameters<AppState['fetchFolderWorkspacePathStatus']>[0]
 
@@ -56,22 +60,17 @@ export function useFolderWorkspacePathStatusRows(args: {
   const folderPathStatusCacheExpiryTick = useFolderWorkspacePathStatusCacheExpiryTick(
     folderWorkspacePathStatuses
   )
-  const projectGroupByIdForFolderPathStatus = useMemo(
-    () => new Map(projectGroups.map((group) => [group.id, group])),
-    [projectGroups]
-  )
-  const folderWorkspaceByIdForFolderPathStatus = useMemo(
-    () => new Map(folderWorkspaces.map((workspace) => [workspace.id, workspace])),
-    [folderWorkspaces]
-  )
   const getFolderPathStatusRouteOptions = useCallback(
-    (request: FolderPathStatusRequest) =>
+    (
+      request: FolderPathStatusRequest,
+      scope: { projectGroup?: ProjectGroup; folderWorkspace?: FolderWorkspace } = {}
+    ) =>
       getFolderPathStatusRouteOptionsForRows({
         request,
-        projectGroupsById: projectGroupByIdForFolderPathStatus,
-        folderWorkspacesById: folderWorkspaceByIdForFolderPathStatus
+        projectGroup: scope.projectGroup,
+        folderWorkspace: scope.folderWorkspace
       }),
-    [folderWorkspaceByIdForFolderPathStatus, projectGroupByIdForFolderPathStatus]
+    []
   )
   useEffect(() => {
     const requests = new Map<
@@ -84,13 +83,15 @@ export function useFolderWorkspacePathStatusRows(args: {
     for (const group of projectGroups) {
       if (group.parentPath) {
         const request = { scope: 'project-group' as const, projectGroupId: group.id }
-        const options = getFolderPathStatusRouteOptions(request)
+        const options = getFolderPathStatusRouteOptions(request, { projectGroup: group })
         requests.set(getFolderWorkspacePathStatusCacheKey(request, options), { request, options })
       }
     }
     for (const workspace of folderWorkspaces) {
       const request = { scope: 'folder-workspace' as const, folderWorkspaceId: workspace.id }
-      const options = getFolderPathStatusRouteOptions(request)
+      const options = getFolderPathStatusRouteOptionsForHost(
+        getFolderWorkspaceHostIdFromGroups(workspace, projectGroups, 'local')
+      )
       requests.set(getFolderWorkspacePathStatusCacheKey(request, options), { request, options })
     }
     for (const { request, options } of requests.values()) {
@@ -107,8 +108,11 @@ export function useFolderWorkspacePathStatusRows(args: {
     projectGroups
   ])
   const getCachedFolderWorkspacePathStatus = useCallback(
-    (request: FolderPathStatusRequest) => {
-      const options = getFolderPathStatusRouteOptions(request)
+    (
+      request: FolderPathStatusRequest,
+      scope?: { projectGroup?: ProjectGroup; folderWorkspace?: FolderWorkspace }
+    ) => {
+      const options = getFolderPathStatusRouteOptions(request, scope)
       const cacheKey = getFolderWorkspacePathStatusCacheKey(request, options)
       // Why: don't let an expired negative status keep folder workspaces disabled while a refresh is in flight.
       void folderWorkspacePathStatuses[cacheKey]

--- a/src/renderer/src/components/sidebar/worktree-list/listing/use-section-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/use-section-rows.ts
@@ -9,9 +9,9 @@ import type { Repo } from '../../../../../../shared/repo-types'
 import type { WorkspaceStatusDefinition, Worktree } from '../../../../../../shared/worktree/types'
 import type { WorktreeLineage } from '../../../../../../shared/worktree/lineage-types'
 import type { ExecutionHostId } from '../../../../../../shared/execution-host'
-import { folderWorkspaceKey } from '../../../../../../shared/workspace-scope'
 import { getHostDisplayLabelOverrides } from '../../../../../../shared/host-setting-overrides'
 import { buildRows } from '../grouping/build-rows'
+import { getFolderWorkspaceSidebarRowKey } from './render-row'
 import type { ProjectGroupingModel } from '../grouping/project-grouping'
 import type { PinnedWorktreeDisplayPolicy, Row, WorktreeGroupBy } from '../grouping/row-types'
 import { getLogicalRepoOrderRankById } from '../../project-header-drop'
@@ -45,7 +45,10 @@ type SectionRowsArgs = {
   workspaceHostScope: AppState['workspaceHostScope']
 }
 
-function collectRenderedSidebarRowKeys(sectionRows: ReturnType<typeof addHostSectionRows>) {
+function collectRenderedSidebarRowKeys(
+  sectionRows: ReturnType<typeof addHostSectionRows>,
+  defaultHostId: ExecutionHostId
+) {
   const keys = new Set<string>()
   for (const row of sectionRows) {
     if (row.type === 'header') {
@@ -53,7 +56,7 @@ function collectRenderedSidebarRowKeys(sectionRows: ReturnType<typeof addHostSec
     } else if (row.type === 'item') {
       keys.add(row.rowKey)
     } else if (row.type === 'folder-workspace') {
-      keys.add(folderWorkspaceKey(row.folderWorkspace.id))
+      keys.add(getFolderWorkspaceSidebarRowKey(row, defaultHostId))
     } else if (row.type === 'pending-creation') {
       keys.add(`pending:${row.creationId}`)
     } else if (row.type === 'imported-worktrees-card') {
@@ -240,8 +243,8 @@ export function useSidebarSectionRows(args: SectionRowsArgs) {
     ]
   )
   const renderedSidebarRowKeys = useMemo(
-    () => collectRenderedSidebarRowKeys(sectionRows),
-    [sectionRows]
+    () => collectRenderedSidebarRowKeys(sectionRows, defaultHostId),
+    [defaultHostId, sectionRows]
   )
 
   return {

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/active-descendant-option.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/active-descendant-option.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import type { Worktree } from '../../../../../../shared/worktree/types'
 import type { WorktreeItemRow } from '../listing/renderable-rows'
+import type { FolderWorkspace } from '../../../../../../shared/folder-workspace-types'
+import type { ProjectGroup } from '../../../../../../shared/project-group-types'
+import { folderWorkspaceKey } from '../../../../../../shared/workspace-scope'
+import { getFolderWorkspaceSidebarRowKey, type RenderRow } from '../listing/render-row'
 import { getWorktreeOptionId } from '../rows/option-dom'
 import { getActiveDescendantOptionId } from './active-descendant-option'
 
@@ -33,5 +37,38 @@ describe('getActiveDescendantOptionId', () => {
         virtualItems: [{ index: 0 }, { index: 1 }]
       })
     ).toBe(getWorktreeOptionId(ssh.rowKey))
+  })
+
+  it('announces the active host folder row when workspace ids collide', () => {
+    const workspace = {
+      id: 'folder-shared',
+      projectGroupId: 'group-shared'
+    } as FolderWorkspace
+    const group = { id: 'group-shared' } as ProjectGroup
+    const rows = ['local', 'runtime:env-1'].map((executionHostId) => ({
+      type: 'folder-workspace',
+      key: `folder-workspace:${executionHostId}`,
+      folderWorkspace: { ...workspace, executionHostId },
+      projectGroup: { ...group, executionHostId },
+      depth: 0,
+      groupDepth: 0
+    })) as RenderRow[]
+
+    expect(
+      getActiveDescendantOptionId({
+        activeWorktreeId: folderWorkspaceKey(workspace.id),
+        activeWorkspaceExecutionHostId: 'runtime:env-1',
+        pinnedDisplayPolicy: 'single-location',
+        renderRows: rows,
+        virtualItems: [{ index: 0 }, { index: 1 }]
+      })
+    ).toBe(
+      getWorktreeOptionId(
+        getFolderWorkspaceSidebarRowKey(
+          rows[1] as Extract<RenderRow, { type: 'folder-workspace' }>,
+          'runtime:env-1'
+        )
+      )
+    )
   })
 })

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/active-descendant-option.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/active-descendant-option.ts
@@ -1,13 +1,14 @@
-import { folderWorkspaceKey } from '../../../../../../shared/workspace-scope'
 import type { RenderRow } from '../listing/render-row'
 import {
   getWorktreeExecutionHostId,
+  LOCAL_EXECUTION_HOST_ID,
   type ExecutionHostId
 } from '../../../../../../shared/execution-host'
 import type { PinnedWorktreeDisplayPolicy } from '../grouping/row-types'
 import { isPinnedWorktreeRow } from '../listing/renderable-rows'
 import { getRenderRowWorktreeItem, renderRowContainsWorktree } from './render-row-lookup'
 import { getWorktreeOptionId } from '../rows/option-dom'
+import { getFolderWorkspaceSidebarRowKey } from '../listing/render-row'
 
 export function getRenderRowOptionId(
   row: RenderRow | undefined,
@@ -33,7 +34,9 @@ export function getRenderRowOptionId(
     return getWorktreeOptionId(row.rowKey)
   }
   if (row.type === 'folder-workspace') {
-    return getWorktreeOptionId(folderWorkspaceKey(row.folderWorkspace.id))
+    return getWorktreeOptionId(
+      getFolderWorkspaceSidebarRowKey(row, executionHostId ?? LOCAL_EXECUTION_HOST_ID)
+    )
   }
   return undefined
 }

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/folder-reveal.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/folder-reveal.test.ts
@@ -85,6 +85,24 @@ describe('worktree list folder reveal', () => {
     })
   })
 
+  it('resolves identical folder ids to the requested execution host', () => {
+    const local = makeFolderWorkspace({ executionHostId: 'local', name: 'Local folder' })
+    const runtime = makeFolderWorkspace({
+      executionHostId: 'runtime:env-1',
+      name: 'Runtime folder'
+    })
+
+    expect(
+      getKnownSidebarWorktreeById(
+        folderWorkspaceKey(runtime.id),
+        new Map(),
+        [local, runtime],
+        [],
+        'runtime:env-1'
+      )
+    ).toMatchObject({ hostId: 'runtime:env-1', displayName: 'Runtime folder' })
+  })
+
   it('keeps pending reveals alive for folder workspaces missing from raw git worktrees', () => {
     const folderWorkspace = makeFolderWorkspace()
     const gitWorktree = makeWorktree('git-worktree-1')

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/folder-reveal.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/folder-reveal.test.ts
@@ -103,6 +103,26 @@ describe('worktree list folder reveal', () => {
     ).toMatchObject({ hostId: 'runtime:env-1', displayName: 'Runtime folder' })
   })
 
+  it('uses the owning group for legacy workspace host resolution', () => {
+    const folderWorkspace = makeFolderWorkspace({ connectionId: 'legacy-target' })
+    const runtimeGroup = makeProjectGroup({
+      id: folderWorkspace.projectGroupId,
+      executionHostId: 'runtime:env-1'
+    })
+
+    expect(
+      getKnownSidebarWorktreeById(
+        folderWorkspaceKey(folderWorkspace.id),
+        new Map(),
+        [folderWorkspace],
+        [],
+        'runtime:env-1',
+        [runtimeGroup],
+        'local'
+      )
+    ).toMatchObject({ hostId: 'runtime:env-1' })
+  })
+
   it('keeps pending reveals alive for folder workspaces missing from raw git worktrees', () => {
     const folderWorkspace = makeFolderWorkspace()
     const gitWorktree = makeWorktree('git-worktree-1')
@@ -135,6 +155,33 @@ describe('worktree list folder reveal', () => {
         [child, root]
       )
     ).toEqual([getProjectGroupHeaderKey(root.id), getProjectGroupHeaderKey(child.id)])
+  })
+
+  it('expands the requested host when folder and group ids collide', () => {
+    const runtimeHostId = 'runtime:env-1' as const
+    const groups = [
+      makeProjectGroup({ id: 'group-child', name: 'Local', executionHostId: 'local' }),
+      makeProjectGroup({
+        id: 'group-child',
+        name: 'Runtime',
+        executionHostId: runtimeHostId
+      })
+    ]
+    const workspaces = [
+      makeFolderWorkspace({ name: 'Local', executionHostId: 'local' }),
+      makeFolderWorkspace({ name: 'Runtime', executionHostId: runtimeHostId })
+    ]
+
+    expect(
+      getFolderWorkspaceRevealGroupKeys(folderWorkspaceKey(workspaces[0]!.id), workspaces, groups, {
+        groupBy: 'repo',
+        defaultHostId: 'local',
+        executionHostId: runtimeHostId
+      })
+    ).toEqual([
+      getProjectGroupHeaderKey(JSON.stringify([runtimeHostId, 'group-child'])),
+      `host:${runtimeHostId}`
+    ])
   })
 })
 

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/folder-reveal.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/folder-reveal.ts
@@ -1,34 +1,47 @@
 import type { FolderWorkspace } from '../../../../../../shared/folder-workspace-types'
 import type { ProjectGroup } from '../../../../../../shared/project-group-types'
 import type { WorkspaceStatusDefinition, Worktree } from '../../../../../../shared/worktree/types'
-import {
-  folderWorkspaceToWorktree,
-  folderWorkspaceToWorktreeForHost
-} from '../../../../../../shared/folder-workspace-worktree'
+import { folderWorkspaceToWorktreeForHost } from '../../../../../../shared/folder-workspace-worktree'
 import { parseWorkspaceKey } from '../../../../../../shared/workspace-scope'
 import { getProjectGroupHeaderKey } from '../grouping/group-keys'
-import type { ExecutionHostId } from '../../../../../../shared/execution-host'
+import {
+  LOCAL_EXECUTION_HOST_ID,
+  type ExecutionHostId
+} from '../../../../../../shared/execution-host'
 import { getFolderWorkspaceLaneKey } from '../grouping/folder-workspace-lanes'
 import type { WorktreeGroupBy } from '../grouping/row-types'
-import { getFolderWorkspaceHostId } from '../../folder-workspace-host-id'
+import {
+  findFolderWorkspaceProjectGroup,
+  getFolderWorkspaceHostId,
+  getProjectGroupHostId
+} from '../../../../../../shared/folder-workspace-host'
 
 function findFolderWorkspaceByKey(
   worktreeId: string,
   folderWorkspaces: readonly FolderWorkspace[],
+  projectGroups: readonly ProjectGroup[],
+  defaultHostId: ExecutionHostId,
   executionHostId?: ExecutionHostId | null
-): FolderWorkspace | null {
+): { folderWorkspace: FolderWorkspace; projectGroup: ProjectGroup | null } | null {
   const scope = parseWorkspaceKey(worktreeId)
   if (scope?.type !== 'folder') {
     return null
   }
-  return (
-    folderWorkspaces.find(
-      (workspace) =>
-        workspace.id === scope.folderWorkspaceId &&
-        (!executionHostId ||
-          getFolderWorkspaceHostId(workspace, undefined, executionHostId) === executionHostId)
-    ) ?? null
-  )
+  for (const folderWorkspace of folderWorkspaces) {
+    if (folderWorkspace.id !== scope.folderWorkspaceId) {
+      continue
+    }
+    const projectGroup = findFolderWorkspaceProjectGroup(
+      folderWorkspace,
+      projectGroups,
+      defaultHostId
+    )
+    const hostId = getFolderWorkspaceHostId(folderWorkspace, projectGroup, defaultHostId)
+    if (!executionHostId || hostId === executionHostId) {
+      return { folderWorkspace, projectGroup }
+    }
+  }
+  return null
 }
 
 export function getKnownSidebarWorktreeById(
@@ -36,7 +49,9 @@ export function getKnownSidebarWorktreeById(
   worktreeMap: ReadonlyMap<string, Worktree>,
   folderWorkspaces: readonly FolderWorkspace[],
   worktrees?: readonly Worktree[],
-  executionHostId?: ExecutionHostId | null
+  executionHostId?: ExecutionHostId | null,
+  projectGroups: readonly ProjectGroup[] = [],
+  defaultHostId: ExecutionHostId = executionHostId ?? LOCAL_EXECUTION_HOST_ID
 ): Worktree | null {
   const worktree = executionHostId
     ? (worktrees?.find(
@@ -46,20 +61,31 @@ export function getKnownSidebarWorktreeById(
   if (worktree) {
     return worktree
   }
-  const folderWorkspace = findFolderWorkspaceByKey(worktreeId, folderWorkspaces, executionHostId)
-  if (!folderWorkspace) {
+  const folder = findFolderWorkspaceByKey(
+    worktreeId,
+    folderWorkspaces,
+    projectGroups,
+    defaultHostId,
+    executionHostId
+  )
+  if (!folder) {
     return null
   }
-  return executionHostId
-    ? folderWorkspaceToWorktreeForHost(folderWorkspace, executionHostId)
-    : folderWorkspaceToWorktree(folderWorkspace)
+  const hostId = getFolderWorkspaceHostId(
+    folder.folderWorkspace,
+    folder.projectGroup,
+    defaultHostId
+  )
+  return folderWorkspaceToWorktreeForHost(folder.folderWorkspace, hostId)
 }
 
 export function sidebarWorkspaceStillExists(
   worktreeId: string,
   worktrees: readonly Worktree[],
   folderWorkspaces: readonly FolderWorkspace[],
-  executionHostId?: ExecutionHostId
+  executionHostId?: ExecutionHostId,
+  projectGroups: readonly ProjectGroup[] = [],
+  defaultHostId: ExecutionHostId = executionHostId ?? LOCAL_EXECUTION_HOST_ID
 ): boolean {
   if (
     worktrees.some(
@@ -70,7 +96,15 @@ export function sidebarWorkspaceStillExists(
   ) {
     return true
   }
-  return findFolderWorkspaceByKey(worktreeId, folderWorkspaces, executionHostId) !== null
+  return (
+    findFolderWorkspaceByKey(
+      worktreeId,
+      folderWorkspaces,
+      projectGroups,
+      defaultHostId,
+      executionHostId
+    ) !== null
+  )
 }
 
 export function getFolderWorkspaceRevealGroupKeys(
@@ -81,31 +115,54 @@ export function getFolderWorkspaceRevealGroupKeys(
     groupBy?: WorktreeGroupBy
     workspaceStatuses?: readonly WorkspaceStatusDefinition[]
     defaultHostId?: ExecutionHostId
+    executionHostId?: ExecutionHostId
   }
 ): string[] {
-  const folderWorkspace = findFolderWorkspaceByKey(worktreeId, folderWorkspaces)
-  if (!folderWorkspace) {
+  const defaultHostId = options?.defaultHostId ?? LOCAL_EXECUTION_HOST_ID
+  const folder = findFolderWorkspaceByKey(
+    worktreeId,
+    folderWorkspaces,
+    projectGroups,
+    defaultHostId,
+    options?.executionHostId
+  )
+  if (!folder?.projectGroup) {
     return []
   }
-
-  const groupsById = new Map(projectGroups.map((group) => [group.id, group]))
+  const { folderWorkspace, projectGroup: owningGroup } = folder
+  const targetHostId = getFolderWorkspaceHostId(folderWorkspace, owningGroup, defaultHostId)
+  const groupsById = new Map<string, ProjectGroup[]>()
+  for (const group of projectGroups) {
+    const matching = groupsById.get(group.id) ?? []
+    matching.push(group)
+    groupsById.set(group.id, matching)
+  }
+  const getGroupForHost = (groupId: string): ProjectGroup | null => {
+    const matching = groupsById.get(groupId) ?? []
+    const hostMatches = matching.filter(
+      (group) => getProjectGroupHostId(group, defaultHostId) === targetHostId
+    )
+    return hostMatches.length === 1 ? hostMatches[0]! : matching.length === 1 ? matching[0]! : null
+  }
+  const getHeaderKey = (group: ProjectGroup): string =>
+    getProjectGroupHeaderKey(
+      (groupsById.get(group.id)?.length ?? 0) > 1
+        ? JSON.stringify([getProjectGroupHostId(group, defaultHostId), group.id])
+        : group.id
+    )
   const keys: string[] = []
   const seen = new Set<string>()
-  let groupId: string | null = folderWorkspace.projectGroupId
-  while (groupId && !seen.has(groupId)) {
-    seen.add(groupId)
-    const group = groupsById.get(groupId)
-    if (!group) {
-      break
-    }
-    keys.unshift(getProjectGroupHeaderKey(group.id))
-    groupId = group.parentGroupId
+  let group: ProjectGroup | null = owningGroup
+  while (group && !seen.has(getHeaderKey(group))) {
+    const key = getHeaderKey(group)
+    seen.add(key)
+    keys.unshift(key)
+    group = group.parentGroupId ? getGroupForHost(group.parentGroupId) : null
   }
 
   // Under non-repo grouping the project-group headers above do not exist, so the
   // lane and host headers are the ones actually hiding the row (#15362). Lane
   // keys come from the same function grouping uses, so the two cannot disagree.
-  const owningGroup = groupsById.get(folderWorkspace.projectGroupId)
   if (options?.groupBy && options.groupBy !== 'repo' && owningGroup) {
     keys.push(
       getFolderWorkspaceLaneKey(
@@ -115,10 +172,8 @@ export function getFolderWorkspaceRevealGroupKeys(
       )
     )
   }
-  if (owningGroup && options?.defaultHostId) {
-    keys.push(
-      `host:${getFolderWorkspaceHostId(folderWorkspace, owningGroup, options.defaultHostId)}`
-    )
+  if (options?.defaultHostId) {
+    keys.push(`host:${targetHostId}`)
   }
   return keys
 }

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/folder-reveal.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/folder-reveal.ts
@@ -1,7 +1,10 @@
 import type { FolderWorkspace } from '../../../../../../shared/folder-workspace-types'
 import type { ProjectGroup } from '../../../../../../shared/project-group-types'
 import type { WorkspaceStatusDefinition, Worktree } from '../../../../../../shared/worktree/types'
-import { folderWorkspaceToWorktree } from '../../../../../../shared/folder-workspace-worktree'
+import {
+  folderWorkspaceToWorktree,
+  folderWorkspaceToWorktreeForHost
+} from '../../../../../../shared/folder-workspace-worktree'
 import { parseWorkspaceKey } from '../../../../../../shared/workspace-scope'
 import { getProjectGroupHeaderKey } from '../grouping/group-keys'
 import type { ExecutionHostId } from '../../../../../../shared/execution-host'
@@ -11,13 +14,21 @@ import { getFolderWorkspaceHostId } from '../../folder-workspace-host-id'
 
 function findFolderWorkspaceByKey(
   worktreeId: string,
-  folderWorkspaces: readonly FolderWorkspace[]
+  folderWorkspaces: readonly FolderWorkspace[],
+  executionHostId?: ExecutionHostId | null
 ): FolderWorkspace | null {
   const scope = parseWorkspaceKey(worktreeId)
   if (scope?.type !== 'folder') {
     return null
   }
-  return folderWorkspaces.find((workspace) => workspace.id === scope.folderWorkspaceId) ?? null
+  return (
+    folderWorkspaces.find(
+      (workspace) =>
+        workspace.id === scope.folderWorkspaceId &&
+        (!executionHostId ||
+          getFolderWorkspaceHostId(workspace, undefined, executionHostId) === executionHostId)
+    ) ?? null
+  )
 }
 
 export function getKnownSidebarWorktreeById(
@@ -35,8 +46,13 @@ export function getKnownSidebarWorktreeById(
   if (worktree) {
     return worktree
   }
-  const folderWorkspace = findFolderWorkspaceByKey(worktreeId, folderWorkspaces)
-  return folderWorkspace ? folderWorkspaceToWorktree(folderWorkspace) : null
+  const folderWorkspace = findFolderWorkspaceByKey(worktreeId, folderWorkspaces, executionHostId)
+  if (!folderWorkspace) {
+    return null
+  }
+  return executionHostId
+    ? folderWorkspaceToWorktreeForHost(folderWorkspace, executionHostId)
+    : folderWorkspaceToWorktree(folderWorkspace)
 }
 
 export function sidebarWorkspaceStillExists(
@@ -54,7 +70,7 @@ export function sidebarWorkspaceStillExists(
   ) {
     return true
   }
-  return findFolderWorkspaceByKey(worktreeId, folderWorkspaces) !== null
+  return findFolderWorkspaceByKey(worktreeId, folderWorkspaces, executionHostId) !== null
 }
 
 export function getFolderWorkspaceRevealGroupKeys(

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/pending-reveal-inputs.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/pending-reveal-inputs.ts
@@ -64,7 +64,8 @@ export function expandGroupsForWorktreeReveal(
     {
       groupBy: args.groupBy,
       workspaceStatuses: args.workspaceStatuses,
-      defaultHostId: args.defaultHostId
+      defaultHostId: args.defaultHostId,
+      executionHostId
     }
   )
   if (folderGroupKeys.length > 0) {

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/render-row-lookup.folder-workspace.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/render-row-lookup.folder-workspace.test.ts
@@ -3,7 +3,10 @@ import type { FolderWorkspace } from '../../../../../../shared/folder-workspace-
 import type { ProjectGroup } from '../../../../../../shared/project-group-types'
 import { folderWorkspaceKey } from '../../../../../../shared/workspace-scope'
 import type { RenderRow } from '../listing/render-row'
-import { findPreferredRenderRowIndexForWorktreeIdentity } from './render-row-lookup'
+import {
+  findPreferredRenderRowIndexForWorktreeIdentity,
+  rowKeyMatchesRenderRow
+} from './render-row-lookup'
 
 const FOLDER_WORKSPACE: FolderWorkspace = {
   id: 'fw-1',
@@ -97,5 +100,24 @@ describe('host-qualified reveal lookup finds folder workspaces', () => {
         'single-location'
       )
     ).toBe(1)
+  })
+
+  it('matches an unowned folder row using the focused host default', () => {
+    const row = {
+      type: 'folder-workspace',
+      key: `folder-workspace:${FOLDER_WORKSPACE.id}`,
+      folderWorkspace: FOLDER_WORKSPACE,
+      projectGroup: PROJECT_GROUP,
+      depth: 0,
+      groupDepth: 0
+    } as RenderRow
+
+    expect(
+      rowKeyMatchesRenderRow(
+        row,
+        `runtime:focused|${folderWorkspaceKey(FOLDER_WORKSPACE.id)}`,
+        'runtime:focused'
+      )
+    ).toBe(true)
   })
 })

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/render-row-lookup.folder-workspace.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/render-row-lookup.folder-workspace.test.ts
@@ -79,4 +79,23 @@ describe('host-qualified reveal lookup finds folder workspaces', () => {
       )
     ).toBe(-1)
   })
+
+  it('selects the requested host when folder ids collide', () => {
+    const rows: RenderRow[] = ['local', 'runtime:env-1'].map((executionHostId) => ({
+      type: 'folder-workspace',
+      key: `folder-workspace:${executionHostId}`,
+      folderWorkspace: { ...FOLDER_WORKSPACE, executionHostId },
+      projectGroup: { ...PROJECT_GROUP, executionHostId },
+      depth: 0,
+      groupDepth: 0
+    })) as RenderRow[]
+
+    expect(
+      findPreferredRenderRowIndexForWorktreeIdentity(
+        rows,
+        { id: folderWorkspaceKey(FOLDER_WORKSPACE.id), hostId: 'runtime:env-1' },
+        'single-location'
+      )
+    ).toBe(1)
+  })
 })

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/render-row-lookup.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/render-row-lookup.ts
@@ -6,6 +6,7 @@ import { getWorktreeHostIdentity } from '../../../../../../shared/worktree/host-
 import type { RenderRow } from '../listing/render-row'
 import type { PinnedWorktreeDisplayPolicy } from '../grouping/row-types'
 import { isPinnedWorktreeRow, type WorktreeItemRow } from '../listing/renderable-rows'
+import { getFolderWorkspaceHostId } from '../../folder-workspace-host-id'
 
 export function getRenderRowSidebarKey(row: RenderRow): string | null {
   if (row.type === 'header') {
@@ -58,7 +59,12 @@ export function renderRowContainsWorktree(
     return false
   }
   if (row.type === 'folder-workspace') {
-    return folderWorkspaceKey(row.folderWorkspace.id) === worktreeId
+    return (
+      folderWorkspaceKey(row.folderWorkspace.id) === worktreeId &&
+      (executionHostId === undefined ||
+        getFolderWorkspaceHostId(row.folderWorkspace, row.projectGroup, executionHostId) ===
+          executionHostId)
+    )
   }
   if (row.type === 'lineage-group') {
     return row.rows.some((item) => itemMatchesWorktree(item, worktreeId, executionHostId))
@@ -112,7 +118,12 @@ export function findPreferredRenderRowIndexForWorktreeIdentity(
     // Why: host-qualified reveals are emitted for folder workspaces too, and a
     // walker that only knows item rows returns -1 so the reveal never lands.
     if (row.type === 'folder-workspace') {
-      if (folderWorkspaceKey(row.folderWorkspace.id) === worktree.id) {
+      if (
+        folderWorkspaceKey(row.folderWorkspace.id) === worktree.id &&
+        (!worktree.hostId ||
+          getFolderWorkspaceHostId(row.folderWorkspace, row.projectGroup, worktree.hostId) ===
+            worktree.hostId)
+      ) {
         return index
       }
       continue

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/render-row-lookup.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/render-row-lookup.ts
@@ -36,12 +36,16 @@ export function getRenderRowSidebarKey(
   return null
 }
 
-export function rowKeyMatchesRenderRow(row: RenderRow, rowKey: string): boolean {
+export function rowKeyMatchesRenderRow(
+  row: RenderRow,
+  rowKey: string,
+  defaultHostId: ExecutionHostId = LOCAL_EXECUTION_HOST_ID
+): boolean {
   if (row.type === 'lineage-group') {
     return row.rows.some((item) => item.rowKey === rowKey)
   }
   return (
-    getRenderRowSidebarKey(row) === rowKey ||
+    getRenderRowSidebarKey(row, defaultHostId) === rowKey ||
     (row.type === 'folder-workspace' && folderWorkspaceKey(row.folderWorkspace.id) === rowKey)
   )
 }

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/render-row-lookup.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/render-row-lookup.ts
@@ -1,14 +1,20 @@
 import { folderWorkspaceKey } from '../../../../../../shared/workspace-scope'
-import { getWorktreeExecutionHostId } from '../../../../../../shared/execution-host'
+import {
+  getWorktreeExecutionHostId,
+  LOCAL_EXECUTION_HOST_ID
+} from '../../../../../../shared/execution-host'
 import type { ExecutionHostId } from '../../../../../../shared/execution-host'
 import type { Worktree } from '../../../../../../shared/worktree/types'
 import { getWorktreeHostIdentity } from '../../../../../../shared/worktree/host-qualified-identity'
-import type { RenderRow } from '../listing/render-row'
+import { getFolderWorkspaceSidebarRowKey, type RenderRow } from '../listing/render-row'
 import type { PinnedWorktreeDisplayPolicy } from '../grouping/row-types'
 import { isPinnedWorktreeRow, type WorktreeItemRow } from '../listing/renderable-rows'
 import { getFolderWorkspaceHostId } from '../../folder-workspace-host-id'
 
-export function getRenderRowSidebarKey(row: RenderRow): string | null {
+export function getRenderRowSidebarKey(
+  row: RenderRow,
+  defaultHostId: ExecutionHostId = LOCAL_EXECUTION_HOST_ID
+): string | null {
   if (row.type === 'header') {
     return row.key
   }
@@ -16,7 +22,7 @@ export function getRenderRowSidebarKey(row: RenderRow): string | null {
     return row.rowKey
   }
   if (row.type === 'folder-workspace') {
-    return folderWorkspaceKey(row.folderWorkspace.id)
+    return getFolderWorkspaceSidebarRowKey(row, defaultHostId)
   }
   if (row.type === 'pending-creation') {
     return `pending:${row.creationId}`
@@ -34,7 +40,10 @@ export function rowKeyMatchesRenderRow(row: RenderRow, rowKey: string): boolean 
   if (row.type === 'lineage-group') {
     return row.rows.some((item) => item.rowKey === rowKey)
   }
-  return getRenderRowSidebarKey(row) === rowKey
+  return (
+    getRenderRowSidebarKey(row) === rowKey ||
+    (row.type === 'folder-workspace' && folderWorkspaceKey(row.folderWorkspace.id) === rowKey)
+  )
 }
 
 function itemMatchesWorktree(

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/use-pending-reveal.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/use-pending-reveal.ts
@@ -78,7 +78,9 @@ export function usePendingSidebarReveal(args: PendingSidebarRevealArgs): void {
         pendingRevealWorktree.worktreeId,
         argsRef.current.worktrees,
         argsRef.current.folderWorkspaces,
-        pendingRevealWorktree.executionHostId
+        pendingRevealWorktree.executionHostId,
+        argsRef.current.projectGroups,
+        argsRef.current.defaultHostId
       )
       const targetIndex = pendingRevealWorktree.executionHostId
         ? findPreferredRenderRowIndexForWorktreeIdentity(

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/use-pending-reveal.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/use-pending-reveal.ts
@@ -123,7 +123,8 @@ export function usePendingSidebarReveal(args: PendingSidebarRevealArgs): void {
       if (revealedOption) {
         if (pendingRevealWorktree.highlight) {
           const revealedRowKey =
-            revealedOption.dataset.worktreeRowKey ?? getRenderRowSidebarKey(targetRow)
+            revealedOption.dataset.worktreeRowKey ??
+            getRenderRowSidebarKey(targetRow, argsRef.current.defaultHostId)
           if (revealedRowKey) {
             flashRevealedRow(revealedRowKey)
           }
@@ -239,7 +240,7 @@ export function usePendingSidebarReveal(args: PendingSidebarRevealArgs): void {
         return
       }
       const targetIndex = renderRows.findIndex((row) =>
-        rowKeyMatchesRenderRow(row, pendingRevealSidebarRow.rowKey)
+        rowKeyMatchesRenderRow(row, pendingRevealSidebarRow.rowKey, argsRef.current.defaultHostId)
       )
       if (targetIndex === -1) {
         if (retryPendingReveal()) {

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/use-reveal-requests.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/use-reveal-requests.ts
@@ -7,6 +7,7 @@ import {
 import type { FolderWorkspace } from '../../../../../../shared/folder-workspace-types'
 import type { Worktree } from '../../../../../../shared/worktree/types'
 import type { ExecutionHostId } from '../../../../../../shared/execution-host'
+import type { ProjectGroup } from '../../../../../../shared/project-group-types'
 import { composeWorktreeHostIdentity } from '../../../../../../shared/worktree/host-qualified-identity'
 import type { WorktreeGroupBy } from '../grouping/row-types'
 import { getKnownSidebarWorktreeById } from './folder-reveal'
@@ -22,6 +23,8 @@ export function useSidebarRevealRequests(args: {
   worktreeMap: Map<string, Worktree>
   worktrees: readonly Worktree[]
   folderWorkspaces: readonly FolderWorkspace[]
+  projectGroups: readonly ProjectGroup[]
+  defaultHostId: ExecutionHostId
   hasFilters: boolean
   clearFilters: () => void
 }): void {
@@ -34,6 +37,8 @@ export function useSidebarRevealRequests(args: {
     worktreeMap,
     worktrees,
     folderWorkspaces,
+    projectGroups,
+    defaultHostId,
     hasFilters,
     clearFilters
   } = args
@@ -92,7 +97,9 @@ export function useSidebarRevealRequests(args: {
         worktreeMap,
         folderWorkspaces,
         worktrees,
-        currentSidebarExecutionHostId
+        currentSidebarExecutionHostId,
+        projectGroups,
+        defaultHostId
       )
       if (!activeWorktree || activeWorktree.isArchived) {
         return
@@ -116,7 +123,9 @@ export function useSidebarRevealRequests(args: {
       clearFilters,
       currentSidebarWorktreeId,
       currentSidebarExecutionHostId,
+      defaultHostId,
       folderWorkspaces,
+      projectGroups,
       revealSidebarRow,
       renderedWorktreeIdentities,
       revealWorktreeInSidebar,

--- a/src/renderer/src/components/sidebar/worktree-list/rows/SectionHeader.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/SectionHeader.tsx
@@ -50,10 +50,13 @@ export type SectionHeaderRowContext = {
   dragOverStatus: WorkspaceStatus | null
   pinDragOver: boolean
   headerDrag: WorktreeSidebarHeaderDrag
-  getCachedFolderWorkspacePathStatus: (request: {
-    scope: 'project-group'
-    projectGroupId: string
-  }) => FolderWorkspacePathStatus | null
+  getCachedFolderWorkspacePathStatus: (
+    request: {
+      scope: 'project-group'
+      projectGroupId: string
+    },
+    scope: { projectGroup: ProjectGroup }
+  ) => FolderWorkspacePathStatus | null
   toggleGroupWithScrollAnchor: (groupKey: string) => void
   projectActions: RepoHeaderProjectActions
   onRenameProjectGroup: (groupId: string, currentName: string) => void
@@ -158,10 +161,13 @@ export function renderWorktreeSectionHeaderRow(args: {
       ? row.projectGroup
       : null
   const projectGroupPathStatus = folderBackedProjectGroup
-    ? ctx.getCachedFolderWorkspacePathStatus({
-        scope: 'project-group',
-        projectGroupId: folderBackedProjectGroup.id
-      })
+    ? ctx.getCachedFolderWorkspacePathStatus(
+        {
+          scope: 'project-group',
+          projectGroupId: folderBackedProjectGroup.id
+        },
+        { projectGroup: folderBackedProjectGroup }
+      )
     : null
   const isHeaderCollapsed = ctx.collapsedGroups.has(row.key)
   // Why: repo/project/status/pinned share compact section chrome; flat "All" stays a simple label.

--- a/src/renderer/src/components/sidebar/worktree-list/rows/folder-row-host-identity.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/folder-row-host-identity.test.tsx
@@ -1,0 +1,91 @@
+import type React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import type { VirtualItem } from '@tanstack/react-virtual'
+import type { FolderWorkspace } from '../../../../../../shared/folder-workspace-types'
+import type { ProjectGroup } from '../../../../../../shared/project-group-types'
+import { folderWorkspaceKey } from '../../../../../../shared/workspace-scope'
+import type { FolderWorkspaceItemRow } from '../listing/renderable-rows'
+import { renderFolderWorkspaceVirtualRow, type FolderWorkspaceRowContext } from './folder-row'
+
+function row(executionHostId: 'local' | 'runtime:env-1'): FolderWorkspaceItemRow {
+  const folderWorkspace = {
+    id: 'folder-shared',
+    projectGroupId: 'group-shared',
+    name: executionHostId,
+    folderPath: `/${executionHostId}`,
+    linkedTask: null,
+    comment: '',
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 1,
+    createdAt: 1,
+    updatedAt: 1,
+    executionHostId
+  } satisfies FolderWorkspace
+  const projectGroup = {
+    id: folderWorkspace.projectGroupId,
+    name: executionHostId,
+    parentPath: folderWorkspace.folderPath,
+    parentGroupId: null,
+    createdFrom: 'manual',
+    tabOrder: 0,
+    isCollapsed: false,
+    color: null,
+    createdAt: 1,
+    updatedAt: 1,
+    executionHostId
+  } satisfies ProjectGroup
+  return {
+    type: 'folder-workspace',
+    key: `folder-workspace:${executionHostId}`,
+    folderWorkspace,
+    projectGroup,
+    depth: 0,
+    groupDepth: 0
+  }
+}
+
+function render(target: FolderWorkspaceItemRow): React.ReactElement<Record<string, unknown>> {
+  const ctx = {
+    defaultHostId: 'local',
+    groupBy: 'none',
+    newCardStyle: false,
+    settings: {} as FolderWorkspaceRowContext['settings'],
+    activeWorktreeId: folderWorkspaceKey(target.folderWorkspace.id),
+    activeWorkspaceExecutionHostId: 'runtime:env-1',
+    currentWorktreeId: folderWorkspaceKey(target.folderWorkspace.id),
+    selectedWorktreeIds: new Set(),
+    repoMap: new Map(),
+    worktreeMap: new Map(),
+    worktreeLineageById: {},
+    workspaceLineageByChildKey: {},
+    prCache: null,
+    hostedReviewCache: null,
+    getCachedFolderWorkspacePathStatus: () => null,
+    onSelectionGesture: () => false,
+    onContextMenuSelect: () => [],
+    onImmediateActivate: vi.fn(),
+    onRowClickCapture: vi.fn(),
+    onRowPointerDown: vi.fn()
+  } satisfies FolderWorkspaceRowContext
+  return renderFolderWorkspaceVirtualRow({
+    ctx,
+    row: target,
+    vItem: { key: target.key, index: 0, start: 0 } as VirtualItem,
+    measureVirtualRowElement: vi.fn()
+  }) as React.ReactElement<Record<string, unknown>>
+}
+
+describe('folder row host identity', () => {
+  it('keeps DOM identity and active state on the requested host', () => {
+    const local = render(row('local'))
+    const runtime = render(row('runtime:env-1'))
+
+    expect(local.props.id).not.toBe(runtime.props.id)
+    expect(local.props['data-worktree-row-key']).not.toBe(runtime.props['data-worktree-row-key'])
+    expect(local.props['aria-current']).toBeUndefined()
+    expect(runtime.props['aria-current']).toBe('page')
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-list/rows/folder-row.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/folder-row.tsx
@@ -7,7 +7,10 @@ import type {
   WorktreeLineage
 } from '../../../../../../shared/worktree/lineage-types'
 import type { Worktree } from '../../../../../../shared/worktree/types'
-import { getWorktreeHostIdentity } from '../../../../../../shared/worktree/host-qualified-identity'
+import {
+  composeWorktreeHostIdentity,
+  getWorktreeHostIdentity
+} from '../../../../../../shared/worktree/host-qualified-identity'
 import type { FolderWorkspacePathStatus } from '../../../../../../shared/folder-workspace-path-status'
 import { isConfirmedStaleFolderPathStatus } from '../../../../../../shared/folder-workspace-path-status'
 import { folderWorkspaceToWorktreeForHost } from '../../../../../../shared/folder-workspace-worktree'
@@ -21,7 +24,6 @@ import type { FolderWorkspaceItemRow } from '../listing/renderable-rows'
 import { getWorktreeOptionId } from './option-dom'
 import { getFolderWorkspaceHostId } from '../../folder-workspace-host-id'
 import type { ExecutionHostId } from '../../../../../../shared/execution-host'
-import { composeWorktreeHostIdentity } from '../../../../../../shared/worktree/host-qualified-identity'
 import { getFolderWorkspaceSidebarRowKey } from '../listing/render-row'
 
 export type FolderWorkspaceRowContext = {

--- a/src/renderer/src/components/sidebar/worktree-list/rows/folder-row.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/folder-row.tsx
@@ -10,7 +10,7 @@ import type { Worktree } from '../../../../../../shared/worktree/types'
 import { getWorktreeHostIdentity } from '../../../../../../shared/worktree/host-qualified-identity'
 import type { FolderWorkspacePathStatus } from '../../../../../../shared/folder-workspace-path-status'
 import { isConfirmedStaleFolderPathStatus } from '../../../../../../shared/folder-workspace-path-status'
-import { folderWorkspaceToWorktree } from '../../../../../../shared/folder-workspace-worktree'
+import { folderWorkspaceToWorktreeForHost } from '../../../../../../shared/folder-workspace-worktree'
 import WorktreeCard from '../../WorktreeCard'
 import type { WorktreeGroupBy } from '../grouping/row-types'
 import { getVirtualRowTransform } from '../viewport/virtual-rows'
@@ -19,8 +19,11 @@ import { getFolderWorkspaceCardPrDisplay } from '../../folder-workspace-card-pr-
 import { FolderPathStatusIndicator } from './FolderPathStatusIndicator'
 import type { FolderWorkspaceItemRow } from '../listing/renderable-rows'
 import { getWorktreeOptionId } from './option-dom'
+import { getFolderWorkspaceHostId } from '../../folder-workspace-host-id'
+import type { ExecutionHostId } from '../../../../../../shared/execution-host'
 
 export type FolderWorkspaceRowContext = {
+  defaultHostId: ExecutionHostId
   groupBy: WorktreeGroupBy
   newCardStyle: boolean
   settings: AppState['settings']
@@ -33,10 +36,16 @@ export type FolderWorkspaceRowContext = {
   workspaceLineageByChildKey: Record<string, WorkspaceLineage>
   prCache: AppState['prCache'] | null
   hostedReviewCache: AppState['hostedReviewCache'] | null
-  getCachedFolderWorkspacePathStatus: (request: {
-    scope: 'folder-workspace'
-    folderWorkspaceId: string
-  }) => FolderWorkspacePathStatus | null
+  getCachedFolderWorkspacePathStatus: (
+    request: {
+      scope: 'folder-workspace'
+      folderWorkspaceId: string
+    },
+    scope: {
+      projectGroup: FolderWorkspaceItemRow['projectGroup']
+      folderWorkspace: FolderWorkspaceItemRow['folderWorkspace']
+    }
+  ) => FolderWorkspacePathStatus | null
   onSelectionGesture: (event: React.MouseEvent<HTMLElement>, worktree: Worktree) => boolean
   onContextMenuSelect: (
     event: React.MouseEvent<HTMLElement>,
@@ -58,12 +67,16 @@ export function renderFolderWorkspaceVirtualRow(args: {
   measureVirtualRowElement: (element: HTMLDivElement | null) => void
 }): React.JSX.Element {
   const { ctx, row, vItem } = args
-  const folderWorktree = folderWorkspaceToWorktree(row.folderWorkspace)
+  const hostId = getFolderWorkspaceHostId(row.folderWorkspace, row.projectGroup, ctx.defaultHostId)
+  const folderWorktree = folderWorkspaceToWorktreeForHost(row.folderWorkspace, hostId)
   const folderWorktreeIdentity = getWorktreeHostIdentity(folderWorktree)
-  const pathStatus = ctx.getCachedFolderWorkspacePathStatus({
-    scope: 'folder-workspace',
-    folderWorkspaceId: row.folderWorkspace.id
-  })
+  const pathStatus = ctx.getCachedFolderWorkspacePathStatus(
+    {
+      scope: 'folder-workspace',
+      folderWorkspaceId: row.folderWorkspace.id
+    },
+    { projectGroup: row.projectGroup, folderWorkspace: row.folderWorkspace }
+  )
   const activationDisabled =
     pathStatus?.exists === false &&
     (isConfirmedStaleFolderPathStatus(pathStatus) || pathStatus.reason === 'ambiguous-connection')

--- a/src/renderer/src/components/sidebar/worktree-list/rows/folder-row.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/folder-row.tsx
@@ -21,6 +21,8 @@ import type { FolderWorkspaceItemRow } from '../listing/renderable-rows'
 import { getWorktreeOptionId } from './option-dom'
 import { getFolderWorkspaceHostId } from '../../folder-workspace-host-id'
 import type { ExecutionHostId } from '../../../../../../shared/execution-host'
+import { composeWorktreeHostIdentity } from '../../../../../../shared/worktree/host-qualified-identity'
+import { getFolderWorkspaceSidebarRowKey } from '../listing/render-row'
 
 export type FolderWorkspaceRowContext = {
   defaultHostId: ExecutionHostId
@@ -28,6 +30,7 @@ export type FolderWorkspaceRowContext = {
   newCardStyle: boolean
   settings: AppState['settings']
   activeWorktreeId: string | null
+  activeWorkspaceExecutionHostId: ExecutionHostId | null
   currentWorktreeId: string | null
   selectedWorktreeIds: ReadonlySet<string>
   repoMap: Map<string, Repo>
@@ -70,6 +73,12 @@ export function renderFolderWorkspaceVirtualRow(args: {
   const hostId = getFolderWorkspaceHostId(row.folderWorkspace, row.projectGroup, ctx.defaultHostId)
   const folderWorktree = folderWorkspaceToWorktreeForHost(row.folderWorkspace, hostId)
   const folderWorktreeIdentity = getWorktreeHostIdentity(folderWorktree)
+  const folderRowKey = getFolderWorkspaceSidebarRowKey(row, ctx.defaultHostId)
+  const isActive =
+    ctx.activeWorktreeId === folderWorktree.id &&
+    (!ctx.activeWorkspaceExecutionHostId ||
+      folderWorktreeIdentity ===
+        composeWorktreeHostIdentity(ctx.activeWorkspaceExecutionHostId, folderWorktree.id))
   const pathStatus = ctx.getCachedFolderWorkspacePathStatus(
     {
       scope: 'folder-workspace',
@@ -101,13 +110,13 @@ export function renderFolderWorkspaceVirtualRow(args: {
   return (
     <div
       key={vItem.key}
-      id={getWorktreeOptionId(folderWorktree.id)}
+      id={getWorktreeOptionId(folderRowKey)}
       role="option"
       aria-selected={ctx.selectedWorktreeIds.has(folderWorktreeIdentity)}
-      aria-current={ctx.activeWorktreeId === folderWorktree.id ? 'page' : undefined}
+      aria-current={isActive ? 'page' : undefined}
       data-worktree-id={folderWorktree.id}
       data-worktree-host-identity={folderWorktreeIdentity}
-      data-worktree-row-key={folderWorktree.id}
+      data-worktree-row-key={folderRowKey}
       data-worktree-virtual-row
       data-worktree-virtual-row-key={String(vItem.key)}
       data-worktree-virtual-row-start={vItem.start}
@@ -116,7 +125,7 @@ export function renderFolderWorkspaceVirtualRow(args: {
       className="absolute left-0 right-0 top-0"
       style={{ transform: getVirtualRowTransform(vItem.start) }}
       onClickCapture={ctx.onRowClickCapture}
-      onPointerDown={(event) => ctx.onRowPointerDown(event, folderWorktree, folderWorktree.id)}
+      onPointerDown={(event) => ctx.onRowPointerDown(event, folderWorktree, folderRowKey)}
     >
       <div
         className="relative"
@@ -125,13 +134,13 @@ export function renderFolderWorkspaceVirtualRow(args: {
         <WorktreeCard
           worktree={folderWorktree}
           repo={undefined}
-          isActive={ctx.activeWorktreeId === folderWorktree.id}
-          isCurrentWorktree={ctx.currentWorktreeId === folderWorktree.id}
+          isActive={isActive}
+          isCurrentWorktree={isActive && ctx.currentWorktreeId === folderWorktree.id}
           contentIndent={cardContentIndent}
           flushSurface
           nativeDragEnabled={false}
           onImmediateActivate={activationDisabled ? undefined : ctx.onImmediateActivate}
-          activationRowKey={folderWorktree.id}
+          activationRowKey={folderRowKey}
           onSelectionGesture={(event) => ctx.onSelectionGesture(event, folderWorktree)}
           onContextMenuSelect={ctx.onContextMenuSelect}
           statusPrDisplay={folderPrDisplay}

--- a/src/renderer/src/components/sidebar/worktree-list/viewport/VirtualizedWorktreeViewport.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/viewport/VirtualizedWorktreeViewport.tsx
@@ -131,6 +131,7 @@ export const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktr
 
   const virtualization = useWorktreeListVirtualizer({
     renderRows,
+    defaultHostId: props.defaultHostId,
     firstHeaderIndex,
     scrollRef,
     scrollOffsetRef,
@@ -169,6 +170,7 @@ export const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktr
 
   const { virtualItems, measureVirtualRowElement } = useVirtualRowMeasurementSync({
     renderRows,
+    defaultHostId: props.defaultHostId,
     virtualization,
     scrollRef,
     scrollOffsetRef,

--- a/src/renderer/src/components/sidebar/worktree-list/viewport/use-row-measurement.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/viewport/use-row-measurement.ts
@@ -14,6 +14,7 @@ import {
 import { getRenderRowKey } from '../listing/render-row'
 import type { RenderRow } from '../listing/render-row'
 import type { WorktreeListVirtualizer } from './use-virtualizer'
+import type { ExecutionHostId } from '../../../../../../shared/execution-host'
 
 const recordKeyCountCache = new WeakMap<Record<string, unknown>, number>()
 
@@ -31,6 +32,7 @@ export function countRecordKeysByReference(record: Record<string, unknown>): num
 // sticky-header slots the render pass reads out of refs.
 export function useVirtualRowMeasurementSync(args: {
   renderRows: RenderRow[]
+  defaultHostId: ExecutionHostId
   virtualization: WorktreeListVirtualizer
   scrollRef: React.RefObject<HTMLDivElement | null>
   scrollOffsetRef: React.MutableRefObject<number>
@@ -40,6 +42,7 @@ export function useVirtualRowMeasurementSync(args: {
 }) {
   const {
     renderRows,
+    defaultHostId,
     virtualization,
     scrollRef,
     scrollOffsetRef,
@@ -51,10 +54,13 @@ export function useVirtualRowMeasurementSync(args: {
   const prCacheLen = useAppStore((s) => countRecordKeysByReference(s.prCache))
   const issueCacheLen = useAppStore((s) => countRecordKeysByReference(s.issueCache))
   const renderRowKeySignature = useMemo(
-    () => renderRows.map(getRenderRowKey).join('\n'),
-    [renderRows]
+    () => renderRows.map((row) => getRenderRowKey(row, defaultHostId)).join('\n'),
+    [defaultHostId, renderRows]
   )
-  const activeRenderRowKeys = useMemo(() => new Set(renderRows.map(getRenderRowKey)), [renderRows])
+  const activeRenderRowKeys = useMemo(
+    () => new Set(renderRows.map((row) => getRenderRowKey(row, defaultHostId))),
+    [defaultHostId, renderRows]
+  )
   const lineageRowRekeys = useMemo(() => buildLineageRowRekeyMap(renderRows), [renderRows])
   const totalSize = virtualizer.getTotalSize()
   const virtualItems = virtualizer.getVirtualItems()

--- a/src/renderer/src/components/sidebar/worktree-list/viewport/use-virtualizer.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/viewport/use-virtualizer.ts
@@ -14,6 +14,7 @@ import {
 } from './virtual-rows'
 import { getRenderRowKey } from '../listing/render-row'
 import type { RenderRow } from '../listing/render-row'
+import type { ExecutionHostId } from '../../../../../../shared/execution-host'
 import { WORKTREE_SIDEBAR_REVEAL_TOP_INSET } from '../../worktree-sidebar-reveal'
 import {
   shouldAdjustWorktreeSidebarMeasuredRowScroll,
@@ -26,12 +27,13 @@ export type WorktreeListVirtualizer = ReturnType<typeof useWorktreeListVirtualiz
 // from writing a stale height into the wrong slot.
 export function useWorktreeListVirtualizer(args: {
   renderRows: RenderRow[]
+  defaultHostId: ExecutionHostId
   firstHeaderIndex: number
   scrollRef: React.RefObject<HTMLDivElement | null>
   scrollOffsetRef: React.MutableRefObject<number>
   suppressMeasurementAdjustmentUntilRef: React.MutableRefObject<number>
 }) {
-  const { renderRows, firstHeaderIndex, scrollRef, scrollOffsetRef } = args
+  const { renderRows, defaultHostId, firstHeaderIndex, scrollRef, scrollOffsetRef } = args
   const stickyHeaderIndexes = useMemo(() => getStickyHeaderIndexes(renderRows), [renderRows])
   const activeStickyHeaderIndexRef = useRef<number | null>(null)
   const activeStickyHostIndexRef = useRef<number | null>(null)
@@ -43,17 +45,17 @@ export function useWorktreeListVirtualizer(args: {
       if (!row) {
         return `__stale_${index}`
       }
-      return getRenderRowKey(row)
+      return getRenderRowKey(row, defaultHostId)
     },
-    [renderRows]
+    [defaultHostId, renderRows]
   )
   const getExpectedVirtualRowKey = useCallback(
     (element: Element) => {
       const index = getVirtualRowIndex(element)
       const row = index === null ? undefined : renderRows[index]
-      return row ? getRenderRowKey(row) : null
+      return row ? getRenderRowKey(row, defaultHostId) : null
     },
-    [renderRows]
+    [defaultHostId, renderRows]
   )
   const isCurrentVirtualRowElement = useCallback(
     (element: Element) => {

--- a/src/renderer/src/components/sidebar/worktree-list/viewport/virtual-row-context.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/viewport/virtual-row-context.ts
@@ -141,6 +141,7 @@ export function buildWorktreeVirtualRowContext(args: BuildArgs): WorktreeVirtual
       newCardStyle: args.newCardStyle,
       settings: args.settings,
       activeWorktreeId: props.activeWorktreeId,
+      activeWorkspaceExecutionHostId: props.activeWorkspaceExecutionHostId,
       currentWorktreeId: props.currentWorktreeId,
       selectedWorktreeIds: props.selectedWorktreeIds,
       repoMap: props.repoMap,

--- a/src/renderer/src/components/sidebar/worktree-list/viewport/virtual-row-context.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/viewport/virtual-row-context.ts
@@ -136,6 +136,7 @@ export function buildWorktreeVirtualRowContext(args: BuildArgs): WorktreeVirtual
       onCardDragEnd: runtime.clearWorktreeDrag
     },
     folderWorkspace: {
+      defaultHostId: props.defaultHostId,
       groupBy: props.groupBy,
       newCardStyle: args.newCardStyle,
       settings: args.settings,

--- a/src/renderer/src/components/sidebar/worktree-list/viewport/virtual-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/viewport/virtual-rows.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import type { VirtualItem } from '@tanstack/react-virtual'
 import type { ExecutionHostId } from '../../../../../../shared/execution-host'
+import type { FolderWorkspace } from '../../../../../../shared/folder-workspace-types'
+import type { ProjectGroup } from '../../../../../../shared/project-group-types'
 import {
   HOST_STICKY_PINNED_HEIGHT,
   buildLineageRowRekeyMap,
@@ -41,6 +43,21 @@ function itemStub(id: string): RenderRow {
   return { type: 'item', key: id } as unknown as RenderRow
 }
 
+function folderRow(executionHostId: ExecutionHostId): RenderRow {
+  return {
+    type: 'folder-workspace',
+    key: 'folder-workspace:same-id',
+    folderWorkspace: {
+      id: 'same-id',
+      executionHostId,
+      projectGroupId: 'group-id'
+    } as FolderWorkspace,
+    projectGroup: { id: 'group-id', executionHostId } as ProjectGroup,
+    depth: 0,
+    groupDepth: 0
+  }
+}
+
 function virtualItem(index: number, start: number): VirtualItem {
   return { index, start } as VirtualItem
 }
@@ -72,6 +89,13 @@ describe('getRenderRowKey', () => {
   it('preserves unsectioned group header keys', () => {
     expect(getRenderRowKey(groupRow('workspace-status:in-progress'))).toBe(
       'hdr:workspace-status:in-progress'
+    )
+  })
+
+  it('keeps identical folder workspace ids distinct across hosts', () => {
+    expect(getRenderRowKey(folderRow('local'))).toBe('folder-workspace:local|folder:same-id')
+    expect(getRenderRowKey(folderRow('runtime:owner'))).toBe(
+      'folder-workspace:runtime:owner|folder:same-id'
     )
   })
 })

--- a/src/renderer/src/components/sidebar/worktree-list/viewport/virtual-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/viewport/virtual-rows.test.ts
@@ -43,7 +43,9 @@ function itemStub(id: string): RenderRow {
   return { type: 'item', key: id } as unknown as RenderRow
 }
 
-function folderRow(executionHostId: ExecutionHostId): RenderRow {
+function folderRow(
+  executionHostId: ExecutionHostId
+): Extract<RenderRow, { type: 'folder-workspace' }> {
   return {
     type: 'folder-workspace',
     key: 'folder-workspace:same-id',
@@ -96,6 +98,15 @@ describe('getRenderRowKey', () => {
     expect(getRenderRowKey(folderRow('local'))).toBe('folder-workspace:local|folder:same-id')
     expect(getRenderRowKey(folderRow('runtime:owner'))).toBe(
       'folder-workspace:runtime:owner|folder:same-id'
+    )
+  })
+
+  it('uses the focused host for a legacy folder with no owner fields', () => {
+    const row = folderRow('local')
+    delete row.folderWorkspace.executionHostId
+    delete row.projectGroup.executionHostId
+    expect(getRenderRowKey(row, 'runtime:focused')).toBe(
+      'folder-workspace:runtime:focused|folder:same-id'
     )
   })
 })

--- a/src/renderer/src/components/sidebar/worktree-sidebar-row-preference.ts
+++ b/src/renderer/src/components/sidebar/worktree-sidebar-row-preference.ts
@@ -1,7 +1,11 @@
-import { folderWorkspaceToWorktree } from '../../../../shared/folder-workspace-worktree'
+import {
+  folderWorkspaceToWorktree,
+  folderWorkspaceToWorktreeForHost
+} from '../../../../shared/folder-workspace-worktree'
 import type { Worktree } from '../../../../shared/worktree/types'
 import { getWorktreeHostIdentity } from '../../../../shared/worktree/host-qualified-identity'
 import type { HostSectionRow } from './host-section-rows'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
 import { PINNED_GROUP_KEY } from './worktree-list/grouping/group-keys'
 import type { PinnedWorktreeDisplayPolicy, WorktreeRow } from './worktree-list/grouping/row-types'
 
@@ -53,12 +57,19 @@ export function getRenderedWorktreesInSidebarOrder(
     getPreferredWorktreeRows(itemRows, pinnedDisplayPolicy).map((row) => row.rowKey)
   )
   const renderedWorktrees: Worktree[] = []
+  let currentHostId: ExecutionHostId | undefined
 
   for (const row of rows) {
-    if (row.type === 'item' && preferredRowKeys.has(row.rowKey)) {
+    if (row.type === 'host-header') {
+      currentHostId = row.hostId
+    } else if (row.type === 'item' && preferredRowKeys.has(row.rowKey)) {
       renderedWorktrees.push(row.worktree)
     } else if (row.type === 'folder-workspace') {
-      renderedWorktrees.push(folderWorkspaceToWorktree(row.folderWorkspace))
+      renderedWorktrees.push(
+        currentHostId
+          ? folderWorkspaceToWorktreeForHost(row.folderWorkspace, currentHostId)
+          : folderWorkspaceToWorktree(row.folderWorkspace)
+      )
     }
   }
   return renderedWorktrees

--- a/src/renderer/src/lib/folder-workspace-runtime-owner.test.ts
+++ b/src/renderer/src/lib/folder-workspace-runtime-owner.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import type { FolderWorkspace } from '../../../shared/folder-workspace-types'
+import type { ProjectGroup } from '../../../shared/project-group-types'
+import { findFolderWorkspaceOwner } from './folder-workspace-runtime-owner'
+
+const folder = {
+  id: 'folder-1',
+  projectGroupId: 'group-1'
+} as FolderWorkspace
+
+const runtimeGroup = {
+  id: 'group-1',
+  executionHostId: 'runtime:owner'
+} as ProjectGroup
+
+describe('folder workspace runtime owner', () => {
+  it('resolves a legacy folder through its runtime-owned project group', () => {
+    const state = {
+      folderWorkspaces: [folder],
+      projectGroups: [runtimeGroup],
+      settings: { activeRuntimeEnvironmentId: null }
+    }
+
+    expect(findFolderWorkspaceOwner(state, folder.id, 'runtime:owner')).toBe(folder)
+    expect(findFolderWorkspaceOwner(state, folder.id, 'local')).toBeNull()
+  })
+
+  it('keeps an explicit folder owner authoritative over its group', () => {
+    const localFolder = { ...folder, executionHostId: 'local' as const }
+    const state = {
+      folderWorkspaces: [localFolder],
+      projectGroups: [runtimeGroup],
+      settings: { activeRuntimeEnvironmentId: 'owner' }
+    }
+
+    expect(findFolderWorkspaceOwner(state, folder.id, 'local')).toBe(localFolder)
+    expect(findFolderWorkspaceOwner(state, folder.id, 'runtime:owner')).toBeNull()
+  })
+})

--- a/src/renderer/src/lib/folder-workspace-runtime-owner.ts
+++ b/src/renderer/src/lib/folder-workspace-runtime-owner.ts
@@ -1,4 +1,8 @@
-import { parseExecutionHostId, toSshExecutionHostId } from '../../../shared/execution-host'
+import {
+  getSettingsFocusedExecutionHostId,
+  parseExecutionHostId,
+  toSshExecutionHostId
+} from '../../../shared/execution-host'
 import type { ExecutionHostId, ParsedExecutionHost } from '../../../shared/execution-host'
 import type { FolderWorkspace } from '../../../shared/folder-workspace-types'
 import type { ProjectGroup } from '../../../shared/project-group-types'
@@ -11,6 +15,7 @@ import {
   getSingleFocusedRuntimeEnvironmentId,
   type SingleRuntimeLegacyOwnerState
 } from './single-runtime-legacy-owner'
+import { getFolderWorkspaceHostIdFromGroups } from '../../../shared/folder-workspace-host'
 
 type RuntimeExecutionHost = Extract<ParsedExecutionHost, { kind: 'runtime' }>
 
@@ -46,11 +51,43 @@ export function findFolderWorkspaceOwner(
   FolderWorkspace,
   'id' | 'projectGroupId' | 'connectionId' | 'executionHostId' | 'diffComments'
 > | null {
-  return findIndexedFolderWorkspaceOwner(
+  const preferredHostId = getPreferredFolderExecutionHostId(
+    state,
+    folderWorkspaceId,
+    executionHostId
+  )
+  const indexedOwner = findIndexedFolderWorkspaceOwner(
     state.folderWorkspaces,
     folderWorkspaceId,
-    getPreferredFolderExecutionHostId(state, folderWorkspaceId, executionHostId)
+    preferredHostId
   )
+  if (!preferredHostId) {
+    return indexedOwner
+  }
+  const ownerCandidates = (state.folderWorkspaces ?? []).filter(
+    (workspace) => workspace.id === folderWorkspaceId
+  )
+  const matchingOwners = ownerCandidates.filter(
+    (workspace) =>
+      getFolderWorkspaceHostIdFromGroups(
+        workspace,
+        state.projectGroups ?? [],
+        getSettingsFocusedExecutionHostId(state.settings)
+      ) === preferredHostId
+  )
+  if (matchingOwners.length === 1) {
+    return matchingOwners[0]!
+  }
+  const hasAuthoritativeOwner = ownerCandidates.some(
+    (workspace) =>
+      Boolean(parseExecutionHostId(workspace.executionHostId) || workspace.connectionId?.trim()) ||
+      (state.projectGroups ?? []).some(
+        (group) =>
+          group.id === workspace.projectGroupId &&
+          Boolean(parseExecutionHostId(group.executionHostId) || group.connectionId?.trim())
+      )
+  )
+  return hasAuthoritativeOwner ? null : indexedOwner
 }
 
 function findFolderProjectGroup(

--- a/src/renderer/src/lib/worktree-activation-emptied-workspace-reseed.test.ts
+++ b/src/renderer/src/lib/worktree-activation-emptied-workspace-reseed.test.ts
@@ -203,11 +203,15 @@ function seedEmptiedFolderWorkspaceOnTwoHosts(): void {
 describe('activating a folder workspace whose last terminal was closed', () => {
   it('re-seeds a terminal when the workspace is opened', () => {
     seedEmptiedFolderWorkspaceOnTwoHosts()
+    const revealWorktreeInSidebar = useAppStore.getState().revealWorktreeInSidebar
 
     const result = activateAndRevealFolderWorkspace(FOLDER_ID, { executionHostId: 'local' })
 
     expect(result).not.toBe(false)
     expect(useAppStore.getState().tabsByWorktree[FOLDER_KEY]).toHaveLength(1)
+    expect(revealWorktreeInSidebar).toHaveBeenCalledWith(FOLDER_KEY, {
+      executionHostId: 'local'
+    })
   })
 
   it('re-seeds when the restored active folder workspace is reopened on the same host', () => {

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -127,8 +127,11 @@ export function activateAndRevealFolderWorkspace(
     opts?.providesInitialSurface
   )
 
-  if (opts?.sidebarRevealBehavior) {
-    state.revealWorktreeInSidebar(workspaceKey, { behavior: opts.sidebarRevealBehavior })
+  if (opts?.sidebarRevealBehavior || opts?.executionHostId) {
+    state.revealWorktreeInSidebar(workspaceKey, {
+      ...(opts.sidebarRevealBehavior ? { behavior: opts.sidebarRevealBehavior } : {}),
+      ...(opts.executionHostId ? { executionHostId: opts.executionHostId } : {})
+    })
   } else {
     state.revealWorktreeInSidebar(workspaceKey)
   }

--- a/src/renderer/src/store/slices/folder-workspace-activation-and-activity.test.ts
+++ b/src/renderer/src/store/slices/folder-workspace-activation-and-activity.test.ts
@@ -121,6 +121,45 @@ describe('folder workspace generic activation and activity', () => {
     })
   })
 
+  it('clears unread only for the requested host when folder ids collide', async () => {
+    const localFolder = makeFolderWorkspace({ executionHostId: 'local', isUnread: true })
+    const runtimeFolder = makeFolderWorkspace({
+      executionHostId: 'runtime:env-1',
+      folderPath: '/runtime/folder',
+      isUnread: true
+    })
+    const updateFolderWorkspace = vi.fn().mockResolvedValue(true)
+    const store = createTestStore()
+    store.setState({
+      projectGroups: [
+        { ...projectGroup, executionHostId: 'local' },
+        { ...projectGroup, executionHostId: 'runtime:env-1' }
+      ],
+      folderWorkspaces: [localFolder, runtimeFolder],
+      refreshGitHubForWorktreeIfStale: vi.fn(),
+      updateFolderWorkspace
+    } as Partial<AppState>)
+
+    store.getState().setActiveWorktree(folderWorkspaceKey(runtimeFolder.id), 'runtime:env-1')
+    await Promise.resolve()
+
+    expect(
+      store.getState().folderWorkspaces.map((workspace) => ({
+        hostId: workspace.executionHostId,
+        isUnread: workspace.isUnread
+      }))
+    ).toEqual([
+      { hostId: 'local', isUnread: true },
+      { hostId: 'runtime:env-1', isUnread: false }
+    ])
+    expect(store.getState().activeWorkspaceExecutionHostId).toBe('runtime:env-1')
+    expect(updateFolderWorkspace).toHaveBeenCalledWith(
+      runtimeFolder.id,
+      { isUnread: false },
+      { executionHostId: 'runtime:env-1' }
+    )
+  })
+
   it('coalesces repeated activity persistence while keeping local activity current', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(1_000)

--- a/src/renderer/src/store/slices/folder-workspace-owner-routed-mutations.test.ts
+++ b/src/renderer/src/store/slices/folder-workspace-owner-routed-mutations.test.ts
@@ -107,7 +107,13 @@ describe('folder workspace owner-routed mutations', () => {
     })
 
     await expect(
-      store.getState().updateFolderWorkspace(folderWorkspace.id, { comment: 'Ready' })
+      store
+        .getState()
+        .updateFolderWorkspace(
+          folderWorkspace.id,
+          { comment: 'Ready' },
+          { executionHostId: 'runtime:env-owner' }
+        )
     ).resolves.toBe(true)
 
     expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
@@ -427,5 +433,38 @@ describe('folder workspace owner-routed mutations', () => {
       timeoutMs: 15_000
     })
     expect(folderWorkspacesDelete).not.toHaveBeenCalled()
+  })
+
+  it('deletes only the requested host when folder ids collide', async () => {
+    const localFolder = makeFolderWorkspace({ executionHostId: 'local' })
+    const runtimeFolder = makeFolderWorkspace({
+      executionHostId: 'runtime:env-owner',
+      folderPath: '/runtime/folder'
+    })
+    const purgeWorktreeTerminalState = vi.fn()
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-delete-colliding-folder',
+      ok: true,
+      result: { deleted: true },
+      _meta: { runtimeId: 'runtime-owner' }
+    })
+    const store = createTestStore()
+    store.setState({
+      projectGroups: [
+        { ...projectGroup, executionHostId: 'local' },
+        { ...projectGroup, executionHostId: 'runtime:env-owner' }
+      ],
+      folderWorkspaces: [localFolder, runtimeFolder],
+      purgeWorktreeTerminalState
+    })
+
+    await expect(
+      store
+        .getState()
+        .deleteFolderWorkspace(runtimeFolder.id, { executionHostId: 'runtime:env-owner' })
+    ).resolves.toBe(true)
+
+    expect(store.getState().folderWorkspaces).toEqual([localFolder])
+    expect(purgeWorktreeTerminalState).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/store/slices/repos-catalog-merge-identity.test.ts
+++ b/src/renderer/src/store/slices/repos-catalog-merge-identity.test.ts
@@ -136,6 +136,26 @@ describe('catalog merge referential stability', () => {
     expect(store.getState().folderWorkspaces[0]).toBe(firstEntry)
   })
 
+  it('stamps a legacy folder from its runtime-owned project group', async () => {
+    const store = createTestStore()
+    store.setState({
+      projectGroups: [
+        {
+          ...projectGroup,
+          connectionId: 'legacy-ssh',
+          executionHostId: 'runtime:env-1'
+        }
+      ]
+    })
+    folderWorkspacesList.mockResolvedValue([
+      clone({ ...folderWorkspace, connectionId: 'legacy-ssh', executionHostId: undefined })
+    ])
+
+    await store.getState().fetchFolderWorkspaces()
+
+    expect(store.getState().folderWorkspaces[0]?.executionHostId).toBe('runtime:env-1')
+  })
+
   it('appends new entries and replaces changed ones while keeping order', async () => {
     const store = createTestStore()
 

--- a/src/renderer/src/store/slices/repos-folder-path-status-host-identity.test.ts
+++ b/src/renderer/src/store/slices/repos-folder-path-status-host-identity.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { FolderWorkspace } from '../../../../shared/folder-workspace-types'
+import type { ProjectGroup } from '../../../../shared/project-group-types'
+import {
+  createCompatibleRuntimeStatusResponseIfNeeded,
+  type RuntimeEnvironmentCallRequest
+} from '../../runtime/runtime-compatibility-test-fixture'
+import { clearRuntimeCompatibilityCacheForTests } from '../../runtime/runtime-rpc-client'
+import { createTestStore } from './store-test-helpers'
+
+const folderWorkspacesGetPathStatus = vi.fn()
+const runtimeEnvironmentCall = vi.fn()
+
+function projectGroup(executionHostId: 'local' | 'runtime:env-1'): ProjectGroup {
+  return {
+    id: 'same-group',
+    name: 'Same group',
+    parentPath: executionHostId === 'local' ? '/local/group' : '/runtime/group',
+    parentGroupId: null,
+    createdFrom: 'manual',
+    tabOrder: 0,
+    isCollapsed: false,
+    color: null,
+    createdAt: 1,
+    updatedAt: 1,
+    executionHostId
+  }
+}
+
+function folderWorkspace(executionHostId: 'local' | 'runtime:env-1'): FolderWorkspace {
+  return {
+    id: 'same-folder',
+    projectGroupId: 'same-group',
+    name: 'Same folder',
+    folderPath: executionHostId === 'local' ? '/local/folder' : '/runtime/folder',
+    linkedTask: null,
+    comment: '',
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 1,
+    lastActivityAt: 0,
+    createdAt: 1,
+    updatedAt: 1,
+    executionHostId
+  }
+}
+
+beforeEach(() => {
+  clearRuntimeCompatibilityCacheForTests()
+  folderWorkspacesGetPathStatus.mockReset()
+  folderWorkspacesGetPathStatus.mockResolvedValue({ path: '/local/folder', exists: true })
+  runtimeEnvironmentCall.mockReset()
+  runtimeEnvironmentCall.mockResolvedValue({
+    id: 'rpc-runtime-folder-status',
+    ok: true,
+    result: { status: { path: '/runtime/folder', exists: true } },
+    _meta: { runtimeId: 'runtime-remote' }
+  })
+  vi.stubGlobal('window', {
+    api: {
+      folderWorkspaces: { getPathStatus: folderWorkspacesGetPathStatus },
+      runtimeEnvironments: {
+        call: (args: RuntimeEnvironmentCallRequest) =>
+          createCompatibleRuntimeStatusResponseIfNeeded(args) ?? runtimeEnvironmentCall(args)
+      }
+    }
+  })
+})
+
+describe('folder path status host identity', () => {
+  it('keeps same-id local and runtime snapshots separate', async () => {
+    const request = { scope: 'folder-workspace' as const, folderWorkspaceId: 'same-folder' }
+    const store = createTestStore()
+    store.setState({
+      projectGroups: [projectGroup('local'), projectGroup('runtime:env-1')],
+      folderWorkspaces: [folderWorkspace('local'), folderWorkspace('runtime:env-1')]
+    })
+
+    await store
+      .getState()
+      .fetchFolderWorkspacePathStatus(request, { force: true, runtimeEnvironmentId: null })
+    await store
+      .getState()
+      .fetchFolderWorkspacePathStatus(request, { force: true, runtimeEnvironmentId: 'env-1' })
+
+    expect(
+      store.getState().getFreshFolderWorkspacePathStatus(request, { runtimeEnvironmentId: null })
+    ).toEqual({ path: '/local/folder', exists: true })
+    expect(
+      store.getState().getFreshFolderWorkspacePathStatus(request, { runtimeEnvironmentId: 'env-1' })
+    ).toEqual({ path: '/runtime/folder', exists: true })
+  })
+})

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -1164,9 +1164,24 @@ function mergeFetchedProjectGroupsForHost(
 }
 
 function getCatalogFolderWorkspaceHostId(
-  workspace: FolderWorkspace,
+  workspace: Pick<FolderWorkspace, 'connectionId' | 'executionHostId' | 'projectGroupId'>,
   projectGroups: readonly ProjectGroup[]
 ): ExecutionHostId {
+  return getFolderWorkspaceHostIdFromGroups(workspace, projectGroups, LOCAL_EXECUTION_HOST_ID)
+}
+
+// Why: a legacy direct-SSH row can outlive its group during independent catalog refreshes.
+function getLegacyCompatibleCatalogFolderWorkspaceHostId(
+  workspace: Pick<FolderWorkspace, 'connectionId' | 'executionHostId' | 'projectGroupId'>,
+  projectGroups: readonly ProjectGroup[]
+): ExecutionHostId {
+  const explicitHostId = parseExecutionHostId(workspace.executionHostId)?.id
+  if (explicitHostId) {
+    return explicitHostId
+  }
+  if (workspace.connectionId) {
+    return toSshExecutionHostId(workspace.connectionId)
+  }
   return getFolderWorkspaceHostIdFromGroups(workspace, projectGroups, LOCAL_EXECUTION_HOST_ID)
 }
 
@@ -1199,7 +1214,7 @@ function mergeFetchedFolderWorkspacesForHost({
     fetched.map((workspace) => getFolderWorkspaceHostIdentity(workspace, projectGroups))
   )
   const preserved = previous.filter((workspace) => {
-    const existingHostId = getCatalogFolderWorkspaceHostId(workspace, projectGroups)
+    const existingHostId = getLegacyCompatibleCatalogFolderWorkspaceHostId(workspace, projectGroups)
     return (
       !catalogOwnsHost(hostId, existingHostId) ||
       fetchedIdentities.has(getFolderWorkspaceHostIdentity(workspace, projectGroups))
@@ -1893,7 +1908,10 @@ export type RepoSlice = {
     updates: FolderWorkspaceUpdates,
     options?: { executionHostId?: ExecutionHostId }
   ) => Promise<boolean>
-  deleteFolderWorkspace: (folderWorkspaceId: string) => Promise<boolean>
+  deleteFolderWorkspace: (
+    folderWorkspaceId: string,
+    options?: { executionHostId?: ExecutionHostId }
+  ) => Promise<boolean>
   updateProjectGroup: (
     groupId: string,
     updates: Partial<Pick<ProjectGroup, 'name' | 'isCollapsed' | 'tabOrder' | 'color'>>
@@ -2967,12 +2985,19 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
     }
   },
 
-  deleteFolderWorkspace: async (folderWorkspaceId) => {
+  deleteFolderWorkspace: async (folderWorkspaceId, options) => {
     const state = get()
-    if (!findFolderWorkspaceOwner(state, folderWorkspaceId)) {
+    const owner = findFolderWorkspaceOwner(state, folderWorkspaceId, options?.executionHostId)
+    if (!owner) {
       return false
     }
-    const runtimeEnvironmentId = getRuntimeEnvironmentIdForFolderWorkspace(state, folderWorkspaceId)
+    const ownerHostId =
+      options?.executionHostId ?? getCatalogFolderWorkspaceHostId(owner, state.projectGroups)
+    const runtimeEnvironmentId = getRuntimeEnvironmentIdForFolderWorkspace(
+      state,
+      folderWorkspaceId,
+      ownerHostId
+    )
     try {
       // Why: deletion targets the folder's owner; focus may be on a different host.
       const target = getActiveRuntimeTarget({ activeRuntimeEnvironmentId: runtimeEnvironmentId })
@@ -2991,13 +3016,21 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
         return false
       }
       const workspaceKey = folderWorkspaceKey(folderWorkspaceId)
-      set((s) => ({
-        folderWorkspaces: s.folderWorkspaces.filter(
-          (workspace) => workspace.id !== folderWorkspaceId
-        ),
-        folderWorkspacePathStatuses: {}
-      }))
-      get().purgeWorktreeTerminalState([workspaceKey])
+      let shouldPurgeTerminalState = false
+      set((s) => {
+        const folderWorkspaces = s.folderWorkspaces.filter(
+          (workspace) =>
+            workspace.id !== folderWorkspaceId ||
+            getCatalogFolderWorkspaceHostId(workspace, s.projectGroups) !== ownerHostId
+        )
+        shouldPurgeTerminalState = !folderWorkspaces.some(
+          (workspace) => workspace.id === folderWorkspaceId
+        )
+        return { folderWorkspaces, folderWorkspacePathStatuses: {} }
+      })
+      if (shouldPurgeTerminalState) {
+        get().purgeWorktreeTerminalState([workspaceKey])
+      }
       return true
     } catch (err) {
       console.error('Failed to delete folder workspace:', err)

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -88,6 +88,7 @@ import {
   getRepoExecutionHostId,
   isRuntimeOwnedSshTargetId,
   LOCAL_EXECUTION_HOST_ID,
+  normalizeExecutionHostId,
   parseExecutionHostId,
   toRuntimeExecutionHostId,
   toSshExecutionHostId,
@@ -100,6 +101,7 @@ import {
 } from '../../../../shared/worktree/visibility-sources'
 import { cleanupEphemeralVmRuntimesForDeleted } from '@/lib/ephemeral-vm-runtime-cleanup'
 import { folderWorkspaceKey, parseWorkspaceKey } from '../../../../shared/workspace-scope'
+import { getFolderWorkspaceHostIdFromGroups } from '../../../../shared/folder-workspace-host'
 import { formatFolderWorkspaceCreateError } from '../../lib/folder-workspace-path-status'
 import { getEnvironmentSshStateGeneration } from './runtime-environment-ssh'
 import { getRuntimeEnvironmentConnectionGeneration } from './runtime-status'
@@ -1120,9 +1122,12 @@ function mergeProjectCompatibilityForHostRepoChange({
   })
 }
 
-function getProjectGroupHostId(group: Pick<ProjectGroup, 'connectionId' | 'executionHostId'>) {
-  if (group.executionHostId) {
-    return group.executionHostId
+function getProjectGroupHostId(
+  group: Pick<ProjectGroup, 'connectionId' | 'executionHostId'>
+): ExecutionHostId {
+  const executionHostId = normalizeExecutionHostId(group.executionHostId)
+  if (executionHostId) {
+    return executionHostId
   }
   return group.connectionId ? toSshExecutionHostId(group.connectionId) : LOCAL_EXECUTION_HOST_ID
 }
@@ -1158,32 +1163,18 @@ function mergeFetchedProjectGroupsForHost(
   )
 }
 
-function getFolderWorkspaceHostId(
+function getCatalogFolderWorkspaceHostId(
   workspace: FolderWorkspace,
   projectGroups: readonly ProjectGroup[]
 ): ExecutionHostId {
-  const explicitHostId = parseExecutionHostId(workspace.executionHostId)?.id
-  if (explicitHostId) {
-    return explicitHostId
-  }
-  if (workspace.connectionId) {
-    return toSshExecutionHostId(workspace.connectionId)
-  }
-  const matchingHosts = new Set(
-    projectGroups
-      .filter((group) => group.id === workspace.projectGroupId)
-      .map(getProjectGroupHostId)
-  )
-  return matchingHosts.size === 1
-    ? ([...matchingHosts][0] as ExecutionHostId)
-    : LOCAL_EXECUTION_HOST_ID
+  return getFolderWorkspaceHostIdFromGroups(workspace, projectGroups, LOCAL_EXECUTION_HOST_ID)
 }
 
 function getFolderWorkspaceHostIdentity(
   workspace: FolderWorkspace,
   projectGroups: readonly ProjectGroup[]
 ): string {
-  return JSON.stringify([getFolderWorkspaceHostId(workspace, projectGroups), workspace.id])
+  return JSON.stringify([getCatalogFolderWorkspaceHostId(workspace, projectGroups), workspace.id])
 }
 
 function getFolderWorkspaceUpdateIdentity(
@@ -1208,7 +1199,7 @@ function mergeFetchedFolderWorkspacesForHost({
     fetched.map((workspace) => getFolderWorkspaceHostIdentity(workspace, projectGroups))
   )
   const preserved = previous.filter((workspace) => {
-    const existingHostId = getFolderWorkspaceHostId(workspace, projectGroups)
+    const existingHostId = getCatalogFolderWorkspaceHostId(workspace, projectGroups)
     return (
       !catalogOwnsHost(hostId, existingHostId) ||
       fetchedIdentities.has(getFolderWorkspaceHostIdentity(workspace, projectGroups))
@@ -1247,13 +1238,13 @@ function getFolderWorkspaceCatalogReplacementIdentities(
   const replacedIdentities = new Set(
     catalog.folderWorkspaces.map((workspace) =>
       getFolderWorkspaceUpdateIdentity(
-        getFolderWorkspaceHostId(workspace, projectGroups),
+        getCatalogFolderWorkspaceHostId(workspace, projectGroups),
         workspace.id
       )
     )
   )
   for (const workspace of currentFolderWorkspaces) {
-    const hostId = getFolderWorkspaceHostId(workspace, projectGroups)
+    const hostId = getCatalogFolderWorkspaceHostId(workspace, projectGroups)
     if (catalogOwnsHost(catalog.hostId, hostId)) {
       replacedIdentities.add(getFolderWorkspaceUpdateIdentity(hostId, workspace.id))
     }
@@ -1461,7 +1452,7 @@ function folderWorkspaceWithFetchedOwner(
     executionHostId:
       target.kind === 'environment'
         ? getRuntimeTargetHostId(target)
-        : getFolderWorkspaceHostId(workspace, projectGroups)
+        : getCatalogFolderWorkspaceHostId(workspace, projectGroups)
   }
 }
 
@@ -1510,14 +1501,14 @@ async function reconcileFailedFolderWorkspaceUpdate(args: {
       folderWorkspaces: refreshed
         ? state.folderWorkspaces.map((workspace) =>
             workspace.id === args.folderWorkspaceId &&
-            getFolderWorkspaceHostId(workspace, state.projectGroups) === args.ownerHostId
+            getCatalogFolderWorkspaceHostId(workspace, state.projectGroups) === args.ownerHostId
               ? mergeFolderWorkspaceUpdateResponse(workspace, refreshed, latestFields)
               : workspace
           )
         : state.folderWorkspaces.filter(
             (workspace) =>
               workspace.id !== args.folderWorkspaceId ||
-              getFolderWorkspaceHostId(workspace, state.projectGroups) !== args.ownerHostId
+              getCatalogFolderWorkspaceHostId(workspace, state.projectGroups) !== args.ownerHostId
           ),
       ...(folderWorkspaceUpdateInvalidatesPathStatus(latestFields) || !refreshed
         ? { folderWorkspacePathStatuses: {} }
@@ -1671,7 +1662,8 @@ async function fetchRuntimeAddProjectPathStatus(args: {
 
 function getFolderWorkspaceStatusRequestSnapshot(
   state: Pick<AppState, 'projectGroups' | 'folderWorkspaces' | 'repos' | 'sshConnectionStates'>,
-  request: FolderWorkspacePathStatusRequest
+  request: FolderWorkspacePathStatusRequest,
+  options?: FolderWorkspacePathStatusRouteOptions
 ): string | null {
   if (request.scope === 'path') {
     const candidateRepos = state.repos.filter((repo) =>
@@ -1704,18 +1696,36 @@ function getFolderWorkspaceStatusRequestSnapshot(
     )
   }
 
-  const scope =
+  const runtimeHostId = options?.runtimeEnvironmentId
+    ? toRuntimeExecutionHostId(options.runtimeEnvironmentId)
+    : null
+  const excludeRuntimeHosts = options?.runtimeEnvironmentId === null
+  const matchesRouteHost = (hostId: ExecutionHostId): boolean =>
+    runtimeHostId
+      ? hostId === runtimeHostId
+      : !excludeRuntimeHosts || parseExecutionHostId(hostId)?.kind !== 'runtime'
+  const scopeCandidates =
     request.scope === 'project-group'
-      ? state.projectGroups.find((group) => group.id === request.projectGroupId)
-      : state.folderWorkspaces.find((workspace) => workspace.id === request.folderWorkspaceId)
+      ? state.projectGroups.filter((group) => group.id === request.projectGroupId)
+      : state.folderWorkspaces.filter((workspace) => workspace.id === request.folderWorkspaceId)
+  const scope =
+    scopeCandidates.find((candidate) =>
+      'parentPath' in candidate
+        ? matchesRouteHost(getProjectGroupHostId(candidate))
+        : matchesRouteHost(getCatalogFolderWorkspaceHostId(candidate, state.projectGroups))
+    ) ?? scopeCandidates[0]
+  const matchingProjectGroups =
+    scope && 'projectGroupId' in scope
+      ? state.projectGroups.filter((group) => group.id === scope.projectGroupId)
+      : []
   const projectGroup =
     request.scope === 'project-group'
       ? scope && 'parentPath' in scope
         ? scope
         : null
-      : scope && 'projectGroupId' in scope
-        ? state.projectGroups.find((group) => group.id === scope.projectGroupId)
-        : null
+      : (matchingProjectGroups.find((group) => matchesRouteHost(getProjectGroupHostId(group))) ??
+        matchingProjectGroups[0] ??
+        null)
   const folderPath =
     request.scope === 'project-group'
       ? scope && 'parentPath' in scope
@@ -1791,9 +1801,10 @@ function getFreshFolderWorkspacePathStatusFromCache(args: {
 
 function getFolderWorkspacePathStatusRequestSnapshotForRead(
   state: AppState,
-  request: FolderWorkspacePathStatusRequest
+  request: FolderWorkspacePathStatusRequest,
+  options?: FolderWorkspacePathStatusRouteOptions
 ): string | null {
-  return getFolderWorkspaceStatusRequestSnapshot(state, request)
+  return getFolderWorkspaceStatusRequestSnapshot(state, request, options)
 }
 
 export type RepoSlice = {
@@ -2626,13 +2637,17 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
     const state = get()
     const cacheKey = get().getFolderWorkspacePathStatusCacheKey(request, options)
     const cached = state.folderWorkspacePathStatuses[cacheKey]
-    const requestSnapshot = getFolderWorkspacePathStatusRequestSnapshotForRead(state, request)
+    const requestSnapshot = getFolderWorkspacePathStatusRequestSnapshotForRead(
+      state,
+      request,
+      options
+    )
     return getFreshFolderWorkspacePathStatusFromCache({ entry: cached, requestSnapshot })
   },
 
   fetchFolderWorkspacePathStatus: async (request, options) => {
     const cacheKey = get().getFolderWorkspacePathStatusCacheKey(request, options)
-    const requestSnapshot = getFolderWorkspaceStatusRequestSnapshot(get(), request)
+    const requestSnapshot = getFolderWorkspaceStatusRequestSnapshot(get(), request, options)
     const cached = get().folderWorkspacePathStatuses[cacheKey]
     const freshCachedStatus = getFreshFolderWorkspacePathStatusFromCache({
       entry: cached,
@@ -2659,7 +2674,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       set((state) => ({
         folderWorkspacePathStatuses:
           requestSnapshot !== null &&
-          getFolderWorkspaceStatusRequestSnapshot(state, request) === requestSnapshot
+          getFolderWorkspaceStatusRequestSnapshot(state, request, options) === requestSnapshot
             ? {
                 ...state.folderWorkspacePathStatuses,
                 [cacheKey]: { status, checkedAt: Date.now(), requestSnapshot }
@@ -2922,7 +2937,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
         set((s) => ({
           folderWorkspaces: s.folderWorkspaces.map((workspace) =>
             workspace.id === folderWorkspaceId &&
-            getFolderWorkspaceHostId(workspace, s.projectGroups) === ownerHostId
+            getCatalogFolderWorkspaceHostId(workspace, s.projectGroups) === ownerHostId
               ? mergeFolderWorkspaceUpdateResponse(workspace, updated, latestFields, {
                   rejectOlderResponse: catalogChanged
                 })

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -76,6 +76,7 @@ export type WorktreeMetaUpdateGuard = (worktree: Worktree | DetectedWorktree | u
 
 export type WorktreeMetaUpdateOptions = {
   shouldApply?: WorktreeMetaUpdateGuard
+  executionHostId?: ExecutionHostId
   /** Skip the automatic review refetch when the caller owns an equivalent refresh. */
   suppressHostedReviewRefresh?: boolean
 }

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -283,7 +283,7 @@ export type WorktreeSlice = {
    * the shortcut action visible even though pinned worktrees also remain in
    * their normal sidebar groups.
    */
-  setWorktreesPinnedAndReveal: (worktreeIds: readonly string[], isPinned: boolean) => void
+  setWorktreesPinnedAndReveal(ids: readonly string[], pinned: boolean, host?: ExecutionHostId): void
   markWorktreeUnread: (worktreeId: string) => void
   observeTerminalGitHubPullRequestLink: (worktreeId: string, link: TerminalGitHubPRLink) => void
   /** Clear the worktree's unread dot. Called on user interaction with any

--- a/src/renderer/src/store/slices/worktrees/listing/detected-folder-workspace-host-identity.test.ts
+++ b/src/renderer/src/store/slices/worktrees/listing/detected-folder-workspace-host-identity.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import type { AppState } from '../../../types'
+import type { FolderWorkspace } from '../../../../../../shared/folder-workspace-types'
+import type { ProjectGroup } from '../../../../../../shared/project-group-types'
+import { getDefaultSettings } from '../../../../../../shared/constants'
+import { folderWorkspaceKey } from '../../../../../../shared/workspace-scope'
+import { findKnownWorktreeById } from './detected-worktree-meta'
+
+const folderWorkspace: FolderWorkspace = {
+  id: 'folder-shared',
+  projectGroupId: 'group-shared',
+  name: 'Runtime folder',
+  folderPath: '/runtime/folder',
+  linkedTask: null,
+  comment: '',
+  isArchived: false,
+  isUnread: false,
+  isPinned: false,
+  sortOrder: 0,
+  lastActivityAt: 1,
+  createdAt: 1,
+  updatedAt: 1,
+  connectionId: 'legacy-target'
+}
+
+const projectGroup: ProjectGroup = {
+  id: folderWorkspace.projectGroupId,
+  name: 'Runtime group',
+  parentPath: '/runtime',
+  parentGroupId: null,
+  createdFrom: 'manual',
+  tabOrder: 0,
+  isCollapsed: false,
+  color: null,
+  createdAt: 1,
+  updatedAt: 1,
+  executionHostId: 'runtime:env-1'
+}
+
+describe('detected folder workspace host identity', () => {
+  it('projects legacy folder records through the owning group host', () => {
+    const state = {
+      worktreesByRepo: {},
+      detectedWorktreesByRepo: {},
+      folderWorkspaces: [folderWorkspace],
+      projectGroups: [projectGroup],
+      settings: getDefaultSettings('/tmp')
+    } as Pick<
+      AppState,
+      | 'worktreesByRepo'
+      | 'detectedWorktreesByRepo'
+      | 'folderWorkspaces'
+      | 'projectGroups'
+      | 'settings'
+    >
+
+    expect(
+      findKnownWorktreeById(state, folderWorkspaceKey(folderWorkspace.id), 'runtime:env-1')
+    ).toMatchObject({ hostId: 'runtime:env-1', displayName: folderWorkspace.name })
+  })
+
+  it('uses the focused host only when folder and group ownership are absent', () => {
+    const legacyFolder = { ...folderWorkspace, connectionId: undefined }
+    const legacyGroup = { ...projectGroup, executionHostId: undefined }
+    const state = {
+      worktreesByRepo: {},
+      detectedWorktreesByRepo: {},
+      folderWorkspaces: [legacyFolder],
+      projectGroups: [legacyGroup],
+      settings: { ...getDefaultSettings('/tmp'), activeRuntimeEnvironmentId: 'focused' }
+    } as Pick<
+      AppState,
+      | 'worktreesByRepo'
+      | 'detectedWorktreesByRepo'
+      | 'folderWorkspaces'
+      | 'projectGroups'
+      | 'settings'
+    >
+
+    expect(
+      findKnownWorktreeById(state, folderWorkspaceKey(legacyFolder.id), 'runtime:other')
+    ).toBeUndefined()
+    expect(
+      findKnownWorktreeById(state, folderWorkspaceKey(legacyFolder.id), 'runtime:focused')
+    ).toMatchObject({ hostId: 'runtime:focused' })
+  })
+})

--- a/src/renderer/src/store/slices/worktrees/listing/detected-worktree-meta.ts
+++ b/src/renderer/src/store/slices/worktrees/listing/detected-worktree-meta.ts
@@ -1,20 +1,21 @@
 import type { AppState } from '../../../types'
 import type { FolderWorkspace } from '../../../../../../shared/folder-workspace-types'
+import type { ProjectGroup } from '../../../../../../shared/project-group-types'
 import type { WorktreeMeta } from '../../../../../../shared/worktree/meta-types'
 import type { DetectedWorktreeListResult, Worktree } from '../../../../../../shared/worktree/types'
 import type { ExecutionHostId } from '../../../../../../shared/execution-host'
 import {
-  LOCAL_EXECUTION_HOST_ID,
-  parseExecutionHostId,
-  toSshExecutionHostId
+  getSettingsFocusedExecutionHostId,
+  LOCAL_EXECUTION_HOST_ID
 } from '../../../../../../shared/execution-host'
 import { parseWorkspaceKey } from '../../../../../../shared/workspace-scope'
-import { folderWorkspaceToWorktree } from '../../../../../../shared/folder-workspace-worktree'
+import { folderWorkspaceToWorktreeForHost } from '../../../../../../shared/folder-workspace-worktree'
+import { getFolderWorkspaceHostIdFromGroups } from '../../../../../../shared/folder-workspace-host'
 import { findIndexedWorktreeOwnerForHost } from '@/lib/worktree-runtime-owner-index'
 import { findWorktreeById, withoutErasedRequiredWorktreeFields } from '../../worktree-helpers'
 import { worktreeMatchesHost } from './worktree-host-ownership'
 
-const folderWorkspaceWorktreeCache = new WeakMap<FolderWorkspace, Worktree>()
+const folderWorkspaceWorktreeCache = new WeakMap<FolderWorkspace, Map<ExecutionHostId, Worktree>>()
 
 export function applyDetectedWorktreeUpdates(
   detectedWorktreesByRepo: AppState['detectedWorktreesByRepo'],
@@ -43,38 +44,51 @@ export function applyDetectedWorktreeUpdates(
 }
 
 export function folderWorkspaceMatchesHost(
-  workspace: Pick<FolderWorkspace, 'connectionId' | 'executionHostId'>,
+  workspace: Pick<FolderWorkspace, 'connectionId' | 'executionHostId' | 'projectGroupId'>,
+  projectGroups: readonly Pick<ProjectGroup, 'id' | 'connectionId' | 'executionHostId'>[],
   executionHostId: ExecutionHostId
 ): boolean {
   return (
-    (parseExecutionHostId(workspace.executionHostId)?.id ??
-      (workspace.connectionId?.trim()
-        ? toSshExecutionHostId(workspace.connectionId)
-        : LOCAL_EXECUTION_HOST_ID)) === executionHostId
+    getFolderWorkspaceHostIdFromGroups(workspace, projectGroups, executionHostId) ===
+    executionHostId
   )
 }
 
 export function findKnownWorktreeById(
-  state: Pick<AppState, 'worktreesByRepo' | 'detectedWorktreesByRepo' | 'folderWorkspaces'>,
+  state: Pick<
+    AppState,
+    | 'worktreesByRepo'
+    | 'detectedWorktreesByRepo'
+    | 'folderWorkspaces'
+    | 'projectGroups'
+    | 'settings'
+  >,
   worktreeId: string,
   executionHostId?: ExecutionHostId
 ): Worktree | DetectedWorktreeListResult['worktrees'][number] | undefined {
   const workspaceScope = parseWorkspaceKey(worktreeId)
   if (workspaceScope?.type === 'folder') {
+    const projectGroups = state.projectGroups ?? []
+    const defaultHostId = getSettingsFocusedExecutionHostId(state.settings)
     const folderWorkspace = state.folderWorkspaces.find(
       (workspace) =>
         workspace.id === workspaceScope.folderWorkspaceId &&
-        (!executionHostId || folderWorkspaceMatchesHost(workspace, executionHostId))
+        (!executionHostId ||
+          getFolderWorkspaceHostIdFromGroups(workspace, projectGroups, defaultHostId) ===
+            executionHostId)
     )
     if (!folderWorkspace) {
       return undefined
     }
-    const cached = folderWorkspaceWorktreeCache.get(folderWorkspace)
+    const hostId = getFolderWorkspaceHostIdFromGroups(folderWorkspace, projectGroups, defaultHostId)
+    const cached = folderWorkspaceWorktreeCache.get(folderWorkspace)?.get(hostId)
     if (cached) {
       return cached
     }
-    const worktree = folderWorkspaceToWorktree(folderWorkspace)
-    folderWorkspaceWorktreeCache.set(folderWorkspace, worktree)
+    const worktree = folderWorkspaceToWorktreeForHost(folderWorkspace, hostId)
+    const byHost = folderWorkspaceWorktreeCache.get(folderWorkspace) ?? new Map()
+    byHost.set(hostId, worktree)
+    folderWorkspaceWorktreeCache.set(folderWorkspace, byHost)
     return worktree
   }
   const visible = executionHostId

--- a/src/renderer/src/store/slices/worktrees/metadata/update-worktree-meta.ts
+++ b/src/renderer/src/store/slices/worktrees/metadata/update-worktree-meta.ts
@@ -34,7 +34,7 @@ export function createUpdateWorktreeMeta(
 ): WorktreeSlice['updateWorktreeMeta'] {
   return async (worktreeId, updates, options) => {
     const shouldApplyUpdate = options?.shouldApply
-    const existingWorktree = get().getKnownWorktreeById(worktreeId)
+    const existingWorktree = get().getKnownWorktreeById(worktreeId, options?.executionHostId)
     if (shouldApplyUpdate && !shouldApplyUpdate(existingWorktree)) {
       return { ok: true }
     }
@@ -49,7 +49,8 @@ export function createUpdateWorktreeMeta(
         // reporting ok would show the dialog a save that silently undid itself.
         const updated = await get().updateFolderWorkspace(
           workspaceScope.folderWorkspaceId,
-          folderUpdates
+          folderUpdates,
+          options?.executionHostId ? { executionHostId: options.executionHostId } : undefined
         )
         return updated
           ? { ok: true }

--- a/src/renderer/src/store/slices/worktrees/session/set-active-folder-workspace.ts
+++ b/src/renderer/src/store/slices/worktrees/session/set-active-folder-workspace.ts
@@ -115,7 +115,8 @@ export function createSetActiveFolderWorkspace(
         folderWorkspaces: workspace.isUnread
           ? s.folderWorkspaces.map((entry) =>
               entry.id === folderWorkspaceId &&
-              (!executionHostId || folderWorkspaceMatchesHost(entry, executionHostId))
+              (!executionHostId ||
+                folderWorkspaceMatchesHost(entry, s.projectGroups, executionHostId))
                 ? { ...entry, isUnread: false }
                 : entry
             )

--- a/src/renderer/src/store/slices/worktrees/session/set-active-folder-workspace.ts
+++ b/src/renderer/src/store/slices/worktrees/session/set-active-folder-workspace.ts
@@ -3,11 +3,10 @@ import type { WorktreeSliceGet, WorktreeSliceSet } from '../listing/worktree-sli
 import { folderWorkspaceKey } from '../../../../../../shared/workspace-scope'
 import { markInputQuietSchedulerInput } from '@/lib/input-quiet-scheduler'
 import { moveFocusToRendererBeforeFocusedWebviewHidden } from '../../browser-webview-cleanup'
-import {
-  findKnownWorktreeById,
-  folderWorkspaceMatchesHost
-} from '../listing/detected-worktree-meta'
+import { findKnownWorktreeById } from '../listing/detected-worktree-meta'
 import { shouldDeferActivationTerminalPrep } from './activation-terminal-prep'
+import { getSettingsFocusedExecutionHostId } from '../../../../../../shared/execution-host'
+import { getFolderWorkspaceHostIdFromGroups } from '../../../../../../shared/folder-workspace-host'
 
 export function createSetActiveFolderWorkspace(
   set: WorktreeSliceSet,
@@ -19,6 +18,7 @@ export function createSetActiveFolderWorkspace(
     if (!workspace) {
       return
     }
+    const ownerHostId = workspace.hostId ?? getSettingsFocusedExecutionHostId(get().settings)
     if (shouldDeferActivationTerminalPrep()) {
       markInputQuietSchedulerInput()
     }
@@ -101,7 +101,7 @@ export function createSetActiveFolderWorkspace(
         activeRepoId: null,
         activeWorktreeId: workspaceKey,
         activeWorkspaceKey: workspaceKey,
-        activeWorkspaceExecutionHostId: executionHostId ?? null,
+        activeWorkspaceExecutionHostId: ownerHostId,
         activePendingCreationId: null,
         activeFileId,
         activeBrowserTabId,
@@ -115,8 +115,11 @@ export function createSetActiveFolderWorkspace(
         folderWorkspaces: workspace.isUnread
           ? s.folderWorkspaces.map((entry) =>
               entry.id === folderWorkspaceId &&
-              (!executionHostId ||
-                folderWorkspaceMatchesHost(entry, s.projectGroups, executionHostId))
+              getFolderWorkspaceHostIdFromGroups(
+                entry,
+                s.projectGroups,
+                getSettingsFocusedExecutionHostId(s.settings)
+              ) === ownerHostId
                 ? { ...entry, isUnread: false }
                 : entry
             )
@@ -127,7 +130,7 @@ export function createSetActiveFolderWorkspace(
       void get().updateFolderWorkspace(
         folderWorkspaceId,
         { isUnread: false },
-        executionHostId ? { executionHostId } : undefined
+        { executionHostId: ownerHostId }
       )
     }
   }

--- a/src/renderer/src/store/slices/worktrees/session/set-active-worktree.ts
+++ b/src/renderer/src/store/slices/worktrees/session/set-active-worktree.ts
@@ -28,6 +28,11 @@ import {
   pendingActivationTerminalPrepCancels,
   shouldDeferActivationTerminalPrep
 } from './activation-terminal-prep'
+import {
+  getSettingsFocusedExecutionHostId,
+  type ExecutionHostId
+} from '../../../../../../shared/execution-host'
+import { getFolderWorkspaceHostIdFromGroups } from '../../../../../../shared/folder-workspace-host'
 
 export function createSetActiveWorktree(
   set: WorktreeSliceSet,
@@ -52,6 +57,7 @@ export function createSetActiveWorktree(
     let shouldClearUnread = false
     let shouldPrepareTerminalTabs = false
     let shouldTagTerminalTabs = false
+    let folderOwnerHostId: ExecutionHostId | null = null
     set((current) => {
       const transitioned = stateTransition
         ? ({ ...current, ...stateTransition.patch } as AppState)
@@ -79,6 +85,11 @@ export function createSetActiveWorktree(
       }
 
       const worktree = findKnownWorktreeById(s, worktreeId, executionHostId)
+      const activeExecutionHostId =
+        workspaceScope?.type === 'folder'
+          ? (worktree?.hostId ?? executionHostId ?? getSettingsFocusedExecutionHostId(s.settings))
+          : (executionHostId ?? null)
+      folderOwnerHostId = workspaceScope?.type === 'folder' ? activeExecutionHostId : null
       shouldClearUnread = Boolean(worktree?.isUnread)
       const {
         restoredRightSidebarExplorerView,
@@ -124,7 +135,12 @@ export function createSetActiveWorktree(
       const nextFolderWorkspaces =
         shouldClearUnread && workspaceScope?.type === 'folder'
           ? s.folderWorkspaces.map((workspace) =>
-              workspace.id === workspaceScope.folderWorkspaceId
+              workspace.id === workspaceScope.folderWorkspaceId &&
+              getFolderWorkspaceHostIdFromGroups(
+                workspace,
+                s.projectGroups,
+                getSettingsFocusedExecutionHostId(s.settings)
+              ) === activeExecutionHostId
                 ? { ...workspace, isUnread: false }
                 : workspace
             )
@@ -157,7 +173,7 @@ export function createSetActiveWorktree(
           : { ...s.activeTabTypeByWorktree, [worktreeId]: activeTabType }
       const hasStateChange =
         s.activeWorktreeId !== worktreeId ||
-        s.activeWorkspaceExecutionHostId !== (executionHostId ?? null) ||
+        s.activeWorkspaceExecutionHostId !== activeExecutionHostId ||
         // Why: a pending-creation panel can show over the prior worktree; a non-null activePendingCreationId counts as a change.
         s.activePendingCreationId !== null ||
         s.activeFileId !== activeFileId ||
@@ -186,7 +202,7 @@ export function createSetActiveWorktree(
         activeWorkspaceKey: isWorkspaceKey(worktreeId)
           ? worktreeId
           : worktreeWorkspaceKey(worktreeId),
-        activeWorkspaceExecutionHostId: executionHostId ?? null,
+        activeWorkspaceExecutionHostId: activeExecutionHostId,
         activePendingCreationId: null,
         activeFileId,
         activeBrowserTabId,
@@ -266,7 +282,11 @@ export function createSetActiveWorktree(
 
     if (shouldClearUnread) {
       if (workspaceScope?.type === 'folder') {
-        void get().updateFolderWorkspace(workspaceScope.folderWorkspaceId, { isUnread: false })
+        void get().updateFolderWorkspace(
+          workspaceScope.folderWorkspaceId,
+          { isUnread: false },
+          folderOwnerHostId ? { executionHostId: folderOwnerHostId } : undefined
+        )
         return true
       }
       persistPassiveWorktreeMetaForOwner(

--- a/src/renderer/src/store/slices/worktrees/session/worktree-pin-reveal.ts
+++ b/src/renderer/src/store/slices/worktrees/session/worktree-pin-reveal.ts
@@ -59,7 +59,7 @@ export function createSetWorktreesPinnedAndReveal(
   _set: WorktreeSliceSet,
   get: WorktreeSliceGet
 ): WorktreeSlice['setWorktreesPinnedAndReveal'] {
-  return (worktreeIds, isPinned) => {
+  return (worktreeIds, isPinned, hostId) => {
     // Only follow a toggled row with the viewport when it's the focused worktree, not an unfocused card.
     const activeSidebarWorktreeId = getActiveSidebarWorkspaceId(
       get().activeWorkspaceKey,
@@ -71,7 +71,7 @@ export function createSetWorktreesPinnedAndReveal(
     let didChange = false
     let revealWorktreeId: string | null = null
     for (const worktreeId of worktreeIds) {
-      const current = get().getKnownWorktreeById(worktreeId)
+      const current = get().getKnownWorktreeById(worktreeId, hostId)
       if (!current || current.isPinned === isPinned) {
         continue
       }
@@ -79,7 +79,11 @@ export function createSetWorktreesPinnedAndReveal(
       changedWorktreeIds.add(worktreeId)
       const workspaceScope = parseWorkspaceKey(worktreeId)
       if (workspaceScope?.type === 'folder') {
-        void get().updateWorktreeMeta(worktreeId, { isPinned })
+        void get().updateWorktreeMeta(
+          worktreeId,
+          { isPinned },
+          hostId ? { executionHostId: hostId } : undefined
+        )
       } else {
         updates.set(worktreeId, { isPinned })
       }
@@ -103,7 +107,11 @@ export function createSetWorktreesPinnedAndReveal(
       void get().updateWorktreesMeta(updates)
     }
     if (revealWorktreeId !== null) {
-      get().revealWorktreeInSidebar(revealWorktreeId, { behavior: 'smooth', highlight: true })
+      get().revealWorktreeInSidebar(revealWorktreeId, {
+        behavior: 'smooth',
+        highlight: true,
+        ...(hostId ? { executionHostId: hostId } : {})
+      })
     }
   }
 }

--- a/src/shared/folder-workspace-host.ts
+++ b/src/shared/folder-workspace-host.ts
@@ -1,0 +1,57 @@
+import {
+  normalizeExecutionHostId,
+  toSshExecutionHostId,
+  type ExecutionHostId
+} from './execution-host'
+import type { FolderWorkspace } from './folder-workspace-types'
+import type { ProjectGroup } from './project-group-types'
+
+export function getFolderWorkspaceHostId(
+  folderWorkspace: Pick<FolderWorkspace, 'connectionId' | 'executionHostId'>,
+  projectGroup: Pick<ProjectGroup, 'connectionId' | 'executionHostId'> | null | undefined,
+  defaultHostId: ExecutionHostId
+): ExecutionHostId {
+  const executionHostId =
+    normalizeExecutionHostId(folderWorkspace.executionHostId) ??
+    normalizeExecutionHostId(projectGroup?.executionHostId)
+  if (executionHostId) {
+    return executionHostId
+  }
+  const connectionId = folderWorkspace.connectionId ?? projectGroup?.connectionId
+  return connectionId ? toSshExecutionHostId(connectionId) : defaultHostId
+}
+
+export function getFolderWorkspaceHostIdFromGroups(
+  folderWorkspace: Pick<FolderWorkspace, 'connectionId' | 'executionHostId' | 'projectGroupId'>,
+  projectGroups: readonly Pick<ProjectGroup, 'id' | 'connectionId' | 'executionHostId'>[],
+  defaultHostId: ExecutionHostId
+): ExecutionHostId {
+  const matchingGroups = projectGroups.filter(
+    (group) => group.id === folderWorkspace.projectGroupId
+  )
+  if (matchingGroups.length <= 1) {
+    return getFolderWorkspaceHostId(folderWorkspace, matchingGroups[0], defaultHostId)
+  }
+  const folderHostId = normalizeExecutionHostId(folderWorkspace.executionHostId)
+  if (folderHostId) {
+    return folderHostId
+  }
+  const groupExecutionHostIds = new Set(
+    matchingGroups
+      .map((group) => normalizeExecutionHostId(group.executionHostId))
+      .filter((hostId): hostId is ExecutionHostId => hostId !== null)
+  )
+  if (groupExecutionHostIds.size === 1) {
+    return [...groupExecutionHostIds][0]!
+  }
+  if (folderWorkspace.connectionId) {
+    return toSshExecutionHostId(folderWorkspace.connectionId)
+  }
+  const groupConnectionHostIds = new Set(
+    matchingGroups
+      .map((group) => group.connectionId)
+      .filter((connectionId): connectionId is string => Boolean(connectionId))
+      .map(toSshExecutionHostId)
+  )
+  return groupConnectionHostIds.size === 1 ? [...groupConnectionHostIds][0]! : defaultHostId
+}

--- a/src/shared/folder-workspace-host.ts
+++ b/src/shared/folder-workspace-host.ts
@@ -6,6 +6,16 @@ import {
 import type { FolderWorkspace } from './folder-workspace-types'
 import type { ProjectGroup } from './project-group-types'
 
+export function getProjectGroupHostId(
+  projectGroup: Pick<ProjectGroup, 'connectionId' | 'executionHostId'>,
+  defaultHostId: ExecutionHostId
+): ExecutionHostId {
+  return (
+    normalizeExecutionHostId(projectGroup.executionHostId) ??
+    (projectGroup.connectionId ? toSshExecutionHostId(projectGroup.connectionId) : defaultHostId)
+  )
+}
+
 export function getFolderWorkspaceHostId(
   folderWorkspace: Pick<FolderWorkspace, 'connectionId' | 'executionHostId'>,
   projectGroup: Pick<ProjectGroup, 'connectionId' | 'executionHostId'> | null | undefined,
@@ -36,22 +46,50 @@ export function getFolderWorkspaceHostIdFromGroups(
   if (folderHostId) {
     return folderHostId
   }
-  const groupExecutionHostIds = new Set(
-    matchingGroups
-      .map((group) => normalizeExecutionHostId(group.executionHostId))
-      .filter((hostId): hostId is ExecutionHostId => hostId !== null)
+  const resolvedGroupHostIds = new Set(
+    matchingGroups.map((group) => getFolderWorkspaceHostId(folderWorkspace, group, defaultHostId))
   )
-  if (groupExecutionHostIds.size === 1) {
-    return [...groupExecutionHostIds][0]!
+  if (resolvedGroupHostIds.size === 1) {
+    return [...resolvedGroupHostIds][0]!
   }
   if (folderWorkspace.connectionId) {
     return toSshExecutionHostId(folderWorkspace.connectionId)
   }
-  const groupConnectionHostIds = new Set(
-    matchingGroups
-      .map((group) => group.connectionId)
-      .filter((connectionId): connectionId is string => Boolean(connectionId))
-      .map(toSshExecutionHostId)
+  return defaultHostId
+}
+
+export function findFolderWorkspaceProjectGroup(
+  folderWorkspace: Pick<FolderWorkspace, 'connectionId' | 'executionHostId' | 'projectGroupId'>,
+  projectGroups: readonly ProjectGroup[],
+  defaultHostId: ExecutionHostId
+): ProjectGroup | null {
+  const matchingGroups = projectGroups.filter(
+    (group) => group.id === folderWorkspace.projectGroupId
   )
-  return groupConnectionHostIds.size === 1 ? [...groupConnectionHostIds][0]! : defaultHostId
+  if (matchingGroups.length <= 1) {
+    return matchingGroups[0] ?? null
+  }
+  const targetHostId = getFolderWorkspaceHostIdFromGroups(
+    folderWorkspace,
+    matchingGroups,
+    defaultHostId
+  )
+  const exactHostMatches = matchingGroups.filter(
+    (group) => normalizeExecutionHostId(group.executionHostId) === targetHostId
+  )
+  if (exactHostMatches.length === 1) {
+    return exactHostMatches[0]!
+  }
+  if (folderWorkspace.connectionId) {
+    const connectionMatches = matchingGroups.filter(
+      (group) => group.connectionId === folderWorkspace.connectionId
+    )
+    if (connectionMatches.length === 1) {
+      return connectionMatches[0]!
+    }
+  }
+  const compatibleGroups = matchingGroups.filter(
+    (group) => getFolderWorkspaceHostId(folderWorkspace, group, defaultHostId) === targetHostId
+  )
+  return compatibleGroups.length === 1 ? compatibleGroups[0]! : null
 }

--- a/src/shared/folder-workspace-worktree.test.ts
+++ b/src/shared/folder-workspace-worktree.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import type { FolderWorkspace } from './folder-workspace-types'
-import { folderWorkspaceToWorktree } from './folder-workspace-worktree'
+import {
+  folderWorkspaceToWorktree,
+  folderWorkspaceToWorktreeForHost
+} from './folder-workspace-worktree'
 
 function makeFolderWorkspace(overrides: Partial<FolderWorkspace> = {}): FolderWorkspace {
   return {
@@ -140,6 +143,18 @@ describe('folderWorkspaceToWorktree', () => {
     expect(worktree).toMatchObject({
       hostId: 'runtime:shared%20server',
       runtimeOwnerEnvironmentId: 'shared server'
+    })
+  })
+
+  it('uses a resolved group owner over legacy folder identity', () => {
+    const worktree = folderWorkspaceToWorktreeForHost(
+      makeFolderWorkspace({ connectionId: 'legacy-ssh' }),
+      'runtime:env-1'
+    )
+
+    expect(worktree).toMatchObject({
+      hostId: 'runtime:env-1',
+      runtimeOwnerEnvironmentId: 'env-1'
     })
   })
 

--- a/src/shared/folder-workspace-worktree.ts
+++ b/src/shared/folder-workspace-worktree.ts
@@ -3,11 +3,16 @@ import type { Worktree } from './worktree/types'
 import { folderWorkspaceKey } from './workspace-scope'
 import { parseExecutionHostId, toSshExecutionHostId } from './execution-host'
 import { normalizeWorkspaceCreatorProvenance } from './workspace-creator-provenance'
+import type { ExecutionHostId } from './execution-host'
 
-export function folderWorkspaceToWorktree(folderWorkspace: FolderWorkspace): Worktree {
+function projectFolderWorkspaceToWorktree(
+  folderWorkspace: FolderWorkspace,
+  resolvedHostId?: ExecutionHostId
+): Worktree {
   const linkedTask = folderWorkspace.linkedTask
   const creatorProvenance = normalizeWorkspaceCreatorProvenance(folderWorkspace.creatorProvenance)
   const hostId =
+    resolvedHostId ??
     folderWorkspace.executionHostId ??
     (folderWorkspace.connectionId ? toSshExecutionHostId(folderWorkspace.connectionId) : 'local')
   const parsedHost = parseExecutionHostId(hostId)
@@ -53,4 +58,15 @@ export function folderWorkspaceToWorktree(folderWorkspace: FolderWorkspace): Wor
       ? { runtimeOwnerEnvironmentId: parsedHost.environmentId }
       : {})
   }
+}
+
+export function folderWorkspaceToWorktree(folderWorkspace: FolderWorkspace): Worktree {
+  return projectFolderWorkspaceToWorktree(folderWorkspace)
+}
+
+export function folderWorkspaceToWorktreeForHost(
+  folderWorkspace: FolderWorkspace,
+  hostId: ExecutionHostId
+): Worktree {
+  return projectFolderWorkspaceToWorktree(folderWorkspace, hostId)
 }

--- a/tests/e2e/helpers/paired-electron-client.ts
+++ b/tests/e2e/helpers/paired-electron-client.ts
@@ -142,7 +142,7 @@ export async function launchPairedElectronClient(
   offer: RuntimeDesktopPairingOffer,
   testInfo: TestInfo,
   name: string,
-  options: { extraEnv?: Record<string, string> } = {}
+  options: { extraEnv?: Record<string, string>; headful?: boolean } = {}
 ): Promise<PairedElectronClient> {
   const userDataDir = mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-paired-desktop-'))
   const directSshProbePath = path.join(userDataDir, 'forbidden-local-ssh-connects.jsonl')
@@ -164,7 +164,7 @@ export async function launchPairedElectronClient(
     env: {
       ...homeIsolation.env,
       NODE_ENV: 'development',
-      ORCA_E2E_HEADLESS: '1',
+      ...(options.headful ? { ORCA_E2E_HEADFUL: '1' } : { ORCA_E2E_HEADLESS: '1' }),
       ORCA_E2E_FORBID_LOCAL_SSH_CONNECT_PROBE: directSshProbePath
     }
   })

--- a/tests/e2e/sta-4964-folder-sidebar-oracle.ts
+++ b/tests/e2e/sta-4964-folder-sidebar-oracle.ts
@@ -81,6 +81,24 @@ export async function expectFolderWorkspaceSidebarGrouping(
     await expect(runtimeRow).toContainText(targets.runtimeWorkspace.name)
     await expect(localRow).toHaveCount(1)
     await expect(localRow).toContainText(targets.localWorkspace.name)
+    await localRow.locator('[data-worktree-card-surface]').click()
+    await expect
+      .poll(() =>
+        page.evaluate(() => ({
+          worktreeId: window.__store?.getState().activeWorktreeId ?? null,
+          hostId: window.__store?.getState().activeWorkspaceExecutionHostId ?? null
+        }))
+      )
+      .toEqual({ worktreeId: `folder:${targets.localWorkspace.id}`, hostId: 'local' })
+    await runtimeRow.locator('[data-worktree-card-surface]').click()
+    await expect
+      .poll(() =>
+        page.evaluate(() => ({
+          worktreeId: window.__store?.getState().activeWorktreeId ?? null,
+          hostId: window.__store?.getState().activeWorkspaceExecutionHostId ?? null
+        }))
+      )
+      .toEqual({ worktreeId: `folder:${targets.runtimeWorkspace.id}`, hostId: args.hostId })
     const placement = await page.evaluate(
       (targetIdentities) => {
         const rows = [

--- a/tests/e2e/sta-4964-folder-sidebar-oracle.ts
+++ b/tests/e2e/sta-4964-folder-sidebar-oracle.ts
@@ -4,25 +4,37 @@ import { expect } from './helpers/orca-app'
 export async function expectFolderWorkspaceSidebarGrouping(
   page: Page,
   testInfo: TestInfo,
-  args: { folderPath: string; hostId: `runtime:${string}` }
+  args: {
+    folderPath: string
+    hostId: `runtime:${string}`
+    localFolderPath: string
+    screenshotPrefix: string
+  }
 ): Promise<void> {
-  const target = await page.evaluate(({ folderPath, hostId }) => {
+  const targets = await page.evaluate(({ folderPath, hostId, localFolderPath }) => {
     const store = window.__store
     if (!store) {
       throw new Error('Renderer store unavailable')
     }
-    const workspace = store
+    const runtimeWorkspace = store
       .getState()
       .folderWorkspaces.find(
         (candidate) => candidate.folderPath === folderPath && candidate.executionHostId === hostId
       )
-    if (!workspace) {
+    const localWorkspace = store
+      .getState()
+      .folderWorkspaces.find(
+        (candidate) =>
+          candidate.folderPath === localFolderPath && candidate.executionHostId === 'local'
+      )
+    if (!runtimeWorkspace || !localWorkspace) {
       throw new Error('Runtime folder unavailable for sidebar grouping')
     }
     store.getState().setVisibleWorkspaceHostIds(['local', hostId])
-    return { id: workspace.id, name: workspace.name, executionHostId: workspace.executionHostId }
+    return { runtimeWorkspace, localWorkspace }
   }, args)
-  expect(target.executionHostId).toBe(args.hostId)
+  expect(targets.runtimeWorkspace.executionHostId).toBe(args.hostId)
+  expect(targets.localWorkspace.executionHostId).toBe('local')
 
   const cases = [
     { id: 'repo', label: 'Project' },
@@ -30,8 +42,9 @@ export async function expectFolderWorkspaceSidebarGrouping(
     { id: 'pr-status', label: 'PR' },
     { id: 'none', label: 'None' }
   ] as const
-  const identity = `${args.hostId}|folder:${target.id}`
-  const placements: { groupBy: string; hostId: string; identity: string }[] = []
+  const runtimeIdentity = `${args.hostId}|folder:${targets.runtimeWorkspace.id}`
+  const localIdentity = `local|folder:${targets.localWorkspace.id}`
+  const placements: { groupBy: string; runtimeHostId: string; localHostId: string }[] = []
 
   for (const groupBy of cases) {
     await page.evaluate((groupById) => window.__store?.getState().setGroupBy(groupById), groupBy.id)
@@ -59,36 +72,48 @@ export async function expectFolderWorkspaceSidebarGrouping(
           executionHostId: hostId
         })
       },
-      { folderWorkspaceId: target.id, hostId: args.hostId }
+      { folderWorkspaceId: targets.runtimeWorkspace.id, hostId: args.hostId }
     )
 
-    const folderRow = page.locator(`[data-worktree-host-identity="${identity}"]`)
-    await expect(folderRow).toBeVisible()
-    await expect(folderRow).toContainText(target.name)
-    const placement = await page.evaluate((targetIdentity) => {
-      const rows = [
-        ...document.querySelectorAll<HTMLElement>('[data-worktree-sidebar] [data-index]')
-      ].sort(
-        (left, right) =>
-          Number(left.dataset.index ?? Number.MAX_SAFE_INTEGER) -
-          Number(right.dataset.index ?? Number.MAX_SAFE_INTEGER)
-      )
-      let hostId: string | null = null
-      for (const row of rows) {
-        const hostHeader = row.querySelector<HTMLElement>('[data-host-header-drag-id]')
-        if (hostHeader) {
-          hostId = hostHeader.dataset.hostHeaderDragId ?? null
+    const runtimeRow = page.locator(`[data-worktree-host-identity="${runtimeIdentity}"]`)
+    const localRow = page.locator(`[data-worktree-host-identity="${localIdentity}"]`)
+    await expect(runtimeRow).toHaveCount(1)
+    await expect(runtimeRow).toContainText(targets.runtimeWorkspace.name)
+    await expect(localRow).toHaveCount(1)
+    await expect(localRow).toContainText(targets.localWorkspace.name)
+    const placement = await page.evaluate(
+      (targetIdentities) => {
+        const rows = [
+          ...document.querySelectorAll<HTMLElement>('[data-worktree-sidebar] [data-index]')
+        ].sort(
+          (left, right) =>
+            Number(left.dataset.index ?? Number.MAX_SAFE_INTEGER) -
+            Number(right.dataset.index ?? Number.MAX_SAFE_INTEGER)
+        )
+        let hostId: string | null = null
+        const result: Record<string, string | null> = {}
+        for (const row of rows) {
+          const hostHeader = row.querySelector<HTMLElement>('[data-host-header-drag-id]')
+          if (hostHeader) {
+            hostId = hostHeader.dataset.hostHeaderDragId ?? null
+          }
+          const identity = row.dataset.worktreeHostIdentity
+          if (identity && targetIdentities.includes(identity)) {
+            result[identity] = hostId
+          }
         }
-        if (row.dataset.worktreeHostIdentity === targetIdentity) {
-          return { hostId, identity: row.dataset.worktreeHostIdentity ?? '' }
-        }
-      }
-      return null
-    }, identity)
-    expect(placement).toEqual({ hostId: args.hostId, identity })
-    placements.push({ groupBy: groupBy.id, ...placement! })
+        return result
+      },
+      [runtimeIdentity, localIdentity]
+    )
+    expect(placement).toEqual({ [runtimeIdentity]: args.hostId, [localIdentity]: 'local' })
+    placements.push({
+      groupBy: groupBy.id,
+      runtimeHostId: placement[runtimeIdentity]!,
+      localHostId: placement[localIdentity]!
+    })
     await page.screenshot({
-      path: testInfo.outputPath(`sta-4964-${groupBy.id}.png`),
+      path: testInfo.outputPath(`sta-4964-${args.screenshotPrefix}-${groupBy.id}.png`),
       fullPage: true
     })
   }

--- a/tests/e2e/sta-4964-folder-sidebar-oracle.ts
+++ b/tests/e2e/sta-4964-folder-sidebar-oracle.ts
@@ -27,11 +27,27 @@ export async function expectFolderWorkspaceSidebarGrouping(
         (candidate) =>
           candidate.folderPath === localFolderPath && candidate.executionHostId === 'local'
       )
-    if (!runtimeWorkspace || !localWorkspace) {
+    const runtimeGroup = runtimeWorkspace
+      ? store
+          .getState()
+          .projectGroups.find(
+            (group) =>
+              group.id === runtimeWorkspace.projectGroupId && group.executionHostId === hostId
+          )
+      : null
+    const localGroup = localWorkspace
+      ? store
+          .getState()
+          .projectGroups.find(
+            (group) =>
+              group.id === localWorkspace.projectGroupId && group.executionHostId === 'local'
+          )
+      : null
+    if (!runtimeWorkspace || !localWorkspace || !runtimeGroup || !localGroup) {
       throw new Error('Runtime folder unavailable for sidebar grouping')
     }
     store.getState().setVisibleWorkspaceHostIds(['local', hostId])
-    return { runtimeWorkspace, localWorkspace }
+    return { runtimeWorkspace, localWorkspace, runtimeGroup, localGroup }
   }, args)
   expect(targets.runtimeWorkspace.executionHostId).toBe(args.hostId)
   expect(targets.localWorkspace.executionHostId).toBe('local')
@@ -109,26 +125,40 @@ export async function expectFolderWorkspaceSidebarGrouping(
             Number(right.dataset.index ?? Number.MAX_SAFE_INTEGER)
         )
         let hostId: string | null = null
-        const result: Record<string, string | null> = {}
+        let projectGroupText: string | null = null
+        const result: Record<string, { hostId: string | null; projectGroupText: string | null }> =
+          {}
         for (const row of rows) {
           const hostHeader = row.querySelector<HTMLElement>('[data-host-header-drag-id]')
           if (hostHeader) {
             hostId = hostHeader.dataset.hostHeaderDragId ?? null
+            projectGroupText = null
+          }
+          const projectGroupHeader = row.querySelector<HTMLElement>(
+            '[data-project-group-header-id]'
+          )
+          if (projectGroupHeader) {
+            projectGroupText = projectGroupHeader.textContent
           }
           const identity = row.dataset.worktreeHostIdentity
           if (identity && targetIdentities.includes(identity)) {
-            result[identity] = hostId
+            result[identity] = { hostId, projectGroupText }
           }
         }
         return result
       },
       [runtimeIdentity, localIdentity]
     )
-    expect(placement).toEqual({ [runtimeIdentity]: args.hostId, [localIdentity]: 'local' })
+    expect(placement[runtimeIdentity]?.hostId).toBe(args.hostId)
+    expect(placement[localIdentity]?.hostId).toBe('local')
+    if (groupBy.id === 'repo') {
+      expect(placement[runtimeIdentity]?.projectGroupText).toContain(targets.runtimeGroup.name)
+      expect(placement[localIdentity]?.projectGroupText).toContain(targets.localGroup.name)
+    }
     placements.push({
       groupBy: groupBy.id,
-      runtimeHostId: placement[runtimeIdentity]!,
-      localHostId: placement[localIdentity]!
+      runtimeHostId: placement[runtimeIdentity]!.hostId!,
+      localHostId: placement[localIdentity]!.hostId!
     })
     await page.screenshot({
       path: testInfo.outputPath(`sta-4964-${args.screenshotPrefix}-${groupBy.id}.png`),

--- a/tests/e2e/sta-4964-folder-sidebar-oracle.ts
+++ b/tests/e2e/sta-4964-folder-sidebar-oracle.ts
@@ -1,0 +1,97 @@
+import type { Page, TestInfo } from '@stablyai/playwright-test'
+import { expect } from './helpers/orca-app'
+
+export async function expectFolderWorkspaceSidebarGrouping(
+  page: Page,
+  testInfo: TestInfo,
+  args: { folderPath: string; hostId: `runtime:${string}` }
+): Promise<void> {
+  const target = await page.evaluate(({ folderPath, hostId }) => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('Renderer store unavailable')
+    }
+    const workspace = store
+      .getState()
+      .folderWorkspaces.find(
+        (candidate) => candidate.folderPath === folderPath && candidate.executionHostId === hostId
+      )
+    if (!workspace) {
+      throw new Error('Runtime folder unavailable for sidebar grouping')
+    }
+    store.getState().setVisibleWorkspaceHostIds(['local', hostId])
+    return { id: workspace.id, name: workspace.name, executionHostId: workspace.executionHostId }
+  }, args)
+  expect(target.executionHostId).toBe(args.hostId)
+
+  const cases = [
+    { id: 'repo', label: 'Project' },
+    { id: 'workspace-status', label: 'Status' },
+    { id: 'pr-status', label: 'PR' },
+    { id: 'none', label: 'None' }
+  ] as const
+  const identity = `${args.hostId}|folder:${target.id}`
+  const placements: { groupBy: string; hostId: string; identity: string }[] = []
+
+  for (const groupBy of cases) {
+    await page.evaluate((groupById) => window.__store?.getState().setGroupBy(groupById), groupBy.id)
+    await expect
+      .poll(() => page.evaluate(() => window.__store?.getState().groupBy ?? null))
+      .toBe(groupBy.id)
+    await expect
+      .poll(() =>
+        page.evaluate(
+          ({ folderPath, hostId }) =>
+            window.__store
+              ?.getState()
+              .folderWorkspaces.some(
+                (workspace) =>
+                  workspace.folderPath === folderPath && workspace.executionHostId === hostId
+              ) ?? false,
+          args
+        )
+      )
+      .toBe(true)
+    await page.evaluate(
+      ({ folderWorkspaceId, hostId }) => {
+        window.__store?.getState().revealWorktreeInSidebar(`folder:${folderWorkspaceId}`, {
+          behavior: 'auto',
+          executionHostId: hostId
+        })
+      },
+      { folderWorkspaceId: target.id, hostId: args.hostId }
+    )
+
+    const folderRow = page.locator(`[data-worktree-host-identity="${identity}"]`)
+    await expect(folderRow).toBeVisible()
+    await expect(folderRow).toContainText(target.name)
+    const placement = await page.evaluate((targetIdentity) => {
+      const rows = [
+        ...document.querySelectorAll<HTMLElement>('[data-worktree-sidebar] [data-index]')
+      ].sort(
+        (left, right) =>
+          Number(left.dataset.index ?? Number.MAX_SAFE_INTEGER) -
+          Number(right.dataset.index ?? Number.MAX_SAFE_INTEGER)
+      )
+      let hostId: string | null = null
+      for (const row of rows) {
+        const hostHeader = row.querySelector<HTMLElement>('[data-host-header-drag-id]')
+        if (hostHeader) {
+          hostId = hostHeader.dataset.hostHeaderDragId ?? null
+        }
+        if (row.dataset.worktreeHostIdentity === targetIdentity) {
+          return { hostId, identity: row.dataset.worktreeHostIdentity ?? '' }
+        }
+      }
+      return null
+    }, identity)
+    expect(placement).toEqual({ hostId: args.hostId, identity })
+    placements.push({ groupBy: groupBy.id, ...placement! })
+    await page.screenshot({
+      path: testInfo.outputPath(`sta-4964-${groupBy.id}.png`),
+      fullPage: true
+    })
+  }
+
+  console.info(`[sta-4964-sidebar] ${JSON.stringify(placements)}`)
+}

--- a/tests/e2e/sta-4964-folder-sidebar.spec.ts
+++ b/tests/e2e/sta-4964-folder-sidebar.spec.ts
@@ -1,0 +1,133 @@
+import { mkdirSync } from 'node:fs'
+import type { FolderWorkspace } from '../../src/shared/folder-workspace-types'
+import type { ProjectGroup } from '../../src/shared/project-group-types'
+import { expect, test } from './helpers/orca-app'
+import {
+  createRuntimeDesktopPairingOffer,
+  launchPairedElectronClient
+} from './helpers/paired-electron-client'
+import { waitForSessionReady } from './helpers/store'
+import { expectFolderWorkspaceSidebarGrouping } from './sta-4964-folder-sidebar-oracle'
+
+test('keeps a runtime-owned folder under its paired host in every grouping mode @headful', async ({
+  orcaPage
+}, testInfo) => {
+  test.setTimeout(120_000)
+  await waitForSessionReady(orcaPage)
+  const offer = await createRuntimeDesktopPairingOffer(orcaPage)
+  const client = await launchPairedElectronClient(offer, testInfo, 'STA-4964 runtime')
+  const runtimeHostId = `runtime:${client.environmentId}` as const
+  const runtimeFolderPath = testInfo.outputPath('runtime-folder')
+  const localFolderPath = testInfo.outputPath('local-collision-folder')
+  mkdirSync(runtimeFolderPath, { recursive: true })
+  mkdirSync(localFolderPath, { recursive: true })
+
+  try {
+    await client.app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows()[0]?.show())
+    await expect.poll(() => client.page.evaluate(() => window.__store != null)).toBe(true)
+    const seeded = await client.page.evaluate(
+      async (args) => {
+        const store = window.__store
+        if (!store) {
+          throw new Error('Renderer store unavailable')
+        }
+        await store.getState().setActiveRuntimeEnvironmentPreference(null)
+        const groupResponse = await window.api.runtimeEnvironments.call({
+          selector: args.environmentId,
+          method: 'projectGroup.create',
+          params: {
+            name: 'Runtime-owned group',
+            parentPath: args.runtimeFolderPath,
+            createdFrom: 'manual'
+          },
+          timeoutMs: 15_000
+        })
+        if (!groupResponse.ok) {
+          throw new Error(groupResponse.error.message)
+        }
+        const createdGroup = (groupResponse.result as { group: ProjectGroup }).group
+        const folderResponse = await window.api.runtimeEnvironments.call({
+          selector: args.environmentId,
+          method: 'folderWorkspace.create',
+          params: {
+            folderPath: args.runtimeFolderPath,
+            name: 'Runtime-owned folder',
+            projectGroupId: createdGroup.id
+          },
+          timeoutMs: 15_000
+        })
+        if (!folderResponse.ok) {
+          throw new Error(folderResponse.error.message)
+        }
+        const createdFolder = (folderResponse.result as { folderWorkspace: FolderWorkspace })
+          .folderWorkspace
+        await Promise.all([
+          store.getState().fetchProjectGroups({ runtimeEnvironmentId: args.environmentId }),
+          store.getState().fetchFolderWorkspaces({ runtimeEnvironmentId: args.environmentId })
+        ])
+        const state = store.getState()
+        const runtimeFolder = state.folderWorkspaces.find(
+          (workspace) =>
+            workspace.id === createdFolder.id && workspace.executionHostId === args.runtimeHostId
+        )
+        const runtimeGroup = state.projectGroups.find(
+          (group) => group.id === createdGroup.id && group.executionHostId === args.runtimeHostId
+        )
+        if (!runtimeFolder || !runtimeGroup) {
+          throw new Error('Runtime-owned folder catalog unavailable')
+        }
+        const localGroupId = `${runtimeGroup.id}-local-collision`
+        store.setState({
+          folderWorkspaces: [
+            {
+              ...runtimeFolder,
+              name: 'Local same-ID collision',
+              folderPath: args.localFolderPath,
+              projectGroupId: localGroupId,
+              executionHostId: 'local'
+            },
+            ...state.folderWorkspaces
+          ],
+          projectGroups: [
+            {
+              ...runtimeGroup,
+              id: localGroupId,
+              name: 'Local same-ID collision',
+              parentPath: args.localFolderPath,
+              executionHostId: 'local'
+            },
+            ...state.projectGroups
+          ],
+          workspaceHostScope: 'all',
+          activeWorkspaceExecutionHostId: 'local'
+        })
+        await Promise.all([
+          store.getState().fetchProjectGroups({ runtimeEnvironmentId: args.environmentId }),
+          store.getState().fetchFolderWorkspaces({ runtimeEnvironmentId: args.environmentId })
+        ])
+        return store
+          .getState()
+          .folderWorkspaces.filter((workspace) => workspace.id === createdFolder.id)
+          .map((workspace) => ({
+            id: workspace.id,
+            executionHostId: workspace.executionHostId
+          }))
+      },
+      {
+        environmentId: client.environmentId,
+        localFolderPath,
+        runtimeFolderPath,
+        runtimeHostId
+      }
+    )
+    expect(new Set(seeded.map((workspace) => workspace.id)).size).toBe(1)
+    expect(seeded.map((workspace) => workspace.executionHostId)).toEqual(['local', runtimeHostId])
+
+    await expectFolderWorkspaceSidebarGrouping(client.page, testInfo, {
+      folderPath: runtimeFolderPath,
+      hostId: runtimeHostId
+    })
+  } finally {
+    await client.dispose()
+  }
+})

--- a/tests/e2e/sta-4964-folder-sidebar.spec.ts
+++ b/tests/e2e/sta-4964-folder-sidebar.spec.ts
@@ -123,9 +123,63 @@ test('keeps a runtime-owned folder under its paired host in every grouping mode 
     expect(new Set(seeded.map((workspace) => workspace.id)).size).toBe(1)
     expect(seeded.map((workspace) => workspace.executionHostId)).toEqual(['local', runtimeHostId])
 
+    await client.page.evaluate(async (environmentId) => {
+      const store = window.__store
+      if (!store) {
+        throw new Error('Renderer store unavailable')
+      }
+      await window.api.runtimeEnvironments.disconnect({ selector: environmentId })
+      store.getState().setRuntimeEnvironmentStatus(environmentId, {
+        status: null,
+        checkedAt: Date.now()
+      })
+    }, client.environmentId)
     await expectFolderWorkspaceSidebarGrouping(client.page, testInfo, {
       folderPath: runtimeFolderPath,
-      hostId: runtimeHostId
+      hostId: runtimeHostId,
+      localFolderPath,
+      screenshotPrefix: 'disconnected'
+    })
+
+    const reconnected = await client.page.evaluate(
+      async (args) => {
+        const store = window.__store
+        if (!store) {
+          throw new Error('Renderer store unavailable')
+        }
+        const response = await window.api.runtimeEnvironments.connect({
+          selector: args.environmentId,
+          timeoutMs: 15_000
+        })
+        if (!response.ok) {
+          throw new Error(response.error.message)
+        }
+        store.getState().setRuntimeEnvironmentStatus(args.environmentId, {
+          status: response.result,
+          checkedAt: Date.now()
+        })
+        await Promise.all([
+          store.getState().fetchProjectGroups({ runtimeEnvironmentId: args.environmentId }),
+          store.getState().fetchFolderWorkspaces({ runtimeEnvironmentId: args.environmentId })
+        ])
+        return store
+          .getState()
+          .folderWorkspaces.filter(
+            (workspace) =>
+              workspace.folderPath === args.runtimeFolderPath ||
+              workspace.folderPath === args.localFolderPath
+          )
+          .map((workspace) => workspace.executionHostId)
+          .sort()
+      },
+      { environmentId: client.environmentId, localFolderPath, runtimeFolderPath }
+    )
+    expect(reconnected).toEqual(['local', runtimeHostId])
+    await expectFolderWorkspaceSidebarGrouping(client.page, testInfo, {
+      folderPath: runtimeFolderPath,
+      hostId: runtimeHostId,
+      localFolderPath,
+      screenshotPrefix: 'reconnected'
     })
   } finally {
     await client.dispose()

--- a/tests/e2e/sta-4964-folder-sidebar.spec.ts
+++ b/tests/e2e/sta-4964-folder-sidebar.spec.ts
@@ -15,7 +15,9 @@ test('keeps a runtime-owned folder under its paired host in every grouping mode 
   test.setTimeout(120_000)
   await waitForSessionReady(orcaPage)
   const offer = await createRuntimeDesktopPairingOffer(orcaPage)
-  const client = await launchPairedElectronClient(offer, testInfo, 'STA-4964 runtime')
+  const client = await launchPairedElectronClient(offer, testInfo, 'STA-4964 runtime', {
+    headful: true
+  })
   const runtimeHostId = `runtime:${client.environmentId}` as const
   const runtimeFolderPath = testInfo.outputPath('runtime-folder')
   const localFolderPath = testInfo.outputPath('local-collision-folder')
@@ -23,7 +25,11 @@ test('keeps a runtime-owned folder under its paired host in every grouping mode 
   mkdirSync(localFolderPath, { recursive: true })
 
   try {
-    await client.app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows()[0]?.show())
+    expect(
+      await client.app.evaluate(({ BrowserWindow }) =>
+        BrowserWindow.getAllWindows()[0]?.isVisible()
+      )
+    ).toBe(true)
     await expect.poll(() => client.page.evaluate(() => window.__store != null)).toBe(true)
     const seeded = await client.page.evaluate(
       async (args) => {
@@ -61,6 +67,17 @@ test('keeps a runtime-owned folder under its paired host in every grouping mode 
         }
         const createdFolder = (folderResponse.result as { folderWorkspace: FolderWorkspace })
           .folderWorkspace
+        const createdLocalGroup = await window.api.projectGroups.create({
+          name: 'Local same-ID collision',
+          parentPath: args.localFolderPath
+        })
+        const createdLocalFolder = await window.api.folderWorkspaces.create({
+          folderPath: args.localFolderPath,
+          name: 'Local same-ID collision',
+          projectGroupId: createdLocalGroup.id
+        })
+        await store.getState().fetchProjectGroups()
+        await store.getState().fetchFolderWorkspaces()
         await Promise.all([
           store.getState().fetchProjectGroups({ runtimeEnvironmentId: args.environmentId }),
           store.getState().fetchFolderWorkspaces({ runtimeEnvironmentId: args.environmentId })
@@ -73,30 +90,33 @@ test('keeps a runtime-owned folder under its paired host in every grouping mode 
         const runtimeGroup = state.projectGroups.find(
           (group) => group.id === createdGroup.id && group.executionHostId === args.runtimeHostId
         )
-        if (!runtimeFolder || !runtimeGroup) {
-          throw new Error('Runtime-owned folder catalog unavailable')
+        const localFolder = state.folderWorkspaces.find(
+          (workspace) =>
+            workspace.id === createdLocalFolder.id && workspace.executionHostId === 'local'
+        )
+        const localGroup = state.projectGroups.find(
+          (group) => group.id === createdLocalGroup.id && group.executionHostId === 'local'
+        )
+        if (!runtimeFolder || !runtimeGroup || !localFolder || !localGroup) {
+          throw new Error('Local/runtime folder catalogs unavailable')
         }
-        const localGroupId = `${runtimeGroup.id}-local-collision`
+        // Fault injection is limited to the claimed collision: both records otherwise came
+        // through their real local/runtime catalogs and owner-stamping paths.
         store.setState({
           folderWorkspaces: [
             {
-              ...runtimeFolder,
-              name: 'Local same-ID collision',
-              folderPath: args.localFolderPath,
-              projectGroupId: localGroupId,
-              executionHostId: 'local'
+              ...localFolder,
+              id: runtimeFolder.id,
+              projectGroupId: runtimeGroup.id
             },
-            ...state.folderWorkspaces
+            ...state.folderWorkspaces.filter((workspace) => workspace.id !== localFolder.id)
           ],
           projectGroups: [
             {
-              ...runtimeGroup,
-              id: localGroupId,
-              name: 'Local same-ID collision',
-              parentPath: args.localFolderPath,
-              executionHostId: 'local'
+              ...localGroup,
+              id: runtimeGroup.id
             },
-            ...state.projectGroups
+            ...state.projectGroups.filter((group) => group.id !== localGroup.id)
           ],
           workspaceHostScope: 'all',
           activeWorkspaceExecutionHostId: 'local'
@@ -105,13 +125,18 @@ test('keeps a runtime-owned folder under its paired host in every grouping mode 
           store.getState().fetchProjectGroups({ runtimeEnvironmentId: args.environmentId }),
           store.getState().fetchFolderWorkspaces({ runtimeEnvironmentId: args.environmentId })
         ])
-        return store
-          .getState()
-          .folderWorkspaces.filter((workspace) => workspace.id === createdFolder.id)
-          .map((workspace) => ({
-            id: workspace.id,
-            executionHostId: workspace.executionHostId
-          }))
+        const hydrated = store.getState()
+        return {
+          folders: hydrated.folderWorkspaces
+            .filter((workspace) => workspace.id === createdFolder.id)
+            .map((workspace) => ({
+              id: workspace.id,
+              executionHostId: workspace.executionHostId
+            })),
+          groups: hydrated.projectGroups
+            .filter((group) => group.id === createdGroup.id)
+            .map((group) => ({ id: group.id, executionHostId: group.executionHostId }))
+        }
       },
       {
         environmentId: client.environmentId,
@@ -120,20 +145,32 @@ test('keeps a runtime-owned folder under its paired host in every grouping mode 
         runtimeHostId
       }
     )
-    expect(new Set(seeded.map((workspace) => workspace.id)).size).toBe(1)
-    expect(seeded.map((workspace) => workspace.executionHostId)).toEqual(['local', runtimeHostId])
+    expect(new Set(seeded.folders.map((workspace) => workspace.id)).size).toBe(1)
+    expect(seeded.folders.map((workspace) => workspace.executionHostId)).toEqual([
+      'local',
+      runtimeHostId
+    ])
+    expect(new Set(seeded.groups.map((group) => group.id)).size).toBe(1)
+    expect(seeded.groups.map((group) => group.executionHostId)).toEqual(['local', runtimeHostId])
 
-    await client.page.evaluate(async (environmentId) => {
+    const disconnected = await client.page.evaluate(async (environmentId) => {
       const store = window.__store
       if (!store) {
         throw new Error('Renderer store unavailable')
       }
-      await window.api.runtimeEnvironments.disconnect({ selector: environmentId })
-      store.getState().setRuntimeEnvironmentStatus(environmentId, {
-        status: null,
-        checkedAt: Date.now()
-      })
+      const result = await window.api.runtimeEnvironments.disconnect({ selector: environmentId })
+      const reachable = await store.getState().refreshRuntimeEnvironmentStatus(environmentId, 1_000)
+      return {
+        disconnectedId: result.disconnected.id,
+        reachable,
+        status: store.getState().runtimeStatusByEnvironmentId.get(environmentId)?.status ?? null
+      }
     }, client.environmentId)
+    expect(disconnected).toEqual({
+      disconnectedId: client.environmentId,
+      reachable: false,
+      status: null
+    })
     await expectFolderWorkspaceSidebarGrouping(client.page, testInfo, {
       folderPath: runtimeFolderPath,
       hostId: runtimeHostId,
@@ -162,19 +199,33 @@ test('keeps a runtime-owned folder under its paired host in every grouping mode 
           store.getState().fetchProjectGroups({ runtimeEnvironmentId: args.environmentId }),
           store.getState().fetchFolderWorkspaces({ runtimeEnvironmentId: args.environmentId })
         ])
-        return store
-          .getState()
-          .folderWorkspaces.filter(
-            (workspace) =>
-              workspace.folderPath === args.runtimeFolderPath ||
-              workspace.folderPath === args.localFolderPath
-          )
-          .map((workspace) => workspace.executionHostId)
-          .sort()
+        const hydrated = store.getState()
+        return {
+          folders: hydrated.folderWorkspaces
+            .filter(
+              (workspace) =>
+                workspace.folderPath === args.runtimeFolderPath ||
+                workspace.folderPath === args.localFolderPath
+            )
+            .map((workspace) => workspace.executionHostId)
+            .sort((left, right) => String(left).localeCompare(String(right))),
+          groups: hydrated.projectGroups
+            .filter((group) => group.id === args.groupId)
+            .map((group) => group.executionHostId)
+            .sort((left, right) => String(left).localeCompare(String(right)))
+        }
       },
-      { environmentId: client.environmentId, localFolderPath, runtimeFolderPath }
+      {
+        environmentId: client.environmentId,
+        groupId: seeded.groups[0]!.id,
+        localFolderPath,
+        runtimeFolderPath
+      }
     )
-    expect(reconnected).toEqual(['local', runtimeHostId])
+    expect(reconnected).toEqual({
+      folders: ['local', runtimeHostId],
+      groups: ['local', runtimeHostId]
+    })
     await expectFolderWorkspaceSidebarGrouping(client.page, testInfo, {
       folderPath: runtimeFolderPath,
       hostId: runtimeHostId,


### PR DESCRIPTION
## Summary

- keep runtime-owned folder workspaces grouped and routed by `executionHostId`
- preserve legacy direct-SSH `connectionId` fallback and use the focused/default host only when neither owner exists
- share one resolver across sidebar filtering, grouping, catalog hydration, card/reveal/path-status routing, and host-qualified virtual row keys

## Root cause

PR #15404 introduced a folder-host resolver that checked only `connectionId`, then fell back to the focused/default host. Runtime catalog records already carry an optional `executionHostId`, so changing focus could move a runtime-owned folder to the wrong host. Filtering had separately learned about `executionHostId`, leaving ownership rules inconsistent.

## Proof

Falsifiable invariant: workspace `executionHostId`, then group `executionHostId`, then legacy `connectionId`, then default host controls folder grouping/routing regardless of focus.

- exact affected merge `12724068b7`: 7 failed / 3 passed
- latest `origin/main` `012e9f410c`: 7 failed / 3 passed
- candidate truth table: 10 passed / 0 failed
- candidate with execution-host precedence disabled: 7 failed / 3 passed
- focused ownership/sidebar/store suite: 209 passed across 21 files

The truth table covers workspace/group execution identity, legacy SSH identity, both fields, neither field, focus changes, disconnect/reconnect, and identical folder IDs across hosts.

## Paired Electron evidence

A genuinely headful paired-desktop test creates local and runtime folders/groups through their real catalogs, injects only the claimed same-ID collision (including the group ID), focuses local, performs a real disconnect with a failed runtime status refresh, reconnects and rehydrates, then proves both copies render exactly once under their own host headers. Clicking each row must also set the matching `activeWorkspaceExecutionHostId` in every mode:

- Project
- Status
- PR
- None

Project mode additionally proves each folder sits beneath the matching local/runtime group header. Result: 1 passed in 17.5s. Eight fresh full-page screenshots cover all four modes before and after reconnect.

## Compatibility

No RPC, stream, persistence, or wire schema changes. `executionHostId` remains optional for mixed versions; legacy `connectionId` records keep routing to SSH; only records with neither identity use the default host. No Git, provider, path, shell, or platform behavior changes.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run typecheck`
- focused Oxlint and format checks
- `pnpm exec electron-vite build --mode e2e`
- changed-code quality gate (Oxlint, type-aware checks, React Doctor)
- 209 focused Vitest assertions across 21 files
- headed paired-runtime Playwright/CDP proof

Three independent gpt-5.6-luna review passes challenged ownership, regressions/compatibility, and proof quality. The first round found virtual-key, card identity, reveal, hydration, and path-status gaps; those were reproduced and fixed. A final fresh round is recorded in the PR comments/status before review.

Full `pnpm run typecheck:e2e` remains red from unrelated pre-existing E2E errors.
