### PR TITLE
fix(computer-use): support helper on macOS 12

### DIFF
--- a/.github/workflows/computer-e2e.yml
+++ b/.github/workflows/computer-e2e.yml
@@ -10,6 +10,8 @@ on:
       - 'config/scripts/build-windows-cli-launcher.test.mjs'
       - 'config/scripts/computer-e2e-workflow.test.mjs'
       - 'config/scripts/macos-computer-helper-owner-loss-benchmark.mjs'
+      - 'config/scripts/macos-computer-helper-build-contract.cjs'
+      - 'config/scripts/macos-computer-helper-build-contract.test.mjs'
       - 'config/scripts/macos-computer-helper-owner-loss-group-recovery.test.mjs'
       - 'config/scripts/macos-computer-helper-owner-loss-metrics.mjs'
       - 'config/scripts/macos-computer-helper-owner-loss-processes.mjs'
@@ -106,7 +108,9 @@ jobs:
           src/main/computer/computer-provider-unavailable-message.test.ts
           src/main/computer/sidecar-client.test.ts
           src/main/computer/macos-native-provider-client.test.ts
+          src/main/computer/macos-native-provider-availability.test.ts
           src/main/computer/macos-native-provider-socket.test.ts
+          src/main/computer/macos-computer-use-helper-compatibility.test.ts
           src/main/computer/macos-computer-use-permissions.test.ts
           src/main/computer/macos-computer-use-permission-status.test.ts
           src/main/providers/windows-shell-preflight-runtime.windows.test.ts
@@ -175,6 +179,12 @@ jobs:
         run: pnpm bench:macos-computer-helper-owner-loss --expect reaped --trials 1
       - name: Swift tests and signed universal helper verification
         run: pnpm verify:computer-native
+      - name: Reproduce LaunchServices helper incompatibility
+        env:
+          ORCA_COMPUTER_HELPER_LAUNCHSERVICES_REPRO: '1'
+        run: >-
+          pnpm vitest run --config config/vitest.config.ts
+          src/main/computer/macos-computer-use-launchservices-repro.test.ts
 
   mac:
     # macOS Accessibility and Screen Recording require user-granted TCC entries.

--- a/.github/workflows/computer-e2e.yml
+++ b/.github/workflows/computer-e2e.yml
@@ -179,6 +179,13 @@ jobs:
         run: pnpm bench:macos-computer-helper-owner-loss --expect reaped --trials 1
       - name: Swift tests and signed universal helper verification
         run: pnpm verify:computer-native
+      - name: Verify helper build contract rejection coverage
+        run: >-
+          pnpm vitest run --config config/vitest.config.ts
+          config/scripts/macos-computer-helper-build-contract.test.mjs
+      # Why: afterPack validates the helper inside the real outer app after nested signing.
+      - name: Package and verify the macOS app and helper
+        run: pnpm build:unpack
       - name: Reproduce LaunchServices helper incompatibility
         env:
           ORCA_COMPUTER_HELPER_LAUNCHSERVICES_REPRO: '1'

