### PR TITLE
fix(crash-reporting): scope renderer breadcrumbs to the renderer that emitted them

### DIFF
--- a/src/main/crash-reporting/crash-breadcrumb-renderer-attribution.test.ts
+++ b/src/main/crash-reporting/crash-breadcrumb-renderer-attribution.test.ts
@@ -1,0 +1,261 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { CrashReportBreadcrumb } from '../../shared/crash-reporting'
+import { rendererCrashBreadcrumbOrigin } from '../../shared/crash-breadcrumb-origin'
+
+const { handlers, listeners } = vi.hoisted(() => ({
+  handlers: new Map<string, (event: unknown, args?: unknown) => unknown>(),
+  listeners: new Map<string, (event: unknown, args?: unknown) => void>()
+}))
+
+vi.mock('electron', () => ({
+  app: { getVersion: () => '1.2.3-test', getAppMetrics: () => [] },
+  clipboard: { writeText: vi.fn() },
+  ipcMain: {
+    removeHandler: vi.fn((channel: string) => handlers.delete(channel)),
+    handle: vi.fn((channel: string, handler: (event: unknown, args?: unknown) => unknown) => {
+      handlers.set(channel, handler)
+    }),
+    removeAllListeners: vi.fn((channel: string) => listeners.delete(channel)),
+    on: vi.fn((channel: string, listener: (event: unknown, args?: unknown) => void) => {
+      listeners.set(channel, listener)
+    })
+  }
+}))
+
+vi.mock('../ipc/feedback', () => ({ submitFeedback: vi.fn() }))
+vi.mock('../observability', () => ({
+  collectDiagnosticBundle: vi.fn(),
+  getDiagnosticsStatus: vi.fn()
+}))
+vi.mock('../observability/diagnostic-upload-endpoint', () => ({
+  resolveDiagnosticOrcaChannel: vi.fn()
+}))
+
+import {
+  _resetRendererErrorReportDedupeForTests,
+  registerCrashReportingHandlers
+} from '../ipc/crash-reporting'
+import { clearCrashBreadcrumbsForTest, recordCrashBreadcrumb } from './crash-breadcrumb-store'
+import { ProcessGoneDedupe } from './process-gone-dedupe'
+import { recordProcessGoneCrash, type ProcessGoneCrashEvent } from './process-gone-recorder'
+import { _resetTracerForTests, setActiveSink } from '../observability/tracer'
+
+/** Two live renderers: an Orca window and a browser-pane webview guest. */
+const RENDERER_A = 11
+const RENDERER_B = 22
+
+const noMinidump = async () => null
+
+type RecordedReport = { id: string; breadcrumbs?: CrashReportBreadcrumb[] }
+
+function crashReportStore(): {
+  record: ReturnType<typeof vi.fn>
+  attachDetails: ReturnType<typeof vi.fn>
+} {
+  return {
+    record: vi.fn(async (input: RecordedReport) => ({
+      ...input,
+      id: 'report-1'
+    })),
+    attachDetails: vi.fn(async () => null)
+  }
+}
+
+function recordedBreadcrumbs(record: ReturnType<typeof vi.fn>): CrashReportBreadcrumb[] {
+  const recorded = record.mock.calls[0]?.[0] as RecordedReport | undefined
+  return recorded?.breadcrumbs ?? []
+}
+
+/** Main already knows the crashing webContents id here (index.ts passes it to
+ *  getExpectedTeardownScope); the crash event is where it must survive. */
+function rendererCrashEvent(webContentsId: number): ProcessGoneCrashEvent {
+  return {
+    source: 'renderer',
+    processType: 'renderer',
+    reason: 'crashed',
+    exitCode: 5,
+    expectedTeardown: 'none',
+    details: { processType: 'renderer' },
+    webContentsId
+  }
+}
+
+/** GPU/utility deaths have no window, so the report keeps the whole ring. */
+function childCrashEvent(): ProcessGoneCrashEvent {
+  return {
+    source: 'child',
+    processType: 'gpu-process',
+    reason: 'crashed',
+    exitCode: 5,
+    expectedTeardown: 'none',
+    details: { processType: 'gpu-process' }
+  }
+}
+
+function emitRendererBreadcrumb(senderId: number, name: string, data?: unknown): void {
+  listeners.get('crashReports:recordBreadcrumb')?.({ sender: { id: senderId } }, { name, data })
+}
+
+async function fileProcessGoneCrash(webContentsId: number): Promise<CrashReportBreadcrumb[]> {
+  const store = crashReportStore()
+  recordProcessGoneCrash(
+    store as never,
+    rendererCrashEvent(webContentsId),
+    new ProcessGoneDedupe(),
+    noMinidump
+  )
+  await Promise.resolve()
+  return recordedBreadcrumbs(store.record)
+}
+
+async function fileReactErrorBoundaryReport(
+  webContentsId: number
+): Promise<CrashReportBreadcrumb[]> {
+  const store = crashReportStore()
+  registerCrashReportingHandlers(store as never)
+  await handlers.get('crashReports:recordRendererError')?.(
+    { sender: { id: webContentsId } },
+    {
+      boundaryId: 'workspace-shell-root',
+      surface: 'workspace-shell',
+      errorName: 'TypeError',
+      errorMessage: 'Cannot read properties of undefined'
+    }
+  )
+  return recordedBreadcrumbs(store.record)
+}
+
+const names = (breadcrumbs: CrashReportBreadcrumb[]): string[] => breadcrumbs.map((b) => b.name)
+
+beforeEach(() => {
+  handlers.clear()
+  listeners.clear()
+  setActiveSink({ push: vi.fn(), flush: vi.fn(), close: vi.fn() })
+  clearCrashBreadcrumbsForTest()
+  _resetRendererErrorReportDedupeForTests()
+  registerCrashReportingHandlers(crashReportStore() as never)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  _resetTracerForTests()
+  clearCrashBreadcrumbsForTest()
+})
+
+// Known and deliberate gap: the ring is still one shared 30-entry budget, so a
+// chatty sibling can still evict the crashing renderer's crumbs before the
+// report is filed. This suite covers attribution only; capacity is a separate
+// change, so no assertion here depends on the ring overflowing.
+describe('crash breadcrumb attribution across renderers', () => {
+  it('does not attach a sibling renderer breadcrumb to a process-gone report', async () => {
+    recordCrashBreadcrumb('app_started', { channel: 'stable' })
+    emitRendererBreadcrumb(RENDERER_A, 'lazy_chunk_reload', {
+      chunk: 'workspace-shell'
+    })
+    emitRendererBreadcrumb(RENDERER_B, 'lazy_chunk_reload_vetoed', {
+      chunk: 'browser-guest'
+    })
+
+    const breadcrumbs = await fileProcessGoneCrash(RENDERER_A)
+
+    // Main-process breadcrumbs are genuinely global and must stay on every report.
+    expect(names(breadcrumbs)).toContain('app_started')
+    expect(names(breadcrumbs)).toContain('lazy_chunk_reload')
+    expect(names(breadcrumbs)).not.toContain('lazy_chunk_reload_vetoed')
+  })
+
+  it('keeps a quiet renderer own trail while other renderers churn', async () => {
+    emitRendererBreadcrumb(RENDERER_A, 'renderer_bootstrap_started')
+    emitRendererBreadcrumb(RENDERER_A, 'sidebar_worktree_activate')
+    for (let generation = 0; generation < 20; generation += 1) {
+      emitRendererBreadcrumb(100 + generation, 'popout_bootstrap_started')
+    }
+
+    const breadcrumbs = await fileProcessGoneCrash(RENDERER_A)
+
+    expect(names(breadcrumbs)).toEqual(['renderer_bootstrap_started', 'sidebar_worktree_activate'])
+  })
+
+  it('keeps an identical coalesced storm on each emitting renderer report', async () => {
+    // Both windows run the same bundle, so the same error fires in both at once.
+    emitRendererBreadcrumb(RENDERER_A, 'renderer_error', { message: 'boom' })
+    emitRendererBreadcrumb(RENDERER_B, 'renderer_error', { message: 'boom' })
+
+    const forA = await fileProcessGoneCrash(RENDERER_A)
+    const forB = await fileProcessGoneCrash(RENDERER_B)
+
+    expect(names(forA)).toEqual(['renderer_error'])
+    expect(names(forB)).toEqual(['renderer_error'])
+    // Neither report may claim the sibling's occurrence as a suppressed repeat.
+    expect(forA[0]?.data?.suppressedSinceLast).toBeUndefined()
+    expect(forB[0]?.data?.suppressedSinceLast).toBeUndefined()
+  })
+
+  it('does not file one renderer payload under a name-only coalesced sibling', async () => {
+    emitRendererBreadcrumb(RENDERER_A, 'terminal_safe_fit_retry_exhausted', { panes: 1 })
+    emitRendererBreadcrumb(RENDERER_B, 'terminal_safe_fit_retry_exhausted', { panes: 9 })
+
+    const forA = await fileProcessGoneCrash(RENDERER_A)
+    const forB = await fileProcessGoneCrash(RENDERER_B)
+
+    expect(forA[0]?.data?.panes).toBe(1)
+    expect(forB[0]?.data?.panes).toBe(9)
+  })
+
+  it('still coalesces one renderer own repeats into a single entry', async () => {
+    for (let repeat = 0; repeat < 5; repeat += 1) {
+      emitRendererBreadcrumb(RENDERER_A, 'renderer_error', { message: 'boom' })
+    }
+
+    const forA = await fileProcessGoneCrash(RENDERER_A)
+
+    expect(names(forA)).toEqual(['renderer_error'])
+    expect(forA[0]?.data?.suppressedSinceLast).toBe(4)
+  })
+
+  it('does not attach a sibling renderer breadcrumb to a react-error-boundary report', async () => {
+    recordCrashBreadcrumb('app_started', { channel: 'stable' })
+    emitRendererBreadcrumb(RENDERER_A, 'lazy_chunk_reload', {
+      chunk: 'workspace-shell'
+    })
+    emitRendererBreadcrumb(RENDERER_B, 'lazy_chunk_reload_vetoed', {
+      chunk: 'browser-guest'
+    })
+
+    const breadcrumbs = await fileReactErrorBoundaryReport(RENDERER_A)
+
+    expect(names(breadcrumbs)).toContain('app_started')
+    expect(names(breadcrumbs)).toContain('lazy_chunk_reload')
+    expect(names(breadcrumbs)).not.toContain('lazy_chunk_reload_vetoed')
+  })
+
+  it('keeps every renderer trail on a child crash that names no webContents', async () => {
+    recordCrashBreadcrumb('app_started', { channel: 'stable' })
+    emitRendererBreadcrumb(RENDERER_A, 'lazy_chunk_reload', { chunk: 'workspace-shell' })
+    emitRendererBreadcrumb(RENDERER_B, 'lazy_chunk_reload_vetoed', { chunk: 'browser-guest' })
+
+    const store = crashReportStore()
+    recordProcessGoneCrash(store as never, childCrashEvent(), new ProcessGoneDedupe(), noMinidump)
+    await Promise.resolve()
+
+    // Why: no surface filed this, so scoping it would delete real evidence.
+    expect(names(recordedBreadcrumbs(store.record))).toEqual([
+      'app_started',
+      'lazy_chunk_reload',
+      'lazy_chunk_reload_vetoed'
+    ])
+  })
+
+  it('stores the origin label sanitization leaves untouched, so filtering matches', async () => {
+    emitRendererBreadcrumb(RENDERER_A, 'lazy_chunk_reload', { chunk: 'workspace-shell' })
+
+    const store = crashReportStore()
+    recordProcessGoneCrash(store as never, childCrashEvent(), new ProcessGoneDedupe(), noMinidump)
+    await Promise.resolve()
+
+    // Why: the reporter builds this label raw while recording sanitizes it; if
+    // sanitizing ever rewrote it the filter would silently drop the crumbs.
+    const stored = recordedBreadcrumbs(store.record).find((b) => b.name === 'lazy_chunk_reload')
+    expect(stored?.origin).toBe(rendererCrashBreadcrumbOrigin(RENDERER_A))
+  })
+})

