### PR TITLE
fix(filesystem-auth): stop an overtaken rebuild writing stale authorized roots

### DIFF
--- a/src/main/ipc/filesystem-auth.test.ts
+++ b/src/main/ipc/filesystem-auth.test.ts
@@ -18,6 +18,7 @@ import {
 } from './filesystem-auth'
 import { isDescendantOrEqual, validateGitRelativeFilePath } from './filesystem-path-containment'
 import {
+  ensureAuthorizedRootsCache,
   invalidateAuthorizedRootsCache,
   rebuildAuthorizedRootsCache,
   resolveRegisteredWorktreePath
@@ -143,6 +144,71 @@ describe('filesystem auth worktree roots', () => {
     expect(maxActive).toBeLessThanOrEqual(8)
   })
 })
+
+
+  it('discards a rebuild that an invalidation overtook, so a just-created worktree is not denied (#15667)', async () => {
+    const firstListingRelease: { fn: (() => void) | null } = { fn: null }
+    const firstListing = new Promise<GitWorktreeInfo[]>((release) => {
+      firstListingRelease.fn = () =>
+        release([{ path: '/repos/app', head: 'a', branch: 'main', isBare: false, isMainWorktree: true }])
+    })
+    let listingCall = 0
+    vi.mocked(listRepoWorktrees).mockImplementation(async () => {
+      listingCall += 1
+      if (listingCall === 1) {
+        // Pre-mutation snapshot: the linked worktree does not exist yet.
+        return firstListing
+      }
+      // The post-invalidation listing knows the new worktree.
+      return Promise.resolve([
+        { path: '/repos/app', head: 'a', branch: 'main', isBare: false, isMainWorktree: true },
+        { path: '/repos/linked/new', head: 'a', branch: 'feature', isBare: false, isMainWorktree: false }
+      ])
+    })
+
+    const store = makeStore()
+    // A leaked rebuild from an earlier test can leave the cache clean; force
+    // dirty so this test's ensure deterministically starts the parked rebuild.
+    invalidateAuthorizedRootsCache()
+    const parkedEnsure = ensureAuthorizedRootsCache(store)
+    expect(listingCall).toBeGreaterThanOrEqual(1)
+    // The overtaking invalidation (what worktrees:create does) lands while parked.
+    invalidateAuthorizedRootsCache()
+    firstListingRelease.fn?.()
+
+    await parkedEnsure
+
+    // The overtaken rebuild was discarded and a fresh one committed its listing.
+    expect(listingCall).toBeGreaterThanOrEqual(2)
+    await expect(
+      resolveRegisteredWorktreePath('/repos/linked/new', store)
+    ).resolves.toBe(resolve('/repos/linked/new'))
+  })
+
+  it('does not re-authorize removed roots when an invalidation overtakes a rebuild (#15667)', async () => {
+    const firstListingRelease: { fn: (() => void) | null } = { fn: null }
+    const firstListing = new Promise<GitWorktreeInfo[]>((release) => {
+      firstListingRelease.fn = () =>
+        release([{ path: '/repos/app', head: 'a', branch: 'main', isBare: false, isMainWorktree: true }])
+    })
+    let listingCall = 0
+    vi.mocked(listRepoWorktrees).mockImplementation(async () => {
+      listingCall += 1
+      return listingCall === 1 ? firstListing : Promise.resolve([])
+    })
+
+    const store = makeStore()
+    const parkedEnsure = ensureAuthorizedRootsCache(store)
+    // The repo is forgotten while the rebuild is parked.
+    invalidateAuthorizedRootsCache()
+    firstListingRelease.fn?.()
+    await parkedEnsure
+
+    const emptyStore = makeStore([])
+    await expect(resolveRegisteredWorktreePath('/repos/app', emptyStore)).rejects.toThrow(
+      'Access denied'
+    )
+  })
 
 describe('filesystem-auth path containment', () => {
   it('authorizes missing nested descendants under an allowed repo', async () => {

--- a/src/main/ipc/registered-worktree-roots-cache.ts
+++ b/src/main/ipc/registered-worktree-roots-cache.ts
@@ -9,9 +9,16 @@ const registeredWorktreeRootsByRepo = new Map<string, Set<string>>()
 const registeredWorktreeRootRepoIds = new Set<string>()
 let registeredWorktreeRootsDirty = true
 let registeredWorktreeRootsRefresh: Promise<void> | null = null
+// Why (#15667): a rebuild parked on `git worktree list` can be overtaken by an
+// invalidation (worktree create/remove, repo forget, ~30 call sites). Without
+// a generation marker the stale rebuild then overwrites the fresher state,
+// marks the cache clean, and filesystem auth serves pre-mutation roots —
+// denying a just-created worktree or re-authorizing removed ones.
+let authorizedRootsInvalidationEpoch = 0
 const AUTHORIZED_ROOTS_REBUILD_CONCURRENCY = 8
 
 export function invalidateAuthorizedRootsCache(): void {
+  authorizedRootsInvalidationEpoch += 1
   registeredWorktreeRootsDirty = true
   // Why: dirty roots can't be trusted for auth short-circuits; fresh worktrees:list seeds safe per-repo roots before a full rebuild.
   registeredWorktreeRoots.clear()
@@ -22,6 +29,7 @@ export function invalidateAuthorizedRootsCache(): void {
 export async function rebuildAuthorizedRootsCache(store: Store): Promise<void> {
   // Why: bounded parallelism keeps the Windows speedup without one git process per repo.
   // Why no realpath here: canonicalizing every root on invalidation would trigger macOS TCC prompts; handlers still canonicalize the target before any operation.
+  const epochAtRebuildStart = authorizedRootsInvalidationEpoch
   const repos = getLocalRepos(store)
   const perProjectResults = await mapWithConcurrency(
     repos,
@@ -42,6 +50,14 @@ export async function rebuildAuthorizedRootsCache(store: Store): Promise<void> {
     }
   )
 
+  if (authorizedRootsInvalidationEpoch !== epochAtRebuildStart) {
+    // Why (#15667): an invalidation landed while this rebuild was parked on git.
+    // Its snapshot predates the mutation, so committing it would clobber the
+    // invalidation (and any fresher per-repo seed) and falsely mark the cache
+    // clean. Discard, stay dirty, and let the next ensure rebuild fresh state.
+    registeredWorktreeRootsDirty = true
+    return
+  }
   registeredWorktreeRoots.clear()
   registeredWorktreeRootsByRepo.clear()
   registeredWorktreeRootRepoIds.clear()
@@ -103,15 +119,17 @@ export function registerWorktreeRootsForRepo(
 }
 
 export async function ensureAuthorizedRootsCache(store: Store): Promise<void> {
-  if (!registeredWorktreeRootsDirty) {
-    return
+  // Why (#15667): loop, not join-once — an in-flight rebuild that started
+  // before this caller's invalidation will discard itself on completion, and
+  // the caller must then start a fresh rebuild rather than trust the stale one.
+  while (registeredWorktreeRootsDirty) {
+    if (!registeredWorktreeRootsRefresh) {
+      registeredWorktreeRootsRefresh = rebuildAuthorizedRootsCache(store).finally(() => {
+        registeredWorktreeRootsRefresh = null
+      })
+    }
+    await registeredWorktreeRootsRefresh
   }
-  if (!registeredWorktreeRootsRefresh) {
-    registeredWorktreeRootsRefresh = rebuildAuthorizedRootsCache(store).finally(() => {
-      registeredWorktreeRootsRefresh = null
-    })
-  }
-  await registeredWorktreeRootsRefresh
 }
 
 /**


### PR DESCRIPTION
## Summary

**What**

The filesystem-auth authorized-roots cache now carries an invalidation epoch. A rebuild captures the epoch before snapshotting and **discards itself** (no writes, dirty stays set) when an invalidation overtook it; `ensureAuthorizedRootsCache` **loops** instead of joining-once, so a caller whose invalidation arrived mid-rebuild starts a fresh rebuild rather than trusting the discarded result.

**Why**

#15667 — `rebuildAuthorizedRootsCache` snapshots repos, parks on `git worktree list` per repo (widest window on Windows), then unconditionally overwrites the root sets and clears the dirty flag. `invalidateAuthorizedRootsCache()` (~30 call sites: worktree create/remove, repo add/forget, git upgrade) can land while the rebuild is parked, and the rebuild then commits its **pre-mutation** snapshot over the invalidation:

- a just-created worktree is missing from the now-"clean" cache, so every `filesystem:*` IPC for it throws `Access denied: unknown repository or worktree path` until some later unrelated invalidation;
- after a repo/worktree removal, the stale write **re-authorizes** the removed roots — the direction `worktrees-forget-local.test.ts` pins against;
- the `registerWorktreeRootsForRepo` seed from `worktrees:list` is clobbered the same way.

**Testing** (`filesystem-auth.test.ts`, using the file's established mocked-`listRepoWorktrees` pattern — 16 passed, 1 pre-existing skip):

- New: the reporter's deterministic repro — rebuild parked on a pre-mutation listing, invalidation lands (what `worktrees:create` does), listing released stale → the just-created `/repos/linked/new` resolves instead of being denied, and a second listing ran. **Verified to fail on the pre-fix code** (denies with Access denied).
- New: a removal-invalidated rebuild does not re-authorize the removed repo's root against an empty store.
- The discard path makes correctness independent of which interleaving won, which is why the second test pins clean-state behaviour even where the old code's failure depended on timing.

`pnpm run typecheck` clean.

Fixes #15667