### PR TITLE
fix(worktree): drop a just-added fork remote when its head fetch fails

### DIFF
--- a/src/main/ipc/worktree-push-target-setup.test.ts
+++ b/src/main/ipc/worktree-push-target-setup.test.ts
@@ -32,6 +32,10 @@ function makeRepoExec(remotes: Record<string, string>): ExecMock {
       remotes[args[2]!] = args[3]!
       return { stdout: '', stderr: '' }
     }
+    if (args[0] === 'remote' && args[1] === 'remove') {
+      delete remotes[args[2]!]
+      return { stdout: '', stderr: '' }
+    }
     return { stdout: '', stderr: '' }
   })
 }
@@ -182,5 +186,56 @@ describe('configureCreatedWorktreePushTargetWithExec', () => {
       '/wt/path'
     )
     expect(result).toBe(target)
+  })
+})
+
+describe('prepareWorktreePushTargetWithExec rollback', () => {
+  it('removes the remote it just added when the fetch fails', async () => {
+    const remotes: Record<string, string> = { origin: 'git@github.com:stablyai/orca.git' }
+    const exec = vi.fn<GitRemoteExec>(async (args: string[]) => {
+      if (args[0] === 'fetch') {
+        throw new Error('network unreachable')
+      }
+      return makeRepoExec(remotes)(args, REPO)
+    })
+
+    await expect(
+      prepareWorktreePushTargetWithExec(
+        exec,
+        REPO,
+        { remoteName: 'pr-contributor-orca', branchName: 'contributor/fix', remoteUrl: FORK_SSH },
+        () => false
+      )
+    ).rejects.toThrow('network unreachable')
+
+    expect(callsMatching(exec, ['remote', 'remove'])).toEqual([
+      ['remote', 'remove', 'pr-contributor-orca']
+    ])
+    expect(remotes).not.toHaveProperty('pr-contributor-orca')
+  })
+
+  it('keeps a reused remote Orca did not add when the fetch fails', async () => {
+    const remotes: Record<string, string> = {
+      origin: 'git@github.com:stablyai/orca.git',
+      existing: FORK_SSH
+    }
+    const exec = vi.fn<GitRemoteExec>(async (args: string[]) => {
+      if (args[0] === 'fetch') {
+        throw new Error('network unreachable')
+      }
+      return makeRepoExec(remotes)(args, REPO)
+    })
+
+    await expect(
+      prepareWorktreePushTargetWithExec(
+        exec,
+        REPO,
+        { remoteName: 'pr-contributor-orca', branchName: 'contributor/fix', remoteUrl: FORK_SSH },
+        () => false
+      )
+    ).rejects.toThrow('network unreachable')
+
+    expect(callsMatching(exec, ['remote', 'remove'])).toEqual([])
+    expect(remotes.existing).toBe(FORK_SSH)
   })
 })

--- a/src/main/ipc/worktree-push-target-setup.ts
+++ b/src/main/ipc/worktree-push-target-setup.ts
@@ -95,14 +95,24 @@ export async function prepareWorktreePushTargetWithExec(
     }
   }
 
-  await execGit(
-    [
-      'fetch',
-      remoteName,
-      `+refs/heads/${target.branchName}:refs/remotes/${remoteName}/${target.branchName}`
-    ],
-    repoPath
-  )
+  try {
+    await execGit(
+      [
+        'fetch',
+        remoteName,
+        `+refs/heads/${target.branchName}:refs/remotes/${remoteName}/${target.branchName}`
+      ],
+      repoPath
+    )
+  } catch (error) {
+    // Why: the create this remote was added for is failing; leaving it behind
+    // orphans a pr-* remote nothing will ever clean up (cleanup runs on worktree
+    // removal, and no worktree exists).
+    if (remoteCreated) {
+      await execGit(['remote', 'remove', remoteName], repoPath).catch(() => {})
+    }
+    throw error
+  }
   return {
     ...sanitizedTarget,
     remoteName,

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -1113,12 +1113,21 @@ async function prepareWorktreePushTargetSsh(
       remoteCreated = true
     }
   }
-  await provider.fetchRemoteTrackingRef(
-    repoPath,
-    remoteName,
-    target.branchName,
-    `refs/remotes/${remoteName}/${target.branchName}`
-  )
+  try {
+    await provider.fetchRemoteTrackingRef(
+      repoPath,
+      remoteName,
+      target.branchName,
+      `refs/remotes/${remoteName}/${target.branchName}`
+    )
+  } catch (error) {
+    // Why: mirrors the local path — a fetch failure aborts the create, so the
+    // remote we just added on the host would be orphaned with no owner to clean it.
+    if (remoteCreated) {
+      await provider.exec(['remote', 'remove', remoteName], repoPath).catch(() => {})
+    }
+    throw error
+  }
   return { ...sanitizedTarget, remoteName, ...(remoteCreated ? { remoteCreated: true } : {}) }
 }
 

