### PR TITLE
fix(terminal): retire tab icon after confirmed shell return (STA-3867)

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection-command-finished-cleanup.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-command-finished-cleanup.test.ts
@@ -333,7 +333,8 @@ describe('connectPanePty', () => {
   it('clears pane-scoped sleeping identity after a confirmed return to shell', async () => {
     vi.useFakeTimers()
     const { connectPanePty } = await import('./pty-connection')
-    vi.mocked(window.api.pty.confirmForegroundProcess).mockResolvedValue('zsh')
+    const confirmForegroundProcess = vi.mocked(window.api.pty.confirmForegroundProcess)
+    confirmForegroundProcess.mockResolvedValue('codex')
     const dataCallbackRef: { current: ((data: string) => void) | null } = { current: null }
     const ptyId = 'pty-codex-confirmed-shell-sleeping'
     const transport = createMockTransport(ptyId)
@@ -361,12 +362,71 @@ describe('connectPanePty', () => {
       agent: 'codex'
     } as StoreState['sleepingAgentSessionsByPaneKey'][string]
 
+    dataCallbackRef.current?.('\x1b]133;C\x07')
+    await vi.advanceTimersByTimeAsync(350)
+    expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toMatchObject({
+      agent: 'codex'
+    })
+    expect(mockStoreState.clearSleepingAgentSession).not.toHaveBeenCalled()
+
+    confirmForegroundProcess.mockResolvedValue('zsh')
     dataCallbackRef.current?.('\x1b]133;D;0\x07')
     expect(mockStoreState.clearSleepingAgentSession).not.toHaveBeenCalled()
 
     await vi.advanceTimersByTimeAsync(350)
     expect(mockStoreState.clearSleepingAgentSession).toHaveBeenCalledExactlyOnceWith(paneKey)
     expect(mockStoreState.sleepingAgentSessionsByPaneKey[paneKey]).toBeUndefined()
+    expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+      agent: null,
+      shellForeground: true
+    })
+  })
+
+  it('keeps sleeping occupancy while a restore shell confirms before resume consumes it', async () => {
+    vi.useFakeTimers()
+    const { connectPanePty } = await import('./pty-connection')
+    vi.mocked(window.api.pty.confirmForegroundProcess).mockResolvedValue('zsh')
+    const dataCallbackRef: { current: ((data: string) => void) | null } = { current: null }
+    const ptyId = 'pty-codex-restore-shell-sleeping'
+    const transport = createMockTransport(ptyId)
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      dataCallbackRef.current = callbacks.onData ?? null
+      return { id: ptyId }
+    })
+    transportFactoryQueue.push(transport)
+    const paneKey = makePaneKey('tab-1', LEAF_1)
+
+    connectPanePty(
+      createPane(1) as never,
+      createManager(1) as never,
+      createDeps({ isVisibleRef: { current: false } }) as never
+    )
+    await vi.advanceTimersByTimeAsync(20)
+    await flushAsyncTicks()
+    mockStoreState.agentLaunchConfigByPaneKey[paneKey] = {
+      launchConfig: { agentArgs: '', agentEnv: {} },
+      identity: { agentType: 'codex' }
+    }
+    mockStoreState.sleepingAgentSessionsByPaneKey[paneKey] = {
+      paneKey,
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      agent: 'codex',
+      providerSession: { key: 'session_id', id: 'codex-session-restore' },
+      prompt: 'resume this',
+      state: 'working',
+      capturedAt: 1,
+      updatedAt: 1,
+      origin: 'worktree-sleep'
+    } as StoreState['sleepingAgentSessionsByPaneKey'][string]
+
+    dataCallbackRef.current?.('\x1b]133;D;0\x07')
+    await vi.advanceTimersByTimeAsync(350)
+    expect(mockStoreState.clearSleepingAgentSession).not.toHaveBeenCalled()
+    expect(mockStoreState.sleepingAgentSessionsByPaneKey[paneKey]).toMatchObject({
+      agent: 'codex',
+      providerSession: { key: 'session_id', id: 'codex-session-restore' }
+    })
     expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
       agent: null,
       shellForeground: true

--- a/src/renderer/src/components/terminal-pane/pty-connection-command-finished-cleanup.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-command-finished-cleanup.test.ts
@@ -330,6 +330,90 @@ describe('connectPanePty', () => {
     expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, paneKey)).toBe('alt-enter')
   })
 
