### PR TITLE
feat(tasks): pick a base branch when creating a workspace from a task

### DIFF
--- a/src/renderer/src/components/NewWorkspaceComposerCard.base-branch.test.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.base-branch.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import React, { act } from 'react'
-import { createRoot } from 'react-dom/client'
+import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import NewWorkspaceComposerCard from './NewWorkspaceComposerCard'
 import type { NewWorkspaceProjectOption } from '@/lib/new-workspace-project-options'
@@ -69,7 +69,7 @@ const projectOptions: NewWorkspaceProjectOption[] = [
 
 function renderCard(
   overrides: Partial<React.ComponentProps<typeof NewWorkspaceComposerCard>> = {}
-): HTMLDivElement {
+): { container: HTMLDivElement; root: Root } {
   const container = document.createElement('div')
   document.body.appendChild(container)
   const root = createRoot(container)
@@ -137,7 +137,7 @@ function renderCard(
       />
     )
   })
-  return container
+  return { container, root }
 }
 
 function hasBranchFromLabel(container: HTMLElement): boolean {
@@ -147,57 +147,60 @@ function hasBranchFromLabel(container: HTMLElement): boolean {
 }
 
 describe('NewWorkspaceComposerCard base branch picker', () => {
-  let container: HTMLDivElement | null = null
+  let current: { container: HTMLDivElement; root: Root } | null = null
 
   afterEach(() => {
-    container?.remove()
-    container = null
+    if (current) {
+      act(() => current?.root.unmount())
+      current.container.remove()
+      current = null
+    }
   })
 
   it('shows Branch from for a GitHub issue source', () => {
-    container = renderCard({
+    current = renderCard({
       smartNameSelection: { kind: 'github-issue', label: '#7 Fix', url: 'https://example.com/i/7' }
     })
 
-    expect(hasBranchFromLabel(container)).toBe(true)
+    expect(hasBranchFromLabel(current.container)).toBe(true)
   })
 
   it('shows Branch from for a Linear source', () => {
-    container = renderCard({
+    current = renderCard({
       smartNameSelection: { kind: 'linear', label: 'ENG-42' }
     })
 
-    expect(hasBranchFromLabel(container)).toBe(true)
+    expect(hasBranchFromLabel(current.container)).toBe(true)
   })
 
   it('omits Branch from for a GitHub PR source', () => {
-    container = renderCard({
+    current = renderCard({
       smartNameSelection: { kind: 'github-pr', label: '#42 Fix', url: 'https://example.com/pr/42' }
     })
 
-    expect(hasBranchFromLabel(container)).toBe(false)
+    expect(hasBranchFromLabel(current.container)).toBe(false)
   })
 
   it('omits Branch from for a bare branch source', () => {
-    container = renderCard({
+    current = renderCard({
       smartNameSelection: { kind: 'branch', label: 'main' }
     })
 
-    expect(hasBranchFromLabel(container)).toBe(false)
+    expect(hasBranchFromLabel(current.container)).toBe(false)
   })
 
   it('omits Branch from when nothing is selected', () => {
-    container = renderCard({ smartNameSelection: null })
+    current = renderCard({ smartNameSelection: null })
 
-    expect(hasBranchFromLabel(container)).toBe(false)
+    expect(hasBranchFromLabel(current.container)).toBe(false)
   })
 
   it('omits Branch from for non-git projects even with a task source', () => {
-    container = renderCard({
+    current = renderCard({
       selectedRepoIsGit: false,
       smartNameSelection: { kind: 'github-issue', label: '#7 Fix', url: 'https://example.com/i/7' }
     })
 
-    expect(hasBranchFromLabel(container)).toBe(false)
+    expect(hasBranchFromLabel(current.container)).toBe(false)
   })
 })

--- a/src/renderer/src/components/NewWorkspaceComposerCard.base-branch.test.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.base-branch.test.tsx
@@ -2,30 +2,14 @@
 
 import React, { act } from 'react'
 import { createRoot } from 'react-dom/client'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import NewWorkspaceComposerCard from './NewWorkspaceComposerCard'
 import type { NewWorkspaceProjectOption } from '@/lib/new-workspace-project-options'
-import type { ProjectHostSetupOption } from '@/lib/project-host-setup-options'
-
-const storeMocks = vi.hoisted(() => ({
-  closeModal: vi.fn(),
-  openModal: vi.fn(),
-  openSettingsPage: vi.fn(),
-  openSettingsTarget: vi.fn()
-}))
 
 vi.mock('@/store', () => ({
   useAppStore: Object.assign(
     (selector: (state: unknown) => unknown) =>
       selector({
-        closeModal: storeMocks.closeModal,
-        openModal: storeMocks.openModal,
-        openSettingsPage: storeMocks.openSettingsPage,
-        openSettingsTarget: storeMocks.openSettingsTarget,
-        setRuntimeEnvironmentStatus: vi.fn(),
-        setupProjectExistingFolder: vi.fn(),
-        setupProjectClone: vi.fn(),
-        activeModal: 'new-workspace-composer',
         settings: { defaultTuiAgent: null, disabledTuiAgents: [] },
         updateSettings: vi.fn(),
         projects: [],
@@ -38,12 +22,6 @@ vi.mock('@/store', () => ({
 
 vi.mock('@/components/contextual-tours/use-contextual-tour', () => ({
   useContextualTour: vi.fn()
-}))
-
-vi.mock('@/components/ui/tooltip', () => ({
-  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>
 }))
 
 vi.mock('@/components/ui/tooltip', () => ({
@@ -73,20 +51,7 @@ vi.mock('@/components/new-workspace/ProjectCombobox', () => ({
 }))
 
 vi.mock('@/components/new-workspace/SetProjectLocationDialog', () => ({
-  SetProjectLocationDialog: ({
-    option,
-    projectName
-  }: {
-    option: { label: string } | null
-    projectName: string
-  }) =>
-    option ? (
-      <div
-        data-testid="set-project-location-dialog"
-        data-host={option.label}
-        data-project={projectName}
-      />
-    ) : null
+  SetProjectLocationDialog: () => null
 }))
 
 const projectOptions: NewWorkspaceProjectOption[] = [
@@ -99,30 +64,6 @@ const projectOptions: NewWorkspaceProjectOption[] = [
     detail: '/workspace/platform',
     parentPath: '/workspace/platform',
     connectionId: null
-  }
-]
-
-const hostOptions: ProjectHostSetupOption[] = [
-  {
-    kind: 'ready',
-    id: 'setup-local',
-    projectId: 'project-group:platform',
-    hostId: 'local',
-    repoId: 'repo-a',
-    label: 'Local Mac',
-    detail: 'Orca',
-    path: '/Users/alice/orca'
-  },
-  {
-    kind: 'needs-setup',
-    id: 'needs-setup:ssh:devbox',
-    projectId: 'project-group:platform',
-    hostId: 'ssh:devbox',
-    label: 'Devbox',
-    detail: 'Project location not set',
-    isAvailable: true,
-    attention: false,
-    canSetLocation: true
   }
 ]
 
@@ -158,6 +99,8 @@ function renderCard(
         canReuseSelectedBranch={false}
         reuseSelectedBranch={false}
         onReuseSelectedBranchChange={() => {}}
+        branchNameOverride={undefined}
+        onBranchNameOverrideChange={() => {}}
         forkPushWarning={null}
         detectedAgentIds={null}
         onOpenAgentSettings={() => {}}
@@ -187,13 +130,9 @@ function renderCard(
         sparsePresets={[]}
         sparseSelectedPresetId={null}
         onSparseSelectPreset={() => {}}
-        branchNameOverride={undefined}
-        onBranchNameOverrideChange={() => {}}
-        branchesEnabled={false}
+        branchesEnabled
         setupControlsEnabled={false}
         sparseControlsEnabled={false}
-        projectHostSetupOptions={hostOptions}
-        selectedProjectHostSetupId="setup-local"
         {...overrides}
       />
     )
@@ -201,41 +140,64 @@ function renderCard(
   return container
 }
 
-describe('NewWorkspaceComposerCard set location', () => {
-  let container: HTMLDivElement | null = null
+function hasBranchFromLabel(container: HTMLElement): boolean {
+  return [...container.querySelectorAll('label')].some(
+    (candidate) => candidate.textContent?.trim() === 'Branch from'
+  )
+}
 
-  beforeEach(() => {
-    storeMocks.closeModal.mockReset()
-    storeMocks.openModal.mockReset()
-    storeMocks.openSettingsPage.mockReset()
-  })
+describe('NewWorkspaceComposerCard base branch picker', () => {
+  let container: HTMLDivElement | null = null
 
   afterEach(() => {
     container?.remove()
     container = null
   })
 
-  it('opens set-location over the composer without leaving the create dialog', () => {
-    const nestedOpenChanges: boolean[] = []
+  it('shows Branch from for a GitHub issue source', () => {
     container = renderCard({
-      onNestedDialogOpenChange: (open) => nestedOpenChanges.push(open)
+      smartNameSelection: { kind: 'github-issue', label: '#7 Fix', url: 'https://example.com/i/7' }
     })
 
-    act(() => {
-      container?.querySelector<HTMLElement>('div[data-run-target-combobox-root="true"]')?.click()
-    })
-    const setLocation = [...document.body.querySelectorAll<HTMLButtonElement>('button')].find(
-      (button) => button.textContent?.includes('Set project location')
-    )
-    expect(setLocation).toBeTruthy()
-    act(() => setLocation?.click())
+    expect(hasBranchFromLabel(container)).toBe(true)
+  })
 
-    const dialog = document.body.querySelector('[data-testid="set-project-location-dialog"]')
-    expect(dialog?.getAttribute('data-host')).toBe('Devbox')
-    expect(dialog?.getAttribute('data-project')).toBe('Platform')
-    expect(nestedOpenChanges).toEqual([true])
-    expect(storeMocks.closeModal).not.toHaveBeenCalled()
-    expect(storeMocks.openModal).not.toHaveBeenCalled()
-    expect(storeMocks.openSettingsPage).not.toHaveBeenCalled()
+  it('shows Branch from for a Linear source', () => {
+    container = renderCard({
+      smartNameSelection: { kind: 'linear', label: 'ENG-42' }
+    })
+
+    expect(hasBranchFromLabel(container)).toBe(true)
+  })
+
+  it('omits Branch from for a GitHub PR source', () => {
+    container = renderCard({
+      smartNameSelection: { kind: 'github-pr', label: '#42 Fix', url: 'https://example.com/pr/42' }
+    })
+
+    expect(hasBranchFromLabel(container)).toBe(false)
+  })
+
+  it('omits Branch from for a bare branch source', () => {
+    container = renderCard({
+      smartNameSelection: { kind: 'branch', label: 'main' }
+    })
+
+    expect(hasBranchFromLabel(container)).toBe(false)
+  })
+
+  it('omits Branch from when nothing is selected', () => {
+    container = renderCard({ smartNameSelection: null })
+
+    expect(hasBranchFromLabel(container)).toBe(false)
+  })
+
+  it('omits Branch from for non-git projects even with a task source', () => {
+    container = renderCard({
+      selectedRepoIsGit: false,
+      smartNameSelection: { kind: 'github-issue', label: '#7 Fix', url: 'https://example.com/i/7' }
+    })
+
+    expect(hasBranchFromLabel(container)).toBe(false)
   })
 })

--- a/src/renderer/src/components/NewWorkspaceComposerCard.test.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.test.tsx
@@ -33,7 +33,8 @@ vi.mock('@/store', () => ({
         settings: { defaultTuiAgent: null, disabledTuiAgents: [] },
         updateSettings: vi.fn(),
         projects: [],
-        repos: []
+        repos: [],
+        worktreesByRepo: {}
       }),
     {
       getState: () => ({
@@ -225,6 +226,8 @@ function renderCard(
         onSmartLinearIssueSelect={() => {}}
         smartNameSelection={null}
         onClearSmartNameSelection={() => {}}
+        baseBranch={undefined}
+        onBaseBranchChange={() => {}}
         canReuseSelectedBranch={false}
         reuseSelectedBranch={false}
         onReuseSelectedBranchChange={() => {}}

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -47,6 +47,8 @@ import SmartWorkspaceNameField, {
   type SmartWorkspaceNameSelection
 } from '@/components/new-workspace/SmartWorkspaceNameField'
 import type { SmartNameMode } from '@/components/new-workspace/smart-workspace-source-results'
+import { BranchFromPicker } from '@/components/new-workspace/BranchFromPicker'
+import { isBaseBranchSelectableSourceKind } from '../../../shared/new-workspace/workspace-source'
 import ProjectCombobox from '@/components/new-workspace/ProjectCombobox'
 import RunTargetCombobox from '@/components/new-workspace/RunTargetCombobox'
 import { SetProjectLocationDialog } from '@/components/new-workspace/SetProjectLocationDialog'
@@ -64,6 +66,8 @@ import type { WorkspaceCreateErrorDisplay } from '@/lib/workspace-create-error-f
 import type { SshConnectionStatus } from '../../../shared/ssh-types'
 import type { TaskSourceContext } from '../../../shared/task-source-context'
 import type { RuntimeStatus } from '../../../shared/runtime-types'
+import type { Repo } from '../../../shared/repo-types'
+import type { Worktree } from '../../../shared/worktree/types'
 import { unwrapRuntimeRpcResult } from '@/runtime/runtime-rpc-client'
 import { translate } from '@/i18n/i18n'
 import { withUiConnectTimeout } from '@/ssh/ssh-connect-ui-timeout'
@@ -74,6 +78,7 @@ type EphemeralVmRecipeOption = NonNullable<OrcaHooks['environmentRecipes']>[numb
 const EMPTY_PROJECT_OPTIONS: NewWorkspaceProjectOption[] = []
 const EMPTY_PROJECT_HOST_SETUP_OPTIONS: ProjectHostSetupOption[] = []
 const EMPTY_EPHEMERAL_VM_RECIPES: EphemeralVmRecipeOption[] = []
+const EMPTY_WORKTREES: Worktree[] = []
 
 type NewWorkspaceComposerCardProps = {
   contextualTourSource?: string
@@ -119,6 +124,8 @@ type NewWorkspaceComposerCardProps = {
   onOpenJiraSettings?: () => void
   smartNameSelection: SmartWorkspaceNameSelection | null
   onClearSmartNameSelection: () => void
+  baseBranch: string | undefined
+  onBaseBranchChange: (next: string | undefined) => void
   /** True when an existing local branch is selected and can be reused. */
   canReuseSelectedBranch: boolean
   reuseSelectedBranch: boolean
@@ -335,6 +342,8 @@ export default function NewWorkspaceComposerCard({
   onOpenJiraSettings,
   smartNameSelection,
   onClearSmartNameSelection,
+  baseBranch,
+  onBaseBranchChange,
   canReuseSelectedBranch,
   reuseSelectedBranch,
   onReuseSelectedBranchChange,
@@ -526,6 +535,18 @@ export default function NewWorkspaceComposerCard({
   )
   const projects = useAppStore((state) => state.projects)
   const repos = useAppStore((state) => state.repos)
+  const repoMap = React.useMemo<Map<string, Repo>>(
+    () => new Map(repos.map((repo) => [repo.id, repo])),
+    [repos]
+  )
+  const repoWorktrees = useAppStore(
+    (state) => state.worktreesByRepo[repoId] ?? EMPTY_WORKTREES
+  )
+  const showBaseBranchPicker =
+    selectedRepoIsGit &&
+    branchesEnabled &&
+    smartNameSelection !== null &&
+    isBaseBranchSelectableSourceKind(smartNameSelection.kind)
   const defaultCloneUrl = React.useMemo(
     () => resolveProjectCloneUrlPrefill(projects, repos, selectedProjectId),
     [projects, repos, selectedProjectId]
@@ -892,6 +913,26 @@ export default function NewWorkspaceComposerCard({
             </div>
           </div>
         </div>
+
+        {showBaseBranchPicker ? (
+          <div className="min-w-0 space-y-1">
+            <label className="text-xs font-medium text-muted-foreground">
+              {translate('auto.components.NewWorkspaceComposerCard.branchFrom', 'Branch from')}
+            </label>
+            <BranchFromPicker
+              // Why: branch search state belongs to the selected project, so repo switches
+              // should reset it before the next paint.
+              key={repoId}
+              repoId={repoId}
+              repoMap={repoMap}
+              worktrees={repoWorktrees}
+              value={baseBranch ?? ''}
+              onValueChange={(next) => onBaseBranchChange(next || undefined)}
+              triggerClassName="h-9 w-full border-input text-sm focus:border-ring focus:ring-[3px] focus:ring-ring/50"
+              inlineLabel={false}
+            />
+          </div>
+        ) : null}
 
         <div className="min-w-0 space-y-1" data-contextual-tour-target="workspace-creation-agent">
           <div className="flex items-center justify-between gap-2">

--- a/src/renderer/src/components/automations/AutomationWorkspaceField.tsx
+++ b/src/renderer/src/components/automations/AutomationWorkspaceField.tsx
@@ -6,7 +6,7 @@ import type { AutomationWorkspaceMode } from '../../../../shared/automations-typ
 import type { Repo } from '../../../../shared/repo-types'
 import type { Worktree } from '../../../../shared/worktree/types'
 import { AUTOMATION_EDITOR_SECTION_LABEL_CLASS, Field } from './automation-page-parts'
-import { CreateFromPicker } from './CreateFromPicker'
+import { BranchFromPicker } from '@/components/new-workspace/BranchFromPicker'
 import { WorkspaceCombobox } from './WorkspaceCombobox'
 import type { AutomationDraft } from './AutomationEditorDialog'
 
@@ -107,7 +107,7 @@ export function AutomationWorkspaceField({
               }
             />
           ) : (
-            <CreateFromPicker
+            <BranchFromPicker
               // Why: branch search state belongs to the selected project,
               // so repo switches should reset it before the next paint.
               key={draft.projectId}

--- a/src/renderer/src/components/new-workspace/BranchFromPicker.test.tsx
+++ b/src/renderer/src/components/new-workspace/BranchFromPicker.test.tsx
@@ -4,7 +4,7 @@ import React, { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Repo } from '../../../../shared/repo-types'
-import { CreateFromPicker } from './CreateFromPicker'
+import { BranchFromPicker } from './BranchFromPicker'
 import {
   getRuntimeRepoBaseRefDefault,
   searchRuntimeRepoBaseRefs
@@ -62,7 +62,7 @@ function makeRepo(overrides: Partial<Repo>): Repo {
 async function renderPicker(repo: Repo): Promise<void> {
   await act(async () => {
     root.render(
-      <CreateFromPicker
+      <BranchFromPicker
         repoId={repo.id}
         repoMap={repoMapFor(repo)}
         worktrees={[]}
@@ -73,7 +73,7 @@ async function renderPicker(repo: Repo): Promise<void> {
   })
 }
 
-describe('CreateFromPicker host routing', () => {
+describe('BranchFromPicker host routing', () => {
   beforeEach(() => {
     container = document.createElement('div')
     document.body.appendChild(container)

--- a/src/renderer/src/components/new-workspace/BranchFromPicker.tsx
+++ b/src/renderer/src/components/new-workspace/BranchFromPicker.tsx
@@ -28,13 +28,14 @@ function displayBranchName(branch: string): string {
   return branch.replace(/^refs\/heads\//, '')
 }
 
-export function CreateFromPicker({
+export function BranchFromPicker({
   repoId,
   repoMap,
   worktrees,
   value,
   triggerClassName,
-  onValueChange
+  onValueChange,
+  inlineLabel = true
 }: {
   repoId: string
   repoMap: Map<string, Repo>
@@ -42,6 +43,8 @@ export function CreateFromPicker({
   value: string
   triggerClassName?: string
   onValueChange: (baseBranch: string) => void
+  /** When false, the trigger shows only the value — the host supplies its own field label. */
+  inlineLabel?: boolean
 }): React.JSX.Element {
   const activeRuntimeEnvironmentId = useAppStore((state) =>
     getRuntimeEnvironmentIdForRepo(state, repoId)
@@ -184,12 +187,14 @@ export function CreateFromPicker({
             className={cn('h-9 w-full justify-between px-3 text-sm font-normal', triggerClassName)}
           >
             <span className="flex min-w-0 items-center gap-1.5">
-              <span className="shrink-0 text-muted-foreground">
-                {translate(
-                  'auto.components.automations.CreateFromPicker.dd3841b442',
-                  'Branch from'
-                )}
-              </span>
+              {inlineLabel ? (
+                <span className="shrink-0 text-muted-foreground">
+                  {translate(
+                    'auto.components.automations.CreateFromPicker.dd3841b442',
+                    'Branch from'
+                  )}
+                </span>
+              ) : null}
               <span className="truncate">{selectedLabel}</span>
             </span>
             <ChevronsUpDown className="size-4 opacity-50" />

--- a/src/renderer/src/hooks/useComposerState-base-branch-linked-item.test.ts
+++ b/src/renderer/src/hooks/useComposerState-base-branch-linked-item.test.ts
@@ -29,13 +29,13 @@ describe('useComposerState base-branch picks preserve a linked task branch name'
     expect(section).toContain('setReuseEligibleBranch(null)')
     expect(section).toContain('setReuseSelectedBranch(false)')
     expect(section).toContain("branchAutoNameRef.current = ''")
-    // compareBaseRef/pushTarget/the GitHub PR start-point ref clear unconditionally.
-    expect(section.indexOf('smartGitHubPrStartPointSelectionRef.current = null')).toBeLessThan(
+    // compareBaseRef/pushTarget/both PR/MR start-point refs clear unconditionally.
+    expect(section.indexOf('invalidateSmartStartPointSelections()')).toBeLessThan(
       section.indexOf('if (!linkedWorkItem) {')
     )
     expect(section.indexOf('setCompareBaseRef(undefined)')).toBeLessThan(
       section.indexOf('if (!linkedWorkItem) {')
     )
-    expect(section).toContain('[linkedWorkItem]')
+    expect(section).toContain('[invalidateSmartStartPointSelections, linkedWorkItem]')
   })
 })

--- a/src/renderer/src/hooks/useComposerState-base-branch-linked-item.test.ts
+++ b/src/renderer/src/hooks/useComposerState-base-branch-linked-item.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const HOOK_SOURCE = readFileSync(join(__dirname, 'useComposerState.ts'), 'utf8')
+
+function sourceBetween(source: string, startPattern: string, endPattern: string): string {
+  const start = source.indexOf(startPattern)
+  expect(start).toBeGreaterThanOrEqual(0)
+  const end = source.indexOf(endPattern, start + startPattern.length)
+  expect(end).toBeGreaterThan(start)
+  return source.slice(start, end)
+}
+
+describe('useComposerState base-branch picks preserve a linked task branch name', () => {
+  it('gates the branch-name-override reset on there being no linked work item', () => {
+    const section = sourceBetween(
+      HOOK_SOURCE,
+      'const handleBaseBranchChange = useCallback(',
+      'const handleBaseBranchPrSelect = useCallback('
+    )
+
+    expect(section).toContain('setBaseBranch(next)')
+    // Why: a Linear/Jira source's branch name is independent of the base it's
+    // cut from — only a bare Start-from branch pick should wipe the override.
+    expect(section).toContain('if (!linkedWorkItem) {')
+    expect(section).toContain('setBranchNameOverride(undefined)')
+    expect(section).toContain('setBranchNameOverridePreservesNameEdits(false)')
+    expect(section).toContain('setReuseEligibleBranch(null)')
+    expect(section).toContain('setReuseSelectedBranch(false)')
+    expect(section).toContain("branchAutoNameRef.current = ''")
+    // compareBaseRef/pushTarget/the GitHub PR start-point ref clear unconditionally.
+    expect(section.indexOf('smartGitHubPrStartPointSelectionRef.current = null')).toBeLessThan(
+      section.indexOf('if (!linkedWorkItem) {')
+    )
+    expect(section.indexOf('setCompareBaseRef(undefined)')).toBeLessThan(
+      section.indexOf('if (!linkedWorkItem) {')
+    )
+    expect(section).toContain('[linkedWorkItem]')
+  })
+})

--- a/src/renderer/src/hooks/useComposerState-gitlab-base-branch-reset.test.ts
+++ b/src/renderer/src/hooks/useComposerState-gitlab-base-branch-reset.test.ts
@@ -90,6 +90,7 @@ describe('useComposerState invalidates both PR/MR start-point refs together', ()
       'const handleRemoveLinkedWorkItem = useCallback((): void => {',
       'const handleRepoChange = useCallback(',
       'const handleFolderSourceRepoChange = useCallback(',
+      'const handleProjectChange = useCallback(',
       'const handleBaseBranchChange = useCallback(',
       'const handleSmartGitHubItemSelect = useCallback(',
       'const handleSmartGitLabItemSelect = useCallback(',
@@ -105,5 +106,28 @@ describe('useComposerState invalidates both PR/MR start-point refs together', ()
       const section = sourceBetween(HOOK_SOURCE, start, end)
       expect(section).toContain('invalidateSmartStartPointSelections()')
     }
+  })
+
+  it('drops a pending GitLab MR resolution even when a repo change preserves the GitHub Start-from selection', () => {
+    // Why: unlike the GitHub PR ref (retargeted to the new repo below), a
+    // GitLab MR resolution has no per-repo retarget path. Before this fix the
+    // preserveStartFrom branch only retargeted the GitHub ref, so a pending
+    // GitLab MR .then/.catch kept its old token and could apply the prior
+    // repo's base/compare/push target after the switch.
+    const section = sourceBetween(
+      HOOK_SOURCE,
+      'const handleRepoChange = useCallback(',
+      'const handleFolderSourceRepoChange = useCallback('
+    )
+    const setRepoIdAt = section.indexOf('setRepoId(value)')
+    const dropGitLabRefAt = section.indexOf('smartGitLabMrStartPointSelectionRef.current = null')
+    const retargetBranchAt = section.indexOf(
+      'if (options.preserveStartFrom && smartGitHubPrStartPointSelectionRef.current) {'
+    )
+    expect(setRepoIdAt).toBeGreaterThanOrEqual(0)
+    expect(dropGitLabRefAt).toBeGreaterThan(setRepoIdAt)
+    // Not nested inside the `!options.preserveStartFrom` guard, and runs ahead of
+    // (independent from) the GitHub-only retarget branch.
+    expect(dropGitLabRefAt).toBeLessThan(retargetBranchAt)
   })
 })

--- a/src/renderer/src/hooks/useComposerState-gitlab-base-branch-reset.test.ts
+++ b/src/renderer/src/hooks/useComposerState-gitlab-base-branch-reset.test.ts
@@ -38,4 +38,37 @@ describe('useComposerState clears stale start-point state on GitLab item selecti
     expect(mrPath).toContain('setBaseBranch(undefined)')
     expect(mrPath).toContain('setPushTarget(undefined)')
   })
+
+  it('ignores a stale resolveMrBase result from a superseded GitLab item pick', () => {
+    const section = sourceBetween(
+      HOOK_SOURCE,
+      'const handleSmartGitLabItemSelect = useCallback(',
+      'const handleSmartBranchSelect = useCallback('
+    )
+
+    // Why: resolveMrBase resolves async — without a per-call token, selecting a
+    // second GitLab item while the first MR's resolution is still in flight let
+    // the stale .then/.catch overwrite the newer selection's baseBranch,
+    // pushTarget, and linked work item (mirrors the GitHub PR ref's guard).
+    const invalidateAt = section.indexOf('smartGitLabMrStartPointSelectionRef.current = null')
+    const projectGroupCheckAt = section.indexOf('if (isProjectGroupTarget) {')
+    expect(invalidateAt).toBeGreaterThanOrEqual(0)
+    expect(invalidateAt).toBeLessThan(projectGroupCheckAt)
+
+    const mintAt = section.indexOf('const mrStartPointSelection = {}')
+    const assignAt = section.indexOf(
+      'smartGitLabMrStartPointSelectionRef.current = mrStartPointSelection'
+    )
+    expect(mintAt).toBeGreaterThan(invalidateAt)
+    expect(assignAt).toBeGreaterThan(mintAt)
+
+    const thenSection = sourceBetween(section, '.then((result) => {', '.catch((error: unknown) => {')
+    expect(thenSection).toContain(
+      'if (smartGitLabMrStartPointSelectionRef.current !== mrStartPointSelection) {'
+    )
+    const catchSection = section.slice(section.indexOf(thenSection) + thenSection.length)
+    expect(catchSection).toContain(
+      'if (smartGitLabMrStartPointSelectionRef.current !== mrStartPointSelection) {'
+    )
+  })
 })

--- a/src/renderer/src/hooks/useComposerState-gitlab-base-branch-reset.test.ts
+++ b/src/renderer/src/hooks/useComposerState-gitlab-base-branch-reset.test.ts
@@ -12,8 +12,8 @@ function sourceBetween(source: string, startPattern: string, endPattern: string)
   return source.slice(start, end)
 }
 
-describe('useComposerState clears a stale base branch on GitLab item selection', () => {
-  it('clears baseBranch on both the issue short-circuit and the MR resolution path', () => {
+describe('useComposerState clears stale start-point state on GitLab item selection', () => {
+  it('clears baseBranch and pushTarget on both the issue short-circuit and the MR resolution path', () => {
     const section = sourceBetween(
       HOOK_SOURCE,
       'const handleSmartGitLabItemSelect = useCallback(',
@@ -21,18 +21,21 @@ describe('useComposerState clears a stale base branch on GitLab item selection',
     )
 
     // Why: without this, selecting a GitLab issue/MR after a Start-from branch (or a
-    // prior PR/MR) pick kept the old baseBranch and would branch the workspace from
-    // the wrong place — mirrors handleSmartGitHubItemSelect's setBaseBranch(undefined)
-    // on both sides of its type check.
+    // prior PR/MR) pick kept the old baseBranch/pushTarget — the workspace could branch
+    // from the wrong place, or a stale fork pushTarget from an earlier GitHub PR could
+    // leak into a GitLab create. Mirrors handleSmartGitHubItemSelect's
+    // setBaseBranch/setPushTarget(undefined) on both sides of its type check.
     const shortCircuit = sourceBetween(
       section,
       "if (item.type !== 'mr' || !runRepo) {",
       '}'
     )
     expect(shortCircuit).toContain('setBaseBranch(undefined)')
+    expect(shortCircuit).toContain('setPushTarget(undefined)')
 
     const afterShortCircuit = section.slice(section.indexOf(shortCircuit) + shortCircuit.length)
     const mrPath = sourceBetween(afterShortCircuit, '', 'const itemRepoSettings =')
     expect(mrPath).toContain('setBaseBranch(undefined)')
+    expect(mrPath).toContain('setPushTarget(undefined)')
   })
 })

--- a/src/renderer/src/hooks/useComposerState-gitlab-base-branch-reset.test.ts
+++ b/src/renderer/src/hooks/useComposerState-gitlab-base-branch-reset.test.ts
@@ -25,11 +25,7 @@ describe('useComposerState clears stale start-point state on GitLab item selecti
     // from the wrong place, or a stale fork pushTarget from an earlier GitHub PR could
     // leak into a GitLab create. Mirrors handleSmartGitHubItemSelect's
     // setBaseBranch/setPushTarget(undefined) on both sides of its type check.
-    const shortCircuit = sourceBetween(
-      section,
-      "if (item.type !== 'mr' || !runRepo) {",
-      '}'
-    )
+    const shortCircuit = sourceBetween(section, "if (item.type !== 'mr' || !runRepo) {", '}')
     expect(shortCircuit).toContain('setBaseBranch(undefined)')
     expect(shortCircuit).toContain('setPushTarget(undefined)')
 
@@ -50,7 +46,7 @@ describe('useComposerState clears stale start-point state on GitLab item selecti
     // second GitLab item while the first MR's resolution is still in flight let
     // the stale .then/.catch overwrite the newer selection's baseBranch,
     // pushTarget, and linked work item (mirrors the GitHub PR ref's guard).
-    const invalidateAt = section.indexOf('smartGitLabMrStartPointSelectionRef.current = null')
+    const invalidateAt = section.indexOf('invalidateSmartStartPointSelections()')
     const projectGroupCheckAt = section.indexOf('if (isProjectGroupTarget) {')
     expect(invalidateAt).toBeGreaterThanOrEqual(0)
     expect(invalidateAt).toBeLessThan(projectGroupCheckAt)
@@ -70,5 +66,44 @@ describe('useComposerState clears stale start-point state on GitLab item selecti
     expect(catchSection).toContain(
       'if (smartGitLabMrStartPointSelectionRef.current !== mrStartPointSelection) {'
     )
+  })
+})
+
+describe('useComposerState invalidates both PR/MR start-point refs together', () => {
+  it('defines one helper that nulls the GitHub PR and GitLab MR refs together', () => {
+    const helper = sourceBetween(
+      HOOK_SOURCE,
+      'const invalidateSmartStartPointSelections = useCallback((): void => {',
+      '}, [])'
+    )
+    expect(helper).toContain('smartGitHubPrStartPointSelectionRef.current = null')
+    expect(helper).toContain('smartGitLabMrStartPointSelectionRef.current = null')
+  })
+
+  it('calls the shared invalidator from every competing selection, not just a GitLab item pick', () => {
+    // Why: a pending GitLab MR (or GitHub PR) base resolution is async — any other
+    // action that changes what's selected (a different provider's item, a manual
+    // base/branch pick, a repo change, or clearing the source) must invalidate it
+    // too, or the stale .then/.catch can still land and restore old state.
+    const handlers = [
+      'const handleSelectLinkedItem = useCallback(',
+      'const handleRemoveLinkedWorkItem = useCallback((): void => {',
+      'const handleRepoChange = useCallback(',
+      'const handleFolderSourceRepoChange = useCallback(',
+      'const handleBaseBranchChange = useCallback(',
+      'const handleSmartGitHubItemSelect = useCallback(',
+      'const handleSmartGitLabItemSelect = useCallback(',
+      'const handleSmartBranchSelect = useCallback(',
+      'const handleSmartLinearIssueSelect = useCallback(',
+      'const handleSmartJiraIssueSelect = useCallback(',
+      'const handleClearSmartNameSelection = useCallback((): void => {'
+    ]
+
+    for (let i = 0; i < handlers.length; i += 1) {
+      const start = handlers[i]
+      const end = handlers[i + 1] ?? 'const smartNameSelection = useMemo<SmartWorkspaceNameSelection | null>('
+      const section = sourceBetween(HOOK_SOURCE, start, end)
+      expect(section).toContain('invalidateSmartStartPointSelections()')
+    }
   })
 })

--- a/src/renderer/src/hooks/useComposerState-gitlab-base-branch-reset.test.ts
+++ b/src/renderer/src/hooks/useComposerState-gitlab-base-branch-reset.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const HOOK_SOURCE = readFileSync(join(__dirname, 'useComposerState.ts'), 'utf8')
+
+function sourceBetween(source: string, startPattern: string, endPattern: string): string {
+  const start = source.indexOf(startPattern)
+  expect(start).toBeGreaterThanOrEqual(0)
+  const end = source.indexOf(endPattern, start + startPattern.length)
+  expect(end).toBeGreaterThan(start)
+  return source.slice(start, end)
+}
+
+describe('useComposerState clears a stale base branch on GitLab item selection', () => {
+  it('clears baseBranch on both the issue short-circuit and the MR resolution path', () => {
+    const section = sourceBetween(
+      HOOK_SOURCE,
+      'const handleSmartGitLabItemSelect = useCallback(',
+      'const handleSmartBranchSelect = useCallback('
+    )
+
+    // Why: without this, selecting a GitLab issue/MR after a Start-from branch (or a
+    // prior PR/MR) pick kept the old baseBranch and would branch the workspace from
+    // the wrong place — mirrors handleSmartGitHubItemSelect's setBaseBranch(undefined)
+    // on both sides of its type check.
+    const shortCircuit = sourceBetween(
+      section,
+      "if (item.type !== 'mr' || !runRepo) {",
+      '}'
+    )
+    expect(shortCircuit).toContain('setBaseBranch(undefined)')
+
+    const afterShortCircuit = section.slice(section.indexOf(shortCircuit) + shortCircuit.length)
+    const mrPath = sourceBetween(afterShortCircuit, '', 'const itemRepoSettings =')
+    expect(mrPath).toContain('setBaseBranch(undefined)')
+  })
+})

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -1287,6 +1287,14 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   // GitLab item pick must not restore an old baseBranch/pushTarget/linkedWorkItem
   // over whatever the user selected next (mirrors the GitHub PR ref above).
   const smartGitLabMrStartPointSelectionRef = useRef<object | null>(null)
+  // Why: any competing selection (a different work item, a manual base/branch
+  // pick, a repo change, or clearing the source) must invalidate BOTH pending
+  // async resolutions together, or whichever one is still in flight can land
+  // after the fact and overwrite the newer selection's state.
+  const invalidateSmartStartPointSelections = useCallback((): void => {
+    smartGitHubPrStartPointSelectionRef.current = null
+    smartGitLabMrStartPointSelectionRef.current = null
+  }, [])
   useEffect(() => {
     const clearAutoManagedName = (): void => {
       if (nameRef.current === lastAutoNameRef.current) {
@@ -2337,7 +2345,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   // Why: review routing prefers one provider identity — clear the opposite provider slots so stale hidden fields can't win later.
   const applyLinkedGitLabWorkItem = useCallback(
     (item: GitLabWorkItem): void => {
-      smartGitHubPrStartPointSelectionRef.current = null
+      invalidateSmartStartPointSelections()
       if (item.type === 'issue') {
         setLinkedGitLabIssue(item.number)
         setLinkedGitLabMR(null)
@@ -2383,19 +2391,19 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       setBranchNameOverridePreservesNameEdits(false)
       branchAutoNameRef.current = ''
     },
-    [name]
+    [invalidateSmartStartPointSelections, name]
   )
 
   const handleSelectLinkedItem = useCallback(
     (item: GitHubWorkItem): void => {
-      smartGitHubPrStartPointSelectionRef.current = null
+      invalidateSmartStartPointSelections()
       applyLinkedWorkItem(item)
       setLinkPopoverOpen(false)
       setLinkQuery('')
       setLinkDebouncedQuery('')
       setLinkDirectItem(null)
     },
-    [applyLinkedWorkItem]
+    [applyLinkedWorkItem, invalidateSmartStartPointSelections]
   )
 
   const handleLinkPopoverChange = useCallback((open: boolean): void => {
@@ -2408,7 +2416,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   }, [])
 
   const handleRemoveLinkedWorkItem = useCallback((): void => {
-    smartGitHubPrStartPointSelectionRef.current = null
+    invalidateSmartStartPointSelections()
     const removedLinearItem = isLinearLinkedWorkItem(linkedWorkItem)
     setLinkedWorkItem(null)
     setLinkedTaskSourceContext(null)
@@ -2424,7 +2432,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       setBranchNameOverridePreservesNameEdits(false)
       branchAutoNameRef.current = ''
     }
-  }, [linkedWorkItem, name])
+  }, [invalidateSmartStartPointSelections, linkedWorkItem, name])
 
   const handleNameValueChange = useCallback(
     (nextName: string): void => {
@@ -2743,7 +2751,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         setForkPushWarning(null)
       }
       if (!options.preserveStartFrom) {
-        smartGitHubPrStartPointSelectionRef.current = null
+        invalidateSmartStartPointSelections()
         setLinkedIssue('')
         setLinkedPR(null)
         setLinkedGitLabIssue(null)
@@ -2776,7 +2784,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         setStartFromResetHint(hint)
       }
     },
-    [baseBranch, linkedWorkItem, repoId, setRepoId]
+    [baseBranch, invalidateSmartStartPointSelections, linkedWorkItem, repoId, setRepoId]
   )
   const handleFolderSourceRepoChange = useCallback(
     (value: string): void => {
@@ -2784,7 +2792,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         return
       }
       setRepoId(value)
-      smartGitHubPrStartPointSelectionRef.current = null
+      invalidateSmartStartPointSelections()
       setLinkedWorkItem((current) =>
         current && !shouldPreserveWorkspaceSourceOnRepoChange(current) ? null : current
       )
@@ -2796,7 +2804,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       setLinkedGitLabIssue(null)
       setLinkedGitLabMR(null)
     },
-    [folderSourceRepos, linkedWorkItem, setRepoId]
+    [folderSourceRepos, invalidateSmartStartPointSelections, linkedWorkItem, setRepoId]
   )
   const handleProjectHostSetupChange = useCallback(
     (setupId: string): void => {
@@ -2945,7 +2953,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
 
   const handleBaseBranchChange = useCallback(
     (next: string | undefined): void => {
-      smartGitHubPrStartPointSelectionRef.current = null
+      invalidateSmartStartPointSelections()
       setBaseBranch(next)
       setCompareBaseRef(undefined)
       setPushTarget(undefined)
@@ -2963,7 +2971,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       setForkPushWarning(null)
       setStartFromResetHint(null)
     },
-    [linkedWorkItem]
+    [invalidateSmartStartPointSelections, linkedWorkItem]
   )
 
   const handleBaseBranchPrSelect = useCallback(
@@ -3026,6 +3034,9 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
 
   const handleSmartGitHubItemSelect = useCallback(
     (item: GitHubWorkItem): void => {
+      // Why: invalidate any in-flight PR/MR base resolution from a prior
+      // selection before doing anything else, so a stale one is a no-op.
+      invalidateSmartStartPointSelections()
       const identity = resolveGitHubWorkItemIdentity(item)
       const normalizedItem: GitHubWorkItem = {
         ...item,
@@ -3058,7 +3069,6 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       setBranchNameOverridePreservesNameEdits(false)
       setForkPushWarning(null)
       branchAutoNameRef.current = ''
-      smartGitHubPrStartPointSelectionRef.current = null
       // Why: provider items can come from a different source host than the run host — resolve refs against the run repo, keep item metadata for provider identity.
       const runRepo = selectedRepo ?? eligibleRepos.find((repo) => repo.id === item.repoId)
       applyLinkedWorkItem(normalizedItem)
@@ -3124,6 +3134,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       applyLinkedWorkItem,
       eligibleRepos,
       handleBaseBranchPrSelect,
+      invalidateSmartStartPointSelections,
       isProjectGroupTarget,
       name,
       selectedRepo,
@@ -3135,9 +3146,9 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   // Why: GitLab parallel of handleSmartGitHubItemSelect — resolves MR base via worktrees:resolveMrBase (refs/merge-requests/<iid>/head); issues short-circuit.
   const handleSmartGitLabItemSelect = useCallback(
     (item: GitLabWorkItem): void => {
-      // Why: invalidate any in-flight MR base resolution from a prior selection
+      // Why: invalidate any in-flight PR/MR base resolution from a prior selection
       // before doing anything else, so its eventual .then/.catch is a no-op.
-      smartGitLabMrStartPointSelectionRef.current = null
+      invalidateSmartStartPointSelections()
       if (isProjectGroupTarget) {
         const linkedItem = toGitLabLinkedWorkItem(item)
         setLinkedGitLabIssue(item.type === 'issue' ? item.number : null)
@@ -3249,6 +3260,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       applyLinkedGitLabWorkItem,
       eligibleRepos,
       handleBaseBranchMrSelect,
+      invalidateSmartStartPointSelections,
       isProjectGroupTarget,
       name,
       selectedRepo,
@@ -3258,7 +3270,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
 
   const handleSmartBranchSelect = useCallback(
     (refName: string, localBranchName: string): void => {
-      smartGitHubPrStartPointSelectionRef.current = null
+      invalidateSmartStartPointSelections()
       const selection = resolveComposerBranchPick({
         refName,
         localBranchName,
@@ -3287,7 +3299,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         branchAutoNameRef.current = selection.branchNameOverride ? selection.branchAutoName : ''
       }
     },
-    [name, worktreesByRepo, repoId]
+    [invalidateSmartStartPointSelections, name, worktreesByRepo, repoId]
   )
 
   const handleReuseSelectedBranchChange = useCallback(
@@ -3308,6 +3320,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
 
   const handleSmartLinearIssueSelect = useCallback(
     (issue: LinearIssue): void => {
+      invalidateSmartStartPointSelections()
       if (isProjectGroupTarget) {
         const linkedItem = toLinearLinkedWorkItem(issue)
         setLinkedIssue('')
@@ -3356,11 +3369,12 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       branchAutoNameRef.current = linearBranchName ?? ''
       // Why: don't prefill the note for a Linear pick — that would turn a source selection into user-authored instructions (matches the GitHub flow).
     },
-    [isProjectGroupTarget, name]
+    [invalidateSmartStartPointSelections, isProjectGroupTarget, name]
   )
 
   const handleSmartJiraIssueSelect = useCallback(
     (issue: JiraIssue, sourceContext: TaskSourceContext): void => {
+      invalidateSmartStartPointSelections()
       const linkedItem: LinkedWorkItemSummary = buildJiraWorkspaceSource(issue)
       setLinkedIssue('')
       setLinkedPR(null)
@@ -3390,11 +3404,11 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         lastAutoNameRef.current = suggestedName
       }
     },
-    [name]
+    [invalidateSmartStartPointSelections, name]
   )
 
   const handleClearSmartNameSelection = useCallback((): void => {
-    smartGitHubPrStartPointSelectionRef.current = null
+    invalidateSmartStartPointSelections()
     setLinkedIssue('')
     setLinkedPR(null)
     setLinkedGitLabIssue(null)
@@ -3419,7 +3433,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       setNote('')
       lastAutoNoteRef.current = ''
     }
-  }, [name])
+  }, [invalidateSmartStartPointSelections, name])
 
   const smartNameSelection = useMemo<SmartWorkspaceNameSelection | null>(() => {
     if (isProjectGroupTarget) {

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -3163,10 +3163,12 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       if (item.type !== 'mr' || !runRepo) {
         setBaseBranch(undefined)
         setCompareBaseRef(undefined)
+        setPushTarget(undefined)
         return
       }
       setBaseBranch(undefined)
       setCompareBaseRef(undefined)
+      setPushTarget(undefined)
       const itemRepoSettings = getSettingsForRepoRuntimeOwner(
         { repos: [runRepo], settings },
         runRepo.id

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -3161,9 +3161,11 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       // Why: MR metadata can be sourced from one host/account while the workspace is created on another for the same logical project.
       const runRepo = selectedRepo ?? eligibleRepos.find((repo) => repo.id === item.repoId)
       if (item.type !== 'mr' || !runRepo) {
+        setBaseBranch(undefined)
         setCompareBaseRef(undefined)
         return
       }
+      setBaseBranch(undefined)
       setCompareBaseRef(undefined)
       const itemRepoSettings = getSettingsForRepoRuntimeOwner(
         { repos: [runRepo], settings },

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -2734,6 +2734,11 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         ? getLinearLinkedWorkItemBranchName(linkedWorkItem)
         : undefined
       setRepoId(value)
+      // Why: unlike the GitHub PR ref (retargeted below), a pending GitLab MR
+      // resolution has no per-repo retarget path — its identity token must
+      // never survive a repo change, preserveStartFrom or not, or a stale
+      // .then/.catch could apply the old repo's base/compare/push target here.
+      smartGitLabMrStartPointSelectionRef.current = null
       if (!options.preserveStartFrom) {
         setSelectedProjectHostSetupOverrideId(null)
       }
@@ -2840,6 +2845,11 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   )
   const handleProjectChange = useCallback(
     (projectId: string): void => {
+      // Why: the folder-project branch below mutates repoId/start-point state
+      // directly instead of going through handleRepoChange, so it needs its own
+      // invalidation before a pending PR/MR resolution can land against the
+      // project being left.
+      invalidateSmartStartPointSelections()
       initialProjectGroupAppliedRef.current = true
       const projectGroupId = getProjectGroupIdFromNewWorkspaceOptionId(projectId)
       if (projectGroupId) {
@@ -2906,6 +2916,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       eligibleRepos,
       actionableHostIds,
       handleRepoChange,
+      invalidateSmartStartPointSelections,
       isProjectGroupTarget,
       linkedWorkItem,
       projectGroups,

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -2939,20 +2939,28 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     }
   }, [])
 
-  const handleBaseBranchChange = useCallback((next: string | undefined): void => {
-    smartGitHubPrStartPointSelectionRef.current = null
-    setBaseBranch(next)
-    setCompareBaseRef(undefined)
-    setPushTarget(undefined)
-    setBranchNameOverride(undefined)
-    // Why (#5181): Start-from means "new branch from this base", so it never reuses — clear reuse state from a prior smart-field branch pick.
-    setBranchNameOverridePreservesNameEdits(false)
-    setReuseEligibleBranch(null)
-    setReuseSelectedBranch(false)
-    setForkPushWarning(null)
-    branchAutoNameRef.current = ''
-    setStartFromResetHint(null)
-  }, [])
+  const handleBaseBranchChange = useCallback(
+    (next: string | undefined): void => {
+      smartGitHubPrStartPointSelectionRef.current = null
+      setBaseBranch(next)
+      setCompareBaseRef(undefined)
+      setPushTarget(undefined)
+      // Why: a linked task's branch name (e.g. Linear's canonical branch) is
+      // independent of the base it's cut from — a base pick here must not
+      // wipe it, unlike a bare "Start-from" branch pick.
+      if (!linkedWorkItem) {
+        setBranchNameOverride(undefined)
+        // Why (#5181): Start-from means "new branch from this base", so it never reuses — clear reuse state from a prior smart-field branch pick.
+        setBranchNameOverridePreservesNameEdits(false)
+        setReuseEligibleBranch(null)
+        setReuseSelectedBranch(false)
+        branchAutoNameRef.current = ''
+      }
+      setForkPushWarning(null)
+      setStartFromResetHint(null)
+    },
+    [linkedWorkItem]
+  )
 
   const handleBaseBranchPrSelect = useCallback(
     (

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -1283,6 +1283,10 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       repoId: selectedRepo?.id ?? initialRepoId
     })
   )
+  // Why: resolveMrBase resolves async — a stale promise from a since-superseded
+  // GitLab item pick must not restore an old baseBranch/pushTarget/linkedWorkItem
+  // over whatever the user selected next (mirrors the GitHub PR ref above).
+  const smartGitLabMrStartPointSelectionRef = useRef<object | null>(null)
   useEffect(() => {
     const clearAutoManagedName = (): void => {
       if (nameRef.current === lastAutoNameRef.current) {
@@ -3131,6 +3135,9 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   // Why: GitLab parallel of handleSmartGitHubItemSelect — resolves MR base via worktrees:resolveMrBase (refs/merge-requests/<iid>/head); issues short-circuit.
   const handleSmartGitLabItemSelect = useCallback(
     (item: GitLabWorkItem): void => {
+      // Why: invalidate any in-flight MR base resolution from a prior selection
+      // before doing anything else, so its eventual .then/.catch is a no-op.
+      smartGitLabMrStartPointSelectionRef.current = null
       if (isProjectGroupTarget) {
         const linkedItem = toGitLabLinkedWorkItem(item)
         setLinkedGitLabIssue(item.type === 'issue' ? item.number : null)
@@ -3169,6 +3176,8 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       setBaseBranch(undefined)
       setCompareBaseRef(undefined)
       setPushTarget(undefined)
+      const mrStartPointSelection = {}
+      smartGitLabMrStartPointSelectionRef.current = mrStartPointSelection
       const itemRepoSettings = getSettingsForRepoRuntimeOwner(
         { repos: [runRepo], settings },
         runRepo.id
@@ -3204,6 +3213,9 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
             )
       void resolveMrBase
         .then((result) => {
+          if (smartGitLabMrStartPointSelectionRef.current !== mrStartPointSelection) {
+            return
+          }
           if ('error' in result) {
             // Why: an unsurfaced failure silently falls back to the repo default branch, so clear stale base state and toast — mirrors the GitHub PR path.
             setBaseBranch(undefined)
@@ -3220,6 +3232,9 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
           )
         })
         .catch((error: unknown) => {
+          if (smartGitLabMrStartPointSelectionRef.current !== mrStartPointSelection) {
+            return
+          }
           setBaseBranch(undefined)
           setCompareBaseRef(undefined)
           setPushTarget(undefined)

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -1523,7 +1523,8 @@
         "addSshHostHint": "Use an existing machine over SSH",
         "addRemoteOrcaServer": "Add Remote Orca Server",
         "addRemoteOrcaServerHint": "Pair another Orca runtime",
-        "hostConnectionFailed": "Connection failed"
+        "hostConnectionFailed": "Connection failed",
+        "branchFrom": "Branch from"
       },
       "NewWorkspaceComposerModal": {
         "createWorktree": "Create worktree",

--- a/src/shared/new-workspace/workspace-source.test.ts
+++ b/src/shared/new-workspace/workspace-source.test.ts
@@ -5,8 +5,10 @@ import {
   buildWorkspaceSourceSelection,
   getWorkspaceSourceName,
   getWorkspaceSourceProvider,
+  isBaseBranchSelectableSourceKind,
   shouldApplyWorkspaceSourceAutoName,
-  shouldPreserveWorkspaceSourceOnRepoChange
+  shouldPreserveWorkspaceSourceOnRepoChange,
+  type WorkspaceSourceSelectionKind
 } from './workspace-source'
 
 describe('workspace source policy', () => {
@@ -122,5 +124,20 @@ describe('workspace source policy', () => {
     expect(
       shouldApplyWorkspaceSourceAutoName({ currentName: 'my workspace', lastAutoName: 'old' })
     ).toBe(false)
+  })
+
+  it('allows picking a base branch only for sources whose branch is not itself the base', () => {
+    const expected: Record<WorkspaceSourceSelectionKind, boolean> = {
+      'github-pr': false,
+      'github-issue': true,
+      'gitlab-mr': false,
+      'gitlab-issue': true,
+      branch: false,
+      linear: true,
+      jira: true
+    }
+    for (const [kind, allowed] of Object.entries(expected)) {
+      expect(isBaseBranchSelectableSourceKind(kind as WorkspaceSourceSelectionKind)).toBe(allowed)
+    }
   })
 })

--- a/src/shared/new-workspace/workspace-source.ts
+++ b/src/shared/new-workspace/workspace-source.ts
@@ -215,6 +215,12 @@ export function buildWorkspaceSourceSelection(args: {
   }
 }
 
+/** True when the source's branch isn't itself the base — a base can still be picked manually.
+ *  False for a PR/MR (base comes from the PR/MR start-point) and a bare branch pick (it IS the base). */
+export function isBaseBranchSelectableSourceKind(kind: WorkspaceSourceSelectionKind): boolean {
+  return kind === 'github-issue' || kind === 'gitlab-issue' || kind === 'linear' || kind === 'jira'
+}
+
 export function shouldPreserveWorkspaceSourceOnRepoChange(
   item: WorkspaceSourceItemLike | null
 ): boolean {


### PR DESCRIPTION
ELI5

When you start a new workspace from a task (a GitHub issue, GitLab issue, Linear issue, or Jira issue), Orca always branched the new worktree off the project's default branch. Now there's a "Branch from" dropdown in the workspace creation form so you can pick a different starting branch — a release branch, a feature branch, whatever the work actually builds on.

What Changed





Moved the existing "Branch from" combobox out of Automations into a shared location (components/new-workspace/BranchFromPicker.tsx, renamed from CreateFromPicker) so the workspace composer can reuse it. Kept its i18n key literals unchanged so no locale strings churned.



Added isBaseBranchSelectableSourceKind (src/shared/new-workspace/workspace-source.ts) to decide when a base-branch pick makes sense: yes for GitHub/GitLab issues, Linear, and Jira; no for a PR/MR (its base comes from the PR/MR itself) or a bare branch pick (the picked branch already is the base).



Rendered the picker in NewWorkspaceComposerCard.tsx, gated on: a git project is selected, branches are enabled, and the active source pill is one of the selectable kinds above.



Fixed handleBaseBranchChange in useComposerState.ts so picking a base branch no longer clears a linked task's canonical branch-name override (Linear supplies one; this used to get wiped on every base change).



Added the branchFrom locale key and synced en.json via the project's localization tooling.

Everything downstream of the UI — baseBranch in the create request, IPC, main-process base-ref resolution/fallback, the actual git worktree add -b ... <base>, and SSH/relay parity — already existed and needed no changes.

Why

The task-seeded composer path was the one place base-branch selection was structurally impossible: the source pill occupies the same field that a manual branch pick would use. Everything the picker needs (search, default-ref resolution, remote-branch handling) was already built for Automations; this reuses it instead of building a second implementation.

Linked Issue

Fixes #15747

Visual Proof

<!-- Not yet captured — before/after screenshots of the composer (with and without the picker visible for a PR vs. an issue source) still need to be attached here. -->

Testing





pnpm typecheck (all projects)



Targeted vitest run across the touched surfaces (NewWorkspaceComposerCard*.test.tsx, BranchFromPicker.test.tsx, automations/*, shared/new-workspace/*, hooks/*) — 1131 tests passed



oxlint on touched files



check:max-lines-ratchet



verify:localization-catalog, verify:localization-extraction, verify:localization-coverage



Full pnpm lint / pnpm test / pnpm build



Manual verification in the running Electron app (Tasks → issue/Linear/Jira → composer shows the picker; PR/sidebar paths don't)





I manually tested these changes locally



Automated tests added/updated

AI Disclosure

Implemented with Claude Code (Claude Sonnet 5), plan reviewed and approved before implementation.

Review

Self-review: no cross-platform-specific code (pure renderer UI + shared TS logic, no OS/path/shell branching); SSH/remote already handled by existing baseBranch plumbing (untouched); no new git-provider assumptions (works identically for GitHub/GitLab/Linear/Jira sources); no new dependencies or hot-path work; no secrets or user input reaches a shell/URL.

Agent skill upstream boundary





Not applicable, or this change follows docs/reference/agent-skill-sharing-upstream-boundary.md and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

Notes

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

Checklist





This PR is small and focused



I explained what changed and why (including ELI5)



Before/after screenshots or videos attached for UI changes, or N/A with reason



Self-reviewed for correctness, security, and performance



Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)



pnpm lint, pnpm typecheck, pnpm test, and pnpm build pass (or CI will cover; local preferred)

