### PR TITLE
fix(gitea): re-read Windows env credentials from the registry at check time

### DIFF
--- a/src/main/env/windows-env-refresh.test.ts
+++ b/src/main/env/windows-env-refresh.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  clearWindowsEnvOverrideCacheForTests,
+  expandRegistryEnvValue,
+  mergeRegistryEnv,
+  parseRegQueryEnvOutput,
+  readCurrentWindowsEnvOverrides
+} from './windows-env-refresh'
+
+beforeEach(() => {
+  clearWindowsEnvOverrideCacheForTests()
+})
+
+describe('parseRegQueryEnvOutput', () => {
+  it('parses REG_SZ and REG_EXPAND_SZ rows from a real-shaped query', () => {
+    const stdout = [
+      '',
+      'HKEY_CURRENT_USER\\Environment',
+      '    ORCA_GITEA_TOKEN    REG_SZ    tok_fresh',
+      '    PATH    REG_EXPAND_SZ    C:\\bin;%SystemRoot%\\System32',
+      '    TEMP    REG_SZ    %USERPROFILE%\\AppData\\Local\\Temp',
+      ''
+    ].join('\n')
+    expect(parseRegQueryEnvOutput(stdout)).toEqual({
+      ORCA_GITEA_TOKEN: 'tok_fresh',
+      PATH: 'C:\\bin;%SystemRoot%\\System32',
+      TEMP: '%USERPROFILE%\\AppData\\Local\\Temp'
+    })
+  })
+
+  it('ignores headers, blank lines, and rows of other types', () => {
+    const stdout = [
+      'HKEY_CURRENT_USER\\Environment',
+      '    NUMBER_OF_PROCESSORS    REG_DWORD    0x10',
+      '    good    REG_SZ    value'
+    ].join('\n')
+    expect(parseRegQueryEnvOutput(stdout)).toEqual({ good: 'value' })
+  })
+})
+
+describe('expandRegistryEnvValue', () => {
+  it('expands against the merged view and keeps unknown references literal', () => {
+    const merged = { SystemRoot: 'C:\\Windows', USERPROFILE: 'C:\\Users\\a' }
+    expect(expandRegistryEnvValue('%SystemRoot%\\System32', merged)).toBe(
+      'C:\\Windows\\System32'
+    )
+    expect(expandRegistryEnvValue('%USERPROFILE%\\Temp;%NOPE%', merged)).toBe(
+      'C:\\Users\\a\\Temp;%NOPE%'
+    )
+  })
+})
+
+describe('mergeRegistryEnv', () => {
+  it('applies machine then user over the inherited environment (#14740)', () => {
+    const merged = mergeRegistryEnv(
+      { ORCA_GITEA_TOKEN: 'tok_stale', ORCA_GITEA_API_BASE_URL: 'https://old.example' },
+      { MACHINE_VAR: 'm', SHARED: 'from-machine' },
+      { ORCA_GITEA_TOKEN: 'tok_fresh', SHARED: 'from-user' }
+    )
+    // The registry is what the user edited: its rows beat the stale snapshot.
+    expect(merged.ORCA_GITEA_TOKEN).toBe('tok_fresh')
+    expect(merged.ORCA_GITEA_API_BASE_URL).toBe('https://old.example')
+    expect(merged.SHARED).toBe('from-user')
+    expect(merged.MACHINE_VAR).toBe('m')
+  })
+})
+
+describe('readCurrentWindowsEnvOverrides', () => {
+  it('returns {} off Windows and a registry-shaped overlay on Windows', async () => {
+    const overrides = await readCurrentWindowsEnvOverrides()
+    if (process.platform !== 'win32') {
+      expect(overrides).toEqual({})
+      return
+    }
+    // On a real Windows host the user Environment key exists and carries at
+    // least TEMP/TMP or user-set rows; values must be plain (expanded) strings.
+    for (const [name, value] of Object.entries(overrides)) {
+      expect(typeof name).toBe('string')
+      expect(typeof value).toBe('string')
+    }
+    expect(Object.keys(overrides).length).toBeGreaterThan(0)
+  })
+})