+  it('clears pane-scoped sleeping identity after a confirmed return to shell', async () => {
+    vi.useFakeTimers()
+    const { connectPanePty } = await import('./pty-connection')
+    vi.mocked(window.api.pty.confirmForegroundProcess).mockResolvedValue('zsh')
+    const dataCallbackRef: { current: ((data: string) => void) | null } = { current: null }
+    const ptyId = 'pty-codex-confirmed-shell-sleeping'
+    const transport = createMockTransport(ptyId)
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      dataCallbackRef.current = callbacks.onData ?? null
+      return { id: ptyId }
+    })
+    transportFactoryQueue.push(transport)
+    const paneKey = makePaneKey('tab-1', LEAF_1)
+
+    connectPanePty(
+      createPane(1) as never,
+      createManager(1) as never,
+      createDeps({ isVisibleRef: { current: false } }) as never
+    )
+    await vi.advanceTimersByTimeAsync(20)
+    await flushAsyncTicks()
+    mockStoreState.agentLaunchConfigByPaneKey[paneKey] = {
+      launchConfig: { agentArgs: '', agentEnv: {} },
+      identity: { agentType: 'codex' }
+    }
+    mockStoreState.sleepingAgentSessionsByPaneKey[paneKey] = {
+      paneKey,
+      worktreeId: 'wt-1',
+      agent: 'codex'
+    } as StoreState['sleepingAgentSessionsByPaneKey'][string]
+
+    dataCallbackRef.current?.('\x1b]133;D;0\x07')
+    expect(mockStoreState.clearSleepingAgentSession).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(350)
+    expect(mockStoreState.clearSleepingAgentSession).toHaveBeenCalledExactlyOnceWith(paneKey)
+    expect(mockStoreState.sleepingAgentSessionsByPaneKey[paneKey]).toBeUndefined()
+    expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+      agent: null,
+      shellForeground: true
+    })
+  })
+
+  it('keeps sleeping identity while a leaked 133;D still shows the agent in the foreground', async () => {
+    vi.useFakeTimers()
+    const { connectPanePty } = await import('./pty-connection')
+    vi.mocked(window.api.pty.confirmForegroundProcess).mockResolvedValue('codex')
+    const dataCallbackRef: { current: ((data: string) => void) | null } = { current: null }
+    const ptyId = 'pty-codex-leaked-d-sleeping'
+    const transport = createMockTransport(ptyId)
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      dataCallbackRef.current = callbacks.onData ?? null
+      return { id: ptyId }
+    })
+    transportFactoryQueue.push(transport)
+    const paneKey = makePaneKey('tab-1', LEAF_1)
+
+    connectPanePty(
+      createPane(1) as never,
+      createManager(1) as never,
+      createDeps({ isVisibleRef: { current: false } }) as never
+    )
+    await vi.advanceTimersByTimeAsync(20)
+    await flushAsyncTicks()
+    mockStoreState.agentLaunchConfigByPaneKey[paneKey] = {
+      launchConfig: { agentArgs: '', agentEnv: {} },
+      identity: { agentType: 'codex' }
+    }
+    mockStoreState.sleepingAgentSessionsByPaneKey[paneKey] = {
+      paneKey,
+      worktreeId: 'wt-1',
+      agent: 'codex'
+    } as StoreState['sleepingAgentSessionsByPaneKey'][string]
+
+    dataCallbackRef.current?.('\x1b]133;D;0\x07')
+    await vi.advanceTimersByTimeAsync(350 + 1200 + 6000)
+    await flushAsyncTicks()
+
+    expect(mockStoreState.clearSleepingAgentSession).not.toHaveBeenCalled()
+    expect(mockStoreState.sleepingAgentSessionsByPaneKey[paneKey]).toMatchObject({
+      agent: 'codex'
+    })
+  })
+
   it('disarms stale TUI modes in the emulator after a confirmed return to shell', async () => {
     vi.useFakeTimers()
     const { connectPanePty } = await import('./pty-connection')

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -2136,18 +2136,34 @@ export function connectPanePty(
       executionHostId: getExecutionHostIdForWorktree(state, deps.worktreeId)
     })
   }
