### PR TITLE
feat(terminal): rename a pane by double-clicking its header

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPaneHeaderOverlay.test.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneHeaderOverlay.test.tsx
@@ -47,6 +47,7 @@ function renderOverlay({
   onClosePane = vi.fn(),
   onRemoveTitle = vi.fn(),
   onRenameSubmit = vi.fn(),
+  onStartRename = vi.fn(),
   canContinueAgentSessionInNewSession = false,
   onContinueAgentSessionInNewSession = vi.fn(),
   renameValue = '',
@@ -59,6 +60,7 @@ function renderOverlay({
   onClosePane?: ReturnType<typeof vi.fn>
   onRemoveTitle?: ReturnType<typeof vi.fn>
   onRenameSubmit?: ReturnType<typeof vi.fn>
+  onStartRename?: ReturnType<typeof vi.fn>
   canContinueAgentSessionInNewSession?: boolean
   onContinueAgentSessionInNewSession?: ReturnType<typeof vi.fn>
   renameValue?: string
@@ -68,6 +70,7 @@ function renderOverlay({
   onClosePane: ReturnType<typeof vi.fn>
   onRemoveTitle: ReturnType<typeof vi.fn>
   onRenameSubmit: ReturnType<typeof vi.fn>
+  onStartRename: ReturnType<typeof vi.fn>
 } {
   const panes = [makePane(1), makePane(2)]
   const container = document.createElement('div')
@@ -106,7 +109,7 @@ function renderOverlay({
         onBeginPaneDrag={vi.fn()}
         onActivatePaneTitleInteraction={vi.fn()}
         onPaneTitleContextMenu={vi.fn()}
-        onStartRename={vi.fn()}
+        onStartRename={onStartRename as (paneId: number) => void}
         onRemoveTitle={onRemoveTitle as (paneId: number) => void}
         onClosePane={onClosePane as (paneId: number) => void}
         onRenameValueChange={vi.fn()}
@@ -117,7 +120,7 @@ function renderOverlay({
     )
   })
   mounted.push({ container, root })
-  return { container, onClosePane, onRemoveTitle, onRenameSubmit }
+  return { container, onClosePane, onRemoveTitle, onRenameSubmit, onStartRename }
 }
 
 function pressInputKey(
@@ -185,6 +188,59 @@ describe('TerminalPaneHeaderOverlay', () => {
     })
 
     expect(container.querySelector('button[aria-label="Split Terminal Right"]')).toBeNull()
+  })
+
+  it('starts a rename when an untitled pane header is double-clicked', () => {
+    const { container, onStartRename } = renderOverlay({ paneTitles: {} })
+    const header = container.querySelector<HTMLElement>('.pane-title-bar')
+    expect(header).not.toBeNull()
+
+    act(() => {
+      header!.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }))
+    })
+
+    expect(onStartRename).toHaveBeenCalledWith(1)
+  })
+
+  it('starts a rename from the drag-handle strip, which is not a title button', () => {
+    const { container, onStartRename } = renderOverlay({
+      paneTitles: { 1: 'Build' },
+      showAlwaysOnHeaders: false
+    })
+    const handle = container.querySelector<HTMLElement>('.pane-title-drag-handle')
+    expect(handle).not.toBeNull()
+
+    act(() => {
+      handle!.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }))
+    })
+
+    expect(onStartRename).toHaveBeenCalledWith(1)
+  })
+
+  it('leaves header action buttons alone on double-click', () => {
+    const { container, onStartRename } = renderOverlay({ paneTitles: { 1: 'Build' } })
+    const action = container.querySelector<HTMLElement>('.pane-title-actions button')
+    expect(action).not.toBeNull()
+
+    act(() => {
+      action!.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }))
+    })
+
+    expect(onStartRename).not.toHaveBeenCalled()
+  })
+
+  it('does not restart a rename that is already open', () => {
+    const { container, onStartRename } = renderOverlay({
+      paneTitles: { 1: 'Build' },
+      renamingPaneId: 1
+    })
+    const header = container.querySelector<HTMLElement>('.pane-title-bar')
+
+    act(() => {
+      header!.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }))
+    })
+
+    expect(onStartRename).not.toHaveBeenCalled()
   })
 
   it('ignores IME composition Enter before submitting a pane title rename', () => {

--- a/src/renderer/src/components/terminal-pane/TerminalPaneHeaderOverlay.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneHeaderOverlay.tsx
@@ -15,6 +15,12 @@ import { isImeCompositionKeyDown } from '@/lib/ime-composition-keyboard-event'
 import type { PtyTransport } from './pty-transport'
 import { handleInternalTerminalFileDrop } from './terminal-drop-handler'
 
+/** True when the event started on one of the header's action buttons, whose own
+ *  double-click must not be reinterpreted as a rename. */
+function isPaneTitleActionTarget(target: EventTarget | null): boolean {
+  return target instanceof Element && target.closest('.pane-title-actions') !== null
+}
+
 export type PaneTitleOverlayRect = {
   left: number
   top: number
@@ -176,6 +182,17 @@ export default function TerminalPaneHeaderOverlay({
               })
             }}
             onContextMenuCapture={(event) => onPaneTitleContextMenu(event, pane.id)}
+            onDoubleClick={(event) => {
+              // Why: an untitled pane renders no title button, so renaming it
+              // otherwise needs the context menu. Double-clicking the bar — the
+              // drag-handle strip included — is the gesture users already try.
+              if (isEditing || isPaneTitleActionTarget(event.target)) {
+                return
+              }
+              event.preventDefault()
+              onActivatePaneTitleInteraction(pane.id)
+              onStartRename(pane.id)
+            }}
             style={{
               left: overlayRect.left,
               top: overlayRect.top,


### PR DESCRIPTION
## ELI5

Double-click the strip at the top of a split pane and you can type a new name for it, then press Enter. Today you have to right-click and hunt for "Set title".

## What Changed

`TerminalPaneHeaderOverlay` now starts the existing inline rename on a double-click anywhere on the pane title bar, including the `...` drag-handle strip.

- Reuses `onStartRename` and the existing rename input — no new UI, no new setting, no new state.
- Enter saves and Escape cancels, unchanged.
- A double-click that starts inside `.pane-title-actions` is ignored, so the split / close / chat buttons keep their own behaviour.
- A double-click while the editor is already open is ignored rather than restarting it.

## Why

Click-to-rename already exists, but only on the title text. An untitled pane renders no title text, so there is nothing to click — and the drag-handle strip drags instead. That leaves the context menu as the only way to name a pane, which is the case people hit most often, since a pane is untitled precisely when you want to name it.

Double-click is the gesture people already try on a title bar, so this makes the existing editor reachable rather than adding a second way to rename.

## Linked Issue

Fixes #15790

## Visual Proof

<!-- TODO(ramzi): before = right-click → Set title; after = double-click the header, type, Enter. -->

## Testing

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `npx vitest run src/renderer/src/components/terminal-pane/TerminalPaneHeaderOverlay.test.tsx` — 9 passed

Four new cases: double-click on an untitled header starts the rename; double-click on the drag-handle strip starts it; a double-click on a header action button does not; a double-click while already editing does not restart it.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated

## AI Disclosure

Written with Claude Opus 5.

## Review

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

- **Cross-platform** — a plain `dblclick`, no modifier or platform key involved.
- **Remote SSH** — renderer-only; the rename commit path is unchanged, including the Tab-commit fallback that exists for headless/no-window-focus environments.
- **Accessibility** — the existing title button and its `aria-label` are untouched, so the keyboard and screen-reader path is unchanged. This adds a pointer shortcut alongside it, not a replacement.
- **Adjacent work** — touches `TerminalPaneHeaderOverlay.tsx`, which #15781 also changes. Happy to rebase whichever lands second.
- **Backwards compatibility / performance** — one handler on an element that already has several; no new state or persisted field.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `pnpm lint` and `pnpm typecheck` pass locally; touched tests pass
