### PR TITLE
fix(mobile): separate image attachment paths from following prompt text (STA-4847)

### DIFF
--- a/mobile/src/session/mobile-image-attachment.test.ts
+++ b/mobile/src/session/mobile-image-attachment.test.ts
@@ -50,7 +50,9 @@ describe('attachMobileImageToTerminal', () => {
     const sendCall = client.calls.find((c) => c.method === 'terminal.send')
     expect(sendCall?.params).toEqual({
       terminal: 'term-1',
-      text: '\x1b[200~/tmp/orca-attach.png\x1b[201~',
+      // Trailing space: the user types on this same line next, so a bare
+      // `…\x1b[201~` would arrive as `…pngadd` (STA-4847).
+      text: '\x1b[200~/tmp/orca-attach.png\x1b[201~ ',
       enter: false,
       client: { id: 'device-9', type: 'mobile' }
     })

--- a/mobile/src/session/mobile-image-attachment.ts
+++ b/mobile/src/session/mobile-image-attachment.ts
@@ -1,4 +1,5 @@
 import type { RpcClient } from '../transport/rpc-client'
+import { separateImagePasteFromFollowingText } from '../../../src/shared/image-paste-following-text'
 import {
   buildMobileImagePastePayload,
   saveMobileClipboardImageAsTempFile
@@ -47,7 +48,10 @@ export async function attachMobileImageToTerminal(
   })
   // Why: a generated image path is terminal image injection, so it's always
   // bracketed (matching desktop paste) regardless of terminal mode.
-  const payload = buildMobileImagePastePayload(imagePath)
+  // Always separated: attach-then-type is the whole interaction here, so the user's
+  // next keystroke would otherwise glue onto the path (`…pngadd`). Unlike native
+  // chat there is no batch to look ahead in, and a trailing space is inert.
+  const payload = separateImagePasteFromFollowingText(buildMobileImagePastePayload(imagePath), true)
   if (beforeTerminalSend && !(await beforeTerminalSend(terminal))) {
     return false
   }

--- a/mobile/src/session/mobile-native-chat-image-send.test.ts
+++ b/mobile/src/session/mobile-native-chat-image-send.test.ts
@@ -38,7 +38,8 @@ describe('pasteMobileNativeChatImagePaths', () => {
       client,
       terminal: 'term-1',
       deviceToken: 'device-9',
-      imagePaths: ['/tmp/a.png', '/tmp/b.png', '/tmp/c.png']
+      imagePaths: ['/tmp/a.png', '/tmp/b.png', '/tmp/c.png'],
+      followedByText: true
     })
 
     expect(ok).toBe(true)
@@ -55,7 +56,7 @@ describe('pasteMobileNativeChatImagePaths', () => {
     })
     expect(client.calls[1]?.params.text).toBe('\x1b[200~/tmp/a.png\x1b[201~')
     expect(client.calls[2]?.params.text).toBe('\x1b[200~/tmp/b.png\x1b[201~')
-    expect(client.calls[3]?.params.text).toBe('\x1b[200~/tmp/c.png\x1b[201~')
+    expect(client.calls[3]?.params.text).toBe('\x1b[200~/tmp/c.png\x1b[201~ ')
   })
 
   it('stops and reports failure as soon as a paste is rejected', async () => {
@@ -66,7 +67,8 @@ describe('pasteMobileNativeChatImagePaths', () => {
       client,
       terminal: 'term-1',
       deviceToken: null,
-      imagePaths: ['/tmp/a.png', '/tmp/b.png']
+      imagePaths: ['/tmp/a.png', '/tmp/b.png'],
+      followedByText: true
     })
 
     expect(ok).toBe(false)
@@ -94,7 +96,8 @@ describe('pasteMobileNativeChatImagePaths', () => {
         client,
         terminal: 'term-1',
         deviceToken: null,
-        imagePaths: ['/tmp/a.png', '/tmp/b.png']
+        imagePaths: ['/tmp/a.png', '/tmp/b.png'],
+        followedByText: true
       })
 
       expect(ok).toBe(false)
@@ -121,6 +124,7 @@ describe('clearing a parked multi-line launch draft before the image paste', () 
       terminal: 'term-1',
       deviceToken: null,
       imagePaths: ['/tmp/a.png'],
+      followedByText: true,
       clearInput
     })
 
@@ -137,6 +141,7 @@ describe('clearing a parked multi-line launch draft before the image paste', () 
       terminal: 'term-1',
       deviceToken: null,
       imagePaths: ['/tmp/a.png', '/tmp/b.png'],
+      followedByText: true,
       clearInput
     })
 
