### PR TITLE
fix(browser): store an empty value in storage set commands

### DIFF
--- a/src/cli/browser-storage-empty-value.test.ts
+++ b/src/cli/browser-storage-empty-value.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const callMock = vi.fn()
+
+vi.mock('./runtime-client', () => {
+  class RuntimeClient {
+    call = callMock
+    getCliStatus = vi.fn()
+    openOrca = vi.fn()
+  }
+
+  class RuntimeClientError extends Error {
+    readonly code: string
+
+    constructor(code: string, message: string) {
+      super(message)
+      this.code = code
+    }
+  }
+
+  class RuntimeRpcFailureError extends RuntimeClientError {
+    readonly response: unknown
+
+    constructor(response: unknown) {
+      super('runtime_error', 'runtime_error')
+      this.response = response
+    }
+  }
+
+  return {
+    RuntimeClient,
+    RuntimeClientError,
+    RuntimeRpcFailureError
+  }
+})
+
+import { main } from './index'
+import { okFixture, queueFixtures } from './test-fixtures'
+
+// Why: the server's StorageKeyValue schema requires a non-empty key but accepts any
+// string value, empty included. setItem(key, '') is a real operation distinct from an
+// absent key, so `--value ""` must reach the RPC rather than being rejected as missing.
+describe('orca cli storage set preserves an empty value', () => {
+  beforeEach(() => {
+    callMock.mockReset()
+    process.exitCode = undefined
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('passes an empty --value through to browser.storage.local.set', async () => {
+    queueFixtures(callMock, okFixture('req_storage_local_set', { success: true }))
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(
+      ['storage', 'local', 'set', '--key', 'flag', '--value', '', '--worktree', 'all', '--json'],
+      '/tmp/not-an-orca-worktree'
+    )
+
+    expect(callMock).toHaveBeenCalledTimes(1)
+    expect(callMock).toHaveBeenCalledWith('browser.storage.local.set', {
+      key: 'flag',
+      value: '',
+      worktree: undefined
+    })
+  })
+
+  it('passes an empty --value through to browser.storage.session.set', async () => {
+    queueFixtures(callMock, okFixture('req_storage_session_set', { success: true }))
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(
+      ['storage', 'session', 'set', '--key', 'flag', '--value', '', '--worktree', 'all', '--json'],
+      '/tmp/not-an-orca-worktree'
+    )
+
+    expect(callMock).toHaveBeenCalledTimes(1)
+    expect(callMock).toHaveBeenCalledWith('browser.storage.session.set', {
+      key: 'flag',
+      value: '',
+      worktree: undefined
+    })
+  })
+
+  it('still rejects a missing --value before RPC dispatch', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const priorExitCode = process.exitCode
+
+    await main(
+      ['storage', 'local', 'set', '--key', 'flag', '--worktree', 'all'],
+      '/tmp/not-an-orca-worktree'
+    )
+
+    expect(callMock).not.toHaveBeenCalled()
+    expect(errorSpy.mock.calls.flat().join('\n')).toContain('Missing required --value')
+    expect(process.exitCode).toBe(1)
+
+    process.exitCode = priorExitCode
+  })
+})

--- a/src/cli/handlers/browser-storage.ts
+++ b/src/cli/handlers/browser-storage.ts
@@ -1,6 +1,6 @@
 import type { CommandHandler } from '../dispatch'
 import { printResult } from '../format'
-import { getRequiredStringFlag } from '../flags'
+import { getRequiredStringFlag, getRequiredStringFlagAllowingEmpty } from '../flags'
 import { getBrowserCommandTarget } from '../selectors'
 
 export const BROWSER_STORAGE_HANDLERS: Record<string, CommandHandler> = {
@@ -12,7 +12,9 @@ export const BROWSER_STORAGE_HANDLERS: Record<string, CommandHandler> = {
   },
   'storage local set': async ({ flags, client, cwd, json }) => {
     const key = getRequiredStringFlag(flags, 'key')
-    const value = getRequiredStringFlag(flags, 'value')
+    // Why: the server's StorageKeyValue schema accepts any string value (empty included),
+    // so `--value ""` must reach it — setItem(key, '') differs from leaving the key unset.
+    const value = getRequiredStringFlagAllowingEmpty(flags, 'value')
     const target = await getBrowserCommandTarget(flags, cwd, client)
     const result = await client.call<unknown>('browser.storage.local.set', {
       key,
@@ -34,7 +36,9 @@ export const BROWSER_STORAGE_HANDLERS: Record<string, CommandHandler> = {
   },
   'storage session set': async ({ flags, client, cwd, json }) => {
     const key = getRequiredStringFlag(flags, 'key')
-    const value = getRequiredStringFlag(flags, 'value')
+    // Why: mirrors the local-storage set — the server accepts an empty value, so `--value ""`
+    // must pass through instead of being rejected as missing.
+    const value = getRequiredStringFlagAllowingEmpty(flags, 'value')
     const target = await getBrowserCommandTarget(flags, cwd, client)
     const result = await client.call<unknown>('browser.storage.session.set', {
       key,


### PR DESCRIPTION
## ELI5
Saving an empty text value into the browser's storage from the command line was blocked, even though the app itself is happy to store an empty string. This lets `--value ""` go through.

## What Changed
`orca storage local set` and `orca storage session set` now read `--value` with `getRequiredStringFlagAllowingEmpty` instead of `getRequiredStringFlag`, so an empty string is accepted. `--key` is unchanged and still must be non-empty.

## Why
The runtime's `StorageKeyValue` schema (`src/main/runtime/rpc/methods/browser-schemas.ts`) deliberately validates `key` as a non-empty string but `value` as *any* string, so `setItem(key, "")` is a supported operation distinct from an absent key. The CLI used `getRequiredStringFlag`, which rejects `""`, so the empty-value case failed with `Missing required --value` before ever reaching the runtime — and there is no other CLI way to store an empty value (`storage clear` wipes everything). This matches the existing convention: computer-use `set-value` already uses `getRequiredStringFlagAllowingEmpty` for the same reason.

## Linked Issue
Fixes #15810

## Visual Proof
N/A — CLI-only behavior with no UI/interaction change.

## Testing
- [x] I manually tested these changes locally
- [x] Automated tests added/updated

Added `src/cli/browser-storage-empty-value.test.ts`: asserts `--value ""` reaches `browser.storage.local.set` / `browser.storage.session.set` with `value: ''`, and that a *missing* `--value` is still rejected before dispatch. Verified fail-without/pass-with by reverting only the source. Ran `oxfmt --check`, `oxlint`, and `typecheck:tsc:{node,cli,web}` (all clean), plus adjacent CLI suites (52 passing). Tested on macOS; change is platform-independent.

## AI Disclosure
Implemented with Claude Code (model `claude-opus-4-8`). The model located the bug, wrote the fix and the regression test, and ran the tests, formatter, linter, and typechecks reported above. I reviewed the change and take responsibility for it.

## Review
Focused two-line behavioral fix plus a regression test; `--key` semantics unchanged. No security/perf impact; pure CLI flag parsing.

## Agent skill upstream boundary
- [x] Not applicable — no skill-installer source touched.

## Checklist
- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or N/A with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (N/A — pure flag parsing)
- [x] lint, typecheck, test pass locally