### PR TITLE
fix(runtime): keepalive slow non-long-poll dispatches past the idle reaper

### DIFF
--- a/src/main/runtime/runtime-rpc-long-poll-transport.test.ts
+++ b/src/main/runtime/runtime-rpc-long-poll-transport.test.ts
@@ -667,6 +667,49 @@ describe('OrcaRuntimeRpcServer', () => {
       }
     })
 
+
+  it('starts keepalive for a slow non-long-poll dispatch instead of letting the idle reaper drop it (#15663)', async () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
+    const runtime = new OrcaRuntimeService()
+    const server = new OrcaRuntimeRpcServer({
+      runtime,
+      userDataPath,
+      keepaliveIntervalMs: 20,
+      slowDispatchKeepaliveDelayMs: 10
+    })
+    await server.start()
+
+    // A "short" RPC that stays silent well past the lazy threshold — the shape
+    // of a forced worktree.rm killing PTYs and running git over a large tree.
+    const originalDispatch = server['dispatcher'].dispatch.bind(server['dispatcher'])
+    server['dispatcher'].dispatch = vi.fn().mockImplementation(
+      (request: { id: string }) =>
+        new Promise((resolve) => setTimeout(() => resolve({ id: request.id, ok: true }), 120))
+    )
+
+    try {
+      const metadata = readRuntimeMetadata(userDataPath)
+      const session = openFramedSession(metadata!.transports[0]!.endpoint, {
+        id: 'req_slow',
+        authToken: metadata!.authToken,
+        method: 'status.get'
+      })
+      await session.done
+
+      const keepalives = session.frames.filter((f) => f._keepalive === true)
+      const terminals = session.frames.filter((f) => f.ok !== undefined)
+      expect(terminals).toHaveLength(1)
+      expect(terminals[0]).toMatchObject({ id: 'req_slow', ok: true })
+      // Why: 120ms dispatch, keepalive armed at 10ms, frames every 20ms →
+      // several frames must have kept the connection alive; assert ≥2 to
+      // tolerate scheduler jitter.
+      expect(keepalives.length).toBeGreaterThanOrEqual(2)
+    } finally {
+      server['dispatcher'].dispatch = originalDispatch
+      await server.stop()
+    }
+  })
+
     it('returns an internal_error envelope when the dispatcher throws', async () => {
       // Why: handlers are designed to return error envelopes, never to throw,
       // but a bug somewhere in the RPC stack (e.g. JSON.stringify choking on

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -76,6 +76,8 @@ type OrcaRuntimeRpcServerOptions = {
   webClientRoot?: string
   // Why: test-only overrides for the two constants below; production must not pass these (defaults set by §3.1).
   keepaliveIntervalMs?: number
+  /** How long a non-long-poll dispatch may stay silent before keepalive frames start (#15663). */
+  slowDispatchKeepaliveDelayMs?: number
   longPollCap?: number
   // Why: test-only override for the ownership reclaim cadence.
   metadataOwnershipPollMs?: number
@@ -149,6 +151,12 @@ export type MobilePairingConnectionContext = Readonly<{
 
 // Why: keepalive frames count as socket activity, resetting both idle timers so long-polls outlive the 30s/60s idle caps. See §3.1.
 const KEEPALIVE_INTERVAL_MS = 10_000
+// Why (#15663): the transport idle-reaper closes a silent connection after 30s,
+// and "short" RPCs are not all short — a forced worktree.rm (PTY kills plus
+// `git worktree remove` over a large tree) can run far past that while writing
+// zero bytes. Well under the 30s deadline, a still-pending dispatch starts
+// writing keepalive frames; fast dispatches clear the one-shot timer first.
+const SLOW_DISPATCH_KEEPALIVE_DELAY_MS = 10_000
 
 // Why: cap long-polls at half the 32-slot connection budget so they can't starve short RPCs; overflow → runtime_busy. See §7 risk #2.
 const LONG_POLL_CAP = 16
@@ -498,6 +506,7 @@ export class OrcaRuntimeRpcServer {
   private stopping = false
   private readonly authToken = randomBytes(24).toString('hex')
   private readonly keepaliveIntervalMs: number
+  private readonly slowDispatchKeepaliveDelayMs: number
   private readonly longPollCap: number
   private readonly metadataOwnershipPollMs: number
   private readonly askLongPollCap: number
@@ -548,6 +557,7 @@ export class OrcaRuntimeRpcServer {
     exposeNetworkByDefault = false,
     webClientRoot,
     keepaliveIntervalMs = KEEPALIVE_INTERVAL_MS,
+    slowDispatchKeepaliveDelayMs = SLOW_DISPATCH_KEEPALIVE_DELAY_MS,
     longPollCap = LONG_POLL_CAP,
     metadataOwnershipPollMs = RUNTIME_METADATA_OWNERSHIP_POLL_MS
   }: OrcaRuntimeRpcServerOptions) {
@@ -562,6 +572,7 @@ export class OrcaRuntimeRpcServer {
     this.exposeNetworkByDefault = exposeNetworkByDefault
     this.webClientRoot = webClientRoot
     this.keepaliveIntervalMs = keepaliveIntervalMs
+    this.slowDispatchKeepaliveDelayMs = slowDispatchKeepaliveDelayMs
     this.longPollCap = longPollCap
     this.metadataOwnershipPollMs = metadataOwnershipPollMs
     // Why: derived, not configurable — the reservation must hold for whatever cap a caller picks.
@@ -1540,8 +1551,26 @@ export class OrcaRuntimeRpcServer {
       return this.buildError(request.id, 'runtime_busy', rejection)
     }
     if (longPoll) {
-      // Why: arm keepalive only for long-polls; short RPCs never create the setInterval. See §3.1.
+      // Why: arm keepalive immediately for long-polls. See §3.1.
       context?.startKeepalive()
+    } else if (context) {
+      // Why (#15663): a non-long-poll dispatch can still outlive the transport's
+      // 30s idle reaper while writing zero bytes (forced worktree removal over a
+      // large tree). Arm keepalive lazily: fast dispatches pay one cleared
+      // setTimeout, and any dispatch still silent near the idle deadline starts
+      // writing frames instead of losing its connection.
+      const lazyKeepalive = setTimeout(() => {
+        context.startKeepalive()
+      }, this.slowDispatchKeepaliveDelayMs)
+      lazyKeepalive.unref?.()
+      try {
+        return await this.dispatcher.dispatch(request, {
+          signal: longPoll ? context?.signal : undefined
+        })
+      } finally {
+        clearTimeout(lazyKeepalive)
+        this.releaseLongPoll(longPoll)
+      }
     }
 
     try {


### PR DESCRIPTION
## Summary

**What**

Non-long-poll RPC dispatches now arm transport keepalive **lazily**: a single `setTimeout` (cleared on reply) that starts the keepalive interval if the dispatch is still silent after 10 seconds — well under the transport's 30s idle deadline.

**Why**

#15663 — batch `orca worktree rm` dies after 0–1 successes with `runtime_unavailable` / "The Orca runtime closed the connection before responding", with the app open and `status --json` reporting ready. As diagnosed in the issue (and by @2sumtech's dig): the unix-socket transport idle-reaps a connection after 30s of no I/O, and keepalive framing was armed only for long-poll methods — the code comment explicitly assumed "short RPCs never create the setInterval". A forced worktree.rm is the counterexample: killing the workspace's PTYs plus `git worktree remove` over a node_modules-heavy tree can run far past 30s while writing **zero bytes**, so the runtime dropped the busy socket, and every subsequent CLI call failed until restart.

The lazy arm rescues *any* slow handler rather than enumerating methods, and keeps the property the existing invariant test pins — fast dispatches still produce zero keepalive frames and zero intervals.

**Testing** (`runtime-rpc-long-poll-transport.test.ts`, 13/13):

- New: a mocked slow non-long-poll dispatch (silent 120ms, keepalive armed at a 10ms lazy threshold, 20ms frames) still gets its terminal reply **and** produced ≥2 keepalive frames — verified to fail on the pre-fix code (no frames).
- The existing "keepalive is long-poll-only for fast RPCs" invariant test (10ms interval, real `status.get`) still passes untouched — fast dispatches never trip the 10s default threshold.
- `pnpm run typecheck` clean.

Fixes #15663