### PR TITLE
fix(skills): discover Hermes-native skills from ~/.hermes/skills

### DIFF
--- a/src/main/skills/discovery.test.ts
+++ b/src/main/skills/discovery.test.ts
@@ -295,6 +295,27 @@ describe('skill discovery', () => {
     )
   })
 
+
+  it('discovers a Hermes-native skill from ~/.hermes/skills (#15628)', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skills-'))
+    const home = join(root, 'home')
+    const hermesSkills = join(home, '.hermes', 'skills')
+    await mkdir(join(hermesSkills, 'research'), { recursive: true })
+    await writeFile(join(hermesSkills, 'research', 'SKILL.md'), '# research')
+
+    const result = await discoverSkills({ homeDir: home, repos: [], includeCwd: false })
+
+    const skill = result.skills.find((entry) => entry.name === 'research')
+    expect(skill).toMatchObject({
+      name: 'research',
+      providers: ['agent-skills']
+    })
+    expect(result.sources.find((source) => source.id === 'home-hermes')).toMatchObject({
+      owner: 'hermes',
+      exists: true
+    })
+  })
+
   it('keys every deduped root to an owning source so per-agent coverage resolves', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-skills-'))
     const home = join(root, 'home')
@@ -364,6 +385,7 @@ describe('skill discovery', () => {
     expect(rootPaths).toEqual(
       expect.arrayContaining([
         '/home/test/.grok/skills',
+        '/home/test/.hermes/skills',
         '/home/test/.config/opencode/skills',
         '/home/test/.pi/agent/skills',
         '/home/test/.omp/agent/skills',

--- a/src/main/skills/skill-discovery-sources.ts
+++ b/src/main/skills/skill-discovery-sources.ts
@@ -145,6 +145,14 @@ export function buildSkillDiscoverySources(
       'omp'
     ),
     source(
+      'home-hermes',
+      'Hermes home',
+      pathApi.join(home, '.hermes', 'skills'),
+      'home',
+      ['agent-skills'],
+      'hermes'
+    ),
+    source(
       'home-prime-agent',
       'Prime Agent home',
       pathApi.join(home, '.prime', 'agent', 'skills'),


### PR DESCRIPTION
## Summary

**What**

`buildSkillDiscoverySources` gains a Hermes home source: `~/.hermes/skills`, owner `hermes`, generic `agent-skills` provider classification — the same shape as every other provider home, through the existing path adapter (so macOS/Linux/Windows/WSL and remote-host scanning all follow).

**Why**

#15628 — Orca maps Hermes to the `hermes-agent` target for skill installation, but never scanned Hermes's native Skill root, which Hermes documents as its source of truth (`https://hermes-agent.nousresearch.com/docs/guides/work-with-skills`). Skills installed directly through Hermes were invisible to Orca's Skills page, discovery, and sharing surfaces.

Scope is exactly the issue's proposed scope: no UI, protocol, or installer change — the `hermes` owner already exists in `AgentType`/`TUI_AGENT_CONFIG` (the "every source owner names a real agent id" invariant test covers it), and the discovery-side provider stays the generic `agent-skills`.

**Testing** (`discovery.test.ts`, 24/24 with the WSL-plugins suite):

- New filesystem case: a `SKILL.md` under `~/.hermes/skills/research/` is discovered with `agent-skills` providers, and the `home-hermes` source reports `owner: hermes, exists: true`. Verified pre-fix: both new assertions fail without the source entry.
- The provider-roots assertion (`npx skills --global` coverage list) now includes `/home/test/.hermes/skills`.

Fixes #15628