### PR TITLE
fix(sleep): resume quiet Claude sessions instead of restoring bare shells

### DIFF
--- a/src/renderer/src/components/sidebar/sleep-worktree-activation-race.test.ts
+++ b/src/renderer/src/components/sidebar/sleep-worktree-activation-race.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => {
   const state = {
     activeWorktreeId: null as string | null,
+    preflightManualWorktreeSleep: vi.fn(),
     setActiveWorktree: vi.fn((worktreeId: string | null) => {
       state.activeWorktreeId = worktreeId
     }),
@@ -57,6 +58,7 @@ describe('sleep flow vs slept-workspace activation', () => {
       }
     })
     mocks.state.activeWorktreeId = 'wt-parent'
+    mocks.state.preflightManualWorktreeSleep.mockReset()
     mocks.state.setActiveWorktree.mockClear()
     mocks.state.shutdownWorktreeBrowsers.mockClear().mockResolvedValue(undefined)
     mocks.state.shutdownWorktreeTerminals.mockClear().mockImplementation(async (worktreeId) => {

--- a/src/renderer/src/components/sidebar/sleep-worktree-flow.test.ts
+++ b/src/renderer/src/components/sidebar/sleep-worktree-flow.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => {
   const state = {
     activeWorktreeId: null as string | null,
+    preflightManualWorktreeSleep: vi.fn(),
     setActiveWorktree: vi.fn(),
     shutdownWorktreeBrowsers: vi.fn().mockResolvedValue(undefined),
     shutdownWorktreeTerminals: vi.fn().mockResolvedValue(undefined),
@@ -49,6 +50,7 @@ describe('runSleepWorktree', () => {
       },
       requestAnimationFrame: vi.fn()
     })
+    mocks.state.preflightManualWorktreeSleep.mockReset()
     mocks.state.setActiveWorktree.mockClear()
     mocks.state.shutdownWorktreeBrowsers.mockClear().mockResolvedValue(undefined)
     mocks.state.shutdownWorktreeTerminals.mockClear().mockResolvedValue(undefined)
@@ -102,11 +104,15 @@ describe('runSleepWorktree', () => {
 
     expect(mocks.markWorktreeSleepIntent).toHaveBeenCalledWith('wt-1')
     expect(mocks.clearWorktreeSleepIntent).toHaveBeenCalledWith('wt-1')
+    const preflightCall = mocks.state.preflightManualWorktreeSleep.mock.invocationCallOrder[0]
     const markCall = mocks.markWorktreeSleepIntent.mock.invocationCallOrder[0]
     const activeClear = mocks.state.setActiveWorktree.mock.invocationCallOrder[0]
+    const browserShutdown = mocks.state.shutdownWorktreeBrowsers.mock.invocationCallOrder[0]
     const terminalShutdown = mocks.state.shutdownWorktreeTerminals.mock.invocationCallOrder[0]
     const clearCall = mocks.clearWorktreeSleepIntent.mock.invocationCallOrder[0]
+    expect(preflightCall).toBeLessThan(markCall)
     expect(markCall).toBeLessThan(activeClear)
+    expect(activeClear).toBeLessThan(browserShutdown)
     expect(terminalShutdown).toBeLessThan(clearCall)
   })
 
@@ -212,15 +218,19 @@ describe('runSleepWorktree', () => {
     )
   })
 
-  it('restores the active workspace when resume metadata cannot be captured', async () => {
+  it('keeps the active workspace untouched when resume metadata cannot be captured', async () => {
     mocks.state.activeWorktreeId = 'wt-1'
-    mocks.state.shutdownWorktreeTerminals.mockRejectedValueOnce(
-      new Error('agent_sleep_capture_missing')
-    )
+    mocks.state.preflightManualWorktreeSleep.mockImplementationOnce(() => {
+      throw new Error('agent_sleep_capture_missing')
+    })
 
     await runSleepWorktree('wt-1')
 
-    expect(mocks.state.setActiveWorktree.mock.calls).toEqual([[null], ['wt-1']])
+    expect(mocks.markWorktreeSleepIntent).not.toHaveBeenCalled()
+    expect(mocks.clearWorktreeSleepIntent).not.toHaveBeenCalled()
+    expect(mocks.state.setActiveWorktree).not.toHaveBeenCalled()
+    expect(mocks.state.shutdownWorktreeBrowsers).not.toHaveBeenCalled()
+    expect(mocks.state.shutdownWorktreeTerminals).not.toHaveBeenCalled()
     expect(mocks.suspendWorkspace).not.toHaveBeenCalled()
     expect(mocks.toastError).toHaveBeenCalledWith(
       'Failed to sleep workspace',
@@ -272,6 +282,37 @@ describe('runSleepWorktree', () => {
       expect.objectContaining({
         description:
           'The workspace was kept open. Try again; if the problem continues, check the host connection.'
+      })
+    )
+  })
+
+  it('leaves a failed active worktree untouched while sleeping a later safe worktree', async () => {
+    mocks.state.activeWorktreeId = 'wt-1'
+    mocks.state.preflightManualWorktreeSleep.mockImplementation((worktreeId: string) => {
+      if (worktreeId === 'wt-1') {
+        throw new Error('agent_sleep_capture_missing')
+      }
+    })
+
+    await runSleepWorktrees(['wt-1', 'wt-2'])
+
+    expect(mocks.state.setActiveWorktree).not.toHaveBeenCalled()
+    expect(mocks.markWorktreeSleepIntent).not.toHaveBeenCalled()
+    expect(mocks.clearWorktreeSleepIntent).not.toHaveBeenCalled()
+    expect(mocks.state.shutdownWorktreeBrowsers).not.toHaveBeenCalledWith('wt-1')
+    expect(mocks.state.shutdownWorktreeTerminals).not.toHaveBeenCalledWith('wt-1', {
+      keepIdentifiers: true
+    })
+    expect(mocks.state.shutdownWorktreeBrowsers).toHaveBeenCalledWith('wt-2')
+    expect(mocks.state.shutdownWorktreeTerminals).toHaveBeenCalledWith('wt-2', {
+      keepIdentifiers: true
+    })
+    expect(mocks.suspendWorkspace).toHaveBeenCalledTimes(1)
+    expect(mocks.suspendWorkspace).toHaveBeenCalledWith({ workspaceId: 'wt-2' })
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      'Failed to sleep some workspaces',
+      expect.objectContaining({
+        description: 'A session could not be saved for resume, so the workspace was kept open.'
       })
     )
   })

--- a/src/renderer/src/components/sidebar/sleep-worktree-flow.test.ts
+++ b/src/renderer/src/components/sidebar/sleep-worktree-flow.test.ts
@@ -212,6 +212,24 @@ describe('runSleepWorktree', () => {
     )
   })
 
+  it('restores the active workspace when resume metadata cannot be captured', async () => {
+    mocks.state.activeWorktreeId = 'wt-1'
+    mocks.state.shutdownWorktreeTerminals.mockRejectedValueOnce(
+      new Error('agent_sleep_capture_missing')
+    )
+
+    await runSleepWorktree('wt-1')
+
+    expect(mocks.state.setActiveWorktree.mock.calls).toEqual([[null], ['wt-1']])
+    expect(mocks.suspendWorkspace).not.toHaveBeenCalled()
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      'Failed to sleep workspace',
+      expect.objectContaining({
+        description: 'A session could not be saved for resume, so the workspace was kept open.'
+      })
+    )
+  })
+
   it('restores the active workspace when terminal convergence fails', async () => {
     mocks.state.activeWorktreeId = 'wt-1'
     mocks.state.shutdownWorktreeTerminals.mockRejectedValueOnce(

--- a/src/renderer/src/components/sidebar/sleep-worktree-flow.ts
+++ b/src/renderer/src/components/sidebar/sleep-worktree-flow.ts
@@ -108,6 +108,12 @@ function preserveSidebarWorktreePosition(worktreeId: string): () => void {
 
 function describeSleepFailure(error: unknown): string {
   const detail = error instanceof Error ? error.message : String(error)
+  if (detail.includes('agent_sleep_capture_missing')) {
+    return translate(
+      'auto.components.sidebar.sleep.worktree.flow.capture.missing',
+      'A session could not be saved for resume, so the workspace was kept open.'
+    )
+  }
   if (detail.includes('legacy')) {
     return translate(
       'auto.components.sidebar.sleep.worktree.flow.legacy.unverified',

--- a/src/renderer/src/components/sidebar/sleep-worktree-flow.ts
+++ b/src/renderer/src/components/sidebar/sleep-worktree-flow.ts
@@ -143,12 +143,31 @@ export async function runSleepWorktrees(worktreeIds: readonly string[]): Promise
   }
   const {
     activeWorktreeId,
+    preflightManualWorktreeSleep,
     setActiveWorktree,
     shutdownWorktreeBrowsers,
     shutdownWorktreeTerminals
   } = useAppStore.getState()
+  const errors: string[] = []
+  const failedWorktreeIds = new Set<string>()
+  for (const worktreeId of worktreeIds) {
+    try {
+      preflightManualWorktreeSleep(worktreeId)
+    } catch (err) {
+      console.error('[sleep-worktree] session capture preflight failed', {
+        worktreeId,
+        error: err
+      })
+      failedWorktreeIds.add(worktreeId)
+      errors.push(describeSleepFailure(err))
+    }
+  }
   let activeSleepIntentWorktreeId: string | null = null
-  if (activeWorktreeId && worktreeIds.includes(activeWorktreeId)) {
+  if (
+    activeWorktreeId &&
+    worktreeIds.includes(activeWorktreeId) &&
+    !failedWorktreeIds.has(activeWorktreeId)
+  ) {
     const restoreSidebarPosition = preserveSidebarWorktreePosition(activeWorktreeId)
     // Why: clearing the active workspace can unmount TerminalPanes before
     // shutdownWorktreeTerminals writes PTY suppressions. Use a non-rendering
@@ -159,10 +178,11 @@ export async function runSleepWorktrees(worktreeIds: readonly string[]): Promise
     setActiveWorktree(null)
     restoreSidebarPosition()
   }
-  const errors: string[] = []
-  const failedWorktreeIds = new Set<string>()
   try {
     for (const worktreeId of worktreeIds) {
+      if (failedWorktreeIds.has(worktreeId)) {
+        continue
+      }
       try {
         // Why: sleep mirrors removeWorktree's shutdown sequence — browsers first
         // so destroyPersistentWebview unregisters the Chromium guests before any

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5517,7 +5517,10 @@
               "host": {
                 "unverified": "The host could not confirm terminal shutdown. The workspace was kept open; check the connection and try again."
               },
-              "retry": "The workspace was kept open. Try again; if the problem continues, check the host connection."
+              "retry": "The workspace was kept open. Try again; if the problem continues, check the host connection.",
+              "capture": {
+                "missing": "A session could not be saved for resume, so the workspace was kept open."
+              }
             }
           }
         },

--- a/src/renderer/src/lib/resume-sleeping-agent-session-stale-recovery.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session-stale-recovery.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-resume'
+import { AGENT_STATUS_STALE_AFTER_MS } from '../../../shared/agent-status-types'
+import { makePaneKey } from '../../../shared/stable-pane-id'
+import { useAppStore } from '@/store'
+import { resumeSleepingAgentSessionsForWorktree } from './resume-sleeping-agent-session'
+
+const initialAppStoreState = useAppStore.getState()
+const LEAF_ID = '55555555-5555-4555-8555-555555555555'
+const STALE_UPDATED_AT = 1
+const STALE_CAPTURED_AT = STALE_UPDATED_AT + AGENT_STATUS_STALE_AFTER_MS + 1
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  useAppStore.setState(initialAppStoreState, true)
+})
+
+function makeRecord(
+  overrides: Partial<SleepingAgentSessionRecord> = {}
+): SleepingAgentSessionRecord {
+  return {
+    paneKey: 'tab-1:leaf-1',
+    tabId: 'tab-1',
+    worktreeId: 'wt-1',
+    agent: 'claude',
+    providerSession: { key: 'session_id', id: 'sess-stale' },
+    prompt: 'finish the task',
+    state: 'working',
+    capturedAt: STALE_CAPTURED_AT,
+    updatedAt: STALE_UPDATED_AT,
+    origin: 'worktree-sleep',
+    ...overrides
+  }
+}
+
+function makeTerminalTab(id: string, worktreeId: string): Record<string, unknown> {
+  return {
+    id,
+    ptyId: null,
+    worktreeId,
+    title: 'shell',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1
+  }
+}
+
+function makeLayout(leafId: string, ptyId = 'pty-1'): Record<string, unknown> {
+  return {
+    root: { type: 'leaf', leafId },
+    activeLeafId: leafId,
+    expandedLeafId: null,
+    ptyIdsByLeafId: { [leafId]: ptyId }
+  }
+}
+
+describe('resumeSleepingAgentSessionsForWorktree stale recovery', () => {
+  // Why: a quiet-past-freshness Claude session is unverifiable, not dead. Wake must still
+  // launch `claude --resume` when the provider session id is recoverable (STA-2844).
+  it('launches claude --resume for a working record that was already stale at capture', () => {
+    const record = makeRecord({ origin: 'live' })
+    useAppStore.setState({
+      tabsByWorktree: { 'wt-1': [] },
+      sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
+    } as never)
+
+    const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
+
+    const state = useAppStore.getState()
+    const resumedTab = state.tabsByWorktree['wt-1']?.[0]
+    expect(launched).toBe(1)
+    expect(resumedTab?.launchAgent).toBe('claude')
+    expect(state.pendingStartupByTabId[resumedTab!.id]?.command).toContain('--resume')
+    expect(state.pendingStartupByTabId[resumedTab!.id]?.command).toContain('sess-stale')
+    expect(state.sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()
+  })
+
+  // Why: manual sleep preserves the pane husk; activation must leave the stale record for
+  // in-place cold restore instead of clearing it as expired (STA-2844).
+  it('keeps a stale worktree-sleep record on a preserved pane for in-place resume', () => {
+    const paneKey = makePaneKey('tab-1', LEAF_ID)
+    const record = makeRecord({ paneKey, origin: 'worktree-sleep' })
+    useAppStore.setState({
+      activeWorktreeId: 'wt-1',
+      activeTabType: 'terminal',
+      activeTabId: 'tab-1',
+      activeTabIdByWorktree: { 'wt-1': 'tab-1' },
+      tabsByWorktree: { 'wt-1': [makeTerminalTab('tab-1', 'wt-1')] },
+      terminalLayoutsByTabId: { 'tab-1': makeLayout(LEAF_ID) },
+      sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
+    } as never)
+
+    const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
+
+    const state = useAppStore.getState()
+    expect(launched).toBe(0)
+    expect(state.tabsByWorktree['wt-1']).toHaveLength(1)
+    expect(state.sleepingAgentSessionsByPaneKey[record.paneKey]).toBe(record)
+  })
+
+  it('does not fabricate a resume for an unresumable Pi checkpoint without a transcript', () => {
+    const record = makeRecord({
+      agent: 'pi',
+      providerSession: { key: 'session_id', id: 'pi-session-1' }
+    })
+    useAppStore.setState({
+      tabsByWorktree: { 'wt-1': [] },
+      sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
+    } as never)
+
+    const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
+
+    expect(launched).toBe(0)
+    expect(useAppStore.getState().tabsByWorktree['wt-1']).toEqual([])
+    expect(useAppStore.getState().sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()
+  })
+})

--- a/src/renderer/src/lib/resume-sleeping-agent-session.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session.test.ts
@@ -768,7 +768,7 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
     expect(state.sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()
   })
 
-  it('clears stale manual records without launching a tab', () => {
+  it('resumes working records that were already stale at capture', () => {
     const record = makeRecord({ capturedAt: 3_000_000, updatedAt: 1 })
     useAppStore.setState({
       tabsByWorktree: { 'wt-1': [] },
@@ -777,9 +777,12 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
 
     const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
 
-    expect(launched).toBe(0)
-    expect(useAppStore.getState().tabsByWorktree['wt-1']).toEqual([])
-    expect(useAppStore.getState().sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()
+    const state = useAppStore.getState()
+    const resumedTab = state.tabsByWorktree['wt-1']?.[0]
+    expect(launched).toBe(1)
+    expect(resumedTab?.launchAgent).toBe('claude')
+    expect(state.pendingStartupByTabId[resumedTab!.id]?.command).toContain('--resume')
+    expect(state.sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()
   })
 
   it('resumes interrupted manual records that no preserved pane can own', () => {

--- a/src/renderer/src/lib/resume-sleeping-agent-session.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session.ts
@@ -1,9 +1,9 @@
 import { useAppStore } from '@/store'
 import {
   agentProviderSessionsEqual,
+  getAgentResumeArgv,
   type SleepingAgentSessionRecord
 } from '../../../shared/agent-session-resume'
-import { AGENT_STATUS_STALE_AFTER_MS } from '../../../shared/agent-status-types'
 import {
   getProviderSessionClaimKey,
   isPassiveCompletedHibernationEvidence,
@@ -130,14 +130,16 @@ function activeOrQueuedResumeClaimsProviderSession(
   return false
 }
 
-// Why: an interrupted turn is still resumable — `claude --resume` reopens the transcript at the
-// prompt — so discarding those records only stranded the session across wake and restart.
+// Why: capturedAt - updatedAt is hook quiet time, not process death. A recoverable provider
+// session id is enough to resume; freshness is a display TTL (STA-2844).
 function isInvalidWorktreeActivationRecord(record: SleepingAgentSessionRecord): boolean {
   if (!record.origin && record.state === 'done') {
     return true
   }
-  return (
-    record.state !== 'done' && record.capturedAt - record.updatedAt > AGENT_STATUS_STALE_AFTER_MS
+  return !getAgentResumeArgv(
+    record.agent,
+    record.providerSession,
+    record.launchConfig?.ompResumeFilePath
   )
 }
 

--- a/src/renderer/src/store/slices/agent-status-manual-sleep-capture.test.ts
+++ b/src/renderer/src/store/slices/agent-status-manual-sleep-capture.test.ts
@@ -106,8 +106,14 @@ describe('manual sleep agent session capture', () => {
       state: 'done'
     })
     expect(records['tab-1:interrupted'].interrupted).toBeUndefined()
-    expect(records['tab-1:post-input']).toMatchObject({ state: 'working', updatedAt: NOW })
-    expect(records['tab-1:stale']).toMatchObject({ state: 'working', updatedAt: NOW })
+    expect(records['tab-1:post-input']).toMatchObject({
+      state: 'working',
+      updatedAt: NOW - 1_000
+    })
+    expect(records['tab-1:stale']).toMatchObject({
+      state: 'working',
+      updatedAt: NOW - AGENT_STATUS_STALE_AFTER_MS - 1
+    })
   })
 
   it('marks finished panes for tab-open-only restore so a mobile wake cannot respawn them all', () => {
@@ -200,8 +206,9 @@ describe('manual sleep agent session capture', () => {
   })
 
   // Why: a retained row is the pane's last status after its pty died, so it is stale by
-  // construction — capturing it verbatim rebuilt a record wake discards as stale (#11598).
-  it('refreshes a stale retained working row so wake cannot discard it', () => {
+  // construction. Capture must keep the real updatedAt; wake resumes from the provider
+  // session id rather than a stamped freshness window (STA-2844).
+  it('keeps the real last-status time on a stale retained working row', () => {
     vi.useFakeTimers()
     vi.setSystemTime(NOW)
     const store = createTestStore()
@@ -226,8 +233,12 @@ describe('manual sleep agent session capture', () => {
     store.getState().captureSleepingAgentSessionsByWorktree('wt-1')
 
     const record = store.getState().sleepingAgentSessionsByPaneKey['tab-1:retained']
-    expect(record).toMatchObject({ origin: 'worktree-sleep', state: 'working', updatedAt: NOW })
-    expect(record.capturedAt - record.updatedAt).toBeLessThanOrEqual(AGENT_STATUS_STALE_AFTER_MS)
+    expect(record).toMatchObject({
+      origin: 'worktree-sleep',
+      state: 'working',
+      updatedAt: NOW - AGENT_STATUS_STALE_AFTER_MS - 1
+    })
+    expect(record.capturedAt - record.updatedAt).toBeGreaterThan(AGENT_STATUS_STALE_AFTER_MS)
     expect(record.interrupted).toBeUndefined()
   })
 
@@ -319,7 +330,7 @@ describe('manual sleep agent session capture', () => {
 
     expect(store.getState().sleepingAgentSessionsByPaneKey['tab-1:stale']).toMatchObject({
       origin: 'worktree-sleep',
-      updatedAt: NOW,
+      updatedAt: NOW - AGENT_STATUS_STALE_AFTER_MS - 1,
       providerSession: { key: 'session_id', id: 'session-tab-1:stale' }
     })
   })
@@ -489,7 +500,7 @@ describe('manual sleep agent session capture', () => {
 
     expect(store.getState().sleepingAgentSessionsByPaneKey['tab-1:stale']).toMatchObject({
       origin: 'worktree-sleep',
-      updatedAt: NOW,
+      updatedAt: NOW - AGENT_STATUS_STALE_AFTER_MS - 1,
       providerSession: { key: 'session_id', id: 'session-tab-1:stale' }
     })
   })

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -656,18 +656,29 @@ function markManualSleepLazyRestore(record: SleepingAgentSessionRecord): void {
   }
 }
 
-// Why: `live`/legacy rows are provisional checkpoints a fresh capture supersedes; an explicit
-// sleep or quit capture is the pane's only resume handle once its live row is gone.
+// Why: `live`/legacy rows are provisional unless they already carry a recoverable provider
+// session id — wiping that id is what left sleep with nothing to resume (STA-2844).
 function isDurableSleepingCapture(record: SleepingAgentSessionRecord): boolean {
-  return record.origin === 'worktree-sleep' || record.origin === 'quit'
+  if (record.origin === 'worktree-sleep' || record.origin === 'quit') {
+    return true
+  }
+  return (
+    record.origin === 'live' &&
+    Boolean(
+      getAgentResumeArgv(
+        record.agent,
+        record.providerSession,
+        record.launchConfig?.ompResumeFilePath
+      )
+    )
+  )
 }
 
-// Why: manual sleep kills the pty either way, so the record carries resume identity, not the dead
-// turn's interrupt flag — and an explicitly slept workspace is never stale at wake, so a row the
-// user is deliberately sleeping must not trip the wake-side staleness discard. `state` is preserved
-// so a done pane wakes lazily in place instead of spawning a new tab.
-function manualSleepCaptureEntry(entry: AgentStatusEntry, capturedAt: number): AgentStatusEntry {
-  return { ...entry, updatedAt: capturedAt, interrupted: false }
+// Why: the record carries resume identity, not the dead turn's interrupt flag. `state` is
+// preserved so a done pane wakes lazily in place instead of spawning a new tab. Do not stamp
+// `updatedAt` — hook quiet time is not death, and wake must not need a fake freshness window.
+function manualSleepCaptureEntry(entry: AgentStatusEntry): AgentStatusEntry {
+  return { ...entry, interrupted: false }
 }
 
 // Why: capture recreates a record the manual-sleep wipe would otherwise remove, so a deliberately
@@ -735,10 +746,15 @@ export function collectSleepingAgentSessionRecordsForWorktree(
   if (isManualWorktreeSleep) {
     for (const existing of Object.values(state.sleepingAgentSessionsByPaneKey)) {
       const liveEntry = state.agentStatusByPaneKey[existing.paneKey]
+      const liveEntryCanRecapture =
+        liveEntry !== undefined &&
+        isResumableTuiAgent(liveEntry.agentType) &&
+        liveEntry.providerSession != null &&
+        Boolean(getAgentResumeArgv(liveEntry.agentType, liveEntry.providerSession))
       if (
         existing.worktreeId !== worktreeId ||
         existing.origin !== 'live' ||
-        (liveEntry !== undefined &&
+        (liveEntryCanRecapture &&
           !isCompletedPiCompatibleAgentWithLiveRecoveryRecord(liveEntry, existing)) ||
         (allowedPaneKeys && !allowedPaneKeys.has(existing.paneKey)) ||
         !getAgentResumeArgv(existing.agent, existing.providerSession)
@@ -746,12 +762,12 @@ export function collectSleepingAgentSessionRecordsForWorktree(
         continue
       }
       // Why: Pi identity is resumable with no turn row and while idle after done, so manual
-      // sleep must promote both instead of deleting the checkpoint.
+      // sleep must promote both instead of deleting the checkpoint. Keep the original
+      // updatedAt — quiet time is not death, and wake must not require a stamped TTL.
       records[existing.paneKey] = {
         ...existing,
         state: 'working',
         capturedAt,
-        updatedAt: capturedAt,
         origin: 'worktree-sleep'
       }
       promotedLiveRecoveryPaneKeys.add(existing.paneKey)
@@ -775,9 +791,7 @@ export function collectSleepingAgentSessionRecordsForWorktree(
     }
     const record = sleepingRecordFromEntry({
       state,
-      entry: isManualWorktreeSleep
-        ? manualSleepCaptureEntry(retained.entry, capturedAt)
-        : retained.entry,
+      entry: isManualWorktreeSleep ? manualSleepCaptureEntry(retained.entry) : retained.entry,
       worktreeId,
       tab: retained.tab,
       capturedAt,
@@ -815,7 +829,7 @@ export function collectSleepingAgentSessionRecordsForWorktree(
     }
     const record = sleepingRecordFromEntry({
       state,
-      entry: isManualWorktreeSleep ? manualSleepCaptureEntry(entry, capturedAt) : entry,
+      entry: isManualWorktreeSleep ? manualSleepCaptureEntry(entry) : entry,
       worktreeId,
       capturedAt,
       launchConfig: getLaunchConfigForEntry(state, entry),

--- a/src/renderer/src/store/slices/manual-sleep-recovery-guard.ts
+++ b/src/renderer/src/store/slices/manual-sleep-recovery-guard.ts
@@ -1,0 +1,72 @@
+import {
+  isResumableTuiAgent,
+  type SleepingAgentSessionRecord
+} from '../../../../shared/agent-session-resume'
+import type { AgentStatusState } from '../../../../shared/agent-status-types'
+import type { AppState } from '../types'
+
+export const AGENT_SLEEP_CAPTURE_MISSING = 'agent_sleep_capture_missing'
+
+function paneBelongsToWorktree(
+  paneKey: string,
+  worktreeId: string,
+  entryWorktreeId: string | undefined,
+  tabPrefixes: readonly string[]
+): boolean {
+  if (entryWorktreeId === worktreeId) {
+    return true
+  }
+  return tabPrefixes.some((prefix) => paneKey.startsWith(prefix))
+}
+
+function isLiveTurnToProtect(state: AgentStatusState, interrupted: boolean | undefined): boolean {
+  return state !== 'done' || interrupted === true
+}
+
+// Why: a still-running (or interrupted) resumable TUI is about to be killed. If capture
+// could not write a provider-session record, abort instead of destroying the only handle.
+export function listUnrecordableManualSleepAgentPanes(
+  state: AppState,
+  worktreeId: string,
+  records: Readonly<Record<string, SleepingAgentSessionRecord>>,
+  paneKeys?: readonly string[]
+): string[] {
+  const recorded = new Set(Object.keys(records))
+  const allowed = paneKeys ? new Set(paneKeys) : null
+  const tabPrefixes = (state.tabsByWorktree[worktreeId] ?? []).map((tab) => `${tab.id}:`)
+  const missing = new Set<string>()
+
+  const consider = (
+    paneKey: string,
+    entryWorktreeId: string | undefined,
+    agentType: unknown,
+    agentState: AgentStatusState,
+    interrupted: boolean | undefined
+  ): void => {
+    if (
+      recorded.has(paneKey) ||
+      missing.has(paneKey) ||
+      (allowed !== null && !allowed.has(paneKey)) ||
+      !paneBelongsToWorktree(paneKey, worktreeId, entryWorktreeId, tabPrefixes) ||
+      !isLiveTurnToProtect(agentState, interrupted) ||
+      !isResumableTuiAgent(agentType)
+    ) {
+      return
+    }
+    missing.add(paneKey)
+  }
+
+  for (const [paneKey, entry] of Object.entries(state.agentStatusByPaneKey)) {
+    consider(paneKey, entry.worktreeId, entry.agentType, entry.state, entry.interrupted)
+  }
+  for (const retained of Object.values(state.retainedAgentsByPaneKey)) {
+    consider(
+      retained.entry.paneKey,
+      retained.worktreeId,
+      retained.entry.agentType,
+      retained.entry.state,
+      retained.entry.interrupted
+    )
+  }
+  return [...missing]
+}

--- a/src/renderer/src/store/slices/manual-sleep-stale-session-recovery.test.ts
+++ b/src/renderer/src/store/slices/manual-sleep-stale-session-recovery.test.ts
@@ -170,6 +170,45 @@ describe('manual sleep stale session recovery', () => {
     expect(mockApi.pty.kill).toHaveBeenCalledWith('pty-shell', { keepHistory: true })
   })
 
+  it('rejects preflight when a renderer PTY has an unrecordable live Claude pane', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+    const store = createTestStore()
+    seedTabs(store)
+    store.setState({
+      ptyIdsByTabId: { 'tab-1': ['pty-claude'] },
+      agentStatusByPaneKey: {
+        'tab-1:leaf-1': makeAgentEntry({ providerSession: undefined })
+      }
+    } as Partial<AppState>)
+
+    expect(() => store.getState().preflightManualWorktreeSleep('wt-1')).toThrow(
+      'agent_sleep_capture_missing'
+    )
+
+    expect(mockApi.pty.kill).not.toHaveBeenCalled()
+    expect(store.getState().sleepingAgentSessionsByPaneKey).toEqual({})
+  })
+
+  it('allows preflight without renderer PTYs even when a stale row cannot be recorded', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+    const store = createTestStore()
+    seedTabs(store)
+    store.setState({
+      ptyIdsByTabId: { 'tab-1': [] },
+      agentStatusByPaneKey: {
+        'tab-1:leaf-1': makeAgentEntry({
+          updatedAt: STALE_AT,
+          providerSession: undefined
+        })
+      }
+    } as Partial<AppState>)
+
+    expect(() => store.getState().preflightManualWorktreeSleep('wt-1')).not.toThrow()
+    expect(store.getState().sleepingAgentSessionsByPaneKey).toEqual({})
+  })
+
   // Why: killing a still-running resumable agent without a recovery record is the
   // destructive gap. Sleep must keep the PTY and surface the miss (STA-2844).
   it('aborts sleep instead of killing a live Claude pane it cannot record', async () => {

--- a/src/renderer/src/store/slices/manual-sleep-stale-session-recovery.test.ts
+++ b/src/renderer/src/store/slices/manual-sleep-stale-session-recovery.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SleepingAgentSessionRecord } from '../../../../shared/agent-session-resume'
+import {
+  AGENT_STATUS_STALE_AFTER_MS,
+  type AgentStatusEntry
+} from '../../../../shared/agent-status-types'
+import type * as AgentStatusModule from '@/lib/agent-status'
+import { shutdownBufferCaptures } from '@/components/terminal-pane/shutdown-buffer-captures'
+import { clearRuntimeCompatibilityCacheForTests } from '../../runtime/runtime-rpc-client'
+import type { AppState } from '../types'
+import {
+  applySleepRuntimeRpcDefault,
+  createStoreCascadesMockApi
+} from './store-cascades-test-harness'
+import { createTestStore, makeTab } from './store-test-helpers'
+
+const NOW = 1_800_000_000_000
+const STALE_AT = NOW - AGENT_STATUS_STALE_AFTER_MS - 1
+
+const mockUnregisterPtyDataHandlers = vi.hoisted(() => vi.fn<() => unknown[]>(() => []))
+const mockRestorePtyDataHandlersAfterFailedShutdown = vi.hoisted(() => vi.fn())
+
+vi.mock('sonner', () => ({
+  toast: { info: vi.fn(), success: vi.fn(), error: vi.fn(), warning: vi.fn() }
+}))
+
+vi.mock('@/components/terminal-pane/pty-dispatcher', () => ({
+  restorePtyDataHandlersAfterFailedShutdown: mockRestorePtyDataHandlersAfterFailedShutdown,
+  unregisterPtyDataHandlers: mockUnregisterPtyDataHandlers
+}))
+
+vi.mock('@/lib/agent-status', async (importOriginal) => {
+  const actual = await importOriginal<typeof AgentStatusModule>()
+  return {
+    ...actual,
+    detectAgentStatusFromTitle: vi.fn().mockReturnValue(null)
+  }
+})
+
+const mockApi = createStoreCascadesMockApi()
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  clearRuntimeCompatibilityCacheForTests()
+  mockApi.pty.kill.mockResolvedValue(undefined)
+  mockUnregisterPtyDataHandlers.mockReturnValue([])
+  applySleepRuntimeRpcDefault(mockApi)
+  shutdownBufferCaptures.clear()
+})
+
+function makeAgentEntry(overrides: Partial<AgentStatusEntry> = {}): AgentStatusEntry {
+  const paneKey = overrides.paneKey ?? 'tab-1:leaf-1'
+  return {
+    state: 'working',
+    prompt: 'finish the task',
+    updatedAt: NOW,
+    stateStartedAt: NOW,
+    stateHistory: [],
+    agentType: 'claude',
+    paneKey,
+    tabId: paneKey.split(':')[0],
+    worktreeId: 'wt-1',
+    providerSession: { key: 'session_id', id: `session-${paneKey}` },
+    ...overrides
+  }
+}
+
+function makeSleepingRecord(
+  overrides: Partial<SleepingAgentSessionRecord> = {}
+): SleepingAgentSessionRecord {
+  const paneKey = overrides.paneKey ?? 'tab-1:leaf-1'
+  return {
+    paneKey,
+    tabId: paneKey.split(':')[0],
+    worktreeId: 'wt-1',
+    agent: 'claude',
+    providerSession: { key: 'session_id', id: `sleeping-${paneKey}` },
+    prompt: 'old prompt',
+    state: 'working',
+    capturedAt: STALE_AT,
+    updatedAt: STALE_AT,
+    origin: 'live',
+    ...overrides
+  }
+}
+
+function seedTabs(store: ReturnType<typeof createTestStore>): void {
+  store.setState({
+    tabsByWorktree: {
+      'wt-1': [makeTab({ id: 'tab-1', worktreeId: 'wt-1' })]
+    }
+  } as Partial<AppState>)
+}
+
+describe('manual sleep stale session recovery', () => {
+  // Why: freshness is a display TTL. A quiet Claude whose provider session id still exists
+  // in an origin:live checkpoint must be promoted even when the live row lost that id (STA-2844).
+  it('promotes a stale origin:live Claude checkpoint when the live row has no session id', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+    const store = createTestStore()
+    seedTabs(store)
+    store.setState({
+      agentStatusByPaneKey: {
+        'tab-1:leaf-1': makeAgentEntry({
+          updatedAt: STALE_AT,
+          providerSession: undefined
+        })
+      },
+      sleepingAgentSessionsByPaneKey: {
+        'tab-1:leaf-1': makeSleepingRecord({
+          providerSession: { key: 'session_id', id: 'claude-persisted' }
+        })
+      }
+    } as Partial<AppState>)
+
+    store.getState().captureSleepingAgentSessionsByWorktree('wt-1')
+
+    const record = store.getState().sleepingAgentSessionsByPaneKey['tab-1:leaf-1']
+    expect(record).toMatchObject({
+      origin: 'worktree-sleep',
+      providerSession: { key: 'session_id', id: 'claude-persisted' },
+      updatedAt: STALE_AT
+    })
+  })
+
+  it('captures a quiet-past-freshness live Claude row without pretending it is fresh', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+    const store = createTestStore()
+    seedTabs(store)
+    store.setState({
+      agentStatusByPaneKey: {
+        'tab-1:stale': makeAgentEntry({
+          paneKey: 'tab-1:stale',
+          updatedAt: STALE_AT,
+          providerSession: { key: 'session_id', id: 'claude-quiet' }
+        })
+      }
+    } as Partial<AppState>)
+
+    store.getState().captureSleepingAgentSessionsByWorktree('wt-1')
+
+    const record = store.getState().sleepingAgentSessionsByPaneKey['tab-1:stale']
+    expect(record).toMatchObject({
+      origin: 'worktree-sleep',
+      providerSession: { key: 'session_id', id: 'claude-quiet' },
+      updatedAt: STALE_AT
+    })
+    expect(record.capturedAt - record.updatedAt).toBeGreaterThan(AGENT_STATUS_STALE_AFTER_MS)
+  })
+
+  it('does not fabricate a resume record for a shell with no agent evidence', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+    const store = createTestStore()
+    seedTabs(store)
+    store.setState({
+      ptyIdsByTabId: { 'tab-1': ['pty-shell'] }
+    } as Partial<AppState>)
+
+    await store.getState().shutdownWorktreeTerminals('wt-1', { keepIdentifiers: true })
+
+    expect(store.getState().sleepingAgentSessionsByPaneKey['tab-1:leaf-1']).toBeUndefined()
+    expect(Object.keys(store.getState().sleepingAgentSessionsByPaneKey)).toEqual([])
+    expect(mockApi.pty.kill).toHaveBeenCalledWith('pty-shell', { keepHistory: true })
+  })
+
+  // Why: killing a still-running resumable agent without a recovery record is the
+  // destructive gap. Sleep must keep the PTY and surface the miss (STA-2844).
+  it('aborts sleep instead of killing a live Claude pane it cannot record', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+    const store = createTestStore()
+    seedTabs(store)
+    store.setState({
+      ptyIdsByTabId: { 'tab-1': ['pty-claude'] },
+      agentStatusByPaneKey: {
+        'tab-1:leaf-1': makeAgentEntry({ providerSession: undefined })
+      }
+    } as Partial<AppState>)
+
+    await expect(
+      store.getState().shutdownWorktreeTerminals('wt-1', { keepIdentifiers: true })
+    ).rejects.toThrow('agent_sleep_capture_missing')
+
+    expect(mockApi.pty.kill).not.toHaveBeenCalled()
+    expect(store.getState().sleepingAgentSessionsByPaneKey['tab-1:leaf-1']).toBeUndefined()
+  })
+})

--- a/src/renderer/src/store/slices/store-sleep-agent-status-retention.test.ts
+++ b/src/renderer/src/store/slices/store-sleep-agent-status-retention.test.ts
@@ -57,11 +57,18 @@ describe('shutdownWorktreeTerminals (sleep) — agent status hygiene', () => {
       ptyIdsByTabId: { 'tab-1': ['pty-1'] }
     })
 
-    store.getState().setAgentStatus('tab-1:0', {
-      state: 'working',
-      prompt: 'p',
-      agentType: 'claude'
-    })
+    store.getState().setAgentStatus(
+      'tab-1:0',
+      {
+        state: 'working',
+        prompt: 'p',
+        agentType: 'claude'
+      },
+      'Claude',
+      { updatedAt: 1000, stateStartedAt: 1000 },
+      { tabId: 'tab-1', worktreeId: wt },
+      { providerSession: { key: 'session_id', id: 'claude-session-1' } }
+    )
     expect(store.getState().agentStatusByPaneKey['tab-1:0']).toBeDefined()
 
     await store.getState().shutdownWorktreeTerminals(wt, { keepIdentifiers: true })
@@ -412,18 +419,22 @@ describe('shutdownWorktreeTerminals (sleep) — agent status hygiene', () => {
       },
       'Claude',
       { updatedAt: 2000, stateStartedAt: 2000 },
-      { tabId: 'tab-1', worktreeId: wt }
+      { tabId: 'tab-1', worktreeId: wt },
+      { providerSession: { key: 'session_id', id: 'claude-session-2' } }
     )
 
     const liveEntry = store.getState().agentStatusByPaneKey['tab-1:0']
     expect(liveEntry?.agentType).toBe('claude')
-    expect(liveEntry?.providerSession).toBeUndefined()
+    expect(liveEntry?.providerSession).toEqual({ key: 'session_id', id: 'claude-session-2' })
 
     await store.getState().shutdownWorktreeTerminals(wt, { keepIdentifiers: true })
 
     const state = store.getState()
     expect(state.agentStatusByPaneKey['tab-1:0']).toBeUndefined()
-    expect(state.sleepingAgentSessionsByPaneKey['tab-1:0']).toBeUndefined()
+    expect(state.sleepingAgentSessionsByPaneKey['tab-1:0']).toMatchObject({
+      agent: 'claude',
+      providerSession: { key: 'session_id', id: 'claude-session-2' }
+    })
   })
 
   it('drops retainedAgentsByPaneKey entries for the slept worktree', async () => {
@@ -528,11 +539,18 @@ describe('shutdownWorktreeTerminals (sleep) — agent status hygiene', () => {
       ptyIdsByTabId: { 'tab-1': ['pty-1'] }
     })
 
-    store.getState().setAgentStatus('tab-1:0', {
-      state: 'working',
-      prompt: 'p',
-      agentType: 'claude'
-    })
+    store.getState().setAgentStatus(
+      'tab-1:0',
+      {
+        state: 'working',
+        prompt: 'p',
+        agentType: 'claude'
+      },
+      'Claude',
+      { updatedAt: 1000, stateStartedAt: 1000 },
+      { tabId: 'tab-1', worktreeId: wt },
+      { providerSession: { key: 'session_id', id: 'claude-session-1' } }
+    )
     store.getState().acknowledgeAgents(['tab-1:0'])
     const ackBeforeSleep = store.getState().acknowledgedAgentsByPaneKey['tab-1:0']
     expect(ackBeforeSleep).toBeGreaterThan(0)
@@ -606,11 +624,18 @@ describe('shutdownWorktreeTerminals (sleep) — agent status hygiene', () => {
       ptyIdsByTabId: { 'tab-1': ['pty-1'] }
     })
 
-    store.getState().setAgentStatus('tab-1:0', {
-      state: 'working',
-      prompt: 'p',
-      agentType: 'claude'
-    })
+    store.getState().setAgentStatus(
+      'tab-1:0',
+      {
+        state: 'working',
+        prompt: 'p',
+        agentType: 'claude'
+      },
+      'Claude',
+      { updatedAt: 1000, stateStartedAt: 1000 },
+      { tabId: 'tab-1', worktreeId: wt },
+      { providerSession: { key: 'session_id', id: 'claude-session-1' } }
+    )
     store.getState().acknowledgeAgents(['tab-1:0'])
     store.getState().retainAgents([
       {

--- a/src/renderer/src/store/slices/store-sleep-runtime-convergence.test.ts
+++ b/src/renderer/src/store/slices/store-sleep-runtime-convergence.test.ts
@@ -189,11 +189,18 @@ describe('shutdownWorktreeTerminals (sleep) — agent status hygiene', () => {
       tabsByWorktree: { [wt]: [makeTab({ id: 'tab-1', worktreeId: wt })] },
       ptyIdsByTabId: { 'tab-1': ['remote:runtime-1@@pty-1'] }
     })
-    store.getState().setAgentStatus('tab-1:leaf-1', {
-      state: 'working',
-      prompt: 'keep running',
-      agentType: 'codex'
-    })
+    store.getState().setAgentStatus(
+      'tab-1:leaf-1',
+      {
+        state: 'working',
+        prompt: 'keep running',
+        agentType: 'codex'
+      },
+      'Codex',
+      { updatedAt: 1000, stateStartedAt: 1000 },
+      { tabId: 'tab-1', worktreeId: wt },
+      { providerSession: { key: 'session_id', id: 'codex-session-1' } }
+    )
 
     await expect(
       store.getState().shutdownWorktreeTerminals(wt, { keepIdentifiers: true })
@@ -681,11 +688,18 @@ describe('shutdownWorktreeTerminals (sleep) — agent status hygiene', () => {
       tabsByWorktree: { [wt]: [makeTab({ id: 'tab-1', worktreeId: wt })] },
       ptyIdsByTabId: { 'tab-1': ['pty-1'] }
     })
-    store.getState().setAgentStatus('tab-1:leaf-1', {
-      state: 'working',
-      prompt: 'still live',
-      agentType: 'codex'
-    })
+    store.getState().setAgentStatus(
+      'tab-1:leaf-1',
+      {
+        state: 'working',
+        prompt: 'still live',
+        agentType: 'codex'
+      },
+      'Codex',
+      { updatedAt: 1000, stateStartedAt: 1000 },
+      { tabId: 'tab-1', worktreeId: wt },
+      { providerSession: { key: 'session_id', id: 'codex-session-1' } }
+    )
 
     await expect(
       store.getState().shutdownWorktreeTerminals(wt, { keepIdentifiers: true })

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -155,6 +155,10 @@ import {
   type AgentStatusWorktreeShutdownReason
 } from './agent-status'
 import {
+  AGENT_SLEEP_CAPTURE_MISSING,
+  listUnrecordableManualSleepAgentPanes
+} from './manual-sleep-recovery-guard'
+import {
   buildTerminalTabRetirementPlan,
   classifyTerminalRetirementWorktree,
   isTerminalTabPresent,
@@ -2946,6 +2950,17 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
             : {})
         })
       : {}
+    if (keepIdentifiers && shutdownReason === 'manual-sleep' && rendererShutdownPtyIds.length > 0) {
+      const unrecordablePaneKeys = listUnrecordableManualSleepAgentPanes(
+        get(),
+        worktreeId,
+        sleepingAgentSessionRecords,
+        opts?.sleepingPaneKeys
+      )
+      if (unrecordablePaneKeys.length > 0) {
+        throw new Error(AGENT_SLEEP_CAPTURE_MISSING)
+      }
+    }
     const retainedCompletionEvidence =
       shutdownReason === 'auto-hibernate-completed-agent'
         ? collectHibernatedCompletionEvidenceForWorktree(get(), worktreeId, opts?.sleepingPaneKeys)

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -449,6 +449,25 @@ function sortedUniquePtyIds(ptyIds: readonly string[] | undefined): string[] {
   return [...new Set((ptyIds ?? []).filter((ptyId) => ptyId.length > 0))].sort()
 }
 
+function collectRecordableManualWorktreeSleepSessions(
+  state: AppState,
+  worktreeId: string,
+  rendererShutdownPtyIds: readonly string[],
+  sleepingPaneKeys?: readonly string[]
+): ReturnType<typeof collectSleepingAgentSessionRecordsForWorktree> {
+  const records = collectSleepingAgentSessionRecordsForWorktree(state, worktreeId, {
+    paneKeys: sleepingPaneKeys,
+    captureMode: 'manual-worktree-sleep'
+  })
+  if (
+    rendererShutdownPtyIds.length > 0 &&
+    listUnrecordableManualSleepAgentPanes(state, worktreeId, records, sleepingPaneKeys).length > 0
+  ) {
+    throw new Error(AGENT_SLEEP_CAPTURE_MISSING)
+  }
+  return records
+}
+
 function equalStringSets(a: readonly string[], b: readonly string[]): boolean {
   if (a.length !== b.length) {
     return false
@@ -689,6 +708,7 @@ export type TerminalSlice = {
   invalidateStaleDirectSshTargetPtyBindings: (authority: DirectSshAuthority) => number
   retryDirectSshTargetPanes: (authority: DirectSshAuthority, now?: number) => number
   settleDirectSshPaneRetry: (result: DirectSshPaneRetryResult, now?: number) => void
+  preflightManualWorktreeSleep: (worktreeId: string, sleepingPaneKeys?: readonly string[]) => void
   shutdownWorktreeTerminals: (
     worktreeId: string,
     opts?: {
@@ -2930,6 +2950,20 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
     })
   },
 
+  preflightManualWorktreeSleep: (worktreeId, sleepingPaneKeys) => {
+    const state = get()
+    const tabs = state.tabsByWorktree[worktreeId] ?? []
+    const rendererShutdownPtyIds = sortedUniquePtyIds(
+      tabs.flatMap((tab) => state.ptyIdsByTabId[tab.id] ?? [])
+    )
+    collectRecordableManualWorktreeSleepSessions(
+      state,
+      worktreeId,
+      rendererShutdownPtyIds,
+      sleepingPaneKeys
+    )
+  },
+
   shutdownWorktreeTerminals: async (worktreeId, opts) => {
     const keepIdentifiers = opts?.keepIdentifiers ?? false
     const shutdownReason: AgentStatusWorktreeShutdownReason =
@@ -2941,26 +2975,21 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
     const runtimeEnvironmentId = resolveTerminalStopRuntimeEnvironmentId(get(), worktreeId)
     // Why: only renderer-bound ids emit pane exit callbacks, so they are the complete guard set (expectedRuntimePtyIds are raw RPC handles).
     const exitGuardPtyIds = rendererShutdownPtyIds
-    const sleepingAgentSessionRecords = keepIdentifiers
-      ? collectSleepingAgentSessionRecordsForWorktree(get(), worktreeId, {
-          paneKeys: opts?.sleepingPaneKeys,
-          ...(shutdownReason === 'manual-sleep' ? { captureMode: 'manual-worktree-sleep' } : {}),
-          ...(shutdownReason === 'auto-hibernate-completed-agent'
-            ? { captureMode: 'completed-agent-hibernation' }
-            : {})
-        })
-      : {}
-    if (keepIdentifiers && shutdownReason === 'manual-sleep' && rendererShutdownPtyIds.length > 0) {
-      const unrecordablePaneKeys = listUnrecordableManualSleepAgentPanes(
-        get(),
-        worktreeId,
-        sleepingAgentSessionRecords,
-        opts?.sleepingPaneKeys
-      )
-      if (unrecordablePaneKeys.length > 0) {
-        throw new Error(AGENT_SLEEP_CAPTURE_MISSING)
-      }
-    }
+    const sleepingAgentSessionRecords = !keepIdentifiers
+      ? {}
+      : shutdownReason === 'manual-sleep'
+        ? collectRecordableManualWorktreeSleepSessions(
+            get(),
+            worktreeId,
+            rendererShutdownPtyIds,
+            opts?.sleepingPaneKeys
+          )
+        : collectSleepingAgentSessionRecordsForWorktree(get(), worktreeId, {
+            paneKeys: opts?.sleepingPaneKeys,
+            ...(shutdownReason === 'auto-hibernate-completed-agent'
+              ? { captureMode: 'completed-agent-hibernation' }
+              : {})
+          })
     const retainedCompletionEvidence =
       shutdownReason === 'auto-hibernate-completed-agent'
         ? collectHibernatedCompletionEvidenceForWorktree(get(), worktreeId, opts?.sleepingPaneKeys)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​505 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​40 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​465 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​195 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​34 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​161 |

<!-- /orca-pr-loc -->

## ELI5

Sleeping a workspace used to treat a quiet Claude session as dead. Wake restored the terminal layout and scrollback, but only as a bare shell — you had to find the saved session id and run `claude --resume` yourself. Sleep now saves a resume record whenever the session id is still known, and wake actually relaunches the agent. If a running session cannot be saved, Sleep is cancelled instead of killing it.

## What Changed

- Manual sleep promotes any recoverable `origin: "live"` provider-session checkpoint even when the live hook row is stale or missing the id.
- Recovery records keep the real last-status time. We no longer stamp `updatedAt` to now to sneak past a 30-minute wake filter.
- Wake resumes from a recoverable provider session id (`claude --resume <id>`). Hook quiet time is not treated as process death. Preserved panes keep the record for in-place restore.
- Sleep aborts (`agent_sleep_capture_missing`) if a still-working or interrupted resumable agent has no recovery record, and the workspace stays open with a toast.
- Empty shells still sleep with no resume record. Unresumable Pi (no transcript) is still not fabricated.

## Why

The 30-minute freshness filter is a display TTL. Using it to authorize PTY shutdown and to discard wake records is the same wrong inference with a constant: a session quiet for 31 minutes is no more dead than one quiet for 29. Staleness is not death (`live` / `unverifiable` / `exited`). The record is cheap; losing the conversation is not.

#12214 captured more panes by stamping freshness. This change decouples the two decisions instead of lengthening the window.

## Linked Issue

Fixes #11160
STA-2844

## Visual Proof

N/A — no renderer layout or chrome change. The user-visible behavior is wake launching `claude --resume <session_id>` in the restored pane instead of a bare shell. Covered by unit tests; Windows 11 PowerShell restore is unvalidated (host unreachable).

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

```
pnpm vitest run --config config/vitest.config.ts \
  src/renderer/src/lib/resume-sleeping-agent-session-stale-recovery.test.ts \
  src/renderer/src/store/slices/manual-sleep-stale-session-recovery.test.ts
```

HOUSE-RULES §4: 5 failed / 2 passed on the unfixed code, 7 passed after the fix, 5 failed / 2 passed again when the production hunks were neutered.

- (a) a session quiet past the freshness window still gets a recovery record and wakes with `claude --resume`
- (b) a genuinely empty shell / unresumable Pi does not fabricate a resume
- (c) a working Claude with no session id is not killed; unreachable-host sleep already fails closed
- (d) wake keeps a stale worktree-sleep record on a preserved pane for in-place restore

Also ran related sleep/resume suites (133 tests) and `pnpm typecheck`.

Platforms: unit tests cover the shared capture/wake path (macOS/Linux/Windows). Windows 11 PowerShell restore is **unvalidated**. SSH/remote sleep already refuses unverified host teardown (`terminal_liveness_unavailable`).

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Author: @BrennanKB5

`AGENT_STATUS_STALE_AFTER_MS` is unchanged for sidebar/display freshness. Related mouse-tracking leftover after a bare-shell restore (#12101 / STA-3210) is a separate defect.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)