+  // Why: restore/hibernation can confirm a replacement shell before resume
+  // consumes the sleeping record; only an agent actually seen on this PTY
+  // generation may retire leftover occupancy at /exit.
+  let paneSawForegroundAgent = false
   const paneForegroundAgentTracker = createPaneForegroundAgentTracker({
     getPtyId: () => transport.getPtyId(),
     isTrackablePtyId: isForegroundTrackingAllowed,
     readForegroundProcess: (id) => window.api.pty.getForegroundProcess(id),
     confirmForegroundProcess: (id) => window.api.pty.confirmForegroundProcess(id),
-    publish: (entry) => useAppStore.getState().setPaneForegroundAgent(cacheKey, entry),
+    publish: (entry) => {
+      if (entry.agent) {
+        paneSawForegroundAgent = true
+      }
+      useAppStore.getState().setPaneForegroundAgent(cacheKey, entry)
+    },
     hasKnownAgentIdentity: paneHasKnownAgentIdentity,
     onConfirmedShellForeground: (reason) => {
-      // Why: confirmed shell already clears titles and launch routing; a leftover
-      // pane sleeping record would keep painting the exited agent on the tab.
-      useAppStore.getState().clearSleepingAgentSession(cacheKey)
-      clearStaleAgentTabTitleOnConfirmedShell()
+      const state = useAppStore.getState()
+      const ptyId = transport.getPtyId()
+      const hibernationKillInFlight = ptyId != null && state.suppressedPtyExitIds[ptyId] === true
+      if (paneSawForegroundAgent && !hibernationKillInFlight) {
+        // Why: confirmed shell already clears titles and launch routing; a leftover
+        // pane sleeping record would keep painting the exited agent on the tab.
+        // Restore shells must not wipe occupancy or the persisted agent title
+        // before resume consumes the sleeping record.
+        state.clearSleepingAgentSession(cacheKey)
+        clearStaleAgentTabTitleOnConfirmedShell()
+      }
       // Why: a hard-killed agent leaves mouse/focus/kitty modes armed, and the
       // surviving shell then receives pointer moves as typed SGR reports; the
       // replay guard keeps xterm's auto-replies from leaking to the shell.
@@ -2690,6 +2706,7 @@ export function connectPanePty(
     // entry so the hover UI only shows what is running *now*.
     useAppStore.getState().removeAgentStatus(cacheKey)
     useAppStore.getState().clearPaneForegroundAgent(cacheKey)
+    paneSawForegroundAgent = false
     // The runtime graph is the CLI's source for live terminal bindings, so
     // we must republish when a pane loses its PTY instead of waiting for a
     // broader layout change that may never happen.

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -2144,6 +2144,9 @@ export function connectPanePty(
     publish: (entry) => useAppStore.getState().setPaneForegroundAgent(cacheKey, entry),
     hasKnownAgentIdentity: paneHasKnownAgentIdentity,
     onConfirmedShellForeground: (reason) => {
+      // Why: confirmed shell already clears titles and launch routing; a leftover
+      // pane sleeping record would keep painting the exited agent on the tab.
+      useAppStore.getState().clearSleepingAgentSession(cacheKey)
       clearStaleAgentTabTitleOnConfirmedShell()
       // Why: a hard-killed agent leaves mouse/focus/kitty modes armed, and the
       // surviving shell then receives pointer moves as typed SGR reports; the

--- a/src/renderer/src/lib/tui-agent-startup.test.ts
+++ b/src/renderer/src/lib/tui-agent-startup.test.ts
@@ -419,4 +419,11 @@ describe('isShellProcess', () => {
     expect(isShellProcess('gemini')).toBe(false)
     expect(isShellProcess('cursor-agent')).toBe(false)
   })
+
+  it('treats non-standard interactive shells as shell foreground', () => {
+    expect(isShellProcess('ksh')).toBe(true)
+    expect(isShellProcess('dash')).toBe(true)
+    expect(isShellProcess('fish')).toBe(true)
+    expect(isShellProcess('/usr/bin/ksh')).toBe(true)
+  })
 })

--- a/src/renderer/src/lib/use-tab-agent-sleeping-session.test.ts
+++ b/src/renderer/src/lib/use-tab-agent-sleeping-session.test.ts
@@ -3,13 +3,14 @@
 import { act, createElement } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { buildTitleDerivedAgentRows } from '@/components/sidebar/worktree-title-derived-agent-rows'
 import { useAppStore } from '@/store'
 import type {
   ResumableTuiAgent,
   SleepingAgentSessionRecord
 } from '../../../shared/agent-session-resume'
 import { makePaneKey } from '../../../shared/stable-pane-id'
-import type { TerminalTab } from '../../../shared/terminal-tab-types'
+import type { TerminalLayoutSnapshot, TerminalTab } from '../../../shared/terminal-tab-types'
 import type { TuiAgent } from '../../../shared/tui-agent'
 import { resolveTabAgentFromSignals, useTabAgent } from './use-tab-agent'
 
@@ -40,6 +41,13 @@ async function renderHookProbe(tab: TerminalTab): Promise<Root> {
   })
   await flushHookEffects()
   return root
+}
+
+async function rerenderHookProbe(root: Root, tab: TerminalTab): Promise<void> {
+  await act(async () => {
+    root.render(createElement(HookProbe, { tab }))
+  })
+  await flushHookEffects()
 }
 
 function sleepingRecord(paneKey: string, agent: ResumableTuiAgent): SleepingAgentSessionRecord {
@@ -110,6 +118,105 @@ describe('resolveTabAgentFromSignals sleeping-session precedence', () => {
       })
     ).toBe('codex')
   })
