### PR TITLE
fix(sidebar): spin the dot for an agent the user started by hand

### DIFF
--- a/src/renderer/src/components/sidebar/use-worktree-activity-status.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-activity-status.ts
@@ -29,7 +29,8 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
     hasInterrupted,
     hasLiveDone,
     hasRetainedDone,
-    agentStatusPaneIdsByTabId
+    agentStatusPaneIdsByTabId,
+    foregroundAgentPaneIdsByTabId
   } = useAppStore(useShallow((s) => selectWorktreeAgentActivitySummary(s, worktreeId)))
 
   // Why: compact and detailed cards need the same status-dot semantics:
@@ -43,6 +44,7 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
         ptyIdsByTabId: ptyIdsForWorktree,
         runtimePaneTitlesByTabId: runtimePaneTitlesForWorktree,
         agentStatusPaneIdsByTabId,
+        foregroundAgentPaneIdsByTabId,
         terminalLayoutRootsByTabId,
         hasPermission,
         hasLiveWorking,
@@ -57,6 +59,7 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
       ptyIdsForWorktree,
       runtimePaneTitlesForWorktree,
       agentStatusPaneIdsByTabId,
+      foregroundAgentPaneIdsByTabId,
       terminalLayoutRootsByTabId,
       hasPermission,
       hasLiveWorking,

--- a/src/renderer/src/components/sidebar/use-worktree-activity-statuses.test.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-activity-statuses.test.ts
@@ -15,7 +15,8 @@ function makeStatusState(): StatusState {
     agentStatusByPaneKey: {},
     migrationUnsupportedByPtyId: {},
     retainedAgentsByPaneKey: {},
-    runtimeAgentOrchestrationByPaneKey: {}
+    runtimeAgentOrchestrationByPaneKey: {},
+    paneForegroundAgentByPaneKey: {}
   }
 }
 

--- a/src/renderer/src/components/sidebar/use-worktree-activity-statuses.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-activity-statuses.ts
@@ -22,6 +22,7 @@ type WorktreeActivityStatusState = Pick<
   | 'migrationUnsupportedByPtyId'
   | 'retainedAgentsByPaneKey'
   | 'runtimeAgentOrchestrationByPaneKey'
