### PR TITLE
feat: add keyboard shortcuts for cycling projects

### DIFF
--- a/src/renderer/src/components/sidebar/project-keyboard-cycle.ts
+++ b/src/renderer/src/components/sidebar/project-keyboard-cycle.ts
@@ -81,11 +81,8 @@ export function getActiveProjectKey(args: {
     (worktree) =>
       worktree.id === args.activeWorktreeId &&
       (!args.activeWorkspaceExecutionHostId ||
-        getWorktreeExecutionHostId(
-          worktree,
-          args.repoMap.get(worktree.repoId),
-          args.activeWorkspaceExecutionHostId
-        ) === args.activeWorkspaceExecutionHostId)
+        getWorktreeExecutionHostId(worktree, args.repoMap.get(worktree.repoId)) ===
+          args.activeWorkspaceExecutionHostId)
   )
   if (!activeWorktree) {
     return null

--- a/src/renderer/src/components/sidebar/project-keyboard-cycle.ts
+++ b/src/renderer/src/components/sidebar/project-keyboard-cycle.ts
@@ -1,0 +1,140 @@
+import type { ProjectGroupingModel } from './worktree-list/grouping/project-grouping'
+import {
+  buildProjectGroupingIndex,
+  getProjectGroupingForRepo
+} from './worktree-list/grouping/project-grouping'
+import type { HostSectionRow } from './host-section-rows'
+import type { Repo } from '../../../../shared/repo-types'
+import type { Worktree } from '../../../../shared/worktree/types'
+import { getWorktreeExecutionHostId, type ExecutionHostId } from '../../../../shared/execution-host'
+
+export type ProjectCycleDirection = 'previous' | 'next'
+
+export type CyclableProject = {
+  key: string
+  worktrees: Worktree[]
+}
+
+function getProjectKey(
+  repoId: string,
+  repoMap: Map<string, Repo>,
+  projectIndex: ReturnType<typeof buildProjectGroupingIndex>
+): string {
+  return getProjectGroupingForRepo(repoId, repoMap, projectIndex).key
+}
+
+export function getCyclableProjects(args: {
+  rows: readonly HostSectionRow[]
+  worktrees: readonly Worktree[]
+  repoMap: Map<string, Repo>
+  projectGrouping?: ProjectGroupingModel
+}): CyclableProject[] {
+  const projectIndex = buildProjectGroupingIndex(args.projectGrouping)
+  const worktreesByProjectKey = new Map<string, Worktree[]>()
+  for (const worktree of args.worktrees) {
+    if (worktree.isArchived) {
+      continue
+    }
+    const key = getProjectKey(worktree.repoId, args.repoMap, projectIndex)
+    const projectWorktrees = worktreesByProjectKey.get(key) ?? []
+    projectWorktrees.push(worktree)
+    worktreesByProjectKey.set(key, projectWorktrees)
+  }
+
+  const orderedKeys: string[] = []
+  const seen = new Set<string>()
+  const appendKey = (key: string): void => {
+    if (!seen.has(key) && worktreesByProjectKey.has(key)) {
+      seen.add(key)
+      orderedKeys.push(key)
+    }
+  }
+
+  // Project headers carry the exact sidebar order, including logical-project and checkout splits.
+  for (const row of args.rows) {
+    if (row.type === 'header' && row.repo) {
+      appendKey(row.key)
+    }
+  }
+  // Collapsed/filtered projects are absent from the rows but must remain keyboard-reachable.
+  for (const repo of args.repoMap.values()) {
+    appendKey(getProjectKey(repo.id, args.repoMap, projectIndex))
+  }
+  for (const key of worktreesByProjectKey.keys()) {
+    appendKey(key)
+  }
+
+  return orderedKeys.map((key) => ({ key, worktrees: worktreesByProjectKey.get(key) ?? [] }))
+}
+
+export function getActiveProjectKey(args: {
+  activeWorktreeId: string | null
+  activeWorkspaceExecutionHostId: ExecutionHostId | null
+  worktrees: readonly Worktree[]
+  repoMap: Map<string, Repo>
+  projectGrouping?: ProjectGroupingModel
+}): string | null {
+  if (!args.activeWorktreeId) {
+    return null
+  }
+  const activeWorktree = args.worktrees.find(
+    (worktree) =>
+      worktree.id === args.activeWorktreeId &&
+      (!args.activeWorkspaceExecutionHostId ||
+        getWorktreeExecutionHostId(
+          worktree,
+          args.repoMap.get(worktree.repoId),
+          args.activeWorkspaceExecutionHostId
+        ) === args.activeWorkspaceExecutionHostId)
+  )
+  if (!activeWorktree) {
+    return null
+  }
+  return getProjectKey(
+    activeWorktree.repoId,
+    args.repoMap,
+    buildProjectGroupingIndex(args.projectGrouping)
+  )
+}
+
+function pickProjectWorktree(
+  worktrees: readonly Worktree[],
+  lastVisitedAtByWorktreeId: Readonly<Record<string, number>>
+): Worktree | null {
+  let mostRecent: Worktree | null = null
+  let mostRecentAt = Number.NEGATIVE_INFINITY
+  for (const worktree of worktrees) {
+    const visitedAt = lastVisitedAtByWorktreeId[worktree.id]
+    if (visitedAt !== undefined && visitedAt > mostRecentAt) {
+      mostRecent = worktree
+      mostRecentAt = visitedAt
+    }
+  }
+  return mostRecent ?? worktrees.find((worktree) => worktree.isMainWorktree) ?? worktrees[0] ?? null
+}
+
+export function resolveCycledProjectWorktree(args: {
+  projects: readonly CyclableProject[]
+  activeProjectKey: string | null
+  direction: ProjectCycleDirection
+  lastVisitedAtByWorktreeId: Readonly<Record<string, number>>
+}): Worktree | null {
+  if (args.projects.length < 2) {
+    return null
+  }
+
+  const currentIndex = args.activeProjectKey
+    ? args.projects.findIndex((project) => project.key === args.activeProjectKey)
+    : -1
+  const targetIndex =
+    currentIndex === -1
+      ? args.direction === 'next'
+        ? 0
+        : args.projects.length - 1
+      : (currentIndex + (args.direction === 'next' ? 1 : -1) + args.projects.length) %
+        args.projects.length
+  return pickProjectWorktree(
+    args.projects[targetIndex]?.worktrees ?? [],
+    args.lastVisitedAtByWorktreeId
+  )
+}

--- a/src/renderer/src/components/sidebar/worktree-keyboard-cycle.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-keyboard-cycle.test.ts
@@ -7,6 +7,11 @@ import {
   getCyclableWorktrees,
   resolveCycledWorktreeId
 } from './worktree-keyboard-cycle'
+import {
+  getActiveProjectKey,
+  getCyclableProjects,
+  resolveCycledProjectWorktree
+} from './project-keyboard-cycle'
 
 describe('resolveCycledWorktreeId', () => {
   const worktreeIds = ['a', 'b', 'c']
@@ -170,5 +175,109 @@ describe('WorktreeList keyboard cycling', () => {
     expect(navigateWorktree).toContain('executionHostId: nextWorktree.hostId')
     expect(navigateWorktree).toContain('resolveCycledWorktreeId')
     expect(navigateWorktree).not.toContain('buildRows(')
+  })
+})
+
+describe('project keyboard cycling', () => {
+  const repos = [
+    { id: 'repo-a', path: '/repo-a', displayName: 'A', badgeColor: '#737373', addedAt: 1 },
+    {
+      id: 'repo-b',
+      path: '/repo-b',
+      displayName: 'B',
+      badgeColor: '#737373',
+      addedAt: 2,
+      executionHostId: 'ssh:dev'
+    },
+    { id: 'repo-c', path: '/repo-c', displayName: 'C', badgeColor: '#737373', addedAt: 3 }
+  ]
+  const repoMap = new Map(repos.map((repo) => [repo.id, repo as never]))
+  const worktrees = [
+    { id: 'a-main', repoId: 'repo-a', isMainWorktree: true, isArchived: false },
+    { id: 'b-main', repoId: 'repo-b', isMainWorktree: true, isArchived: false },
+    { id: 'b-recent', repoId: 'repo-b', isMainWorktree: false, isArchived: false },
+    { id: 'c-main', repoId: 'repo-c', isMainWorktree: true, isArchived: false }
+  ] as never[]
+
+  it('uses rendered project order and appends collapsed or filtered projects', () => {
+    const rows: HostSectionRow[] = [
+      {
+        type: 'header',
+        key: 'repo:repo-b',
+        label: 'B',
+        count: 2,
+        tone: 'neutral',
+        repo: repos[1] as never
+      },
+      {
+        type: 'header',
+        key: 'repo:repo-a',
+        label: 'A',
+        count: 1,
+        tone: 'neutral',
+        repo: repos[0] as never
+      }
+    ]
+
+    expect(getCyclableProjects({ rows, worktrees, repoMap }).map((project) => project.key)).toEqual(
+      ['repo:repo-b', 'repo:repo-a', 'repo:repo-c']
+    )
+  })
+
+  it('wraps between projects and restores the target project’s recent workspace', () => {
+    const projects = getCyclableProjects({ rows: [], worktrees, repoMap })
+
+    expect(
+      resolveCycledProjectWorktree({
+        projects,
+        activeProjectKey: 'repo:repo-a',
+        direction: 'previous',
+        lastVisitedAtByWorktreeId: {}
+      })?.id
+    ).toBe('c-main')
+    expect(
+      resolveCycledProjectWorktree({
+        projects,
+        activeProjectKey: 'repo:repo-a',
+        direction: 'next',
+        lastVisitedAtByWorktreeId: { 'b-main': 10, 'b-recent': 20 }
+      })?.id
+    ).toBe('b-recent')
+  })
+
+  it('enters from the requested edge for folder workspaces and no-ops with one project', () => {
+    const projects = getCyclableProjects({ rows: [], worktrees, repoMap })
+    expect(
+      resolveCycledProjectWorktree({
+        projects,
+        activeProjectKey: null,
+        direction: 'previous',
+        lastVisitedAtByWorktreeId: {}
+      })?.id
+    ).toBe('c-main')
+    expect(
+      resolveCycledProjectWorktree({
+        projects: projects.slice(0, 1),
+        activeProjectKey: projects[0]?.key ?? null,
+        direction: 'next',
+        lastVisitedAtByWorktreeId: {}
+      })
+    ).toBeNull()
+  })
+
+  it('resolves the active project with host-qualified worktree selection', () => {
+    const hostWorktrees = [
+      { id: 'shared', repoId: 'repo-a', hostId: 'local', isArchived: false },
+      { id: 'shared', repoId: 'repo-b', isArchived: false }
+    ] as never[]
+
+    expect(
+      getActiveProjectKey({
+        activeWorktreeId: 'shared',
+        activeWorkspaceExecutionHostId: 'ssh:dev',
+        worktrees: hostWorktrees,
+        repoMap
+      })
+    ).toBe('repo:repo-b')
   })
 })

--- a/src/renderer/src/components/sidebar/worktree-keyboard-cycle.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-keyboard-cycle.test.ts
@@ -267,7 +267,7 @@ describe('project keyboard cycling', () => {
 
   it('resolves the active project with host-qualified worktree selection', () => {
     const hostWorktrees = [
-      { id: 'shared', repoId: 'repo-a', hostId: 'local', isArchived: false },
+      { id: 'shared', repoId: 'repo-a', isArchived: false },
       { id: 'shared', repoId: 'repo-b', isArchived: false }
     ] as never[]
 

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/use-keyboard.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/use-keyboard.ts
@@ -3,7 +3,11 @@ import type React from 'react'
 import type { Virtualizer } from '@tanstack/react-virtual'
 import { useAppStore } from '@/store'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
-import type { ExecutionHostId } from '../../../../../../shared/execution-host'
+import {
+  getSettingsFocusedExecutionHostId,
+  getWorktreeExecutionHostId,
+  type ExecutionHostId
+} from '../../../../../../shared/execution-host'
 import {
   composeWorktreeHostIdentity,
   getWorktreeHostIdentity
@@ -15,6 +19,14 @@ import type { PinnedWorktreeDisplayPolicy } from '../grouping/row-types'
 import type { RenderRow } from '../listing/render-row'
 import { getCyclableWorktrees, resolveCycledWorktreeId } from '../../worktree-keyboard-cycle'
 import { findPreferredRenderRowIndexForWorktreeIdentity } from './render-row-lookup'
+import {
+  getActiveProjectKey,
+  getCyclableProjects,
+  resolveCycledProjectWorktree,
+  type ProjectCycleDirection
+} from '../../project-keyboard-cycle'
+import { getAllWorktreesFromState, getRepoMapFromState } from '@/store/selectors'
+import { getProjectHostSetupProjectionFromState } from '@/store/project-host-setup-selector'
 
 function isEditableTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) {
@@ -112,6 +124,57 @@ export function useWorktreeListKeyboardNavigation(args: {
     ]
   )
 
+  const navigateProject = useCallback(
+    (direction: ProjectCycleDirection) => {
+      const state = useAppStore.getState()
+      const worktrees = getAllWorktreesFromState(state)
+      const repoMap = getRepoMapFromState(state)
+      const projection = getProjectHostSetupProjectionFromState(state)
+      const projectGrouping = {
+        projects: projection.projects,
+        projectHostSetups: projection.setups
+      }
+      const target = resolveCycledProjectWorktree({
+        projects: getCyclableProjects({ rows, worktrees, repoMap, projectGrouping }),
+        activeProjectKey: getActiveProjectKey({
+          activeWorktreeId,
+          activeWorkspaceExecutionHostId,
+          worktrees,
+          repoMap,
+          projectGrouping
+        }),
+        direction,
+        lastVisitedAtByWorktreeId: state.lastVisitedAtByWorktreeId
+      })
+      if (!target) {
+        return
+      }
+
+      const targetExecutionHostId = getWorktreeExecutionHostId(
+        target,
+        repoMap.get(target.repoId),
+        getSettingsFocusedExecutionHostId(state.settings)
+      )
+      activateAndRevealWorktree(target.id, { executionHostId: targetExecutionHostId })
+      const rowIndex = findPreferredRenderRowIndexForWorktreeIdentity(
+        renderRows,
+        target,
+        pinnedDisplayPolicy
+      )
+      if (rowIndex !== -1) {
+        virtualizer.scrollToIndex(rowIndex, { align: 'auto' })
+      }
+    },
+    [
+      activeWorkspaceExecutionHostId,
+      activeWorktreeId,
+      pinnedDisplayPolicy,
+      renderRows,
+      rows,
+      virtualizer
+    ]
+  )
+
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (activeModal !== 'none' || isEditableTarget(e.target)) {
@@ -134,12 +197,36 @@ export function useWorktreeListKeyboardNavigation(args: {
         markDirectScrollInput()
         navigateWorktree(direction)
         e.preventDefault()
+        return
+      }
+
+      const projectDirection = keybindingMatchesAction(
+        'project.navigatePrevious',
+        e,
+        platform,
+        keybindings
+      )
+        ? 'previous'
+        : keybindingMatchesAction('project.navigateNext', e, platform, keybindings)
+          ? 'next'
+          : null
+      if (projectDirection) {
+        markDirectScrollInput()
+        navigateProject(projectDirection)
+        e.preventDefault()
       }
     }
 
     window.addEventListener('keydown', handleKeyDown, { capture: true })
     return () => window.removeEventListener('keydown', handleKeyDown, { capture: true })
-  }, [activeModal, keybindings, markDirectScrollInput, navigateWorktree, scrollRef])
+  }, [
+    activeModal,
+    keybindings,
+    markDirectScrollInput,
+    navigateProject,
+    navigateWorktree,
+    scrollRef
+  ])
 
   const handleContainerKeyDown = useCallback(
     (e: React.KeyboardEvent) => {

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/use-keyboard.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/use-keyboard.ts
@@ -4,7 +4,6 @@ import type { Virtualizer } from '@tanstack/react-virtual'
 import { useAppStore } from '@/store'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import {
-  getSettingsFocusedExecutionHostId,
   getWorktreeExecutionHostId,
   type ExecutionHostId
 } from '../../../../../../shared/execution-host'
@@ -150,11 +149,7 @@ export function useWorktreeListKeyboardNavigation(args: {
         return
       }
 
-      const targetExecutionHostId = getWorktreeExecutionHostId(
-        target,
-        repoMap.get(target.repoId),
-        getSettingsFocusedExecutionHostId(state.settings)
-      )
+      const targetExecutionHostId = getWorktreeExecutionHostId(target, repoMap.get(target.repoId))
       activateAndRevealWorktree(target.id, { executionHostId: targetExecutionHostId })
       const rowIndex = findPreferredRenderRowIndexForWorktreeIdentity(
         renderRows,

--- a/src/shared/keybindings-default-bindings.test.ts
+++ b/src/shared/keybindings-default-bindings.test.ts
@@ -19,6 +19,17 @@ describe('keybindings', () => {
     expect(formatKeybindingList(['Mod+Shift+O'], 'darwin')).toBe('⌘⇧O')
   })
 
+  it('binds adjacent project cycling to horizontal workspace navigation chords', () => {
+    expect(getEffectiveKeybindingsForAction('project.navigatePrevious', 'darwin')).toEqual([
+      'Mod+Shift+ArrowLeft'
+    ])
+    expect(getEffectiveKeybindingsForAction('project.navigateNext', 'linux')).toEqual([
+      'Mod+Shift+ArrowRight'
+    ])
+    expect(formatKeybindingList(['Mod+Shift+ArrowLeft'], 'darwin')).toBe('⌘⇧←')
+    expect(formatKeybindingList(['Mod+Shift+ArrowRight'], 'linux')).toBe('Ctrl+Shift+→')
+  })
+
   it.each(['darwin', 'linux', 'win32'] as const)(
     'binds editor word wrap to Alt+Z on %s',
     (platform) => {

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -31,6 +31,8 @@ export type KeybindingActionId =
   | 'worktree.palette'
   | 'worktree.navigateUp'
   | 'worktree.navigateDown'
+  | 'project.navigatePrevious'
+  | 'project.navigateNext'
   | 'app.settings'
   | 'app.forceReload'
   | 'workspace.create'
@@ -254,6 +256,22 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     scope: 'global',
     searchKeywords: ['shortcut', 'global', 'worktree', 'next', 'down'],
     defaultBindings: platformBindings(['Mod+Shift+ArrowDown'])
+  },
+  {
+    id: 'project.navigatePrevious',
+    title: 'Previous project',
+    group: 'Global',
+    scope: 'global',
+    searchKeywords: ['shortcut', 'global', 'project', 'previous', 'left', 'cycle'],
+    defaultBindings: platformBindings(['Mod+Shift+ArrowLeft'])
+  },
+  {
+    id: 'project.navigateNext',
+    title: 'Next project',
+    group: 'Global',
+    scope: 'global',
+    searchKeywords: ['shortcut', 'global', 'project', 'next', 'right', 'cycle'],
+    defaultBindings: platformBindings(['Mod+Shift+ArrowRight'])
   },
   {
     id: 'workspace.create',

--- a/tests/e2e/project-cycle-shortcut.spec.ts
+++ b/tests/e2e/project-cycle-shortcut.spec.ts
@@ -82,7 +82,10 @@ test.describe('Project cycle shortcuts', () => {
     await orcaPage.keyboard.press(`${primaryModifier}+Shift+ArrowRight`)
     await expect(targetRow).toHaveAttribute('aria-current', 'page')
 
-    await orcaPage.keyboard.press(`${primaryModifier}+Shift+ArrowLeft`)
+    await orcaPage.keyboard.press(`${primaryModifier}+Shift+ArrowRight`)
     await expect(sourceRow).toHaveAttribute('aria-current', 'page')
+
+    await orcaPage.keyboard.press(`${primaryModifier}+Shift+ArrowLeft`)
+    await expect(targetRow).toHaveAttribute('aria-current', 'page')
   })
 })

--- a/tests/e2e/project-cycle-shortcut.spec.ts
+++ b/tests/e2e/project-cycle-shortcut.spec.ts
@@ -1,0 +1,88 @@
+import type { Page } from '@stablyai/playwright-test'
+import { expect, test } from './helpers/orca-app'
+import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import { worktreeRow } from './worktree-row-locators'
+
+async function seedAdjacentProject(page: Page): Promise<{ sourceId: string; targetId: string }> {
+  return page.evaluate(() => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('window.__store is unavailable')
+    }
+    const state = store.getState()
+    const sourceRepo = state.repos[0]
+    const sourceWorktree = sourceRepo
+      ? (state.worktreesByRepo[sourceRepo.id] ?? []).find((worktree) => !worktree.isArchived)
+      : null
+    if (!sourceRepo || !sourceWorktree) {
+      throw new Error('Project cycle E2E needs the seeded local repository')
+    }
+
+    const token = crypto.randomUUID()
+    const targetRepoId = `e2e-project-cycle-repo-${token}`
+    const targetWorktreeId = `e2e-project-cycle-worktree-${token}`
+    const targetRepo = {
+      ...sourceRepo,
+      id: targetRepoId,
+      displayName: 'Adjacent E2E Project',
+      upstream: undefined,
+      repoIcon: null,
+      gitRemoteIdentity: null,
+      executionHostId: 'local' as const,
+      connectionId: null
+    }
+    const targetWorktree = {
+      ...sourceWorktree,
+      id: targetWorktreeId,
+      repoId: targetRepoId,
+      displayName: 'Adjacent E2E Workspace',
+      title: 'Adjacent E2E Workspace',
+      branch: 'refs/heads/e2e-project-cycle',
+      isMainWorktree: true,
+      isArchived: false,
+      hostId: 'local' as const
+    }
+
+    store.setState({
+      repos: [sourceRepo, targetRepo],
+      worktreesByRepo: {
+        [sourceRepo.id]: [sourceWorktree],
+        [targetRepoId]: [targetWorktree]
+      }
+    })
+    const next = store.getState()
+    next.setActiveView('terminal')
+    next.setSidebarOpen(true)
+    next.setGroupBy('repo')
+    next.setShowActiveOnly(false)
+    next.setShowSleepingWorkspaces(true)
+    next.setHideDefaultBranchWorkspace(false)
+    next.setFilterRepoIds([sourceRepo.id])
+    next.setActiveRepo(sourceRepo.id)
+    next.setActiveWorktree(sourceWorktree.id, 'local')
+    return { sourceId: sourceWorktree.id, targetId: targetWorktreeId }
+  })
+}
+
+test.describe('Project cycle shortcuts', () => {
+  test.beforeEach(async ({ orcaPage }) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+  })
+
+  test('moves to adjacent projects, wraps, and reveals filtered targets', async ({ orcaPage }) => {
+    const { sourceId, targetId } = await seedAdjacentProject(orcaPage)
+    const sourceRow = worktreeRow(orcaPage, sourceId)
+    const targetRow = worktreeRow(orcaPage, targetId)
+    const primaryModifier = process.platform === 'darwin' ? 'Meta' : 'Control'
+
+    await expect(sourceRow).toHaveAttribute('aria-current', 'page')
+    await expect(targetRow).toHaveCount(0)
+
+    await orcaPage.keyboard.press(`${primaryModifier}+Shift+ArrowRight`)
+    await expect(targetRow).toHaveAttribute('aria-current', 'page')
+
+    await orcaPage.keyboard.press(`${primaryModifier}+Shift+ArrowLeft`)
+    await expect(sourceRow).toHaveAttribute('aria-current', 'page')
+  })
+})


### PR DESCRIPTION
## ELI5

Use one shortcut to move to the project on the left or right instead of selecting projects by number.

## What Changed

- Added configurable Previous project and Next project actions with Cmd/Ctrl+Shift+Left/Right defaults.
- Cycles through logical projects in sidebar order, including filtered or collapsed projects, with wraparound.
- Restores the most recently visited workspace in the target project and preserves host-aware activation.

## Why

Direct numeric shortcuts do not scale beyond a fixed set of projects. Adjacent navigation works for any project count and follows the sidebar mental model.

## Linked Issue

Fixes #15851

## Visual Proof

N/A — the shortcut changes selection without adding persistent UI. The Electron E2E verifies filtered-target reveal and forward/reverse boundary wraparound through rendered DOM state.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Verified on macOS:
- 35 focused unit tests
- renderer and node typechecks
- focused oxlint, React Doctor lint, formatting, and max-lines ratchet
- Electron Playwright E2E for filtered target reveal and bidirectional wraparound

## AI Disclosure

OpenAI Codex was used to implement and test this change and to respond to review feedback.

## Review

CodeRabbit findings for hostless local fallback and explicit endpoint wraparound were addressed in 9c7988e378. The incremental review reports no actionable comments.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows docs/reference/agent-skill-sharing-upstream-boundary.md and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Shortcut labels and modifiers are cross-platform. Project activation uses the canonical execution-host resolver, including local and SSH identity handling. Folder workspaces enter the project sequence from the requested edge.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or N/A with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] pnpm lint, pnpm typecheck, pnpm test, and pnpm build pass (focused checks and the Electron build/E2E passed; the full repository-wide suite was not run)