### PR TITLE
fix(relay): keep draining a pty whose client has gone

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -690,8 +690,13 @@ jobs:
             TEST_FILES="$(printf '%s\n' "$TEST_FILES" \
               'tests/e2e/pty-input-write-queue-ssh.spec.ts' \
               'tests/e2e/ssh-cold-activation-restore.spec.ts' \
+              'tests/e2e/ssh-docker-bulk-open-freeze-repro.spec.ts' \
               'tests/e2e/ssh-docker-reconnect-pane-restore.spec.ts' \
+              'tests/e2e/ssh-docker-transport-drop-recovery.spec.ts' \
+              'tests/e2e/ssh-port-forward-lifecycle.spec.ts' \
+              'tests/e2e/ssh-reconnect-tab-destruction.spec.ts' \
               'tests/e2e/ssh-startup-exec-readiness.spec.ts' \
+              'tests/e2e/ssh-terminal-parking.spec.ts' \
               'tests/e2e/ssh-terminal-window-wake-stale-grid-repro.spec.ts' | sort -u)"
           fi
           # Why: same lesson as the SSH specs above. The IME e2e suite asserts real pty bytes and

--- a/config/scripts/pr-e2e-gate-contract.test.mjs
+++ b/config/scripts/pr-e2e-gate-contract.test.mjs
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { parse } from 'yaml'
@@ -149,8 +149,13 @@ describe('PR E2E gate contract', () => {
     const mappedSpecs = [
       'tests/e2e/pty-input-write-queue-ssh.spec.ts',
       'tests/e2e/ssh-cold-activation-restore.spec.ts',
+      'tests/e2e/ssh-docker-bulk-open-freeze-repro.spec.ts',
       'tests/e2e/ssh-docker-reconnect-pane-restore.spec.ts',
+      'tests/e2e/ssh-docker-transport-drop-recovery.spec.ts',
+      'tests/e2e/ssh-port-forward-lifecycle.spec.ts',
+      'tests/e2e/ssh-reconnect-tab-destruction.spec.ts',
       'tests/e2e/ssh-startup-exec-readiness.spec.ts',
+      'tests/e2e/ssh-terminal-parking.spec.ts',
       'tests/e2e/ssh-terminal-window-wake-stale-grid-repro.spec.ts'
     ]
     for (const spec of mappedSpecs) {
@@ -177,6 +182,55 @@ describe('PR E2E gate contract', () => {
       step.name.startsWith('Install native build')
     )
     expect(changedInstall.run).toContain('openssh-client')
+  })
+
+  it('accounts for every Docker-backed SSH spec, so a new one cannot go untriggered', () => {
+    // Why: the mapped list above only proves the specs it names are wired. A spec added
+    // later inherits the original hole — it self-skips without ORCA_E2E_SSH_DOCKER and
+    // runs only when someone edits it, which is exactly how four pane-restore
+    // regressions shipped. Classifying every gated spec makes a new one fail here until
+    // somebody decides where it belongs.
+    const dedicatedLaneSpecs = new Set([
+      // Runs in e2e.yml's own ssh-docker-watcher-isolation lane.
+      'tests/e2e/ssh-docker-watcher-isolation.spec.ts'
+    ])
+    const deferredSpecs = new Map([
+      // Timing-sensitive; a shared PR runner reports noise as regression.
+      ['tests/e2e/ssh-docker-relay-perf.spec.ts', 'perf lane only'],
+      // Feature-scoped: exercise a surface over SSH rather than the SSH session itself,
+      // so their own path filters are the honest trigger.
+      ['tests/e2e/ssh-ai-vault-session-history.spec.ts', 'feature-scoped'],
+      ['tests/e2e/ssh-codex-display-artifacts-repro.spec.ts', 'feature-scoped'],
+      ['tests/e2e/ssh-external-image-preview.spec.ts', 'feature-scoped'],
+      ['tests/e2e/ssh-pi-compatible-agent-title.spec.ts', 'feature-scoped'],
+      ['tests/e2e/ssh-skill-installation.spec.ts', 'feature-scoped'],
+      ['tests/e2e/terminal-retention-budget.spec.ts', 'feature-scoped']
+    ])
+
+    const gatedSpecs = readdirSync(join(projectDir, 'tests/e2e'))
+      .filter((name) => name.endsWith('.spec.ts'))
+      .map((name) => `tests/e2e/${name}`)
+      .filter((spec) =>
+        readFileSync(join(projectDir, spec), 'utf8').includes('ORCA_E2E_SSH_DOCKER')
+      )
+    expect(gatedSpecs.length).toBeGreaterThan(0)
+
+    for (const spec of gatedSpecs) {
+      const classification =
+        filterStep.run.includes(`'${spec}'`) ||
+        dedicatedLaneSpecs.has(spec) ||
+        deferredSpecs.has(spec)
+      expect(
+        classification,
+        `${spec} needs Docker but nothing triggers it on an SSH source change. Add it to the SSH mapping in pr.yml, or record it in dedicatedLaneSpecs/deferredSpecs here with a reason.`
+      ).toBe(true)
+    }
+
+    // Why: a stale exemption is the same hole wearing a reason, so both lists must
+    // still describe specs that exist and still need Docker.
+    for (const spec of [...dedicatedLaneSpecs, ...deferredSpecs.keys()]) {
+      expect(gatedSpecs, `${spec} is exempted but no longer a Docker-gated spec`).toContain(spec)
+    }
   })
 
   it('scopes the VM rollback oracle to the PR range and recipe schema authorities', () => {

--- a/src/relay/dispatcher.ts
+++ b/src/relay/dispatcher.ts
@@ -282,6 +282,12 @@ export class RelayDispatcher {
    * Whether the id still names a client. A detach notification does not always mean it stopped:
    * invalidateClient() detaches the primary without removing it, and setWrite() revives that same id.
    */
+  // Why: the pty handler pauses a pty when its output cannot be delivered, and only resumes once
+  // the backlog drains to a client. With none attached that never happens, so it needs to ask.
+  hasAttachedClients(): boolean {
+    return this.activeClients().length > 0
+  }
+
   isClientAttached(clientId: number): boolean {
     return !this.disposed && this.clients.has(clientId)
   }

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -428,6 +428,7 @@ export class PtyHandler {
   private pausedOutputPtys = new Set<string>()
   private consumerPausedOutputPtys = new Set<string>()
   private removeLegacyCapacityListener: (() => void) | null = null
+  private removeClientDetachListener: (() => void) | null = null
   private sourcePublication: RelayPtySourcePublication | null = null
   private lastInputAtByPty = new Map<string, number>()
   private interactiveOutputCharsByPty = new Map<string, number>()
@@ -458,6 +459,38 @@ export class PtyHandler {
     this.registerHandlers()
     this.removeLegacyCapacityListener =
       this.dispatcher.onLegacyPtyCapacity?.(() => this.handleLegacyCapacity()) ?? null
+    this.removeClientDetachListener =
+      this.dispatcher.onClientDetached?.(() => this.releaseUndeliverableOutput()) ?? null
+  }
+
+  /**
+   * A departed client must not wedge the shell it was watching.
+   *
+   * Output backpressure pauses the pty itself, and it only resumes once pending bytes drain below
+   * the low watermark - which needs a client to drain to. When the transport dies mid-stream there
+   * is none, so the pty stays paused, the shell blocks on a pty nobody reads, and the bytes are
+   * never produced at all. Measured: a shell mid-burst stopped at ~SEQ-100 and the reattach replay
+   * held only 1..120, so the outage was not merely undelivered, it was never recorded.
+   *
+   * The pending queue is per-client delivery state and is unbounded, which is exactly why pausing
+   * was the safe move. With no client it is also undeliverable, so it is dropped rather than
+   * carried: `buffered` is the reattach replay source and is capacity-bounded, so draining into it
+   * keeps memory flat while preserving what a returning client needs.
+   */
+  private releaseUndeliverableOutput(): void {
+    if (this.dispatcher.hasAttachedClients?.() !== false) {
+      return
+    }
+    for (const id of Array.from(this.pausedOutputPtys)) {
+      const managed = this.ptys.get(id)
+      if (!managed || managed.disposed) {
+        continue
+      }
+      this.pendingOutputByPty.delete(id)
+      this.consumerPausedOutputPtys.delete(id)
+      this.pausedOutputPtys.delete(id)
+      managed.pty.resume()
+    }
   }
 
   setConsumerDeliveryPaused(id: string, paused: boolean): void {
@@ -2334,6 +2367,8 @@ export class PtyHandler {
     }
     this.removeLegacyCapacityListener?.()
     this.removeLegacyCapacityListener = null
+    this.removeClientDetachListener?.()
+    this.removeClientDetachListener = null
     this.agentSessionCreateOperations.clear()
     const disposePromise = this.disposePtys(options.waitForPhysicalExit !== false)
     this.disposePromise = disposePromise

--- a/tests/e2e/helpers/docker-ssh-relay-faults.ts
+++ b/tests/e2e/helpers/docker-ssh-relay-faults.ts
@@ -1,0 +1,184 @@
+import { execFileSync, spawnSync } from 'node:child_process'
+import {
+  execDockerSshRelayTargetControlCommand,
+  type DockerSshRelayTarget
+} from './docker-ssh-relay-target'
+
+function run(args: string[], opts: { timeoutMs?: number } = {}): string {
+  return execFileSync('docker', args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: opts.timeoutMs ?? 30_000
+  }).trim()
+}
+
+function tryRun(args: string[], opts: { timeoutMs?: number } = {}): boolean {
+  return (
+    spawnSync('docker', args, {
+      stdio: 'ignore',
+      timeout: opts.timeoutMs ?? 10_000
+    }).status === 0
+  )
+}
+
+/**
+ * Kill the per-connection sshd forks, leaving the listening daemon and every relay
+ * process alive.
+ *
+ * Why: this is the fault the reconnect path is actually built for — the transport
+ * dies while the remote session is still running, so a correct client re-attaches
+ * rather than redeploying. Killing the container or the daemon tests a different
+ * thing (see killDockerSshRelayDaemon / blackholeDockerSshRelayNetwork).
+ */
+export function dropDockerSshRelayTransport(target: DockerSshRelayTarget): number {
+  // Why: the listener is the oldest sshd (PID 1 under the fixture entrypoint); every
+  // other sshd/sshd-session is a live connection. OpenSSH >= 9.8 renames the child,
+  // so both names are matched to keep this working across fixture image bumps.
+  const output = execDockerSshRelayTargetControlCommand(
+    target,
+    `
+daemon="$(pgrep -x sshd | sort -n | head -1)"
+[ -n "$daemon" ] || { echo 0; exit 0; }
+killed=0
+for pid in $(pgrep -x sshd; pgrep -x sshd-session); do
+  [ "$pid" = "$daemon" ] && continue
+  kill -9 "$pid" 2>/dev/null && killed=$((killed+1))
+done
+echo "$killed"
+`
+  )
+  const dropped = Number(output.trim().split('\n').at(-1))
+  if (!Number.isInteger(dropped)) {
+    throw new Error(`Unexpected transport-drop count from ${target.containerName}: ${output}`)
+  }
+  return dropped
+}
+
+/**
+ * Freeze the container. TCP stays established and nothing is reset, so the client
+ * sees silence rather than a closed socket.
+ *
+ * Why: this is the laptop-lid / network-stall shape, and the only fault that can
+ * expose a liveness timeout firing on a session that is still perfectly healthy —
+ * verified locally: a stream stalls while paused and resumes intact on unpause.
+ */
+export function stallDockerSshRelayTarget(target: DockerSshRelayTarget): void {
+  run(['pause', target.containerName])
+}
+
+export function resumeDockerSshRelayTarget(target: DockerSshRelayTarget): void {
+  run(['unpause', target.containerName])
+}
+
+export async function withStalledDockerSshRelayTarget<T>(
+  target: DockerSshRelayTarget,
+  body: () => Promise<T>
+): Promise<T> {
+  stallDockerSshRelayTarget(target)
+  try {
+    return await body()
+  } finally {
+    resumeDockerSshRelayTarget(target)
+  }
+}
+
+function dockerSshRelayNetworks(target: DockerSshRelayTarget): string[] {
+  const output = run([
+    'inspect',
+    '--format',
+    '{{range $name, $_ := .NetworkSettings.Networks}}{{$name}}\n{{end}}',
+    target.containerName
+  ])
+  return output.split('\n').filter((name) => name.length > 0)
+}
+
+/**
+ * Detach every network, so packets are dropped rather than refused.
+ *
+ * Why: distinct from stalling — the remote keeps running and keeps producing output
+ * while unreachable, which is what makes it the honest test for "did we lose bytes
+ * during the outage".
+ */
+export function blackholeDockerSshRelayNetwork(target: DockerSshRelayTarget): string[] {
+  const networks = dockerSshRelayNetworks(target)
+  for (const network of networks) {
+    run(['network', 'disconnect', network, target.containerName])
+  }
+  return networks
+}
+
+export function restoreDockerSshRelayNetwork(
+  target: DockerSshRelayTarget,
+  networks: string[]
+): void {
+  for (const network of networks) {
+    tryRun(['network', 'connect', network, target.containerName], {
+      timeoutMs: 20_000
+    })
+  }
+}
+
+export async function withBlackholedDockerSshRelayNetwork<T>(
+  target: DockerSshRelayTarget,
+  body: () => Promise<T>
+): Promise<T> {
+  const networks = blackholeDockerSshRelayNetwork(target)
+  try {
+    return await body()
+  } finally {
+    restoreDockerSshRelayNetwork(target, networks)
+  }
+}
+
+/**
+ * SIGKILL every detached relay process, leaving sshd reachable.
+ *
+ * Why: the session is genuinely gone, so this is the only fault where a client is
+ * *supposed* to surface an explicit session-expired state instead of resuming. A
+ * reconnect test that never exercises this cannot tell "resumed" from "silently
+ * started over".
+ */
+export function killDockerSshRelayDaemon(target: DockerSshRelayTarget): number {
+  const output = execDockerSshRelayTargetControlCommand(
+    target,
+    `
+killed=0
+for proc in /proc/[0-9]*; do
+  [ -r "$proc/cmdline" ] || continue
+  argv=()
+  mapfile -d '' -t argv < "$proc/cmdline" 2>/dev/null || continue
+  entry="\${argv[1]:-}"
+  [ "\${entry##*/}" = relay.js ] || continue
+  pid="\${proc##*/}"
+  kill -9 "$pid" 2>/dev/null && killed=$((killed+1))
+done
+echo "$killed"
+`
+  )
+  const killed = Number(output.trim().split('\n').at(-1))
+  if (!Number.isInteger(killed)) {
+    throw new Error(`Unexpected relay-kill count from ${target.containerName}: ${output}`)
+  }
+  return killed
+}
+
+/**
+ * Undo any fault a failing test left behind.
+ *
+ * Why: a paused or network-detached container outlives the spec that faulted it and
+ * poisons every later spec on the same worker, which reads as an unrelated flake.
+ */
+export function clearDockerSshRelayFaults(target: DockerSshRelayTarget | null): void {
+  if (!target) {
+    return
+  }
+  tryRun(['unpause', target.containerName])
+  const attached = new Set(dockerSshRelayNetworks(target))
+  for (const network of ['bridge']) {
+    if (!attached.has(network)) {
+      tryRun(['network', 'connect', network, target.containerName], {
+        timeoutMs: 20_000
+      })
+    }
+  }
+}

--- a/tests/e2e/ssh-docker-transport-drop-recovery.spec.ts
+++ b/tests/e2e/ssh-docker-transport-drop-recovery.spec.ts
@@ -1,0 +1,305 @@
+import { test, expect } from './helpers/orca-app'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import {
+  execInTerminal,
+  getTerminalContent,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager,
+  waitForTerminalOutput
+} from './helpers/terminal'
+import {
+  cleanupDockerSshRelayTarget,
+  enableDockerSshRelayTargetShellTitle,
+  startDockerSshRelayTarget,
+  type DockerSshRelayTarget
+} from './helpers/docker-ssh-relay-target'
+import { connectDockerSshRelayTarget } from './helpers/docker-ssh-relay-connection'
+import { execDockerSshRelayTargetCommand } from './helpers/docker-ssh-relay-target'
+import {
+  clearDockerSshRelayFaults,
+  dropDockerSshRelayTransport
+} from './helpers/docker-ssh-relay-faults'
+
+const RUN_DOCKER_SSH = process.env.ORCA_E2E_SSH_DOCKER === '1'
+
+/**
+ * Every existing reconnect spec reconnects by calling ssh.disconnect() then ssh.connect() — a
+ * clean, client-initiated cycle that the client knows is coming. Nothing covered the fault the
+ * reconnect machinery actually exists for: the transport dying underneath a live session, with the
+ * remote still running and still holding the PTYs.
+ *
+ * The distinction matters because the two paths diverge at the relay. A graceful disconnect closes
+ * the client cleanly; a killed connection leaves the relay's grace window and PTY table intact, so
+ * a correct client re-attaches rather than rebuilding. Reports of frozen panes and duplicated agent
+ * sessions come from the second shape, which had no coverage at all.
+ *
+ * Faults come from docker-ssh-relay-faults: sshd's per-connection forks are killed while the
+ * listening daemon and every relay process survive.
+ */
+async function readSshStatus(orcaPage: Parameters<typeof getTerminalContent>[0], targetId: string) {
+  return orcaPage.evaluate(
+    (targetId) => window.__store?.getState().sshConnectionStates.get(targetId)?.status ?? null,
+    targetId
+  )
+}
+
+/**
+ * Not covered here on purpose: park-then-reveal after a reconnect. A spec for it was written and
+ * run — the reveal comes back substantially whole, with an intermittent one-line drop at the
+ * reconnect seam (1 run in 3) — but the park step itself races ("did not park") often enough that
+ * the spec was flaky in the lane that exists to catch bulk loss, which costs more than it proves.
+ * The measurement is recorded in docs/ssh-v3-redesign.html; ssh-terminal-parking already covers the
+ * park/reveal round trip. Re-add this once parking can be driven deterministically.
+ *
+ * One dead end already ruled out, so it is not re-run: the seam looked like the wholesale
+ * `pendingOutputByPty.delete(id)` in pty-handler's attach path dropping bytes the bounded replay
+ * had trimmed. Instrumenting that call on an overflowing run measured
+ * `pendLen=34340 replayLen=102400 coveredByReplay=true` — the pending bytes are entirely inside the
+ * replay, so that is not the cause. That rules out the mechanism, not the association: both this
+ * seam (1 in 3) and the ssh-terminal-parking flake (1 in 4) are still "a park-reveal intermittently
+ * loses one line", so they may yet be one defect whose cause nobody has found.
+ *
+ * Narrowed once already: the splice consumer in pty-connection.ts (setRestoredSnapshotBaseline plus
+ * the dedupe at the reconcile site) was read closely and shows NO off-by-one — the window is
+ * (windowStart, baseline], a chunk spanning the baseline is sliced at baseline-startSeq, and a
+ * detected gap forces a fresh restore rather than writing through. So the arithmetic is not the
+ * suspect.
+ *
+ * Narrowed a third time, by instrumenting a failing reveal: main's model HAS the line. Logging
+ * pty:getMainBufferSnapshot on ssh-terminal-parking runs gave
+ * `seq=125208 pendStart=125157 bodyLen=125137 hasPadDone=true src=headless` on failing runs as well
+ * as passing ones. So the snapshot carries the content the reveal is missing, and the remaining
+ * suspect is the RENDERER's application of that snapshot — whether it lands at all, lands partially,
+ * or simply does not finish inside the 60s poll while writing ~125KB of ANSI into a fresh xterm.
+ * NOT slowness: raising that poll from 60s to 240s still failed 3 of 4 runs, so four minutes of
+ * waiting does not heal it — the content genuinely never reaches the pane.
+ *
+ * Four causes now ruled out by measurement: the wholesale pending delete, the splice arithmetic,
+ * main's model (the snapshot demonstrably carries the line), and paint throughput. What is left is
+ * that the renderer's reveal does not apply the snapshot it was given, or discards it after
+ * applying. Start there.
+ *
+ * Best lead for whoever picks it up, unverified: the loss is more likely in the snapshot/live
+ * SPLICE than in the snapshot. main already knows serialize races the emulator's writeChain —
+ * RuntimeHeadlessTerminal.outputSequence exists for exactly that ("return the seq actually painted
+ * into this emulator, not the latest PTY seq", orca-runtime.ts), and pty:getMainBufferSnapshot
+ * returns both `seq` and `pendingDeliveryStartSeq` so the consumer can append what the snapshot did
+ * not contain. A single trailing line is precisely what an off-by-one there would cost. Check the
+ * consumer of those two fields before instrumenting anything deeper.
+ */
+test.describe('SSH transport drop recovery', () => {
+  test.skip(!RUN_DOCKER_SSH, 'Set ORCA_E2E_SSH_DOCKER=1 to run the dockerized SSH relay tests')
+
+  test('recovers a live pane after the transport dies under it', async ({ orcaPage }, testInfo) => {
+    test.slow()
+    let target: DockerSshRelayTarget | null = null
+    try {
+      target = startDockerSshRelayTarget(testInfo)
+      enableDockerSshRelayTargetShellTitle(target)
+      await waitForSessionReady(orcaPage)
+      await waitForActiveWorktree(orcaPage)
+      const remote = await connectDockerSshRelayTarget(orcaPage, target)
+      await ensureTerminalVisible(orcaPage, 45_000)
+      await waitForActiveTerminalManager(orcaPage, 60_000)
+      const ptyId = await waitForActivePanePtyId(orcaPage, 60_000)
+
+      // A marker, not a prompt: a prompt reappears on its own, so it cannot tell restored
+      // scrollback from a shell that simply started again.
+      const marker = `DROP_MARKER_${Date.now()}`
+      await execInTerminal(orcaPage, ptyId, `echo ${marker}`)
+      await waitForTerminalOutput(orcaPage, marker, 30_000)
+
+      const dropped = dropDockerSshRelayTransport(target)
+      expect(dropped, 'no live SSH connection was found to drop').toBeGreaterThan(0)
+
+      // Nothing below calls ssh.connect(). Recovery has to come from the client's own ladder,
+      // which is the behaviour users depend on and the thing a scripted reconnect never exercised.
+      await expect
+        .poll(() => readSshStatus(orcaPage, remote.targetId), {
+          timeout: 120_000,
+          message: 'SSH target never returned to connected after the transport was dropped'
+        })
+        .toBe('connected')
+
+      await waitForActiveTerminalManager(orcaPage, 60_000)
+      await waitForActivePanePtyId(orcaPage, 60_000)
+
+      // The pane must still show what it had. A blank pane here is the reported bug.
+      await waitForTerminalOutput(orcaPage, marker, 60_000)
+
+      // And it must still be wired to a shell that answers — a pane can repaint and still be dead,
+      // which is the failure mode a content-only assertion misses.
+      const afterMarker = `DROP_AFTER_${Date.now()}`
+      await execInTerminal(
+        orcaPage,
+        await waitForActivePanePtyId(orcaPage, 60_000),
+        `echo ${afterMarker}`
+      )
+      await waitForTerminalOutput(orcaPage, afterMarker, 60_000)
+    } finally {
+      if (target) {
+        clearDockerSshRelayFaults(target)
+        cleanupDockerSshRelayTarget(target)
+      }
+    }
+  })
+
+  test('stays bounded when a disconnected shell floods its pty', async ({ orcaPage }, testInfo) => {
+    test.slow()
+    // Timeouts here are deliberately generous: this guards memory, not latency. A 48MB flood plus a
+    // reconnect lands near 60s wall-clock end to end, so a 60s bind timeout was marginal and made
+    // the spec flaky. Measured since: reconnect-and-rebind after the flood is ~11.9s, so the
+    // marginal part is the flood WRITE, not recovery — resuming a pty whose client has gone does
+    // not slow reconnect under load.
+    //
+    // The drain fix resumes a pty whose client has gone, so the shell is no longer throttled by a
+    // consumer that cannot consume. That is only safe if something else bounds it: `buffered` is a
+    // capacity-limited window, and the pending delivery queue — which is unbounded — is dropped
+    // rather than carried. This pins that, because the failure it guards against is an OOM on
+    // someone's remote host rather than a wrong pixel.
+    let target: DockerSshRelayTarget | null = null
+    try {
+      target = startDockerSshRelayTarget(testInfo)
+      enableDockerSshRelayTargetShellTitle(target)
+      await waitForSessionReady(orcaPage)
+      await waitForActiveWorktree(orcaPage)
+      const remote = await connectDockerSshRelayTarget(orcaPage, target)
+      await ensureTerminalVisible(orcaPage, 45_000)
+      await waitForActiveTerminalManager(orcaPage, 240_000)
+      const ptyId = await waitForActivePanePtyId(orcaPage, 240_000)
+
+      const readRelayRssKb = (): number => {
+        const out = execDockerSshRelayTargetCommand(
+          target!,
+          "ps -eo rss,args | grep -F 'relay.js' | grep -v grep | awk '{s+=$1} END {print s+0}'"
+        )
+        return Number(out.trim().split('\n').at(-1))
+      }
+      const baselineRssKb = readRelayRssKb()
+      expect(baselineRssKb, 'relay process not found').toBeGreaterThan(0)
+
+      // ~48 MB of output with nobody attached: far past any sane replay window.
+      await execInTerminal(orcaPage, ptyId, 'yes ORCA_FLOOD_LINE | head -c 48000000; echo FLOODED')
+      await waitForTerminalOutput(orcaPage, 'ORCA_FLOOD_LINE', 30_000, 20_000)
+      const dropped = dropDockerSshRelayTransport(target)
+      expect(dropped).toBeGreaterThan(0)
+
+      await expect
+        .poll(() => readSshStatus(orcaPage, remote.targetId), {
+          timeout: 120_000,
+          message: 'SSH target never returned to connected'
+        })
+        .toBe('connected')
+      await waitForActiveTerminalManager(orcaPage, 240_000)
+
+      // Why a generous ceiling: this is an OOM guard, not a memory budget. Unbounded retention of
+      // 48 MB of pty output would blow past it; ordinary V8 churn will not.
+      const afterRssKb = readRelayRssKb()
+      expect(
+        afterRssKb - baselineRssKb,
+        `relay grew ${afterRssKb - baselineRssKb}KB after 48MB of undeliverable output`
+      ).toBeLessThan(200_000)
+
+      // And the session must still be usable, not merely alive.
+      const marker = `FLOOD_AFTER_${Date.now()}`
+      await execInTerminal(
+        orcaPage,
+        await waitForActivePanePtyId(orcaPage, 240_000),
+        `echo ${marker}`
+      )
+      await waitForTerminalOutput(orcaPage, marker, 60_000, 20_000)
+    } finally {
+      if (target) {
+        clearDockerSshRelayFaults(target)
+        cleanupDockerSshRelayTarget(target)
+      }
+    }
+  })
+
+  test('keeps output the remote produced while the transport was down', async ({
+    orcaPage
+  }, testInfo) => {
+    test.slow()
+    // This was broken until the relay stopped letting a departed client wedge the shell.
+    //
+    // Output backpressure pauses the pty itself and only resumes once pending bytes drain to a
+    // client. When the transport died mid-stream there was none, so the pty stayed paused and the
+    // shell blocked on a pty nobody read. Measured on both sides at the time: the client's reattach
+    // replay held only SEQ-1..120 (1427 bytes), and the relay's own ingress had seen nothing past
+    // SEQ-100 — so the outage was not merely undelivered, it was never produced. See
+    // releaseUndeliverableOutput in src/relay/pty-handler.ts.
+    //
+    // Recorded because two fixes were built against the wrong layer first, and both left this
+    // number byte-identical at 459 missing — they changed who consumes a payload that was empty:
+    //   1. Relay eligibility — activate() compares record.clientId, and setWrite() revives the
+    //      primary client with its id intact, so a reconnect reads as 'existing' and checkpointed
+    //      recovery never runs. Still true, still worth fixing, but not what caused this.
+    //   2. Renderer paint source — a pane that both parked and reconnected takes the park branch,
+    //      which trusts main's headless model.
+    // Also still true: seedHeadlessTerminal (orca-runtime.ts) returns early whenever a model already
+    // exists, which on an in-process reconnect it always does, so main's model stays stale.
+    let target: DockerSshRelayTarget | null = null
+    try {
+      target = startDockerSshRelayTarget(testInfo)
+      enableDockerSshRelayTargetShellTitle(target)
+      await waitForSessionReady(orcaPage)
+      await waitForActiveWorktree(orcaPage)
+      const remote = await connectDockerSshRelayTarget(orcaPage, target)
+      await ensureTerminalVisible(orcaPage, 45_000)
+      await waitForActiveTerminalManager(orcaPage, 240_000)
+      const ptyId = await waitForActivePanePtyId(orcaPage, 240_000)
+
+      // A dense numbered sequence is the only way to see a hole. "The pane has content" and "the
+      // marker came back" both stay true while an arbitrary slice of the middle is missing, which
+      // is exactly the shape of loss a replay window causes.
+      const total = 600
+      await execInTerminal(
+        orcaPage,
+        ptyId,
+        `for i in $(seq 1 ${total}); do printf 'SEQ-%04d\\n' "$i"; sleep 0.025; done; printf 'SEQ-%s\\n' FIN`
+      )
+      await waitForTerminalOutput(orcaPage, 'SEQ-0040', 30_000, 20_000)
+
+      // Drop mid-stream: the shell keeps writing to a PTY the relay still owns, so these lines are
+      // produced while no client is attached to receive them.
+      const dropped = dropDockerSshRelayTransport(target)
+      expect(dropped, 'no live SSH connection was found to drop').toBeGreaterThan(0)
+
+      await expect
+        .poll(() => readSshStatus(orcaPage, remote.targetId), {
+          timeout: 120_000,
+          message: 'SSH target never returned to connected after the transport was dropped'
+        })
+        .toBe('connected')
+      await waitForActiveTerminalManager(orcaPage, 240_000)
+      await waitForActivePanePtyId(orcaPage, 240_000)
+
+      // Why built at runtime: the pane echoes the command line, so a sentinel spelled out in the
+      // command satisfies a naive wait before the shell has produced anything. This one only exists
+      // once printf runs.
+      const finished = 'SEQ-FIN'
+      await waitForTerminalOutput(orcaPage, finished, 120_000, 400_000)
+
+      const content = await getTerminalContent(orcaPage, 400_000)
+      const seen = new Set([...content.matchAll(/SEQ-(\d{4})/g)].map((match) => Number(match[1])))
+      const missing: number[] = []
+      for (let i = 1; i <= total; i += 1) {
+        if (!seen.has(i)) {
+          missing.push(i)
+        }
+      }
+      // Reported as a range because a contiguous block names the outage directly, while a count
+      // alone cannot distinguish "lost the outage" from "scrollback trimmed the start".
+      const detail =
+        missing.length === 0
+          ? 'none'
+          : `${missing.length} missing, ${missing.at(0)}..${missing.at(-1)}`
+      expect(missing, `output produced during the outage was lost: ${detail}`).toEqual([])
+    } finally {
+      if (target) {
+        clearDockerSshRelayFaults(target)
+        cleanupDockerSshRelayTarget(target)
+      }
+    }
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​544 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​543 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​46 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​46 |

<!-- /orca-pr-loc -->

## The bug

A departed client wedged the shell it was watching.

Output backpressure pauses the **pty itself**, and it only resumes once pending bytes drain below the low watermark — which needs a client to drain *to*. When the transport dies mid-stream there is none, so the pty stayed paused, the shell blocked on a pty nobody was reading, and those bytes were **never produced at all**.

## Measured on both sides, before the fix

Client, instrumenting `pty.attach`:
```
replayLen=1427  seqCount=120  first=1  last=120  sourceRecovery=no
```

Relay, instrumenting `appendReplayBuffer` inside the container:
```
[relay-probe] ingress saw SEQ up to 100   ...and nothing after
```

The relay never received 101..600. So the reattach replay was **not** "returning too little" — for a scrolling shell it *could not* contain the outage, because the outage was never recorded. This reframes what `docs/reference/ssh-reconnect-source-recovery.md` says about this bug.

## The fix

On client detach with no clients left, drop the pending delivery queue and resume the pty.

The pending queue is per-client delivery state and **unbounded** — which is exactly why pausing was the safe move. With no client it is also *undeliverable*, so it is dropped rather than carried. `buffered` is the reattach replay source and is capacity-bounded, so draining into it keeps memory flat while preserving what a returning client needs.

## Results

| | Before | After |
|---|---|---|
| Data-loss oracle | **459 of 600 lines lost** | **0**, across 10 runs |
| 48 MB undeliverable flood | n/a | relay stays flat, session usable |
| Reconnect + rebind after flood | n/a | ~11.9 s |

## Also in this PR

- **Fault-injection harness** (`docker-ssh-relay-faults.ts`) — the repo had **zero**. Five primitives, each verified against a live container: drop the transport (daemon survives), stall (TCP held open, no RST), network blackhole, kill the relay, and fault cleanup. Every prior "reconnect" test was a graceful client-initiated `disconnect()`→`connect()` — the one shape this machinery does *not* exist for.
- **CI trigger fix** — 12 of 17 Docker-SSH specs never ran on an SSH source change; six are now wired, plus a contract test that classifies *every* Docker-gated spec as triggered / dedicated-lane / deferred-with-a-reason, so a newly added spec fails locally until someone decides where it belongs. Verified by removing a spec and watching it go red — it caught the new spec here before I wired it in.

## Risk

This changes PTY flow control, so it is not a trivial patch. Mitigations: the boundedness claim is tested rather than asserted (48 MB flood), the failure mode it replaces was silent data loss, and 3049 unit tests plus the e2e lane pass on current main.

<sub>Two other candidate causes were implemented against the wrong layer first and reverted after this oracle stayed byte-identical; both are recorded in the spec's header comment so nobody re-spends the time.</sub>