### PR TITLE
fix(worktree): fast-forward a checked-out existing branch inside its new worktree

### DIFF
--- a/src/main/git/worktree-add-local-base-refresh.test.ts
+++ b/src/main/git/worktree-add-local-base-refresh.test.ts
@@ -42,6 +42,45 @@ describe('addWorktree', () => {
     translateWslOutputPathsMock.mockClear()
   })
 
+
+  it('fast-forwards a checked-out existing branch inside the new worktree (#15645)', async () => {
+    // The branch pre-exists locally, is behind origin, and the new worktree just
+    // checked it out — so the branch is OWNED by /repo-feature now.
+    const worktreeListOutput =
+      'worktree /repo\nHEAD aaa111\nbranch refs/heads/main\n\nworktree /repo-feature\nHEAD old-tip\nbranch refs/heads/feature\n'
+    gitExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: '' }) // worktree add /repo-feature feature
+      .mockResolvedValueOnce({ stdout: 'remote-tip\n' }) // resolveWorktreeAddBaseRef existence probe (OID required)
+      .mockResolvedValueOnce({ stdout: '0\t2\n' }) // rev-list --left-right --count (behind only)
+      .mockResolvedValueOnce({ stdout: 'old-tip\n' }) // rev-parse refs/heads/feature^{commit}
+      .mockResolvedValueOnce({ stdout: 'remote-tip\n' }) // rev-parse remote tracking ref^{commit}
+      .mockResolvedValueOnce({ stdout: '' }) // merge-base --is-ancestor
+      .mockResolvedValueOnce({ stdout: worktreeListOutput }) // worktree list --porcelain
+      .mockResolvedValueOnce({ stdout: '' }) // status --porcelain (in /repo-feature, clean)
+      .mockResolvedValueOnce({ stdout: worktreeListOutput }) // worktree list recheck
+      .mockResolvedValueOnce({ stdout: '' }) // status recheck (still clean)
+      .mockResolvedValueOnce({ stdout: '' }) // reset --hard remote-tip (in /repo-feature)
+
+    const result = await addWorktree(
+      '/repo',
+      '/repo-feature',
+      'feature',
+      'origin/feature',
+      true,
+      false,
+      { checkoutExistingBranch: true }
+    )
+
+    // eslint-disable-next-line no-console
+    console.log('CALLS', JSON.stringify(gitExecFileAsyncMock.mock.calls.map((c) => c[0])))
+    expect(result.localBaseRefRefresh).toMatchObject({ status: 'updated' })
+    const reset = gitExecFileAsyncMock.mock.calls.find(
+      (call) => call[0][0] === 'reset'
+    ) as unknown as [string[], { cwd?: string }]
+    expect(reset[0]).toEqual(['reset', '--hard', 'remote-tip'])
+    expect(reset[1].cwd).toBe('/repo-feature')
+  })
+
   it('fast-forwards with reset --hard when localBranch is checked out in primary worktree', async () => {
     const worktreeListOutput =
       'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /repo-other\nHEAD def456\nbranch refs/heads/feature\n'

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -1018,6 +1018,23 @@ async function performAddWorktree(
   })
 
   if (options.checkoutExistingBranch) {
+    // Why (#15645): the just-created worktree owns the branch now, so the
+    // refresh's owner path fast-forwards it in place (reset --hard inside the
+    // owning worktree is the one mutation git permits here). Skipping this
+    // left a pre-existing local branch checked out at its own stale commit —
+    // with no upstream, nothing ever signalled the staleness.
+    if (refreshLocalBaseRef && baseBranch) {
+      const effectiveExistingBase = await resolveWorktreeAddBaseRef(baseBranch, (qualifiedRef) =>
+        hasWorktreeBaseCommitRef(repoPath, qualifiedRef, options)
+      )
+      localBaseRefRefresh = await refreshLocalBaseRefForWorktreeCreate(
+        repoPath,
+        baseBranch,
+        effectiveExistingBase,
+        options.remoteTrackingBase,
+        options
+      )
+    }
     return localBaseRefRefresh ? { localBaseRefRefresh } : {}
   }
 


### PR DESCRIPTION
## Summary

**What**

`addWorktree`'s checkout-existing-branch path now runs the local-base refresh **after** the worktree add, reusing the existing `refreshLocalBaseRefForWorktreeCreate` machinery unchanged.

**Why**

#15645 — creating a workspace from `origin/<b>` when local `<b>` already exists takes the `checkoutExistingBranch` path (`git worktree add <path> <branch>`), which checks the branch out **at its own commit**. The refresh that would correct a stale local branch only ran in the `-b` create path — in the existing-branch path it was never called at all. The result: a pre-existing branch behind origin lands the workspace on old code, silently — no upstream is set either (`--no-track` philosophy), so `git status` shows no ahead/behind line and nothing signals the staleness. The reporter verified the shape with plain git: `git worktree add wt feat/x` on a 1-behind local branch → stale HEAD, and `git fetch origin feat/x:feat/x` is refused precisely because the new worktree owns the branch.

**Why after the add, and why this is safe**: at that moment the new worktree *owns* the branch, so the refresh's owner-worktree branch is the one that runs — it re-lists worktrees, verifies the owner is still the fresh checkout, requires a **clean** `status --porcelain`, and fast-forwards with `reset --hard` inside that worktree. That is exactly the one mutation git permits for a checked-out branch. A brand-new worktree is clean by construction, so the reset only moves the just-checked-out stale commit to the remote tip. Diverged locals (ahead≠0) and any dirty state fall through to the existing `skipped_not_fast_forward` / `skipped_dirty_worktree` statuses, which the create-time toast already explains to the user.

**Scope**: this fixes the stale-checkout half. Setting a real upstream (`branch.<b>.remote/.merge`) is a separate design question — the `-b` path deliberately uses `--no-track` + `push.autoSetupRemote`, and extending that policy is not sneaked in here.

**Testing** (`worktree-add-local-base-refresh.test.ts`, 11/11):

- New: `fast-forwards a checked-out existing branch inside the new worktree (#15645)` — existing branch 2 behind, worktree list shows the new worktree as owner, clean status; asserts the result is `status: 'updated'` and that the `reset --hard <remote-tip>` ran **with cwd = the new worktree**. **Verified to fail on the pre-change code** (no refresh ran at all).
- All 10 existing refresh/safety tests unchanged; `worktree-add-creation-config` + `add-sparse-worktree` suites 18/18; `pnpm run typecheck` clean.

Fixes #15645