### PR TITLE
fix(ssh): let fork-PR worktrees add their contributor remote via the relay

### DIFF
--- a/src/main/ipc/worktree-push-target-cleanup.test.ts
+++ b/src/main/ipc/worktree-push-target-cleanup.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, type Mock } from 'vitest'
+import { validateGitExecArgs } from '../../relay/git-exec-validator'
 import type { WorktreeMeta } from '../../shared/worktree/meta-types'
 import type { GitPushTarget } from '../../shared/worktree/types'
 import {
@@ -79,6 +80,20 @@ describe('cleanupUnusedWorktreePushTargetRemoteWithExec', () => {
       exec
     )
     expect(removeCalls(exec)).toEqual([['remote', 'remove', FORK_REMOTE]])
+  })
+
+  it('sends only argv the relay accepts, so SSH cleanup is not silently skipped', async () => {
+    const exec = makeExec()
+    await cleanupUnusedWorktreePushTargetRemoteWithExec(
+      REPO_PATH,
+      'repo-1::/wt/a',
+      forkTarget(),
+      storeOf({ 'repo-1::/wt/a': forkTarget() }),
+      exec
+    )
+    for (const [args] of exec.mock.calls) {
+      expect(() => validateGitExecArgs(args)).not.toThrow()
+    }
   })
 
   it('keeps a remote Orca did not create (remoteCreated falsy)', async () => {

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -1099,7 +1099,17 @@ async function prepareWorktreePushTargetSsh(
         : false
     } else {
       remoteName = await ensureUniqueRemoteName(execGit, repoPath, target.remoteName)
-      await provider.exec(['remote', 'add', remoteName, target.remoteUrl], repoPath)
+      try {
+        await provider.exec(['remote', 'add', remoteName, target.remoteUrl], repoPath)
+      } catch (error) {
+        // Why: relays predating fork-remote support reject this exec by policy; name the fix instead of surfacing their rule.
+        if (error instanceof Error && error.message.includes('Destructive git remote operations')) {
+          throw new Error(
+            'This SSH host is running an older Orca relay that cannot add a fork remote for a PR workspace. Reconnect to deploy the latest relay, then try again.'
+          )
+        }
+        throw error
+      }
       remoteCreated = true
     }
   }

--- a/src/main/ipc/worktrees-ssh-fork-push-target-remote.test.ts
+++ b/src/main/ipc/worktrees-ssh-fork-push-target-remote.test.ts
@@ -1,0 +1,214 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { validateGitExecArgs } from '../../relay/git-exec-validator'
+import { getSshGitProviderMock, getActiveMultiplexerMock } from './worktrees-test-module-mocks'
+import { handlers, setupWorktreeHandlers, store } from './worktrees-test-harness'
+
+vi.mock('electron', async () =>
+  (await import('./worktrees-test-module-mocks')).electronModuleMock()
+)
+vi.mock('../git/worktree', async () =>
+  (await import('./worktrees-test-module-mocks')).gitWorktreeModuleMock()
+)
+vi.mock('../git/runner', async () =>
+  (await import('./worktrees-test-module-mocks')).gitRunnerModuleMock()
+)
+vi.mock('../git/repo', async () =>
+  (await import('./worktrees-test-module-mocks')).gitRepoModuleMock()
+)
+vi.mock('../git/git-username', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  resolveLocalGitUsername: (await import('./worktrees-test-module-mocks'))
+    .resolveLocalGitUsernameMock
+}))
+vi.mock('../github/client', async () =>
+  (await import('./worktrees-test-module-mocks')).githubClientModuleMock()
+)
+vi.mock('../source-control/hosted-review', async () =>
+  (await import('./worktrees-test-module-mocks')).hostedReviewModuleMock()
+)
+vi.mock('../providers/ssh-git-dispatch', async () =>
+  (await import('./worktrees-test-module-mocks')).sshGitDispatchModuleMock()
+)
+vi.mock('../providers/ssh-filesystem-dispatch', async () =>
+  (await import('./worktrees-test-module-mocks')).sshFilesystemDispatchModuleMock()
+)
+vi.mock('./worktree-symlinks', async () =>
+  (await import('./worktrees-test-module-mocks')).worktreeSymlinksModuleMock()
+)
+vi.mock('./ssh', async () => (await import('./worktrees-test-module-mocks')).sshModuleMock())
+vi.mock('../hooks', async () => (await import('./worktrees-test-module-mocks')).hooksModuleMock())
+vi.mock('../setup-runner-script-text', async (importOriginal) =>
+  (await import('./worktrees-test-module-mocks')).setupRunnerScriptTextModuleMock(
+    (await importOriginal()) as Record<string, unknown>
+  )
+)
+vi.mock('../worktree-runner-script', async (importOriginal) =>
+  (await import('./worktrees-test-module-mocks')).worktreeRunnerScriptModuleMock(
+    (await importOriginal()) as Record<string, unknown>
+  )
+)
+vi.mock('../effective-hook-config', async (importOriginal) =>
+  (await import('./worktrees-test-module-mocks')).effectiveHookConfigModuleMock(
+    (await importOriginal()) as Record<string, unknown>
+  )
+)
+vi.mock('../setup-hook-env-vars', async (importOriginal) =>
+  (await import('./worktrees-test-module-mocks')).setupHookEnvVarsModuleMock(
+    (await importOriginal()) as Record<string, unknown>
+  )
+)
+vi.mock('./worktree-logic', async (importOriginal) =>
+  (await import('./worktrees-test-module-mocks')).worktreeLogicModuleMock(
+    (await importOriginal()) as Record<string, unknown>
+  )
+)
+vi.mock('../terminal-history-deletion', async () =>
+  (await import('./worktrees-test-module-mocks')).terminalHistoryDeletionModuleMock()
+)
+vi.mock('../ports/advertised-url-watcher', async () =>
+  (await import('./worktrees-test-module-mocks')).advertisedUrlWatcherModuleMock()
+)
+vi.mock('../workspace-cleanup-scan-snapshot', async () =>
+  (await import('./worktrees-test-module-mocks')).workspaceCleanupScanSnapshotModuleMock()
+)
+vi.mock('../workspace-space-analysis-snapshot', async () =>
+  (await import('./worktrees-test-module-mocks')).workspaceSpaceAnalysisSnapshotModuleMock()
+)
+vi.mock('../workspace-cleanup-removal-snapshot-prune', async () =>
+  (await import('./worktrees-test-module-mocks')).workspaceCleanupRemovalSnapshotPruneModuleMock()
+)
+vi.mock('../runtime/worktree-teardown', async () =>
+  (await import('./worktrees-test-module-mocks')).worktreeTeardownModuleMock()
+)
+vi.mock('./pty', async () => (await import('./worktrees-test-module-mocks')).ptyModuleMock())
+
+describe('registerWorktreeHandlers', () => {
+  beforeEach(() => {
+    setupWorktreeHandlers()
+  })
+
+  it('adds the fork remote for an SSH fork-PR worktree through git.exec', async () => {
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/repo',
+      displayName: 'ssh',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1',
+      worktreeBaseRef: 'origin/main'
+    }
+    // Why: run every exec through the relay's own validator so a create shape the
+    // relay rejects fails here instead of on the user's SSH host.
+    const exec = vi.fn().mockImplementation(async (args: string[]) => {
+      validateGitExecArgs(args)
+      if (args[0] === 'remote' && args[1] === 'get-url') {
+        return { stdout: 'git@github.com:stablyai/orca.git\n', stderr: '' }
+      }
+      if (args[0] === 'remote' && args.length === 1) {
+        return { stdout: 'origin\n', stderr: '' }
+      }
+      return { stdout: '', stderr: '' }
+    })
+    const provider = {
+      exec,
+      fetchRemoteTrackingRef: vi.fn().mockResolvedValue(undefined),
+      addWorktree: vi.fn().mockResolvedValue(undefined),
+      listWorktrees: vi.fn().mockResolvedValue([
+        {
+          path: '/remote/repo-contributor-fix',
+          head: 'abc123',
+          branch: 'refs/heads/contributor/fix',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ])
+    }
+    const mux = { request: vi.fn().mockResolvedValue(undefined), notify: vi.fn() }
+    store.getRepos.mockReturnValue([repo])
+    store.getRepo.mockReturnValue(repo)
+    getSshGitProviderMock.mockReturnValue(provider)
+    getActiveMultiplexerMock.mockReturnValue(mux)
+    store.setWorktreeMeta.mockImplementation((_worktreeId, meta) => meta)
+
+    await handlers['worktrees:create'](null, {
+      repoId: 'repo-ssh',
+      name: 'contributor-fix',
+      branchNameOverride: 'contributor/fix',
+      pushTarget: {
+        remoteName: 'pr-contributor-orca',
+        branchName: 'contributor/fix',
+        remoteUrl: 'https://github.com/contributor/orca.git'
+      }
+    })
+
+    expect(exec).toHaveBeenCalledWith(
+      ['remote', 'add', 'pr-contributor-orca', 'https://github.com/contributor/orca.git'],
+      '/remote/repo'
+    )
+    expect(provider.fetchRemoteTrackingRef).toHaveBeenCalledWith(
+      '/remote/repo',
+      'pr-contributor-orca',
+      'contributor/fix',
+      'refs/remotes/pr-contributor-orca/contributor/fix'
+    )
+    expect(store.setWorktreeMeta).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        pushTarget: {
+          remoteName: 'pr-contributor-orca',
+          branchName: 'contributor/fix',
+          remoteUrl: 'https://github.com/contributor/orca.git',
+          remoteCreated: true
+        }
+      })
+    )
+  })
+
+  it('names the relay upgrade when an older host still rejects the fork remote', async () => {
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/repo',
+      displayName: 'ssh',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1',
+      worktreeBaseRef: 'origin/main'
+    }
+    const provider = {
+      exec: vi.fn().mockImplementation(async (args: string[]) => {
+        if (args[0] === 'remote' && args[1] === 'add') {
+          throw new Error('Destructive git remote operations are not allowed via exec')
+        }
+        if (args[0] === 'remote' && args[1] === 'get-url') {
+          return { stdout: 'git@github.com:stablyai/orca.git\n', stderr: '' }
+        }
+        if (args[0] === 'remote' && args.length === 1) {
+          return { stdout: 'origin\n', stderr: '' }
+        }
+        return { stdout: '', stderr: '' }
+      }),
+      fetchRemoteTrackingRef: vi.fn().mockResolvedValue(undefined),
+      addWorktree: vi.fn().mockResolvedValue(undefined),
+      listWorktrees: vi.fn().mockResolvedValue([])
+    }
+    const mux = { request: vi.fn().mockResolvedValue(undefined), notify: vi.fn() }
+    store.getRepos.mockReturnValue([repo])
+    store.getRepo.mockReturnValue(repo)
+    getSshGitProviderMock.mockReturnValue(provider)
+    getActiveMultiplexerMock.mockReturnValue(mux)
+
+    await expect(
+      handlers['worktrees:create'](null, {
+        repoId: 'repo-ssh',
+        name: 'contributor-fix',
+        branchNameOverride: 'contributor/fix',
+        pushTarget: {
+          remoteName: 'pr-contributor-orca',
+          branchName: 'contributor/fix',
+          remoteUrl: 'https://github.com/contributor/orca.git'
+        }
+      })
+    ).rejects.toThrow('Reconnect to deploy the latest relay')
+    expect(provider.addWorktree).not.toHaveBeenCalled()
+  })
+})

