### PR TITLE
feat(sidebar): let users unpin main workspaces from the top of their group

### DIFF
--- a/src/renderer/src/components/settings/AppearanceWindowSidebarSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceWindowSidebarSection.tsx
@@ -337,6 +337,34 @@ export function AppearanceWindowSidebarSection({
                       }
                     />
                   </SearchableSetting>
+
+                  <SearchableSetting
+                    title={translate(
+                      'auto.components.settings.AppearancePane.pinMainWorkspaceFirst.title',
+                      'Keep main workspaces at the top'
+                    )}
+                    keywords={['main', 'primary', 'worktree', 'workspace', 'order', 'sort', 'pin']}
+                  >
+                    <SettingsSwitchRow
+                      label={translate(
+                        'auto.components.settings.AppearancePane.pinMainWorkspaceFirst.title',
+                        'Keep main workspaces at the top'
+                      )}
+                      // Why: repos group their canonical workspace first by default so the
+                      // anchor row never moves; turning this off lets the chosen sort
+                      // (Smart/Recent) rank it like any other workspace (#15770).
+                      description={translate(
+                        'auto.components.settings.AppearancePane.pinMainWorkspaceFirst.description',
+                        'Each project’s main workspace stays at the top of its group. Turn off to let the workspace sort order rank it like any other.'
+                      )}
+                      checked={settings.pinMainWorkspaceFirst !== false}
+                      onChange={() =>
+                        updateSettings({
+                          pinMainWorkspaceFirst: !(settings.pinMainWorkspaceFirst !== false)
+                        })
+                      }
+                    />
+                  </SearchableSetting>
                 </div>
               </div>
             ) : null}

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.main-worktree-pin.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.main-worktree-pin.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import type { Repo } from '../../../../../../shared/repo-types'
+import type { Worktree } from '../../../../../../shared/worktree/types'
+import type { AppState } from '@/store/types'
+import { buildRows } from './build-rows'
+
+const repo: Repo = {
+  id: 'repo-1',
+  path: '/repos/app',
+  displayName: 'app',
+  badgeColor: '#000000',
+  addedAt: 1,
+  kind: 'git'
+}
+
+function makeWorktree(id: string, isMainWorktree: boolean): Worktree {
+  return {
+    id,
+    repoId: repo.id,
+    path: `/repos/app/${id}`,
+    branch: id,
+    displayName: id,
+    isMainWorktree
+  } as Worktree as Worktree
+}
+
+// A child workspace sorted ahead of the main by createdAt (Recent-style input order).
+const childFirst = makeWorktree('child-hot', false)
+const main = makeWorktree('main', true)
+const repoMap = new Map([[repo.id, repo]])
+
+describe('buildRows main-workspace pinning (#15770)', () => {
+  it('anchors the main workspace at the top of its repo group by default', () => {
+    const rows = buildRows('repo', [childFirst, main], repoMap, null, new Set())
+    const itemIds = rows
+      .filter((row) => row.type === 'item')
+      .map((row) => (row.type === 'item' ? row.worktree.id : ''))
+    expect(itemIds).toEqual(['main', 'child-hot'])
+  })
+
+  it('lets the natural order rank the main workspace when pinMainWorkspaceFirst is off', () => {
+    const settings = { pinMainWorkspaceFirst: false } as AppState['settings']
+    const rows = buildRows(
+      'repo',
+      [childFirst, main],
+      repoMap,
+      null,
+      new Set(),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      settings
+    )
+    const itemIds = rows
+      .filter((row) => row.type === 'item')
+      .map((row) => (row.type === 'item' ? row.worktree.id : ''))
+    expect(itemIds).toEqual(['child-hot', 'main'])
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.ts
@@ -225,7 +225,8 @@ export function buildRows(
     lineageById,
     worktreeMap,
     nestLineage,
-    cyclicLineageIds
+    cyclicLineageIds,
+    pinMainWorktreeFirst: settings?.pinMainWorkspaceFirst !== false
   }
 
   if (groupBy !== 'repo' || projectGroups.length === 0) {

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/group-sections.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/group-sections.ts
@@ -50,6 +50,8 @@ export type SectionAppendContext = {
   worktreeMap: Map<string, Worktree>
   nestLineage: boolean
   cyclicLineageIds: ReadonlySet<string>
+  /** False lets dynamic sorts rank the main workspace anywhere in its group (#15770). */
+  pinMainWorktreeFirst?: boolean
 }
 
 export function appendOrderedGroups(
@@ -190,7 +192,10 @@ export function appendOrderedGroups(
           }
         }
       }
-      const items = groupBy === 'repo' ? orderMainWorktreeFirst(group.items) : group.items
+      const items =
+        groupBy === 'repo' && ctx.pinMainWorktreeFirst !== false
+          ? orderMainWorktreeFirst(group.items)
+          : group.items
       const hostContextLabelByRepoId =
         groupBy === 'repo'
           ? getMixedHostContextLabels(group, repoMap, projectIndex, hostLabelById)

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -238,6 +238,8 @@ export type GlobalSettings = {
   showMobileButton?: boolean
   /** Pinned workspaces show in one sidebar location by default; opt in to also show them in their natural groups. */
   showPinnedWorktreesInGroups?: boolean
+  /** Keep each project's main workspace anchored at the top of its group (#15770). Absent = on. */
+  pinMainWorkspaceFirst?: boolean
   /** How Ctrl+Tab picks the next visible tab; optional (older profiles), readers default to MRU. */
   ctrlTabOrderMode?: CtrlTabOrderMode
   /** Orca-first keeps app shortcuts from TUIs; terminal-first is opt-in to let shell/TUI bindings win. */


### PR DESCRIPTION
## Summary

**What**

A new Appearance → Window & Sidebar setting, **"Keep main workspaces at the top"** (default **on**, preserving today's behavior). Turned off, the user's chosen sort (Smart/Recent) ranks each project's main workspace like any other row in its group instead of unconditionally hoisting it first.

Plumbing: `GlobalSettings.pinMainWorkspaceFirst?: boolean` → `buildRows` derives it into `SectionAppendContext` → the single `orderMainWorktreeFirst` call site in `group-sections.ts` respects it. Absent = on, matching the `showPinnedWorktreesInGroups` optional-boolean precedent the neighboring toggle uses.

**Why**

#15770 — "Any way to not pin primary worktrees to top? Would like to re-order them." The hoist (`orderMainWorktreeFirst`, applied whenever `groupBy === 'repo'`) is deliberate — the code comment says "keep the repo's canonical workspace anchored" — but it makes in-project reordering impossible: no sort can move the main row. The default keeps the anchor; the opt-out restores the user's authority over ordering.

**Testing**

- New `build-rows.main-worktree-pin.test.ts` (2 cases): default anchors the main workspace above a child that sorts ahead; with the setting off the natural order ranks the child first. **Verified the off-toggle case fails on the pre-change builder** (main anchored regardless).
- Adjacent grouping suites (`build-rows`, `folder-workspace-lanes`, `imported-rows`) 49/49 unchanged; `pnpm run typecheck` clean.

Closes #15770