@@ -151,9 +156,27 @@ describe('clearing a parked multi-line launch draft before the image paste', () 
       client,
       terminal: 'term-1',
       deviceToken: null,
-      imagePaths: ['/tmp/a.png']
+      imagePaths: ['/tmp/a.png'],
+      followedByText: true
     })
 
     expect(client.calls[0]?.params.text).toBe('\x15')
+  })
+
+  it('keeps image writes byte-clean when no text or submit follows', async () => {
+    const client = clientWithResponses([sendResult(true), sendResult(true), sendResult(true)])
+
+    await pasteMobileNativeChatImagePaths({
+      client,
+      terminal: 'term-1',
+      deviceToken: null,
+      imagePaths: ['/tmp/a.png', '/tmp/b.png'],
+      followedByText: false
+    })
+
+    expect(client.calls.slice(1).map((call) => call.params.text)).toEqual([
+      '\x1b[200~/tmp/a.png\x1b[201~',
+      '\x1b[200~/tmp/b.png\x1b[201~'
+    ])
   })
 })

--- a/mobile/src/session/mobile-native-chat-image-send.ts
+++ b/mobile/src/session/mobile-native-chat-image-send.ts
@@ -1,4 +1,5 @@
 import type { RpcClient } from '../transport/rpc-client'
