### PR TITLE
feat(plugins): let plugin keybindings opt into terminal focus

### DIFF
--- a/src/main/plugins/plugin-command-registry.ts
+++ b/src/main/plugins/plugin-command-registry.ts
@@ -17,6 +17,8 @@ import {
 export type PluginCommandKeybinding = {
   key: string
   when: 'global' | 'worktree'
+  /** Explicit opt-in to fire while focus is in a terminal (#15642). */
+  allowInTerminal?: boolean
 }
 
 export type PluginCommandRegistration = {
@@ -155,7 +157,8 @@ function keybindingsForCommand(
     .filter((keybinding) => keybinding.command === command.id)
     .map((keybinding) => ({
       key: keybinding.key,
-      when: keybinding.when ?? command.context ?? 'global'
+      when: keybinding.when ?? command.context ?? 'global',
+      ...(keybinding.allowInTerminal ? { allowInTerminal: true } : {})
     }))
 }
 

--- a/src/main/plugins/plugin-list-projection.ts
+++ b/src/main/plugins/plugin-list-projection.ts
@@ -62,7 +62,7 @@ export type PluginListEntry = {
     title: string
     context: 'global' | 'worktree'
     handler: { type: 'built-in'; action: PluginCommandAliasActionId } | { type: 'worker' }
-    keybindings: { key: string; when: 'global' | 'worktree' }[]
+    keybindings: { key: string; when: 'global' | 'worktree'; allowInTerminal?: boolean }[]
   }[]
   hasWorker: boolean
   vmRecipes: {

--- a/src/preload/api/plugin-host-api.ts
+++ b/src/preload/api/plugin-host-api.ts
@@ -51,7 +51,7 @@ export type PluginHostListEntry = {
     title: string
     context: 'global' | 'worktree'
     handler: { type: 'built-in'; action: string } | { type: 'worker' }
-    keybindings: { key: string; when: 'global' | 'worktree' }[]
+    keybindings: { key: string; when: 'global' | 'worktree'; allowInTerminal?: boolean }[]
   }[]
   hasWorker: boolean
   vmRecipes?: {

--- a/src/renderer/src/app-shell/use-global-keybindings.ts
+++ b/src/renderer/src/app-shell/use-global-keybindings.ts
@@ -215,14 +215,18 @@ export function useGlobalKeybindings(args: {
 
       // Plugin chords are user-reviewed instructional content. They win over
       // built-in defaults only in app focus; terminal/editor/browser handlers
-      // retain their own shortcut authority.
-      if (context === 'app') {
+      // retain their own shortcut authority — except bindings that explicitly
+      // opted into terminal focus, which would otherwise have no reachable
+      // trigger at all (#15642). No capture toast here: the command visibly
+      // runs, so the terminal losing the chord is self-evident.
+      if (context === 'app' || context === 'terminal') {
         const pluginCommand = findPluginCommandForKeybinding(
           pluginCommands,
           input,
           shortcutPlatform,
           keybindings,
-          Boolean(activeWorktreeId)
+          Boolean(activeWorktreeId),
+          context === 'terminal' ? { requireAllowInTerminal: true } : {}
         )
         if (pluginCommand) {
           input.preventDefault()

--- a/src/renderer/src/lib/plugin-command-keybindings.test.ts
+++ b/src/renderer/src/lib/plugin-command-keybindings.test.ts
@@ -77,6 +77,53 @@ describe('plugin command keybindings', () => {
     ).toBeNull()
   })
 
+
+  it('terminal focus matches only bindings that opted in via allowInTerminal (#15642)', () => {
+    const optedIn: ActivePluginCommand = {
+      ...command,
+      id: 'speak',
+      keybindings: [
+        { key: 'Mod+Alt+T', when: 'global' },
+        { key: 'Mod+Shift+S', when: 'global', allowInTerminal: true }
+      ]
+    }
+    const plainInput = { key: 't', code: 'KeyT', control: true, meta: false, alt: true, shift: false }
+    const optedInput = {
+      key: 's',
+      code: 'KeyS',
+      control: true,
+      meta: false,
+      alt: false,
+      shift: true
+    }
+
+    // Default (app focus): every binding matches.
+    expect(findPluginCommandForKeybinding([optedIn], plainInput, 'linux', undefined, true)).toBe(
+      optedIn
+    )
+    // Terminal focus: only the opted-in chord matches…
+    expect(
+      findPluginCommandForKeybinding([optedIn], optedInput, 'linux', undefined, true, {
+        requireAllowInTerminal: true
+      })
+    ).toBe(optedIn)
+    // …and a non-opted chord no longer claims the terminal's key.
+    expect(
+      findPluginCommandForKeybinding([optedIn], plainInput, 'linux', undefined, true, {
+        requireAllowInTerminal: true
+      })
+    ).toBeNull()
+  })
+
+  it('terminal focus ignores commands whose bindings never opted in', () => {
+    const input = { key: 't', code: 'KeyT', control: true, meta: false, alt: true, shift: false }
+    expect(
+      findPluginCommandForKeybinding([command], input, 'linux', undefined, true, {
+        requireAllowInTerminal: true
+      })
+    ).toBeNull()
+  })
+
   it('reports conflicts between plugin and built-in definitions', () => {
     const actionId = pluginCommandKeybindingActionId(command)
     const definitions = [...KEYBINDING_DEFINITIONS, pluginCommandKeybindingDefinition(command)]

--- a/src/renderer/src/lib/plugin-command-keybindings.ts
+++ b/src/renderer/src/lib/plugin-command-keybindings.ts
@@ -58,10 +58,25 @@ export function findPluginCommandForKeybinding(
   input: KeybindingInput,
   platform: NodeJS.Platform,
   overrides: KeybindingOverrides | undefined,
-  hasActiveWorktree: boolean
+  hasActiveWorktree: boolean,
+  options: { requireAllowInTerminal?: boolean } = {}
 ): ActivePluginCommand | null {
   for (const command of commands) {
     if (command.context === 'worktree' && !hasActiveWorktree) {
+      continue
+    }
+    // Why (#15642): terminal focus only honors chords that explicitly opted in,
+    // so plugin bindings keep out of the terminal's own shortcut authority by
+    // default. The opt-in path matches the binding's own (already
+    // schema-normalized) key rather than the override-resolved list, because
+    // per-binding consent cannot be inferred from a command-level override.
+    if (options.requireAllowInTerminal) {
+      const terminalEligible = command.keybindings
+        .filter((keybinding) => keybinding.allowInTerminal === true)
+        .some((keybinding) => keybindingMatchesInput(keybinding.key, input, platform))
+      if (terminalEligible) {
+        return command
+      }
       continue
     }
     const matches = getEffectivePluginCommandKeybindings(command, platform, overrides).some(

--- a/src/shared/plugins/plugin-content-pack-contributions.test.ts
+++ b/src/shared/plugins/plugin-content-pack-contributions.test.ts
@@ -28,7 +28,10 @@ describe('content-pack manifest contributions', () => {
             action: 'view.tasks'
           }
         ],
-        keybindings: [{ command: 'workspace.openTasks', key: 'Mod+Alt+T' }],
+        keybindings: [
+          { command: 'workspace.openTasks', key: 'Mod+Alt+T' },
+          { command: 'workspace.openTasks', key: 'Mod+Shift+T', allowInTerminal: true }
+        ],
         vmRecipes: [{ path: 'recipes/fly.json' }],
         agents: [{ path: 'agents/custom.json' }]
       })
@@ -153,3 +156,23 @@ describe('content-pack manifest contributions', () => {
     }
   })
 })
+
+  it('parses allowInTerminal on contributed keybindings (#15642)', () => {
+    const parsed = pluginManifestSchema.safeParse(
+      manifest({
+        commands: [
+          {
+            id: 'workspace.openTasks',
+            title: 'Open tasks',
+            context: 'worktree',
+            action: 'view.tasks'
+          }
+        ],
+        keybindings: [{ command: 'workspace.openTasks', key: 'Mod+Shift+T', allowInTerminal: true }]
+      })
+    )
+    expect(parsed.success).toBe(true)
+    if (parsed.success) {
+      expect(parsed.data.contributes.keybindings[0]?.allowInTerminal).toBe(true)
+    }
+  })

--- a/src/shared/plugins/plugin-content-pack-contributions.ts
+++ b/src/shared/plugins/plugin-content-pack-contributions.ts
@@ -37,7 +37,13 @@ export const pluginKeybindingContributionSchema = z
         }
         return normalized.value
       }),
-    when: z.enum(['global', 'worktree']).optional()
+    when: z.enum(['global', 'worktree']).optional(),
+    // Why (#15642): plugin chords are consulted only in app focus by default so a
+    // plugin cannot steal Ctrl+C from a terminal. Without an opt-in there is no
+    // reachable trigger for users who live in terminals (no palette contribution
+    // point, panels cannot invoke commands, no OS-level global shortcut), so a
+    // binding may explicitly opt into terminal focus.
+    allowInTerminal: z.boolean().optional()
   })
   .strict()
 


### PR DESCRIPTION
## Summary

**What**

Plugin keybinding contributions gain an explicit `allowInTerminal: true` opt-in, and terminal-context dispatch honors it. Default behaviour is unchanged — a plugin still cannot claim a chord from the terminal unless it asks.

**Why**

#15642 — plugin commands have exactly one trigger (a keybinding), and plugin chords were consulted only when `getKeybindingContext(event.target) === 'app'`. The reporter measured it: the same physical chord fires from app focus and does nothing with focus in `xterm-helper-textarea`. Combined with no palette contribution point, panels rejecting `commands.invoke`, and no OS-level `globalShortcut` anywhere in the tree, a plugin command is effectively unreachable for users who live in terminals — Orca's core workflow. (The reporter's TTS plugin's headline hotkey works sidebar-focused and does nothing where the user actually is.)

I kept the reporter's suggested shape (a boolean on the binding rather than a third `when` value) so `when: 'global' | 'worktree'` keeps meaning *scope*, and terminal-eligibility stays an independent axis.

**How**

- `pluginKeybindingContributionSchema` accepts `allowInTerminal: boolean` (optional).
- The flag travels the full chain: manifest → `plugin-command-registry` (`keybindingsForCommand` copies it) → host list projection → preload type → renderer.
- `findPluginCommandForKeybinding` grows `{ requireAllowInTerminal }`: in terminal context only bindings that opted in can match, and the match runs on the binding's own (already schema-normalized) key — per-binding consent cannot be inferred from a command-level override, which resolves to a flat string list.
- `use-global-keybindings.ts` consults plugin chords in terminal context with that restriction. No capture toast for plugin chords: the command visibly runs, so the terminal losing the chord is self-evident (built-in capture toasts exist for invisible actions).

**Testing**

- `plugin-content-pack-contributions.test.ts`: the documented contribution fixture now exercises `allowInTerminal`, plus a parse case for the flag. 15/15.
- `plugin-command-keybindings.test.ts`: app focus matches every binding (unchanged); terminal focus matches only the opted-in chord; a non-opted chord and a command with no opt-ins match nothing in terminal. 8/8.
- `plugin-panels.test.ts` unchanged; `pnpm run typecheck` clean.

Fixes #15642