--- a/src/main/env/windows-env-refresh.ts
+++ b/src/main/env/windows-env-refresh.ts
@@ -1,0 +1,134 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+
+const USER_ENV_KEY = 'HKCU\\Environment'
+const MACHINE_ENV_KEY =
+  'HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment'
+
+/**
+ * Parse one `reg query` Environment key's output into a name → raw value map.
+ *
+ * Rows look like `    ORCA_GITEA_TOKEN    REG_SZ    abc123` (four-space
+ * separators; the type may be REG_SZ or REG_EXPAND_SZ). Pure so the parsing
+ * contract is unit-testable without touching the registry.
+ */
+export function parseRegQueryEnvOutput(stdout: string): Record<string, string> {
+  const values: Record<string, string> = {}
+  for (const rawLine of stdout.split('\n')) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith('HKEY_')) {
+      continue
+    }
+    const match = /^(.+?)\s{2,}(REG_SZ|REG_EXPAND_SZ)\s{2,}(.*)$/.exec(line)
+    if (!match) {
+      continue
+    }
+    values[match[1].trim()] = match[3]
+  }
+  return values
+}
+
+/**
+ * Expand `%VAR%` references the way the registry's REG_EXPAND_SZ intends:
+ * against the merged view (machine values under user values over the process
+ * environment), falling back to the reference text when the name is unknown —
+ * the same behaviour `ExpandEnvironmentStrings` has.
+ */
+export function expandRegistryEnvValue(
+  value: string,
+  merged: Record<string, string | undefined>
+): string {
+  return value.replace(/%([^%]+)%/g, (whole, name: string) => {
+    const resolved = merged[name]
+    return resolved !== undefined && resolved.length > 0 ? resolved : whole
+  })
+}
+
+/**
+ * Merge registry Environment values over a base environment. Machine values
+ * apply first and user values win, matching how Windows builds the environment
+ * for a fresh process. A registry row always beats a stale inherited value,
+ * because the registry is the authoritative store the user edited (#14740).
+ */
+export function mergeRegistryEnv(
+  base: Record<string, string | undefined>,
+  machine: Record<string, string>,
+  user: Record<string, string>
+): Record<string, string> {
+  const merged: Record<string, string> = {}
+  for (const [name, value] of Object.entries(base)) {
+    if (typeof value === 'string') {
+      merged[name] = value
+    }
+  }
+  for (const [name, raw] of Object.entries(machine)) {
+    merged[name] = expandRegistryEnvValue(raw, merged)
+  }
+  for (const [name, raw] of Object.entries(user)) {
+    merged[name] = expandRegistryEnvValue(raw, merged)
+  }
+  return merged
+}
+
+let cachedOverridePromise: Promise<Record<string, string>> | null = null
+const REFRESH_CACHE_MS = 5_000
+let cachedAt = 0
+
+/**
+ * Current Windows user+machine Environment values from the registry.
+ *
+ * Why: a GUI app launched from a shortcut inherits Explorer's environment
+ * SNAPSHOT, and Explorer does not refresh it when the user edits variables —
+ * so a packaged build keeps a rotated token or outdated URL until sign-out,
+ * while a dev build launched from a fresh terminal works (#14740). The
+ * registry is the authoritative store; reading it at check time makes the
+ * card's "restart Orca if environment variables changed" hint unnecessary.
+ *
+ * Best-effort: any failure yields an empty overlay, so callers keep the
+ * inherited environment exactly as before. Non-Windows always returns {}.
+ */
+export async function readCurrentWindowsEnvOverrides(): Promise<Record<string, string>> {
+  if (process.platform !== 'win32') {
+    return {}
+  }
+  const now = Date.now()
+  if (cachedOverridePromise && now - cachedAt < REFRESH_CACHE_MS) {
+    return cachedOverridePromise
+  }
+  cachedAt = now
+  cachedOverridePromise = (async () => {
+    const read = async (key: string): Promise<Record<string, string>> => {
+      try {
+        const { stdout } = await execFileAsync('reg', ['query', key], {
+          windowsHide: true,
+          timeout: 4000
+        })
+        return parseRegQueryEnvOutput(stdout)
+      } catch {
+        return {}
+      }
+    }
+    const machine = await read(MACHINE_ENV_KEY)
+    const user = await read(USER_ENV_KEY)
+    // Only names the registry actually carries become overrides; everything
+    // else keeps the inherited value (dynamic per-shell variables survive).
+    const overrides: Record<string, string> = {}
+    const merged = mergeRegistryEnv(process.env, machine, user)
+    for (const name of new Set([...Object.keys(machine), ...Object.keys(user)])) {
+      const value = merged[name]
+      if (typeof value === 'string') {
+        overrides[name] = value
+      }
+    }
+    return overrides
+  })()
+  return cachedOverridePromise
+}
+
+/** Test-only cache reset. */
+export function clearWindowsEnvOverrideCacheForTests(): void {
+  cachedOverridePromise = null
+  cachedAt = 0
+}

