### PR TITLE
fix(agent-hooks): install SSH Codex hooks into login-shell CODEX_HOME (STA-4054)

### DIFF
--- a/src/main/agent-hooks/managed-hook-runtime.test.ts
+++ b/src/main/agent-hooks/managed-hook-runtime.test.ts
@@ -17,7 +17,8 @@ const { execFile } = await import('node:child_process')
 const execFileMock = vi.mocked(execFile)
 const { execFile: actualExecFile } =
   await vi.importActual<typeof NodeChildProcess>('node:child_process')
-const { installManagedHooks, resolveRelayGrokHome } = await import('./managed-hook-runtime')
+const { installManagedHooks, resolveRelayCodexHome, resolveRelayGrokHome } =
+  await import('./managed-hook-runtime')
 
 type ExecFileCallback = (error: Error | null, result?: { stdout: string; stderr: string }) => void
 
@@ -32,6 +33,22 @@ function stubProbeFailure(error: Error): void {
   execFileMock.mockImplementation(((...args: unknown[]) => {
     ;(args.at(-1) as ExecFileCallback)(error)
     return undefined
+  }) as unknown as typeof execFile)
+}
+
+function stubPrintenv(values: Record<string, string>): void {
+  execFileMock.mockImplementation(((...args: unknown[]) => {
+    const command = (args[1] as string[] | undefined)?.[1] ?? ''
+    const matched = Object.entries(values).find(([name]) => command.includes(`printenv ${name}`))
+    const callback = args.at(-1) as ExecFileCallback
+    if (matched) {
+      callback(null, { stdout: `${matched[1]}\n`, stderr: '' })
+      return undefined
+    }
+    return (actualExecFile as (...callArgs: unknown[]) => unknown)(
+      ...args.slice(0, -1),
+      (error: Error | null, stdout: string, stderr: string) => callback(error, { stdout, stderr })
+    )
   }) as unknown as typeof execFile)
 }
 
@@ -156,5 +173,51 @@ describe.runIf(process.platform !== 'win32')('installManagedHooks', () => {
     })
 
     expect((await readdir(home)).sort()).toEqual(['.claude', '.orca', SHELL_NAME, SHELL_RUNS_NAME])
+  })
+
+  it('installs Codex hooks into the login-shell CODEX_HOME, not ~/.codex', async () => {
+    const home = await createTempHome()
+    const probedHome = join(home, 'custom-codex-home')
+    vi.stubEnv('HOME', home)
+    vi.stubEnv('SHELL', '/bin/sh')
+    stubPrintenv({ CODEX_HOME: probedHome })
+
+    await expect(installManagedHooks({ agents: ['codex'] })).resolves.toEqual({
+      installers: 1,
+      errors: 0
+    })
+
+    const { readFile } = await import('node:fs/promises')
+    const hooks = await readFile(join(probedHome, 'hooks.json'), 'utf8')
+    expect(hooks).toContain('codex-hook.sh')
+    const toml = await readFile(join(probedHome, 'config.toml'), 'utf8')
+    expect(toml).toContain('trusted_hash')
+    await expect(readdir(join(home, '.codex'))).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+})
+
+describe.runIf(process.platform !== 'win32')('resolveRelayCodexHome', () => {
+  it('uses the login-shell CODEX_HOME and normalizes trailing separators', async () => {
+    vi.stubEnv('SHELL', '/bin/sh')
+    stubProbeOutput('/srv/codex///\n')
+
+    await expect(resolveRelayCodexHome('/home/orca')).resolves.toBe('/srv/codex')
+
+    const [shell, args] = execFileMock.mock.calls[0] ?? []
+    expect(shell).toBe('/bin/sh')
+    expect(args?.[0]).toBe('-c')
+    expect(args?.[1]).toContain('printenv CODEX_HOME')
+  })
+
+  it('falls back to ~/.codex when the probe is empty, relative, or fails', async () => {
+    vi.stubEnv('SHELL', '/bin/sh')
+    stubProbeOutput('\n')
+    await expect(resolveRelayCodexHome('/home/orca')).resolves.toBe('/home/orca/.codex')
+
+    stubProbeOutput('../relative\n')
+    await expect(resolveRelayCodexHome('/home/orca')).resolves.toBe('/home/orca/.codex')
+
+    stubProbeFailure(Object.assign(new Error('spawn timed out'), { killed: true }))
+    await expect(resolveRelayCodexHome('/home/orca')).resolves.toBe('/home/orca/.codex')
   })
 })

