### PR TITLE
fix(remote): keep editor focus after unfocused HTML side preview (STA-5001)

### DIFF
--- a/src/renderer/src/lib/file-preview.test.ts
+++ b/src/renderer/src/lib/file-preview.test.ts
@@ -111,6 +111,9 @@ describe('openFileInBrowserTab', () => {
       sourceGroupId: 'group-1'
     })
 
+    expect(mocks.createEmptySplitGroup).toHaveBeenCalledWith('wt-1', 'group-1', 'right', {
+      activate: false
+    })
     expect(mocks.createWebRuntimeSessionBrowserTab).toHaveBeenCalledWith({
       worktreeId: 'wt-1',
       environmentId: 'runtime-1',
@@ -122,6 +125,22 @@ describe('openFileInBrowserTab', () => {
       stagedFocusAddressBar: false
     })
     expect(mocks.createBrowserTab).not.toHaveBeenCalled()
+  })
+
+  it('creates local side previews in an activated right-hand split', () => {
+    openFilePreviewToSide({
+      language: 'html',
+      filePath: '/tmp/example.html',
+      worktreeId: 'wt-1',
+      sourceGroupId: 'group-1'
+    })
+
+    expect(mocks.createEmptySplitGroup).toHaveBeenCalledWith('wt-1', 'group-1', 'right')
+    expect(mocks.createBrowserTab).toHaveBeenCalledWith('wt-1', 'file:///tmp/example.html', {
+      title: 'example.html',
+      targetGroupId: 'group-2',
+      activate: true
+    })
   })
 
   it('reports a paired-runtime recovery failure without an unhandled rejection', async () => {

--- a/src/renderer/src/lib/file-preview.ts
+++ b/src/renderer/src/lib/file-preview.ts
@@ -207,8 +207,11 @@ export function openFilePreviewToSide(params: {
   let targetGroupId = existingSibling
   if (!targetGroupId) {
     // Why: no split yet — create one to the right so the preview lands beside
-    // the editor. createEmptySplitGroup returns the new (empty) group id.
-    targetGroupId = state.createEmptySplitGroup(worktreeId, sourceGroupId, 'right')
+    // the editor. Remote previews stay unfocused until click, so do not activate
+    // the empty group or a host snapshot will treat it as a terminal pane.
+    targetGroupId = environmentId
+      ? state.createEmptySplitGroup(worktreeId, sourceGroupId, 'right', { activate: false })
+      : state.createEmptySplitGroup(worktreeId, sourceGroupId, 'right')
   }
   if (!targetGroupId) {
     return

--- a/src/renderer/src/runtime/web-session-focus-intent-visible-tab.test.ts
+++ b/src/renderer/src/runtime/web-session-focus-intent-visible-tab.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { resolveWebSessionVisibleTabId } from './web-session-focus-intent'
+import {
+  resolveWebSessionSiblingVisibleTabId,
+  resolveWebSessionVisibleTabId
+} from './web-session-focus-intent'
 import {
   toVisibleTabType,
   type Tab,
@@ -232,6 +235,33 @@ describe('resolveWebSessionVisibleTabId — no-group compatibility path', () => 
     })
 
     expect(resolveWebSessionVisibleTabId(state, WT)).toBeNull()
+  })
+})
+
+describe('resolveWebSessionSiblingVisibleTabId', () => {
+  it('returns the sibling whose active tab matches the remembered visible type', () => {
+    const editor = tab({ id: 'tab-editor', entityId: 'file-1', contentType: 'editor' })
+    const terminal = tab({
+      id: 'tab-terminal',
+      entityId: 'term-1',
+      contentType: 'terminal',
+      groupId: GROUP_B
+    })
+    const state = makeState({
+      unifiedTabsByWorktree: { [WT]: [editor, terminal] },
+      groupsByWorktree: {
+        [WT]: [
+          group({ id: GROUP_A, activeTabId: editor.id, tabOrder: [editor.id] }),
+          group({ id: GROUP_B, activeTabId: null, tabOrder: [] })
+        ]
+      },
+      activeGroupIdByWorktree: { [WT]: GROUP_B },
+      activeTabType: 'editor',
+      activeTabTypeByWorktree: { [WT]: 'editor' }
+    })
+
+    expect(resolveWebSessionVisibleTabId(state, WT)).toBeNull()
+    expect(resolveWebSessionSiblingVisibleTabId(state, WT)).toBe(editor.id)
   })
 })
 

--- a/src/renderer/src/runtime/web-session-focus-intent.ts
+++ b/src/renderer/src/runtime/web-session-focus-intent.ts
@@ -95,6 +95,33 @@ export function resolveWebSessionVisibleTabId(
   )
 }
 
