### PR TITLE
fix: match permission title keywords on word boundaries

### DIFF
--- a/src/shared/agent-title-core.ts
+++ b/src/shared/agent-title-core.ts
@@ -42,6 +42,20 @@ export const STRONG_WORKING_KEYWORDS_RE = new RegExp(
 
 export const STRONG_WORKING_KEYWORDS_RE_GLOBAL = new RegExp(STRONG_WORKING_KEYWORDS_RE.source, 'gi')
 
+const STRONG_PERMISSION_KEYWORDS = [
+  'action required',
+  'permissions',
+  'permission',
+  'waiting'
+] as const
+
+// Why: same boundary as the idle matcher — a bare substring read `~/repo/permissions`
+// and `awaiting-review` as a permission prompt, outranking the title's own status word.
+export const STRONG_PERMISSION_KEYWORDS_RE = new RegExp(
+  `(?<![\\w./\\\\-])(${STRONG_PERMISSION_KEYWORDS.join('|')})(?![\\w\\-])`,
+  'i'
+)
+
 export const CURSOR_NATIVE_TITLE_LOWER = 'cursor agent'
 
 // eslint-disable-next-line no-control-regex -- intentional unicode range

--- a/src/shared/agent-title-core.ts
+++ b/src/shared/agent-title-core.ts
@@ -49,10 +49,12 @@ const STRONG_PERMISSION_KEYWORDS = [
   'waiting'
 ] as const
 
-// Why: same boundary as the idle matcher — a bare substring read `~/repo/permissions`
-// and `awaiting-review` as a permission prompt, outranking the title's own status word.
+// Why: a bare substring read `~/repo/permissions` and `awaiting-review` as a permission
+// prompt, outranking the title's own status word. The right side also blocks path
+// separators, which the idle matcher does not need: `permissions/` is a common directory
+// name, so the keyword shows up at the *start* of a path segment too, not only its end.
 export const STRONG_PERMISSION_KEYWORDS_RE = new RegExp(
-  `(?<![\\w./\\\\-])(${STRONG_PERMISSION_KEYWORDS.join('|')})(?![\\w\\-])`,
+  `(?<![\\w./\\\\-])(${STRONG_PERMISSION_KEYWORDS.join('|')})(?![\\w/\\\\-])`,
   'i'
 )
 

--- a/src/shared/agent-title-owner.ts
+++ b/src/shared/agent-title-owner.ts
@@ -5,6 +5,7 @@ import {
   SYNTHETIC_AGENT_TITLE_PROFILES,
   type SyntheticAgentTitleProfile
 } from './synthetic-agent-title'
+import { STRONG_PERMISSION_KEYWORDS_RE } from './agent-title-core'
 import { isLegacyPiCompatibleTitle } from './pi-compatible-synthetic-title'
 import { getWrapperTitleSegments } from './terminal-title-wrapper-segments'
 
@@ -88,9 +89,7 @@ function hasPermissionSuffix(title: string, sourceProfile: SyntheticAgentTitlePr
   const normalizedTitle = title.trim().toLowerCase()
   return (
     normalizedTitle === sourceProfile.permissionLabel.toLowerCase() ||
-    normalizedTitle.includes('action required') ||
-    normalizedTitle.includes('permission') ||
-    normalizedTitle.includes('waiting')
+    STRONG_PERMISSION_KEYWORDS_RE.test(title)
   )
 }
 

--- a/src/shared/agent-title-status.test.ts
+++ b/src/shared/agent-title-status.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { detectAgentStatusFromTitle } from './agent-title-status'
+
+// Why: the idle/working matchers are boundary-aware precisely because a title
+// carries the cwd; the permission check next to them was a bare substring.
+describe('detectAgentStatusFromTitle permission matching', () => {
+  it('does not read a permission-shaped path segment as a permission prompt', () => {
+    expect(detectAgentStatusFromTitle('Claude ready — ~/repo/permissions')).toBe('idle')
+    expect(detectAgentStatusFromTitle('Claude done — ~/work/permissions-audit')).toBe('idle')
+    expect(detectAgentStatusFromTitle('Claude working — /home/u/awaiting-review')).toBe('working')
+    expect(detectAgentStatusFromTitle('Claude working — C:\\src\\permissions')).toBe('working')
+  })
+
+  it('still reads a real permission prompt', () => {
+    expect(detectAgentStatusFromTitle('Claude - action required')).toBe('permission')
+    expect(detectAgentStatusFromTitle('Claude — permission needed')).toBe('permission')
+    expect(detectAgentStatusFromTitle('Claude — 2 permissions pending')).toBe('permission')
+    expect(detectAgentStatusFromTitle('Claude — waiting for input')).toBe('permission')
+  })
+
+  it('leaves the boundary-aware idle and working matchers alone', () => {
+    expect(detectAgentStatusFromTitle('Claude ready — ~/src/auth')).toBe('idle')
+    expect(detectAgentStatusFromTitle('Claude — reworking the parser')).toBe('idle')
+  })
+})

--- a/src/shared/agent-title-status.test.ts
+++ b/src/shared/agent-title-status.test.ts
@@ -9,6 +9,10 @@ describe('detectAgentStatusFromTitle permission matching', () => {
     expect(detectAgentStatusFromTitle('Claude done — ~/work/permissions-audit')).toBe('idle')
     expect(detectAgentStatusFromTitle('Claude working — /home/u/awaiting-review')).toBe('working')
     expect(detectAgentStatusFromTitle('Claude working — C:\\src\\permissions')).toBe('working')
+    // Why both ends: `permissions/` is a common directory name, so the keyword
+    // lands at the start of a path segment too, not only at its end.
+    expect(detectAgentStatusFromTitle('Claude ready — permissions/foo')).toBe('idle')
+    expect(detectAgentStatusFromTitle('Claude ready — permissions\\foo')).toBe('idle')
   })
 
   it('still reads a real permission prompt', () => {

--- a/src/shared/agent-title-status.ts
+++ b/src/shared/agent-title-status.ts
@@ -11,11 +11,11 @@ import {
   HERMES_AGENT_NAME_RE,
   QUARTER_CIRCLE_SPINNER_RE,
   STRONG_IDLE_KEYWORDS_RE,
+  STRONG_PERMISSION_KEYWORDS_RE,
   STRONG_WORKING_KEYWORDS_RE,
   STRONG_WORKING_KEYWORDS_RE_GLOBAL,
   containsAgentName,
   containsAgentSpinnerGlyph,
-  containsAny,
   containsQuarterCircleSpinner,
   containsLegacyAgentName,
   isClaudeManagementTitle,
@@ -199,7 +199,7 @@ export function detectAgentStatusFromTitle(title: string): AgentStatus | null {
   if (!hasLegacyAgentName && !hasDroidAgentName && !hasHermesAgentName && !hasAgyAgentName) {
     return null
   }
-  if (containsAny(title, ['action required', 'permission', 'waiting'])) {
+  if (STRONG_PERMISSION_KEYWORDS_RE.test(title)) {
     return 'permission'
   }
   // Why: boundary-aware regexes avoid cwd/path and substring false positives.


### PR DESCRIPTION
## ELI5

If your project folder is called `permissions`, your agent showed up as "waiting for permission" the whole time it was working. Nothing in the pane was asking for anything — the word just happened to be in the path.

## What Changed

`detectAgentStatusFromTitle` matched `'action required'`, `'permission'` and `'waiting'` with `lower.includes(word)`. Replaced with `STRONG_PERMISSION_KEYWORDS_RE`, a new export next to the two matchers it mirrors, using the identical boundary:

```
(?<![\w./\\-])(action required|permissions|permission|waiting)(?![\w\-])
```

`hasPermissionSuffix` in `agent-title-owner.ts` had the same three `includes` calls as its fallback; it now uses the same regex, so the root cause is fixed once rather than at each caller.

`permissions` is in the keyword list so a real "2 permissions pending" still matches while `~/repo/permissions` does not.

## Why

Three lines below the substring check, the idle and working matchers already use a boundary-aware regex, and their comment names this exact hazard:

> `// Why: plain \b matches inside hyphenated tokens and cwd paths such as "~/codex/ready"; the left side also blocks path separators for Windows/Unix.`

A terminal title carries the cwd, so within one function the same kind of keyword match was boundary-aware for idle/working and a bare substring for permission. And because the permission branch runs **first**, it outranked the title's own status word.

Measured against the current matcher:

| Title | Want | Got |
|---|---|---|
| `Claude ready — ~/repo/permissions` | idle | **permission** |
| `Claude done — ~/work/permissions-audit` | idle | **permission** |
| `Claude working — /home/u/awaiting-review` | working | **permission** |
| `Claude ready — ~/src/auth` *(control)* | idle | idle |

The control line isolates the path segment as the cause. The user-visible effect is a pane that reads as needing authorization while the agent is working — a false positive on the attention state, which erodes trust in the signal that a pane genuinely needs input.

## Linked Issue

Fixes #15728

## Visual Proof

N/A — no layout or interaction change. The observable difference is which status a title resolves to, shown as a table above and asserted in the new tests.

## Testing

- [x] I manually tested these changes locally — drove `detectAgentStatusFromTitle` over the affected and control titles; not exercised through the sidebar UI
- [x] Automated tests added/updated, or explained why not below

`agent-title-status.ts` had **no test file** — which is likely why this went unnoticed. This adds one covering three groups: permission-shaped path segments (POSIX and Windows), real permission prompts that must keep matching, and the boundary-aware idle/working matchers left alone (`reworking` must not read as working).

| Check | Result |
|---|---|
| Every suite referencing the title modules (49 files) | **1819 passed**, 1 skipped |
| `pnpm run typecheck` (node + cli + web) | exit 0 |
| oxlint / oxfmt | clean |

Red→green: the path-segment assertions were written first and observed returning `permission`; the other two groups passed before and after, which is what pins that this narrows the match rather than changing it.

Not run locally: `pnpm build` and the full Vitest suite.

## AI Disclosure

Claude Opus 5 (via Claude Code) investigated, implemented, and verified this change.

## Review

- **Security:** none — status classification only.
- **Cross-platform:** the boundary blocks both `/` and `\`, so a Windows cwd (`C:\src\permissions`) is covered; asserted in the tests.
- **Remote SSH:** titles from remote panes go through the same shared matcher.
- **Mobile:** same shared module.
- **Backwards compatibility:** this narrows a match. A title that legitimately reads as a permission prompt keeps matching (covered); only path-embedded and hyphen-joined occurrences stop.
- **Performance:** one regex test replaces three `includes` scans.

## Agent skill upstream boundary

- [x] Not applicable

## Notes

The keyword list keeps `permissions` before `permission` so the alternation prefers the longer form; with the trailing `(?![\w\-])` guard either order resolves the same way, but the explicit order makes that independent of regex-engine behaviour.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass — typecheck, oxlint and the affected suites pass locally; full `pnpm test` and `pnpm build` not run, see Testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)