### PR TITLE
fix(workspaces): preserve provisioned-root startup draft

### DIFF
--- a/src/renderer/src/store/slices/worktrees-create-base-status.test.ts
+++ b/src/renderer/src/store/slices/worktrees-create-base-status.test.ts
@@ -214,6 +214,7 @@ describe('createWorktree base status merge', () => {
         undefined,
         undefined,
         {
+          startupDraft: 'https://github.com/stablyai/orca/issues/42',
           provisionedRoot: {
             runtimeId: 'runtime-1',
             executionHostId: 'ssh:runtime-ssh-runtime-1',
@@ -227,7 +228,8 @@ describe('createWorktree base status merge', () => {
         repoId: 'repo1',
         runtimeId: 'runtime-1',
         executionHostId: 'ssh:runtime-ssh-runtime-1',
-        expectedPath: '/workspace/repo'
+        expectedPath: '/workspace/repo',
+        startupDraft: 'https://github.com/stablyai/orca/issues/42'
       })
     )
     expect(mockApi.worktrees.create).not.toHaveBeenCalled()

--- a/src/renderer/src/store/slices/worktrees/create/create-worktree.ts
+++ b/src/renderer/src/store/slices/worktrees/create/create-worktree.ts
@@ -113,6 +113,7 @@ export function createCreateWorktree(
             ...(linkedWorkItem !== undefined ? { linkedWorkItem } : {}),
             ...(linkedTaskSourceContext !== undefined ? { linkedTaskSourceContext } : {}),
             ...(startup ? { startup } : {}),
+            ...(startupDraft ? { startupDraft } : {}),
             ...(creationId ? { creationId } : {}),
             ...(automationProvenanceRequest ? { automationProvenanceRequest } : {})
           }


### PR DESCRIPTION
## Summary

- forward `startupDraft` through the `adoptProvisionedRoot` request
- preserve the linked work-item URL/prompt when a provisioned-root workspace launches its initial agent
- add regression coverage for the adoption request

## Root cause

`createWorktree` extracted `options.startupDraft`, and ordinary remote workspace creation forwarded it to `worktree.create`, but the `createArgs` object passed to `adoptProvisionedRoot` omitted it. The provisioned-root runtime therefore launched the selected agent in the correct single terminal without delivering the linked issue URL.

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/worktrees-create-base-status.test.ts` (23/23 passed)
- `pnpm exec oxfmt --check src/renderer/src/store/slices/worktrees/create/create-worktree.ts src/renderer/src/store/slices/worktrees-create-base-status.test.ts`
- repository pre-commit oxlint, react-doctor lint, and formatting hooks passed