### PR TITLE
fix(skills): isolate concurrent upload staging

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -13643,17 +13643,19 @@
       "providers": ["orca-server", "ssh"],
       "coveredPlatforms": ["macos"],
       "coveredProviders": ["ssh"],
-      "coverageNotes": "Two independent services share one parent under controlled ordering, four real crash boundaries run in child processes, and two bundled relays share one isolated home through distinct socket and hook endpoints. A current relay also shares that home safely with the originating relay in both launch orders. Linux, Windows, and paired headed/headless runtime process evidence remain uncollected; the change is host-local and changes no wire payload.",
+      "coverageNotes": "Two independent services share one parent under controlled ordering, four real crash boundaries run in child processes, and two bundled relays share one isolated home through distinct socket and hook endpoints. A current relay also shares that home safely with the originating relay in both launch orders. Graceful relay and desktop-runtime disposal join service cleanup. Linux, Windows, and paired headed/headless runtime process evidence remain uncollected; the change is host-local and changes no wire payload.",
       "motivatingLinks": [
         "https://linear.app/stably/issue/STA-4967",
         "https://github.com/stablyai/orca/pull/14934"
       ],
-      "invariant": "Initialization, cleanup, or disposal by one service process can never remove bytes owned by a still-live upload in another process. Each service owns one atomic PID-and-UUID namespace, each upload remains capped by the existing four-session and package-size limits, abandoned owner cleanup inspects at most 64 entries per attempt, and success, failure, cancellation, restart, and disposal release only their exact owned paths.",
-      "oracle": "Begin and partially append upload A, then begin upload B from an independent service or relay sharing the same parent. Require two exact owner directories, two exact archives, and byte-for-byte survival of A. Cancel B then A and require archive counts 1 then 0; dispose each owner and require directory counts 1 then 0. Kill real child owners at begun, partial, uploaded, and committed boundaries and require a fresh owner to remove only exited-process staging and complete its own transfer. Seed 65 exited owners, require one attempt to remove exactly 64 and reject before adding bytes, then require retry to drain the final stale owner and begin normally.",
+      "invariant": "Initialization, cleanup, or disposal by one service process can never remove bytes owned by a still-live upload in another process. Each service owns one atomic PID-and-UUID namespace, serializes begin admission at four active sessions, and retains the package-size limit. Abandoned owner cleanup inspects at most 64 entries per attempt, and success, failure, cancellation, restart, and disposal release only their exact owned paths.",
+      "oracle": "Begin and partially append upload A, then begin and append upload B from an independent service or relay sharing the same parent. Require two exact PID-and-UUID owner directories, two upload-ID archives, and byte-for-byte survival of both. Cancel B then A and require archive counts 1 then 0. Stage two more live uploads, terminate relay A, and require relay B's exact owner, archive, and bytes to survive before B terminates and the root becomes empty. Kill real child owners at begun, partial, uploaded, and committed boundaries and require a fresh owner to remove only exited-process staging and complete its own transfer. Seed 65 exited owners, require one attempt to remove exactly 64 and reject before adding bytes, then require retry to drain the final stale owner and begin normally.",
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/main/skills/skill-upload-session-service.test.ts --reporter=verbose",
         "ORCA_REAL_PROCESS_SKILL_TEST=1 pnpm exec vitest run --config config/vitest.config.ts src/main/skills/skill-upload-process-restart.integration.test.ts src/main/skills/skill-upload-process-restart-child.test.ts --pool=forks --maxWorkers=1 --no-file-parallelism --reporter=verbose",
-        "pnpm exec vitest run --config config/vitest.config.ts src/relay/skill-upload-multi-relay.integration.test.ts --pool=forks --maxWorkers=1 --no-file-parallelism --reporter=verbose"
+        "pnpm exec vitest run --config config/vitest.config.ts src/relay/skill-upload-multi-relay.integration.test.ts --pool=forks --maxWorkers=1 --no-file-parallelism --reporter=verbose",
+        "ORCA_REAL_PROCESS_SKILL_TEST=1 pnpm exec vitest run --config config/vitest.config.ts src/main/skills/skill-upload-session-service.test.ts src/main/skills/skill-upload-process-restart.integration.test.ts src/main/skills/skill-upload-process-restart-child.test.ts src/relay/skill-upload-multi-relay.integration.test.ts --pool=forks --maxWorkers=1 --no-file-parallelism --reporter=verbose",
+        "ORCA_SKILL_UPLOAD_LEGACY_RELAY_ENTRY=<fa9b20cb4163-relay.js> pnpm exec vitest run --config config/vitest.config.ts src/relay/skill-upload-multi-relay.integration.test.ts --pool=forks --maxWorkers=1 --no-file-parallelism --reporter=verbose"
       ],
       "testFiles": [
         "src/main/skills/skill-upload-session-service.test.ts",
@@ -13666,6 +13668,8 @@
           "file": "src/main/skills/skill-upload-session-service.test.ts",
           "assertions": [
             "a second service preserves the first service's exact file and bytes",
+            "five concurrent begins admit exactly four sessions and disposal removes them",
+            "disposal waits for an initializing begin and leaves no owner",
             "cancellation and disposal reduce exact archive and owner counts",
             "one abandoned-owner sweep removes at most 64 entries and retry completes"
           ]
@@ -13682,7 +13686,7 @@
           "assertions": [
             "two bundled relay PIDs retain separate archives under one account home",
             "current and originating relay bundles retain separate archives in both launch orders",
-            "relay cancellation and graceful shutdown clean only the exact owner"
+            "relay cancellation and live-upload graceful shutdown clean only the exact owner"
           ]
         }
       ],
@@ -13692,9 +13696,18 @@
           "runner": "local",
           "platform": "macos",
           "result": "passed",
-          "command": "pnpm exec vitest run --config config/vitest.config.ts src/relay/skill-upload-multi-relay.integration.test.ts --pool=forks --maxWorkers=1 --no-file-parallelism --reporter=verbose",
-          "durationSeconds": 4.8,
-          "summary": "Nine service tests, four crash-boundary cases, one two-current-relay topology, and two originating/current mixed-version launch orders passed with exact archive and owner counts."
+          "command": "ORCA_REAL_PROCESS_SKILL_TEST=1 pnpm exec vitest run --config config/vitest.config.ts src/main/skills/skill-upload-session-service.test.ts src/main/skills/skill-upload-process-restart.integration.test.ts src/main/skills/skill-upload-process-restart-child.test.ts src/relay/skill-upload-multi-relay.integration.test.ts --pool=forks --maxWorkers=1 --no-file-parallelism --reporter=verbose",
+          "durationSeconds": 3.5,
+          "summary": "Eleven service tests, four crash-boundary cases, and one two-current-relay topology passed; the child fixture and two explicitly separate mixed-version cases skipped."
+        },
+        {
+          "date": "2026-08-20",
+          "runner": "local",
+          "platform": "macos",
+          "result": "passed",
+          "command": "ORCA_SKILL_UPLOAD_LEGACY_RELAY_ENTRY=<fa9b20cb4163-relay.js> pnpm exec vitest run --config config/vitest.config.ts src/relay/skill-upload-multi-relay.integration.test.ts --pool=forks --maxWorkers=1 --no-file-parallelism --reporter=verbose",
+          "durationSeconds": 0.9,
+          "summary": "The current/current case and both originating/current mixed-version launch orders passed with exact per-root archive bytes."
         }
       ],
       "runtimeBudget": {
@@ -13722,7 +13735,8 @@
       "knownGaps": [
         "The live two-relay and crash evidence was collected on macOS; Linux and Windows process/filesystem behavior remains CI coverage.",
         "The service is shared by paired runtimes, but separate headed and headless paired-runtime process journeys were not run.",
-        "PID reuse is handled conservatively: an abandoned namespace whose PID is currently occupied is preserved until a later process generation rather than risking deletion of live bytes."
+        "PID reuse is handled conservatively: an abandoned namespace whose PID is currently occupied is preserved until a later process generation rather than risking deletion of live bytes.",
+        "The legacy remote-uploads root is intentionally not reclaimed while a mixed-version relay may still own bytes there; eventual legacy-root retirement requires a separate compatibility decision."
       ],
       "demotionRule": "Demote if one live owner can remove another owner's bytes, cleanup exceeds 64 inspected entries per attempt, a lifecycle path retains its exact owned archive after settlement, or the process oracle flakes without an identified harness or product defect."
     }

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -13673,6 +13673,7 @@
             "five concurrent begins admit exactly four sessions and disposal removes them",
             "disposal waits for an initializing begin and leaves no owner",
             "concurrent disposal callers join the same exact cleanup promise",
+            "archive hashing failure releases the session and rejects later appends",
             "cancellation and disposal reduce exact archive and owner counts",
             "one abandoned-owner sweep removes at most 64 entries and retry completes"
           ]
@@ -13701,7 +13702,7 @@
           "result": "passed",
           "command": "ORCA_REAL_PROCESS_SKILL_TEST=1 pnpm exec vitest run --config config/vitest.config.ts src/main/skills/skill-upload-session-service.test.ts src/main/skills/skill-upload-process-restart.integration.test.ts src/main/skills/skill-upload-process-restart-child.test.ts src/relay/skill-upload-multi-relay.integration.test.ts --pool=forks --maxWorkers=1 --no-file-parallelism --reporter=verbose",
           "durationSeconds": 3.5,
-          "summary": "Twelve service tests, four crash-boundary cases, and one two-current-relay topology passed; the child fixture and two explicitly separate mixed-version cases skipped."
+          "summary": "Thirteen service tests, four crash-boundary cases, and one two-current-relay topology passed; the child fixture and two explicitly separate mixed-version cases skipped."
         },
         {
           "date": "2026-08-20",

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -13674,6 +13674,8 @@
             "disposal waits for an initializing begin and leaves no owner",
             "concurrent disposal callers join the same exact cleanup promise",
             "archive hashing failure releases the session and rejects later appends",
+            "symlink or junction staging roots are rejected before cleanup or admission",
+            "failed archive removal remains owned and counts toward the four-path bound",
             "cancellation and disposal reduce exact archive and owner counts",
             "one abandoned-owner sweep removes at most 64 entries and retry completes"
           ]
@@ -13701,8 +13703,8 @@
           "platform": "macos",
           "result": "passed",
           "command": "ORCA_REAL_PROCESS_SKILL_TEST=1 pnpm exec vitest run --config config/vitest.config.ts src/main/skills/skill-upload-session-service.test.ts src/main/skills/skill-upload-process-restart.integration.test.ts src/main/skills/skill-upload-process-restart-child.test.ts src/relay/skill-upload-multi-relay.integration.test.ts --pool=forks --maxWorkers=1 --no-file-parallelism --reporter=verbose",