+import { imagePasteWritesFollowedByText } from '../../../src/shared/image-paste-following-text'
 import { buildMobileImagePastePayload } from './mobile-clipboard-image'
 import {
   MOBILE_NATIVE_CHAT_MIN_WRITE_TIMEOUT_MS,
@@ -23,6 +24,7 @@ type PasteImagesArgs = {
   readonly terminal: string
   readonly deviceToken: string | null
   readonly imagePaths: readonly string[]
+  readonly followedByText: boolean
   /** Budget shared with the rest of the user action (the text body that follows, or
    *  the send this is healing for). Omit to open a fresh one for this paste alone. */
   readonly deadline?: number
@@ -42,6 +44,7 @@ export async function pasteMobileNativeChatImagePaths({
   terminal,
   deviceToken,
   imagePaths,
+  followedByText,
   deadline: sharedDeadline,
   clearInput
 }: PasteImagesArgs): Promise<boolean> {
@@ -55,7 +58,7 @@ export async function pasteMobileNativeChatImagePaths({
   const deadline = sharedDeadline ?? openMobileNativeChatSendBudget()
   for (const text of [
     clearInput ?? MOBILE_NATIVE_CHAT_CLEAR_UNSUBMITTED_INPUT,
-    ...imagePaths.map(buildMobileImagePastePayload)
+    ...imagePasteWritesFollowedByText(imagePaths.map(buildMobileImagePastePayload), followedByText)
   ]) {
     const remainingMs = deadline - Date.now()
     // Why: the budget is the whole sequence's — starting a write it can't fund would

--- a/mobile/src/session/mobile-native-chat-stale-input.ts
+++ b/mobile/src/session/mobile-native-chat-stale-input.ts
@@ -55,6 +55,7 @@ export async function healMobileNativeChatStaleInput(args: {
       terminal: args.terminal,
       deviceToken: args.deviceToken,
       imagePaths: [],
+      followedByText: false,
       ...(args.deadline === undefined ? {} : { deadline: args.deadline })
     })
   } catch {

--- a/mobile/src/session/use-mobile-native-chat-image-attachments.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-image-attachments.test.ts
@@ -182,9 +182,12 @@ describe('useMobileNativeChatImageAttachments', () => {
     expect(sendCalls).toHaveLength(2)
     expect(sendCalls[0]?.params).toMatchObject({ text: '\x15', enter: false })
     expect(sendCalls[1]?.params).toMatchObject({
-      text: '\x1b[200~/tmp/a.png\x1b[201~',
+      text: '\x1b[200~/tmp/a.png\x1b[201~ ',
       enter: false
     })
+    const combined = String(sendCalls[1]?.params.text ?? '') + 'look at this'
+    expect(combined).toContain('.png\x1b[201~ look')
+    expect(combined).not.toContain('.png\x1b[201~look')
     // Clear, then paste, then settle, then the text send — in that order.
     expect(order).toEqual(['clear', 'paste', 'settle', 'text:look at this'])
     // The local preview URI rides along so the sent bubble shows the photo.
@@ -267,7 +270,10 @@ describe('useMobileNativeChatImageAttachments', () => {
     }
   })
 
-  it('routes an attachments-only send through baseSend with empty text so the echo still shows the photo', async () => {
+  it.each([
+    ['empty', ''],
+    ['whitespace-only', '   ']
+  ])('routes an attachments-only send through baseSend with %s text', async (_label, text) => {
     pick.mockResolvedValue([{ base64: 'AAAA', uri: 'file:///a.jpg' }])
     const client = makeClient([
       methodNotFound('start'),
@@ -283,16 +289,17 @@ describe('useMobileNativeChatImageAttachments', () => {
     })
     let accepted = false
     await act(async () => {
-      accepted = await hook!.sendNativeChat('')
+      accepted = await hook!.sendNativeChat(text)
     })
 
     expect(accepted).toBe(true)
-    // Empty text still goes through baseSend (which submits the bare Enter) so the
+    // Attachment-only text still goes through baseSend (which submits Enter) so the
     // optimistic echo carries the preview URI.
-    expect(baseSend).toHaveBeenCalledWith('', ['file:///a.jpg'], expect.any(Number))
+    expect(baseSend).toHaveBeenCalledWith(text, ['file:///a.jpg'], expect.any(Number))
     const sendCalls = client.calls.filter((c) => c.method === 'terminal.send')
     // Only the clear + image paste hit the wire here; baseSend owns the submit.
     expect(sendCalls).toHaveLength(2)
+    expect(sendCalls[1]?.params.text).toBe('\x1b[200~/tmp/a.png\x1b[201~')
     expect(hook!.attachments).toEqual([])
   })
 

--- a/mobile/src/session/use-mobile-native-chat-image-attachments.ts
+++ b/mobile/src/session/use-mobile-native-chat-image-attachments.ts
@@ -34,14 +34,16 @@ import { useMobileNativeChatImageUpload } from './use-mobile-native-chat-image-u
 
 type CurrentRef<T> = { readonly current: T }
 type ShowToast = (message: string, durationMs?: number) => void
+
 type Args = {
   readonly client: RpcClient | null
   readonly activeHandleRef: CurrentRef<string | null>
   readonly deviceTokenRef: CurrentRef<string | null>
   readonly getActiveWorktreeConnectionId: () => Promise<string | null>
   readonly connState: ConnectionState
-  /** Active composer identity: chips cannot ride a tab switch into another
-   *  terminal. Null disables attaching. */
+  /** Identity of the active composer surface (same key shape as the drafts hook):
+   *  chips are scoped to the tab that picked them, so a tab switch cannot ride
+   *  one tab's image into another tab's terminal. Null disables attaching. */
   readonly scopeKey: string | null
   /** The native-chat input lease is ready — same gate `handleNativeChatSend` uses. */
   readonly enabled: boolean
@@ -259,6 +261,7 @@ export function useMobileNativeChatImageAttachments({
           await sleep(MOBILE_NATIVE_CHAT_IMAGE_SETTLE_MS)
           // The settle is deliberate pacing, not transport latency — credit it back
           // so a shared budget doesn't charge the text body for the TUI's beat.
+          const textDeadline = deadline + MOBILE_NATIVE_CHAT_IMAGE_SETTLE_MS
           // The paste above targeted `handle`; a tab switch during the settle would
           // route the text + Enter to a different terminal than the images. Abort —
           // the chips keep their scope and a retry's Ctrl+U clears the stale paste.
@@ -271,7 +274,7 @@ export function useMobileNativeChatImageAttachments({
           const outcome = await baseSend(
             text,
             pendingImages.map((attachment) => attachment.previewUri),
-            deadline + MOBILE_NATIVE_CHAT_IMAGE_SETTLE_MS
+            textDeadline
           )
           if (outcome !== 'accepted') {
             // 'rejected' leaves the pasted image path on this input line; 'unknown'

--- a/mobile/src/session/use-mobile-native-chat-image-attachments.ts
+++ b/mobile/src/session/use-mobile-native-chat-image-attachments.ts
@@ -34,16 +34,14 @@ import { useMobileNativeChatImageUpload } from './use-mobile-native-chat-image-u
 
 type CurrentRef<T> = { readonly current: T }
 type ShowToast = (message: string, durationMs?: number) => void
-
 type Args = {
   readonly client: RpcClient | null
   readonly activeHandleRef: CurrentRef<string | null>
   readonly deviceTokenRef: CurrentRef<string | null>
   readonly getActiveWorktreeConnectionId: () => Promise<string | null>
   readonly connState: ConnectionState
-  /** Identity of the active composer surface (same key shape as the drafts hook):
-   *  chips are scoped to the tab that picked them, so a tab switch cannot ride
-   *  one tab's image into another tab's terminal. Null disables attaching. */
+  /** Active composer identity: chips cannot ride a tab switch into another
+   *  terminal. Null disables attaching. */
   readonly scopeKey: string | null
   /** The native-chat input lease is ready — same gate `handleNativeChatSend` uses. */
   readonly enabled: boolean
@@ -240,6 +238,7 @@ export function useMobileNativeChatImageAttachments({
             terminal: handle,
             deviceToken: deviceTokenRef.current,
             imagePaths: pendingImages.map((attachment) => attachment.path),
+            followedByText: text.trim().length > 0,
             deadline,
             ...(seededLaunchDraft
               ? { clearInput: buildAgentTuiClearInputForText(seededLaunchDraft) }
@@ -260,7 +259,6 @@ export function useMobileNativeChatImageAttachments({
           await sleep(MOBILE_NATIVE_CHAT_IMAGE_SETTLE_MS)
           // The settle is deliberate pacing, not transport latency — credit it back
           // so a shared budget doesn't charge the text body for the TUI's beat.
-          const textDeadline = deadline + MOBILE_NATIVE_CHAT_IMAGE_SETTLE_MS
           // The paste above targeted `handle`; a tab switch during the settle would
           // route the text + Enter to a different terminal than the images. Abort —
           // the chips keep their scope and a retry's Ctrl+U clears the stale paste.
@@ -273,7 +271,7 @@ export function useMobileNativeChatImageAttachments({
           const outcome = await baseSend(
             text,
             pendingImages.map((attachment) => attachment.previewUri),
-            textDeadline
+            deadline + MOBILE_NATIVE_CHAT_IMAGE_SETTLE_MS
           )
           if (outcome !== 'accepted') {
             // 'rejected' leaves the pasted image path on this input line; 'unknown'


### PR DESCRIPTION
## ELI5

On mobile, attaching an image sent the image's file path to the agent as a bracketed paste with no trailing byte, then sent your prompt text as a separate write. The agent TUI unwrapped the paste and got `…png` glued straight onto your text — `…pngadd` instead of `…png add` — so it looked up a file that doesn't exist. This adds exactly one space, and only after the final image, and only when actual prompt text follows.

## What changed

Both mobile image-attach surfaces now route through `src/shared/image-paste-following-text`, the contract #15820 introduced for desktop.

- **Native chat composer** — `pasteMobileNativeChatImagePaths` takes `followedByText`, passed as `text.trim().length > 0`. Back-to-back image frames stay bare; only the final image gets the separator.
- **Terminal-mode attach button** — `attachMobileImageToTerminal` always separates. Attach-then-type is the whole interaction there, so there is no following text to test and no batch to look ahead in.
- `buildMobileImagePastePayload` stays byte-clean; the separator is applied at each call site.

## What stayed the same

- No RPC schema, persisted state, wire opcode, or platform-specific path contract changed.
- Upload, retry, stale-input, send-budget, tab-switch, SSH/folder, and relay behavior unchanged.
- Desktop is untouched; this only reuses the helper desktop already owns.

## Why

STA-4847. The separator belongs at the composing call site, which is the only place that knows whether prompt text follows — not in the attachment-only payload builder, which other callers rely on staying byte-clean.

## Verification

**Live emulator QA (iPhone 17 Pro / iOS 26.5, isolated dev host, LAN-only pairing).** Onboarding forks users between Chat UI and terminal view, so both surfaces are first-class; Grok is available in each. I captured the exact bytes the host writes to the PTY, running the identical flow twice against the same host — attach the same image, type `add`, send:

| Build | Paste write ends | Next write | Agent TUI sees |
| --- | --- | --- | --- |
| Pre-fix | `…png\x1b[201~` | `Add` | `…pngAdd` |
| Post-fix | `…png\x1b[201~ ` | `Add` | `…png Add` |

Only the fix differed between the two runs.

On a **terminal** tab I reproduced the ticket's symptom verbatim — the shell line rendered `…ab817e3739b.pngadd`. That is the gap the second commit closes. The terminal-attach fix is covered by an exact-byte unit test (non-vacuous: ablating the line fails it) and reuses the mechanism already proven end-to-end above, but I did not re-run the device capture for that specific path after tearing the rig down.

**Automated:**

- Ablation: reverting the one production line fails exactly 2 byte assertions (`\x1b[201~ ` vs `\x1b[201~`) — the tests are non-vacuous.
- Focused suites: 4 files / 50 tests pass.
- Full `mobile/src/session` suite: 147 files / 1373 tests pass.
- `tsc --noEmit` clean; `oxlint` clean on changed files.

## Deliberate divergence from desktop — worth a second opinion

The terminal attach button separates **unconditionally**. Desktop's twin of that button (`terminal-drop-path-writer`, fixed in #15820) only separates when a *next path in the same batch* is a non-image — it does not separate for "a human is about to type." Mirroring desktop literally would therefore still emit nothing for a single-image mobile attach, which is exactly the reported bug.

So this diverges on purpose: on mobile the following keystrokes are the interaction, a trailing space in a TUI input is inert, and a glued path is a hard failure. Flagging it explicitly rather than burying it.

**Still deferred:** terminal *clipboard* image paste (`use-mobile-terminal-paste.ts`) remains bare. That one's desktop twin (`terminal-clipboard-paste.ts`) is also bare and is tracked as STA-5258, so mobile stays consistent with desktop and should follow that ticket rather than diverge here.

## Linked issue

Fixes STA-4847
https://linear.app/stably/issue/STA-4847/unable-to-attach-an-imagine-with-grok-on-mobile-app

Desktop counterpart: #15820 (STA-4993), merged 2026-08-27 — this branch is now rebased onto it and carries only the mobile commit.

## Review

Author: @BrennanKB5

## Agent skill upstream boundary

- [x] Not applicable.
