### PR TITLE
fix(tasks): keep the project selection per task source

### DIFF
--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -381,6 +381,10 @@ import type {
 } from '../../../shared/linear/workspace-types'
 import type { Repo } from '../../../shared/repo-types'
 import type { TaskProvider } from '../../../shared/task-providers'
+import {
+  resolveTaskSourceSelectionSwap,
+  type TaskSourceSelectionStash
+} from './task-source-selection-swap'
 import type { TaskViewPresetId } from '../../../shared/ui-chrome-types'
 import type { PreflightStatus } from '../../../preload/api-types'
 import {
@@ -3227,6 +3231,27 @@ export default function TaskPage(): React.JSX.Element {
   const [taskSource, setTaskSource] = useState<TaskProvider>(
     resolveVisibleTaskProvider(preferredTaskSource, visibleTaskProviders)
   )
+  // Why (#15784): one project selection shared across task tools made every
+  // source switch fetch against the wrong provider (GitHub repos under glab,
+  // GitLab repos with no GitHub source). Stash per source, restore on switch.
+  const repoSelectionBySourceRef = useRef<TaskSourceSelectionStash>({})
+  const lastTaskSourceRef = useRef<TaskProvider>(taskSource)
+  useEffect(() => {
+    const previousSource = lastTaskSourceRef.current
+    if (previousSource === taskSource) {
+      return
+    }
+    lastTaskSourceRef.current = taskSource
+    const swap = resolveTaskSourceSelectionSwap({
+      previousSource,
+      nextSource: taskSource,
+      currentSelection: repoSelection,
+      stash: repoSelectionBySourceRef.current,
+      fallbackSelection: resolvedInitialSelection
+    })
+    repoSelectionBySourceRef.current = swap.stash
+    setRepoSelection(swap.nextSelection)
+  }, [taskSource, repoSelection, resolvedInitialSelection])
   const runtimePreflightMountedRef = useRef(true)
   const runtimePreflightRequestedHostIdsRef = useRef<Set<TaskSourceContext['hostId']>>(new Set())
   const [runtimePreflightStatusByHostId, setRuntimePreflightStatusByHostId] = useState<

--- a/src/renderer/src/components/task-source-selection-swap.test.ts
+++ b/src/renderer/src/components/task-source-selection-swap.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { resolveTaskSourceSelectionSwap } from './task-source-selection-swap'
+
+describe('resolveTaskSourceSelectionSwap', () => {
+  it('stashes the outgoing source selection and restores the incoming source stash', () => {
+    const { stash, nextSelection } = resolveTaskSourceSelectionSwap({
+      previousSource: 'github',
+      nextSource: 'gitlab',
+      currentSelection: new Set(['gh-repo-1', 'gh-repo-2']),
+      stash: { gitlab: new Set(['gl-repo-1']) },
+      fallbackSelection: new Set(['default'])
+    })
+    expect([...stash.github ?? []].sort()).toEqual(['gh-repo-1', 'gh-repo-2'])
+    expect([...nextSelection]).toEqual(['gl-repo-1'])
+  })
+
+  it('falls back to the page initial selection on a source never visited (#15784)', () => {
+    const { stash, nextSelection } = resolveTaskSourceSelectionSwap({
+      previousSource: 'gitlab',
+      nextSource: 'github',
+      currentSelection: new Set(['gl-repo-1']),
+      stash: {},
+      fallbackSelection: new Set(['default-1', 'default-2'])
+    })
+    expect([...stash.gitlab ?? []]).toEqual(['gl-repo-1'])
+    expect([...nextSelection].sort()).toEqual(['default-1', 'default-2'])
+  })
+
+  it('round-trips: switching back restores the first selection untouched', () => {
+    const first = resolveTaskSourceSelectionSwap({
+      previousSource: 'github',
+      nextSource: 'linear',
+      currentSelection: new Set(['gh-1']),
+      stash: {},
+      fallbackSelection: new Set(['default'])
+    })
+    const back = resolveTaskSourceSelectionSwap({
+      previousSource: 'linear',
+      nextSource: 'github',
+      currentSelection: first.nextSelection,
+      stash: first.stash,
+      fallbackSelection: new Set(['default'])
+    })
+    expect([...back.nextSelection]).toEqual(['gh-1'])
+  })
+})

--- a/src/renderer/src/components/task-source-selection-swap.ts
+++ b/src/renderer/src/components/task-source-selection-swap.ts
@@ -1,0 +1,31 @@
+import type { TaskProvider } from '../../../shared/task-providers'
+
+export type TaskSourceSelectionStash = Partial<Record<TaskProvider, ReadonlySet<string>>>
+
+/**
+ * Resolve a task-source switch's selection swap (#15784).
+ *
+ * The Tasks page keeps one project selection, but the tools it drives are
+ * provider-specific: a repo selected for GitLab has no GitHub source and a
+ * GitHub repo has no GitLab remote, so sharing one selection across tools made
+ * every switch run fetches against the wrong provider. The swap stashes the
+ * outgoing source's selection and restores the incoming source's own stash —
+ * or the page's initial selection the first time that source is visited.
+ */
+export function resolveTaskSourceSelectionSwap(args: {
+  previousSource: TaskProvider
+  nextSource: TaskProvider
+  currentSelection: ReadonlySet<string>
+  stash: TaskSourceSelectionStash
+  fallbackSelection: ReadonlySet<string>
+}): { stash: TaskSourceSelectionStash; nextSelection: ReadonlySet<string> } {
+  const nextStash: TaskSourceSelectionStash = {
+    ...args.stash,
+    [args.previousSource]: args.currentSelection
+  }
+  const stashed = nextStash[args.nextSource]
+  return {
+    stash: nextStash,
+    nextSelection: stashed ?? args.fallbackSelection
+  }
+}


### PR DESCRIPTION
## Summary

**What**

Switching task sources (GitHub / GitLab / Linear / Jira) now stashes the outgoing source's project selection and restores the incoming source's own stash — or the page's initial selection the first time that source is visited. Selection changes within one tool are untouched.

Implemented as a small pure helper (`resolveTaskSourceSelectionSwap`) wired into one effect next to the `taskSource` state, storing per-source selections in a ref — no store or persistence changes.

**Why**

#15784 — the Tasks screen's project filter was one shared selection across every tool, but the tools are provider-specific: a repo selected for GitLab has no GitHub source ("No GitHub source detected for xxx") and a GitHub repo has no GitLab remote (`glab … None of the git remotes configured for this repository point to a known GitLab host`). With projects from two Git servers, every tab showed the other server's errors. Scoping the selection per source is exactly the reporter's proposed solution.

**Testing**

- New `task-source-selection-swap.test.ts` (3 cases): stash + restore across a switch; first visit falls back to the page's initial selection; a round-trip (GitHub → Linear → GitHub) restores the original selection untouched. 3/3.
- `task-page-cache-selectors.test.ts` 17/17 unchanged; `pnpm run typecheck` clean.

Fixes #15784