### PR TITLE
fix: guard SshConnection's SFTP calls against protocol-layer errors (#15479)

### DIFF
--- a/src/main/providers/ssh-filesystem-file-upload.ts
+++ b/src/main/providers/ssh-filesystem-file-upload.ts
@@ -14,6 +14,19 @@ export type SshRawTransferOptions = {
   ) => Promise<void>
 }
 
+async function guardSftpOperation<T>(sftp: SFTPWrapper, operation: () => Promise<T>): Promise<T> {
+  let onSftpError!: (error: Error) => void
+  const sftpError = new Promise<never>((_resolve, reject) => {
+    onSftpError = (error: Error): void => reject(error)
+    sftp.prependOnceListener('error', onSftpError)
+  })
+  try {
+    return await Promise.race([operation(), sftpError])
+  } finally {
+    sftp.removeListener('error', onSftpError)
+  }
+}
+
 export async function openSshFileUploadSession(
   createSftp?: SftpFactory,
   rawTransfer?: SshRawTransferOptions
@@ -25,11 +38,21 @@ export async function openSshFileUploadSession(
     throw new Error('Remote file upload is unavailable. Reconnect the SSH target and retry.')
   }
   const sftp = await createSftp()
+  const swallowLateSftpError = (): void => {}
+  let sftpEndRequested = false
+  const endSftp = (): void => {
+    if (!sftpEndRequested) {
+      sftpEndRequested = true
+      sftp.end()
+    }
+  }
+  sftp.on('error', swallowLateSftpError)
+  sftp.once('close', () => sftp.removeListener('error', swallowLateSftpError))
   return {
     // Why: one session covers the whole import so normal SSH keeps its prior
     // channel count even when a directory contains many files.
     uploadFile: (sourcePath, destinationPath, options) =>
-      uploadFileViaSftp(sftp, sourcePath, destinationPath, options),
-    close: () => sftp.end()
+      guardSftpOperation(sftp, () => uploadFileViaSftp(sftp, sourcePath, destinationPath, options)),
+    close: endSftp
   }
 }

--- a/src/main/providers/ssh-filesystem-file-upload.ts
+++ b/src/main/providers/ssh-filesystem-file-upload.ts
@@ -14,14 +14,36 @@ export type SshRawTransferOptions = {
   ) => Promise<void>
 }
 
