### PR TITLE
fix(runtime): recognize Antigravity 1.1.17 ready prompt

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -16315,7 +16315,10 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
-  it('resolves tui-idle from the Antigravity 1.1.17 accept-edits prompt', async () => {
+  it.each([
+    '> Accept-edits mode: file edits auto-approved (shift+tab to cycle)',
+    '> Plan mode: research & plan only (shift+tab to cycle)'
+  ])('resolves tui-idle from Antigravity 1.1.17 mode prompt %s', async (prompt) => {
     const runtime = new OrcaRuntimeService(store)
     runtime.setPtyController({
       spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
@@ -16331,7 +16334,7 @@ describe('OrcaRuntimeService', () => {
         'user@example.com (Google AI Pro)',
         'Gemini 3.7 Flash (High)',
         '~/orca/workspaces/orca/agy-dispatch-issue',
-        '> Accept-edits mode: file edits auto-approved (shift+tab to cycle)',
+        prompt,
         '? for shortcuts'
       ].join('\n'),
       Date.now()

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -16315,6 +16315,38 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
+  it('resolves tui-idle from the Antigravity 1.1.17 accept-edits prompt', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+    runtime.onPtyData(
+      'pty-bg',
+      [
+        'Antigravity CLI 1.1.17',
+        'user@example.com (Google AI Pro)',
+        'Gemini 3.7 Flash (High)',
+        '~/orca/workspaces/orca/agy-dispatch-issue',
+        '> Accept-edits mode: file edits auto-approved (shift+tab to cycle)',
+        '? for shortcuts'
+      ].join('\n'),
+      Date.now()
+    )
+
+    await expect(
+      runtime.waitForTerminal(handle, { condition: 'tui-idle', timeoutMs: 200 })
+    ).resolves.toMatchObject({
+      handle,
+      condition: 'tui-idle',
+      satisfied: true,
+      status: 'running'
+    })
+  })
+
   it('resolves Antigravity ready prompts with newline-heavy pasted tails without splitting', async () => {
     const runtime = new OrcaRuntimeService(store)
     runtime.setPtyController({

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -40051,12 +40051,7 @@ function findAntigravityReadyPromptIndex(normalized: string): number | null {
       if (modelIndex === null && normalized.startsWith('gemini', trimmedStart)) {
         modelIndex = trimmedStart
       }
-      if (
-        promptIndex === null &&
-        normalized.charCodeAt(trimmedStart) === 62 &&
-        (trimmedEnd - trimmedStart === 1 ||
-          normalized.startsWith('> accept-edits mode:', trimmedStart))
-      ) {
+      if (promptIndex === null && normalized.charCodeAt(trimmedStart) === 62) {
         promptIndex = trimmedStart
       }
     }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -40053,8 +40053,9 @@ function findAntigravityReadyPromptIndex(normalized: string): number | null {
       }
       if (
         promptIndex === null &&
-        trimmedEnd - trimmedStart === 1 &&
-        normalized.charCodeAt(trimmedStart) === 62
+        normalized.charCodeAt(trimmedStart) === 62 &&
+        (trimmedEnd - trimmedStart === 1 ||
+          normalized.startsWith('> accept-edits mode:', trimmedStart))
       ) {
         promptIndex = trimmedStart
       }


### PR DESCRIPTION
## ELI5

Antigravity CLI 1.1.17 no longer keeps its ready prompt as a bare `>`. The text after `>` changes with the active mode — for example, Accept-edits and Plan. Orca only recognized the old bare prompt, so supervised workers timed out even though the terminal was ready. This keeps the existing banner/model gates and treats the leading `>` as the stable prompt marker.

## What Changed

- Preserve the existing bare-`>` Antigravity ready prompt.
- Recognize any trimmed Antigravity prompt line beginning with `>` after the existing Antigravity banner and Gemini model checks.
- Add parameterized regression coverage for the observed Accept-edits and Plan mode screens without parsing a specific mode name or description.

## Why

`findAntigravityReadyPromptIndex()` required the trimmed prompt line to contain exactly one character. Antigravity 1.1.17 appends mode-dependent status text, so `tui-idle` did not resolve and `worker-start` failed at `agent_readiness`.

The mode label and description are not stable. The stable contract used here is the existing Antigravity banner, a Gemini model line, and a subsequent trimmed line beginning with `>`.

## Linked Issue

Fixes #15838

Related but independent from #10740: that PR changes which Antigravity prompt occurrence wins after a dismissed startup modal. This PR changes which prompt shapes are recognized. Both touch the same matcher hunk, so a mechanical rebase may be required depending on merge order.

## Visual Proof

N/A — this only changes runtime terminal-text readiness detection; there is no Orca UI change. The Accept-edits capture is attached to #15838; the follow-up Plan mode capture confirmed that the text after `>` varies by mode.

## Testing

- Red: with the Accept-edits-only implementation, Accept-edits passed while the Plan mode case failed with `Error: timeout`.
- Green: both parameterized mode cases pass after matching the leading `>`.
- `14 passed`: all current Antigravity tests in `orca-runtime.test.ts`.
- Oxlint passed for both changed files.
- `git diff --check` passed.
- An earlier full `orca-runtime.test.ts` run completed 1180 tests and had 5 environment-bound failures (`EPERM` for `/tmp` or `C:\tmp`, plus an unrelated legacy runtime-graph timeout); the full file was not rerun after the mode follow-up.
- Node 24 typecheck passed on the original PR revision; the follow-up simplifies the same string predicate and was checked with Oxlint.
- Dependency postinstall could not rebuild optional `windows-native-registry` because Visual Studio Build Tools are not installed; full `pnpm build` was not run.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated

## AI Disclosure

OpenAI Codex was used for diagnosis, implementation, targeted verification, and independent Standards/Spec reviews.

## Review

- **Spec:** Pass. The implementation follows the requested mode-agnostic leading-`>` contract and retains the Antigravity banner/model gates.
- **Cross-platform:** string-only matching on normalized PTY text; no OS-specific paths or APIs.
- **Local / SSH / remote:** the existing shared runtime matcher is changed; no transport, RPC, or ownership semantics change.
- **Agent compatibility:** matching remains inside the Antigravity banner + Gemini model probe; other agents are unaffected, and legacy bare-`>` coverage still passes.
- **Performance:** one character check inside the existing bounded line scan; no new allocation, polling, timer, or process probe.
- **Security:** blocked-prompt detection is unchanged.
- **UI / mobile:** N/A; no rendered UI or mobile code changed.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

The change is intentionally limited to the existing Antigravity ready-prompt predicate and its regression test. No launch command, PATH, permission setting, timeout, or orchestration lifecycle behavior changes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: N/A