+export function resolveWebSessionSiblingVisibleTabId(
+  state: WebSessionVisibleTabState,
+  worktreeId: string,
+  tabs = state.unifiedTabsByWorktree?.[worktreeId] ?? []
+): string | null {
+  const activeGroupId = state.activeGroupIdByWorktree?.[worktreeId] ?? null
+  const preferredType =
+    state.activeTabTypeByWorktree?.[worktreeId] ??
+    (state.activeWorktreeId === worktreeId ? state.activeTabType : null)
+  const tabById = new Map(tabs.map((tab) => [tab.id, tab]))
+  let fallback: string | null = null
+  for (const group of state.groupsByWorktree?.[worktreeId] ?? []) {
+    if (group.id === activeGroupId || group.activeTabId == null) {
+      continue
+    }
+    const tab = tabById.get(group.activeTabId)
+    if (!tab || tab.groupId !== group.id) {
+      continue
+    }
+    if (preferredType && toVisibleTabType(tab.contentType) === preferredType) {
+      return tab.id
+    }
+    fallback ??= tab.id
+  }
+  return fallback
+}
+
 function focusIntentPartitionKey(owner: WebSessionIntentOwner, worktreeId: string): string {
   return `${webSessionIntentOwnerKey(owner)}\0${worktreeId}`
 }

