### PR TITLE
fix(startup): reconcile every hydrated workspace's tab model

### DIFF
--- a/src/renderer/src/app-shell/reconcile-hydrated-workspace-tab-models.test.ts
+++ b/src/renderer/src/app-shell/reconcile-hydrated-workspace-tab-models.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from 'vitest'
+import { reconcileHydratedWorkspaceTabModels } from './reconcile-hydrated-workspace-tab-models'
+
+describe('reconcileHydratedWorkspaceTabModels', () => {
+  it('reconciles every workspace the session hydrated, in session order', () => {
+    const reconcile = vi.fn()
+    const reconciled = reconcileHydratedWorkspaceTabModels(
+      { tabsByWorktree: { 'wt-a': [], 'wt-b': [], 'wt-c': [] } },
+      reconcile
+    )
+    expect(reconcile.mock.calls.map((call) => call[0])).toEqual(['wt-a', 'wt-b', 'wt-c'])
+    expect(reconciled).toEqual(['wt-a', 'wt-b', 'wt-c'])
+  })
+
+  it('reconciles nothing for a session without terminal rows', () => {
+    const reconcile = vi.fn()
+    expect(reconcileHydratedWorkspaceTabModels({ tabsByWorktree: {} }, reconcile)).toEqual([])
+    expect(reconcile).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/app-shell/reconcile-hydrated-workspace-tab-models.ts
+++ b/src/renderer/src/app-shell/reconcile-hydrated-workspace-tab-models.ts
@@ -1,0 +1,26 @@
+import type { WorkspaceSessionState } from '../../shared/workspace-session-state-types'
+
+/**
+ * Re-run tab-model reconciliation for every workspace the boot hydration just
+ * loaded (#15710).
+ *
+ * Why: the unified tab model is hydrated verbatim from `session.unifiedTabs`,
+ * but the same session's terminal rows can hold live PTYs that no canonical
+ * entry claims — rows that re-attached on a host after its canonical model was
+ * emptied (an update restart's PTY kill, a client writing a subset). The
+ * per-workspace reconcile performs the same restoration the active-worktree
+ * path runs, re-entering those rows into the unified model so a paired client's
+ * tab bar reflects the host's real terminal set instead of a stale subset that
+ * a later tab creation would rewrite.
+ */
+export function reconcileHydratedWorkspaceTabModels(
+  session: Pick<WorkspaceSessionState, 'tabsByWorktree'>,
+  reconcileWorktreeTabModel: (worktreeId: string) => unknown
+): string[] {
+  const reconciled: string[] = []
+  for (const worktreeId of Object.keys(session.tabsByWorktree)) {
+    reconcileWorktreeTabModel(worktreeId)
+    reconciled.push(worktreeId)
+  }
+  return reconciled
+}

--- a/src/renderer/src/app-shell/use-app-startup-hydration.ts
+++ b/src/renderer/src/app-shell/use-app-startup-hydration.ts
@@ -3,6 +3,7 @@ import { useShallow } from 'zustand/react/shallow'
 import { syncZoomCSSVar } from '@/lib/ui-zoom'
 import { installCodexDetachedPaneRestartExecutor } from '@/components/terminal-pane/codex-detached-pane-restart-scheduler'
 import { useAppStore } from '../store'
+import { reconcileHydratedWorkspaceTabModels } from './reconcile-hydrated-workspace-tab-models'
 import { WORKTREE_REFRESH_CONCURRENCY } from '../store/slices/worktrees'
 import { sweepRestoredCodexPanesForStaleAccounts } from '../lib/codex-stale-pane-sweep'
 import { fetchWorkspaceSessionWithRuntimeHostOwners } from '../lib/workspace-session-host-persistence'
@@ -225,6 +226,10 @@ export function useAppStartupHydration(onOnboardingLoaded: (state: OnboardingSta
             actions.hydrateTabsSession(sessionRead.session, sessionHydrationOptions)
             actions.hydrateEditorSession(sessionRead.session, sessionHydrationOptions)
             actions.hydrateBrowserSession(sessionRead.session, sessionHydrationOptions)
+            reconcileHydratedWorkspaceTabModels(
+              sessionRead.session,
+              useAppStore.getState().reconcileWorktreeTabModel
+            )
           })
           // Why: prune visit timestamps AFTER hydration (earlier, worktreesByRepo may be empty and prune would drop entries for worktrees about to appear); seed the active worktree if missing.
           // See docs/cmd-j-empty-query-ordering.md.


### PR DESCRIPTION
## Summary

**What**

Boot hydration now runs `reconcileWorktreeTabModel` for **every workspace the session loaded** (via a small pure helper, `reconcileHydratedWorkspaceTabModels`), instead of only the active worktree receiving reconciliation later.

**Why**

#15710 — the unified tab model is hydrated verbatim from `session.unifiedTabs`, but the same session's terminal rows can hold live PTYs that no canonical entry claims. Rows like that arise when a host's canonical model is emptied while its terminals re-attach — exactly your §5 timeline: the 1.4.185→1.4.186 auto-update ran `local_pty_kill_all`, sessions re-attached afterwards, and from that moment the `unifiedTabs` snapshots in §3 stayed empty while the terminal store kept its rows.

The reconcile that re-enters such rows into the unified model only ran for the **active** worktree (the auto-create-first-tab effect in `Terminal.tsx`), so every other workspace kept its stale canonical list — a paired Viewer rendered that subset (your 5-of-11 live terminals missing, 74-of-105 persisted tabs orphaned), and creating a tab rewrote the model from the client's subset, which is precisely the "new tab appears, previous one vanishes" shape of §3.

**Safety** — this reuses the exact projection the active-worktree path already runs, whose invariants the reconciliation suite pins:
- a row qualifies for restoration only through `terminalTabHasReconnectablePty` (live attachment or a reconnect map — your orphaned five all carry `ptyId`);
- the orphan sweep still prunes dead rows (`getOrphanTerminalIds` runs on the same state);
- groups/layouts are ensured only when a restoration actually happens;
- an existing canonical entry can never be duplicated (the restore filters to rows the canonical model lacks).

**Testing**

- New `reconcile-hydrated-workspace-tab-models.test.ts` (2 cases): every session workspace is reconciled in session order; a session without rows reconciles nothing.
- The store-level mechanism this wires in is covered by the existing `tabs-model-reconciliation.test.ts` — including `restores live runtime terminal tabs into the unified tab model`, whose shape matches your `c8f7a077` case exactly (row with `ptyId`, empty `unifiedTabs`, empty groups → tab + group + layout restored). 10/10 across both suites.
- `pnpm run typecheck` clean; wiring verified present in `use-app-startup-hydration.ts` (stash check).

Fixes #15710