--- a/src/relay/git-exec-validator.test.ts
+++ b/src/relay/git-exec-validator.test.ts
@@ -150,22 +150,43 @@ describe('validateGitExecArgs', () => {
   })
 
   describe('git remote', () => {
-    it.each([
-      'add',
-      'remove',
-      'rm',
-      'rename',
-      'set-url',
-      'set-head',
-      'set-branches',
-      'prune',
-      'update'
-    ])('rejects remote %s', (subcmd) => {
-      expectBlocked(['remote', subcmd, 'arg'], 'Destructive git remote operations')
-    })
+    it.each(['rm', 'rename', 'set-url', 'set-head', 'set-branches', 'prune', 'update'])(
+      'rejects remote %s',
+      (subcmd) => {
+        expectBlocked(['remote', subcmd, 'arg'], 'Destructive git remote operations')
+      }
+    )
 
     it('skips flags when finding remote subcommand', () => {
       expectBlocked(['remote', '-v', 'add', 'evil', 'url'], 'Destructive git remote operations')
+    })
+
+    it('allows the fork-PR remote add and remove shapes', () => {
+      expectAllowed([
+        'remote',
+        'add',
+        'pr-contributor-orca',
+        'https://github.com/contributor/orca.git'
+      ])
+      expectAllowed(['remote', 'add', 'pr-contributor-orca', 'git@github.com:contributor/orca.git'])
+      expectAllowed(['remote', 'remove', 'pr-contributor-orca'])
+    })
+
+    it.each([
+      // Extra or missing operands are not a shape main ever sends.
+      [['remote', 'add', 'fork']],
+      [['remote', 'add', 'fork', 'https://github.com/contributor/orca.git', '--tags']],
+      [['remote', 'remove']],
+      [['remote', 'remove', 'fork', 'extra']],
+      // Names and URLs must pass the same rules the pushTarget RPCs enforce.
+      [['remote', 'add', '--mirror=push', 'https://github.com/contributor/orca.git']],
+      [['remote', 'add', '../escape', 'https://github.com/contributor/orca.git']],
+      [['remote', 'remove', '-f']],
+      [['remote', 'add', 'fork', 'ext::sh -c payload']],
+      [['remote', 'add', 'fork', 'https://evil.test/contributor/orca.git']],
+      [['remote', 'add', 'fork', '/etc/passwd']]
+    ])('rejects unsafe remote write args %j', (args) => {
+      expectBlocked(args, 'Destructive git remote operations')
     })
   })
 

