### PR TITLE
fix(checks): roll up cancelled checks as their own muted aggregate verdict

### DIFF
--- a/src/renderer/src/components/github-item-dialog/inspect-pull-request/checks-tab-summary.ts
+++ b/src/renderer/src/components/github-item-dialog/inspect-pull-request/checks-tab-summary.ts
@@ -15,9 +15,11 @@ export function getChecksTabSummaryPresentation(counts: ReturnType<typeof getChe
         ? CHECK_ICON.action_required
         : counts.pending > 0
           ? CHECK_ICON.pending
-          : counts.passing > 0
-            ? CHECK_ICON.success
-            : CircleDashed
+          : counts.cancelled > 0
+            ? CHECK_ICON.cancelled
+            : counts.passing > 0
+              ? CHECK_ICON.success
+              : CircleDashed
   const summaryColor =
     counts.failing > 0
       ? CHECK_COLOR.failure
@@ -25,8 +27,10 @@ export function getChecksTabSummaryPresentation(counts: ReturnType<typeof getChe
         ? CHECK_COLOR.action_required
         : counts.pending > 0
           ? CHECK_COLOR.pending
-          : counts.passing > 0
-            ? CHECK_COLOR.success
-            : 'text-muted-foreground'
+          : counts.cancelled > 0
+            ? CHECK_COLOR.cancelled
+            : counts.passing > 0
+              ? CHECK_COLOR.success
+              : 'text-muted-foreground'
   return { SummaryIcon, summaryColor }
 }

--- a/src/renderer/src/components/pr-check-counts.test.ts
+++ b/src/renderer/src/components/pr-check-counts.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { getCheckCounts, getChecksSummaryLabel } from './pr-check-counts'
+import { getCheckCountChips, getCheckCounts, getChecksSummaryLabel } from './pr-check-counts'
 import {
   getProviderChecksLabel,
   summarizeProviderChecks
@@ -27,6 +27,7 @@ describe('getCheckCounts', () => {
       failing: 0,
       needsAction: 0,
       pending: 0,
+      cancelled: 0,
       neutral: 0
     })
     expect(getChecksSummaryLabel(checks)).toBe('All checks passing')
@@ -42,6 +43,7 @@ describe('getCheckCounts', () => {
       failing: 1,
       needsAction: 1,
       pending: 0,
+      cancelled: 0,
       neutral: 0
     })
     expect(getChecksSummaryLabel([check('action_required')])).toBe('1 check needs action')
@@ -58,6 +60,7 @@ describe('getCheckCounts', () => {
       failing: 0,
       needsAction: 0,
       pending: 1,
+      cancelled: 0,
       neutral: 1
     })
     expect(getChecksSummaryLabel(checks)).toBe('1 check pending')
@@ -73,6 +76,7 @@ describe('getCheckCounts', () => {
       failing: 0,
       needsAction: 0,
       pending: 0,
+      cancelled: 0,
       neutral: 1
     })
     expect(getChecksSummaryLabel(checks)).toBe('0 of 1 checks passing')
@@ -80,5 +84,31 @@ describe('getCheckCounts', () => {
 
   it('reports no checks for an empty list', () => {
     expect(getChecksSummaryLabel([])).toBe('No checks found')
+  })
+
+  // Why: a cancellation blocks the merge but is not a defect — counting it under `failing` made
+  // the check tabs call a deliberately stopped run "1 failing" (#15847).
+  it('counts cancelled checks in their own bucket, never as failing', () => {
+    const checks = [check('cancelled', 'build'), check('success', 'lint')]
+
+    expect(getCheckCounts(checks)).toEqual({
+      passing: 1,
+      failing: 0,
+      needsAction: 0,
+      pending: 0,
+      cancelled: 1,
+      neutral: 0
+    })
+    expect(getChecksSummaryLabel(checks)).toBe('1 check cancelled')
+    expect(getProviderChecksLabel(summarizeProviderChecks(checks))).toBe('1 cancelled')
+    expect(getCheckCountChips(getCheckCounts(checks))).toContainEqual({
+      tone: 'cancelled',
+      label: '1 cancelled'
+    })
+  })
+
+  it('still labels a set with a real failure as failing when cancellations ride along', () => {
+    const checks = [check('cancelled', 'build'), check('failure', 'test')]
+    expect(getChecksSummaryLabel(checks)).toBe('1 check failing')
   })
 })

--- a/src/renderer/src/components/pr-check-counts.ts
+++ b/src/renderer/src/components/pr-check-counts.ts
@@ -7,6 +7,7 @@ export type PRCheckCounts = {
   failing: number
   needsAction: number
   pending: number
+  cancelled: number
   neutral: number
 }
 
@@ -34,13 +35,14 @@ export function getCheckCounts(checks: readonly PRCheckDetail[]): PRCheckCounts 
     failing: summary.failed - needsAction,
     needsAction,
     pending: summary.pending,
+    cancelled: summary.cancelled ?? 0,
     neutral: summary.neutral
   }
 }
 
 /** `tone` keys the caller's `CHECK_COLOR`/`CHECK_ICON` maps so styling stays with the surface. */
 export type PRCheckCountChip = {
-  tone: 'success' | 'failure' | 'action_required' | 'pending' | 'neutral'
+  tone: 'success' | 'failure' | 'action_required' | 'pending' | 'cancelled' | 'neutral'
   label: string
 }
 
