### PR TITLE
fix: flag a config host whose machine is already registered under another name

### DIFF
--- a/src/main/ssh/ssh-config-host-picker.test.ts
+++ b/src/main/ssh/ssh-config-host-picker.test.ts
@@ -57,6 +57,58 @@ describe('SSH config host picker search', () => {
     expect(last.hasMore).toBe(false)
   })
 
+  it('flags a config host whose machine is already registered under another label', () => {
+    // Why: the same box gets added twice — once manually by IP, once from the config
+    // picker — and alias comparison cannot see that because the names differ.
+    const result = searchSshConfigHosts(
+      [{ host: 'aimp', hostname: '172.16.203.131', user: 'chanmuzi' }],
+      [
+        {
+          configHost: '172.16.203.131',
+          label: 'AI Box',
+          host: '172.16.203.131',
+          port: 22,
+          username: 'chanmuzi'
+        }
+      ]
+    )
+
+    expect(result.hosts[0]).toMatchObject({ alias: 'aimp', alreadyInOrca: true })
+    expect(result.newHostCount).toBe(0)
+  })
+
+  it('leaves a different machine unflagged', () => {
+    const result = searchSshConfigHosts(
+      [{ host: 'aimp', hostname: '172.16.203.131', user: 'chanmuzi' }],
+      [
+        {
+          configHost: '10.0.0.9',
+          label: 'Other Box',
+          host: '10.0.0.9',
+          port: 22,
+          username: 'chanmuzi'
+        }
+      ]
+    )
+
+    expect(result.hosts[0]).toMatchObject({ alias: 'aimp', alreadyInOrca: false })
+    expect(result.newHostCount).toBe(1)
+  })
+
+  it('does not collide config hosts that carry no HostName', () => {
+    // Why: without HostName the candidate host degrades to the alias itself, so the
+    // endpoint check must not start matching unrelated aliases against each other.
+    const result = searchSshConfigHosts(
+      [{ host: 'alpha' }, { host: 'beta' }],
+      [{ configHost: 'gamma', label: 'Gamma', host: 'gamma', port: 22, username: '' }]
+    )
+
+    expect(result.hosts.map((host) => [host.alias, host.alreadyInOrca])).toEqual([
+      ['alpha', false],
+      ['beta', false]
+    ])
+  })
+
   it('counts de-duplicated and existing aliases while matching effective display fields', () => {
     const result = searchSshConfigHosts(
       [

--- a/src/main/ssh/ssh-config-host-picker.ts
+++ b/src/main/ssh/ssh-config-host-picker.ts
@@ -5,7 +5,7 @@ import type {
   SshTarget
 } from '../../shared/ssh-types'
 import { SSH_CONFIG_HOST_RESULT_LIMIT } from '../../shared/ssh-types'
-import { normalizeSshConfigAlias } from '../../shared/ssh-config-alias'
+import { normalizeSshConfigAlias, sshEndpointIdentity } from '../../shared/ssh-config-alias'
 import { loadUserSshConfig, type SshConfigHost } from './ssh-config-parser'
 import { resolveWithSshG, type SshResolvedConfig } from './ssh-g-config-resolution'
 
@@ -27,7 +27,10 @@ function getUserSshConfigHosts(refresh: boolean): SshConfigHost[] {
 
 export function searchSshConfigHosts(
   hosts: SshConfigHost[],
-  existingTargets: readonly Pick<SshTarget, 'configHost' | 'label'>[],
+  // Why partial: callers that only know the names still type-check, and an entry with
+  // no host yields an empty identity rather than a false match.
+  existingTargets: readonly (Pick<SshTarget, 'configHost' | 'label'> &
+    Partial<Pick<SshTarget, 'host' | 'port' | 'username'>>)[],
   query = '',
   suppressedAliases: readonly string[] = []
 ): SshConfigHostListResult {
@@ -36,6 +39,9 @@ export function searchSshConfigHosts(
       [target.configHost, target.label].map(normalizeSshConfigAlias).filter(Boolean)
     )
   )
+  // Why: the same machine can be registered twice under different names — once by IP,
+  // once from this picker — and comparing names cannot see that.
+  const existingEndpoints = new Set(existingTargets.map(sshEndpointIdentity).filter(Boolean))
   const normalizedQuery = query.trim().toLowerCase()
   const suppressedAliasSet = new Set(suppressedAliases.map(normalizeSshConfigAlias))
   const summaries: SshConfigHostSummary[] = []
@@ -50,7 +56,13 @@ export function searchSshConfigHosts(
       continue
     }
     seenAliases.add(normalizedAlias)
-    const alreadyInOrca = existingAliases.has(normalizedAlias)
+    // Why `entry.hostname` only: without HostName the candidate host degrades to the
+    // alias itself, and matching on that would just re-run the alias check.
+    const endpoint = entry.hostname
+      ? sshEndpointIdentity({ host: entry.hostname, port: entry.port, username: entry.user })
+      : ''
+    const alreadyInOrca =
+      existingAliases.has(normalizedAlias) || (endpoint !== '' && existingEndpoints.has(endpoint))
     // Why: tombstones only block passive bulk import — the picker still lists the
     // Host so deleting one Orca target never looks like "~/.ssh/config is empty".
     const previouslyRemoved = !alreadyInOrca && suppressedAliasSet.has(normalizedAlias)
@@ -76,7 +88,10 @@ export function searchSshConfigHosts(
 }
 
 export function listUserSshConfigHostSummaries(
-  existingTargets: readonly Pick<SshTarget, 'configHost' | 'label'>[],
+  // Why partial: callers that only know the names still type-check, and an entry with
+  // no host yields an empty identity rather than a false match.
+  existingTargets: readonly (Pick<SshTarget, 'configHost' | 'label'> &
+    Partial<Pick<SshTarget, 'host' | 'port' | 'username'>>)[],
   query?: string,
   suppressedAliases?: readonly string[],
   options?: { refresh?: boolean }

--- a/src/shared/ssh-config-alias.test.ts
+++ b/src/shared/ssh-config-alias.test.ts
@@ -45,8 +45,17 @@ describe('sshEndpointIdentity', () => {
     expect(sshEndpointIdentity({ port: 22, username: 'me' })).toBe('')
   })
 
-  it('ignores a non-finite port rather than keying on NaN', () => {
-    expect(sshEndpointIdentity({ host: 'box', port: Number.NaN, username: 'me' })).toBe(
+  it.each([Number.NaN, 0, -1, 1.5, 65_536])(
+    'normalizes invalid port %s to the SSH default',
+    (port) => {
+      expect(sshEndpointIdentity({ host: 'box', port, username: 'me' })).toBe(
+        sshEndpointIdentity({ host: 'box', port: 22, username: 'me' })
+      )
+    }
+  )
+
+  it.each([1, 65_535])('keeps valid boundary port %s', (port) => {
+    expect(sshEndpointIdentity({ host: 'box', port, username: 'me' })).not.toBe(
       sshEndpointIdentity({ host: 'box', port: 22, username: 'me' })
     )
   })

--- a/src/shared/ssh-config-alias.test.ts
+++ b/src/shared/ssh-config-alias.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { sshEndpointIdentity } from './ssh-config-alias'
+
+describe('sshEndpointIdentity', () => {
+  it('treats the same machine reached under different names as one endpoint', () => {
+    const manual = sshEndpointIdentity({
+      host: '172.16.203.131',
+      port: 22,
+      username: 'chanmuzi'
+    })
+    const fromConfig = sshEndpointIdentity({
+      host: '172.16.203.131',
+      port: 22,
+      username: 'chanmuzi'
+    })
+
+    expect(manual).toBe(fromConfig)
+  })
+
+  it('defaults a missing port to 22 so an explicit 22 matches an omitted one', () => {
+    expect(sshEndpointIdentity({ host: 'box', username: 'me' })).toBe(
+      sshEndpointIdentity({ host: 'box', port: 22, username: 'me' })
+    )
+  })
+
+  it('separates host, port and user so no concatenation can alias them', () => {
+    // Why: 'a' + '1:2' and 'a:1' + '2' must not collapse into the same key.
+    expect(sshEndpointIdentity({ host: 'a', port: 12, username: '' })).not.toBe(
+      sshEndpointIdentity({ host: 'a', port: 1, username: '2' })
+    )
+  })
+
+  it('folds host and user case but keeps a different user distinct', () => {
+    expect(sshEndpointIdentity({ host: 'BOX', port: 22, username: 'Me' })).toBe(
+      sshEndpointIdentity({ host: 'box', port: 22, username: 'me' })
+    )
+    expect(sshEndpointIdentity({ host: 'box', port: 22, username: 'me' })).not.toBe(
+      sshEndpointIdentity({ host: 'box', port: 22, username: 'other' })
+    )
+  })
+
+  it('is empty for an unknown host so unresolved entries never collide', () => {
+    expect(sshEndpointIdentity({ host: '', port: 22, username: 'me' })).toBe('')
+    expect(sshEndpointIdentity({ host: '   ', port: 22, username: 'me' })).toBe('')
+    expect(sshEndpointIdentity({ port: 22, username: 'me' })).toBe('')
+  })
+
+  it('ignores a non-finite port rather than keying on NaN', () => {
+    expect(sshEndpointIdentity({ host: 'box', port: Number.NaN, username: 'me' })).toBe(
+      sshEndpointIdentity({ host: 'box', port: 22, username: 'me' })
+    )
+  })
+})

--- a/src/shared/ssh-config-alias.ts
+++ b/src/shared/ssh-config-alias.ts
@@ -6,3 +6,18 @@
 export function normalizeSshConfigAlias(alias: string | null | undefined): string {
   return alias ? alias.trim().toLowerCase() : ''
 }
+
+/** The machine a target actually reaches: hostname, port and user, normalized.
+ *  Empty when the host is unknown, so an unresolved alias never collides. */
+export function sshEndpointIdentity(target: {
+  host?: string | null
+  port?: number | null
+  username?: string | null
+}): string {
+  const host = target.host?.trim().toLowerCase() ?? ''
+  if (!host) {
+    return ''
+  }
+  const port = typeof target.port === 'number' && Number.isFinite(target.port) ? target.port : 22
+  return `${host}\u0000${port}\u0000${target.username?.trim().toLowerCase() ?? ''}`
+}

--- a/src/shared/ssh-config-alias.ts
+++ b/src/shared/ssh-config-alias.ts
@@ -18,6 +18,12 @@ export function sshEndpointIdentity(target: {
   if (!host) {
     return ''
   }
-  const port = typeof target.port === 'number' && Number.isFinite(target.port) ? target.port : 22
+  const port =
+    typeof target.port === 'number' &&
+    Number.isInteger(target.port) &&
+    target.port >= 1 &&
+    target.port <= 65_535
+      ? target.port
+      : 22
   return `${host}\u0000${port}\u0000${target.username?.trim().toLowerCase() ?? ''}`
 }


### PR DESCRIPTION
## ELI5

Add a machine by IP, then open the ssh-config picker: the same box shows up as new, because Orca compared the *names* and `172.16.203.131` is not the string `aimp`. Now it also compares where the entry actually connects, so the picker says it is already there.

## What Changed

New pure function in `shared/ssh-config-alias.ts` — host, port and user, normalized and NUL-separated:

```ts
export function sshEndpointIdentity(target: {
  host?: string | null; port?: number | null; username?: string | null
}): string {
  const host = target.host?.trim().toLowerCase() ?? ''
  if (!host) return ''
  const port = typeof target.port === 'number' && Number.isFinite(target.port) ? target.port : 22
  return [host, port, target.username?.trim().toLowerCase() ?? ''].join(NUL)
}
```

`searchSshConfigHosts` now flags a candidate when **either** its alias or its endpoint matches an existing target:

```ts
const endpoint = entry.hostname
  ? sshEndpointIdentity({ host: entry.hostname, port: entry.port, username: entry.user })
  : ''
const alreadyInOrca =
  existingAliases.has(normalizedAlias) || (endpoint !== '' && existingEndpoints.has(endpoint))
```

## Why

The duplicate check was name-only, so two names for one machine both pass:

```
manual   { label: 'AI Box', configHost: '172.16.203.131', host: '172.16.203.131' }
picker   Host aimp / HostName 172.16.203.131
```

Nothing there is string-equal. Both targets then connect to the same endpoint and attach to the same relay daemon, so they list the same remote sessions and operating either one drives the same underlying ones — from the UI it looks like clicking one host also clicks the other.

`alreadyInOrca` is a display flag, not a gate. A deliberate second target for the same endpoint (different identity file, different jump host) still gets added; it just says so first. That matches the reporter's "warn or offer to merge rather than silently create".

## Scope: this does not cover the reporter's own config

Only entries carrying `HostName` participate in the endpoint check, guarded by `entry.hostname`. Without it, `sshConfigHostsToTargets` degrades the candidate host to the alias itself (`entry.hostname || entry.host`), and matching on that would both re-run the alias check and let unrelated aliases collide — there is a test pinning that `alpha`/`beta`/`gamma` stay unflagged.

That bounds what this fixes. In #15478 the persisted record is:

```json
{"label": "aimp", "configHost": "aimp", "host": "aimp"}
```

`host` landed as `aimp`, not the IP — so that `Host aimp` block has **no `HostName`**, and the address resolves through DNS or `/etc/hosts`. The suggested fix of resolving through `ssh -G` would not close it either: `ssh -G aimp` echoes `hostname aimp` when no `HostName` is configured, because it does not resolve names. Covering that case needs real name resolution in the duplicate check, which is network I/O whose answer moves with the environment — a separate decision, not something to fold in here.

I have posted that finding on the issue.

## Linked Issue

Fixes #15478

## Visual Proof

N/A — no layout change. The observable difference is whether the picker marks a row as already added, asserted in the new tests.

## Testing

- [x] I manually tested these changes locally — exercised through `searchSshConfigHosts`, which is exactly what the IPC handler calls; not driven through the actual Add-Remote-Host dialog
- [x] Automated tests added/updated, or explained why not below

Three picker cases: same machine under a different label, flagged; a different machine, unflagged; config entries with no `HostName`, still unflagged and non-colliding. Six cases on the pure function: port defaulting, NUL separation (so `a` + `1:2` cannot alias `a:1` + `2`), case folding of host and user, distinct users staying distinct, empty/whitespace/missing host yielding an empty identity, and a non-finite port falling back to 22 rather than keying on NaN.

| Check | Result |
|---|---|
| `src/main/ssh` + new pure-function suite + IPC + sidebar consumers | **111 files / 1615 passed** |
| `pnpm run typecheck` (node + cli + web) | exit 0 |
| oxlint / oxfmt | clean |

Red to green: the "same machine, different label" assertion was written first and observed failing. The other two picker cases passed before and after — which is the point, since this widens the match rather than changing existing behaviour.

Not run locally: `pnpm build` and the full Vitest suite.

**Unrelated flakiness observed:** `src/renderer/src/components/sidebar` fails a varying set of tests under concurrency (7 failures on one run, 3 on the next, all green when the file is run alone). Pre-existing and unrelated — these are renderer component tests with no path to the main-process picker — but flagging it rather than leaving a red run unexplained.

## AI Disclosure

Claude Opus 5 (via Claude Code) investigated, implemented, and verified this change.

## Review

- **Security:** no new input surface; the identity is derived from values already persisted, and the extra comparison is in-memory.
- **Cross-platform:** pure string handling, no path or platform branches.
- **Remote SSH:** this *is* the SSH path — it makes the picker's duplicate detection see the machine rather than the name.
- **Backwards compatibility:** widens `alreadyInOrca` only. The `existingTargets` parameter takes the three new fields as `Partial`, so callers that pass only names keep type-checking and behave exactly as before.
- **Performance:** one extra Set built per picker query, sized by target count.
- **Mobile / shortcuts / visual:** N/A.

## Agent skill upstream boundary

- [x] Not applicable

## Notes

Deliberately narrow: it does not touch `sshConfigHostsToTargets`, whose empty-exclusion-set call is documented as intentional with reconciliation happening in `ssh-connection-store.ts`, and it does not add merge/dedupe of already-persisted duplicates.

One observation while reading: `existingAliases` already collects both `configHost` **and** `label`, so the reporter's own case — manual target labelled `aimp`, config alias `aimp` — should have matched on the name alone. Either the manual target was labelled differently and the JSON was reconstructed afterwards, or `existingTargets` did not include it at that moment. Worth a maintainer eye, since it may be a second, distinct defect in how the picker is fed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass — typecheck, oxlint and the affected suites pass locally; full `pnpm test` and `pnpm build` not run, see Testing

Generated with [Claude Code](https://claude.com/claude-code)