+
+  it('retires a leftover sleeping identity once the local pane returns to a shell', () => {
+    // Why: confirmed-shell / shell-title exit already clears launch identity;
+    // sleeping occupancy must not refill the tab icon after /exit.
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: true,
+        isRemote: false,
+        title: 'zsh',
+        hookAgent: null,
+        sleepingSessionAgent: 'codex',
+        launchAgent: 'codex'
+      })
+    ).toBeNull()
+  })
+
+  it('retires a leftover sleeping identity on confirmed shell even when the OSC title is stuck', () => {
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: true,
+        isRemote: false,
+        title: '✳ Codex',
+        hookAgent: null,
+        processAgent: null,
+        processShellForeground: true,
+        sleepingSessionAgent: 'codex',
+        launchAgent: 'codex'
+      })
+    ).toBeNull()
+  })
+
+  it('keeps the icon when a launched agent only changes its conversation title', () => {
+    // Why: #15665 — conversation names are not exit evidence.
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: true,
+        isRemote: false,
+        title: 'Explain GitHub issue simply',
+        hookAgent: null,
+        sleepingSessionAgent: 'codex',
+        launchAgent: 'codex'
+      })
+    ).toBe('codex')
+  })
+
+  it.each(['ksh', 'dash', 'fish'] as const)(
+    'retires sleeping identity when the pane returns to %s',
+    (shell) => {
+      expect(
+        resolveTabAgentFromSignals({
+          hasObservedAgentSignal: true,
+          isRemote: false,
+          title: shell,
+          hookAgent: null,
+          sleepingSessionAgent: 'codex',
+          launchAgent: 'codex'
+        })
+      ).toBeNull()
+    }
+  )
+
+  it('retires the tab icon and the title-derived sidebar row together at a shell title', () => {
+    const layout: TerminalLayoutSnapshot = {
+      root: { type: 'leaf', leafId: LEAF_ID },
+      activeLeafId: LEAF_ID,
+      expandedLeafId: null
+    }
+    const tab: TerminalTab = {
+      id: 'tab-1',
+      ptyId: 'pty-1',
+      worktreeId: 'wt-1',
+      title: 'zsh',
+      customTitle: null,
+      color: null,
+      sortOrder: 0,
+      createdAt: 1,
+      launchAgent: 'codex'
+    }
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: true,
+        isRemote: false,
+        title: tab.title,
+        defaultTitle: tab.defaultTitle,
+        hookAgent: null,
+        sleepingSessionAgent: 'codex',
+        launchAgent: tab.launchAgent
+      })
+    ).toBeNull()
+    expect(
+      buildTitleDerivedAgentRows({
+        tabs: [tab],
+        ptyIdsByTabId: { 'tab-1': ['pty-1'] },
+        terminalLayoutsByTabId: { 'tab-1': layout },
+        seenPaneKeys: new Set(),
+        now: 1
+      })
+    ).toEqual([])
+  })
 })
 
 describe('useTabAgent sleeping-session', () => {
@@ -179,5 +286,38 @@ describe('useTabAgent sleeping-session', () => {
 
     expect(latestHookAgent).toBe('claude')
     expect(getForegroundProcess).not.toHaveBeenCalled()
+  })
+
+  it('retires the tab icon when a sleeping session remains after confirmed shell foreground', async () => {
+    const paneKey = makePaneKey('tab-1', LEAF_ID)
+    useAppStore.setState({
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: LEAF_ID },
+          activeLeafId: LEAF_ID,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [LEAF_ID]: 'pty-1' }
+        }
+      },
+      agentStatusByPaneKey: {},
+      paneForegroundAgentByPaneKey: {
+        [paneKey]: { agent: 'codex', shellForeground: false }
+      }
+    })
+
+    const root = await renderHookProbe({ ...baseTab, title: '✳ Codex' })
+    expect(latestHookAgent).toBe('codex')
+
+    await act(async () => {
+      useAppStore.setState({
+        sleepingAgentSessionsByPaneKey: { [paneKey]: sleepingRecord(paneKey, 'codex') },
+        paneForegroundAgentByPaneKey: {
+          [paneKey]: { agent: null, shellForeground: true }
+        }
+      })
+    })
+    await rerenderHookProbe(root, { ...baseTab, title: 'zsh' })
+
+    expect(latestHookAgent).toBeNull()
   })
 })

