### PR TITLE
fix(codex): suppress false restart notices after reauth

### DIFF
--- a/src/renderer/src/lib/codex-session-restart.test.ts
+++ b/src/renderer/src/lib/codex-session-restart.test.ts
@@ -668,16 +668,90 @@ describe('markLiveCodexSessionsForRestart lane scoping', () => {
       vi.mocked(window.api.codexAccounts.listRecordedPaneLanes).mockResolvedValue({
         'pty-1': 'host'
       })
+      vi.mocked(window.api.codexAccounts.listStalePanes).mockResolvedValue([
+        {
+          ptyId: 'pty-1',
+          launchAccountId: 'account-a',
+          activeAccountId: 'account-b',
+          reason: 'account-change'
+        }
+      ])
 
       await markLiveCodexSessionsForRestart({
         previousAccountLabel: ACCOUNT_A,
         nextAccountLabel: ACCOUNT_B,
+        previousAccountId: 'account-a',
+        nextAccountId: 'account-b',
         target: { runtime: 'host' }
       })
 
       expect(useAppStore.getState().codexRestartNoticeByPtyId['pty-1']).toEqual({
         previousAccountLabel: ACCOUNT_A,
-        nextAccountLabel: ACCOUNT_B
+        nextAccountLabel: ACCOUNT_B,
+        previousAccountId: 'account-a',
+        nextAccountId: 'account-b'
+      })
+    })
+
+    it('suppresses a null-to-account reauth notice when the recorded pane is already current', async () => {
+      seedPanes([{ ptyId: 'pty-1' }])
+      vi.mocked(window.api.codexAccounts.listRecordedPaneLanes).mockResolvedValue({
+        'pty-1': 'host'
+      })
+
+      await markLiveCodexSessionsForRestart({
+        previousAccountLabel: 'System default',
+        nextAccountLabel: ACCOUNT_A,
+        previousAccountId: null,
+        nextAccountId: 'account-a',
+        target: { runtime: 'host' }
+      })
+
+      expect(window.api.codexAccounts.listStalePanes).toHaveBeenCalledWith({
+        ptyIds: ['pty-1']
+      })
+      expect(useAppStore.getState().codexRestartNoticeByPtyId).toEqual({})
+    })
+
+    it('classifies current, stale, and unrecorded panes independently', async () => {
+      seedPanes([{ ptyId: 'pty-current' }, { ptyId: 'pty-stale' }, { ptyId: 'pty-unknown' }])
+      vi.mocked(window.api.codexAccounts.listRecordedPaneLanes).mockResolvedValue({
+        'pty-current': 'host',
+        'pty-stale': 'host'
+      })
+      vi.mocked(window.api.codexAccounts.listStalePanes).mockResolvedValue([
+        {
+          ptyId: 'pty-stale',
+          launchAccountId: 'account-a',
+          activeAccountId: 'account-b',
+          reason: 'account-change'
+        }
+      ])
+
+      await markLiveCodexSessionsForRestart({
+        previousAccountLabel: ACCOUNT_A,
+        nextAccountLabel: ACCOUNT_B,
+        previousAccountId: 'account-a',
+        nextAccountId: 'account-b',
+        target: { runtime: 'host' }
+      })
+
+      expect(window.api.codexAccounts.listStalePanes).toHaveBeenCalledWith({
+        ptyIds: ['pty-current', 'pty-stale']
+      })
+      expect(useAppStore.getState().codexRestartNoticeByPtyId).toEqual({
+        'pty-stale': {
+          previousAccountLabel: ACCOUNT_A,
+          nextAccountLabel: ACCOUNT_B,
+          previousAccountId: 'account-a',
+          nextAccountId: 'account-b'
+        },
+        'pty-unknown': {
+          previousAccountLabel: ACCOUNT_A,
+          nextAccountLabel: ACCOUNT_B,
+          previousAccountId: 'account-a',
+          nextAccountId: 'account-b'
+        }
       })
     })
 

