### PR TITLE
fix: recognize antigravity/agy and stop reading inject's error text as an allowlist (#15125)

### DIFF
--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -1645,7 +1645,8 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
         if (!hasAgent) {
           throw new Error(
             `Cannot dispatch --inject to terminal ${to}: no recognized agent detected. ` +
-              'Start an agent CLI (e.g. claude, codex, gemini, droid, cursor) in the terminal first, ' +
+              'Inject accepts any agent CLI Orca supports (for example claude, codex, or agy) — ' +
+              'this list is not an allowlist. Start one in the terminal first, ' +
               'or dispatch without --inject and send the prompt manually.'
           )
         }

--- a/src/shared/agent-process-recognition.test.ts
+++ b/src/shared/agent-process-recognition.test.ts
@@ -360,6 +360,30 @@ describe('agent process recognition', () => {
     expect(isAgentForegroundWrapperProcess('vim.exe')).toBe(false)
   })
 
+  it('recognizes the Antigravity CLI from its native `agy` install layouts', () => {
+    // Why: the installer ships a flat native build named `agy` (~/.local/bin/agy on
+    // Unix, %LOCALAPPDATA%\agy\bin\agy.exe on Windows) — there is no npm package,
+    // so `node_modules/antigravity/` is somebody else's placeholder, not this agent.
+    const agy = { agent: 'antigravity', processName: 'agy' }
+
+    expect(recognizeAgentProcess('agy')).toEqual(agy)
+    expect(recognizeAgentProcess('/Users/dev/.local/bin/agy')).toEqual(agy)
+    expect(recognizeAgentProcess(String.raw`C:\Users\dev\AppData\Local\agy\bin\agy.exe`)).toEqual(
+      agy
+    )
+    expect(
+      recognizeAgentProcessFromCommandLine(
+        String.raw`"C:\Users\dev\AppData\Local\agy\bin\agy.exe" --dangerously-skip-permissions`
+      )
+    ).toEqual(agy)
+    expect(recognizeAgentProcessFromCommandLine('agy --dangerously-skip-permissions')).toEqual(agy)
+    expect(
+      recognizeAgentProcessFromCommandLine(
+        'node /usr/local/lib/node_modules/antigravity/bin/antigravity.js'
+      )
+    ).toBeNull()
+  })
+
   it('recognizes versioned Grok process names observed from the installed CLI', () => {
     expect(recognizeAgentProcess('grok-0.2.51')).toEqual({
       agent: 'grok',


### PR DESCRIPTION
## Summary

Addresses #15125. The report describes `orchestration dispatch --inject`
rejecting antigravity with a hardcoded allowlist of
`claude, codex, gemini, droid, cursor`.

**That allowlist doesn't exist.** The actual gate is
`runtime.isTerminalRunningAgent(to)` (`src/main/runtime/rpc/methods/orchestration.ts:1644-1648`);
the five names were only the error message's illustrative examples
(`e.g.`), which reads misleadingly like a closed list.

## What was actually verified

Independently curled the official installers
(`antigravity.google/cli/install.sh` / `.ps1` / `.cmd`): Antigravity
ships as a flat native Go binary named `agy`
(`$HOME/.local/bin/agy` or `%LOCALAPPDATA%\agy\bin\agy.exe`), downloaded
from a Cloud Run auto-updater with sha512 verification — **not an npm
package**. The `antigravity` / `antigravity-cli` packages on npm are
unrelated third-party placeholders.

Direct binary-name recognition for `agy`/`agy.exe` already works
correctly today — it's generically derived from `tui-agent-config.ts`'s
`antigravity: { expectedProcess: 'agy', ... }` entry. So this PR does
**not** add entries to `NODE_PACKAGE_SCRIPT_ENTRYPOINTS` or
`EXACT_NODE_ENTRYPOINT_IDENTITIES` — doing so would fabricate a
`node_modules/` install path that doesn't exist, and would risk
misidentifying the unrelated npm placeholder packages as this agent.

## Changes

- Reword the inject error text so it reads as an example, not an allowlist.
- Add a regression test locking in the real native-binary recognition
  (`agy`, `agy.exe`, full Unix/Windows install paths, the issue's own
  `--dangerously-skip-permissions` command line) plus a negative case
  proving a node-hosted `antigravity` script is correctly **not**
  recognized (guards against someone "fixing" this into a false
  positive later).

## What's still open

Since `agy`/`agy.exe` recognition already works today, the reporter's
exact Windows repro may already be fixed by unrelated changes — or the
real failure is in the Windows foreground-process scanning path
(`windows-agent-foreground-process.ts`, ConPTY membership filtering /
timing), which has no agent-name allowlist either. This PR doesn't chase
that further; it needs a Windows environment to reproduce and diagnose,
which wasn't available here.

## Verification

- `agent-process-recognition.test.ts`: 25/25 passing
- `windows-agent-foreground-process-scan-volume.test.ts`: 2/2 passing
- Existing orchestration dispatch tests: 30/30 passing
- `pnpm run typecheck`: exit 0, `oxlint`: clean
- Independently confirmed by two separate reviewers, including a
  mutation-testing pass proving the new test isn't tautological
  (reverting the fix or adding the fabricated entries makes the
  relevant assertions fail).

## Non-goals

- `worker-start` blocked by `codex-trust-workspace`, and the
  `terminal send` capability gap (#15123/#15124) — related issues
  named in the same report, out of scope here.