-async function guardSftpOperation<T>(sftp: SFTPWrapper, operation: () => Promise<T>): Promise<T> {
+async function guardSftpOperation<T>(
+  sftp: SFTPWrapper,
+  operation: () => Promise<T>,
+  onChannelError: () => void
+): Promise<T> {
   let onSftpError!: (error: Error) => void
+  let sftpErrorWonRace = false
   const sftpError = new Promise<never>((_resolve, reject) => {
-    onSftpError = (error: Error): void => reject(error)
+    onSftpError = (error: Error): void => {
+      sftpErrorWonRace = true
+      reject(error)
+    }
     sftp.prependOnceListener('error', onSftpError)
   })
   try {
-    return await Promise.race([operation(), sftpError])
+    // Why: if sftpError wins the race, this keeps running unobserved and may reject later
+    // (e.g. once onChannelError() closes the channel) — swallow that so it doesn't surface
+    // as an unhandled rejection; the race's winner is what callers see.
+    // Called inside try so a synchronous throw from operation() still runs finally's
+    // listener removal below.
+    const operationResult = operation()
+    operationResult.catch(() => {})
+    return await Promise.race([operationResult, sftpError])
+  } catch (error) {
+    // Why: a channel-level error leaves the session unusable for later calls — close it so
+    // callers don't keep writing to a dead channel.
+    if (sftpErrorWonRace) {
+      onChannelError()
+    }
+    throw error
   } finally {
     sftp.removeListener('error', onSftpError)
   }
@@ -52,7 +74,11 @@ export async function openSshFileUploadSession(
     // Why: one session covers the whole import so normal SSH keeps its prior
     // channel count even when a directory contains many files.
     uploadFile: (sourcePath, destinationPath, options) =>
-      guardSftpOperation(sftp, () => uploadFileViaSftp(sftp, sourcePath, destinationPath, options)),
+      guardSftpOperation(
+        sftp,
+        () => uploadFileViaSftp(sftp, sourcePath, destinationPath, options),
+        endSftp
+      ),
     close: endSftp
   }
 }

--- a/src/main/providers/ssh-filesystem-provider-upload-session-race.test.ts
+++ b/src/main/providers/ssh-filesystem-provider-upload-session-race.test.ts
@@ -1,0 +1,77 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { PassThrough, Writable } from 'node:stream'
+import { describe, expect, it, vi } from 'vitest'
+import { SshFilesystemProvider } from './ssh-filesystem-provider'
+
+function createMux(): { onNotification: ReturnType<typeof vi.fn> } {
+  return { onNotification: vi.fn(() => () => {}) }
+}
+
+describe('SshFilesystemProvider openFileUploadSession sftp-error race', () => {
+  it('closes the retained session when the sftp channel emits a genuine error mid-upload', async () => {
+    // Why: a write() that never calls back keeps uploadFile's operation promise
+    // pending, so the channel-level error is guaranteed to win the internal race.
+    const createWriteStream = vi.fn(() => new Writable({ write() {} }))
+    const sftp = Object.assign(new PassThrough(), { createWriteStream, end: vi.fn() })
+    const createSftp = vi.fn().mockResolvedValue(sftp)
+    const provider = new SshFilesystemProvider('conn-1', createMux() as never, createSftp as never)
+    const dir = mkdtempSync(join(tmpdir(), 'orca-sftp-upload-session-error-'))
+    const filePath = join(dir, 'payload.txt')
+    writeFileSync(filePath, 'payload')
+
+    try {
+      const session = await provider.openFileUploadSession()
+      const pending = session.uploadFile(filePath, '/remote/payload.txt', {})
+      sftp.emit('error', new Error('simulated channel error'))
+
+      await expect(pending).rejects.toThrow('simulated channel error')
+      expect(sftp.end).toHaveBeenCalledTimes(1)
+
+      session.close()
+      expect(sftp.end).toHaveBeenCalledTimes(1)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps the retained session open when a local operation fails without a channel error', async () => {
+    const createWriteStream = vi.fn(() => {
+      const stream = new PassThrough()
+      stream.resume()
+      return stream
+    })
+    const sftp = Object.assign(new PassThrough(), { createWriteStream, end: vi.fn() })
+    const createSftp = vi.fn().mockResolvedValue(sftp)
+    const provider = new SshFilesystemProvider('conn-1', createMux() as never, createSftp as never)
+    const dir = mkdtempSync(join(tmpdir(), 'orca-sftp-upload-session-local-fail-'))
+    const targetPath = join(dir, process.platform === 'win32' ? 'target-dir' : 'target.txt')
+    const linkPath = join(dir, process.platform === 'win32' ? 'link-dir' : 'link.txt')
+    if (process.platform === 'win32') {
+      mkdirSync(targetPath)
+      // Why: file symlinks often require Developer Mode/admin on Windows, while
+      // junctions still exercise the symlink rejection branch.
+      symlinkSync(targetPath, linkPath, 'junction')
+    } else {
+      writeFileSync(targetPath, 'secret')
+      symlinkSync(targetPath, linkPath)
+    }
+
+    try {
+      const session = await provider.openFileUploadSession()
+
+      // Why: opening a symlink source fails locally (O_NOFOLLOW/lstat) before
+      // createWriteStream() is ever called, so this is a genuine local-only
+      // failure with no sftp channel error involved.
+      await expect(session.uploadFile(linkPath, '/remote/link.txt', {})).rejects.toThrow()
+      expect(sftp.end).not.toHaveBeenCalled()
+      expect(createWriteStream).not.toHaveBeenCalled()
+
+      session.close()
+      expect(sftp.end).toHaveBeenCalledTimes(1)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/main/providers/ssh-filesystem-provider.test.ts
+++ b/src/main/providers/ssh-filesystem-provider.test.ts
@@ -300,7 +300,7 @@ describe('SshFilesystemProvider', () => {
         stream.resume()
         return stream
       })
-      const sftp = { createWriteStream, end: vi.fn() }
+      const sftp = Object.assign(new PassThrough(), { createWriteStream, end: vi.fn() })
       const createSftp = vi.fn().mockResolvedValue(sftp)
       provider = new SshFilesystemProvider('conn-1', mux as never, createSftp as never)
       const dir = mkdtempSync(join(tmpdir(), 'orca-sftp-upload-session-'))

--- a/src/main/ssh/sftp-upload.ts
+++ b/src/main/ssh/sftp-upload.ts
@@ -48,6 +48,7 @@ async function uploadFileAndJoinTeardown(
     handleClose ??= handle.close()
     return handleClose
   }
+  const swallowLateStreamError = (): void => {}
   try {
     options?.signal?.throwIfAborted()
     const statResult = await lstat(localPath)
@@ -68,6 +69,22 @@ async function uploadFileAndJoinTeardown(
       flags: options?.exclusive ? 'wx' : 'w'
     })
     readStream = handle.createReadStream({ autoClose: false })
+    // Why: finished(stream, {cleanup:true}) removes its own 'error' listener once it
+    // settles. If the peer stream (or abortTransfer) later calls destroy(err) on a
+    // stream that already settled — e.g. a small file finishes reading before the
+    // remote write fails — the destroy-triggered error emission would have zero
+    // listeners and crash the process. Node's fs.ReadStream closes its fd via async
+    // I/O, so the deferred error emission can land well after this function's own
+    // finally runs; 'close' always follows 'error' in the same destroy cycle for this
+    // stream, so anchoring the read-side removal there (rather than guessing a tick)
+    // is safe. ssh2's own WriteStream, unlike Node's streams, never emits 'close' on an
+    // errored destroy (see ssh2/lib/protocol/SFTP.js closeStream()), so the write-side
+    // no-op listener is deliberately left attached instead of relying on 'close' —
+    // harmless, since the stream is discarded either way.
+    writeStream.on('error', swallowLateStreamError)
+    readStream.on('error', swallowLateStreamError)
+    writeStream.once('close', () => writeStream?.removeListener('error', swallowLateStreamError))
+    readStream.once('close', () => readStream?.removeListener('error', swallowLateStreamError))
     const abortTransfer = (): void => {
       const reason =
         options?.signal?.reason instanceof Error

--- a/src/main/ssh/ssh-connection-sftp-wire.test.ts
+++ b/src/main/ssh/ssh-connection-sftp-wire.test.ts
@@ -1,4 +1,14 @@
-import { lstat, mkdir, mkdtemp, open, readFile, realpath, rm, writeFile } from 'node:fs/promises'
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  open,
+  readFile,
+  realpath,
+  rm,
+  symlink,
+  writeFile
+} from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, posix } from 'node:path'
 import { Client, Server as Ssh2Server, utils, type Connection, type SFTPWrapper } from 'ssh2'
@@ -23,6 +33,8 @@ const SFTP_RESPONSE_HANDLE = 102
 
 type SftpWireServerOptions = {
   malformedHandleOnOpen?: boolean
+  /** Never responds to OPEN for this path, so the client's operation stays pending. */
+  hangOnOpenPath?: string
 }
 
 type SftpWireServer = {
@@ -134,6 +146,9 @@ function installSftpHandlers(
     operations.push(`OPEN:${remotePath}`)
     if (options?.malformedHandleOnOpen) {
       sendMalformedHandle(sftp, requestId)
+      return
+    }
+    if (options?.hangOnOpenPath === remotePath) {
       return
     }
     const localPath = backingPath(backingRoot, remotePath)
@@ -406,4 +421,97 @@ it('rejects writeBuffer when the server sends a fatal SFTP protocol error', asyn
     },
     { malformedHandleOnOpen: true }
   )
+}, 15_000)
+
+it('closes a retained upload session when the sftp channel errors mid-transfer', async () => {
+  const localDir = await realpath(await mkdtemp(join(tmpdir(), 'orca-sftp-wire-local-')))
+  await writeFile(join(localDir, 'payload.bin'), Buffer.from([1, 2, 3]))
+  const hangPath = `${SFTP_HOME}/hangs.bin`
+
+  try {
+    await withSplitNamespaceFixture(
+      async ({ connection, fixture }) => {
+        const client = (connection as unknown as { client: Client }).client
+        const originalSftp = client.sftp.bind(client)
+        let capturedSftp: SFTPWrapper | undefined
+        vi.spyOn(client, 'sftp').mockImplementation((cb) => {
+          return originalSftp((err, sftp) => {
+            if (!err) {
+              capturedSftp = sftp
+            }
+            cb(err, sftp)
+          })
+        })
+
+        const session = await connection.openFileUploadSession()
+        expect(capturedSftp).toBeDefined()
+        const endSpy = vi.spyOn(capturedSftp!, 'end')
+
+        const pending = session.uploadFile(join(localDir, 'payload.bin'), hangPath, {})
+        await vi.waitFor(() => expect(fixture.operations).toContain(`OPEN:${hangPath}`))
+
+        capturedSftp!.emit('error', new Error('simulated channel error'))
+
+        await expect(pending).rejects.toThrow('simulated channel error')
+        // The fix: a genuine channel-level error closes the session so a later
+        // file in the same import batch doesn't write over a dead sftp channel.
+        expect(endSpy).toHaveBeenCalledTimes(1)
+
+        session.close()
+        expect(endSpy).toHaveBeenCalledTimes(1)
+      },
+      { hangOnOpenPath: hangPath }
+    )
+  } finally {
+    await rm(localDir, { recursive: true, force: true })
+  }
+}, 15_000)
+
+it('keeps a retained upload session open when a local operation fails without a channel error', async () => {
+  const localDir = await realpath(await mkdtemp(join(tmpdir(), 'orca-sftp-wire-local-')))
+  const targetPath = join(localDir, process.platform === 'win32' ? 'target-dir' : 'target.txt')
+  const linkPath = join(localDir, process.platform === 'win32' ? 'link-dir' : 'link.txt')
+  if (process.platform === 'win32') {
+    await mkdir(targetPath)
+    // Why: file symlinks often require Developer Mode/admin on Windows, while
+    // junctions still exercise the symlink rejection branch.
+    await symlink(targetPath, linkPath, 'junction')
+  } else {
+    await writeFile(targetPath, 'secret')
+    await symlink(targetPath, linkPath)
+  }
+
+  try {
+    await withSplitNamespaceFixture(async ({ connection, fixture }) => {
+      const client = (connection as unknown as { client: Client }).client
+      const originalSftp = client.sftp.bind(client)
+      let capturedSftp: SFTPWrapper | undefined
+      vi.spyOn(client, 'sftp').mockImplementation((cb) => {
+        return originalSftp((err, sftp) => {
+          if (!err) {
+            capturedSftp = sftp
+          }
+          cb(err, sftp)
+        })
+      })
+
+      const session = await connection.openFileUploadSession()
+      expect(capturedSftp).toBeDefined()
+      const endSpy = vi.spyOn(capturedSftp!, 'end')
+
+      // Why: opening a symlink source fails locally (O_NOFOLLOW/lstat) before any
+      // sftp request is sent, so this is a genuine local-only failure with no
+      // sftp channel error involved.
+      await expect(session.uploadFile(linkPath, `${SFTP_HOME}/link.txt`, {})).rejects.toThrow()
+      // A plain operation-level failure must not close the retained session — only a
+      // genuine sftp channel error should (see the companion test above).
+      expect(endSpy).not.toHaveBeenCalled()
+      expect(fixture.operations).not.toContain(`OPEN:${SFTP_HOME}/link.txt`)
+
+      session.close()
+      expect(endSpy).toHaveBeenCalledTimes(1)
+    })
+  } finally {
+    await rm(localDir, { recursive: true, force: true })
+  }
 }, 15_000)

--- a/src/main/ssh/ssh-connection-sftp-wire.test.ts
+++ b/src/main/ssh/ssh-connection-sftp-wire.test.ts
@@ -19,6 +19,11 @@ const SFTP_OPEN_WRITE = 2
 const SFTP_STATUS_OK = 0
 const SFTP_STATUS_NO_SUCH_FILE = 2
 const SFTP_STATUS_FAILURE = 4
+const SFTP_RESPONSE_HANDLE = 102
+
+type SftpWireServerOptions = {
+  malformedHandleOnOpen?: boolean
+}
 
 type SftpWireServer = {
   port: number
@@ -58,7 +63,24 @@ function fileId(handle: Buffer, files: Map<number, OpenFile>): number | null {
   return files.has(id) ? id : null
 }
 
-function installSftpHandlers(sftp: SFTPWrapper, backingRoot: string, operations: string[]): void {
+function sendMalformedHandle(sftp: SFTPWrapper, requestId: number): void {
+  const packet = Buffer.alloc(9)
+  packet.writeUInt32BE(5, 0)
+  packet[4] = SFTP_RESPONSE_HANDLE
+  packet.writeUInt32BE(requestId, 5)
+  const wire = sftp as unknown as {
+    _protocol: { channelData: (channelId: number, data: Buffer) => void }
+    outgoing: { id: number }
+  }
+  wire._protocol.channelData(wire.outgoing.id, packet)
+}
+
+function installSftpHandlers(
+  sftp: SFTPWrapper,
+  backingRoot: string,
+  operations: string[],
+  options?: SftpWireServerOptions
+): void {
   const files = new Map<number, OpenFile>()
   let nextFileId = 0
   sftp.on('error', () => {})
@@ -110,6 +132,10 @@ function installSftpHandlers(sftp: SFTPWrapper, backingRoot: string, operations:
   })
   sftp.on('OPEN', (requestId, remotePath, flags) => {
     operations.push(`OPEN:${remotePath}`)
+    if (options?.malformedHandleOnOpen) {
+      sendMalformedHandle(sftp, requestId)
+      return
+    }
     const localPath = backingPath(backingRoot, remotePath)
     if (!localPath || !(flags & SFTP_OPEN_WRITE)) {
       sftp.status(requestId, SFTP_STATUS_NO_SUCH_FILE)
@@ -157,7 +183,10 @@ function installSftpHandlers(sftp: SFTPWrapper, backingRoot: string, operations:
   })
 }
 
-async function startSftpWireServer(backingRoot: string): Promise<SftpWireServer> {
+async function startSftpWireServer(
+  backingRoot: string,
+  options?: SftpWireServerOptions
+): Promise<SftpWireServer> {
   const operations: string[] = []
   const connections = new Set<Connection>()
   // Ed25519 keygen can produce an invalid 31-byte key; ECDSA points always start with 0x04.
@@ -181,7 +210,7 @@ async function startSftpWireServer(backingRoot: string): Promise<SftpWireServer>
       connection.on('session', (accept) => {
         const session = accept()
         session.on('sftp', (acceptSftp) => {
-          installSftpHandlers(acceptSftp(), backingRoot, operations)
+          installSftpHandlers(acceptSftp(), backingRoot, operations, options)
         })
       })
     })
@@ -279,7 +308,8 @@ async function withSplitNamespaceFixture(
     connection: SshConnection
     fixture: SftpWireServer
     backingRelayDir: string
-  }) => Promise<void>
+  }) => Promise<void>,
+  options?: SftpWireServerOptions
 ): Promise<void> {
   const backingRoot = await mkdtemp(join(tmpdir(), 'orca-sftp-wire-remote-'))
   const backingRelayDir = join(backingRoot, ...RELAY_DIR.split('/'))
@@ -289,7 +319,7 @@ async function withSplitNamespaceFixture(
   let fixture: SftpWireServer | undefined
   let client: Client | undefined
   try {
-    fixture = await startSftpWireServer(backingRoot)
+    fixture = await startSftpWireServer(backingRoot, options)
     client = await connectSshClient(fixture.port)
     await run({
       connection: connectionWithClient(client),
@@ -360,4 +390,20 @@ it('writes a mapped file through a verified split namespace over a real ssh2 SFT
     // Shell-namespace path must never be opened for a confirmed split write.
     expect(fixture.operations).not.toContain(`OPEN:${shellFilePath}`)
   })
+}, 15_000)
+
+it('rejects writeBuffer when the server sends a fatal SFTP protocol error', async () => {
+  await withSplitNamespaceFixture(
+    async ({ connection, fixture }) => {
+      await expect(
+        boundedTransfer(
+          connection.writeBuffer(`${SFTP_HOME}/fatal.bin`, Buffer.from('payload')),
+          fixture.operations,
+          'writeBuffer fatal error'
+        )
+      ).rejects.toThrow('Malformed HANDLE packet')
+      expect(fixture.operations).toContain(`OPEN:${SFTP_HOME}/fatal.bin`)
+    },
+    { malformedHandleOnOpen: true }
+  )
 }, 15_000)

--- a/src/main/ssh/ssh-connection.ts
+++ b/src/main/ssh/ssh-connection.ts
@@ -297,6 +297,51 @@ export class SshConnection {
     )
   }
 
+  private async withGuardedSftp<T>(
+    signal: AbortSignal | undefined,
+    run: (
+      sftp: SFTPWrapper,
+      endSftp: () => void,
+      guardOperation: <R>(operation: () => Promise<R>) => Promise<R>
+    ) => Promise<T>,
+    options?: { retainAfterSuccess?: boolean }
+  ): Promise<T> {
+    const sftp = await this.sftp(signal)
+    const swallowLateSftpError = (): void => {}
+    let sftpEndRequested = false
+    const endSftp = (): void => {
+      if (!sftpEndRequested) {
+        sftpEndRequested = true
+        sftp.end()
+      }
+    }
+    const guardOperation = async <R>(operation: () => Promise<R>): Promise<R> => {
+      let onSftpError!: (error: Error) => void
+      const sftpError = new Promise<never>((_resolve, reject) => {
+        onSftpError = (error: Error): void => reject(error)
+        sftp.prependOnceListener('error', onSftpError)
+      })
+      try {
+        return await Promise.race([operation(), sftpError])
+      } finally {
+        sftp.removeListener('error', onSftpError)
+      }
+    }
+    sftp.on('error', swallowLateSftpError)
+    sftp.once('close', () => sftp.removeListener('error', swallowLateSftpError))
+
+    let succeeded = false
+    try {
+      const result = await guardOperation(() => run(sftp, endSftp, guardOperation))
+      succeeded = true
+      return result
+    } finally {
+      if (!succeeded || !options?.retainAfterSuccess) {
+        endSftp()
+      }
+    }
+  }
+
   private async openSessionChannelWithRetry<T>(
     open: () => Promise<T>,
     signal?: AbortSignal
@@ -487,18 +532,7 @@ export class SshConnection {
     )
     try {
       if (!this.useSystemSshTransport) {
-        const sftp = await this.sftp(linkedSignal.signal)
-        const swallowLateSftpError = (): void => {}
-        let sftpEndRequested = false
-        const endSftp = (): void => {
-          if (!sftpEndRequested) {
-            sftpEndRequested = true
-            sftp.end()
-          }
-        }
-        sftp.on('error', swallowLateSftpError)
-        sftp.once('close', () => sftp.removeListener('error', swallowLateSftpError))
-        try {
+        await this.withGuardedSftp(linkedSignal.signal, async (sftp, endSftp) => {
           // Why: resolve on the same session that transfers — a later session is not authoritative for this one's namespace.
           const transfer = (async (): Promise<void> => {
             const targetDir = await resolveSftpTransferPathIfMapped(sftp, remoteDir, options)
@@ -513,9 +547,7 @@ export class SshConnection {
             endSftp()
             return () => sftp.removeListener('close', onClose)
           })
-        } finally {
-          endSftp()
-        }
+        })
         return
       }
       await uploadDirectoryViaSystemSsh(this.target, localDir, remoteDir, {
@@ -534,13 +566,10 @@ export class SshConnection {
     options?: SshRemoteFileOptions
   ): Promise<void> {
     if (!this.useSystemSshTransport) {
-      const sftp = await this.sftp()
-      try {
+      await this.withGuardedSftp(undefined, async (sftp) => {
         const { fastGetViaSftp } = await import('../providers/ssh-filesystem-provider-sftp')
         await fastGetViaSftp(sftp, remotePath, localPath)
-      } finally {
-        sftp.end()
-      }
+      })
       return
     }
     await downloadFileViaSystemSsh(this.target, remotePath, localPath, {
@@ -552,13 +581,18 @@ export class SshConnection {
 
   async openFileUploadSession(options?: SshRemoteFileOptions): Promise<FileUploadSession> {
     if (!this.useSystemSshTransport) {
-      const sftp = await this.sftp()
-      const { uploadFile } = await import('./sftp-upload')
-      return {
-        uploadFile: (localPath, remotePath, uploadOptions) =>
-          uploadFile(sftp, localPath, remotePath, uploadOptions),
-        close: () => sftp.end()
-      }
+      return this.withGuardedSftp(
+        undefined,
+        async (sftp, endSftp, guardOperation) => {
+          const { uploadFile } = await import('./sftp-upload')
+          return {
+            uploadFile: (localPath, remotePath, uploadOptions) =>
+              guardOperation(() => uploadFile(sftp, localPath, remotePath, uploadOptions)),
+            close: endSftp
+          }
+        },
+        { retainAfterSuccess: true }
+      )
     }
     // Why: disconnect replaces the connection controller, so an existing import session must stay bound to the signal and SSH config it opened with.
     const signal = this.systemOperationAbortController.signal
@@ -588,18 +622,7 @@ export class SshConnection {
     )
     try {
       if (!this.useSystemSshTransport) {
-        const sftp = await this.sftp(linkedSignal.signal)
-        const swallowLateSftpError = (): void => {}
-        let sftpEndRequested = false
-        const endSftp = (): void => {
-          if (!sftpEndRequested) {
-            sftpEndRequested = true
-            sftp.end()
-          }
-        }
-        sftp.on('error', swallowLateSftpError)
-        sftp.once('close', () => sftp.removeListener('error', swallowLateSftpError))
-        try {
+        await this.withGuardedSftp(linkedSignal.signal, async (sftp, endSftp) => {
           // Why: resolve on the same session that writes — a later session is not authoritative for this one's namespace.
           const write = (async (): Promise<void> => {
             const targetPath = await resolveSftpTransferPathIfMapped(sftp, remotePath, options)
@@ -612,9 +635,7 @@ export class SshConnection {
             endSftp()
             return () => sftp.removeListener('close', onClose)
           })
-        } finally {
-          endSftp()
-        }
+        })
         return
       }
       await writeFileViaSystemSsh(this.target, remotePath, contents, {
@@ -633,13 +654,10 @@ export class SshConnection {
     options?: SshRemoteFileOptions & { append?: boolean; exclusive?: boolean }
   ): Promise<void> {
     if (!this.useSystemSshTransport) {
-      const sftp = await this.sftp()
-      try {
+      await this.withGuardedSftp(undefined, async (sftp) => {
         const { uploadBuffer } = await import('./sftp-upload')
         await uploadBuffer(sftp, contents, remotePath, options)
-      } finally {
-        sftp.end()
-      }
+      })
       return
     }
     await writeBufferViaSystemSsh(this.target, remotePath, contents, {

--- a/src/main/ssh/ssh-connection.ts
+++ b/src/main/ssh/ssh-connection.ts
@@ -317,12 +317,30 @@ export class SshConnection {
     }
     const guardOperation = async <R>(operation: () => Promise<R>): Promise<R> => {
       let onSftpError!: (error: Error) => void
+      let sftpErrorWonRace = false
       const sftpError = new Promise<never>((_resolve, reject) => {
-        onSftpError = (error: Error): void => reject(error)
+        onSftpError = (error: Error): void => {
+          sftpErrorWonRace = true
+          reject(error)
+        }
         sftp.prependOnceListener('error', onSftpError)
       })
       try {
-        return await Promise.race([operation(), sftpError])
+        // Why: if sftpError wins the race, this keeps running unobserved and may reject
+        // later (e.g. once endSftp() closes the channel) — swallow that so it doesn't
+        // surface as an unhandled rejection; the race's winner is what callers see.
+        // Called inside try so a synchronous throw from operation() still runs finally's
+        // listener removal below.
+        const operationResult = operation()
+        operationResult.catch(() => {})
+        return await Promise.race([operationResult, sftpError])
+      } catch (error) {
+        // Why: a channel-level error leaves the session unusable for later calls (e.g. a
+        // retained upload session) — close it so callers don't keep writing to a dead channel.
+        if (sftpErrorWonRace) {
+          endSftp()
+        }
+        throw error
       } finally {
         sftp.removeListener('error', onSftpError)
       }


### PR DESCRIPTION
> [!IMPORTANT]
> **Superseded by #17862, which has merged and closed #15479.** The merged fix installs durable SFTP stream error handling across the broader production path. This PR remains open for historical review but should not be treated as the active merge path.

Fixes #15479 — uncaught exception crashes the app when relay deployment hits a fatal SFTP protocol error (e.g. `SSH_FX_NO_SUCH_FILE` from a bastion whose SFTP subsystem is sandboxed to a different filesystem view than its shell channel).

## Root cause

`SshConnection.sftp()` returns a raw `SFTPWrapper`. Every consumer (`uploadDirectory`, `downloadFile`, `openFileUploadSession`, `writeFile`, `writeBuffer`) called it without listening for the stream's `'error'` event. A fatal SFTP protocol error had nowhere to be caught, so it propagated synchronously up through `ssh2`'s parse/decrypt call stack as an uncaught exception instead of rejecting the in-flight operation normally.

## Fix

Adds `withGuardedSftp()`, a shared helper that races the operation against the sftp stream's `'error'` event (via `prependOnceListener` + `Promise.race`) and rejects with the real protocol error. All five `SshConnection` call sites now route through it; the provider-layer fallback (`openSshFileUploadSession` in `ssh-filesystem-file-upload.ts`) gets an equivalent guard.

Existing protections are preserved byte-for-byte where they already existed (`uploadDirectory`/`writeFile`'s swallow-late-error + idempotent `endSftp` + `once('close')` sequence); the change is additive — fatal errors now reject instead of being silently absorbed by the close-race.

## What this does NOT fix — same root cause remains reachable elsewhere

Independent review found two other production-reachable bare `connection.sftp()` consumers in `src/main/providers/ssh-filesystem-provider.ts` that this diff does not touch and that can hit the identical uncaught-exception crash:

- **`downloadFolderViaSftp`** (`ssh-filesystem-provider.ts:66-70`, implementation in `ssh-filesystem-download.ts:144-184`) — only guards the abort signal and calls `sftp.end()` in `finally`; no `sftp.on('error')`. Not routed through `rawTransfer` (no `downloadFolder` entry), so directly reachable in production for any SFTP-transport folder download.
- **`lstatViaSftp`** (`ssh-filesystem-provider.ts:226`, `ssh-filesystem-provider-sftp.ts:74`) — same bare pattern, reachable when relay falls back to SFTP for `fs.lstat` on older relay versions.

(`downloadFileViaSftp` and `uploadBuffer` in the same file have the identical bare pattern but are pre-empted by `rawTransfer` routing to the now-guarded `SshConnection` methods in production, so they're lower risk.)

Left as a follow-up rather than expanding this diff's scope — recommend a separate issue to route these two through the same guard or through `rawTransfer`.

## Verification

- 4 target test files, 77/77 passed: `ssh-connection-sftp-wire.test.ts`, `ssh-connection.test.ts`, `ssh-connection-file-transfer.test.ts`, `ssh-filesystem-provider.test.ts`.
- New regression test (`ssh-connection-sftp-wire.test.ts`) uses a real `ssh2` wire (real Server/Client), sends a malformed `HANDLE` packet on `OPEN`, and asserts `writeBuffer` rejects with the real `'Malformed HANDLE packet'` protocol error rather than timing out. Confirmed red before the fix (times out / uncaught 'error') and green after.
- `pnpm run typecheck` — exit 0.
- Independently reviewed by two reviewers (Claude + Codex, neither the implementer), each pulling the diff and re-running tests/typecheck themselves. Both confirmed the 4-file diff is correct and behavior-preserving; the Claude reviewer additionally swept for other bare `connection.sftp()` consumers and surfaced the two gaps documented above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)