### PR TITLE
fix(skills): normalize contributor-facing paths in the skill guide generator

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -638,6 +638,7 @@ jobs:
           src/main/windows/windows-host-job.win32.test.ts
           src/main/cli/wsl-cli-powershell-boundary.test.ts
           src/main/orca-profiles/profile-index-store.test.ts
+          config/scripts/generate-bundled-skill-guides.test.mjs
           src/main/runtime/repo-worktree-admin-fingerprint.test.ts
           src/main/runtime/worktree-scan-admin-fingerprint-gate.test.ts
           src/shared/secure-file-fsync-flags.test.ts

--- a/config/scripts/generate-bundled-skill-guides.mjs
+++ b/config/scripts/generate-bundled-skill-guides.mjs
@@ -243,7 +243,7 @@ async function verifyArtifacts(artifacts, repoRoot = REPO_ROOT) {
   if (stale.length > 0) {
     throw new Error(
       `Generated bundled skill guides are stale:\n${stale
-        .map((filePath) => path.relative(repoRoot, filePath))
+        .map((filePath) => path.relative(repoRoot, filePath).split(path.sep).join('/'))
         .join('\n')}\nRun node config/scripts/generate-bundled-skill-guides.mjs --write.`
     )
   }

--- a/config/scripts/generate-bundled-skill-guides.mjs
+++ b/config/scripts/generate-bundled-skill-guides.mjs
@@ -169,6 +169,12 @@ async function assertStubSourcesMatchTopics(repoRoot) {
   }
 }
 
