### PR TITLE
fix(ai-vault): prefer Pi/OMP harness names in session history (STA-2467)

### DIFF
--- a/src/main/ai-vault/session-scanner-graph-parsers.ts
+++ b/src/main/ai-vault/session-scanner-graph-parsers.ts
@@ -22,6 +22,7 @@ import {
 import {
   applyGraphSessionTitle,
   cloneGraphSessionTitleState,
+  type GraphSessionAgent,
   type GraphSessionTitleState
 } from './session-scanner-graph-session-title'
 import {
@@ -174,7 +175,7 @@ export function rovoPartsText(parts: unknown[], role: 'user' | 'assistant'): str
 // Agents whose transcripts are append-only message-graph JSONL (session +
 // model_change + message records). OMP and Prime Agent are Pi forks and
 // share the format.
-export type MessageGraphAgent = 'openclaw' | 'pi' | 'omp' | 'prime-agent'
+export type MessageGraphAgent = GraphSessionAgent
 
 export async function parseMessageGraphSessionFile(
   agent: MessageGraphAgent,
@@ -255,6 +256,7 @@ export function createMessageGraphSessionResumeState(
   file: FileWithMtime
 ): ResumableSessionParseState {
   const resume = createMessageGraphResumeFrom({
+    agent,
     accumulator: createAccumulator({ agent, file, sessionId: sessionIdFromFileName(file.path) }),
     source: null
   })

--- a/src/main/ai-vault/session-scanner-graph-parsers.ts
+++ b/src/main/ai-vault/session-scanner-graph-parsers.ts
@@ -11,14 +11,19 @@ import type {
   SessionAccumulator
 } from './session-scanner-types'
 import {
-  accumulatorFoldResumeState,
   addPreviewContent,
   addPreviewMessage,
+  cloneSessionAccumulator,
   createAccumulator,
   finalizeSession,
   sessionIdFromFileName,
   updateTimeline
 } from './session-scanner-accumulator'
+import {
+  applyGraphSessionTitle,
+  cloneGraphSessionTitleState,
+  type GraphSessionTitleState
+} from './session-scanner-graph-session-title'
 import {
   arrayValue,
   asRecord,
@@ -205,12 +210,14 @@ export async function parseMessageGraphSessionContent(
   })
 }
 
-function consumeMessageGraphRecordLine(accumulator: SessionAccumulator, line: string): void {
+function consumeMessageGraphRecordLine(state: GraphSessionTitleState, line: string): void {
   const record = parseJsonObject(line)
   if (!record) {
     return
   }
+  const { accumulator } = state
   updateTimeline(accumulator, extractString(record.timestamp))
+  applyGraphSessionTitle(state, record)
   if (record.type === 'session') {
     const sessionId = extractString(record.id)
     if (sessionId) {
@@ -234,7 +241,7 @@ function consumeMessageGraphRecordLine(accumulator: SessionAccumulator, line: st
   if (role === 'user' || role === 'assistant') {
     accumulator.messageCount++
     if (role === 'user') {
-      accumulator.title ??= extractMessageText(message)
+      accumulator.fallbackTitle ??= extractMessageText(message)
     } else {
       accumulator.model = extractString(message?.model) ?? accumulator.model
       accumulator.totalTokens += tokenTotal(message?.usage)
@@ -247,14 +254,26 @@ export function createMessageGraphSessionResumeState(
   agent: MessageGraphAgent,
   file: FileWithMtime
 ): ResumableSessionParseState {
-  const state = accumulatorFoldResumeState(
-    createAccumulator({ agent, file, sessionId: sessionIdFromFileName(file.path) }),
-    consumeMessageGraphRecordLine
-  )
+  const resume = createMessageGraphResumeFrom({
+    accumulator: createAccumulator({ agent, file, sessionId: sessionIdFromFileName(file.path) }),
+    source: null
+  })
   // Why: only OMP materializes task-subagent transcripts beside its sessions
   // (in the same-named artifact dir); the row UI shows the count without
   // expanding details. Pi/OpenClaw/Prime Agent have no such layout — skip the readdir.
-  return agent === 'omp' ? withOmpSubagentTranscriptCount(state, file.path) : state
+  return agent === 'omp' ? withOmpSubagentTranscriptCount(resume, file.path) : resume
+}
+
+function createMessageGraphResumeFrom(state: GraphSessionTitleState): ResumableSessionParseState {
+  return {
+    consumeLine: (line) => consumeMessageGraphRecordLine(state, line),
+    clone: () => createMessageGraphResumeFrom(cloneGraphSessionTitleState(state)),
+    touchFile: (nextFile) => {
+      state.accumulator.modifiedAt = nextFile.modifiedAt
+    },
+    finalize: (platform, options) =>
+      finalizeSession(cloneSessionAccumulator(state.accumulator), platform, options)
+  }
 }
 
 async function parseMessageGraphSessionLines(args: {

--- a/src/main/ai-vault/session-scanner-graph-session-title.test.ts
+++ b/src/main/ai-vault/session-scanner-graph-session-title.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest'
+import {
+  parseMessageGraphSessionContent,
+  type MessageGraphAgent
+} from './session-scanner-graph-parsers'
+import type { FileWithMtime } from './session-scanner-types'
+
+function graphFile(sessionFile: string): FileWithMtime {
+  return {
+    path: `/tmp/${sessionFile}`,
+    mtimeMs: 1,
+    modifiedAt: '2026-05-01T10:00:00.000Z'
+  }
+}
+
+function jsonl(records: unknown[]): string {
+  return `${records.map((record) => JSON.stringify(record)).join('\n')}\n`
+}
+
+async function parseGraph(
+  agent: MessageGraphAgent,
+  records: unknown[],
+  sessionFile = `${agent}-session.jsonl`
+) {
+  return parseMessageGraphSessionContent(agent, graphFile(sessionFile), jsonl(records), 'darwin')
+}
+
+const firstPrompt = {
+  type: 'message',
+  timestamp: '2026-05-01T10:00:05.000Z',
+  message: { role: 'user', content: 'first user prompt' }
+}
+
+describe('message-graph harness session titles', () => {
+  it('uses the latest Pi session_info.name ahead of the first user prompt', async () => {
+    const session = await parseGraph('pi', [
+      {
+        type: 'session',
+        id: 'pi-session',
+        cwd: '/tmp/pi',
+        timestamp: '2026-05-01T10:00:00.000Z'
+      },
+      firstPrompt,
+      { type: 'session_info', name: 'old name', timestamp: '2026-05-01T10:00:10.000Z' },
+      { type: 'session_info', name: '111', timestamp: '2026-05-01T10:00:20.000Z' }
+    ])
+    expect(session?.title).toBe('111')
+  })
+
+  it('keeps the first Pi user prompt when no session_info name exists', async () => {
+    const session = await parseGraph('pi', [
+      {
+        type: 'session',
+        id: 'pi-session',
+        cwd: '/tmp/pi',
+        timestamp: '2026-05-01T10:00:00.000Z'
+      },
+      firstPrompt
+    ])
+    expect(session?.title).toBe('first user prompt')
+  })
+
+  it('uses the OMP session header title ahead of the first user prompt', async () => {
+    const session = await parseGraph('omp', [
+      {
+        type: 'session',
+        version: 3,
+        id: 'omp-session',
+        cwd: '/tmp/omp',
+        title: 'OMP session title',
+        timestamp: '2026-05-01T10:00:00.000Z'
+      },
+      firstPrompt
+    ])
+    expect(session?.title).toBe('OMP session title')
+  })
+
+  it('lets a later OMP user title replace an automatic title', async () => {
+    const session = await parseGraph('omp', [
+      {
+        type: 'title',
+        v: 1,
+        title: 'auto generated',
+        source: 'auto',
+        updatedAt: '2026-05-01T10:00:00.000Z',
+        pad: ''
+      },
+      {
+        type: 'session',
+        version: 3,
+        id: 'omp-session',
+        cwd: '/tmp/omp',
+        title: 'auto generated',
+        titleSource: 'auto',
+        timestamp: '2026-05-01T10:00:00.000Z'
+      },
+      firstPrompt,
+      {
+        type: 'title_change',
+        title: 'useful title',
+        source: 'user',
+        timestamp: '2026-05-01T10:00:30.000Z'
+      }
+    ])
+    expect(session?.title).toBe('useful title')
+  })
+
+  it('does not let an automatic OMP title overwrite a user title', async () => {
+    const session = await parseGraph('omp', [
+      {
+        type: 'session',
+        version: 3,
+        id: 'omp-session',
+        cwd: '/tmp/omp',
+        title: 'useful title',
+        titleSource: 'user',
+        timestamp: '2026-05-01T10:00:00.000Z'
+      },
+      firstPrompt,
+      {
+        type: 'title_change',
+        title: 'auto generated',
+        source: 'auto',
+        timestamp: '2026-05-01T10:00:30.000Z'
+      }
+    ])
+    expect(session?.title).toBe('useful title')
+  })
+
+  it('uses a user title slot even after a later first prompt', async () => {
+    const session = await parseGraph('omp', [
+      {
+        type: 'title',
+        v: 1,
+        title: 'useful title',
+        source: 'user',
+        updatedAt: '2026-05-01T10:00:00.000Z',
+        pad: ''
+      },
+      {
+        type: 'session',
+        version: 3,
+        id: 'omp-session',
+        cwd: '/tmp/omp',
+        timestamp: '2026-05-01T10:00:00.000Z'
+      },
+      firstPrompt
+    ])
+    expect(session?.title).toBe('useful title')
+  })
+})

--- a/src/main/ai-vault/session-scanner-graph-session-title.test.ts
+++ b/src/main/ai-vault/session-scanner-graph-session-title.test.ts
@@ -31,6 +31,8 @@ const firstPrompt = {
   message: { role: 'user', content: 'first user prompt' }
 }
 
+const piFamilyAgents = ['pi', 'openclaw', 'prime-agent'] as const
+
 describe('message-graph harness session titles', () => {
   it('uses the latest Pi session_info.name ahead of the first user prompt', async () => {
     const session = await parseGraph('pi', [
@@ -58,6 +60,31 @@ describe('message-graph harness session titles', () => {
       firstPrompt
     ])
     expect(session?.title).toBe('first user prompt')
+  })
+
+  it.each(piFamilyAgents)(
+    'uses %s session_info.name but ignores OMP-only title records',
+    async (agent) => {
+      const session = await parseGraph(agent, [
+        { type: 'session', id: `${agent}-session`, timestamp: '2026-05-01T10:00:00.000Z' },
+        firstPrompt,
+        { type: 'session_info', name: `${agent} name` },
+        { type: 'title', title: 'wrong slot title', source: 'user' },
+        { type: 'session', id: `${agent}-session`, title: 'wrong header title' },
+        { type: 'title_change', title: 'wrong changed title', source: 'user' },
+        { type: 'session_info', title: 'wrong session info title' }
+      ])
+      expect(session?.title).toBe(`${agent} name`)
+    }
+  )
+
+  it('accepts legacy OMP session_info.name but rejects session_info.title', async () => {
+    const [unsupported, legacy] = await Promise.all([
+      parseGraph('omp', [firstPrompt, { type: 'session_info', title: 'unsupported title' }]),
+      parseGraph('omp', [firstPrompt, { type: 'session_info', name: 'legacy OMP name' }])
+    ])
+    expect(unsupported?.title).toBe('first user prompt')
+    expect(legacy?.title).toBe('legacy OMP name')
   })
 
   it('uses the OMP session header title ahead of the first user prompt', async () => {
@@ -127,7 +154,26 @@ describe('message-graph harness session titles', () => {
     expect(session?.title).toBe('useful title')
   })
 
-  it('uses a user title slot even after a later first prompt', async () => {
+  it('lets a later automatic OMP title update a source-less legacy header', async () => {
+    const session = await parseGraph('omp', [
+      {
+        type: 'session',
+        id: 'omp-session',
+        title: 'legacy automatic title',
+        timestamp: '2026-05-01T10:00:00.000Z'
+      },
+      firstPrompt,
+      {
+        type: 'title_change',
+        title: 'new automatic title',
+        source: 'auto',
+        timestamp: '2026-05-01T10:00:30.000Z'
+      }
+    ])
+    expect(session?.title).toBe('new automatic title')
+  })
+
+  it('keeps a user title slot ahead of a stale source-less header', async () => {
     const session = await parseGraph('omp', [
       {
         type: 'title',
@@ -142,6 +188,7 @@ describe('message-graph harness session titles', () => {
         version: 3,
         id: 'omp-session',
         cwd: '/tmp/omp',
+        title: 'stale automatic title',
         timestamp: '2026-05-01T10:00:00.000Z'
       },
       firstPrompt

--- a/src/main/ai-vault/session-scanner-graph-session-title.ts
+++ b/src/main/ai-vault/session-scanner-graph-session-title.ts
@@ -1,0 +1,56 @@
+import { cloneSessionAccumulator } from './session-scanner-accumulator'
+import type { SessionAccumulator } from './session-scanner-types'
+import { extractString, normalizeTitleText } from './session-scanner-values'
+
+export type GraphSessionTitleSource = 'user' | 'auto'
+
+export type GraphSessionTitleState = {
+  accumulator: SessionAccumulator
+  source: GraphSessionTitleSource | null
+}
+
+export function cloneGraphSessionTitleState(state: GraphSessionTitleState): GraphSessionTitleState {
+  return {
+    accumulator: cloneSessionAccumulator(state.accumulator),
+    source: state.source
+  }
+}
+
+// Why: Pi `/name` and OMP `/rename` persist as harness metadata, not as the
+// first user prompt. A later user title must replace auto/prompt titles, and
+// an automatic title must never clobber a user title.
+export function applyGraphSessionTitle(
+  state: GraphSessionTitleState,
+  record: Record<string, unknown>
+): void {
+  const incoming = graphSessionTitleFromRecord(record)
+  if (!incoming) {
+    return
+  }
+  if (state.source === 'user' && incoming.source !== 'user') {
+    return
+  }
+  state.accumulator.title = incoming.title
+  state.source = incoming.source
+}
+
+function graphSessionTitleFromRecord(
+  record: Record<string, unknown>
+): { title: string; source: GraphSessionTitleSource } | null {
+  const type = extractString(record.type)
+  if (type === 'session_info') {
+    const title = normalizeTitleText(
+      extractString(record.name) ?? extractString(record.title) ?? ''
+    )
+    return title ? { title, source: 'user' } : null
+  }
+  if (type !== 'title' && type !== 'title_change' && type !== 'session') {
+    return null
+  }
+  const title = normalizeTitleText(extractString(record.title) ?? '')
+  if (!title) {
+    return null
+  }
+  const raw = extractString(record.source) ?? extractString(record.titleSource)
+  return { title, source: raw === 'user' ? 'user' : 'auto' }
+}

--- a/src/main/ai-vault/session-scanner-graph-session-title.ts
+++ b/src/main/ai-vault/session-scanner-graph-session-title.ts
@@ -2,28 +2,29 @@ import { cloneSessionAccumulator } from './session-scanner-accumulator'
 import type { SessionAccumulator } from './session-scanner-types'
 import { extractString, normalizeTitleText } from './session-scanner-values'
 
+export type GraphSessionAgent = 'openclaw' | 'pi' | 'omp' | 'prime-agent'
 export type GraphSessionTitleSource = 'user' | 'auto'
 
 export type GraphSessionTitleState = {
+  agent: GraphSessionAgent
   accumulator: SessionAccumulator
   source: GraphSessionTitleSource | null
 }
 
 export function cloneGraphSessionTitleState(state: GraphSessionTitleState): GraphSessionTitleState {
   return {
+    agent: state.agent,
     accumulator: cloneSessionAccumulator(state.accumulator),
     source: state.source
   }
 }
 
-// Why: Pi `/name` and OMP `/rename` persist as harness metadata, not as the
-// first user prompt. A later user title must replace auto/prompt titles, and
-// an automatic title must never clobber a user title.
+// Harness names are persisted metadata; explicit names outrank automatic and prompt fallbacks.
 export function applyGraphSessionTitle(
   state: GraphSessionTitleState,
   record: Record<string, unknown>
 ): void {
-  const incoming = graphSessionTitleFromRecord(record)
+  const incoming = graphSessionTitleFromRecord(state.agent, record)
   if (!incoming) {
     return
   }
@@ -35,16 +36,15 @@ export function applyGraphSessionTitle(
 }
 
 function graphSessionTitleFromRecord(
+  agent: GraphSessionAgent,
   record: Record<string, unknown>
 ): { title: string; source: GraphSessionTitleSource } | null {
   const type = extractString(record.type)
   if (type === 'session_info') {
-    const title = normalizeTitleText(
-      extractString(record.name) ?? extractString(record.title) ?? ''
-    )
+    const title = normalizeTitleText(extractString(record.name) ?? '')
     return title ? { title, source: 'user' } : null
   }
-  if (type !== 'title' && type !== 'title_change' && type !== 'session') {
+  if (agent !== 'omp' || (type !== 'title' && type !== 'title_change' && type !== 'session')) {
     return null
   }
   const title = normalizeTitleText(extractString(record.title) ?? '')
@@ -52,5 +52,8 @@ function graphSessionTitleFromRecord(
     return null
   }
   const raw = extractString(record.source) ?? extractString(record.titleSource)
+  if (raw !== null && raw !== 'user' && raw !== 'auto') {
+    return null
+  }
   return { title, source: raw === 'user' ? 'user' : 'auto' }
 }

--- a/src/main/ai-vault/session-scanner-incremental-fixtures.ts
+++ b/src/main/ai-vault/session-scanner-incremental-fixtures.ts
@@ -192,8 +192,8 @@ export function piFixture(): IncrementalAgentFixture {
 
 // OMP is a Pi fork sharing the message-graph format, but keys the model on
 // `model` (not Pi's `modelId`); its own fixture exercises the registry's 'omp'
-// branch and that model-key difference. (The session `title` is included for
-// realism only — the parser derives the title from the first user message.)
+// branch and that model-key difference. The header title outranks the first
+// user prompt, matching a real `/rename`.
 export function ompFixture(): IncrementalAgentFixture {
   return {
     agent: 'omp',

--- a/src/main/ai-vault/session-scanner-incremental-fixtures.ts
+++ b/src/main/ai-vault/session-scanner-incremental-fixtures.ts
@@ -170,6 +170,13 @@ export function piFixture(): IncrementalAgentFixture {
     ],
     appendLines: [
       JSON.stringify({
+        type: 'session_info',
+        id: 'pi-name-1',
+        parentId: null,
+        name: 'Pi renamed session',
+        timestamp: '2026-05-01T10:00:20.000Z'
+      }),
+      JSON.stringify({
         type: 'model_change',
         modelId: 'pi-2',
         timestamp: '2026-05-01T10:00:30.000Z'
@@ -192,8 +199,8 @@ export function piFixture(): IncrementalAgentFixture {
 
 // OMP is a Pi fork sharing the message-graph format, but keys the model on
 // `model` (not Pi's `modelId`); its own fixture exercises the registry's 'omp'
-// branch and that model-key difference. The header title outranks the first
-// user prompt, matching a real `/rename`.
+// branch and that model-key difference. The appended title change mirrors a
+// persisted `/rename` after the initial scan.
 export function ompFixture(): IncrementalAgentFixture {
   return {
     agent: 'omp',
@@ -204,7 +211,8 @@ export function ompFixture(): IncrementalAgentFixture {
         version: 3,
         id: 'cccccccc-dddd-4eee-8fff-000000000000',
         cwd: '/repo/app',
-        title: 'OMP session title',
+        title: 'OMP automatic title',
+        titleSource: 'auto',
         timestamp: '2026-05-01T10:00:00.000Z'
       }),
       JSON.stringify({
@@ -219,6 +227,15 @@ export function ompFixture(): IncrementalAgentFixture {
       })
     ],
     appendLines: [
+      JSON.stringify({
+        type: 'title_change',
+        id: 'omp-title-1',
+        parentId: null,
+        title: 'OMP renamed session',
+        previousTitle: 'OMP automatic title',
+        source: 'user',
+        timestamp: '2026-05-01T10:00:30.000Z'
+      }),
       JSON.stringify({
         type: 'message',
         message: {

--- a/src/main/ai-vault/session-scanner-parse-cache-agents.test.ts
+++ b/src/main/ai-vault/session-scanner-parse-cache-agents.test.ts
@@ -8,7 +8,11 @@ import {
   codexFixture,
   codexWorkerFixtureLines
 } from './session-scanner-codex-fixtures'
-import { allIncrementalAgentFixtures } from './session-scanner-incremental-fixtures'
+import {
+  allIncrementalAgentFixtures,
+  ompFixture,
+  piFixture
+} from './session-scanner-incremental-fixtures'
 import {
   createSessionParseStats,
   parseAgentSessionFileCached,
@@ -17,6 +21,11 @@ import {
 import type { SessionFileCandidate } from './session-scanner-types'
 
 let tempRoots: string[] = []
+
+const titleMetadataFixtures = [
+  { name: 'pi', fixture: piFixture(), expectedTitle: 'Pi renamed session' },
+  { name: 'omp', fixture: ompFixture(), expectedTitle: 'OMP renamed session' }
+]
 
 beforeEach(() => {
   resetSessionParseCacheForTests()
@@ -133,6 +142,78 @@ describe.each(allIncrementalAgentFixtures())('incremental parse parity: $agent',
     expect(completed).toEqual(
       await parseAgentSessionFile(await candidateFor(fixture.agent, path), process.platform)
     )
+  })
+})
+
+describe.each(titleMetadataFixtures)('incremental title metadata: $name', (entry) => {
+  it('adopts a harness rename appended after the cached scan', async () => {
+    const root = await makeTempDir()
+    const path = join(root, entry.fixture.fileName)
+    await mkdir(dirname(path), { recursive: true })
+    await writeFile(path, `${entry.fixture.seedLines.join('\n')}\n`)
+    await parseAgentSessionFileCached(
+      await candidateFor(entry.fixture.agent, path),
+      process.platform
+    )
+
+    await appendFile(path, `${entry.fixture.appendLines.join('\n')}\n`)
+    const grownCandidate = await candidateFor(entry.fixture.agent, path)
+    const stats = createSessionParseStats()
+    const incremental = await parseAgentSessionFileCached(grownCandidate, process.platform, stats)
+    expect(stats.incremental).toBe(1)
+    expect(incremental?.title).toBe(entry.expectedTitle)
+    expect(incremental).toEqual(await parseAgentSessionFile(grownCandidate, process.platform))
+  })
+})
+
+describe('incremental OMP title precedence', () => {
+  it('keeps a user title ahead of an appended automatic title', async () => {
+    const root = await makeTempDir()
+    const path = join(root, ompFixture().fileName)
+    await writeFile(
+      path,
+      `${[
+        JSON.stringify({
+          type: 'title',
+          v: 1,
+          title: 'Persisted user title',
+          source: 'user',
+          updatedAt: '2026-05-01T10:00:00.000Z',
+          pad: ''
+        }),
+        JSON.stringify({
+          type: 'session',
+          id: 'omp-session',
+          cwd: '/repo/app',
+          title: 'Stale source-less title',
+          timestamp: '2026-05-01T10:00:00.000Z'
+        }),
+        JSON.stringify({
+          type: 'message',
+          message: { role: 'user', content: 'first prompt' },
+          timestamp: '2026-05-01T10:00:05.000Z'
+        })
+      ].join('\n')}\n`
+    )
+    await parseAgentSessionFileCached(await candidateFor('omp', path), process.platform)
+
+    await appendFile(
+      path,
+      `${JSON.stringify({
+        type: 'title_change',
+        title: 'Later automatic title',
+        source: 'auto',
+        timestamp: '2026-05-01T10:00:30.000Z'
+      })}\n`
+    )
+    const stats = createSessionParseStats()
+    const incremental = await parseAgentSessionFileCached(
+      await candidateFor('omp', path),
+      process.platform,
+      stats
+    )
+    expect(stats.incremental).toBe(1)
+    expect(incremental?.title).toBe('Persisted user title')
   })
 })
 

--- a/src/main/ai-vault/session-scanner.test.ts
+++ b/src/main/ai-vault/session-scanner.test.ts
@@ -747,6 +747,7 @@ describe('scanAiVaultSessions', () => {
     const ompSession = result.sessions.find((session) => session.agent === 'omp')
     expect(ompSession?.model).toBe('gpt-5.4-mini')
     expect(ompSession?.totalTokens).toBe(160)
+    expect(ompSession?.title).toBe('OMP session title')
 
     // Prime Agent keeps Pi's `model_change.modelId` key, so the pre-reply model
     // must come through even though no assistant message was written yet.


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​281 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​280 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​109 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​97 |

<!-- /orca-pr-loc -->

## ELI5

If you rename a Pi or OMP session inside the agent (`/name` or `/rename`), Agent Session History kept showing the first prompt instead. History now uses the name you set, including after the tab is closed.

## What Changed

- The shared Pi/OMP/OpenClaw/Prime Agent transcript parser now reads harness title metadata:
  - Pi: latest `session_info.name` from `/name`
  - OMP: title slot, session header `title`/`titleSource`, and later `title_change` records from `/rename`
- User-set titles outrank automatic titles, which outrank the first user prompt. Automatic titles cannot overwrite a user title.
- First-prompt fallback is unchanged when the harness never set a name.

## Why

STA-2467 is "session list names don't match custom names the user set." #15659 already aligns the **live** sidebar with the tab bar for Claude/Codex `aiVaultTitle` (and Orca `customTitle` already won). This PR covers the remaining **Agent Session History** gap for Pi and OMP: the scanner dropped `session_info` / title-slot records and always took the first user message.

Claude `custom-title`, Codex `thread_name` (including idle index-only `/rename` via `refreshCachedCodexTitle`), and OpenCode `session.title` already win in History on `main`.

## Linked Issue

Fixes https://github.com/stablyai/orca/issues/10250
Linear: https://linear.app/stably/issue/STA-2467

## Visual Proof

N/A — no layout, styling, or interaction-path change. History rows already render `session.title`; this only changes which string the scanner writes for Pi/OMP transcripts. Covered by unit tests (Pi `/name`, OMP header/slot/`title_change`, user vs auto, first-prompt fallback).

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Pre-fix (tests against unfixed code): 5 failed. History titles were `"first user prompt"` instead of `"111"` / `"OMP session title"` / `"useful title"`.

Post-fix: `pnpm vitest run --config config/vitest.config.ts src/main/ai-vault/session-scanner-graph-session-title.test.ts src/main/ai-vault/session-scanner.test.ts src/main/ai-vault/session-scanner-parse-cache-agents.test.ts src/main/ai-vault/remote-session-scanner.test.ts` — all passed.

Neutered (no-op'd `applyGraphSessionTitle`, kept tests): same 5 failed again.

`pnpm typecheck` and oxlint on the changed files passed.

Platform: scanner-only, host-agnostic (macOS / Linux / Windows / WSL / SSH). Remote scans use the same `parseMessageGraphSessionContent` fold.

## AI Disclosure

Internal contributor — ignore.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Author X: @BrennanKB5

Does **not** edit #15659 (`brennanb2025/sta-4865-stale-session-name`). That PR covers live sidebar vs tab-bar Claude/Codex names.

Sibling work, not in this PR:

- **#15659 (STA-4865)** — live session list reads `aiVaultTitle` so Claude/Codex `/rename` matches the tab bar.
- **#10393** — overlay Orca tab `customTitle` onto History while a live/retained/sleeping tab still exists. Needed for Orca-side renames after this parser fix; unavailable once the tab is gone.
- **Codex idle `/rename` cache** — already fixed on `main` (`refreshCachedCodexTitle` on parse-cache hits; covered by `picks up a session_index title that appears after the transcript was cached`).

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)