### PR TITLE
test(ssh): pin the relay re-establish budget to the deadlines it covers

### DIFF
--- a/src/main/ssh/ssh-relay-reestablish-budget.test.ts
+++ b/src/main/ssh/ssh-relay-reestablish-budget.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { MIN_SSH_RELAY_GRACE_PERIOD_SECONDS } from '../../shared/ssh-types'
+import { CONNECT_TIMEOUT_MS, RECONNECT_BACKOFF_MS } from './ssh-connection-utils'
+import { FLAP_DELAY_CAP_MS, RELAY_REESTABLISH_BUDGET_MS } from './ssh-reconnect-ladder'
+import { SSH_PTY_OPEN_CLIENT_TIMEOUT_MS } from './ssh-pty-consumer-session'
+import { SSH_PTY_REATTACH_ATTEMPT_TIMEOUT_MS } from './ssh-relay-session'
+
+/**
+ * FLAP_DELAY_CAP_MS decides how long the client may wait before retrying a flap, and it is derived
+ * from RELAY_REESTABLISH_BUDGET_MS — a hardcoded 20_000 whose comment says it covers "existing-relay
+ * attach and one bounded PTY reattach, 10s each". Nothing tied that literal to either deadline.
+ *
+ * The failure mode is silent and total: if reattach grows past the budget, the ladder retries after
+ * the remote relay's grace has already expired, so the relay shuts down and takes every remote PTY
+ * with it. No error, no reconnect — the user's sessions are simply gone. The client is guessing at a
+ * window the daemon owns, so at minimum that guess must stay pessimistic.
+ */
+describe('relay re-establish budget', () => {
+  it('covers both deadlines a reconnect must fit before grace expires', () => {
+    expect(RELAY_REESTABLISH_BUDGET_MS).toBeGreaterThanOrEqual(
+      SSH_PTY_OPEN_CLIENT_TIMEOUT_MS + SSH_PTY_REATTACH_ATTEMPT_TIMEOUT_MS
+    )
+  })
+
+  it('leaves a full connect attempt inside the shortest configurable grace', () => {
+    // Why >, not >=: at equality the retry lands exactly as grace expires, and which side wins is
+    // a race on the two clocks rather than a decision.
+    expect(MIN_SSH_RELAY_GRACE_PERIOD_SECONDS * 1000).toBeGreaterThan(
+      CONNECT_TIMEOUT_MS + RELAY_REESTABLISH_BUDGET_MS
+    )
+  })
+
+  it('caps a flap retry early enough to still re-establish', () => {
+    expect(FLAP_DELAY_CAP_MS + CONNECT_TIMEOUT_MS + RELAY_REESTABLISH_BUDGET_MS).toBeLessThan(
+      MIN_SSH_RELAY_GRACE_PERIOD_SECONDS * 1000
+    )
+  })
+
+  it('keeps the cap meaningful — it must actually shorten some table delay', () => {
+    // Why: if every backoff step already fits, the cap is dead code and a later table change could
+    // reintroduce the unbounded wait without anything failing here.
+    expect(RECONNECT_BACKOFF_MS.some((delayMs) => delayMs > FLAP_DELAY_CAP_MS)).toBe(true)
+    expect(RECONNECT_BACKOFF_MS).toContain(FLAP_DELAY_CAP_MS)
+  })
+})

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -135,7 +135,9 @@ type SshPtyExitPayload = Parameters<SshPtyExitCallback>[0]
 type SshPtyDataPayload = Parameters<SshPtyDataCallback>[0]
 type SshPtyLease = ReturnType<Store['getSshRemotePtyLeases']>[number]
 const SSH_PTY_REATTACH_MAX_CONCURRENCY = 8
-const SSH_PTY_REATTACH_ATTEMPT_TIMEOUT_MS = 10_000
+// Exported so ssh-relay-reestablish-budget.test.ts can hold RELAY_REESTABLISH_BUDGET_MS to the
+// deadlines it claims to cover; that constant is a literal and drifts silently otherwise.
+export const SSH_PTY_REATTACH_ATTEMPT_TIMEOUT_MS = 10_000
 const SSH_PTY_REATTACH_RETRY_MIN_DELAY_MS = 50
 const SSH_PTY_REATTACH_RETRY_JITTER_MS = 200
 const SSH_REJECTED_PTY_RECOVERY_MAX_ATTEMPTS = 2


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​45 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​45 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |

<!-- /orca-pr-loc -->

## What

`FLAP_DELAY_CAP_MS` caps how long the client waits before retrying a flap, and it is derived from `RELAY_REESTABLISH_BUDGET_MS` — a hardcoded `20_000` whose comment says it covers *"existing-relay attach and one bounded PTY reattach, 10s each"*. Nothing tied that literal to either deadline.

## Why it matters

The failure mode is silent and total. If reattach ever grows past the budget, the ladder retries **after** the remote relay's grace window has expired — so the relay shuts down and takes every remote PTY with it. No error, no reconnect; the user's sessions are simply gone.

## Is anything broken today?

**No.** `SSH_PTY_OPEN_CLIENT_TIMEOUT_MS` and `SSH_PTY_REATTACH_ATTEMPT_TIMEOUT_MS` are both `10_000`, so the 20s budget is currently correct. This is a guard against drift, not a fix.

## Verified to actually catch drift

Raising `SSH_PTY_REATTACH_ATTEMPT_TIMEOUT_MS` to `15_000` fails it:

```
AssertionError: expected 20000 to be greater than or equal to 25000
```

## Risk

Test-only, apart from adding `export` to one existing constant. No behaviour change.

Four assertions: the budget covers both deadlines; a full connect attempt fits inside the shortest configurable grace; a capped flap retry still leaves room to re-establish; and the cap still actually shortens some backoff step (so it can't quietly become dead code).

<sub>Found while investigating SSH reconnect data loss on `nwparker/SSH-v3`.</sub>