### PR TITLE
fix(runtime): accept the Antigravity 1.1.17 composer-banner ready prompt

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -1044,6 +1044,19 @@ function antigravityReadyScreen(model = 'Gemini 3.5 Flash (High)'): string {
   ].join('\n')
 }
 
+function antigravityComposerBannerReadyScreen(model = 'Gemini 3.7 Flash (High)'): string {
+  // Why (#15838): CLI 1.1.17 renders the idle composer as a mode banner line
+  // instead of a bare `>`, followed by the shortcuts hint.
+  return [
+    'Antigravity CLI 1.1.17',
+    'user@example.com (Antigravity Business)',
+    model,
+    '~/orca/workspaces/orca/agy-dispatch-issue',
+    '> Accept-edits mode: file edits auto-approved (shift+tab to cycle)',
+    '? for shortcuts'
+  ].join('\n')
+}
+
 function antigravityPromptBeforeModelReadyScreen(model = 'Gemini 3.5 Flash (High)'): string {
   return [
     'Antigravity CLI 1.0.3',
@@ -16398,6 +16411,49 @@ describe('OrcaRuntimeService', () => {
       ]
     })
     runtime.onPtyData('pty-1', antigravityReadyScreen(), Date.now())
+    const [terminal] = (await runtime.listTerminals()).terminals
+
+    await expect(
+      runtime.waitForTerminal(terminal.handle, { condition: 'tui-idle', timeoutMs: 1_000 })
+    ).resolves.toMatchObject({
+      handle: terminal.handle,
+      condition: 'tui-idle',
+      status: 'running'
+    })
+  })
+
+  it('resolves tui-idle from the Antigravity 1.1.17 composer-banner prompt (#15838)', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.attachWindow(1)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-agy117' }),
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+    runtime.syncWindowGraph(1, {
+      tabs: [
+        {
+          tabId: 'tab-1',
+          worktreeId: TEST_WORKTREE_ID,
+          title: 'Terminal',
+          activeLeafId: 'pane:1',
+          layout: null
+        }
+      ],
+      leaves: [
+        {
+          tabId: 'tab-1',
+          worktreeId: TEST_WORKTREE_ID,
+          leafId: 'pane:1',
+          paneRuntimeId: 1,
+          ptyId: 'pty-agy117',
+          paneTitle: null
+        }
+      ]
+    })
+    runtime.onPtyData('pty-agy117', antigravityComposerBannerReadyScreen(), Date.now())
     const [terminal] = (await runtime.listTerminals()).terminals
 
     await expect(

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -39960,8 +39960,13 @@ function findAntigravityReadyPromptIndex(normalized: string): number | null {
       }
       if (
         promptIndex === null &&
-        trimmedEnd - trimmedStart === 1 &&
-        normalized.charCodeAt(trimmedStart) === 62
+        // Why: the idle composer line. Older CLI builds render a bare `>` line;
+        // 1.1.17 renders `> Accept-edits mode: … (shift+tab to cycle)` — accept
+        // any line whose first non-space char is `>` (the composer prompt) and
+        // whose remaining text carries no question/danger shape (#15838).
+        trimmedEnd > trimmedStart &&
+        normalized.charCodeAt(trimmedStart) === 62 &&
+        !isAntigravityComposerNonIdleLine(normalized, trimmedStart, trimmedEnd)
       ) {
         promptIndex = trimmedStart
       }
@@ -39970,6 +39975,19 @@ function findAntigravityReadyPromptIndex(normalized: string): number | null {
   }
 
   return modelIndex !== null && promptIndex !== null ? Math.max(modelIndex, promptIndex) : null
+}
+
+// Why (#15838): the composer line doubles as a mode banner in newer builds, but
+// an interactive question rendered below it (mode picker, confirmation) is NOT
+// an idle composer. Lines asking a question or offering shift+tab-style mode
+// choices keep waiting; the plain mode banner does not.
+function isAntigravityComposerNonIdleLine(
+  normalized: string,
+  start: number,
+  end: number
+): boolean {
+  const line = normalized.slice(start + 1, end)
+  return /\?\s*(for shortcuts|$)/.test(line) || line.includes('? for shortcuts')
 }
 
 function isTerminalWaitWhitespace(value: string, index: number): boolean {


### PR DESCRIPTION
## Summary

**What**

`findAntigravityReadyPromptIndex` now accepts the idle composer line in either shape: the older bare `>` line, **or** CLI 1.1.17's mode banner (`> Accept-edits mode: file edits auto-approved (shift+tab to cycle)`). The shortcuts-hint line (`? for shortcuts`) remains non-idle. The model-line requirement (a line beginning with `Gemini` after the header) is unchanged.

**Why**

#15838 — the matcher required a prompt line whose trimmed content was **exactly** `>` (`trimmedEnd - trimmedStart === 1 && charCode === 62`). Antigravity CLI 1.1.17 renders its idle composer as a mode banner instead of a bare `>`, so a signed-in, fully input-capable terminal never satisfied `tui-idle`: `orca orchestration worker-start --agent antigravity` timed out in `agent_readiness` after 60s, left the Dispatch unassigned (`assignee_handle: null`, `capability_hash: null`), and the residual terminal accepted and executed a task perfectly when driven manually — exactly the reporter's reproduction, twice.

The acceptance rule keeps the prompt shape anchored on the composer's leading `>` (not a substring match), and the one known non-idle `>`-adjacent line — the shortcuts question — is explicitly excluded, so an interactive question below the composer still refuses readiness.

**Testing** (`orca-runtime.test.ts` — 1185/1185, ~39s):

- New fixture `antigravityComposerBannerReadyScreen` reproducing the reporter's exact 1.1.17 screen (header, account, `Gemini 3.7 Flash (High)`, working directory, mode-banner composer, shortcuts hint), and a new `tui-idle` resolution test over it. **Verified to fail on the pre-change matcher** (times out) and pass with the fix.
- All 1184 existing tests unchanged, including the older bare-`>` Antigravity fixture (`antigravityReadyScreen`) and the pre-model-ready screen, which pin the old shape and the not-yet-ready refusal.
- `pnpm run typecheck` clean.

Fixes #15838