### PR TITLE
fix(terminal-pane): gate remote pane spawns on the first session.tabs snapshot

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -42,6 +42,11 @@ import type { PtyBufferSnapshot, PtyConnectResult, PtyReplayDataMeta } from './p
 import type { IpcPtyTransportOptions, PtyTransportRecoveryState } from './pty-transport-types'
 import { createIpcPtyTransport } from './pty-transport'
 import { createRemoteRuntimePtyTransport } from './remote-runtime-pty-transport'
+import { getLatestWebSessionTabsPublicationEpoch } from '@/runtime/web-session-tabs-sync'
+import {
+  RUNTIME_SNAPSHOT_SPAWN_POLL_MS,
+  shouldDeferRuntimePaneSpawn
+} from './runtime-pane-spawn-gate'
 import { toAgentLaunchPreferences } from '@/runtime/agent-session-create-operation'
 import { createUnresolvedOwnerPtyTransport } from './unresolved-owner-pty-transport'
 import { resolveTerminalWorktreeRoute } from '@/lib/terminal-worktree-route'
@@ -1126,6 +1131,14 @@ export function connectPanePty(
   const structuralReplayCoordinator = createTerminalStructuralReplayCoordinator(pane.terminal)
   let connectFrame: number | null = null
   let connectFallbackTimer: ReturnType<typeof setTimeout> | null = null
+  // Why (#15622): a restored PTY-less row on a paired-runtime worktree must not
+  // spawn a remote shell on mount; the first accepted session.tabs snapshot
+  // either attaches this pane to the host's existing PTY (the connect path then
+  // reattaches) or drops the stale row. Poll with a timer — hidden tabs get no
+  // animation frames — and bound the wait so an unreachable runtime still
+  // gets a pane.
+  let runtimeSnapshotWaitTimer: ReturnType<typeof setTimeout> | null = null
+  let runtimeSnapshotWaitStartedAt: number | null = null
   let startupGridSettleHandle: TerminalStartupGridSettleHandle | null = null
   let startupGridSettledForConnect = false
   let connectStarted = false
@@ -4716,10 +4729,32 @@ export function connectPanePty(
         clearTimeout(connectFallbackTimer)
         connectFallbackTimer = null
       }
+      if (runtimeSnapshotWaitTimer !== null) {
+        clearTimeout(runtimeSnapshotWaitTimer)
+        runtimeSnapshotWaitTimer = null
+      }
       settleStartupGridBeforeConnect(() => {
         startupGridSettledForConnect = true
         runDeferredConnect()
       })
+      return
+    }
+    const spawnGate = shouldDeferRuntimePaneSpawn({
+      runtimeEnvironmentId,
+      hasPtyBinding: (useAppStore.getState().ptyIdsByTabId[deps.tabId] ?? []).length > 0,
+      hasRestoredPtyHandle: restoredPtyIdForTransport !== null,
+      snapshotAccepted:
+        runtimeEnvironmentId !== null &&
+        getLatestWebSessionTabsPublicationEpoch(runtimeEnvironmentId, deps.worktreeId) !== null,
+      waitStartedAt: runtimeSnapshotWaitStartedAt,
+      now: Date.now()
+    })
+    runtimeSnapshotWaitStartedAt = spawnGate.waitStartedAt
+    if (spawnGate.defer) {
+      runtimeSnapshotWaitTimer = setTimeout(() => {
+        runtimeSnapshotWaitTimer = null
+        runDeferredConnect()
+      }, RUNTIME_SNAPSHOT_SPAWN_POLL_MS)
       return
     }
     connectStarted = true