--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -15,6 +15,9 @@ const { verifyLinuxGlibcFloor } = require('./scripts/verify-linux-glibc-floor.cj
 const { writeMacBuildCompatibility } = require('./scripts/mac-build-compatibility.cjs')
 const { verifyPackagedPluginResources } = require('./scripts/verify-packaged-plugin-resources.cjs')
 const { verifySkillsCliRuntime } = require('./scripts/verify-skills-cli-runtime.cjs')
+const {
+  verifyMacOSComputerHelperBuild
+} = require('./scripts/macos-computer-helper-build-contract.cjs')
 
 // Why: dev-channel builds must carry the *release* identity — same bundle id,
 // Developer ID signature, and notarization ticket — or Squirrel.Mac refuses to
@@ -300,7 +303,11 @@ module.exports = {
       chmodSync(join(resourcesDir, filename), 0o755)
     }
     if (context.electronPlatformName === 'darwin') {
-      await signMacComputerUseHelper(join(resourcesDir, 'Orca Computer Use.app'), context.packager)
+      const computerUseHelperPath = join(resourcesDir, 'Orca Computer Use.app')
+      await signMacComputerUseHelper(computerUseHelperPath, context.packager)
+      verifyMacOSComputerHelperBuild(computerUseHelperPath, {
+        productAppPath: join(context.appOutDir, `${context.packager.appInfo.productFilename}.app`)
+      })
       await signMacStandaloneHelper(
         join(resourcesDir, '..', 'MacOS', 'orca-notification-status'),
         'orca-notification-status',

--- a/config/scripts/build-computer-macos.mjs
+++ b/config/scripts/build-computer-macos.mjs
@@ -1,6 +1,12 @@
 import { spawnSync } from 'node:child_process'
 import { chmodSync, copyFileSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
 import path from 'node:path'
+
+const require = createRequire(import.meta.url)
+const {
+  MACOS_COMPUTER_HELPER_MINIMUM_VERSION
+} = require('./macos-computer-helper-build-contract.cjs')
 
 const repoRoot = path.resolve(import.meta.dirname, '../..')
 const packagePath = path.join(repoRoot, 'native', 'computer-use-macos')
@@ -119,7 +125,7 @@ function infoPlist() {
   <key>CFBundleVersion</key>
   <string>1</string>
   <key>LSMinimumSystemVersion</key>
-  <string>14.0</string>
+  <string>${MACOS_COMPUTER_HELPER_MINIMUM_VERSION}</string>
   <key>LSUIElement</key>
   <true/>
   <key>NSAccessibilityUsageDescription</key>

--- a/config/scripts/computer-e2e-workflow.test.mjs
+++ b/config/scripts/computer-e2e-workflow.test.mjs
@@ -140,10 +140,15 @@ describe('computer-use e2e workflow', () => {
       'config/scripts/macos-computer-helper-owner-loss-group-recovery.test.mjs'
     )
     expect(runs).toContain('pnpm verify:computer-native')
+    expect(runs).toContain(
+      'pnpm vitest run --config config/vitest.config.ts config/scripts/macos-computer-helper-build-contract.test.mjs'
+    )
+    expect(runs).toContain('pnpm build:unpack')
     const launchServicesRepro = runs.find((run) =>
       run.includes('macos-computer-use-launchservices-repro.test.ts')
     )
     expect(launchServicesRepro).toBeTruthy()
+    expect(runs.indexOf('pnpm build:unpack')).toBeLessThan(runs.indexOf(launchServicesRepro))
     expect(runs.join('\n')).not.toContain('test:e2e:computer')
     expect(workflow.on.pull_request.paths).toEqual(
       expect.arrayContaining([

--- a/config/scripts/computer-e2e-workflow.test.mjs
+++ b/config/scripts/computer-e2e-workflow.test.mjs
@@ -86,7 +86,9 @@ describe('computer-use e2e workflow', () => {
       'src/main/computer/computer-provider-unavailable-message.test.ts',
       'src/main/computer/sidecar-client.test.ts',
       'src/main/computer/macos-native-provider-client.test.ts',
+      'src/main/computer/macos-native-provider-availability.test.ts',
       'src/main/computer/macos-native-provider-socket.test.ts',
+      'src/main/computer/macos-computer-use-helper-compatibility.test.ts',
       'src/main/computer/macos-computer-use-permissions.test.ts',
       'src/main/computer/macos-computer-use-permission-status.test.ts',
       'src/main/computer/desktop-script-provider-client.test.ts',
@@ -138,10 +140,16 @@ describe('computer-use e2e workflow', () => {
       'config/scripts/macos-computer-helper-owner-loss-group-recovery.test.mjs'
     )
     expect(runs).toContain('pnpm verify:computer-native')
+    const launchServicesRepro = runs.find((run) =>
+      run.includes('macos-computer-use-launchservices-repro.test.ts')
+    )
+    expect(launchServicesRepro).toBeTruthy()
     expect(runs.join('\n')).not.toContain('test:e2e:computer')
     expect(workflow.on.pull_request.paths).toEqual(
       expect.arrayContaining([
         'config/scripts/macos-computer-helper-owner-loss-benchmark.mjs',
+        'config/scripts/macos-computer-helper-build-contract.cjs',
+        'config/scripts/macos-computer-helper-build-contract.test.mjs',
         'config/scripts/macos-computer-helper-owner-loss-group-recovery.test.mjs',
         'config/scripts/macos-computer-helper-owner-loss-metrics.mjs',
         'config/scripts/macos-computer-helper-owner-loss-processes.mjs',

--- a/config/scripts/macos-computer-helper-build-contract.cjs
+++ b/config/scripts/macos-computer-helper-build-contract.cjs
@@ -1,0 +1,80 @@
+const { execFileSync } = require('node:child_process')
+const { existsSync } = require('node:fs')
+const { join } = require('node:path')
+
+const MACOS_COMPUTER_HELPER_MINIMUM_VERSION = '12.0'
+const MACOS_COMPUTER_HELPER_ARCHITECTURES = ['arm64', 'x86_64']
+
+function verifyMacOSComputerHelperBuild(appPath, options = {}) {
+  if (!existsSync(appPath)) {
+    throw new Error(`Missing Orca Computer Use helper app at ${appPath}`)
+  }
+  const infoPlistPath = join(appPath, 'Contents', 'Info.plist')
+  const executablePath = join(appPath, 'Contents', 'MacOS', 'orca-computer-use-macos')
+  const plistMinimum = execFileSync(
+    '/usr/bin/plutil',
+    ['-extract', 'LSMinimumSystemVersion', 'raw', '-o', '-', infoPlistPath],
+    { encoding: 'utf8' }
+  ).trim()
+  if (plistMinimum !== MACOS_COMPUTER_HELPER_MINIMUM_VERSION) {
+    throw new Error(
+      `Orca Computer Use plist minimum is ${plistMinimum}; expected ${MACOS_COMPUTER_HELPER_MINIMUM_VERSION}`
+    )
+  }
+  if (options.productAppPath) {
+    const productMinimum = execFileSync(
+      '/usr/bin/plutil',
+      [
+        '-extract',
+        'LSMinimumSystemVersion',
+        'raw',
+        '-o',
+        '-',
+        join(options.productAppPath, 'Contents', 'Info.plist')
+      ],
+      { encoding: 'utf8' }
+    ).trim()
+    if (productMinimum !== MACOS_COMPUTER_HELPER_MINIMUM_VERSION) {
+      throw new Error(
+        `Orca.app minimum is ${productMinimum}; expected ${MACOS_COMPUTER_HELPER_MINIMUM_VERSION}`
+      )
+    }
+  }
+
+  const architectures = execFileSync('/usr/bin/lipo', ['-archs', executablePath], {
+    encoding: 'utf8'
+  })
+    .trim()
+    .split(/\s+/)
+    .sort()
+  const expectedArchitectures = [...MACOS_COMPUTER_HELPER_ARCHITECTURES].sort()
+  if (architectures.join(',') !== expectedArchitectures.join(',')) {
+    throw new Error(
+      `Orca Computer Use architectures are ${architectures.join(',')}; expected ${expectedArchitectures.join(',')}`
+    )
+  }
+
+  for (const architecture of MACOS_COMPUTER_HELPER_ARCHITECTURES) {
+    const build = execFileSync(
+      '/usr/bin/xcrun',
+      ['vtool', '-show-build', '-arch', architecture, executablePath],
+      { encoding: 'utf8' }
+    )
+    const minimum = /^\s*minos\s+(\S+)$/m.exec(build)?.[1]
+    if (minimum !== MACOS_COMPUTER_HELPER_MINIMUM_VERSION) {
+      throw new Error(
+        `Orca Computer Use ${architecture} minimum is ${minimum ?? 'missing'}; expected ${MACOS_COMPUTER_HELPER_MINIMUM_VERSION}`
+      )
+    }
+  }
+
+  execFileSync('/usr/bin/codesign', ['--verify', '--deep', '--strict', appPath], {
+    stdio: 'inherit'
+  })
+}
+
+module.exports = {
+  MACOS_COMPUTER_HELPER_ARCHITECTURES,
+  MACOS_COMPUTER_HELPER_MINIMUM_VERSION,
+  verifyMacOSComputerHelperBuild
+}

--- a/config/scripts/macos-computer-helper-build-contract.test.mjs
+++ b/config/scripts/macos-computer-helper-build-contract.test.mjs
@@ -1,0 +1,56 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  MACOS_COMPUTER_HELPER_MINIMUM_VERSION,
+  verifyMacOSComputerHelperBuild
+} from './macos-computer-helper-build-contract.cjs'
+
+describe.skipIf(process.platform !== 'darwin')('macOS Computer Use build contract', () => {
+  it('verifies the staged signed universal helper metadata', () => {
+    const appPath = join(
+      import.meta.dirname,
+      '..',
+      '..',
+      'native',
+      'computer-use-macos',
+      '.build',
+      'release',
+      'Orca Computer Use.app'
+    )
+
+    expect(() => verifyMacOSComputerHelperBuild(appPath)).not.toThrow()
+  })
+
+  it('rejects plist drift before inspecting binary slices', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'orca-computer-helper-contract-'))
+    const infoPlistPath = join(directory, 'Contents', 'Info.plist')
+    try {
+      mkdirSync(join(directory, 'Contents'), { recursive: true })
+      const source = join(
+        import.meta.dirname,
+        '..',
+        '..',
+        'native',
+        'computer-use-macos',
+        '.build',
+        'release',
+        'Orca Computer Use.app',
+        'Contents',
+        'Info.plist'
+      )
+      const plist = readFileSync(source, 'utf8').replace(
+        `<string>${MACOS_COMPUTER_HELPER_MINIMUM_VERSION}</string>`,
+        '<string>99.0</string>'
+      )
+      writeFileSync(infoPlistPath, plist)
+
+      expect(() => verifyMacOSComputerHelperBuild(directory)).toThrow(
+        'Orca Computer Use plist minimum is 99.0'
+      )
+    } finally {
+      rmSync(directory, { recursive: true, force: true })
+    }
+  })
+})

--- a/config/scripts/verify-computer-native.mjs
+++ b/config/scripts/verify-computer-native.mjs
@@ -4,6 +4,10 @@ import { spawnSync } from 'node:child_process'
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+const { verifyMacOSComputerHelperBuild } = require('./macos-computer-helper-build-contract.cjs')
 
 const repoRoot = resolve(import.meta.dirname, '..', '..')
 const checks = [
@@ -156,7 +160,13 @@ function verifyMacOSHelperApp() {
     )
     return false
   }
-  return run('codesign', ['--verify', '--deep', '--strict', appPath])
+  try {
+    verifyMacOSComputerHelperBuild(appPath)
+    return true
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    return false
+  }
 }
 
 function verifyWindowsProviderHandshake() {
@@ -533,18 +543,6 @@ function swiftFunctionBody(source, name) {
     }
   }
   return null
-}
-
-function run(command, args) {
-  if (!hasCommand(command)) {
-    console.log(`[computer-native] skip ${command}: command not found`)
-    return true
-  }
-  const result = spawnSync(command, args, {
-    cwd: repoRoot,
-    stdio: 'inherit'
-  })
-  return result.status === 0 && !result.error
 }
 
 function quoteShell(value) {

--- a/native/computer-use-macos/Package.swift
+++ b/native/computer-use-macos/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "OrcaComputerUseMacOS",
     platforms: [
-        .macOS(.v14)
+        .macOS(.v12)
     ],
     products: [
         .library(

--- a/native/computer-use-macos/Sources/OrcaComputerUseMacOS/main.swift
+++ b/native/computer-use-macos/Sources/OrcaComputerUseMacOS/main.swift
@@ -2459,7 +2459,8 @@ private struct WindowCapture {
     }
 
     private static func captureImage(windowId: CGWindowID, bounds: CGRect) -> CapturedImage? {
-        if ProcessInfo.processInfo.environment["ORCA_COMPUTER_USE_SCK_SCREENSHOTS"] == "1",
+        if #available(macOS 14.0, *),
+           ProcessInfo.processInfo.environment["ORCA_COMPUTER_USE_SCK_SCREENSHOTS"] == "1",
            let image = captureImageWithScreenCaptureKit(windowId: windowId, bounds: bounds) {
             return CapturedImage(image: image, engine: "screenCaptureKit")
         }
@@ -2469,6 +2470,7 @@ private struct WindowCapture {
         return nil
     }
 
+    @available(macOS 14.0, *)
     private static func captureImageWithScreenCaptureKit(windowId: CGWindowID, bounds: CGRect) -> CGImage? {
         try? BlockingAsync.run(timeout: 3) {
             let content = try await SCShareableContent.current

--- a/src/main/computer/macos-computer-use-helper-compatibility.test.ts
+++ b/src/main/computer/macos-computer-use-helper-compatibility.test.ts
@@ -1,0 +1,49 @@
+import { execFileSync } from 'node:child_process'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  compareVersions,
+  formatMacOSComputerUseHelperUnavailableReason,
+  getMacOSComputerUseHelperCompatibility
+} from './macos-computer-use-helper-compatibility'
+
+vi.mock('node:child_process', () => ({ execFileSync: vi.fn() }))
+
+describe('macOS Computer Use helper compatibility', () => {
+  beforeEach(() => {
+    vi.mocked(execFileSync).mockReset()
+  })
+
+  it('compares dotted macOS versions numerically', () => {
+    expect(compareVersions('13.6.9', '14.0')).toBeLessThan(0)
+    expect(compareVersions('14.0', '14')).toBe(0)
+    expect(compareVersions('14.10', '14.9')).toBeGreaterThan(0)
+  })
+
+  it('reports an installed helper whose minimum exceeds the current OS', () => {
+    vi.mocked(execFileSync).mockImplementation((command) => {
+      if (command === '/usr/bin/sw_vers') {
+        return '13.6.9\n'
+      }
+      return '14.0\n'
+    })
+
+    const result = getMacOSComputerUseHelperCompatibility('/Applications/Orca Computer Use.app')
+
+    expect(result).toEqual({
+      compatible: false,
+      currentVersion: '13.6.9',
+      minimumVersion: '14.0'
+    })
+    expect(formatMacOSComputerUseHelperUnavailableReason(result!)).toBe(
+      'Orca Computer Use requires macOS 14.0 or newer (this Mac is running macOS 13.6.9)'
+    )
+  })
+
+  it('does not classify unreadable metadata as a known incompatibility', () => {
+    vi.mocked(execFileSync).mockImplementation(() => {
+      throw new Error('unreadable')
+    })
+
+    expect(getMacOSComputerUseHelperCompatibility('/Applications/Orca Computer Use.app')).toBeNull()
+  })
+})

--- a/src/main/computer/macos-computer-use-helper-compatibility.test.ts
+++ b/src/main/computer/macos-computer-use-helper-compatibility.test.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from 'node:child_process'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  clearMacOSComputerUseHelperCompatibilityCache,
   compareVersions,
   formatMacOSComputerUseHelperUnavailableReason,
   getMacOSComputerUseHelperCompatibility
@@ -11,6 +12,7 @@ vi.mock('node:child_process', () => ({ execFileSync: vi.fn() }))
 describe('macOS Computer Use helper compatibility', () => {
   beforeEach(() => {
     vi.mocked(execFileSync).mockReset()
+    clearMacOSComputerUseHelperCompatibilityCache()
   })
 
   it('compares dotted macOS versions numerically', () => {
@@ -45,5 +47,16 @@ describe('macOS Computer Use helper compatibility', () => {
     })
 
     expect(getMacOSComputerUseHelperCompatibility('/Applications/Orca Computer Use.app')).toBeNull()
+  })
+
+  it('caches successful compatibility metadata for the immutable helper app', () => {
+    vi.mocked(execFileSync).mockImplementation((command) => {
+      return command === '/usr/bin/sw_vers' ? '12.7.6\n' : '12.0\n'
+    })
+
+    getMacOSComputerUseHelperCompatibility('/Applications/Orca Computer Use.app')
+    getMacOSComputerUseHelperCompatibility('/Applications/Orca Computer Use.app')
+
+    expect(execFileSync).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/main/computer/macos-computer-use-helper-compatibility.ts
+++ b/src/main/computer/macos-computer-use-helper-compatibility.ts
@@ -1,0 +1,83 @@
+import { execFileSync } from 'node:child_process'
+import { join } from 'node:path'
+
+export type MacOSHelperSystemCompatibility = {
+  compatible: boolean
+  currentVersion: string
+  minimumVersion: string
+}
+
+export function getMacOSComputerUseHelperCompatibility(
+  helperAppPath: string
+): MacOSHelperSystemCompatibility | null {
+  const currentVersion = readCurrentMacOSVersion()
+  const minimumVersion = readHelperMinimumMacOSVersion(helperAppPath)
+  if (!currentVersion || !minimumVersion) {
+    return null
+  }
+  return {
+    compatible: compareVersions(currentVersion, minimumVersion) >= 0,
+    currentVersion,
+    minimumVersion
+  }
+}
+
+export function formatMacOSComputerUseHelperUnavailableReason(
+  compatibility: MacOSHelperSystemCompatibility
+): string {
+  return `Orca Computer Use requires macOS ${compatibility.minimumVersion} or newer (this Mac is running macOS ${compatibility.currentVersion})`
+}
+
+export function compareVersions(left: string, right: string): number {
+  const leftParts = parseVersion(left)
+  const rightParts = parseVersion(right)
+  if (!leftParts || !rightParts) {
+    return Number.NaN
+  }
+  const count = Math.max(leftParts.length, rightParts.length)
+  for (let index = 0; index < count; index++) {
+    const difference = (leftParts[index] ?? 0) - (rightParts[index] ?? 0)
+    if (difference !== 0) {
+      return difference
+    }
+  }
+  return 0
+}
+
+function readCurrentMacOSVersion(): string | null {
+  const electronVersion = (
+    process as NodeJS.Process & { getSystemVersion?: () => string }
+  ).getSystemVersion?.()
+  if (parseVersion(electronVersion)) {
+    return electronVersion ?? null
+  }
+  try {
+    const version = execFileSync('/usr/bin/sw_vers', ['-productVersion'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore']
+    }).trim()
+    return parseVersion(version) ? version : null
+  } catch {
+    return null
+  }
+}
+
+function readHelperMinimumMacOSVersion(helperAppPath: string): string | null {
+  try {
+    const version = execFileSync(
+      '/usr/libexec/PlistBuddy',
+      ['-c', 'Print :LSMinimumSystemVersion', join(helperAppPath, 'Contents', 'Info.plist')],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }
+    ).trim()
+    return parseVersion(version) ? version : null
+  } catch {
+    return null
+  }
+}
+
+function parseVersion(version: string | null | undefined): number[] | null {
+  if (!version || !/^\d+(?:\.\d+)*$/.test(version)) {
+    return null
+  }
+  return version.split('.').map(Number)
+}

--- a/src/main/computer/macos-computer-use-helper-compatibility.ts
+++ b/src/main/computer/macos-computer-use-helper-compatibility.ts
@@ -7,19 +7,31 @@ export type MacOSHelperSystemCompatibility = {
   minimumVersion: string
 }
 
+const compatibilityByHelperAppPath = new Map<string, MacOSHelperSystemCompatibility>()
+
 export function getMacOSComputerUseHelperCompatibility(
   helperAppPath: string
 ): MacOSHelperSystemCompatibility | null {
+  const cached = compatibilityByHelperAppPath.get(helperAppPath)
+  if (cached) {
+    return cached
+  }
   const currentVersion = readCurrentMacOSVersion()
   const minimumVersion = readHelperMinimumMacOSVersion(helperAppPath)
   if (!currentVersion || !minimumVersion) {
     return null
   }
-  return {
+  const compatibility = {
     compatible: compareVersions(currentVersion, minimumVersion) >= 0,
     currentVersion,
     minimumVersion
   }
+  compatibilityByHelperAppPath.set(helperAppPath, compatibility)
+  return compatibility
+}
+
+export function clearMacOSComputerUseHelperCompatibilityCache(): void {
+  compatibilityByHelperAppPath.clear()
 }
 
 export function formatMacOSComputerUseHelperUnavailableReason(

--- a/src/main/computer/macos-computer-use-launchservices-repro.test.ts
+++ b/src/main/computer/macos-computer-use-launchservices-repro.test.ts
@@ -1,0 +1,134 @@
+import { execFileSync, spawnSync } from 'node:child_process'
+import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import type * as CompatibilityModule from './macos-computer-use-helper-compatibility'
+
+const compatibilityOverride = vi.hoisted(() => ({ disabled: false }))
+
+vi.mock('./macos-computer-use-helper-compatibility', async (importOriginal) => {
+  const actual = await importOriginal<typeof CompatibilityModule>()
+  return {
+    ...actual,
+    getMacOSComputerUseHelperCompatibility: (helperAppPath: string) =>
+      compatibilityOverride.disabled
+        ? { compatible: true, currentVersion: '0', minimumVersion: '0' }
+        : actual.getMacOSComputerUseHelperCompatibility(helperAppPath)
+  }
+})
+
+const runRepro =
+  process.platform === 'darwin' && process.env.ORCA_COMPUTER_HELPER_LAUNCHSERVICES_REPRO === '1'
+
+describe.skipIf(!runRepro)('macOS Computer Use LaunchServices compatibility repro', () => {
+  let directory = ''
+  let helperAppPath = ''
+  let originalOverride: string | undefined
+
+  beforeAll(() => {
+    directory = mkdtempSync(join(tmpdir(), 'orca-computer-helper-launchservices-'))
+    helperAppPath = join(directory, 'Orca Computer Use Incompatible.app')
+    const sourceAppPath = join(
+      process.cwd(),
+      'native',
+      'computer-use-macos',
+      '.build',
+      'release',
+      'Orca Computer Use.app'
+    )
+    if (!existsSync(sourceAppPath)) {
+      throw new Error(`Missing staged helper at ${sourceAppPath}; run pnpm build:computer-macos`)
+    }
+    execFileSync('/usr/bin/ditto', [sourceAppPath, helperAppPath])
+    raiseHelperMinimumAboveCurrentOS(helperAppPath, directory)
+    originalOverride = process.env.ORCA_COMPUTER_MACOS_HELPER_APP_PATH
+    process.env.ORCA_COMPUTER_MACOS_HELPER_APP_PATH = helperAppPath
+  }, 30_000)
+
+  afterAll(() => {
+    if (originalOverride === undefined) {
+      delete process.env.ORCA_COMPUTER_MACOS_HELPER_APP_PATH
+    } else {
+      process.env.ORCA_COMPUTER_MACOS_HELPER_APP_PATH = originalOverride
+    }
+    rmSync(directory, { recursive: true, force: true })
+  })
+
+  it('gets exact -10825 from real open and no helper status file', () => {
+    const statusPath = join(directory, 'raw-status.json')
+    const result = spawnSync(
+      '/usr/bin/open',
+      ['-n', helperAppPath, '--args', '--permission-status-file', statusPath],
+      { encoding: 'utf8' }
+    )
+
+    expect(result.status).not.toBe(0)
+    expect(`${result.stderr}${result.stdout}`).toContain('-10825')
+    expect(existsSync(statusPath)).toBe(false)
+  })
+
+  it('returns structured unavailability before launching the incompatible helper', async () => {
+    compatibilityOverride.disabled = false
+    const { getComputerUsePermissionStatus } = await import('./macos-computer-use-permissions')
+
+    await expect(getComputerUsePermissionStatus()).resolves.toMatchObject({
+      platform: 'darwin',
+      helperAppPath,
+      helperUnavailableReason: expect.stringContaining('requires macOS')
+    })
+  })
+
+  it('reproduces the raw -10825 when the compatibility fix is disabled', async () => {
+    compatibilityOverride.disabled = true
+    const { getComputerUsePermissionStatus } = await import('./macos-computer-use-permissions')
+
+    await expect(getComputerUsePermissionStatus()).rejects.toMatchObject({
+      name: 'RuntimeClientError',
+      code: 'accessibility_error',
+      message: expect.stringContaining('-10825')
+    })
+  })
+})
+
+function raiseHelperMinimumAboveCurrentOS(helperAppPath: string, directory: string): void {
+  const currentVersion = execFileSync('/usr/bin/sw_vers', ['-productVersion'], {
+    encoding: 'utf8'
+  }).trim()
+  const futureVersion = `${Number.parseInt(currentVersion.split('.')[0] ?? '', 10) + 1}.0`
+  const executablePath = join(helperAppPath, 'Contents', 'MacOS', 'orca-computer-use-macos')
+  const mutatedSlices: string[] = []
+  for (const architecture of ['arm64', 'x86_64']) {
+    const thinPath = join(directory, `helper-${architecture}`)
+    const mutatedPath = join(directory, `helper-${architecture}-future`)
+    execFileSync('/usr/bin/lipo', [executablePath, '-thin', architecture, '-output', thinPath])
+    execFileSync('/usr/bin/xcrun', [
+      'vtool',
+      '-set-build-version',
+      'macos',
+      futureVersion,
+      futureVersion,
+      '-replace',
+      '-output',
+      mutatedPath,
+      thinPath
+    ])
+    mutatedSlices.push(mutatedPath)
+  }
+  execFileSync('/usr/bin/lipo', ['-create', ...mutatedSlices, '-output', executablePath])
+  execFileSync('/usr/bin/plutil', [
+    '-replace',
+    'LSMinimumSystemVersion',
+    '-string',
+    futureVersion,
+    join(helperAppPath, 'Contents', 'Info.plist')
+  ])
+  execFileSync('/usr/bin/plutil', [
+    '-replace',
+    'CFBundleIdentifier',
+    '-string',
+    'com.stablyai.orca.computer-use.launchservices-repro',
+    join(helperAppPath, 'Contents', 'Info.plist')
+  ])
+  execFileSync('/usr/bin/codesign', ['--force', '--deep', '--sign', '-', helperAppPath])
+}

--- a/src/main/computer/macos-computer-use-permission-status.test.ts
+++ b/src/main/computer/macos-computer-use-permission-status.test.ts
@@ -194,6 +194,28 @@ describe('getComputerUsePermissionStatus', () => {
     })
   })
 
+  it('returns unavailable status without launching an incompatible helper app', async () => {
+    vi.mocked(execFileSync).mockImplementation((command) => {
+      if (command === '/usr/bin/sw_vers') {
+        return '13.6.9\n'
+      }
+      return '14.0\n'
+    })
+    const { getComputerUsePermissionStatus } = await import('./macos-computer-use-permissions')
+
+    await expect(getComputerUsePermissionStatus()).resolves.toEqual({
+      platform: 'darwin',
+      helperAppPath: '/Applications/Orca Computer Use.app',
+      helperUnavailableReason:
+        'Orca Computer Use requires macOS 14.0 or newer (this Mac is running macOS 13.6.9)',
+      permissions: [
+        { id: 'accessibility', status: 'not-granted' },
+        { id: 'screenshots', status: 'not-granted' }
+      ]
+    })
+    expect(spawn).not.toHaveBeenCalled()
+  })
+
   it('returns unavailable permission status when the helper app is missing on macOS', async () => {
     const { getComputerUsePermissionStatus } = await import('./macos-computer-use-permissions')
     resolveHelperAppPathMock.mockReturnValue(null)

--- a/src/main/computer/macos-computer-use-permission-status.ts
+++ b/src/main/computer/macos-computer-use-permission-status.ts
@@ -12,6 +12,10 @@ import {
   resolveMacOSComputerUseAppPath,
   resolveMacOSComputerUseExecutablePath
 } from './macos-native-provider-paths'
+import {
+  formatMacOSComputerUseHelperUnavailableReason,
+  getMacOSComputerUseHelperCompatibility
+} from './macos-computer-use-helper-compatibility'
 import { RuntimeClientError } from './runtime-client-error'
 
 const PERMISSION_STATUS_HELPER_LAUNCH_TIMEOUT_MS = 5_000
@@ -42,6 +46,14 @@ async function getComputerUsePermissionStatusAsync(): Promise<ComputerUsePermiss
   if (!executablePath) {
     return createUnavailablePermissionStatus(
       `${helperAppPath}/Contents/MacOS/orca-computer-use-macos was not found`,
+      helperAppPath
+    )
+  }
+
+  const compatibility = getMacOSComputerUseHelperCompatibility(helperAppPath)
+  if (compatibility && !compatibility.compatible) {
+    return createUnavailablePermissionStatus(
+      formatMacOSComputerUseHelperUnavailableReason(compatibility),
       helperAppPath
     )
   }

--- a/src/main/computer/macos-computer-use-permissions.test.ts
+++ b/src/main/computer/macos-computer-use-permissions.test.ts
@@ -213,7 +213,12 @@ describe('openComputerUsePermissions', () => {
     vi.mocked(readFile)
       .mockResolvedValueOnce('{"accessibility":"granted","screenshots":"granted"}')
       .mockResolvedValueOnce('{"accessibility":"not-granted","screenshots":"not-granted"}')
-    vi.mocked(execFileSync).mockReturnValueOnce('com.example.orca.computer-use\n')
+    vi.mocked(execFileSync).mockImplementation((_command, args) => {
+      if (args?.includes('Print :CFBundleIdentifier')) {
+        return 'com.example.orca.computer-use\n'
+      }
+      throw new Error('compatibility metadata unavailable')
+    })
     vi.mocked(spawnSync).mockReturnValue({ status: 0 } as ReturnType<typeof spawnSync>)
 
     await expect(resetComputerUsePermissions()).resolves.toEqual({

--- a/src/main/computer/macos-native-provider-availability.test.ts
+++ b/src/main/computer/macos-native-provider-availability.test.ts
@@ -1,0 +1,53 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const resolveAppPathMock = vi.hoisted(() => vi.fn())
+const resolveExecutablePathMock = vi.hoisted(() => vi.fn())
+const getCompatibilityMock = vi.hoisted(() => vi.fn())
+
+vi.mock('./macos-native-provider-paths', () => ({
+  resolveMacOSComputerUseAppPath: resolveAppPathMock,
+  resolveMacOSComputerUseExecutablePath: resolveExecutablePathMock
+}))
+
+vi.mock('./macos-computer-use-helper-compatibility', () => ({
+  getMacOSComputerUseHelperCompatibility: getCompatibilityMock
+}))
+
+import { shouldUseMacOSNativeProvider } from './macos-native-provider-availability'
+
+describe('macOS native provider availability', () => {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
+
+  beforeEach(() => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'darwin' })
+    resolveAppPathMock.mockReset().mockReturnValue('/Applications/Orca Computer Use.app')
+    resolveExecutablePathMock
+      .mockReset()
+      .mockReturnValue('/Applications/Orca Computer Use.app/Contents/MacOS/orca-computer-use-macos')
+    getCompatibilityMock.mockReset()
+  })
+
+  afterAll(() => {
+    Object.defineProperty(process, 'platform', originalPlatform)
+  })
+
+  it('selects a helper compatible with the current macOS version', () => {
+    getCompatibilityMock.mockReturnValue({
+      compatible: true,
+      currentVersion: '12.0',
+      minimumVersion: '12.0'
+    })
+
+    expect(shouldUseMacOSNativeProvider()).toBe(true)
+  })
+
+  it('rejects a helper whose minimum exceeds the current macOS version', () => {
+    getCompatibilityMock.mockReturnValue({
+      compatible: false,
+      currentVersion: '13.6.9',
+      minimumVersion: '14.0'
+    })
+
+    expect(shouldUseMacOSNativeProvider()).toBe(false)
+  })
+})

--- a/src/main/computer/macos-native-provider-availability.ts
+++ b/src/main/computer/macos-native-provider-availability.ts
@@ -1,10 +1,16 @@
-import { resolveMacOSComputerUseExecutablePath } from './macos-native-provider-paths'
-import { isMacOS14OrNewer } from './macos-native-provider-transport'
+import {
+  resolveMacOSComputerUseAppPath,
+  resolveMacOSComputerUseExecutablePath
+} from './macos-native-provider-paths'
+import { getMacOSComputerUseHelperCompatibility } from './macos-computer-use-helper-compatibility'
 
 export function shouldUseMacOSNativeProvider(): boolean {
+  if (process.platform !== 'darwin' || resolveMacOSComputerUseExecutablePath() === null) {
+    return false
+  }
+  const helperAppPath = resolveMacOSComputerUseAppPath()
   return (
-    process.platform === 'darwin' &&
-    isMacOS14OrNewer() &&
-    resolveMacOSComputerUseExecutablePath() !== null
+    helperAppPath !== null &&
+    getMacOSComputerUseHelperCompatibility(helperAppPath)?.compatible === true
   )
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​346 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​345 |
| Prod | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​245 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​22 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​223 |

<!-- /orca-pr-loc -->

## Summary

- lower the bundled Computer Use helper deployment target from macOS 14 to the Orca product floor, macOS 12
- availability-guard the macOS 14 ScreenCaptureKit screenshot path and retain the existing Core Graphics fallback on macOS 12 and 13
- preflight helper metadata in the main process so a future helper/host mismatch returns structured `helperUnavailableReason` instead of leaking LaunchServices error `-10825`
- enforce matching plist and Mach-O minimums, universal slices, and signatures during native verification and packaging

## Reproduction

A real copied helper is rewritten to a future plist and Mach-O minimum, ad-hoc signed, and launched through the production `/usr/bin/open -n` path. The harness proves:

1. real LaunchServices exits nonzero with exact `-10825` and no status file
2. the candidate returns structured unavailability without launching it
3. disabling the compatibility decision restores the raw `RuntimeClientError` containing `-10825`

## Validation

- real LaunchServices oracle: 3/3
- focused Vitest: 35/35
- Swift XCTest: 92/92
- Swift Testing: 4/4
- `pnpm verify:computer-native`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build:unpack`
- unpacked Orca.app plist minimum: 12.0
- unpacked helper plist and both arm64/x86_64 Mach-O minimums: 12.0
- packaged outer/helper signatures verified
- Electron CDP with isolated profile: visible Settings state showed Computer Use unavailable, clear minimum/current macOS copy, disabled Open/reset controls; backing IPC returned the same structured status

## Remaining platform gap

No physical macOS 12 or 13 VM was available. Deployment, weak-link, architecture, package-contract, fallback-path, real LaunchServices, and visible Electron behavior are covered mechanically; macOS 12/13 runtime smoke remains desirable before release.
