### PR TITLE
fix(ai-vault): attribute Cursor transcripts to their project workspace (STA-3959)

### DIFF
--- a/src/main/agent-trust-presets.ts
+++ b/src/main/agent-trust-presets.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, realpathSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { basename, dirname, join, resolve } from 'node:path'
+import { cursorWorkspaceSlug } from '../shared/cursor-workspace-slug'
 import { writeFileAtomically } from './codex-accounts/fs-utils'
 import { getOrcaManagedCodexHomePath } from './codex/codex-home-paths'
 import { upsertProjectTrustLevel } from './codex/config-toml-trust'
@@ -166,12 +167,4 @@ function canonicalize(p: string): string {
     // Fall through to the raw input.
   }
   return p
-}
-
-function cursorWorkspaceSlug(absPath: string): string {
-  const stripped = absPath.replace(/^[\\/]+/, '')
-  // Why: Windows absolute paths include characters such as ":" that cannot
-  // be used in the ~/.cursor/projects/<slug> directory name.
-  const slug = stripped.replace(/[\\/:*?"<>|]+/g, '-')
-  return slug
 }

--- a/src/main/ai-vault/remote-session-scanner.test.ts
+++ b/src/main/ai-vault/remote-session-scanner.test.ts
@@ -643,6 +643,47 @@ describe('scanRemoteAiVaultSessions', () => {
     ])
   })
 