@@ -9579,6 +9614,10 @@ export function connectPanePty(
       if (connectFallbackTimer !== null) {
         clearTimeout(connectFallbackTimer)
         connectFallbackTimer = null
+      }
+      if (runtimeSnapshotWaitTimer !== null) {
+        clearTimeout(runtimeSnapshotWaitTimer)
+        runtimeSnapshotWaitTimer = null
       }
       imeCompositionRouteDisposable.dispose()
       onDataDisposable.dispose()

--- a/src/renderer/src/components/terminal-pane/runtime-pane-spawn-gate.test.ts
+++ b/src/renderer/src/components/terminal-pane/runtime-pane-spawn-gate.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+import {
+  RUNTIME_SNAPSHOT_SPAWN_WAIT_MS,
+  shouldDeferRuntimePaneSpawn
+} from './runtime-pane-spawn-gate'
+
+const ENV = 'runtime:env-1'
+
+describe('shouldDeferRuntimePaneSpawn', () => {
+  it('never gates a local or SSH pane', () => {
+    const decision = shouldDeferRuntimePaneSpawn({
+      runtimeEnvironmentId: null,
+      hasPtyBinding: false,
+      snapshotAccepted: false,
+      hasRestoredPtyHandle: false,
+      waitStartedAt: null,
+      now: 1_000
+    })
+    expect(decision.defer).toBe(false)
+  })
+
+  it('never gates a pane that already has a PTY binding (the reattach path)', () => {
+    const decision = shouldDeferRuntimePaneSpawn({
+      runtimeEnvironmentId: ENV,
+      hasPtyBinding: true,
+      snapshotAccepted: false,
+      hasRestoredPtyHandle: false,
+      waitStartedAt: null,
+      now: 1_000
+    })
+    expect(decision.defer).toBe(false)
+  })
+
+  it('defers a PTY-less runtime pane until the first snapshot is accepted (#15622)', () => {
+    const started = shouldDeferRuntimePaneSpawn({
+      runtimeEnvironmentId: ENV,
+      hasPtyBinding: false,
+      snapshotAccepted: false,
+      hasRestoredPtyHandle: false,
+      waitStartedAt: null,
+      now: 1_000
+    })
+    expect(started).toEqual({ defer: true, waitStartedAt: 1_000 })
+
+    const stillWaiting = shouldDeferRuntimePaneSpawn({
+      runtimeEnvironmentId: ENV,
+      hasPtyBinding: false,
+      snapshotAccepted: false,
+      hasRestoredPtyHandle: false,
+      waitStartedAt: started.waitStartedAt,
+      now: 1_000 + 500
+    })
+    expect(stillWaiting.defer).toBe(true)
+
+    const accepted = shouldDeferRuntimePaneSpawn({
+      runtimeEnvironmentId: ENV,
+      hasPtyBinding: false,
+      snapshotAccepted: true,
+      hasRestoredPtyHandle: false,
+      waitStartedAt: started.waitStartedAt,
+      now: 1_000 + 500
+    })
+    expect(accepted.defer).toBe(false)
+  })
+
+
+  it('never gates a sleep-resume pane carrying a preserved PTY handle', () => {
+    const decision = shouldDeferRuntimePaneSpawn({
+      runtimeEnvironmentId: ENV,
+      hasPtyBinding: false,
+      snapshotAccepted: false,
+      hasRestoredPtyHandle: true,
+      waitStartedAt: null,
+      now: 1_000
+    })
+    expect(decision.defer).toBe(false)
+  })
+
+  it('stops deferring after the bounded wait so an unreachable runtime still gets a pane', () => {
+    const decision = shouldDeferRuntimePaneSpawn({
+      runtimeEnvironmentId: ENV,
+      hasPtyBinding: false,
+      snapshotAccepted: false,
+      hasRestoredPtyHandle: false,
+      waitStartedAt: 1_000,
+      now: 1_000 + RUNTIME_SNAPSHOT_SPAWN_WAIT_MS + 1
+    })
+    expect(decision.defer).toBe(false)
+  })
+
+  it('a snapshot acquired mid-wait wins even for a pane that gained no binding', () => {
+    // The snapshot dropped the stale row's expectation: connecting is now safe
+    // because the authoritative list no longer contains a PTY this pane would
+    // double-spawn beside.
+    const decision = shouldDeferRuntimePaneSpawn({
+      runtimeEnvironmentId: ENV,
+      hasPtyBinding: false,
+      snapshotAccepted: true,
+      hasRestoredPtyHandle: false,
+      waitStartedAt: 1_000,
+      now: 1_000 + 50
+    })
+    expect(decision.defer).toBe(false)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/runtime-pane-spawn-gate.ts
+++ b/src/renderer/src/components/terminal-pane/runtime-pane-spawn-gate.ts
@@ -1,0 +1,47 @@
+/** Bounded wait before a paired-runtime pane with no PTY spawns its own shell (#15622). */
+export const RUNTIME_SNAPSHOT_SPAWN_WAIT_MS = 10_000
+/** Timer-based re-check cadence; hidden tabs get no animation frames. */
+export const RUNTIME_SNAPSHOT_SPAWN_POLL_MS = 200
+
+export type RuntimePaneSpawnGateInput = {
+  /** Remote runtime owning the worktree; null = local/SSH pane, never gated. */
+  runtimeEnvironmentId: string | null
+  /** Whether the tab already has a PTY binding (restore reattach path) — never gated. */
+  hasPtyBinding: boolean
+  /** Whether the runtime's first authoritative session.tabs snapshot was accepted. */
+  snapshotAccepted: boolean
+  /** Whether the pane carries a preserved sleep-resume PTY handle — an
+   * intentional cold-spawn resume that must connect immediately, not a stale row. */
+  hasRestoredPtyHandle: boolean
+  /** Epoch ms when the wait started, null before the first deferred decision. */
+  waitStartedAt: number | null
+  now: number
+}
+
+export type RuntimePaneSpawnGateDecision = {
+  /** True while the pane must keep waiting instead of spawning. */
+  defer: boolean
+  /** The wait-start timestamp to carry into the next decision. */
+  waitStartedAt: number
+}
+
+/**
+ * A restored PTY-less terminal row on a paired-runtime worktree must not spawn
+ * on mount (#15622): each mount-created remote shell turns a stale row into a
+ * live terminal. The first accepted session.tabs snapshot either attaches the
+ * pane to the host's existing PTY (the connect path then reattaches instead of
+ * spawning) or drops the stale row. The wait is bounded so an unreachable
+ * runtime still gets a working pane after the deadline.
+ */
+export function shouldDeferRuntimePaneSpawn(
+  input: RuntimePaneSpawnGateInput
+): RuntimePaneSpawnGateDecision {
+  const waitStartedAt = input.waitStartedAt ?? input.now
+  const defer =
+    input.runtimeEnvironmentId !== null &&
+    !input.hasPtyBinding &&
+    !input.hasRestoredPtyHandle &&
+    !input.snapshotAccepted &&
+    input.now - waitStartedAt < RUNTIME_SNAPSHOT_SPAWN_WAIT_MS
+  return { defer, waitStartedAt }
+}


### PR DESCRIPTION
## Summary

**What**

A runtime-owned pane with **no PTY binding** now waits for its worktree's first accepted `session.tabs` snapshot before connecting its transport (timer-polled at 200ms — hidden tabs get no animation frames — bounded at 10s). Panes carrying a preserved sleep-resume PTY handle are exempt; local and SSH panes are never gated.

**Why**

#15622 — opening a paired-runtime worktree restores persisted PTY-less terminal rows, and each pane's mount connected its transport immediately; on a remote runtime that connection **creates a shell**, so every stale row respawned as a live terminal. The first authoritative snapshot resolves the ambiguity: it either attaches the pane to the host's existing PTY (the connect path then reattaches instead of spawning) or drops the stale row — but only if the pane hasn't already spawned beside it.

The gate lives at the single connect chokepoint (`runDeferredConnect` inside `connectPanePty`), so both mount paths (TerminalPane + the lifecycle hook) get it, and the bounded wait preserves today's behavior when the runtime is unreachable. The sleep-resume exemption matters because that path *is* an intentional cold-spawn of a preserved handle — the existing remote-attach suite caught it before shipping (`cold-spawns slept remote runtime PTYs instead of reattaching the preserved handle` now passes unchanged).

The snapshot-accepted check reuses `getLatestWebSessionTabsPublicationEpoch` from `web-session-tabs-sync` — the same acceptance record the tab reconciliation trusts.

**Testing**

- New `runtime-pane-spawn-gate.test.ts` (6 cases): local/SSH never gated; existing PTY binding never gated (reattach path); PTY-less runtime pane defers until snapshot accepted then proceeds; bounded wait expires so an unreachable runtime gets a pane; mid-wait snapshot wins; **sleep-resume preserved-handle panes are never gated**. 6/6.
- Full `terminal-pane` suite: **3695 passed, 1 skipped, 380/380 files** — including the remote-runtime attach suite that pinned the slept-resume semantics.
- `pnpm run typecheck` clean.

Fixes #15622