### PR TITLE
fix(explorer): resync the file tree after a watch subscription gap

### DIFF
--- a/src/renderer/src/components/right-sidebar/file-explorer-watch-reconcile.test.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-watch-reconcile.test.ts
@@ -58,6 +58,83 @@ function processUpdate(args: {
   return refreshDir
 }
 
+function processEvent(args: {
+  root: string
+  event: {
+    kind: 'create' | 'update' | 'delete' | 'rename' | 'overflow'
+    absolutePath: string
+    oldAbsolutePath?: string
+    isDirectory?: boolean
+  }
+  cache: Record<string, DirCache>
+}): ReturnType<typeof vi.fn> {
+  const refreshDir = vi.fn()
+  processFileExplorerFsPayload({
+    payload: {
+      worktreePath: args.root,
+      events: [args.event]
+    },
+    currentWorktreePath: args.root,
+    worktreeId: 'wt-1',
+    cache: args.cache,
+    expanded: new Set(),
+    setDirCache: vi.fn(),
+    setSelectedPath: vi.fn(),
+    refreshDir,
+    refreshTree: vi.fn()
+  })
+  return refreshDir
+}
+
+describe('processFileExplorerFsPayload create/delete reconciliation', () => {
+  it('refreshes a cached parent when an external process creates a file', () => {
+    const root = '/repo'
+    const refreshDir = processEvent({
+      root,
+      event: { kind: 'create', absolutePath: `${root}/new.ts`, isDirectory: false },
+      cache: { [root]: cacheWithChildren([`${root}/existing.ts`]) }
+    })
+
+    expect(refreshDir).toHaveBeenCalledOnce()
+    expect(refreshDir).toHaveBeenCalledWith(root)
+  })
+
+  it('refreshes a cached Windows parent when create casing differs from the worktree key', () => {
+    const root = 'C:\\Repo'
+    const refreshDir = processEvent({
+      root,
+      event: { kind: 'create', absolutePath: 'c:\\repo\\new.ts', isDirectory: false },
+      cache: { [root]: cacheWithChildren([`${root}\\existing.ts`]) }
+    })
+
+    expect(refreshDir).toHaveBeenCalledOnce()
+    expect(refreshDir).toHaveBeenCalledWith(root)
+  })
+
+  it('refreshes a cached parent when an external process deletes a file', () => {
+    const root = '/repo'
+    const refreshDir = processEvent({
+      root,
+      event: { kind: 'delete', absolutePath: `${root}/existing.ts` },
+      cache: { [root]: cacheWithChildren([`${root}/existing.ts`]) }
+    })
+
+    expect(refreshDir).toHaveBeenCalledOnce()
+    expect(refreshDir).toHaveBeenCalledWith(root)
+  })
+
+  it('does not reread a directory for an existing file content modify', () => {
+    const root = '/repo'
+    const refreshDir = processEvent({
+      root,
+      event: { kind: 'update', absolutePath: `${root}/existing.ts`, isDirectory: false },
+      cache: { [root]: cacheWithChildren([`${root}/existing.ts`]) }
+    })
+
+    expect(refreshDir).not.toHaveBeenCalled()
+  })
+})
+
 describe('processFileExplorerFsPayload update reconciliation', () => {
   it('purges Windows descendants case-insensitively without folding remote POSIX paths', () => {
     let cache: Record<string, DirCache> = {

--- a/src/renderer/src/components/right-sidebar/useFileExplorerWatch.pending-refresh.test.tsx
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerWatch.pending-refresh.test.tsx
@@ -110,6 +110,44 @@ describe('useFileExplorerWatch pending refreshes', () => {
     expect(refreshDir).not.toHaveBeenCalled()
   })
 
+  it('resyncs on reopen after hiding Files with no pending refresh', async () => {
+    const unsubscribe = vi.fn()
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: {
+        fs: {
+          onFsChanged: vi.fn((handler: WatchHandler) => {
+            mainWatchHandler = handler
+            return unsubscribe
+          })
+        }
+      }
+    })
+    const hook = renderWatch()
+    expect(unsubscribe).not.toHaveBeenCalled()
+
+    hook.rerender({ visiblePath: null })
+    expect(unsubscribe).toHaveBeenCalledOnce()
+    expect(refreshTree).not.toHaveBeenCalled()
+
+    hook.rerender({ visiblePath: '/repo' })
+    await act(async () => vi.advanceTimersByTimeAsync(0))
+
+    expect(refreshTree).toHaveBeenCalledOnce()
+    expect(refreshDir).not.toHaveBeenCalled()
+  })
+
+  it('does not resync from a worktree switch that already drops the cache', async () => {
+    const hook = renderWatch('/repo')
+    hook.rerender({ visiblePath: '/other' })
+    await act(async () => vi.advanceTimersByTimeAsync(0))
+    expect(refreshTree).not.toHaveBeenCalled()
+
+    hook.rerender({ visiblePath: '/repo' })
+    await act(async () => vi.advanceTimersByTimeAsync(0))
+    expect(refreshTree).not.toHaveBeenCalled()
+  })
+
   it('flushes main SSH batches on the next turn without another debounce window', async () => {
     ownerRef.current = { kind: 'ssh', connectionId: 'ssh-1' }
     renderWatch()

--- a/src/renderer/src/components/right-sidebar/useFileExplorerWatch.pending-refresh.test.tsx
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerWatch.pending-refresh.test.tsx
@@ -148,6 +148,18 @@ describe('useFileExplorerWatch pending refreshes', () => {
     expect(refreshTree).not.toHaveBeenCalled()
   })
 
+  it('does not resync after hiding Files and revealing a different worktree', async () => {
+    const hook = renderWatch('/repo')
+    hook.rerender({ visiblePath: null })
+    hook.rerender({ visiblePath: '/other' })
+    await act(async () => vi.advanceTimersByTimeAsync(0))
+    expect(refreshTree).not.toHaveBeenCalled()
+
+    hook.rerender({ visiblePath: '/repo' })
+    await act(async () => vi.advanceTimersByTimeAsync(0))
+    expect(refreshTree).not.toHaveBeenCalled()
+  })
+
   it('flushes main SSH batches on the next turn without another debounce window', async () => {
     ownerRef.current = { kind: 'ssh', connectionId: 'ssh-1' }
     renderWatch()

--- a/src/renderer/src/components/right-sidebar/useFileExplorerWatch.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerWatch.ts
@@ -122,8 +122,7 @@ export function useFileExplorerWatch({
   const deferredRef = useRef<FsChangedPayload[]>([])
   const resyncWatchKeysRef = useRef(new Set<string>())
   const activeResyncByWatchKeyRef = useRef(new Map<string, () => void>())
-  const visibleWorktreePathRef = useRef(worktreePath)
-  visibleWorktreePathRef.current = worktreePath
+  const subscribedWatchKeyRef = useRef<string | null>(null)
 
   // Why: a ref bridges processPayload to the flush effect so it can replay deferred payloads without re-subscribing (design §6.2).
   const processPayloadRef = useRef<((payload: FsChangedPayload) => void) | null>(null)
@@ -144,6 +143,16 @@ export function useFileExplorerWatch({
       currentWorktreeId,
       normalizeRuntimePathForComparison(currentWorktreePath)
     ])
+
+    // Why: cleanup always queues; drop a different previous key so a switch
+    // that already resetAndLoad does not keep a second full read.
+    if (
+      subscribedWatchKeyRef.current !== null &&
+      subscribedWatchKeyRef.current !== currentWatchKey
+    ) {
+      resyncWatchKeys.delete(subscribedWatchKeyRef.current)
+    }
+    subscribedWatchKeyRef.current = currentWatchKey
 
     // Why: one scheduler per subscription covers BOTH remote transports (the
     // Electron fs:changed bus and the runtime-RPC subscription below), and its
@@ -267,13 +276,9 @@ export function useFileExplorerWatch({
         activeResyncByWatchKey.delete(currentWatchKey)
       }
       scheduler.cancel()
-      // Why: Files stays mounted while hidden (search / owner flicker), so the
-      // tree cache survives and events in the unsubscribed gap never arrive.
-      // Worktree switches already resetAndLoad — don't queue a second full read.
-      const latestVisiblePath = visibleWorktreePathRef.current
-      if (latestVisiblePath === null || latestVisiblePath === currentWorktreePath) {
-        resyncWatchKeys.add(currentWatchKey)
-      }
+      // Why: the tree cache survives Files being hidden; a switch's next effect
+      // drops this key because resetAndLoad already ran.
+      resyncWatchKeys.add(currentWatchKey)
       deferredRef.current = []
       processPayloadRef.current = null
     }

--- a/src/renderer/src/components/right-sidebar/useFileExplorerWatch.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerWatch.ts
@@ -122,6 +122,8 @@ export function useFileExplorerWatch({
   const deferredRef = useRef<FsChangedPayload[]>([])
   const resyncWatchKeysRef = useRef(new Set<string>())
   const activeResyncByWatchKeyRef = useRef(new Map<string, () => void>())
+  const visibleWorktreePathRef = useRef(worktreePath)
+  visibleWorktreePathRef.current = worktreePath
 
   // Why: a ref bridges processPayload to the flush effect so it can replay deferred payloads without re-subscribing (design §6.2).
   const processPayloadRef = useRef<((payload: FsChangedPayload) => void) | null>(null)
@@ -264,9 +266,12 @@ export function useFileExplorerWatch({
       if (activeResyncByWatchKey.get(currentWatchKey) === scheduler.requestFullRefresh) {
         activeResyncByWatchKey.delete(currentWatchKey)
       }
-      const hadDeferredEvents = deferredRef.current.length > 0
-      if (scheduler.cancel() || hadDeferredEvents) {
-        // The tree cache survives Files being hidden, so remember work canceled after receipt.
+      scheduler.cancel()
+      // Why: Files stays mounted while hidden (search / owner flicker), so the
+      // tree cache survives and events in the unsubscribed gap never arrive.
+      // Worktree switches already resetAndLoad — don't queue a second full read.
+      const latestVisiblePath = visibleWorktreePathRef.current
+      if (latestVisiblePath === null || latestVisiblePath === currentWorktreePath) {
         resyncWatchKeys.add(currentWatchKey)
       }
       deferredRef.current = []


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​127 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​127 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​15 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 |

<!-- /orca-pr-loc -->

## ELI5

The file tree on the right can stay stale after an agent creates files, even though a watcher is installed. Two things caused that: Windows path casing used to miss create events (already fixed), and hiding Files (search view / owner flicker) dropped the subscriber while keeping the cached listing, so later creates never appeared until a manual refresh. This PR closes that second gap by re-reading the tree when the same worktree's subscriber comes back.

## What Changed

- When File Explorer unsubscribes from `fs:changed` but the same worktree's dir cache will survive (Files hidden, search view, owner flicker), mark that worktree for a full tree resync on the next subscribe.
- Worktree switches still go through `resetAndLoad` and do **not** queue a second full read.
- Added create/delete/modify reconciliation tests (including Windows create-casing) and a disposal assertion that the `onFsChanged` subscriber is torn down when Files is hidden.

## Why

STA-2730 / #10902: explorer stays stale until manual refresh after an agent creates files.

The original 1.4.158 failure was **mechanism 3** (event arrives, UI does not re-render): create required an exact `parent in cache` match, rename was ignored, and Windows often classifies a new file as `update`. That path was fixed in #10392 (`processFileExplorerFsPayload` + case-tolerant cache keys).

A sibling still remained: Files stays mounted while hidden, so the tree cache survives, but the watch subscriber unmounts. Events during that gap never reach reconciliation unless a refresh happened to be in flight at hide time. That is **mechanism 2** for the hidden-Files window (events missed because nobody is subscribed) plus **mechanism 3** afterwards (surviving stale cache). The fix is a one-shot disk resync on resubscribe, not a poller.

## Linked Issue

Fixes #10902
Fixes STA-2730

Related: #14802 (same symptom reported on 1.4.180), #10264 / #10392 (Windows create/rename cache keys).

## Visual Proof

N/A — no layout or chrome change. The behavior is a filesystem-watch resync: the existing listing updates from disk after a subscription gap, with no new UI.

## Testing

- [x] Automated tests added/updated
- [ ] I manually tested these changes locally
- [ ] Windows host unvalidated (`remote_runtime_unavailable`) — covered by unit tests for Windows path casing and subscription-gap resync, not a live Windows watcher.

Commands:

```
pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/useFileExplorerWatch.pending-refresh.test.tsx src/renderer/src/components/right-sidebar/file-explorer-watch-reconcile.test.ts
```

HOUSE-RULES §4 (resync-on-gap test):

1. **Pre-fix FAIL:** `resyncs on reopen after hiding Files with no pending refresh` — `expected "vi.fn()" to be called once, but got 0 times`
2. **Post-fix PASS:** 6 tests in `useFileExplorerWatch.pending-refresh.test.tsx`, 18 in `file-explorer-watch-reconcile.test.ts`
3. **Neutered FAIL:** same assertion as (1) after restoring the pending-work-only `resyncWatchKeys.add` guard

Also covered: create, delete, existing-file modify (no parent reread), Windows create-casing, subscriber disposed on hide, worktree switch does not double-refresh, large-batch create does not full-rescan (existing tests).

## Cross-platform / SSH / folder workspaces

- **macOS / Linux:** resync is transport-agnostic (same scheduler that already sits above the Electron `fs:changed` bus and runtime-RPC watches).
- **Windows:** reported platform. Live watcher still unvalidated here; unit tests cover drive-letter casing and update-as-create from #10392 plus this resync.
- **SSH / remote:** remote watches already use this subscriber. A subscription gap now resyncs from the execution host via the existing `refreshTree` read, instead of trusting a stale cache. Loss of contact is not treated as process death.
- **Folder workspaces:** same `useFileExplorerWatch` path as git worktrees.

## Notes

- Not a poller. One `refreshTree` when the same worktree's subscriber returns.
- Watcher teardown is unchanged: `onFsChanged` unsubscribe on hide, native watcher still uses the existing 30s reuse grace.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] Agent skill upstream boundary: Not applicable

Author: @BrennanKB5

## Follow-up (React Doctor)

Cleanup now queues its own watch key from the effect closure. The next effect drops a different previous key so a worktree switch that already `resetAndLoad` does not keep a second full read. That removes the render-phase path ref without moving the write into a later effect (cleanup would still see the old path). Added a sibling test for hide-then-reveal-a-different-worktree; the original switch test is unchanged.