@@ -85,6 +87,14 @@ export function getCheckCountChips(counts: PRCheckCounts): PRCheckCountChip[] {
       })
     })
   }
+  if (counts.cancelled > 0) {
+    chips.push({
+      tone: 'cancelled',
+      label: translate('auto.components.pr-check-counts.cancelledChip', '{{value0}} cancelled', {
+        value0: counts.cancelled
+      })
+    })
+  }
   if (counts.neutral > 0) {
     chips.push({
       tone: 'neutral',
@@ -110,6 +120,10 @@ export function getChecksSummaryLabel(checks: readonly PRCheckDetail[]): string 
   }
   if (counts.pending > 0) {
     return `${counts.pending} ${counts.pending === 1 ? 'check' : 'checks'} pending`
+  }
+  // Why: cancelled blocks the merge but is not a defect — it must not read as failing (#15847).
+  if (counts.cancelled > 0) {
+    return `${counts.cancelled} ${counts.cancelled === 1 ? 'check' : 'checks'} cancelled`
   }
   if (counts.passing === checks.length) {
     return 'All checks passing'

--- a/src/renderer/src/components/provider-check-classification-parity.test.ts
+++ b/src/renderer/src/components/provider-check-classification-parity.test.ts
@@ -83,32 +83,32 @@ const PARITY_CASES: ParityCase[] = [
   {
     name: 'all success',
     checks: [completed('success'), completed('success')],
-    expected: { state: 'success', passed: 2, failed: 0, pending: 0, neutral: 0 }
+    expected: { state: 'success', passed: 2, failed: 0, pending: 0, cancelled: 0, neutral: 0 }
   },
   {
     name: 'success plus skipped',
     checks: [completed('success'), completed('skipped')],
-    expected: { state: 'success', passed: 2, failed: 0, pending: 0, neutral: 0 }
+    expected: { state: 'success', passed: 2, failed: 0, pending: 0, cancelled: 0, neutral: 0 }
   },
   {
     name: 'all skipped',
     checks: [completed('skipped'), completed('skipped')],
-    expected: { state: 'success', passed: 2, failed: 0, pending: 0, neutral: 0 }
+    expected: { state: 'success', passed: 2, failed: 0, pending: 0, cancelled: 0, neutral: 0 }
   },
   {
     name: 'success plus neutral',
     checks: [completed('success'), completed('neutral')],
-    expected: { state: 'success', passed: 1, failed: 0, pending: 0, neutral: 1 }
+    expected: { state: 'success', passed: 1, failed: 0, pending: 0, cancelled: 0, neutral: 1 }
   },
   {
     name: 'all neutral',
     checks: [completed('neutral')],
-    expected: { state: 'neutral', passed: 0, failed: 0, pending: 0, neutral: 1 }
+    expected: { state: 'neutral', passed: 0, failed: 0, pending: 0, cancelled: 0, neutral: 1 }
   },
   {
     name: 'success plus failure',
     checks: [completed('success'), completed('failure')],
-    expected: { state: 'failure', passed: 1, failed: 1, pending: 0, neutral: 0 }
+    expected: { state: 'failure', passed: 1, failed: 1, pending: 0, cancelled: 0, neutral: 0 }
   },
   {
     name: 'success plus running',
@@ -116,13 +116,14 @@ const PARITY_CASES: ParityCase[] = [
       completed('success'),
       { name: 'ci', status: 'in_progress', conclusion: null, url: null }
     ],
-    expected: { state: 'pending', passed: 1, failed: 0, pending: 1, neutral: 0 }
+    expected: { state: 'pending', passed: 1, failed: 0, pending: 1, cancelled: 0, neutral: 0 }
   },
   gitLabCase('GitLab manual gate only', ['manual'], {
     state: 'neutral',
     passed: 0,
     failed: 0,
     pending: 0,
+    cancelled: 0,
     neutral: 1
   }),
   gitLabCase('GitLab manual gate alongside a green pipeline', ['manual', 'success'], {
@@ -130,6 +131,7 @@ const PARITY_CASES: ParityCase[] = [
     passed: 1,
     failed: 0,
     pending: 0,
+    cancelled: 0,
     neutral: 1
   }),
   gitLabCase('GitLab skipped-only pipeline', ['skipped', 'skipped'], {
@@ -137,6 +139,7 @@ const PARITY_CASES: ParityCase[] = [
     passed: 2,
     failed: 0,
     pending: 0,
+    cancelled: 0,
     neutral: 0
   }),
   gitLabCase('GitLab success alongside an unrecognized job status', ['success', 'wat'], {
@@ -144,25 +147,29 @@ const PARITY_CASES: ParityCase[] = [
     passed: 1,
     failed: 0,
     pending: 0,
+    cancelled: 0,
     neutral: 1
   }),
+  // Why: a canceled job is the GitLab face of #15847 — it keeps blocking the merge but rolls up
+  // into the cancelled bucket instead of painting the MR red.
   gitLabCase('GitLab canceled job', ['success', 'canceled'], {
-    state: 'failure',
+    state: 'cancelled',
     passed: 1,
-    failed: 1,
+    failed: 0,
     pending: 0,
+    cancelled: 1,
     neutral: 0
   }),
   gitLabCase(
     'GitLab manual gate alongside a running job',
     ['manual', 'running'],
-    { state: 'pending', passed: 0, failed: 0, pending: 1, neutral: 1 },
+    { state: 'pending', passed: 0, failed: 0, pending: 1, cancelled: 0, neutral: 1 },
     'running'
   ),
   {
     name: 'genuine action_required',
     checks: [completed('success'), completed('action_required')],
-    expected: { state: 'failure', passed: 1, failed: 1, pending: 0, neutral: 0 }
+    expected: { state: 'failure', passed: 1, failed: 1, pending: 0, cancelled: 0, neutral: 0 }
   }
 ]
 
@@ -181,11 +188,13 @@ describe('provider check classification parity', () => {
         // Both panes split action_required into its own amber chip; it is still the failed bucket.
         failed: paneCounts.failing + paneCounts.needsAction,
         pending: paneCounts.pending,
+        cancelled: paneCounts.cancelled,
         neutral: paneCounts.neutral
       }).toEqual({
         passed: expected.passed,
         failed: expected.failed,
         pending: expected.pending,
+        cancelled: expected.cancelled ?? 0,
         neutral: expected.neutral
       })
       expect(getCheckCountChips(paneCounts).find((chip) => chip.tone === 'neutral')?.label).toBe(

--- a/src/renderer/src/components/right-sidebar/GitHubPRStackMap.tsx
+++ b/src/renderer/src/components/right-sidebar/GitHubPRStackMap.tsx
@@ -32,6 +32,13 @@ function stackEntryStatus(entry: GitHubPRStackEntry): string {
   if (entry.checksStatus === 'pending') {
     return translate('auto.components.right.sidebar.GitHubPRStackMap.316039b5db', 'checks pending')
   }
+  if (entry.checksStatus === 'cancelled') {
+    // Why: the stack badge names what happened — a cancelled set is not a failed one (#15847).
+    return translate(
+      'auto.components.right.sidebar.GitHubPRStackMap.9f14c3e2a1',
+      'checks cancelled'
+    )
+  }
   if (entry.reviewDecision === 'CHANGES_REQUESTED') {
     return translate(
       'auto.components.right.sidebar.GitHubPRStackMap.4b1e5ee9d3',

--- a/src/renderer/src/components/right-sidebar/activity-bar-buttons.tsx
+++ b/src/renderer/src/components/right-sidebar/activity-bar-buttons.tsx
@@ -33,6 +33,8 @@ const STATUS_DOT_COLOR: Record<CheckStatus, string> = {
   success: 'bg-emerald-500',
   failure: 'bg-rose-500',
   pending: 'bg-amber-500',
+  // Why: grey, matching the Checks panel's muted cancelled tone — not the failure red (#15847).
+  cancelled: 'bg-muted-foreground/70',
   neutral: 'bg-muted-foreground'
 }
 

--- a/src/renderer/src/components/sidebar/WorktreeCardHelpers.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardHelpers.tsx
@@ -17,6 +17,9 @@ export function checksLabel(status: CheckStatus): string {
       return 'Failing'
     case 'pending':
       return 'Pending'
+    case 'cancelled':
+      // Why: muted wording, not "Failing" — a deliberate cancellation is not a defect (#15847).
+      return 'Cancelled'
     case 'neutral':
       return ''
   }

--- a/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx
@@ -214,6 +214,29 @@ describe('WorktreeCardStatusSlot', () => {
     expect(markup).not.toContain('bg-emerald-500')
   })
 
+  // Why: the tooltip is the first place a user learns why the PR glyph is flagged; a stopped run
+  // must say "Cancelled" with the muted tone instead of claiming "Failed" (#15847).
+  it('words and tones a cancelled review as cancelled, not failed', () => {
+    const markup = renderToStaticMarkup(
+      <WorktreeCardStatusSlot
+        worktreeId="wt-1"
+        showStatus
+        showUnreadAction={false}
+        isUnread={false}
+        unreadTooltip="Mark as unread"
+        onPointerDown={vi.fn()}
+        onToggleUnread={vi.fn()}
+        prDisplay={{ ...review, status: 'cancelled' }}
+        newCardStyle
+      />
+    )
+
+    expect(markup).toContain('PR checks: Cancelled')
+    expect(markup).toContain('text-muted-foreground/60')
+    expect(markup).not.toContain('PR checks: Failed')
+    expect(markup).not.toContain('text-rose-500/85')
+  })
+
   it('uses the unified compact review glyph for GitLab MR status', () => {
     const markup = renderToStaticMarkup(
       <WorktreeCardStatusSlot

--- a/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.tsx
@@ -80,6 +80,10 @@ function getReviewStatusTooltip(review: WorktreeCardPrDisplay): string {
   if (review.status === 'pending') {
     return `${label} checks: Pending`
   }
+  if (review.status === 'cancelled') {
+    // Why: "Cancelled", not "Failed" — the run was stopped on purpose (#15847).
+    return `${label} checks: Cancelled`
+  }
   if (review.status === 'success') {
     return `${label} checks: Passing`
   }

--- a/src/renderer/src/components/sidebar/folder-workspace-card-pr-display.ts
+++ b/src/renderer/src/components/sidebar/folder-workspace-card-pr-display.ts
@@ -24,8 +24,11 @@ type FolderWorkspaceCardPrDisplayArgs = {
 const REVIEW_STATUS_PRIORITY: Record<NonNullable<WorktreeCardPrDisplay['status']>, number> = {
   failure: 0,
   pending: 1,
-  success: 2,
-  neutral: 3
+  // Why: cancelled outranks green in the folder rollup — a cancelled child is still not passing —
+  // but sits below pending while anything is still running.
+  cancelled: 2,
+  success: 3,
+  neutral: 4
 }
 
 export function getFolderWorkspaceCardPrDisplay({

--- a/src/renderer/src/components/sidebar/worktree-review-helpers.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-review-helpers.test.tsx
@@ -125,4 +125,15 @@ describe('ReviewIcon', () => {
     expect(stateless('pending')).toContain('text-amber-500/85')
     expect(stateless('success')).not.toContain('text-emerald-500/80')
   })
+
+  // Why: a cancelled rollup must keep the muted tone of the Checks panel rows — painting it rose
+  // told the user a deliberately stopped run had failed (#15847).
+  it('paints a cancelled review with the muted tone, not the failure tone', () => {
+    const markup = renderToStaticMarkup(
+      <ReviewIcon review={{ ...gitlabReview, status: 'cancelled' }} className="size-3" />
+    )
+
+    expect(markup).toContain('text-muted-foreground/60')
+    expect(markup).not.toContain('text-rose-500/85')
+  })
 })

--- a/src/renderer/src/components/sidebar/worktree-review-helpers.tsx
+++ b/src/renderer/src/components/sidebar/worktree-review-helpers.tsx
@@ -55,6 +55,11 @@ function getCheckTone(review: WorktreeCardPrDisplay): string | null {
   if (review.status === 'pending') {
     return 'text-amber-500/85'
   }
+  // Why: cancelled reads muted like the Checks panel's own rows — red would claim a defect the
+  // run never had (#15847).
+  if (review.status === 'cancelled') {
+    return 'text-muted-foreground/60'
+  }
   if (review.state === 'open' && review.status === 'success') {
     return 'text-emerald-500/80'
   }

--- a/src/renderer/src/components/task-page-checks-pill.test.ts
+++ b/src/renderer/src/components/task-page-checks-pill.test.ts
@@ -51,4 +51,24 @@ describe('task page checks pill', () => {
       })
     ).toBe('No checks')
   })
+
+  // Why: the pill is the aggregate surface users scan first; a cancelled-only set must read
+  // "cancelled" on a muted pill, not "failing" on a red one (#15847).
+  it('labels a cancelled-only summary as cancelled on the muted pill', () => {
+    const item = {
+      checksSummary: {
+        state: 'cancelled' as const,
+        total: 2,
+        passed: 1,
+        failed: 0,
+        pending: 0,
+        cancelled: 1,
+        neutral: 0
+      }
+    }
+
+    expect(getChecksLabel(item)).toBe('1 cancelled')
+    expect(getChecksPillTone(item)).toContain('text-muted-foreground')
+    expect(getChecksPillTone(item)).not.toContain('rose')
+  })
 })

--- a/src/renderer/src/components/task-page-checks-pill.test.ts
+++ b/src/renderer/src/components/task-page-checks-pill.test.ts
@@ -59,15 +59,15 @@ describe('task page checks pill', () => {
       checksSummary: {
         state: 'cancelled' as const,
         total: 2,
-        passed: 1,
+        passed: 0,
         failed: 0,
         pending: 0,
-        cancelled: 1,
+        cancelled: 2,
         neutral: 0
       }
     }
 
-    expect(getChecksLabel(item)).toBe('1 cancelled')
+    expect(getChecksLabel(item)).toBe('2 cancelled')
     expect(getChecksPillTone(item)).toContain('text-muted-foreground')
     expect(getChecksPillTone(item)).not.toContain('rose')
   })

--- a/src/shared/github/pull-request-types.ts
+++ b/src/shared/github/pull-request-types.ts
@@ -1,6 +1,9 @@
 export type PRState = 'open' | 'closed' | 'merged' | 'draft'
 export type IssueState = 'open' | 'closed'
-export type CheckStatus = 'pending' | 'success' | 'failure' | 'neutral'
+// Why: `cancelled` is its own aggregate verdict — it blocks merging like a failure but must not
+// read as one anywhere (#15847). Older hosts never send it (they fold it into `failure`), so
+// renderer switches may simply fall through to their neutral branch for it.
+export type CheckStatus = 'pending' | 'success' | 'failure' | 'cancelled' | 'neutral'
 
 export type PRMergeableState = 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN'
 export type PRReviewDecision = 'APPROVED' | 'CHANGES_REQUESTED' | 'REVIEW_REQUIRED'
@@ -111,12 +114,15 @@ export type GitHubAssignableUser = {
 }
 
 export type ProviderCheckSummary = {
-  state: 'success' | 'failure' | 'pending' | 'neutral' | 'none'
+  state: 'success' | 'failure' | 'pending' | 'cancelled' | 'neutral' | 'none'
   total: number
   passed: number
   failed: number
   pending: number
   neutral: number
+  // Why: optional because a paired host can predate the cancelled bucket; an absent count
+  // reads as zero everywhere, which is exactly the old-host behavior.
+  cancelled?: number
 }
 
 export type GitHubPRReviewSummary = {

--- a/src/shared/pr-check-status.test.ts
+++ b/src/shared/pr-check-status.test.ts
@@ -38,3 +38,30 @@ describe('provider-neutral check status', () => {
     expect(derivePRCheckStatusFromRollup([{ status: 'COMPLETED', conclusion }])).toBe('failure')
   })
 })
+
+describe('cancelled aggregates', () => {
+  // Why: a deliberate cancellation blocks merging exactly like a failure, but presenting it as
+  // one made the sidebar call a stopped run "Failed" (#15847). The aggregate must carry its own
+  // verdict down to PR metadata instead of collapsing into `failure`.
+  it('derives a cancelled-only set as cancelled, not failure', () => {
+    expect(derivePRCheckStatus([check('completed', 'cancelled')])).toBe('cancelled')
+    expect(derivePRCheckStatusFromRollup([{ status: 'COMPLETED', conclusion: 'CANCELLED' }])).toBe(
+      'cancelled'
+    )
+  })
+
+  it('lets a real failure win over cancellations in a mixed set', () => {
+    const status = derivePRCheckStatus([check('completed', 'cancelled'), check('completed', 'failure')])
+    expect(status).toBe('failure')
+  })
+
+  it('keeps a set with a still-running check pending until it settles', () => {
+    const status = derivePRCheckStatus([check('completed', 'cancelled'), check('in_progress', null)])
+    expect(status).toBe('pending')
+  })
+
+  it('does not let a cancelled check turn the rollup green', () => {
+    const status = derivePRCheckStatus([check('completed', 'success'), check('completed', 'cancelled')])
+    expect(status).toBe('cancelled')
+  })
+})

--- a/src/shared/provider-check-summary.ts
+++ b/src/shared/provider-check-summary.ts
@@ -1,6 +1,6 @@
 import type { ProviderCheckSummary } from './github/pull-request-types'
 
-export type CheckOutcome = 'passed' | 'failed' | 'pending' | 'neutral'
+export type CheckOutcome = 'passed' | 'failed' | 'pending' | 'cancelled' | 'neutral'
 
 export type CheckOutcomeInput = { status?: string | null; conclusion?: string | null }
 
@@ -14,9 +14,13 @@ const FAILED_CONCLUSIONS = new Set([
   'error',
   'startup_failure',
   'timed_out',
-  'cancelled',
   'action_required'
 ])
+
+// Why: a cancellation blocks the merge exactly like a failure, but it is not one — the
+// user (or a superseding push) stopped the run. It rolls up into its own bucket so
+// aggregate surfaces can say "Cancelled" instead of "Failed" (#15847).
+const CANCELLED_CONCLUSIONS = new Set(['cancelled'])
 
 /** The single provider-neutral verdict for one check; every check surface must route through it. */
 export function classifyCheckOutcome(check: CheckOutcomeInput): CheckOutcome {
@@ -24,6 +28,9 @@ export function classifyCheckOutcome(check: CheckOutcomeInput): CheckOutcome {
   const status = (check.status ?? '').toLowerCase()
   if (FAILED_CONCLUSIONS.has(conclusion)) {
     return 'failed'
+  }
+  if (CANCELLED_CONCLUSIONS.has(conclusion)) {
+    return 'cancelled'
   }
   if (PASSED_CONCLUSIONS.has(conclusion)) {
     return 'passed'
@@ -37,7 +44,8 @@ export function classifyCheckOutcome(check: CheckOutcomeInput): CheckOutcome {
 
 /** Rolls up counted outcomes; passing checks win over neutral ones so one neutral cannot demote a green PR. */
 export function resolveProviderCheckState(
-  counts: Pick<ProviderCheckSummary, 'total' | 'passed' | 'failed' | 'pending'>
+  counts: Pick<ProviderCheckSummary, 'total' | 'passed' | 'failed' | 'pending'> &
+    Partial<Pick<ProviderCheckSummary, 'cancelled'>>
 ): ProviderCheckSummary['state'] {
   if (counts.total === 0) {
     return 'none'
@@ -47,6 +55,11 @@ export function resolveProviderCheckState(
   }
   if (counts.pending > 0) {
     return 'pending'
+  }
+  // Why: cancelled sits below pending — while anything is still running the honest live state is
+  // pending — and above passing, because a cancelled set is deliberately not green.
+  if ((counts.cancelled ?? 0) > 0) {
+    return 'cancelled'
   }
   return counts.passed > 0 ? 'success' : 'neutral'
 }
@@ -58,6 +71,7 @@ export function summarizeProviderChecks(
   let failed = 0
   let pending = 0
   let neutral = 0
+  let cancelled = 0
   for (const check of checks) {
     const outcome = classifyCheckOutcome(check)
     if (outcome === 'passed') {
@@ -66,18 +80,21 @@ export function summarizeProviderChecks(
       failed += 1
     } else if (outcome === 'pending') {
       pending += 1
+    } else if (outcome === 'cancelled') {
+      cancelled += 1
     } else {
       neutral += 1
     }
   }
   const total = checks.length
   return {
-    state: resolveProviderCheckState({ total, passed, failed, pending }),
+    state: resolveProviderCheckState({ total, passed, failed, pending, cancelled }),
     total,
     passed,
     failed,
     pending,
-    neutral
+    neutral,
+    cancelled
   }
 }
 
@@ -94,6 +111,9 @@ export function getProviderChecksLabel(summary: ProviderCheckSummary | undefined
   }
   if (summary.pending > 0) {
     return `${summary.pending} pending`
+  }
+  if ((summary.cancelled ?? 0) > 0) {
+    return `${summary.cancelled} cancelled`
   }
   return summary.state === 'neutral'
     ? 'Unresolved checks'


### PR DESCRIPTION
## What

Cancelled PR checks now roll up into their own **cancelled** aggregate verdict instead of being presented as failures. The left worktree sidebar says `PR checks: Cancelled` on the muted grey tone, the Tasks checks pill reads `N cancelled` on the muted pill, and the check-tab counts/chips carry a `N cancelled` bucket — matching the wording the detailed Checks rows already used.

## Why (issue #15847)

`classifyCheckOutcome` folded `cancelled` into `FAILED_CONCLUSIONS` (deliberately, for merge gating — see #4077), and `CheckStatus` had no cancelled member, so `derivePRCheckStatus` reduced a cancelled-only rollup to `failure` before any surface could tell them apart. The result: a deliberate cancellation was rose/red in the sidebar with the tooltip `PR checks: Failed`, while the very same check rendered correctly as muted `Cancelled` in the Checks UI. Merge-gating semantics and presentation were sharing one coarse bucket.

## How

- `classifyCheckOutcome` gains a `'cancelled'` outcome (`CANCELLED_CONCLUSIONS` split out of `FAILED_CONCLUSIONS`).
- `ProviderCheckSummary.state` gains `'cancelled'` and an optional `cancelled` count; rollup priority is **failure > pending > cancelled > success > neutral** — a real failure still wins when mixed, a still-running check keeps the set pending, and a cancelled set never turns green.
- `CheckStatus` gains `'cancelled'`. It is additive over the wire: older hosts never emit it (they keep folding it into `failure`), and every renderer switch either handles it explicitly or falls through to its neutral branch, so mixed client/server versions degrade to today's behavior rather than breaking.
- Presentation wiring: sidebar glyph tone + tooltip (`worktree-review-helpers`, `WorktreeCardStatusSlot`, `WorktreeCardHelpers.checksLabel`), activity-bar status dot, PR stack map label, tasks-grid checks pill label, check-tab counts/chips/summary (`pr-check-counts`, `checks-tab-summary`), folder-workspace rollup priority.
- Merge gating is untouched: cancelled still blocks `checksPassed` and the Checks panel's not-passing set (`isFailedCheck`), same as before.

## Testing

- `src/shared/pr-check-status.test.ts` — cancelled-only → `cancelled`; failure+cancelled → `failure`; cancelled+running → `pending`; success+cancelled → `cancelled`.
- `provider-check-classification-parity.test.ts` — every-surface parity extended with the cancelled bucket, including the GitLab `canceled` job case which now rolls up cancelled instead of failure.
- `pr-check-counts.test.ts` / `task-page-checks-pill.test.ts` — counts, chips (`1 cancelled`), summary labels, muted pill tone (not rose).
- `WorktreeCardStatusSlot.test.tsx` / `worktree-review-helpers.test.tsx` — sidebar tooltip `PR checks: Cancelled` and muted glyph tone, with the rose failure tone asserted absent.
- Diff-verified: with only the shared rollup changes stashed, 3 of the new aggregate tests fail against the old classifier.
- Full `pnpm run typecheck` clean; 241 tests across the touched + adjacent suites (checks panel, stack map, activity bar, folder rollup, hosted-review IPC, GitLab mappers) pass.

Fixes #15847