--- a/src/renderer/src/lib/use-tab-agent-sleeping-session.test.ts
+++ b/src/renderer/src/lib/use-tab-agent-sleeping-session.test.ts
@@ -134,7 +134,24 @@ describe('resolveTabAgentFromSignals sleeping-session precedence', () => {
     ).toBeNull()
   })
 
-  it('retires a leftover sleeping identity on confirmed shell even when the OSC title is stuck', () => {
+  it('keeps sleeping occupancy while a restore shell is foreground before the agent relaunches', () => {
+    // Why: processProvesShell is a replacement-shell fact, not /exit. A
+    // stale launchAgent must not win during the restore-from-sleep window.
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: false,
+        isRemote: false,
+        title: 'Terminal 1',
+        hookAgent: null,
+        processAgent: null,
+        processShellForeground: true,
+        sleepingSessionAgent: 'claude',
+        launchAgent: 'codex'
+      })
+    ).toBe('claude')
+  })
+
+  it('keeps sleeping occupancy on a stuck agent title while a restore shell is foreground', () => {
     expect(
       resolveTabAgentFromSignals({
         hasObservedAgentSignal: true,
@@ -146,7 +163,7 @@ describe('resolveTabAgentFromSignals sleeping-session precedence', () => {
         sleepingSessionAgent: 'codex',
         launchAgent: 'codex'
       })
-    ).toBeNull()
+    ).toBe('codex')
   })
 
   it('keeps the icon when a launched agent only changes its conversation title', () => {
@@ -286,6 +303,28 @@ describe('useTabAgent sleeping-session', () => {
 
     expect(latestHookAgent).toBe('claude')
     expect(getForegroundProcess).not.toHaveBeenCalled()
+  })
+
+  it('keeps the tab icon when a restore shell is foreground and sleeping occupancy remains', async () => {
+    const paneKey = makePaneKey('tab-1', LEAF_ID)
+    useAppStore.setState({
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: LEAF_ID },
+          activeLeafId: LEAF_ID,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [LEAF_ID]: 'pty-1' }
+        }
+      },
+      agentStatusByPaneKey: {},
+      sleepingAgentSessionsByPaneKey: { [paneKey]: sleepingRecord(paneKey, 'claude') },
+      paneForegroundAgentByPaneKey: {
+        [paneKey]: { agent: null, shellForeground: true }
+      }
+    })
+
+    await renderHookProbe({ ...baseTab, title: '✳ Codex' })
+    expect(latestHookAgent).toBe('claude')
   })
 
   it('retires the tab icon when a sleeping session remains after confirmed shell foreground', async () => {

--- a/src/renderer/src/lib/use-tab-agent.ts
+++ b/src/renderer/src/lib/use-tab-agent.ts
@@ -148,10 +148,11 @@ export function resolveTabAgentFromSignals(args: {
     processShellForeground: args.processShellForeground
   })
   const activeLaunchAgent = launchedAgentExited ? null : launchAgent
-  // Why: exit evidence already clears launch identity; a leftover sleeping
-  // record is hibernation occupancy, not a live occupant after /exit.
+  // Why: a shell-named title is /exit occupancy loss. processProvesShell alone
+  // is not — restore spawns a shell before the agent relaunches, and the
+  // sleeping record is still the occupant until resume consumes it.
   const activeSleepingSessionAgent =
-    launchedAgentExited || processProvesShell ? null : sleepingSessionAgent
+    launchedAgentExited && noAgentTitle ? null : sleepingSessionAgent
   // Why: re-own the foreground process within its title-identity group so OMP's nested pi (shell → omp → pi) can't flip an OMP-owned tab's icon.
   const processAgent = resolveSignalAgentForLaunchOwner(args.processAgent, owner)
   // Identity-first precedence (see JSDoc): live hook > process > title > completed > sleeping > launch > sibling.
@@ -177,7 +178,7 @@ export function resolveTabAgentFromSignals(args: {
  * 2. Process identity — recognized foreground process (local only); re-owned within its title-identity group so OMP's nested `pi` (shell → omp → pi) can't flip the icon.
  * 3. Title — only a reuse override or legacy standalone identity; native OpenCode titles cannot displace durable ownership.
  * 4. Idle focused identity — the pane's completed hook or sidebar-retained completion; suppressed locally once OSC 133;D proves exit.
- * 5. Sleeping session identity — current provider-session ownership; suppressed on the same local exit evidence as launch identity.
+ * 5. Sleeping session identity — current provider-session ownership; suppressed only when a shell-named title proves /exit, not when a restore shell is merely foreground.
  * 6. launchAgent — bootstrap before any hook/process signal; cleared once exit evidence shows it left.
  * 7. Sibling-pane identity (live, then completed/retained) — split-tab fallback.
  */

--- a/src/renderer/src/lib/use-tab-agent.ts
+++ b/src/renderer/src/lib/use-tab-agent.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { useAppStore } from '@/store'
-import { isShellProcess } from '../../../shared/agent-detection'
+import { titleShowsNoAgent } from '../../../shared/agent-detection'
 import { worktreeUsesRemoteConnection } from '@/store/slices/terminals'
 import { parseRemoteRuntimePtyId } from '@/runtime/runtime-terminal-stream'
 import { isTerminalLeafId, makePaneKey } from '../../../shared/stable-pane-id'
@@ -21,12 +21,6 @@ import { isOpenCodeNativeTitle } from '../../../shared/opencode-terminal-title'
 import { resolvePaneAgentOwner } from '../../../shared/pane-agent-owner'
 import type { TerminalTab } from '../../../shared/terminal-tab-types'
 import type { TuiAgent } from '../../../shared/tui-agent'
-
-// A shell name or the tab's neutral default title (where inferred-interrupt reset parks it); blank titles are no evidence.
-function titleShowsNoAgent(title: string, defaultTitle?: string): boolean {
-  const trimmed = title.trim()
-  return trimmed.length > 0 && (isShellProcess(trimmed) || trimmed === defaultTitle?.trim())
-}
 
 /**
  * Resolves wrapper-compatible signal identity against the launch owner.
@@ -154,6 +148,10 @@ export function resolveTabAgentFromSignals(args: {
     processShellForeground: args.processShellForeground
   })
   const activeLaunchAgent = launchedAgentExited ? null : launchAgent
+  // Why: exit evidence already clears launch identity; a leftover sleeping
+  // record is hibernation occupancy, not a live occupant after /exit.
+  const activeSleepingSessionAgent =
+    launchedAgentExited || processProvesShell ? null : sleepingSessionAgent
   // Why: re-own the foreground process within its title-identity group so OMP's nested pi (shell → omp → pi) can't flip an OMP-owned tab's icon.
   const processAgent = resolveSignalAgentForLaunchOwner(args.processAgent, owner)
   // Identity-first precedence (see JSDoc): live hook > process > title > completed > sleeping > launch > sibling.
@@ -162,7 +160,7 @@ export function resolveTabAgentFromSignals(args: {
     processAgent ??
     titleAgent ??
     idleFocusedIdentity ??
-    sleepingSessionAgent ??
+    activeSleepingSessionAgent ??
     activeLaunchAgent ??
     liveSiblingIdentity ??
     idleSiblingIdentity
@@ -179,7 +177,7 @@ export function resolveTabAgentFromSignals(args: {
  * 2. Process identity — recognized foreground process (local only); re-owned within its title-identity group so OMP's nested `pi` (shell → omp → pi) can't flip the icon.
  * 3. Title — only a reuse override or legacy standalone identity; native OpenCode titles cannot displace durable ownership.
  * 4. Idle focused identity — the pane's completed hook or sidebar-retained completion; suppressed locally once OSC 133;D proves exit.
- * 5. Sleeping session identity — current provider-session ownership.
+ * 5. Sleeping session identity — current provider-session ownership; suppressed on the same local exit evidence as launch identity.
  * 6. launchAgent — bootstrap before any hook/process signal; cleared once exit evidence shows it left.
  * 7. Sibling-pane identity (live, then completed/retained) — split-tab fallback.
  */

--- a/src/shared/agent-detection.ts
+++ b/src/shared/agent-detection.ts
@@ -37,4 +37,4 @@ export {
   MAX_OSC_TITLE_CHARS,
   MAX_OSC_TITLES_PER_CHUNK
 } from './osc-title-extraction'
-export { isShellProcess } from './shell-process-detection'
+export { isShellProcess, titleShowsNoAgent } from './shell-process-detection'

--- a/src/shared/shell-process-detection.ts
+++ b/src/shared/shell-process-detection.ts
@@ -2,7 +2,9 @@
 // renderer (agent-ready-wait, new-workspace). A bare shell is the negative
 // signal for "is an agent running" because it garbles injected preambles.
 const SHELL_NAMES = new Set(
-  '|bash|zsh|sh|fish|cmd|cmd.exe|powershell|powershell.exe|pwsh|pwsh.exe|nu'.split('|')
+  '|bash|zsh|sh|fish|cmd|cmd.exe|powershell|powershell.exe|pwsh|pwsh.exe|nu|ksh|mksh|dash|ash|tcsh|csh|elvish|xonsh'.split(
+    '|'
+  )
 )
 const WINDOWS_PROCESS_EXTENSION_RE = /\.(?:exe|cmd|bat|ps1)$/i
 
@@ -20,6 +22,12 @@ export function isShellProcess(processName: string): boolean {
     SHELL_NAMES.has(basename) ||
     SHELL_NAMES.has(basenameWithoutWindowsExtension)
   )
+}
+
+/** A shell name or the tab's own neutral default title; blank titles are no evidence. */
+export function titleShowsNoAgent(title: string, defaultTitle?: string): boolean {
+  const trimmed = title.trim()
+  return trimmed.length > 0 && (isShellProcess(trimmed) || trimmed === defaultTitle?.trim())
 }
 
 // Why: a ConPTY-side buffer clear cannot reach PSReadLine's cached cursor


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​331 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​330 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​40 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​27 |

<!-- /orca-pr-loc -->

## ELI5

After Codex (or another agent) finishes and you `/exit` back to a live shell, the tab could still show the agent's icon even though the prompt is back. Orca now treats that leftover sleeping-session identity as stale, and only keeps the agent icon when there is still a real occupant.

## What Changed

- Tab-icon identity no longer treats a leftover sleeping-session record as occupancy when the pane has already returned to a local shell.
- The confirmed-shell lifecycle now clears that pane-scoped sleeping identity the same way it already cleared titles and launch routing.
- `ksh`/`dash`/`fish`-style interactive shells stay recognized as shells, so a confirmed return to those prompts retires the same way as `zsh`/`bash`.

## Why

STA-3867 / #13749: after a launched Codex pane completed and `/exit`ed, the process tracker correctly saw a shell, but identity resolution still fell back to the sleeping-session record that owned the same pane. That is the same class of "last occupant wins" bug as launch-routing reuse, not a missing title-change.

Related in-flight work this does **not** replace:

- #15665 (STA-4774) keeps launched rows from vanishing on conversation titles; this change is the opposite hole (shell return must retire).
- #15658 (STA-4521) still owns nested-shell `133;D` / `willContinue` launch-authority. Shell-name overlap is intentional and identical.
- #15695 / #15679 do not cover sleeping-identity retirement after `/exit`.

## Linked Issue

Fixes #13749
STA-3867

## Visual Proof

N/A — no new chrome. The user-visible effect is the existing terminal tab icon retiring to the shell after `/exit`. Automated tests pin the live identity ladder, including leftover sleeping occupancy, confirmed-shell clearing, and ksh/dash/fish shell names.

## Testing

- [x] Automated tests added/updated
- [ ] I manually tested these changes locally (live Codex `/exit` not driven from this worktree)

TDD:

| Stage | Result |
| --- | --- |
| Pre-fix (`012e9f410c`) | FAIL. `use-tab-agent-sleeping-session` expected a retired icon after `/exit` with leftover sleeping occupancy (`expected 'codex' to be null`). Confirmed-shell did not clear the sleeping record. `ksh`/`dash` were not treated as shells. |
| Post-fix | PASS. `use-tab-agent-sleeping-session.test.ts`, `tui-agent-startup.test.ts` shell names, `pty-connection-command-finished-cleanup.test.ts` confirmed-shell sleeping clear. |
| Neutered (sleeping occupancy treated as live again; confirmed-shell clear removed) | FAIL, same assertions. |

Also: `pnpm typecheck` passed. `oxlint` on changed files — clean.

Covered: leftover sleeping occupancy after `/exit`; confirmed-shell clearing of pane-scoped sleeping identity; ksh/dash/fish recognized as shells; conversation-title keep path from #15665 left intact.

Platforms: identity is process-table + sleeping-record state (macOS / Linux / Windows / SSH identical once the host reports a shell). Folder workspaces use the same tab/leaf model.

## Review

- **Security:** no new network, credentials, or command execution. Sleeping-record clear is pane-scoped.
- **Cross-platform:** shell-name matching is basename-based; Windows `.exe` stripping already happens in `isShellProcess`.
- **SSH/remote:** confirmed-shell retirement stays local-only (`processProvesShell`); remote panes still require the existing title/hook evidence and are not inferred from an unconfirmed shell.
- **Agent compatibility:** conversation-title keep from #15665 is unchanged. Explicit title identity still outranks sleeping occupancy.
- **Performance:** one extra sleeping-record delete on confirmed shell; no extra process scans.
- **UI:** no new controls.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Out of scope (file separately):

- #15665 conversation-title keep for sidebar rows (already in flight).
- Nested-shell `133;D` launch-authority (STA-4521 / #15658).
- Live Electron Codex `/exit` on a real pane — unit tests cover the identity ladder; a hosted agent session was not driven from this worktree.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Focused unit tests and `pnpm typecheck` passed locally.

## Author

- X / Twitter: @BrennanKB5