--- a/src/relay/git-exec-validator.ts
+++ b/src/relay/git-exec-validator.ts
@@ -5,9 +5,15 @@
  * Extracted from git-handler-ops.ts to keep both files under the limit.
  */
 
+import {
+  isSafeGitRemoteName,
+  isSafePushTargetRemoteUrl
+} from '../shared/git-push-target-validation'
+
 // Why: only read-only git subcommands are allowed via exec, except for the
 // exact init/empty-commit shapes used by SSH Create Project after the parent
-// directory has already been validated by main.
+// directory has already been validated by main, and the exact fork-remote
+// add/remove shapes used by SSH fork-PR worktrees.
 const ALLOWED_GIT_SUBCOMMANDS = new Set([
   'rev-parse',
   'branch',
@@ -84,6 +90,21 @@ const DIFF_ALLOWED_FLAGS = new Set([
   '--no-color',
   '--no-ext-diff'
 ])
+
+// Why: fork-PR worktrees on an SSH host must add the contributor's fork as a
+// remote (and drop it again when the last worktree using it is removed). Allow
+// only those two exact shapes, held to the same remote-name and URL rules the
+// relay already enforces on every pushTarget-carrying RPC. Everything else --
+// set-url, rename, prune, flags before the action -- stays blocked.
+function isAllowedRemoteWriteShape(args: string[]): boolean {
+  if (args[1] === 'add') {
+    return args.length === 4 && isSafeGitRemoteName(args[2]) && isSafePushTargetRemoteUrl(args[3])
+  }
+  if (args[1] === 'remove') {
+    return args.length === 3 && isSafeGitRemoteName(args[2])
+  }
+  return false
+}
 
 function validateCloneArgs(args: string[]): void {
   // Why: project-host setup needs remote clone, but git.exec must not become a
@@ -173,7 +194,11 @@ export function validateGitExecArgs(args: string[]): void {
   }
   if (subcommand === 'remote') {
     const remoteSubcmd = restArgs.find((a) => !a.startsWith('-'))
-    if (remoteSubcmd && REMOTE_WRITE_SUBCOMMANDS.has(remoteSubcmd)) {
+    if (
+      remoteSubcmd &&
+      REMOTE_WRITE_SUBCOMMANDS.has(remoteSubcmd) &&
+      !isAllowedRemoteWriteShape(args)
+    ) {
       throw new Error('Destructive git remote operations are not allowed via exec')
     }
   }

--- a/src/relay/git-handler-fork-remote-exec.test.ts
+++ b/src/relay/git-handler-fork-remote-exec.test.ts
@@ -1,0 +1,64 @@
+/**
+ * The relay's git.exec must carry the fork-PR remote setup that SSH worktree
+ * creation performs: adding the contributor's fork as a remote, and dropping it
+ * again when the last worktree using it is removed.
+ */
+import { describe, expect, it, beforeEach, afterEach } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { gitInit, type MockDispatcher } from './git-handler-test-setup'
+import {
+  createGitHandlerRelay,
+  createGitTempDir,
+  removeGitTempDir
+} from './git-handler-test-harness'
+
+const FORK_REMOTE = 'pr-contributor-orca'
+const FORK_URL = 'https://github.com/contributor/orca.git'
+
+describe('GitHandler git.exec fork remote', () => {
+  let dispatcher: MockDispatcher
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = createGitTempDir()
+    ;({ dispatcher } = createGitHandlerRelay())
+    gitInit(tmpDir)
+  })
+
+  afterEach(async () => {
+    await removeGitTempDir(tmpDir)
+  })
+
+  function configuredRemotes(): string {
+    return execFileSync('git', ['remote'], { cwd: tmpDir, encoding: 'utf-8' }).trim()
+  }
+
+  it('adds and removes the fork remote', async () => {
+    await dispatcher.callRequest('git.exec', {
+      args: ['remote', 'add', FORK_REMOTE, FORK_URL],
+      cwd: tmpDir
+    })
+    expect(configuredRemotes()).toBe(FORK_REMOTE)
+
+    const url = (await dispatcher.callRequest('git.exec', {
+      args: ['remote', 'get-url', FORK_REMOTE],
+      cwd: tmpDir
+    })) as { stdout: string }
+    expect(url.stdout.trim()).toBe(FORK_URL)
+
+    await dispatcher.callRequest('git.exec', {
+      args: ['remote', 'remove', FORK_REMOTE],
+      cwd: tmpDir
+    })
+    expect(configuredRemotes()).toBe('')
+  })
+
+  it('still refuses to repoint an existing remote', async () => {
+    await expect(
+      dispatcher.callRequest('git.exec', {
+        args: ['remote', 'set-url', 'origin', FORK_URL],
+        cwd: tmpDir
+      })
+    ).rejects.toThrow('Destructive git remote operations are not allowed via exec')
+  })
+})

--- a/src/shared/git-exec-mutation.test.ts
+++ b/src/shared/git-exec-mutation.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { gitExecMutatesRepository } from './git-exec-mutation'
+
+describe('gitExecMutatesRepository', () => {
+  it.each([
+    [['remote', 'add', 'pr-contributor-orca', 'https://github.com/contributor/orca.git']],
+    [['remote', 'remove', 'pr-contributor-orca']],
+    [['clone', '--', 'https://github.com/stablyai/orca.git', 'orca']],
+    [['commit', '--allow-empty', '-m', 'Initial commit']],
+    [['init']]
+  ])('treats %j as mutating', (args) => {
+    expect(gitExecMutatesRepository(args)).toBe(true)
+  })
+
+  it.each([
+    // Why: these run on read-heavy paths; misclassifying them would flush the
+    // git read cache on every remote probe.
+    [['remote']],
+    [['remote', '-v']],
+    [['remote', 'get-url', 'origin']],
+    [['remote', 'show', 'origin']],
+    [['rev-parse', '--show-toplevel']],
+    [[]]
+  ])('treats %j as read-only', (args) => {
+    expect(gitExecMutatesRepository(args)).toBe(false)
+  })
+})

--- a/src/shared/git-exec-mutation.ts
+++ b/src/shared/git-exec-mutation.ts
@@ -1,7 +1,13 @@
 const MUTATING_GIT_EXEC_SUBCOMMANDS = new Set(['clone', 'commit', 'init'])
+// Why: `git remote` also serves the bare list and get-url reads, so only the
+// permitted fork-remote writes may invalidate cached reads.
+const MUTATING_GIT_REMOTE_ACTIONS = new Set(['add', 'remove'])
 
 // Why: relay git.exec permits these narrow write shapes alongside read-only
 // probes, so cache invalidation must distinguish them before dispatch.
 export function gitExecMutatesRepository(args: readonly string[]): boolean {
+  if (args[0] === 'remote') {
+    return MUTATING_GIT_REMOTE_ACTIONS.has(args[1] ?? '')
+  }
   return MUTATING_GIT_EXEC_SUBCOMMANDS.has(args[0] ?? '')
 }

--- a/src/shared/git-push-target-validation.ts
+++ b/src/shared/git-push-target-validation.ts
@@ -10,7 +10,7 @@ function assertString(value: unknown, name: string): asserts value is string {
   }
 }
 
-function isSafeRemoteName(remoteName: string): boolean {
+export function isSafeGitRemoteName(remoteName: string): boolean {
   if (remoteName.length === 0 || remoteName.length > 100) {
     return false
   }
@@ -26,6 +26,12 @@ function isSafeRemoteName(remoteName: string): boolean {
   })
 }
 
+// Why: the relay allows a fork remote to be added via git.exec, so the exec
+// validator needs the same URL rule the pushTarget-carrying RPCs already apply.
+export function isSafePushTargetRemoteUrl(remoteUrl: string): boolean {
+  return GITHUB_CLONE_URL.test(remoteUrl) || GITHUB_SSH_URL.test(remoteUrl)
+}
+
 export function assertGitPushTargetShape(target: unknown): asserts target is GitPushTarget {
   if (typeof target !== 'object' || target === null) {
     throw new Error('Invalid PR push target.')
@@ -33,7 +39,7 @@ export function assertGitPushTargetShape(target: unknown): asserts target is Git
   const candidate = target as Record<string, unknown>
   assertString(candidate.remoteName, 'remote name')
   assertString(candidate.branchName, 'branch name')
-  if (!isSafeRemoteName(candidate.remoteName)) {
+  if (!isSafeGitRemoteName(candidate.remoteName)) {
     throw new Error(`Invalid git remote name: ${candidate.remoteName}`)
   }
   if (!candidate.branchName || candidate.branchName.startsWith('-')) {
@@ -41,7 +47,7 @@ export function assertGitPushTargetShape(target: unknown): asserts target is Git
   }
   if (candidate.remoteUrl !== undefined) {
     assertString(candidate.remoteUrl, 'remote URL')
-    if (!(GITHUB_CLONE_URL.test(candidate.remoteUrl) || GITHUB_SSH_URL.test(candidate.remoteUrl))) {
+    if (!isSafePushTargetRemoteUrl(candidate.remoteUrl)) {
       throw new Error('Invalid PR push target remote URL.')
     }
   }


### PR DESCRIPTION
## ELI5

Orca can build a workspace straight from someone else's pull request. When that PR comes from a **fork**, Orca has to teach the repo where the contributor's copy lives — that's `git remote add`. On a local repo that just works. On an **SSH host**, Orca asks the little Orca helper program on that machine (the "relay") to run git for it, and the relay keeps a strict list of git commands it's willing to run. `git remote add` wasn't on the list, so the relay said *"Destructive git remote operations are not allowed via exec"* and the whole workspace creation died before it started.

This PR puts two very specific commands on that list — "add this fork remote" and "remove this fork remote" — and nothing else. The relay still refuses to rename remotes, repoint them, prune them, or point one at some random URL.

## The bug

Reported as:

> Error invoking remote method 'worktrees:create': Error: Destructive git remote operations are not allowed via exec

The trace shows the `worktree.create` span failing in ~114ms with the error arriving through `SshChannelMultiplexer.handleResponse` — thrown on the **remote relay**, not locally. A plain worktree create on the same SSH host succeeds; only fork-PR workspaces fail.

**Chain:**

1. Creating a workspace from a fork PR resolves a push target with the contributor's fork URL (`getPullRequestPushTarget` → `resolveGitHubPrStartPoint`).
2. `createRemoteWorktree` calls `prepareWorktreePushTargetSsh`, which runs `git remote add <fork-remote> <fork-url>` on the host via `git.exec` (`src/main/ipc/worktree-remote.ts:1101`).
3. The relay's exec allowlist rejects every `remote` write subcommand (`src/relay/git-exec-validator.ts:177`), so the create aborts before `git worktree add`.

The same block also broke the **paired cleanup**: removing such a worktree runs `git remote remove`, whose failure is caught and only `console.warn`ed — so fork remotes accumulated silently on SSH hosts.

## The fix

- **`src/relay/git-exec-validator.ts`** — allow exactly `remote add <name> <url>` and `remote remove <name>`. Names and URLs are checked with `isSafeGitRemoteName` / `isSafePushTargetRemoteUrl` from `src/shared/git-push-target-validation.ts` — the same rules the relay already enforces on every `pushTarget`-carrying RPC (push/pull/fetch). Since the relay already accepts a client-supplied push target pointing at a GitHub URL, this grants no reach it didn't have.
- **`src/shared/git-exec-mutation.ts`** — those two shapes now count as repository-mutating so git read caches invalidate. Bare `git remote` and `remote get-url` stay classified as reads (they're on hot paths).
- **`src/main/ipc/worktree-remote.ts`** — a host still running an older relay now gets *"This SSH host is running an older Orca relay... Reconnect to deploy the latest relay, then try again"* instead of the raw policy error, matching the existing `forceDeletePreservedBranch` / stale-relay `addWorktree` precedents.

Still blocked: `set-url`, `rename`, `set-head`, `set-branches`, `prune`, `update`, `rm`, extra or missing operands, flags before the action (`remote -v add …`), unsafe names (`--mirror=push`, `../escape`), and non-GitHub or remote-helper URLs (`ext::sh -c …`).

## Tests

Four angles, all red before the fix:

| Test | What it pins |
|---|---|
| `src/relay/git-exec-validator.test.ts` | the policy itself: the two allowed shapes + 10 adversarial variants stay blocked |
| `src/relay/git-handler-fork-remote-exec.test.ts` (new) | real git through the real relay dispatcher: add → `get-url` → remove against a temp repo; `set-url` still rejected |
| `src/main/ipc/worktrees-ssh-fork-push-target-remote.test.ts` (new) | the SSH create path with its provider `exec` routed through the **real** `validateGitExecArgs`, so a shape the relay rejects fails in CI instead of on a user's host — plus the older-relay message |
| `src/main/ipc/worktree-push-target-cleanup.test.ts` | every argv the cleanup sends passes the relay validator, so SSH cleanup can't silently no-op again |
| `src/shared/git-exec-mutation.test.ts` (new) | `remote` / `remote get-url` stay classified as reads, so the git read cache isn't flushed on every remote probe |

Verified: `oxlint`, code-quality-native lint, max-lines ratchet, `tsc -p config/tsconfig.node.json`, `pnpm build:relay`, and the full `src/relay` + `src/main/ipc` + `src/shared` suites (9,761 tests).

## Rollout note

The relay is deployed from the client, so this reaches an SSH host on the next connect after the app updates; live connections keep the old relay until they reconnect — which is exactly what the new error message tells the user to do.

## Not validated

I did not drive the real fork-PR create through the UI end-to-end — the reporter's app had no CDP port open. The call chain is covered by the tests above, but the literal click path is unverified.