--- a/src/main/crash-reporting/crash-breadcrumb-store.test.ts
+++ b/src/main/crash-reporting/crash-breadcrumb-store.test.ts
@@ -12,6 +12,46 @@ afterEach(() => {
 })
 
 describe('crash breadcrumb store', () => {
+  describe('reporter-origin filtering', () => {
+    it('drops other renderers crumbs while keeping unattributed ones', () => {
+      recordCrashBreadcrumb('app_started')
+      recordCrashBreadcrumb('own_event', undefined, 'renderer:1')
+      recordCrashBreadcrumb('sibling_event', undefined, 'renderer:2')
+
+      expect(getCrashBreadcrumbSnapshot('renderer:1').map((entry) => entry.name)).toEqual([
+        'app_started',
+        'own_event'
+      ])
+    })
+
+    it('returns the whole ring when the reporter has no origin', () => {
+      recordCrashBreadcrumb('app_started')
+      recordCrashBreadcrumb('own_event', undefined, 'renderer:1')
+      recordCrashBreadcrumb('sibling_event', undefined, 'renderer:2')
+
+      expect(getCrashBreadcrumbSnapshot().map((entry) => entry.name)).toEqual([
+        'app_started',
+        'own_event',
+        'sibling_event'
+      ])
+    })
+
+    it('keeps a coalesced crumb on its emitter report only', () => {
+      recordCoalescedCrashBreadcrumb({
+        name: 'renderer_error',
+        data: { message: 'boom' },
+        coalesceKey: 'renderer_error:boom',
+        minIntervalMs: 30_000,
+        origin: 'renderer:1'
+      })
+
+      expect(getCrashBreadcrumbSnapshot('renderer:1').map((entry) => entry.name)).toEqual([
+        'renderer_error'
+      ])
+      expect(getCrashBreadcrumbSnapshot('renderer:2')).toEqual([])
+    })
+  })
+
   it('keeps a fixed-size in-memory snapshot', () => {
     for (let index = 0; index < 32; index += 1) {
       recordCrashBreadcrumb(`event_${index}`, { index })

--- a/src/main/crash-reporting/crash-breadcrumb-store.ts
+++ b/src/main/crash-reporting/crash-breadcrumb-store.ts
@@ -30,6 +30,8 @@ type CoalescedBreadcrumbState = {
   emitted?: CrashReportBreadcrumb
   /** Newest suppressed payload, sanitized only if a snapshot actually asks for it. */
   pending?: CrashReportBreadcrumbData
+  /** Origin of the key's emitter, so a materialized orphan stays attributed. */
+  origin?: string
 }
 
 let breadcrumbs: CrashReportBreadcrumb[] = []
@@ -45,16 +47,19 @@ function retainedBreadcrumbKey(breadcrumb: CrashReportBreadcrumb): string | null
   return `${breadcrumb.name}:${String(surface)}:${String(threshold)}`
 }
 
-/** Returns the stored breadcrumb so coalescing can refresh the entry it owns. */
+/** Returns the stored breadcrumb so coalescing can refresh the entry it owns.
+ *  `origin` marks a renderer-scoped crumb; main-process callers omit it. */
 export function recordCrashBreadcrumb(
   name: string,
-  data?: CrashReportBreadcrumbData
+  data?: CrashReportBreadcrumbData,
+  origin?: string
 ): CrashReportBreadcrumb | undefined {
   const sanitized = sanitizeCrashReportBreadcrumbs([
     {
       createdAt: new Date().toISOString(),
       name,
-      data
+      data,
+      ...(origin ? { origin } : {})
     }
   ])
   const breadcrumb = sanitized?.[0]
@@ -85,12 +90,14 @@ export function recordCoalescedCrashBreadcrumb({
   name,
   data,
   coalesceKey,
-  minIntervalMs
+  minIntervalMs,
+  origin
 }: {
   name: string
   data?: CrashReportBreadcrumbData
   coalesceKey: string
   minIntervalMs: number
+  origin?: string
 }): { suppressedSinceLast: number } | undefined {
   const now = monotonicNow()
   const previous = coalescedBreadcrumbs.get(coalesceKey)
@@ -136,7 +143,8 @@ export function recordCoalescedCrashBreadcrumb({
     windowStartedAtMs: now,
     suppressed: 0,
     carried: suppressedSinceLast,
-    resolved: 0
+    resolved: 0,
+    ...(origin ? { origin } : {})
   }
   coalescedBreadcrumbs.set(coalesceKey, state)
   while (coalescedBreadcrumbs.size > MAX_COALESCE_KEYS) {
@@ -149,7 +157,8 @@ export function recordCoalescedCrashBreadcrumb({
   }
   state.emitted = recordCrashBreadcrumb(
     name,
-    suppressedSinceLast > 0 ? { ...data, suppressedSinceLast } : data
+    suppressedSinceLast > 0 ? { ...data, suppressedSinceLast } : data,
+    origin
   )
   return { suppressedSinceLast }
 }
@@ -206,10 +215,14 @@ function preservePendingCoalescedBreadcrumb(state: CoalescedBreadcrumbState): vo
   if (state.emitted || unresolved <= 0) {
     return
   }
-  recordCrashBreadcrumb(state.name, {
-    ...state.pending,
-    suppressedSinceLast: unresolved
-  })
+  recordCrashBreadcrumb(
+    state.name,
+    {
+      ...state.pending,
+      suppressedSinceLast: unresolved
+    },
+    state.origin
+  )
   state.resolved = state.suppressed
   state.pending = undefined
 }
@@ -220,12 +233,26 @@ function resolveAllPendingCoalescedBreadcrumbs(): void {
   }
 }
 
-export function getCrashBreadcrumbSnapshot(): CrashReportBreadcrumb[] {
+/** Main-process crumbs (no origin) are evidence for every report; a renderer's
+ *  crumbs belong only to its own. Callers scope coalesce keys by origin so a
+ *  suppressed repeat never lands in an entry the emitter's report filters out. */
+function isVisibleToReporter(
+  breadcrumb: CrashReportBreadcrumb,
+  reporterOrigin: string | undefined
+): boolean {
+  return !reporterOrigin || !breadcrumb.origin || breadcrumb.origin === reporterOrigin
+}
+
+/** Without `reporterOrigin` (GPU/utility/child crashes) the whole ring is
+ *  returned. Filtering runs after the shared budget on purpose: a sibling's
+ *  crumbs can still cost this report ring slots — capacity is a separate change. */
+export function getCrashBreadcrumbSnapshot(reporterOrigin?: string): CrashReportBreadcrumb[] {
   resolveAllPendingCoalescedBreadcrumbs()
   // Why: long sessions must retain threshold profiles without growing the 30-entry budget.
   const retained = [...retainedBreadcrumbs.values()]
   const recent = breadcrumbs.slice(-(MAX_BREADCRUMBS - retained.length))
   return [...retained, ...recent]
+    .filter((breadcrumb) => isVisibleToReporter(breadcrumb, reporterOrigin))
     .sort((left, right) => left.createdAt.localeCompare(right.createdAt))
     .map((breadcrumb) => ({
       ...breadcrumb,

--- a/src/main/crash-reporting/process-gone-recorder.ts
+++ b/src/main/crash-reporting/process-gone-recorder.ts
@@ -6,6 +6,7 @@ import {
   sanitizeCrashReportString,
   type CrashReportBreadcrumbData
 } from '../../shared/crash-reporting'
+import { rendererCrashBreadcrumbOrigin } from '../../shared/crash-breadcrumb-origin'
 import { decodePosixWaitStatus, describePosixWaitStatus } from '../../shared/posix-wait-status'
 import type { CrashReportStore } from './crash-report-store'
 import { getCrashBreadcrumbSnapshot } from './crash-breadcrumb-store'
@@ -41,6 +42,9 @@ export type ProcessGoneCrashEvent = {
   exitCode: number | null
   expectedTeardown: ExpectedTeardownScope
   details: Record<string, unknown>
+  /** Crashing webContents, when the source is a renderer. Kept out of `details`
+   *  so this internal Chromium id never reaches the user-facing report text. */
+  webContentsId?: number
 }
 
 type CrashReportRecorderStore = Pick<CrashReportStore, 'record' | 'attachDetails'>
@@ -209,7 +213,13 @@ export function recordProcessGoneCrash(
     },
     event.processType
   )
-  const breadcrumbs = getCrashBreadcrumbSnapshot()
+  // Why: renderer crumbs are per-window evidence, so a report scopes to its own
+  // renderer; child/GPU crashes have no window and keep the whole ring.
+  const breadcrumbs = getCrashBreadcrumbSnapshot(
+    event.webContentsId === undefined
+      ? undefined
+      : rendererCrashBreadcrumbOrigin(event.webContentsId)
+  )
   const span = startSpan('electron.process_gone', {
     attributes: {
       'crash.source': event.source,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1845,7 +1845,8 @@ function recordProcessGoneCrash(
     reason,
     exitCode,
     expectedTeardown: getExpectedTeardownScope(webContentsId),
-    details
+    details,
+    ...(webContentsId !== undefined ? { webContentsId } : {})
   })
 }
 

--- a/src/main/ipc/crash-reporting-renderer-breadcrumbs.test.ts
+++ b/src/main/ipc/crash-reporting-renderer-breadcrumbs.test.ts
@@ -76,8 +76,11 @@ function registerHandlersWithStubStore(): void {
   } as never)
 }
 
-function emitRendererBreadcrumb(args: unknown): void {
-  listeners.get('crashReports:recordBreadcrumb')?.(null, args)
+function emitRendererBreadcrumb(args: unknown, senderId?: number): void {
+  listeners.get('crashReports:recordBreadcrumb')?.(
+    senderId === undefined ? null : { sender: { id: senderId } },
+    args
+  )
 }
 
 describe('renderer breadcrumb IPC routing', () => {
@@ -187,9 +190,11 @@ describe('renderer breadcrumb IPC routing', () => {
       data: { reasonType: 'Object' }
     })
 
-    expect(recordCrashBreadcrumbMock).toHaveBeenCalledWith('renderer_unhandled_rejection', {
-      reasonType: 'Object'
-    })
+    expect(recordCrashBreadcrumbMock).toHaveBeenCalledWith(
+      'renderer_unhandled_rejection',
+      { reasonType: 'Object' },
+      undefined
+    )
     expect(recordCoalescedCrashBreadcrumbMock).not.toHaveBeenCalled()
     expect(startSpanMock).toHaveBeenCalledTimes(1)
   })
@@ -382,10 +387,39 @@ describe('renderer breadcrumb IPC routing', () => {
   it('records non-error renderer breadcrumbs without coalescing', () => {
     emitRendererBreadcrumb({ name: 'renderer_bootstrap_started', data: { dev: true } })
 
-    expect(recordCrashBreadcrumbMock).toHaveBeenCalledWith('renderer_bootstrap_started', {
-      dev: true
-    })
+    expect(recordCrashBreadcrumbMock).toHaveBeenCalledWith(
+      'renderer_bootstrap_started',
+      { dev: true },
+      undefined
+    )
     expect(recordCoalescedCrashBreadcrumbMock).not.toHaveBeenCalled()
+  })
+
+  it('attributes breadcrumbs to the sending webContents on both record paths', () => {
+    emitRendererBreadcrumb({ name: 'renderer_bootstrap_started', data: { dev: true } }, 7)
+    emitRendererBreadcrumb({ name: 'renderer_error', data: { message: 'boom' } }, 7)
+
+    expect(recordCrashBreadcrumbMock).toHaveBeenCalledWith(
+      'renderer_bootstrap_started',
+      { dev: true },
+      'renderer:7'
+    )
+    expect(recordCoalescedCrashBreadcrumbMock.mock.calls[0]?.[0]).toMatchObject({
+      origin: 'renderer:7'
+    })
+  })
+
+  it('scopes the coalesce key per sender so windows do not share one entry', () => {
+    emitRendererBreadcrumb({ name: 'renderer_error', data: { message: 'boom' } }, 7)
+    emitRendererBreadcrumb({ name: 'renderer_error', data: { message: 'boom' } }, 9)
+    emitRendererBreadcrumb({ name: 'renderer_error', data: { message: 'boom' } })
+
+    const keys = recordCoalescedCrashBreadcrumbMock.mock.calls.map((call) => call[0].coalesceKey)
+    expect(new Set(keys).size).toBe(3)
+    // An unattributed sender keeps the pre-attribution key, so nothing shifts for it.
+    expect(keys[2]).not.toContain('renderer:')
+    expect(keys[0]).toContain('renderer:7')
+    expect(keys[1]).toContain('renderer:9')
   })
 
   it('ignores renderer breadcrumbs without a string name', () => {

--- a/src/main/ipc/crash-reporting-renderer-breadcrumbs.ts
+++ b/src/main/ipc/crash-reporting-renderer-breadcrumbs.ts
@@ -125,26 +125,37 @@ function rendererBreadcrumbCoalesceKey(
   return JSON.stringify([name, message, ...sourceIdentity])
 }
 
-export function recordRendererBreadcrumbFromRenderer(args?: {
-  name?: unknown
-  data?: unknown
-}): void {
+/** `origin` scopes the crumb to the sending renderer; absent means unattributed
+ *  (visible on every report), which is how this behaved before attribution. */
+export function recordRendererBreadcrumbFromRenderer(
+  args?: {
+    name?: unknown
+    data?: unknown
+  },
+  origin?: string
+): void {
   if (!args || typeof args.name !== 'string') {
     return
   }
   const data = sanitizeRendererBreadcrumbData(args.data)
   if (COALESCED_RENDERER_BREADCRUMB_NAMES.has(args.name)) {
-    const coalesceKey = rendererBreadcrumbCoalesceKey(args.name, data)
-    if (!coalesceKey) {
-      recordCrashBreadcrumb(args.name, data)
+    const eventKey = rendererBreadcrumbCoalesceKey(args.name, data)
+    if (!eventKey) {
+      recordCrashBreadcrumb(args.name, data, origin)
       recordRendererBreadcrumbTrace(args.name, data)
       return
     }
+    // Why: windows run the same bundle, so an unscoped key lets whichever
+    // emitted first own the entry — the sibling's copy is suppressed into a
+    // crumb its own report filters out, and the owner's count claims it.
+    // Costs one slot per storming window; still MAX_COALESCE_KEYS-bounded.
+    const coalesceKey = origin ? `${origin}\u0000${eventKey}` : eventKey
     const coalesceResult = recordCoalescedCrashBreadcrumb({
       name: args.name,
       data,
       coalesceKey,
-      minIntervalMs: RENDERER_BREADCRUMB_COALESCE_MS
+      minIntervalMs: RENDERER_BREADCRUMB_COALESCE_MS,
+      origin
     })
     // Why: tracing every suppressed duplicate would preserve the same
     // serialization and disk churn that breadcrumb coalescing removes.
@@ -157,7 +168,7 @@ export function recordRendererBreadcrumbFromRenderer(args?: {
       )
     }
   } else {
-    recordCrashBreadcrumb(args.name, data)
+    recordCrashBreadcrumb(args.name, data, origin)
     recordRendererBreadcrumbTrace(args.name, data)
   }
 }

--- a/src/main/ipc/crash-reporting-renderer-error-report.ts
+++ b/src/main/ipc/crash-reporting-renderer-error-report.ts
@@ -4,6 +4,7 @@ import type {
   ReactErrorBoundaryReportArgs,
   ReactErrorBoundaryReportResult
 } from '../../shared/crash-reporting'
+import { rendererCrashBreadcrumbOrigin } from '../../shared/crash-breadcrumb-origin'
 import type { CrashReportStore } from '../crash-reporting/crash-report-store'
 import { getCrashBreadcrumbSnapshot } from '../crash-reporting/crash-breadcrumb-store'
 
@@ -118,7 +119,8 @@ function getRendererErrorReportKey(args: ReactErrorBoundaryReportArgs): string {
 
 export async function recordRendererErrorReport(
   store: CrashReportStore,
-  args: unknown
+  args: unknown,
+  webContentsId?: number
 ): Promise<ReactErrorBoundaryReportResult> {
   const normalized = normalizeRendererErrorReportArgs(args)
   if (!normalized) {
@@ -167,7 +169,9 @@ export async function recordRendererErrorReport(
     },
     // Why: React render failures are recoverable only because a boundary
     // caught them; persist the same recent app breadcrumbs as native crashes.
-    breadcrumbs: getCrashBreadcrumbSnapshot()
+    breadcrumbs: getCrashBreadcrumbSnapshot(
+      webContentsId === undefined ? undefined : rendererCrashBreadcrumbOrigin(webContentsId)
+    )
   })
 
   return { ok: true, report, deduped: false }

--- a/src/main/ipc/crash-reporting.ts
+++ b/src/main/ipc/crash-reporting.ts
@@ -4,6 +4,7 @@ import {
   type CrashReportSubmitArgs,
   formatCrashReportText
 } from '../../shared/crash-reporting'
+import { rendererCrashBreadcrumbOrigin } from '../../shared/crash-breadcrumb-origin'
 import type { CrashReportStore } from '../crash-reporting/crash-report-store'
 import {
   assertClipboardTextWriteWithinLimit,
@@ -64,8 +65,14 @@ export function registerCrashReportingHandlers(store: CrashReportStore): void {
   ipcMain.removeAllListeners('crashReports:recordBreadcrumb')
   ipcMain.on(
     'crashReports:recordBreadcrumb',
-    (_event, args?: { name?: unknown; data?: unknown }) => {
-      recordRendererBreadcrumbFromRenderer(args)
+    (event, args?: { name?: unknown; data?: unknown }) => {
+      // Why: the sender is the only place the emitting renderer is known; drop it
+      // and a sibling window's trail lands on this window's crash report.
+      const senderId = event?.sender?.id
+      recordRendererBreadcrumbFromRenderer(
+        args,
+        typeof senderId === 'number' ? rendererCrashBreadcrumbOrigin(senderId) : undefined
+      )
     }
   )
 
@@ -94,9 +101,9 @@ export function registerCrashReportingHandlers(store: CrashReportStore): void {
   )
 
   ipcMain.removeHandler('crashReports:recordRendererError')
-  ipcMain.handle('crashReports:recordRendererError', async (_event, args: unknown) => {
+  ipcMain.handle('crashReports:recordRendererError', async (event, args: unknown) => {
     try {
-      return await recordRendererErrorReport(store, args)
+      return await recordRendererErrorReport(store, args, event?.sender?.id)
     } catch (error) {
       console.error('[crash-reporting] Failed to record renderer error report:', error)
       return { ok: false, error: 'Failed to record renderer error report.' }

--- a/src/shared/crash-breadcrumb-origin.ts
+++ b/src/shared/crash-breadcrumb-origin.ts
@@ -1,0 +1,5 @@
+/** Single definition of the breadcrumb `origin` label so the recording side
+ *  (IPC sender) and the reporting side (crash snapshot) agree on the format. */
+export function rendererCrashBreadcrumbOrigin(webContentsId: number): string {
+  return `renderer:${webContentsId}`
+}

--- a/src/shared/crash-reporting.test.ts
+++ b/src/shared/crash-reporting.test.ts
@@ -91,6 +91,22 @@ describe('crash-reporting shared helpers', () => {
     })
   })
 
+  it('carries a breadcrumb origin through sanitization and redaction', () => {
+    const breadcrumbs = sanitizeCrashReportBreadcrumbs([
+      { createdAt: '2026-05-16T01:00:00.000Z', name: 'main_event' },
+      { createdAt: '2026-05-16T01:00:01.000Z', name: 'renderer_event', origin: 'renderer:7' },
+      {
+        createdAt: '2026-05-16T01:00:02.000Z',
+        name: 'spoofed_event',
+        origin: '/Users/alice/project'
+      }
+    ])
+
+    expect(breadcrumbs?.[0].origin).toBeUndefined()
+    expect(breadcrumbs?.[1].origin).toBe('renderer:7')
+    expect(breadcrumbs?.[2].origin).toBe('[redacted-path]')
+  })
+
   it('recognizes crash reasons captured by Electron process-gone events', () => {
     expect(isCrashReportReason('abnormal-exit')).toBe(true)
     expect(isCrashReportReason('crashed')).toBe(true)

--- a/src/shared/crash-reporting.ts
+++ b/src/shared/crash-reporting.ts
@@ -17,12 +17,15 @@ export type CrashReportBreadcrumb = {
   createdAt: string
   name: string
   data?: CrashReportBreadcrumbData
+  /** Emitting surface, absent for main-process crumbs (global evidence). */
+  origin?: string
 }
 
 export type CrashReportBreadcrumbInput = {
   createdAt: string
   name: string
   data?: Record<string, unknown>
+  origin?: string
 }
 
 export type CrashReportRecord = {
@@ -127,6 +130,7 @@ export type CrashReportCopyDiagnosticsArgs = {
 const MAX_STRING_DETAIL_LENGTH = 240
 const MAX_STACK_DETAIL_LENGTH = 4_000
 const MAX_BREADCRUMB_NAME_LENGTH = 80
+const MAX_BREADCRUMB_ORIGIN_LENGTH = 80
 const MAX_BREADCRUMBS = 30
 const MAX_FORMATTED_REPORT_LENGTH = 64_000
 const FORMATTED_REPORT_TRUNCATION_SUFFIX =
@@ -221,10 +225,14 @@ export function sanitizeCrashReportBreadcrumbs(
         return null
       }
       const data = breadcrumb.data ? sanitizeCrashReportDetails(breadcrumb.data) : {}
+      const origin = breadcrumb.origin
+        ? sanitizeCrashReportString(breadcrumb.origin).slice(0, MAX_BREADCRUMB_ORIGIN_LENGTH)
+        : ''
       return {
         createdAt: sanitizeCrashReportString(breadcrumb.createdAt),
         name: sanitizeCrashReportString(breadcrumb.name).slice(0, MAX_BREADCRUMB_NAME_LENGTH),
-        ...(Object.keys(data).length > 0 ? { data } : {})
+        ...(Object.keys(data).length > 0 ? { data } : {}),
+        ...(origin ? { origin } : {})
       }
     })
     .filter((breadcrumb): breadcrumb is CrashReportBreadcrumb => breadcrumb !== null)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​359 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​351 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​102 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​29 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​73 |

<!-- /orca-pr-loc -->

## Description

Crash breadcrumbs are stored in a **single global ring** in the main process (`crash-breadcrumb-store.ts`, `MAX_BREADCRUMBS = 30`), and the IPC listener that receives renderer breadcrumbs **discarded the sender**:

```ts
// src/main/ipc/crash-reporting.ts — before
ipcMain.on('crashReports:recordBreadcrumb', (_event, args) => {
  recordRendererBreadcrumbFromRenderer(args)   // _event.sender.id thrown away
})
```

`getCrashBreadcrumbSnapshot()` was then attached **unfiltered** to every renderer crash report. So a report filed by renderer A carried breadcrumbs emitted by renderer B — a second window, a browser-pane webview guest, or the dashboard popout. Orca genuinely runs multiple renderers; the `renderer_memory` breadcrumb literally reports `browserWebviews` and `registeredBrowserGuests` counts.

This fix tags each renderer breadcrumb with its originating `webContents` and filters the snapshot to the reporting renderer. Main-process breadcrumbs (`app_started`, `updater_*`, `gpu_fallback_applied`, …) carry no origin and stay visible on every report, because they are genuinely global evidence.

**This is not a theoretical bug — it produced a wrong diagnosis during the triage that found it.** Investigating crash `b05f68db` / `sidebar.worktrees` from #orca-crashes, I read a `lazy_chunk_reload` + `lazy_chunk_reload_vetoed` breadcrumb pair in the bundle as proof that the crashing renderer had taken the lazy-chunk reload branch, and built a whole root-cause theory on it. Because the ring is global and unattributed, those crumbs could have come from any renderer. The theory was wrong.

## Fix evidence

`src/main/crash-reporting/crash-breadcrumb-renderer-attribution.test.ts` drives the **real** main-process code — the real `registerCrashReportingHandlers`, the real store (not mocked; the pre-existing IPC suites mock the store, which is exactly why they never caught this), the real `recordProcessGoneCrash`, and the real `crashReports:recordRendererError` handler. Two renderers are simulated by invoking the captured IPC listener with `{ sender: { id: 11 } }` and `{ sender: { id: 22 } }`. Assertions read what actually lands in `store.record(...)`.

**BEFORE** — production code at `origin/main`, new tests applied:

```
× does not attach a sibling renderer breadcrumb to a process-gone report
  → expected [ 'app_started', …(2) ] to not include 'lazy_chunk_reload_vetoed'
× keeps a quiet renderer own trail while other renderers churn
  → expected [ 'renderer_bootstrap_started', …(21) ] to deeply equal [ 'renderer_bootstrap_started', …(1) ]
× keeps an identical coalesced storm on each emitting renderer report
  → expected 1 to be undefined
× does not file one renderer payload under a name-only coalesced sibling
  → expected 9 to be 1
× does not attach a sibling renderer breadcrumb to a react-error-boundary report
  → expected [ 'app_started', …(2) ] to not include 'lazy_chunk_reload_vetoed'
× stores the origin label sanitization leaves untouched, so filtering matches
  → expected undefined to be 'renderer:11'
✓ still coalesces one renderer own repeats into a single entry
✓ keeps every renderer trail on a child crash that names no webContents

Tests  6 failed | 2 passed (8)
```

**AFTER** — fix applied, same tests, nothing weakened:

```
✓ does not attach a sibling renderer breadcrumb to a process-gone report
✓ keeps a quiet renderer own trail while other renderers churn
✓ keeps an identical coalesced storm on each emitting renderer report
✓ does not file one renderer payload under a name-only coalesced sibling
✓ still coalesces one renderer own repeats into a single entry
✓ does not attach a sibling renderer breadcrumb to a react-error-boundary report
✓ keeps every renderer trail on a child crash that names no webContents
✓ stores the origin label sanitization leaves untouched, so filtering matches

Tests  8 passed (8)
```

Note the two tests that **pass before and after** — they are the guard rails proving the fix does not over-correct: a child/GPU crash that names no renderer still gets the whole ring, and one renderer's own repeats still coalesce normally.

Wider verification, macOS (arm64):
```
src/main/crash-reporting + ipc/crash-reporting + shared/crash-reporting
+ renderer crash-diagnostics + react-error-boundary-reporting + createMainWindow-renderer-crash-recovery
  Test Files  26 passed (26)      Tests  291 passed (291)
```
`tsc --noEmit -p config/tsconfig.node.json` → exit 0. `oxlint` clean.

**Windows (win32, `awin`)** — 42 of the 66 crashes in this triage batch were Windows, so the suite was re-run natively there:
```
neil@awin MINGW64 ~/orca/workspaces/orca/crash-win-08-20 (verify-crumbs)
 Test Files  23 passed (23)      Tests  263 passed (263)
```

## ELI5

Imagine one shared notepad on the wall of a building. Every room writes what it's doing on that same notepad, and nobody signs their name. When one room catches fire, we photocopy the last 30 lines of the notepad and staple it to the incident report as "what this room was doing."

Except half those lines were written by other rooms. So the fire investigator reads "was heating oil" and blames the wrong room — which is exactly what happened to me while triaging these crashes.

This change makes each room sign its notes. Building-wide announcements ("power came back on") stay unsigned and go on every report, because they really do apply to everyone. When a room catches fire, the report now includes the building-wide announcements plus that room's own notes, and nobody else's.

## Trade-offs

Real ones, including things that get *worse*:

1. **The eviction half is deliberately NOT fixed.** The ring is still one shared 30-entry budget and the filter runs *after* the budget slice. A chatty sibling renderer can still push the crashing renderer's crumbs out before the report is filed, so a scoped report can now come back with **fewer than 30 entries** where it previously came back with 30. Those extra entries were another renderer's and were misleading — but "fewer breadcrumbs" is a visible change, and it means a busy multi-window session can still produce a thin report. Fixing it properly is a capacity/tuning decision; see "Rejected approach" below for why it is not in this PR. Comments on `getCrashBreadcrumbSnapshot` and in the test say so explicitly.

2. **Webview guests and popouts drop off the main window's report.** Browser-pane guests and `dashboard-popout` are separate `webContents`, so their breadcrumbs no longer appear on the main window's crash report. This is the intended semantics, but if you were relying on seeing browser-guest activity on a main-window crash, you will not see it any more. The flip side is that a popout's own boundary report now gets its own trail instead of the main window's.

3. **Cross-renderer coalescing changed.** The renderer coalesce key now includes origin, so two renderers emitting an identical coalesced breadcrumb inside the 30s window no longer share one entry. This costs **one extra ring slot per storming window** (still `MAX_COALESCE_KEYS`-bounded). Without it, the sibling's copy was suppressed into an entry its own report then filtered out — the count vanished. That was a blocker finding in review loop 1.

4. **`origin` is a new optional field on the serialized breadcrumb** and appears in crash-report text as `- <ts>: <name> [renderer:11]`. Per `docs/reference/remote-wire-compatibility.md` this is the safe case: additive, no new stream opcode. Absent origin degrades to today's behavior (visible on every report), never to a disappearance. It goes through the same `sanitizeCrashReportString` redaction and length cap as every other breadcrumb string, and there is a test locking the round-trip so filtering can never silently stop matching.

5. **No behavior change for GPU/utility/child crashes** — they name no renderer and keep the full ring, because no single surface filed the report and scoping it would delete real evidence.

## Rejected approach (worth knowing before review)

The first attempt at this fix tried to solve misattribution **and** eviction together, and redesigned the storage layer: per-origin rings, per-origin retained crumbs, reserved snapshot budgets, and a 16-origin LRU. It **failed 5 consecutive adversarial review loops without converging**. Every blocker/major finding was about the machinery it added, not the bug — LRU-evicting a live renderer's entire trail, erasing evidence on the `webContents destroyed` path, losing retained-crumb dedup, and over-reporting coalesce visibility (the same class of error "fixed" wrongly three times). A perf pass measured it introducing a **13× regression** on the coalesce expiry sweep (0.242ms → 3.267ms) plus 2.5ms of synchronous main-process work on every window close.

That approach was discarded and the problem split. This PR does misattribution only: **~60 net lines of production code**, filtering on read, single ring untouched.

## Adversarial review

**2 loops to clean.** Each loop was a fresh sub-agent with no prior context, instructed to break the change and to treat any reintroduced per-origin ring / budget / LRU as a blocker.

- **Loop 1 — not clean. 1 blocker, 1 minor, 1 nit.**
  - *blocker*: the coalesce key excluded `origin`, so two renderers emitting the same coalesced breadcrumb shared one ring entry owned by whichever emitted first; the sibling's copy was suppressed into a crumb its own report filtered out, and the count was lost. **Fixed** (trade-off 3 above).
  - *minor*: no recorder-level test locked the "absent reporter id degrades to the full ring" contract.
  - *nit*: the reporting side built the origin label raw while the recording side stored it sanitized; equality held only by luck.
- **Loop 2 — clean.** No blockers or majors. Three residual minor/nit items were reported, two of which I then closed by hand with the last two tests in the suite (`keeps every renderer trail on a child crash that names no webContents`, `stores the origin label sanitization leaves untouched`). The remaining minor — retained `renderer_memory_highwater` crumbs carry an origin while `retainedBreadcrumbKey` is still `name:surface:threshold` — is noted and left; it only affects which of two same-surface high-water profiles is retained, not attribution.

## Perf

`/perf` audit: **no meaningful impact.**
- +~0.31 µs per renderer breadcrumb (one sanitize pass over the `renderer:<id>` string) and +~0.06 µs on the coalesce suppressed path. At the worst observed emission rate (1459/min crash loop ≈ 24 crumbs/s) that is **+1.3 µs of main-process CPU per second**.
- The snapshot path gets **64.7% faster** when filtered, because `.filter` drops entries before the `sort` and deep `map`.
- The `O(origins × ring)` shape that caused the rejected attempt's 13× regression is absent: `isVisibleToReporter` is O(1) per crumb on crash-time-only paths, and `isCoalescedCrumbStillInEvidence` (the O(ring) `indexOf` the expiry sweep calls) is **byte-identical to HEAD**.
- No optimizations applied — every candidate was either unsafe or not worth the code.

## Scope / collisions

Deliberately does not touch process-gone classification or suppression policy. Verified no overlap with open PRs #12484, #15251, #15059, #15294. `webContentsId` is added as a first-class optional field on `ProcessGoneCrashEvent` rather than stuffed into the untyped `details` blob, so the internal Chromium id never reaches the persisted report or the user-facing copy-diagnostics text.
