### PR TITLE
fix(agent-hooks): restore Cursor launch tokens and new-turn restart (STA-3487)

### DIFF
--- a/src/main/agent-hooks/server-cursor-pane-authority.test.ts
+++ b/src/main/agent-hooks/server-cursor-pane-authority.test.ts
@@ -1,0 +1,199 @@
+import { createHash } from 'node:crypto'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AgentHookServer, _internals } from './server'
+import { buildBody, PANE, GOOD_PANE, postHookEvent } from './server.test-fixtures'
+
+const { getCohortAtEmitMock, trackMock } = vi.hoisted(() => ({
+  getCohortAtEmitMock: vi.fn(),
+  trackMock: vi.fn()
+}))
+
+vi.mock('../telemetry/client', () => ({
+  track: trackMock
+}))
+
+vi.mock('../telemetry/cohort-classifier', () => ({
+  getCohortAtEmit: getCohortAtEmitMock
+}))
+
+beforeEach(() => {
+  _internals.resetCachesForTests()
+  trackMock.mockReset()
+  getCohortAtEmitMock.mockReset()
+  getCohortAtEmitMock.mockReturnValue({ nth_repo_added: 2 })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+async function postCursorHook(
+  server: AgentHookServer,
+  payload: Record<string, unknown>,
+  overrides: Parameters<typeof buildBody>[1] = {}
+): Promise<Response> {
+  return postHookEvent(server, buildBody(payload, overrides), '/hook/cursor')
+}
+
+describe('Cursor pane authority ingest', () => {
+  it('a completed stop settles a tokenless Cursor pane to done', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      await postCursorHook(server, {
+        hook_event_name: 'beforeSubmitPrompt',
+        prompt: 'add a README'
+      })
+      await postCursorHook(server, { hook_event_name: 'stop', status: 'completed' })
+      await postCursorHook(server, {
+        hook_event_name: 'afterAgentResponse',
+        text: 'Wrote the README.'
+      })
+
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({
+          paneKey: PANE,
+          state: 'done',
+          agentType: 'cursor',
+          prompt: 'add a README',
+          lastAssistantMessage: 'Wrote the README.'
+        })
+      ])
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('a remote Cursor beforeSubmitPrompt restarts a retired pane so stop can settle', () => {
+    const server = new AgentHookServer()
+    server.ingestRemote(
+      {
+        paneKey: PANE,
+        source: 'cursor',
+        hookEventName: 'beforeSubmitPrompt',
+        launchToken: 'remote-cursor-token',
+        payload: { state: 'working', prompt: 'first remote', agentType: 'cursor' }
+      },
+      'ssh-1'
+    )
+    server.retirePaneAuthority(PANE)
+
+    server.ingestRemote(
+      {
+        paneKey: PANE,
+        source: 'cursor',
+        hookEventName: 'beforeSubmitPrompt',
+        launchToken: 'remote-cursor-token',
+        payload: { state: 'working', prompt: 'second remote', agentType: 'cursor' }
+      },
+      'ssh-1'
+    )
+    server.ingestRemote(
+      {
+        paneKey: PANE,
+        source: 'cursor',
+        hookEventName: 'stop',
+        launchToken: 'remote-cursor-token',
+        payload: { state: 'done', prompt: 'second remote', agentType: 'cursor' }
+      },
+      'ssh-1'
+    )
+
+    expect(server.getStatusSnapshot()).toEqual([
+      expect.objectContaining({
+        paneKey: PANE,
+        state: 'done',
+        agentType: 'cursor',
+        prompt: 'second remote',
+        connectionId: 'ssh-1'
+      })
+    ])
+  })
+
+  it('a completed stop after launch-authority retire still settles the same Cursor pane', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      await postCursorHook(
+        server,
+        { hook_event_name: 'beforeSubmitPrompt', prompt: 'add tests' },
+        { launchToken: 'cursor-launch-token' }
+      )
+      server.retirePaneAuthority(PANE)
+
+      await postCursorHook(
+        server,
+        { hook_event_name: 'beforeSubmitPrompt', prompt: 'add tests again' },
+        { launchToken: 'cursor-launch-token' }
+      )
+      await postCursorHook(
+        server,
+        { hook_event_name: 'stop', status: 'completed' },
+        { launchToken: 'cursor-launch-token' }
+      )
+
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({
+          paneKey: PANE,
+          state: 'done',
+          agentType: 'cursor',
+          prompt: 'add tests again'
+        })
+      ])
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('a pane without matching launch authority cannot stamp a sibling Cursor pane done', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      await postCursorHook(
+        server,
+        { hook_event_name: 'beforeSubmitPrompt', prompt: 'control turn' },
+        { launchToken: 'control-token' }
+      )
+      await postCursorHook(
+        server,
+        { hook_event_name: 'beforeSubmitPrompt', prompt: 'foreign turn' },
+        { paneKey: GOOD_PANE, tabId: 'tab-good', launchToken: 'foreign-token' }
+      )
+      server.retirePaneAuthority(GOOD_PANE)
+
+      // Why: a completed stop is not a new-turn proof. Without this fence a
+      // retired pane could stamp itself (or, with a stolen paneKey, a sibling).
+      await postCursorHook(
+        server,
+        { hook_event_name: 'stop', status: 'completed' },
+        { paneKey: GOOD_PANE, tabId: 'tab-good' }
+      )
+
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({
+          paneKey: PANE,
+          state: 'working',
+          prompt: 'control turn'
+        })
+      ])
+      expect(
+        server.attestCompatibilityAuthority({
+          paneKey: PANE,
+          launchTokenHash: createHash('sha256').update('control-token').digest('hex'),
+          connectionId: null,
+          terminalProvenance: 'current_runtime'
+        })
+      ).toEqual({ paneKey: PANE, source: 'current_hook' })
+      expect(
+        server.attestCompatibilityAuthority({
+          paneKey: GOOD_PANE,
+          launchTokenHash: createHash('sha256').update('foreign-token').digest('hex'),
+          connectionId: null,
+          terminalProvenance: 'current_runtime'
+        })
+      ).toBeNull()
+    } finally {
+      server.stop()
+    }
+  })
+})

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -1123,7 +1123,7 @@ export class AgentHookServer {
 
   private getAgentStatusDisposition(
     paneKey: string,
-    event?: { hookEventName?: string; isReplay?: boolean }
+    event?: { hookEventName?: string; isReplay?: boolean; source?: AgentHookSource }
   ): 'accept' | 'restart' | 'suppress' {
     const ownerPaneKey = this.resolvePaneKeyAlias(paneKey)
     const paneRetired =
@@ -1139,9 +1139,12 @@ export class AgentHookServer {
     // Why: command completion retires launch authority but leaves its shell pane reusable.
     // A live SessionStart proves a new agent process owns the retired pane just like a
     // fresh prompt does — without it, a session resumed in a reused pane stays rowless (STA-3386).
+    // Cursor's new-turn events are beforeSubmitPrompt/sessionStart, not UserPromptSubmit (STA-3487).
     if (
-      (event?.hookEventName === 'UserPromptSubmit' || event?.hookEventName === 'SessionStart') &&
-      event.isReplay !== true
+      event?.isReplay !== true &&
+      (event?.hookEventName === 'UserPromptSubmit' ||
+        event?.hookEventName === 'SessionStart' ||
+        (event?.source === 'cursor' && isNewTurnEvent('cursor', event.hookEventName)))
     ) {
       this.closedAgentStatusPaneKeys.delete(paneKey)
       this.closedAgentStatusPaneKeys.delete(ownerPaneKey)
@@ -2250,7 +2253,8 @@ export class AgentHookServer {
         : undefined
     const statusDisposition = this.getAgentStatusDisposition(paneKey, {
       hookEventName,
-      isReplay: envelope.isReplay === true
+      isReplay: envelope.isReplay === true,
+      source
     })
     if (statusDisposition === 'suppress') {
       return
@@ -2468,7 +2472,8 @@ export class AgentHookServer {
         const statusDisposition = normalized.event
           ? this.getAgentStatusDisposition(normalized.event.paneKey, {
               hookEventName: normalized.event.hookEventName,
-              isReplay: normalized.event.isReplay
+              isReplay: normalized.event.isReplay,
+              source: normalized.event.source
             })
           : 'suppress'
         if (normalized.event && statusDisposition !== 'suppress') {

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -1140,6 +1140,10 @@ export class AgentHookServer {
     // A live SessionStart proves a new agent process owns the retired pane just like a
     // fresh prompt does — without it, a session resumed in a reused pane stays rowless (STA-3386).
     // Cursor's new-turn events are beforeSubmitPrompt/sessionStart, not UserPromptSubmit (STA-3487).
+    // Why not the full isNewTurnEvent map: that classifier stamps observation boundaries, but
+    // this gate is also a fence. pi/omp/prime-agent `before_agent_start` is a new-turn for
+    // stamping, yet lifting the retired-pane fence on it unfences a closed tab's pane after
+    // closedAgentStatusTabIds LRU eviction (STA-4114).
     if (
       event?.isReplay !== true &&
       (event?.hookEventName === 'UserPromptSubmit' ||

--- a/src/renderer/src/lib/resume-sleeping-agent-session.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session.test.ts
@@ -542,7 +542,16 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
     expect(startup?.command).toBe(
       "codex --profile captured '--model' 'gpt-5' '--reasoning-effort' 'high' 'resume' 'sess-1'"
     )
-    expect(startup?.env).toEqual({ CODEX_PROFILE: 'captured' })
+    // STA-3487 stamps the resumed agent's own launch token into env; the captured
+    // profile must still win over the changed setting, and the token must be the
+    // one queued alongside it so hook authority binds to this launch.
+    expect(startup?.env?.CODEX_PROFILE).toBe('captured')
+    expect(startup?.env?.ORCA_AGENT_LAUNCH_TOKEN).toBe(startup?.launchToken)
+    expect(startup?.launchToken).toBeTruthy()
+    expect(Object.keys(startup?.env ?? {}).sort()).toEqual([
+      'CODEX_PROFILE',
+      'ORCA_AGENT_LAUNCH_TOKEN'
+    ])
     expect(startup?.command).not.toContain('changed')
     expect(startup?.launchConfig).toEqual(record.launchConfig)
     expect(startup?.resumeProviderSession).toEqual(record.providerSession)

--- a/src/renderer/src/store/slices/terminal-startup-command-retention.test.ts
+++ b/src/renderer/src/store/slices/terminal-startup-command-retention.test.ts
@@ -75,4 +75,20 @@ describe('queued startup command retention', () => {
 
     expect(store.getState().pendingStartupByTabId[siblingId]).toEqual({ command: 'echo theirs' })
   })
+
+  it('stamps a bare cursor-agent startup with a launch token so the pane env can carry it', () => {
+    const store = createTestStore()
+    const tabId = seedWorktreeWithTab(store)
+    store.getState().queueTabStartupCommand(tabId, { command: 'cursor-agent' })
+
+    const queued = store.getState().pendingStartupByTabId[tabId]
+    expect(queued?.launchAgent).toBe('cursor')
+    expect(queued?.launchConfig).toEqual({
+      agentCommand: 'cursor-agent',
+      agentArgs: '',
+      agentEnv: {}
+    })
+    expect(queued?.launchToken).toEqual(expect.stringMatching(/^[0-9a-f-]{36}$/i))
+    expect(queued?.env?.ORCA_AGENT_LAUNCH_TOKEN).toBe(queued?.launchToken)
+  })
 })

--- a/src/renderer/src/store/slices/terminal-startup-command-retention.test.ts
+++ b/src/renderer/src/store/slices/terminal-startup-command-retention.test.ts
@@ -91,4 +91,54 @@ describe('queued startup command retention', () => {
     expect(queued?.launchToken).toEqual(expect.stringMatching(/^[0-9a-f-]{36}$/i))
     expect(queued?.env?.ORCA_AGENT_LAUNCH_TOKEN).toBe(queued?.launchToken)
   })
+
+  it('does not mint a token for an unrecognized command even when launchConfig is present', () => {
+    const store = createTestStore()
+    const tabId = seedWorktreeWithTab(store)
+    store.getState().queueTabStartupCommand(tabId, {
+      command: 'echo hi',
+      launchConfig: { agentArgs: '', agentEnv: {} }
+    })
+
+    const queued = store.getState().pendingStartupByTabId[tabId]
+    expect(queued?.launchToken).toBeUndefined()
+    expect(queued?.env?.ORCA_AGENT_LAUNCH_TOKEN).toBeUndefined()
+    expect(queued?.command).toBe('echo hi')
+  })
+
+  it('overwrites a captured ORCA_AGENT_LAUNCH_TOKEN when resume-shaped startup is queued', () => {
+    const store = createTestStore()
+    const tabId = seedWorktreeWithTab(store)
+    store.getState().queueTabStartupCommand(tabId, {
+      command: 'codex resume sess-1',
+      launchAgent: 'codex',
+      launchConfig: {
+        agentCommand: 'codex',
+        agentArgs: '',
+        agentEnv: { CODEX_PROFILE: 'captured', ORCA_AGENT_LAUNCH_TOKEN: 'stale-persisted-token' }
+      },
+      env: { CODEX_PROFILE: 'captured', ORCA_AGENT_LAUNCH_TOKEN: 'stale-persisted-token' }
+    })
+
+    const queued = store.getState().pendingStartupByTabId[tabId]
+    expect(queued?.env?.CODEX_PROFILE).toBe('captured')
+    expect(queued?.launchToken).toEqual(expect.stringMatching(/^[0-9a-f-]{36}$/i))
+    expect(queued?.launchToken).not.toBe('stale-persisted-token')
+    expect(queued?.env?.ORCA_AGENT_LAUNCH_TOKEN).toBe(queued?.launchToken)
+  })
+
+  it('mints a distinct launch token per tab so a sibling cannot inherit authority', () => {
+    const store = createTestStore()
+    const tabId = seedWorktreeWithTab(store)
+    const siblingId = store.getState().createTab(WORKTREE_ID).id
+    store.getState().queueTabStartupCommand(tabId, { command: 'cursor-agent' })
+    store.getState().queueTabStartupCommand(siblingId, { command: 'cursor-agent' })
+
+    const queued = store.getState().pendingStartupByTabId[tabId]
+    const sibling = store.getState().pendingStartupByTabId[siblingId]
+    expect(queued?.launchToken).toEqual(expect.stringMatching(/^[0-9a-f-]{36}$/i))
+    expect(sibling?.launchToken).toEqual(expect.stringMatching(/^[0-9a-f-]{36}$/i))
+    expect(queued?.launchToken).not.toBe(sibling?.launchToken)
+    expect(queued?.env?.ORCA_AGENT_LAUNCH_TOKEN).not.toBe(sibling?.env?.ORCA_AGENT_LAUNCH_TOKEN)
+  })
 })

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -110,6 +110,7 @@ import { parseRemoteRuntimePtyId, toRemoteRuntimePtyId } from '@/runtime/runtime
 import { toRuntimeWorktreeSelector } from '@/runtime/runtime-worktree-selector'
 import { requestRemoteWorktreeSleep } from '@/runtime/remote-worktree-sleep'
 import { createBrowserUuid } from '@/lib/browser-uuid'
+import { attachQueuedAgentLaunchAuthority } from '../../../../shared/queued-agent-launch-authority'
 import { getFolderWorkspaceConnectionId } from '@/lib/folder-workspace-connection'
 import {
   clearDirectSshTerminalBindings,
@@ -3668,15 +3669,17 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
   },
 
   queueTabStartupCommand: (tabId, startup) => {
-    // Why: launchToken is only meaningful for tracked launch-config reuse; plain startup commands must not mint a synthetic token.
-    const launchToken = startup.launchConfig
-      ? (startup.launchToken ?? createBrowserUuid())
+    // Why: launchToken is only meaningful for tracked TUI-agent launches; plain
+    // shell commands must not mint a synthetic token a later typed agent could inherit.
+    const authorized = attachQueuedAgentLaunchAuthority(startup)
+    const launchToken = authorized.launchConfig
+      ? (authorized.launchToken ?? createBrowserUuid())
       : undefined
     set((s) => ({
       pendingStartupByTabId: {
         ...s.pendingStartupByTabId,
         [tabId]: {
-          ...startup,
+          ...authorized,
           ...(launchToken ? { launchToken } : {})
         }
       }

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -3671,17 +3671,13 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
   queueTabStartupCommand: (tabId, startup) => {
     // Why: launchToken is only meaningful for tracked TUI-agent launches; plain
     // shell commands must not mint a synthetic token a later typed agent could inherit.
+    // attachQueuedAgentLaunchAuthority is the sole mint — a leftover launchConfig
+    // fallback would stamp a token without injecting ORCA_AGENT_LAUNCH_TOKEN.
     const authorized = attachQueuedAgentLaunchAuthority(startup)
-    const launchToken = authorized.launchConfig
-      ? (authorized.launchToken ?? createBrowserUuid())
-      : undefined
     set((s) => ({
       pendingStartupByTabId: {
         ...s.pendingStartupByTabId,
-        [tabId]: {
-          ...authorized,
-          ...(launchToken ? { launchToken } : {})
-        }
+        [tabId]: { ...authorized }
       }
     }))
   },

--- a/src/shared/queued-agent-launch-authority.test.ts
+++ b/src/shared/queued-agent-launch-authority.test.ts
@@ -24,6 +24,57 @@ describe('attachQueuedAgentLaunchAuthority', () => {
     expect(attachQueuedAgentLaunchAuthority({ command: 'codex exec summarize' })).toEqual({
       command: 'codex exec summarize'
     })
+    expect(attachQueuedAgentLaunchAuthority({ command: 'cursor-agent --foo' })).toEqual({
+      command: 'cursor-agent --foo'
+    })
+  })
+
+  it('does not mint a token for an unrecognized command even when launchConfig is present', () => {
+    expect(
+      attachQueuedAgentLaunchAuthority({
+        command: 'echo hi',
+        launchConfig: { agentArgs: '', agentEnv: {} }
+      })
+    ).toEqual({
+      command: 'echo hi',
+      launchConfig: { agentArgs: '', agentEnv: {} }
+    })
+  })
+
+  it('stamps a non-bare invocation when launchConfig is already present', () => {
+    const stamped = attachQueuedAgentLaunchAuthority({
+      command: 'codex exec summarize',
+      launchConfig: { agentCommand: 'codex exec summarize', agentArgs: '', agentEnv: {} }
+    })
+    expect(stamped.launchAgent).toBe('codex')
+    expect(stamped.launchToken).toMatch(UUID_RE)
+    expect(stamped.env?.ORCA_AGENT_LAUNCH_TOKEN).toBe(stamped.launchToken)
+  })
+
+  it('overwrites a captured ORCA_AGENT_LAUNCH_TOKEN with the minted token', () => {
+    const stamped = attachQueuedAgentLaunchAuthority({
+      command: 'codex resume sess-1',
+      launchAgent: 'codex',
+      launchConfig: {
+        agentCommand: 'codex',
+        agentArgs: '',
+        agentEnv: { CODEX_PROFILE: 'captured', ORCA_AGENT_LAUNCH_TOKEN: 'stale-token' }
+      },
+      env: { CODEX_PROFILE: 'captured', ORCA_AGENT_LAUNCH_TOKEN: 'stale-token' }
+    })
+    expect(stamped.launchToken).toMatch(UUID_RE)
+    expect(stamped.launchToken).not.toBe('stale-token')
+    expect(stamped.env?.ORCA_AGENT_LAUNCH_TOKEN).toBe(stamped.launchToken)
+    expect(stamped.env?.CODEX_PROFILE).toBe('captured')
+  })
+
+  it('mints a distinct token per call so a sibling cannot inherit authority', () => {
+    const first = attachQueuedAgentLaunchAuthority({ command: 'cursor-agent' })
+    const second = attachQueuedAgentLaunchAuthority({ command: 'cursor-agent' })
+    expect(first.launchToken).toMatch(UUID_RE)
+    expect(second.launchToken).toMatch(UUID_RE)
+    expect(first.launchToken).not.toBe(second.launchToken)
+    expect(first.env?.ORCA_AGENT_LAUNCH_TOKEN).not.toBe(second.env?.ORCA_AGENT_LAUNCH_TOKEN)
   })
 
   it('reuses an explicit launch token instead of minting another', () => {

--- a/src/shared/queued-agent-launch-authority.test.ts
+++ b/src/shared/queued-agent-launch-authority.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { attachQueuedAgentLaunchAuthority } from './queued-agent-launch-authority'
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+describe('attachQueuedAgentLaunchAuthority', () => {
+  it('stamps a bare cursor-agent command with launch config and a launch token', () => {
+    const stamped = attachQueuedAgentLaunchAuthority({ command: 'cursor-agent' })
+    expect(stamped.launchAgent).toBe('cursor')
+    expect(stamped.launchConfig).toEqual({
+      agentCommand: 'cursor-agent',
+      agentArgs: '',
+      agentEnv: {}
+    })
+    expect(stamped.launchToken).toMatch(UUID_RE)
+    expect(stamped.env?.ORCA_AGENT_LAUNCH_TOKEN).toBe(stamped.launchToken)
+  })
+
+  it('leaves a plain shell command tokenless', () => {
+    expect(attachQueuedAgentLaunchAuthority({ command: 'echo hi' })).toEqual({ command: 'echo hi' })
+  })
+
+  it('does not mint authority for a non-bare agent invocation', () => {
+    expect(attachQueuedAgentLaunchAuthority({ command: 'codex exec summarize' })).toEqual({
+      command: 'codex exec summarize'
+    })
+  })
+
+  it('reuses an explicit launch token instead of minting another', () => {
+    const stamped = attachQueuedAgentLaunchAuthority({
+      command: 'cursor-agent',
+      launchToken: 'explicit-token'
+    })
+    expect(stamped.launchToken).toBe('explicit-token')
+    expect(stamped.env?.ORCA_AGENT_LAUNCH_TOKEN).toBe('explicit-token')
+  })
+})

--- a/src/shared/queued-agent-launch-authority.ts
+++ b/src/shared/queued-agent-launch-authority.ts
@@ -1,0 +1,58 @@
+import { recognizeAgentProcessFromCommandLine } from './agent-process-recognition'
+import type { SleepingAgentLaunchConfig } from './agent-session-resume'
+import { buildSleepingAgentLaunchConfig } from './sleeping-agent-launch-config'
+import type { TuiAgent } from './tui-agent'
+
+export type QueuedAgentLaunchStartup = {
+  command: string
+  launchConfig?: SleepingAgentLaunchConfig
+  launchAgent?: TuiAgent
+  launchToken?: string
+  env?: Record<string, string>
+}
+
+function mintLaunchToken(): string {
+  return globalThis.crypto.randomUUID()
+}
+
+function isBareRecognizedAgentCommand(command: string, agent: TuiAgent): boolean {
+  const trimmed = command.trim()
+  if (!trimmed || /\s/.test(trimmed)) {
+    return false
+  }
+  return recognizeAgentProcessFromCommandLine(trimmed)?.agent === agent
+}
+
+/**
+ * Stamps launchConfig + ORCA_AGENT_LAUNCH_TOKEN onto a queued TUI agent startup.
+ * Plain shell commands stay tokenless so a later typed agent cannot inherit a sibling's authority.
+ */
+export function attachQueuedAgentLaunchAuthority<T extends QueuedAgentLaunchStartup>(
+  startup: T
+): T & QueuedAgentLaunchStartup {
+  const recognizedAgent =
+    startup.launchAgent ?? recognizeAgentProcessFromCommandLine(startup.command)?.agent
+  if (!recognizedAgent) {
+    return startup
+  }
+  if (
+    !startup.launchConfig &&
+    !startup.launchAgent &&
+    !isBareRecognizedAgentCommand(startup.command, recognizedAgent)
+  ) {
+    return startup
+  }
+  const launchConfig =
+    startup.launchConfig ?? buildSleepingAgentLaunchConfig({ agentCommand: startup.command })
+  const launchToken = startup.launchToken ?? mintLaunchToken()
+  return {
+    ...startup,
+    launchAgent: startup.launchAgent ?? recognizedAgent,
+    launchConfig,
+    launchToken,
+    env: {
+      ...startup.env,
+      ORCA_AGENT_LAUNCH_TOKEN: launchToken
+    }
+  }
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​363 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​362 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​79 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​66 |

<!-- /orca-pr-loc -->

## ELI5

Some Cursor panes kept showing Working after the agent finished. Two things stacked: a Cursor pane started as a plain `cursor-agent` command never got a launch token, and when launch authority was later retired, Orca only treated Claude's `UserPromptSubmit` / `SessionStart` as a new turn. Cursor's `beforeSubmitPrompt` was ignored, so a completed `stop` never landed. This stamps a launch token on bare Cursor launches and lets Cursor's own new-turn events reopen a retired pane. A completed stop still cannot stamp a sibling pane.

## What Changed

- Queued bare TUI agent commands (`cursor-agent`, `codex`, …) now get `launchConfig` + `ORCA_AGENT_LAUNCH_TOKEN`. Plain shell commands and non-bare invocations like `codex exec` stay tokenless.
- Retired-pane restart now includes Cursor `beforeSubmitPrompt` / `sessionStart` (in addition to Claude `UserPromptSubmit` / `SessionStart`).
- Tests: tokenless Cursor `stop` still settles; a retired Cursor pane restarts on `beforeSubmitPrompt` (local HTTP and SSH `ingestRemote`) then `stop` reaches `done`; a retired sibling cannot stamp another pane; queued `cursor-agent` carries the token.

## Why

Paired Windows observation: same hook sequence (`beforeSubmitPrompt` → `stop completed` → `afterAgentResponse`), one pane `done` with a persisted authority commitment, the other stuck `working` with `ORCA_AGENT_LAUNCH_TOKEN` absent and no commitment.

Tokenless HTTP ingest already accepted `stop` (so loosening the authority check would not have been the right fix). The missing token is minted only when `launchConfig` exists; default-tab / command-only Cursor starts queue `{ command: 'cursor-agent' }` and never got one. Independently, `retirePaneAuthority` (command-finished / restored receipt) deletes the row and fences the pane; Claude can restart on the next prompt, Cursor could not.

Related in-flight work: #15658 still owns nested-shell OSC `133;D` falsely retiring launch authority while an agent is in the foreground. This PR does not duplicate that guard. It restores the lost token on the command-only launch path and makes Cursor's new-turn event reopen a retired pane the same way Claude already does.

## Linked Issue

Fixes #12686
Fixes STA-3487

## Visual Proof

N/A — hook-server ingest and queued-startup env stamping. No new chrome. The user-visible effect is the existing Cursor Working indicator settling to idle after a completed `stop`.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

TDD:

| Stage | Result |
| --- | --- |
| Pre-fix | Tokenless Cursor `stop` already passed. Retired-pane Cursor restart failed (`expected []` vs done). Queued `cursor-agent` had no `launchToken` (`expected 'cursor'`, received `undefined`). |
| Post-fix | `server-cursor-pane-authority.test.ts` 4/4, `server-closed-tab-suppression.test.ts` 20/20, `queued-agent-launch-authority.test.ts` 4/4, `terminal-startup-command-retention.test.ts` 6/6, `launch-agent-in-new-tab.test.ts` 27/27 |
| Neutered (Cursor restart branch and queue attach removed, tests kept) | Same two ingest restart tests and the queued `cursor-agent` token test failed again |

Also: `pnpm typecheck` passed. `oxlint --deny-warnings` and `oxfmt` on changed files only — clean.

Windows host unreachable this session — Windows env propagation into Cursor panes is unvalidated.

## Review

- **Security:** launch tokens are still not a license to stamp another paneKey. Retired Cursor `stop` without a new-turn event stays suppressed. Plain shell startups remain tokenless so a typed agent cannot inherit a sibling token.
- **Cross-platform:** token minting and hook disposition are host-agnostic. Windows ConPTY env was the original report and is unvalidated here.
- **Remote SSH:** `ingestRemote` now forwards `source` into disposition; covered by the remote restart test. Folder workspaces use the same `queueTabStartupCommand` path.
- **Mobile:** no client change; mobile consumes the same hook status rows.
- **Backwards compatibility:** additive. No wire/RPC/stream opcode changes.
- **Performance:** one command-line recognition pass when queueing a startup command.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @BrennanKB5

## Out of scope

- #15658 / STA-4521 — nested-shell OSC `133;D` retiring launch authority while the agent is still in the foreground. Complementary, not overlapping the Cursor new-turn / command-only token hole.
- #15674 / STA-3817 — interrupt inference over a live working row.
- #15665 / STA-4774 — title-derived sidebar rows / `launchAgentLeafId`.