--- a/src/main/ipc/worktrees-ssh-fork-push-target-remote.test.ts
+++ b/src/main/ipc/worktrees-ssh-fork-push-target-remote.test.ts
@@ -211,4 +211,59 @@ describe('registerWorktreeHandlers', () => {
     ).rejects.toThrow('Reconnect to deploy the latest relay')
     expect(provider.addWorktree).not.toHaveBeenCalled()
   })
+
+  it('drops the fork remote it just added when the SSH head fetch fails', async () => {
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/repo',
+      displayName: 'ssh',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1',
+      worktreeBaseRef: 'origin/main'
+    }
+    const exec = vi.fn().mockImplementation(async (args: string[]) => {
+      validateGitExecArgs(args)
+      if (args[0] === 'remote' && args[1] === 'get-url') {
+        return { stdout: 'git@github.com:stablyai/orca.git\n', stderr: '' }
+      }
+      if (args[0] === 'remote' && args.length === 1) {
+        return { stdout: 'origin\n', stderr: '' }
+      }
+      return { stdout: '', stderr: '' }
+    })
+    const provider = {
+      exec,
+      fetchRemoteTrackingRef: vi
+        .fn()
+        .mockImplementation(async (_repoPath: string, remote: string) => {
+          if (remote === 'pr-contributor-orca') {
+            throw new Error('network unreachable')
+          }
+        }),
+      addWorktree: vi.fn().mockResolvedValue(undefined),
+      listWorktrees: vi.fn().mockResolvedValue([])
+    }
+    const mux = { request: vi.fn().mockResolvedValue(undefined), notify: vi.fn() }
+    store.getRepos.mockReturnValue([repo])
+    store.getRepo.mockReturnValue(repo)
+    getSshGitProviderMock.mockReturnValue(provider)
+    getActiveMultiplexerMock.mockReturnValue(mux)
+
+    await expect(
+      handlers['worktrees:create'](null, {
+        repoId: 'repo-ssh',
+        name: 'contributor-fix',
+        branchNameOverride: 'contributor/fix',
+        pushTarget: {
+          remoteName: 'pr-contributor-orca',
+          branchName: 'contributor/fix',
+          remoteUrl: 'https://github.com/contributor/orca.git'
+        }
+      })
+    ).rejects.toThrow('network unreachable')
+
+    expect(exec).toHaveBeenCalledWith(['remote', 'remove', 'pr-contributor-orca'], '/remote/repo')
+    expect(provider.addWorktree).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​110 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​110 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​33 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​19 |

<!-- /orca-pr-loc -->

## ELI5

Follow-up to #15827. When Orca sets up a workspace for a fork PR it does two things in a row: "remember where this contributor's copy lives" (`git remote add`), then "go download their branch" (`git fetch`). If the download fails — flaky network, private fork, deleted branch — the whole workspace creation gives up, but the remote we just wrote stayed in the repo forever. Nothing ever cleaned it up, because the cleanup only runs when you delete a workspace and no workspace was ever created. Retry three times, get three junk `pr-*` remotes.

Now, if the fetch fails, we take the remote back out.

## Detail

`prepareWorktreePushTargetWithExec` (local) and `prepareWorktreePushTargetSsh` (SSH) both `remote add` then fetch, with no rollback. Flagged as a P2 residual during the readiness review of #15827; the SSH path only became reachable in that PR, so this is a good time to fix both.

Rollback is gated on `remoteCreated` — the flag already tracking whether *this call* added the remote — so a reused remote is never touched, whether Orca created it earlier or the user added it by hand. The rollback itself is best-effort (`.catch(() => {})`) so it can't mask the fetch error that actually aborted the create.

## Tests

- `worktree-push-target-setup.test.ts` — the local path removes a remote it just added on fetch failure, and leaves a reused remote alone. The stateful fake git now models `remote remove`, so the assertion is on real resulting state, not just the argv.
- `worktrees-ssh-fork-push-target-remote.test.ts` — same for SSH through `worktrees:create`, with the provider's `exec` still routed through the real relay validator, and `addWorktree` asserted never to run.

Verified: full `src/relay` + `src/main/ipc` + `src/shared` suites (9,775 tests), `oxlint`, `tsc -p config/tsconfig.node.json`.
