### PR TITLE
fix(status-bar): show the Active Server's usage in the rate-limit badges

### DIFF
--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -63,6 +63,8 @@ import { ClaudeIcon, GeminiIcon, MiniMaxIcon, OpenAIIcon, OpenCodeGoIcon } from 
 import { AgentIcon } from '@/lib/agent-catalog'
 import { UsageRosterPanel, getTightestUsageSection } from './UsageRosterPanel'
 import { getUsageProviderAccountsSectionId } from './usage-provider-settings-target'
+import type { RateLimitState } from '../../../../shared/rate-limit-types'
+import { resolveStatusBarUsageRateLimits } from './usage-rate-limits-source'
 import { formatRateLimitWindowChipLabel } from '@/lib/window-label-formatter'
 import { useResetCountdownClock } from '@/hooks/useResetCountdownClock'
 import {
@@ -93,8 +95,10 @@ import {
 import { getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import {
   fetchProviderAccountsSnapshot,
+  hasRemoteProviderAccountOwner,
   selectClaudeProviderAccount,
-  selectCodexProviderAccount
+  selectCodexProviderAccount,
+  watchProviderAccounts
 } from '@/runtime/runtime-provider-accounts-client'
 import { toast } from 'sonner'
 import { translate } from '@/i18n/i18n'
@@ -2045,6 +2049,40 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
   const mountedRef = useRef(true)
   const [isRefreshing, setIsRefreshing] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
+  // Why (#15798): with a remote Active Server the usage badges must describe the
+  // machine actually running agents. The provider-accounts snapshot already
+  // carries the server's full RateLimitState; the watcher streams its 5-minute
+  // poll refreshes, and the manual refresh button re-fetches the snapshot.
+  const remoteUsageOwner = hasRemoteProviderAccountOwner(settings)
+  const activeRuntimeEnvironmentId = settings?.activeRuntimeEnvironmentId?.trim() || null
+  const [remoteRateLimits, setRemoteRateLimits] = useState<RateLimitState | null>(null)
+  useEffect(() => {
+    if (!remoteUsageOwner) {
+      setRemoteRateLimits(null)
+      return
+    }
+    const watcher = watchProviderAccounts(
+      { activeRuntimeEnvironmentId },
+      {
+        onSnapshot: (snapshot) => {
+          if (snapshot.rateLimits) {
+            setRemoteRateLimits(snapshot.rateLimits)
+          }
+        },
+        onError: (error) => {
+          console.error('Failed to stream remote usage snapshot:', error)
+        }
+      }
+    )
+    return () => {
+      watcher.close()
+    }
+  }, [remoteUsageOwner, activeRuntimeEnvironmentId])
+  const effectiveRateLimits = resolveStatusBarUsageRateLimits(
+    rateLimits,
+    remoteRateLimits,
+    remoteUsageOwner
+  )
   const [menuPoint, setMenuPoint] = useState({ x: 0, y: 0 })
 
   const [containerWidth, setContainerWidth] = useState(900)
@@ -2093,8 +2131,21 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
     }
     setIsRefreshing(true)
     try {
+      // Why (#15798): remote-owned usage refreshes by re-fetching the server's
+      // snapshot; the local poll would describe the wrong machine.
+      const usageRefresh = remoteUsageOwner
+        ? fetchProviderAccountsSnapshot({ activeRuntimeEnvironmentId })
+            .then((snapshot) => {
+              if (snapshot.rateLimits) {
+                setRemoteRateLimits(snapshot.rateLimits)
+              }
+            })
+            .catch((error) => {
+              console.error('Failed to refresh remote usage snapshot:', error)
+            })
+        : refreshRateLimits()
       // Why: re-run PATH detection so a freshly-installed/removed CLI's bar appears/hides without restarting Orca.
-      await Promise.all([refreshRateLimits(), refreshDetectedAgents()])
+      await Promise.all([usageRefresh, refreshDetectedAgents()])
     } finally {
       if (mountedRef.current) {
         setIsRefreshing(false)
@@ -2106,7 +2157,8 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
     return null
   }
 
-  const { claude, codex, gemini, opencodeGo, kimi, antigravity, minimax, grok } = rateLimits
+  const { claude, codex, gemini, opencodeGo, kimi, antigravity, minimax, grok } =
+    effectiveRateLimits
 
   // Why: a bar is earned by a live snapshot or durable Settings setup; detection-gating hides per-CLI bars when the agent isn't on PATH.
   // Why: Antigravity has no persisted credential, so a checked status item + detected CLI is the durable "show its slot" signal.
@@ -2118,8 +2170,8 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
   const usageSettings = {
     ...settings,
     antigravityUsageConfigured,
-    minimaxCookieConfigured: rateLimits.minimaxCookieConfigured,
-    grokAuthConfigured: rateLimits.grokAuthConfigured
+    minimaxCookieConfigured: effectiveRateLimits.minimaxCookieConfigured,
+    grokAuthConfigured: effectiveRateLimits.grokAuthConfigured
   }
   const visibleClaude = getVisibleUsageProvider('claude', claude, usageSettings)
   const visibleCodex = getVisibleUsageProvider('codex', codex, usageSettings)

--- a/src/renderer/src/components/status-bar/usage-rate-limits-source.test.ts
+++ b/src/renderer/src/components/status-bar/usage-rate-limits-source.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import type { RateLimitState } from '../../../../shared/rate-limit-types'
+import { resolveStatusBarUsageRateLimits } from './usage-rate-limits-source'
+
+function localState(): RateLimitState {
+  return {
+    claude: {
+      provider: 'claude',
+      session: null,
+      weekly: null,
+      updatedAt: 1,
+      error: 'Refresh failed',
+      status: 'error'
+    },
+    codex: null,
+    gemini: null,
+    opencodeGo: null,
+    kimi: null,
+    antigravity: null,
+    minimax: null,
+    grok: null,
+    minimaxCookieConfigured: true,
+    grokAuthConfigured: false,
+    claudeTarget: { runtime: 'host', wslDistro: null },
+    codexTarget: { runtime: 'host', wslDistro: null },
+    inactiveClaudeAccounts: [],
+    inactiveCodexAccounts: []
+  } as RateLimitState
+}
+
+function remoteState(): RateLimitState {
+  return { ...localState(), minimaxCookieConfigured: false }
+}
+
+describe('resolveStatusBarUsageRateLimits', () => {
+  it('shows local usage when no remote Active Server owns accounts', () => {
+    const local = localState()
+    expect(resolveStatusBarUsageRateLimits(local, remoteState(), false)).toBe(local)
+  })
+
+  it('shows the remote snapshot when a remote Active Server owns accounts (#15798)', () => {
+    const local = localState()
+    const remote = remoteState()
+    const resolved = resolveStatusBarUsageRateLimits(local, remote, true)
+    expect(resolved).toBe(remote)
+  })
+
+  it('degrades to a fetching state rather than flashing local numbers before the first snapshot', () => {
+    const local = localState()
+    const resolved = resolveStatusBarUsageRateLimits(local, null, true)
+    expect(resolved.claude).toMatchObject({ status: 'fetching' })
+    // The stale local error must not read as the remote machine's state.
+    expect(resolved.claude).not.toMatchObject({ status: 'error' })
+    // Durability flags stay local so provider bars keep their visibility rules.
+    expect(resolved.minimaxCookieConfigured).toBe(true)
+  })
+
+  it('keeps a null provider null in the fetching degrade', () => {
+    const resolved = resolveStatusBarUsageRateLimits(localState(), null, true)
+    expect(resolved.codex).toBeNull()
+  })
+})

--- a/src/renderer/src/components/status-bar/usage-rate-limits-source.ts
+++ b/src/renderer/src/components/status-bar/usage-rate-limits-source.ts
@@ -1,0 +1,33 @@
+import type { RateLimitState } from '../../../../shared/rate-limit-types'
+
+/**
+ * Which machine's usage the status-bar badges describe (#15798).
+ *
+ * With a remote Active Server, agents run there and the provider-accounts
+ * snapshot carries the server's full RateLimitState — the badges must show
+ * those numbers, not the viewer's local poll (which describes a machine that
+ * runs nothing and can look correct while being wrong). While the first
+ * remote snapshot is still in flight, the Claude/Codex rows degrade to a
+ * fetching state rather than flashing local numbers.
+ */
+export function resolveStatusBarUsageRateLimits(
+  localRateLimits: RateLimitState,
+  remoteRateLimits: RateLimitState | null,
+  remoteUsageOwner: boolean
+): RateLimitState {
+  if (!remoteUsageOwner) {
+    return localRateLimits
+  }
+  if (remoteRateLimits) {
+    return remoteRateLimits
+  }
+  return {
+    ...localRateLimits,
+    claude: markProviderFetching(localRateLimits.claude),
+    codex: markProviderFetching(localRateLimits.codex)
+  }
+}
+
+function markProviderFetching<T extends { status: string } | null>(provider: T): T | null {
+  return provider ? { ...provider, status: 'fetching' } : null
+}


### PR DESCRIPTION
## Summary

**What**

When a remote Active Server owns provider accounts (`hasRemoteProviderAccountOwner`), the status-bar usage badges now render the **server's** `RateLimitState` — taken from the provider-accounts snapshot the neighboring account roster already consumes (`snapshot.rateLimits`), which the status bar now watches for the pane's lifetime. The manual refresh button re-fetches that snapshot instead of running the local poll. Until the first remote snapshot lands, the Claude/Codex rows degrade to a fetching state rather than flashing local numbers; durability flags (minimax cookie / grok auth configured) stay local so bar visibility rules keep working. Without a remote owner, nothing changes.

**Why**

#15798 — the accounts list is environment-aware ("Showing accounts managed by <server>") while the usage badges beside it polled the local device, so they sat on `Refresh failed` / `Refreshing sign-in…` forever against stale local logins — and when local logins happened to be valid, they showed numbers describing a machine that runs no agents, which looks correct while being wrong.

The data was already flowing: the runtime's accounts snapshot carries the full server-side `RateLimitState` (streamed with its 5-minute poll), and the AccountsPane subscribed to the same watcher but dropped the `rateLimits` field. The status bar now consumes it.

**Testing**

- New `usage-rate-limits-source.test.ts` (4 cases): local owner sees the local state untouched; remote owner sees the remote snapshot verbatim; before the first snapshot the Claude/Codex rows read `fetching` — never the stale local `error` — while durability flags stay local; a null provider stays null through the degrade. 4/4.
- Status-bar suites: 287/288 — the one failure (`resource-session-classification-parity`) is **pre-existing on main** (verified identical with this change stashed; it scans `mergeSnapshotAndSessions` source, untouched here).
- `pnpm run typecheck` clean.

Fixes #15798