### PR TITLE
fix(codex): show unlimited Business usage

### DIFF
--- a/src/main/rate-limits/codex-fetcher-backend.test.ts
+++ b/src/main/rate-limits/codex-fetcher-backend.test.ts
@@ -97,6 +97,54 @@ describe('Codex backend rate-limit requests', () => {
     )
   })
 
+  it('maps unlimited usage from the backend response used by WSL', async () => {
+    readFileMock.mockResolvedValue(
+      JSON.stringify({ tokens: { access_token: 'access-token', account_id: 'account-id' } })
+    )
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          plan_type: 'business',
+          rate_limit: null,
+          credits: { unlimited: true }
+        })
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ available_count: 0, credits: [] })
+      } as Response)
+
+    await expect(
+      fetchCodexRateLimits({
+        codexHomePath: '\\\\wsl.localhost\\Ubuntu\\home\\alice\\.local\\share\\orca\\account\\home'
+      })
+    ).resolves.toMatchObject({ planType: 'business', isUnlimited: true, status: 'ok' })
+    expect(childSpawnMock).not.toHaveBeenCalled()
+    expect(ptySpawnMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects empty non-unlimited backend usage and continues to the CLI fallback', async () => {
+    readFileMock.mockResolvedValue(
+      JSON.stringify({ tokens: { access_token: 'access-token', account_id: 'account-id' } })
+    )
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ plan_type: 'plus', rate_limit: null })
+    } as Response)
+    childSpawnMock.mockImplementation(() => {
+      throw new Error('spawn failed')
+    })
+
+    await expect(
+      fetchCodexRateLimits({
+        codexHomePath: '\\\\wsl.localhost\\Ubuntu\\home\\alice\\.local\\share\\orca\\account\\home',
+        allowPtyFallback: false
+      })
+    ).resolves.toMatchObject({ status: 'error', error: 'RPC failed' })
+    expect(childSpawnMock).toHaveBeenCalled()
+  })
+
   it('classifies a sole seven-day backend primary window as weekly', async () => {
     readFileMock.mockResolvedValue(
       JSON.stringify({

--- a/src/main/rate-limits/codex-fetcher.test.ts
+++ b/src/main/rate-limits/codex-fetcher.test.ts
@@ -356,20 +356,20 @@ describe('fetchCodexRateLimits', () => {
     })
   })
 
-  it('does not start the PTY fallback when disabled for background account previews', async () => {
+  it('rejects empty non-unlimited RPC usage without a PTY fallback when disabled', async () => {
     const rpcChild = makeRpcChild()
     childSpawnMock.mockReturnValue(rpcChild)
+    respondToRpcRateLimitRead(rpcChild, { planType: 'plus' })
 
     const resultPromise = fetchCodexRateLimits({ allowPtyFallback: false })
-    await vi.advanceTimersByTimeAsync(0)
-    rpcChild.emit('close')
-    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(2)
 
     await expect(resultPromise).resolves.toMatchObject({
       provider: 'codex',
       session: null,
       weekly: null,
-      status: 'error'
+      status: 'error',
+      error: 'RPC response did not include rate-limit windows'
     })
     expect(rpcChild.stdin.listenerCount('error')).toBe(0)
     expect(ptySpawnMock).not.toHaveBeenCalled()
@@ -413,6 +413,18 @@ describe('fetchCodexRateLimits', () => {
 
     expect(result.session?.windowMinutes).toBe(300)
     expect(result.weekly?.windowMinutes).toBe(10080)
+  })
+
+  it('maps an unlimited Codex account without falling back to the PTY reader', async () => {
+    const rpcChild = makeRpcChild()
+    childSpawnMock.mockReturnValue(rpcChild)
+    respondToRpcRateLimitRead(rpcChild, { credits: { unlimited: true }, planType: 'business' })
+    const resultPromise = fetchCodexRateLimits()
+    await vi.advanceTimersByTimeAsync(2)
+    const result = await resultPromise
+    expect(result.planType).toBe('business')
+    expect(result.isUnlimited).toBe(true)
+    expect(ptySpawnMock).not.toHaveBeenCalled()
   })
 
   it('keeps a weekly-only Codex primary window out of the 5-hour slot', async () => {

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -93,7 +93,12 @@ type RateLimitResetCredits = {
 
 // Why: the Codex app-server wraps rate limit data as { rateLimits: { primary, secondary, ... } }.
 type RpcRateLimitsResponse = {
-  rateLimits?: CodexRateLimitWindowsSnapshot | null
+  rateLimits?:
+    | (CodexRateLimitWindowsSnapshot & {
+        credits?: { unlimited?: boolean } | null
+        planType?: string | null
+      })
+    | null
   rateLimitResetCredits?: {
     availableCount?: number
     totalEarnedCount?: number
@@ -131,6 +136,7 @@ type BackendRateLimitWindow = {
 
 type BackendUsageResponse = {
   plan_type?: string
+  credits?: { unlimited?: boolean } | null
   rate_limit?: {
     primary_window?: BackendRateLimitWindow | null
     secondary_window?: BackendRateLimitWindow | null
@@ -556,6 +562,10 @@ async function fetchViaBackend(
     primary: backendWindowToSnapshot(payload.rate_limit?.primary_window),
     secondary: backendWindowToSnapshot(payload.rate_limit?.secondary_window)
   })
+  const isUnlimited = payload.credits?.unlimited === true
+  if (!classified.session && !classified.weekly && !isUnlimited) {
+    return null
+  }
   return {
     provider: 'codex',
     session: mapRpcWindow(
@@ -568,6 +578,7 @@ async function fetchViaBackend(
     ),
     // Surfaced for the status-bar Usage row (e.g. "Codex · Plus").
     planType: payload.plan_type,
+    ...(isUnlimited ? { isUnlimited: true } : {}),
     ...(payload.rate_limit_reset_credits !== undefined
       ? {
           rateLimitResetCredits:
@@ -807,6 +818,25 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
             const rateLimitResetCredits = mapRpcRateLimitResetCredits(
               wrapper?.rateLimitResetCredits
             )
+            const planType =
+              typeof result?.planType === 'string' && result.planType.trim()
+                ? result.planType
+                : undefined
+            const isUnlimited = result?.credits?.unlimited === true
+            if (!session && !weekly && !isUnlimited) {
+              settle(
+                {
+                  provider: 'codex',
+                  session: null,
+                  weekly: null,
+                  updatedAt: Date.now(),
+                  error: 'RPC response did not include rate-limit windows',
+                  status: 'error'
+                },
+                { kill: true }
+              )
+              return
+            }
 
             settle(
               {
@@ -814,6 +844,8 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
                 session,
                 weekly,
                 ...(rateLimitResetCredits !== undefined ? { rateLimitResetCredits } : {}),
+                ...(planType !== undefined ? { planType } : {}),
+                ...(isUnlimited ? { isUnlimited: true } : {}),
                 updatedAt: Date.now(),
                 error: null,
                 status: 'ok'

--- a/src/main/rate-limits/service-refresh-orchestration.test.ts
+++ b/src/main/rate-limits/service-refresh-orchestration.test.ts
@@ -174,6 +174,31 @@ describe('RateLimitService', () => {
     expect(state.claude?.error).toBe('still failing')
   })
 
+  it('keeps recent unlimited usage through a transient refresh failure', async () => {
+    const service = new RateLimitService()
+    const internal = serviceInternals(service)
+    vi.mocked(fetchClaudeRateLimits).mockResolvedValue(okProvider('claude', 0))
+    vi.mocked(fetchCodexRateLimits)
+      .mockResolvedValueOnce({
+        ...okProvider('codex', 0, Date.now()),
+        session: null,
+        weekly: null,
+        planType: 'business',
+        isUnlimited: true
+      })
+      .mockResolvedValueOnce(errorProvider('codex', 'temporary failure'))
+
+    await internal.fetchAll()
+    await internal.fetchAll()
+
+    expect(service.getState().codex).toMatchObject({
+      planType: 'business',
+      isUnlimited: true,
+      status: 'error',
+      error: 'temporary failure'
+    })
+  })
+
   it('bypasses the debounce for explicit manual refreshes', async () => {
     const service = new RateLimitService()
 

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -2104,6 +2104,7 @@ export class RateLimitService {
     }
 
     const previousHasData = Boolean(
+      previous?.isUnlimited ||
       previous?.session ||
       previous?.weekly ||
       previous?.fableWeekly ||

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -1042,7 +1042,11 @@ export function InlineUsageBars({
           </span>
         </div>
       ))}
-      {usageWindows.length === 0 && limits.status === 'error' ? (
+      {limits.isUnlimited ? (
+        <span className="text-[10px] text-muted-foreground">
+          {translate('auto.components.status.bar.StatusBar.unlimitedUsage', 'Unlimited')}
+        </span>
+      ) : usageWindows.length === 0 && limits.status === 'error' ? (
         <span className="text-[10px] text-muted-foreground">
           {translate('auto.components.status.bar.StatusBar.f19a63e7cd', 'Sign in to see usage')}
         </span>
@@ -1052,7 +1056,13 @@ export function InlineUsageBars({
 }
 
 function isUnavailableInactiveUsage(limits: ProviderRateLimits | null | undefined): boolean {
-  return limits?.status === 'error' && !limits.session && !limits.weekly && !limits.fableWeekly
+  return (
+    limits?.status === 'error' &&
+    !limits.isUnlimited &&
+    !limits.session &&
+    !limits.weekly &&
+    !limits.fableWeekly
+  )
 }
 
 function InlineUsageSignInAction({
@@ -1133,7 +1143,9 @@ function WindowLabel({
 // the roster trigger and ProviderDetailsMenu so the dot's has-data condition
 // and markup can't drift between the two.
 function ProviderLetterBadge({ p }: { p: ProviderRateLimits }): React.JSX.Element {
-  const hasData = Boolean(p.session || p.weekly || p.fableWeekly || p.monthly || p.buckets?.length)
+  const hasData = Boolean(
+    p.isUnlimited || p.session || p.weekly || p.fableWeekly || p.monthly || p.buckets?.length
+  )
   return (
     <span className="inline-flex items-center gap-1 text-muted-foreground">
       <span
@@ -1275,7 +1287,7 @@ export function ProviderSegment({
   const tightest = getTightestUsageSection(p)
 
   // Fetching with no prior data
-  if (p.status === 'fetching' && !tightest) {
+  if (p.status === 'fetching' && !tightest && !p.isUnlimited) {
     return (
       <span className="inline-flex items-center gap-1 text-muted-foreground">
         <ProviderIcon provider={provider} />
@@ -1294,7 +1306,7 @@ export function ProviderSegment({
   }
 
   // Error with no data
-  if (p.status === 'error' && !tightest) {
+  if (p.status === 'error' && !tightest && !p.isUnlimited) {
     return (
       <span className="inline-flex items-center gap-1 text-muted-foreground">
         <ProviderIcon provider={provider} />
@@ -1310,7 +1322,11 @@ export function ProviderSegment({
   return (
     <span className="inline-flex items-center gap-1.5">
       <ProviderIcon provider={provider} />
-      {mode === 'verbose' ? (
+      {p.isUnlimited && !compact ? (
+        <span className="text-[11px] font-medium">
+          {translate('auto.components.status.bar.StatusBar.unlimitedUsage', 'Unlimited')}
+        </span>
+      ) : mode === 'verbose' ? (
         <>
           {tightest && !compact ? (
             <MiniBar usedPct={clampUsedPercent(tightest.window.usedPercent)} display={display} />

--- a/src/renderer/src/components/status-bar/codex-status-sign-in.test.tsx
+++ b/src/renderer/src/components/status-bar/codex-status-sign-in.test.tsx
@@ -71,6 +71,7 @@ const unavailableUsage: ProviderRateLimits = {
   error: 'Not signed in',
   updatedAt: 1
 } as unknown as ProviderRateLimits
+let inactiveUsage = unavailableUsage
 
 vi.mock('sonner', () => ({
   toast: { success: toastSuccess, error: toastError }
@@ -158,7 +159,7 @@ vi.mock('../../store', () => {
     fetchInactiveCodexAccountUsage,
     rateLimits: {
       inactiveCodexAccounts: [
-        { accountId: 'account-2', isFetching: false, rateLimits: unavailableUsage }
+        { accountId: 'account-2', isFetching: false, rateLimits: inactiveUsage }
       ],
       codexTarget: { runtime: 'host', wslDistro: null }
     }
@@ -196,6 +197,7 @@ describe('status bar Codex sign-in action', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     storeSettings = settingsWithActive(null)
+    inactiveUsage = unavailableUsage
     Object.defineProperty(window, 'api', {
       configurable: true,
       writable: true,
@@ -205,6 +207,28 @@ describe('status bar Codex sign-in action', () => {
 
   afterEach(() => {
     cleanup()
+  })
+
+  it('does not offer sign-in for stale unlimited inactive usage', async () => {
+    inactiveUsage = {
+      ...unavailableUsage,
+      isUnlimited: true,
+      error: 'temporary failure'
+    }
+    const { CodexSwitcherMenu } = await import('./StatusBar')
+    render(
+      React.createElement(CodexSwitcherMenu, {
+        codex: codexProvider,
+        compact: false,
+        iconOnly: false
+      })
+    )
+
+    fireEvent.click(screen.getByText('System default'))
+
+    await waitFor(() => expect(screen.getByText('Unlimited')).toBeTruthy())
+    expect(screen.queryByRole('button', { name: /Sign in/ })).toBeNull()
+    expect(screen.queryByText('Sign in to see usage')).toBeNull()
   })
 
   it('activates the signed-in account and runs the same restart workflow a switch runs', async () => {

--- a/src/renderer/src/components/status-bar/inline-usage-bars.test.tsx
+++ b/src/renderer/src/components/status-bar/inline-usage-bars.test.tsx
@@ -124,6 +124,24 @@ describe('InlineUsageBars', () => {
     expect(markup).toContain('37% used wk')
   })
 
+  it('renders unlimited inactive Codex usage without sign-in copy', async () => {
+    const { InlineUsageBars } = await import('./StatusBar')
+    const limits: ProviderRateLimits = {
+      provider: 'codex',
+      session: null,
+      weekly: null,
+      isUnlimited: true,
+      updatedAt: Date.now(),
+      error: 'temporary failure',
+      status: 'error'
+    }
+
+    const markup = renderToStaticMarkup(<InlineUsageBars limits={limits} isFetching={false} />)
+
+    expect(markup).toContain('Unlimited')
+    expect(markup).not.toContain('Sign in to see usage')
+  })
+
   it('shows remaining copy and remaining meter fill', async () => {
     mocks.usagePercentageDisplay = 'remaining'
     const { InlineUsageBars } = await import('./StatusBar')

--- a/src/renderer/src/components/status-bar/provider-segment-monthly-window.test.tsx
+++ b/src/renderer/src/components/status-bar/provider-segment-monthly-window.test.tsx
@@ -70,6 +70,27 @@ describe('ProviderSegment monthly window', () => {
     expect(markup).not.toContain('···')
   })
 
+  it('renders stale unlimited Codex usage instead of a refresh failure', async () => {
+    const { ProviderSegment } = await import('./StatusBar')
+    const limits: ProviderRateLimits = {
+      provider: 'codex',
+      session: null,
+      weekly: null,
+      planType: 'business',
+      isUnlimited: true,
+      updatedAt: Date.now(),
+      error: 'temporary failure',
+      status: 'error'
+    }
+
+    const markup = renderToStaticMarkup(
+      <ProviderSegment p={limits} compact={false} display="used" mode="compact" />
+    )
+
+    expect(markup).toContain('Unlimited')
+    expect(markup).not.toContain('Refresh failed')
+  })
+
   it('shows only the highest-used window when several windows exist', async () => {
     const { ProviderSegment } = await import('./StatusBar')
 

--- a/src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts
+++ b/src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts
@@ -61,6 +61,7 @@ describe('isProviderConfigured', () => {
         })
       )
     ).toBe(true)
+    expect(isProviderConfigured(provider('fetching', { isUnlimited: true }))).toBe(true)
     expect(isProviderConfigured(provider('idle'))).toBe(true)
   })
 })

--- a/src/renderer/src/components/status-bar/status-bar-provider-visibility.ts
+++ b/src/renderer/src/components/status-bar/status-bar-provider-visibility.ts
@@ -34,6 +34,7 @@ type UsageProviderId = ProviderRateLimits['provider']
 
 function hasUsageData(provider: ProviderRateLimits): boolean {
   return Boolean(
+    provider.isUnlimited ||
     provider.session ||
     provider.weekly ||
     provider.fableWeekly ||

--- a/src/renderer/src/components/status-bar/tooltip.test.ts
+++ b/src/renderer/src/components/status-bar/tooltip.test.ts
@@ -469,6 +469,21 @@ describe('ProviderPanel reset rendering', () => {
     expect(markup).toContain('Resets in 6d 17h')
   })
 
+  it('renders stale unlimited usage alongside its refresh error', () => {
+    const p = provider({
+      provider: 'codex',
+      planType: 'business',
+      isUnlimited: true,
+      error: 'temporary failure'
+    })
+
+    const markup = renderToStaticMarkup(ProviderPanel({ p }))
+
+    expect(markup).toContain('Unlimited usage')
+    expect(markup).toContain('temporary failure')
+    expect(markup).toContain('Refresh failed — showing cached data')
+  })
+
   it('renders MiniMax session as usedPercent so the value matches the bar', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date(2026, 6, 4, 15, 0))

--- a/src/renderer/src/components/status-bar/tooltip.tsx
+++ b/src/renderer/src/components/status-bar/tooltip.tsx
@@ -280,7 +280,14 @@ export function ProviderPanel({
     )
   }
 
-  if (p.status === 'error' && !p.session && !p.weekly && !p.fableWeekly && !p.monthly) {
+  if (
+    p.status === 'error' &&
+    !p.isUnlimited &&
+    !p.session &&
+    !p.weekly &&
+    !p.fableWeekly &&
+    !p.monthly
+  ) {
     return (
       <div className={`text-xs ${className ?? 'w-full'}`}>
         <div className={`flex items-center gap-1.5 font-medium ${textClass}`}>
@@ -335,22 +342,28 @@ export function ProviderPanel({
 
       <div className={`border-t ${dividerClass}`} />
 
-      {getWindowSections(p).map((s) => (
-        <ProviderRateLimitWindowSection
-          key={s.label}
-          window={s.window}
-          label={s.label}
-          textClass={textClass}
-          mutedClass={mutedClass}
-          emptyBarClass={emptyBarClass}
-          usagePercentageDisplay={usagePercentageDisplay}
-        />
-      ))}
+      {p.isUnlimited ? (
+        <div className={textClass}>
+          {translate('auto.components.status.bar.tooltip.unlimitedUsage', 'Unlimited usage')}
+        </div>
+      ) : (
+        getWindowSections(p).map((s) => (
+          <ProviderRateLimitWindowSection
+            key={s.label}
+            window={s.window}
+            label={s.label}
+            textClass={textClass}
+            mutedClass={mutedClass}
+            emptyBarClass={emptyBarClass}
+            usagePercentageDisplay={usagePercentageDisplay}
+          />
+        ))
+      )}
 
       {p.error ? (
         <ErrorMessage
           message={p.error}
-          stale={!!(p.session || p.weekly || p.fableWeekly || p.monthly)}
+          stale={!!(p.isUnlimited || p.session || p.weekly || p.fableWeekly || p.monthly)}
           inverted={inverted}
         />
       ) : null}

--- a/src/renderer/src/components/status-bar/usage-roster-row-state.test.ts
+++ b/src/renderer/src/components/status-bar/usage-roster-row-state.test.ts
@@ -82,6 +82,15 @@ describe('getUsageRosterRowState', () => {
     ).toEqual({ kind: 'error', statusLabel: 'Refresh failed' })
   })
 
+  it('shows unlimited accounts as a successful unmetered state', () => {
+    expect(
+      getUsageRosterRowState(
+        provider({ provider: 'codex', planType: 'business', isUnlimited: true }),
+        false
+      )
+    ).toEqual({ kind: 'unlimited', statusLabel: 'Unlimited' })
+  })
+
   it('distinguishes unavailable and empty successful responses', () => {
     expect(
       getUsageRosterRowState(

--- a/src/renderer/src/components/status-bar/usage-roster-row-state.ts
+++ b/src/renderer/src/components/status-bar/usage-roster-row-state.ts
@@ -3,7 +3,7 @@ import type { ProviderRateLimits } from '../../../../shared/rate-limit-types'
 import { getProviderUsageStatusLabel } from './usage-error-copy'
 
 export type UsageRosterRowState = {
-  kind: 'usage' | 'loading' | 'sign-in' | 'unavailable' | 'error' | 'empty'
+  kind: 'usage' | 'unlimited' | 'loading' | 'sign-in' | 'unavailable' | 'error' | 'empty'
   statusLabel: string | null
 }
 
@@ -36,6 +36,15 @@ export function getUsageRosterRowState(
 ): UsageRosterRowState {
   if (hasUsage) {
     return { kind: 'usage', statusLabel: null }
+  }
+  if (provider.isUnlimited) {
+    return {
+      kind: 'unlimited',
+      statusLabel: translate(
+        'auto.components.status.bar.UsageRosterPanel.unlimitedUsage',
+        'Unlimited'
+      )
+    }
   }
   if (provider.status === 'idle' || provider.status === 'fetching') {
     return {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3510,7 +3510,8 @@
             "grokUsageMenu": "Grok Usage",
             "floatingTerminalNewActivity": "{{label}}, new activity",
             "codexSignInSuccess": "Signed in to Codex",
-            "codexSignInError": "Codex sign-in failed. Please try again."
+            "codexSignInError": "Codex sign-in failed. Please try again.",
+            "unlimitedUsage": "Unlimited"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "Connect an account",
@@ -3689,7 +3690,8 @@
             "e2c6a4f917": "Run Grok to refresh",
             "d1b7f509ac": "Run grok in a terminal on the computer running Orca and wait for it to start. If prompted, complete sign-in, then retry usage. You do not need to send a chat message.",
             "f90b3d7a16": "Run Kimi to refresh",
-            "a37e8c15d4": "Run kimi in a terminal on the computer running Orca and wait for it to start, then retry usage."
+            "a37e8c15d4": "Run kimi in a terminal on the computer running Orca and wait for it to start, then retry usage.",
+            "unlimitedUsage": "Unlimited usage"
           },
           "SshTargetStatusRow": {
             "sshHost": "SSH Host"
@@ -3718,7 +3720,8 @@
             "compact": "Compact",
             "detailedTooltip": "Full usage with bars, labels, and percentages",
             "compactTooltip": "Condensed usage: only the tightest window",
-            "footerDetailAria": "Usage footer detail"
+            "footerDetailAria": "Usage footer detail",
+            "unlimitedUsage": "Unlimited"
           },
           "RemoteServerUpdateStatusSegment": {
             "updating": "Updating {{value0}}/{{value1}}",

--- a/src/shared/rate-limit-types.ts
+++ b/src/shared/rate-limit-types.ts
@@ -80,6 +80,8 @@ export type ProviderRateLimits = {
   } | null
   /** Subscription plan tier for the active account (Codex `plan_type`, e.g. "plus"). */
   planType?: string | null
+  /** Whether the provider reports unmetered usage instead of rate-limit windows. */
+  isUnlimited?: boolean
   /** Unix ms timestamp of the last successful data update. */
   updatedAt: number
   /** Human-readable error message, null when status is 'ok'. */


### PR DESCRIPTION
## ELI5

Codex Business accounts can have unlimited usage instead of percentage-based limits. Orca now recognizes that response and shows `Unlimited` instead of reporting a refresh failure.

## What Changed

- Map unlimited usage and plan metadata from both app-server RPC and the backend path used by WSL.
- Preserve unlimited snapshots through transient refresh failures.
- Render `Codex · Business Unlimited` in the usage roster, status bar, details panel, and inactive account previews.

Codex app-server launch compatibility is handled by #15823 and is not changed by this PR.

## Why

Business accounts return no primary or secondary rate-limit windows and explicitly report `credits.unlimited: true`. The previous parser treated the missing windows as a failure, fell back to the PTY reader, and eventually timed out. Modeling the explicit unlimited state keeps metered and unmetered accounts distinct without inventing a percentage window.

## Linked Issue

Fixes #15764

## Visual Proof

**Before**

<img width="275" height="27" alt="Codex usage refresh failure before this change" src="https://github.com/user-attachments/assets/d069c900-c2ba-4fe3-ad65-484558a377b5" />

**After**

<img width="800" height="650" alt="Codex Business unlimited usage after this change" src="https://github.com/user-attachments/assets/5b62de68-ebb6-4a36-ad9f-55b6607dcb86" />

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Verified on macOS with a real Codex Business account. The RPC result reported `planType: business`, `isUnlimited: true`, and `status: ok`; the dev UI rendered `Codex · Business Unlimited`.

- `pnpm typecheck` — passed after rebasing onto `upstream/main`
- Changed-code quality and React Doctor — passed with no new findings
- Focused regression suite — 147 tests passed across 9 files
- Localization catalog, extraction, and coverage checks — passed
- Earlier full validation: `pnpm lint`, `pnpm build`, and the complete test suite were run before the rebase. The full suite reported 56,801 passes and 14 failures in unrelated files; serial reruns passed 1,266 tests, with three environment-dependent assertions remaining. None of those files differ in this PR; CI will run the suite in its standard environment.

Cross-platform coverage: the WSL backend response has a regression test. Windows/SSH/mobile were not manually exercised; the shared wire field is optional for mixed-version compatibility.

## Author

X (Twitter): [@hgijeon](https://x.com/hgijeon)

## AI Disclosure

OpenAI Codex with GPT-5.6 was used to investigate, implement, and test this change. The author reviewed the resulting diff and validation output.

## Review

The production change is limited to Codex rate-limit ingestion and existing usage presentation surfaces. No auth material is logged or persisted by this change.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Security: this PR does not alter the app-server launch contract; #15823 keeps it read-only and non-interactive. Cross-platform support: local RPC and WSL backend paths both map unlimited usage. Remote compatibility: `isUnlimited` is optional, so older peers ignore it and newer peers tolerate its absence. Performance is unchanged beyond parsing two scalar fields.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