--- a/src/main/agent-hooks/managed-hook-runtime.ts
+++ b/src/main/agent-hooks/managed-hook-runtime.ts
@@ -12,16 +12,18 @@ import {
 } from './managed-hook-owner-identity'
 
 const execFileAsync = promisify(execFile)
-const GROK_HOME_MAX_LENGTH = 4096
-const GROK_HOME_PROBE_TIMEOUT_MS = 8_000
+const RELAY_ENV_HOME_MAX_LENGTH = 4096
+const RELAY_ENV_HOME_PROBE_TIMEOUT_MS = 8_000
 
 export type ManagedHookInstallSummary = {
   installers: number
   errors: number
 }
 
-function defaultGrokHome(home: string): string {
-  return `${home.replace(/\/+$/, '') || home}/.grok`
+type RelayLoginEnvHome = 'GROK_HOME' | 'CODEX_HOME'
+
+function defaultAgentHome(home: string, dirName: string): string {
+  return `${home.replace(/\/+$/, '') || home}/${dirName}`
 }
 
 function hasControlCharacter(value: string): boolean {
@@ -31,10 +33,10 @@ function hasControlCharacter(value: string): boolean {
   })
 }
 
-function normalizeGrokHome(candidate: string): string | null {
+function normalizePosixHome(candidate: string): string | null {
   if (
     candidate.length === 0 ||
-    candidate.length > GROK_HOME_MAX_LENGTH ||
+    candidate.length > RELAY_ENV_HOME_MAX_LENGTH ||
     candidate !== candidate.trim() ||
     !candidate.startsWith('/') ||
     candidate.includes('\\') ||
@@ -53,24 +55,37 @@ function resolveLoginShell(): string {
   return candidate
 }
 
-export async function resolveRelayGrokHome(home: string, signal?: AbortSignal): Promise<string> {
-  const fallback = defaultGrokHome(home)
+async function resolveRelayLoginEnvHome(
+  home: string,
+  envName: RelayLoginEnvHome,
+  defaultDirName: string,
+  signal?: AbortSignal
+): Promise<string> {
+  const fallback = defaultAgentHome(home, defaultDirName)
   try {
     const shell = resolveLoginShell()
     const shellName = basename(shell)
     const mode = shellName === 'sh' || shellName === 'dash' ? '-c' : '-lc'
     // Why: agent PTYs start login shells, so read the same profile-derived
-    // GROK_HOME without opening two additional SSH exec channels.
+    // home without opening two additional SSH exec channels.
     const { stdout } = await execFileAsync(
       shell,
-      [mode, `printenv GROK_HOME | head -c ${GROK_HOME_MAX_LENGTH + 1}`],
-      { encoding: 'utf8', timeout: GROK_HOME_PROBE_TIMEOUT_MS, signal }
+      [mode, `printenv ${envName} | head -c ${RELAY_ENV_HOME_MAX_LENGTH + 1}`],
+      { encoding: 'utf8', timeout: RELAY_ENV_HOME_PROBE_TIMEOUT_MS, signal }
     )
-    return normalizeGrokHome(stdout.split(/\r?\n/, 1)[0] ?? '') ?? fallback
+    return normalizePosixHome(stdout.split(/\r?\n/, 1)[0] ?? '') ?? fallback
   } catch {
     signal?.throwIfAborted()
     return fallback
   }
+}
+
+export async function resolveRelayGrokHome(home: string, signal?: AbortSignal): Promise<string> {
+  return resolveRelayLoginEnvHome(home, 'GROK_HOME', '.grok', signal)
+}
+
+export async function resolveRelayCodexHome(home: string, signal?: AbortSignal): Promise<string> {
+  return resolveRelayLoginEnvHome(home, 'CODEX_HOME', '.codex', signal)
 }
 
 export async function installManagedHooks(options?: {
@@ -86,6 +101,9 @@ export async function installManagedHooks(options?: {
   }
   const home = homedir()
   const grokHomeDir = await resolveRelayGrokHome(home, options?.signal)
+  const codexHomeDir = agents.includes('codex')
+    ? await resolveRelayCodexHome(home, options?.signal)
+    : undefined
   options?.signal?.throwIfAborted()
   const hostIdentity = scopeManagedHookHostIdentity(
     await readManagedHookHostIdentity(),
@@ -100,6 +118,7 @@ export async function installManagedHooks(options?: {
         home,
         {
           grokHomeDir,
+          ...(codexHomeDir ? { codexHomeDir } : {}),
           signal: options?.signal,
           agents
         }

--- a/src/main/agent-hooks/remote-codex-probed-home-install.test.ts
+++ b/src/main/agent-hooks/remote-codex-probed-home-install.test.ts
@@ -1,0 +1,41 @@
+import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => '/tmp/orca-user-data'
+  }
+}))
+
+import { createManagedHookLocalFilesystem } from './managed-hook-local-filesystem'
+import { installRemoteManagedAgentHooks } from './remote-managed-hook-installers'
+
+const tempHomes: string[] = []
+
+afterEach(async () => {
+  await Promise.all(tempHomes.splice(0).map((home) => rm(home, { recursive: true, force: true })))
+})
+
+describe.runIf(process.platform !== 'win32')('SSH Codex probed-home hook install', () => {
+  it('writes Codex trust immediately when installing into a probed CODEX_HOME', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'orca-codex-probed-home-'))
+    tempHomes.push(home)
+    const runtimeHome = join(home, '.config', 'codex')
+
+    const results = await installRemoteManagedAgentHooks(createManagedHookLocalFilesystem(), home, {
+      agents: ['codex'],
+      codexHomeDir: runtimeHome
+    })
+
+    expect(results).toEqual([
+      expect.objectContaining({ agent: 'codex', state: 'installed', managedHooksPresent: true })
+    ])
+    const hooks = await readFile(join(runtimeHome, 'hooks.json'), 'utf8')
+    expect(hooks).toContain('codex-hook.sh')
+    const toml = await readFile(join(runtimeHome, 'config.toml'), 'utf8')
+    expect(toml).toContain('trusted_hash = "sha256:')
+    await expect(readdir(join(home, '.codex'))).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+})

--- a/src/main/agent-hooks/remote-managed-hook-installers.ts
+++ b/src/main/agent-hooks/remote-managed-hook-installers.ts
@@ -16,11 +16,15 @@ import { kimiHookService } from '../kimi/hook-service'
 import { openClaudeHookService } from '../openclaude/hook-service'
 
 export type RemoteManagedHookInstallOptions = {
-  /** Explicit CODEX_HOME dir for redirected runtimes (WSL managed runtime
-   *  home). Codex-only: it is the one agent whose home Orca redirects. Also
-   *  defers the config.toml trust write until that file exists, so the
-   *  launch path's only-if-absent seed is never pre-empted. */
+  /** Explicit CODEX_HOME dir (WSL managed runtime home, or the SSH host's
+   *  login-shell CODEX_HOME). Codex is the one agent whose home Orca may
+   *  redirect; installing into ~/.codex when the process reads another home
+   *  leaves the pane hookless. */
   codexHomeDir?: string
+  /** WSL-only: skip the trust write when config.toml is absent so the launch
+   *  path's only-if-absent seed is never pre-empted. SSH probed homes write
+   *  trust immediately. */
+  deferCodexTrustUntilConfigToml?: boolean
   /** Explicit GROK_HOME for remote runtimes that redirect Grok's config. */
   grokHomeDir?: string
   /** Stops before starting the next installer when the owning relay request
@@ -50,7 +54,10 @@ const REMOTE_MANAGED_HOOK_INSTALLERS: readonly RemoteManagedHookInstaller[] = [
         sftp,
         remoteHome,
         options?.codexHomeDir
-          ? { codexHomeDir: options.codexHomeDir, deferTrustUntilConfigToml: true }
+          ? {
+              codexHomeDir: options.codexHomeDir,
+              deferTrustUntilConfigToml: options.deferCodexTrustUntilConfigToml === true
+            }
           : undefined
       )
   ],

--- a/src/main/agent-hooks/wsl-hook-fs-adapter.ts
+++ b/src/main/agent-hooks/wsl-hook-fs-adapter.ts
@@ -46,6 +46,7 @@ export async function installWslGuestHooks(options: {
   }
   const results = await installHooks(createWslHookSftpAdapter(mux), guestHome, {
     codexHomeDir: wslCodexRuntimeHomeForGuestHome(guestHome),
+    deferCodexTrustUntilConfigToml: true,
     agents
   })
   const failed = results.filter((r) => r.state === 'error').length

--- a/src/main/agent-hooks/wsl-hook-relay-manager.test.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-manager.test.ts
@@ -247,6 +247,7 @@ describe('WslHookRelayManager', () => {
     // Codex is the one agent whose home Orca redirects for WSL sessions.
     expect(deps.installHooks).toHaveBeenCalledWith(expect.anything(), home, {
       codexHomeDir: `${home}/.local/share/orca/codex-runtime-home/home`,
+      deferCodexTrustUntilConfigToml: true,
       agents: ['codex']
     })
 

--- a/src/renderer/src/components/dashboard/build-dashboard-snapshot.test.ts
+++ b/src/renderer/src/components/dashboard/build-dashboard-snapshot.test.ts
@@ -552,6 +552,48 @@ describe('buildDashboardSnapshot', () => {
     expect(done?.bucket).toBe('done')
   })
 
+  it('shows a stopped Codex agent as done instead of dropping the card', () => {
+    const donePaneKey = makePaneKey(TAB_ID, GONE_LEAF_ID)
+    const snapshot = buildDashboardSnapshot(
+      baseState({
+        retainedAgentsByPaneKey: {
+          [donePaneKey]: {
+            entry: entry({
+              paneKey: donePaneKey,
+              state: 'done',
+              agentType: 'codex',
+              prompt: 'Codex'
+            }),
+            worktreeId: 'w1',
+            tab: tab() as never,
+            agentType: 'codex',
+            startedAt: NOW - 60_000
+          } as never
+        }
+      }),
+      NOW
+    )
+    const done = snapshot.cards.find((c) => c.agentType === 'codex')
+    expect(done?.bucket).toBe('done')
+    expect(done?.dotState).toBe('done')
+  })
+
+  it('keeps a live Codex hook card when the title no longer names the agent', () => {
+    const snapshot = buildDashboardSnapshot(
+      baseState({
+        tabsByWorktree: { w1: [{ ...tab(), launchAgent: 'codex', title: 'zsh' }] },
+        agentStatusByPaneKey: {
+          [PANE_KEY]: entry({ agentType: 'codex', state: 'working', prompt: 'Codex' })
+        },
+        runtimePaneTitlesByTabId: { [TAB_ID]: { 1: 'zsh' } }
+      }),
+      NOW
+    )
+    expect(snapshot.cards).toEqual([
+      expect.objectContaining({ agentType: 'codex', bucket: 'working' })
+    ])
+  })
+
   it('includes collapsed subagents and workspace status metadata on the parent card', () => {
     const snapshot = buildDashboardSnapshot(
       baseState({

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -239,6 +239,35 @@ describe('buildTitleDerivedAgentRows', () => {
     expect(rows.map((row) => [row.agentType, row.state])).toEqual([['codex', 'working']])
   })
 
+  it('keeps a Claude title-derived row when Codex is also launched elsewhere', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [
+        makeTab('tab-claude', { launchAgent: 'claude' }),
+        makeTab('tab-codex', { launchAgent: 'codex' })
+      ],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        'tab-claude': { 1: '✳ Claude Code' },
+        'tab-codex': { 1: '⠼ demo-repo' }
+      },
+      ptyIdsByTabId: {
+        'tab-claude': ['pty-claude'],
+        'tab-codex': ['pty-codex']
+      },
+      terminalLayoutsByTabId: {
+        'tab-claude': makeSingleLayout(LEAF_ID_1),
+        'tab-codex': makeSingleLayout(LEAF_ID_2)
+      },
+      now: 2000
+    })
+
+    expect(rows.map((row) => [row.tab.id, row.agentType, row.state])).toEqual([
+      ['tab-claude', 'claude', 'idle'],
+      ['tab-codex', 'codex', 'working']
+    ])
+  })
+
   it('produces no row for a spinner-only title when the tab has no launch identity', () => {
     const rows = buildWorktreeAgentRows({
       tabs: [makeTab('tab-1')],

--- a/src/renderer/src/lib/use-tab-agent.test.ts
+++ b/src/renderer/src/lib/use-tab-agent.test.ts
@@ -483,6 +483,19 @@ describe('resolveTabAgentFromSignals', () => {
     ).toBe('claude')
   })
 
+  it('does not treat an unreachable SSH Codex pane as missing', () => {
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: true,
+        isRemote: true,
+        title: '~/demo-repo',
+        hookAgent: null,
+        processAgent: null,
+        launchAgent: 'codex'
+      })
+    ).toBe('codex')
+  })
+
   it('treats the neutral default title as exit evidence alongside shell titles', () => {
     expect(
       resolveTabAgentFromSignals({


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​190 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​189 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​44 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​27 |

<!-- /orca-pr-loc -->

## ELI5

Claude over SSH shows up in the Agent Dashboard because Orca installs Claude's status hooks into the home Claude actually reads. Codex is different: it can run from a custom `CODEX_HOME`. SSH install always wrote hooks to `~/.codex`, so Codex never saw them, never reported status, and a stopped Codex pane vanished instead of staying as done.

## What Changed

- SSH/relay managed-hook install probes login-shell `CODEX_HOME` the same way it already probes `GROK_HOME`, and installs Codex hooks there.
- WSL still defers the `config.toml` trust write until that file exists (launch-path seed). SSH probed homes write trust immediately so Codex will actually run the hooks.
- Tests cover the probe, install-to-probed-home, immediate trust, Claude title rows staying Claude, retained stopped Codex as done, and an unreachable SSH Codex pane staying an agent rather than disappearing.

## Why

**Root cause is a missing SSH-side signal, not a loose client check.** Claude hooks land in `~/.claude`. Codex is the one agent whose home Orca redirects. Native WSL already passed `codexHomeDir`; SSH did not. Title-derived rows cannot save a stopped Codex pane (SSH Codex titles are spinner+cwd with no agent name), and renderer process tracking is local-only.

Passing `codexHomeDir` used to imply `deferTrustUntilConfigToml: true`. That is correct for WSL. It is wrong for SSH: there is no later launch-path seed, so deferred trust means hooks that Codex will not run.

## Linked Issue

Fixes https://linear.app/stably/issue/STA-4054/bug-codex-agents-are-not-recognized-as-agents-in-orca-and-the-agent
Fixes #14113

## Visual Proof

N/A — hook install path on the execution host. No new chrome. The user-visible effect is the existing Agent Dashboard / workspace agent rows recognising Codex over SSH and keeping a stopped Codex row as done once hooks fire.

## Testing

- [ ] I manually tested these changes locally (Windows+WSL-over-SSH unvalidated; reporter host unreachable this session)
- [x] Automated tests added/updated, or explained why not below

TDD:

| Stage | Result |
| --- | --- |
| Pre-fix | `installManagedHooks` wrote `~/.codex` (`ENOENT` on probed home). `resolveRelayCodexHome` did not exist. Aggregate installer deferred trust so `config.toml` was missing. |
| Post-fix | `managed-hook-runtime.test.ts` 11/11, `remote-codex-probed-home-install.test.ts` 1/1, `remote-hook-service-installers.test.ts` 24/24, `wsl-hook-relay-manager.test.ts` 18/18, title-derived / dashboard / tab-agent files 92/92 |
| Neutered (stopped passing `codexHomeDir`; restored WSL-only defer coupling; tests kept) | The two high-value install tests failed again |

Also: `pnpm typecheck` passed. `oxlint --deny-warnings` and `oxfmt` on changed files only — clean.

## Review

- **Security:** still fail-closed on an empty agent allowlist. Probed home must be an absolute POSIX path without control characters. Trust is written only into that home.
- **Cross-platform:** probe is POSIX login-shell (`printenv`). Windows remotes still skip POSIX hook installers. Windows+WSL-over-SSH unvalidated.
- **Remote SSH:** this is the SSH path. Folder workspaces use the same relay installer. Native WSL still defers trust.
- **Mobile:** no client change; mobile consumes the same hook status rows.
- **Backwards compatibility:** additive. Default when `CODEX_HOME` is unset remains `~/.codex`. No wire/RPC/stream opcode changes.
- **Performance:** one extra login-shell `printenv` only when Codex is in the install allowlist.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Related in-flight work checked, not overlapping:

- #15650 (STA-4973) — WSL `/mnt/c` session-history path aliases
- #15705 (STA-3959) — Cursor missing JSONL `cwd`
- #15695 (STA-3487) — Cursor launch tokens / new-turn restart
- #15658 (STA-4521) — OMP `willContinue` / nested OSC `133;D`

## Author

- X / Twitter: @BrennanKB5

## Out of scope

- Enabling SSH renderer foreground-process tracking (explicitly local-only; routing-authority, not this hook-home miss).
- Manufacturing title-derived rows from plain shell/cwd titles.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)