### PR TITLE
fix: don't warn about a stale local-branch refresh after worktree create fills it in (#15331)

### DIFF
--- a/src/main/git/worktree-add-local-base-refresh.test.ts
+++ b/src/main/git/worktree-add-local-base-refresh.test.ts
@@ -396,6 +396,47 @@ describe('addWorktree', () => {
     ])
   })
 
+  // #15331: evaluation runs before `-b <branch>` exists, so rev-list fails on the missing local ref.
+  it('does not warn when worktree add itself creates the local base branch', async () => {
+    gitExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: 'abc123\n' }) // rev-parse --verify --quiet refs/remotes/origin/feature-x^{commit}
+      .mockRejectedValueOnce(
+        new Error(
+          "fatal: ambiguous argument 'refs/heads/feature-x...refs/remotes/origin/feature-x': unknown revision or path not in the working tree."
+        )
+      ) // rev-list: refs/heads/feature-x does not exist yet
+      .mockResolvedValueOnce({ stdout: '' }) // worktree add
+      .mockResolvedValueOnce({ stdout: '' }) // config --local --replace-all branch.<branch>.base
+      .mockRejectedValueOnce(Object.assign(new Error('key unset'), { code: 1 })) // config --get push.autoSetupRemote (unset)
+      .mockResolvedValueOnce({ stdout: '' }) // config --local set push.autoSetupRemote
+
+    const result = await addWorktree(
+      '/repo',
+      '/repo-feature-x',
+      'feature-x',
+      'origin/feature-x',
+      true
+    )
+
+    expect(result.localBaseRefRefresh?.status).not.toBe('skipped_not_fast_forward')
+    expect(result.localBaseRefRefresh).toEqual({
+      status: 'updated',
+      baseRef: 'origin/feature-x',
+      localBranch: 'feature-x'
+    })
+    // The branch was created at the remote base — no extra probing, no ref mutation.
+    expect(gitExecFileAsyncMock.mock.calls).toHaveLength(6)
+    expect(gitExecFileAsyncMock.mock.calls[2]?.[0]).toEqual([
+      'worktree',
+      'add',
+      '--no-track',
+      '-b',
+      'feature-x',
+      '/repo-feature-x',
+      'refs/remotes/origin/feature-x'
+    ])
+  })
+
   it('skips local base refresh when captured OIDs are no longer ancestor-safe', async () => {
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'abc123\n' }) // rev-parse refs/remotes/origin/main^{commit}
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '0\t2\n' }) // stale rev-list result

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -1021,6 +1021,18 @@ async function performAddWorktree(
     return localBaseRefRefresh ? { localBaseRefRefresh } : {}
   }
 
+  // #15331: `-b` refuses an existing branch, so reaching here proves git just created localBranch at
+  // the remote base; the pre-create rev-list only failed because refs/heads/<branch> did not exist yet.
+  // SHORTCUT: local path only. The SSH equivalent (refreshLocalBaseRefForRemoteWorktreeCreate in
+  // src/main/ipc/worktree-remote.ts) evaluates pre-create too; mirror this once the warning is
+  // reported against a remote repo.
+  if (
+    localBaseRefRefresh?.status === 'skipped_not_fast_forward' &&
+    localBaseRefRefresh.localBranch === branch
+  ) {
+    localBaseRefRefresh = { ...localBaseRefRefresh, status: 'updated' }
+  }
+
   if (effectiveBase) {
     await persistWorktreeCreationBase(worktreePath, branch, effectiveBase, options)
   }


### PR DESCRIPTION
## Summary

Fixes #15331. Creating a workspace from `origin/<branch>` when the local
branch doesn't exist yet succeeded and tracked correctly (ahead=0
behind=0), but Orca still displayed:

> Local `<branch>` was not refreshed for "..."
> Workspace was created from `origin/<branch>`, but Orca could not
> fast-forward local `<branch>`. Local `<branch>` does not exist or
> cannot be fast-forwarded cleanly from the remote base.

## Root cause

`refreshLocalBaseRefForWorktreeCreate` (`src/main/git/worktree.ts:994-1001`)
runs **before** `git worktree add -b <branch>` creates the branch
(`worktree.ts:1014`). At that point `refs/heads/<branch>` doesn't exist
yet, so `evaluateLocalBaseRefRefreshability`'s
`rev-list --left-right --count refs/heads/<branch>...<remoteTrackingRef>`
fails with "unknown revision", is caught by a blanket `catch`, and is
mislabelled `status: 'skipped_not_fast_forward'` — the same status used
for a genuinely diverged branch. That pre-create result is then returned
as-is (`worktree.ts:1056-1059`) without ever being re-evaluated after the
branch actually gets created.

This is distinct from #15645 (local branch **already exists**, fast-forward
genuinely refused by git) — different code path (`ownerWorktree` present
vs. absent), not touched by this fix.

## Fix

`git worktree add -b <branch>` refuses to create a branch that already
exists (`fatal: a branch named <branch> already exists`, verified across
loose ref / packed-refs / checked-out-elsewhere / case-collision cases).
So reaching the point right after a successful `-b` create is proof the
branch didn't exist before — no extra git calls needed. When the
pre-create evaluation was `skipped_not_fast_forward` for exactly the
branch just created, rewrite it to `updated`.

SSH/relay worktree creation (`worktree-remote.ts`) runs the same
pre-create check and likely has the identical defect — left as a
`SHORTCUT:` comment for a follow-up; this PR only touches the local path.

## Verification

- New regression test in `worktree-add-local-base-refresh.test.ts`
  reproduces the stale-warning scenario and asserts `status: 'updated'`.
- Red/green verified: reverting the 12-line fix fails only the new test;
  restoring it passes all 11.
- `worktree-add-local-base-refresh.test.ts`: 11/11 passing
- SSH-side worktree tests (`worktrees-ssh-local-base-refresh.test.ts`,
  `ssh-git-provider-worktree.test.ts`): 18/18 passing
- `pnpm run typecheck`: exit 0
- Independently confirmed by two separate reviewers (verified the `-b`
  invariant against a real temp repo, confirmed #15645's path and the
  SSH/relay files are untouched).

## Non-goals

- SSH/relay path (`worktree-remote.ts`) — same defect suspected, not fixed here.
- #15645 ("local branch exists, FF refused") — untouched, different code path.