+  it('backfills an older cwd-null Cursor transcript through its project slug', async () => {
+    const provider = new MemoryRemoteProvider()
+    provider.addFile(
+      '/home/ada/.codex/sessions/other.jsonl',
+      codexTranscript({
+        sessionId: 'other-session',
+        title: 'Other workspace',
+        cwd: '/home/ada/other',
+        timestamp: '2026-07-04T05:00:00.000Z'
+      }),
+      50
+    )
+    provider.addFile(
+      '/home/ada/.cursor/projects/home-ada-repo/agent-transcripts/cursor-scoped.jsonl',
+      jsonLines([
+        {
+          role: 'user',
+          timestamp: '2026-07-04T01:00:00.000Z',
+          message: { content: 'Scoped Cursor workspace' }
+        }
+      ]),
+      10
+    )
+
+    const result = await scanRemoteAiVaultSessions({
+      provider,
+      executionHostId: 'ssh:dev-box',
+      remoteHome: '/home/ada',
+      hostPlatform: getRemoteHostPlatform('linux-x64'),
+      limit: 1,
+      scopePaths: ['/home/ada/repo']
+    })
+
+    expect(result.issues).toEqual([])
+    expect(result.sessions.map((session) => session.sessionId)).toEqual([
+      'other-session',
+      'cursor-scoped'
+    ])
+    expect(result.sessions[1]?.cwd).toBeNull()
+  })
+
   it('keeps looking past newer out-of-scope candidates during scoped backfill', async () => {
     const provider = new MemoryRemoteProvider()
     for (const [sessionId, mtimeMs, hour] of [

--- a/src/main/ai-vault/remote-session-scanner.ts
+++ b/src/main/ai-vault/remote-session-scanner.ts
@@ -3,7 +3,7 @@ import type {
   AiVaultScanIssue,
   AiVaultSession
 } from '../../shared/ai-vault-types'
-import { isPathInsideOrEqual } from '../../shared/cross-platform-path'
+import { isAiVaultSessionInWorkspace } from '../../shared/ai-vault-session-filters'
 import type { ExecutionHostId } from '../../shared/execution-host'
 import { setImmediate as yieldToEventLoop } from 'node:timers/promises'
 import type { RemoteHostPlatform } from '../ssh/ssh-remote-platform'
@@ -269,8 +269,7 @@ function mergeRemoteSessions(
 }
 
 function isRemoteSessionInScope(session: AiVaultSession, scopePaths: readonly string[]): boolean {
-  const cwd = session.cwd
-  return Boolean(cwd && scopePaths.some((scopePath) => isPathInsideOrEqual(scopePath, cwd)))
+  return scopePaths.some((scopePath) => isAiVaultSessionInWorkspace(session, scopePath))
 }
 
 function normalizeRemoteScopePaths(scopePaths: readonly string[]): string[] {

--- a/src/main/ai-vault/session-scanner-cursor-parser.test.ts
+++ b/src/main/ai-vault/session-scanner-cursor-parser.test.ts
@@ -2,6 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
+import { cursorWorkspaceSlug } from '../../shared/cursor-workspace-slug'
 import { folderLabel, groupAiVaultSessions } from '../../shared/ai-vault-session-filters'
 import { parseCursorSessionContent, parseCursorSessionFile } from './session-scanner-cursor-parser'
 import { resetCursorTrustedCwdCacheForTests } from './session-scanner-cursor-project-cwd'
@@ -32,15 +33,18 @@ const jsonl = [
 ].join('\n')
 
 describe('parseCursorSessionFile cwd attribution', () => {
-  it('sets cwd from an existing workspace decoded from the Cursor project slug', async () => {
+  it('sets cwd from a matching workspace trust marker', async () => {
     const root = mkdtempSync(join(tmpdir(), 'orca-cursor-parse-'))
     tempDirs.push(root)
-    const workspace = join(tmpdir(), 'orcacwdparseopc')
+    const workspace = join(root, 'orcacwdparseopc')
     mkdirSync(workspace, { recursive: true })
-    tempDirs.push(workspace)
-    const slug = workspace.replace(/^[\\/]+/, '').replace(/[\\/:*?"<>|]+/g, '-')
+    const slug = cursorWorkspaceSlug(workspace)
     const transcripts = join(root, '.cursor', 'projects', slug, 'agent-transcripts')
     mkdirSync(transcripts, { recursive: true })
+    writeFileSync(
+      join(root, '.cursor', 'projects', slug, '.workspace-trusted'),
+      JSON.stringify({ workspacePath: workspace })
+    )
     const filePath = join(transcripts, 'cursor-session.jsonl')
     writeFileSync(filePath, jsonl)
 

--- a/src/main/ai-vault/session-scanner-cursor-parser.test.ts
+++ b/src/main/ai-vault/session-scanner-cursor-parser.test.ts
@@ -1,0 +1,70 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { folderLabel, groupAiVaultSessions } from '../../shared/ai-vault-session-filters'
+import { parseCursorSessionContent, parseCursorSessionFile } from './session-scanner-cursor-parser'
+import { resetCursorTrustedCwdCacheForTests } from './session-scanner-cursor-project-cwd'
+
+const tempDirs: string[] = []
+
+afterEach(() => {
+  resetCursorTrustedCwdCacheForTests()
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop()
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  }
+})
+
+const jsonl = [
+  JSON.stringify({
+    role: 'user',
+    message: { content: [{ type: 'text', text: 'Hello' }] },
+    timestamp: '2026-08-12T00:00:00.000Z'
+  }),
+  JSON.stringify({
+    role: 'assistant',
+    message: { content: [{ type: 'text', text: 'Hi' }] },
+    timestamp: '2026-08-12T00:00:01.000Z'
+  })
+].join('\n')
+
+describe('parseCursorSessionFile cwd attribution', () => {
+  it('sets cwd from an existing workspace decoded from the Cursor project slug', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-cursor-parse-'))
+    tempDirs.push(root)
+    const workspace = join(tmpdir(), 'orcacwdparseopc')
+    mkdirSync(workspace, { recursive: true })
+    tempDirs.push(workspace)
+    const slug = workspace.replace(/^[\\/]+/, '').replace(/[\\/:*?"<>|]+/g, '-')
+    const transcripts = join(root, '.cursor', 'projects', slug, 'agent-transcripts')
+    mkdirSync(transcripts, { recursive: true })
+    const filePath = join(transcripts, 'cursor-session.jsonl')
+    writeFileSync(filePath, jsonl)
+
+    const session = await parseCursorSessionFile({ path: filePath, mtimeMs: 1, modifiedAt: '' })
+    expect(session?.cwd).toBe(workspace)
+    expect(session?.sessionId).toBe('cursor-session')
+    expect(
+      groupAiVaultSessions(session ? [session] : [], 'folder').map((group) => group.label)
+    ).toEqual([folderLabel(workspace)])
+  })
+})
+
+describe('parseCursorSessionContent cwd attribution', () => {
+  it('does not invent a remote cwd from a lossy slug or the local filesystem', async () => {
+    const session = await parseCursorSessionContent(
+      {
+        path: 'C:\\Users\\u\\.cursor\\projects\\c-Dev-simulations-opc\\agent-transcripts\\83e98eef-916b-4d99-95bf-bc66fab9741e.jsonl',
+        mtimeMs: 1,
+        modifiedAt: ''
+      },
+      jsonl,
+      'win32'
+    )
+    expect(session?.cwd).toBeNull()
+    expect(session?.sessionId).toBe('83e98eef-916b-4d99-95bf-bc66fab9741e')
+  })
+})

--- a/src/main/ai-vault/session-scanner-cursor-parser.ts
+++ b/src/main/ai-vault/session-scanner-cursor-parser.ts
@@ -15,6 +15,7 @@ import {
   sessionIdFromFileName,
   updateTimeline
 } from './session-scanner-accumulator'
+import { resolveCursorTranscriptCwd } from './session-scanner-cursor-project-cwd'
 import {
   asRecord,
   extractContentText,
@@ -36,7 +37,7 @@ export async function parseCursorSessionFile(
     input: openTranscriptReadStream(file.path, { encoding: 'utf-8' }, 'scan'),
     crlfDelay: Infinity
   })
-  return parseCursorSessionLines({ file, lines, platform })
+  return parseCursorSessionLines({ file, lines, platform, readTrustFile: true })
 }
 
 export async function parseCursorSessionContent(
@@ -50,7 +51,8 @@ export async function parseCursorSessionContent(
     file,
     lines: remoteSessionContentLines(content, signal),
     platform,
-    options
+    options,
+    readTrustFile: false
   })
 }
 
@@ -75,11 +77,20 @@ function consumeCursorRecordLine(accumulator: SessionAccumulator, line: string):
   }
 }
 
-export function createCursorSessionResumeState(file: FileWithMtime): ResumableSessionParseState {
-  return accumulatorFoldResumeState(
-    createAccumulator({ agent: 'cursor', file, sessionId: sessionIdFromFileName(file.path) }),
-    consumeCursorRecordLine
-  )
+export function createCursorSessionResumeState(
+  file: FileWithMtime,
+  options: { readTrustFile?: boolean } = {}
+): ResumableSessionParseState {
+  const accumulator = createAccumulator({
+    agent: 'cursor',
+    file,
+    sessionId: sessionIdFromFileName(file.path)
+  })
+  // Why: Cursor JSONL has no cwd field. Legacy buckets encode the workspace
+  // only as ~/.cursor/projects/<slug>/…; without this, sessions group under
+  // "Unknown location" and drop out of Workspace scope (STA-3959).
+  accumulator.cwd = resolveCursorTranscriptCwd(file.path, options)
+  return accumulatorFoldResumeState(accumulator, consumeCursorRecordLine)
 }
 
 async function parseCursorSessionLines(args: {
@@ -87,8 +98,9 @@ async function parseCursorSessionLines(args: {
   lines: AsyncIterable<string> | Iterable<string>
   platform: NodeJS.Platform
   options?: ParserSessionOptions
+  readTrustFile?: boolean
 }): Promise<AiVaultSession | null> {
-  const state = createCursorSessionResumeState(args.file)
+  const state = createCursorSessionResumeState(args.file, { readTrustFile: args.readTrustFile })
   for await (const line of args.lines) {
     state.consumeLine(line)
   }

--- a/src/main/ai-vault/session-scanner-cursor-project-cwd.test.ts
+++ b/src/main/ai-vault/session-scanner-cursor-project-cwd.test.ts
@@ -1,0 +1,146 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { cursorWorkspaceSlug } from '../../shared/cursor-workspace-slug'
+import {
+  cursorProjectDirFromTranscriptPath,
+  resetCursorTrustedCwdCacheForTests,
+  resolveCursorTranscriptCwd
+} from './session-scanner-cursor-project-cwd'
+
+const tempDirs: string[] = []
+
+afterEach(() => {
+  resetCursorTrustedCwdCacheForTests()
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop()
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  }
+})
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'orca-cursor-cwd-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+describe('cursorProjectDirFromTranscriptPath', () => {
+  it('returns the projects/<slug> dir only for Cursor transcript layouts', () => {
+    expect(
+      cursorProjectDirFromTranscriptPath(
+        '/home/u/.cursor/projects/Users-u-repo/agent-transcripts/sid/sid.jsonl'
+      )
+    ).toBe('/home/u/.cursor/projects/Users-u-repo')
+    expect(
+      cursorProjectDirFromTranscriptPath(
+        'C:\\Users\\u\\.cursor\\projects\\c-Dev-simulations-opc\\agent-transcripts\\sid.jsonl'
+      )
+    ).toBe('C:\\Users\\u\\.cursor\\projects\\c-Dev-simulations-opc')
+    expect(
+      cursorProjectDirFromTranscriptPath('/tmp/unrelated/agent-transcripts/sid.jsonl')
+    ).toBeNull()
+  })
+})
+
+describe('resolveCursorTranscriptCwd', () => {
+  it('prefers .workspace-trusted workspacePath over slug decode', () => {
+    const root = tempDir()
+    const projectDir = join(root, '.cursor', 'projects', 'c-Dev-simulations-opc')
+    const transcripts = join(projectDir, 'agent-transcripts', 'sid')
+    mkdirSync(transcripts, { recursive: true })
+    writeFileSync(
+      join(projectDir, '.workspace-trusted'),
+      JSON.stringify({
+        trustedAt: '2026-08-12T00:00:00.000Z',
+        workspacePath: 'C:\\Dev\\simulations\\opc'
+      })
+    )
+    expect(resolveCursorTranscriptCwd(join(transcripts, 'sid.jsonl'))).toBe(
+      'C:\\Dev\\simulations\\opc'
+    )
+  })
+
+  it('reads the drive-letter sibling trust file Cursor and Orca can split', () => {
+    const root = tempDir()
+    const cursorDir = join(root, '.cursor', 'projects', 'c-Dev-simulations-opc')
+    const orcaDir = join(root, '.cursor', 'projects', 'C-Dev-simulations-opc')
+    mkdirSync(join(cursorDir, 'agent-transcripts'), { recursive: true })
+    mkdirSync(orcaDir, { recursive: true })
+    writeFileSync(
+      join(orcaDir, '.workspace-trusted'),
+      JSON.stringify({ workspacePath: 'C:\\Dev\\simulations\\opc' })
+    )
+    expect(resolveCursorTranscriptCwd(join(cursorDir, 'agent-transcripts', 'sid.jsonl'))).toBe(
+      'C:\\Dev\\simulations\\opc'
+    )
+  })
+
+  it('publishes a decoded slug only when that workspace path exists', () => {
+    const workspace = join(tmpdir(), 'orcacwdopc')
+    mkdirSync(workspace, { recursive: true })
+    tempDirs.push(workspace)
+    const root = tempDir()
+    const projectDir = join(root, '.cursor', 'projects', cursorWorkspaceSlug(workspace))
+    mkdirSync(join(projectDir, 'agent-transcripts'), { recursive: true })
+    expect(resolveCursorTranscriptCwd(join(projectDir, 'agent-transcripts', 'session.jsonl'))).toBe(
+      workspace
+    )
+  })
+
+  it('does not invent a cwd for a hyphenated folder slug whose decode does not exist', () => {
+    const root = tempDir()
+    const projectDir = join(
+      root,
+      '.cursor',
+      'projects',
+      'c-Users-neil-orca-workspaces-orca-pr-13935-internal-review'
+    )
+    mkdirSync(join(projectDir, 'agent-transcripts'), { recursive: true })
+    expect(
+      resolveCursorTranscriptCwd(join(projectDir, 'agent-transcripts', 'session.jsonl'))
+    ).toBeNull()
+  })
+
+  it('does not read a trust file or invent cwd for a WSL UNC transcript path', () => {
+    expect(
+      resolveCursorTranscriptCwd(
+        '\\\\wsl.localhost\\Ubuntu\\home\\ada\\.cursor\\projects\\home-ada-repo\\agent-transcripts\\sid.jsonl'
+      )
+    ).toBeNull()
+  })
+
+  it('picks up a trust file written after an earlier miss once the scan cache resets', () => {
+    const root = tempDir()
+    const projectDir = join(root, '.cursor', 'projects', 'c-Dev-simulations-opc')
+    const filePath = join(projectDir, 'agent-transcripts', 'sid.jsonl')
+    mkdirSync(join(projectDir, 'agent-transcripts'), { recursive: true })
+    expect(resolveCursorTranscriptCwd(filePath)).toBeNull()
+    writeFileSync(
+      join(projectDir, '.workspace-trusted'),
+      JSON.stringify({ workspacePath: 'C:\\Dev\\simulations\\opc' })
+    )
+    expect(resolveCursorTranscriptCwd(filePath)).toBeNull()
+    resetCursorTrustedCwdCacheForTests()
+    expect(resolveCursorTranscriptCwd(filePath)).toBe('C:\\Dev\\simulations\\opc')
+  })
+
+  it('skips the local trust file when remote content is parsed', () => {
+    const root = tempDir()
+    const projectDir = join(root, '.cursor', 'projects', 'c-Dev-simulations-opc')
+    const transcripts = join(projectDir, 'agent-transcripts')
+    mkdirSync(transcripts, { recursive: true })
+    writeFileSync(
+      join(projectDir, '.workspace-trusted'),
+      JSON.stringify({ workspacePath: 'C:\\Dev\\simulations\\my-project' })
+    )
+    expect(resolveCursorTranscriptCwd(join(transcripts, 'sid.jsonl'))).toBe(
+      'C:\\Dev\\simulations\\my-project'
+    )
+    expect(
+      resolveCursorTranscriptCwd(join(transcripts, 'sid.jsonl'), { readTrustFile: false })
+    ).toBeNull()
+  })
+})

--- a/src/main/ai-vault/session-scanner-cursor-project-cwd.test.ts
+++ b/src/main/ai-vault/session-scanner-cursor-project-cwd.test.ts
@@ -1,7 +1,8 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import type * as NodeFs from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { cursorWorkspaceSlug } from '../../shared/cursor-workspace-slug'
 import {
   cursorProjectDirFromTranscriptPath,
@@ -10,6 +11,20 @@ import {
 } from './session-scanner-cursor-project-cwd'
 
 const tempDirs: string[] = []
+const fsMocks = vi.hoisted(() => ({ existsSync: vi.fn(), readFileSync: vi.fn() }))
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFs>()
+  fsMocks.existsSync.mockImplementation(actual.existsSync)
+  fsMocks.readFileSync.mockImplementation(actual.readFileSync)
+  return { ...actual, existsSync: fsMocks.existsSync, readFileSync: fsMocks.readFileSync }
+})
+
+beforeEach(async () => {
+  const actual = await vi.importActual<typeof NodeFs>('node:fs')
+  fsMocks.existsSync.mockReset().mockImplementation(actual.existsSync)
+  fsMocks.readFileSync.mockReset().mockImplementation(actual.readFileSync)
+})
 
 afterEach(() => {
   resetCursorTrustedCwdCacheForTests()
@@ -40,57 +55,123 @@ describe('cursorProjectDirFromTranscriptPath', () => {
       )
     ).toBe('C:\\Users\\u\\.cursor\\projects\\c-Dev-simulations-opc')
     expect(
+      cursorProjectDirFromTranscriptPath(
+        '\\\\server\\share\\Users\\u\\.cursor\\projects\\c-repo\\agent-transcripts\\sid.jsonl'
+      )
+    ).toBe('\\\\server\\share\\Users\\u\\.cursor\\projects\\c-repo')
+    expect(
+      cursorProjectDirFromTranscriptPath(
+        'C:\\Users/u/.cursor/projects/c-repo\\agent-transcripts/sid.jsonl'
+      )
+    ).toBe('C:\\Users\\u\\.cursor\\projects\\c-repo')
+    expect(
       cursorProjectDirFromTranscriptPath('/tmp/unrelated/agent-transcripts/sid.jsonl')
     ).toBeNull()
   })
 })
 
 describe('resolveCursorTranscriptCwd', () => {
-  it('prefers .workspace-trusted workspacePath over slug decode', () => {
+  it('uses a matching absolute .workspace-trusted workspacePath', () => {
     const root = tempDir()
-    const projectDir = join(root, '.cursor', 'projects', 'c-Dev-simulations-opc')
+    const workspace = join(root, 'simulations', 'opc')
+    const projectDir = join(root, '.cursor', 'projects', cursorWorkspaceSlug(workspace))
     const transcripts = join(projectDir, 'agent-transcripts', 'sid')
     mkdirSync(transcripts, { recursive: true })
+    mkdirSync(workspace, { recursive: true })
     writeFileSync(
       join(projectDir, '.workspace-trusted'),
       JSON.stringify({
         trustedAt: '2026-08-12T00:00:00.000Z',
-        workspacePath: 'C:\\Dev\\simulations\\opc'
+        workspacePath: workspace
       })
     )
-    expect(resolveCursorTranscriptCwd(join(transcripts, 'sid.jsonl'))).toBe(
-      'C:\\Dev\\simulations\\opc'
-    )
+    expect(resolveCursorTranscriptCwd(join(transcripts, 'sid.jsonl'))).toBe(workspace)
   })
 
   it('reads the drive-letter sibling trust file Cursor and Orca can split', () => {
-    const root = tempDir()
-    const cursorDir = join(root, '.cursor', 'projects', 'c-Dev-simulations-opc')
-    const orcaDir = join(root, '.cursor', 'projects', 'C-Dev-simulations-opc')
-    mkdirSync(join(cursorDir, 'agent-transcripts'), { recursive: true })
-    mkdirSync(orcaDir, { recursive: true })
-    writeFileSync(
-      join(orcaDir, '.workspace-trusted'),
+    const filePath =
+      'C:\\Users\\ada\\.cursor\\projects\\c-Dev-simulations-opc\\agent-transcripts\\sid.jsonl'
+    fsMocks.readFileSync.mockImplementationOnce(() => {
+      throw new Error('missing primary marker')
+    })
+    fsMocks.readFileSync.mockReturnValueOnce(
       JSON.stringify({ workspacePath: 'C:\\Dev\\simulations\\opc' })
     )
-    expect(resolveCursorTranscriptCwd(join(cursorDir, 'agent-transcripts', 'sid.jsonl'))).toBe(
-      'C:\\Dev\\simulations\\opc'
-    )
+
+    expect(resolveCursorTranscriptCwd(filePath)).toBe('C:\\Dev\\simulations\\opc')
+    expect(fsMocks.readFileSync.mock.calls.map(([path]) => String(path))).toEqual([
+      'C:\\Users\\ada\\.cursor\\projects\\c-Dev-simulations-opc\\.workspace-trusted',
+      'C:\\Users\\ada\\.cursor\\projects\\C-Dev-simulations-opc\\.workspace-trusted'
+    ])
   })
 
-  it('publishes a decoded slug only when that workspace path exists', () => {
-    const workspace = join(tmpdir(), 'orcacwdopc')
+  it('does not publish a decoded cwd when two existing paths share a slug', () => {
+    const collisionRoot = join(
+      tmpdir(),
+      `orcacwdcollision${process.pid}${Math.random().toString(16).slice(2)}`
+    )
+    const workspace = join(collisionRoot, 'team-repo')
+    const decoded = join(collisionRoot, 'team', 'repo')
     mkdirSync(workspace, { recursive: true })
-    tempDirs.push(workspace)
+    mkdirSync(decoded, { recursive: true })
+    tempDirs.push(collisionRoot)
     const root = tempDir()
     const projectDir = join(root, '.cursor', 'projects', cursorWorkspaceSlug(workspace))
     mkdirSync(join(projectDir, 'agent-transcripts'), { recursive: true })
-    expect(resolveCursorTranscriptCwd(join(projectDir, 'agent-transcripts', 'session.jsonl'))).toBe(
-      workspace
-    )
+    expect(
+      resolveCursorTranscriptCwd(join(projectDir, 'agent-transcripts', 'session.jsonl'))
+    ).toBeNull()
   })
 
-  it('does not invent a cwd for a hyphenated folder slug whose decode does not exist', () => {
+  it.each([
+    ['a POSIX lookalike', '/c/repo'],
+    ['the wrong drive', 'D:\\repo'],
+    ['a different workspace on the same drive', 'C:\\other']
+  ])('rejects a drive-case sibling marker for %s', (_case, workspacePath) => {
+    const filePath = 'C:\\Users\\ada\\.cursor\\projects\\c-repo\\agent-transcripts\\sid.jsonl'
+    fsMocks.readFileSync.mockImplementationOnce(() => {
+      throw new Error('missing primary marker')
+    })
+    fsMocks.readFileSync.mockReturnValueOnce(JSON.stringify({ workspacePath }))
+
+    expect(resolveCursorTranscriptCwd(filePath)).toBeNull()
+    expect(fsMocks.readFileSync.mock.calls.map(([path]) => String(path))).toEqual([
+      'C:\\Users\\ada\\.cursor\\projects\\c-repo\\.workspace-trusted',
+      'C:\\Users\\ada\\.cursor\\projects\\C-repo\\.workspace-trusted'
+    ])
+  })
+
+  it('does not inspect a drive-case sibling for a POSIX project bucket', () => {
+    const root = tempDir()
+    const cursorDir = join(root, '.cursor', 'projects', 'c-repo')
+    mkdirSync(join(cursorDir, 'agent-transcripts'), { recursive: true })
+    fsMocks.readFileSync.mockImplementationOnce(() => {
+      throw new Error('missing primary marker')
+    })
+    fsMocks.readFileSync.mockReturnValueOnce(JSON.stringify({ workspacePath: '/c/repo' }))
+
+    fsMocks.readFileSync.mockClear()
+    expect(resolveCursorTranscriptCwd(join(cursorDir, 'agent-transcripts', 'sid.jsonl'))).toBeNull()
+    expect(fsMocks.readFileSync.mock.calls.map(([path]) => String(path))).toEqual([
+      join(cursorDir, '.workspace-trusted')
+    ])
+  })
+
+  it.each([
+    ['a stale absolute path', '/other/repo'],
+    ['a relative path', 'repo']
+  ])('rejects a primary marker with %s', (_case, workspacePath) => {
+    const root = tempDir()
+    const projectDir = join(root, '.cursor', 'projects', 'home-ada-repo')
+    mkdirSync(join(projectDir, 'agent-transcripts'), { recursive: true })
+    writeFileSync(join(projectDir, '.workspace-trusted'), JSON.stringify({ workspacePath }))
+
+    expect(
+      resolveCursorTranscriptCwd(join(projectDir, 'agent-transcripts', 'sid.jsonl'))
+    ).toBeNull()
+  })
+
+  it('does not invent a cwd for a hyphenated folder slug without trusted metadata', () => {
     const root = tempDir()
     const projectDir = join(
       root,
@@ -105,40 +186,46 @@ describe('resolveCursorTranscriptCwd', () => {
   })
 
   it('does not read a trust file or invent cwd for a WSL UNC transcript path', () => {
+    fsMocks.existsSync.mockClear()
+    fsMocks.readFileSync.mockClear()
     expect(
       resolveCursorTranscriptCwd(
         '\\\\wsl.localhost\\Ubuntu\\home\\ada\\.cursor\\projects\\home-ada-repo\\agent-transcripts\\sid.jsonl'
       )
     ).toBeNull()
+    expect(fsMocks.existsSync).not.toHaveBeenCalled()
+    expect(fsMocks.readFileSync).not.toHaveBeenCalled()
   })
 
   it('picks up a trust file written after an earlier miss once the scan cache resets', () => {
     const root = tempDir()
-    const projectDir = join(root, '.cursor', 'projects', 'c-Dev-simulations-opc')
+    const workspace = join(root, 'simulations', 'opc')
+    const projectDir = join(root, '.cursor', 'projects', cursorWorkspaceSlug(workspace))
     const filePath = join(projectDir, 'agent-transcripts', 'sid.jsonl')
     mkdirSync(join(projectDir, 'agent-transcripts'), { recursive: true })
+    mkdirSync(workspace, { recursive: true })
     expect(resolveCursorTranscriptCwd(filePath)).toBeNull()
     writeFileSync(
       join(projectDir, '.workspace-trusted'),
-      JSON.stringify({ workspacePath: 'C:\\Dev\\simulations\\opc' })
+      JSON.stringify({ workspacePath: workspace })
     )
     expect(resolveCursorTranscriptCwd(filePath)).toBeNull()
     resetCursorTrustedCwdCacheForTests()
-    expect(resolveCursorTranscriptCwd(filePath)).toBe('C:\\Dev\\simulations\\opc')
+    expect(resolveCursorTranscriptCwd(filePath)).toBe(workspace)
   })
 
   it('skips the local trust file when remote content is parsed', () => {
     const root = tempDir()
-    const projectDir = join(root, '.cursor', 'projects', 'c-Dev-simulations-opc')
+    const workspace = join(root, 'simulations', 'opc')
+    const projectDir = join(root, '.cursor', 'projects', cursorWorkspaceSlug(workspace))
     const transcripts = join(projectDir, 'agent-transcripts')
     mkdirSync(transcripts, { recursive: true })
+    mkdirSync(workspace, { recursive: true })
     writeFileSync(
       join(projectDir, '.workspace-trusted'),
-      JSON.stringify({ workspacePath: 'C:\\Dev\\simulations\\my-project' })
+      JSON.stringify({ workspacePath: workspace })
     )
-    expect(resolveCursorTranscriptCwd(join(transcripts, 'sid.jsonl'))).toBe(
-      'C:\\Dev\\simulations\\my-project'
-    )
+    expect(resolveCursorTranscriptCwd(join(transcripts, 'sid.jsonl'))).toBe(workspace)
     expect(
       resolveCursorTranscriptCwd(join(transcripts, 'sid.jsonl'), { readTrustFile: false })
     ).toBeNull()

--- a/src/main/ai-vault/session-scanner-cursor-project-cwd.ts
+++ b/src/main/ai-vault/session-scanner-cursor-project-cwd.ts
@@ -1,0 +1,124 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import type { AiVaultAgent, AiVaultSession } from '../../shared/ai-vault-types'
+import {
+  cursorProjectSlugFromTranscriptPath,
+  decodeCursorProjectSlug
+} from '../../shared/cursor-workspace-slug'
+import { isWslUncPath } from '../../shared/wsl-paths'
+import { extractString, parseJsonObject } from './session-scanner-values'
+
+const TRUSTED_CWD_CACHE_MAX = 2048
+const trustedCwdCache = new Map<string, string | null>()
+
+export function resetCursorTrustedCwdCache(): void {
+  trustedCwdCache.clear()
+}
+
+export function resetCursorTrustedCwdCacheForTests(): void {
+  resetCursorTrustedCwdCache()
+}
+
+export function refreshCachedCursorCwd(session: AiVaultSession): AiVaultSession {
+  const cwd = resolveCursorTranscriptCwd(session.filePath)
+  return cwd === session.cwd ? session : { ...session, cwd }
+}
+
+export function maybeRefreshCachedCursorCwd(
+  agent: AiVaultAgent,
+  session: AiVaultSession | null
+): AiVaultSession | null {
+  return agent === 'cursor' && session ? refreshCachedCursorCwd(session) : session
+}
+
+export function resolveCursorTranscriptCwd(
+  filePath: string,
+  options: { readTrustFile?: boolean } = {}
+): string | null {
+  const slug = cursorProjectSlugFromTranscriptPath(filePath)
+  if (!slug) {
+    return null
+  }
+  const projectDir = cursorProjectDirFromTranscriptPath(filePath)
+  // Why: never raw-read WSL UNC 9P or a remote host path as if it were local.
+  if (options.readTrustFile !== false && projectDir && !isWslUncPath(filePath)) {
+    const trusted = readCachedTrustedWorkspacePath(projectDir)
+    if (trusted) {
+      return trusted
+    }
+  }
+  // Why: inverse slug decode is lossy for hyphenated folder names. Only publish
+  // it as cwd when the reconstructed path actually exists on this host.
+  if (options.readTrustFile === false || isWslUncPath(filePath)) {
+    return null
+  }
+  const decoded = decodeCursorProjectSlug(slug)
+  return decoded && existsSync(decoded) ? decoded : null
+}
+
+export function cursorProjectDirFromTranscriptPath(filePath: string): string | null {
+  if (!cursorProjectSlugFromTranscriptPath(filePath)) {
+    return null
+  }
+  const segments = filePath.split(/[\\/]+/).filter(Boolean)
+  const marker = segments.lastIndexOf('agent-transcripts')
+  return joinPathSegments(segments.slice(0, marker), filePath)
+}
+
+function readCachedTrustedWorkspacePath(projectDir: string): string | null {
+  if (trustedCwdCache.has(projectDir)) {
+    return trustedCwdCache.get(projectDir) ?? null
+  }
+  const cwd =
+    readCursorWorkspaceTrustedPath(projectDir) ??
+    readCursorWorkspaceTrustedPath(driveCaseSiblingProjectDir(projectDir))
+  if (trustedCwdCache.size >= TRUSTED_CWD_CACHE_MAX) {
+    const oldest = trustedCwdCache.keys().next()
+    if (!oldest.done) {
+      trustedCwdCache.delete(oldest.value)
+    }
+  }
+  trustedCwdCache.set(projectDir, cwd)
+  return cwd
+}
+
+function readCursorWorkspaceTrustedPath(projectDir: string | null): string | null {
+  if (!projectDir) {
+    return null
+  }
+  try {
+    const record = parseJsonObject(readFileSync(join(projectDir, '.workspace-trusted'), 'utf-8'))
+    return extractString(record?.workspacePath)?.trim() || null
+  } catch {
+    return null
+  }
+}
+
+function driveCaseSiblingProjectDir(projectDir: string): string | null {
+  const segments = projectDir.split(/[\\/]+/).filter(Boolean)
+  const slug = segments.at(-1)
+  if (!slug) {
+    return null
+  }
+  const flipped = slug.replace(/^([A-Za-z])-/, (_, drive: string) => {
+    const next = drive === drive.toLowerCase() ? drive.toUpperCase() : drive.toLowerCase()
+    return `${next}-`
+  })
+  if (flipped === slug) {
+    return null
+  }
+  segments[segments.length - 1] = flipped
+  return joinPathSegments(segments, projectDir)
+}
+
+function joinPathSegments(segments: string[], originalPath: string): string {
+  if (segments.length === 0) {
+    return originalPath.startsWith('/') ? '/' : ''
+  }
+  const useBackslash = originalPath.includes('\\') && !originalPath.includes('/')
+  const joined = segments.join(useBackslash ? '\\' : '/')
+  if (originalPath.startsWith('/') && !/^[A-Za-z]:/.test(segments[0] ?? '')) {
+    return `/${joined}`
+  }
+  return joined
+}

--- a/src/main/ai-vault/session-scanner-cursor-project-cwd.ts
+++ b/src/main/ai-vault/session-scanner-cursor-project-cwd.ts
@@ -1,10 +1,11 @@
-import { existsSync, readFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { readFileSync } from 'node:fs'
+import { posix, win32 } from 'node:path'
 import type { AiVaultAgent, AiVaultSession } from '../../shared/ai-vault-types'
 import {
   cursorProjectSlugFromTranscriptPath,
-  decodeCursorProjectSlug
+  isCursorTranscriptInWorkspace
 } from '../../shared/cursor-workspace-slug'
+import { isRuntimePathAbsolute, isWindowsAbsolutePathLike } from '../../shared/cross-platform-path'
 import { isWslUncPath } from '../../shared/wsl-paths'
 import { extractString, parseJsonObject } from './session-scanner-values'
 
@@ -39,39 +40,53 @@ export function resolveCursorTranscriptCwd(
   if (!slug) {
     return null
   }
-  const projectDir = cursorProjectDirFromTranscriptPath(filePath)
-  // Why: never raw-read WSL UNC 9P or a remote host path as if it were local.
-  if (options.readTrustFile !== false && projectDir && !isWslUncPath(filePath)) {
-    const trusted = readCachedTrustedWorkspacePath(projectDir)
-    if (trusted) {
-      return trusted
-    }
-  }
-  // Why: inverse slug decode is lossy for hyphenated folder names. Only publish
-  // it as cwd when the reconstructed path actually exists on this host.
   if (options.readTrustFile === false || isWslUncPath(filePath)) {
     return null
   }
-  const decoded = decodeCursorProjectSlug(slug)
-  return decoded && existsSync(decoded) ? decoded : null
+  const projectDir = cursorProjectDirFromTranscriptPath(filePath)
+  if (!projectDir) {
+    return null
+  }
+  return readCachedTrustedWorkspacePath(projectDir, filePath, slug)
 }
 
 export function cursorProjectDirFromTranscriptPath(filePath: string): string | null {
   if (!cursorProjectSlugFromTranscriptPath(filePath)) {
     return null
   }
-  const segments = filePath.split(/[\\/]+/).filter(Boolean)
-  const marker = segments.lastIndexOf('agent-transcripts')
-  return joinPathSegments(segments.slice(0, marker), filePath)
+  const pathApi = pathImplementation(filePath)
+  let current = pathApi.normalize(filePath)
+  while (true) {
+    if (pathApi.basename(current) === 'agent-transcripts') {
+      return pathApi.dirname(current)
+    }
+    const parent = pathApi.dirname(current)
+    if (parent === current) {
+      return null
+    }
+    current = parent
+  }
 }
 
-function readCachedTrustedWorkspacePath(projectDir: string): string | null {
+function readCachedTrustedWorkspacePath(
+  projectDir: string,
+  filePath: string,
+  slug: string
+): string | null {
   if (trustedCwdCache.has(projectDir)) {
     return trustedCwdCache.get(projectDir) ?? null
   }
-  const cwd =
-    readCursorWorkspaceTrustedPath(projectDir) ??
-    readCursorWorkspaceTrustedPath(driveCaseSiblingProjectDir(projectDir))
+  const primary = readCursorWorkspaceTrustedPath(projectDir)
+  let cwd = isTrustedWorkspacePath(primary, projectDir, filePath) ? primary : null
+  if (!cwd) {
+    const siblingProjectDir = driveCaseSiblingProjectDir(projectDir)
+    const siblingWorkspacePath = siblingProjectDir
+      ? readCursorWorkspaceTrustedPath(siblingProjectDir)
+      : null
+    cwd = isTrustedDriveSiblingWorkspacePath(siblingWorkspacePath, projectDir, filePath, slug)
+      ? siblingWorkspacePath
+      : null
+  }
   if (trustedCwdCache.size >= TRUSTED_CWD_CACHE_MAX) {
     const oldest = trustedCwdCache.keys().next()
     if (!oldest.done) {
@@ -87,7 +102,9 @@ function readCursorWorkspaceTrustedPath(projectDir: string | null): string | nul
     return null
   }
   try {
-    const record = parseJsonObject(readFileSync(join(projectDir, '.workspace-trusted'), 'utf-8'))
+    const record = parseJsonObject(
+      readFileSync(pathImplementation(projectDir).join(projectDir, '.workspace-trusted'), 'utf-8')
+    )
     return extractString(record?.workspacePath)?.trim() || null
   } catch {
     return null
@@ -95,30 +112,55 @@ function readCursorWorkspaceTrustedPath(projectDir: string | null): string | nul
 }
 
 function driveCaseSiblingProjectDir(projectDir: string): string | null {
-  const segments = projectDir.split(/[\\/]+/).filter(Boolean)
-  const slug = segments.at(-1)
-  if (!slug) {
+  if (!isWindowsAbsolutePathLike(projectDir) || isWslUncPath(projectDir)) {
     return null
   }
-  const flipped = slug.replace(/^([A-Za-z])-/, (_, drive: string) => {
-    const next = drive === drive.toLowerCase() ? drive.toUpperCase() : drive.toLowerCase()
-    return `${next}-`
-  })
-  if (flipped === slug) {
+  const slug = win32.basename(projectDir)
+  const driveMatch = slug.match(/^([A-Za-z])-/)
+  if (!driveMatch) {
     return null
   }
-  segments[segments.length - 1] = flipped
-  return joinPathSegments(segments, projectDir)
+  const drive = driveMatch[1]
+  const flippedDrive = drive === drive.toLowerCase() ? drive.toUpperCase() : drive.toLowerCase()
+  return win32.join(win32.dirname(projectDir), `${flippedDrive}${slug.slice(1)}`)
 }
 
-function joinPathSegments(segments: string[], originalPath: string): string {
-  if (segments.length === 0) {
-    return originalPath.startsWith('/') ? '/' : ''
+function isTrustedWorkspacePath(
+  workspacePath: string | null,
+  projectDir: string,
+  filePath: string
+): workspacePath is string {
+  if (!workspacePath) {
+    return false
   }
-  const useBackslash = originalPath.includes('\\') && !originalPath.includes('/')
-  const joined = segments.join(useBackslash ? '\\' : '/')
-  if (originalPath.startsWith('/') && !/^[A-Za-z]:/.test(segments[0] ?? '')) {
-    return `/${joined}`
+  const projectIsWindows = isWindowsAbsolutePathLike(projectDir)
+  const workspaceIsWindows = isWindowsAbsolutePathLike(workspacePath)
+  if (projectIsWindows !== workspaceIsWindows) {
+    return false
   }
-  return joined
+  const pathFlavor = workspaceIsWindows ? 'windows' : 'posix'
+  return (
+    isRuntimePathAbsolute(workspacePath, pathFlavor) &&
+    isCursorTranscriptInWorkspace(workspacePath, filePath)
+  )
+}
+
+function isTrustedDriveSiblingWorkspacePath(
+  workspacePath: string | null,
+  projectDir: string,
+  filePath: string,
+  slug: string
+): workspacePath is string {
+  if (!isTrustedWorkspacePath(workspacePath, projectDir, filePath)) {
+    return false
+  }
+  const slugDrive = slug.match(/^([A-Za-z])-/)?.[1]
+  const workspaceDrive = workspacePath.match(/^([A-Za-z]):[\\/]/)?.[1]
+  return Boolean(
+    slugDrive && workspaceDrive && slugDrive.toLowerCase() === workspaceDrive.toLowerCase()
+  )
+}
+
+function pathImplementation(value: string): typeof posix {
+  return isWindowsAbsolutePathLike(value) ? win32 : posix
 }

--- a/src/main/ai-vault/session-scanner-fs-import-guard.test.ts
+++ b/src/main/ai-vault/session-scanner-fs-import-guard.test.ts
@@ -28,7 +28,10 @@ const ALLOWLIST = new Set([
   'session-scanner-claude-subagents.ts',
   'session-scanner-omp-subagent-listing.ts',
   // Test-only fixture builder.
-  'session-scanner-test-fixtures.ts'
+  'session-scanner-test-fixtures.ts',
+  // Local ~/.cursor/projects/<slug>/.workspace-trusted only. WSL UNC
+  // transcripts skip this read in resolveCursorTranscriptCwd.
+  'session-scanner-cursor-project-cwd.ts'
 ])
 
 const FS_IMPORT = /import\s+([\s\S]*?)\s+from\s+['"]node:fs(?:\/promises)?['"]/g

--- a/src/main/ai-vault/session-scanner-parse-cache-refresh.ts
+++ b/src/main/ai-vault/session-scanner-parse-cache-refresh.ts
@@ -1,0 +1,36 @@
+import type { AiVaultSession } from '../../shared/ai-vault-types'
+import { refreshCachedCodexTitle } from './session-scanner-codex-cached-title'
+import { refreshCachedCursorCwd } from './session-scanner-cursor-project-cwd'
+import { countOmpSubagentTranscripts } from './session-scanner-omp-subagent-transcripts'
+import { countSubagentTranscripts } from './session-scanner-subagent-transcripts'
+import type { SessionFileCandidate } from './session-scanner-types'
+
+export async function refreshCachedSessionSideChannels(
+  candidate: SessionFileCandidate,
+  session: AiVaultSession
+): Promise<AiVaultSession> {
+  // Why: a zero-turn transcript usually never changes again, but its sibling
+  // subagent dir can gain files after the parent's last write.
+  let next = session
+  if (next.messageCount === 0) {
+    const subagentTranscriptCount =
+      candidate.agent === 'claude'
+        ? await countSubagentTranscripts(candidate.file.path)
+        : candidate.agent === 'omp'
+          ? await countOmpSubagentTranscripts(candidate.file.path)
+          : null
+    if (
+      subagentTranscriptCount !== null &&
+      subagentTranscriptCount !== next.subagentTranscriptCount
+    ) {
+      next = { ...next, subagentTranscriptCount }
+    }
+  }
+  if (candidate.agent === 'codex') {
+    next = await refreshCachedCodexTitle(candidate, next)
+  }
+  if (candidate.agent === 'cursor') {
+    next = refreshCachedCursorCwd(next)
+  }
+  return next
+}

--- a/src/main/ai-vault/session-scanner-parse-cache.test.ts
+++ b/src/main/ai-vault/session-scanner-parse-cache.test.ts
@@ -2,11 +2,13 @@ import { appendFile, mkdir, mkdtemp, rm, stat, writeFile } from 'node:fs/promise
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { cursorWorkspaceSlug } from '../../shared/cursor-workspace-slug'
 import {
   parseAgentSessionFileCached,
   resetSessionParseCacheForTests,
   createSessionParseStats
 } from './session-scanner-parse-cache'
+import { resetCursorTrustedCwdCacheForTests } from './session-scanner-cursor-project-cwd'
 import { parseClaudeSessionFile } from './session-scanner-primary-parsers'
 import type { FileWithMtime, SessionFileCandidate } from './session-scanner-types'
 
@@ -14,6 +16,7 @@ let tempRoots: string[] = []
 
 beforeEach(() => {
   resetSessionParseCacheForTests()
+  resetCursorTrustedCwdCacheForTests()
 })
 
 afterEach(async () => {
@@ -36,6 +39,20 @@ async function claudeCandidate(path: string): Promise<SessionFileCandidate> {
     sizeBytes: fileStat.size
   }
   return { agent: 'claude', file, codexHome: null }
+}
+
+async function cursorCandidate(path: string): Promise<SessionFileCandidate> {
+  const fileStat = await stat(path)
+  return {
+    agent: 'cursor',
+    file: {
+      path,
+      mtimeMs: fileStat.mtimeMs,
+      modifiedAt: fileStat.mtime.toISOString(),
+      sizeBytes: fileStat.size
+    },
+    codexHome: null
+  }
 }
 
 function userRecord(index: number, text: string): string {
@@ -90,6 +107,38 @@ describe('parseAgentSessionFileCached', () => {
     expect(stats.fullParses).toBe(1)
     expect(stats.reused).toBe(1)
     expect(stats.incremental).toBe(0)
+  })
+
+  it('refreshes Cursor cwd when a trust marker appears beside a cached transcript', async () => {
+    const root = await makeTempDir()
+    const workspace = join(root, 'repo')
+    const projectDir = join(root, '.cursor', 'projects', cursorWorkspaceSlug(workspace))
+    const path = join(projectDir, 'agent-transcripts', 'cursor-session.jsonl')
+    await mkdir(join(projectDir, 'agent-transcripts'), { recursive: true })
+    await mkdir(workspace, { recursive: true })
+    await writeFile(
+      path,
+      `${JSON.stringify({
+        role: 'user',
+        timestamp: '2026-08-12T00:00:00.000Z',
+        message: { content: 'cached question' }
+      })}\n`
+    )
+
+    const stats = createSessionParseStats()
+    const candidate = await cursorCandidate(path)
+    const first = await parseAgentSessionFileCached(candidate, process.platform, stats)
+    await writeFile(
+      join(projectDir, '.workspace-trusted'),
+      JSON.stringify({ workspacePath: workspace })
+    )
+    resetCursorTrustedCwdCacheForTests()
+    const second = await parseAgentSessionFileCached(candidate, process.platform, stats)
+
+    expect(first?.cwd).toBeNull()
+    expect(second?.cwd).toBe(workspace)
+    expect(stats.fullParses).toBe(1)
+    expect(stats.reused).toBe(1)
   })
 
   it('incrementally parses appended lines and matches a cold parse exactly', async () => {

--- a/src/main/ai-vault/session-scanner-parse-cache.ts
+++ b/src/main/ai-vault/session-scanner-parse-cache.ts
@@ -12,10 +12,9 @@ import { createClaudeSessionResumeState } from './session-scanner-primary-parser
 import { createGeminiJsonlSessionResumeState } from './session-scanner-gemini-parsers'
 import { createCopilotSessionResumeState } from './session-scanner-copilot-parser'
 import { createCursorSessionResumeState } from './session-scanner-cursor-parser'
-import { countSubagentTranscripts } from './session-scanner-subagent-transcripts'
-import { countOmpSubagentTranscripts } from './session-scanner-omp-subagent-transcripts'
+import { maybeRefreshCachedCursorCwd } from './session-scanner-cursor-project-cwd'
+import { refreshCachedSessionSideChannels } from './session-scanner-parse-cache-refresh'
 import type { ResumableSessionParseState, SessionFileCandidate } from './session-scanner-types'
-import { refreshCachedCodexTitle } from './session-scanner-codex-cached-title'
 
 // Sized past the default recency cap (1000) plus the in-scope cap (2000) so a
 // full steady-state result set stays resident between forced rescans.
@@ -189,27 +188,8 @@ export async function parseAgentSessionFileCached(
     if (stats) {
       stats.reused++
     }
-    // A zero-turn transcript usually never changes again, but its sibling
-    // subagent dir (Claude `<session>/subagents/`, OMP's same-named artifact
-    // dir) can gain files after the parent's last write (a still-running
-    // subagent finishing). The mtime+size key can't see that, so refresh the
-    // cheap directory count on reuse.
-    if (entry.session && entry.session.messageCount === 0) {
-      const subagentTranscriptCount =
-        candidate.agent === 'claude'
-          ? await countSubagentTranscripts(file.path)
-          : candidate.agent === 'omp'
-            ? await countOmpSubagentTranscripts(file.path)
-            : null
-      if (
-        subagentTranscriptCount !== null &&
-        subagentTranscriptCount !== entry.session.subagentTranscriptCount
-      ) {
-        entry.session = { ...entry.session, subagentTranscriptCount }
-      }
-    }
-    if (entry.session && candidate.agent === 'codex') {
-      entry.session = await refreshCachedCodexTitle(candidate, entry.session)
+    if (entry.session) {
+      entry.session = await refreshCachedSessionSideChannels(candidate, entry.session)
     }
     storeEntry(file.path, entry)
     return entry.session
@@ -296,7 +276,10 @@ async function parseResumableCandidate(args: {
     mtimeMs: file.mtimeMs,
     sizeBytes: file.sizeBytes ?? null,
     platform: args.platform,
-    session: await displayState.finalize(args.platform),
+    session: maybeRefreshCachedCursorCwd(
+      args.candidate.agent,
+      await displayState.finalize(args.platform)
+    ),
     resume: { state, byteOffset: readResult.consumedThrough }
   }
 }

--- a/src/main/ai-vault/session-scanner.ts
+++ b/src/main/ai-vault/session-scanner.ts
@@ -42,6 +42,7 @@ import type {
 import { clampPositiveInteger, errorMessage } from './session-scanner-values'
 import { throwIfAiVaultScanCancelled } from './ai-vault-scan-cancellation'
 import { DEFAULT_AI_VAULT_SCAN_LIMIT } from '../../shared/ai-vault-session-depth'
+import { resetCursorTrustedCwdCache } from './session-scanner-cursor-project-cwd'
 
 const SESSION_PARSE_CONCURRENCY = 8
 const SESSION_PARSE_CANDIDATE_MULTIPLIER = 2
@@ -78,6 +79,7 @@ export async function scanAiVaultSessions(
     // Why: persisted entries must be seeded before any candidate is parsed, or
     // the cold scan gains nothing from the cache file (#9210).
     throwIfAiVaultScanCancelled(options.signal)
+    resetCursorTrustedCwdCache()
     await ensureSessionParseCacheLoaded()
     const discoveries = await discoverAiVaultSessionSources({ options, limitPerAgent, issues })
     throwIfAiVaultScanCancelled(options.signal)

--- a/src/main/remote-agent-trust-presets.ts
+++ b/src/main/remote-agent-trust-presets.ts
@@ -7,6 +7,7 @@ import {
   isWindowsAbsolutePathLike,
   normalizeRuntimePathSeparators
 } from '../shared/cross-platform-path'
+import { cursorWorkspaceSlug } from '../shared/cursor-workspace-slug'
 
 export async function markRemoteAgentWorkspaceTrusted(args: {
   preset: AgentTrustPreset
@@ -100,7 +101,7 @@ async function markRemoteCursorWorkspaceTrusted(
   remoteHome: string,
   workspacePath: string
 ): Promise<void> {
-  const slug = workspacePath.replace(/^[\\/]+/, '').replace(/[\\/:*?"<>|]+/g, '-')
+  const slug = cursorWorkspaceSlug(workspacePath)
   if (!slug) {
     return
   }

--- a/src/shared/ai-vault-session-depth.test.ts
+++ b/src/shared/ai-vault-session-depth.test.ts
@@ -82,4 +82,21 @@ describe('Agent Session History depth', () => {
     ])
     expect(truncateAiVaultListResult(loaded, 'unlimited')).toBe(loaded)
   })
+
+  it('keeps cwd-less Cursor sessions whose project slug matches the workspace', () => {
+    const cursor = {
+      ...session('cursor-legacy', '', 1),
+      agent: 'cursor' as const,
+      cwd: null,
+      filePath: '/home/ada/.cursor/projects/home-ada-repo/agent-transcripts/sid.jsonl'
+    }
+    const loaded = result([
+      session('global-1', '/other', 3),
+      session('global-2', '/other', 2),
+      cursor
+    ])
+    expect(
+      truncateAiVaultListResult(loaded, 1, ['/home/ada/repo']).sessions.map(({ id }) => id)
+    ).toEqual(['global-1', 'cursor-legacy'])
+  })
 })

--- a/src/shared/ai-vault-session-depth.ts
+++ b/src/shared/ai-vault-session-depth.ts
@@ -1,5 +1,5 @@
-import { isPathInsideOrEqual } from './cross-platform-path'
 import type { AiVaultListArgs, AiVaultListResult } from './ai-vault-types'
+import { isAiVaultSessionInWorkspace } from './ai-vault-session-filters'
 
 export const DEFAULT_AI_VAULT_SCAN_LIMIT = 1000
 
@@ -42,8 +42,7 @@ export function truncateAiVaultListResult(
   if (scopePaths.length > 0) {
     let scopedCount = 0
     for (const session of result.sessions) {
-      const cwd = session.cwd
-      if (cwd && scopePaths.some((scopePath) => isPathInsideOrEqual(scopePath, cwd))) {
+      if (scopePaths.some((scopePath) => isAiVaultSessionInWorkspace(session, scopePath))) {
         selectedIds.add(session.id)
         if (++scopedCount >= depth) {
           break

--- a/src/shared/ai-vault-session-filters.test.ts
+++ b/src/shared/ai-vault-session-filters.test.ts
@@ -267,6 +267,28 @@ describe('/shared ai-vault-session-filters (lifted core)', () => {
     ).toEqual(['cursor:opc'])
   })
 
+  it('does not override an authoritative cwd with a colliding Cursor project slug', () => {
+    const cursorSession: AiVaultSession = {
+      ...baseSession,
+      id: 'cursor:authoritative-cwd',
+      agent: 'cursor',
+      sessionId: 'sid',
+      cwd: 'C:\\Dev\\other',
+      filePath:
+        'C:\\Users\\ada\\.cursor\\projects\\c-Dev-simulations-opc\\agent-transcripts\\sid.jsonl'
+    }
+    expect(
+      filterAiVaultSessions([cursorSession], {
+        query: '',
+        agents: ['cursor'],
+        scope: 'workspace',
+        sort: 'updated',
+        activeWorktreePaths: ['C:\\Dev\\simulations\\opc'],
+        hideEmptySessions: true
+      })
+    ).toEqual([])
+  })
+
   it('does not guess a genuinely unlocated session into the active workspace', () => {
     const unlocated: AiVaultSession = {
       ...baseSession,

--- a/src/shared/ai-vault-session-filters.test.ts
+++ b/src/shared/ai-vault-session-filters.test.ts
@@ -197,4 +197,107 @@ describe('/shared ai-vault-session-filters (lifted core)', () => {
   it('builds preview search text from conversation turns', () => {
     expect(sessionPreviewSearchText(baseSession)).toContain('scope tabs')
   })
+
+  it('groups a Cursor session with a recognisable workspace path, not Unknown location', () => {
+    const cursorSession: AiVaultSession = {
+      ...baseSession,
+      id: 'cursor:opc',
+      agent: 'cursor',
+      sessionId: '83e98eef-916b-4d99-95bf-bc66fab9741e',
+      cwd: 'C:\\Dev\\simulations\\opc',
+      filePath:
+        'C:\\Users\\ada\\.cursor\\projects\\c-Dev-simulations-opc\\agent-transcripts\\83e98eef-916b-4d99-95bf-bc66fab9741e.jsonl'
+    }
+    const groups = groupAiVaultSessions([cursorSession], 'folder')
+    expect(groups).toHaveLength(1)
+    expect(groups[0].label).toBe('simulations/opc')
+    expect(groups[0].label).not.toBe('Unknown location')
+  })
+
+  it('keeps Cursor sessions in Workspace scope via the project slug when cwd is missing', () => {
+    const cursorSession: AiVaultSession = {
+      ...baseSession,
+      id: 'cursor:legacy',
+      agent: 'cursor',
+      sessionId: 'sid',
+      cwd: null,
+      filePath:
+        'C:\\Users\\neil\\.cursor\\projects\\c-Users-neil-orca-workspaces-orca-pr-13935-internal-review\\agent-transcripts\\sid.jsonl'
+    }
+    expect(
+      filterAiVaultSessions([cursorSession], {
+        query: '',
+        agents: ['cursor'],
+        scope: 'workspace',
+        sort: 'updated',
+        activeWorktreePaths: ['C:\\Users\\neil\\orca\\workspaces\\orca\\pr-13935-internal-review'],
+        hideEmptySessions: true
+      }).map((session) => session.id)
+    ).toEqual(['cursor:legacy'])
+  })
+
+  it('matches case and separator variants of the same Windows Cursor workspace', () => {
+    const cursorSession: AiVaultSession = {
+      ...baseSession,
+      id: 'cursor:opc',
+      agent: 'cursor',
+      sessionId: 'sid',
+      cwd: null,
+      filePath:
+        'C:\\Users\\ada\\.cursor\\projects\\c-Dev-simulations-opc\\agent-transcripts\\sid.jsonl'
+    }
+    const workspaceFilters = {
+      query: '',
+      agents: ['cursor'] as const,
+      scope: 'workspace' as const,
+      sort: 'updated' as const,
+      hideEmptySessions: true
+    }
+    expect(
+      filterAiVaultSessions([cursorSession], {
+        ...workspaceFilters,
+        activeWorktreePaths: ['C:\\Dev\\simulations\\opc']
+      }).map((session) => session.id)
+    ).toEqual(['cursor:opc'])
+    expect(
+      filterAiVaultSessions([cursorSession], {
+        ...workspaceFilters,
+        activeWorktreePaths: ['c:/dev/simulations/opc']
+      }).map((session) => session.id)
+    ).toEqual(['cursor:opc'])
+  })
+
+  it('does not guess a genuinely unlocated session into the active workspace', () => {
+    const unlocated: AiVaultSession = {
+      ...baseSession,
+      id: 'cursor:unknown',
+      agent: 'cursor',
+      sessionId: 'sid',
+      cwd: null,
+      filePath: 'C:\\Users\\ada\\.cursor\\projects\\agent-transcripts\\sid.jsonl'
+    }
+    expect(
+      filterAiVaultSessions([unlocated], {
+        query: '',
+        agents: ['cursor'],
+        scope: 'workspace',
+        sort: 'updated',
+        activeWorktreePaths: ['C:\\Dev\\simulations\\opc'],
+        hideEmptySessions: true
+      })
+    ).toEqual([])
+    expect(groupAiVaultSessions([unlocated], 'folder').map((group) => group.label)).toEqual([
+      'Unknown location'
+    ])
+  })
+
+  it('leaves Claude and Codex folder grouping on their recorded cwd', () => {
+    const groups = groupAiVaultSessions([baseSession, otherSession], 'folder')
+    expect(
+      groups.map((group) => ({ label: group.label, agents: group.sessions.map((s) => s.agent) }))
+    ).toEqual([
+      { label: 'repo/app', agents: ['claude'] },
+      { label: 'packages/ui', agents: ['codex'] }
+    ])
+  })
 })

--- a/src/shared/ai-vault-session-filters.ts
+++ b/src/shared/ai-vault-session-filters.ts
@@ -8,6 +8,7 @@ import {
   normalizeRuntimePathSeparators
 } from './cross-platform-path'
 import { isClipboardTextByteLengthOverLimit } from './clipboard-text'
+import { isCursorTranscriptInWorkspace } from './cursor-workspace-slug'
 import { parseWslUncPath } from './wsl-paths'
 import type {
   AiVaultAgent,
@@ -96,16 +97,11 @@ export function filterAiVaultSessions(
       ) {
         return false
       }
-      if (filters.scope === 'workspace') {
-        const cwd = session.cwd
-        if (
-          !cwd ||
-          !filters.activeWorktreePaths.some((pathValue) =>
-            isAiVaultSessionInWorkspacePath(pathValue, cwd)
-          )
-        ) {
-          return false
-        }
+      if (
+        filters.scope === 'workspace' &&
+        !isAiVaultSessionInActiveWorkspace(session, filters.activeWorktreePaths)
+      ) {
+        return false
       }
       if (filters.scope === 'project') {
         if (!filters.activeProjectKey) {
@@ -274,6 +270,27 @@ function getGroupIdentity(
     }
   }
   return { key: folderGroupKey(session.cwd), label: folderLabel(session.cwd) }
+}
+
+export function isAiVaultSessionInWorkspace(
+  session: Pick<AiVaultSession, 'agent' | 'cwd' | 'filePath'>,
+  workspacePath: string
+): boolean {
+  if (session.cwd && isAiVaultSessionInWorkspacePath(workspacePath, session.cwd)) {
+    return true
+  }
+  // Why: Cursor JSONL has no cwd and slug decode is lossy for hyphenated
+  // folder workspaces. Matching the encoded project bucket is lossless.
+  return (
+    session.agent === 'cursor' && isCursorTranscriptInWorkspace(workspacePath, session.filePath)
+  )
+}
+
+function isAiVaultSessionInActiveWorkspace(
+  session: AiVaultSession,
+  activeWorktreePaths: readonly string[]
+): boolean {
+  return activeWorktreePaths.some((pathValue) => isAiVaultSessionInWorkspace(session, pathValue))
 }
 
 function isAiVaultSessionInWorkspacePath(workspacePath: string, sessionCwd: string): boolean {

--- a/src/shared/ai-vault-session-filters.ts
+++ b/src/shared/ai-vault-session-filters.ts
@@ -276,11 +276,11 @@ export function isAiVaultSessionInWorkspace(
   session: Pick<AiVaultSession, 'agent' | 'cwd' | 'filePath'>,
   workspacePath: string
 ): boolean {
-  if (session.cwd && isAiVaultSessionInWorkspacePath(workspacePath, session.cwd)) {
-    return true
+  if (session.cwd) {
+    return isAiVaultSessionInWorkspacePath(workspacePath, session.cwd)
   }
-  // Why: Cursor JSONL has no cwd and slug decode is lossy for hyphenated
-  // folder workspaces. Matching the encoded project bucket is lossless.
+  // Why: Cursor JSONL has no cwd, so forward-match the workspace instead of
+  // reverse-decoding a non-injective project slug.
   return (
     session.agent === 'cursor' && isCursorTranscriptInWorkspace(workspacePath, session.filePath)
   )

--- a/src/shared/cursor-workspace-slug.test.ts
+++ b/src/shared/cursor-workspace-slug.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest'
 import {
   cursorProjectSlugFromTranscriptPath,
   cursorWorkspaceSlug,
-  decodeCursorProjectSlug,
   isCursorTranscriptInWorkspace
 } from './cursor-workspace-slug'
 
@@ -35,23 +34,11 @@ describe('cursorProjectSlugFromTranscriptPath', () => {
     expect(
       cursorProjectSlugFromTranscriptPath('/tmp/unrelated/agent-transcripts/sid.jsonl')
     ).toBeNull()
-  })
-})
-
-describe('decodeCursorProjectSlug', () => {
-  it('reconstructs Windows drive paths, including a drive root', () => {
-    expect(decodeCursorProjectSlug('c-Dev-simulations-opc')).toBe('C:\\Dev\\simulations\\opc')
-    expect(decodeCursorProjectSlug('c-')).toBe('C:\\')
-  })
-
-  it('reconstructs POSIX paths with the leading slash restored', () => {
-    expect(decodeCursorProjectSlug('Users-ada-code-orca')).toBe('/Users/ada/code/orca')
-  })
-
-  it('rejects empty, relative, and parent-segment slugs', () => {
-    expect(decodeCursorProjectSlug('')).toBeNull()
-    expect(decodeCursorProjectSlug('..')).toBeNull()
-    expect(decodeCursorProjectSlug('foo-..-bar')).toBeNull()
+    expect(
+      cursorProjectSlugFromTranscriptPath(
+        '/home/u/.cursor/projects/repo\\agent-transcripts/sid.jsonl'
+      )
+    ).toBeNull()
   })
 })
 
@@ -89,4 +76,16 @@ describe('isCursorTranscriptInWorkspace', () => {
       )
     ).toBe(true)
   })
+
+  it.each(['/a/Repo', '/A/repo'])(
+    'does not case-fold a one-letter POSIX workspace root: %s',
+    (workspacePath) => {
+      expect(
+        isCursorTranscriptInWorkspace(
+          workspacePath,
+          '/home/ada/.cursor/projects/a-repo/agent-transcripts/sid.jsonl'
+        )
+      ).toBe(false)
+    }
+  )
 })

--- a/src/shared/cursor-workspace-slug.test.ts
+++ b/src/shared/cursor-workspace-slug.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import {
+  cursorProjectSlugFromTranscriptPath,
+  cursorWorkspaceSlug,
+  decodeCursorProjectSlug,
+  isCursorTranscriptInWorkspace
+} from './cursor-workspace-slug'
+
+describe('cursorWorkspaceSlug', () => {
+  it('encodes POSIX paths the way Cursor names project buckets', () => {
+    expect(cursorWorkspaceSlug('/Users/ada/code/orca')).toBe('Users-ada-code-orca')
+  })
+
+  it('encodes Windows drive paths, including the colon', () => {
+    expect(cursorWorkspaceSlug('C:\\Dev\\simulations\\opc')).toBe('C-Dev-simulations-opc')
+    expect(cursorWorkspaceSlug('C:/Users/alice/platform')).toBe('C-Users-alice-platform')
+  })
+})
+
+describe('cursorProjectSlugFromTranscriptPath', () => {
+  it('requires the .cursor/projects/<slug>/agent-transcripts layout', () => {
+    expect(
+      cursorProjectSlugFromTranscriptPath(
+        '/home/u/.cursor/projects/Users-u-repo/agent-transcripts/sid/sid.jsonl'
+      )
+    ).toBe('Users-u-repo')
+    expect(
+      cursorProjectSlugFromTranscriptPath(
+        'C:\\Users\\u\\.cursor\\projects\\c-Dev-simulations-opc\\agent-transcripts\\sid.jsonl'
+      )
+    ).toBe('c-Dev-simulations-opc')
+    expect(
+      cursorProjectSlugFromTranscriptPath('/home/u/.cursor/projects/slug/sid.jsonl')
+    ).toBeNull()
+    expect(
+      cursorProjectSlugFromTranscriptPath('/tmp/unrelated/agent-transcripts/sid.jsonl')
+    ).toBeNull()
+  })
+})
+
+describe('decodeCursorProjectSlug', () => {
+  it('reconstructs Windows drive paths, including a drive root', () => {
+    expect(decodeCursorProjectSlug('c-Dev-simulations-opc')).toBe('C:\\Dev\\simulations\\opc')
+    expect(decodeCursorProjectSlug('c-')).toBe('C:\\')
+  })
+
+  it('reconstructs POSIX paths with the leading slash restored', () => {
+    expect(decodeCursorProjectSlug('Users-ada-code-orca')).toBe('/Users/ada/code/orca')
+  })
+
+  it('rejects empty, relative, and parent-segment slugs', () => {
+    expect(decodeCursorProjectSlug('')).toBeNull()
+    expect(decodeCursorProjectSlug('..')).toBeNull()
+    expect(decodeCursorProjectSlug('foo-..-bar')).toBeNull()
+  })
+})
+
+describe('isCursorTranscriptInWorkspace', () => {
+  it('matches a Windows folder workspace whose slug Cursor lowercased', () => {
+    expect(
+      isCursorTranscriptInWorkspace(
+        'C:\\Users\\neil\\orca\\workspaces\\orca\\pr-13935-internal-review',
+        'C:\\Users\\neil\\.cursor\\projects\\c-Users-neil-orca-workspaces-orca-pr-13935-internal-review\\agent-transcripts\\sid.jsonl'
+      )
+    ).toBe(true)
+  })
+
+  it('matches case and separator variants of the reported Windows workspace', () => {
+    const transcript =
+      'C:\\Users\\ada\\.cursor\\projects\\c-Dev-simulations-opc\\agent-transcripts\\sid.jsonl'
+    expect(isCursorTranscriptInWorkspace('C:\\Dev\\simulations\\opc', transcript)).toBe(true)
+    expect(isCursorTranscriptInWorkspace('c:/dev/simulations/opc', transcript)).toBe(true)
+  })
+
+  it('does not match a different Windows workspace', () => {
+    expect(
+      isCursorTranscriptInWorkspace(
+        'C:\\Dev\\simulations\\opc',
+        'C:\\Users\\u\\.cursor\\projects\\c-Dev-other\\agent-transcripts\\sid.jsonl'
+      )
+    ).toBe(false)
+  })
+
+  it('matches a WSL UNC workspace against a Linux Cursor project slug', () => {
+    expect(
+      isCursorTranscriptInWorkspace(
+        '\\\\wsl.localhost\\Ubuntu\\home\\ada\\repo',
+        '/home/ada/.cursor/projects/home-ada-repo/agent-transcripts/sid.jsonl'
+      )
+    ).toBe(true)
+  })
+})

--- a/src/shared/cursor-workspace-slug.ts
+++ b/src/shared/cursor-workspace-slug.ts
@@ -1,0 +1,84 @@
+import { isWindowsAbsolutePathLike } from './cross-platform-path'
+import { parseWslUncPath } from './wsl-paths'
+
+/**
+ * Cursor stores per-workspace state under `~/.cursor/projects/<slug>/`.
+ * The slug is the absolute path with a leading slash stripped and reserved
+ * path characters (`/ \ : * ? " < > |`) replaced with `-`.
+ *
+ * Inverse decode is lossy when a path segment itself contains `-`. Prefer
+ * `.workspace-trusted` workspacePath, or match by encoding the workspace.
+ */
+export function cursorWorkspaceSlug(absPath: string): string {
+  const stripped = absPath.replace(/^[\\/]+/, '')
+  return stripped.replace(/[\\/:*?"<>|]+/g, '-')
+}
+
+export function cursorProjectSlugFromTranscriptPath(filePath: string): string | null {
+  const segments = splitPathSegments(filePath)
+  const marker = segments.lastIndexOf('agent-transcripts')
+  if (
+    marker < 3 ||
+    segments[marker - 3] !== '.cursor' ||
+    segments[marker - 2] !== 'projects' ||
+    !segments[marker - 1]
+  ) {
+    return null
+  }
+  return segments[marker - 1] ?? null
+}
+
+export function decodeCursorProjectSlug(slug: string): string | null {
+  const trimmed = slug.trim()
+  if (!trimmed || trimmed === '.' || trimmed === '..') {
+    return null
+  }
+  const windowsDrive = trimmed.match(/^([A-Za-z])-(.*)$/)
+  const decoded = windowsDrive
+    ? `${windowsDrive[1].toUpperCase()}:\\${windowsDrive[2].replace(/-/g, '\\')}`
+    : `/${trimmed.replace(/-/g, '/')}`
+  if (splitPathSegments(decoded).includes('..')) {
+    return null
+  }
+  return decoded
+}
+
+export function isCursorTranscriptInWorkspace(
+  workspacePath: string,
+  transcriptPath: string
+): boolean {
+  const transcriptSlug = cursorProjectSlugFromTranscriptPath(transcriptPath)
+  if (!transcriptSlug) {
+    return false
+  }
+  return workspaceSlugSources(workspacePath).some((source) =>
+    cursorWorkspaceSlugCandidates(source).some((candidate) =>
+      slugsMatch(source, candidate, transcriptSlug)
+    )
+  )
+}
+
+function workspaceSlugSources(workspacePath: string): string[] {
+  const wsl = parseWslUncPath(workspacePath)
+  return wsl ? [workspacePath, wsl.linuxPath] : [workspacePath]
+}
+
+function cursorWorkspaceSlugCandidates(absPath: string): string[] {
+  const slug = cursorWorkspaceSlug(absPath)
+  if (!slug) {
+    return []
+  }
+  const driveFolded = slug.replace(/^([A-Za-z])-/, (_, drive: string) => `${drive.toLowerCase()}-`)
+  return driveFolded === slug ? [slug] : [slug, driveFolded]
+}
+
+function slugsMatch(workspacePath: string, encoded: string, transcriptSlug: string): boolean {
+  if (isWindowsAbsolutePathLike(workspacePath) || /^[A-Za-z]-/.test(transcriptSlug)) {
+    return encoded.toLowerCase() === transcriptSlug.toLowerCase()
+  }
+  return encoded === transcriptSlug
+}
+
+function splitPathSegments(filePath: string): string[] {
+  return filePath.split(/[\\/]+/).filter(Boolean)
+}

--- a/src/shared/cursor-workspace-slug.ts
+++ b/src/shared/cursor-workspace-slug.ts
@@ -1,4 +1,4 @@
-import { isWindowsAbsolutePathLike } from './cross-platform-path'
+import { isCaseInsensitiveRuntimeRoot, isWindowsAbsolutePathLike } from './cross-platform-path'
 import { parseWslUncPath } from './wsl-paths'
 
 /**
@@ -28,21 +28,6 @@ export function cursorProjectSlugFromTranscriptPath(filePath: string): string | 
   return segments[marker - 1] ?? null
 }
 
-export function decodeCursorProjectSlug(slug: string): string | null {
-  const trimmed = slug.trim()
-  if (!trimmed || trimmed === '.' || trimmed === '..') {
-    return null
-  }
-  const windowsDrive = trimmed.match(/^([A-Za-z])-(.*)$/)
-  const decoded = windowsDrive
-    ? `${windowsDrive[1].toUpperCase()}:\\${windowsDrive[2].replace(/-/g, '\\')}`
-    : `/${trimmed.replace(/-/g, '/')}`
-  if (splitPathSegments(decoded).includes('..')) {
-    return null
-  }
-  return decoded
-}
-
 export function isCursorTranscriptInWorkspace(
   workspacePath: string,
   transcriptPath: string
@@ -68,17 +53,20 @@ function cursorWorkspaceSlugCandidates(absPath: string): string[] {
   if (!slug) {
     return []
   }
+  if (!isCaseInsensitiveRuntimeRoot(absPath)) {
+    return [slug]
+  }
   const driveFolded = slug.replace(/^([A-Za-z])-/, (_, drive: string) => `${drive.toLowerCase()}-`)
   return driveFolded === slug ? [slug] : [slug, driveFolded]
 }
 
 function slugsMatch(workspacePath: string, encoded: string, transcriptSlug: string): boolean {
-  if (isWindowsAbsolutePathLike(workspacePath) || /^[A-Za-z]-/.test(transcriptSlug)) {
+  if (isCaseInsensitiveRuntimeRoot(workspacePath)) {
     return encoded.toLowerCase() === transcriptSlug.toLowerCase()
   }
   return encoded === transcriptSlug
 }
 
 function splitPathSegments(filePath: string): string[] {
-  return filePath.split(/[\\/]+/).filter(Boolean)
+  return filePath.split(isWindowsAbsolutePathLike(filePath) ? /[\\/]+/ : /\/+/).filter(Boolean)
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​634 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​633 |
| Prod | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​338 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​58 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​280 |

<!-- /orca-pr-loc -->

## ELI5

Cursor Agent Session History rows were showing up under **Unknown location** and disappearing from the **Workspace** tab. Orca found the transcripts, but Cursor's JSONL never records a folder. This PR attaches those sessions to the right project when we can do it safely, and still includes them in Workspace by matching the Cursor project folder name even when the folder name has hyphens.

## What Changed

- Shared Cursor project-slug encode/decode used by trust presets and Agent Session History.
- Local scans set `cwd` from `.workspace-trusted` (including the `C-` / `c-` drive-letter sibling) or from a decoded slug **only if that path exists**.
- Remote/WSL parses never invent a cwd and never read the local disk.
- Workspace scope, scan-depth truncation, and remote SSH scope match Cursor transcripts by encoding the workspace path (lossless for hyphenated folder workspaces).

## Why

**Cause is a missing field, not an unrecognised cwd shape.** Cursor `agent-transcripts` JSONL has no `cwd` (`session-scanner-cursor-parser.ts` `consumeCursorRecordLine` never reads one; the accumulator starts `cwd: null`). The workspace lives only in `~/.cursor/projects/<slug>/`, e.g. `c-Dev-simulations-opc` → `C:\Dev\simulations\opc`.

Decoding that slug is lossy when a folder name contains `-`. Publishing the guess as `cwd` can hide sessions from the real folder. Encoding the workspace and comparing it to the project bucket is lossless. A session with no usable slug still stays **Unknown location** and is not guessed into the active workspace.

## Linked Issue

Fixes https://linear.app/stably/issue/STA-3959/bug-cursor-sessions-are-grouped-under-unknown-location-and-missing
Fixes #13931

Supersedes #13935 and #14616 as the focused attribution path. How this differs:

1. Does not publish a decoded slug as `cwd` unless that path exists on this host (hyphenated folder names stay unknown rather than inventing `pr\13935\internal\review`).
2. Workspace membership matches by encoding the worktree path, so hyphenated folder workspaces still appear under **Workspace** even when `cwd` stays null.
3. Remote content parse and WSL UNC paths never raw-read the local disk.
4. Drive-letter sibling `.workspace-trusted` lookup (`c-Dev-…` vs `C-Dev-…`).
5. Acceptance tests cover (a) grouped under the workspace not Unknown, (b) Windows case/separator variants, (c) genuinely unlocated sessions stay Unknown, (d) Claude/Codex grouping unchanged.

Does **not** duplicate #15650 (`C:\` ↔ `/mnt/c` aliases). That PR is still the WSL drive-letter matcher; this one only recovers a missing Cursor cwd / slug.

#14582 remains the bounded Cursor *sidecar* history feature. This PR is the legacy `agent-transcripts` attribution fix the Windows reporter hit.

## Visual Proof

N/A — no layout, copy, or control change. Grouping/filter membership is proven with unit tests for the reported Windows slug `c-Dev-simulations-opc`, hyphenated folder workspaces, remote parse (no local fs), and trust-file sibling lookup.

## Testing

- [ ] I manually tested these changes locally (Windows host unreachable; mark Windows behaviour unvalidated)
- [x] Automated tests added/updated

```
pnpm vitest run --config config/vitest.config.ts \
  src/shared/ai-vault-session-filters.test.ts \
  src/shared/cursor-workspace-slug.test.ts \
  src/shared/ai-vault-session-depth.test.ts \
  src/main/ai-vault/session-scanner-cursor-parser.test.ts \
  src/main/ai-vault/session-scanner-cursor-project-cwd.test.ts \
  src/main/ai-vault/session-scanner-fs-import-guard.test.ts \
  src/main/agent-trust-presets.test.ts \
  src/main/remote-agent-trust-presets.test.ts \
  src/main/ai-vault/session-scanner.test.ts \
  src/main/ai-vault/session-scanner-parse-cache.test.ts \
  src/main/ai-vault/session-scanner-parse-cache-agents.test.ts \
  src/main/ai-vault/remote-session-scanner.test.ts
```

Pre-fix FAIL / post-fix PASS / neutered FAIL proven for Workspace slug matching, Windows case/separator variants, parser cwd attribution, and scoped-depth inclusion. The unlocated-session test stays green in all three, which is what keeps a "default everything to the current workspace" cheat from passing.

## Author

@BrennanKB5

## Review

Root cause is missing JSONL `cwd`, recovered from the Cursor project bucket. Folder workspaces use the same encoder. SSH/remote scans match by slug and do not invent a local cwd. #15650's WSL `/mnt/c` aliases are intentionally untouched.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Credit: #13935 by @bbingz (missing-cwd diagnosis and slug decode) and #14616 (lossless encode-match, no invented remote cwd).

Windows behaviour is unit-tested, not QA'd on a Windows host.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)