+  | 'paneForegroundAgentByPaneKey'
 >
 
 export function selectWorktreeActivityStatuses(
@@ -37,7 +38,8 @@ export function selectWorktreeActivityStatuses(
       hasInterrupted,
       hasLiveDone,
       hasRetainedDone,
-      agentStatusPaneIdsByTabId
+      agentStatusPaneIdsByTabId,
+      foregroundAgentPaneIdsByTabId
     } = selectWorktreeAgentActivitySummary(statusInputs, worktreeId)
     statuses.set(
       worktreeId,
@@ -47,6 +49,7 @@ export function selectWorktreeActivityStatuses(
         ptyIdsByTabId: selectLivePtyIdsForWorktree(statusInputs, worktreeId),
         runtimePaneTitlesByTabId: selectRuntimePaneTitlesForWorktree(statusInputs, worktreeId),
         agentStatusPaneIdsByTabId,
+        foregroundAgentPaneIdsByTabId,
         terminalLayoutRootsByTabId: selectTerminalLayoutRootsForWorktree(statusInputs, worktreeId),
         hasPermission,
         hasLiveWorking,

--- a/src/renderer/src/components/sidebar/worktree-agent-activity-summary.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-activity-summary.test.ts
@@ -441,3 +441,40 @@ describe('selectWorktreeAgentActivitySummary', () => {
     expect(summary.agentStatusPaneIdsByTabId['tab-parent']).toEqual(new Set([LEAF_ID]))
   })
 })
+
+// Why: process-table identity is what lets the dot attribute a bare agent status
+// title to the pane that owns it, so the summary must carry it per worktree.
+describe('selectWorktreeAgentActivitySummary foreground agent panes', () => {
+  const worktreeId = 'repo::/wt-1'
+
+  function stateWithForegroundAgent(
+    agent: 'claude' | null
+  ): Parameters<typeof selectWorktreeAgentActivitySummary>[0] {
+    return {
+      tabsByWorktree: { [worktreeId]: [makeTab('tab-1', worktreeId)] },
+      agentStatusEpoch: 0,
+      agentStatusByPaneKey: {},
+      migrationUnsupportedByPtyId: {},
+      runtimeAgentOrchestrationByPaneKey: {},
+      retainedAgentsByPaneKey: {},
+      paneForegroundAgentByPaneKey: {
+        [makePaneKey('tab-1', LEAF_ID)]: { agent, shellForeground: false }
+      }
+    }
+  }
+
+  it('indexes a recognized foreground agent by tab and pane', () => {
+    const summary = selectWorktreeAgentActivitySummary(
+      stateWithForegroundAgent('claude'),
+      worktreeId
+    )
+
+    expect(summary.foregroundAgentPaneIdsByTabId['tab-1']?.has(LEAF_ID)).toBe(true)
+  })
+
+  it('ignores a pane whose foreground process is not an agent', () => {
+    const summary = selectWorktreeAgentActivitySummary(stateWithForegroundAgent(null), worktreeId)
+
+    expect(summary.foregroundAgentPaneIdsByTabId['tab-1']).toBeUndefined()
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-agent-activity-summary.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-activity-summary.test.ts
@@ -442,8 +442,6 @@ describe('selectWorktreeAgentActivitySummary', () => {
   })
 })
 
-// Why: process-table identity is what lets the dot attribute a bare agent status
-// title to the pane that owns it, so the summary must carry it per worktree.
 describe('selectWorktreeAgentActivitySummary foreground agent panes', () => {
   const worktreeId = 'repo::/wt-1'
 

--- a/src/renderer/src/components/sidebar/worktree-agent-activity-summary.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-activity-summary.ts
@@ -109,9 +109,7 @@ function getWorktreeAgentActivitySummaries(
     return summary
   }
 
-  // Why: process-table identity is the only durable proof that a pane runs an agent
-  // when the user started it by hand — `tab.launchAgent` is cleared on exit and
-  // persists as null, and Claude's auto session title names Claude only by accident.
+  // Why: the process table is the only durable proof of an agent the user started by hand.
   for (const [paneKey, entry] of Object.entries(paneForegroundAgentByPaneKey ?? {})) {
     if (!entry.agent) {
       continue
@@ -290,8 +288,7 @@ function addAgentStatusPaneId(
   paneIds.add(paneId)
 }
 
-/** Records a pane whose foreground process is a recognized agent, so the status
- *  dot can attribute a bare agent status title to the pane that owns it. */
+/** Records a pane whose foreground process is a recognized agent. */
 function addForegroundAgentPaneId(
   summary: WorktreeAgentActivitySummary,
   tabId: string,

--- a/src/renderer/src/components/sidebar/worktree-agent-activity-summary.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-activity-summary.ts
@@ -290,6 +290,8 @@ function addAgentStatusPaneId(
   paneIds.add(paneId)
 }
 
+/** Records a pane whose foreground process is a recognized agent, so the status
+ *  dot can attribute a bare agent status title to the pane that owns it. */
 function addForegroundAgentPaneId(
   summary: WorktreeAgentActivitySummary,
   tabId: string,

--- a/src/renderer/src/components/sidebar/worktree-agent-activity-summary.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-activity-summary.ts
@@ -21,9 +21,12 @@ export type WorktreeAgentActivitySummary = {
   hasLiveDone: boolean
   hasRetainedDone: boolean
   agentStatusPaneIdsByTabId: Record<string, ReadonlySet<string>>
+  /** Panes whose foreground process is a recognized agent, from the process table. */
+  foregroundAgentPaneIdsByTabId: Record<string, ReadonlySet<string>>
 }
 
 const EMPTY_AGENT_STATUS_PANE_IDS_BY_TAB_ID: Record<string, ReadonlySet<string>> = {}
+const EMPTY_FOREGROUND_AGENT_PANE_IDS_BY_TAB_ID: Record<string, ReadonlySet<string>> = {}
 
 const EMPTY_SUMMARY: WorktreeAgentActivitySummary = {
   hasPermission: false,
@@ -32,7 +35,8 @@ const EMPTY_SUMMARY: WorktreeAgentActivitySummary = {
   hasInterrupted: false,
   hasLiveDone: false,
   hasRetainedDone: false,
-  agentStatusPaneIdsByTabId: EMPTY_AGENT_STATUS_PANE_IDS_BY_TAB_ID
+  agentStatusPaneIdsByTabId: EMPTY_AGENT_STATUS_PANE_IDS_BY_TAB_ID,
+  foregroundAgentPaneIdsByTabId: EMPTY_FOREGROUND_AGENT_PANE_IDS_BY_TAB_ID
 }
 
 type AgentActivityTabsByWorktree = Record<string, readonly { id: string }[]>
@@ -46,6 +50,7 @@ export type AgentActivityInput = Pick<
 > & {
   tabsByWorktree: AgentActivityTabsByWorktree
   runtimeAgentOrchestrationByPaneKey?: AppState['runtimeAgentOrchestrationByPaneKey']
+  paneForegroundAgentByPaneKey?: AppState['paneForegroundAgentByPaneKey']
 }
 
 type AgentActivityCache = {
@@ -54,6 +59,7 @@ type AgentActivityCache = {
   migrationUnsupportedByPtyId: AppState['migrationUnsupportedByPtyId']
   retainedAgentsByPaneKey: AppState['retainedAgentsByPaneKey']
   runtimeAgentOrchestrationByPaneKey: AppState['runtimeAgentOrchestrationByPaneKey'] | undefined
+  paneForegroundAgentByPaneKey: AppState['paneForegroundAgentByPaneKey'] | undefined
   summaries: Map<string, WorktreeAgentActivitySummary>
 }
 
@@ -70,13 +76,15 @@ function getWorktreeAgentActivitySummaries(
   state: AgentActivityInput
 ): Map<string, WorktreeAgentActivitySummary> {
   const runtimeAgentOrchestrationByPaneKey = state.runtimeAgentOrchestrationByPaneKey
+  const paneForegroundAgentByPaneKey = state.paneForegroundAgentByPaneKey
   if (
     agentActivityCache &&
     agentActivityCache.tabsByWorktree === state.tabsByWorktree &&
     agentActivityCache.agentStatusEpoch === state.agentStatusEpoch &&
     agentActivityCache.migrationUnsupportedByPtyId === state.migrationUnsupportedByPtyId &&
     agentActivityCache.retainedAgentsByPaneKey === state.retainedAgentsByPaneKey &&
-    agentActivityCache.runtimeAgentOrchestrationByPaneKey === runtimeAgentOrchestrationByPaneKey
+    agentActivityCache.runtimeAgentOrchestrationByPaneKey === runtimeAgentOrchestrationByPaneKey &&
+    agentActivityCache.paneForegroundAgentByPaneKey === paneForegroundAgentByPaneKey
   ) {
     return agentActivityCache.summaries
   }
@@ -99,6 +107,28 @@ function getWorktreeAgentActivitySummaries(
       summaries.set(worktreeId, summary)
     }
     return summary
+  }
+
+  // Why: process-table identity is the only durable proof that a pane runs an agent
+  // when the user started it by hand — `tab.launchAgent` is cleared on exit and
+  // persists as null, and Claude's auto session title names Claude only by accident.
+  for (const [paneKey, entry] of Object.entries(paneForegroundAgentByPaneKey ?? {})) {
+    if (!entry.agent) {
+      continue
+    }
+    const paneIdentity = parseAgentStatusPaneIdentity(paneKey)
+    if (!paneIdentity) {
+      continue
+    }
+    const worktreeId = tabIdToWorktreeId.get(paneIdentity.tabId)
+    if (!worktreeId) {
+      continue
+    }
+    addForegroundAgentPaneId(
+      summaryForWorktree(worktreeId),
+      paneIdentity.tabId,
+      paneIdentity.paneId
+    )
   }
 
   const now = Date.now()
@@ -170,6 +200,7 @@ function getWorktreeAgentActivitySummaries(
     migrationUnsupportedByPtyId: state.migrationUnsupportedByPtyId,
     retainedAgentsByPaneKey: state.retainedAgentsByPaneKey,
     runtimeAgentOrchestrationByPaneKey,
+    paneForegroundAgentByPaneKey,
     summaries
   }
   return summaries
@@ -189,6 +220,10 @@ function summariesEqual(
     agentStatusPaneIdsByTabIdEqual(
       previous.agentStatusPaneIdsByTabId,
       next.agentStatusPaneIdsByTabId
+    ) &&
+    agentStatusPaneIdsByTabIdEqual(
+      previous.foregroundAgentPaneIdsByTabId,
+      next.foregroundAgentPaneIdsByTabId
     )
   )
 }
@@ -251,6 +286,22 @@ function addAgentStatusPaneId(
   if (!paneIds) {
     paneIds = new Set<string>()
     summary.agentStatusPaneIdsByTabId[tabId] = paneIds
+  }
+  paneIds.add(paneId)
+}
+
+function addForegroundAgentPaneId(
+  summary: WorktreeAgentActivitySummary,
+  tabId: string,
+  paneId: string
+): void {
+  if (summary.foregroundAgentPaneIdsByTabId === EMPTY_FOREGROUND_AGENT_PANE_IDS_BY_TAB_ID) {
+    summary.foregroundAgentPaneIdsByTabId = {}
+  }
+  let paneIds = summary.foregroundAgentPaneIdsByTabId[tabId] as Set<string> | undefined
+  if (!paneIds) {
+    paneIds = new Set<string>()
+    summary.foregroundAgentPaneIdsByTabId[tabId] = paneIds
   }
   paneIds.add(paneId)
 }

--- a/src/renderer/src/components/tab-bar/SortableTab.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.tsx
@@ -103,7 +103,8 @@ export default function SortableTab({
       agentStatusEpoch: s.agentStatusEpoch,
       runtimePaneTitlesByTabId: s.runtimePaneTitlesByTabId,
       ptyIdsByTabId: s.ptyIdsByTabId,
-      terminalLayout: s.terminalLayoutsByTabId?.[tab.id]
+      terminalLayout: s.terminalLayoutsByTabId?.[tab.id],
+      paneForegroundAgentByPaneKey: s.paneForegroundAgentByPaneKey
     })
   )
   const renamingTabId = useAppStore((s) => s.renamingTabId)

--- a/src/renderer/src/components/tab-bar/terminal-tab-activity-status.test.ts
+++ b/src/renderer/src/components/tab-bar/terminal-tab-activity-status.test.ts
@@ -326,9 +326,6 @@ describe('terminalTabActivityToAgentDotState', () => {
   })
 })
 
-// Why: the tab dot runs the same attribution gate as the sidebar card, so a Claude
-// whose busy title carries only its status frame and generated session summary must
-// spin here too once the process table names the pane's agent.
 describe('resolveTerminalTabActivityStatus foreground agent attribution', () => {
   const CLAUDE_BUSY_TITLE = '◐ Orca automatic session title renaming'
 

--- a/src/renderer/src/components/tab-bar/terminal-tab-activity-status.test.ts
+++ b/src/renderer/src/components/tab-bar/terminal-tab-activity-status.test.ts
@@ -325,3 +325,31 @@ describe('terminalTabActivityToAgentDotState', () => {
     expect(terminalTabActivityToAgentDotState('inactive')).toBeNull()
   })
 })
+
+// Why: the tab dot runs the same attribution gate as the sidebar card, so a Claude
+// whose busy title carries only its status frame and generated session summary must
+// spin here too once the process table names the pane's agent.
+describe('resolveTerminalTabActivityStatus foreground agent attribution', () => {
+  const CLAUDE_BUSY_TITLE = '◐ Orca automatic session title renaming'
+
+  it('spins for an agent status title when the pane foreground process is an agent', () => {
+    const status = resolveTerminalTabActivityStatus({
+      tab: { id: TAB_ID, title: CLAUDE_BUSY_TITLE },
+      ptyIdsByTabId: LIVE_PTY,
+      paneForegroundAgentByPaneKey: {
+        [`${TAB_ID}:${FIRST_LEAF_ID}`]: { agent: 'claude', shellForeground: false }
+      }
+    })
+
+    expect(status).toBe('working')
+  })
+
+  it('stays active for the same title with no agent process in the tab', () => {
+    const status = resolveTerminalTabActivityStatus({
+      tab: { id: TAB_ID, title: CLAUDE_BUSY_TITLE },
+      ptyIdsByTabId: LIVE_PTY
+    })
+
+    expect(status).toBe('active')
+  })
+})

--- a/src/renderer/src/components/tab-bar/terminal-tab-activity-status.ts
+++ b/src/renderer/src/components/tab-bar/terminal-tab-activity-status.ts
@@ -133,12 +133,10 @@ type ForegroundAgentPaneIdsCache = {
   paneIdsByTabId: Map<string, Set<string>>
 }
 
-// Why: same per-snapshot bucketing as the flags cache above — this map is read by
-// every tab's selector on every store write.
+// Why: same per-snapshot bucketing as the flags cache above — every tab's selector reads it on every store write.
 let foregroundAgentPaneIdsCache: ForegroundAgentPaneIdsCache | null = null
 
-/** Buckets process-table pane identity by tab, once per store snapshot. Mirrors the
- *  sidebar summary's index so the tab dot and the worktree dot attribute alike. */
+/** Buckets process-table pane identity by tab, so the tab dot and the worktree dot attribute alike. */
 function getForegroundAgentPaneIdsByTabId(
   paneForegroundAgentByPaneKey: Record<string, PaneForegroundAgentEntry> | undefined
 ): Map<string, Set<string>> {
@@ -180,9 +178,7 @@ type TerminalTabActivityInput = {
   runtimePaneTitlesByTabId?: Record<string, Record<number, string>>
   ptyIdsByTabId?: Record<string, string[]>
   terminalLayout?: TerminalLayoutSnapshot
-  // Why: process-table identity attributes a bare spinner title to the agent that
-  // owns the pane, which is the only durable signal for an agent the user started
-  // by hand — see titleStatusIsAgentAttributable.
+  // Why: the only durable signal for an agent the user started by hand — see titleStatusIsAgentAttributable.
   paneForegroundAgentByPaneKey?: Record<string, PaneForegroundAgentEntry>
 }
 

--- a/src/renderer/src/components/tab-bar/terminal-tab-activity-status.ts
+++ b/src/renderer/src/components/tab-bar/terminal-tab-activity-status.ts
@@ -6,6 +6,7 @@ import {
 } from '../../../../shared/agent-status-types'
 import { parseLegacyNumericPaneKey, parsePaneKey } from '../../../../shared/stable-pane-id'
 import type { TerminalLayoutSnapshot, TerminalTab } from '../../../../shared/terminal-tab-types'
+import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
 
 // Why: a terminal tab is a container of panes, exactly like a worktree card is
 // a container of tabs. Reuse the WorktreeCard status vocabulary and resolver so
@@ -127,6 +128,44 @@ function parseAgentStatusPaneKey(paneKey: string): { tabId: string; paneId: stri
 
 const EMPTY_PANE_IDS: ReadonlySet<string> = new Set()
 
+type ForegroundAgentPaneIdsCache = {
+  paneForegroundAgentByPaneKey: Record<string, PaneForegroundAgentEntry> | undefined
+  paneIdsByTabId: Map<string, Set<string>>
+}
+
+// Why: same per-snapshot bucketing as the flags cache above — this map is read by
+// every tab's selector on every store write.
+let foregroundAgentPaneIdsCache: ForegroundAgentPaneIdsCache | null = null
+
+function getForegroundAgentPaneIdsByTabId(
+  paneForegroundAgentByPaneKey: Record<string, PaneForegroundAgentEntry> | undefined
+): Map<string, Set<string>> {
+  if (
+    foregroundAgentPaneIdsCache &&
+    foregroundAgentPaneIdsCache.paneForegroundAgentByPaneKey === paneForegroundAgentByPaneKey
+  ) {
+    return foregroundAgentPaneIdsCache.paneIdsByTabId
+  }
+  const paneIdsByTabId = new Map<string, Set<string>>()
+  for (const [paneKey, entry] of Object.entries(paneForegroundAgentByPaneKey ?? {})) {
+    if (!entry.agent) {
+      continue
+    }
+    const identity = parseAgentStatusPaneKey(paneKey)
+    if (!identity) {
+      continue
+    }
+    const paneIds = paneIdsByTabId.get(identity.tabId)
+    if (paneIds) {
+      paneIds.add(identity.paneId)
+    } else {
+      paneIdsByTabId.set(identity.tabId, new Set([identity.paneId]))
+    }
+  }
+  foregroundAgentPaneIdsCache = { paneForegroundAgentByPaneKey, paneIdsByTabId }
+  return paneIdsByTabId
+}
+
 type TerminalTabActivityInput = {
   // Why: launchAgent is read, not just carried — the status gate needs it to attribute a
   // bare spinner title to an agent (#9040). Narrowing it away here compiles (it is optional)
@@ -139,6 +178,10 @@ type TerminalTabActivityInput = {
   runtimePaneTitlesByTabId?: Record<string, Record<number, string>>
   ptyIdsByTabId?: Record<string, string[]>
   terminalLayout?: TerminalLayoutSnapshot
+  // Why: process-table identity attributes a bare spinner title to the agent that
+  // owns the pane, which is the only durable signal for an agent the user started
+  // by hand — see titleStatusIsAgentAttributable.
+  paneForegroundAgentByPaneKey?: Record<string, PaneForegroundAgentEntry>
 }
 
 /**
@@ -153,15 +196,19 @@ export function resolveTerminalTabActivityStatus({
   agentStatusEpoch,
   runtimePaneTitlesByTabId,
   ptyIdsByTabId,
-  terminalLayout
+  terminalLayout,
+  paneForegroundAgentByPaneKey
 }: TerminalTabActivityInput): TerminalTabActivityStatus {
   const flags = getTerminalTabActivityFlags(agentStatusByPaneKey, agentStatusEpoch).get(tab.id)
+  const foregroundAgentPaneIds =
+    getForegroundAgentPaneIdsByTabId(paneForegroundAgentByPaneKey).get(tab.id) ?? EMPTY_PANE_IDS
   return resolveWorktreeStatus({
     tabs: [tab],
     browserTabs: [],
     ptyIdsByTabId: ptyIdsByTabId ?? {},
     runtimePaneTitlesByTabId: runtimePaneTitlesByTabId ?? {},
     agentStatusPaneIdsByTabId: { [tab.id]: flags?.paneIds ?? EMPTY_PANE_IDS },
+    foregroundAgentPaneIdsByTabId: { [tab.id]: foregroundAgentPaneIds },
     terminalLayoutsByTabId: terminalLayout ? { [tab.id]: terminalLayout } : undefined,
     hasPermission: flags?.hasPermission ?? false,
     hasLiveWorking: flags?.hasLiveWorking ?? false,
@@ -281,4 +328,5 @@ export function hasUnreadAgentCompletionForTerminalTab(
 /** Test-only: clear the memoized per-tab flag cache between cases. */
 export function resetTerminalTabActivityFlagsCacheForTest(): void {
   flagsCache = null
+  foregroundAgentPaneIdsCache = null
 }

--- a/src/renderer/src/components/tab-bar/terminal-tab-activity-status.ts
+++ b/src/renderer/src/components/tab-bar/terminal-tab-activity-status.ts
@@ -137,6 +137,8 @@ type ForegroundAgentPaneIdsCache = {
 // every tab's selector on every store write.
 let foregroundAgentPaneIdsCache: ForegroundAgentPaneIdsCache | null = null
 
+/** Buckets process-table pane identity by tab, once per store snapshot. Mirrors the
+ *  sidebar summary's index so the tab dot and the worktree dot attribute alike. */
 function getForegroundAgentPaneIdsByTabId(
   paneForegroundAgentByPaneKey: Record<string, PaneForegroundAgentEntry> | undefined
 ): Map<string, Set<string>> {

--- a/src/renderer/src/lib/worktree-status-foreground-agent.test.ts
+++ b/src/renderer/src/lib/worktree-status-foreground-agent.test.ts
@@ -46,10 +46,16 @@ function tab(overrides: Partial<TerminalTab> = {}): TerminalTab {
 // the word "claude". Process-table identity settles ownership without the title.
 describe('worktree dot attributes a title status to the pane process running the agent', () => {
   it('spins when the pane foreground process is an agent and the title never names one', () => {
-    const status = getWorktreeStatus([tab({ title: CLAUDE_BUSY_TITLE })], [], livePty(), undefined, {
-      foregroundAgentPaneIdsByTabId: { 'tab-1': new Set([LEAF_A]) },
-      terminalLayoutRootsByTabId: { 'tab-1': singleLeafLayout().root }
-    })
+    const status = getWorktreeStatus(
+      [tab({ title: CLAUDE_BUSY_TITLE })],
+      [],
+      livePty(),
+      undefined,
+      {
+        foregroundAgentPaneIdsByTabId: { 'tab-1': new Set([LEAF_A]) },
+        terminalLayoutRootsByTabId: { 'tab-1': singleLeafLayout().root }
+      }
+    )
 
     expect(status).toBe('working')
   })
@@ -78,9 +84,9 @@ describe('worktree dot attributes a title status to the pane process running the
   // Control: the pre-existing named-title path resolves the same way, so the fix
   // closes a gap rather than changing what a named title means.
   it('spins without process evidence when the title happens to name the agent', () => {
-    expect(getWorktreeStatus([tab({ title: CLAUDE_BUSY_TITLE_NAMING_CLAUDE })], [], livePty())).toBe(
-      'working'
-    )
+    expect(
+      getWorktreeStatus([tab({ title: CLAUDE_BUSY_TITLE_NAMING_CLAUDE })], [], livePty())
+    ).toBe('working')
   })
 
   it('attributes per pane, so a sibling pane spinner is not covered by another pane process', () => {
@@ -93,6 +99,35 @@ describe('worktree dot attributes a title status to the pane process running the
         foregroundAgentPaneIdsByTabId: { 'tab-1': new Set([LEAF_A]) },
         terminalLayoutRootsByTabId: { 'tab-1': splitLayout().root }
       }
+    )
+
+    expect(status).toBe('active')
+  })
+
+  // Why: process evidence is keyed by stable leaf id, so a runtime pane title that
+  // arrives before the layout (SSH/replay) has nothing to match against. One title and
+  // one agent pane pair unambiguously — mirrors the agent-row branch's same fallback.
+  it('attributes a lone pane title to a lone agent pane before the layout hydrates', () => {
+    const status = getWorktreeStatus(
+      [tab()],
+      [],
+      livePty(),
+      { 'tab-1': { 1: CLAUDE_BUSY_TITLE } },
+      {
+        foregroundAgentPaneIdsByTabId: { 'tab-1': new Set([LEAF_A]) }
+      }
+    )
+
+    expect(status).toBe('working')
+  })
+
+  it('does not guess when an unhydrated tab reports more than one pane title', () => {
+    const status = getWorktreeStatus(
+      [tab()],
+      [],
+      livePty(),
+      { 'tab-1': { 1: CLAUDE_BUSY_TITLE, 2: CLAUDE_BUSY_TITLE } },
+      { foregroundAgentPaneIdsByTabId: { 'tab-1': new Set([LEAF_A]) } }
     )
 
     expect(status).toBe('active')

--- a/src/renderer/src/lib/worktree-status-foreground-agent.test.ts
+++ b/src/renderer/src/lib/worktree-status-foreground-agent.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+import type { TerminalLayoutSnapshot, TerminalTab } from '../../../shared/terminal-tab-types'
+import { getWorktreeStatus } from './worktree-status'
+
+const LEAF_A = '11111111-1111-4111-8111-111111111111'
+const LEAF_B = '22222222-2222-4222-8222-222222222222'
+
+// A real Claude Code busy title: a quarter-circle spinner frame plus the
+// auto-generated session summary. The summary names Claude only by accident.
+const CLAUDE_BUSY_TITLE = '◐ Orca automatic session title renaming'
+const CLAUDE_BUSY_TITLE_NAMING_CLAUDE = '◐ Claude status missing from to-do workspaces'
+
+function livePty(): Record<string, string[]> {
+  return { 'tab-1': ['pty-0'] }
+}
+
+function splitLayout(): TerminalLayoutSnapshot {
+  return {
+    root: {
+      type: 'split',
+      first: { type: 'leaf', leafId: LEAF_A },
+      second: { type: 'leaf', leafId: LEAF_B }
+    },
+    activeLeafId: LEAF_A,
+    titlesByLeafId: {}
+  } as unknown as TerminalLayoutSnapshot
+}
+
+function singleLeafLayout(): TerminalLayoutSnapshot {
+  return {
+    root: { type: 'leaf', leafId: LEAF_A },
+    activeLeafId: LEAF_A,
+    titlesByLeafId: {}
+  } as unknown as TerminalLayoutSnapshot
+}
+
+function tab(overrides: Partial<TerminalTab> = {}): TerminalTab {
+  return { id: 'tab-1', title: 'bash', ...overrides } as TerminalTab
+}
+
+// Why: Claude Code's busy OSC title is a status frame plus its own generated session
+// summary, and `tab.launchAgent` is cleared when an agent exits and persists as null.
+// So the dot's attribution gate had no identity to work with for a `claude` the user
+// started by hand, and every such working session rendered the quiet emerald 'active'
+// dot — the same glyph as 'done' — unless the generated summary happened to contain
+// the word "claude". Process-table identity settles ownership without the title.
+describe('worktree dot attributes a title status to the pane process running the agent', () => {
+  it('spins when the pane foreground process is an agent and the title never names one', () => {
+    const status = getWorktreeStatus([tab({ title: CLAUDE_BUSY_TITLE })], [], livePty(), undefined, {
+      foregroundAgentPaneIdsByTabId: { 'tab-1': new Set([LEAF_A]) },
+      terminalLayoutRootsByTabId: { 'tab-1': singleLeafLayout().root }
+    })
+
+    expect(status).toBe('working')
+  })
+
+  it('spins for a pane title too', () => {
+    const status = getWorktreeStatus(
+      [tab()],
+      [],
+      livePty(),
+      { 'tab-1': { 1: CLAUDE_BUSY_TITLE } },
+      {
+        foregroundAgentPaneIdsByTabId: { 'tab-1': new Set([LEAF_A]) },
+        terminalLayoutRootsByTabId: { 'tab-1': singleLeafLayout().root }
+      }
+    )
+
+    expect(status).toBe('working')
+  })
+
+  // Why: pins the #9647 gate — the process table is the new identity source, not a
+  // licence for any spinner. A pane with no agent process still cannot spin the dot.
+  it('stays active for the same title when no pane runs an agent process', () => {
+    expect(getWorktreeStatus([tab({ title: CLAUDE_BUSY_TITLE })], [], livePty())).toBe('active')
+  })
+
+  // Control: the pre-existing named-title path resolves the same way, so the fix
+  // closes a gap rather than changing what a named title means.
+  it('spins without process evidence when the title happens to name the agent', () => {
+    expect(getWorktreeStatus([tab({ title: CLAUDE_BUSY_TITLE_NAMING_CLAUDE })], [], livePty())).toBe(
+      'working'
+    )
+  })
+
+  it('attributes per pane, so a sibling pane spinner is not covered by another pane process', () => {
+    const status = getWorktreeStatus(
+      [tab()],
+      [],
+      livePty(),
+      { 'tab-1': { 2: CLAUDE_BUSY_TITLE } },
+      {
+        foregroundAgentPaneIdsByTabId: { 'tab-1': new Set([LEAF_A]) },
+        terminalLayoutRootsByTabId: { 'tab-1': splitLayout().root }
+      }
+    )
+
+    expect(status).toBe('active')
+  })
+
+  it('still reports a dead PTY as inactive', () => {
+    const status = getWorktreeStatus([tab({ title: CLAUDE_BUSY_TITLE })], [], {}, undefined, {
+      foregroundAgentPaneIdsByTabId: { 'tab-1': new Set([LEAF_A]) },
+      terminalLayoutRootsByTabId: { 'tab-1': singleLeafLayout().root }
+    })
+
+    expect(status).toBe('inactive')
+  })
+})

--- a/src/renderer/src/lib/worktree-status-foreground-agent.test.ts
+++ b/src/renderer/src/lib/worktree-status-foreground-agent.test.ts
@@ -5,8 +5,7 @@ import { getWorktreeStatus } from './worktree-status'
 const LEAF_A = '11111111-1111-4111-8111-111111111111'
 const LEAF_B = '22222222-2222-4222-8222-222222222222'
 
-// A real Claude Code busy title: a quarter-circle spinner frame plus the
-// auto-generated session summary. The summary names Claude only by accident.
+// A real Claude Code busy title: spinner frame plus generated summary, naming Claude only by accident.
 const CLAUDE_BUSY_TITLE = '◐ Orca automatic session title renaming'
 const CLAUDE_BUSY_TITLE_NAMING_CLAUDE = '◐ Claude status missing from to-do workspaces'
 
@@ -38,12 +37,7 @@ function tab(overrides: Partial<TerminalTab> = {}): TerminalTab {
   return { id: 'tab-1', title: 'bash', ...overrides } as TerminalTab
 }
 
-// Why: Claude Code's busy OSC title is a status frame plus its own generated session
-// summary, and `tab.launchAgent` is cleared when an agent exits and persists as null.
-// So the dot's attribution gate had no identity to work with for a `claude` the user
-// started by hand, and every such working session rendered the quiet emerald 'active'
-// dot — the same glyph as 'done' — unless the generated summary happened to contain
-// the word "claude". Process-table identity settles ownership without the title.
+// Why: neither the busy title nor the null `launchAgent` identifies a hand-started agent (#15776); the process table does.
 describe('worktree dot attributes a title status to the pane process running the agent', () => {
   it('spins when the pane foreground process is an agent and the title never names one', () => {
     const status = getWorktreeStatus(
@@ -75,14 +69,11 @@ describe('worktree dot attributes a title status to the pane process running the
     expect(status).toBe('working')
   })
 
-  // Why: pins the #9647 gate — the process table is the new identity source, not a
-  // licence for any spinner. A pane with no agent process still cannot spin the dot.
+  // Why: pins the #9647 gate — process evidence is a new identity source, not a licence for any spinner.
   it('stays active for the same title when no pane runs an agent process', () => {
     expect(getWorktreeStatus([tab({ title: CLAUDE_BUSY_TITLE })], [], livePty())).toBe('active')
   })
 
-  // Control: the pre-existing named-title path resolves the same way, so the fix
-  // closes a gap rather than changing what a named title means.
   it('spins without process evidence when the title happens to name the agent', () => {
     expect(
       getWorktreeStatus([tab({ title: CLAUDE_BUSY_TITLE_NAMING_CLAUDE })], [], livePty())
@@ -104,9 +95,7 @@ describe('worktree dot attributes a title status to the pane process running the
     expect(status).toBe('active')
   })
 
-  // Why: process evidence is keyed by stable leaf id, so a runtime pane title that
-  // arrives before the layout (SSH/replay) has nothing to match against. One title and
-  // one agent pane pair unambiguously — mirrors the agent-row branch's same fallback.
+  // Why: process evidence is keyed by leaf id, so a title arriving before the layout (SSH/replay) has nothing to match.
   it('attributes a lone pane title to a lone agent pane before the layout hydrates', () => {
     const status = getWorktreeStatus(
       [tab()],

--- a/src/renderer/src/lib/worktree-status.ts
+++ b/src/renderer/src/lib/worktree-status.ts
@@ -23,6 +23,7 @@ export type WorktreeStatus =
 type WorktreeStatusHeuristicOptions = {
   liveAgentStatus?: LiveAgentWorktreeStatus
   agentStatusPaneIdsByTabId?: Record<string, ReadonlySet<string>>
+  foregroundAgentPaneIdsByTabId?: Record<string, ReadonlySet<string>>
   terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot | undefined>
   terminalLayoutRootsByTabId?: Record<string, TerminalPaneLayoutNode | null | undefined>
 }
@@ -74,6 +75,7 @@ function tabHasStatus(
   options: WorktreeStatusHeuristicOptions
 ): boolean {
   const agentStatusPaneIds = options.agentStatusPaneIdsByTabId?.[tab.id]
+  const foregroundAgentPaneIds = options.foregroundAgentPaneIdsByTabId?.[tab.id]
   const paneTitles = runtimePaneTitlesByTabId[tab.id]
   if (paneTitles && Object.keys(paneTitles).length > 0) {
     const tabLayoutRoot =
@@ -91,9 +93,12 @@ function tabHasStatus(
       ) {
         continue
       }
+      const paneRunsAgentProcess =
+        foregroundAgentPaneIds?.has(runtimePaneId) === true ||
+        (leafId !== null && foregroundAgentPaneIds?.has(leafId) === true)
       if (
         classifyTitleActivity(title) === status &&
-        titleStatusIsAgentAttributable(title, tab.launchAgent)
+        titleStatusIsAgentAttributable(title, tab.launchAgent, paneRunsAgentProcess)
       ) {
         return true
       }
@@ -104,15 +109,34 @@ function tabHasStatus(
   if (agentStatusPaneIds && agentStatusPaneIds.size > 0) {
     return false
   }
+  // Why: this branch has no pane titles to map process evidence onto, so an agent
+  // process in any of the tab's panes attributes its title — the same tab-wide reach
+  // `launchAgent` already has here.
   return (
     classifyTitleActivity(tab.title) === status &&
-    titleStatusIsAgentAttributable(tab.title, tab.launchAgent)
+    titleStatusIsAgentAttributable(
+      tab.title,
+      tab.launchAgent,
+      (foregroundAgentPaneIds?.size ?? 0) > 0
+    )
   )
 }
 
 // Why: require agent attribution so a bare never-cleared spinner title can't spin the dot "0 agents" forever with no matching sidebar row.
-function titleStatusIsAgentAttributable(title: string, launchAgent?: TuiAgent | null): boolean {
+function titleStatusIsAgentAttributable(
+  title: string,
+  launchAgent?: TuiAgent | null,
+  paneRunsAgentProcess = false
+): boolean {
   if (resolveAgentTypeFromTerminalTitle(title) !== null) {
+    return true
+  }
+  // Why: process-table identity settles ownership outright, so the title only has to
+  // carry the activity. It is the sole durable signal for an agent the user started by
+  // hand: launchAgent is cleared on exit and persists as null, and Claude's generated
+  // session title names Claude only by accident — so a working session showed the quiet
+  // 'active' dot whenever that title happened not to say "claude".
+  if (paneRunsAgentProcess) {
     return true
   }
   // Why: a spinner proves activity but not identity (Claude's thinking title has no provider
@@ -139,6 +163,7 @@ export function resolveWorktreeStatus(args: {
   ptyIdsByTabId: Record<string, string[]>
   runtimePaneTitlesByTabId?: Record<string, Record<number, string>>
   agentStatusPaneIdsByTabId?: Record<string, ReadonlySet<string>>
+  foregroundAgentPaneIdsByTabId?: Record<string, ReadonlySet<string>>
   terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot | undefined>
   terminalLayoutRootsByTabId?: Record<string, TerminalPaneLayoutNode | null | undefined>
   hasPermission: boolean
@@ -155,6 +180,7 @@ export function resolveWorktreeStatus(args: {
     args.runtimePaneTitlesByTabId ?? {},
     {
       agentStatusPaneIdsByTabId: args.agentStatusPaneIdsByTabId,
+      foregroundAgentPaneIdsByTabId: args.foregroundAgentPaneIdsByTabId,
       terminalLayoutsByTabId: args.terminalLayoutsByTabId,
       terminalLayoutRootsByTabId: args.terminalLayoutRootsByTabId
     }

--- a/src/renderer/src/lib/worktree-status.ts
+++ b/src/renderer/src/lib/worktree-status.ts
@@ -93,11 +93,7 @@ function tabHasStatus(
       ) {
         continue
       }
-      // Why: same layout-hydration gap the agent-row branch above covers — process
-      // evidence is keyed by stable leaf id, so before the layout lands there is
-      // nothing to match a numeric runtime pane id against. With one title and one
-      // agent pane the pairing is unambiguous, so attribute it instead of stalling
-      // the spinner until hydration.
+      // Why: same pre-hydration gap as the agent-row branch above; one title and one agent pane pair unambiguously.
       const hasSingleUnmappedForegroundAgentPane =
         leafId === null && foregroundAgentPaneIds?.size === 1 && paneTitleEntries.length === 1
       const paneRunsAgentProcess =
@@ -117,9 +113,7 @@ function tabHasStatus(
   if (agentStatusPaneIds && agentStatusPaneIds.size > 0) {
     return false
   }
-  // Why: this branch has no pane titles to map process evidence onto, so an agent
-  // process in any of the tab's panes attributes its title — the same tab-wide reach
-  // `launchAgent` already has here.
+  // Why: no pane titles to map process evidence onto, so any agent pane attributes the tab title — the same reach `launchAgent` has here.
   return (
     classifyTitleActivity(tab.title) === status &&
     titleStatusIsAgentAttributable(
@@ -139,11 +133,7 @@ function titleStatusIsAgentAttributable(
   if (resolveAgentTypeFromTerminalTitle(title) !== null) {
     return true
   }
-  // Why: process-table identity settles ownership outright, so the title only has to
-  // carry the activity. It is the sole durable signal for an agent the user started by
-  // hand: launchAgent is cleared on exit and persists as null, and Claude's generated
-  // session title names Claude only by accident — so a working session showed the quiet
-  // 'active' dot whenever that title happened not to say "claude".
+  // Why: the process table is the only durable identity for a hand-started agent — launchAgent persists as null and the generated title names Claude only by accident.
   if (paneRunsAgentProcess) {
     return true
   }

--- a/src/renderer/src/lib/worktree-status.ts
+++ b/src/renderer/src/lib/worktree-status.ts
@@ -93,9 +93,17 @@ function tabHasStatus(
       ) {
         continue
       }
+      // Why: same layout-hydration gap the agent-row branch above covers — process
+      // evidence is keyed by stable leaf id, so before the layout lands there is
+      // nothing to match a numeric runtime pane id against. With one title and one
+      // agent pane the pairing is unambiguous, so attribute it instead of stalling
+      // the spinner until hydration.
+      const hasSingleUnmappedForegroundAgentPane =
+        leafId === null && foregroundAgentPaneIds?.size === 1 && paneTitleEntries.length === 1
       const paneRunsAgentProcess =
         foregroundAgentPaneIds?.has(runtimePaneId) === true ||
-        (leafId !== null && foregroundAgentPaneIds?.has(leafId) === true)
+        (leafId !== null && foregroundAgentPaneIds?.has(leafId) === true) ||
+        hasSingleUnmappedForegroundAgentPane
       if (
         classifyTitleActivity(title) === status &&
         titleStatusIsAgentAttributable(title, tab.launchAgent, paneRunsAgentProcess)


### PR DESCRIPTION
## ELI5

The sidebar dot only knew a Claude was working if Claude's own auto-generated session title happened to contain the word "claude". Now it asks the process table instead, which always knows.

## What Changed

`titleStatusIsAgentAttributable` (the gate that decides whether a title-derived `working`/`permission` belongs to an agent) gains a third source of identity: the pane's foreground process.

- `worktree-agent-activity-summary.ts` now indexes `paneForegroundAgentByPaneKey` into `foregroundAgentPaneIdsByTabId` per worktree, inside the existing per-snapshot cache and structural-reuse path, so no extra selector churn.
- `getWorktreeStatus` / `resolveWorktreeStatus` accept that map and pass per-pane process evidence into the gate. Pane titles are matched per pane (via the layout leaf id); the tab-title fallback branch, which has no pane titles to map onto, uses the same tab-wide reach `launchAgent` already has there.
- `resolveTerminalTabActivityStatus` runs the same resolver, so the tab-bar dot gets the same evidence, with the same per-snapshot bucketing the flags cache uses.

No change to the sidebar agent rows, the dashboard, or any identity resolver.

## Why

Claude Code's busy OSC title is a status frame plus its own generated session summary:

- `◐ Claude status missing from to-do workspaces` → dot spins
- `◐ Orca automatic session title renaming` → dot shows `active`

Same agent, same pane, one turn apart. The gate needed either a provider name in the title or a spinner glyph paired with `tab.launchAgent`, and the summary names Claude only by accident.

`tab.launchAgent` cannot cover the gap: it is cleared on agent exit and persists as `null` — every tab in my `orca-data.json` has `"launchAgent": null`, including ones with four live Claude panes. So an agent started by hand, or any session that outlived a restart, had no identity at all and the dot went quiet.

Meanwhile `orca worktree ps` and mobile report `working` for those same panes, because `getLeafWorktreeStatus` classifies the title with no attribution gate. The desktop sidebar was the only surface calling a busy Claude idle.

`paneForegroundAgentByPaneKey` is the right source: its own doc comment says it "covers agents that emit neither hooks nor titles", it is read at OSC 133 command boundaries and when a pane's PTY becomes visible, and it is pane-scoped — so it survives a restart and cannot let one pane brand its sibling in a split, which is why `resolveTitleDerivedPaneOwner` has to refuse the tab-scoped `launchAgent` there.

The `#9647` guard is intact. Process evidence settles ownership; it is not a licence for any spinner:

- a spinner in a pane with no agent process and no launch identity still resolves `active`
- a sibling pane's spinner is not covered by another pane's agent process
- a dead PTY still resolves `inactive`

## Linked Issue

Fixes #15776

## Visual Proof

N/A for a static capture — the difference is a solid emerald dot versus an animated yellow spinner ring on the same workspace row, which does not survive a screenshot pair. The observable state is reproducible from the CLI instead: with a hand-started Claude mid-turn, `orca worktree ps --json` reports `"status": "working"` for the workspace while the sidebar row renders the `Active` dot. After this change both agree.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

New `src/renderer/src/lib/worktree-status-foreground-agent.test.ts` covers, with real Claude Code titles: attribution from process evidence for a tab title and a pane title; the unchanged `active` result with no process evidence; the unchanged `working` result for a title that does name the agent; per-pane scoping in a split; and `inactive` on a dead PTY. `worktree-agent-activity-summary.test.ts` pins the new index (recognized agent in, `agent: null` out). `terminal-tab-activity-status.test.ts` pins the tab-bar dot both ways.

Reviewer steps:

1. Open a terminal tab in a workspace and run `claude` by hand.
2. Give it work that takes a while, with a session title that does not contain the word "claude".
3. Before: the sidebar row shows the green `Active` dot. After: it shows the working spinner, matching `orca worktree ps --json`.

Ran locally on macOS: `vitest run` over `src/renderer/src/lib`, `src/renderer/src/components/{sidebar,tab-bar,dashboard}` (822 files, 7423 tests, all passing), `tsc --noEmit -p config/tsconfig.tc.web.json`, `oxlint` native and `--type-aware` code-quality configs, `oxfmt`.

Platforms: renderer-only, no platform-specific code. The foreground-agent tracker is already local-pane-only by design (`isTrackablePtyId`), so remote/SSH panes are unaffected and keep their existing behavior. Mobile reads `worktree.ps`, which was already correct and is untouched. Backwards compatible: the new map is optional on every signature, and absent evidence reproduces the old result exactly.

## AI Disclosure

Investigated and written with Claude Opus 5 in Claude Code.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Security: none — no new IPC, no new data leaves the renderer. Performance: the new index is built once per store snapshot inside the existing caches, keyed on the map reference, and the summaries keep their structural-equality reuse, so no extra renders. Cross-platform, SSH, mobile, and backwards compatibility as described above.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — lint, typecheck and the affected test surface run locally as listed above; `pnpm build` left to CI (renderer-only change, no build config touched)
