### PR TITLE
fix(tabs): let live conversation names outrank a stale first-prompt title (STA-2848)

### DIFF
--- a/src/renderer/src/store/pinned-tab-close-guard.test.ts
+++ b/src/renderer/src/store/pinned-tab-close-guard.test.ts
@@ -161,6 +161,14 @@ describe('resolvePinnedTabLabel', () => {
             quickCommandLabel: null,
             generatedLabel: null,
             label: ' Plain '
+          },
+          {
+            id: 'e',
+            entityId: 'ee',
+            customLabel: null,
+            quickCommandLabel: null,
+            generatedLabel: ' Gen only ',
+            label: null
           }
         ]
       } as unknown as AppState['unifiedTabsByWorktree']
@@ -168,8 +176,14 @@ describe('resolvePinnedTabLabel', () => {
 
     expect(resolvePinnedTabLabel(state, 'wt-1', 'a')).toBe('Custom')
     expect(resolvePinnedTabLabel(state, 'wt-1', 'b')).toBe('Run tests')
-    expect(resolvePinnedTabLabel(state, 'wt-1', 'ec')).toBe('Gen')
+    // STA-2848 demoted the generated first-prompt title below a meaningful live
+    // title in the tab strip, and this helper exists to mirror that priority — so
+    // 'ec' (generated + live) now resolves to the live label.
+    expect(resolvePinnedTabLabel(state, 'wt-1', 'ec')).toBe('Plain')
+    // Generated is still the fallback when there is no live label ('ee'), and the
+    // live label is used when there is no generated one ('ed').
     expect(resolvePinnedTabLabel(state, 'wt-1', 'ed')).toBe('Plain')
+    expect(resolvePinnedTabLabel(state, 'wt-1', 'ee')).toBe('Gen only')
   })
 
   it('falls back to the live label when generated tab titles are disabled', () => {

--- a/src/renderer/src/store/pinned-tab-close-guard.test.ts
+++ b/src/renderer/src/store/pinned-tab-close-guard.test.ts
@@ -176,12 +176,7 @@ describe('resolvePinnedTabLabel', () => {
 
     expect(resolvePinnedTabLabel(state, 'wt-1', 'a')).toBe('Custom')
     expect(resolvePinnedTabLabel(state, 'wt-1', 'b')).toBe('Run tests')
-    // STA-2848 demoted the generated first-prompt title below a meaningful live
-    // title in the tab strip, and this helper exists to mirror that priority — so
-    // 'ec' (generated + live) now resolves to the live label.
     expect(resolvePinnedTabLabel(state, 'wt-1', 'ec')).toBe('Plain')
-    // Generated is still the fallback when there is no live label ('ee'), and the
-    // live label is used when there is no generated one ('ed').
     expect(resolvePinnedTabLabel(state, 'wt-1', 'ed')).toBe('Plain')
     expect(resolvePinnedTabLabel(state, 'wt-1', 'ee')).toBe('Gen only')
   })

--- a/src/renderer/src/store/slices/agent-generated-tab-title-session.test.ts
+++ b/src/renderer/src/store/slices/agent-generated-tab-title-session.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getAgentRowConversationName } from '../../../../shared/agent-row-conversation-name'
+import { getDefaultSettings } from '../../../../shared/constants'
+import { makePaneKey } from '../../../../shared/stable-pane-id'
+import { resolveTerminalTabTitle } from '../../../../shared/tab-title-resolution'
+import { createTestStore, makeWorktree, seedStore } from './store-test-helpers'
+
+const WORKTREE_ID = 'repo1::/path/wt1'
+const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+
+function seedWorktree(store: ReturnType<typeof createTestStore>, enabled: boolean): string {
+  seedStore(store, {
+    settings: {
+      ...getDefaultSettings('/tmp'),
+      tabAutoGenerateTitle: enabled
+    },
+    worktreesByRepo: {
+      repo1: [makeWorktree({ id: WORKTREE_ID, repoId: 'repo1', path: '/path/wt1' })]
+    }
+  })
+  return store.getState().createTab(WORKTREE_ID).id
+}
+
+describe('generated agent tab titles across provider sessions', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('replaces the first-prompt generated title when the provider session changes', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    const tabId = seedWorktree(store, true)
+    const paneKey = makePaneKey(tabId, LEAF_ID)
+    const sessionMetadata = (id: string) => ({
+      providerSession: { key: 'session_id' as const, id }
+    })
+
+    store.getState().setAgentStatus(
+      paneKey,
+      {
+        state: 'working',
+        prompt: 'Upload the Kimi-K3 model to GitHub',
+        agentType: 'claude'
+      },
+      undefined,
+      { updatedAt: 1_000 },
+      undefined,
+      sessionMetadata('claude-session-1')
+    )
+    expect(store.getState().tabsByWorktree[WORKTREE_ID][0].generatedTitle).toBe(
+      'Upload the Kimi K3 model to GitHub'
+    )
+
+    vi.stubGlobal('window', { api: { gh: {} } })
+    // Why: /clear finishes the previous turn (`done`) then starts a new
+    // provider session on the same PTY. `existingProviderSession` is dropped
+    // on done→working, so staleness must compare the previous entry's id.
+    store.getState().setAgentStatus(
+      paneKey,
+      {
+        state: 'done',
+        prompt: 'Upload the Kimi-K3 model to GitHub',
+        agentType: 'claude'
+      },
+      undefined,
+      { updatedAt: 2_000 },
+      undefined,
+      sessionMetadata('claude-session-1')
+    )
+    store.getState().setAgentStatus(
+      paneKey,
+      {
+        state: 'working',
+        prompt: 'Can you please refactor the auth middleware to use JWT tokens?',
+        agentType: 'claude'
+      },
+      undefined,
+      { updatedAt: 3_000 },
+      undefined,
+      sessionMetadata('claude-session-2')
+    )
+
+    const tab = store.getState().tabsByWorktree[WORKTREE_ID][0]
+    expect(tab.generatedTitle).toBe('Refactor the auth middleware to use JWT')
+    expect(store.getState().unifiedTabsByWorktree[WORKTREE_ID][0].generatedLabel).toBe(
+      'Refactor the auth middleware to use JWT'
+    )
+    expect(resolveTerminalTabTitle(tab, true)).toBe('Refactor the auth middleware to use JWT')
+    expect(getAgentRowConversationName(tab, 'claude', true)).toBe(
+      'Refactor the auth middleware to use JWT'
+    )
+  })
+
+  it('keeps the first-prompt generated title across follow-up turns of the same session', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    const tabId = seedWorktree(store, true)
+    const paneKey = makePaneKey(tabId, LEAF_ID)
+    const sessionMetadata = {
+      providerSession: { key: 'session_id' as const, id: 'claude-session-1' }
+    }
+
+    store.getState().setAgentStatus(
+      paneKey,
+      {
+        state: 'working',
+        prompt: 'Upload the Kimi-K3 model to GitHub',
+        agentType: 'claude'
+      },
+      undefined,
+      { updatedAt: 1_000 },
+      undefined,
+      sessionMetadata
+    )
+    store.getState().setAgentStatus(
+      paneKey,
+      {
+        state: 'working',
+        prompt: 'Can you please refactor the auth middleware to use JWT tokens?',
+        agentType: 'claude'
+      },
+      undefined,
+      { updatedAt: 3_000 },
+      undefined,
+      sessionMetadata
+    )
+
+    expect(store.getState().tabsByWorktree[WORKTREE_ID][0].generatedTitle).toBe(
+      'Upload the Kimi K3 model to GitHub'
+    )
+  })
+})

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -2115,6 +2115,7 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
       }
       let completionRefreshWorktreeId: string | null = null
       let suppressedInheritedTerminalStatus = false
