### PR TITLE
feat(automations): navigate table search results with arrows

### DIFF
--- a/src/renderer/src/components/automations/AutomationListSearchField.test.tsx
+++ b/src/renderer/src/components/automations/AutomationListSearchField.test.tsx
@@ -2,7 +2,7 @@
 
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { AutomationListSearchField } from './AutomationListSearchField'
 
 let container: HTMLDivElement
@@ -35,5 +35,49 @@ describe('AutomationListSearchField', () => {
     const input = container.querySelector('input')
     expect(input).not.toBeNull()
     expect(document.activeElement).toBe(input)
+  })
+
+  it('routes ArrowDown/ArrowUp into onArrowNavigate and keeps Escape clear working', () => {
+    const onArrowNavigate = vi.fn()
+    const onClear = vi.fn()
+    act(() => {
+      root.render(
+        <AutomationListSearchField
+          query="prod"
+          isTooLarge={false}
+          onQueryChange={() => undefined}
+          onClear={onClear}
+          onArrowNavigate={onArrowNavigate}
+        />
+      )
+    })
+
+    const input = container.querySelector('input')
+    expect(input).not.toBeNull()
+
+    const down = new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true })
+    input?.dispatchEvent(down)
+    expect(down.defaultPrevented).toBe(true)
+    expect(onArrowNavigate).toHaveBeenCalledWith('ArrowDown')
+
+    const up = new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true, cancelable: true })
+    input?.dispatchEvent(up)
+    expect(up.defaultPrevented).toBe(true)
+    expect(onArrowNavigate).toHaveBeenCalledWith('ArrowUp')
+
+    const modified = new KeyboardEvent('keydown', {
+      key: 'ArrowDown',
+      metaKey: true,
+      bubbles: true,
+      cancelable: true
+    })
+    input?.dispatchEvent(modified)
+    expect(modified.defaultPrevented).toBe(false)
+    expect(onArrowNavigate).toHaveBeenCalledTimes(2)
+
+    const escape = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true })
+    input?.dispatchEvent(escape)
+    expect(escape.defaultPrevented).toBe(true)
+    expect(onClear).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/src/components/automations/AutomationListSearchField.tsx
+++ b/src/renderer/src/components/automations/AutomationListSearchField.tsx
@@ -4,12 +4,18 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { translate } from '@/i18n/i18n'
 import { cn } from '@/lib/utils'
+import {
+  isAutomationListArrowKey,
+  shouldHandleAutomationListSearchArrowKey,
+  type AutomationListArrowKey
+} from './automation-list-keyboard-navigation'
 
 type AutomationListSearchFieldProps = {
   query: string
   isTooLarge: boolean
   onQueryChange: (query: string) => void
   onClear: () => void
+  onArrowNavigate?: (key: AutomationListArrowKey) => void
   className?: string
 }
 