--- a/src/renderer/src/runtime/web-session-tabs-sync-html-preview-focus.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync-html-preview-focus.test.ts
@@ -1,0 +1,265 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { toWebTerminalSurfaceTabId } from '../../../shared/terminal-surface-id'
+import type { OpenFile } from '../store/slices/editor'
+import type { Tab } from '../../../shared/tab-types'
+import { recordWebSessionBrowserPlacement } from './web-session-browser-placement'
+import { applyWebSessionTabsSnapshot, type WebSessionTabsSyncState } from './web-session-tabs-sync'
+import {
+  ENV,
+  LEAF_ID,
+  NOW,
+  WT,
+  makeSnapshot,
+  makeState,
+  resetWebSessionTabsSyncTestState
+} from './web-session-tabs-sync-test-harness'
+
+vi.mock('../store', () => ({
+  useAppStore: {
+    setState: vi.fn()
+  }
+}))
+
+const EDITOR_GROUP = 'client-editor-group'
+const PREVIEW_GROUP = 'client-preview-group'
+const EDITOR_FILE_ID = '/repo/paired-html-focus.html'
+const EDITOR_TAB_ID = 'local-html-editor'
+const HOST_TERMINAL_PARENT = 'host-terminal'
+const HOST_TERMINAL_SURFACE = `${HOST_TERMINAL_PARENT}::${LEAF_ID}`
+const HOST_BROWSER_TAB = 'host-html-browser-tab'
+const HOST_BROWSER_PAGE = 'host-html-browser-page'
+
+function htmlOpenFile(): OpenFile {
+  return {
+    id: EDITOR_FILE_ID,
+    filePath: EDITOR_FILE_ID,
+    relativePath: 'paired-html-focus.html',
+    worktreeId: WT,
+    language: 'html',
+    isDirty: false,
+    runtimeEnvironmentId: ENV,
+    mode: 'edit'
+  }
+}
+
+function htmlEditorTab(): Tab {
+  return {
+    id: EDITOR_TAB_ID,
+    entityId: EDITOR_FILE_ID,
+    groupId: EDITOR_GROUP,
+    worktreeId: WT,
+    contentType: 'editor',
+    label: 'paired-html-focus.html',
+    customLabel: null,
+    color: null,
+    sortOrder: 1,
+    createdAt: NOW,
+    isPreview: false,
+    isPinned: false
+  }
+}
+
+function mirroredTerminalTab(terminalTabId: string): Tab {
+  return {
+    id: terminalTabId,
+    entityId: terminalTabId,
+    groupId: EDITOR_GROUP,
+    worktreeId: WT,
+    contentType: 'terminal',
+    label: 'host shell',
+    customLabel: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: NOW,
+    isPreview: false,
+    isPinned: false
+  }
+}
+
+function editorFocusedSplitState(activeGroupId: string): WebSessionTabsSyncState {
+  const terminalTabId = toWebTerminalSurfaceTabId(HOST_TERMINAL_PARENT)
+  const editorTab = htmlEditorTab()
+  const openFile = htmlOpenFile()
+  return makeState({
+    activeFileId: openFile.id,
+    activeFileIdByWorktree: { [WT]: openFile.id },
+    activeGroupIdByWorktree: { [WT]: activeGroupId },
+    activeTabId: terminalTabId,
+    activeTabIdByWorktree: { [WT]: terminalTabId },
+    activeTabType: 'editor',
+    activeTabTypeByWorktree: { [WT]: 'editor' },
+    openFiles: [openFile],
+    tabsByWorktree: {
+      [WT]: [
+        {
+          id: terminalTabId,
+          ptyId: 'remote:web-env-1@@terminal-1',
+          worktreeId: WT,
+          title: 'host shell',
+          customTitle: null,
+          color: null,
+          sortOrder: 0,
+          createdAt: NOW
+        }
+      ]
+    },
+    unifiedTabsByWorktree: { [WT]: [mirroredTerminalTab(terminalTabId), editorTab] },
+    groupsByWorktree: {
+      [WT]: [
+        {
+          id: EDITOR_GROUP,
+          worktreeId: WT,
+          activeTabId: editorTab.id,
+          tabOrder: [terminalTabId, editorTab.id],
+          recentTabIds: [terminalTabId, editorTab.id]
+        },
+        {
+          id: PREVIEW_GROUP,
+          worktreeId: WT,
+          activeTabId: null,
+          tabOrder: []
+        }
+      ]
+    },
+    layoutByWorktree: {
+      [WT]: {
+        type: 'split',
+        direction: 'horizontal',
+        first: { type: 'leaf', groupId: EDITOR_GROUP },
+        second: { type: 'leaf', groupId: PREVIEW_GROUP },
+        ratio: 0.5
+      }
+    }
+  })
+}
+
+function unfocusedHtmlPreviewSnapshot() {
+  return makeSnapshot(
+    [
+      {
+        type: 'terminal',
+        id: HOST_TERMINAL_SURFACE,
+        title: 'host shell',
+        parentTabId: HOST_TERMINAL_PARENT,
+        leafId: LEAF_ID,
+        isActive: true,
+        status: 'ready',
+        terminal: 'terminal-1'
+      },
+      {
+        type: 'browser',
+        id: HOST_BROWSER_TAB,
+        title: 'paired-html-focus.html',
+        browserWorkspaceId: 'host-html-workspace',
+        browserPageId: HOST_BROWSER_PAGE,
+        url: 'file:///repo/paired-html-focus.html',
+        loading: false,
+        canGoBack: false,
+        canGoForward: false,
+        isActive: false
+      }
+    ],
+    {
+      activeGroupId: 'host-group-1',
+      activeTabId: HOST_TERMINAL_SURFACE,
+      activeTabType: 'terminal',
+      tabGroups: [
+        {
+          id: 'host-group-1',
+          activeTabId: HOST_TERMINAL_PARENT,
+          tabOrder: [HOST_TERMINAL_PARENT, HOST_BROWSER_TAB]
+        }
+      ]
+    }
+  )
+}
+
+function previewFocus(state: WebSessionTabsSyncState): {
+  activeGroupId: string | null
+  activeTabId: string | null
+  activeTabType: WebSessionTabsSyncState['activeTabType'] | null
+} {
+  const activeGroup = (state.groupsByWorktree[WT] ?? []).find(
+    (group) => group.id === state.activeGroupIdByWorktree[WT]
+  )
+  return {
+    activeGroupId: activeGroup?.id ?? null,
+    activeTabId: activeGroup?.activeTabId ?? null,
+    activeTabType: state.activeTabTypeByWorktree[WT] ?? null
+  }
+}
+
+describe('applyWebSessionTabsSnapshot — unfocused HTML side preview', () => {
+  beforeEach(resetWebSessionTabsSyncTestState)
+
+  it('keeps the source editor focused when the empty preview split is still the active group', () => {
+    // Why: Open Preview to the Side creates the right-hand group first. Until the
+    // host browser lands, that group is empty — a host snapshot with terminal still
+    // active must not treat that emptiness as "the user focused a terminal".
+    recordWebSessionBrowserPlacement({
+      environmentId: ENV,
+      worktreeId: WT,
+      remotePageId: HOST_BROWSER_PAGE,
+      groupId: PREVIEW_GROUP,
+      callerCreatedGroup: true
+    })
+    const state = editorFocusedSplitState(PREVIEW_GROUP)
+
+    const patch = applyWebSessionTabsSnapshot(
+      state,
+      unfocusedHtmlPreviewSnapshot(),
+      ENV,
+      NOW + 10
+    ) as Partial<WebSessionTabsSyncState>
+    const next = { ...state, ...patch }
+
+    expect(previewFocus(next)).toEqual({
+      activeGroupId: EDITOR_GROUP,
+      activeTabId: EDITOR_TAB_ID,
+      activeTabType: 'editor'
+    })
+    expect(
+      next.unifiedTabsByWorktree[WT]?.find((tab) => tab.contentType === 'browser')
+    ).toMatchObject({ id: HOST_BROWSER_TAB, groupId: PREVIEW_GROUP })
+  })
+
+  it('still follows a host terminal snapshot when the empty split is not a reserved preview', () => {
+    const state = editorFocusedSplitState(PREVIEW_GROUP)
+
+    const patch = applyWebSessionTabsSnapshot(
+      state,
+      unfocusedHtmlPreviewSnapshot(),
+      ENV,
+      NOW + 10
+    ) as Partial<WebSessionTabsSyncState>
+    const next = { ...state, ...patch }
+
+    expect(previewFocus(next).activeGroupId).not.toBe(EDITOR_GROUP)
+    expect(previewFocus(next).activeTabType).toBe('editor')
+  })
+
+  it('keeps the source editor focused when the editor group is still active', () => {
+    recordWebSessionBrowserPlacement({
+      environmentId: ENV,
+      worktreeId: WT,
+      remotePageId: HOST_BROWSER_PAGE,
+      groupId: PREVIEW_GROUP,
+      callerCreatedGroup: true
+    })
+    const state = editorFocusedSplitState(EDITOR_GROUP)
+
+    const patch = applyWebSessionTabsSnapshot(
+      state,
+      unfocusedHtmlPreviewSnapshot(),
+      ENV,
+      NOW + 10
+    ) as Partial<WebSessionTabsSyncState>
+    const next = { ...state, ...patch }
+
+    expect(previewFocus(next)).toEqual({
+      activeGroupId: EDITOR_GROUP,
+      activeTabId: EDITOR_TAB_ID,
+      activeTabType: 'editor'
+    })
+  })
+})

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -58,6 +58,7 @@ import {
   clearWebSessionFocusIntent,
   clearWebSessionFocusIntentsForOwner,
   peekWebSessionFocusIntent,
+  resolveWebSessionSiblingVisibleTabId,
   resolveWebSessionVisibleTabId
 } from './web-session-focus-intent'
 import {
@@ -2839,6 +2840,16 @@ function applyWebSessionTabsSnapshotWithContext(
     worktreeId,
     nextUnifiedTabs ?? []
   )
+  const activeGroupId = state.activeGroupIdByWorktree[worktreeId]
+  // Why: Open Preview to the Side can activate an empty reserved group before the host
+  // browser lands. A snapshot that still has the host terminal active must not treat
+  // that emptiness as a terminal focus change.
+  const reservedEmptyPreviewFallbackTabId =
+    currentVisibleUnifiedTabId == null &&
+    activeGroupId != null &&
+    isWebSessionBrowserPlacementGroupReserved({ worktreeId, groupId: activeGroupId })
+      ? resolveWebSessionSiblingVisibleTabId(state, worktreeId, nextUnifiedTabs ?? [])
+      : null
   // Why: a client-initiated activation also drives the visible unified tab, overriding the sticky current-visible tab.
   const intentUnifiedTabId = honorSnapshotActiveFocus
     ? navigationIntentTab?.type === 'browser'
@@ -2852,6 +2863,7 @@ function applyWebSessionTabsSnapshotWithContext(
   const nextActiveUnifiedTabId =
     intentUnifiedTabId ??
     currentVisibleUnifiedTabId ??
+    reservedEmptyPreviewFallbackTabId ??
     (snapshot.activeTabType === 'browser'
       ? (activeMirroredBrowserTabId ??
         mirroredBrowserTabs[0]?.unifiedTab.id ??

--- a/src/renderer/src/store/slices/tabs-empty-split-activation.test.ts
+++ b/src/renderer/src/store/slices/tabs-empty-split-activation.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type * as AgentStatusModule from '@/lib/agent-status'
+import { createTabsSliceMockApi } from './tabs-slice-test-harness'
+import { createTestStore } from './store-test-helpers'
+
+vi.mock('sonner', () => ({ toast: { info: vi.fn(), success: vi.fn(), error: vi.fn() } }))
+
+vi.mock('@/lib/agent-status', async (importOriginal) => {
+  const actual = await importOriginal<typeof AgentStatusModule>()
+  return {
+    ...actual,
+    detectAgentStatusFromTitle: vi.fn().mockReturnValue(null)
+  }
+})
+
+createTabsSliceMockApi()
+
+const WT = 'repo1::/tmp/feature'
+
+describe('createEmptySplitGroup', () => {
+  let store: ReturnType<typeof createTestStore>
+
+  beforeEach(() => {
+    store = createTestStore()
+  })
+
+  it('activates the new group by default so terminal splits land in the empty pane', () => {
+    const tab = store.getState().createUnifiedTab(WT, 'terminal')
+    const sourceGroupId = store.getState().groupsByWorktree[WT][0].id
+
+    const targetGroupId = store.getState().createEmptySplitGroup(WT, sourceGroupId, 'right')
+
+    expect(targetGroupId).toBeTruthy()
+    expect(store.getState().activeGroupIdByWorktree[WT]).toBe(targetGroupId)
+    expect(
+      store.getState().groupsByWorktree[WT].find((group) => group.id === sourceGroupId)
+    ).toEqual(expect.objectContaining({ tabOrder: [tab.id] }))
+  })
+
+  it('keeps the source group focused when activate is false', () => {
+    store.getState().createUnifiedTab(WT, 'editor', { id: 'file-a.ts', label: 'file-a.ts' })
+    const sourceGroupId = store.getState().groupsByWorktree[WT][0].id
+
+    const targetGroupId = store.getState().createEmptySplitGroup(WT, sourceGroupId, 'right', {
+      activate: false
+    })
+
+    expect(targetGroupId).toBeTruthy()
+    expect(store.getState().activeGroupIdByWorktree[WT]).toBe(sourceGroupId)
+    expect(store.getState().groupsByWorktree[WT].map((group) => group.id)).toEqual([
+      sourceGroupId,
+      targetGroupId
+    ])
+  })
+})

--- a/src/renderer/src/store/slices/tabs.ts
+++ b/src/renderer/src/store/slices/tabs.ts
@@ -154,7 +154,8 @@ export type TabsSlice = {
   createEmptySplitGroup: (
     worktreeId: string,
     sourceGroupId: string,
-    direction: TabSplitDirection
+    direction: TabSplitDirection,
+    opts?: { activate?: boolean }
   ) => string | null
   moveUnifiedTabToGroup: (
     tabId: string,
@@ -1636,7 +1637,7 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
     return true
   },
 
-  createEmptySplitGroup: (worktreeId, sourceGroupId, direction) => {
+  createEmptySplitGroup: (worktreeId, sourceGroupId, direction, opts) => {
     const newGroupId = createBrowserUuid()
     const newGroup: TabGroup = {
       id: newGroupId,
@@ -1644,6 +1645,7 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
       activeTabId: null,
       tabOrder: []
     }
+    const shouldActivate = opts?.activate !== false
     set((state) => {
       const existing = state.groupsByWorktree[worktreeId] ?? []
       const currentLayout =
@@ -1660,7 +1662,14 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
           ...state.layoutByWorktree,
           [worktreeId]: replaceLeaf(currentLayout, sourceGroupId, replacement)
         },
-        activeGroupIdByWorktree: { ...state.activeGroupIdByWorktree, [worktreeId]: newGroupId }
+        ...(shouldActivate
+          ? {
+              activeGroupIdByWorktree: {
+                ...state.activeGroupIdByWorktree,
+                [worktreeId]: newGroupId
+              }
+            }
+          : {})
       }
     })
     get().recordFeatureInteraction?.('terminal-panes')


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​370 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​369 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​56 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​51 |

<!-- /orca-pr-loc -->

## ELI5

Opening an HTML preview beside the editor on a paired remote client left the client thinking a terminal was focused. The preview split was created empty and marked active, then a host snapshot still saying "terminal is active" stole focus. The preview is supposed to sit to the side and only take focus after you click it.

## What Changed

- Remote "Open Preview to the Side" no longer activates the empty right-hand split. Local previews still activate so the preview takes focus once the tab exists.
- Session-tab snapshot apply: if the active group is an empty *reserved* preview split, keep the sibling editor as the visible tab instead of following the host's still-active terminal.
- Empty terminal splits are unchanged: they still activate and still follow a host terminal snapshot when they are not a reserved preview group.

## Why

This is a **real bug**, not a flake.

`tests/e2e/paired-remote-html-browser-focus.spec.ts` failed on `main` at `4e058d4a52` (`e2e 4-of-10`) with `activeTabType` `'terminal'` instead of `'editor'`. The spec was introduced in #13876 (2026-08-12). A full 40-run log sweep of every `e2e 4-of-10` job timed out, so I did not get a complete main-branch fail rate. Code inspection plus a deterministic unit repro is enough: the preview tab is created on the host with `activate: false`, and the paired client must keep the source editor as the focused surface until a click.

Root cause (`file:line`):

1. `openFilePreviewToSide` called `createEmptySplitGroup`, which always set `activeGroupIdByWorktree` to the new empty group (`src/renderer/src/store/slices/tabs.ts`).
2. `createWebRuntimeSessionBrowserTab({ focusOnCreate: false })` then asked the host to create the browser without activating it, so the host snapshot still had `activeTabType: 'terminal'`.
3. `applyWebSessionTabsSnapshot` saw the empty active group (`resolveWebSessionVisibleTabId` returns null) and fell through to the host terminal (`src/renderer/src/runtime/web-session-tabs-sync.ts`).

That is an ordering/synchronization bug on a paired remote surface. Snapshot timing makes the e2e look flaky, but the settled state after an empty-group snapshot is wrong.

## Remote wire compatibility

No wire change.

- Rule 1: no new JSON field.
- Rule 2: no new stream opcode; nothing to capability-negotiate.
- Rule 3: the host still publishes the same snapshot (terminal remains active after `browser.tabCreate` with `activate: false`). This PR only changes how a **new client** interprets that existing snapshot when it has a reserved empty preview split. Old clients keep the previous behavior. Old hosts against new clients are fine because the host content is unchanged.

## Linked Issue

STA-5001. No GitHub issue was found for this e2e failure.

https://linear.app/stably/issue/STA-5001/bug-active-tab-type-remains-terminal-after-opening-remote-html-preview

## Visual Proof

N/A. This is paired session-tab focus sync, not a chrome/layout change. The proof is the unit repro of the e2e assertion (group + active tab + `activeTabType`).

## Testing

Acceptance test (must be able to fail):
`src/renderer/src/runtime/web-session-tabs-sync-html-preview-focus.test.ts`
"keeps the source editor focused when the empty preview split is still the active group"

- **Pre-fix / neutered fix FAILS:**
  ```
  AssertionError: expected { activeGroupId: 'host-group-1', … } to deeply equal { … }
  -   "activeGroupId": "client-editor-group",
  -   "activeTabId": "local-html-editor",
  +   "activeGroupId": "host-group-1",
  +   "activeTabId": "web-terminal-host-terminal",
      "activeTabType": "editor",
  ```
- **Post-fix PASSES** (3 tests in that file).
- Neutered by removing `reservedEmptyPreviewFallbackTabId` from `nextActiveUnifiedTabId`; the same test went red again, then the fix was restored.

Also ran:

- `pnpm typecheck`
- `node config/scripts/check-changed-code-quality.mjs`
- `node config/scripts/check-react-doctor-changed.mjs`
- `pnpm vitest run --config config/vitest.config.ts` on the affected suites (`file-preview`, `web-session-tabs-sync-*`, `web-runtime-session-browser-create-*`, `tabs-empty-split-activation`, `tabs-pane-layout-operations`, `tabs-unread-and-focus`, `editor-tab-placement`, `web-session-focus-intent-visible-tab`)

Not run: the full Playwright spec `tests/e2e/paired-remote-html-browser-focus.spec.ts` (paired Electron, 240s). I did not have a CI-like paired-host environment here. Say so rather than claim that spec is green.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)