+      let replaceGeneratedTitleOnProviderSessionChange = false
       const generatedTitleEntry: { current: AgentStatusEntry | null } = { current: null }
       set((s) => {
         const existing = s.agentStatusByPaneKey[paneKey]
@@ -2256,6 +2257,18 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
             metadata?.providerSession,
             existingProviderSession
           )
+        // Why: done→working (/clear) drops existingProviderSession so a reused
+        // pane cannot inherit a finished id. The previous entry's id is still
+        // the signal that this first-prompt title belongs to another session.
+        replaceGeneratedTitleOnProviderSessionChange = Boolean(
+          existing?.providerSession &&
+          metadata?.providerSession &&
+          !agentProviderSessionsEqual(
+            identity.agentType,
+            metadata.providerSession,
+            existing.providerSession
+          )
+        )
         const statusTabId =
           routing?.tabId ?? existing?.tabId ?? getTabIdFromPaneKey(paneKey) ?? undefined
         const statusTerminalHandle = routing?.terminalHandle ?? existing?.terminalHandle
@@ -2550,7 +2563,9 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
           liveDispatchTaskId !== stickyOrchestrationTaskId
         )
         const shouldReplaceGeneratedTitle =
-          hasMatchingOrchestrationLabels || isNewDispatchAgainstStickyOrchestration
+          hasMatchingOrchestrationLabels ||
+          isNewDispatchAgainstStickyOrchestration ||
+          replaceGeneratedTitleOnProviderSessionChange
         // Why: setAgentStatus is high-frequency, so only parse dispatch preambles when a title write is actually possible.
         const mayWriteGeneratedTitle =
           get().settings?.tabAutoGenerateTitle === true &&

