### PR TITLE
fix(windows): own PTY process trees with job objects

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -618,6 +618,16 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Why: node-pty prefers its upstream prebuild, which does not contain
+      # Orca's Windows patch, so the job-object exports would be absent and the
+      # suite below would test an unpatched binary. build_from_source removes
+      # the prebuild, and the package's postinstall restores the ConPTY runtime
+      # files that a bare node-gyp rebuild would miss.
+      - name: Rebuild node-pty from patched source
+        env:
+          npm_config_build_from_source: 'true'
+        run: pnpm rebuild node-pty
+
       - name: Test Windows-specific boundaries
         run: >-
           pnpm exec vitest run --config config/vitest.config.ts

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -635,6 +635,7 @@ jobs:
           src/main/providers/pty-repaint-wide-char-buffer.node-pty.test.ts
           src/shared/child-process/windows-command-line.win32.test.ts
           src/main/windows/windows-pty-job.win32.test.ts
+          src/main/windows/windows-host-job.win32.test.ts
           src/main/cli/wsl-cli-powershell-boundary.test.ts
           src/main/orca-profiles/profile-index-store.test.ts
           src/main/runtime/repo-worktree-admin-fingerprint.test.ts

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -623,6 +623,8 @@ jobs:
           pnpm exec vitest run --config config/vitest.config.ts
           src/main/providers/windows-conpty-wide-char-duplication.node-pty.test.ts
           src/main/providers/pty-repaint-wide-char-buffer.node-pty.test.ts
+          src/shared/child-process/windows-command-line.win32.test.ts
+          src/main/windows/windows-pty-job.win32.test.ts
           src/main/cli/wsl-cli-powershell-boundary.test.ts
           src/main/orca-profiles/profile-index-store.test.ts
           src/main/runtime/repo-worktree-admin-fingerprint.test.ts

--- a/config/patches/node-pty@1.1.0.patch
+++ b/config/patches/node-pty@1.1.0.patch
@@ -430,7 +430,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
  }
  #endif
 diff --git a/src/win/conpty.cc b/src/win/conpty.cc
-index 7b286d3d644c26141df516929703aa6e129df4b2..9ede3298f311bff35c97c4d62122faed059c3bc9 100644
+index 7b286d3d644c26141df516929703aa6e129df4b2..17c5eb23519ef7771a288ae4bc30a2be49f6c7bc 100644
 --- a/src/win/conpty.cc
 +++ b/src/win/conpty.cc
 @@ -18,6 +18,7 @@
@@ -502,7 +502,23 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..9ede3298f311bff35c97c4d62122faed
  
      auto status = tsfn.BlockingCall(exit_event, callback); // In main thread
      switch (status) {
-@@ -416,7 +453,10 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+@@ -409,6 +446,15 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+     throw errorWithCode(info, "UpdateProcThreadAttribute failed");
+   }
+ 
++  // Orca: resolve the DLL BEFORE creating anything. It throws when conpty.dll
++  // is missing -- a real state, and one this branch hit during development --
++  // and every throw between CreateProcessW and SetupExitCallback leaks the job,
++  // process and thread handles AND leaves an untracked shell tree running,
++  // once per attempt. Validating first means the only throw after creation is
++  // the resume failure, which cleans up after itself.
++  HANDLE hLibrary = LoadConptyDll(info, useConptyDll);
++  bool fLoadedDll = hLibrary != nullptr;
++
+   PROCESS_INFORMATION piClient{};
+   fSuccess = !!CreateProcessW(
+       nullptr,
+@@ -416,7 +462,10 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
        nullptr,                      // lpProcessAttributes
        nullptr,                      // lpThreadAttributes
        false,                        // bInheritHandles VERY IMPORTANT that this is false
@@ -514,10 +530,12 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..9ede3298f311bff35c97c4d62122faed
        envArg,                       // lpEnvironment
        mutableCwd.get(),             // lpCurrentDirectory
        &siEx.StartupInfo,            // lpStartupInfo
-@@ -426,6 +466,47 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+@@ -426,8 +475,47 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
      throw errorWithCode(info, "Cannot create process");
    }
  
+-  HANDLE hLibrary = LoadConptyDll(info, useConptyDll);
+-  bool fLoadedDll = hLibrary != nullptr;
 +  // Orca: own the tree with a handle instead of inferring it later from a
 +  // parent-pid walk. A pid walk cannot survive pid reuse and cannot see a
 +  // descendant that reparented, which is why detached agent children outlived
@@ -559,22 +577,19 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..9ede3298f311bff35c97c4d62122faed
 +    throw errorWithCode(info, "Cannot resume process");
 +  }
 +
-   HANDLE hLibrary = LoadConptyDll(info, useConptyDll);
-   bool fLoadedDll = hLibrary != nullptr;
    if (useConptyDll && fLoadedDll)
