### PR TITLE
feat(terminal): auto-generate titles for the panes in a split tab

### DIFF
--- a/src/main/codex-accounts/runtime-home-settings-test-fixtures.ts
+++ b/src/main/codex-accounts/runtime-home-settings-test-fixtures.ts
@@ -15,6 +15,7 @@ export function createSettings(overrides: TestSettingsOverrides = {}): GlobalSet
   const appFontFamily = overrides.appFontFamily ?? 'Geist'
   const agentStatusHooksEnabled = overrides.agentStatusHooksEnabled ?? true
   const tabAutoGenerateTitle = overrides.tabAutoGenerateTitle ?? false
+  const terminalAutoGenerateTitle = overrides.terminalAutoGenerateTitle ?? false
   // Mirror-path tests assert the shared runtime home, which production still uses
   // on Windows; opt these cases onto that lane unless a test overrides it.
   setShellStartupEnvProbeSupportedForTest(overrides.shellStartupEnvProbeSupported ?? false)
@@ -134,6 +135,7 @@ export function createSettings(overrides: TestSettingsOverrides = {}): GlobalSet
     leftSidebarAppearanceMode: overrides.leftSidebarAppearanceMode ?? 'default',
     appFontFamily,
     agentStatusHooksEnabled,
-    tabAutoGenerateTitle
+    tabAutoGenerateTitle,
+    terminalAutoGenerateTitle
   }
 }

--- a/src/main/codex-accounts/service-test-harness.ts
+++ b/src/main/codex-accounts/service-test-harness.ts
@@ -39,6 +39,7 @@ export function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalS
   const appFontFamily = overrides.appFontFamily ?? 'Geist'
   const agentStatusHooksEnabled = overrides.agentStatusHooksEnabled ?? true
   const tabAutoGenerateTitle = overrides.tabAutoGenerateTitle ?? false
+  const terminalAutoGenerateTitle = overrides.terminalAutoGenerateTitle ?? false
   return {
     workspaceDir: testState.fakeHomeDir,
     nestWorkspaces: false,
@@ -155,7 +156,8 @@ export function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalS
     leftSidebarAppearanceMode: overrides.leftSidebarAppearanceMode ?? 'default',
     appFontFamily,
     agentStatusHooksEnabled,
-    tabAutoGenerateTitle
+    tabAutoGenerateTitle,
+    terminalAutoGenerateTitle
   }
 }
 

--- a/src/renderer/src/components/settings/AgentsPane.tsx
+++ b/src/renderer/src/components/settings/AgentsPane.tsx
@@ -13,6 +13,10 @@ import {
   getAgentGeneratedTabTitlesDescription,
   getAgentGeneratedTabTitlesTitle
 } from './agent-generated-tab-title-copy'
