### PR TITLE
feat(sidebar): add New Group button and group selector in add-project dialog

### DIFF
--- a/src/renderer/src/components/Landing.tsx
+++ b/src/renderer/src/components/Landing.tsx
@@ -1,5 +1,13 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { AlertTriangle, ExternalLink, FolderPlus, GitBranchPlus, Star, X } from 'lucide-react'
+import {
+  AlertTriangle,
+  ExternalLink,
+  FolderPlus,
+  GitBranchPlus,
+  Layers,
+  Star,
+  X
+} from 'lucide-react'
 import { cn } from '../lib/utils'
 import { useAppStore } from '../store'
 import { isGitRepoKind } from '../../../shared/repo-kind'
@@ -16,6 +24,7 @@ import logo from '../../../../resources/logo.svg'
 import { translate } from '@/i18n/i18n'
 import { hasGitHubBackedProject, type PreflightIssue } from './landing-preflight-issues'
 import { useLandingPreflightRuntime } from './landing-preflight-runtime'
+import { ProjectGroupNameDialog } from './sidebar/ProjectGroupNameDialog'
 
 type ShortcutItem = {
   id: string
@@ -228,6 +237,8 @@ function PreflightBanner({
 export default function Landing(): React.JSX.Element {
   const repos = useAppStore((s) => s.repos)
   const openModal = useAppStore((s) => s.openModal)
+  const createProjectGroup = useAppStore((s) => s.createProjectGroup)
+  const [createGroupDialogOpen, setCreateGroupDialogOpen] = useState(false)
 
   const createTargetLabel =
     repos.length > 0 && repos.every((repo) => isGitRepoKind(repo)) ? 'Worktree' : 'Workspace'
@@ -282,9 +293,9 @@ export default function Landing(): React.JSX.Element {
               : translate('auto.components.Landing.cd21242762', 'Add a project to get started.')}
           </p>
 
-          <div className="flex items-center justify-center gap-2.5 flex-wrap">
+          <div className="flex items-center justify-center gap-2.5">
             <button
-              className="inline-flex items-center gap-1.5 bg-secondary/70 border border-border/80 text-foreground font-medium text-sm px-4 py-2 rounded-md cursor-pointer hover:bg-accent transition-colors"
+              className="inline-flex items-center gap-1.5 bg-secondary/70 border border-border/80 text-foreground font-medium text-sm px-3 py-1.5 rounded-md cursor-pointer hover:bg-accent transition-colors"
               onClick={() => openModal('add-repo')}
             >
               <FolderPlus className="size-3.5" />
@@ -292,14 +303,40 @@ export default function Landing(): React.JSX.Element {
             </button>
 
             <button
-              className="inline-flex items-center gap-1.5 bg-secondary/70 border border-border/80 text-foreground font-medium text-sm px-4 py-2 rounded-md cursor-pointer hover:bg-accent transition-colors"
+              className="inline-flex items-center gap-1.5 bg-secondary/70 border border-border/80 text-foreground font-medium text-sm px-3 py-1.5 rounded-md cursor-pointer hover:bg-accent transition-colors"
               onClick={() => openModal('new-workspace-composer', { telemetrySource: 'unknown' })}
             >
               <GitBranchPlus className="size-3.5" />
               {translate('auto.components.Landing.76a95f7f47', 'Create')}{' '}
               {createTargetLabel.toLowerCase()}
             </button>
+
+            <button
+              className="inline-flex items-center gap-1.5 bg-secondary/70 border border-border/80 text-foreground font-medium text-sm px-3 py-1.5 rounded-md cursor-pointer hover:bg-accent transition-colors"
+              onClick={() => setCreateGroupDialogOpen(true)}
+            >
+              <Layers className="size-3.5" />
+              {translate('components.sidebar.projectGroups.newGroupLabel', 'New Group')}
+            </button>
           </div>
+
+          <ProjectGroupNameDialog
+            open={createGroupDialogOpen}
+            title={translate(
+              'components.sidebar.projectGroups.createDialogTitle',
+              'New Project Group'
+            )}
+            description={translate(
+              'components.sidebar.projectGroups.createDialogDescription',
+              'Create a group to organize your projects in the sidebar.'
+            )}
+            initialName=""
+            confirmLabel="Create"
+            onOpenChange={setCreateGroupDialogOpen}
+            onSubmit={async (name) => {
+              await createProjectGroup(name)
+            }}
+          />
 
           <div className="mt-6 w-full max-w-xs space-y-2">
             {shortcuts.map((shortcut) => (

--- a/src/renderer/src/components/Landing.tsx
+++ b/src/renderer/src/components/Landing.tsx
@@ -331,7 +331,10 @@ export default function Landing(): React.JSX.Element {
               'Create a group to organize your projects in the sidebar.'
             )}
             initialName=""
-            confirmLabel="Create"
+            confirmLabel={translate(
+              'components.sidebar.projectGroups.createDialogConfirmLabel',
+              'Create'
+            )}
             onOpenChange={setCreateGroupDialogOpen}
             onSubmit={async (name) => {
               await createProjectGroup(name)

--- a/src/renderer/src/components/sidebar/AddRepoDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialog.tsx
@@ -19,6 +19,8 @@ import {
   type AddRepoDialogHostedController
 } from './use-add-repo-hosted-controller'
 import { routeAddRepoBrowse } from './add-repo-browse-authority'
+import { AddRepoGroupSelectorSlot } from './AddRepoGroupSelectorSlot'
+import { useAddRepoGroupCompletion } from './use-add-repo-group-completion'
 
 export default React.memo(function AddRepoDialog({
   hosted
@@ -44,11 +46,13 @@ export default React.memo(function AddRepoDialog({
   const [step, setStep] = useState<AddRepoDialogStep>('add')
   const [isAdding, setIsAdding] = useState(false)
   const [addProjectBusyLabel, setAddProjectBusyLabel] = useState<string | null>(null)
-  const completeGitRepoAdd = useCompleteGitRepoAdd({
+  const baseCompleteGitRepoAdd = useCompleteGitRepoAdd({
     closeModal,
     setHideDefaultBranchWorkspace,
     finishProjectAdd
   })
+  const { projectGroups, selectedGroupId, setSelectedGroupId, completeGitRepoAdd } =
+    useAddRepoGroupCompletion(baseCompleteGitRepoAdd)
   const hostSelection = useAddRepoHostSelection({ isOpen, setStep })
   const selectedRuntimeEnvironmentId =
     hostSelection.selectedParsedHost?.kind === 'runtime'
@@ -222,6 +226,7 @@ export default React.memo(function AddRepoDialog({
     resetCreateDefaultState()
     resetCreateState()
     resetRemoteState()
+    setSelectedGroupId(null)
   }, [
     resetCloneFlow,
     resetLocalFolderFlow,
@@ -230,7 +235,8 @@ export default React.memo(function AddRepoDialog({
     resetServerPathFlow,
     resetNestedImportFlow,
     resetRemoteState,
-    resetCreateState
+    resetCreateState,
+    setSelectedGroupId
   ])
 
   const resetHostScopedState = useCallback(() => {
@@ -324,6 +330,15 @@ export default React.memo(function AddRepoDialog({
         createError={createError}
         isCreating={isCreating}
         hostSelector={<AddRepoHostSelectorSlot hostSelection={hostSelection} />}
+        groupSelector={
+          projectGroups.length > 0 ? (
+            <AddRepoGroupSelectorSlot
+              projectGroups={projectGroups}
+              selectedGroupId={selectedGroupId}
+              onGroupChange={setSelectedGroupId}
+            />
+          ) : undefined
+        }
         showRemoteAction={false}
         actionsDisabled={!hostSelection.selectedHostId}
         browseHostKind={selectedHostKind ?? 'runtime'}

--- a/src/renderer/src/components/sidebar/AddRepoDialogStepContent.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialogStepContent.tsx
@@ -44,6 +44,7 @@ type AddRepoDialogStepContentProps = {
   createError: string | null
   isCreating: boolean
   hostSelector?: ReactNode
+  groupSelector?: ReactNode
   showRemoteAction?: boolean
   canCreateProject?: boolean
   actionsDisabled?: boolean
@@ -114,6 +115,7 @@ export function AddRepoDialogStepContent({
   createError,
   isCreating,
   hostSelector,
+  groupSelector,
   showRemoteAction = true,
   canCreateProject = true,
   actionsDisabled = false,
@@ -159,6 +161,7 @@ export function AddRepoDialogStepContent({
         nestedScanInProgress={nestedScanInProgress}
         nestedScanId={nestedScanId}
         hostSelector={hostSelector}
+        groupSelector={groupSelector}
         showRemoteAction={showRemoteAction}
         canCreateProject={canCreateProject}
         actionsDisabled={actionsDisabled}

--- a/src/renderer/src/components/sidebar/AddRepoGroupSelectorSlot.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoGroupSelectorSlot.tsx
@@ -1,0 +1,52 @@
+import { Layers } from 'lucide-react'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select'
+import { Label } from '@/components/ui/label'
+import { translate } from '@/i18n/i18n'
+import type { ProjectGroup } from '../../../../shared/project-group-types'
+
+const NO_GROUP_VALUE = '__none__'
+
+type AddRepoGroupSelectorSlotProps = {
+  projectGroups: readonly ProjectGroup[]
+  selectedGroupId: string | null
+  onGroupChange: (groupId: string | null) => void
+}
+
+export function AddRepoGroupSelectorSlot({
+  projectGroups,
+  selectedGroupId,
+  onGroupChange
+}: AddRepoGroupSelectorSlotProps): React.JSX.Element {
+  return (
+    <div className="space-y-1">
+      <Label className="text-[11px] text-muted-foreground">
+        <Layers className="mr-1 inline size-3" />
+        {translate('components.sidebar.addRepo.groupSelectorLabel', 'Add to group (optional)')}
+      </Label>
+      <Select
+        value={selectedGroupId ?? NO_GROUP_VALUE}
+        onValueChange={(value) => onGroupChange(value === NO_GROUP_VALUE ? null : value)}
+      >
+        <SelectTrigger size="sm" className="w-full text-xs">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={NO_GROUP_VALUE} className="text-xs text-muted-foreground">
+            {translate('components.sidebar.addRepo.groupSelectorNoGroup', 'No group')}
+          </SelectItem>
+          {projectGroups.map((group) => (
+            <SelectItem key={group.id} value={group.id} className="text-xs">
+              {group.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}

--- a/src/renderer/src/components/sidebar/AddRepoGroupSelectorSlot.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoGroupSelectorSlot.tsx
@@ -1,3 +1,4 @@
+import { useId } from 'react'
 import { Layers } from 'lucide-react'
 import {
   Select,
@@ -23,9 +24,10 @@ export function AddRepoGroupSelectorSlot({
   selectedGroupId,
   onGroupChange
 }: AddRepoGroupSelectorSlotProps): React.JSX.Element {
+  const id = useId()
   return (
     <div className="space-y-1">
-      <Label className="text-[11px] text-muted-foreground">
+      <Label htmlFor={id} className="text-[11px] text-muted-foreground">
         <Layers className="mr-1 inline size-3" />
         {translate('components.sidebar.addRepo.groupSelectorLabel', 'Add to group (optional)')}
       </Label>
@@ -33,7 +35,7 @@ export function AddRepoGroupSelectorSlot({
         value={selectedGroupId ?? NO_GROUP_VALUE}
         onValueChange={(value) => onGroupChange(value === NO_GROUP_VALUE ? null : value)}
       >
-        <SelectTrigger size="sm" className="w-full text-xs">
+        <SelectTrigger id={id} size="sm" className="w-full text-xs">
           <SelectValue />
         </SelectTrigger>
         <SelectContent>

--- a/src/renderer/src/components/sidebar/AddRepoStartSteps.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoStartSteps.tsx
@@ -129,6 +129,12 @@ export function AddRepoLocalStartStep({
     if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') {
       return
     }
+    if (
+      !(event.target instanceof HTMLElement) ||
+      !event.target.closest('button[data-add-repo-action]')
+    ) {
+      return
+    }
     const buttons = Array.from(
       actionsRef.current?.querySelectorAll<HTMLButtonElement>('button[data-add-repo-action]') ?? []
     )

--- a/src/renderer/src/components/sidebar/AddRepoStartSteps.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoStartSteps.tsx
@@ -67,6 +67,7 @@ type AddRepoLocalStartStepProps = {
   nestedScanInProgress: boolean
   nestedScanId: string | null
   hostSelector?: ReactNode
+  groupSelector?: ReactNode
   showRemoteAction?: boolean
   canCreateProject?: boolean
   actionsDisabled?: boolean
@@ -86,6 +87,7 @@ export function AddRepoLocalStartStep({
   nestedScanInProgress,
   nestedScanId,
   hostSelector,
+  groupSelector,
   showRemoteAction = true,
   canCreateProject = true,
   actionsDisabled = false,
@@ -173,6 +175,7 @@ export function AddRepoLocalStartStep({
         onKeyDown={handleArrowNavigation}
       >
         {hostSelector}
+        {groupSelector}
         <AddRepoPrimaryStartAction
           icon={primaryAction.icon}
           title={primaryAction.title}

--- a/src/renderer/src/components/sidebar/SidebarHeader.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarHeader.test.tsx
@@ -64,7 +64,9 @@ afterEach(() => {
 describe('SidebarHeader', () => {
   it('keeps New workspace clickable with zero projects, since the composer adds the first one', () => {
     act(() => {
-      root.render(<SidebarHeader onWorkspaceBoardMenuOpenChange={vi.fn()} />)
+      root.render(
+        <SidebarHeader onWorkspaceBoardMenuOpenChange={vi.fn()} onCreateGroup={vi.fn()} />
+      )
     })
 
     const button = newWorkspaceButton()
@@ -80,7 +82,9 @@ describe('SidebarHeader', () => {
   it('opens the composer the same way once projects exist', () => {
     mockState.repos = [{ id: 'repo-a' }]
     act(() => {
-      root.render(<SidebarHeader onWorkspaceBoardMenuOpenChange={vi.fn()} />)
+      root.render(
+        <SidebarHeader onWorkspaceBoardMenuOpenChange={vi.fn()} onCreateGroup={vi.fn()} />
+      )
     })
 
     act(() => {

--- a/src/renderer/src/components/sidebar/SidebarHeader.tsx
+++ b/src/renderer/src/components/sidebar/SidebarHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { FolderPlus, Plus } from 'lucide-react'
+import { FolderPlus, Layers, Plus } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
@@ -10,10 +10,12 @@ import { translate } from '@/i18n/i18n'
 
 type SidebarHeaderProps = {
   onWorkspaceBoardMenuOpenChange: (open: boolean) => void
+  onCreateGroup: () => void
 }
 
 const SidebarHeader = React.memo(function SidebarHeader({
-  onWorkspaceBoardMenuOpenChange
+  onWorkspaceBoardMenuOpenChange,
+  onCreateGroup
 }: SidebarHeaderProps) {
   const openModal = useAppStore((s) => s.openModal)
   const newWorktreeShortcutLabel = useShortcutLabel('workspace.create')
@@ -35,6 +37,28 @@ const SidebarHeader = React.memo(function SidebarHeader({
           preserveWorkspaceBoardOpen
           onMenuOpenChange={onWorkspaceBoardMenuOpenChange}
         />
+
+        {groupBy === 'repo' && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                className="text-muted-foreground"
+                aria-label={translate(
+                  'components.sidebar.projectGroups.newGroupLabel',
+                  'New Group'
+                )}
+                onClick={onCreateGroup}
+              >
+                <Layers className="size-3.5" strokeWidth={2.25} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" sideOffset={6}>
+              {translate('components.sidebar.projectGroups.newGroupLabel', 'New Group')}
+            </TooltipContent>
+          </Tooltip>
+        )}
 
         <Tooltip>
           <TooltipTrigger asChild>

--- a/src/renderer/src/components/sidebar/index.tsx
+++ b/src/renderer/src/components/sidebar/index.tsx
@@ -16,6 +16,8 @@ import { useWorkspaceBoardPanel } from './useWorkspaceBoardPanel'
 import { resolveLeftSidebarStyleVariables } from '@/lib/left-sidebar-appearance'
 import { useSystemPrefersDark } from '@/components/terminal-pane/use-system-prefers-dark'
 import { lazyWithRetry } from '@/lib/lazy-with-retry'
+import { ProjectGroupNameDialog } from './ProjectGroupNameDialog'
+import { translate } from '@/i18n/i18n'
 
 const WorktreeMetaDialog = lazyWithRetry(() => import('./WorktreeMetaDialog'))
 const RemoveFolderDialog = lazyWithRetry(() => import('./RemoveFolderDialog'))
@@ -56,6 +58,8 @@ function Sidebar({
     () => resolveLeftSidebarStyleVariables(settings, systemPrefersDark),
     [settings, systemPrefersDark]
   ) as React.CSSProperties | undefined
+  const createProjectGroup = useAppStore((s) => s.createProjectGroup)
+  const [createGroupDialogOpen, setCreateGroupDialogOpen] = React.useState(false)
   const { nativeDropTarget, dropHandlers, affordance } = useSidebarProjectDrop()
   const {
     workspaceBoardOpen,
@@ -115,7 +119,10 @@ function Sidebar({
           <>
             {/* Fixed controls */}
             <SidebarNav />
-            <SidebarHeader onWorkspaceBoardMenuOpenChange={setWorkspaceBoardMenuOpen} />
+            <SidebarHeader
+              onWorkspaceBoardMenuOpenChange={setWorkspaceBoardMenuOpen}
+              onCreateGroup={() => setCreateGroupDialogOpen(true)}
+            />
 
             <WorktreeList
               scrollOffsetRef={worktreeScrollOffsetRef}
@@ -177,6 +184,20 @@ function Sidebar({
 
       {/* Dialogs render outside sidebar to avoid clipping. Lazy-load them only
       for the modal that needs their flow-specific hooks and UI. */}
+      <ProjectGroupNameDialog
+        open={createGroupDialogOpen}
+        title={translate('components.sidebar.projectGroups.createDialogTitle', 'New Project Group')}
+        description={translate(
+          'components.sidebar.projectGroups.createDialogDescription',
+          'Create a group to organize your projects in the sidebar.'
+        )}
+        initialName=""
+        confirmLabel="Create"
+        onOpenChange={setCreateGroupDialogOpen}
+        onSubmit={async (name) => {
+          await createProjectGroup(name)
+        }}
+      />
       <React.Suspense fallback={null}>
         {activeModal === 'edit-meta' ? <WorktreeMetaDialog /> : null}
         {activeModal === 'confirm-remove-folder' ? <RemoveFolderDialog /> : null}

--- a/src/renderer/src/components/sidebar/index.tsx
+++ b/src/renderer/src/components/sidebar/index.tsx
@@ -192,7 +192,10 @@ function Sidebar({
           'Create a group to organize your projects in the sidebar.'
         )}
         initialName=""
-        confirmLabel="Create"
+        confirmLabel={translate(
+          'components.sidebar.projectGroups.createDialogConfirmLabel',
+          'Create'
+        )}
         onOpenChange={setCreateGroupDialogOpen}
         onSubmit={async (name) => {
           await createProjectGroup(name)

--- a/src/renderer/src/components/sidebar/use-add-repo-group-completion.ts
+++ b/src/renderer/src/components/sidebar/use-add-repo-group-completion.ts
@@ -1,0 +1,32 @@
+import { useState, useCallback } from 'react'
+import { useAppStore } from '@/store'
+import type { AddRepoExistingWorkspaceSource } from '../../../../shared/telemetry-events'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
+
+type BaseCompleteGitRepoAdd = (
+  repoId: string,
+  source: AddRepoExistingWorkspaceSource,
+  executionHostId?: ExecutionHostId
+) => Promise<void>
+
+export function useAddRepoGroupCompletion(baseComplete: BaseCompleteGitRepoAdd) {
+  const projectGroups = useAppStore((s) => s.projectGroups)
+  const moveProjectToGroup = useAppStore((s) => s.moveProjectToGroup)
+  const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null)
+
+  const completeGitRepoAdd = useCallback(
+    async (
+      repoId: string,
+      source: AddRepoExistingWorkspaceSource,
+      executionHostId?: ExecutionHostId
+    ): Promise<void> => {
+      await baseComplete(repoId, source, executionHostId)
+      if (selectedGroupId) {
+        await moveProjectToGroup(repoId, selectedGroupId)
+      }
+    },
+    [baseComplete, moveProjectToGroup, selectedGroupId]
+  )
+
+  return { projectGroups, selectedGroupId, setSelectedGroupId, completeGitRepoAdd }
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -16262,6 +16262,17 @@
         "days": "{{value0}}d",
         "underOneMinute": "<1m"
       }
+    },
+    "sidebar": {
+      "projectGroups": {
+        "newGroupLabel": "New Group",
+        "createDialogTitle": "New Project Group",
+        "createDialogDescription": "Create a group to organize your projects in the sidebar."
+      },
+      "addRepo": {
+        "groupSelectorLabel": "Add to group (optional)",
+        "groupSelectorNoGroup": "No group"
+      }
     }
   },
   "dashboardPopout": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -16267,7 +16267,8 @@
       "projectGroups": {
         "newGroupLabel": "New Group",
         "createDialogTitle": "New Project Group",
-        "createDialogDescription": "Create a group to organize your projects in the sidebar."
+        "createDialogDescription": "Create a group to organize your projects in the sidebar.",
+        "createDialogConfirmLabel": "Create"
       },
       "addRepo": {
         "groupSelectorLabel": "Add to group (optional)",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -14522,6 +14522,17 @@
       "sent": "El contexto de la sesión se envió a {{agent}} en una sesión nueva.",
       "deliveryFailed": "La nueva sesión de {{agent}} se inició, pero no se pudo enviar su contexto.",
       "launchFailed": "No se pudo iniciar una sesión nueva de {{agent}}."
+    },
+    "sidebar": {
+      "projectGroups": {
+        "newGroupLabel": "Nuevo grupo",
+        "createDialogTitle": "Nuevo grupo de proyectos",
+        "createDialogDescription": "Crea un grupo para organizar tus proyectos en la barra lateral."
+      },
+      "addRepo": {
+        "groupSelectorLabel": "Añadir al grupo (opcional)",
+        "groupSelectorNoGroup": "Sin grupo"
+      }
     }
   },
   "dashboardPopout": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -14527,7 +14527,8 @@
       "projectGroups": {
         "newGroupLabel": "Nuevo grupo",
         "createDialogTitle": "Nuevo grupo de proyectos",
-        "createDialogDescription": "Crea un grupo para organizar tus proyectos en la barra lateral."
+        "createDialogDescription": "Crea un grupo para organizar tus proyectos en la barra lateral.",
+        "createDialogConfirmLabel": "Crear"
       },
       "addRepo": {
         "groupSelectorLabel": "Añadir al grupo (opcional)",


### PR DESCRIPTION
## ELI5

Groups existed in Orca but you could only create one through the right-click context menu — and only by grouping two existing projects together. If you had projects loaded and just wanted a new empty group, there was no button for that. This adds a direct \"New Group\" button in two places: the sidebar header and the empty-state landing page. It also adds a group selector inside the Add Project dialog so you can assign a project to a group at add time.

## What Changed

- `SidebarHeader`: new icon button using `Layers` from lucide, placed next to the existing `+`. Only visible when the sidebar is in group-by-repo mode. Requires a new `onCreateGroup` prop wired from `Sidebar`.
- `Landing`: new \"New Group\" button alongside the existing Add Project and Create Workspace buttons.
- `AddRepoGroupSelectorSlot`: new component, a small `Select` dropdown that lists existing groups. Renders inside the Add Project dialog when groups are present.
- `AddRepoDialog` + `AddRepoDialogStepContent` + `AddRepoStartSteps`: plumbed the selector through the step content as an optional `groupSelector` slot. After the project is added, `moveProjectToGroup` is called if a group was selected. Group selection resets on dialog close.
- `use-add-repo-group-completion`: new hook that wraps `useCompleteGitRepoAdd` with the group-assignment step. Extracted to keep `AddRepoDialog` under the file line limit.
- `en.json` / `es.json`: translation keys under `components.sidebar.projectGroups` and `components.sidebar.addRepo`.

New button for add groups (layers):
<img width="278" height="63" alt="image" src="https://github.com/user-attachments/assets/f541ee51-6f07-4d2a-a379-e724db09cc37" />

Modal for add group confirm:
<img width="627" height="444" alt="image" src="https://github.com/user-attachments/assets/e58bf2de-2b0b-4ef9-869b-52238d1c3c86" />

New shortcut on main page:

<img width="580" height="245" alt="image" src="https://github.com/user-attachments/assets/b9156760-9bb7-4a02-a268-cbfb3e36a07e" />


## Why

Group creation was only reachable via context menu, which is not obvious to new users. The sidebar header and landing page are the two natural places to surface a create action. The group selector in Add Project saves an extra drag-and-drop step after adding a project.

## Linked Issue

Not found any issue related.

## Visual Proof

Three surfaces changed visually:

- Sidebar header: `Layers` icon button appears next to `+` when the sidebar is grouped by repo
- Landing page: \"New Group\" button in the empty-state action row
- Add Project dialog (step 1): group selector dropdown appears above the primary actions when groups exist

Screenshots not attached — straightforward to verify by running the app with at least one existing project group.

## Testing

- [x] I manually tested these changes locally
- [ ] Automated tests added/updated, or explained why not below

`SidebarHeader.test.tsx` updated to pass the required `onCreateGroup` prop. No new tests for `AddRepoGroupSelectorSlot` or the landing button: both are thin presentational wrappers over existing primitives with no conditional logic beyond a length check.

## AI Disclosure

Developed with Claude Code (claude-sonnet-4-6).

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)