### PR TITLE
feat(tabs): make Move Tab to Split keybindable

### DIFF
--- a/src/renderer/src/app-shell/app-command-handlers.test.ts
+++ b/src/renderer/src/app-shell/app-command-handlers.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Tab } from '../../../shared/tab-types'
+import { useAppStore } from '../store'
+import {
+  createAppCommandHandlers,
+  type AppShortcutState,
+  type ShortcutDispatchInput
+} from './app-command-handlers'
+
+const WT = 'wt-1'
+
+vi.mock('@/lib/floating-workspace-terminal-actions', () => ({
+  isFloatingWorkspacePanelFocused: () => false
+}))
+
+describe('createAppCommandHandlers', () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState(), true)
+  })
+
+  it('does not claim a move-to-split chord when the store rejects the move', () => {
+    const dropUnifiedTab = vi.fn(() => false)
+    useAppStore.setState({
+      activeWorktreeId: WT,
+      activeGroupIdByWorktree: { [WT]: 'group-1' },
+      groupsByWorktree: {
+        [WT]: [
+          {
+            id: 'group-1',
+            worktreeId: WT,
+            activeTabId: 'tab-a',
+            tabOrder: ['tab-a', 'tab-b']
+          }
+        ]
+      },
+      unifiedTabsByWorktree: {
+        [WT]: [
+          {
+            id: 'tab-a',
+            groupId: 'group-1',
+            worktreeId: WT,
+            contentType: 'terminal',
+            entityId: 'term-a',
+            label: 'A',
+            customLabel: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 0
+          } satisfies Tab,
+          {
+            id: 'tab-b',
+            groupId: 'group-1',
+            worktreeId: WT,
+            contentType: 'terminal',
+            entityId: 'term-b',
+            label: 'B',
+            customLabel: null,
+            color: null,
+            sortOrder: 1,
+            createdAt: 1
+          } satisfies Tab
+        ]
+      },
+      dropUnifiedTab
+    })
+
+    const preventDefault = vi.fn()
+    const input: ShortcutDispatchInput = {
+      target: null,
+      defaultPrevented: false,
+      preventDefault
+    }
+    const state: AppShortcutState = {
+      activeView: 'terminal',
+      activeWorktreeId: WT,
+      actions: {} as AppShortcutState['actions'],
+      creationLayoutActive: false,
+      floatingTerminalEnabled: false,
+      floatingTerminalOpen: false,
+      floatingVisibleTabCount: 0,
+      keybindings: useAppStore.getState().keybindings,
+      openFloatingWorkspaceMaximized: vi.fn(),
+      pluginCommands: [],
+      setFloatingTerminalOpen: vi.fn(),
+      terminalShortcutPolicy: 'orca-first',
+      workspaceChromeActive: true
+    }
+
+    const handled = createAppCommandHandlers(state, input).get('tab.moveToSplitRight')?.()
+
+    expect(handled).toBe(false)
+    expect(dropUnifiedTab).toHaveBeenCalledWith('tab-a', {
+      groupId: 'group-1',
+      splitDirection: 'right'
+    })
+    expect(preventDefault).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/app-shell/app-command-handlers.ts
+++ b/src/renderer/src/app-shell/app-command-handlers.ts
@@ -117,7 +117,7 @@ export function createAppCommandHandlers(
     run()
     return true
   }
-  // Why: an unmovable tab (alone in its group) must not swallow the chord — fall through instead.
+  /** Claims a move-to-split chord only after the store accepts the move. */
   const claimMoveTabToSplit = ({
     id,
     direction
@@ -126,7 +126,10 @@ export function createAppCommandHandlers(
       return false
     }
     const target = resolveActiveTabPaneColumnMoveTarget(useAppStore.getState())
-    return target ? claim(id, () => moveTabToNewPaneColumn({ target, direction })) : false
+    if (!target || !moveTabToNewPaneColumn({ target, direction })) {
+      return false
+    }
+    return claim(id, () => {})
   }
   const revealRightSidebarTab = (
     actionId: KeybindingActionId,

--- a/src/renderer/src/app-shell/app-command-handlers.ts
+++ b/src/renderer/src/app-shell/app-command-handlers.ts
@@ -5,13 +5,18 @@ import { requestScrollToCurrentWorkspaceRevealAndRename } from '@/lib/scroll-to-
 import { showTerminalShortcutCaptureNotification } from '@/lib/terminal-shortcut-capture-notification'
 import { shouldShowWorktreeHistoryControls } from '../lib/titlebar-worktree-history-controls'
 import { TOGGLE_WORKSPACE_BOARD_EVENT } from '../components/sidebar/useWorkspaceBoardPanel'
+import {
+  moveTabToNewPaneColumn,
+  resolveActiveTabPaneColumnMoveTarget
+} from '../components/tab-bar/tab-move-to-pane-column'
 import { useAppStore } from '../store'
 import type { usePluginCommands } from '@/store/plugin-panels'
 import { isGitRepoKind } from '../../../shared/repo-kind'
-import type {
-  KeybindingActionId,
-  KeybindingContext,
-  PhysicalModifierToken
+import {
+  TAB_MOVE_TO_SPLIT_COMMANDS,
+  type KeybindingActionId,
+  type KeybindingContext,
+  type PhysicalModifierToken
 } from '../../../shared/keybindings'
 import { shortcutPlatform } from './app-window-chrome'
 
@@ -112,6 +117,17 @@ export function createAppCommandHandlers(
     run()
     return true
   }
+  // Why: an unmovable tab (alone in its group) must not swallow the chord — fall through instead.
+  const claimMoveTabToSplit = ({
+    id,
+    direction
+  }: (typeof TAB_MOVE_TO_SPLIT_COMMANDS)[number]): boolean => {
+    if (!workspaceChromeActive || floatingWorkspaceFocused) {
+      return false
+    }
+    const target = resolveActiveTabPaneColumnMoveTarget(useAppStore.getState())
+    return target ? claim(id, () => moveTabToNewPaneColumn({ target, direction })) : false
+  }
   const revealRightSidebarTab = (
     actionId: KeybindingActionId,
     tab: Parameters<AppShortcutActions['setRightSidebarTab']>[0]
@@ -179,6 +195,9 @@ export function createAppCommandHandlers(
         return claim('tab.rename', () => store.setRenamingTabId(store.activeTabId!))
       }
     ],
+    ...TAB_MOVE_TO_SPLIT_COMMANDS.map(
+      (command) => [command.id, () => claimMoveTabToSplit(command)] as const
+    ),
     [
       'workspace.rename',
       () => {

--- a/src/renderer/src/app-shell/use-global-keybindings.ts
+++ b/src/renderer/src/app-shell/use-global-keybindings.ts
@@ -22,6 +22,7 @@ import { usePluginCommands } from '@/store/plugin-panels'
 import { useAppStore } from '../store'
 import {
   keybindingMatchesAction,
+  TAB_MOVE_TO_SPLIT_COMMANDS,
   type KeybindingActionId,
   type KeybindingMatchOptions
 } from '../../../shared/keybindings'
@@ -237,6 +238,15 @@ export function useGlobalKeybindings(args: {
 
       const handlers = createAppCommandHandlers(state, input, context)
       for (const actionId of PLUGIN_COMMAND_ALIAS_ACTION_IDS) {
+        if (matchShortcut(actionId) && handlers.get(actionId)?.()) {
+          return
+        }
+      }
+
+      // Unbound by default like sourceControl.sendReviewNotes below, and deliberately outside
+      // PLUGIN_COMMAND_ALIAS_ACTION_IDS — that list is the closed set plugins may alias, not the
+      // dispatch table. The handler returns false when the tab cannot move, so the chord falls through.
+      for (const { id: actionId } of TAB_MOVE_TO_SPLIT_COMMANDS) {
         if (matchShortcut(actionId) && handlers.get(actionId)?.()) {
           return
         }

--- a/src/renderer/src/app-shell/use-global-keybindings.ts
+++ b/src/renderer/src/app-shell/use-global-keybindings.ts
@@ -243,9 +243,7 @@ export function useGlobalKeybindings(args: {
         }
       }
 
-      // Unbound by default like sourceControl.sendReviewNotes below, and deliberately outside
-      // PLUGIN_COMMAND_ALIAS_ACTION_IDS — that list is the closed set plugins may alias, not the
-      // dispatch table. The handler returns false when the tab cannot move, so the chord falls through.
+      // Why: these unbound built-ins are not plugin aliases and must fall through when unavailable.
       for (const { id: actionId } of TAB_MOVE_TO_SPLIT_COMMANDS) {
         if (matchShortcut(actionId) && handlers.get(actionId)?.()) {
           return

--- a/src/renderer/src/components/tab-bar/TabWorkspaceLayoutMenuSection.tsx
+++ b/src/renderer/src/components/tab-bar/TabWorkspaceLayoutMenuSection.tsx
@@ -15,7 +15,7 @@ import { TAB_CONTEXT_SUBMENU_CONTENT_CLASS } from './tab-context-menu-sizing'
 import { useOptionalShortcutLabel } from '@/hooks/useShortcutLabel'
 import { TAB_MOVE_TO_SPLIT_COMMANDS, type KeybindingActionId } from '../../../../shared/keybindings'
 
-// Why: the action is discovered here, so a chord the user assigned has to be visible here too.
+/** Gives each fixed direction its own shortcut-label hook boundary. */
 function PaneColumnDirectionItem({
   actionId,
   direction,
@@ -61,6 +61,7 @@ function paneColumnDirectionLabel(direction: TabSplitDirection): string {
   }
 }
 
+/** Hides the submenu when moving the tab would collapse back to the same layout. */
 export function TabWorkspaceLayoutMenuSection({
   unifiedTabId,
   groupId,

--- a/src/renderer/src/components/tab-bar/TabWorkspaceLayoutMenuSection.tsx
+++ b/src/renderer/src/components/tab-bar/TabWorkspaceLayoutMenuSection.tsx
@@ -1,5 +1,6 @@
 import {
   DropdownMenuSeparator,
+  DropdownMenuShortcut,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
@@ -8,10 +9,31 @@ import {
 import { ArrowDown, ArrowLeft, ArrowRight, ArrowUp, Columns2 } from 'lucide-react'
 import type { TabSplitDirection } from '../../store/slices/tabs'
 import { translate } from '@/i18n/i18n'
-import { canMoveTabToNewPaneColumn, moveTabToNewPaneColumn } from './tab-move-to-pane-column'
+import { useAppStore } from '../../store'
+import { moveTabToNewPaneColumn, resolveTabPaneColumnMoveTarget } from './tab-move-to-pane-column'
 import { TAB_CONTEXT_SUBMENU_CONTENT_CLASS } from './tab-context-menu-sizing'
+import { useOptionalShortcutLabel } from '@/hooks/useShortcutLabel'
+import { TAB_MOVE_TO_SPLIT_COMMANDS, type KeybindingActionId } from '../../../../shared/keybindings'
 
-const PANE_COLUMN_DIRECTIONS: TabSplitDirection[] = ['right', 'left', 'down', 'up']
+// Why: the action is discovered here, so a chord the user assigned has to be visible here too.
+function PaneColumnDirectionItem({
+  actionId,
+  direction,
+  onSelect
+}: {
+  actionId: KeybindingActionId
+  direction: TabSplitDirection
+  onSelect: () => void
+}): React.JSX.Element {
+  const shortcut = useOptionalShortcutLabel(actionId)
+  return (
+    <DropdownMenuItem onSelect={onSelect}>
+      {paneColumnDirectionIcon(direction)}
+      {paneColumnDirectionLabel(direction)}
+      {shortcut ? <DropdownMenuShortcut>{shortcut}</DropdownMenuShortcut> : null}
+    </DropdownMenuItem>
+  )
+}
 
 function paneColumnDirectionIcon(direction: TabSplitDirection): React.JSX.Element {
   switch (direction) {
@@ -48,7 +70,8 @@ export function TabWorkspaceLayoutMenuSection({
   groupId: string
   trailingSeparator?: boolean
 }): React.JSX.Element | null {
-  if (!canMoveTabToNewPaneColumn(unifiedTabId, groupId)) {
+  const target = resolveTabPaneColumnMoveTarget(useAppStore.getState(), unifiedTabId, groupId)
+  if (!target) {
     return null
   }
 
@@ -63,16 +86,15 @@ export function TabWorkspaceLayoutMenuSection({
           )}
         </DropdownMenuSubTrigger>
         <DropdownMenuSubContent className={TAB_CONTEXT_SUBMENU_CONTENT_CLASS}>
-          {PANE_COLUMN_DIRECTIONS.map((direction) => (
-            <DropdownMenuItem
-              key={direction}
+          {TAB_MOVE_TO_SPLIT_COMMANDS.map(({ id, direction }) => (
+            <PaneColumnDirectionItem
+              key={id}
+              actionId={id}
+              direction={direction}
               onSelect={() => {
-                moveTabToNewPaneColumn({ unifiedTabId, groupId, direction })
+                moveTabToNewPaneColumn({ target, direction })
               }}
-            >
-              {paneColumnDirectionIcon(direction)}
-              {paneColumnDirectionLabel(direction)}
-            </DropdownMenuItem>
+            />
           ))}
         </DropdownMenuSubContent>
       </DropdownMenuSub>

--- a/src/renderer/src/components/tab-bar/tab-move-to-pane-column.test.ts
+++ b/src/renderer/src/components/tab-bar/tab-move-to-pane-column.test.ts
@@ -143,4 +143,27 @@ describe('tab-move-to-pane-column', () => {
     expect(moveTabToNewPaneColumn({ target: target!, direction: 'right' })).toBe(false)
     expect(mocks.mirrorWebRuntimeTabMove).not.toHaveBeenCalled()
   })
+
+  it('rejects a target that became stale while its menu was open', () => {
+    const dropUnifiedTab = vi.fn(() => true)
+    const target = resolveTabPaneColumnMoveTarget(useAppStore.getState(), 'tab-b', 'group-1')
+    expect(target).not.toBeNull()
+    useAppStore.setState({
+      groupsByWorktree: {
+        [WT]: [
+          {
+            id: 'group-1',
+            worktreeId: WT,
+            activeTabId: 'tab-a',
+            tabOrder: ['tab-a']
+          }
+        ]
+      },
+      dropUnifiedTab
+    })
+
+    expect(moveTabToNewPaneColumn({ target: target!, direction: 'right' })).toBe(false)
+    expect(dropUnifiedTab).not.toHaveBeenCalled()
+    expect(mocks.mirrorWebRuntimeTabMove).not.toHaveBeenCalled()
+  })
 })

--- a/src/renderer/src/components/tab-bar/tab-move-to-pane-column.test.ts
+++ b/src/renderer/src/components/tab-bar/tab-move-to-pane-column.test.ts
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useAppStore } from '../../store'
 import type { Tab } from '../../../../shared/tab-types'
-import { canMoveTabToNewPaneColumn, moveTabToNewPaneColumn } from './tab-move-to-pane-column'
+import {
+  moveTabToNewPaneColumn,
+  resolveActiveTabPaneColumnMoveTarget,
+  resolveTabPaneColumnMoveTarget
+} from './tab-move-to-pane-column'
 
 const WT = 'wt-1'
 
@@ -62,11 +66,15 @@ describe('tab-move-to-pane-column', () => {
     })
   })
 
-  it('allows moving when the source group has more than one tab', () => {
-    expect(canMoveTabToNewPaneColumn('tab-b', 'group-1')).toBe(true)
+  it('resolves an executable target once', () => {
+    expect(resolveTabPaneColumnMoveTarget(useAppStore.getState(), 'tab-b', 'group-1')).toEqual({
+      worktreeId: WT,
+      unifiedTabId: 'tab-b',
+      groupId: 'group-1'
+    })
   })
 
-  it('blocks moving the only tab in a group', () => {
+  it('resolves nothing for the only tab in a group', () => {
     useAppStore.setState({
       groupsByWorktree: {
         [WT]: [
@@ -80,19 +88,17 @@ describe('tab-move-to-pane-column', () => {
       }
     })
 
-    expect(canMoveTabToNewPaneColumn('tab-a', 'group-1')).toBe(false)
-    expect(
-      moveTabToNewPaneColumn({ unifiedTabId: 'tab-a', groupId: 'group-1', direction: 'right' })
-    ).toBe(false)
+    expect(resolveTabPaneColumnMoveTarget(useAppStore.getState(), 'tab-a', 'group-1')).toBeNull()
+    expect(resolveActiveTabPaneColumnMoveTarget(useAppStore.getState())).toBeNull()
   })
 
-  it('creates a sibling split pane via dropUnifiedTab', () => {
+  it('executes a resolved target and mirrors the same worktree', () => {
     const dropUnifiedTab = vi.fn(() => true)
     useAppStore.setState({ dropUnifiedTab } as Partial<ReturnType<typeof useAppStore.getState>>)
+    const target = resolveTabPaneColumnMoveTarget(useAppStore.getState(), 'tab-b', 'group-1')
+    expect(target).not.toBeNull()
 
-    expect(
-      moveTabToNewPaneColumn({ unifiedTabId: 'tab-b', groupId: 'group-1', direction: 'right' })
-    ).toBe(true)
+    expect(moveTabToNewPaneColumn({ target: target!, direction: 'right' })).toBe(true)
     expect(dropUnifiedTab).toHaveBeenCalledWith('tab-b', {
       groupId: 'group-1',
       splitDirection: 'right'
@@ -106,13 +112,35 @@ describe('tab-move-to-pane-column', () => {
     })
   })
 
+  // Why: activeTabId is a terminal entity id, so active commands resolve through the active group.
+  it('resolves the active unified tab', () => {
+    useAppStore.setState({ activeGroupIdByWorktree: { [WT]: 'group-1' } })
+
+    expect(resolveActiveTabPaneColumnMoveTarget(useAppStore.getState())).toEqual({
+      worktreeId: WT,
+      unifiedTabId: 'tab-a',
+      groupId: 'group-1'
+    })
+  })
+
+  it('resolves nothing when the active group has no active tab', () => {
+    useAppStore.setState({
+      activeGroupIdByWorktree: { [WT]: 'group-1' },
+      groupsByWorktree: {
+        [WT]: [{ id: 'group-1', worktreeId: WT, activeTabId: null, tabOrder: ['tab-a', 'tab-b'] }]
+      }
+    })
+
+    expect(resolveActiveTabPaneColumnMoveTarget(useAppStore.getState())).toBeNull()
+  })
+
   it('does not mirror when the local store rejects the move', () => {
     const dropUnifiedTab = vi.fn(() => false)
     useAppStore.setState({ dropUnifiedTab } as Partial<ReturnType<typeof useAppStore.getState>>)
+    const target = resolveTabPaneColumnMoveTarget(useAppStore.getState(), 'tab-b', 'group-1')
+    expect(target).not.toBeNull()
 
-    expect(
-      moveTabToNewPaneColumn({ unifiedTabId: 'tab-b', groupId: 'group-1', direction: 'right' })
-    ).toBe(false)
+    expect(moveTabToNewPaneColumn({ target: target!, direction: 'right' })).toBe(false)
     expect(mocks.mirrorWebRuntimeTabMove).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/tab-bar/tab-move-to-pane-column.ts
+++ b/src/renderer/src/components/tab-bar/tab-move-to-pane-column.ts
@@ -4,60 +4,76 @@ import { mirrorWebRuntimeTabMove } from './web-runtime-tab-move-mirror'
 
 type TabMovePaneColumnState = Pick<
   ReturnType<typeof useAppStore.getState>,
-  'unifiedTabsByWorktree' | 'groupsByWorktree'
+  'activeWorktreeId' | 'getActiveTab' | 'unifiedTabsByWorktree' | 'groupsByWorktree'
 >
 
-export function canMoveTabToNewPaneColumnFromState(
+export type TabPaneColumnMoveTarget = {
+  worktreeId: string
+  unifiedTabId: string
+  groupId: string
+}
+
+function resolveTabPaneColumnMoveTargetInWorktree(
+  state: TabMovePaneColumnState,
+  worktreeId: string,
+  unifiedTabId: string,
+  groupId: string
+): TabPaneColumnMoveTarget | null {
+  const tab = (state.unifiedTabsByWorktree[worktreeId] ?? []).find(
+    (candidate) => candidate.id === unifiedTabId && candidate.groupId === groupId
+  )
+  const group = (state.groupsByWorktree[worktreeId] ?? []).find(
+    (candidate) => candidate.id === groupId
+  )
+  // Why: dropUnifiedTab rejects splitting a group's only tab, so unavailable commands fall through.
+  if (!tab || !group || group.tabOrder.length < 2) {
+    return null
+  }
+  return { worktreeId, unifiedTabId, groupId }
+}
+
+export function resolveTabPaneColumnMoveTarget(
   state: TabMovePaneColumnState,
   unifiedTabId: string,
   groupId: string
-): boolean {
-  for (const [worktreeId, tabs] of Object.entries(state.unifiedTabsByWorktree)) {
-    const tab = tabs.find((candidate) => candidate.id === unifiedTabId)
-    if (!tab || tab.groupId !== groupId) {
-      continue
-    }
-    const group = (state.groupsByWorktree[worktreeId] ?? []).find(
-      (candidate) => candidate.id === groupId
-    )
-    if (!group) {
-      return false
-    }
-    // Why: mirror dropUnifiedTab — splitting the only tab in a group onto an
-    // adjacent split pane is a layout no-op the store rejects.
-    return group.tabOrder.length > 1
-  }
-  return false
+): TabPaneColumnMoveTarget | null {
+  const worktreeId = Object.entries(state.unifiedTabsByWorktree).find(([, tabs]) =>
+    tabs.some((candidate) => candidate.id === unifiedTabId && candidate.groupId === groupId)
+  )?.[0]
+  return worktreeId
+    ? resolveTabPaneColumnMoveTargetInWorktree(state, worktreeId, unifiedTabId, groupId)
+    : null
 }
 
-export function canMoveTabToNewPaneColumn(unifiedTabId: string, groupId: string): boolean {
-  return canMoveTabToNewPaneColumnFromState(useAppStore.getState(), unifiedTabId, groupId)
+// Why: activeTabId is a terminal entity id; commands must resolve the active unified tab via its group.
+export function resolveActiveTabPaneColumnMoveTarget(
+  state: TabMovePaneColumnState
+): TabPaneColumnMoveTarget | null {
+  const worktreeId = state.activeWorktreeId
+  if (!worktreeId) {
+    return null
+  }
+  const tab = state.getActiveTab(worktreeId)
+  return tab
+    ? resolveTabPaneColumnMoveTargetInWorktree(state, worktreeId, tab.id, tab.groupId)
+    : null
 }
 
 export function moveTabToNewPaneColumn(args: {
-  unifiedTabId: string
-  groupId: string
+  target: TabPaneColumnMoveTarget
   direction: TabSplitDirection
 }): boolean {
   const state = useAppStore.getState()
-  const worktreeId = Object.entries(state.unifiedTabsByWorktree).find(([, tabs]) =>
-    tabs.some(
-      (candidate) => candidate.id === args.unifiedTabId && candidate.groupId === args.groupId
-    )
-  )?.[0]
-  if (!worktreeId || !canMoveTabToNewPaneColumnFromState(state, args.unifiedTabId, args.groupId)) {
-    return false
-  }
-  const moved = state.dropUnifiedTab(args.unifiedTabId, {
-    groupId: args.groupId,
+  const moved = state.dropUnifiedTab(args.target.unifiedTabId, {
+    groupId: args.target.groupId,
     splitDirection: args.direction
   })
   if (moved) {
     mirrorWebRuntimeTabMove({
       kind: 'split',
-      worktreeId,
-      tabId: args.unifiedTabId,
-      targetGroupId: args.groupId,
+      worktreeId: args.target.worktreeId,
+      tabId: args.target.unifiedTabId,
+      targetGroupId: args.target.groupId,
       splitDirection: args.direction
     })
   }

--- a/src/renderer/src/components/tab-bar/tab-move-to-pane-column.ts
+++ b/src/renderer/src/components/tab-bar/tab-move-to-pane-column.ts
@@ -13,6 +13,7 @@ export type TabPaneColumnMoveTarget = {
   groupId: string
 }
 
+/** Rejects single-tab groups because splitting their only tab is a layout no-op. */
 function resolveTabPaneColumnMoveTargetInWorktree(
   state: TabMovePaneColumnState,
   worktreeId: string,
@@ -32,6 +33,7 @@ function resolveTabPaneColumnMoveTargetInWorktree(
   return { worktreeId, unifiedTabId, groupId }
 }
 
+/** Resolves worktree ownership once so execution and web mirroring share one target. */
 export function resolveTabPaneColumnMoveTarget(
   state: TabMovePaneColumnState,
   unifiedTabId: string,
@@ -45,7 +47,7 @@ export function resolveTabPaneColumnMoveTarget(
     : null
 }
 
-// Why: activeTabId is a terminal entity id; commands must resolve the active unified tab via its group.
+/** Resolves the active unified tab rather than the terminal entity id stored globally. */
 export function resolveActiveTabPaneColumnMoveTarget(
   state: TabMovePaneColumnState
 ): TabPaneColumnMoveTarget | null {
@@ -59,21 +61,31 @@ export function resolveActiveTabPaneColumnMoveTarget(
     : null
 }
 
+/** Mirrors only accepted local moves so paired web state cannot diverge. */
 export function moveTabToNewPaneColumn(args: {
   target: TabPaneColumnMoveTarget
   direction: TabSplitDirection
 }): boolean {
   const state = useAppStore.getState()
-  const moved = state.dropUnifiedTab(args.target.unifiedTabId, {
-    groupId: args.target.groupId,
+  const target = resolveTabPaneColumnMoveTargetInWorktree(
+    state,
+    args.target.worktreeId,
+    args.target.unifiedTabId,
+    args.target.groupId
+  )
+  if (!target) {
+    return false
+  }
+  const moved = state.dropUnifiedTab(target.unifiedTabId, {
+    groupId: target.groupId,
     splitDirection: args.direction
   })
   if (moved) {
     mirrorWebRuntimeTabMove({
       kind: 'split',
-      worktreeId: args.target.worktreeId,
-      tabId: args.target.unifiedTabId,
-      targetGroupId: args.target.groupId,
+      worktreeId: target.worktreeId,
+      tabId: target.unifiedTabId,
+      targetGroupId: target.groupId,
       splitDirection: args.direction
     })
   }

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -1174,6 +1174,7 @@ function buildAgentTabKeybindingDefinitions(): KeybindingDefinition[] {
   }))
 }
 
+/** Leaves all directions unassigned to avoid claiming four new global chords by default. */
 function buildTabMoveToSplitKeybindingDefinitions(): KeybindingDefinition[] {
   return TAB_MOVE_TO_SPLIT_COMMANDS.map(({ id, direction }) => ({
     id,

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -69,6 +69,10 @@ export type KeybindingActionId =
   | 'tab.closeAll'
   | 'tab.rename'
   | 'tab.reopenClosed'
+  | 'tab.moveToSplitRight'
+  | 'tab.moveToSplitLeft'
+  | 'tab.moveToSplitUp'
+  | 'tab.moveToSplitDown'
   | 'tab.nextSameType'
   | 'tab.previousSameType'
   | 'tab.nextAllTypes'
@@ -119,6 +123,16 @@ export type KeybindingActionId =
   | PluginKeybindingActionId
 
 export type KeybindingOverrides = Partial<Record<KeybindingActionId, string[]>>
+
+export const TAB_MOVE_TO_SPLIT_COMMANDS = [
+  { id: 'tab.moveToSplitRight', direction: 'right' },
+  { id: 'tab.moveToSplitLeft', direction: 'left' },
+  { id: 'tab.moveToSplitDown', direction: 'down' },
+  { id: 'tab.moveToSplitUp', direction: 'up' }
+] as const satisfies readonly {
+  id: KeybindingActionId
+  direction: 'right' | 'left' | 'down' | 'up'
+}[]
 
 export type KeybindingFileDiagnostic = {
   severity: 'warning' | 'error'
@@ -656,6 +670,7 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     searchKeywords: ['shortcut', 'tab', 'reopen', 'restore', 'closed'],
     defaultBindings: platformBindings(['Mod+Shift+T'])
   },
+  ...buildTabMoveToSplitKeybindingDefinitions(),
   {
     id: 'tab.nextSameType',
     title: 'Next tab (same type)',
@@ -1155,6 +1170,19 @@ function buildAgentTabKeybindingDefinitions(): KeybindingDefinition[] {
       agent,
       TUI_AGENT_DISPLAY_NAMES[agent].toLowerCase()
     ],
+    defaultBindings: platformBindings([])
+  }))
+}
+
+function buildTabMoveToSplitKeybindingDefinitions(): KeybindingDefinition[] {
+  return TAB_MOVE_TO_SPLIT_COMMANDS.map(({ id, direction }) => ({
+    id,
+    title: `Move tab to split ${direction}`,
+    group: 'Tabs',
+    scope: 'tabs',
+    // Why: these run in global capture, so Settings must warn when an earlier global action owns the chord.
+    conflictGroup: 'global',
+    searchKeywords: ['shortcut', 'tab', 'split', 'move', direction],
     defaultBindings: platformBindings([])
   }))
 }

--- a/tests/e2e/tab-move-to-split-shortcut.spec.ts
+++ b/tests/e2e/tab-move-to-split-shortcut.spec.ts
@@ -1,10 +1,4 @@
-/**
- * E2E for the "Move Tab to Split" commands.
- *
- * A store-level test calls moveTabToNewPaneColumn directly and passes even when no keypress
- * reaches the handler, so it cannot tell a wired command from an unreachable one. This drives
- * the real path instead: assign a binding, press the chord, assert on the tab group strips.
- */
+/** Drives a real chord because store-only tests cannot prove the shortcut reaches its handler. */
 
 import { test, expect } from './helpers/orca-app'
 import { waitForActiveTerminalManager } from './helpers/terminal'

--- a/tests/e2e/tab-move-to-split-shortcut.spec.ts
+++ b/tests/e2e/tab-move-to-split-shortcut.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * E2E for the "Move Tab to Split" commands.
+ *
+ * A store-level test calls moveTabToNewPaneColumn directly and passes even when no keypress
+ * reaches the handler, so it cannot tell a wired command from an unreachable one. This drives
+ * the real path instead: assign a binding, press the chord, assert on the tab group strips.
+ */
+
+import { test, expect } from './helpers/orca-app'
+import { waitForActiveTerminalManager } from './helpers/terminal'
+import {
+  waitForSessionReady,
+  waitForActiveWorktree,
+  ensureTerminalVisible,
+  getActiveTabId
+} from './helpers/store'
+import { openTerminalTabInActiveGroup } from './helpers/terminal-tab-open'
+
+// Mod+Alt+M is unused by the built-in map, so the chord cannot be stolen by another action.
+const CHORD = 'Mod+Alt+M'
+
+test('a bound chord moves the active tab into a split pane column', async ({ orcaPage }) => {
+  await waitForSessionReady(orcaPage)
+  await waitForActiveWorktree(orcaPage)
+  await ensureTerminalVisible(orcaPage)
+  await waitForActiveTerminalManager(orcaPage)
+
+  // A lone tab cannot move — dropUnifiedTab rejects splitting a group's only tab.
+  await openTerminalTabInActiveGroup(orcaPage)
+
+  await orcaPage.evaluate(async (chord) => {
+    await window.__store!.getState().setKeybindingOverride('tab.moveToSplitRight', [chord])
+  }, CHORD)
+
+  // Why not countVisibleTerminalPanes(): that counts terminal panes *inside* one tab (the Cmd+D
+  // split). Moving a tab to a split creates a new tab group, and each group renders its own strip.
+  // Scoped to the active worktree because hidden worktree surfaces stay mounted and would be counted.
+  const worktreeId = await orcaPage.evaluate(() => window.__store!.getState().activeWorktreeId)
+  const groupStrips = orcaPage.locator(
+    `[data-tab-group-strip-id][data-worktree-id="${worktreeId}"]`
+  )
+  await expect(groupStrips).toHaveCount(1)
+
+  const activeTabId = await getActiveTabId(orcaPage)
+  expect(activeTabId).not.toBeNull()
+  await orcaPage
+    .locator(`[data-testid="sortable-tab"][data-tab-id="${activeTabId}"]`)
+    .click({ button: 'right' })
+  const contextMenu = orcaPage.getByRole('menu')
+  await expect(contextMenu).toBeVisible()
+  await contextMenu.getByRole('menuitem').first().hover()
+
+  const isMac = await orcaPage.evaluate(() => navigator.userAgent.includes('Mac'))
+  const splitMenu = orcaPage.getByRole('menu').nth(1)
+  const rightMenuItem = splitMenu.getByRole('menuitem').first()
+  await expect(rightMenuItem).toBeVisible()
+  await expect(rightMenuItem.locator('[data-slot="dropdown-menu-shortcut"]')).toHaveText(
+    isMac ? '⌘⌥M' : 'Ctrl+Alt+M'
+  )
+  await orcaPage.keyboard.press('Escape')
+
+  // Why: a real input/contenteditable suppresses global shortcuts, but the xterm textarea is carved
+  // out of isEditableTarget — so blur everything except it, leaving the terminal's normal focus state.
+  await orcaPage.evaluate(() => {
+    const active = document.activeElement
+    if (active instanceof HTMLElement && !active.classList.contains('xterm-helper-textarea')) {
+      active.blur()
+    }
+  })
+
+  // pressShortcut() has no Alt option, so resolve the platform modifier here.
+  await orcaPage.keyboard.press(`${isMac ? 'Meta' : 'Control'}+Alt+m`)
+
+  await expect(groupStrips, 'the bound chord did not move the tab into a new group').toHaveCount(
+    2,
+    {
+      timeout: 5_000
+    }
+  )
+})


### PR DESCRIPTION
## ELI5

Move the active tab into a new split with a user-assigned shortcut, in any of four directions.

## What Changed

- Added `tab.moveToSplitRight`, `Left`, `Down`, and `Up` as unassigned commands.
- Reused one command catalog across Settings, dispatch, and the existing context menu.
- Resolve availability for the menu and shortcut, revalidate it at execution time, reuse the existing local/remote move path, and let unavailable commands fall through.
- Added unit coverage and an Electron E2E that assigns a shortcut, checks its menu label, presses it, and observes the new split.

## Why

“Move Tab to Split” was only reachable with the mouse. This PR covers the keybinding portion of #12083: users can assign any of the four directions in Settings and use the action without returning to the context menu. Cmd+J command-palette invocation remains out of scope. Leaving the commands unassigned avoids imposing a new default keymap.

## Linked Issue

Addresses #12083 (keybinding portion only)

Related: #10055

## Visual Proof

N/A — this adds commands and shortcut labels to existing Settings and menu surfaces; it adds no new user-facing surface or layout. The Electron E2E verifies the rendered label and resulting split.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Post-rebase validation on `upstream/main`:

- `pnpm typecheck` — passed
- Changed-code quality and React Doctor — passed with no new findings
- Focused unit suite — 8 tests passed across 2 files
- Electron E2E — passed 1/1 on macOS

Earlier full validation:

- `pnpm lint` — passed
- `pnpm build` — passed; the optional `/usr/local/bin/orca-dev` symlink was not writable
- `pnpm test` — 56,790 passed; two WSL scanner assertions saw an ignored cross-version checkout generated concurrently. After removing that cache, the scanner passed 4/4 standalone.
- Manual — passed on macOS by assigning a shortcut and moving the active tab into a new split.

Not manually tested on Linux, Windows, or SSH.

## AI Disclosure

OpenAI Codex was used to refactor the implementation, review the diff, and run the checks above. I reviewed the resulting code and test evidence.

## Review

- Cross-platform: no default chord or hardcoded modifier; labels use the existing platform formatter.
- SSH/remote/local: the command reuses `dropUnifiedTab` and the existing web-runtime mirror; no wire format changes.
- Agents, integrations, git providers, and mobile: not touched.
- Performance: bounded target lookup runs when rendering the affected menu and when invoking the command; there is no polling or background work.
- UI: reuses the existing menu primitives and shortcut label component.
- Security: no IPC, dependency, credential, path, or command-execution changes.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Cmd+J command-palette invocation is intentionally out of scope; users opt in by assigning one or more directions in Settings. #10067 and #10076 cover only Right and assign a default chord; this follows the four-direction, user-assigned keybinding scope described by #12083.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: @hgijeon