-          "durationSeconds": 3.5,
-          "summary": "Thirteen service tests, four crash-boundary cases, and one two-current-relay topology passed; the child fixture and two explicitly separate mixed-version cases skipped."
+          "durationSeconds": 5.95,
+          "summary": "Fifteen service tests, four crash-boundary cases, and one two-current-relay topology passed; the child fixture and two explicitly separate mixed-version cases skipped."
         },
         {
           "date": "2026-08-20",

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-08-18",
+  "updatedAt": "2026-08-20",
   "policy": {
     "maturityLevels": ["experimental", "soak", "blocking", "accepted-gap", "deprecated"],
     "blockingPromotion": {
@@ -13625,6 +13625,106 @@
         "The reverted-source failure is established from the old process-wide call path but was not executed."
       ],
       "demotionRule": "Demote if unrelated reattach joins a stalled session tail, overlay or periodic work exceeds its admission bound, a deadline cancels durable work, final checkpoints defer, or failures and deadline fallbacks lose their diagnostic breadcrumbs."
+    },
+    {
+      "id": "skill-upload.cross-process-staging-ownership",
+      "title": "Concurrent runtime and relay uploads retain exact staging ownership",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "skill-upload-session-service",
+      "layer": "host-filesystem-lifecycle",
+      "surfaces": [
+        "paired-runtime skill upload",
+        "SSH relay skill upload",
+        "upload cancellation",
+        "process restart and disposal"
+      ],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["orca-server", "ssh"],
+      "coveredPlatforms": ["macos"],
+      "coveredProviders": ["ssh"],
+      "coverageNotes": "Two independent services share one parent under controlled ordering, four real crash boundaries run in child processes, and two bundled relays share one isolated home through distinct socket and hook endpoints. A current relay also shares that home safely with the originating relay in both launch orders. Linux, Windows, and paired headed/headless runtime process evidence remain uncollected; the change is host-local and changes no wire payload.",
+      "motivatingLinks": [
+        "https://linear.app/stably/issue/STA-4967",
+        "https://github.com/stablyai/orca/pull/14934"
+      ],
+      "invariant": "Initialization, cleanup, or disposal by one service process can never remove bytes owned by a still-live upload in another process. Each service owns one atomic PID-and-UUID namespace, each upload remains capped by the existing four-session and package-size limits, abandoned owner cleanup inspects at most 64 entries per attempt, and success, failure, cancellation, restart, and disposal release only their exact owned paths.",
+      "oracle": "Begin and partially append upload A, then begin upload B from an independent service or relay sharing the same parent. Require two exact owner directories, two exact archives, and byte-for-byte survival of A. Cancel B then A and require archive counts 1 then 0; dispose each owner and require directory counts 1 then 0. Kill real child owners at begun, partial, uploaded, and committed boundaries and require a fresh owner to remove only exited-process staging and complete its own transfer. Seed 65 exited owners, require one attempt to remove exactly 64 and reject before adding bytes, then require retry to drain the final stale owner and begin normally.",
+      "commands": [
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/skills/skill-upload-session-service.test.ts --reporter=verbose",
+        "ORCA_REAL_PROCESS_SKILL_TEST=1 pnpm exec vitest run --config config/vitest.config.ts src/main/skills/skill-upload-process-restart.integration.test.ts src/main/skills/skill-upload-process-restart-child.test.ts --pool=forks --maxWorkers=1 --no-file-parallelism --reporter=verbose",
+        "pnpm exec vitest run --config config/vitest.config.ts src/relay/skill-upload-multi-relay.integration.test.ts --pool=forks --maxWorkers=1 --no-file-parallelism --reporter=verbose"
+      ],
+      "testFiles": [
+        "src/main/skills/skill-upload-session-service.test.ts",
+        "src/main/skills/skill-upload-process-restart.integration.test.ts",
+        "src/main/skills/skill-upload-process-restart-child.test.ts",
+        "src/relay/skill-upload-multi-relay.integration.test.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/main/skills/skill-upload-session-service.test.ts",
+          "assertions": [
+            "a second service preserves the first service's exact file and bytes",
+            "cancellation and disposal reduce exact archive and owner counts",
+            "one abandoned-owner sweep removes at most 64 entries and retry completes"
+          ]
+        },
+        {
+          "file": "src/main/skills/skill-upload-process-restart.integration.test.ts",
+          "assertions": [
+            "begun, partial, uploaded, and committed crash residue is reclaimed",
+            "the replacement transfer completes and leaves no owner directory"
+          ]
+        },
+        {
+          "file": "src/relay/skill-upload-multi-relay.integration.test.ts",
+          "assertions": [
+            "two bundled relay PIDs retain separate archives under one account home",
+            "current and originating relay bundles retain separate archives in both launch orders",
+            "relay cancellation and graceful shutdown clean only the exact owner"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-08-20",
+          "runner": "local",
+          "platform": "macos",
+          "result": "passed",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/relay/skill-upload-multi-relay.integration.test.ts --pool=forks --maxWorkers=1 --no-file-parallelism --reporter=verbose",
+          "durationSeconds": 4.8,
+          "summary": "Nine service tests, four crash-boundary cases, one two-current-relay topology, and two originating/current mixed-version launch orders passed with exact archive and owner counts."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 15,
+        "scope": "focused service, four child-process restarts, and two bundled relays"
+      },
+      "flakeHistory": {
+        "status": "not-started",
+        "evidence": "The barriers are request acknowledgements, filesystem state, and process exit; CI and soak history have not started."
+      },
+      "redGreenEvidence": {
+        "status": "complete",
+        "evidence": "The byte-identical two-relay oracle failed at the exact two-owner count on originating merge fa9b20cb4163 and latest-main/reverted source 012e9f410c76, each observing one shared-root entry after relay B began. The candidate passed with two owner directories, two archives, A-byte survival, 1-to-0 cancellation cleanup, and 1-to-0 owner disposal cleanup."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "Initialization scans at most 64 direct parent entries, creates one owner directory per live service, retains the existing four active sessions and package-size caps, and adds no polling, timer, subprocess, wire field, renderer work, or provider fanout. An over-budget parent rejects before creating new staged bytes."
+      },
+      "promotionCriteria": [
+        "Collect 100 consecutive focused CI passes or 14 days without an unexplained flake.",
+        "Run the same two-owner relay topology on Linux and Windows.",
+        "Run paired headed and headless runtime uploads under one OS account.",
+        "Keep exact owner/file counts, byte survival, bounded sweep, and all four crash boundaries green."
+      ],
+      "knownGaps": [
+        "The live two-relay and crash evidence was collected on macOS; Linux and Windows process/filesystem behavior remains CI coverage.",
+        "The service is shared by paired runtimes, but separate headed and headless paired-runtime process journeys were not run.",
+        "PID reuse is handled conservatively: an abandoned namespace whose PID is currently occupied is preserved until a later process generation rather than risking deletion of live bytes."
+      ],
+      "demotionRule": "Demote if one live owner can remove another owner's bytes, cleanup exceeds 64 inspected entries per attempt, a lifecycle path retains its exact owned archive after settlement, or the process oracle flakes without an identified harness or product defect."
     }
   ]
 }

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -13655,7 +13655,9 @@
         "ORCA_REAL_PROCESS_SKILL_TEST=1 pnpm exec vitest run --config config/vitest.config.ts src/main/skills/skill-upload-process-restart.integration.test.ts src/main/skills/skill-upload-process-restart-child.test.ts --pool=forks --maxWorkers=1 --no-file-parallelism --reporter=verbose",
         "pnpm exec vitest run --config config/vitest.config.ts src/relay/skill-upload-multi-relay.integration.test.ts --pool=forks --maxWorkers=1 --no-file-parallelism --reporter=verbose",
         "ORCA_REAL_PROCESS_SKILL_TEST=1 pnpm exec vitest run --config config/vitest.config.ts src/main/skills/skill-upload-session-service.test.ts src/main/skills/skill-upload-process-restart.integration.test.ts src/main/skills/skill-upload-process-restart-child.test.ts src/relay/skill-upload-multi-relay.integration.test.ts --pool=forks --maxWorkers=1 --no-file-parallelism --reporter=verbose",
-        "ORCA_SKILL_UPLOAD_LEGACY_RELAY_ENTRY=<fa9b20cb4163-relay.js> pnpm exec vitest run --config config/vitest.config.ts src/relay/skill-upload-multi-relay.integration.test.ts --pool=forks --maxWorkers=1 --no-file-parallelism --reporter=verbose"
+        "ORCA_SKILL_UPLOAD_LEGACY_RELAY_ENTRY=<fa9b20cb4163-relay.js> pnpm exec vitest run --config config/vitest.config.ts src/relay/skill-upload-multi-relay.integration.test.ts --pool=forks --maxWorkers=1 --no-file-parallelism --reporter=verbose",
+        "ORCA_SKILL_UPLOAD_RELAY_ENTRY=<fa9b20cb4163-relay.js;sha256=4db8609c4e1772f1efa9b0c0cf6affa8f64ff9ebc8e2b6f9e71678992ccdcf1a> pnpm exec vitest run --config config/vitest.config.ts src/relay/skill-upload-multi-relay.integration.test.ts --pool=forks --maxWorkers=1 --no-file-parallelism --reporter=verbose",
+        "ORCA_SKILL_UPLOAD_RELAY_ENTRY=<012e9f410c-fix-reverted-relay.js;sha256=ca03bf47d93828ec30473391b542d945df887b7881cce3df17e95d90226e34fb> pnpm exec vitest run --config config/vitest.config.ts src/relay/skill-upload-multi-relay.integration.test.ts --pool=forks --maxWorkers=1 --no-file-parallelism --reporter=verbose"
       ],
       "testFiles": [
         "src/main/skills/skill-upload-session-service.test.ts",
@@ -13670,6 +13672,7 @@
             "a second service preserves the first service's exact file and bytes",
             "five concurrent begins admit exactly four sessions and disposal removes them",
             "disposal waits for an initializing begin and leaves no owner",
+            "concurrent disposal callers join the same exact cleanup promise",
             "cancellation and disposal reduce exact archive and owner counts",
             "one abandoned-owner sweep removes at most 64 entries and retry completes"
           ]
@@ -13698,7 +13701,7 @@
           "result": "passed",
           "command": "ORCA_REAL_PROCESS_SKILL_TEST=1 pnpm exec vitest run --config config/vitest.config.ts src/main/skills/skill-upload-session-service.test.ts src/main/skills/skill-upload-process-restart.integration.test.ts src/main/skills/skill-upload-process-restart-child.test.ts src/relay/skill-upload-multi-relay.integration.test.ts --pool=forks --maxWorkers=1 --no-file-parallelism --reporter=verbose",
           "durationSeconds": 3.5,