@@ -18,6 +24,7 @@ export function AutomationListSearchField({
   isTooLarge,
   onQueryChange,
   onClear,
+  onArrowNavigate,
   className
 }: AutomationListSearchFieldProps): React.JSX.Element {
   const inputRef = useRef<HTMLInputElement>(null)
@@ -57,6 +64,16 @@ export function AutomationListSearchField({
         )}
         onChange={(event) => onQueryChange(event.target.value)}
         onKeyDown={(event) => {
+          if (
+            onArrowNavigate &&
+            isAutomationListArrowKey(event.key) &&
+            shouldHandleAutomationListSearchArrowKey(event)
+          ) {
+            // Why: ArrowUp/Down should step the visible list instead of moving the input caret.
+            event.preventDefault()
+            onArrowNavigate(event.key)
+            return
+          }
           if (event.key !== 'Escape' || event.nativeEvent.isComposing) {
             return
           }

--- a/src/renderer/src/components/automations/AutomationListToolbar.tsx
+++ b/src/renderer/src/components/automations/AutomationListToolbar.tsx
@@ -6,6 +6,7 @@ import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
 import { clampAutomationListSearchQueryInput } from './automation-list-search'
 import type { AutomationListFilter } from './automation-list-view'
+import type { AutomationListArrowKey } from './automation-list-keyboard-navigation'
 import { AutomationListFilterMenu, AutomationListFilterPills } from './AutomationListFilterMenu'
 import { AutomationListSearchField } from './AutomationListSearchField'
 import type { AutomationTemplate } from './automation-templates'
@@ -14,6 +15,7 @@ export function AutomationListToolbar({
   listSearchQuery,
   isListSearchQueryTooLarge,
   onListSearchQueryChange,
+  onSearchArrowNavigate,
   filter,
   onFilterChange,
   onRefresh,
@@ -23,6 +25,7 @@ export function AutomationListToolbar({
   listSearchQuery: string
   isListSearchQueryTooLarge: boolean
   onListSearchQueryChange: (query: string) => void
+  onSearchArrowNavigate: (key: AutomationListArrowKey) => void
   filter: AutomationListFilter
   onFilterChange: (filter: AutomationListFilter) => void
   onRefresh: () => void
@@ -41,6 +44,7 @@ export function AutomationListToolbar({
               onListSearchQueryChange(clampAutomationListSearchQueryInput(query))
             }
             onClear={() => onListSearchQueryChange('')}
+            onArrowNavigate={onSearchArrowNavigate}
           />
           <AutomationListFilterMenu filter={filter} onChange={onFilterChange} />
           <Tooltip>

--- a/src/renderer/src/components/automations/AutomationsListPanel.tsx
+++ b/src/renderer/src/components/automations/AutomationsListPanel.tsx
@@ -31,6 +31,10 @@ import type {
 import { AutomationListTableHeader } from './AutomationListTableHeader'
 import { AutomationListToolbar } from './AutomationListToolbar'
 import { indexLatestAutomationRuns } from './automation-list-last-run'
+import {
+  getAutomationListArrowNavigationTarget,
+  type AutomationListArrowKey
+} from './automation-list-keyboard-navigation'
 
 type AutomationsListPanelProps = {
   hasListItems: boolean
@@ -125,6 +129,51 @@ export function AutomationsListPanel({
   // Why: one pass over runs for the whole list — each row renders its own
   // component, so indexing per row would be O(rows × runs) on every re-render.
   const lastRunByAutomationId = React.useMemo(() => indexLatestAutomationRuns(runs), [runs])
+  const listScrollRef = React.useRef<HTMLDivElement>(null)
+  const pendingKeyboardScrollRef = React.useRef(false)
+
+  const handleSearchArrowNavigate = React.useCallback(
+    (key: AutomationListArrowKey) => {
+      const next = getAutomationListArrowNavigationTarget({
+        items: visibleItems,
+        selectedId,
+        selectedExternalKey,
+        key
+      })
+      if (!next) {
+        return
+      }
+      const alreadySelected =
+        next.kind === 'local'
+          ? selectedExternalKey === null && selectedId === next.id
+          : selectedExternalKey === next.id
+      if (alreadySelected) {
+        listScrollRef.current
+          ?.querySelector('[data-current="true"]')
+          ?.scrollIntoView({ block: 'nearest' })
+        return
+      }
+      pendingKeyboardScrollRef.current = true
+      if (next.kind === 'local') {
+        selectExternalKey(null)
+        selectAutomationId(next.id)
+      } else {
+        selectAutomationId(null)
+        selectExternalKey(next.id)
+      }
+    },
+    [selectAutomationId, selectExternalKey, selectedExternalKey, selectedId, visibleItems]
+  )
+
+  React.useEffect(() => {
+    if (!pendingKeyboardScrollRef.current) {
+      return
+    }
+    pendingKeyboardScrollRef.current = false
+    listScrollRef.current
+      ?.querySelector('[data-current="true"]')
+      ?.scrollIntoView({ block: 'nearest' })
+  }, [selectedExternalKey, selectedId])
 
   return (
     <section
@@ -173,6 +222,7 @@ export function AutomationsListPanel({
             listSearchQuery={listSearchQuery}
             isListSearchQueryTooLarge={isListSearchQueryTooLarge}
             onListSearchQueryChange={onListSearchQueryChange}
+            onSearchArrowNavigate={handleSearchArrowNavigate}
             filter={listFilter}
             onFilterChange={onListFilterChange}
             onRefresh={onRefresh}
@@ -181,6 +231,7 @@ export function AutomationsListPanel({
           />
 
           <div
+            ref={listScrollRef}
             className={cn(
               'scrollbar-sleek min-h-0 flex-1 overflow-auto',
               LIST_TABLE_CONTAINER_CLASS

--- a/src/renderer/src/components/automations/AutomationsListPanel.tsx
+++ b/src/renderer/src/components/automations/AutomationsListPanel.tsx
@@ -154,15 +154,26 @@ export function AutomationsListPanel({
         return
       }
       pendingKeyboardScrollRef.current = true
+      // Why: arrows only move the highlight — detail is a full-page drill-in that
+      // unmounts this list, so opening it here would end navigation on first press.
       if (next.kind === 'local') {
         selectExternalKey(null)
         selectAutomationId(next.id)
       } else {
         selectAutomationId(null)
         selectExternalKey(next.id)
+        // External items have no runs tab; keep the pane tab valid for the next open.
+        setActivePaneTab('overview')
       }
     },
-    [selectAutomationId, selectExternalKey, selectedExternalKey, selectedId, visibleItems]
+    [
+      selectAutomationId,
+      selectExternalKey,
+      selectedExternalKey,
+      selectedId,
+      setActivePaneTab,
+      visibleItems
+    ]
   )
 
   React.useEffect(() => {

--- a/src/renderer/src/components/automations/automation-list-keyboard-navigation.test.ts
+++ b/src/renderer/src/components/automations/automation-list-keyboard-navigation.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest'
+import {
+  findAutomationListSelectionIndex,
+  getAutomationListArrowNavigationTarget,
+  isAutomationListArrowKey,
+  shouldHandleAutomationListSearchArrowKey
+} from './automation-list-keyboard-navigation'
+
+const items = [
+  { id: 'local-1', kind: 'local' as const },
+  { id: 'local-2', kind: 'local' as const },
+  { id: 'ext-1', kind: 'external' as const }
+]
+
+describe('isAutomationListArrowKey', () => {
+  it('accepts only unmodified ArrowUp/ArrowDown names', () => {
+    expect(isAutomationListArrowKey('ArrowDown')).toBe(true)
+    expect(isAutomationListArrowKey('ArrowUp')).toBe(true)
+    expect(isAutomationListArrowKey('ArrowLeft')).toBe(false)
+    expect(isAutomationListArrowKey('Enter')).toBe(false)
+  })
+})
+
+describe('shouldHandleAutomationListSearchArrowKey', () => {
+  function event(
+    overrides: Partial<{
+      key: string
+      altKey: boolean
+      ctrlKey: boolean
+      metaKey: boolean
+      shiftKey: boolean
+      isComposing: boolean
+    }> = {}
+  ) {
+    return {
+      key: 'ArrowDown',
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      nativeEvent: { isComposing: overrides.isComposing ?? false },
+      ...overrides
+    }
+  }
+
+  it('handles plain ArrowUp/ArrowDown', () => {
+    expect(shouldHandleAutomationListSearchArrowKey(event())).toBe(true)
+    expect(shouldHandleAutomationListSearchArrowKey(event({ key: 'ArrowUp' }))).toBe(true)
+  })
+
+  it('ignores composing, modified, and non-arrow keys', () => {
+    expect(shouldHandleAutomationListSearchArrowKey(event({ isComposing: true }))).toBe(false)
+    expect(shouldHandleAutomationListSearchArrowKey(event({ metaKey: true }))).toBe(false)
+    expect(shouldHandleAutomationListSearchArrowKey(event({ ctrlKey: true }))).toBe(false)
+    expect(shouldHandleAutomationListSearchArrowKey(event({ altKey: true }))).toBe(false)
+    expect(shouldHandleAutomationListSearchArrowKey(event({ shiftKey: true }))).toBe(false)
+    expect(shouldHandleAutomationListSearchArrowKey(event({ key: 'Escape' }))).toBe(false)
+  })
+})
+
+describe('findAutomationListSelectionIndex', () => {
+  it('prefers the external key when one is set', () => {
+    expect(findAutomationListSelectionIndex(items, 'local-1', 'ext-1')).toBe(2)
+  })
+
+  it('finds the local row when no external key is set', () => {
+    expect(findAutomationListSelectionIndex(items, 'local-2', null)).toBe(1)
+  })
+
+  it('returns -1 when nothing in the visible list is selected', () => {
+    expect(findAutomationListSelectionIndex(items, 'missing', null)).toBe(-1)
+    expect(findAutomationListSelectionIndex(items, null, null)).toBe(-1)
+  })
+})
+
+describe('getAutomationListArrowNavigationTarget', () => {
+  it('returns null when the list is empty', () => {
+    expect(
+      getAutomationListArrowNavigationTarget({
+        items: [],
+        selectedId: null,
+        selectedExternalKey: null,
+        key: 'ArrowDown'
+      })
+    ).toBeNull()
+  })
+
+  it('selects the first row on ArrowDown and the last on ArrowUp when nothing is selected', () => {
+    expect(
+      getAutomationListArrowNavigationTarget({
+        items,
+        selectedId: null,
+        selectedExternalKey: null,
+        key: 'ArrowDown'
+      })
+    ).toEqual(items[0])
+    expect(
+      getAutomationListArrowNavigationTarget({
+        items,
+        selectedId: null,
+        selectedExternalKey: null,
+        key: 'ArrowUp'
+      })
+    ).toEqual(items[2])
+  })
+
+  it('steps to the next and previous visible rows, including across local/external', () => {
+    expect(
+      getAutomationListArrowNavigationTarget({
+        items,
+        selectedId: 'local-1',
+        selectedExternalKey: null,
+        key: 'ArrowDown'
+      })
+    ).toEqual(items[1])
+    expect(
+      getAutomationListArrowNavigationTarget({
+        items,
+        selectedId: 'local-2',
+        selectedExternalKey: null,
+        key: 'ArrowDown'
+      })
+    ).toEqual(items[2])
+    expect(
+      getAutomationListArrowNavigationTarget({
+        items,
+        selectedId: null,
+        selectedExternalKey: 'ext-1',
+        key: 'ArrowUp'
+      })
+    ).toEqual(items[1])
+  })
+
+  it('clamps at the ends instead of wrapping', () => {
+    expect(
+      getAutomationListArrowNavigationTarget({
+        items,
+        selectedId: 'local-1',
+        selectedExternalKey: null,
+        key: 'ArrowUp'
+      })
+    ).toEqual(items[0])
+    expect(
+      getAutomationListArrowNavigationTarget({
+        items,
+        selectedId: null,
+        selectedExternalKey: 'ext-1',
+        key: 'ArrowDown'
+      })
+    ).toEqual(items[2])
+  })
+})

--- a/src/renderer/src/components/automations/automation-list-keyboard-navigation.ts
+++ b/src/renderer/src/components/automations/automation-list-keyboard-navigation.ts
@@ -1,0 +1,60 @@
+import type { AutomationListViewItem } from './automation-list-view'
+
+export type AutomationListArrowKey = 'ArrowUp' | 'ArrowDown'
+
+export function isAutomationListArrowKey(key: string): key is AutomationListArrowKey {
+  return key === 'ArrowUp' || key === 'ArrowDown'
+}
+
+export function shouldHandleAutomationListSearchArrowKey(event: {
+  key: string
+  altKey: boolean
+  ctrlKey: boolean
+  metaKey: boolean
+  shiftKey: boolean
+  nativeEvent: { isComposing: boolean }
+}): boolean {
+  return (
+    isAutomationListArrowKey(event.key) &&
+    !event.nativeEvent.isComposing &&
+    !event.altKey &&
+    !event.ctrlKey &&
+    !event.metaKey &&
+    !event.shiftKey
+  )
+}
+
+export function findAutomationListSelectionIndex(
+  items: readonly Pick<AutomationListViewItem, 'id' | 'kind'>[],
+  selectedId: string | null,
+  selectedExternalKey: string | null
+): number {
+  if (selectedExternalKey !== null) {
+    return items.findIndex((item) => item.kind === 'external' && item.id === selectedExternalKey)
+  }
+  if (selectedId != null) {
+    return items.findIndex((item) => item.kind === 'local' && item.id === selectedId)
+  }
+  return -1
+}
+
+export function getAutomationListArrowNavigationTarget(args: {
+  items: readonly Pick<AutomationListViewItem, 'id' | 'kind'>[]
+  selectedId: string | null
+  selectedExternalKey: string | null
+  key: AutomationListArrowKey
+}): Pick<AutomationListViewItem, 'id' | 'kind'> | null {
+  const { items, selectedId, selectedExternalKey, key } = args
+  if (items.length === 0) {
+    return null
+  }
+  const currentIndex = findAutomationListSelectionIndex(items, selectedId, selectedExternalKey)
+  if (currentIndex < 0) {
+    return items[key === 'ArrowDown' ? 0 : items.length - 1] ?? null
+  }
+  const nextIndex = key === 'ArrowDown' ? currentIndex + 1 : currentIndex - 1
+  if (nextIndex < 0 || nextIndex >= items.length) {
+    return items[currentIndex] ?? null
+  }
+  return items[nextIndex] ?? null
+}

--- a/src/renderer/src/lib/list-table-layout.ts
+++ b/src/renderer/src/lib/list-table-layout.ts
@@ -8,7 +8,8 @@ export const LIST_TABLE_CONTAINER_CLASS = 'rounded-md border border-border/50 bg
 export const LIST_TABLE_HEADER_CLASS =
   'sticky top-0 z-10 h-8 items-center gap-3 border-b border-border/50 bg-muted/25 px-3 text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground'
 
+// Why: keep keyboard-selected rows clear of the sticky table header.
 export const LIST_TABLE_ROW_CLASS =
-  'w-full min-h-11 cursor-pointer items-center gap-3 px-3 py-3 text-left text-sm transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50'
+  'w-full min-h-11 scroll-mt-8 cursor-pointer items-center gap-3 px-3 py-3 text-left text-sm transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50'
 
 export const LIST_TABLE_ROW_SELECTED_CLASS = 'bg-accent text-accent-foreground'


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​197 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​196 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​145 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​144 |

<!-- /orca-pr-loc -->

## Summary
- let plain ArrowUp/ArrowDown in the automation search field select adjacent visible rows
- support local and external automation rows, clamp at list boundaries, and preserve modified/composing input behavior
- keep keyboard-selected rows visible below the sticky table header

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/automations
- pnpm run typecheck:web
- pnpm exec oxlint <changed files> --deny-warnings
- pnpm exec oxfmt --check <changed files>
- pnpm run build:electron-vite

Note: pnpm run check:code-quality:changed could not run because its JSON parser consumed pnpm's Node 26 unsupported-engine warning; direct changed-file oxlint passed.