### PR TITLE
fix(git): enable long paths when creating Windows worktrees

### DIFF
--- a/src/main/git/worktree-add-creation-config.test.ts
+++ b/src/main/git/worktree-add-creation-config.test.ts
@@ -99,6 +99,43 @@ describe('addWorktree', () => {
     ])
   })
 
+  it('enables long paths for native Windows worktree creation', async () => {
+    const platform = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
+
+    try {
+      await addWorktree('/repo', '/repo-feature', 'feature/test', 'feature/test', false, false, {
+        checkoutExistingBranch: true
+      })
+
+      expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+        ['-c', 'core.longpaths=true', 'worktree', 'add', '/repo-feature', 'feature/test'],
+        { cwd: '/repo', timeout: WORKTREE_ADD_TIMEOUT_MS }
+      )
+    } finally {
+      platform.mockRestore()
+    }
+  })
+
+  it('does not pass the Windows-only long-path option to WSL Git', async () => {
+    const platform = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
+
+    try {
+      await addWorktree('/repo', '/repo-feature', 'feature/test', 'feature/test', false, false, {
+        checkoutExistingBranch: true,
+        wslDistro: 'Ubuntu'
+      })
+
+      expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+        ['worktree', 'add', '/repo-feature', 'feature/test'],
+        { cwd: '/repo', wslDistro: 'Ubuntu', timeout: WORKTREE_ADD_TIMEOUT_MS }
+      )
+    } finally {
+      platform.mockRestore()
+    }
+  })
+
   it('bounds the worktree add call with a positive timeout (STA-1292 OneDrive stall guard)', async () => {
     // Why: without a timeout, a OneDrive cloud-placeholder checkout can stall
     // `git worktree add` for minutes. Assert the runner receives a non-zero

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -975,7 +975,11 @@ async function performAddWorktree(
 ): Promise<AddWorktreeResult> {
   let localBaseRefRefresh: LocalBaseRefRefreshResult | undefined
   let localBaseRefUpdateSuggestion: LocalBaseRefUpdateSuggestion | undefined
-  const args = ['worktree', 'add']
+  // Why: enable long paths for this Windows checkout without changing user Git config.
+  const args =
+    process.platform === 'win32' && !options.wslDistro
+      ? ['-c', 'core.longpaths=true', 'worktree', 'add']
+      : ['worktree', 'add']
   let effectiveBase: string | undefined
   if (noCheckout) {
     args.push('--no-checkout')


### PR DESCRIPTION
## ELI5

Windows can reject deeply nested checkout paths. Git for Windows can be installed with long-path handling disabled, so ordinary users can hit this while creating a worktree in a deep directory. When Orca creates a local worktree on Windows, it now asks Git to enable long-path handling for that one `git worktree add` command. Users do not need to discover and change their global Git settings to use a core Orca workflow.

## What Changed

- Updated `src/main/git/worktree.ts` so native Windows `git worktree add` is invoked as `git -c core.longpaths=true worktree add ...`.
- Kept the option before the `worktree` subcommand because `-c` is a global Git option.
- Excluded WSL-routed Git (`wslDistro`), which runs in the Linux guest rather than against native Windows paths.
- Added unit coverage in `src/main/git/worktree-add-creation-config.test.ts` for both native Windows and WSL command construction.

## Why

The worktree checkout can exceed the legacy Windows path limit when the workspace root, branch name, and tracked file path are combined. This can affect users with a standard Git for Windows installation because the current manual remedy is a `git config` change. Since worktree creation is a core Orca workflow, failing before the worktree is created is a high-impact failure. Applying `core.longpaths=true` on the command avoids persistent changes to global or repository Git configuration and is compatible with Orca's Git 2.25 baseline because it uses Git's command-line configuration option rather than the newer indexed environment-config protocol.

## Linked Issue

Fixes #15785

## Visual Proof

<img width="800" height="544" alt="image" src="https://github.com/user-attachments/assets/9afd4bcd-1860-42d1-b01a-d870f9777332" />

## Testing

- [x] Manually verified on native Windows.
- [x] Automated tests added/updated.

Commands run:

- `pnpm exec vitest run --config config/vitest.config.ts src/main/git/worktree-add-creation-config.test.ts`
- `git diff --check`
- `pnpm exec oxlint src/main/git/worktree.ts src/main/git/worktree-add-creation-config.test.ts`
- `pnpm exec tsc --noEmit -p config/tsconfig.node.json --composite false`

## AI Disclosure

Developed with OpenAI Codex (GPT-5).

## Review

- **Cross-platform:** The command option is gated by `process.platform === 'win32'`; macOS and Linux keep the existing argv.
- **WSL:** Calls with `wslDistro` keep the existing Linux Git argv.
- **SSH / remote:** Unchanged. This path handles local worktree creation; remote hosts keep their existing execution paths.
- **Git compatibility:** `-c core.longpaths=true` is placed before the subcommand and avoids reliance on `GIT_CONFIG_COUNT` support.
- **Security / configuration:** No user or repository Git configuration is written.
- **Performance:** One static Git option is added only to native Windows worktree creation.

## Agent skill upstream boundary

- [x] Not applicable; this change copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Checklist

- [x] This PR is small and focused.
- [x] I explained what changed and why, including ELI5.
- [ ] Visual proof is N/A because there is no UI change.
- [x] Self-reviewed for correctness, security, and performance.
- [x] Cross-platform, WSL, SSH, and remote impact considered.
- [x] Full `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` were not run locally; CI should cover the remaining checks.

## Author

Github: @hwantage 
