### PR TITLE
fix(ai-vault): restore Antigravity workspace metadata

### DIFF
--- a/src/main/ai-vault/session-scanner-antigravity-history.ts
+++ b/src/main/ai-vault/session-scanner-antigravity-history.ts
@@ -28,7 +28,10 @@ type AntigravityHistoryEntry = {
   workspace: string
 }
 
-type AntigravityHistoryIndex = Map<string, AntigravityHistoryEntry[]>
+type AntigravityHistoryIndex = {
+  byConversationId: Map<string, AntigravityHistoryEntry>
+  byDisplay: Map<string, AntigravityHistoryEntry[]>
+}
 
 export type AntigravityWorkspaceResolver = {
   enrich(session: AiVaultSession, historyPath: string): Promise<AiVaultSession>
@@ -67,18 +70,31 @@ export function createAntigravityWorkspaceResolver(
 }
 
 function indexAntigravityHistory(content: string | null): AntigravityHistoryIndex {
-  const index: AntigravityHistoryIndex = new Map()
+  const index: AntigravityHistoryIndex = {
+    byConversationId: new Map(),
+    byDisplay: new Map()
+  }
   for (const line of content?.split(/\r?\n/) ?? []) {
     const record = parseJsonObject(line)
     const display = typeof record?.display === 'string' ? normalizeTitleText(record.display) : null
     const workspace = typeof record?.workspace === 'string' ? record.workspace.trim() : ''
+    const conversationId =
+      typeof record?.conversationId === 'string' ? record.conversationId.trim() : ''
     const entryTimestampMs = timestampMs(record?.timestamp)
-    if (!display || !workspace || !Number.isFinite(entryTimestampMs)) {
+    if (!workspace || !Number.isFinite(entryTimestampMs)) {
       continue
     }
-    const entries = index.get(display) ?? []
-    entries.push({ timestampMs: entryTimestampMs, workspace })
-    index.set(display, entries)
+    const entry = { timestampMs: entryTimestampMs, workspace }
+    const directEntry = index.byConversationId.get(conversationId)
+    if (conversationId && (!directEntry || entryTimestampMs < directEntry.timestampMs)) {
+      index.byConversationId.set(conversationId, entry)
+    }
+    if (!display) {
+      continue
+    }
+    const entries = index.byDisplay.get(display) ?? []
+    entries.push(entry)
+    index.byDisplay.set(display, entries)
   }
   return index
 }
@@ -87,6 +103,10 @@ function findAntigravityWorkspace(
   session: AiVaultSession,
   index: AntigravityHistoryIndex
 ): string | null {
+  const directMatch = index.byConversationId.get(session.sessionId)
+  if (directMatch) {
+    return directMatch.workspace
+  }
   // Why: truncated titles are not prompt identities; long worker prompts often
   // share the same 96-character prefix across unrelated workspaces.
   if (session.title.endsWith('...')) {
@@ -99,10 +119,10 @@ function findAntigravityWorkspace(
   if (!Number.isFinite(promptTimestampMs)) {
     return null
   }
-  const matches = (index.get(session.title) ?? []).filter(
+  const matches = (index.byDisplay.get(session.title) ?? []).filter(
     (entry) => Math.abs(entry.timestampMs - promptTimestampMs) <= HISTORY_MATCH_WINDOW_MS
   )
-  // Why: history rows have no conversation id. A unique prompt/time match is
-  // evidence for cwd; ambiguity must stay unknown instead of crossing projects.
+  // Why: legacy history rows have no conversation id. A unique prompt/time
+  // match is evidence for cwd; ambiguity must stay unknown instead of crossing projects.
   return matches.length === 1 ? (matches[0]?.workspace ?? null) : null
 }

--- a/src/main/ai-vault/session-scanner-antigravity-source.test.ts
+++ b/src/main/ai-vault/session-scanner-antigravity-source.test.ts
@@ -105,6 +105,44 @@ describe('Antigravity AI Vault discovery', () => {
     ).toEqual([sessionId])
   })
 
+  it('uses the conversation id when an earlier setup prompt became the session title', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-antigravity-conversation-id-'))
+    tempRoots.push(root)
+    const roots = isolatedScanRoots(root)
+    const sessionId = 'dddddddd-eeee-4fff-8aaa-bbbbbbbbbbbb'
+    const workspace = join(root, 'active-workspace')
+    await writeAntigravityTranscript(roots.antigravityBrainDir, sessionId, [
+      {
+        source: 'USER_EXPLICIT',
+        type: 'USER_INPUT',
+        created_at: '2026-07-15T11:39:10.000Z',
+        content: '<USER_REQUEST>Connectivity setup only</USER_REQUEST>'
+      },
+      {
+        source: 'USER_EXPLICIT',
+        type: 'USER_INPUT',
+        created_at: '2026-07-15T11:40:00.000Z',
+        content: `<USER_REQUEST>${'long dispatched worker prompt '.repeat(8)}</USER_REQUEST>`
+      }
+    ])
+    await writeAntigravityHistory(roots.antigravityBrainDir, [
+      {
+        conversationId: sessionId,
+        display: 'A later prompt with a different title',
+        timestamp: Date.parse('2026-07-15T11:40:00.100Z'),
+        workspace
+      }
+    ])
+
+    const result = await scanAiVaultSessions({ ...roots, platform: 'darwin' })
+
+    expect(result.sessions[0]).toMatchObject({
+      sessionId,
+      title: 'Connectivity setup only',
+      cwd: workspace
+    })
+  })
+
   it('keeps workspace unknown when matching history rows are ambiguous', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-antigravity-ambiguous-'))
     tempRoots.push(root)


### PR DESCRIPTION
## ELI5

Antigravity already records a conversation ID alongside its workspace. Use that exact ID instead of guessing from prompt text, so conversations that begin with setup prompts still appear in the correct workspace history.

## What Changed

- Index Antigravity history rows by `conversationId` and by the existing normalized display text.
- Prefer the direct conversation-ID match when enriching workspace metadata.
- Keep the conservative title/timestamp fallback for legacy history rows without a conversation ID.
- Add a regression test for a conversation whose setup prompt becomes the session title while a later prompt carries the workspace record.

## Why

The transcript parser titles a session from its first user prompt. Antigravity history may only record a later prompt, so the existing title/timestamp join leaves `cwd` unset even though the history row has the same stable conversation ID. Matching that identifier is both more reliable and safer than broadening truncated-title matching.

## Linked Issue

Fixes #15774

## Visual Proof

N/A — this is a metadata parser fix with no UI code changes; the workspace-filter behavior is covered by the regression test.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Validated locally:

- `vitest` targeted Antigravity parser and source suites: 8 tests passed
- Node TypeScript project typecheck
- `oxlint` on both changed files
- `oxfmt --check` on both changed files
- `git diff --check`

## AI Disclosure

GPT-5.6 Sol via Pi assisted with diagnosis, implementation, and test drafting. The change was reviewed against the repository's existing Antigravity history safety constraints.

## Review

The direct join only accepts an exact conversation ID. The earliest valid history row wins if a conversation has multiple workspace entries, preserving origin-workspace semantics. Legacy rows retain the existing ambiguity and truncated-title protections.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

The change is path-independent and reuses the same history transport for local, WSL, and remote scans. It adds one bounded map lookup per session and preserves backward compatibility with history rows that omit `conversationId`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