+// Why: path.relative yields `\` on Windows, but these paths are asserted in tests and pasted into commands.
+// split(sep) rather than replaceAll('\\', '/') so a POSIX filename containing a backslash survives intact.
+function toPosixRelativePath(repoRoot, filePath, pathModule = path) {
+  return pathModule.relative(repoRoot, filePath).split(pathModule.sep).join('/')
+}
+
 async function buildArtifacts(repoRoot = REPO_ROOT) {
   const guideRoot = path.join(repoRoot, 'skill-guides')
   const sourceFiles = (await readdir(guideRoot, { withFileTypes: true }))
@@ -193,7 +199,7 @@ async function buildArtifacts(repoRoot = REPO_ROOT) {
     // Why: Git may render text with native EOLs despite repository policy; the
     // embedded guide and generated projection must have one platform-neutral identity.
     const markdown = normalizeMarkdown(await readFile(sourcePath, 'utf8'))
-    const frontmatter = parseFrontmatter(markdown, path.relative(repoRoot, sourcePath))
+    const frontmatter = parseFrontmatter(markdown, toPosixRelativePath(repoRoot, sourcePath))
     if (frontmatter.name !== name) {
       throw new Error(`Guide source ${name}.md declares mismatched name ${frontmatter.name}`)
     }
@@ -243,7 +249,7 @@ async function verifyArtifacts(artifacts, repoRoot = REPO_ROOT) {
   if (stale.length > 0) {
     throw new Error(
       `Generated bundled skill guides are stale:\n${stale
-        .map((filePath) => path.relative(repoRoot, filePath).split(path.sep).join('/'))
+        .map((filePath) => toPosixRelativePath(repoRoot, filePath))
         .join('\n')}\nRun node config/scripts/generate-bundled-skill-guides.mjs --write.`
     )
   }
@@ -272,6 +278,7 @@ export {
   normalizeMarkdown,
   parseFrontmatter,
   serializeEmbeddedModule,
+  toPosixRelativePath,
   verifyArtifacts,
   writeArtifacts
 }

--- a/config/scripts/generate-bundled-skill-guides.test.mjs
+++ b/config/scripts/generate-bundled-skill-guides.test.mjs
@@ -14,6 +14,7 @@ import {
   frontmatterBlock,
   normalizeMarkdown,
   parseFrontmatter,
+  toPosixRelativePath,
   verifyArtifacts,
   writeArtifacts
 } from './generate-bundled-skill-guides.mjs'
@@ -230,6 +231,20 @@ describe('bundled skill guide generator', () => {
 
     await writeFile(path.join(root, 'skills', 'computer-use', 'SKILL.md'), 'stale\n')
     await expect(verifyArtifacts(artifacts, root)).rejects.toThrow('skills/computer-use/SKILL.md')
+  })
+
+  // Why: the stale-artifact assertions above only exercise the Windows separator on Windows,
+  // and this file is not in pr.yml's Windows test allowlist — inject path.win32 so CI covers it.
+  it('formats contributor-facing paths with forward slashes on every platform', () => {
+    expect(
+      toPosixRelativePath('C:\\repo', 'C:\\repo\\src\\cli\\bundled-skill-guides.ts', path.win32)
+    ).toBe('src/cli/bundled-skill-guides.ts')
+    expect(
+      toPosixRelativePath('C:\\repo', 'C:\\repo\\skills\\computer-use\\SKILL.md', path.win32)
+    ).toBe('skills/computer-use/SKILL.md')
+    expect(toPosixRelativePath('/repo', '/repo/skills/computer-use/SKILL.md', path.posix)).toBe(
+      'skills/computer-use/SKILL.md'
+    )
   })
 
   it('rejects mismatched source names and ambiguous aliases', async () => {

--- a/config/scripts/generate-bundled-skill-guides.test.mjs
+++ b/config/scripts/generate-bundled-skill-guides.test.mjs
@@ -233,8 +233,8 @@ describe('bundled skill guide generator', () => {
     await expect(verifyArtifacts(artifacts, root)).rejects.toThrow('skills/computer-use/SKILL.md')
   })
 
-  // Why: the stale-artifact assertions above only exercise the Windows separator on Windows,
-  // and this file is not in pr.yml's Windows test allowlist — inject path.win32 so CI covers it.
+  // Why: the stale-artifact assertions above only hit the Windows separator when the host is
+  // Windows; injecting path.win32 makes the Linux/macOS shards catch the regression too.
   it('formats contributor-facing paths with forward slashes on every platform', () => {
     expect(
       toPosixRelativePath('C:\\repo', 'C:\\repo\\src\\cli\\bundled-skill-guides.ts', path.win32)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​15 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​15 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​8 |

<!-- /orca-pr-loc -->

Supersedes #15278 by @poorpaper — carried over so it can run full CI (fork PRs only run `track-community-pr` in this repo). Original authorship preserved in the commit.

## ELI5

Windows spells file paths with backslashes (`src\cli\foo.ts`); everywhere else uses forward slashes (`src/cli/foo.ts`). A build script that tells you "these generated files are out of date, here's the list" was printing the raw platform path. On Windows that made the script's own test fail, and it meant the path it printed didn't match what the docs and tests say. Now the script always prints forward slashes, on every OS.

## What Changed

- `config/scripts/generate-bundled-skill-guides.mjs`: added a named `toPosixRelativePath(repoRoot, filePath, pathModule = path)` and routed both contributor-facing path diagnostics through it — the stale-artifact list in `verifyArtifacts` (@poorpaper's original fix) and the frontmatter-error path in `buildArtifacts`, which had the identical defect. Exported for the test.
- `config/scripts/generate-bundled-skill-guides.test.mjs`: new platform-agnostic regression test that injects `path.win32` (and `path.posix`) so Linux/macOS CI actually exercises the Windows branch.
- `.github/workflows/pr.yml`: added this test file to the `package_windows` "Test Windows-specific boundaries" allowlist so the real end-to-end assertions get genuine windows-2022 coverage.

No behavior change to generated artifacts. `node config/scripts/generate-bundled-skill-guides.mjs --write` produces a zero-diff regeneration — `src/cli/bundled-skill-guides.ts` and `skills/*/SKILL.md` are byte-for-byte unchanged. The change lives entirely in the verify/diagnostic path.

## Why

Root cause: `path.relative()` returns platform-native separators. `verifyArtifacts` interpolated that directly into its "Generated bundled skill guides are stale" message, so on Windows it emitted `src\cli\bundled-skill-guides.ts` while the test asserts `src/cli/bundled-skill-guides.ts` (and `skills/computer-use/SKILL.md`). Both failing assertions flow through the same `.map()`, so one normalization fixes both.

`split(pathModule.sep).join('/')` rather than `replaceAll('\\', '/')`: on POSIX a backslash is a legal filename character, and a file literally named `a\b.ts` must survive intact. This idiom already exists in the repo (`src/renderer/src/components/settings/agent-skill-installed-command-callers.test.ts`).

Two hardening additions on top of the contributor's one-liner:

1. **Coverage.** The existing assertions pass on Linux/macOS whether or not the fix exists, and this file was not in the Windows CI allowlist — so reverting the fix would have been green on every CI job. Injecting the path flavor makes the regression catchable on the platforms CI actually runs, and the allowlist entry adds the real Windows run.
2. **The second call site.** Line 196 (`parseFrontmatter(markdown, path.relative(...))`) had the same bug, feeding a native path into three error messages. Line 206 already hardcodes the posix form `skill-stubs/${name}.md`, confirming `/` is this script's intended convention.

## Linked Issue

No linked issue — reported via PR #15278.

## Visual Proof

N/A — this is a build/verification script. It has no UI surface and produces no user-visible rendering; the only observable output is an error message printed to a terminal by a `node` script.

## Testing

Run on **macOS (darwin arm64) only**. Windows behavior is covered by the injected-`path.win32` unit test (which reproduces the exact Windows string on any host) plus the new windows-2022 CI allowlist entry, not by a local Windows run.

```
npx vitest run --config config/vitest.config.ts config/scripts/generate-bundled-skill-guides.test.mjs
  -> 13 passed (baseline on main is 12)

npx oxlint config/scripts/generate-bundled-skill-guides.mjs config/scripts/generate-bundled-skill-guides.test.mjs
  -> exit 0, clean

npx oxlint --config config/oxlint-code-quality-native-plugins.json <same two files> --deny-warnings
  -> exit 0, clean

npx oxfmt --check <same two files>
  -> "All matched files use the correct format."

node config/scripts/generate-bundled-skill-guides.mjs            -> exit 0 (verify mode)
node config/scripts/generate-bundled-skill-guides.mjs --write    -> no change to any generated artifact

python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pr.yml'))"  -> parses
```

**Regression proof.** Temporarily reverted the `.split(pathModule.sep).join('/')` inside `toPosixRelativePath` and re-ran the suite:

```
FAIL  ... > formats contributor-facing paths with forward slashes on every platform
AssertionError: expected 'src\cli\bundled-skill-guides.ts' to be 'src/cli/bundled-skill-guides.ts'
Tests  1 failed | 12 passed (13)
```

Restored the line; back to 13/13. The new test genuinely fails without the product change.

Per repo agent guidance I did not run project-wide `pnpm typecheck` / full `pnpm lint` locally (they OOM with concurrent agents); CI covers them.

**CI note.** All 46 required checks are green on `f0352f05473`. One earlier attempt of `tests node 24 7/16` failed on `src/main/runtime/runtime-rpc-metadata-lifecycle.test.ts > leaves runtime metadata owned by a live sibling runtime untouched` — unrelated to this diff (this PR touches only `config/scripts/*` and `.github/workflows/pr.yml`, no `src/`). It is a timing flake in that test's 10s `watchRuntimeMetadataOwnership` poll: `tests node 26 7/16` ran the identical file set in the same workflow run and passed, the parent commit was green on every job, and a re-run of the failed job went green with no code change.

## Review

I audited @poorpaper's contributed diff for malicious code before carrying it: it is a single commit, a single file, +1/-1, entirely one expression inside a template literal. No dependency, lockfile, `package.json`, workflow, postinstall/prepare-hook, or electron-builder/signing/updater changes. No network sinks (`fetch`/`http`/`net`/`dns`), no `child_process`, no `eval`/`new Function`/`vm`, no `process.env` or credential reads, no obfuscation (`LC_ALL=C grep '[^\x00-\x7F]'` over the diff returns nothing — no homoglyphs, bidi, or zero-width characters). The changed value is only interpolated into an `Error` message, never into a command. **Found nothing suspicious.**

- **Cross-platform:** this *is* the cross-platform fix. Correct on all three OSes; the POSIX-backslash-in-filename edge case is handled by using `split(sep)` instead of a blind string replace. `stale[]` only ever holds absolute paths joined from `repoRoot`, so there is no `..` or drive-mismatch case to worry about.
- **SSH / remote:** N/A. This is a repo-local build-time script that never runs on an execution host; it touches nothing in the SSH execution boundary and no verdict vocabulary.
- **Remote wire compatibility:** N/A. No RPC params, stream opcodes, or published content changed. The generated skill-guide artifacts that clients and hosts exchange are byte-identical.
- **Agent / integration compatibility:** the artifacts agents actually read (`src/cli/bundled-skill-guides.ts`, `skills/*/SKILL.md`) are unchanged — verified by a zero-diff `--write` regeneration. `verifyArtifacts` keeps its exact signature and its existing exported use.
- **Folder workspaces / git provider neutrality:** N/A — no workspace-type or provider-specific logic involved.
- **Performance:** negligible; one `split`/`join` on an error path that only executes when artifacts are already stale, plus once per guide during frontmatter parsing (8 guides).
- **UI quality:** N/A — no UI surface.
- **Security:** no new attack surface. Pure string reformat of an already-computed local path used only in a diagnostic message.
- **Lint hygiene:** no `max-lines` disable added (script stays ~285 lines), no `utils`/`helpers` module created — the function lives in the script that owns it.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance — all reviewed above. Nothing outstanding.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — targeted lint/format/tests run locally; project-wide checks deferred to CI

