### PR TITLE
Move worktree palette search to top of sidebar nav

### DIFF
--- a/src/renderer/src/components/sidebar/SidebarNav.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarNav.test.tsx
@@ -429,6 +429,20 @@ describe('SidebarNav', () => {
     expect(mocks.updateSettings).toHaveBeenCalledWith({ showMobileButton: false })
   })
 
+  it('places the worktree palette search above the sidebar nav rows', async () => {
+    const container = await renderSidebarNav()
+    const nav = container.querySelector('[data-contextual-tour-target="sidebar-navigation"]')
+    const searchButton = container.querySelector(
+      'button[aria-label="Search worktrees and browser tabs"]'
+    )
+    const tasksButton = getButtonByText(container, 'Tasks')
+
+    expect(nav?.firstElementChild).toBe(searchButton)
+    expect(
+      searchButton?.compareDocumentPosition(tasksButton) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+  })
+
   it('hides the worktree palette shortcut until the search field is hovered or focused', async () => {
     const container = await renderSidebarNav()
 
@@ -439,8 +453,8 @@ describe('SidebarNav', () => {
 
     const shortcuts = searchButton?.querySelector('span.hidden')
     expect(shortcuts?.className).toContain('hidden')
-    expect(shortcuts?.className).toContain('group-hover:inline-flex')
-    expect(shortcuts?.className).toContain('group-focus-within:inline-flex')
+    expect(shortcuts?.className).toContain('group-hover:flex')
+    expect(shortcuts?.className).toContain('group-focus-within:flex')
     expect(shortcuts?.textContent).toContain('⌘')
     expect(shortcuts?.textContent).toContain('J')
     expect(searchButton?.querySelector('kbd')).toBeNull()

--- a/src/renderer/src/components/sidebar/SidebarNav.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarNav.test.tsx
@@ -432,14 +432,17 @@ describe('SidebarNav', () => {
   it('places the worktree palette search above the sidebar nav rows', async () => {
     const container = await renderSidebarNav()
     const nav = container.querySelector('[data-contextual-tour-target="sidebar-navigation"]')
-    const searchButton = container.querySelector(
+    const searchButton = container.querySelector<HTMLButtonElement>(
       'button[aria-label="Search worktrees and browser tabs"]'
     )
     const tasksButton = getButtonByText(container, 'Tasks')
 
     expect(nav?.firstElementChild).toBe(searchButton)
+    if (!searchButton) {
+      throw new Error('worktree palette search button not rendered')
+    }
     expect(
-      searchButton?.compareDocumentPosition(tasksButton) & Node.DOCUMENT_POSITION_FOLLOWING
+      searchButton.compareDocumentPosition(tasksButton) & Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy()
   })
 

--- a/src/renderer/src/components/sidebar/SidebarNav.tsx
+++ b/src/renderer/src/components/sidebar/SidebarNav.tsx
@@ -106,6 +106,35 @@ const SidebarNav = React.memo(function SidebarNav() {
       className="flex flex-col gap-0.5 px-2 pt-2 pb-1"
       data-contextual-tour-target="sidebar-navigation"
     >
+      <button
+        type="button"
+        onClick={() => openModal('worktree-palette')}
+        aria-label={translate(
+          'auto.components.sidebar.SidebarNav.0c3395fd32',
+          'Search worktrees and browser tabs'
+        )}
+        className="group flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium tracking-tight text-worktree-sidebar-foreground/60 transition-colors hover:bg-worktree-sidebar-foreground/8"
+      >
+        <Search
+          className="size-4 shrink-0 text-worktree-sidebar-foreground/30"
+          strokeWidth={1.75}
+        />
+        <span className="flex-1">
+          {translate('auto.components.sidebar.SidebarNav.80611a8b10', 'Search')}
+        </span>
+        <span className="pointer-events-none hidden shrink-0 items-center gap-1 group-hover:flex group-focus-within:flex">
+          {worktreePaletteShortcutCombos.map((combo) => (
+            <ShortcutKeyCombo
+              key={combo.keys.join('-')}
+              keys={combo.keys}
+              doubleTap={combo.doubleTap}
+              className="inline-flex gap-0.5"
+              keyCapClassName="min-w-4 border-worktree-sidebar-border/80 bg-worktree-sidebar-foreground/8 px-1 py-px text-[9px] text-worktree-sidebar-foreground/55 shadow-none"
+              separatorClassName="text-[9px] text-worktree-sidebar-foreground/45"
+            />
+          ))}
+        </span>
+      </button>
       <SetupGuideSidebarEntry />
       <SidebarTaskNavButton />
       {showArtifactsButton ? (
@@ -302,35 +331,6 @@ const SidebarNav = React.memo(function SidebarNav() {
           <HideSidebarMenu onHide={hideMobileButton} />
         </ContextMenu>
       ) : null}
-      <button
-        type="button"
-        onClick={() => openModal('worktree-palette')}
-        aria-label={translate(
-          'auto.components.sidebar.SidebarNav.0c3395fd32',
-          'Search worktrees and browser tabs'
-        )}
-        className="group relative flex h-7 w-full items-center rounded-md border border-worktree-sidebar-border/70 bg-worktree-sidebar-foreground/5 pl-7 pr-1.5 text-left text-[12px] font-medium tracking-tight text-worktree-sidebar-foreground/45 transition-colors hover:border-worktree-sidebar-border hover:bg-worktree-sidebar-foreground/8 hover:text-worktree-sidebar-foreground/60 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-worktree-sidebar-ring/50"
-      >
-        <Search
-          className="pointer-events-none absolute left-2 top-1/2 size-3 -translate-y-1/2 text-worktree-sidebar-foreground/30"
-          strokeWidth={1.75}
-        />
-        <span className="min-w-0 flex-1 truncate">
-          {translate('auto.components.sidebar.SidebarNav.80611a8b10', 'Search')}
-        </span>
-        <span className="pointer-events-none ml-1.5 hidden shrink-0 items-center gap-1.5 group-hover:inline-flex group-focus-within:inline-flex">
-          {worktreePaletteShortcutCombos.map((combo) => (
-            <ShortcutKeyCombo
-              key={combo.keys.join('-')}
-              keys={combo.keys}
-              doubleTap={combo.doubleTap}
-              className="inline-flex gap-0.5"
-              keyCapClassName="min-w-4 border-worktree-sidebar-border/80 bg-worktree-sidebar-foreground/8 px-1 py-px text-[9px] text-worktree-sidebar-foreground/55 shadow-none"
-              separatorClassName="text-[9px] text-worktree-sidebar-foreground/45"
-            />
-          ))}
-        </span>
-      </button>
     </div>
   )
 })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​19 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​17 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​29 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​29 | 0 |

<!-- /orca-pr-loc -->

## Problem

The worktree palette search button was positioned at the bottom of the sidebar navigation, making it less discoverable and requiring users to scroll through the menu to access this frequently-used feature.

## Solution

Moved the worktree palette search button to the top of the sidebar navigation, immediately after the nav container opens. This makes it the first visible option and improves discoverability. Simplified the styling to integrate it as a regular nav item rather than a separate input-like element at the bottom.

## ELI5

The search button for finding worktrees is now at the top of the sidebar instead of the bottom, so it's easier to find and use.

## What Changed

- Moved worktree palette search button from bottom to top of SidebarNav component
- Updated styling from bordered input appearance to integrated nav button style
- Added test verifying search button is positioned first in navigation
- Updated test expectations for shortcut visibility classes

## Why

Top-level placement improves discoverability and emphasizes this frequently-used feature. The simplified styling makes it feel like a natural sidebar item rather than a separate search input.

## Linked Issue

Fixes #

## Visual Proof

N/A — This is a sidebar reorganization. The search button's functionality and labels remain unchanged; only position and styling were adjusted.

## Testing

- Added test case "places the worktree palette search above the sidebar nav rows" verifying DOM positioning and order
- Updated existing test expectations for shortcut visibility classes
- [ ] I manually tested these changes locally
- [ ] Automated tests added/updated, or explained why not below

## AI Disclosure

<!-- DO NOT FILL IN IF YOU ARE STABLYAI TEAM MEMBER (INTERNAL CONTRIBUTOR), IGNORE SECTION: -->
<!-- Which AI model if anyone was used, please state the details -->

## Review

## Agent skill upstream boundary

- [ ] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [ ] Self-reviewed for correctness, security, and performance
- [ ] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)