### PR TITLE
fix(ui): keep dialog title and footer inside the panel

### DIFF
--- a/src/renderer/src/components/ui/dialog.tsx
+++ b/src/renderer/src/components/ui/dialog.tsx
@@ -63,8 +63,11 @@ function DialogContent({
         // A translucent surface, solid 14% border, dual shadow, and 2xl backdrop
         // blur match the dropdown-menu recipe (which already works) and read
         // clearly in both light and dark mode.
+        // grid-cols-[minmax(0,1fr)]: default grid column sizes to min-content, so an
+        // unbreakable token (long filename in the title) widens the column past the
+        // panel and pushes justify-end footers outside the visible surface.
         className={cn(
-          'fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border border-black/14 bg-background/96 p-6 text-foreground shadow-[0_20px_60px_rgba(0,0,0,0.28),inset_0_1px_0_rgba(255,255,255,0.08)] backdrop-blur-2xl duration-200 outline-none dark:border-white/14 dark:bg-[rgba(23,23,23,0.96)] dark:shadow-[0_24px_72px_rgba(0,0,0,0.55),inset_0_1px_0_rgba(255,255,255,0.06)] data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg',
+          'fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] grid-cols-[minmax(0,1fr)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border border-black/14 bg-background/96 p-6 text-foreground shadow-[0_20px_60px_rgba(0,0,0,0.28),inset_0_1px_0_rgba(255,255,255,0.08)] backdrop-blur-2xl duration-200 outline-none dark:border-white/14 dark:bg-[rgba(23,23,23,0.96)] dark:shadow-[0_24px_72px_rgba(0,0,0,0.55),inset_0_1px_0_rgba(255,255,255,0.06)] data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg',
           className
         )}
         {...props}
@@ -126,7 +129,7 @@ function DialogTitle({ className, ...props }: React.ComponentProps<typeof Dialog
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn('text-lg leading-none font-semibold', className)}
+      className={cn('text-lg leading-snug font-semibold break-words', className)}
       {...props}
     />
   )


### PR DESCRIPTION
## ELI5

A dialog whose title held one very long word (a filename) leaked outside its own box — the title ran past the right edge and the buttons floated outside the panel. This pins the dialog's layout column to the panel width and lets long titles wrap.

## What Changed

`src/renderer/src/components/ui/dialog.tsx`, two class changes:

- `DialogContent`: added `grid-cols-[minmax(0,1fr)]`, so the single column is capped at the container width instead of being sized to min-content.
- `DialogTitle`: `leading-none` → `leading-snug`, added `break-words`, so a long token wraps inside the panel and a two-line title is not cramped.

`DialogDescription` already wraps at spaces and is unchanged.

## Why

`DialogContent` uses `grid` with no `grid-template-columns`. The implicit column is sized to the largest min-content contribution of its children, so a token with no break opportunity — `dml_ads_cst_as_cms_139indcls_volt_eqty_stat_day_di.sql` in the report — widens that column past the panel. The panel itself stays clamped by `sm:max-w-lg`, so the background stops where it does while the children spill to the right, and `DialogFooter`'s `sm:justify-end` aligns the buttons to the right edge of the oversized column rather than the visible panel.

Fixing the shared primitive rather than the call site matters because this is not specific to the delete confirmation: `dialog.tsx` is the only place using this recipe, and every dialog whose title can carry a long token hits the same overflow.

Note that `min-width: 0` on the children is not needed here: a grid item's automatic minimum size only applies when the track's min sizing function is `auto`, and `minmax(0,1fr)` makes it `0`.

## Linked Issue

Fixes #15706

## Visual Proof

<!-- before/after screenshots attached below -->

<details open>
<summary><b>Before</b> — title overflows the panel, footer buttons render outside it</summary>

![before](https://github.com/user-attachments/assets/e55f20a0-dc96-47d4-97fa-6e1abdc4a0b1)

</details>

<details>
<summary><b>After</b> — long title wraps inside the panel, footer buttons sit inside it</summary>

![after](https://github.com/user-attachments/assets/ab454b35-2091-4bce-99f6-6ac4a0ae9d64)

</details>

## Testing

Manually tested on Linux (Electron dev build) with the file-explorer delete confirmation and a file named `testtesttesttesttesttesttesttesttesttesttesttest.txt`. Before the change the title overflowed the panel and the Cancel/Delete buttons rendered outside it; after the change the title wraps inside the panel and both buttons sit inside the footer.

- [x] I manually tested these changes locally
- [ ] Automated tests added/updated, or explained why not below

No automated test: the change is CSS-only and jsdom does not perform layout, so a unit test cannot observe the overflow. The regression is only visible in a real rendering engine.

## AI Disclosure

Claude (MiniMax-M3 via Claude Code) assisted with the diagnosis and the patch.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

CSS-only, no behavior or API change. No impact on security, cross-platform support, remote SSH, mobile, backwards compatibility, or performance.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
