### PR TITLE
feat(tabs): optional agent-state emoji in tab titles

### DIFF
--- a/src/main/codex-accounts/runtime-home-settings-test-fixtures.ts
+++ b/src/main/codex-accounts/runtime-home-settings-test-fixtures.ts
@@ -15,6 +15,7 @@ export function createSettings(overrides: TestSettingsOverrides = {}): GlobalSet
   const appFontFamily = overrides.appFontFamily ?? 'Geist'
   const agentStatusHooksEnabled = overrides.agentStatusHooksEnabled ?? true
   const tabAutoGenerateTitle = overrides.tabAutoGenerateTitle ?? false
+  const tabStatusEmoji = overrides.tabStatusEmoji ?? false
   // Mirror-path tests assert the shared runtime home, which production still uses
   // on Windows; opt these cases onto that lane unless a test overrides it.
   setShellStartupEnvProbeSupportedForTest(overrides.shellStartupEnvProbeSupported ?? false)
@@ -134,6 +135,7 @@ export function createSettings(overrides: TestSettingsOverrides = {}): GlobalSet
     leftSidebarAppearanceMode: overrides.leftSidebarAppearanceMode ?? 'default',
     appFontFamily,
     agentStatusHooksEnabled,
-    tabAutoGenerateTitle
+    tabAutoGenerateTitle,
+    tabStatusEmoji
   }
 }

--- a/src/main/codex-accounts/service-test-harness.ts
+++ b/src/main/codex-accounts/service-test-harness.ts
@@ -39,6 +39,7 @@ export function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalS
   const appFontFamily = overrides.appFontFamily ?? 'Geist'
   const agentStatusHooksEnabled = overrides.agentStatusHooksEnabled ?? true
   const tabAutoGenerateTitle = overrides.tabAutoGenerateTitle ?? false
+  const tabStatusEmoji = overrides.tabStatusEmoji ?? false
   return {
     workspaceDir: testState.fakeHomeDir,
     nestWorkspaces: false,
@@ -155,7 +156,8 @@ export function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalS
     leftSidebarAppearanceMode: overrides.leftSidebarAppearanceMode ?? 'default',
     appFontFamily,
     agentStatusHooksEnabled,
-    tabAutoGenerateTitle
+    tabAutoGenerateTitle,
+    tabStatusEmoji
   }
 }
 