-          "summary": "Eleven service tests, four crash-boundary cases, and one two-current-relay topology passed; the child fixture and two explicitly separate mixed-version cases skipped."
+          "summary": "Twelve service tests, four crash-boundary cases, and one two-current-relay topology passed; the child fixture and two explicitly separate mixed-version cases skipped."
         },
         {
           "date": "2026-08-20",
@@ -13708,6 +13711,24 @@
           "command": "ORCA_SKILL_UPLOAD_LEGACY_RELAY_ENTRY=<fa9b20cb4163-relay.js> pnpm exec vitest run --config config/vitest.config.ts src/relay/skill-upload-multi-relay.integration.test.ts --pool=forks --maxWorkers=1 --no-file-parallelism --reporter=verbose",
           "durationSeconds": 0.9,
           "summary": "The current/current case and both originating/current mixed-version launch orders passed with exact per-root archive bytes."
+        },
+        {
+          "date": "2026-08-20",
+          "runner": "local",
+          "platform": "macos",
+          "result": "failed",
+          "command": "ORCA_SKILL_UPLOAD_RELAY_ENTRY=<fa9b20cb4163-relay.js;sha256=4db8609c4e1772f1efa9b0c0cf6affa8f64ff9ebc8e2b6f9e71678992ccdcf1a> pnpm exec vitest run --config config/vitest.config.ts src/relay/skill-upload-multi-relay.integration.test.ts --pool=forks --maxWorkers=1 --no-file-parallelism --reporter=verbose",
+          "durationSeconds": 0.4,
+          "summary": "Expected red: zero PID/UUID owner directories and one archive were observed where two each were required; relay A's exact first five bytes were missing."
+        },
+        {
+          "date": "2026-08-20",
+          "runner": "local",
+          "platform": "macos",
+          "result": "failed",
+          "command": "ORCA_SKILL_UPLOAD_RELAY_ENTRY=<012e9f410c-fix-reverted-relay.js;sha256=ca03bf47d93828ec30473391b542d945df887b7881cce3df17e95d90226e34fb> pnpm exec vitest run --config config/vitest.config.ts src/relay/skill-upload-multi-relay.integration.test.ts --pool=forks --maxWorkers=1 --no-file-parallelism --reporter=verbose",
+          "durationSeconds": 0.4,
+          "summary": "Expected red: zero PID/UUID owner directories and one archive were observed where two each were required; relay A's exact first five bytes were missing."
         }
       ],
       "runtimeBudget": {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3376,6 +3376,7 @@ app.on('will-quit', (e) => {
     codexUsage?.flush(),
     openCodeUsage?.flush()
   ]).then(() => {})
+  const skillUploadShutdown = runtime?.disposeSkillUploadSessions() ?? Promise.resolve()
 
   // Why: capture pid/runtimeId synchronously (before any await) so a later teardown path can't null them out mid-chain.
   const ownedPid = process.pid
@@ -3410,6 +3411,7 @@ app.on('will-quit', (e) => {
     { name: 'emulator', promise: emulatorShutdown },
     { name: 'ssh', promise: sshShutdown },
     { name: 'plugin-hosts', promise: pluginHostShutdown },
+    { name: 'skill-uploads', promise: skillUploadShutdown },
     { name: 'codex-backfill-recovery', promise: codexBackfillRecoveryShutdown },
     { name: 'usage-cache', promise: usageCacheFlush },
     { name: 'stats', promise: statsFlush },

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -3661,6 +3661,7 @@ export class OrcaRuntimeService {
   private skillCloudService: SkillCloudService | null = null
   private agentSkillShareInProgress = false
   private skillUploadSessions: SkillUploadSessionService | null = null
+  private skillUploadSessionsDisposed = false
   private readonly skillTransactionRecovery: Promise<unknown>
   private readonly skillInstallOperations = new Map<string, AbortController>()
   private readonly skillInstallProgress = new Map<string, SkillBundleInstallProgress>()
@@ -5696,10 +5697,20 @@ export class OrcaRuntimeService {
   }
 
   private requireSkillUploadSessions(): SkillUploadSessionService {
+    if (this.skillUploadSessionsDisposed) {
+      throw new Error('skill-upload-service-disposed')
+    }
     this.skillUploadSessions ??= new SkillUploadSessionService(
       join(app.getPath('userData'), 'skill-installs', SKILL_UPLOAD_STAGING_ROOT_NAME)
     )
     return this.skillUploadSessions
+  }
+
+  async disposeSkillUploadSessions(): Promise<void> {
+    this.skillUploadSessionsDisposed = true
+    const sessions = this.skillUploadSessions
+    this.skillUploadSessions = null
+    await sessions?.dispose()
   }
 
   getRuntimeId(): string {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -215,6 +215,7 @@ import type {
   SkillUploadChunkRequest
 } from '../../shared/skill-upload-session-contract'
 import { SkillUploadSessionService } from '../skills/skill-upload-session-service'
+import { SKILL_UPLOAD_STAGING_ROOT_NAME } from '../skills/skill-upload-staging-ownership'
 import type { SkillSshWorkspaceAuthority } from '../../shared/skill-ssh-relay-contract'
 import {
   installSkillBundleOnSshHost,
@@ -5696,7 +5697,7 @@ export class OrcaRuntimeService {
 
   private requireSkillUploadSessions(): SkillUploadSessionService {
     this.skillUploadSessions ??= new SkillUploadSessionService(
-      join(app.getPath('userData'), 'skill-installs', 'remote-uploads')
+      join(app.getPath('userData'), 'skill-installs', SKILL_UPLOAD_STAGING_ROOT_NAME)
     )
     return this.skillUploadSessions
   }

--- a/src/main/skills/skill-upload-archive-hash.ts
+++ b/src/main/skills/skill-upload-archive-hash.ts
@@ -1,0 +1,16 @@
+import { createHash } from 'node:crypto'
+import { createReadStream } from 'node:fs'
+import { stat } from 'node:fs/promises'
+import { SKILL_PACKAGE_MAX_COMPRESSED_BYTES } from '../../shared/skill-package-manifest'
+
+export async function hashSkillUploadArchive(path: string): Promise<string> {
+  const size = (await stat(path)).size
+  if (size < 1 || size > SKILL_PACKAGE_MAX_COMPRESSED_BYTES) {
+    throw new Error('skill-upload-size-limit')
+  }
+  const hash = createHash('sha256')
+  for await (const chunk of createReadStream(path)) {
+    hash.update(chunk as Buffer)
+  }
+  return hash.digest('hex')
+}

--- a/src/main/skills/skill-upload-operation-lifecycle.ts
+++ b/src/main/skills/skill-upload-operation-lifecycle.ts
@@ -1,0 +1,58 @@
+export class SkillUploadOperationLifecycle {
+  private beginTurn = Promise.resolve()
+  private operationsSettled = Promise.resolve()
+  private resolveOperationsSettled: (() => void) | null = null
+  private inFlight = 0
+
+  get hasInFlight(): boolean {
+    return this.inFlight > 0
+  }
+
+  enter(assertAvailable: () => void): () => void {
+    assertAvailable()
+    if (this.inFlight === 0) {
+      this.operationsSettled = new Promise<void>((resolve) => {
+        this.resolveOperationsSettled = resolve
+      })
+    }
+    this.inFlight += 1
+    let left = false
+    return () => {
+      if (left) {
+        return
+      }
+      left = true
+      this.inFlight -= 1
+      if (this.inFlight === 0) {
+        const resolve = this.resolveOperationsSettled
+        this.resolveOperationsSettled = null
+        resolve?.()
+      }
+    }
+  }
+
+  async enterBegin(assertAvailable: () => void): Promise<() => void> {
+    const leaveOperation = this.enter(assertAvailable)
+    const previousTurn = this.beginTurn
+    let releaseTurn!: () => void
+    this.beginTurn = new Promise<void>((resolve) => {
+      releaseTurn = resolve
+    })
+    await previousTurn
+    try {
+      assertAvailable()
+    } catch (error) {
+      releaseTurn()
+      leaveOperation()
+      throw error
+    }
+    return () => {
+      releaseTurn()
+      leaveOperation()
+    }
+  }
+
+  async settle(): Promise<void> {
+    await this.operationsSettled
+  }
+}

--- a/src/main/skills/skill-upload-process-restart.integration.test.ts
+++ b/src/main/skills/skill-upload-process-restart.integration.test.ts
@@ -146,7 +146,7 @@ async function terminateUpload(root: string, boundary: string): Promise<string> 
 async function completeFreshTransfer(uploadRoot: string): Promise<void> {
   const service = new SkillUploadSessionService(uploadRoot)
   const begun = await service.begin({ package: identity(), transferId: 'operation-fresh' })
-  expect(await readdir(uploadRoot)).toEqual([`${begun.uploadId}.tar.gz`])
+  expect(await stagedArchiveNames(uploadRoot)).toEqual([`${begun.uploadId}.tar.gz`])
   await service.append({
     uploadId: begun.uploadId,
     offset: 0,
@@ -156,7 +156,22 @@ async function completeFreshTransfer(uploadRoot: string): Promise<void> {
   const taken = await service.take(begun.uploadId, identity())
   expect(await readFile(taken.archivePath)).toEqual(bytes)
   await taken.cleanup()
+  expect(await stagedArchiveNames(uploadRoot)).toEqual([])
+  await service.dispose()
   expect(await readdir(uploadRoot)).toEqual([])
+}
+
+async function stagedArchiveNames(uploadRoot: string): Promise<string[]> {
+  const owners = await readdir(uploadRoot, { withFileTypes: true })
+  const names = await Promise.all(
+    owners
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => readdir(join(uploadRoot, entry.name)))
+  )
+  return names
+    .flat()
+    .filter((name) => name.endsWith('.tar.gz'))
+    .sort()
 }
 
 afterEach(async () => {
@@ -177,7 +192,7 @@ describe.runIf(RUN_REAL_PROCESS)('skill upload process restart recovery', () => 
       const uploadRoot = join(root, 'uploads')
       const abandonedId = await terminateUpload(root, boundary)
 
-      expect(await readdir(uploadRoot)).toEqual([`${abandonedId}.tar.gz`])
+      expect(await stagedArchiveNames(uploadRoot)).toEqual([`${abandonedId}.tar.gz`])
       await completeFreshTransfer(uploadRoot)
     },
     30_000

--- a/src/main/skills/skill-upload-retained-paths.ts
+++ b/src/main/skills/skill-upload-retained-paths.ts
@@ -1,0 +1,36 @@
+import { rm } from 'node:fs/promises'
+
+export class SkillUploadRetainedPaths {
+  private readonly transferred = new Set<string>()
+  private readonly failedCleanup = new Set<string>()
+
+  get failedCleanupCount(): number {
+    return this.failedCleanup.size
+  }
+
+  get isEmpty(): boolean {
+    return this.transferred.size === 0 && this.failedCleanup.size === 0
+  }
+
+  retainTransferred(path: string): void {
+    this.transferred.add(path)
+  }
+
+  retainFailedCleanup(path: string): void {
+    this.failedCleanup.add(path)
+  }
+
+  async removeTransferred(path: string): Promise<void> {
+    await rm(path, { force: true })
+    this.transferred.delete(path)
+  }
+
+  async removeFailedCleanup(path: string): Promise<void> {
+    await rm(path, { force: true })
+    this.failedCleanup.delete(path)
+  }
+
+  async removeAllFailedCleanup(): Promise<void> {
+    await Promise.all([...this.failedCleanup].map((path) => this.removeFailedCleanup(path)))
+  }
+}

--- a/src/main/skills/skill-upload-session-record.ts
+++ b/src/main/skills/skill-upload-session-record.ts
@@ -1,0 +1,14 @@
+import type { FileHandle } from 'node:fs/promises'
+import type { SkillUploadBeginRequest } from '../../shared/skill-upload-session-contract'
+
+export type SkillUploadSessionRecord = {
+  id: string
+  path: string
+  package: SkillUploadBeginRequest['package']
+  transferId: string | null
+  handle: FileHandle | null
+  idleTimer: ReturnType<typeof setTimeout> | null
+  bytesReceived: number
+  touchedAt: number
+  committed: boolean
+}

--- a/src/main/skills/skill-upload-session-record.ts
+++ b/src/main/skills/skill-upload-session-record.ts
@@ -1,5 +1,9 @@
 import type { FileHandle } from 'node:fs/promises'
-import type { SkillUploadBeginRequest } from '../../shared/skill-upload-session-contract'
+import {
+  SKILL_UPLOAD_CHUNK_MAX_BYTES,
+  type SkillUploadBeginRequest,
+  type SkillUploadBeginResult
+} from '../../shared/skill-upload-session-contract'
 
 export type SkillUploadSessionRecord = {
   id: string
@@ -11,4 +15,12 @@ export type SkillUploadSessionRecord = {
   bytesReceived: number
   touchedAt: number
   committed: boolean
+}
+
+export function skillUploadBeginResult(session: SkillUploadSessionRecord): SkillUploadBeginResult {
+  return {
+    uploadId: session.id,
+    chunkBytes: SKILL_UPLOAD_CHUNK_MAX_BYTES,
+    acknowledgedOffset: session.bytesReceived
+  }
 }

--- a/src/main/skills/skill-upload-session-service-options.ts
+++ b/src/main/skills/skill-upload-session-service-options.ts
@@ -1,0 +1,9 @@
+import type { hashSkillUploadArchive } from './skill-upload-archive-hash'
+import type { SkillUploadStagingOwnershipOptions } from './skill-upload-staging-ownership'
+
+export type SkillUploadSessionServiceOptions = {
+  idleMs?: number
+  initializeRoot?: () => Promise<void>
+  hashArchive?: typeof hashSkillUploadArchive
+  ownership?: SkillUploadStagingOwnershipOptions
+}

--- a/src/main/skills/skill-upload-session-service.test.ts
+++ b/src/main/skills/skill-upload-session-service.test.ts
@@ -103,6 +103,57 @@ describe('SkillUploadSessionService', () => {
     expect(await readdir(uploads)).toEqual([])
   })
 
+  it('serializes concurrent admission at four sessions', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skill-upload-session-'))
+    roots.push(root)
+    const uploads = join(root, 'uploads')
+    const service = new SkillUploadSessionService(uploads)
+    const results = await Promise.allSettled(
+      Array.from({ length: 5 }, (_, index) =>
+        service.begin({
+          package: identity(Buffer.from(`package-${index}`)),
+          transferId: `operation-${index}`
+        })
+      )
+    )
+
+    expect(results.filter((result) => result.status === 'fulfilled')).toHaveLength(4)
+    expect(results.filter((result) => result.status === 'rejected')).toHaveLength(1)
+    expect(await stagedArchives(uploads)).toHaveLength(4)
+    await service.dispose()
+    expect(await readdir(uploads)).toEqual([])
+  })
+
+  it('waits for an initializing begin before disposal removes ownership', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skill-upload-session-'))
+    roots.push(root)
+    const uploads = join(root, 'uploads')
+    let releaseInitialization!: () => void
+    const initializationReleased = new Promise<void>((resolve) => {
+      releaseInitialization = resolve
+    })
+    let markInitializationStarted!: () => void
+    const initializationStarted = new Promise<void>((resolve) => {
+      markInitializationStarted = resolve
+    })
+    const service = new SkillUploadSessionService(uploads, {
+      initializeRoot: async () => {
+        await mkdir(uploads, { recursive: true })
+        markInitializationStarted()
+        await initializationReleased
+      }
+    })
+    const begin = service.begin({ package: identity(Buffer.from('closing package')) })
+    await initializationStarted
+
+    const disposal = service.dispose()
+    releaseInitialization()
+
+    await expect(begin).rejects.toThrow('skill-upload-service-disposed')
+    await disposal
+    expect(await readdir(uploads)).toEqual([])
+  })
+
   it('bounds each abandoned-owner sweep and can resume cleanup on retry', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-skill-upload-session-'))
     roots.push(root)

--- a/src/main/skills/skill-upload-session-service.test.ts
+++ b/src/main/skills/skill-upload-session-service.test.ts
@@ -1,5 +1,15 @@
 import { createHash } from 'node:crypto'
-import { mkdir, mkdtemp, readFile, readdir, rename, rm, stat, writeFile } from 'node:fs/promises'
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  stat,
+  symlink,
+  writeFile
+} from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { basename, join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -52,6 +62,21 @@ describe('SkillUploadSessionService', () => {
     await expect(service.begin(request)).rejects.toThrow('transient-init-failure')
     await expect(service.begin(request)).resolves.toMatchObject({ acknowledgedOffset: 0 })
     expect(initializeRoot).toHaveBeenCalledTimes(2)
+  })
+
+  it('rejects a staging root that redirects through a symlink or junction', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skill-upload-session-'))
+    roots.push(root)
+    const outside = join(root, 'outside')
+    const uploads = join(root, 'uploads')
+    await mkdir(outside)
+    await symlink(outside, uploads, process.platform === 'win32' ? 'junction' : 'dir')
+    const service = new SkillUploadSessionService(uploads)
+
+    await expect(service.begin({ package: identity(Buffer.from('new package')) })).rejects.toThrow(
+      'skill-upload-staging-root-invalid'
+    )
+    expect(await readdir(outside)).toEqual([])
   })
 
   it('removes only staging owned by an exited process when a fresh service starts', async () => {
@@ -333,6 +358,34 @@ describe('SkillUploadSessionService', () => {
       expect.objectContaining({ acknowledgedOffset: 0 })
     )
     await service.dispose()
+  })
+
+  it('retains failed archive cleanup within the four-path admission bound', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skill-upload-session-'))
+    roots.push(root)
+    const uploads = join(root, 'uploads')
+    const service = new SkillUploadSessionService(uploads)
+    const begun = await service.begin({ package: identity(Buffer.from('retained')) })
+    const [archivePath] = await stagedArchives(uploads)
+    const retainedPath = `${archivePath}.retained`
+    await rename(archivePath!, retainedPath)
+    await mkdir(archivePath!)
+
+    await expect(service.cancel(begun.uploadId)).rejects.toThrow()
+    const replacements = await Promise.all(
+      Array.from({ length: 3 }, (_, index) =>
+        service.begin({ package: identity(Buffer.from(`replacement-${index}`)) })
+      )
+    )
+    expect(replacements).toHaveLength(3)
+    await expect(service.begin({ package: identity(Buffer.from('over-budget')) })).rejects.toThrow(
+      'skill-upload-session-limit'
+    )
+
+    await rm(archivePath!, { recursive: true })
+    await rename(retainedPath, archivePath!)
+    await service.dispose()
+    expect(await readdir(uploads)).toEqual([])
   })
 
   it('rejects gaps, changed retries, and an archive hash mismatch', async () => {

--- a/src/main/skills/skill-upload-session-service.test.ts
+++ b/src/main/skills/skill-upload-session-service.test.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto'
-import { mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, readdir, rename, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { basename, join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { SkillUploadSessionService } from './skill-upload-session-service'
 
@@ -19,6 +19,20 @@ function identity(bytes: Buffer) {
     archiveSha256: createHash('sha256').update(bytes).digest('hex'),
     compressedBytes: bytes.length
   }
+}
+
+async function stagedArchives(uploads: string): Promise<string[]> {
+  const owners = await readdir(uploads, { withFileTypes: true })
+  const archives = await Promise.all(
+    owners
+      .filter((entry) => entry.isDirectory())
+      .map(async (entry) =>
+        (await readdir(join(uploads, entry.name)))
+          .filter((name) => name.endsWith('.tar.gz'))
+          .map((name) => join(uploads, entry.name, name))
+      )
+  )
+  return archives.flat().sort()
 }
 
 describe('SkillUploadSessionService', () => {
@@ -40,17 +54,76 @@ describe('SkillUploadSessionService', () => {
     expect(initializeRoot).toHaveBeenCalledTimes(2)
   })
 
-  it('removes abandoned staging bytes when a runtime starts a fresh service', async () => {
+  it('removes only staging owned by an exited process when a fresh service starts', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-skill-upload-session-'))
     roots.push(root)
     const uploads = join(root, 'uploads')
-    await mkdir(uploads)
-    await writeFile(join(uploads, 'abandoned.tar.gz'), 'partial package')
-    const service = new SkillUploadSessionService(uploads)
+    const staleOwner = join(uploads, 'owner-2147483646-00000000-0000-4000-8000-000000000000')
+    await mkdir(staleOwner, { recursive: true })
+    await writeFile(join(staleOwner, 'abandoned.tar.gz'), 'partial package')
+    const service = new SkillUploadSessionService(uploads, {
+      ownership: { processIsAlive: (pid) => pid === process.pid }
+    })
 
-    await service.begin({ package: identity(Buffer.from('new package')) })
+    const begun = await service.begin({ package: identity(Buffer.from('new package')) })
 
-    expect(await readdir(uploads)).not.toContain('abandoned.tar.gz')
+    expect((await stagedArchives(uploads)).map((path) => basename(path))).toEqual([
+      `${begun.uploadId}.tar.gz`
+    ])
+    expect(await readdir(uploads)).toHaveLength(1)
+  })
+
+  it('never lets a second service delete a live upload owned by the first', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skill-upload-session-'))
+    roots.push(root)
+    const uploads = join(root, 'uploads')
+    const first = new SkillUploadSessionService(uploads)
+    const second = new SkillUploadSessionService(uploads)
+    const firstBytes = Buffer.from('first live package')
+    const firstUpload = await first.begin({ package: identity(firstBytes) })
+    await first.append({
+      uploadId: firstUpload.uploadId,
+      offset: 0,
+      bytesBase64: firstBytes.subarray(0, 5).toString('base64')
+    })
+
+    const secondUpload = await second.begin({ package: identity(Buffer.from('second package')) })
+    const archives = await stagedArchives(uploads)
+    const firstPath = archives.find((path) => path.endsWith(`${firstUpload.uploadId}.tar.gz`))
+
+    expect(await readdir(uploads)).toHaveLength(2)
+    expect(archives).toHaveLength(2)
+    expect(firstPath).toBeDefined()
+    await expect(readFile(firstPath!)).resolves.toEqual(firstBytes.subarray(0, 5))
+    await second.cancel(secondUpload.uploadId)
+    expect(await stagedArchives(uploads)).toEqual([firstPath])
+    await first.cancel(firstUpload.uploadId)
+    expect(await stagedArchives(uploads)).toEqual([])
+    await Promise.all([first.dispose(), second.dispose()])
+    expect(await readdir(uploads)).toEqual([])
+  })
+
+  it('bounds each abandoned-owner sweep and can resume cleanup on retry', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skill-upload-session-'))
+    roots.push(root)
+    const uploads = join(root, 'uploads')
+    await Promise.all(
+      Array.from({ length: 65 }, async (_, index) => {
+        const suffix = String(index).padStart(12, '0')
+        const owner = join(uploads, `owner-${100_000 + index}-00000000-0000-4000-8000-${suffix}`)
+        await mkdir(owner, { recursive: true })
+        await writeFile(join(owner, 'abandoned.tar.gz'), 'partial package')
+      })
+    )
+    const service = new SkillUploadSessionService(uploads, {
+      ownership: { processIsAlive: () => false }
+    })
+    const request = { package: identity(Buffer.from('new package')) }
+
+    await expect(service.begin(request)).rejects.toThrow('skill-upload-staging-entry-limit')
+    expect(await readdir(uploads)).toHaveLength(1)
+    await expect(service.begin(request)).resolves.toMatchObject({ acknowledgedOffset: 0 })
+    expect(await readdir(uploads)).toHaveLength(1)
   })
 
   it('accepts monotonic chunks, acknowledges identical retries, and transfers ownership', async () => {
@@ -62,9 +135,8 @@ describe('SkillUploadSessionService', () => {
     const begun = await service.begin({ package: packageIdentity })
     if (process.platform !== 'win32') {
       expect((await stat(join(root, 'uploads'))).mode & 0o777).toBe(0o700)
-      expect((await stat(join(root, 'uploads', `${begun.uploadId}.tar.gz`))).mode & 0o777).toBe(
-        0o600
-      )
+      const [archivePath] = await stagedArchives(join(root, 'uploads'))
+      expect((await stat(archivePath!)).mode & 0o777).toBe(0o600)
     }
     const first = bytes.subarray(0, 8)
     const second = bytes.subarray(8)
@@ -109,7 +181,9 @@ describe('SkillUploadSessionService', () => {
         transferId: request.transferId
       })
     ).rejects.toThrow('skill-upload-transfer-mismatch')
-    expect(await readdir(join(root, 'uploads'))).toEqual([`${begun.uploadId}.tar.gz`])
+    expect((await stagedArchives(join(root, 'uploads'))).map((path) => basename(path))).toEqual([
+      `${begun.uploadId}.tar.gz`
+    ])
   })
 
   it('removes an abandoned upload when its idle lifetime expires', async () => {
@@ -120,13 +194,13 @@ describe('SkillUploadSessionService', () => {
     const begun = await service.begin({ package: identity(Buffer.from('abandoned')) })
     await service.append({ uploadId: begun.uploadId, offset: 0, bytesBase64: 'YQ==' })
 
-    await vi.waitFor(async () => expect(await readdir(uploads)).toEqual([]))
+    await vi.waitFor(async () => expect(await stagedArchives(uploads)).toEqual([]))
     await expect(
       service.append({ uploadId: begun.uploadId, offset: 1, bytesBase64: 'Yg==' })
     ).rejects.toThrow('skill-upload-session-unavailable')
   })
 
-  it('keeps a taken archive until its new owner cleans it', async () => {
+  it('keeps a taken archive until retryable cleanup succeeds', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-skill-upload-session-'))
     roots.push(root)
     vi.useFakeTimers()
@@ -148,9 +222,21 @@ describe('SkillUploadSessionService', () => {
       await expect(service.take(begun.uploadId, packageIdentity)).rejects.toThrow(
         'skill-upload-session-unavailable'
       )
+      await service.dispose()
+      await expect(service.begin({ package: packageIdentity })).rejects.toThrow(
+        'skill-upload-service-disposed'
+      )
+      await expect(readFile(staged.archivePath)).resolves.toEqual(bytes)
+      const retainedPath = `${staged.archivePath}.retained`
+      await rename(staged.archivePath, retainedPath)
+      await mkdir(staged.archivePath)
+      await expect(staged.cleanup()).rejects.toThrow()
+      await rm(staged.archivePath, { recursive: true })
+      await rename(retainedPath, staged.archivePath)
       await staged.cleanup()
       await staged.cleanup()
       await expect(readFile(staged.archivePath)).rejects.toThrow()
+      expect(await readdir(join(root, 'uploads'))).toEqual([])
     } finally {
       vi.useRealTimers()
     }

--- a/src/main/skills/skill-upload-session-service.test.ts
+++ b/src/main/skills/skill-upload-session-service.test.ts
@@ -154,6 +154,21 @@ describe('SkillUploadSessionService', () => {
     expect(await readdir(uploads)).toEqual([])
   })
 
+  it('joins concurrent disposal callers through exact cleanup completion', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skill-upload-session-'))
+    roots.push(root)
+    const uploads = join(root, 'uploads')
+    const service = new SkillUploadSessionService(uploads)
+    await service.begin({ package: identity(Buffer.from('closing package')) })
+
+    const first = service.dispose()
+    const second = service.dispose()
+
+    expect(second).toBe(first)
+    await Promise.all([first, second])
+    expect(await readdir(uploads)).toEqual([])
+  })
+
   it('bounds each abandoned-owner sweep and can resume cleanup on retry', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-skill-upload-session-'))
     roots.push(root)

--- a/src/main/skills/skill-upload-session-service.test.ts
+++ b/src/main/skills/skill-upload-session-service.test.ts
@@ -308,6 +308,33 @@ describe('SkillUploadSessionService', () => {
     }
   })
 
+  it('releases a session when archive hashing fails after its handle closes', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skill-upload-session-'))
+    roots.push(root)
+    const uploads = join(root, 'uploads')
+    const hashFailure = new Error('injected-hash-failure')
+    const service = new SkillUploadSessionService(uploads, {
+      hashArchive: vi.fn().mockRejectedValue(hashFailure)
+    })
+    const bytes = Buffer.from('unreadable package')
+    const begun = await service.begin({ package: identity(bytes) })
+    await service.append({
+      uploadId: begun.uploadId,
+      offset: 0,
+      bytesBase64: bytes.toString('base64')
+    })
+
+    await expect(service.commit(begun.uploadId)).rejects.toBe(hashFailure)
+    await expect(
+      service.append({ uploadId: begun.uploadId, offset: bytes.length, bytesBase64: 'YQ==' })
+    ).rejects.toThrow('skill-upload-session-unavailable')
+    expect(await stagedArchives(uploads)).toEqual([])
+    await expect(service.begin({ package: identity(Buffer.from('replacement')) })).resolves.toEqual(
+      expect.objectContaining({ acknowledgedOffset: 0 })
+    )
+    await service.dispose()
+  })
+
   it('rejects gaps, changed retries, and an archive hash mismatch', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-skill-upload-session-'))
     roots.push(root)

--- a/src/main/skills/skill-upload-session-service.ts
+++ b/src/main/skills/skill-upload-session-service.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import { open, rm } from 'node:fs/promises'
+import { open } from 'node:fs/promises'
 import { join } from 'node:path'
 import {
   SKILL_UPLOAD_CHUNK_MAX_BYTES,
@@ -10,6 +10,7 @@ import {
 import { SkillUploadStagingOwnership } from './skill-upload-staging-ownership'
 import { hashSkillUploadArchive } from './skill-upload-archive-hash'
 import { SkillUploadOperationLifecycle } from './skill-upload-operation-lifecycle'
+import { SkillUploadRetainedPaths } from './skill-upload-retained-paths'
 import type { SkillUploadSessionServiceOptions } from './skill-upload-session-service-options'
 import {
   skillUploadBeginResult,
@@ -24,7 +25,7 @@ export class SkillUploadSessionService {
   private initialized: Promise<void> | null = null
   private readonly idleMs: number
   private readonly ownership: SkillUploadStagingOwnership
-  private readonly transferredPaths = new Set<string>()
+  private readonly retainedPaths = new SkillUploadRetainedPaths()
   private readonly operations = new SkillUploadOperationLifecycle()
   private disposal: Promise<void> | null = null
   private disposed = false
@@ -53,7 +54,7 @@ export class SkillUploadSessionService {
         this.touch(existing)
         return skillUploadBeginResult(existing)
       }
-      if (this.sessions.size >= MAX_SESSIONS) {
+      if (this.sessions.size + this.retainedPaths.failedCleanupCount >= MAX_SESSIONS) {
         throw new Error('skill-upload-session-limit')
       }
       const id = randomUUID()
@@ -150,7 +151,7 @@ export class SkillUploadSessionService {
       try {
         identity = await (this.options.hashArchive ?? hashSkillUploadArchive)(session.path)
       } catch (error) {
-        await this.cancelSession(uploadId)
+        await this.cancelSession(uploadId).catch(() => undefined)
         throw error
       }
       if (identity !== session.package.archiveSha256) {
@@ -184,13 +185,13 @@ export class SkillUploadSessionService {
       }
       this.sessions.delete(uploadId)
       this.clearIdleTimer(session)
-      this.transferredPaths.add(session.path)
+      this.retainedPaths.retainTransferred(session.path)
       let cleanup: Promise<void> | null = null
       return {
         archivePath: session.path,
         cleanup: async () => {
           if (!cleanup) {
-            cleanup = this.cleanupTransferredPath(session.path).catch((error) => {
+            cleanup = this.cleanupRetainedPath(session.path).catch((error) => {
               cleanup = null
               throw error
             })
@@ -225,7 +226,8 @@ export class SkillUploadSessionService {
 
   private async disposeOwnedStaging(): Promise<void> {
     await this.operations.settle()
-    await Promise.all([...this.sessions.keys()].map((id) => this.cancelSession(id)))
+    await Promise.allSettled([...this.sessions.keys()].map((id) => this.cancelSession(id)))
+    await this.retainedPaths.removeAllFailedCleanup()
     await this.removeOwnershipIfDisposed()
   }
 
@@ -236,8 +238,9 @@ export class SkillUploadSessionService {
     }
     this.sessions.delete(uploadId)
     this.clearIdleTimer(session)
+    this.retainedPaths.retainFailedCleanup(session.path)
     await session.handle?.close().catch(() => undefined)
-    await rm(session.path, { force: true })
+    await this.retainedPaths.removeFailedCleanup(session.path)
   }
 
   private async requireActive(uploadId: string): Promise<SkillUploadSessionRecord> {
@@ -296,15 +299,14 @@ export class SkillUploadSessionService {
       this.disposed &&
       !this.operations.hasInFlight &&
       this.sessions.size === 0 &&
-      this.transferredPaths.size === 0
+      this.retainedPaths.isEmpty
     ) {
       await this.ownership.remove()
     }
   }
 
-  private async cleanupTransferredPath(path: string): Promise<void> {
-    await rm(path, { force: true })
-    this.transferredPaths.delete(path)
+  private async cleanupRetainedPath(path: string): Promise<void> {
+    await this.retainedPaths.removeTransferred(path)
     await this.removeOwnershipIfDisposed()
   }
 

--- a/src/main/skills/skill-upload-session-service.ts
+++ b/src/main/skills/skill-upload-session-service.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import { open, rm, type FileHandle } from 'node:fs/promises'
+import { open, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import {
   SKILL_UPLOAD_CHUNK_MAX_BYTES,
@@ -12,29 +12,19 @@ import {
   type SkillUploadStagingOwnershipOptions
 } from './skill-upload-staging-ownership'
 import { hashSkillUploadArchive } from './skill-upload-archive-hash'
+import { SkillUploadOperationLifecycle } from './skill-upload-operation-lifecycle'
+import type { SkillUploadSessionRecord } from './skill-upload-session-record'
 
 const MAX_SESSIONS = 4
 const SESSION_IDLE_MS = 10 * 60_000
 
-type UploadSession = {
-  id: string
-  path: string
-  package: SkillUploadBeginRequest['package']
-  transferId: string | null
-  handle: FileHandle | null
-  idleTimer: ReturnType<typeof setTimeout> | null
-  bytesReceived: number
-  touchedAt: number
-  committed: boolean
-}
-
 export class SkillUploadSessionService {
-  private readonly sessions = new Map<string, UploadSession>()
+  private readonly sessions = new Map<string, SkillUploadSessionRecord>()
   private initialized: Promise<void> | null = null
   private readonly idleMs: number
   private readonly ownership: SkillUploadStagingOwnership
   private readonly transferredPaths = new Set<string>()
-  private pendingBegins = 0
+  private readonly operations = new SkillUploadOperationLifecycle()
   private disposed = false
 
   constructor(
@@ -50,8 +40,7 @@ export class SkillUploadSessionService {
   }
 
   async begin(request: SkillUploadBeginRequest): Promise<SkillUploadBeginResult> {
-    this.assertAvailable()
-    this.pendingBegins += 1
+    const leaveOperation = await this.operations.enterBegin(() => this.assertAvailable())
     try {
       await this.initialize()
       this.assertAvailable()
@@ -72,7 +61,7 @@ export class SkillUploadSessionService {
       const id = randomUUID()
       const path = join(this.ownership.directory, `${id}.tar.gz`)
       const handle = await open(path, 'wx+', 0o600)
-      const session: UploadSession = {
+      const session: SkillUploadSessionRecord = {
         id,
         path,
         package: request.package,
@@ -87,111 +76,150 @@ export class SkillUploadSessionService {
       this.touch(session)
       return this.beginResult(session)
     } finally {
-      this.pendingBegins -= 1
+      leaveOperation()
       await this.removeOwnershipIfDisposed()
     }
   }
 
   async append(request: SkillUploadChunkRequest): Promise<{ acknowledgedOffset: number }> {
-    const session = await this.requireActive(request.uploadId)
-    const bytes = Buffer.from(request.bytesBase64, 'base64')
-    if (
-      bytes.length === 0 ||
-      bytes.length > SKILL_UPLOAD_CHUNK_MAX_BYTES ||
-      bytes.toString('base64') !== request.bytesBase64
-    ) {
-      throw new Error('skill-upload-chunk-invalid')
-    }
-    if (request.offset > session.bytesReceived) {
-      throw new Error('skill-upload-offset-invalid')
-    }
-    if (request.offset < session.bytesReceived) {
-      if (request.offset + bytes.length > session.bytesReceived || !session.handle) {
+    const leaveOperation = this.operations.enter(() => this.assertAvailable())
+    try {
+      const session = await this.requireActive(request.uploadId)
+      const bytes = Buffer.from(request.bytesBase64, 'base64')
+      if (
+        bytes.length === 0 ||
+        bytes.length > SKILL_UPLOAD_CHUNK_MAX_BYTES ||
+        bytes.toString('base64') !== request.bytesBase64
+      ) {
+        throw new Error('skill-upload-chunk-invalid')
+      }
+      if (request.offset > session.bytesReceived) {
         throw new Error('skill-upload-offset-invalid')
       }
-      const existing = Buffer.alloc(bytes.length)
-      const read = await session.handle.read(existing, 0, existing.length, request.offset)
-      if (read.bytesRead !== bytes.length || !existing.equals(bytes)) {
-        throw new Error('skill-upload-retry-mismatch')
+      if (request.offset < session.bytesReceived) {
+        if (request.offset + bytes.length > session.bytesReceived || !session.handle) {
+          throw new Error('skill-upload-offset-invalid')
+        }
+        const existing = Buffer.alloc(bytes.length)
+        const read = await session.handle.read(existing, 0, existing.length, request.offset)
+        if (read.bytesRead !== bytes.length || !existing.equals(bytes)) {
+          throw new Error('skill-upload-retry-mismatch')
+        }
+        this.touch(session)
+        return { acknowledgedOffset: session.bytesReceived }
       }
+      if (session.bytesReceived + bytes.length > session.package.compressedBytes) {
+        throw new Error('skill-upload-size-limit')
+      }
+      const write = await session.handle!.write(bytes, 0, bytes.length, request.offset)
+      if (write.bytesWritten !== bytes.length) {
+        throw new Error('skill-upload-write-incomplete')
+      }
+      session.bytesReceived += bytes.length
       this.touch(session)
       return { acknowledgedOffset: session.bytesReceived }
+    } finally {
+      leaveOperation()
     }
-    if (session.bytesReceived + bytes.length > session.package.compressedBytes) {
-      throw new Error('skill-upload-size-limit')
-    }
-    const write = await session.handle!.write(bytes, 0, bytes.length, request.offset)
-    if (write.bytesWritten !== bytes.length) {
-      throw new Error('skill-upload-write-incomplete')
-    }
-    session.bytesReceived += bytes.length
-    this.touch(session)
-    return { acknowledgedOffset: session.bytesReceived }
   }
 
   async commit(uploadId: string): Promise<{ uploadId: string }> {
-    const session = this.sessions.get(uploadId)
-    if (!session) {
-      throw new Error('skill-upload-session-unavailable')
-    }
-    if (this.expired(session)) {
-      await this.cancel(uploadId)
-      throw new Error('skill-upload-session-unavailable')
-    }
-    if (session.committed) {
+    const leaveOperation = this.operations.enter(() => this.assertAvailable())
+    try {
+      const session = this.sessions.get(uploadId)
+      if (!session) {
+        throw new Error('skill-upload-session-unavailable')
+      }
+      if (this.expired(session)) {
+        await this.cancelSession(uploadId)
+        throw new Error('skill-upload-session-unavailable')
+      }
+      if (session.committed) {
+        this.touch(session)
+        return { uploadId }
+      }
+      if (session.bytesReceived !== session.package.compressedBytes || !session.handle) {
+        throw new Error('skill-upload-size-mismatch')
+      }
+      await session.handle.sync()
+      await session.handle.close()
+      session.handle = null
+      const identity = await hashSkillUploadArchive(session.path)
+      if (identity !== session.package.archiveSha256) {
+        await this.cancelSession(uploadId)
+        throw new Error('skill-upload-archive-hash-mismatch')
+      }
+      session.committed = true
       this.touch(session)
       return { uploadId }
+    } finally {
+      leaveOperation()
     }
-    if (session.bytesReceived !== session.package.compressedBytes || !session.handle) {
-      throw new Error('skill-upload-size-mismatch')
-    }
-    await session.handle.sync()
-    await session.handle.close()
-    session.handle = null
-    const identity = await hashSkillUploadArchive(session.path)
-    if (identity !== session.package.archiveSha256) {
-      await this.cancel(uploadId)
-      throw new Error('skill-upload-archive-hash-mismatch')
-    }
-    session.committed = true
-    this.touch(session)
-    return { uploadId }
   }
 
   async take(
     uploadId: string,
     identity: SkillUploadBeginRequest['package']
   ): Promise<{ archivePath: string; cleanup(): Promise<void> }> {
-    const session = this.sessions.get(uploadId)
-    if (!session) {
-      throw new Error('skill-upload-session-unavailable')
-    }
-    if (this.expired(session)) {
-      await this.cancel(uploadId)
-      throw new Error('skill-upload-session-unavailable')
-    }
-    if (!session.committed || JSON.stringify(session.package) !== JSON.stringify(identity)) {
-      throw new Error('skill-upload-session-unavailable')
-    }
-    this.sessions.delete(uploadId)
-    this.clearIdleTimer(session)
-    this.transferredPaths.add(session.path)
-    let cleanup: Promise<void> | null = null
-    return {
-      archivePath: session.path,
-      cleanup: async () => {
-        if (!cleanup) {
-          cleanup = this.cleanupTransferredPath(session.path).catch((error) => {
-            cleanup = null
-            throw error
-          })
-        }
-        await cleanup
+    const leaveOperation = this.operations.enter(() => this.assertAvailable())
+    try {
+      const session = this.sessions.get(uploadId)
+      if (!session) {
+        throw new Error('skill-upload-session-unavailable')
       }
+      if (this.expired(session)) {
+        await this.cancelSession(uploadId)
+        throw new Error('skill-upload-session-unavailable')
+      }
+      if (!session.committed || JSON.stringify(session.package) !== JSON.stringify(identity)) {
+        throw new Error('skill-upload-session-unavailable')
+      }
+      this.sessions.delete(uploadId)
+      this.clearIdleTimer(session)
+      this.transferredPaths.add(session.path)
+      let cleanup: Promise<void> | null = null
+      return {
+        archivePath: session.path,
+        cleanup: async () => {
+          if (!cleanup) {
+            cleanup = this.cleanupTransferredPath(session.path).catch((error) => {
+              cleanup = null
+              throw error
+            })
+          }
+          await cleanup
+        }
+      }
+    } finally {
+      leaveOperation()
     }
   }
 
   async cancel(uploadId: string): Promise<void> {
+    if (this.disposed) {
+      return
+    }
+    const leaveOperation = this.operations.enter(() => this.assertAvailable())
+    try {
+      await this.cancelSession(uploadId)
+    } finally {
+      leaveOperation()
+    }
+  }
+
+  async dispose(): Promise<void> {
+    if (this.disposed) {
+      await this.operations.settle()
+      await this.removeOwnershipIfDisposed()
+      return
+    }
+    this.disposed = true
+    await this.operations.settle()
+    await Promise.all([...this.sessions.keys()].map((id) => this.cancelSession(id)))
+    await this.removeOwnershipIfDisposed()
+  }
+
+  private async cancelSession(uploadId: string): Promise<void> {
     const session = this.sessions.get(uploadId)
     if (!session) {
       return
@@ -202,29 +230,23 @@ export class SkillUploadSessionService {
     await rm(session.path, { force: true })
   }
 
-  async dispose(): Promise<void> {
-    this.disposed = true
-    await Promise.all([...this.sessions.keys()].map((id) => this.cancel(id)))
-    await this.removeOwnershipIfDisposed()
-  }
-
-  private async requireActive(uploadId: string): Promise<UploadSession> {
+  private async requireActive(uploadId: string): Promise<SkillUploadSessionRecord> {
     const session = this.sessions.get(uploadId)
     if (!session || session.committed) {
       throw new Error('skill-upload-session-unavailable')
     }
     if (this.expired(session)) {
-      await this.cancel(uploadId)
+      await this.cancelSession(uploadId)
       throw new Error('skill-upload-session-unavailable')
     }
     return session
   }
 
-  private expired(session: UploadSession): boolean {
+  private expired(session: SkillUploadSessionRecord): boolean {
     return Date.now() - session.touchedAt >= this.idleMs
   }
 
-  private beginResult(session: UploadSession): SkillUploadBeginResult {
+  private beginResult(session: SkillUploadSessionRecord): SkillUploadBeginResult {
     return {
       uploadId: session.id,
       chunkBytes: SKILL_UPLOAD_CHUNK_MAX_BYTES,
@@ -232,7 +254,7 @@ export class SkillUploadSessionService {
     }
   }
 
-  private touch(session: UploadSession): void {
+  private touch(session: SkillUploadSessionRecord): void {
     session.touchedAt = Date.now()
     this.clearIdleTimer(session)
     session.idleTimer = setTimeout(() => {
@@ -241,7 +263,7 @@ export class SkillUploadSessionService {
     session.idleTimer.unref()
   }
 
-  private clearIdleTimer(session: UploadSession): void {
+  private clearIdleTimer(session: SkillUploadSessionRecord): void {
     if (session.idleTimer) {
       clearTimeout(session.idleTimer)
       session.idleTimer = null
@@ -270,7 +292,7 @@ export class SkillUploadSessionService {
   private async removeOwnershipIfDisposed(): Promise<void> {
     if (
       this.disposed &&
-      this.pendingBegins === 0 &&
+      !this.operations.hasInFlight &&
       this.sessions.size === 0 &&
       this.transferredPaths.size === 0
     ) {

--- a/src/main/skills/skill-upload-session-service.ts
+++ b/src/main/skills/skill-upload-session-service.ts
@@ -1,14 +1,17 @@
-import { createHash, randomUUID } from 'node:crypto'
-import { createReadStream } from 'node:fs'
-import { mkdir, open, rm, stat, type FileHandle } from 'node:fs/promises'
+import { randomUUID } from 'node:crypto'
+import { open, rm, type FileHandle } from 'node:fs/promises'
 import { join } from 'node:path'
-import { SKILL_PACKAGE_MAX_COMPRESSED_BYTES } from '../../shared/skill-package-manifest'
 import {
   SKILL_UPLOAD_CHUNK_MAX_BYTES,
   type SkillUploadBeginRequest,
   type SkillUploadBeginResult,
   type SkillUploadChunkRequest
 } from '../../shared/skill-upload-session-contract'
+import {
+  SkillUploadStagingOwnership,
+  type SkillUploadStagingOwnershipOptions
+} from './skill-upload-staging-ownership'
+import { hashSkillUploadArchive } from './skill-upload-archive-hash'
 
 const MAX_SESSIONS = 4
 const SESSION_IDLE_MS = 10 * 60_000
@@ -29,47 +32,64 @@ export class SkillUploadSessionService {
   private readonly sessions = new Map<string, UploadSession>()
   private initialized: Promise<void> | null = null
   private readonly idleMs: number
+  private readonly ownership: SkillUploadStagingOwnership
+  private readonly transferredPaths = new Set<string>()
+  private pendingBegins = 0
+  private disposed = false
 
   constructor(
-    private readonly root: string,
-    private readonly options: { idleMs?: number; initializeRoot?: () => Promise<void> } = {}
+    root: string,
+    private readonly options: {
+      idleMs?: number
+      initializeRoot?: () => Promise<void>
+      ownership?: SkillUploadStagingOwnershipOptions
+    } = {}
   ) {
     this.idleMs = options.idleMs ?? SESSION_IDLE_MS
+    this.ownership = new SkillUploadStagingOwnership(root, options.ownership)
   }
 
   async begin(request: SkillUploadBeginRequest): Promise<SkillUploadBeginResult> {
-    await this.initialize()
-    await this.prune()
-    const existing = request.transferId
-      ? [...this.sessions.values()].find((session) => session.transferId === request.transferId)
-      : undefined
-    if (existing) {
-      if (JSON.stringify(existing.package) !== JSON.stringify(request.package)) {
-        throw new Error('skill-upload-transfer-mismatch')
+    this.assertAvailable()
+    this.pendingBegins += 1
+    try {
+      await this.initialize()
+      this.assertAvailable()
+      await this.prune()
+      const existing = request.transferId
+        ? [...this.sessions.values()].find((session) => session.transferId === request.transferId)
+        : undefined
+      if (existing) {
+        if (JSON.stringify(existing.package) !== JSON.stringify(request.package)) {
+          throw new Error('skill-upload-transfer-mismatch')
+        }
+        this.touch(existing)
+        return this.beginResult(existing)
       }
-      this.touch(existing)
-      return this.beginResult(existing)
+      if (this.sessions.size >= MAX_SESSIONS) {
+        throw new Error('skill-upload-session-limit')
+      }
+      const id = randomUUID()
+      const path = join(this.ownership.directory, `${id}.tar.gz`)
+      const handle = await open(path, 'wx+', 0o600)
+      const session: UploadSession = {
+        id,
+        path,
+        package: request.package,
+        transferId: request.transferId ?? null,
+        handle,
+        idleTimer: null,
+        bytesReceived: 0,
+        touchedAt: Date.now(),
+        committed: false
+      }
+      this.sessions.set(id, session)
+      this.touch(session)
+      return this.beginResult(session)
+    } finally {
+      this.pendingBegins -= 1
+      await this.removeOwnershipIfDisposed()
     }
-    if (this.sessions.size >= MAX_SESSIONS) {
-      throw new Error('skill-upload-session-limit')
-    }
-    const id = randomUUID()
-    const path = join(this.root, `${id}.tar.gz`)
-    const handle = await open(path, 'wx+', 0o600)
-    const session: UploadSession = {
-      id,
-      path,
-      package: request.package,
-      transferId: request.transferId ?? null,
-      handle,
-      idleTimer: null,
-      bytesReceived: 0,
-      touchedAt: Date.now(),
-      committed: false
-    }
-    this.sessions.set(id, session)
-    this.touch(session)
-    return this.beginResult(session)
   }
 
   async append(request: SkillUploadChunkRequest): Promise<{ acknowledgedOffset: number }> {
@@ -128,7 +148,7 @@ export class SkillUploadSessionService {
     await session.handle.sync()
     await session.handle.close()
     session.handle = null
-    const identity = await this.hash(session.path)
+    const identity = await hashSkillUploadArchive(session.path)
     if (identity !== session.package.archiveSha256) {
       await this.cancel(uploadId)
       throw new Error('skill-upload-archive-hash-mismatch')
@@ -155,15 +175,18 @@ export class SkillUploadSessionService {
     }
     this.sessions.delete(uploadId)
     this.clearIdleTimer(session)
-    let cleaned = false
+    this.transferredPaths.add(session.path)
+    let cleanup: Promise<void> | null = null
     return {
       archivePath: session.path,
       cleanup: async () => {
-        if (cleaned) {
-          return
+        if (!cleanup) {
+          cleanup = this.cleanupTransferredPath(session.path).catch((error) => {
+            cleanup = null
+            throw error
+          })
         }
-        cleaned = true
-        await rm(session.path, { force: true })
+        await cleanup
       }
     }
   }
@@ -177,6 +200,12 @@ export class SkillUploadSessionService {
     this.clearIdleTimer(session)
     await session.handle?.close().catch(() => undefined)
     await rm(session.path, { force: true })
+  }
+
+  async dispose(): Promise<void> {
+    this.disposed = true
+    await Promise.all([...this.sessions.keys()].map((id) => this.cancel(id)))
+    await this.removeOwnershipIfDisposed()
   }
 
   private async requireActive(uploadId: string): Promise<UploadSession> {
@@ -221,14 +250,7 @@ export class SkillUploadSessionService {
 
   private async initialize(): Promise<void> {
     if (!this.initialized) {
-      const initialization = (async () => {
-        if (this.options.initializeRoot) {
-          await this.options.initializeRoot()
-        } else {
-          await rm(this.root, { recursive: true, force: true })
-          await mkdir(this.root, { recursive: true, mode: 0o700 })
-        }
-      })()
+      const initialization = this.ownership.initialize(this.options.initializeRoot)
       this.initialized = initialization
       void initialization.catch(() => {
         if (this.initialized === initialization) {
@@ -239,22 +261,33 @@ export class SkillUploadSessionService {
     await this.initialized
   }
 
+  private assertAvailable(): void {
+    if (this.disposed) {
+      throw new Error('skill-upload-service-disposed')
+    }
+  }
+
+  private async removeOwnershipIfDisposed(): Promise<void> {
+    if (
+      this.disposed &&
+      this.pendingBegins === 0 &&
+      this.sessions.size === 0 &&
+      this.transferredPaths.size === 0
+    ) {
+      await this.ownership.remove()
+    }
+  }
+
+  private async cleanupTransferredPath(path: string): Promise<void> {
+    await rm(path, { force: true })
+    this.transferredPaths.delete(path)
+    await this.removeOwnershipIfDisposed()
+  }
+
   private async prune(): Promise<void> {
     const expired = [...this.sessions.values()]
       .filter((session) => this.expired(session))
       .map((session) => session.id)
     await Promise.all(expired.map((id) => this.cancel(id)))
-  }
-
-  private async hash(path: string): Promise<string> {
-    const size = (await stat(path)).size
-    if (size < 1 || size > SKILL_PACKAGE_MAX_COMPRESSED_BYTES) {
-      throw new Error('skill-upload-size-limit')
-    }
-    const hash = createHash('sha256')
-    for await (const chunk of createReadStream(path)) {
-      hash.update(chunk as Buffer)
-    }
-    return hash.digest('hex')
   }
 }

--- a/src/main/skills/skill-upload-session-service.ts
+++ b/src/main/skills/skill-upload-session-service.ts
@@ -25,6 +25,7 @@ export class SkillUploadSessionService {
   private readonly ownership: SkillUploadStagingOwnership
   private readonly transferredPaths = new Set<string>()
   private readonly operations = new SkillUploadOperationLifecycle()
+  private disposal: Promise<void> | null = null
   private disposed = false
 
   constructor(
@@ -207,13 +208,15 @@ export class SkillUploadSessionService {
     }
   }
 
-  async dispose(): Promise<void> {
-    if (this.disposed) {
-      await this.operations.settle()
-      await this.removeOwnershipIfDisposed()
-      return
+  dispose(): Promise<void> {
+    if (!this.disposal) {
+      this.disposed = true
+      this.disposal = this.disposeOwnedStaging()
     }
-    this.disposed = true
+    return this.disposal
+  }
+
+  private async disposeOwnedStaging(): Promise<void> {
     await this.operations.settle()
     await Promise.all([...this.sessions.keys()].map((id) => this.cancelSession(id)))
     await this.removeOwnershipIfDisposed()

--- a/src/main/skills/skill-upload-session-service.ts
+++ b/src/main/skills/skill-upload-session-service.ts
@@ -7,13 +7,14 @@ import {
   type SkillUploadBeginResult,
   type SkillUploadChunkRequest
 } from '../../shared/skill-upload-session-contract'
-import {
-  SkillUploadStagingOwnership,
-  type SkillUploadStagingOwnershipOptions
-} from './skill-upload-staging-ownership'
+import { SkillUploadStagingOwnership } from './skill-upload-staging-ownership'
 import { hashSkillUploadArchive } from './skill-upload-archive-hash'
 import { SkillUploadOperationLifecycle } from './skill-upload-operation-lifecycle'
-import type { SkillUploadSessionRecord } from './skill-upload-session-record'
+import type { SkillUploadSessionServiceOptions } from './skill-upload-session-service-options'
+import {
+  skillUploadBeginResult,
+  type SkillUploadSessionRecord
+} from './skill-upload-session-record'
 
 const MAX_SESSIONS = 4
 const SESSION_IDLE_MS = 10 * 60_000
@@ -30,11 +31,7 @@ export class SkillUploadSessionService {
 
   constructor(
     root: string,
-    private readonly options: {
-      idleMs?: number
-      initializeRoot?: () => Promise<void>
-      ownership?: SkillUploadStagingOwnershipOptions
-    } = {}
+    private readonly options: SkillUploadSessionServiceOptions = {}
   ) {
     this.idleMs = options.idleMs ?? SESSION_IDLE_MS
     this.ownership = new SkillUploadStagingOwnership(root, options.ownership)
@@ -54,7 +51,7 @@ export class SkillUploadSessionService {
           throw new Error('skill-upload-transfer-mismatch')
         }
         this.touch(existing)
-        return this.beginResult(existing)
+        return skillUploadBeginResult(existing)
       }
       if (this.sessions.size >= MAX_SESSIONS) {
         throw new Error('skill-upload-session-limit')
@@ -75,7 +72,7 @@ export class SkillUploadSessionService {
       }
       this.sessions.set(id, session)
       this.touch(session)
-      return this.beginResult(session)
+      return skillUploadBeginResult(session)
     } finally {
       leaveOperation()
       await this.removeOwnershipIfDisposed()
@@ -112,7 +109,11 @@ export class SkillUploadSessionService {
       if (session.bytesReceived + bytes.length > session.package.compressedBytes) {
         throw new Error('skill-upload-size-limit')
       }
-      const write = await session.handle!.write(bytes, 0, bytes.length, request.offset)
+      const handle = session.handle
+      if (!handle) {
+        throw new Error('skill-upload-session-unavailable')
+      }
+      const write = await handle.write(bytes, 0, bytes.length, request.offset)
       if (write.bytesWritten !== bytes.length) {
         throw new Error('skill-upload-write-incomplete')
       }
@@ -145,7 +146,13 @@ export class SkillUploadSessionService {
       await session.handle.sync()
       await session.handle.close()
       session.handle = null
-      const identity = await hashSkillUploadArchive(session.path)
+      let identity: string
+      try {
+        identity = await (this.options.hashArchive ?? hashSkillUploadArchive)(session.path)
+      } catch (error) {
+        await this.cancelSession(uploadId)
+        throw error
+      }
       if (identity !== session.package.archiveSha256) {
         await this.cancelSession(uploadId)
         throw new Error('skill-upload-archive-hash-mismatch')
@@ -247,14 +254,6 @@ export class SkillUploadSessionService {
 
   private expired(session: SkillUploadSessionRecord): boolean {
     return Date.now() - session.touchedAt >= this.idleMs
-  }
-
-  private beginResult(session: SkillUploadSessionRecord): SkillUploadBeginResult {
-    return {
-      uploadId: session.id,
-      chunkBytes: SKILL_UPLOAD_CHUNK_MAX_BYTES,
-      acknowledgedOffset: session.bytesReceived
-    }
   }
 
   private touch(session: SkillUploadSessionRecord): void {

--- a/src/main/skills/skill-upload-staging-ownership.ts
+++ b/src/main/skills/skill-upload-staging-ownership.ts
@@ -27,6 +27,10 @@ export class SkillUploadStagingOwnership {
 
   async initialize(initializeRoot?: () => Promise<void>): Promise<void> {
     await (initializeRoot ? initializeRoot() : mkdir(this.root, { recursive: true, mode: 0o700 }))
+    const rootStats = await lstat(this.root)
+    if (!rootStats.isDirectory() || rootStats.isSymbolicLink()) {
+      throw new Error('skill-upload-staging-root-invalid')
+    }
     await this.cleanupAbandonedOwners()
     await mkdir(this.directory, { recursive: true, mode: 0o700 })
   }

--- a/src/main/skills/skill-upload-staging-ownership.ts
+++ b/src/main/skills/skill-upload-staging-ownership.ts
@@ -1,0 +1,79 @@
+import { randomUUID } from 'node:crypto'
+import { lstat, mkdir, opendir, rm } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const OWNER_DIRECTORY_PREFIX = 'owner-'
+const OWNER_DIRECTORY_PATTERN =
+  /^owner-(\d+)-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i
+const STAGING_ENTRY_SCAN_LIMIT = 64
+
+export const SKILL_UPLOAD_STAGING_ROOT_NAME = 'remote-uploads-v2'
+
+export type SkillUploadStagingOwnershipOptions = {
+  processIsAlive?: (pid: number) => boolean
+}
+
+export class SkillUploadStagingOwnership {
+  readonly directory: string
+  private readonly processIsAlive: (pid: number) => boolean
+
+  constructor(
+    private readonly root: string,
+    options: SkillUploadStagingOwnershipOptions = {}
+  ) {
+    this.directory = join(root, `${OWNER_DIRECTORY_PREFIX}${process.pid}-${randomUUID()}`)
+    this.processIsAlive = options.processIsAlive ?? processIsAlive
+  }
+
+  async initialize(initializeRoot?: () => Promise<void>): Promise<void> {
+    await (initializeRoot ? initializeRoot() : mkdir(this.root, { recursive: true, mode: 0o700 }))
+    await this.cleanupAbandonedOwners()
+    await mkdir(this.directory, { recursive: true, mode: 0o700 })
+  }
+
+  async remove(): Promise<void> {
+    await rm(this.directory, { recursive: true, force: true })
+  }
+
+  private async cleanupAbandonedOwners(): Promise<void> {
+    const root = await opendir(this.root)
+    let visited = 0
+    try {
+      for await (const entry of root) {
+        visited += 1
+        if (visited > STAGING_ENTRY_SCAN_LIMIT) {
+          throw new Error('skill-upload-staging-entry-limit')
+        }
+        const ownerPid = parseOwnerPid(entry.name)
+        if (!entry.isDirectory() || ownerPid === null || this.processIsAlive(ownerPid)) {
+          continue
+        }
+        const candidate = join(this.root, entry.name)
+        const stats = await lstat(candidate).catch(() => null)
+        if (stats?.isDirectory() && !stats.isSymbolicLink()) {
+          await rm(candidate, { recursive: true, force: true })
+        }
+      }
+    } finally {
+      await root.close().catch(() => undefined)
+    }
+  }
+}
+
+function parseOwnerPid(name: string): number | null {
+  const match = OWNER_DIRECTORY_PATTERN.exec(name)
+  if (!match) {
+    return null
+  }
+  const pid = Number(match[1])
+  return Number.isSafeInteger(pid) && pid > 0 ? pid : null
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== 'ESRCH'
+  }
+}

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -1305,6 +1305,11 @@ async function main(): Promise<void> {
     void ptyHandler
       .dispose()
       .then(async () => {
+        await _skillInstallHandler.dispose().catch((error) => {
+          relayLogLine(
+            `[relay] Skill upload cleanup failed: ${error instanceof Error ? error.message : String(error)}`
+          )
+        })
         await aiVaultService?.dispose().catch((error) => {
           relayLogLine(
             `[relay] AI Vault sidecar shutdown failed: ${error instanceof Error ? error.message : String(error)}`

--- a/src/relay/skill-install-handler.ts
+++ b/src/relay/skill-install-handler.ts
@@ -54,6 +54,7 @@ import { listManagedSkillInstalls } from '../main/skills/skill-install-provenanc
 import { executeSkillInstallRequest } from '../main/skills/skill-install-request-service'
 import { executeSkillBundleInstallRequest } from '../main/skills/skill-bundle-install-request-service'
 import { SkillUploadSessionService } from '../main/skills/skill-upload-session-service'
+import { SKILL_UPLOAD_STAGING_ROOT_NAME } from '../main/skills/skill-upload-staging-ownership'
 import {
   SkillInstallOperationError,
   skillInstallFailureFromError
@@ -93,7 +94,7 @@ export class SkillInstallHandler {
     this.homeDirectory = options.homeDirectory ?? homedir()
     this.stateDirectory = options.stateDirectory ?? join(this.homeDirectory, '.orca')
     this.uploads = new SkillUploadSessionService(
-      join(this.stateDirectory, 'skill-installs', 'remote-uploads')
+      join(this.stateDirectory, 'skill-installs', SKILL_UPLOAD_STAGING_ROOT_NAME)
     )
     this.detectProviders = options.detectProviders ?? detectRelaySkillProviders
     this.recovery = (
@@ -219,6 +220,10 @@ export class SkillInstallHandler {
       }
       throw new SkillInstallOperationError(failure, { cause: error })
     }
+  }
+
+  async dispose(): Promise<void> {
+    await this.uploads.dispose()
   }
 
   private async listManagedInstalls(

--- a/src/relay/skill-upload-multi-relay.integration.test.ts
+++ b/src/relay/skill-upload-multi-relay.integration.test.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto'
 import { mkdtemp, readFile, readdir, rm, stat } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join, resolve } from 'node:path'
+import { basename, dirname, join, resolve } from 'node:path'
 import { build } from 'esbuild'
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 import { spawnRelay, type RelayProcess } from './subprocess-test-utils'
@@ -147,6 +147,8 @@ describe('skill upload ownership across relay processes', () => {
       .soft(ownerEntries.some((entry) => entry.name.startsWith(`owner-${second.proc.pid}-`)))
       .toBe(true)
     expect.soft(archives).toHaveLength(2)
+    expect.soft(basename(dirname(firstPath!))).toMatch(new RegExp(`^owner-${first.proc.pid}-`))
+    expect.soft(basename(dirname(secondPath!))).toMatch(new RegExp(`^owner-${second.proc.pid}-`))
     expect.soft(firstStagedBytes).toEqual(firstBytes.subarray(0, 5))
     expect.soft(secondStagedBytes).toEqual(secondBytes)
     await request(second, 'skills.cancelUpload', { uploadId: secondUpload.uploadId })

--- a/src/relay/skill-upload-multi-relay.integration.test.ts
+++ b/src/relay/skill-upload-multi-relay.integration.test.ts
@@ -1,0 +1,208 @@
+import { createHash } from 'node:crypto'
+import { mkdtemp, readFile, readdir, rm, stat } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { build } from 'esbuild'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { spawnRelay, type RelayProcess } from './subprocess-test-utils'
+
+let bundleRoot: string
+let relayEntry: string
+const relays: RelayProcess[] = []
+const roots: string[] = []
+
+beforeAll(async () => {
+  const externalEntry = process.env.ORCA_SKILL_UPLOAD_RELAY_ENTRY
+  if (externalEntry) {
+    relayEntry = resolve(externalEntry)
+    return
+  }
+  bundleRoot = await mkdtemp(join(tmpdir(), 'orca-skill-multi-relay-bundle-'))
+  relayEntry = join(bundleRoot, 'relay.js')
+  await build({
+    entryPoints: [resolve('src/relay/relay.ts')],
+    bundle: true,
+    platform: 'node',
+    target: 'node18',
+    format: 'cjs',
+    outfile: relayEntry,
+    external: ['node-pty', '@parcel/watcher', 'electron'],
+    logLevel: 'silent'
+  })
+})
+
+afterAll(async () => {
+  if (bundleRoot) {
+    await rm(bundleRoot, { recursive: true, force: true })
+  }
+})
+
+afterEach(async () => {
+  await Promise.all(
+    relays.splice(0).map(async (relay) => {
+      relay.kill('SIGTERM')
+      await relay.waitForExit().catch(() => undefined)
+    })
+  )
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+async function request(
+  relay: RelayProcess,
+  method: string,
+  params: Record<string, unknown>
+): Promise<unknown> {
+  const response = await relay.waitForResponse(relay.send(method, params))
+  expect(response.error).toBeUndefined()
+  return response.result
+}
+
+async function stagedArchives(uploadRoot: string): Promise<string[]> {
+  const owners = await readdir(uploadRoot, { withFileTypes: true })
+  const archives = await Promise.all(
+    owners
+      .filter((entry) => entry.isDirectory())
+      .map(async (entry) =>
+        (await readdir(join(uploadRoot, entry.name)))
+          .filter((name) => name.endsWith('.tar.gz'))
+          .map((name) => join(uploadRoot, entry.name, name))
+      )
+  )
+  return archives.flat().sort()
+}
+
+async function uploadRootForOracle(home: string): Promise<string> {
+  const installRoot = join(home, '.orca', 'skill-installs')
+  const current = join(installRoot, 'remote-uploads-v2')
+  return (await stat(current).catch(() => null)) ? current : join(installRoot, 'remote-uploads')
+}
+
+function packageIdentity(bytes: Buffer, suffix: string) {
+  return {
+    packageId: `package_${suffix}`,
+    versionId: `version_${suffix}`,
+    packageDigest: 'a'.repeat(64),
+    archiveSha256: createHash('sha256').update(bytes).digest('hex'),
+    compressedBytes: bytes.length
+  }
+}
+
+describe('skill upload ownership across relay processes', () => {
+  it('keeps each live relay upload isolated and cleans each exact owner', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skill-multi-relay-'))
+    roots.push(root)
+    const home = join(root, 'home')
+    const environment = { ...process.env, HOME: home, USERPROFILE: home }
+    const first = spawnRelay(
+      relayEntry,
+      ['--sock-path', join(root, 'first.sock'), '--endpoint-dir', join(root, 'first-hooks')],
+      { env: environment }
+    )
+    const second = spawnRelay(
+      relayEntry,
+      ['--sock-path', join(root, 'second.sock'), '--endpoint-dir', join(root, 'second-hooks')],
+      { env: environment }
+    )
+    relays.push(first, second)
+    await Promise.all([first.sentinelReceived, second.sentinelReceived])
+    const firstBytes = Buffer.from('first relay live upload')
+    const secondBytes = Buffer.from('second relay upload')
+    const firstUpload = (await request(first, 'skills.beginUpload', {
+      package: packageIdentity(firstBytes, 'first')
+    })) as { uploadId: string }
+    await request(first, 'skills.uploadChunk', {
+      uploadId: firstUpload.uploadId,
+      offset: 0,
+      bytesBase64: firstBytes.subarray(0, 5).toString('base64')
+    })
+
+    const secondUpload = (await request(second, 'skills.beginUpload', {
+      package: packageIdentity(secondBytes, 'second')
+    })) as { uploadId: string }
+    const uploadRoot = await uploadRootForOracle(home)
+    const archives = await stagedArchives(uploadRoot)
+    const firstPath = archives.find((path) => path.endsWith(`${firstUpload.uploadId}.tar.gz`))
+
+    expect(await readdir(uploadRoot)).toHaveLength(2)
+    expect(archives).toHaveLength(2)
+    expect(firstPath).toBeDefined()
+    await expect(readFile(firstPath!)).resolves.toEqual(firstBytes.subarray(0, 5))
+    await request(second, 'skills.cancelUpload', { uploadId: secondUpload.uploadId })
+    expect(await stagedArchives(uploadRoot)).toEqual([firstPath])
+    await request(first, 'skills.cancelUpload', { uploadId: firstUpload.uploadId })
+    expect(await stagedArchives(uploadRoot)).toEqual([])
+
+    first.kill('SIGTERM')
+    await first.waitForExit()
+    relays.splice(relays.indexOf(first), 1)
+    expect(await readdir(uploadRoot)).toHaveLength(1)
+    second.kill('SIGTERM')
+    await second.waitForExit()
+    relays.splice(relays.indexOf(second), 1)
+    expect(await readdir(uploadRoot)).toEqual([])
+  })
+
+  it
+    .runIf(Boolean(process.env.ORCA_SKILL_UPLOAD_LEGACY_RELAY_ENTRY))
+    .each(['legacy-first', 'current-first'] as const)(
+    'keeps %s mixed-version uploads isolated',
+    async (order) => {
+      const root = await mkdtemp(join(tmpdir(), 'orca-skill-mixed-relay-'))
+      roots.push(root)
+      const home = join(root, 'home')
+      const environment = { ...process.env, HOME: home, USERPROFILE: home }
+      const legacyEntry = resolve(process.env.ORCA_SKILL_UPLOAD_LEGACY_RELAY_ENTRY!)
+      const entries =
+        order === 'legacy-first'
+          ? [
+              { kind: 'legacy', entry: legacyEntry },
+              { kind: 'current', entry: relayEntry }
+            ]
+          : [
+              { kind: 'current', entry: relayEntry },
+              { kind: 'legacy', entry: legacyEntry }
+            ]
+      const uploads: { relay: RelayProcess; uploadId: string; bytes: Buffer; kind: string }[] = []
+      for (const [index, owner] of entries.entries()) {
+        const relay = spawnRelay(
+          owner.entry,
+          [
+            '--sock-path',
+            join(root, `${owner.kind}.sock`),
+            '--endpoint-dir',
+            join(root, `${owner.kind}-hooks`)
+          ],
+          { env: environment }
+        )
+        relays.push(relay)
+        await relay.sentinelReceived
+        const bytes = Buffer.from(`${owner.kind} live upload`)
+        const begun = (await request(relay, 'skills.beginUpload', {
+          package: packageIdentity(bytes, `${owner.kind}_${index}`)
+        })) as { uploadId: string }
+        await request(relay, 'skills.uploadChunk', {
+          uploadId: begun.uploadId,
+          offset: 0,
+          bytesBase64: bytes.toString('base64')
+        })
+        uploads.push({ relay, uploadId: begun.uploadId, bytes, kind: owner.kind })
+      }
+
+      const installRoot = join(home, '.orca', 'skill-installs')
+      const legacyFiles = (await readdir(join(installRoot, 'remote-uploads'))).filter((name) =>
+        name.endsWith('.tar.gz')
+      )
+      const currentFiles = await stagedArchives(join(installRoot, 'remote-uploads-v2'))
+      expect(legacyFiles).toHaveLength(1)
+      expect(currentFiles).toHaveLength(1)
+      for (const upload of uploads) {
+        const path =
+          upload.kind === 'legacy'
+            ? join(installRoot, 'remote-uploads', legacyFiles[0]!)
+            : currentFiles[0]!
+        await expect(readFile(path)).resolves.toEqual(upload.bytes)
+        await request(upload.relay, 'skills.cancelUpload', { uploadId: upload.uploadId })
+      }
+    }
+  )
+})

--- a/src/relay/skill-upload-multi-relay.integration.test.ts
+++ b/src/relay/skill-upload-multi-relay.integration.test.ts
@@ -58,9 +58,12 @@ async function request(
 }
 
 async function stagedArchives(uploadRoot: string): Promise<string[]> {
-  const owners = await readdir(uploadRoot, { withFileTypes: true })
+  const entries = await readdir(uploadRoot, { withFileTypes: true })
+  const rootArchives = entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.tar.gz'))
+    .map((entry) => join(uploadRoot, entry.name))
   const archives = await Promise.all(
-    owners
+    entries
       .filter((entry) => entry.isDirectory())
       .map(async (entry) =>
         (await readdir(join(uploadRoot, entry.name)))
@@ -68,7 +71,7 @@ async function stagedArchives(uploadRoot: string): Promise<string[]> {
           .map((name) => join(uploadRoot, entry.name, name))
       )
   )
-  return archives.flat().sort()
+  return [...rootArchives, ...archives.flat()].sort()
 }
 
 async function uploadRootForOracle(home: string): Promise<string> {
@@ -81,7 +84,7 @@ function packageIdentity(bytes: Buffer, suffix: string) {
   return {
     packageId: `package_${suffix}`,
     versionId: `version_${suffix}`,
-    packageDigest: 'a'.repeat(64),
+    packageDigest: createHash('sha256').update(`manifest-${suffix}`).digest('hex'),
     archiveSha256: createHash('sha256').update(bytes).digest('hex'),
     compressedBytes: bytes.length
   }
@@ -119,23 +122,69 @@ describe('skill upload ownership across relay processes', () => {
     const secondUpload = (await request(second, 'skills.beginUpload', {
       package: packageIdentity(secondBytes, 'second')
     })) as { uploadId: string }
+    await request(second, 'skills.uploadChunk', {
+      uploadId: secondUpload.uploadId,
+      offset: 0,
+      bytesBase64: secondBytes.toString('base64')
+    })
     const uploadRoot = await uploadRootForOracle(home)
+    const ownerEntries = (await readdir(uploadRoot, { withFileTypes: true })).filter((entry) =>
+      entry.isDirectory()
+    )
     const archives = await stagedArchives(uploadRoot)
     const firstPath = archives.find((path) => path.endsWith(`${firstUpload.uploadId}.tar.gz`))
+    const secondPath = archives.find((path) => path.endsWith(`${secondUpload.uploadId}.tar.gz`))
+    const firstStagedBytes = firstPath ? await readFile(firstPath) : null
+    const secondStagedBytes = secondPath ? await readFile(secondPath) : null
+    const ownerPattern = /^owner-\d+-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
-    expect(await readdir(uploadRoot)).toHaveLength(2)
-    expect(archives).toHaveLength(2)
-    expect(firstPath).toBeDefined()
-    await expect(readFile(firstPath!)).resolves.toEqual(firstBytes.subarray(0, 5))
+    expect.soft(ownerEntries).toHaveLength(2)
+    expect.soft(ownerEntries.every((entry) => ownerPattern.test(entry.name))).toBe(true)
+    expect
+      .soft(ownerEntries.some((entry) => entry.name.startsWith(`owner-${first.proc.pid}-`)))
+      .toBe(true)
+    expect
+      .soft(ownerEntries.some((entry) => entry.name.startsWith(`owner-${second.proc.pid}-`)))
+      .toBe(true)
+    expect.soft(archives).toHaveLength(2)
+    expect.soft(firstStagedBytes).toEqual(firstBytes.subarray(0, 5))
+    expect.soft(secondStagedBytes).toEqual(secondBytes)
     await request(second, 'skills.cancelUpload', { uploadId: secondUpload.uploadId })
     expect(await stagedArchives(uploadRoot)).toEqual([firstPath])
     await request(first, 'skills.cancelUpload', { uploadId: firstUpload.uploadId })
     expect(await stagedArchives(uploadRoot)).toEqual([])
 
+    const firstDisposalBytes = Buffer.from('first relay disposal upload')
+    const secondDisposalBytes = Buffer.from('second relay disposal upload')
+    const firstDisposalUpload = (await request(first, 'skills.beginUpload', {
+      package: packageIdentity(firstDisposalBytes, 'first_disposal')
+    })) as { uploadId: string }
+    await request(first, 'skills.uploadChunk', {
+      uploadId: firstDisposalUpload.uploadId,
+      offset: 0,
+      bytesBase64: firstDisposalBytes.toString('base64')
+    })
+    const secondDisposalUpload = (await request(second, 'skills.beginUpload', {
+      package: packageIdentity(secondDisposalBytes, 'second_disposal')
+    })) as { uploadId: string }
+    await request(second, 'skills.uploadChunk', {
+      uploadId: secondDisposalUpload.uploadId,
+      offset: 0,
+      bytesBase64: secondDisposalBytes.toString('base64')
+    })
+    const disposalArchives = await stagedArchives(uploadRoot)
+    const secondDisposalPath = disposalArchives.find((path) =>
+      path.endsWith(`${secondDisposalUpload.uploadId}.tar.gz`)
+    )
+
     first.kill('SIGTERM')
     await first.waitForExit()
     relays.splice(relays.indexOf(first), 1)
-    expect(await readdir(uploadRoot)).toHaveLength(1)
+    expect(await readdir(uploadRoot)).toEqual([
+      expect.stringMatching(new RegExp(`^owner-${second.proc.pid}-`))
+    ])
+    expect(await stagedArchives(uploadRoot)).toEqual([secondDisposalPath])
+    await expect(readFile(secondDisposalPath!)).resolves.toEqual(secondDisposalBytes)
     second.kill('SIGTERM')
     await second.waitForExit()
     relays.splice(relays.indexOf(second), 1)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​521 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​15 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​506 |
| Prod | 12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​607 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​158 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​449 |

<!-- /orca-pr-loc -->

## ELI5

Two Orca relays signed in as the same OS user used one temporary upload folder. When relay B accepted its first upload, it erased the whole folder—including relay A's live file. This gives every service process its own clearly owned subfolder and only cleans subfolders whose owning process is positively gone.

## What Changed

- Stage new uploads under the sibling `remote-uploads-v2` root so a live old relay's legacy global wipe cannot reach new uploads.
- Give each service an atomic `owner-<pid>-<uuid>` namespace.
- Reclaim only namespaces whose PID is positively absent; uncertain and PID-reuse cases are preserved.
- Inspect at most 64 direct entries per cleanup attempt and fail closed before adding bytes when capacity cannot be established.
- Serialize begin admission, account for failed deletion against the four-path bound, join active operations during disposal, and preserve transferred archives until consumer cleanup succeeds.
- Join relay and desktop shutdown to upload disposal.
- Cover controlled two-service interleaving, real crash/restart boundaries, real two-relay operation, and old/new mixed-version operation.

## Why This Boundary

Latest `origin/main` at `4fd93ead19` still recursively removed the shared `remote-uploads` root on first `begin()`. The filesystem-owning upload service is the first authoritative layer that knows the exact staged path, its owning process, and its lifecycle. Fixing only the relay handler would leave the same service unsafe in desktop/headless runtimes.

A versioned sibling root is required for backward compatibility: nesting owner directories under the legacy root would still let an older live relay erase them.

## Reproduction and Proof

The byte-identical real two-relay oracle partially uploads A, starts B with the same isolated account home but different socket/hook endpoints, then asserts exact PID/UUID owners, upload-ID paths, archive counts, and byte survival.

- Originating merge `fa9b20cb4163`: expected red—0 owner namespaces, 1 archive instead of 2, and A's bytes gone.
- Latest-main/fix-reverted bundle `012e9f410c`: same expected red result.
- Candidate `ba69b39533`: green—2 exact owners and 2 archives; A and B bytes survive; cancellation cleans archives 2 → 1 → 0; graceful disposal cleans owners 2 → 1 → 0 without touching the live peer.
- Real crash/restart cases at begun, partial, uploaded, and committed boundaries all reclaim only the dead owner and complete a replacement transfer.
- Mixed originating/current relays pass in both launch orders with one exact archive in each isolated root.

Artifact hashes and the exact expected-red commands are recorded in `skill-upload.cross-process-staging-ownership` in `config/reliability-gates.jsonc`.

## Validation

Local macOS evidence at rebased head `ba69b39533`:

- Service ownership/lifecycle contract: 15/15 passed.
- Focused aggregate: 20 passed, 3 intentional skips.
- Skill-sharing release suite: 572 passed, 38 skipped.
- Full `pnpm lint`, `pnpm typecheck`, max-lines ratchet, reliability-gate validation, and `git diff --check`: passed.
- Current PR CI: fully green, including Node 24/26 shards, static analysis, typecheck, package, Windows package, cross-version wire compatibility, changed E2E, SSH Docker watcher isolation, and final verify.

The earlier CI reds were unrelated. The SSH watcher failure was terminal-liveness infrastructure on a branch six commits behind main and passed after a conflict-free rebase. The Node 26 metadata-lifecycle shard failed on a generated mocked runtime ID while its Node 24 twin and 3,327 sibling assertions passed; the exact rerun and final verify are now green.

## Review

Three fresh `gpt-5.6-luna high` Codex reviewers challenged the reproduction, ownership boundary, lifecycle, regressions, and tests. Their legitimate findings were fixed; the final Luna round was clean.

Three fresh OpenCode reviewers independently reviewed pre-rebase head `2ddb895fa8` in this same worktree; the conflict-free rebase to `ba69b39533` is patch-equivalent:

- Reproduction reviewer: CLEAN; independently reproduced both red bundles and verified candidate, mixed-version, restart, cancellation, disposal, lint, and typecheck.
- Regression/platform reviewer: CLEAN after rechecking three observations as intentional fail-closed behavior or an explicit platform evidence gap.
- Ownership reviewer: no high/medium findings and no regression; one accepted low compatibility debt is documented below.

CodeRabbit's valid hash-failure and failed-cleanup lifecycle findings were fixed. Its bounded-scan concern was withdrawn after validating fail-closed admission. Its Windows-junction and duplicate UUID-assertion suggestions were reviewed, answered, and resolved without weakening coverage.

## Compatibility, Downsides, and Gaps

- Backward compatible: no RPC, wire, bundle, provider, renderer, Git, or Orca Cloud contract changes. No Orca Cloud change or deployment is required.
- A pre-upgrade legacy `remote-uploads` directory is intentionally not reclaimed while a live old relay may own unmarked files there. Safe retirement needs a separate compatibility decision; a wipe or TTL would recreate the data-loss class.
- PID reuse is conservative: stale data can be retained until a later process generation instead of risking deletion.
- More than 64 root entries fail admission; retries drain dead owners in bounded batches. Foreign/live entries fail closed.
- A transient archive-deletion failure counts against the four-path limit until disposal retries it or restart reclaims the dead owner.
- The real topology evidence is macOS. Windows packaging is green, but physical Windows process semantics and separate paired headed/headless runtime journeys remain explicit promotion gaps.
- Pre-existing concurrent append/commit/cancel serialization is unchanged and belongs in a future PR.

## Linked Issue

[STA-4967](https://linear.app/stably/issue/STA-4967)

Originating PR: #14934

## Visual Proof

N/A — host filesystem lifecycle only; no UI changes.

## Future PR Suggestions

- Serialize concurrent operations for one upload at the protocol boundary.
- Retire the legacy root after mixed-version safety permits it.
- Consider process-incarnation markers if conservative PID-reuse retention proves costly.
- Define a host-wide staging quota if adversarial same-account process counts enter the threat model.

## Checklist

- [x] Automated deterministic red/green/revert coverage added.
- [x] Cross-platform, SSH/relay, paired-runtime, and mixed-version impact considered.
- [x] No polling, broad TTL, global wipe, or unbounded cleanup scan.
- [x] Full PR CI is green.
- [x] Draft only; do not merge as part of STA-4967 ownership work.

