### PR TITLE
fix(agents): skip Devin first-run workspace trust prompt

### DIFF
--- a/src/renderer/src/lib/tui-agent-startup.test.ts
+++ b/src/renderer/src/lib/tui-agent-startup.test.ts
@@ -252,11 +252,11 @@ describe('buildAgentStartupPlan', () => {
       })
     ).toEqual({
       agent: 'devin',
-      launchCommand: "devin '--permission-mode' 'bypass'",
+      launchCommand: "devin --respect-workspace-trust=false '--permission-mode' 'bypass'",
       expectedProcess: 'devin',
       followupPrompt: 'Trace the failing test',
       launchConfig: {
-        agentCommand: "devin '--permission-mode' 'bypass'",
+        agentCommand: "devin --respect-workspace-trust=false '--permission-mode' 'bypass'",
         agentArgs: '--permission-mode bypass',
         agentEnv: {}
       }

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -329,7 +329,8 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
   },
   devin: {
     detectCmd: 'devin',
-    launchCmd: 'devin',
+    // Why: first-run trust menu swallows PTY input as "No, exit"; `--permission-mode bypass` does not skip it.
+    launchCmd: 'devin --respect-workspace-trust=false',
     expectedProcess: 'devin',
     // Why: `devin -- <prompt>` auto-submits immediately (docs.devin.ai/cli), so start the REPL with no argv prompt.
     promptInjectionMode: 'stdin-after-start'

--- a/src/shared/tui-agent-startup-devin.test.ts
+++ b/src/shared/tui-agent-startup-devin.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { buildAgentResumeStartupPlan, buildAgentStartupPlan } from './tui-agent-startup'
+import { resolveTuiAgentLaunchArgs } from './tui-agent-launch-defaults'
+
+describe('Devin workspace-trust skip', () => {
+  it('keeps the skip when YOLO args are cleared', () => {
+    const plan = buildAgentStartupPlan({
+      agent: 'devin',
+      prompt: '',
+      allowEmptyPromptLaunch: true,
+      cmdOverrides: {},
+      agentArgs: '',
+      platform: 'linux'
+    })
+    expect(plan).toEqual({
+      agent: 'devin',
+      launchCommand: 'devin --respect-workspace-trust=false',
+      expectedProcess: 'devin',
+      followupPrompt: null,
+      launchConfig: {
+        agentCommand: 'devin --respect-workspace-trust=false',
+        agentArgs: '',
+        agentEnv: {}
+      }
+    })
+  })
+
+  it('keeps the skip on resume so a new worktree does not re-prompt', () => {
+    const plan = buildAgentResumeStartupPlan({
+      agent: 'devin',
+      providerSession: { key: 'session_id', id: 'abc12345' },
+      cmdOverrides: {},
+      agentArgs: resolveTuiAgentLaunchArgs('devin', null),
+      platform: 'linux'
+    })
+    expect(plan?.launchCommand).toBe(
+      "devin --respect-workspace-trust=false '--permission-mode' 'bypass' '--resume' 'abc12345'"
+    )
+  })
+})

--- a/src/shared/tui-agent-startup.test.ts
+++ b/src/shared/tui-agent-startup.test.ts
@@ -916,11 +916,11 @@ describe('tui agent startup plans', () => {
     })
     expect(plan).toEqual({
       agent: 'devin',
-      launchCommand: "devin '--permission-mode' 'bypass'",
+      launchCommand: "devin --respect-workspace-trust=false '--permission-mode' 'bypass'",
       expectedProcess: 'devin',
       followupPrompt: 'fix the tests',
       launchConfig: {
-        agentCommand: "devin '--permission-mode' 'bypass'",
+        agentCommand: "devin --respect-workspace-trust=false '--permission-mode' 'bypass'",
         agentArgs: '--permission-mode bypass',
         agentEnv: {}
       }


### PR DESCRIPTION
## ELI5

Creating a Devin agent in Orca was dying immediately. Devin asks "do you trust this folder?" with a numbered menu, and Orca's first keystrokes into the terminal were answering **No, exit**. This change tells Devin not to show that menu when Orca launches it.

## What Changed

Devin's launch command is now `devin --respect-workspace-trust=false` (still followed by `--permission-mode bypass` in YOLO mode). That is Devin's documented skip for the first-run workspace-trust prompt, the same pattern as `command-code --trust`.

The flag lives on `launchCmd`, not YOLO args, so manual permission mode and session resume also skip the menu. New Orca worktrees are not written into Devin's global trust store; the skip is per invocation.

## Why

`--permission-mode bypass` only auto-approves **tools**. It does not skip workspace trust. Devin uses `stdin-after-start`, so as soon as `devin` is the foreground process — which it already is while the trust menu is up — Orca's follow-up prompt or draft paste is consumed as a menu choice. Option 2 is "No, exit".

Orca already pre-writes trust artifacts for Cursor, Copilot, and Codex (`preflightTrust`). Devin has a public CLI flag for this, so the launch command is the smaller, more reliable fix than reverse-engineering `trusted_workspaces.json`.

## Linked Issue

Fixes #15859

Related: #11765 (Cursor trust auto-quit), #10666 (inject answers Codex trust prompt)

## Visual Proof

N/A — launch-command change only. No UI, layout, or interaction surface.

## Testing

- [x] Automated tests added/updated, or explained why not below
- [x] I manually tested these changes locally

Ran:

```text
pnpm exec vitest run src/shared/tui-agent-startup.test.ts src/shared/tui-agent-startup-devin.test.ts src/renderer/src/lib/tui-agent-startup.test.ts
```

98 passed.

Verified on this machine that `devin --respect-workspace-trust=false -p "…"` runs in an untrusted directory instead of failing the trust check (Devin CLI 3000.5.20). Did not re-create a Devin agent inside a running Orca app.

Platforms: macOS unit tests. The flag is Devin CLI argv, so Linux, Windows, WSL, and SSH hosts pick it up as long as that host's Devin supports `--respect-workspace-trust` (current docs / 3000.x). Older Devin without the flag would fail at clap parse; Devin auto-updates by default.

## Review

- Cross-platform: launchCmd is the same string on macOS/Linux/Windows; `=false` is one token so `false` cannot be parsed as a PATH.
- SSH/remote: the flag is sent with the remote spawn command. Trust skip is evaluated by the Devin binary on the execution host.
- Folder workspaces: applies to any cwd Orca launches Devin in, git worktree or not.
- Permission mode: YOLO remains `--permission-mode bypass`; the trust skip is independent so toggling manual/yolo cannot reintroduce the menu.
- Security: scoped to Orca-launched Devin only. Does not set `skip_workspace_trust` in `~/.config/devin/config.json`, so a Devin run outside Orca still prompts.
- Performance: none.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Custom **command overrides** that replace the whole launch with bare `devin` will drop the flag, same as `command-code --trust` today.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)