--- a/src/renderer/src/components/settings/AgentsPane.tsx
+++ b/src/renderer/src/components/settings/AgentsPane.tsx
@@ -46,6 +46,7 @@ import {
 import { AgentAvailabilityControl, type AgentCatalogRowProps } from './AgentCatalogRow'
 import { AgentDefaultSetting } from './AgentDefaultSetting'
 import { AgentDetectionCatalog } from './AgentDetectionCatalog'
+import { getTabStatusEmojiDescription, getTabStatusEmojiTitle } from './tab-status-emoji-copy'
 
 export {
   buildAgentAvailabilitySettingsUpdate,
@@ -256,6 +257,7 @@ export function AgentsPane({
       />
       <AgentStatusHooksSetting settings={settings} updateSettings={updateSettings} />
       <AgentGeneratedTabTitlesSetting settings={settings} updateSettings={updateSettings} />
+      <TabStatusEmojiSetting settings={settings} updateSettings={updateSettings} />
       {!isPairedWebClientWindow() ? (
         <AgentAwakeSetting settings={settings} updateSettings={updateSettings} />
       ) : null}
@@ -306,6 +308,24 @@ export function AgentGeneratedTabTitlesSetting({ settings, updateSettings }: Age
         checked={enabled}
         onChange={() => updateSettings({ tabAutoGenerateTitle: !enabled })}
         ariaLabel={getAgentGeneratedTabTitlesTitle()}
+      />
+    </section>
+  )
+}
+
+export function TabStatusEmojiSetting({
+  settings,
+  updateSettings
+}: AgentsPaneProps): React.JSX.Element {
+  const enabled = settings.tabStatusEmoji === true
+  return (
+    <section className="space-y-3">
+      <SettingsSwitchRow
+        label={getTabStatusEmojiTitle()}
+        description={getTabStatusEmojiDescription()}
+        checked={enabled}
+        onChange={() => updateSettings({ tabStatusEmoji: !enabled })}
+        ariaLabel={getTabStatusEmojiTitle()}
       />
     </section>
   )

--- a/src/renderer/src/components/settings/agents-search.ts
+++ b/src/renderer/src/components/settings/agents-search.ts
@@ -18,6 +18,11 @@ import { getAgentCacheTimerSearchEntries } from './agent-cache-timer-search'
 import { translate } from '@/i18n/i18n'
 import { searchKeywords, translateSearchKeyword, uniqueKeywords } from './settings-search-keywords'
 import { createLocalizedCatalog } from '@/i18n/localized-catalog'
+import {
+  getTabStatusEmojiDescription,
+  getTabStatusEmojiSearchKeywords,
+  getTabStatusEmojiTitle
+} from './tab-status-emoji-copy'
 
 function buildAgentSettingsKeywords(): string[] {
   const keywords = searchKeywords([
@@ -112,6 +117,11 @@ const getAllAgentsPaneSearchEntries = createLocalizedCatalog(() => [
     title: getAgentGeneratedTabTitlesTitle(),
     description: getAgentGeneratedTabTitlesDescription(),
     keywords: getAgentGeneratedTabTitlesSearchKeywords()
+  },
+  {
+    title: getTabStatusEmojiTitle(),
+    description: getTabStatusEmojiDescription(),
+    keywords: getTabStatusEmojiSearchKeywords()
   },
   {
     title: getAgentAwakeTitle(),

--- a/src/renderer/src/components/settings/tab-status-emoji-copy.ts
+++ b/src/renderer/src/components/settings/tab-status-emoji-copy.ts
@@ -1,0 +1,30 @@
+import { translate } from '@/i18n/i18n'
+import { searchKeywords } from './settings-search-keywords'
+
+const TAB_STATUS_EMOJI_TITLE_KEY = 'auto.components.settings.tab-status-emoji-copy.title'
+const TAB_STATUS_EMOJI_DESCRIPTION_KEY =
+  'auto.components.settings.tab-status-emoji-copy.description'
+
+export function getTabStatusEmojiTitle(): string {
+  return translate(TAB_STATUS_EMOJI_TITLE_KEY, 'Show agent state in tab titles')
+}
+
+export function getTabStatusEmojiDescription(): string {
+  return translate(
+    TAB_STATUS_EMOJI_DESCRIPTION_KEY,
+    'Prefix a tab with ⚙ while its agent works, ✋ when it needs you, and ✅ when it finishes.'
+  )
+}
+
+export function getTabStatusEmojiSearchKeywords(): string[] {
+  return searchKeywords([
+    { key: 'auto.components.settings.agents.search.96ba2373b6', fallback: 'agent' },
+    { key: 'auto.components.settings.agents.search.be7ea3553b', fallback: 'tab' },
+    { key: 'auto.components.settings.agents.search.6956646a1e', fallback: 'title' },
+    { key: 'auto.components.settings.tab.status.emoji.emoji', fallback: 'emoji' },
+    { key: 'auto.components.settings.tab.status.emoji.status', fallback: 'status' },
+    { key: 'auto.components.settings.tab.status.emoji.indicator', fallback: 'indicator' },
+    { key: 'auto.components.settings.tab.status.emoji.working', fallback: 'working' },
+    { key: 'auto.components.settings.tab.status.emoji.done', fallback: 'done' }
+  ])
+}

--- a/src/renderer/src/components/tab-bar/SortableTab.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useSortable } from '@dnd-kit/sortable'
 import { X, Minimize2, Pin } from 'lucide-react'
-import { stripLeadingAgentTitleDecoration } from '../../../../shared/agent-title-decoration'
 import { useTabAgent } from '@/lib/use-tab-agent'
 import { isImeCompositionKeyDown } from '@/lib/ime-composition-keyboard-event'
 import { Input } from '@/components/ui/input'
@@ -23,6 +22,7 @@ import { TAB_CONTAINER_WIDTH_CLASSES, TAB_LABEL_WIDTH_CLASSES } from './tab-widt
 import { useOptionalShortcutLabel } from '@/hooks/useShortcutLabel'
 import { useTabStripPointerActivation } from './tab-strip-pointer-activation'
 import { TerminalTabLeadingIcon } from './TerminalTabLeadingIcon'
+import { useTabDisplayTitle } from '@/lib/tab-status-emoji'
 import {
   isTerminalTabActivityLive,
   resolveTerminalTabActivityStatus,
@@ -116,8 +116,7 @@ export default function SortableTab({
   const tabAgent = useTabAgent(tab)
 
   // Why: with a provider icon shown, strip the agent's own leading glyph so the tab doesn't show two icons for one agent.
-  const displayTitle =
-    tab.customTitle ?? (tabAgent ? stripLeadingAgentTitleDecoration(tab.title) : tab.title)
+  const displayTitle = useTabDisplayTitle(tab, Boolean(tabAgent), activityStatus)
 
   const { attributes, listeners, setNodeRef } = useSortable({
     id: tab.id,

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11305,6 +11305,21 @@
         },
         "shortcutDefinitionCatalog": {
           "missionControlConflict": "Blocked by Mission Control. Remap here or change it in System Settings."
+        },
+        "tab-status-emoji-copy": {
+          "title": "Show agent state in tab titles",
+          "description": "Prefix a tab with ⚙ while its agent works, ✋ when it needs you, and ✅ when it finishes."
+        },
+        "tab": {
+          "status": {
+            "emoji": {
+              "emoji": "emoji",
+              "status": "status",
+              "indicator": "indicator",
+              "working": "working",
+              "done": "done"
+            }
+          }
         }
       },
       "right": {

--- a/src/renderer/src/lib/tab-status-emoji.test.ts
+++ b/src/renderer/src/lib/tab-status-emoji.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { getTabStatusEmoji, prefixTabTitleWithStatusEmoji } from './tab-status-emoji'
+
+describe('getTabStatusEmoji', () => {
+  it.each([
+    ['working', '⚙'],
+    ['permission', '✋'],
+    ['done', '✅']
+  ] as const)('marks %s', (status, emoji) => {
+    expect(getTabStatusEmoji(status)).toBe(emoji)
+  })
+
+  it.each(['active', 'inactive'] as const)('leaves %s unmarked', (status) => {
+    expect(getTabStatusEmoji(status)).toBeNull()
+  })
+
+  it('tolerates a missing status', () => {
+    expect(getTabStatusEmoji(null)).toBeNull()
+    expect(getTabStatusEmoji(undefined)).toBeNull()
+  })
+})
+
+describe('prefixTabTitleWithStatusEmoji', () => {
+  it('prefixes only when the setting is on', () => {
+    expect(prefixTabTitleWithStatusEmoji('Build', 'working', true)).toBe('⚙ Build')
+    expect(prefixTabTitleWithStatusEmoji('Build', 'working', false)).toBe('Build')
+  })
+
+  it('leaves a title alone when the status carries no marker', () => {
+    expect(prefixTabTitleWithStatusEmoji('Build', 'inactive', true)).toBe('Build')
+  })
+
+  it('never returns a lone glyph for an empty title', () => {
+    expect(prefixTabTitleWithStatusEmoji('', 'working', true)).toBe('')
+    expect(prefixTabTitleWithStatusEmoji('   ', 'done', true)).toBe('   ')
+  })
+
+  // Why: the status resolver reruns on every store write, so a naive prefix
+  // would stack glyphs into "⚙ ⚙ ⚙ Build".
+  it('does not stack the marker when reapplied', () => {
+    const once = prefixTabTitleWithStatusEmoji('Build', 'working', true)
+    expect(prefixTabTitleWithStatusEmoji(once, 'working', true)).toBe('⚙ Build')
+  })
+
+  it('replaces the previous marker when the status changes', () => {
+    const working = prefixTabTitleWithStatusEmoji('Build', 'working', true)
+    expect(prefixTabTitleWithStatusEmoji(working, 'done', true)).toBe('✅ Build')
+  })
+})

--- a/src/renderer/src/lib/tab-status-emoji.ts
+++ b/src/renderer/src/lib/tab-status-emoji.ts
@@ -1,0 +1,83 @@
+import { useAppStore } from '@/store'
+import { stripLeadingAgentTitleDecoration } from '../../../shared/agent-title-decoration'
+import type { WorktreeStatus } from './worktree-status'
+
+// Why: Orca strips the agent's own leading glyph so a tab does not show two
+// icons for one agent (agent-title-decoration.ts). This puts back a single
+// glyph that reports *state* rather than identity, and only when the user asks
+// for it — the provider icon still owns "which agent".
+const TAB_STATUS_EMOJI: Partial<Record<WorktreeStatus, string>> = {
+  working: '⚙',
+  permission: '✋',
+  done: '✅'
+}
+
+export function getTabStatusEmoji(status: WorktreeStatus | null | undefined): string | null {
+  return (status && TAB_STATUS_EMOJI[status]) ?? null
+}
+
+// Why: the status resolver reruns on every store write and the status itself
+// changes as the agent works, so stripping any known marker first keeps the
+// prefix idempotent instead of stacking "✅ ⚙ Build".
+const LEADING_TAB_STATUS_EMOJI_RE = new RegExp(
+  `^(?:${Object.values(TAB_STATUS_EMOJI).join('|')})\\s+`
+)
+
+export function stripTabStatusEmoji(title: string): string {
+  return title.replace(LEADING_TAB_STATUS_EMOJI_RE, '')
+}
+
+/**
+ * Prefix a tab title with a one-glyph status marker.
+ *
+ * Returns the title untouched when the setting is off, when the status carries
+ * no marker ('active' / 'inactive' are not states worth a glyph), or when the
+ * title is empty — a lone glyph would read as a blank tab.
+ */
+export function prefixTabTitleWithStatusEmoji(
+  title: string,
+  status: WorktreeStatus | null | undefined,
+  enabled: boolean
+): string {
+  if (!enabled) {
+    return title
+  }
+  const emoji = getTabStatusEmoji(status)
+  if (!emoji || !title.trim()) {
+    return title
+  }
+  return `${emoji} ${stripTabStatusEmoji(title)}`
+}
+
+/**
+ * The label a tab shows: the manual rename if there is one, otherwise the live
+ * title with the agent's own leading glyph stripped, optionally prefixed with a
+ * state marker.
+ */
+export function resolveTabDisplayTitle(args: {
+  customTitle: string | null | undefined
+  title: string
+  hasAgent: boolean
+  status: WorktreeStatus | null | undefined
+  statusEmojiEnabled: boolean
+}): string {
+  const resolved =
+    args.customTitle ?? (args.hasAgent ? stripLeadingAgentTitleDecoration(args.title) : args.title)
+  return prefixTabTitleWithStatusEmoji(resolved, args.status, args.statusEmojiEnabled)
+}
+
+/** Selector-scoped wrapper so a tab reads the setting as one primitive. */
+export function useTabDisplayTitle(
+  tab: { customTitle?: string | null; title: string },
+  hasAgent: boolean,
+  status: WorktreeStatus | null | undefined
+): string {
+  const statusEmojiEnabled = useAppStore((s) => s.settings?.tabStatusEmoji === true)
+  return resolveTabDisplayTitle({
+    customTitle: tab.customTitle,
+    title: tab.title,
+    hasAgent,
+    status,
+    statusEmojiEnabled
+  })
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -343,6 +343,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     agentYoloDefaultsMigrated: true,
     agentStatusHooksEnabled: true,
     tabAutoGenerateTitle: false,
+    tabStatusEmoji: false,
     confirmClosePinnedTab: true,
     keepComputerAwakeWhileAgentsRun: false,
     // Why: 'auto' probes keyboard layout so non-US users can type Option chars like @/€/[ out of the box (issue #903). See src/renderer/src/lib/keyboard-layout/*.

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -369,6 +369,8 @@ export type GlobalSettings = {
   dismissedSkillFreshnessNudges?: string[]
   /** Why: generated tab titles are subjective, so they stay opt-in and manual renames win. */
   tabAutoGenerateTitle: boolean
+  /** Prefix tab titles with a one-glyph agent-state marker (off by default). */
+  tabStatusEmoji: boolean
   /** Why: pinned tabs can still be closed via keyboard/native-menu; this gates that behind a confirmation. Defaults on. */
   confirmClosePinnedTab: boolean
   /** When true, Orca requests local awake assertions while hook-reported agents are working. */


### PR DESCRIPTION
## ELI5

Turn on a setting and each tab gets a small glyph in front of its name: ⚙ while the agent is working, ✋ when it wants your input, ✅ when it is finished. Off by default, so nothing changes unless you ask for it.

## What Changed

- New `tabStatusEmoji` setting (default `false`) in `global-settings-types.ts` / `constants.ts`, with a toggle beside "Auto-generate tab titles" in Settings → Agents and an entry in settings search.
- New `src/renderer/src/lib/tab-status-emoji.ts`: `getTabStatusEmoji`, `prefixTabTitleWithStatusEmoji`, `stripTabStatusEmoji`, and a `useTabDisplayTitle` hook that folds the existing custom-title / strip-decoration resolution together with the marker.
- `SortableTab` now calls that hook instead of resolving the title inline — a net line reduction in a file already close to its `max-lines` budget.

Mapping: `working` → ⚙, `permission` → ✋, `done` → ✅. `active` and `inactive` get nothing, since neither is a state worth a glyph.

## Why

Orca already resolves per-tab agent state and paints it as a dot. With a narrow tab strip and several tabs open the dot is easy to miss, and the tab that just finished is exactly the one you are looking for.

Default off is deliberate. `agent-title-decoration.ts` strips the agent's *own* leading glyph so a tab never shows two icons for one agent. This marker reports state rather than identity, so it does not reintroduce that problem — but it still changes the tab strip, and an existing user should opt in rather than be opted in.

Two details worth a look in review:

- The prefix strips any known marker before applying one, so it is idempotent both when the resolver reruns on every store write and when the status itself changes (`⚙ Build` → `✅ Build`, never `✅ ⚙ Build`).
- An empty title is returned untouched, so a tab never renders as a lone glyph.

## Linked Issue

Fixes #15793

## Visual Proof

<!-- TODO(ramzi): before = tab strip with the setting off; after = same strip with ⚙ / ✋ / ✅. -->

## Testing

- `pnpm typecheck` — clean (node, cli, web)
- `pnpm lint` — clean, including the localization audits and the max-lines ratchet
- `npx vitest run src/renderer/src/lib/tab-status-emoji.test.ts src/renderer/src/components/settings/AgentsPane.test.tsx src/renderer/src/components/tab-bar/` — 430 passed

New `tab-status-emoji.test.ts` covers each status, the unmarked statuses, a missing status, the setting being off, the empty-title guard, idempotence on reapply, and marker replacement on a status change.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated

## AI Disclosure

Written with Claude Opus 5.

## Review

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

- **Cross-platform** — the three glyphs are single-codepoint BMP characters (U+2699, U+270B, U+2705), chosen over multi-codepoint ZWJ emoji so they measure predictably in the tab strip across platform fonts.
- **Remote SSH / mobile** — renderer-only, reading a setting that already syncs; no wire or persistence change beyond the new optional boolean.
- **Backwards compatibility** — new setting defaults to `false`, so an existing profile sees no change.
- **Performance** — the hook reads one boolean primitive from the store, so an unrelated agent update cannot repaint a tab; the title work is a regex and a concat.
- **Adjacent work** — #15781 also touches settings and terminal-title code. Happy to rebase whichever lands second.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `pnpm lint` and `pnpm typecheck` pass locally; touched tests pass
