### PR TITLE
fix(cli): allow an empty --value for storage set commands

### DIFF
--- a/src/cli/browser-storage-empty-value.test.ts
+++ b/src/cli/browser-storage-empty-value.test.ts
@@ -37,9 +37,7 @@ vi.mock('./runtime-client', () => {
 import { main } from './index'
 import { okFixture, queueFixtures } from './test-fixtures'
 
-// Why: the server's StorageKeyValue schema requires a non-empty key but accepts any
-// string value, empty included. setItem(key, '') is a real operation distinct from an
-// absent key, so `--value ""` must reach the RPC rather than being rejected as missing.
+// Why: StorageKeyValue requires a non-empty key but accepts any string value, empty included.
 describe('orca cli storage set preserves an empty value', () => {
   beforeEach(() => {
     callMock.mockReset()
@@ -82,6 +80,40 @@ describe('orca cli storage set preserves an empty value', () => {
       value: '',
       worktree: undefined
     })
+  })
+
+  // Why: PowerShell 5.1 drops empty native-exe args, so `--value=` is the Windows escape hatch.
+  it('passes an empty --value= (equals form) through to browser.storage.local.set', async () => {
+    queueFixtures(callMock, okFixture('req_storage_local_set', { success: true }))
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(
+      ['storage', 'local', 'set', '--key=flag', '--value=', '--worktree', 'all', '--json'],
+      '/tmp/not-an-orca-worktree'
+    )
+
+    expect(callMock).toHaveBeenCalledTimes(1)
+    expect(callMock).toHaveBeenCalledWith('browser.storage.local.set', {
+      key: 'flag',
+      value: '',
+      worktree: undefined
+    })
+  })
+
+  it('still rejects an empty --key before RPC dispatch', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const priorExitCode = process.exitCode
+
+    await main(
+      ['storage', 'local', 'set', '--key', '', '--value', 'x', '--worktree', 'all'],
+      '/tmp/not-an-orca-worktree'
+    )
+
+    expect(callMock).not.toHaveBeenCalled()
+    expect(errorSpy.mock.calls.flat().join('\n')).toContain('Missing required --key')
+    expect(process.exitCode).toBe(1)
+
+    process.exitCode = priorExitCode
   })
 
   it('still rejects a missing --value before RPC dispatch', async () => {

--- a/src/cli/browser-storage-empty-value.test.ts
+++ b/src/cli/browser-storage-empty-value.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const callMock = vi.fn()
+
+vi.mock('./runtime-client', () => {
+  class RuntimeClient {
+    call = callMock
+    getCliStatus = vi.fn()
+    openOrca = vi.fn()
+  }
+
+  class RuntimeClientError extends Error {
+    readonly code: string
+
+    constructor(code: string, message: string) {
+      super(message)
+      this.code = code
+    }
+  }
+
+  class RuntimeRpcFailureError extends RuntimeClientError {
+    readonly response: unknown
+
+    constructor(response: unknown) {
+      super('runtime_error', 'runtime_error')
+      this.response = response
+    }
+  }
+
+  return {
+    RuntimeClient,
+    RuntimeClientError,
+    RuntimeRpcFailureError
+  }
+})
+
+import { main } from './index'
+import { okFixture, queueFixtures } from './test-fixtures'
+
+// Why: the server's StorageKeyValue schema requires a non-empty key but accepts any
+// string value, empty included. setItem(key, '') is a real operation distinct from an
+// absent key, so `--value ""` must reach the RPC rather than being rejected as missing.
+describe('orca cli storage set preserves an empty value', () => {
+  beforeEach(() => {
+    callMock.mockReset()
+    process.exitCode = undefined
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('passes an empty --value through to browser.storage.local.set', async () => {
+    queueFixtures(callMock, okFixture('req_storage_local_set', { success: true }))
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(
+      ['storage', 'local', 'set', '--key', 'flag', '--value', '', '--worktree', 'all', '--json'],
+      '/tmp/not-an-orca-worktree'
+    )
+
+    expect(callMock).toHaveBeenCalledTimes(1)
+    expect(callMock).toHaveBeenCalledWith('browser.storage.local.set', {
+      key: 'flag',
+      value: '',
+      worktree: undefined
+    })
+  })
+
+  it('passes an empty --value through to browser.storage.session.set', async () => {
+    queueFixtures(callMock, okFixture('req_storage_session_set', { success: true }))
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(
+      ['storage', 'session', 'set', '--key', 'flag', '--value', '', '--worktree', 'all', '--json'],
+      '/tmp/not-an-orca-worktree'
+    )
+
+    expect(callMock).toHaveBeenCalledTimes(1)
+    expect(callMock).toHaveBeenCalledWith('browser.storage.session.set', {
+      key: 'flag',
+      value: '',
+      worktree: undefined
+    })
+  })
+
+  it('still rejects a missing --value before RPC dispatch', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const priorExitCode = process.exitCode
+
+    await main(
+      ['storage', 'local', 'set', '--key', 'flag', '--worktree', 'all'],
+      '/tmp/not-an-orca-worktree'
+    )
+
+    expect(callMock).not.toHaveBeenCalled()
+    expect(errorSpy.mock.calls.flat().join('\n')).toContain('Missing required --value')
+    expect(process.exitCode).toBe(1)
+
+    process.exitCode = priorExitCode
+  })
+})

--- a/src/cli/handlers/browser-storage.ts
+++ b/src/cli/handlers/browser-storage.ts
@@ -12,8 +12,7 @@ export const BROWSER_STORAGE_HANDLERS: Record<string, CommandHandler> = {
   },
   'storage local set': async ({ flags, client, cwd, json }) => {
     const key = getRequiredStringFlag(flags, 'key')
-    // Why: the server's StorageKeyValue schema accepts any string value (empty included),
-    // so `--value ""` must reach it — setItem(key, '') differs from leaving the key unset.
+    // Why: the server accepts any string value; setItem(key, '') differs from an unset key.
     const value = getRequiredStringFlagAllowingEmpty(flags, 'value')
     const target = await getBrowserCommandTarget(flags, cwd, client)
     const result = await client.call<unknown>('browser.storage.local.set', {
@@ -36,8 +35,6 @@ export const BROWSER_STORAGE_HANDLERS: Record<string, CommandHandler> = {
   },
   'storage session set': async ({ flags, client, cwd, json }) => {
     const key = getRequiredStringFlag(flags, 'key')
-    // Why: mirrors the local-storage set — the server accepts an empty value, so `--value ""`
-    // must pass through instead of being rejected as missing.
     const value = getRequiredStringFlagAllowingEmpty(flags, 'value')
     const target = await getBrowserCommandTarget(flags, cwd, client)
     const result = await client.call<unknown>('browser.storage.session.set', {

--- a/src/cli/handlers/browser-storage.ts
+++ b/src/cli/handlers/browser-storage.ts
@@ -1,6 +1,6 @@
 import type { CommandHandler } from '../dispatch'
 import { printResult } from '../format'
-import { getRequiredStringFlag } from '../flags'
+import { getRequiredStringFlag, getRequiredStringFlagAllowingEmpty } from '../flags'
 import { getBrowserCommandTarget } from '../selectors'
 
 export const BROWSER_STORAGE_HANDLERS: Record<string, CommandHandler> = {
@@ -12,7 +12,9 @@ export const BROWSER_STORAGE_HANDLERS: Record<string, CommandHandler> = {
   },
   'storage local set': async ({ flags, client, cwd, json }) => {
     const key = getRequiredStringFlag(flags, 'key')
-    const value = getRequiredStringFlag(flags, 'value')
+    // Why: the server's StorageKeyValue schema accepts any string value (empty included),
+    // so `--value ""` must reach it — setItem(key, '') differs from leaving the key unset.
+    const value = getRequiredStringFlagAllowingEmpty(flags, 'value')
     const target = await getBrowserCommandTarget(flags, cwd, client)
     const result = await client.call<unknown>('browser.storage.local.set', {
       key,
@@ -34,7 +36,9 @@ export const BROWSER_STORAGE_HANDLERS: Record<string, CommandHandler> = {
   },
   'storage session set': async ({ flags, client, cwd, json }) => {
     const key = getRequiredStringFlag(flags, 'key')
-    const value = getRequiredStringFlag(flags, 'value')
+    // Why: mirrors the local-storage set — the server accepts an empty value, so `--value ""`
+    // must pass through instead of being rejected as missing.
+    const value = getRequiredStringFlagAllowingEmpty(flags, 'value')
     const target = await getBrowserCommandTarget(flags, cwd, client)
     const result = await client.call<unknown>('browser.storage.session.set', {
       key,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​134 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​134 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 |

<!-- /orca-pr-loc -->

Supersedes #15812 by @2sumtech — carried over so it can run full CI (fork PRs only run `track-community-pr` in this repo). Original authorship preserved in the commit.

## ELI5

`orca storage local set --key flag --value ""` used to fail with "Missing required --value", even though storing an empty string is a perfectly legal thing to do — in the browser, `localStorage.setItem('flag', '')` is real and different from the key not existing at all. The CLI was treating "empty" as "you forgot to pass it". Now an empty value goes through to the browser like any other string, while forgetting the flag entirely still errors like before.

## What Changed

- `src/cli/handlers/browser-storage.ts`: `storage local set` and `storage session set` now read `--value` with the already-existing `getRequiredStringFlagAllowingEmpty` instead of `getRequiredStringFlag`. `--key` is unchanged and still requires a non-empty string.
- `src/cli/browser-storage-empty-value.test.ts` (new): regression coverage for the empty value on both local and session storage, the `--value=` equals form, plus the two negative cases (`--key ""` and a missing `--value`) that must still be rejected before RPC dispatch.

No flag definitions, help/usage text, RPC schemas, or wire formats were touched.

## Why

Root cause is a contract mismatch between CLI flag parsing and the runtime schema. `StorageKeyValue` (`src/main/runtime/rpc/methods/browser-schemas.ts`) deliberately validates `key` as a non-empty string but `value` as *any* string:

```ts
key:   z.custom<string>((v) => typeof v === 'string' && v.length > 0, ...),
value: z.custom<string>((v) => typeof v === 'string', ...)
```

The CLI, however, read both with `getRequiredStringFlag`, which rejects `''`. So the request died in local flag parsing and never reached the RPC — the runtime's intent to accept an empty value was unreachable from the CLI. `getRequiredStringFlagAllowingEmpty` already existed in `src/cli/flags.ts` for exactly this case (it keeps the `typeof value === 'string'` check, so a bare `--value` with no argument — which `parseArgs` records as boolean `true` — still errors). Using it makes the CLI match the schema instead of being stricter than it.

## Linked Issue

Fixes #15810

## Visual Proof

`N/A` — CLI-only change, no UI surface. The only observable difference is that a previously-rejected command now succeeds.

## Testing

Run on **macOS only** (Darwin 25.3.0, arm64). Linux/Windows/SSH are covered by reasoning, not execution — see Review below.

```
npx vitest run --config config/vitest.config.ts \
  src/cli/browser-storage-empty-value.test.ts src/cli/browser.test.ts \
  src/cli/flags.test.ts src/cli/args.test.ts \
  src/cli/registry-parity.test.ts src/cli/handler-group-manifest.test.ts
  → Test Files 6 passed (6) | Tests 89 passed (89)

npx oxlint src/cli/handlers/browser-storage.ts src/cli/browser-storage-empty-value.test.ts
  → exit 0, no findings

npx oxlint --config config/oxlint-code-quality-native-plugins.json \
  src/cli/handlers/browser-storage.ts src/cli/browser-storage-empty-value.test.ts --deny-warnings
  → exit 0, no findings

npx oxfmt --check <both files>
  → All matched files use the correct format.
```

**Regression proof** — reverted `src/cli/handlers/browser-storage.ts` to `origin/main` and re-ran the new test file:

```
× passes an empty --value through to browser.storage.local.set
× passes an empty --value through to browser.storage.session.set
× passes an empty --value= (equals form) through to browser.storage.local.set
Tests  3 failed | 2 passed (5)
```

The three positive cases fail without the product change (the throw happens before any RPC call, so the `callMock` assertion never fires); the two negative cases stay green in both directions, confirming they pin behavior rather than tracking the change. With the fix restored: 5 passed.

Project-wide `pnpm typecheck` / `pnpm lint` were deliberately not run locally (they OOM in this environment when several agents share the machine); CI covers them.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

**Correctness.** The widening is bounded and intentional: only `''` becomes newly acceptable, the `typeof === 'string'` guard remains, and `--key` keeps its non-empty requirement so the CLI still fails fast rather than producing a confusing server-side `Missing required --key and --value`. Both directions are now pinned by tests. I also verified `parseArgs` (`src/cli/args.ts`) preserves an empty next token and handles the `--value=` equals branch separately, and that `validateCommandAndFlags` only enforces non-emptiness for `GLOBAL_VALUE_FLAGS` (pairing-code / environment), so `value` is unaffected there.

**Cross-platform.** No path handling, no keyboard accelerators, no shell interpolation. One genuine platform wrinkle: PowerShell 5.1 drops empty-string arguments when invoking a native exe, so `--value ""` can still surface as missing on that host. `--value=` is the escape hatch and it now has a dedicated test so the parser branch can't regress. The WSL bridge already quotes an empty arg as `""` under `[AllowEmptyString()]` (`src/main/cli/wsl-cli-scripts.ts`), and the Windows `.cmd` launcher forwards `%*`.

**SSH / remote.** Safe. The passthrough carries argv as `string[]` and spawns it directly (`src/main/ssh/ssh-remote-cli-host-passthrough.ts`) — no shell round-trip that could collapse an empty token. Nothing here reports on, stops, or lists remote work, so the `live`/`unverifiable`/`exited` boundary is untouched.

**Agent / integration & wire compatibility.** No new RPC field, no new stream opcode, no schema or help-text change. `StorageKeyValue` has accepted any string `value` since it was introduced, so a new client against an older host behaves identically and vice versa. `browser.storage.local.set` / `.session.set` have a single CLI consumer, so there is no other caller to keep in sync. Provider-neutral (no git-forge surface), and unaffected by folder-workspace vs. worktree since the worktree selector path is unchanged.

**Performance.** None — one flag-reader swap, no added I/O or allocation.

**UI quality.** N/A, CLI only.

**Security.** I scanned the full contributor diff, not just the visible hunks, and found nothing malicious: exactly two files changed, single commit, no `package.json`/lockfile/workflow/script/binary/postinstall changes, no network calls, no `child_process`/`fs`/`eval`/dynamic import, no env or credential reads, no obfuscated blobs, and no text added anywhere an agent later ingests as instructions (AGENTS.md, CLAUDE.md, docs/, skills/). The test's `vi.mock('./runtime-client')` is shape-identical to the pattern already used across ~26 `src/cli/*.test.ts` files, and `/tmp/not-an-orca-worktree` is only a cwd string — never created or read. On the change's own semantics: the value reaches the agent-browser binary as an `execFile` argv element with `shell: false`, so permitting an empty token opens no injection surface.

**Follow-up (intentionally not bundled here).** The same CLI-vs-schema mismatch exists for `fill --value` (`Fill.value` is `requiredStringAllowingEmpty` — clearing a field is explicitly intended), `select --value`, and `cookie set --value`. Note `find --value` must *not* change: `Find.value` uses `requiredString`, so the CLI already matches. I'll file that separately to keep this PR scoped to #15810.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Security, cross-platform, SSH, mobile, backwards compatibility, and performance all reviewed above — no issues found. Backwards compatible in both directions: commands that worked before still work, and the only new behavior is a command that previously errored.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
