### PR TITLE
fix(ssh): preserve relay sessions across build updates

### DIFF
--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -639,7 +639,10 @@ function isCompatiblePreferredRelayBuild(
   preferredServerBuildId: string | undefined,
   currentServerBuildId: string
 ): preferredServerBuildId is string {
-  if (!preferredServerBuildId || preferredServerBuildId === currentServerBuildId) {
+  if (!preferredServerBuildId) {
+    return false
+  }
+  if (preferredServerBuildId.replace(/^v/, '') === currentServerBuildId.replace(/^v/, '')) {
     return false
   }
   const versionPattern = /^v?(\d+\.\d+\.\d+)(?:\+[0-9a-f]+)?$/

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -642,10 +642,43 @@ function isCompatiblePreferredRelayBuild(
   if (!preferredServerBuildId || preferredServerBuildId === currentServerBuildId) {
     return false
   }
-  const versionPattern = /^(v?\d+\.\d+\.\d+)(?:\+[0-9a-f]+)?$/
+  const versionPattern = /^v?(\d+\.\d+\.\d+)(?:\+[0-9a-f]+)?$/
   const preferredVersion = versionPattern.exec(preferredServerBuildId)?.[1]
   const currentVersion = versionPattern.exec(currentServerBuildId)?.[1]
   return preferredVersion !== undefined && preferredVersion === currentVersion
+}
+
+/** Probes and connects to an existing POSIX relay without mutating its socket. */
+async function reconnectExistingPosixRelay(
+  conn: SshConnection,
+  remoteDir: string,
+  nodePath: string,
+  sockPath: string,
+  credentialFile: string,
+  signal?: AbortSignal
+): Promise<MultiplexerTransport | null> {
+  const probeOutput = await execCommand(
+    conn,
+    `test -S ${shellEscape(sockPath)} && echo ALIVE || echo DEAD`,
+    { signal }
+  ).catch((error) => {
+    signal?.throwIfAborted()
+    if (isUnconfirmedSshCommandTermination(error)) {
+      throw error
+    }
+    return 'DEAD'
+  })
+  console.warn(`[ssh-relay] Socket probe result: "${probeOutput.trim()}"`)
+  if (probeOutput.trim() !== 'ALIVE') {
+    return null
+  }
+
+  console.log('[ssh-relay] Existing relay socket found, attempting reconnect...')
+  const channel = await conn.exec(
+    `cd ${shellEscape(remoteDir)} && ${shellEscape(nodePath)} relay.js --connect --sock-path ${shellEscape(sockPath)} --credential-file ${shellEscape(credentialFile)}`,
+    { signal }
+  )
+  return waitForSentinel(channel, signal)
 }
 
 async function tryReconnectExistingRelay(
@@ -703,29 +736,19 @@ async function tryReconnectExistingRelay(
   }
 
   const sockPath = relayEndpointForHost(hostPlatform, remoteDir, sockName)
-  const alive = await execCommand(
-    conn,
-    `test -S ${shellEscape(sockPath)} && echo ALIVE || echo DEAD`,
-    { signal }
-  ).catch(() => {
-    signal?.throwIfAborted()
-    return 'DEAD'
-  })
-  if (alive.trim() !== 'ALIVE') {
-    return null
-  }
-
   try {
-    const channel = await conn.exec(
-      `cd ${shellEscape(remoteDir)} && ${shellEscape(nodePath)} relay.js --connect --sock-path ${shellEscape(sockPath)} --credential-file ${shellEscape(credentialFile)}`,
-      { signal }
-    )
-    return {
-      transport: await waitForSentinel(channel, signal),
+    const transport = await reconnectExistingPosixRelay(
+      conn,
+      remoteDir,
       nodePath,
       sockPath,
-      credentialFile
+      credentialFile,
+      signal
+    )
+    if (!transport) {
+      return null
     }
+    return { transport, nodePath, sockPath, credentialFile }
   } catch (error) {
     signal?.throwIfAborted()
     console.warn(
@@ -1550,45 +1573,34 @@ async function launchRelay(
 
   // Why: after a restart the relay may still be alive in its grace period; --connect to its socket preserves PTY state and scrollback.
   try {
-    const probeOutput = await execCommand(
+    const transport = await reconnectExistingPosixRelay(
       conn,
-      `test -S ${shellEscape(sockFile)} && echo ALIVE || echo DEAD`,
-      { signal }
+      remoteDir,
+      nodePath,
+      sockFile,
+      credentialFile,
+      signal
     )
-    console.warn(`[ssh-relay] Socket probe result: "${probeOutput.trim()}"`)
-    if (probeOutput.trim() === 'ALIVE') {
-      console.log('[ssh-relay] Existing relay socket found, attempting reconnect...')
-      try {
-        const channel = await conn.exec(
-          `cd ${escapedDir} && ${escapedNode} relay.js --connect --sock-path ${shellEscape(sockFile)} --credential-file ${shellEscape(credentialFile)}`,
-          { signal }
-        )
-        const transport = await waitForSentinel(channel, signal)
-        console.log('[ssh-relay] Reconnected to existing relay via socket')
-        return { transport, nodePath, sockPath: sockFile, credentialFile }
-      } catch (err) {
-        signal?.throwIfAborted()
-        console.warn(
-          '[ssh-relay] Socket reconnect failed, launching fresh relay:',
-          err instanceof Error ? err.message : String(err)
-        )
-        // Why: stale socket from a crashed relay — remove it so the fresh launch can bind at the same path.
-        await execCommand(conn, `rm -f ${shellEscape(sockFile)}`, { signal }).catch(
-          (cleanupErr) => {
-            if (isUnconfirmedSshCommandTermination(cleanupErr)) {
-              throw cleanupErr
-            }
-          }
-        )
-        signal?.throwIfAborted()
-      }
+    if (transport) {
+      console.log('[ssh-relay] Reconnected to existing relay via socket')
+      return { transport, nodePath, sockPath: sockFile, credentialFile }
     }
   } catch (err) {
     if (isUnconfirmedSshCommandTermination(err)) {
       throw err
     }
     signal?.throwIfAborted()
-    // Probe failed — fall through to fresh launch
+    console.warn(
+      '[ssh-relay] Socket reconnect failed, launching fresh relay:',
+      err instanceof Error ? err.message : String(err)
+    )
+    // Why: stale socket from a crashed relay — remove it so the fresh launch can bind at the same path.
+    await execCommand(conn, `rm -f ${shellEscape(sockFile)}`, { signal }).catch((cleanupErr) => {
+      if (isUnconfirmedSshCommandTermination(cleanupErr)) {
+        throw cleanupErr
+      }
+    })
+    signal?.throwIfAborted()
   }
 
   // Why: relay must outlive the SSH connection so PTY sessions survive app restarts — nohup + </dev/null + & detach it from the exec channel.

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -132,7 +132,8 @@ export async function deployAndLaunchRelay(
   conn: SshConnection,
   onProgress?: (status: string) => void,
   graceTimeSeconds?: number,
-  relayInstanceId?: string
+  relayInstanceId?: string,
+  preferredServerBuildId?: string
 ): Promise<RelayDeployResult> {
   let timeoutHandle: ReturnType<typeof setTimeout>
   const deployAbortController = new AbortController()
@@ -142,7 +143,8 @@ export async function deployAndLaunchRelay(
     onProgress,
     graceTimeSeconds,
     relayInstanceId,
-    deployAbortController.signal
+    deployAbortController.signal,
+    preferredServerBuildId
   ).then(
     (result) => ({ status: 'fulfilled' as const, result }),
     (error: unknown) => ({ status: 'rejected' as const, error })
@@ -328,7 +330,8 @@ async function deployAndLaunchRelayInner(
   onProgress?: (status: string) => void,
   graceTimeSeconds?: number,
   relayInstanceId?: string,
-  deploySignal?: AbortSignal
+  deploySignal?: AbortSignal,
+  preferredServerBuildId?: string
 ): Promise<RelayDeployResult> {
   while (true) {
     deploySignal?.throwIfAborted()
@@ -338,7 +341,8 @@ async function deployAndLaunchRelayInner(
         onProgress,
         graceTimeSeconds,
         relayInstanceId,
-        deploySignal
+        deploySignal,
+        preferredServerBuildId
       )
     } catch (err) {
       if (!(err instanceof RelayDirectoryGcConflictError)) {
@@ -355,7 +359,8 @@ async function deployAndLaunchRelayAttempt(
   onProgress?: (status: string) => void,
   graceTimeSeconds?: number,
   relayInstanceId?: string,
-  deploySignal?: AbortSignal
+  deploySignal?: AbortSignal,
+  preferredServerBuildId?: string
 ): Promise<RelayDeployResult> {
   onProgress?.('Detecting remote platform...')
   console.log('[ssh-relay] Detecting remote platform...')
@@ -384,6 +389,34 @@ async function deployAndLaunchRelayAttempt(
     await resolveRelayBootstrapState(conn, hostPlatform, fullVersion, deploySignal)
   console.log(`[ssh-relay] Remote dir: ${remoteRelayDir}`)
   console.log(`[ssh-relay] Already installed at ${fullVersion}: ${alreadyInstalled}`)
+
+  if (isCompatiblePreferredRelayBuild(preferredServerBuildId, fullVersion)) {
+    const preferredRelayDir = computeRemoteRelayDir(
+      remoteHome,
+      preferredServerBuildId,
+      hostPlatform.pathFlavor
+    )
+    onProgress?.('Reconnecting preserved relay...')
+    const preferred = await tryReconnectExistingRelay(
+      conn,
+      preferredRelayDir,
+      hostPlatform,
+      nodePath,
+      relayInstanceId,
+      deploySignal
+    )
+    if (preferred) {
+      console.log(`[ssh-relay] Reconnected to preserved build ${preferredServerBuildId}`)
+      return {
+        ...preferred,
+        serverBuildId: preferredServerBuildId,
+        platform,
+        hostPlatform,
+        remoteHome,
+        remoteRelayDir: preferredRelayDir
+      }
+    }
+  }
 
   // Why: derive the home-relative suffix once — recomputing it by stripping the shell home breaks on a split namespace.
   const homeRelativeRelayDir = relayHomeRelativeDir(fullVersion)
@@ -599,6 +632,106 @@ async function deployAndLaunchRelayAttempt(
     nodePath: launched.nodePath,
     sockPath: launched.sockPath,
     credentialFile: launched.credentialFile
+  }
+}
+
+function isCompatiblePreferredRelayBuild(
+  preferredServerBuildId: string | undefined,
+  currentServerBuildId: string
+): preferredServerBuildId is string {
+  if (!preferredServerBuildId || preferredServerBuildId === currentServerBuildId) {
+    return false
+  }
+  const versionPattern = /^(v?\d+\.\d+\.\d+)(?:\+[0-9a-f]+)?$/
+  const preferredVersion = versionPattern.exec(preferredServerBuildId)?.[1]
+  const currentVersion = versionPattern.exec(currentServerBuildId)?.[1]
+  return preferredVersion !== undefined && preferredVersion === currentVersion
+}
+
+async function tryReconnectExistingRelay(
+  conn: SshConnection,
+  remoteDir: string,
+  hostPlatform: RemoteHostPlatform,
+  nodePath: string,
+  relayInstanceId?: string,
+  signal?: AbortSignal
+): Promise<{
+  transport: MultiplexerTransport
+  nodePath: string
+  sockPath: string
+  credentialFile: string
+} | null> {
+  const sockName = relaySocketNameForInstanceId(relayInstanceId)
+  const credentialFile = joinRemotePath(hostPlatform, remoteDir, `${sockName}.credential`)
+
+  if (isWindowsRemoteHost(hostPlatform)) {
+    const markerPath = windowsActivePipeMarkerPath(hostPlatform, remoteDir, sockName)
+    const discovered = await readWindowsActiveRelayEndpoint(
+      conn,
+      hostPlatform,
+      remoteDir,
+      markerPath,
+      signal
+    )
+    const candidates = [
+      discovered?.sockPath,
+      relayEndpointForHost(hostPlatform, remoteDir, sockName),
+      relayEndpointForHost(hostPlatform, remoteDir, windowsRelayFallbackSocketName(sockName))
+    ].filter((sockPath, index, all): sockPath is string =>
+      Boolean(sockPath && all.indexOf(sockPath) === index)
+    )
+    for (const sockPath of candidates) {
+      const opts = { remoteDir, nodePath, sockPath, credentialFile }
+      try {
+        if ((await probeWindowsRelayPipe(conn, hostPlatform, opts, signal)) !== 'READY') {
+          continue
+        }
+        return {
+          transport: await connectWindowsRelay(conn, hostPlatform, opts, signal),
+          nodePath,
+          sockPath,
+          credentialFile
+        }
+      } catch (error) {
+        signal?.throwIfAborted()
+        console.warn(
+          `[ssh-relay] Preserved Windows relay reconnect failed at ${sockPath}: ${error instanceof Error ? error.message : String(error)}`
+        )
+      }
+    }
+    return null
+  }
+
+  const sockPath = relayEndpointForHost(hostPlatform, remoteDir, sockName)
+  const alive = await execCommand(
+    conn,
+    `test -S ${shellEscape(sockPath)} && echo ALIVE || echo DEAD`,
+    { signal }
+  ).catch(() => {
+    signal?.throwIfAborted()
+    return 'DEAD'
+  })
+  if (alive.trim() !== 'ALIVE') {
+    return null
+  }
+
+  try {
+    const channel = await conn.exec(
+      `cd ${shellEscape(remoteDir)} && ${shellEscape(nodePath)} relay.js --connect --sock-path ${shellEscape(sockPath)} --credential-file ${shellEscape(credentialFile)}`,
+      { signal }
+    )
+    return {
+      transport: await waitForSentinel(channel, signal),
+      nodePath,
+      sockPath,
+      credentialFile
+    }
+  } catch (error) {
+    signal?.throwIfAborted()
+    console.warn(
+      `[ssh-relay] Preserved relay reconnect failed at ${sockPath}: ${error instanceof Error ? error.message : String(error)}`
+    )
+    return null
   }
 }
 

--- a/src/main/ssh/ssh-relay-preserved-build-reconnect.test.ts
+++ b/src/main/ssh/ssh-relay-preserved-build-reconnect.test.ts
@@ -178,10 +178,11 @@ describe('preserved relay build reconnect', () => {
     )
 
     expect(result.serverBuildId).toBe('0.1.0+abcdef012345')
-    const commands = [
-      ...vi.mocked(execCommand).mock.calls.map(([, command]) => command),
-      ...vi.mocked(conn.exec).mock.calls.map(([command]) => command as string)
-    ]
+    const hostCommands = vi.mocked(execCommand).mock.calls.map(([, command]) => command)
+    const channelCommands = vi.mocked(conn.exec).mock.calls.map(([command]) => command as string)
+    const commands = [...hostCommands, ...channelCommands]
+    expect(hostCommands.filter((command) => command.startsWith('test -S '))).toHaveLength(1)
+    expect(channelCommands.some((command) => command.includes('relay.js --detached'))).toBe(true)
     expect(commands.some((command) => command.includes(previousBuildId))).toBe(false)
   })
 

--- a/src/main/ssh/ssh-relay-preserved-build-reconnect.test.ts
+++ b/src/main/ssh/ssh-relay-preserved-build-reconnect.test.ts
@@ -97,9 +97,11 @@ describe('preserved relay build reconnect', () => {
     vi.mocked(resolveRemoteNodePath).mockReset().mockResolvedValue('/usr/bin/node')
   })
 
-  it('reconnects the persisted relay before deploying a new content hash', async () => {
+  it.each([
+    ['without a version prefix', '0.1.0+111111111111'],
+    ['with a version prefix', 'v0.1.0+111111111111']
+  ])('reconnects the persisted relay $label', async (_label, previousBuildId) => {
     const conn = makeMockConnection()
-    const previousBuildId = '0.1.0+111111111111'
     vi.mocked(execCommand)
       .mockResolvedValueOnce('__ORCA_REMOTE_PLATFORM__ Linux x86_64')
       .mockResolvedValueOnce('/home/user')

--- a/src/main/ssh/ssh-relay-preserved-build-reconnect.test.ts
+++ b/src/main/ssh/ssh-relay-preserved-build-reconnect.test.ts
@@ -1,0 +1,213 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SshConnection } from './ssh-connection'
+
+vi.mock('electron', () => ({
+  app: { getAppPath: () => '/mock/app' }
+}))
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn().mockReturnValue(true),
+  readFileSync: vi.fn().mockReturnValue('0.1.0+abcdef012345')
+}))
+
+vi.mock('./relay-protocol', () => ({
+  RELAY_VERSION: '0.1.0',
+  RELAY_REMOTE_DIR: '.orca-remote',
+  parseUnameToRelayPlatform: vi.fn((os: string, arch: string) => {
+    const relayArch = ['arm64', 'aarch64'].includes(arch.toLowerCase()) ? 'arm64' : 'x64'
+    return os.toLowerCase() === 'windows' ? `win32-${relayArch}` : `linux-${relayArch}`
+  }),
+  RELAY_SENTINEL: 'ORCA-RELAY v0.1.0 READY\n',
+  RELAY_SENTINEL_TIMEOUT_MS: 10_000
+}))
+
+vi.mock('./ssh-relay-deploy-helpers', () => ({
+  uploadDirectory: vi.fn().mockResolvedValue(undefined),
+  waitForSentinel: vi.fn(),
+  isUnconfirmedSshCommandTermination: (error: unknown) =>
+    error instanceof Error &&
+    (error as Error & { sshChannelCloseConfirmed?: boolean }).sshChannelCloseConfirmed === false,
+  execCommand: vi.fn()
+}))
+
+vi.mock('./ssh-remote-node-resolution', () => ({
+  resolveRemoteNodePath: vi.fn().mockResolvedValue('/usr/bin/node')
+}))
+
+vi.mock('./ssh-relay-endpoint-credential', () => ({
+  writeRelayEndpointCredential: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('./ssh-relay-versioned-install', () => ({
+  readLocalFullVersion: vi.fn().mockReturnValue('0.1.0+abcdef012345'),
+  computeRemoteRelayDir: (home: string, version: string) => `${home}/.orca-remote/relay-${version}`,
+  isRelayAlreadyInstalled: vi.fn().mockResolvedValue(true),
+  finalizeInstall: vi.fn().mockResolvedValue(undefined),
+  abandonInstall: vi.fn().mockResolvedValue(undefined),
+  gcOldRelayVersions: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('./ssh-relay-install-lock', () => ({
+  acquireInstallLock: vi.fn().mockResolvedValue(undefined),
+  RELAY_INSTALL_LOCK_NAME: '.install-lock'
+}))
+
+vi.mock('./ssh-relay-repair-lock', () => ({
+  tryAcquireRelayRepairLock: vi.fn().mockResolvedValue('acquired')
+}))
+
+vi.mock('./ssh-connection-utils', () => ({
+  shellEscape: (value: string) => `'${value}'`,
+  createSshOperationAbortError: () =>
+    Object.assign(new Error('SSH operation was cancelled'), { name: 'AbortError' })
+}))
+
+import { deployAndLaunchRelay } from './ssh-relay-deploy'
+import { execCommand, waitForSentinel } from './ssh-relay-deploy-helpers'
+import { resolveRemoteNodePath } from './ssh-remote-node-resolution'
+import { isRelayAlreadyInstalled } from './ssh-relay-versioned-install'
+
+function makeMockConnection(): SshConnection {
+  return {
+    canRunConcurrentExecCommands: vi.fn().mockReturnValue(true),
+    exec: vi.fn().mockResolvedValue({
+      on: vi.fn(),
+      stderr: { on: vi.fn() },
+      stdin: {},
+      stdout: { on: vi.fn() },
+      close: vi.fn()
+    }),
+    writeFile: vi.fn().mockResolvedValue(undefined)
+  } as unknown as SshConnection
+}
+
+function decodePowerShellCommand(command: string): string {
+  const encoded = command.match(/-EncodedCommand\s+([A-Za-z0-9+/=]+)/)?.[1] ?? ''
+  return Buffer.from(encoded, 'base64').toString('utf16le')
+}
+
+describe('preserved relay build reconnect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(execCommand).mockReset().mockResolvedValue('__ORCA_REMOTE_PLATFORM__ Linux x86_64')
+    vi.mocked(waitForSentinel)
+      .mockReset()
+      .mockResolvedValue({ write: vi.fn(), onData: vi.fn(), onClose: vi.fn() })
+    vi.mocked(isRelayAlreadyInstalled).mockReset().mockResolvedValue(true)
+    vi.mocked(resolveRemoteNodePath).mockReset().mockResolvedValue('/usr/bin/node')
+  })
+
+  it('reconnects the persisted relay before deploying a new content hash', async () => {
+    const conn = makeMockConnection()
+    const previousBuildId = '0.1.0+111111111111'
+    vi.mocked(execCommand)
+      .mockResolvedValueOnce('__ORCA_REMOTE_PLATFORM__ Linux x86_64')
+      .mockResolvedValueOnce('/home/user')
+      .mockResolvedValueOnce('ALIVE')
+
+    const result = await deployAndLaunchRelay(
+      conn,
+      undefined,
+      undefined,
+      'target-a',
+      previousBuildId
+    )
+
+    expect(result.serverBuildId).toBe(previousBuildId)
+    expect(result.remoteRelayDir).toBe(`/home/user/.orca-remote/relay-${previousBuildId}`)
+    const commands = vi.mocked(conn.exec).mock.calls.map(([command]) => command as string)
+    expect(commands).toHaveLength(1)
+    expect(commands[0]).toContain(`/relay-${previousBuildId}`)
+    expect(commands[0]).toContain('relay.js --connect')
+    expect(commands[0]).not.toContain('--detached')
+  })
+
+  it('falls back without unlinking the preserved relay socket', async () => {
+    const conn = makeMockConnection()
+    const previousBuildId = '0.1.0+111111111111'
+    vi.mocked(waitForSentinel)
+      .mockRejectedValueOnce(new Error('preserved relay unavailable'))
+      .mockResolvedValueOnce({ write: vi.fn(), onData: vi.fn(), onClose: vi.fn() })
+    vi.mocked(execCommand)
+      .mockResolvedValueOnce('__ORCA_REMOTE_PLATFORM__ Linux x86_64')
+      .mockResolvedValueOnce('/home/user')
+      .mockResolvedValueOnce('ALIVE')
+      .mockResolvedValueOnce('ORCA-NATIVE-DEPS-OK')
+      .mockResolvedValueOnce('')
+      .mockResolvedValueOnce('DEAD')
+      .mockResolvedValueOnce('READY')
+
+    const result = await deployAndLaunchRelay(
+      conn,
+      undefined,
+      undefined,
+      'target-a',
+      previousBuildId
+    )
+
+    expect(result.serverBuildId).toBe('0.1.0+abcdef012345')
+    const commands = vi.mocked(execCommand).mock.calls.map(([, command]) => command)
+    expect(
+      commands.some(
+        (command) => command.includes('rm -f') && command.includes(`/relay-${previousBuildId}/`)
+      )
+    ).toBe(false)
+  })
+
+  it('does not reconnect a build from another relay protocol version', async () => {
+    const conn = makeMockConnection()
+    vi.mocked(execCommand)
+      .mockResolvedValueOnce('__ORCA_REMOTE_PLATFORM__ Linux x86_64')
+      .mockResolvedValueOnce('/home/user')
+      .mockResolvedValueOnce('ORCA-NATIVE-DEPS-OK')
+      .mockResolvedValueOnce('')
+      .mockResolvedValueOnce('DEAD')
+      .mockResolvedValueOnce('READY')
+
+    const result = await deployAndLaunchRelay(
+      conn,
+      undefined,
+      undefined,
+      'target-a',
+      '0.2.0+111111111111'
+    )
+
+    expect(result.serverBuildId).toBe('0.1.0+abcdef012345')
+    const commands = [
+      ...vi.mocked(execCommand).mock.calls.map(([, command]) => command),
+      ...vi.mocked(conn.exec).mock.calls.map(([command]) => command as string)
+    ]
+    expect(commands.some((command) => command.includes('0.2.0+111111111111'))).toBe(false)
+  })
+
+  it('reconnects the persisted build through its Windows active pipe', async () => {
+    const conn = makeMockConnection()
+    const previousBuildId = '0.1.0+111111111111'
+    const persistedPipe = '\\\\.\\pipe\\orca-relay-1234567890abcdef1234'
+    vi.mocked(resolveRemoteNodePath).mockResolvedValue('C:/Program Files/nodejs/node.exe')
+    vi.mocked(execCommand)
+      .mockRejectedValueOnce(new Error('uname not found'))
+      .mockResolvedValueOnce('__ORCA_REMOTE_PLATFORM__ Windows X64')
+      .mockResolvedValueOnce('C:\\Users\\me')
+      .mockResolvedValueOnce(persistedPipe)
+      .mockResolvedValueOnce('READY')
+
+    const result = await deployAndLaunchRelay(
+      conn,
+      undefined,
+      undefined,
+      'target-a',
+      previousBuildId
+    )
+
+    expect(result.serverBuildId).toBe(previousBuildId)
+    expect(result.sockPath).toBe(persistedPipe)
+    const commands = vi
+      .mocked(conn.exec)
+      .mock.calls.map(([command]) => decodePowerShellCommand(command as string))
+    expect(commands).toHaveLength(1)
+    expect(commands[0]).toContain(`relay-${previousBuildId}`)
+    expect(commands[0]).toContain('relay.js --connect')
+    expect(commands[0]).not.toContain('Invoke-CimMethod')
+  })
+})

--- a/src/main/ssh/ssh-relay-preserved-build-reconnect.test.ts
+++ b/src/main/ssh/ssh-relay-preserved-build-reconnect.test.ts
@@ -100,7 +100,7 @@ describe('preserved relay build reconnect', () => {
   it.each([
     ['without a version prefix', '0.1.0+111111111111'],
     ['with a version prefix', 'v0.1.0+111111111111']
-  ])('reconnects the persisted relay $label', async (_label, previousBuildId) => {
+  ])('reconnects the persisted relay %s', async (_label, previousBuildId) => {
     const conn = makeMockConnection()
     vi.mocked(execCommand)
       .mockResolvedValueOnce('__ORCA_REMOTE_PLATFORM__ Linux x86_64')
@@ -156,7 +156,10 @@ describe('preserved relay build reconnect', () => {
     ).toBe(false)
   })
 
-  it('does not reconnect a build from another relay protocol version', async () => {
+  it.each([
+    ['another relay protocol version', '0.2.0+111111111111'],
+    ['the current build with a version prefix', 'v0.1.0+abcdef012345']
+  ])('does not reconnect %s', async (_label, previousBuildId) => {
     const conn = makeMockConnection()
     vi.mocked(execCommand)
       .mockResolvedValueOnce('__ORCA_REMOTE_PLATFORM__ Linux x86_64')
@@ -171,7 +174,7 @@ describe('preserved relay build reconnect', () => {
       undefined,
       undefined,
       'target-a',
-      '0.2.0+111111111111'
+      previousBuildId
     )
 
     expect(result.serverBuildId).toBe('0.1.0+abcdef012345')
@@ -179,7 +182,7 @@ describe('preserved relay build reconnect', () => {
       ...vi.mocked(execCommand).mock.calls.map(([, command]) => command),
       ...vi.mocked(conn.exec).mock.calls.map(([command]) => command as string)
     ]
-    expect(commands.some((command) => command.includes('0.2.0+111111111111'))).toBe(false)
+    expect(commands.some((command) => command.includes(previousBuildId))).toBe(false)
   })
 
   it('reconnects the persisted build through its Windows active pipe', async () => {

--- a/src/main/ssh/ssh-relay-session-preserved-build.test.ts
+++ b/src/main/ssh/ssh-relay-session-preserved-build.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createMockDeps, mockDeploySuccess } from './ssh-relay-session-test-fixtures'
+
+const { muxRequestMock, openConsumerSessionMock } = vi.hoisted(() => ({
+  muxRequestMock: vi.fn(),
+  openConsumerSessionMock: vi.fn()
+}))
+
+vi.mock('./ssh-relay-deploy', () => ({ deployAndLaunchRelay: vi.fn() }))
+
+vi.mock('./ssh-pty-consumer-session', () => ({
+  openSshPtyConsumerSession: openConsumerSessionMock
+}))
+
+vi.mock('../ipc/ssh-pty-output-intake-registry', () => ({
+  acceptSshPtyOutputData: vi.fn().mockResolvedValue(undefined),
+  acceptSshPtyOutputExit: vi.fn().mockResolvedValue(undefined),
+  allocateSshPtyProviderGeneration: vi.fn(() => 17),
+  beginSshPtyOutputGenerationMigration: vi.fn(() => ({
+    byPty: new Map(),
+    completion: Promise.resolve()
+  })),
+  closeSshPtyOutputGeneration: vi.fn(),
+  getSshPtyAcceptedSourceCheckpoints: vi.fn(() => []),
+  applySshPtySourceRecoveryCancellationProof: vi.fn(() => true),
+  installSshPtySourceAckPublisher: vi.fn(() => () => {}),
+  installSshPtySourceCancellationPublisher: vi.fn(() => () => {})
+}))
+
+vi.mock('./ssh-relay-deploy-helpers', () => ({
+  execCommand: vi.fn().mockResolvedValue('')
+}))
+
+vi.mock('./ssh-channel-multiplexer', () => ({
+  SshChannelMultiplexer: class MockSshChannelMultiplexer {
+    notify = vi.fn()
+    notifyWithSettlement = vi.fn()
+    request = muxRequestMock
+    onNotification = vi.fn().mockReturnValue(() => {})
+    onNotificationByMethod = vi.fn().mockReturnValue(() => {})
+    onRequest = vi.fn().mockReturnValue(() => {})
+    onDispose = vi.fn().mockReturnValue(() => {})
+    dispose = vi.fn()
+    isDisposed = vi.fn().mockReturnValue(false)
+  }
+}))
+
+vi.mock('../providers/ssh-pty-provider', () => ({
+  SshPtyProvider: class MockSshPtyProvider {
+    onData = vi.fn().mockReturnValue(() => {})
+    onReplay = vi.fn().mockReturnValue(() => {})
+    onExit = vi.fn().mockReturnValue(() => {})
+    attachForReconnect = vi.fn().mockResolvedValue({})
+    dispose = vi.fn()
+  }
+}))
+
+vi.mock('../providers/ssh-filesystem-provider', () => ({
+  SshFilesystemProvider: class MockSshFilesystemProvider {
+    dispose = vi.fn()
+  }
+}))
+
+vi.mock('../providers/ssh-git-provider', () => ({
+  SshGitProvider: class MockSshGitProvider {}
+}))
+
+vi.mock('../ipc/pty', () => ({
+  registerSshPtyProvider: vi.fn(),
+  unregisterSshPtyProvider: vi.fn(),
+  getSshPtyProvider: vi.fn().mockReturnValue({
+    attachForReconnect: vi.fn().mockResolvedValue({}),
+    dispose: vi.fn()
+  }),
+  getPtyIdsForConnection: vi.fn().mockReturnValue([]),
+  clearPtyOwnershipForConnection: vi.fn(),
+  clearProviderPtyState: vi.fn(),
+  deletePtyOwnership: vi.fn(),
+  setPtyOwnership: vi.fn(),
+  restorePtyIncarnation: vi.fn(),
+  isCurrentPtyExit: vi.fn(() => true)
+}))
+
+vi.mock('../providers/ssh-filesystem-dispatch', () => ({
+  registerSshFilesystemProvider: vi.fn(),
+  unregisterSshFilesystemProvider: vi.fn(),
+  getSshFilesystemProvider: vi.fn().mockReturnValue({ dispose: vi.fn() })
+}))
+
+vi.mock('../providers/ssh-git-dispatch', () => ({
+  registerSshGitProvider: vi.fn(),
+  unregisterSshGitProvider: vi.fn()
+}))
+
+import { SshRelaySession } from './ssh-relay-session'
+import { deployAndLaunchRelay } from './ssh-relay-deploy'
+
+describe('SshRelaySession preserved relay build', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    muxRequestMock.mockReset().mockResolvedValue([])
+    openConsumerSessionMock.mockImplementation(async (_mux, options) => ({
+      mode: 'legacy-fallback',
+      clientInstanceId: options.clientInstanceId,
+      serverBuildId: 'test-relay-build'
+    }))
+    mockDeploySuccess()
+  })
+
+  it('prefers the persisted build while it still owns a PTY lease', async () => {
+    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    const targetId = 'target-with-previous-build'
+    vi.mocked(mockStore.getSshPtyConsumerRecovery).mockReturnValue({
+      targetId,
+      clientInstanceId: 'client-1',
+      serverBuildId: '0.1.0+111111111111',
+      clientGeneration: 1,
+      ownerGeneration: 1,
+      ownerLease: 'owner-lease'
+    })
+    vi.mocked(mockStore.getSshRemotePtyLeases).mockReturnValue([
+      {
+        targetId,
+        ptyId: 'pty-1',
+        state: 'detached',
+        createdAt: 1,
+        updatedAt: 1
+      }
+    ])
+    const session = new SshRelaySession(targetId, getMainWindow, mockStore, mockPortForward)
+
+    await session.establish(mockConn)
+
+    expect(deployAndLaunchRelay).toHaveBeenCalledWith(
+      mockConn,
+      undefined,
+      undefined,
+      targetId,
+      '0.1.0+111111111111'
+    )
+  })
+
+  it('uses the current build when no attached or detached lease remains', async () => {
+    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    const targetId = 'target-with-terminal-leases'
+    vi.mocked(mockStore.getSshPtyConsumerRecovery).mockReturnValue({
+      targetId,
+      clientInstanceId: 'client-2',
+      serverBuildId: '0.1.0+111111111111',
+      clientGeneration: 1,
+      ownerGeneration: 1,
+      ownerLease: 'owner-lease'
+    })
+    vi.mocked(mockStore.getSshRemotePtyLeases).mockReturnValue([
+      {
+        targetId,
+        ptyId: 'pty-1',
+        state: 'terminated',
+        createdAt: 1,
+        updatedAt: 1
+      },
+      {
+        targetId,
+        ptyId: 'pty-2',
+        state: 'expired',
+        createdAt: 1,
+        updatedAt: 1
+      }
+    ])
+    const session = new SshRelaySession(targetId, getMainWindow, mockStore, mockPortForward)
+
+    await session.establish(mockConn)
+
+    expect(deployAndLaunchRelay).toHaveBeenCalledWith(mockConn, undefined, undefined, targetId)
+  })
+})

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -521,7 +521,7 @@ export class SshRelaySession {
         sockPath,
         credentialFile,
         hostPlatform
-      } = await deployAndLaunchRelay(conn, undefined, graceTimeSeconds, this.targetId)
+      } = await this.deployRelay(conn, graceTimeSeconds)
       this.hostPlatform = hostPlatform ?? null
       this.remoteCliBridgeEnv =
         remoteHome && remoteRelayDir && nodePath && sockPath && hostPlatform
@@ -667,7 +667,7 @@ export class SshRelaySession {
         sockPath,
         credentialFile,
         hostPlatform
-      } = await deployAndLaunchRelay(conn, undefined, graceTimeSeconds, this.targetId)
+      } = await this.deployRelay(conn, graceTimeSeconds)
       this.hostPlatform = hostPlatform ?? null
       this.remoteCliBridgeEnv =
         remoteHome && remoteRelayDir && nodePath && sockPath && hostPlatform
@@ -1256,6 +1256,25 @@ export class SshRelaySession {
       owner,
       store: this.store
     })
+  }
+
+  private deployRelay(
+    conn: SshConnection,
+    graceTimeSeconds?: number
+  ): ReturnType<typeof deployAndLaunchRelay> {
+    const recovery = getSshPtyConsumerRecovery(this.targetId)
+    const hasRecoverableLease = this.store
+      .getSshRemotePtyLeases(this.targetId)
+      .some((lease) => lease.state === 'attached' || lease.state === 'detached')
+    return recovery?.serverBuildId && hasRecoverableLease
+      ? deployAndLaunchRelay(
+          conn,
+          undefined,
+          graceTimeSeconds,
+          this.targetId,
+          recovery.serverBuildId
+        )
+      : deployAndLaunchRelay(conn, undefined, graceTimeSeconds, this.targetId)
   }
 
   private configureRelayGraceTime(


### PR DESCRIPTION
## ELI5

When Orca updates, an older SSH relay can still own open terminal sessions. Orca now reconnects to that exact relay build instead of making those terminals unreachable while their processes continue running.

## What Changed

- reconnect the persisted relay build while it owns attached or detached PTY leases
- restrict preserved-build reconnects to content-hash changes within the same relay protocol version
- normalize an optional v prefix when comparing protocol versions
- share the POSIX socket probe-and-connect path between preserved and current relay reconnects
- support Windows active and fallback named pipes
- fall back to the current build without unlinking or mutating a preserved relay

## Why

Relay bundles install in content-hashed directories. After an app update, the client always selected the new directory, so the previous relay kept its PTYs but became unreachable from the UI. With unlimited grace, those relay and agent process trees could remain alive indefinitely.

Persisted PTY consumer recovery already records the relay build that owns the target. Reusing that ownership record preserves the existing transport until its active leases end while retaining a safe fallback to the current relay.

## Linked Issue

Fixes #13614

Related: #9819

## Visual Proof

N/A — this changes SSH relay lifecycle behavior and has no UI change.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added and updated

Validation performed:

- 1,613 SSH and relay tests passed; 15 skipped
- Node TypeScript check passed
- type-aware oxlint passed
- lint-staged checks passed
- max-lines ratchet passed
- formatting check passed
- regression coverage includes POSIX reconnect, optional v-prefix normalization, Windows named-pipe reconnect, incompatible protocol fencing, and non-destructive fallback

## AI Disclosure

OpenAI Codex using GPT-5 assisted with diagnosis, implementation, tests, and review follow-up.

## Review

Please focus on mixed-version relay selection and the guarantee that preserved relay sockets are never removed during fallback.

## Agent skill upstream boundary

- [x] Not applicable; this change contains no agent skill source or registry changes.

## Notes

Existing relay generations that were already untracked before this fix still require an explicit relay reset or manual cleanup.

The change does not alter relay wire messages. It only selects a compatible content-hashed installation before opening the existing transport.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why, including ELI5
- [x] Visual proof is marked N/A because there is no UI change
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform and SSH impact considered
- [x] Targeted lint, typecheck, and test commands pass; full build and remaining checks may be covered by repository CI