### PR TITLE
fix(relay): let activate() tell a reconnected client from one that never left

### DIFF
--- a/src/relay/dispatcher.ts
+++ b/src/relay/dispatcher.ts
@@ -44,6 +44,16 @@ export type {
 
 export type RequestContext = {
   clientId: number
+  /**
+   * Which transport incarnation of `clientId` this request arrived on.
+   *
+   * Why: setWrite() reuses the primary client - id included - so a reconnected client is
+   * indistinguishable from the one that never left, and every "is this the same client?" test
+   * answers yes across a reconnect. resetClient() already bumps this on that path. Optional because
+   * it only has meaning for contexts the dispatcher builds; a harness that omits it keeps the
+   * id-only comparison.
+   */
+  transportGeneration?: number
   isStale: () => boolean
   signal?: AbortSignal
   sessionIdentity?: RelayClientSessionIdentity
@@ -1016,6 +1026,7 @@ export class RelayDispatcher {
     }
     const context: RequestContext = {
       clientId: client.id,
+      transportGeneration: gen,
       isStale: () =>
         client.generation !== gen || !this.clients.has(client.id) || abortController.signal.aborted,
       signal: abortController.signal,
@@ -1086,6 +1097,7 @@ export class RelayDispatcher {
       const gen = client.generation
       handler(notif.params ?? {}, {
         clientId: client.id,
+        transportGeneration: gen,
         isStale: () => client.generation !== gen || !this.clients.has(client.id),
         sessionIdentity: client.sessionIdentity,
         onResponseSettled: () => {

--- a/src/relay/relay-pty-source-delivery-record.ts
+++ b/src/relay/relay-pty-source-delivery-record.ts
@@ -1,0 +1,49 @@
+import type { PtySourceDeliveryIdentity } from '../shared/pty-source-credit-contract'
+import type { PtySourceRecoveryCheckpoint } from '../shared/pty-source-recovery-contract'
+import type { PtySourceReceivingActivation } from '../shared/pty-source-receiving-activation'
+
+export type RelayPtySourceDeliveryRecord = {
+  clientId: number
+  clientTransportGeneration?: number // transport incarnation of clientId; see RequestContext
+  identity: PtySourceDeliveryIdentity
+  sourceActivation: PtySourceReceivingActivation
+  displayEnd: number
+  activating: boolean
+  activationRecoveryRequest: PtySourceRecoveryCheckpoint | null
+  sealed: boolean
+  legacyExitAccepted: boolean
+  sourceExitState: 'idle' | 'pending' | 'published'
+  sending: boolean
+  turnFrames: number
+  turnSourceSu: number
+  turnScheduled: boolean
+  sendWaiters: Set<() => void>
+  recoveryCheckpointSourceEndSu: number | null
+  recoveryEndSu: number | null
+  recoveryCompletionPending: boolean
+  restoreRequired: boolean
+  rotationPending: boolean
+}
+
+/**
+ * Is a request the same client on the same transport that opened this delivery?
+ *
+ * Why not clientId alone: Dispatcher.setWrite() revives the primary client without changing its id,
+ * so a reconnected client compared by id is indistinguishable from one that never left. activate()
+ * then answers 'existing' and returns before it ever reads the recovery argument, which is why
+ * checkpointed source recovery has never run on an SSH reconnect (see
+ * docs/reference/ssh-reconnect-source-recovery.md). resetClient() already bumps the transport
+ * generation on exactly that path, so it is the term that separates the two.
+ *
+ * Both sides undefined means the caller does not model transports — a harness, or any non-dispatcher
+ * caller — so it keeps the id-only answer rather than rotating on every attach.
+ */
+export function sameClientTransport(
+  record: { clientId: number; clientTransportGeneration?: number },
+  context: { clientId: number; transportGeneration?: number }
+): boolean {
+  return (
+    record.clientId === context.clientId &&
+    record.clientTransportGeneration === context.transportGeneration
+  )
+}

--- a/src/relay/relay-pty-source-publication.ts
+++ b/src/relay/relay-pty-source-publication.ts
@@ -7,12 +7,16 @@ import type { PtySourceReceivingActivation } from '../shared/pty-source-receivin
 import {
   createPtySourceReceivingActivation,
   pendingPtySourceRecoveryResult,
-  registerCanceledPtySourceRetirement,
   registerPtySourceActivationSettlement,
   samePtySourceRecoveryRequest
 } from './relay-pty-source-activation'
 import {
+  publishPtySourceRestoreRequired,
+  requirePtySourceRestore
+} from './relay-pty-source-restore-required'
+import {
   RelayPtySourceSendScheduler,
+  sameClientTransport,
   type RelayPtySourceDeliveryRecord,
   type RelayPtySourcePublicationCounters
 } from './relay-pty-source-send-scheduler'
@@ -85,7 +89,8 @@ export class RelayPtySourcePublication {
       return false
     }
     if (
-      current?.clientId === context.clientId &&
+      current !== undefined &&
+      sameClientTransport(current, context) &&
       !current.restoreRequired &&
       current.sourceExitState !== 'pending' &&
       this.deliveryClosedUnderRecord(current)
@@ -96,11 +101,16 @@ export class RelayPtySourcePublication {
       this.onCapacity(id)
       current = undefined
     }
-    if (current?.clientId === context.clientId) {
+    if (current !== undefined && sameClientTransport(current, context)) {
       this.sender.releaseRotationFence(current)
       if (current.activating && current.activationRecoveryRequest) {
         if (!samePtySourceRecoveryRequest(current.activationRecoveryRequest, recovery)) {
-          return this.publishRestoreRequired(id, context, 'checkpointUnavailable')
+          return publishPtySourceRestoreRequired(
+            this.restoreDeps,
+            id,
+            context,
+            'checkpointUnavailable'
+          )
         }
         this.registerActivationSettlement(id, current, context)
         return pendingPtySourceRecoveryResult(current)
@@ -113,7 +123,7 @@ export class RelayPtySourcePublication {
     let recoveryEndSu: number | null = null
     let recoveryWasSealed = false
     if (!current && recovery) {
-      return this.publishRestoreRequired(id, context, 'deliveryUnavailable')
+      return publishPtySourceRestoreRequired(this.restoreDeps, id, context, 'deliveryUnavailable')
     }
     if (current) {
       try {
@@ -127,7 +137,13 @@ export class RelayPtySourcePublication {
           recovery.ownerGeneration !== current.identity.ownerGeneration ||
           recovery.ptyIncarnation !== current.identity.ptyIncarnation
         ) {
-          return this.requireRestore(id, current, context, 'checkpointUnavailable')
+          return requirePtySourceRestore(
+            this.restoreDeps,
+            id,
+            current,
+            context,
+            'checkpointUnavailable'
+          )
         }
         const rotation = this.session.rotateDelivery(
           current.identity,
@@ -141,7 +157,8 @@ export class RelayPtySourcePublication {
         recoveryWasSealed = snapshot.state === 'sealed-unsettled'
         this.counters.rotated++
       } catch (error) {
-        return this.requireRestore(
+        return requirePtySourceRestore(
+          this.restoreDeps,
           id,
           current,
           context,
@@ -162,6 +179,7 @@ export class RelayPtySourcePublication {
     const activationRecoveryEndSu = recoveryEndSu ?? activationSnapshot.receivedEndSu
     const record: RelayPtySourceDeliveryRecord = {
       clientId: context.clientId,
+      clientTransportGeneration: context.transportGeneration,
       identity,
       sourceActivation: createPtySourceReceivingActivation(
         identity,
@@ -295,32 +313,13 @@ export class RelayPtySourcePublication {
     })
   }
 
-  private requireRestore(
-    id: string,
-    current: RelayPtySourceDeliveryRecord,
-    context: RequestContext,
-    reason: string
-  ): Readonly<{ status: 'restoreRequired'; reason: string }> {
-    this.session.cancelDelivery(current.identity, `recovery-${reason}`)
-    current.restoreRequired = true
-    current.activating = false
-    this.sender.wakeSendWaiters(current)
-    registerCanceledPtySourceRetirement(current, context, this.deliveries, this.onCapacity)
-    return this.publishRestoreRequired(id, context, reason)
-  }
-
-  private publishRestoreRequired(
-    id: string,
-    context: RequestContext,
-    reason: string
-  ): Readonly<{ status: 'restoreRequired'; reason: string }> {
-    const result = Object.freeze({ status: 'restoreRequired' as const, reason })
-    context.onResponseSettled?.((settlement) => {
-      if (settlement.ok) {
-        this.dispatcher.notifyClient(context.clientId, 'pty.restoreRequired', { id, reason })
-      }
-    })
-    this.onCapacity(id)
-    return result
+  private get restoreDeps() {
+    return {
+      dispatcher: this.dispatcher,
+      onCapacity: this.onCapacity,
+      session: this.session,
+      sender: this.sender,
+      deliveries: this.deliveries
+    }
   }
 }

--- a/src/relay/relay-pty-source-restore-required.ts
+++ b/src/relay/relay-pty-source-restore-required.ts
@@ -1,0 +1,66 @@
+import type { RelayDispatcher, RequestContext } from './dispatcher'
+import { registerCanceledPtySourceRetirement } from './relay-pty-source-activation'
+import type { RelayPtySourceDeliveryRecord } from './relay-pty-source-send-scheduler'
+import type { RelayPtySourceSendScheduler } from './relay-pty-source-send-scheduler'
+import type { SshPtyConsumerSessionAdapter } from './ssh-pty-consumer-session-adapter'
+
+export type PtySourceRestoreRequiredResult = Readonly<{
+  status: 'restoreRequired'
+  reason: string
+}>
+
+type RestoreRequiredDeps = {
+  dispatcher: RelayDispatcher
+  onCapacity: (id: string) => void
+}
+
+/**
+ * Tell one client it must restore, once the response carrying that verdict has actually landed.
+ *
+ * Why the settlement fence: the notification is only meaningful to a client that received the
+ * response it answers. Firing it eagerly would reach a client that never learned why, or a socket
+ * that has already gone — and a restoreRequired the client cannot correlate reads as an expired
+ * session, which is the one outcome this path exists to avoid.
+ */
+export function publishPtySourceRestoreRequired(
+  deps: RestoreRequiredDeps,
+  id: string,
+  context: RequestContext,
+  reason: string
+): PtySourceRestoreRequiredResult {
+  const result = Object.freeze({ status: 'restoreRequired' as const, reason })
+  context.onResponseSettled?.((settlement) => {
+    if (settlement.ok) {
+      deps.dispatcher.notifyClient(context.clientId, 'pty.restoreRequired', { id, reason })
+    }
+  })
+  deps.onCapacity(id)
+  return result
+}
+
+/**
+ * Retire a delivery that cannot be resumed, then tell its client to restore.
+ *
+ * Why cancel before publishing: the credit ledger holds one upstream owner per pty, and a record
+ * left open under a delivery nobody will resume strands that slot — the next open then fails with
+ * "already has an upstream owner", which surfaces as an error toast and a blank pane rather than
+ * as the recoverable restore this is meant to be.
+ */
+export function requirePtySourceRestore(
+  deps: RestoreRequiredDeps & {
+    session: SshPtyConsumerSessionAdapter
+    sender: RelayPtySourceSendScheduler
+    deliveries: Map<string, RelayPtySourceDeliveryRecord>
+  },
+  id: string,
+  current: RelayPtySourceDeliveryRecord,
+  context: RequestContext,
+  reason: string
+): PtySourceRestoreRequiredResult {
+  deps.session.cancelDelivery(current.identity, `recovery-${reason}`)
+  current.restoreRequired = true
+  current.activating = false
+  deps.sender.wakeSendWaiters(current)
+  registerCanceledPtySourceRetirement(current, context, deps.deliveries, deps.onCapacity)
+  return publishPtySourceRestoreRequired(deps, id, context, reason)
+}

--- a/src/relay/relay-pty-source-send-scheduler.ts
+++ b/src/relay/relay-pty-source-send-scheduler.ts
@@ -1,9 +1,7 @@
-import type {
-  PtySourceDeliveryIdentity,
-  PtySourceDeliverySnapshot
-} from '../shared/pty-source-credit-contract'
-import type { PtySourceRecoveryCheckpoint } from '../shared/pty-source-recovery-contract'
-import type { PtySourceReceivingActivation } from '../shared/pty-source-receiving-activation'
+import type { RelayPtySourceDeliveryRecord } from './relay-pty-source-delivery-record'
+export { sameClientTransport } from './relay-pty-source-delivery-record'
+export type { RelayPtySourceDeliveryRecord } from './relay-pty-source-delivery-record'
+import type { PtySourceDeliverySnapshot } from '../shared/pty-source-credit-contract'
 import type { RelayDispatcher, SinkWriteSettlement } from './dispatcher'
 import {
   PTY_SOURCE_SCHEDULER_MAX_FRAMES,
@@ -11,28 +9,6 @@ import {
 } from './pty-source-credit-scheduler'
 import type { SshPtyConsumerSessionAdapter } from './ssh-pty-consumer-session-adapter'
 import { completePtySourceRecovery } from './relay-pty-source-recovery-completion'
-
-export type RelayPtySourceDeliveryRecord = {
-  clientId: number
-  identity: PtySourceDeliveryIdentity
-  sourceActivation: PtySourceReceivingActivation
-  displayEnd: number
-  activating: boolean
-  activationRecoveryRequest: PtySourceRecoveryCheckpoint | null
-  sealed: boolean
-  legacyExitAccepted: boolean
-  sourceExitState: 'idle' | 'pending' | 'published'
-  sending: boolean
-  turnFrames: number
-  turnSourceSu: number
-  turnScheduled: boolean
-  sendWaiters: Set<() => void>
-  recoveryCheckpointSourceEndSu: number | null
-  recoveryEndSu: number | null
-  recoveryCompletionPending: boolean
-  restoreRequired: boolean
-  rotationPending: boolean
-}
 
 export type RelayPtySourcePublicationCounters = {
   opened: number

--- a/src/relay/relay-pty-source-transport-generation.test.ts
+++ b/src/relay/relay-pty-source-transport-generation.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  RelayDispatcher,
+  type RelayClientSessionIdentity,
+  type RequestContext,
+  type SinkWriteSettlement
+} from './dispatcher'
+import { encodeJsonRpcFrame } from './protocol'
+import { RelayPtySourcePublication } from './relay-pty-source-publication'
+import { SshPtyConsumerSessionAdapter } from './ssh-pty-consumer-session-adapter'
+
+/**
+ * A reconnected client must be distinguishable from one that never disconnected.
+ *
+ * setWrite() revives the primary client without changing its id, so activate()'s
+ * `record.clientId === context.clientId` test answered yes across a reconnect and returned
+ * 'existing' before ever reading the recovery argument. Checkpointed source recovery therefore
+ * never ran on an SSH reconnect (docs/reference/ssh-reconnect-source-recovery.md).
+ *
+ * Scope, because it is easy to over-read: this restores the relay's ability to *notice* a
+ * reconnect. It is not what caused the transport-drop data loss — that was the pty pausing with no
+ * client to drain to, fixed separately in pty-handler. Both were needed.
+ */
+const endpointIdentity: RelayClientSessionIdentity = {
+  principal: 'endpoint-principal',
+  authenticated: true,
+  allowSessionOwner: true,
+  authenticationKind: 'endpoint-credential'
+}
+
+function requestFrame(id: number, method: string, params: Record<string, unknown>): Buffer {
+  return encodeJsonRpcFrame({ jsonrpc: '2.0', id, method, params }, id, 0)
+}
+
+async function flushRequests(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve))
+}
+
+describe('pty source activation across a transport change', () => {
+  let dispatcher: RelayDispatcher | null = null
+
+  afterEach(() => {
+    dispatcher?.dispose()
+    dispatcher = null
+  })
+
+  async function createHarness() {
+    const settlements: ((result: SinkWriteSettlement) => void)[] = []
+    dispatcher = new RelayDispatcher(
+      (_data, onSettled) => {
+        onSettled({ ok: true })
+        return true
+      },
+      { supportsWriteCallback: true },
+      endpointIdentity
+    )
+    let publication: RelayPtySourcePublication
+    const adapter = new SshPtyConsumerSessionAdapter(dispatcher, 'build-a', undefined, (id) =>
+      publication.onCreditAvailable(id)
+    )
+    publication = new RelayPtySourcePublication(dispatcher, adapter, () => {})
+    dispatcher.feed(
+      requestFrame(1, 'pty.openClient', {
+        protocolVersion: 1,
+        clientInstanceId: 'client-1',
+        requestedRole: 'session-owner',
+        capabilities: { outputFlowControl: { versions: [1], requestedWindowSu: 4 } }
+      })
+    )
+    await flushRequests()
+    return { publication, settlements }
+  }
+
+  function contextOn(
+    transportGeneration: number | undefined,
+    settlements: unknown[]
+  ): RequestContext {
+    return {
+      clientId: 1,
+      ...(transportGeneration === undefined ? {} : { transportGeneration }),
+      isStale: () => false,
+      sessionIdentity: endpointIdentity,
+      onResponseSettled: (callback) => settlements.push(callback)
+    }
+  }
+
+  it('still short-circuits when the same client re-activates on the same transport', async () => {
+    const { publication, settlements } = await createHarness()
+    expect(publication.activate('pty-1', 'incarnation-1', contextOn(0, settlements))).toBe('opened')
+    ;(settlements[0] as (result: SinkWriteSettlement) => void)({ ok: true })
+
+    // Why this case matters: a plain re-attach on a live transport must keep costing nothing.
+    expect(publication.activate('pty-1', 'incarnation-1', contextOn(0, settlements))).toBe(
+      'existing'
+    )
+  })
+
+  it('does not claim "existing" when the client returns on a new transport', async () => {
+    const { publication, settlements } = await createHarness()
+    expect(publication.activate('pty-1', 'incarnation-1', contextOn(0, settlements))).toBe('opened')
+    ;(settlements[0] as (result: SinkWriteSettlement) => void)({ ok: true })
+
+    // Same clientId, next transport incarnation — what a reconnect actually looks like.
+    expect(publication.activate('pty-1', 'incarnation-1', contextOn(1, settlements))).not.toBe(
+      'existing'
+    )
+  })
+
+  it('keeps the id-only answer for callers that do not model transports', async () => {
+    const { publication, settlements } = await createHarness()
+    expect(publication.activate('pty-1', 'incarnation-1', contextOn(undefined, settlements))).toBe(
+      'opened'
+    )
+    ;(settlements[0] as (result: SinkWriteSettlement) => void)({ ok: true })
+
+    // Why: harnesses and non-dispatcher callers omit the field; they must not start rotating on
+    // every attach just because the comparison grew a second term.
+    expect(publication.activate('pty-1', 'incarnation-1', contextOn(undefined, settlements))).toBe(
+      'existing'
+    )
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​122 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​122 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​164 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​62 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​102 |

<!-- /orca-pr-loc -->

## The bug

`Dispatcher.setWrite()` revives the primary client **with its id intact**, so `activate()`'s `record.clientId === context.clientId` test answers *yes* across a reconnect and returns `'existing'` before it ever reads the recovery argument.

Checkpointed source recovery has therefore **never run on an SSH reconnect** — which is what `docs/reference/ssh-reconnect-source-recovery.md` traced and left as the implied fix.

## The fix

`resetClient()` already bumps a transport generation on exactly that path. It simply wasn't surfaced where the decision is made. `RequestContext` now carries it, and the publication compares both terms.

The field is **optional**, so any caller that doesn't model transports — harnesses, non-dispatcher callers — keeps the id-only answer rather than rotating on every attach. Three tests pin all three cases.

## Scope — easy to over-read

This restores the relay's ability to **notice** a reconnect. It is **not** what caused the transport-drop data loss; that was the pty pausing with no client to drain to (#15761). Both were needed, and I only know that because each was measured separately — this change alone left the data-loss oracle byte-identical.

## Two extractions came first

Both files sat at **exactly** the 300-line cap that AGENTS.md forbids disabling, so the change didn't fit:

- `relay-pty-source-restore-required.ts` — restore-required signalling out of the publication (300 → 297)
- `relay-pty-source-delivery-record.ts` — the delivery record out of the send scheduler (300 → 277), which shouldn't have owned the record it schedules

Each split was verified green **on its own**, before any behaviour changed. Both files are now back under the cap with room.

## Verification

3052 unit tests pass on current main. Line budgets: publication 300, scheduler 277.

<sub>One earlier attempt at this reached for a type predicate on the comparison, which was semantically wrong — it returns false for a *defined* record on a different transport, so narrowing the false branch to `undefined` lies to the compiler. TypeScript caught it; noting it so it isn't retried.</sub>