--- a/src/shared/agent-row-conversation-name.test.ts
+++ b/src/shared/agent-row-conversation-name.test.ts
@@ -31,10 +31,29 @@ describe('getAgentRowConversationName', () => {
     )
   })
 
-  it('uses the generated title only when generated titles are enabled', () => {
-    const tab = makeTab({ generatedTitle: 'Fix intake flow', title: '✳ Investigate replay bug' })
-    expect(getAgentRowConversationName(tab, 'claude', true)).toBe('Fix intake flow')
+  it('uses a meaningful live title ahead of a generated first-prompt title', () => {
+    const tab = makeTab({
+      generatedTitle: 'Upload the Kimi-K3 model to GitHub',
+      title: '✳ Investigate replay bug'
+    })
+    expect(getAgentRowConversationName(tab, 'claude', true)).toBe('Investigate replay bug')
     expect(getAgentRowConversationName(tab, 'claude', false)).toBe('Investigate replay bug')
+  })
+
+  it('falls back to the generated title when the live title is only status', () => {
+    const tab = makeTab({ generatedTitle: 'Fix intake flow', title: '✳ Claude working' })
+    expect(getAgentRowConversationName(tab, 'claude', true)).toBe('Fix intake flow')
+    expect(getAgentRowConversationName(tab, 'claude', false)).toBeNull()
+  })
+
+  it('heals a persisted first-prompt name when a later live conversation name is present', () => {
+    const tab = makeTab({
+      generatedTitle: 'Upload the Kimi-K3 model to GitHub',
+      title: 'Recent Project Progress Status Inquiry - grok'
+    })
+    expect(getAgentRowConversationName(tab, 'grok', true)).toBe(
+      'Recent Project Progress Status Inquiry - grok'
+    )
   })
 
   it('names a split pane from its own live title, not the tab title', () => {
@@ -72,6 +91,17 @@ describe('getAgentRowConversationName', () => {
     expect(
       getAgentRowConversationName(makeTab({ title: '⠋ Refactor replay guard' }), 'codex', false)
     ).toBe('Refactor replay guard')
+  })
+
+  it('rejects spinner plus a single project token instead of treating it as a name', () => {
+    expect(getAgentRowConversationName(makeTab({ title: '⠋ albacore' }), 'codex', false)).toBeNull()
+    expect(
+      getAgentRowConversationName(
+        makeTab({ generatedTitle: 'Fix intake flow', title: '⠋ albacore' }),
+        'codex',
+        true
+      )
+    ).toBe('Fix intake flow')
   })
 
   it('rejects spinner+cwd titles instead of surfacing paths as names', () => {

--- a/src/shared/agent-row-conversation-name.test.ts
+++ b/src/shared/agent-row-conversation-name.test.ts
@@ -46,6 +46,28 @@ describe('getAgentRowConversationName', () => {
     expect(getAgentRowConversationName(tab, 'claude', false)).toBeNull()
   })
 
+  it('falls back to the generated title for Codex is-thinking OSC frames', () => {
+    const tab = makeTab({ generatedTitle: 'Fix intake flow', title: '⠋ Codex is thinking' })
+    expect(getAgentRowConversationName(tab, 'codex', true)).toBe('Fix intake flow')
+    expect(getAgentRowConversationName(tab, 'codex', false)).toBeNull()
+    expect(
+      getAgentRowConversationName(
+        makeTab({ generatedTitle: 'Fix intake flow', title: '⠋ Codex is thinking' }),
+        null,
+        true
+      )
+    ).toBe('Fix intake flow')
+  })
+
+  it('falls back to the generated title for Grok rotating working frames', () => {
+    const tab = makeTab({
+      generatedTitle: 'Fix intake flow',
+      title: '⠋ - Waiting for response… - grok'
+    })
+    expect(getAgentRowConversationName(tab, 'grok', true)).toBe('Fix intake flow')
+    expect(getAgentRowConversationName(tab, 'grok', false)).toBeNull()
+  })
+
   it('heals a persisted first-prompt name when a later live conversation name is present', () => {
     const tab = makeTab({
       generatedTitle: 'Upload the Kimi-K3 model to GitHub',

--- a/src/shared/agent-row-conversation-name.ts
+++ b/src/shared/agent-row-conversation-name.ts
@@ -11,6 +11,7 @@ import { stripLeadingAgentTitleDecorationOrEmpty } from './agent-title-decoratio
 import { formatAgentTypeLabel, WELL_KNOWN_AGENT_TYPE_LABELS } from './agent-type-label'
 import { isMeaningfulOpenCodeTerminalTitle } from './opencode-terminal-title'
 import { SYNTHETIC_AGENT_TITLE_PROFILES } from './synthetic-agent-title'
+import { isGrokRotatingWorkingTitle } from './terminal-title-agent-type'
 import type { TerminalTab } from './terminal-tab-types'
 
 export type ConversationNameTab = Pick<
@@ -37,6 +38,8 @@ const AGENT_IDENTITY_ALIASES_LOWER: Readonly<Record<string, readonly string[]>> 
   gemini: ['gemini cli']
 }
 
+// Why: Claude OSC is "Claude working"; Codex's stored working title is
+// "Codex is thinking". Both must lose to a generated conversation name.
 const IDENTITY_STATUS_SUFFIXES = [
   '',
   ' ready',
@@ -45,6 +48,12 @@ const IDENTITY_STATUS_SUFFIXES = [
   ' working',
   ' thinking',
   ' running',
+  ' is ready',
+  ' is idle',
+  ' is done',
+  ' is working',
+  ' is thinking',
+  ' is running',
   ' - action required'
 ] as const
 
@@ -89,6 +98,10 @@ export function conversationNameFromLiveTitle(
   const original = liveTitle.trim()
   const stripped = stripLeadingAgentTitleDecorationOrEmpty(original).trim()
   if (!stripped) {
+    return null
+  }
+  // Why: rotating Grok frames keep the spinner; classify before stripping.
+  if (isGrokRotatingWorkingTitle(original)) {
     return null
   }
   const lower = stripped.toLowerCase()

--- a/src/shared/agent-row-conversation-name.ts
+++ b/src/shared/agent-row-conversation-name.ts
@@ -60,33 +60,14 @@ const STATUS_WITH_CONTEXT_RE = /^(?:ready|idle|done)(?:\s+\([^)]*\))?$/i
 const DEFAULT_TERMINAL_TITLE_RE = /^terminal \d+$/i
 
 function isIdentityStatusTitle(titleLower: string, identityLower: string): boolean {
-  return (
-    titleLower === identityLower ||
-    titleLower === `${identityLower} ready` ||
-    titleLower === `${identityLower} idle` ||
-    titleLower === `${identityLower} done` ||
-    titleLower === `${identityLower} working` ||
-    titleLower === `${identityLower} thinking` ||
-    titleLower === `${identityLower} running` ||
-    titleLower === `${identityLower} - action required`
-  )
+  return IDENTITY_STATUS_SUFFIXES.some((suffix) => titleLower === `${identityLower}${suffix}`)
 }
 
-function isAgentIdentityStatusTitle(
-  titleLower: string,
-  agentType: AgentType | null | undefined,
-  agentTypeLabelLower: string
-): boolean {
-  if (KNOWN_IDENTITY_STATUS_TITLES_LOWER.has(titleLower)) {
-    return true
-  }
-  if (isIdentityStatusTitle(titleLower, agentTypeLabelLower)) {
-    return true
-  }
+function isAgentIdentityStatusTitle(titleLower: string, agentTypeLabelLower: string): boolean {
+  // Why: the Set covers well-known labels when the tab bar passes no agent type.
   return (
-    AGENT_IDENTITY_ALIASES_LOWER[agentType ?? '']?.some((identity) =>
-      isIdentityStatusTitle(titleLower, identity)
-    ) ?? false
+    KNOWN_IDENTITY_STATUS_TITLES_LOWER.has(titleLower) ||
+    isIdentityStatusTitle(titleLower, agentTypeLabelLower)
   )
 }
 
@@ -115,7 +96,7 @@ export function conversationNameFromLiveTitle(
   if (
     SYNTHETIC_STATUS_TITLES_LOWER.has(lower) ||
     lower === FALLBACK_TAB_TITLE_LOWER ||
-    isAgentIdentityStatusTitle(lower, agentType, agentTypeLabelLower) ||
+    isAgentIdentityStatusTitle(lower, agentTypeLabelLower) ||
     STATUS_WITH_CONTEXT_RE.test(stripped) ||
     DEFAULT_TERMINAL_TITLE_RE.test(stripped) ||
     isClaudeManagementTitle(stripped) ||

--- a/src/shared/agent-row-conversation-name.ts
+++ b/src/shared/agent-row-conversation-name.ts
@@ -1,14 +1,14 @@
 // Resolves the stable "conversation name" an agent row can show instead of the
 // live last-message preview. Sources, in the same precedence the tab bar uses
 // (tab-title-resolution.ts): manual rename → quick-command label → OpenCode's
-// semantic session title → Orca's generated title → the agent-set live title.
-// Live titles are accepted only when they carry a real name — pure status,
-// identity-echo, and spinner/cwd titles yield null so callers keep the
-// last-message label.
+// semantic session title → a meaningful agent-set live title → Orca's
+// generated first-prompt title. Live titles are accepted only when they carry
+// a real name — pure status, identity-echo, and spinner/cwd titles yield null
+// so the generated fallback (or the caller's last-message label) can win.
 import type { AgentType } from './agent-status-types'
 import { isClaudeManagementTitle } from './agent-title-core'
 import { stripLeadingAgentTitleDecorationOrEmpty } from './agent-title-decoration'
-import { formatAgentTypeLabel } from './agent-type-label'
+import { formatAgentTypeLabel, WELL_KNOWN_AGENT_TYPE_LABELS } from './agent-type-label'
 import { isMeaningfulOpenCodeTerminalTitle } from './opencode-terminal-title'
 import { SYNTHETIC_AGENT_TITLE_PROFILES } from './synthetic-agent-title'
 import type { TerminalTab } from './terminal-tab-types'
@@ -37,6 +37,25 @@ const AGENT_IDENTITY_ALIASES_LOWER: Readonly<Record<string, readonly string[]>> 
   gemini: ['gemini cli']
 }
 
+const IDENTITY_STATUS_SUFFIXES = [
+  '',
+  ' ready',
+  ' idle',
+  ' done',
+  ' working',
+  ' thinking',
+  ' running',
+  ' - action required'
+] as const
+
+const KNOWN_IDENTITY_STATUS_TITLES_LOWER: ReadonlySet<string> = new Set(
+  [
+    FALLBACK_TAB_TITLE_LOWER,
+    ...Object.values(WELL_KNOWN_AGENT_TYPE_LABELS).map((label) => label.toLowerCase()),
+    ...Object.values(AGENT_IDENTITY_ALIASES_LOWER).flat()
+  ].flatMap((identity) => IDENTITY_STATUS_SUFFIXES.map((suffix) => `${identity}${suffix}`))
+)
+
 const STATUS_WITH_CONTEXT_RE = /^(?:ready|idle|done)(?:\s+\([^)]*\))?$/i
 const DEFAULT_TERMINAL_TITLE_RE = /^terminal \d+$/i
 
@@ -58,6 +77,9 @@ function isAgentIdentityStatusTitle(
   agentType: AgentType | null | undefined,
   agentTypeLabelLower: string
 ): boolean {
+  if (KNOWN_IDENTITY_STATUS_TITLES_LOWER.has(titleLower)) {
+    return true
+  }
   if (isIdentityStatusTitle(titleLower, agentTypeLabelLower)) {
     return true
   }
@@ -78,17 +100,18 @@ function isCwdLikeTitle(title: string): boolean {
   return !/\s/.test(title) && /[\\/]/.test(title)
 }
 
-function conversationNameFromLiveTitle(
+export function conversationNameFromLiveTitle(
   liveTitle: string,
   agentType: AgentType | null | undefined,
-  agentTypeLabelLower: string,
-  defaultTitle: string | undefined
+  defaultTitle?: string
 ): string | null {
-  const stripped = stripLeadingAgentTitleDecorationOrEmpty(liveTitle.trim()).trim()
+  const original = liveTitle.trim()
+  const stripped = stripLeadingAgentTitleDecorationOrEmpty(original).trim()
   if (!stripped) {
     return null
   }
   const lower = stripped.toLowerCase()
+  const agentTypeLabelLower = formatAgentTypeLabel(agentType).toLowerCase()
   if (
     SYNTHETIC_STATUS_TITLES_LOWER.has(lower) ||
     lower === FALLBACK_TAB_TITLE_LOWER ||
@@ -98,6 +121,11 @@ function conversationNameFromLiveTitle(
     isClaudeManagementTitle(stripped) ||
     isCwdLikeTitle(stripped)
   ) {
+    return null
+  }
+  // Why: spinner + a single token is a project/cwd OSC frame ("⠋ albacore"),
+  // not a conversation name. Multi-word decorated titles still count.
+  if (stripped !== original && !/\s/.test(stripped)) {
     return null
   }
   if (defaultTitle && stripped === defaultTitle.trim()) {
@@ -134,17 +162,15 @@ export function getAgentRowConversationName(
   if (isMeaningfulOpenCodeTerminalTitle(liveTitle)) {
     return liveTitle
   }
+  const namedLiveTitle = liveTitle
+    ? conversationNameFromLiveTitle(liveTitle, agentType, tab.defaultTitle)
+    : null
+  if (namedLiveTitle) {
+    return namedLiveTitle
+  }
   const generatedTitle = generatedTitlesEnabled ? tab.generatedTitle?.trim() : ''
   if (generatedTitle) {
     return generatedTitle
   }
-  if (!liveTitle) {
-    return null
-  }
-  return conversationNameFromLiveTitle(
-    liveTitle,
-    agentType,
-    formatAgentTypeLabel(agentType).toLowerCase(),
-    tab.defaultTitle
-  )
+  return null
 }

--- a/src/shared/agent-type-label.ts
+++ b/src/shared/agent-type-label.ts
@@ -2,7 +2,7 @@ import type { AgentType } from './agent-status-types'
 
 // Shared so the desktop renderer and the mobile app show the same agent name
 // (e.g. native chat's empty state on both surfaces) from one source of truth.
-const WELL_KNOWN_LABELS: Record<string, string> = {
+export const WELL_KNOWN_AGENT_TYPE_LABELS: Record<string, string> = {
   claude: 'Claude',
   openclaude: 'OpenClaude',
   codex: 'Codex',
@@ -32,5 +32,5 @@ export function formatAgentTypeLabel(agentType: AgentType | null | undefined): s
     return 'Agent'
   }
   // Capitalize well-known names nicely; pass through custom names as-is
-  return WELL_KNOWN_LABELS[agentType] ?? agentType
+  return WELL_KNOWN_AGENT_TYPE_LABELS[agentType] ?? agentType
 }

--- a/src/shared/tab-title-resolution.test.ts
+++ b/src/shared/tab-title-resolution.test.ts
@@ -11,7 +11,7 @@ describe('tab title resolution', () => {
     ).toBe('Claude working')
   })
 
-  it('places generated titles between manual and live titles when enabled', () => {
+  it('places generated titles between manual and status live titles when enabled', () => {
     expect(
       resolveTerminalTabTitle(
         { customTitle: null, generatedTitle: 'Refactor auth', title: 'Claude working' },
@@ -24,6 +24,19 @@ describe('tab title resolution', () => {
         true
       )
     ).toBe('Payments')
+  })
+
+  it('uses a meaningful live title ahead of a generated first-prompt title', () => {
+    expect(
+      resolveTerminalTabTitle(
+        {
+          customTitle: null,
+          generatedTitle: 'Upload the Kimi-K3 model to GitHub',
+          title: 'Refactor auth middleware'
+        },
+        true
+      )
+    ).toBe('Refactor auth middleware')
   })
 
   it('uses meaningful native OpenCode session titles before generated titles', () => {
@@ -152,6 +165,19 @@ describe('tab title resolution', () => {
         true
       )
     ).toBe('Fix flaky tests')
+  })
+
+  it('uses a meaningful live unified label ahead of a generated label', () => {
+    expect(
+      resolveUnifiedTabLabel(
+        {
+          customLabel: null,
+          generatedLabel: 'Upload the Kimi-K3 model to GitHub',
+          label: 'Refactor auth middleware'
+        },
+        true
+      )
+    ).toBe('Refactor auth middleware')
   })
 
   it('uses quick command labels before generated unified labels', () => {

--- a/src/shared/tab-title-resolution.test.ts
+++ b/src/shared/tab-title-resolution.test.ts
@@ -141,6 +141,26 @@ describe('tab title resolution', () => {
       )
     ).toBe('First prompt title')
     expect(
+      resolveTerminalTabTitle(
+        {
+          customTitle: null,
+          generatedTitle: 'First prompt title',
+          title: '⠋ Codex is thinking'
+        },
+        true
+      )
+    ).toBe('First prompt title')
+    expect(
+      resolveTerminalTabTitle(
+        {
+          customTitle: null,
+          generatedTitle: 'First prompt title',
+          title: '⠋ - Waiting for response… - grok'
+        },
+        true
+      )
+    ).toBe('First prompt title')
+    expect(
       resolveUnifiedTabLabel(
         {
           customLabel: null,

--- a/src/shared/tab-title-resolution.test.ts
+++ b/src/shared/tab-title-resolution.test.ts
@@ -103,6 +103,56 @@ describe('tab title resolution', () => {
     ).toBe('Repair provider-native tab titles')
   })
 
+  it('keeps AI Vault titles above a meaningful live title, which still beats generated', () => {
+    const aiVaultTitle = {
+      agent: 'codex' as const,
+      sessionId: 'codex-session',
+      title: 'Vault conversation'
+    }
+    expect(
+      resolveTerminalTabTitle(
+        {
+          customTitle: null,
+          aiVaultTitle,
+          generatedTitle: 'First prompt title',
+          title: 'Investigate replay bug'
+        },
+        true
+      )
+    ).toBe('Vault conversation')
+    expect(
+      resolveTerminalTabTitle(
+        {
+          customTitle: null,
+          generatedTitle: 'First prompt title',
+          title: 'Investigate replay bug'
+        },
+        true
+      )
+    ).toBe('Investigate replay bug')
+    expect(
+      resolveTerminalTabTitle(
+        {
+          customTitle: null,
+          generatedTitle: 'First prompt title',
+          title: 'Claude working'
+        },
+        true
+      )
+    ).toBe('First prompt title')
+    expect(
+      resolveUnifiedTabLabel(
+        {
+          customLabel: null,
+          aiVaultTitle,
+          generatedLabel: 'First prompt title',
+          label: 'Investigate replay bug'
+        },
+        true
+      )
+    ).toBe('Vault conversation')
+  })
+
   it('keeps manual and quick-command labels ahead of AI Vault titles', () => {
     const aiVaultTitle = {
       agent: 'claude' as const,

--- a/src/shared/tab-title-resolution.ts
+++ b/src/shared/tab-title-resolution.ts
@@ -1,11 +1,17 @@
+import { conversationNameFromLiveTitle } from './agent-row-conversation-name'
+import { isMeaningfulOpenCodeTerminalTitle } from './opencode-terminal-title'
 import type { Tab } from './tab-types'
 import type { TerminalTab } from './terminal-tab-types'
-import { isMeaningfulOpenCodeTerminalTitle } from './opencode-terminal-title'
 
 export function resolveTerminalTabTitle(
   tab: Pick<
     TerminalTab,
-    'customTitle' | 'quickCommandLabel' | 'aiVaultTitle' | 'generatedTitle' | 'title'
+    | 'customTitle'
+    | 'quickCommandLabel'
+    | 'aiVaultTitle'
+    | 'generatedTitle'
+    | 'title'
+    | 'defaultTitle'
   >,
   generatedTitlesEnabled: boolean,
   fallback = ''
@@ -16,6 +22,7 @@ export function resolveTerminalTabTitle(
     tab.quickCommandLabel?.trim() ||
     (isMeaningfulOpenCodeTerminalTitle(liveTitle) ? liveTitle : '') ||
     tab.aiVaultTitle?.title.trim() ||
+    conversationNameFromLiveTitle(liveTitle, null, tab.defaultTitle) ||
     (generatedTitlesEnabled ? tab.generatedTitle?.trim() : '') ||
     liveTitle ||
     fallback
@@ -35,6 +42,7 @@ export function resolveUnifiedTabLabel(
     tab?.quickCommandLabel?.trim() ||
     (isMeaningfulOpenCodeTerminalTitle(liveLabel) ? liveLabel : '') ||
     tab?.aiVaultTitle?.title.trim() ||
+    conversationNameFromLiveTitle(liveLabel, null) ||
     (generatedTitlesEnabled ? tab?.generatedLabel?.trim() : '') ||
     liveLabel ||
     fallback


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​295 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​290 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​88 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​45 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​43 |

<!-- /orca-pr-loc -->

## ELI5

A tab named itself after the first prompt and never let go. After `/clear` or a topic change, the tab and the sidebar still showed the finished conversation even when the agent was already publishing a better live name. Now a real live conversation name wins, and a new provider session can mint a new first-prompt fallback. Status frames like "Claude working" still keep the generated name so the tab is never blank.

## What Changed

- Tab bar and sidebar conversation names now rank a **meaningful live title** above the write-once first-prompt `generatedTitle`.
- Status, identity-echo, spinner+project (`⠋ albacore`), cwd, and generic titles still lose to the generated fallback, so that fallback is not removed.
- When the pane's provider session id changes (`/clear` on the same PTY, no AI Vault rebind required), the next prompt replaces the stale generated title. Same-session follow-ups stay first-write-wins.
- User-set `customTitle` and `quickCommandLabel` still outrank everything.

## Why

Two things combined into the bug:

1. `setGeneratedTabTitleFromAgentPrompt` returned early whenever `generatedTitle` already existed, and nothing cleared it on `/clear`.
2. `getAgentRowConversationName` / `resolveTerminalTabTitle` ranked that stale generated name above an accurate live OSC title.

The generated title exists because agents often publish only a spinner or identity frame. The ordering was the bug, not the feature. #15659 (STA-4865) already ranks Claude/Codex **AI Vault** names above generated titles and drops the generated title on vault rebind; this PR does not duplicate that. It covers the remaining gap: live titles, agents without a vault title, and `/clear` with no vault rebind.

## Linked Issue

Fixes https://github.com/stablyai/orca/issues/11167
Linear: https://linear.app/stably/issue/STA-2848

Sibling, not in this PR: https://github.com/stablyai/orca/pull/15659 (STA-4865 AI Vault ranking + vault rebind). STA-2467 (harness custom names) is also separate.

## Visual Proof

N/A — no layout, styling, or interaction-path change. The only user-visible difference is which existing string the tab label and session-list row already render, and that derivation is covered by unit tests (`/clear` session change, live name vs generated, status fallback, persisted-stale heal). Reproducing in a running app requires a live agent session.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Pre-fix (tests against unfixed code): 5 failed. Sidebar/tab still returned the first-prompt generated title (`"Upload the Kimi-K3 model to GitHub"`) instead of the live name, and `/clear` left `generatedTitle` set.

Post-fix: `pnpm vitest run --config config/vitest.config.ts src/shared/agent-row-conversation-name.test.ts src/shared/tab-title-resolution.test.ts src/renderer/src/store/slices/agent-generated-tab-title.test.ts src/renderer/src/store/slices/agent-generated-tab-title-session.test.ts` — 41 passed. `pnpm typecheck` passed.

Neutered (reverted the four production files, kept tests): 6 failed again.

Platform: logic is host-agnostic (macOS / Linux / Windows / WSL / SSH). Title ranking is pure string derivation; session-id invalidation uses the existing hook `providerSession` already carried for resume.

## AI Disclosure

Internal contributor — ignore.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- STA-2069 / `--resume` forks still make "session id changed" an imperfect conversation-identity test. This PR uses that signal the same way #15659 does for vault rebind, and does not try to invent a `/clear` hook (Orca still does not register Claude `SessionStart`).
- Grok `summary.json` `generated_title` is still not wired into `aiVaultTitle`; when Grok publishes a real idle live title, this PR now shows it. Wiring the harness title is a separate follow-up.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)