### PR TITLE
feat(i18n): localize Orca Account settings and navigation to Korean

### DIFF
--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -10161,6 +10161,28 @@
           "updateServer": "소스 기본값을 구성하려면 이 서버를 업데이트하세요.",
           "updateServerDefaults": "표시 기본값을 구성하려면 이 서버를 업데이트하세요."
         },
+        "orcaAccount": {
+          "connected": "연결됨",
+          "reconnectRequired": "세션이 만료되었습니다. 클라우드 기능을 사용하려면 다시 로그인하세요.",
+          "unavailable": "이 빌드에서는 Orca 로그인을 사용할 수 없습니다.",
+          "signedOut": "로그인하여 아티팩트 및 Orca Relay를 비롯한 클라우드 기능으로 Orca를 확장하세요.",
+          "checking": "계정 상태 확인 중…",
+          "account": "Orca 계정",
+          "signOut": "로그아웃",
+          "signingIn": "로그인 중…",
+          "signInAgain": "다시 로그인",
+          "signIn": "Orca 로그인",
+          "title": "Orca 계정",
+          "description": "작업을 즉시 공유하고 어디서나 Orca Mobile로 데스크톱에 연결하세요.",
+          "searchDescription": "아티팩트 및 Orca Relay에서 사용하는 계정에 로그인하거나 로그아웃합니다.",
+          "benefitsTitle": "계정에 포함된 기능",
+          "artifactsTitle": "아티팩트 공유",
+          "artifactsDescription": "HTML 및 Markdown 파일을 게시하고 Orca에서 모든 공유 링크를 관리합니다.",
+          "relayTitle": "Orca Relay",
+          "relayDescription": "셀룰러 또는 모든 Wi-Fi 네트워크를 통해 Orca Mobile을 이 데스크톱에 연결합니다.",
+          "skillsTitle": "스킬 공유",
+          "skillsDescription": "단일 스킬 또는 전체 세트를 비공개 링크로 공유하고 사용하는 모든 기기에 설치하세요."
+        },
         "automations": {
           "title": "자동화",
           "description": "에이전트 작업을 예약하고 사이드바에 자동화 표시 여부를 선택합니다.",


### PR DESCRIPTION
## ELI5

The Orca Account menu item and its settings page were displaying in English even when the app language was set to Korean. This PR adds the missing Korean translations so everything in Settings → Orca Account appears naturally in Korean.

## What Changed

Added 20 missing Korean localization keys in `src/renderer/src/i18n/locales/ko.json`:
- **Settings Navigation & Search** (keys in `auto.components.settings.orcaAccount`): Localizes the Settings sidebar menu item title ("Orca 계정"), description, and search metadata.
- **Orca Account Settings Pane** (keys in `auto.components.settings.orcaAccount`): Localizes connection statuses, sign-in/sign-out buttons, account benefits section ("계정에 포함된 기능"), and the three benefit cards

Kept the change strictly scoped to `ko.json` (no source code, English source, or other locale files touched), consistent with the sparse-target-catalog architecture in `config/i18n-translation-source.md`

## Why

In `src/renderer/src/hooks/useSettingsNavigationMetadata.ts`, `OrcaAccountSettingsPane.tsx`, and `Settings.tsx`, translations are requested via `auto.components.settings.orcaAccount.*`.

`ko.json` lacked these keys, causing i18next to fall back to inline English defaults. Adding these translations restores complete Korean localization for the Orca Account settings workflow.


## Linked Issue

Fixes #15846

## Visual Proof

|before|after|
|---|---|
|<img width="877" height="427" alt="image" src="https://github.com/user-attachments/assets/91c4aec3-4d80-45de-b68e-e0774d0d9560" />|<img width="1214" height="616" alt="image" src="https://github.com/user-attachments/assets/8d60bc61-a6f5-4714-9531-4cef4e253f0e" />|


## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Developed and validated with Gemini 3.7 Flash via Antigravity pair-programming agent. All Korean translations were reviewed against existing `ko.json` catalog conventions and terminology policies.

## Review

- **Cross-platform**: UI-only text additions to `ko.json`. No platform-specific branching, shortcuts, shell scripts, or Electron APIs touched.
- **SSH / Remote / Local**: Pure renderer translation data with zero runtime execution impact.
- **Catalog Integrity**: All 20 keys match `en.json` exact structure. No interpolation placeholder discrepancies.


## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Security**: No risk — pure static translation JSON data. No user input handling, command execution, auth, secrets, or IPC changes.
- **Cross-platform support**: Consumed identically across macOS, Linux, and Windows.
- **Terminology**: Follows existing `ko.json` polite register (`-합니다` descriptions, `-하세요` guides) and established terms (아티팩트, 스킬, 바로가기, 연결).

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