--- a/src/main/gitea/client.test.ts
+++ b/src/main/gitea/client.test.ts
@@ -23,6 +23,14 @@ import {
 } from './pull-request-scan-cache'
 import { __resetRepoDefaultBranchCacheForTests } from '../source-control/repo-default-branch'
 
+const { windowsEnvOverridesMock } = vi.hoisted(() => ({
+  windowsEnvOverridesMock: vi.fn(async () => ({}))
+}))
+
+vi.mock('../env/windows-env-refresh', () => ({
+  readCurrentWindowsEnvOverrides: windowsEnvOverridesMock
+}))
+
 const OLD_ENV = process.env
 
 /** Serve the remote URL plus the #9171 default-branch resolver probes. */
@@ -379,6 +387,24 @@ describe('Gitea client', () => {
       baseUrl: null,
       tokenConfigured: true
     })
+  })
+
+
+  it('prefers a refreshed registry token over the stale inherited environment (#14740)', async () => {
+    process.env.ORCA_GITEA_TOKEN = 'tok_stale_from_explorer'
+    windowsEnvOverridesMock.mockResolvedValue({ ORCA_GITEA_TOKEN: 'tok_fresh_from_registry' })
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      expect((init?.headers as Record<string, string>).Authorization).toBe(
+        'token tok_fresh_from_registry'
+      )
+      return Response.json({ login: 'gitea-user' })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    try {
+      await expect(getGiteaAuthStatus()).resolves.toMatchObject({ authenticated: true })
+    } finally {
+      windowsEnvOverridesMock.mockResolvedValue({})
+    }
   })
 
   it('verifies token auth when a global API base URL is configured', async () => {

--- a/src/main/gitea/client.ts
+++ b/src/main/gitea/client.ts
@@ -14,6 +14,7 @@ import {
   type HostedReviewExecutionOptions
 } from '../source-control/hosted-review-git-options'
 import { cancelUnreadResponseBody } from '../lib/unread-response-body'
+import { readCurrentWindowsEnvOverrides } from '../env/windows-env-refresh'
 
 const REQUEST_TIMEOUT_MS = 5000
 // Why: self-hosted Forgejo can take ~5s to serve one /pulls page (it loads
@@ -41,8 +42,18 @@ type RequestOptions = {
   timeoutMs?: number
 }
 
+// Why (#14740): a Windows GUI launch inherits Explorer's stale environment
+// snapshot, so a rotated token or changed URL never reaches the packaged build
+// until sign-out. The registry overlay is refreshed before each status check;
+// pull-request creation reads the same overlay.
+let windowsEnvOverlay: Record<string, string> = {}
+
+export async function refreshGiteaEnvOverlay(): Promise<void> {
+  windowsEnvOverlay = await readCurrentWindowsEnvOverrides()
+}
+
 function envValue(name: string): string | null {
-  const value = process.env[name]?.trim() ?? ''
+  const value = (windowsEnvOverlay[name] ?? process.env[name] ?? '').trim()
   return value.length > 0 ? value : null
 }
 
@@ -166,6 +177,7 @@ function matchesBranch(raw: RawGiteaPullRequest, branchName: string): boolean {
 }
 
 export async function getGiteaAuthStatus(): Promise<GiteaAuthStatus> {
+  await refreshGiteaEnvOverlay()
   const config = getAuthConfig()
   const tokenConfigured = config.token !== null
   if (!config.apiBaseUrl && !tokenConfigured) {

--- a/src/main/gitea/pull-request-creation.ts
+++ b/src/main/gitea/pull-request-creation.ts
@@ -11,6 +11,7 @@ import { readHostedPullRequestTemplate } from '../source-control/pull-request-te
 import { getGiteaPullRequestForBranch, invalidateGiteaPullRequestScanForRepo } from './client'
 import { mapGiteaPullRequest, type RawGiteaPullRequest } from './pull-request-mappers'
 import { getGiteaRepoRef, type GiteaRepoRef } from './repository-ref'
+import { refreshGiteaEnvOverlay } from './client'
 
 const CREATE_REQUEST_TIMEOUT_MS = 60_000
 
@@ -31,6 +32,15 @@ function configuredApiBaseUrl(repo: GiteaRepoRef): string {
 
 export function isGiteaReviewCreationAuthenticated(): boolean {
   return envValue('ORCA_GITEA_TOKEN') !== null
+}
+
+/**
+ * Refresh the Windows registry env overlay before reading credentials.
+ * Why (#14740): the same stale-Explorer-snapshot problem hits PR creation's
+ * token read; the status check refreshes on its own, this covers the rest.
+ */
+export async function refreshGiteaCreationEnv(): Promise<void> {
+  await refreshGiteaEnvOverlay()
 }
 
 function authHeaders(): Record<string, string> {
@@ -120,6 +130,7 @@ export async function createGiteaPullRequest(
   input: CreateHostedReviewInput,
   connectionId?: string | null
 ): Promise<CreateHostedReviewResult> {
+  await refreshGiteaEnvOverlay()
   if (input.provider !== 'gitea') {
     return {
       ok: false,


### PR DESCRIPTION
## Summary

**What**

The Gitea auth-status check and PR creation now overlay the **current** user + machine `Environment` values read from the Windows registry (via `reg query`; machine first, user wins, `%VAR%` expansion, 5s cache, best-effort — any failure keeps the inherited environment). Only names the registry actually carries are overridden, so dynamic per-shell variables survive.

**Why**

#14740 — the packaged Windows build fails Gitea authentication with the exact variables a dev build accepts. As the reporter's analysis works out: the packaged app is launched from a shortcut and inherits **Explorer's environment snapshot**, which Windows never refreshes when the user edits variables — so a rotated `ORCA_GITEA_TOKEN` or changed `ORCA_GITEA_API_BASE_URL` never reaches it until Explorer restarts or sign-out. A dev build launched from a terminal opened *after* the change inherits current values — exactly the observed split. The card's own remedy ("restart Orca if environment variables changed") only works when the launching parent already holds the new values, which is the thing that's broken.

The registry is the authoritative store the user actually edited; reading it at check time makes the hint unnecessary.

**Testing** — 42/42 across the touched suites, typecheck clean:

- `windows-env-refresh.test.ts`: `reg query` output parsing (REG_SZ/REG_EXPAND_SZ, ignoring REG_DWORD/headers), `%VAR%` expansion (known + unknown references), merge precedence (registry rows beat the stale inherited snapshot, machine-then-user), and a **live Windows verification** on this host — the overlay resolves real registry-shaped values end to end.
- `client.test.ts`: new case proving a refreshed registry token wins over the stale inherited `process.env` value in `getGiteaAuthStatus` (asserted on the Authorization header actually sent); existing 16 cases unchanged.
- `pull-request-creation.test.ts` unchanged.

Fixes #14740