### PR TITLE
fix(rate-limits): support Codex 0.149 approval policy

### DIFF
--- a/src/main/codex-accounts/wsl-codex-command.test.ts
+++ b/src/main/codex-accounts/wsl-codex-command.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildWslCodexAvailabilityArgs,
+  buildWslCodexAppServerArgs,
   buildWslCodexIdentityProbe,
   buildWslCodexLoginArgs
 } from './wsl-codex-command'
+import { CODEX_READ_ONLY_APP_SERVER_ARGS } from '../codex-cli/codex-read-only-app-server-args'
 
 describe('WSL Codex commands', () => {
   it('checks the alias-neutral PATH from the distro login shell', () => {
@@ -23,6 +25,21 @@ describe('WSL Codex commands', () => {
     expect(command).toContain('export CODEX_HOME=')
     expect(command).toContain('/home/alice/managed-home')
     expect(command).toContain('exec "$resolved" login')
+  })
+
+  it('quotes an explicit read-only app-server contract without changing the default', () => {
+    const readOnlyCommand = buildWslCodexAppServerArgs(
+      'Ubuntu',
+      '/home/alice/managed-home',
+      CODEX_READ_ONLY_APP_SERVER_ARGS
+    ).at(-1)
+    const defaultCommand = buildWslCodexAppServerArgs('Ubuntu', '/home/alice/managed-home').at(-1)
+
+    for (const arg of CODEX_READ_ONLY_APP_SERVER_ARGS) {
+      expect(readOnlyCommand).toContain(arg)
+    }
+    expect(defaultCommand).toContain('app-server')
+    expect(defaultCommand).not.toContain('approval_policy=never')
   })
 
   it('reports the login-shell binary path and version for identity checks', () => {

--- a/src/main/codex-accounts/wsl-codex-command.ts
+++ b/src/main/codex-accounts/wsl-codex-command.ts
@@ -46,7 +46,11 @@ export function buildWslCodexIdentityProbe(distro: string): WslCodexIdentityProb
   }
 }
 
-export function buildWslCodexAppServerArgs(distro: string, linuxHomePath: string): string[] {
+export function buildWslCodexAppServerArgs(
+  distro: string,
+  linuxHomePath: string,
+  appServerArgs: readonly string[] = ['app-server']
+): string[] {
   const command = [
     buildCodexPathLookup(),
     'if [ -z "$resolved" ]; then',
@@ -54,7 +58,7 @@ export function buildWslCodexAppServerArgs(distro: string, linuxHomePath: string
     '  exit 127',
     'fi',
     `export CODEX_HOME=${quotePosixShell(linuxHomePath)}`,
-    'exec "$resolved" app-server'
+    `exec "$resolved" ${appServerArgs.map(quotePosixShell).join(' ')}`
   ].join('\n')
   return buildWslCodexShellArgs(distro, command)
 }

--- a/src/main/codex-cli/codex-read-only-app-server-args.ts
+++ b/src/main/codex-cli/codex-read-only-app-server-args.ts
@@ -1,0 +1,10 @@
+// The config override replaces legacy values before Codex validates config.toml.
+export const CODEX_READ_ONLY_APP_SERVER_ARGS = [
+  '-c',
+  'approval_policy=never',
+  '-s',
+  'read-only',
+  '-a',
+  'never',
+  'app-server'
+] as const

--- a/src/main/codex/codex-state-db-backfill-recovery.test.ts
+++ b/src/main/codex/codex-state-db-backfill-recovery.test.ts
@@ -4,6 +4,8 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import * as ownerIdentity from '../agent-hooks/managed-hook-owner-identity'
+import { CODEX_READ_ONLY_APP_SERVER_ARGS } from '../codex-cli/codex-read-only-app-server-args'
+import { getCmdExePath } from '../win32-utils'
 import {
   _internals,
   resolveCodexBackfillSupervisorLockRoot,
@@ -12,7 +14,6 @@ import {
   withCodexBackfillSupervisorLock
 } from './codex-state-db-backfill-recovery'
 import type { CodexStateDbBackfillStatus } from './codex-state-db'
-import { getCmdExePath } from '../win32-utils'
 
 const temporaryRoots: string[] = []
 const originalPlatform = process.platform
@@ -477,6 +478,9 @@ describe('Codex state DB backfill recovery', () => {
     const command = spawnCall[1].join(' ')
     expect(command).toContain('export CODEX_HOME=')
     expect(command).toContain('/home/alice/.codex')
+    for (const arg of CODEX_READ_ONLY_APP_SERVER_ARGS) {
+      expect(command).toContain(arg)
+    }
   })
 })
 

--- a/src/main/codex/codex-state-db-backfill-recovery.test.ts
+++ b/src/main/codex/codex-state-db-backfill-recovery.test.ts
@@ -12,6 +12,7 @@ import {
   withCodexBackfillSupervisorLock
 } from './codex-state-db-backfill-recovery'
 import type { CodexStateDbBackfillStatus } from './codex-state-db'
+import { getCmdExePath } from '../win32-utils'
 
 const temporaryRoots: string[] = []
 const originalPlatform = process.platform
@@ -365,6 +366,51 @@ describe('Codex state DB backfill recovery', () => {
       })
     ).resolves.toEqual({ outcome: 'completed', spawnCount: 1 })
     expect(terminate).toHaveBeenCalledWith(child)
+  })
+
+  it('uses batch-safe read-only arguments for native Windows recovery', async () => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    const child = createFakeChild()
+    const spawnProcess = vi.fn(() => child)
+    const codexCommand = 'C:\\Users\\alice\\AppData\\Roaming\\npm\\codex.cmd'
+    const readStatus = vi
+      .fn()
+      .mockReturnValueOnce({ kind: 'incomplete', stateDbPath: 'state.sqlite', status: 'running' })
+      .mockReturnValue({ kind: 'complete', stateDbPath: 'state.sqlite' })
+
+    await runCodexStateDbBackfillRecovery(
+      'C:\\Users\\alice\\.codex',
+      new AbortController().signal,
+      {
+        spawnProcess: spawnProcess as never,
+        resolveCommand: () => codexCommand,
+        readStatus,
+        terminate: vi.fn(async () => {}),
+        sleep: vi.fn(async () => {}),
+        now: vi.fn(() => 1_000)
+      }
+    )
+
+    const [spawnFile, spawnArgs, spawnOptions] = spawnProcess.mock.calls[0] as unknown as [
+      string,
+      string[],
+      { cwd?: string; env?: NodeJS.ProcessEnv }
+    ]
+    expect(spawnFile).toBe(getCmdExePath())
+    expect(spawnArgs).toEqual([
+      '/d',
+      '/c',
+      codexCommand,
+      '-c',
+      'approval_policy=never',
+      '-s',
+      'read-only',
+      '-a',
+      'never',
+      'app-server'
+    ])
+    expect(spawnOptions.cwd).toBe('C:\\Users\\alice\\.codex')
+    expect(spawnOptions.env?.CODEX_HOME).toBe('C:\\Users\\alice\\.codex')
   })
 
   it('retries a live foreign lease until one durable claimant can recover it', async () => {

--- a/src/main/codex/codex-state-db-backfill-recovery.ts
+++ b/src/main/codex/codex-state-db-backfill-recovery.ts
@@ -90,7 +90,11 @@ function spawnRecoveryProcess(
   if (wslHome) {
     return dependencies.spawnProcess(
       'wsl.exe',
-      buildWslCodexAppServerArgs(wslHome.distro, wslHome.linuxPath),
+      buildWslCodexAppServerArgs(
+        wslHome.distro,
+        wslHome.linuxPath,
+        CODEX_READ_ONLY_APP_SERVER_ARGS
+      ),
       {
         stdio: ['pipe', 'ignore', 'ignore'],
         windowsHide: true,

--- a/src/main/codex/codex-state-db-backfill-recovery.ts
+++ b/src/main/codex/codex-state-db-backfill-recovery.ts
@@ -8,6 +8,7 @@ import { withManagedHookInstallLock } from '../agent-hooks/managed-hook-install-
 import { readManagedHookHostIdentity } from '../agent-hooks/managed-hook-owner-identity'
 import { buildWslCodexAppServerArgs } from '../codex-accounts/wsl-codex-command'
 import { resolveCodexCommand } from '../codex-cli/command'
+import { CODEX_READ_ONLY_APP_SERVER_ARGS } from '../codex-cli/codex-read-only-app-server-args'
 import { terminateCodexProbeChild } from '../rate-limits/codex-probe-termination'
 import { getSpawnArgsForWindows } from '../win32-utils'
 import { getOrcaUserDataPath } from './codex-home-paths'
@@ -25,7 +26,6 @@ const RECOVERY_MAX_COORDINATOR_FAILURES = 5
 const RECOVERY_MAX_SPAWNS = 5
 const RECOVERY_MAX_TOTAL_MS = 60 * 60_000
 const RECOVERY_OWNER_CHECK_TIMEOUT_MS = 1_000
-const RECOVERY_CODEX_ARGS = ['-s', 'read-only', '-a', 'untrusted', 'app-server'] as const
 
 export type CodexStateDbBackfillRecoverySummary = {
   outcome: 'completed' | 'already-complete' | 'not-needed' | 'unreadable' | 'stopped' | 'gave-up'
@@ -99,7 +99,9 @@ function spawnRecoveryProcess(
     )
   }
   const command = dependencies.resolveCommand()
-  const { spawnCmd, spawnArgs } = getSpawnArgsForWindows(command, [...RECOVERY_CODEX_ARGS])
+  const { spawnCmd, spawnArgs } = getSpawnArgsForWindows(command, [
+    ...CODEX_READ_ONLY_APP_SERVER_ARGS
+  ])
   return dependencies.spawnProcess(spawnCmd, spawnArgs, {
     cwd: codexHomePath,
     stdio: ['pipe', 'ignore', 'ignore'],

--- a/src/main/rate-limits/codex-fetcher-process-contract.test.ts
+++ b/src/main/rate-limits/codex-fetcher-process-contract.test.ts
@@ -1,0 +1,137 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as Win32Utils from '../win32-utils'
+
+const { getSpawnArgsForWindowsMock, ptySpawnMock, resolveCodexCommandMock } = vi.hoisted(() => ({
+  getSpawnArgsForWindowsMock: vi.fn(),
+  ptySpawnMock: vi.fn(),
+  resolveCodexCommandMock: vi.fn()
+}))
+
+vi.mock('../win32-utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof Win32Utils>()),
+  getSpawnArgsForWindows: getSpawnArgsForWindowsMock
+}))
+
+vi.mock('../codex-cli/command', () => ({
+  resolveCodexCommand: resolveCodexCommandMock
+}))
+
+vi.mock('node-pty', () => ({
+  spawn: ptySpawnMock
+}))
+
+vi.mock('./codex-auth-presence', () => ({
+  probeCodexAuthPresence: vi.fn(() => 'present')
+}))
+
+vi.mock('../codex/codex-state-db', () => ({
+  isCodexStateDbBackfillPending: vi.fn(() => false)
+}))
+
+vi.mock('../codex/codex-state-db-backfill-recovery', () => ({
+  startCodexStateDbBackfillRecoveryInBackground: vi.fn(() => Promise.resolve(null))
+}))
+
+import { fetchCodexRateLimits } from './codex-fetcher'
+
+const STUB_CODEX_SOURCE = `
+const expectedArgs = [
+  '-c',
+  'approval_policy=never',
+  '-s',
+  'read-only',
+  '-a',
+  'never',
+  'app-server'
+]
+if (JSON.stringify(process.argv.slice(2)) !== JSON.stringify(expectedArgs)) {
+  process.stderr.write(
+    "error: invalid value 'untrusted' for '--ask-for-approval <APPROVAL_POLICY>'\\n" +
+      '  [possible values: on-request, never]\\n'
+  )
+  process.exit(2)
+}
+if (process.env.CODEX_HOME !== process.env.ORCA_EXPECTED_CODEX_HOME) {
+  process.stderr.write('managed CODEX_HOME was not preserved\\n')
+  process.exit(3)
+}
+let buffer = ''
+function send(message) {
+  process.stdout.write(JSON.stringify(message) + '\\n')
+}
+process.stdin.setEncoding('utf8')
+process.stdin.on('data', (chunk) => {
+  buffer += chunk
+  let newlineIndex
+  while ((newlineIndex = buffer.indexOf('\\n')) !== -1) {
+    const line = buffer.slice(0, newlineIndex).trim()
+    buffer = buffer.slice(newlineIndex + 1)
+    if (!line) continue
+    const message = JSON.parse(line)
+    if (message.method === 'initialize') {
+      send({ id: message.id, result: { userAgent: 'codex-contract/0.149.0' } })
+      continue
+    }
+    if (message.method === 'account/rateLimits/read') {
+      send({
+        id: message.id,
+        result: {
+          rateLimits: {
+            primary: { usedPercent: 17, windowDurationMins: 300 },
+            secondary: { usedPercent: 29, windowDurationMins: 10080 }
+          }
+        }
+      })
+    }
+  }
+})
+process.stdin.on('end', () => process.exit(0))
+`
+
+let tempRoot: string
+let stubPath: string
+let previousExpectedHome: string | undefined
+
+describe('Codex rate-limit process contract', () => {
+  beforeEach(() => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'orca-codex-rate-limit-contract-'))
+    stubPath = join(tempRoot, 'codex-contract.cjs')
+    writeFileSync(stubPath, STUB_CODEX_SOURCE)
+    previousExpectedHome = process.env.ORCA_EXPECTED_CODEX_HOME
+    process.env.ORCA_EXPECTED_CODEX_HOME = join(tempRoot, 'managed-codex-home')
+    resolveCodexCommandMock.mockReturnValue('codex')
+    getSpawnArgsForWindowsMock.mockImplementation((_command: string, args: string[]) => ({
+      spawnCmd: process.execPath,
+      spawnArgs: [stubPath, ...args]
+    }))
+  })
+
+  afterEach(() => {
+    if (previousExpectedHome === undefined) {
+      delete process.env.ORCA_EXPECTED_CODEX_HOME
+    } else {
+      process.env.ORCA_EXPECTED_CODEX_HOME = previousExpectedHome
+    }
+    rmSync(tempRoot, { recursive: true, force: true })
+    vi.clearAllMocks()
+  })
+
+  it('starts a read-only non-interactive app-server with the managed home', async () => {
+    await expect(
+      fetchCodexRateLimits({
+        codexHomePath: process.env.ORCA_EXPECTED_CODEX_HOME,
+        allowPtyFallback: false
+      })
+    ).resolves.toMatchObject({
+      provider: 'codex',
+      session: { usedPercent: 17, windowMinutes: 300 },
+      weekly: { usedPercent: 29, windowMinutes: 10080 },
+      status: 'ok',
+      error: null
+    })
+    expect(ptySpawnMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/rate-limits/codex-fetcher.test.ts
+++ b/src/main/rate-limits/codex-fetcher.test.ts
@@ -51,6 +51,8 @@ vi.mock('./codex-auth-presence', () => ({
 import { fetchCodexRateLimits } from './codex-fetcher'
 import { probeCodexAuthPresence } from './codex-auth-presence'
 import { getActiveHiddenRateLimitPtyCount } from './hidden-pty-cleanup'
+import { getCmdExePath } from '../win32-utils'
+import { CODEX_READ_ONLY_APP_SERVER_ARGS } from '../codex-cli/codex-read-only-app-server-args'
 
 function makeDisposable() {
   return { dispose: vi.fn() }
@@ -722,7 +724,7 @@ describe('fetchCodexRateLimits', () => {
         "export CODEX_HOME='\\''/home/alice/.local/share/orca/account/home'\\''"
       )
       expect(shellCommand).toContain(
-        "exec codex '\\''-s'\\'' '\\''read-only'\\'' '\\''-a'\\'' '\\''untrusted'\\'' '\\''app-server'\\'' <&3 >&4 3<&- 4>&-"
+        "exec codex '\\''-c'\\'' '\\''approval_policy=never'\\'' '\\''-s'\\'' '\\''read-only'\\'' '\\''-a'\\'' '\\''never'\\'' '\\''app-server'\\'' <&3 >&4 3<&- 4>&-"
       )
       expect(shellCommand.match(/<&3 >&4 3<&- 4>&-/g)).toHaveLength(3)
       expect(shellCommand.match(/exec codex [^\n]+<&3 >&4 3<&- 4>&-/g)).toHaveLength(3)
@@ -748,6 +750,8 @@ describe('fetchCodexRateLimits', () => {
       configurable: true,
       value: 'win32'
     })
+    const codexCommand = 'C:\\Users\\alice\\AppData\\Roaming\\npm\\codex.cmd'
+    resolveCodexCommandMock.mockReturnValue(codexCommand)
     const rpcChild = makeRpcChild()
     childSpawnMock.mockReturnValue(rpcChild)
     rpcChild.stdin.write.mockImplementation((line: string) => {
@@ -783,8 +787,8 @@ describe('fetchCodexRateLimits', () => {
       await resultPromise
 
       const [spawnFile, spawnArgs, spawnOptions] = childSpawnMock.mock.calls[0]
-      expect(spawnFile).toBe('codex')
-      expect(spawnArgs).toEqual(['-s', 'read-only', '-a', 'untrusted', 'app-server'])
+      expect(spawnFile).toBe(getCmdExePath())
+      expect(spawnArgs).toEqual(['/d', '/c', codexCommand, ...CODEX_READ_ONLY_APP_SERVER_ARGS])
       expect(spawnOptions).toEqual(
         expect.objectContaining({
           env: expect.objectContaining({ CODEX_HOME: 'C:\\Users\\alice\\.codex' })

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -19,6 +19,7 @@ import {
   type CodexRateWindowSnapshot
 } from './codex-rate-limit-window-classification'
 import { resolveCodexCommand } from '../codex-cli/command'
+import { CODEX_READ_ONLY_APP_SERVER_ARGS } from '../codex-cli/codex-read-only-app-server-args'
 import { withMacTailscaleDnsHint } from '../network/macos-tailscale-dns-diagnostic'
 import { getCmdExePath, getSpawnArgsForWindows } from '../win32-utils'
 import { cleanupHiddenRateLimitPty, registerHiddenRateLimitPty } from './hidden-pty-cleanup'
@@ -611,7 +612,7 @@ async function withBackendSessionWindow(
 }
 
 // ---------------------------------------------------------------------------
-// RPC fetch — spawn `codex -s read-only -a untrusted app-server`
+// RPC fetch — spawn a read-only, non-interactive `codex app-server`
 // ---------------------------------------------------------------------------
 
 async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<ProviderRateLimits> {
@@ -624,7 +625,7 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
     let resolved = false
     let rpcId = 0
 
-    const codexArgs = ['-s', 'read-only', '-a', 'untrusted', 'app-server']
+    const codexArgs = [...CODEX_READ_ONLY_APP_SERVER_ARGS]
     const wslCodex = options?.codexHomePath
       ? buildWslCodexCommand(options.codexHomePath, codexArgs, { isolateRpcStdio: true })
       : null


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​211 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​208 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​28 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​21 |

<!-- /orca-pr-loc -->

## Summary

- replace the removed Codex `untrusted` approval policy with an explicit read-only, non-interactive `never` contract
- override stale `approval_policy = "untrusted"` config before Codex validates `config.toml`
- share the same argv with native and WSL state-DB backfill recovery and keep it safe for Windows `.cmd` shims
- add a real-child JSON-RPC process/argv contract plus native Windows batch coverage

Fixes #15737.

## Root cause

Orca launched `codex -s read-only -a untrusted app-server`. Codex 0.149.0 removed `untrusted`, so argument parsing exits with code 2 before authentication or network activity. Re-login and network troubleshooting cannot affect that failure.

The final argv is:

`codex -c approval_policy=never -s read-only -a never app-server`

The config override is required because `-a never` alone cannot rescue a managed home whose existing `config.toml` still contains the removed value. The override is quote-free so Orca can safely route npm `codex.cmd` shims through `cmd.exe`.

## Scope and #15772

This is a focused replacement for the Codex compatibility portion of #15772. That PR targets the separate unlimited Business-plan issue #15764 and changes only `-a never`; it does not handle stale config and bundles unrelated UI/product work. This PR contains no unlimited-plan UI scope.

## Evidence

- Exact Codex 0.149.0 baseline: exit 2 with possible values `on-request` and `never`
- Network-denied, empty-home reproduction exits identically before auth/network
- Version matrix: 0.134.0 and 0.148.0 accept the old value; 0.149.0 and 0.150.0-alpha.5 reject it
- Final quote-free argv initializes on 0.134.0, 0.148.0, 0.149.0, and 0.150.0-alpha.5 with a poisoned `config.toml` containing `approval_policy = "untrusted"`
- Identical focused oracle: candidate 36/36; shared fix disabled 4 failures / 32 passes. Original main oracle was 3 failures / 20 passes
- Windows 2 real WSL with isolated Codex 0.149.0 and stale `approval_policy = "untrusted"`: bare `app-server` exited 1 before auth/network; the shared read-only argv initialized successfully with exit 0
- Electron with an isolated Orca profile and authenticated Codex 0.149.0: visible status-bar refresh rendered real Codex usage; backing state was `status: ok`; sampled process argv matched the final contract
- Controlled child exit 17: visible `Refresh failed`; backing error `CLI exited before status was available`, not auth/network
- Two OpenCode rounds found and drove the Windows and WSL recovery refinements; three fresh final reviewers independently returned `VERDICT: CLEAN`

## Tests

- focused Codex oracle: 36 passed
- all rate-limit tests: 423 passed
- backfill recovery plus WSL argv contract: 17 passed
- focused rate-limit, backfill, and WSL suites: 440 passed
- oxlint
- oxfmt
- Node typecheck
- Electron CDP visible + backing-state validation