+import {
+  getAgentGeneratedTerminalTitlesDescription,
+  getAgentGeneratedTerminalTitlesTitle
+} from './agent-generated-terminal-title-copy'
 import { getAgentStatusHooksDescription, getAgentStatusHooksTitle } from './agent-status-hooks-copy'
 import {
   SettingsSegmentedControl,
@@ -256,6 +260,7 @@ export function AgentsPane({
       />
       <AgentStatusHooksSetting settings={settings} updateSettings={updateSettings} />
       <AgentGeneratedTabTitlesSetting settings={settings} updateSettings={updateSettings} />
+      <AgentGeneratedTerminalTitlesSetting settings={settings} updateSettings={updateSettings} />
       {!isPairedWebClientWindow() ? (
         <AgentAwakeSetting settings={settings} updateSettings={updateSettings} />
       ) : null}
@@ -291,6 +296,28 @@ export function AgentStatusHooksSetting({ settings, updateSettings }: AgentsPane
         checked={enabled}
         onChange={() => updateSettings({ agentStatusHooksEnabled: !enabled })}
         ariaLabel={getAgentStatusHooksTitle()}
+      />
+    </section>
+  )
+}
+
+export function AgentGeneratedTerminalTitlesSetting({
+  settings,
+  updateSettings
+}: AgentsPaneProps): React.JSX.Element {
+  const enabled = settings.terminalAutoGenerateTitle === true
+  return (
+    <section className="space-y-3">
+      <SettingsSwitchRow
+        label={getAgentGeneratedTerminalTitlesTitle()}
+        description={getAgentGeneratedTerminalTitlesDescription()}
+        checked={enabled}
+        onChange={() =>
+          updateSettings({
+            terminalAutoGenerateTitle: !enabled
+          })
+        }
+        ariaLabel={getAgentGeneratedTerminalTitlesTitle()}
       />
     </section>
   )

--- a/src/renderer/src/components/settings/agent-generated-terminal-title-copy.ts
+++ b/src/renderer/src/components/settings/agent-generated-terminal-title-copy.ts
@@ -1,0 +1,37 @@
+import { translate } from '@/i18n/i18n'
+import { searchKeywords } from './settings-search-keywords'
+
+const AGENT_GENERATED_TERMINAL_TITLES_TITLE_KEY =
+  'components.settings.agentGeneratedTerminalTitles.title'
+const AGENT_GENERATED_TERMINAL_TITLES_DESCRIPTION_KEY =
+  'components.settings.agentGeneratedTerminalTitles.description'
+
+export function getAgentGeneratedTerminalTitlesTitle(): string {
+  return translate(AGENT_GENERATED_TERMINAL_TITLES_TITLE_KEY, 'Auto-generate terminal titles')
+}
+
+export function getAgentGeneratedTerminalTitlesDescription(): string {
+  return translate(
+    AGENT_GENERATED_TERMINAL_TITLES_DESCRIPTION_KEY,
+    'Name each terminal in a split from the agent running in it, so a tab full of sessions reads at a glance. Manual renames always win.'
+  )
+}
+
+export function getAgentGeneratedTerminalTitlesSearchKeywords(): string[] {
+  return searchKeywords([
+    { key: 'auto.components.settings.agents.search.96ba2373b6', fallback: 'agent' },
+    {
+      key: 'components.settings.agentGeneratedTerminalTitles.keyword.terminal',
+      fallback: 'terminal'
+    },
+    { key: 'components.settings.agentGeneratedTerminalTitles.keyword.pane', fallback: 'pane' },
+    { key: 'components.settings.agentGeneratedTerminalTitles.keyword.split', fallback: 'split' },
+    { key: 'auto.components.settings.agents.search.6956646a1e', fallback: 'title' },
+    { key: 'auto.components.settings.agents.search.966890236d', fallback: 'name' },
+    { key: 'auto.components.settings.agents.search.848dcae8d3', fallback: 'generated' },
+    { key: 'auto.components.settings.agents.search.52115d0d7c', fallback: 'auto' },
+    { key: 'auto.components.settings.agents.search.c64059f50d', fallback: 'prompt' },
+    { key: 'auto.components.settings.agents.search.5784ae8c43', fallback: 'rename' },
+    { key: 'auto.components.settings.agents.search.a79d266f71', fallback: 'session' }
+  ])
+}

--- a/src/renderer/src/components/settings/agents-search.ts
+++ b/src/renderer/src/components/settings/agents-search.ts
@@ -10,6 +10,11 @@ import {
   getAgentGeneratedTabTitlesTitle
 } from './agent-generated-tab-title-copy'
 import {
+  getAgentGeneratedTerminalTitlesDescription,
+  getAgentGeneratedTerminalTitlesSearchKeywords,
+  getAgentGeneratedTerminalTitlesTitle
+} from './agent-generated-terminal-title-copy'
+import {
   getAgentStatusHooksDescription,
   getAgentStatusHooksSearchKeywords,
   getAgentStatusHooksTitle
@@ -112,6 +117,11 @@ const getAllAgentsPaneSearchEntries = createLocalizedCatalog(() => [
     title: getAgentGeneratedTabTitlesTitle(),
     description: getAgentGeneratedTabTitlesDescription(),
     keywords: getAgentGeneratedTabTitlesSearchKeywords()
+  },
+  {
+    title: getAgentGeneratedTerminalTitlesTitle(),
+    description: getAgentGeneratedTerminalTitlesDescription(),
+    keywords: getAgentGeneratedTerminalTitlesSearchKeywords()
   },
   {
     title: getAgentAwakeTitle(),

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -198,6 +198,11 @@ import { useVisibleTerminalTabClaim } from './use-visible-terminal-tab-claim'
 import { TerminalSshReconnectOverlay } from './TerminalSshReconnectOverlay'
 import { TerminalRemoteRuntimeReconnectBanner } from './TerminalRemoteRuntimeReconnectBanner'
 import { selectTerminalTabAgentTypesByLeaf } from './terminal-tab-agent-type-index'
+import {
+  EMPTY_GENERATED_PANE_TITLES,
+  selectTerminalTabGeneratedPaneTitles,
+  type GeneratedPaneTitlesByLeaf
+} from './terminal-tab-generated-pane-titles'
 import { resolveProtectedMultilinePasteOptionsForPane } from './terminal-agent-paste-bracketing'
 import { resolveTerminalInputHostPlatform } from './terminal-input-host-platform'
 import { canContinueAgentSessionInNewSession } from './terminal-agent-session-continuation'
@@ -422,6 +427,9 @@ function TerminalPane(
   const [paneTitles, setPaneTitles] = useState<Record<number, string>>({})
   const paneTitlesRef = useRef<Record<number, string>>({})
   paneTitlesRef.current = paneTitles
+  // Generated titles are display-only: they never enter paneTitles, so they are
+  // never persisted into titlesByLeafId and a manual rename always outranks one.
+  const generatedPaneTitlesRef = useRef<GeneratedPaneTitlesByLeaf>(EMPTY_GENERATED_PANE_TITLES)
   const removedTitleLeafIdsRef = useRef<Set<string>>(new Set())
   const clearedScrollbackLeafIdsRef = useRef<Set<string>>(new Set())
   const remotePaneLayoutPusherRef = useRef<RemotePaneLayoutPusher | null>(null)
@@ -481,7 +489,13 @@ function TerminalPane(
       renameBlurCommitEnabledRef.current = false
       renameUserRequestedBlurCommitRef.current = false
       renameSubmittedRef.current = false
-      setRenameValue(paneTitlesRef.current[paneId] ?? '')
+      // Why: Set Title on an auto-named pane opens on that name, so editing it is
+      // a correction rather than retyping what the header already shows.
+      const leafId = managerRef.current?.getPanes().find((pane) => pane.id === paneId)?.leafId
+      setRenameValue(
+        paneTitlesRef.current[paneId] ??
+          (leafId ? (generatedPaneTitlesRef.current[leafId] ?? '') : '')
+      )
       setRenamingPaneId(paneId)
     },
     [cancelPendingRenameFrames]
@@ -540,6 +554,12 @@ function TerminalPane(
   const tabAgentTypeByLeaf = useAppStore((store) =>
     selectTerminalTabAgentTypesByLeaf(store.agentStatusByPaneKey, tabId)
   )
+  const generatedPaneTitlesByLeaf = useAppStore((store) =>
+    store.settings?.terminalAutoGenerateTitle === true
+      ? selectTerminalTabGeneratedPaneTitles(store.agentStatusByPaneKey, tabId)
+      : EMPTY_GENERATED_PANE_TITLES
+  )
+  generatedPaneTitlesRef.current = generatedPaneTitlesByLeaf
   const toggleTabViewMode = useAppStore((store) => store.toggleTabViewMode)
   const setTabViewMode = useAppStore((store) => store.setTabViewMode)
   const savedLayout = useAppStore((store) => store.terminalLayoutsByTabId[tabId] ?? EMPTY_LAYOUT)
@@ -2303,6 +2323,7 @@ function TerminalPane(
     const needsFit = syncSessionRestoredBannerTitleSpace({
       panes: manager.getPanes(),
       paneTitles,
+      generatedPaneTitlesByLeaf,
       renamingPaneId,
       sessionRestoredBannerPaneIds
     })
@@ -2314,6 +2335,7 @@ function TerminalPane(
     paneCount,
     paneLayoutRevision,
     paneTitles,
+    generatedPaneTitlesByLeaf,
     renamingPaneId,
     sessionRestoredBannerPaneIds,
     isVisible,
@@ -3268,6 +3290,7 @@ function TerminalPane(
         activePaneId={activePane?.id}
         panes={managedPanes}
         paneTitles={paneTitles}
+        generatedPaneTitlesByLeaf={generatedPaneTitlesByLeaf}
         paneTitleOverlayRects={paneTitleOverlayRects}
         renamingPaneId={renamingPaneId}
         renameValue={renameValue}

--- a/src/renderer/src/components/terminal-pane/TerminalPaneHeaderOverlay.test.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneHeaderOverlay.test.tsx
@@ -41,6 +41,7 @@ function makePane(id: number): ManagedPane {
 
 function renderOverlay({
   paneTitles,
+  generatedPaneTitlesByLeaf = {},
   paneCount = 2,
   showAlwaysOnHeaders = true,
   showSplitButton = true,
@@ -53,6 +54,7 @@ function renderOverlay({
   renamingPaneId = null
 }: {
   paneTitles: Record<number, string>
+  generatedPaneTitlesByLeaf?: Record<string, string>
   paneCount?: number
   showAlwaysOnHeaders?: boolean
   showSplitButton?: boolean
@@ -85,6 +87,7 @@ function renderOverlay({
         activePaneId={1}
         panes={panes}
         paneTitles={paneTitles}
+        generatedPaneTitlesByLeaf={generatedPaneTitlesByLeaf}
         paneTitleOverlayRects={{
           1: { left: 0, top: 0, width: 200 },
           2: { left: 220, top: 0, width: 200 }
@@ -159,6 +162,35 @@ describe('TerminalPaneHeaderOverlay', () => {
 
     expect(onRemoveTitle).toHaveBeenCalledWith(1)
     expect(onClosePane).not.toHaveBeenCalledWith(1)
+  })
+
+  it('shows the agent-generated name on a pane the user has not renamed', () => {
+    const { container } = renderOverlay({
+      paneTitles: { 1: '', 2: '' },
+      generatedPaneTitlesByLeaf: { 'leaf-1': 'Fix the flaky upload test' }
+    })
+
+    expect(
+      container.querySelector('button[aria-label="Edit pane title: Fix the flaky upload test"]')
+        ?.textContent
+    ).toBe('Fix the flaky upload test')
+    // Why: nothing is stored for a generated name, so the header must not offer
+    // to remove one; the untitled pane's close control stays in that slot.
+    expect(container.querySelector('button[aria-label^="Remove pane title"]')).toBeNull()
+    expect(container.querySelector('button[aria-label="Close Pane"]')).not.toBeNull()
+  })
+
+  it('lets a manual rename outrank the agent-generated name', () => {
+    const { container } = renderOverlay({
+      paneTitles: { 1: 'server', 2: '' },
+      generatedPaneTitlesByLeaf: { 'leaf-1': 'Fix the flaky upload test' }
+    })
+
+    expect(container.querySelector('button[aria-label="Edit pane title: server"]')).not.toBeNull()
+    expect(
+      container.querySelector('button[aria-label="Edit pane title: Fix the flaky upload test"]')
+    ).toBeNull()
+    expect(container.querySelector('button[aria-label="Remove pane title: server"]')).not.toBeNull()
   })
 
   it('keeps split and close-pane controls available for untitled split pane headers', () => {

--- a/src/renderer/src/components/terminal-pane/TerminalPaneHeaderOverlay.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneHeaderOverlay.tsx
@@ -32,6 +32,8 @@ type TerminalPaneHeaderOverlayProps = {
   activePaneId: number | null | undefined
   panes: readonly ManagedPane[]
   paneTitles: Readonly<Record<number, string>>
+  /** Agent-derived names keyed by leaf id, shown only where the pane has no manual title. */
+  generatedPaneTitlesByLeaf: Readonly<Record<string, string>>
   paneTitleOverlayRects: Readonly<Record<number, PaneTitleOverlayRect>>
   renamingPaneId: number | null
   renameValue: string
@@ -75,6 +77,7 @@ export default function TerminalPaneHeaderOverlay({
   activePaneId,
   panes,
   paneTitles,
+  generatedPaneTitlesByLeaf,
   paneTitleOverlayRects,
   renamingPaneId,
   renameValue,
@@ -118,7 +121,8 @@ export default function TerminalPaneHeaderOverlay({
       }}
     >
       {panes.map((pane) => {
-        const title = paneTitles[pane.id]
+        const manualTitle = paneTitles[pane.id]
+        const title = manualTitle || generatedPaneTitlesByLeaf[pane.leafId]
         const isEditing = renamingPaneId === pane.id
         const overlayRect = paneTitleOverlayRects[pane.id]
         const isActivePane = activePaneId === pane.id
@@ -338,7 +342,7 @@ export default function TerminalPaneHeaderOverlay({
                       </TooltipContent>
                     </Tooltip>
                   ) : null}
-                  {title ? (
+                  {manualTitle ? (
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <Button
@@ -353,7 +357,7 @@ export default function TerminalPaneHeaderOverlay({
                           aria-label={translate(
                             'auto.components.terminal.pane.TerminalPane.f984ab2a30',
                             'Remove pane title: {{value0}}',
-                            { value0: title }
+                            { value0: manualTitle }
                           )}
                         >
                           <X className="size-3" />

--- a/src/renderer/src/components/terminal-pane/session-restored-banner-pane-state.test.tsx
+++ b/src/renderer/src/components/terminal-pane/session-restored-banner-pane-state.test.tsx
@@ -26,7 +26,7 @@ function createPane(id: number): SessionRestoredBannerPane {
   container.className = 'pane'
   container.dataset.leafId = `leaf-${id}`
   document.body.appendChild(container)
-  return { id, container }
+  return { id, container, leafId: `leaf-${id}` as SessionRestoredBannerPane['leafId'] }
 }
 
 async function renderPortals(
@@ -98,6 +98,25 @@ describe('session restored banner pane state', () => {
     expect(needsFit).toBe(false)
     expect(activePane.container.hasAttribute('data-has-title')).toBe(false)
     expect(secondPane.container.hasAttribute('data-has-title')).toBe(false)
+  })
+
+  it('reserves title space for an agent-generated pane name', () => {
+    const generatedPane = createPane(1)
+    const plainPane = createPane(2)
+
+    const needsFit = syncSessionRestoredBannerTitleSpace({
+      panes: [generatedPane, plainPane],
+      paneTitles: {},
+      generatedPaneTitlesByLeaf: { 'leaf-1': 'Fix the flaky upload test' },
+      renamingPaneId: null,
+      sessionRestoredBannerPaneIds: new Map()
+    })
+
+    expect(needsFit).toBe(true)
+    // Why: the bar is absolutely positioned over xterm, so without the reservation
+    // the generated name would sit on top of the terminal's first row.
+    expect(generatedPane.container.hasAttribute('data-has-title')).toBe(true)
+    expect(plainPane.container.hasAttribute('data-has-title')).toBe(false)
   })
 
   it('reserves title space for explicit titles and inline rename', () => {

--- a/src/renderer/src/components/terminal-pane/session-restored-banner-pane-state.ts
+++ b/src/renderer/src/components/terminal-pane/session-restored-banner-pane-state.ts
@@ -1,6 +1,6 @@
 import type { ManagedPane } from '@/lib/pane-manager/pane-manager'
 
-export type SessionRestoredBannerPane = Pick<ManagedPane, 'id' | 'container'>
+export type SessionRestoredBannerPane = Pick<ManagedPane, 'id' | 'container' | 'leafId'>
 
 /** `resume-unavailable`: the pane asked to resume a provider session Orca could not
  *  verify, so it launched a fresh one — silence would read as a successful restore. */
@@ -93,6 +93,7 @@ export function seedStartupSessionRestoredBanner(
 export function syncSessionRestoredBannerTitleSpace(args: {
   panes: readonly SessionRestoredBannerPane[]
   paneTitles: Readonly<Record<number, string>>
+  generatedPaneTitlesByLeaf?: Readonly<Record<string, string>>
   renamingPaneId: number | null
   sessionRestoredBannerPaneIds: SessionRestoredBannerPaneReasons
 }): boolean {
@@ -100,6 +101,9 @@ export function syncSessionRestoredBannerTitleSpace(args: {
   for (const pane of args.panes) {
     const shouldShow =
       !!args.paneTitles[pane.id] ||
+      // Why: a generated name fills the same header bar, so the pane owes it the
+      // same reserved height or the bar would cover the terminal's first row.
+      !!args.generatedPaneTitlesByLeaf?.[pane.leafId] ||
       args.renamingPaneId === pane.id ||
       args.sessionRestoredBannerPaneIds.has(pane.id)
     const hadTitle = pane.container.hasAttribute('data-has-title')

--- a/src/renderer/src/components/terminal-pane/terminal-tab-generated-pane-titles.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-tab-generated-pane-titles.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import { createTerminalTabGeneratedPaneTitleSelector } from './terminal-tab-generated-pane-titles'
+
+function entry(paneKey: string, prompt: string): AgentStatusEntry {
+  const tabId = paneKey.slice(0, paneKey.indexOf(':'))
+  return {
+    state: 'working',
+    prompt,
+    updatedAt: 1,
+    stateStartedAt: 1,
+    agentType: 'claude',
+    paneKey,
+    tabId,
+    worktreeId: 'wt-1',
+    stateHistory: []
+  } as unknown as AgentStatusEntry
+}
+
+describe('generated pane titles', () => {
+  it('names each pane of a tab after its own agent prompt', () => {
+    const select = createTerminalTabGeneratedPaneTitleSelector()
+
+    expect(
+      select(
+        {
+          'tab-1:leaf-1': entry('tab-1:leaf-1', 'Please fix the flaky upload test. It times out.'),
+          'tab-1:leaf-2': entry('tab-1:leaf-2', 'can you write the release notes for the launch'),
+          'tab-2:leaf-1': entry('tab-2:leaf-1', 'Audit the billing webhook')
+        },
+        'tab-1'
+      )
+    ).toEqual({
+      'leaf-1': 'Fix the flaky upload test',
+      'leaf-2': 'Write the release notes for the launch'
+    })
+  })
+
+  it('keeps the record identity stable so an unrelated status write does not re-render a pane', () => {
+    const select = createTerminalTabGeneratedPaneTitleSelector()
+    const first = { 'tab-1:leaf-1': entry('tab-1:leaf-1', 'Fix the flaky upload test') }
+    const before = select(first, 'tab-1')
+    // A new map with the same prompt: production replaces this object on every write.
+    const after = select({ ...first }, 'tab-1')
+
+    expect(after).toBe(before)
+  })
+
+  it('follows the prompt when the pane starts a new piece of work', () => {
+    const select = createTerminalTabGeneratedPaneTitleSelector()
+    select({ 'tab-1:leaf-1': entry('tab-1:leaf-1', 'Fix the flaky upload test') }, 'tab-1')
+
+    expect(
+      select({ 'tab-1:leaf-1': entry('tab-1:leaf-1', 'Audit the billing webhook') }, 'tab-1')
+    ).toEqual({ 'leaf-1': 'Audit the billing webhook' })
+  })
+
+  it('omits a pane with no prompt and a tab with no agents', () => {
+    const select = createTerminalTabGeneratedPaneTitleSelector()
+    const state = {
+      'tab-1:leaf-1': entry('tab-1:leaf-1', ''),
+      'tab-1:leaf-2': entry('tab-1:leaf-2', '...')
+    }
+
+    expect(select(state, 'tab-1')).toEqual({})
+    expect(select(state, 'tab-9')).toEqual({})
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-tab-generated-pane-titles.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-tab-generated-pane-titles.ts
@@ -1,0 +1,86 @@
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import { deriveGeneratedTabTitle } from '../../../../shared/agent-tab-title'
+
+export type TerminalTabAgentStatusState = Record<string, AgentStatusEntry>
+export type GeneratedPaneTitlesByLeaf = Readonly<Record<string, string>>
+
+export const EMPTY_GENERATED_PANE_TITLES: GeneratedPaneTitlesByLeaf = Object.freeze({})
+
+function reuseRecordIfEqual(
+  previous: GeneratedPaneTitlesByLeaf | undefined,
+  next: Record<string, string>
+): GeneratedPaneTitlesByLeaf {
+  if (!previous) {
+    return next
+  }
+  const nextKeys = Object.keys(next)
+  if (Object.keys(previous).length !== nextKeys.length) {
+    return next
+  }
+  return nextKeys.every((key) => previous[key] === next[key]) ? previous : next
+}
+
+export function createTerminalTabGeneratedPaneTitleSelector(): (
+  state: TerminalTabAgentStatusState,
+  tabId: string
+) => GeneratedPaneTitlesByLeaf {
+  let cachedState: TerminalTabAgentStatusState | null = null
+  let cachedByTabId = new Map<string, GeneratedPaneTitlesByLeaf>()
+  // Why: setAgentStatus is high-frequency and most writes carry the same prompt,
+  // so the derivation is memoized per pane and only reruns when its prompt moves.
+  let cachedTitleByPaneKey = new Map<string, { prompt: string; title: string | null }>()
+
+  return (state, tabId) => {
+    // Why: production writes replace this map. Its identity lets unrelated
+    // Zustand notifications skip the global scan entirely.
+    if (state !== cachedState) {
+      const previousByTabId = cachedByTabId
+      const previousTitleByPaneKey = cachedTitleByPaneKey
+      const nextTitleByPaneKey = new Map<string, { prompt: string; title: string | null }>()
+      const nextByTabId = new Map<string, Record<string, string>>()
+      for (const [paneKey, entry] of Object.entries(state)) {
+        const prompt = entry.prompt
+        if (!prompt) {
+          continue
+        }
+        const separator = paneKey.indexOf(':')
+        if (separator <= 0) {
+          continue
+        }
+        const memoized = previousTitleByPaneKey.get(paneKey)
+        const derived =
+          memoized?.prompt === prompt
+            ? memoized
+            : { prompt, title: deriveGeneratedTabTitle(prompt) }
+        nextTitleByPaneKey.set(paneKey, derived)
+        if (!derived.title) {
+          continue
+        }
+        const entryTabId = paneKey.slice(0, separator)
+        const leafId = paneKey.slice(separator + 1)
+        const byLeaf = nextByTabId.get(entryTabId)
+        if (byLeaf) {
+          byLeaf[leafId] = derived.title
+        } else {
+          nextByTabId.set(entryTabId, { [leafId]: derived.title })
+        }
+      }
+
+      const stabilizedByTabId = new Map<string, GeneratedPaneTitlesByLeaf>()
+      for (const [entryTabId, byLeaf] of nextByTabId) {
+        stabilizedByTabId.set(
+          entryTabId,
+          reuseRecordIfEqual(previousByTabId.get(entryTabId), byLeaf)
+        )
+      }
+      cachedByTabId = stabilizedByTabId
+      cachedTitleByPaneKey = nextTitleByPaneKey
+      cachedState = state
+    }
+    return cachedByTabId.get(tabId) ?? EMPTY_GENERATED_PANE_TITLES
+  }
+}
+
+// Why: TerminalPane is mounted once per retained tab. Share one index so a
+// store write derives each pane's title once, not once for every hidden tab.
+export const selectTerminalTabGeneratedPaneTitles = createTerminalTabGeneratedPaneTitleSelector()

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -16368,6 +16368,17 @@
         "days": "{{value0}}d",
         "underOneMinute": "<1m"
       }
+    },
+    "settings": {
+      "agentGeneratedTerminalTitles": {
+        "title": "Auto-generate terminal titles",
+        "description": "Name each terminal in a split from the agent running in it, so a tab full of sessions reads at a glance. Manual renames always win.",
+        "keyword": {
+          "terminal": "terminal",
+          "pane": "pane",
+          "split": "split"
+        }
+      }
     }
   },
   "dashboardPopout": {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -343,6 +343,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     agentYoloDefaultsMigrated: true,
     agentStatusHooksEnabled: true,
     tabAutoGenerateTitle: false,
+    terminalAutoGenerateTitle: false,
     confirmClosePinnedTab: true,
     keepComputerAwakeWhileAgentsRun: false,
     // Why: 'auto' probes keyboard layout so non-US users can type Option chars like @/€/[ out of the box (issue #903). See src/renderer/src/lib/keyboard-layout/*.

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -369,6 +369,9 @@ export type GlobalSettings = {
   dismissedSkillFreshnessNudges?: string[]
   /** Why: generated tab titles are subjective, so they stay opt-in and manual renames win. */
   tabAutoGenerateTitle: boolean
+  /** Why: a titled pane reserves header height and refits its PTY, so naming the
+   *  terminals inside a split stays opt-in and separate from the tab setting. */
+  terminalAutoGenerateTitle: boolean
   /** Why: pinned tabs can still be closed via keyboard/native-menu; this gates that behind a confirmation. Defaults on. */
   confirmClosePinnedTab: boolean
   /** When true, Orca requests local awake assertions while hook-reported agents are working. */


### PR DESCRIPTION
## ELI5

Orca can already name a **tab** after what the agent is doing. It cannot name the **terminals inside** it. Split a tab into four panes and you get four identical black rectangles, and the only way to tell them apart is to rename each one by hand from the context menu. This adds the pane version of the setting that already exists for tabs: each terminal shows a short name taken from the prompt of the agent running in it, and typing your own name over it still wins.

## What Changed

New setting **Auto-generate terminal titles**, off by default, next to **Auto-generate tab titles** in Settings → Agents.

When it is on, a pane with no manual title renders a name in the header bar it already has, derived from that pane's own agent prompt through the existing `deriveGeneratedTabTitle`. Concretely:

- `terminal-tab-generated-pane-titles.ts` — a shared, cached selector, built on the same pattern as `terminal-tab-agent-type-index.ts`: one scan per `agentStatusByPaneKey` write for every mounted tab, memoized per pane so a repeated prompt does not re-derive, and identity-stable so an unrelated status write re-renders nothing.
- `TerminalPaneHeaderOverlay` — falls back to the generated name only when the pane has no manual title. The **Remove title** control stays bound to the manual title, so an auto-named pane keeps the ordinary close-pane control.
- `TerminalPane` — subscribes only when the setting is on (`EMPTY_GENERATED_PANE_TITLES` otherwise), and **Set Title…** on an auto-named pane opens on that name so editing is a correction rather than a retype.
- `syncSessionRestoredBannerTitleSpace` — reserves the same header height a manual title reserves. Without it the absolutely-positioned bar would sit on the terminal's first row.

The generated name is display-only. It never enters `paneTitles`, so it is never persisted into `titlesByLeafId`, nothing is written to disk, and turning the setting off restores the previous look exactly.

## Why

The tab strip can carry one name; a split tab runs several sessions. The name that is missing is the one on the terminal itself, which is why **Set Title…** exists at all — this just stops it being manual for the common case.

Off by default is deliberate: a titled pane reserves 24px and refits its PTY, and a layout change should be asked for, not delivered by an update.

## Linked Issue

Fixes #15780

## Visual Proof

Two panes in one tab, one agent per pane, tab titles left off so only the new behaviour moves.

**Before** — the tab reads `Terminal 1`, both panes are anonymous:

![before](https://raw.githubusercontent.com/heyramzi/orca/assets/generated-terminal-titles/pane-titles-before.png)

**After** — each terminal says what it is doing:

![after](https://raw.githubusercontent.com/heyramzi/orca/assets/generated-terminal-titles/pane-titles-after.png)

Captured on macOS from the Electron app under the repo's own Playwright harness, with two agent statuses seeded onto the two panes.

## Testing

- `pnpm lint`, `pnpm typecheck` clean.
- `npx vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane src/renderer/src/components/settings src/shared/workspace-session-schema.test.ts src/main/codex-accounts` → 578 files, 5059 passed.
- New tests: the selector (per-pane naming, identity stability across a same-prompt write, following the prompt into new work, empty prompts omitted), the header (generated name shown and no remove-title affordance; a manual rename outranking it), and the header-height reservation for a generated name.
- Ran on macOS through the repo's Playwright Electron harness: split a tab, seeded one agent per pane, captured the two screenshots above, and confirmed the panes return to chromeless when the setting is toggled back off. The rename-on-generated-name path is covered by review and the header tests, not by an interactive click-through.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Written with Claude Opus 5 in Claude Code, reviewed line by line by me.

## Review

Cross-platform: no platform branches, no paths, no shortcuts; the selector and the fallback are plain data and JSX.

SSH / remote / paired web: reads `agentStatusByPaneKey`, which the runtime already fans out to remote and paired hosts, and writes nothing back. Panes on a remote host behave the same as local ones; a host that reports no agent status simply produces no title.

Agents and integrations: provider-neutral. Any agent that reports a prompt gets a name, no per-agent branch anywhere.

Performance: the derivation is shared across mounted tabs, memoized per pane, and skipped entirely while the setting is off; the returned record keeps its identity when nothing changed, so a status write does not re-render an unaffected pane. The one cost is the existing refit when a header first appears, the same one a manual title pays.

Security: no new IPC, no new file or network access, and nothing is persisted.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Backwards compatible: the setting defaults to `false`, older sessions without the key read as off, and nothing new is written to the workspace session file.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

X: [@heyramzi](https://x.com/heyramzi)
