### PR TITLE
fix: protect repository-managed hook config symlinks

### DIFF
--- a/src/main/agent-hooks/hook-config-write-path.ts
+++ b/src/main/agent-hooks/hook-config-write-path.ts
@@ -1,4 +1,32 @@
-import { lstatSync, realpathSync } from 'node:fs'
+import { existsSync, lstatSync, realpathSync } from 'node:fs'
+import { dirname, join, parse } from 'node:path'
+
+export function isRepositoryManagedHookConfigSymlink(configPath: string): boolean {
+  let isSymlink = false
+  try {
+    isSymlink = lstatSync(configPath).isSymbolicLink()
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return false
+    }
+    throw error
+  }
+  if (!isSymlink) {
+    return false
+  }
+
+  let current = dirname(realpathSync.native(configPath))
+  const root = parse(current).root
+  while (true) {
+    if (existsSync(join(current, '.git'))) {
+      return true
+    }
+    if (current === root) {
+      return false
+    }
+    current = dirname(current)
+  }
+}
 
 export function resolveHooksJsonWritePath(configPath: string): string {
   let isSymlink = false

--- a/src/main/agent-hooks/repository-managed-hook-config.ts
+++ b/src/main/agent-hooks/repository-managed-hook-config.ts
@@ -1,0 +1,20 @@
+import type { AgentHookInstallStatus } from '../../shared/agent-hook-types'
+import { isRepositoryManagedHookConfigSymlink } from './hook-config-write-path'
+
+type HookConfigIdentity = Pick<AgentHookInstallStatus, 'agent'> & { displayName: string }
+
+export function getRepositoryManagedHookConfigStatus(
+  configPath: string,
+  identity: HookConfigIdentity
+): AgentHookInstallStatus | null {
+  if (!isRepositoryManagedHookConfigSymlink(configPath)) {
+    return null
+  }
+  return {
+    agent: identity.agent,
+    state: 'not_installed',
+    configPath,
+    managedHooksPresent: false,
+    detail: `Refusing to modify repository-managed ${identity.displayName} settings symlink`
+  }
+}

--- a/src/main/claude/hook-service.test.ts
+++ b/src/main/claude/hook-service.test.ts
@@ -3,7 +3,15 @@
 // or the script body that lands on the remote box. Local install behavior
 // is exercised through `installer-utils.test.ts` and the per-CLI status
 // audit; this file covers ONLY the SFTP-backed path added in commit #8.
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { vi, describe, expect, it } from 'vitest'
@@ -145,6 +153,34 @@ function createFakeSftp(): { sftp: SFTPWrapper; fs: FakeFs } {
 }
 
 describe('ClaudeHookService.install', () => {
+  it('does not mutate a repository-managed settings symlink or create a backup', () => {
+    const tmpHome = mkdtempSync(join(tmpdir(), 'orca-claude-repo-settings-'))
+    vi.stubEnv('HOME', tmpHome)
+    vi.stubEnv('USERPROFILE', tmpHome)
+    try {
+      const repo = join(tmpHome, 'dotfiles')
+      const targetPath = join(repo, 'config', 'claude', 'settings.json')
+      const settingsPath = join(tmpHome, '.claude', 'settings.json')
+      const original = `${JSON.stringify({ hooks: { Stop: [] } }, null, 2)}\n`
+      mkdirSync(join(repo, '.git'), { recursive: true })
+      mkdirSync(join(repo, 'config', 'claude'), { recursive: true })
+      mkdirSync(join(tmpHome, '.claude'), { recursive: true })
+      writeFileSync(targetPath, original)
+      symlinkSync(targetPath, settingsPath)
+
+      const status = new ClaudeHookService().install()
+
+      expect(status.state).toBe('not_installed')
+      expect(status.detail).toContain('repository-managed')
+      expect(readFileSync(targetPath, 'utf-8')).toBe(original)
+      expect(existsSync(`${targetPath}.bak`)).toBe(false)
+      expect(existsSync(`${settingsPath}.bak`)).toBe(false)
+    } finally {
+      vi.unstubAllEnvs()
+      rmSync(tmpHome, { recursive: true, force: true })
+    }
+  })
+
   it('installs managed hooks into Claude settings and preserves user Bedrock settings', () => {
     const tmpHome = mkdtempSync(join(tmpdir(), 'orca-claude-hooks-'))
     vi.stubEnv('HOME', tmpHome)

--- a/src/main/claude/hook-service.test.ts
+++ b/src/main/claude/hook-service.test.ts
@@ -153,33 +153,36 @@ function createFakeSftp(): { sftp: SFTPWrapper; fs: FakeFs } {
 }
 
 describe('ClaudeHookService.install', () => {
-  it('does not mutate a repository-managed settings symlink or create a backup', () => {
-    const tmpHome = mkdtempSync(join(tmpdir(), 'orca-claude-repo-settings-'))
-    vi.stubEnv('HOME', tmpHome)
-    vi.stubEnv('USERPROFILE', tmpHome)
-    try {
-      const repo = join(tmpHome, 'dotfiles')
-      const targetPath = join(repo, 'config', 'claude', 'settings.json')
-      const settingsPath = join(tmpHome, '.claude', 'settings.json')
-      const original = `${JSON.stringify({ hooks: { Stop: [] } }, null, 2)}\n`
-      mkdirSync(join(repo, '.git'), { recursive: true })
-      mkdirSync(join(repo, 'config', 'claude'), { recursive: true })
-      mkdirSync(join(tmpHome, '.claude'), { recursive: true })
-      writeFileSync(targetPath, original)
-      symlinkSync(targetPath, settingsPath)
+  it.skipIf(process.platform === 'win32')(
+    'does not mutate a repository-managed settings symlink or create a backup',
+    () => {
+      const tmpHome = mkdtempSync(join(tmpdir(), 'orca-claude-repo-settings-'))
+      vi.stubEnv('HOME', tmpHome)
+      vi.stubEnv('USERPROFILE', tmpHome)
+      try {
+        const repo = join(tmpHome, 'dotfiles')
+        const targetPath = join(repo, 'config', 'claude', 'settings.json')
+        const settingsPath = join(tmpHome, '.claude', 'settings.json')
+        const original = `${JSON.stringify({ hooks: { Stop: [] } }, null, 2)}\n`
+        mkdirSync(join(repo, '.git'), { recursive: true })
+        mkdirSync(join(repo, 'config', 'claude'), { recursive: true })
+        mkdirSync(join(tmpHome, '.claude'), { recursive: true })
+        writeFileSync(targetPath, original)
+        symlinkSync(targetPath, settingsPath)
 
-      const status = new ClaudeHookService().install()
+        const status = new ClaudeHookService().install()
 
-      expect(status.state).toBe('not_installed')
-      expect(status.detail).toContain('repository-managed')
-      expect(readFileSync(targetPath, 'utf-8')).toBe(original)
-      expect(existsSync(`${targetPath}.bak`)).toBe(false)
-      expect(existsSync(`${settingsPath}.bak`)).toBe(false)
-    } finally {
-      vi.unstubAllEnvs()
-      rmSync(tmpHome, { recursive: true, force: true })
+        expect(status.state).toBe('not_installed')
+        expect(status.detail).toContain('repository-managed')
+        expect(readFileSync(targetPath, 'utf-8')).toBe(original)
+        expect(existsSync(`${targetPath}.bak`)).toBe(false)
+        expect(existsSync(`${settingsPath}.bak`)).toBe(false)
+      } finally {
+        vi.unstubAllEnvs()
+        rmSync(tmpHome, { recursive: true, force: true })
+      }
     }
-  })
+  )
 
   it('installs managed hooks into Claude settings and preserves user Bedrock settings', () => {
     const tmpHome = mkdtempSync(join(tmpdir(), 'orca-claude-hooks-'))

--- a/src/main/claude/hook-service.ts
+++ b/src/main/claude/hook-service.ts
@@ -15,6 +15,7 @@ import {
   writeManagedScriptRemote
 } from '../agent-hooks/installer-utils-remote'
 import { refreshManagedScriptIfPresent } from '../agent-hooks/managed-hook-script-refresh'
+import { getRepositoryManagedHookConfigStatus } from '../agent-hooks/repository-managed-hook-config'
 import {
   buildPosixHookPayloadCapture,
   buildWindowsHookEnvironmentGuardLines,
@@ -204,6 +205,10 @@ export class ClaudeHookService {
   install(): AgentHookInstallStatus {
     const configPath = getConfigPath(this.options.settings)
     const scriptPath = getManagedScriptPath(this.options.settings)
+    const protectedStatus = getRepositoryManagedHookConfigStatus(configPath, this.options)
+    if (protectedStatus) {
+      return protectedStatus
+    }
     const config = readHooksJson(configPath)
     if (!config) {
       return {


### PR DESCRIPTION
## ELI5

Orca should not rewrite a Claude settings file that is deliberately stored in a Git repository. When the settings path is a symlink into a repository, hook installation now leaves it untouched and explains why installation was skipped.

## What Changed

- detect when a local Claude-compatible hook config path is a symlink into a Git-managed tree
- return a structured `not_installed` status before writing scripts, settings, or rolling backups
- preserve existing support for ordinary machine-local and non-repository symlinks
- add a regression test for target-byte and backup preservation, skipped on Windows where creating the test symlink is not portable

## Why

When `~/.claude/settings.json` points into a tracked repository, the atomic writer resolves the link, rewrites the tracked target, and can create `settings.json.bak` beside it. This silently dirties a shared checkout. Refusing only repository-managed symlinks protects source-controlled configuration without breaking valid non-repository symlink setups.

## Linked Issue

Related: #6879. That issue proposes a broader settings-path change; this PR addresses the narrower repository-managed symlink mutation defect.

## Visual Proof

N/A — this is a non-visual hook installer safety change.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Verification:

- `pnpm exec vitest run --config config/vitest.config.ts src/main/claude/hook-service.test.ts src/main/agent-hooks/installer-utils.test.ts` — 77 passed, 5 skipped
- `pnpm run typecheck:node`
- targeted `oxlint` and `oxfmt`
- `pnpm run check:code-quality:changed`

Platforms exercised locally: macOS. Windows is handled by skipping the filesystem-symlink regression setup; the production guard uses Node's cross-platform filesystem APIs.

## AI Disclosure

OpenAI Codex assisted with implementation, testing, and review feedback.

## Review

Please focus on the repository-boundary detection and whether returning `not_installed` before any mutation is the appropriate installer behavior.

## Agent skill upstream boundary

- [x] Not applicable; this change copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

The adjacent stronger rule—reject every symlinked settings path—is intentionally not used because ordinary non-repository symlinks are valid and already supported.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] Relevant lint, typecheck, and targeted tests pass locally; CI can cover the broader suite
