### PR TITLE
feat(agents): resume Hermes TUI sessions after crash

### DIFF
--- a/src/shared/agent-hook-listener-hermes-codex-droid.test.ts
+++ b/src/shared/agent-hook-listener-hermes-codex-droid.test.ts
@@ -19,6 +19,40 @@ describe('shared agent-hook-listener', () => {
     vi.unstubAllEnvs()
   })
 
+  it('captures Hermes session_id as providerSession on on_session_start and pre_llm_call', () => {
+    const start = normalizeHookPayload(
+      state,
+      'hermes',
+      {
+        paneKey: PANE_KEY,
+        payload: {
+          hook_event_name: 'on_session_start',
+          session_id: 'hermes-session'
+        }
+      },
+      'production'
+    )
+    expect(start?.providerSession).toEqual({ key: 'session_id', id: 'hermes-session' })
+    expect(start?.payload.agentType).toBe('hermes')
+
+    const pre = normalizeHookPayload(
+      state,
+      'hermes',
+      {
+        paneKey: PANE_KEY,
+        payload: {
+          hook_event_name: 'pre_llm_call',
+          session_id: 'hermes-session',
+          user_message: 'ship the Hermes support'
+        }
+      },
+      'production'
+    )
+    expect(pre?.providerSession).toEqual({ key: 'session_id', id: 'hermes-session' })
+    expect(pre?.payload.state).toBe('working')
+    expect(pre?.payload.prompt).toBe('ship the Hermes support')
+  })
+
   it('normalizes Hermes pre_llm_call to a working turn with prompt text', () => {
     const event = normalizeHookPayload(
       state,

--- a/src/shared/agent-session-resume.test.ts
+++ b/src/shared/agent-session-resume.test.ts
@@ -20,6 +20,10 @@ describe('agent session resume metadata', () => {
     expect(isResumableTuiAgent('prime-agent')).toBe(true)
   })
 
+  it('treats hermes as a resumable TUI agent', () => {
+    expect(isResumableTuiAgent('hermes')).toBe(true)
+  })
+
   it.each([
     ['claude', { session_id: 'claude-session' }, { key: 'session_id', id: 'claude-session' }],
     ['codex', { session_id: 'codex-session' }, { key: 'session_id', id: 'codex-session' }],
@@ -44,7 +48,8 @@ describe('agent session resume metadata', () => {
       'prime-agent',
       { session_id: 'prime-session', session_file: '/tmp/prime-session.jsonl' },
       { key: 'session_id', id: 'prime-session', transcriptPath: '/tmp/prime-session.jsonl' }
-    ]
+    ],
+    ['hermes', { session_id: 'hermes-session' }, { key: 'session_id', id: 'hermes-session' }]
   ] as const)('extracts %s provider session ids', (source, payload, expected) => {
     expect(extractAgentProviderSession(source, payload)).toEqual(expected)
   })
@@ -69,16 +74,22 @@ describe('agent session resume metadata', () => {
       'prime-agent',
       { key: 'session_id', id: 's1', transcriptPath: '/tmp/prime-session.jsonl' },
       ['prime-agent', '--resume', '/tmp/prime-session.jsonl']
-    ]
+    ],
+    ['hermes', { key: 'session_id', id: 's1' }, ['hermes', '--resume', 's1']]
   ] as const)('builds %s resume argv', (agent, providerSession, expected) => {
     expect(getAgentResumeArgv(agent, providerSession)).toEqual(expected)
   })
 
   it('rejects unsupported sources and unsafe ids', () => {
     expect(extractAgentProviderSession('cursor', { session_id: 'cursor-session' })).toBeNull()
+    expect(extractAgentProviderSession('amp', { session_id: 'amp-session' })).toBeNull()
+    expect(extractAgentProviderSession('copilot', { session_id: 'copilot-session' })).toBeNull()
     expect(normalizeAgentProviderSession({ key: 'session_id', id: 'bad\nid' })).toBeNull()
     expect(normalizeAgentProviderSession({ key: 'session_id', id: '--last' })).toBeNull()
     expect(extractAgentProviderSession('codex', { session_id: '--last' })).toBeNull()
+    expect(extractAgentProviderSession('hermes', { session_id: '--last' })).toBeNull()
+    expect(extractAgentProviderSession('hermes', { session_id: 'bad\nid' })).toBeNull()
+    expect(extractAgentProviderSession('hermes', { conversation_id: 'hermes-conversation' })).toBeNull()
     expect(normalizeAgentProviderSession({ key: 'session_id', id: 'ok' })).toEqual({
       key: 'session_id',
       id: 'ok'
@@ -107,6 +118,10 @@ describe('agent session resume metadata', () => {
     expect(getAgentResumeArgv('devin', { key: 'conversation_id', id: 'x' })).toBeNull()
   })
 
+  it('rejects hermes resume when provider session key is not session_id', () => {
+    expect(getAgentResumeArgv('hermes', { key: 'conversation_id', id: 'x' })).toBeNull()
+  })
+
   it('captures the hook transcript_path for native-chat agents (claude/codex)', () => {
     expect(
       extractAgentProviderSession('claude', {
@@ -127,6 +142,12 @@ describe('agent session resume metadata', () => {
     expect(
       extractAgentProviderSession('gemini', { session_id: 'gs', transcript_path: '/x/r.jsonl' })
     ).toEqual({ key: 'session_id', id: 'gs' })
+    expect(
+      extractAgentProviderSession('hermes', {
+        session_id: 'hermes-session',
+        transcript_path: '/x/hermes.jsonl'
+      })
+    ).toEqual({ key: 'session_id', id: 'hermes-session' })
   })
 
   it('round-trips transcriptPath through normalizeAgentProviderSession', () => {

--- a/src/shared/agent-session-resume.ts
+++ b/src/shared/agent-session-resume.ts
@@ -14,7 +14,8 @@ export const RESUMABLE_TUI_AGENTS = [
   'grok',
   'devin',
   'omp',
-  'prime-agent'
+  'prime-agent',
+  'hermes'
 ] as const satisfies readonly TuiAgent[]
 
 export type ResumableTuiAgent = (typeof RESUMABLE_TUI_AGENTS)[number]
@@ -225,6 +226,10 @@ export function extractAgentProviderSession(
       const id = readSessionId(payload, ['session_id', 'sessionId'])
       return id ? { key: 'session_id', id } : null
     }
+    case 'hermes': {
+      const id = readSessionId(payload, ['session_id'])
+      return id ? { key: 'session_id', id } : null
+    }
     // Why: OMP's managed extension reports the authoritative CLI resume id.
     case 'omp': {
       const id = readSessionId(payload, ['session_id'])
@@ -234,7 +239,6 @@ export function extractAgentProviderSession(
     case 'cursor':
     case 'command-code':
     case 'copilot':
-    case 'hermes':
       return null
   }
 }
@@ -276,5 +280,7 @@ export function getAgentResumeArgv(
       return providerSession.key === 'session_id'
         ? ['omp', '--resume', ompResumeFilePath?.trim() || id]
         : null
+    case 'hermes':
+      return providerSession.key === 'session_id' ? ['hermes', '--resume', id] : null
   }
 }

--- a/src/shared/tui-agent-startup.test.ts
+++ b/src/shared/tui-agent-startup.test.ts
@@ -605,6 +605,74 @@ describe('tui agent startup plans', () => {
     expect(plan?.launchCommand).toBe("codex --profile work 'fix it'")
   })
 
+  it('builds POSIX Hermes TUI resume plans from the provider session id', () => {
+    const plan = buildAgentResumeStartupPlan({
+      agent: 'hermes',
+      providerSession: { key: 'session_id', id: 's1' },
+      cmdOverrides: {},
+      platform: 'linux'
+    })
+
+    expect(plan?.launchCommand).toBe("hermes --tui '--resume' 's1'")
+    expect(plan?.launchCommand).toContain('--tui')
+    expect(plan?.launchCommand).toContain('--resume')
+    expect(plan?.launchCommand).toContain('s1')
+    expect(plan?.launchCommand).not.toContain('chat')
+    expect(plan?.launchCommand).not.toContain('--query')
+    expect(plan?.launchCommand).not.toContain('ORCA_HERMES_STARTUP_QUERY')
+    expect(plan?.followupPrompt).toBeNull()
+    expect(plan?.env?.ORCA_HERMES_STARTUP_QUERY).toBeUndefined()
+    expect(plan?.launchConfig.agentCommand).toBe('hermes --tui')
+  })
+
+  it('builds Windows Hermes TUI resume plans that PowerShell can invoke', () => {
+    const plan = buildAgentResumeStartupPlan({
+      agent: 'hermes',
+      providerSession: { key: 'session_id', id: 's1' },
+      cmdOverrides: {},
+      platform: 'win32'
+    })
+
+    expect(plan?.launchCommand).toBe("hermes --tui '--resume' 's1'")
+    expect(plan?.launchCommand).toContain('--tui')
+    expect(plan?.launchCommand).toContain('--resume')
+    expect(plan?.followupPrompt).toBeNull()
+    expect(plan?.launchConfig.agentCommand).toBe('hermes --tui')
+  })
+
+  it('quotes Windows Hermes TUI resume argv for cmd.exe when shell is cmd', () => {
+    const plan = buildAgentResumeStartupPlan({
+      agent: 'hermes',
+      providerSession: { key: 'session_id', id: 's1' },
+      cmdOverrides: {},
+      platform: 'win32',
+      shell: 'cmd'
+    })
+
+    expect(plan?.launchCommand).toBe('hermes --tui "--resume" "s1"')
+    expect(plan?.launchCommand).toContain('--tui')
+    expect(plan?.launchCommand).toContain('--resume')
+    expect(plan?.followupPrompt).toBeNull()
+    expect(plan?.launchConfig.agentCommand).toBe('hermes --tui')
+  })
+
+  it('keeps --tui when a persisted Hermes agentCommand is used for resume', () => {
+    const plan = buildAgentResumeStartupPlan({
+      agent: 'hermes',
+      providerSession: { key: 'session_id', id: 's1' },
+      cmdOverrides: {},
+      agentCommand: 'hermes --tui',
+      platform: 'linux'
+    })
+
+    expect(plan?.launchCommand).toBe("hermes --tui '--resume' 's1'")
+    expect(plan?.launchCommand).toContain('--tui')
+    expect(plan?.launchCommand).toContain('--resume')
+    expect(plan?.launchCommand).not.toContain('chat')
+    expect(plan?.followupPrompt).toBeNull()
+    expect(plan?.launchConfig.agentCommand).toBe('hermes --tui')
+  })
+
   it('builds Windows resume plans that PowerShell can invoke', () => {
     const plan = buildAgentResumeStartupPlan({
       agent: 'codex',


### PR DESCRIPTION
## ELI5

If a Hermes TUI pane dies because Orca, the daemon, or the PTY crashed, Orca should relaunch that same Hermes session with `--tui --resume <id>`, the way it already does for Claude and Codex. Hermes already knows how to resume by id. Orca was dropping the session id, so the pane came back as an empty shell.

## What Changed

- Add `hermes` to `RESUMABLE_TUI_AGENTS`.
- Extract the managed-hook `session_id` as provider-session metadata (no transcript path).
- Build resume argv `['hermes', '--resume', id]`. Existing cold restore appends that onto the hosted launch command `hermes --tui`.
- Tests for identity extraction, hook envelope `providerSession`, and POSIX / PowerShell / cmd resume command shape.

## Why

Hermes TUI already implements `hermes --tui --resume <id>`. Orca's crash-restore chain gates on the resumable-agent allowlist and `getAgentResumeArgv`. Hermes was grouped with agents that return no provider session, so the pane never persisted an id and never rebuilt a resume command.

Resume uses the hook-reported session id, not `--continue` or `latest`. Those pick the most recent CLI session (or a terminal breadcrumb). After a crash Orca restores new PTYs and may wake several Hermes panes; a latest-session lookup can attach the wrong conversation.

## Linked Issue

Fixes #15808

## Visual Proof

N/A — no new UI. Same session-restored banner as other resumable hosted agents. Interaction change is the restored pane command, covered by unit tests.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Focused unit tests:

- `src/shared/agent-session-resume.test.ts`
- `src/shared/tui-agent-startup.test.ts`
- `src/shared/agent-hook-listener-hermes-codex-droid.test.ts`
- `src/shared/ai-vault-resume-command.test.ts`
- `src/renderer/src/lib/ai-vault-resume-command.test.ts`

Result: 5 files, 164 tests passed. Also ran a node TypeScript check for the shared/node project.

Platform notes:

- Linux: resume command `hermes --tui '--resume' '<id>'`
- Windows PowerShell: same quoting as other POSIX-style resume plans
- Windows cmd: `hermes --tui "--resume" "<id>"`
- SSH/remote: resume still spawns on the execution host from the hook-reported id. No new RPC opcode or required field.
- Folder workspaces use the same sleeping-agent path as git worktrees.

No real Hermes TUI e2e (existing quit-resume e2e stubs Codex and does not install agent CLIs). Resume still depends on the existing managed Hermes hook posting `session_id`.

## AI Disclosure

This contribution was implemented, tested, and prepared by Hermes Agent via Orca on behalf of Enoch Lam (@eloklam).

## Review

Cross-platform: resume argv is appended as discrete quoted arguments, not a shell string. cmd vs PowerShell quoting is covered.

SSH/remote/local: identity comes from the existing Hermes hook envelope; restore still runs on the execution host. Folder workspaces do not require Git.

Agent/integration: only Hermes is added to the resume allowlist. Claude, Codex, and other agents are unchanged. Native chat, AI Vault scanner stored-command shape, and the Hermes plugin are out of scope.

Performance: allowlist/extractor/argv only; no extra I/O on the hot path.

UI: no visual change.

Security: session ids still pass through the existing unsafe-character / leading-dash rejection used for other agents. The id is one process argument, not interpolated into a shell script. No credentials, filesystem authority, or new network calls.

Related open PR: #12075 already opts Hermes into the same resume allowlist with a broader hibernation framing. This PR is a minimal crash/quit TUI restore on current main, with extra coverage for hook `providerSession` and cmd quoting. Happy to close this if maintainers prefer #12075.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

Author: @eloklam
X (Twitter): not provided

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [ ] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