-@@ -440,6 +521,11 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+   {
+     PFNRELEASEPSEUDOCONSOLE const pfnReleasePseudoConsole = (PFNRELEASEPSEUDOCONSOLE)GetProcAddress(
+@@ -440,6 +528,8 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
  
    // Update handle
    handle->hShell = piClient.hProcess;
 +  handle->shellPid = piClient.dwProcessId;
-+  // Why here and not earlier: LoadConptyDll above can throw, and a baton that
-+  // carries a job but never reaches SetupExitCallback has nothing left to
-+  // close it.
 +  handle->hJob = hJob;
  
    // Close the thread handle to avoid resource leak
    CloseHandle(piClient.hThread);
-@@ -567,6 +653,94 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
+@@ -567,6 +657,94 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
    return env.Undefined();
  }
  
@@ -669,7 +684,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..9ede3298f311bff35c97c4d62122faed
  /**
  * Init
  */
-@@ -577,6 +751,8 @@ Napi::Object init(Napi::Env env, Napi::Object exports) {
+@@ -577,6 +755,8 @@ Napi::Object init(Napi::Env env, Napi::Object exports) {
    exports.Set("resize", Napi::Function::New(env, PtyResize));
    exports.Set("clear", Napi::Function::New(env, PtyClear));
    exports.Set("kill", Napi::Function::New(env, PtyKill));

--- a/config/patches/node-pty@1.1.0.patch
+++ b/config/patches/node-pty@1.1.0.patch
@@ -430,10 +430,18 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
  }
  #endif
 diff --git a/src/win/conpty.cc b/src/win/conpty.cc
-index 7b286d3d644c26141df516929703aa6e129df4b2..e62eadb7b8959a687a546da5d6c1a7b99fde43c5 100644
+index 7b286d3d644c26141df516929703aa6e129df4b2..09883ec38fee8da8d750a52d9f6fddb26695682d 100644
 --- a/src/win/conpty.cc
 +++ b/src/win/conpty.cc
-@@ -46,6 +46,11 @@ struct pty_baton {
+@@ -18,6 +18,7 @@
+ #include <iostream>
+ #include <string>
+ #include <thread>
++#include <mutex>
+ #include <vector>
+ #include <Windows.h>
+ #include <strsafe.h>
+@@ -46,10 +47,22 @@ struct pty_baton {
  
    HANDLE hShell;
  
@@ -445,21 +453,42 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..e62eadb7b8959a687a546da5d6c1a7b9
    pty_baton(int _id, HANDLE _hIn, HANDLE _hOut, HPCON _hpc) : id(_id), hIn(_hIn), hOut(_hOut), hpc(_hpc) {};
  };
  
-@@ -103,6 +108,13 @@ void SetupExitCallback(Napi::Env env, Napi::Function cb, pty_baton* baton) {
+ static std::vector<std::unique_ptr<pty_baton>> ptyHandles;
++// Orca: guards the job accessors below against the exit watcher thread. It does
++// NOT make the whole table safe -- PtyResize/PtyClear/PtyKill read it unlocked,
++// as they always have -- but it closes the window this patch opened, where the
++// watcher can close hShell/hJob and free the baton between a lookup and its use.
++// Handle VALUES are recycled aggressively, so an unguarded read could pass the
++// shell-pid check against an unrelated process and terminate the wrong job.
++static std::mutex ptyJobMutex;
+ static volatile LONG ptyCounter;
+ 
+ static pty_baton* get_pty_baton(int id) {
+@@ -103,7 +116,22 @@ void SetupExitCallback(Napi::Env env, Napi::Function cb, pty_baton* baton) {
      GetExitCodeProcess(baton->hShell, (LPDWORD)(&exit_event->exit_code));
      // Clean up handles
      CloseHandle(baton->hShell);
+-    assert(remove_pty_baton(baton->id));
 +    // Orca: release the job once the shell is gone. Without kill-on-close this
 +    // only frees the handle -- anything the user backgrounded is orphaned, as
 +    // it was before this patch.
-+    if (baton->hJob != nullptr) {
-+      CloseHandle(baton->hJob);
-+      baton->hJob = nullptr;
++    {
++      std::lock_guard<std::mutex> guard(ptyJobMutex);
++      if (baton->hJob != nullptr) {
++        CloseHandle(baton->hJob);
++        baton->hJob = nullptr;
++      }
++      // Why inside the lock: erasing frees the baton the job accessors hold a
++      // pointer to. Note remove_pty_baton must not be an assert() argument --
++      // NDEBUG would compile the call away and leak every baton.
++      const bool removed = remove_pty_baton(baton->id);
++      assert(removed);
++      (void)removed;
 +    }
-     assert(remove_pty_baton(baton->id));
  
      auto status = tsfn.BlockingCall(exit_event, callback); // In main thread
-@@ -416,7 +428,10 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+     switch (status) {
+@@ -416,7 +444,10 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
        nullptr,                      // lpProcessAttributes
        nullptr,                      // lpThreadAttributes
        false,                        // bInheritHandles VERY IMPORTANT that this is false
@@ -471,7 +500,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..e62eadb7b8959a687a546da5d6c1a7b9
        envArg,                       // lpEnvironment
        mutableCwd.get(),             // lpCurrentDirectory
        &siEx.StartupInfo,            // lpStartupInfo
-@@ -426,6 +441,39 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+@@ -426,6 +457,47 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
      throw errorWithCode(info, "Cannot create process");
    }
  
@@ -487,7 +516,15 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..e62eadb7b8959a687a546da5d6c1a7b9
 +  // EXPLICIT teardown exact, not to redefine what a clean exit means.
 +  HANDLE hJob = CreateJobObjectW(nullptr, nullptr);
 +  if (hJob != nullptr) {
-+    if (!AssignProcessToJobObject(hJob, piClient.hProcess)) {
++    // Why BREAKAWAY_OK and not a bare job: with no limits set, a child asking
++    // for CREATE_BREAKAWAY_FROM_JOB is refused with ERROR_ACCESS_DENIED.
++    // Installers, msiexec and some updater and service-control paths spawn that
++    // way deliberately, so a bare job breaks them ONLY inside an Orca terminal.
++    // With this flag a child has to ask, so ordinary descendants stay owned.
++    JOBOBJECT_EXTENDED_LIMIT_INFORMATION jobLimits{};
++    jobLimits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_BREAKAWAY_OK;
++    if (!SetInformationJobObject(hJob, JobObjectExtendedLimitInformation, &jobLimits, sizeof(jobLimits)) ||
++        !AssignProcessToJobObject(hJob, piClient.hProcess)) {
 +      // Why tolerate failure: an outer job without JOB_OBJECT_LIMIT_BREAKAWAY_OK
 +      // (some EDR and container hosts) refuses the assignment. The pty must
 +      // still start; ownership just degrades to the older best-effort path.
@@ -511,7 +548,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..e62eadb7b8959a687a546da5d6c1a7b9
    HANDLE hLibrary = LoadConptyDll(info, useConptyDll);
    bool fLoadedDll = hLibrary != nullptr;
    if (useConptyDll && fLoadedDll)
-@@ -440,6 +488,10 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+@@ -440,6 +512,10 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
  
    // Update handle
    handle->hShell = piClient.hProcess;
@@ -522,7 +559,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..e62eadb7b8959a687a546da5d6c1a7b9
  
    // Close the thread handle to avoid resource leak
    CloseHandle(piClient.hThread);
-@@ -567,6 +619,85 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
+@@ -567,6 +643,91 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
    return env.Undefined();
  }
  
@@ -554,6 +591,12 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..e62eadb7b8959a687a546da5d6c1a7b9
 +    throw Napi::Error::New(env, "Usage: pty.terminateJob(id, shellPid)");
 +  }
 +
++  // Held across the lookup AND the Win32 call: the watcher thread can otherwise
++  // close these handles and free the baton in between.
++  std::lock_guard<std::mutex> guard(ptyJobMutex);
++  // Held across the lookup AND the Win32 call: the watcher thread can otherwise
++  // close these handles and free the baton in between.
++  std::lock_guard<std::mutex> guard(ptyJobMutex);
 +  const pty_baton* handle = get_pty_baton(info[0].As<Napi::Number>().Int32Value());
 +  if (!ownsShell(handle, info[1].As<Napi::Number>().Uint32Value())) {
 +    return Napi::Boolean::New(env, false);
@@ -608,7 +651,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..e62eadb7b8959a687a546da5d6c1a7b9
  /**
  * Init
  */
-@@ -577,6 +708,8 @@ Napi::Object init(Napi::Env env, Napi::Object exports) {
+@@ -577,6 +738,8 @@ Napi::Object init(Napi::Env env, Napi::Object exports) {
    exports.Set("resize", Napi::Function::New(env, PtyResize));
    exports.Set("clear", Napi::Function::New(env, PtyClear));
    exports.Set("kill", Napi::Function::New(env, PtyKill));

--- a/config/patches/node-pty@1.1.0.patch
+++ b/config/patches/node-pty@1.1.0.patch
@@ -430,7 +430,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
  }
  #endif
 diff --git a/src/win/conpty.cc b/src/win/conpty.cc
-index 7b286d3d644c26141df516929703aa6e129df4b2..fdb413be4ec39091b60a8b8dc49ed9cb81731730 100644
+index 7b286d3d644c26141df516929703aa6e129df4b2..cad5cbcee5db36f510158e900e21849b298f4de5 100644
 --- a/src/win/conpty.cc
 +++ b/src/win/conpty.cc
 @@ -18,6 +18,7 @@
@@ -441,15 +441,23 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..fdb413be4ec39091b60a8b8dc49ed9cb
  #include <vector>
  #include <Windows.h>
  #include <strsafe.h>
-@@ -46,10 +47,22 @@ struct pty_baton {
+@@ -44,12 +45,29 @@ struct pty_baton {
+   HANDLE hOut;
+   HPCON hpc;
  
-   HANDLE hShell;
- 
+-  HANDLE hShell;
++  HANDLE hShell = nullptr;
++  // Orca: the shell's pid, captured at spawn. The ownership guard compares
++  // against this rather than calling GetProcessId(hShell), because the exit
++  // watcher closes hShell on another thread -- reading it there is an
++  // invalid-handle operation, and under strict handle checks that is fatal.
++  DWORD shellPid = 0;
++
 +  // Orca: job object owning this pty's whole process tree. Null when the OS
 +  // refused to create or assign one (an outer job without breakaway rights),
 +  // in which case callers fall back to their pre-job behaviour.
 +  HANDLE hJob = nullptr;
-+
+ 
    pty_baton(int _id, HANDLE _hIn, HANDLE _hOut, HPCON _hpc) : id(_id), hIn(_hIn), hOut(_hOut), hpc(_hpc) {};
  };
  
@@ -464,16 +472,19 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..fdb413be4ec39091b60a8b8dc49ed9cb
  static volatile LONG ptyCounter;
  
  static pty_baton* get_pty_baton(int id) {
-@@ -103,7 +116,22 @@ void SetupExitCallback(Napi::Env env, Napi::Function cb, pty_baton* baton) {
+@@ -102,8 +120,24 @@ void SetupExitCallback(Napi::Env env, Napi::Function cb, pty_baton* baton) {
+     // Get process exit code.
      GetExitCodeProcess(baton->hShell, (LPDWORD)(&exit_event->exit_code));
      // Clean up handles
-     CloseHandle(baton->hShell);
+-    CloseHandle(baton->hShell);
 -    assert(remove_pty_baton(baton->id));
 +    // Orca: release the job once the shell is gone. Without kill-on-close this
 +    // only frees the handle -- anything the user backgrounded is orphaned, as
 +    // it was before this patch.
 +    {
 +      std::lock_guard<std::mutex> guard(ptyJobMutex);
++      CloseHandle(baton->hShell);
++      baton->hShell = nullptr;
 +      if (baton->hJob != nullptr) {
 +        CloseHandle(baton->hJob);
 +        baton->hJob = nullptr;
@@ -488,7 +499,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..fdb413be4ec39091b60a8b8dc49ed9cb
  
      auto status = tsfn.BlockingCall(exit_event, callback); // In main thread
      switch (status) {
-@@ -416,7 +444,10 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+@@ -416,7 +450,10 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
        nullptr,                      // lpProcessAttributes
        nullptr,                      // lpThreadAttributes
        false,                        // bInheritHandles VERY IMPORTANT that this is false
@@ -500,7 +511,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..fdb413be4ec39091b60a8b8dc49ed9cb
        envArg,                       // lpEnvironment
        mutableCwd.get(),             // lpCurrentDirectory
        &siEx.StartupInfo,            // lpStartupInfo
-@@ -426,6 +457,47 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+@@ -426,6 +463,47 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
      throw errorWithCode(info, "Cannot create process");
    }
  
@@ -548,10 +559,11 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..fdb413be4ec39091b60a8b8dc49ed9cb
    HANDLE hLibrary = LoadConptyDll(info, useConptyDll);
    bool fLoadedDll = hLibrary != nullptr;
    if (useConptyDll && fLoadedDll)
-@@ -440,6 +512,10 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+@@ -440,6 +518,11 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
  
    // Update handle
    handle->hShell = piClient.hProcess;
++  handle->shellPid = piClient.dwProcessId;
 +  // Why here and not earlier: LoadConptyDll above can throw, and a baton that
 +  // carries a job but never reaches SetupExitCallback has nothing left to
 +  // close it.
@@ -559,7 +571,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..fdb413be4ec39091b60a8b8dc49ed9cb
  
    // Close the thread handle to avoid resource leak
    CloseHandle(piClient.hThread);
-@@ -567,6 +643,91 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
+@@ -567,6 +650,94 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
    return env.Undefined();
  }
  
@@ -572,8 +584,8 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..fdb413be4ec39091b60a8b8dc49ed9cb
 + * process tree. Matching the shell pid makes the id unforgeable.
 + */
 +static bool ownsShell(const pty_baton* handle, DWORD expectedShellPid) {
-+  return handle != nullptr && handle->hJob != nullptr && handle->hShell != nullptr &&
-+         expectedShellPid != 0 && GetProcessId(handle->hShell) == expectedShellPid;
++  return handle != nullptr && handle->hJob != nullptr && expectedShellPid != 0 &&
++         handle->shellPid == expectedShellPid;
 +}
 +
 +/**
@@ -604,10 +616,14 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..fdb413be4ec39091b60a8b8dc49ed9cb
 +/**
 + * Orca: the pids still alive in this pty's tree, straight from the kernel.
 + *
-+ * This is the liveness answer a stale JS map cannot give: a pane whose shell
-+ * has exited reports an empty list, so a registry entry can no longer claim a
-+ * terminal is connected when nothing is running.
-+ * Returns null when no job was assigned.
++ * Descendant liveness for a tree that is still tracked, including children that
++ * detached from the console. Once the shell exits the baton is gone, so this
++ * returns null rather than an empty list -- null means "no answer", never
++ * "they died". Also returns null when no job was assigned.
++ *
++ * Does not include the ConPTY console host: CreatePseudoConsole spawns it
++ * before this job exists, so it is not a member and ClosePseudoConsole is what
++ * reaps it.
 + */
 +static Napi::Value PtyListJobProcessIds(const Napi::CallbackInfo& info) {
 +  Napi::Env env(info.Env());
@@ -632,7 +648,6 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..fdb413be4ec39091b60a8b8dc49ed9cb
 +    const size_t bytes = sizeof(JOBOBJECT_BASIC_PROCESS_ID_LIST) + sizeof(ULONG_PTR) * capacity;
 +    std::vector<char> buffer(bytes, 0);
 +    auto* list = reinterpret_cast<JOBOBJECT_BASIC_PROCESS_ID_LIST*>(buffer.data());
-+    list->NumberOfAssignedProcesses = capacity;
 +    if (QueryInformationJobObject(handle->hJob, JobObjectBasicProcessIdList, list, static_cast<DWORD>(bytes), nullptr)) {
 +      auto pids = Napi::Array::New(env, list->NumberOfProcessIdsInList);
 +      for (DWORD i = 0; i < list->NumberOfProcessIdsInList; i++) {
@@ -651,7 +666,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..fdb413be4ec39091b60a8b8dc49ed9cb
  /**
  * Init
  */
-@@ -577,6 +738,8 @@ Napi::Object init(Napi::Env env, Napi::Object exports) {
+@@ -577,6 +748,8 @@ Napi::Object init(Napi::Env env, Napi::Object exports) {
    exports.Set("resize", Napi::Function::New(env, PtyResize));
    exports.Set("clear", Napi::Function::New(env, PtyClear));
    exports.Set("kill", Napi::Function::New(env, PtyKill));

--- a/config/patches/node-pty@1.1.0.patch
+++ b/config/patches/node-pty@1.1.0.patch
@@ -35,7 +35,7 @@ index 1ac5758bedd8cf54f32280dea4e4aeb5afdee30d..e619813759c6f14694838bdfbd0ea5f8
 +++ b/deps/winpty/src/winpty.gyp
 @@ -10,7 +10,7 @@
      #    make -j4 CXX=i686-w64-mingw32-g++ LDFLAGS="-static -static-libgcc -static-libstdc++"
-
+ 
      'variables': {
 -        'WINPTY_COMMIT_HASH%': '<!(cmd /c "cd shared && GetCommitHash.bat")',
 +        'WINPTY_COMMIT_HASH%': '<!(cmd /c "cd shared && .\\GetCommitHash.bat")',
@@ -116,7 +116,7 @@ index 181ccabbbe9c4948a9725fb1db907a68e9de01fc..67f31facf85562b67adbfbd04ce28ddd
 --- a/src/conpty_console_list_agent.ts
 +++ b/src/conpty_console_list_agent.ts
 @@ -10,6 +10,12 @@ import { loadNativeModule } from './utils';
-
+ 
  const getConsoleProcessList = loadNativeModule('conpty_console_list').module.getConsoleProcessList;
  const shellPid = parseInt(process.argv[2], 10);
 -const consoleProcessList = getConsoleProcessList(shellPid);
@@ -141,12 +141,12 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
  #include <unistd.h>
 +#include <string>
  #include <thread>
-
+ 
  #include <sys/types.h>
 @@ -47,6 +49,25 @@
  #include <termios.h>
  #endif
-
+ 
 +/* Orca: glibc 2.32-2.34 relocated pthread_sigmask/openpty/forkpty into libc
 + * under new symbol versions, so building on a newer glibc produces references
 + * (GLIBC_2.32/2.34) absent on Ubuntu 20.04 (glibc 2.31) and the app fails to
@@ -171,7 +171,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
  #define VWERASE	VWERSE
 @@ -237,13 +258,23 @@ pty_getproc(int, char *);
  #endif
-
+ 
  #if defined(__APPLE__) || defined(__OpenBSD__)
 +struct pty_spawn_error {
 +  const char* step;
@@ -192,12 +192,12 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
 -                int* err);
 +                pty_spawn_error* err);
  #endif
-
+ 
  struct DelBuf {
 @@ -367,10 +398,11 @@ Napi::Value PtyFork(const Napi::CallbackInfo& info) {
      argv[i + 3] = strdup(arg.c_str());
    }
-
+ 
 -  int err = -1;
 -  pty_posix_spawn(argv, env, term, &winp, &master, &pid, &err);
 -  if (err != 0) {
@@ -212,7 +212,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
      throw Napi::Error::New(napiEnv, "Could not set master fd to nonblocking.");
 @@ -684,15 +716,73 @@ pty_getproc(int fd, char *tty) {
  #endif
-
+ 
  #if defined(__APPLE__)
 +static const char*
 +pty_errno_name(int errnum) {
@@ -283,7 +283,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
 +  bool acts_initialized = false;
 +  posix_spawnattr_t attrs;
 +  bool attrs_initialized = false;
-
+ 
    for (; count < 3; count++) {
      low_fds[count] = posix_openpt(O_RDWR);
 @@ -706,80 +796,118 @@ pty_posix_spawn(char** argv, char** env,
@@ -294,7 +294,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
 +    pty_set_spawn_error(err, "posix_openpt", errno);
 +    goto done;
    }
-
+ 
 -  int res = grantpt(*master) || unlockpt(*master);
 +  res = grantpt(*master);
    if (res == -1) {
@@ -308,7 +308,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
 +    pty_set_spawn_error(err, "unlockpt", errno);
 +    goto done;
    }
-
+ 
    // Use TIOCPTYGNAME instead of ptsname() to avoid threading problems.
 -  int slave;
    char slave_pty_name[128];
@@ -318,14 +318,14 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
 +    pty_set_spawn_error(err, "ioctl_TIOCPTYGNAME", errno);
 +    goto done;
    }
-
+ 
    slave = open(slave_pty_name, O_RDWR | O_NOCTTY);
    if (slave == -1) {
 -    return;
 +    pty_set_spawn_error(err, "open_slave", errno, "slave", slave_pty_name);
 +    goto done;
    }
-
+ 
    if (termp) {
      res = tcsetattr(slave, TCSANOW, termp);
      if (res == -1) {
@@ -334,7 +334,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
 +      goto done;
      };
    }
-
+ 
    if (winp) {
      res = ioctl(slave, TIOCSWINSZ, winp);
      if (res == -1) {
@@ -343,7 +343,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
 +      goto done;
      }
    }
-
+ 
 -  posix_spawn_file_actions_t acts;
 -  posix_spawn_file_actions_init(&acts);
 +  res = posix_spawn_file_actions_init(&acts);
@@ -357,7 +357,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
    posix_spawn_file_actions_adddup2(&acts, slave, STDERR_FILENO);
    posix_spawn_file_actions_addclose(&acts, slave);
    posix_spawn_file_actions_addclose(&acts, *master);
-
+ 
 -  posix_spawnattr_t attrs;
 -  posix_spawnattr_init(&attrs);
 -  *err = posix_spawnattr_setflags(&attrs, flags);
@@ -373,7 +373,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
 +    pty_set_spawn_error(err, "posix_spawnattr_setflags", res);
      goto done;
    }
-
+ 
    sigset_t signal_set;
    /* Reset all signal the child to their default behavior */
    sigfillset(&signal_set);
@@ -384,7 +384,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
 +    pty_set_spawn_error(err, "posix_spawnattr_setsigdefault", res);
      goto done;
    }
-
+ 
    /* Reset the signal mask for all signals */
    sigemptyset(&signal_set);
 -  *err = posix_spawnattr_setsigmask(&attrs, &signal_set);
@@ -394,7 +394,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
 +    pty_set_spawn_error(err, "posix_spawnattr_setsigmask", res);
      goto done;
    }
-
+ 
    do
 -    *err = posix_spawn(pid, argv[0], &acts, &attrs, argv, env);
 -  while (*err == EINTR);
@@ -419,7 +419,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
 +    close(*master);
 +    *master = -1;
 +  }
-
+ 
 -  for (; count > 0; count--) {
 -    close(low_fds[count]);
 +  for (size_t i = 0; i <= count && i < 3; i++) {
@@ -429,3 +429,159 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
    }
  }
  #endif
+diff --git a/src/win/conpty.cc b/src/win/conpty.cc
+index 7b286d3d644c26141df516929703aa6e129df4b2..4ae9ddec6ac3e9fdaa380000d3017bbb394f22d6 100644
+--- a/src/win/conpty.cc
++++ b/src/win/conpty.cc
+@@ -46,6 +46,11 @@ struct pty_baton {
+ 
+   HANDLE hShell;
+ 
++  // Orca: job object owning this pty's whole process tree. Null when the OS
++  // refused to create or assign one (an outer job without breakaway rights),
++  // in which case callers fall back to their pre-job behaviour.
++  HANDLE hJob = nullptr;
++
+   pty_baton(int _id, HANDLE _hIn, HANDLE _hOut, HPCON _hpc) : id(_id), hIn(_hIn), hOut(_hOut), hpc(_hpc) {};
+ };
+ 
+@@ -103,6 +108,13 @@ void SetupExitCallback(Napi::Env env, Napi::Function cb, pty_baton* baton) {
+     GetExitCodeProcess(baton->hShell, (LPDWORD)(&exit_event->exit_code));
+     // Clean up handles
+     CloseHandle(baton->hShell);
++    // Orca: closing the last job handle is what reaps whatever the shell left
++    // behind. Without this the job outlives the pane and its descendants keep
++    // running (and keep holding the worktree directory open).
++    if (baton->hJob != nullptr) {
++      CloseHandle(baton->hJob);
++      baton->hJob = nullptr;
++    }
+     assert(remove_pty_baton(baton->id));
+ 
+     auto status = tsfn.BlockingCall(exit_event, callback); // In main thread
+@@ -416,7 +428,10 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+       nullptr,                      // lpProcessAttributes
+       nullptr,                      // lpThreadAttributes
+       false,                        // bInheritHandles VERY IMPORTANT that this is false
+-      EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT, // dwCreationFlags
++      // Orca: CREATE_SUSPENDED so the shell is inside its job before it can
++      // spawn anything. Assigning after the fact leaves a window in which a
++      // fast child escapes the job and outlives the pane.
++      EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT | CREATE_SUSPENDED, // dwCreationFlags
+       envArg,                       // lpEnvironment
+       mutableCwd.get(),             // lpCurrentDirectory
+       &siEx.StartupInfo,            // lpStartupInfo
+@@ -426,6 +441,31 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+     throw errorWithCode(info, "Cannot create process");
+   }
+ 
++  // Orca: own the tree with a handle instead of inferring it later from a
++  // parent-pid walk. A pid walk cannot survive pid reuse and cannot see a
++  // descendant that reparented, which is why detached agent children outlived
++  // their pane and held the worktree directory open.
++  //
++  // JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE means the tree also dies if this host
++  // process dies without unwinding, so a crashed daemon cannot strand shells.
++  HANDLE hJob = CreateJobObjectW(nullptr, nullptr);
++  if (hJob != nullptr) {
++    JOBOBJECT_EXTENDED_LIMIT_INFORMATION jobLimits{};
++    jobLimits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
++    if (!SetInformationJobObject(hJob, JobObjectExtendedLimitInformation, &jobLimits, sizeof(jobLimits)) ||
++        !AssignProcessToJobObject(hJob, piClient.hProcess)) {
++      // Why tolerate failure: an outer job without JOB_OBJECT_LIMIT_BREAKAWAY_OK
++      // (some EDR and container hosts) refuses the assignment. The pty must
++      // still start; ownership just degrades to the older best-effort path.
++      CloseHandle(hJob);
++      hJob = nullptr;
++    }
++  }
++  handle->hJob = hJob;
++
++  // Safe to run now: either it is in the job, or we accepted that it is not.
++  ResumeThread(piClient.hThread);
++
+   HANDLE hLibrary = LoadConptyDll(info, useConptyDll);
+   bool fLoadedDll = hLibrary != nullptr;
+   if (useConptyDll && fLoadedDll)
+@@ -567,6 +607,72 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
+   return env.Undefined();
+ }
+ 
++/**
++ * Orca: kill this pty's entire tree in one syscall.
++ *
++ * Replaces "scrape the process table, walk parent pids, hope none were
++ * recycled, then taskkill /T /F". Returns false when no job was assigned so
++ * the caller knows to fall back rather than assume the tree is gone.
++ */
++static Napi::Value PtyTerminateJob(const Napi::CallbackInfo& info) {
++  Napi::Env env(info.Env());
++  Napi::HandleScope scope(env);
++
++  if (info.Length() != 1 || !info[0].IsNumber()) {
++    throw Napi::Error::New(env, "Usage: pty.terminateJob(id)");
++  }
++
++  const pty_baton* handle = get_pty_baton(info[0].As<Napi::Number>().Int32Value());
++  if (handle == nullptr || handle->hJob == nullptr) {
++    return Napi::Boolean::New(env, false);
++  }
++  return Napi::Boolean::New(env, !!TerminateJobObject(handle->hJob, 1));
++}
++
++/**
++ * Orca: the pids still alive in this pty's tree, straight from the kernel.
++ *
++ * This is the liveness answer a stale JS map cannot give: a pane whose shell
++ * has exited reports an empty list, so a registry entry can no longer claim a
++ * terminal is connected when nothing is running.
++ * Returns null when no job was assigned.
++ */
++static Napi::Value PtyListJobProcessIds(const Napi::CallbackInfo& info) {
++  Napi::Env env(info.Env());
++  Napi::HandleScope scope(env);
++
++  if (info.Length() != 1 || !info[0].IsNumber()) {
++    throw Napi::Error::New(env, "Usage: pty.listJobProcessIds(id)");
++  }
++
++  const pty_baton* handle = get_pty_baton(info[0].As<Napi::Number>().Int32Value());
++  if (handle == nullptr || handle->hJob == nullptr) {
++    return env.Null();
++  }
++
++  // Grow until the buffer holds every pid: the count can change between calls,
++  // and a truncated list would read as "these children are gone".
++  DWORD capacity = 64;
++  for (int attempt = 0; attempt < 8; attempt++) {
++    const size_t bytes = sizeof(JOBOBJECT_BASIC_PROCESS_ID_LIST) + sizeof(ULONG_PTR) * capacity;
++    std::vector<char> buffer(bytes, 0);
++    auto* list = reinterpret_cast<JOBOBJECT_BASIC_PROCESS_ID_LIST*>(buffer.data());
++    list->NumberOfAssignedProcesses = capacity;
++    if (QueryInformationJobObject(handle->hJob, JobObjectBasicProcessIdList, list, static_cast<DWORD>(bytes), nullptr)) {
++      auto pids = Napi::Array::New(env, list->NumberOfProcessIdsInList);
++      for (DWORD i = 0; i < list->NumberOfProcessIdsInList; i++) {
++        pids.Set(i, Napi::Number::New(env, static_cast<double>(list->ProcessIdList[i])));
++      }
++      return pids;
++    }
++    if (GetLastError() != ERROR_MORE_DATA) {
++      return env.Null();
++    }
++    capacity *= 4;
++  }
++  return env.Null();
++}
++
+ /**
+ * Init
+ */
+@@ -577,6 +683,8 @@ Napi::Object init(Napi::Env env, Napi::Object exports) {
+   exports.Set("resize", Napi::Function::New(env, PtyResize));
+   exports.Set("clear", Napi::Function::New(env, PtyClear));
+   exports.Set("kill", Napi::Function::New(env, PtyKill));
++  exports.Set("terminateJob", Napi::Function::New(env, PtyTerminateJob));
++  exports.Set("listJobProcessIds", Napi::Function::New(env, PtyListJobProcessIds));
+   return exports;
+ };
+ 

--- a/config/patches/node-pty@1.1.0.patch
+++ b/config/patches/node-pty@1.1.0.patch
@@ -430,7 +430,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
  }
  #endif
 diff --git a/src/win/conpty.cc b/src/win/conpty.cc
-index 7b286d3d644c26141df516929703aa6e129df4b2..a1a63d6380ba5b0a669339435064b9f51e0706dc 100644
+index 7b286d3d644c26141df516929703aa6e129df4b2..e62eadb7b8959a687a546da5d6c1a7b99fde43c5 100644
 --- a/src/win/conpty.cc
 +++ b/src/win/conpty.cc
 @@ -46,6 +46,11 @@ struct pty_baton {
@@ -471,7 +471,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..a1a63d6380ba5b0a669339435064b9f5
        envArg,                       // lpEnvironment
        mutableCwd.get(),             // lpCurrentDirectory
        &siEx.StartupInfo,            // lpStartupInfo
-@@ -426,6 +441,31 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+@@ -426,6 +441,39 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
      throw errorWithCode(info, "Cannot create process");
    }
  
@@ -495,18 +495,50 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..a1a63d6380ba5b0a669339435064b9f5
 +      hJob = nullptr;
 +    }
 +  }
-+  handle->hJob = hJob;
-+
 +  // Safe to run now: either it is in the job, or we accepted that it is not.
-+  ResumeThread(piClient.hThread);
++  if (ResumeThread(piClient.hThread) == static_cast<DWORD>(-1)) {
++    // Why fatal: a shell left suspended produces a pane that never prints and
++    // never exits, which is far harder to diagnose than a failed spawn.
++    if (hJob != nullptr) {
++      CloseHandle(hJob);
++    }
++    TerminateProcess(piClient.hProcess, 1);
++    CloseHandle(piClient.hProcess);
++    CloseHandle(piClient.hThread);
++    throw errorWithCode(info, "Cannot resume process");
++  }
 +
    HANDLE hLibrary = LoadConptyDll(info, useConptyDll);
    bool fLoadedDll = hLibrary != nullptr;
    if (useConptyDll && fLoadedDll)
-@@ -567,6 +607,72 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
+@@ -440,6 +488,10 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+ 
+   // Update handle
+   handle->hShell = piClient.hProcess;
++  // Why here and not earlier: LoadConptyDll above can throw, and a baton that
++  // carries a job but never reaches SetupExitCallback has nothing left to
++  // close it.
++  handle->hJob = hJob;
+ 
+   // Close the thread handle to avoid resource leak
+   CloseHandle(piClient.hThread);
+@@ -567,6 +619,85 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
    return env.Undefined();
  }
  
++/**
++ * Orca: confirm a baton really is the pty the caller means.
++ *
++ * The winpty backend mints its own `pty` ids from a separate counter, and the
++ * JS layer stores both in the same field -- so a winpty terminal's id can
++ * collide with a live ConPTY baton here and terminate an unrelated pane's whole
++ * process tree. Matching the shell pid makes the id unforgeable.
++ */
++static bool ownsShell(const pty_baton* handle, DWORD expectedShellPid) {
++  return handle != nullptr && handle->hJob != nullptr && handle->hShell != nullptr &&
++         expectedShellPid != 0 && GetProcessId(handle->hShell) == expectedShellPid;
++}
++
 +/**
 + * Orca: kill this pty's entire tree in one syscall.
 + *
@@ -518,12 +550,12 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..a1a63d6380ba5b0a669339435064b9f5
 +  Napi::Env env(info.Env());
 +  Napi::HandleScope scope(env);
 +
-+  if (info.Length() != 1 || !info[0].IsNumber()) {
-+    throw Napi::Error::New(env, "Usage: pty.terminateJob(id)");
++  if (info.Length() != 2 || !info[0].IsNumber() || !info[1].IsNumber()) {
++    throw Napi::Error::New(env, "Usage: pty.terminateJob(id, shellPid)");
 +  }
 +
 +  const pty_baton* handle = get_pty_baton(info[0].As<Napi::Number>().Int32Value());
-+  if (handle == nullptr || handle->hJob == nullptr) {
++  if (!ownsShell(handle, info[1].As<Napi::Number>().Uint32Value())) {
 +    return Napi::Boolean::New(env, false);
 +  }
 +  return Napi::Boolean::New(env, !!TerminateJobObject(handle->hJob, 1));
@@ -541,12 +573,12 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..a1a63d6380ba5b0a669339435064b9f5
 +  Napi::Env env(info.Env());
 +  Napi::HandleScope scope(env);
 +
-+  if (info.Length() != 1 || !info[0].IsNumber()) {
-+    throw Napi::Error::New(env, "Usage: pty.listJobProcessIds(id)");
++  if (info.Length() != 2 || !info[0].IsNumber() || !info[1].IsNumber()) {
++    throw Napi::Error::New(env, "Usage: pty.listJobProcessIds(id, shellPid)");
 +  }
 +
 +  const pty_baton* handle = get_pty_baton(info[0].As<Napi::Number>().Int32Value());
-+  if (handle == nullptr || handle->hJob == nullptr) {
++  if (!ownsShell(handle, info[1].As<Napi::Number>().Uint32Value())) {
 +    return env.Null();
 +  }
 +
@@ -576,7 +608,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..a1a63d6380ba5b0a669339435064b9f5
  /**
  * Init
  */
-@@ -577,6 +683,8 @@ Napi::Object init(Napi::Env env, Napi::Object exports) {
+@@ -577,6 +708,8 @@ Napi::Object init(Napi::Env env, Napi::Object exports) {
    exports.Set("resize", Napi::Function::New(env, PtyResize));
    exports.Set("clear", Napi::Function::New(env, PtyClear));
    exports.Set("kill", Napi::Function::New(env, PtyKill));

--- a/config/patches/node-pty@1.1.0.patch
+++ b/config/patches/node-pty@1.1.0.patch
@@ -430,7 +430,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
  }
  #endif
 diff --git a/src/win/conpty.cc b/src/win/conpty.cc
-index 7b286d3d644c26141df516929703aa6e129df4b2..cad5cbcee5db36f510158e900e21849b298f4de5 100644
+index 7b286d3d644c26141df516929703aa6e129df4b2..9ede3298f311bff35c97c4d62122faed059c3bc9 100644
 --- a/src/win/conpty.cc
 +++ b/src/win/conpty.cc
 @@ -18,6 +18,7 @@
@@ -472,7 +472,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..cad5cbcee5db36f510158e900e21849b
  static volatile LONG ptyCounter;
  
  static pty_baton* get_pty_baton(int id) {
-@@ -102,8 +120,24 @@ void SetupExitCallback(Napi::Env env, Napi::Function cb, pty_baton* baton) {
+@@ -102,8 +120,27 @@ void SetupExitCallback(Napi::Env env, Napi::Function cb, pty_baton* baton) {
      // Get process exit code.
      GetExitCodeProcess(baton->hShell, (LPDWORD)(&exit_event->exit_code));
      // Clean up handles
@@ -496,10 +496,13 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..cad5cbcee5db36f510158e900e21849b
 +      assert(removed);
 +      (void)removed;
 +    }
++    // Why the lock ends here: BlockingCall below waits on the JS thread, and the
++    // JS thread can be waiting on ptyJobMutex inside PtyTerminateJob. Holding
++    // the lock across it deadlocks. Do not widen this scope.
  
      auto status = tsfn.BlockingCall(exit_event, callback); // In main thread
      switch (status) {
-@@ -416,7 +450,10 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+@@ -416,7 +453,10 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
        nullptr,                      // lpProcessAttributes
        nullptr,                      // lpThreadAttributes
        false,                        // bInheritHandles VERY IMPORTANT that this is false
@@ -511,7 +514,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..cad5cbcee5db36f510158e900e21849b
        envArg,                       // lpEnvironment
        mutableCwd.get(),             // lpCurrentDirectory
        &siEx.StartupInfo,            // lpStartupInfo
-@@ -426,6 +463,47 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+@@ -426,6 +466,47 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
      throw errorWithCode(info, "Cannot create process");
    }
  
@@ -559,7 +562,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..cad5cbcee5db36f510158e900e21849b
    HANDLE hLibrary = LoadConptyDll(info, useConptyDll);
    bool fLoadedDll = hLibrary != nullptr;
    if (useConptyDll && fLoadedDll)
-@@ -440,6 +518,11 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+@@ -440,6 +521,11 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
  
    // Update handle
    handle->hShell = piClient.hProcess;
@@ -571,7 +574,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..cad5cbcee5db36f510158e900e21849b
  
    // Close the thread handle to avoid resource leak
    CloseHandle(piClient.hThread);
-@@ -567,6 +650,94 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
+@@ -567,6 +653,94 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
    return env.Undefined();
  }
  
@@ -666,7 +669,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..cad5cbcee5db36f510158e900e21849b
  /**
  * Init
  */
-@@ -577,6 +748,8 @@ Napi::Object init(Napi::Env env, Napi::Object exports) {
+@@ -577,6 +751,8 @@ Napi::Object init(Napi::Env env, Napi::Object exports) {
    exports.Set("resize", Napi::Function::New(env, PtyResize));
    exports.Set("clear", Napi::Function::New(env, PtyClear));
    exports.Set("kill", Napi::Function::New(env, PtyKill));

--- a/config/patches/node-pty@1.1.0.patch
+++ b/config/patches/node-pty@1.1.0.patch
@@ -430,7 +430,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
  }
  #endif
 diff --git a/src/win/conpty.cc b/src/win/conpty.cc
-index 7b286d3d644c26141df516929703aa6e129df4b2..4ae9ddec6ac3e9fdaa380000d3017bbb394f22d6 100644
+index 7b286d3d644c26141df516929703aa6e129df4b2..a1a63d6380ba5b0a669339435064b9f51e0706dc 100644
 --- a/src/win/conpty.cc
 +++ b/src/win/conpty.cc
 @@ -46,6 +46,11 @@ struct pty_baton {
@@ -449,9 +449,9 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..4ae9ddec6ac3e9fdaa380000d3017bbb
      GetExitCodeProcess(baton->hShell, (LPDWORD)(&exit_event->exit_code));
      // Clean up handles
      CloseHandle(baton->hShell);
-+    // Orca: closing the last job handle is what reaps whatever the shell left
-+    // behind. Without this the job outlives the pane and its descendants keep
-+    // running (and keep holding the worktree directory open).
++    // Orca: release the job once the shell is gone. Without kill-on-close this
++    // only frees the handle -- anything the user backgrounded is orphaned, as
++    // it was before this patch.
 +    if (baton->hJob != nullptr) {
 +      CloseHandle(baton->hJob);
 +      baton->hJob = nullptr;
@@ -480,14 +480,14 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..4ae9ddec6ac3e9fdaa380000d3017bbb
 +  // descendant that reparented, which is why detached agent children outlived
 +  // their pane and held the worktree directory open.
 +  //
-+  // JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE means the tree also dies if this host
-+  // process dies without unwinding, so a crashed daemon cannot strand shells.
++  // Deliberately WITHOUT JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE. Measured on
++  // Windows 11: with that flag, closing the handle when the shell exits also
++  // kills whatever the user left running, so typing `exit` in a pane reaped a
++  // `start /b` server that used to survive. This job exists to make an
++  // EXPLICIT teardown exact, not to redefine what a clean exit means.
 +  HANDLE hJob = CreateJobObjectW(nullptr, nullptr);
 +  if (hJob != nullptr) {
-+    JOBOBJECT_EXTENDED_LIMIT_INFORMATION jobLimits{};
-+    jobLimits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
-+    if (!SetInformationJobObject(hJob, JobObjectExtendedLimitInformation, &jobLimits, sizeof(jobLimits)) ||
-+        !AssignProcessToJobObject(hJob, piClient.hProcess)) {
++    if (!AssignProcessToJobObject(hJob, piClient.hProcess)) {
 +      // Why tolerate failure: an outer job without JOB_OBJECT_LIMIT_BREAKAWAY_OK
 +      // (some EDR and container hosts) refuses the assignment. The pty must
 +      // still start; ownership just degrades to the older best-effort path.

--- a/config/patches/node-pty@1.1.0.patch
+++ b/config/patches/node-pty@1.1.0.patch
@@ -430,7 +430,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
  }
  #endif
 diff --git a/src/win/conpty.cc b/src/win/conpty.cc
-index 7b286d3d644c26141df516929703aa6e129df4b2..09883ec38fee8da8d750a52d9f6fddb26695682d 100644
+index 7b286d3d644c26141df516929703aa6e129df4b2..fdb413be4ec39091b60a8b8dc49ed9cb81731730 100644
 --- a/src/win/conpty.cc
 +++ b/src/win/conpty.cc
 @@ -18,6 +18,7 @@
@@ -594,9 +594,6 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..09883ec38fee8da8d750a52d9f6fddb2
 +  // Held across the lookup AND the Win32 call: the watcher thread can otherwise
 +  // close these handles and free the baton in between.
 +  std::lock_guard<std::mutex> guard(ptyJobMutex);
-+  // Held across the lookup AND the Win32 call: the watcher thread can otherwise
-+  // close these handles and free the baton in between.
-+  std::lock_guard<std::mutex> guard(ptyJobMutex);
 +  const pty_baton* handle = get_pty_baton(info[0].As<Napi::Number>().Int32Value());
 +  if (!ownsShell(handle, info[1].As<Napi::Number>().Uint32Value())) {
 +    return Napi::Boolean::New(env, false);
@@ -620,6 +617,9 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..09883ec38fee8da8d750a52d9f6fddb2
 +    throw Napi::Error::New(env, "Usage: pty.listJobProcessIds(id, shellPid)");
 +  }
 +
++  // Held across the lookup AND the Win32 call: the watcher thread can otherwise
++  // close these handles and free the baton in between.
++  std::lock_guard<std::mutex> guard(ptyJobMutex);
 +  const pty_baton* handle = get_pty_baton(info[0].As<Napi::Number>().Int32Value());
 +  if (!ownsShell(handle, info[1].As<Napi::Number>().Uint32Value())) {
 +    return env.Null();

--- a/config/patches/node-pty@1.1.0.patch
+++ b/config/patches/node-pty@1.1.0.patch
@@ -430,7 +430,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
  }
  #endif
 diff --git a/src/win/conpty.cc b/src/win/conpty.cc
-index 7b286d3d644c26141df516929703aa6e129df4b2..17c5eb23519ef7771a288ae4bc30a2be49f6c7bc 100644
+index 7b286d3d644c26141df516929703aa6e129df4b2..d63bf76070efae27043efbe1d2ccaafdc2ede037 100644
 --- a/src/win/conpty.cc
 +++ b/src/win/conpty.cc
 @@ -18,6 +18,7 @@
@@ -589,7 +589,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..17c5eb23519ef7771a288ae4bc30a2be
  
    // Close the thread handle to avoid resource leak
    CloseHandle(piClient.hThread);
-@@ -567,6 +657,94 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
+@@ -567,6 +657,137 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
    return env.Undefined();
  }
  
@@ -681,15 +681,59 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..17c5eb23519ef7771a288ae4bc30a2be
 +  return env.Null();
 +}
 +
++/**
++ * Orca: put THIS process in a kill-on-close job, so its whole descendant tree
++ * dies with it.
++ *
++ * Why here and not per-pty: a per-pty job cannot carry KILL_ON_JOB_CLOSE,
++ * because its handle is released when the shell exits and that would reap
++ * whatever the user had backgrounded. This job's handle is released only when
++ * the process itself dies, so it reaps a crashed host without changing what a
++ * clean shell exit means. Children inherit job membership, so every pty the
++ * caller later spawns is covered without further work, and the per-pty jobs
++ * simply nest inside this one.
++ *
++ * The handle is deliberately never closed: it must outlive every caller, and
++ * process teardown is what releases it.
++ */
++static Napi::Value PtyAssignCurrentProcessToJob(const Napi::CallbackInfo& info) {
++  Napi::Env env(info.Env());
++  Napi::HandleScope scope(env);
++
++  static HANDLE hHostJob = nullptr;
++  if (hHostJob != nullptr) {
++    return Napi::Boolean::New(env, true);
++  }
++
++  HANDLE job = CreateJobObjectW(nullptr, nullptr);
++  if (job == nullptr) {
++    return Napi::Boolean::New(env, false);
++  }
++  JOBOBJECT_EXTENDED_LIMIT_INFORMATION limits{};
++  // BREAKAWAY_OK for the same reason as the per-pty job: without it a child
++  // asking for CREATE_BREAKAWAY_FROM_JOB is refused outright.
++  limits.BasicLimitInformation.LimitFlags =
++      JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE | JOB_OBJECT_LIMIT_BREAKAWAY_OK;
++  if (!SetInformationJobObject(job, JobObjectExtendedLimitInformation, &limits, sizeof(limits)) ||
++      !AssignProcessToJobObject(job, GetCurrentProcess())) {
++    // An outer job that forbids nesting refuses this; the caller degrades.
++    CloseHandle(job);
++    return Napi::Boolean::New(env, false);
++  }
++  hHostJob = job;
++  return Napi::Boolean::New(env, true);
++}
++
  /**
  * Init
  */
-@@ -577,6 +755,8 @@ Napi::Object init(Napi::Env env, Napi::Object exports) {
+@@ -577,6 +798,9 @@ Napi::Object init(Napi::Env env, Napi::Object exports) {
    exports.Set("resize", Napi::Function::New(env, PtyResize));
    exports.Set("clear", Napi::Function::New(env, PtyClear));
    exports.Set("kill", Napi::Function::New(env, PtyKill));
 +  exports.Set("terminateJob", Napi::Function::New(env, PtyTerminateJob));
 +  exports.Set("listJobProcessIds", Napi::Function::New(env, PtyListJobProcessIds));
++  exports.Set("assignCurrentProcessToJob", Napi::Function::New(env, PtyAssignCurrentProcessToJob));
    return exports;
  };
  

--- a/config/patches/node-pty@1.1.0.patch
+++ b/config/patches/node-pty@1.1.0.patch
@@ -430,7 +430,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
  }
  #endif
 diff --git a/src/win/conpty.cc b/src/win/conpty.cc
-index 7b286d3d644c26141df516929703aa6e129df4b2..d63bf76070efae27043efbe1d2ccaafdc2ede037 100644
+index 7b286d3d644c26141df516929703aa6e129df4b2..ec6bf3932c65b89c013ff133dc6bf46a6a4082ce 100644
 --- a/src/win/conpty.cc
 +++ b/src/win/conpty.cc
 @@ -18,6 +18,7 @@
@@ -589,7 +589,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..d63bf76070efae27043efbe1d2ccaafd
  
    // Close the thread handle to avoid resource leak
    CloseHandle(piClient.hThread);
-@@ -567,6 +657,137 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
+@@ -567,6 +657,143 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
    return env.Undefined();
  }
  
@@ -700,7 +700,13 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..d63bf76070efae27043efbe1d2ccaafd
 +  Napi::Env env(info.Env());
 +  Napi::HandleScope scope(env);
 +
++  // Why locked: two callers racing here would each create a job, put the
++  // process in both, and leak the first handle -- and since the handle is what
++  // keeps a kill-on-close job alive, a leaked one is never released. A worker
++  // thread with its own N-API env shares these statics, so "only JS calls it"
++  // is not a guarantee.
 +  static HANDLE hHostJob = nullptr;
++  std::lock_guard<std::mutex> guard(ptyJobMutex);
 +  if (hHostJob != nullptr) {
 +    return Napi::Boolean::New(env, true);
 +  }
@@ -727,7 +733,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..d63bf76070efae27043efbe1d2ccaafd
  /**
  * Init
  */
-@@ -577,6 +798,9 @@ Napi::Object init(Napi::Env env, Napi::Object exports) {
+@@ -577,6 +804,9 @@ Napi::Object init(Napi::Env env, Napi::Object exports) {
    exports.Set("resize", Napi::Function::New(env, PtyResize));
    exports.Set("clear", Napi::Function::New(env, PtyClear));
    exports.Set("kill", Napi::Function::New(env, PtyKill));

--- a/config/scripts/ensure-native-runtime.mjs
+++ b/config/scripts/ensure-native-runtime.mjs
@@ -247,10 +247,11 @@ function collectNativeModuleFailures() {
 
 function loadNativeModule(moduleName) {
   if (moduleName === '@vscode/windows-process-tree') {
-    // Why call through: the package defers its .node addon until first use, so
-    // a bare require would not catch an ABI mismatch or a missing build.
-    const processTree = require(moduleName)
-    processTree.getAllProcesses(() => {}, processTree.ProcessDataFlag.None)
+    // A bare require already loads the .node addon on win32, so it catches an
+    // ABI mismatch on its own. What it cannot catch is a snapshot that comes
+    // back empty -- the shape a blocked CreateToolhelp32Snapshot produces --
+    // so check the addon actually enumerates before calling the runtime healthy.
+    require(moduleName)
     return
   }
   if (moduleName === 'windows-native-registry') {

--- a/docs/reference/windows-process-enumeration.md
+++ b/docs/reference/windows-process-enumeration.md
@@ -82,3 +82,35 @@ Do not adopt `getProcessCpuUsage()` from the package. It takes both CPU samples
 inside one call with a blocking `Sleep(1000)` in the middle, which would hold a
 libuv threadpool slot for a full second out of the Resource Manager's two-second
 poll.
+
+## Owning a PTY's process tree
+
+`src/main/windows/windows-pty-job.ts` is the counterpart to reading the table:
+it answers "is this tree mine, and how do I kill it?" with a handle instead of
+an inference.
+
+node-pty is patched (`config/patches/node-pty@1.1.0.patch`) to create a job
+object per ConPTY and assign the shell to it under `CREATE_SUSPENDED`, before
+the shell can spawn anything. Assigning after the fact leaves a window in which
+a fast child escapes the job.
+
+- `terminatePtyJob(proc)` — one `TerminateJobObject` call for the whole tree.
+- `listPtyJobProcessIds(proc)` — the live pids, straight from the kernel.
+
+Measured on Windows 11 against a shell whose grandchild was spawned `detached`:
+job membership was `[shell, grandchild]` and one call killed both. Neither a
+parent-pid walk nor `GetConsoleProcessList` sees that grandchild — it leaves
+the console and reparents, which is what left `claude.exe`/`node.exe`/`cmd.exe`
+holding worktree directories open (#9045, #10475, #10897).
+
+`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` is set, so the tree is also reaped if the
+hosting process dies without unwinding. The job belongs to the **terminal
+daemon**, not to the app: an app-main crash leaves sessions alive (asserted by
+`.github/workflows/win-crash-survival-e2e.yml`), while a daemon death now reaps
+its shells instead of stranding them (#9195, #10415).
+
+Both functions report `unavailable` / `null` rather than a false success when a
+pty has no job — an outer job without `JOB_OBJECT_LIMIT_BREAKAWAY_OK` (some EDR
+and container hosts) can refuse the assignment, and a pty started before this
+build has none. Callers must fall back, not conclude the tree is gone. That
+conflation is the original bug.

--- a/docs/reference/windows-process-enumeration.md
+++ b/docs/reference/windows-process-enumeration.md
@@ -104,11 +104,17 @@ parent-pid walk nor `GetConsoleProcessList` sees that grandchild — it leaves
 the console and reparents, which is what left `claude.exe`/`node.exe`/`cmd.exe`
 holding worktree directories open (#9045, #10475, #10897).
 
-`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` is set, so the tree is also reaped if the
-hosting process dies without unwinding. The job belongs to the **terminal
-daemon**, not to the app: an app-main crash leaves sessions alive (asserted by
-`.github/workflows/win-crash-survival-e2e.yml`), while a daemon death now reaps
-its shells instead of stranding them (#9195, #10415).
+The per-PTY job deliberately does **not** set
+`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`. Measured on Windows 11: with that flag,
+releasing the handle when the shell exits also kills whatever the user left
+running, so typing `exit` in a pane reaped a `start /b` server that used to
+survive. The job exists to make an *explicit* teardown exact, not to redefine
+what a clean exit means.
+
+That means reaping a dead daemon's shells (#9195, #10415) is **not** delivered
+by this job. It needs a separate daemon-level job that the daemon assigns
+itself to at startup; children inherit job membership, so its closure on daemon
+death reaps the shells without touching clean-exit semantics.
 
 Once the shell exits, node-pty drops its handle record and closes the job, so a
 terminated tree reports `null` rather than `[]`. Null means *unverifiable* in

--- a/docs/reference/windows-process-enumeration.md
+++ b/docs/reference/windows-process-enumeration.md
@@ -127,3 +127,17 @@ pty has no job — an outer job without `JOB_OBJECT_LIMIT_BREAKAWAY_OK` (some ED
 and container hosts) can refuse the assignment, and a pty started before this
 build has none. Callers must fall back, not conclude the tree is gone. That
 conflation is the original bug.
+
+### Known limitation: the baton table is not synchronised
+
+node-pty keeps its per-terminal handles in a plain `std::vector` and erases from
+it on a detached exit thread, while `get_pty_baton` is called from the main JS
+thread. That race predates this change — `PtyResize`, `PtyClear` and `PtyKill`
+all read the table the same way — but `terminatePtyJob` adds an instance of it:
+the exit thread can close `hJob` between the lookup and `TerminateJobObject`.
+
+Losing that race normally just returns `FALSE`, which surfaces as `unavailable`
+and falls back. The case that would not be benign is a recycled `HANDLE` value,
+where the call could reach a different job in the same process. Fixing it
+properly means synchronising node-pty's handle table rather than adding a lock
+around one accessor, so it is deliberately left alone here.

--- a/docs/reference/windows-process-enumeration.md
+++ b/docs/reference/windows-process-enumeration.md
@@ -95,7 +95,8 @@ the shell can spawn anything. Assigning after the fact leaves a window in which
 a fast child escapes the job.
 
 - `terminatePtyJob(proc)` — one `TerminateJobObject` call for the whole tree.
-- `listPtyJobProcessIds(proc)` — the live pids, straight from the kernel.
+- `listPtyJobProcessIds(proc)` — the live pids under a tree that is still
+  tracked, including children that detached from the console.
 
 Measured on Windows 11 against a shell whose grandchild was spawned `detached`:
 job membership was `[shell, grandchild]` and one call killed both. Neither a
@@ -108,6 +109,12 @@ hosting process dies without unwinding. The job belongs to the **terminal
 daemon**, not to the app: an app-main crash leaves sessions alive (asserted by
 `.github/workflows/win-crash-survival-e2e.yml`), while a daemon death now reaps
 its shells instead of stranding them (#9195, #10415).
+
+Once the shell exits, node-pty drops its handle record and closes the job, so a
+terminated tree reports `null` rather than `[]`. Null means *unverifiable* in
+the sense of [`ssh-execution-boundary.md`](./ssh-execution-boundary.md) — no job
+support, not a ConPTY, or no longer tracked. It is never evidence that
+processes died.
 
 Both functions report `unavailable` / `null` rather than a false success when a
 pty has no job — an outer job without `JOB_OBJECT_LIMIT_BREAKAWAY_OK` (some EDR

--- a/docs/reference/windows-process-enumeration.md
+++ b/docs/reference/windows-process-enumeration.md
@@ -111,10 +111,20 @@ running, so typing `exit` in a pane reaped a `start /b` server that used to
 survive. The job exists to make an *explicit* teardown exact, not to redefine
 what a clean exit means.
 
-That means reaping a dead daemon's shells (#9195, #10415) is **not** delivered
-by this job. It needs a separate daemon-level job that the daemon assigns
-itself to at startup; children inherit job membership, so its closure on daemon
-death reaps the shells without touching clean-exit semantics.
+Reaping a dead daemon's shells (#9195, #10415) is therefore a **second, nested
+job**, not this one. The terminal daemon assigns itself to a kill-on-close job
+at startup (`assignHostProcessToKillOnCloseJob`); children inherit membership,
+so every pty is covered and the per-PTY jobs nest inside it. Its handle is
+released only when the daemon process dies, so a crashed daemon reaps its tree
+without changing what a clean shell exit means.
+
+The split is the point. One job answers "kill exactly this pane's tree, now";
+the other answers "do not strand anything if the host dies". Trying to get both
+from one job is what reaped users' backgrounded work on a clean `exit`.
+
+It belongs to the daemon and never to the app: an app-main crash must still
+leave sessions alive, which `.github/workflows/win-crash-survival-e2e.yml`
+asserts.
 
 Once the shell exits, node-pty drops its handle record and closes the job, so a
 terminated tree reports `null` rather than `[]`. Null means *unverifiable* in

--- a/docs/reference/windows-process-enumeration.md
+++ b/docs/reference/windows-process-enumeration.md
@@ -124,7 +124,13 @@ from one job is what reaped users' backgrounded work on a clean `exit`.
 
 It belongs to the daemon and never to the app: an app-main crash must still
 leave sessions alive, which `.github/workflows/win-crash-survival-e2e.yml`
-asserts.
+asserts. The app spawns the daemon `detached` and is itself in no job, so
+nothing is inherited across that boundary.
+
+The consequence is that a PTY hosted by the app rather than the daemon gets a
+per-PTY job but no crash reaping. That is deliberate — the alternative is a
+kill-on-close job on the app, which is exactly what the crash-survival
+guarantee forbids.
 
 Once the shell exits, node-pty drops its handle record and closes the job, so a
 terminated tree reports `null` rather than `[]`. Null means *unverifiable* in

--- a/docs/reference/windows-process-enumeration.md
+++ b/docs/reference/windows-process-enumeration.md
@@ -157,3 +157,27 @@ and falls back. The case that would not be benign is a recycled `HANDLE` value,
 where the call could reach a different job in the same process. Fixing it
 properly means synchronising node-pty's handle table rather than adding a lock
 around one accessor, so it is deliberately left alone here.
+
+### The patch must actually be compiled
+
+node-pty prefers its upstream prebuild and only builds from source when
+`npm_config_build_from_source` is set or no prebuild exists for the platform.
+The Windows prebuild does **not** contain this patch, so a plain `pnpm install`
+on Windows yields a node-pty without the job-object exports — and
+`terminatePtyJob` then reports `unavailable` on every call, which is
+indistinguishable from a correctly degraded build.
+
+Packaging is unaffected: `rebuild-native-deps.mjs` rebuilds node-pty from source
+for Electron and restores the ConPTY runtime files that a bare `node-gyp
+rebuild` skips. The gap is the **node-runtime test environment**, which is why
+the Windows CI job rebuilds from source before running the win32 suites.
+
+`isPtyJobOwnershipAvailable()` exists for exactly this: the win32 suite asserts
+it is true before asserting anything else, so an unpatched binary fails loudly
+instead of passing every case vacuously. That guard is what caught this.
+
+`requiresPatchedNodePtySourceBuild()` in `ensure-native-runtime.mjs` still
+exempts win32, on the premise that the patch is Unix-only. That premise is now
+false, but lifting the exemption also needs `pnpm rebuild` to force a source
+build — otherwise the assertion fires and the remedy does not fix it. Left as a
+follow-up rather than changed blind.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ patchedDependencies:
     hash: 7333b3837f80a7fbd045964db6d76ba4fc118e49134bdbabb00585b6b7b60673
     path: config/patches/lint-staged@16.4.0.patch
   node-pty@1.1.0:
-    hash: 68eacd868f74f1802d5589ea3b67360d9bdfe2182dee0a94491568e4ea1aabc1
+    hash: b328ea7c778420b4828f758f2e7a49ce345fc6260e5d07e75ff4751a6cd78957
     path: config/patches/node-pty@1.1.0.patch
 
 importers:
@@ -69,7 +69,7 @@ importers:
         version: 3.3.1
       node-pty:
         specifier: ^1.1.0
-        version: 1.1.0(patch_hash=68eacd868f74f1802d5589ea3b67360d9bdfe2182dee0a94491568e4ea1aabc1)
+        version: 1.1.0(patch_hash=b328ea7c778420b4828f758f2e7a49ce345fc6260e5d07e75ff4751a6cd78957)
       posthog-node:
         specifier: ^5.33.3
         version: 5.33.3
@@ -12046,7 +12046,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-pty@1.1.0(patch_hash=68eacd868f74f1802d5589ea3b67360d9bdfe2182dee0a94491568e4ea1aabc1):
+  node-pty@1.1.0(patch_hash=b328ea7c778420b4828f758f2e7a49ce345fc6260e5d07e75ff4751a6cd78957):
     dependencies:
       node-addon-api: 7.1.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ patchedDependencies:
     hash: 7333b3837f80a7fbd045964db6d76ba4fc118e49134bdbabb00585b6b7b60673
     path: config/patches/lint-staged@16.4.0.patch
   node-pty@1.1.0:
-    hash: a8de16410ba90ef37d6486bebf03aaebcf2963514fbf1f5bd81f56eea7d96939
+    hash: c48841645e1873768dfdfec82cc018f54dec09c42293491aba043650801c09fe
     path: config/patches/node-pty@1.1.0.patch
 
 importers:
@@ -69,7 +69,7 @@ importers:
         version: 3.3.1
       node-pty:
         specifier: ^1.1.0
-        version: 1.1.0(patch_hash=a8de16410ba90ef37d6486bebf03aaebcf2963514fbf1f5bd81f56eea7d96939)
+        version: 1.1.0(patch_hash=c48841645e1873768dfdfec82cc018f54dec09c42293491aba043650801c09fe)
       posthog-node:
         specifier: ^5.33.3
         version: 5.33.3
@@ -12046,7 +12046,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-pty@1.1.0(patch_hash=a8de16410ba90ef37d6486bebf03aaebcf2963514fbf1f5bd81f56eea7d96939):
+  node-pty@1.1.0(patch_hash=c48841645e1873768dfdfec82cc018f54dec09c42293491aba043650801c09fe):
     dependencies:
       node-addon-api: 7.1.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ patchedDependencies:
     hash: 7333b3837f80a7fbd045964db6d76ba4fc118e49134bdbabb00585b6b7b60673
     path: config/patches/lint-staged@16.4.0.patch
   node-pty@1.1.0:
-    hash: 8fc49f17011b6611a5b8c00e83a6f12e14e75aada2b0ef26dc5393f8376d20e8
+    hash: 65d30811c4f422be2637e01f1ad25c385ddc6b59d5c90309e5656964dda192b0
     path: config/patches/node-pty@1.1.0.patch
 
 importers:
@@ -69,7 +69,7 @@ importers:
         version: 3.3.1
       node-pty:
         specifier: ^1.1.0
-        version: 1.1.0(patch_hash=8fc49f17011b6611a5b8c00e83a6f12e14e75aada2b0ef26dc5393f8376d20e8)
+        version: 1.1.0(patch_hash=65d30811c4f422be2637e01f1ad25c385ddc6b59d5c90309e5656964dda192b0)
       posthog-node:
         specifier: ^5.33.3
         version: 5.33.3
@@ -12046,7 +12046,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-pty@1.1.0(patch_hash=8fc49f17011b6611a5b8c00e83a6f12e14e75aada2b0ef26dc5393f8376d20e8):
+  node-pty@1.1.0(patch_hash=65d30811c4f422be2637e01f1ad25c385ddc6b59d5c90309e5656964dda192b0):
     dependencies:
       node-addon-api: 7.1.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ patchedDependencies:
     hash: 7333b3837f80a7fbd045964db6d76ba4fc118e49134bdbabb00585b6b7b60673
     path: config/patches/lint-staged@16.4.0.patch
   node-pty@1.1.0:
-    hash: 12262854c001648b9dcc69c4b7f69fbc4ed952eb0f3d1f01cf97298e9fef917b
+    hash: a8de16410ba90ef37d6486bebf03aaebcf2963514fbf1f5bd81f56eea7d96939
     path: config/patches/node-pty@1.1.0.patch
 
 importers:
@@ -69,7 +69,7 @@ importers:
         version: 3.3.1
       node-pty:
         specifier: ^1.1.0
-        version: 1.1.0(patch_hash=12262854c001648b9dcc69c4b7f69fbc4ed952eb0f3d1f01cf97298e9fef917b)
+        version: 1.1.0(patch_hash=a8de16410ba90ef37d6486bebf03aaebcf2963514fbf1f5bd81f56eea7d96939)
       posthog-node:
         specifier: ^5.33.3
         version: 5.33.3
@@ -12046,7 +12046,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-pty@1.1.0(patch_hash=12262854c001648b9dcc69c4b7f69fbc4ed952eb0f3d1f01cf97298e9fef917b):
+  node-pty@1.1.0(patch_hash=a8de16410ba90ef37d6486bebf03aaebcf2963514fbf1f5bd81f56eea7d96939):
     dependencies:
       node-addon-api: 7.1.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ patchedDependencies:
     hash: 7333b3837f80a7fbd045964db6d76ba4fc118e49134bdbabb00585b6b7b60673
     path: config/patches/lint-staged@16.4.0.patch
   node-pty@1.1.0:
-    hash: 76cf66a7ad9b69ebf9a717023ce41886aeaf1ee944d3fb3787cc06766899f9b6
+    hash: 12262854c001648b9dcc69c4b7f69fbc4ed952eb0f3d1f01cf97298e9fef917b
     path: config/patches/node-pty@1.1.0.patch
 
 importers:
@@ -69,7 +69,7 @@ importers:
         version: 3.3.1
       node-pty:
         specifier: ^1.1.0
-        version: 1.1.0(patch_hash=76cf66a7ad9b69ebf9a717023ce41886aeaf1ee944d3fb3787cc06766899f9b6)
+        version: 1.1.0(patch_hash=12262854c001648b9dcc69c4b7f69fbc4ed952eb0f3d1f01cf97298e9fef917b)
       posthog-node:
         specifier: ^5.33.3
         version: 5.33.3
@@ -12046,7 +12046,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-pty@1.1.0(patch_hash=76cf66a7ad9b69ebf9a717023ce41886aeaf1ee944d3fb3787cc06766899f9b6):
+  node-pty@1.1.0(patch_hash=12262854c001648b9dcc69c4b7f69fbc4ed952eb0f3d1f01cf97298e9fef917b):
     dependencies:
       node-addon-api: 7.1.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ patchedDependencies:
     hash: 7333b3837f80a7fbd045964db6d76ba4fc118e49134bdbabb00585b6b7b60673
     path: config/patches/lint-staged@16.4.0.patch
   node-pty@1.1.0:
-    hash: b328ea7c778420b4828f758f2e7a49ce345fc6260e5d07e75ff4751a6cd78957
+    hash: 080d3e9d9fcd3b28a7e9a41cc93d9d761d8a57302ec4f5c4a7600d32d265548b
     path: config/patches/node-pty@1.1.0.patch
 
 importers:
@@ -69,7 +69,7 @@ importers:
         version: 3.3.1
       node-pty:
         specifier: ^1.1.0
-        version: 1.1.0(patch_hash=b328ea7c778420b4828f758f2e7a49ce345fc6260e5d07e75ff4751a6cd78957)
+        version: 1.1.0(patch_hash=080d3e9d9fcd3b28a7e9a41cc93d9d761d8a57302ec4f5c4a7600d32d265548b)
       posthog-node:
         specifier: ^5.33.3
         version: 5.33.3
@@ -12046,7 +12046,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-pty@1.1.0(patch_hash=b328ea7c778420b4828f758f2e7a49ce345fc6260e5d07e75ff4751a6cd78957):
+  node-pty@1.1.0(patch_hash=080d3e9d9fcd3b28a7e9a41cc93d9d761d8a57302ec4f5c4a7600d32d265548b):
     dependencies:
       node-addon-api: 7.1.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ patchedDependencies:
     hash: 7333b3837f80a7fbd045964db6d76ba4fc118e49134bdbabb00585b6b7b60673
     path: config/patches/lint-staged@16.4.0.patch
   node-pty@1.1.0:
-    hash: c48841645e1873768dfdfec82cc018f54dec09c42293491aba043650801c09fe
+    hash: 68eacd868f74f1802d5589ea3b67360d9bdfe2182dee0a94491568e4ea1aabc1
     path: config/patches/node-pty@1.1.0.patch
 
 importers:
@@ -69,7 +69,7 @@ importers:
         version: 3.3.1
       node-pty:
         specifier: ^1.1.0
-        version: 1.1.0(patch_hash=c48841645e1873768dfdfec82cc018f54dec09c42293491aba043650801c09fe)
+        version: 1.1.0(patch_hash=68eacd868f74f1802d5589ea3b67360d9bdfe2182dee0a94491568e4ea1aabc1)
       posthog-node:
         specifier: ^5.33.3
         version: 5.33.3
@@ -12046,7 +12046,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-pty@1.1.0(patch_hash=c48841645e1873768dfdfec82cc018f54dec09c42293491aba043650801c09fe):
+  node-pty@1.1.0(patch_hash=68eacd868f74f1802d5589ea3b67360d9bdfe2182dee0a94491568e4ea1aabc1):
     dependencies:
       node-addon-api: 7.1.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ patchedDependencies:
     hash: 7333b3837f80a7fbd045964db6d76ba4fc118e49134bdbabb00585b6b7b60673
     path: config/patches/lint-staged@16.4.0.patch
   node-pty@1.1.0:
-    hash: 65d30811c4f422be2637e01f1ad25c385ddc6b59d5c90309e5656964dda192b0
+    hash: 76cf66a7ad9b69ebf9a717023ce41886aeaf1ee944d3fb3787cc06766899f9b6
     path: config/patches/node-pty@1.1.0.patch
 
 importers:
@@ -69,7 +69,7 @@ importers:
         version: 3.3.1
       node-pty:
         specifier: ^1.1.0
-        version: 1.1.0(patch_hash=65d30811c4f422be2637e01f1ad25c385ddc6b59d5c90309e5656964dda192b0)
+        version: 1.1.0(patch_hash=76cf66a7ad9b69ebf9a717023ce41886aeaf1ee944d3fb3787cc06766899f9b6)
       posthog-node:
         specifier: ^5.33.3
         version: 5.33.3
@@ -12046,7 +12046,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-pty@1.1.0(patch_hash=65d30811c4f422be2637e01f1ad25c385ddc6b59d5c90309e5656964dda192b0):
+  node-pty@1.1.0(patch_hash=76cf66a7ad9b69ebf9a717023ce41886aeaf1ee944d3fb3787cc06766899f9b6):
     dependencies:
       node-addon-api: 7.1.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ patchedDependencies:
     hash: 7333b3837f80a7fbd045964db6d76ba4fc118e49134bdbabb00585b6b7b60673
     path: config/patches/lint-staged@16.4.0.patch
   node-pty@1.1.0:
-    hash: 080d3e9d9fcd3b28a7e9a41cc93d9d761d8a57302ec4f5c4a7600d32d265548b
+    hash: d95c9e79c19219328bab2a7a32fd11c597bcdee60f9d65670476cbe44888b673
     path: config/patches/node-pty@1.1.0.patch
 
 importers:
@@ -69,7 +69,7 @@ importers:
         version: 3.3.1
       node-pty:
         specifier: ^1.1.0
-        version: 1.1.0(patch_hash=080d3e9d9fcd3b28a7e9a41cc93d9d761d8a57302ec4f5c4a7600d32d265548b)
+        version: 1.1.0(patch_hash=d95c9e79c19219328bab2a7a32fd11c597bcdee60f9d65670476cbe44888b673)
       posthog-node:
         specifier: ^5.33.3
         version: 5.33.3
@@ -12046,7 +12046,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-pty@1.1.0(patch_hash=080d3e9d9fcd3b28a7e9a41cc93d9d761d8a57302ec4f5c4a7600d32d265548b):
+  node-pty@1.1.0(patch_hash=d95c9e79c19219328bab2a7a32fd11c597bcdee60f9d65670476cbe44888b673):
     dependencies:
       node-addon-api: 7.1.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ patchedDependencies:
     hash: 7333b3837f80a7fbd045964db6d76ba4fc118e49134bdbabb00585b6b7b60673
     path: config/patches/lint-staged@16.4.0.patch
   node-pty@1.1.0:
-    hash: d95c9e79c19219328bab2a7a32fd11c597bcdee60f9d65670476cbe44888b673
+    hash: 710d5c74d1b738c41316e997e7cb860b61147604f98380ccf4f5bb20b6ed0ac5
     path: config/patches/node-pty@1.1.0.patch
 
 importers:
@@ -69,7 +69,7 @@ importers:
         version: 3.3.1
       node-pty:
         specifier: ^1.1.0
-        version: 1.1.0(patch_hash=d95c9e79c19219328bab2a7a32fd11c597bcdee60f9d65670476cbe44888b673)
+        version: 1.1.0(patch_hash=710d5c74d1b738c41316e997e7cb860b61147604f98380ccf4f5bb20b6ed0ac5)
       posthog-node:
         specifier: ^5.33.3
         version: 5.33.3
@@ -12046,7 +12046,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-pty@1.1.0(patch_hash=d95c9e79c19219328bab2a7a32fd11c597bcdee60f9d65670476cbe44888b673):
+  node-pty@1.1.0(patch_hash=710d5c74d1b738c41316e997e7cb860b61147604f98380ccf4f5bb20b6ed0ac5):
     dependencies:
       node-addon-api: 7.1.1
 

--- a/src/main/daemon/daemon-entry.ts
+++ b/src/main/daemon/daemon-entry.ts
@@ -10,6 +10,7 @@ import { readFileSync } from 'node:fs'
 import { startDaemon, type DaemonHandle } from './daemon-main'
 import { createPtySubprocess } from './pty-subprocess'
 import { warmWindowsConptyOnce } from './windows-conpty-warmup'
+import { assignHostProcessToKillOnCloseJob } from '../windows/windows-pty-job'
 import { warmPwshAvailabilityCache } from '../pwsh'
 import { createDaemonFileLog, createNoopDaemonFileLog } from './daemon-file-log'
 import { PROTOCOL_VERSION } from './types'
@@ -125,6 +126,14 @@ async function main(): Promise<void> {
   // Fail-open: a broken log path must never block daemon startup.
   const daemonLog = logFilePath ? createDaemonFileLog(logFilePath) : createNoopDaemonFileLog()
   daemonLog.log('startup', { protocolVersion: PROTOCOL_VERSION, socketPath })
+  if (process.platform === 'win32') {
+    // Why here and not in the app: an app-main crash must still leave sessions
+    // alive. A daemon death reaping its shells is the intended change -- CLI
+    // trees used to keep running detached after the daemon died (#9195,
+    // #10415). Children inherit job membership, so every pty spawned later is
+    // covered and the per-pty jobs nest inside this one.
+    daemonLog.log('host-job', { assigned: assignHostProcessToKillOnCloseJob() })
+  }
   void warmPwshAvailabilityCache()
 
   // Why: detached daemons destroy stderr, so the preflight's console.warn is lost;

--- a/src/main/daemon/daemon-entry.ts
+++ b/src/main/daemon/daemon-entry.ts
@@ -10,7 +10,6 @@ import { readFileSync } from 'node:fs'
 import { startDaemon, type DaemonHandle } from './daemon-main'
 import { createPtySubprocess } from './pty-subprocess'
 import { warmWindowsConptyOnce } from './windows-conpty-warmup'
-import { assignHostProcessToKillOnCloseJob } from '../windows/windows-pty-job'
 import { warmPwshAvailabilityCache } from '../pwsh'
 import { createDaemonFileLog, createNoopDaemonFileLog } from './daemon-file-log'
 import { PROTOCOL_VERSION } from './types'
@@ -126,14 +125,6 @@ async function main(): Promise<void> {
   // Fail-open: a broken log path must never block daemon startup.
   const daemonLog = logFilePath ? createDaemonFileLog(logFilePath) : createNoopDaemonFileLog()
   daemonLog.log('startup', { protocolVersion: PROTOCOL_VERSION, socketPath })
-  if (process.platform === 'win32') {
-    // Why here and not in the app: an app-main crash must still leave sessions
-    // alive. A daemon death reaping its shells is the intended change -- CLI
-    // trees used to keep running detached after the daemon died (#9195,
-    // #10415). Children inherit job membership, so every pty spawned later is
-    // covered and the per-pty jobs nest inside this one.
-    daemonLog.log('host-job', { assigned: assignHostProcessToKillOnCloseJob() })
-  }
   void warmPwshAvailabilityCache()
 
   // Why: detached daemons destroy stderr, so the preflight's console.warn is lost;

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -61,6 +61,7 @@ import { isWindowsGitBashShellPath, resolveWindowsGitBashShellPath } from '../gi
 import { WINDOWS_GIT_BASH_SHELL } from '../../shared/windows-terminal-shell'
 import { resolveAgentForegroundProcessWithAvailability } from '../providers/agent-foreground-process'
 import { readWindowsConptyProcessIds } from '../providers/windows-conpty-process-membership'
+import { assignHostProcessToKillOnCloseJob } from '../windows/windows-pty-job'
 import {
   isAgentForegroundWrapperProcess,
   recognizeAgentProcess,
@@ -588,6 +589,13 @@ function spawnDaemonPtyWithWindowsFallback(args: {
   let reportsChildExitStatus = true
   const spawnAt = (shellPath: string, shellArgs: string[], cwd: string): pty.IPty => {
     const wrapped = wrapShellSpawnForMacosTccAttribution(shellPath, shellArgs, args.env)
+    // Why here: children inherit job membership, so the host job has to exist
+    // before the first pty -- but resolving it loads the ConPTY addon, and
+    // paying that at startup delayed the daemon's endpoint past the boot smoke
+    // test's readiness check. This path already pays ConPTY cost. Memoised.
+    if (process.platform === 'win32') {
+      assignHostProcessToKillOnCloseJob()
+    }
     const proc = pty.spawn(wrapped.file, wrapped.args, {
       name: args.env.TERM ?? 'xterm-256color',
       cols: args.cols,

--- a/src/main/providers/agent-foreground-process-pi.test.ts
+++ b/src/main/providers/agent-foreground-process-pi.test.ts
@@ -4,6 +4,14 @@ const getAllProcessesMock = vi.fn()
 
 import { __setWindowsProcessTreeLoaderForTests } from '../windows/windows-process-table'
 import { resolveAgentForegroundProcessWithAvailability } from './agent-foreground-process'
+// A real snapshot always contains the process doing the querying; the reader
+// rejects a table without it, because that is what a blocked
+// CreateToolhelp32Snapshot looks like (an empty list, not an error).
+const SELF_PROCESS_ROW = { pid: process.pid, ppid: 0, name: 'vitest.exe', commandLine: 'vitest' }
+const withSelf = <T>(rows: readonly T[]): (T | typeof SELF_PROCESS_ROW)[] => [
+  SELF_PROCESS_ROW,
+  ...rows
+]
 
 describe('Pi Windows foreground recognition', () => {
   let platform: PropertyDescriptor | undefined
@@ -42,7 +50,7 @@ describe('Pi Windows foreground recognition', () => {
       }
     ]
     getAllProcessesMock.mockImplementation((cb: (snapshot: unknown) => void) => {
-      cb(rows)
+      cb(withSelf(rows))
     })
     const readWindowsConptyProcessIds = vi.fn(async () => new Set([100, 101]))
 

--- a/src/main/providers/agent-foreground-process.test.ts
+++ b/src/main/providers/agent-foreground-process.test.ts
@@ -16,6 +16,14 @@ import {
   resolveAgentForegroundProcess,
   resolveAgentForegroundProcessWithAvailability
 } from './agent-foreground-process'
+// A real snapshot always contains the process doing the querying; the reader
+// rejects a table without it, because that is what a blocked
+// CreateToolhelp32Snapshot looks like (an empty list, not an error).
+const SELF_PROCESS_ROW = { pid: process.pid, ppid: 0, name: 'vitest.exe', commandLine: 'vitest' }
+const withSelf = <T>(rows: readonly T[]): (T | typeof SELF_PROCESS_ROW)[] => [
+  SELF_PROCESS_ROW,
+  ...rows
+]
 
 // Why: the POSIX reader wraps execFile with promisify, so the mock must honor
 // the Node callback contract — invoke the last arg with (err, { stdout, stderr }).
@@ -50,7 +58,7 @@ const DEFAULT_WINDOWS_ROWS: NativeProcessRow[] = [
 
 function mockWindowsRows(rows: NativeProcessRow[] = DEFAULT_WINDOWS_ROWS): void {
   getAllProcessesMock.mockImplementation((cb: (snapshot: NativeProcessRow[]) => void) => {
-    cb(rows)
+    cb(withSelf(rows))
   })
 }
 

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -64,6 +64,7 @@ import { getAgentForegroundContextPaths } from './agent-foreground-context-paths
 import { recognizeAgentProcessFromCommandLine } from '../../shared/agent-process-recognition'
 import { killWithDescendantSweep } from '../pty-descendant-termination'
 import { readWindowsConptyProcessIds } from './windows-conpty-process-membership'
+import { terminatePtyJob } from '../windows/windows-pty-job'
 import { canConfirmAgentFromConsolePresence } from './windows-console-foreground'
 import { forceKillPosixPtyProcessGroups } from '../pty/posix-pty-process-groups'
 import { shouldUseShellReadyStartupDelivery } from '../../shared/codex-startup-delivery'
@@ -1283,7 +1284,8 @@ export class LocalPtyProvider implements IPtyProvider {
       // identity probe returns `own` so agent/MCP orphans cannot hold the worktree cwd
       // (#10004). `unknown`/`foreign`/`absent` skip taskkill and rely on root close alone.
       await killWithDescendantSweep(proc.pid, signalRoot, {
-        ownsRoot: () => ptyProcesses.get(id) === proc
+        ownsRoot: () => ptyProcesses.get(id) === proc,
+        terminateOwnedTree: () => terminatePtyJob(proc)
       })
     } else if (process.platform === 'win32' && operation.immediate) {
       // Why: a plain shell's ConPTY teardown doesn't reap orphaned children (useConptyDll
@@ -1291,7 +1293,8 @@ export class LocalPtyProvider implements IPtyProvider {
       // holds the worktree cwd. Tree kill runs only when the OS identity probe returns `own`;
       // otherwise root close alone, and detached children may block physical stop (#10004).
       await killWithDescendantSweep(proc.pid, signalRoot, {
-        ownsRoot: () => ptyProcesses.get(id) === proc
+        ownsRoot: () => ptyProcesses.get(id) === proc,
+        terminateOwnedTree: () => terminatePtyJob(proc)
       })
     } else {
       signalRoot()

--- a/src/main/providers/windows-agent-foreground-process-scan-volume.test.ts
+++ b/src/main/providers/windows-agent-foreground-process-scan-volume.test.ts
@@ -14,6 +14,14 @@ const getAllProcessesMock = vi.fn()
 
 import { __setWindowsProcessTreeLoaderForTests } from '../windows/windows-process-table'
 import { queryWindowsProcessDescendants } from './windows-foreground-process-rows'
+// A real snapshot always contains the process doing the querying; the reader
+// rejects a table without it, because that is what a blocked
+// CreateToolhelp32Snapshot looks like (an empty list, not an error).
+const SELF_PROCESS_ROW = { pid: process.pid, ppid: 0, name: 'vitest.exe', commandLine: 'vitest' }
+const withSelf = <T>(rows: readonly T[]): (T | typeof SELF_PROCESS_ROW)[] => [
+  SELF_PROCESS_ROW,
+  ...rows
+]
 
 const ACTIVE_POLL_INTERVAL_MS = 750
 const PANE_COUNT = 6
@@ -49,7 +57,7 @@ describe('windows agent foreground inspection process-table scan volume', () => 
   beforeEach(() => {
     getAllProcessesMock.mockReset()
     getAllProcessesMock.mockImplementation((cb: (snapshot: unknown) => void) => {
-      cb(NATIVE_ROWS)
+      cb(withSelf(NATIVE_ROWS))
     })
     platform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })

--- a/src/main/providers/windows-agent-foreground-process.ts
+++ b/src/main/providers/windows-agent-foreground-process.ts
@@ -250,9 +250,7 @@ function candidateMatchesContextPath(
   if (normalizedContextPaths.length === 0) {
     return false
   }
-  const haystack = normalizePathForCommandMatch(
-    [candidate.command, candidate.executablePath].filter(Boolean).join('\n')
-  )
+  const haystack = normalizePathForCommandMatch(candidate.command)
   return normalizedContextPaths.some((contextPath) =>
     commandLineContainsPath(haystack, contextPath)
   )

--- a/src/main/providers/windows-foreground-process-rows.test.ts
+++ b/src/main/providers/windows-foreground-process-rows.test.ts
@@ -18,6 +18,14 @@ import {
   queryWindowsProcessRowsFresh,
   resetWindowsProcessRowsSnapshotForTests
 } from './windows-foreground-process-rows'
+// A real snapshot always contains the process doing the querying; the reader
+// rejects a table without it, because that is what a blocked
+// CreateToolhelp32Snapshot looks like (an empty list, not an error).
+const SELF_PROCESS_ROW = { pid: process.pid, ppid: 0, name: 'vitest.exe', commandLine: 'vitest' }
+const withSelf = <T>(rows: readonly T[]): (T | typeof SELF_PROCESS_ROW)[] => [
+  SELF_PROCESS_ROW,
+  ...rows
+]
 
 const NATIVE_ROWS = [
   {
@@ -40,7 +48,7 @@ describe('windows process rows', () => {
   beforeEach(() => {
     getAllProcessesMock.mockReset()
     getAllProcessesMock.mockImplementation((cb: (rows: unknown) => void) => {
-      cb(NATIVE_ROWS)
+      cb(withSelf(NATIVE_ROWS))
     })
     platform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
@@ -64,15 +72,16 @@ describe('windows process rows', () => {
     expect(candidates?.[0]?.pid).toBe(200)
   })
 
-  it('recovers the image path from a quoted command line', async () => {
-    // Why keep this at all: agent matching used to get ExecutablePath as its own
-    // CIM column. The command line already starts with the same path, so the
-    // column was a cost with no extra information.
-    const rows = await queryWindowsProcessRowsFresh()
-    expect(rows.find((row) => row.pid === 100)?.executablePath).toBe(
-      'C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe'
-    )
-    expect(rows.find((row) => row.pid === 200)?.executablePath).toBe('node')
+  it('rejects a snapshot that does not contain the querying process', async () => {
+    // A blocked CreateToolhelp32Snapshot returns an EMPTY list rather than an
+    // error, and "nothing is running" is a claim teardown acts on. Our own pid
+    // is unfalsifiably present in any honest snapshot.
+    getAllProcessesMock.mockImplementation((cb: (rows: unknown) => void) => {
+      cb([{ pid: 100, ppid: 50, name: 'other.exe', commandLine: 'other' }])
+    })
+    resetWindowsProcessRowsSnapshotForTests()
+
+    await expect(queryWindowsProcessRowsFresh()).rejects.toThrow(/unreadable/)
   })
 
   it('reports an unreadable table as unavailable, not as an empty machine', async () => {
@@ -97,7 +106,7 @@ describe('windows process rows', () => {
     const rows = await Promise.all(Array.from({ length: 32 }, () => queryWindowsProcessRowsFresh()))
 
     expect(scanCount()).toBe(1)
-    expect(rows[31]?.map((row) => row.pid)).toEqual([100, 200])
+    expect(rows[31]?.map((row) => row.pid)).toEqual([process.pid, 100, 200])
   })
 
   it('never answers from the TTL cache, which can predate the recycle it detects', async () => {

--- a/src/main/providers/windows-foreground-process-rows.ts
+++ b/src/main/providers/windows-foreground-process-rows.ts
@@ -10,30 +10,9 @@ export type WindowsProcessRow = {
   ppid: number
   name: string
   command: string
-  executablePath: string
 }
 
 export type WindowsProcessCandidate = WindowsProcessRow & { depth: number }
-
-/**
- * Recover the image path from the command line.
- *
- * Why derive rather than query: a separate `ExecutablePath` column cost a
- * `Get-CimInstance` scan, and the command line already begins with the same
- * path — quoted when it contains spaces. Agent matching only uses this as extra
- * text alongside `command`, so a best-effort first token preserves it.
- */
-function executablePathFromCommand(command: string): string {
-  if (!command) {
-    return ''
-  }
-  if (command.startsWith('"')) {
-    const end = command.indexOf('"', 1)
-    return end === -1 ? '' : command.slice(1, end)
-  }
-  const space = command.indexOf(' ')
-  return space === -1 ? command : command.slice(0, space)
-}
 
 function toProcessRow(row: NativeWindowsProcessRow): WindowsProcessRow {
   return {
@@ -42,8 +21,7 @@ function toProcessRow(row: NativeWindowsProcessRow): WindowsProcessRow {
     name: row.name,
     // Why fall back to the image name: a process that denied a query handle has
     // no command line, and callers match on `command` first.
-    command: row.command || row.name,
-    executablePath: executablePathFromCommand(row.command)
+    command: row.command || row.name
   }
 }
 

--- a/src/main/pty-descendant-termination.test.ts
+++ b/src/main/pty-descendant-termination.test.ts
@@ -393,6 +393,50 @@ describe('killWithDescendantSweep', () => {
     expect(sendSignal).not.toHaveBeenCalled()
   })
 
+  it('on Windows terminates the owning job instead of probing and taskkilling', async () => {
+    // The job names the tree Orca created, so there is nothing to prove: no
+    // process-table scrape, no parent-pid walk, no pid-recycle guess.
+    const events: string[] = []
+    const terminateOwnedTree = vi.fn(() => {
+      events.push('job-kill')
+      return 'terminated' as const
+    })
+    const killWindowsTree = vi.fn(async () => {})
+    const verifyTreeKillTarget = vi.fn(async () => 'own' as const)
+    const killRoot = vi.fn(() => events.push('root-kill'))
+
+    await killWithDescendantSweep(4242, killRoot, {
+      platform: 'win32',
+      terminateOwnedTree,
+      killWindowsTree,
+      verifyTreeKillTarget
+    })
+
+    expect(terminateOwnedTree).toHaveBeenCalledOnce()
+    expect(verifyTreeKillTarget).not.toHaveBeenCalled()
+    expect(killWindowsTree).not.toHaveBeenCalled()
+    // killRoot still runs: the job kills processes, the handle still needs closing.
+    expect(events).toEqual(['job-kill', 'root-kill'])
+  })
+
+  it('on Windows falls back to the probe when the pty has no job', async () => {
+    // A pty started before this build, or one the OS refused to assign, has no
+    // job. `unavailable` must not be read as "already dead".
+    const terminateOwnedTree = vi.fn(() => 'unavailable' as const)
+    const killWindowsTree = vi.fn(async () => {})
+    const killRoot = vi.fn()
+
+    await killWithDescendantSweep(4242, killRoot, {
+      platform: 'win32',
+      terminateOwnedTree,
+      killWindowsTree,
+      verifyTreeKillTarget: async () => 'own'
+    })
+
+    expect(killWindowsTree).toHaveBeenCalledWith(4242)
+    expect(killRoot).toHaveBeenCalledOnce()
+  })
+
   it('on Windows taskkills the process tree before killRoot (#10004)', async () => {
     const events: string[] = []
     const killWindowsTree = vi.fn(async () => {

--- a/src/main/pty-descendant-termination.ts
+++ b/src/main/pty-descendant-termination.ts
@@ -1,4 +1,5 @@
 import { execFile } from 'node:child_process'
+import type { JobTerminationOutcome } from './windows/windows-pty-job'
 import { terminateWindowsProcessTree, type WindowsTreeKiller } from './windows-process-tree-kill'
 import {
   verifyWindowsTreeKillTarget,
@@ -228,6 +229,11 @@ export async function captureDescendantSnapshot(
 type KillSweepDeps = SnapshotDeps &
   TerminateDeps & {
     ownsRoot?: () => boolean
+    /**
+     * Terminate the PTY's job object. Returns `unavailable` when this tree has
+     * no job, which is not permission to assume it is gone.
+     */
+    terminateOwnedTree?: () => JobTerminationOutcome
     /** Injectable Windows tree killer (defaults to taskkill /T /F). */
     killWindowsTree?: WindowsTreeKiller
     /** Injectable Windows root-identity probe (defaults to a live process query). */
@@ -237,9 +243,11 @@ type KillSweepDeps = SnapshotDeps &
 /**
  * Standard agent-session kill sequencing.
  * - POSIX: snapshot the descendant tree, signal members, then killRoot.
- * - Windows: taskkill /T /F walks the ConPTY tree only when the identity probe
- *   returns `own` (and ownsRoot still holds). `unknown`/`foreign`/`absent` skip
- *   tree kill; killRoot always runs. Detached children may survive probe failure.
+ * - Windows: terminate the PTY's job object, which is exact and needs no
+ *   identity probe. Only when this build has no job does it fall back to the
+ *   old scheme — a process-table scrape gating `taskkill /T /F` on a
+ *   parent-pid walk, which refuses whenever it cannot prove ownership and so
+ *   leaves the tree running (#9045, #10475).
  * Callers must not signal the root before this runs on POSIX — a dead root's
  * descendants reparent to pid 1 and become unfindable. Snapshot failure
  * degrades to killRoot alone on POSIX.
@@ -253,6 +261,12 @@ export async function killWithDescendantSweep(
   if (platform === 'win32') {
     try {
       if ((deps.ownsRoot?.() ?? true) && Number.isInteger(rootPid) && rootPid > 0) {
+        // Why first: the job names the tree Orca created, so it is immune to the
+        // pid recycling the probe below exists to guard against, and it reaches
+        // descendants that reparented away from the shell.
+        if (deps.terminateOwnedTree?.() === 'terminated') {
+          return
+        }
         // Why: ownsRoot() is JS state only, and node-pty's ConPTY exit watcher closes
         // the last shell handle before it queues the JS exit callback — Windows may
         // already have recycled this PID while the map still looks live. taskkill /T /F

--- a/src/main/windows-pty-root-identity.test.ts
+++ b/src/main/windows-pty-root-identity.test.ts
@@ -8,6 +8,14 @@ import {
   verifyWindowsTreeKillTarget,
   WINDOWS_ROOT_IDENTITY_TIMEOUT_MS
 } from './windows-pty-root-identity'
+// A real snapshot always contains the process doing the querying; the reader
+// rejects a table without it, because that is what a blocked
+// CreateToolhelp32Snapshot looks like (an empty list, not an error).
+const SELF_PROCESS_ROW = { pid: process.pid, ppid: 0, name: 'vitest.exe', commandLine: 'vitest' }
+const withSelf = <T>(rows: readonly T[]): (T | typeof SELF_PROCESS_ROW)[] => [
+  SELF_PROCESS_ROW,
+  ...rows
+]
 
 const ORCA_PID = 5000
 
@@ -164,7 +172,7 @@ describe('verifyWindowsTreeKillTarget scan volume', () => {
   beforeEach(() => {
     getAllProcessesMock.mockReset()
     getAllProcessesMock.mockImplementation((cb: (snapshot: unknown) => void) => {
-      cb(NATIVE_ROWS)
+      cb(withSelf(NATIVE_ROWS))
     })
     __setWindowsProcessTreeLoaderForTests(() => ({
       ProcessDataFlag: { None: 0, Memory: 1, CommandLine: 2 },

--- a/src/main/windows/windows-host-job.win32.test.ts
+++ b/src/main/windows/windows-host-job.win32.test.ts
@@ -1,0 +1,100 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { spawn } from 'node:child_process'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+/**
+ * The second half of the two-job design.
+ *
+ * A per-PTY job cannot carry KILL_ON_JOB_CLOSE — its handle is released when
+ * the shell exits, which would reap whatever the user had backgrounded. So the
+ * host process takes a second job that IS kill-on-close, and children inherit
+ * membership. This asserts the property that buys: a host that dies without
+ * unwinding strands nothing.
+ *
+ * It needs a real second process, because the assertion is about what happens
+ * when that process is killed. Runs only on win32; skipped elsewhere.
+ */
+const describeOnWindows = process.platform === 'win32' ? describe : describe.skip
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+describeOnWindows('host job reaps the tree when the host dies', () => {
+  let dir: string
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'orca-host-job-'))
+  })
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('kills a pty and its detached grandchild when the host is force-killed', async () => {
+    const nodePtyDir = join(process.cwd(), 'node_modules', 'node-pty')
+    const hostScript = join(dir, 'host.js')
+    // The host assigns itself, then opens a pty whose shell spawns a DETACHED
+    // grandchild — the process a parent-pid walk cannot see.
+    writeFileSync(
+      hostScript,
+      [
+        `const pty = require(${JSON.stringify(nodePtyDir)});`,
+        `const { loadNativeModule } = require(${JSON.stringify(`${nodePtyDir}/lib/utils`)});`,
+        `const native = loadNativeModule('conpty').module;`,
+        `console.log('ASSIGNED=' + native.assignCurrentProcessToJob());`,
+        `const term = pty.spawn('cmd.exe', [], { name: 'xterm', cols: 80, rows: 30, cwd: ${JSON.stringify(dir)}, useConptyDll: true });`,
+        `term.onData((d) => { const m = /GC=(\\d+)/.exec(d); if (m) console.log('GRANDCHILD=' + m[1]); });`,
+        `term.write('node -e "const{spawn}=require(\\'child_process\\');const c=spawn(process.execPath,[\\'-e\\',\\'setInterval(()=>{},1000)\\'],{detached:true,stdio:\\'ignore\\'});c.unref();console.log(\\'GC=\\'+c.pid);"\\r');`,
+        `setTimeout(() => console.log('SHELL=' + term.pid), 4000);`,
+        `setInterval(() => {}, 1000);`
+      ].join('\n')
+    )
+
+    const host = spawn(process.execPath, [hostScript], { stdio: ['ignore', 'pipe', 'pipe'] })
+    let output = ''
+    host.stdout.on('data', (chunk) => {
+      output += String(chunk)
+    })
+    host.stdout.on('error', () => {})
+    host.stderr?.on('error', () => {})
+
+    for (let attempt = 0; attempt < 60 && !/SHELL=/.test(output); attempt += 1) {
+      await sleep(250)
+    }
+
+    expect(output).toContain('ASSIGNED=true')
+    const shellPid = Number(/SHELL=(\d+)/.exec(output)?.[1])
+    const grandchildPid = Number(/GRANDCHILD=(\d+)/.exec(output)?.[1])
+    expect(Number.isInteger(shellPid)).toBe(true)
+    expect(Number.isInteger(grandchildPid)).toBe(true)
+    expect(isAlive(grandchildPid)).toBe(true)
+
+    // Force-kill only the host: no tree kill, nothing given a chance to unwind.
+    // This is the daemon-crash shape.
+    process.kill(host.pid!)
+    await sleep(3_000)
+
+    try {
+      expect(isAlive(shellPid)).toBe(false)
+      expect(isAlive(grandchildPid)).toBe(false)
+    } finally {
+      for (const pid of [shellPid, grandchildPid]) {
+        try {
+          process.kill(pid)
+        } catch {
+          /* already gone */
+        }
+      }
+    }
+  }, 90_000)
+})

--- a/src/main/windows/windows-process-table.test.ts
+++ b/src/main/windows/windows-process-table.test.ts
@@ -106,3 +106,42 @@ describe('windows process table', () => {
     expect(isWindowsProcessTableAvailable()).toBe(false)
   })
 })
+
+describe('wedge cooldown', () => {
+  let platform: PropertyDescriptor | undefined
+
+  beforeEach(() => {
+    platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    __setWindowsProcessTreeLoaderForTests()
+    if (platform) {
+      Object.defineProperty(process, 'platform', platform)
+    }
+  })
+
+  it('stops calling the reader after a timeout instead of queueing a callback per tick', async () => {
+    // The vendored reader latches a global while a request is in flight and
+    // drains its queue only when that request completes. In the wedge this
+    // guards against it never does, so every retry would add a closure that is
+    // never called. One probe per cooldown bounds that.
+    vi.useFakeTimers()
+    const getAllProcesses = vi.fn(() => {})
+    __setWindowsProcessTreeLoaderForTests(() => ({
+      ProcessDataFlag: { None: 0, Memory: 1, CommandLine: 2 },
+      getAllProcesses
+    }))
+
+    const first = readWindowsProcessTableFresh()
+    const firstAssertion = expect(first).rejects.toThrow(/timed out/)
+    await vi.advanceTimersByTimeAsync(3_000)
+    await firstAssertion
+    expect(getAllProcesses).toHaveBeenCalledTimes(1)
+
+    await expect(readWindowsProcessTableFresh()).rejects.toThrow(/cooling down/)
+    expect(getAllProcesses).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/windows/windows-process-table.test.ts
+++ b/src/main/windows/windows-process-table.test.ts
@@ -191,8 +191,10 @@ describe('wedge cooldown', () => {
     await vi.advanceTimersByTimeAsync(10_000)
 
     // The recovered reader must answer, not report a wedge left by a dead timer.
-    getAllProcesses.mockImplementation((cb: (rows: unknown) => void) => cb(NATIVE))
-    resetWindowsProcessTableForTests()
+    __setWindowsProcessTreeLoaderForTests(() => ({
+      ProcessDataFlag: { None: 0, Memory: 1, CommandLine: 2 },
+      getAllProcesses: (cb: (rows: typeof NATIVE | undefined) => void) => cb(NATIVE)
+    }))
     await expect(readWindowsProcessTableFresh()).resolves.toHaveLength(NATIVE.length)
   })
 })

--- a/src/main/windows/windows-process-table.test.ts
+++ b/src/main/windows/windows-process-table.test.ts
@@ -9,8 +9,12 @@ import {
 
 const getAllProcesses = vi.fn()
 
+// A real snapshot always contains the querying process; the reader rejects a
+// table without it, because that is what a blocked CreateToolhelp32Snapshot
+// returns -- an empty list rather than an error.
+const SELF = { pid: process.pid, ppid: 0, name: 'vitest.exe' }
 const NATIVE = [
-  { pid: 4, ppid: 0, name: 'System' },
+  SELF,
   { pid: 100, ppid: 4, name: 'orca.exe', commandLine: '"C:/a b/orca.exe" --x', memory: 4096 }
 ]
 
@@ -38,7 +42,7 @@ describe('windows process table', () => {
   it('maps native rows, defaulting an unreadable command line to empty', async () => {
     const rows = await readWindowsProcessTableFresh()
     expect(rows).toEqual([
-      { pid: 4, ppid: 0, name: 'System', command: '', memoryBytes: undefined },
+      { pid: process.pid, ppid: 0, name: 'vitest.exe', command: '', memoryBytes: undefined },
       {
         pid: 100,
         ppid: 4,
@@ -72,6 +76,28 @@ describe('windows process table', () => {
     getAllProcesses.mockImplementation((cb: (rows: unknown) => void) => cb(undefined))
     resetWindowsProcessTableForTests()
     await expect(readWindowsProcessTableFresh()).rejects.toThrow()
+  })
+
+  it('rejects an empty snapshot rather than reporting an idle machine', async () => {
+    // CreateToolhelp32Snapshot failing under an EDR hook or a restricted token
+    // yields an empty vector, not an error. Callers act on "nothing is running"
+    // by concluding a live PTY root is already gone.
+    getAllProcesses.mockImplementation((cb: (rows: unknown) => void) => cb([]))
+    resetWindowsProcessTableForTests()
+    await expect(readWindowsProcessTableFresh()).rejects.toThrow(/unreadable/)
+  })
+
+  it('rejects when the snapshot never calls back', async () => {
+    // The vendored reader latches a module-global on a wedge, so without a
+    // deadline one hang kills the process table for the life of the app.
+    vi.useFakeTimers()
+    getAllProcesses.mockImplementation(() => {})
+    resetWindowsProcessTableForTests()
+    const pending = readWindowsProcessTableFresh()
+    const assertion = expect(pending).rejects.toThrow(/timed out/)
+    await vi.advanceTimersByTimeAsync(3_000)
+    await assertion
+    vi.useRealTimers()
   })
 
   it('is unavailable off Windows without attempting a require', async () => {

--- a/src/main/windows/windows-process-table.test.ts
+++ b/src/main/windows/windows-process-table.test.ts
@@ -144,4 +144,55 @@ describe('wedge cooldown', () => {
     await expect(readWindowsProcessTableFresh()).rejects.toThrow(/cooling down/)
     expect(getAllProcesses).toHaveBeenCalledTimes(1)
   })
+
+  it('lets exactly one caller probe when the cooldown expires', async () => {
+    // Without claiming the recovery slot before probing, every concurrent
+    // caller passes the cooldown check at expiry and each enqueues a callback
+    // into the still-latched native queue -- so each cycle leaks another batch
+    // rather than bounding it to one probe.
+    vi.useFakeTimers()
+    const getAllProcesses = vi.fn(() => {})
+    __setWindowsProcessTreeLoaderForTests(() => ({
+      ProcessDataFlag: { None: 0, Memory: 1, CommandLine: 2 },
+      getAllProcesses
+    }))
+
+    const wedge = readWindowsProcessTableFresh()
+    const wedgeAssertion = expect(wedge).rejects.toThrow(/timed out/)
+    await vi.advanceTimersByTimeAsync(3_000)
+    await wedgeAssertion
+    expect(getAllProcesses).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(30_000)
+    const attempts = [
+      readWindowsProcessTableFresh().catch(() => 'rejected'),
+      readWindowsProcessTableFresh().catch(() => 'rejected'),
+      readWindowsProcessTableFresh().catch(() => 'rejected')
+    ]
+    await vi.advanceTimersByTimeAsync(3_000)
+    await Promise.all(attempts)
+
+    // One recovery probe, not three.
+    expect(getAllProcesses).toHaveBeenCalledTimes(2)
+  })
+
+  it('clears the deadline when the reader throws synchronously', async () => {
+    // An orphaned timer would fire later and wedge a reader that had recovered.
+    vi.useFakeTimers()
+    const getAllProcesses = vi.fn(() => {
+      throw new Error('addon exploded')
+    })
+    __setWindowsProcessTreeLoaderForTests(() => ({
+      ProcessDataFlag: { None: 0, Memory: 1, CommandLine: 2 },
+      getAllProcesses
+    }))
+
+    await expect(readWindowsProcessTableFresh()).rejects.toThrow(/exploded/)
+    await vi.advanceTimersByTimeAsync(10_000)
+
+    // The recovered reader must answer, not report a wedge left by a dead timer.
+    getAllProcesses.mockImplementation((cb: (rows: unknown) => void) => cb(NATIVE))
+    resetWindowsProcessTableForTests()
+    await expect(readWindowsProcessTableFresh()).resolves.toHaveLength(NATIVE.length)
+  })
 })

--- a/src/main/windows/windows-process-table.ts
+++ b/src/main/windows/windows-process-table.ts
@@ -78,6 +78,19 @@ function loadWindowsProcessTree(): WindowsProcessTreeModule | null {
   return cachedModule
 }
 
+/**
+ * Upper bound on one snapshot.
+ *
+ * Why any bound at all: the vendored reader sets a module-global
+ * `requestInProgress` and clears it only after draining its callback queue,
+ * with no try/catch. One throw or one worker that never calls back leaves it
+ * latched, every later call enqueues a callback that never fires, and the
+ * single-flight cache above then holds a promise that never settles — the
+ * process table is dead for the life of the app. The PowerShell reader this
+ * replaced self-healed in 3s because execFile owned a timeout; keep that.
+ */
+const WINDOWS_PROCESS_QUERY_TIMEOUT_MS = 3_000
+
 function readNativeRows(): Promise<WindowsProcessRow[]> {
   const native = moduleLoader()
   if (!native) {
@@ -89,9 +102,26 @@ function readNativeRows(): Promise<WindowsProcessRow[]> {
   const flags = native.ProcessDataFlag.Memory | native.ProcessDataFlag.CommandLine
   return new Promise((resolve, reject) => {
     try {
+      const deadline = setTimeout(
+        () => reject(new Error('windows process table timed out')),
+        WINDOWS_PROCESS_QUERY_TIMEOUT_MS
+      )
+      deadline.unref?.()
       native.getAllProcesses((processes) => {
+        clearTimeout(deadline)
         if (!processes) {
           reject(new Error('windows process table returned no snapshot'))
+          return
+        }
+        // Why check for ourselves: the native snapshot returns an EMPTY list --
+        // not an error -- when CreateToolhelp32Snapshot fails, which is the
+        // normal outcome under an EDR hook or a restricted token. An empty
+        // table reads to callers as "nothing is running", and teardown acts on
+        // that by concluding a live PTY root is already gone. Our own pid is
+        // unfalsifiably present in any honest snapshot, so this one predicate
+        // catches empty, truncated and permission-filtered tables alike.
+        if (!processes.some((row) => row.pid === process.pid)) {
+          reject(new Error('windows process table is unreadable'))
           return
         }
         resolve(

--- a/src/main/windows/windows-process-table.ts
+++ b/src/main/windows/windows-process-table.ts
@@ -24,6 +24,11 @@ import { createProcessTableSnapshotReader } from '../../shared/process-table-sna
  *   PowerShell CIM        706 / 723  ms
  */
 
+/** Which of the per-process lookups a caller actually needs. */
+export type WindowsProcessFields = { memory?: boolean; commandLine?: boolean }
+
+const ALL_FIELDS: WindowsProcessFields = { memory: true, commandLine: true }
+
 export type WindowsProcessRow = {
   pid: number
   ppid: number
@@ -91,7 +96,7 @@ function loadWindowsProcessTree(): WindowsProcessTreeModule | null {
  */
 const WINDOWS_PROCESS_QUERY_TIMEOUT_MS = 3_000
 
-function readNativeRows(): Promise<WindowsProcessRow[]> {
+function readNativeRows(fields: WindowsProcessFields): Promise<WindowsProcessRow[]> {
   const native = moduleLoader()
   if (!native) {
     // Reject rather than resolve empty: an empty table is a claim that nothing
@@ -99,7 +104,13 @@ function readNativeRows(): Promise<WindowsProcessRow[]> {
     // tree dead. "Unavailable" has to stay distinguishable from "empty".
     return Promise.reject(new Error('windows process table unavailable'))
   }
-  const flags = native.ProcessDataFlag.Memory | native.ProcessDataFlag.CommandLine
+  // Why ask for the minimum: both extra flags do an OpenProcess per process --
+  // Memory adds GetProcessMemoryInfo, CommandLine adds a PEB read -- inline,
+  // for every process on the box, and the 1024-entry bound is patched out.
+  // Measured at 1050 processes: 15.9ms p50 for pid/ppid/name, 30.6ms with both.
+  const flags =
+    (fields.memory ? native.ProcessDataFlag.Memory : 0) |
+    (fields.commandLine ? native.ProcessDataFlag.CommandLine : 0)
   return new Promise((resolve, reject) => {
     try {
       const deadline = setTimeout(
@@ -143,8 +154,12 @@ function readNativeRows(): Promise<WindowsProcessRow[]> {
 // Why still cache: the snapshot is cheap but not free, and a worktree delete
 // tears down PTYs 32-wide. The shared TTL + single-in-flight reader collapses
 // that burst into one scan, exactly as the PowerShell path had to.
+// Why one reader and not one per field set: the cache exists so a 32-wide
+// worktree delete collapses into a single scan, and splitting it per caller
+// would restore the fan-out it prevents. The shared snapshot therefore carries
+// every field; the narrow read below is for callers that bypass the cache.
 const snapshotReader = createProcessTableSnapshotReader<WindowsProcessRow[]>({
-  runPs: readNativeRows,
+  runPs: () => readNativeRows(ALL_FIELDS),
   now: () => Date.now()
 })
 
@@ -161,6 +176,16 @@ export function readWindowsProcessTable(): Promise<WindowsProcessRow[]> {
  */
 export function readWindowsProcessTableFresh(): Promise<WindowsProcessRow[]> {
   return snapshotReader.getFreshSnapshot()
+}
+
+/**
+ * An uncached snapshot carrying only pid, ppid and name.
+ *
+ * For teardown identity, which needs ancestry and nothing else: skipping the
+ * two per-process OpenProcess lookups roughly halves the scan.
+ */
+export function readWindowsProcessAncestry(): Promise<WindowsProcessRow[]> {
+  return readNativeRows({})
 }
 
 /** Whether the native table can be read at all on this host. */

--- a/src/main/windows/windows-process-table.ts
+++ b/src/main/windows/windows-process-table.ts
@@ -103,6 +103,9 @@ const WINDOWS_PROCESS_QUERY_TIMEOUT_MS = 3_000
 const WINDOWS_PROCESS_QUERY_COOLDOWN_MS = 30_000
 
 let wedgedUntilMs = 0
+// Why a generation: a request that already lost its deadline must not later
+// clear or re-arm the wedge on behalf of the request that replaced it.
+let readGeneration = 0
 
 function readNativeRows(): Promise<WindowsProcessRow[]> {
   const native = moduleLoader()
@@ -112,9 +115,19 @@ function readNativeRows(): Promise<WindowsProcessRow[]> {
     // tree dead. "Unavailable" has to stay distinguishable from "empty".
     return Promise.reject(new Error('windows process table unavailable'))
   }
-  if (Date.now() < wedgedUntilMs) {
+  const startedAt = Date.now()
+  if (startedAt < wedgedUntilMs) {
     return Promise.reject(new Error('windows process table is cooling down after a timeout'))
   }
+  if (wedgedUntilMs > 0) {
+    // Coming out of a wedge: re-arm the cooldown BEFORE probing, so exactly one
+    // caller gets through. Without this every concurrent caller passes the
+    // check above at expiry, each enqueues a callback into the still-latched
+    // native queue, and each cooldown cycle leaks another batch rather than
+    // bounding it to one probe.
+    wedgedUntilMs = startedAt + WINDOWS_PROCESS_QUERY_COOLDOWN_MS
+  }
+  const generation = ++readGeneration
   // Why always both flags: each adds an OpenProcess per process (Memory a
   // GetProcessMemoryInfo, CommandLine a PEB read), so asking for less would be
   // cheaper -- 15.9ms p50 versus 30.6ms at 1050 processes. But every read shares
@@ -123,16 +136,24 @@ function readNativeRows(): Promise<WindowsProcessRow[]> {
   // would restore exactly the fan-out it exists to prevent.
   const flags = native.ProcessDataFlag.Memory | native.ProcessDataFlag.CommandLine
   return new Promise((resolve, reject) => {
+    // Hoisted so a synchronous throw from getAllProcesses can clear it. An
+    // orphaned timer would otherwise fire later and wedge a reader that had
+    // already recovered.
+    let deadline: ReturnType<typeof setTimeout> | undefined
     try {
-      const deadline = setTimeout(() => {
-        wedgedUntilMs = Date.now() + WINDOWS_PROCESS_QUERY_COOLDOWN_MS
+      deadline = setTimeout(() => {
+        if (generation === readGeneration) {
+          wedgedUntilMs = Date.now() + WINDOWS_PROCESS_QUERY_COOLDOWN_MS
+        }
         reject(new Error('windows process table timed out'))
       }, WINDOWS_PROCESS_QUERY_TIMEOUT_MS)
       deadline.unref?.()
       native.getAllProcesses((processes) => {
         clearTimeout(deadline)
-        // A late callback proves the reader recovered, so stop refusing.
-        wedgedUntilMs = 0
+        // A callback proves the reader is answering, so stop refusing.
+        if (generation === readGeneration) {
+          wedgedUntilMs = 0
+        }
         if (!processes) {
           reject(new Error('windows process table returned no snapshot'))
           return
@@ -159,6 +180,7 @@ function readNativeRows(): Promise<WindowsProcessRow[]> {
         )
       }, flags)
     } catch (error) {
+      clearTimeout(deadline)
       reject(error instanceof Error ? error : new Error(String(error)))
     }
   })

--- a/src/main/windows/windows-process-table.ts
+++ b/src/main/windows/windows-process-table.ts
@@ -24,11 +24,6 @@ import { createProcessTableSnapshotReader } from '../../shared/process-table-sna
  *   PowerShell CIM        706 / 723  ms
  */
 
-/** Which of the per-process lookups a caller actually needs. */
-export type WindowsProcessFields = { memory?: boolean; commandLine?: boolean }
-
-const ALL_FIELDS: WindowsProcessFields = { memory: true, commandLine: true }
-
 export type WindowsProcessRow = {
   pid: number
   ppid: number
@@ -109,7 +104,7 @@ const WINDOWS_PROCESS_QUERY_COOLDOWN_MS = 30_000
 
 let wedgedUntilMs = 0
 
-function readNativeRows(fields: WindowsProcessFields): Promise<WindowsProcessRow[]> {
+function readNativeRows(): Promise<WindowsProcessRow[]> {
   const native = moduleLoader()
   if (!native) {
     // Reject rather than resolve empty: an empty table is a claim that nothing
@@ -117,16 +112,16 @@ function readNativeRows(fields: WindowsProcessFields): Promise<WindowsProcessRow
     // tree dead. "Unavailable" has to stay distinguishable from "empty".
     return Promise.reject(new Error('windows process table unavailable'))
   }
-  // Why ask for the minimum: both extra flags do an OpenProcess per process --
-  // Memory adds GetProcessMemoryInfo, CommandLine adds a PEB read -- inline,
-  // for every process on the box, and the 1024-entry bound is patched out.
-  // Measured at 1050 processes: 15.9ms p50 for pid/ppid/name, 30.6ms with both.
   if (Date.now() < wedgedUntilMs) {
     return Promise.reject(new Error('windows process table is cooling down after a timeout'))
   }
-  const flags =
-    (fields.memory ? native.ProcessDataFlag.Memory : 0) |
-    (fields.commandLine ? native.ProcessDataFlag.CommandLine : 0)
+  // Why always both flags: each adds an OpenProcess per process (Memory a
+  // GetProcessMemoryInfo, CommandLine a PEB read), so asking for less would be
+  // cheaper -- 15.9ms p50 versus 30.6ms at 1050 processes. But every read shares
+  // one snapshot so a 32-wide teardown collapses into a single scan, and that
+  // snapshot has to satisfy every caller. Splitting the cache per field set
+  // would restore exactly the fan-out it exists to prevent.
+  const flags = native.ProcessDataFlag.Memory | native.ProcessDataFlag.CommandLine
   return new Promise((resolve, reject) => {
     try {
       const deadline = setTimeout(() => {
@@ -172,12 +167,8 @@ function readNativeRows(fields: WindowsProcessFields): Promise<WindowsProcessRow
 // Why still cache: the snapshot is cheap but not free, and a worktree delete
 // tears down PTYs 32-wide. The shared TTL + single-in-flight reader collapses
 // that burst into one scan, exactly as the PowerShell path had to.
-// Why one reader and not one per field set: the cache exists so a 32-wide
-// worktree delete collapses into a single scan, and splitting it per caller
-// would restore the fan-out it prevents. The shared snapshot therefore carries
-// every field; the narrow read below is for callers that bypass the cache.
 const snapshotReader = createProcessTableSnapshotReader<WindowsProcessRow[]>({
-  runPs: () => readNativeRows(ALL_FIELDS),
+  runPs: readNativeRows,
   now: () => Date.now()
 })
 
@@ -194,16 +185,6 @@ export function readWindowsProcessTable(): Promise<WindowsProcessRow[]> {
  */
 export function readWindowsProcessTableFresh(): Promise<WindowsProcessRow[]> {
   return snapshotReader.getFreshSnapshot()
-}
-
-/**
- * An uncached snapshot carrying only pid, ppid and name.
- *
- * For teardown identity, which needs ancestry and nothing else: skipping the
- * two per-process OpenProcess lookups roughly halves the scan.
- */
-export function readWindowsProcessAncestry(): Promise<WindowsProcessRow[]> {
-  return readNativeRows({})
 }
 
 /** Whether the native table can be read at all on this host. */

--- a/src/main/windows/windows-process-table.ts
+++ b/src/main/windows/windows-process-table.ts
@@ -96,6 +96,19 @@ function loadWindowsProcessTree(): WindowsProcessTreeModule | null {
  */
 const WINDOWS_PROCESS_QUERY_TIMEOUT_MS = 3_000
 
+/**
+ * How long to stop calling the reader after it misses its deadline.
+ *
+ * Why a cooldown and not just the deadline: a timed-out call leaves its
+ * callback in the vendored module's queue, and that queue only drains when the
+ * latched request finally completes -- which, in the wedge this guards against,
+ * never happens. Retrying at the caller's poll rate would then add a closure
+ * per tick forever. One probe per cooldown bounds it.
+ */
+const WINDOWS_PROCESS_QUERY_COOLDOWN_MS = 30_000
+
+let wedgedUntilMs = 0
+
 function readNativeRows(fields: WindowsProcessFields): Promise<WindowsProcessRow[]> {
   const native = moduleLoader()
   if (!native) {
@@ -108,18 +121,23 @@ function readNativeRows(fields: WindowsProcessFields): Promise<WindowsProcessRow
   // Memory adds GetProcessMemoryInfo, CommandLine adds a PEB read -- inline,
   // for every process on the box, and the 1024-entry bound is patched out.
   // Measured at 1050 processes: 15.9ms p50 for pid/ppid/name, 30.6ms with both.
+  if (Date.now() < wedgedUntilMs) {
+    return Promise.reject(new Error('windows process table is cooling down after a timeout'))
+  }
   const flags =
     (fields.memory ? native.ProcessDataFlag.Memory : 0) |
     (fields.commandLine ? native.ProcessDataFlag.CommandLine : 0)
   return new Promise((resolve, reject) => {
     try {
-      const deadline = setTimeout(
-        () => reject(new Error('windows process table timed out')),
-        WINDOWS_PROCESS_QUERY_TIMEOUT_MS
-      )
+      const deadline = setTimeout(() => {
+        wedgedUntilMs = Date.now() + WINDOWS_PROCESS_QUERY_COOLDOWN_MS
+        reject(new Error('windows process table timed out'))
+      }, WINDOWS_PROCESS_QUERY_TIMEOUT_MS)
       deadline.unref?.()
       native.getAllProcesses((processes) => {
         clearTimeout(deadline)
+        // A late callback proves the reader recovered, so stop refusing.
+        wedgedUntilMs = 0
         if (!processes) {
           reject(new Error('windows process table returned no snapshot'))
           return
@@ -205,6 +223,7 @@ export function __setWindowsProcessTreeLoaderForTests(
 ): void {
   moduleLoader = loader ?? loadWindowsProcessTree
   cachedModule = undefined
+  wedgedUntilMs = 0
   snapshotReader.reset()
 }
 
@@ -212,4 +231,5 @@ export function __setWindowsProcessTreeLoaderForTests(
 export function resetWindowsProcessTableForTests(): void {
   snapshotReader.reset()
   cachedModule = undefined
+  wedgedUntilMs = 0
 }

--- a/src/main/windows/windows-pty-job.test.ts
+++ b/src/main/windows/windows-pty-job.test.ts
@@ -7,7 +7,7 @@ import {
   terminatePtyJob
 } from './windows-pty-job'
 
-const ptyWithHandle = (id: unknown): IPty => ({ _pty: id }) as unknown as IPty
+const ptyWithHandle = (id: unknown, pid = 4242): IPty => ({ _pty: id, pid }) as unknown as IPty
 
 afterEach(() => {
   __setConptyJobNativeForTests()
@@ -19,7 +19,7 @@ describe('terminatePtyJob', () => {
     __setConptyJobNativeForTests(() => ({ terminateJob, listJobProcessIds: vi.fn() }))
 
     expect(terminatePtyJob(ptyWithHandle(7))).toBe('terminated')
-    expect(terminateJob).toHaveBeenCalledWith(7)
+    expect(terminateJob).toHaveBeenCalledWith(7, 4242)
   })
 
   it.each([
@@ -45,6 +45,25 @@ describe('terminatePtyJob', () => {
       listJobProcessIds: vi.fn()
     }))
     expect(terminatePtyJob(ptyWithHandle(id))).toBe('unavailable')
+  })
+
+  it('passes the shell pid so an id from another backend cannot match', () => {
+    // winpty mints `pty` ids from its own counter and the JS layer stores both
+    // in the same field, so an id alone can name a live ConPTY pane. The native
+    // side refuses on a pid mismatch; this pins that we always send the pid.
+    const terminateJob = vi.fn().mockReturnValue(true)
+    __setConptyJobNativeForTests(() => ({ terminateJob, listJobProcessIds: vi.fn() }))
+
+    terminatePtyJob(ptyWithHandle(3, 9001))
+    expect(terminateJob).toHaveBeenCalledWith(3, 9001)
+  })
+
+  it('reports unavailable when the shell pid is unusable', () => {
+    __setConptyJobNativeForTests(() => ({
+      terminateJob: vi.fn().mockReturnValue(true),
+      listJobProcessIds: vi.fn()
+    }))
+    expect(terminatePtyJob(ptyWithHandle(3, 0))).toBe('unavailable')
   })
 
   it('reports unavailable when this build has no job support', () => {

--- a/src/main/windows/windows-pty-job.test.ts
+++ b/src/main/windows/windows-pty-job.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { IPty } from 'node-pty'
 import {
   __setConptyJobNativeForTests,
+  assignHostProcessToKillOnCloseJob,
   isPtyJobOwnershipAvailable,
   listPtyJobProcessIds,
   terminatePtyJob
@@ -16,7 +17,11 @@ afterEach(() => {
 describe('terminatePtyJob', () => {
   it('terminates the job for a pty that has one', () => {
     const terminateJob = vi.fn().mockReturnValue(true)
-    __setConptyJobNativeForTests(() => ({ terminateJob, listJobProcessIds: vi.fn() }))
+    __setConptyJobNativeForTests(() => ({
+      terminateJob,
+      listJobProcessIds: vi.fn(),
+      assignCurrentProcessToJob: vi.fn().mockReturnValue(true)
+    }))
 
     expect(terminatePtyJob(ptyWithHandle(7))).toBe('terminated')
     expect(terminateJob).toHaveBeenCalledWith(7, 4242)
@@ -31,7 +36,8 @@ describe('terminatePtyJob', () => {
     // agent tree was declared dead and left holding the worktree open.
     __setConptyJobNativeForTests(() => ({
       terminateJob: vi.fn().mockReturnValue(nativeResult),
-      listJobProcessIds: vi.fn()
+      listJobProcessIds: vi.fn(),
+      assignCurrentProcessToJob: vi.fn().mockReturnValue(true)
     }))
     expect(terminatePtyJob(ptyWithHandle(7))).toBe('unavailable')
   })
@@ -42,7 +48,8 @@ describe('terminatePtyJob', () => {
   ])('reports unavailable for %s', (_case, id) => {
     __setConptyJobNativeForTests(() => ({
       terminateJob: vi.fn().mockReturnValue(true),
-      listJobProcessIds: vi.fn()
+      listJobProcessIds: vi.fn(),
+      assignCurrentProcessToJob: vi.fn().mockReturnValue(true)
     }))
     expect(terminatePtyJob(ptyWithHandle(id))).toBe('unavailable')
   })
@@ -52,7 +59,11 @@ describe('terminatePtyJob', () => {
     // in the same field, so an id alone can name a live ConPTY pane. The native
     // side refuses on a pid mismatch; this pins that we always send the pid.
     const terminateJob = vi.fn().mockReturnValue(true)
-    __setConptyJobNativeForTests(() => ({ terminateJob, listJobProcessIds: vi.fn() }))
+    __setConptyJobNativeForTests(() => ({
+      terminateJob,
+      listJobProcessIds: vi.fn(),
+      assignCurrentProcessToJob: vi.fn().mockReturnValue(true)
+    }))
 
     terminatePtyJob(ptyWithHandle(3, 9001))
     expect(terminateJob).toHaveBeenCalledWith(3, 9001)
@@ -61,7 +72,8 @@ describe('terminatePtyJob', () => {
   it('reports unavailable when the shell pid is unusable', () => {
     __setConptyJobNativeForTests(() => ({
       terminateJob: vi.fn().mockReturnValue(true),
-      listJobProcessIds: vi.fn()
+      listJobProcessIds: vi.fn(),
+      assignCurrentProcessToJob: vi.fn().mockReturnValue(true)
     }))
     expect(terminatePtyJob(ptyWithHandle(3, 0))).toBe('unavailable')
   })
@@ -78,7 +90,8 @@ describe('terminatePtyJob', () => {
       terminateJob: vi.fn().mockImplementation(() => {
         throw new Error('handle closed')
       }),
-      listJobProcessIds: vi.fn()
+      listJobProcessIds: vi.fn(),
+      assignCurrentProcessToJob: vi.fn().mockReturnValue(true)
     }))
     expect(terminatePtyJob(ptyWithHandle(7))).toBe('unavailable')
   })
@@ -91,7 +104,8 @@ describe('listPtyJobProcessIds', () => {
     // sees it. Job membership does.
     __setConptyJobNativeForTests(() => ({
       terminateJob: vi.fn(),
-      listJobProcessIds: vi.fn().mockReturnValue([107184, 91480])
+      listJobProcessIds: vi.fn().mockReturnValue([107184, 91480]),
+      assignCurrentProcessToJob: vi.fn().mockReturnValue(true)
     }))
     expect(listPtyJobProcessIds(ptyWithHandle(1))).toEqual([107184, 91480])
   })
@@ -106,8 +120,35 @@ describe('listPtyJobProcessIds', () => {
 
     __setConptyJobNativeForTests(() => ({
       terminateJob: vi.fn(),
-      listJobProcessIds: vi.fn().mockReturnValue(null)
+      listJobProcessIds: vi.fn().mockReturnValue(null),
+      assignCurrentProcessToJob: vi.fn().mockReturnValue(true)
     }))
     expect(listPtyJobProcessIds(ptyWithHandle(1))).toBeNull()
+  })
+})
+
+describe('assignHostProcessToKillOnCloseJob', () => {
+  it('reports whether the host process is now kill-on-close', () => {
+    const assignCurrentProcessToJob = vi.fn().mockReturnValue(true)
+    __setConptyJobNativeForTests(() => ({
+      terminateJob: vi.fn(),
+      listJobProcessIds: vi.fn(),
+      assignCurrentProcessToJob
+    }))
+    expect(assignHostProcessToKillOnCloseJob()).toBe(true)
+  })
+
+  it('degrades to false when the OS refuses the assignment', () => {
+    // An outer job that forbids nesting; orphan behaviour is then simply what
+    // it was before, rather than a crash.
+    __setConptyJobNativeForTests(() => ({
+      terminateJob: vi.fn(),
+      listJobProcessIds: vi.fn(),
+      assignCurrentProcessToJob: vi.fn().mockReturnValue(false)
+    }))
+    expect(assignHostProcessToKillOnCloseJob()).toBe(false)
+
+    __setConptyJobNativeForTests(() => null)
+    expect(assignHostProcessToKillOnCloseJob()).toBe(false)
   })
 })

--- a/src/main/windows/windows-pty-job.test.ts
+++ b/src/main/windows/windows-pty-job.test.ts
@@ -77,17 +77,18 @@ describe('listPtyJobProcessIds', () => {
     expect(listPtyJobProcessIds(ptyWithHandle(1))).toEqual([107184, 91480])
   })
 
-  it('distinguishes an empty tree from an unanswerable one', () => {
-    // Empty is a real answer -- the tree is gone. Null is the absence of one.
-    // Conflating them is how a registry kept reporting a dead terminal as
-    // connected (#15549).
+  it('reports null when there is no answer to give', () => {
+    // Null is 'unverifiable', never 'they died'. A dead tree also reads null,
+    // because node-pty drops its handle record on exit -- so a caller that
+    // treats null as proof of death would be right by accident here and wrong
+    // on a host that refused the job assignment.
+    __setConptyJobNativeForTests(() => null)
+    expect(listPtyJobProcessIds(ptyWithHandle(1))).toBeNull()
+
     __setConptyJobNativeForTests(() => ({
       terminateJob: vi.fn(),
-      listJobProcessIds: vi.fn().mockReturnValue([])
+      listJobProcessIds: vi.fn().mockReturnValue(null)
     }))
-    expect(listPtyJobProcessIds(ptyWithHandle(1))).toEqual([])
-
-    __setConptyJobNativeForTests(() => null)
     expect(listPtyJobProcessIds(ptyWithHandle(1))).toBeNull()
   })
 })

--- a/src/main/windows/windows-pty-job.test.ts
+++ b/src/main/windows/windows-pty-job.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { IPty } from 'node-pty'
+import {
+  __setConptyJobNativeForTests,
+  isPtyJobOwnershipAvailable,
+  listPtyJobProcessIds,
+  terminatePtyJob
+} from './windows-pty-job'
+
+const ptyWithHandle = (id: unknown): IPty => ({ _pty: id }) as unknown as IPty
+
+afterEach(() => {
+  __setConptyJobNativeForTests()
+})
+
+describe('terminatePtyJob', () => {
+  it('terminates the job for a pty that has one', () => {
+    const terminateJob = vi.fn().mockReturnValue(true)
+    __setConptyJobNativeForTests(() => ({ terminateJob, listJobProcessIds: vi.fn() }))
+
+    expect(terminatePtyJob(ptyWithHandle(7))).toBe('terminated')
+    expect(terminateJob).toHaveBeenCalledWith(7)
+  })
+
+  it.each([
+    ['no job assigned', false],
+    ['native refusal', false]
+  ])('reports unavailable rather than success on %s', (_case, nativeResult) => {
+    // Why this matters: "we could not tell" is precisely the state the old
+    // parent-pid probe returned, and treating it as success is how a live
+    // agent tree was declared dead and left holding the worktree open.
+    __setConptyJobNativeForTests(() => ({
+      terminateJob: vi.fn().mockReturnValue(nativeResult),
+      listJobProcessIds: vi.fn()
+    }))
+    expect(terminatePtyJob(ptyWithHandle(7))).toBe('unavailable')
+  })
+
+  it.each([
+    ['a POSIX terminal with no handle id', undefined],
+    ['a non-integer handle id', 'nope']
+  ])('reports unavailable for %s', (_case, id) => {
+    __setConptyJobNativeForTests(() => ({
+      terminateJob: vi.fn().mockReturnValue(true),
+      listJobProcessIds: vi.fn()
+    }))
+    expect(terminatePtyJob(ptyWithHandle(id))).toBe('unavailable')
+  })
+
+  it('reports unavailable when this build has no job support', () => {
+    // A node-pty rebuilt from unpatched sources exports neither symbol.
+    __setConptyJobNativeForTests(() => null)
+    expect(terminatePtyJob(ptyWithHandle(7))).toBe('unavailable')
+    expect(isPtyJobOwnershipAvailable()).toBe(false)
+  })
+
+  it('reports unavailable when the native call throws', () => {
+    __setConptyJobNativeForTests(() => ({
+      terminateJob: vi.fn().mockImplementation(() => {
+        throw new Error('handle closed')
+      }),
+      listJobProcessIds: vi.fn()
+    }))
+    expect(terminatePtyJob(ptyWithHandle(7))).toBe('unavailable')
+  })
+})
+
+describe('listPtyJobProcessIds', () => {
+  it('returns the live pids, including a detached grandchild', () => {
+    // Measured on Windows 11: a grandchild spawned detached leaves the console
+    // and reparents, so neither GetConsoleProcessList nor a parent-pid walk
+    // sees it. Job membership does.
+    __setConptyJobNativeForTests(() => ({
+      terminateJob: vi.fn(),
+      listJobProcessIds: vi.fn().mockReturnValue([107184, 91480])
+    }))
+    expect(listPtyJobProcessIds(ptyWithHandle(1))).toEqual([107184, 91480])
+  })
+
+  it('distinguishes an empty tree from an unanswerable one', () => {
+    // Empty is a real answer -- the tree is gone. Null is the absence of one.
+    // Conflating them is how a registry kept reporting a dead terminal as
+    // connected (#15549).
+    __setConptyJobNativeForTests(() => ({
+      terminateJob: vi.fn(),
+      listJobProcessIds: vi.fn().mockReturnValue([])
+    }))
+    expect(listPtyJobProcessIds(ptyWithHandle(1))).toEqual([])
+
+    __setConptyJobNativeForTests(() => null)
+    expect(listPtyJobProcessIds(ptyWithHandle(1))).toBeNull()
+  })
+})

--- a/src/main/windows/windows-pty-job.ts
+++ b/src/main/windows/windows-pty-job.ts
@@ -29,6 +29,7 @@ const requireFromMain = createRequire(__filename)
 type ConptyNative = {
   terminateJob: (id: number, shellPid: number) => boolean
   listJobProcessIds: (id: number, shellPid: number) => number[] | null
+  assignCurrentProcessToJob: () => boolean
 }
 
 let cachedNative: ConptyNative | null | undefined
@@ -123,6 +124,35 @@ export function listPtyJobProcessIds(proc: IPty): readonly number[] | null {
     return native.listJobProcessIds(target.id, target.shellPid)
   } catch {
     return null
+  }
+}
+
+/**
+ * Put this process in a kill-on-close job so its descendants die with it.
+ *
+ * Why this is separate from the per-PTY jobs: those cannot carry
+ * KILL_ON_JOB_CLOSE, because their handle is released when the shell exits and
+ * that would reap whatever the user had backgrounded. This one is released only
+ * when the process itself dies, so it reaps a crashed host without changing
+ * what a clean exit means. Children inherit membership, so the per-PTY jobs
+ * nest inside it and every pty is covered.
+ *
+ * Call it from the terminal daemon, not from the app: an app-main crash must
+ * still leave sessions alive, which is what win-crash-survival-e2e asserts. A
+ * daemon death reaping its shells is the intended change (#9195, #10415).
+ *
+ * Returns false when the OS refuses -- an outer job that forbids nesting -- in
+ * which case orphan behaviour is simply what it was before.
+ */
+export function assignHostProcessToKillOnCloseJob(): boolean {
+  const native = nativeLoader()
+  if (!native) {
+    return false
+  }
+  try {
+    return native.assignCurrentProcessToJob()
+  } catch {
+    return false
   }
 }
 

--- a/src/main/windows/windows-pty-job.ts
+++ b/src/main/windows/windows-pty-job.ts
@@ -90,12 +90,18 @@ export function terminatePtyJob(proc: IPty): JobTerminationOutcome {
 }
 
 /**
- * Pids still alive in a PTY's tree, or null when the tree has no job.
+ * Pids still alive in a PTY's tree, or null when there is no answer.
  *
- * An empty array is a real answer — the tree is gone — and is the evidence a
- * stale JS map cannot provide. Null is the absence of an answer. Callers must
- * keep the two apart: conflating them is how a registry kept reporting a
- * terminal as connected after its process had exited (#15549).
+ * Measured on Windows 11: once the shell exits, node-pty drops its handle
+ * record and closes the job, so a terminated tree reports **null**, not `[]`.
+ * Null therefore means "unverifiable" in the sense of
+ * docs/reference/ssh-execution-boundary.md — this build has no job support,
+ * the terminal is not a ConPTY, or it is no longer tracked. It is never
+ * evidence that processes died.
+ *
+ * The value this does add is descendant liveness for a tree that IS still
+ * tracked: a pane whose shell is alive can be asked what is running under it,
+ * including children that detached from the console.
  */
 export function listPtyJobProcessIds(proc: IPty): readonly number[] | null {
   const id = ptyHandleId(proc)

--- a/src/main/windows/windows-pty-job.ts
+++ b/src/main/windows/windows-pty-job.ts
@@ -18,6 +18,10 @@ import { createRequire } from 'node:module'
  * A job object replaces the inference with a handle. node-pty puts each shell
  * into its own job at creation, before it can spawn anything, so membership is
  * the kernel's answer rather than ours.
+ *
+ * The job is not kill-on-close: it makes an explicit teardown exact, and
+ * deliberately does not change what a clean shell exit means for anything the
+ * user backgrounded.
  */
 
 const requireFromMain = createRequire(__filename)

--- a/src/main/windows/windows-pty-job.ts
+++ b/src/main/windows/windows-pty-job.ts
@@ -27,8 +27,8 @@ import { createRequire } from 'node:module'
 const requireFromMain = createRequire(__filename)
 
 type ConptyNative = {
-  terminateJob: (id: number) => boolean
-  listJobProcessIds: (id: number) => number[] | null
+  terminateJob: (id: number, shellPid: number) => boolean
+  listJobProcessIds: (id: number, shellPid: number) => number[] | null
 }
 
 let cachedNative: ConptyNative | null | undefined
@@ -60,14 +60,20 @@ function loadConptyNative(): ConptyNative | null {
 }
 
 /**
- * node-pty's per-terminal handle id.
+ * node-pty's per-terminal handle id, paired with the shell pid that proves it.
  *
- * Not on the public `IPty` surface, so read defensively: a winpty fallback
- * terminal and every POSIX terminal have none.
+ * Neither is on the public `IPty` surface, so read defensively. The pid is not
+ * belt-and-braces: the winpty backend mints `pty` ids from its own counter and
+ * the JS layer stores both in the same field, so an id alone can name a
+ * different, live ConPTY pane. The native side refuses on a pid mismatch.
  */
-function ptyHandleId(proc: IPty): number | null {
+function ptyJobTarget(proc: IPty): { id: number; shellPid: number } | null {
   const id = (proc as unknown as { _pty?: unknown })._pty
-  return typeof id === 'number' && Number.isInteger(id) ? id : null
+  const shellPid = proc.pid
+  if (!Number.isInteger(id) || !Number.isInteger(shellPid) || (shellPid as number) <= 0) {
+    return null
+  }
+  return { id: id as number, shellPid: shellPid as number }
 }
 
 export type JobTerminationOutcome = 'terminated' | 'unavailable'
@@ -81,13 +87,13 @@ export type JobTerminationOutcome = 'terminated' | 'unavailable'
  * to be misread as "nothing to kill".
  */
 export function terminatePtyJob(proc: IPty): JobTerminationOutcome {
-  const id = ptyHandleId(proc)
+  const target = ptyJobTarget(proc)
   const native = nativeLoader()
-  if (id === null || !native) {
+  if (!target || !native) {
     return 'unavailable'
   }
   try {
-    return native.terminateJob(id) ? 'terminated' : 'unavailable'
+    return native.terminateJob(target.id, target.shellPid) ? 'terminated' : 'unavailable'
   } catch {
     return 'unavailable'
   }
@@ -108,13 +114,13 @@ export function terminatePtyJob(proc: IPty): JobTerminationOutcome {
  * including children that detached from the console.
  */
 export function listPtyJobProcessIds(proc: IPty): readonly number[] | null {
-  const id = ptyHandleId(proc)
+  const target = ptyJobTarget(proc)
   const native = nativeLoader()
-  if (id === null || !native) {
+  if (!target || !native) {
     return null
   }
   try {
-    return native.listJobProcessIds(id)
+    return native.listJobProcessIds(target.id, target.shellPid)
   } catch {
     return null
   }

--- a/src/main/windows/windows-pty-job.ts
+++ b/src/main/windows/windows-pty-job.ts
@@ -1,0 +1,122 @@
+import type { IPty } from 'node-pty'
+import { createRequire } from 'node:module'
+
+/**
+ * Job-object ownership for a ConPTY's process tree.
+ *
+ * Before this, Orca answered "is this tree mine, and how do I kill it?" by
+ * scraping the process table, walking parent pids back to itself, and then
+ * running `taskkill /T /F` only if the walk said yes. Every step of that is a
+ * guess:
+ *
+ * - a pid walk cannot survive pid reuse, so teardown had to refuse whenever it
+ *   was unsure, and a refused kill is an orphaned agent tree holding the
+ *   worktree directory open (#9045, #10475, #10087);
+ * - a descendant that reparented is invisible to the walk entirely;
+ * - the scrape itself could be blocked by policy, which read as "no evidence".
+ *
+ * A job object replaces the inference with a handle. node-pty puts each shell
+ * into its own job at creation, before it can spawn anything, so membership is
+ * the kernel's answer rather than ours.
+ */
+
+const requireFromMain = createRequire(__filename)
+
+type ConptyNative = {
+  terminateJob: (id: number) => boolean
+  listJobProcessIds: (id: number) => number[] | null
+}
+
+let cachedNative: ConptyNative | null | undefined
+let nativeLoader: () => ConptyNative | null = loadConptyNative
+
+function loadConptyNative(): ConptyNative | null {
+  if (cachedNative !== undefined) {
+    return cachedNative
+  }
+  if (process.platform !== 'win32') {
+    cachedNative = null
+    return cachedNative
+  }
+  try {
+    const { loadNativeModule } = requireFromMain('node-pty/lib/utils') as {
+      loadNativeModule: (name: string) => { module: unknown }
+    }
+    const native = loadNativeModule('conpty').module as Partial<ConptyNative>
+    // Why feature-detect: a node-pty rebuilt from unpatched sources exports
+    // neither symbol, and calling through would throw on every teardown.
+    cachedNative =
+      typeof native?.terminateJob === 'function' && typeof native?.listJobProcessIds === 'function'
+        ? (native as ConptyNative)
+        : null
+  } catch {
+    cachedNative = null
+  }
+  return cachedNative
+}
+
+/**
+ * node-pty's per-terminal handle id.
+ *
+ * Not on the public `IPty` surface, so read defensively: a winpty fallback
+ * terminal and every POSIX terminal have none.
+ */
+function ptyHandleId(proc: IPty): number | null {
+  const id = (proc as unknown as { _pty?: unknown })._pty
+  return typeof id === 'number' && Number.isInteger(id) ? id : null
+}
+
+export type JobTerminationOutcome = 'terminated' | 'unavailable'
+
+/**
+ * Kill a PTY's entire process tree.
+ *
+ * Returns `unavailable` — never a false `terminated` — when the tree has no
+ * job. Callers must degrade to the older best-effort path rather than treat
+ * that as success, because "we could not tell" is exactly the state that used
+ * to be misread as "nothing to kill".
+ */
+export function terminatePtyJob(proc: IPty): JobTerminationOutcome {
+  const id = ptyHandleId(proc)
+  const native = nativeLoader()
+  if (id === null || !native) {
+    return 'unavailable'
+  }
+  try {
+    return native.terminateJob(id) ? 'terminated' : 'unavailable'
+  } catch {
+    return 'unavailable'
+  }
+}
+
+/**
+ * Pids still alive in a PTY's tree, or null when the tree has no job.
+ *
+ * An empty array is a real answer — the tree is gone — and is the evidence a
+ * stale JS map cannot provide. Null is the absence of an answer. Callers must
+ * keep the two apart: conflating them is how a registry kept reporting a
+ * terminal as connected after its process had exited (#15549).
+ */
+export function listPtyJobProcessIds(proc: IPty): readonly number[] | null {
+  const id = ptyHandleId(proc)
+  const native = nativeLoader()
+  if (id === null || !native) {
+    return null
+  }
+  try {
+    return native.listJobProcessIds(id)
+  } catch {
+    return null
+  }
+}
+
+/** Whether this build can own PTY trees with job objects at all. */
+export function isPtyJobOwnershipAvailable(): boolean {
+  return nativeLoader() !== null
+}
+
+/** Test-only: substitute the native module (it is resolved via createRequire). */
+export function __setConptyJobNativeForTests(loader?: () => ConptyNative | null): void {
+  nativeLoader = loader ?? loadConptyNative
+  cachedNative = undefined
+}

--- a/src/main/windows/windows-pty-job.ts
+++ b/src/main/windows/windows-pty-job.ts
@@ -137,6 +137,10 @@ export function listPtyJobProcessIds(proc: IPty): readonly number[] | null {
  * what a clean exit means. Children inherit membership, so the per-PTY jobs
  * nest inside it and every pty is covered.
  *
+ * Call it from the pty spawn path, not from startup: resolving the native
+ * module loads the ConPTY addon, and paying that before the daemon publishes
+ * its endpoint delays readiness — the boot smoke test caught exactly that.
+ *
  * Call it BEFORE the first pty. `AssignProcessToJobObject` adds only the named
  * process; children inherit membership, but a pty that already exists does not
  * join retroactively and would not be reaped.
@@ -148,7 +152,17 @@ export function listPtyJobProcessIds(proc: IPty): readonly number[] | null {
  * Returns false when the OS refuses -- an outer job that forbids nesting -- in
  * which case orphan behaviour is simply what it was before.
  */
+let hostJobAssigned: boolean | null = null
+
 export function assignHostProcessToKillOnCloseJob(): boolean {
+  if (hostJobAssigned !== null) {
+    return hostJobAssigned
+  }
+  hostJobAssigned = assignHostProcessOnce()
+  return hostJobAssigned
+}
+
+function assignHostProcessOnce(): boolean {
   const native = nativeLoader()
   if (!native) {
     return false
@@ -169,4 +183,5 @@ export function isPtyJobOwnershipAvailable(): boolean {
 export function __setConptyJobNativeForTests(loader?: () => ConptyNative | null): void {
   nativeLoader = loader ?? loadConptyNative
   cachedNative = undefined
+  hostJobAssigned = null
 }

--- a/src/main/windows/windows-pty-job.ts
+++ b/src/main/windows/windows-pty-job.ts
@@ -137,6 +137,10 @@ export function listPtyJobProcessIds(proc: IPty): readonly number[] | null {
  * what a clean exit means. Children inherit membership, so the per-PTY jobs
  * nest inside it and every pty is covered.
  *
+ * Call it BEFORE the first pty. `AssignProcessToJobObject` adds only the named
+ * process; children inherit membership, but a pty that already exists does not
+ * join retroactively and would not be reaped.
+ *
  * Call it from the terminal daemon, not from the app: an app-main crash must
  * still leave sessions alive, which is what win-crash-survival-e2e asserts. A
  * daemon death reaping its shells is the intended change (#9195, #10415).

--- a/src/main/windows/windows-pty-job.win32.test.ts
+++ b/src/main/windows/windows-pty-job.win32.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import type { IPty } from 'node-pty'
+import {
+  isPtyJobOwnershipAvailable,
+  listPtyJobProcessIds,
+  terminatePtyJob
+} from './windows-pty-job'
+
+/**
+ * The unit tests pin the contract; this pins the thing the contract is for.
+ *
+ * A grandchild spawned `detached` leaves the pane's console and reparents, so
+ * neither `GetConsoleProcessList` nor a parent-pid walk can see it. That is the
+ * process that outlived its pane and held the worktree directory open
+ * (#9045, #10475, #10897). Job membership is the only mechanism that finds it,
+ * so the assertion below is the whole justification for the node-pty patch.
+ *
+ * Runs only on win32; skipped elsewhere.
+ */
+const describeOnWindows = process.platform === 'win32' ? describe : describe.skip
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+describeOnWindows('ConPTY job ownership', () => {
+  const spawned: IPty[] = []
+
+  afterEach(() => {
+    for (const proc of spawned.splice(0)) {
+      try {
+        proc.kill()
+      } catch {
+        /* already gone */
+      }
+    }
+  })
+
+  async function spawnShellWithDetachedGrandchild(): Promise<{
+    proc: IPty
+    grandchildPid: number
+  }> {
+    const nodePty = await import('node-pty')
+    const proc = nodePty.spawn('cmd.exe', [], {
+      name: 'xterm-256color',
+      cols: 80,
+      rows: 30,
+      cwd: process.cwd(),
+      useConptyDll: true
+    })
+    spawned.push(proc)
+
+    let grandchildPid: number | null = null
+    proc.onData((chunk) => {
+      const match = /ORCA_GC=(\d+)/.exec(chunk)
+      if (match && grandchildPid === null) {
+        grandchildPid = Number(match[1])
+      }
+    })
+
+    const script = [
+      "const{spawn}=require('child_process');",
+      "const c=spawn(process.execPath,['-e','setInterval(()=>{},1000)'],",
+      "{detached:true,stdio:'ignore'});",
+      "c.unref();console.log('ORCA_GC='+c.pid);"
+    ].join('')
+    proc.write(`node -e "${script}"\r`)
+
+    for (let attempt = 0; attempt < 80 && grandchildPid === null; attempt += 1) {
+      await sleep(250)
+    }
+    if (grandchildPid === null) {
+      throw new Error('grandchild never reported its pid')
+    }
+    // Let the shell settle so the pid list is not read mid-spawn.
+    await sleep(1_000)
+    return { proc, grandchildPid }
+  }
+
+  it('reports this build as able to own pty trees', () => {
+    // A node-pty rebuilt from unpatched sources would silently fall back to the
+    // old probe, so every assertion below would pass vacuously.
+    expect(isPtyJobOwnershipAvailable()).toBe(true)
+  })
+
+  it('counts a detached grandchild as part of the pane tree', async () => {
+    const { proc, grandchildPid } = await spawnShellWithDetachedGrandchild()
+
+    const pids = listPtyJobProcessIds(proc)
+    expect(pids).not.toBeNull()
+    expect(pids).toContain(proc.pid)
+    expect(pids).toContain(grandchildPid)
+  }, 60_000)
+
+  it('kills the shell and the detached grandchild in one call', async () => {
+    const { proc, grandchildPid } = await spawnShellWithDetachedGrandchild()
+    expect(isAlive(grandchildPid)).toBe(true)
+
+    expect(terminatePtyJob(proc)).toBe('terminated')
+    await sleep(1_500)
+
+    expect(isAlive(proc.pid)).toBe(false)
+    expect(isAlive(grandchildPid)).toBe(false)
+  }, 60_000)
+
+  it('reports an emptied tree as empty, not as unavailable', async () => {
+    // Empty is evidence the pane is gone; null is the absence of evidence.
+    // A registry that cannot tell them apart keeps reporting dead terminals as
+    // connected (#15549).
+    const { proc } = await spawnShellWithDetachedGrandchild()
+    terminatePtyJob(proc)
+    await sleep(1_500)
+
+    expect(listPtyJobProcessIds(proc)).toEqual([])
+  }, 60_000)
+})

--- a/src/main/windows/windows-pty-job.win32.test.ts
+++ b/src/main/windows/windows-pty-job.win32.test.ts
@@ -1,4 +1,7 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { IPty } from 'node-pty'
 import {
   isPtyJobOwnershipAvailable,
@@ -128,6 +131,33 @@ describeOnWindows('ConPTY job ownership', () => {
     } catch {
       /* already gone */
     }
+  }, 60_000)
+
+  it('still lets a child break away from the job', async () => {
+    // A job with no limits denies CREATE_BREAKAWAY_FROM_JOB outright, and
+    // installers, msiexec and some updater paths spawn that way deliberately.
+    // They would fail ONLY inside an Orca terminal, which is the worst shape a
+    // bug report can take, so JOB_OBJECT_LIMIT_BREAKAWAY_OK is load-bearing.
+    const nodePty = await import('node-pty')
+    const marker = join(mkdtempSync(join(tmpdir(), 'orca-breakaway-')), 'marker.txt')
+    const proc = nodePty.spawn('cmd.exe', [], {
+      name: 'xterm-256color',
+      cols: 100,
+      rows: 30,
+      cwd: tmpdir(),
+      useConptyDll: true
+    })
+    spawned.push(proc)
+
+    let output = ''
+    proc.onData((chunk) => {
+      output += chunk
+    })
+    proc.write(`start /b cmd /c "echo ORCA_BREAKAWAY> ${marker}"\r`)
+
+    await vi.waitFor(() => expect(existsSync(marker)).toBe(true), { timeout: 15_000 })
+    expect(output).not.toMatch(/Access is denied/i)
+    rmSync(marker, { force: true })
   }, 60_000)
 
   it('stops answering once the tree is gone, rather than claiming it is empty', async () => {

--- a/src/main/windows/windows-pty-job.win32.test.ts
+++ b/src/main/windows/windows-pty-job.win32.test.ts
@@ -110,14 +110,15 @@ describeOnWindows('ConPTY job ownership', () => {
     expect(isAlive(grandchildPid)).toBe(false)
   }, 60_000)
 
-  it('reports an emptied tree as empty, not as unavailable', async () => {
-    // Empty is evidence the pane is gone; null is the absence of evidence.
-    // A registry that cannot tell them apart keeps reporting dead terminals as
-    // connected (#15549).
+  it('stops answering once the tree is gone, rather than claiming it is empty', async () => {
+    // Measured, not assumed: node-pty drops its handle record and closes the
+    // job when the shell exits, so a dead tree is unverifiable here rather than
+    // observably empty. Callers must not read null as proof of death -- the
+    // verdict vocabulary in docs/reference/ssh-execution-boundary.md applies.
     const { proc } = await spawnShellWithDetachedGrandchild()
     terminatePtyJob(proc)
     await sleep(1_500)
 
-    expect(listPtyJobProcessIds(proc)).toEqual([])
+    expect(listPtyJobProcessIds(proc)).toBeNull()
   }, 60_000)
 })

--- a/src/main/windows/windows-pty-job.win32.test.ts
+++ b/src/main/windows/windows-pty-job.win32.test.ts
@@ -110,6 +110,26 @@ describeOnWindows('ConPTY job ownership', () => {
     expect(isAlive(grandchildPid)).toBe(false)
   }, 60_000)
 
+  it('leaves a backgrounded process alone when the shell exits cleanly', async () => {
+    // The job must make an EXPLICIT teardown exact without redefining what a
+    // clean exit means. Measured: with JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE set,
+    // typing `exit` reaped a detached server that survived before the patch --
+    // a behaviour change nobody asked for. This pins the absence of that flag.
+    const { proc, grandchildPid } = await spawnShellWithDetachedGrandchild()
+
+    const exited = new Promise<void>((resolve) => proc.onExit(() => resolve()))
+    proc.write('exit\r')
+    await exited
+    await sleep(2_000)
+
+    expect(isAlive(grandchildPid)).toBe(true)
+    try {
+      process.kill(grandchildPid)
+    } catch {
+      /* already gone */
+    }
+  }, 60_000)
+
   it('stops answering once the tree is gone, rather than claiming it is empty', async () => {
     // Measured, not assumed: node-pty drops its handle record and closes the
     // job when the shell exits, so a dead tree is unverifiable here rather than

--- a/src/main/windows/windows-pty-job.win32.test.ts
+++ b/src/main/windows/windows-pty-job.win32.test.ts
@@ -133,11 +133,14 @@ describeOnWindows('ConPTY job ownership', () => {
     }
   }, 60_000)
 
-  it('still lets a child break away from the job', async () => {
-    // A job with no limits denies CREATE_BREAKAWAY_FROM_JOB outright, and
-    // installers, msiexec and some updater paths spawn that way deliberately.
-    // They would fail ONLY inside an Orca terminal, which is the worst shape a
-    // bug report can take, so JOB_OBJECT_LIMIT_BREAKAWAY_OK is load-bearing.
+  it('still starts a backgrounded child from inside the job', async () => {
+    // Scope note: `start /b` uses CREATE_NEW_CONSOLE, not
+    // CREATE_BREAKAWAY_FROM_JOB, so this does NOT prove the BREAKAWAY_OK flag
+    // is doing its job -- it proves job membership does not block ordinary
+    // backgrounding. The flag itself rests on the Win32 contract (a job lacking
+    // JOB_OBJECT_LIMIT_BREAKAWAY_OK denies breakaway with ERROR_ACCESS_DENIED
+    // regardless of its other limits) and is not covered by a test here.
+    // Covering it needs a helper that passes the flag to CreateProcess.
     const nodePty = await import('node-pty')
     const marker = join(mkdtempSync(join(tmpdir(), 'orca-breakaway-')), 'marker.txt')
     const proc = nodePty.spawn('cmd.exe', [], {

--- a/src/shared/child-process/run-process.ts
+++ b/src/shared/child-process/run-process.ts
@@ -248,6 +248,13 @@ export function runProcess(spec: ProcessSpec): Promise<ProcessResult> {
     // Why close rather than leave open: a child that reads stdin (a hook
     // draining its payload, a CLI probing for a TTY) otherwise blocks until the
     // timeout instead of seeing EOF immediately.
+    // Why an error listener and not just end(): a child that exits without
+    // reading makes the queued write fail with EPIPE, and an unhandled error on
+    // a stream is an uncaught exception -- which takes the whole main process
+    // down. The child's own error listener does not cover this stream. The
+    // exit code already carries the outcome, so failing to deliver stdin is
+    // not separately interesting.
+    child.stdin?.on('error', () => {})
     child.stdin?.end(spec.input)
   })
 }

--- a/src/shared/child-process/run-process.ts
+++ b/src/shared/child-process/run-process.ts
@@ -248,13 +248,6 @@ export function runProcess(spec: ProcessSpec): Promise<ProcessResult> {
     // Why close rather than leave open: a child that reads stdin (a hook
     // draining its payload, a CLI probing for a TTY) otherwise blocks until the
     // timeout instead of seeing EOF immediately.
-    // Why an error listener and not just end(): a child that exits without
-    // reading makes the queued write fail with EPIPE, and an unhandled error on
-    // a stream is an uncaught exception -- which takes the whole main process
-    // down. The child's own error listener does not cover this stream. The
-    // exit code already carries the outcome, so failing to deliver stdin is
-    // not separately interesting.
-    child.stdin?.on('error', () => {})
     child.stdin?.end(spec.input)
   })
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​651 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​634 |
| Prod | 12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​751 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​58 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​693 |

<!-- /orca-pr-loc -->

> Stacked on #15749 (which is stacked on #15746). Review those first; this diff is against #15749.

## Why

Teardown answered "is this tree mine, and how do I kill it?" by scraping the process table, walking parent PIDs back to Orca, and running `taskkill /T /F` only if the walk said yes.

Every step of that is a guess. The code already said so — `src/main/windows/../windows-pty-root-identity.ts:35`, unchanged, in a comment:

> Closing it needs real identity (a `Win32_Process.CreationDate` baseline … or an inherited handle / **Job Object**).

That file is 138 lines of production code plus 196 lines of tests whose entire job is to approximate — probabilistically, behind a 3-second PowerShell probe — what a job object answers exactly and synchronously.

The guesses fail in the ways users report:

- **A PID walk can't survive PID reuse.** So teardown refused whenever it couldn't prove ownership — and a refused kill is an orphaned agent tree holding the worktree directory open (#9045, #10475, #10087).
- **A descendant that reparented is invisible to the walk**, and one that detached from the console is invisible to `GetConsoleProcessList` too.
- **The scrape itself could be blocked** by Group Policy or AV, which read as "no evidence", which read as "don't kill".

## The proof

Run on Windows 11 against a real ConPTY whose grandchild was spawned `detached: true, stdio: 'ignore'` — the case both existing mechanisms miss:

```
pty id = 1  shell pid = 107184
grandchild pid = 91480  alive = true
job pids before = [107184,91480]
  contains detached grandchild = true
terminateJob returned = true
shell alive after      = false
grandchild alive after = false
RESULT: PASS
```

That grandchild is exactly the `claude.exe` / `node.exe` / `cmd.exe` in #9045's `handle.exe` output.

## What changed

`node-pty` creates a job object per ConPTY and assigns the shell under **`CREATE_SUSPENDED`**, then resumes. The suspend matters: assigning after `CreateProcessW` returns leaves a window in which a fast child spawns outside the job and outlives the pane.

- Termination: one `TerminateJobObject`.
- Liveness: `QueryInformationJobObject(JobObjectBasicProcessIdList)` — the answer a stale JS map can't give (#15549).
- `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`: a host that dies without unwinding no longer strands its trees.

The patch is ~60 lines of C++ in the node-pty patch Orca already maintains. It **compiles clean** on the Windows toolchain (`gyp info ok`), and all six pre-existing hunks are preserved.

## Scope of the behaviour change (revised — see comments)

The job is deliberately **not** `KILL_ON_JOB_CLOSE`. I tried that first and it reaped background processes on a clean `exit`, which is a change nobody asked for. Details in the comments.

So this PR changes exactly one thing: an **explicit** teardown (pane close, worktree delete) now reliably kills the tree instead of refusing whenever a PID walk could not prove ownership. Clean-exit semantics are unchanged, and both are pinned by tests on real Windows.

Reaping a dead daemon's shells (#9195, #10415) is **not** in this PR. It needs the separate daemon-level job from the design.

## Degradation

`terminatePtyJob` returns `unavailable` — never a false `terminated` — when a pty has no job. Two real cases: an outer job without `JOB_OBJECT_LIMIT_BREAKAWAY_OK` (some EDR and container hosts) refuses the assignment, and a pty from a build without the patch has none.

The old probe stays as the fallback for exactly that reason. Reading "we could not tell" as "already dead" is the original bug; this PR must not reintroduce it in the other direction. Tests pin both directions.

## Tests

- 15 unit tests on the job layer, including that a native refusal, a missing handle id, an unpatched build, and a throwing native call all report `unavailable` rather than success.
- Two tests in the kill-sweep suite: the job path runs **instead of** the probe and taskkill (asserting `verifyTreeKillTarget` is never called), and `unavailable` falls back to the old path.
- `killRoot` still runs after a job kill — the job kills processes, the handle still needs closing.

## Issues

Closes #9045, #10475, #10897. Materially addresses #10087, #8275, #10358, #10150.

Withdrawn from the original claim after testing on real hardware: #15549 (job liveness reports `null`, not `[]`, for a dead tree) and #9195 / #10415 (need the daemon-level job, not this one). Both explained in the comments.

## Follow-ups

- `windows-pty-root-identity.ts` and `windows-process-tree-kill.ts` become dead once job coverage is confirmed in the field. Deliberately **not** deleted here — they are the fallback, and I would rather delete them after a release of telemetry than on the same PR that introduces their replacement.
- The three `CreationDate` identity probes left out of #15749 are answerable by the same handle. Separate PR.
- Packaged E2E (`win-process-ownership-e2e.yml`) per the plan: pane-close reaps a detached grandchild, worktree delete under load 20×, daemon-kill reaps / app-kill does not.