### PR TITLE
fix(renderer): prevent restored terminal spawn storms

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -3433,6 +3433,129 @@
       "demotionRule": "Demote or quarantine if the gate flakes once without a product bug or harness bug filed to the owner."
     },
     {
+      "id": "terminal-session.restored-spawn-hold",
+      "title": "Cold activation of a paired workspace cannot spawn host shells before the host answers",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "terminal-runtime",
+      "layer": "renderer-unit",
+      "surfaces": [
+        "terminal lifecycle",
+        "paired runtime activation",
+        "host session-tabs mirror",
+        "cold-activation mounting"
+      ],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["runtime"],
+      "coveredPlatforms": ["macos"],
+      "coveredProviders": [],
+      "coverageNotes": "Local macOS renderer-unit evidence only: a helper suite over the hold policy and a rendered Terminal suite whose oracle is which tabs Terminal actually instantiates a TerminalPane for. No live headed/headless paired-runtime topology is exercised, and Linux, Windows, and SSH hosts are not run. Scope is paired runtime workspaces; local, SSH, and folder workspaces resolve no runtime environment and are asserted to hold nothing.",
+      "motivatingLinks": [
+        "https://linear.app/stably/issue/STA-4953",
+        "https://github.com/stablyai/orca/pull/15742",
+        "https://github.com/stablyai/orca/pull/15644"
+      ],
+      "invariant": "While a paired workspace's first authoritative session.tabs answer is outstanding, cold activation must not mount a restored row that would take pty-connection's fresh-spawn branch (no ptyId on the row, none in ptyIdsByTabId, none on a surviving layout leaf, and not a web-terminal mirror row). The hold is scoped to one host epoch (environmentId plus that environment's connection generation), settles only on evidence that landed in the store for that epoch, and fails open after a 20s per-window deadline and a 60s total ceiling because a blank workspace must never wedge. It never withholds the active tab, a remembered per-worktree active tab, any group's active tab (including a unified-tab id mapped to its terminal entityId), an activity-terminal-portal tab, a queued pendingStartup tab, a live tab, or a row an earlier pass already mounted.",
+      "oracle": "Two independent oracles. Helper level: planRestoredTerminalSpawnHold's held set, window bookkeeping, and epoch identity, plus applyRestoredTerminalSpawnHold's allowed/deferred sets and their referential stability. Render level: the set of tabs the real Terminal component instantiates a (mocked) TerminalPane for, driven through the shipping web-session-tabs accept path and its host-session-mirror settle receipt, so a helper-only assertion cannot stand in for the wiring.",
+      "commands": [
+        "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal/restored-terminal-spawn-hold.test.ts src/renderer/src/components/terminal/restored-terminal-spawn-hold.render.test.tsx",
+        "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/runtime/host-session-mirror-hydration-frame-ordering.test.tsx src/renderer/src/runtime/host-session-mirror-settle-census.test.ts src/renderer/src/runtime/host-session-mirror-settle-receipt-frames.test.tsx src/renderer/src/runtime/web-session-tabs-sync.test.ts src/renderer/src/runtime/web-session-tabs-sync-snapshot-batch.test.ts src/renderer/src/runtime/web-session-tabs-sync-mirror-identity.test.ts"
+      ],
+      "testFiles": [
+        "src/renderer/src/components/terminal/restored-terminal-spawn-hold.test.ts",
+        "src/renderer/src/components/terminal/restored-terminal-spawn-hold.render.test.tsx",
+        "src/renderer/src/runtime/host-session-mirror-hydration-frame-ordering.test.tsx",
+        "src/renderer/src/runtime/host-session-mirror-settle-census.test.ts",
+        "src/renderer/src/runtime/host-session-mirror-settle-receipt-frames.test.tsx",
+        "src/renderer/src/runtime/web-session-tabs-sync.test.ts",
+        "src/renderer/src/runtime/web-session-tabs-sync-snapshot-batch.test.ts",
+        "src/renderer/src/runtime/web-session-tabs-sync-mirror-identity.test.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/renderer/src/components/terminal/restored-terminal-spawn-hold.render.test.tsx",
+          "assertions": [
+            "withholds restored pty-less rows on a paired worktree until the host answers",
+            "always mounts the active tab and any queued startup, even while holding",
+            "never holds a group active tab, through the unified tab or the raw id",
+            "never holds a tab an activity thread is portaling",
+            "mounts the attach-class rows the gate does not govern",
+            "fails open and mounts held rows when no answer ever arrives",
+            "measures its silence from the live connection, not the one it armed on",
+            "starts a fresh window when the workspace moves to a host at the same generation",
+            "never lets the previous host answer for the one the workspace moved to",
+            "settles on a full inventory that omits the worktree",
+            "does not settle on a single frame published for another worktree",
+            "does not carry an answer from the previous connection into a new hold",
+            "never re-holds rows a previous activation already mounted"
+          ]
+        },
+        {
+          "file": "src/renderer/src/components/terminal/restored-terminal-spawn-hold.test.ts",
+          "assertions": [
+            "is true only for a row with no pty anywhere",
+            "outlasts the session.tabs timeout it waits on",
+            "never holds a carve-out row",
+            "holds nothing on a local, ssh or folder workspace",
+            "gives a reconnect a fresh window but never waits past the ceiling",
+            "gives a workspace that moved hosts a fresh window at the same generation",
+            "never lets one host answer speak for a different host",
+            "still bounds a workspace that keeps moving hosts by the total ceiling",
+            "keeps both set identities while the held membership is unchanged",
+            "replaces both sets when the held membership changes"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-08-21",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal/restored-terminal-spawn-hold.test.ts src/renderer/src/components/terminal/restored-terminal-spawn-hold.render.test.tsx",
+          "result": "passed",
+          "durationSeconds": 3.3,
+          "summary": "2 test file(s) passed, 43 tests passed on the STA-4953 branch."
+        },
+        {
+          "date": "2026-08-21",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/runtime/host-session-mirror-hydration-frame-ordering.test.tsx src/renderer/src/runtime/host-session-mirror-settle-census.test.ts src/renderer/src/runtime/host-session-mirror-settle-receipt-frames.test.tsx src/renderer/src/runtime/web-session-tabs-sync.test.ts src/renderer/src/runtime/web-session-tabs-sync-snapshot-batch.test.ts src/renderer/src/runtime/web-session-tabs-sync-mirror-identity.test.ts",
+          "result": "passed",
+          "durationSeconds": 6.0,
+          "summary": "6 test file(s) passed, 60 tests passed on the STA-4953 branch; covers the mirror-hydration evidence this gate consumes."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 20,
+        "scope": "local renderer unit and rendered-component tests"
+      },
+      "flakeHistory": {
+        "status": "unknown",
+        "evidence": "New gate; only local macOS passes exist. No CI soak history yet."
+      },
+      "redGreenEvidence": {
+        "status": "partial",
+        "evidence": "Wiring red/green, run locally on this branch: with only the applyRestoredTerminalSpawnHold call removed from Terminal.tsx, all 21 rendered tests fail; with it restored, all 21 pass. Carve-out mutations each killed exactly their own test: deleting the unified-tab-to-entityId mapping failed only 'never holds a group active tab' (row-2 missing), and deleting the activity-portal loop failed only 'never holds a tab an activity thread is portaling' (row-4 missing). Host-epoch mutations: dropping the environmentId identity check failed 5 tests, not resetting settled on a host move failed 2, and re-arming armedAtMs on a host move failed 1. Set-identity mutation: making the apply path always re-set failed only the referential-stability test. No saved CI artifact yet."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "The gate exists to prevent a fan-out, not to add one: holding issues no IPC, no RPC, and no probe. It reads two in-memory values per rendered Terminal pass (the mirror-hydration latch and the environment's connection generation) — every ready render pass, including settled holds, not only activation passes — and iterates only the rendered active worktree's own tabs. Fail-open scheduling is at most one active hold timer, for the rendered active worktree only, re-armed each render at min(window deadline, total ceiling) and cleared on cleanup. The allowed/deferred sets keep their identity while membership is unchanged, so a settled hold does not re-render the memoized worktree surface tree on every Terminal render. No renderer throughput or event-loop-delay measurement has been taken."
+      },
+      "promotionCriteria": [
+        "Run in soak on macOS, Linux, and Windows CI for 100 consecutive passes or 14 days without unexplained flakes.",
+        "Add a live paired-runtime topology gate (headed or headless) that counts host terminal.create calls across a cold activation instead of counting mounted panes.",
+        "Attach a saved CI red/green artifact for the removed-wiring run rather than a local transcript."
+      ],
+      "knownGaps": [
+        "No live headed or headless paired-runtime topology is exercised; the render oracle counts mounted panes, not host terminal.create calls.",
+        "Linux, Windows, and SSH hosts are not run for this gate.",
+        "The 20s fail-open window is a real exposure: a host that answers later than the deadline still storms, by design, because a mount gate must not wedge a blank workspace.",
+        "Whether a host ever publishes a floating-worktree frame in its listAll inventory is unverified, so inventory-omission settling rests on the documented enumeration contract."
+      ],
+      "demotionRule": "Demote or quarantine if the gate flakes without a product or harness bug, if a held row is ever observed still dark past the 60s ceiling, or if any carve-out row (active, group-active, portal, queued startup, live, already-mounted) is observed withheld."
+    },
+    {
       "id": "terminal-session.layout-pty-ownership",
       "title": "Restored terminal layouts retain one renderer owner per PTY",
       "maturity": "experimental",

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -100,6 +100,19 @@ import {
 } from './terminal/background-terminal-worktree-mount'
 import { hasRegisteredRuntimeTerminalTab } from '../runtime/sync-runtime-graph'
 import {
+  applyRestoredTerminalSpawnHold,
+  planRestoredTerminalSpawnHold,
+  readRestoredSpawnHoldEvidence,
+  RESTORED_TERMINAL_SPAWN_HOLD_MAX_TOTAL_MS,
+  RESTORED_TERMINAL_SPAWN_HOLD_TIMEOUT_MS,
+  willRestoredTabSpawnHostTerminal,
+  type RestoredSpawnHoldEntry
+} from './terminal/restored-terminal-spawn-hold'
+import {
+  getExplicitRuntimeEnvironmentIdForWorktree,
+  getRuntimeEnvironmentIdForWorktree
+} from '@/lib/worktree-runtime-owner'
+import {
   getEffectiveLayoutForWorktree as getEffectiveLayout,
   anyMountedWorktreeHasLayout as computeAnyMountedWorktreeHasLayout
 } from './terminal/split-group-mount'
@@ -183,7 +196,6 @@ import { useContextualTour } from './contextual-tours/use-contextual-tour'
 import { openTabBarEntry, type TabCreateEntryArgs } from './tab-bar/tab-create-entry-action'
 import { closeTerminalTab } from './terminal/terminal-tab-actions'
 import { translate } from '@/i18n/i18n'
-import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { getResolvedExecutionHostIdForWorktree } from '@/lib/resolved-worktree-execution-host'
 import { browserWorkspaceHasRemoteOwner } from '@/runtime/remote-browser-tab-ownership'
 import {
@@ -336,6 +348,10 @@ function Terminal(): React.JSX.Element | null {
   const renderedActiveWorktreeId = activeWorktreeId
   const activeWorktreeDeferralHostId = useAppStore((s) =>
     getResolvedExecutionHostIdForWorktree(s, renderedActiveWorktreeId)
+  )
+  // Same resolver web-session-tabs-sync subscribes with; a hold on an environment nobody subscribed to could never be answered.
+  const spawnHoldEnvironmentId = useAppStore((s) =>
+    getExplicitRuntimeEnvironmentIdForWorktree(s, renderedActiveWorktreeId)
   )
   const activeView = useAppStore((s) => s.activeView)
   // Why: terminal titles are leaf chrome. The root host only subscribes to
@@ -853,6 +869,27 @@ function Terminal(): React.JSX.Element | null {
   const activationDeferredMountTabIdsByWorktreeRef = useRef(new Map<string, ReadonlySet<string>>())
   // Why: run the cold-activation deferral decision once per activation transition, not on every re-render.
   const lastActivationWorktreeIdRef = useRef<string | null>(null)
+  const restoredSpawnHoldByWorktreeRef = useRef(new Map<string, RestoredSpawnHoldEntry>())
+  const [, setRestoredSpawnHoldRevision] = useState(0)
+  // Fail open at the deadline: an unanswered hold must eventually mount, and the answer
+  // itself can land without a store patch (an accepted empty snapshot changes nothing).
+  useEffect(() => {
+    const entry = renderedActiveWorktreeId
+      ? restoredSpawnHoldByWorktreeRef.current.get(renderedActiveWorktreeId)
+      : undefined
+    if (!entry || entry.settled) {
+      return
+    }
+    const deadline = Math.min(
+      entry.windowStartedAtMs + RESTORED_TERMINAL_SPAWN_HOLD_TIMEOUT_MS,
+      entry.armedAtMs + RESTORED_TERMINAL_SPAWN_HOLD_MAX_TOTAL_MS
+    )
+    const timer = setTimeout(
+      () => setRestoredSpawnHoldRevision((revision) => revision + 1),
+      Math.max(0, deadline - Date.now())
+    )
+    return () => clearTimeout(timer)
+  })
   useEffect(() => {
     const timers = measurableBackgroundWorktreeTimersRef.current
     const closeDialogDebounceTimers = closeDialogDebounceTimersRef.current
@@ -1350,7 +1387,30 @@ function Terminal(): React.JSX.Element | null {
             pairedRuntimeParkingEnvironmentIds
           })
         : terminalProviderHasAuthoritativeSnapshot(ptyId)
-    if (lastActivationWorktreeIdRef.current !== renderedActiveWorktreeId) {
+    // Before the branch: it reads the pre-activation ref that the cold pass overwrites.
+    const isColdActivationPass = lastActivationWorktreeIdRef.current !== renderedActiveWorktreeId
+    const priorMountRestriction =
+      backgroundMountTabIdsByWorktreeRef.current.get(renderedActiveWorktreeId)
+    const worktreeWasMounted = mountedWorktreeIdsRef.current.has(renderedActiveWorktreeId)
+    const spawnHoldPlan = planRestoredTerminalSpawnHold({
+      holdByWorktreeId: restoredSpawnHoldByWorktreeRef.current,
+      worktreeId: renderedActiveWorktreeId,
+      environmentId: spawnHoldEnvironmentId,
+      evidence: readRestoredSpawnHoldEvidence(
+        spawnHoldEnvironmentId ?? '',
+        renderedActiveWorktreeId
+      ),
+      isColdActivationPass,
+      nowMs: Date.now(),
+      allTabs: worktreeTabs,
+      wouldSpawnHostTerminal: (tab) =>
+        willRestoredTabSpawnHostTerminal(tab, useAppStore.getState()),
+      immediateTabIds,
+      isTabLive: hasRegisteredRuntimeTerminalTab,
+      // Same rule as applyBackgroundMountTabRestriction: never narrow out a tab an earlier pass mounted.
+      hasMountedTab: (tabId) => worktreeWasMounted && (priorMountRestriction?.has(tabId) ?? true)
+    })
+    if (isColdActivationPass) {
       lastActivationWorktreeIdRef.current = renderedActiveWorktreeId
       const tabById = new Map(worktreeTabs.map((tab) => [tab.id, tab]))
       planColdActivationTabDeferral({
@@ -1377,7 +1437,7 @@ function Terminal(): React.JSX.Element | null {
         immediateTabIds
       })
     } else if (!coldActivationDeferralEnabled || !activationHostSupportsDeferral) {
-      // Why: kill-switch or host-ownership change while active must restore eager mounting, not strand an old restriction.
+      // Why: disable only watcher deferral here; the spawn-safety hold below is independent.
       backgroundMountTabIdsByWorktreeRef.current.delete(renderedActiveWorktreeId)
       activationDeferredMountTabIdsByWorktreeRef.current.delete(renderedActiveWorktreeId)
     } else {
@@ -1401,6 +1461,13 @@ function Terminal(): React.JSX.Element | null {
         immediateTabIds
       })
     }
+    applyRestoredTerminalSpawnHold({
+      restrictions: backgroundMountTabIdsByWorktreeRef.current,
+      deferredMountTabIdsByWorktree: activationDeferredMountTabIdsByWorktreeRef.current,
+      worktreeId: renderedActiveWorktreeId,
+      allTabIds: worktreeTabs.map((tab) => tab.id),
+      plan: spawnHoldPlan
+    })
     mountedWorktreeIdsRef.current.add(renderedActiveWorktreeId)
   } else {
     // Why: reset so the next ready activation re-runs the deferral decision even for the same worktree.
@@ -1419,6 +1486,7 @@ function Terminal(): React.JSX.Element | null {
       mountedWorktreeIdsRef.current.delete(id)
       backgroundMountTabIdsByWorktreeRef.current.delete(id)
       activationDeferredMountTabIdsByWorktreeRef.current.delete(id)
+      restoredSpawnHoldByWorktreeRef.current.delete(id)
     }
   }
   const anyMountedWorktreeHasLayout = computeAnyMountedWorktreeHasLayout(

--- a/src/renderer/src/components/terminal/restored-terminal-spawn-hold.render.test.tsx
+++ b/src/renderer/src/components/terminal/restored-terminal-spawn-hold.render.test.tsx
@@ -1,0 +1,591 @@
+/** @vitest-environment happy-dom */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAppStore } from '@/store'
+import { ConfirmationDialogContext } from '../confirmation-dialog-context'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import {
+  setActivityTerminalPortals,
+  type ActivityTerminalPortalTarget
+} from '../activity/activity-terminal-portal'
+import type { Tab, TabGroup, TabGroupLayoutNode } from '../../../../shared/tab-types'
+import type { TerminalTab } from '../../../../shared/terminal-tab-types'
+import type { RuntimeMobileSessionTabsResult } from '../../../../shared/runtime-types'
+import {
+  acceptReplayedWebSessionTabsSnapshot,
+  applyWebSessionTabsSnapshots,
+  applyWebSessionTabsStorePatch,
+  decideWebSessionTabsSnapshot,
+  resetWebSessionTabsSnapshotFreshnessForTests
+} from '../../runtime/web-session-tabs-sync'
+import { resetHostSessionMirrorHydrationForTests } from '../../runtime/host-session-mirror-hydration'
+import { clearRuntimeEnvironmentConnectionGenerationsForTests } from '@/store/slices/runtime-status'
+import { RESTORED_TERMINAL_SPAWN_HOLD_TIMEOUT_MS } from './restored-terminal-spawn-hold'
+
+// Why a marker: the oracle is which tabs Terminal.tsx actually instantiates a
+// pane for. A helper-level assertion would still pass with the wiring deleted.
+vi.mock('../terminal-pane/TerminalPane', () => ({
+  default: ({ tabId }: { tabId: string }) => <div data-mounted-tab={tabId} />
+}))
+// The tab strip needs app-level providers and decides nothing about mounting.
+vi.mock('../tab-bar/TabBar', () => ({ default: () => null }))
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+/** Terminal reaches for a wide slice of window.api on mount; none of it decides
+ *  mounting, so every member answers as an inert callable. */
+function inertApi(): unknown {
+  return new Proxy(function (): void {}, {
+    get: (_target, property) => (typeof property === 'symbol' ? undefined : inertApi()),
+    apply: () => inertApi()
+  })
+}
+
+const WORKTREE_ID = 'wt-paired'
+const OTHER_WORKTREE_ID = 'wt-other'
+const ENVIRONMENT_ID = 'env-1'
+const SPAWNING_TAB_IDS = ['row-1', 'row-2', 'row-3', 'row-4', 'row-5']
+/** The mirrored and pty-owning rows attach instead of spawning; the pre-existing
+ *  coverage deferral independently decides those, so the oracle is the spawn
+ *  class alone — exactly the rows this gate governs. */
+/** The seeded workspace has no active tab, so useActiveTerminalRepair selects the
+ *  first row — and the visible tab is never withheld. */
+const SHOWN_ONLY = ['row-1']
+
+function terminalTab(id: string, worktreeId = WORKTREE_ID): TerminalTab {
+  return {
+    id,
+    worktreeId,
+    title: id,
+    ptyId: null,
+    createdAt: 0,
+    sortOrder: 0
+  } as unknown as TerminalTab
+}
+
+/** The persisted rows of a paired workspace reopened after a restart: five
+ *  local-uuid rows with no pty anywhere (the spawn class), one mirrored row and
+ *  one row whose layout leaf still owns a remote pty (both attach instead). */
+const RESTORED_TABS: TerminalTab[] = [
+  ...SPAWNING_TAB_IDS.map((id) => terminalTab(id)),
+  terminalTab('web-terminal-mirrored'),
+  terminalTab('row-adoptable')
+]
+
+function hostSnapshot(
+  worktree: string,
+  overrides: Partial<RuntimeMobileSessionTabsResult> = {}
+): RuntimeMobileSessionTabsResult {
+  return {
+    worktree,
+    publicationEpoch: 'epoch-1',
+    snapshotVersion: 1,
+    activeGroupId: null,
+    activeTabId: null,
+    activeTabType: null,
+    tabs: [],
+    ...overrides
+  }
+}
+
+/** Drives the shipping accept path and its settle receipt, so the hold sees an
+ *  answer only for frames the store really took. Raw: the `deliver*` wrappers add
+ *  the act boundary, and a test needing several events to land with no render
+ *  between them composes these directly inside one act block. */
+function applyHostSnapshots(
+  snapshots: readonly RuntimeMobileSessionTabsResult[],
+  environmentId: string,
+  fullInventory: boolean
+): void {
+  const decisions = snapshots.map((snapshot) =>
+    decideWebSessionTabsSnapshot(snapshot, environmentId)
+  )
+  const fresh = snapshots.filter((_snapshot, index) => decisions[index]!.apply)
+  const settleMirror = applyWebSessionTabsStorePatch(
+    (state) => applyWebSessionTabsSnapshots(state, fresh, environmentId),
+    {
+      frames: snapshots.map((snapshot, index) => ({
+        environmentId,
+        worktreeId: snapshot.worktree,
+        decision: decisions[index]!
+      })),
+      ...(fullInventory
+        ? { fullInventory: { environmentId, publishedSnapshotCount: snapshots.length } }
+        : {})
+    }
+  )
+  settleMirror()
+}
+
+/** Raw: a new runtime process. The store action is what advances the canonical
+ *  connection generation the hydration latch scopes its verdicts to. */
+function connectRuntime(runtimeId: string): void {
+  useAppStore
+    .getState()
+    .setRuntimeEnvironmentStatus(ENVIRONMENT_ID, { status: { runtimeId }, checkedAt: 0 } as never)
+}
+
+/** One subscribed worktree's frame: it speaks for that worktree and no other. */
+async function deliverHostFrame(
+  snapshot: RuntimeMobileSessionTabsResult,
+  environmentId = ENVIRONMENT_ID
+): Promise<void> {
+  await act(async () => {
+    applyHostSnapshots([snapshot], environmentId, false)
+  })
+}
+
+/** The listAll/subscribeAll shape: one patch carrying the whole enumeration, so
+ *  absence from it is itself the host answering. */
+async function deliverHostInventory(
+  snapshots: readonly RuntimeMobileSessionTabsResult[]
+): Promise<void> {
+  await act(async () => {
+    applyHostSnapshots(snapshots, ENVIRONMENT_ID, true)
+  })
+}
+
+/** A reconnect can repeat the frame the client already holds; the shipping
+ *  stream arms the replay before offering it to the accept path. */
+async function deliverReplayedHostFrame(snapshot: RuntimeMobileSessionTabsResult): Promise<void> {
+  await act(async () => {
+    acceptReplayedWebSessionTabsSnapshot(ENVIRONMENT_ID, snapshot.worktree)
+    applyHostSnapshots([snapshot], ENVIRONMENT_ID, false)
+  })
+}
+
+async function reconnect(runtimeId: string): Promise<void> {
+  await act(async () => {
+    connectRuntime(runtimeId)
+  })
+}
+
+/** Re-pairing points the workspace at another runtime environment. */
+async function moveWorktreeToHost(hostId: string): Promise<void> {
+  await act(async () => {
+    useAppStore.setState(
+      (state) =>
+        ({
+          worktreesByRepo: {
+            'repo-1': (state.worktreesByRepo['repo-1'] ?? []).map((worktree) =>
+              worktree.id === WORKTREE_ID ? { ...worktree, hostId } : worktree
+            )
+          }
+        }) as never
+    )
+  })
+}
+
+/** A split group holding one active tab; `activeTabId` is a unified-tab id on
+ *  current sessions and a raw terminal id on ones persisted before that split. */
+function tabGroup(id: string, activeTabId: string): TabGroup {
+  return { id, worktreeId: WORKTREE_ID, activeTabId, tabOrder: [activeTabId] }
+}
+
+function unifiedTerminalTab(id: string, entityId: string, groupId: string): Tab {
+  return {
+    id,
+    entityId,
+    groupId,
+    worktreeId: WORKTREE_ID,
+    contentType: 'terminal',
+    label: entityId,
+    customLabel: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0
+  }
+}
+
+/** An Activity thread portaling one terminal leaf into its own surface. */
+function activityPortal(tabId: string, target: HTMLElement): ActivityTerminalPortalTarget {
+  return {
+    slotId: `slot-${tabId}`,
+    requestToken: `token-${tabId}`,
+    target,
+    worktreeId: WORKTREE_ID,
+    tabId,
+    paneKey: `pane-${tabId}`,
+    active: true
+  }
+}
+
+function seedStore(
+  overrides: {
+    runtimeStatus?: { status: unknown; checkedAt: number } | null
+    activeTabId?: string | null
+    activeWorktreeId?: string
+    activeView?: string
+    pendingStartupByTabId?: Record<string, unknown>
+    groups?: readonly TabGroup[]
+    unifiedTabs?: readonly Tab[]
+    activeGroupId?: string
+    layout?: TabGroupLayoutNode
+    /** Runtime environment that owns the worktree under test. */
+    hostId?: string
+    /** Further environments that are paired and live at the same time. */
+    alsoLiveEnvironmentIds?: readonly string[]
+  } = {}
+): void {
+  const runtimeStatus =
+    overrides.runtimeStatus === undefined
+      ? { status: { runtimeId: 'rt-1' }, checkedAt: 0 }
+      : overrides.runtimeStatus
+  const runtimeStatusByEnvironmentId = new Map<string, unknown>(
+    runtimeStatus ? [[ENVIRONMENT_ID, runtimeStatus]] : []
+  )
+  for (const environmentId of overrides.alsoLiveEnvironmentIds ?? []) {
+    runtimeStatusByEnvironmentId.set(environmentId, {
+      status: { runtimeId: `rt-${environmentId}` },
+      checkedAt: 0
+    })
+  }
+  useAppStore.setState({
+    worktreesByRepo: {
+      'repo-1': [
+        {
+          id: WORKTREE_ID,
+          repoId: 'repo-1',
+          path: '/tmp/wt',
+          hostId: overrides.hostId ?? `runtime:${ENVIRONMENT_ID}`
+        },
+        {
+          id: OTHER_WORKTREE_ID,
+          repoId: 'repo-1',
+          path: '/tmp/wt-other',
+          hostId: `runtime:${ENVIRONMENT_ID}`
+        }
+      ]
+    },
+    folderWorkspaces: [],
+    activeWorktreeId: overrides.activeWorktreeId ?? WORKTREE_ID,
+    activeWorkspaceExecutionHostId: null,
+    activeView: overrides.activeView ?? 'terminal',
+    activeTabType: 'terminal',
+    activeTabId: overrides.activeTabId === undefined ? null : overrides.activeTabId,
+    activeTabIdByWorktree: {},
+    tabsByWorktree: { [WORKTREE_ID]: RESTORED_TABS, [OTHER_WORKTREE_ID]: [] },
+    unifiedTabsByWorktree: overrides.unifiedTabs ? { [WORKTREE_ID]: overrides.unifiedTabs } : {},
+    groupsByWorktree: overrides.groups ? { [WORKTREE_ID]: overrides.groups } : {},
+    layoutByWorktree: overrides.layout ? { [WORKTREE_ID]: overrides.layout } : {},
+    activeGroupIdByWorktree: overrides.activeGroupId
+      ? { [WORKTREE_ID]: overrides.activeGroupId }
+      : {},
+    terminalLayoutsByTabId: {
+      'row-adoptable': {
+        ptyIdsByLeafId: { '11111111-1111-4111-8111-111111111111': `remote:${ENVIRONMENT_ID}:pty-9` }
+      }
+    },
+    pendingStartupByTabId: overrides.pendingStartupByTabId ?? {},
+    openFiles: [],
+    browserTabsByWorktree: {},
+    workspaceSessionReady: true,
+    hydrationSucceeded: true,
+    startupWorktreeRefreshCompleted: true,
+    runtimeStatusByEnvironmentId
+  } as never)
+}
+
+const confirmStub = async (): Promise<boolean> => true
+
+let root: Root | null = null
+let host: HTMLDivElement | null = null
+let portalHost: HTMLDivElement | null = null
+
+/** The Activity surface element a portaled pane renders into. */
+function portalTarget(): HTMLDivElement {
+  if (!portalHost) {
+    portalHost = document.createElement('div')
+    document.body.appendChild(portalHost)
+  }
+  return portalHost
+}
+
+async function renderTerminal(): Promise<HTMLDivElement> {
+  const { default: Terminal } = await import('@/components/Terminal')
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+  await act(async () => {
+    root?.render(
+      // Both providers are App-level; split-group chrome renders tooltips.
+      <TooltipProvider>
+        <ConfirmationDialogContext.Provider value={confirmStub}>
+          <Terminal />
+        </ConfirmationDialogContext.Provider>
+      </TooltipProvider>
+    )
+  })
+  return host
+}
+
+function mountedTabIds(container: HTMLElement): string[] {
+  return [...container.querySelectorAll('[data-mounted-tab]')]
+    .map((node) => node.getAttribute('data-mounted-tab') ?? '')
+    .sort()
+}
+
+/** Mounting one of these issues terminal.create against the paired host. */
+function mountedSpawnRows(container: HTMLElement): string[] {
+  return mountedTabIds(container).filter((tabId) => SPAWNING_TAB_IDS.includes(tabId))
+}
+
+async function advanceBy(ms: number): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms)
+  })
+}
+
+async function advancePastDeadline(): Promise<void> {
+  await advanceBy(RESTORED_TERMINAL_SPAWN_HOLD_TIMEOUT_MS + 1_000)
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  resetWebSessionTabsSnapshotFreshnessForTests()
+  resetHostSessionMirrorHydrationForTests()
+  clearRuntimeEnvironmentConnectionGenerationsForTests()
+  ;(window as unknown as { api: unknown }).api = inertApi()
+})
+
+afterEach(() => {
+  act(() => root?.unmount())
+  host?.remove()
+  portalHost?.remove()
+  setActivityTerminalPortals([])
+  root = null
+  host = null
+  portalHost = null
+  vi.useRealTimers()
+})
+
+describe('Terminal restored spawn hold (render seam)', () => {
+  it('withholds restored pty-less rows on a paired worktree until the host answers', async () => {
+    seedStore()
+    const container = await renderTerminal()
+    expect(mountedSpawnRows(container)).toEqual(SHOWN_ONLY)
+  })
+
+  it('always mounts the active tab and any queued startup, even while holding', async () => {
+    seedStore({ activeTabId: 'row-1', pendingStartupByTabId: { 'row-2': { command: 'echo hi' } } })
+    const container = await renderTerminal()
+    // row-1 is visible and row-2 has a startup command with nowhere else to run.
+    expect(mountedSpawnRows(container)).toEqual(['row-1', 'row-2'])
+  })
+
+  it('never holds a group active tab, through the unified tab or the raw id', async () => {
+    // Split mode shows every group's active tab at once, so none may defer. group-1
+    // stores the unified-tab id (current sessions); group-2 stores the entity id.
+    seedStore({
+      activeTabId: 'row-1',
+      groups: [tabGroup('group-1', 'unified-row-2'), tabGroup('group-2', 'row-3')],
+      unifiedTabs: [unifiedTerminalTab('unified-row-2', 'row-2', 'group-1')],
+      activeGroupId: 'group-1',
+      layout: {
+        type: 'split',
+        direction: 'horizontal',
+        first: { type: 'leaf', groupId: 'group-1' },
+        second: { type: 'leaf', groupId: 'group-2' }
+      }
+    })
+    const container = await renderTerminal()
+    expect(mountedSpawnRows(container)).toEqual(['row-1', 'row-2', 'row-3'])
+  })
+
+  it('never holds a tab an activity thread is portaling', async () => {
+    // The portaled pane renders into the Activity surface, not the workspace tree.
+    seedStore({ activeTabId: 'row-1', activeView: 'activity' })
+    setActivityTerminalPortals([activityPortal('row-4', portalTarget())])
+    const container = await renderTerminal()
+    expect([...mountedSpawnRows(container), ...mountedSpawnRows(portalTarget())].sort()).toEqual([
+      'row-1',
+      'row-4'
+    ])
+  })
+
+  it('mounts the attach-class rows the gate does not govern', async () => {
+    seedStore()
+    const container = await renderTerminal()
+    // Mirrored and pty-owning rows cannot spawn, so holding them buys nothing.
+    expect(mountedSpawnRows(container)).toEqual(SHOWN_ONLY)
+    expect(mountedTabIds(container)).toContain('web-terminal-mirrored')
+    expect(mountedTabIds(container)).toContain('row-adoptable')
+  })
+
+  it('does not blank a paired workspace whose runtime is merely disconnected', async () => {
+    // A failed probe stores status null: a reachable id, no liveness. The gate
+    // still arms — a probe blip must not spend the only cold pass — but the
+    // workspace keeps its visible pane and fails open on its own.
+    seedStore({ runtimeStatus: { status: null, checkedAt: 0 } })
+    const container = await renderTerminal()
+    expect(mountedSpawnRows(container)).toEqual(SHOWN_ONLY)
+    await advancePastDeadline()
+    expect(mountedSpawnRows(container)).toEqual(SPAWNING_TAB_IDS)
+  })
+
+  it('holds when no probe has landed yet and settles once the answer arrives', async () => {
+    // Slow start: workspaceSessionReady is true before any status exists.
+    seedStore({ runtimeStatus: null })
+    const container = await renderTerminal()
+    expect(mountedSpawnRows(container)).toEqual(SHOWN_ONLY)
+    await reconnect('rt-1')
+    await deliverHostFrame(hostSnapshot(WORKTREE_ID))
+    await advancePastDeadline()
+    expect(mountedSpawnRows(container)).toEqual(SHOWN_ONLY)
+  })
+
+  it('waits on the environment that owns the worktree, not any live one', async () => {
+    seedStore({ hostId: 'runtime:env-2', alsoLiveEnvironmentIds: ['env-2'] })
+    const container = await renderTerminal()
+    expect(mountedSpawnRows(container)).toEqual(SHOWN_ONLY)
+    // An answer from the other paired environment says nothing about this one.
+    await deliverHostFrame(hostSnapshot(WORKTREE_ID), ENVIRONMENT_ID)
+    await advancePastDeadline()
+    expect(mountedSpawnRows(container)).toEqual(SPAWNING_TAB_IDS)
+  })
+
+  it('settles on an answer from the environment that owns the worktree', async () => {
+    seedStore({ hostId: 'runtime:env-2', alsoLiveEnvironmentIds: ['env-2'] })
+    const container = await renderTerminal()
+    await deliverHostFrame(hostSnapshot(WORKTREE_ID), 'env-2')
+    await advancePastDeadline()
+    expect(mountedSpawnRows(container)).toEqual(SHOWN_ONLY)
+  })
+
+  it('fails open and mounts held rows when no answer ever arrives', async () => {
+    seedStore()
+    const container = await renderTerminal()
+    expect(mountedSpawnRows(container)).toEqual(SHOWN_ONLY)
+    await advancePastDeadline()
+    expect(mountedSpawnRows(container)).toEqual(SPAWNING_TAB_IDS)
+  })
+
+  it('measures its silence from the live connection, not the one it armed on', async () => {
+    seedStore()
+    const container = await renderTerminal()
+    const halfWindow = RESTORED_TERMINAL_SPAWN_HOLD_TIMEOUT_MS / 2
+    await advanceBy(halfWindow)
+    await reconnect('rt-2')
+    // Past the first window's deadline, but this connection has not been silent
+    // that long: a reconnect owes the hold a fresh window.
+    await advanceBy(halfWindow + 1_000)
+    expect(mountedSpawnRows(container)).toEqual(SHOWN_ONLY)
+    await advancePastDeadline()
+    expect(mountedSpawnRows(container)).toEqual(SPAWNING_TAB_IDS)
+  })
+
+  it('starts a fresh window when the workspace moves to a host at the same generation', async () => {
+    // Neither environment has connected in this test, so both sit at generation 0:
+    // only host identity separates the two epochs.
+    seedStore({ alsoLiveEnvironmentIds: ['env-2'] })
+    const container = await renderTerminal()
+    await advanceBy(RESTORED_TERMINAL_SPAWN_HOLD_TIMEOUT_MS - 2_000)
+    await moveWorktreeToHost('runtime:env-2')
+    // Past the first host's deadline, but env-2 has been silent for 2s, not 20s.
+    await advanceBy(4_000)
+    expect(mountedSpawnRows(container)).toEqual(SHOWN_ONLY)
+    await advancePastDeadline()
+    expect(mountedSpawnRows(container)).toEqual(SPAWNING_TAB_IDS)
+  })
+
+  it('never lets the previous host answer for the one the workspace moved to', async () => {
+    seedStore({ alsoLiveEnvironmentIds: ['env-2'] })
+    const container = await renderTerminal()
+    expect(mountedSpawnRows(container)).toEqual(SHOWN_ONLY)
+    await deliverHostFrame(hostSnapshot(WORKTREE_ID))
+    await moveWorktreeToHost('runtime:env-2')
+    // Inheriting env-1's verdict would leave this workspace dark forever on a host
+    // that never answered, which is exactly the wedge a mount gate must not cause.
+    await advancePastDeadline()
+    expect(mountedSpawnRows(container)).toEqual(SPAWNING_TAB_IDS)
+  })
+
+  it('keeps rows dark past the deadline once an empty snapshot proves them dead', async () => {
+    seedStore()
+    const container = await renderTerminal()
+    // The answer patches no held row into the store; only a later render sees it.
+    await deliverHostFrame(hostSnapshot(WORKTREE_ID))
+    await advancePastDeadline()
+    expect(mountedSpawnRows(container)).toEqual(SHOWN_ONLY)
+  })
+
+  it('settles on a full inventory that covers the worktree', async () => {
+    seedStore()
+    const container = await renderTerminal()
+    await deliverHostInventory([hostSnapshot(OTHER_WORKTREE_ID), hostSnapshot(WORKTREE_ID)])
+    await advancePastDeadline()
+    expect(mountedSpawnRows(container)).toEqual(SHOWN_ONLY)
+  })
+
+  it('settles on a full inventory that omits the worktree', async () => {
+    // An inventory enumerates every worktree the host knows, so omission is an
+    // answer too: these rows exist on no host session.
+    seedStore()
+    const container = await renderTerminal()
+    await deliverHostInventory([hostSnapshot(OTHER_WORKTREE_ID)])
+    await advancePastDeadline()
+    expect(mountedSpawnRows(container)).toEqual(SHOWN_ONLY)
+  })
+
+  it('does not settle on a single frame published for another worktree', async () => {
+    seedStore()
+    const container = await renderTerminal()
+    expect(mountedSpawnRows(container)).toEqual(SHOWN_ONLY)
+    await deliverHostFrame(hostSnapshot(OTHER_WORKTREE_ID))
+    await advancePastDeadline()
+    expect(mountedSpawnRows(container)).toEqual(SPAWNING_TAB_IDS)
+  })
+
+  it('settles on a reconnect replay of the frame it already held', async () => {
+    // Identity repeats across a reconnect; the receipt does not.
+    seedStore()
+    await deliverHostFrame(hostSnapshot(WORKTREE_ID))
+    const container = await renderTerminal()
+    await reconnect('rt-2')
+    await deliverReplayedHostFrame(hostSnapshot(WORKTREE_ID))
+    await advancePastDeadline()
+    expect(mountedSpawnRows(container)).toEqual(SHOWN_ONLY)
+  })
+
+  it('does not carry an answer from the previous connection into a new hold', async () => {
+    seedStore()
+    const container = await renderTerminal()
+    expect(mountedSpawnRows(container)).toEqual(SHOWN_ONLY)
+    // One batch, so no render observes the answer while its connection is still
+    // current: the client only ever sees it stamped with a superseded generation.
+    await act(async () => {
+      applyHostSnapshots([hostSnapshot(WORKTREE_ID)], ENVIRONMENT_ID, false)
+      connectRuntime('rt-2')
+    })
+    await advancePastDeadline()
+    expect(mountedSpawnRows(container)).toEqual(SPAWNING_TAB_IDS)
+  })
+
+  it('settles on evidence this connection already accepted before the hold armed', async () => {
+    // Reopening a workspace the host answered for must not run the storm late.
+    seedStore()
+    await deliverHostFrame(hostSnapshot(WORKTREE_ID))
+    const container = await renderTerminal()
+    expect(mountedSpawnRows(container)).toEqual(SHOWN_ONLY)
+    await advancePastDeadline()
+    expect(mountedSpawnRows(container)).toEqual(SHOWN_ONLY)
+  })
+
+  it('never re-holds rows a previous activation already mounted', async () => {
+    seedStore()
+    const container = await renderTerminal()
+    expect(mountedSpawnRows(container)).toEqual(SHOWN_ONLY)
+    await advancePastDeadline()
+    expect(mountedSpawnRows(container)).toEqual(SPAWNING_TAB_IDS)
+    // Reconnect, then leave and re-enter so a fresh activation pass runs.
+    await reconnect('rt-2')
+    await act(async () => {
+      useAppStore.setState({ activeWorktreeId: OTHER_WORKTREE_ID } as never)
+    })
+    await act(async () => {
+      useAppStore.setState({ activeWorktreeId: WORKTREE_ID } as never)
+    })
+    expect(mountedSpawnRows(container)).toEqual(SPAWNING_TAB_IDS)
+  })
+})

--- a/src/renderer/src/components/terminal/restored-terminal-spawn-hold.test.ts
+++ b/src/renderer/src/components/terminal/restored-terminal-spawn-hold.test.ts
@@ -1,0 +1,398 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { WEB_SESSION_TABS_RPC_TIMEOUT_MS } from '../../runtime/web-session-tabs-sync'
+import {
+  markHostSessionMirrorWorktreeHydrated,
+  resetHostSessionMirrorHydrationForTests
+} from '../../runtime/host-session-mirror-hydration'
+import {
+  applyRestoredTerminalSpawnHold,
+  planRestoredTerminalSpawnHold,
+  readRestoredSpawnHoldEvidence,
+  RESTORED_TERMINAL_SPAWN_HOLD_MAX_TOTAL_MS,
+  RESTORED_TERMINAL_SPAWN_HOLD_TIMEOUT_MS,
+  willRestoredTabSpawnHostTerminal,
+  type RestoredSpawnHoldEntry,
+  type RestoredSpawnHoldPaneState,
+  type RestoredSpawnHoldTab
+} from './restored-terminal-spawn-hold'
+
+const WORKTREE_ID = 'wt-1'
+const ENVIRONMENT_ID = 'env-1'
+const GENERATION = 1
+const NEXT_GENERATION = 2
+const WAITING = { connectionGeneration: GENERATION, hostAnswered: false }
+const ANSWERED = { connectionGeneration: GENERATION, hostAnswered: true }
+const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+const TABS: RestoredSpawnHoldTab[] = [
+  { id: 'row-1', ptyId: null },
+  { id: 'row-2', ptyId: null }
+]
+
+function plan(
+  overrides: Partial<Parameters<typeof planRestoredTerminalSpawnHold>[0]> = {}
+): ReturnType<typeof planRestoredTerminalSpawnHold> {
+  return planRestoredTerminalSpawnHold({
+    holdByWorktreeId: new Map<string, RestoredSpawnHoldEntry>(),
+    worktreeId: WORKTREE_ID,
+    environmentId: ENVIRONMENT_ID,
+    evidence: WAITING,
+    isColdActivationPass: true,
+    nowMs: 1_000,
+    allTabs: TABS,
+    wouldSpawnHostTerminal: () => true,
+    immediateTabIds: new Set<string>(),
+    isTabLive: () => false,
+    hasMountedTab: () => false,
+    ...overrides
+  })
+}
+
+function paneState(
+  overrides: Partial<RestoredSpawnHoldPaneState> = {}
+): RestoredSpawnHoldPaneState {
+  return {
+    terminalLayoutsByTabId: {},
+    runtimePaneTitlesByTabId: {},
+    ptyIdsByTabId: {},
+    ...overrides
+  } as RestoredSpawnHoldPaneState
+}
+
+describe('willRestoredTabSpawnHostTerminal', () => {
+  it('is true only for a row with no pty anywhere', () => {
+    expect(willRestoredTabSpawnHostTerminal({ id: 'row-1', ptyId: null }, paneState())).toBe(true)
+    expect(willRestoredTabSpawnHostTerminal({ id: 'row-1', ptyId: 'pty-1' }, paneState())).toBe(
+      false
+    )
+    // Mirrored rows route to the host-session mirror, which has no create path.
+    expect(
+      willRestoredTabSpawnHostTerminal({ id: 'web-terminal-1', ptyId: null }, paneState())
+    ).toBe(false)
+    expect(
+      willRestoredTabSpawnHostTerminal(
+        { id: 'row-1', ptyId: null },
+        paneState({ ptyIdsByTabId: { 'row-1': ['remote:env-1:pty-2'] } })
+      )
+    ).toBe(false)
+    // A persisted layout leaf that still owns a pty attaches instead of spawning.
+    expect(
+      willRestoredTabSpawnHostTerminal(
+        { id: 'row-1', ptyId: null },
+        paneState({
+          terminalLayoutsByTabId: {
+            'row-1': {
+              root: null,
+              activeLeafId: LEAF_ID,
+              expandedLeafId: null,
+              ptyIdsByLeafId: { [LEAF_ID]: 'remote:env-1:pty-3' }
+            }
+          }
+        })
+      )
+    ).toBe(false)
+  })
+})
+
+describe('restored spawn hold deadline', () => {
+  it('outlasts the session.tabs timeout it waits on', () => {
+    // A reply at 12s must not lose to a fail-open at 10s.
+    expect(RESTORED_TERMINAL_SPAWN_HOLD_TIMEOUT_MS).toBeGreaterThan(WEB_SESSION_TABS_RPC_TIMEOUT_MS)
+    expect(RESTORED_TERMINAL_SPAWN_HOLD_MAX_TOTAL_MS).toBeGreaterThanOrEqual(
+      RESTORED_TERMINAL_SPAWN_HOLD_TIMEOUT_MS
+    )
+  })
+})
+
+describe('planRestoredTerminalSpawnHold', () => {
+  it('arms only on the activation pass', () => {
+    expect([...plan().heldTabIds]).toEqual(['row-1', 'row-2'])
+    expect([...plan({ isColdActivationPass: false }).heldTabIds]).toEqual([])
+  })
+
+  it('never holds a carve-out row', () => {
+    expect([...plan({ immediateTabIds: new Set(['row-1']) }).heldTabIds]).toEqual(['row-2'])
+    expect([...plan({ isTabLive: (tabId) => tabId === 'row-1' }).heldTabIds]).toEqual(['row-2'])
+    expect([...plan({ hasMountedTab: (tabId) => tabId === 'row-1' }).heldTabIds]).toEqual(['row-2'])
+    expect([...plan({ wouldSpawnHostTerminal: (tab) => tab.id !== 'row-1' }).heldTabIds]).toEqual([
+      'row-2'
+    ])
+  })
+
+  it('holds nothing on a local, ssh or folder workspace', () => {
+    // Those resolve no runtime environment, so the hold can never scope itself.
+    const holdByWorktreeId = new Map<string, RestoredSpawnHoldEntry>()
+    const result = plan({ holdByWorktreeId, environmentId: null })
+    expect(result.heldTabIds.size).toBe(0)
+    expect(holdByWorktreeId.size).toBe(0)
+  })
+
+  it('arms before any probe has landed and settles when the answer arrives', () => {
+    // Slow startup: workspaceSessionReady is true while runtimeStatus is absent, so
+    // the environment still sits at its initial generation.
+    const holdByWorktreeId = new Map<string, RestoredSpawnHoldEntry>()
+    const armed = plan({
+      holdByWorktreeId,
+      evidence: { connectionGeneration: 0, hostAnswered: false }
+    })
+    expect([...armed.heldTabIds]).toEqual(['row-1', 'row-2'])
+    plan({ holdByWorktreeId, evidence: ANSWERED, isColdActivationPass: false, nowMs: 2_000 })
+    expect(holdByWorktreeId.get(WORKTREE_ID)?.settled).toBe(true)
+  })
+
+  it('keeps the clock running through a disconnect instead of restarting it', () => {
+    // A dropped connection leaves the generation alone, so an unanswered hold on a
+    // merely disconnected workspace still reaches its deadline and fails open.
+    const holdByWorktreeId = new Map<string, RestoredSpawnHoldEntry>()
+    plan({ holdByWorktreeId })
+    const disconnected = plan({ holdByWorktreeId, isColdActivationPass: false, nowMs: 2_000 })
+    expect([...disconnected.heldTabIds]).toEqual(['row-1', 'row-2'])
+    const timedOut = plan({
+      holdByWorktreeId,
+      isColdActivationPass: false,
+      nowMs: 1_000 + RESTORED_TERMINAL_SPAWN_HOLD_TIMEOUT_MS
+    })
+    expect([...timedOut.heldTabIds]).toEqual([])
+  })
+
+  it('settles at once on evidence already accepted for this connection', () => {
+    // Reactivating a worktree the host answered for must not run the storm late.
+    const holdByWorktreeId = new Map<string, RestoredSpawnHoldEntry>()
+    plan({ holdByWorktreeId, evidence: ANSWERED })
+    expect(holdByWorktreeId.get(WORKTREE_ID)?.settled).toBe(true)
+    const later = plan({
+      holdByWorktreeId,
+      evidence: ANSWERED,
+      isColdActivationPass: false,
+      nowMs: 1_000_000
+    })
+    expect([...later.heldTabIds]).toEqual(['row-1', 'row-2'])
+  })
+
+  it('ignores evidence stamped with a previous connection', () => {
+    const holdByWorktreeId = new Map<string, RestoredSpawnHoldEntry>()
+    // hostAnswered:false is what the generation-scoped latch reports once the
+    // generation moved on, so the earlier answer cannot settle the new window.
+    plan({
+      holdByWorktreeId,
+      evidence: { connectionGeneration: NEXT_GENERATION, hostAnswered: false }
+    })
+    expect(holdByWorktreeId.get(WORKTREE_ID)?.settled).toBe(false)
+    const timedOut = plan({
+      holdByWorktreeId,
+      evidence: { connectionGeneration: NEXT_GENERATION, hostAnswered: false },
+      isColdActivationPass: false,
+      nowMs: 1_000 + RESTORED_TERMINAL_SPAWN_HOLD_TIMEOUT_MS
+    })
+    expect([...timedOut.heldTabIds]).toEqual([])
+  })
+
+  it('releases and reports the rows it let go when the workspace stops being paired', () => {
+    const holdByWorktreeId = new Map<string, RestoredSpawnHoldEntry>()
+    plan({ holdByWorktreeId })
+    const released = plan({ holdByWorktreeId, environmentId: null })
+    expect([...released.releasedTabIds]).toEqual(['row-1', 'row-2'])
+    expect(holdByWorktreeId.has(WORKTREE_ID)).toBe(false)
+  })
+
+  it('fails open when no answer arrives before the deadline', () => {
+    const holdByWorktreeId = new Map<string, RestoredSpawnHoldEntry>()
+    plan({ holdByWorktreeId })
+    const timedOut = plan({
+      holdByWorktreeId,
+      isColdActivationPass: false,
+      nowMs: 1_000 + RESTORED_TERMINAL_SPAWN_HOLD_TIMEOUT_MS
+    })
+    expect([...timedOut.heldTabIds]).toEqual([])
+    expect([...timedOut.releasedTabIds]).toEqual(['row-1', 'row-2'])
+  })
+
+  it('gives a reconnect a fresh window but never waits past the ceiling', () => {
+    const holdByWorktreeId = new Map<string, RestoredSpawnHoldEntry>()
+    plan({ holdByWorktreeId })
+    // A flapping runtime reconnects faster than the window ever expires, so only
+    // the ceiling can end this hold.
+    const step = RESTORED_TERMINAL_SPAWN_HOLD_TIMEOUT_MS / 2
+    const flap = (generation: number): ReturnType<typeof plan> =>
+      plan({
+        holdByWorktreeId,
+        evidence: { connectionGeneration: generation, hostAnswered: false },
+        isColdActivationPass: false,
+        nowMs: 1_000 + step * (generation - 1)
+      })
+    expect([...flap(2).heldTabIds]).toEqual(['row-1', 'row-2'])
+    expect(holdByWorktreeId.get(WORKTREE_ID)?.windowStartedAtMs).toBe(1_000 + step)
+    for (let generation = 3; generation <= 6; generation++) {
+      expect([...flap(generation).heldTabIds]).toEqual(['row-1', 'row-2'])
+    }
+    expect([...flap(7).heldTabIds]).toEqual([])
+  })
+
+  it('gives a workspace that moved hosts a fresh window at the same generation', () => {
+    // Per-environment generations: env-2's first connection is not a continuation of env-1's.
+    const holdByWorktreeId = new Map<string, RestoredSpawnHoldEntry>()
+    plan({ holdByWorktreeId })
+    const moved = plan({
+      holdByWorktreeId,
+      environmentId: 'env-2',
+      isColdActivationPass: false,
+      nowMs: 1_000 + RESTORED_TERMINAL_SPAWN_HOLD_TIMEOUT_MS
+    })
+    expect([...moved.heldTabIds]).toEqual(['row-1', 'row-2'])
+    expect(holdByWorktreeId.get(WORKTREE_ID)?.windowStartedAtMs).toBe(
+      1_000 + RESTORED_TERMINAL_SPAWN_HOLD_TIMEOUT_MS
+    )
+  })
+
+  it('never lets one host answer speak for a different host', () => {
+    const holdByWorktreeId = new Map<string, RestoredSpawnHoldEntry>()
+    plan({ holdByWorktreeId, evidence: ANSWERED })
+    const moved = plan({
+      holdByWorktreeId,
+      environmentId: 'env-2',
+      isColdActivationPass: false,
+      nowMs: 2_000
+    })
+    expect(holdByWorktreeId.get(WORKTREE_ID)?.settled).toBe(false)
+    expect([...moved.heldTabIds]).toEqual(['row-1', 'row-2'])
+    // Inheriting the verdict would leave the rows dark forever on a host that never answered.
+    const timedOut = plan({
+      holdByWorktreeId,
+      environmentId: 'env-2',
+      isColdActivationPass: false,
+      nowMs: 2_000 + RESTORED_TERMINAL_SPAWN_HOLD_TIMEOUT_MS
+    })
+    expect([...timedOut.heldTabIds]).toEqual([])
+  })
+
+  it('still bounds a workspace that keeps moving hosts by the total ceiling', () => {
+    const holdByWorktreeId = new Map<string, RestoredSpawnHoldEntry>()
+    plan({ holdByWorktreeId })
+    const step = RESTORED_TERMINAL_SPAWN_HOLD_TIMEOUT_MS / 2
+    const moveTo = (index: number): ReturnType<typeof plan> =>
+      plan({
+        holdByWorktreeId,
+        environmentId: `env-${index}`,
+        isColdActivationPass: false,
+        nowMs: 1_000 + step * (index - 1)
+      })
+    for (let index = 2; index <= 6; index++) {
+      expect([...moveTo(index).heldTabIds]).toEqual(['row-1', 'row-2'])
+    }
+    expect([...moveTo(7).heldTabIds]).toEqual([])
+  })
+
+  it('carries a settled verdict across a reconnect', () => {
+    // A local row the host never knew about cannot become host-owned on reconnect.
+    const holdByWorktreeId = new Map<string, RestoredSpawnHoldEntry>()
+    plan({ holdByWorktreeId, evidence: ANSWERED })
+    const afterReconnect = plan({
+      holdByWorktreeId,
+      evidence: { connectionGeneration: NEXT_GENERATION, hostAnswered: false },
+      isColdActivationPass: false,
+      nowMs: 1_000_000
+    })
+    expect([...afterReconnect.heldTabIds]).toEqual(['row-1', 'row-2'])
+  })
+})
+
+describe('readRestoredSpawnHoldEvidence', () => {
+  afterEach(() => resetHostSessionMirrorHydrationForTests())
+
+  it('reads the host answer from the shared mirror-hydration latch', () => {
+    expect(readRestoredSpawnHoldEvidence(ENVIRONMENT_ID, WORKTREE_ID).hostAnswered).toBe(false)
+    markHostSessionMirrorWorktreeHydrated(ENVIRONMENT_ID, WORKTREE_ID)
+    expect(readRestoredSpawnHoldEvidence(ENVIRONMENT_ID, WORKTREE_ID).hostAnswered).toBe(true)
+    // A frame for a sibling workspace is no answer for this one.
+    expect(readRestoredSpawnHoldEvidence(ENVIRONMENT_ID, 'wt-other').hostAnswered).toBe(false)
+  })
+})
+
+describe('applyRestoredTerminalSpawnHold', () => {
+  it('removes held rows from the allowed set and lists them as deferred', () => {
+    const restrictions = new Map<string, ReadonlySet<string>>()
+    const deferredMountTabIdsByWorktree = new Map<string, ReadonlySet<string>>()
+    applyRestoredTerminalSpawnHold({
+      restrictions,
+      deferredMountTabIdsByWorktree,
+      worktreeId: WORKTREE_ID,
+      allTabIds: ['row-1', 'row-2'],
+      plan: { heldTabIds: new Set(['row-2']), releasedTabIds: new Set() }
+    })
+    expect([...(restrictions.get(WORKTREE_ID) ?? [])]).toEqual(['row-1'])
+    expect([...(deferredMountTabIdsByWorktree.get(WORKTREE_ID) ?? [])]).toEqual(['row-2'])
+  })
+
+  it('puts released rows back and drops the restriction once nothing is deferred', () => {
+    const restrictions = new Map<string, ReadonlySet<string>>([[WORKTREE_ID, new Set(['row-1'])]])
+    const deferredMountTabIdsByWorktree = new Map<string, ReadonlySet<string>>([
+      [WORKTREE_ID, new Set(['row-2'])]
+    ])
+    applyRestoredTerminalSpawnHold({
+      restrictions,
+      deferredMountTabIdsByWorktree,
+      worktreeId: WORKTREE_ID,
+      allTabIds: ['row-1', 'row-2'],
+      plan: { heldTabIds: new Set(), releasedTabIds: new Set(['row-2']) }
+    })
+    expect(restrictions.has(WORKTREE_ID)).toBe(false)
+    expect(deferredMountTabIdsByWorktree.has(WORKTREE_ID)).toBe(false)
+  })
+
+  it('keeps both set identities while the held membership is unchanged', () => {
+    // A settled hold re-runs every render; a fresh Set is a new prop identity downstream.
+    const restrictions = new Map<string, ReadonlySet<string>>()
+    const deferredMountTabIdsByWorktree = new Map<string, ReadonlySet<string>>()
+    const apply = (heldTabIds: readonly string[]): void =>
+      applyRestoredTerminalSpawnHold({
+        restrictions,
+        deferredMountTabIdsByWorktree,
+        worktreeId: WORKTREE_ID,
+        allTabIds: ['row-1', 'row-2', 'row-3'],
+        plan: { heldTabIds: new Set(heldTabIds), releasedTabIds: new Set() }
+      })
+    apply(['row-2', 'row-3'])
+    const allowed = restrictions.get(WORKTREE_ID)
+    const deferred = deferredMountTabIdsByWorktree.get(WORKTREE_ID)
+    // Same membership, a different plan object: exactly what a re-render produces.
+    apply(['row-3', 'row-2'])
+    expect(restrictions.get(WORKTREE_ID)).toBe(allowed)
+    expect(deferredMountTabIdsByWorktree.get(WORKTREE_ID)).toBe(deferred)
+  })
+
+  it('replaces both sets when the held membership changes', () => {
+    const restrictions = new Map<string, ReadonlySet<string>>()
+    const deferredMountTabIdsByWorktree = new Map<string, ReadonlySet<string>>()
+    applyRestoredTerminalSpawnHold({
+      restrictions,
+      deferredMountTabIdsByWorktree,
+      worktreeId: WORKTREE_ID,
+      allTabIds: ['row-1', 'row-2', 'row-3'],
+      plan: { heldTabIds: new Set(['row-2', 'row-3']), releasedTabIds: new Set() }
+    })
+    const allowed = restrictions.get(WORKTREE_ID)
+    const deferred = deferredMountTabIdsByWorktree.get(WORKTREE_ID)
+    applyRestoredTerminalSpawnHold({
+      restrictions,
+      deferredMountTabIdsByWorktree,
+      worktreeId: WORKTREE_ID,
+      allTabIds: ['row-1', 'row-2', 'row-3'],
+      plan: { heldTabIds: new Set(['row-3']), releasedTabIds: new Set(['row-2']) }
+    })
+    expect(restrictions.get(WORKTREE_ID)).not.toBe(allowed)
+    expect(deferredMountTabIdsByWorktree.get(WORKTREE_ID)).not.toBe(deferred)
+    expect([...(restrictions.get(WORKTREE_ID) ?? [])]).toEqual(['row-1', 'row-2'])
+    expect([...(deferredMountTabIdsByWorktree.get(WORKTREE_ID) ?? [])]).toEqual(['row-3'])
+  })
+
+  it('leaves an unrelated restriction untouched when nothing is held or released', () => {
+    const restrictions = new Map<string, ReadonlySet<string>>([[WORKTREE_ID, new Set(['row-1'])]])
+    applyRestoredTerminalSpawnHold({
+      restrictions,
+      deferredMountTabIdsByWorktree: new Map(),
+      worktreeId: WORKTREE_ID,
+      allTabIds: ['row-1', 'row-2'],
+      plan: { heldTabIds: new Set(), releasedTabIds: new Set() }
+    })
+    expect([...(restrictions.get(WORKTREE_ID) ?? [])]).toEqual(['row-1'])
+  })
+})

--- a/src/renderer/src/components/terminal/restored-terminal-spawn-hold.ts
+++ b/src/renderer/src/components/terminal/restored-terminal-spawn-hold.ts
@@ -1,0 +1,274 @@
+import { isWebTerminalSurfaceTabId } from '../../../../shared/terminal-surface-id'
+import {
+  resolveParkedTerminalPaneCandidates,
+  type ParkableTerminalTabModel
+} from '../terminal-pane/terminal-parked-watcher-reconciliation'
+import { WEB_SESSION_TABS_RPC_TIMEOUT_MS } from '../../runtime/web-session-tabs-sync'
+import { hasHostSessionMirrorHydrated } from '../../runtime/host-session-mirror-hydration'
+import { getRuntimeEnvironmentConnectionGeneration } from '@/store/slices/runtime-status'
+import type { useAppStore } from '@/store'
+
+/**
+ * Holds restored rows that would spawn a brand-new host shell: activation mounts
+ * every persisted row before the host answers `session.tabs`, and a row with no
+ * PTY left anywhere takes pty-connection's FRESH SPAWN branch. Watcher coverage
+ * cannot defer them — a PTY-less row never satisfies `canWatcherCoverParkedTerminalTab`.
+ */
+
+/**
+ * Derived from the session.tabs timeout it waits on, so a reply that arrives just
+ * under the wire still wins. Bounded only because this gate releases into
+ * *mounting*, where failing open is safe; a gate releasing into spawning must not
+ * (docs/reference/ssh-execution-boundary.md).
+ */
+export const RESTORED_TERMINAL_SPAWN_HOLD_TIMEOUT_MS = WEB_SESSION_TABS_RPC_TIMEOUT_MS + 5_000
+
+/** Ceiling across reconnects: a flapping runtime must not hold rows indefinitely. */
+export const RESTORED_TERMINAL_SPAWN_HOLD_MAX_TOTAL_MS = RESTORED_TERMINAL_SPAWN_HOLD_TIMEOUT_MS * 3
+
+export type RestoredSpawnHoldTab = ParkableTerminalTabModel
+
+export type RestoredSpawnHoldPaneState = Pick<
+  ReturnType<typeof useAppStore.getState>,
+  'terminalLayoutsByTabId' | 'runtimePaneTitlesByTabId' | 'ptyIdsByTabId'
+>
+
+export type RestoredSpawnHoldEntry = {
+  /** Half the epoch: generations count per environment, so env-2 generation 1 is not env-1's. */
+  environmentId: string
+  /** Connection the current wait window is scoped to. */
+  connectionGeneration: number
+  armedAtMs: number
+  /** Start of the current window; a new connection earns a fresh one. */
+  windowStartedAtMs: number
+  /** Host answered: the rows are proven dead, so the hold stops timing out. */
+  settled: boolean
+  heldTabIds: ReadonlySet<string>
+}
+
+/**
+ * The host's answer for one workspace, read from the mirror-hydration latch that
+ * `web-session-tabs-sync` settles from its landed store patches. Reused rather
+ * than re-derived: only that latch knows which frames actually reached the store,
+ * and a frame the client dropped is no answer.
+ */
+export type RestoredSpawnHoldEvidence = {
+  connectionGeneration: number
+  /** A frame for this worktree, or an inventory covering it, landed on that connection. */
+  hostAnswered: boolean
+}
+
+export function readRestoredSpawnHoldEvidence(
+  environmentId: string,
+  worktreeId: string
+): RestoredSpawnHoldEvidence {
+  return {
+    connectionGeneration: getRuntimeEnvironmentConnectionGeneration(environmentId),
+    hostAnswered: hasHostSessionMirrorHydrated(environmentId, worktreeId)
+  }
+}
+
+export type RestoredSpawnHoldPlan = {
+  heldTabIds: ReadonlySet<string>
+  /** Rows the hold just let go of; callers must re-allow them to mount. */
+  releasedTabIds: ReadonlySet<string>
+}
+
+const EMPTY_TAB_IDS: ReadonlySet<string> = new Set<string>()
+
+/**
+ * Whether mounting this restored row would create a new host shell: `web-terminal-`
+ * rows route to the host-session mirror, which has no create path, and a row still
+ * owning a PTY anywhere attaches to it instead.
+ */
+export function willRestoredTabSpawnHostTerminal(
+  tab: RestoredSpawnHoldTab,
+  state: RestoredSpawnHoldPaneState
+): boolean {
+  if (isWebTerminalSurfaceTabId(tab.id) || tab.ptyId !== null) {
+    return false
+  }
+  if ((state.ptyIdsByTabId[tab.id]?.length ?? 0) > 0) {
+    return false
+  }
+  return resolveParkedTerminalPaneCandidates(tab, state).every((pane) => pane.ptyId === null)
+}
+
+function differenceOf(from: ReadonlySet<string>, remove: ReadonlySet<string>): ReadonlySet<string> {
+  const result = new Set<string>()
+  for (const id of from) {
+    if (!remove.has(id)) {
+      result.add(id)
+    }
+  }
+  return result
+}
+
+/**
+ * Which restored rows stay unmounted while the host's answer for `worktreeId` is
+ * outstanding. Holding a visible, group-active, portal, queued, live or
+ * already-mounted row would strand an agent resume or unmount a live pane, so those
+ * are never held; arming only on the activation pass keeps later user-created tabs out.
+ *
+ * The answer settles the hold rather than releasing it: an accepted snapshot keeps
+ * the dead local row (`shouldReplaceTerminalTab`), so releasing on it would just run
+ * the storm one pass later. Held rows stay dark and mount on click.
+ */
+export function planRestoredTerminalSpawnHold(opts: {
+  holdByWorktreeId: Map<string, RestoredSpawnHoldEntry>
+  worktreeId: string
+  /** Null for local, SSH and folder work, which never wait on a host answer. */
+  environmentId: string | null
+  evidence: RestoredSpawnHoldEvidence
+  /** True only on the activation pass that plans this worktree's mounts. */
+  isColdActivationPass: boolean
+  nowMs: number
+  timeoutMs?: number
+  maxTotalMs?: number
+  allTabs: readonly RestoredSpawnHoldTab[]
+  wouldSpawnHostTerminal: (tab: RestoredSpawnHoldTab) => boolean
+  immediateTabIds: ReadonlySet<string>
+  isTabLive: (tabId: string) => boolean
+  hasMountedTab: (tabId: string) => boolean
+}): RestoredSpawnHoldPlan {
+  const {
+    holdByWorktreeId,
+    worktreeId,
+    environmentId,
+    evidence,
+    isColdActivationPass,
+    nowMs,
+    timeoutMs = RESTORED_TERMINAL_SPAWN_HOLD_TIMEOUT_MS,
+    maxTotalMs = RESTORED_TERMINAL_SPAWN_HOLD_MAX_TOTAL_MS,
+    allTabs,
+    wouldSpawnHostTerminal,
+    immediateTabIds,
+    isTabLive,
+    hasMountedTab
+  } = opts
+  const previous = holdByWorktreeId.get(worktreeId)
+  const previousHeld = previous?.heldTabIds ?? EMPTY_TAB_IDS
+  const release = (): RestoredSpawnHoldPlan => {
+    holdByWorktreeId.delete(worktreeId)
+    return { heldTabIds: EMPTY_TAB_IDS, releasedTabIds: previousHeld }
+  }
+  // Liveness is deliberately not a precondition: on a slow start the probe can still
+  // be missing while the workspace mounts, and that cold pass is the storm itself.
+  if (!environmentId) {
+    return release()
+  }
+  const isHoldable = (tab: RestoredSpawnHoldTab): boolean =>
+    wouldSpawnHostTerminal(tab) &&
+    !immediateTabIds.has(tab.id) &&
+    !isTabLive(tab.id) &&
+    !hasMountedTab(tab.id)
+  let entry: RestoredSpawnHoldEntry
+  if (!previous) {
+    if (!isColdActivationPass) {
+      return release()
+    }
+    const armed = new Set<string>()
+    for (const tab of allTabs) {
+      if (isHoldable(tab)) {
+        armed.add(tab.id)
+      }
+    }
+    entry = {
+      environmentId,
+      connectionGeneration: evidence.connectionGeneration,
+      armedAtMs: nowMs,
+      windowStartedAtMs: nowMs,
+      settled: false,
+      heldTabIds: armed
+    }
+  } else if (
+    previous.environmentId !== environmentId ||
+    previous.connectionGeneration !== evidence.connectionGeneration
+  ) {
+    // A reconnect or host move owes an unsettled hold a fresh window; a mere disconnect
+    // advances no generation, so its clock keeps running. armedAtMs stays, so the ceiling holds.
+    const movedHost = previous.environmentId !== environmentId
+    // A verdict is one host's answer about these rows; the new host has said nothing.
+    const settled = movedHost ? false : previous.settled
+    entry = {
+      ...previous,
+      environmentId,
+      connectionGeneration: evidence.connectionGeneration,
+      settled,
+      windowStartedAtMs: settled ? previous.windowStartedAtMs : nowMs
+    }
+  } else {
+    entry = previous
+  }
+  // Evidence from before the hold armed still counts: those rows are proven dead now.
+  const settled = entry.settled || evidence.hostAnswered
+  if (
+    !settled &&
+    (nowMs - entry.windowStartedAtMs >= timeoutMs || nowMs - entry.armedAtMs >= maxTotalMs)
+  ) {
+    return release()
+  }
+  const tabById = new Map(allTabs.map((tab) => [tab.id, tab]))
+  const next = new Set<string>()
+  for (const tabId of entry.heldTabIds) {
+    const tab = tabById.get(tabId)
+    if (tab && isHoldable(tab)) {
+      next.add(tabId)
+    }
+  }
+  if (next.size === 0) {
+    return release()
+  }
+  holdByWorktreeId.set(worktreeId, { ...entry, settled, heldTabIds: next })
+  return { heldTabIds: next, releasedTabIds: differenceOf(previousHeld, next) }
+}
+
+function haveSameTabIds(current: ReadonlySet<string>, next: ReadonlySet<string>): boolean {
+  return current.size === next.size && [...next].every((tabId) => current.has(tabId))
+}
+
+/** A held row re-runs this every render; a fresh identity for unchanged membership
+ *  re-renders the whole memoized surface tree. */
+function keepStableTabIds(
+  byWorktreeId: Map<string, ReadonlySet<string>>,
+  worktreeId: string,
+  next: ReadonlySet<string>
+): void {
+  const current = byWorktreeId.get(worktreeId)
+  if (current && haveSameTabIds(current, next)) {
+    return
+  }
+  byWorktreeId.set(worktreeId, next)
+}
+
+/**
+ * Held rows leave the shared allowed set and join the activation-deferred set,
+ * which keeps the worktree surface mounted when no allowed row is left.
+ */
+export function applyRestoredTerminalSpawnHold(opts: {
+  restrictions: Map<string, ReadonlySet<string>>
+  deferredMountTabIdsByWorktree: Map<string, ReadonlySet<string>>
+  worktreeId: string
+  allTabIds: readonly string[]
+  plan: RestoredSpawnHoldPlan
+}): void {
+  const { restrictions, deferredMountTabIdsByWorktree, worktreeId, allTabIds, plan } = opts
+  if (plan.heldTabIds.size === 0 && plan.releasedTabIds.size === 0) {
+    return
+  }
+  const allowed = new Set(restrictions.get(worktreeId) ?? allTabIds)
+  for (const tabId of plan.releasedTabIds) {
+    allowed.add(tabId)
+  }
+  for (const tabId of plan.heldTabIds) {
+    allowed.delete(tabId)
+  }
+  const deferred = new Set(allTabIds.filter((tabId) => !allowed.has(tabId)))
+  if (deferred.size === 0) {
+    restrictions.delete(worktreeId)
+    deferredMountTabIdsByWorktree.delete(worktreeId)
+    return
+  }
+  keepStableTabIds(restrictions, worktreeId, allowed)
+  keepStableTabIds(deferredMountTabIdsByWorktree, worktreeId, deferred)
+}

--- a/src/renderer/src/hooks/ipc-events/browser-automation-bootstrap-lease.test.ts
+++ b/src/renderer/src/hooks/ipc-events/browser-automation-bootstrap-lease.test.ts
@@ -50,9 +50,9 @@ describe('browser automation bootstrap lease ownership', () => {
     expect(mocks.releaseVisibility).toHaveBeenCalledTimes(1)
     expect(mocks.releaseVisibility).toHaveBeenLastCalledWith('lease-1')
     expect(mocks.requestBackgroundMount.mock.calls).toEqual([
-      [{ worktreeId: 'wt-1' }],
-      [{ worktreeId: 'wt-1' }],
-      [{ worktreeId: 'wt-2' }]
+      [{ worktreeId: 'wt-1', tabIds: [] }],
+      [{ worktreeId: 'wt-1', tabIds: [] }],
+      [{ worktreeId: 'wt-2', tabIds: [] }]
     ])
 
     vi.advanceTimersByTime(9_999)

--- a/src/renderer/src/hooks/ipc-events/browser-automation-bootstrap-lease.ts
+++ b/src/renderer/src/hooks/ipc-events/browser-automation-bootstrap-lease.ts
@@ -52,7 +52,8 @@ export function acquireBrowserAutomationBootstrapLease(
   if (!targetWorktreeId) {
     return
   }
-  requestBackgroundTerminalWorktreeMount({ worktreeId: targetWorktreeId })
+  // Why tabIds: []: bootstrap needs only the surface; untargeted mounts fan restored PTY-less rows into host spawns.
+  requestBackgroundTerminalWorktreeMount({ worktreeId: targetWorktreeId, tabIds: [] })
   let targetBrowserPageId = browserPageId ?? null
   if (!targetBrowserPageId) {
     const browserTabs = store.browserTabsByWorktree[targetWorktreeId] ?? []

--- a/src/renderer/src/hooks/useIpcEvents-browser-tab-create.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents-browser-tab-create.test.ts
@@ -279,7 +279,7 @@ describe('useIpcEvents browser tab create routing', () => {
 
     expect(acquireBrowserAutomationVisibility).toHaveBeenCalledWith('page-detached')
     expect(dispatchEvent).toHaveBeenCalledWith(
-      expect.objectContaining({ detail: { worktreeId: 'wt-2' } })
+      expect.objectContaining({ detail: { worktreeId: 'wt-2', tabIds: [] } })
     )
   })
 })

--- a/src/renderer/src/lib/wake-sleeping-agents-in-background.test.ts
+++ b/src/renderer/src/lib/wake-sleeping-agents-in-background.test.ts
@@ -156,7 +156,7 @@ describe('wakeSleepingAgentsForWorktreeInBackground', () => {
     )
   })
 
-  it('falls back to a whole-worktree mount when a passive record has no resolvable tab', () => {
+  it('does not background-mount when only an untargetable passive record exists (STA-4953)', () => {
     sleepingRecords = { k1: { worktreeId: 'wt-1', paneKey: 'not-a-pane-key' } }
     isPassiveSpy.mockReturnValue(true)
     const rec = recordEvents()
@@ -164,8 +164,10 @@ describe('wakeSleepingAgentsForWorktreeInBackground', () => {
     wakeSleepingAgentsForWorktreeInBackground('wt-1')
 
     rec.stop()
-    expect(rec.events).toEqual(['wake:wt-1', 'mount:wt-1'])
-    expect(rec.mountDetails[0]?.tabIds).toBeUndefined()
+    // Why: no tabId or parseable pane key means getSleepingRecordTabId
+    // returns null — mounting would bypass STA-4953's targeted restriction.
+    expect(rec.events).toEqual(['wake:wt-1'])
+    expect(rec.mountDetails).toEqual([])
   })
 
   it('mounts one canonical tab and clears cold aliases for the same provider session', () => {

--- a/src/renderer/src/lib/wake-sleeping-agents-in-background.ts
+++ b/src/renderer/src/lib/wake-sleeping-agents-in-background.ts
@@ -185,7 +185,6 @@ export function wakeSleepingAgentsForWorktreeInBackground(worktreeId: string): v
   // that needs a fresh-connect cold-restore (step b). Non-passive records are
   // recovered by step (c) into a fresh tab, mounted in step (d).
   const passiveTabIds = new Set<string>()
-  let hasUntargetablePassiveRecord = false
   // Why: a workspace the user explicitly slept must not respawn every finished agent because a
   // phone opened it. Those panes cold-restore `--resume` when their own tab is opened, which is
   // also what the desktop does (#11598). Filtering before canonicalization keeps a lazy record
@@ -195,19 +194,14 @@ export function wakeSleepingAgentsForWorktreeInBackground(worktreeId: string): v
   )
   for (const record of getCanonicalPassiveWakeRecords(backgroundWakeRecords, wokenClaimKeys)) {
     const tabId = getSleepingRecordTabId(record)
+    // Why: getSleepingRecordTabId needs a stable pane key or parseable legacy
+    // key — a record with neither cannot be recovered by mounting tabs.
     if (tabId) {
       passiveTabIds.add(tabId)
-    } else {
-      hasUntargetablePassiveRecord = true
     }
   }
-  if (passiveTabIds.size > 0 || hasUntargetablePassiveRecord) {
-    // Why: a record whose tab cannot be resolved falls back to the untargeted
-    // whole-worktree mount rather than silently never waking.
-    dispatchBackgroundMount(
-      worktreeId,
-      hasUntargetablePassiveRecord ? undefined : [...passiveTabIds]
-    )
+  if (passiveTabIds.size > 0) {
+    dispatchBackgroundMount(worktreeId, [...passiveTabIds])
   }
   resumeSleepingAgentSessionsForWorktree(worktreeId, {
     suppressNavigation: true,

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -117,6 +117,9 @@ import {
 
 const WEB_SESSION_GROUP_PREFIX = 'web-session-tabs:'
 export const WEB_SESSION_TABS_VISIBILITY_RESUME_STAGGER_MS = 100
+/** Anything gating on a host answer must outlast this, or it gives up while a reply
+ *  is still in flight. */
+export const WEB_SESSION_TABS_RPC_TIMEOUT_MS = 15_000
 
 type SessionTabsStreamEvent =
   | (RuntimeMobileSessionTabsResult & { type: 'snapshot' | 'updated' })
@@ -3909,7 +3912,7 @@ function loadInitialWebSessionTabs(
       selector: environmentId,
       method: 'session.tabs.listAll',
       params: {},
-      timeoutMs: 15_000,
+      timeoutMs: WEB_SESSION_TABS_RPC_TIMEOUT_MS,
       expectedEnvironmentPairingRevision
     })
     .then(async (response: RuntimeRpcResponse<unknown>) => {
@@ -4524,7 +4527,7 @@ export function useWebSessionTabsSync(): void {
               selector: environmentId,
               method: 'session.tabs.subscribeAll',
               params: {},
-              timeoutMs: 15_000,
+              timeoutMs: WEB_SESSION_TABS_RPC_TIMEOUT_MS,
               expectedEnvironmentPairingRevision
             },
             {
@@ -4923,7 +4926,7 @@ export function useWebSessionTabsSync(): void {
               selector: environmentId,
               method: 'session.tabs.subscribe',
               params: { worktree: toRuntimeWorktreeSelector(activeWorktreeId) },
-              timeoutMs: 15_000,
+              timeoutMs: WEB_SESSION_TABS_RPC_TIMEOUT_MS,
               expectedEnvironmentPairingRevision
             },
             {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​998 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​991 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​480 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​463 |

<!-- /orca-pr-loc -->

## Summary

STA-4953 was reported and diagnosed by Revofusion in [#15624](https://github.com/stablyai/orca/pull/15624).

Opening a paired-runtime workspace could mount restored PTY-less terminal rows before the current connection received an authoritative `session.tabs` answer. Every affected mount took the fresh-spawn path and created a new host shell.

Now that [#15644](https://github.com/stablyai/orca/pull/15644) is merged, this PR consumes its canonical, generation-scoped `hasHostSessionMirrorHydrated` evidence. It does not add another answer or connection latch. This PR owns only the mount policy.

## Mount policy

- Hold only cold-restored, non-mirrored rows that would fresh-spawn: no tab PTY, no tracked pane PTY, and no surviving layout-leaf PTY.
- Scope each wait to the environment id plus that environment connection generation, and accept only evidence that landed in the store. A full inventory speaks for every covered worktree; a single-worktree frame speaks only for that worktree.
- Never withhold the active or remembered-active tab, group actives, activity portals, pending-startup tabs, live tabs, or rows an earlier pass already mounted.
- Keep rows proven dead by an accepted empty snapshot unmounted until the user explicitly activates them; that click intentionally creates a new shell.
- Fail open into mounting after 20 seconds for an unanswered host epoch, with a 60-second total ceiling across reconnects and host moves.
- Keep allowed/deferred `Set` identities stable when membership is unchanged, avoiding memoized worktree-surface rerenders.
- Request browser-automation bootstrap with `tabIds: []`, so it mounts only the surface. Do not whole-worktree mount an unparseable sleeping record that no pane matcher can consume.
- Make no IPC, RPC, stream, or host-publication change. Local, direct-SSH, and folder workspaces remain outside the gate.

## Red-first evidence

- The bug was reproduced on clean main at the rendered `Terminal` seam: restored PTY-less rows mounted before host evidence and reached the fresh-spawn class.
- With only the shipping `applyRestoredTerminalSpawnHold` call removed, all 21 rendered scenarios fail; with it restored, all 21 pass.
- Targeted mutations kill the group-active mapping, activity-portal carve-out, environment/connection epoch checks, settled-verdict reset on host move, 60-second ceiling, and stable-`Set` identity tests.

## Verification

- Mount policy and rendered seam: 2 files, 43/43 tests passed.
- #15644 hydration evidence and session-tabs consumers: 6 files, 61/61 tests passed.
- Broader renderer sweep after rebase: 1,077 files, 9,853 tests passed, 2 skipped.
- `pnpm run typecheck:web`
- `pnpm run check:code-quality:changed`
- `pnpm run check:react-doctor:changed`
- `pnpm run check:reliability-gates`
- `git diff --check`, formatting, raw control-byte scan, and binary diff scan
- Independent OpenCode reviews found and drove fixes for host-environment epoch identity and stable set references. A final read-only review found no blocker after its kill-switch and untargetable-wake concerns were independently traced and rejected as intentional or unrecoverable.

## Known tradeoffs and gaps

- A host that does not answer within 20 seconds can still spawn the restored rows when the gate fails open. This is deliberate: a mount gate must not leave a workspace blank forever.
- A dead restored row remains visible but unmounted after an accepted empty snapshot; explicitly activating it starts a new shell.
- The spawn-safety hold is intentionally independent of the watcher-deferral kill switch. Disabling watcher deferral must not reopen the spawn storm.
- Coverage is deterministic renderer/hydration evidence on macOS. There is not yet a live headed or headless paired-runtime test counting host `terminal.create` calls, nor Linux, Windows, or live SSH execution for this gate.