--- a/src/renderer/src/lib/codex-session-restart.ts
+++ b/src/renderer/src/lib/codex-session-restart.ts
@@ -214,38 +214,39 @@ export async function markLiveCodexSessionsForRestart(args: {
     return
   }
 
-  const currentState = useAppStore.getState()
-  const restoredRouteNoticePtyIds = liveCodexSessionPtyIds.filter(
-    (ptyId) => currentState.codexRestartNoticeByPtyId[ptyId]?.homeRouteChanged === true
-  )
-  const restoredRouteNoticePtyIdSet = new Set(restoredRouteNoticePtyIds)
+  const recordedLiveScans = scans.filter((scan) => scan.eligible && scan.laneSource === 'recorded')
+  // Why: a reauth can report null -> A even though a pane's immutable launch
+  // route was already A; main's per-PTY record is the restart authority.
   const authoritativeStalePanes =
-    restoredRouteNoticePtyIds.length === 0
+    recordedLiveScans.length === 0
       ? null
       : await window.api.codexAccounts
-          .listStalePanes({ ptyIds: restoredRouteNoticePtyIds })
+          .listStalePanes({ ptyIds: recordedLiveScans.map((scan) => scan.ptyId) })
           .catch(() => null)
   const authoritativeStaleByPtyId = authoritativeStalePanes
     ? new Map(authoritativeStalePanes.map((pane) => [pane.ptyId, pane]))
     : null
   if (authoritativeStaleByPtyId) {
-    for (const ptyId of restoredRouteNoticePtyIds) {
-      if (!authoritativeStaleByPtyId.has(ptyId)) {
-        useAppStore.getState().clearCodexRestartNotice(ptyId)
+    for (const scan of recordedLiveScans) {
+      if (!authoritativeStaleByPtyId.has(scan.ptyId)) {
+        useAppStore.getState().clearCodexRestartNotice(scan.ptyId)
       }
     }
   }
 
   useAppStore.getState().markCodexRestartNotices(
-    liveCodexSessionPtyIds.flatMap((ptyId) => {
-      if (authoritativeStaleByPtyId && restoredRouteNoticePtyIdSet.has(ptyId)) {
-        const stalePane = authoritativeStaleByPtyId.get(ptyId)
+    scans.flatMap((scan) => {
+      if (!scan.eligible) {
+        return []
+      }
+      if (authoritativeStaleByPtyId && scan.laneSource === 'recorded') {
+        const stalePane = authoritativeStaleByPtyId.get(scan.ptyId)
         if (!stalePane) {
           return []
         }
         return [
           {
-            ptyId,
+            ptyId: scan.ptyId,
             previousAccountLabel: args.previousAccountLabel,
             nextAccountLabel: args.nextAccountLabel,
             previousAccountId: stalePane.launchAccountId,
@@ -256,7 +257,7 @@ export async function markLiveCodexSessionsForRestart(args: {
       }
       return [
         {
-          ptyId,
+          ptyId: scan.ptyId,
           previousAccountLabel: args.previousAccountLabel,
           nextAccountLabel: args.nextAccountLabel,
           ...(args.previousAccountId === undefined


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​75 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​74 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​15 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 |

<!-- /orca-pr-loc -->

## Summary

- consult main's recorded per-PTY account state before raising live Codex restart notices
- suppress notices for recorded panes already on the current account/home route
- preserve authoritative stale notices and the existing conservative fallback for unrecorded panes or failed lookups

This fixes the [Slack-reported reauth sequence](https://stablygroup.slack.com/archives/C0AK2T3JEF4/p1787347869989459) where a transient empty selection was reported as `System default -> A` and incorrectly fanned out a restart notice to every terminal already launched under A.

## Reliability contract

- **Invariant (`codex-session.account-route-ownership`):** a recorded local/WSL PTY shows a restart notice only when its recorded launch account/home route differs from the current account/home route.
- **Failure source:** empty-selection reauthentication activates the same account but supplies caller-wide `null -> A` metadata to the live-pane sweep.
- **Oracle:** deterministic current/stale/unknown renderer coverage plus an isolated Electron profile with a real live Codex process. Recorded A/current A remains unblocked; recorded A/current B renders the normal restart overlay.
- **Gate:** no dedicated manifest gate exists; the focused deterministic contract is the accepted coverage for this bounded renderer decision, and the repository's 87-gate manifest validation remains green.
- **Performance budget:** one batched local IPC lookup per explicit account event when eligible recorded panes exist. No polling, timers, subprocesses, startup waits, per-pane IPC loop, or remote/SSH fan-out was added.
- **Diagnostics:** the existing recorded-lane and stale-pane APIs expose the launch/current account IDs and route reason; the mixed-pane test identifies current, stale, and unknown decisions independently.

## Provider/platform coverage

- **Local/daemon PTY:** covered by deterministic tests and isolated Electron validation.
- **WSL:** existing distro-scoped stale classifier coverage remains green.
- **SSH/remote:** unaffected; foreign pane IDs remain outside the local registry lookup and lane filter.
- **Folder workspaces:** unaffected; classification is keyed by PTY provenance, not Git worktree identity.
- **Mobile/relay:** unaffected; no wire or provider contract changed.
- **macOS/Linux/Windows:** no platform-specific behavior was added. Electron proof ran on macOS; live Windows/WSL was not rerun.

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/status-bar/codex-status-sign-in.test.tsx src/renderer/src/lib/codex-session-restart.test.ts src/renderer/src/lib/codex-session-restart-route-recheck.test.ts src/renderer/src/components/codex-restart-chip.test.tsx src/main/codex-accounts/sta-4422-transient-ownership-error.test.ts src/main/codex-accounts/service-reauthenticate-activation.test.ts src/main/codex/codex-stale-pane-accounts.test.ts --reporter=dot --silent` (92 tests)
- `pnpm typecheck`
- `pnpm lint`
- isolated Electron fixture: recorded A/current A produced no backing notice or visible overlay; recorded A/current B produced authoritative A/B state and the expected per-pane overlay

The Electron fixture used a fresh HOME/profile and fake `.invalid` accounts; no real Codex credentials were read or changed.
